### PR TITLE
fix(browser): persist theme setting by checking system theme before reset

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.cc
@@ -63,6 +63,12 @@ index 0000000000000..c191fb3963968
 +}
 +
 +void SyncDefaultTheme(PrefService* pref_service) {
++  // BrowserOS: If the user is using a system theme (GTK on Linux), do not
++  // overwrite it with the default BrowserOS value.
++  if (pref_service->GetBoolean(::prefs::kUsesSystemTheme)) {
++    return;
++  }
++
 +  const PrefService::Preference* user_color_pref =
 +      pref_service->FindPreference(::prefs::kUserColor);
 +  if (user_color_pref && user_color_pref->IsDefaultValue()) {


### PR DESCRIPTION
This PR fixes this [issue](https://github.com/browseros-ai/BrowserOS/issues/641) where the user's theme selection (specifically "Use GTK" on Linux) would not persist after restarting the browser.

The Problem: The SyncDefaultTheme function was executing on every startup and overwriting the theme with the "BrowserOS Blue" tonal spot if it found the kUserColor preference at its default value. When using GTK, kUserColor is indeed default, causing the reset.

The Fix: Added a guard clause to SyncDefaultTheme in browseros_prefs.cc that check if ::prefs::kUsesSystemTheme is enabled. If true, the function returns early, preserving the user's system theme selection.