### PR TITLE
fix(cli): update goreleaser tag_prefix to match browseros-cli-v* format

### DIFF
--- a/packages/browseros-agent/apps/cli/.goreleaser.yml
+++ b/packages/browseros-agent/apps/cli/.goreleaser.yml
@@ -2,6 +2,9 @@ version: 2
 
 project_name: browseros-cli
 
+monorepo:
+  tag_prefix: browseros-cli-
+
 builds:
   - main: .
     binary: browseros-cli


### PR DESCRIPTION
## Summary
PR #578 changed tags from `cli/v*` to `browseros-cli-v*` but didn't update the goreleaser config. GoReleaser can't parse `browseros-cli-v0.1.0` without the matching `tag_prefix`.

Adds `monorepo.tag_prefix: browseros-cli-` so GoReleaser strips it before parsing semver.

## Test plan
- [ ] Merge, then run **Actions → Release CLI → version: 0.1.0**

🤖 Generated with [Claude Code](https://claude.com/claude-code)