### PR TITLE
feat: reimplement shared background klavis proxy

### DIFF
--- a/packages/browseros-agent/apps/server/src/agent/ai-sdk-agent.ts
+++ b/packages/browseros-agent/apps/server/src/agent/ai-sdk-agent.ts
@@ -146,6 +146,14 @@ export class AiSdkAgent {
       browserContext: config.browserContext,
     })
     const { clients, tools: customMcpTools } = await createMcpClients(specs)
+    const collidingToolNames = Object.keys(customMcpTools).filter(
+      (name) => name in klavisTools,
+    )
+    if (collidingToolNames.length > 0) {
+      logger.warn('Custom MCP tools override Klavis tools', {
+        toolNames: collidingToolNames,
+      })
+    }
     const rawExternalMcpTools = { ...klavisTools, ...customMcpTools }
 
     // Wrap external MCP tools (Klavis, custom) with metrics

--- a/packages/browseros-agent/apps/server/src/agent/ai-sdk-agent.ts
+++ b/packages/browseros-agent/apps/server/src/agent/ai-sdk-agent.ts
@@ -16,8 +16,11 @@ import {
   type UIMessage,
   wrapLanguageModel,
 } from 'ai'
+import {
+  buildKlavisToolSet,
+  type KlavisProxyRef,
+} from '../api/services/klavis/strata-proxy'
 import type { Browser } from '../browser/browser'
-import type { KlavisClient } from '../lib/clients/klavis/klavis-client'
 import { logger } from '../lib/logger'
 import { metrics } from '../lib/metrics'
 import { isSoulBootstrap, readSoul } from '../lib/soul'
@@ -45,7 +48,7 @@ export interface AiSdkAgentConfig {
   browser: Browser
   registry: ToolRegistry
   browserContext?: BrowserContext
-  klavisClient?: KlavisClient
+  klavisRef?: KlavisProxyRef
   browserosId?: string
   aiSdkDevtoolsEnabled?: boolean
   aclRules?: AclRule[]
@@ -130,14 +133,20 @@ export class AiSdkAgent {
       })
     }
 
-    // Build external MCP server specs (Klavis, custom) and connect clients
+    // Get Klavis tools from shared background handle (no per-session connection).
+    // Only expose when user has enabled servers — matches old per-session gating.
+    const klavisTools =
+      config.klavisRef?.handle &&
+      config.browserContext?.enabledMcpServers?.length
+        ? buildKlavisToolSet(config.klavisRef.handle)
+        : {}
+
+    // Connect custom (non-Klavis) MCP servers per-session
     const specs = await buildMcpServerSpecs({
       browserContext: config.browserContext,
-      klavisClient: config.klavisClient,
-      browserosId: config.browserosId,
     })
-    const { clients, tools: rawExternalMcpTools } =
-      await createMcpClients(specs)
+    const { clients, tools: customMcpTools } = await createMcpClients(specs)
+    const rawExternalMcpTools = { ...klavisTools, ...customMcpTools }
 
     // Wrap external MCP tools (Klavis, custom) with metrics
     const externalMcpTools: ToolSet = {}

--- a/packages/browseros-agent/apps/server/src/agent/mcp-builder.ts
+++ b/packages/browseros-agent/apps/server/src/agent/mcp-builder.ts
@@ -2,8 +2,6 @@ import { createMCPClient } from '@ai-sdk/mcp'
 import { TIMEOUTS } from '@browseros/shared/constants/timeouts'
 import type { BrowserContext } from '@browseros/shared/schemas/browser-context'
 import type { ToolSet } from 'ai'
-import { klavisStrataCache } from '../api/services/klavis/strata-cache'
-import type { KlavisClient } from '../lib/clients/klavis/klavis-client'
 import { logger } from '../lib/logger'
 import {
   detectMcpTransport,
@@ -19,8 +17,6 @@ export interface McpServerSpec {
 
 export interface McpServerSpecDeps {
   browserContext?: BrowserContext
-  klavisClient?: KlavisClient
-  browserosId?: string
 }
 
 export interface McpClientBundle {
@@ -28,39 +24,12 @@ export interface McpClientBundle {
   tools: ToolSet
 }
 
-// Build list of MCP server specs from config + browser context
+// Build list of custom MCP server specs from browser context
+// (Klavis Strata is handled separately via shared background connection)
 export async function buildMcpServerSpecs(
   deps: McpServerSpecDeps,
 ): Promise<McpServerSpec[]> {
   const specs: McpServerSpec[] = []
-
-  // Klavis Strata MCP servers
-  if (
-    deps.browserosId &&
-    deps.klavisClient &&
-    deps.browserContext?.enabledMcpServers?.length
-  ) {
-    try {
-      const result = await klavisStrataCache.getOrFetch(
-        deps.klavisClient,
-        deps.browserosId,
-        deps.browserContext.enabledMcpServers,
-      )
-      specs.push({
-        name: 'klavis-strata',
-        url: result.strataServerUrl,
-        transport: 'streamable-http',
-      })
-      logger.info('Added Klavis Strata MCP server', {
-        browserosId: deps.browserosId.slice(0, 12),
-        servers: deps.browserContext.enabledMcpServers,
-      })
-    } catch (error) {
-      logger.error('Failed to create Klavis Strata MCP server', {
-        error: error instanceof Error ? error.message : String(error),
-      })
-    }
-  }
 
   // User-provided custom MCP servers
   if (deps.browserContext?.customMcpServers?.length) {

--- a/packages/browseros-agent/apps/server/src/api/routes/chat.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/chat.ts
@@ -2,12 +2,12 @@ import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { SessionStore } from '../../agent/session-store'
 import type { Browser } from '../../browser/browser'
-import { KlavisClient } from '../../lib/clients/klavis/klavis-client'
 import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
 import { Sentry } from '../../lib/sentry'
 import type { ToolRegistry } from '../../tools/tool-registry'
 import { ChatService } from '../services/chat-service'
+import type { KlavisProxyRef } from '../services/klavis/strata-proxy'
 import { ChatRequestSchema } from '../types'
 import { ConversationIdParamSchema } from '../utils/validation'
 
@@ -15,6 +15,7 @@ interface ChatRouteDeps {
   browser: Browser
   registry: ToolRegistry
   browserosId?: string
+  klavisRef?: KlavisProxyRef
   aiSdkDevtoolsEnabled?: boolean
 }
 
@@ -22,10 +23,9 @@ export function createChatRoutes(deps: ChatRouteDeps) {
   const { browserosId } = deps
 
   const sessionStore = new SessionStore()
-  const klavisClient = new KlavisClient()
   const service = new ChatService({
     sessionStore,
-    klavisClient,
+    klavisRef: deps.klavisRef,
     browser: deps.browser,
     registry: deps.registry,
     browserosId,

--- a/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
@@ -11,7 +11,7 @@ import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
 import { Sentry } from '../../lib/sentry'
 import type { ToolRegistry } from '../../tools/tool-registry'
-import type { KlavisProxyHandle } from '../services/klavis/strata-proxy'
+import type { KlavisProxyRef } from '../services/klavis/strata-proxy'
 import { createMcpServer } from '../services/mcp/mcp-server'
 import type { Env } from '../types'
 
@@ -21,7 +21,7 @@ interface McpRouteDeps {
   browser: Browser
   executionDir: string
   resourcesDir: string
-  klavisProxy?: KlavisProxyHandle | null
+  klavisRef?: KlavisProxyRef
 }
 
 export function createMcpRoutes(deps: McpRouteDeps) {

--- a/packages/browseros-agent/apps/server/src/api/server.ts
+++ b/packages/browseros-agent/apps/server/src/api/server.ts
@@ -91,12 +91,12 @@ export async function createHttpServer(config: HttpServerConfig) {
 
   // Connect Klavis proxy in background with retry — browser tools available immediately
   const klavisRef: KlavisProxyRef = { handle: null }
-  if (browserosId) {
-    connectKlavisInBackground(klavisRef, {
-      klavisClient: new KlavisClient(),
-      browserosId,
-    })
-  }
+  const stopKlavisBackground = browserosId
+    ? connectKlavisInBackground(klavisRef, {
+        klavisClient: new KlavisClient(),
+        browserosId,
+      })
+    : () => {}
 
   const clawRoutes = new Hono<Env>()
     .use('/*', requireTrustedAppOrigin())
@@ -120,6 +120,7 @@ export async function createHttpServer(config: HttpServerConfig) {
       createShutdownRoute({
         onShutdown: () => {
           tokenManager?.stopCallbackServer()
+          stopKlavisBackground()
           klavisRef.handle?.close().catch((err) =>
             logger.warn('Failed to close Klavis proxy transport', {
               error: err instanceof Error ? err.message : String(err),

--- a/packages/browseros-agent/apps/server/src/api/server.ts
+++ b/packages/browseros-agent/apps/server/src/api/server.ts
@@ -39,8 +39,8 @@ import { createSoulRoutes } from './routes/soul'
 import { createStatusRoute } from './routes/status'
 import { createTerminalRoutes } from './routes/terminal'
 import {
-  connectKlavisProxy,
-  type KlavisProxyHandle,
+  connectKlavisInBackground,
+  type KlavisProxyRef,
 } from './services/klavis/strata-proxy'
 import { getPodmanRuntime } from './services/openclaw/podman-runtime'
 import type { Env, HttpServerConfig } from './types'
@@ -89,22 +89,13 @@ export async function createHttpServer(config: HttpServerConfig) {
     ? initializeOAuth(getDb(), browserosId)
     : null
 
-  // Connect Klavis proxy (non-blocking: browser tools still work if this fails)
-  let klavisProxy: KlavisProxyHandle | null = null
+  // Connect Klavis proxy in background with retry — browser tools available immediately
+  const klavisRef: KlavisProxyRef = { handle: null }
   if (browserosId) {
-    try {
-      klavisProxy = await connectKlavisProxy({
-        klavisClient: new KlavisClient(),
-        browserosId,
-      })
-    } catch (error) {
-      logger.warn(
-        'Failed to connect Klavis proxy, MCP will serve browser tools only',
-        {
-          error: error instanceof Error ? error.message : String(error),
-        },
-      )
-    }
+    connectKlavisInBackground(klavisRef, {
+      klavisClient: new KlavisClient(),
+      browserosId,
+    })
   }
 
   const clawRoutes = new Hono<Env>()
@@ -129,7 +120,7 @@ export async function createHttpServer(config: HttpServerConfig) {
       createShutdownRoute({
         onShutdown: () => {
           tokenManager?.stopCallbackServer()
-          klavisProxy?.close().catch((err) =>
+          klavisRef.handle?.close().catch((err) =>
             logger.warn('Failed to close Klavis proxy transport', {
               error: err instanceof Error ? err.message : String(err),
             }),
@@ -170,7 +161,7 @@ export async function createHttpServer(config: HttpServerConfig) {
         browser,
         executionDir,
         resourcesDir,
-        klavisProxy,
+        klavisRef,
       }),
     )
     .route(
@@ -179,6 +170,7 @@ export async function createHttpServer(config: HttpServerConfig) {
         browser,
         registry,
         browserosId,
+        klavisRef,
         aiSdkDevtoolsEnabled: config.aiSdkDevtoolsEnabled,
       }),
     )

--- a/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
@@ -92,13 +92,15 @@ export class ChatService {
         mcpServerKey,
       )
 
+      const oldParts = (previousMcpKey ?? '').split(',').filter(Boolean)
+      const newParts = mcpServerKey.split(',').filter(Boolean)
+      const oldKlavisState = oldParts.find((s) => s.startsWith('klavis:'))
+      const newKlavisState = newParts.find((s) => s.startsWith('klavis:'))
       const oldServers = new Set(
-        (previousMcpKey ?? '')
-          .split(',')
-          .filter((s) => s && !s.startsWith('klavis:')),
+        oldParts.filter((s) => !s.startsWith('klavis:')),
       )
       const newServers = new Set(
-        mcpServerKey.split(',').filter((s) => s && !s.startsWith('klavis:')),
+        newParts.filter((s) => !s.startsWith('klavis:')),
       )
       const added = [...newServers].filter((s) => !oldServers.has(s))
       const removed = [...oldServers].filter((s) => !newServers.has(s))
@@ -115,9 +117,19 @@ export class ChatService {
         )
       }
       if (parts.length === 0) {
-        parts.push(
-          'Connected app integrations changed during this conversation. Use only tools that are currently registered.',
-        )
+        if (
+          oldKlavisState === 'klavis:pending' &&
+          newKlavisState === 'klavis:connected' &&
+          newServers.size > 0
+        ) {
+          parts.push(
+            `Klavis app integration tools are now available for the following connected apps: ${[...newServers].join(', ')}.`,
+          )
+        } else {
+          parts.push(
+            'Connected app integrations changed during this conversation. Use only tools that are currently registered.',
+          )
+        }
       }
       contextChanges.push(parts.join(' '))
     }

--- a/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
@@ -14,15 +14,15 @@ import {
 import type { AgentSession, SessionStore } from '../../agent/session-store'
 import type { ResolvedAgentConfig } from '../../agent/types'
 import type { Browser } from '../../browser/browser'
-import type { KlavisClient } from '../../lib/clients/klavis/klavis-client'
 import { resolveLLMConfig } from '../../lib/clients/llm/config'
 import { logger } from '../../lib/logger'
 import type { ToolRegistry } from '../../tools/tool-registry'
+import type { KlavisProxyRef } from '../services/klavis/strata-proxy'
 import type { BrowserContext, ChatRequest } from '../types'
 
 export interface ChatServiceDeps {
   sessionStore: SessionStore
-  klavisClient: KlavisClient
+  klavisRef?: KlavisProxyRef
   browser: Browser
   registry: ToolRegistry
   browserosId?: string
@@ -93,9 +93,13 @@ export class ChatService {
       )
 
       const oldServers = new Set(
-        (previousMcpKey ?? '').split(',').filter(Boolean),
+        (previousMcpKey ?? '')
+          .split(',')
+          .filter((s) => s && !s.startsWith('klavis:')),
       )
-      const newServers = new Set(mcpServerKey.split(',').filter(Boolean))
+      const newServers = new Set(
+        mcpServerKey.split(',').filter((s) => s && !s.startsWith('klavis:')),
+      )
       const added = [...newServers].filter((s) => !oldServers.has(s))
       const removed = [...oldServers].filter((s) => !newServers.has(s))
 
@@ -217,7 +221,7 @@ export class ChatService {
         browser: this.deps.browser,
         registry: this.deps.registry,
         browserContext,
-        klavisClient: this.deps.klavisClient,
+        klavisRef: this.deps.klavisRef,
         browserosId: this.deps.browserosId,
         aiSdkDevtoolsEnabled: this.deps.aiSdkDevtoolsEnabled,
         aclRules: request.aclRules,
@@ -397,7 +401,7 @@ export class ChatService {
       browser: this.deps.browser,
       registry: this.deps.registry,
       browserContext,
-      klavisClient: this.deps.klavisClient,
+      klavisRef: this.deps.klavisRef,
       browserosId: this.deps.browserosId,
       aiSdkDevtoolsEnabled: this.deps.aiSdkDevtoolsEnabled,
       aclRules: request.aclRules,
@@ -469,6 +473,12 @@ export class ChatService {
     const managed = browserContext?.enabledMcpServers?.slice().sort() ?? []
     const custom =
       browserContext?.customMcpServers?.map((s) => s.url).sort() ?? []
-    return [...managed, ...custom].join(',')
+    const klavisState =
+      managed.length > 0
+        ? this.deps.klavisRef?.handle
+          ? 'klavis:connected'
+          : 'klavis:pending'
+        : null
+    return [klavisState, ...managed, ...custom].filter(Boolean).join(',')
   }
 }

--- a/packages/browseros-agent/apps/server/src/api/services/klavis/strata-proxy.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/klavis/strata-proxy.ts
@@ -4,16 +4,15 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { TIMEOUTS } from '@browseros/shared/constants/timeouts'
-import { Client } from '@modelcontextprotocol/sdk/client/index.js'
-import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
-import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import type { JSONValue } from '@ai-sdk/provider'
 import {
   KLAVIS_PROXY_RETRY_BACKOFF_MS,
   TIMEOUTS,
 } from '@browseros/shared/constants/timeouts'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
 import type { ToolSet } from 'ai'
 import { z } from 'zod'
 import { jsonSchemaObjectToZodRawShape } from 'zod-from-json-schema'
@@ -59,12 +58,9 @@ interface BackgroundConnectOptions {
   retryDelaysMs?: readonly number[]
 }
 
-// One-time async setup: connect to Klavis Strata and discover tools
 export async function connectKlavisProxy(
   deps: ConnectDeps,
 ): Promise<KlavisProxyHandle> {
-  // Use the full curated OAuth server list so all tools are exposed,
-  // even unauthenticated ones (Klavis handles auth prompts on call)
   const allServers = OAUTH_MCP_SERVERS.map((s) => s.name)
 
   const strata = await klavisStrataCache.getOrFetch(
@@ -73,7 +69,6 @@ export async function connectKlavisProxy(
     allServers,
   )
 
-  // Connect MCP client to Strata endpoint
   const client = new Client({
     name: 'browseros-klavis-proxy',
     version: '1.0.0',
@@ -85,8 +80,6 @@ export async function connectKlavisProxy(
 
   const { tools } = await withTimeout(client.listTools(), 'listTools')
 
-  // Pre-compute Zod schemas once so registerKlavisTools avoids per-request conversion.
-  // Double cast works around TS2589 in registerTool's recursive generics.
   const inputSchemas = new Map(
     tools.map((t) => [
       t.name,
@@ -118,7 +111,6 @@ const serverDescriptions = OAUTH_MCP_SERVERS.map(
   (s) => `${s.name} (${s.description})`,
 ).join(', ')
 
-// Double cast works around TS2589 in registerTool's recursive generics.
 const connectorInputSchema = {
   server_name: z
     .enum(serverNames)
@@ -248,7 +240,6 @@ export function registerKlavisTools(
   mcpServer: McpServer,
   handle: KlavisProxyHandle,
 ): void {
-  // Register the connector discovery tool
   mcpServer.registerTool(
     'connector_mcp_servers',
     {
@@ -290,7 +281,6 @@ export function registerKlavisTools(
           }
         }
 
-        // Not connected — get auth URL
         const strata = await klavisClient.createStrata(handle.browserosId, [
           server_name,
         ])
@@ -340,7 +330,6 @@ export function registerKlavisTools(
     },
   )
 
-  // Register Strata proxy tools
   for (const tool of handle.tools) {
     const inputSchema = handle.inputSchemas.get(tool.name)
 

--- a/packages/browseros-agent/apps/server/src/api/services/klavis/strata-proxy.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/klavis/strata-proxy.ts
@@ -118,7 +118,6 @@ const connectorInputSchema = {
       `The name of the service to check. Available: ${serverDescriptions}`,
     ),
 } as unknown as Record<string, never>
-
 function klavisResultToModelOutput(output: unknown) {
   const result = output as CallToolResult
 

--- a/packages/browseros-agent/apps/server/src/api/services/klavis/strata-proxy.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/klavis/strata-proxy.ts
@@ -9,6 +9,12 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
+import type { JSONValue } from '@ai-sdk/provider'
+import {
+  KLAVIS_PROXY_RETRY_BACKOFF_MS,
+  TIMEOUTS,
+} from '@browseros/shared/constants/timeouts'
+import type { ToolSet } from 'ai'
 import { z } from 'zod'
 import { jsonSchemaObjectToZodRawShape } from 'zod-from-json-schema'
 import { KlavisClient } from '../../../lib/clients/klavis/klavis-client'
@@ -39,9 +45,18 @@ export interface KlavisProxyHandle {
   close: () => Promise<void>
 }
 
+export interface KlavisProxyRef {
+  handle: KlavisProxyHandle | null
+}
+
 interface ConnectDeps {
   klavisClient: KlavisClient
   browserosId: string
+}
+
+interface BackgroundConnectOptions {
+  connect?: (deps: ConnectDeps) => Promise<KlavisProxyHandle>
+  retryDelaysMs?: readonly number[]
 }
 
 // One-time async setup: connect to Klavis Strata and discover tools
@@ -81,17 +96,15 @@ export async function connectKlavisProxy(
     ]),
   )
 
-  logger.info('Klavis proxy connected', {
-    toolCount: tools.length,
-    serverCount: allServers.length,
-  })
-
   return {
     browserosId: deps.browserosId,
     tools,
     inputSchemas,
     callTool: (name, args) =>
-      client.callTool({ name, arguments: args }) as Promise<CallToolResult>,
+      withTimeout(
+        client.callTool({ name, arguments: args }) as Promise<CallToolResult>,
+        `callTool(${name})`,
+      ),
     close: () => client.close(),
   }
 }
@@ -113,6 +126,123 @@ const connectorInputSchema = {
       `The name of the service to check. Available: ${serverDescriptions}`,
     ),
 } as unknown as Record<string, never>
+
+function klavisResultToModelOutput(output: unknown) {
+  const result = output as CallToolResult
+
+  if (!('content' in result) || !Array.isArray(result.content)) {
+    return {
+      type: 'json' as const,
+      value: (result as JSONValue | undefined) ?? null,
+    }
+  }
+
+  return {
+    type: 'content' as const,
+    value: result.content.map((part) => {
+      if (part.type === 'text') {
+        return {
+          type: 'text' as const,
+          text: part.text,
+        }
+      }
+      if (part.type === 'image') {
+        return {
+          type: 'image-data' as const,
+          data: part.data,
+          mediaType: part.mimeType ?? 'image/png',
+        }
+      }
+      return {
+        type: 'text' as const,
+        text: JSON.stringify(part),
+      }
+    }),
+  }
+}
+
+export function connectKlavisInBackground(
+  ref: KlavisProxyRef,
+  deps: ConnectDeps,
+  options: BackgroundConnectOptions = {},
+): () => void {
+  const connect = options.connect ?? connectKlavisProxy
+  const retryDelaysMs =
+    options.retryDelaysMs ?? KLAVIS_PROXY_RETRY_BACKOFF_MS
+  let stopped = false
+  let retryTimer: ReturnType<typeof setTimeout> | undefined
+
+  async function attempt(n: number): Promise<void> {
+    if (stopped) return
+
+    try {
+      const handle = await connect(deps)
+      if (stopped) {
+        await handle.close().catch((error) => {
+          logger.warn('Failed to close Klavis proxy transport after stop', {
+            error: error instanceof Error ? error.message : String(error),
+          })
+        })
+        return
+      }
+      ref.handle = handle
+      logger.info('Klavis proxy connected', {
+        attempt: n + 1,
+        toolCount: handle.tools.length,
+      })
+    } catch (error) {
+      if (stopped) return
+
+      const msg = error instanceof Error ? error.message : String(error)
+      if (n < retryDelaysMs.length) {
+        const delay = retryDelaysMs[n]
+        logger.info('Retrying Klavis proxy connection', {
+          attempt: n + 1,
+          nextRetryMs: delay,
+          error: msg,
+        })
+        retryTimer = setTimeout(() => {
+          retryTimer = undefined
+          void attempt(n + 1)
+        }, delay)
+      } else {
+        logger.warn(
+          'Klavis proxy connection failed after all retries, MCP will serve browser tools only',
+          { attempts: n + 1, error: msg },
+        )
+      }
+    }
+  }
+
+  void attempt(0)
+
+  return () => {
+    stopped = true
+    if (retryTimer) {
+      clearTimeout(retryTimer)
+      retryTimer = undefined
+    }
+  }
+}
+
+export function buildKlavisToolSet(handle: KlavisProxyHandle): ToolSet {
+  const toolSet: ToolSet = {}
+
+  for (const t of handle.tools) {
+    const rawShape = handle.inputSchemas.get(t.name)
+    const name = t.name
+    toolSet[name] = {
+      description: t.description ?? '',
+      inputSchema: z.object((rawShape ?? {}) as z.ZodRawShape),
+      execute: async (args: Record<string, unknown>) =>
+        handle.callTool(name, args),
+      toModelOutput: ({ output }: { output: unknown }) =>
+        klavisResultToModelOutput(output),
+    } satisfies ToolSet[string]
+  }
+
+  return toolSet
+}
 
 export function registerKlavisTools(
   mcpServer: McpServer,

--- a/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-server.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-server.ts
@@ -9,7 +9,7 @@ import { SetLevelRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import type { Browser } from '../../../browser/browser'
 import type { ToolRegistry } from '../../../tools/tool-registry'
 import {
-  type KlavisProxyHandle,
+  type KlavisProxyRef,
   registerKlavisTools,
 } from '../klavis/strata-proxy'
 import { MCP_INSTRUCTIONS } from './mcp-prompt'
@@ -21,7 +21,7 @@ export interface McpServiceDeps {
   browser: Browser
   executionDir: string
   resourcesDir: string
-  klavisProxy?: KlavisProxyHandle | null
+  klavisRef?: KlavisProxyRef
 }
 
 export function createMcpServer(deps: McpServiceDeps): McpServer {
@@ -47,9 +47,9 @@ export function createMcpServer(deps: McpServiceDeps): McpServer {
     },
   })
 
-  // Register Klavis proxy tools (if connected)
-  if (deps.klavisProxy) {
-    registerKlavisTools(server, deps.klavisProxy)
+  // Register Klavis proxy tools (if connected via background init)
+  if (deps.klavisRef?.handle) {
+    registerKlavisTools(server, deps.klavisRef.handle)
   }
 
   return server

--- a/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
@@ -351,7 +351,7 @@ describe('ChatService Klavis session rebuilds', () => {
     expect(secondAgent.messages).toHaveLength(2)
     const rebuiltMessage = secondAgent.messages[1]?.parts[0]?.text ?? ''
     expect(rebuiltMessage).toContain(
-      'Connected app integrations changed during this conversation.',
+      'Klavis app integration tools are now available for the following connected apps: slack.',
     )
     expect(rebuiltMessage).not.toContain('klavis:pending')
     expect(rebuiltMessage).not.toContain('klavis:connected')

--- a/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
@@ -11,6 +11,7 @@ interface MockAgent {
   toolNames: Set<string>
   messages: MockMessage[]
   appendUserMessage(text: string): void
+  updateAclRules(rules: unknown): void
   dispose(): Promise<void>
 }
 
@@ -20,6 +21,7 @@ interface StoredSession {
 }
 
 interface StreamResponseOptions {
+  uiMessages?: MockMessage[]
   onFinish(args: { messages: MockMessage[] }): Promise<void>
 }
 
@@ -106,12 +108,13 @@ function createFakeAgent() {
     toolNames: new Set<string>(),
     messages,
     appendUserMessage(text: string) {
-      messages.push({
+      this.messages.push({
         id: 'user-1',
         role: 'user',
         parts: [{ type: 'text', text }],
       })
     },
+    updateAclRules: mock(() => {}),
     dispose: mock(async () => {}),
   }
 }
@@ -120,8 +123,8 @@ describe('ChatService scheduled task hidden page lifecycle', () => {
   it('creates and cleans up a hidden page without creating a hidden window', async () => {
     const fakeAgent = createFakeAgent()
     agentToReturn = fakeAgent
-    streamResponseHandler = async ({ onFinish }) => {
-      await onFinish({ messages: fakeAgent.messages })
+    streamResponseHandler = async ({ onFinish, uiMessages }) => {
+      await onFinish({ messages: uiMessages ?? fakeAgent.messages })
       return new Response('ok')
     }
 
@@ -141,7 +144,7 @@ describe('ChatService scheduled task hidden page lifecycle', () => {
     const sessionStore = createSessionStore()
     const service = new ChatService({
       sessionStore: sessionStore as never,
-      klavisClient: {} as never,
+      klavisRef: { handle: null },
       browser: browser as never,
       registry: {} as never,
     })
@@ -214,7 +217,7 @@ describe('ChatService scheduled task hidden page lifecycle', () => {
 
     const service = new ChatService({
       sessionStore: sessionStore as never,
-      klavisClient: {} as never,
+      klavisRef: { handle: null },
       browser: browser as never,
       registry: {} as never,
     })
@@ -229,8 +232,8 @@ describe('ChatService scheduled task hidden page lifecycle', () => {
   it('keeps the scheduled hidden page context when metadata lookup fails', async () => {
     const fakeAgent = createFakeAgent()
     agentToReturn = fakeAgent
-    streamResponseHandler = async ({ onFinish }) => {
-      await onFinish({ messages: fakeAgent.messages })
+    streamResponseHandler = async ({ onFinish, uiMessages }) => {
+      await onFinish({ messages: uiMessages ?? fakeAgent.messages })
       return new Response('ok')
     }
 
@@ -245,7 +248,7 @@ describe('ChatService scheduled task hidden page lifecycle', () => {
     const sessionStore = createSessionStore()
     const service = new ChatService({
       sessionStore: sessionStore as never,
-      klavisClient: {} as never,
+      klavisRef: { handle: null },
       browser: browser as never,
       registry: {} as never,
     })
@@ -287,5 +290,126 @@ describe('ChatService scheduled task hidden page lifecycle', () => {
       title: 'Scheduled Task',
     })
     expect(browser.closePage).toHaveBeenCalledWith(88)
+  })
+})
+
+describe('ChatService Klavis session rebuilds', () => {
+  it('rebuilds a managed-app session when the shared Klavis handle appears', async () => {
+    const firstAgent = createFakeAgent()
+    const secondAgent = createFakeAgent()
+    agentToReturn = firstAgent
+    streamResponseHandler = async ({ onFinish, uiMessages }) => {
+      await onFinish({ messages: uiMessages ?? [] })
+      return new Response('ok')
+    }
+
+    const klavisRef = { handle: null as object | null }
+    const browser = {
+      resolveTabIds: mock(
+        async (tabIds: number[]) =>
+          new Map(tabIds.map((tabId) => [tabId, tabId + 100])),
+      ),
+      closePage: mock(async () => {}),
+    }
+    const sessionStore = createSessionStore()
+    const service = new ChatService({
+      sessionStore: sessionStore as never,
+      klavisRef: klavisRef as never,
+      browser: browser as never,
+      registry: {} as never,
+    })
+    const createCallsBefore = createAgentSpy.mock.calls.length
+    const conversationId = crypto.randomUUID()
+    const request = {
+      conversationId,
+      message: 'check integrations',
+      isScheduledTask: false,
+      mode: 'agent',
+      origin: 'sidepanel',
+      browserContext: {
+        activeTab: {
+          id: 3,
+          url: 'https://example.com',
+          title: 'Example',
+        },
+        enabledMcpServers: ['slack'],
+      },
+    } as never
+
+    await service.processMessage(request, new AbortController().signal)
+
+    agentToReturn = secondAgent
+    klavisRef.handle = {}
+
+    await service.processMessage(
+      { ...request, message: 'check integrations again' },
+      new AbortController().signal,
+    )
+
+    expect(createAgentSpy.mock.calls.length - createCallsBefore).toBe(2)
+    expect(firstAgent.dispose).toHaveBeenCalledTimes(1)
+    expect(secondAgent.messages).toHaveLength(2)
+    const rebuiltMessage = secondAgent.messages[1]?.parts[0]?.text ?? ''
+    expect(rebuiltMessage).toContain(
+      'Connected app integrations changed during this conversation.',
+    )
+    expect(rebuiltMessage).not.toContain('klavis:pending')
+    expect(rebuiltMessage).not.toContain('klavis:connected')
+  })
+
+  it('does not rebuild a session with no enabled managed apps when Klavis connects', async () => {
+    const firstAgent = createFakeAgent()
+    const secondAgent = createFakeAgent()
+    agentToReturn = firstAgent
+    streamResponseHandler = async ({ onFinish, uiMessages }) => {
+      await onFinish({ messages: uiMessages ?? [] })
+      return new Response('ok')
+    }
+
+    const klavisRef = { handle: null as object | null }
+    const browser = {
+      resolveTabIds: mock(
+        async (tabIds: number[]) =>
+          new Map(tabIds.map((tabId) => [tabId, tabId + 200])),
+      ),
+      closePage: mock(async () => {}),
+    }
+    const sessionStore = createSessionStore()
+    const service = new ChatService({
+      sessionStore: sessionStore as never,
+      klavisRef: klavisRef as never,
+      browser: browser as never,
+      registry: {} as never,
+    })
+    const createCallsBefore = createAgentSpy.mock.calls.length
+    const conversationId = crypto.randomUUID()
+    const request = {
+      conversationId,
+      message: 'check browser only',
+      isScheduledTask: false,
+      mode: 'agent',
+      origin: 'sidepanel',
+      browserContext: {
+        activeTab: {
+          id: 5,
+          url: 'https://example.com',
+          title: 'Example',
+        },
+      },
+    } as never
+
+    await service.processMessage(request, new AbortController().signal)
+
+    agentToReturn = secondAgent
+    klavisRef.handle = {}
+
+    await service.processMessage(
+      { ...request, message: 'check browser only again' },
+      new AbortController().signal,
+    )
+
+    expect(createAgentSpy.mock.calls.length - createCallsBefore).toBe(1)
+    expect(firstAgent.dispose).not.toHaveBeenCalled()
+    expect(firstAgent.messages).toHaveLength(2)
   })
 })

--- a/packages/browseros-agent/apps/server/tests/api/services/klavis/strata-proxy.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/klavis/strata-proxy.test.ts
@@ -1,0 +1,102 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { describe, expect, it, mock } from 'bun:test'
+import {
+  buildKlavisToolSet,
+  type KlavisProxyHandle,
+} from '../../../../src/api/services/klavis/strata-proxy'
+
+describe('buildKlavisToolSet', () => {
+  it('maps MCP content results into model content parts', async () => {
+    const handle: KlavisProxyHandle = {
+      tools: [
+        {
+          name: 'gmail_search',
+          description: 'Search Gmail',
+          inputSchema: { type: 'object' },
+        } as never,
+      ],
+      inputSchemas: new Map([['gmail_search', {} as never]]),
+      callTool: mock(async () => ({
+        content: [
+          { type: 'text', text: 'Found 2 threads' },
+          {
+            type: 'image',
+            data: 'ZmFrZS1pbWFnZQ==',
+            mimeType: 'image/png',
+          },
+        ],
+      })),
+      close: async () => {},
+    }
+
+    const toolSet = buildKlavisToolSet(handle)
+    const searchTool = toolSet.gmail_search
+
+    expect(searchTool).toBeDefined()
+
+    const output = await searchTool.execute?.({})
+    const modelOutput = await searchTool.toModelOutput?.({
+      toolCallId: 'call-1',
+      input: {},
+      output,
+    })
+
+    expect(modelOutput).toEqual({
+      type: 'content',
+      value: [
+        { type: 'text', text: 'Found 2 threads' },
+        {
+          type: 'image-data',
+          data: 'ZmFrZS1pbWFnZQ==',
+          mediaType: 'image/png',
+        },
+      ],
+    })
+  })
+
+  it('falls back to JSON output for non-content MCP responses', async () => {
+    const handle: KlavisProxyHandle = {
+      tools: [
+        {
+          name: 'notion_lookup',
+          description: 'Lookup Notion',
+          inputSchema: { type: 'object' },
+        } as never,
+      ],
+      inputSchemas: new Map([['notion_lookup', {} as never]]),
+      callTool: mock(async () => ({
+        toolResult: {
+          pageId: 'abc123',
+          title: 'Quarterly Plan',
+        },
+      })),
+      close: async () => {},
+    }
+
+    const toolSet = buildKlavisToolSet(handle)
+    const lookupTool = toolSet.notion_lookup
+
+    expect(lookupTool).toBeDefined()
+
+    const output = await lookupTool.execute?.({})
+    const modelOutput = await lookupTool.toModelOutput?.({
+      toolCallId: 'call-2',
+      input: {},
+      output,
+    })
+
+    expect(modelOutput).toEqual({
+      type: 'json',
+      value: {
+        toolResult: {
+          pageId: 'abc123',
+          title: 'Quarterly Plan',
+        },
+      },
+    })
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/api/services/klavis/strata-proxy.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/klavis/strata-proxy.test.ts
@@ -6,6 +6,7 @@
 import { describe, expect, it, mock } from 'bun:test'
 import {
   buildKlavisToolSet,
+  connectKlavisInBackground,
   type KlavisProxyHandle,
 } from '../../../../src/api/services/klavis/strata-proxy'
 
@@ -98,5 +99,145 @@ describe('buildKlavisToolSet', () => {
         },
       },
     })
+  })
+
+  it('falls back to image/png when the MCP image result omits a mime type', async () => {
+    const handle: KlavisProxyHandle = {
+      tools: [
+        {
+          name: 'drive_preview',
+          description: 'Preview Drive file',
+          inputSchema: { type: 'object' },
+        } as never,
+      ],
+      inputSchemas: new Map([['drive_preview', {} as never]]),
+      callTool: mock(async () => ({
+        content: [{ type: 'image', data: 'ZmFrZS1pbWFnZQ==' }],
+      })),
+      close: async () => {},
+    }
+
+    const toolSet = buildKlavisToolSet(handle)
+    const previewTool = toolSet.drive_preview
+    const output = await previewTool.execute?.({})
+    const modelOutput = await previewTool.toModelOutput?.({
+      toolCallId: 'call-3',
+      input: {},
+      output,
+    })
+
+    expect(modelOutput).toEqual({
+      type: 'content',
+      value: [
+        {
+          type: 'image-data',
+          data: 'ZmFrZS1pbWFnZQ==',
+          mediaType: 'image/png',
+        },
+      ],
+    })
+  })
+})
+
+describe('connectKlavisInBackground', () => {
+  it('retries in the background until a connection succeeds', async () => {
+    const handle: KlavisProxyHandle = {
+      tools: [],
+      inputSchemas: new Map(),
+      callTool: mock(async () => ({ content: [] })),
+      close: mock(async () => {}),
+    }
+    const ref = { handle: null as KlavisProxyHandle | null }
+    let attempts = 0
+
+    const stop = connectKlavisInBackground(
+      ref,
+      { klavisClient: {} as never, browserosId: 'browseros-1' },
+      {
+        retryDelaysMs: [1],
+        connect: async () => {
+          attempts++
+          if (attempts === 1) {
+            throw new Error('boom')
+          }
+          return handle
+        },
+      },
+    )
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(attempts).toBe(2)
+    expect(ref.handle).toBe(handle)
+    stop()
+  })
+
+  it('closes a late handle when stopped during an in-flight connect', async () => {
+    let releaseConnect: (() => void) | undefined
+    const connectStarted = new Promise<void>((resolve) => {
+      releaseConnect = resolve
+    })
+    const handle: KlavisProxyHandle = {
+      tools: [],
+      inputSchemas: new Map(),
+      callTool: mock(async () => ({ content: [] })),
+      close: mock(async () => {}),
+    }
+    const ref = { handle: null as KlavisProxyHandle | null }
+
+    const stop = connectKlavisInBackground(
+      ref,
+      { klavisClient: {} as never, browserosId: 'browseros-2' },
+      {
+        connect: async () => {
+          await connectStarted
+          return handle
+        },
+      },
+    )
+
+    stop()
+    releaseConnect?.()
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(ref.handle).toBeNull()
+    expect(handle.close).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels a scheduled retry when stopped', async () => {
+    let resolveFirstAttempt: (() => void) | undefined
+    const firstAttemptDone = new Promise<void>((resolve) => {
+      resolveFirstAttempt = resolve
+    })
+    const ref = { handle: null as KlavisProxyHandle | null }
+    let attempts = 0
+
+    const stop = connectKlavisInBackground(
+      ref,
+      { klavisClient: {} as never, browserosId: 'browseros-3' },
+      {
+        retryDelaysMs: [20],
+        connect: async () => {
+          attempts++
+          if (attempts === 1) {
+            resolveFirstAttempt?.()
+            throw new Error('boom')
+          }
+          return {
+            tools: [],
+            inputSchemas: new Map(),
+            callTool: mock(async () => ({ content: [] })),
+            close: mock(async () => {}),
+          }
+        },
+      },
+    )
+
+    await firstAttemptDone
+    stop()
+    await new Promise((resolve) => setTimeout(resolve, 40))
+
+    expect(attempts).toBe(1)
+    expect(ref.handle).toBeNull()
   })
 })

--- a/packages/browseros-agent/packages/shared/src/constants/timeouts.ts
+++ b/packages/browseros-agent/packages/shared/src/constants/timeouts.ts
@@ -6,6 +6,10 @@
  * Centralized timeout configuration.
  */
 
+export const KLAVIS_PROXY_RETRY_BACKOFF_MS = [
+  5_000, 10_000, 20_000, 40_000, 60_000,
+] as const
+
 export const TIMEOUTS = {
   // Agent/Tool execution
   TOOL_CALL: 120_000,


### PR DESCRIPTION
## Summary
- Make Klavis startup non-blocking so the server can start before Strata finishes connecting.
- Share one mutable Klavis connection lifecycle across `/mcp` and `/chat`, and remove per-session Klavis MCP clients from chat.
- Rebuild chat sessions when managed apps gain a live Klavis handle, while avoiding zero-app rebuilds and filtering internal `klavis:*` markers from user-facing context.

## Design
This PR implements the shared-background-proxy design from the replan docs. `server.ts` now creates a shared `KlavisProxyRef` and starts a retrying background connector. `/mcp` reads the current shared handle per request, while chat consumes the same handle through `buildKlavisToolSet(...)` and uses the existing `mcpServerKey` rebuild path to self-heal sessions created before Klavis is ready. Custom MCP servers remain per-session, and prompt-level connected-app context continues to come from `enabledMcpServers`.

## Test plan
- `bun test apps/server/tests/api/services/klavis/strata-proxy.test.ts apps/server/tests/api/services/chat-service.test.ts apps/server/tests/api/services/klavis/strata-cache.test.ts`
- `bun run --filter @browseros/server typecheck`
- `bun run --filter @browseros/server test:sdk`
