### PR TITLE
fix: restore openai-compatible OpenClaw providers

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -105,6 +105,8 @@ export const AgentsPage: FC = () => {
     try {
       await setupOpenClaw({
         providerType: provider?.type,
+        providerName: provider?.name,
+        baseUrl: provider?.baseUrl,
         apiKey: provider?.apiKey,
         modelId: provider?.modelId,
       })
@@ -126,6 +128,8 @@ export const AgentsPage: FC = () => {
       await createAgent({
         name: newName.trim().toLowerCase().replace(/\s+/g, '-'),
         providerType: provider?.type,
+        providerName: provider?.name,
+        baseUrl: provider?.baseUrl,
         apiKey: provider?.apiKey,
         modelId: provider?.modelId,
       })
@@ -472,7 +476,13 @@ export const AgentsPage: FC = () => {
 }
 
 interface ProviderSelectorProps {
-  providers: Array<{ id: string; type: string; name: string; modelId: string }>
+  providers: Array<{
+    id: string
+    type: string
+    name: string
+    modelId: string
+    baseUrl?: string
+  }>
   defaultProviderId: string
   selectedId: string
   onSelect: (id: string) => void

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/useOpenClaw.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/useOpenClaw.ts
@@ -90,6 +90,8 @@ export function useOpenClawAgents(refreshKey: number) {
 
 export async function setupOpenClaw(input: {
   providerType?: string
+  providerName?: string
+  baseUrl?: string
   apiKey?: string
   modelId?: string
 }) {
@@ -103,6 +105,8 @@ export async function setupOpenClaw(input: {
 export async function createAgent(input: {
   name: string
   providerType?: string
+  providerName?: string
+  baseUrl?: string
   apiKey?: string
   modelId?: string
 }) {

--- a/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
@@ -28,6 +28,8 @@ export function createOpenClawRoutes() {
     .post('/setup', async (c) => {
       const body = await c.req.json<{
         providerType?: string
+        providerName?: string
+        baseUrl?: string
         apiKey?: string
         modelId?: string
       }>()
@@ -103,6 +105,8 @@ export function createOpenClawRoutes() {
       const body = await c.req.json<{
         name: string
         providerType?: string
+        providerName?: string
+        baseUrl?: string
         apiKey?: string
         modelId?: string
       }>()
@@ -116,6 +120,8 @@ export function createOpenClawRoutes() {
         const agent = await getOpenClawService().createAgent({
           name,
           providerType: body.providerType,
+          providerName: body.providerName,
+          baseUrl: body.baseUrl,
           apiKey: body.apiKey,
           modelId: body.modelId,
         })
@@ -210,6 +216,8 @@ export function createOpenClawRoutes() {
       const body = await c.req.json<{
         providerType: string
         apiKey: string
+        providerName?: string
+        baseUrl?: string
         modelId?: string
       }>()
 
@@ -218,10 +226,7 @@ export function createOpenClawRoutes() {
       }
 
       try {
-        await getOpenClawService().updateProviderKeys(
-          body.providerType,
-          body.apiKey,
-        )
+        await getOpenClawService().updateProviderKeys(body)
         return c.json({
           status: 'restarting',
           message: 'Provider updated, restarting gateway',

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-config.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-config.ts
@@ -25,11 +25,21 @@ export const PROVIDER_ENV_MAP: Record<string, string> = {
   mistral: 'MISTRAL_API_KEY',
 }
 
+export interface OpenClawProviderInput {
+  providerType?: string
+  providerName?: string
+  baseUrl?: string
+  modelId?: string
+  apiKey?: string
+}
+
 export interface BootstrapConfigInput {
   gatewayPort: number
   gatewayToken: string
   browserosServerPort?: number
   providerType?: string
+  providerName?: string
+  baseUrl?: string
   modelId?: string
 }
 
@@ -42,10 +52,103 @@ export interface EnvFileInput {
   providerKeys?: Record<string, string>
 }
 
+export interface ResolvedProviderConfig {
+  model?: string
+  providerKeys: Record<string, string>
+  models?: {
+    mode: 'merge'
+    providers: Record<string, Record<string, unknown>>
+  }
+}
+
+function hasBuiltinProvider(providerType?: string): providerType is string {
+  return !!providerType && providerType in PROVIDER_ENV_MAP
+}
+
+export function deriveOpenClawProviderId(providerInput: {
+  providerType?: string
+  providerName?: string
+  baseUrl?: string
+}): string {
+  const source =
+    providerInput.providerName?.trim() ||
+    providerInput.baseUrl?.trim() ||
+    providerInput.providerType?.trim() ||
+    'custom-provider'
+
+  const candidate = source
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+
+  return candidate || 'custom-provider'
+}
+
+export function deriveOpenClawApiKeyEnvVar(providerId: string): string {
+  return `${providerId.toUpperCase().replace(/-/g, '_')}_API_KEY`
+}
+
+export function resolveProviderConfig(
+  input: OpenClawProviderInput,
+): ResolvedProviderConfig {
+  if (!input.providerType) {
+    return { providerKeys: {} }
+  }
+
+  if (hasBuiltinProvider(input.providerType)) {
+    const providerKeys: Record<string, string> = {}
+    if (input.apiKey) {
+      providerKeys[PROVIDER_ENV_MAP[input.providerType]] = input.apiKey
+    }
+
+    return {
+      providerKeys,
+      model: input.modelId
+        ? `${input.providerType}/${input.modelId}`
+        : undefined,
+    }
+  }
+
+  if (!input.baseUrl) {
+    return { providerKeys: {} }
+  }
+
+  const providerId = deriveOpenClawProviderId(input)
+  const apiKeyEnvVar = deriveOpenClawApiKeyEnvVar(providerId)
+  const providerKeys: Record<string, string> = {}
+
+  if (input.apiKey) {
+    providerKeys[apiKeyEnvVar] = input.apiKey
+  }
+
+  const providerConfig: Record<string, unknown> = {
+    baseUrl: input.baseUrl,
+    apiKey: `\${${apiKeyEnvVar}}`,
+    api: 'openai-completions',
+  }
+
+  if (input.modelId) {
+    providerConfig.models = [{ id: input.modelId, name: input.modelId }]
+  }
+
+  return {
+    providerKeys,
+    model: input.modelId ? `${providerId}/${input.modelId}` : undefined,
+    models: {
+      mode: 'merge',
+      providers: {
+        [providerId]: providerConfig,
+      },
+    },
+  }
+}
+
 export function buildBootstrapConfig(
   input: BootstrapConfigInput,
 ): Record<string, unknown> {
   const serverPort = input.browserosServerPort ?? DEFAULT_PORTS.server
+  const provider = resolveProviderConfig(input)
 
   const defaults: Record<string, unknown> = {
     workspace: `${OPENCLAW_CONTAINER_HOME}/workspace`,
@@ -53,11 +156,10 @@ export function buildBootstrapConfig(
     thinkingDefault: 'adaptive',
   }
 
-  if (input.providerType && input.modelId) {
-    defaults.model = { primary: `${input.providerType}/${input.modelId}` }
+  if (provider.model) {
+    defaults.model = { primary: provider.model }
   }
-
-  return {
+  const config: Record<string, unknown> = {
     gateway: {
       mode: 'local',
       port: input.gatewayPort,
@@ -115,6 +217,12 @@ export function buildBootstrapConfig(
       install: { nodeManager: 'bun' },
     },
   }
+
+  if (provider.models) {
+    config.models = provider.models
+  }
+
+  return config
 }
 
 export function buildEnvFile(input: EnvFileInput): string {
@@ -136,15 +244,13 @@ export function buildEnvFile(input: EnvFileInput): string {
 }
 
 export function resolveProviderKeys(
-  providerType?: string,
-  apiKey?: string,
+  input: OpenClawProviderInput,
 ): Record<string, string> {
-  const keys: Record<string, string> = {}
-  if (!providerType || !apiKey) return keys
+  return resolveProviderConfig(input).providerKeys
+}
 
-  const envVar = PROVIDER_ENV_MAP[providerType]
-  if (envVar) {
-    keys[envVar] = apiKey
-  }
-  return keys
+export function resolveProviderModel(
+  input: OpenClawProviderInput,
+): string | undefined {
+  return resolveProviderConfig(input).model
 }

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -31,7 +31,11 @@ import {
 import {
   buildBootstrapConfig,
   buildEnvFile,
+  deriveOpenClawApiKeyEnvVar,
+  deriveOpenClawProviderId,
+  PROVIDER_ENV_MAP,
   resolveProviderKeys,
+  resolveProviderModel,
 } from './openclaw-config'
 import { getPodmanRuntime } from './podman-runtime'
 
@@ -61,6 +65,8 @@ export interface OpenClawStatusResponse {
 
 export interface SetupInput {
   providerType?: string
+  providerName?: string
+  baseUrl?: string
   apiKey?: string
   modelId?: string
 }
@@ -104,7 +110,7 @@ export class OpenClawService {
     await this.runtime.copyComposeFile(COMPOSE_RESOURCE)
 
     this.token = crypto.randomUUID()
-    const providerKeys = resolveProviderKeys(input.providerType, input.apiKey)
+    const providerKeys = resolveProviderKeys(input)
     const envContent = buildEnvFile({
       token: this.token,
       configDir: this.openclawDir,
@@ -118,6 +124,8 @@ export class OpenClawService {
       gatewayToken: this.token,
       browserosServerPort: this.browserosServerPort,
       providerType: input.providerType,
+      providerName: input.providerName,
+      baseUrl: input.baseUrl,
       modelId: input.modelId,
     })
     await this.writeBootstrapConfig(config)
@@ -169,10 +177,7 @@ export class OpenClawService {
     const hasMain = existingAgents.some((a) => a.agentId === 'main')
     if (!hasMain) {
       logProgress('Creating main agent...')
-      const model =
-        input.providerType && input.modelId
-          ? `${input.providerType}/${input.modelId}`
-          : undefined
+      const model = resolveProviderModel(input)
       // biome-ignore lint/style/noNonNullAssertion: gateway is connected
       await this.gateway!.createAgent({
         name: 'main',
@@ -308,6 +313,8 @@ export class OpenClawService {
   async createAgent(input: {
     name: string
     providerType?: string
+    providerName?: string
+    baseUrl?: string
     apiKey?: string
     modelId?: string
   }): Promise<GatewayAgentEntry> {
@@ -319,27 +326,24 @@ export class OpenClawService {
     logger.debug('Creating OpenClaw agent', {
       name,
       providerType: input.providerType,
+      providerName: input.providerName,
+      hasBaseUrl: !!input.baseUrl,
       hasModel: !!input.modelId,
       hasApiKey: !!input.apiKey,
     })
     this.ensureGatewayConnected()
 
-    let needsRestart = false
-    if (input.providerType && input.apiKey) {
-      needsRestart = await this.mergeProviderKeyIfNew(
-        input.providerType,
-        input.apiKey,
-      )
-    }
+    const configChanged = await this.mergeProviderConfigIfChanged(input)
+    const keysChanged =
+      input.providerType && input.apiKey
+        ? await this.mergeProviderKeyIfChanged(input)
+        : false
 
-    if (needsRestart) {
+    if (configChanged || keysChanged) {
       await this.restart()
     }
 
-    const model =
-      input.providerType && input.modelId
-        ? `${input.providerType}/${input.modelId}`
-        : undefined
+    const model = resolveProviderModel(input)
 
     const gateway = this.gateway
     if (!gateway) {
@@ -409,13 +413,17 @@ export class OpenClawService {
 
   // ── Provider Keys ────────────────────────────────────────────────────
 
-  async updateProviderKeys(
-    providerType: string,
-    apiKey: string,
-  ): Promise<void> {
-    await this.mergeProviderKeyIfNew(providerType, apiKey)
+  async updateProviderKeys(input: {
+    providerType: string
+    providerName?: string
+    baseUrl?: string
+    apiKey: string
+    modelId?: string
+  }): Promise<void> {
+    await this.mergeProviderConfigIfChanged(input)
+    await this.mergeProviderKeyIfChanged(input)
     await this.restart()
-    logger.info('Provider keys updated', { providerType })
+    logger.info('Provider keys updated', { providerType: input.providerType })
   }
 
   // ── Logs ─────────────────────────────────────────────────────────────
@@ -614,15 +622,17 @@ export class OpenClawService {
   }
 
   /**
-   * Merges a provider API key into .env. Returns true if the key was NEW
-   * (not previously present), meaning a container restart is needed to
-   * pick up the new env var.
+   * Merges provider credentials into .env. Returns true when the env file
+   * changed, meaning the container should restart to pick up the update.
    */
-  private async mergeProviderKeyIfNew(
-    providerType: string,
-    apiKey: string,
-  ): Promise<boolean> {
-    const newKeys = resolveProviderKeys(providerType, apiKey)
+  private async mergeProviderKeyIfChanged(input: {
+    providerType?: string
+    providerName?: string
+    baseUrl?: string
+    apiKey?: string
+    modelId?: string
+  }): Promise<boolean> {
+    const newKeys = resolveProviderKeys(input)
     if (Object.keys(newKeys).length === 0) return false
 
     const envPath = join(this.openclawDir, '.env')
@@ -649,11 +659,92 @@ export class OpenClawService {
 
     await writeFile(envPath, content, { mode: 0o600 })
     logger.debug('Updated OpenClaw provider credentials', {
-      providerType,
+      providerType: input.providerType,
       addedNew,
       updatedExisting,
     })
-    return addedNew
+    return addedNew || updatedExisting
+  }
+
+  private async mergeProviderConfigIfChanged(input: {
+    providerType?: string
+    providerName?: string
+    baseUrl?: string
+    modelId?: string
+  }): Promise<boolean> {
+    if (
+      !input.providerType ||
+      !input.baseUrl ||
+      input.providerType in PROVIDER_ENV_MAP
+    ) {
+      return false
+    }
+
+    const configPath = join(this.openclawDir, OPENCLAW_CONFIG_FILE)
+    let content = ''
+    try {
+      content = await readFile(configPath, 'utf-8')
+    } catch {
+      return false
+    }
+
+    const config = JSON.parse(content) as Record<string, unknown>
+    const models = (config.models ?? {}) as Record<string, unknown>
+    const providers = ((models.providers as
+      | Record<string, unknown>
+      | undefined) ?? {}) as Record<string, Record<string, unknown>>
+
+    const providerId = deriveOpenClawProviderId(input)
+    const existingProvider = providers[providerId] ?? {}
+    const nextProvider: Record<string, unknown> = {
+      ...existingProvider,
+      baseUrl: input.baseUrl,
+      apiKey:
+        existingProvider.apiKey ??
+        `\${${deriveOpenClawApiKeyEnvVar(providerId)}}`,
+    }
+
+    if (!existingProvider.api) {
+      nextProvider.api = 'openai-completions'
+    }
+
+    if (input.modelId) {
+      const existingModels = Array.isArray(existingProvider.models)
+        ? (existingProvider.models as Array<Record<string, unknown>>)
+        : []
+      const hasModel = existingModels.some(
+        (model) => model.id === input.modelId || model.name === input.modelId,
+      )
+      if (!hasModel) {
+        nextProvider.models = [
+          ...existingModels,
+          { id: input.modelId, name: input.modelId },
+        ]
+      }
+    }
+
+    if (
+      JSON.stringify(existingProvider) === JSON.stringify(nextProvider) &&
+      models.mode === 'merge'
+    ) {
+      return false
+    }
+
+    config.models = {
+      ...models,
+      mode: 'merge',
+      providers: {
+        ...providers,
+        [providerId]: nextProvider,
+      },
+    }
+    await this.writeBootstrapConfig(config)
+    logger.debug('Updated OpenClaw provider config', {
+      providerId,
+      providerType: input.providerType,
+      hasModel: !!input.modelId,
+    })
+    return true
   }
 
   private async loadTokenFromEnv(): Promise<void> {


### PR DESCRIPTION
## Summary
- restore custom OpenAI-compatible provider support for OpenClaw setup and agent creation
- pass provider name and base URL from the agent UI into the OpenClaw server routes
- generate custom OpenClaw provider definitions instead of emitting invalid `openai-compatible/<modelId>` model ids

## Problem
`dev` only handled built-in OpenClaw provider ids. For BrowserOS providers of type `openai-compatible`, BrowserOS was generating model ids like `openai-compatible/accounts/fireworks/models/kimi-k2p5` without defining a matching OpenClaw provider block, which caused `FailoverError: Unknown model`.

## Fix
- keep the existing built-in provider env-map path unchanged
- add a custom-provider path for non-built-in providers with `baseUrl`
- generate a stable provider id, API key env var, merged provider config, and resolved default model
- update runtime agent creation so custom providers are merged into `openclaw.json` before gateway restart

## Validation
- `bun run typecheck` in `packages/browseros-agent/apps/server`
- `bun run typecheck` in `packages/browseros-agent/apps/agent`