### PR TITLE
feat: add passive lazy monitoring substrate for MCP tool calls

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
@@ -10,6 +10,7 @@ import type { Browser } from '../../browser/browser'
 import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
 import { Sentry } from '../../lib/sentry'
+import { getMonitoringService } from '../../monitoring/service'
 import type { ToolRegistry } from '../../tools/tool-registry'
 import type { GlobalAclPolicyService } from '../services/acl/global-acl-policy'
 import { resolveAclPolicyForMcpRequest } from '../services/acl/resolve-acl-policy'
@@ -39,16 +40,28 @@ export function createMcpRoutes(deps: McpRouteDeps) {
 
   app.post('/', async (c) => {
     const scopeId = c.req.header('X-BrowserOS-Scope-Id') || 'ephemeral'
+    const agentId =
+      c.req.query('agentId') ??
+      c.req.header('X-BrowserOS-Agent-Id') ??
+      undefined
     metrics.log('mcp.request', { scopeId })
     const aclRules = await resolveAclPolicyForMcpRequest({
       policyService: deps.policyService,
     })
+    const monitoringSessionId = agentId
+      ? getMonitoringService().getActiveSessionId(agentId)
+      : undefined
+    const observer =
+      monitoringSessionId && agentId
+        ? getMonitoringService().createObserver(monitoringSessionId, agentId)
+        : undefined
 
     // Per-request server + transport: no shared state, no race conditions,
     // no ID collisions. Required by MCP SDK 1.26.0+ security fix (GHSA-345p-7cg4-v4c7).
     const mcpServer = createMcpServer({
       ...deps,
       aclRules,
+      observer,
     })
     const transport = new StreamableHTTPTransport({
       sessionIdGenerator: undefined,
@@ -62,6 +75,9 @@ export function createMcpRoutes(deps: McpRouteDeps) {
       Sentry.withScope((scope) => {
         scope.setTag('route', 'mcp')
         scope.setTag('scopeId', scopeId)
+        if (agentId) {
+          scope.setTag('agentId', agentId)
+        }
         Sentry.captureException(error)
       })
       logger.error('Error handling MCP request', {

--- a/packages/browseros-agent/apps/server/src/api/routes/monitoring.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/monitoring.ts
@@ -1,5 +1,6 @@
 import { Hono } from 'hono'
 import { getMonitoringService } from '../../monitoring/service'
+import { isValidMonitoringRunId } from '../../monitoring/storage'
 
 export function createMonitoringRoutes() {
   return new Hono()
@@ -14,6 +15,9 @@ export function createMonitoringRoutes() {
     })
     .get('/runs/:id', async (c) => {
       const runId = c.req.param('id')
+      if (!isValidMonitoringRunId(runId)) {
+        return c.json({ error: 'Invalid monitoring run id' }, 400)
+      }
       const envelope = await getMonitoringService().getRunEnvelope(runId)
 
       if (!envelope) {
@@ -65,6 +69,9 @@ export function createMonitoringRoutes() {
     })
     .post('/debug/runs/:id/finalize', async (c) => {
       const runId = c.req.param('id')
+      if (!isValidMonitoringRunId(runId)) {
+        return c.json({ error: 'Invalid monitoring run id' }, 400)
+      }
       const body = await c.req.json<{
         agentId?: string
         sessionKey?: string

--- a/packages/browseros-agent/apps/server/src/api/routes/monitoring.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/monitoring.ts
@@ -1,0 +1,106 @@
+import { Hono } from 'hono'
+import { getMonitoringService } from '../../monitoring/service'
+
+export function createMonitoringRoutes() {
+  return new Hono()
+    .get('/runs', async (c) => {
+      const limitParam = c.req.query('limit')
+      const parsedLimit = limitParam ? Number.parseInt(limitParam, 10) : 50
+      const limit =
+        Number.isFinite(parsedLimit) && parsedLimit > 0 ? parsedLimit : 50
+
+      const runs = await getMonitoringService().listRuns(limit)
+      return c.json({ runs })
+    })
+    .get('/runs/:id', async (c) => {
+      const runId = c.req.param('id')
+      const envelope = await getMonitoringService().getRunEnvelope(runId)
+
+      if (!envelope) {
+        return c.json({ error: 'Monitoring run not found' }, 404)
+      }
+
+      return c.json({ run: envelope })
+    })
+    .post('/debug/runs', async (c) => {
+      const body = await c.req.json<{
+        agentId?: string
+        sessionKey?: string
+        originalPrompt?: string
+        chatHistory?: Array<{ role?: 'user' | 'assistant'; content?: string }>
+      }>()
+
+      if (!body.agentId?.trim()) {
+        return c.json({ error: 'agentId is required' }, 400)
+      }
+      if (!body.sessionKey?.trim()) {
+        return c.json({ error: 'sessionKey is required' }, 400)
+      }
+      if (!body.originalPrompt?.trim()) {
+        return c.json({ error: 'originalPrompt is required' }, 400)
+      }
+
+      const chatHistory = Array.isArray(body.chatHistory)
+        ? body.chatHistory
+            .filter(
+              (turn): turn is { role: 'user' | 'assistant'; content: string } =>
+                (turn.role === 'user' || turn.role === 'assistant') &&
+                typeof turn.content === 'string',
+            )
+            .map((turn) => ({
+              role: turn.role,
+              content: turn.content,
+            }))
+        : []
+
+      const session = await getMonitoringService().startSession({
+        agentId: body.agentId.trim(),
+        sessionKey: body.sessionKey.trim(),
+        originalPrompt: body.originalPrompt.trim(),
+        chatHistory,
+        source: 'debug',
+      })
+
+      return c.json({ session }, 201)
+    })
+    .post('/debug/runs/:id/finalize', async (c) => {
+      const runId = c.req.param('id')
+      const body = await c.req.json<{
+        agentId?: string
+        sessionKey?: string
+        status?: 'completed' | 'failed' | 'aborted' | 'incomplete'
+        finalAssistantMessage?: string
+        error?: string
+      }>()
+
+      if (!body.agentId?.trim()) {
+        return c.json({ error: 'agentId is required' }, 400)
+      }
+      if (!body.sessionKey?.trim()) {
+        return c.json({ error: 'sessionKey is required' }, 400)
+      }
+      if (
+        body.status !== 'completed' &&
+        body.status !== 'failed' &&
+        body.status !== 'aborted' &&
+        body.status !== 'incomplete'
+      ) {
+        return c.json({ error: 'status is invalid' }, 400)
+      }
+
+      const envelope = await getMonitoringService().finalizeSession({
+        monitoringSessionId: runId,
+        agentId: body.agentId.trim(),
+        sessionKey: body.sessionKey.trim(),
+        status: body.status,
+        finalAssistantMessage: body.finalAssistantMessage,
+        error: body.error,
+      })
+
+      if (!envelope) {
+        return c.json({ error: 'Monitoring run not found' }, 404)
+      }
+
+      return c.json({ run: envelope })
+    })
+}

--- a/packages/browseros-agent/apps/server/src/api/server.ts
+++ b/packages/browseros-agent/apps/server/src/api/server.ts
@@ -29,6 +29,7 @@ import { createHealthRoute } from './routes/health'
 import { createKlavisRoutes } from './routes/klavis'
 import { createMcpRoutes } from './routes/mcp'
 import { createMemoryRoutes } from './routes/memory'
+import { createMonitoringRoutes } from './routes/monitoring'
 import { createOAuthRoutes } from './routes/oauth'
 import { createOpenClawRoutes } from './routes/openclaw'
 import { createProviderRoutes } from './routes/provider'
@@ -121,6 +122,10 @@ export async function createHttpServer(config: HttpServerConfig) {
     .use('/*', requireTrustedAppOrigin())
     .route('/', createAclRoutes({ policyService: aclPolicyService }))
 
+  const monitoringRoutes = new Hono<Env>()
+    .use('/*', requireTrustedAppOrigin())
+    .route('/', createMonitoringRoutes())
+
   const app = new Hono<Env>()
     .use('/*', cors(defaultCorsConfig))
     .route('/health', createHealthRoute({ browser }))
@@ -143,6 +148,7 @@ export async function createHttpServer(config: HttpServerConfig) {
     .route('/soul', createSoulRoutes())
     .route('/memory', createMemoryRoutes())
     .route('/skills', createSkillsRoutes())
+    .route('/monitoring', monitoringRoutes)
     .route('/acl-rules', aclRoutes)
     .route('/test-provider', createProviderRoutes({ browserosId }))
     .route('/refine-prompt', createRefinePromptRoutes({ browserosId }))

--- a/packages/browseros-agent/apps/server/src/api/services/klavis/strata-proxy.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/klavis/strata-proxy.ts
@@ -20,6 +20,7 @@ import { KlavisClient } from '../../../lib/clients/klavis/klavis-client'
 import { OAUTH_MCP_SERVERS } from '../../../lib/clients/klavis/oauth-mcp-servers'
 import { logger } from '../../../lib/logger'
 import { metrics } from '../../../lib/metrics'
+import type { ToolExecutionObserver } from '../../../monitoring/observer'
 import { klavisStrataCache } from './strata-cache'
 
 function withTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
@@ -237,6 +238,7 @@ export function buildKlavisToolSet(handle: KlavisProxyHandle): ToolSet {
 export function registerKlavisTools(
   mcpServer: McpServer,
   handle: KlavisProxyHandle,
+  observer?: ToolExecutionObserver,
 ): void {
   mcpServer.registerTool(
     'connector_mcp_servers',
@@ -247,9 +249,16 @@ export function registerKlavisTools(
     },
     async (args: Record<string, unknown>) => {
       const startTime = performance.now()
+      const toolCallId = crypto.randomUUID()
       const server_name = args.server_name as string
 
       try {
+        await observer?.onToolStart({
+          toolCallId,
+          toolName: 'connector_mcp_servers',
+          source: 'klavis-tool',
+          args,
+        })
         const klavisClient = new KlavisClient()
         const integrations = await klavisClient.getUserIntegrations(
           handle.browserosId,
@@ -264,6 +273,14 @@ export function registerKlavisTools(
             source: 'mcp',
             duration_ms: Math.round(performance.now() - startTime),
             success: true,
+          })
+
+          await observer?.onToolEnd({
+            toolCallId,
+            output: {
+              connected: true,
+              server_name,
+            },
           })
 
           return {
@@ -294,6 +311,15 @@ export function registerKlavisTools(
           success: true,
         })
 
+        await observer?.onToolEnd({
+          toolCallId,
+          output: {
+            connected: false,
+            server_name,
+            authUrl,
+          },
+        })
+
         return {
           content: [
             {
@@ -320,6 +346,11 @@ export function registerKlavisTools(
           error_message: errorText,
         })
 
+        await observer?.onToolEnd({
+          toolCallId,
+          error: errorText,
+        })
+
         return {
           content: [{ type: 'text' as const, text: errorText }],
           isError: true,
@@ -339,7 +370,14 @@ export function registerKlavisTools(
       },
       async (args: Record<string, unknown>) => {
         const startTime = performance.now()
+        const toolCallId = crypto.randomUUID()
         try {
+          await observer?.onToolStart({
+            toolCallId,
+            toolName: tool.name,
+            source: 'klavis-tool',
+            args,
+          })
           const result = await handle.callTool(tool.name, args)
 
           metrics.log('tool_executed', {
@@ -347,6 +385,12 @@ export function registerKlavisTools(
             source: 'mcp',
             duration_ms: Math.round(performance.now() - startTime),
             success: !result.isError,
+          })
+
+          await observer?.onToolEnd({
+            toolCallId,
+            output: result,
+            error: result.isError ? 'Tool returned isError=true' : undefined,
           })
 
           return result
@@ -360,6 +404,11 @@ export function registerKlavisTools(
             duration_ms: Math.round(performance.now() - startTime),
             success: false,
             error_message: errorText,
+          })
+
+          await observer?.onToolEnd({
+            toolCallId,
+            error: errorText,
           })
 
           return {

--- a/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-server.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-server.ts
@@ -8,6 +8,7 @@ import type { AclRule } from '@browseros/shared/types/acl'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { SetLevelRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import type { Browser } from '../../../browser/browser'
+import type { ToolExecutionObserver } from '../../../monitoring/observer'
 import type { ToolRegistry } from '../../../tools/tool-registry'
 import {
   type KlavisProxyRef,
@@ -24,6 +25,7 @@ export interface McpServiceDeps {
   resourcesDir: string
   aclRules?: AclRule[]
   klavisRef?: KlavisProxyRef
+  observer?: ToolExecutionObserver
 }
 
 export function createMcpServer(deps: McpServiceDeps): McpServer {
@@ -48,11 +50,12 @@ export function createMcpServer(deps: McpServiceDeps): McpServer {
       resourcesDir: deps.resourcesDir,
     },
     aclRules: deps.aclRules,
+    observer: deps.observer,
   })
 
   // Register Klavis proxy tools (if connected via background init)
   if (deps.klavisRef?.handle) {
-    registerKlavisTools(server, deps.klavisRef.handle)
+    registerKlavisTools(server, deps.klavisRef.handle, deps.observer)
   }
 
   return server

--- a/packages/browseros-agent/apps/server/src/api/services/mcp/register-mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/mcp/register-mcp.ts
@@ -1,13 +1,14 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { logger } from '../../../lib/logger'
 import { metrics } from '../../../lib/metrics'
+import type { ToolExecutionObserver } from '../../../monitoring/observer'
 import { executeTool, type ToolContext } from '../../../tools/framework'
 import type { ToolRegistry } from '../../../tools/tool-registry'
 
 export function registerTools(
   mcpServer: McpServer,
   registry: ToolRegistry,
-  ctx: ToolContext,
+  ctx: ToolContext & { observer?: ToolExecutionObserver },
 ): void {
   for (const tool of registry.all()) {
     const handler = async (
@@ -15,9 +16,16 @@ export function registerTools(
       extra: { signal: AbortSignal },
     ) => {
       const startTime = performance.now()
+      const toolCallId = crypto.randomUUID()
 
       try {
         logger.info(`${tool.name} request: ${JSON.stringify(args, null, '  ')}`)
+        await ctx.observer?.onToolStart({
+          toolCallId,
+          toolName: tool.name,
+          source: 'browser-tool',
+          args,
+        })
 
         const result = await executeTool(tool, args, ctx, extra.signal)
 
@@ -26,6 +34,12 @@ export function registerTools(
           duration_ms: Math.round(performance.now() - startTime),
           success: !result.isError,
           source: 'mcp',
+        })
+
+        await ctx.observer?.onToolEnd({
+          toolCallId,
+          output: result.structuredContent ?? result.content,
+          error: result.isError ? 'Tool returned isError=true' : undefined,
         })
 
         return {
@@ -42,6 +56,11 @@ export function registerTools(
           success: false,
           error_message: errorText,
           source: 'mcp',
+        })
+
+        await ctx.observer?.onToolEnd({
+          toolCallId,
+          error: errorText,
         })
 
         return {

--- a/packages/browseros-agent/apps/server/src/lib/browseros-dir.ts
+++ b/packages/browseros-agent/apps/server/src/lib/browseros-dir.ts
@@ -49,6 +49,18 @@ export function getOpenClawDir(): string {
   return join(getBrowserosDir(), PATHS.OPENCLAW_DIR_NAME)
 }
 
+export function getLazyMonitoringDir(): string {
+  return join(getBrowserosDir(), 'lazy-monitoring')
+}
+
+export function getLazyMonitoringRunsDir(): string {
+  return join(getLazyMonitoringDir(), 'runs')
+}
+
+export function getLazyMonitoringRunDir(runId: string): string {
+  return join(getLazyMonitoringRunsDir(), runId)
+}
+
 export function getServerConfigPath(): string {
   return join(getBrowserosDir(), PATHS.SERVER_CONFIG_FILE_NAME)
 }
@@ -73,6 +85,7 @@ export async function ensureBrowserosDir(): Promise<void> {
   await mkdir(getSkillsDir(), { recursive: true })
   await mkdir(getBuiltinSkillsDir(), { recursive: true })
   await mkdir(getSessionsDir(), { recursive: true })
+  await mkdir(getLazyMonitoringRunsDir(), { recursive: true })
 }
 
 export async function cleanOldSessions(): Promise<void> {

--- a/packages/browseros-agent/apps/server/src/monitoring/envelope.ts
+++ b/packages/browseros-agent/apps/server/src/monitoring/envelope.ts
@@ -1,0 +1,23 @@
+import type {
+  JudgeAuditEnvelope,
+  MonitoringFinalization,
+  MonitoringSessionContext,
+  MonitoringToolCallRecord,
+} from './types'
+
+export function buildJudgeAuditEnvelope(input: {
+  context: MonitoringSessionContext
+  toolCalls: MonitoringToolCallRecord[]
+  finalization: MonitoringFinalization | null
+}): JudgeAuditEnvelope {
+  const envelope: JudgeAuditEnvelope = {
+    run: input.context,
+    toolCalls: input.toolCalls,
+  }
+
+  if (input.finalization) {
+    envelope.finalization = input.finalization
+  }
+
+  return envelope
+}

--- a/packages/browseros-agent/apps/server/src/monitoring/observer.ts
+++ b/packages/browseros-agent/apps/server/src/monitoring/observer.ts
@@ -1,0 +1,18 @@
+import { logger } from '../lib/logger'
+import type { MonitoringToolEndInput, MonitoringToolStartInput } from './types'
+
+export interface ToolExecutionObserver {
+  onToolStart(input: MonitoringToolStartInput): Promise<void>
+  onToolEnd(input: MonitoringToolEndInput): Promise<void>
+}
+
+export function swallowMonitoringError(
+  operation: string,
+  error: unknown,
+  metadata: Record<string, unknown>,
+): void {
+  logger.warn(`Lazy monitoring ${operation} failed`, {
+    ...metadata,
+    error: error instanceof Error ? error.message : String(error),
+  })
+}

--- a/packages/browseros-agent/apps/server/src/monitoring/service.ts
+++ b/packages/browseros-agent/apps/server/src/monitoring/service.ts
@@ -1,0 +1,217 @@
+import { buildJudgeAuditEnvelope } from './envelope'
+import { swallowMonitoringError, type ToolExecutionObserver } from './observer'
+import { MonitoringSessionRegistry } from './session-registry'
+import { MonitoringStorage } from './storage'
+import type {
+  JudgeAuditEnvelope,
+  MonitoringFinalization,
+  MonitoringFinalizeInput,
+  MonitoringRunSummary,
+  MonitoringSessionContext,
+  MonitoringSessionStartInput,
+  MonitoringToolCallRecord,
+  MonitoringToolEndInput,
+  MonitoringToolStartInput,
+} from './types'
+
+type ActiveToolCallState = Omit<
+  MonitoringToolCallRecord,
+  'finishedAt' | 'durationMs' | 'error' | 'output'
+>
+
+export class MonitoringService {
+  private readonly storage = new MonitoringStorage()
+  private readonly registry = new MonitoringSessionRegistry()
+
+  async startSession(
+    input: MonitoringSessionStartInput,
+  ): Promise<MonitoringSessionContext> {
+    const context: MonitoringSessionContext = {
+      monitoringSessionId: crypto.randomUUID(),
+      agentId: input.agentId,
+      sessionKey: input.sessionKey,
+      originalPrompt: input.originalPrompt,
+      chatHistory: input.chatHistory,
+      startedAt: new Date().toISOString(),
+      source: input.source ?? 'openclaw-agent-chat',
+    }
+
+    await this.storage.writeContext(context)
+    this.registry.setActive(context.agentId, context.monitoringSessionId)
+    return context
+  }
+
+  getActiveSessionId(agentId: string): string | undefined {
+    return this.registry.getActive(agentId)
+  }
+
+  clearActiveSession(agentId: string, monitoringSessionId: string): void {
+    this.registry.clearIfMatches(agentId, monitoringSessionId)
+  }
+
+  createObserver(
+    monitoringSessionId: string,
+    agentId: string,
+  ): ToolExecutionObserver {
+    const activeToolCalls = new Map<string, ActiveToolCallState>()
+
+    return {
+      onToolStart: async (input: MonitoringToolStartInput) => {
+        try {
+          activeToolCalls.set(input.toolCallId, {
+            monitoringSessionId,
+            agentId,
+            toolCallId: input.toolCallId,
+            toolName: input.toolName,
+            source: input.source,
+            args: input.args,
+            startedAt: new Date().toISOString(),
+          })
+        } catch (error) {
+          swallowMonitoringError('tool start recording', error, {
+            monitoringSessionId,
+            agentId,
+            toolCallId: input.toolCallId,
+            toolName: input.toolName,
+          })
+        }
+      },
+
+      onToolEnd: async (input: MonitoringToolEndInput) => {
+        try {
+          const active = activeToolCalls.get(input.toolCallId)
+          if (!active) return
+
+          const finishedAt = new Date().toISOString()
+          const durationMs = Math.max(
+            0,
+            new Date(finishedAt).getTime() -
+              new Date(active.startedAt).getTime(),
+          )
+
+          const record: MonitoringToolCallRecord = {
+            ...active,
+            finishedAt,
+            durationMs,
+          }
+
+          if (input.error) {
+            record.error = input.error
+          }
+          if (input.output !== undefined) {
+            record.output = input.output
+          }
+
+          await this.storage.appendToolCall(record)
+          activeToolCalls.delete(input.toolCallId)
+        } catch (error) {
+          swallowMonitoringError('tool end recording', error, {
+            monitoringSessionId,
+            agentId,
+            toolCallId: input.toolCallId,
+          })
+        }
+      },
+    }
+  }
+
+  async finalizeSession(
+    input: MonitoringFinalizeInput,
+  ): Promise<JudgeAuditEnvelope | null> {
+    const context = await this.storage.readContext(input.monitoringSessionId)
+    if (!context) {
+      return null
+    }
+
+    const finalization: MonitoringFinalization = {
+      monitoringSessionId: input.monitoringSessionId,
+      agentId: input.agentId,
+      sessionKey: input.sessionKey,
+      status: input.status,
+      finalizedAt: new Date().toISOString(),
+    }
+
+    if (input.finalAssistantMessage) {
+      finalization.finalAssistantMessage = input.finalAssistantMessage
+    }
+    if (input.error) {
+      finalization.error = input.error
+    }
+
+    await this.storage.writeFinalization(finalization)
+    this.registry.clearIfMatches(input.agentId, input.monitoringSessionId)
+    return this.buildAndPersistEnvelope(input.monitoringSessionId)
+  }
+
+  async getRunEnvelope(runId: string): Promise<JudgeAuditEnvelope | null> {
+    const context = await this.storage.readContext(runId)
+    if (!context) return null
+
+    const toolCalls = await this.storage.readToolCalls(runId)
+    const finalization = await this.storage.readFinalization(runId)
+
+    return buildJudgeAuditEnvelope({
+      context,
+      toolCalls,
+      finalization,
+    })
+  }
+
+  async listRuns(limit = 50): Promise<MonitoringRunSummary[]> {
+    const runIds = (await this.storage.listRunIds()).slice(0, limit)
+    const summaries = await Promise.all(
+      runIds.map(async (runId) => {
+        const context = await this.storage.readContext(runId)
+        if (!context) return null
+
+        const [toolCalls, finalization] = await Promise.all([
+          this.storage.readToolCalls(runId),
+          this.storage.readFinalization(runId),
+        ])
+
+        const summary: MonitoringRunSummary = {
+          monitoringSessionId: context.monitoringSessionId,
+          agentId: context.agentId,
+          sessionKey: context.sessionKey,
+          originalPrompt: context.originalPrompt,
+          startedAt: context.startedAt,
+          source: context.source,
+          toolCallCount: toolCalls.length,
+        }
+
+        if (finalization) {
+          summary.finalization = {
+            status: finalization.status,
+            finalizedAt: finalization.finalizedAt,
+            error: finalization.error,
+          }
+        }
+
+        return summary
+      }),
+    )
+
+    return summaries.filter((summary): summary is MonitoringRunSummary =>
+      Boolean(summary),
+    )
+  }
+
+  private async buildAndPersistEnvelope(
+    runId: string,
+  ): Promise<JudgeAuditEnvelope | null> {
+    const envelope = await this.getRunEnvelope(runId)
+    if (!envelope) return null
+
+    await this.storage.writeAuditEnvelope(runId, envelope)
+    return envelope
+  }
+}
+
+let monitoringService: MonitoringService | null = null
+
+export function getMonitoringService(): MonitoringService {
+  if (!monitoringService) {
+    monitoringService = new MonitoringService()
+  }
+  return monitoringService
+}

--- a/packages/browseros-agent/apps/server/src/monitoring/session-registry.ts
+++ b/packages/browseros-agent/apps/server/src/monitoring/session-registry.ts
@@ -1,0 +1,18 @@
+export class MonitoringSessionRegistry {
+  private readonly activeSessionsByAgent = new Map<string, string>()
+
+  setActive(agentId: string, monitoringSessionId: string): void {
+    this.activeSessionsByAgent.set(agentId, monitoringSessionId)
+  }
+
+  getActive(agentId: string): string | undefined {
+    return this.activeSessionsByAgent.get(agentId)
+  }
+
+  clearIfMatches(agentId: string, monitoringSessionId: string): void {
+    if (this.activeSessionsByAgent.get(agentId) !== monitoringSessionId) {
+      return
+    }
+    this.activeSessionsByAgent.delete(agentId)
+  }
+}

--- a/packages/browseros-agent/apps/server/src/monitoring/storage.ts
+++ b/packages/browseros-agent/apps/server/src/monitoring/storage.ts
@@ -95,7 +95,13 @@ export class MonitoringStorage {
         .split('\n')
         .map((line) => line.trim())
         .filter(Boolean)
-        .map((line) => JSON.parse(line) as MonitoringToolCallRecord)
+        .flatMap((line) => {
+          try {
+            return [JSON.parse(line) as MonitoringToolCallRecord]
+          } catch {
+            return []
+          }
+        })
     } catch {
       return []
     }
@@ -106,7 +112,9 @@ export class MonitoringStorage {
       const entries = await readdir(getLazyMonitoringRunsDir(), {
         withFileTypes: true,
       })
-      const directories = entries.filter((entry) => entry.isDirectory())
+      const directories = entries.filter(
+        (entry) => entry.isDirectory() && isValidMonitoringRunId(entry.name),
+      )
       const runStats = await Promise.all(
         directories.map(async (entry) => ({
           runId: entry.name,

--- a/packages/browseros-agent/apps/server/src/monitoring/storage.ts
+++ b/packages/browseros-agent/apps/server/src/monitoring/storage.ts
@@ -1,0 +1,143 @@
+import {
+  appendFile,
+  mkdir,
+  readdir,
+  readFile,
+  stat,
+  writeFile,
+} from 'node:fs/promises'
+import { join } from 'node:path'
+import {
+  getLazyMonitoringRunDir,
+  getLazyMonitoringRunsDir,
+} from '../lib/browseros-dir'
+import type {
+  MonitoringFinalization,
+  MonitoringSessionContext,
+  MonitoringToolCallRecord,
+} from './types'
+
+const CONTEXT_FILE_NAME = 'context.json'
+const TOOL_CALLS_FILE_NAME = 'tool-calls.jsonl'
+const FINALIZATION_FILE_NAME = 'finalization.json'
+const AUDIT_ENVELOPE_FILE_NAME = 'audit-envelope.json'
+
+export class MonitoringStorage {
+  async writeContext(context: MonitoringSessionContext): Promise<void> {
+    await this.ensureRunDir(context.monitoringSessionId)
+    await writeFile(
+      this.getContextPath(context.monitoringSessionId),
+      `${JSON.stringify(context, null, 2)}\n`,
+    )
+  }
+
+  async appendToolCall(record: MonitoringToolCallRecord): Promise<void> {
+    await this.ensureRunDir(record.monitoringSessionId)
+    await appendFile(
+      this.getToolCallsPath(record.monitoringSessionId),
+      `${JSON.stringify(record)}\n`,
+    )
+  }
+
+  async writeFinalization(finalization: MonitoringFinalization): Promise<void> {
+    await this.ensureRunDir(finalization.monitoringSessionId)
+    await writeFile(
+      this.getFinalizationPath(finalization.monitoringSessionId),
+      `${JSON.stringify(finalization, null, 2)}\n`,
+    )
+  }
+
+  async writeAuditEnvelope(runId: string, envelope: unknown): Promise<void> {
+    await this.ensureRunDir(runId)
+    await writeFile(
+      this.getAuditEnvelopePath(runId),
+      `${JSON.stringify(envelope, null, 2)}\n`,
+    )
+  }
+
+  async readContext(runId: string): Promise<MonitoringSessionContext | null> {
+    return this.readJsonFile<MonitoringSessionContext>(
+      this.getContextPath(runId),
+    )
+  }
+
+  async readFinalization(
+    runId: string,
+  ): Promise<MonitoringFinalization | null> {
+    return this.readJsonFile<MonitoringFinalization>(
+      this.getFinalizationPath(runId),
+    )
+  }
+
+  async readToolCalls(runId: string): Promise<MonitoringToolCallRecord[]> {
+    try {
+      const content = await readFile(this.getToolCallsPath(runId), 'utf8')
+      return content
+        .split('\n')
+        .map((line) => line.trim())
+        .filter(Boolean)
+        .map((line) => JSON.parse(line) as MonitoringToolCallRecord)
+    } catch {
+      return []
+    }
+  }
+
+  async listRunIds(): Promise<string[]> {
+    try {
+      const entries = await readdir(getLazyMonitoringRunsDir(), {
+        withFileTypes: true,
+      })
+      const directories = entries.filter((entry) => entry.isDirectory())
+      const runStats = await Promise.all(
+        directories.map(async (entry) => ({
+          runId: entry.name,
+          mtimeMs: await this.getDirectoryMtimeMs(entry.name),
+        })),
+      )
+      return runStats
+        .sort((a, b) => b.mtimeMs - a.mtimeMs)
+        .map((entry) => entry.runId)
+    } catch {
+      return []
+    }
+  }
+
+  private async ensureRunDir(runId: string): Promise<void> {
+    await mkdir(getLazyMonitoringRunsDir(), { recursive: true })
+    await mkdir(getLazyMonitoringRunDir(runId), { recursive: true })
+  }
+
+  private async getDirectoryMtimeMs(runId: string): Promise<number> {
+    try {
+      const info = await stat(getLazyMonitoringRunDir(runId))
+      return info.mtimeMs
+    } catch {
+      return 0
+    }
+  }
+
+  private async readJsonFile<T>(path: string): Promise<T | null> {
+    try {
+      const content = await readFile(path, 'utf8')
+      return JSON.parse(content) as T
+    } catch {
+      return null
+    }
+  }
+
+  private getContextPath(runId: string): string {
+    return join(getLazyMonitoringRunDir(runId), CONTEXT_FILE_NAME)
+  }
+
+  private getToolCallsPath(runId: string): string {
+    return join(getLazyMonitoringRunDir(runId), TOOL_CALLS_FILE_NAME)
+  }
+
+  private getFinalizationPath(runId: string): string {
+    return join(getLazyMonitoringRunDir(runId), FINALIZATION_FILE_NAME)
+  }
+
+  private getAuditEnvelopePath(runId: string): string {
+    return join(getLazyMonitoringRunDir(runId), AUDIT_ENVELOPE_FILE_NAME)
+  }
+}

--- a/packages/browseros-agent/apps/server/src/monitoring/storage.ts
+++ b/packages/browseros-agent/apps/server/src/monitoring/storage.ts
@@ -21,6 +21,25 @@ const CONTEXT_FILE_NAME = 'context.json'
 const TOOL_CALLS_FILE_NAME = 'tool-calls.jsonl'
 const FINALIZATION_FILE_NAME = 'finalization.json'
 const AUDIT_ENVELOPE_FILE_NAME = 'audit-envelope.json'
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+export class InvalidMonitoringRunIdError extends Error {
+  constructor(runId: string) {
+    super(`Invalid monitoring run id: ${runId}`)
+    this.name = 'InvalidMonitoringRunIdError'
+  }
+}
+
+export function isValidMonitoringRunId(runId: string): boolean {
+  return UUID_PATTERN.test(runId)
+}
+
+function assertValidMonitoringRunId(runId: string): void {
+  if (!isValidMonitoringRunId(runId)) {
+    throw new InvalidMonitoringRunIdError(runId)
+  }
+}
 
 export class MonitoringStorage {
   async writeContext(context: MonitoringSessionContext): Promise<void> {
@@ -103,6 +122,7 @@ export class MonitoringStorage {
   }
 
   private async ensureRunDir(runId: string): Promise<void> {
+    assertValidMonitoringRunId(runId)
     await mkdir(getLazyMonitoringRunsDir(), { recursive: true })
     await mkdir(getLazyMonitoringRunDir(runId), { recursive: true })
   }
@@ -126,18 +146,22 @@ export class MonitoringStorage {
   }
 
   private getContextPath(runId: string): string {
+    assertValidMonitoringRunId(runId)
     return join(getLazyMonitoringRunDir(runId), CONTEXT_FILE_NAME)
   }
 
   private getToolCallsPath(runId: string): string {
+    assertValidMonitoringRunId(runId)
     return join(getLazyMonitoringRunDir(runId), TOOL_CALLS_FILE_NAME)
   }
 
   private getFinalizationPath(runId: string): string {
+    assertValidMonitoringRunId(runId)
     return join(getLazyMonitoringRunDir(runId), FINALIZATION_FILE_NAME)
   }
 
   private getAuditEnvelopePath(runId: string): string {
+    assertValidMonitoringRunId(runId)
     return join(getLazyMonitoringRunDir(runId), AUDIT_ENVELOPE_FILE_NAME)
   }
 }

--- a/packages/browseros-agent/apps/server/src/monitoring/types.ts
+++ b/packages/browseros-agent/apps/server/src/monitoring/types.ts
@@ -1,0 +1,92 @@
+export type MonitoringChatTurnRole = 'user' | 'assistant'
+
+export interface MonitoringChatTurn {
+  role: MonitoringChatTurnRole
+  content: string
+}
+
+export interface MonitoringSessionContext {
+  monitoringSessionId: string
+  agentId: string
+  sessionKey: string
+  originalPrompt: string
+  chatHistory: MonitoringChatTurn[]
+  startedAt: string
+  source: 'openclaw-agent-chat' | 'debug'
+}
+
+export type MonitoringToolCallSource = 'browser-tool' | 'klavis-tool'
+
+export interface MonitoringToolCallRecord {
+  monitoringSessionId: string
+  agentId: string
+  toolCallId: string
+  toolName: string
+  source: MonitoringToolCallSource
+  args: unknown
+  output?: unknown
+  error?: string
+  startedAt: string
+  finishedAt?: string
+  durationMs?: number
+}
+
+export interface MonitoringFinalization {
+  monitoringSessionId: string
+  agentId: string
+  sessionKey: string
+  status: 'completed' | 'failed' | 'aborted' | 'incomplete'
+  finalAssistantMessage?: string
+  error?: string
+  finalizedAt: string
+}
+
+export interface JudgeAuditEnvelope {
+  run: MonitoringSessionContext
+  toolCalls: MonitoringToolCallRecord[]
+  finalization?: MonitoringFinalization
+}
+
+export interface MonitoringRunSummary {
+  monitoringSessionId: string
+  agentId: string
+  sessionKey: string
+  originalPrompt: string
+  startedAt: string
+  source: MonitoringSessionContext['source']
+  toolCallCount: number
+  finalization?: Pick<
+    MonitoringFinalization,
+    'status' | 'finalizedAt' | 'error'
+  >
+}
+
+export interface MonitoringSessionStartInput {
+  agentId: string
+  sessionKey: string
+  originalPrompt: string
+  chatHistory: MonitoringChatTurn[]
+  source?: MonitoringSessionContext['source']
+}
+
+export interface MonitoringToolStartInput {
+  toolCallId: string
+  toolName: string
+  source: MonitoringToolCallSource
+  args: unknown
+}
+
+export interface MonitoringToolEndInput {
+  toolCallId: string
+  output?: unknown
+  error?: string
+}
+
+export interface MonitoringFinalizeInput {
+  monitoringSessionId: string
+  agentId: string
+  sessionKey: string
+  status: MonitoringFinalization['status']
+  finalAssistantMessage?: string
+  error?: string
+}

--- a/packages/browseros-agent/apps/server/tests/monitoring-storage.test.ts
+++ b/packages/browseros-agent/apps/server/tests/monitoring-storage.test.ts
@@ -1,9 +1,25 @@
-import { describe, expect, it } from 'bun:test'
+import { afterEach, describe, expect, it } from 'bun:test'
+import { appendFile, mkdir, rm } from 'node:fs/promises'
+import {
+  getLazyMonitoringRunDir,
+  getLazyMonitoringRunsDir,
+} from '../src/lib/browseros-dir'
 import {
   InvalidMonitoringRunIdError,
   isValidMonitoringRunId,
   MonitoringStorage,
 } from '../src/monitoring/storage'
+
+const createdRunDirs = new Set<string>()
+
+afterEach(async () => {
+  await Promise.all(
+    [...createdRunDirs].map(async (runId) => {
+      await rm(getLazyMonitoringRunDir(runId), { recursive: true, force: true })
+    }),
+  )
+  createdRunDirs.clear()
+})
 
 describe('MonitoringStorage run id validation', () => {
   it('accepts UUID monitoring run ids', () => {
@@ -19,5 +35,78 @@ describe('MonitoringStorage run id validation', () => {
     await expect(storage.readContext('../../secret')).rejects.toBeInstanceOf(
       InvalidMonitoringRunIdError,
     )
+  })
+
+  it('preserves valid JSONL records when one line is malformed', async () => {
+    const runId = '123e4567-e89b-12d3-a456-426614174001'
+    createdRunDirs.add(runId)
+
+    const storage = new MonitoringStorage()
+    await storage.writeContext({
+      monitoringSessionId: runId,
+      agentId: 'test-agent',
+      sessionKey: 'session-1',
+      originalPrompt: 'Inspect browser state safely',
+      chatHistory: [{ role: 'user', content: 'Inspect browser state safely' }],
+      startedAt: new Date().toISOString(),
+      source: 'debug',
+    })
+
+    await appendFile(
+      getLazyMonitoringRunDir(runId) + '/tool-calls.jsonl',
+      [
+        JSON.stringify({
+          monitoringSessionId: runId,
+          agentId: 'test-agent',
+          toolCallId: 'tool-1',
+          toolName: 'list_windows',
+          source: 'browser-tool',
+          args: {},
+          startedAt: '2026-04-20T15:22:49.817Z',
+          finishedAt: '2026-04-20T15:22:49.818Z',
+          durationMs: 1,
+        }),
+        '{"broken":',
+        JSON.stringify({
+          monitoringSessionId: runId,
+          agentId: 'test-agent',
+          toolCallId: 'tool-2',
+          toolName: 'take_snapshot',
+          source: 'browser-tool',
+          args: {},
+          startedAt: '2026-04-20T15:22:50.817Z',
+          finishedAt: '2026-04-20T15:22:50.818Z',
+          durationMs: 1,
+        }),
+        '',
+      ].join('\n'),
+    )
+
+    const toolCalls = await storage.readToolCalls(runId)
+    expect(toolCalls).toHaveLength(2)
+    expect(toolCalls.map((record) => record.toolCallId)).toEqual([
+      'tool-1',
+      'tool-2',
+    ])
+  })
+
+  it('skips non-uuid directories when listing run ids', async () => {
+    const validRunId = '123e4567-e89b-12d3-a456-426614174002'
+    createdRunDirs.add(validRunId)
+
+    await mkdir(getLazyMonitoringRunsDir(), { recursive: true })
+    await mkdir(getLazyMonitoringRunDir(validRunId), { recursive: true })
+    await mkdir(getLazyMonitoringRunsDir() + '/not-a-uuid', { recursive: true })
+
+    const storage = new MonitoringStorage()
+    const runIds = await storage.listRunIds()
+
+    expect(runIds).toContain(validRunId)
+    expect(runIds).not.toContain('not-a-uuid')
+
+    await rm(getLazyMonitoringRunsDir() + '/not-a-uuid', {
+      recursive: true,
+      force: true,
+    })
   })
 })

--- a/packages/browseros-agent/apps/server/tests/monitoring-storage.test.ts
+++ b/packages/browseros-agent/apps/server/tests/monitoring-storage.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  InvalidMonitoringRunIdError,
+  isValidMonitoringRunId,
+  MonitoringStorage,
+} from '../src/monitoring/storage'
+
+describe('MonitoringStorage run id validation', () => {
+  it('accepts UUID monitoring run ids', () => {
+    expect(isValidMonitoringRunId('123e4567-e89b-12d3-a456-426614174000')).toBe(
+      true,
+    )
+  })
+
+  it('rejects path traversal run ids', async () => {
+    expect(isValidMonitoringRunId('../../secret')).toBe(false)
+
+    const storage = new MonitoringStorage()
+    await expect(storage.readContext('../../secret')).rejects.toBeInstanceOf(
+      InvalidMonitoringRunIdError,
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- add a passive lazy-monitoring substrate for BrowserOS MCP traffic
- record MCP tool call lifecycle data for native browser tools and Klavis proxy tools
- add debug inspection routes to review captured monitoring runs and envelopes

## What this does
This PR adds the BrowserOS-side audit substrate for a non-blocking monitoring flow. It does not change tool behavior or block requests. Instead, it captures enough MCP execution data to support downstream audit and judging workflows.

## Included
- monitoring session storage and envelope assembly
- request-scoped MCP observation when an active monitoring session exists
- tool lifecycle capture for BrowserOS MCP tools and Klavis MCP tools
- monitoring debug routes for local verification

## Not included
- automatic OpenClaw run handoff integration
- monitoring session creation/finalization from the chat lifecycle
- any blocking or policy enforcement behavior
