### PR TITLE
fix: update the process-compose install path in readme

### DIFF
--- a/packages/browseros-agent/README.md
+++ b/packages/browseros-agent/README.md
@@ -78,7 +78,7 @@ packages/
 Requires [process-compose](https://github.com/F1bonacc1/process-compose):
 
 ```bash
-brew install process-compose
+brew install f1bonacc1/tap/process-compose
 ```
 
 ```bash


### PR DESCRIPTION
The default path to install process-compose does not exist; it is updated to f1bonacc1/tap/process-compose.

Source: https://f1bonacc1.github.io/process-compose/installation/