### PR TITLE
fix(cli): move install instructions below What's Changed in release notes

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -101,7 +101,9 @@ jobs:
             fi
           fi
 
-          cat > /tmp/release-notes.md <<'EOF'
+          cat "$CHANGELOG_FILE" > /tmp/release-notes.md
+          cat >> /tmp/release-notes.md <<'EOF'
+
           ## Install `browseros-cli`
 
           ### macOS / Linux
@@ -118,9 +120,6 @@ jobs:
 
           After install, run `browseros-cli init` to point the CLI at your BrowserOS MCP server.
           EOF
-
-          echo "" >> /tmp/release-notes.md
-          cat "$CHANGELOG_FILE" >> /tmp/release-notes.md
         working-directory: ${{ github.workspace }}
 
       - name: Create tag and release


### PR DESCRIPTION
## Summary
- Reorders CLI GitHub release notes so the **What's Changed** changelog appears first
- Install instructions (`curl | bash` / `irm | iex`) now render below the changelog

## Design
Swapped the write order in the `Generate release notes` step: the changelog file is written to `release-notes.md` first, then the install heredoc is appended after it.

## Test plan
- Trigger a CLI release via `workflow_dispatch` and verify the GitHub release page shows "What's Changed" above the install block

🤖 Generated with [Claude Code](https://claude.com/claude-code)