### PR TITLE
feat(openclaw): make podman machine CPUs + memory configurable

### DIFF
--- a/packages/browseros-agent/apps/server/.env.example
+++ b/packages/browseros-agent/apps/server/.env.example
@@ -26,5 +26,9 @@ LOG_LEVEL=info
 # Debug — captures every LLM call to .devtools/generations.json (view with `npx @ai-sdk/devtools`)
 # BROWSEROS_AI_SDK_DEVTOOLS=true
 
+# Podman machine (macOS/Windows VM). No-op on Linux.
+BROWSEROS_PODMAN_CPUS=4
+BROWSEROS_PODMAN_MEMORY_MB=4096
+
 # Testing
 BROWSEROS_TEST_HEADLESS=false

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/podman-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/podman-runtime.ts
@@ -28,7 +28,7 @@ function readPositiveInt(value: string | undefined, fallback: number): number {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
 }
 
-function readMachineResources(): { cpus: number; memoryMb: number } {
+export function readMachineResources(): { cpus: number; memoryMb: number } {
   return {
     cpus: readPositiveInt(
       process.env.BROWSEROS_PODMAN_CPUS,
@@ -114,7 +114,7 @@ export class PodmanRuntime {
     if (isLinux) return
 
     const { cpus, memoryMb } = readMachineResources()
-    onLog?.(`Initializing Podman machine (${cpus} CPUs, ${memoryMb} MB RAM)`)
+    onLog?.(`Allocating ${cpus} CPUs, ${memoryMb} MB RAM`)
 
     const proc = Bun.spawn(
       [

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/podman-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/podman-runtime.ts
@@ -13,11 +13,32 @@ import { join } from 'node:path'
 
 const isLinux = process.platform === 'linux'
 const PODMAN_BUNDLE_PATH = ['bin', 'third_party', 'podman'] as const
+const DEFAULT_MACHINE_CPUS = 4
+const DEFAULT_MACHINE_MEMORY_MB = 4096
 
 export type LogFn = (msg: string) => void
 
 function getPodmanBinaryName(platform: NodeJS.Platform): string {
   return platform === 'win32' ? 'podman.exe' : 'podman'
+}
+
+function readPositiveInt(value: string | undefined, fallback: number): number {
+  if (!value) return fallback
+  const parsed = parseInt(value, 10)
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback
+}
+
+function readMachineResources(): { cpus: number; memoryMb: number } {
+  return {
+    cpus: readPositiveInt(
+      process.env.BROWSEROS_PODMAN_CPUS,
+      DEFAULT_MACHINE_CPUS,
+    ),
+    memoryMb: readPositiveInt(
+      process.env.BROWSEROS_PODMAN_MEMORY_MB,
+      DEFAULT_MACHINE_MEMORY_MB,
+    ),
+  }
 }
 
 export function resolveBundledPodmanPath(
@@ -92,15 +113,18 @@ export class PodmanRuntime {
   async initMachine(onLog?: LogFn): Promise<void> {
     if (isLinux) return
 
+    const { cpus, memoryMb } = readMachineResources()
+    onLog?.(`Initializing Podman machine (${cpus} CPUs, ${memoryMb} MB RAM)`)
+
     const proc = Bun.spawn(
       [
         this.podmanPath,
         'machine',
         'init',
         '--cpus',
-        '8',
+        String(cpus),
         '--memory',
-        '8096',
+        String(memoryMb),
         '--disk-size',
         '10',
       ],

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/podman-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/podman-runtime.test.ts
@@ -12,6 +12,7 @@ import {
   configurePodmanRuntime,
   getPodmanRuntime,
   PodmanRuntime,
+  readMachineResources,
   resolveBundledPodmanPath,
 } from '../../../../src/api/services/openclaw/podman-runtime'
 
@@ -167,3 +168,46 @@ describe('podman runtime', () => {
     expect(runtime.startCalls).toBe(1)
   })
 })
+
+describe('readMachineResources', () => {
+  const ORIGINAL_CPUS = process.env.BROWSEROS_PODMAN_CPUS
+  const ORIGINAL_MEMORY = process.env.BROWSEROS_PODMAN_MEMORY_MB
+
+  afterEach(() => {
+    restoreEnv('BROWSEROS_PODMAN_CPUS', ORIGINAL_CPUS)
+    restoreEnv('BROWSEROS_PODMAN_MEMORY_MB', ORIGINAL_MEMORY)
+  })
+
+  it('returns defaults when env vars are unset', () => {
+    delete process.env.BROWSEROS_PODMAN_CPUS
+    delete process.env.BROWSEROS_PODMAN_MEMORY_MB
+
+    expect(readMachineResources()).toEqual({ cpus: 4, memoryMb: 4096 })
+  })
+
+  it('parses valid env values', () => {
+    process.env.BROWSEROS_PODMAN_CPUS = '6'
+    process.env.BROWSEROS_PODMAN_MEMORY_MB = '8192'
+
+    expect(readMachineResources()).toEqual({ cpus: 6, memoryMb: 8192 })
+  })
+
+  it('falls back to defaults for non-numeric input', () => {
+    process.env.BROWSEROS_PODMAN_CPUS = 'abc'
+    process.env.BROWSEROS_PODMAN_MEMORY_MB = ''
+
+    expect(readMachineResources()).toEqual({ cpus: 4, memoryMb: 4096 })
+  })
+
+  it('falls back to defaults for zero and negative values', () => {
+    process.env.BROWSEROS_PODMAN_CPUS = '0'
+    process.env.BROWSEROS_PODMAN_MEMORY_MB = '-512'
+
+    expect(readMachineResources()).toEqual({ cpus: 4, memoryMb: 4096 })
+  })
+})
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[key]
+  else process.env[key] = value
+}


### PR DESCRIPTION
## Summary

- `podman machine init` previously hardcoded **8 CPUs / 8096 MB RAM**, which over-allocates on 16 GB dev laptops and forced devs to re-init the machine by hand.
- Exposes two env vars — `BROWSEROS_PODMAN_CPUS` and `BROWSEROS_PODMAN_MEMORY_MB` — read at init time.
- Lowers defaults to **4 CPUs / 4096 MB** so a fresh `ensureReady()` boots a machine that runs the gateway comfortably without starving the host.

## Design

Values are read directly inside `initMachine()` via a small helper (`readMachineResources()`) rather than threaded through `configurePodmanRuntime()`. Rationale: the two values are only consumed at one call site, `configurePodmanRuntime` already has two callers (`main.ts` + `openclaw-service.applyPodmanOverrides`), and plumbing them through both would be churn without a testability win — the existing `FakePodmanRuntime` already overrides `initMachine` entirely. Invalid or non-positive env values fall back to defaults so malformed config never reaches the CLI. Linux path is unchanged (machine init is a no-op there). Disk size stays at 10 GB — not in scope.

`.env.example` documents both vars under a "Podman machine (macOS/Windows VM)" section. `.env.development` is gitignored; devs copy from the example.

## Test plan

- [x] `bun x @biomejs/biome check` on changed files — clean
- [x] `bun run typecheck` — all workspace packages pass
- [x] `bun test apps/server/tests/api/services/openclaw/` — 80/80 tests pass (9 in `podman-runtime.test.ts`)
- [ ] On macOS: `rm -rf ~/.local/share/containers/podman/machine/applehv/*` (or destroy the existing machine), set `BROWSEROS_PODMAN_CPUS=2` + `BROWSEROS_PODMAN_MEMORY_MB=2048`, start the server, confirm the init log line shows the configured values and `podman machine inspect` reflects them.
- [ ] On Linux: start the server, confirm init still no-ops (no CLI spawned, no log line).
- [ ] With `BROWSEROS_PODMAN_CPUS=abc` (malformed), confirm default `4` is used.