### PR TITLE
test: add build smoke test to catch compile failures

### DIFF
--- a/packages/browseros-agent/apps/server/tests/build.test.ts
+++ b/packages/browseros-agent/apps/server/tests/build.test.ts
@@ -12,6 +12,18 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
+// Derive the build target from the current platform so the test is portable
+function getNativeTarget(): { id: string; ext: string } {
+  const os =
+    process.platform === 'darwin'
+      ? 'darwin'
+      : process.platform === 'win32'
+        ? 'windows'
+        : 'linux'
+  const cpu = process.arch === 'arm64' ? 'arm64' : 'x64'
+  return { id: `${os}-${cpu}`, ext: process.platform === 'win32' ? '.exe' : '' }
+}
+
 // Stub values so the build config validation passes without real secrets
 const BUILD_ENV_STUBS: Record<string, string> = {
   BROWSEROS_CONFIG_URL: 'https://stub.test/config',
@@ -28,9 +40,10 @@ describe('server build', () => {
   const rootDir = resolve(import.meta.dir, '../../..')
   const serverPkgPath = resolve(rootDir, 'apps/server/package.json')
   const buildScript = resolve(rootDir, 'scripts/build/server.ts')
+  const target = getNativeTarget()
   const binaryPath = resolve(
     rootDir,
-    'dist/prod/server/.tmp/binaries/browseros-server-darwin-arm64',
+    `dist/prod/server/.tmp/binaries/browseros-server-${target.id}${target.ext}`,
   )
 
   // Empty manifest so the build skips R2 resource downloads
@@ -50,7 +63,7 @@ describe('server build', () => {
       [
         'bun',
         buildScript,
-        '--target=darwin-arm64',
+        `--target=${target.id}`,
         '--no-upload',
         `--manifest=${emptyManifestPath}`,
       ],
@@ -71,10 +84,17 @@ describe('server build', () => {
       stdout: 'pipe',
       stderr: 'pipe',
     })
-    const versionOutput = (await new Response(proc.stdout).text()).trim()
+    const [versionOutput, versionStderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ])
     const versionExit = await proc.exited
 
-    assert.strictEqual(versionExit, 0, 'Binary --version exited non-zero')
-    assert.strictEqual(versionOutput, expectedVersion)
+    assert.strictEqual(
+      versionExit,
+      0,
+      `Binary --version exited non-zero:\n${versionStderr}`,
+    )
+    assert.strictEqual(versionOutput.trim(), expectedVersion)
   }, 300_000)
 })


### PR DESCRIPTION
## Summary
- Adds `apps/server/tests/build.test.ts` — a build smoke test that compiles the server binary and verifies `--version` outputs the correct version
- Catches compile failures, broken imports, and version injection bugs before they ship
- Uses an empty resource manifest and stub env vars so the test runs without R2 access or real secrets

## Design
The test shells out to `scripts/build/server.ts --target=darwin-arm64 --no-upload` with a custom empty manifest (to skip R2 resource downloads), then runs the compiled binary with `--version` and asserts the output matches `apps/server/package.json` version.

## Test plan
- [x] `bun --env-file=apps/server/.env.development test apps/server/tests/build.test.ts` passes
- [x] `bunx biome check` passes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)