### PR TITLE
feat(ota): bundle full server resources tree in Sparkle payload

### DIFF
--- a/packages/browseros-agent/apps/server/package.json
+++ b/packages/browseros-agent/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browseros/server",
-  "version": "0.0.85",
+  "version": "0.0.87",
   "description": "BrowserOS server",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -156,7 +156,7 @@
     },
     "apps/server": {
       "name": "@browseros/server",
-      "version": "0.0.85",
+      "version": "0.0.87",
       "bin": {
         "browseros-server": "./src/index.ts",
       },

--- a/packages/browseros/build/common/server_binaries.py
+++ b/packages/browseros/build/common/server_binaries.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Shared sign metadata for BrowserOS Server binaries.
+
+Consumed by both the Chromium-build signing path (build/modules/sign/) and the
+OTA release path (build/modules/ota/). Adding a new third-party binary here
+means both paths pick it up automatically.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class SignSpec:
+    """Per-binary codesign metadata.
+
+    ``entitlements`` is the filename of the plist under
+    ``resources/entitlements/``; ``None`` means no extra entitlements.
+    """
+
+    identifier_suffix: str
+    options: str
+    entitlements: Optional[str] = None
+
+
+MACOS_SERVER_BINARIES: Dict[str, SignSpec] = {
+    "browseros_server": SignSpec(
+        "browseros_server", "runtime", "browseros-executable-entitlements.plist"
+    ),
+    "bun": SignSpec("bun", "runtime", "browseros-executable-entitlements.plist"),
+    "rg": SignSpec("rg", "runtime"),
+    "podman": SignSpec("podman", "runtime"),
+    "gvproxy": SignSpec("gvproxy", "runtime"),
+    "vfkit": SignSpec("vfkit", "runtime", "podman-vfkit-entitlements.plist"),
+    "krunkit": SignSpec("krunkit", "runtime", "podman-krunkit-entitlements.plist"),
+    "podman-mac-helper": SignSpec("podman_mac_helper", "runtime"),
+}
+
+
+WINDOWS_SERVER_BINARIES: List[str] = [
+    "browseros_server.exe",
+    "third_party/bun.exe",
+    "third_party/rg.exe",
+    "third_party/podman/podman.exe",
+    "third_party/podman/gvproxy.exe",
+    "third_party/podman/win-sshproxy.exe",
+]
+
+
+def macos_sign_spec_for(binary_path: Path) -> Optional[SignSpec]:
+    """Look up sign metadata by file stem (e.g., ``podman-mac-helper``)."""
+    return MACOS_SERVER_BINARIES.get(binary_path.stem)
+
+
+def expected_windows_binary_paths(server_bin_dir: Path) -> List[Path]:
+    """Resolve the Windows relative-path list against a ``resources/bin`` dir."""
+    return [server_bin_dir / rel for rel in WINDOWS_SERVER_BINARIES]

--- a/packages/browseros/build/common/server_binaries_test.py
+++ b/packages/browseros/build/common/server_binaries_test.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""Tests for the shared server-binary sign table."""
+
+import unittest
+from pathlib import Path
+
+from .server_binaries import (
+    MACOS_SERVER_BINARIES,
+    WINDOWS_SERVER_BINARIES,
+    expected_windows_binary_paths,
+    macos_sign_spec_for,
+)
+
+ENTITLEMENTS_DIR = Path(__file__).resolve().parents[2] / "resources" / "entitlements"
+
+
+class MacosServerBinariesTest(unittest.TestCase):
+    def test_every_entry_has_identifier_and_options(self):
+        for stem, spec in MACOS_SERVER_BINARIES.items():
+            self.assertTrue(spec.identifier_suffix, f"{stem} missing identifier_suffix")
+            self.assertTrue(spec.options, f"{stem} missing options")
+
+    def test_every_entitlements_plist_exists_on_disk(self):
+        for stem, spec in MACOS_SERVER_BINARIES.items():
+            if spec.entitlements is None:
+                continue
+            plist = ENTITLEMENTS_DIR / spec.entitlements
+            self.assertTrue(plist.exists(), f"{stem}: entitlements {plist} missing")
+
+    def test_macos_sign_spec_for_resolves_by_stem(self):
+        spec = macos_sign_spec_for(Path("/x/podman-mac-helper"))
+        assert spec is not None
+        self.assertEqual(spec.identifier_suffix, "podman_mac_helper")
+        self.assertIsNone(macos_sign_spec_for(Path("/x/not_a_known_binary")))
+
+    def test_matches_podman_bundle_layout(self):
+        required = {"podman", "gvproxy", "vfkit", "krunkit", "podman-mac-helper"}
+        self.assertTrue(required.issubset(MACOS_SERVER_BINARIES.keys()))
+
+
+class WindowsServerBinariesTest(unittest.TestCase):
+    def test_no_duplicates(self):
+        self.assertEqual(
+            len(WINDOWS_SERVER_BINARIES), len(set(WINDOWS_SERVER_BINARIES))
+        )
+
+    def test_paths_within_expected_layout(self):
+        for rel in WINDOWS_SERVER_BINARIES:
+            self.assertTrue(
+                rel == "browseros_server.exe" or rel.startswith("third_party/"),
+                f"{rel} outside expected layout",
+            )
+
+    def test_expected_windows_binary_paths_joins_root(self):
+        root = Path("/tmp/fake/resources/bin")
+        resolved = expected_windows_binary_paths(root)
+        self.assertEqual(len(resolved), len(WINDOWS_SERVER_BINARIES))
+        for rel, abs_path in zip(WINDOWS_SERVER_BINARIES, resolved):
+            self.assertEqual(abs_path, root / rel)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/config/appcast/appcast-server.alpha.xml
+++ b/packages/browseros/build/config/appcast/appcast-server.alpha.xml
@@ -7,52 +7,16 @@
     <language>en</language>
 
     <item>
-      <sparkle:version>0.0.74</sparkle:version>
-      <pubDate>Thu, 12 Mar 2026 21:20:48 +0000</pubDate>
+      <sparkle:version>0.0.86</sparkle:version>
+      <pubDate>Thu, 16 Apr 2026 18:58:59 +0000</pubDate>
 
       <!-- macOS arm64 -->
       <enclosure
-        url="https://cdn.browseros.com/server/browseros_server_0.0.74_darwin_arm64.zip"
+        url="https://cdn.browseros.com/server/browseros_server_0.0.86_darwin_arm64.zip"
         sparkle:os="macos"
         sparkle:arch="arm64"
-        sparkle:edSignature="aPuQG3dtQj5v857CNSZ+Ahz3bxUOM7+tSEskW0mIbJV6969a3j1kAqOQ20D1FcxlEyYqquFOaeHpoGaDi6LsDg=="
-        length="22191352"
-        type="application/zip"/>
-
-      <!-- macOS x86_64 -->
-      <enclosure
-        url="https://cdn.browseros.com/server/browseros_server_0.0.74_darwin_x64.zip"
-        sparkle:os="macos"
-        sparkle:arch="x86_64"
-        sparkle:edSignature="X+FCQFH2HpBG43UiJjE0FkheyfOAUW2dhtmKn9HKRrJkqMGsaw+bhjdze1lP02oz71b8Q9AkC2NYwSUN0m0FAQ=="
-        length="24641802"
-        type="application/zip"/>
-
-      <!-- Linux arm64 -->
-      <enclosure
-        url="https://cdn.browseros.com/server/browseros_server_0.0.74_linux_arm64.zip"
-        sparkle:os="linux"
-        sparkle:arch="arm64"
-        sparkle:edSignature="1tnET+iFDYEc9kdwV9U3mo4rExX0JBnlJOrcEQOGBwR/478NxbOsPx3AI/H7216HlylayNj7bYLVJY/FJqY2Dg=="
-        length="37751728"
-        type="application/zip"/>
-
-      <!-- Linux x86_64 -->
-      <enclosure
-        url="https://cdn.browseros.com/server/browseros_server_0.0.74_linux_x64.zip"
-        sparkle:os="linux"
-        sparkle:arch="x86_64"
-        sparkle:edSignature="/OUrTZmgYWIWWWu71XAzN0B6hgs2WD9MOiZsXMvsv22TZwlEP1RdQsEO84JgFMb9if37MZX47utA2UWpSfFtAg=="
-        length="39041390"
-        type="application/zip"/>
-
-      <!-- Windows x86_64 -->
-      <enclosure
-        url="https://cdn.browseros.com/server/browseros_server_0.0.74_windows_x64.zip"
-        sparkle:os="windows"
-        sparkle:arch="x86_64"
-        sparkle:edSignature="qd7XYvoa59QA1bSUkaXbtBCti8DQGh3mWWfPG1qtgk5InLXJ07Y0ve/Y6ZAn8fyz6XGLEgMVhUa6eblmVuUODw=="
-        length="40986233"
+        sparkle:edSignature="kkM3dFanJr9TQgRPV7NOs7GwYpVfLHH+Db6oUWLHTWQFODBy8wx46fD6sioQdsB4k+9Ra9QCBm0WRSvKDkljDQ=="
+        length="101284695"
         type="application/zip"/>
     </item>
 

--- a/packages/browseros/build/modules/ota/__init__.py
+++ b/packages/browseros/build/modules/ota/__init__.py
@@ -15,6 +15,7 @@ from .common import (
 from .sign_binary import (
     sign_macos_binary,
     notarize_macos_binary,
+    notarize_macos_zip,
     sign_windows_binary,
     sign_server_bundle_macos,
     sign_server_bundle_windows,
@@ -37,6 +38,7 @@ __all__ = [
     "create_server_bundle_zip",
     "sign_macos_binary",
     "notarize_macos_binary",
+    "notarize_macos_zip",
     "sign_windows_binary",
     "sign_server_bundle_macos",
     "sign_server_bundle_windows",

--- a/packages/browseros/build/modules/ota/__init__.py
+++ b/packages/browseros/build/modules/ota/__init__.py
@@ -9,12 +9,15 @@ from .common import (
     SignedArtifact,
     SERVER_PLATFORMS,
     APPCAST_TEMPLATE,
-    find_server_binary,
+    find_server_resources_dir,
+    create_server_bundle_zip,
 )
 from .sign_binary import (
     sign_macos_binary,
     notarize_macos_binary,
     sign_windows_binary,
+    sign_server_bundle_macos,
+    sign_server_bundle_windows,
 )
 from .server import ServerOTAModule
 
@@ -30,10 +33,13 @@ __all__ = [
     "parse_existing_appcast",
     "ExistingAppcast",
     "SignedArtifact",
-    "find_server_binary",
+    "find_server_resources_dir",
+    "create_server_bundle_zip",
     "sign_macos_binary",
     "notarize_macos_binary",
     "sign_windows_binary",
+    "sign_server_bundle_macos",
+    "sign_server_bundle_windows",
     "SERVER_PLATFORMS",
     "APPCAST_TEMPLATE",
 ]

--- a/packages/browseros/build/modules/ota/bundle_test.py
+++ b/packages/browseros/build/modules/ota/bundle_test.py
@@ -47,7 +47,7 @@ class CreateServerBundleZipTest(unittest.TestCase):
                 },
             )
 
-    @unittest.skipIf(sys.platform == "win32", "Windows zip does not carry unix modes")
+    @unittest.skipIf(sys.platform == "win32", "file mode check is meaningless on Windows")
     def test_preserves_executable_bits(self):
         with tempfile.TemporaryDirectory() as tmp:
             resources = Path(tmp) / "darwin-arm64" / "resources"

--- a/packages/browseros/build/modules/ota/bundle_test.py
+++ b/packages/browseros/build/modules/ota/bundle_test.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Tests for OTA bundle-zip creation."""
+
+import stat
+import sys
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+
+from .common import create_server_bundle_zip, find_server_resources_dir
+
+
+def _write_exec(path: Path, content: bytes) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    path.chmod(path.stat().st_mode | 0o755)
+
+
+class CreateServerBundleZipTest(unittest.TestCase):
+    def test_bundles_full_resources_tree(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            staging = Path(tmp) / "darwin-arm64"
+            resources = staging / "resources"
+            _write_exec(resources / "bin" / "browseros_server", b"server")
+            _write_exec(resources / "bin" / "third_party" / "bun", b"bun")
+            _write_exec(resources / "bin" / "third_party" / "rg", b"rg")
+            _write_exec(resources / "bin" / "third_party" / "podman" / "podman", b"pd")
+            _write_exec(
+                resources / "bin" / "third_party" / "podman" / "gvproxy", b"gv"
+            )
+
+            zip_path = Path(tmp) / "bundle.zip"
+            self.assertTrue(create_server_bundle_zip(resources, zip_path))
+
+            with zipfile.ZipFile(zip_path) as zf:
+                names = set(zf.namelist())
+
+            self.assertEqual(
+                names,
+                {
+                    "resources/bin/browseros_server",
+                    "resources/bin/third_party/bun",
+                    "resources/bin/third_party/rg",
+                    "resources/bin/third_party/podman/podman",
+                    "resources/bin/third_party/podman/gvproxy",
+                },
+            )
+
+    @unittest.skipIf(sys.platform == "win32", "Windows zip does not carry unix modes")
+    def test_preserves_executable_bits(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            resources = Path(tmp) / "darwin-arm64" / "resources"
+            _write_exec(resources / "bin" / "browseros_server", b"server")
+
+            zip_path = Path(tmp) / "bundle.zip"
+            self.assertTrue(create_server_bundle_zip(resources, zip_path))
+
+            with zipfile.ZipFile(zip_path) as zf:
+                info = zf.getinfo("resources/bin/browseros_server")
+
+            mode = (info.external_attr >> 16) & 0o777
+            self.assertTrue(mode & stat.S_IXUSR)
+
+    def test_missing_resources_dir_fails(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "does-not-exist"
+            zip_path = Path(tmp) / "bundle.zip"
+            self.assertFalse(create_server_bundle_zip(missing, zip_path))
+
+
+class FindServerResourcesDirTest(unittest.TestCase):
+    def test_returns_resources_dir_when_present(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "darwin-arm64" / "resources" / "bin").mkdir(parents=True)
+            found = find_server_resources_dir(
+                root, {"name": "darwin_arm64", "target": "darwin-arm64"}
+            )
+            self.assertEqual(found, root / "darwin-arm64" / "resources")
+
+    def test_returns_none_when_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            self.assertIsNone(
+                find_server_resources_dir(
+                    root, {"name": "darwin_arm64", "target": "darwin-arm64"}
+                )
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/modules/ota/common.py
+++ b/packages/browseros/build/modules/ota/common.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
 """Common utilities for OTA update modules"""
 
-import os
 import re
-import shutil
 import zipfile
 import xml.etree.ElementTree as ET
 from datetime import datetime, timezone
@@ -13,8 +11,8 @@ from dataclasses import dataclass
 
 from ...common.utils import log_error, log_info, log_success
 
-# Re-export sparkle_sign_file from common module
-from ...common.sparkle import sparkle_sign_file
+# Re-exported for callers that used to get this from ota.common
+from ...common.sparkle import sparkle_sign_file  # noqa: F401
 
 # Sparkle XML namespace
 SPARKLE_NS = "http://www.andymatuschak.org/xml-namespaces/sparkle"
@@ -76,33 +74,15 @@ class ExistingAppcast:
     artifacts: Dict[str, SignedArtifact]
 
 
-def find_server_binary(binaries_dir: Path, platform: dict) -> Optional[Path]:
-    """Find server binary in either flat or artifact-extracted directory structure.
+def find_server_resources_dir(binaries_dir: Path, platform: dict) -> Optional[Path]:
+    """Return the extracted ``resources/`` dir for a platform, or ``None``.
 
-    Supports two layouts:
-      Flat:     {binaries_dir}/{binary_name}        (e.g., browseros-server-darwin-arm64)
-      Artifact: {binaries_dir}/{target}/resources/bin/browseros_server[.exe]
-
-    Args:
-        binaries_dir: Root directory containing server binaries
-        platform: Platform dict from SERVER_PLATFORMS
-
-    Returns:
-        Path to binary if found, None otherwise
+    ``binaries_dir`` is the temp root created by ``_download_artifacts``; each
+    platform lives at ``<binaries_dir>/<target>/resources/``.
     """
-    # Flat structure (used with --binaries pointing to mono build output)
-    flat_path = binaries_dir / platform["binary"]
-    if flat_path.exists():
-        return flat_path
-
-    # Artifact-extracted structure (used after download_resources)
     target = platform.get("target", platform["name"].replace("_", "-"))
-    bin_name = "browseros_server.exe" if platform["os"] == "windows" else "browseros_server"
-    artifact_path = binaries_dir / target / "resources" / "bin" / bin_name
-    if artifact_path.exists():
-        return artifact_path
-
-    return None
+    resources = binaries_dir / target / "resources"
+    return resources if resources.is_dir() else None
 
 
 def parse_existing_appcast(appcast_path: Path) -> Optional[ExistingAppcast]:
@@ -254,46 +234,31 @@ def generate_server_appcast(
     )
 
 
-def create_server_zip(
-    binary_path: Path,
-    output_zip: Path,
-    is_windows: bool = False,
-) -> bool:
-    """Create zip with proper structure: resources/bin/browseros_server
+def create_server_bundle_zip(resources_dir: Path, output_zip: Path) -> bool:
+    """Zip an extracted ``resources/`` tree into a Sparkle payload.
 
-    Args:
-        binary_path: Path to the binary to package
-        output_zip: Path for output zip file
-        is_windows: Whether this is Windows binary (affects target name)
-
-    Returns:
-        True on success, False on failure
+    Produces entries like ``resources/bin/browseros_server``,
+    ``resources/bin/third_party/podman/podman`` — mirroring what the agent
+    build staged and what the Chromium build bakes into the installed app.
+    File modes are preserved by ``ZipFile.write`` so executable bits survive.
     """
-    staging_dir = output_zip.parent / f"staging_{output_zip.stem}"
+    if not resources_dir.is_dir():
+        log_error(f"Resources dir not found: {resources_dir}")
+        return False
+
+    bundle_root = resources_dir.parent
     try:
-        staging_dir.mkdir(parents=True, exist_ok=True)
-        bin_dir = staging_dir / "resources" / "bin"
-        bin_dir.mkdir(parents=True, exist_ok=True)
-
-        target_name = "browseros_server.exe" if is_windows else "browseros_server"
-        shutil.copy2(binary_path, bin_dir / target_name)
-
-        with zipfile.ZipFile(output_zip, 'w', zipfile.ZIP_DEFLATED) as zf:
-            for root, _, files in os.walk(staging_dir):
-                for file in files:
-                    file_path = Path(root) / file
-                    arcname = file_path.relative_to(staging_dir)
-                    zf.write(file_path, arcname)
-
+        with zipfile.ZipFile(output_zip, "w", zipfile.ZIP_DEFLATED) as zf:
+            for path in sorted(resources_dir.rglob("*")):
+                if not path.is_file():
+                    continue
+                arcname = path.relative_to(bundle_root).as_posix()
+                zf.write(path, arcname)
         log_success(f"Created {output_zip.name}")
         return True
-
     except Exception as e:
-        log_error(f"Failed to create zip: {e}")
+        log_error(f"Failed to create bundle zip: {e}")
         return False
-    finally:
-        if staging_dir.exists():
-            shutil.rmtree(staging_dir)
 
 
 def get_appcast_path(channel: str = "alpha") -> Path:

--- a/packages/browseros/build/modules/ota/common.py
+++ b/packages/browseros/build/modules/ota/common.py
@@ -11,8 +11,9 @@ from dataclasses import dataclass
 
 from ...common.utils import log_error, log_info, log_success
 
-# Re-exported for callers that used to get this from ota.common
-from ...common.sparkle import sparkle_sign_file  # noqa: F401
+# Re-exported so callers (and ota/__init__.py) can get sparkle_sign_file
+# from ota.common alongside the other OTA helpers.
+from ...common.sparkle import sparkle_sign_file as sparkle_sign_file
 
 # Sparkle XML namespace
 SPARKLE_NS = "http://www.andymatuschak.org/xml-namespaces/sparkle"

--- a/packages/browseros/build/modules/ota/server.py
+++ b/packages/browseros/build/modules/ota/server.py
@@ -23,15 +23,14 @@ from .common import (
     sparkle_sign_file,
     generate_server_appcast,
     parse_existing_appcast,
-    create_server_zip,
+    create_server_bundle_zip,
     get_appcast_path,
-    find_server_binary,
+    find_server_resources_dir,
 )
 from .sign_binary import (
-    sign_macos_binary,
     notarize_macos_binary,
-    sign_windows_binary,
-    get_entitlements_path,
+    sign_server_bundle_macos,
+    sign_server_bundle_windows,
 )
 from ..storage import get_r2_client, upload_file_to_r2, download_file_from_r2
 from ..storage.download import extract_artifact_zip
@@ -136,26 +135,32 @@ class ServerOTAModule(CommandModule):
         for platform in platforms:
             log_info(f"\n📦 Processing {platform['name']}...")
 
-            source_binary = find_server_binary(binaries_dir, platform)
-            if not source_binary:
-                log_warning(f"Binary not found for {platform['name']}, skipping")
+            source_resources = find_server_resources_dir(binaries_dir, platform)
+            if not source_resources:
+                log_warning(
+                    f"Resources dir not found for {platform['name']}, skipping"
+                )
                 continue
 
-            # Copy binary to temp to preserve original
-            temp_binary = temp_dir / platform["binary"]
-            shutil.copy2(source_binary, temp_binary)
+            staging_resources = temp_dir / platform["name"] / "resources"
+            shutil.copytree(source_resources, staging_resources)
 
-            if not self._sign_binary(temp_binary, platform, ctx):
+            if not self._sign_bundle(staging_resources, platform, ctx):
                 log_warning(f"Skipping {platform['name']} due to signing failure")
                 continue
 
             zip_name = f"browseros_server_{self.version}_{platform['name']}.zip"
             zip_path = temp_dir / zip_name
-            is_windows = platform["os"] == "windows"
 
-            if not create_server_zip(temp_binary, zip_path, is_windows):
-                log_error(f"Failed to create zip for {platform['name']}")
+            if not create_server_bundle_zip(staging_resources, zip_path):
+                log_error(f"Failed to create bundle for {platform['name']}")
                 continue
+
+            if platform["os"] == "macos" and IS_MACOS():
+                log_info(f"Notarizing {zip_name}...")
+                if not notarize_macos_binary(zip_path, ctx.env):
+                    log_error(f"Notarization failed for {platform['name']}")
+                    continue
 
             log_info(f"Signing {zip_name} with Sparkle...")
             signature, length = sparkle_sign_file(zip_path, ctx.env)
@@ -219,27 +224,27 @@ class ServerOTAModule(CommandModule):
         log_info(f"\nAppcast saved to: {appcast_path}")
         log_info("\n📋 Next step: Run 'browseros ota server release-appcast' to make the release live")
 
-    def _sign_binary(self, binary_path: Path, platform: dict, ctx: Context) -> bool:
-        """Sign binary based on platform"""
+    def _sign_bundle(
+        self, staging_resources: Path, platform: dict, ctx: Context
+    ) -> bool:
+        """Codesign every binary in the staged resources tree for a platform.
+
+        macOS notarization happens separately, on the outer Sparkle zip.
+        """
         os_type = platform["os"]
 
         if os_type == "macos":
             if not IS_MACOS():
-                log_warning(f"macOS signing requires macOS - skipping {platform['name']}")
+                log_warning(
+                    f"macOS signing requires macOS - leaving {platform['name']} unsigned"
+                )
                 return True
+            return sign_server_bundle_macos(
+                staging_resources, ctx.env, ctx.get_entitlements_dir()
+            )
 
-            entitlements = get_entitlements_path(ctx.root_dir)
-            if not sign_macos_binary(binary_path, ctx.env, entitlements):
-                return False
+        if os_type == "windows":
+            return sign_server_bundle_windows(staging_resources, ctx.env)
 
-            log_info("Notarizing...")
-            return notarize_macos_binary(binary_path, ctx.env)
-
-        elif os_type == "windows":
-            return sign_windows_binary(binary_path, ctx.env)
-
-        elif os_type == "linux":
-            log_info(f"No code signing for Linux binaries")
-            return True
-
+        log_info("No code signing for Linux binaries")
         return True

--- a/packages/browseros/build/modules/ota/server.py
+++ b/packages/browseros/build/modules/ota/server.py
@@ -10,7 +10,6 @@ from ...common.module import CommandModule, ValidationError
 from ...common.context import Context
 from ...common.utils import (
     log_info,
-    log_error,
     log_success,
     log_warning,
     IS_MACOS,
@@ -88,11 +87,8 @@ class ServerOTAModule(CommandModule):
             return [p for p in SERVER_PLATFORMS if p["name"] in requested]
         return SERVER_PLATFORMS
 
-    def _download_artifacts(self, ctx: Context) -> Path:
-        """Download server artifact zips from R2 latest/ and extract them."""
-        download_dir = Path(tempfile.mkdtemp(prefix="ota_artifacts_"))
-        self._download_dir = download_dir
-
+    def _download_artifacts(self, ctx: Context, download_dir: Path) -> None:
+        """Download and extract server artifact zips from R2 into ``download_dir``."""
         r2_client = get_r2_client(ctx.env)
         if not r2_client:
             raise RuntimeError("Failed to create R2 client")
@@ -116,74 +112,85 @@ class ServerOTAModule(CommandModule):
             zip_path.unlink()
 
         log_success(f"Downloaded {len(platforms)} artifact(s)")
-        return download_dir
 
     def execute(self, context: Context) -> None:
         ctx = context
         log_info(f"\n🚀 BrowserOS Server OTA v{self.version} ({self.channel})")
         log_info("=" * 70)
 
-        # Download artifacts from R2
-        binaries_dir = self._download_artifacts(ctx)
+        with tempfile.TemporaryDirectory(prefix="ota_artifacts_") as dl, \
+             tempfile.TemporaryDirectory(prefix="ota_staging_") as st:
+            binaries_dir = Path(dl)
+            temp_dir = Path(st)
+            log_info(f"Temp directory: {temp_dir}")
 
-        platforms = self._get_platforms()
-        temp_dir = Path(tempfile.mkdtemp())
-        log_info(f"Temp directory: {temp_dir}")
+            self._download_artifacts(ctx, binaries_dir)
+            signed_artifacts = self._build_platform_artifacts(
+                ctx, binaries_dir, temp_dir
+            )
+            self._finalize_release(ctx, signed_artifacts)
 
+    def _build_platform_artifacts(
+        self, ctx: Context, binaries_dir: Path, temp_dir: Path
+    ) -> List[SignedArtifact]:
+        """Sign + zip + Sparkle-sign each platform; fail fast on any error.
+
+        Any per-platform failure raises ``RuntimeError`` so a broken
+        credential or unregistered binary cannot silently omit a platform
+        from a published release.
+        """
         signed_artifacts: List[SignedArtifact] = []
 
-        for platform in platforms:
+        for platform in self._get_platforms():
             log_info(f"\n📦 Processing {platform['name']}...")
 
             source_resources = find_server_resources_dir(binaries_dir, platform)
             if not source_resources:
-                log_warning(
-                    f"Resources dir not found for {platform['name']}, skipping"
+                raise RuntimeError(
+                    f"Resources dir not found for {platform['name']}"
                 )
-                continue
 
             staging_resources = temp_dir / platform["name"] / "resources"
             shutil.copytree(source_resources, staging_resources)
 
             if not self._sign_bundle(staging_resources, platform, ctx):
-                log_warning(f"Skipping {platform['name']} due to signing failure")
-                continue
+                raise RuntimeError(f"Signing failed for {platform['name']}")
 
             zip_name = f"browseros_server_{self.version}_{platform['name']}.zip"
             zip_path = temp_dir / zip_name
 
             if not create_server_bundle_zip(staging_resources, zip_path):
-                log_error(f"Failed to create bundle for {platform['name']}")
-                continue
+                raise RuntimeError(f"Failed to create bundle for {platform['name']}")
 
             if platform["os"] == "macos" and IS_MACOS():
                 if not notarize_macos_zip(zip_path, ctx.env):
-                    log_error(f"Notarization failed for {platform['name']}")
-                    continue
+                    raise RuntimeError(
+                        f"Notarization failed for {platform['name']}"
+                    )
 
             log_info(f"Signing {zip_name} with Sparkle...")
             signature, length = sparkle_sign_file(zip_path, ctx.env)
-
             if not signature:
-                log_error(f"Failed to sign zip for {platform['name']}")
-                continue
+                raise RuntimeError(f"Sparkle signing failed for {platform['name']}")
 
             log_success(f"  {platform['name']}: {length} bytes")
-
-            artifact = SignedArtifact(
+            signed_artifacts.append(SignedArtifact(
                 platform=platform["name"],
                 zip_path=zip_path,
                 signature=signature,
                 length=length,
                 os=platform["os"],
                 arch=platform["arch"],
-            )
-            signed_artifacts.append(artifact)
+            ))
 
         if not signed_artifacts:
-            log_error("No artifacts were processed successfully")
-            raise RuntimeError("OTA failed - no artifacts")
+            raise RuntimeError("OTA failed - no artifacts processed")
+        return signed_artifacts
 
+    def _finalize_release(
+        self, ctx: Context, signed_artifacts: List[SignedArtifact]
+    ) -> None:
+        """Write the appcast, upload every signed zip to R2, and surface URLs."""
         log_info("\n📝 Generating appcast...")
         appcast_path = get_appcast_path(self.channel)
         existing_appcast = parse_existing_appcast(appcast_path)

--- a/packages/browseros/build/modules/ota/server.py
+++ b/packages/browseros/build/modules/ota/server.py
@@ -28,7 +28,7 @@ from .common import (
     find_server_resources_dir,
 )
 from .sign_binary import (
-    notarize_macos_binary,
+    notarize_macos_zip,
     sign_server_bundle_macos,
     sign_server_bundle_windows,
 )
@@ -157,8 +157,7 @@ class ServerOTAModule(CommandModule):
                 continue
 
             if platform["os"] == "macos" and IS_MACOS():
-                log_info(f"Notarizing {zip_name}...")
-                if not notarize_macos_binary(zip_path, ctx.env):
+                if not notarize_macos_zip(zip_path, ctx.env):
                     log_error(f"Notarization failed for {platform['name']}")
                     continue
 

--- a/packages/browseros/build/modules/ota/sign_binary.py
+++ b/packages/browseros/build/modules/ota/sign_binary.py
@@ -4,9 +4,13 @@
 import subprocess
 import tempfile
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 from ...common.env import EnvConfig
+from ...common.server_binaries import (
+    expected_windows_binary_paths,
+    macos_sign_spec_for,
+)
 from ...common.utils import (
     log_info,
     log_error,
@@ -21,16 +25,17 @@ def sign_macos_binary(
     binary_path: Path,
     env: Optional[EnvConfig] = None,
     entitlements_path: Optional[Path] = None,
+    *,
+    identifier: Optional[str] = None,
+    options: str = "runtime",
 ) -> bool:
-    """Sign a macOS binary with codesign
+    """Sign a macOS binary with codesign.
 
-    Args:
-        binary_path: Path to binary to sign
-        env: Environment config with certificate name
-        entitlements_path: Optional path to entitlements plist
-
-    Returns:
-        True on success, False on failure
+    ``identifier`` defaults to ``com.browseros.<stem>`` to preserve the
+    previous single-binary signature shape. Callers that have a shared sign
+    table (see ``common/server_binaries.py``) should pass identifier and
+    options derived from that table so OTA-signed and Chromium-build-signed
+    binaries share the same code identifier.
     """
     if not IS_MACOS():
         log_error("macOS signing requires macOS")
@@ -46,13 +51,14 @@ def sign_macos_binary(
 
     log_info(f"Signing {binary_path.name}...")
 
+    resolved_identifier = identifier or f"com.browseros.{binary_path.stem}"
     cmd = [
         "codesign",
         "--sign", certificate_name,
         "--force",
         "--timestamp",
-        "--identifier", f"com.browseros.{binary_path.stem}",
-        "--options", "runtime",
+        "--identifier", resolved_identifier,
+        "--options", options,
     ]
 
     if entitlements_path and entitlements_path.exists():
@@ -306,3 +312,73 @@ def get_entitlements_path(root_dir: Path) -> Optional[Path]:
             return candidate
 
     return None
+
+
+def sign_server_bundle_macos(
+    resources_dir: Path,
+    env: EnvConfig,
+    entitlements_root: Path,
+) -> bool:
+    """Codesign every known binary under ``resources_dir/bin/**``.
+
+    Unknown executables are a hard error: every regular file under
+    ``resources/bin/`` must have an entry in ``MACOS_SERVER_BINARIES``.
+    This prevents silently shipping an unsigned binary when a new
+    third-party dep is added to the agent build without being registered
+    in the shared sign table.
+    """
+    bin_dir = resources_dir / "bin"
+    if not bin_dir.is_dir():
+        log_error(f"bin dir not found: {bin_dir}")
+        return False
+
+    unknowns: List[Path] = []
+    for path in sorted(bin_dir.rglob("*")):
+        if not path.is_file():
+            continue
+
+        spec = macos_sign_spec_for(path)
+        if spec is None:
+            unknowns.append(path)
+            continue
+
+        entitlements_path: Optional[Path] = None
+        if spec.entitlements:
+            entitlements_path = entitlements_root / spec.entitlements
+            if not entitlements_path.exists():
+                log_error(
+                    f"Missing entitlements for {path.name}: {entitlements_path}"
+                )
+                return False
+
+        if not sign_macos_binary(
+            path,
+            env,
+            entitlements_path,
+            identifier=f"com.browseros.{spec.identifier_suffix}",
+            options=spec.options,
+        ):
+            return False
+
+    if unknowns:
+        log_error(
+            "Unknown executables found under resources/bin/ not registered in "
+            "MACOS_SERVER_BINARIES (see build/common/server_binaries.py):"
+        )
+        for path in unknowns:
+            log_error(f"  - {path.relative_to(resources_dir)}")
+        return False
+
+    return True
+
+
+def sign_server_bundle_windows(resources_dir: Path, env: EnvConfig) -> bool:
+    """Sign each Windows binary enumerated in ``WINDOWS_SERVER_BINARIES``."""
+    bin_dir = resources_dir / "bin"
+    for path in expected_windows_binary_paths(bin_dir):
+        if not path.exists():
+            log_warning(f"Windows binary missing (skipping): {path}")
+            continue
+        if not sign_windows_binary(path, env):
+            return False
+    return True

--- a/packages/browseros/build/modules/ota/sign_binary.py
+++ b/packages/browseros/build/modules/ota/sign_binary.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 """Platform-specific binary signing for OTA binaries"""
 
+import os
+import shutil
 import subprocess
 import tempfile
 from pathlib import Path
@@ -182,7 +184,6 @@ def notarize_macos_binary(
     notarize_zip: Optional[Path] = None
     try:
         fd, tmp_path = tempfile.mkstemp(suffix=".zip")
-        import os
         os.close(fd)
         notarize_zip = Path(tmp_path)
 
@@ -307,7 +308,6 @@ def sign_windows_binary(
 
         signed_file = temp_output_dir / binary_path.name
         if signed_file.exists():
-            import shutil
             shutil.move(str(signed_file), str(binary_path))
 
         try:
@@ -357,8 +357,15 @@ def sign_server_bundle_macos(
         log_error(f"bin dir not found: {bin_dir}")
         return False
 
-    files = [p for p in sorted(bin_dir.rglob("*")) if p.is_file()]
-    unknowns = [p for p in files if macos_sign_spec_for(p) is None]
+    # Only Mach-O-style executables need signing; any future data/config file
+    # shipped under resources/bin/ (plists, shell completion, etc.) is not a
+    # codesign target and must not trigger the unknown-binary guard.
+    executables = [
+        p
+        for p in sorted(bin_dir.rglob("*"))
+        if p.is_file() and not p.is_symlink() and os.access(p, os.X_OK)
+    ]
+    unknowns = [p for p in executables if macos_sign_spec_for(p) is None]
     if unknowns:
         log_error(
             "Unknown executables found under resources/bin/ not registered in "
@@ -368,7 +375,7 @@ def sign_server_bundle_macos(
             log_error(f"  - {path.relative_to(resources_dir)}")
         return False
 
-    for path in files:
+    for path in executables:
         spec = macos_sign_spec_for(path)
         assert spec is not None  # unknowns filtered above
 
@@ -394,12 +401,17 @@ def sign_server_bundle_macos(
 
 
 def sign_server_bundle_windows(resources_dir: Path, env: EnvConfig) -> bool:
-    """Sign each Windows binary enumerated in ``WINDOWS_SERVER_BINARIES``."""
+    """Sign each Windows binary enumerated in ``WINDOWS_SERVER_BINARIES``.
+
+    A missing expected binary is a hard error: publishing an incomplete
+    Windows bundle would ship a broken OTA update without a pipeline signal.
+    Symmetric with the macOS bundle's unknown-file guard.
+    """
     bin_dir = resources_dir / "bin"
     for path in expected_windows_binary_paths(bin_dir):
         if not path.exists():
-            log_warning(f"Windows binary missing (skipping): {path}")
-            continue
+            log_error(f"Windows binary missing (cannot sign): {path}")
+            return False
         if not sign_windows_binary(path, env):
             return False
     return True

--- a/packages/browseros/build/modules/ota/sign_binary.py
+++ b/packages/browseros/build/modules/ota/sign_binary.py
@@ -97,45 +97,89 @@ def verify_macos_signature(binary_path: Path) -> bool:
         return False
 
 
+def _resolve_notarization_credentials(
+    env: Optional[EnvConfig],
+) -> Optional[EnvConfig]:
+    if env is None:
+        env = EnvConfig()
+
+    missing: List[str] = []
+    if not env.macos_notarization_apple_id:
+        missing.append("PROD_MACOS_NOTARIZATION_APPLE_ID")
+    if not env.macos_notarization_team_id:
+        missing.append("PROD_MACOS_NOTARIZATION_TEAM_ID")
+    if not env.macos_notarization_password:
+        missing.append("PROD_MACOS_NOTARIZATION_PWD")
+    if missing:
+        log_error("Missing notarization credentials:")
+        for name in missing:
+            log_error(f"  {name} not set")
+        return None
+    return env
+
+
+def _submit_notarization(submission_path: Path, env: EnvConfig) -> bool:
+    assert env.macos_notarization_apple_id is not None
+    assert env.macos_notarization_team_id is not None
+    assert env.macos_notarization_password is not None
+
+    subprocess.run(
+        [
+            "xcrun", "notarytool", "store-credentials", "notarytool-profile",
+            "--apple-id", env.macos_notarization_apple_id,
+            "--team-id", env.macos_notarization_team_id,
+            "--password", env.macos_notarization_password,
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    log_info("Submitting for notarization (this may take a while)...")
+    result = subprocess.run(
+        [
+            "xcrun", "notarytool", "submit", str(submission_path),
+            "--keychain-profile", "notarytool-profile",
+            "--wait",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    if result.returncode != 0:
+        log_error(f"Notarization failed: {result.stderr}")
+        log_error(result.stdout)
+        return False
+
+    if "status: Accepted" not in result.stdout:
+        log_error("Notarization was not accepted")
+        log_error(result.stdout)
+        return False
+    return True
+
+
 def notarize_macos_binary(
     binary_path: Path,
     env: Optional[EnvConfig] = None,
 ) -> bool:
-    """Notarize a macOS binary with Apple
+    """Notarize a single macOS binary with Apple.
 
-    The binary must be zipped for notarization submission.
-
-    Args:
-        binary_path: Path to binary to notarize (will be zipped internally)
-        env: Environment config with notarization credentials
-
-    Returns:
-        True on success, False on failure
+    The binary is first wrapped in a zip via ``ditto --keepParent`` because
+    ``notarytool`` does not accept bare executables. For an already-zipped
+    Sparkle bundle, call :func:`notarize_macos_zip` instead — double-wrapping
+    nests zips and notarytool does not descend into nested archives.
     """
     if not IS_MACOS():
         log_error("macOS notarization requires macOS")
         return False
 
+    env = _resolve_notarization_credentials(env)
     if env is None:
-        env = EnvConfig()
-
-    apple_id = env.macos_notarization_apple_id
-    team_id = env.macos_notarization_team_id
-    password = env.macos_notarization_password
-
-    if not all([apple_id, team_id, password]):
-        log_error("Missing notarization credentials:")
-        if not apple_id:
-            log_error("  PROD_MACOS_NOTARIZATION_APPLE_ID not set")
-        if not team_id:
-            log_error("  PROD_MACOS_NOTARIZATION_TEAM_ID not set")
-        if not password:
-            log_error("  PROD_MACOS_NOTARIZATION_PWD not set")
         return False
 
     log_info(f"Notarizing {binary_path.name}...")
-
-    notarize_zip = None
+    notarize_zip: Optional[Path] = None
     try:
         fd, tmp_path = tempfile.mkstemp(suffix=".zip")
         import os
@@ -152,41 +196,7 @@ def notarize_macos_binary(
             log_error(f"Failed to create zip: {result.stderr}")
             return False
 
-        assert apple_id is not None
-        assert team_id is not None
-        assert password is not None
-        subprocess.run(
-            [
-                "xcrun", "notarytool", "store-credentials", "notarytool-profile",
-                "--apple-id", apple_id,
-                "--team-id", team_id,
-                "--password", password,
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-
-        log_info("Submitting for notarization (this may take a while)...")
-        result = subprocess.run(
-            [
-                "xcrun", "notarytool", "submit", str(notarize_zip),
-                "--keychain-profile", "notarytool-profile",
-                "--wait",
-            ],
-            capture_output=True,
-            text=True,
-            check=False,
-        )
-
-        if result.returncode != 0:
-            log_error(f"Notarization failed: {result.stderr}")
-            log_error(result.stdout)
-            return False
-
-        if "status: Accepted" not in result.stdout:
-            log_error("Notarization was not accepted")
-            log_error(result.stdout)
+        if not _submit_notarization(notarize_zip, env):
             return False
 
         log_success(f"Notarized {binary_path.name}")
@@ -198,6 +208,33 @@ def notarize_macos_binary(
     finally:
         if notarize_zip and notarize_zip.exists():
             notarize_zip.unlink()
+
+
+def notarize_macos_zip(zip_path: Path, env: Optional[EnvConfig] = None) -> bool:
+    """Notarize a pre-built Sparkle bundle zip by submitting it directly.
+
+    ``notarytool`` accepts ``.zip`` submissions and recursively scans the
+    Mach-O binaries inside. No extra wrapping — passing this zip through
+    ``ditto --keepParent`` would nest zips and Apple's service would not
+    descend into the inner archive.
+    """
+    if not IS_MACOS():
+        log_error("macOS notarization requires macOS")
+        return False
+
+    env = _resolve_notarization_credentials(env)
+    if env is None:
+        return False
+
+    log_info(f"Notarizing {zip_path.name}...")
+    try:
+        if not _submit_notarization(zip_path, env):
+            return False
+        log_success(f"Notarized {zip_path.name}")
+        return True
+    except Exception as e:
+        log_error(f"Notarization failed: {e}")
+        return False
 
 
 def sign_windows_binary(
@@ -300,20 +337,6 @@ def sign_windows_binary(
         return False
 
 
-def get_entitlements_path(root_dir: Path) -> Optional[Path]:
-    """Get path to server binary entitlements file"""
-    candidates = [
-        root_dir / "resources" / "entitlements" / "browseros-executable-entitlements.plist",
-        root_dir / "packages" / "browseros" / "resources" / "entitlements" / "browseros-executable-entitlements.plist",
-    ]
-
-    for candidate in candidates:
-        if candidate.exists():
-            return candidate
-
-    return None
-
-
 def sign_server_bundle_macos(
     resources_dir: Path,
     env: EnvConfig,
@@ -325,22 +348,29 @@ def sign_server_bundle_macos(
     ``resources/bin/`` must have an entry in ``MACOS_SERVER_BINARIES``.
     This prevents silently shipping an unsigned binary when a new
     third-party dep is added to the agent build without being registered
-    in the shared sign table.
+    in the shared sign table. The unknown-file check runs before any
+    codesign call so a bad release fails in seconds rather than after
+    several minutes of signing.
     """
     bin_dir = resources_dir / "bin"
     if not bin_dir.is_dir():
         log_error(f"bin dir not found: {bin_dir}")
         return False
 
-    unknowns: List[Path] = []
-    for path in sorted(bin_dir.rglob("*")):
-        if not path.is_file():
-            continue
+    files = [p for p in sorted(bin_dir.rglob("*")) if p.is_file()]
+    unknowns = [p for p in files if macos_sign_spec_for(p) is None]
+    if unknowns:
+        log_error(
+            "Unknown executables found under resources/bin/ not registered in "
+            "MACOS_SERVER_BINARIES (see build/common/server_binaries.py):"
+        )
+        for path in unknowns:
+            log_error(f"  - {path.relative_to(resources_dir)}")
+        return False
 
+    for path in files:
         spec = macos_sign_spec_for(path)
-        if spec is None:
-            unknowns.append(path)
-            continue
+        assert spec is not None  # unknowns filtered above
 
         entitlements_path: Optional[Path] = None
         if spec.entitlements:
@@ -359,15 +389,6 @@ def sign_server_bundle_macos(
             options=spec.options,
         ):
             return False
-
-    if unknowns:
-        log_error(
-            "Unknown executables found under resources/bin/ not registered in "
-            "MACOS_SERVER_BINARIES (see build/common/server_binaries.py):"
-        )
-        for path in unknowns:
-            log_error(f"  - {path.relative_to(resources_dir)}")
-        return False
 
     return True
 

--- a/packages/browseros/build/modules/sign/macos.py
+++ b/packages/browseros/build/modules/sign/macos.py
@@ -10,6 +10,7 @@ from typing import Optional, List, Dict, Tuple
 from ...common.module import CommandModule, ValidationError
 from ...common.context import Context
 from ...common.env import EnvConfig
+from ...common.server_binaries import macos_sign_spec_for
 from ...common.utils import (
     run_command as utils_run_command,
     log_info,
@@ -20,49 +21,19 @@ from ...common.utils import (
     join_paths,
 )
 
-# Central list of BrowserOS Server binaries we need to sign explicitly.
-# Each entry controls identifiers, signing options, and entitlement files so
-# adding a new binary is a one-line update here rather than scattered changes.
-BROWSEROS_SERVER_BINARIES: Dict[str, Dict[str, str]] = {
-    "browseros_server": {
-        "identifier_suffix": "browseros_server",
-        "options": "runtime",
-        "entitlements": "browseros-executable-entitlements.plist",
-    },
-    "bun": {
-        "identifier_suffix": "bun",
-        "options": "runtime",
-        "entitlements": "browseros-executable-entitlements.plist",
-    },
-    "podman": {
-        "identifier_suffix": "podman",
-        "options": "runtime",
-    },
-    "gvproxy": {
-        "identifier_suffix": "gvproxy",
-        "options": "runtime",
-    },
-    "vfkit": {
-        "identifier_suffix": "vfkit",
-        "options": "runtime",
-        "entitlements": "podman-vfkit-entitlements.plist",
-    },
-    "krunkit": {
-        "identifier_suffix": "krunkit",
-        "options": "runtime",
-        "entitlements": "podman-krunkit-entitlements.plist",
-    },
-    "podman-mac-helper": {
-        "identifier_suffix": "podman_mac_helper",
-        "options": "runtime",
-    },
-}
-
 
 def get_browseros_server_binary_info(component_path: Path) -> Optional[Dict[str, str]]:
     """Return metadata for known BrowserOS Server binaries, if applicable."""
-    name = component_path.stem.lower()
-    return BROWSEROS_SERVER_BINARIES.get(name)
+    spec = macos_sign_spec_for(component_path)
+    if spec is None:
+        return None
+    info: Dict[str, str] = {
+        "identifier_suffix": spec.identifier_suffix,
+        "options": spec.options,
+    }
+    if spec.entitlements:
+        info["entitlements"] = spec.entitlements
+    return info
 
 
 def run_command(

--- a/packages/browseros/build/modules/sign/windows.py
+++ b/packages/browseros/build/modules/sign/windows.py
@@ -7,6 +7,7 @@ from typing import List, Optional
 from ...common.module import CommandModule, ValidationError
 from ...common.context import Context
 from ...common.env import EnvConfig
+from ...common.server_binaries import expected_windows_binary_paths
 from ...common.utils import (
     log_info,
     log_error,
@@ -15,15 +16,6 @@ from ...common.utils import (
     join_paths,
     IS_WINDOWS,
 )
-
-BROWSEROS_SERVER_BINARIES: List[str] = [
-    "browseros_server.exe",
-    "third_party/bun.exe",
-    "third_party/rg.exe",
-    "third_party/podman/podman.exe",
-    "third_party/podman/gvproxy.exe",
-    "third_party/podman/win-sshproxy.exe",
-]
 
 
 class WindowsSignModule(CommandModule):
@@ -105,7 +97,7 @@ class WindowsSignModule(CommandModule):
 def get_browseros_server_binary_paths(build_output_dir: Path) -> List[Path]:
     """Return absolute paths to BrowserOS Server binaries for signing."""
     server_dir = build_output_dir / "BrowserOSServer" / "default" / "resources" / "bin"
-    return [server_dir / Path(binary) for binary in BROWSEROS_SERVER_BINARIES]
+    return expected_windows_binary_paths(server_dir)
 
 
 def build_mini_installer(ctx: Context) -> bool:


### PR DESCRIPTION
## Summary

- OTA Sparkle zip now ships the full `resources/` tree the agent build produced (browseros_server + bun + rg + podman + gvproxy + vfkit + krunkit + podman-mac-helper + win-sshproxy), not just `browseros_server`. After an OTA update, `versions/<X>/resources/bin/third_party/` exists and matches a fresh Chromium-build install.
- Every binary inside the Sparkle zip is codesigned with the identifier + options + entitlements from a single shared table (`build/common/server_binaries.py`) that the Chromium-build sign path and the OTA sign path both consume — so adding a new third-party dep is a one-file edit that flows to both paths automatically.
- Unknown executables under `resources/bin/` are a hard error at release time, preventing silent unsigned shipment when the shared table hasn't been updated.

## Background

PR #719 added Podman to the Chromium-build path but did not touch the OTA pipeline at `packages/browseros/build/modules/ota/`. That pipeline was built around a single-binary abstraction: `find_server_binary()` returned one path, `create_server_zip()` staged exactly that one file, `sign_binary.py` signed one path at a time. Every third-party binary in the upstream artifact zip was silently discarded when the OTA payload was built.

Empirically verified: after OTA to v0.0.86, `~/Library/Application Support/BrowserOS/.browseros/versions/0.0.86/resources/bin/` contained only `browseros_server` — no `third_party/` dir. Podman integration was non-functional for any user updating via OTA, which is the primary distribution channel for existing installs. No appcast schema change, no client-side updater change, no agent-build change needed — just a refactor of the OTA bundling step.

## Design

- `build/common/server_binaries.py` (new) holds `MACOS_SERVER_BINARIES: Dict[str, SignSpec]` keyed by binary stem and `WINDOWS_SERVER_BINARIES: List[str]` of relative paths. `modules/sign/macos.py` and `modules/sign/windows.py` now import from here; OTA imports the same table.
- `modules/ota/common.py`: `create_server_zip(binary_path, ...)` → `create_server_bundle_zip(resources_dir, output_zip)` that zips the whole extracted tree; `find_server_binary` → `find_server_resources_dir` that returns the extracted `resources/` directory.
- `modules/ota/sign_binary.py`: adds `sign_server_bundle_macos` (walks `resources/bin/**`, fails fast on unknowns, codesigns each file using the shared table's identifier + options + entitlements) and `sign_server_bundle_windows` (signs the explicit Windows relative-path list). Also adds `notarize_macos_zip` so the outer Sparkle zip is submitted to `notarytool` directly — the existing `notarize_macos_binary` wraps its input via `ditto --keepParent`, which would double-zip the already-built bundle and prevent Apple's service from reaching the inner Mach-O binaries.
- `modules/ota/server.py::ServerOTAModule.execute()`: per-platform flow becomes copy-resources → codesign bundle → zip → notarize zip → Sparkle-sign. Sparkle zip layout is identical to what the Chromium build already bakes into `.app`, so BrowserOS's in-process updater needs zero changes.

## Test plan

- [ ] `cd packages/browseros && python -m build.common.server_binaries_test` (7 tests, validates table shape + entitlements plists exist)
- [ ] `cd packages/browseros && python -m build.modules.ota.bundle_test` (5 tests, validates bundle-zip layout + exec-bit preservation + missing-dir failure)
- [ ] `cd packages/browseros && python -m build.modules.storage.download_test` and `upload_test` — pre-existing tests still pass
- [ ] On macOS release box: `browseros ota server release --version <X> --channel alpha`, then unzip the published `browseros_server_<X>_darwin_arm64.zip` from `cdn.browseros.com/server/` and confirm it contains `resources/bin/browseros_server` + `resources/bin/third_party/{bun,rg,podman/*}`; run `codesign -dv` on a few inner binaries (especially `vfkit`, `krunkit`) to confirm entitlements are applied.
- [ ] `browseros ota server release-appcast --channel alpha`, install BrowserOS alpha on a clean machine, trigger auto-update, verify `~/Library/Application Support/BrowserOS/.browseros/versions/<X>/resources/bin/third_party/podman/podman` exists and runs.
- [ ] Promote to `prod` channel only after alpha verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)