### PR TITLE
feat: gate ChatGPT Pro and GitHub Copilot behind server version 0.0.77

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
@@ -191,6 +191,10 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
   const kimiLaunch = useKimiLaunch()
 
   const filteredProviderTypeOptions = providerTypeOptions.filter((opt) => {
+    if (opt.value === 'chatgpt-pro')
+      return supports(Feature.CHATGPT_PRO_SUPPORT)
+    if (opt.value === 'github-copilot')
+      return supports(Feature.GITHUB_COPILOT_SUPPORT)
     if (opt.value === 'moonshot')
       return kimiLaunch || initialValues?.type === 'moonshot'
     if (opt.value === 'openai-compatible') {

--- a/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/ProviderTemplatesSection.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/ProviderTemplatesSection.tsx
@@ -26,6 +26,10 @@ export const ProviderTemplatesSection: FC<ProviderTemplatesSectionProps> = ({
   const kimiLaunch = useKimiLaunch()
 
   const filteredTemplates = providerTemplates.filter((template) => {
+    if (template.id === 'chatgpt-pro')
+      return supports(Feature.CHATGPT_PRO_SUPPORT)
+    if (template.id === 'github-copilot')
+      return supports(Feature.GITHUB_COPILOT_SUPPORT)
     if (template.id === 'moonshot') return kimiLaunch
     if (template.id === 'openai-compatible') {
       return supports(Feature.OPENAI_COMPATIBLE_SUPPORT)

--- a/packages/browseros-agent/apps/agent/lib/browseros/capabilities.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/capabilities.ts
@@ -45,6 +45,10 @@ export enum Feature {
   MEMORY_SUPPORT = 'MEMORY_SUPPORT',
   // Skills page: agent skills viewer and editor
   SKILLS_SUPPORT = 'SKILLS_SUPPORT',
+  // ChatGPT Pro OAuth LLM provider
+  CHATGPT_PRO_SUPPORT = 'CHATGPT_PRO_SUPPORT',
+  // GitHub Copilot OAuth LLM provider
+  GITHUB_COPILOT_SUPPORT = 'GITHUB_COPILOT_SUPPORT',
 }
 
 /**
@@ -72,6 +76,8 @@ const FEATURE_CONFIG: { [K in Feature]: FeatureConfig } = {
   [Feature.VERTICAL_TABS_SUPPORT]: { minBrowserOSVersion: '0.42.0.0' },
   [Feature.MEMORY_SUPPORT]: { minServerVersion: '0.0.73' },
   [Feature.SKILLS_SUPPORT]: { minBrowserOSVersion: '0.43.0.0' },
+  [Feature.CHATGPT_PRO_SUPPORT]: { minServerVersion: '0.0.77' },
+  [Feature.GITHUB_COPILOT_SUPPORT]: { minServerVersion: '0.0.77' },
 }
 
 function parseVersion(version: string): number[] {


### PR DESCRIPTION
## Summary
- Add `CHATGPT_PRO_SUPPORT` and `GITHUB_COPILOT_SUPPORT` feature flags gated on `minServerVersion: '0.0.77'`
- Hide ChatGPT Pro and GitHub Copilot template cards and dropdown options when the connected server doesn't support their OAuth endpoints
- Existing configured providers continue to work regardless of server version

## Design
Two new entries in the `Feature` enum with corresponding `FEATURE_CONFIG` entries. Filters applied at the UI boundary in `ProviderTemplatesSection.tsx` and `NewProviderDialog.tsx`, following the same pattern as `OPENAI_COMPATIBLE_SUPPORT`.

## Test plan
- [ ] Verify ChatGPT Pro and GitHub Copilot templates are hidden when server version < 0.0.77
- [ ] Verify they appear when server version >= 0.0.77
- [ ] Verify they appear in dev mode (all features enabled)
- [ ] Verify existing ChatGPT Pro / GitHub Copilot providers still work on older servers

🤖 Generated with [Claude Code](https://claude.com/claude-code)