### PR TITLE
fix: exclude eval framework from language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,4 +9,6 @@ packages/browseros/chromium_patches/**/*.py linguist-generated
 scripts/*.py linguist-generated
 # Mark build directories as generated
 build/* linguist-generated
+# Mark eval/test framework as vendored so it's excluded from language stats
+packages/browseros-agent/apps/eval/** linguist-vendored
 docs/videos/** filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
## Summary
- Adds `packages/browseros-agent/apps/eval/**` as `linguist-vendored` in `.gitattributes`
- Excludes eval/test framework files from GitHub language statistics

## Test plan
- [ ] Verify GitHub language stats no longer count eval directory files