### PR TITLE
fix: use separate BrowserOS dir in development

### DIFF
--- a/packages/browseros-agent/apps/server/src/lib/browseros-dir.ts
+++ b/packages/browseros-agent/apps/server/src/lib/browseros-dir.ts
@@ -6,8 +6,19 @@ import { PATHS } from '@browseros/shared/constants/paths'
 import type { ServerDiscoveryConfig } from '@browseros/shared/types/server-config'
 import { logger } from './logger'
 
+const DEV_BROWSEROS_DIR_NAME = '.browseros-dev'
+
 export function getBrowserosDir(): string {
-  return join(homedir(), PATHS.BROWSEROS_DIR_NAME)
+  const dirName =
+    process.env.NODE_ENV === 'development'
+      ? DEV_BROWSEROS_DIR_NAME
+      : PATHS.BROWSEROS_DIR_NAME
+  return join(homedir(), dirName)
+}
+
+export function logDevelopmentBrowserosDir(): void {
+  if (process.env.NODE_ENV !== 'development') return
+  logger.info(`Using development BrowserOS directory: ${getBrowserosDir()}`)
 }
 
 export function getMemoryDir(): string {
@@ -57,6 +68,7 @@ export function removeServerConfigSync(): void {
 }
 
 export async function ensureBrowserosDir(): Promise<void> {
+  logDevelopmentBrowserosDir()
   await mkdir(getMemoryDir(), { recursive: true })
   await mkdir(getSkillsDir(), { recursive: true })
   await mkdir(getBuiltinSkillsDir(), { recursive: true })

--- a/packages/browseros-agent/apps/server/tests/browseros-dir.test.ts
+++ b/packages/browseros-agent/apps/server/tests/browseros-dir.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { PATHS } from '@browseros/shared/constants/paths'
+import {
+  getBrowserosDir,
+  logDevelopmentBrowserosDir,
+} from '../src/lib/browseros-dir'
+import { logger } from '../src/lib/logger'
+
+describe('getBrowserosDir', () => {
+  const originalNodeEnv = process.env.NODE_ENV
+
+  beforeEach(() => {
+    delete process.env.NODE_ENV
+  })
+
+  afterEach(() => {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV
+      return
+    }
+
+    process.env.NODE_ENV = originalNodeEnv
+  })
+
+  it('uses a separate home directory in development', () => {
+    process.env.NODE_ENV = 'development'
+
+    expect(getBrowserosDir()).toBe(join(homedir(), '.browseros-dev'))
+  })
+
+  it('uses the standard home directory outside development', () => {
+    process.env.NODE_ENV = 'test'
+
+    expect(getBrowserosDir()).toBe(join(homedir(), PATHS.BROWSEROS_DIR_NAME))
+  })
+
+  it('logs the resolved development directory path', () => {
+    process.env.NODE_ENV = 'development'
+    const originalInfo = logger.info
+    const info = mock(() => {})
+    logger.info = info
+
+    try {
+      logDevelopmentBrowserosDir()
+
+      expect(info).toHaveBeenCalledWith(
+        `Using development BrowserOS directory: ${join(homedir(), '.browseros-dev')}`,
+      )
+    } finally {
+      logger.info = originalInfo
+    }
+  })
+
+  it('does not log a development directory outside development', () => {
+    process.env.NODE_ENV = 'test'
+    const originalInfo = logger.info
+    const info = mock(() => {})
+    logger.info = info
+
+    try {
+      logDevelopmentBrowserosDir()
+
+      expect(info).not.toHaveBeenCalled()
+    } finally {
+      logger.info = originalInfo
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- Use `~/.browseros-dev` when `NODE_ENV=development` so local dev state does not mix with the production BrowserOS home directory.
- Preserve the existing production path by continuing to use `PATHS.BROWSEROS_DIR_NAME` outside development.
- Log the resolved development BrowserOS directory during startup and cover the behavior with focused regression tests.

## Design
Keep the change local to `apps/server/src/lib/browseros-dir.ts` by branching on `process.env.NODE_ENV` inside `getBrowserosDir()` and emitting a development-only info log during BrowserOS directory initialization. This follows the server's existing development-environment pattern without changing shared constants or adding new config.

## Test plan
- `bun --env-file=.env.development test apps/server/tests/browseros-dir.test.ts`
- `bunx biome check apps/server/src/lib/browseros-dir.ts apps/server/tests/browseros-dir.test.ts`
- `bun run --filter @browseros/server typecheck`
- `bun run test` currently fails in existing unrelated `apps/server/tests/tools/input.test.ts` CDP disconnect/timeouts (`fill`, `click`, `check`, `press_key`).