### PR TITLE
test(server): reap orphaned test browsers before spawn

### DIFF
--- a/packages/browseros-agent/apps/server/tests/__helpers__/browser.ts
+++ b/packages/browseros-agent/apps/server/tests/__helpers__/browser.ts
@@ -6,8 +6,10 @@
  * Use setup.ts:ensureBrowserOS() for the full test environment.
  */
 import type { ChildProcess } from 'node:child_process'
-import { spawn } from 'node:child_process'
+import { spawn, spawnSync } from 'node:child_process'
 import { rmSync } from 'node:fs'
+
+const TEST_USER_DATA_PREFIX = 'browseros-test-'
 
 export interface BrowserConfig {
   cdpPort: number
@@ -58,6 +60,16 @@ export function getBrowserState(): BrowserState | null {
   return browserState
 }
 
+function killOrphanedTestBrowsers(): void {
+  // Matches only BrowserOS processes launched with a test user-data-dir
+  // (e.g., /var/folders/.../browseros-test-XXXX). Never matches a dev
+  // BrowserOS run from ~/Library/Application Support/BrowserOS.
+  const result = spawnSync('pkill', ['-9', '-f', TEST_USER_DATA_PREFIX])
+  if (result.status === 0) {
+    console.log('Killed orphaned test browsers from a previous run')
+  }
+}
+
 export async function spawnBrowser(
   config: BrowserConfig,
 ): Promise<BrowserState> {
@@ -72,6 +84,8 @@ export async function spawnBrowser(
     console.log('Config changed, cleaning up existing browser...')
     await killBrowser()
   }
+
+  killOrphanedTestBrowsers()
 
   console.log(`Starting BrowserOS on CDP port ${config.cdpPort}...`)
   const browserProcess = spawn(

--- a/packages/browseros-agent/apps/server/tests/__helpers__/cleanup.sh
+++ b/packages/browseros-agent/apps/server/tests/__helpers__/cleanup.sh
@@ -20,6 +20,14 @@ for port in $CDP_PORT $SERVER_PORT $EXTENSION_PORT; do
   fi
 done
 
+# Kill orphaned test browser processes (matches only BrowserOS launched with
+# a test user-data-dir — never the user's dev BrowserOS)
+orphan_pids=$(pgrep -f 'browseros-test-' 2>/dev/null || true)
+if [ -n "$orphan_pids" ]; then
+  echo "  Killing orphaned test browser processes: $(echo "$orphan_pids" | tr '\n' ' ')"
+  echo "$orphan_pids" | xargs kill -9 2>/dev/null || true
+fi
+
 # Clean up orphaned temp directories (created by browser.ts)
 # Uses $TMPDIR which matches Node's os.tmpdir()
 TEMP_DIR="${TMPDIR:-/tmp}"


### PR DESCRIPTION
## Summary
- Pre-kill any BrowserOS process whose `--user-data-dir` path contains the `browseros-test-` prefix before each `spawnBrowser`, and during the `test:cleanup` hook.
- The pattern is scoped tightly: it never matches a developer's regular BrowserOS (its user-data-dir is `~/Library/Application Support/BrowserOS`).

## Why
`BROWSEROS_TEST_HEADLESS=true` + `--headless=new` already work correctly — verified via direct `spawn` of `/Applications/BrowserOS.app/Contents/MacOS/BrowserOS` reporting `HeadlessChrome/146.0.0.0` in its user-agent. But orphaned test browsers from a crashed prior run could linger on a stale CDP port and cause flaky startup for the next run. This reap closes that gap.

## Test plan
- [ ] `bun run --filter @browseros/server test:tools` with `BROWSEROS_TEST_HEADLESS=true` in `apps/server/.env.development`; confirm no visible window from the test-spawned browser.
- [ ] Open your normal BrowserOS (regular profile) during the test run; confirm it is not killed.
- [ ] Kill a test mid-run (leaving a `browseros-test-*` browser alive), re-run; confirm `test:cleanup` reaps the orphan.