### PR TITLE
feat: bundle Podman runtime for BrowserOS server

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/podman-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/podman-runtime.ts
@@ -8,9 +8,32 @@
  * On Linux, machine operations are no-ops since Podman runs natively.
  */
 
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+
 const isLinux = process.platform === 'linux'
+const PODMAN_BUNDLE_PATH = ['bin', 'third_party', 'podman'] as const
 
 export type LogFn = (msg: string) => void
+
+function getPodmanBinaryName(platform: NodeJS.Platform): string {
+  return platform === 'win32' ? 'podman.exe' : 'podman'
+}
+
+export function resolveBundledPodmanPath(
+  resourcesDir?: string,
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  if (!resourcesDir) return null
+
+  const bundledPath = join(
+    resourcesDir,
+    ...PODMAN_BUNDLE_PATH,
+    getPodmanBinaryName(platform),
+  )
+
+  return existsSync(bundledPath) ? bundledPath : null
+}
 
 export class PodmanRuntime {
   private podmanPath: string
@@ -242,6 +265,19 @@ export class PodmanRuntime {
 }
 
 let runtime: PodmanRuntime | null = null
+
+export function configurePodmanRuntime(config: {
+  resourcesDir?: string
+  podmanPath?: string
+}): PodmanRuntime {
+  const podmanPath =
+    config.podmanPath ??
+    resolveBundledPodmanPath(config.resourcesDir) ??
+    'podman'
+
+  runtime = new PodmanRuntime({ podmanPath })
+  return runtime
+}
 
 export function getPodmanRuntime(): PodmanRuntime {
   if (!runtime) runtime = new PodmanRuntime()

--- a/packages/browseros-agent/apps/server/src/main.ts
+++ b/packages/browseros-agent/apps/server/src/main.ts
@@ -14,6 +14,7 @@ import path from 'node:path'
 import { EXIT_CODES } from '@browseros/shared/constants/exit-codes'
 import { createHttpServer } from './api/server'
 import { getOpenClawService } from './api/services/openclaw/openclaw-service'
+import { configurePodmanRuntime } from './api/services/openclaw/podman-runtime'
 import { CdpBackend } from './browser/backends/cdp'
 import { Browser } from './browser/browser'
 import type { ServerConfig } from './config'
@@ -55,6 +56,7 @@ export class Application {
       resourcesDir: path.resolve(this.config.resourcesDir),
     })
 
+    configurePodmanRuntime({ resourcesDir: this.config.resourcesDir })
     await this.initCoreServices()
 
     if (!this.config.cdpPort) {

--- a/packages/browseros-agent/apps/server/src/main.ts
+++ b/packages/browseros-agent/apps/server/src/main.ts
@@ -56,7 +56,9 @@ export class Application {
       resourcesDir: path.resolve(this.config.resourcesDir),
     })
 
-    configurePodmanRuntime({ resourcesDir: this.config.resourcesDir })
+    configurePodmanRuntime({
+      resourcesDir: path.resolve(this.config.resourcesDir),
+    })
     await this.initCoreServices()
 
     if (!this.config.cdpPort) {

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/podman-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/podman-runtime.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import {
+  configurePodmanRuntime,
+  getPodmanRuntime,
+  resolveBundledPodmanPath,
+} from '../../../../src/api/services/openclaw/podman-runtime'
+
+describe('podman runtime', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'browseros-podman-test-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+    configurePodmanRuntime({ podmanPath: 'podman' })
+  })
+
+  it('returns the bundled podman path when the executable exists', () => {
+    const bundledPath = path.join(
+      tempDir,
+      'bin',
+      'third_party',
+      'podman',
+      'podman',
+    )
+    fs.mkdirSync(path.dirname(bundledPath), { recursive: true })
+    fs.writeFileSync(bundledPath, 'podman')
+
+    expect(resolveBundledPodmanPath(tempDir, 'darwin')).toBe(bundledPath)
+  })
+
+  it('uses the windows executable name for bundled podman', () => {
+    const bundledPath = path.join(
+      tempDir,
+      'bin',
+      'third_party',
+      'podman',
+      'podman.exe',
+    )
+    fs.mkdirSync(path.dirname(bundledPath), { recursive: true })
+    fs.writeFileSync(bundledPath, 'podman')
+
+    expect(resolveBundledPodmanPath(tempDir, 'win32')).toBe(bundledPath)
+  })
+
+  it('returns null when no bundled podman executable exists', () => {
+    expect(resolveBundledPodmanPath(tempDir, 'darwin')).toBeNull()
+  })
+
+  it('configures the runtime to prefer the bundled podman path', () => {
+    const bundledPath = path.join(
+      tempDir,
+      'bin',
+      'third_party',
+      'podman',
+      'podman',
+    )
+    fs.mkdirSync(path.dirname(bundledPath), { recursive: true })
+    fs.writeFileSync(bundledPath, 'podman')
+
+    const runtime = configurePodmanRuntime({ resourcesDir: tempDir })
+
+    expect(runtime.getPodmanPath()).toBe(bundledPath)
+    expect(getPodmanRuntime().getPodmanPath()).toBe(bundledPath)
+  })
+
+  it('falls back to PATH podman when no bundled executable is present', () => {
+    const runtime = configurePodmanRuntime({ resourcesDir: tempDir })
+
+    expect(runtime.getPodmanPath()).toBe('podman')
+  })
+})

--- a/packages/browseros-agent/scripts/build/config/server-prod-resources.json
+++ b/packages/browseros-agent/scripts/build/config/server-prod-resources.json
@@ -55,6 +55,135 @@
       "arch": ["x64"]
     },
     {
+      "name": "Podman CLI - macOS ARM64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/podman/podman-darwin-arm64"
+      },
+      "destination": "resources/bin/third_party/podman/podman",
+      "os": ["macos"],
+      "arch": ["arm64"],
+      "executable": true
+    },
+    {
+      "name": "Podman gvproxy - macOS ARM64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/podman/gvproxy-darwin-arm64"
+      },
+      "destination": "resources/bin/third_party/podman/gvproxy",
+      "os": ["macos"],
+      "arch": ["arm64"],
+      "executable": true
+    },
+    {
+      "name": "Podman vfkit - macOS ARM64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/podman/vfkit-darwin-arm64"
+      },
+      "destination": "resources/bin/third_party/podman/vfkit",
+      "os": ["macos"],
+      "arch": ["arm64"],
+      "executable": true
+    },
+    {
+      "name": "Podman krunkit - macOS ARM64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/podman/krunkit-darwin-arm64"
+      },
+      "destination": "resources/bin/third_party/podman/krunkit",
+      "os": ["macos"],
+      "arch": ["arm64"],
+      "executable": true
+    },
+    {
+      "name": "Podman mac helper - macOS ARM64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/podman/podman-mac-helper-darwin-arm64"
+      },
+      "destination": "resources/bin/third_party/podman/podman-mac-helper",
+      "os": ["macos"],
+      "arch": ["arm64"],
+      "executable": true
+    },
+    {
+      "name": "Podman CLI - macOS x64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/podman/podman-darwin-x64"
+      },
+      "destination": "resources/bin/third_party/podman/podman",
+      "os": ["macos"],
+      "arch": ["x64"],
+      "executable": true
+    },
+    {
+      "name": "Podman gvproxy - macOS x64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/podman/gvproxy-darwin-x64"
+      },
+      "destination": "resources/bin/third_party/podman/gvproxy",
+      "os": ["macos"],
+      "arch": ["x64"],
+      "executable": true
+    },
+    {
+      "name": "Podman vfkit - macOS x64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/podman/vfkit-darwin-x64"
+      },
+      "destination": "resources/bin/third_party/podman/vfkit",
+      "os": ["macos"],
+      "arch": ["x64"],
+      "executable": true
+    },
+    {
+      "name": "Podman mac helper - macOS x64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/podman/podman-mac-helper-darwin-x64"
+      },
+      "destination": "resources/bin/third_party/podman/podman-mac-helper",
+      "os": ["macos"],
+      "arch": ["x64"],
+      "executable": true
+    },
+    {
+      "name": "Podman CLI - Windows x64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/podman/podman-windows-x64.exe"
+      },
+      "destination": "resources/bin/third_party/podman/podman.exe",
+      "os": ["windows"],
+      "arch": ["x64"]
+    },
+    {
+      "name": "Podman gvproxy - Windows x64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/podman/gvproxy-windows-x64.exe"
+      },
+      "destination": "resources/bin/third_party/podman/gvproxy.exe",
+      "os": ["windows"],
+      "arch": ["x64"]
+    },
+    {
+      "name": "Podman win-sshproxy - Windows x64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/podman/win-sshproxy-windows-x64.exe"
+      },
+      "destination": "resources/bin/third_party/podman/win-sshproxy.exe",
+      "os": ["windows"],
+      "arch": ["x64"]
+    },
+    {
       "name": "ripgrep - macOS ARM64",
       "source": {
         "type": "r2",

--- a/packages/browseros-agent/scripts/build/config/server-prod-resources.json
+++ b/packages/browseros-agent/scripts/build/config/server-prod-resources.json
@@ -111,6 +111,7 @@
     },
     {
       "name": "Podman CLI - macOS x64",
+      "notes": "krunkit is intentionally omitted on macOS x64 because the official amd64 Podman installer ships an arm64-only krunkit helper",
       "source": {
         "type": "r2",
         "key": "third_party/podman/podman-darwin-x64"

--- a/packages/browseros/build/modules/sign/macos.py
+++ b/packages/browseros/build/modules/sign/macos.py
@@ -29,15 +29,32 @@ BROWSEROS_SERVER_BINARIES: Dict[str, Dict[str, str]] = {
         "options": "runtime",
         "entitlements": "browseros-executable-entitlements.plist",
     },
-    "codex": {
-        "identifier_suffix": "codex",
-        "options": "runtime",
-        "entitlements": "browseros-executable-entitlements.plist",
-    },
     "bun": {
         "identifier_suffix": "bun",
         "options": "runtime",
         "entitlements": "browseros-executable-entitlements.plist",
+    },
+    "podman": {
+        "identifier_suffix": "podman",
+        "options": "runtime",
+    },
+    "gvproxy": {
+        "identifier_suffix": "gvproxy",
+        "options": "runtime",
+    },
+    "vfkit": {
+        "identifier_suffix": "vfkit",
+        "options": "runtime",
+        "entitlements": "podman-vfkit-entitlements.plist",
+    },
+    "krunkit": {
+        "identifier_suffix": "krunkit",
+        "options": "runtime",
+        "entitlements": "podman-krunkit-entitlements.plist",
+    },
+    "podman-mac-helper": {
+        "identifier_suffix": "podman_mac_helper",
+        "options": "runtime",
     },
 }
 

--- a/packages/browseros/build/modules/sign/windows.py
+++ b/packages/browseros/build/modules/sign/windows.py
@@ -18,8 +18,11 @@ from ...common.utils import (
 
 BROWSEROS_SERVER_BINARIES: List[str] = [
     "browseros_server.exe",
-    "codex.exe",
-    "bun.exe",
+    "third_party/bun.exe",
+    "third_party/rg.exe",
+    "third_party/podman/podman.exe",
+    "third_party/podman/gvproxy.exe",
+    "third_party/podman/win-sshproxy.exe",
 ]
 
 
@@ -102,7 +105,7 @@ class WindowsSignModule(CommandModule):
 def get_browseros_server_binary_paths(build_output_dir: Path) -> List[Path]:
     """Return absolute paths to BrowserOS Server binaries for signing."""
     server_dir = build_output_dir / "BrowserOSServer" / "default" / "resources" / "bin"
-    return [server_dir / binary for binary in BROWSEROS_SERVER_BINARIES]
+    return [server_dir / Path(binary) for binary in BROWSEROS_SERVER_BINARIES]
 
 
 def build_mini_installer(ctx: Context) -> bool:

--- a/packages/browseros/build/modules/storage/download_test.py
+++ b/packages/browseros/build/modules/storage/download_test.py
@@ -22,6 +22,8 @@ class ExtractArtifactZipTest(unittest.TestCase):
             "resources/bin/browseros_server": b"server-binary",
             "resources/bin/third_party/bun": b"bun-binary",
             "resources/bin/third_party/rg": b"rg-binary",
+            "resources/bin/third_party/podman/podman": b"podman-binary",
+            "resources/bin/third_party/podman/gvproxy": b"gvproxy-binary",
         }
 
         with tempfile.TemporaryDirectory() as temp_dir:

--- a/packages/browseros/resources/entitlements/podman-krunkit-entitlements.plist
+++ b/packages/browseros/resources/entitlements/podman-krunkit-entitlements.plist
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.hypervisor</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validationr</key>
+  <true/>
+</dict>
+</plist>

--- a/packages/browseros/resources/entitlements/podman-krunkit-entitlements.plist
+++ b/packages/browseros/resources/entitlements/podman-krunkit-entitlements.plist
@@ -4,7 +4,7 @@
 <dict>
   <key>com.apple.security.hypervisor</key>
   <true/>
-  <key>com.apple.security.cs.disable-library-validationr</key>
+  <key>com.apple.security.cs.disable-library-validation</key>
   <true/>
 </dict>
 </plist>

--- a/packages/browseros/resources/entitlements/podman-vfkit-entitlements.plist
+++ b/packages/browseros/resources/entitlements/podman-vfkit-entitlements.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.network.client</key>
+  <true/>
+  <key>com.apple.security.network.server</key>
+  <true/>
+  <key>com.apple.security.virtualization</key>
+  <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- bundle Podman client/helper binaries into BrowserOS Server resource artifacts for macOS and Windows, and resolve the runtime path relative to BrowserOS resources in production
- sign the bundled Podman executables during BrowserOS packaging, remove obsolete `codex` signing, and fix Windows signing paths for nested third-party executables
- keep Linux on system `podman` fallback for now because the latest official GitHub Podman release on April 14, 2026 (`v5.8.2`) only publishes a remote Linux client, not a local runtime bundle

## Design
This reuses the existing BrowserOS Server resource artifact pipeline instead of inventing a new installer flow. The server build manifest now pulls Podman payloads from R2 into `resources/bin/third_party/podman`, `PodmanRuntime` prefers the bundled executable under `resourcesDir`, and packaging signs the new executables as part of the normal BrowserOS bundle. macOS uses binaries extracted from the official Podman installer payload because the remote zip is incomplete for `podman machine` support.

## Test plan
- `bun test ./tests/api/services/openclaw/podman-runtime.test.ts ./tests/api/routes/terminal-protocol.test.ts`
- `bun run --filter @browseros/server typecheck`
- `PYTHONPATH=packages/browseros python3 -m unittest build.modules.storage.download_test`
- `python3 -m py_compile packages/browseros/build/modules/sign/macos.py packages/browseros/build/modules/sign/windows.py packages/browseros/build/modules/storage/download_test.py`
- `bunx biome check apps/server/src/api/services/openclaw/podman-runtime.ts apps/server/src/main.ts apps/server/tests/api/services/openclaw/podman-runtime.test.ts scripts/build/config/server-prod-resources.json`
