### PR TITLE
feat: add connector_mcp_servers tool for strata MCP discovery

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/services/klavis/strata-proxy.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/klavis/strata-proxy.ts
@@ -9,8 +9,9 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { CallToolResult, Tool } from '@modelcontextprotocol/sdk/types.js'
+import { z } from 'zod'
 import { jsonSchemaObjectToZodRawShape } from 'zod-from-json-schema'
-import type { KlavisClient } from '../../../lib/clients/klavis/klavis-client'
+import { KlavisClient } from '../../../lib/clients/klavis/klavis-client'
 import { OAUTH_MCP_SERVERS } from '../../../lib/clients/klavis/oauth-mcp-servers'
 import { logger } from '../../../lib/logger'
 import { metrics } from '../../../lib/metrics'
@@ -28,6 +29,7 @@ function withTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
 }
 
 export interface KlavisProxyHandle {
+  browserosId: string
   tools: Tool[]
   inputSchemas: Map<string, Record<string, never>>
   callTool: (
@@ -85,6 +87,7 @@ export async function connectKlavisProxy(
   })
 
   return {
+    browserosId: deps.browserosId,
     tools,
     inputSchemas,
     callTool: (name, args) =>
@@ -93,10 +96,121 @@ export async function connectKlavisProxy(
   }
 }
 
+const serverNames = OAUTH_MCP_SERVERS.map((s) => s.name) as [
+  string,
+  ...string[],
+]
+
+const serverDescriptions = OAUTH_MCP_SERVERS.map(
+  (s) => `${s.name} (${s.description})`,
+).join(', ')
+
+// Double cast works around TS2589 in registerTool's recursive generics.
+const connectorInputSchema = {
+  server_name: z
+    .enum(serverNames)
+    .describe(
+      `The name of the service to check. Available: ${serverDescriptions}`,
+    ),
+} as unknown as Record<string, never>
+
 export function registerKlavisTools(
   mcpServer: McpServer,
   handle: KlavisProxyHandle,
 ): void {
+  // Register the connector discovery tool
+  mcpServer.registerTool(
+    'connector_mcp_servers',
+    {
+      description:
+        'Check if an external service is connected and ready for use with Strata MCP tools (discover_server_categories_or_actions, execute_action, etc.). Call this BEFORE using any Strata integration tool. If connected, proceed with Strata tools. If not connected, returns an authUrl — prompt the user to open it and authenticate.',
+      inputSchema: connectorInputSchema,
+    },
+    async (args: Record<string, unknown>) => {
+      const startTime = performance.now()
+      const server_name = args.server_name as string
+
+      try {
+        const klavisClient = new KlavisClient()
+        const integrations = await klavisClient.getUserIntegrations(
+          handle.browserosId,
+        )
+
+        const integration = integrations.find((i) => i.name === server_name)
+        const isConnected = integration?.isAuthenticated === true
+
+        if (isConnected) {
+          metrics.log('tool_executed', {
+            tool_name: 'connector_mcp_servers',
+            source: 'mcp',
+            duration_ms: Math.round(performance.now() - startTime),
+            success: true,
+          })
+
+          return {
+            content: [
+              {
+                type: 'text' as const,
+                text: JSON.stringify({
+                  connected: true,
+                  server_name,
+                }),
+              },
+            ],
+          }
+        }
+
+        // Not connected — get auth URL
+        const strata = await klavisClient.createStrata(handle.browserosId, [
+          server_name,
+        ])
+        const authUrl =
+          strata.oauthUrls?.[server_name] ??
+          strata.apiKeyUrls?.[server_name] ??
+          null
+
+        metrics.log('tool_executed', {
+          tool_name: 'connector_mcp_servers',
+          source: 'mcp',
+          duration_ms: Math.round(performance.now() - startTime),
+          success: true,
+        })
+
+        return {
+          content: [
+            {
+              type: 'text' as const,
+              text: JSON.stringify({
+                connected: false,
+                server_name,
+                authUrl,
+                message: authUrl
+                  ? `${server_name} is not connected. Ask the user to open this URL to authenticate: ${authUrl}`
+                  : `${server_name} is not connected. Could not retrieve auth URL.`,
+              }),
+            },
+          ],
+        }
+      } catch (error) {
+        const errorText = error instanceof Error ? error.message : String(error)
+
+        metrics.log('tool_executed', {
+          tool_name: 'connector_mcp_servers',
+          source: 'mcp',
+          duration_ms: Math.round(performance.now() - startTime),
+          success: false,
+          error_message: errorText,
+        })
+
+        return {
+          content: [{ type: 'text' as const, text: errorText }],
+          isError: true,
+        }
+      }
+    },
+  )
+
+  // Register Strata proxy tools
   for (const tool of handle.tools) {
     const inputSchema = handle.inputSchemas.get(tool.name)
 
@@ -141,6 +255,6 @@ export function registerKlavisTools(
   }
 
   logger.debug('Registered Klavis tools on MCP server', {
-    count: handle.tools.length,
+    count: handle.tools.length + 1,
   })
 }

--- a/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-prompt.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-prompt.ts
@@ -27,16 +27,21 @@ Error recovery:
 
 40+ services: Gmail, Slack, GitHub, Notion, Google Calendar, Jira, Linear, Figma, Salesforce, and more.
 
+Before using any Strata integration, call connector_mcp_servers(server_name) to verify the service is connected.
+- If connected → proceed with Strata discovery tools below.
+- If not connected → prompt the user with the returned authUrl to authenticate. After they confirm, call connector_mcp_servers again to verify.
+
 Progressive discovery — do not guess action names:
-1. discover_server_categories_or_actions → always start here.
-2. get_category_actions → expand categories from step 1.
-3. get_action_details → get parameter schema before executing.
-4. execute_action → use include_output_fields to limit response size.
-5. search_documentation → fallback keyword search.
+1. connector_mcp_servers → check connection status first.
+2. discover_server_categories_or_actions → discover available actions.
+3. get_category_actions → expand categories from step 2.
+4. get_action_details → get parameter schema before executing.
+5. execute_action → use include_output_fields to limit response size.
+6. search_documentation → fallback keyword search.
 
 Authentication — when execute_action returns an auth error:
-1. handle_auth_failure(server_name, intention: "get_auth_url").
-2. new_page(auth_url) to open in browser for user to authenticate.
+1. Call connector_mcp_servers(server_name) to get a fresh authUrl.
+2. Prompt the user to open the authUrl and authenticate.
 3. Wait for explicit user confirmation before retrying.
 
 ## General


### PR DESCRIPTION
## Summary

- Adds `connector_mcp_servers` MCP tool that lets external agents (claude-code, gemini-cli) check if a Klavis connector is authenticated before using Strata tools
- Tool input is an enum of all 45 supported services (Gmail, Slack, GitHub, etc.) — agents see the full list in the tool schema
- Returns `{ connected: true }` or `{ connected: false, authUrl }` so agents can prompt users to authenticate
- Updates MCP instructions to make `connector_mcp_servers` step 1 of the Strata discovery flow

## Problem

Agents connecting over MCP URL/CLI had no way to know which connectors were available or authenticated. They would fall back to browser automation (navigating to gmail.com) instead of using the faster Strata MCP tools.

## Test plan

- [x] Typecheck passes (`bun run typecheck`)
- [x] Lint passes (`biome check`)
- [x] Dev server starts without errors
- [x] Tool appears in `tools/list` response (67 tools total)
- [x] Tool schema has correct enum of 45 server names with descriptions
- [x] Calling with unauthenticated service returns `{ connected: false, authUrl: "https://..." }`
- [x] After authenticating via the returned URL, calling again returns `{ connected: true }`
- [x] MCP instructions include `connector_mcp_servers` in the discovery flow