### PR TITLE
Fix typo in onboarding documentation

### DIFF
--- a/docs/onboarding.mdx
+++ b/docs/onboarding.mdx
@@ -19,7 +19,7 @@ Bring your bookmarks, history, and settings over from Chrome.
 
 ### Step 2: BYOK (Bring Your Own Keys)
 
-BrowserOS comes with a default LLM provider to test things out. But ou have full control over your AI models! Navigate to `New Tab` page or `chrome://settings/browseros` and click on settings to configure your own API keys for various providers.
+BrowserOS comes with a default LLM provider to test things out. But you have full control over your AI models! Navigate to `New Tab` page or `chrome://settings/browseros` and click on settings to configure your own API keys for various providers.
 
 <Card title="Configure LLM Provider" icon="key" href="/llm-setup-guide">
   Set up Gemini, Claude, OpenAI, or run models locally with Ollama


### PR DESCRIPTION
I noticed a typo in the guide 