### PR TITLE
docs: add citation section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,24 @@ BrowserOS is open source under the [AGPL-3.0 license](LICENSE).
 
 - [ungoogled-chromium](https://github.com/ungoogled-software/ungoogled-chromium) - BrowserOS uses some patches for enhanced privacy. Thanks to everyone behind this project!
 - [The Chromium Project](https://www.chromium.org/) - At the core of BrowserOS, making it possible to exist in the first place.
-  
+
+## Citation
+
+If you use BrowserOS in your research or project, please cite:
+
+```bibtex
+@software{browseros2025,
+  author = {Sonti, Nithin Venkat and Sonti, Nikhil Venkat and {BrowserOS-team}},
+  title = {BrowserOS: The open-source Agentic browser},
+  url = {https://github.com/browseros-ai/BrowserOS},
+  year = {2025},
+  publisher = {GitHub},
+  license = {AGPL-3.0},
+}
+```
+
+Copyright &copy; 2025 Felafax, Inc.
+
 ## Stargazers
 Thank you to all our supporters!
 


### PR DESCRIPTION
## Summary
- Add a `## Citation` section to `README.md` with a BibTeX `@software` entry
- Authors: Nithin Venkat Sonti, Nikhil Venkat Sonti, and the BrowserOS team
- Includes copyright line for Felafax, Inc
- Placed between the existing Credits and Stargazers sections

## Design
Single documentation change to README.md. Adds a standard BibTeX citation block following the convention used by other open-source AI projects (e.g., notte). This allows academics and developers to properly credit BrowserOS when referencing it in papers or derivative projects.

## Test plan
- [ ] Verify the Citation section renders correctly on GitHub
- [ ] Verify the BibTeX entry is valid and copy-pasteable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change in `README.md` with no code or runtime impact.
> 
> **Overview**
> Adds a new **`## Citation`** section to `README.md` (between Credits and Stargazers) with a copy-pasteable BibTeX `@software` entry for BrowserOS, plus a Felafax, Inc. copyright line.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cabbca1c1bf797c7569c6cfdc135f775dccbb37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->