### PR TITLE
feat(referral): show tweet share rules and lower default daily limit fallback

### DIFF
--- a/packages/browseros-agent/apps/agent/components/referral/ShareForCredits.tsx
+++ b/packages/browseros-agent/apps/agent/components/referral/ShareForCredits.tsx
@@ -61,6 +61,14 @@ export const ShareForCredits: FC<ShareForCreditsProps> = ({ compact }) => {
         Share BrowserOS on Twitter to earn 200 bonus credits!
       </p>
 
+      <ul className="list-disc space-y-0.5 pl-4 text-muted-foreground text-xs">
+        <li>
+          Tweet must mention <span className="font-medium">@browserOS_ai</span>
+        </li>
+        <li>Tweet must be posted within the last 30 minutes</li>
+        <li>Each tweet can only be submitted once</li>
+      </ul>
+
       <Button variant="outline" size="sm" className="w-full gap-2" asChild>
         <a
           href={getShareOnTwitterUrl()}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/usage/UsagePage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/usage/UsagePage.tsx
@@ -44,7 +44,7 @@ export const UsagePage: FC = () => {
   }
 
   const credits = data?.credits ?? 0
-  const total = data?.dailyLimit ?? 100
+  const total = data?.dailyLimit ?? 50
   const percentage = Math.min((credits / total) * 100, 100)
 
   return (

--- a/packages/browseros-agent/apps/agent/entrypoints/app/usage/UsagePage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/usage/UsagePage.tsx
@@ -46,6 +46,8 @@ export const UsagePage: FC = () => {
   const credits = data?.credits ?? 0
   const total = data?.dailyLimit ?? 50
   const percentage = Math.min((credits / total) * 100, 100)
+  const bonusCredits = Math.max(0, credits - total)
+  const creditsUsed = Math.max(0, total - credits)
 
   return (
     <div className="space-y-6 p-6">
@@ -96,10 +98,21 @@ export const UsagePage: FC = () => {
           <div className="flex items-center gap-2.5 rounded-lg bg-muted/50 px-3 py-2.5">
             <Zap className="h-4 w-4 shrink-0 text-muted-foreground" />
             <div>
-              <p className="font-medium text-xs">Credits used today</p>
-              <p className="text-muted-foreground text-xs">
-                {total - credits} of {total}
-              </p>
+              {bonusCredits > 0 ? (
+                <>
+                  <p className="font-medium text-xs">Bonus credits</p>
+                  <p className="text-muted-foreground text-xs">
+                    +{bonusCredits} from referrals
+                  </p>
+                </>
+              ) : (
+                <>
+                  <p className="font-medium text-xs">Credits used today</p>
+                  <p className="text-muted-foreground text-xs">
+                    {creditsUsed} of {total}
+                  </p>
+                </>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Surface the three referral validation rules (must mention `@browserOS_ai`, posted within last 30 minutes, single-use) directly in the `ShareForCredits` UI so users understand submission requirements before pasting a tweet link. The rules render in both the Usage page and inline in `ChatError` when credits are exhausted.
- Lower the `UsagePage` daily-limit fallback from `100` → `50` so the loading-state placeholder matches the gateway's actual default.

## Test plan
- [ ] Open `app.html#/settings/usage` and confirm the three bullet rules appear above the Share button.
- [ ] Trigger a `CREDITS_EXHAUSTED` error in chat and confirm the same rules render inline in the error block.
- [ ] Confirm the Daily Credits ring shows `X / 50` (not `X / 100`) before the gateway response loads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)