### PR TITLE
fix: restore openai-compatible OpenClaw providers

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/openclaw-supported-providers.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/openclaw-supported-providers.ts
@@ -3,6 +3,7 @@ import type { LlmProviderConfig, ProviderType } from '@/lib/llm-providers/types'
 const OPENCLAW_SUPPORTED_PROVIDER_TYPES: ProviderType[] = [
   'openrouter',
   'openai',
+  'openai-compatible',
   'anthropic',
   'moonshot',
 ]

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-provider-map.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-provider-map.ts
@@ -14,6 +14,19 @@ export const SUPPORTED_OPENCLAW_PROVIDERS = [
 export type SupportedOpenClawProvider =
   (typeof SUPPORTED_OPENCLAW_PROVIDERS)[number]
 
+export interface CustomOpenClawProviderConfig {
+  providerId: string
+  apiKeyEnvVar: string
+  config: Record<string, unknown>
+}
+
+export interface ResolvedOpenClawProviderConfig {
+  envValues: Record<string, string>
+  model?: string
+  providerType?: SupportedOpenClawProvider
+  customProvider?: CustomOpenClawProviderConfig
+}
+
 const PROVIDER_ENV_VARS: Record<SupportedOpenClawProvider, string> = {
   anthropic: 'ANTHROPIC_API_KEY',
   moonshot: 'MOONSHOT_API_KEY',
@@ -65,6 +78,30 @@ export function buildOpenClawModelRef(
   return modelId ? `${providerType}/${modelId}` : undefined
 }
 
+export function deriveOpenClawProviderId(input: {
+  providerType?: string
+  providerName?: string
+  baseUrl?: string
+}): string {
+  const source =
+    input.providerName?.trim() ||
+    input.baseUrl?.trim() ||
+    input.providerType?.trim() ||
+    'custom-provider'
+
+  const candidate = source
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+
+  return candidate || 'custom-provider'
+}
+
+export function deriveOpenClawApiKeyEnvVar(providerId: string): string {
+  return `${providerId.toUpperCase().replace(/-/g, '_')}_API_KEY`
+}
+
 export function getOpenClawProviderEnvVar(
   providerType: SupportedOpenClawProvider,
 ): string {
@@ -77,20 +114,44 @@ export function resolveSupportedOpenClawProvider(input: {
   baseUrl?: string
   apiKey?: string
   modelId?: string
-}): {
-  envValues: Record<string, string>
-  model?: string
-  providerType?: SupportedOpenClawProvider
-} {
-  const providerType = assertSupportedOpenClawProvider(input.providerType)
-  if (!providerType) {
+}): ResolvedOpenClawProviderConfig {
+  if (!input.providerType) {
     return { envValues: {} }
   }
 
-  const envVar = getOpenClawProviderEnvVar(providerType)
+  if (isSupportedOpenClawProvider(input.providerType)) {
+    const providerType = input.providerType
+    const envVar = getOpenClawProviderEnvVar(providerType)
+    return {
+      envValues: input.apiKey ? { [envVar]: input.apiKey } : {},
+      model: buildOpenClawModelRef(providerType, input.modelId),
+      providerType,
+    }
+  }
+
+  if (!input.baseUrl) {
+    throw new UnsupportedOpenClawProviderError(input.providerType)
+  }
+
+  const providerId = deriveOpenClawProviderId(input)
+  const apiKeyEnvVar = deriveOpenClawApiKeyEnvVar(providerId)
+
   return {
-    envValues: input.apiKey ? { [envVar]: input.apiKey } : {},
-    model: buildOpenClawModelRef(providerType, input.modelId),
-    providerType,
+    envValues: input.apiKey ? { [apiKeyEnvVar]: input.apiKey } : {},
+    model: input.modelId ? `${providerId}/${input.modelId}` : undefined,
+    customProvider: {
+      providerId,
+      apiKeyEnvVar,
+      config: {
+        api: 'openai-completions',
+        baseUrl: input.baseUrl,
+        apiKey: `\${${apiKeyEnvVar}}`,
+        ...(input.modelId
+          ? {
+              models: [{ id: input.modelId, name: input.modelId }],
+            }
+          : {}),
+      },
+    },
   }
 }

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -991,13 +991,19 @@ export class OpenClawService {
             model.name === desiredModelEntry.name,
         )
       : true
+    const mergedModels =
+      desiredModelEntry && !hasDesiredModel
+        ? [...existingModels, desiredModelEntry]
+        : existingModels.length > 0
+          ? existingModels
+          : Array.isArray(provider.customProvider.config.models)
+            ? provider.customProvider.config.models
+            : undefined
 
     const nextProvider: Record<string, unknown> = {
       ...existingProvider,
       ...provider.customProvider.config,
-      ...(desiredModelEntry && !hasDesiredModel
-        ? { models: [...existingModels, desiredModelEntry] }
-        : {}),
+      ...(mergedModels ? { models: mergedModels } : {}),
     }
     const nextModels: Record<string, unknown> = {
       ...models,

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -40,7 +40,10 @@ import {
   mergeEnvContent,
 } from './openclaw-env'
 import { OpenClawHttpChatClient } from './openclaw-http-chat-client'
-import { resolveSupportedOpenClawProvider } from './openclaw-provider-map'
+import {
+  type ResolvedOpenClawProviderConfig,
+  resolveSupportedOpenClawProvider,
+} from './openclaw-provider-map'
 import type { OpenClawStreamEvent } from './openclaw-types'
 import { loadPodmanOverrides, savePodmanOverrides } from './podman-overrides'
 import { configurePodmanRuntime, getPodmanRuntime } from './podman-runtime'
@@ -204,6 +207,7 @@ export class OpenClawService {
       skipHealth: true,
     })
     await this.applyBrowserosConfig()
+    await this.mergeProviderConfigIfChanged(provider)
     if (provider.model) {
       await this.bootstrapCliClient.setDefaultModel(provider.model)
     }
@@ -448,11 +452,13 @@ export class OpenClawService {
     await this.assertGatewayReady()
 
     const provider = resolveSupportedOpenClawProvider(input)
+    const configChanged = await this.mergeProviderConfigIfChanged(provider)
     const keysChanged = await this.writeStateEnv(provider.envValues)
 
-    if (keysChanged) {
+    if (configChanged || keysChanged) {
       logger.info('OpenClaw provider config changed while creating agent', {
         name,
+        configChanged,
         keysChanged,
       })
       await this.restart()
@@ -577,21 +583,23 @@ export class OpenClawService {
     modelId?: string
   }): Promise<OpenClawProviderUpdateResult> {
     const provider = resolveSupportedOpenClawProvider(input)
+    const configChanged = await this.mergeProviderConfigIfChanged(provider)
+    const envChanged = await this.writeStateEnv(provider.envValues)
+    const restarted = configChanged || envChanged
+    if (restarted) {
+      await this.restart()
+    }
     if (provider.model) {
       const model = provider.model
       await this.applyCliMutation(() => this.cliClient.setDefaultModel(model))
     }
-    const changed = await this.writeStateEnv(provider.envValues)
-    if (changed) {
-      await this.restart()
-    }
     logger.info('Provider keys updated', {
       providerType: input.providerType,
       modelUpdated: !!provider.model,
-      restarted: changed,
+      restarted,
     })
     return {
-      restarted: changed,
+      restarted,
       modelUpdated: !!provider.model,
     }
   }
@@ -945,6 +953,76 @@ export class OpenClawService {
     await writeFile(envPath, next.content, { mode: 0o600 })
     logger.debug('Updated OpenClaw provider credentials', {
       keys: Object.keys(values),
+    })
+    return true
+  }
+
+  private async mergeProviderConfigIfChanged(
+    provider: ResolvedOpenClawProviderConfig,
+  ): Promise<boolean> {
+    if (!provider.customProvider) {
+      return false
+    }
+
+    const configPath = this.getStateConfigPath()
+    const content = await readFile(configPath, 'utf-8')
+    const config = JSON.parse(content) as Record<string, unknown>
+    const models =
+      config.models && typeof config.models === 'object'
+        ? (config.models as Record<string, unknown>)
+        : {}
+    const providers =
+      models.providers && typeof models.providers === 'object'
+        ? (models.providers as Record<string, Record<string, unknown>>)
+        : {}
+    const existingProvider = providers[provider.customProvider.providerId] ?? {}
+    const existingModels = Array.isArray(existingProvider.models)
+      ? (existingProvider.models as Array<Record<string, unknown>>)
+      : []
+    const desiredModelEntry =
+      Array.isArray(provider.customProvider.config.models) &&
+      provider.customProvider.config.models.length > 0
+        ? (provider.customProvider.config.models[0] as Record<string, unknown>)
+        : null
+    const hasDesiredModel = desiredModelEntry
+      ? existingModels.some(
+          (model) =>
+            model.id === desiredModelEntry.id ||
+            model.name === desiredModelEntry.name,
+        )
+      : true
+
+    const nextProvider: Record<string, unknown> = {
+      ...existingProvider,
+      ...provider.customProvider.config,
+      ...(desiredModelEntry && !hasDesiredModel
+        ? { models: [...existingModels, desiredModelEntry] }
+        : {}),
+    }
+    const nextModels: Record<string, unknown> = {
+      ...models,
+      mode: 'merge',
+      providers: {
+        ...providers,
+        [provider.customProvider.providerId]: nextProvider,
+      },
+    }
+    const nextConfig: Record<string, unknown> = {
+      ...config,
+      models: nextModels,
+    }
+
+    if (JSON.stringify(config) === JSON.stringify(nextConfig)) {
+      return false
+    }
+
+    await writeFile(
+      configPath,
+      `${JSON.stringify(nextConfig, null, 2)}\n`,
+      'utf-8',
+    )
+    logger.debug('Updated OpenClaw custom provider config', {
+      providerId: provider.customProvider.providerId,
     })
     return true
   }

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-service.test.ts
@@ -46,6 +46,7 @@ type MutableOpenClawService = OpenClawService & {
     createAgent?: ReturnType<typeof mock>
     getConfig?: ReturnType<typeof mock>
     listAgents?: ReturnType<typeof mock>
+    setDefaultModel?: ReturnType<typeof mock>
   }
   bootstrapCliClient: {
     runOnboard?: ReturnType<typeof mock>
@@ -458,6 +459,98 @@ describe('OpenClawService', () => {
     ).toContain('OPENAI_API_KEY=sk-test')
   })
 
+  it('merges custom openai-compatible providers into config during setup', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
+    const openclawTempDir = tempDir
+    const runOnboard = mock(async () => {
+      await mkdir(join(openclawTempDir, '.openclaw'), { recursive: true })
+      await writeFile(
+        join(openclawTempDir, '.openclaw', 'openclaw.json'),
+        JSON.stringify({
+          gateway: {
+            auth: {
+              token: 'cli-token',
+            },
+          },
+        }),
+        'utf-8',
+      )
+    })
+    const setConfigBatch = mock(async () => {})
+    const setDefaultModel = mock(async () => {})
+    const validateConfig = mock(async () => ({ ok: true }))
+    const createAgent = mock(async () => ({
+      agentId: 'main',
+      name: 'main',
+      workspace: `${OPENCLAW_CONTAINER_HOME}/workspace`,
+    }))
+    const service = new OpenClawService() as MutableOpenClawService
+
+    service.openclawDir = tempDir
+    service.runtime = {
+      isPodmanAvailable: async () => true,
+      ensureReady: async () => {},
+      isReady: async () => true,
+      pullImage: async () => {},
+      restartGateway: async () => {},
+      startGateway: async () => {},
+      waitForReady: async () => true,
+    }
+    service.cliClient = {
+      probe: mock(async () => {}),
+      listAgents: mock(async () => []),
+      createAgent,
+    }
+    service.bootstrapCliClient = {
+      runOnboard,
+      setConfigBatch,
+      setDefaultModel,
+      validateConfig,
+    }
+
+    await service.setup({
+      providerType: 'openai-compatible',
+      providerName: 'Kimi K2.5',
+      baseUrl: 'https://api.fireworks.ai/inference/v1',
+      apiKey: 'custom-key',
+      modelId: 'accounts/fireworks/models/kimi-k2p5',
+    })
+
+    expect(setDefaultModel).toHaveBeenCalledWith(
+      'kimi-k2-5/accounts/fireworks/models/kimi-k2p5',
+    )
+    expect(
+      await readFile(join(tempDir, '.openclaw', '.env'), 'utf-8'),
+    ).toContain('KIMI_K2_5_API_KEY=custom-key')
+    expect(
+      JSON.parse(
+        await readFile(join(tempDir, '.openclaw', 'openclaw.json'), 'utf-8'),
+      ),
+    ).toMatchObject({
+      gateway: {
+        auth: {
+          token: 'cli-token',
+        },
+      },
+      models: {
+        mode: 'merge',
+        providers: {
+          'kimi-k2-5': {
+            api: 'openai-completions',
+            baseUrl: 'https://api.fireworks.ai/inference/v1',
+            apiKey: `\${KIMI_K2_5_API_KEY}`,
+            models: [
+              {
+                id: 'accounts/fireworks/models/kimi-k2p5',
+                name: 'accounts/fireworks/models/kimi-k2p5',
+              },
+            ],
+          },
+        },
+      },
+    })
+  })
+
   it('start uses the direct runtime startGateway flow', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
     await mkdir(join(tempDir, '.openclaw'), { recursive: true })
@@ -677,7 +770,7 @@ describe('OpenClawService', () => {
     })
   })
 
-  it('only resolves env vars for the supported bootstrap providers', () => {
+  it('resolves builtin and custom providers into OpenClaw config inputs', () => {
     expect(
       resolveSupportedOpenClawProvider({
         providerType: 'anthropic',
@@ -706,6 +799,36 @@ describe('OpenClawService', () => {
       providerType: 'moonshot',
     })
 
+    expect(
+      resolveSupportedOpenClawProvider({
+        providerType: 'openai-compatible',
+        providerName: 'Kimi K2.5',
+        baseUrl: 'https://api.fireworks.ai/inference/v1',
+        apiKey: 'custom-key',
+        modelId: 'accounts/fireworks/models/kimi-k2p5',
+      }),
+    ).toEqual({
+      envValues: {
+        KIMI_K2_5_API_KEY: 'custom-key',
+      },
+      model: 'kimi-k2-5/accounts/fireworks/models/kimi-k2p5',
+      customProvider: {
+        providerId: 'kimi-k2-5',
+        apiKeyEnvVar: 'KIMI_K2_5_API_KEY',
+        config: {
+          api: 'openai-completions',
+          baseUrl: 'https://api.fireworks.ai/inference/v1',
+          apiKey: `\${KIMI_K2_5_API_KEY}`,
+          models: [
+            {
+              id: 'accounts/fireworks/models/kimi-k2p5',
+              name: 'accounts/fireworks/models/kimi-k2p5',
+            },
+          ],
+        },
+      },
+    })
+
     expect(() =>
       resolveSupportedOpenClawProvider({
         providerType: 'google',
@@ -713,15 +836,6 @@ describe('OpenClawService', () => {
         modelId: 'gemini-2.5-pro',
       }),
     ).toThrow(new UnsupportedOpenClawProviderError('google'))
-
-    expect(() =>
-      resolveSupportedOpenClawProvider({
-        providerType: 'custom-api-key',
-        baseUrl: 'https://example.test/v1',
-        apiKey: 'custom-key',
-        modelId: 'custom-model',
-      }),
-    ).toThrow(new UnsupportedOpenClawProviderError('custom-api-key'))
   })
 
   it('rejects unsupported providers before mutating env or creating agents', async () => {
@@ -797,6 +911,86 @@ describe('OpenClawService', () => {
     expect(restart).not.toHaveBeenCalled()
   })
 
+  it('merges custom openai-compatible providers before creating agents', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
+    await mkdir(join(tempDir, '.openclaw'), { recursive: true })
+    await writeFile(
+      join(tempDir, '.openclaw', 'openclaw.json'),
+      JSON.stringify({
+        gateway: {
+          auth: {
+            token: 'cli-token',
+          },
+        },
+      }),
+      'utf-8',
+    )
+    await writeFile(join(tempDir, '.openclaw', '.env'), '', 'utf-8')
+
+    const createAgent = mock(async () => ({
+      agentId: 'research',
+      name: 'research',
+      workspace: `${OPENCLAW_CONTAINER_HOME}/workspace-research`,
+      model: 'kimi-k2-5/accounts/fireworks/models/kimi-k2p5',
+    }))
+    const restart = mock(async () => {})
+    const service = new OpenClawService() as MutableOpenClawService
+
+    service.openclawDir = tempDir
+    service.restart = restart
+    service.runtime = {
+      isReady: async () => true,
+    }
+    service.cliClient = {
+      createAgent,
+    }
+
+    await service.createAgent({
+      name: 'research',
+      providerType: 'openai-compatible',
+      providerName: 'Kimi K2.5',
+      baseUrl: 'https://api.fireworks.ai/inference/v1',
+      apiKey: 'custom-key',
+      modelId: 'accounts/fireworks/models/kimi-k2p5',
+    })
+
+    expect(restart).toHaveBeenCalledTimes(1)
+    expect(createAgent).toHaveBeenCalledWith({
+      name: 'research',
+      model: 'kimi-k2-5/accounts/fireworks/models/kimi-k2p5',
+    })
+    expect(
+      await readFile(join(tempDir, '.openclaw', '.env'), 'utf-8'),
+    ).toContain('KIMI_K2_5_API_KEY=custom-key')
+    expect(
+      JSON.parse(
+        await readFile(join(tempDir, '.openclaw', 'openclaw.json'), 'utf-8'),
+      ),
+    ).toMatchObject({
+      gateway: {
+        auth: {
+          token: 'cli-token',
+        },
+      },
+      models: {
+        mode: 'merge',
+        providers: {
+          'kimi-k2-5': {
+            api: 'openai-completions',
+            baseUrl: 'https://api.fireworks.ai/inference/v1',
+            apiKey: `\${KIMI_K2_5_API_KEY}`,
+            models: [
+              {
+                id: 'accounts/fireworks/models/kimi-k2p5',
+                name: 'accounts/fireworks/models/kimi-k2p5',
+              },
+            ],
+          },
+        },
+      },
+    })
+  })
+
   it('updateProviderKeys rejects unsupported providers without restarting', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
     const restart = mock(async () => {})
@@ -814,6 +1008,73 @@ describe('OpenClawService', () => {
     ).rejects.toThrow('Unsupported OpenClaw provider')
 
     expect(restart).not.toHaveBeenCalled()
+  })
+
+  it('updateProviderKeys restores custom openai-compatible providers and restarts once', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
+    await mkdir(join(tempDir, '.openclaw'), { recursive: true })
+    await writeFile(
+      join(tempDir, '.openclaw', 'openclaw.json'),
+      JSON.stringify({
+        gateway: {
+          auth: {
+            token: 'cli-token',
+          },
+        },
+      }),
+      'utf-8',
+    )
+    await writeFile(join(tempDir, '.openclaw', '.env'), '', 'utf-8')
+
+    const restart = mock(async () => {})
+    const setDefaultModel = mock(async () => {})
+    const service = new OpenClawService() as MutableOpenClawService
+
+    service.openclawDir = tempDir
+    service.restart = restart
+    service.runtime = {
+      isReady: async () => true,
+      waitForReady: mock(async () => true),
+    }
+    service.cliClient = {
+      setDefaultModel,
+    }
+
+    const result = await service.updateProviderKeys({
+      providerType: 'openai-compatible',
+      providerName: 'Kimi K2.5',
+      baseUrl: 'https://api.fireworks.ai/inference/v1',
+      apiKey: 'custom-key',
+      modelId: 'accounts/fireworks/models/kimi-k2p5',
+    })
+
+    expect(result).toEqual({
+      restarted: true,
+      modelUpdated: true,
+    })
+    expect(restart).toHaveBeenCalledTimes(1)
+    expect(setDefaultModel).toHaveBeenCalledWith(
+      'kimi-k2-5/accounts/fireworks/models/kimi-k2p5',
+    )
+    expect(
+      await readFile(join(tempDir, '.openclaw', '.env'), 'utf-8'),
+    ).toContain('KIMI_K2_5_API_KEY=custom-key')
+    expect(
+      JSON.parse(
+        await readFile(join(tempDir, '.openclaw', 'openclaw.json'), 'utf-8'),
+      ),
+    ).toMatchObject({
+      models: {
+        mode: 'merge',
+        providers: {
+          'kimi-k2-5': {
+            api: 'openai-completions',
+            baseUrl: 'https://api.fireworks.ai/inference/v1',
+            apiKey: `\${KIMI_K2_5_API_KEY}`,
+          },
+        },
+      },
+    })
   })
 
   it('does not restart when provider env content is unchanged', async () => {
@@ -883,7 +1144,7 @@ describe('OpenClawService', () => {
     )
   })
 
-  it('does not persist env updates when setting the default model fails', async () => {
+  it('persists env updates before surfacing default-model failures', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
     await mkdir(join(tempDir, '.openclaw'), { recursive: true })
 
@@ -908,8 +1169,10 @@ describe('OpenClawService', () => {
     ).rejects.toThrow('container unavailable')
 
     expect(setDefaultModel).toHaveBeenCalledWith('openai/gpt-5.4-mini')
-    expect(restart).not.toHaveBeenCalled()
-    expect(existsSync(join(tempDir, '.openclaw', '.env'))).toBe(false)
+    expect(restart).toHaveBeenCalledTimes(1)
+    expect(await readFile(join(tempDir, '.openclaw', '.env'), 'utf-8')).toBe(
+      'OPENAI_API_KEY=sk-test\n',
+    )
   })
 
   it('applyPodmanOverrides persists the override and refreshes the runtime', async () => {

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-service.test.ts
@@ -991,6 +991,94 @@ describe('OpenClawService', () => {
     })
   })
 
+  it('preserves previously-registered custom provider models when re-registering an existing model', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
+    await mkdir(join(tempDir, '.openclaw'), { recursive: true })
+    await writeFile(
+      join(tempDir, '.openclaw', 'openclaw.json'),
+      JSON.stringify({
+        gateway: {
+          auth: {
+            token: 'cli-token',
+          },
+        },
+        models: {
+          mode: 'merge',
+          providers: {
+            'kimi-k2-5': {
+              api: 'openai-completions',
+              baseUrl: 'https://api.fireworks.ai/inference/v1',
+              apiKey: `\${KIMI_K2_5_API_KEY}`,
+              models: [
+                {
+                  id: 'accounts/fireworks/models/kimi-k2p5',
+                  name: 'accounts/fireworks/models/kimi-k2p5',
+                },
+                {
+                  id: 'accounts/fireworks/models/kimi-k2p5-thinking',
+                  name: 'accounts/fireworks/models/kimi-k2p5-thinking',
+                },
+              ],
+            },
+          },
+        },
+      }),
+      'utf-8',
+    )
+    await writeFile(join(tempDir, '.openclaw', '.env'), '', 'utf-8')
+
+    const createAgent = mock(async () => ({
+      agentId: 'research',
+      name: 'research',
+      workspace: `${OPENCLAW_CONTAINER_HOME}/workspace-research`,
+      model: 'kimi-k2-5/accounts/fireworks/models/kimi-k2p5',
+    }))
+    const restart = mock(async () => {})
+    const service = new OpenClawService() as MutableOpenClawService
+
+    service.openclawDir = tempDir
+    service.restart = restart
+    service.runtime = {
+      isReady: async () => true,
+    }
+    service.cliClient = {
+      createAgent,
+    }
+
+    await service.createAgent({
+      name: 'research',
+      providerType: 'openai-compatible',
+      providerName: 'Kimi K2.5',
+      baseUrl: 'https://api.fireworks.ai/inference/v1',
+      apiKey: 'custom-key',
+      modelId: 'accounts/fireworks/models/kimi-k2p5',
+    })
+
+    expect(
+      JSON.parse(
+        await readFile(join(tempDir, '.openclaw', 'openclaw.json'), 'utf-8'),
+      ),
+    ).toMatchObject({
+      models: {
+        mode: 'merge',
+        providers: {
+          'kimi-k2-5': {
+            models: [
+              {
+                id: 'accounts/fireworks/models/kimi-k2p5',
+                name: 'accounts/fireworks/models/kimi-k2p5',
+              },
+              {
+                id: 'accounts/fireworks/models/kimi-k2p5-thinking',
+                name: 'accounts/fireworks/models/kimi-k2p5-thinking',
+              },
+            ],
+          },
+        },
+      },
+    })
+  })
+
   it('updateProviderKeys rejects unsupported providers without restarting', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
     const restart = mock(async () => {})


### PR DESCRIPTION
## Summary
- restore `openai-compatible` providers in the OpenClaw-compatible provider filter
- reintroduce custom OpenClaw provider resolution for providers configured with `baseUrl`
- merge custom provider definitions into OpenClaw config during setup, provider updates, and agent creation
- add regression coverage for Kimi-style provider flows and align the lifecycle failure test with current service behavior

## Context
This restores the behavior that previously existed in #699 and regressed on current branches, where AI Settings can store an OpenAI-compatible provider but OpenClaw setup rejects it as having no compatible provider.

## Testing
- `bunx biome check ...`
- `git diff --check`
- `bun test apps/server/tests/api/services/openclaw/openclaw-service.test.ts`
- `bun test apps/server/tests/api/routes/openclaw.test.ts`
- `bun run --filter @browseros/server typecheck`
