### PR TITLE
fix: address Greptile comments from WS3 Lima uploader PR

### DIFF
--- a/packages/browseros/build/cli/storage.py
+++ b/packages/browseros/build/cli/storage.py
@@ -96,7 +96,8 @@ def upload_lima(
                 )
                 tarball_shas[arch.internal] = tarball_sha
                 object_shas[arch.internal] = object_sha
-                uploaded_keys.append(r2_key)
+                if not dry_run:
+                    uploaded_keys.append(r2_key)
 
             manifest = _build_manifest(tag, tarball_shas, object_shas)
             _upload_manifest(client, env, manifest, tmp_dir, dry_run)
@@ -217,7 +218,9 @@ def _build_manifest(
         "tarball_shas_upstream": tarball_shas,
         "r2_object_shas": object_shas,
         "uploaded_at": datetime.now(timezone.utc).isoformat(),
-        "uploaded_by": os.environ.get("USER") or os.environ.get("USERNAME") or "unknown",
+        # Prefer CI context so we don't leak an individual's OS login when
+        # running locally. manifest.json is surfaced via the public CDN.
+        "uploaded_by": os.environ.get("GITHUB_ACTOR") or "local",
     }
 
 

--- a/packages/browseros/build/common/server_binaries_test.py
+++ b/packages/browseros/build/common/server_binaries_test.py
@@ -61,14 +61,16 @@ class WindowsServerBinariesTest(unittest.TestCase):
         for rel, abs_path in zip(WINDOWS_SERVER_BINARIES, resolved):
             self.assertEqual(abs_path, root / rel)
 
-    def test_windows_has_no_podman(self):
+    def test_windows_has_no_stale_third_party(self):
         forbidden = {
             "third_party/podman/podman.exe",
             "third_party/podman/gvproxy.exe",
             "third_party/podman/win-sshproxy.exe",
+            "third_party/bun.exe",
+            "third_party/rg.exe",
         }
         leftover = forbidden & set(WINDOWS_SERVER_BINARIES)
-        self.assertFalse(leftover, f"podman-era entries still present: {leftover}")
+        self.assertFalse(leftover, f"stale entries still present: {leftover}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Follow-up to #778 — applies the three Greptile suggestions that were pushed after the squash-merge:

- **`storage.py`** — guard `uploaded_keys.append(r2_key)` with `if not dry_run` so the rollback list never carries keys for objects that were never written. Prevents latent bugs if the rollback guard is later moved.
- **`storage.py`** — `manifest.json::uploaded_by` now prefers `GITHUB_ACTOR`, falling back to `"local"`. Avoids leaking an individual's OS login via the CDN-fronted manifest.
- **`server_binaries_test.py`** — rename `test_windows_has_no_podman` → `test_windows_has_no_stale_third_party` and extend the forbidden set to also cover `bun.exe` / `rg.exe` (removed in the landing PR), matching the macOS forbidden-set pattern.

## Test plan

- [x] `uv run python -m unittest discover -s build -p "*_test.py"` — 23 tests pass
- [x] No runtime behavior changes from #778; only hardening + a test assertion broadening