### PR TITLE
fix: harden openclaw gateway recovery

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
@@ -170,7 +170,7 @@ export function createOpenClawRoutes() {
       const sessionKey = body.sessionKey ?? crypto.randomUUID()
 
       try {
-        const eventStream = getOpenClawService().chatStream(
+        const eventStream = await getOpenClawService().chatStream(
           id,
           sessionKey,
           body.message,

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/gateway-client.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/gateway-client.ts
@@ -16,8 +16,6 @@ import { OPENCLAW_CONTAINER_HOME } from '@browseros/shared/constants/openclaw'
 import { logger } from '../../../lib/logger'
 
 const RPC_TIMEOUT_MS = 15_000
-const RECONNECT_DELAY_MS = 2_000
-const MAX_RECONNECT_RETRIES = 5
 const SCOPES = [
   'operator.read',
   'operator.write',
@@ -47,6 +45,18 @@ interface WsFrame {
   payload?: Record<string, unknown>
   error?: { message: string; code?: string }
   event?: string
+}
+
+export type GatewayClientConnectionState =
+  | 'idle'
+  | 'connecting'
+  | 'connected'
+  | 'closed'
+  | 'failed'
+
+export interface GatewayHandshakeError {
+  code?: string
+  message: string
 }
 
 export interface OpenClawStreamEvent {
@@ -167,9 +177,9 @@ export class GatewayClient {
   private ws: WebSocket | null = null
   private _connected = false
   private pendingRequests = new Map<string, PendingRequest>()
-  private reconnectAttempts = 0
-  private shouldReconnect = true
   private device: DeviceIdentity | null = null
+  private connectionState: GatewayClientConnectionState = 'idle'
+  private lastHandshakeError: GatewayHandshakeError | null = null
 
   constructor(
     private readonly port: number,
@@ -189,8 +199,18 @@ export class GatewayClient {
     return this._connected
   }
 
+  get state(): GatewayClientConnectionState {
+    return this.connectionState
+  }
+
+  get lastError(): GatewayHandshakeError | null {
+    return this.lastHandshakeError
+  }
+
   async connect(): Promise<void> {
     return new Promise((resolve, reject) => {
+      this.connectionState = 'connecting'
+      this.lastHandshakeError = null
       const url = `ws://127.0.0.1:${this.port}`
       this.ws = new WebSocket(url, {
         headers: { Origin: `http://127.0.0.1:${this.port}` },
@@ -254,11 +274,16 @@ export class GatewayClient {
             if (frame.ok) {
               handshakeComplete = true
               this._connected = true
-              this.reconnectAttempts = 0
+              this.connectionState = 'connected'
               logger.info('Gateway WS connected')
               resolve()
             } else {
               const msg = frame.error?.message ?? 'Handshake failed'
+              this.connectionState = 'failed'
+              this.lastHandshakeError = {
+                message: msg,
+                code: frame.error?.code,
+              }
               logger.error('Gateway WS handshake rejected', {
                 error: msg,
                 code: frame.error?.code,
@@ -275,6 +300,7 @@ export class GatewayClient {
 
       this.ws.onerror = (err) => {
         if (!handshakeComplete) {
+          this.connectionState = 'failed'
           reject(
             new Error(
               `WS connection error: ${err instanceof Error ? err.message : 'unknown'}`,
@@ -285,18 +311,19 @@ export class GatewayClient {
 
       this.ws.onclose = () => {
         this._connected = false
+        this.connectionState = 'closed'
         this.rejectAllPending('WebSocket closed')
         if (handshakeComplete) {
           logger.info('Gateway WS disconnected')
-          this.tryReconnect()
         }
+        this.ws = null
       }
     })
   }
 
   disconnect(): void {
-    this.shouldReconnect = false
     this._connected = false
+    this.connectionState = 'closed'
     this.rejectAllPending('Client disconnecting')
     if (this.ws) {
       this.ws.onclose = null
@@ -534,28 +561,6 @@ export class GatewayClient {
     } catch {
       return null
     }
-  }
-
-  private tryReconnect(): void {
-    if (!this.shouldReconnect) return
-    if (this.reconnectAttempts >= MAX_RECONNECT_RETRIES) {
-      logger.warn('Gateway WS max reconnect attempts reached')
-      return
-    }
-
-    this.reconnectAttempts++
-    logger.info('Gateway WS reconnecting...', {
-      attempt: this.reconnectAttempts,
-    })
-
-    setTimeout(() => {
-      this.connect().catch((err) => {
-        logger.warn('Gateway WS reconnect failed', {
-          error: err instanceof Error ? err.message : String(err),
-          attempt: this.reconnectAttempts,
-        })
-      })
-    }, RECONNECT_DELAY_MS)
   }
 
   private rejectAllPending(reason: string): void {

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -47,6 +47,22 @@ const OPENCLAW_CONFIG_FILE = 'openclaw.json'
 const READY_TIMEOUT_MS = 30_000
 const AGENT_NAME_PATTERN = /^[a-z][a-z0-9-]*$/
 
+export type OpenClawControlPlaneStatus =
+  | 'disconnected'
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'recovering'
+  | 'failed'
+
+export type OpenClawGatewayRecoveryReason =
+  | 'transient_disconnect'
+  | 'signature_expired'
+  | 'pairing_required'
+  | 'token_mismatch'
+  | 'container_not_ready'
+  | 'unknown'
+
 export type OpenClawStatus =
   | 'uninitialized'
   | 'starting'
@@ -61,6 +77,9 @@ export interface OpenClawStatusResponse {
   port: number | null
   agentCount: number
   error: string | null
+  controlPlaneStatus: OpenClawControlPlaneStatus
+  lastGatewayError: string | null
+  lastRecoveryReason: OpenClawGatewayRecoveryReason | null
 }
 
 export interface SetupInput {
@@ -79,6 +98,10 @@ export class OpenClawService {
   private token: string
   private lastError: string | null = null
   private browserosServerPort: number
+  private controlPlaneStatus: OpenClawControlPlaneStatus = 'disconnected'
+  private lastGatewayError: string | null = null
+  private lastRecoveryReason: OpenClawGatewayRecoveryReason | null = null
+  private gatewayReconnectPromise: Promise<void> | null = null
 
   constructor(browserosServerPort?: number) {
     this.openclawDir = getOpenClawDir()
@@ -151,25 +174,8 @@ export class OpenClawService {
     logProgress('Generating client device identity...')
     ensureClientIdentity(this.openclawDir)
 
-    // Attempt WS connect — this triggers a pending pair request
-    logProgress('Pairing client device...')
-    try {
-      await this.connectGateway()
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      if (
-        !msg.includes('pairing required') &&
-        !msg.includes('signature expired')
-      ) {
-        throw err
-      }
-    }
-
-    // Approve the pending device via the openclaw CLI inside the container
-    await this.approvePendingDevice(logProgress)
-
     logProgress('Connecting to gateway...')
-    await this.connectGateway()
+    await this.connectGatewayResiliently(logProgress)
 
     // Ensure main agent exists (gateway may auto-create it)
     // biome-ignore lint/style/noNonNullAssertion: gateway is guaranteed connected after connectGateway()
@@ -210,7 +216,7 @@ export class OpenClawService {
     }
 
     logProgress('Connecting to gateway...')
-    await this.connectGateway()
+    await this.connectGatewayResiliently(logProgress)
     this.lastError = null
     logger.info('OpenClaw gateway started', { port: this.port })
   }
@@ -238,7 +244,7 @@ export class OpenClawService {
     }
 
     logProgress('Connecting to gateway...')
-    await this.connectGateway()
+    await this.connectGatewayResiliently(logProgress)
     this.lastError = null
     logProgress('Gateway restarted successfully')
     logger.info('OpenClaw gateway restarted', { port: this.port })
@@ -267,6 +273,9 @@ export class OpenClawService {
         port: null,
         agentCount: 0,
         error: null,
+        controlPlaneStatus: 'disconnected',
+        lastGatewayError: null,
+        lastRecoveryReason: null,
       }
     }
 
@@ -280,6 +289,9 @@ export class OpenClawService {
         port: null,
         agentCount: 0,
         error: null,
+        controlPlaneStatus: 'disconnected',
+        lastGatewayError: this.lastGatewayError,
+        lastRecoveryReason: this.lastRecoveryReason,
       }
     }
 
@@ -305,6 +317,13 @@ export class OpenClawService {
       port: this.port,
       agentCount,
       error: this.lastError,
+      controlPlaneStatus: ready
+        ? this.gateway?.isConnected
+          ? 'connected'
+          : this.controlPlaneStatus
+        : 'disconnected',
+      lastGatewayError: this.lastGatewayError,
+      lastRecoveryReason: this.lastRecoveryReason,
     }
   }
 
@@ -331,7 +350,7 @@ export class OpenClawService {
       hasModel: !!input.modelId,
       hasApiKey: !!input.apiKey,
     })
-    this.ensureGatewayConnected()
+    await this.ensureGatewayReady()
 
     const configChanged = await this.mergeProviderConfigIfChanged(input)
     const keysChanged =
@@ -377,9 +396,9 @@ export class OpenClawService {
       throw new OpenClawProtectedAgentError('Cannot delete the main agent')
     }
 
-    this.ensureGatewayConnected()
+    await this.ensureGatewayReady()
     try {
-      // biome-ignore lint/style/noNonNullAssertion: ensureGatewayConnected() guards above
+      // biome-ignore lint/style/noNonNullAssertion: ensureGatewayReady() guarantees a connected client
       await this.gateway!.deleteAgent(agentId)
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error)
@@ -392,22 +411,22 @@ export class OpenClawService {
   }
 
   async listAgents(): Promise<GatewayAgentEntry[]> {
-    this.ensureGatewayConnected()
+    await this.ensureGatewayReady()
     logger.debug('Listing OpenClaw agents')
-    // biome-ignore lint/style/noNonNullAssertion: ensureGatewayConnected() guards above
+    // biome-ignore lint/style/noNonNullAssertion: ensureGatewayReady() guarantees a connected client
     return this.gateway!.listAgents()
   }
 
   // ── Chat Stream (WS) ─────────────────────────────────────────────────
 
-  chatStream(
+  async chatStream(
     agentId: string,
     sessionKey: string,
     message: string,
-  ): ReadableStream<OpenClawStreamEvent> {
-    this.ensureGatewayConnected()
+  ): Promise<ReadableStream<OpenClawStreamEvent>> {
+    await this.ensureGatewayReady()
     logger.debug('Starting OpenClaw chat stream', { agentId, sessionKey })
-    // biome-ignore lint/style/noNonNullAssertion: ensureGatewayConnected() guards above
+    // biome-ignore lint/style/noNonNullAssertion: ensureGatewayReady() guarantees a connected client
     return this.gateway!.chatStream(agentId, sessionKey, message)
   }
 
@@ -458,7 +477,7 @@ export class OpenClawService {
         }
       }
 
-      await this.connectGatewayWithRetry()
+      await this.connectGatewayResiliently()
       logger.info('OpenClaw gateway auto-started')
     } catch (err) {
       logger.warn('OpenClaw auto-start failed', {
@@ -467,47 +486,60 @@ export class OpenClawService {
     }
   }
 
-  /**
-   * Connects to the gateway, retrying once after a container restart
-   * if the signature is expired (clock skew from Podman VM sleep).
-   */
-  private async connectGatewayWithRetry(): Promise<void> {
+  private async connectGatewayResiliently(
+    onLog?: (msg: string) => void,
+  ): Promise<void> {
+    const logProgress = this.createProgressLogger(onLog)
+    const existingConnection =
+      !!this.gateway || this.controlPlaneStatus !== 'disconnected'
+    this.controlPlaneStatus = existingConnection ? 'reconnecting' : 'connecting'
+    this.lastGatewayError = null
+    this.lastRecoveryReason = null
+
     try {
       await this.connectGateway()
-    } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
-      if (
-        msg.includes('signature expired') ||
-        msg.includes('pairing required')
-      ) {
-        logger.info(
-          'Gateway WS auth failed, restarting container to resync clock...',
-        )
-        await this.runtime.composeRestart()
-        const ready = await this.runtime.waitForReady(
-          this.port,
-          READY_TIMEOUT_MS,
-        )
-        if (!ready)
-          throw new Error('Gateway not ready after clock resync restart')
+      this.controlPlaneStatus = 'connected'
+      this.lastGatewayError = null
+      this.lastRecoveryReason = null
+      logger.info('OpenClaw gateway control plane connected', {
+        port: this.port,
+      })
+      return
+    } catch (error) {
+      const reason = this.classifyGatewayError(error)
+      const message = error instanceof Error ? error.message : String(error)
+      this.lastGatewayError = message
+      this.lastRecoveryReason = reason
+      logger.warn('OpenClaw gateway connect failed', { reason, error: message })
 
-        // Re-approve device if needed (pairing may have been lost)
-        try {
-          await this.connectGateway()
-        } catch (retryErr) {
-          const retryMsg =
-            retryErr instanceof Error ? retryErr.message : String(retryErr)
-          if (retryMsg.includes('pairing required')) {
-            await this.approvePendingDevice((m) =>
-              logger.debug(`Auto-start: ${m}`),
-            )
-            await this.connectGateway()
-          } else {
-            throw retryErr
-          }
-        }
-      } else {
-        throw err
+      if (!this.isRecoverableGatewayError(reason)) {
+        this.controlPlaneStatus = 'failed'
+        throw error
+      }
+
+      this.controlPlaneStatus = 'recovering'
+      logProgress(`Recovering gateway connection: ${reason}`)
+      await this.performGatewayRecovery(reason, logProgress)
+
+      try {
+        await this.connectGateway()
+        this.controlPlaneStatus = 'connected'
+        this.lastGatewayError = null
+        logger.info('OpenClaw gateway control plane recovered', {
+          reason,
+          port: this.port,
+        })
+      } catch (retryError) {
+        const retryMessage =
+          retryError instanceof Error ? retryError.message : String(retryError)
+        this.lastGatewayError = retryMessage
+        this.lastRecoveryReason = this.classifyGatewayError(retryError)
+        this.controlPlaneStatus = 'failed'
+        logger.error('OpenClaw gateway recovery failed', {
+          reason,
+          error: retryMessage,
+        })
+        throw retryError
       }
     }
   }
@@ -596,8 +628,9 @@ export class OpenClawService {
   private async connectGateway(): Promise<void> {
     this.disconnectGateway()
     logger.debug('Connecting OpenClaw gateway client', { port: this.port })
-    this.gateway = new GatewayClient(this.port, this.token, this.openclawDir)
-    await this.gateway.connect()
+    const gateway = new GatewayClient(this.port, this.token, this.openclawDir)
+    await gateway.connect()
+    this.gateway = gateway
   }
 
   private disconnectGateway(): void {
@@ -605,12 +638,92 @@ export class OpenClawService {
       this.gateway.disconnect()
       this.gateway = null
     }
+    this.controlPlaneStatus = 'disconnected'
   }
 
-  private ensureGatewayConnected(): void {
-    if (!this.gateway?.isConnected) {
-      logger.debug('OpenClaw gateway client is not connected')
-      throw new Error('Gateway WS not connected')
+  private async ensureGatewayReady(): Promise<void> {
+    if (this.gateway?.isConnected) {
+      this.controlPlaneStatus = 'connected'
+      return
+    }
+
+    const portReady = await this.runtime.isReady(this.port)
+    if (!portReady) {
+      this.controlPlaneStatus = 'failed'
+      this.lastGatewayError = 'OpenClaw gateway is not ready'
+      this.lastRecoveryReason = 'container_not_ready'
+      throw new Error('OpenClaw gateway is not ready')
+    }
+
+    if (this.gatewayReconnectPromise) {
+      await this.gatewayReconnectPromise
+      return
+    }
+
+    this.gatewayReconnectPromise = this.connectGatewayResiliently()
+    try {
+      await this.gatewayReconnectPromise
+    } finally {
+      this.gatewayReconnectPromise = null
+    }
+  }
+
+  private classifyGatewayError(error: unknown): OpenClawGatewayRecoveryReason {
+    const message = error instanceof Error ? error.message : String(error)
+    if (message.includes('signature expired')) return 'signature_expired'
+    if (message.includes('pairing required')) return 'pairing_required'
+    if (message.includes('Gateway WS not connected'))
+      return 'transient_disconnect'
+    if (message.includes('token')) return 'token_mismatch'
+    if (message.includes('not ready')) return 'container_not_ready'
+    return 'unknown'
+  }
+
+  private isRecoverableGatewayError(
+    reason: OpenClawGatewayRecoveryReason,
+  ): boolean {
+    return (
+      reason === 'transient_disconnect' ||
+      reason === 'signature_expired' ||
+      reason === 'pairing_required' ||
+      reason === 'token_mismatch'
+    )
+  }
+
+  private async performGatewayRecovery(
+    reason: OpenClawGatewayRecoveryReason,
+    logProgress: (msg: string) => void,
+  ): Promise<void> {
+    switch (reason) {
+      case 'signature_expired': {
+        logProgress('Restarting gateway to resync device signature clock...')
+        await this.runtime.composeRestart(logProgress)
+        const ready = await this.runtime.waitForReady(
+          this.port,
+          READY_TIMEOUT_MS,
+        )
+        if (!ready) {
+          throw new Error('Gateway not ready after clock resync restart')
+        }
+        return
+      }
+
+      case 'pairing_required':
+        logProgress('Approving pending device pairing...')
+        await this.approvePendingDevice(logProgress)
+        return
+
+      case 'token_mismatch':
+        logProgress('Reloading gateway auth token...')
+        await this.loadTokenFromEnv()
+        return
+
+      case 'transient_disconnect':
+        logProgress('Retrying gateway connection...')
+        return
+
+      default:
+        throw new Error(`Unrecoverable gateway error: ${reason}`)
     }
   }
 


### PR DESCRIPTION
## Summary
- move OpenClaw gateway reconnect ownership into the service layer
- add explicit control-plane status and recovery state to gateway status reporting
- replace fail-fast gateway checks with reconnect-before-use logic for agent control operations

## Changes
- remove client-owned background reconnect from the gateway WebSocket client
- add connection state and handshake error tracking to the gateway client
- standardize setup, start, restart, and auto-start on one resilient gateway connect path
- classify recoverable failures such as signature expiry and pairing-required conditions
- make agent CRUD and chat preflight wait for a healthy gateway control plane before proceeding

## Validation
- bun install in packages/browseros-agent
- bun run typecheck in packages/browseros-agent/apps/server

## Notes
- this PR is scoped to the service/client reliability layer only
- UI recovery polish is intentionally deferred to a follow-up change