### PR TITLE
feat(cli): add install scripts for macOS, Linux, and Windows

### DIFF
--- a/packages/browseros-agent/apps/cli/scripts/install.ps1
+++ b/packages/browseros-agent/apps/cli/scripts/install.ps1
@@ -68,7 +68,8 @@ if (-not [Environment]::Is64BitOperatingSystem) {
 $Tag = "browseros-cli-v$Version"
 $Filename = "${Binary}_${Version}_windows_${Arch}.zip"
 $Url = "https://github.com/$Repo/releases/download/$Tag/$Filename"
-$TmpDir = Join-Path $env:TEMP ("browseros-cli-install-" + [System.IO.Path]::GetRandomFileName())
+$ChecksumUrl = "https://github.com/$Repo/releases/download/$Tag/checksums.txt"
+$TmpDir = Join-Path ([System.IO.Path]::GetTempPath()) ("browseros-cli-install-" + [System.IO.Path]::GetRandomFileName())
 
 try {
     New-Item -ItemType Directory -Path $TmpDir | Out-Null
@@ -78,30 +79,41 @@ try {
     Write-Host "Downloading $Url..."
     Invoke-WebRequest -Uri $Url -OutFile $ZipPath -UseBasicParsing
 
-    # Verify checksum
-    $ChecksumUrl = "https://github.com/$Repo/releases/download/$Tag/checksums.txt"
     $ChecksumPath = Join-Path $TmpDir "checksums.txt"
+    $ChecksumAvailable = $true
     try {
         Invoke-WebRequest -Uri $ChecksumUrl -OutFile $ChecksumPath -UseBasicParsing
-        $expected = (Get-Content $ChecksumPath | Where-Object { $_ -match [regex]::Escape($Filename) }) -split '\s+' | Select-Object -First 1
-        if ($expected) {
-            $actual = (Get-FileHash -Path $ZipPath -Algorithm SHA256).Hash.ToLower()
-            if ($actual -ne $expected.ToLower()) {
-                Write-Error "Checksum mismatch (expected $expected, got $actual)"
+    } catch {
+        $ChecksumAvailable = $false
+        Write-Warning "Could not fetch checksums.txt; skipping checksum verification. $($_.Exception.Message)"
+    }
+
+    if ($ChecksumAvailable) {
+        $ExpectedChecksum = $null
+        foreach ($line in Get-Content $ChecksumPath) {
+            $parts = $line -split '\s+', 2
+            if ($parts.Length -eq 2 -and $parts[1] -eq $Filename) {
+                $ExpectedChecksum = $parts[0].ToLowerInvariant()
+                break
+            }
+        }
+
+        if ($ExpectedChecksum) {
+            $ActualChecksum = (Get-FileHash -Path $ZipPath -Algorithm SHA256).Hash.ToLowerInvariant()
+            if ($ActualChecksum -ne $ExpectedChecksum) {
+                Write-Error "Checksum mismatch (expected $ExpectedChecksum, got $ActualChecksum)"
                 exit 1
             }
             Write-Host "Checksum verified."
         } else {
-            Write-Warning "Checksum not found in checksums.txt; skipping verification."
+            Write-Warning "Checksum not found in checksums.txt; skipping checksum verification."
         }
-    } catch {
-        Write-Warning "Could not verify checksum: $_"
     }
 
     Expand-Archive -Path $ZipPath -DestinationPath $TmpDir -Force
 
-    $ExePath = Join-Path $TmpDir "$Binary.exe"
-    if (-not (Test-Path $ExePath)) {
+    $Exe = Get-ChildItem -Path $TmpDir -Filter "$Binary.exe" -File -Recurse | Select-Object -First 1
+    if (-not $Exe) {
         Write-Error "Binary not found in archive."
         exit 1
     }
@@ -112,7 +124,7 @@ try {
         New-Item -ItemType Directory -Path $Dir -Force | Out-Null
     }
 
-    Move-Item -Force $ExePath (Join-Path $Dir "$Binary.exe")
+    Move-Item -Force $Exe.FullName (Join-Path $Dir "$Binary.exe")
 
     Write-Host "Installed $Binary.exe to $Dir"
 } finally {
@@ -125,7 +137,7 @@ $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
 $PathEntries = $UserPath -split ";" | Where-Object { $_ -ne "" }
 if ($Dir -notin $PathEntries) {
     Write-Host ""
-    Write-Host "Adding $Dir to your PATH..."
+    Write-Host "Adding $Dir to your user PATH..."
     [Environment]::SetEnvironmentVariable("Path", "$Dir;$UserPath", "User")
     $env:Path = "$Dir;$env:Path"
     Write-Host "Done. Restart your terminal for PATH changes to take effect."

--- a/packages/browseros-agent/apps/cli/scripts/install.sh
+++ b/packages/browseros-agent/apps/cli/scripts/install.sh
@@ -92,7 +92,7 @@ curl -fSL --progress-bar -o "${TMPDIR_DL}/${FILENAME}" "$URL"
 
 # Verify checksum if sha256sum/shasum is available
 if curl -fsSL -o "${TMPDIR_DL}/checksums.txt" "$CHECKSUM_URL" 2>/dev/null; then
-  expected=$(grep -F "$FILENAME" "${TMPDIR_DL}/checksums.txt" | awk '{print $1}')
+  expected=$(awk -v filename="$FILENAME" '$2 == filename { print $1; exit }' "${TMPDIR_DL}/checksums.txt")
   if [[ -n "$expected" ]]; then
     if command -v sha256sum >/dev/null 2>&1; then
       actual=$(sha256sum "${TMPDIR_DL}/${FILENAME}" | awk '{print $1}')
@@ -116,7 +116,12 @@ fi
 
 tar -xzf "${TMPDIR_DL}/${FILENAME}" -C "$TMPDIR_DL"
 
-if [[ ! -f "${TMPDIR_DL}/${BINARY}" ]]; then
+BINARY_PATH="${TMPDIR_DL}/${BINARY}"
+if [[ ! -f "$BINARY_PATH" ]]; then
+  BINARY_PATH=$(find "$TMPDIR_DL" -type f -name "$BINARY" -print -quit)
+fi
+
+if [[ -z "$BINARY_PATH" || ! -f "$BINARY_PATH" ]]; then
   echo "Error: binary not found in archive." >&2
   exit 1
 fi
@@ -124,7 +129,7 @@ fi
 # ── Install ──────────────────────────────────────────────────────────────────
 
 mkdir -p "$INSTALL_DIR"
-mv "${TMPDIR_DL}/${BINARY}" "${INSTALL_DIR}/${BINARY}"
+mv "$BINARY_PATH" "${INSTALL_DIR}/${BINARY}"
 chmod +x "${INSTALL_DIR}/${BINARY}"
 
 echo "Installed ${BINARY} to ${INSTALL_DIR}/${BINARY}"


### PR DESCRIPTION
## Summary
- Add cross-platform install scripts for `browseros-cli` on macOS, Linux, and Windows
- Resolve versions from GitHub Releases and download the matching prebuilt archive for the current platform
- Verify archive integrity against release `checksums.txt` before install when checksum data is available

## Rework
Addressed the PR review feedback by tightening checksum handling and archive extraction behavior instead of widening scope. Windows installs now verify the downloaded zip, bash warns on every skipped verification path, and both scripts tolerate nested archive layouts.

## Test plan
- [x] `bash packages/browseros-agent/apps/cli/scripts/install.sh --version 0.1.0 --dir "$TMPDIR/bin"`
- [x] `browseros-cli --help` after install from the script output path
- [x] Verified live `checksums.txt` format for `browseros-cli-v0.1.0`
- [ ] Run `.\install.ps1 -Version "0.1.0"` on Windows