### PR TITLE
feat(openclaw): user-supplied Podman binary path override

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -1,5 +1,7 @@
 import {
   AlertCircle,
+  ChevronDown,
+  ChevronRight,
   Cpu,
   Loader2,
   MessageSquare,
@@ -41,6 +43,7 @@ import {
   useOpenClawAgents,
   useOpenClawMutations,
   useOpenClawStatus,
+  usePodmanOverrides,
 } from './useOpenClaw'
 
 const CONTROL_PLANE_COPY: Record<
@@ -223,6 +226,138 @@ const ProviderSelector: FC<ProviderSelectorProps> = ({
         the container and never leaves your machine.
       </p>
     </div>
+  )
+}
+
+interface PodmanOverridesCardProps {
+  variant: 'inline' | 'standalone'
+}
+
+const PodmanOverridesCard: FC<PodmanOverridesCardProps> = ({ variant }) => {
+  const { overrides, loading, saving, error, saveOverrides, clearOverrides } =
+    usePodmanOverrides()
+
+  const [value, setValue] = useState('')
+  const [touched, setTouched] = useState(false)
+  const [collapsed, setCollapsed] = useState(variant === 'standalone')
+  const [localError, setLocalError] = useState<string | null>(null)
+
+  useEffect(() => {
+    if (!touched && overrides) setValue(overrides.podmanPath ?? '')
+  }, [overrides, touched])
+
+  const handleSave = async () => {
+    const trimmed = value.trim()
+    if (!trimmed) return
+    setLocalError(null)
+    try {
+      await saveOverrides(trimmed)
+      setTouched(false)
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const handleClear = async () => {
+    setLocalError(null)
+    try {
+      await clearOverrides()
+      setValue('')
+      setTouched(false)
+    } catch (err) {
+      setLocalError(err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  const hasOverride = !!overrides?.podmanPath
+  const effective = overrides?.effectivePodmanPath ?? null
+  const inlineErrorMessage = localError ?? error?.message ?? null
+
+  const body = (
+    <div className="space-y-3">
+      <div className="space-y-1">
+        <label
+          htmlFor={`podman-path-${variant}`}
+          className="font-medium text-sm"
+        >
+          Podman binary path
+        </label>
+        <Input
+          id={`podman-path-${variant}`}
+          value={value}
+          onChange={(event) => {
+            setTouched(true)
+            setValue(event.target.value)
+          }}
+          placeholder="/opt/homebrew/bin/podman"
+          spellCheck={false}
+          autoCapitalize="none"
+          autoCorrect="off"
+        />
+        <p className="text-muted-foreground text-xs">
+          Install Podman yourself (e.g. <code>brew install podman</code>) and
+          paste the absolute path to the binary. Restart the gateway after
+          saving.
+        </p>
+      </div>
+
+      {effective && (
+        <p className="text-muted-foreground text-xs">
+          Currently using: <code className="break-all">{effective}</code>
+        </p>
+      )}
+
+      {inlineErrorMessage && (
+        <p className="text-destructive text-xs">{inlineErrorMessage}</p>
+      )}
+
+      <div className="flex flex-wrap gap-2">
+        <Button
+          size="sm"
+          onClick={handleSave}
+          disabled={saving || loading || !value.trim()}
+        >
+          {saving ? <Loader2 className="mr-2 size-4 animate-spin" /> : null}
+          Save
+        </Button>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={handleClear}
+          disabled={saving || loading || !hasOverride}
+        >
+          Clear
+        </Button>
+      </div>
+    </div>
+  )
+
+  if (variant === 'inline') {
+    return (
+      <div className="mt-3 rounded-md border bg-background p-3">
+        <p className="mb-2 font-medium text-sm">Use your own Podman</p>
+        {body}
+      </div>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader
+        className="cursor-pointer py-3"
+        onClick={() => setCollapsed((prev) => !prev)}
+      >
+        <CardTitle className="flex items-center gap-2 text-base">
+          {collapsed ? (
+            <ChevronRight className="size-4" />
+          ) : (
+            <ChevronDown className="size-4" />
+          )}
+          Advanced: Podman binary path
+        </CardTitle>
+      </CardHeader>
+      {!collapsed && <CardContent className="pt-0">{body}</CardContent>}
+    </Card>
   )
 }
 
@@ -552,6 +687,7 @@ export const AgentsPage: FC = () => {
                 Restart Gateway
               </Button>
             </div>
+            <PodmanOverridesCard variant="inline" />
           </AlertDescription>
         </Alert>
       )}
@@ -571,6 +707,9 @@ export const AgentsPage: FC = () => {
             {status.podmanAvailable && (
               <Button onClick={() => setSetupOpen(true)}>Set Up Now</Button>
             )}
+            <div className="w-full max-w-md">
+              <PodmanOverridesCard variant="inline" />
+            </div>
           </CardContent>
         </Card>
       )}
@@ -613,6 +752,9 @@ export const AgentsPage: FC = () => {
               >
                 Restart Gateway
               </Button>
+            </div>
+            <div className="w-full max-w-md">
+              <PodmanOverridesCard variant="inline" />
             </div>
           </CardContent>
         </Card>
@@ -684,6 +826,8 @@ export const AgentsPage: FC = () => {
           )}
         </div>
       )}
+
+      <PodmanOverridesCard variant="standalone" />
 
       <Dialog open={setupOpen} onOpenChange={setSetupOpen}>
         <DialogContent>

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/useOpenClaw.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/useOpenClaw.ts
@@ -59,7 +59,13 @@ export function getModelDisplayName(model: unknown): string | undefined {
 export const OPENCLAW_QUERY_KEYS = {
   status: 'openclaw-status',
   agents: 'openclaw-agents',
+  podmanOverrides: 'openclaw-podman-overrides',
 } as const
+
+export interface PodmanOverrides {
+  podmanPath: string | null
+  effectivePodmanPath: string
+}
 
 async function clawFetch<T>(
   baseUrl: string,
@@ -238,6 +244,50 @@ export function useOpenClawMutations() {
     creating: createMutation.isPending,
     deleting: deleteMutation.isPending,
     reconnecting: reconnectMutation.isPending,
+  }
+}
+
+export function usePodmanOverrides() {
+  const {
+    baseUrl,
+    isLoading: urlLoading,
+    error: urlError,
+  } = useAgentServerUrl()
+  const queryClient = useQueryClient()
+
+  const query = useQuery<PodmanOverrides, Error>({
+    queryKey: [OPENCLAW_QUERY_KEYS.podmanOverrides, baseUrl],
+    queryFn: () =>
+      clawFetch<PodmanOverrides>(baseUrl as string, '/podman-overrides'),
+    enabled: !!baseUrl && !urlLoading,
+  })
+
+  const saveMutation = useMutation({
+    mutationFn: async (podmanPath: string | null) =>
+      clawFetch<PodmanOverrides>(baseUrl as string, '/podman-overrides', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ podmanPath }),
+      }),
+    onSuccess: async () => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: [OPENCLAW_QUERY_KEYS.podmanOverrides],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [OPENCLAW_QUERY_KEYS.status],
+        }),
+      ])
+    },
+  })
+
+  return {
+    overrides: query.data ?? null,
+    loading: query.isLoading || urlLoading,
+    error: (query.error ?? urlError) as Error | null,
+    saving: saveMutation.isPending,
+    saveOverrides: (podmanPath: string) => saveMutation.mutateAsync(podmanPath),
+    clearOverrides: () => saveMutation.mutateAsync(null),
   }
 }
 

--- a/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
@@ -7,7 +7,7 @@
  * Thin layer delegating to OpenClawService.
  */
 
-import { existsSync } from 'node:fs'
+import { accessSync, existsSync, constants as fsConstants } from 'node:fs'
 import path from 'node:path'
 import { OPENCLAW_GATEWAY_PORT } from '@browseros/shared/constants/openclaw'
 import { Hono } from 'hono'
@@ -41,6 +41,11 @@ function getPodmanOverrideValidationError(body: {
   }
   if (!existsSync(body.podmanPath)) {
     return `File does not exist: ${body.podmanPath}`
+  }
+  try {
+    accessSync(body.podmanPath, fsConstants.X_OK)
+  } catch {
+    return `File is not executable: ${body.podmanPath}`
   }
   return null
 }

--- a/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
@@ -29,6 +29,22 @@ function getCreateAgentValidationError(body: { name?: string }): string | null {
   return null
 }
 
+function getPodmanOverrideValidationError(body: {
+  podmanPath?: string | null
+}): string | null {
+  if (body.podmanPath === null) return null
+  if (typeof body.podmanPath !== 'string' || !body.podmanPath.trim()) {
+    return 'podmanPath must be a non-empty absolute path or null'
+  }
+  if (!path.isAbsolute(body.podmanPath)) {
+    return 'podmanPath must be an absolute path'
+  }
+  if (!existsSync(body.podmanPath)) {
+    return `File does not exist: ${body.podmanPath}`
+  }
+  return null
+}
+
 export function createOpenClawRoutes() {
   return new Hono()
     .get('/status', async (c) => {
@@ -304,23 +320,9 @@ export function createOpenClawRoutes() {
 
     .post('/podman-overrides', async (c) => {
       const body = await c.req.json<{ podmanPath: string | null }>()
-
-      if (body.podmanPath !== null) {
-        if (typeof body.podmanPath !== 'string' || !body.podmanPath.trim()) {
-          return c.json(
-            { error: 'podmanPath must be a non-empty absolute path or null' },
-            400,
-          )
-        }
-        if (!path.isAbsolute(body.podmanPath)) {
-          return c.json({ error: 'podmanPath must be an absolute path' }, 400)
-        }
-        if (!existsSync(body.podmanPath)) {
-          return c.json(
-            { error: `File does not exist: ${body.podmanPath}` },
-            400,
-          )
-        }
+      const validationError = getPodmanOverrideValidationError(body)
+      if (validationError) {
+        return c.json({ error: validationError }, 400)
       }
 
       try {

--- a/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
@@ -7,6 +7,8 @@
  * Thin layer delegating to OpenClawService.
  */
 
+import { existsSync } from 'node:fs'
+import path from 'node:path'
 import { OPENCLAW_GATEWAY_PORT } from '@browseros/shared/constants/openclaw'
 import { Hono } from 'hono'
 import { stream } from 'hono/streaming'
@@ -285,6 +287,53 @@ export function createOpenClawRoutes() {
           return c.json({ error: err.message }, 400)
         }
         const message = err instanceof Error ? err.message : String(err)
+        return c.json({ error: message }, 500)
+      }
+    })
+
+    .get('/podman-overrides', async (c) => {
+      try {
+        const overrides = await getOpenClawService().getPodmanOverrides()
+        return c.json(overrides)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        logger.error('Podman overrides read failed', { error: message })
+        return c.json({ error: message }, 500)
+      }
+    })
+
+    .post('/podman-overrides', async (c) => {
+      const body = await c.req.json<{ podmanPath: string | null }>()
+
+      if (body.podmanPath !== null) {
+        if (typeof body.podmanPath !== 'string' || !body.podmanPath.trim()) {
+          return c.json(
+            { error: 'podmanPath must be a non-empty absolute path or null' },
+            400,
+          )
+        }
+        if (!path.isAbsolute(body.podmanPath)) {
+          return c.json({ error: 'podmanPath must be an absolute path' }, 400)
+        }
+        if (!existsSync(body.podmanPath)) {
+          return c.json(
+            { error: `File does not exist: ${body.podmanPath}` },
+            400,
+          )
+        }
+      }
+
+      try {
+        logger.info('OpenClaw podman override requested', {
+          podmanPath: body.podmanPath,
+        })
+        const result = await getOpenClawService().applyPodmanOverrides({
+          podmanPath: body.podmanPath,
+        })
+        return c.json(result)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        logger.error('Podman overrides apply failed', { error: message })
         return c.json({ error: message }, 500)
       }
     })

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -655,6 +655,7 @@ export class OpenClawService {
   }
 
   private rebuildRuntimeClients(): void {
+    this.stopGatewayLogTail()
     this.runtime = new ContainerRuntime(getPodmanRuntime(), this.openclawDir)
     this.cliClient = new OpenClawCliClient(this.runtime)
     this.bootstrapCliClient = this.buildBootstrapCliClient()

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -538,6 +538,8 @@ export class OpenClawService {
       podmanPath: input.podmanPath,
     })
 
+    // Intentionally mutates the module-level PodmanRuntime singleton so every
+    // consumer (including future service instances) sees the new path.
     configurePodmanRuntime({
       resourcesDir: this.resourcesDir ?? undefined,
       podmanPath: input.podmanPath ?? undefined,

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -42,7 +42,8 @@ import {
 import { OpenClawHttpChatClient } from './openclaw-http-chat-client'
 import { resolveSupportedOpenClawProvider } from './openclaw-provider-map'
 import type { OpenClawStreamEvent } from './openclaw-types'
-import { getPodmanRuntime } from './podman-runtime'
+import { loadPodmanOverrides, savePodmanOverrides } from './podman-overrides'
+import { configurePodmanRuntime, getPodmanRuntime } from './podman-runtime'
 
 const READY_TIMEOUT_MS = 30_000
 const AGENT_NAME_PATTERN = /^[a-z][a-z0-9-]*$/
@@ -101,6 +102,12 @@ export interface OpenClawProviderUpdateResult {
 
 export interface OpenClawServiceConfig {
   browserosServerPort?: number
+  resourcesDir?: string
+}
+
+export interface OpenClawPodmanOverridesResponse {
+  podmanPath: string | null
+  effectivePodmanPath: string
 }
 
 export class OpenClawService {
@@ -114,6 +121,7 @@ export class OpenClawService {
   private tokenLoaded = false
   private lastError: string | null = null
   private browserosServerPort: number
+  private resourcesDir: string | null
   private controlPlaneStatus: OpenClawControlPlaneStatus = 'disconnected'
   private lastGatewayError: string | null = null
   private lastRecoveryReason: OpenClawGatewayRecoveryReason | null = null
@@ -124,25 +132,22 @@ export class OpenClawService {
     this.runtime = new ContainerRuntime(getPodmanRuntime(), this.openclawDir)
     this.token = crypto.randomUUID()
     this.cliClient = new OpenClawCliClient(this.runtime)
-    this.bootstrapCliClient = new OpenClawCliClient({
-      execInContainer: (command, onLog) =>
-        this.runtime.runGatewaySetupCommand(
-          command,
-          this.buildGatewayRuntimeSpec(),
-          onLog,
-        ),
-    })
+    this.bootstrapCliClient = this.buildBootstrapCliClient()
     this.chatClient = new OpenClawHttpChatClient(
       this.port,
       async () => this.token,
     )
     this.browserosServerPort =
       config.browserosServerPort ?? DEFAULT_PORTS.server
+    this.resourcesDir = config.resourcesDir ?? null
   }
 
   configure(config: OpenClawServiceConfig): void {
     if (config.browserosServerPort !== undefined) {
       this.browserosServerPort = config.browserosServerPort
+    }
+    if (config.resourcesDir !== undefined) {
+      this.resourcesDir = config.resourcesDir
     }
   }
 
@@ -524,6 +529,44 @@ export class OpenClawService {
     )
   }
 
+  // ── Podman Overrides ─────────────────────────────────────────────────
+
+  async applyPodmanOverrides(input: {
+    podmanPath: string | null
+  }): Promise<OpenClawPodmanOverridesResponse> {
+    await savePodmanOverrides(this.openclawDir, {
+      podmanPath: input.podmanPath,
+    })
+
+    configurePodmanRuntime({
+      resourcesDir: this.resourcesDir ?? undefined,
+      podmanPath: input.podmanPath ?? undefined,
+    })
+
+    const podman = getPodmanRuntime()
+    this.runtime = new ContainerRuntime(podman, this.openclawDir)
+    this.cliClient = new OpenClawCliClient(this.runtime)
+    this.bootstrapCliClient = this.buildBootstrapCliClient()
+
+    logger.info('Applied Podman overrides', {
+      podmanPath: input.podmanPath,
+      effectivePodmanPath: podman.getPodmanPath(),
+    })
+
+    return {
+      podmanPath: input.podmanPath,
+      effectivePodmanPath: podman.getPodmanPath(),
+    }
+  }
+
+  async getPodmanOverrides(): Promise<OpenClawPodmanOverridesResponse> {
+    const { podmanPath } = await loadPodmanOverrides(this.openclawDir)
+    return {
+      podmanPath,
+      effectivePodmanPath: getPodmanRuntime().getPodmanPath(),
+    }
+  }
+
   // ── Provider Keys ────────────────────────────────────────────────────
 
   async updateProviderKeys(input: {
@@ -601,6 +644,17 @@ export class OpenClawService {
   }
 
   // ── Internal ─────────────────────────────────────────────────────────
+
+  private buildBootstrapCliClient(): OpenClawCliClient {
+    return new OpenClawCliClient({
+      execInContainer: (command, onLog) =>
+        this.runtime.runGatewaySetupCommand(
+          command,
+          this.buildGatewayRuntimeSpec(),
+          onLog,
+        ),
+    })
+  }
 
   private async assertGatewayReady(): Promise<void> {
     const portReady = await this.runtime.isReady(this.port)

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -543,19 +543,17 @@ export class OpenClawService {
       podmanPath: input.podmanPath ?? undefined,
     })
 
-    const podman = getPodmanRuntime()
-    this.runtime = new ContainerRuntime(podman, this.openclawDir)
-    this.cliClient = new OpenClawCliClient(this.runtime)
-    this.bootstrapCliClient = this.buildBootstrapCliClient()
+    this.rebuildRuntimeClients()
+    const effectivePodmanPath = getPodmanRuntime().getPodmanPath()
 
     logger.info('Applied Podman overrides', {
       podmanPath: input.podmanPath,
-      effectivePodmanPath: podman.getPodmanPath(),
+      effectivePodmanPath,
     })
 
     return {
       podmanPath: input.podmanPath,
-      effectivePodmanPath: podman.getPodmanPath(),
+      effectivePodmanPath,
     }
   }
 
@@ -654,6 +652,12 @@ export class OpenClawService {
           onLog,
         ),
     })
+  }
+
+  private rebuildRuntimeClients(): void {
+    this.runtime = new ContainerRuntime(getPodmanRuntime(), this.openclawDir)
+    this.cliClient = new OpenClawCliClient(this.runtime)
+    this.bootstrapCliClient = this.buildBootstrapCliClient()
   }
 
   private async assertGatewayReady(): Promise<void> {

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/podman-overrides.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/podman-overrides.ts
@@ -1,0 +1,54 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Persistence for user-supplied Podman runtime overrides.
+ * Temporary escape hatch so users can point BrowserOS at their own Podman
+ * (e.g. `brew install podman`) when the bundled runtime doesn't resolve helpers.
+ */
+
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export interface PodmanOverrides {
+  podmanPath: string | null
+}
+
+const OVERRIDES_FILE_NAME = 'podman-overrides.json'
+
+export function getPodmanOverridesPath(openclawDir: string): string {
+  return join(openclawDir, OVERRIDES_FILE_NAME)
+}
+
+export async function loadPodmanOverrides(
+  openclawDir: string,
+): Promise<PodmanOverrides> {
+  const path = getPodmanOverridesPath(openclawDir)
+  if (!existsSync(path)) return { podmanPath: null }
+  try {
+    const parsed = JSON.parse(
+      await readFile(path, 'utf-8'),
+    ) as Partial<PodmanOverrides>
+    return {
+      podmanPath:
+        typeof parsed.podmanPath === 'string' && parsed.podmanPath.length > 0
+          ? parsed.podmanPath
+          : null,
+    }
+  } catch {
+    return { podmanPath: null }
+  }
+}
+
+export async function savePodmanOverrides(
+  openclawDir: string,
+  overrides: PodmanOverrides,
+): Promise<void> {
+  await mkdir(openclawDir, { recursive: true })
+  await writeFile(
+    getPodmanOverridesPath(openclawDir),
+    `${JSON.stringify(overrides, null, 2)}\n`,
+  )
+}

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/podman-overrides.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/podman-overrides.ts
@@ -25,11 +25,11 @@ export function getPodmanOverridesPath(openclawDir: string): string {
 export async function loadPodmanOverrides(
   openclawDir: string,
 ): Promise<PodmanOverrides> {
-  const path = getPodmanOverridesPath(openclawDir)
-  if (!existsSync(path)) return { podmanPath: null }
+  const overridesPath = getPodmanOverridesPath(openclawDir)
+  if (!existsSync(overridesPath)) return { podmanPath: null }
   try {
     const parsed = JSON.parse(
-      await readFile(path, 'utf-8'),
+      await readFile(overridesPath, 'utf-8'),
     ) as Partial<PodmanOverrides>
     return {
       podmanPath:

--- a/packages/browseros-agent/apps/server/src/main.ts
+++ b/packages/browseros-agent/apps/server/src/main.ts
@@ -17,6 +17,7 @@ import {
   configureOpenClawService,
   getOpenClawService,
 } from './api/services/openclaw/openclaw-service'
+import { loadPodmanOverrides } from './api/services/openclaw/podman-overrides'
 import { configurePodmanRuntime } from './api/services/openclaw/podman-runtime'
 import { CdpBackend } from './browser/backends/cdp'
 import { Browser } from './browser/browser'
@@ -25,6 +26,7 @@ import { INLINED_ENV } from './env'
 import {
   cleanOldSessions,
   ensureBrowserosDir,
+  getOpenClawDir,
   removeServerConfigSync,
   writeServerConfig,
 } from './lib/browseros-dir'
@@ -59,9 +61,17 @@ export class Application {
       resourcesDir: path.resolve(this.config.resourcesDir),
     })
 
+    const resourcesDir = path.resolve(this.config.resourcesDir)
+    const podmanOverrides = await loadPodmanOverrides(getOpenClawDir())
     configurePodmanRuntime({
-      resourcesDir: path.resolve(this.config.resourcesDir),
+      resourcesDir,
+      podmanPath: podmanOverrides.podmanPath ?? undefined,
     })
+    if (podmanOverrides.podmanPath) {
+      logger.info('Using user-overridden Podman binary', {
+        podmanPath: podmanOverrides.podmanPath,
+      })
+    }
     await this.initCoreServices()
 
     if (!this.config.cdpPort) {
@@ -128,6 +138,7 @@ export class Application {
 
     configureOpenClawService({
       browserosServerPort: this.config.serverPort,
+      resourcesDir,
     })
       .tryAutoStart()
       .catch((err) =>

--- a/packages/browseros-agent/apps/server/tests/api/routes/openclaw.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/openclaw.test.ts
@@ -4,6 +4,9 @@
  */
 
 import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { UnsupportedOpenClawProviderError } from '../../../src/api/services/openclaw/openclaw-provider-map'
 
 describe('createOpenClawRoutes', () => {
@@ -219,6 +222,31 @@ describe('createOpenClawRoutes', () => {
     expect(await response.json()).toEqual({
       error: 'File does not exist: /does/not/exist/podman',
     })
+  })
+
+  it('rejects a non-executable podman path on POST', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'openclaw-route-'))
+    const nonExec = join(tempDir, 'podman')
+    writeFileSync(nonExec, 'not a binary')
+    chmodSync(nonExec, 0o644)
+    try {
+      const { createOpenClawRoutes } = await import(
+        '../../../src/api/routes/openclaw'
+      )
+      const route = createOpenClawRoutes()
+
+      const response = await route.request('/podman-overrides', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ podmanPath: nonExec }),
+      })
+      expect(response.status).toBe(400)
+      expect(await response.json()).toEqual({
+        error: `File is not executable: ${nonExec}`,
+      })
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
   })
 
   it('applies and echoes when POST clears the override', async () => {

--- a/packages/browseros-agent/apps/server/tests/api/routes/openclaw.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/openclaw.test.ts
@@ -160,6 +160,99 @@ describe('createOpenClawRoutes', () => {
     expect(response.status).toBe(404)
   })
 
+  it('returns the current podman overrides on GET', async () => {
+    const actualOpenClawService = await import(
+      '../../../src/api/services/openclaw/openclaw-service'
+    )
+    const getPodmanOverrides = mock(async () => ({
+      podmanPath: '/opt/homebrew/bin/podman',
+      effectivePodmanPath: '/opt/homebrew/bin/podman',
+    }))
+
+    mock.module('../../../src/api/services/openclaw/openclaw-service', () => ({
+      ...actualOpenClawService,
+      getOpenClawService: () => ({ getPodmanOverrides }) as never,
+    }))
+
+    const { createOpenClawRoutes } = await import(
+      '../../../src/api/routes/openclaw'
+    )
+    const route = createOpenClawRoutes()
+
+    const response = await route.request('/podman-overrides')
+    expect(response.status).toBe(200)
+    expect(await response.json()).toEqual({
+      podmanPath: '/opt/homebrew/bin/podman',
+      effectivePodmanPath: '/opt/homebrew/bin/podman',
+    })
+  })
+
+  it('rejects a relative podman path on POST', async () => {
+    const { createOpenClawRoutes } = await import(
+      '../../../src/api/routes/openclaw'
+    )
+    const route = createOpenClawRoutes()
+
+    const response = await route.request('/podman-overrides', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ podmanPath: 'podman' }),
+    })
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'podmanPath must be an absolute path',
+    })
+  })
+
+  it('rejects a nonexistent podman path on POST', async () => {
+    const { createOpenClawRoutes } = await import(
+      '../../../src/api/routes/openclaw'
+    )
+    const route = createOpenClawRoutes()
+
+    const response = await route.request('/podman-overrides', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ podmanPath: '/does/not/exist/podman' }),
+    })
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'File does not exist: /does/not/exist/podman',
+    })
+  })
+
+  it('applies and echoes when POST clears the override', async () => {
+    const actualOpenClawService = await import(
+      '../../../src/api/services/openclaw/openclaw-service'
+    )
+    const applyPodmanOverrides = mock(async () => ({
+      podmanPath: null,
+      effectivePodmanPath: 'podman',
+    }))
+
+    mock.module('../../../src/api/services/openclaw/openclaw-service', () => ({
+      ...actualOpenClawService,
+      getOpenClawService: () => ({ applyPodmanOverrides }) as never,
+    }))
+
+    const { createOpenClawRoutes } = await import(
+      '../../../src/api/routes/openclaw'
+    )
+    const route = createOpenClawRoutes()
+
+    const response = await route.request('/podman-overrides', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ podmanPath: null }),
+    })
+    expect(response.status).toBe(200)
+    expect(applyPodmanOverrides).toHaveBeenCalledWith({ podmanPath: null })
+    expect(await response.json()).toEqual({
+      podmanPath: null,
+      effectivePodmanPath: 'podman',
+    })
+  })
+
   it('ignores role fields when creating agents', async () => {
     const actualOpenClawService = await import(
       '../../../src/api/services/openclaw/openclaw-service'

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-service.test.ts
@@ -911,4 +911,61 @@ describe('OpenClawService', () => {
     expect(restart).not.toHaveBeenCalled()
     expect(existsSync(join(tempDir, '.openclaw', '.env'))).toBe(false)
   })
+
+  it('applyPodmanOverrides persists the override and refreshes the runtime', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
+    const service = new OpenClawService() as MutableOpenClawService
+    service.openclawDir = tempDir
+
+    const result = await service.applyPodmanOverrides({
+      podmanPath: '/opt/homebrew/bin/podman',
+    })
+
+    expect(result.podmanPath).toBe('/opt/homebrew/bin/podman')
+    expect(result.effectivePodmanPath).toBe('/opt/homebrew/bin/podman')
+
+    const persisted = JSON.parse(
+      await readFile(join(tempDir, 'podman-overrides.json'), 'utf-8'),
+    )
+    expect(persisted).toEqual({ podmanPath: '/opt/homebrew/bin/podman' })
+
+    const reloaded = await service.getPodmanOverrides()
+    expect(reloaded.podmanPath).toBe('/opt/homebrew/bin/podman')
+    expect(reloaded.effectivePodmanPath).toBe('/opt/homebrew/bin/podman')
+  })
+
+  it('applyPodmanOverrides with null clears the override and falls back', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
+    const service = new OpenClawService({
+      resourcesDir: tempDir,
+    }) as MutableOpenClawService
+    service.openclawDir = tempDir
+
+    await service.applyPodmanOverrides({
+      podmanPath: '/opt/homebrew/bin/podman',
+    })
+    const cleared = await service.applyPodmanOverrides({ podmanPath: null })
+
+    expect(cleared.podmanPath).toBeNull()
+    // resourcesDir has no bundled binary, so the runtime falls through to 'podman'
+    expect(cleared.effectivePodmanPath).toBe('podman')
+
+    const persisted = JSON.parse(
+      await readFile(join(tempDir, 'podman-overrides.json'), 'utf-8'),
+    )
+    expect(persisted).toEqual({ podmanPath: null })
+  })
+
+  it('applyPodmanOverrides rebuilds ContainerRuntime so it picks up the new Podman reference', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
+    const service = new OpenClawService() as MutableOpenClawService
+    service.openclawDir = tempDir
+
+    const before = service.runtime
+    await service.applyPodmanOverrides({
+      podmanPath: '/opt/homebrew/bin/podman',
+    })
+
+    expect(service.runtime).not.toBe(before)
+  })
 })

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/podman-overrides.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/podman-overrides.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+
+import {
+  getPodmanOverridesPath,
+  loadPodmanOverrides,
+  savePodmanOverrides,
+} from '../../../../src/api/services/openclaw/podman-overrides'
+
+describe('podman overrides', () => {
+  let tempDir: string
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'browseros-podman-ovr-'))
+  })
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true })
+  })
+
+  it('returns null podmanPath when the overrides file is missing', async () => {
+    expect(await loadPodmanOverrides(tempDir)).toEqual({ podmanPath: null })
+  })
+
+  it('round-trips save and load', async () => {
+    await savePodmanOverrides(tempDir, {
+      podmanPath: '/opt/homebrew/bin/podman',
+    })
+    expect(await loadPodmanOverrides(tempDir)).toEqual({
+      podmanPath: '/opt/homebrew/bin/podman',
+    })
+  })
+
+  it('returns null when the overrides file is malformed JSON', async () => {
+    fs.writeFileSync(getPodmanOverridesPath(tempDir), '{not json')
+    expect(await loadPodmanOverrides(tempDir)).toEqual({ podmanPath: null })
+  })
+
+  it('treats empty string and wrong types as null', async () => {
+    fs.writeFileSync(
+      getPodmanOverridesPath(tempDir),
+      JSON.stringify({ podmanPath: '' }),
+    )
+    expect(await loadPodmanOverrides(tempDir)).toEqual({ podmanPath: null })
+
+    fs.writeFileSync(
+      getPodmanOverridesPath(tempDir),
+      JSON.stringify({ podmanPath: 42 }),
+    )
+    expect(await loadPodmanOverrides(tempDir)).toEqual({ podmanPath: null })
+  })
+
+  it('persists an explicit null', async () => {
+    await savePodmanOverrides(tempDir, { podmanPath: null })
+    expect(await loadPodmanOverrides(tempDir)).toEqual({ podmanPath: null })
+    expect(fs.existsSync(getPodmanOverridesPath(tempDir))).toBe(true)
+  })
+
+  it('creates the openclaw directory if it does not exist', async () => {
+    const nested = path.join(tempDir, 'does-not-exist')
+    await savePodmanOverrides(nested, { podmanPath: '/usr/local/bin/podman' })
+    expect(fs.existsSync(getPodmanOverridesPath(nested))).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

- Add a UI override on the Agents page so users can point BrowserOS at their own Podman binary when the bundled runtime's helper discovery fails (`could not find "gvproxy"` on `podman machine start`).
- Persist `{ podmanPath }` at `~/.browseros/.openclaw/podman-overrides.json`; loaded at server boot, hot-applied via `POST /claw/podman-overrides` without a server restart.
- Dev mode behavior is unchanged (same `$PATH` fallback as today); this just exposes that same lever to prod users.

## Background

On some macOS machines, `podman machine start` exits 125 with `could not find "gvproxy"` even though the helpers are physically present in the bundled directory. Fixing the bundled runtime properly (wiring `CONTAINERS_HELPER_BINARIES_DIR` / `containers.conf`) is a separate effort. This PR is the **temporary escape hatch for internal dev tails**: a blocked user runs `brew install podman` and pastes `/opt/homebrew/bin/podman` into the Agents page. System Podman finds its helpers the normal way.

## Design

Exposes the existing `configurePodmanRuntime({ podmanPath })` knob (already used by dev mode via the `'podman'` fallback) as a UI input. A new `podman-overrides.ts` owns the JSON persistence; `OpenClawService` gains `applyPodmanOverrides`/`getPodmanOverrides` plus a private `rebuildRuntimeClients()` helper to swap the `ContainerRuntime` + CLI client references in place. Two new routes (`GET/POST /claw/podman-overrides`) with absolute-path + `existsSync` validation extracted to a helper matching the existing `getCreateAgentValidationError` pattern. On the UI, a `PodmanOverridesCard` is rendered inline inside the degraded / uninitialized / error states (primary discovery channel for blocked users) and as a collapsible standalone section otherwise.

## Explicit non-goal

This does **not** make the bundled Podman work. A user hit by the gvproxy bug still needs to install their own Podman to use this override. Fixing the bundled runtime is tracked separately.

## Test plan

- [x] `bun run --filter @browseros/server typecheck` — clean
- [x] `bun run --filter @browseros/agent typecheck` — clean
- [x] `bunx biome check <touched files>` — clean (preexisting complexity warning on `AgentsPage` is unchanged)
- [x] `bun test apps/server/tests/api/services/openclaw apps/server/tests/api/routes/openclaw.test.ts` — 78 pass, 0 fail
- [x] `bun test apps/agent` — 20 pass, 0 fail
- [ ] Manual: on a machine with bundled-podman gvproxy failure, `brew install podman`, paste `/opt/homebrew/bin/podman` into the new card, click "Restart Gateway", confirm setup succeeds.
- [ ] Manual: clear override via the Clear button, confirm server reverts to bundled resolution on next restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)