### PR TITLE
feat(llm): add MiniMax provider support

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
@@ -88,6 +88,7 @@ const providerTypeEnum = z.enum([
   'chatgpt-pro',
   'github-copilot',
   'qwen-code',
+  'minimax',
 ])
 
 /**

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/models-dev-data.json
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/models-dev-data.json
@@ -5402,5 +5402,89 @@
         "outputCost": 0
       }
     ]
+  },
+  "minimax": {
+    "name": "MiniMax",
+    "api": "https://api.minimaxi.com",
+    "doc": "https://platform.minimaxi.com",
+    "models": [
+      {
+        "id": "MiniMax-M2.7",
+        "name": "MiniMax M2.7",
+        "contextWindow": 204800,
+        "maxOutput": 8192,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "MiniMax-M2.7-highspeed",
+        "name": "MiniMax M2.7 Highspeed",
+        "contextWindow": 204800,
+        "maxOutput": 8192,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "MiniMax-M2.5",
+        "name": "MiniMax M2.5",
+        "contextWindow": 204800,
+        "maxOutput": 8192,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "MiniMax-M2.5-highspeed",
+        "name": "MiniMax M2.5 Highspeed",
+        "contextWindow": 204800,
+        "maxOutput": 8192,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "MiniMax-M2.1",
+        "name": "MiniMax M2.1",
+        "contextWindow": 204800,
+        "maxOutput": 8192,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "MiniMax-M2.1-highspeed",
+        "name": "MiniMax M2.1 Highspeed",
+        "contextWindow": 204800,
+        "maxOutput": 8192,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "M2-her",
+        "name": "M2-her",
+        "contextWindow": 204800,
+        "maxOutput": 8192,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0,
+        "outputCost": 0
+      }
+    ]
   }
 }

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/providerTemplates.ts
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/providerTemplates.ts
@@ -140,6 +140,12 @@ export const providerTemplates: ProviderTemplate[] = [
     setupGuideUrl:
       'https://docs.aws.amazon.com/bedrock/latest/userguide/getting-started.html',
   }),
+  enrichTemplate('minimax', {
+    defaultModelId: 'MiniMax-M2.7',
+    apiKeyUrl:
+      'https://platform.minimaxi.com/user-center/basic-information/interface-key',
+    setupGuideUrl: 'https://platform.minimaxi.com/document',
+  }),
 ]
 
 /**
@@ -161,6 +167,7 @@ export const providerTypeOptions: { value: ProviderType; label: string }[] = [
   { value: 'lmstudio', label: 'LM Studio' },
   { value: 'bedrock', label: 'AWS Bedrock' },
   { value: 'browseros', label: 'BrowserOS' },
+  { value: 'minimax', label: 'MiniMax' },
 ]
 
 /**
@@ -192,6 +199,7 @@ export const DEFAULT_BASE_URLS: Record<ProviderType, string> = {
   lmstudio: 'http://localhost:1234/v1',
   bedrock: '',
   browseros: '',
+  minimax: 'https://api.minimaxi.com',
 }
 
 /**

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/types.ts
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/types.ts
@@ -17,6 +17,7 @@ export type ProviderType =
   | 'chatgpt-pro'
   | 'github-copilot'
   | 'qwen-code'
+  | 'minimax'
 
 /**
  * LLM Provider configuration

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/provider.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/provider.ts
@@ -148,6 +148,16 @@ function createMoonshotModel(config: ResolvedLLMConfig): LanguageModel {
   })(config.model)
 }
 
+function createMinimaxModel(config: ResolvedLLMConfig): LanguageModel {
+  if (!config.baseUrl) throw new Error('Minimax provider requires baseUrl')
+  if (!config.apiKey) throw new Error('Minimax provider requires apiKey')
+  return createOpenAICompatible({
+    name: 'minimax',
+    baseURL: config.baseUrl,
+    apiKey: config.apiKey,
+  })(config.model)
+}
+
 function createQwenCodeModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.apiKey) throw new Error('Qwen Code requires OAuth authentication')
   return createOpenAICompatible({
@@ -192,6 +202,7 @@ const PROVIDER_FACTORIES: Record<string, ProviderFactory> = {
   [LLM_PROVIDERS.CHATGPT_PRO]: createChatGPTProModel,
   [LLM_PROVIDERS.GITHUB_COPILOT]: createGitHubCopilotModel,
   [LLM_PROVIDERS.QWEN_CODE]: createQwenCodeModel,
+  [LLM_PROVIDERS.MINIMAX]: createMinimaxModel,
 }
 
 export function createLLMProvider(config: ResolvedLLMConfig): LanguageModel {

--- a/packages/browseros-agent/packages/shared/src/schemas/llm.ts
+++ b/packages/browseros-agent/packages/shared/src/schemas/llm.ts
@@ -27,6 +27,7 @@ export const LLM_PROVIDERS = {
   CHATGPT_PRO: 'chatgpt-pro',
   GITHUB_COPILOT: 'github-copilot',
   QWEN_CODE: 'qwen-code',
+  MINIMAX: 'minimax',
 } as const
 
 /**
@@ -48,6 +49,7 @@ export const LLMProviderSchema: z.ZodEnum<
     'chatgpt-pro',
     'github-copilot',
     'qwen-code',
+    'minimax',
   ]
 > = z.enum([
   LLM_PROVIDERS.ANTHROPIC,
@@ -64,6 +66,7 @@ export const LLMProviderSchema: z.ZodEnum<
   LLM_PROVIDERS.CHATGPT_PRO,
   LLM_PROVIDERS.GITHUB_COPILOT,
   LLM_PROVIDERS.QWEN_CODE,
+  LLM_PROVIDERS.MINIMAX,
 ])
 
 export type LLMProvider = z.infer<typeof LLMProviderSchema>


### PR DESCRIPTION
## Summary

Add MiniMax as a new LLM provider option in the "Configure New Provider" dialog.

### Changes

- **`packages/shared/src/schemas/llm.ts`**: Add `MINIMAX` to `LLM_PROVIDERS` constant and `LLMProviderSchema` enum
- **`apps/server/src/lib/clients/llm/provider.ts`**: Add `createMinimaxModel()` factory using OpenAI-compatible SDK
- **`apps/agent/lib/llm-providers/types.ts`**: Add `minimax` to `ProviderType` union
- **`apps/agent/lib/llm-providers/models-dev-data.json`**: Add MiniMax models (M2.7, M2.5, M2.1, M2-her) with context window 204800
- **`apps/agent/lib/llm-providers/providerTemplates.ts`**: Add MiniMax template with default base URL `https://api.minimaxi.com` and API key guide link
- **`apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx`**: Add `minimax` to `providerTypeEnum`

### Supported Models

| Model | Context Window | Reasoning | Tool Call |
|-------|--------------|-----------|-----------|
| MiniMax-M2.7 | 204800 | Yes | Yes |
| MiniMax-M2.7-highspeed | 204800 | Yes | Yes |
| MiniMax-M2.5 | 204800 | Yes | Yes |
| MiniMax-M2.5-highspeed | 204800 | Yes | Yes |
| MiniMax-M2.1 | 204800 | Yes | Yes |
| MiniMax-M2.1-highspeed | 204800 | Yes | Yes |
| M2-her | 204800 | No | Yes |

### API Details

- **Endpoint**: `https://api.minimaxi.com/v1` (OpenAI-compatible)
- **API Key**: https://platform.minimaxi.com/user-center/basic-information/interface-key
- **Docs**: https://platform.minimaxi.com/document

### Testing

Verified API connectivity with MiniMax-M2.7 model using the OpenAI-compatible endpoint. Response: `status_code: 0` (success).

### Notes

- MiniMax follows the same OpenAI-compatible pattern as Moonshot, making integration straightforward
- Both Chinese domestic (`api.minimaxi.com`) and international (`api.minimax.io`) versions use the same API format — this PR targets the domestic version following the Moonshot precedent