### PR TITLE
fix: use BookOpen icon for Docs button in settings sidebar

### DIFF
--- a/packages/browseros-agent/apps/agent/components/sidebar/SettingsSidebar.tsx
+++ b/packages/browseros-agent/apps/agent/components/sidebar/SettingsSidebar.tsx
@@ -1,9 +1,9 @@
 import {
   ArrowLeft,
+  BookOpen,
   Bot,
   Compass,
   GitBranch,
-  Info,
   MessageSquare,
   Palette,
   RotateCcw,
@@ -90,7 +90,7 @@ const primarySettingsSections: NavSection[] = [
 ]
 
 const helpItems: NavItem[] = [
-  { name: 'Docs', href: 'https://docs.browseros.com/', icon: Info },
+  { name: 'Docs', href: 'https://docs.browseros.com/', icon: BookOpen },
   { name: 'Features', to: '/onboarding/features', icon: Compass },
   { name: 'Revisit Onboarding', to: '/onboarding', icon: RotateCcw },
 ]


### PR DESCRIPTION
## Summary
- Changed the Docs button icon in the settings sidebar from `Info` (circle with "i") to `BookOpen`, which is the standard icon for documentation links

## Test plan
- [ ] Open settings sidebar and verify the Docs icon displays as a book icon
- [ ] Verify the Docs link still opens https://docs.browseros.com/

🤖 Generated with [Claude Code](https://claude.com/claude-code)