### PR TITLE
feat(agent): V4 Ambient conversation redesign

### DIFF
--- a/packages/browseros-agent/apps/agent/components/ai-elements/conversation.tsx
+++ b/packages/browseros-agent/apps/agent/components/ai-elements/conversation.tsx
@@ -80,13 +80,17 @@ export const ConversationEmptyState = ({
   </div>
 )
 
-export type ConversationScrollButtonProps = ComponentProps<typeof Button>
+export type ConversationScrollButtonProps = ComponentProps<typeof Button> & {
+  offsetBottom?: number
+}
 
 /**
  * @public
  */
 export const ConversationScrollButton = ({
   className,
+  offsetBottom,
+  style,
   ...props
 }: ConversationScrollButtonProps) => {
   const { isAtBottom, scrollToBottom } = useStickToBottomContext()
@@ -95,13 +99,18 @@ export const ConversationScrollButton = ({
     scrollToBottom()
   }, [scrollToBottom])
 
+  const resolvedStyle =
+    offsetBottom != null ? { ...style, bottom: offsetBottom } : style
+
   return (
     !isAtBottom && (
       <Button
         className={cn(
-          'absolute right-[16px] bottom-4 translate-x-[-50%] rounded-full',
+          'absolute right-[16px] translate-x-[-50%] rounded-full',
+          offsetBottom == null && 'bottom-4',
           className,
         )}
+        style={resolvedStyle}
         onClick={handleScrollToBottom}
         size="icon"
         type="button"

--- a/packages/browseros-agent/apps/agent/components/ai-elements/reasoning.tsx
+++ b/packages/browseros-agent/apps/agent/components/ai-elements/reasoning.tsx
@@ -132,18 +132,18 @@ export const ReasoningTrigger = memo(
     return (
       <CollapsibleTrigger
         className={cn(
-          'flex w-full items-center gap-2 text-muted-foreground text-sm transition-colors hover:text-foreground',
+          'flex items-center gap-1.5 font-medium text-[12px] text-muted-foreground transition-colors hover:text-foreground',
           className,
         )}
         {...props}
       >
         {children ?? (
           <>
-            <BrainIcon className="size-4" />
+            <BrainIcon className="size-3" />
             {getThinkingMessage(isStreaming, duration)}
             <ChevronDownIcon
               className={cn(
-                'size-4 transition-transform',
+                'size-2.5 transition-transform',
                 isOpen ? 'rotate-180' : 'rotate-0',
               )}
             />
@@ -165,13 +165,15 @@ export const ReasoningContent = memo(
   ({ className, children, ...props }: ReasoningContentProps) => (
     <CollapsibleContent
       className={cn(
-        'mt-4 text-sm',
-        'data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 text-muted-foreground outline-none data-[state=closed]:animate-out data-[state=open]:animate-in',
+        'mt-2',
+        'data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 outline-none data-[state=closed]:animate-out data-[state=open]:animate-in',
         className,
       )}
       {...props}
     >
-      <Streamdown {...props}>{children}</Streamdown>
+      <div className="rounded-lg bg-muted px-3.5 py-3 text-[13px] text-muted-foreground italic leading-[1.6]">
+        <Streamdown {...props}>{children}</Streamdown>
+      </div>
     </CollapsibleContent>
   ),
 )

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/Chat.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/Chat.tsx
@@ -1,5 +1,5 @@
 import { Loader2 } from 'lucide-react'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { createBrowserOSAction } from '@/lib/chat-actions/types'
 import {
   SIDEPANEL_AI_TRIGGERED_EVENT,
@@ -17,11 +17,12 @@ import { useJtbdPopup } from '@/lib/jtbd-popup/useJtbdPopup'
 import { track } from '@/lib/metrics/track'
 import { useVoiceInput } from '@/lib/voice/useVoiceInput'
 import { useChatSessionContext } from '../layout/ChatSessionContext'
-import { ChatEmptyState } from './ChatEmptyState'
+import { ChatComposerFloating } from './ambient/ChatComposerFloating'
+import { ChatOverlayBar } from './ambient/ChatOverlayBar'
+import { EditorialHeader } from './ambient/EditorialHeader'
 import { ChatError } from './ChatError'
-import { ChatFooter } from './ChatFooter'
 import { ChatMessages } from './ChatMessages'
-import type { ChatMode } from './chatTypes'
+import { AGENT_SUGGESTIONS, CHAT_SUGGESTIONS, type ChatMode } from './chatTypes'
 
 /**
  * @public
@@ -36,7 +37,10 @@ export const Chat = () => {
     stop,
     agentUrlError,
     chatError,
+    providers,
     selectedProvider,
+    handleSelectProvider,
+    resetConversation,
     getActionForMessage,
     liked,
     onClickLike,
@@ -60,6 +64,11 @@ export const Chat = () => {
   const [input, setInput] = useState('')
   const [attachedTabs, setAttachedTabs] = useState<chrome.tabs.Tab[]>([])
   const [mounted, setMounted] = useState(false)
+
+  const sessionHash = useMemo(() => {
+    return crypto.randomUUID().slice(0, 6)
+    // Rotates on full remount (new provider / new session); fine for display-only.
+  }, [])
 
   useEffect(() => {
     setMounted(true)
@@ -197,19 +206,32 @@ export const Chat = () => {
     onStopRecording: handleStopRecording,
   }
 
+  const suggestions = mode === 'chat' ? CHAT_SUGGESTIONS : AGENT_SUGGESTIONS
+  const title = selectedProvider?.name ?? 'Agent'
+  const subtitleParts = [
+    mode === 'agent' ? 'Agent mode' : 'Chat with this page',
+    `session/${sessionHash}`,
+    `${messages.length} turn${messages.length === 1 ? '' : 's'}`,
+  ]
+
   return (
-    <>
-      <main className="mt-4 flex h-full flex-1 flex-col space-y-4 overflow-y-auto">
+    <div className="relative flex h-full min-h-0 w-full flex-1 flex-col">
+      <ChatOverlayBar
+        status={status}
+        mode={mode}
+        onModeChange={handleModeChange}
+        selectedProvider={selectedProvider}
+        providers={providers}
+        onSelectProvider={handleSelectProvider}
+        onNewConversation={resetConversation}
+        hasMessages={messages.length > 0}
+      />
+
+      <main className="flex h-full min-h-0 flex-1 flex-col overflow-hidden">
         {isRestoringConversation ? (
           <div className="flex flex-1 items-center justify-center">
             <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
           </div>
-        ) : messages.length === 0 ? (
-          <ChatEmptyState
-            mode={mode}
-            mounted={mounted}
-            onSuggestionClick={handleSuggestionClick}
-          />
         ) : (
           <ChatMessages
             messages={messages}
@@ -229,22 +251,43 @@ export const Chat = () => {
             onToolDeny={(id) =>
               addToolApprovalResponse({ id, approved: false })
             }
+            variant="ambient"
+            header={
+              <EditorialHeader title={title} subtitleParts={subtitleParts} />
+            }
+            emptyStateSlot={
+              <AmbientEmptyStateSuggestions
+                mounted={mounted}
+                suggestions={suggestions}
+                onClick={handleSuggestionClick}
+              />
+            }
           />
         )}
         {agentUrlError && (
-          <ChatError
-            error={agentUrlError}
-            providerType={selectedProvider?.type}
-          />
+          <div className="pointer-events-none absolute inset-x-0 bottom-[130px] z-20 flex justify-center px-6">
+            <div className="pointer-events-auto w-full max-w-[720px]">
+              <ChatError
+                error={agentUrlError}
+                providerType={selectedProvider?.type}
+              />
+            </div>
+          </div>
         )}
         {chatError && (
-          <ChatError error={chatError} providerType={selectedProvider?.type} />
+          <div className="pointer-events-none absolute inset-x-0 bottom-[130px] z-20 flex justify-center px-6">
+            <div className="pointer-events-auto w-full max-w-[720px]">
+              <ChatError
+                error={chatError}
+                providerType={selectedProvider?.type}
+              />
+            </div>
+          </div>
         )}
       </main>
 
-      <ChatFooter
+      <ChatComposerFloating
         mode={mode}
-        onModeChange={handleModeChange}
         input={input}
         onInputChange={setInput}
         onSubmit={handleSubmit}
@@ -255,6 +298,33 @@ export const Chat = () => {
         onRemoveTab={removeTab}
         voice={voiceState}
       />
-    </>
+    </div>
   )
 }
+
+const AmbientEmptyStateSuggestions: React.FC<{
+  mounted: boolean
+  suggestions: { display: string; prompt: string; icon: string }[]
+  onClick: (prompt: string) => void
+}> = ({ mounted, suggestions, onClick }) => (
+  <div
+    className={`mt-2 flex flex-col gap-2 transition-all duration-500 ${
+      mounted ? 'translate-y-0 opacity-100' : 'translate-y-2 opacity-0'
+    }`}
+  >
+    <div className="mb-1 text-[13px] text-muted-foreground">Try asking…</div>
+    {suggestions.map((s) => (
+      <button
+        type="button"
+        key={s.display}
+        onClick={() => onClick(s.prompt)}
+        className="group flex items-center justify-between rounded-[10px] border border-border bg-background px-3.5 py-3 text-left text-sm transition-all hover:border-[var(--accent-orange)]/50 hover:bg-[var(--accent-orange)]/5"
+      >
+        <span>{s.display}</span>
+        <span className="text-muted-foreground opacity-0 transition-opacity group-hover:opacity-100">
+          {s.icon}
+        </span>
+      </button>
+    ))}
+  </div>
+)

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/Chat.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/Chat.tsx
@@ -1,5 +1,5 @@
 import { Loader2 } from 'lucide-react'
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { createBrowserOSAction } from '@/lib/chat-actions/types'
 import {
   SIDEPANEL_AI_TRIGGERED_EVENT,
@@ -65,10 +65,8 @@ export const Chat = () => {
   const [attachedTabs, setAttachedTabs] = useState<chrome.tabs.Tab[]>([])
   const [mounted, setMounted] = useState(false)
 
-  const sessionHash = useMemo(() => {
-    return crypto.randomUUID().slice(0, 6)
-    // Rotates on full remount (new provider / new session); fine for display-only.
-  }, [])
+  // Stable across renders; lazy-init via useState so crypto.randomUUID runs once.
+  const [sessionHash] = useState(() => crypto.randomUUID().slice(0, 6))
 
   useEffect(() => {
     setMounted(true)
@@ -265,24 +263,20 @@ export const Chat = () => {
           />
         )}
         {agentUrlError && (
-          <div className="pointer-events-none absolute inset-x-0 bottom-[130px] z-20 flex justify-center px-6">
-            <div className="pointer-events-auto w-full max-w-[720px]">
-              <ChatError
-                error={agentUrlError}
-                providerType={selectedProvider?.type}
-              />
-            </div>
-          </div>
+          <FloatingErrorBanner>
+            <ChatError
+              error={agentUrlError}
+              providerType={selectedProvider?.type}
+            />
+          </FloatingErrorBanner>
         )}
         {chatError && (
-          <div className="pointer-events-none absolute inset-x-0 bottom-[130px] z-20 flex justify-center px-6">
-            <div className="pointer-events-auto w-full max-w-[720px]">
-              <ChatError
-                error={chatError}
-                providerType={selectedProvider?.type}
-              />
-            </div>
-          </div>
+          <FloatingErrorBanner>
+            <ChatError
+              error={chatError}
+              providerType={selectedProvider?.type}
+            />
+          </FloatingErrorBanner>
         )}
       </main>
 
@@ -301,6 +295,14 @@ export const Chat = () => {
     </div>
   )
 }
+
+const FloatingErrorBanner: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => (
+  <div className="pointer-events-none absolute inset-x-0 bottom-[130px] z-20 flex justify-center px-6">
+    <div className="pointer-events-auto w-full max-w-[720px]">{children}</div>
+  </div>
+)
 
 const AmbientEmptyStateSuggestions: React.FC<{
   mounted: boolean

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/Chat.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/Chat.tsx
@@ -296,10 +296,12 @@ export const Chat = () => {
   )
 }
 
+// Leaves headroom above the composer even when attached-tab and selected-text
+// rows expand it by ~80px beyond the baseline pill height (~110px).
 const FloatingErrorBanner: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => (
-  <div className="pointer-events-none absolute inset-x-0 bottom-[130px] z-20 flex justify-center px-6">
+  <div className="pointer-events-none absolute inset-x-0 bottom-[220px] z-20 flex justify-center px-6">
     <div className="pointer-events-auto w-full max-w-[720px]">{children}</div>
   </div>
 )
@@ -318,7 +320,7 @@ const AmbientEmptyStateSuggestions: React.FC<{
     {suggestions.map((s) => (
       <button
         type="button"
-        key={s.display}
+        key={s.prompt}
         onClick={() => onClick(s.prompt)}
         className="group flex items-center justify-between rounded-[10px] border border-border bg-background px-3.5 py-3 text-left text-sm transition-all hover:border-[var(--accent-orange)]/50 hover:bg-[var(--accent-orange)]/5"
       >

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ChatMessages.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ChatMessages.tsx
@@ -1,6 +1,6 @@
 import type { UIMessage } from 'ai'
 import { Bot } from 'lucide-react'
-import { type FC, Fragment } from 'react'
+import { type FC, Fragment, type ReactNode } from 'react'
 import {
   Conversation,
   ConversationContent,
@@ -17,6 +17,8 @@ import {
   ReasoningTrigger,
 } from '@/components/ai-elements/reasoning'
 import type { ChatAction } from '@/lib/chat-actions/types'
+import { cn } from '@/lib/utils'
+import { AmbientUserTurn } from './ambient/AmbientUserTurn'
 import { ChatMessageActions } from './ChatMessageActions'
 import { ConnectAppCard } from './ConnectAppCard'
 import { getMessageSegments } from './getMessageSegments'
@@ -24,6 +26,8 @@ import { JtbdPopup } from './JtbdPopup'
 import { ScheduleSuggestionCard } from './ScheduleSuggestionCard'
 import { ToolBatch } from './ToolBatch'
 import { UserActionMessage } from './UserActionMessage'
+
+type ChatMessagesVariant = 'default' | 'ambient'
 
 interface ChatMessagesProps {
   messages: UIMessage[]
@@ -39,6 +43,9 @@ interface ChatMessagesProps {
   onDismissJtbdPopup: (dontShowAgain: boolean) => void
   onToolApprove?: (approvalId: string) => void
   onToolDeny?: (approvalId: string) => void
+  variant?: ChatMessagesVariant
+  header?: ReactNode
+  emptyStateSlot?: ReactNode
 }
 
 export const ChatMessages: FC<ChatMessagesProps> = ({
@@ -55,13 +62,24 @@ export const ChatMessages: FC<ChatMessagesProps> = ({
   onDismissJtbdPopup,
   onToolApprove,
   onToolDeny,
+  variant = 'default',
+  header,
+  emptyStateSlot,
 }) => {
   const isStreaming = status === 'streaming' || status === 'submitted'
+  const ambient = variant === 'ambient'
 
   return (
     <>
       <Conversation className="ph-mask">
-        <ConversationContent>
+        <ConversationContent
+          className={cn(
+            ambient &&
+              'mx-auto w-full max-w-[760px] gap-4 px-4 pt-10 pb-[160px] sm:px-8 sm:pt-[72px]',
+          )}
+        >
+          {header}
+          {ambient && messages.length === 0 && emptyStateSlot}
           {messages.map((message, messageIndex) => {
             const action = getActionForMessage?.(message)
             const isLastMessage = messageIndex === messages.length - 1
@@ -82,10 +100,33 @@ export const ChatMessages: FC<ChatMessagesProps> = ({
             const dislikeAction = (comment?: string) =>
               onClickDislike(message.id, comment)
 
+            if (ambient && message.role === 'user' && !action) {
+              return (
+                <Fragment key={message.id}>
+                  <AmbientUserTurn>
+                    <div className="whitespace-pre-wrap">
+                      {segments
+                        .filter((s) => s.type === 'text')
+                        .map((s) => s.text)
+                        .join('\n\n')}
+                    </div>
+                  </AmbientUserTurn>
+                </Fragment>
+              )
+            }
+
             return (
               <Fragment key={message.id}>
-                <Message from={message.role}>
-                  <MessageContent>
+                <Message
+                  from={message.role}
+                  className={cn(ambient && 'max-w-full')}
+                >
+                  <MessageContent
+                    className={cn(
+                      ambient &&
+                        'group-[.is-assistant]:pl-0 sm:group-[.is-assistant]:pl-[42px]',
+                    )}
+                  >
                     {action ? (
                       <UserActionMessage action={action} />
                     ) : (
@@ -93,15 +134,23 @@ export const ChatMessages: FC<ChatMessagesProps> = ({
                         switch (segment.type) {
                           case 'text':
                             return (
-                              <MessageResponse key={segment.key}>
-                                {segment.text}
-                              </MessageResponse>
+                              <div
+                                key={segment.key}
+                                className={cn(
+                                  ambient &&
+                                    'my-2 text-[14.5px] leading-[1.65]',
+                                )}
+                              >
+                                <MessageResponse>
+                                  {segment.text}
+                                </MessageResponse>
+                              </div>
                             )
                           case 'reasoning':
                             return (
                               <Reasoning
                                 key={segment.key}
-                                className="w-full"
+                                className={cn('w-full', ambient && 'my-3')}
                                 isStreaming={segment.isStreaming}
                               >
                                 <ReasoningTrigger />
@@ -146,14 +195,16 @@ export const ChatMessages: FC<ChatMessagesProps> = ({
                 </Message>
                 {message.role === 'assistant' &&
                 (!isLastMessage || !isStreaming) ? (
-                  <ChatMessageActions
-                    messageId={message.id}
-                    messageText={messageText}
-                    liked={liked[message.id] ?? false}
-                    disliked={disliked[message.id] ?? false}
-                    onClickLike={likeAction}
-                    onClickDislike={dislikeAction}
-                  />
+                  <div className={cn(ambient && 'sm:pl-[42px]')}>
+                    <ChatMessageActions
+                      messageId={message.id}
+                      messageText={messageText}
+                      liked={liked[message.id] ?? false}
+                      disliked={disliked[message.id] ?? false}
+                      onClickLike={likeAction}
+                      onClickDislike={dislikeAction}
+                    />
+                  </div>
                 ) : null}
               </Fragment>
             )
@@ -165,11 +216,12 @@ export const ChatMessages: FC<ChatMessagesProps> = ({
               showDontShowAgain={showDontShowAgain}
             />
           )}
+          {ambient && isStreaming && <AmbientStreamingIndicator />}
         </ConversationContent>
-        <ConversationScrollButton />
+        <ConversationScrollButton offsetBottom={ambient ? 170 : undefined} />
       </Conversation>
 
-      {isStreaming && (
+      {!ambient && isStreaming && (
         <div className="flex animate-fadeInUp gap-2 px-3">
           <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[var(--accent-orange)] text-white">
             <Bot className="h-3.5 w-3.5" />
@@ -185,3 +237,13 @@ export const ChatMessages: FC<ChatMessagesProps> = ({
     </>
   )
 }
+
+const AmbientStreamingIndicator = () => (
+  <div className="mt-2 mb-1 flex items-center gap-2 text-[13px] text-muted-foreground sm:pl-[42px]">
+    <span className="flex gap-1">
+      <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--accent-orange)] [animation-delay:-0.3s]" />
+      <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--accent-orange)] [animation-delay:-0.15s]" />
+      <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--accent-orange)]" />
+    </span>
+  </div>
+)

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ChatMessages.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ChatMessages.tsx
@@ -102,16 +102,14 @@ export const ChatMessages: FC<ChatMessagesProps> = ({
 
             if (ambient && message.role === 'user' && !action) {
               return (
-                <Fragment key={message.id}>
-                  <AmbientUserTurn>
-                    <div className="whitespace-pre-wrap">
-                      {segments
-                        .filter((s) => s.type === 'text')
-                        .map((s) => s.text)
-                        .join('\n\n')}
-                    </div>
-                  </AmbientUserTurn>
-                </Fragment>
+                <AmbientUserTurn key={message.id}>
+                  <div className="whitespace-pre-wrap">
+                    {segments
+                      .filter((s) => s.type === 'text')
+                      .map((s) => s.text)
+                      .join('\n\n')}
+                  </div>
+                </AmbientUserTurn>
               )
             }
 
@@ -216,7 +214,7 @@ export const ChatMessages: FC<ChatMessagesProps> = ({
               showDontShowAgain={showDontShowAgain}
             />
           )}
-          {ambient && isStreaming && <AmbientStreamingIndicator />}
+          {ambient && <AmbientStreamingIndicator visible={isStreaming} />}
         </ConversationContent>
         <ConversationScrollButton offsetBottom={ambient ? 170 : undefined} />
       </Conversation>
@@ -233,17 +231,18 @@ export const ChatMessages: FC<ChatMessagesProps> = ({
           </div>
         </div>
       )}
-      <div />
     </>
   )
 }
 
-const AmbientStreamingIndicator = () => (
-  <div className="mt-2 mb-1 flex items-center gap-2 text-[13px] text-muted-foreground sm:pl-[42px]">
-    <span className="flex gap-1">
-      <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--accent-orange)] [animation-delay:-0.3s]" />
-      <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--accent-orange)] [animation-delay:-0.15s]" />
-      <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--accent-orange)]" />
-    </span>
+const AmbientStreamingIndicator: FC<{ visible: boolean }> = ({ visible }) => (
+  <div className="mt-2 mb-1 flex min-h-[18px] items-center gap-2 text-[13px] text-muted-foreground sm:pl-[42px]">
+    {visible && (
+      <span className="flex gap-1">
+        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--accent-orange)] [animation-delay:-0.3s]" />
+        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--accent-orange)] [animation-delay:-0.15s]" />
+        <span className="h-1.5 w-1.5 animate-bounce rounded-full bg-[var(--accent-orange)]" />
+      </span>
+    )}
   </div>
 )

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ChatMessages.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ChatMessages.tsx
@@ -75,7 +75,7 @@ export const ChatMessages: FC<ChatMessagesProps> = ({
         <ConversationContent
           className={cn(
             ambient &&
-              'mx-auto w-full max-w-[760px] gap-4 px-4 pt-10 pb-[160px] sm:px-8 sm:pt-[72px]',
+              'mx-auto w-full max-w-[760px] gap-4 px-4 pt-14 pb-[160px] sm:px-8 sm:pt-[72px]',
           )}
         >
           {header}

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ToolBatch.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ToolBatch.tsx
@@ -132,12 +132,36 @@ const formatToolName = (name: string) => {
     ?.replace(/^./, (s) => s.toUpperCase())
 }
 
+// Allowlisted keys that are safe to preview — excludes fields like `token`,
+// `password`, `apiKey`, or arbitrary free-form strings that may contain
+// credentials or page content.
+const SAFE_PREVIEW_KEYS = new Set([
+  'url',
+  'href',
+  'link',
+  'query',
+  'search',
+  'path',
+  'file',
+  'filename',
+  'name',
+  'title',
+  'selector',
+  'tabId',
+  'id',
+])
+const MAX_PREVIEW_LEN = 80
+
 const formatInputPreview = (input: Record<string, unknown> | undefined) => {
   if (!input) return ''
-  const firstValue = Object.values(input).find(
-    (v) => typeof v === 'string' && v.length > 0,
-  )
-  if (typeof firstValue === 'string') return firstValue
+  for (const key of SAFE_PREVIEW_KEYS) {
+    const value = input[key]
+    if (typeof value === 'string' && value.length > 0) {
+      return value.length > MAX_PREVIEW_LEN
+        ? `${value.slice(0, MAX_PREVIEW_LEN)}…`
+        : value
+    }
+  }
   return ''
 }
 

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ToolBatch.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ToolBatch.tsx
@@ -1,6 +1,6 @@
 import {
-  BotIcon,
-  CheckCircle2,
+  Check,
+  ChevronDown,
   CircleDashed,
   Clock,
   Loader2,
@@ -9,13 +9,13 @@ import {
   XCircle,
 } from 'lucide-react'
 import { type FC, useEffect, useState } from 'react'
-import {
-  Task,
-  TaskContent,
-  TaskItem,
-  TaskTrigger,
-} from '@/components/ai-elements/task'
 import { Button } from '@/components/ui/button'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import { cn } from '@/lib/utils'
 import type {
   ToolInvocationInfo,
   ToolInvocationState,
@@ -65,9 +65,10 @@ export const ToolBatch: FC<ToolBatchProps> = ({
   ])
 
   const completedCount = tools.filter((t) => isToolCompleted(t.state)).length
-  const triggerTitle = hasPendingApproval
-    ? 'Waiting for approval...'
-    : `${completedCount}/${tools.length} actions completed`
+  const allDone = completedCount === tools.length && !hasPendingApproval
+  const headerLabel = hasPendingApproval
+    ? 'Waiting for approval'
+    : `${tools.length} tool ${tools.length === 1 ? 'call' : 'calls'}${allDone ? '' : ` · ${completedCount}/${tools.length}`}`
 
   const onManualToggle = (newState: boolean) => {
     setHasUserInteracted(true)
@@ -75,15 +76,40 @@ export const ToolBatch: FC<ToolBatchProps> = ({
   }
 
   return (
-    <Task open={isOpen} onOpenChange={onManualToggle}>
-      <TaskTrigger title={triggerTitle} TriggerIcon={BotIcon} />
-      <TaskContent>
+    <Collapsible
+      open={isOpen}
+      onOpenChange={onManualToggle}
+      className="my-3 rounded-[10px] border border-border bg-background px-3 py-2.5"
+    >
+      <CollapsibleTrigger asChild>
+        <button
+          type="button"
+          className="group flex w-full items-center gap-2 text-left"
+        >
+          <span className="font-semibold text-[11px] text-muted-foreground uppercase tracking-[0.4px]">
+            {headerLabel}
+          </span>
+          <div className="flex-1" />
+          <ChevronDown className="h-3 w-3 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+        </button>
+      </CollapsibleTrigger>
+      <CollapsibleContent
+        className={cn(
+          'mt-2 grid gap-0.5',
+          'data-[state=closed]:fade-out-0 data-[state=closed]:slide-out-to-top-2 data-[state=open]:slide-in-from-top-2 outline-none data-[state=closed]:animate-out data-[state=open]:animate-in',
+        )}
+      >
         {tools.map((tool) => (
           <div key={tool.toolCallId}>
-            <TaskItem className="flex items-center gap-2">
+            <div className="flex items-center gap-2.5 py-1 font-mono text-xs">
               <ToolStatusIcon state={tool.state} />
-              <span className="flex-1">{formatToolName(tool.toolName)}</span>
-            </TaskItem>
+              <span className="font-medium">
+                {formatToolName(tool.toolName)}
+              </span>
+              <span className="flex-1 overflow-hidden text-ellipsis whitespace-nowrap text-muted-foreground">
+                {formatInputPreview(tool.input)}
+              </span>
+            </div>
             {tool.state === 'approval-requested' &&
               tool.approval?.id != null && (
                 <ApprovalButtons
@@ -94,8 +120,8 @@ export const ToolBatch: FC<ToolBatchProps> = ({
               )}
           </div>
         ))}
-      </TaskContent>
-    </Task>
+      </CollapsibleContent>
+    </Collapsible>
   )
 }
 
@@ -104,6 +130,15 @@ const formatToolName = (name: string) => {
     ?.replace(/_/g, ' ')
     ?.replace(/([a-z])([A-Z])/g, '$1 $2')
     ?.replace(/^./, (s) => s.toUpperCase())
+}
+
+const formatInputPreview = (input: Record<string, unknown> | undefined) => {
+  if (!input) return ''
+  const firstValue = Object.values(input).find(
+    (v) => typeof v === 'string' && v.length > 0,
+  )
+  if (typeof firstValue === 'string') return firstValue
+  return ''
 }
 
 const isToolCompleted = (state: ToolInvocationState) =>
@@ -124,7 +159,7 @@ const ApprovalButtons: FC<{
   onApprove?: (id: string) => void
   onDeny?: (id: string) => void
 }> = ({ approvalId, onApprove, onDeny }) => (
-  <div className="mt-1 mb-2 ml-6 flex items-center gap-2">
+  <div className="mt-1 mb-1.5 ml-5 flex items-center gap-2">
     <Button
       size="sm"
       className="h-7 gap-1 px-2.5 text-xs"
@@ -147,21 +182,26 @@ const ApprovalButtons: FC<{
 
 const ToolStatusIcon: FC<{ state: ToolInvocationState }> = ({ state }) => {
   if (isToolCompleted(state)) {
-    return <CheckCircle2 className="h-3.5 w-3.5 text-green-500" />
+    return (
+      <Check
+        className="h-3 w-3 text-[var(--accent-orange)]"
+        strokeWidth={2.5}
+      />
+    )
   }
   if (isToolApprovalPending(state)) {
-    return <Clock className="h-3.5 w-3.5 text-yellow-500" />
+    return <Clock className="h-3 w-3 text-yellow-500" />
   }
   if (isToolDenied(state)) {
-    return <ShieldX className="h-3.5 w-3.5 text-red-400" />
+    return <ShieldX className="h-3 w-3 text-red-400" />
   }
   if (isToolInProgress(state)) {
     return (
-      <Loader2 className="h-3.5 w-3.5 animate-spin text-[var(--accent-orange)]" />
+      <Loader2 className="h-3 w-3 animate-spin text-[var(--accent-orange)]" />
     )
   }
   if (isToolError(state)) {
-    return <XCircle className="h-3.5 w-3.5 text-destructive" />
+    return <XCircle className="h-3 w-3 text-destructive" />
   }
-  return <CircleDashed className="h-3.5 w-3.5 text-muted-foreground" />
+  return <CircleDashed className="h-3 w-3 text-muted-foreground" />
 }

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ambient/AmbientUserTurn.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ambient/AmbientUserTurn.tsx
@@ -1,0 +1,16 @@
+import type { FC, ReactNode } from 'react'
+
+interface AmbientUserTurnProps {
+  children: ReactNode
+}
+
+export const AmbientUserTurn: FC<AmbientUserTurnProps> = ({ children }) => (
+  <div className="mt-8 mb-5 flex gap-3.5">
+    <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[var(--accent-orange-soft)] font-semibold text-[var(--accent-orange)] text-xs">
+      U
+    </div>
+    <div className="pt-1 font-medium text-[15px] leading-[1.55]">
+      {children}
+    </div>
+  </div>
+)

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ambient/ChatComposerFloating.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ambient/ChatComposerFloating.tsx
@@ -75,6 +75,8 @@ export const ChatComposerFloating: FC<ChatComposerFloatingProps> = ({
 
   useEffect(() => {
     const focusInput = () => {
+      // A Radix popover being open means the user is mid-interaction — don't steal focus.
+      if (document.querySelector('[data-radix-popper-content-wrapper]')) return
       const active = document.activeElement
       const isInteractiveElementFocused =
         active instanceof HTMLInputElement ||

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ambient/ChatComposerFloating.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ambient/ChatComposerFloating.tsx
@@ -1,0 +1,236 @@
+import { ChevronDown, Folder, Layers, PlugZap, Sparkles } from 'lucide-react'
+import type { FC, FormEvent } from 'react'
+import { useEffect, useRef, useState } from 'react'
+import { AppSelector } from '@/components/elements/AppSelector'
+import { WorkspaceSelector } from '@/components/elements/workspace-selector'
+import { McpServerIcon } from '@/entrypoints/app/connect-mcp/McpServerIcon'
+import { useGetUserMCPIntegrations } from '@/entrypoints/app/connect-mcp/useGetUserMCPIntegrations'
+import { Feature } from '@/lib/browseros/capabilities'
+import { useCapabilities } from '@/lib/browseros/useCapabilities'
+import { useMcpServers } from '@/lib/mcp/mcpServerStorage'
+import {
+  type SelectedTextData,
+  selectedTextStorage,
+} from '@/lib/selected-text/selectedTextStorage'
+import { cn } from '@/lib/utils'
+import type { VoiceInputState } from '@/lib/voice/useVoiceInput'
+import { useWorkspace } from '@/lib/workspace/use-workspace'
+import { ChatAttachedTabs } from '../ChatAttachedTabs'
+import { ChatInput, type ChatInputHandle } from '../ChatInput'
+import { ChatSelectedText } from '../ChatSelectedText'
+import type { ChatMode } from '../chatTypes'
+
+interface ChatComposerFloatingProps {
+  mode: ChatMode
+  input: string
+  onInputChange: (v: string) => void
+  onSubmit: (e: FormEvent) => void
+  status: 'streaming' | 'submitted' | 'ready' | 'error'
+  onStop: () => void
+  attachedTabs: chrome.tabs.Tab[]
+  onToggleTab: (t: chrome.tabs.Tab) => void
+  onRemoveTab: (id?: number) => void
+  voice?: VoiceInputState
+}
+
+export const ChatComposerFloating: FC<ChatComposerFloatingProps> = ({
+  mode,
+  input,
+  onInputChange,
+  onSubmit,
+  status,
+  onStop,
+  attachedTabs,
+  onToggleTab,
+  onRemoveTab,
+  voice,
+}) => {
+  const { selectedFolder } = useWorkspace()
+  const { supports } = useCapabilities()
+  const { servers: mcpServers } = useMcpServers()
+  const { data: userMCPIntegrations } = useGetUserMCPIntegrations()
+  const chatInputRef = useRef<ChatInputHandle>(null)
+  const [selectionMap, setSelectionMap] = useState<
+    Record<string, SelectedTextData>
+  >({})
+  const [activeTabId, setActiveTabId] = useState<number | undefined>()
+  const [isTabMentionOpen, setIsTabMentionOpen] = useState(false)
+
+  useEffect(() => {
+    chrome.tabs
+      .query({ active: true, currentWindow: true })
+      .then((tabs) => setActiveTabId(tabs[0]?.id))
+    const listener = (activeInfo: { tabId: number }) => {
+      setActiveTabId(activeInfo.tabId)
+    }
+    chrome.tabs.onActivated.addListener(listener)
+    return () => chrome.tabs.onActivated.removeListener(listener)
+  }, [])
+
+  useEffect(() => {
+    selectedTextStorage.getValue().then(setSelectionMap)
+    const unwatch = selectedTextStorage.watch(setSelectionMap)
+    return () => unwatch()
+  }, [])
+
+  useEffect(() => {
+    const focusInput = () => {
+      const active = document.activeElement
+      const isInteractiveElementFocused =
+        active instanceof HTMLInputElement ||
+        active instanceof HTMLTextAreaElement ||
+        active instanceof HTMLSelectElement ||
+        active instanceof HTMLButtonElement
+      if (!isInteractiveElementFocused) {
+        chatInputRef.current?.focus()
+      }
+    }
+    if (document.hasFocus()) {
+      focusInput()
+    }
+    window.addEventListener('focus', focusInput)
+    return () => window.removeEventListener('focus', focusInput)
+  }, [])
+
+  const visibleSelectedText = activeTabId
+    ? (selectionMap[String(activeTabId)] ?? null)
+    : null
+
+  const connectedManagedServers = mcpServers.filter((s) => {
+    if (s.type !== 'managed' || !s.managedServerName) return false
+    return userMCPIntegrations?.integrations?.find(
+      (i) => i.name === s.managedServerName,
+    )?.is_authenticated
+  })
+
+  return (
+    <div className="pointer-events-none absolute inset-x-0 bottom-5 z-30 flex justify-center px-6">
+      <div className="pointer-events-auto w-full max-w-[720px]">
+        {(attachedTabs.length > 0 || visibleSelectedText) && (
+          <div className="mb-2 overflow-hidden rounded-[14px] border border-border bg-background shadow-[0_4px_18px_rgba(0,0,0,0.06)]">
+            <ChatAttachedTabs tabs={attachedTabs} onRemoveTab={onRemoveTab} />
+            {visibleSelectedText && (
+              <ChatSelectedText
+                selectedText={visibleSelectedText}
+                onDismiss={() => {
+                  if (!activeTabId) return
+                  const key = String(activeTabId)
+                  selectedTextStorage.getValue().then((map) => {
+                    const { [key]: _, ...rest } = map
+                    selectedTextStorage.setValue(rest)
+                  })
+                }}
+              />
+            )}
+          </div>
+        )}
+
+        <div className="rounded-[14px] border border-border bg-background px-3.5 py-2.5 shadow-[0_2px_12px_rgba(0,0,0,0.10)] sm:shadow-[0_8px_40px_rgba(0,0,0,0.08)]">
+          <div className="flex items-start gap-2 [&_form]:mt-0 [&_textarea:focus]:border-0 [&_textarea:hover]:border-0 [&_textarea]:rounded-none [&_textarea]:border-0 [&_textarea]:bg-transparent [&_textarea]:px-0 [&_textarea]:py-2">
+            <Sparkles className="mt-[11px] h-[15px] w-[15px] shrink-0 text-[var(--accent-orange)]" />
+            <div className="flex-1">
+              <ChatInput
+                ref={chatInputRef}
+                input={input}
+                status={status}
+                mode={mode}
+                onInputChange={onInputChange}
+                onSubmit={onSubmit}
+                onStop={onStop}
+                selectedTabs={attachedTabs}
+                onToggleTab={onToggleTab}
+                onTabMentionOpenChange={setIsTabMentionOpen}
+                voice={voice}
+              />
+            </div>
+          </div>
+
+          {voice?.error && (
+            <div className="mt-1 text-destructive text-xs">{voice.error}</div>
+          )}
+
+          <div className="mt-2 flex items-center gap-3 pl-[23px] text-[11px] text-muted-foreground">
+            <button
+              type="button"
+              onClick={() => chatInputRef.current?.toggleTabMention()}
+              data-tab-mention-trigger
+              data-state={isTabMentionOpen ? 'open' : 'closed'}
+              aria-expanded={isTabMentionOpen}
+              aria-haspopup="dialog"
+              className={cn(
+                'inline-flex cursor-pointer items-center gap-1 rounded transition-colors hover:text-foreground data-[state=open]:text-foreground',
+                attachedTabs.length > 0 && 'text-foreground',
+              )}
+              title="Attach tabs (@)"
+            >
+              <Layers className="h-3 w-3" />
+              <span>
+                {attachedTabs.length > 0
+                  ? `${attachedTabs.length} tab${attachedTabs.length > 1 ? 's' : ''}`
+                  : 'tabs'}
+              </span>
+              <ChevronDown className="h-2.5 w-2.5" />
+            </button>
+
+            {supports(Feature.WORKSPACE_FOLDER_SUPPORT) && (
+              <WorkspaceSelector side="top">
+                <button
+                  type="button"
+                  className={cn(
+                    'inline-flex cursor-pointer items-center gap-1 rounded transition-colors hover:text-foreground data-[state=open]:text-foreground',
+                    selectedFolder && 'text-foreground',
+                  )}
+                  title={selectedFolder ? selectedFolder.name : 'Workspace'}
+                >
+                  <Folder className="h-3 w-3" />
+                  <span>{selectedFolder?.name ?? 'workspace'}</span>
+                  <ChevronDown className="h-2.5 w-2.5" />
+                </button>
+              </WorkspaceSelector>
+            )}
+
+            {supports(Feature.MANAGED_MCP_SUPPORT) && (
+              <AppSelector side="top">
+                <button
+                  type="button"
+                  className="inline-flex cursor-pointer items-center gap-1 rounded transition-colors hover:text-foreground data-[state=open]:text-foreground"
+                  title="Connect apps"
+                >
+                  {connectedManagedServers.length > 0 ? (
+                    <>
+                      <div className="flex items-center -space-x-1">
+                        {connectedManagedServers.slice(0, 3).map((s) => (
+                          <div
+                            key={s.id}
+                            className="rounded-full ring-2 ring-background"
+                          >
+                            <McpServerIcon
+                              serverName={s.managedServerName ?? ''}
+                              size={10}
+                            />
+                          </div>
+                        ))}
+                      </div>
+                      {connectedManagedServers.length > 3 && (
+                        <span>+{connectedManagedServers.length - 3}</span>
+                      )}
+                    </>
+                  ) : (
+                    <>
+                      <PlugZap className="h-3 w-3" />
+                      <span>apps</span>
+                    </>
+                  )}
+                  <ChevronDown className="h-2.5 w-2.5" />
+                </button>
+              </AppSelector>
+            )}
+
+            <div className="flex-1" />
+            <span className="hidden sm:inline">/ commands · @ mention</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ambient/ChatOverlayBar.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ambient/ChatOverlayBar.tsx
@@ -1,0 +1,66 @@
+import { Home, Plus } from 'lucide-react'
+import type { FC } from 'react'
+import { useNavigate } from 'react-router'
+import type { Provider } from '@/components/chat/chatComponentTypes'
+import type { ChatMode } from '../chatTypes'
+import { StatusPill } from './StatusPill'
+
+interface ChatOverlayBarProps {
+  status: 'streaming' | 'submitted' | 'ready' | 'error'
+  mode: ChatMode
+  onModeChange: (m: ChatMode) => void
+  selectedProvider: Provider
+  providers: Provider[]
+  onSelectProvider: (p: Provider) => void
+  onNewConversation: () => void
+  hasMessages: boolean
+}
+
+export const ChatOverlayBar: FC<ChatOverlayBarProps> = ({
+  status,
+  mode,
+  onModeChange,
+  selectedProvider,
+  providers,
+  onSelectProvider,
+  onNewConversation,
+  hasMessages,
+}) => {
+  const navigate = useNavigate()
+
+  return (
+    <div className="pointer-events-none absolute inset-x-5 top-4 z-40 flex items-center gap-2.5">
+      <button
+        type="button"
+        onClick={() => navigate('/')}
+        title="Home"
+        className="pointer-events-auto inline-flex cursor-pointer items-center justify-center rounded-full border border-border bg-background p-1.5 text-muted-foreground shadow-sm transition-colors hover:bg-muted/50 hover:text-foreground"
+      >
+        <Home className="h-3.5 w-3.5" />
+      </button>
+
+      <div className="flex flex-1 justify-center">
+        <StatusPill
+          status={status}
+          mode={mode}
+          onModeChange={onModeChange}
+          selectedProvider={selectedProvider}
+          providers={providers}
+          onSelectProvider={onSelectProvider}
+          onNewConversation={onNewConversation}
+          hasMessages={hasMessages}
+        />
+      </div>
+
+      <button
+        type="button"
+        onClick={onNewConversation}
+        title="New conversation"
+        className="pointer-events-auto inline-flex cursor-pointer items-center gap-1 rounded-full border border-border bg-background px-2.5 py-1.5 text-[11.5px] text-muted-foreground shadow-sm transition-colors hover:bg-muted/50 hover:text-foreground"
+      >
+        <Plus className="h-3 w-3" />
+        <span className="hidden sm:inline">New</span>
+      </button>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ambient/EditorialHeader.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ambient/EditorialHeader.tsx
@@ -1,0 +1,31 @@
+import type { FC } from 'react'
+
+interface EditorialHeaderProps {
+  title: string
+  subtitleParts?: (string | null | undefined)[]
+}
+
+export const EditorialHeader: FC<EditorialHeaderProps> = ({
+  title,
+  subtitleParts,
+}) => {
+  const parts = (subtitleParts ?? []).filter(
+    (p): p is string => !!p && p.trim().length > 0,
+  )
+
+  const joined = parts.join(' · ')
+
+  return (
+    <div className="mb-9">
+      <div
+        className="font-serif text-[32px] leading-[1.05] tracking-[-0.5px] sm:text-[44px] sm:tracking-[-1px]"
+        style={{ fontFamily: 'var(--font-serif)' }}
+      >
+        {title}
+      </div>
+      {joined && (
+        <div className="mt-1.5 text-[13px] text-muted-foreground">{joined}</div>
+      )}
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ambient/StatusPill.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ambient/StatusPill.tsx
@@ -1,0 +1,253 @@
+import {
+  Check,
+  Github,
+  History,
+  MessageSquare,
+  MousePointer2,
+  Plus,
+  SettingsIcon,
+} from 'lucide-react'
+import type { FC } from 'react'
+import { useNavigate } from 'react-router'
+import { ChatProviderSelector } from '@/components/chat/ChatProviderSelector'
+import type { Provider } from '@/components/chat/chatComponentTypes'
+import { ThemeToggle } from '@/components/elements/theme-toggle'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import { productRepositoryUrl } from '@/lib/constants/productUrls'
+import { BrowserOSIcon, ProviderIcon } from '@/lib/llm-providers/providerIcons'
+import type { ProviderType } from '@/lib/llm-providers/types'
+import { cn } from '@/lib/utils'
+import type { ChatMode } from '../chatTypes'
+import { useElapsedTimer } from './useElapsedTimer'
+
+type ChatStatus = 'streaming' | 'submitted' | 'ready' | 'error'
+
+interface StatusPillProps {
+  status: ChatStatus
+  mode: ChatMode
+  onModeChange: (mode: ChatMode) => void
+  selectedProvider: Provider
+  providers: Provider[]
+  onSelectProvider: (p: Provider) => void
+  onNewConversation: () => void
+  hasMessages: boolean
+}
+
+const isBusy = (s: ChatStatus) => s === 'submitted' || s === 'streaming'
+
+export const StatusPill: FC<StatusPillProps> = ({
+  status,
+  mode,
+  onModeChange,
+  selectedProvider,
+  providers,
+  onSelectProvider,
+  onNewConversation,
+  hasMessages,
+}) => {
+  const elapsed = useElapsedTimer(isBusy(status))
+  const navigate = useNavigate()
+
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          className="pointer-events-auto inline-flex cursor-pointer items-center gap-2 rounded-full border border-border bg-background px-3 py-1.5 text-[11.5px] shadow-sm transition-colors hover:bg-muted/50"
+        >
+          <StatusDot status={status} />
+          <PillLabel
+            status={status}
+            mode={mode}
+            providerName={selectedProvider.name}
+            elapsed={elapsed}
+          />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent
+        side="bottom"
+        align="center"
+        className="w-64 p-0"
+        sideOffset={6}
+      >
+        <div className="space-y-1 p-1">
+          <ProviderRow
+            selectedProvider={selectedProvider}
+            providers={providers}
+            onSelectProvider={onSelectProvider}
+          />
+          <ModeRow mode={mode} onModeChange={onModeChange} />
+        </div>
+        <div className="border-border/60 border-t p-1">
+          {hasMessages && (
+            <MenuButton
+              icon={<Plus className="h-3.5 w-3.5" />}
+              label="New conversation"
+              onClick={onNewConversation}
+            />
+          )}
+          <MenuButton
+            icon={<History className="h-3.5 w-3.5" />}
+            label="Chat history"
+            onClick={() => navigate('/history')}
+          />
+          <MenuLink
+            icon={<Github className="h-3.5 w-3.5" />}
+            label="Star on Github"
+            href={productRepositoryUrl}
+          />
+          <MenuLink
+            icon={<SettingsIcon className="h-3.5 w-3.5" />}
+            label="Settings"
+            href="/app.html#/settings"
+          />
+          <div className="flex items-center justify-between gap-2 rounded-md px-2 py-1.5 text-muted-foreground text-sm">
+            <span>Theme</span>
+            <ThemeToggle iconClassName="h-3.5 w-3.5" />
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}
+
+const StatusDot: FC<{ status: ChatStatus }> = ({ status }) => {
+  const colorClass =
+    status === 'error'
+      ? 'bg-destructive'
+      : isBusy(status)
+        ? 'animate-pulse bg-[var(--accent-orange)]'
+        : 'bg-muted-foreground/60'
+  return <span className={cn('h-1.5 w-1.5 rounded-full', colorClass)} />
+}
+
+const PillLabel: FC<{
+  status: ChatStatus
+  mode: ChatMode
+  providerName: string
+  elapsed: string
+}> = ({ status, mode, providerName, elapsed }) => {
+  if (status === 'error') {
+    return <span className="font-medium text-destructive">Failed</span>
+  }
+  if (isBusy(status)) {
+    return (
+      <>
+        <span className="font-medium">Running</span>
+        <span className="text-muted-foreground">· {elapsed}</span>
+      </>
+    )
+  }
+  const modeLabel = mode === 'agent' ? 'Agent' : 'Chat'
+  return (
+    <>
+      <span className="font-medium">{providerName}</span>
+      <span className="text-muted-foreground">· {modeLabel}</span>
+    </>
+  )
+}
+
+const ProviderRow: FC<{
+  selectedProvider: Provider
+  providers: Provider[]
+  onSelectProvider: (p: Provider) => void
+}> = ({ selectedProvider, providers, onSelectProvider }) => (
+  <ChatProviderSelector
+    providers={providers}
+    selectedProvider={selectedProvider}
+    onSelectProvider={onSelectProvider}
+  >
+    <button
+      type="button"
+      className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-muted/50"
+    >
+      {selectedProvider.type === 'browseros' ? (
+        <BrowserOSIcon size={14} />
+      ) : (
+        <ProviderIcon type={selectedProvider.type as ProviderType} size={14} />
+      )}
+      <span className="flex-1 truncate text-left">{selectedProvider.name}</span>
+      <span className="text-muted-foreground text-xs">Provider</span>
+    </button>
+  </ChatProviderSelector>
+)
+
+const ModeRow: FC<{ mode: ChatMode; onModeChange: (m: ChatMode) => void }> = ({
+  mode,
+  onModeChange,
+}) => {
+  const isAgent = mode === 'agent'
+  return (
+    <div className="flex items-center gap-1 rounded-md p-1">
+      <ModeButton
+        active={!isAgent}
+        onClick={() => onModeChange('chat')}
+        icon={<MessageSquare className="h-3 w-3" />}
+        label="Chat"
+      />
+      <ModeButton
+        active={isAgent}
+        onClick={() => onModeChange('agent')}
+        icon={<MousePointer2 className="h-3 w-3" />}
+        label="Agent"
+      />
+    </div>
+  )
+}
+
+const ModeButton: FC<{
+  active: boolean
+  onClick: () => void
+  icon: React.ReactNode
+  label: string
+}> = ({ active, onClick, icon, label }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className={cn(
+      'flex flex-1 items-center justify-center gap-1 rounded px-2 py-1 font-medium text-xs transition-colors',
+      active
+        ? 'bg-[var(--accent-orange)]/10 text-[var(--accent-orange)]'
+        : 'text-muted-foreground hover:bg-muted/60 hover:text-foreground',
+    )}
+  >
+    {icon}
+    {label}
+    {active && <Check className="h-2.5 w-2.5" />}
+  </button>
+)
+
+const MenuButton: FC<{
+  icon: React.ReactNode
+  label: string
+  onClick: () => void
+}> = ({ icon, label, onClick }) => (
+  <button
+    type="button"
+    onClick={onClick}
+    className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left text-sm transition-colors hover:bg-muted/50"
+  >
+    <span className="text-muted-foreground">{icon}</span>
+    <span>{label}</span>
+  </button>
+)
+
+const MenuLink: FC<{
+  icon: React.ReactNode
+  label: string
+  href: string
+}> = ({ icon, label, href }) => (
+  <a
+    href={href}
+    target="_blank"
+    rel="noopener noreferrer"
+    className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-sm transition-colors hover:bg-muted/50"
+  >
+    <span className="text-muted-foreground">{icon}</span>
+    <span>{label}</span>
+  </a>
+)

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ambient/StatusPill.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ambient/StatusPill.tsx
@@ -7,7 +7,7 @@ import {
   Plus,
   SettingsIcon,
 } from 'lucide-react'
-import type { FC } from 'react'
+import { type FC, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { ChatProviderSelector } from '@/components/chat/ChatProviderSelector'
 import type { Provider } from '@/components/chat/chatComponentTypes'
@@ -51,9 +51,32 @@ export const StatusPill: FC<StatusPillProps> = ({
 }) => {
   const elapsed = useElapsedTimer(isBusy(status))
   const navigate = useNavigate()
+  const [open, setOpen] = useState(false)
+
+  const close = () => setOpen(false)
+
+  const handleSelectProvider = (p: Provider) => {
+    onSelectProvider(p)
+    queueMicrotask(close)
+  }
+
+  const handleModeChange = (m: ChatMode) => {
+    onModeChange(m)
+    close()
+  }
+
+  const handleNewConversation = () => {
+    onNewConversation()
+    close()
+  }
+
+  const handleNavigateHistory = () => {
+    close()
+    navigate('/history')
+  }
 
   return (
-    <Popover>
+    <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <button
           type="button"
@@ -78,22 +101,22 @@ export const StatusPill: FC<StatusPillProps> = ({
           <ProviderRow
             selectedProvider={selectedProvider}
             providers={providers}
-            onSelectProvider={onSelectProvider}
+            onSelectProvider={handleSelectProvider}
           />
-          <ModeRow mode={mode} onModeChange={onModeChange} />
+          <ModeRow mode={mode} onModeChange={handleModeChange} />
         </div>
         <div className="border-border/60 border-t p-1">
           {hasMessages && (
             <MenuButton
               icon={<Plus className="h-3.5 w-3.5" />}
               label="New conversation"
-              onClick={onNewConversation}
+              onClick={handleNewConversation}
             />
           )}
           <MenuButton
             icon={<History className="h-3.5 w-3.5" />}
             label="Chat history"
-            onClick={() => navigate('/history')}
+            onClick={handleNavigateHistory}
           />
           <MenuLink
             icon={<Github className="h-3.5 w-3.5" />}

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ambient/useElapsedTimer.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ambient/useElapsedTimer.ts
@@ -1,0 +1,32 @@
+import { useEffect, useRef, useState } from 'react'
+
+const formatElapsed = (elapsedMs: number): string => {
+  const totalSeconds = Math.floor(elapsedMs / 1000)
+  const minutes = Math.floor(totalSeconds / 60)
+  const seconds = totalSeconds % 60
+  return `${minutes}:${seconds.toString().padStart(2, '0')}`
+}
+
+export function useElapsedTimer(active: boolean): string {
+  const [elapsed, setElapsed] = useState('0:00')
+  const startRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    if (!active) {
+      startRef.current = null
+      setElapsed('0:00')
+      return
+    }
+
+    startRef.current = Date.now()
+    setElapsed('0:00')
+    const tick = () => {
+      if (startRef.current == null) return
+      setElapsed(formatElapsed(Date.now() - startRef.current))
+    }
+    const id = setInterval(tick, 1000)
+    return () => clearInterval(id)
+  }, [active])
+
+  return elapsed
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/layout/ChatLayout.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/layout/ChatLayout.tsx
@@ -1,5 +1,5 @@
 import type { FC } from 'react'
-import { Outlet } from 'react-router'
+import { Outlet, useLocation } from 'react-router'
 import { ChatHeader } from '../index/ChatHeader'
 import {
   ChatSessionProvider,
@@ -16,6 +16,9 @@ const ChatLayoutContent: FC = () => {
     isLoading,
   } = useChatSessionContext()
 
+  const pathname = useLocation().pathname
+  const showHeader = pathname !== '/'
+
   if (isLoading || !selectedProvider) {
     return (
       <div className="flex h-screen w-screen items-center justify-center bg-background">
@@ -26,13 +29,15 @@ const ChatLayoutContent: FC = () => {
 
   return (
     <div className="mx-auto flex h-screen w-screen flex-col overflow-hidden bg-background text-foreground">
-      <ChatHeader
-        selectedProvider={selectedProvider}
-        onSelectProvider={handleSelectProvider}
-        providers={providers}
-        onNewConversation={resetConversation}
-        hasMessages={messages.length > 0}
-      />
+      {showHeader && (
+        <ChatHeader
+          selectedProvider={selectedProvider}
+          onSelectProvider={handleSelectProvider}
+          providers={providers}
+          onNewConversation={resetConversation}
+          hasMessages={messages.length > 0}
+        />
+      )}
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         <Outlet />
       </div>

--- a/packages/browseros-agent/apps/agent/public/instrument-serif/README.md
+++ b/packages/browseros-agent/apps/agent/public/instrument-serif/README.md
@@ -1,0 +1,32 @@
+# Instrument Serif
+
+Drop `InstrumentSerif-Regular.woff2` (weight 400) into this folder.
+
+## Why it's missing
+
+The font ships with this repo referenced from `apps/agent/styles/global.css`
+via `@font-face`, but the binary is not committed here. Until the file is
+present, the editorial title in the agent conversation falls back to
+`Iowan Old Style, Georgia, serif`.
+
+## How to fetch
+
+Instrument Serif is SIL OFL 1.1. Grab a woff2 build from Google Fonts and drop
+it here:
+
+```sh
+curl -L \
+  "https://fonts.googleapis.com/css2?family=Instrument+Serif&display=swap" \
+  | grep -Eo 'https://fonts\.gstatic\.com/s/instrumentserif/[^)]+woff2' \
+  | head -1 \
+  | xargs curl -Lo apps/agent/public/instrument-serif/InstrumentSerif-Regular.woff2
+```
+
+Or open [fonts.google.com/specimen/Instrument+Serif](https://fonts.google.com/specimen/Instrument+Serif)
+and download the weight-400 woff2 manually.
+
+The file path **must** match the one referenced in `apps/agent/styles/global.css`:
+
+```css
+src: url("../instrument-serif/InstrumentSerif-Regular.woff2") format("woff2");
+```

--- a/packages/browseros-agent/apps/agent/styles/global.css
+++ b/packages/browseros-agent/apps/agent/styles/global.css
@@ -40,6 +40,16 @@
   font-display: swap;
 }
 
+/* Instrument Serif (editorial title). Self-hosted; falls back to system serifs when the
+   woff2 isn't present in the bundle — see public/instrument-serif/README.md. */
+@font-face {
+  font-family: "Instrument Serif";
+  src: url("../instrument-serif/InstrumentSerif-Regular.woff2") format("woff2");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
 :root {
   --radius: 0.65rem;
   --background: oklch(0.985 0.002 85);
@@ -78,6 +88,8 @@
   --accent-orange: oklch(0.6781 0.1663 43.21);
   /* Added brighter orange variant for shimmer animation */
   --accent-orange-bright: oklch(0.7531 0.1963 43.21);
+  /* Soft orange for user avatar bg, subtle accent surfaces */
+  --accent-orange-soft: oklch(0.6781 0.1663 43.21 / 0.12);
 }
 
 .dark {
@@ -118,6 +130,7 @@
 @theme inline {
   --font-sans: "Geist", "Geist Fallback";
   --font-mono: "Geist Mono", "Geist Mono Fallback";
+  --font-serif: "Instrument Serif", "Iowan Old Style", Georgia, serif;
   --color-background: var(--background);
   --color-foreground: var(--foreground);
   --color-card: var(--card);
@@ -157,6 +170,7 @@
   --color-accent-orange: var(--accent-orange);
   /* Added brighter orange to theme */
   --color-accent-orange-bright: var(--accent-orange-bright);
+  --color-accent-orange-soft: var(--accent-orange-soft);
 
   /* Custom keyframe animations for hero section */
   --animate-float: float 3s ease-in-out infinite;


### PR DESCRIPTION
## Summary

Restructures the BrowserOS Agent sidepanel conversation route into the V4
Ambient layout — a full-bleed editorial treatment per the user-provided spec.

- **Floating top overlay** (home · state-aware status pill · new) replaces
  the fixed `ChatHeader` on `/`. The pill consolidates provider selection,
  mode toggle, and session controls into a single popover.
- **Editorial serif title** (Instrument Serif, 44px / 32px narrow) renders as
  the first scroll item, above the turns, with a subtitle row showing mode,
  session hash, and turn count.
- **Floating composer pill** (720px, shadow, sparkle prefix) replaces the
  in-flow `ChatFooter`. Compact meta row underneath retains tab attachment,
  workspace, and MCP app selectors.
- **Turn restyle** — ambient user turn is an avatar + text row; reasoning is
  a muted italic soft-bg block; tool batches are an uppercase "N tool calls"
  card with mono rows and orange check icons; assistant text keeps the
  existing Streamdown rendering at 14.5px / 1.65 line-height.
- **History route (`/history`) is untouched** — still uses the existing
  `ChatHeader`. Layout is conditional in `ChatLayout`.

## Design

Keeps `use-stick-to-bottom` as the sole scroll owner; the editorial header
and streaming indicator render inside `ConversationContent` so auto-scroll
still works. `pointer-events: none` on the overlay / composer wrappers so
clicks fall through to the thread gutters. `ConversationScrollButton` gets
an `offsetBottom` prop to clear the floating composer.

Self-hosted Instrument Serif via `@font-face` reading
`public/instrument-serif/InstrumentSerif-Regular.woff2`. Until the binary is
dropped in (see `public/instrument-serif/README.md`), the title falls back
to `Iowan Old Style, Georgia, serif` — visually acceptable and non-blocking.

No data-layer, streaming, or session-storage changes. Voice input, @ mention,
tool approvals, selected-text pills, JTBD popup, and feedback actions are all
preserved.

## Test plan

- [ ] Run \`bun run dev\` and open the BrowserOS sidepanel.
- [ ] Confirm the editorial title renders at the top of a new conversation.
- [ ] Submit a prompt; confirm status pill transitions idle → Running (with
      elapsed timer) → back to idle.
- [ ] Click the status pill; confirm the popover shows provider selector,
      mode toggle, new/history/settings/theme. Switching providers and modes
      no longer race-closes the outer popover.
- [ ] Submit a prompt that triggers tool calls; verify the new uppercase
      "N tool calls" card renders with mono rows.
- [ ] Submit a prompt that triggers thinking; verify the reasoning block is
      collapsible with the V4 soft muted italic box styling.
- [ ] Attach a tab via \`@\`; verify the mention popover still anchors under
      the textarea without clipping against the floating composer.
- [ ] Start voice recording; confirm the red waveform overlay renders inside
      the composer pill.
- [ ] Trigger a tool approval flow; confirm the inline approve/deny buttons
      still appear in the tool batch.
- [ ] Resize the sidepanel to ~400px; confirm serif title shrinks to 32px
      and composer shadow softens.
- [ ] Navigate to \`/history\`; verify the old \`ChatHeader\` is still shown.
- [ ] Toggle light / dark theme; verify all ambient components read correctly.

## Follow-ups

- Drop \`InstrumentSerif-Regular.woff2\` into \`public/instrument-serif/\`
  (curl command in the README).
- Add a real step-count signal to the status pill once the agent backend
  exposes a planner-level progress stream (currently we only show elapsed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)