### PR TITLE
fix: accept port-only input in CLI init command

### DIFF
--- a/packages/browseros-agent/apps/cli/cmd/init.go
+++ b/packages/browseros-agent/apps/cli/cmd/init.go
@@ -25,13 +25,17 @@ func init() {
 		Long: `Set up the CLI by providing the MCP server URL from BrowserOS.
 
 Open BrowserOS → Settings → BrowserOS MCP to find your Server URL.
-The URL looks like: http://127.0.0.1:9004/mcp
+The URL looks like: http://127.0.0.1:9000/mcp
 
 The port varies per installation, so this step is required on first use.
 Run again if your port changes.
 
+You can provide the full URL or just the port number:
+  browseros-cli init http://127.0.0.1:9000/mcp
+  browseros-cli init 9000
+
 Three modes:
-  browseros-cli init <url>    Non-interactive, use the provided URL
+  browseros-cli init <url>    Non-interactive (full URL or port number)
   browseros-cli init --auto   Auto-discover from ~/.browseros/server.json
   browseros-cli init          Interactive prompt`,
 		Annotations: map[string]string{"group": "Setup:"},
@@ -65,13 +69,14 @@ Three modes:
 				bold.Println("BrowserOS CLI Setup")
 				fmt.Println()
 				fmt.Println("Open BrowserOS → Settings → BrowserOS MCP")
-				fmt.Println("Copy the Server URL shown there.")
+				fmt.Println("Copy the Server URL or port number shown there.")
 				fmt.Println()
-				dim.Println("It looks like: http://127.0.0.1:9004/mcp")
+				dim.Println("Examples:  http://127.0.0.1:9000/mcp")
+				dim.Println("           9000")
 				fmt.Println()
 
 				reader := bufio.NewReader(os.Stdin)
-				fmt.Print("Server URL: ")
+				fmt.Print("Server URL or port: ")
 				line, err := reader.ReadString('\n')
 				if err != nil {
 					output.Error("failed to read input", 1)

--- a/packages/browseros-agent/apps/cli/cmd/root.go
+++ b/packages/browseros-agent/apps/cli/cmd/root.go
@@ -338,8 +338,25 @@ func loadBrowserosServerURL() string {
 
 func normalizeServerURL(raw string) string {
 	normalized := strings.TrimSpace(raw)
+
+	if isPortOnly(normalized) {
+		normalized = "http://127.0.0.1:" + normalized
+	}
+
 	normalized = strings.TrimSuffix(normalized, "/mcp")
 	return strings.TrimSuffix(normalized, "/")
+}
+
+func isPortOnly(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func validateServerURL(raw string) (string, error) {


### PR DESCRIPTION
## Summary
- Users can now run `browseros-cli init 9000` (port only) in addition to the full URL `browseros-cli init http://127.0.0.1:9000/mcp`
- `normalizeServerURL` detects all-digit input and expands it to `http://127.0.0.1:<port>`
- Updated default example port from 9004 to 9000 across help text and interactive prompt

## Test plan
- [ ] `browseros-cli init 9000` — should expand to `http://127.0.0.1:9000` and connect
- [ ] `browseros-cli init http://127.0.0.1:9000/mcp` — should work as before
- [ ] `browseros-cli init` interactive mode — prompt shows both examples
- [ ] `browseros-cli init --help` — long description shows both input formats