### PR TITLE
fix: remove duplicate PR numbers and contributors from release notes

### DIFF
--- a/.github/workflows/release-agent-sdk.yml
+++ b/.github/workflows/release-agent-sdk.yml
@@ -79,27 +79,14 @@ jobs:
                 # Find associated PR number
                 PR_NUM=$(gh api "/repos/${{ github.repository }}/commits/${SHA}/pulls" --jq '.[0].number // empty' 2>/dev/null)
 
-                # Format line
-                if [ -n "$PR_NUM" ]; then
-                  echo "- ${SUBJECT} (#${PR_NUM}) @${GITHUB_USER:-$AUTHOR}" >> /tmp/release-notes.md
+                # Format line: skip PR number if already in the commit subject
+                # (squash merges include "(#123)" in the subject automatically)
+                if [ -n "$PR_NUM" ] && ! echo "$SUBJECT" | grep -qF "(#${PR_NUM})"; then
+                  echo "- ${SUBJECT} (#${PR_NUM})" >> /tmp/release-notes.md
                 else
-                  echo "- ${SUBJECT} (${SHA:0:7}) @${GITHUB_USER:-$AUTHOR}" >> /tmp/release-notes.md
-                fi
-
-                # Collect unique contributors (exact word match to avoid substring collisions)
-                HANDLE="${GITHUB_USER:-$AUTHOR}"
-                if ! echo "$CONTRIBUTORS" | grep -qw "$HANDLE"; then
-                  CONTRIBUTORS="${CONTRIBUTORS} ${HANDLE}"
+                  echo "- ${SUBJECT}" >> /tmp/release-notes.md
                 fi
               done <<< "$COMMITS"
-
-              # Add contributors section
-              echo "" >> /tmp/release-notes.md
-              echo "## Contributors" >> /tmp/release-notes.md
-              echo "" >> /tmp/release-notes.md
-              for CONTRIB in $CONTRIBUTORS; do
-                echo "- @${CONTRIB}" >> /tmp/release-notes.md
-              done
             fi
           fi
         working-directory: ${{ github.workspace }}


### PR DESCRIPTION
This pull request updates the release notes generation logic in the `.github/workflows/release-agent-sdk.yml` workflow. The main focus is on simplifying and clarifying how release note entries are formatted and removing the contributors section from the generated notes.

Release notes formatting improvements:
* The script now avoids duplicating PR numbers in the release notes if the commit subject already contains the PR number (which is common for squash merges).
* The author/committer handle is no longer appended to each release note entry.

Contributors section removal:
* The logic for collecting and displaying a unique list of contributors at the end of the release notes has been removed.