### PR TITLE
fix: complete openclaw gateway recovery UX

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/agent-command-layout.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/agent-command-layout.tsx
@@ -16,7 +16,9 @@ interface AgentCommandContextValue {
 
 export const AgentCommandLayout: FC = () => {
   const { status, loading: statusLoading } = useOpenClawStatus(5000)
-  const { agents, loading: agentsLoading } = useOpenClawAgents(0)
+  const { agents, loading: agentsLoading } = useOpenClawAgents(
+    status?.status === 'running' && status.controlPlaneStatus === 'connected',
+  )
 
   return (
     <Outlet

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -135,7 +135,10 @@ const StatusBadge: FC<{ status: OpenClawStatus['status'] }> = ({ status }) => {
     error: { variant: 'destructive', label: 'Error' },
     uninitialized: { variant: 'outline', label: 'Not Set Up' },
   }
-  const current = variants[status]
+  const current = variants[status] ?? {
+    variant: 'outline' as const,
+    label: 'Unknown',
+  }
   return <Badge variant={current.variant}>{current.label}</Badge>
 }
 

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -95,6 +95,14 @@ const CONTROL_PLANE_COPY: Record<
   },
 }
 
+const FALLBACK_CONTROL_PLANE_COPY = {
+  badgeVariant: 'outline' as const,
+  badgeLabel: 'Unknown',
+  title: 'Gateway State Unknown',
+  description:
+    'BrowserOS received a gateway status it does not recognize yet. Refreshing or reconnecting should restore a known state.',
+}
+
 const RECOVERY_REASON_COPY: Record<
   NonNullable<OpenClawStatus['lastRecoveryReason']>,
   string
@@ -134,8 +142,12 @@ const StatusBadge: FC<{ status: OpenClawStatus['status'] }> = ({ status }) => {
 const ControlPlaneBadge: FC<{
   status: OpenClawStatus['controlPlaneStatus']
 }> = ({ status }) => {
-  const current = CONTROL_PLANE_COPY[status]
+  const current = CONTROL_PLANE_COPY[status] ?? FALLBACK_CONTROL_PLANE_COPY
   return <Badge variant={current.badgeVariant}>{current.badgeLabel}</Badge>
+}
+
+function getControlPlaneCopy(status: OpenClawStatus['controlPlaneStatus']) {
+  return CONTROL_PLANE_COPY[status] ?? FALLBACK_CONTROL_PLANE_COPY
 }
 
 function getRecoveryDetail(status: OpenClawStatus): string | null {
@@ -304,6 +316,9 @@ export const AgentsPage: FC = () => {
   }, [status])
 
   const recoveryDetail = status ? getRecoveryDetail(status) : null
+  const controlPlaneCopy = status
+    ? getControlPlaneCopy(status.controlPlaneStatus)
+    : null
 
   const runWithErrorHandling = async (fn: () => Promise<unknown>) => {
     setError(null)
@@ -501,11 +516,9 @@ export const AgentsPage: FC = () => {
           ) : (
             <WifiOff />
           )}
-          <AlertTitle>
-            {CONTROL_PLANE_COPY[status.controlPlaneStatus].title}
-          </AlertTitle>
+          <AlertTitle>{controlPlaneCopy?.title}</AlertTitle>
           <AlertDescription>
-            <p>{CONTROL_PLANE_COPY[status.controlPlaneStatus].description}</p>
+            <p>{controlPlaneCopy?.description}</p>
             {recoveryDetail && <p>{recoveryDetail}</p>}
             <div className="mt-2 flex flex-wrap gap-2">
               <Button

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -5,11 +5,15 @@ import {
   MessageSquare,
   Plus,
   RefreshCw,
+  ShieldAlert,
   Square,
   TerminalSquare,
   Trash2,
+  WifiOff,
+  Wrench,
 } from 'lucide-react'
-import { type FC, useEffect, useState } from 'react'
+import { type FC, useEffect, useMemo, useState } from 'react'
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -32,21 +36,86 @@ import { AgentChat } from './AgentChat'
 import { AgentTerminal } from './AgentTerminal'
 import {
   type AgentEntry,
-  createAgent,
-  deleteAgent,
-  restartOpenClaw,
-  setupOpenClaw,
-  startOpenClaw,
-  stopOpenClaw,
+  type OpenClawStatus,
   useOpenClawAgents,
+  useOpenClawMutations,
   useOpenClawStatus,
 } from './useOpenClaw'
 
 const OAUTH_ONLY_TYPES = new Set(['chatgpt-pro', 'github-copilot', 'qwen-code'])
 
-const StatusBadge: FC<{ status: string }> = ({ status }) => {
+const CONTROL_PLANE_COPY: Record<
+  OpenClawStatus['controlPlaneStatus'],
+  {
+    badgeVariant: 'default' | 'secondary' | 'outline' | 'destructive'
+    badgeLabel: string
+    title: string
+    description: string
+  }
+> = {
+  connected: {
+    badgeVariant: 'default',
+    badgeLabel: 'Control Plane Ready',
+    title: 'Gateway Connected',
+    description: 'OpenClaw can create, manage, and chat with agents normally.',
+  },
+  connecting: {
+    badgeVariant: 'secondary',
+    badgeLabel: 'Connecting',
+    title: 'Connecting to Gateway',
+    description:
+      'BrowserOS is establishing the OpenClaw control channel for agent operations.',
+  },
+  reconnecting: {
+    badgeVariant: 'secondary',
+    badgeLabel: 'Reconnecting',
+    title: 'Reconnecting Control Plane',
+    description:
+      'The gateway process is up, but BrowserOS is restoring the control channel.',
+  },
+  recovering: {
+    badgeVariant: 'secondary',
+    badgeLabel: 'Recovering',
+    title: 'Recovering Gateway Connection',
+    description:
+      'BrowserOS detected a control-plane fault and is trying a safe recovery path.',
+  },
+  disconnected: {
+    badgeVariant: 'outline',
+    badgeLabel: 'Disconnected',
+    title: 'Gateway Disconnected',
+    description: 'The gateway process is not available to BrowserOS right now.',
+  },
+  failed: {
+    badgeVariant: 'destructive',
+    badgeLabel: 'Needs Attention',
+    title: 'Gateway Recovery Failed',
+    description:
+      'BrowserOS could not restore the OpenClaw control channel automatically.',
+  },
+}
+
+const RECOVERY_REASON_COPY: Record<
+  NonNullable<OpenClawStatus['lastRecoveryReason']>,
+  string
+> = {
+  transient_disconnect:
+    'The control channel dropped briefly and BrowserOS is retrying it.',
+  signature_expired:
+    'The gateway rejected the signed device handshake because its clock drifted.',
+  pairing_required:
+    'The gateway asked BrowserOS to approve its local device identity again.',
+  token_mismatch:
+    'BrowserOS had to reload the gateway token before reconnecting.',
+  container_not_ready:
+    'The OpenClaw gateway process is not ready yet, so control-plane recovery cannot start.',
+  unknown:
+    'BrowserOS hit an unexpected gateway error and could not classify it cleanly.',
+}
+
+const StatusBadge: FC<{ status: OpenClawStatus['status'] }> = ({ status }) => {
   const variants: Record<
-    string,
+    OpenClawStatus['status'],
     {
       variant: 'default' | 'secondary' | 'outline' | 'destructive'
       label: string
@@ -58,421 +127,29 @@ const StatusBadge: FC<{ status: string }> = ({ status }) => {
     error: { variant: 'destructive', label: 'Error' },
     uninitialized: { variant: 'outline', label: 'Not Set Up' },
   }
-  const v = variants[status] ?? { variant: 'outline' as const, label: status }
-  return <Badge variant={v.variant}>{v.label}</Badge>
+  const current = variants[status]
+  return <Badge variant={current.variant}>{current.label}</Badge>
 }
 
-export const AgentsPage: FC = () => {
-  const { status, loading: statusLoading } = useOpenClawStatus()
-  const { providers, defaultProviderId } = useLlmProviders()
-  const [refreshKey, setRefreshKey] = useState(0)
-  const { agents, loading: agentsLoading } = useOpenClawAgents(refreshKey)
+const ControlPlaneBadge: FC<{
+  status: OpenClawStatus['controlPlaneStatus']
+}> = ({ status }) => {
+  const current = CONTROL_PLANE_COPY[status]
+  return <Badge variant={current.badgeVariant}>{current.badgeLabel}</Badge>
+}
 
-  const [setupOpen, setSetupOpen] = useState(false)
-  const [setupProviderId, setSetupProviderId] = useState('')
-  const [settingUp, setSettingUp] = useState(false)
+function getRecoveryDetail(status: OpenClawStatus): string | null {
+  if (!status.lastRecoveryReason && !status.lastGatewayError) return null
 
-  const [createOpen, setCreateOpen] = useState(false)
-  const [newName, setNewName] = useState('')
-  const [createProviderId, setCreateProviderId] = useState('')
-  const [creating, setCreating] = useState(false)
+  const detail = status.lastRecoveryReason
+    ? RECOVERY_REASON_COPY[status.lastRecoveryReason]
+    : null
 
-  const [actionInProgress, setActionInProgress] = useState(false)
-  const [chatAgent, setChatAgent] = useState<AgentEntry | null>(null)
-  const [showTerminal, setShowTerminal] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-
-  const compatibleProviders = providers.filter(
-    (p) => p.apiKey && !OAUTH_ONLY_TYPES.has(p.type),
-  )
-
-  // Pre-select default provider when dialogs open
-  useEffect(() => {
-    if (compatibleProviders.length === 0) return
-    const fallbackId =
-      compatibleProviders.find((p) => p.id === defaultProviderId)?.id ??
-      compatibleProviders[0].id
-    if (setupOpen) setSetupProviderId(fallbackId)
-    if (createOpen) setCreateProviderId(fallbackId)
-  }, [setupOpen, createOpen, compatibleProviders, defaultProviderId])
-
-  const refresh = () => setRefreshKey((k) => k + 1)
-
-  const handleSetup = async () => {
-    const provider = compatibleProviders.find((p) => p.id === setupProviderId)
-    setSettingUp(true)
-    setError(null)
-    try {
-      await setupOpenClaw({
-        providerType: provider?.type,
-        providerName: provider?.name,
-        baseUrl: provider?.baseUrl,
-        apiKey: provider?.apiKey,
-        modelId: provider?.modelId,
-      })
-      setSetupOpen(false)
-      refresh()
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-    } finally {
-      setSettingUp(false)
-    }
+  if (status.lastGatewayError && detail) {
+    return `${detail} Latest gateway error: ${status.lastGatewayError}`
   }
 
-  const handleCreate = async () => {
-    if (!newName.trim()) return
-    const provider = compatibleProviders.find((p) => p.id === createProviderId)
-    setCreating(true)
-    setError(null)
-    try {
-      await createAgent({
-        name: newName.trim().toLowerCase().replace(/\s+/g, '-'),
-        providerType: provider?.type,
-        providerName: provider?.name,
-        baseUrl: provider?.baseUrl,
-        apiKey: provider?.apiKey,
-        modelId: provider?.modelId,
-      })
-      setCreateOpen(false)
-      setNewName('')
-      refresh()
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-    } finally {
-      setCreating(false)
-    }
-  }
-
-  const handleDelete = async (id: string) => {
-    setActionInProgress(true)
-    try {
-      await deleteAgent(id)
-      refresh()
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-    } finally {
-      setActionInProgress(false)
-    }
-  }
-
-  const handleStop = async () => {
-    setActionInProgress(true)
-    try {
-      await stopOpenClaw()
-      refresh()
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-    } finally {
-      setActionInProgress(false)
-    }
-  }
-
-  const handleStart = async () => {
-    setActionInProgress(true)
-    setError(null)
-    try {
-      await startOpenClaw()
-      refresh()
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-    } finally {
-      setActionInProgress(false)
-    }
-  }
-
-  const handleRestart = async () => {
-    setActionInProgress(true)
-    try {
-      await restartOpenClaw()
-      refresh()
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err))
-    } finally {
-      setActionInProgress(false)
-    }
-  }
-
-  if (showTerminal) {
-    return <AgentTerminal onBack={() => setShowTerminal(false)} />
-  }
-
-  if (chatAgent) {
-    return (
-      <AgentChat
-        agentId={chatAgent.agentId}
-        agentName={chatAgent.name}
-        onBack={() => setChatAgent(null)}
-      />
-    )
-  }
-
-  if (statusLoading) {
-    return (
-      <div className="flex items-center justify-center py-20">
-        <Loader2 className="size-6 animate-spin text-muted-foreground" />
-      </div>
-    )
-  }
-
-  return (
-    <div className="fade-in slide-in-from-bottom-5 animate-in space-y-6 duration-500">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="font-bold text-2xl">Agents</h1>
-          <p className="text-muted-foreground text-sm">
-            OpenClaw agents running in a local container
-          </p>
-        </div>
-        <div className="flex items-center gap-2">
-          {status?.status === 'running' && (
-            <>
-              <StatusBadge status="running" />
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={handleRestart}
-                disabled={actionInProgress}
-                title="Restart gateway"
-              >
-                <RefreshCw className="size-4" />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon"
-                onClick={handleStop}
-                disabled={actionInProgress}
-                title="Stop gateway"
-              >
-                <Square className="size-4" />
-              </Button>
-              <Button variant="outline" onClick={() => setShowTerminal(true)}>
-                <TerminalSquare className="mr-1 size-4" />
-                Terminal
-              </Button>
-              <Button onClick={() => setCreateOpen(true)}>
-                <Plus className="mr-1 size-4" />
-                New Agent
-              </Button>
-            </>
-          )}
-        </div>
-      </div>
-
-      {/* Error banner */}
-      {error && (
-        <Card className="border-destructive">
-          <CardContent className="flex items-center gap-2 py-3">
-            <AlertCircle className="size-4 text-destructive" />
-            <p className="text-destructive text-sm">{error}</p>
-            <Button
-              variant="ghost"
-              size="sm"
-              className="ml-auto"
-              onClick={() => setError(null)}
-            >
-              Dismiss
-            </Button>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Uninitialized state */}
-      {status?.status === 'uninitialized' && (
-        <Card>
-          <CardContent className="flex flex-col items-center gap-4 py-12">
-            <Cpu className="size-12 text-muted-foreground" />
-            <div className="text-center">
-              <h3 className="font-semibold text-lg">Set Up OpenClaw</h3>
-              <p className="text-muted-foreground text-sm">
-                {status.podmanAvailable
-                  ? 'Create a local container to run autonomous agents with full tool access.'
-                  : 'Podman is required to run OpenClaw agents. Install Podman first.'}
-              </p>
-            </div>
-            {status.podmanAvailable && (
-              <Button onClick={() => setSetupOpen(true)}>Set Up Now</Button>
-            )}
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Stopped state */}
-      {status?.status === 'stopped' && (
-        <Card>
-          <CardContent className="flex flex-col items-center gap-4 py-12">
-            <Cpu className="size-12 text-muted-foreground" />
-            <div className="text-center">
-              <h3 className="font-semibold text-lg">Gateway Stopped</h3>
-              <p className="text-muted-foreground text-sm">
-                The OpenClaw gateway is not running.
-              </p>
-            </div>
-            <Button onClick={handleStart} disabled={actionInProgress}>
-              Start Gateway
-            </Button>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Error state */}
-      {status?.status === 'error' && (
-        <Card className="border-destructive">
-          <CardContent className="flex flex-col items-center gap-4 py-12">
-            <AlertCircle className="size-12 text-destructive" />
-            <div className="text-center">
-              <h3 className="font-semibold text-lg">Gateway Error</h3>
-              <p className="text-muted-foreground text-sm">{status.error}</p>
-            </div>
-            <Button onClick={handleRestart} disabled={actionInProgress}>
-              Retry
-            </Button>
-          </CardContent>
-        </Card>
-      )}
-
-      {/* Agent list */}
-      {status?.status === 'running' && (
-        <div className="space-y-3">
-          {agentsLoading ? (
-            <div className="flex justify-center py-8">
-              <Loader2 className="size-5 animate-spin text-muted-foreground" />
-            </div>
-          ) : agents.length === 0 ? (
-            <Card>
-              <CardContent className="flex flex-col items-center gap-3 py-8">
-                <p className="text-muted-foreground text-sm">
-                  No agents yet. Create one to get started.
-                </p>
-                <Button variant="outline" onClick={() => setCreateOpen(true)}>
-                  <Plus className="mr-1 size-4" />
-                  Create Agent
-                </Button>
-              </CardContent>
-            </Card>
-          ) : (
-            agents.map((agent) => (
-              <Card key={agent.agentId}>
-                <CardHeader className="flex flex-row items-center justify-between py-3">
-                  <div className="flex items-center gap-3">
-                    <Cpu className="size-5 text-muted-foreground" />
-                    <div>
-                      <CardTitle className="text-base">{agent.name}</CardTitle>
-                      <p className="font-mono text-muted-foreground text-xs">
-                        {agent.workspace}
-                      </p>
-                    </div>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      onClick={() => setChatAgent(agent)}
-                    >
-                      <MessageSquare className="mr-1 size-4" />
-                      Chat
-                    </Button>
-                    {agent.agentId !== 'main' && (
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => handleDelete(agent.agentId)}
-                        disabled={actionInProgress}
-                      >
-                        <Trash2 className="size-4 text-destructive" />
-                      </Button>
-                    )}
-                  </div>
-                </CardHeader>
-              </Card>
-            ))
-          )}
-        </div>
-      )}
-
-      {/* Setup Dialog (with provider selector) */}
-      <Dialog open={setupOpen} onOpenChange={setSetupOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Set Up OpenClaw</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4 py-2">
-            <ProviderSelector
-              providers={compatibleProviders}
-              defaultProviderId={defaultProviderId}
-              selectedId={setupProviderId}
-              onSelect={setSetupProviderId}
-            />
-            <Button
-              onClick={handleSetup}
-              disabled={settingUp}
-              className="w-full"
-            >
-              {settingUp ? (
-                <>
-                  <Loader2 className="mr-2 size-4 animate-spin" />
-                  Setting up...
-                </>
-              ) : (
-                'Set Up & Start'
-              )}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
-
-      {/* Create Agent Dialog */}
-      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Create Agent</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-4 py-2">
-            <div>
-              <label
-                htmlFor="agent-name"
-                className="mb-1 block font-medium text-sm"
-              >
-                Agent Name
-              </label>
-              <Input
-                id="agent-name"
-                value={newName}
-                onChange={(e) => setNewName(e.target.value)}
-                placeholder="research-agent"
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') handleCreate()
-                }}
-              />
-              <p className="mt-1 text-muted-foreground text-xs">
-                Lowercase letters, numbers, and hyphens only.
-              </p>
-            </div>
-            <ProviderSelector
-              providers={compatibleProviders}
-              defaultProviderId={defaultProviderId}
-              selectedId={createProviderId}
-              onSelect={setCreateProviderId}
-            />
-            <Button
-              onClick={handleCreate}
-              disabled={!newName.trim() || creating}
-              className="w-full"
-            >
-              {creating ? (
-                <>
-                  <Loader2 className="mr-2 size-4 animate-spin" />
-                  Creating...
-                </>
-              ) : (
-                'Create Agent'
-              )}
-            </Button>
-          </div>
-        </DialogContent>
-      </Dialog>
-    </div>
-  )
+  return status.lastGatewayError ?? detail
 }
 
 interface ProviderSelectorProps {
@@ -531,6 +208,541 @@ const ProviderSelector: FC<ProviderSelectorProps> = ({
         Uses your existing API key from BrowserOS settings. The key is passed to
         the container and never leaves your machine.
       </p>
+    </div>
+  )
+}
+
+export const AgentsPage: FC = () => {
+  const {
+    status,
+    loading: statusLoading,
+    error: statusError,
+  } = useOpenClawStatus()
+  const { providers, defaultProviderId } = useLlmProviders()
+  const agentsQueryEnabled =
+    status?.status === 'running' && status.controlPlaneStatus === 'connected'
+  const {
+    agents,
+    loading: agentsLoading,
+    error: agentsError,
+  } = useOpenClawAgents(agentsQueryEnabled)
+  const {
+    setupOpenClaw,
+    createAgent,
+    deleteAgent,
+    startOpenClaw,
+    stopOpenClaw,
+    restartOpenClaw,
+    reconnectOpenClaw,
+    actionInProgress,
+    settingUp,
+    creating,
+    deleting,
+    reconnecting,
+  } = useOpenClawMutations()
+
+  const [setupOpen, setSetupOpen] = useState(false)
+  const [setupProviderId, setSetupProviderId] = useState('')
+
+  const [createOpen, setCreateOpen] = useState(false)
+  const [newName, setNewName] = useState('')
+  const [createProviderId, setCreateProviderId] = useState('')
+
+  const [chatAgent, setChatAgent] = useState<AgentEntry | null>(null)
+  const [showTerminal, setShowTerminal] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const compatibleProviders = providers.filter(
+    (provider) => provider.apiKey && !OAUTH_ONLY_TYPES.has(provider.type),
+  )
+
+  useEffect(() => {
+    if (compatibleProviders.length === 0) return
+    const fallbackId =
+      compatibleProviders.find((provider) => provider.id === defaultProviderId)
+        ?.id ?? compatibleProviders[0].id
+
+    if (setupOpen && !setupProviderId) setSetupProviderId(fallbackId)
+    if (createOpen && !createProviderId) setCreateProviderId(fallbackId)
+  }, [
+    setupOpen,
+    createOpen,
+    setupProviderId,
+    createProviderId,
+    compatibleProviders,
+    defaultProviderId,
+  ])
+
+  const inlineError =
+    error ?? statusError?.message ?? agentsError?.message ?? null
+
+  const gatewayUiState = useMemo(() => {
+    if (!status) {
+      return {
+        canManageAgents: false,
+        controlPlaneDegraded: false,
+        controlPlaneBusy: false,
+      }
+    }
+
+    const controlPlaneBusy =
+      status.controlPlaneStatus === 'connecting' ||
+      status.controlPlaneStatus === 'reconnecting' ||
+      status.controlPlaneStatus === 'recovering'
+
+    const canManageAgents =
+      status.status === 'running' && status.controlPlaneStatus === 'connected'
+
+    const controlPlaneDegraded =
+      status.status === 'running' && status.controlPlaneStatus !== 'connected'
+
+    return {
+      canManageAgents,
+      controlPlaneBusy,
+      controlPlaneDegraded,
+    }
+  }, [status])
+
+  const recoveryDetail = status ? getRecoveryDetail(status) : null
+
+  const runWithErrorHandling = async (fn: () => Promise<unknown>) => {
+    setError(null)
+    try {
+      await fn()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const handleSetup = async () => {
+    const provider = compatibleProviders.find((p) => p.id === setupProviderId)
+
+    await runWithErrorHandling(async () => {
+      await setupOpenClaw({
+        providerType: provider?.type,
+        providerName: provider?.name,
+        baseUrl: provider?.baseUrl,
+        apiKey: provider?.apiKey,
+        modelId: provider?.modelId,
+      })
+      setSetupOpen(false)
+    })
+  }
+
+  const handleCreate = async () => {
+    if (!newName.trim()) return
+    const provider = compatibleProviders.find((p) => p.id === createProviderId)
+
+    await runWithErrorHandling(async () => {
+      await createAgent({
+        name: newName.trim().toLowerCase().replace(/\s+/g, '-'),
+        providerType: provider?.type,
+        providerName: provider?.name,
+        baseUrl: provider?.baseUrl,
+        apiKey: provider?.apiKey,
+        modelId: provider?.modelId,
+      })
+      setCreateOpen(false)
+      setNewName('')
+    })
+  }
+
+  const handleDelete = async (id: string) => {
+    await runWithErrorHandling(async () => {
+      await deleteAgent(id)
+    })
+  }
+
+  const handleStop = async () => {
+    await runWithErrorHandling(async () => {
+      await stopOpenClaw()
+    })
+  }
+
+  const handleStart = async () => {
+    await runWithErrorHandling(async () => {
+      await startOpenClaw()
+    })
+  }
+
+  const handleRestart = async () => {
+    await runWithErrorHandling(async () => {
+      await restartOpenClaw()
+    })
+  }
+
+  const handleReconnect = async () => {
+    await runWithErrorHandling(async () => {
+      await reconnectOpenClaw()
+    })
+  }
+
+  if (showTerminal) {
+    return <AgentTerminal onBack={() => setShowTerminal(false)} />
+  }
+
+  if (chatAgent) {
+    return (
+      <AgentChat
+        agentId={chatAgent.agentId}
+        agentName={chatAgent.name}
+        onBack={() => setChatAgent(null)}
+      />
+    )
+  }
+
+  if (statusLoading && !status) {
+    return (
+      <div className="flex items-center justify-center py-20">
+        <Loader2 className="size-6 animate-spin text-muted-foreground" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="fade-in slide-in-from-bottom-5 animate-in space-y-6 duration-500">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="font-bold text-2xl">Agents</h1>
+          <p className="text-muted-foreground text-sm">
+            OpenClaw agents running in a local container
+          </p>
+        </div>
+
+        {status && (
+          <div className="flex items-center gap-2">
+            <StatusBadge status={status.status} />
+            {status.status !== 'uninitialized' && (
+              <ControlPlaneBadge status={status.controlPlaneStatus} />
+            )}
+
+            {status.status === 'running' && (
+              <>
+                {status.controlPlaneStatus !== 'connected' && (
+                  <Button
+                    variant="outline"
+                    onClick={handleReconnect}
+                    disabled={
+                      actionInProgress || gatewayUiState.controlPlaneBusy
+                    }
+                  >
+                    {reconnecting ? (
+                      <Loader2 className="mr-2 size-4 animate-spin" />
+                    ) : (
+                      <RefreshCw className="mr-2 size-4" />
+                    )}
+                    Retry Connection
+                  </Button>
+                )}
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={handleRestart}
+                  disabled={actionInProgress}
+                  title="Restart gateway"
+                >
+                  <RefreshCw className="size-4" />
+                </Button>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={handleStop}
+                  disabled={actionInProgress}
+                  title="Stop gateway"
+                >
+                  <Square className="size-4" />
+                </Button>
+                <Button variant="outline" onClick={() => setShowTerminal(true)}>
+                  <TerminalSquare className="mr-1 size-4" />
+                  Terminal
+                </Button>
+                <Button
+                  onClick={() => setCreateOpen(true)}
+                  disabled={!gatewayUiState.canManageAgents}
+                >
+                  <Plus className="mr-1 size-4" />
+                  New Agent
+                </Button>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+
+      {inlineError && (
+        <Alert variant="destructive">
+          <AlertCircle />
+          <AlertTitle>OpenClaw action failed</AlertTitle>
+          <AlertDescription>
+            <p>{inlineError}</p>
+            <div className="mt-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setError(null)}
+              >
+                Dismiss
+              </Button>
+            </div>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {status && gatewayUiState.controlPlaneDegraded && (
+        <Alert
+          variant={
+            status.controlPlaneStatus === 'failed' ? 'destructive' : 'default'
+          }
+        >
+          {status.controlPlaneStatus === 'failed' ? (
+            <ShieldAlert />
+          ) : status.controlPlaneStatus === 'recovering' ? (
+            <Wrench />
+          ) : (
+            <WifiOff />
+          )}
+          <AlertTitle>
+            {CONTROL_PLANE_COPY[status.controlPlaneStatus].title}
+          </AlertTitle>
+          <AlertDescription>
+            <p>{CONTROL_PLANE_COPY[status.controlPlaneStatus].description}</p>
+            {recoveryDetail && <p>{recoveryDetail}</p>}
+            <div className="mt-2 flex flex-wrap gap-2">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleReconnect}
+                disabled={actionInProgress || gatewayUiState.controlPlaneBusy}
+              >
+                {reconnecting ? (
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                ) : (
+                  <RefreshCw className="mr-2 size-4" />
+                )}
+                Retry Connection
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleRestart}
+                disabled={actionInProgress}
+              >
+                Restart Gateway
+              </Button>
+            </div>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {status?.status === 'uninitialized' && (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-4 py-12">
+            <Cpu className="size-12 text-muted-foreground" />
+            <div className="text-center">
+              <h3 className="font-semibold text-lg">Set Up OpenClaw</h3>
+              <p className="text-muted-foreground text-sm">
+                {status.podmanAvailable
+                  ? 'Create a local container to run autonomous agents with full tool access.'
+                  : 'Podman is required to run OpenClaw agents. Install Podman first.'}
+              </p>
+            </div>
+            {status.podmanAvailable && (
+              <Button onClick={() => setSetupOpen(true)}>Set Up Now</Button>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {status?.status === 'stopped' && (
+        <Card>
+          <CardContent className="flex flex-col items-center gap-4 py-12">
+            <Cpu className="size-12 text-muted-foreground" />
+            <div className="text-center">
+              <h3 className="font-semibold text-lg">Gateway Stopped</h3>
+              <p className="text-muted-foreground text-sm">
+                The OpenClaw gateway is not running.
+              </p>
+            </div>
+            <Button onClick={handleStart} disabled={actionInProgress}>
+              Start Gateway
+            </Button>
+          </CardContent>
+        </Card>
+      )}
+
+      {status?.status === 'error' && (
+        <Card className="border-destructive">
+          <CardContent className="flex flex-col items-center gap-4 py-12">
+            <AlertCircle className="size-12 text-destructive" />
+            <div className="text-center">
+              <h3 className="font-semibold text-lg">Gateway Error</h3>
+              <p className="text-muted-foreground text-sm">
+                {status.error ?? status.lastGatewayError}
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <Button onClick={handleStart} disabled={actionInProgress}>
+                Start Gateway
+              </Button>
+              <Button
+                variant="outline"
+                onClick={handleRestart}
+                disabled={actionInProgress}
+              >
+                Restart Gateway
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {status?.status === 'running' && (
+        <div className="space-y-3">
+          {agentsLoading ? (
+            <div className="flex justify-center py-8">
+              <Loader2 className="size-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : agents.length === 0 ? (
+            <Card>
+              <CardContent className="flex flex-col items-center gap-3 py-8">
+                <p className="text-muted-foreground text-sm">
+                  No agents yet. Create one to get started.
+                </p>
+                <Button
+                  variant="outline"
+                  onClick={() => setCreateOpen(true)}
+                  disabled={!gatewayUiState.canManageAgents}
+                >
+                  <Plus className="mr-1 size-4" />
+                  Create Agent
+                </Button>
+              </CardContent>
+            </Card>
+          ) : (
+            agents.map((agent) => (
+              <Card key={agent.agentId}>
+                <CardHeader className="flex flex-row items-center justify-between py-3">
+                  <div className="flex items-center gap-3">
+                    <Cpu className="size-5 text-muted-foreground" />
+                    <div>
+                      <CardTitle className="text-base">{agent.name}</CardTitle>
+                      <p className="font-mono text-muted-foreground text-xs">
+                        {agent.workspace}
+                      </p>
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-1">
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setChatAgent(agent)}
+                      disabled={!gatewayUiState.canManageAgents}
+                    >
+                      <MessageSquare className="mr-1 size-4" />
+                      Chat
+                    </Button>
+                    {agent.agentId !== 'main' && (
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => handleDelete(agent.agentId)}
+                        disabled={!gatewayUiState.canManageAgents || deleting}
+                      >
+                        <Trash2 className="size-4 text-destructive" />
+                      </Button>
+                    )}
+                  </div>
+                </CardHeader>
+              </Card>
+            ))
+          )}
+        </div>
+      )}
+
+      <Dialog open={setupOpen} onOpenChange={setSetupOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Set Up OpenClaw</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <ProviderSelector
+              providers={compatibleProviders}
+              defaultProviderId={defaultProviderId}
+              selectedId={setupProviderId}
+              onSelect={setSetupProviderId}
+            />
+            <Button
+              onClick={handleSetup}
+              disabled={settingUp || compatibleProviders.length === 0}
+              className="w-full"
+            >
+              {settingUp ? (
+                <>
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                  Setting up...
+                </>
+              ) : (
+                'Set Up & Start'
+              )}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Create Agent</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div>
+              <label
+                htmlFor="agent-name"
+                className="mb-1 block font-medium text-sm"
+              >
+                Agent Name
+              </label>
+              <Input
+                id="agent-name"
+                value={newName}
+                onChange={(event) => setNewName(event.target.value)}
+                placeholder="research-agent"
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') void handleCreate()
+                }}
+              />
+              <p className="mt-1 text-muted-foreground text-xs">
+                Lowercase letters, numbers, and hyphens only.
+              </p>
+            </div>
+            <ProviderSelector
+              providers={compatibleProviders}
+              defaultProviderId={defaultProviderId}
+              selectedId={createProviderId}
+              onSelect={setCreateProviderId}
+            />
+            <Button
+              onClick={handleCreate}
+              disabled={
+                !newName.trim() ||
+                creating ||
+                !gatewayUiState.canManageAgents ||
+                compatibleProviders.length === 0
+              }
+              className="w-full"
+            >
+              {creating ? (
+                <>
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                  Creating...
+                </>
+              ) : (
+                'Create Agent'
+              )}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
     </div>
   )
 }

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/useOpenClaw.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/useOpenClaw.ts
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react'
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { getAgentServerUrl } from '@/lib/browseros/helpers'
+import { useAgentServerUrl } from '@/lib/browseros/useBrowserOSProviders'
 
 export interface AgentEntry {
   agentId: string
@@ -20,10 +21,32 @@ export interface OpenClawStatus {
   port: number | null
   agentCount: number
   error: string | null
+  controlPlaneStatus:
+    | 'disconnected'
+    | 'connecting'
+    | 'connected'
+    | 'reconnecting'
+    | 'recovering'
+    | 'failed'
+  lastGatewayError: string | null
+  lastRecoveryReason:
+    | 'transient_disconnect'
+    | 'signature_expired'
+    | 'pairing_required'
+    | 'token_mismatch'
+    | 'container_not_ready'
+    | 'unknown'
+    | null
 }
 
-async function clawFetch<T>(path: string, init?: RequestInit): Promise<T> {
-  const baseUrl = await getAgentServerUrl()
+const OPENCLAW_STATUS_QUERY_KEY = 'openclaw-status'
+const OPENCLAW_AGENTS_QUERY_KEY = 'openclaw-agents'
+
+async function clawFetch<T>(
+  baseUrl: string,
+  path: string,
+  init?: RequestInit,
+): Promise<T> {
   const res = await fetch(`${baseUrl}/claw${path}`, init)
   if (!res.ok) {
     let message = `Request failed with status ${res.status}`
@@ -38,101 +61,178 @@ async function clawFetch<T>(path: string, init?: RequestInit): Promise<T> {
   return res.json() as Promise<T>
 }
 
+async function fetchOpenClawStatus(baseUrl: string): Promise<OpenClawStatus> {
+  return clawFetch<OpenClawStatus>(baseUrl, '/status')
+}
+
+async function fetchOpenClawAgents(baseUrl: string): Promise<AgentEntry[]> {
+  const data = await clawFetch<{ agents: AgentEntry[] }>(baseUrl, '/agents')
+  return data.agents ?? []
+}
+
+async function invalidateOpenClawQueries(
+  queryClient: ReturnType<typeof useQueryClient>,
+): Promise<void> {
+  await Promise.all([
+    queryClient.invalidateQueries({ queryKey: [OPENCLAW_STATUS_QUERY_KEY] }),
+    queryClient.invalidateQueries({ queryKey: [OPENCLAW_AGENTS_QUERY_KEY] }),
+  ])
+}
+
 export function useOpenClawStatus(pollMs = 5000) {
-  const [status, setStatus] = useState<OpenClawStatus | null>(null)
-  const [loading, setLoading] = useState(true)
+  const {
+    baseUrl,
+    isLoading: urlLoading,
+    error: urlError,
+  } = useAgentServerUrl()
 
-  useEffect(() => {
-    let active = true
-    const poll = async () => {
-      try {
-        const s = await clawFetch<OpenClawStatus>('/status')
-        if (active) setStatus(s)
-      } catch {
-        // Server may not be running
-      } finally {
-        if (active) setLoading(false)
-      }
-    }
-    poll()
-    const id = setInterval(poll, pollMs)
-    return () => {
-      active = false
-      clearInterval(id)
-    }
-  }, [pollMs])
-
-  return { status, loading }
-}
-
-export function useOpenClawAgents(refreshKey: number) {
-  const [agents, setAgents] = useState<AgentEntry[]>([])
-  const [loading, setLoading] = useState(true)
-
-  // biome-ignore lint/correctness/useExhaustiveDependencies: refreshKey is an intentional refetch trigger
-  useEffect(() => {
-    let active = true
-    clawFetch<{ agents: AgentEntry[] }>('/agents')
-      .then((data) => {
-        if (active) setAgents(data.agents ?? [])
-      })
-      .catch(() => {})
-      .finally(() => {
-        if (active) setLoading(false)
-      })
-    return () => {
-      active = false
-    }
-  }, [refreshKey])
-
-  return { agents, loading }
-}
-
-export async function setupOpenClaw(input: {
-  providerType?: string
-  providerName?: string
-  baseUrl?: string
-  apiKey?: string
-  modelId?: string
-}) {
-  return clawFetch<{ status: string; agents: AgentEntry[] }>('/setup', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(input),
+  const query = useQuery<OpenClawStatus, Error>({
+    queryKey: [OPENCLAW_STATUS_QUERY_KEY, baseUrl],
+    queryFn: () => fetchOpenClawStatus(baseUrl as string),
+    enabled: !!baseUrl && !urlLoading,
+    refetchInterval: pollMs,
   })
+
+  return {
+    status: query.data ?? null,
+    loading: query.isLoading || urlLoading,
+    error: query.error ?? urlError,
+    refetch: query.refetch,
+  }
 }
 
-export async function createAgent(input: {
-  name: string
-  providerType?: string
-  providerName?: string
-  baseUrl?: string
-  apiKey?: string
-  modelId?: string
-}) {
-  return clawFetch<{ agent: AgentEntry }>('/agents', {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(input),
+export function useOpenClawAgents(enabled = true) {
+  const {
+    baseUrl,
+    isLoading: urlLoading,
+    error: urlError,
+  } = useAgentServerUrl()
+
+  const query = useQuery<AgentEntry[], Error>({
+    queryKey: [OPENCLAW_AGENTS_QUERY_KEY, baseUrl],
+    queryFn: () => fetchOpenClawAgents(baseUrl as string),
+    enabled: !!baseUrl && !urlLoading && enabled,
   })
+
+  return {
+    agents: query.data ?? [],
+    loading: query.isLoading || urlLoading,
+    error: query.error ?? urlError,
+    refetch: query.refetch,
+  }
 }
 
-export async function deleteAgent(id: string) {
-  return clawFetch<{ success: boolean }>(`/agents/${id}`, {
-    method: 'DELETE',
+export function useOpenClawMutations() {
+  const { baseUrl, isLoading: urlLoading } = useAgentServerUrl()
+  const queryClient = useQueryClient()
+
+  const ensureBaseUrl = () => {
+    if (!baseUrl || urlLoading) {
+      throw new Error('BrowserOS agent server URL is not ready')
+    }
+    return baseUrl
+  }
+
+  const onSuccess = () => invalidateOpenClawQueries(queryClient)
+
+  const setupMutation = useMutation({
+    mutationFn: async (input: {
+      providerType?: string
+      providerName?: string
+      baseUrl?: string
+      apiKey?: string
+      modelId?: string
+    }) =>
+      clawFetch<{ status: string; agents: AgentEntry[] }>(
+        ensureBaseUrl(),
+        '/setup',
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(input),
+        },
+      ),
+    onSuccess,
   })
-}
 
-export async function startOpenClaw() {
-  return clawFetch<{ status: string }>('/start', { method: 'POST' })
-}
+  const createMutation = useMutation({
+    mutationFn: async (input: {
+      name: string
+      providerType?: string
+      providerName?: string
+      baseUrl?: string
+      apiKey?: string
+      modelId?: string
+    }) =>
+      clawFetch<{ agent: AgentEntry }>(ensureBaseUrl(), '/agents', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(input),
+      }),
+    onSuccess,
+  })
 
-export async function stopOpenClaw() {
-  return clawFetch<{ status: string }>('/stop', { method: 'POST' })
-}
+  const deleteMutation = useMutation({
+    mutationFn: async (id: string) =>
+      clawFetch<{ success: boolean }>(ensureBaseUrl(), `/agents/${id}`, {
+        method: 'DELETE',
+      }),
+    onSuccess,
+  })
 
-export async function restartOpenClaw() {
-  return clawFetch<{ status: string }>('/restart', { method: 'POST' })
+  const startMutation = useMutation({
+    mutationFn: async () =>
+      clawFetch<{ status: string }>(ensureBaseUrl(), '/start', {
+        method: 'POST',
+      }),
+    onSuccess,
+  })
+
+  const stopMutation = useMutation({
+    mutationFn: async () =>
+      clawFetch<{ status: string }>(ensureBaseUrl(), '/stop', {
+        method: 'POST',
+      }),
+    onSuccess,
+  })
+
+  const restartMutation = useMutation({
+    mutationFn: async () =>
+      clawFetch<{ status: string }>(ensureBaseUrl(), '/restart', {
+        method: 'POST',
+      }),
+    onSuccess,
+  })
+
+  const reconnectMutation = useMutation({
+    mutationFn: async () =>
+      clawFetch<{ status: string }>(ensureBaseUrl(), '/reconnect', {
+        method: 'POST',
+      }),
+    onSuccess,
+  })
+
+  return {
+    setupOpenClaw: setupMutation.mutateAsync,
+    createAgent: createMutation.mutateAsync,
+    deleteAgent: deleteMutation.mutateAsync,
+    startOpenClaw: startMutation.mutateAsync,
+    stopOpenClaw: stopMutation.mutateAsync,
+    restartOpenClaw: restartMutation.mutateAsync,
+    reconnectOpenClaw: reconnectMutation.mutateAsync,
+    actionInProgress:
+      setupMutation.isPending ||
+      createMutation.isPending ||
+      deleteMutation.isPending ||
+      startMutation.isPending ||
+      stopMutation.isPending ||
+      restartMutation.isPending ||
+      reconnectMutation.isPending,
+    settingUp: setupMutation.isPending,
+    creating: createMutation.isPending,
+    deleting: deleteMutation.isPending,
+    reconnecting: reconnectMutation.isPending,
+  }
 }
 
 export interface OpenClawStreamEvent {

--- a/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
@@ -91,6 +91,16 @@ export function createOpenClawRoutes() {
       }
     })
 
+    .post('/reconnect', async (c) => {
+      try {
+        await getOpenClawService().reconnectControlPlane()
+        return c.json({ status: 'connected' })
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        return c.json({ error: message }, 500)
+      }
+    })
+
     .get('/agents', async (c) => {
       try {
         const agents = await getOpenClawService().listAgents()

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -250,6 +250,27 @@ export class OpenClawService {
     logger.info('OpenClaw gateway restarted', { port: this.port })
   }
 
+  async reconnectControlPlane(onLog?: (msg: string) => void): Promise<void> {
+    const logProgress = this.createProgressLogger(onLog)
+
+    logProgress('Checking gateway readiness...')
+    const ready = await this.runtime.isReady(this.port)
+    if (!ready) {
+      this.controlPlaneStatus = 'failed'
+      this.lastGatewayError = 'OpenClaw gateway is not ready'
+      this.lastRecoveryReason = 'container_not_ready'
+      throw new Error('OpenClaw gateway is not ready')
+    }
+
+    logProgress('Reloading gateway auth token...')
+    await this.loadTokenFromEnv()
+    this.disconnectGateway()
+
+    logProgress('Reconnecting control plane...')
+    await this.ensureGatewayReady()
+    logProgress('Control plane connected')
+  }
+
   async shutdown(): Promise<void> {
     this.disconnectGateway()
     try {


### PR DESCRIPTION
## Summary
- add a focused /claw/reconnect action for control-plane repair
- move the Agents page onto TanStack Query for OpenClaw status and mutations
- surface control-plane health, recovery state, and explicit retry actions in the UI

## Validation
- bun run typecheck (apps/server)
- bun run typecheck (apps/agent)