### PR TITLE
fix: make ProviderSettingsCard select respond to dark/light theme

### DIFF
--- a/agent/src/sidepanel/components/ProviderSettingsCard.tsx
+++ b/agent/src/sidepanel/components/ProviderSettingsCard.tsx
@@ -315,7 +315,7 @@ export function ProviderSettingsCard(): JSX.Element | null {
               </label>
               <select
                 id="prov-type"
-                className="px-2 py-1 rounded-md border border-border bg-background text-sm"
+                className="px-2 py-1 rounded-md border border-border bg-white text-sm text-black dark:bg-gray-800 dark:text-white dark:border-gray-700 focus:outline-none focus:ring-1 focus:ring-sky-400"
                 value={draft.type}
                 onChange={e => setDraft({ ...draft, type: e.target.value as BrowserOSProviderType })}
               >


### PR DESCRIPTION
This PR addresses an issue with the ProviderSettingsCard component where the provider type <select> did not adapt to the browser’s light or dark theme.

Changes made:

Updated the <select> element to use Tailwind dark: variants for background, text, and border colors.

Added focus styling for better accessibility.

Ensures that the component now correctly responds to both light and dark modes.

Before:

Select input had static bg-background and text-sm classes, which did not adapt to dark mode.

After:

Select input now uses bg-white text-black dark:bg-gray-800 dark:text-white dark:border-gray-700 and a focus ring.

This improves the UI consistency and accessibility across different themes.