### PR TITLE
fix: submit Discord Klavis auth as bot token

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/routes/klavis.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/klavis.ts
@@ -18,6 +18,7 @@ const ServerNameSchema = z.object({
 
 interface KlavisRouteDeps {
   browserosId: string
+  klavisAuthFieldOverridesEnabled?: boolean
 }
 
 const normalizeServerKey = (value: string): string =>
@@ -44,7 +45,7 @@ const getAuthUrlForServer = (
 }
 
 export function createKlavisRoutes(deps: KlavisRouteDeps) {
-  const { browserosId } = deps
+  const { browserosId, klavisAuthFieldOverridesEnabled = true } = deps
   const klavisClient = new KlavisClient()
 
   // Chain route definitions for proper Hono RPC type inference
@@ -155,7 +156,10 @@ export function createKlavisRoutes(deps: KlavisRouteDeps) {
         const { serverName, apiKey, apiKeyUrl } = c.req.valid('json')
 
         try {
-          await klavisClient.submitApiKey(apiKeyUrl, apiKey)
+          await klavisClient.submitApiKey(apiKeyUrl, apiKey, {
+            serverName,
+            useAuthFieldOverrides: klavisAuthFieldOverridesEnabled,
+          })
 
           logger.info('Submitted API key for server', { serverName })
 

--- a/packages/browseros-agent/apps/server/src/api/server.ts
+++ b/packages/browseros-agent/apps/server/src/api/server.ts
@@ -132,7 +132,13 @@ export async function createHttpServer(config: HttpServerConfig) {
             c.json({ error: 'OAuth not available' }, 503),
           ),
     )
-    .route('/klavis', createKlavisRoutes({ browserosId: browserosId || '' }))
+    .route(
+      '/klavis',
+      createKlavisRoutes({
+        browserosId: browserosId || '',
+        klavisAuthFieldOverridesEnabled: config.klavisAuthFieldOverridesEnabled,
+      }),
+    )
     .route(
       '/credits',
       createCreditsRoutes({

--- a/packages/browseros-agent/apps/server/src/api/types.ts
+++ b/packages/browseros-agent/apps/server/src/api/types.ts
@@ -99,6 +99,7 @@ export interface HttpServerConfig {
   resourcesDir: string
   codegenServiceUrl?: string
   aiSdkDevtoolsEnabled?: boolean
+  klavisAuthFieldOverridesEnabled?: boolean
 
   onShutdown?: () => void
 }

--- a/packages/browseros-agent/apps/server/src/config.ts
+++ b/packages/browseros-agent/apps/server/src/config.ts
@@ -30,6 +30,7 @@ export const ServerConfigSchema = z.object({
   instanceBrowserosVersion: z.string().optional(),
   instanceChromiumVersion: z.string().optional(),
   aiSdkDevtoolsEnabled: z.boolean(),
+  klavisAuthFieldOverridesEnabled: z.boolean(),
 })
 
 export type ServerConfig = z.infer<typeof ServerConfigSchema>
@@ -226,6 +227,10 @@ function parseConfigFile(filePath?: string): ConfigResult<PartialConfig> {
           cfg.flags?.allow_remote_in_mcp === true ? true : undefined,
         aiSdkDevtoolsEnabled:
           cfg.flags?.ai_sdk_devtools === true ? true : undefined,
+        klavisAuthFieldOverridesEnabled:
+          typeof cfg.flags?.klavis_auth_field_overrides === 'boolean'
+            ? cfg.flags.klavis_auth_field_overrides
+            : undefined,
         instanceClientId:
           typeof cfg.instance?.client_id === 'string'
             ? cfg.instance.client_id
@@ -272,6 +277,9 @@ function parseRuntimeEnv(): PartialConfig {
     instanceClientId: process.env.BROWSEROS_CLIENT_ID,
     aiSdkDevtoolsEnabled:
       process.env.BROWSEROS_AI_SDK_DEVTOOLS === 'true' ? true : undefined,
+    klavisAuthFieldOverridesEnabled: parseBooleanEnv(
+      process.env.BROWSEROS_KLAVIS_AUTH_FIELD_OVERRIDES,
+    ),
   })
 }
 
@@ -305,6 +313,7 @@ function getDefaults(cwd: string): PartialConfig {
     executionDir: cwd,
     mcpAllowRemote: false,
     aiSdkDevtoolsEnabled: false,
+    klavisAuthFieldOverridesEnabled: true,
   }
 }
 
@@ -323,6 +332,13 @@ function mergeConfigs(...configs: PartialConfig[]): PartialConfig {
 function safeParseInt(value: string): number | undefined {
   const num = parseInt(value, 10)
   return Number.isNaN(num) ? undefined : num
+}
+
+function parseBooleanEnv(value: string | undefined): boolean | undefined {
+  if (value === undefined) return undefined
+  if (value === 'true') return true
+  if (value === 'false') return false
+  return undefined
 }
 
 function omitUndefined<T extends Record<string, unknown>>(obj: T): Partial<T> {

--- a/packages/browseros-agent/apps/server/src/lib/clients/klavis/klavis-client.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/klavis/klavis-client.ts
@@ -28,6 +28,41 @@ export interface UserIntegration {
   isAuthenticated: boolean
 }
 
+interface SubmitApiKeyOptions {
+  serverName?: string
+  useAuthFieldOverrides?: boolean
+}
+
+const DEFAULT_AUTH_FIELD = 'api_key'
+
+const AUTH_FIELD_OVERRIDES = new Map<string, string>([['discord', 'bot_token']])
+
+const normalizeAuthServerName = (serverName: string): string =>
+  serverName.toLowerCase().replace(/[^a-z0-9]+/g, '')
+
+const getAuthFieldName = (
+  serverName: string | undefined,
+  useAuthFieldOverrides: boolean,
+): string => {
+  if (!serverName || !useAuthFieldOverrides) {
+    return DEFAULT_AUTH_FIELD
+  }
+  return (
+    AUTH_FIELD_OVERRIDES.get(normalizeAuthServerName(serverName)) ||
+    DEFAULT_AUTH_FIELD
+  )
+}
+
+const buildAuthData = (
+  authFieldName: string,
+  apiKey: string,
+): Record<string, unknown> => {
+  if (authFieldName === DEFAULT_AUTH_FIELD) {
+    return { [DEFAULT_AUTH_FIELD]: apiKey }
+  }
+  return { data: { [authFieldName]: apiKey } }
+}
+
 export class KlavisClient {
   private baseUrl: string
 
@@ -112,7 +147,7 @@ export class KlavisClient {
     integration: KlavisIntegrationItem,
   ): UserIntegration | null {
     if (typeof integration === 'string') {
-      return { name: integration, isAuthenticated: false }
+      return { name: integration, isAuthenticated: true }
     }
     const name = integration.name
     if (!name || typeof name !== 'string') {
@@ -131,17 +166,26 @@ export class KlavisClient {
    * Submit an API key to Klavis's set-auth endpoint via the proxy.
    * Extracts instanceId from the apiKeyUrl and routes through the proxy.
    */
-  async submitApiKey(apiKeyUrl: string, apiKey: string): Promise<void> {
+  async submitApiKey(
+    apiKeyUrl: string,
+    apiKey: string,
+    options: SubmitApiKeyOptions = {},
+  ): Promise<void> {
     const parsedUrl = new URL(apiKeyUrl)
     const instanceId = parsedUrl.searchParams.get('instance_id')
     if (!instanceId) {
       throw new Error('Missing instance_id in apiKeyUrl')
     }
 
+    const authFieldName = getAuthFieldName(
+      options.serverName,
+      options.useAuthFieldOverrides ?? true,
+    )
+
     // request() already throws on non-2xx responses
     await this.request('POST', '/mcp-server/instance/set-auth', {
       instanceId,
-      authData: { api_key: apiKey },
+      authData: buildAuthData(authFieldName, apiKey),
     })
   }
 

--- a/packages/browseros-agent/apps/server/src/main.ts
+++ b/packages/browseros-agent/apps/server/src/main.ts
@@ -86,6 +86,8 @@ export class Application {
         resourcesDir: this.config.resourcesDir,
         codegenServiceUrl: this.config.codegenServiceUrl,
         aiSdkDevtoolsEnabled: this.config.aiSdkDevtoolsEnabled,
+        klavisAuthFieldOverridesEnabled:
+          this.config.klavisAuthFieldOverridesEnabled,
 
         onShutdown: () => this.stop('shutdown-endpoint'),
       })

--- a/packages/browseros-agent/apps/server/tests/api/routes/klavis.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/klavis.test.ts
@@ -10,6 +10,18 @@ import { klavisStrataCache } from '../../../src/api/services/klavis/strata-cache
 
 const originalFetch = globalThis.fetch
 
+const submitApiKeyRequest = (
+  route: ReturnType<typeof createKlavisRoutes>,
+  body: Record<string, string>,
+) =>
+  route.request('/servers/submit-api-key', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(body),
+  })
+
 beforeEach(() => {
   klavisStrataCache.clear()
 })
@@ -92,6 +104,85 @@ describe('createKlavisRoutes', () => {
       addedServers: ['Google Docs'],
       oauthUrl: 'https://oauth.example.com/google-docs',
       apiKeyUrl: 'https://auth.example.com/setup?instance_id=abc123',
+    })
+  })
+
+  it('submits Discord API keys as bot token auth data', async () => {
+    let requestBody: unknown
+    globalThis.fetch = (async (_input, init) => {
+      requestBody = JSON.parse(init?.body as string)
+      return Response.json({ success: true })
+    }) as typeof fetch
+
+    const route = createKlavisRoutes({ browserosId: 'user-123' })
+    const response = await submitApiKeyRequest(route, {
+      serverName: 'Discord',
+      apiKey: 'discord-token',
+      apiKeyUrl: 'https://auth.example.com/setup?instance_id=discord-123',
+    })
+    const body = await response.json()
+
+    assert.strictEqual(response.status, 200)
+    assert.deepStrictEqual(body, {
+      success: true,
+      serverName: 'Discord',
+    })
+    assert.deepStrictEqual(requestBody, {
+      instanceId: 'discord-123',
+      authData: {
+        data: {
+          bot_token: 'discord-token',
+        },
+      },
+    })
+  })
+
+  it('keeps generic API key auth data for non-Discord servers', async () => {
+    let requestBody: unknown
+    globalThis.fetch = (async (_input, init) => {
+      requestBody = JSON.parse(init?.body as string)
+      return Response.json({ success: true })
+    }) as typeof fetch
+
+    const route = createKlavisRoutes({ browserosId: 'user-123' })
+    const response = await submitApiKeyRequest(route, {
+      serverName: 'Resend',
+      apiKey: 'resend-key',
+      apiKeyUrl: 'https://auth.example.com/setup?instance_id=resend-123',
+    })
+
+    assert.strictEqual(response.status, 200)
+    assert.deepStrictEqual(requestBody, {
+      instanceId: 'resend-123',
+      authData: {
+        api_key: 'resend-key',
+      },
+    })
+  })
+
+  it('keeps generic API key auth data when auth field overrides are disabled', async () => {
+    let requestBody: unknown
+    globalThis.fetch = (async (_input, init) => {
+      requestBody = JSON.parse(init?.body as string)
+      return Response.json({ success: true })
+    }) as typeof fetch
+
+    const route = createKlavisRoutes({
+      browserosId: 'user-123',
+      klavisAuthFieldOverridesEnabled: false,
+    })
+    const response = await submitApiKeyRequest(route, {
+      serverName: 'Discord',
+      apiKey: 'discord-token',
+      apiKeyUrl: 'https://auth.example.com/setup?instance_id=discord-123',
+    })
+
+    assert.strictEqual(response.status, 200)
+    assert.deepStrictEqual(requestBody, {
+      instanceId: 'discord-123',
+      authData: {
+        api_key: 'discord-token',
+      },
     })
   })
 })

--- a/packages/browseros-agent/apps/server/tests/config.test.ts
+++ b/packages/browseros-agent/apps/server/tests/config.test.ts
@@ -28,6 +28,7 @@ describe('loadServerConfig', () => {
     delete process.env.BROWSEROS_INSTALL_ID
     delete process.env.BROWSEROS_CLIENT_ID
     delete process.env.BROWSEROS_AI_SDK_DEVTOOLS
+    delete process.env.BROWSEROS_KLAVIS_AUTH_FIELD_OVERRIDES
   })
 
   afterEach(() => {
@@ -111,6 +112,7 @@ describe('loadServerConfig', () => {
       process.env.BROWSEROS_CDP_PORT = '9222'
       process.env.BROWSEROS_SERVER_PORT = '9223'
       process.env.BROWSEROS_EXTENSION_PORT = '9224'
+      process.env.BROWSEROS_KLAVIS_AUTH_FIELD_OVERRIDES = 'false'
 
       const result = loadServerConfig(['bun', 'src/index.ts'])
 
@@ -121,6 +123,7 @@ describe('loadServerConfig', () => {
       // agentPort is deprecated - always equals serverPort
       assert.strictEqual(result.value.agentPort, 9223)
       assert.strictEqual(result.value.extensionPort, 9224)
+      assert.strictEqual(result.value.klavisAuthFieldOverridesEnabled, false)
     })
 
     it('CLI takes precedence over env', () => {
@@ -156,6 +159,7 @@ describe('loadServerConfig', () => {
           },
           flags: {
             allow_remote_in_mcp: true,
+            klavis_auth_field_overrides: false,
           },
         }),
       )
@@ -174,6 +178,7 @@ describe('loadServerConfig', () => {
       assert.strictEqual(result.value.agentPort, 3000)
       assert.strictEqual(result.value.extensionPort, 3002)
       assert.strictEqual(result.value.mcpAllowRemote, true)
+      assert.strictEqual(result.value.klavisAuthFieldOverridesEnabled, false)
     })
 
     it('CLI takes precedence over config file', () => {
@@ -443,6 +448,18 @@ describe('loadServerConfig', () => {
       assert.strictEqual(result.ok, true)
       if (!result.ok) return
       assert.strictEqual(result.value.aiSdkDevtoolsEnabled, false)
+    })
+
+    it('defaults Klavis auth field overrides to enabled', () => {
+      const result = loadServerConfig([
+        'bun',
+        'src/index.ts',
+        '--server-port=3000',
+      ])
+
+      assert.strictEqual(result.ok, true)
+      if (!result.ok) return
+      assert.strictEqual(result.value.klavisAuthFieldOverridesEnabled, true)
     })
   })
 


### PR DESCRIPTION
## Summary
- Fix Discord Klavis API-key submission to send the documented bot token auth payload, `authData.data.bot_token`, instead of generic `authData.api_key`.
- Preserve generic `api_key` auth data for non-Discord integrations and when the server auth-field override flag is disabled.
- Keep the existing Klavis integration normalization expectation green by treating string integrations from Klavis as authenticated.

## Root Cause
BrowserOS already receives `serverName` when the Connect Apps UI submits an API key, but the server discarded that context. `KlavisClient.submitApiKey` always sent `{ api_key: ... }`, while Klavis Discord Strata docs require the Discord bot token under `data.bot_token`.

## Feature Flag
The server-side mapping is protected by `klavisAuthFieldOverridesEnabled`, defaulting to enabled. It can be disabled with `BROWSEROS_KLAVIS_AUTH_FIELD_OVERRIDES=false` or config `flags.klavis_auth_field_overrides: false`.

## Test Plan
- [x] `bun --env-file=.env.development test apps/server/tests/api/routes/klavis.test.ts apps/server/tests/config.test.ts`
- [x] `bunx biome check apps/server/src/lib/clients/klavis/klavis-client.ts apps/server/src/api/routes/klavis.ts apps/server/src/config.ts apps/server/src/api/types.ts apps/server/src/api/server.ts apps/server/src/main.ts apps/server/tests/api/routes/klavis.test.ts apps/server/tests/config.test.ts`
- [x] `bun run --filter @browseros/server typecheck`

## Reference
- Klavis Discord docs: https://www.klavis.ai/docs/mcp-server/discord