### PR TITLE
feat: add missing patches and split sparkle in features.yaml

### DIFF
--- a/packages/browseros/build/features.yaml
+++ b/packages/browseros/build/features.yaml
@@ -103,7 +103,7 @@ features:
       - chrome/browser/upgrade_detector/upgrade_detector_impl.cc
 
   sparkle-third-party:
-    description: "test: sparkle third party framework (downloaded on-the-fly)"
+    description: "feat: sparkle third party framework (downloaded on-the-fly)"
     files:
       - third_party/sparkle/
 


### PR DESCRIPTION
## Summary
- Add 37 missing patch files from `chromium_patches/` to `features.yaml` across 3 new features (`cdp-api`, `vertical-tabs`, `crash-reporter`) and 3 existing features (`chromium-ui-fixes`, `side-panel-fixes`, `first-run`)
- Split `third_party/sparkle/` from `mac-sparkle-updater` into its own `sparkle-third-party` feature since it's downloaded on-the-fly during build

## Design
Direct reconciliation of `chromium_patches/` directory contents against `features.yaml` manifest. New features are categorized by layer: crash-reporter in Layer 2 (platform patches), cdp-api and vertical-tabs in Layer 4 (features), sparkle-third-party in Layer 3 (infrastructure).

## Test plan
- [ ] Verify `features.yaml` parses correctly (valid YAML)
- [ ] Confirm all files in `chromium_patches/` are accounted for in `features.yaml`
- [ ] Run patch application pipeline to ensure no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)