### PR TITLE
feat: add clone action for AI providers

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/AISettingsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/AISettingsPage.tsx
@@ -235,7 +235,22 @@ export const AISettingsPage: FC = () => {
     setIsNewDialogOpen(true)
   }
 
-  const handleEditProvider = (provider: LlmProviderConfig) => {
+  const handleEditProvider = (
+    provider: LlmProviderConfig,
+    isCloning = false,
+  ) => {
+    if (isCloning) {
+      setTemplateValues({
+        ...provider,
+        name: `${provider.name} Copy`,
+        id: undefined,
+        createdAt: undefined,
+        updatedAt: undefined,
+      })
+      setIsNewDialogOpen(true)
+      return
+    }
+
     setEditingProvider(provider)
     setIsEditDialogOpen(true)
   }

--- a/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/ConfiguredProvidersList.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/ConfiguredProvidersList.tsx
@@ -8,7 +8,7 @@ interface ConfiguredProvidersListProps {
   testingProviderId: string | null
   onSelectProvider: (providerId: string) => void
   onTestProvider: (provider: LlmProviderConfig) => void
-  onEditProvider: (provider: LlmProviderConfig) => void
+  onEditProvider: (provider: LlmProviderConfig, isCloning?: boolean) => void
   onDeleteProvider: (provider: LlmProviderConfig) => void
 }
 
@@ -38,7 +38,7 @@ export const ConfiguredProvidersList: FC<ConfiguredProvidersListProps> = ({
             isTesting={testingProviderId === provider.id}
             onSelect={() => onSelectProvider(provider.id)}
             onTest={() => onTestProvider(provider)}
-            onEdit={() => onEditProvider(provider)}
+            onEdit={(isCloning) => onEditProvider(provider, isCloning)}
             onDelete={() => onDeleteProvider(provider)}
           />
         )

--- a/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
@@ -13,7 +13,7 @@ interface ProviderCardProps {
   isBuiltIn: boolean
   onSelect: () => void
   onTest?: () => void
-  onEdit?: () => void
+  onEdit?: (isCloning?: boolean) => void
   onDelete?: () => void
   isTesting?: boolean
 }
@@ -112,6 +112,9 @@ export const ProviderCard: FC<ProviderCardProps> = ({
       </div>
       {!isBuiltIn && (
         <div className="flex shrink-0 items-center gap-2">
+          <Button variant="outline" size="sm" onClick={() => onEdit?.(true)}>
+            Clone
+          </Button>
           <Button
             variant="outline"
             size="sm"


### PR DESCRIPTION
Let users duplicate an existing custom provider into the create flow so they can quickly reuse provider settings without editing in place

I have read the CLA Document and I hereby sign the CLA