### PR TITLE
chore: add .omc/ to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ packages/browseros/build/tools/
 
 # AI SDK DevTools traces
 .devtools/
+.omc/


### PR DESCRIPTION
## Summary
- Adds `.omc/` to `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)