### PR TITLE
feat(eval): Linux runner, captcha solver, OAuth token, parallel runs

### DIFF
--- a/.github/workflows/eval-weekly.yml
+++ b/.github/workflows/eval-weekly.yml
@@ -51,7 +51,7 @@ jobs:
           FIREWORKS_API_KEY: ${{ secrets.FIREWORKS_API_KEY }}
           OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
-          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           BROWSEROS_BINARY: /usr/bin/browseros
           EVAL_CONFIG: ${{ github.event.inputs.config || 'configs/browseros-agent-weekly.json' }}
         run: |


### PR DESCRIPTION
## Summary
- Switch to `ubuntu-latest` runner with BrowserOS Linux `.deb`
- Add NopeCHA captcha solver extension (auto-loaded, free tier)
- Use `CLAUDE_CODE_OAUTH_TOKEN` for performance grader auth
- Remove concurrency limit — parallel runs on separate VMs
- Add `browseros-oe-clado-weekly.json` config
- Make `BROWSEROS_BINARY` configurable via env var
- Fix report chart to show date+time