### PR TITLE
fix: build system reliability fixes and docs corrections

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,26 +115,27 @@ Once you have Chromium checked out, navigate to our build system:
 ```bash
 cd packages/browseros
 
-# Debug build (for development)
-# macOS
-python build/build.py --config build/config/debug.macos.yaml --chromium-src /path/to/chromium/src --build
+# Debug build (for development — works on all platforms)
+# Set your Chromium source path in build/config/debug.yaml first, or use CHROMIUM_SRC env var
+browseros build --config build/config/debug.yaml
 
-# Linux
-python build/build.py --config build/config/debug.linux.yaml --chromium-src /path/to/chromium/src --build
-
-# Windows
-python build/build.py --config build/config/debug.windows.yaml --chromium-src /path/to/chromium/src --build
+# Alternative using the Python module directly:
+python -m build.browseros build --config build/config/debug.yaml
 
 # Release build (for production)
 # macOS
-python build/build.py --config build/config/release.macos.yaml --chromium-src /path/to/chromium/src --build
+browseros build --config build/config/release.macos.yaml
 
 # Linux
-python build/build.py --config build/config/release.linux.yaml --chromium-src /path/to/chromium/src --build
+browseros build --config build/config/release.linux.yaml
 
 # Windows
-python build/build.py --config build/config/release.windows.yaml --chromium-src /path/to/chromium/src --build
+browseros build --config build/config/release.windows.yaml
 ```
+
+> **Note:** When using `--config`, all build parameters (including `chromium_src`) come from the
+> YAML file. Set `chromium_src` in the YAML or via the `CHROMIUM_SRC` environment variable.
+> Do **not** mix `--config` with `--build` / `--arch` flags — they are mutually exclusive.
 
 The build typically takes 1-3 hours on modern hardware (M4 Max, Ryzen 9, etc.).
 

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -20,8 +20,8 @@ BrowserOS is an AI-native browser that lets you automate any web task by describ
   <Card title="Agent Mode" icon="robot">
     Describe a task and watch AI execute it: clicking, typing, navigating. Automate form filling, data extraction, and multi-step workflows.
   </Card>
-  <Card title="Graph Mode" icon="sitemap">
-    Build reliable, repeatable workflows as visual graphs. Edit steps, save, and run anytime. *Coming soon.*
+  <Card title="Graph Mode" icon="sitemap" href="/features/workflows">
+    Build reliable, repeatable workflows as visual graphs. Edit steps, save, and run anytime.
   </Card>
 </Columns>
 

--- a/packages/browseros/build/cli/build.py
+++ b/packages/browseros/build/cli/build.py
@@ -32,6 +32,7 @@ from ..common.utils import (
     IS_WINDOWS,
     IS_LINUX,
 )
+from ..common.logger import close_log_file
 
 # Import all module classes
 from ..modules.setup.clean import CleanModule
@@ -238,6 +239,8 @@ def execute_pipeline(
         log_error(f"\n❌ Pipeline failed: {e}")
         notify_pipeline_error(pipeline_name, str(e))
         raise typer.Exit(1)
+    finally:
+        close_log_file()
 
 
 def main(

--- a/packages/browseros/build/modules/compile/standard.py
+++ b/packages/browseros/build/modules/compile/standard.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Standard single-architecture build module for BrowserOS"""
 
-import tempfile
 import shutil
 from pathlib import Path
 from ...common.module import CommandModule, ValidationError
@@ -60,13 +59,8 @@ class CompileModule(CommandModule):
 
         version_content = f"MAJOR={parts[0]}\nMINOR={parts[1]}\nBUILD={parts[2]}\nPATCH={parts[3]}"
 
-        with tempfile.NamedTemporaryFile(mode="w", delete=False) as temp_file:
-            temp_file.write(version_content)
-            temp_path = temp_file.name
-
         chrome_version_path = join_paths(ctx.chromium_src, "chrome", "VERSION")
-        shutil.copy2(temp_path, chrome_version_path)
-        Path(temp_path).unlink()
+        chrome_version_path.write_text(version_content)
 
         log_info(f"Created VERSION file: {ctx.browseros_chromium_version}")
 

--- a/packages/browseros/build/modules/patches/series_patches.py
+++ b/packages/browseros/build/modules/patches/series_patches.py
@@ -60,9 +60,9 @@ def parse_series(series_path: Path) -> Iterator[str]:
             continue
         if line.startswith("#"):
             continue
-        # Strip inline comments
-        if " #" in line:
-            line = line.split(" #")[0].strip()
+        # Strip inline comments (GNU Quilt uses ' # ' with trailing space)
+        if " # " in line:
+            line = line.split(" # ")[0].strip()
         if line:
             yield line
 

--- a/packages/browseros/build/modules/setup/configure.py
+++ b/packages/browseros/build/modules/setup/configure.py
@@ -12,6 +12,12 @@ class ConfigureModule(CommandModule):
     description = "Configure build with GN"
 
     def validate(self, ctx: Context) -> None:
+        valid_build_types = {"debug", "release"}
+        if ctx.build_type not in valid_build_types:
+            raise ValidationError(
+                f"Invalid build_type '{ctx.build_type}'. Must be one of: {sorted(valid_build_types)}"
+            )
+
         if not ctx.chromium_src.exists():
             raise ValidationError(f"Chromium source not found: {ctx.chromium_src}")
 

--- a/packages/browseros/build/modules/setup/git.py
+++ b/packages/browseros/build/modules/setup/git.py
@@ -6,7 +6,7 @@ import tarfile
 import urllib.request
 from ...common.module import CommandModule, ValidationError
 from ...common.context import Context
-from ...common.utils import run_command, log_info, log_error, log_success, IS_WINDOWS, safe_rmtree
+from ...common.utils import run_command, log_info, log_error, log_success, IS_MACOS, IS_WINDOWS, safe_rmtree
 
 
 class GitSetupModule(CommandModule):
@@ -68,7 +68,6 @@ class SparkleSetupModule(CommandModule):
     description = "Download and setup Sparkle framework (macOS only)"
 
     def validate(self, ctx: Context) -> None:
-        from ...common.utils import IS_MACOS
         if not IS_MACOS():
             raise ValidationError("Sparkle setup requires macOS")
 


### PR DESCRIPTION
- Remove temp file leak in CompileModule._create_version_file: write VERSION directly via Path.write_text() instead of tempfile+shutil.copy2
- Always close build log: add finally: close_log_file() in execute_pipeline() so logs are flushed on success, failure, and KeyboardInterrupt
- Fix fragile series patch comment stripping: change ' #' to ' # ' (GNU Quilt convention) so patch filenames containing ' #' are preserved
- Move IS_MACOS to module-level import in git.py, remove redundant inner-function re-import in SparkleSetupModule.validate()
- Validate build_type in ConfigureModule.validate(): reject values other than 'debug' or 'release' with a clear error message
- Fix CONTRIBUTING.md build commands: correct binary name to 'browseros build', fix non-existent config filenames (debug.macos.yaml -> debug.yaml), remove --chromium-src which conflicts with --config mode
- Remove stale 'Coming soon' from Graph Mode card in docs/index.mdx and add href to the existing /features/workflows page