### PR TITLE
feat: docs update for new settings

### DIFF
--- a/docs/features/connect-mcps.mdx
+++ b/docs/features/connect-mcps.mdx
@@ -42,13 +42,13 @@ When you ask the assistant to do something that needs an app you have not connec
 
 See [Smart Nudges](/features/smart-nudges#app-connection) for more details on how connection suggestions work.
 
-You can also connect apps ahead of time from Settings if you prefer.
+You can also connect apps ahead of time from the sidebar if you prefer.
 
-## Connect from Settings
+## Connect from the Sidebar
 
 <Steps>
-  <Step title="Open Connected Apps">
-    Go to **Settings > Connected Apps**
+  <Step title="Open Connect Apps">
+    Click **Connect Apps** in the sidebar.
   </Step>
   <Step title="Add an app">
     Click **Add built-in app** and select the app you want

--- a/docs/features/scheduled-tasks.mdx
+++ b/docs/features/scheduled-tasks.mdx
@@ -31,7 +31,7 @@ The agent fills in the task details for you. Just review and confirm. See [Smart
 
 <Steps>
   <Step title="Open Scheduled Tasks">
-    Go to **Scheduled Tasks** in the sidebar, or find it under **Settings**.
+    Click **Scheduled Tasks** in the sidebar.
   </Step>
   <Step title="Click New Task">
     Click the **New Task** button to open the creation dialog.

--- a/docs/features/skills.mdx
+++ b/docs/features/skills.mdx
@@ -25,7 +25,7 @@ BrowserOS implements the open [Agent Skills specification](https://agentskills.i
 
 <Steps>
   <Step title="Open Skills settings">
-    Go to **Settings** and click **Skills** in the sidebar.
+    Click **Skills** in the sidebar.
   </Step>
   <Step title="Click New Skill">
     Click the **New Skill** button to open the creation form.
@@ -101,7 +101,7 @@ Write your description like a trigger. The agent uses it to decide whether to ac
 
 ## Managing Skills
 
-From the Skills settings page, you can:
+From the Skills page, you can:
 
 - **Enable or disable** a skill using the toggle switch. Disabled skills are not loaded by the agent.
 - **Edit** a skill's name, description, or instructions by clicking the edit icon.

--- a/docs/features/soul.mdx
+++ b/docs/features/soul.mdx
@@ -39,7 +39,7 @@ You do not need to write or edit SOUL.md yourself. The assistant handles it. But
 
 ## Viewing Your SOUL.md
 
-Open **Settings > Agent Soul** to see what your assistant's personality file looks like right now. The page shows the current contents of SOUL.md in a read-only viewer.
+Open **Agent Soul** from the sidebar to see what your assistant's personality file looks like right now. The page shows the current contents of SOUL.md in a read-only viewer.
 
 {/* <Frame caption="View your assistant's personality in Settings">
   <img src="/images/features/soul-settings.png" alt="Agent Soul settings page" />


### PR DESCRIPTION
This pull request updates the documentation to reflect recent changes in the user interface, specifically around navigation and where to access key features. The main focus is on clarifying that several features are now accessed directly from the sidebar, rather than through the Settings menu, to better match the current UI and improve user guidance.

Navigation and UI documentation updates:

* Updated instructions in multiple feature docs (`connect-mcps.mdx`, `scheduled-tasks.mdx`, `skills.mdx`, `soul.mdx`) to indicate that users should now access "Connect Apps", "Scheduled Tasks", "Skills", and "Agent Soul" directly from the sidebar instead of through Settings. [[1]](diffhunk://#diff-687a40ad7e798562bf23af4edb40bfe79e904cead8a2989bf55d8e5e43aa049fL45-R51) [[2]](diffhunk://#diff-71d7b18c7901ab0f1f0e2ade135229e52ebe82f92a7dcb8ea0e417e4ce91c824L34-R34) [[3]](diffhunk://#diff-6c1973248dc6915ecc3ee839200536101dd9f830b63b14c2dc82a96a4ff9440dL28-R28) [[4]](diffhunk://#diff-cb2766cfb9317c10d5a93f4266ae318f5c7474c95f931f55969dbb7b13f61d38L42-R42)
* Adjusted descriptive text in the skills documentation to refer to the "Skills page" instead of "Skills settings page", aligning terminology with the updated navigation.