### PR TITLE
feat(build): add arm64-only macOS release config

### DIFF
--- a/packages/browseros/build/config/release.macos.arm64.yaml
+++ b/packages/browseros/build/config/release.macos.arm64.yaml
@@ -1,0 +1,55 @@
+# BrowserOS macOS Release Build Configuration (arm64 only)
+#
+# Single-architecture arm64 release build. Skips the universal_build
+# pipeline (no x64, no lipo merge) — follows the standard per-arch flow
+# like release.windows.yaml / release.linux.yaml.
+#
+# Environment Variables:
+#   Use !env tag to reference environment variables:
+#     Example: chromium_src: !env CHROMIUM_SRC
+
+build:
+  type: release
+  architecture: arm64
+
+gn_flags:
+  file: build/config/gn/flags.macos.release.gn
+
+# Explicit module execution order
+modules:
+  # Phase 1: Setup
+  - clean
+  - git_setup
+  - sparkle_setup
+
+  # Phase 2: Patches & Resources
+  - download_resources
+  - resources
+  - bundled_extensions
+  - chromium_replace
+  - string_replaces
+  - series_patches
+  - patches
+
+  # Phase 3: Build
+  - configure
+  - compile
+
+  # Phase 4: Sign & Package
+  - sign_macos
+  - package_macos
+
+  # Phase 5: Upload
+  - upload
+
+# Required environment variables
+# Note: CHROMIUM_SRC can be provided via --chromium-src CLI flag, YAML config, or env var
+required_envs:
+  - MACOS_CERTIFICATE_NAME
+  - PROD_MACOS_NOTARIZATION_APPLE_ID
+  - PROD_MACOS_NOTARIZATION_TEAM_ID
+  - PROD_MACOS_NOTARIZATION_PWD
+
+# Notification settings
+notifications:
+  slack: true


### PR DESCRIPTION
## Summary

- Adds `packages/browseros/build/config/release.macos.arm64.yaml` for single-architecture arm64 macOS release builds.
- Skips the `universal_build` module (no x64 build, no lipo merge) — follows the per-arch pattern used by `release.windows.yaml` and `release.linux.yaml`.
- Keeps `sparkle_setup` and the same notarization env vars (`MACOS_CERTIFICATE_NAME`, `PROD_MACOS_NOTARIZATION_*`) as the universal macOS config.

## Design

The existing `release.macos.yaml` drives a universal binary (arm64 + x64 + lipo merge) through a single `universal_build` super-module. For arm64-only releases we don't need the x64 pass or the merge step, so the new config wires the standard per-arch pipeline explicitly: `clean` → `git_setup` → `sparkle_setup` → resource/patch phase → `configure` → `compile` → `sign_macos` → `package_macos` → `upload`. The GN flags file is reused (`flags.macos.release.gn`); architecture is pinned to `arm64` at the top.

## Test plan

- [ ] Run `browseros build --config build/config/release.macos.arm64.yaml` on an arm64 mac and confirm the pipeline produces a signed, notarized arm64 DMG and uploads it.
- [ ] Confirm no x64 output is produced and no `universal_build`/lipo steps run.
- [ ] Sanity-check that the existing `release.macos.yaml` (universal) is unchanged and still builds cleanly.