### PR TITLE
fix: prevent Shift+Enter from triggering chat in new tab search input

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/newtab/index/NewTab.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/newtab/index/NewTab.tsx
@@ -93,6 +93,7 @@ export const NewTab = () => {
   const [mounted, setMounted] = useState(false)
   const inputRef = useRef<HTMLInputElement>(null)
   const tabsDropdownRef = useRef<HTMLDivElement>(null)
+  const shiftHeldRef = useRef(false)
   const [selectedTabs, setSelectedTabs] = useState<chrome.tabs.Tab[]>([])
   const [shortcutsDialogOpen, setShortcutsDialogOpen] = useState(false)
   const [mentionState, setMentionState] = useState<MentionState>({
@@ -180,6 +181,16 @@ export const NewTab = () => {
   } = useCombobox<SuggestionItem>({
     items: flatItems,
     itemToString: (item) => (item ? getSuggestionLabel(item) : ''),
+    stateReducer: (state, actionAndChanges) => {
+      if (
+        actionAndChanges.type ===
+          useCombobox.stateChangeTypes.InputKeyDownEnter &&
+        shiftHeldRef.current
+      ) {
+        return state
+      }
+      return actionAndChanges.changes
+    },
     onSelectedItemChange({ selectedItem }) {
       if (selectedItem) {
         runSelectedAction(selectedItem)
@@ -492,14 +503,7 @@ export const NewTab = () => {
                     ref: inputRef,
                     onChange: (e) => handleInputChange(e.currentTarget.value),
                     onKeyDown: (e) => {
-                      if (e.key === 'Enter' && e.shiftKey) {
-                        ;(
-                          e.nativeEvent as Event & {
-                            preventDownshiftDefault?: boolean
-                          }
-                        ).preventDownshiftDefault = true
-                        return
-                      }
+                      shiftHeldRef.current = e.shiftKey
                       if (!mentionStateRef.current.isOpen) return
                       if (e.key === 'Tab') {
                         e.preventDefault()


### PR DESCRIPTION
## Summary
- Fixes Shift+Enter in the new tab search input starting a chat session instead of being ignored
- Uses downshift's `stateReducer` to intercept `InputKeyDownEnter` when Shift is held, returning the current state (no-op)
- Tracks `shiftKey` in a ref via the input's `onKeyDown` handler

Closes #560

## Rework
Initial approach using `preventDownshiftDefault` on the SyntheticEvent didn't reliably prevent downshift from processing Enter. Switched to `stateReducer`, which is downshift's official customization mechanism and works at the state management level rather than the event level.

## Test plan
- [ ] Open a new tab, type text, press Shift+Enter — should NOT start a chat
- [ ] Open a new tab, type text, press Enter — should still execute the default action (search/chat) as before
- [ ] Open a new tab, type `@` to trigger mention picker, press Tab — should still close mention picker
- [ ] Verify sidepanel chat Shift+Enter still inserts newline (no regression)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)