### PR TITLE
fix: issue with fill tool

### DIFF
--- a/packages/browseros-agent/apps/server/src/browser/browser.ts
+++ b/packages/browseros-agent/apps/server/src/browser/browser.ts
@@ -798,25 +798,43 @@ export class Browser {
 
     await elements.scrollIntoView(session, element)
 
+    // Always click to guarantee real keyboard focus.
+    // DOM.focus() is unreliable for shadow DOM, iframes, and custom components.
     let coords: { x: number; y: number } | undefined
     try {
-      await elements.focusElement(session, element)
-      try {
-        coords = await elements.getElementCenter(session, element)
-      } catch {
-        // coordinates are best-effort
-      }
+      const { x, y } = await elements.getElementCenter(session, element)
+      await mouse.dispatchClick(session, x, y, 'left', 1, 0)
+      coords = { x, y }
     } catch {
+      // Fallback to DOM.focus() if we can't get coordinates
       try {
-        const { x, y } = await elements.getElementCenter(session, element)
-        await mouse.dispatchClick(session, x, y, 'left', 1, 0)
-        coords = { x, y }
+        await elements.focusElement(session, element)
       } catch {
-        logger.warn('Could not focus element via click either')
+        logger.warn('Could not focus element via click or DOM.focus()')
       }
     }
 
-    if (clear) await keyboard.clearField(session)
+    if (clear) {
+      // Primary: keyboard select-all + backspace
+      await keyboard.clearField(session)
+
+      // Fallback: if field still has content, triple-click to select all
+      // then typeText will overwrite the selection
+      if (coords) {
+        const value = await elements.getInputValue(session, element)
+        if (value) {
+          await mouse.dispatchClick(
+            session,
+            coords.x,
+            coords.y,
+            'left',
+            3,
+            0,
+          )
+        }
+      }
+    }
+
     await keyboard.typeText(session, text)
     return coords
   }

--- a/packages/browseros-agent/apps/server/src/browser/elements.ts
+++ b/packages/browseros-agent/apps/server/src/browser/elements.ts
@@ -94,6 +94,23 @@ export async function resolveObjectId(
   return objectId
 }
 
+/** Read the current value/textContent of an input, textarea, or contenteditable element. */
+export async function getInputValue(
+  session: ProtocolApi,
+  backendNodeId: number,
+): Promise<string> {
+  try {
+    const value = await callOnElement(
+      session,
+      backendNodeId,
+      'function(){return this.value??this.textContent??""}',
+    )
+    return (value as string) ?? ''
+  } catch {
+    return ''
+  }
+}
+
 export async function callOnElement(
   session: ProtocolApi,
   backendNodeId: number,

--- a/packages/browseros-agent/apps/server/src/browser/keyboard.ts
+++ b/packages/browseros-agent/apps/server/src/browser/keyboard.ts
@@ -1,4 +1,8 @@
+import { platform } from 'node:os'
 import type { ProtocolApi } from '@browseros/cdp-protocol/protocol-api'
+
+// Meta (Cmd) on macOS, Control on everything else
+const PLATFORM_MODIFIER = platform() === 'darwin' ? 4 : 2
 
 type KeyInfo = { code: string; keyCode: number | undefined }
 
@@ -180,31 +184,33 @@ export async function typeText(
 }
 
 export async function clearField(session: ProtocolApi): Promise<void> {
+  // Select all: Cmd+A on macOS, Ctrl+A on others
   await session.Input.dispatchKeyEvent({
     type: 'keyDown',
     key: 'a',
     code: 'KeyA',
-    modifiers: 2,
+    modifiers: PLATFORM_MODIFIER,
     windowsVirtualKeyCode: 65,
   })
   await session.Input.dispatchKeyEvent({
     type: 'keyUp',
     key: 'a',
     code: 'KeyA',
-    modifiers: 2,
+    modifiers: PLATFORM_MODIFIER,
     windowsVirtualKeyCode: 65,
   })
+  // Backspace to delete selection (more reliable cross-platform than Delete)
   await session.Input.dispatchKeyEvent({
     type: 'keyDown',
-    key: 'Delete',
-    code: 'Delete',
-    windowsVirtualKeyCode: 46,
+    key: 'Backspace',
+    code: 'Backspace',
+    windowsVirtualKeyCode: 8,
   })
   await session.Input.dispatchKeyEvent({
     type: 'keyUp',
-    key: 'Delete',
-    code: 'Delete',
-    windowsVirtualKeyCode: 46,
+    key: 'Backspace',
+    code: 'Backspace',
+    windowsVirtualKeyCode: 8,
   })
 }
 


### PR DESCRIPTION
This pull request improves the reliability and cross-platform compatibility of input field interactions in the browser automation agent. The main changes ensure that input fields are properly focused and cleared before typing, with robust fallbacks for different browser and OS behaviors.

**Input field focus and clearing improvements:**

* The `Browser` class now always clicks on elements to guarantee real keyboard focus, as `DOM.focus()` can be unreliable for shadow DOM, iframes, and custom components. If clicking fails, it falls back to `DOM.focus()`. When clearing a field, it first tries keyboard select-all and backspace, then (if needed) triple-clicks to select all before typing, ensuring the field is empty before input. (`browser.ts`)

* A new `getInputValue` function was added to reliably read the current value or text content of input, textarea, or contenteditable elements, used to verify if clearing was successful. (`elements.ts`)

**Cross-platform keyboard handling enhancements:**

* The keyboard module now detects the OS and uses Cmd+A for select-all on macOS and Ctrl+A elsewhere, making field clearing work correctly across platforms. (`keyboard.ts`) [[1]](diffhunk://#diff-ddaf805fdf558a9f2a5cf4966f7c80f3fcc65b8142f2c70cd17af74049c35b02R1-R6) [[2]](diffhunk://#diff-ddaf805fdf558a9f2a5cf4966f7c80f3fcc65b8142f2c70cd17af74049c35b02R187-R213)

* The field-clearing logic now uses Backspace instead of Delete to remove selected text, as Backspace is more reliable across different platforms. (`keyboard.ts`)