### PR TITLE
refactor: remove --compile-only flag, consolidate into --ci

### DIFF
--- a/packages/browseros-agent/apps/server/tests/build.test.ts
+++ b/packages/browseros-agent/apps/server/tests/build.test.ts
@@ -156,28 +156,6 @@ describe('server build', () => {
     assert.strictEqual(versionOutput.trim(), expectedVersion)
   }, 300_000)
 
-  it('keeps compile-only on the strict production validation path', async () => {
-    resetProdEnvToTemplate()
-
-    const build = Bun.spawn(
-      ['bun', buildScript, `--target=${target.id}`, '--compile-only'],
-      {
-        cwd: rootDir,
-        stdout: 'pipe',
-        stderr: 'pipe',
-        env: buildEnv({}, PROD_SECRET_KEYS),
-      },
-    )
-    const buildExit = await build.exited
-    const stderr = await new Response(build.stderr).text()
-
-    assert.notStrictEqual(buildExit, 0, 'Compile-only build should fail')
-    assert.match(stderr, /Production build requires variables:/)
-    assert.match(stderr, /CODEGEN_SERVICE_URL/)
-    assert.match(stderr, /POSTHOG_API_KEY/)
-    assert.match(stderr, /SENTRY_DSN/)
-  }, 300_000)
-
   it('archives CI builds without R2 config or production env secrets', async () => {
     resetProdEnvToTemplate()
     rmSync(zipPath, { force: true })

--- a/packages/browseros-agent/scripts/build/server/cli.ts
+++ b/packages/browseros-agent/scripts/build/server/cli.ts
@@ -22,10 +22,6 @@ export function parseBuildArgs(argv: string[]): BuildArgs {
     .option('--upload', 'Upload artifact zips to R2')
     .option('--no-upload', 'Skip zip upload to R2')
     .option(
-      '--compile-only',
-      'Compile binaries only (skip artifact packaging, R2 staging, and upload)',
-    )
-    .option(
       '--ci',
       'Build local release zip artifacts for CI without R2 and without requiring production env secrets',
     )
@@ -34,15 +30,10 @@ export function parseBuildArgs(argv: string[]): BuildArgs {
     target: string
     manifest: string
     upload: boolean
-    compileOnly: boolean
     ci: boolean
   }>()
 
-  const compileOnly = options.compileOnly ?? false
   const ci = options.ci ?? false
-  if (ci && compileOnly) {
-    throw new Error('--ci cannot be combined with --compile-only')
-  }
   if (ci && options.upload) {
     throw new Error('--ci cannot be combined with --upload')
   }
@@ -50,8 +41,7 @@ export function parseBuildArgs(argv: string[]): BuildArgs {
   return {
     targets: resolveTargets(options.target),
     manifestPath: options.manifest,
-    upload: ci || compileOnly ? false : (options.upload ?? true),
-    compileOnly,
+    upload: ci ? false : (options.upload ?? true),
     ci,
   }
 }

--- a/packages/browseros-agent/scripts/build/server/config.ts
+++ b/packages/browseros-agent/scripts/build/server/config.ts
@@ -75,7 +75,6 @@ function validateProductionEnv(envVars: Record<string, string>): void {
 }
 
 export interface LoadBuildConfigOptions {
-  compileOnly?: boolean
   ci?: boolean
 }
 
@@ -95,7 +94,7 @@ export function loadBuildConfig(
     ...process.env,
   }
 
-  if (options.compileOnly || options.ci) {
+  if (options.ci) {
     return { version: readServerVersion(rootDir), envVars, processEnv }
   }
 

--- a/packages/browseros-agent/scripts/build/server/orchestrator.ts
+++ b/packages/browseros-agent/scripts/build/server/orchestrator.ts
@@ -10,11 +10,8 @@ import { getTargetRules, loadManifest } from './manifest'
 import { createR2Client } from './r2'
 import { stageCompiledArtifact, stageTargetArtifact } from './stage'
 
-function buildModeLabel(argv: { compileOnly: boolean; ci: boolean }): string {
-  if (argv.ci) {
-    return 'ci'
-  }
-  return argv.compileOnly ? 'compile-only' : 'full'
+function buildModeLabel(ci: boolean): string {
+  return ci ? 'ci' : 'full'
 }
 
 export async function runProdResourceBuild(argv: string[]): Promise<void> {
@@ -23,14 +20,11 @@ export async function runProdResourceBuild(argv: string[]): Promise<void> {
 
   const args = parseBuildArgs(argv)
 
-  const buildConfig = loadBuildConfig(rootDir, {
-    compileOnly: args.compileOnly,
-    ci: args.ci,
-  })
+  const buildConfig = loadBuildConfig(rootDir, { ci: args.ci })
 
   log.header(`Building BrowserOS server artifacts v${buildConfig.version}`)
   log.info(`Targets: ${args.targets.map((target) => target.id).join(', ')}`)
-  log.info(`Mode: ${buildModeLabel(args)}`)
+  log.info(`Mode: ${buildModeLabel(args.ci)}`)
 
   const compiled = await compileServerBinaries(
     args.targets,
@@ -60,14 +54,6 @@ export async function runProdResourceBuild(argv: string[]): Promise<void> {
     log.done('CI build completed')
     for (const result of archiveResults) {
       log.info(`${result.targetId}: ${result.zipPath}`)
-    }
-    return
-  }
-
-  if (args.compileOnly) {
-    log.done('Compile-only build completed')
-    for (const binary of compiled) {
-      log.info(`${binary.target.id}: ${binary.binaryPath}`)
     }
     return
   }

--- a/packages/browseros-agent/scripts/build/server/types.ts
+++ b/packages/browseros-agent/scripts/build/server/types.ts
@@ -21,7 +21,6 @@ export interface BuildArgs {
   targets: BuildTarget[]
   manifestPath: string
   upload: boolean
-  compileOnly: boolean
   ci: boolean
 }
 


### PR DESCRIPTION
## Summary

- Removes the `--compile-only` build flag which overlapped with `--ci`
- Both were meant for CI builds — `--ci` already handles skip R2 + skip prod env validation + local zip packaging
- `--no-upload` covers the upload-skipping use case for full builds
- Removes the associated test for `--compile-only` strict validation

## Changes

- `scripts/build/server/cli.ts` — Remove `--compile-only` option and validation
- `scripts/build/server/types.ts` — Remove `compileOnly` from `BuildArgs`
- `scripts/build/server/config.ts` — Remove `compileOnly` from options, simplify R2 skip check
- `scripts/build/server/orchestrator.ts` — Remove `compileOnly` branch, simplify `buildModeLabel`
- `apps/server/tests/build.test.ts` — Remove `--compile-only` test

## Test plan

- [ ] Existing CI build test (`archives CI builds without R2 config`) still passes
- [ ] `bun run build:server:ci` works as before
- [ ] `bun run build:server:test` (uses `--no-upload`) works as before