### PR TITLE
feat: add clone action for AI providers

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/AISettingsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/AISettingsPage.tsx
@@ -235,7 +235,22 @@ export const AISettingsPage: FC = () => {
     setIsNewDialogOpen(true)
   }
 
-  const handleEditProvider = (provider: LlmProviderConfig) => {
+  const handleEditProvider = (
+    provider: LlmProviderConfig,
+    isCloning = false,
+  ) => {
+    if (isCloning) {
+      setTemplateValues({
+        ...provider,
+        name: `${provider.name} Copy`,
+        id: undefined,
+        createdAt: undefined,
+        updatedAt: undefined,
+      })
+      setIsNewDialogOpen(true)
+      return
+    }
+
     setEditingProvider(provider)
     setIsEditDialogOpen(true)
   }

--- a/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/AISettingsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/AISettingsPage.tsx
@@ -145,6 +145,7 @@ export const AISettingsPage: FC = () => {
 
   const [isNewDialogOpen, setIsNewDialogOpen] = useState(false)
   const [isEditDialogOpen, setIsEditDialogOpen] = useState(false)
+  const [isCloningAction, setIsCloningAction] = useState(false)
   const [templateValues, setTemplateValues] = useState<
     Partial<LlmProviderConfig> | undefined
   >()
@@ -210,9 +211,14 @@ export const AISettingsPage: FC = () => {
     },
   }
 
+  const setIsNewDialogOpenAndCloning = (_isNew: boolean, _isCloning: boolean) => {
+    setIsCloningAction(_isCloning)
+    setIsNewDialogOpen(_isNew)
+  }
+
   const handleAddProvider = () => {
     setTemplateValues(undefined)
-    setIsNewDialogOpen(true)
+    setIsNewDialogOpenAndCloning(true, false)
   }
 
   const handleUseTemplate = (template: ProviderTemplate) => {
@@ -232,7 +238,7 @@ export const AISettingsPage: FC = () => {
       contextWindow: template.contextWindow,
       temperature: 0.2,
     })
-    setIsNewDialogOpen(true)
+    setIsNewDialogOpenAndCloning(true, false)
   }
 
   const handleEditProvider = (
@@ -242,12 +248,12 @@ export const AISettingsPage: FC = () => {
     if (isCloning) {
       setTemplateValues({
         ...provider,
-        name: `${provider.name} Copy`,
+        name: `${provider.name.replace(/\s+Copy$/g, '')} Copy`,
         id: undefined,
         createdAt: undefined,
         updatedAt: undefined,
       })
-      setIsNewDialogOpen(true)
+      setIsNewDialogOpenAndCloning(true, true)
       return
     }
 
@@ -290,7 +296,7 @@ export const AISettingsPage: FC = () => {
       createdAt: timestamp,
       updatedAt: timestamp,
     })
-    setIsNewDialogOpen(true)
+    setIsNewDialogOpenAndCloning(true, false)
   }
 
   const handleDeleteIncompleteProvider = (provider: IncompleteProvider) => {
@@ -396,9 +402,13 @@ export const AISettingsPage: FC = () => {
 
       <NewProviderDialog
         open={isNewDialogOpen}
-        onOpenChange={setIsNewDialogOpen}
+        onOpenChange={(open) => {
+          setIsCloningAction(false)
+          setIsNewDialogOpen(open)
+        }}
         initialValues={templateValues}
         onSave={handleSaveProvider}
+        isCloningAction={isCloningAction}
       />
 
       <NewProviderDialog

--- a/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/ConfiguredProvidersList.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/ConfiguredProvidersList.tsx
@@ -8,7 +8,7 @@ interface ConfiguredProvidersListProps {
   testingProviderId: string | null
   onSelectProvider: (providerId: string) => void
   onTestProvider: (provider: LlmProviderConfig) => void
-  onEditProvider: (provider: LlmProviderConfig) => void
+  onEditProvider: (provider: LlmProviderConfig, isCloning?: boolean) => void
   onDeleteProvider: (provider: LlmProviderConfig) => void
 }
 
@@ -38,7 +38,7 @@ export const ConfiguredProvidersList: FC<ConfiguredProvidersListProps> = ({
             isTesting={testingProviderId === provider.id}
             onSelect={() => onSelectProvider(provider.id)}
             onTest={() => onTestProvider(provider)}
-            onEdit={() => onEditProvider(provider)}
+            onEdit={(isCloning) => onEditProvider(provider, isCloning)}
             onDelete={() => onDeleteProvider(provider)}
           />
         )

--- a/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
@@ -57,6 +57,7 @@ import { useCapabilities } from '@/lib/browseros/useCapabilities'
 import {
   AI_PROVIDER_ADDED_EVENT,
   AI_PROVIDER_UPDATED_EVENT,
+  AI_PROVIDER_CLONED_EVENT,
   KIMI_API_KEY_CONFIGURED_EVENT,
   KIMI_API_KEY_GUIDE_CLICKED_EVENT,
   MODEL_SELECTED_EVENT,
@@ -207,6 +208,8 @@ export interface NewProviderDialogProps {
   initialValues?: Partial<LlmProviderConfig>
   /** Callback when provider is saved */
   onSave: (provider: LlmProviderConfig) => Promise<void>
+  /** Whether the dialog is for cloning an existing provider */
+  isCloningAction?: boolean
 }
 
 /**
@@ -218,6 +221,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
   onOpenChange,
   initialValues,
   onSave,
+  isCloningAction,
 }) => {
   const [isTesting, setIsTesting] = useState(false)
   const [testResult, setTestResult] = useState<TestResult | null>(null)
@@ -400,7 +404,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
 
     await onSave(provider)
     if (isNewProvider) {
-      track(AI_PROVIDER_ADDED_EVENT, {
+      track(isCloningAction ? AI_PROVIDER_CLONED_EVENT : AI_PROVIDER_ADDED_EVENT, {
         provider_type: values.type,
         model: values.modelId,
       })

--- a/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/ProviderCard.tsx
@@ -13,7 +13,7 @@ interface ProviderCardProps {
   isBuiltIn: boolean
   onSelect: () => void
   onTest?: () => void
-  onEdit?: () => void
+  onEdit?: (isCloning?: boolean) => void
   onDelete?: () => void
   isTesting?: boolean
 }
@@ -112,6 +112,9 @@ export const ProviderCard: FC<ProviderCardProps> = ({
       </div>
       {!isBuiltIn && (
         <div className="flex shrink-0 items-center gap-2">
+          <Button variant="outline" size="sm" onClick={() => onEdit?.(true)}>
+            Clone
+          </Button>
           <Button
             variant="outline"
             size="sm"

--- a/packages/browseros-agent/apps/agent/lib/constants/analyticsEvents.ts
+++ b/packages/browseros-agent/apps/agent/lib/constants/analyticsEvents.ts
@@ -33,6 +33,9 @@ export const AI_PROVIDER_ADDED_EVENT = 'settings.ai_provider.added'
 export const AI_PROVIDER_UPDATED_EVENT = 'settings.ai_provider.updated'
 
 /** @public */
+export const AI_PROVIDER_CLONED_EVENT = 'settings.ai_provider.cloned'
+
+/** @public */
 export const MODEL_SELECTED_EVENT = 'settings.model.selected'
 
 /** @public */


### PR DESCRIPTION
Let users duplicate an existing custom provider into the create flow so they can quickly reuse provider settings without editing in place

I have read the CLA Document and I hereby sign the CLA