### PR TITLE
fix: newtab layout

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/layout/SidebarLayout.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/layout/SidebarLayout.tsx
@@ -97,7 +97,7 @@ export const SidebarLayout: FC = () => {
 
         {/* Main content - full width, centered */}
         {location.pathname === '/home/chat' ? (
-          <main className="h-screen overflow-hidden">
+          <main className="relative h-dvh overflow-hidden">
             <Outlet />
           </main>
         ) : (

--- a/packages/browseros-agent/apps/agent/entrypoints/newtab/index/NewTabChat.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/newtab/index/NewTabChat.tsx
@@ -131,7 +131,7 @@ export const NewTabChat: FC = () => {
   if (!selectedProvider) return null
 
   return (
-    <div className="flex h-full flex-col overflow-hidden">
+    <div className="absolute inset-0 flex flex-col overflow-hidden">
       <div className="mx-auto w-full max-w-3xl">
         <ChatHeader
           selectedProvider={selectedProvider}


### PR DESCRIPTION
This pull request makes small layout adjustments to improve the full-screen and positioning behavior of main content areas in the chat UI.

- Layout and positioning improvements:
  * Updated the main content area in `SidebarLayout.tsx` to use `h-dvh` (dynamic viewport height) and `relative` positioning for better fullscreen handling.
  * Changed the root container in `NewTabChat.tsx` to use `absolute` positioning and fill the viewport with `inset-0`, ensuring the chat interface occupies the full available space.