### PR TITLE
fix: ChatGPT Pro UI polish — fix undefined display and add icon

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
@@ -104,7 +104,9 @@ export const ProviderCard: FC<ProviderCardProps> = ({
               </>
             )
           ) : (
-            `${provider.modelId} • ${provider.baseUrl}`
+            provider.baseUrl
+              ? `${provider.modelId} • ${provider.baseUrl}`
+              : provider.modelId
           )}
         </p>
       </div>

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/providerIcons.tsx
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/providerIcons.tsx
@@ -32,6 +32,7 @@ const providerIconMap: Record<ProviderType, IconComponent | null> = {
   bedrock: Bedrock,
   browseros: null,
   moonshot: Kimi,
+  'chatgpt-pro': OpenAI,
 }
 
 interface ProviderIconProps {


### PR DESCRIPTION
## Summary

- Fix "gpt-5.3-codex · undefined" in provider card — hide baseUrl when not set (OAuth providers don't have one)
- Add OpenAI icon for chatgpt-pro provider in the icon map

Small follow-up to #476.