### PR TITLE
fix(sidepanel): prevent input field and mode toggle from scrolling

### DIFF
--- a/agent/src/sidepanel/App.tsx
+++ b/agent/src/sidepanel/App.tsx
@@ -55,7 +55,7 @@ export function App() {
         announcer.announce('An error occurred. Please try again.', 'assertive')
       }}
     >
-      <div className="h-screen bg-background overflow-x-hidden" role="main" aria-label="BrowserOS Chat Assistant">
+      <div className="h-screen bg-background overflow-hidden" role="main" aria-label="BrowserOS Chat Assistant">
         <SkipLink />
         <Chat isConnected={connected} />
         {humanInputRequest && (


### PR DESCRIPTION
## Description
   Fixes the issue where the input field and Chat/Agent mode toggle scroll away when browsing suggestions or messages in the Agent sidebar.

   ## Problem
   The main sidebar container was allowing vertical overflow, causing the input field and mode toggle to disappear when users scrolled through agent suggestions and messages.

   ## Solution
   Changed `overflow-x-hidden` to `overflow-hidden` on the main container (`src/sidepanel/App.tsx`), ensuring:
   - Only the MessageList area is scrollable
   - Input field remains fixed at the bottom
   - Mode toggle stays accessible at all times

   ## Testing
   - ✅ Input field now stays fixed at bottom during scrolling
   - ✅ Chat/Agent mode toggle remains accessible 
   - ✅ Only messages/suggestions area scrolls as expected

  ## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

Closes #100