### PR TITLE
fix(openclaw): normalize openrouter model slug + stream gateway logs in dev

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
@@ -141,6 +141,13 @@ export class ContainerRuntime {
     )
   }
 
+  tailGatewayLogs(onLine: LogFn): () => void {
+    return this.podman.tailContainerLogs(
+      OPENCLAW_GATEWAY_CONTAINER_NAME,
+      onLine,
+    )
+  }
+
   private async compose(args: string[], onLog?: LogFn): Promise<number> {
     const lines: string[] = []
     const code = await this.podman.runCommand(['compose', ...args], {

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-config.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-config.ts
@@ -65,6 +65,21 @@ function hasBuiltinProvider(providerType?: string): providerType is string {
   return !!providerType && providerType in PROVIDER_ENV_MAP
 }
 
+/**
+ * OpenRouter's public slugs use dots for version numbers
+ * (e.g. `anthropic/claude-haiku-4.5`), but openclaw's model registry expects
+ * dashes (`claude-haiku-4-5`). Passing the dotted form makes openclaw fail
+ * the registry lookup silently and the agent turn completes with zero
+ * payloads. Rewrite dots to dashes for openrouter model ids only.
+ */
+function normalizeBuiltinModelId(
+  providerType: string,
+  modelId: string,
+): string {
+  if (providerType !== 'openrouter') return modelId
+  return modelId.replace(/\./g, '-')
+}
+
 export function deriveOpenClawProviderId(providerInput: {
   providerType?: string
   providerName?: string
@@ -102,10 +117,14 @@ export function resolveProviderConfig(
       providerKeys[PROVIDER_ENV_MAP[input.providerType]] = input.apiKey
     }
 
+    const normalizedModelId = input.modelId
+      ? normalizeBuiltinModelId(input.providerType, input.modelId)
+      : undefined
+
     return {
       providerKeys,
-      model: input.modelId
-        ? `${input.providerType}/${input.modelId}`
+      model: normalizedModelId
+        ? `${input.providerType}/${normalizedModelId}`
         : undefined,
     }
   }
@@ -220,6 +239,10 @@ export function buildBootstrapConfig(
 
   if (provider.models) {
     config.models = provider.models
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    config.logging = { level: 'debug', consoleLevel: 'debug' }
   }
 
   return config

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -116,6 +116,7 @@ export class OpenClawService {
   private lastGatewayError: string | null = null
   private lastRecoveryReason: OpenClawGatewayRecoveryReason | null = null
   private gatewayReconnectPromise: Promise<void> | null = null
+  private stopLogTail: (() => void) | null = null
 
   constructor(browserosServerPort?: number) {
     this.openclawDir = getOpenClawDir()
@@ -174,6 +175,7 @@ export class OpenClawService {
 
     logProgress('Starting OpenClaw gateway...')
     await this.runtime.composeUp(logProgress)
+    this.startGatewayLogTail()
 
     logProgress('Waiting for gateway readiness...')
     const ready = await this.runtime.waitForReady(this.port, READY_TIMEOUT_MS)
@@ -218,9 +220,11 @@ export class OpenClawService {
 
     logProgress('Loading gateway auth token...')
     await this.loadTokenFromEnv()
+    await this.ensureDevLoggingInConfig()
     await this.runtime.ensureReady(logProgress)
     logProgress('Starting OpenClaw gateway...')
     await this.runtime.composeUp(logProgress)
+    this.startGatewayLogTail()
 
     logProgress('Waiting for gateway readiness...')
     const ready = await this.runtime.waitForReady(this.port, READY_TIMEOUT_MS)
@@ -237,6 +241,7 @@ export class OpenClawService {
 
   async stop(): Promise<void> {
     this.disconnectGateway()
+    this.stopGatewayLogTail()
     await this.runtime.composeStop()
     logger.info('OpenClaw container stopped')
   }
@@ -245,10 +250,13 @@ export class OpenClawService {
     const logProgress = this.createProgressLogger(onLog)
 
     this.disconnectGateway()
+    this.stopGatewayLogTail()
     logProgress('Loading gateway auth token...')
     await this.loadTokenFromEnv()
+    await this.ensureDevLoggingInConfig()
     logProgress('Restarting OpenClaw gateway...')
     await this.runtime.composeRestart(logProgress)
+    this.startGatewayLogTail()
 
     logProgress('Waiting for gateway readiness...')
     const ready = await this.runtime.waitForReady(this.port, READY_TIMEOUT_MS)
@@ -287,6 +295,7 @@ export class OpenClawService {
 
   async shutdown(): Promise<void> {
     this.disconnectGateway()
+    this.stopGatewayLogTail()
     try {
       await this.runtime.composeStop()
     } catch {
@@ -795,6 +804,52 @@ export class OpenClawService {
   ): Promise<void> {
     const configPath = join(this.openclawDir, OPENCLAW_CONFIG_FILE)
     await writeFile(configPath, JSON.stringify(config, null, 2))
+  }
+
+  private async ensureDevLoggingInConfig(): Promise<void> {
+    if (process.env.NODE_ENV !== 'development') return
+    const configPath = join(this.openclawDir, OPENCLAW_CONFIG_FILE)
+    if (!existsSync(configPath)) return
+    try {
+      const raw = await readFile(configPath, 'utf-8')
+      const parsed = JSON.parse(raw) as Record<string, unknown>
+      const existing = (parsed.logging ?? {}) as Record<string, unknown>
+      if (existing.level === 'debug' && existing.consoleLevel === 'debug') {
+        return
+      }
+      parsed.logging = { ...existing, level: 'debug', consoleLevel: 'debug' }
+      await writeFile(configPath, JSON.stringify(parsed, null, 2))
+      logger.info('Patched openclaw.json for dev debug logging')
+    } catch (err) {
+      logger.warn('Failed to patch openclaw.json for dev debug logging', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  private startGatewayLogTail(): void {
+    if (process.env.NODE_ENV !== 'development') return
+    if (this.stopLogTail) return
+    try {
+      this.stopLogTail = this.runtime.tailGatewayLogs((line) => {
+        logger.debug(`[openclaw] ${line}`)
+      })
+      logger.info('Streaming OpenClaw gateway logs into server log (dev mode)')
+    } catch (err) {
+      logger.warn('Failed to start OpenClaw gateway log tail', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+
+  private stopGatewayLogTail(): void {
+    if (!this.stopLogTail) return
+    try {
+      this.stopLogTail()
+    } catch {
+      // best effort
+    }
+    this.stopLogTail = null
   }
 
   private getHostWorkspaceDir(agentName: string): string {

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/podman-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/podman-runtime.ts
@@ -163,6 +163,32 @@ export class PodmanRuntime {
   }
 
   /**
+   * Follow container logs. Returns a stop function that terminates the
+   * underlying `podman logs -f` process. Each output line is passed to
+   * onLine as-is.
+   */
+  tailContainerLogs(containerName: string, onLine: LogFn): () => void {
+    const proc = Bun.spawn(
+      [this.podmanPath, 'logs', '-f', '--tail', '0', containerName],
+      { stdout: 'pipe', stderr: 'pipe' },
+    )
+
+    void this.drainStream(proc.stdout ?? null, onLine)
+    void this.drainStream(proc.stderr ?? null, onLine)
+
+    let stopped = false
+    return () => {
+      if (stopped) return
+      stopped = true
+      try {
+        proc.kill()
+      } catch {
+        // process may already be gone
+      }
+    }
+  }
+
+  /**
    * Lists running container names. Used to check whether non-BrowserOS
    * containers are running before stopping the Podman machine.
    */


### PR DESCRIPTION
## Summary

OpenRouter's public model slugs use dots in version numbers (e.g. `anthropic/claude-haiku-4.5`), but openclaw's model registry only recognises the dashed form (`claude-haiku-4-5`). Passing the dotted form makes openclaw's registry lookup miss silently — the embedded agent completes the turn with `stopReason=stop payloads=0` and the UI shows nothing. Users copy-pasting slugs from openrouter.ai would hit this on first run.

- **Fix:** for `providerType: 'openrouter'` only, rewrite dots to dashes in the model portion before building the `openrouter/<...>` string. Other providers (openai, anthropic direct, etc.) are untouched — `openai/gpt-5.4-mini` keeps its dot and works fine today.
- **Dev ergonomics:** make this class of failure visible next time by (a) injecting `logging.level: "debug"` into generated `openclaw.json` in `NODE_ENV=development`, (b) patching an already-provisioned config on start/restart, and (c) tailing the gateway container's logs through the browseros server logger so they appear in the same dev stream.

## Repro (before this PR)

1. Run setup with provider OpenRouter, model `anthropic/claude-haiku-4.5` (the slug shown on openrouter.ai).
2. Send any message. UI sits silent. Container logs: `[agent/embedded] incomplete turn detected: stopReason=stop payloads=0`.

With this PR the model string written to `openclaw.json` becomes `openrouter/anthropic/claude-haiku-4-5`, the registry resolves it, and chat completions stream normally.

## Files touched

- `openclaw-config.ts` — `normalizeBuiltinModelId` + dev logging injection.
- `openclaw-service.ts` — `ensureDevLoggingInConfig`, `startGatewayLogTail`, `stopGatewayLogTail`; wired into setup/start/restart/stop/shutdown.
- `container-runtime.ts` — `tailGatewayLogs` wrapper.
- `podman-runtime.ts` — `tailContainerLogs(name, onLine)` helper.

## Test plan

- [ ] Fresh setup (delete `~/.browseros/openclaw/`) with OpenRouter + `anthropic/claude-haiku-4.5` → inspect generated `openclaw.json`, confirm primary is `openrouter/anthropic/claude-haiku-4-5`, confirm chat returns a real response from the UI.
- [ ] Existing user (has `openclaw.json` already) on `bun run start` → `logging.level: "debug"` is added on next start.
- [ ] In dev mode, `bun run start` output interleaves `[openclaw] …` lines from the container.
- [ ] In production build, dev logging + log tail are no-ops (both gated on `NODE_ENV === 'development'`).
- [ ] OpenAI flow (`openai/gpt-5.4-mini`) still produces the same model string — confirm `gpt-5.4-mini` kept its dot.