### PR TITLE
feat: only parse browseros provider errors

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/Chat.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/Chat.tsx
@@ -36,6 +36,7 @@ export const Chat = () => {
     stop,
     agentUrlError,
     chatError,
+    selectedProvider,
     getActionForMessage,
     liked,
     onClickLike,
@@ -224,7 +225,9 @@ export const Chat = () => {
           />
         )}
         {agentUrlError && <ChatError error={agentUrlError} />}
-        {chatError && <ChatError error={chatError} />}
+        {chatError && (
+          <ChatError error={chatError} providerType={selectedProvider?.type} />
+        )}
       </main>
 
       <ChatFooter

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ChatError.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ChatError.tsx
@@ -24,16 +24,22 @@ import { track } from '@/lib/metrics/track'
 interface ChatErrorProps {
   error: Error
   onRetry?: () => void
+  providerType?: string
 }
 
-function parseErrorMessage(message: string): {
+function parseErrorMessage(
+  message: string,
+  providerType?: string,
+): {
   text: string
   url?: string
   isRateLimit?: boolean
   isCreditsExhausted?: boolean
   isConnectionError?: boolean
 } {
-  // Detect MCP server connection failures
+  const isBrowserosProvider = providerType === 'browseros'
+
+  // Detect MCP server connection failures (universal — affects all providers)
   if (
     (message.includes('Failed to fetch') || message.includes('fetch failed')) &&
     message.includes('127.0.0.1')
@@ -45,10 +51,11 @@ function parseErrorMessage(message: string): {
     }
   }
 
-  // Detect credit exhaustion from gateway
+  // Detect credit exhaustion from gateway (BrowserOS provider only)
   if (
-    message.includes('CREDITS_EXHAUSTED') ||
-    message.includes('Daily credits exhausted')
+    isBrowserosProvider &&
+    (message.includes('CREDITS_EXHAUSTED') ||
+      message.includes('Daily credits exhausted'))
   ) {
     return {
       text: 'Daily credits exhausted. Credits reset at midnight UTC.',
@@ -58,8 +65,11 @@ function parseErrorMessage(message: string): {
     }
   }
 
-  // Detect BrowserOS rate limit (unique pattern, no provider uses this)
-  if (message.includes('BrowserOS LLM daily limit reached')) {
+  // Detect BrowserOS rate limit (BrowserOS provider only)
+  if (
+    isBrowserosProvider &&
+    message.includes('BrowserOS LLM daily limit reached')
+  ) {
     return {
       text: 'Add your own API key for unlimited usage.',
       url: 'https://dub.sh/browseros-usage-limit',
@@ -83,9 +93,13 @@ function parseErrorMessage(message: string): {
   return { text: text || 'An unexpected error occurred', url }
 }
 
-export const ChatError: FC<ChatErrorProps> = ({ error, onRetry }) => {
+export const ChatError: FC<ChatErrorProps> = ({
+  error,
+  onRetry,
+  providerType,
+}) => {
   const { text, url, isRateLimit, isCreditsExhausted, isConnectionError } =
-    parseErrorMessage(error.message)
+    parseErrorMessage(error.message, providerType)
 
   // --- Commented out for Kimi partnership launch (restore after) ---
   // const surveyUrl = useMemo(
@@ -151,7 +165,7 @@ export const ChatError: FC<ChatErrorProps> = ({ error, onRetry }) => {
           View Usage & Billing
         </a>
       )}
-      {isRateLimit && !isCreditsExhausted && (
+      {isRateLimit && !isCreditsExhausted && providerType === 'browseros' && (
         <div className="flex flex-col items-center gap-1">
           <p className="text-muted-foreground text-xs">
             {/* biome-ignore lint/a11y/useValidAnchor: link with click tracking */}


### PR DESCRIPTION
This pull request improves error handling in the chat UI by making error messages more provider-aware. Specifically, it ensures that certain error messages and UI elements are only shown for the BrowserOS provider, preventing confusion when using other providers. The most important changes are grouped below.

**Provider-aware error handling:**

* The `ChatError` component and its underlying logic now accept an optional `providerType` prop, allowing error parsing and display to be tailored based on the selected provider. [[1]](diffhunk://#diff-fc98cf2262886b0fadf14296b7d33303a926d42278926e2767f967a083ab52b3R27-R42) [[2]](diffhunk://#diff-845cbdd617068a234a0017bc11017c64d20775daca112359c525ed0975aeb365R39) [[3]](diffhunk://#diff-845cbdd617068a234a0017bc11017c64d20775daca112359c525ed0975aeb365L227-R230) [[4]](diffhunk://#diff-fc98cf2262886b0fadf14296b7d33303a926d42278926e2767f967a083ab52b3L86-R102)
* Error parsing logic in `parseErrorMessage` was updated to ensure that BrowserOS-specific error messages (like credit exhaustion and rate limits) are only shown when the provider is BrowserOS. [[1]](diffhunk://#diff-fc98cf2262886b0fadf14296b7d33303a926d42278926e2767f967a083ab52b3L48-R58) [[2]](diffhunk://#diff-fc98cf2262886b0fadf14296b7d33303a926d42278926e2767f967a083ab52b3L61-R72)

**UI improvements:**

* The rate limit warning and associated UI elements are now only displayed for the BrowserOS provider, avoiding irrelevant messaging for other providers.