### PR TITLE
fix(eval): include browser context in agent prompt

### DIFF
--- a/packages/browseros-agent/apps/eval/src/agents/single-agent.ts
+++ b/packages/browseros-agent/apps/eval/src/agents/single-agent.ts
@@ -1,5 +1,8 @@
 import { randomUUID } from 'node:crypto'
-import { AiSdkAgent } from '@browseros/server/agent/tool-loop'
+import {
+  AiSdkAgent,
+  formatUserMessage,
+} from '@browseros/server/agent/tool-loop'
 import type { ResolvedAgentConfig } from '@browseros/server/agent/types'
 import { Browser } from '@browseros/server/browser'
 import { CdpBackend } from '@browseros/server/browser/backends/cdp'
@@ -91,8 +94,11 @@ export class SingleAgentEvaluator implements AgentEvaluator {
         capture,
         async (signal) => {
           if (!agent) throw new Error('Agent was not initialized')
+          // Format prompt with browser context so the agent knows what page it's on
+          // (same formatting as chat-service.ts → formatUserMessage)
+          const prompt = formatUserMessage(task.query, browserContext)
           const result = await agent.toolLoopAgent.generate({
-            prompt: task.query,
+            prompt,
             abortSignal: signal,
 
             experimental_onToolCallStart: ({ toolCall }) => {

--- a/packages/browseros-agent/apps/server/src/agent/ai-sdk-agent.ts
+++ b/packages/browseros-agent/apps/server/src/agent/ai-sdk-agent.ts
@@ -254,3 +254,5 @@ export class AiSdkAgent {
     logger.info('Agent disposed', { conversationId: this.conversationId })
   }
 }
+
+export { formatUserMessage } from './format-message'


### PR DESCRIPTION
## Problem
The eval's single-agent was passing raw `task.query` as the prompt without browser context. The agent didn't know which page it was on after Phase 1 navigation, causing it to ask "which website?" and return immediately (0 steps, 2s duration).

This affected 4+ tasks that consistently scored 0% and contributed to flaky results on 21 tasks.

## Fix
Use `formatUserMessage()` (same function used by `chat-service.ts`) to include browser context (active tab URL, title, page ID) in the prompt. The agent now sees:

```
## Browser Context
**Active Tab:** Tab 1 (Page ID: 1) - "University of Pennsylvania" (https://www.upenn.edu/)

---

<USER_QUERY>
Visit the "Contact Us" page and record the phone number...
</USER_QUERY>
```

Instead of just the raw query.

## Changes
- `apps/eval/src/agents/single-agent.ts` — use `formatUserMessage(task.query, browserContext)` instead of raw `task.query`
- `apps/server/src/agent/ai-sdk-agent.ts` — re-export `formatUserMessage` from `agent/tool-loop`