### PR TITLE
feat: add source tag to tool_executed PostHog events

### DIFF
--- a/packages/browseros-agent/apps/server/src/agent/ai-sdk-agent.ts
+++ b/packages/browseros-agent/apps/server/src/agent/ai-sdk-agent.ts
@@ -11,12 +11,14 @@ import {
   type ModelMessage,
   stepCountIs,
   ToolLoopAgent,
+  type ToolSet,
   type UIMessage,
   wrapLanguageModel,
 } from 'ai'
 import type { Browser } from '../browser/browser'
 import type { KlavisClient } from '../lib/clients/klavis/klavis-client'
 import { logger } from '../lib/logger'
+import { metrics } from '../lib/metrics'
 import { isSoulBootstrap, readSoul } from '../lib/soul'
 import { buildSkillsCatalog } from '../skills/catalog'
 import { loadSkills } from '../skills/loader'
@@ -114,7 +116,44 @@ export class AiSdkAgent {
       klavisClient: config.klavisClient,
       browserosId: config.browserosId,
     })
-    const { clients, tools: externalMcpTools } = await createMcpClients(specs)
+    const { clients, tools: rawExternalMcpTools } =
+      await createMcpClients(specs)
+
+    // Wrap external MCP tools (Klavis, custom) with metrics
+    const externalMcpTools: ToolSet = {}
+    for (const [name, t] of Object.entries(rawExternalMcpTools)) {
+      const originalExecute = t.execute
+      externalMcpTools[name] = {
+        ...t,
+        execute: originalExecute
+          ? async (
+              ...args: Parameters<NonNullable<typeof originalExecute>>
+            ) => {
+              const startTime = performance.now()
+              try {
+                const result = await originalExecute(...args)
+                metrics.log('tool_executed', {
+                  tool_name: name,
+                  duration_ms: Math.round(performance.now() - startTime),
+                  success: true,
+                  source: 'chat',
+                })
+                return result
+              } catch (error) {
+                metrics.log('tool_executed', {
+                  tool_name: name,
+                  duration_ms: Math.round(performance.now() - startTime),
+                  success: false,
+                  error_message:
+                    error instanceof Error ? error.message : String(error),
+                  source: 'chat',
+                })
+                throw error
+              }
+            }
+          : undefined,
+      }
+    }
 
     // Add filesystem tools (Pi coding agent) — skip in chat mode (read-only)
     const filesystemTools = config.resolvedConfig.chatMode

--- a/packages/browseros-agent/apps/server/src/agent/tool-adapter.ts
+++ b/packages/browseros-agent/apps/server/src/agent/tool-adapter.ts
@@ -64,6 +64,7 @@ export function buildBrowserToolSet(
             tool_name: def.name,
             duration_ms: Math.round(performance.now() - startTime),
             success: !result.isError,
+            source: 'chat',
           })
 
           return {
@@ -85,6 +86,7 @@ export function buildBrowserToolSet(
             success: false,
             error_message:
               error instanceof Error ? error.message : 'Unknown error',
+            source: 'chat',
           })
 
           return {

--- a/packages/browseros-agent/apps/server/src/api/services/mcp/register-klavis-mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/mcp/register-klavis-mcp.ts
@@ -111,7 +111,7 @@ export function registerKlavisTools(
 
           metrics.log('tool_executed', {
             tool_name: tool.name,
-            source: 'klavis',
+            source: 'mcp',
             duration_ms: Math.round(performance.now() - startTime),
             success: !result.isError,
           })
@@ -123,7 +123,7 @@ export function registerKlavisTools(
 
           metrics.log('tool_executed', {
             tool_name: tool.name,
-            source: 'klavis',
+            source: 'mcp',
             duration_ms: Math.round(performance.now() - startTime),
             success: false,
             error_message: errorText,

--- a/packages/browseros-agent/apps/server/src/api/services/mcp/register-mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/mcp/register-mcp.ts
@@ -25,6 +25,7 @@ export function registerTools(
           tool_name: tool.name,
           duration_ms: Math.round(performance.now() - startTime),
           success: !result.isError,
+          source: 'mcp',
         })
 
         return {
@@ -40,6 +41,7 @@ export function registerTools(
           duration_ms: Math.round(performance.now() - startTime),
           success: false,
           error_message: errorText,
+          source: 'mcp',
         })
 
         return {

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/utils.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/utils.ts
@@ -264,6 +264,7 @@ export function executeWithMetrics(
         tool_name: toolName,
         duration_ms: Math.round(performance.now() - startTime),
         success: !result.isError,
+        source: 'chat',
       })
       return result
     },
@@ -278,6 +279,7 @@ export function executeWithMetrics(
         duration_ms: Math.round(performance.now() - startTime),
         success: false,
         error_message: errorText,
+        source: 'chat',
       })
       return { text: errorText, isError: true }
     },


### PR DESCRIPTION
## Summary
- Adds `source: 'mcp' | 'chat'` property to all `tool_executed` PostHog events to distinguish tool calls from external MCP clients (Claude Code, Cursor) vs the built-in BrowserOS agent
- Wraps previously untracked Klavis/external MCP tool calls in the chat path (`ai-sdk-agent.ts`) with metrics logging
- Enables PostHog breakdown of tool usage by entry point (`source`) alongside existing `tool_name`

## Changes
| File | `source` value | Description |
|------|---------------|-------------|
| `register-mcp.ts` | `mcp` | Browser tools called via MCP endpoint |
| `register-klavis-mcp.ts` | `mcp` | Klavis tools called via MCP endpoint (was `klavis`, now aligned) |
| `tool-adapter.ts` | `chat` | Browser tools called by built-in agent |
| `ai-sdk-agent.ts` | `chat` | Klavis/external MCP tools called by built-in agent (previously untracked) |
| `filesystem/utils.ts` | `chat` | Filesystem tools called by built-in agent |

## Test plan
- [ ] Verify `bun run typecheck` passes
- [ ] Deploy and confirm `tool_executed` events in PostHog now include `source` property
- [ ] Verify no double-logging: chat path Klavis tools go directly to Strata URL, not through local `/mcp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)