### PR TITLE
fix: add null guard in getYahooIndiaSuggestions to prevent TypeError

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/newtab/index/lib/searchSuggestions/getSearchSuggestions.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/newtab/index/lib/searchSuggestions/getSearchSuggestions.ts
@@ -25,7 +25,7 @@ const getYahooIndiaSuggestions = async (query: string): Promise<string[]> => {
     `https://in.search.yahoo.com/sugg/gossip/gossip-in-loc/?command=${encodeURIComponent(query)}&output=json`,
   )
   const data = await response.json()
-  return data.gossip.results.map((item: YahooSuggestionItem) => item.key) || []
+  return data?.gossip?.results?.map((item: YahooSuggestionItem) => item.key) ?? []
 }
 
 const getDuckDuckGoSuggestions = async (query: string): Promise<string[]> => {


### PR DESCRIPTION
Closes #722

## Problem

In `getSearchSuggestions.ts`, the `getYahooIndiaSuggestions` function accesses `data.gossip.results` without any null/undefined guard:

```ts
return data.gossip.results.map((item: YahooSuggestionItem) => item.key) || []
```

If the Yahoo API returns an unexpected response shape (e.g. `data.gossip` is `null` or `undefined`), this throws an uncaught `TypeError` that can break the search suggestions UI entirely. Every other provider safely uses `data[1] || []`, but Yahoo lacks this protection.

## Fix

Use optional chaining and nullish coalescing, consistent with how other providers handle missing data:

```ts
return data?.gossip?.results?.map((item: YahooSuggestionItem) => item.key) ?? []
```

This ensures an empty array is safely returned when the API response is missing or malformed.