### PR TITLE
fix: add monorepo tag prefix for goreleaser to parse cli/ tags

### DIFF
--- a/packages/browseros-agent/apps/cli/.goreleaser.yml
+++ b/packages/browseros-agent/apps/cli/.goreleaser.yml
@@ -2,6 +2,9 @@ version: 2
 
 project_name: browseros-cli
 
+monorepo:
+  tag_prefix: cli/
+
 builds:
   - main: .
     binary: browseros-cli


### PR DESCRIPTION
This pull request introduces a configuration update to the `.goreleaser.yml` file for the `browseros-cli` project. The most important change is the addition of a `monorepo` configuration, which specifies a `tag_prefix` for releases.

Release configuration:

* Added a `monorepo` section with `tag_prefix: cli/` to the `.goreleaser.yml` file, enabling proper version tagging for the CLI within a monorepo setup.