### PR TITLE
fix: pin OpenClaw image to 2026.4.12

### DIFF
--- a/packages/browseros-agent/apps/server/resources/openclaw-compose.yml
+++ b/packages/browseros-agent/apps/server/resources/openclaw-compose.yml
@@ -1,6 +1,7 @@
 services:
   openclaw-gateway:
-    image: ${OPENCLAW_IMAGE:-ghcr.io/openclaw/openclaw:latest}
+    # Pin away from latest because newer OpenClaw releases regress OpenRouter chat streams.
+    image: ${OPENCLAW_IMAGE:-ghcr.io/openclaw/openclaw:2026.4.12}
     ports:
       - "127.0.0.1:${OPENCLAW_GATEWAY_PORT:-18789}:18789"
     env_file:

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-env.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-env.ts
@@ -7,7 +7,8 @@
 import { join } from 'node:path'
 import { OPENCLAW_GATEWAY_PORT } from '@browseros/shared/constants/openclaw'
 
-const OPENCLAW_IMAGE = 'ghcr.io/openclaw/openclaw:latest'
+// Pin away from latest because newer OpenClaw releases regress OpenRouter chat streams.
+const OPENCLAW_IMAGE = 'ghcr.io/openclaw/openclaw:2026.4.12'
 const STATE_DIR_NAME = '.openclaw'
 
 export function getOpenClawStateDir(openclawDir: string): string {

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw-env.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw-env.test.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { buildComposeEnvFile } from '../../../src/api/services/openclaw/openclaw-env'
+
+describe('buildComposeEnvFile', () => {
+  it('pins the default OpenClaw image to 2026.4.12', () => {
+    expect(
+      buildComposeEnvFile({
+        hostHome: '/tmp/openclaw-home',
+        timezone: 'UTC',
+      }),
+    ).toContain('OPENCLAW_IMAGE=ghcr.io/openclaw/openclaw:2026.4.12')
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-env.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-env.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, expect, it } from 'bun:test'
-import { buildComposeEnvFile } from '../../../src/api/services/openclaw/openclaw-env'
+import { buildComposeEnvFile } from '../../../../src/api/services/openclaw/openclaw-env'
 
 describe('buildComposeEnvFile', () => {
   it('pins the default OpenClaw image to 2026.4.12', () => {
@@ -14,5 +14,15 @@ describe('buildComposeEnvFile', () => {
         timezone: 'UTC',
       }),
     ).toContain('OPENCLAW_IMAGE=ghcr.io/openclaw/openclaw:2026.4.12')
+  })
+
+  it('respects an explicit image override', () => {
+    expect(
+      buildComposeEnvFile({
+        hostHome: '/tmp/openclaw-home',
+        timezone: 'UTC',
+        image: 'ghcr.io/openclaw/openclaw:custom',
+      }),
+    ).toContain('OPENCLAW_IMAGE=ghcr.io/openclaw/openclaw:custom')
   })
 })


### PR DESCRIPTION
## Summary
- Pin the default OpenClaw image to `ghcr.io/openclaw/openclaw:2026.4.12` instead of `latest`
- Update both the compose template fallback and the generated compose env default so runtime startup uses the same pinned image
- Add a focused test covering `buildComposeEnvFile()` and document the reason for the pin inline

## Design
This keeps the change minimal and coherent by updating the two actual default sources that control the gateway container image: the compose template fallback and the env file generated by `buildComposeEnvFile()`. The pin is documented inline because the downgrade is intentional: newer OpenClaw releases regress OpenRouter chat streams, while `2026.4.12` is the known-good image we want BrowserOS to use by default unless an explicit override is supplied.

## Test plan
- `bun test ./tests/api/services/openclaw-env.test.ts`
- `bun run typecheck`
