### PR TITLE
fix(ci): report test pass/fail status on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -137,4 +137,5 @@ jobs:
             echo "### :x: ${{ matrix.suite }} suite failed (exit code ${{ steps.test.outputs.exit_code }})" >> "$GITHUB_STEP_SUMMARY"
             echo "" >> "$GITHUB_STEP_SUMMARY"
             echo "See the uploaded \`junit-${{ matrix.suite }}\` artifact for details." >> "$GITHUB_STEP_SUMMARY"
+            exit 1
           fi


### PR DESCRIPTION
## Summary
- The test workflow captured exit codes but never failed the job, so PR checks always showed green even when tests failed
- Added `exit 1` in the summarize step's failure branch so each matrix suite (tools, integration, sdk) properly reports pass/fail as a GitHub check
- Not a required check, so failures remain non-blocking — just visible

## Test plan
- [ ] Open a PR with a failing test to verify the check shows red
- [ ] Open a PR with passing tests to verify the check shows green
- [ ] Verify JUnit artifacts are still uploaded on failure
- [ ] Verify step summary still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)