### PR TITLE
feat: gate Qwen Code behind server version 0.0.77

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
@@ -200,6 +200,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
       return supports(Feature.CHATGPT_PRO_SUPPORT)
     if (opt.value === 'github-copilot')
       return supports(Feature.GITHUB_COPILOT_SUPPORT)
+    if (opt.value === 'qwen-code') return supports(Feature.QWEN_CODE_SUPPORT)
     if (opt.value === 'moonshot')
       return kimiLaunch || initialValues?.type === 'moonshot'
     if (opt.value === 'openai-compatible') {

--- a/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/ProviderTemplatesSection.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/ProviderTemplatesSection.tsx
@@ -30,6 +30,7 @@ export const ProviderTemplatesSection: FC<ProviderTemplatesSectionProps> = ({
       return supports(Feature.CHATGPT_PRO_SUPPORT)
     if (template.id === 'github-copilot')
       return supports(Feature.GITHUB_COPILOT_SUPPORT)
+    if (template.id === 'qwen-code') return supports(Feature.QWEN_CODE_SUPPORT)
     if (template.id === 'moonshot') return kimiLaunch
     if (template.id === 'openai-compatible') {
       return supports(Feature.OPENAI_COMPATIBLE_SUPPORT)

--- a/packages/browseros-agent/apps/agent/lib/browseros/capabilities.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/capabilities.ts
@@ -49,6 +49,8 @@ export enum Feature {
   CHATGPT_PRO_SUPPORT = 'CHATGPT_PRO_SUPPORT',
   // GitHub Copilot OAuth LLM provider
   GITHUB_COPILOT_SUPPORT = 'GITHUB_COPILOT_SUPPORT',
+  // Qwen Code OAuth LLM provider
+  QWEN_CODE_SUPPORT = 'QWEN_CODE_SUPPORT',
 }
 
 /**
@@ -78,6 +80,7 @@ const FEATURE_CONFIG: { [K in Feature]: FeatureConfig } = {
   [Feature.SKILLS_SUPPORT]: { minBrowserOSVersion: '0.43.0.0' },
   [Feature.CHATGPT_PRO_SUPPORT]: { minServerVersion: '0.0.77' },
   [Feature.GITHUB_COPILOT_SUPPORT]: { minServerVersion: '0.0.77' },
+  [Feature.QWEN_CODE_SUPPORT]: { minServerVersion: '0.0.77' },
 }
 
 function parseVersion(version: string): number[] {


### PR DESCRIPTION
## Summary
- Add `QWEN_CODE_SUPPORT` feature flag gated behind server version `0.0.77`
- Gate Qwen Code in provider type dropdown (`NewProviderDialog`) and provider templates (`ProviderTemplatesSection`)
- Follows the same pattern as ChatGPT Pro and GitHub Copilot gating from #503

## Test plan
- [ ] Verify Qwen Code option is hidden when server version < 0.0.77
- [ ] Verify Qwen Code option appears when server version >= 0.0.77
- [ ] Verify ChatGPT Pro and GitHub Copilot gating still works correctly