### PR TITLE
fix: stop sending port-in-use errors to Sentry

### DIFF
--- a/packages/browseros-agent/apps/server/src/index.ts
+++ b/packages/browseros-agent/apps/server/src/index.ts
@@ -20,6 +20,7 @@ import './lib/polyfill'
 import { EXIT_CODES } from '@browseros/shared/constants/exit-codes'
 import { CommanderError } from 'commander'
 import { loadServerConfig } from './config'
+import { isPortInUseError } from './lib/port-binding'
 import { Sentry } from './lib/sentry'
 import { Application } from './main'
 
@@ -38,6 +39,9 @@ try {
 } catch (error) {
   if (error instanceof CommanderError) {
     process.exit(error.exitCode)
+  }
+  if (isPortInUseError(error)) {
+    process.exit(EXIT_CODES.PORT_CONFLICT)
   }
   Sentry.captureException(error)
   console.error('Failed to start server:', error)

--- a/packages/browseros-agent/apps/server/src/main.ts
+++ b/packages/browseros-agent/apps/server/src/main.ts
@@ -231,7 +231,6 @@ export class Application {
     console.error(
       `[FATAL] Failed to start ${serverName} on port ${port}: ${errorMsg}`,
     )
-    Sentry.captureException(error)
 
     if (isPortInUseError(error)) {
       console.error(
@@ -240,6 +239,7 @@ export class Application {
       process.exit(EXIT_CODES.PORT_CONFLICT)
     }
 
+    Sentry.captureException(error)
     process.exit(EXIT_CODES.GENERAL_ERROR)
   }
 
@@ -255,7 +255,9 @@ export class Application {
         { port },
       )
     }
-    Sentry.captureException(error)
+    if (!isPortInUseError(error)) {
+      Sentry.captureException(error)
+    }
   }
 
   private logStartupSummary(controllerServerStarted: boolean): void {


### PR DESCRIPTION
## Summary

Port conflicts are expected behavior — when the server can't bind to its default port, Chromium retries with a different one. These errors were flooding Sentry with 14,000+ events without any user impact.

Resolves TKT-621

## Changes

### `apps/server/src/main.ts`

**`handleStartupError()`**: Moved `Sentry.captureException()` below the `isPortInUseError()` check. Port-in-use errors now exit immediately with `EXIT_CODES.PORT_CONFLICT` without reporting to Sentry. Non-port errors still get captured.

**`handleControllerStartupError()`**: Added `isPortInUseError()` guard around `Sentry.captureException()`. Controller port conflicts are logged as warnings but not sent to Sentry.

### `apps/server/src/index.ts`

Added `isPortInUseError()` early exit in the top-level catch block, before `Sentry.captureException()`.

## Why this is safe

The code already handles port conflicts gracefully:
- `handleStartupError` exits with `EXIT_CODES.PORT_CONFLICT` (not `GENERAL_ERROR`)
- The log message says "Chromium should try a different port" — confirming this is expected
- `handleControllerStartupError` explicitly continues without the controller bridge
- No user-facing functionality is lost when a port conflict occurs

## Test plan
- [ ] Server starts normally on available port
- [ ] When port is in use, server exits with PORT_CONFLICT code (no Sentry event)
- [ ] Non-port startup errors still get captured to Sentry
- [ ] Controller port conflict logs warning but doesn't send to Sentry