### PR TITLE
feat: migrate agent runtime from Docker to Podman

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -52,7 +52,7 @@ export const AgentsPage: FC = () => {
   const { providers, defaultProviderId } = useLlmProviders()
   const [agents, setAgents] = useState<AgentInstance[]>([])
   const [loading, setLoading] = useState(true)
-  const [dockerAvailable, setDockerAvailable] = useState<boolean | null>(null)
+  const [runtimeAvailable, setRuntimeAvailable] = useState<boolean | null>(null)
   const [createDialogOpen, setCreateDialogOpen] = useState(false)
   const [newAgentName, setNewAgentName] = useState('')
   const [creating, setCreating] = useState(false)
@@ -102,18 +102,19 @@ export const AgentsPage: FC = () => {
       }
     }
 
-    const checkDocker = async () => {
+    const checkRuntime = async () => {
       try {
-        const res = await client.agents['docker-status'].$get()
-        const data = (await res.json()) as { available: boolean }
-        if (!cancelled) setDockerAvailable(data.available)
+        const serverUrl = await getAgentServerUrl()
+        const res = await fetch(`${serverUrl}/agents/runtime-status`)
+        const data = await res.json()
+        if (!cancelled) setRuntimeAvailable(data.available)
       } catch {
-        if (!cancelled) setDockerAvailable(false)
+        if (!cancelled) setRuntimeAvailable(false)
       }
     }
 
     fetchAgents()
-    checkDocker()
+    checkRuntime()
     const interval = setInterval(fetchAgents, 3000)
     return () => {
       cancelled = true
@@ -220,13 +221,12 @@ export const AgentsPage: FC = () => {
         <div>
           <h1 className="font-semibold text-2xl tracking-tight">Agents</h1>
           <p className="text-muted-foreground text-sm">
-            Create and manage OpenClaw agent instances running in Docker
-            containers.
+            Create and manage OpenClaw agent instances.
           </p>
         </div>
         <Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
           <DialogTrigger asChild>
-            <Button disabled={dockerAvailable === false}>
+            <Button disabled={runtimeAvailable === false}>
               <Plus className="mr-2 size-4" />
               New Agent
             </Button>
@@ -309,32 +309,17 @@ export const AgentsPage: FC = () => {
         </Dialog>
       </div>
 
-      {dockerAvailable === false && (
+      {runtimeAvailable === false && (
         <Card className="border-destructive/50 bg-destructive/5 p-4">
           <div className="flex items-start gap-3">
             <AlertCircle className="mt-0.5 size-5 shrink-0 text-destructive" />
             <div>
-              <p className="font-medium text-sm">Docker is not available</p>
+              <p className="font-medium text-sm">
+                Container runtime not available
+              </p>
               <p className="text-muted-foreground text-sm">
-                Install{' '}
-                <a
-                  href="https://www.docker.com/products/docker-desktop/"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline"
-                >
-                  Docker Desktop
-                </a>{' '}
-                or{' '}
-                <a
-                  href="https://orbstack.dev"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="underline"
-                >
-                  OrbStack
-                </a>{' '}
-                to create local OpenClaw agents.
+                Podman is required to run OpenClaw agents. It will be bundled
+                with BrowserOS in a future update.
               </p>
             </div>
           </div>
@@ -347,7 +332,7 @@ export const AgentsPage: FC = () => {
           <h3 className="font-medium text-lg">No agents yet</h3>
           <p className="mt-1 max-w-sm text-muted-foreground text-sm">
             Create your first OpenClaw agent to get started. Each agent runs in
-            an isolated Docker container with its own workspace.
+            an isolated container with its own workspace.
           </p>
         </Card>
       ) : (

--- a/packages/browseros-agent/apps/server/src/api/routes/agents.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/agents.ts
@@ -289,6 +289,70 @@ async function dumpContainerLogs(
   }
 }
 
+// ─── Lifecycle ──────────────────────────────────────────────────────────────
+
+/**
+ * Call on server startup. If agents exist from a previous session,
+ * pre-start the Podman machine in the background so it's ready
+ * when the user interacts with agents.
+ */
+export function initAgentRuntime(): void {
+  if (instances.size === 0) return
+
+  const hasActiveAgents = Array.from(instances.values()).some(
+    (i) => i.status === 'running' || i.status === 'creating',
+  )
+  if (!hasActiveAgents) return
+
+  logger.info('Agents exist from previous session, pre-starting Podman machine')
+  getPodmanRuntime()
+    .ensureReady()
+    .then(() => logger.info('Podman machine ready'))
+    .catch((err) =>
+      logger.warn('Failed to pre-start Podman machine', {
+        error: err instanceof Error ? err.message : String(err),
+      }),
+    )
+}
+
+/**
+ * Call on server shutdown. Stops all running agent containers
+ * and then stops the Podman machine to free resources.
+ */
+export async function shutdownAgentRuntime(): Promise<void> {
+  const runtime = getPodmanRuntime()
+  const available = await runtime.isPodmanAvailable()
+  if (!available) return
+
+  const runningAgents = Array.from(instances.values()).filter(
+    (i) => i.status === 'running',
+  )
+
+  for (const instance of runningAgents) {
+    try {
+      logger.info(`Stopping agent container: ${instance.name}`)
+      await runtime.runCommand(['compose', 'stop'], {
+        cwd: instance.dir,
+        env: composeEnv(instance.name),
+      })
+      instance.status = 'stopped'
+    } catch {
+      // Best effort — shutting down
+    }
+  }
+  saveAgents()
+
+  const status = await runtime.getMachineStatus()
+  if (status.running) {
+    try {
+      logger.info('Stopping Podman machine')
+      await runtime.stopMachine()
+    } catch {
+      // Best effort
+    }
+  }
+}
+
 // ─── Routes ─────────────────────────────────────────────────────────────────
 
 export function createAgentsRoutes() {
@@ -685,6 +749,17 @@ export function createAgentsRoutes() {
         fs.rmSync(instance.dir, { recursive: true, force: true })
         instances.delete(id)
         saveAgents()
+
+        // Stop machine if no agents remain
+        if (instances.size === 0) {
+          const runtime = getPodmanRuntime()
+          const status = await runtime.getMachineStatus()
+          if (status.running) {
+            logger.info('Last agent deleted, stopping Podman machine')
+            runtime.stopMachine().catch(() => {})
+          }
+        }
+
         return c.json({ success: true })
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)

--- a/packages/browseros-agent/apps/server/src/api/routes/agents.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/agents.ts
@@ -3,9 +3,9 @@
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
- * Agent management routes for OpenClaw Docker instances.
- * Generates docker-compose.yml directly and uses docker compose for lifecycle.
- * Provides SSE log streaming for real-time setup visibility.
+ * Agent management routes for OpenClaw container instances.
+ * Generates docker-compose.yml and uses Podman compose for lifecycle.
+ * Manages Podman machine (Linux VM) automatically on macOS/Windows.
  * Persists agent metadata to ~/.browseros/agents.json.
  */
 
@@ -15,6 +15,7 @@ import { Hono } from 'hono'
 import { stream } from 'hono/streaming'
 import { getBrowserosDir } from '../../lib/browseros-dir'
 import { logger } from '../../lib/logger'
+import { getPodmanRuntime } from '../services/podman-runtime'
 
 const OPENCLAW_IMAGE = 'ghcr.io/openclaw/openclaw:latest'
 const MAX_LOG_LINES = 1000
@@ -125,17 +126,8 @@ function updateStatus(
   saveAgents()
 }
 
-async function isDockerAvailable(): Promise<boolean> {
-  try {
-    const proc = Bun.spawn(['docker', 'info'], {
-      stdout: 'pipe',
-      stderr: 'pipe',
-    })
-    const exitCode = await proc.exited
-    return exitCode === 0
-  } catch {
-    return false
-  }
+async function isRuntimeAvailable(): Promise<boolean> {
+  return getPodmanRuntime().isPodmanAvailable()
 }
 
 async function findAvailablePort(startPort: number): Promise<number> {
@@ -151,58 +143,22 @@ async function findAvailablePort(startPort: number): Promise<number> {
   })
 }
 
-async function streamProcessOutput(
-  proc: ReturnType<typeof Bun.spawn>,
-  instance: AgentInstance,
-  prefix: string,
-): Promise<void> {
-  const seen = new Set<string>()
-  const dedup =
-    (tag: string) => async (readable: ReadableStream<Uint8Array>) => {
-      const reader = readable.getReader()
-      const decoder = new TextDecoder()
-      let buf = ''
-      while (true) {
-        const { done, value } = await reader.read()
-        if (done) break
-        buf += decoder.decode(value, { stream: true })
-        const lines = buf.split('\n')
-        buf = lines.pop() ?? ''
-        for (const line of lines) {
-          const trimmed = line.trim()
-          if (trimmed && !seen.has(trimmed)) {
-            seen.add(trimmed)
-            pushLog(instance, `[${tag}] ${trimmed}`)
-          }
-        }
-      }
-      const trimmed = buf.trim()
-      if (trimmed && !seen.has(trimmed)) {
-        seen.add(trimmed)
-        pushLog(instance, `[${tag}] ${trimmed}`)
-      }
-    }
-
-  await Promise.all([
-    dedup(prefix)(proc.stdout as ReadableStream<Uint8Array>),
-    dedup(prefix)(proc.stderr as ReadableStream<Uint8Array>),
-  ])
-}
-
 async function runCommandWithLogs(
   instance: AgentInstance,
-  cmd: string,
   args: string[],
   options?: { cwd?: string; env?: Record<string, string> },
 ): Promise<number> {
-  const proc = Bun.spawn([cmd, ...args], {
-    stdout: 'pipe',
-    stderr: 'pipe',
+  const seen = new Set<string>()
+  return getPodmanRuntime().runCommand(args, {
     cwd: options?.cwd,
-    env: { ...process.env, ...options?.env },
+    env: options?.env,
+    onOutput: (line) => {
+      if (!seen.has(line)) {
+        seen.add(line)
+        pushLog(instance, line)
+      }
+    },
   })
-  await streamProcessOutput(proc, instance, cmd)
-  return proc.exited
 }
 
 function composeEnv(name: string): Record<string, string> {
@@ -323,7 +279,6 @@ async function dumpContainerLogs(
       pushLog(instance, '--- Container logs ---')
       await runCommandWithLogs(
         instance,
-        'docker',
         ['compose', 'logs', '--no-color', '--tail', '50'],
         { cwd: agentDir, env: composeEnv(name) },
       )
@@ -345,9 +300,16 @@ export function createAgentsRoutes() {
       return c.json({ agents: agentList })
     })
 
-    .get('/docker-status', async (c) => {
-      const available = await isDockerAvailable()
-      return c.json({ available })
+    .get('/runtime-status', async (c) => {
+      const runtime = getPodmanRuntime()
+      const available = await runtime.isPodmanAvailable()
+      const machineStatus = available ? await runtime.getMachineStatus() : null
+      return c.json({
+        available,
+        machineInitialized: machineStatus?.initialized ?? false,
+        machineRunning: machineStatus?.running ?? false,
+        needsSetup: available && !machineStatus?.initialized,
+      })
     })
 
     .get('/:id/logs', (c) => {
@@ -419,12 +381,12 @@ export function createAgentsRoutes() {
         return c.json({ error: `Agent "${name}" already exists` }, 409)
       }
 
-      const dockerAvailable = await isDockerAvailable()
-      if (!dockerAvailable) {
+      const runtimeAvailable = await isRuntimeAvailable()
+      if (!runtimeAvailable) {
         return c.json(
           {
             error:
-              'Docker is not available. Install Docker Desktop or OrbStack to create local agents.',
+              'Podman is not available. Install Podman to create local agents.',
           },
           503,
         )
@@ -495,11 +457,13 @@ export function createAgentsRoutes() {
           )
           pushLog(instance, 'Wrote openclaw.json configuration')
 
-          // Pull image
+          pushLog(instance, 'Checking container runtime...')
+          await getPodmanRuntime().ensureReady((msg) => pushLog(instance, msg))
+          pushLog(instance, 'Container runtime ready')
+
           pushLog(instance, `Pulling image ${OPENCLAW_IMAGE}...`)
           const pullExit = await runCommandWithLogs(
             instance,
-            'docker',
             ['compose', 'pull', '--quiet'],
             { cwd: agentDir, env: composeEnv(name) },
           )
@@ -511,7 +475,6 @@ export function createAgentsRoutes() {
           pushLog(instance, 'Starting OpenClaw gateway...')
           const upExit = await runCommandWithLogs(
             instance,
-            'docker',
             ['compose', 'up', '-d'],
             { cwd: agentDir, env: composeEnv(name) },
           )
@@ -584,7 +547,7 @@ export function createAgentsRoutes() {
 
       try {
         pushLog(instance, 'Stopping agent...')
-        await runCommandWithLogs(instance, 'docker', ['compose', 'stop'], {
+        await runCommandWithLogs(instance, ['compose', 'stop'], {
           cwd: instance.dir,
           env: composeEnv(instance.name),
         })
@@ -615,7 +578,7 @@ export function createAgentsRoutes() {
 
       try {
         pushLog(instance, 'Starting agent...')
-        await runCommandWithLogs(instance, 'docker', ['compose', 'up', '-d'], {
+        await runCommandWithLogs(instance, ['compose', 'up', '-d'], {
           cwd: instance.dir,
           env: composeEnv(instance.name),
         })
@@ -708,12 +671,10 @@ export function createAgentsRoutes() {
           instance.logListeners.delete(listener)
         }
 
-        await runCommandWithLogs(
-          instance,
-          'docker',
-          ['compose', 'down', '-v'],
-          { cwd: instance.dir, env: composeEnv(instance.name) },
-        )
+        await runCommandWithLogs(instance, ['compose', 'down', '-v'], {
+          cwd: instance.dir,
+          env: composeEnv(instance.name),
+        })
         fs.rmSync(instance.dir, { recursive: true, force: true })
         instances.delete(id)
         saveAgents()

--- a/packages/browseros-agent/apps/server/src/api/routes/agents.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/agents.ts
@@ -20,24 +20,15 @@ import { getPodmanRuntime } from '../services/podman-runtime'
 const OPENCLAW_IMAGE = 'ghcr.io/openclaw/openclaw:latest'
 const MAX_LOG_LINES = 1000
 
-// Maps BrowserOS provider types to OpenClaw environment variable names and default models
-const OPENCLAW_PROVIDERS: Record<
-  string,
-  { envVar: string; defaultModel: string }
-> = {
-  anthropic: { envVar: 'ANTHROPIC_API_KEY', defaultModel: 'claude-sonnet-4-6' },
-  openai: { envVar: 'OPENAI_API_KEY', defaultModel: 'gpt-5' },
-  google: { envVar: 'GEMINI_API_KEY', defaultModel: 'gemini-2.5-flash' },
-  openrouter: {
-    envVar: 'OPENROUTER_API_KEY',
-    defaultModel: 'anthropic/claude-sonnet-4',
-  },
-  moonshot: { envVar: 'MOONSHOT_API_KEY', defaultModel: 'kimi-k2.5' },
-  groq: { envVar: 'GROQ_API_KEY', defaultModel: 'llama-3.3-70b-versatile' },
-  mistral: {
-    envVar: 'MISTRAL_API_KEY',
-    defaultModel: 'mistral-large-latest',
-  },
+// Maps BrowserOS provider types to OpenClaw environment variable names
+const OPENCLAW_PROVIDER_ENV_MAP: Record<string, string> = {
+  anthropic: 'ANTHROPIC_API_KEY',
+  openai: 'OPENAI_API_KEY',
+  google: 'GEMINI_API_KEY',
+  openrouter: 'OPENROUTER_API_KEY',
+  moonshot: 'MOONSHOT_API_KEY',
+  groq: 'GROQ_API_KEY',
+  mistral: 'MISTRAL_API_KEY',
 }
 
 // Persisted to agents.json
@@ -228,20 +219,21 @@ function generateOpenClawConfig(config: {
     },
   }
 
-  if (!config.providerType) {
+  if (!config.apiKey || !config.providerType) {
     return openclawConfig
   }
 
-  const builtinProvider = OPENCLAW_PROVIDERS[config.providerType]
+  const directEnvVar = OPENCLAW_PROVIDER_ENV_MAP[config.providerType]
 
-  if (builtinProvider) {
-    // Built-in provider (Anthropic, OpenAI, Google, OpenRouter, etc.)
-    const modelId = config.modelId || builtinProvider.defaultModel
-    openclawConfig.env = { [builtinProvider.envVar]: config.apiKey }
-    openclawConfig.agents = {
-      defaults: {
-        model: { primary: `${config.providerType}/${modelId}` },
-      },
+  if (directEnvVar) {
+    // Built-in provider (Anthropic, OpenAI, Google, etc.)
+    openclawConfig.env = { [directEnvVar]: config.apiKey }
+    if (config.modelId) {
+      openclawConfig.agents = {
+        defaults: {
+          model: { primary: `${config.providerType}/${config.modelId}` },
+        },
+      }
     }
   } else if (config.baseUrl) {
     // Custom OpenAI-compatible provider

--- a/packages/browseros-agent/apps/server/src/api/routes/agents.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/agents.ts
@@ -15,7 +15,10 @@ import { Hono } from 'hono'
 import { stream } from 'hono/streaming'
 import { getBrowserosDir } from '../../lib/browseros-dir'
 import { logger } from '../../lib/logger'
-import { getPodmanRuntime } from '../services/podman-runtime'
+import {
+  getPodmanRuntime,
+  type PodmanRuntime,
+} from '../services/podman-runtime'
 
 const OPENCLAW_IMAGE = 'ghcr.io/openclaw/openclaw:latest'
 const MAX_LOG_LINES = 1000
@@ -316,8 +319,9 @@ export function initAgentRuntime(): void {
 }
 
 /**
- * Call on server shutdown. Stops all running agent containers
- * and then stops the Podman machine to free resources.
+ * Call on server shutdown. Stops all BrowserOS agent containers.
+ * Only stops the Podman machine if no other containers are running
+ * (to avoid killing the user's own Podman workloads).
  */
 export async function shutdownAgentRuntime(): Promise<void> {
   const runtime = getPodmanRuntime()
@@ -342,14 +346,44 @@ export async function shutdownAgentRuntime(): Promise<void> {
   }
   saveAgents()
 
+  await stopMachineIfOnlyOurs(runtime)
+}
+
+/**
+ * Stops the Podman machine only if no non-BrowserOS containers are running.
+ * This prevents killing the user's own Podman workloads.
+ */
+async function stopMachineIfOnlyOurs(runtime: PodmanRuntime): Promise<void> {
   const status = await runtime.getMachineStatus()
-  if (status.running) {
-    try {
-      logger.info('Stopping Podman machine')
+  if (!status.running) return
+
+  try {
+    const proc = Bun.spawn(
+      [runtime.getPodmanPath(), 'ps', '--format', '{{.Names}}'],
+      { stdout: 'pipe', stderr: 'ignore' },
+    )
+    const output = await new Response(proc.stdout).text()
+    await proc.exited
+
+    const runningContainers = output
+      .trim()
+      .split('\n')
+      .filter((name) => name.trim())
+
+    const allOurs = runningContainers.every((name) =>
+      name.startsWith('browseros-claw-'),
+    )
+
+    if (runningContainers.length === 0 || allOurs) {
+      logger.info('No other containers running, stopping Podman machine')
       await runtime.stopMachine()
-    } catch {
-      // Best effort
+    } else {
+      logger.info('Other containers running, keeping Podman machine alive', {
+        count: runningContainers.length,
+      })
     }
+  } catch {
+    // Best effort — don't stop machine if we can't check
   }
 }
 
@@ -750,14 +784,9 @@ export function createAgentsRoutes() {
         instances.delete(id)
         saveAgents()
 
-        // Stop machine if no agents remain
+        // Stop machine if no agents remain and no other containers running
         if (instances.size === 0) {
-          const runtime = getPodmanRuntime()
-          const status = await runtime.getMachineStatus()
-          if (status.running) {
-            logger.info('Last agent deleted, stopping Podman machine')
-            runtime.stopMachine().catch(() => {})
-          }
+          stopMachineIfOnlyOurs(getPodmanRuntime()).catch(() => {})
         }
 
         return c.json({ success: true })

--- a/packages/browseros-agent/apps/server/src/api/routes/agents.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/agents.ts
@@ -20,15 +20,24 @@ import { getPodmanRuntime } from '../services/podman-runtime'
 const OPENCLAW_IMAGE = 'ghcr.io/openclaw/openclaw:latest'
 const MAX_LOG_LINES = 1000
 
-// Maps BrowserOS provider types to OpenClaw environment variable names
-const OPENCLAW_PROVIDER_ENV_MAP: Record<string, string> = {
-  anthropic: 'ANTHROPIC_API_KEY',
-  openai: 'OPENAI_API_KEY',
-  google: 'GEMINI_API_KEY',
-  openrouter: 'OPENROUTER_API_KEY',
-  moonshot: 'MOONSHOT_API_KEY',
-  groq: 'GROQ_API_KEY',
-  mistral: 'MISTRAL_API_KEY',
+// Maps BrowserOS provider types to OpenClaw environment variable names and default models
+const OPENCLAW_PROVIDERS: Record<
+  string,
+  { envVar: string; defaultModel: string }
+> = {
+  anthropic: { envVar: 'ANTHROPIC_API_KEY', defaultModel: 'claude-sonnet-4-6' },
+  openai: { envVar: 'OPENAI_API_KEY', defaultModel: 'gpt-5' },
+  google: { envVar: 'GEMINI_API_KEY', defaultModel: 'gemini-2.5-flash' },
+  openrouter: {
+    envVar: 'OPENROUTER_API_KEY',
+    defaultModel: 'anthropic/claude-sonnet-4',
+  },
+  moonshot: { envVar: 'MOONSHOT_API_KEY', defaultModel: 'kimi-k2.5' },
+  groq: { envVar: 'GROQ_API_KEY', defaultModel: 'llama-3.3-70b-versatile' },
+  mistral: {
+    envVar: 'MISTRAL_API_KEY',
+    defaultModel: 'mistral-large-latest',
+  },
 }
 
 // Persisted to agents.json
@@ -219,21 +228,20 @@ function generateOpenClawConfig(config: {
     },
   }
 
-  if (!config.apiKey || !config.providerType) {
+  if (!config.providerType) {
     return openclawConfig
   }
 
-  const directEnvVar = OPENCLAW_PROVIDER_ENV_MAP[config.providerType]
+  const builtinProvider = OPENCLAW_PROVIDERS[config.providerType]
 
-  if (directEnvVar) {
-    // Built-in provider (Anthropic, OpenAI, Google, etc.)
-    openclawConfig.env = { [directEnvVar]: config.apiKey }
-    if (config.modelId) {
-      openclawConfig.agents = {
-        defaults: {
-          model: { primary: `${config.providerType}/${config.modelId}` },
-        },
-      }
+  if (builtinProvider) {
+    // Built-in provider (Anthropic, OpenAI, Google, OpenRouter, etc.)
+    const modelId = config.modelId || builtinProvider.defaultModel
+    openclawConfig.env = { [builtinProvider.envVar]: config.apiKey }
+    openclawConfig.agents = {
+      defaults: {
+        model: { primary: `${config.providerType}/${modelId}` },
+      },
     }
   } else if (config.baseUrl) {
     // Custom OpenAI-compatible provider

--- a/packages/browseros-agent/apps/server/src/api/routes/agents.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/agents.ts
@@ -546,6 +546,8 @@ export function createAgentsRoutes() {
       }
 
       try {
+        await getPodmanRuntime().ensureReady()
+
         pushLog(instance, 'Stopping agent...')
         await runCommandWithLogs(instance, ['compose', 'stop'], {
           cwd: instance.dir,
@@ -577,6 +579,9 @@ export function createAgentsRoutes() {
       }
 
       try {
+        pushLog(instance, 'Ensuring container runtime is ready...')
+        await getPodmanRuntime().ensureReady((msg) => pushLog(instance, msg))
+
         pushLog(instance, 'Starting agent...')
         await runCommandWithLogs(instance, ['compose', 'up', '-d'], {
           cwd: instance.dir,
@@ -667,6 +672,8 @@ export function createAgentsRoutes() {
       }
 
       try {
+        await getPodmanRuntime().ensureReady()
+
         for (const listener of instance.logListeners) {
           instance.logListeners.delete(listener)
         }

--- a/packages/browseros-agent/apps/server/src/api/server.ts
+++ b/packages/browseros-agent/apps/server/src/api/server.ts
@@ -20,7 +20,11 @@ import { initializeOAuth } from '../lib/clients/oauth'
 import { getDb } from '../lib/db'
 import { logger } from '../lib/logger'
 import { Sentry } from '../lib/sentry'
-import { createAgentsRoutes } from './routes/agents'
+import {
+  createAgentsRoutes,
+  initAgentRuntime,
+  shutdownAgentRuntime,
+} from './routes/agents'
 import { createChatRoutes } from './routes/chat'
 import { createCreditsRoutes } from './routes/credits'
 import { createGraphRoutes } from './routes/graph'
@@ -114,6 +118,11 @@ export async function createHttpServer(config: HttpServerConfig) {
           tokenManager?.stopCallbackServer()
           klavisProxy?.close().catch((err) =>
             logger.warn('Failed to close Klavis proxy transport', {
+              error: err instanceof Error ? err.message : String(err),
+            }),
+          )
+          shutdownAgentRuntime().catch((err) =>
+            logger.warn('Failed to shut down agent runtime', {
               error: err instanceof Error ? err.message : String(err),
             }),
           )
@@ -230,6 +239,9 @@ export async function createHttpServer(config: HttpServerConfig) {
   })
 
   logger.info('Consolidated HTTP Server started', { port, host })
+
+  // Pre-start Podman machine if agents exist from a previous session
+  initAgentRuntime()
 
   if (config.aiSdkDevtoolsEnabled) {
     logger.info(

--- a/packages/browseros-agent/apps/server/src/api/services/podman-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/podman-runtime.ts
@@ -146,6 +146,7 @@ export class PodmanRuntime {
     const code = await proc.exited
     if (code !== 0)
       throw new Error(`podman machine stop failed with code ${code}`)
+    this.machineReady = false
   }
 
   async ensureReady(onLog?: (msg: string) => void): Promise<void> {
@@ -174,11 +175,12 @@ export class PodmanRuntime {
       onOutput?: (line: string) => void
     },
   ): Promise<number> {
+    const useStreaming = !!options?.onOutput
     const proc = Bun.spawn([this.podmanPath, ...args], {
       cwd: options?.cwd,
       env: options?.env ? { ...process.env, ...options.env } : undefined,
-      stdout: 'pipe',
-      stderr: 'pipe',
+      stdout: useStreaming ? 'pipe' : 'ignore',
+      stderr: useStreaming ? 'pipe' : 'ignore',
     })
 
     if (options?.onOutput) {

--- a/packages/browseros-agent/apps/server/src/api/services/podman-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/podman-runtime.ts
@@ -1,0 +1,217 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+const isLinux = process.platform === 'linux'
+
+export class PodmanRuntime {
+  private podmanPath: string
+  private machineReady = false
+
+  constructor(config?: { podmanPath?: string }) {
+    this.podmanPath = config?.podmanPath ?? 'podman'
+  }
+
+  getPodmanPath(): string {
+    return this.podmanPath
+  }
+
+  async isPodmanAvailable(): Promise<boolean> {
+    try {
+      const proc = Bun.spawn([this.podmanPath, '--version'], {
+        stdout: 'ignore',
+        stderr: 'ignore',
+      })
+      const code = await proc.exited
+      return code === 0
+    } catch {
+      return false
+    }
+  }
+
+  async getMachineStatus(): Promise<{
+    initialized: boolean
+    running: boolean
+  }> {
+    if (isLinux) return { initialized: true, running: true }
+
+    try {
+      const proc = Bun.spawn(
+        [this.podmanPath, 'machine', 'list', '--format', 'json'],
+        { stdout: 'pipe', stderr: 'ignore' },
+      )
+      const output = await new Response(proc.stdout).text()
+      await proc.exited
+
+      const machines = JSON.parse(output) as Array<{
+        Running?: boolean
+        LastUp?: string
+      }>
+
+      if (!machines.length) return { initialized: false, running: false }
+
+      const machine = machines[0]
+      const running =
+        machine.Running === true || machine.LastUp === 'Currently running'
+
+      return { initialized: true, running }
+    } catch {
+      return { initialized: false, running: false }
+    }
+  }
+
+  async initMachine(onLog?: (msg: string) => void): Promise<void> {
+    if (isLinux) return
+
+    const proc = Bun.spawn(
+      [
+        this.podmanPath,
+        'machine',
+        'init',
+        '--cpus',
+        '2',
+        '--memory',
+        '2048',
+        '--disk-size',
+        '10',
+      ],
+      { stdout: 'ignore', stderr: 'pipe' },
+    )
+
+    if (onLog && proc.stderr) {
+      const reader = proc.stderr.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop() ?? ''
+        for (const line of lines) {
+          const trimmed = line.trim()
+          if (trimmed) onLog(trimmed)
+        }
+      }
+      if (buffer.trim()) onLog(buffer.trim())
+    }
+
+    const code = await proc.exited
+    if (code !== 0)
+      throw new Error(`podman machine init failed with code ${code}`)
+  }
+
+  async startMachine(onLog?: (msg: string) => void): Promise<void> {
+    if (isLinux) return
+
+    const proc = Bun.spawn([this.podmanPath, 'machine', 'start'], {
+      stdout: 'ignore',
+      stderr: 'pipe',
+    })
+
+    if (onLog && proc.stderr) {
+      const reader = proc.stderr.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split('\n')
+        buffer = lines.pop() ?? ''
+        for (const line of lines) {
+          const trimmed = line.trim()
+          if (trimmed) onLog(trimmed)
+        }
+      }
+      if (buffer.trim()) onLog(buffer.trim())
+    }
+
+    const code = await proc.exited
+    if (code !== 0)
+      throw new Error(`podman machine start failed with code ${code}`)
+  }
+
+  async stopMachine(): Promise<void> {
+    if (isLinux) return
+
+    const proc = Bun.spawn([this.podmanPath, 'machine', 'stop'], {
+      stdout: 'ignore',
+      stderr: 'ignore',
+    })
+    const code = await proc.exited
+    if (code !== 0)
+      throw new Error(`podman machine stop failed with code ${code}`)
+  }
+
+  async ensureReady(onLog?: (msg: string) => void): Promise<void> {
+    if (this.machineReady) return
+
+    const status = await this.getMachineStatus()
+
+    if (!status.initialized) {
+      onLog?.('Initializing Podman machine...')
+      await this.initMachine(onLog)
+    }
+
+    if (!status.running) {
+      onLog?.('Starting Podman machine...')
+      await this.startMachine(onLog)
+    }
+
+    this.machineReady = true
+  }
+
+  async runCommand(
+    args: string[],
+    options?: {
+      cwd?: string
+      env?: Record<string, string>
+      onOutput?: (line: string) => void
+    },
+  ): Promise<number> {
+    const proc = Bun.spawn([this.podmanPath, ...args], {
+      cwd: options?.cwd,
+      env: options?.env ? { ...process.env, ...options.env } : undefined,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+
+    if (options?.onOutput) {
+      const streamLines = async (stream: ReadableStream<Uint8Array> | null) => {
+        if (!stream) return
+        const reader = stream.getReader()
+        const decoder = new TextDecoder()
+        let buffer = ''
+
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          buffer += decoder.decode(value, { stream: true })
+          const lines = buffer.split('\n')
+          buffer = lines.pop() ?? ''
+          for (const line of lines) {
+            const trimmed = line.trim()
+            if (trimmed) options.onOutput!(trimmed)
+          }
+        }
+        if (buffer.trim()) options.onOutput!(buffer.trim())
+      }
+
+      await Promise.all([streamLines(proc.stdout), streamLines(proc.stderr)])
+    }
+
+    return proc.exited
+  }
+}
+
+let runtime: PodmanRuntime | null = null
+
+export function getPodmanRuntime(): PodmanRuntime {
+  if (!runtime) runtime = new PodmanRuntime()
+  return runtime
+}


### PR DESCRIPTION
## Summary

- Replace all Docker CLI calls with a new `PodmanRuntime` module that manages the Podman machine (Linux VM) lifecycle automatically
- Users no longer need to install Docker — Podman is used instead (currently from system PATH, binary bundling in follow-up)
- On macOS/Windows, Podman creates a Linux VM via Apple Virtualization.framework / WSL2. On Linux, containers run natively.

## Changes

### New: `podman-runtime.ts`
- `PodmanRuntime` class wrapping all Podman interactions
- Machine lifecycle: `initMachine()`, `startMachine()`, `stopMachine()`, `ensureReady()`
- `ensureReady()` auto-initializes the machine on first use (~2.2GB one-time download)
- `runCommand()` with line-buffered output streaming

### Modified: `agents.ts`
- All 6 `docker` CLI calls replaced with `PodmanRuntime`
- `/docker-status` endpoint renamed to `/runtime-status` (returns machine init/running state)
- `ensureReady()` called before every container operation (create, start, stop, delete)
- Lifecycle management:
  - **Server startup**: pre-starts Podman machine if agents exist from previous session
  - **Server shutdown**: stops all BrowserOS containers + stops machine (only if no other user containers are running)
  - **Delete last agent**: stops machine (only if no other user containers are running)
- Safe machine stop: checks `podman ps` — only stops machine if all running containers are ours (`browseros-claw-*` prefix)

### Modified: `AgentsPage.tsx`
- Replaced Docker warning with runtime-agnostic messaging
- Uses new `/runtime-status` endpoint
- Removed Docker Desktop / OrbStack install links

## Prerequisites for reviewers

```bash
brew install podman
```

The `runtime-status` endpoint handles missing Podman gracefully — UI shows "Container runtime not available" if Podman isn't installed.

## Test plan

- [ ] `curl localhost:9105/agents/runtime-status` returns `available: true` with Podman installed
- [ ] Create an agent — machine auto-inits if needed, container starts, health check passes
- [ ] Stop/start/delete agent — all work through Podman compose
- [ ] Delete last agent — machine stops (if no other containers running)
- [ ] Quit BrowserOS — containers stop, machine stops (if safe)
- [ ] User's own Podman containers are NOT affected by BrowserOS shutdown
- [ ] No `'docker'` string references remain in agents.ts (except docker-compose.yml filename)

## Follow-up work

- [ ] Bundle Podman binary with BrowserOS (upload to R2, add to `server-prod-resources.json`)
- [ ] First-run progress UI for the ~2.2GB machine init download
- [ ] Windows testing (WSL2 backend)

🤖 Generated with [Claude Code](https://claude.com/claude-code)