### PR TITLE
fix(packaging): Correctly enable SUID sandbox for .deb

### DIFF
--- a/packages/browseros/build/config/gn/flags.linux.release.gn
+++ b/packages/browseros/build/config/gn/flags.linux.release.gn
@@ -6,6 +6,9 @@ is_official_build = true
 is_component_build = false
 use_siso=false
 
+# Enable SUID sandbox
+use_suid_sandbox = true
+
 # Compiler
 use_sysroot = true
 use_custom_libcxx = true

--- a/packages/browseros/build/modules/package/linux.py
+++ b/packages/browseros/build/modules/package/linux.py
@@ -355,6 +355,7 @@ def create_launcher_script(ctx: Context, bin_dir: Path) -> None:
     launcher_content = f"""#!/bin/sh
 # BrowserOS launcher script
 export LD_LIBRARY_PATH=/usr/lib/browseros:$LD_LIBRARY_PATH
+export CHROME_DEVEL_SANDBOX=/usr/lib/browseros/chrome_sandbox
 exec /usr/lib/browseros/{ctx.BROWSEROS_APP_NAME} "$@"
 """
 


### PR DESCRIPTION
This change fixes an issue where the installed `.deb` package on Linux fails to
     launch due to an un-set `CHROME_DEVEL_SANDBOX` environment variable and a missing 
     `chrome_sandbox` executable.
   2 
   3      The fix addresses two core problems:
   4      1.  **Missing `chrome_sandbox` binary:** The GN build flag `use_setuid_sandbox 
     true` is explicitly added to `flags.linux.release.gn` to ensure the SUID sandbox 
     helper is compiled and included in the build.
   5      2.  **Incorrect sandbox environment:** The launcher script generated by 
     `linux.py` is modified to export the `CHROME_DEVEL_SANDBOX` environment variable, 
     pointing to the correct location of the `chrome_sandbox` executable (
     `/usr/lib/browseros/chrome_sandbox`).
   6 
   7      This combination ensures that BrowserOS can correctly use the SUID sandbox on 
     Linux distributions (like Ubuntu 23.10+) that have disabled unprivileged user 
     namespaces, resolving the "No usable sandbox!" and misleading "cannot read AppImage 
     file" errors without resorting to the insecure `--no-sandbox` flag.
    
 I have read the CLA Document and I hereby sign the CLA   