### PR TITLE
fix: add cursor-pointer to credit badge in sidepanel

### DIFF
--- a/packages/browseros-agent/apps/agent/components/credits/CreditBadge.tsx
+++ b/packages/browseros-agent/apps/agent/components/credits/CreditBadge.tsx
@@ -14,7 +14,7 @@ export const CreditBadge: FC<CreditBadgeProps> = ({ credits, onClick }) => {
       type="button"
       onClick={onClick}
       className={cn(
-        'inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 font-medium text-xs transition-colors hover:bg-muted/50',
+        'inline-flex cursor-pointer items-center gap-1 rounded-md px-1.5 py-0.5 font-medium text-xs transition-colors hover:bg-muted/50',
         getCreditTextColor(credits),
       )}
       title={`${credits} credits remaining`}


### PR DESCRIPTION
## Summary
- Add `cursor-pointer` class to the CreditBadge component so users see the hand cursor on hover, indicating it's clickable

## Test plan
- [ ] Hover over the credits badge in the sidepanel header → cursor should be a pointer hand

🤖 Generated with [Claude Code](https://claude.com/claude-code)