### PR TITLE
fix: report release cli version correctly

### DIFF
--- a/packages/browseros-agent/apps/cli/Makefile
+++ b/packages/browseros-agent/apps/cli/Makefile
@@ -2,13 +2,17 @@ BINARY := browseros-cli
 SOURCES := $(shell find . -name '*.go')
 VERSION ?= dev
 POSTHOG_API_KEY ?=
+DIST := dist
 LDFLAGS := -X main.version=$(VERSION) -X browseros-cli/analytics.posthogAPIKey=$(POSTHOG_API_KEY)
+HOST_OS := $(shell go env GOOS)
+HOST_ARCH := $(shell go env GOARCH)
+HOST_EXT := $(if $(filter windows,$(HOST_OS)),.exe,)
+HOST_BINARY = $(DIST)/$(BINARY)_$(HOST_OS)_$(HOST_ARCH)$(HOST_EXT)
 
 $(BINARY): $(SOURCES)
 	go build -ldflags "$(LDFLAGS)" -o $(BINARY) .
 
 PLATFORMS := darwin/amd64 darwin/arm64 linux/amd64 linux/arm64 windows/amd64 windows/arm64
-DIST := dist
 
 .PHONY: install clean vet test release
 
@@ -45,6 +49,11 @@ release:
 		fi; \
 		mv "$(DIST)/$(BINARY)$$EXT" "$(DIST)/$(BINARY)_$${OS}_$${ARCH}$$EXT"; \
 	done
+	@ACTUAL_VERSION=$$($(HOST_BINARY) --version | awk '{print $$3}'); \
+		if [ "$$ACTUAL_VERSION" != "$(VERSION)" ]; then \
+			echo "Error: expected $(HOST_BINARY) to report version $(VERSION), got $$ACTUAL_VERSION" >&2; \
+			exit 1; \
+		fi
 	@cd $(DIST) && (command -v sha256sum >/dev/null 2>&1 && sha256sum *.tar.gz *.zip || shasum -a 256 *.tar.gz *.zip) > checksums.txt
 	@echo "=== Built artifacts ==="
 	@ls -lh $(DIST)

--- a/packages/browseros-agent/apps/cli/cmd/root.go
+++ b/packages/browseros-agent/apps/cli/cmd/root.go
@@ -34,6 +34,7 @@ const automaticUpdateDrainTimeout = 150 * time.Millisecond
 
 func SetVersion(v string) {
 	version = v
+	rootCmd.Version = v
 }
 
 var (

--- a/packages/browseros-agent/apps/cli/cmd/root_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/root_test.go
@@ -5,6 +5,24 @@ import (
 	"time"
 )
 
+func TestSetVersionUpdatesRootCommand(t *testing.T) {
+	originalVersion := version
+	originalRootVersion := rootCmd.Version
+	t.Cleanup(func() {
+		version = originalVersion
+		rootCmd.Version = originalRootVersion
+	})
+
+	SetVersion("1.2.3")
+
+	if version != "1.2.3" {
+		t.Fatalf("version = %q, want %q", version, "1.2.3")
+	}
+	if rootCmd.Version != "1.2.3" {
+		t.Fatalf("rootCmd.Version = %q, want %q", rootCmd.Version, "1.2.3")
+	}
+}
+
 func TestCommandName(t *testing.T) {
 	tests := []struct {
 		name string


### PR DESCRIPTION
## Summary
- fix `browseros-cli --version` so release builds report the injected version instead of staying on `dev`
- add a regression test covering `cmd.SetVersion` and Cobra version state
- verify release artifacts in `make release` by running the host-platform binary and checking its reported version

## Design
The workflow already passed `VERSION` into the CLI release build, so the real issue was runtime initialization order inside the Go CLI. `main.version` was being injected correctly, but Cobra's `rootCmd.Version` was initialized earlier and never refreshed. The fix updates `SetVersion` to synchronize both values and adds a release-time smoke check so future regressions fail before artifacts are published.

## Test plan
- `go run -ldflags "-X main.version=1.2.3" . --version`
- `go test ./...`
- `go vet ./...`
- `make release VERSION=1.2.3 POSTHOG_API_KEY=test-key`
