### PR TITLE
chore: remove bun and ripgrep prod resources

### DIFF
--- a/packages/browseros-agent/scripts/build/config/server-prod-resources.json
+++ b/packages/browseros-agent/scripts/build/config/server-prod-resources.json
@@ -1,60 +1,6 @@
 {
   "resources": [
     {
-      "name": "Bun Runtime - macOS ARM64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/bun/bun-darwin-arm64"
-      },
-      "destination": "resources/bin/third_party/bun",
-      "os": ["macos"],
-      "arch": ["arm64"],
-      "executable": true
-    },
-    {
-      "name": "Bun Runtime - macOS x64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/bun/bun-darwin-x64"
-      },
-      "destination": "resources/bin/third_party/bun",
-      "os": ["macos"],
-      "arch": ["x64"],
-      "executable": true
-    },
-    {
-      "name": "Bun Runtime - Linux ARM64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/bun/bun-linux-arm64"
-      },
-      "destination": "resources/bin/third_party/bun",
-      "os": ["linux"],
-      "arch": ["arm64"],
-      "executable": true
-    },
-    {
-      "name": "Bun Runtime - Linux x64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/bun/bun-linux-x64"
-      },
-      "destination": "resources/bin/third_party/bun",
-      "os": ["linux"],
-      "arch": ["x64"],
-      "executable": true
-    },
-    {
-      "name": "Bun Runtime - Windows x64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/bun/bun-windows-x64.exe"
-      },
-      "destination": "resources/bin/third_party/bun.exe",
-      "os": ["windows"],
-      "arch": ["x64"]
-    },
-    {
       "name": "Podman CLI - macOS ARM64",
       "source": {
         "type": "r2",
@@ -181,60 +127,6 @@
         "key": "third_party/podman/win-sshproxy-windows-x64.exe"
       },
       "destination": "resources/bin/third_party/podman/win-sshproxy.exe",
-      "os": ["windows"],
-      "arch": ["x64"]
-    },
-    {
-      "name": "ripgrep - macOS ARM64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/ripgrep/rg-darwin-arm64"
-      },
-      "destination": "resources/bin/third_party/rg",
-      "os": ["macos"],
-      "arch": ["arm64"],
-      "executable": true
-    },
-    {
-      "name": "ripgrep - macOS x64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/ripgrep/rg-darwin-x64"
-      },
-      "destination": "resources/bin/third_party/rg",
-      "os": ["macos"],
-      "arch": ["x64"],
-      "executable": true
-    },
-    {
-      "name": "ripgrep - Linux ARM64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/ripgrep/rg-linux-arm64"
-      },
-      "destination": "resources/bin/third_party/rg",
-      "os": ["linux"],
-      "arch": ["arm64"],
-      "executable": true
-    },
-    {
-      "name": "ripgrep - Linux x64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/ripgrep/rg-linux-x64"
-      },
-      "destination": "resources/bin/third_party/rg",
-      "os": ["linux"],
-      "arch": ["x64"],
-      "executable": true
-    },
-    {
-      "name": "ripgrep - Windows x64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/ripgrep/rg-windows-x64.exe"
-      },
-      "destination": "resources/bin/third_party/rg.exe",
       "os": ["windows"],
       "arch": ["x64"]
     }


### PR DESCRIPTION
## Summary
- Remove Bun runtime resources from `scripts/build/config/server-prod-resources.json`
- Remove ripgrep resources from `scripts/build/config/server-prod-resources.json`
- Keep the remaining production resource packaging unchanged

## Design
This change updates only the production resource manifest. Because the manifest is strict JSON, the requested temporary "comment out" behavior is implemented by removing the Bun and ripgrep entries from the `resources` array instead of adding invalid comments or new manifest semantics.

## Test Plan
- Load the manifest through `scripts/build/server/manifest.ts` and confirm Bun and ripgrep rules are absent
- Run `bunx biome check scripts/build/config/server-prod-resources.json`
- Run `bun run typecheck`
- Run `bun run test` (currently fails in pre-existing server tests unrelated to this manifest-only change)
