### PR TITLE
fix: widen scheduled task results dialog for better table display

### DIFF
--- a/packages/browseros-agent/apps/agent/components/ai-elements/run-result-dialog.tsx
+++ b/packages/browseros-agent/apps/agent/components/ai-elements/run-result-dialog.tsx
@@ -66,7 +66,7 @@ export const RunResultDialog: FC<RunResultDialogProps> = ({
 
   return (
     <Dialog open={!!run} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-2xl">
+      <DialogContent className="sm:w-[70vw] sm:max-w-4xl">
         <DialogHeader>
           <DialogTitle className="flex items-center gap-2">
             {run.status === 'completed' ? (
@@ -94,7 +94,7 @@ export const RunResultDialog: FC<RunResultDialogProps> = ({
               <p className="text-destructive text-sm">{run.result}</p>
             </div>
           ) : run.result ? (
-            <div className="prose prose-sm dark:prose-invert [&_[data-streamdown='code-block']]:!w-full [&_[data-streamdown='table-wrapper']]:!w-full max-w-none break-words rounded-lg border border-border bg-muted/50 p-4">
+            <div className="prose prose-sm dark:prose-invert [&_[data-streamdown='code-block']]:!w-full [&_[data-streamdown='table-wrapper']]:!w-full max-w-none break-words rounded-lg border border-border bg-muted/50 p-4 [&_[data-streamdown='table-wrapper']]:overflow-x-auto">
               <MessageResponse>{run.result}</MessageResponse>
             </div>
           ) : (


### PR DESCRIPTION
## Summary
- Widens the scheduled task results dialog from `sm:max-w-2xl` (672px) to `sm:w-[70vw] sm:max-w-4xl` (70% viewport width, capped at 896px)
- Adds horizontal scrolling for table wrappers so wide tables scroll instead of being clipped
- Fixes the issue where table content in run results was awkwardly cut off on the right side

## Design
CSS-only change in `run-result-dialog.tsx`. Uses `sm:w-[70vw] sm:max-w-4xl` for responsive width and `[&_[data-streamdown='table-wrapper']]:overflow-x-auto` for table overflow handling. No structural or behavioral changes.

## Test plan
- [ ] Open a scheduled task result that contains a wide table (5+ columns)
- [ ] Verify the dialog takes ~70% of viewport width
- [ ] Verify table content is not clipped — horizontal scroll appears if needed
- [ ] Verify dialog doesn't exceed 896px on very wide monitors
- [ ] Verify dialog still works on narrow screens (mobile-like widths)

Generated with [Claude Code](https://claude.com/claude-code)