### PR TITLE
feat: show custom model ID as first option in model selector

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
@@ -305,9 +305,14 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
     [modelInfoList],
   )
 
-  const filteredModels = modelSearch
-    ? modelFuse.search(modelSearch).map((r) => r.item)
-    : modelInfoList
+  const filteredModels = useMemo(() => {
+    if (!modelSearch) return modelInfoList
+    const fuzzyResults = modelFuse.search(modelSearch).map((r) => r.item)
+    const hasExactMatch = fuzzyResults.some((m) => m.modelId === modelSearch)
+    if (hasExactMatch) return fuzzyResults
+    const customEntry = { modelId: modelSearch, contextLength: 0 }
+    return [customEntry, ...fuzzyResults]
+  }, [modelSearch, modelFuse, modelInfoList])
 
   // Handle provider type change (user-initiated via Select)
   const handleTypeChange = (newType: ProviderType) => {
@@ -896,11 +901,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
                             value={modelSearch}
                             onValueChange={setModelSearch}
                             onKeyDown={(e) => {
-                              if (
-                                e.key === 'Enter' &&
-                                modelSearch &&
-                                filteredModels.length === 0
-                              ) {
+                              if (e.key === 'Enter' && modelSearch) {
                                 e.preventDefault()
                                 form.setValue('modelId', modelSearch)
                                 track(MODEL_SELECTED_EVENT, {
@@ -918,35 +919,43 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
                               No models found. Press Enter to use &quot;
                               {modelSearch}&quot;
                             </CommandEmpty>
-                            <CommandGroup>
-                              {filteredModels.map((model) => (
-                                <CommandItem
-                                  key={model.modelId}
-                                  value={model.modelId}
-                                  onSelect={() => {
-                                    form.setValue('modelId', model.modelId)
-                                    track(MODEL_SELECTED_EVENT, {
-                                      provider_type: watchedType,
-                                      model_id: model.modelId,
-                                      context_window: model.contextLength,
-                                      is_custom_model: false,
-                                    })
-                                    setModelPickerOpen(false)
-                                    setModelSearch('')
-                                  }}
-                                >
-                                  <span className="flex-1 truncate">
-                                    {model.modelId}
-                                  </span>
-                                  <span className="ml-2 shrink-0 rounded-md bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
-                                    {formatContextWindow(model.contextLength)}
-                                  </span>
-                                  {field.value === model.modelId && (
-                                    <Check className="ml-2 h-4 w-4 shrink-0" />
-                                  )}
-                                </CommandItem>
-                              ))}
-                            </CommandGroup>
+                            {filteredModels.length > 0 && (
+                              <CommandGroup>
+                                {filteredModels.map((model) => (
+                                  <CommandItem
+                                    key={model.modelId}
+                                    value={model.modelId}
+                                    onSelect={() => {
+                                      form.setValue('modelId', model.modelId)
+                                      track(MODEL_SELECTED_EVENT, {
+                                        provider_type: watchedType,
+                                        model_id: model.modelId,
+                                        context_window: model.contextLength,
+                                        is_custom_model: !modelInfoList.some(
+                                          (m) => m.modelId === model.modelId,
+                                        ),
+                                      })
+                                      setModelPickerOpen(false)
+                                      setModelSearch('')
+                                    }}
+                                  >
+                                    <span className="flex-1 truncate">
+                                      {model.modelId}
+                                    </span>
+                                    {model.contextLength > 0 && (
+                                      <span className="ml-2 shrink-0 rounded-md bg-muted px-1.5 py-0.5 font-mono text-[10px] text-muted-foreground">
+                                        {formatContextWindow(
+                                          model.contextLength,
+                                        )}
+                                      </span>
+                                    )}
+                                    {field.value === model.modelId && (
+                                      <Check className="ml-2 h-4 w-4 shrink-0" />
+                                    )}
+                                  </CommandItem>
+                                ))}
+                              </CommandGroup>
+                            )}
                           </CommandList>
                         </Command>
                       </PopoverContent>

--- a/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
@@ -903,11 +903,14 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
                             onKeyDown={(e) => {
                               if (e.key === 'Enter' && modelSearch) {
                                 e.preventDefault()
+                                e.stopPropagation()
                                 form.setValue('modelId', modelSearch)
                                 track(MODEL_SELECTED_EVENT, {
                                   provider_type: watchedType,
                                   model_id: modelSearch,
-                                  is_custom_model: true,
+                                  is_custom_model: !modelInfoList.some(
+                                    (m) => m.modelId === modelSearch,
+                                  ),
                                 })
                                 setModelPickerOpen(false)
                                 setModelSearch('')


### PR DESCRIPTION
## Summary
- When typing in the model dropdown, the user's exact input now appears as the first selectable row, followed by fuzzy search suggestions
- Pressing Enter always commits the typed text as a custom model ID
- Context window badge is hidden for custom entries (since it's unknown)
- Analytics correctly tracks `is_custom_model` by checking against the known model list

## Context
Previously, entering a custom model ID required typing something that returned zero fuzzy matches, then pressing Enter. Since fuzzy search (Fuse.js threshold 0.4) almost always returns results, users could never discover the custom model path.

## Test plan
- [ ] Open Settings → Add Provider (e.g. OpenRouter)
- [ ] Type a custom model ID (e.g. `my-org/my-model`) → verify it appears as the first row without a context window badge
- [ ] Click it or press Enter → verify it's selected as the model
- [ ] Type a known model prefix (e.g. `anthropic/`) → verify the exact text appears first, followed by matching suggestions with context window badges
- [ ] Type an exact model ID (e.g. `anthropic/claude-sonnet-4.5`) → verify no duplicate first row appears
- [ ] Open dropdown without typing → verify full model list shows as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)