### PR TITLE
fix(credits): move credits fetch to extension side

### DIFF
--- a/packages/browseros-agent/apps/agent/lib/credits/browseros-id.ts
+++ b/packages/browseros-agent/apps/agent/lib/credits/browseros-id.ts
@@ -1,34 +1,11 @@
 import { getBrowserOSAdapter } from '@/lib/browseros/adapter'
 import { BROWSEROS_PREFS } from '@/lib/browseros/prefs'
 
-const STORAGE_KEY = 'browseros_id'
-
-async function readInstallIdFromPrefs(): Promise<string | null> {
-  try {
-    const adapter = getBrowserOSAdapter()
-    const pref = await adapter.getPref(BROWSEROS_PREFS.INSTALL_ID)
-    if (typeof pref?.value === 'string' && pref.value.length > 0) {
-      return pref.value
-    }
-  } catch {
-    // BrowserOS prefs API not available (non-BrowserOS Chrome)
-  }
-  return null
-}
-
-async function getFallbackId(): Promise<string> {
-  const result = await chrome.storage.local.get(STORAGE_KEY)
-  const existing = result[STORAGE_KEY]
-  if (typeof existing === 'string' && existing.length > 0) {
-    return existing
-  }
-  const id = crypto.randomUUID()
-  await chrome.storage.local.set({ [STORAGE_KEY]: id })
-  return id
-}
-
-export async function getOrCreateBrowserosId(): Promise<string> {
-  const installId = await readInstallIdFromPrefs()
-  if (installId) return installId
-  return getFallbackId()
+// TODO(credits-identity): temporary shim — reuses the BrowserOS metrics
+// install_id as the credits/referral identifier. Replace with a dedicated
+// identity module once we have one.
+export async function getBrowserosId(): Promise<string> {
+  const adapter = getBrowserOSAdapter()
+  const pref = await adapter.getPref(BROWSEROS_PREFS.INSTALL_ID)
+  return pref.value as string
 }

--- a/packages/browseros-agent/apps/agent/lib/credits/browseros-id.ts
+++ b/packages/browseros-agent/apps/agent/lib/credits/browseros-id.ts
@@ -7,5 +7,9 @@ import { BROWSEROS_PREFS } from '@/lib/browseros/prefs'
 export async function getBrowserosId(): Promise<string> {
   const adapter = getBrowserOSAdapter()
   const pref = await adapter.getPref(BROWSEROS_PREFS.INSTALL_ID)
-  return pref.value as string
+  const id = pref.value
+  if (typeof id !== 'string' || id.length === 0) {
+    throw new Error('browseros.metrics_install_id is not set')
+  }
+  return id
 }

--- a/packages/browseros-agent/apps/agent/lib/credits/browseros-id.ts
+++ b/packages/browseros-agent/apps/agent/lib/credits/browseros-id.ts
@@ -1,0 +1,34 @@
+import { getBrowserOSAdapter } from '@/lib/browseros/adapter'
+import { BROWSEROS_PREFS } from '@/lib/browseros/prefs'
+
+const STORAGE_KEY = 'browseros_id'
+
+async function readInstallIdFromPrefs(): Promise<string | null> {
+  try {
+    const adapter = getBrowserOSAdapter()
+    const pref = await adapter.getPref(BROWSEROS_PREFS.INSTALL_ID)
+    if (typeof pref?.value === 'string' && pref.value.length > 0) {
+      return pref.value
+    }
+  } catch {
+    // BrowserOS prefs API not available (non-BrowserOS Chrome)
+  }
+  return null
+}
+
+async function getFallbackId(): Promise<string> {
+  const result = await chrome.storage.local.get(STORAGE_KEY)
+  const existing = result[STORAGE_KEY]
+  if (typeof existing === 'string' && existing.length > 0) {
+    return existing
+  }
+  const id = crypto.randomUUID()
+  await chrome.storage.local.set({ [STORAGE_KEY]: id })
+  return id
+}
+
+export async function getOrCreateBrowserosId(): Promise<string> {
+  const installId = await readInstallIdFromPrefs()
+  if (installId) return installId
+  return getFallbackId()
+}

--- a/packages/browseros-agent/apps/agent/lib/credits/useCredits.ts
+++ b/packages/browseros-agent/apps/agent/lib/credits/useCredits.ts
@@ -1,5 +1,6 @@
+import { EXTERNAL_URLS } from '@browseros/shared/constants/urls'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { getAgentServerUrl } from '@/lib/browseros/helpers'
+import { getOrCreateBrowserosId } from './browseros-id'
 
 export interface CreditsInfo {
   credits: number
@@ -11,11 +12,14 @@ export interface CreditsInfo {
 const CREDITS_QUERY_KEY = ['credits']
 
 async function fetchCredits(): Promise<CreditsInfo> {
-  const baseUrl = await getAgentServerUrl()
-  const response = await fetch(`${baseUrl}/credits`)
+  const browserosId = await getOrCreateBrowserosId()
+  const response = await fetch(
+    `${EXTERNAL_URLS.CREDITS_GATEWAY}/credits/${browserosId}`,
+  )
   if (!response.ok)
     throw new Error(`Failed to fetch credits: ${response.status}`)
-  return response.json()
+  const data = (await response.json()) as CreditsInfo
+  return { ...data, browserosId }
 }
 
 export function useCredits() {

--- a/packages/browseros-agent/apps/agent/lib/credits/useCredits.ts
+++ b/packages/browseros-agent/apps/agent/lib/credits/useCredits.ts
@@ -1,6 +1,6 @@
 import { EXTERNAL_URLS } from '@browseros/shared/constants/urls'
 import { useQuery, useQueryClient } from '@tanstack/react-query'
-import { getOrCreateBrowserosId } from './browseros-id'
+import { getBrowserosId } from './browseros-id'
 
 export interface CreditsInfo {
   credits: number
@@ -12,7 +12,7 @@ export interface CreditsInfo {
 const CREDITS_QUERY_KEY = ['credits']
 
 async function fetchCredits(): Promise<CreditsInfo> {
-  const browserosId = await getOrCreateBrowserosId()
+  const browserosId = await getBrowserosId()
   const response = await fetch(
     `${EXTERNAL_URLS.CREDITS_GATEWAY}/credits/${browserosId}`,
   )

--- a/packages/browseros-agent/apps/server/src/api/routes/credits.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/credits.ts
@@ -25,7 +25,7 @@ export function createCreditsRoutes(deps: CreditsDeps) {
   return new Hono().get('/', async (c) => {
     try {
       const credits = await fetchCredits(gatewayBaseUrl, browserosId)
-      return c.json({ ...credits, browserosId })
+      return c.json(credits)
     } catch (error) {
       logger.error('Failed to fetch credits', {
         error: error instanceof Error ? error.message : String(error),

--- a/packages/browseros-agent/packages/shared/src/constants/urls.ts
+++ b/packages/browseros-agent/packages/shared/src/constants/urls.ts
@@ -20,4 +20,5 @@ export const EXTERNAL_URLS = {
   QWEN_OAUTH_TOKEN: 'https://chat.qwen.ai/api/v1/oauth2/token',
   QWEN_CODE_API: 'https://portal.qwen.ai/v1',
   REFERRAL_SERVICE: 'https://browseros-referral.fly.dev',
+  CREDITS_GATEWAY: 'https://llm.browseros.com',
 } as const


### PR DESCRIPTION
## Summary
- Unblocks the Twitter-share referral flow in production without requiring a BrowserOS binary release.
- Extension now reads `browseros.metrics_install_id` directly and fetches `/credits/{installId}` from `llm.browseros.com`, bypassing the bundled server entirely.
- Reverts the `/credits` server route change from PR #729 (which required a server release to reach users in prod).
- Uses the same `install_id` the server already persists in its SQLite identity — so both sides converge on one ID.

## Why
Production BrowserOS bundles an older server build that doesn't expose `browserosId` in the `/credits` response. Without it, the Share-for-Credits submit button silently no-ops (`!data?.browserosId` gate). Moving identity + credits fetch to the extension ships the fix via extension-only release.

## Test plan
- [ ] Confirm `chrome.browserOS.getPref('browseros.metrics_install_id')` returns the expected UUID in prod BrowserOS
- [ ] Confirm `useCredits()` returns balance + `browserosId` from `llm.browseros.com`
- [ ] Submit a valid tweet via Share-for-Credits → confirm referral service accepts it and balance updates
- [ ] Verify credit badge reflects the new balance after referral

🤖 Generated with [Claude Code](https://claude.com/claude-code)