### PR TITLE
Remove outdated LLM reconfiguration tip

### DIFF
--- a/docs/update.mdx
+++ b/docs/update.mdx
@@ -32,7 +32,3 @@ Please download the latest binary and install:
     Download from GitHub
   </Card>
 </CardGroup>
-
-<Tip>
-  After installing, you'll need to reconfigure your LLM provider settings as they won't carry over from the previous version.
-</Tip>


### PR DESCRIPTION
## Summary
- remove outdated tip about reconfiguring LLM provider settings after installs

## Testing
- not run (docs change only)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694da71cf4a8832a9984f32e5aac21b3)