### PR TITLE
test: mock BrowserOS LLM in chat integration

### DIFF
--- a/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
+++ b/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
@@ -9,6 +9,10 @@ import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
 import { createOpenRouter } from '@openrouter/ai-sdk-provider'
 import type { LanguageModel } from 'ai'
 import { createBrowserOSFetch } from '../lib/browseros-fetch'
+import {
+  createMockBrowserOSLanguageModel,
+  shouldUseMockBrowserOSLLM,
+} from '../lib/clients/llm/mock-language-model'
 import { createCodexFetch } from '../lib/clients/oauth/codex-fetch'
 import { createCopilotFetch } from '../lib/clients/oauth/copilot-fetch'
 import { logger } from '../lib/logger'
@@ -219,6 +223,9 @@ const PROVIDER_FACTORIES: Record<string, ProviderFactory> = {
 export function createLanguageModel(
   config: ResolvedAgentConfig,
 ): LanguageModel {
+  if (shouldUseMockBrowserOSLLM(config)) {
+    return createMockBrowserOSLanguageModel()
+  }
   const provider = config.provider as string
   const factory = PROVIDER_FACTORIES[provider]
   if (!factory) throw new Error(`Unknown provider: ${provider}`)

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/config.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/config.ts
@@ -11,6 +11,10 @@ import { INLINED_ENV } from '../../../env'
 import { logger } from '../../logger'
 import { fetchBrowserOSConfig, getLLMConfigFromProvider } from '../gateway'
 import { getOAuthTokenManager } from '../oauth'
+import {
+  resolveMockBrowserOSConfig,
+  shouldUseMockBrowserOSLLM,
+} from './mock-language-model'
 import type { ResolvedLLMConfig } from './types'
 
 export async function resolveLLMConfig(
@@ -49,6 +53,9 @@ export async function resolveLLMConfig(
 
   // BrowserOS gateway: fetch config from remote service
   if (config.provider === LLM_PROVIDERS.BROWSEROS) {
+    if (shouldUseMockBrowserOSLLM(config)) {
+      return resolveMockBrowserOSConfig(config, browserosId)
+    }
     return resolveBrowserOSConfig(config, browserosId)
   }
 

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/mock-language-model.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/mock-language-model.ts
@@ -1,0 +1,83 @@
+import type {
+  LanguageModelV3GenerateResult,
+  LanguageModelV3StreamPart,
+  LanguageModelV3Usage,
+} from '@ai-sdk/provider'
+import { LLM_PROVIDERS, type LLMConfig } from '@browseros/shared/schemas/llm'
+import { type LanguageModel, simulateReadableStream } from 'ai'
+import { MockLanguageModelV3 } from 'ai/test'
+import type { ResolvedLLMConfig } from './types'
+
+export const MOCK_BROWSEROS_MODEL_ID = 'browseros-test-mock'
+export const MOCK_BROWSEROS_RESPONSE_TEXT = 'Mock BrowserOS test response.'
+
+const MOCK_USAGE: LanguageModelV3Usage = {
+  inputTokens: {
+    total: 1,
+    noCache: 1,
+    cacheRead: undefined,
+    cacheWrite: undefined,
+  },
+  outputTokens: {
+    total: 4,
+    text: 4,
+    reasoning: undefined,
+  },
+}
+
+function createMockResult(): LanguageModelV3GenerateResult {
+  return {
+    content: [{ type: 'text', text: MOCK_BROWSEROS_RESPONSE_TEXT }],
+    finishReason: { unified: 'stop', raw: 'stop' },
+    usage: MOCK_USAGE,
+    warnings: [],
+  }
+}
+
+export function isMockBrowserOSLLMEnabled(): boolean {
+  return process.env.BROWSEROS_USE_MOCK_LLM === 'true'
+}
+
+export function shouldUseMockBrowserOSLLM(
+  config: Pick<LLMConfig, 'provider'>,
+): boolean {
+  return (
+    config.provider === LLM_PROVIDERS.BROWSEROS && isMockBrowserOSLLMEnabled()
+  )
+}
+
+export function resolveMockBrowserOSConfig(
+  config: LLMConfig,
+  browserosId?: string,
+): ResolvedLLMConfig {
+  return {
+    ...config,
+    model: config.model ?? MOCK_BROWSEROS_MODEL_ID,
+    browserosId,
+    upstreamProvider: LLM_PROVIDERS.OPENAI,
+  }
+}
+
+export function createMockBrowserOSLanguageModel(): LanguageModel {
+  const chunks: LanguageModelV3StreamPart[] = [
+    { type: 'text-start', id: 'text-1' },
+    {
+      type: 'text-delta',
+      id: 'text-1',
+      delta: MOCK_BROWSEROS_RESPONSE_TEXT,
+    },
+    { type: 'text-end', id: 'text-1' },
+    {
+      type: 'finish',
+      finishReason: { unified: 'stop', raw: 'stop' },
+      usage: MOCK_USAGE,
+    },
+  ]
+
+  return new MockLanguageModelV3({
+    doGenerate: async () => createMockResult(),
+    doStream: async () => ({
+      stream: simulateReadableStream({ chunks }),
+    }),
+  }) as LanguageModel
+}

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/provider.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/provider.ts
@@ -21,6 +21,10 @@ import { logger } from '../../logger'
 import { createOpenRouterCompatibleFetch } from '../../openrouter-fetch'
 import { createCodexFetch } from '../oauth/codex-fetch'
 import { createCopilotFetch } from '../oauth/copilot-fetch'
+import {
+  createMockBrowserOSLanguageModel,
+  shouldUseMockBrowserOSLLM,
+} from './mock-language-model'
 import type { ResolvedLLMConfig } from './types'
 
 type ProviderFactory = (config: ResolvedLLMConfig) => LanguageModel
@@ -195,6 +199,9 @@ const PROVIDER_FACTORIES: Record<string, ProviderFactory> = {
 }
 
 export function createLLMProvider(config: ResolvedLLMConfig): LanguageModel {
+  if (shouldUseMockBrowserOSLLM(config)) {
+    return createMockBrowserOSLanguageModel()
+  }
   const factory = PROVIDER_FACTORIES[config.provider]
   if (!factory) throw new Error(`Unknown provider: ${config.provider}`)
   return factory(config)

--- a/packages/browseros-agent/apps/server/tests/__helpers__/server.ts
+++ b/packages/browseros-agent/apps/server/tests/__helpers__/server.ts
@@ -79,7 +79,11 @@ export async function spawnServer(config: ServerConfig): Promise<ServerState> {
     ],
     {
       stdio: ['ignore', 'pipe', 'pipe'],
-      env: { ...globalThis.process.env, NODE_ENV: 'test' },
+      env: {
+        ...globalThis.process.env,
+        NODE_ENV: 'test',
+        BROWSEROS_USE_MOCK_LLM: 'true',
+      },
     },
   )
 

--- a/packages/browseros-agent/apps/server/tests/server.integration.test.ts
+++ b/packages/browseros-agent/apps/server/tests/server.integration.test.ts
@@ -12,6 +12,7 @@ import { URL } from 'node:url'
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 
+import { MOCK_BROWSEROS_RESPONSE_TEXT } from '../src/lib/clients/llm/mock-language-model'
 import {
   cleanupBrowserOS,
   ensureBrowserOS,
@@ -155,7 +156,7 @@ describe('HTTP Server Integration Tests', () => {
 
   describe('Chat endpoint', () => {
     it(
-      'streams a chat response with BrowserOS provider',
+      'streams a mocked chat response for BrowserOS provider requests in test mode',
       async () => {
         const conversationId = crypto.randomUUID()
 
@@ -205,6 +206,10 @@ describe('HTTP Server Integration Tests', () => {
         assert.ok(
           fullResponse.includes('data:'),
           'Should contain SSE data events',
+        )
+        assert.ok(
+          fullResponse.includes(MOCK_BROWSEROS_RESPONSE_TEXT),
+          'Should include the mocked BrowserOS chat response',
         )
 
         const deleteResponse = await fetch(


### PR DESCRIPTION
## Summary
- replace the live BrowserOS `/chat` integration LLM path with a test-only AI SDK mock model
- keep the `/chat` request contract as `provider: browseros` while avoiding remote BrowserOS config fetches in the test server
- assert the mocked SSE response text in the integration suite

## Rework
The prior integration test exercised the real HTTP route but still depended on the live BrowserOS LLM resolution path. This rework keeps the route and session lifecycle real while switching the dedicated test server environment to a deterministic `MockLanguageModelV3`.

## Test plan
- `bun run test`
- `bun run --filter @browseros/server typecheck`
- `bunx biome check apps/server/src/lib/clients/llm/mock-language-model.ts apps/server/src/lib/clients/llm/config.ts apps/server/src/lib/clients/llm/provider.ts apps/server/src/agent/provider-factory.ts apps/server/tests/__helpers__/server.ts apps/server/tests/server.integration.test.ts`