### PR TITLE
fix: skip windows exe patching in ci mode to avoid wine dependency

### DIFF
--- a/packages/browseros-agent/scripts/build/server/compile.ts
+++ b/packages/browseros-agent/scripts/build/server/compile.ts
@@ -1,6 +1,7 @@
 import { mkdirSync, rmSync } from 'node:fs'
 import { join } from 'node:path'
 
+import { log } from '../log'
 import { wasmBinaryPlugin } from '../plugins/wasm-binary'
 import { runCommand } from './command'
 import type { BuildTarget, CompiledServerBinary } from './types'
@@ -52,6 +53,7 @@ async function bundleServer(
 async function compileTarget(
   target: BuildTarget,
   env: NodeJS.ProcessEnv,
+  ci: boolean,
 ): Promise<string> {
   const binaryPath = compiledBinaryPath(target)
   const args = [
@@ -66,11 +68,15 @@ async function compileTarget(
   await runCommand('bun', args, env)
 
   if (target.os === 'windows') {
-    await runCommand(
-      'bun',
-      ['scripts/patch-windows-exe.ts', binaryPath],
-      process.env,
-    )
+    if (ci) {
+      log.warn('Skipping Windows exe metadata patching in CI mode')
+    } else {
+      await runCommand(
+        'bun',
+        ['scripts/patch-windows-exe.ts', binaryPath],
+        process.env,
+      )
+    }
   }
 
   return binaryPath
@@ -81,14 +87,16 @@ export async function compileServerBinaries(
   envVars: Record<string, string>,
   processEnv: NodeJS.ProcessEnv,
   version: string,
+  options?: { ci?: boolean },
 ): Promise<CompiledServerBinary[]> {
+  const ci = options?.ci ?? false
   rmSync(TMP_ROOT, { recursive: true, force: true })
   mkdirSync(BINARIES_DIR, { recursive: true })
   await bundleServer(envVars, version)
 
   const compiled: CompiledServerBinary[] = []
   for (const target of targets) {
-    const binaryPath = await compileTarget(target, processEnv)
+    const binaryPath = await compileTarget(target, processEnv, ci)
     compiled.push({ target, binaryPath })
   }
 

--- a/packages/browseros-agent/scripts/build/server/orchestrator.ts
+++ b/packages/browseros-agent/scripts/build/server/orchestrator.ts
@@ -37,6 +37,7 @@ export async function runProdResourceBuild(argv: string[]): Promise<void> {
     buildConfig.envVars,
     buildConfig.processEnv,
     buildConfig.version,
+    { ci: args.ci },
   )
 
   if (args.ci) {


### PR DESCRIPTION
## Summary

- The server release CI workflow (`release-server.yml`) fails on `ubuntu-latest` because `patch-windows-exe.ts` requires Wine to run `rcedit-x64.exe`, and Wine is not available on the CI runner
- Threads the existing `--ci` flag through `compileServerBinaries` → `compileTarget` so Windows PE metadata patching is skipped in CI mode with a warning log
- Consistent with the existing CI isolation pattern where `--ci` already skips R2 uploads and production secrets

## Changes

- `scripts/build/server/compile.ts` — Added `ci` parameter to `compileTarget` and optional `options` to `compileServerBinaries`. When `ci=true` and target is Windows, logs a warning and skips patching instead of failing.
- `scripts/build/server/orchestrator.ts` — Passes `{ ci: args.ci }` to `compileServerBinaries`.

## Test plan

- [ ] Re-run the `Release BrowserOS Server` workflow on main after merging — should pass the "Build release artifacts" step
- [ ] Verify local `bun run build:server:test` still works (non-CI mode, no behavior change)
- [ ] Verify CI log shows warning: "Skipping Windows exe metadata patching in CI mode"