### PR TITLE
fix: add unlimited storage permission to agent

### DIFF
--- a/packages/browseros-agent/apps/agent/wxt.config.ts
+++ b/packages/browseros-agent/apps/agent/wxt.config.ts
@@ -57,6 +57,7 @@ export default defineConfig({
       'tabs',
       'tabGroups',
       'storage',
+      'unlimitedStorage',
       'sidePanel',
       'browserOS',
       'alarms',


### PR DESCRIPTION
This pull request makes a minor update to the permissions configuration for the browser extension agent. The only change is the addition of the `unlimitedStorage` permission, which allows the extension to store an unlimited amount of data locally.

- Added the `unlimitedStorage` permission to the `permissions` array in `wxt.config.ts` to enable the extension to store more data locally.