### PR TITLE
feat(openclaw): support updating existing agent models

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -5,6 +5,7 @@ import {
   Cpu,
   Loader2,
   MessageSquare,
+  Pencil,
   Plus,
   RefreshCw,
   ShieldAlert,
@@ -40,6 +41,7 @@ import { getOpenClawSupportedProviders } from './openclaw-supported-providers'
 import {
   type AgentEntry,
   type GatewayLifecycleAction,
+  getModelDisplayName,
   type OpenClawStatus,
   useOpenClawAgents,
   useOpenClawMutations,
@@ -179,16 +181,18 @@ function getRecoveryDetail(status: OpenClawStatus): string | null {
 }
 
 interface ProviderSelectorProps {
-  providers: Array<{
-    id: string
-    type: string
-    name: string
-    modelId: string
-    baseUrl?: string
-  }>
+  providers: OpenClawProviderOption[]
   defaultProviderId: string
   selectedId: string
   onSelect: (id: string) => void
+}
+
+interface OpenClawProviderOption {
+  id: string
+  type: string
+  name: string
+  modelId: string
+  baseUrl?: string
 }
 
 const ProviderSelector: FC<ProviderSelectorProps> = ({
@@ -235,6 +239,37 @@ const ProviderSelector: FC<ProviderSelectorProps> = ({
         the container and never leaves your machine.
       </p>
     </div>
+  )
+}
+
+function getDefaultCompatibleProviderId(
+  providers: OpenClawProviderOption[],
+  defaultProviderId: string,
+): string {
+  return (
+    providers.find((provider) => provider.id === defaultProviderId)?.id ??
+    providers[0]?.id ??
+    ''
+  )
+}
+
+function getProviderIdForAgentModel(
+  model: unknown,
+  providers: OpenClawProviderOption[],
+  defaultProviderId: string,
+): string {
+  if (typeof model !== 'string') {
+    return getDefaultCompatibleProviderId(providers, defaultProviderId)
+  }
+
+  const matchingProvider = providers.find((provider) => {
+    const builtInModelRef = `${provider.type}/${provider.modelId}`
+    return model === builtInModelRef || model.endsWith(`/${provider.modelId}`)
+  })
+
+  return (
+    matchingProvider?.id ??
+    getDefaultCompatibleProviderId(providers, defaultProviderId)
   )
 }
 
@@ -372,6 +407,7 @@ export const AgentsPage: FC = () => {
     setupOpenClaw,
     createAgent,
     deleteAgent,
+    updateAgent,
     startOpenClaw,
     stopOpenClaw,
     restartOpenClaw,
@@ -380,6 +416,7 @@ export const AgentsPage: FC = () => {
     settingUp,
     creating,
     deleting,
+    updating,
     reconnecting,
     pendingGatewayAction,
   } = useOpenClawMutations()
@@ -389,6 +426,8 @@ export const AgentsPage: FC = () => {
   const [createOpen, setCreateOpen] = useState(false)
   const [newName, setNewName] = useState('')
   const [createProviderId, setCreateProviderId] = useState('')
+  const [editAgent, setEditAgent] = useState<AgentEntry | null>(null)
+  const [editProviderId, setEditProviderId] = useState('')
 
   const [chatAgent, setChatAgent] = useState<AgentEntry | null>(null)
   const [showTerminal, setShowTerminal] = useState(false)
@@ -398,9 +437,10 @@ export const AgentsPage: FC = () => {
 
   useEffect(() => {
     if (compatibleProviders.length === 0) return
-    const fallbackId =
-      compatibleProviders.find((provider) => provider.id === defaultProviderId)
-        ?.id ?? compatibleProviders[0].id
+    const fallbackId = getDefaultCompatibleProviderId(
+      compatibleProviders,
+      defaultProviderId,
+    )
 
     if (setupOpen && !setupProviderId) setSetupProviderId(fallbackId)
     if (createOpen && !createProviderId) setCreateProviderId(fallbackId)
@@ -412,6 +452,18 @@ export const AgentsPage: FC = () => {
     compatibleProviders,
     defaultProviderId,
   ])
+
+  useEffect(() => {
+    if (!editAgent || compatibleProviders.length === 0 || editProviderId) return
+
+    setEditProviderId(
+      getProviderIdForAgentModel(
+        editAgent.model,
+        compatibleProviders,
+        defaultProviderId,
+      ),
+    )
+  }, [editAgent, editProviderId, compatibleProviders, defaultProviderId])
 
   useEffect(() => {
     if (!createOpen) return
@@ -512,6 +564,30 @@ export const AgentsPage: FC = () => {
   const handleDelete = async (id: string) => {
     await runWithErrorHandling(async () => {
       await deleteAgent(id)
+    })
+  }
+
+  const closeEditDialog = () => {
+    setEditAgent(null)
+    setEditProviderId('')
+  }
+
+  const handleUpdate = async () => {
+    if (!editAgent) return
+    const provider = compatibleProviders.find(
+      (item) => item.id === editProviderId,
+    )
+
+    await runWithErrorHandling(async () => {
+      await updateAgent({
+        agentId: editAgent.agentId,
+        providerType: provider?.type,
+        providerName: provider?.name,
+        baseUrl: provider?.baseUrl,
+        apiKey: provider?.apiKey,
+        modelId: provider?.modelId,
+      })
+      closeEditDialog()
     })
   }
 
@@ -800,6 +876,10 @@ export const AgentsPage: FC = () => {
                       <p className="font-mono text-muted-foreground text-xs">
                         {agent.workspace}
                       </p>
+                      <p className="text-muted-foreground text-xs">
+                        Model:{' '}
+                        {getModelDisplayName(agent.model) ?? 'Using default'}
+                      </p>
                     </div>
                   </div>
                   <div className="flex items-center gap-1">
@@ -811,6 +891,15 @@ export const AgentsPage: FC = () => {
                     >
                       <MessageSquare className="mr-1 size-4" />
                       Chat
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setEditAgent(agent)}
+                      disabled={!canManageAgents}
+                    >
+                      <Pencil className="mr-1 size-4" />
+                      Model
                     </Button>
                     {agent.agentId !== 'main' && (
                       <Button
@@ -913,6 +1002,56 @@ export const AgentsPage: FC = () => {
                 </>
               ) : (
                 'Create Agent'
+              )}
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={!!editAgent}
+        onOpenChange={(open) => {
+          if (!open) closeEditDialog()
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Update Agent Model</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4 py-2">
+            <div className="space-y-1">
+              <p className="font-medium text-sm">{editAgent?.name}</p>
+              <p className="text-muted-foreground text-xs">
+                Current model:{' '}
+                {getModelDisplayName(editAgent?.model) ?? 'Using default'}
+              </p>
+            </div>
+
+            <ProviderSelector
+              providers={compatibleProviders}
+              defaultProviderId={defaultProviderId}
+              selectedId={editProviderId}
+              onSelect={setEditProviderId}
+            />
+
+            <Button
+              onClick={handleUpdate}
+              disabled={
+                !editAgent ||
+                !editProviderId ||
+                updating ||
+                !canManageAgents ||
+                compatibleProviders.length === 0
+              }
+              className="w-full"
+            >
+              {updating ? (
+                <>
+                  <Loader2 className="mr-2 size-4 animate-spin" />
+                  Updating...
+                </>
+              ) : (
+                'Update Model'
               )}
             </Button>
           </div>

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -253,6 +253,28 @@ function getDefaultCompatibleProviderId(
   )
 }
 
+function deriveOpenClawProviderId(
+  provider: Pick<OpenClawProviderOption, 'type' | 'name' | 'baseUrl'>,
+): string {
+  const source =
+    provider.name.trim() || provider.baseUrl?.trim() || provider.type
+  const candidate = source
+    .toLowerCase()
+    .replace(/^https?:\/\//, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+
+  return candidate || 'custom-provider'
+}
+
+function getProviderModelRefs(provider: OpenClawProviderOption): string[] {
+  if (provider.type === 'openai-compatible') {
+    return [`${deriveOpenClawProviderId(provider)}/${provider.modelId}`]
+  }
+
+  return [`${provider.type}/${provider.modelId}`]
+}
+
 function getProviderIdForAgentModel(
   model: unknown,
   providers: OpenClawProviderOption[],
@@ -262,10 +284,9 @@ function getProviderIdForAgentModel(
     return getDefaultCompatibleProviderId(providers, defaultProviderId)
   }
 
-  const matchingProvider = providers.find((provider) => {
-    const builtInModelRef = `${provider.type}/${provider.modelId}`
-    return model === builtInModelRef || model.endsWith(`/${provider.modelId}`)
-  })
+  const matchingProvider = providers.find((provider) =>
+    getProviderModelRefs(provider).includes(model),
+  )
 
   return (
     matchingProvider?.id ??

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/useOpenClaw.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/useOpenClaw.ts
@@ -51,6 +51,15 @@ export interface OpenClawSetupInput {
   modelId?: string
 }
 
+export interface OpenClawAgentUpdateInput {
+  agentId: string
+  providerType?: string
+  providerName?: string
+  baseUrl?: string
+  apiKey?: string
+  modelId?: string
+}
+
 export function getModelDisplayName(model: unknown): string | undefined {
   if (typeof model === 'string') return model.split('/').pop()
   return undefined
@@ -199,6 +208,26 @@ export function useOpenClawMutations() {
     onSuccess,
   })
 
+  const updateMutation = useMutation({
+    mutationFn: async (input: OpenClawAgentUpdateInput) =>
+      clawFetch<{ agent: AgentEntry }>(
+        ensureBaseUrl(),
+        `/agents/${input.agentId}`,
+        {
+          method: 'PATCH',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            providerType: input.providerType,
+            providerName: input.providerName,
+            baseUrl: input.baseUrl,
+            apiKey: input.apiKey,
+            modelId: input.modelId,
+          }),
+        },
+      ),
+    onSuccess,
+  })
+
   const startMutation = useMutation({
     mutationFn: async () =>
       clawFetch<{ status: string }>(ensureBaseUrl(), '/start', {
@@ -242,6 +271,7 @@ export function useOpenClawMutations() {
     setupOpenClaw: setupMutation.mutateAsync,
     createAgent: createMutation.mutateAsync,
     deleteAgent: deleteMutation.mutateAsync,
+    updateAgent: updateMutation.mutateAsync,
     startOpenClaw: startMutation.mutateAsync,
     stopOpenClaw: stopMutation.mutateAsync,
     restartOpenClaw: restartMutation.mutateAsync,
@@ -250,6 +280,7 @@ export function useOpenClawMutations() {
       setupMutation.isPending ||
       createMutation.isPending ||
       deleteMutation.isPending ||
+      updateMutation.isPending ||
       startMutation.isPending ||
       stopMutation.isPending ||
       restartMutation.isPending ||
@@ -257,6 +288,7 @@ export function useOpenClawMutations() {
     settingUp: setupMutation.isPending,
     creating: createMutation.isPending,
     deleting: deleteMutation.isPending,
+    updating: updateMutation.isPending,
     reconnecting: reconnectMutation.isPending,
     pendingGatewayAction,
   }

--- a/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
@@ -17,6 +17,7 @@ import type { MonitoringChatTurn } from '../../monitoring/types'
 import {
   OpenClawAgentAlreadyExistsError,
   OpenClawAgentNotFoundError,
+  OpenClawInvalidAgentModelError,
   OpenClawInvalidAgentNameError,
   OpenClawProtectedAgentError,
 } from '../services/openclaw/errors'
@@ -26,6 +27,19 @@ import { getOpenClawService } from '../services/openclaw/openclaw-service'
 function getCreateAgentValidationError(body: { name?: string }): string | null {
   if (!body.name?.trim()) {
     return 'Name is required'
+  }
+  return null
+}
+
+function getUpdateAgentValidationError(body: {
+  providerType?: string
+  modelId?: string
+}): string | null {
+  if (!body.providerType?.trim()) {
+    return 'providerType is required'
+  }
+  if (!body.modelId?.trim()) {
+    return 'modelId is required'
   }
   return null
 }
@@ -196,6 +210,45 @@ export function createOpenClawRoutes() {
           return c.json({ error: err.message }, 409)
         }
         if (err instanceof OpenClawInvalidAgentNameError) {
+          return c.json({ error: err.message }, 400)
+        }
+        if (isUnsupportedOpenClawProviderError(err)) {
+          return c.json({ error: err.message }, 400)
+        }
+        const message = err instanceof Error ? err.message : String(err)
+        return c.json({ error: message }, 500)
+      }
+    })
+
+    .patch('/agents/:id', async (c) => {
+      const { id } = c.req.param()
+      const body = await c.req.json<{
+        providerType?: string
+        providerName?: string
+        baseUrl?: string
+        apiKey?: string
+        modelId?: string
+      }>()
+      const validationError = getUpdateAgentValidationError(body)
+      if (validationError) {
+        return c.json({ error: validationError }, 400)
+      }
+
+      try {
+        const agent = await getOpenClawService().updateAgent({
+          agentId: id,
+          providerType: body.providerType,
+          providerName: body.providerName,
+          baseUrl: body.baseUrl,
+          apiKey: body.apiKey,
+          modelId: body.modelId,
+        })
+        return c.json({ agent })
+      } catch (err) {
+        if (err instanceof OpenClawAgentNotFoundError) {
+          return c.json({ error: err.message }, 404)
+        }
+        if (err instanceof OpenClawInvalidAgentModelError) {
           return c.json({ error: err.message }, 400)
         }
         if (isUnsupportedOpenClawProviderError(err)) {

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/errors.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/errors.ts
@@ -21,6 +21,13 @@ export class OpenClawAgentNotFoundError extends Error {
   }
 }
 
+export class OpenClawInvalidAgentModelError extends Error {
+  constructor() {
+    super('A provider-backed model selection is required to update an agent')
+    this.name = 'OpenClawInvalidAgentModelError'
+  }
+}
+
 export class OpenClawProtectedAgentError extends Error {
   constructor(message: string) {
     super(message)

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-client.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-client.ts
@@ -24,6 +24,12 @@ interface RawAgentRecord {
   model?: string
 }
 
+interface RawConfiguredAgentRecord {
+  id?: string
+  name?: string
+  model?: string | { primary?: string; fallbacks?: string[] }
+}
+
 export interface OpenClawAgentRecord {
   agentId: string
   name: string
@@ -183,6 +189,40 @@ export class OpenClawCliClient {
     return agent
   }
 
+  async updateAgentModel(input: {
+    agentId: string
+    model: string
+  }): Promise<OpenClawAgentRecord> {
+    const agents = this.extractConfiguredAgents(
+      await this.getConfig('agents.list'),
+    )
+    const agentIndex = agents.findIndex((agent) =>
+      isConfiguredAgentId(agent, input.agentId),
+    )
+
+    if (agentIndex === -1) {
+      throw new Error(`Agent "${input.agentId}" not found in OpenClaw config`)
+    }
+
+    const nextModel = buildUpdatedAgentModel(agents[agentIndex]?.model, {
+      primary: input.model,
+    })
+
+    await this.setConfig(`agents.list[${agentIndex}].model`, nextModel)
+
+    const updatedAgents = await this.listAgents()
+    const updatedAgent = updatedAgents.find(
+      (agent) => agent.agentId === input.agentId,
+    )
+    if (!updatedAgent) {
+      throw new Error(
+        `Updated agent ${input.agentId} was not found in agent list`,
+      )
+    }
+
+    return updatedAgent
+  }
+
   async deleteAgent(agentId: string): Promise<void> {
     await this.runCommand(['agents', 'delete', agentId, '--force', '--json'])
   }
@@ -219,6 +259,35 @@ export class OpenClawCliClient {
   > {
     const output = await this.runCommand(['agents', 'list', '--json'])
     return parseAgentListOutput(output)
+  }
+
+  private extractConfiguredAgents(value: unknown): RawConfiguredAgentRecord[] {
+    if (Array.isArray(value) && value.every(isRawConfiguredAgentRecord)) {
+      return value
+    }
+
+    if (!isPlainObject(value)) {
+      throw new Error('Failed to read OpenClaw configured agents')
+    }
+
+    if (
+      'agents' in value &&
+      isPlainObject(value.agents) &&
+      Array.isArray(value.agents.list) &&
+      value.agents.list.every(isRawConfiguredAgentRecord)
+    ) {
+      return value.agents.list
+    }
+
+    if (
+      'list' in value &&
+      Array.isArray(value.list) &&
+      value.list.every(isRawConfiguredAgentRecord)
+    ) {
+      return value.list
+    }
+
+    throw new Error('Failed to read OpenClaw configured agents')
   }
 }
 
@@ -390,6 +459,52 @@ function isRawAgentRecord(value: unknown): value is RawAgentRecord {
     typeof value.workspace === 'string' &&
     (value.name === undefined || typeof value.name === 'string') &&
     (value.model === undefined || typeof value.model === 'string')
+  )
+}
+
+function isRawConfiguredAgentRecord(
+  value: unknown,
+): value is RawConfiguredAgentRecord {
+  return (
+    isPlainObject(value) &&
+    (value.id === undefined || typeof value.id === 'string') &&
+    (value.name === undefined || typeof value.name === 'string') &&
+    (value.model === undefined ||
+      typeof value.model === 'string' ||
+      isModelConfigObject(value.model))
+  )
+}
+
+function isConfiguredAgentId(
+  value: RawConfiguredAgentRecord,
+  agentId: string,
+): boolean {
+  return value.id === agentId || value.name === agentId
+}
+
+function buildUpdatedAgentModel(
+  current: RawConfiguredAgentRecord['model'],
+  input: { primary: string },
+): string | { primary: string; fallbacks?: string[] } {
+  if (isModelConfigObject(current)) {
+    return {
+      ...current,
+      primary: input.primary,
+    }
+  }
+
+  return input.primary
+}
+
+function isModelConfigObject(
+  value: unknown,
+): value is { primary?: string; fallbacks?: string[] } {
+  return (
+    isPlainObject(value) &&
+    (value.primary === undefined || typeof value.primary === 'string') &&
+    (value.fallbacks === undefined ||
+      (Array.isArray(value.fallbacks) &&
+        value.fallbacks.every((entry) => typeof entry === 'string')))
   )
 }
 

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-client.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-client.ts
@@ -204,15 +204,20 @@ export class OpenClawCliClient {
       throw new Error(`Agent "${input.agentId}" not found in OpenClaw config`)
     }
 
-    const nextModel = buildUpdatedAgentModel(agents[agentIndex]?.model, {
+    const configuredAgent = agents[agentIndex]
+    const nextModel = buildUpdatedAgentModel(configuredAgent?.model, {
       primary: input.model,
     })
 
     await this.setConfig(`agents.list[${agentIndex}].model`, nextModel)
 
+    const configuredAgentIds = getConfiguredAgentIds(
+      configuredAgent,
+      input.agentId,
+    )
     const updatedAgents = await this.listAgents()
-    const updatedAgent = updatedAgents.find(
-      (agent) => agent.agentId === input.agentId,
+    const updatedAgent = updatedAgents.find((agent) =>
+      hasConfiguredAgentId(agent, configuredAgentIds),
     )
     if (!updatedAgent) {
       throw new Error(
@@ -480,6 +485,21 @@ function isConfiguredAgentId(
   agentId: string,
 ): boolean {
   return value.id === agentId || value.name === agentId
+}
+
+function getConfiguredAgentIds(
+  value: RawConfiguredAgentRecord | undefined,
+  fallback: string,
+): string[] {
+  const ids = [value?.id, value?.name, fallback]
+  return [...new Set(ids.filter((entry): entry is string => !!entry))]
+}
+
+function hasConfiguredAgentId(
+  value: OpenClawAgentRecord,
+  ids: string[],
+): boolean {
+  return ids.includes(value.agentId) || ids.includes(value.name)
 }
 
 function buildUpdatedAgentModel(

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -25,6 +25,7 @@ import {
 import {
   OpenClawAgentAlreadyExistsError,
   OpenClawAgentNotFoundError,
+  OpenClawInvalidAgentModelError,
   OpenClawInvalidAgentNameError,
   OpenClawProtectedAgentError,
 } from './errors'
@@ -548,6 +549,65 @@ export class OpenClawService {
     return agent
   }
 
+  async updateAgent(input: {
+    agentId: string
+    providerType?: string
+    providerName?: string
+    baseUrl?: string
+    apiKey?: string
+    modelId?: string
+  }): Promise<OpenClawAgentEntry> {
+    logger.debug('Updating OpenClaw agent model', {
+      agentId: input.agentId,
+      providerType: input.providerType,
+      providerName: input.providerName,
+      hasBaseUrl: !!input.baseUrl,
+      hasModel: !!input.modelId,
+      hasApiKey: !!input.apiKey,
+    })
+    await this.assertGatewayReady()
+
+    const existingAgent = await this.runControlPlaneCall(() =>
+      this.cliClient.listAgents(),
+    ).then((agents) => agents.find((agent) => agent.agentId === input.agentId))
+    if (!existingAgent) {
+      throw new OpenClawAgentNotFoundError(input.agentId)
+    }
+
+    const provider = resolveSupportedOpenClawProvider(input)
+    if (!provider.model) {
+      throw new OpenClawInvalidAgentModelError()
+    }
+
+    const configChanged = await this.mergeProviderConfigIfChanged(provider)
+    const keysChanged = await this.writeStateEnv(provider.envValues)
+
+    if (configChanged || keysChanged) {
+      logger.info('OpenClaw provider config changed while updating agent', {
+        agentId: input.agentId,
+        configChanged,
+        keysChanged,
+      })
+      await this.restart()
+    }
+
+    const agent = await this.runControlPlaneCall(() =>
+      this.applyCliMutation(() =>
+        this.cliClient.updateAgentModel({
+          agentId: input.agentId,
+          model: provider.model as string,
+        }),
+      ),
+    )
+
+    logger.info('Agent model updated via CLI', {
+      agentId: agent.agentId,
+      model: provider.model,
+      providerType: input.providerType,
+    })
+    return agent
+  }
+
   async removeAgent(agentId: string): Promise<void> {
     logger.info('Removing OpenClaw agent', { agentId })
     if (agentId === 'main') {
@@ -967,14 +1027,14 @@ export class OpenClawService {
     return entries
   }
 
-  private async applyCliMutation(action: () => Promise<void>): Promise<void> {
+  private async applyCliMutation<T>(action: () => Promise<T>): Promise<T> {
     let retried = false
 
     while (true) {
       try {
-        await action()
+        const result = await action()
         await this.waitForGatewayAfterCliMutation()
-        return
+        return result
       } catch (error) {
         if (!this.isRestartInterruptedCliMutation(error) || retried) {
           throw error

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -578,6 +578,7 @@ export class OpenClawService {
     if (!provider.model) {
       throw new OpenClawInvalidAgentModelError()
     }
+    const model = provider.model
 
     const configChanged = await this.mergeProviderConfigIfChanged(provider)
     const keysChanged = await this.writeStateEnv(provider.envValues)
@@ -595,14 +596,14 @@ export class OpenClawService {
       this.applyCliMutation(() =>
         this.cliClient.updateAgentModel({
           agentId: input.agentId,
-          model: provider.model as string,
+          model,
         }),
       ),
     )
 
     logger.info('Agent model updated via CLI', {
       agentId: agent.agentId,
-      model: provider.model,
+      model,
       providerType: input.providerType,
     })
     return agent

--- a/packages/browseros-agent/apps/server/tests/api/routes/openclaw.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/openclaw.test.ts
@@ -365,6 +365,45 @@ describe('createOpenClawRoutes', () => {
     })
   })
 
+  it('maps invalid agent model updates to 400', async () => {
+    const actualOpenClawService = await import(
+      '../../../src/api/services/openclaw/openclaw-service'
+    )
+    const actualErrors = await import(
+      '../../../src/api/services/openclaw/errors'
+    )
+    const updateAgent = mock(async () => {
+      throw new actualErrors.OpenClawInvalidAgentModelError()
+    })
+
+    mock.module('../../../src/api/services/openclaw/openclaw-service', () => ({
+      ...actualOpenClawService,
+      getOpenClawService: () =>
+        ({
+          updateAgent,
+        }) as never,
+    }))
+
+    const { createOpenClawRoutes } = await import(
+      '../../../src/api/routes/openclaw'
+    )
+    const route = createOpenClawRoutes()
+
+    const response = await route.request('/agents/research', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        providerType: 'openai',
+        modelId: 'gpt-5.4-mini',
+      }),
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'A provider-backed model selection is required to update an agent',
+    })
+  })
+
   it('does not expose a roles route', async () => {
     const { createOpenClawRoutes } = await import(
       '../../../src/api/routes/openclaw'

--- a/packages/browseros-agent/apps/server/tests/api/routes/openclaw.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/openclaw.test.ts
@@ -253,6 +253,118 @@ describe('createOpenClawRoutes', () => {
     })
   })
 
+  it('updates an existing agent model through the agent route', async () => {
+    const actualOpenClawService = await import(
+      '../../../src/api/services/openclaw/openclaw-service'
+    )
+    const updateAgent = mock(async () => ({
+      agentId: 'research',
+      name: 'research',
+      workspace: '/home/node/.openclaw/workspace-research',
+      model: 'openai/gpt-5.4-mini',
+    }))
+
+    mock.module('../../../src/api/services/openclaw/openclaw-service', () => ({
+      ...actualOpenClawService,
+      getOpenClawService: () =>
+        ({
+          updateAgent,
+        }) as never,
+    }))
+
+    const { createOpenClawRoutes } = await import(
+      '../../../src/api/routes/openclaw'
+    )
+    const route = createOpenClawRoutes()
+
+    const response = await route.request('/agents/research', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        providerType: 'openai',
+        apiKey: 'sk-test',
+        modelId: 'gpt-5.4-mini',
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(updateAgent).toHaveBeenCalledWith({
+      agentId: 'research',
+      providerType: 'openai',
+      providerName: undefined,
+      baseUrl: undefined,
+      apiKey: 'sk-test',
+      modelId: 'gpt-5.4-mini',
+    })
+    expect(await response.json()).toEqual({
+      agent: {
+        agentId: 'research',
+        name: 'research',
+        workspace: '/home/node/.openclaw/workspace-research',
+        model: 'openai/gpt-5.4-mini',
+      },
+    })
+  })
+
+  it('rejects agent model updates without a provider type', async () => {
+    const { createOpenClawRoutes } = await import(
+      '../../../src/api/routes/openclaw'
+    )
+    const route = createOpenClawRoutes()
+
+    const response = await route.request('/agents/research', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        modelId: 'gpt-5.4-mini',
+      }),
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({
+      error: 'providerType is required',
+    })
+  })
+
+  it('maps missing agents to 404 on model update', async () => {
+    const actualOpenClawService = await import(
+      '../../../src/api/services/openclaw/openclaw-service'
+    )
+    const actualErrors = await import(
+      '../../../src/api/services/openclaw/errors'
+    )
+    const updateAgent = mock(async () => {
+      throw new actualErrors.OpenClawAgentNotFoundError('missing')
+    })
+
+    mock.module('../../../src/api/services/openclaw/openclaw-service', () => ({
+      ...actualOpenClawService,
+      getOpenClawService: () =>
+        ({
+          updateAgent,
+        }) as never,
+    }))
+
+    const { createOpenClawRoutes } = await import(
+      '../../../src/api/routes/openclaw'
+    )
+    const route = createOpenClawRoutes()
+
+    const response = await route.request('/agents/missing', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        providerType: 'openai',
+        modelId: 'gpt-5.4-mini',
+      }),
+    })
+
+    expect(response.status).toBe(404)
+    expect(await response.json()).toEqual({
+      error: 'Agent "missing" not found',
+    })
+  })
+
   it('does not expose a roles route', async () => {
     const { createOpenClawRoutes } = await import(
       '../../../src/api/routes/openclaw'

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-cli-client.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-cli-client.test.ts
@@ -157,6 +157,141 @@ describe('OpenClawCliClient', () => {
     })
   })
 
+  it('updates an existing agent model through config set', async () => {
+    let callIndex = 0
+    const execInContainer = mock(
+      async (command: string[], onLog?: (line: string) => void) => {
+        callIndex += 1
+
+        if (callIndex === 1) {
+          expect(command).toEqual([
+            'node',
+            'dist/index.js',
+            'config',
+            'get',
+            'agents.list',
+          ])
+          onLog?.(
+            JSON.stringify({
+              agents: {
+                list: [
+                  {
+                    id: 'main',
+                    workspace: `${OPENCLAW_CONTAINER_HOME}/workspace`,
+                  },
+                  {
+                    id: 'research',
+                    model: 'openai/gpt-5.4-mini',
+                  },
+                ],
+              },
+            }),
+          )
+          return 0
+        }
+
+        if (callIndex === 2) {
+          expect(command).toEqual([
+            'node',
+            'dist/index.js',
+            'config',
+            'set',
+            'agents.list[1].model',
+            'openrouter/anthropic/claude-sonnet-4.5',
+          ])
+          return 0
+        }
+
+        onLog?.(
+          JSON.stringify([
+            {
+              id: 'main',
+              workspace: `${OPENCLAW_CONTAINER_HOME}/workspace`,
+            },
+            {
+              id: 'research',
+              workspace: `${OPENCLAW_CONTAINER_HOME}/workspace-research`,
+              model: 'openrouter/anthropic/claude-sonnet-4.5',
+            },
+          ]),
+        )
+        return 0
+      },
+    )
+
+    const client = new OpenClawCliClient({ execInContainer })
+    const agent = await client.updateAgentModel({
+      agentId: 'research',
+      model: 'openrouter/anthropic/claude-sonnet-4.5',
+    })
+
+    expect(execInContainer).toHaveBeenCalledTimes(3)
+    expect(agent).toEqual({
+      agentId: 'research',
+      name: 'research',
+      workspace: `${OPENCLAW_CONTAINER_HOME}/workspace-research`,
+      model: 'openrouter/anthropic/claude-sonnet-4.5',
+    })
+  })
+
+  it('preserves existing model fallbacks when updating an agent model', async () => {
+    let callIndex = 0
+    const execInContainer = mock(
+      async (command: string[], onLog?: (line: string) => void) => {
+        callIndex += 1
+
+        if (callIndex === 1) {
+          onLog?.(
+            JSON.stringify({
+              list: [
+                {
+                  id: 'research',
+                  model: {
+                    primary: 'openai/gpt-5.4-mini',
+                    fallbacks: ['openai/gpt-5.4-nano'],
+                  },
+                },
+              ],
+            }),
+          )
+          return 0
+        }
+
+        if (callIndex === 2) {
+          expect(command).toEqual([
+            'node',
+            'dist/index.js',
+            'config',
+            'set',
+            'agents.list[0].model',
+            '{"primary":"openrouter/anthropic/claude-sonnet-4.5","fallbacks":["openai/gpt-5.4-nano"]}',
+          ])
+          return 0
+        }
+
+        onLog?.(
+          JSON.stringify([
+            {
+              id: 'research',
+              workspace: `${OPENCLAW_CONTAINER_HOME}/workspace-research`,
+              model: 'openrouter/anthropic/claude-sonnet-4.5',
+            },
+          ]),
+        )
+        return 0
+      },
+    )
+
+    const client = new OpenClawCliClient({ execInContainer })
+
+    await client.updateAgentModel({
+      agentId: 'research',
+      model: 'openrouter/anthropic/claude-sonnet-4.5',
+    })
+
+    expect(execInContainer).toHaveBeenCalledTimes(3)
+  })
+
   it('parses agent lists from mixed log and JSON output', async () => {
     const execInContainer = mock(
       async (_command: string[], onLog?: (line: string) => void) => {

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-cli-client.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-cli-client.test.ts
@@ -292,6 +292,67 @@ describe('OpenClawCliClient', () => {
     expect(execInContainer).toHaveBeenCalledTimes(3)
   })
 
+  it('matches the updated agent by configured name when the config omits id', async () => {
+    let callIndex = 0
+    const execInContainer = mock(
+      async (command: string[], onLog?: (line: string) => void) => {
+        callIndex += 1
+
+        if (callIndex === 1) {
+          onLog?.(
+            JSON.stringify({
+              list: [
+                {
+                  name: 'research',
+                  model: 'openai/gpt-5.4-mini',
+                },
+              ],
+            }),
+          )
+          return 0
+        }
+
+        if (callIndex === 2) {
+          expect(command).toEqual([
+            'node',
+            'dist/index.js',
+            'config',
+            'set',
+            'agents.list[0].model',
+            'openrouter/anthropic/claude-sonnet-4.5',
+          ])
+          return 0
+        }
+
+        onLog?.(
+          JSON.stringify([
+            {
+              id: 'research-1',
+              name: 'research',
+              workspace: `${OPENCLAW_CONTAINER_HOME}/workspace-research`,
+              model: 'openrouter/anthropic/claude-sonnet-4.5',
+            },
+          ]),
+        )
+        return 0
+      },
+    )
+
+    const client = new OpenClawCliClient({ execInContainer })
+    const agent = await client.updateAgentModel({
+      agentId: 'research',
+      model: 'openrouter/anthropic/claude-sonnet-4.5',
+    })
+
+    expect(execInContainer).toHaveBeenCalledTimes(3)
+    expect(agent).toEqual({
+      agentId: 'research-1',
+      name: 'research',
+      workspace: `${OPENCLAW_CONTAINER_HOME}/workspace-research`,
+      model: 'openrouter/anthropic/claude-sonnet-4.5',
+    })
+  })
+
   it('parses agent lists from mixed log and JSON output', async () => {
     const execInContainer = mock(
       async (_command: string[], onLog?: (line: string) => void) => {

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-service.test.ts
@@ -49,6 +49,7 @@ type MutableOpenClawService = OpenClawService & {
     getConfig?: ReturnType<typeof mock>
     listAgents?: ReturnType<typeof mock>
     setDefaultModel?: ReturnType<typeof mock>
+    updateAgentModel?: ReturnType<typeof mock>
   }
   bootstrapCliClient: {
     runOnboard?: ReturnType<typeof mock>
@@ -106,6 +107,122 @@ describe('OpenClawService', () => {
         join(tempDir, '.openclaw', 'workspace-ops', '.browseros-role.json'),
       ),
     ).toBe(false)
+  })
+
+  it('updates an existing agent model through the cli client', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
+    const updateAgentModel = mock(async () => ({
+      agentId: 'ops',
+      name: 'ops',
+      workspace: `${OPENCLAW_CONTAINER_HOME}/workspace-ops`,
+      model: 'openrouter/anthropic/claude-sonnet-4.5',
+    }))
+    const service = new OpenClawService() as MutableOpenClawService
+
+    service.openclawDir = tempDir
+    service.runtime = {
+      isReady: async () => true,
+      waitForReady: mock(async () => true),
+    }
+    service.cliClient = {
+      listAgents: mock(async () => [
+        {
+          agentId: 'ops',
+          name: 'ops',
+          workspace: `${OPENCLAW_CONTAINER_HOME}/workspace-ops`,
+          model: 'openai/gpt-5.4-mini',
+        },
+      ]),
+      updateAgentModel,
+    }
+
+    const agent = await service.updateAgent({
+      agentId: 'ops',
+      providerType: 'openrouter',
+      modelId: 'anthropic/claude-sonnet-4.5',
+    })
+
+    expect(updateAgentModel).toHaveBeenCalledWith({
+      agentId: 'ops',
+      model: 'openrouter/anthropic/claude-sonnet-4.5',
+    })
+    expect(agent).toEqual({
+      agentId: 'ops',
+      name: 'ops',
+      workspace: `${OPENCLAW_CONTAINER_HOME}/workspace-ops`,
+      model: 'openrouter/anthropic/claude-sonnet-4.5',
+    })
+  })
+
+  it('restarts before updating an agent model when provider credentials change', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
+    const restart = mock(async () => {})
+    const updateAgentModel = mock(async () => ({
+      agentId: 'ops',
+      name: 'ops',
+      workspace: `${OPENCLAW_CONTAINER_HOME}/workspace-ops`,
+      model: 'openai/gpt-5.4-mini',
+    }))
+    const service = new OpenClawService() as MutableOpenClawService
+
+    service.openclawDir = tempDir
+    service.restart = restart
+    service.runtime = {
+      isReady: async () => true,
+      waitForReady: mock(async () => true),
+    }
+    service.cliClient = {
+      listAgents: mock(async () => [
+        {
+          agentId: 'ops',
+          name: 'ops',
+          workspace: `${OPENCLAW_CONTAINER_HOME}/workspace-ops`,
+        },
+      ]),
+      updateAgentModel,
+    }
+
+    await service.updateAgent({
+      agentId: 'ops',
+      providerType: 'openai',
+      apiKey: 'sk-openai',
+      modelId: 'gpt-5.4-mini',
+    })
+
+    expect(restart).toHaveBeenCalledTimes(1)
+    expect(updateAgentModel).toHaveBeenCalledWith({
+      agentId: 'ops',
+      model: 'openai/gpt-5.4-mini',
+    })
+  })
+
+  it('rejects updates for unknown agents', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'openclaw-service-'))
+    const updateAgentModel = mock(async () => ({
+      agentId: 'ops',
+      name: 'ops',
+      workspace: `${OPENCLAW_CONTAINER_HOME}/workspace-ops`,
+    }))
+    const service = new OpenClawService() as MutableOpenClawService
+
+    service.openclawDir = tempDir
+    service.runtime = {
+      isReady: async () => true,
+      waitForReady: mock(async () => true),
+    }
+    service.cliClient = {
+      listAgents: mock(async () => []),
+      updateAgentModel,
+    }
+
+    await expect(
+      service.updateAgent({
+        agentId: 'missing',
+        providerType: 'openai',
+        modelId: 'gpt-5.4-mini',
+      }),
+    ).rejects.toThrow('Agent "missing" not found')
+    expect(updateAgentModel).not.toHaveBeenCalled()
   })
 
   it('lists plain agent entries without role metadata', async () => {


### PR DESCRIPTION
## Summary

- Add backend support to update the configured model for an existing OpenClaw agent after the container has already been created.
- Route agent model changes through the OpenClaw service/CLI layer and return the updated agent so the UI refreshes from backend state.
- Reuse the existing provider selector in the Agents page and add automated coverage for the CLI client, service, and route behavior.

## Design

Add a first-class per-agent model update flow across the OpenClaw CLI client, service, route, React mutation, and Agents page. The service resolves the selected BrowserOS provider into an OpenClaw model reference, syncs provider config and env only when needed, restarts only when those provider settings actually change, then updates `agents.list[index].model` through the CLI and returns the refreshed agent entry.

## Test plan

- `bun test apps/server/tests/api/services/openclaw/openclaw-cli-client.test.ts apps/server/tests/api/services/openclaw/openclaw-service.test.ts apps/server/tests/api/routes/openclaw.test.ts`
- `bun run typecheck`
- `bun run test`
