### PR TITLE
fix: ensure custom model entry is always visible in model selector

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/NewProviderDialog.tsx
@@ -8,7 +8,7 @@ import {
   Loader2,
   XCircle,
 } from 'lucide-react'
-import { type FC, useEffect, useMemo, useState } from 'react'
+import { type FC, useEffect, useMemo, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { z } from 'zod/v3'
 import { Button } from '@/components/ui/button'
@@ -223,6 +223,7 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
   const [testResult, setTestResult] = useState<TestResult | null>(null)
   const [modelPickerOpen, setModelPickerOpen] = useState(false)
   const [modelSearch, setModelSearch] = useState('')
+  const modelListRef = useRef<HTMLDivElement>(null)
   const { supports } = useCapabilities()
   const { baseUrl: agentServerUrl } = useAgentServerUrl()
   const kimiLaunch = useKimiLaunch()
@@ -305,14 +306,12 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
     [modelInfoList],
   )
 
-  const filteredModels = useMemo(() => {
-    if (!modelSearch) return modelInfoList
-    const fuzzyResults = modelFuse.search(modelSearch).map((r) => r.item)
-    const hasExactMatch = fuzzyResults.some((m) => m.modelId === modelSearch)
-    if (hasExactMatch) return fuzzyResults
-    const customEntry = { modelId: modelSearch, contextLength: 0 }
-    return [customEntry, ...fuzzyResults]
-  }, [modelSearch, modelFuse, modelInfoList])
+  const filteredModels = modelSearch
+    ? modelFuse.search(modelSearch).map((r) => r.item)
+    : modelInfoList
+
+  const showCustomEntry =
+    modelSearch && !filteredModels.some((m) => m.modelId === modelSearch)
 
   // Handle provider type change (user-initiated via Select)
   const handleTypeChange = (newType: ProviderType) => {
@@ -899,7 +898,12 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
                           <CommandInput
                             placeholder="Search models..."
                             value={modelSearch}
-                            onValueChange={setModelSearch}
+                            onValueChange={(v) => {
+                              setModelSearch(v)
+                              requestAnimationFrame(() => {
+                                modelListRef.current?.scrollTo(0, 0)
+                              })
+                            }}
                             onKeyDown={(e) => {
                               if (e.key === 'Enter' && modelSearch) {
                                 e.preventDefault()
@@ -917,11 +921,36 @@ export const NewProviderDialog: FC<NewProviderDialogProps> = ({
                               }
                             }}
                           />
-                          <CommandList>
+                          <CommandList ref={modelListRef}>
                             <CommandEmpty>
                               No models found. Press Enter to use &quot;
                               {modelSearch}&quot;
                             </CommandEmpty>
+                            {showCustomEntry && (
+                              <CommandGroup forceMount>
+                                <CommandItem
+                                  forceMount
+                                  value={`custom:${modelSearch}`}
+                                  onSelect={() => {
+                                    form.setValue('modelId', modelSearch)
+                                    track(MODEL_SELECTED_EVENT, {
+                                      provider_type: watchedType,
+                                      model_id: modelSearch,
+                                      is_custom_model: true,
+                                    })
+                                    setModelPickerOpen(false)
+                                    setModelSearch('')
+                                  }}
+                                >
+                                  <span className="flex-1 truncate">
+                                    {modelSearch}
+                                  </span>
+                                  {field.value === modelSearch && (
+                                    <Check className="ml-2 h-4 w-4 shrink-0" />
+                                  )}
+                                </CommandItem>
+                              </CommandGroup>
+                            )}
                             {filteredModels.length > 0 && (
                               <CommandGroup>
                                 {filteredModels.map((model) => (


### PR DESCRIPTION
## Summary
- Fixes the custom model entry being scrolled out of view in the model selector dropdown
- Uses cmdk's `forceMount` prop to prevent the custom entry from being hidden by internal filtering
- Resets scroll to top on every keystroke via `requestAnimationFrame` to counter cmdk's auto-scroll behavior
- Follows up on #661 which introduced the custom model entry feature

## Context
PR #661 injected the custom entry into `filteredModels` as a regular `CommandItem`. However, cmdk auto-selects and scrolls to its first recognized item in the suggestions group, pushing the custom entry above the visible area. This was intermittent — depending on timing of cmdk's scroll-into-view logic.

## Test plan
- [ ] Open Settings → Add Provider (e.g. OpenRouter)
- [ ] Type "anth" → verify "anth" appears as the first visible row (not scrolled away)
- [ ] Type "anthropic/" → verify "anthropic/" is first, followed by matching models
- [ ] Type "my-custom-model" → verify it appears as first row
- [ ] Type exact model ID (e.g. `anthropic/claude-sonnet-4.5`) → verify no duplicate custom entry
- [ ] Click the custom entry → verify it's selected as the model
- [ ] Press Enter → verify typed text is committed as model ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)