### PR TITLE
fix(agent): clarify upstream provider rate-limit errors

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ChatError.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ChatError.tsx
@@ -3,6 +3,7 @@ import type { FC } from 'react'
 import { useMemo } from 'react'
 import { ShareForCredits } from '@/components/referral/ShareForCredits'
 import { Button } from '@/components/ui/button'
+import type { ProviderType } from '@/lib/llm-providers/types'
 
 const SURVEY_DIRECTIONS = [
   'competitor',
@@ -13,6 +14,44 @@ const SURVEY_DIRECTIONS = [
 
 function pickRandomDirection(): string {
   return SURVEY_DIRECTIONS[Math.floor(Math.random() * SURVEY_DIRECTIONS.length)]
+}
+
+const PROVIDER_DISPLAY_NAMES: Record<ProviderType, string> = {
+  anthropic: 'Anthropic',
+  openai: 'OpenAI',
+  'openai-compatible': 'OpenAI-compatible',
+  google: 'Google',
+  openrouter: 'OpenRouter',
+  azure: 'Azure OpenAI',
+  ollama: 'Ollama',
+  lmstudio: 'LM Studio',
+  bedrock: 'AWS Bedrock',
+  browseros: 'BrowserOS',
+  moonshot: 'Moonshot',
+  'chatgpt-pro': 'ChatGPT Pro',
+  'github-copilot': 'GitHub Copilot',
+  'qwen-code': 'Qwen Code',
+}
+
+const UPSTREAM_RATE_LIMIT_PATTERNS = [
+  'usage limit',
+  'rate limit',
+  'rate-limit',
+  'quota',
+  '429',
+  'too many requests',
+  'insufficient_quota',
+]
+
+function getProviderDisplayName(providerType?: string): string {
+  if (providerType && providerType in PROVIDER_DISPLAY_NAMES) {
+    return PROVIDER_DISPLAY_NAMES[providerType as ProviderType]
+  }
+  return 'your provider'
+}
+
+function stripRetryPrefix(message: string): string {
+  return message.replace(/^Failed after \d+ attempts?\.\s*Last error:\s*/i, '')
 }
 
 interface ChatErrorProps {
@@ -30,6 +69,8 @@ function parseErrorMessage(
   isRateLimit?: boolean
   isCreditsExhausted?: boolean
   isConnectionError?: boolean
+  isUpstreamRateLimit?: boolean
+  providerName?: string
 } {
   const isBrowserosProvider = providerType === 'browseros'
 
@@ -70,6 +111,24 @@ function parseErrorMessage(
     }
   }
 
+  // Detect rate limits from non-BrowserOS upstream providers. Users were
+  // confused that a quota/429 from OpenAI/Anthropic/etc. looked like a
+  // BrowserOS-imposed limit.
+  if (!isBrowserosProvider && providerType) {
+    const lower = message.toLowerCase()
+    const matchesRateLimit = UPSTREAM_RATE_LIMIT_PATTERNS.some((p) =>
+      lower.includes(p),
+    )
+    if (matchesRateLimit) {
+      const stripped = stripRetryPrefix(message).trim()
+      return {
+        text: stripped || message,
+        isUpstreamRateLimit: true,
+        providerName: getProviderDisplayName(providerType),
+      }
+    }
+  }
+
   let text = message
   try {
     const parsed = JSON.parse(message)
@@ -91,8 +150,15 @@ export const ChatError: FC<ChatErrorProps> = ({
   onRetry,
   providerType,
 }) => {
-  const { text, url, isRateLimit, isCreditsExhausted, isConnectionError } =
-    parseErrorMessage(error.message, providerType)
+  const {
+    text,
+    url,
+    isRateLimit,
+    isCreditsExhausted,
+    isConnectionError,
+    isUpstreamRateLimit,
+    providerName,
+  } = parseErrorMessage(error.message, providerType)
 
   const surveyUrl = useMemo(
     () =>
@@ -101,6 +167,11 @@ export const ChatError: FC<ChatErrorProps> = ({
   )
 
   const getTitle = () => {
+    if (isUpstreamRateLimit) {
+      return providerName && providerName !== 'your provider'
+        ? `${providerName} rate limit reached`
+        : 'Upstream rate limit reached'
+    }
     if (isRateLimit) return 'Daily limit reached'
     if (isConnectionError) return 'Connection failed'
     return 'Something went wrong'
@@ -113,6 +184,14 @@ export const ChatError: FC<ChatErrorProps> = ({
         <span className="font-medium text-sm">{getTitle()}</span>
       </div>
       <p className="text-center text-destructive text-xs">{text}</p>
+      {isUpstreamRateLimit && (
+        <p className="text-center text-muted-foreground text-xs">
+          This is a limit from{' '}
+          <span className="font-medium">{providerName}</span>
+          {' — your configured model provider — not BrowserOS. Check your '}
+          provider's dashboard for quota, usage, or billing details.
+        </p>
+      )}
       {isConnectionError && url && (
         <a
           href={url}

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ChatError.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ChatError.tsx
@@ -33,12 +33,12 @@ const PROVIDER_DISPLAY_NAMES: Record<ProviderType, string> = {
   'qwen-code': 'Qwen Code',
 }
 
-const UPSTREAM_RATE_LIMIT_PATTERNS = [
+const UPSTREAM_RATE_LIMIT_PATTERNS: Array<string | RegExp> = [
   'usage limit',
   'rate limit',
   'rate-limit',
   'quota',
-  '429',
+  /\b429\b/,
   'too many requests',
   'insufficient_quota',
 ]
@@ -117,10 +117,14 @@ function parseErrorMessage(
   if (!isBrowserosProvider && providerType) {
     const lower = message.toLowerCase()
     const matchesRateLimit = UPSTREAM_RATE_LIMIT_PATTERNS.some((p) =>
-      lower.includes(p),
+      typeof p === 'string' ? lower.includes(p) : p.test(lower),
     )
     if (matchesRateLimit) {
-      const stripped = stripRetryPrefix(message).trim()
+      let stripped = stripRetryPrefix(message).trim()
+      try {
+        const parsed = JSON.parse(stripped)
+        if (parsed?.error?.message) stripped = parsed.error.message
+      } catch {}
       return {
         text: stripped || message,
         isUpstreamRateLimit: true,


### PR DESCRIPTION
## Summary
- Non-BrowserOS providers (OpenAI, Anthropic, OpenRouter, etc.) returning 429 rendered an opaque "Failed after 3 attempts. Last error: The usage limit has been reached" with a generic "Something went wrong" title — users blamed BrowserOS for limits imposed by their own upstream provider.
- Detect upstream 429s in `parseErrorMessage`, title the error with the provider's display name ("OpenAI rate limit reached"), strip the retry-wrapper noise, show the raw upstream message, and add subtext that explicitly names the provider and excludes BrowserOS.
- Skip BrowserOS-specific remedies (ShareForCredits, daily-limit survey, upgrade CTA) on this path.

## Scope
One file: `packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ChatError.tsx` (+81/−2). Frontend-only. Existing BrowserOS-provider and connection-error paths unchanged.

## Note
There is a sibling PR #733 on `feat/upstream-provider-429-errors` targeting `dev` with an earlier attempt at the same fix. This PR is a fresh implementation against `main`. Decide which to land.

## Test plan
- [ ] Configure OpenAI/Anthropic provider with an exhausted quota key; confirm title shows "`{Provider}` rate limit reached"
- [ ] Confirm body shows raw upstream error (no "Failed after 3 attempts" prefix)
- [ ] Confirm subtext explicitly says "not BrowserOS"
- [ ] Confirm no ShareForCredits, no survey link on the upstream-429 path
- [ ] Confirm "Try again" still works
- [ ] Configure BrowserOS provider, trigger daily limit — verify existing UX unchanged
- [ ] Verify connection error (stop agent server) — existing "Unable to connect" path unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)