### PR TITLE
feat(openclaw): load chat history on agent chat page

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentChat.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentChat.tsx
@@ -22,7 +22,9 @@ import { Textarea } from '@/components/ui/textarea'
 import { consumeSSEStream } from '@/lib/sse'
 import {
   buildChatHistoryFromTurns,
+  type ChatHistoryEntry,
   chatWithAgent,
+  fetchAgentHistory,
   type OpenClawStreamEvent,
 } from './useOpenClaw'
 
@@ -43,6 +45,75 @@ interface ChatTurn {
   userText: string
   parts: AssistantPart[]
   done: boolean
+  source?: string
+}
+
+function cleanUserText(text: string): string {
+  return text
+    .replace(/^\[cron:[^\]]*\]\s*/i, '')
+    .replace(/Current time:.*$/gm, '')
+    .trim()
+}
+
+function historyToTurns(entries: ChatHistoryEntry[]): ChatTurn[] {
+  const sorted = [...entries].sort((a, b) => {
+    const aTs = a.messages[0]?.timestamp ?? 0
+    const bTs = b.messages[0]?.timestamp ?? 0
+    return aTs - bTs
+  })
+
+  const turns: ChatTurn[] = []
+
+  for (const entry of sorted) {
+    // Limit to last 20 messages per session to avoid huge histories
+    const msgs = entry.messages.slice(-20)
+    let current: ChatTurn | null = null
+
+    for (const msg of msgs) {
+      if (msg.role === 'user') {
+        if (current) turns.push(current)
+        const rawText = msg.content
+          .filter((b) => b.type === 'text' && b.text)
+          .map((b) => b.text ?? '')
+          .join('\n')
+
+        const userText = cleanUserText(rawText)
+        if (!userText) {
+          current = null
+          continue
+        }
+
+        current = {
+          id: crypto.randomUUID(),
+          userText,
+          parts: [],
+          done: true,
+          source: entry.session.source,
+        }
+      } else if (msg.role === 'assistant') {
+        // If no current turn (e.g. user message was filtered), create
+        // one without user text — this handles proactive/cron responses
+        if (!current) {
+          current = {
+            id: crypto.randomUUID(),
+            userText: '',
+            parts: [],
+            done: true,
+            source: entry.session.source,
+          }
+        }
+        for (const block of msg.content) {
+          if (block.type === 'text' && block.text) {
+            current.parts.push({ kind: 'text', text: block.text })
+          }
+        }
+      }
+    }
+
+    if (current && current.parts.length > 0) turns.push(current)
+  }
+
+  return turns
 }
 
 interface AgentChatProps {
@@ -59,6 +130,7 @@ export const AgentChat: FC<AgentChatProps> = ({
   const [turns, setTurns] = useState<ChatTurn[]>([])
   const [input, setInput] = useState('')
   const [streaming, setStreaming] = useState(false)
+  const [historyLoaded, setHistoryLoaded] = useState(false)
   const scrollRef = useRef<HTMLDivElement>(null)
   const sessionKeyRef = useRef(crypto.randomUUID())
   const streamAbortRef = useRef<AbortController | null>(null)
@@ -74,6 +146,23 @@ export const AgentChat: FC<AgentChatProps> = ({
   useEffect(() => {
     scrollToBottom()
   }, [turns])
+
+  useEffect(() => {
+    let active = true
+    fetchAgentHistory(agentId)
+      .then((entries) => {
+        if (!active) return
+        const historicTurns = historyToTurns(entries)
+        if (historicTurns.length > 0) setTurns(historicTurns)
+        setHistoryLoaded(true)
+      })
+      .catch(() => {
+        if (active) setHistoryLoaded(true)
+      })
+    return () => {
+      active = false
+    }
+  }, [agentId])
 
   useEffect(() => {
     return () => {
@@ -263,6 +352,22 @@ export const AgentChat: FC<AgentChatProps> = ({
     }
   }
 
+  if (!historyLoaded) {
+    return (
+      <div className="flex h-[calc(100vh-4rem)] flex-col">
+        <div className="flex items-center gap-2 border-b px-4 py-3">
+          <Button variant="ghost" size="icon" onClick={onBack}>
+            <ArrowLeft className="size-4" />
+          </Button>
+          <h2 className="font-semibold text-lg">{agentName}</h2>
+        </div>
+        <div className="flex flex-1 items-center justify-center">
+          <Loader2 className="size-6 animate-spin text-muted-foreground" />
+        </div>
+      </div>
+    )
+  }
+
   return (
     <div className="flex h-[calc(100vh-4rem)] flex-col">
       <div className="flex items-center gap-2 border-b px-4 py-3">
@@ -275,14 +380,27 @@ export const AgentChat: FC<AgentChatProps> = ({
       <div ref={scrollRef} className="flex-1 space-y-4 overflow-y-auto p-4">
         {turns.map((turn) => (
           <div key={turn.id} className="space-y-3">
-            {/* User message */}
-            <Message from="user">
-              <MessageContent>
-                <pre className="whitespace-pre-wrap font-sans text-sm">
-                  {turn.userText}
-                </pre>
-              </MessageContent>
-            </Message>
+            {turn.source &&
+              turn.source !== 'user-chat' &&
+              turn.source !== 'other' && (
+                <div className="mb-1 text-muted-foreground text-xs">
+                  {turn.source === 'cron'
+                    ? 'Scheduled Task'
+                    : turn.source === 'hook'
+                      ? 'Hook'
+                      : turn.source}
+                </div>
+              )}
+            {/* User message (skip if empty — proactive/cron response) */}
+            {turn.userText && (
+              <Message from="user">
+                <MessageContent>
+                  <pre className="whitespace-pre-wrap font-sans text-sm">
+                    {turn.userText}
+                  </pre>
+                </MessageContent>
+              </Message>
+            )}
 
             {/* Assistant response — all parts grouped */}
             {turn.parts.length > 0 && (

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/useOpenClaw.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/useOpenClaw.ts
@@ -361,6 +361,50 @@ export function buildChatHistoryFromTurns(
   return messages
 }
 
+export interface ChatHistoryBlock {
+  type: 'text' | 'toolCall' | 'thinking'
+  text?: string
+  name?: string
+  arguments?: unknown
+  thinking?: string
+}
+
+export interface ChatHistoryMessage {
+  role: 'user' | 'assistant' | 'toolResult'
+  content: ChatHistoryBlock[]
+  timestamp?: number
+  usage?: { input: number; output: number }
+  stopReason?: string
+  toolName?: string
+  isError?: boolean
+}
+
+export interface ChatHistorySession {
+  key: string
+  updatedAt: number
+  sessionId: string
+  agentId: string
+  source: string
+}
+
+export interface ChatHistoryEntry {
+  session: ChatHistorySession
+  messages: ChatHistoryMessage[]
+}
+
+export async function fetchAgentHistory(
+  agentId: string,
+  limit = 10,
+): Promise<ChatHistoryEntry[]> {
+  const baseUrl = await getAgentServerUrl()
+  const res = await fetch(
+    `${baseUrl}/claw/agents/${agentId}/history?limit=${limit}`,
+  )
+  if (!res.ok) return []
+  const data = (await res.json()) as { entries: ChatHistoryEntry[] }
+  return data.entries ?? []
+}
+
 export async function chatWithAgent(
   agentId: string,
   message: string,

--- a/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
@@ -20,8 +20,72 @@ import {
   OpenClawInvalidAgentNameError,
   OpenClawProtectedAgentError,
 } from '../services/openclaw/errors'
+import type { OpenClawChatMessage } from '../services/openclaw/openclaw-cli-client'
 import { isUnsupportedOpenClawProviderError } from '../services/openclaw/openclaw-provider-map'
 import { getOpenClawService } from '../services/openclaw/openclaw-service'
+
+/**
+ * Filter non-user-facing messages from chat.history.
+ *
+ * OpenClaw's session history contains three kinds of noise:
+ *
+ * 1. Context replays — When a new message arrives in an existing session,
+ *    OpenClaw bundles the entire prior conversation into a single user
+ *    message prefixed with "[Chat messages since your last reply]".
+ *    This is internal context for the model, not user input.
+ *
+ * 2. System events — Cron/heartbeat triggers formatted as user messages
+ *    starting with "System: [timestamp]" and containing
+ *    "Handle this reminder internally".
+ *
+ * 3. Heartbeat responses — Assistant messages that are just "HEARTBEAT_OK",
+ *    which is OpenClaw's standard heartbeat acknowledgment token.
+ */
+function filterSystemMessages(
+  messages: OpenClawChatMessage[],
+): OpenClawChatMessage[] {
+  const result: OpenClawChatMessage[] = []
+
+  for (const msg of messages) {
+    const text = msg.content
+      .filter((b) => b.type === 'text')
+      .map((b) => b.text ?? '')
+      .join('')
+      .trim()
+
+    // Skip heartbeat responses
+    if (msg.role === 'assistant' && text.startsWith('HEARTBEAT')) continue
+
+    // Skip system event triggers (cron/heartbeat)
+    if (msg.role === 'user' && text.includes('Handle this reminder internally'))
+      continue
+
+    // Context-replay messages: extract the actual new user message
+    if (
+      msg.role === 'user' &&
+      text.startsWith('[Chat messages since your last reply')
+    ) {
+      const marker = '[Current message - respond to this]'
+      const idx = text.indexOf(marker)
+      if (idx >= 0) {
+        let actual = text.slice(idx + marker.length).trim()
+        // Strip "User: " prefix
+        actual = actual.replace(/^User:\s*/i, '')
+        if (actual) {
+          result.push({
+            ...msg,
+            content: [{ type: 'text', text: actual }],
+          })
+        }
+      }
+      continue
+    }
+
+    result.push(msg)
+  }
+
+  return result
+}
 
 function getCreateAgentValidationError(body: { name?: string }): string | null {
   if (!body.name?.trim()) {
@@ -339,6 +403,52 @@ export function createOpenClawRoutes() {
         if (isUnsupportedOpenClawProviderError(err)) {
           return c.json({ error: err.message }, 400)
         }
+        const message = err instanceof Error ? err.message : String(err)
+        return c.json({ error: message }, 500)
+      }
+    })
+
+    .get('/agents/:id/history', async (c) => {
+      const { id } = c.req.param()
+      const limit = Number(c.req.query('limit')) || 10
+
+      try {
+        const allSessions = await getOpenClawService().listSessions(id)
+        const filtered = allSessions
+          .filter((s) => s.agentId === id || s.key.includes(`agent:${id}:`))
+          .sort((a, b) => b.updatedAt - a.updatedAt)
+          .slice(0, limit)
+
+        const classifySource = (key: string): string => {
+          if (key.includes(':cron:')) return 'cron'
+          if (key.includes(':hook:')) return 'hook'
+          if (key.includes('openai-user:browseros')) return 'user-chat'
+          if (key.includes('qa-channel')) return 'channel'
+          return 'other'
+        }
+
+        const entries = await Promise.all(
+          filtered.map(async (s) => {
+            const source = classifySource(s.key)
+            try {
+              const rawMessages = await getOpenClawService().getChatHistory(
+                s.key,
+              )
+
+              const messages = filterSystemMessages(rawMessages)
+
+              return { session: { ...s, source }, messages }
+            } catch {
+              return { session: { ...s, source }, messages: [] }
+            }
+          }),
+        )
+
+        // Filter out entries with no meaningful messages
+        const nonEmpty = entries.filter((e) => e.messages.length > 0)
+
+        return c.json({ entries: nonEmpty })
+      } catch (err) {
         const message = err instanceof Error ? err.message : String(err)
         return c.json({ error: message }, 500)
       }

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-client.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-client.ts
@@ -31,6 +31,37 @@ export interface OpenClawAgentRecord {
   model?: string
 }
 
+export interface OpenClawSessionEntry {
+  key: string
+  updatedAt: number
+  sessionId: string
+  agentId: string
+  kind: string
+  status?: string
+  totalTokens?: number
+  model?: string
+  modelProvider?: string
+}
+
+export interface OpenClawChatBlock {
+  type: 'text' | 'toolCall' | 'thinking'
+  text?: string
+  name?: string
+  arguments?: unknown
+  thinking?: string
+}
+
+export interface OpenClawChatMessage {
+  role: 'user' | 'assistant' | 'toolResult'
+  content: OpenClawChatBlock[]
+  timestamp?: number
+  usage?: { input: number; output: number }
+  stopReason?: string
+  toolName?: string
+  toolCallId?: string
+  isError?: boolean
+}
+
 export class OpenClawCliClient {
   constructor(private readonly executor: ContainerExecutor) {}
 
@@ -189,6 +220,55 @@ export class OpenClawCliClient {
 
   async probe(): Promise<void> {
     await this.listAgents()
+  }
+
+  async listSessions(agentId?: string): Promise<OpenClawSessionEntry[]> {
+    const args = ['sessions', '--json']
+    if (agentId) {
+      args.push('--agent', agentId)
+    } else {
+      args.push('--all-agents')
+    }
+
+    const output = await this.runCommand(args)
+    const parsed = parseFirstMatchingJson<
+      { sessions?: unknown[]; count?: number } | unknown[]
+    >(output, isSessionListPayload)
+
+    if (parsed === null) {
+      throw new Error(
+        `Failed to parse OpenClaw sessions output: ${output.slice(0, 200)}`,
+      )
+    }
+
+    const entries = Array.isArray(parsed) ? parsed : (parsed.sessions ?? [])
+
+    return entries.map(toSessionEntry)
+  }
+
+  async getChatHistory(sessionKey: string): Promise<OpenClawChatMessage[]> {
+    const output = await this.runCommand([
+      'gateway',
+      'call',
+      'chat.history',
+      '--params',
+      JSON.stringify({ sessionKey }),
+      '--json',
+    ])
+
+    const parsed = parseFirstMatchingJson<{ messages?: unknown[] }>(
+      output,
+      (value) => isPlainObject(value) && 'messages' in value,
+    )
+
+    if (parsed === null) {
+      throw new Error(
+        `Failed to parse OpenClaw chat history output: ${output.slice(0, 200)}`,
+      )
+    }
+
+    const rawMessages = parsed.messages ?? []
+    return rawMessages.map(toChatMessage)
   }
 
   private agentWorkspace(name: string): string {
@@ -404,4 +484,76 @@ function isStructuredLogPayload(value: unknown): boolean {
     typeof value.level === 'string' &&
     (typeof value.message === 'string' || typeof value.msg === 'string')
   )
+}
+
+function isSessionListPayload(value: unknown): boolean {
+  if (Array.isArray(value)) return true
+  if (!isPlainObject(value)) return false
+  return 'sessions' in value || 'count' in value
+}
+
+function toSessionEntry(raw: unknown): OpenClawSessionEntry {
+  const record = raw as Record<string, unknown>
+  return {
+    key: String(record.key ?? ''),
+    updatedAt: typeof record.updatedAt === 'number' ? record.updatedAt : 0,
+    sessionId: String(record.sessionId ?? ''),
+    agentId: String(record.agentId ?? ''),
+    kind: String(record.kind ?? ''),
+    status: typeof record.status === 'string' ? record.status : undefined,
+    totalTokens:
+      typeof record.totalTokens === 'number' ? record.totalTokens : undefined,
+    model: typeof record.model === 'string' ? record.model : undefined,
+    modelProvider:
+      typeof record.modelProvider === 'string'
+        ? record.modelProvider
+        : undefined,
+  }
+}
+
+function toChatMessage(raw: unknown): OpenClawChatMessage {
+  const record = raw as Record<string, unknown>
+  const role = String(record.role ?? 'assistant') as OpenClawChatMessage['role']
+
+  const blocks: OpenClawChatBlock[] = []
+  const rawContent = record.content
+
+  if (Array.isArray(rawContent)) {
+    for (const block of rawContent) {
+      if (!isPlainObject(block)) continue
+      const type = String(block.type ?? 'text') as OpenClawChatBlock['type']
+      const entry: OpenClawChatBlock = { type }
+
+      if (type === 'text' && typeof block.text === 'string') {
+        entry.text = block.text
+      } else if (type === 'toolCall') {
+        if (typeof block.name === 'string') entry.name = block.name
+        if (block.arguments !== undefined) entry.arguments = block.arguments
+      } else if (type === 'thinking' && typeof block.thinking === 'string') {
+        entry.thinking = block.thinking
+      }
+
+      blocks.push(entry)
+    }
+  } else if (typeof rawContent === 'string') {
+    blocks.push({ type: 'text', text: rawContent })
+  }
+
+  const message: OpenClawChatMessage = { role, content: blocks }
+
+  if (typeof record.timestamp === 'number') message.timestamp = record.timestamp
+  if (isPlainObject(record.usage)) {
+    const usage = record.usage as Record<string, unknown>
+    if (typeof usage.input === 'number' && typeof usage.output === 'number') {
+      message.usage = { input: usage.input, output: usage.output }
+    }
+  }
+  if (typeof record.stopReason === 'string')
+    message.stopReason = record.stopReason
+  if (typeof record.toolName === 'string') message.toolName = record.toolName
+  if (typeof record.toolCallId === 'string')
+    message.toolCallId = record.toolCallId
+  if (typeof record.isError === 'boolean') message.isError = record.isError
+
+  return message
 }

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -30,8 +30,11 @@ import {
 } from './errors'
 import {
   type OpenClawAgentRecord,
+  type OpenClawChatBlock,
+  type OpenClawChatMessage,
   OpenClawCliClient,
   type OpenClawConfigBatchEntry,
+  type OpenClawSessionEntry,
 } from './openclaw-cli-client'
 import {
   getHostWorkspaceDir,
@@ -91,6 +94,7 @@ export interface OpenClawStatusResponse {
 }
 
 export type OpenClawAgentEntry = OpenClawAgentRecord
+export type { OpenClawChatBlock, OpenClawChatMessage, OpenClawSessionEntry }
 
 export interface SetupInput {
   providerType?: string
@@ -571,6 +575,19 @@ export class OpenClawService {
     await this.assertGatewayReady()
     logger.debug('Listing OpenClaw agents')
     return this.runControlPlaneCall(() => this.cliClient.listAgents())
+  }
+
+  async listSessions(agentId?: string): Promise<OpenClawSessionEntry[]> {
+    logger.debug('Listing OpenClaw sessions', { agentId })
+    return this.cliClient.listSessions(agentId)
+  }
+
+  async getChatHistory(sessionKey: string): Promise<OpenClawChatMessage[]> {
+    await this.assertGatewayReady()
+    logger.debug('Fetching OpenClaw chat history', { sessionKey })
+    return this.runControlPlaneCall(() =>
+      this.cliClient.getChatHistory(sessionKey),
+    )
   }
 
   // ── Chat Stream (HTTP) ───────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- Add `listSessions()` and `getChatHistory()` to `OpenClawCliClient` using existing `podman exec` CLI pattern
- Add `GET /claw/agents/:id/history` route that fetches sessions + chat history, filters system noise, and returns unified entries
- AgentChat loads history on mount and displays past conversations

## How it works

- `listSessions()` runs `sessions --json` (file-based, no gateway auth needed)
- `getChatHistory()` runs `gateway call chat.history` (gateway WS RPC via CLI)
- Server-side filtering removes: HEARTBEAT responses, system event triggers, context-replay messages (extracts actual user message from context bundles)
- Frontend renders user messages + assistant text responses (no tool cards in history, matching Telegram display)

## Known limitations

- Context-replay extraction is pattern-based (`[Current message - respond to this]` marker) — could break if OpenClaw changes the format
- `chat.history` mixes user content with OpenClaw internal messages — long-term solution should track conversations locally in BrowserOS rather than reconstructing from OpenClaw's session format
- No cron-specific session display yet (cron messages go into the user-chat session)

## Test plan

- [ ] Open agent chat → history loads with past conversations
- [ ] Heartbeat/system messages filtered out
- [ ] User messages extracted correctly from context replays
- [ ] New messages via SSE still work after history loads
- [ ] Empty history (fresh setup) shows empty chat correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)