### PR TITLE
feat: change agent extension theme from orange to pink

### DIFF
--- a/packages/browseros-agent/apps/agent/styles/global.css
+++ b/packages/browseros-agent/apps/agent/styles/global.css
@@ -48,8 +48,8 @@
   --card-foreground: oklch(0.141 0.005 285.823);
   --popover: oklch(0.99 0.001 85);
   --popover-foreground: oklch(0.141 0.005 285.823);
-  --primary: oklch(0.646 0.222 41.116);
-  --primary-foreground: oklch(0.98 0.016 73.684);
+  --primary: oklch(0.646 0.222 350);
+  --primary-foreground: oklch(0.98 0.016 350);
   --secondary: oklch(0.97 0.002 85);
   --secondary-foreground: oklch(0.21 0.006 285.885);
   --muted: oklch(0.97 0.002 85);
@@ -60,24 +60,24 @@
   --destructive-foreground: oklch(0.99 0 0);
   --border: oklch(0.92 0.004 286.32);
   --input: oklch(0.92 0.004 286.32);
-  --ring: oklch(0.75 0.183 55.934);
-  --chart-1: oklch(0.837 0.128 66.29);
-  --chart-2: oklch(0.705 0.213 47.604);
-  --chart-3: oklch(0.646 0.222 41.116);
-  --chart-4: oklch(0.553 0.195 38.402);
-  --chart-5: oklch(0.47 0.157 37.304);
+  --ring: oklch(0.75 0.15 350);
+  --chart-1: oklch(0.837 0.1 350);
+  --chart-2: oklch(0.705 0.17 350);
+  --chart-3: oklch(0.646 0.2 350);
+  --chart-4: oklch(0.553 0.17 350);
+  --chart-5: oklch(0.47 0.14 350);
   --sidebar: oklch(0.98 0.002 85);
   --sidebar-foreground: oklch(0.141 0.005 285.823);
-  --sidebar-primary: oklch(0.646 0.222 41.116);
-  --sidebar-primary-foreground: oklch(0.98 0.016 73.684);
+  --sidebar-primary: oklch(0.646 0.222 350);
+  --sidebar-primary-foreground: oklch(0.98 0.016 350);
   --sidebar-accent: oklch(0.92 0.004 85);
   --sidebar-accent-foreground: oklch(0.21 0.006 285.885);
   --sidebar-border: oklch(0.92 0.004 286.32);
-  --sidebar-ring: oklch(0.75 0.183 55.934);
+  --sidebar-ring: oklch(0.75 0.15 350);
   /* Custom accent color for BrowserOS branding */
-  --accent-orange: oklch(0.6781 0.1663 43.21);
-  /* Added brighter orange variant for shimmer animation */
-  --accent-orange-bright: oklch(0.7531 0.1963 43.21);
+  --accent-orange: oklch(0.6781 0.1663 350);
+  /* Brighter pink variant for shimmer animation */
+  --accent-orange-bright: oklch(0.7531 0.1963 350);
 }
 
 .dark {
@@ -87,8 +87,8 @@
   --card-foreground: oklch(0.92 0 0);
   --popover: oklch(0.28 0.01 265);
   --popover-foreground: oklch(0.92 0 0);
-  --primary: oklch(0.705 0.213 47.604);
-  --primary-foreground: oklch(0.98 0.016 73.684);
+  --primary: oklch(0.705 0.17 350);
+  --primary-foreground: oklch(0.98 0.016 350);
   --secondary: oklch(0.32 0.01 265);
   --secondary-foreground: oklch(0.92 0 0);
   --muted: oklch(0.32 0.01 265);
@@ -99,20 +99,20 @@
   --destructive-foreground: oklch(0.92 0 0);
   --border: oklch(0.38 0.01 265);
   --input: oklch(0.38 0.01 265);
-  --ring: oklch(0.408 0.123 38.172);
-  --chart-1: oklch(0.837 0.128 66.29);
-  --chart-2: oklch(0.705 0.213 47.604);
-  --chart-3: oklch(0.646 0.222 41.116);
-  --chart-4: oklch(0.553 0.195 38.402);
-  --chart-5: oklch(0.47 0.157 37.304);
+  --ring: oklch(0.408 0.1 350);
+  --chart-1: oklch(0.837 0.1 350);
+  --chart-2: oklch(0.705 0.17 350);
+  --chart-3: oklch(0.646 0.2 350);
+  --chart-4: oklch(0.553 0.17 350);
+  --chart-5: oklch(0.47 0.14 350);
   --sidebar: oklch(0.25 0.01 265);
   --sidebar-foreground: oklch(0.92 0 0);
-  --sidebar-primary: oklch(0.705 0.213 47.604);
+  --sidebar-primary: oklch(0.705 0.17 350);
   --sidebar-primary-foreground: oklch(0.92 0 0);
   --sidebar-accent: oklch(0.32 0.01 265);
   --sidebar-accent-foreground: oklch(0.92 0 0);
   --sidebar-border: oklch(0.38 0.01 265);
-  --sidebar-ring: oklch(0.408 0.123 38.172);
+  --sidebar-ring: oklch(0.408 0.1 350);
 }
 
 @theme inline {
@@ -155,7 +155,7 @@
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-ring: var(--sidebar-ring);
   --color-accent-orange: var(--accent-orange);
-  /* Added brighter orange to theme */
+  /* Brighter pink variant for theme */
   --color-accent-orange-bright: var(--accent-orange-bright);
 
   /* Custom keyframe animations for hero section */
@@ -261,9 +261,9 @@
     }
     50% {
       text-shadow:
-        0 0 20px rgba(214, 123, 68, 0.6),
-        0 0 40px rgba(214, 123, 68, 0.4),
-        0 0 60px rgba(214, 123, 68, 0.2);
+        0 0 20px rgba(219, 112, 147, 0.6),
+        0 0 40px rgba(219, 112, 147, 0.4),
+        0 0 60px rgba(219, 112, 147, 0.2);
       transform: scale(1.02);
     }
     100% {


### PR DESCRIPTION
## Summary
- Swap all OKLCH hue values from orange (~41-47) to pink (350) in CSS custom properties
- Updates primary, ring, chart, sidebar, and accent variables for both light and dark modes
- Updates glow-once keyframe hardcoded rgba values to pink

## Design
Single-file CSS-only change in `apps/agent/styles/global.css`. All 67+ component files automatically pick up the new pink theme through CSS variable references — no component code changes needed. Variable names (`accent-orange`) kept as-is to minimize churn.

## Test plan
- [ ] Open the extension side panel and verify pink primary colors in light mode
- [ ] Toggle to dark mode and verify pink colors render correctly
- [ ] Check onboarding flow for pink accent colors
- [ ] Check new tab page for pink theme consistency
- [ ] Verify destructive/error colors (red) remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)