### PR TITLE
feat: setup docs for skills and nudges

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -28,6 +28,8 @@
           "features/scheduled-tasks",
           "features/cowork",
           "features/connect-mcps",
+          "features/skills",
+          "features/smart-nudges",
           "features/use-with-claude-code",
           "features/soul",
           "features/memory",

--- a/docs/features/connect-mcps.mdx
+++ b/docs/features/connect-mcps.mdx
@@ -18,26 +18,29 @@ BrowserOS uses the [Model Context Protocol (MCP)](https://modelcontextprotocol.i
 
 ## Smart App Connection
 
-When you ask the assistant to do something that needs an app you have not connected yet, it will detect this automatically and guide you through signing in, right in the conversation. No need to set things up in advance. You only sign in once per app, and it stays connected for future requests.
+When you ask the assistant to do something that needs an app you have not connected yet, it shows an interactive card right in the conversation. You can connect the app with one click or choose to skip it. No need to set things up in advance.
 
 <Steps>
   <Step title="You make a request">
     Ask the assistant something like "What's on my calendar today?" or "Send an email to Sarah."
   </Step>
-  <Step title="The assistant detects the app is not connected">
-    If you have not signed into that app yet, the assistant opens a sign-in page in your browser.
+  <Step title="A connection card appears">
+    The assistant detects the app is not connected and shows a card explaining why connecting it would help. You get two choices: **Connect** or **Do it manually**.
   </Step>
-  <Step title="You sign in once">
-    Complete the OAuth sign-in. Your credentials are never stored in BrowserOS.
+  <Step title="You connect or skip">
+    - **Connect**: Opens a sign-in page. Authorize the app and the assistant continues with full integration access.
+    - **Do it manually**: The assistant skips the integration and navigates to the app's website directly using browser automation.
   </Step>
-  <Step title="The assistant continues where it left off">
-    Once you confirm you are signed in, the assistant picks up right where it stopped and completes your request.
+  <Step title="The assistant continues">
+    Once connected, the app stays linked for all future conversations. If you chose to skip, the assistant remembers and will not ask again.
   </Step>
 </Steps>
 
-{/* <Frame caption="The assistant detects an unconnected app and opens the sign-in page">
+{/* <Frame caption="The assistant detects an unconnected app and shows a connection card">
   <img src="/images/connect-apps-smart-connection.png" alt="Smart app connection prompt in chat" />
 </Frame> */}
+
+See [Smart Nudges](/features/smart-nudges#app-connection) for more details on how connection suggestions work.
 
 You can also connect apps ahead of time from Settings if you prefer.
 

--- a/docs/features/scheduled-tasks.mdx
+++ b/docs/features/scheduled-tasks.mdx
@@ -15,6 +15,20 @@ Watch how to set up a scheduled task from scratch:
 
 ## Creating a Scheduled Task
 
+There are two ways to create a scheduled task: from a conversation or from the settings page.
+
+### From a conversation
+
+After the agent completes a task that could run on a schedule, it will suggest scheduling it with an interactive card. You can also ask directly:
+
+- "Schedule this to run every morning"
+- "Can this run daily at 8am?"
+- "Automate this task"
+
+The agent fills in the task details for you. Just review and confirm. See [Smart Nudges](/features/smart-nudges#schedule-suggestion) for more details.
+
+### From settings
+
 <Steps>
   <Step title="Open Scheduled Tasks">
     Go to **Scheduled Tasks** in the sidebar, or find it under **Settings**.

--- a/docs/features/skills.mdx
+++ b/docs/features/skills.mdx
@@ -1,0 +1,193 @@
+---
+title: "Skills"
+description: "Teach your BrowserOS agent new abilities with reusable, custom instructions"
+---
+
+Skills let you teach the BrowserOS agent how to handle specific tasks. Each skill is a set of instructions written in plain Markdown that the agent loads when it recognizes a matching task. Think of skills as recipes: you write the steps once, and the agent follows them whenever that type of task comes up.
+
+BrowserOS implements the open [Agent Skills specification](https://agentskills.io/specification), so skills you create are portable across any AI agent that supports the standard.
+
+## How Skills Work
+
+<Steps>
+  <Step title="You create a skill">
+    Give it a name, a short description of when to use it, and write the instructions in Markdown.
+  </Step>
+  <Step title="The agent sees the skill catalog">
+    When a conversation starts, the agent loads a list of all your enabled skills with their names and descriptions.
+  </Step>
+  <Step title="The agent matches a task">
+    When your request matches a skill's description, the agent loads that skill's full instructions and follows them.
+  </Step>
+</Steps>
+
+## Creating a Skill
+
+<Steps>
+  <Step title="Open Skills settings">
+    Go to **Settings** and click **Skills** in the sidebar.
+  </Step>
+  <Step title="Click New Skill">
+    Click the **New Skill** button to open the creation form.
+  </Step>
+  <Step title="Fill in the details">
+    - **Name**: A short, descriptive name (e.g., "Morning Status Report")
+    - **Description**: Tell the agent when to use this skill. Be specific. For example: "When the user wants to read status updates from work across Notion, Linear, and Slack"
+    - **Content**: Write your instructions in Markdown. Include step-by-step directions, examples, and edge cases.
+  </Step>
+  <Step title="Save and enable">
+    Click **Create**. The skill is enabled by default and will be available to the agent immediately.
+  </Step>
+</Steps>
+
+<Tip>
+Write your description like a trigger. The agent uses it to decide whether to activate the skill. A good description says both **what** the skill does and **when** to use it.
+</Tip>
+
+## Example Skills
+
+<AccordionGroup>
+  <Accordion title="Morning status report">
+    **Description:** When the user wants to read status updates from work
+
+    **Instructions:**
+    ```markdown
+    Always look for updates in 3 sources:
+    1. **Notion** - Check the team updates page for any new entries from today
+    2. **Linear** - Look at issues assigned to the user that were updated in the last 24 hours
+    3. **Slack** - Check the #team-updates and #engineering channels for unread messages
+
+    Summarize everything in a single report grouped by source.
+    If a source has no updates, say so.
+    ```
+  </Accordion>
+
+  <Accordion title="PDF processing">
+    **Description:** Extract text and tables from PDF files, fill PDF forms, and merge multiple PDFs. Use when the user mentions PDFs, forms, or document extraction.
+
+    **Instructions:**
+    ```markdown
+    When extracting text from a PDF:
+    1. Download or open the PDF in the browser
+    2. Use the page content tool to extract visible text
+    3. Preserve table structure using Markdown tables
+    4. If the PDF has multiple pages, process each page
+
+    When filling a PDF form:
+    - Ask the user for the values if not provided
+    - Fill each field carefully and confirm before submitting
+
+    See references/FORMS.md for common form templates.
+    ```
+  </Accordion>
+
+  <Accordion title="Code review checklist">
+    **Description:** When the user asks to review code, a pull request, or wants feedback on code quality
+
+    **Instructions:**
+    ```markdown
+    Follow this checklist for every code review:
+    1. Check for security issues (XSS, injection, hardcoded secrets)
+    2. Look for performance problems (N+1 queries, unnecessary re-renders)
+    3. Verify error handling is present and meaningful
+    4. Check that naming is clear and consistent
+    5. Look for missing tests for new logic
+
+    Format your review as a list of findings with severity: Critical, Warning, or Suggestion.
+    Always start with what the code does well.
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## Managing Skills
+
+From the Skills settings page, you can:
+
+- **Enable or disable** a skill using the toggle switch. Disabled skills are not loaded by the agent.
+- **Edit** a skill's name, description, or instructions by clicking the edit icon.
+- **Delete** a skill by clicking the trash icon. This removes the skill permanently.
+
+## Skill File Format
+
+Under the hood, each skill is stored as a `SKILL.md` file following the [Agent Skills specification](https://agentskills.io/specification):
+
+```markdown
+---
+name: morning-status-report
+description: When the user wants to read status updates from work
+metadata:
+  display-name: Morning Status Report
+  enabled: "true"
+---
+Always look for updates in 3 sources:
+1. Notion - Check the team updates page
+2. Linear - Look at assigned issues updated in the last 24 hours
+3. Slack - Check #team-updates and #engineering channels
+
+Summarize everything in a single report grouped by source.
+```
+
+The file uses YAML frontmatter for metadata and Markdown for the instructions.
+
+### Frontmatter fields
+
+| Field | Required | Description |
+|---|---|---|
+| `name` | Yes | Lowercase, hyphenated identifier (e.g., `morning-status-report`) |
+| `description` | Yes | When and how the agent should use this skill |
+| `license` | No | License for the skill |
+| `compatibility` | No | Environment requirements |
+| `metadata` | No | Extra fields like `display-name`, `enabled`, `version` |
+| `allowed-tools` | No | Restrict which tools the skill can use (experimental) |
+
+### Supporting files
+
+A skill can include additional directories alongside `SKILL.md`:
+
+- **`scripts/`** for executable code the agent can run
+- **`references/`** for detailed documentation loaded on demand
+- **`assets/`** for templates, images, or data files
+
+```
+morning-status-report/
+├── SKILL.md
+├── scripts/
+│   └── format-report.py
+└── references/
+    └── REFERENCE.md
+```
+
+The agent loads the main `SKILL.md` first. Supporting files are only loaded when the instructions reference them, keeping context usage efficient.
+
+## Where Skills Live
+
+Skills are stored as folders inside your BrowserOS configuration directory:
+
+| OS | Path |
+|---|---|
+| macOS | `~/.browseros/skills/` |
+| Windows | `%USERPROFILE%\.browseros\skills\` |
+| Linux | `~/.browseros/skills/` |
+
+Each skill gets its own folder named after the skill's `name` field.
+
+## Tips for Writing Good Skills
+
+<CardGroup cols={2}>
+  <Card title="Be specific in descriptions" icon="crosshairs">
+    Include keywords the agent can match against. "When the user asks about PDFs, forms, or document extraction" is better than "Helps with documents."
+  </Card>
+  <Card title="Keep instructions focused" icon="scissors">
+    A skill should do one thing well. Split complex workflows into multiple skills rather than one large one.
+  </Card>
+  <Card title="Include examples" icon="lightbulb">
+    Show the agent what good output looks like. Examples reduce ambiguity and improve results.
+  </Card>
+  <Card title="Use supporting files" icon="folder-tree">
+    Move detailed references to separate files. The agent loads them only when needed, saving context space.
+  </Card>
+</CardGroup>
+
+<Note>
+Skills follow the open [Agent Skills specification](https://agentskills.io/specification). Skills you create in BrowserOS work with any agent that supports the standard.
+</Note>

--- a/docs/features/smart-nudges.mdx
+++ b/docs/features/smart-nudges.mdx
@@ -1,0 +1,117 @@
+---
+title: "Smart Nudges"
+description: "BrowserOS suggests app connections and task scheduling at the right moment"
+---
+
+Smart Nudges are context-aware suggestions that appear as interactive cards during a conversation. The agent detects opportunities to connect an app or schedule a task, and shows you a card at the right moment. You decide whether to act on it or skip it.
+
+There are two types of nudges: **App Connection** and **Schedule Suggestion**.
+
+## App Connection
+
+When you ask the agent to do something that involves an external app (like sending an email or checking your calendar), it checks whether that app is connected. If it is not, the agent shows a connection card before starting the task.
+
+<Steps>
+  <Step title="You make a request">
+    For example: "Send Sarah an email with the meeting notes."
+  </Step>
+  <Step title="The agent detects an unconnected app">
+    Gmail is not connected yet, so the agent cannot send emails through the integration.
+  </Step>
+  <Step title="A connection card appears">
+    The card explains why connecting the app would help and gives you two choices: **Connect** or **Do it manually**.
+  </Step>
+  <Step title="You choose">
+    - **Connect**: Opens a sign-in page for the app. Once you authorize, the agent continues with full integration access.
+    - **Do it manually**: The agent skips the integration and uses browser automation instead (navigates to the website directly).
+  </Step>
+</Steps>
+
+### What happens after you choose
+
+<CardGroup cols={2}>
+  <Card title="Connected" icon="circle-check">
+    The app is added to your connected list. The agent uses the integration for this and all future conversations. You can manage connected apps in [Connect Apps](/features/connect-mcps).
+  </Card>
+  <Card title="Declined" icon="forward">
+    The agent remembers your choice and will not ask about this app again. It uses browser automation to complete the task instead.
+  </Card>
+</CardGroup>
+
+<Tip>
+If you declined an app but change your mind later, you can connect it anytime from the [Connect Apps](/features/connect-mcps) settings page.
+</Tip>
+
+### Supported apps
+
+The agent can suggest connections for all 40+ built-in integrations, including Gmail, Google Calendar, Slack, Notion, GitHub, Linear, Jira, Figma, Salesforce, and many more. See [Connect Apps](/features/connect-mcps) for the full list.
+
+## Schedule Suggestion
+
+After the agent completes a task that could run on a recurring schedule, it shows a scheduling card. This helps you turn one-time tasks into automated routines without leaving the conversation.
+
+<Steps>
+  <Step title="The agent completes a task">
+    For example: "Here are the top 5 tech headlines from today."
+  </Step>
+  <Step title="The agent recognizes a schedulable task">
+    News gathering, price monitoring, report building, data tracking, and similar tasks that do not need your real-time input are good candidates.
+  </Step>
+  <Step title="A scheduling card appears">
+    The card suggests a name and schedule. For example: "Run this automatically? 'Morning News Briefing' - daily at 09:00."
+  </Step>
+  <Step title="You choose">
+    - **Schedule this task**: Opens the Scheduled Tasks page with the details pre-filled. Review and confirm to create the task.
+    - **Maybe later**: Dismisses the card. You can always create the scheduled task manually later.
+  </Step>
+</Steps>
+
+### You can also ask directly
+
+You do not have to wait for the agent to suggest it. Just tell the agent you want to schedule the task:
+
+<AccordionGroup>
+  <Accordion title="Example prompts" icon="message">
+    - "Schedule this to run every morning"
+    - "Can this run daily at 8am?"
+    - "Automate this task"
+    - "Run this every hour"
+
+    The agent will infer the task name, schedule type, and timing from your conversation and show the scheduling card immediately.
+  </Accordion>
+</AccordionGroup>
+
+### What gets scheduled
+
+The scheduling card pre-fills the [Scheduled Tasks](/features/scheduled-tasks) dialog with:
+
+- **Task name**: A short description based on the conversation
+- **Prompt**: The original query you asked the agent
+- **Schedule type**: Daily or hourly, based on what makes sense for the task
+- **Time**: A suggested time (for daily tasks)
+
+You can adjust any of these before confirming.
+
+## When Nudges Appear
+
+Nudges are designed to appear at the right moment without interrupting your workflow:
+
+| Nudge | When it appears | How often |
+|---|---|---|
+| App Connection | Before the agent starts working, when it detects an unconnected app | Once per app per conversation |
+| Schedule Suggestion | After the agent finishes a task that could be automated | Once per conversation |
+
+Nudges do not appear in:
+- **Scheduled tasks** running in the background
+- **Chat mode** (read-only, no browser automation)
+
+## Privacy
+
+<CardGroup cols={2}>
+  <Card title="Nothing is sent without your approval" icon="shield-check">
+    The agent only suggests a connection. No data is shared with the app until you explicitly authorize it.
+  </Card>
+  <Card title="Your choices are remembered locally" icon="hard-drive">
+    Declined apps are stored on your device. The agent will not ask about them again unless you reconnect from settings.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
This pull request expands the BrowserOS documentation to cover new features and improves clarity around app connection and task scheduling workflows. The main additions are new docs for Skills and Smart Nudges, and updates to existing pages to reference these features and explain their integration with the agent.

New feature documentation:

* Added a new `features/skills` page describing how to create, manage, and use Skills to teach the agent custom tasks, following the Agent Skills specification. Includes examples, file format details, and writing tips.
* Added a new `features/smart-nudges` page explaining Smart Nudges—context-aware cards that suggest app connections or task scheduling during conversations. Covers both app connection and schedule suggestion nudges, their workflow, supported apps, and privacy.

Enhancements to app connection and scheduling documentation:

* Updated `features/connect-mcps` to clarify the app connection workflow, replacing the old sign-in flow with interactive connection cards and referencing Smart Nudges for further details.
* Updated `features/scheduled-tasks` to explain both conversation-based and settings-based task scheduling, and to reference Smart Nudges for schedule suggestions.

Navigation updates:

* Added `features/skills` and `features/smart-nudges` to the documentation navigation structure in `docs.json` for discoverability.