### PR TITLE
fix: package OpenClaw compose resource

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -10,7 +10,7 @@
 
 import { existsSync } from 'node:fs'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
-import { resolve } from 'node:path'
+import { join, resolve } from 'node:path'
 import {
   OPENCLAW_CONTAINER_HOME,
   OPENCLAW_GATEWAY_PORT,
@@ -43,12 +43,22 @@ import { resolveSupportedOpenClawProvider } from './openclaw-provider-map'
 import type { OpenClawStreamEvent } from './openclaw-types'
 import { getPodmanRuntime } from './podman-runtime'
 
-const COMPOSE_RESOURCE = resolve(
+const SOURCE_COMPOSE_RESOURCE = resolve(
   import.meta.dir,
   '../../../../resources/openclaw-compose.yml',
 )
 const READY_TIMEOUT_MS = 30_000
 const AGENT_NAME_PATTERN = /^[a-z][a-z0-9-]*$/
+
+export function resolveComposeResourcePath(resourcesDir?: string): string {
+  if (resourcesDir) {
+    const bundledComposePath = join(resourcesDir, 'openclaw-compose.yml')
+    if (existsSync(bundledComposePath)) {
+      return bundledComposePath
+    }
+  }
+  return SOURCE_COMPOSE_RESOURCE
+}
 
 export type OpenClawControlPlaneStatus =
   | 'disconnected'
@@ -102,12 +112,18 @@ export interface OpenClawProviderUpdateResult {
   modelUpdated: boolean
 }
 
+export interface OpenClawServiceConfig {
+  browserosServerPort?: number
+  resourcesDir?: string
+}
+
 export class OpenClawService {
   private runtime: ContainerRuntime
   private cliClient: OpenClawCliClient
   private bootstrapCliClient: OpenClawCliClient
   private chatClient: OpenClawHttpChatClient
   private openclawDir: string
+  private composeResourcePath: string
   private port = OPENCLAW_GATEWAY_PORT
   private token: string
   private tokenLoaded = false
@@ -118,7 +134,7 @@ export class OpenClawService {
   private lastRecoveryReason: OpenClawGatewayRecoveryReason | null = null
   private stopLogTail: (() => void) | null = null
 
-  constructor(browserosServerPort?: number) {
+  constructor(config: OpenClawServiceConfig = {}) {
     this.openclawDir = getOpenClawDir()
     this.runtime = new ContainerRuntime(getPodmanRuntime(), this.openclawDir)
     this.token = crypto.randomUUID()
@@ -131,7 +147,18 @@ export class OpenClawService {
       this.port,
       async () => this.token,
     )
-    this.browserosServerPort = browserosServerPort ?? DEFAULT_PORTS.server
+    this.composeResourcePath = resolveComposeResourcePath(config.resourcesDir)
+    this.browserosServerPort =
+      config.browserosServerPort ?? DEFAULT_PORTS.server
+  }
+
+  configure(config: OpenClawServiceConfig): void {
+    if (config.browserosServerPort !== undefined) {
+      this.browserosServerPort = config.browserosServerPort
+    }
+    if (config.resourcesDir !== undefined) {
+      this.composeResourcePath = resolveComposeResourcePath(config.resourcesDir)
+    }
   }
 
   // ── Lifecycle ────────────────────────────────────────────────────────
@@ -165,7 +192,7 @@ export class OpenClawService {
     await mkdir(this.getHostWorkspaceDir('main'), { recursive: true })
 
     logProgress('Copying compose file...')
-    await this.runtime.copyComposeFile(COMPOSE_RESOURCE)
+    await this.runtime.copyComposeFile(this.composeResourcePath)
 
     await this.writeComposeEnv()
     logProgress('Generated .env file')
@@ -530,9 +557,8 @@ export class OpenClawService {
   }): Promise<OpenClawProviderUpdateResult> {
     const provider = resolveSupportedOpenClawProvider(input)
     if (provider.model) {
-      await this.applyCliMutation(() =>
-        this.cliClient.setDefaultModel(provider.model!),
-      )
+      const model = provider.model
+      await this.applyCliMutation(() => this.cliClient.setDefaultModel(model))
     }
     const changed = await this.writeStateEnv(provider.envValues)
     if (changed) {
@@ -925,9 +951,19 @@ export class OpenClawService {
 
 let service: OpenClawService | null = null
 
-export function getOpenClawService(
-  browserosServerPort?: number,
+export function configureOpenClawService(
+  config: OpenClawServiceConfig,
 ): OpenClawService {
-  if (!service) service = new OpenClawService(browserosServerPort)
+  if (!service) {
+    service = new OpenClawService(config)
+    return service
+  }
+
+  service.configure(config)
+  return service
+}
+
+export function getOpenClawService(): OpenClawService {
+  if (!service) service = new OpenClawService()
   return service
 }

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -43,7 +43,7 @@ import { resolveSupportedOpenClawProvider } from './openclaw-provider-map'
 import type { OpenClawStreamEvent } from './openclaw-types'
 import { getPodmanRuntime } from './podman-runtime'
 
-const SOURCE_COMPOSE_RESOURCE = resolve(
+export const SOURCE_COMPOSE_RESOURCE = resolve(
   import.meta.dir,
   '../../../../resources/openclaw-compose.yml',
 )
@@ -56,6 +56,10 @@ export function resolveComposeResourcePath(resourcesDir?: string): string {
     if (existsSync(bundledComposePath)) {
       return bundledComposePath
     }
+    logger.warn(
+      'Bundled openclaw-compose.yml not found in resourcesDir, falling back to source tree',
+      { resourcesDir },
+    )
   }
   return SOURCE_COMPOSE_RESOURCE
 }

--- a/packages/browseros-agent/apps/server/src/main.ts
+++ b/packages/browseros-agent/apps/server/src/main.ts
@@ -13,7 +13,10 @@ import fs from 'node:fs'
 import path from 'node:path'
 import { EXIT_CODES } from '@browseros/shared/constants/exit-codes'
 import { createHttpServer } from './api/server'
-import { getOpenClawService } from './api/services/openclaw/openclaw-service'
+import {
+  configureOpenClawService,
+  getOpenClawService,
+} from './api/services/openclaw/openclaw-service'
 import { configurePodmanRuntime } from './api/services/openclaw/podman-runtime'
 import { CdpBackend } from './browser/backends/cdp'
 import { Browser } from './browser/browser'
@@ -123,7 +126,10 @@ export class Application {
     this.logStartupSummary()
     startSkillSync()
 
-    getOpenClawService(this.config.serverPort)
+    configureOpenClawService({
+      browserosServerPort: this.config.serverPort,
+      resourcesDir: path.resolve(this.config.resourcesDir),
+    })
       .tryAutoStart()
       .catch((err) =>
         logger.warn('OpenClaw auto-start failed', {

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-compose-resource.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-compose-resource.test.ts
@@ -1,8 +1,11 @@
 import { afterEach, describe, expect, it } from 'bun:test'
 import { mkdtemp, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join, resolve } from 'node:path'
-import { resolveComposeResourcePath } from '../../../../src/api/services/openclaw/openclaw-service'
+import { join } from 'node:path'
+import {
+  resolveComposeResourcePath,
+  SOURCE_COMPOSE_RESOURCE,
+} from '../../../../src/api/services/openclaw/openclaw-service'
 
 describe('resolveComposeResourcePath', () => {
   let tempDir: string | null = null
@@ -24,8 +27,6 @@ describe('resolveComposeResourcePath', () => {
   })
 
   it('falls back to the source tree when no packaged copy exists', () => {
-    expect(resolveComposeResourcePath(undefined)).toBe(
-      resolve(import.meta.dir, '../../../../resources/openclaw-compose.yml'),
-    )
+    expect(resolveComposeResourcePath(undefined)).toBe(SOURCE_COMPOSE_RESOURCE)
   })
 })

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-compose-resource.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-compose-resource.test.ts
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { resolveComposeResourcePath } from '../../../../src/api/services/openclaw/openclaw-service'
+
+describe('resolveComposeResourcePath', () => {
+  let tempDir: string | null = null
+
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true })
+      tempDir = null
+    }
+  })
+
+  it('prefers the packaged resourcesDir copy when present', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'openclaw-compose-resource-'))
+    const resourcesDir = join(tempDir, 'resources')
+    const composePath = join(resourcesDir, 'openclaw-compose.yml')
+    await Bun.write(composePath, 'services:\n')
+
+    expect(resolveComposeResourcePath(resourcesDir)).toBe(composePath)
+  })
+
+  it('falls back to the source tree when no packaged copy exists', () => {
+    expect(resolveComposeResourcePath(undefined)).toBe(
+      resolve(import.meta.dir, '../../../../resources/openclaw-compose.yml'),
+    )
+  })
+})

--- a/packages/browseros-agent/scripts/build/config/server-prod-resources.json
+++ b/packages/browseros-agent/scripts/build/config/server-prod-resources.json
@@ -1,6 +1,14 @@
 {
   "resources": [
     {
+      "name": "OpenClaw compose file",
+      "source": {
+        "type": "local",
+        "path": "apps/server/resources/openclaw-compose.yml"
+      },
+      "destination": "resources/openclaw-compose.yml"
+    },
+    {
       "name": "Podman CLI - macOS ARM64",
       "source": {
         "type": "r2",

--- a/packages/browseros-agent/scripts/build/server/manifest.ts
+++ b/packages/browseros-agent/scripts/build/server/manifest.ts
@@ -12,9 +12,12 @@ function validateRule(rule: ResourceRule): void {
   if (!rule.name || rule.name.trim().length === 0) {
     throw new Error('Manifest rule is missing name')
   }
-  if (!rule.source.key || !rule.destination) {
+  const hasSourcePath =
+    (rule.source.type === 'r2' && rule.source.key) ||
+    (rule.source.type === 'local' && rule.source.path)
+  if (!hasSourcePath || !rule.destination) {
     throw new Error(
-      `Manifest rule ${rule.name} is missing source key or destination`,
+      `Manifest rule ${rule.name} is missing source path or destination`,
     )
   }
 }
@@ -24,16 +27,21 @@ function parseSource(raw: unknown): ResourceRule['source'] {
     throw new Error('Manifest source must be an object')
   }
   const source = raw as Record<string, unknown>
-  if (source.type !== 'r2') {
-    throw new Error(
-      `Unsupported source type in manifest: ${String(source.type)}`,
-    )
+  if (source.type === 'r2') {
+    const key = source.key
+    if (typeof key !== 'string' || key.length === 0) {
+      throw new Error('Manifest source key is required')
+    }
+    return { type: 'r2', key }
   }
-  const key = source.key
-  if (typeof key !== 'string' || key.length === 0) {
-    throw new Error('Manifest source key is required')
+  if (source.type === 'local') {
+    const path = source.path
+    if (typeof path !== 'string' || path.length === 0) {
+      throw new Error('Manifest source path is required')
+    }
+    return { type: 'local', path }
   }
-  return { type: 'r2', key }
+  throw new Error(`Unsupported source type in manifest: ${String(source.type)}`)
 }
 
 function parseRule(raw: unknown): ResourceRule {

--- a/packages/browseros-agent/scripts/build/server/orchestrator.ts
+++ b/packages/browseros-agent/scripts/build/server/orchestrator.ts
@@ -34,17 +34,28 @@ export async function runProdResourceBuild(argv: string[]): Promise<void> {
     { ci: args.ci },
   )
 
+  const manifestPath = resolve(rootDir, args.manifestPath)
+  if (!existsSync(manifestPath)) {
+    throw new Error(`Manifest not found: ${manifestPath}`)
+  }
+  const manifest = loadManifest(manifestPath)
+
   if (args.ci) {
     const distRoot = getDistProdRoot()
     const localArtifacts = []
 
     for (const binary of compiled) {
       log.step(`Packaging ${binary.target.name}`)
+      const rules = getTargetRules(manifest, binary.target).filter(
+        (rule) => rule.source.type === 'local',
+      )
       const staged = await stageCompiledArtifact(
         distRoot,
         binary.binaryPath,
         binary.target,
         buildConfig.version,
+        rules,
+        rootDir,
       )
       localArtifacts.push(staged)
       log.success(`Packaged ${binary.target.id}`)
@@ -58,12 +69,6 @@ export async function runProdResourceBuild(argv: string[]): Promise<void> {
     return
   }
 
-  const manifestPath = resolve(rootDir, args.manifestPath)
-  if (!existsSync(manifestPath)) {
-    throw new Error(`Manifest not found: ${manifestPath}`)
-  }
-
-  const manifest = loadManifest(manifestPath)
   const distRoot = getDistProdRoot()
   const r2 = buildConfig.r2
   if (!r2) {
@@ -76,13 +81,14 @@ export async function runProdResourceBuild(argv: string[]): Promise<void> {
     for (const binary of compiled) {
       const rules = getTargetRules(manifest, binary.target)
       log.step(
-        `Staging ${binary.target.name} (${rules.length} download rule(s))`,
+        `Staging ${binary.target.name} (${rules.length} resource rule(s))`,
       )
       const staged = await stageTargetArtifact(
         distRoot,
         binary.binaryPath,
         binary.target,
         rules,
+        rootDir,
         client,
         r2,
         buildConfig.version,

--- a/packages/browseros-agent/scripts/build/server/stage.test.ts
+++ b/packages/browseros-agent/scripts/build/server/stage.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { loadManifest } from './manifest'
+import { stageCompiledArtifact } from './stage'
+import type { BuildTarget } from './types'
+
+const TARGET: BuildTarget = {
+  id: 'darwin-arm64',
+  name: 'macOS arm64',
+  os: 'macos',
+  arch: 'arm64',
+  bunTarget: 'bun-darwin-arm64-modern',
+  serverBinaryName: 'browseros-server-darwin-arm64',
+}
+
+describe('server artifact staging', () => {
+  let tempDir: string | null = null
+
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true })
+      tempDir = null
+    }
+  })
+
+  it('loads local resource rules from the manifest', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'browseros-stage-test-'))
+    const manifestPath = join(tempDir, 'manifest.json')
+    await writeFile(
+      manifestPath,
+      JSON.stringify({
+        resources: [
+          {
+            name: 'OpenClaw compose file',
+            source: {
+              type: 'local',
+              path: 'apps/server/resources/openclaw-compose.yml',
+            },
+            destination: 'resources/openclaw-compose.yml',
+          },
+        ],
+      }),
+    )
+
+    expect(loadManifest(manifestPath)).toEqual({
+      resources: [
+        {
+          name: 'OpenClaw compose file',
+          source: {
+            type: 'local',
+            path: 'apps/server/resources/openclaw-compose.yml',
+          },
+          destination: 'resources/openclaw-compose.yml',
+          executable: false,
+        },
+      ],
+    })
+  })
+
+  it('copies local resource files into the packaged artifact', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'browseros-stage-test-'))
+    const distRoot = join(tempDir, 'dist')
+    const compiledBinaryPath = join(tempDir, 'browseros-server')
+    const sourceRoot = join(tempDir, 'repo')
+    const composeSourcePath = join(
+      sourceRoot,
+      'apps/server/resources/openclaw-compose.yml',
+    )
+    await writeFile(compiledBinaryPath, '#!/bin/sh\n')
+    await Bun.write(composeSourcePath, 'services:\n')
+
+    const staged = await stageCompiledArtifact(
+      distRoot,
+      compiledBinaryPath,
+      TARGET,
+      '1.2.3',
+      [
+        {
+          name: 'OpenClaw compose file',
+          source: {
+            type: 'local',
+            path: 'apps/server/resources/openclaw-compose.yml',
+          },
+          destination: 'resources/openclaw-compose.yml',
+        },
+      ],
+      sourceRoot,
+    )
+
+    expect(
+      await readFile(
+        join(staged.resourcesDir, 'openclaw-compose.yml'),
+        'utf-8',
+      ),
+    ).toBe('services:\n')
+  })
+})

--- a/packages/browseros-agent/scripts/build/server/stage.ts
+++ b/packages/browseros-agent/scripts/build/server/stage.ts
@@ -104,6 +104,7 @@ async function stageLocalRule(
     throw new Error(`Expected local source rule, got ${rule.source.type}`)
   }
 
+  await mkdir(dirname(destinationPath), { recursive: true })
   const sourcePath = isAbsolute(rule.source.path)
     ? rule.source.path
     : resolve(sourceRoot, rule.source.path)

--- a/packages/browseros-agent/scripts/build/server/stage.ts
+++ b/packages/browseros-agent/scripts/build/server/stage.ts
@@ -1,5 +1,5 @@
 import { chmod, cp, mkdir, rm } from 'node:fs/promises'
-import { dirname, isAbsolute, join, relative } from 'node:path'
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 
 import type { S3Client } from '@aws-sdk/client-s3'
 
@@ -75,13 +75,39 @@ function resolveDestination(rootDir: string, destination: string): string {
 
 async function stageRule(
   rootDir: string,
+  sourceRoot: string,
   rule: ResourceRule,
   target: BuildTarget,
   client: S3Client,
   r2: R2Config,
 ): Promise<void> {
   const destinationPath = resolveDestination(rootDir, rule.destination)
-  await downloadObjectToFile(client, r2, rule.source.key, destinationPath)
+  await mkdir(dirname(destinationPath), { recursive: true })
+
+  if (rule.source.type === 'local') {
+    await stageLocalRule(destinationPath, sourceRoot, rule, target)
+  } else {
+    await downloadObjectToFile(client, r2, rule.source.key, destinationPath)
+    if (rule.executable && target.os !== 'windows') {
+      await chmod(destinationPath, 0o755)
+    }
+  }
+}
+
+async function stageLocalRule(
+  destinationPath: string,
+  sourceRoot: string,
+  rule: ResourceRule,
+  target: BuildTarget,
+): Promise<void> {
+  if (rule.source.type !== 'local') {
+    throw new Error(`Expected local source rule, got ${rule.source.type}`)
+  }
+
+  const sourcePath = isAbsolute(rule.source.path)
+    ? rule.source.path
+    : resolve(sourceRoot, rule.source.path)
+  await cp(sourcePath, destinationPath)
 
   if (rule.executable && target.os !== 'windows') {
     await chmod(destinationPath, 0o755)
@@ -93,6 +119,7 @@ export async function stageTargetArtifact(
   compiledBinaryPath: string,
   target: BuildTarget,
   rules: ResourceRule[],
+  sourceRoot: string,
   client: S3Client,
   r2: R2Config,
   version: string,
@@ -100,7 +127,7 @@ export async function stageTargetArtifact(
   const rootDir = await createArtifactRoot(distRoot, compiledBinaryPath, target)
 
   for (const rule of rules) {
-    await stageRule(rootDir, rule, target, client, r2)
+    await stageRule(rootDir, sourceRoot, rule, target, client, r2)
   }
 
   return finalizeArtifact(rootDir, target, version)
@@ -111,7 +138,22 @@ export async function stageCompiledArtifact(
   compiledBinaryPath: string,
   target: BuildTarget,
   version: string,
+  rules: ResourceRule[] = [],
+  sourceRoot = process.cwd(),
 ): Promise<StagedArtifact> {
   const rootDir = await createArtifactRoot(distRoot, compiledBinaryPath, target)
+
+  for (const rule of rules) {
+    if (rule.source.type !== 'local') {
+      continue
+    }
+    await stageLocalRule(
+      resolveDestination(rootDir, rule.destination),
+      sourceRoot,
+      rule,
+      target,
+    )
+  }
+
   return finalizeArtifact(rootDir, target, version)
 }

--- a/packages/browseros-agent/scripts/build/server/types.ts
+++ b/packages/browseros-agent/scripts/build/server/types.ts
@@ -40,10 +40,17 @@ export interface BuildConfig {
   r2?: R2Config
 }
 
-export interface ResourceSource {
+export interface R2ResourceSource {
   type: 'r2'
   key: string
 }
+
+export interface LocalResourceSource {
+  type: 'local'
+  path: string
+}
+
+export type ResourceSource = R2ResourceSource | LocalResourceSource
 
 export interface ResourceRule {
   name: string


### PR DESCRIPTION
## Summary
- package `apps/server/resources/openclaw-compose.yml` into the server artifact so production builds include the OpenClaw compose file
- resolve the compose file from the packaged `resourcesDir` at runtime, with a source-tree fallback for development
- add regression coverage for local manifest resources and packaged compose path resolution

## Design
The fix treats `openclaw-compose.yml` as a repo-owned local resource instead of an R2-hosted vendor blob. The server artifact manifest and staging pipeline now support `local` resources, the default production resource manifest stages the compose file into `resources/openclaw-compose.yml`, and `OpenClawService` is configured with the server `resourcesDir` so packaged builds read the bundled compose file while development still falls back to the source path.

## Test plan
- `bun test scripts/build/server/stage.test.ts apps/server/tests/api/services/openclaw/openclaw-compose-resource.test.ts apps/server/tests/api/services/openclaw/openclaw-service.test.ts`
- `bun run typecheck`
- `bun run build:server --target darwin-arm64`
