### PR TITLE
docs: updated cowork section

### DIFF
--- a/docs/comparisons/claude-cowork.mdx
+++ b/docs/comparisons/claude-cowork.mdx
@@ -1,0 +1,161 @@
+---
+title: "Claude Cowork"
+description: "How BrowserOS Cowork compares to Claude Cowork for getting real work done with AI"
+---
+
+Both BrowserOS Cowork and [Claude Cowork](https://claude.com/product/cowork) let an AI agent work with your local files autonomously. You describe a task, step away, and come back to completed work. They share a similar file toolkit under the hood. The key difference is what else each product can do. BrowserOS Cowork runs inside a real browser with full web access and 40+ app integrations. Claude Cowork runs inside an isolated VM with professional document generation.
+
+This page compares both products so you can decide which fits your workflow.
+
+---
+
+## At a Glance
+
+| | **BrowserOS Cowork** | **Claude Cowork** |
+|---|---|---|
+| **Runs in** | Your real browser | Claude Desktop app (VM) |
+| **File tools** | Read, write, edit, search, organize | Read, write, edit, search, organize |
+| **Browser automation** | Yes, 53 tools (click, type, screenshot, navigate, etc.) | No |
+| **App integrations** | 40+ (Gmail, Slack, GitHub, Calendar, Notion, etc.) | ~4 connectors (Google Drive, Gmail, DocuSign) |
+| **AI model** | Your choice (Claude, GPT, Gemini, Kimi, local models) | Claude only |
+| **Internet access** | Full (through your real browser) | Restricted |
+| **Document generation** | Basic (HTML, Markdown, CSV) | Advanced (Excel with formulas, PowerPoint, formatted docs) |
+| **Pricing** | Free (bring your own AI key) | Requires paid Claude subscription |
+| **Platform** | Any OS with BrowserOS | macOS, Windows x64 |
+
+---
+
+## Feature Comparison
+
+### File Operations
+
+Both products provide a comparable set of file tools. You can read, write, edit, search, and organize files in both. This is table-stakes for both products.
+
+| What you can do | BrowserOS Cowork | Claude Cowork |
+|-----------------|:---:|:---:|
+| Read and view files | Yes | Yes |
+| Create and save new files | Yes | Yes |
+| Edit specific parts of a file | Yes | Yes |
+| Search inside files for text | Yes | Yes |
+| Find files by name or pattern | Yes | Yes |
+| List and browse folders | Yes | Yes |
+| Run commands/scripts | Yes | Yes |
+| Break work into parallel subtasks | Coming soon | Built-in sub-agents |
+
+<Note>
+The file tools are largely equivalent. The real differentiator is what else each product can do beyond file operations.
+</Note>
+
+### Working with the Web
+
+This is the biggest difference. BrowserOS Cowork runs inside a real browser with your existing logins and sessions.
+
+| What you can do | BrowserOS Cowork | Claude Cowork |
+|-----------------|:---:|:---:|
+| Open and navigate websites | Yes | No |
+| Click buttons, fill forms, type text | Yes | No |
+| Take screenshots of web pages | Yes | No |
+| Extract content from web pages | Yes | No |
+| Save pages as PDF | Yes | No |
+| Download files from the web | Yes | No |
+| Access sites where you're logged in | Yes (your real browser session) | No |
+| Manage tabs, windows, and bookmarks | Yes | No |
+| Search your browsing history | Yes | No |
+
+Claude Cowork has no browser access. If your task involves anything on the web, whether that's researching, filling out forms, grabbing content from a site, or checking on a web app, you need BrowserOS.
+
+### Connected Apps
+
+BrowserOS connects to 40+ services directly. Claude Cowork has a handful of connectors.
+
+| Service | BrowserOS Cowork | Claude Cowork |
+|---------|:---:|:---:|
+| Gmail | Yes | Yes |
+| Google Drive | Yes | Yes |
+| Google Calendar | Yes | Limited |
+| Slack | Yes | No |
+| GitHub | Yes | No |
+| Linear / Jira / Asana | Yes | No |
+| Notion | Yes | No |
+| Figma | Yes | No |
+| Salesforce / HubSpot | Yes | No |
+| Shopify / Stripe | Yes | No |
+| 30+ more services | Yes | No |
+
+### Document Generation
+
+Claude Cowork has an edge when it comes to creating polished office documents.
+
+| What you can do | BrowserOS Cowork | Claude Cowork |
+|-----------------|:---:|:---:|
+| HTML and Markdown files | Yes | Yes |
+| CSV and data files | Yes | Yes |
+| Excel with working formulas | No | Yes |
+| PowerPoint presentations | No | Yes |
+| Formatted Word documents | No | Yes |
+
+---
+
+## How They Work
+
+<Tabs>
+  <Tab title="BrowserOS Cowork">
+    BrowserOS Cowork runs inside the browser. The agent has access to your real browser session (cookies, logins, extensions) and a sandboxed folder on your computer.
+
+    - Works in your real browser with your existing logins
+    - File access sandboxed to the folder you select
+    - 40+ app integrations via OAuth
+    - Connect from any AI tool (Claude Code, Gemini CLI, Cursor, etc.)
+    - Uses whatever AI model you choose
+  </Tab>
+  <Tab title="Claude Cowork">
+    Claude Cowork runs in an isolated virtual machine on your desktop via the Claude Desktop app.
+
+    - Runs in a secure VM, isolated from your main system
+    - File access to folders you grant permission to
+    - ~4 connectors (Google Drive, Gmail, DocuSign, FactSet)
+    - Only works in the Claude Desktop app
+    - Uses Claude models only
+    - Comes pre-loaded with Python, Node.js, Ruby, and common tools
+  </Tab>
+</Tabs>
+
+---
+
+## Where Claude Cowork Shines
+
+- **Professional documents**: Create Excel spreadsheets with working formulas, PowerPoint presentations, and formatted Word documents
+- **Parallel subtasks**: Automatically breaks complex work into smaller tasks that run at the same time
+- **Stronger isolation**: Runs in a full virtual machine, giving you OS-level separation from your main system
+- **Zero setup**: Works out of the box in the Claude Desktop app with pre-installed tools and languages
+
+---
+
+## Where BrowserOS Cowork Shines
+
+- **Full browser access**: Navigate websites, fill forms, click buttons, take screenshots, and extract content from any page. Claude Cowork cannot touch the web.
+- **Your real logins**: Because it runs in your actual browser, the agent can access sites where you're already logged in: dashboards, internal tools, social media, banking portals, anything.
+- **40+ app integrations**: Gmail, Slack, GitHub, Calendar, Notion, Linear, Figma, Salesforce, and more. All accessible in the same session as your file work. Claude Cowork has about 4 connectors.
+- **Pick your AI model**: Use Claude, GPT-5, Gemini, Kimi K2.5, or a local model. Claude Cowork only works with Claude.
+- **Full internet access**: Your agent can visit any website. Claude Cowork's VM is restricted to a short list of allowed sites.
+- **Free**: BrowserOS is free. Just bring your own AI API key. Claude Cowork requires a paid Claude subscription.
+
+---
+
+## Summary
+
+| | BrowserOS Cowork | Claude Cowork |
+|---|:---:|:---:|
+| File tools (read, write, edit, search) | Yes | Yes |
+| Browse the web | **Yes (53 tools)** | No |
+| Connected apps | **40+** | ~4 |
+| Internet access | Full | Restricted |
+| Choose your AI model | Yes | Claude only |
+| Works with other AI tools | Yes (Claude Code, Gemini CLI, Cursor, etc.) | Claude Desktop only |
+| Excel, PowerPoint, Word | No | **Yes** |
+| Parallel subtasks | Coming soon | **Built-in** |
+| Security model | Folder-level sandbox | VM isolation |
+| Platform | Any OS | macOS, Windows x64 |
+| Pricing | Free + API key | Paid subscription |
+
+Both products handle file operations equally well. The choice comes down to what else you need. If your work touches the web, connected apps, or you want to choose your own AI model, BrowserOS Cowork gives you that. If you need polished office documents and prefer a fully isolated desktop experience, Claude Cowork is a good fit.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -34,6 +34,12 @@
         ]
       },
       {
+        "group": "Comparisons",
+        "pages": [
+          "comparisons/claude-cowork"
+        ]
+      },
+      {
         "group": "Integrations",
         "pages": ["integrations/n8n"]
       },

--- a/docs/features/cowork.mdx
+++ b/docs/features/cowork.mdx
@@ -1,9 +1,9 @@
 ---
-title: "Filesystem Access"
-description: "Give the assistant controlled access to local files and commands"
+title: "Cowork"
+description: "Give the agent controlled access to local files and commands alongside browser automation"
 ---
 
-Filesystem Access lets you describe complex tasks and let the agent handle them end-to-end. Combine browser automation with local file operations — research on the web, then save reports directly to your folder.
+Cowork lets you describe complex tasks and let the agent handle them end-to-end. It combines browser automation with local file operations: research on the web, then save reports directly to your folder. Read code, edit files, run shell commands, and search through your project, all in the same session as your browser tasks.
 
 Here's what it looks like to give the agent access to your local files:
 
@@ -13,29 +13,38 @@ Here's what it looks like to give the agent access to your local files:
   src="https://pub-80f8a01e6e8b4239ae53a7652ef85877.r2.dev/resources/feature-videos/3-filesystem-access.mp4"
 ></video>
 
-## Why Filesystem Access?
+## Why Cowork?
 
-Without Filesystem Access, the agent can only interact with browser tabs. With Filesystem Access enabled, it gains full access to a folder on your machine:
+Without Cowork, the agent can only interact with browser tabs. With Cowork enabled, it gains full access to a folder on your machine through 7 filesystem tools:
 
-<Columns cols={3}>
-  <Card title="Read files" icon="file-import">
-    Access documents, data files, and more from your selected folder
+<CardGroup cols={3}>
+  <Card title="Read & write files" icon="file-lines">
+    Read documents and data files, write reports, markdown, HTML, and other outputs
   </Card>
-  <Card title="Write files" icon="file-export">
-    Save reports, spreadsheets, markdown, HTML, and other outputs
+  <Card title="Edit files" icon="pen-to-square">
+    Make targeted edits to existing files with surgical string replacement
   </Card>
   <Card title="Run commands" icon="terminal">
-    Execute shell commands within the folder
+    Execute shell commands within the sandboxed folder
   </Card>
-</Columns>
+  <Card title="Search content" icon="magnifying-glass">
+    Search file contents with regex or literal patterns across your project
+  </Card>
+  <Card title="Find files" icon="folder-tree">
+    Find files by glob pattern, with smart filtering of build directories
+  </Card>
+  <Card title="Browse directories" icon="list">
+    List directory contents with file sizes, sorted and organized
+  </Card>
+</CardGroup>
 
 The real power: do both browser automation AND file operations in a single task. Describe what you want, step away, and come back to finished work.
 
-## Setting Up Filesystem Access
+## Setting Up Cowork
 
 <Steps>
-  <Step title="Open the Filesystem Access selector">
-    Click the **Filesystem Access** dropdown next to the prompt input
+  <Step title="Open the Cowork selector">
+    Click the **Cowork** dropdown next to the prompt input
   </Step>
   <Step title="Choose a folder">
     Select a recent folder or click **Choose a different folder**
@@ -49,15 +58,106 @@ The real power: do both browser automation AND file operations in a single task.
   <img src="/features/cowork/cowork-selector.png" alt="Select a folder for the agent to operate in" />
 </Frame>
 
-The agent is sandboxed to your selected folder — it cannot access files outside of it.
+The agent is sandboxed to your selected folder. It cannot access files outside of it.
+
+<Note>
+Cowork is available in **Agent Mode** only. In Chat Mode, the agent works with browser tabs only.
+</Note>
 
 <Tip>
 To disable file access, select **No folder** and the agent will work with browser tabs only.
 </Tip>
 
+## Filesystem Tools
+
+Cowork provides 7 filesystem tools that the agent can use alongside browser automation:
+
+<AccordionGroup>
+  <Accordion title="filesystem_read" icon="file-import">
+    Read a file from the filesystem. Returns text content with line numbers, or image data for image files (PNG, JPG, GIF, WEBP, BMP, SVG, ICO). Supports pagination through large files with `offset` and `limit` parameters.
+
+    | Parameter | Type | Description |
+    |-----------|------|-------------|
+    | `path` | string (required) | File path relative to working directory |
+    | `offset` | number (optional) | Starting line number (1-indexed) |
+    | `limit` | number (optional) | Max lines to read |
+
+    Responses are capped at 2000 lines or 50KB per request.
+  </Accordion>
+
+  <Accordion title="filesystem_write" icon="file-export">
+    Create or overwrite a file. Automatically creates parent directories if they don't exist.
+
+    | Parameter | Type | Description |
+    |-----------|------|-------------|
+    | `path` | string (required) | File path relative to working directory |
+    | `content` | string (required) | Complete file content to write |
+  </Accordion>
+
+  <Accordion title="filesystem_edit" icon="pen-to-square">
+    Make a targeted edit by replacing an exact string match. If the exact match fails, a whitespace-tolerant fuzzy match is attempted. Preserves original line endings (CRLF, CR, LF) and BOM.
+
+    | Parameter | Type | Description |
+    |-----------|------|-------------|
+    | `path` | string (required) | File path relative to working directory |
+    | `old_string` | string (required) | Exact text to find |
+    | `new_string` | string (required) | Replacement text |
+
+    Returns a side-by-side diff of the change.
+  </Accordion>
+
+  <Accordion title="filesystem_bash" icon="terminal">
+    Execute a shell command and return its output. Commands run in `sh`/`bash` on Unix or `cmd` on Windows.
+
+    | Parameter | Type | Description |
+    |-----------|------|-------------|
+    | `command` | string (required) | Shell command to execute |
+    | `timeout` | number (optional) | Timeout in seconds (default: 120) |
+
+    Output is truncated to the last 2000 lines if too large. Returns the exit code on failure.
+  </Accordion>
+
+  <Accordion title="filesystem_find" icon="folder-tree">
+    Find files matching a glob pattern. Searches recursively while skipping common build directories (`node_modules`, `.git`, `dist`, `build`, `.next`, `coverage`, `__pycache__`, and more).
+
+    | Parameter | Type | Description |
+    |-----------|------|-------------|
+    | `pattern` | string (required) | Glob pattern (e.g., `*.ts`, `**/*.json`) |
+    | `path` | string (optional) | Directory to search (default: working directory) |
+    | `limit` | number (optional) | Max results (default: 1000) |
+
+    Returns relative file paths sorted alphabetically.
+  </Accordion>
+
+  <Accordion title="filesystem_grep" icon="magnifying-glass">
+    Search file contents using regex or literal string matching. Skips binary files and files over 2MB.
+
+    | Parameter | Type | Description |
+    |-----------|------|-------------|
+    | `pattern` | string (required) | Search pattern (regex by default) |
+    | `path` | string (optional) | Directory or file to search |
+    | `glob` | string (optional) | Filter files by glob (e.g., `*.ts`) |
+    | `ignore_case` | boolean (optional) | Case-insensitive search |
+    | `literal` | boolean (optional) | Treat pattern as literal string |
+    | `context` | number (optional) | Lines of context around matches |
+    | `limit` | number (optional) | Max matches (default: 100) |
+  </Accordion>
+
+  <Accordion title="filesystem_ls" icon="list">
+    List directory contents. Shows directories first (with trailing `/`), then files with human-readable sizes.
+
+    | Parameter | Type | Description |
+    |-----------|------|-------------|
+    | `path` | string (optional) | Directory path (default: working directory) |
+    | `limit` | number (optional) | Max entries (default: 500) |
+
+    Entries are sorted alphabetically, case-insensitive.
+  </Accordion>
+</AccordionGroup>
+
 ## Try It: Research and Create a Report
 
-With Filesystem Access enabled, try this prompt:
+With Cowork enabled, try this prompt:
 
 ```
 Read the top 3 stories on Hacker News, read the comments too, and write an HTML report.
@@ -88,7 +188,7 @@ The agent will:
 
 <AccordionGroup>
   <Accordion title="Organize your downloads" icon="folder-tree">
-    > Go through my Downloads folder and organize files by type — documents, images, videos, archives.
+    > Go through my Downloads folder and organize files by type: documents, images, videos, archives.
   </Accordion>
   <Accordion title="Competitive research report" icon="magnifying-glass-chart">
     > Research key trends about [topic] on Reddit, Twitter, and LinkedIn. Create an HTML report with your findings.
@@ -99,13 +199,19 @@ The agent will:
   <Accordion title="Content aggregation" icon="newspaper">
     > Find the top posts from these 5 subreddits today and compile them into a daily digest document.
   </Accordion>
+  <Accordion title="Codebase exploration" icon="code">
+    > Search my project for all TODO comments, list them with file paths and line numbers, then create a summary markdown file.
+  </Accordion>
+  <Accordion title="Log analysis" icon="file-lines">
+    > Grep through the log files in this folder for errors from the last 24 hours and write a summary of what went wrong.
+  </Accordion>
 </AccordionGroup>
 
 ## Security
 
-<Columns cols={3}>
+<CardGroup cols={3}>
   <Card title="Sandboxed access" icon="box">
-    The agent can only access the folder you select — no parent directories or other locations
+    The agent can only access the folder you select. No parent directories, no path traversal.
   </Card>
   <Card title="Revoke anytime" icon="ban">
     Select **No folder** to instantly disable file access
@@ -113,8 +219,4 @@ The agent will:
   <Card title="Local only" icon="house-laptop">
     All file operations happen locally on your machine
   </Card>
-</Columns>
-
-## Feedback
-
-Filesystem Access is a new feature. If you have feedback or feature requests, [open a GitHub issue](https://github.com/browseros-ai/BrowserOS/issues).
+</CardGroup>


### PR DESCRIPTION
This pull request updates and expands the documentation around the "Cowork" feature, clarifying its capabilities, renaming it from "Filesystem Access" to "Cowork," and adding a detailed product comparison with Claude Cowork. The documentation now provides a clearer overview of Cowork's tools, usage, and security, as well as a new comparison page to help users evaluate BrowserOS Cowork against a major competitor.

**Documentation improvements and feature renaming:**

* Renamed the "Filesystem Access" feature to "Cowork" throughout the documentation for clarity and consistency, and updated descriptions to emphasize the integration of browser automation and local file operations. [[1]](diffhunk://#diff-68ec1917730618799c43fa5f5212600e002ff8c9e03aa73e5ea195d6ec0e319dL2-R6) [[2]](diffhunk://#diff-68ec1917730618799c43fa5f5212600e002ff8c9e03aa73e5ea195d6ec0e319dL16-R47)
* Expanded the Cowork documentation to include detailed descriptions of the seven filesystem tools, their parameters, and usage examples, using new UI components (`CardGroup`, `AccordionGroup`) for better readability.
* Added new real-world usage examples, including codebase exploration and log analysis, and improved the security section with clearer explanations and updated UI. [[1]](diffhunk://#diff-68ec1917730618799c43fa5f5212600e002ff8c9e03aa73e5ea195d6ec0e319dL91-R191) [[2]](diffhunk://#diff-68ec1917730618799c43fa5f5212600e002ff8c9e03aa73e5ea195d6ec0e319dR202-R222)

**New product comparison content:**

* Added a comprehensive comparison page (`docs/comparisons/claude-cowork.mdx`) detailing the differences between BrowserOS Cowork and Claude Cowork, including feature tables, platform differences, and use case breakdowns.
* Updated the documentation navigation (`docs/docs.json`) to include the new Comparisons section and the Claude Cowork comparison page.