### PR TITLE
fix: detect custom clickable elements in take_snapshot

### DIFF
--- a/packages/browseros-agent/apps/server/src/browser/browser.ts
+++ b/packages/browseros-agent/apps/server/src/browser/browser.ts
@@ -389,7 +389,30 @@ export class Browser {
     const session = await this.resolveSession(page)
     const nodes = await this.fetchAXTree(session)
     if (nodes.length === 0) return ''
-    return snapshot.buildInteractiveTree(nodes).join('\n')
+
+    const lines = snapshot.buildInteractiveTree(nodes)
+
+    try {
+      const cursorElements =
+        await snapshot.findCursorInteractiveElements(session)
+
+      if (cursorElements.length > 0) {
+        const includedIds = new Set<number>()
+        for (const line of lines) {
+          const match = line.match(/^\[(\d+)\]/)
+          if (match) includedIds.add(Number(match[1]))
+        }
+
+        for (const el of cursorElements) {
+          if (includedIds.has(el.backendNodeId)) continue
+          lines.push(`[${el.backendNodeId}] clickable "${el.text}"`)
+        }
+      }
+    } catch {
+      // cursor detection is best-effort; AX tree results are still returned
+    }
+
+    return lines.join('\n')
   }
 
   async getPageLinks(
@@ -441,15 +464,15 @@ export class Browser {
         await snapshot.findCursorInteractiveElements(session)
 
       if (cursorElements.length > 0) {
-        const existingIds = new Set<number>()
-        for (const node of nodes) {
-          if (node.backendDOMNodeId !== undefined)
-            existingIds.add(node.backendDOMNodeId)
+        const includedIds = new Set<number>()
+        for (const line of treeLines) {
+          const match = line.match(/\[(\d+)\]/)
+          if (match) includedIds.add(Number(match[1]))
         }
 
         const extras: string[] = []
         for (const el of cursorElements) {
-          if (existingIds.has(el.backendNodeId)) continue
+          if (includedIds.has(el.backendNodeId)) continue
           extras.push(
             `[${el.backendNodeId}] clickable "${el.text}" (${el.reasons.join(', ')})`,
           )

--- a/packages/browseros-agent/apps/server/src/browser/snapshot.ts
+++ b/packages/browseros-agent/apps/server/src/browser/snapshot.ts
@@ -41,6 +41,7 @@ const INTERACTIVE_ROLES = new Set([
   'option',
   'treeitem',
   'listbox',
+  'DisclosureTriangle',
 ])
 
 const NAMED_CONTENT_ROLES = new Set([
@@ -196,6 +197,7 @@ const CURSOR_INTERACTIVE_JS = `(function() {
 			if (parent && getComputedStyle(parent).cursor === 'pointer') continue;
 		}
 		var text = (el.textContent || '').trim().slice(0, 100);
+		if (!text) text = (el.getAttribute('aria-label') || '').trim();
 		if (!text) continue;
 		var rect = el.getBoundingClientRect();
 		if (rect.width === 0 || rect.height === 0) continue;


### PR DESCRIPTION
## Summary
- Merges cursor-interactive detection (cursor:pointer, onclick, tabindex) into `take_snapshot` so the agent sees custom components — upvote buttons, dropdown triggers, clickable cards, etc.
- Adds `DisclosureTriangle` to `INTERACTIVE_ROLES` so `<summary>` elements are captured
- Uses `aria-label` as text fallback in cursor detection for icon-only buttons (e.g. close ✕)
- Fixes dedup bug in `enhancedSnapshot` that silently dropped all cursor-detected elements

## Before → After
`take_snapshot` on a page with custom components:

**Before** (16/31 elements):
```
[16] button "Standard Button"
[17] link "Standard Link"
[1]  textbox "Email"
```

**After** (28/31 elements — adds cursor-detected elements):
```
[16] button "Standard Button"
[17] link "Standard Link"
[1]  textbox "Email"
[38] DisclosureTriangle "Expand me" (collapsed)
[52] clickable "Clickable Div"
[58] clickable "▲ 42"
[62] clickable "Select option ▾"
[63] clickable "Dark mode"
```

## Test plan
- [x] Live CDP test: all standard HTML, ARIA, and custom elements detected
- [x] Verified `DisclosureTriangle` captures `<summary>` elements
- [x] Verified `aria-label` fallback captures icon-only buttons
- [x] Verified dedup fix: cursor elements no longer silently dropped
- [x] Full server pipeline test via chat API confirmed all elements visible
- [x] Typecheck passes