### PR TITLE
feat(openclaw): WS streaming, device auth, MCP port fix

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentChat.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentChat.tsx
@@ -1,19 +1,43 @@
-import { ArrowLeft, Loader2, Send } from 'lucide-react'
 import {
-  type Dispatch,
-  type FC,
-  type SetStateAction,
-  useRef,
-  useState,
-} from 'react'
+  ArrowLeft,
+  Bot,
+  CheckCircle2,
+  Loader2,
+  Send,
+  XCircle,
+} from 'lucide-react'
+import { type FC, useEffect, useRef, useState } from 'react'
+import {
+  Message,
+  MessageContent,
+  MessageResponse,
+} from '@/components/ai-elements/message'
+import {
+  Reasoning,
+  ReasoningContent,
+  ReasoningTrigger,
+} from '@/components/ai-elements/reasoning'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
-import { chatWithAgent } from './useOpenClaw'
+import { chatWithAgent, type OpenClawStreamEvent } from './useOpenClaw'
 
-interface ChatMessage {
+interface ToolEntry {
   id: string
-  role: 'user' | 'assistant'
-  content: string
+  name: string
+  status: 'running' | 'completed' | 'error'
+  durationMs?: number
+}
+
+type AssistantPart =
+  | { kind: 'thinking'; text: string; done: boolean }
+  | { kind: 'tool-batch'; tools: ToolEntry[] }
+  | { kind: 'text'; text: string }
+
+interface ChatTurn {
+  id: string
+  userText: string
+  parts: AssistantPart[]
+  done: boolean
 }
 
 interface AgentChatProps {
@@ -22,58 +46,26 @@ interface AgentChatProps {
   onBack: () => void
 }
 
-function appendDelta(
-  setMessages: Dispatch<SetStateAction<ChatMessage[]>>,
-  targetId: string,
-  delta: string,
-) {
-  setMessages((prev) =>
-    prev.map((m) =>
-      m.id === targetId ? { ...m, content: m.content + delta } : m,
-    ),
-  )
-}
+function parseSSELines(buffer: string): {
+  events: OpenClawStreamEvent[]
+  remainder: string
+} {
+  const lines = buffer.split('\n')
+  const remainder = lines.pop() ?? ''
+  const events: OpenClawStreamEvent[] = []
 
-function setMessageContent(
-  setMessages: Dispatch<SetStateAction<ChatMessage[]>>,
-  targetId: string,
-  content: string,
-) {
-  setMessages((prev) =>
-    prev.map((m) => (m.id === targetId ? { ...m, content } : m)),
-  )
-}
-
-async function streamResponse(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
-  assistantId: string,
-  setMessages: Dispatch<SetStateAction<ChatMessage[]>>,
-) {
-  const decoder = new TextDecoder()
-  let buffer = ''
-
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
-
-    buffer += decoder.decode(value, { stream: true })
-    const lines = buffer.split('\n')
-    buffer = lines.pop() ?? ''
-
-    for (const line of lines) {
-      if (!line.startsWith('data: ')) continue
-      const data = line.slice(6)
-      if (data === '[DONE]') continue
-
-      try {
-        const parsed = JSON.parse(data)
-        const delta = parsed.choices?.[0]?.delta?.content
-        if (delta) appendDelta(setMessages, assistantId, delta)
-      } catch {
-        // Skip unparseable chunks
-      }
+  for (const line of lines) {
+    if (!line.startsWith('data: ')) continue
+    const payload = line.slice(6)
+    if (payload === '[DONE]') continue
+    try {
+      events.push(JSON.parse(payload) as OpenClawStreamEvent)
+    } catch {
+      // skip
     }
   }
+
+  return { events, remainder }
 }
 
 export const AgentChat: FC<AgentChatProps> = ({
@@ -81,61 +73,207 @@ export const AgentChat: FC<AgentChatProps> = ({
   agentName,
   onBack,
 }) => {
-  const [messages, setMessages] = useState<ChatMessage[]>([])
+  const [turns, setTurns] = useState<ChatTurn[]>([])
   const [input, setInput] = useState('')
   const [streaming, setStreaming] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
-  const messagesRef = useRef(messages)
-  messagesRef.current = messages
+  const sessionKeyRef = useRef(crypto.randomUUID())
+
+  const textAccRef = useRef('')
+  const thinkAccRef = useRef('')
 
   const scrollToBottom = () => {
     scrollRef.current?.scrollTo(0, scrollRef.current.scrollHeight)
+  }
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: scroll on every turns change
+  useEffect(() => {
+    scrollToBottom()
+  }, [turns])
+
+  const updateCurrentTurnParts = (
+    updater: (parts: AssistantPart[]) => AssistantPart[],
+  ) => {
+    setTurns((prev) => {
+      const last = prev[prev.length - 1]
+      if (!last) return prev
+      return [...prev.slice(0, -1), { ...last, parts: updater(last.parts) }]
+    })
+  }
+
+  const processStream = async (response: Response) => {
+    const reader = response.body?.getReader()
+    if (!reader) return
+
+    const decoder = new TextDecoder()
+    let buffer = ''
+
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+
+      buffer += decoder.decode(value, { stream: true })
+      const { events, remainder } = parseSSELines(buffer)
+      buffer = remainder
+
+      for (const event of events) {
+        switch (event.type) {
+          case 'text-delta': {
+            const delta = (event.data.text as string) ?? ''
+            textAccRef.current += delta
+            const text = textAccRef.current
+            updateCurrentTurnParts((parts) => {
+              const last = parts[parts.length - 1]
+              if (last?.kind === 'text') {
+                return [...parts.slice(0, -1), { ...last, text }]
+              }
+              return [...parts, { kind: 'text', text }]
+            })
+            break
+          }
+
+          case 'thinking': {
+            const delta = (event.data.text as string) ?? ''
+            thinkAccRef.current += delta
+            const text = thinkAccRef.current
+            updateCurrentTurnParts((parts) => {
+              const idx = parts.findIndex(
+                (p) => p.kind === 'thinking' && !p.done,
+              )
+              if (idx >= 0) {
+                return [
+                  ...parts.slice(0, idx),
+                  { ...parts[idx], text, done: false },
+                  ...parts.slice(idx + 1),
+                ]
+              }
+              return [...parts, { kind: 'thinking', text, done: false }]
+            })
+            break
+          }
+
+          case 'tool-start': {
+            const tool: ToolEntry = {
+              id: (event.data.toolCallId as string) ?? crypto.randomUUID(),
+              name: (event.data.toolName as string) ?? 'unknown',
+              status: 'running',
+            }
+            updateCurrentTurnParts((parts) => {
+              // Append to last batch if it's consecutive, otherwise start new batch
+              const last = parts[parts.length - 1]
+              if (last?.kind === 'tool-batch') {
+                return [
+                  ...parts.slice(0, -1),
+                  { ...last, tools: [...last.tools, tool] },
+                ]
+              }
+              return [...parts, { kind: 'tool-batch', tools: [tool] }]
+            })
+            break
+          }
+
+          case 'tool-end': {
+            const toolId = event.data.toolCallId as string
+            const status =
+              (event.data.status as string) === 'error' ? 'error' : 'completed'
+            const durationMs = event.data.durationMs as number | undefined
+            updateCurrentTurnParts((parts) => {
+              // Find the batch containing this tool (search from end)
+              for (let i = parts.length - 1; i >= 0; i--) {
+                const part = parts[i]
+                if (
+                  part.kind === 'tool-batch' &&
+                  part.tools.some((t) => t.id === toolId)
+                ) {
+                  const updatedTools = part.tools.map((t) =>
+                    t.id === toolId
+                      ? {
+                          ...t,
+                          status: status as ToolEntry['status'],
+                          durationMs,
+                        }
+                      : t,
+                  )
+                  return [
+                    ...parts.slice(0, i),
+                    { ...part, tools: updatedTools },
+                    ...parts.slice(i + 1),
+                  ]
+                }
+              }
+              return parts
+            })
+            break
+          }
+
+          case 'done': {
+            updateCurrentTurnParts((parts) =>
+              parts.map((p) =>
+                p.kind === 'thinking' ? { ...p, done: true } : p,
+              ),
+            )
+            setTurns((prev) => {
+              const last = prev[prev.length - 1]
+              if (!last) return prev
+              return [...prev.slice(0, -1), { ...last, done: true }]
+            })
+            break
+          }
+
+          case 'error': {
+            const msg =
+              (event.data.message as string) ??
+              (event.data.error as string) ??
+              'Unknown error'
+            updateCurrentTurnParts((parts) => [
+              ...parts,
+              { kind: 'text', text: `Error: ${msg}` },
+            ])
+            break
+          }
+        }
+      }
+    }
   }
 
   const handleSend = async () => {
     const text = input.trim()
     if (!text || streaming) return
 
-    setMessages((prev) => [
-      ...prev,
-      { id: crypto.randomUUID(), role: 'user', content: text },
-    ])
+    const turn: ChatTurn = {
+      id: crypto.randomUUID(),
+      userText: text,
+      parts: [],
+      done: false,
+    }
+    setTurns((prev) => [...prev, turn])
     setInput('')
     setStreaming(true)
-    setTimeout(scrollToBottom, 0)
 
-    const assistantId = crypto.randomUUID()
-    setMessages((prev) => [
-      ...prev,
-      { id: assistantId, role: 'assistant', content: '' },
-    ])
+    textAccRef.current = ''
+    thinkAccRef.current = ''
 
     try {
-      const allMessages = [
-        ...messagesRef.current.map((m) => ({
-          role: m.role,
-          content: m.content,
-        })),
-        { role: 'user' as const, content: text },
-      ]
-      const response = await chatWithAgent(agentId, allMessages)
+      const response = await chatWithAgent(agentId, text, sessionKeyRef.current)
 
       if (!response.ok) {
         const err = await response.text()
-        setMessageContent(setMessages, assistantId, `Error: ${err}`)
+        updateCurrentTurnParts((parts) => [
+          ...parts,
+          { kind: 'text', text: `Error: ${err}` },
+        ])
         return
       }
 
-      const reader = response.body?.getReader()
-      if (!reader) return
-
-      await streamResponse(reader, assistantId, setMessages)
+      await processStream(response)
     } catch (err) {
       const msg = err instanceof Error ? err.message : String(err)
-      setMessageContent(setMessages, assistantId, `Error: ${msg}`)
+      updateCurrentTurnParts((parts) => [
+        ...parts,
+        { kind: 'text', text: `Error: ${msg}` },
+      ])
     } finally {
       setStreaming(false)
-      setTimeout(scrollToBottom, 0)
     }
   }
 
@@ -149,25 +287,95 @@ export const AgentChat: FC<AgentChatProps> = ({
       </div>
 
       <div ref={scrollRef} className="flex-1 space-y-4 overflow-y-auto p-4">
-        {messages.map((msg) => (
-          <div
-            key={msg.id}
-            className={`flex ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
-          >
-            <div
-              className={`max-w-[80%] rounded-lg px-4 py-2 ${
-                msg.role === 'user'
-                  ? 'bg-primary text-primary-foreground'
-                  : 'bg-muted'
-              }`}
-            >
-              <pre className="whitespace-pre-wrap font-sans text-sm">
-                {msg.content}
-                {msg.role === 'assistant' && streaming && !msg.content && (
-                  <Loader2 className="inline size-3 animate-spin" />
-                )}
-              </pre>
-            </div>
+        {turns.map((turn) => (
+          <div key={turn.id} className="space-y-3">
+            {/* User message */}
+            <Message from="user">
+              <MessageContent>
+                <pre className="whitespace-pre-wrap font-sans text-sm">
+                  {turn.userText}
+                </pre>
+              </MessageContent>
+            </Message>
+
+            {/* Assistant response — all parts grouped */}
+            {turn.parts.length > 0 && (
+              <Message from="assistant">
+                <MessageContent>
+                  {turn.parts.map((part, i) => {
+                    const key = `${turn.id}-part-${i}`
+
+                    switch (part.kind) {
+                      case 'thinking':
+                        return (
+                          <Reasoning
+                            key={key}
+                            className="w-full"
+                            isStreaming={!part.done}
+                            defaultOpen={!part.done}
+                          >
+                            <ReasoningTrigger />
+                            <ReasoningContent>{part.text}</ReasoningContent>
+                          </Reasoning>
+                        )
+
+                      case 'tool-batch':
+                        return (
+                          <div key={key} className="w-full space-y-1">
+                            {part.tools.map((tool) => (
+                              <div
+                                key={tool.id}
+                                className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
+                              >
+                                {tool.status === 'running' && (
+                                  <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
+                                )}
+                                {tool.status === 'completed' && (
+                                  <CheckCircle2 className="size-3.5 text-green-500" />
+                                )}
+                                {tool.status === 'error' && (
+                                  <XCircle className="size-3.5 text-destructive" />
+                                )}
+                                <span className="font-mono text-xs">
+                                  {tool.name}
+                                </span>
+                                {tool.durationMs != null && (
+                                  <span className="ml-auto text-muted-foreground text-xs">
+                                    {(tool.durationMs / 1000).toFixed(1)}s
+                                  </span>
+                                )}
+                              </div>
+                            ))}
+                          </div>
+                        )
+
+                      case 'text':
+                        return (
+                          <MessageResponse key={key}>
+                            {part.text}
+                          </MessageResponse>
+                        )
+                      default:
+                        return null
+                    }
+                  })}
+                </MessageContent>
+              </Message>
+            )}
+
+            {/* Streaming indicator when waiting for first part */}
+            {!turn.done && turn.parts.length === 0 && streaming && (
+              <div className="flex gap-2">
+                <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[var(--accent-orange)] text-white">
+                  <Bot className="h-3.5 w-3.5" />
+                </div>
+                <div className="flex items-center gap-1 rounded-xl rounded-tl-none border border-border/50 bg-card px-3 py-2.5 shadow-sm">
+                  <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--accent-orange)] [animation-delay:-0.3s]" />
+                  <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--accent-orange)] [animation-delay:-0.15s]" />
+                  <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--accent-orange)]" />
+                </div>
+              </div>
+            )}
           </div>
         ))}
       </div>

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/useOpenClaw.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/useOpenClaw.ts
@@ -116,14 +116,28 @@ export async function restartOpenClaw() {
   return clawFetch<{ status: string }>('/restart', { method: 'POST' })
 }
 
+export interface OpenClawStreamEvent {
+  type:
+    | 'text-delta'
+    | 'thinking'
+    | 'tool-start'
+    | 'tool-end'
+    | 'tool-output'
+    | 'lifecycle'
+    | 'done'
+    | 'error'
+  data: Record<string, unknown>
+}
+
 export async function chatWithAgent(
   agentId: string,
-  messages: Array<{ role: string; content: string }>,
+  message: string,
+  sessionKey?: string,
 ): Promise<Response> {
   const baseUrl = await getAgentServerUrl()
   return fetch(`${baseUrl}/claw/agents/${agentId}/chat`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ messages }),
+    body: JSON.stringify({ message, sessionKey }),
   })
 }

--- a/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
@@ -170,12 +170,18 @@ export function createOpenClawRoutes() {
         return stream(c, async (s) => {
           const reader = eventStream.getReader()
           const encoder = new TextEncoder()
-          while (true) {
-            const { done, value } = await reader.read()
-            if (done) break
-            await s.write(encoder.encode(`data: ${JSON.stringify(value)}\n\n`))
+          try {
+            while (true) {
+              const { done, value } = await reader.read()
+              if (done) break
+              await s.write(
+                encoder.encode(`data: ${JSON.stringify(value)}\n\n`),
+              )
+            }
+            await s.write(encoder.encode('data: [DONE]\n\n'))
+          } finally {
+            await reader.cancel()
           }
-          await s.write(encoder.encode('data: [DONE]\n\n'))
         })
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)

--- a/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
@@ -146,31 +146,36 @@ export function createOpenClawRoutes() {
     .post('/agents/:id/chat', async (c) => {
       const { id } = c.req.param()
       const body = await c.req.json<{
-        messages: Array<{
-          role: 'user' | 'assistant' | 'system'
-          content: string
-        }>
+        message: string
+        sessionKey?: string
       }>()
 
-      if (!body.messages?.length) {
-        return c.json({ error: 'Messages are required' }, 400)
+      if (!body.message?.trim()) {
+        return c.json({ error: 'Message is required' }, 400)
       }
 
+      const sessionKey = body.sessionKey ?? crypto.randomUUID()
+
       try {
-        const response = await getOpenClawService().chat(id, body.messages)
+        const eventStream = getOpenClawService().chatStream(
+          id,
+          sessionKey,
+          body.message,
+        )
 
         c.header('Content-Type', 'text/event-stream')
         c.header('Cache-Control', 'no-cache')
+        c.header('X-Session-Key', sessionKey)
 
         return stream(c, async (s) => {
-          const reader = (
-            response.body as ReadableStream<Uint8Array>
-          ).getReader()
+          const reader = eventStream.getReader()
+          const encoder = new TextEncoder()
           while (true) {
             const { done, value } = await reader.read()
             if (done) break
-            await s.write(value)
+            await s.write(encoder.encode(`data: ${JSON.stringify(value)}\n\n`))
           }
+          await s.write(encoder.encode('data: [DONE]\n\n'))
         })
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err)

--- a/packages/browseros-agent/apps/server/src/main.ts
+++ b/packages/browseros-agent/apps/server/src/main.ts
@@ -119,7 +119,7 @@ export class Application {
     this.logStartupSummary()
     startSkillSync()
 
-    getOpenClawService()
+    getOpenClawService(this.config.serverPort)
       .tryAutoStart()
       .catch((err) =>
         logger.warn('OpenClaw auto-start failed', {

--- a/packages/browseros-agent/apps/server/src/services/openclaw/container-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/services/openclaw/container-runtime.ts
@@ -128,6 +128,13 @@ export class ContainerRuntime {
     }
   }
 
+  async execInContainer(command: string[], onLog?: LogFn): Promise<number> {
+    const containerName = `${COMPOSE_PROJECT_NAME}-openclaw-gateway-1`
+    return this.podman.runCommand(['exec', containerName, ...command], {
+      onOutput: onLog,
+    })
+  }
+
   private async compose(args: string[], onLog?: LogFn): Promise<number> {
     return this.podman.runCommand(['compose', ...args], {
       cwd: this.projectDir,

--- a/packages/browseros-agent/apps/server/src/services/openclaw/gateway-client.ts
+++ b/packages/browseros-agent/apps/server/src/services/openclaw/gateway-client.ts
@@ -421,15 +421,14 @@ export class GatewayClient {
     const pendingRequests = this.pendingRequests
     const fullSessionKey = `agent:${agentId}:browseros-${sessionKey}`
     const idempotencyKey = globalThis.crypto.randomUUID()
+    const originalOnMessage = ws.onmessage
+
+    const restore = () => {
+      ws.onmessage = originalOnMessage
+    }
 
     return new ReadableStream<OpenClawStreamEvent>({
       start: (controller) => {
-        const originalOnMessage = ws.onmessage
-
-        const restore = () => {
-          ws.onmessage = originalOnMessage
-        }
-
         const subscribeId = globalThis.crypto.randomUUID()
         const agentReqId = globalThis.crypto.randomUUID()
 
@@ -608,6 +607,9 @@ export class GatewayClient {
             },
           }),
         )
+      },
+      cancel: () => {
+        restore()
       },
     })
   }

--- a/packages/browseros-agent/apps/server/src/services/openclaw/gateway-client.ts
+++ b/packages/browseros-agent/apps/server/src/services/openclaw/gateway-client.ts
@@ -4,16 +4,34 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
  * WebSocket client for the OpenClaw Gateway protocol.
- * Handles handshake (challenge → connect → hello-ok), JSON-RPC over WS,
- * and auto-reconnect. Used for agent CRUD and health — chat uses HTTP.
+ * Handles handshake (challenge → connect → hello-ok) with Ed25519 device
+ * identity signing, JSON-RPC over WS, and auto-reconnect.
+ * Used for agent CRUD and health — chat uses HTTP.
  */
 
+import crypto from 'node:crypto'
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { logger } from '../../lib/logger'
 
 const RPC_TIMEOUT_MS = 15_000
 const RECONNECT_DELAY_MS = 2_000
 const MAX_RECONNECT_RETRIES = 5
 const CONTAINER_HOME = '/home/node/.openclaw'
+
+const SCOPES = [
+  'operator.read',
+  'operator.write',
+  'operator.admin',
+  'operator.approvals',
+  'operator.pairing',
+]
+
+interface DeviceIdentity {
+  deviceId: string
+  publicKeyPem: string
+  privateKeyPem: string
+}
 
 interface PendingRequest {
   resolve: (value: unknown) => void
@@ -32,12 +50,119 @@ interface WsFrame {
   event?: string
 }
 
+export interface OpenClawStreamEvent {
+  type:
+    | 'text-delta'
+    | 'thinking'
+    | 'tool-start'
+    | 'tool-end'
+    | 'tool-output'
+    | 'lifecycle'
+    | 'done'
+    | 'error'
+  data: Record<string, unknown>
+}
+
 export interface GatewayAgentEntry {
   agentId: string
   name: string
   workspace: string
   model?: string
 }
+
+// ── Device Identity Helpers ─────────────────────────────────────────
+
+function rawPublicKeyFromPem(pem: string): Buffer {
+  const der = Buffer.from(
+    pem.replace(/-----[^-]+-----/g, '').replace(/\s/g, ''),
+    'base64',
+  )
+  return der.subarray(12)
+}
+
+function signChallenge(
+  device: DeviceIdentity,
+  nonce: string,
+  token: string,
+): { signature: string; signedAt: number; publicKey: string } {
+  const signedAt = Date.now()
+  const payload = `v3|${device.deviceId}|cli|cli|operator|${SCOPES.join(',')}|${signedAt}|${token}|${nonce}|${process.platform}|`
+  const privateKey = crypto.createPrivateKey(device.privateKeyPem)
+  const sig = crypto.sign(null, Buffer.from(payload, 'utf-8'), privateKey)
+
+  return {
+    signature: sig.toString('base64url'),
+    signedAt,
+    publicKey: rawPublicKeyFromPem(device.publicKeyPem).toString('base64url'),
+  }
+}
+
+/**
+ * Generates a client Ed25519 identity and pre-seeds it into the gateway's
+ * paired devices file so the gateway trusts it on next boot.
+ * Must be called before compose up (or requires a restart after).
+ */
+export function ensureClientIdentity(openclawDir: string): DeviceIdentity {
+  const identityPath = join(openclawDir, 'client-identity.json')
+
+  try {
+    return JSON.parse(readFileSync(identityPath, 'utf-8'))
+  } catch {
+    // Generate new identity
+  }
+
+  const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519')
+  const publicKeyPem = publicKey
+    .export({ type: 'spki', format: 'pem' })
+    .toString()
+  const privateKeyPem = privateKey
+    .export({ type: 'pkcs8', format: 'pem' })
+    .toString()
+
+  const rawPub = rawPublicKeyFromPem(publicKeyPem)
+  const deviceId = crypto.createHash('sha256').update(rawPub).digest('hex')
+
+  const identity: DeviceIdentity = { deviceId, publicKeyPem, privateKeyPem }
+  writeFileSync(identityPath, JSON.stringify(identity, null, 2), {
+    mode: 0o600,
+  })
+
+  seedPairedDevice(openclawDir, identity)
+  logger.info('Generated client device identity and pre-seeded pairing')
+
+  return identity
+}
+
+function seedPairedDevice(openclawDir: string, identity: DeviceIdentity): void {
+  const devicesDir = join(openclawDir, 'devices')
+  mkdirSync(devicesDir, { recursive: true })
+
+  const pairedPath = join(devicesDir, 'paired.json')
+  let paired: Record<string, unknown> = {}
+  try {
+    paired = JSON.parse(readFileSync(pairedPath, 'utf-8'))
+  } catch {
+    // First time
+  }
+
+  const rawPub = rawPublicKeyFromPem(identity.publicKeyPem)
+  paired[identity.deviceId] = {
+    deviceId: identity.deviceId,
+    publicKey: rawPub.toString('base64url'),
+    platform: process.platform,
+    clientId: 'cli',
+    clientMode: 'cli',
+    role: 'operator',
+    roles: ['operator'],
+    scopes: SCOPES,
+    pairedAt: Date.now(),
+    label: 'browseros-server',
+  }
+
+  writeFileSync(pairedPath, JSON.stringify(paired, null, 2), { mode: 0o600 })
+}
+
+// ── Gateway Client ──────────────────────────────────────────────────
 
 export class GatewayClient {
   private ws: WebSocket | null = null
@@ -46,13 +171,21 @@ export class GatewayClient {
   private reconnectAttempts = 0
   private shouldReconnect = true
   private version: string
+  private device: DeviceIdentity | null = null
 
   constructor(
     private port: number,
     private token: string,
+    openclawDir: string,
     version = '1.0.0',
   ) {
     this.version = version
+    try {
+      const identityPath = join(openclawDir, 'client-identity.json')
+      this.device = JSON.parse(readFileSync(identityPath, 'utf-8'))
+    } catch {
+      logger.warn('Client device identity not found, WS auth may fail')
+    }
   }
 
   get isConnected(): boolean {
@@ -62,7 +195,9 @@ export class GatewayClient {
   async connect(): Promise<void> {
     return new Promise((resolve, reject) => {
       const url = `ws://127.0.0.1:${this.port}`
-      this.ws = new WebSocket(url)
+      this.ws = new WebSocket(url, {
+        headers: { Origin: `http://127.0.0.1:${this.port}` },
+      } as unknown as string[])
 
       let handshakeComplete = false
       let connectReqId: string | null = null
@@ -79,30 +214,48 @@ export class GatewayClient {
           return
         }
 
-        // During handshake: wait for challenge, then hello-ok
         if (!handshakeComplete) {
           if (frame.type === 'event' && frame.event === 'connect.challenge') {
-            connectReqId = crypto.randomUUID()
-            this.ws!.send(
+            const nonce = (frame.payload as Record<string, unknown>)
+              ?.nonce as string
+            connectReqId = globalThis.crypto.randomUUID()
+
+            const params: Record<string, unknown> = {
+              minProtocol: 3,
+              maxProtocol: 3,
+              client: {
+                id: 'cli',
+                version: this.version,
+                platform: process.platform,
+                mode: 'cli',
+              },
+              role: 'operator',
+              scopes: SCOPES,
+              caps: [],
+              commands: [],
+              permissions: {},
+              auth: { token: this.token },
+              locale: 'en-US',
+              userAgent: `browseros-server/${this.version}`,
+            }
+
+            if (this.device && nonce) {
+              const signed = signChallenge(this.device, nonce, this.token)
+              params.device = {
+                id: this.device.deviceId,
+                publicKey: signed.publicKey,
+                signature: signed.signature,
+                signedAt: signed.signedAt,
+                nonce,
+              }
+            }
+
+            this.ws?.send(
               JSON.stringify({
                 type: 'req',
                 id: connectReqId,
                 method: 'connect',
-                params: {
-                  minProtocol: 3,
-                  maxProtocol: 3,
-                  client: {
-                    id: 'openclaw-control-ui',
-                    version: this.version,
-                    platform: process.platform,
-                    mode: 'ui',
-                  },
-                  role: 'operator',
-                  scopes: ['operator.read', 'operator.write', 'operator.admin'],
-                  auth: { token: this.token },
-                  locale: 'en-US',
-                  userAgent: `browseros-server/${this.version}`,
-                },
+                params,
               }),
             )
             return
@@ -128,7 +281,6 @@ export class GatewayClient {
           return
         }
 
-        // After handshake: route responses and events
         if (frame.type === 'res' && frame.id) {
           const pending = this.pendingRequests.get(frame.id)
           if (pending) {
@@ -141,7 +293,6 @@ export class GatewayClient {
             }
           }
         }
-        // Events (tick, health, etc.) — log for now, extend later
       }
 
       this.ws.onerror = (err) => {
@@ -186,7 +337,7 @@ export class GatewayClient {
       throw new Error('Gateway WS not connected')
     }
 
-    const id = crypto.randomUUID()
+    const id = globalThis.crypto.randomUUID()
 
     return new Promise<T>((resolve, reject) => {
       const timer = setTimeout(() => {
@@ -200,17 +351,28 @@ export class GatewayClient {
         timer,
       })
 
-      this.ws!.send(JSON.stringify({ type: 'req', id, method, params }))
+      this.ws?.send(JSON.stringify({ type: 'req', id, method, params }))
     })
   }
 
   // ── Agent Methods ────────────────────────────────────────────────────
 
   async listAgents(): Promise<GatewayAgentEntry[]> {
-    const result = await this.rpc<{ agents: GatewayAgentEntry[] }>(
-      'agents.list',
-    )
-    return result.agents ?? []
+    const result = await this.rpc<{
+      agents: Array<{
+        id: string
+        name?: string
+        workspace: string
+        model?: string
+      }>
+    }>('agents.list')
+
+    return (result.agents ?? []).map((a) => ({
+      agentId: a.id,
+      name: a.name ?? a.id,
+      workspace: a.workspace,
+      model: a.model,
+    }))
   }
 
   async createAgent(input: {
@@ -218,7 +380,20 @@ export class GatewayClient {
     workspace: string
     model?: string
   }): Promise<GatewayAgentEntry> {
-    return this.rpc<GatewayAgentEntry>('agents.create', input)
+    const result = await this.rpc<{
+      agentId?: string
+      id?: string
+      name?: string
+      workspace?: string
+      model?: string
+    }>('agents.create', input)
+
+    return {
+      agentId: result.agentId ?? result.id ?? input.name,
+      name: result.name ?? input.name,
+      workspace: result.workspace ?? input.workspace,
+      model: result.model ?? input.model,
+    }
   }
 
   async deleteAgent(agentId: string): Promise<void> {
@@ -229,6 +404,212 @@ export class GatewayClient {
 
   async getHealth(): Promise<Record<string, unknown>> {
     return this.rpc('health')
+  }
+
+  // ── Chat Stream ─────────────────────────────────────────────────────
+
+  chatStream(
+    agentId: string,
+    sessionKey: string,
+    message: string,
+  ): ReadableStream<OpenClawStreamEvent> {
+    if (!this._connected || !this.ws) {
+      throw new Error('Gateway WS not connected')
+    }
+
+    const ws = this.ws
+    const pendingRequests = this.pendingRequests
+    const fullSessionKey = `agent:${agentId}:browseros-${sessionKey}`
+    const idempotencyKey = globalThis.crypto.randomUUID()
+
+    return new ReadableStream<OpenClawStreamEvent>({
+      start: (controller) => {
+        const originalOnMessage = ws.onmessage
+
+        const restore = () => {
+          ws.onmessage = originalOnMessage
+        }
+
+        const subscribeId = globalThis.crypto.randomUUID()
+        const agentReqId = globalThis.crypto.randomUUID()
+
+        ws.onmessage = (event) => {
+          let frame: WsFrame
+          try {
+            frame = JSON.parse(
+              typeof event.data === 'string'
+                ? event.data
+                : new TextDecoder().decode(event.data as ArrayBuffer),
+            )
+          } catch {
+            return
+          }
+
+          if (frame.type === 'res' && frame.id) {
+            if (frame.id === subscribeId || frame.id === agentReqId) {
+              if (!frame.ok) {
+                controller.enqueue({
+                  type: 'error',
+                  data: {
+                    message: frame.error?.message ?? 'RPC error',
+                    code: frame.error?.code,
+                  },
+                })
+                controller.close()
+                restore()
+              }
+              return
+            }
+
+            const pending = pendingRequests.get(frame.id)
+            if (pending) {
+              pendingRequests.delete(frame.id)
+              clearTimeout(pending.timer)
+              if (frame.ok) {
+                pending.resolve(frame.payload)
+              } else {
+                pending.reject(new Error(frame.error?.message ?? 'RPC error'))
+              }
+            }
+            return
+          }
+
+          const anyFrame = frame as any
+          const eventName = anyFrame.event as string | undefined
+          const payload = anyFrame.payload as
+            | Record<string, unknown>
+            | undefined
+
+          if (!eventName || !payload) return
+
+          if (eventName === 'agent') {
+            const streamType = payload.stream as string | undefined
+            const data = payload.data as Record<string, unknown> | undefined
+
+            if (streamType === 'assistant' && data?.delta) {
+              controller.enqueue({
+                type: 'text-delta',
+                data: { text: data.delta },
+              })
+              return
+            }
+
+            if (streamType === 'item' && data) {
+              const phase = data.phase as string | undefined
+              if (phase === 'start') {
+                controller.enqueue({
+                  type: 'tool-start',
+                  data: {
+                    toolCallId: data.toolCallId ?? data.id,
+                    toolName: data.name ?? data.title,
+                    kind: data.kind,
+                  },
+                })
+                return
+              }
+              if (phase === 'end') {
+                controller.enqueue({
+                  type: 'tool-end',
+                  data: {
+                    toolCallId: data.toolCallId ?? data.id,
+                    status: data.status,
+                    durationMs: data.durationMs,
+                  },
+                })
+                return
+              }
+            }
+
+            if (streamType === 'lifecycle') {
+              controller.enqueue({
+                type: 'lifecycle',
+                data: { phase: data?.phase ?? payload.phase },
+              })
+              return
+            }
+          }
+
+          if (eventName === 'session.tool') {
+            const toolData =
+              (payload.data as Record<string, unknown>) ?? payload
+            const phase =
+              (toolData.phase as string) ?? (payload.phase as string)
+            if (phase === 'result') {
+              controller.enqueue({
+                type: 'tool-output',
+                data: {
+                  toolCallId: toolData.toolCallId,
+                  isError: toolData.isError ?? false,
+                  meta: toolData.meta,
+                },
+              })
+              return
+            }
+          }
+
+          if (eventName === 'session.message') {
+            const msg = payload.message as Record<string, unknown> | undefined
+            if (msg?.role === 'assistant') {
+              const content = msg.content as
+                | Array<Record<string, unknown>>
+                | undefined
+              if (content) {
+                for (const block of content) {
+                  if (block.type === 'thinking') {
+                    const text =
+                      (block.thinking as string) ??
+                      (block.content as string) ??
+                      (block.text as string) ??
+                      ''
+                    if (text) {
+                      controller.enqueue({
+                        type: 'thinking',
+                        data: { text },
+                      })
+                    }
+                  }
+                }
+              }
+            }
+          }
+
+          if (eventName === 'chat') {
+            const state = payload.state as string | undefined
+            if (state === 'final') {
+              controller.enqueue({
+                type: 'done',
+                data: { text: (payload.text as string) ?? '' },
+              })
+              controller.close()
+              restore()
+              return
+            }
+          }
+        }
+
+        ws.send(
+          JSON.stringify({
+            type: 'req',
+            id: subscribeId,
+            method: 'sessions.subscribe',
+            params: { sessionKey: fullSessionKey },
+          }),
+        )
+
+        ws.send(
+          JSON.stringify({
+            type: 'req',
+            id: agentReqId,
+            method: 'agent',
+            params: {
+              message,
+              sessionKey: fullSessionKey,
+              idempotencyKey,
+            },
+          }),
+        )
+      },
+    })
   }
 
   // ── Helpers ──────────────────────────────────────────────────────────

--- a/packages/browseros-agent/apps/server/src/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/services/openclaw/openclaw-service.ts
@@ -141,8 +141,14 @@ export class OpenClawService {
     logProgress('Pairing client device...')
     try {
       await this.connectGateway()
-    } catch {
-      // Expected: "pairing required" — now approve via CLI
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      if (
+        !msg.includes('pairing required') &&
+        !msg.includes('signature expired')
+      ) {
+        throw err
+      }
     }
 
     // Approve the pending device via the openclaw CLI inside the container
@@ -479,7 +485,7 @@ export class OpenClawService {
   ): Promise<void> {
     // List pending devices to get the request ID
     const output: string[] = []
-    await this.runtime.execInContainer(
+    const listCode = await this.runtime.execInContainer(
       [
         'node',
         'dist/index.js',
@@ -492,10 +498,21 @@ export class OpenClawService {
       (line) => output.push(line),
     )
 
-    const jsonStr = output.join('\n')
-    const data = JSON.parse(jsonStr)
-    const pending = data.pending as Array<{ requestId: string }> | undefined
+    if (listCode !== 0) {
+      throw new Error(`Failed to list pending devices (exit ${listCode})`)
+    }
 
+    const jsonStr = output.join('\n')
+    let data: { pending?: Array<{ requestId: string }> }
+    try {
+      data = JSON.parse(jsonStr)
+    } catch {
+      throw new Error(
+        `Failed to parse device list output: ${jsonStr.slice(0, 200)}`,
+      )
+    }
+
+    const pending = data.pending
     if (!pending?.length) {
       logger.warn('No pending device pair requests found')
       throw new Error('No pending device pair requests to approve')

--- a/packages/browseros-agent/apps/server/src/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/services/openclaw/openclaw-service.ts
@@ -11,11 +11,16 @@
 import { existsSync } from 'node:fs'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join, resolve } from 'node:path'
-import { TIMEOUTS } from '@browseros/shared/constants/timeouts'
+import { DEFAULT_PORTS } from '@browseros/shared/constants/ports'
 import { getOpenClawDir } from '../../lib/browseros-dir'
 import { logger } from '../../lib/logger'
 import { ContainerRuntime } from './container-runtime'
-import { type GatewayAgentEntry, GatewayClient } from './gateway-client'
+import {
+  ensureClientIdentity,
+  type GatewayAgentEntry,
+  GatewayClient,
+  type OpenClawStreamEvent,
+} from './gateway-client'
 import {
   buildBootstrapConfig,
   buildEnvFile,
@@ -30,7 +35,6 @@ const COMPOSE_RESOURCE = resolve(
 const OPENCLAW_CONFIG_FILE = 'openclaw.json'
 const GATEWAY_PORT = 18789
 const READY_TIMEOUT_MS = 30_000
-const CHAT_TIMEOUT_MS = TIMEOUTS.TOOL_CALL
 const AGENT_NAME_PATTERN = /^[a-z][a-z0-9-]*$/
 
 export type OpenClawStatus =
@@ -55,11 +59,6 @@ export interface SetupInput {
   modelId?: string
 }
 
-export interface ChatMessage {
-  role: 'user' | 'assistant' | 'system'
-  content: string
-}
-
 export class OpenClawService {
   private runtime: ContainerRuntime
   private gateway: GatewayClient | null = null
@@ -67,11 +66,13 @@ export class OpenClawService {
   private port = GATEWAY_PORT
   private token: string
   private lastError: string | null = null
+  private browserosServerPort: number
 
-  constructor() {
+  constructor(browserosServerPort?: number) {
     this.openclawDir = getOpenClawDir()
     this.runtime = new ContainerRuntime(getPodmanRuntime(), this.openclawDir)
     this.token = crypto.randomUUID()
+    this.browserosServerPort = browserosServerPort ?? DEFAULT_PORTS.server
   }
 
   // ── Lifecycle ────────────────────────────────────────────────────────
@@ -109,6 +110,7 @@ export class OpenClawService {
     const config = buildBootstrapConfig({
       gatewayPort: this.port,
       gatewayToken: this.token,
+      browserosServerPort: this.browserosServerPort,
       providerType: input.providerType,
       modelId: input.modelId,
     })
@@ -131,19 +133,41 @@ export class OpenClawService {
       throw new Error(this.lastError)
     }
 
+    // Generate client device identity for WS auth
+    logProgress('Generating client device identity...')
+    ensureClientIdentity(this.openclawDir)
+
+    // Attempt WS connect — this triggers a pending pair request
+    logProgress('Pairing client device...')
+    try {
+      await this.connectGateway()
+    } catch {
+      // Expected: "pairing required" — now approve via CLI
+    }
+
+    // Approve the pending device via the openclaw CLI inside the container
+    await this.approvePendingDevice(logProgress)
+
     logProgress('Connecting to gateway...')
     await this.connectGateway()
 
-    logProgress('Creating main agent...')
-    const model =
-      input.providerType && input.modelId
-        ? `${input.providerType}/${input.modelId}`
-        : undefined
-    await this.gateway!.createAgent({
-      name: 'main',
-      workspace: GatewayClient.agentWorkspace('main'),
-      model,
-    })
+    // Ensure main agent exists (gateway may auto-create it)
+    const existingAgents = await this.gateway!.listAgents()
+    const hasMain = existingAgents.some((a) => a.agentId === 'main')
+    if (!hasMain) {
+      logProgress('Creating main agent...')
+      const model =
+        input.providerType && input.modelId
+          ? `${input.providerType}/${input.modelId}`
+          : undefined
+      await this.gateway!.createAgent({
+        name: 'main',
+        workspace: GatewayClient.agentWorkspace('main'),
+        model,
+      })
+    } else {
+      logProgress('Main agent already exists')
+    }
 
     this.lastError = null
     logProgress(`OpenClaw gateway running at http://127.0.0.1:${this.port}`)
@@ -334,41 +358,16 @@ export class OpenClawService {
     return this.gateway!.listAgents()
   }
 
-  // ── Chat Proxy (HTTP) ───────────────────────────────────────────────
+  // ── Chat Stream (WS) ─────────────────────────────────────────────────
 
-  async chat(agentId: string, messages: ChatMessage[]): Promise<Response> {
-    await this.loadTokenFromEnv()
-    const url = `http://127.0.0.1:${this.port}/v1/chat/completions`
-    logger.debug('Proxying OpenClaw chat request', {
-      agentId,
-      messageCount: messages.length,
-      port: this.port,
-    })
-
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${this.token}`,
-      },
-      body: JSON.stringify({
-        model: `openclaw/${agentId}`,
-        stream: true,
-        messages,
-      }),
-      signal: AbortSignal.timeout(CHAT_TIMEOUT_MS),
-    })
-
-    if (!response.ok) {
-      const errText = await response.text()
-      throw new Error(`OpenClaw error (${response.status}): ${errText}`)
-    }
-
-    logger.debug('OpenClaw chat stream accepted', {
-      agentId,
-      status: response.status,
-    })
-    return response
+  chatStream(
+    agentId: string,
+    sessionKey: string,
+    message: string,
+  ): ReadableStream<OpenClawStreamEvent> {
+    this.ensureGatewayConnected()
+    logger.debug('Starting OpenClaw chat stream', { agentId, sessionKey })
+    return this.gateway!.chatStream(agentId, sessionKey, message)
   }
 
   // ── Provider Keys ────────────────────────────────────────────────────
@@ -425,10 +424,64 @@ export class OpenClawService {
 
   // ── Internal ─────────────────────────────────────────────────────────
 
+  /**
+   * Approves the latest pending device pair request via the openclaw CLI
+   * running inside the container. This is needed because the gateway requires
+   * Ed25519 device identity and approval before granting operator scopes.
+   */
+  private async approvePendingDevice(
+    logProgress: (msg: string) => void,
+  ): Promise<void> {
+    // List pending devices to get the request ID
+    const output: string[] = []
+    await this.runtime.execInContainer(
+      [
+        'node',
+        'dist/index.js',
+        'devices',
+        'list',
+        '--json',
+        '--token',
+        this.token,
+      ],
+      (line) => output.push(line),
+    )
+
+    const jsonStr = output.join('\n')
+    const data = JSON.parse(jsonStr)
+    const pending = data.pending as Array<{ requestId: string }> | undefined
+
+    if (!pending?.length) {
+      logger.warn('No pending device pair requests found')
+      throw new Error('No pending device pair requests to approve')
+    }
+
+    const requestId = pending[0].requestId
+    logProgress(`Approving device pair request ${requestId.slice(0, 8)}...`)
+
+    const code = await this.runtime.execInContainer([
+      'node',
+      'dist/index.js',
+      'devices',
+      'approve',
+      requestId,
+      '--token',
+      this.token,
+      '--json',
+    ])
+
+    if (code !== 0) {
+      logger.warn('Device approval command exited with code', { code })
+      throw new Error('Failed to approve client device pairing')
+    }
+
+    logProgress('Client device approved')
+  }
+
   private async connectGateway(): Promise<void> {
     this.disconnectGateway()
     logger.debug('Connecting OpenClaw gateway client', { port: this.port })
-    this.gateway = new GatewayClient(this.port, this.token)
+    this.gateway = new GatewayClient(this.port, this.token, this.openclawDir)
     await this.gateway.connect()
   }
 
@@ -521,7 +574,9 @@ export class OpenClawService {
 
 let service: OpenClawService | null = null
 
-export function getOpenClawService(): OpenClawService {
-  if (!service) service = new OpenClawService()
+export function getOpenClawService(
+  browserosServerPort?: number,
+): OpenClawService {
+  if (!service) service = new OpenClawService(browserosServerPort)
   return service
 }

--- a/packages/browseros-agent/apps/server/src/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/services/openclaw/openclaw-service.ts
@@ -401,24 +401,69 @@ export class OpenClawService {
       await this.loadTokenFromEnv()
       await this.runtime.ensureReady()
 
-      if (await this.runtime.isReady(this.port)) {
-        await this.connectGateway()
-        logger.info('OpenClaw gateway already running')
-        return
+      if (!(await this.runtime.isReady(this.port))) {
+        await this.runtime.composeUp()
+        const ready = await this.runtime.waitForReady(
+          this.port,
+          READY_TIMEOUT_MS,
+        )
+        if (!ready) {
+          logger.warn('OpenClaw gateway failed to become ready on auto-start')
+          return
+        }
       }
 
-      await this.runtime.composeUp()
-      const ready = await this.runtime.waitForReady(this.port, READY_TIMEOUT_MS)
-      if (ready) {
-        await this.connectGateway()
-        logger.info('OpenClaw gateway auto-started')
-      } else {
-        logger.warn('OpenClaw gateway failed to become ready on auto-start')
-      }
+      await this.connectGatewayWithRetry()
+      logger.info('OpenClaw gateway auto-started')
     } catch (err) {
       logger.warn('OpenClaw auto-start failed', {
         error: err instanceof Error ? err.message : String(err),
       })
+    }
+  }
+
+  /**
+   * Connects to the gateway, retrying once after a container restart
+   * if the signature is expired (clock skew from Podman VM sleep).
+   */
+  private async connectGatewayWithRetry(): Promise<void> {
+    try {
+      await this.connectGateway()
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      if (
+        msg.includes('signature expired') ||
+        msg.includes('pairing required')
+      ) {
+        logger.info(
+          'Gateway WS auth failed, restarting container to resync clock...',
+        )
+        await this.runtime.composeRestart()
+        const ready = await this.runtime.waitForReady(
+          this.port,
+          READY_TIMEOUT_MS,
+        )
+        if (!ready)
+          throw new Error('Gateway not ready after clock resync restart')
+
+        // Re-approve device if needed (pairing may have been lost)
+        try {
+          await this.connectGateway()
+        } catch (retryErr) {
+          const retryMsg =
+            retryErr instanceof Error ? retryErr.message : String(retryErr)
+          if (retryMsg.includes('pairing required')) {
+            await this.approvePendingDevice((m) =>
+              logger.debug(`Auto-start: ${m}`),
+            )
+            await this.connectGateway()
+          } else {
+            throw retryErr
+          }
+        }
+      } else {
+        throw err
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- Fix GatewayClient WS handshake with Ed25519 device identity signing and auto device pairing flow (generate identity → attempt connect → approve via CLI → reconnect)
- Replace HTTP `/v1/chat/completions` proxy with WS-based streaming that surfaces tool calls, thinking blocks, and text deltas as typed `OpenClawStreamEvent`s
- Rewrite AgentChat.tsx with turn-based model using Message/MessageContent components matching sidepanel pattern, with consecutive tool batching
- Pass actual server port to OpenClaw bootstrap config (fixes MCP bridge URL in dev mode: 9105 instead of hardcoded 9100)

## Changes

| File | Change |
|------|--------|
| `gateway-client.ts` | Ed25519 device auth, Origin header, `chatStream()`, `ensureClientIdentity()`, field mapping fixes |
| `openclaw-service.ts` | Two-boot setup with device pairing, `chatStream()` replacing HTTP proxy, MCP port passthrough |
| `container-runtime.ts` | `execInContainer()` for CLI device approval |
| `openclaw.ts` (routes) | Chat route: WS stream → SSE, new `{message, sessionKey}` shape |
| `main.ts` | Pass `serverPort` to `getOpenClawService()` |
| `useOpenClaw.ts` | Updated `chatWithAgent` signature + `OpenClawStreamEvent` type |
| `AgentChat.tsx` | Turn-based model, streaming segments, Message/Reasoning/tool cards |

## Test plan

- [ ] Clean setup via API or UI with a provider (e.g. OpenRouter) — verify `openclaw.json` has correct MCP port
- [ ] Send simple message — verify text-delta streaming works
- [ ] Send message triggering tools — verify tool cards show with spinners, then checkmarks
- [ ] Verify thinking blocks render and collapse when done
- [ ] Verify consecutive tools batch together, text/thinking breaks the batch
- [ ] Verify multi-turn conversation (session persists across messages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)