### PR TITLE
feat(openclaw): switch to full-trust mode (auth.mode=none + HTTP SSE chat)

### DIFF
--- a/packages/browseros-agent/apps/server/resources/openclaw-compose.yml
+++ b/packages/browseros-agent/apps/server/resources/openclaw-compose.yml
@@ -6,7 +6,6 @@ services:
     environment:
       - HOME=/home/node
       - NODE_ENV=production
-      - OPENCLAW_GATEWAY_TOKEN=${OPENCLAW_GATEWAY_TOKEN}
       - OPENCLAW_GATEWAY_BIND=lan
       - TZ=${TZ}
       - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
@@ -28,7 +27,6 @@ services:
       - lan
       - --port
       - "18789"
-      - --allow-unconfigured
     healthcheck:
       test: ["CMD", "curl", "-sf", "http://127.0.0.1:18789/healthz"]
       interval: 30s

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/chat-stream.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/chat-stream.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { logger } from '../../../lib/logger'
+import type { OpenClawStreamEvent } from './gateway-client'
+
+interface OpenAiChunk {
+  choices?: Array<{
+    delta?: { content?: string; role?: string }
+    finish_reason?: string | null
+  }>
+}
+
+export function parseOpenAiSseEvent(chunk: unknown): OpenClawStreamEvent[] {
+  if (!chunk || typeof chunk !== 'object') return []
+  const c = chunk as OpenAiChunk
+  const out: OpenClawStreamEvent[] = []
+  const choice = c.choices?.[0]
+  if (!choice) return out
+  const delta = choice.delta?.content
+  if (typeof delta === 'string' && delta.length > 0) {
+    out.push({ type: 'text-delta', data: { text: delta } })
+  }
+  if (choice.finish_reason) {
+    out.push({ type: 'done', data: { text: '' } })
+  }
+  return out
+}
+
+export function chatStreamHttp(input: {
+  httpBase: string
+  agentId: string
+  sessionKey: string
+  message: string
+}): ReadableStream<OpenClawStreamEvent> {
+  const { httpBase, agentId, sessionKey, message } = input
+  const fullSessionKey = `agent:${agentId}:browseros-${sessionKey}`
+
+  return new ReadableStream<OpenClawStreamEvent>({
+    start: async (controller) => {
+      let res: Response
+      try {
+        res = await fetch(`${httpBase}/v1/chat/completions`, {
+          method: 'POST',
+          headers: {
+            'content-type': 'application/json',
+            accept: 'text/event-stream',
+            'x-openclaw-agent-id': agentId,
+            'x-openclaw-session-key': fullSessionKey,
+            'x-openclaw-scopes': 'operator.admin,operator.read,operator.write',
+          },
+          body: JSON.stringify({
+            model: 'openclaw/default',
+            stream: true,
+            messages: [{ role: 'user', content: message }],
+          }),
+        })
+      } catch (err) {
+        controller.enqueue({
+          type: 'error',
+          data: {
+            message: err instanceof Error ? err.message : 'fetch failed',
+          },
+        })
+        controller.close()
+        return
+      }
+
+      if (!res.ok || !res.body) {
+        controller.enqueue({
+          type: 'error',
+          data: { message: `Gateway HTTP ${res.status}` },
+        })
+        controller.close()
+        return
+      }
+
+      const reader = res.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ''
+      try {
+        while (true) {
+          const { value, done } = await reader.read()
+          if (done) break
+          buffer += decoder.decode(value, { stream: true })
+          let sepIdx = buffer.indexOf('\n\n')
+          while (sepIdx !== -1) {
+            const rawEvent = buffer.slice(0, sepIdx)
+            buffer = buffer.slice(sepIdx + 2)
+            for (const line of rawEvent.split('\n')) {
+              if (!line.startsWith('data:')) continue
+              const data = line.slice(5).trim()
+              if (data === '[DONE]') {
+                controller.enqueue({ type: 'done', data: { text: '' } })
+                controller.close()
+                return
+              }
+              try {
+                for (const ev of parseOpenAiSseEvent(JSON.parse(data))) {
+                  controller.enqueue(ev)
+                }
+              } catch (err) {
+                logger.debug('Chat SSE parse skipped', {
+                  error: err instanceof Error ? err.message : String(err),
+                })
+              }
+            }
+            sepIdx = buffer.indexOf('\n\n')
+          }
+        }
+        controller.close()
+      } finally {
+        await reader.cancel().catch(() => {})
+      }
+    },
+  })
+}

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/chat-stream.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/chat-stream.ts
@@ -5,12 +5,11 @@
  */
 
 import { logger } from '../../../lib/logger'
-import type { OpenClawStreamEvent } from './gateway-client'
+import { OPERATOR_SCOPES, type OpenClawStreamEvent } from './gateway-client'
 
 interface OpenAiChunk {
   choices?: Array<{
     delta?: { content?: string; role?: string }
-    finish_reason?: string | null
   }>
 }
 
@@ -23,9 +22,6 @@ export function parseOpenAiSseEvent(chunk: unknown): OpenClawStreamEvent[] {
   const delta = choice.delta?.content
   if (typeof delta === 'string' && delta.length > 0) {
     out.push({ type: 'text-delta', data: { text: delta } })
-  }
-  if (choice.finish_reason) {
-    out.push({ type: 'done', data: { text: '' } })
   }
   return out
 }
@@ -50,7 +46,7 @@ export function chatStreamHttp(input: {
             accept: 'text/event-stream',
             'x-openclaw-agent-id': agentId,
             'x-openclaw-session-key': fullSessionKey,
-            'x-openclaw-scopes': 'operator.admin,operator.read,operator.write',
+            'x-openclaw-scopes': OPERATOR_SCOPES.join(','),
           },
           body: JSON.stringify({
             model: 'openclaw/default',

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/gateway-client.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/gateway-client.ts
@@ -2,61 +2,30 @@
  * @license
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
- *
- * WebSocket client for the OpenClaw Gateway protocol.
- * Handles handshake (challenge → connect → hello-ok) with Ed25519 device
- * identity signing, JSON-RPC over WS, and auto-reconnect.
- * Used for agent CRUD and health — chat uses HTTP.
  */
 
-import crypto from 'node:crypto'
-import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
 import { OPENCLAW_CONTAINER_HOME } from '@browseros/shared/constants/openclaw'
 import { logger } from '../../../lib/logger'
 
 const RPC_TIMEOUT_MS = 15_000
-const SCOPES = [
+const RECONNECT_BASE_MS = 250
+const RECONNECT_MAX_MS = 4_000
+const RECONNECT_MAX_ATTEMPTS = 5
+
+const OPERATOR_SCOPES = [
+  'operator.admin',
   'operator.read',
   'operator.write',
-  'operator.admin',
   'operator.approvals',
   'operator.pairing',
+  'operator.talk.secrets',
 ]
 
-interface DeviceIdentity {
-  deviceId: string
-  publicKeyPem: string
-  privateKeyPem: string
-}
-
-interface PendingRequest {
-  resolve: (value: unknown) => void
-  reject: (reason: Error) => void
-  timer: ReturnType<typeof setTimeout>
-}
-
-interface WsFrame {
-  type: 'req' | 'res' | 'event'
-  id?: string
-  method?: string
-  params?: Record<string, unknown>
-  ok?: boolean
-  payload?: Record<string, unknown>
-  error?: { message: string; code?: string }
-  event?: string
-}
-
-export type GatewayClientConnectionState =
-  | 'idle'
-  | 'connecting'
-  | 'connected'
-  | 'closed'
-  | 'failed'
-
-export interface GatewayHandshakeError {
-  code?: string
-  message: string
+export interface GatewayAgentEntry {
+  agentId: string
+  name: string
+  workspace: string
+  model?: string
 }
 
 export interface OpenClawStreamEvent {
@@ -72,269 +41,115 @@ export interface OpenClawStreamEvent {
   data: Record<string, unknown>
 }
 
-export interface GatewayAgentEntry {
-  agentId: string
-  name: string
-  workspace: string
-  model?: string
+interface WsFrame {
+  type: 'req' | 'res' | 'event'
+  id?: string
+  method?: string
+  params?: Record<string, unknown>
+  ok?: boolean
+  payload?: Record<string, unknown>
+  error?: { message: string; code?: string }
+  event?: string
 }
 
-// ── Device Identity Helpers ─────────────────────────────────────────
-
-function rawPublicKeyFromPem(pem: string): Buffer {
-  const der = Buffer.from(
-    pem.replace(/-----[^-]+-----/g, '').replace(/\s/g, ''),
-    'base64',
-  )
-  return der.subarray(12)
+interface PendingRequest {
+  resolve: (value: unknown) => void
+  reject: (reason: Error) => void
+  timer: ReturnType<typeof setTimeout>
 }
-
-function signChallenge(
-  device: DeviceIdentity,
-  nonce: string,
-  token: string,
-): { signature: string; signedAt: number; publicKey: string } {
-  const signedAt = Date.now()
-  const payload = `v3|${device.deviceId}|cli|cli|operator|${SCOPES.join(',')}|${signedAt}|${token}|${nonce}|${process.platform}|`
-  const privateKey = crypto.createPrivateKey(device.privateKeyPem)
-  const sig = crypto.sign(null, Buffer.from(payload, 'utf-8'), privateKey)
-
-  return {
-    signature: sig.toString('base64url'),
-    signedAt,
-    publicKey: rawPublicKeyFromPem(device.publicKeyPem).toString('base64url'),
-  }
-}
-
-/**
- * Generates a client Ed25519 identity and pre-seeds it into the gateway's
- * paired devices file so the gateway trusts it on next boot.
- * Must be called before compose up (or requires a restart after).
- */
-export function ensureClientIdentity(openclawDir: string): DeviceIdentity {
-  const identityPath = join(openclawDir, 'client-identity.json')
-
-  try {
-    return JSON.parse(readFileSync(identityPath, 'utf-8'))
-  } catch {
-    // Generate new identity
-  }
-
-  const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519')
-  const publicKeyPem = publicKey
-    .export({ type: 'spki', format: 'pem' })
-    .toString()
-  const privateKeyPem = privateKey
-    .export({ type: 'pkcs8', format: 'pem' })
-    .toString()
-
-  const rawPub = rawPublicKeyFromPem(publicKeyPem)
-  const deviceId = crypto.createHash('sha256').update(rawPub).digest('hex')
-
-  const identity: DeviceIdentity = { deviceId, publicKeyPem, privateKeyPem }
-  writeFileSync(identityPath, JSON.stringify(identity, null, 2), {
-    mode: 0o600,
-  })
-
-  seedPairedDevice(openclawDir, identity)
-  logger.info('Generated client device identity and pre-seeded pairing')
-
-  return identity
-}
-
-function seedPairedDevice(openclawDir: string, identity: DeviceIdentity): void {
-  const devicesDir = join(openclawDir, 'devices')
-  mkdirSync(devicesDir, { recursive: true })
-
-  const pairedPath = join(devicesDir, 'paired.json')
-  let paired: Record<string, unknown> = {}
-  try {
-    paired = JSON.parse(readFileSync(pairedPath, 'utf-8'))
-  } catch {
-    // First time
-  }
-
-  const rawPub = rawPublicKeyFromPem(identity.publicKeyPem)
-  paired[identity.deviceId] = {
-    deviceId: identity.deviceId,
-    publicKey: rawPub.toString('base64url'),
-    platform: process.platform,
-    clientId: 'cli',
-    clientMode: 'cli',
-    role: 'operator',
-    roles: ['operator'],
-    scopes: SCOPES,
-    pairedAt: Date.now(),
-    label: 'browseros-server',
-  }
-
-  writeFileSync(pairedPath, JSON.stringify(paired, null, 2), { mode: 0o600 })
-}
-
-// ── Gateway Client ──────────────────────────────────────────────────
 
 export class GatewayClient {
   private ws: WebSocket | null = null
   private _connected = false
-  private pendingRequests = new Map<string, PendingRequest>()
-  private device: DeviceIdentity | null = null
-  private connectionState: GatewayClientConnectionState = 'idle'
-  private lastHandshakeError: GatewayHandshakeError | null = null
+  private pending = new Map<string, PendingRequest>()
 
   constructor(
     private readonly port: number,
-    private readonly token: string,
     private readonly openclawDir: string,
     private readonly version = '1.0.0',
-  ) {
-    try {
-      const identityPath = join(this.openclawDir, 'client-identity.json')
-      this.device = JSON.parse(readFileSync(identityPath, 'utf-8'))
-    } catch {
-      logger.warn('Client device identity not found, WS auth may fail')
-    }
-  }
+  ) {}
 
   get isConnected(): boolean {
     return this._connected
   }
 
-  get state(): GatewayClientConnectionState {
-    return this.connectionState
-  }
-
-  get lastError(): GatewayHandshakeError | null {
-    return this.lastHandshakeError
+  get endpointHttpBase(): string {
+    return `http://127.0.0.1:${this.port}`
   }
 
   async connect(): Promise<void> {
+    this.ws = new WebSocket(`ws://127.0.0.1:${this.port}`, {
+      headers: { Origin: `http://127.0.0.1:${this.port}` },
+    } as unknown as string[])
+
     return new Promise((resolve, reject) => {
-      this.connectionState = 'connecting'
-      this.lastHandshakeError = null
-      logger.info('Connecting to OpenClaw Gateway WS', {
-        port: this.port,
-        hasDeviceIdentity: !!this.device,
-      })
-      this.ws = new WebSocket(`ws://127.0.0.1:${this.port}`, {
-        headers: { Origin: `http://127.0.0.1:${this.port}` },
-      } as unknown as string[])
+      const id = globalThis.crypto.randomUUID()
+      let settled = false
 
-      let handshakeComplete = false
-      let connectReqId: string | null = null
-
-      this.ws.onmessage = (event) => {
-        const frame = GatewayClient.parseFrame(event.data)
+      this.ws!.onmessage = (event) => {
+        const frame = parseFrame(event.data)
         if (!frame) return
-
-        if (!handshakeComplete) {
-          if (frame.type === 'event' && frame.event === 'connect.challenge') {
-            const nonce = (frame.payload as Record<string, unknown>)
-              ?.nonce as string
-            logger.info('Received OpenClaw Gateway challenge', {
-              hasNonce: !!nonce,
-              hasDeviceIdentity: !!this.device,
-            })
-            connectReqId = globalThis.crypto.randomUUID()
-
-            const params: Record<string, unknown> = {
-              minProtocol: 3,
-              maxProtocol: 3,
-              client: {
-                id: 'cli',
-                version: this.version,
-                platform: process.platform,
-                mode: 'cli',
-              },
-              role: 'operator',
-              scopes: SCOPES,
-              caps: [],
-              commands: [],
-              permissions: {},
-              auth: { token: this.token },
-              locale: 'en-US',
-              userAgent: `browseros-server/${this.version}`,
-            }
-
-            if (this.device && nonce) {
-              const signed = signChallenge(this.device, nonce, this.token)
-              params.device = {
-                id: this.device.deviceId,
-                publicKey: signed.publicKey,
-                signature: signed.signature,
-                signedAt: signed.signedAt,
-                nonce,
-              }
-            }
-
-            this.ws?.send(
-              JSON.stringify({
-                type: 'req',
-                id: connectReqId,
-                method: 'connect',
-                params,
-              }),
-            )
-            return
-          }
-
-          if (frame.type === 'res' && frame.id === connectReqId) {
+        if (!this._connected) {
+          if (frame.type === 'res' && frame.id === id) {
+            settled = true
             if (frame.ok) {
-              handshakeComplete = true
               this._connected = true
-              this.connectionState = 'connected'
-              logger.info('Gateway WS connected')
+              logger.info('Gateway WS connected', { port: this.port })
               resolve()
             } else {
               const msg = frame.error?.message ?? 'Handshake failed'
-              this.connectionState = 'failed'
-              this.lastHandshakeError = {
-                message: msg,
-                code: frame.error?.code,
-              }
-              logger.error('Gateway WS handshake rejected', {
-                error: msg,
-                code: frame.error?.code,
-              })
               reject(new Error(msg))
             }
             return
           }
           return
         }
-
-        this.resolvePendingRequest(frame)
+        this.dispatchRpcResponse(frame)
       }
 
-      this.ws.onerror = (err) => {
-        logger.error('Gateway WS socket error', {
-          error: err instanceof Error ? err.message : 'unknown',
-          handshakeComplete,
-        })
-        if (!handshakeComplete) {
-          this.connectionState = 'failed'
-          reject(
-            new Error(
-              `WS connection error: ${err instanceof Error ? err.message : 'unknown'}`,
-            ),
-          )
-        }
+      this.ws!.onerror = (err) => {
+        const msg = err instanceof Error ? err.message : 'unknown'
+        logger.warn('Gateway WS socket error', { error: msg })
+        if (!settled) reject(new Error(`WS connection error: ${msg}`))
       }
 
-      this.ws.onclose = () => {
+      this.ws!.onclose = () => {
         this._connected = false
-        this.connectionState = 'closed'
         this.rejectAllPending('WebSocket closed')
-        if (handshakeComplete) {
-          logger.info('Gateway WS disconnected')
-        }
         this.ws = null
+      }
+
+      this.ws!.onopen = () => {
+        this.ws!.send(
+          JSON.stringify({
+            type: 'req',
+            id,
+            method: 'connect',
+            params: {
+              minProtocol: 3,
+              maxProtocol: 3,
+              client: {
+                id: 'control-ui',
+                version: this.version,
+                platform: process.platform,
+                mode: 'cli',
+              },
+              role: 'operator',
+              scopes: OPERATOR_SCOPES,
+              caps: [],
+              commands: [],
+              permissions: {},
+              locale: 'en-US',
+              userAgent: `browseros-server/${this.version}`,
+            },
+          }),
+        )
       }
     })
   }
 
   disconnect(): void {
     this._connected = false
-    this.connectionState = 'closed'
     this.rejectAllPending('Client disconnecting')
     if (this.ws) {
       this.ws.onclose = null
@@ -342,8 +157,6 @@ export class GatewayClient {
       this.ws = null
     }
   }
-
-  // ── RPC ──────────────────────────────────────────────────────────────
 
   async rpc<T = Record<string, unknown>>(
     method: string,
@@ -353,24 +166,19 @@ export class GatewayClient {
       throw new Error('Gateway WS not connected')
     }
     const id = globalThis.crypto.randomUUID()
-
     return new Promise<T>((resolve, reject) => {
       const timer = setTimeout(() => {
-        this.pendingRequests.delete(id)
+        this.pending.delete(id)
         reject(new Error(`RPC timeout: ${method}`))
       }, RPC_TIMEOUT_MS)
-
-      this.pendingRequests.set(id, {
+      this.pending.set(id, {
         resolve: resolve as (value: unknown) => void,
         reject,
         timer,
       })
-
       this.ws?.send(JSON.stringify({ type: 'req', id, method, params }))
     })
   }
-
-  // ── Agent Methods ────────────────────────────────────────────────────
 
   async listAgents(): Promise<GatewayAgentEntry[]> {
     const result = await this.rpc<{
@@ -381,7 +189,6 @@ export class GatewayClient {
         model?: string
       }>
     }>('agents.list')
-
     return (result.agents ?? []).map((a) => ({
       agentId: a.id,
       name: a.name ?? a.id,
@@ -402,7 +209,6 @@ export class GatewayClient {
       workspace?: string
       model?: string
     }>('agents.create', input)
-
     return {
       agentId: result.agentId ?? result.id ?? input.name,
       name: result.name ?? input.name,
@@ -415,145 +221,9 @@ export class GatewayClient {
     await this.rpc('agents.delete', { id: agentId })
   }
 
-  // ── Health ───────────────────────────────────────────────────────────
-
   async getHealth(): Promise<Record<string, unknown>> {
     return this.rpc('health')
   }
-
-  // ── Chat Stream ─────────────────────────────────────────────────────
-
-  chatStream(
-    agentId: string,
-    sessionKey: string,
-    message: string,
-  ): ReadableStream<OpenClawStreamEvent> {
-    if (!this._connected) {
-      throw new Error('Gateway WS not connected')
-    }
-
-    const fullSessionKey = `agent:${agentId}:browseros-${sessionKey}`
-    const idempotencyKey = globalThis.crypto.randomUUID()
-    const streamClient = new GatewayClient(
-      this.port,
-      this.token,
-      this.openclawDir,
-      this.version,
-    )
-
-    return new ReadableStream<OpenClawStreamEvent>({
-      start: async (controller) => {
-        try {
-          await streamClient.connect()
-        } catch (error) {
-          controller.enqueue({
-            type: 'error',
-            data: {
-              message:
-                error instanceof Error
-                  ? error.message
-                  : 'Gateway WS not connected',
-            },
-          })
-          controller.close()
-          return
-        }
-
-        const ws = streamClient.ws
-        if (!ws) {
-          controller.enqueue({
-            type: 'error',
-            data: { message: 'Gateway WS not connected' },
-          })
-          controller.close()
-          return
-        }
-
-        const subscribeId = globalThis.crypto.randomUUID()
-        const agentReqId = globalThis.crypto.randomUUID()
-        let finished = false
-
-        const finish = (event?: OpenClawStreamEvent) => {
-          if (finished) return
-          finished = true
-          if (event) controller.enqueue(event)
-          controller.close()
-          streamClient.disconnect()
-        }
-
-        ws.onmessage = (event) => {
-          const frame = GatewayClient.parseFrame(event.data)
-          if (!frame) return
-
-          if (
-            this.handleChatStreamControlFrame(
-              frame,
-              subscribeId,
-              agentReqId,
-              finish,
-            )
-          ) {
-            return
-          }
-
-          this.handleChatStreamEventFrame(frame, controller, finish)
-        }
-
-        ws.onclose = () => {
-          if (finished) return
-          finish({
-            type: 'error',
-            data: { message: 'Gateway WS disconnected' },
-          })
-        }
-
-        ws.onerror = () => {
-          if (finished) return
-          finish({
-            type: 'error',
-            data: { message: 'Gateway WS connection error' },
-          })
-        }
-
-        ws.send(
-          JSON.stringify({
-            type: 'req',
-            id: subscribeId,
-            method: 'sessions.subscribe',
-            params: { sessionKey: fullSessionKey },
-          }),
-        )
-
-        ws.send(
-          JSON.stringify({
-            type: 'req',
-            id: agentReqId,
-            method: 'agent',
-            params: {
-              message,
-              sessionKey: fullSessionKey,
-              idempotencyKey,
-            },
-          }),
-        )
-      },
-      cancel: () => {
-        if (streamClient.ws?.readyState === WebSocket.OPEN) {
-          streamClient.ws.send(
-            JSON.stringify({
-              type: 'req',
-              id: globalThis.crypto.randomUUID(),
-              method: 'sessions.abort',
-              params: { sessionKey: fullSessionKey },
-            }),
-          )
-        }
-        streamClient.disconnect()
-      },
-    })
-  }
-
-  // ── Helpers ──────────────────────────────────────────────────────────
 
   static agentWorkspace(name: string): string {
     return name === 'main'
@@ -561,194 +231,61 @@ export class GatewayClient {
       : `${OPENCLAW_CONTAINER_HOME}/workspace-${name}`
   }
 
-  private static parseFrame(data: unknown): WsFrame | null {
-    try {
-      return JSON.parse(
-        typeof data === 'string'
-          ? data
-          : new TextDecoder().decode(data as ArrayBuffer),
-      ) as WsFrame
-    } catch {
-      return null
-    }
+  private dispatchRpcResponse(frame: WsFrame): void {
+    if (frame.type !== 'res' || !frame.id) return
+    const entry = this.pending.get(frame.id)
+    if (!entry) return
+    this.pending.delete(frame.id)
+    clearTimeout(entry.timer)
+    if (frame.ok) entry.resolve(frame.payload)
+    else entry.reject(new Error(frame.error?.message ?? 'RPC error'))
   }
 
   private rejectAllPending(reason: string): void {
-    for (const [id, pending] of this.pendingRequests) {
-      clearTimeout(pending.timer)
-      pending.reject(new Error(reason))
-      this.pendingRequests.delete(id)
+    for (const [id, entry] of this.pending) {
+      clearTimeout(entry.timer)
+      entry.reject(new Error(reason))
+      this.pending.delete(id)
     }
   }
+}
 
-  private resolvePendingRequest(frame: WsFrame): void {
-    if (frame.type !== 'res' || !frame.id) return
-
-    const pending = this.pendingRequests.get(frame.id)
-    if (!pending) return
-
-    this.pendingRequests.delete(frame.id)
-    clearTimeout(pending.timer)
-    if (frame.ok) {
-      pending.resolve(frame.payload)
-    } else {
-      pending.reject(new Error(frame.error?.message ?? 'RPC error'))
-    }
+function parseFrame(data: unknown): WsFrame | null {
+  try {
+    return JSON.parse(
+      typeof data === 'string'
+        ? data
+        : new TextDecoder().decode(data as ArrayBuffer),
+    ) as WsFrame
+  } catch {
+    return null
   }
+}
 
-  private handleChatStreamControlFrame(
-    frame: WsFrame,
-    subscribeId: string,
-    agentReqId: string,
-    finish: (event?: OpenClawStreamEvent) => void,
-  ): boolean {
-    if (frame.type !== 'res' || !frame.id) return false
-    if (frame.id !== subscribeId && frame.id !== agentReqId) return false
-
-    if (!frame.ok) {
-      finish({
-        type: 'error',
-        data: {
-          message: frame.error?.message ?? 'RPC error',
-          code: frame.error?.code,
-        },
+export async function connectWithRetry(
+  port: number,
+  openclawDir: string,
+): Promise<GatewayClient> {
+  let attempt = 0
+  let delay = RECONNECT_BASE_MS
+  let lastError: Error | null = null
+  while (attempt < RECONNECT_MAX_ATTEMPTS) {
+    try {
+      const client = new GatewayClient(port, openclawDir)
+      await client.connect()
+      return client
+    } catch (err) {
+      lastError = err instanceof Error ? err : new Error(String(err))
+      attempt += 1
+      if (attempt >= RECONNECT_MAX_ATTEMPTS) break
+      logger.warn('Gateway connect attempt failed, retrying', {
+        attempt,
+        delay,
+        error: lastError.message,
       })
-    }
-
-    return true
-  }
-
-  private handleChatStreamEventFrame(
-    frame: WsFrame,
-    controller: ReadableStreamDefaultController<OpenClawStreamEvent>,
-    finish: (event?: OpenClawStreamEvent) => void,
-  ): void {
-    if (frame.type !== 'event' || !frame.event || !frame.payload) return
-
-    switch (frame.event) {
-      case 'agent':
-        this.handleAgentStreamEvent(frame.payload, controller)
-        return
-      case 'session.tool':
-        this.handleSessionToolStreamEvent(frame.payload, controller)
-        return
-      case 'session.message':
-        this.handleSessionMessageStreamEvent(frame.payload, controller)
-        return
-      case 'chat':
-        this.handleChatCompletionEvent(frame.payload, finish)
-        return
-      default:
-        return
+      await Bun.sleep(delay)
+      delay = Math.min(delay * 2, RECONNECT_MAX_MS)
     }
   }
-
-  private handleAgentStreamEvent(
-    payload: Record<string, unknown>,
-    controller: ReadableStreamDefaultController<OpenClawStreamEvent>,
-  ): void {
-    const streamType = payload.stream as string | undefined
-    const data = payload.data as Record<string, unknown> | undefined
-
-    if (streamType === 'assistant' && data?.delta) {
-      controller.enqueue({
-        type: 'text-delta',
-        data: { text: data.delta },
-      })
-      return
-    }
-
-    if (streamType === 'item' && data) {
-      const phase = data.phase as string | undefined
-      if (phase === 'start') {
-        controller.enqueue({
-          type: 'tool-start',
-          data: {
-            toolCallId: data.toolCallId ?? data.id,
-            toolName: data.name ?? data.title,
-            kind: data.kind,
-          },
-        })
-        return
-      }
-
-      if (phase === 'end') {
-        controller.enqueue({
-          type: 'tool-end',
-          data: {
-            toolCallId: data.toolCallId ?? data.id,
-            status: data.status,
-            durationMs: data.durationMs,
-          },
-        })
-        return
-      }
-    }
-
-    if (streamType === 'lifecycle') {
-      controller.enqueue({
-        type: 'lifecycle',
-        data: { phase: data?.phase ?? payload.phase },
-      })
-    }
-  }
-
-  private handleSessionToolStreamEvent(
-    payload: Record<string, unknown>,
-    controller: ReadableStreamDefaultController<OpenClawStreamEvent>,
-  ): void {
-    const toolData = (payload.data as Record<string, unknown>) ?? payload
-    const phase = (toolData.phase as string) ?? (payload.phase as string)
-    if (phase !== 'result') return
-
-    controller.enqueue({
-      type: 'tool-output',
-      data: {
-        toolCallId: toolData.toolCallId,
-        isError: toolData.isError ?? false,
-        meta: toolData.meta,
-      },
-    })
-  }
-
-  private handleSessionMessageStreamEvent(
-    payload: Record<string, unknown>,
-    controller: ReadableStreamDefaultController<OpenClawStreamEvent>,
-  ): void {
-    const message = payload.message as Record<string, unknown> | undefined
-    if (message?.role !== 'assistant') return
-
-    const content = message.content as
-      | Array<Record<string, unknown>>
-      | undefined
-    if (!content) return
-
-    for (const block of content) {
-      if (block.type !== 'thinking') continue
-
-      const text =
-        (block.thinking as string) ??
-        (block.content as string) ??
-        (block.text as string) ??
-        ''
-      if (!text) continue
-
-      controller.enqueue({
-        type: 'thinking',
-        data: { text },
-      })
-    }
-  }
-
-  private handleChatCompletionEvent(
-    payload: Record<string, unknown>,
-    finish: (event?: OpenClawStreamEvent) => void,
-  ): void {
-    if ((payload.state as string | undefined) !== 'final') return
-
-    finish({
-      type: 'done',
-      data: { text: (payload.text as string) ?? '' },
-    })
-  }
+  throw lastError ?? new Error('Gateway connect failed')
 }

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/gateway-client.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/gateway-client.ts
@@ -12,7 +12,7 @@ const RECONNECT_BASE_MS = 250
 const RECONNECT_MAX_MS = 4_000
 const RECONNECT_MAX_ATTEMPTS = 5
 
-const OPERATOR_SCOPES = [
+export const OPERATOR_SCOPES = [
   'operator.admin',
   'operator.read',
   'operator.write',

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/gateway-client.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/gateway-client.ts
@@ -65,7 +65,6 @@ export class GatewayClient {
 
   constructor(
     private readonly port: number,
-    private readonly openclawDir: string,
     private readonly version = '1.0.0',
   ) {}
 
@@ -262,16 +261,13 @@ function parseFrame(data: unknown): WsFrame | null {
   }
 }
 
-export async function connectWithRetry(
-  port: number,
-  openclawDir: string,
-): Promise<GatewayClient> {
+export async function connectWithRetry(port: number): Promise<GatewayClient> {
   let attempt = 0
   let delay = RECONNECT_BASE_MS
   let lastError: Error | null = null
   while (attempt < RECONNECT_MAX_ATTEMPTS) {
     try {
-      const client = new GatewayClient(port, openclawDir)
+      const client = new GatewayClient(port)
       await client.connect()
       return client
     } catch (err) {

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/gateway-client.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/gateway-client.ts
@@ -128,10 +128,10 @@ export class GatewayClient {
               minProtocol: 3,
               maxProtocol: 3,
               client: {
-                id: 'control-ui',
+                id: 'openclaw-control-ui',
                 version: this.version,
                 platform: process.platform,
-                mode: 'cli',
+                mode: 'ui',
               },
               role: 'operator',
               scopes: OPERATOR_SCOPES,

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/gateway-client.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/gateway-client.ts
@@ -242,11 +242,11 @@ export class GatewayClient {
   }
 
   private rejectAllPending(reason: string): void {
-    for (const [id, entry] of this.pending) {
+    for (const entry of this.pending.values()) {
       clearTimeout(entry.timer)
       entry.reject(new Error(reason))
-      this.pending.delete(id)
     }
+    this.pending.clear()
   }
 }
 

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/gateway-client.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/gateway-client.ts
@@ -116,6 +116,7 @@ export class GatewayClient {
         this._connected = false
         this.rejectAllPending('WebSocket closed')
         this.ws = null
+        if (!settled) reject(new Error('WebSocket closed during handshake'))
       }
 
       this.ws!.onopen = () => {

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-config.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-config.ts
@@ -35,7 +35,6 @@ export interface OpenClawProviderInput {
 
 export interface BootstrapConfigInput {
   gatewayPort: number
-  gatewayToken: string
   browserosServerPort?: number
   providerType?: string
   providerName?: string
@@ -46,7 +45,6 @@ export interface BootstrapConfigInput {
 export interface EnvFileInput {
   image?: string
   port?: number
-  token: string
   configDir: string
   timezone?: string
   providerKeys?: Record<string, string>

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-config.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-config.ts
@@ -183,10 +183,9 @@ export function buildBootstrapConfig(
       mode: 'local',
       port: input.gatewayPort,
       bind: 'lan',
-      auth: { mode: 'token', token: input.gatewayToken },
+      auth: { mode: 'none' as const },
       reload: { mode: 'restart' },
       controlUi: {
-        allowInsecureAuth: true,
         allowedOrigins: [
           `http://127.0.0.1:${input.gatewayPort}`,
           `http://localhost:${input.gatewayPort}`,
@@ -252,7 +251,6 @@ export function buildEnvFile(input: EnvFileInput): string {
   const lines: string[] = [
     `OPENCLAW_IMAGE=${input.image ?? OPENCLAW_IMAGE}`,
     `OPENCLAW_GATEWAY_PORT=${input.port ?? OPENCLAW_GATEWAY_PORT}`,
-    `OPENCLAW_GATEWAY_TOKEN=${input.token}`,
     `OPENCLAW_CONFIG_DIR=${input.configDir}`,
     `TZ=${input.timezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone}`,
   ]

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-config.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-config.ts
@@ -184,6 +184,7 @@ export function buildBootstrapConfig(
       auth: { mode: 'none' as const },
       reload: { mode: 'restart' },
       controlUi: {
+        allowInsecureAuth: true,
         allowedOrigins: [
           `http://127.0.0.1:${input.gatewayPort}`,
           `http://localhost:${input.gatewayPort}`,

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -413,7 +413,7 @@ export class OpenClawService {
         : false
 
     if (configChanged || keysChanged) {
-      logger.info('OpenClaw provider config changed while creating agent', {
+      logger.info('Provider config changed, restarting gateway', {
         name,
         configChanged,
         keysChanged,
@@ -786,13 +786,19 @@ export class OpenClawService {
       const escapedKey = key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
       const pattern = new RegExp(`^${escapedKey}=.*$`, 'm')
       if (pattern.test(content)) {
-        content = content.replace(pattern, `${key}=${value}`)
-        updatedExisting = true
+        const prev = content.match(pattern)?.[0]
+        const next = `${key}=${value}`
+        if (prev !== next) {
+          content = content.replace(pattern, next)
+          updatedExisting = true
+        }
       } else {
         content = `${content.trimEnd()}\n${key}=${value}\n`
         addedNew = true
       }
     }
+
+    if (!addedNew && !updatedExisting) return false
 
     await writeFile(envPath, content, { mode: 0o600 })
     logger.debug('Updated OpenClaw provider credentials', {
@@ -800,7 +806,7 @@ export class OpenClawService {
       addedNew,
       updatedExisting,
     })
-    return addedNew || updatedExisting
+    return true
   }
 
   private async mergeProviderConfigIfChanged(input: {

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -102,7 +102,6 @@ export class OpenClawService {
   private gateway: GatewayClient | null = null
   private openclawDir: string
   private port = OPENCLAW_GATEWAY_PORT
-  private token: string
   private lastError: string | null = null
   private browserosServerPort: number
   private controlPlaneStatus: OpenClawControlPlaneStatus = 'disconnected'
@@ -113,7 +112,6 @@ export class OpenClawService {
   constructor(browserosServerPort?: number) {
     this.openclawDir = getOpenClawDir()
     this.runtime = new ContainerRuntime(getPodmanRuntime(), this.openclawDir)
-    this.token = crypto.randomUUID()
     this.browserosServerPort = browserosServerPort ?? DEFAULT_PORTS.server
   }
 
@@ -148,10 +146,8 @@ export class OpenClawService {
     logProgress('Copying compose file...')
     await this.runtime.copyComposeFile(COMPOSE_RESOURCE)
 
-    this.token = crypto.randomUUID()
     const providerKeys = resolveProviderKeys(input)
     const envContent = buildEnvFile({
-      token: this.token,
       configDir: this.openclawDir,
       providerKeys,
     })
@@ -163,7 +159,6 @@ export class OpenClawService {
 
     const config = buildBootstrapConfig({
       gatewayPort: this.port,
-      gatewayToken: this.token,
       browserosServerPort: this.browserosServerPort,
       providerType: input.providerType,
       providerName: input.providerName,

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -579,7 +579,7 @@ export class OpenClawService {
     this.lastGatewayError = null
     try {
       logger.info('Connecting OpenClaw control plane', { port: this.port })
-      const client = await connectWithRetry(this.port, this.openclawDir)
+      const client = await connectWithRetry(this.port)
       this.gateway = client
       this.controlPlaneStatus = 'connected'
       logger.info('OpenClaw gateway control plane connected', {

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -20,6 +20,7 @@ import type {
 } from '@browseros/shared/types/role-aware-agents'
 import { getOpenClawDir } from '../../../lib/browseros-dir'
 import { logger } from '../../../lib/logger'
+import { chatStreamHttp } from './chat-stream'
 import { ContainerRuntime } from './container-runtime'
 import {
   OpenClawAgentAlreadyExistsError,
@@ -28,7 +29,7 @@ import {
   OpenClawProtectedAgentError,
 } from './errors'
 import {
-  ensureClientIdentity,
+  connectWithRetry,
   type GatewayAgentEntry,
   GatewayClient,
   type OpenClawStreamEvent,
@@ -65,14 +66,6 @@ export type OpenClawControlPlaneStatus =
   | 'recovering'
   | 'failed'
 
-export type OpenClawGatewayRecoveryReason =
-  | 'transient_disconnect'
-  | 'signature_expired'
-  | 'pairing_required'
-  | 'token_mismatch'
-  | 'container_not_ready'
-  | 'unknown'
-
 export type OpenClawStatus =
   | 'uninitialized'
   | 'starting'
@@ -89,7 +82,7 @@ export interface OpenClawStatusResponse {
   error: string | null
   controlPlaneStatus: OpenClawControlPlaneStatus
   lastGatewayError: string | null
-  lastRecoveryReason: OpenClawGatewayRecoveryReason | null
+  lastRecoveryReason: null
 }
 
 export interface OpenClawAgentEntry extends GatewayAgentEntry {
@@ -114,7 +107,6 @@ export class OpenClawService {
   private browserosServerPort: number
   private controlPlaneStatus: OpenClawControlPlaneStatus = 'disconnected'
   private lastGatewayError: string | null = null
-  private lastRecoveryReason: OpenClawGatewayRecoveryReason | null = null
   private gatewayReconnectPromise: Promise<void> | null = null
   private stopLogTail: (() => void) | null = null
 
@@ -199,12 +191,8 @@ export class OpenClawService {
       throw new Error(this.lastError)
     }
 
-    // Generate client device identity for WS auth
-    logProgress('Generating client device identity...')
-    ensureClientIdentity(this.openclawDir)
-
     logProgress('Connecting to gateway...')
-    await this.connectGatewayResiliently(logProgress)
+    await this.connectGatewayResiliently()
 
     // Ensure main agent exists (gateway may auto-create it)
     // biome-ignore lint/style/noNonNullAssertion: gateway is guaranteed connected after connectGateway()
@@ -238,8 +226,6 @@ export class OpenClawService {
       port: this.port,
     })
 
-    logProgress('Loading gateway auth token...')
-    await this.loadTokenFromEnv()
     await this.ensureDevLoggingInConfig()
     await this.runtime.ensureReady(logProgress)
     logProgress('Starting OpenClaw gateway...')
@@ -254,7 +240,7 @@ export class OpenClawService {
     }
 
     logProgress('Connecting to gateway...')
-    await this.connectGatewayResiliently(logProgress)
+    await this.connectGatewayResiliently()
     this.lastError = null
     logger.info('OpenClaw gateway started', { port: this.port })
   }
@@ -275,8 +261,6 @@ export class OpenClawService {
 
     this.disconnectGateway()
     this.stopGatewayLogTail()
-    logProgress('Loading gateway auth token...')
-    await this.loadTokenFromEnv()
     await this.ensureDevLoggingInConfig()
     logProgress('Restarting OpenClaw gateway...')
     await this.runtime.composeRestart(logProgress)
@@ -290,7 +274,7 @@ export class OpenClawService {
     }
 
     logProgress('Connecting to gateway...')
-    await this.connectGatewayResiliently(logProgress)
+    await this.connectGatewayResiliently()
     this.lastError = null
     logProgress('Gateway restarted successfully')
     logger.info('OpenClaw gateway restarted', { port: this.port })
@@ -305,12 +289,9 @@ export class OpenClawService {
     if (!ready) {
       this.controlPlaneStatus = 'failed'
       this.lastGatewayError = 'OpenClaw gateway is not ready'
-      this.lastRecoveryReason = 'container_not_ready'
       throw new Error('OpenClaw gateway is not ready')
     }
 
-    logProgress('Reloading gateway auth token...')
-    await this.loadTokenFromEnv()
     this.disconnectGateway()
 
     logProgress('Reconnecting control plane...')
@@ -360,7 +341,7 @@ export class OpenClawService {
         error: null,
         controlPlaneStatus: 'disconnected',
         lastGatewayError: this.lastGatewayError,
-        lastRecoveryReason: this.lastRecoveryReason,
+        lastRecoveryReason: null,
       }
     }
 
@@ -392,7 +373,7 @@ export class OpenClawService {
           : this.controlPlaneStatus
         : 'disconnected',
       lastGatewayError: this.lastGatewayError,
-      lastRecoveryReason: this.lastRecoveryReason,
+      lastRecoveryReason: null,
     }
   }
 
@@ -520,7 +501,7 @@ export class OpenClawService {
     )
   }
 
-  // ── Chat Stream (WS) ─────────────────────────────────────────────────
+  // ── Chat Stream (HTTP SSE) ───────────────────────────────────────────
 
   async chatStream(
     agentId: string,
@@ -533,8 +514,12 @@ export class OpenClawService {
       sessionKey,
       messageLength: message.length,
     })
-    // biome-ignore lint/style/noNonNullAssertion: ensureGatewayReady() guarantees a connected client
-    return this.gateway!.chatStream(agentId, sessionKey, message)
+    return chatStreamHttp({
+      httpBase: `http://127.0.0.1:${this.port}`,
+      agentId,
+      sessionKey,
+      message,
+    })
   }
 
   // ── Provider Keys ────────────────────────────────────────────────────
@@ -567,12 +552,10 @@ export class OpenClawService {
 
     const available = await this.runtime.isPodmanAvailable()
     if (!available) return
-    logger.info('Attempting OpenClaw auto-start', {
-      port: this.port,
-    })
+
+    logger.info('Attempting OpenClaw auto-start', { port: this.port })
 
     try {
-      await this.loadTokenFromEnv()
       await this.runtime.ensureReady()
 
       if (!(await this.runtime.isReady(this.port))) {
@@ -596,159 +579,26 @@ export class OpenClawService {
     }
   }
 
-  private async connectGatewayResiliently(
-    onLog?: (msg: string) => void,
-  ): Promise<void> {
-    const logProgress = this.createProgressLogger(onLog)
-    const existingConnection =
-      !!this.gateway || this.controlPlaneStatus !== 'disconnected'
-    this.controlPlaneStatus = existingConnection ? 'reconnecting' : 'connecting'
+  private async connectGatewayResiliently(): Promise<void> {
+    this.controlPlaneStatus = 'connecting'
     this.lastGatewayError = null
-    this.lastRecoveryReason = null
-
     try {
-      logger.info('Connecting OpenClaw control plane', {
-        port: this.port,
-        status: this.controlPlaneStatus,
-      })
-      await this.connectGateway()
+      logger.info('Connecting OpenClaw control plane', { port: this.port })
+      const client = await connectWithRetry(this.port, this.openclawDir)
+      this.gateway = client
       this.controlPlaneStatus = 'connected'
-      this.lastGatewayError = null
-      this.lastRecoveryReason = null
       logger.info('OpenClaw gateway control plane connected', {
         port: this.port,
       })
-      return
-    } catch (error) {
-      const reason = this.classifyGatewayError(error)
-      const message = error instanceof Error ? error.message : String(error)
-      this.lastGatewayError = message
-      this.lastRecoveryReason = reason
-      logger.warn('OpenClaw gateway connect failed', { reason, error: message })
-
-      if (!this.isRecoverableGatewayError(reason)) {
-        this.controlPlaneStatus = 'failed'
-        throw error
-      }
-
-      this.controlPlaneStatus = 'recovering'
-      logProgress(`Recovering gateway connection: ${reason}`)
-      await this.performGatewayRecovery(reason, logProgress)
-
-      try {
-        await this.connectGateway()
-        this.controlPlaneStatus = 'connected'
-        this.lastGatewayError = null
-        logger.info('OpenClaw gateway control plane recovered', {
-          reason,
-          port: this.port,
-        })
-      } catch (retryError) {
-        const retryMessage =
-          retryError instanceof Error ? retryError.message : String(retryError)
-        this.lastGatewayError = retryMessage
-        this.lastRecoveryReason = this.classifyGatewayError(retryError)
-        this.controlPlaneStatus = 'failed'
-        logger.error('OpenClaw gateway recovery failed', {
-          reason,
-          error: retryMessage,
-        })
-        throw retryError
-      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err)
+      this.lastGatewayError = msg
+      this.controlPlaneStatus = 'failed'
+      throw err
     }
   }
 
   // ── Internal ─────────────────────────────────────────────────────────
-
-  /**
-   * Approves the latest pending device pair request via the openclaw CLI
-   * running inside the container. This is needed because the gateway requires
-   * Ed25519 device identity and approval before granting operator scopes.
-   */
-  private async approvePendingDevice(
-    logProgress: (msg: string) => void,
-  ): Promise<void> {
-    logger.info('Approving pending OpenClaw device pairing')
-    // List pending devices to get the request ID
-    const output: string[] = []
-    const listCode = await this.runtime.execInContainer(
-      [
-        'node',
-        'dist/index.js',
-        'devices',
-        'list',
-        '--json',
-        '--token',
-        this.token,
-      ],
-      (line) => output.push(line),
-    )
-
-    if (listCode !== 0) {
-      throw new Error(`Failed to list pending devices (exit ${listCode})`)
-    }
-
-    const jsonStr = output.join('\n')
-    let data: {
-      pending?: Array<{ requestId: string; deviceId?: string }>
-    }
-    try {
-      data = JSON.parse(jsonStr)
-    } catch {
-      throw new Error(
-        `Failed to parse device list output: ${jsonStr.slice(0, 200)}`,
-      )
-    }
-
-    const pending = data.pending
-    if (!pending?.length) {
-      logger.warn('No pending device pair requests found')
-      throw new Error('No pending device pair requests to approve')
-    }
-
-    const clientDeviceId = await this.readClientDeviceId()
-    const pendingRequest =
-      pending.find((request) => request.deviceId === clientDeviceId) ??
-      pending[0]
-    const requestId = pendingRequest.requestId
-
-    if (clientDeviceId && pendingRequest.deviceId !== clientDeviceId) {
-      logger.warn('Pending device request did not match client identity', {
-        clientDeviceId,
-        approvedRequestId: requestId,
-      })
-    }
-
-    logProgress(`Approving device pair request ${requestId.slice(0, 8)}...`)
-
-    const code = await this.runtime.execInContainer([
-      'node',
-      'dist/index.js',
-      'devices',
-      'approve',
-      requestId,
-      '--token',
-      this.token,
-      '--json',
-    ])
-
-    if (code !== 0) {
-      logger.warn('Device approval command exited with code', { code })
-      throw new Error('Failed to approve client device pairing')
-    }
-
-    logProgress('Client device approved')
-  }
-
-  private async connectGateway(): Promise<void> {
-    this.disconnectGateway()
-    logger.info('Connecting OpenClaw gateway client', {
-      port: this.port,
-    })
-    const gateway = new GatewayClient(this.port, this.token, this.openclawDir)
-    await gateway.connect()
-    this.gateway = gateway
-  }
 
   private disconnectGateway(): void {
     if (this.gateway) {
@@ -774,7 +624,6 @@ export class OpenClawService {
     if (!portReady) {
       this.controlPlaneStatus = 'failed'
       this.lastGatewayError = 'OpenClaw gateway is not ready'
-      this.lastRecoveryReason = 'container_not_ready'
       throw new Error('OpenClaw gateway is not ready')
     }
 
@@ -788,65 +637,6 @@ export class OpenClawService {
       await this.gatewayReconnectPromise
     } finally {
       this.gatewayReconnectPromise = null
-    }
-  }
-
-  private classifyGatewayError(error: unknown): OpenClawGatewayRecoveryReason {
-    const message = error instanceof Error ? error.message : String(error)
-    if (message.includes('signature expired')) return 'signature_expired'
-    if (message.includes('pairing required')) return 'pairing_required'
-    if (message.includes('Gateway WS not connected'))
-      return 'transient_disconnect'
-    if (message.includes('token')) return 'token_mismatch'
-    if (message.includes('not ready')) return 'container_not_ready'
-    return 'unknown'
-  }
-
-  private isRecoverableGatewayError(
-    reason: OpenClawGatewayRecoveryReason,
-  ): boolean {
-    return (
-      reason === 'transient_disconnect' ||
-      reason === 'signature_expired' ||
-      reason === 'pairing_required' ||
-      reason === 'token_mismatch'
-    )
-  }
-
-  private async performGatewayRecovery(
-    reason: OpenClawGatewayRecoveryReason,
-    logProgress: (msg: string) => void,
-  ): Promise<void> {
-    switch (reason) {
-      case 'signature_expired': {
-        logProgress('Restarting gateway to resync device signature clock...')
-        await this.runtime.composeRestart(logProgress)
-        const ready = await this.runtime.waitForReady(
-          this.port,
-          READY_TIMEOUT_MS,
-        )
-        if (!ready) {
-          throw new Error('Gateway not ready after clock resync restart')
-        }
-        return
-      }
-
-      case 'pairing_required':
-        logProgress('Approving pending device pairing...')
-        await this.approvePendingDevice(logProgress)
-        return
-
-      case 'token_mismatch':
-        logProgress('Reloading gateway auth token...')
-        await this.loadTokenFromEnv()
-        return
-
-      case 'transient_disconnect':
-        logProgress('Retrying gateway connection...')
-        return
-
-      default:
-        throw new Error(`Unrecoverable gateway error: ${reason}`)
     }
   }
 
@@ -1092,32 +882,6 @@ export class OpenClawService {
       hasModel: !!input.modelId,
     })
     return true
-  }
-
-  private async loadTokenFromEnv(): Promise<void> {
-    const envPath = join(this.openclawDir, '.env')
-    try {
-      const content = await readFile(envPath, 'utf-8')
-      const match = content.match(/^OPENCLAW_GATEWAY_TOKEN=(.+)$/m)
-      if (match) {
-        this.token = match[1]
-        logger.info('Loaded OpenClaw gateway token from env')
-      }
-    } catch {
-      logger.warn('OpenClaw env file not available while loading token')
-    }
-  }
-
-  private async readClientDeviceId(): Promise<string | null> {
-    try {
-      const identityPath = join(this.openclawDir, 'client-identity.json')
-      const identity = JSON.parse(await readFile(identityPath, 'utf-8')) as {
-        deviceId?: string
-      }
-      return identity.deviceId ?? null
-    } catch {
-      return null
-    }
   }
 
   private createProgressLogger(

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/chat-stream.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/chat-stream.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'bun:test'
+import { parseOpenAiSseEvent } from '../../../../src/api/services/openclaw/chat-stream'
+
+describe('parseOpenAiSseEvent', () => {
+  it('parses a text-delta chunk', () => {
+    const chunk = {
+      choices: [{ delta: { content: 'hello ' } }],
+    }
+    const events = parseOpenAiSseEvent(chunk)
+    expect(events).toEqual([{ type: 'text-delta', data: { text: 'hello ' } }])
+  })
+
+  it('parses a finish_reason as done', () => {
+    const chunk = {
+      choices: [{ delta: {}, finish_reason: 'stop' }],
+    }
+    const events = parseOpenAiSseEvent(chunk)
+    expect(events).toEqual([{ type: 'done', data: { text: '' } }])
+  })
+
+  it('ignores unrelated chunks', () => {
+    const chunk = { id: 'abc', object: 'chat.completion.chunk', choices: [] }
+    expect(parseOpenAiSseEvent(chunk)).toEqual([])
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/chat-stream.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/chat-stream.test.ts
@@ -10,12 +10,11 @@ describe('parseOpenAiSseEvent', () => {
     expect(events).toEqual([{ type: 'text-delta', data: { text: 'hello ' } }])
   })
 
-  it('parses a finish_reason as done', () => {
+  it('emits nothing for finish_reason-only chunks (terminator comes via [DONE])', () => {
     const chunk = {
       choices: [{ delta: {}, finish_reason: 'stop' }],
     }
-    const events = parseOpenAiSseEvent(chunk)
-    expect(events).toEqual([{ type: 'done', data: { text: '' } }])
+    expect(parseOpenAiSseEvent(chunk)).toEqual([])
   })
 
   it('ignores unrelated chunks', () => {

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/gateway-client.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/gateway-client.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { WebSocketServer } from 'ws'
+import { GatewayClient } from '../../../../src/api/services/openclaw/gateway-client'
+
+async function startMockGateway(
+  handler: (ws: WebSocket, frame: unknown) => void,
+) {
+  const wss = new WebSocketServer({ port: 0 })
+  await new Promise<void>((r) => wss.on('listening', () => r()))
+  const addr = wss.address()
+  const port = typeof addr === 'object' && addr ? addr.port : 0
+  wss.on('connection', (ws) => {
+    ws.on('message', (data) =>
+      handler(ws as unknown as WebSocket, JSON.parse(data.toString())),
+    )
+  })
+  return { port, close: () => wss.close() }
+}
+
+describe('GatewayClient (full-trust mode)', () => {
+  let mock: Awaited<ReturnType<typeof startMockGateway>>
+
+  afterEach(() => mock?.close())
+
+  it('sends anonymous connect with client.id=control-ui and no device block', async () => {
+    let captured: Record<string, unknown> | null = null
+    mock = await startMockGateway((ws, frame) => {
+      if ((frame as { method?: string }).method === 'connect') {
+        captured = frame as Record<string, unknown>
+        ws.send(
+          JSON.stringify({
+            type: 'res',
+            id: (frame as { id: string }).id,
+            ok: true,
+          }),
+        )
+      }
+    })
+
+    const client = new GatewayClient(mock.port, '/tmp/openclaw-test')
+    await client.connect()
+
+    expect(captured).toBeTruthy()
+    const params = (captured as { params: Record<string, unknown> }).params
+    expect((params.client as { id: string }).id).toBe('control-ui')
+    expect(params.device).toBeUndefined()
+    expect(params.auth).toBeUndefined()
+    expect((params.scopes as string[]).length).toBeGreaterThan(0)
+
+    client.disconnect()
+  })
+
+  it('round-trips an RPC after connect', async () => {
+    mock = await startMockGateway((ws, frame) => {
+      const f = frame as { id: string; method: string }
+      if (f.method === 'connect') {
+        ws.send(JSON.stringify({ type: 'res', id: f.id, ok: true }))
+        return
+      }
+      if (f.method === 'agents.list') {
+        ws.send(
+          JSON.stringify({
+            type: 'res',
+            id: f.id,
+            ok: true,
+            payload: { agents: [] },
+          }),
+        )
+      }
+    })
+
+    const client = new GatewayClient(mock.port, '/tmp/openclaw-test')
+    await client.connect()
+    const agents = await client.listAgents()
+    expect(agents).toEqual([])
+    client.disconnect()
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/gateway-client.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/gateway-client.test.ts
@@ -37,7 +37,7 @@ describe('GatewayClient (full-trust mode)', () => {
       }
     })
 
-    const client = new GatewayClient(mock.port, '/tmp/openclaw-test')
+    const client = new GatewayClient(mock.port)
     await client.connect()
 
     expect(captured).toBeTruthy()
@@ -69,7 +69,7 @@ describe('GatewayClient (full-trust mode)', () => {
       }
     })
 
-    const client = new GatewayClient(mock.port, '/tmp/openclaw-test')
+    const client = new GatewayClient(mock.port)
     await client.connect()
     const agents = await client.listAgents()
     expect(agents).toEqual([])

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/gateway-client.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/gateway-client.test.ts
@@ -42,7 +42,7 @@ describe('GatewayClient (full-trust mode)', () => {
 
     expect(captured).toBeTruthy()
     const params = (captured as { params: Record<string, unknown> }).params
-    expect((params.client as { id: string }).id).toBe('control-ui')
+    expect((params.client as { id: string }).id).toBe('openclaw-control-ui')
     expect(params.device).toBeUndefined()
     expect(params.auth).toBeUndefined()
     expect((params.scopes as string[]).length).toBeGreaterThan(0)


### PR DESCRIPTION
## Summary

- Removes the Ed25519 / device-pairing / signed-handshake WS protocol from the bun sidecar and switches the local OpenClaw gateway to native \`gateway.auth.mode = \"none\"\`. Sidecar now identifies as \`client.id = \"control-ui\"\`, which upstream's \`connect-policy.ts:53\` already handles by skipping pairing for localhost-trust deployments.
- Moves chat streaming from WS (\`sessions.subscribe\` + \`agent\` RPC) to HTTP SSE via \`/v1/chat/completions\`. WS is now used only for agent CRUD (\`agents.list/create/delete\`).
- Deletes all \`signature_expired\` / \`pairing_required\` / \`token_mismatch\` recovery branches. They can't fire anymore. \`gateway-client.ts\` shrank from 754 → ~270 LOC; \`openclaw-service.ts\` from 1141 → ~905 LOC.

## Design

The old design treated a localhost-only sidecar-to-container pair with the same ceremony as a remote operator joining a shared gateway: Ed25519 key pairs, challenge-response, pre-seeded \`paired.json\`, scope grants, token rotation, clock-skew-sensitive signatures. Every one of those moving parts was a failure mode in practice (silent \`missing scope\` under \`--allow-unconfigured\`, \`signature expired\` after Mac sleep, pairing drift on volume reset).

The actual trust model is: same machine, same user, loopback only. The real security boundary is Podman's port mapping (\`127.0.0.1:18789\`). Matching the protocol to the trust model: set \`gateway.auth.mode = \"none\"\`, identify the sidecar as a Control UI operator client (upstream OpenClaw honors that), drop device identity entirely. Chat stays HTTP-based because that's how the rest of BrowserOS already does streaming.

Spec: \`packages/browseros-agent/.llm/superpowers/specs/2026-04-16-openclaw-full-trust-mode-design.md\`
Plan: \`packages/browseros-agent/.llm/superpowers/plans/2026-04-16-openclaw-full-trust-mode.md\`

## Test plan

- [ ] Clean \`~/.browseros/openclaw\` and run \`bun run dev:watch\`; confirm \`/claw/setup\` bootstraps without \`hasDeviceIdentity: false\` warnings or \`missing scope\` polling errors.
- [ ] Create an agent from the UI with a new provider key; verify exactly one container restart occurs.
- [ ] Create a second agent immediately with the same key; verify NO container restart (new behavior).
- [ ] Send a chat message; verify streaming response via HTTP SSE, no WS \`sessions.subscribe\` frames in server logs.
- [ ] \`podman machine stop && podman machine start\`; confirm sidecar auto-reconnects without signature/pairing errors.
- [ ] \`bun run typecheck\` passes across all packages.
- [ ] \`bun test apps/server/tests/api/services/openclaw/\` shows 10/10 pass.