### PR TITLE
fix: harden OpenClaw Podman runtime flow

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -7,15 +7,11 @@ import {
   MessageSquare,
   Plus,
   RefreshCw,
-  ShieldAlert,
   Square,
   TerminalSquare,
   Trash2,
-  WifiOff,
-  Wrench,
 } from 'lucide-react'
 import { type FC, useEffect, useMemo, useState } from 'react'
-import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -36,6 +32,10 @@ import {
 import { useLlmProviders } from '@/lib/llm-providers/useLlmProviders'
 import { AgentChat } from './AgentChat'
 import { AgentTerminal } from './AgentTerminal'
+import {
+  getOpenClawOperatorState,
+  type OpenClawOperatorState,
+} from './openclaw-operator-state'
 import { getOpenClawSupportedProviders } from './openclaw-supported-providers'
 import {
   type AgentEntry,
@@ -51,58 +51,37 @@ const CONTROL_PLANE_COPY: Record<
   {
     badgeVariant: 'default' | 'secondary' | 'outline' | 'destructive'
     badgeLabel: string
-    title: string
-    description: string
   }
 > = {
   connected: {
     badgeVariant: 'default',
     badgeLabel: 'Control Plane Ready',
-    title: 'Gateway Connected',
-    description: 'OpenClaw can create, manage, and chat with agents normally.',
   },
   connecting: {
     badgeVariant: 'secondary',
     badgeLabel: 'Connecting',
-    title: 'Connecting to Gateway',
-    description:
-      'BrowserOS is establishing the OpenClaw control channel for agent operations.',
   },
   reconnecting: {
     badgeVariant: 'secondary',
     badgeLabel: 'Reconnecting',
-    title: 'Reconnecting Control Plane',
-    description:
-      'The gateway process is up, but BrowserOS is restoring the control channel.',
   },
   recovering: {
     badgeVariant: 'secondary',
     badgeLabel: 'Recovering',
-    title: 'Recovering Gateway Connection',
-    description:
-      'BrowserOS detected a control-plane fault and is trying a safe recovery path.',
   },
   disconnected: {
     badgeVariant: 'outline',
     badgeLabel: 'Disconnected',
-    title: 'Gateway Disconnected',
-    description: 'The gateway process is not available to BrowserOS right now.',
   },
   failed: {
     badgeVariant: 'destructive',
     badgeLabel: 'Needs Attention',
-    title: 'Gateway Recovery Failed',
-    description:
-      'BrowserOS could not restore the OpenClaw control channel automatically.',
   },
 }
 
 const FALLBACK_CONTROL_PLANE_COPY = {
   badgeVariant: 'outline' as const,
   badgeLabel: 'Unknown',
-  title: 'Gateway State Unknown',
-  description:
-    'BrowserOS received a gateway status it does not recognize yet. Refreshing or reconnecting should restore a known state.',
 }
 
 const RECOVERY_REASON_COPY: Record<
@@ -151,10 +130,6 @@ const ControlPlaneBadge: FC<{
   return <Badge variant={current.badgeVariant}>{current.badgeLabel}</Badge>
 }
 
-function getControlPlaneCopy(status: OpenClawStatus['controlPlaneStatus']) {
-  return CONTROL_PLANE_COPY[status] ?? FALLBACK_CONTROL_PLANE_COPY
-}
-
 function getRecoveryDetail(status: OpenClawStatus): string | null {
   if (!status.lastRecoveryReason && !status.lastGatewayError) return null
 
@@ -167,6 +142,58 @@ function getRecoveryDetail(status: OpenClawStatus): string | null {
   }
 
   return status.lastGatewayError ?? detail
+}
+
+function getOperatorCardCopy(
+  status: OpenClawStatus | null,
+  operatorState: OpenClawOperatorState,
+) {
+  switch (operatorState) {
+    case 'loading':
+      return {
+        title: 'Loading OpenClaw',
+        description: 'Checking runtime status...',
+        tone: 'muted' as const,
+      }
+    case 'setup-needed':
+      return {
+        title: 'Set Up OpenClaw',
+        description: status?.podmanAvailable
+          ? 'Create the local runtime so agents can run in a container.'
+          : 'Podman is required before OpenClaw can run agents.',
+        tone: 'muted' as const,
+      }
+    case 'starting':
+      return {
+        title: 'OpenClaw is Starting',
+        description:
+          status?.controlPlaneStatus === 'recovering'
+            ? 'BrowserOS is recovering the runtime and bringing the control plane back up.'
+            : 'OpenClaw is still coming up. Wait for it to become ready before creating agents.',
+        tone: 'muted' as const,
+      }
+    case 'healthy':
+      return {
+        title: 'OpenClaw Ready',
+        description:
+          'OpenClaw can create, manage, and chat with agents normally.',
+        tone: 'healthy' as const,
+      }
+    case 'needs-attention':
+      return {
+        title:
+          status?.status === 'stopped'
+            ? 'Gateway Stopped'
+            : status?.status === 'error'
+              ? 'Gateway Error'
+              : 'OpenClaw Needs Attention',
+        description:
+          status?.error ??
+          status?.lastGatewayError ??
+          'BrowserOS could not keep the OpenClaw runtime healthy.',
+        tone: 'destructive' as const,
+      }
+  }
 }
 
 interface ProviderSelectorProps {
@@ -361,6 +388,7 @@ const PodmanOverridesCard: FC<PodmanOverridesCardProps> = ({ variant }) => {
   )
 }
 
+// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: page orchestration spans setup, runtime, agents, and dialogs.
 export const AgentsPage: FC = () => {
   const {
     status,
@@ -382,12 +410,14 @@ export const AgentsPage: FC = () => {
     startOpenClaw,
     stopOpenClaw,
     restartOpenClaw,
-    reconnectOpenClaw,
+    repairOpenClaw,
+    resetOpenClaw,
     actionInProgress,
     settingUp,
     creating,
     deleting,
-    reconnecting,
+    repairing,
+    resetting,
   } = useOpenClawMutations()
 
   const [setupOpen, setSetupOpen] = useState(false)
@@ -398,6 +428,7 @@ export const AgentsPage: FC = () => {
 
   const [chatAgent, setChatAgent] = useState<AgentEntry | null>(null)
   const [showTerminal, setShowTerminal] = useState(false)
+  const [resetConfirmOpen, setResetConfirmOpen] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const compatibleProviders = getOpenClawSupportedProviders(providers)
@@ -424,40 +455,16 @@ export const AgentsPage: FC = () => {
     setNewName((current) => current || 'agent')
   }, [createOpen])
 
-  const inlineError =
+  const operatorState = useMemo(() => {
+    if (status) return getOpenClawOperatorState(status).kind
+    return statusError || agentsError ? 'needs-attention' : 'loading'
+  }, [status, statusError, agentsError])
+
+  const canManageAgents = operatorState === 'healthy'
+  const operatorCopy = getOperatorCardCopy(status, operatorState)
+  const operatorIssue =
     error ?? statusError?.message ?? agentsError?.message ?? null
-
-  const gatewayUiState = useMemo(() => {
-    if (!status) {
-      return {
-        canManageAgents: false,
-        controlPlaneDegraded: false,
-        controlPlaneBusy: false,
-      }
-    }
-
-    const controlPlaneBusy =
-      status.controlPlaneStatus === 'connecting' ||
-      status.controlPlaneStatus === 'reconnecting' ||
-      status.controlPlaneStatus === 'recovering'
-
-    const canManageAgents =
-      status.status === 'running' && status.controlPlaneStatus === 'connected'
-
-    const controlPlaneDegraded =
-      status.status === 'running' && status.controlPlaneStatus !== 'connected'
-
-    return {
-      canManageAgents,
-      controlPlaneBusy,
-      controlPlaneDegraded,
-    }
-  }, [status])
-
   const recoveryDetail = status ? getRecoveryDetail(status) : null
-  const controlPlaneCopy = status
-    ? getControlPlaneCopy(status.controlPlaneStatus)
-    : null
 
   const runWithErrorHandling = async (fn: () => Promise<unknown>) => {
     setError(null)
@@ -530,9 +537,16 @@ export const AgentsPage: FC = () => {
     })
   }
 
-  const handleReconnect = async () => {
+  const handleRepair = async () => {
     await runWithErrorHandling(async () => {
-      await reconnectOpenClaw()
+      await repairOpenClaw()
+    })
+  }
+
+  const handleReset = async () => {
+    setResetConfirmOpen(false)
+    await runWithErrorHandling(async () => {
+      await resetOpenClaw()
     })
   }
 
@@ -560,7 +574,7 @@ export const AgentsPage: FC = () => {
 
   return (
     <div className="fade-in slide-in-from-bottom-5 animate-in space-y-6 duration-500">
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-4">
         <div>
           <h1 className="font-bold text-2xl">Agents</h1>
           <p className="text-muted-foreground text-sm">
@@ -569,30 +583,13 @@ export const AgentsPage: FC = () => {
         </div>
 
         {status && (
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center justify-end gap-2">
             <StatusBadge status={status.status} />
             {status.status !== 'uninitialized' && (
               <ControlPlaneBadge status={status.controlPlaneStatus} />
             )}
-
-            {status.status === 'running' && (
+            {operatorState === 'healthy' && (
               <>
-                {status.controlPlaneStatus !== 'connected' && (
-                  <Button
-                    variant="outline"
-                    onClick={handleReconnect}
-                    disabled={
-                      actionInProgress || gatewayUiState.controlPlaneBusy
-                    }
-                  >
-                    {reconnecting ? (
-                      <Loader2 className="mr-2 size-4 animate-spin" />
-                    ) : (
-                      <RefreshCw className="mr-2 size-4" />
-                    )}
-                    Retry Connection
-                  </Button>
-                )}
                 <Button
                   variant="ghost"
                   size="icon"
@@ -617,7 +614,7 @@ export const AgentsPage: FC = () => {
                 </Button>
                 <Button
                   onClick={() => setCreateOpen(true)}
-                  disabled={!gatewayUiState.canManageAgents}
+                  disabled={!canManageAgents}
                 >
                   <Plus className="mr-1 size-4" />
                   New Agent
@@ -628,123 +625,65 @@ export const AgentsPage: FC = () => {
         )}
       </div>
 
-      {inlineError && (
-        <Alert variant="destructive">
-          <AlertCircle />
-          <AlertTitle>OpenClaw action failed</AlertTitle>
-          <AlertDescription>
-            <p>{inlineError}</p>
-            <div className="mt-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => setError(null)}
-              >
-                Dismiss
-              </Button>
+      <Card
+        className={
+          operatorCopy.tone === 'destructive' ? 'border-destructive' : ''
+        }
+      >
+        <CardContent className="space-y-4 py-8">
+          <div className="flex items-start gap-4">
+            <div
+              className={`flex size-12 items-center justify-center rounded-full border ${
+                operatorCopy.tone === 'destructive'
+                  ? 'border-destructive/40 bg-destructive/10 text-destructive'
+                  : 'border-border bg-muted text-muted-foreground'
+              }`}
+            >
+              {operatorState === 'loading' || operatorState === 'starting' ? (
+                <Loader2 className="size-5 animate-spin" />
+              ) : operatorState === 'needs-attention' ? (
+                <AlertCircle className="size-5" />
+              ) : (
+                <Cpu className="size-5" />
+              )}
             </div>
-          </AlertDescription>
-        </Alert>
-      )}
 
-      {status && gatewayUiState.controlPlaneDegraded && (
-        <Alert
-          variant={
-            status.controlPlaneStatus === 'failed' ? 'destructive' : 'default'
-          }
-        >
-          {status.controlPlaneStatus === 'failed' ? (
-            <ShieldAlert />
-          ) : status.controlPlaneStatus === 'recovering' ? (
-            <Wrench />
-          ) : (
-            <WifiOff />
-          )}
-          <AlertTitle>{controlPlaneCopy?.title}</AlertTitle>
-          <AlertDescription>
-            <p>{controlPlaneCopy?.description}</p>
-            {recoveryDetail && <p>{recoveryDetail}</p>}
-            <div className="mt-2 flex flex-wrap gap-2">
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleReconnect}
-                disabled={actionInProgress || gatewayUiState.controlPlaneBusy}
-              >
-                {reconnecting ? (
-                  <Loader2 className="mr-2 size-4 animate-spin" />
-                ) : (
-                  <RefreshCw className="mr-2 size-4" />
+            <div className="min-w-0 flex-1 space-y-1">
+              <div className="flex flex-wrap items-center gap-2">
+                <h3 className="font-semibold text-lg">{operatorCopy.title}</h3>
+                {status && status.status !== 'uninitialized' && (
+                  <ControlPlaneBadge status={status.controlPlaneStatus} />
                 )}
-                Retry Connection
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleRestart}
-                disabled={actionInProgress}
-              >
-                Restart Gateway
-              </Button>
-            </div>
-            <PodmanOverridesCard variant="inline" />
-          </AlertDescription>
-        </Alert>
-      )}
-
-      {status?.status === 'uninitialized' && (
-        <Card>
-          <CardContent className="flex flex-col items-center gap-4 py-12">
-            <Cpu className="size-12 text-muted-foreground" />
-            <div className="text-center">
-              <h3 className="font-semibold text-lg">Set Up OpenClaw</h3>
+              </div>
               <p className="text-muted-foreground text-sm">
-                {status.podmanAvailable
-                  ? 'Create a local container to run autonomous agents with full tool access.'
-                  : 'Podman is required to run OpenClaw agents. Install Podman first.'}
+                {operatorCopy.description}
               </p>
+              {recoveryDetail && operatorState === 'needs-attention' && (
+                <p className="text-muted-foreground text-sm">
+                  {recoveryDetail}
+                </p>
+              )}
+              {operatorIssue && (
+                <p className="text-destructive text-sm">{operatorIssue}</p>
+              )}
+              {status?.port !== null && status?.port !== undefined && (
+                <p className="text-muted-foreground text-xs">
+                  Runtime port: <code>{status.port}</code>
+                </p>
+              )}
+              {status?.status === 'running' && (
+                <p className="text-muted-foreground text-xs">
+                  Agent count: {status.agentCount}
+                </p>
+              )}
             </div>
-            {status.podmanAvailable && (
+          </div>
+
+          <div className="flex flex-wrap gap-2">
+            {operatorState === 'setup-needed' && status?.podmanAvailable && (
               <Button onClick={() => setSetupOpen(true)}>Set Up Now</Button>
             )}
-            <div className="w-full max-w-md">
-              <PodmanOverridesCard variant="inline" />
-            </div>
-          </CardContent>
-        </Card>
-      )}
-
-      {status?.status === 'stopped' && (
-        <Card>
-          <CardContent className="flex flex-col items-center gap-4 py-12">
-            <Cpu className="size-12 text-muted-foreground" />
-            <div className="text-center">
-              <h3 className="font-semibold text-lg">Gateway Stopped</h3>
-              <p className="text-muted-foreground text-sm">
-                The OpenClaw gateway is not running.
-              </p>
-            </div>
-            <Button onClick={handleStart} disabled={actionInProgress}>
-              Start Gateway
-            </Button>
-          </CardContent>
-        </Card>
-      )}
-
-      {status?.status === 'error' && (
-        <Card className="border-destructive">
-          <CardContent className="flex flex-col items-center gap-4 py-12">
-            <AlertCircle className="size-12 text-destructive" />
-            <div className="text-center">
-              <h3 className="font-semibold text-lg">Gateway Error</h3>
-              <p className="text-muted-foreground text-sm">
-                {status.error ?? status.lastGatewayError}
-              </p>
-            </div>
-            <div className="flex gap-2">
-              <Button onClick={handleStart} disabled={actionInProgress}>
-                Start Gateway
-              </Button>
+            {operatorState === 'starting' && (
               <Button
                 variant="outline"
                 onClick={handleRestart}
@@ -752,15 +691,54 @@ export const AgentsPage: FC = () => {
               >
                 Restart Gateway
               </Button>
-            </div>
+            )}
+            {operatorState === 'needs-attention' && (
+              <>
+                {status?.status === 'stopped' || status?.status === 'error' ? (
+                  <Button onClick={handleStart} disabled={actionInProgress}>
+                    Start Gateway
+                  </Button>
+                ) : null}
+                <Button
+                  variant="outline"
+                  onClick={handleRepair}
+                  disabled={actionInProgress || repairing}
+                >
+                  {repairing ? (
+                    <Loader2 className="mr-2 size-4 animate-spin" />
+                  ) : (
+                    <RefreshCw className="mr-2 size-4" />
+                  )}
+                  Repair Runtime
+                </Button>
+                <Button
+                  variant="destructive"
+                  onClick={() => setResetConfirmOpen(true)}
+                  disabled={actionInProgress || resetting}
+                >
+                  Reset Runtime
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={handleRestart}
+                  disabled={actionInProgress}
+                >
+                  Restart Gateway
+                </Button>
+              </>
+            )}
+          </div>
+
+          {(operatorState === 'setup-needed' ||
+            operatorState === 'needs-attention') && (
             <div className="w-full max-w-md">
               <PodmanOverridesCard variant="inline" />
             </div>
-          </CardContent>
-        </Card>
-      )}
+          )}
+        </CardContent>
+      </Card>
 
-      {status?.status === 'running' && (
+      {status?.status === 'running' && operatorState === 'healthy' && (
         <div className="space-y-3">
           {agentsLoading ? (
             <div className="flex justify-center py-8">
@@ -775,7 +753,7 @@ export const AgentsPage: FC = () => {
                 <Button
                   variant="outline"
                   onClick={() => setCreateOpen(true)}
-                  disabled={!gatewayUiState.canManageAgents}
+                  disabled={!canManageAgents}
                 >
                   <Plus className="mr-1 size-4" />
                   Create Agent
@@ -804,7 +782,7 @@ export const AgentsPage: FC = () => {
                       variant="ghost"
                       size="sm"
                       onClick={() => setChatAgent(agent)}
-                      disabled={!gatewayUiState.canManageAgents}
+                      disabled={!canManageAgents}
                     >
                       <MessageSquare className="mr-1 size-4" />
                       Chat
@@ -814,7 +792,7 @@ export const AgentsPage: FC = () => {
                         variant="ghost"
                         size="icon"
                         onClick={() => handleDelete(agent.agentId)}
-                        disabled={!gatewayUiState.canManageAgents || deleting}
+                        disabled={!canManageAgents || deleting}
                       >
                         <Trash2 className="size-4 text-destructive" />
                       </Button>
@@ -898,7 +876,7 @@ export const AgentsPage: FC = () => {
               disabled={
                 !newName.trim() ||
                 creating ||
-                !gatewayUiState.canManageAgents ||
+                !canManageAgents ||
                 compatibleProviders.length === 0
               }
               className="w-full"
@@ -912,6 +890,39 @@ export const AgentsPage: FC = () => {
                 'Create Agent'
               )}
             </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={resetConfirmOpen} onOpenChange={setResetConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Reset OpenClaw runtime?</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <p className="text-muted-foreground text-sm">
+              This stops the gateway and Podman machine, clears the stored
+              runtime port, and removes recovery state. Use repair first if you
+              just need a non-destructive restart.
+            </p>
+            <div className="flex justify-end gap-2">
+              <Button
+                variant="outline"
+                onClick={() => setResetConfirmOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button
+                variant="destructive"
+                onClick={() => void handleReset()}
+                disabled={actionInProgress || resetting}
+              >
+                {resetting ? (
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                ) : null}
+                Reset Runtime
+              </Button>
+            </div>
           </div>
         </DialogContent>
       </Dialog>

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -493,7 +493,8 @@ export const AgentsPage: FC = () => {
   }
 
   const handleCreate = async () => {
-    if (!newName.trim()) return
+    if (!newName.trim() || creating || !canManageAgents) return
+    if (compatibleProviders.length === 0) return
     const provider = compatibleProviders.find(
       (item) => item.id === createProviderId,
     )

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/openclaw-operator-state.test.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/openclaw-operator-state.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'bun:test'
 import { getOpenClawOperatorState } from './openclaw-operator-state'
 import type { OpenClawStatus } from './useOpenClaw'
 
-function buildStatus(overrides: Partial<OpenClawStatus>): OpenClawStatus {
+function buildStatus(overrides: Partial<OpenClawStatus> = {}): OpenClawStatus {
   return {
     status: 'running',
     podmanAvailable: true,

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/openclaw-operator-state.test.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/openclaw-operator-state.test.ts
@@ -66,4 +66,22 @@ describe('getOpenClawOperatorState', () => {
 
     expect(state.kind).toBe('starting')
   })
+
+  it('treats transient control-plane states as needs-attention when runtime is stopped or error', () => {
+    const stoppedState = getOpenClawOperatorState(
+      buildStatus({
+        status: 'stopped',
+        controlPlaneStatus: 'recovering',
+      }),
+    )
+    const errorState = getOpenClawOperatorState(
+      buildStatus({
+        status: 'error',
+        controlPlaneStatus: 'reconnecting',
+      }),
+    )
+
+    expect(stoppedState.kind).toBe('needs-attention')
+    expect(errorState.kind).toBe('needs-attention')
+  })
 })

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/openclaw-operator-state.test.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/openclaw-operator-state.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'bun:test'
+import { getOpenClawOperatorState } from './openclaw-operator-state'
+import type { OpenClawStatus } from './useOpenClaw'
+
+function buildStatus(overrides: Partial<OpenClawStatus>): OpenClawStatus {
+  return {
+    status: 'running',
+    podmanAvailable: true,
+    machineReady: true,
+    port: 18789,
+    agentCount: 1,
+    error: null,
+    controlPlaneStatus: 'connected',
+    lastGatewayError: null,
+    lastRecoveryReason: null,
+    ...overrides,
+  }
+}
+
+describe('getOpenClawOperatorState', () => {
+  it('returns setup-needed when OpenClaw is uninitialized', () => {
+    const state = getOpenClawOperatorState(
+      buildStatus({ status: 'uninitialized', port: null }),
+    )
+
+    expect(state.kind).toBe('setup-needed')
+  })
+
+  it('returns needs-attention for degraded or failed runtime states', () => {
+    const cases = [
+      buildStatus({
+        status: 'running',
+        controlPlaneStatus: 'failed',
+        lastGatewayError: 'Gateway recovery failed',
+      }),
+      buildStatus({
+        status: 'error',
+        controlPlaneStatus: 'failed',
+        error: 'Gateway error',
+      }),
+      buildStatus({
+        status: 'stopped',
+        controlPlaneStatus: 'disconnected',
+      }),
+    ]
+
+    for (const status of cases) {
+      const state = getOpenClawOperatorState(status)
+      expect(state.kind).toBe('needs-attention')
+    }
+  })
+
+  it('returns healthy when the runtime and control plane are connected', () => {
+    const state = getOpenClawOperatorState(buildStatus())
+
+    expect(state.kind).toBe('healthy')
+  })
+
+  it('keeps transient reconnecting states separate from needs-attention', () => {
+    const state = getOpenClawOperatorState(
+      buildStatus({
+        status: 'running',
+        controlPlaneStatus: 'reconnecting',
+      }),
+    )
+
+    expect(state.kind).toBe('starting')
+  })
+})

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/openclaw-operator-state.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/openclaw-operator-state.ts
@@ -28,7 +28,8 @@ export function getOpenClawOperatorState(
   }
   if (
     status.status === 'starting' ||
-    TRANSIENT_CONTROL_PLANE_STATUSES.has(status.controlPlaneStatus)
+    (status.status === 'running' &&
+      TRANSIENT_CONTROL_PLANE_STATUSES.has(status.controlPlaneStatus))
   ) {
     return { kind: 'starting' }
   }

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/openclaw-operator-state.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/openclaw-operator-state.ts
@@ -1,0 +1,36 @@
+import type { OpenClawStatus } from './useOpenClaw'
+
+export type OpenClawOperatorState =
+  | 'loading'
+  | 'setup-needed'
+  | 'starting'
+  | 'healthy'
+  | 'needs-attention'
+
+export interface OpenClawOperatorStateResult {
+  kind: OpenClawOperatorState
+}
+
+const TRANSIENT_CONTROL_PLANE_STATUSES = new Set<
+  OpenClawStatus['controlPlaneStatus']
+>(['connecting', 'reconnecting', 'recovering'])
+
+export function getOpenClawOperatorState(
+  status: OpenClawStatus | null | undefined,
+): OpenClawOperatorStateResult {
+  if (!status) return { kind: 'loading' }
+  if (status.status === 'uninitialized') return { kind: 'setup-needed' }
+  if (
+    status.status === 'running' &&
+    status.controlPlaneStatus === 'connected'
+  ) {
+    return { kind: 'healthy' }
+  }
+  if (
+    status.status === 'starting' ||
+    TRANSIENT_CONTROL_PLANE_STATUSES.has(status.controlPlaneStatus)
+  ) {
+    return { kind: 'starting' }
+  }
+  return { kind: 'needs-attention' }
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/useOpenClaw.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/useOpenClaw.ts
@@ -216,6 +216,22 @@ export function useOpenClawMutations() {
     onSuccess,
   })
 
+  const repairMutation = useMutation({
+    mutationFn: async () =>
+      clawFetch<OpenClawStatus>(ensureBaseUrl(), '/repair', {
+        method: 'POST',
+      }),
+    onSuccess,
+  })
+
+  const resetMutation = useMutation({
+    mutationFn: async () =>
+      clawFetch<OpenClawStatus>(ensureBaseUrl(), '/reset', {
+        method: 'POST',
+      }),
+    onSuccess,
+  })
+
   const reconnectMutation = useMutation({
     mutationFn: async () =>
       clawFetch<{ status: string }>(ensureBaseUrl(), '/reconnect', {
@@ -231,6 +247,8 @@ export function useOpenClawMutations() {
     startOpenClaw: startMutation.mutateAsync,
     stopOpenClaw: stopMutation.mutateAsync,
     restartOpenClaw: restartMutation.mutateAsync,
+    repairOpenClaw: repairMutation.mutateAsync,
+    resetOpenClaw: resetMutation.mutateAsync,
     reconnectOpenClaw: reconnectMutation.mutateAsync,
     actionInProgress:
       setupMutation.isPending ||
@@ -239,10 +257,14 @@ export function useOpenClawMutations() {
       startMutation.isPending ||
       stopMutation.isPending ||
       restartMutation.isPending ||
+      repairMutation.isPending ||
+      resetMutation.isPending ||
       reconnectMutation.isPending,
     settingUp: setupMutation.isPending,
     creating: createMutation.isPending,
     deleting: deleteMutation.isPending,
+    repairing: repairMutation.isPending,
+    resetting: resetMutation.isPending,
     reconnecting: reconnectMutation.isPending,
   }
 }

--- a/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
@@ -7,7 +7,12 @@
  * Thin layer delegating to OpenClawService.
  */
 
-import { accessSync, existsSync, constants as fsConstants } from 'node:fs'
+import {
+  accessSync,
+  existsSync,
+  constants as fsConstants,
+  statSync,
+} from 'node:fs'
 import path from 'node:path'
 import { OPENCLAW_GATEWAY_PORT } from '@browseros/shared/constants/openclaw'
 import { Hono } from 'hono'
@@ -23,6 +28,8 @@ import {
 } from '../services/openclaw/errors'
 import { isUnsupportedOpenClawProviderError } from '../services/openclaw/openclaw-provider-map'
 import { getOpenClawService } from '../services/openclaw/openclaw-service'
+
+const activeMonitoredChatStartLocks = new Set<string>()
 
 function getCreateAgentValidationError(body: { name?: string }): string | null {
   if (!body.name?.trim()) {
@@ -43,6 +50,9 @@ function getPodmanOverrideValidationError(body: {
   }
   if (!existsSync(body.podmanPath)) {
     return `File does not exist: ${body.podmanPath}`
+  }
+  if (statSync(body.podmanPath).isDirectory()) {
+    return `Path is a directory: ${body.podmanPath}`
   }
   try {
     accessSync(body.podmanPath, fsConstants.X_OK)
@@ -275,7 +285,7 @@ export function createOpenClawRoutes() {
             ),
           )
         : []
-      if (getMonitoringService().getActiveSessionId(id)) {
+      if (activeMonitoredChatStartLocks.has(id)) {
         return c.json(
           {
             error:
@@ -284,12 +294,30 @@ export function createOpenClawRoutes() {
           409,
         )
       }
-      const monitoringContext = await getMonitoringService().startSession({
-        agentId: id,
-        sessionKey,
-        originalPrompt: body.message.trim(),
-        chatHistory: history,
-      })
+      activeMonitoredChatStartLocks.add(id)
+      let monitoringContext: { monitoringSessionId: string } | undefined
+      try {
+        if (getMonitoringService().getActiveSessionId(id)) {
+          return c.json(
+            {
+              error:
+                'A monitored chat session is already active for this agent. Wait for it to finish before starting another.',
+            },
+            409,
+          )
+        }
+        monitoringContext = await getMonitoringService().startSession({
+          agentId: id,
+          sessionKey,
+          originalPrompt: body.message.trim(),
+          chatHistory: history,
+        })
+      } finally {
+        activeMonitoredChatStartLocks.delete(id)
+      }
+      if (!monitoringContext) {
+        throw new Error('OpenClaw monitored chat session did not start')
+      }
 
       try {
         const eventStream = await getOpenClawService().chatStream(

--- a/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
@@ -77,13 +77,15 @@ export function createOpenClawRoutes() {
           hasApiKey: !!body.apiKey,
         })
         const logs: string[] = []
-        await getOpenClawService().setup(body, (msg) => logs.push(msg))
+        const service = getOpenClawService()
+        await service.setup(body, (msg) => logs.push(msg))
+        const status = await service.getStatus()
 
-        const agents = await getOpenClawService().listAgents()
+        const agents = await service.listAgents()
         return c.json(
           {
             status: 'running',
-            port: OPENCLAW_GATEWAY_PORT,
+            port: status.port ?? OPENCLAW_GATEWAY_PORT,
             agents: agents.map((a) => ({
               agentId: a.agentId,
               name: a.name,
@@ -106,6 +108,32 @@ export function createOpenClawRoutes() {
         if (message.includes('Podman is not available')) {
           return c.json({ error: message }, 503)
         }
+        return c.json({ error: message }, 500)
+      }
+    })
+
+    .post('/repair', async (c) => {
+      try {
+        logger.info('OpenClaw repair requested')
+        const service = getOpenClawService()
+        await service.repairRuntime()
+        return c.json(await service.getStatus())
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        logger.error('OpenClaw repair failed', { error: message })
+        return c.json({ error: message }, 500)
+      }
+    })
+
+    .post('/reset', async (c) => {
+      try {
+        logger.info('OpenClaw reset requested')
+        const service = getOpenClawService()
+        await service.resetRuntime()
+        return c.json(await service.getStatus())
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        logger.error('OpenClaw reset failed', { error: message })
         return c.json({ error: message }, 500)
       }
     })
@@ -275,60 +303,64 @@ export function createOpenClawRoutes() {
         c.header('Cache-Control', 'no-cache')
         c.header('X-Session-Key', sessionKey)
 
-        return stream(c, async (s) => {
-          const reader = eventStream.getReader()
-          const encoder = new TextEncoder()
-          let finalAssistantMessage: string | undefined
-          let status: 'completed' | 'failed' | 'aborted' | 'incomplete' =
-            'incomplete'
-          let finalError: string | undefined
-          try {
-            while (true) {
-              const { done, value } = await reader.read()
-              if (done) break
-              if (
-                value.type === 'done' &&
-                typeof value.data.text === 'string' &&
-                value.data.text.trim()
-              ) {
-                finalAssistantMessage = value.data.text
-                status = 'completed'
+        return stream(
+          c,
+          // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: SSE framing needs several branches.
+          async (s) => {
+            const reader = eventStream.getReader()
+            const encoder = new TextEncoder()
+            let finalAssistantMessage: string | undefined
+            let status: 'completed' | 'failed' | 'aborted' | 'incomplete' =
+              'incomplete'
+            let finalError: string | undefined
+            try {
+              while (true) {
+                const { done, value } = await reader.read()
+                if (done) break
+                if (
+                  value.type === 'done' &&
+                  typeof value.data.text === 'string' &&
+                  value.data.text.trim()
+                ) {
+                  finalAssistantMessage = value.data.text
+                  status = 'completed'
+                }
+                if (value.type === 'error') {
+                  finalError =
+                    (typeof value.data.message === 'string'
+                      ? value.data.message
+                      : typeof value.data.error === 'string'
+                        ? value.data.error
+                        : undefined) ?? 'Unknown chat stream error'
+                  status = 'failed'
+                }
+                await s.write(
+                  encoder.encode(`data: ${JSON.stringify(value)}\n\n`),
+                )
               }
-              if (value.type === 'error') {
-                finalError =
-                  (typeof value.data.message === 'string'
-                    ? value.data.message
-                    : typeof value.data.error === 'string'
-                      ? value.data.error
-                      : undefined) ?? 'Unknown chat stream error'
+              await s.write(encoder.encode('data: [DONE]\n\n'))
+            } catch (error) {
+              if (c.req.raw.signal.aborted) {
+                status = 'aborted'
+              } else {
                 status = 'failed'
+                finalError =
+                  error instanceof Error ? error.message : String(error)
               }
-              await s.write(
-                encoder.encode(`data: ${JSON.stringify(value)}\n\n`),
-              )
+              throw error
+            } finally {
+              await reader.cancel()
+              await getMonitoringService().finalizeSession({
+                monitoringSessionId: monitoringContext.monitoringSessionId,
+                agentId: id,
+                sessionKey,
+                status,
+                finalAssistantMessage,
+                error: finalError,
+              })
             }
-            await s.write(encoder.encode('data: [DONE]\n\n'))
-          } catch (error) {
-            if (c.req.raw.signal.aborted) {
-              status = 'aborted'
-            } else {
-              status = 'failed'
-              finalError =
-                error instanceof Error ? error.message : String(error)
-            }
-            throw error
-          } finally {
-            await reader.cancel()
-            await getMonitoringService().finalizeSession({
-              monitoringSessionId: monitoringContext.monitoringSessionId,
-              agentId: id,
-              sessionKey,
-              status,
-              finalAssistantMessage,
-              error: finalError,
-            })
-          }
-        })
+          },
+        )
       } catch (err) {
         await getMonitoringService().finalizeSession({
           monitoringSessionId: monitoringContext.monitoringSessionId,

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
@@ -9,7 +9,11 @@
 import { createServer } from 'node:net'
 import { OPENCLAW_GATEWAY_CONTAINER_NAME } from '@browseros/shared/constants/openclaw'
 import { logger } from '../../../lib/logger'
-import type { LogFn, PodmanRuntime } from './podman-runtime'
+import {
+  BROWSEROS_OPENCLAW_PODMAN_MACHINE_NAME,
+  type LogFn,
+  type PodmanRuntime,
+} from './podman-runtime'
 
 const GATEWAY_CONTAINER_HOME = '/home/node'
 const GATEWAY_STATE_DIR = `${GATEWAY_CONTAINER_HOME}/.openclaw`
@@ -117,6 +121,11 @@ export class ContainerRuntime {
       this.logPodmanCommandResult(runArgs, result)
 
       if (result.code === 0) {
+        logger.info('OpenClaw gateway bound to host port', {
+          hostPort,
+          preferredPort: input.port,
+          attempt,
+        })
         return hostPort
       }
 
@@ -317,7 +326,13 @@ export class ContainerRuntime {
   ): Promise<{ code: number; output: string[] }> {
     const lines: string[] = []
     const command = ['podman', ...args].join(' ')
+    const podmanPath =
+      typeof this.podman.getPodmanPath === 'function'
+        ? this.podman.getPodmanPath()
+        : 'podman'
     logger.info('Running OpenClaw podman command', {
+      podmanPath,
+      machineName: BROWSEROS_OPENCLAW_PODMAN_MACHINE_NAME,
       command,
     })
     const code = await this.podman.runCommand(args, {

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
@@ -128,6 +128,7 @@ export class ContainerRuntime {
           attempt,
           hostPort,
         })
+        await this.removeGatewayContainer(onLog)
         continue
       }
 

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
@@ -120,15 +120,20 @@ export class ContainerRuntime {
         return hostPort
       }
 
-      if (
-        this.isGatewayBindConflict(result.output) &&
-        attempt < GATEWAY_START_MAX_ATTEMPTS
-      ) {
+      const bindConflict = this.isGatewayBindConflict(result.output)
+
+      if (bindConflict && attempt < GATEWAY_START_MAX_ATTEMPTS) {
         logger.warn('OpenClaw gateway start hit a bind conflict; retrying', {
           attempt,
           hostPort,
         })
+      }
+
+      if (bindConflict) {
         await this.removeGatewayContainer(onLog)
+      }
+
+      if (bindConflict && attempt < GATEWAY_START_MAX_ATTEMPTS) {
         continue
       }
 

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
@@ -6,12 +6,14 @@
  * OpenClaw container lifecycle abstraction over PodmanRuntime.
  */
 
+import { createServer } from 'node:net'
 import { OPENCLAW_GATEWAY_CONTAINER_NAME } from '@browseros/shared/constants/openclaw'
 import { logger } from '../../../lib/logger'
 import type { LogFn, PodmanRuntime } from './podman-runtime'
 
 const GATEWAY_CONTAINER_HOME = '/home/node'
 const GATEWAY_STATE_DIR = `${GATEWAY_CONTAINER_HOME}/.openclaw`
+const GATEWAY_CONTAINER_PORT = 18789
 
 export type GatewayContainerSpec = {
   image: string
@@ -20,6 +22,30 @@ export type GatewayContainerSpec = {
   envFilePath: string
   gatewayToken?: string
   timezone: string
+}
+
+export type GatewayInspection = {
+  exists: boolean
+  running: boolean
+  hostPort: number | null
+}
+
+type PodmanInspectPortBinding = {
+  HostIp?: string
+  HostPort?: string
+}
+
+type PodmanInspectContainer = {
+  State?: {
+    Running?: boolean
+    Status?: string
+  }
+  NetworkSettings?: {
+    Ports?: Record<string, PodmanInspectPortBinding[] | null>
+  }
+  HostConfig?: {
+    PortBindings?: Record<string, PodmanInspectPortBinding[] | null>
+  }
 }
 
 export class ContainerRuntime {
@@ -52,8 +78,9 @@ export class ContainerRuntime {
   async startGateway(
     input: GatewayContainerSpec,
     onLog?: LogFn,
-  ): Promise<void> {
+  ): Promise<number> {
     await this.ensureGatewayRemoved(onLog)
+    const hostPort = await this.chooseGatewayHostPort(input.port)
     const code = await this.runPodmanCommand(
       [
         'run',
@@ -63,10 +90,10 @@ export class ContainerRuntime {
         '--restart',
         'unless-stopped',
         '-p',
-        `127.0.0.1:${input.port}:18789`,
+        `127.0.0.1:${hostPort}:${GATEWAY_CONTAINER_PORT}`,
         ...this.buildGatewayContainerRuntimeArgs(input),
         '--health-cmd',
-        'curl -sf http://127.0.0.1:18789/healthz',
+        `curl -sf http://127.0.0.1:${GATEWAY_CONTAINER_PORT}/healthz`,
         '--health-interval',
         '30s',
         '--health-timeout',
@@ -80,12 +107,14 @@ export class ContainerRuntime {
         '--bind',
         'lan',
         '--port',
-        '18789',
+        String(GATEWAY_CONTAINER_PORT),
         '--allow-unconfigured',
       ],
       onLog,
     )
     if (code !== 0) throw new Error(`gateway start failed with code ${code}`)
+
+    return hostPort
   }
 
   async stopGateway(onLog?: LogFn): Promise<void> {
@@ -98,8 +127,40 @@ export class ContainerRuntime {
   async restartGateway(
     input: GatewayContainerSpec,
     onLog?: LogFn,
-  ): Promise<void> {
-    await this.startGateway(input, onLog)
+  ): Promise<number> {
+    return this.startGateway(input, onLog)
+  }
+
+  async inspectGateway(): Promise<GatewayInspection> {
+    const result = await this.runPodmanCommandCapture([
+      'inspect',
+      OPENCLAW_GATEWAY_CONTAINER_NAME,
+    ])
+
+    if (result.code !== 0) {
+      if (this.isMissingGatewayContainer(result.output)) {
+        return {
+          exists: false,
+          running: false,
+          hostPort: null,
+        }
+      }
+
+      throw new Error(`gateway inspect failed with code ${result.code}`)
+    }
+
+    const container = this.parseGatewayInspection(result.output)
+    if (!container) {
+      throw new Error('gateway inspect returned unexpected output')
+    }
+
+    return {
+      exists: true,
+      running:
+        container.State?.Running === true ||
+        container.State?.Status?.toLowerCase() === 'running',
+      hostPort: this.extractGatewayHostPort(container),
+    }
   }
 
   async getGatewayLogs(tail = 50): Promise<string[]> {
@@ -217,6 +278,27 @@ export class ContainerRuntime {
     args: string[],
     onLog?: LogFn,
   ): Promise<number> {
+    const result = await this.runPodmanCommandCapture(args, onLog)
+    const command = ['podman', ...args].join(' ')
+    if (result.code !== 0) {
+      logger.error('OpenClaw podman command failed', {
+        command,
+        exitCode: result.code,
+        output: result.output,
+      })
+    } else {
+      logger.info('OpenClaw podman command succeeded', {
+        command,
+      })
+    }
+
+    return result.code
+  }
+
+  private async runPodmanCommandCapture(
+    args: string[],
+    onLog?: LogFn,
+  ): Promise<{ code: number; output: string[] }> {
     const lines: string[] = []
     const command = ['podman', ...args].join(' ')
     logger.info('Running OpenClaw podman command', {
@@ -230,19 +312,10 @@ export class ContainerRuntime {
       },
     })
 
-    if (code !== 0) {
-      logger.error('OpenClaw podman command failed', {
-        command,
-        exitCode: code,
-        output: lines,
-      })
-    } else {
-      logger.info('OpenClaw podman command succeeded', {
-        command,
-      })
+    return {
+      code,
+      output: lines,
     }
-
-    return code
   }
 
   private async ensureGatewayRemoved(onLog?: LogFn): Promise<void> {
@@ -254,6 +327,87 @@ export class ContainerRuntime {
       ['rm', '-f', '--ignore', OPENCLAW_GATEWAY_CONTAINER_NAME],
       onLog,
     )
+  }
+
+  private async chooseGatewayHostPort(preferredPort: number): Promise<number> {
+    if (await this.isLocalPortAvailable(preferredPort)) {
+      return preferredPort
+    }
+
+    return this.allocateEphemeralPort()
+  }
+
+  private async isLocalPortAvailable(port: number): Promise<boolean> {
+    return new Promise((resolve) => {
+      const server = createServer()
+      server.unref()
+      server.once('error', () => resolve(false))
+      server.listen({ host: '127.0.0.1', port, exclusive: true }, () => {
+        server.close(() => resolve(true))
+      })
+    })
+  }
+
+  private async allocateEphemeralPort(): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const server = createServer()
+      server.unref()
+      server.once('error', reject)
+      server.listen({ host: '127.0.0.1', port: 0, exclusive: true }, () => {
+        const address = server.address()
+        if (!address || typeof address === 'string') {
+          server.close(() =>
+            reject(new Error('failed to resolve ephemeral port')),
+          )
+          return
+        }
+
+        const port = address.port
+        server.close((closeError) => {
+          if (closeError) {
+            reject(closeError)
+            return
+          }
+          resolve(port)
+        })
+      })
+    })
+  }
+
+  private isMissingGatewayContainer(output: string[]): boolean {
+    const text = output.join('\n').toLowerCase()
+    return (
+      text.includes('no such object') ||
+      text.includes('no container') ||
+      text.includes('cannot inspect') ||
+      text.includes('not found')
+    )
+  }
+
+  private parseGatewayInspection(
+    output: string[],
+  ): PodmanInspectContainer | null {
+    const raw = output.join('\n').trim()
+    if (!raw) return null
+
+    const parsed = JSON.parse(raw) as
+      | PodmanInspectContainer
+      | PodmanInspectContainer[]
+    return Array.isArray(parsed) ? (parsed[0] ?? null) : parsed
+  }
+
+  private extractGatewayHostPort(
+    container: PodmanInspectContainer,
+  ): number | null {
+    const bindings =
+      container.NetworkSettings?.Ports?.[`${GATEWAY_CONTAINER_PORT}/tcp`] ??
+      container.HostConfig?.PortBindings?.[`${GATEWAY_CONTAINER_PORT}/tcp`]
+
+    const hostPort = bindings?.find((binding) => binding?.HostPort)?.HostPort
+    if (!hostPort) return null
+
+    const parsed = Number.parseInt(hostPort, 10)
+    return Number.isInteger(parsed) ? parsed : null
   }
 
   private buildGatewayContainerRuntimeArgs(

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
@@ -14,6 +14,7 @@ import type { LogFn, PodmanRuntime } from './podman-runtime'
 const GATEWAY_CONTAINER_HOME = '/home/node'
 const GATEWAY_STATE_DIR = `${GATEWAY_CONTAINER_HOME}/.openclaw`
 const GATEWAY_CONTAINER_PORT = 18789
+const GATEWAY_START_MAX_ATTEMPTS = 3
 
 export type GatewayContainerSpec = {
   image: string
@@ -48,11 +49,33 @@ type PodmanInspectContainer = {
   }
 }
 
+type PodmanCommandCaptureResult = {
+  code: number
+  stdout: string
+  stderr: string
+}
+
+type PodmanCommandCaptureFn = (
+  args: string[],
+  options?: {
+    cwd?: string
+  },
+) => Promise<PodmanCommandCaptureResult>
+
 export class ContainerRuntime {
+  private readonly capturePodmanCommand: PodmanCommandCaptureFn
+
   constructor(
     private podman: PodmanRuntime,
     private projectDir: string,
-  ) {}
+    options?: {
+      capturePodmanCommand?: PodmanCommandCaptureFn
+    },
+  ) {
+    this.capturePodmanCommand =
+      options?.capturePodmanCommand ??
+      this.defaultCapturePodmanCommand.bind(this)
+  }
 
   async ensureReady(onLog?: LogFn): Promise<void> {
     logger.info('Ensuring Podman runtime readiness')
@@ -80,41 +103,38 @@ export class ContainerRuntime {
     onLog?: LogFn,
   ): Promise<number> {
     await this.ensureGatewayRemoved(onLog)
-    const hostPort = await this.chooseGatewayHostPort(input.port)
-    const code = await this.runPodmanCommand(
-      [
-        'run',
-        '-d',
-        '--name',
-        OPENCLAW_GATEWAY_CONTAINER_NAME,
-        '--restart',
-        'unless-stopped',
-        '-p',
-        `127.0.0.1:${hostPort}:${GATEWAY_CONTAINER_PORT}`,
-        ...this.buildGatewayContainerRuntimeArgs(input),
-        '--health-cmd',
-        `curl -sf http://127.0.0.1:${GATEWAY_CONTAINER_PORT}/healthz`,
-        '--health-interval',
-        '30s',
-        '--health-timeout',
-        '10s',
-        '--health-retries',
-        '3',
-        input.image,
-        'node',
-        'dist/index.js',
-        'gateway',
-        '--bind',
-        'lan',
-        '--port',
-        String(GATEWAY_CONTAINER_PORT),
-        '--allow-unconfigured',
-      ],
-      onLog,
-    )
-    if (code !== 0) throw new Error(`gateway start failed with code ${code}`)
+    const attemptedPorts = new Set<number>()
 
-    return hostPort
+    for (let attempt = 1; attempt <= GATEWAY_START_MAX_ATTEMPTS; attempt++) {
+      const hostPort = await this.chooseGatewayHostPort(
+        input.port,
+        attemptedPorts,
+      )
+      attemptedPorts.add(hostPort)
+      const runArgs = this.buildGatewayStartArgs(input, hostPort)
+
+      const result = await this.runPodmanCommandResult(runArgs, onLog)
+      this.logPodmanCommandResult(runArgs, result)
+
+      if (result.code === 0) {
+        return hostPort
+      }
+
+      if (
+        this.isGatewayBindConflict(result.output) &&
+        attempt < GATEWAY_START_MAX_ATTEMPTS
+      ) {
+        logger.warn('OpenClaw gateway start hit a bind conflict; retrying', {
+          attempt,
+          hostPort,
+        })
+        continue
+      }
+
+      throw new Error(`gateway start failed with code ${result.code}`)
+    }
+
+    throw new Error('gateway start failed after exhausting retries')
   }
 
   async stopGateway(onLog?: LogFn): Promise<void> {
@@ -132,13 +152,15 @@ export class ContainerRuntime {
   }
 
   async inspectGateway(): Promise<GatewayInspection> {
-    const result = await this.runPodmanCommandCapture([
+    const result = await this.capturePodmanCommand([
       'inspect',
       OPENCLAW_GATEWAY_CONTAINER_NAME,
     ])
 
     if (result.code !== 0) {
-      if (this.isMissingGatewayContainer(result.output)) {
+      if (
+        this.isMissingGatewayContainer(`${result.stdout}\n${result.stderr}`)
+      ) {
         return {
           exists: false,
           running: false,
@@ -149,7 +171,7 @@ export class ContainerRuntime {
       throw new Error(`gateway inspect failed with code ${result.code}`)
     }
 
-    const container = this.parseGatewayInspection(result.output)
+    const container = this.parseGatewayInspection(result.stdout)
     if (!container) {
       throw new Error('gateway inspect returned unexpected output')
     }
@@ -278,24 +300,12 @@ export class ContainerRuntime {
     args: string[],
     onLog?: LogFn,
   ): Promise<number> {
-    const result = await this.runPodmanCommandCapture(args, onLog)
-    const command = ['podman', ...args].join(' ')
-    if (result.code !== 0) {
-      logger.error('OpenClaw podman command failed', {
-        command,
-        exitCode: result.code,
-        output: result.output,
-      })
-    } else {
-      logger.info('OpenClaw podman command succeeded', {
-        command,
-      })
-    }
-
+    const result = await this.runPodmanCommandResult(args, onLog)
+    this.logPodmanCommandResult(args, result)
     return result.code
   }
 
-  private async runPodmanCommandCapture(
+  private async runPodmanCommandResult(
     args: string[],
     onLog?: LogFn,
   ): Promise<{ code: number; output: string[] }> {
@@ -318,6 +328,24 @@ export class ContainerRuntime {
     }
   }
 
+  private logPodmanCommandResult(
+    args: string[],
+    result: { code: number; output: string[] },
+  ): void {
+    const command = ['podman', ...args].join(' ')
+    if (result.code !== 0) {
+      logger.error('OpenClaw podman command failed', {
+        command,
+        exitCode: result.code,
+        output: result.output,
+      })
+    } else {
+      logger.info('OpenClaw podman command succeeded', {
+        command,
+      })
+    }
+  }
+
   private async ensureGatewayRemoved(onLog?: LogFn): Promise<void> {
     await this.removeGatewayContainer(onLog)
   }
@@ -329,12 +357,18 @@ export class ContainerRuntime {
     )
   }
 
-  private async chooseGatewayHostPort(preferredPort: number): Promise<number> {
-    if (await this.isLocalPortAvailable(preferredPort)) {
+  private async chooseGatewayHostPort(
+    preferredPort: number,
+    attemptedPorts = new Set<number>(),
+  ): Promise<number> {
+    if (
+      !attemptedPorts.has(preferredPort) &&
+      (await this.isLocalPortAvailable(preferredPort))
+    ) {
       return preferredPort
     }
 
-    return this.allocateEphemeralPort()
+    return this.allocateDistinctEphemeralPort(attemptedPorts)
   }
 
   private async isLocalPortAvailable(port: number): Promise<boolean> {
@@ -374,8 +408,21 @@ export class ContainerRuntime {
     })
   }
 
-  private isMissingGatewayContainer(output: string[]): boolean {
-    const text = output.join('\n').toLowerCase()
+  private async allocateDistinctEphemeralPort(
+    attemptedPorts: Set<number>,
+  ): Promise<number> {
+    for (let attempt = 0; attempt < 10; attempt++) {
+      const port = await this.allocateEphemeralPort()
+      if (!attemptedPorts.has(port)) {
+        return port
+      }
+    }
+
+    throw new Error('failed to allocate a distinct gateway host port')
+  }
+
+  private isMissingGatewayContainer(output: string): boolean {
+    const text = output.toLowerCase()
     return (
       text.includes('no such object') ||
       text.includes('no container') ||
@@ -385,15 +432,26 @@ export class ContainerRuntime {
   }
 
   private parseGatewayInspection(
-    output: string[],
+    output: string,
   ): PodmanInspectContainer | null {
-    const raw = output.join('\n').trim()
+    const raw = output.trim()
     if (!raw) return null
 
     const parsed = JSON.parse(raw) as
       | PodmanInspectContainer
       | PodmanInspectContainer[]
     return Array.isArray(parsed) ? (parsed[0] ?? null) : parsed
+  }
+
+  private isGatewayBindConflict(output: string[]): boolean {
+    const text = output.join('\n').toLowerCase()
+    return (
+      text.includes('address already in use') ||
+      text.includes('eaddrinuse') ||
+      text.includes('port is already allocated') ||
+      text.includes('port already allocated') ||
+      text.includes('bind: address already in use')
+    )
   }
 
   private extractGatewayHostPort(
@@ -408,6 +466,73 @@ export class ContainerRuntime {
 
     const parsed = Number.parseInt(hostPort, 10)
     return Number.isInteger(parsed) ? parsed : null
+  }
+
+  private buildGatewayStartArgs(
+    input: GatewayContainerSpec,
+    hostPort: number,
+  ): string[] {
+    return [
+      'run',
+      '-d',
+      '--name',
+      OPENCLAW_GATEWAY_CONTAINER_NAME,
+      '--restart',
+      'unless-stopped',
+      '-p',
+      `127.0.0.1:${hostPort}:${GATEWAY_CONTAINER_PORT}`,
+      ...this.buildGatewayContainerRuntimeArgs(input),
+      '--health-cmd',
+      `curl -sf http://127.0.0.1:${GATEWAY_CONTAINER_PORT}/healthz`,
+      '--health-interval',
+      '30s',
+      '--health-timeout',
+      '10s',
+      '--health-retries',
+      '3',
+      input.image,
+      'node',
+      'dist/index.js',
+      'gateway',
+      '--bind',
+      'lan',
+      '--port',
+      String(GATEWAY_CONTAINER_PORT),
+      '--allow-unconfigured',
+    ]
+  }
+
+  private async defaultCapturePodmanCommand(
+    args: string[],
+    options?: {
+      cwd?: string
+    },
+  ): Promise<PodmanCommandCaptureResult> {
+    const command = [this.podman.getPodmanPath(), ...args]
+    logger.info('Running OpenClaw podman command', {
+      command: command.join(' '),
+    })
+
+    const proc = Bun.spawn(command, {
+      cwd: options?.cwd,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+
+    const [stdout, stderr, code] = await Promise.all([
+      this.readStreamText(proc.stdout),
+      this.readStreamText(proc.stderr),
+      proc.exited,
+    ])
+
+    return { code, stdout, stderr }
+  }
+
+  private async readStreamText(
+    stream: ReadableStream<Uint8Array> | null,
+  ): Promise<string> {
+    if (!stream) return ''
+    return new Response(stream).text()
   }
 
   private buildGatewayContainerRuntimeArgs(

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-runtime-state.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-runtime-state.ts
@@ -8,13 +8,6 @@ import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { z } from 'zod'
 
-export interface OpenClawRuntimeState {
-  hostGatewayPort: number | null
-  lastSuccessfulStartAt: string | null
-  repairGeneration: number
-  lastRepairOutcome: 'success' | 'failed' | null
-}
-
 const RUNTIME_STATE_FILE_NAME = 'runtime-state.json'
 const openClawRuntimeStateSchema = z
   .object({
@@ -24,6 +17,8 @@ const openClawRuntimeStateSchema = z
     lastRepairOutcome: z.enum(['success', 'failed']).nullable(),
   })
   .strict()
+
+export type OpenClawRuntimeState = z.infer<typeof openClawRuntimeStateSchema>
 
 export function getOpenClawRuntimeStatePath(openclawDir: string): string {
   return join(openclawDir, RUNTIME_STATE_FILE_NAME)

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-runtime-state.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-runtime-state.ts
@@ -6,6 +6,7 @@
 
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
+import { z } from 'zod'
 
 export interface OpenClawRuntimeState {
   hostGatewayPort: number | null
@@ -15,6 +16,14 @@ export interface OpenClawRuntimeState {
 }
 
 const RUNTIME_STATE_FILE_NAME = 'runtime-state.json'
+const openClawRuntimeStateSchema = z
+  .object({
+    hostGatewayPort: z.number().int().min(1).max(65535).nullable(),
+    lastSuccessfulStartAt: z.string().datetime({ offset: true }).nullable(),
+    repairGeneration: z.number().int().nonnegative(),
+    lastRepairOutcome: z.enum(['success', 'failed']).nullable(),
+  })
+  .strict()
 
 export function getOpenClawRuntimeStatePath(openclawDir: string): string {
   return join(openclawDir, RUNTIME_STATE_FILE_NAME)
@@ -27,8 +36,9 @@ export async function loadOpenClawRuntimeState(
     const parsed = JSON.parse(
       await readFile(getOpenClawRuntimeStatePath(openclawDir), 'utf-8'),
     ) as unknown
-    if (!isOpenClawRuntimeState(parsed)) return null
-    return parsed
+    const result = openClawRuntimeStateSchema.safeParse(parsed)
+    if (!result.success) return null
+    return result.data
   } catch {
     return null
   }
@@ -44,35 +54,4 @@ export async function saveOpenClawRuntimeState(
     `${JSON.stringify(state, null, 2)}\n`,
     'utf-8',
   )
-}
-
-function isOpenClawRuntimeState(value: unknown): value is OpenClawRuntimeState {
-  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
-    return false
-  }
-
-  const state = value as Record<string, unknown>
-  return (
-    isValidHostGatewayPort(state.hostGatewayPort) &&
-    (typeof state.lastSuccessfulStartAt === 'string' ||
-      state.lastSuccessfulStartAt === null) &&
-    isValidRepairGeneration(state.repairGeneration) &&
-    (state.lastRepairOutcome === 'success' ||
-      state.lastRepairOutcome === 'failed' ||
-      state.lastRepairOutcome === null)
-  )
-}
-
-function isValidHostGatewayPort(value: unknown): value is number | null {
-  return (
-    value === null ||
-    (typeof value === 'number' &&
-      Number.isInteger(value) &&
-      value >= 1 &&
-      value <= 65535)
-  )
-}
-
-function isValidRepairGeneration(value: unknown): value is number {
-  return typeof value === 'number' && Number.isInteger(value) && value >= 0
 }

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-runtime-state.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-runtime-state.ts
@@ -53,13 +53,26 @@ function isOpenClawRuntimeState(value: unknown): value is OpenClawRuntimeState {
 
   const state = value as Record<string, unknown>
   return (
-    (typeof state.hostGatewayPort === 'number' ||
-      state.hostGatewayPort === null) &&
+    isValidHostGatewayPort(state.hostGatewayPort) &&
     (typeof state.lastSuccessfulStartAt === 'string' ||
       state.lastSuccessfulStartAt === null) &&
-    typeof state.repairGeneration === 'number' &&
+    isValidRepairGeneration(state.repairGeneration) &&
     (state.lastRepairOutcome === 'success' ||
       state.lastRepairOutcome === 'failed' ||
       state.lastRepairOutcome === null)
   )
+}
+
+function isValidHostGatewayPort(value: unknown): value is number | null {
+  return (
+    value === null ||
+    (typeof value === 'number' &&
+      Number.isInteger(value) &&
+      value >= 1 &&
+      value <= 65535)
+  )
+}
+
+function isValidRepairGeneration(value: unknown): value is number {
+  return typeof value === 'number' && Number.isInteger(value) && value >= 0
 }

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-runtime-state.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-runtime-state.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+
+export interface OpenClawRuntimeState {
+  hostGatewayPort: number | null
+  lastSuccessfulStartAt: string | null
+  repairGeneration: number
+  lastRepairOutcome: 'success' | 'failed' | null
+}
+
+const RUNTIME_STATE_FILE_NAME = 'runtime-state.json'
+
+export function getOpenClawRuntimeStatePath(openclawDir: string): string {
+  return join(openclawDir, RUNTIME_STATE_FILE_NAME)
+}
+
+export async function loadOpenClawRuntimeState(
+  openclawDir: string,
+): Promise<OpenClawRuntimeState | null> {
+  try {
+    const parsed = JSON.parse(
+      await readFile(getOpenClawRuntimeStatePath(openclawDir), 'utf-8'),
+    ) as Partial<OpenClawRuntimeState>
+    return {
+      hostGatewayPort:
+        typeof parsed.hostGatewayPort === 'number'
+          ? parsed.hostGatewayPort
+          : null,
+      lastSuccessfulStartAt:
+        typeof parsed.lastSuccessfulStartAt === 'string'
+          ? parsed.lastSuccessfulStartAt
+          : null,
+      repairGeneration:
+        typeof parsed.repairGeneration === 'number'
+          ? parsed.repairGeneration
+          : 0,
+      lastRepairOutcome:
+        parsed.lastRepairOutcome === 'success' ||
+        parsed.lastRepairOutcome === 'failed'
+          ? parsed.lastRepairOutcome
+          : null,
+    }
+  } catch {
+    return null
+  }
+}
+
+export async function saveOpenClawRuntimeState(
+  openclawDir: string,
+  state: OpenClawRuntimeState,
+): Promise<void> {
+  await mkdir(openclawDir, { recursive: true })
+  await writeFile(
+    getOpenClawRuntimeStatePath(openclawDir),
+    `${JSON.stringify(state, null, 2)}\n`,
+    'utf-8',
+  )
+}

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-runtime-state.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-runtime-state.ts
@@ -26,26 +26,9 @@ export async function loadOpenClawRuntimeState(
   try {
     const parsed = JSON.parse(
       await readFile(getOpenClawRuntimeStatePath(openclawDir), 'utf-8'),
-    ) as Partial<OpenClawRuntimeState>
-    return {
-      hostGatewayPort:
-        typeof parsed.hostGatewayPort === 'number'
-          ? parsed.hostGatewayPort
-          : null,
-      lastSuccessfulStartAt:
-        typeof parsed.lastSuccessfulStartAt === 'string'
-          ? parsed.lastSuccessfulStartAt
-          : null,
-      repairGeneration:
-        typeof parsed.repairGeneration === 'number'
-          ? parsed.repairGeneration
-          : 0,
-      lastRepairOutcome:
-        parsed.lastRepairOutcome === 'success' ||
-        parsed.lastRepairOutcome === 'failed'
-          ? parsed.lastRepairOutcome
-          : null,
-    }
+    ) as unknown
+    if (!isOpenClawRuntimeState(parsed)) return null
+    return parsed
   } catch {
     return null
   }
@@ -60,5 +43,23 @@ export async function saveOpenClawRuntimeState(
     getOpenClawRuntimeStatePath(openclawDir),
     `${JSON.stringify(state, null, 2)}\n`,
     'utf-8',
+  )
+}
+
+function isOpenClawRuntimeState(value: unknown): value is OpenClawRuntimeState {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+
+  const state = value as Record<string, unknown>
+  return (
+    (typeof state.hostGatewayPort === 'number' ||
+      state.hostGatewayPort === null) &&
+    (typeof state.lastSuccessfulStartAt === 'string' ||
+      state.lastSuccessfulStartAt === null) &&
+    typeof state.repairGeneration === 'number' &&
+    (state.lastRepairOutcome === 'success' ||
+      state.lastRepairOutcome === 'failed' ||
+      state.lastRepairOutcome === null)
   )
 }

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -380,33 +380,33 @@ export class OpenClawService {
     await this.loadRuntimeState()
     const nextRepairGeneration = (this.runtimeState?.repairGeneration ?? 0) + 1
 
-    this.controlPlaneStatus = 'recovering'
-    this.stopGatewayLogTail()
-
-    logProgress('Stopping OpenClaw gateway...')
     try {
-      await this.runtime.stopGateway(logProgress)
-    } catch {
-      // Best effort before a repair start.
-    }
+      this.controlPlaneStatus = 'recovering'
+      this.stopGatewayLogTail()
 
-    logProgress('Checking Podman machine...')
-    try {
-      await this.runtime.stopMachineIfSafe()
-    } catch {
-      // Best effort before a repair start.
-    }
+      logProgress('Stopping OpenClaw gateway...')
+      try {
+        await this.runtime.stopGateway(logProgress)
+      } catch {
+        // Best effort before a repair start.
+      }
 
-    logProgress('Ensuring Podman runtime is ready...')
-    await this.runtime.ensureReady(logProgress)
+      logProgress('Checking Podman machine...')
+      try {
+        await this.runtime.stopMachineIfSafe()
+      } catch {
+        // Best effort before a repair start.
+      }
 
-    logProgress('Refreshing gateway auth token...')
-    this.tokenLoaded = false
-    await this.loadTokenFromConfig()
-    await this.ensureStateEnvFile()
+      logProgress('Ensuring Podman runtime is ready...')
+      await this.runtime.ensureReady(logProgress)
 
-    logProgress('Starting repaired OpenClaw gateway...')
-    try {
+      logProgress('Refreshing gateway auth token...')
+      this.tokenLoaded = false
+      await this.loadTokenFromConfig()
+      await this.ensureStateEnvFile()
+
+      logProgress('Starting repaired OpenClaw gateway...')
       this.controlPlaneStatus = 'connecting'
       await this.launchGatewayRuntime({
         logProgress,
@@ -440,28 +440,25 @@ export class OpenClawService {
   }
 
   async resetRuntime(): Promise<void> {
-    this.stopGatewayLogTail()
-    this.controlPlaneStatus = 'disconnected'
-    this.tokenLoaded = false
-    this.lastGatewayError = null
-    this.lastRecoveryReason = null
-    this.lastError = null
-
     try {
+      this.stopGatewayLogTail()
       await this.runtime.stopGateway()
-    } catch {
-      // Best effort reset.
-    }
-
-    try {
       await this.runtime.stopMachineIfSafe()
-    } catch {
-      // Best effort reset.
+      this.controlPlaneStatus = 'disconnected'
+      this.tokenLoaded = false
+      this.lastGatewayError = null
+      this.lastRecoveryReason = null
+      this.lastError = null
+      this.applyGatewayPort(OPENCLAW_GATEWAY_PORT)
+      await this.saveRuntimeState(this.defaultRuntimeState())
+      logger.info('OpenClaw runtime reset', { port: this.port })
+    } catch (error) {
+      this.controlPlaneStatus = 'failed'
+      this.lastError = error instanceof Error ? error.message : String(error)
+      this.lastGatewayError = this.lastError
+      this.lastRecoveryReason = this.classifyControlPlaneError(error)
+      throw error
     }
-
-    this.applyGatewayPort(OPENCLAW_GATEWAY_PORT)
-    await this.saveRuntimeState(this.defaultRuntimeState())
-    logger.info('OpenClaw runtime reset', { port: this.port })
   }
 
   // ── Status ───────────────────────────────────────────────────────────

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -21,6 +21,7 @@ import type { MonitoringChatTurn } from '../../../monitoring/types'
 import {
   ContainerRuntime,
   type GatewayContainerSpec,
+  type GatewayInspection,
 } from './container-runtime'
 import {
   OpenClawAgentAlreadyExistsError,
@@ -45,6 +46,11 @@ import {
   type ResolvedOpenClawProviderConfig,
   resolveSupportedOpenClawProvider,
 } from './openclaw-provider-map'
+import {
+  loadOpenClawRuntimeState,
+  type OpenClawRuntimeState,
+  saveOpenClawRuntimeState,
+} from './openclaw-runtime-state'
 import type { OpenClawStreamEvent } from './openclaw-types'
 import { loadPodmanOverrides, savePodmanOverrides } from './podman-overrides'
 import { configurePodmanRuntime, getPodmanRuntime } from './podman-runtime'
@@ -130,6 +136,8 @@ export class OpenClawService {
   private lastGatewayError: string | null = null
   private lastRecoveryReason: OpenClawGatewayRecoveryReason | null = null
   private stopLogTail: (() => void) | null = null
+  private runtimeState: OpenClawRuntimeState | null = null
+  private runtimeStateLoaded = false
 
   constructor(config: OpenClawServiceConfig = {}) {
     this.openclawDir = getOpenClawDir()
@@ -160,6 +168,7 @@ export class OpenClawService {
   async setup(input: SetupInput, onLog?: (msg: string) => void): Promise<void> {
     const logProgress = this.createProgressLogger(onLog)
     const provider = resolveSupportedOpenClawProvider(input)
+    await this.loadRuntimeState()
     logger.info('Starting OpenClaw setup', {
       port: this.port,
       browserosServerPort: this.browserosServerPort,
@@ -220,7 +229,11 @@ export class OpenClawService {
     await this.loadTokenFromConfig()
 
     logProgress('Starting OpenClaw gateway...')
-    await this.runtime.startGateway(this.buildGatewayRuntimeSpec(), logProgress)
+    const hostPort = await this.runtime.startGateway(
+      this.buildGatewayRuntimeSpec(),
+      logProgress,
+    )
+    await this.recordSuccessfulGatewayStart(hostPort)
     this.startGatewayLogTail()
     logProgress('Waiting for gateway readiness...')
     const ready = await this.runtime.waitForReady(this.port, READY_TIMEOUT_MS)
@@ -259,6 +272,7 @@ export class OpenClawService {
 
   async start(onLog?: (msg: string) => void): Promise<void> {
     const logProgress = this.createProgressLogger(onLog)
+    await this.loadRuntimeState()
     logger.info('Starting OpenClaw service', {
       port: this.port,
     })
@@ -271,7 +285,11 @@ export class OpenClawService {
     await this.ensureStateEnvFile()
 
     logProgress('Starting OpenClaw gateway...')
-    await this.runtime.startGateway(this.buildGatewayRuntimeSpec(), logProgress)
+    const hostPort = await this.runtime.startGateway(
+      this.buildGatewayRuntimeSpec(),
+      logProgress,
+    )
+    await this.recordSuccessfulGatewayStart(hostPort)
     this.startGatewayLogTail()
 
     logProgress('Waiting for gateway readiness...')
@@ -298,6 +316,7 @@ export class OpenClawService {
 
   async restart(onLog?: (msg: string) => void): Promise<void> {
     const logProgress = this.createProgressLogger(onLog)
+    await this.loadRuntimeState()
     logger.info('Restarting OpenClaw service', {
       port: this.port,
     })
@@ -309,28 +328,48 @@ export class OpenClawService {
     await this.loadTokenFromConfig()
     await this.ensureStateEnvFile()
     logProgress('Restarting OpenClaw gateway...')
-    await this.runtime.restartGateway(
-      this.buildGatewayRuntimeSpec(),
-      logProgress,
-    )
-    this.startGatewayLogTail()
+    try {
+      const hostPort = await this.runtime.restartGateway(
+        this.buildGatewayRuntimeSpec(),
+        logProgress,
+      )
+      await this.recordSuccessfulGatewayStart(hostPort)
+      this.startGatewayLogTail()
 
-    logProgress('Waiting for gateway readiness...')
-    const ready = await this.runtime.waitForReady(this.port, READY_TIMEOUT_MS)
-    if (!ready) {
-      this.lastError = 'Gateway did not become ready after restart'
-      throw new Error(this.lastError)
+      logProgress('Waiting for gateway readiness...')
+      const ready = await this.runtime.waitForReady(this.port, READY_TIMEOUT_MS)
+      if (!ready) {
+        this.lastError = 'Gateway did not become ready after restart'
+        throw new Error(this.lastError)
+      }
+
+      logProgress('Probing OpenClaw control plane...')
+      await this.runControlPlaneCall(() => this.cliClient.probe())
+      this.lastError = null
+      logProgress('Gateway restarted successfully')
+      logger.info('OpenClaw gateway restarted', { port: this.port })
+    } catch (error) {
+      if (this.isStrongMachineCorruptionSignature(error)) {
+        logger.warn(
+          'OpenClaw restart hit machine corruption; repairing runtime',
+          {
+            error: error instanceof Error ? error.message : String(error),
+          },
+        )
+        await this.repairRuntime(onLog)
+        return
+      }
+      this.controlPlaneStatus = 'failed'
+      this.lastGatewayError =
+        error instanceof Error ? error.message : String(error)
+      this.lastRecoveryReason = this.classifyControlPlaneError(error)
+      throw error
     }
-
-    logProgress('Probing OpenClaw control plane...')
-    await this.runControlPlaneCall(() => this.cliClient.probe())
-    this.lastError = null
-    logProgress('Gateway restarted successfully')
-    logger.info('OpenClaw gateway restarted', { port: this.port })
   }
 
   async reconnectControlPlane(onLog?: (msg: string) => void): Promise<void> {
     const logProgress = this.createProgressLogger(onLog)
+    await this.loadRuntimeState()
     logger.info('Reconnecting OpenClaw control plane', { port: this.port })
 
     logProgress('Checking gateway readiness...')
@@ -361,6 +400,101 @@ export class OpenClawService {
     }
     await this.runtime.stopMachineIfSafe()
     logger.info('OpenClaw shutdown complete')
+  }
+
+  async repairRuntime(onLog?: (msg: string) => void): Promise<void> {
+    const logProgress = this.createProgressLogger(onLog)
+    await this.loadRuntimeState()
+    const nextRepairGeneration = (this.runtimeState?.repairGeneration ?? 0) + 1
+
+    this.controlPlaneStatus = 'recovering'
+    this.stopGatewayLogTail()
+
+    logProgress('Stopping OpenClaw gateway...')
+    try {
+      await this.runtime.stopGateway(logProgress)
+    } catch {
+      // Best effort before a repair start.
+    }
+
+    logProgress('Checking Podman machine...')
+    try {
+      await this.runtime.stopMachineIfSafe()
+    } catch {
+      // Best effort before a repair start.
+    }
+
+    logProgress('Ensuring Podman runtime is ready...')
+    await this.runtime.ensureReady(logProgress)
+
+    logProgress('Refreshing gateway auth token...')
+    this.tokenLoaded = false
+    await this.loadTokenFromConfig()
+    await this.ensureStateEnvFile()
+
+    logProgress('Starting repaired OpenClaw gateway...')
+    try {
+      const hostPort = await this.runtime.startGateway(
+        this.buildGatewayRuntimeSpec(),
+        logProgress,
+      )
+      await this.recordSuccessfulGatewayStart(hostPort)
+      this.startGatewayLogTail()
+
+      logProgress('Waiting for gateway readiness...')
+      const ready = await this.runtime.waitForReady(this.port, READY_TIMEOUT_MS)
+      if (!ready) {
+        throw new Error('Gateway did not become ready after repair')
+      }
+
+      this.controlPlaneStatus = 'connecting'
+      logProgress('Probing OpenClaw control plane...')
+      await this.runControlPlaneCall(() => this.cliClient.probe())
+      await this.saveRuntimeState({
+        ...(this.runtimeState ?? this.defaultRuntimeState()),
+        repairGeneration: nextRepairGeneration,
+        lastRepairOutcome: 'success',
+      })
+      this.lastError = null
+      logger.info('OpenClaw runtime repaired', { port: this.port })
+    } catch (error) {
+      await this.saveRuntimeState({
+        ...(this.runtimeState ?? this.defaultRuntimeState()),
+        repairGeneration: nextRepairGeneration,
+        lastRepairOutcome: 'failed',
+      })
+      this.controlPlaneStatus = 'failed'
+      this.lastError =
+        error instanceof Error ? error.message : 'Gateway repair failed'
+      this.lastGatewayError = this.lastError
+      this.lastRecoveryReason = this.classifyControlPlaneError(error)
+      throw error
+    }
+  }
+
+  async resetRuntime(): Promise<void> {
+    this.stopGatewayLogTail()
+    this.controlPlaneStatus = 'disconnected'
+    this.tokenLoaded = false
+    this.lastGatewayError = null
+    this.lastRecoveryReason = null
+    this.lastError = null
+
+    try {
+      await this.runtime.stopGateway()
+    } catch {
+      // Best effort reset.
+    }
+
+    try {
+      await this.runtime.stopMachineIfSafe()
+    } catch {
+      // Best effort reset.
+    }
+
+    this.applyGatewayPort(OPENCLAW_GATEWAY_PORT)
+    await this.saveRuntimeState(this.defaultRuntimeState())
+    logger.info('OpenClaw runtime reset', { port: this.port })
   }
 
   // ── Status ───────────────────────────────────────────────────────────
@@ -397,10 +531,19 @@ export class OpenClawService {
       }
     }
 
+    await this.loadRuntimeState()
+    const inspection = await this.inspectGateway()
+    const runtimePort =
+      inspection?.hostPort ?? this.runtimeState?.hostGatewayPort
+    if (runtimePort && runtimePort !== this.port) {
+      await this.updateGatewayPort(runtimePort)
+    }
+
     const machineStatus = await this.runtime.getMachineStatus()
-    const ready = machineStatus.running
-      ? await this.runtime.isReady(this.port)
-      : false
+    const ready =
+      runtimePort && machineStatus.running
+        ? await this.runtime.isReady(runtimePort)
+        : false
 
     let agentCount = 0
     if (ready) {
@@ -415,13 +558,13 @@ export class OpenClawService {
     }
 
     return {
-      status: ready ? 'running' : this.lastError ? 'error' : 'stopped',
+      status: this.resolveStatus(machineStatus.running, ready),
       podmanAvailable: true,
       machineReady: machineStatus.running,
-      port: this.port,
+      port: runtimePort ?? null,
       agentCount,
       error: this.lastError,
-      controlPlaneStatus: ready ? this.controlPlaneStatus : 'disconnected',
+      controlPlaneStatus: this.resolveControlPlaneStatus(ready),
       lastGatewayError: this.lastGatewayError,
       lastRecoveryReason: this.lastRecoveryReason,
     }
@@ -618,6 +761,7 @@ export class OpenClawService {
   // ── Auto-start on BrowserOS boot ────────────────────────────────────
 
   async tryAutoStart(): Promise<void> {
+    await this.loadRuntimeState()
     const isSetUp = existsSync(this.getStateConfigPath())
     if (!isSetUp) return
 
@@ -635,7 +779,10 @@ export class OpenClawService {
       await this.ensureStateEnvFile()
 
       if (!(await this.runtime.isReady(this.port))) {
-        await this.runtime.startGateway(this.buildGatewayRuntimeSpec())
+        const hostPort = await this.runtime.startGateway(
+          this.buildGatewayRuntimeSpec(),
+        )
+        await this.recordSuccessfulGatewayStart(hostPort)
         const ready = await this.runtime.waitForReady(
           this.port,
           READY_TIMEOUT_MS,
@@ -676,6 +823,7 @@ export class OpenClawService {
   }
 
   private async assertGatewayReady(): Promise<void> {
+    await this.loadRuntimeState()
     const portReady = await this.runtime.isReady(this.port)
     logger.debug('Checking OpenClaw gateway readiness before use', {
       port: this.port,
@@ -858,6 +1006,139 @@ export class OpenClawService {
     }
 
     return entries
+  }
+
+  private defaultRuntimeState(): OpenClawRuntimeState {
+    return {
+      hostGatewayPort: null,
+      lastSuccessfulStartAt: null,
+      repairGeneration: 0,
+      lastRepairOutcome: null,
+    }
+  }
+
+  private async loadRuntimeState(): Promise<OpenClawRuntimeState> {
+    if (!this.runtimeStateLoaded) {
+      this.runtimeState =
+        (await loadOpenClawRuntimeState(this.openclawDir)) ??
+        this.defaultRuntimeState()
+      this.runtimeStateLoaded = true
+      if (this.runtimeState.hostGatewayPort !== null) {
+        this.applyGatewayPort(this.runtimeState.hostGatewayPort)
+      }
+    }
+
+    return this.runtimeState ?? this.defaultRuntimeState()
+  }
+
+  private async saveRuntimeState(
+    state: OpenClawRuntimeState,
+  ): Promise<OpenClawRuntimeState> {
+    this.runtimeState = state
+    this.runtimeStateLoaded = true
+    await saveOpenClawRuntimeState(this.openclawDir, state)
+    return state
+  }
+
+  private applyGatewayPort(port: number): void {
+    if (this.port === port) return
+    this.port = port
+    this.chatClient = new OpenClawHttpChatClient(
+      this.port,
+      async () => this.token,
+    )
+  }
+
+  private async updateGatewayPort(port: number): Promise<void> {
+    const current = await this.loadRuntimeState()
+    this.applyGatewayPort(port)
+    await this.saveRuntimeState({
+      ...current,
+      hostGatewayPort: port,
+    })
+  }
+
+  private async recordSuccessfulGatewayStart(port: number): Promise<void> {
+    const current = await this.loadRuntimeState()
+    this.applyGatewayPort(port)
+    await this.saveRuntimeState({
+      ...current,
+      hostGatewayPort: port,
+      lastSuccessfulStartAt: new Date().toISOString(),
+      lastRepairOutcome: null,
+    })
+  }
+
+  private async inspectGateway(): Promise<GatewayInspection | null> {
+    const runtime = this.runtime as Partial<ContainerRuntime> & {
+      inspectGateway?: () => Promise<GatewayInspection>
+    }
+    if (typeof runtime.inspectGateway !== 'function') {
+      return null
+    }
+
+    try {
+      return await runtime.inspectGateway()
+    } catch (error) {
+      logger.debug('OpenClaw gateway inspection failed', {
+        error: error instanceof Error ? error.message : String(error),
+      })
+      return null
+    }
+  }
+
+  private resolveStatus(
+    machineRunning: boolean,
+    ready: boolean,
+  ): OpenClawStatus {
+    if (!machineRunning) {
+      return this.lastError ? 'error' : 'stopped'
+    }
+
+    if (ready) {
+      return 'running'
+    }
+
+    if (
+      this.controlPlaneStatus === 'connecting' ||
+      this.controlPlaneStatus === 'reconnecting' ||
+      this.controlPlaneStatus === 'recovering'
+    ) {
+      return 'starting'
+    }
+
+    return this.lastError ? 'error' : 'stopped'
+  }
+
+  private resolveControlPlaneStatus(
+    ready: boolean,
+  ): OpenClawControlPlaneStatus {
+    if (ready) {
+      return this.controlPlaneStatus
+    }
+
+    if (
+      this.controlPlaneStatus === 'connecting' ||
+      this.controlPlaneStatus === 'reconnecting' ||
+      this.controlPlaneStatus === 'recovering'
+    ) {
+      return this.controlPlaneStatus
+    }
+
+    return this.lastGatewayError || this.lastError ? 'failed' : 'disconnected'
+  }
+
+  private isStrongMachineCorruptionSignature(error: unknown): boolean {
+    const message = error instanceof Error ? error.message : String(error)
+    const text = message.toLowerCase()
+    return (
+      text.includes('machine is corrupted') ||
+      text.includes('needs to be removed') ||
+      text.includes('podman machine start failed') ||
+      text.includes('failed to start podman machine') ||
+      text.includes('could not start podman machine') ||
+      (text.includes('podman machine') && text.includes('corrupt'))
+    )
   }
 
   private async applyCliMutation(action: () => Promise<void>): Promise<void> {

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -229,24 +229,13 @@ export class OpenClawService {
     await this.loadTokenFromConfig()
 
     logProgress('Starting OpenClaw gateway...')
-    const hostPort = await this.runtime.startGateway(
-      this.buildGatewayRuntimeSpec(),
-      logProgress,
-    )
-    await this.recordSuccessfulGatewayStart(hostPort)
-    this.startGatewayLogTail()
-    logProgress('Waiting for gateway readiness...')
-    const ready = await this.runtime.waitForReady(this.port, READY_TIMEOUT_MS)
-    if (!ready) {
-      this.lastError = 'Gateway did not become ready within 30 seconds'
-      const logs = await this.runtime.getGatewayLogs()
-      logger.error('Gateway readiness check failed', { logs })
-      throw new Error(this.lastError)
-    }
-
     this.controlPlaneStatus = 'connecting'
-    logProgress('Probing OpenClaw control plane...')
-    await this.runControlPlaneCall(() => this.cliClient.probe())
+    await this.launchGatewayRuntime({
+      logProgress,
+      readyFailureMessage: 'Gateway did not become ready within 30 seconds',
+      start: () =>
+        this.runtime.startGateway(this.buildGatewayRuntimeSpec(), logProgress),
+    })
 
     const existingAgents = await this.listAgents()
     logger.info('Fetched existing OpenClaw agents after setup', {
@@ -285,23 +274,13 @@ export class OpenClawService {
     await this.ensureStateEnvFile()
 
     logProgress('Starting OpenClaw gateway...')
-    const hostPort = await this.runtime.startGateway(
-      this.buildGatewayRuntimeSpec(),
-      logProgress,
-    )
-    await this.recordSuccessfulGatewayStart(hostPort)
-    this.startGatewayLogTail()
-
-    logProgress('Waiting for gateway readiness...')
-    const ready = await this.runtime.waitForReady(this.port, READY_TIMEOUT_MS)
-    if (!ready) {
-      this.lastError = 'Gateway did not become ready after start'
-      throw new Error(this.lastError)
-    }
-
     this.controlPlaneStatus = 'connecting'
-    logProgress('Probing OpenClaw control plane...')
-    await this.runControlPlaneCall(() => this.cliClient.probe())
+    await this.launchGatewayRuntime({
+      logProgress,
+      readyFailureMessage: 'Gateway did not become ready after start',
+      start: () =>
+        this.runtime.startGateway(this.buildGatewayRuntimeSpec(), logProgress),
+    })
     this.lastError = null
     logger.info('OpenClaw gateway started', { port: this.port })
   }
@@ -329,22 +308,15 @@ export class OpenClawService {
     await this.ensureStateEnvFile()
     logProgress('Restarting OpenClaw gateway...')
     try {
-      const hostPort = await this.runtime.restartGateway(
-        this.buildGatewayRuntimeSpec(),
+      await this.launchGatewayRuntime({
         logProgress,
-      )
-      await this.recordSuccessfulGatewayStart(hostPort)
-      this.startGatewayLogTail()
-
-      logProgress('Waiting for gateway readiness...')
-      const ready = await this.runtime.waitForReady(this.port, READY_TIMEOUT_MS)
-      if (!ready) {
-        this.lastError = 'Gateway did not become ready after restart'
-        throw new Error(this.lastError)
-      }
-
-      logProgress('Probing OpenClaw control plane...')
-      await this.runControlPlaneCall(() => this.cliClient.probe())
+        readyFailureMessage: 'Gateway did not become ready after restart',
+        start: () =>
+          this.runtime.restartGateway(
+            this.buildGatewayRuntimeSpec(),
+            logProgress,
+          ),
+      })
       this.lastError = null
       logProgress('Gateway restarted successfully')
       logger.info('OpenClaw gateway restarted', { port: this.port })
@@ -387,6 +359,7 @@ export class OpenClawService {
     this.controlPlaneStatus = 'reconnecting'
     logProgress('Reconnecting control plane...')
     await this.runControlPlaneCall(() => this.cliClient.probe())
+    this.lastError = null
     logProgress('Control plane connected')
   }
 
@@ -434,22 +407,16 @@ export class OpenClawService {
 
     logProgress('Starting repaired OpenClaw gateway...')
     try {
-      const hostPort = await this.runtime.startGateway(
-        this.buildGatewayRuntimeSpec(),
-        logProgress,
-      )
-      await this.recordSuccessfulGatewayStart(hostPort)
-      this.startGatewayLogTail()
-
-      logProgress('Waiting for gateway readiness...')
-      const ready = await this.runtime.waitForReady(this.port, READY_TIMEOUT_MS)
-      if (!ready) {
-        throw new Error('Gateway did not become ready after repair')
-      }
-
       this.controlPlaneStatus = 'connecting'
-      logProgress('Probing OpenClaw control plane...')
-      await this.runControlPlaneCall(() => this.cliClient.probe())
+      await this.launchGatewayRuntime({
+        logProgress,
+        readyFailureMessage: 'Gateway did not become ready after repair',
+        start: () =>
+          this.runtime.startGateway(
+            this.buildGatewayRuntimeSpec(),
+            logProgress,
+          ),
+      })
       await this.saveRuntimeState({
         ...(this.runtimeState ?? this.defaultRuntimeState()),
         repairGeneration: nextRepairGeneration,
@@ -502,11 +469,12 @@ export class OpenClawService {
   async getStatus(): Promise<OpenClawStatusResponse> {
     const podmanAvailable = await this.runtime.isPodmanAvailable()
     if (!podmanAvailable) {
+      await this.loadRuntimeState()
       return {
         status: 'uninitialized',
         podmanAvailable: false,
         machineReady: false,
-        port: null,
+        port: this.runtimeState?.hostGatewayPort ?? null,
         agentCount: 0,
         error: null,
         controlPlaneStatus: 'disconnected',
@@ -779,21 +747,16 @@ export class OpenClawService {
       await this.ensureStateEnvFile()
 
       if (!(await this.runtime.isReady(this.port))) {
-        const hostPort = await this.runtime.startGateway(
-          this.buildGatewayRuntimeSpec(),
-        )
-        await this.recordSuccessfulGatewayStart(hostPort)
-        const ready = await this.runtime.waitForReady(
-          this.port,
-          READY_TIMEOUT_MS,
-        )
-        if (!ready) {
-          logger.warn('OpenClaw gateway failed to become ready on auto-start')
-          return
-        }
+        await this.launchGatewayRuntime({
+          logProgress: (msg) => logger.debug(`OpenClaw: ${msg}`),
+          readyFailureMessage: 'Gateway did not become ready on auto-start',
+          start: () =>
+            this.runtime.startGateway(this.buildGatewayRuntimeSpec()),
+        })
       }
 
       await this.runControlPlaneCall(() => this.cliClient.probe())
+      this.lastError = null
       logger.info('OpenClaw gateway auto-started')
     } catch (err) {
       logger.warn('OpenClaw auto-start failed', {
@@ -1087,12 +1050,49 @@ export class OpenClawService {
     }
   }
 
+  private async launchGatewayRuntime(input: {
+    logProgress: (msg: string) => void
+    readyFailureMessage: string
+    start: () => Promise<number>
+  }): Promise<number> {
+    const previousPort = this.port
+    let hostPort: number | null = null
+
+    try {
+      hostPort = await input.start()
+      this.applyGatewayPort(hostPort)
+      this.startGatewayLogTail()
+
+      input.logProgress('Waiting for gateway readiness...')
+      const ready = await this.runtime.waitForReady(this.port, READY_TIMEOUT_MS)
+      if (!ready) {
+        this.lastError = input.readyFailureMessage
+        throw new Error(this.lastError)
+      }
+
+      input.logProgress('Probing OpenClaw control plane...')
+      await this.runControlPlaneCall(() => this.cliClient.probe())
+      await this.recordSuccessfulGatewayStart(hostPort)
+      return hostPort
+    } catch (error) {
+      this.stopGatewayLogTail()
+      if (hostPort !== null) {
+        this.applyGatewayPort(previousPort)
+      }
+      throw error
+    }
+  }
+
   private resolveStatus(
     machineRunning: boolean,
     ready: boolean,
   ): OpenClawStatus {
+    if (this.hasFailureState()) {
+      return 'error'
+    }
+
     if (!machineRunning) {
-      return this.lastError ? 'error' : 'stopped'
+      return 'stopped'
     }
 
     if (ready) {
@@ -1107,7 +1107,7 @@ export class OpenClawService {
       return 'starting'
     }
 
-    return this.lastError ? 'error' : 'stopped'
+    return 'stopped'
   }
 
   private resolveControlPlaneStatus(
@@ -1126,6 +1126,16 @@ export class OpenClawService {
     }
 
     return this.lastGatewayError || this.lastError ? 'failed' : 'disconnected'
+  }
+
+  private hasFailureState(): boolean {
+    return (
+      this.controlPlaneStatus === 'failed' ||
+      this.controlPlaneStatus === 'recovering' ||
+      this.lastGatewayError !== null ||
+      this.lastError !== null ||
+      this.lastRecoveryReason !== null
+    )
   }
 
   private isStrongMachineCorruptionSignature(error: unknown): boolean {

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/podman-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/podman-runtime.ts
@@ -287,6 +287,7 @@ export function configurePodmanRuntime(config: {
   resourcesDir?: string
   podmanPath?: string
   machineName?: string
+  platform?: NodeJS.Platform
 }): PodmanRuntime {
   const podmanPath =
     config.podmanPath ??
@@ -296,6 +297,7 @@ export function configurePodmanRuntime(config: {
   runtime = new PodmanRuntime({
     podmanPath,
     machineName: config.machineName,
+    platform: config.platform,
   })
   return runtime
 }

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/podman-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/podman-runtime.ts
@@ -291,7 +291,7 @@ export function configurePodmanRuntime(config: {
 }): PodmanRuntime {
   const podmanPath =
     config.podmanPath ??
-    resolveBundledPodmanPath(config.resourcesDir) ??
+    resolveBundledPodmanPath(config.resourcesDir, config.platform) ??
     'podman'
 
   runtime = new PodmanRuntime({

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/podman-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/podman-runtime.ts
@@ -11,8 +11,8 @@
 import { existsSync } from 'node:fs'
 import { join } from 'node:path'
 
-const isLinux = process.platform === 'linux'
 const PODMAN_BUNDLE_PATH = ['bin', 'third_party', 'podman'] as const
+export const BROWSEROS_OPENCLAW_PODMAN_MACHINE_NAME = 'browseros-openclaw'
 
 export type LogFn = (msg: string) => void
 
@@ -37,10 +37,19 @@ export function resolveBundledPodmanPath(
 
 export class PodmanRuntime {
   private podmanPath: string
+  private machineName: string
+  private platform: NodeJS.Platform
   private machineReady = false
 
-  constructor(config?: { podmanPath?: string }) {
+  constructor(config?: {
+    podmanPath?: string
+    machineName?: string
+    platform?: NodeJS.Platform
+  }) {
     this.podmanPath = config?.podmanPath ?? 'podman'
+    this.machineName =
+      config?.machineName ?? BROWSEROS_OPENCLAW_PODMAN_MACHINE_NAME
+    this.platform = config?.platform ?? process.platform
   }
 
   getPodmanPath(): string {
@@ -63,7 +72,7 @@ export class PodmanRuntime {
     initialized: boolean
     running: boolean
   }> {
-    if (isLinux) return { initialized: true, running: true }
+    if (this.platform === 'linux') return { initialized: true, running: true }
 
     try {
       const proc = Bun.spawn(
@@ -74,13 +83,14 @@ export class PodmanRuntime {
       await proc.exited
 
       const machines = JSON.parse(output) as Array<{
+        Name?: string
         Running?: boolean
         LastUp?: string
       }>
 
-      if (!machines.length) return { initialized: false, running: false }
+      const machine = machines.find((entry) => entry.Name === this.machineName)
 
-      const machine = machines[0]
+      if (!machine) return { initialized: false, running: false }
       const running =
         machine.Running === true || machine.LastUp === 'Currently running'
 
@@ -91,7 +101,7 @@ export class PodmanRuntime {
   }
 
   async initMachine(onLog?: LogFn): Promise<void> {
-    if (isLinux) return
+    if (this.platform === 'linux') return
 
     const proc = Bun.spawn(
       [
@@ -104,6 +114,7 @@ export class PodmanRuntime {
         '8096',
         '--disk-size',
         '10',
+        this.machineName,
       ],
       { stdout: 'ignore', stderr: 'pipe' },
     )
@@ -115,12 +126,15 @@ export class PodmanRuntime {
   }
 
   async startMachine(onLog?: LogFn): Promise<void> {
-    if (isLinux) return
+    if (this.platform === 'linux') return
 
-    const proc = Bun.spawn([this.podmanPath, 'machine', 'start'], {
-      stdout: 'ignore',
-      stderr: 'pipe',
-    })
+    const proc = Bun.spawn(
+      [this.podmanPath, 'machine', 'start', this.machineName],
+      {
+        stdout: 'ignore',
+        stderr: 'pipe',
+      },
+    )
 
     await this.drainStderr(proc, onLog)
     const code = await proc.exited
@@ -129,12 +143,15 @@ export class PodmanRuntime {
   }
 
   async stopMachine(): Promise<void> {
-    if (isLinux) return
+    if (this.platform === 'linux') return
 
-    const proc = Bun.spawn([this.podmanPath, 'machine', 'stop'], {
-      stdout: 'ignore',
-      stderr: 'ignore',
-    })
+    const proc = Bun.spawn(
+      [this.podmanPath, 'machine', 'stop', this.machineName],
+      {
+        stdout: 'ignore',
+        stderr: 'ignore',
+      },
+    )
     const code = await proc.exited
     if (code !== 0)
       throw new Error(`podman machine stop failed with code ${code}`)
@@ -269,13 +286,17 @@ let runtime: PodmanRuntime | null = null
 export function configurePodmanRuntime(config: {
   resourcesDir?: string
   podmanPath?: string
+  machineName?: string
 }): PodmanRuntime {
   const podmanPath =
     config.podmanPath ??
     resolveBundledPodmanPath(config.resourcesDir) ??
     'podman'
 
-  runtime = new PodmanRuntime({ podmanPath })
+  runtime = new PodmanRuntime({
+    podmanPath,
+    machineName: config.machineName,
+  })
   return runtime
 }
 

--- a/packages/browseros-agent/apps/server/tests/api/routes/openclaw.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/openclaw.test.ts
@@ -169,6 +169,96 @@ describe('createOpenClawRoutes', () => {
     })
   })
 
+  it('rejects a concurrent monitored chat start while the first session is pending', async () => {
+    const actualOpenClawService = await import(
+      '../../../src/api/services/openclaw/openclaw-service'
+    )
+    const actualMonitoringService = await import(
+      '../../../src/monitoring/service'
+    )
+    const chatStream = mock(
+      async () =>
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue({
+              type: 'done',
+              data: { text: 'Done' },
+            })
+            controller.close()
+          },
+        }),
+    )
+
+    let resolveStartSession: (() => void) | undefined
+    let startSessionCalls = 0
+    const startSession = mock(async () => {
+      startSessionCalls += 1
+      await new Promise<void>((resolve) => {
+        resolveStartSession = resolve
+      })
+      return {
+        monitoringSessionId: 'session-1',
+      }
+    })
+    const finalizeSession = mock(async () => {})
+
+    mock.module('../../../src/api/services/openclaw/openclaw-service', () => ({
+      ...actualOpenClawService,
+      getOpenClawService: () =>
+        ({
+          chatStream,
+        }) as never,
+    }))
+
+    mock.module('../../../src/monitoring/service', () => ({
+      ...actualMonitoringService,
+      getMonitoringService: () =>
+        ({
+          getActiveSessionId: () => undefined,
+          startSession,
+          finalizeSession,
+        }) as never,
+    }))
+
+    const { createOpenClawRoutes } = await import(
+      '../../../src/api/routes/openclaw'
+    )
+    const route = createOpenClawRoutes()
+
+    const firstResponsePromise = route.request('/agents/research/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: 'first',
+        sessionKey: 'session-first',
+      }),
+    })
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+
+    const secondResponse = await route.request('/agents/research/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        message: 'second',
+        sessionKey: 'session-second',
+      }),
+    })
+
+    expect(secondResponse.status).toBe(409)
+    expect(await secondResponse.json()).toEqual({
+      error:
+        'A monitored chat session is already active for this agent. Wait for it to finish before starting another.',
+    })
+    expect(startSessionCalls).toBe(1)
+
+    resolveStartSession?.()
+    const firstResponse = await firstResponsePromise
+    expect(firstResponse.status).toBe(200)
+    expect(await firstResponse.text()).toContain('data: [DONE]')
+    expect(finalizeSession).toHaveBeenCalledTimes(1)
+  })
+
   it('returns 400 for unsupported provider payloads', async () => {
     const actualOpenClawService = await import(
       '../../../src/api/services/openclaw/openclaw-service'
@@ -471,6 +561,28 @@ describe('createOpenClawRoutes', () => {
     expect(await response.json()).toEqual({
       error: 'File does not exist: /does/not/exist/podman',
     })
+  })
+
+  it('rejects a directory podman path on POST', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'openclaw-route-'))
+    try {
+      const { createOpenClawRoutes } = await import(
+        '../../../src/api/routes/openclaw'
+      )
+      const route = createOpenClawRoutes()
+
+      const response = await route.request('/podman-overrides', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ podmanPath: tempDir }),
+      })
+      expect(response.status).toBe(400)
+      expect(await response.json()).toEqual({
+        error: `Path is a directory: ${tempDir}`,
+      })
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
   })
 
   it('rejects a non-executable podman path on POST', async () => {

--- a/packages/browseros-agent/apps/server/tests/api/routes/openclaw.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/openclaw.test.ts
@@ -253,6 +253,154 @@ describe('createOpenClawRoutes', () => {
     })
   })
 
+  it('returns the runtime-aware port after setup', async () => {
+    const actualOpenClawService = await import(
+      '../../../src/api/services/openclaw/openclaw-service'
+    )
+    const setup = mock(async () => {})
+    const listAgents = mock(async () => [
+      {
+        agentId: 'main',
+        name: 'main',
+        workspace: '/home/node/.openclaw/workspace-main',
+      },
+    ])
+    const getStatus = mock(async () => ({
+      status: 'running' as const,
+      podmanAvailable: true,
+      machineReady: true,
+      port: 45678,
+      agentCount: 1,
+      error: null,
+      controlPlaneStatus: 'connected' as const,
+      lastGatewayError: null,
+      lastRecoveryReason: null,
+    }))
+
+    mock.module('../../../src/api/services/openclaw/openclaw-service', () => ({
+      ...actualOpenClawService,
+      getOpenClawService: () =>
+        ({
+          setup,
+          listAgents,
+          getStatus,
+        }) as never,
+    }))
+
+    const { createOpenClawRoutes } = await import(
+      '../../../src/api/routes/openclaw'
+    )
+    const route = createOpenClawRoutes()
+
+    const response = await route.request('/setup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        providerType: 'openai',
+        apiKey: 'sk-test',
+      }),
+    })
+
+    expect(response.status).toBe(201)
+    expect(setup).toHaveBeenCalledTimes(1)
+    expect(getStatus).toHaveBeenCalledTimes(1)
+    expect(await response.json()).toMatchObject({
+      status: 'running',
+      port: 45678,
+      agents: [
+        {
+          agentId: 'main',
+          name: 'main',
+          status: 'running',
+        },
+      ],
+    })
+  })
+
+  it('wires POST /repair to repairRuntime', async () => {
+    const actualOpenClawService = await import(
+      '../../../src/api/services/openclaw/openclaw-service'
+    )
+    const repairRuntime = mock(async () => {})
+    const getStatus = mock(async () => ({
+      status: 'running' as const,
+      podmanAvailable: true,
+      machineReady: true,
+      port: 46789,
+      agentCount: 2,
+      error: null,
+      controlPlaneStatus: 'connected' as const,
+      lastGatewayError: null,
+      lastRecoveryReason: null,
+    }))
+
+    mock.module('../../../src/api/services/openclaw/openclaw-service', () => ({
+      ...actualOpenClawService,
+      getOpenClawService: () =>
+        ({
+          repairRuntime,
+          getStatus,
+        }) as never,
+    }))
+
+    const { createOpenClawRoutes } = await import(
+      '../../../src/api/routes/openclaw'
+    )
+    const route = createOpenClawRoutes()
+
+    const response = await route.request('/repair', { method: 'POST' })
+
+    expect(response.status).toBe(200)
+    expect(repairRuntime).toHaveBeenCalledTimes(1)
+    expect(getStatus).toHaveBeenCalledTimes(1)
+    expect(await response.json()).toMatchObject({
+      status: 'running',
+      port: 46789,
+    })
+  })
+
+  it('wires POST /reset to resetRuntime', async () => {
+    const actualOpenClawService = await import(
+      '../../../src/api/services/openclaw/openclaw-service'
+    )
+    const resetRuntime = mock(async () => {})
+    const getStatus = mock(async () => ({
+      status: 'stopped' as const,
+      podmanAvailable: true,
+      machineReady: false,
+      port: null,
+      agentCount: 0,
+      error: null,
+      controlPlaneStatus: 'disconnected' as const,
+      lastGatewayError: null,
+      lastRecoveryReason: null,
+    }))
+
+    mock.module('../../../src/api/services/openclaw/openclaw-service', () => ({
+      ...actualOpenClawService,
+      getOpenClawService: () =>
+        ({
+          resetRuntime,
+          getStatus,
+        }) as never,
+    }))
+
+    const { createOpenClawRoutes } = await import(
+      '../../../src/api/routes/openclaw'
+    )
+    const route = createOpenClawRoutes()
+
+    const response = await route.request('/reset', { method: 'POST' })
+
+    expect(response.status).toBe(200)
+    expect(resetRuntime).toHaveBeenCalledTimes(1)
+    expect(getStatus).toHaveBeenCalledTimes(1)
+    expect(await response.json()).toMatchObject({
+      status: 'stopped',
+      port: null,
+    })
+  })
+
   it('does not expose a roles route', async () => {
     const { createOpenClawRoutes } = await import(
       '../../../src/api/routes/openclaw'

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/container-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/container-runtime.test.ts
@@ -330,6 +330,45 @@ describe('ContainerRuntime', () => {
     expect(chosenPort).toBeGreaterThan(0)
   })
 
+  it('startGateway cleans up the managed container after an exhausted bind-conflict retry sequence', async () => {
+    const calls: Array<{ args: string[]; cwd?: string }> = []
+    const runtime = createRuntime(async (args, options) => {
+      calls.push({ args, cwd: options?.cwd })
+      if (args[0] === 'run') {
+        options?.onOutput?.(
+          'Error: unable to bind 127.0.0.1:18789: address already in use',
+        )
+        return 1
+      }
+      return 0
+    })
+
+    await expect(runtime.startGateway(defaultSpec)).rejects.toThrow(
+      'gateway start failed with code 1',
+    )
+
+    expect(calls).toHaveLength(7)
+    expect(calls[0]).toEqual({
+      cwd: PROJECT_DIR,
+      args: ['rm', '-f', '--ignore', OPENCLAW_GATEWAY_CONTAINER_NAME],
+    })
+    expect(calls[1].args).toContain(`127.0.0.1:${defaultSpec.port}:18789`)
+    expect(calls[2]).toEqual({
+      cwd: PROJECT_DIR,
+      args: ['rm', '-f', '--ignore', OPENCLAW_GATEWAY_CONTAINER_NAME],
+    })
+    expect(calls[3].args).not.toContain(`127.0.0.1:${defaultSpec.port}:18789`)
+    expect(calls[4]).toEqual({
+      cwd: PROJECT_DIR,
+      args: ['rm', '-f', '--ignore', OPENCLAW_GATEWAY_CONTAINER_NAME],
+    })
+    expect(calls[5].args).not.toContain(`127.0.0.1:${defaultSpec.port}:18789`)
+    expect(calls[6]).toEqual({
+      cwd: PROJECT_DIR,
+      args: ['rm', '-f', '--ignore', OPENCLAW_GATEWAY_CONTAINER_NAME],
+    })
+  })
+
   it('runGatewaySetupCommand in direct mode builds a one-off podman run command', async () => {
     const calls: Array<{ args: string[]; cwd?: string }> = []
     const runtime = createRuntime(async (args, options) => {

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/container-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/container-runtime.test.ts
@@ -133,6 +133,29 @@ async function withOccupiedPort<T>(
   }
 }
 
+async function getAvailablePort(): Promise<number> {
+  const server = createServer()
+  return new Promise<number>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen({ port: 0, host: '127.0.0.1', exclusive: true }, () => {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        server.close(() =>
+          reject(new Error('failed to resolve available port')),
+        )
+        return
+      }
+      server.close((closeError) => {
+        if (closeError) {
+          reject(closeError)
+          return
+        }
+        resolve(address.port)
+      })
+    })
+  })
+}
+
 describe('ContainerRuntime', () => {
   it('pullImage runs podman pull for the requested image', async () => {
     const calls: Array<{ args: string[]; cwd?: string }> = []
@@ -157,8 +180,9 @@ describe('ContainerRuntime', () => {
       calls.push({ args, cwd: options?.cwd })
       return 0
     })
+    const spec = { ...defaultSpec, port: await getAvailablePort() }
 
-    await runtime.startGateway(defaultSpec)
+    const chosenPort = await runtime.startGateway(spec)
 
     expect(calls).toHaveLength(2)
     expect(calls[0]).toEqual({
@@ -167,7 +191,7 @@ describe('ContainerRuntime', () => {
     })
     expect(calls[1]).toEqual({
       cwd: PROJECT_DIR,
-      args: expectedStartGatewayRunArgs(defaultSpec),
+      args: expectedStartGatewayRunArgs({ ...spec, port: chosenPort }),
     })
   })
 
@@ -177,16 +201,17 @@ describe('ContainerRuntime', () => {
       calls.push({ args, cwd: options?.cwd })
       return 0
     })
+    const spec = { ...defaultSpec, port: await getAvailablePort() }
 
-    await withOccupiedPort(defaultSpec.port, async () => {
+    await withOccupiedPort(spec.port, async () => {
       const chosenPort = await (
         runtime as unknown as {
           startGateway: typeof runtime.startGateway
         }
-      ).startGateway(defaultSpec)
+      ).startGateway(spec)
 
       expect(chosenPort).toBeGreaterThan(0)
-      expect(chosenPort).not.toBe(defaultSpec.port)
+      expect(chosenPort).not.toBe(spec.port)
       expect(calls[1]?.args).toContain(`127.0.0.1:${chosenPort}:18789`)
     })
   })
@@ -300,13 +325,14 @@ describe('ContainerRuntime', () => {
   it('startGateway retries with a different host port when podman reports a bind conflict', async () => {
     const calls: Array<{ args: string[]; cwd?: string }> = []
     let runAttempts = 0
+    const spec = { ...defaultSpec, port: await getAvailablePort() }
     const runtime = createRuntime(async (args, options) => {
       calls.push({ args, cwd: options?.cwd })
       if (args[0] === 'run') {
         runAttempts += 1
         if (runAttempts === 1) {
           options?.onOutput?.(
-            'Error: unable to bind 127.0.0.1:18789: address already in use',
+            `Error: unable to bind 127.0.0.1:${spec.port}: address already in use`,
           )
           return 1
         }
@@ -314,36 +340,37 @@ describe('ContainerRuntime', () => {
       return 0
     })
 
-    const chosenPort = await runtime.startGateway(defaultSpec)
+    const chosenPort = await runtime.startGateway(spec)
 
     expect(calls).toHaveLength(4)
     expect(calls[0]).toEqual({
       cwd: PROJECT_DIR,
       args: ['rm', '-f', '--ignore', OPENCLAW_GATEWAY_CONTAINER_NAME],
     })
-    expect(calls[1].args).toContain(`127.0.0.1:${defaultSpec.port}:18789`)
+    expect(calls[1].args).toContain(`127.0.0.1:${spec.port}:18789`)
     expect(calls[2]).toEqual({
       cwd: PROJECT_DIR,
       args: ['rm', '-f', '--ignore', OPENCLAW_GATEWAY_CONTAINER_NAME],
     })
-    expect(calls[3].args).not.toContain(`127.0.0.1:${defaultSpec.port}:18789`)
+    expect(calls[3].args).not.toContain(`127.0.0.1:${spec.port}:18789`)
     expect(chosenPort).toBeGreaterThan(0)
   })
 
   it('startGateway cleans up the managed container after an exhausted bind-conflict retry sequence', async () => {
     const calls: Array<{ args: string[]; cwd?: string }> = []
+    const spec = { ...defaultSpec, port: await getAvailablePort() }
     const runtime = createRuntime(async (args, options) => {
       calls.push({ args, cwd: options?.cwd })
       if (args[0] === 'run') {
         options?.onOutput?.(
-          'Error: unable to bind 127.0.0.1:18789: address already in use',
+          `Error: unable to bind 127.0.0.1:${spec.port}: address already in use`,
         )
         return 1
       }
       return 0
     })
 
-    await expect(runtime.startGateway(defaultSpec)).rejects.toThrow(
+    await expect(runtime.startGateway(spec)).rejects.toThrow(
       'gateway start failed with code 1',
     )
 
@@ -352,17 +379,17 @@ describe('ContainerRuntime', () => {
       cwd: PROJECT_DIR,
       args: ['rm', '-f', '--ignore', OPENCLAW_GATEWAY_CONTAINER_NAME],
     })
-    expect(calls[1].args).toContain(`127.0.0.1:${defaultSpec.port}:18789`)
+    expect(calls[1].args).toContain(`127.0.0.1:${spec.port}:18789`)
     expect(calls[2]).toEqual({
       cwd: PROJECT_DIR,
       args: ['rm', '-f', '--ignore', OPENCLAW_GATEWAY_CONTAINER_NAME],
     })
-    expect(calls[3].args).not.toContain(`127.0.0.1:${defaultSpec.port}:18789`)
+    expect(calls[3].args).not.toContain(`127.0.0.1:${spec.port}:18789`)
     expect(calls[4]).toEqual({
       cwd: PROJECT_DIR,
       args: ['rm', '-f', '--ignore', OPENCLAW_GATEWAY_CONTAINER_NAME],
     })
-    expect(calls[5].args).not.toContain(`127.0.0.1:${defaultSpec.port}:18789`)
+    expect(calls[5].args).not.toContain(`127.0.0.1:${spec.port}:18789`)
     expect(calls[6]).toEqual({
       cwd: PROJECT_DIR,
       args: ['rm', '-f', '--ignore', OPENCLAW_GATEWAY_CONTAINER_NAME],
@@ -472,8 +499,9 @@ describe('ContainerRuntime', () => {
       calls.push({ args, cwd: options?.cwd })
       return 0
     })
+    const spec = { ...defaultSpec, port: await getAvailablePort() }
 
-    await runtime.restartGateway(defaultSpec)
+    const chosenPort = await runtime.restartGateway(spec)
 
     expect(calls).toEqual([
       {
@@ -482,7 +510,7 @@ describe('ContainerRuntime', () => {
       },
       {
         cwd: PROJECT_DIR,
-        args: expectedStartGatewayRunArgs(defaultSpec),
+        args: expectedStartGatewayRunArgs({ ...spec, port: chosenPort }),
       },
     ])
   })

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/container-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/container-runtime.test.ts
@@ -213,6 +213,70 @@ describe('ContainerRuntime', () => {
     })
   })
 
+  it('inspectGateway reports an absent container when podman inspect says it is missing', async () => {
+    const runtime = createRuntime(async (args, options) => {
+      if (args[0] === 'inspect') {
+        options?.onOutput?.(
+          `Error: no such object: ${OPENCLAW_GATEWAY_CONTAINER_NAME}`,
+        )
+        return 1
+      }
+      return 0
+    })
+
+    const result = await (
+      runtime as unknown as {
+        inspectGateway: typeof runtime.inspectGateway
+      }
+    ).inspectGateway()
+
+    expect(result).toEqual({
+      exists: false,
+      running: false,
+      hostPort: null,
+    })
+  })
+
+  it('inspectGateway falls back to HostConfig PortBindings for the host port', async () => {
+    const runtime = createRuntime(async (args, options) => {
+      if (args[0] === 'inspect') {
+        options?.onOutput?.(
+          JSON.stringify([
+            {
+              State: { Status: 'running' },
+              NetworkSettings: {
+                Ports: {},
+              },
+              HostConfig: {
+                PortBindings: {
+                  '18789/tcp': [
+                    {
+                      HostIp: '127.0.0.1',
+                      HostPort: '54321',
+                    },
+                  ],
+                },
+              },
+            },
+          ]),
+        )
+      }
+      return 0
+    })
+
+    const result = await (
+      runtime as unknown as {
+        inspectGateway: typeof runtime.inspectGateway
+      }
+    ).inspectGateway()
+
+    expect(result).toEqual({
+      exists: true,
+      running: true,
+      hostPort: 54321,
+    })
+  })
+
   it('runGatewaySetupCommand in direct mode builds a one-off podman run command', async () => {
     const calls: Array<{ args: string[]; cwd?: string }> = []
     const runtime = createRuntime(async (args, options) => {

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/container-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/container-runtime.test.ts
@@ -316,12 +316,17 @@ describe('ContainerRuntime', () => {
 
     const chosenPort = await runtime.startGateway(defaultSpec)
 
-    const runCalls = calls.filter((call) => call.args[0] === 'run')
-    expect(runCalls).toHaveLength(2)
-    expect(runCalls[0].args).toContain(`127.0.0.1:${defaultSpec.port}:18789`)
-    expect(runCalls[1].args).not.toContain(
-      `127.0.0.1:${defaultSpec.port}:18789`,
-    )
+    expect(calls).toHaveLength(4)
+    expect(calls[0]).toEqual({
+      cwd: PROJECT_DIR,
+      args: ['rm', '-f', '--ignore', OPENCLAW_GATEWAY_CONTAINER_NAME],
+    })
+    expect(calls[1].args).toContain(`127.0.0.1:${defaultSpec.port}:18789`)
+    expect(calls[2]).toEqual({
+      cwd: PROJECT_DIR,
+      args: ['rm', '-f', '--ignore', OPENCLAW_GATEWAY_CONTAINER_NAME],
+    })
+    expect(calls[3].args).not.toContain(`127.0.0.1:${defaultSpec.port}:18789`)
     expect(chosenPort).toBeGreaterThan(0)
   })
 

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/container-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/container-runtime.test.ts
@@ -4,6 +4,7 @@
  */
 
 import { describe, expect, it } from 'bun:test'
+import { createServer } from 'node:net'
 import { OPENCLAW_GATEWAY_CONTAINER_NAME } from '@browseros/shared/constants/openclaw'
 import { ContainerRuntime } from '../../../../src/api/services/openclaw/container-runtime'
 
@@ -97,6 +98,26 @@ function expectedStartGatewayRunArgs(spec: typeof defaultSpec): string[] {
   ]
 }
 
+async function withOccupiedPort<T>(
+  port: number,
+  run: () => Promise<T>,
+): Promise<T> {
+  const server = createServer()
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen({ port, host: '127.0.0.1', exclusive: true }, () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+
+  try {
+    return await run()
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()))
+  }
+}
+
 describe('ContainerRuntime', () => {
   it('pullImage runs podman pull for the requested image', async () => {
     const calls: Array<{ args: string[]; cwd?: string }> = []
@@ -132,6 +153,63 @@ describe('ContainerRuntime', () => {
     expect(calls[1]).toEqual({
       cwd: PROJECT_DIR,
       args: expectedStartGatewayRunArgs(defaultSpec),
+    })
+  })
+
+  it('startGateway chooses a free host port when the preferred port is occupied', async () => {
+    const calls: Array<{ args: string[]; cwd?: string }> = []
+    const runtime = createRuntime(async (args, options) => {
+      calls.push({ args, cwd: options?.cwd })
+      return 0
+    })
+
+    await withOccupiedPort(defaultSpec.port, async () => {
+      const chosenPort = await (
+        runtime as unknown as {
+          startGateway: typeof runtime.startGateway
+        }
+      ).startGateway(defaultSpec)
+
+      expect(chosenPort).toBeGreaterThan(0)
+      expect(chosenPort).not.toBe(defaultSpec.port)
+      expect(calls[1]?.args).toContain(`127.0.0.1:${chosenPort}:18789`)
+    })
+  })
+
+  it('inspectGateway reports container state and mapped host port', async () => {
+    const runtime = createRuntime(async (args, options) => {
+      if (args[0] === 'inspect') {
+        options?.onOutput?.(
+          JSON.stringify([
+            {
+              State: { Running: true },
+              NetworkSettings: {
+                Ports: {
+                  '18789/tcp': [
+                    {
+                      HostIp: '127.0.0.1',
+                      HostPort: '43210',
+                    },
+                  ],
+                },
+              },
+            },
+          ]),
+        )
+      }
+      return 0
+    })
+
+    const result = await (
+      runtime as unknown as {
+        inspectGateway: typeof runtime.inspectGateway
+      }
+    ).inspectGateway()
+
+    expect(result).toEqual({
+      exists: true,
+      running: true,
+      hostPort: 43210,
     })
   })
 

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/container-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/container-runtime.test.ts
@@ -18,6 +18,12 @@ const defaultSpec = {
   timezone: 'America/Los_Angeles',
 }
 
+type InspectCaptureResult = {
+  code: number
+  stdout: string
+  stderr: string
+}
+
 function createRuntime(
   runCommand: (
     args: string[],
@@ -25,6 +31,10 @@ function createRuntime(
   ) => Promise<number>,
   listRunningContainers: () => Promise<string[]> = async () => [],
   stopMachine: () => Promise<void> = async () => {},
+  captureCommand?: (
+    args: string[],
+    options?: { cwd?: string },
+  ) => Promise<InspectCaptureResult>,
 ): ContainerRuntime {
   return new ContainerRuntime(
     {
@@ -37,6 +47,11 @@ function createRuntime(
       stopMachine,
     } as never,
     PROJECT_DIR,
+    captureCommand
+      ? ({
+          capturePodmanCommand: captureCommand,
+        } as never)
+      : undefined,
   )
 }
 
@@ -177,28 +192,30 @@ describe('ContainerRuntime', () => {
   })
 
   it('inspectGateway reports container state and mapped host port', async () => {
-    const runtime = createRuntime(async (args, options) => {
-      if (args[0] === 'inspect') {
-        options?.onOutput?.(
-          JSON.stringify([
-            {
-              State: { Running: true },
-              NetworkSettings: {
-                Ports: {
-                  '18789/tcp': [
-                    {
-                      HostIp: '127.0.0.1',
-                      HostPort: '43210',
-                    },
-                  ],
-                },
+    const runtime = createRuntime(
+      async () => 0,
+      async () => [],
+      async () => {},
+      async () => ({
+        code: 0,
+        stdout: JSON.stringify([
+          {
+            State: { Running: true },
+            NetworkSettings: {
+              Ports: {
+                '18789/tcp': [
+                  {
+                    HostIp: '127.0.0.1',
+                    HostPort: '43210',
+                  },
+                ],
               },
             },
-          ]),
-        )
-      }
-      return 0
-    })
+          },
+        ]),
+        stderr: 'warning: harmless stderr output',
+      }),
+    )
 
     const result = await (
       runtime as unknown as {
@@ -214,15 +231,16 @@ describe('ContainerRuntime', () => {
   })
 
   it('inspectGateway reports an absent container when podman inspect says it is missing', async () => {
-    const runtime = createRuntime(async (args, options) => {
-      if (args[0] === 'inspect') {
-        options?.onOutput?.(
-          `Error: no such object: ${OPENCLAW_GATEWAY_CONTAINER_NAME}`,
-        )
-        return 1
-      }
-      return 0
-    })
+    const runtime = createRuntime(
+      async () => 0,
+      async () => [],
+      async () => {},
+      async () => ({
+        code: 1,
+        stdout: '',
+        stderr: `Error: no such object: ${OPENCLAW_GATEWAY_CONTAINER_NAME}`,
+      }),
+    )
 
     const result = await (
       runtime as unknown as {
@@ -238,31 +256,33 @@ describe('ContainerRuntime', () => {
   })
 
   it('inspectGateway falls back to HostConfig PortBindings for the host port', async () => {
-    const runtime = createRuntime(async (args, options) => {
-      if (args[0] === 'inspect') {
-        options?.onOutput?.(
-          JSON.stringify([
-            {
-              State: { Status: 'running' },
-              NetworkSettings: {
-                Ports: {},
-              },
-              HostConfig: {
-                PortBindings: {
-                  '18789/tcp': [
-                    {
-                      HostIp: '127.0.0.1',
-                      HostPort: '54321',
-                    },
-                  ],
-                },
+    const runtime = createRuntime(
+      async () => 0,
+      async () => [],
+      async () => {},
+      async () => ({
+        code: 0,
+        stdout: JSON.stringify([
+          {
+            State: { Status: 'running' },
+            NetworkSettings: {
+              Ports: {},
+            },
+            HostConfig: {
+              PortBindings: {
+                '18789/tcp': [
+                  {
+                    HostIp: '127.0.0.1',
+                    HostPort: '54321',
+                  },
+                ],
               },
             },
-          ]),
-        )
-      }
-      return 0
-    })
+          },
+        ]),
+        stderr: '',
+      }),
+    )
 
     const result = await (
       runtime as unknown as {
@@ -275,6 +295,34 @@ describe('ContainerRuntime', () => {
       running: true,
       hostPort: 54321,
     })
+  })
+
+  it('startGateway retries with a different host port when podman reports a bind conflict', async () => {
+    const calls: Array<{ args: string[]; cwd?: string }> = []
+    let runAttempts = 0
+    const runtime = createRuntime(async (args, options) => {
+      calls.push({ args, cwd: options?.cwd })
+      if (args[0] === 'run') {
+        runAttempts += 1
+        if (runAttempts === 1) {
+          options?.onOutput?.(
+            'Error: unable to bind 127.0.0.1:18789: address already in use',
+          )
+          return 1
+        }
+      }
+      return 0
+    })
+
+    const chosenPort = await runtime.startGateway(defaultSpec)
+
+    const runCalls = calls.filter((call) => call.args[0] === 'run')
+    expect(runCalls).toHaveLength(2)
+    expect(runCalls[0].args).toContain(`127.0.0.1:${defaultSpec.port}:18789`)
+    expect(runCalls[1].args).not.toContain(
+      `127.0.0.1:${defaultSpec.port}:18789`,
+    )
+    expect(chosenPort).toBeGreaterThan(0)
   })
 
   it('runGatewaySetupCommand in direct mode builds a one-off podman run command', async () => {

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-runtime-state.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-runtime-state.test.ts
@@ -1,0 +1,79 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { describe, expect, it } from 'bun:test'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import {
+  getOpenClawRuntimeStatePath,
+  loadOpenClawRuntimeState,
+  saveOpenClawRuntimeState,
+} from '../../../../src/api/services/openclaw/openclaw-runtime-state'
+
+describe('openclaw runtime state', () => {
+  it('returns null when the runtime state file is missing', async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'browseros-openclaw-runtime-state-'),
+    )
+
+    try {
+      await expect(loadOpenClawRuntimeState(tempDir)).resolves.toBeNull()
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('round-trips saved runtime state', async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'browseros-openclaw-runtime-state-'),
+    )
+
+    try {
+      const state = {
+        hostGatewayPort: 31234,
+        lastSuccessfulStartAt: '2026-04-20T18:00:00.000Z',
+        repairGeneration: 7,
+        lastRepairOutcome: 'success' as const,
+      }
+
+      await saveOpenClawRuntimeState(tempDir, state)
+
+      await expect(loadOpenClawRuntimeState(tempDir)).resolves.toEqual(state)
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('writes pretty JSON with a trailing newline', async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'browseros-openclaw-runtime-state-'),
+    )
+
+    try {
+      const state = {
+        hostGatewayPort: null,
+        lastSuccessfulStartAt: null,
+        repairGeneration: 0,
+        lastRepairOutcome: null,
+      }
+
+      await saveOpenClawRuntimeState(tempDir, state)
+
+      expect(
+        fs.readFileSync(getOpenClawRuntimeStatePath(tempDir), 'utf-8'),
+      ).toBe(
+        '{\n' +
+          '  "hostGatewayPort": null,\n' +
+          '  "lastSuccessfulStartAt": null,\n' +
+          '  "repairGeneration": 0,\n' +
+          '  "lastRepairOutcome": null\n' +
+          '}\n',
+      )
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-runtime-state.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-runtime-state.test.ts
@@ -40,6 +40,29 @@ describe('openclaw runtime state', () => {
     }
   })
 
+  it('returns null when persisted numeric values are invalid', async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'browseros-openclaw-runtime-state-'),
+    )
+
+    try {
+      fs.writeFileSync(
+        getOpenClawRuntimeStatePath(tempDir),
+        JSON.stringify({
+          hostGatewayPort: -1,
+          lastSuccessfulStartAt: null,
+          repairGeneration: 1.5,
+          lastRepairOutcome: 'success',
+        }),
+        'utf-8',
+      )
+
+      await expect(loadOpenClawRuntimeState(tempDir)).resolves.toBeNull()
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
   it('round-trips saved runtime state', async () => {
     const tempDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'browseros-openclaw-runtime-state-'),

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-runtime-state.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-runtime-state.test.ts
@@ -26,6 +26,20 @@ describe('openclaw runtime state', () => {
     }
   })
 
+  it('returns null when the runtime state file is partial JSON', async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'browseros-openclaw-runtime-state-'),
+    )
+
+    try {
+      fs.writeFileSync(getOpenClawRuntimeStatePath(tempDir), '{}', 'utf-8')
+
+      await expect(loadOpenClawRuntimeState(tempDir)).resolves.toBeNull()
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
   it('round-trips saved runtime state', async () => {
     const tempDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'browseros-openclaw-runtime-state-'),
@@ -74,6 +88,26 @@ describe('openclaw runtime state', () => {
       )
     } finally {
       fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  it('creates the runtime state directory tree when saving', async () => {
+    const tempRoot = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'browseros-openclaw-runtime-state-'),
+    )
+    const nestedDir = path.join(tempRoot, 'a', 'b')
+
+    try {
+      await saveOpenClawRuntimeState(nestedDir, {
+        hostGatewayPort: 31234,
+        lastSuccessfulStartAt: null,
+        repairGeneration: 1,
+        lastRepairOutcome: 'failed',
+      })
+
+      expect(fs.existsSync(getOpenClawRuntimeStatePath(nestedDir))).toBe(true)
+    } finally {
+      fs.rmSync(tempRoot, { recursive: true, force: true })
     }
   })
 })

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-runtime-state.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-runtime-state.test.ts
@@ -63,6 +63,29 @@ describe('openclaw runtime state', () => {
     }
   })
 
+  it('returns null when the persisted timestamp is invalid', async () => {
+    const tempDir = fs.mkdtempSync(
+      path.join(os.tmpdir(), 'browseros-openclaw-runtime-state-'),
+    )
+
+    try {
+      fs.writeFileSync(
+        getOpenClawRuntimeStatePath(tempDir),
+        JSON.stringify({
+          hostGatewayPort: 31234,
+          lastSuccessfulStartAt: 'not-a-timestamp',
+          repairGeneration: 1,
+          lastRepairOutcome: 'success',
+        }),
+        'utf-8',
+      )
+
+      await expect(loadOpenClawRuntimeState(tempDir)).resolves.toBeNull()
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+
   it('round-trips saved runtime state', async () => {
     const tempDir = fs.mkdtempSync(
       path.join(os.tmpdir(), 'browseros-openclaw-runtime-state-'),

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-service.test.ts
@@ -1012,6 +1012,79 @@ describe('OpenClawService', () => {
     })
   })
 
+  it('records failed repair attempts even when repair fails before gateway relaunch', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
+    await mkdir(join(tempDir, '.openclaw'), { recursive: true })
+    await writeFile(
+      join(tempDir, '.openclaw', 'openclaw.json'),
+      JSON.stringify({
+        gateway: {
+          auth: {
+            token: 'cli-token',
+          },
+        },
+      }),
+    )
+    await saveOpenClawRuntimeState(tempDir, {
+      hostGatewayPort: 61234,
+      lastSuccessfulStartAt: '2026-04-20T18:00:00.000Z',
+      repairGeneration: 4,
+      lastRepairOutcome: 'success',
+    })
+    const ensureReady = mock(async () => {
+      throw new Error('machine bootstrap failed')
+    })
+    const service = new OpenClawService() as MutableOpenClawService
+
+    service.openclawDir = tempDir
+    service.runtime = {
+      ensureReady,
+      isReady: async (_port: number) => false,
+      stopGateway: async () => {},
+      stopMachineIfSafe: async () => {},
+    }
+
+    await expect(service.repairRuntime()).rejects.toThrow(
+      'machine bootstrap failed',
+    )
+    await expect(loadOpenClawRuntimeState(tempDir)).resolves.toMatchObject({
+      hostGatewayPort: 61234,
+      repairGeneration: 5,
+      lastRepairOutcome: 'failed',
+    })
+  })
+
+  it('does not clear runtime state when reset teardown fails', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
+    await mkdir(join(tempDir, '.openclaw'), { recursive: true })
+    await writeFile(join(tempDir, '.openclaw', 'openclaw.json'), '{}')
+    await saveOpenClawRuntimeState(tempDir, {
+      hostGatewayPort: 74444,
+      lastSuccessfulStartAt: '2026-04-20T18:00:00.000Z',
+      repairGeneration: 7,
+      lastRepairOutcome: 'success',
+    })
+    const service = new OpenClawService() as MutableOpenClawService
+
+    service.openclawDir = tempDir
+    service.runtime = {
+      isReady: async (_port: number) => false,
+      stopGateway: async () => {
+        throw new Error('stop failed')
+      },
+      stopMachineIfSafe: async () => {},
+    }
+
+    await expect(service.resetRuntime()).rejects.toThrow('stop failed')
+    expect(
+      JSON.parse(await readFile(join(tempDir, 'runtime-state.json'), 'utf-8')),
+    ).toMatchObject({
+      hostGatewayPort: 74444,
+      repairGeneration: 7,
+      lastRepairOutcome: 'success',
+    })
+  })
+
   it('stop calls runtime.stopGateway', async () => {
     const stopGateway = mock(async () => {})
     const service = new OpenClawService() as MutableOpenClawService

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-service.test.ts
@@ -25,6 +25,20 @@ type MutableOpenClawService = OpenClawService & {
   restart: ReturnType<typeof mock>
   repairRuntime: ReturnType<typeof mock>
   resetRuntime: ReturnType<typeof mock>
+  controlPlaneStatus:
+    | 'connected'
+    | 'connecting'
+    | 'reconnecting'
+    | 'recovering'
+    | 'failed'
+    | 'disconnected'
+  lastError: string | null
+  lastGatewayError: string | null
+  lastRecoveryReason:
+    | 'token_mismatch'
+    | 'container_not_ready'
+    | 'unknown'
+    | null
   runtime: {
     ensureReady?: (_onLog?: (_line: string) => void) => Promise<void>
     isPodmanAvailable?: () => Promise<boolean>
@@ -49,6 +63,7 @@ type MutableOpenClawService = OpenClawService & {
     ) => Promise<number>
     stopGateway?: (_onLog?: (_line: string) => void) => Promise<void>
     getGatewayLogs?: (_tail?: number) => Promise<string[]>
+    tailGatewayLogs?: (_onLog?: (_line: string) => void) => () => void
     waitForReady?: (_port: number, _timeoutMs: number) => Promise<boolean>
     stopMachineIfSafe?: () => Promise<void>
   }
@@ -207,6 +222,73 @@ describe('OpenClawService', () => {
       hostGatewayPort: 52345,
       repairGeneration: 0,
       lastRepairOutcome: null,
+    })
+  })
+
+  it('preserves the persisted gateway port when Podman is unavailable', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
+    await saveOpenClawRuntimeState(tempDir, {
+      hostGatewayPort: 44321,
+      lastSuccessfulStartAt: '2026-04-20T18:00:00.000Z',
+      repairGeneration: 1,
+      lastRepairOutcome: 'success',
+    })
+    const service = new OpenClawService() as MutableOpenClawService
+
+    service.openclawDir = tempDir
+    service.runtime = {
+      isPodmanAvailable: async () => false,
+    }
+
+    await expect(service.getStatus()).resolves.toMatchObject({
+      status: 'uninitialized',
+      podmanAvailable: false,
+      machineReady: false,
+      port: 44321,
+      agentCount: 0,
+      error: null,
+      controlPlaneStatus: 'disconnected',
+      lastGatewayError: null,
+      lastRecoveryReason: null,
+    })
+  })
+
+  it('reports error status when gateway failure state is present', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
+    await mkdir(join(tempDir, '.openclaw'), { recursive: true })
+    await writeFile(join(tempDir, '.openclaw', 'openclaw.json'), '{}')
+    await saveOpenClawRuntimeState(tempDir, {
+      hostGatewayPort: 45555,
+      lastSuccessfulStartAt: '2026-04-20T18:00:00.000Z',
+      repairGeneration: 2,
+      lastRepairOutcome: 'success',
+    })
+    const service = new OpenClawService() as MutableOpenClawService
+
+    service.openclawDir = tempDir
+    service.controlPlaneStatus = 'failed'
+    service.lastGatewayError = 'OpenClaw gateway is not ready'
+    service.runtime = {
+      isPodmanAvailable: async () => true,
+      getMachineStatus: async () => ({ initialized: true, running: false }),
+      inspectGateway: async () => ({
+        exists: true,
+        running: false,
+        hostPort: 45555,
+      }),
+      isReady: async (_port: number) => false,
+    }
+
+    await expect(service.getStatus()).resolves.toMatchObject({
+      status: 'error',
+      podmanAvailable: true,
+      machineReady: false,
+      port: 45555,
+      agentCount: 0,
+      error: null,
+      controlPlaneStatus: 'failed',
+      lastGatewayError: 'OpenClaw gateway is not ready',
+      lastRecoveryReason: null,
     })
   })
 
@@ -645,6 +727,67 @@ describe('OpenClawService', () => {
     })
   })
 
+  it('does not persist a successful start until readiness and probe succeed', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
+    await mkdir(join(tempDir, '.openclaw'), { recursive: true })
+    await writeFile(
+      join(tempDir, '.openclaw', 'openclaw.json'),
+      JSON.stringify({
+        gateway: {
+          auth: {
+            token: 'cli-token',
+          },
+        },
+      }),
+    )
+    await saveOpenClawRuntimeState(tempDir, {
+      hostGatewayPort: 41234,
+      lastSuccessfulStartAt: '2026-04-20T18:00:00.000Z',
+      repairGeneration: 2,
+      lastRepairOutcome: 'success',
+    })
+    const stopLogTail = mock(() => {})
+    const tailGatewayLogs = mock(() => stopLogTail)
+    const startGateway = mock(async () => 51234)
+    const waitForReady = mock(async () => false)
+    const service = new OpenClawService() as MutableOpenClawService
+    const previousNodeEnv = process.env.NODE_ENV
+
+    process.env.NODE_ENV = 'development'
+    service.openclawDir = tempDir
+    service.runtime = {
+      ensureReady: async () => {},
+      isReady: async () => true,
+      startGateway,
+      tailGatewayLogs,
+      waitForReady,
+    }
+    service.cliClient = {
+      probe: mock(async () => {
+        throw new Error('probe should not run when readiness fails')
+      }),
+    }
+
+    try {
+      await expect(service.start()).rejects.toThrow(
+        'Gateway did not become ready after start',
+      )
+    } finally {
+      process.env.NODE_ENV = previousNodeEnv
+    }
+
+    expect(tailGatewayLogs).toHaveBeenCalledTimes(1)
+    expect(stopLogTail).toHaveBeenCalledTimes(1)
+    expect(waitForReady).toHaveBeenCalledWith(51234, expect.any(Number))
+    expect(startGateway).toHaveBeenCalledTimes(1)
+    await expect(loadOpenClawRuntimeState(tempDir)).resolves.toMatchObject({
+      hostGatewayPort: 41234,
+      lastSuccessfulStartAt: '2026-04-20T18:00:00.000Z',
+      repairGeneration: 2,
+      lastRepairOutcome: 'success',
+    })
+  })
+
   it('restart uses the direct runtime restartGateway flow', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
     await mkdir(join(tempDir, '.openclaw'), { recursive: true })
@@ -702,6 +845,51 @@ describe('OpenClawService', () => {
       repairGeneration: 3,
       lastRepairOutcome: null,
     })
+  })
+
+  it('clears stale lastError after reconnecting the control plane', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
+    await mkdir(join(tempDir, '.openclaw'), { recursive: true })
+    await writeFile(join(tempDir, '.openclaw', 'openclaw.json'), '{}')
+    await saveOpenClawRuntimeState(tempDir, {
+      hostGatewayPort: 54545,
+      lastSuccessfulStartAt: '2026-04-20T18:00:00.000Z',
+      repairGeneration: 1,
+      lastRepairOutcome: 'success',
+    })
+    const probe = mock(async () => {})
+    const service = new OpenClawService() as MutableOpenClawService
+
+    service.openclawDir = tempDir
+    service.controlPlaneStatus = 'failed'
+    service.lastError = 'stale reconnect failure'
+    service.lastGatewayError = 'stale gateway failure'
+    service.lastRecoveryReason = 'unknown'
+    service.runtime = {
+      isPodmanAvailable: async () => true,
+      getMachineStatus: async () => ({ initialized: true, running: true }),
+      inspectGateway: async () => ({
+        exists: true,
+        running: true,
+        hostPort: 54545,
+      }),
+      isReady: async (_port: number) => true,
+    }
+    service.cliClient = {
+      probe,
+      listAgents: mock(async () => []),
+    }
+
+    await service.reconnectControlPlane()
+
+    await expect(service.getStatus()).resolves.toMatchObject({
+      status: 'running',
+      error: null,
+      controlPlaneStatus: 'connected',
+      lastGatewayError: null,
+      lastRecoveryReason: null,
+    })
+    expect(probe).toHaveBeenCalledTimes(1)
   })
 
   it('escalates restart failures with machine corruption signatures into repair', async () => {
@@ -935,7 +1123,7 @@ describe('OpenClawService', () => {
       }),
     )
     expect(waitForReady).toHaveBeenCalledTimes(1)
-    expect(probe).toHaveBeenCalledTimes(1)
+    expect(probe).toHaveBeenCalledTimes(2)
     expect(isReady).toHaveBeenCalledTimes(1)
   })
 

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-service.test.ts
@@ -13,17 +13,28 @@ import {
   resolveSupportedOpenClawProvider,
   UnsupportedOpenClawProviderError,
 } from '../../../../src/api/services/openclaw/openclaw-provider-map'
+import {
+  loadOpenClawRuntimeState,
+  saveOpenClawRuntimeState,
+} from '../../../../src/api/services/openclaw/openclaw-runtime-state'
 import { OpenClawService } from '../../../../src/api/services/openclaw/openclaw-service'
 
 type MutableOpenClawService = OpenClawService & {
   openclawDir: string
   token: string
   restart: ReturnType<typeof mock>
+  repairRuntime: ReturnType<typeof mock>
+  resetRuntime: ReturnType<typeof mock>
   runtime: {
-    ensureReady?: () => Promise<void>
+    ensureReady?: (_onLog?: (_line: string) => void) => Promise<void>
     isPodmanAvailable?: () => Promise<boolean>
     getMachineStatus?: () => Promise<{ initialized: boolean; running: boolean }>
-    isReady: () => Promise<boolean>
+    inspectGateway?: () => Promise<{
+      exists: boolean
+      running: boolean
+      hostPort: number | null
+    }>
+    isReady: (_port: number) => Promise<boolean>
     pullImage?: (
       _image: string,
       _onLog?: (_line: string) => void,
@@ -31,14 +42,14 @@ type MutableOpenClawService = OpenClawService & {
     startGateway?: (
       _input: unknown,
       _onLog?: (_line: string) => void,
-    ) => Promise<void>
+    ) => Promise<number>
     restartGateway?: (
       _input: unknown,
       _onLog?: (_line: string) => void,
-    ) => Promise<void>
+    ) => Promise<number>
     stopGateway?: (_onLog?: (_line: string) => void) => Promise<void>
     getGatewayLogs?: (_tail?: number) => Promise<string[]>
-    waitForReady?: () => Promise<boolean>
+    waitForReady?: (_port: number, _timeoutMs: number) => Promise<boolean>
     stopMachineIfSafe?: () => Promise<void>
   }
   cliClient: {
@@ -155,7 +166,12 @@ describe('OpenClawService', () => {
     service.runtime = {
       isPodmanAvailable: async () => true,
       getMachineStatus: async () => ({ initialized: true, running: true }),
-      isReady: async () => true,
+      inspectGateway: async () => ({
+        exists: true,
+        running: true,
+        hostPort: 52345,
+      }),
+      isReady: async (_port: number) => true,
     }
     service.cliClient = {
       getConfig: mock(async () => 'cli-token'),
@@ -179,12 +195,18 @@ describe('OpenClawService', () => {
       status: 'running',
       podmanAvailable: true,
       machineReady: true,
-      port: 18789,
+      port: 52345,
       agentCount: 2,
       error: null,
       controlPlaneStatus: 'connected',
       lastGatewayError: null,
       lastRecoveryReason: null,
+    })
+    const runtimeState = await loadOpenClawRuntimeState(tempDir)
+    expect(runtimeState).toMatchObject({
+      hostGatewayPort: 52345,
+      repairGeneration: 0,
+      lastRepairOutcome: null,
     })
   })
 
@@ -215,9 +237,11 @@ describe('OpenClawService', () => {
     })
     const restartGateway = mock(async () => {
       steps.push('restart')
+      return 18789
     })
     const startGateway = mock(async () => {
       steps.push('start')
+      return 31234
     })
     service.runtime = {
       isPodmanAvailable: async () => true,
@@ -226,8 +250,9 @@ describe('OpenClawService', () => {
       pullImage,
       restartGateway,
       startGateway,
-      waitForReady: mock(async () => {
+      waitForReady: mock(async (port: number) => {
         steps.push('ready')
+        expect(port).toBe(31234)
         return true
       }),
     }
@@ -300,6 +325,13 @@ describe('OpenClawService', () => {
       expect.any(Function),
     )
     expect(restartGateway).not.toHaveBeenCalled()
+    const runtimeState = await loadOpenClawRuntimeState(tempDir)
+    expect(runtimeState).toMatchObject({
+      hostGatewayPort: 31234,
+      repairGeneration: 0,
+      lastRepairOutcome: null,
+    })
+    expect(runtimeState?.lastSuccessfulStartAt).not.toBeNull()
   })
 
   it('applies setup-time config in one batch before the gateway starts', async () => {
@@ -312,12 +344,12 @@ describe('OpenClawService', () => {
       name: 'main',
       workspace: `${OPENCLAW_CONTAINER_HOME}/workspace`,
     }))
-    const waitForReady = mock(async () => true)
+    const waitForReady = mock(async (_port: number) => true)
     const service = new OpenClawService() as MutableOpenClawService
 
     service.openclawDir = tempDir
-    const restartGateway = mock(async () => {})
-    const startGateway = mock(async () => {})
+    const restartGateway = mock(async () => 18789)
+    const startGateway = mock(async () => 31234)
     service.runtime = {
       isPodmanAvailable: async () => true,
       ensureReady: async () => {},
@@ -421,9 +453,9 @@ describe('OpenClawService', () => {
       ensureReady: async () => {},
       isReady: async () => true,
       pullImage: async () => {},
-      restartGateway: async () => {},
-      startGateway: async () => {},
-      waitForReady: async () => true,
+      restartGateway: async () => 18789,
+      startGateway: async () => 31234,
+      waitForReady: async (_port: number) => true,
     }
     service.cliClient = {
       getConfig: mock(async (path: string) =>
@@ -492,9 +524,9 @@ describe('OpenClawService', () => {
       ensureReady: async () => {},
       isReady: async () => true,
       pullImage: async () => {},
-      restartGateway: async () => {},
-      startGateway: async () => {},
-      waitForReady: async () => true,
+      restartGateway: async () => 18789,
+      startGateway: async () => 31234,
+      waitForReady: async (_port: number) => true,
     }
     service.cliClient = {
       probe: mock(async () => {}),
@@ -564,9 +596,18 @@ describe('OpenClawService', () => {
         },
       }),
     )
+    await saveOpenClawRuntimeState(tempDir, {
+      hostGatewayPort: 41234,
+      lastSuccessfulStartAt: '2026-04-20T18:00:00.000Z',
+      repairGeneration: 2,
+      lastRepairOutcome: 'success',
+    })
     const ensureReady = mock(async () => {})
-    const startGateway = mock(async () => {})
-    const waitForReady = mock(async () => true)
+    const startGateway = mock(async () => 51234)
+    const waitForReady = mock(async (port: number) => {
+      expect(port).toBe(51234)
+      return true
+    })
     const probe = mock(async () => {})
     const service = new OpenClawService() as MutableOpenClawService
 
@@ -587,7 +628,7 @@ describe('OpenClawService', () => {
     expect(startGateway).toHaveBeenCalledWith(
       expect.objectContaining({
         image: 'ghcr.io/openclaw/openclaw:2026.4.12',
-        port: 18789,
+        port: 41234,
         hostHome: tempDir,
         envFilePath: join(tempDir, '.openclaw', '.env'),
         gatewayToken: 'cli-token',
@@ -596,6 +637,12 @@ describe('OpenClawService', () => {
     )
     expect(waitForReady).toHaveBeenCalledTimes(1)
     expect(probe).toHaveBeenCalledTimes(1)
+    const runtimeState = await loadOpenClawRuntimeState(tempDir)
+    expect(runtimeState).toMatchObject({
+      hostGatewayPort: 51234,
+      repairGeneration: 2,
+      lastRepairOutcome: null,
+    })
   })
 
   it('restart uses the direct runtime restartGateway flow', async () => {
@@ -611,8 +658,17 @@ describe('OpenClawService', () => {
         },
       }),
     )
-    const restartGateway = mock(async () => {})
-    const waitForReady = mock(async () => true)
+    await saveOpenClawRuntimeState(tempDir, {
+      hostGatewayPort: 51234,
+      lastSuccessfulStartAt: '2026-04-20T18:00:00.000Z',
+      repairGeneration: 3,
+      lastRepairOutcome: 'success',
+    })
+    const restartGateway = mock(async () => 61234)
+    const waitForReady = mock(async (port: number) => {
+      expect(port).toBe(61234)
+      return true
+    })
     const probe = mock(async () => {})
     const service = new OpenClawService() as MutableOpenClawService
 
@@ -631,7 +687,7 @@ describe('OpenClawService', () => {
     expect(restartGateway).toHaveBeenCalledWith(
       expect.objectContaining({
         image: 'ghcr.io/openclaw/openclaw:2026.4.12',
-        port: 18789,
+        port: 51234,
         hostHome: tempDir,
         envFilePath: join(tempDir, '.openclaw', '.env'),
         gatewayToken: 'cli-token',
@@ -640,6 +696,132 @@ describe('OpenClawService', () => {
     )
     expect(waitForReady).toHaveBeenCalledTimes(1)
     expect(probe).toHaveBeenCalledTimes(1)
+    const runtimeState = await loadOpenClawRuntimeState(tempDir)
+    expect(runtimeState).toMatchObject({
+      hostGatewayPort: 61234,
+      repairGeneration: 3,
+      lastRepairOutcome: null,
+    })
+  })
+
+  it('escalates restart failures with machine corruption signatures into repair', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
+    await mkdir(join(tempDir, '.openclaw'), { recursive: true })
+    await writeFile(
+      join(tempDir, '.openclaw', 'openclaw.json'),
+      JSON.stringify({
+        gateway: {
+          auth: {
+            token: 'cli-token',
+          },
+        },
+      }),
+    )
+    await saveOpenClawRuntimeState(tempDir, {
+      hostGatewayPort: 63234,
+      lastSuccessfulStartAt: '2026-04-20T18:00:00.000Z',
+      repairGeneration: 4,
+      lastRepairOutcome: 'success',
+    })
+    const restartGateway = mock(async () => {
+      throw new Error(
+        'podman machine start failed: machine is corrupted and needs to be removed',
+      )
+    })
+    const stopGateway = mock(async () => {})
+    const stopMachineIfSafe = mock(async () => {})
+    const ensureReady = mock(async () => {})
+    const startGateway = mock(async () => 71234)
+    const waitForReady = mock(async (port: number) => {
+      expect(port).toBe(71234)
+      return true
+    })
+    const probe = mock(async () => {})
+    const service = new OpenClawService() as MutableOpenClawService
+
+    service.openclawDir = tempDir
+    service.runtime = {
+      ensureReady,
+      isReady: async () => true,
+      restartGateway,
+      startGateway,
+      stopGateway,
+      stopMachineIfSafe,
+      waitForReady,
+    }
+    service.cliClient = {
+      probe,
+    }
+
+    await service.restart()
+
+    expect(restartGateway).toHaveBeenCalledTimes(1)
+    expect(stopGateway).toHaveBeenCalledTimes(1)
+    expect(stopMachineIfSafe).toHaveBeenCalledTimes(1)
+    expect(ensureReady).toHaveBeenCalledTimes(1)
+    expect(startGateway).toHaveBeenCalledWith(
+      expect.objectContaining({
+        image: 'ghcr.io/openclaw/openclaw:2026.4.12',
+        port: 63234,
+        hostHome: tempDir,
+        envFilePath: join(tempDir, '.openclaw', '.env'),
+        gatewayToken: 'cli-token',
+      }),
+      expect.any(Function),
+    )
+    expect(waitForReady).toHaveBeenCalledWith(71234, expect.any(Number))
+    expect(probe).toHaveBeenCalledTimes(1)
+    expect(
+      JSON.parse(await readFile(join(tempDir, 'runtime-state.json'), 'utf-8')),
+    ).toMatchObject({
+      hostGatewayPort: 71234,
+      repairGeneration: 5,
+      lastRepairOutcome: 'success',
+    })
+  })
+
+  it('resets runtime state and clears the persisted host port', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
+    await mkdir(join(tempDir, '.openclaw'), { recursive: true })
+    await writeFile(join(tempDir, '.openclaw', 'openclaw.json'), '{}')
+    await saveOpenClawRuntimeState(tempDir, {
+      hostGatewayPort: 73234,
+      lastSuccessfulStartAt: '2026-04-20T18:00:00.000Z',
+      repairGeneration: 9,
+      lastRepairOutcome: 'failed',
+    })
+    const stopGateway = mock(async () => {})
+    const stopMachineIfSafe = mock(async () => {})
+    const service = new OpenClawService() as MutableOpenClawService
+
+    service.openclawDir = tempDir
+    service.runtime = {
+      isPodmanAvailable: async () => true,
+      getMachineStatus: async () => ({ initialized: true, running: false }),
+      inspectGateway: async () => ({
+        exists: false,
+        running: false,
+        hostPort: null,
+      }),
+      isReady: async (_port: number) => false,
+      stopGateway,
+      stopMachineIfSafe,
+    }
+
+    await service.resetRuntime()
+
+    expect(stopGateway).toHaveBeenCalledTimes(1)
+    expect(stopMachineIfSafe).toHaveBeenCalledTimes(1)
+    await expect(loadOpenClawRuntimeState(tempDir)).resolves.toEqual({
+      hostGatewayPort: null,
+      lastSuccessfulStartAt: null,
+      repairGeneration: 0,
+      lastRepairOutcome: null,
+    })
+    await expect(service.getStatus()).resolves.toMatchObject({
+      port: null,
+      status: 'stopped',
+    })
   })
 
   it('stop calls runtime.stopGateway', async () => {
@@ -720,8 +902,11 @@ describe('OpenClawService', () => {
     )
     const ensureReady = mock(async () => {})
     const isReady = mock(async () => false)
-    const startGateway = mock(async () => {})
-    const waitForReady = mock(async () => true)
+    const startGateway = mock(async () => 61234)
+    const waitForReady = mock(async (port: number) => {
+      expect(port).toBe(61234)
+      return true
+    })
     const probe = mock(async () => {})
     const service = new OpenClawService() as MutableOpenClawService
 
@@ -1208,7 +1393,7 @@ describe('OpenClawService', () => {
     service.restart = restart
     service.runtime = {
       isReady: async () => true,
-      waitForReady: async () => true,
+      waitForReady: async (_port: number) => true,
     }
     service.cliClient = {
       setDefaultModel,

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/podman-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/podman-runtime.test.ts
@@ -115,6 +115,145 @@ describe('podman runtime', () => {
     expect(runtime.getPodmanPath()).toBe('podman')
   })
 
+  it('forwards platform overrides through configurePodmanRuntime', async () => {
+    const spawnSpy = spyOn(Bun, 'spawn')
+    const runtime = configurePodmanRuntime({
+      podmanPath: 'podman',
+      platform: 'linux',
+    })
+
+    expect(getPodmanRuntime()).toBe(runtime)
+    expect(await runtime.getMachineStatus()).toEqual({
+      initialized: true,
+      running: true,
+    })
+    expect(spawnSpy).not.toHaveBeenCalled()
+  })
+
+  it('preserves the default OpenClaw machine name through the factory singleton path', async () => {
+    spyOn(Bun, 'spawn').mockReturnValue(
+      createSpawnResult({
+        stdout: JSON.stringify([
+          { Name: 'podman-machine-default', Running: true },
+          {
+            Name: BROWSEROS_OPENCLAW_PODMAN_MACHINE_NAME,
+            Running: false,
+            LastUp: '',
+          },
+        ]),
+      }),
+    )
+    const runtime = configurePodmanRuntime({
+      podmanPath: 'podman',
+      platform: 'darwin',
+    })
+
+    expect(getPodmanRuntime()).toBe(runtime)
+    expect(await getPodmanRuntime().getMachineStatus()).toEqual({
+      initialized: true,
+      running: false,
+    })
+  })
+
+  it('ensureReady initializes and starts the default named machine when it is missing', async () => {
+    const spawnSpy = spyOn(Bun, 'spawn')
+      .mockReturnValueOnce(
+        createSpawnResult({
+          stdout: JSON.stringify([
+            { Name: 'podman-machine-default', Running: true },
+          ]),
+        }),
+      )
+      .mockReturnValueOnce(createSpawnResult())
+      .mockReturnValueOnce(createSpawnResult())
+    const runtime = configurePodmanRuntime({
+      podmanPath: 'podman',
+      platform: 'darwin',
+    })
+    const logs: string[] = []
+
+    await runtime.ensureReady((line) => logs.push(line))
+    await runtime.ensureReady((line) => logs.push(line))
+
+    expect(logs).toEqual([
+      'Initializing Podman machine...',
+      'Starting Podman machine...',
+    ])
+    expect(spawnSpy).toHaveBeenNthCalledWith(
+      1,
+      ['podman', 'machine', 'list', '--format', 'json'],
+      { stdout: 'pipe', stderr: 'ignore' },
+    )
+    expect(spawnSpy).toHaveBeenNthCalledWith(
+      2,
+      [
+        'podman',
+        'machine',
+        'init',
+        '--cpus',
+        '8',
+        '--memory',
+        '8096',
+        '--disk-size',
+        '10',
+        BROWSEROS_OPENCLAW_PODMAN_MACHINE_NAME,
+      ],
+      {
+        stdout: 'ignore',
+        stderr: 'pipe',
+      },
+    )
+    expect(spawnSpy).toHaveBeenNthCalledWith(
+      3,
+      ['podman', 'machine', 'start', BROWSEROS_OPENCLAW_PODMAN_MACHINE_NAME],
+      {
+        stdout: 'ignore',
+        stderr: 'pipe',
+      },
+    )
+    expect(spawnSpy).toHaveBeenCalledTimes(3)
+  })
+
+  it('ensureReady starts but does not reinitialize the default named machine when it exists but is stopped', async () => {
+    const spawnSpy = spyOn(Bun, 'spawn')
+      .mockReturnValueOnce(
+        createSpawnResult({
+          stdout: JSON.stringify([
+            {
+              Name: BROWSEROS_OPENCLAW_PODMAN_MACHINE_NAME,
+              Running: false,
+              LastUp: '',
+            },
+          ]),
+        }),
+      )
+      .mockReturnValueOnce(createSpawnResult())
+    const runtime = configurePodmanRuntime({
+      podmanPath: 'podman',
+      platform: 'darwin',
+    })
+    const logs: string[] = []
+
+    await runtime.ensureReady((line) => logs.push(line))
+    await runtime.ensureReady((line) => logs.push(line))
+
+    expect(logs).toEqual(['Starting Podman machine...'])
+    expect(spawnSpy).toHaveBeenNthCalledWith(
+      1,
+      ['podman', 'machine', 'list', '--format', 'json'],
+      { stdout: 'pipe', stderr: 'ignore' },
+    )
+    expect(spawnSpy).toHaveBeenNthCalledWith(
+      2,
+      ['podman', 'machine', 'start', BROWSEROS_OPENCLAW_PODMAN_MACHINE_NAME],
+      {
+        stdout: 'ignore',
+        stderr: 'pipe',
+      },
+    )
+    expect(spawnSpy).toHaveBeenCalledTimes(2)
+  })
+
   it('selects the configured machine by name from machine list output', async () => {
     const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
       createSpawnResult({

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/podman-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/podman-runtime.test.ts
@@ -109,6 +109,25 @@ describe('podman runtime', () => {
     expect(getPodmanRuntime().getPodmanPath()).toBe(bundledPath)
   })
 
+  it('uses the configured platform when resolving the bundled podman path', () => {
+    const bundledPath = path.join(
+      tempDir,
+      'bin',
+      'third_party',
+      'podman',
+      'podman.exe',
+    )
+    fs.mkdirSync(path.dirname(bundledPath), { recursive: true })
+    fs.writeFileSync(bundledPath, 'podman')
+
+    const runtime = configurePodmanRuntime({
+      resourcesDir: tempDir,
+      platform: 'win32',
+    })
+
+    expect(runtime.getPodmanPath()).toBe(bundledPath)
+  })
+
   it('falls back to PATH podman when no bundled executable is present', () => {
     const runtime = configurePodmanRuntime({ resourcesDir: tempDir })
 

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/podman-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/podman-runtime.test.ts
@@ -3,16 +3,48 @@
  * Copyright 2025 BrowserOS
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  mock,
+  spyOn,
+} from 'bun:test'
 import fs from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
 
 import {
+  BROWSEROS_OPENCLAW_PODMAN_MACHINE_NAME,
   configurePodmanRuntime,
   getPodmanRuntime,
+  PodmanRuntime,
   resolveBundledPodmanPath,
 } from '../../../../src/api/services/openclaw/podman-runtime'
+
+function createStream(text: string): ReadableStream<Uint8Array> {
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(new TextEncoder().encode(text))
+      controller.close()
+    },
+  })
+}
+
+function createSpawnResult(options?: {
+  stdout?: string
+  stderr?: string
+  exitCode?: number
+}) {
+  return {
+    stdout: options?.stdout === undefined ? null : createStream(options.stdout),
+    stderr: options?.stderr === undefined ? null : createStream(options.stderr),
+    exited: Promise.resolve(options?.exitCode ?? 0),
+    kill() {},
+  } as ReturnType<typeof Bun.spawn>
+}
 
 describe('podman runtime', () => {
   let tempDir: string
@@ -24,6 +56,8 @@ describe('podman runtime', () => {
   afterEach(() => {
     fs.rmSync(tempDir, { recursive: true, force: true })
     configurePodmanRuntime({ podmanPath: 'podman' })
+    mock.restore()
+    mock.clearAllMocks()
   })
 
   it('returns the bundled podman path when the executable exists', () => {
@@ -79,5 +113,123 @@ describe('podman runtime', () => {
     const runtime = configurePodmanRuntime({ resourcesDir: tempDir })
 
     expect(runtime.getPodmanPath()).toBe('podman')
+  })
+
+  it('selects the configured machine by name from machine list output', async () => {
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(
+      createSpawnResult({
+        stdout: JSON.stringify([
+          { Name: 'podman-machine-default', Running: true },
+          {
+            Name: BROWSEROS_OPENCLAW_PODMAN_MACHINE_NAME,
+            Running: false,
+            LastUp: '',
+          },
+        ]),
+      }),
+    )
+    const runtime = new PodmanRuntime({
+      podmanPath: 'podman',
+      machineName: BROWSEROS_OPENCLAW_PODMAN_MACHINE_NAME,
+      platform: 'darwin',
+    })
+
+    expect(await runtime.getMachineStatus()).toEqual({
+      initialized: true,
+      running: false,
+    })
+    expect(spawnSpy).toHaveBeenCalledWith(
+      ['podman', 'machine', 'list', '--format', 'json'],
+      { stdout: 'pipe', stderr: 'ignore' },
+    )
+  })
+
+  it('reports uninitialized when the configured machine is absent', async () => {
+    spyOn(Bun, 'spawn').mockReturnValue(
+      createSpawnResult({
+        stdout: JSON.stringify([
+          { Name: 'podman-machine-default', Running: true },
+        ]),
+      }),
+    )
+    const runtime = new PodmanRuntime({
+      podmanPath: 'podman',
+      machineName: BROWSEROS_OPENCLAW_PODMAN_MACHINE_NAME,
+      platform: 'win32',
+    })
+
+    expect(await runtime.getMachineStatus()).toEqual({
+      initialized: false,
+      running: false,
+    })
+  })
+
+  it('targets the configured machine for init, start, and stop', async () => {
+    const spawnSpy = spyOn(Bun, 'spawn').mockReturnValue(createSpawnResult())
+    const runtime = new PodmanRuntime({
+      podmanPath: 'podman',
+      machineName: 'browseros-openclaw-custom',
+      platform: 'darwin',
+    })
+
+    await runtime.initMachine()
+    await runtime.startMachine()
+    await runtime.stopMachine()
+
+    expect(spawnSpy).toHaveBeenNthCalledWith(
+      1,
+      [
+        'podman',
+        'machine',
+        'init',
+        '--cpus',
+        '8',
+        '--memory',
+        '8096',
+        '--disk-size',
+        '10',
+        'browseros-openclaw-custom',
+      ],
+      {
+        stdout: 'ignore',
+        stderr: 'pipe',
+      },
+    )
+    expect(spawnSpy).toHaveBeenNthCalledWith(
+      2,
+      ['podman', 'machine', 'start', 'browseros-openclaw-custom'],
+      {
+        stdout: 'ignore',
+        stderr: 'pipe',
+      },
+    )
+    expect(spawnSpy).toHaveBeenNthCalledWith(
+      3,
+      ['podman', 'machine', 'stop', 'browseros-openclaw-custom'],
+      {
+        stdout: 'ignore',
+        stderr: 'ignore',
+      },
+    )
+  })
+
+  it('keeps linux machine handling as a no-op native path', async () => {
+    const spawnSpy = spyOn(Bun, 'spawn')
+    const runtime = new PodmanRuntime({
+      podmanPath: 'podman',
+      machineName: BROWSEROS_OPENCLAW_PODMAN_MACHINE_NAME,
+      platform: 'linux',
+    })
+
+    expect(await runtime.getMachineStatus()).toEqual({
+      initialized: true,
+      running: true,
+    })
+
+    await runtime.initMachine()
+    await runtime.startMachine()
+    await runtime.stopMachine()
+
+    expect(spawnSpy).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- give BrowserOS a dedicated named Podman machine and dynamic host-port handling for the OpenClaw gateway
- persist small runtime state, make OpenClawService runtime-aware, and add repair/reset recovery flows with restart auto-escalation on strong machine failures
- simplify the Agents page into one operator/runtime card and expose repair/reset controls through the API and client hooks

## Design
This change keeps BrowserOS in control of a dedicated OpenClaw runtime without exposing container or VM concepts in the UI. The server now owns named-machine lifecycle, discovers and retries host-port binding safely, persists the chosen host port plus repair metadata, and uses runtime inspection/status to drive service recovery. The agent UI collapses raw runtime/control-plane details into a simpler operator state with explicit repair/reset actions while preserving setup, agent management, and Podman override flows.

## Test plan
- [x] `bun test apps/server/tests/api/services/openclaw/openclaw-runtime-state.test.ts apps/server/tests/api/services/openclaw/podman-runtime.test.ts apps/server/tests/api/services/openclaw/container-runtime.test.ts apps/server/tests/api/services/openclaw/openclaw-service.test.ts apps/server/tests/api/routes/openclaw.test.ts`
- [x] `bun test apps/agent/entrypoints/app/agents/openclaw-operator-state.test.ts`
- [x] `bun run --filter @browseros/server typecheck`
- [x] `bun run --filter @browseros/agent typecheck`