### PR TITLE
feat: use cache key to persist klavis client

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/routes/chat.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/chat.ts
@@ -16,16 +16,16 @@ import { ConversationIdParamSchema } from '../utils/validation'
 interface ChatRouteDeps {
   browser: Browser
   registry: ToolRegistry
+  klavisClient: KlavisClient
   browserosId?: string
   rateLimiter?: RateLimiter
   aiSdkDevtoolsEnabled?: boolean
 }
 
 export function createChatRoutes(deps: ChatRouteDeps) {
-  const { browserosId, rateLimiter } = deps
+  const { browserosId, rateLimiter, klavisClient } = deps
 
   const sessionStore = new SessionStore()
-  const klavisClient = new KlavisClient()
   const service = new ChatService({
     sessionStore,
     klavisClient,

--- a/packages/browseros-agent/apps/server/src/api/routes/klavis.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/klavis.ts
@@ -17,6 +17,7 @@ const ServerNameSchema = z.object({
 
 interface KlavisRouteDeps {
   browserosId: string
+  klavisClient: KlavisClient
 }
 
 const normalizeServerKey = (value: string): string =>
@@ -43,8 +44,7 @@ const getAuthUrlForServer = (
 }
 
 export function createKlavisRoutes(deps: KlavisRouteDeps) {
-  const { browserosId } = deps
-  const klavisClient = new KlavisClient()
+  const { browserosId, klavisClient } = deps
 
   // Chain route definitions for proper Hono RPC type inference
   return new Hono()
@@ -124,6 +124,7 @@ export function createKlavisRoutes(deps: KlavisRouteDeps) {
 
       logger.info('Adding server to strata', { serverName })
 
+      klavisClient.invalidateStrataCache(browserosId)
       const result = await klavisClient.createStrata(browserosId, [serverName])
 
       return c.json({
@@ -154,6 +155,7 @@ export function createKlavisRoutes(deps: KlavisRouteDeps) {
 
         try {
           await klavisClient.submitApiKey(apiKeyUrl, apiKey)
+          klavisClient.invalidateStrataCache(browserosId)
 
           logger.info('Submitted API key for server', { serverName })
 
@@ -185,6 +187,7 @@ export function createKlavisRoutes(deps: KlavisRouteDeps) {
         logger.info('Removing server from strata', { serverName })
 
         await klavisClient.removeServer(browserosId, serverName)
+        klavisClient.invalidateStrataCache(browserosId)
 
         return c.json({
           success: true,

--- a/packages/browseros-agent/apps/server/src/api/server.ts
+++ b/packages/browseros-agent/apps/server/src/api/server.ts
@@ -75,12 +75,15 @@ export async function createHttpServer(config: HttpServerConfig) {
 
   const { onShutdown } = config
 
+  // Single KlavisClient shared across all routes for cache effectiveness
+  const klavisClient = new KlavisClient()
+
   // Connect Klavis proxy (non-blocking: browser tools still work if this fails)
   let klavisProxy: KlavisProxyHandle | null = null
   if (browserosId) {
     try {
       klavisProxy = await connectKlavisProxy({
-        klavisClient: new KlavisClient(),
+        klavisClient,
         browserosId,
       })
     } catch (error) {
@@ -115,7 +118,7 @@ export async function createHttpServer(config: HttpServerConfig) {
     .route('/skills', createSkillsRoutes())
     .route('/test-provider', createProviderRoutes())
     .route('/refine-prompt', createRefinePromptRoutes())
-    .route('/klavis', createKlavisRoutes({ browserosId: browserosId || '' }))
+    .route('/klavis', createKlavisRoutes({ browserosId: browserosId || '', klavisClient }))
     .route(
       '/mcp',
       createMcpRoutes({
@@ -132,6 +135,7 @@ export async function createHttpServer(config: HttpServerConfig) {
       createChatRoutes({
         browser,
         registry,
+        klavisClient,
         browserosId,
         rateLimiter,
         aiSdkDevtoolsEnabled: config.aiSdkDevtoolsEnabled,

--- a/packages/browseros-agent/apps/server/src/lib/clients/klavis/klavis-client.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/klavis/klavis-client.ts
@@ -196,4 +196,13 @@ export class KlavisClient {
     )
     this.strataCache.delete(this.buildStrataCacheKey(userId, [serverName]))
   }
+
+  /** Clear all cached Strata entries for a user (call after auth changes). */
+  invalidateStrataCache(userId: string): void {
+    for (const key of this.strataCache.keys()) {
+      if (key.startsWith(`["${userId}"`)) {
+        this.strataCache.delete(key)
+      }
+    }
+  }
 }


### PR DESCRIPTION
This pull request adds caching and request deduplication to the `createStrata` method in the `KlavisClient` class to improve efficiency and prevent redundant network calls. Now, repeated or concurrent requests for the same user and server combination within a 5-minute window will return cached results or share the same in-flight request.

Caching and deduplication improvements:

* Added a `strataCache` with a 5-minute TTL to store `StrataCreateResponse` objects, preventing unnecessary API calls for the same `(userId, servers)` combination. [[1]](diffhunk://#diff-69d976e23db083969e85f761096179d562508faccc8bbd8dafe156b80c098b14R31-R49) [[2]](diffhunk://#diff-69d976e23db083969e85f761096179d562508faccc8bbd8dafe156b80c098b14L80-R129)
* Implemented a `pendingRequests` map to deduplicate concurrent requests for the same key, ensuring only one network request is made and shared among callers. [[1]](diffhunk://#diff-69d976e23db083969e85f761096179d562508faccc8bbd8dafe156b80c098b14R31-R49) [[2]](diffhunk://#diff-69d976e23db083969e85f761096179d562508faccc8bbd8dafe156b80c098b14L80-R129)
* Introduced a cache key generation method (`buildStrataCacheKey`) that uniquely identifies requests by `userId` and a sorted list of servers.
* Updated the `createStrata` method to use the new caching and deduplication logic, and to clean up pending requests after completion or error.