### PR TITLE
fix: TypeError in chrome-newtab settings button

### DIFF
--- a/agent/src/newtab/components/SettingsDialog.tsx
+++ b/agent/src/newtab/components/SettingsDialog.tsx
@@ -16,7 +16,7 @@ export function SettingsDialog({ isOpen, onClose }: SettingsDialogProps) {
   useEffect(() => {
     if (isOpen) {
       // Get BrowserOS version from API if available
-      if ('getVersionNumber' in chrome.browserOS && typeof chrome.browserOS.getVersionNumber === 'function') {
+      if (chrome.browserOS && 'getVersionNumber' in chrome.browserOS && typeof chrome.browserOS.getVersionNumber === 'function') {
         getBrowserOSAdapter().getVersion()
           .then(v => setBrowserOSVersion(v))
           .catch(() => setBrowserOSVersion(null))


### PR DESCRIPTION
### What this PR does?

This PR fixes an error in `SettingsDialog.tsx` where the `in` operator was used on `chrome.browserOS` when it was `undefined`. The error occurred when clicking the Settings button in the new tab, causing it to break.

### Before

The error occurred because the `in` operator can only be used with objects. If the right-hand side is null or undefined, it throws a TypeError.

<img width="800"  alt="Screenshot 2025-09-08 193754" src="https://github.com/user-attachments/assets/659ea20d-0702-4158-a8b6-b149a0253448" />

### After

The condition is updated to safely check whether `chrome.browserOS` exists before using the `in` operator ensuring the dialog doesn't break now:

```
if (
  chrome.browserOS &&
  'getVersionNumber' in chrome.browserOS &&
  typeof chrome.browserOS.getVersionNumber === 'function'
)  { ... }
```