### PR TITLE
feat(cli): add install commands to GitHub release notes

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -74,31 +74,53 @@ jobs:
         run: |
           CLI_PATH="packages/browseros-agent/apps/cli"
           TAG="browseros-cli-v${{ inputs.version }}"
+          CHANGELOG_FILE="/tmp/release-changelog.md"
           PREV_TAG=$(git tag -l "browseros-cli-v*" --sort=-v:refname | grep -v "^${TAG}$" | head -n 1)
 
           if [ -z "$PREV_TAG" ]; then
-            echo "Initial release of browseros-cli." > /tmp/release-notes.md
+            echo "Initial release of browseros-cli." > "$CHANGELOG_FILE"
           else
             COMMITS=$(git log "$PREV_TAG"..HEAD --pretty=format:"%H" -- "$CLI_PATH")
 
             if [ -z "$COMMITS" ]; then
-              echo "No notable changes." > /tmp/release-notes.md
+              echo "No notable changes." > "$CHANGELOG_FILE"
             else
-              echo "## What's Changed" > /tmp/release-notes.md
-              echo "" >> /tmp/release-notes.md
+              echo "## What's Changed" > "$CHANGELOG_FILE"
+              echo "" >> "$CHANGELOG_FILE"
 
               while IFS= read -r SHA; do
                 SUBJECT=$(git log -1 --pretty=format:"%s" "$SHA")
                 PR_NUM=$(gh api "/repos/${{ github.repository }}/commits/${SHA}/pulls" --jq '.[0].number // empty' 2>/dev/null)
 
                 if [ -n "$PR_NUM" ] && ! echo "$SUBJECT" | grep -qF "(#${PR_NUM})"; then
-                  echo "- ${SUBJECT} (#${PR_NUM})" >> /tmp/release-notes.md
+                  echo "- ${SUBJECT} (#${PR_NUM})" >> "$CHANGELOG_FILE"
                 else
-                  echo "- ${SUBJECT}" >> /tmp/release-notes.md
+                  echo "- ${SUBJECT}" >> "$CHANGELOG_FILE"
                 fi
               done <<< "$COMMITS"
             fi
           fi
+
+          cat > /tmp/release-notes.md <<'EOF'
+          ## Install `browseros-cli`
+
+          ### macOS / Linux
+
+          ```bash
+          curl -fsSL https://cdn.browseros.com/cli/install.sh | bash
+          ```
+
+          ### Windows
+
+          ```powershell
+          irm https://cdn.browseros.com/cli/install.ps1 | iex
+          ```
+
+          After install, run `browseros-cli init` to point the CLI at your BrowserOS MCP server.
+          EOF
+
+          echo "" >> /tmp/release-notes.md
+          cat "$CHANGELOG_FILE" >> /tmp/release-notes.md
         working-directory: ${{ github.workspace }}
 
       - name: Create tag and release

--- a/packages/browseros-agent/apps/cli/.goreleaser.yml
+++ b/packages/browseros-agent/apps/cli/.goreleaser.yml
@@ -46,21 +46,5 @@ release:
   github:
     owner: browseros-ai
     name: BrowserOS
-  header: |
-    ## Install `browseros-cli`
-
-    ### macOS / Linux
-
-    ```bash
-    curl -fsSL https://cdn.browseros.com/cli/install.sh | bash
-    ```
-
-    ### Windows
-
-    ```powershell
-    irm https://cdn.browseros.com/cli/install.ps1 | iex
-    ```
-
-    After install, run `browseros-cli init` to point the CLI at your BrowserOS MCP server.
   prerelease: auto
   name_template: "browseros-cli v{{ .Version }}"


### PR DESCRIPTION
## Summary
- prepend `browseros-cli` install commands to the GitHub CLI release notes in `.github/workflows/release-cli.yml`
- keep the release-page commands aligned with the CDN installer endpoints already documented in the repo README
- remove the dead `.goreleaser.yml` release header so the implementation matches the real release path

## Design
The CLI release workflow creates releases with `gh release create --notes-file /tmp/release-notes.md`, so the install block needs to be injected there rather than in GoReleaser config. This keeps the fix on the actual code path used to publish release notes and avoids carrying inert configuration.

## Test plan
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-cli.yml"); YAML.load_file("packages/browseros-agent/apps/cli/.goreleaser.yml"); puts "yaml ok"'`
- inspect `git diff origin/main..HEAD -- .github/workflows/release-cli.yml packages/browseros-agent/apps/cli/.goreleaser.yml`
