### PR TITLE
fix(openclaw): allocate gateway host port dynamically + name the two ports distinctly

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -229,17 +229,13 @@ const ProviderSelector: FC<ProviderSelectorProps> = ({
   )
 }
 
-interface PodmanOverridesCardProps {
-  variant: 'inline' | 'standalone'
-}
-
-const PodmanOverridesCard: FC<PodmanOverridesCardProps> = ({ variant }) => {
+const PodmanOverridesCard: FC = () => {
   const { overrides, loading, saving, error, saveOverrides, clearOverrides } =
     usePodmanOverrides()
 
   const [value, setValue] = useState('')
   const [touched, setTouched] = useState(false)
-  const [collapsed, setCollapsed] = useState(variant === 'standalone')
+  const [collapsed, setCollapsed] = useState(true)
   const [localError, setLocalError] = useState<string | null>(null)
 
   useEffect(() => {
@@ -276,14 +272,11 @@ const PodmanOverridesCard: FC<PodmanOverridesCardProps> = ({ variant }) => {
   const body = (
     <div className="space-y-3">
       <div className="space-y-1">
-        <label
-          htmlFor={`podman-path-${variant}`}
-          className="font-medium text-sm"
-        >
+        <label htmlFor="podman-path" className="font-medium text-sm">
           Podman binary path
         </label>
         <Input
-          id={`podman-path-${variant}`}
+          id="podman-path"
           value={value}
           onChange={(event) => {
             setTouched(true)
@@ -331,15 +324,6 @@ const PodmanOverridesCard: FC<PodmanOverridesCardProps> = ({ variant }) => {
       </div>
     </div>
   )
-
-  if (variant === 'inline') {
-    return (
-      <div className="mt-3 rounded-md border bg-background p-3">
-        <p className="mb-2 font-medium text-sm">Use your own Podman</p>
-        {body}
-      </div>
-    )
-  }
 
   return (
     <Card>
@@ -687,7 +671,6 @@ export const AgentsPage: FC = () => {
                 Restart Gateway
               </Button>
             </div>
-            <PodmanOverridesCard variant="inline" />
           </AlertDescription>
         </Alert>
       )}
@@ -707,9 +690,6 @@ export const AgentsPage: FC = () => {
             {status.podmanAvailable && (
               <Button onClick={() => setSetupOpen(true)}>Set Up Now</Button>
             )}
-            <div className="w-full max-w-md">
-              <PodmanOverridesCard variant="inline" />
-            </div>
           </CardContent>
         </Card>
       )}
@@ -752,9 +732,6 @@ export const AgentsPage: FC = () => {
               >
                 Restart Gateway
               </Button>
-            </div>
-            <div className="w-full max-w-md">
-              <PodmanOverridesCard variant="inline" />
             </div>
           </CardContent>
         </Card>
@@ -827,7 +804,7 @@ export const AgentsPage: FC = () => {
         </div>
       )}
 
-      <PodmanOverridesCard variant="standalone" />
+      <PodmanOverridesCard />
 
       <Dialog open={setupOpen} onOpenChange={setSetupOpen}>
         <DialogContent>

--- a/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
@@ -9,7 +9,6 @@
 
 import { accessSync, existsSync, constants as fsConstants } from 'node:fs'
 import path from 'node:path'
-import { OPENCLAW_GATEWAY_PORT } from '@browseros/shared/constants/openclaw'
 import { Hono } from 'hono'
 import { stream } from 'hono/streaming'
 import { logger } from '../../lib/logger'
@@ -83,7 +82,7 @@ export function createOpenClawRoutes() {
         return c.json(
           {
             status: 'running',
-            port: OPENCLAW_GATEWAY_PORT,
+            port: getOpenClawService().getPort(),
             agents: agents.map((a) => ({
               agentId: a.agentId,
               name: a.name,

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
@@ -6,7 +6,10 @@
  * OpenClaw container lifecycle abstraction over PodmanRuntime.
  */
 
-import { OPENCLAW_GATEWAY_CONTAINER_NAME } from '@browseros/shared/constants/openclaw'
+import {
+  OPENCLAW_GATEWAY_CONTAINER_NAME,
+  OPENCLAW_GATEWAY_CONTAINER_PORT,
+} from '@browseros/shared/constants/openclaw'
 import { logger } from '../../../lib/logger'
 import type { LogFn, PodmanRuntime } from './podman-runtime'
 
@@ -15,7 +18,7 @@ const GATEWAY_STATE_DIR = `${GATEWAY_CONTAINER_HOME}/.openclaw`
 
 export type GatewayContainerSpec = {
   image: string
-  port: number
+  hostPort: number
   hostHome: string
   envFilePath: string
   gatewayToken?: string
@@ -54,6 +57,7 @@ export class ContainerRuntime {
     onLog?: LogFn,
   ): Promise<void> {
     await this.ensureGatewayRemoved(onLog)
+    const containerPort = String(OPENCLAW_GATEWAY_CONTAINER_PORT)
     const code = await this.runPodmanCommand(
       [
         'run',
@@ -63,10 +67,10 @@ export class ContainerRuntime {
         '--restart',
         'unless-stopped',
         '-p',
-        `127.0.0.1:${input.port}:18789`,
+        `127.0.0.1:${input.hostPort}:${containerPort}`,
         ...this.buildGatewayContainerRuntimeArgs(input),
         '--health-cmd',
-        'curl -sf http://127.0.0.1:18789/healthz',
+        `curl -sf http://127.0.0.1:${containerPort}/healthz`,
         '--health-interval',
         '30s',
         '--health-timeout',
@@ -80,7 +84,7 @@ export class ContainerRuntime {
         '--bind',
         'lan',
         '--port',
-        '18789',
+        containerPort,
         '--allow-unconfigured',
       ],
       onLog,
@@ -111,31 +115,34 @@ export class ContainerRuntime {
     return lines
   }
 
-  async isHealthy(port: number): Promise<boolean> {
+  async isHealthy(hostPort: number): Promise<boolean> {
     try {
-      const res = await fetch(`http://127.0.0.1:${port}/healthz`)
+      const res = await fetch(`http://127.0.0.1:${hostPort}/healthz`)
       return res.ok
     } catch {
       return false
     }
   }
 
-  async isReady(port: number): Promise<boolean> {
+  async isReady(hostPort: number): Promise<boolean> {
     try {
-      const res = await fetch(`http://127.0.0.1:${port}/readyz`)
+      const res = await fetch(`http://127.0.0.1:${hostPort}/readyz`)
       return res.ok
     } catch {
       return false
     }
   }
 
-  async waitForReady(port: number, timeoutMs = 30_000): Promise<boolean> {
-    logger.info('Waiting for OpenClaw gateway readiness', { port, timeoutMs })
+  async waitForReady(hostPort: number, timeoutMs = 30_000): Promise<boolean> {
+    logger.info('Waiting for OpenClaw gateway readiness', {
+      hostPort,
+      timeoutMs,
+    })
     const start = Date.now()
     while (Date.now() - start < timeoutMs) {
-      if (await this.isReady(port)) {
+      if (await this.isReady(hostPort)) {
         logger.info('OpenClaw gateway became ready', {
-          port,
+          hostPort,
           waitMs: Date.now() - start,
         })
         return true
@@ -143,7 +150,7 @@ export class ContainerRuntime {
       await Bun.sleep(1000)
     }
     logger.error('Timed out waiting for OpenClaw gateway readiness', {
-      port,
+      hostPort,
       timeoutMs,
     })
     return false

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-http-chat-client.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-http-chat-client.ts
@@ -22,7 +22,7 @@ export interface OpenClawChatRequest {
 
 export class OpenClawHttpChatClient {
   constructor(
-    private readonly port: number,
+    private readonly hostPort: number,
     private readonly getToken: () => Promise<string>,
   ) {}
 
@@ -42,7 +42,7 @@ export class OpenClawHttpChatClient {
   private async fetchChat(input: OpenClawChatRequest): Promise<Response> {
     const token = await this.getToken()
     const response = await fetch(
-      `http://127.0.0.1:${this.port}/v1/chat/completions`,
+      `http://127.0.0.1:${this.hostPort}/v1/chat/completions`,
       {
         method: 'POST',
         headers: {

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -12,7 +12,7 @@ import { existsSync } from 'node:fs'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import {
   OPENCLAW_CONTAINER_HOME,
-  OPENCLAW_GATEWAY_PORT,
+  OPENCLAW_GATEWAY_CONTAINER_PORT,
 } from '@browseros/shared/constants/openclaw'
 import { DEFAULT_PORTS } from '@browseros/shared/constants/ports'
 import { getOpenClawDir } from '../../../lib/browseros-dir'
@@ -48,6 +48,7 @@ import {
 import type { OpenClawStreamEvent } from './openclaw-types'
 import { loadPodmanOverrides, savePodmanOverrides } from './podman-overrides'
 import { configurePodmanRuntime, getPodmanRuntime } from './podman-runtime'
+import { allocateGatewayPort, readPersistedGatewayPort } from './runtime-state'
 
 const READY_TIMEOUT_MS = 30_000
 const AGENT_NAME_PATTERN = /^[a-z][a-z0-9-]*$/
@@ -120,7 +121,7 @@ export class OpenClawService {
   private bootstrapCliClient: OpenClawCliClient
   private chatClient: OpenClawHttpChatClient
   private openclawDir: string
-  private port = OPENCLAW_GATEWAY_PORT
+  private hostPort = OPENCLAW_GATEWAY_CONTAINER_PORT
   private token: string
   private tokenLoaded = false
   private lastError: string | null = null
@@ -138,7 +139,7 @@ export class OpenClawService {
     this.cliClient = new OpenClawCliClient(this.runtime)
     this.bootstrapCliClient = this.buildBootstrapCliClient()
     this.chatClient = new OpenClawHttpChatClient(
-      this.port,
+      this.hostPort,
       async () => this.token,
     )
     this.browserosServerPort =
@@ -155,13 +156,17 @@ export class OpenClawService {
     }
   }
 
+  getPort(): number {
+    return this.hostPort
+  }
+
   // ── Lifecycle ────────────────────────────────────────────────────────
 
   async setup(input: SetupInput, onLog?: (msg: string) => void): Promise<void> {
     const logProgress = this.createProgressLogger(onLog)
     const provider = resolveSupportedOpenClawProvider(input)
     logger.info('Starting OpenClaw setup', {
-      port: this.port,
+      hostPort: this.hostPort,
       browserosServerPort: this.browserosServerPort,
       providerType: input.providerType,
       providerName: input.providerName,
@@ -195,13 +200,15 @@ export class OpenClawService {
     await this.runtime.pullImage(this.getGatewayImage(), logProgress)
     logProgress('Image ready')
 
+    await this.ensureGatewayPortAllocated(logProgress)
+
     logProgress('Bootstrapping OpenClaw config...')
     await this.bootstrapCliClient.runOnboard({
       acceptRisk: true,
       authChoice: 'skip',
       gatewayAuth: 'token',
       gatewayBind: 'lan',
-      gatewayPort: this.port,
+      gatewayPort: OPENCLAW_GATEWAY_CONTAINER_PORT,
       installDaemon: false,
       mode: 'local',
       nonInteractive: true,
@@ -223,7 +230,10 @@ export class OpenClawService {
     await this.runtime.startGateway(this.buildGatewayRuntimeSpec(), logProgress)
     this.startGatewayLogTail()
     logProgress('Waiting for gateway readiness...')
-    const ready = await this.runtime.waitForReady(this.port, READY_TIMEOUT_MS)
+    const ready = await this.runtime.waitForReady(
+      this.hostPort,
+      READY_TIMEOUT_MS,
+    )
     if (!ready) {
       this.lastError = 'Gateway did not become ready within 30 seconds'
       const logs = await this.runtime.getGatewayLogs()
@@ -253,14 +263,14 @@ export class OpenClawService {
     }
 
     this.lastError = null
-    logProgress(`OpenClaw gateway running at http://127.0.0.1:${this.port}`)
-    logger.info('OpenClaw setup complete', { port: this.port })
+    logProgress(`OpenClaw gateway running at http://127.0.0.1:${this.hostPort}`)
+    logger.info('OpenClaw setup complete', { hostPort: this.hostPort })
   }
 
   async start(onLog?: (msg: string) => void): Promise<void> {
     const logProgress = this.createProgressLogger(onLog)
     logger.info('Starting OpenClaw service', {
-      port: this.port,
+      hostPort: this.hostPort,
     })
 
     await this.runtime.ensureReady(logProgress)
@@ -270,12 +280,17 @@ export class OpenClawService {
     await this.loadTokenFromConfig()
     await this.ensureStateEnvFile()
 
+    await this.ensureGatewayPortAllocated(logProgress)
+
     logProgress('Starting OpenClaw gateway...')
     await this.runtime.startGateway(this.buildGatewayRuntimeSpec(), logProgress)
     this.startGatewayLogTail()
 
     logProgress('Waiting for gateway readiness...')
-    const ready = await this.runtime.waitForReady(this.port, READY_TIMEOUT_MS)
+    const ready = await this.runtime.waitForReady(
+      this.hostPort,
+      READY_TIMEOUT_MS,
+    )
     if (!ready) {
       this.lastError = 'Gateway did not become ready after start'
       throw new Error(this.lastError)
@@ -285,11 +300,11 @@ export class OpenClawService {
     logProgress('Probing OpenClaw control plane...')
     await this.runControlPlaneCall(() => this.cliClient.probe())
     this.lastError = null
-    logger.info('OpenClaw gateway started', { port: this.port })
+    logger.info('OpenClaw gateway started', { hostPort: this.hostPort })
   }
 
   async stop(): Promise<void> {
-    logger.info('Stopping OpenClaw service', { port: this.port })
+    logger.info('Stopping OpenClaw service', { hostPort: this.hostPort })
     this.controlPlaneStatus = 'disconnected'
     this.stopGatewayLogTail()
     await this.runtime.stopGateway()
@@ -299,7 +314,7 @@ export class OpenClawService {
   async restart(onLog?: (msg: string) => void): Promise<void> {
     const logProgress = this.createProgressLogger(onLog)
     logger.info('Restarting OpenClaw service', {
-      port: this.port,
+      hostPort: this.hostPort,
     })
 
     this.controlPlaneStatus = 'reconnecting'
@@ -308,6 +323,7 @@ export class OpenClawService {
     this.tokenLoaded = false
     await this.loadTokenFromConfig()
     await this.ensureStateEnvFile()
+    await this.ensureGatewayPortAllocated(logProgress)
     logProgress('Restarting OpenClaw gateway...')
     await this.runtime.restartGateway(
       this.buildGatewayRuntimeSpec(),
@@ -316,7 +332,10 @@ export class OpenClawService {
     this.startGatewayLogTail()
 
     logProgress('Waiting for gateway readiness...')
-    const ready = await this.runtime.waitForReady(this.port, READY_TIMEOUT_MS)
+    const ready = await this.runtime.waitForReady(
+      this.hostPort,
+      READY_TIMEOUT_MS,
+    )
     if (!ready) {
       this.lastError = 'Gateway did not become ready after restart'
       throw new Error(this.lastError)
@@ -326,15 +345,17 @@ export class OpenClawService {
     await this.runControlPlaneCall(() => this.cliClient.probe())
     this.lastError = null
     logProgress('Gateway restarted successfully')
-    logger.info('OpenClaw gateway restarted', { port: this.port })
+    logger.info('OpenClaw gateway restarted', { hostPort: this.hostPort })
   }
 
   async reconnectControlPlane(onLog?: (msg: string) => void): Promise<void> {
     const logProgress = this.createProgressLogger(onLog)
-    logger.info('Reconnecting OpenClaw control plane', { port: this.port })
+    logger.info('Reconnecting OpenClaw control plane', {
+      hostPort: this.hostPort,
+    })
 
     logProgress('Checking gateway readiness...')
-    const ready = await this.runtime.isReady(this.port)
+    const ready = await this.runtime.isReady(this.hostPort)
     if (!ready) {
       this.controlPlaneStatus = 'failed'
       this.lastGatewayError = 'OpenClaw gateway is not ready'
@@ -399,7 +420,7 @@ export class OpenClawService {
 
     const machineStatus = await this.runtime.getMachineStatus()
     const ready = machineStatus.running
-      ? await this.runtime.isReady(this.port)
+      ? await this.runtime.isReady(this.hostPort)
       : false
 
     let agentCount = 0
@@ -418,7 +439,7 @@ export class OpenClawService {
       status: ready ? 'running' : this.lastError ? 'error' : 'stopped',
       podmanAvailable: true,
       machineReady: machineStatus.running,
-      port: this.port,
+      port: this.hostPort,
       agentCount,
       error: this.lastError,
       controlPlaneStatus: ready ? this.controlPlaneStatus : 'disconnected',
@@ -624,7 +645,7 @@ export class OpenClawService {
     const available = await this.runtime.isPodmanAvailable()
     if (!available) return
     logger.info('Attempting OpenClaw auto-start', {
-      port: this.port,
+      hostPort: this.hostPort,
     })
 
     try {
@@ -634,10 +655,16 @@ export class OpenClawService {
       await this.loadTokenFromConfig()
       await this.ensureStateEnvFile()
 
-      if (!(await this.runtime.isReady(this.port))) {
+      const persistedPort = await readPersistedGatewayPort(this.openclawDir)
+      if (persistedPort !== null) {
+        this.setPort(persistedPort)
+      }
+
+      if (!(await this.runtime.isReady(this.hostPort))) {
+        await this.ensureGatewayPortAllocated()
         await this.runtime.startGateway(this.buildGatewayRuntimeSpec())
         const ready = await this.runtime.waitForReady(
-          this.port,
+          this.hostPort,
           READY_TIMEOUT_MS,
         )
         if (!ready) {
@@ -675,10 +702,30 @@ export class OpenClawService {
     this.bootstrapCliClient = this.buildBootstrapCliClient()
   }
 
+  private setPort(hostPort: number): void {
+    if (hostPort === this.hostPort) return
+    this.hostPort = hostPort
+    this.chatClient = new OpenClawHttpChatClient(
+      this.hostPort,
+      async () => this.token,
+    )
+  }
+
+  private async ensureGatewayPortAllocated(
+    logProgress?: (msg: string) => void,
+  ): Promise<void> {
+    const hostPort = await allocateGatewayPort(this.openclawDir)
+    if (hostPort !== this.hostPort) {
+      logProgress?.(`Allocated OpenClaw gateway host port ${hostPort}`)
+      logger.info('Allocated OpenClaw gateway host port', { hostPort })
+      this.setPort(hostPort)
+    }
+  }
+
   private async assertGatewayReady(): Promise<void> {
-    const portReady = await this.runtime.isReady(this.port)
+    const portReady = await this.runtime.isReady(this.hostPort)
     logger.debug('Checking OpenClaw gateway readiness before use', {
-      port: this.port,
+      hostPort: this.hostPort,
       portReady,
       controlPlaneStatus: this.controlPlaneStatus,
     })
@@ -782,8 +829,8 @@ export class OpenClawService {
       {
         path: 'gateway.controlUi.allowedOrigins',
         value: [
-          `http://127.0.0.1:${this.port}`,
-          `http://localhost:${this.port}`,
+          `http://127.0.0.1:${this.hostPort}`,
+          `http://localhost:${this.hostPort}`,
         ],
       },
       {
@@ -893,7 +940,10 @@ export class OpenClawService {
   }
 
   private async waitForGatewayAfterCliMutation(): Promise<void> {
-    const ready = await this.runtime.waitForReady(this.port, READY_TIMEOUT_MS)
+    const ready = await this.runtime.waitForReady(
+      this.hostPort,
+      READY_TIMEOUT_MS,
+    )
     if (!ready) {
       this.lastError = 'Gateway did not become ready after applying config'
       throw new Error(this.lastError)
@@ -929,7 +979,7 @@ export class OpenClawService {
   private buildGatewayRuntimeSpec(): GatewayContainerSpec {
     return {
       image: this.getGatewayImage(),
-      port: this.port,
+      hostPort: this.hostPort,
       hostHome: this.openclawDir,
       envFilePath: this.getStateEnvPath(),
       gatewayToken: this.tokenLoaded ? this.token : undefined,

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/runtime-state.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/runtime-state.ts
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Runtime state for the OpenClaw gateway. Today this is just the host port
+ * we mapped the gateway container to, persisted so that a once-chosen port
+ * is reused across restarts when it's still free.
+ */
+
+import { existsSync } from 'node:fs'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { createServer } from 'node:net'
+import { join } from 'node:path'
+import { OPENCLAW_GATEWAY_CONTAINER_PORT } from '@browseros/shared/constants/openclaw'
+import { getOpenClawStateDir } from './openclaw-env'
+
+const RUNTIME_STATE_FILE = 'runtime-state.json'
+
+interface RuntimeState {
+  gatewayPort: number
+}
+
+function getRuntimeStatePath(openclawDir: string): string {
+  return join(getOpenClawStateDir(openclawDir), RUNTIME_STATE_FILE)
+}
+
+export async function readPersistedGatewayPort(
+  openclawDir: string,
+): Promise<number | null> {
+  const path = getRuntimeStatePath(openclawDir)
+  if (!existsSync(path)) return null
+  try {
+    const parsed = JSON.parse(
+      await readFile(path, 'utf-8'),
+    ) as Partial<RuntimeState>
+    if (
+      typeof parsed.gatewayPort === 'number' &&
+      Number.isInteger(parsed.gatewayPort) &&
+      parsed.gatewayPort > 0 &&
+      parsed.gatewayPort <= 65535
+    ) {
+      return parsed.gatewayPort
+    }
+    return null
+  } catch {
+    return null
+  }
+}
+
+async function writePersistedGatewayPort(
+  openclawDir: string,
+  port: number,
+): Promise<void> {
+  await mkdir(getOpenClawStateDir(openclawDir), { recursive: true })
+  const state: RuntimeState = { gatewayPort: port }
+  await writeFile(
+    getRuntimeStatePath(openclawDir),
+    `${JSON.stringify(state, null, 2)}\n`,
+  )
+}
+
+function isPortAvailable(port: number): Promise<boolean> {
+  return new Promise((resolve) => {
+    const server = createServer()
+    server.once('error', () => resolve(false))
+    server.once('listening', () => {
+      server.close(() => resolve(true))
+    })
+    server.listen(port, '127.0.0.1')
+  })
+}
+
+async function findAvailablePort(startPort: number): Promise<number> {
+  let port = startPort
+  while (!(await isPortAvailable(port))) {
+    port++
+  }
+  return port
+}
+
+/**
+ * Pick a host port for the gateway container and persist it. Prefers the
+ * previously persisted port when it's still bindable; otherwise scans
+ * upward from OPENCLAW_GATEWAY_CONTAINER_PORT until a free port is found.
+ */
+export async function allocateGatewayPort(
+  openclawDir: string,
+): Promise<number> {
+  const persisted = await readPersistedGatewayPort(openclawDir)
+  if (persisted !== null && (await isPortAvailable(persisted))) {
+    return persisted
+  }
+  const port = await findAvailablePort(OPENCLAW_GATEWAY_CONTAINER_PORT)
+  await writePersistedGatewayPort(openclawDir, port)
+  return port
+}

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/container-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/container-runtime.test.ts
@@ -10,7 +10,7 @@ import { ContainerRuntime } from '../../../../src/api/services/openclaw/containe
 const PROJECT_DIR = '/tmp/openclaw'
 const defaultSpec = {
   image: 'ghcr.io/openclaw/openclaw:2026.4.12',
-  port: 18789,
+  hostPort: 18789,
   hostHome: '/tmp/openclaw',
   envFilePath: '/tmp/openclaw/.openclaw/.env',
   gatewayToken: 'token-123',
@@ -75,7 +75,7 @@ function expectedStartGatewayRunArgs(spec: typeof defaultSpec): string[] {
     '--restart',
     'unless-stopped',
     '-p',
-    `127.0.0.1:${spec.port}:18789`,
+    `127.0.0.1:${spec.hostPort}:18789`,
     ...expectedGatewayRuntimeArgs(spec),
     '--health-cmd',
     'curl -sf http://127.0.0.1:18789/healthz',

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-service.test.ts
@@ -292,7 +292,7 @@ describe('OpenClawService', () => {
     expect(startGateway).toHaveBeenCalledWith(
       expect.objectContaining({
         image: 'ghcr.io/openclaw/openclaw:2026.4.12',
-        port: 18789,
+        hostPort: expect.any(Number),
         hostHome: tempDir,
         envFilePath: join(tempDir, '.openclaw', '.env'),
         gatewayToken: undefined,
@@ -587,7 +587,7 @@ describe('OpenClawService', () => {
     expect(startGateway).toHaveBeenCalledWith(
       expect.objectContaining({
         image: 'ghcr.io/openclaw/openclaw:2026.4.12',
-        port: 18789,
+        hostPort: expect.any(Number),
         hostHome: tempDir,
         envFilePath: join(tempDir, '.openclaw', '.env'),
         gatewayToken: 'cli-token',
@@ -631,7 +631,7 @@ describe('OpenClawService', () => {
     expect(restartGateway).toHaveBeenCalledWith(
       expect.objectContaining({
         image: 'ghcr.io/openclaw/openclaw:2026.4.12',
-        port: 18789,
+        hostPort: expect.any(Number),
         hostHome: tempDir,
         envFilePath: join(tempDir, '.openclaw', '.env'),
         gatewayToken: 'cli-token',
@@ -743,7 +743,7 @@ describe('OpenClawService', () => {
     expect(startGateway).toHaveBeenCalledWith(
       expect.objectContaining({
         image: 'ghcr.io/openclaw/openclaw:2026.4.12',
-        port: 18789,
+        hostPort: expect.any(Number),
         hostHome: tempDir,
         envFilePath: join(tempDir, '.openclaw', '.env'),
         gatewayToken: 'cli-token',

--- a/packages/browseros-agent/packages/shared/src/constants/openclaw.ts
+++ b/packages/browseros-agent/packages/shared/src/constants/openclaw.ts
@@ -1,4 +1,4 @@
-export const OPENCLAW_GATEWAY_PORT = 18789
+export const OPENCLAW_GATEWAY_CONTAINER_PORT = 18789
 export const OPENCLAW_CONTAINER_HOME = '/home/node/.openclaw'
 export const OPENCLAW_COMPOSE_PROJECT_NAME = 'browseros-openclaw'
 export const OPENCLAW_GATEWAY_CONTAINER_NAME = `${OPENCLAW_COMPOSE_PROJECT_NAME}-openclaw-gateway-1`


### PR DESCRIPTION
## Summary

- The gateway container always listens on **18789 internally**, but that port may be taken on the host (seen in the wild: a stale `gvproxy` from a previous container). The host-side mapping port is now **allocated dynamically** on each lifecycle transition and persisted to `~/.browseros/openclaw/.openclaw/runtime-state.json` so the choice is stable across restarts.
- The shared constant becomes `OPENCLAW_GATEWAY_CONTAINER_PORT` (container-internal, fixed) and the service/spec/runtime probes/chat-client now use `hostPort` for the dynamically mapped host-side port — so the two sides of the `-p 127.0.0.1:<host>:<container>` mapping are no longer ambiguous.
- Small UI follow-up: removed a duplicate Podman overrides card from the status panels.

## Design

Simple linear port scan modeled on `scripts/dev/start.ts`: `isPortAvailable` via `net.createServer.listen('127.0.0.1')`, `findAvailablePort` scans upward from `OPENCLAW_GATEWAY_CONTAINER_PORT`. `allocateGatewayPort(openclawDir)` prefers the persisted port when still free, otherwise scans and persists the winner. Lives in a new `apps/server/src/api/services/openclaw/runtime-state.ts`, mirroring the shape of `podman-overrides.ts`.

Allocation runs once per lifecycle method:
- `setup()` allocates right after `pullImage` so `setConfigBatch` writes `gateway.controlUi.allowedOrigins` with the correct host port, and `runOnboard`'s `gatewayPort` argument switches to the container-internal constant (always 18789).
- `start()` and `restart()` allocate just before `runtime.startGateway` / `restartGateway`.
- `tryAutoStart()` loads the persisted port first so `isReady()` probes the right port; it only reallocates when the gateway isn't already running.

The chat client captures the port at construction, so it's rebuilt whenever `setPort` changes the host port. `/status` and `/setup` both return the real allocated port via `getOpenClawService().getPort()`; the extension already reads `port` from `/status`, so no client changes were needed.

## Test plan

- [x] `bun run typecheck` — clean across all packages
- [x] `bun test apps/server/tests/api/services/openclaw/` — 73/73 pass
- [x] Verified allocator end-to-end: on a machine where `gvproxy` held 18789, the service correctly allocated **18790** and persisted it to `~/.browseros/openclaw/.openclaw/runtime-state.json`
- [ ] Manual: fresh setup on a clean host → observe `runtime-state.json` created with `{"gatewayPort": 18789}`, gateway reachable at `http://127.0.0.1:18789`
- [ ] Manual: bind 18789 with `nc -l 18789` before setup → observe allocator picks 18790 and persists it; restart with 18789 released → observe persisted 18790 is reused
- [ ] Manual: confirm the status panels no longer render two Podman overrides cards