### PR TITLE
fix: standardize release names to BrowserOS <Product> - vX.Y.Z

### DIFF
--- a/.github/workflows/release-agent-extension.yml
+++ b/.github/workflows/release-agent-extension.yml
@@ -1,4 +1,4 @@
-name: Release Agent Extension
+name: Release BrowserOS Extension
 
 on:
   workflow_dispatch:
@@ -83,7 +83,7 @@ jobs:
         run: |
           TAG="agent-extension-v${{ steps.version.outputs.version }}"
           RELEASE_SHA="${{ steps.version.outputs.release_sha }}"
-          TITLE="BrowserOS Agent Extension v${{ steps.version.outputs.version }}"
+          TITLE="BrowserOS Extension - v${{ steps.version.outputs.version }}"
 
           if git rev-parse "$TAG" >/dev/null 2>&1; then
             echo "Tag $TAG already exists, skipping tag creation"
@@ -140,7 +140,7 @@ jobs:
 
           gh pr create \
             --title "docs: update agent extension changelog for v${VERSION}" \
-            --body "Auto-generated changelog update for BrowserOS Agent Extension v${VERSION}." \
+            --body "Auto-generated changelog update for BrowserOS Extension v${VERSION}." \
             --base main \
             --head "$BRANCH"
 

--- a/.github/workflows/release-agent-sdk.yml
+++ b/.github/workflows/release-agent-sdk.yml
@@ -1,4 +1,4 @@
-name: Release Agent SDK
+name: Release BrowserOS Agent SDK
 
 on:
   workflow_dispatch:
@@ -102,7 +102,7 @@ jobs:
         run: |
           TAG="agent-sdk-v${{ steps.version.outputs.version }}"
           RELEASE_SHA="${{ steps.version.outputs.release_sha }}"
-          TITLE="@browseros-ai/agent-sdk v${{ steps.version.outputs.version }}"
+          TITLE="BrowserOS Agent SDK - v${{ steps.version.outputs.version }}"
 
           # Create or reuse tag (idempotent for re-runs)
           if git rev-parse "$TAG" >/dev/null 2>&1; then
@@ -160,7 +160,7 @@ jobs:
 
           gh pr create \
             --title "docs: update agent-sdk changelog for v${VERSION}" \
-            --body "Auto-generated changelog update for @browseros-ai/agent-sdk v${VERSION}." \
+            --body "Auto-generated changelog update for BrowserOS Agent SDK v${VERSION}." \
             --base main \
             --head "$BRANCH"
 

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,4 +1,4 @@
-name: Release CLI
+name: Release BrowserOS CLI
 
 on:
   workflow_dispatch:
@@ -161,7 +161,7 @@ jobs:
 
           CLI_DIST="packages/browseros-agent/apps/cli/dist"
           gh release create "$TAG" \
-            --title "browseros-cli v${{ inputs.version }}" \
+            --title "BrowserOS CLI - v${{ inputs.version }}" \
             --notes-file /tmp/release-notes.md \
             ${CLI_DIST}/*
         working-directory: ${{ github.workspace }}


### PR DESCRIPTION
## Summary
- Rename workflow release titles for Extension, Agent SDK, and CLI to consistent `BrowserOS <Product> - vX.Y.Z` format
- Rename 5 existing GitHub releases to match (`gh release edit`)
- Workflow `name:` fields updated to match product branding

## Changes
| File | Change |
|---|---|
| `release-agent-extension.yml` | `BrowserOS Agent Extension` → `BrowserOS Extension` |
| `release-agent-sdk.yml` | `@browseros-ai/agent-sdk` → `BrowserOS Agent SDK` |
| `release-cli.yml` | `browseros-cli` → `BrowserOS CLI` |

## Existing releases renamed
- `browseros-cli v0.1.1` → `BrowserOS CLI - v0.1.1`
- `browseros-cli v0.1.0` → `BrowserOS CLI - v0.1.0`
- `BrowserOS Agent Extension v0.0.52` → `BrowserOS Extension - v0.0.52`
- `agent-sdk - 0.0.7` → `BrowserOS Agent SDK - v0.0.7`
- `@browseros-ai/agent-sdk v0.0.6` → `BrowserOS Agent SDK - v0.0.6`

## Test plan
- [x] Verify existing releases renamed on GitHub
- [ ] Trigger each release workflow on next version bump to confirm new titles