### PR TITLE
feat(openclaw): add Claude CLI as a CLI-backed provider

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentTerminal.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentTerminal.tsx
@@ -5,8 +5,8 @@ import {
 import { FitAddon } from '@xterm/addon-fit'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { Terminal } from '@xterm/xterm'
-import { ArrowLeft } from 'lucide-react'
-import { type FC, useEffect, useRef } from 'react'
+import { ArrowLeft, Check, Copy } from 'lucide-react'
+import { type FC, useEffect, useRef, useState } from 'react'
 import '@xterm/xterm/css/xterm.css'
 import { Button } from '@/components/ui/button'
 import { getAgentServerUrl } from '@/lib/browseros/helpers'
@@ -126,12 +126,42 @@ export const AgentTerminal: FC<AgentTerminalProps> = ({
   onSessionExit,
 }) => {
   const containerRef = useRef<HTMLDivElement>(null)
+  const terminalRef = useRef<Terminal | null>(null)
   // Refs keep the mount-once effect from tearing down the PTY when the
   // parent re-renders with new inline callbacks.
   const initialCommandRef = useRef(initialCommand)
   const onSessionExitRef = useRef(onSessionExit)
   initialCommandRef.current = initialCommand
   onSessionExitRef.current = onSessionExit
+
+  const [copied, setCopied] = useState(false)
+
+  // Copy whatever the user has selected in xterm; fall back to the full
+  // visible viewport when nothing is selected. This works even when the
+  // running TUI (e.g. claude /login) has enabled mouse tracking and
+  // intercepts click-drag selection.
+  const handleCopy = async (): Promise<void> => {
+    const term = terminalRef.current
+    if (!term) return
+    let text = term.getSelection()
+    if (!text) {
+      const buf = term.buffer.active
+      const lines: string[] = []
+      for (let y = 0; y < buf.length; y++) {
+        const line = buf.getLine(y)
+        if (line) lines.push(line.translateToString(true))
+      }
+      text = lines.join('\n').replace(/\n+$/, '')
+    }
+    if (!text) return
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch {
+      // clipboard permission denied or unavailable — swallow, user will retry
+    }
+  }
 
   useEffect(() => {
     if (!containerRef.current) return
@@ -144,6 +174,34 @@ export const AgentTerminal: FC<AgentTerminalProps> = ({
       lineHeight: 1.25,
       scrollback: 8000,
       theme: createTerminalTheme(),
+      // Opt+click+drag forces a native text selection even when the
+      // running TUI has mouse-tracking enabled (xterm would otherwise
+      // forward every click to the app and selection wouldn't work).
+      macOptionClickForcesSelection: true,
+    })
+    terminalRef.current = terminal
+
+    // Cmd+A → select all, Cmd+C → copy selection via the browser
+    // clipboard. Return false so xterm doesn't also forward the keys
+    // to the running program.
+    terminal.attachCustomKeyEventHandler((event) => {
+      if (event.type !== 'keydown') return true
+      const isMac = navigator.platform.toUpperCase().includes('MAC')
+      const mod = isMac ? event.metaKey : event.ctrlKey
+      if (!mod) return true
+      const key = event.key.toLowerCase()
+      if (key === 'a') {
+        terminal.selectAll()
+        return false
+      }
+      if (key === 'c') {
+        const sel = terminal.getSelection()
+        if (sel) {
+          void navigator.clipboard.writeText(sel)
+          return false
+        }
+      }
+      return true
     })
 
     const fitAddon = new FitAddon()
@@ -264,13 +322,14 @@ export const AgentTerminal: FC<AgentTerminalProps> = ({
       disposeSocketBindings?.()
       ws?.close()
       terminal.dispose()
+      terminalRef.current = null
     }
   }, [])
 
   return (
     <div className="flex h-[calc(100dvh-10rem)] min-h-[32rem] w-full flex-col py-2 sm:min-h-[42rem] sm:py-4">
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden rounded-xl border border-border bg-card shadow-sm">
-        <div className="flex items-center gap-3 border-border border-b px-4 py-3 sm:px-6">
+        <div className="flex items-center justify-between gap-3 border-border border-b px-4 py-3 sm:px-6">
           <div className="flex min-w-0 items-center gap-3">
             <Button variant="ghost" size="icon" onClick={onBack}>
               <ArrowLeft className="size-4" />
@@ -284,6 +343,14 @@ export const AgentTerminal: FC<AgentTerminalProps> = ({
               </div>
             </div>
           </div>
+          <Button variant="outline" size="sm" onClick={handleCopy}>
+            {copied ? (
+              <Check className="mr-1 size-3.5" />
+            ) : (
+              <Copy className="mr-1 size-3.5" />
+            )}
+            {copied ? 'Copied' : 'Copy'}
+          </Button>
         </div>
 
         <div className="min-h-0 flex-1 p-4 sm:p-6">

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentTerminal.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentTerminal.tsx
@@ -153,6 +153,10 @@ export const AgentTerminal: FC<AgentTerminalProps> = ({
 
     let ws: WebSocket | null = null
     let sawExit = false
+    // React 18 StrictMode double-invokes effects in dev. The cleanup for the
+    // first mount fires before `connect()` resolves, so without this guard
+    // the pending WS is born orphaned and we end up with two live sessions.
+    let cancelled = false
 
     const applyTheme = (): void => {
       terminal.options.theme = createTerminalTheme()
@@ -173,10 +177,16 @@ export const AgentTerminal: FC<AgentTerminalProps> = ({
 
     const connect = async () => {
       const baseUrl = await getAgentServerUrl()
+      if (cancelled) return
       const wsUrl = new URL('/terminal/ws', baseUrl)
       wsUrl.protocol = wsUrl.protocol === 'https:' ? 'wss:' : 'ws:'
 
       ws = new WebSocket(wsUrl)
+      if (cancelled) {
+        ws.close()
+        ws = null
+        return
+      }
 
       ws.onopen = () => {
         fitAddon.fit()
@@ -248,6 +258,7 @@ export const AgentTerminal: FC<AgentTerminalProps> = ({
     })
 
     return () => {
+      cancelled = true
       resizeObserver.disconnect()
       themeObserver.disconnect()
       disposeSocketBindings?.()
@@ -286,7 +297,7 @@ export const AgentTerminal: FC<AgentTerminalProps> = ({
               </div>
             </div>
 
-            <div className="min-h-0 flex-1 px-4 py-4 sm:px-5 sm:py-5">
+            <div className="min-h-0 flex-1 cursor-text px-4 py-4 sm:px-5 sm:py-5">
               <div ref={containerRef} className="h-full w-full" />
             </div>
           </div>

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentTerminal.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentTerminal.tsx
@@ -13,6 +13,8 @@ import { getAgentServerUrl } from '@/lib/browseros/helpers'
 
 interface AgentTerminalProps {
   onBack: () => void
+  initialCommand?: string
+  onSessionExit?: () => void
 }
 
 type TerminalServerMessage =
@@ -118,8 +120,18 @@ function parseTerminalMessage(data: unknown): TerminalServerMessage | null {
   return null
 }
 
-export const AgentTerminal: FC<AgentTerminalProps> = ({ onBack }) => {
+export const AgentTerminal: FC<AgentTerminalProps> = ({
+  onBack,
+  initialCommand,
+  onSessionExit,
+}) => {
   const containerRef = useRef<HTMLDivElement>(null)
+  // Refs keep the mount-once effect from tearing down the PTY when the
+  // parent re-renders with new inline callbacks.
+  const initialCommandRef = useRef(initialCommand)
+  const onSessionExitRef = useRef(onSessionExit)
+  initialCommandRef.current = initialCommand
+  onSessionExitRef.current = onSessionExit
 
   useEffect(() => {
     if (!containerRef.current) return
@@ -170,6 +182,10 @@ export const AgentTerminal: FC<AgentTerminalProps> = ({ onBack }) => {
         fitAddon.fit()
         terminal.focus()
         sendResize()
+        const cmd = initialCommandRef.current
+        if (cmd) {
+          sendMessage({ type: 'input', data: `${cmd}\n` })
+        }
       }
 
       ws.onmessage = (event) => {
@@ -185,6 +201,7 @@ export const AgentTerminal: FC<AgentTerminalProps> = ({ onBack }) => {
           terminal.write(
             `\r\n\x1b[90m[session ended with exit ${message.exitCode}]\x1b[0m\r\n`,
           )
+          onSessionExitRef.current?.()
         }
       }
 

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentTerminal.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentTerminal.tsx
@@ -132,23 +132,13 @@ export const AgentTerminal: FC<AgentTerminalProps> = ({
 
   const [copied, setCopied] = useState(false)
 
-  // Copy whatever the user has selected in xterm; fall back to the full
-  // visible viewport when nothing is selected. This works even when the
-  // running TUI (e.g. claude /login) has enabled mouse tracking and
-  // intercepts click-drag selection.
+  // Copy the current xterm selection to the browser clipboard. No-op
+  // if nothing is selected — users who want the whole buffer can
+  // Cmd+A first. Uses the browser clipboard, not the container's, so
+  // it works even when the running TUI has mouse tracking enabled
+  // (Opt+drag forces a selection regardless, see terminal config).
   const handleCopy = async (): Promise<void> => {
-    const term = terminalRef.current
-    if (!term) return
-    let text = term.getSelection()
-    if (!text) {
-      const buf = term.buffer.active
-      const lines: string[] = []
-      for (let y = 0; y < buf.length; y++) {
-        const line = buf.getLine(y)
-        if (line) lines.push(line.translateToString(true))
-      }
-      text = lines.join('\n').replace(/\n+$/, '')
-    }
+    const text = terminalRef.current?.getSelection()
     if (!text) return
     try {
       await navigator.clipboard.writeText(text)
@@ -205,12 +195,14 @@ export const AgentTerminal: FC<AgentTerminalProps> = ({
     terminal.loadAddon(new WebLinksAddon())
     terminal.open(containerRef.current)
 
+    // React 18 StrictMode double-invokes effects in dev. Everything
+    // async inside this effect is scoped to an AbortController; the
+    // cleanup aborts it and any pending awaits bail out, so we never
+    // leak a second live WebSocket or duplicate xterm listeners.
+    const ac = new AbortController()
+    const cleanups: Array<() => void> = []
     let ws: WebSocket | null = null
     let sawExit = false
-    // React 18 StrictMode double-invokes effects in dev. The cleanup for the
-    // first mount fires before `connect()` resolves, so without this guard
-    // the pending WS is born orphaned and we end up with two live sessions.
-    let cancelled = false
 
     const applyTheme = (): void => {
       terminal.options.theme = createTerminalTheme()
@@ -229,27 +221,28 @@ export const AgentTerminal: FC<AgentTerminalProps> = ({
       sendMessage({ type: 'resize', cols, rows })
     }
 
-    const connect = async () => {
+    const connect = async (): Promise<void> => {
       const baseUrl = await getAgentServerUrl()
-      if (cancelled) return
+      if (ac.signal.aborted) return
       const wsUrl = new URL('/terminal/ws', baseUrl)
       wsUrl.protocol = wsUrl.protocol === 'https:' ? 'wss:' : 'ws:'
 
       ws = new WebSocket(wsUrl)
-      if (cancelled) {
+      // If the effect was cleaned up between the await above and now,
+      // close the socket we just opened and bail.
+      if (ac.signal.aborted) {
         ws.close()
         ws = null
         return
       }
+      cleanups.push(() => ws?.close())
 
       ws.onopen = () => {
         fitAddon.fit()
         terminal.focus()
         sendResize()
         const cmd = initialCommandRef.current
-        if (cmd) {
-          sendMessage({ type: 'input', data: `${cmd}\n` })
-        }
+        if (cmd) sendMessage({ type: 'input', data: `${cmd}\n` })
       }
 
       ws.onmessage = (event) => {
@@ -281,42 +274,32 @@ export const AgentTerminal: FC<AgentTerminalProps> = ({
       const inputDisposable = terminal.onData((data) => {
         sendMessage({ type: 'input', data })
       })
-
       const resizeDisposable = terminal.onResize(({ cols, rows }) => {
         sendResize(cols, rows)
       })
-
-      return () => {
-        inputDisposable.dispose()
-        resizeDisposable.dispose()
-      }
+      cleanups.push(() => inputDisposable.dispose())
+      cleanups.push(() => resizeDisposable.dispose())
     }
 
-    let disposeSocketBindings: (() => void) | undefined
-    void connect().then((disposeBindings) => {
-      disposeSocketBindings = disposeBindings
-    })
+    void connect()
 
     const resizeObserver = new ResizeObserver(() => {
       fitAddon.fit()
       sendResize()
     })
     resizeObserver.observe(containerRef.current)
+    cleanups.push(() => resizeObserver.disconnect())
 
-    const themeObserver = new MutationObserver(() => {
-      applyTheme()
-    })
+    const themeObserver = new MutationObserver(() => applyTheme())
     themeObserver.observe(document.documentElement, {
       attributes: true,
       attributeFilter: ['class'],
     })
+    cleanups.push(() => themeObserver.disconnect())
 
     return () => {
-      cancelled = true
-      resizeObserver.disconnect()
-      themeObserver.disconnect()
-      disposeSocketBindings?.()
-      ws?.close()
+      ac.abort()
+      for (const dispose of cleanups) dispose()
       terminal.dispose()
       terminalRef.current = null
     }

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentTerminal.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentTerminal.tsx
@@ -38,26 +38,22 @@ function resolveCssColor(variableName: string): string {
   return color
 }
 
-function withAlpha(color: string, alpha: number): string {
-  const channels = color.match(/[\d.]+/g)
-  if (!channels || channels.length < 3) return color
-  const [red, green, blue] = channels
-  return `rgb(${red} ${green} ${blue} / ${alpha})`
-}
-
 function createTerminalTheme() {
   const isDark = document.documentElement.classList.contains('dark')
   const background = resolveCssColor('--background')
   const foreground = resolveCssColor('--foreground')
   const muted = resolveCssColor('--muted-foreground')
-  const accent = resolveCssColor('--accent-orange')
 
   return {
     background,
     foreground,
     cursor: foreground,
     cursorAccent: background,
-    selectionBackground: withAlpha(accent, isDark ? 0.3 : 0.2),
+    // Solid terminal-standard selection colors. Deriving from a CSS var
+    // with alpha composed against the background produced near-white
+    // rectangles on light mode, making selection invisible.
+    selectionBackground: isDark ? '#3a4463' : '#b4d4f4',
+    selectionInactiveBackground: isDark ? '#2b3348' : '#d9e5f3',
     selectionForeground: foreground,
     black: isDark ? '#16131a' : '#1f1b22',
     red: isDark ? '#ef8c7c' : '#c25544',

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -836,6 +836,16 @@ export const AgentsPage: FC = () => {
     return <AgentTerminal onBack={() => setShowTerminal(false)} />
   }
 
+  if (cliAuthModalOpen && selectedCliProvider) {
+    return (
+      <AgentTerminal
+        onBack={() => setCliAuthModalOpen(false)}
+        initialCommand={selectedCliProvider.authLoginCommand}
+        onSessionExit={() => setCliAuthModalOpen(false)}
+      />
+    )
+  }
+
   if (statusLoading && !status) {
     return (
       <div className="flex items-center justify-center py-20">
@@ -997,25 +1007,6 @@ export const AgentsPage: FC = () => {
               )}
             </Button>
           </div>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog open={cliAuthModalOpen} onOpenChange={setCliAuthModalOpen}>
-        <DialogContent className="max-w-4xl">
-          <DialogHeader>
-            <DialogTitle>
-              {selectedCliProvider
-                ? `Connect ${selectedCliProvider.displayName}`
-                : 'Connect CLI Provider'}
-            </DialogTitle>
-          </DialogHeader>
-          {selectedCliProvider && (
-            <AgentTerminal
-              onBack={() => setCliAuthModalOpen(false)}
-              initialCommand={selectedCliProvider.authLoginCommand}
-              onSessionExit={() => setCliAuthModalOpen(false)}
-            />
-          )}
         </DialogContent>
       </Dialog>
     </div>

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -32,6 +32,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
+import type { LlmProviderConfig } from '@/lib/llm-providers/types'
 import { useLlmProviders } from '@/lib/llm-providers/useLlmProviders'
 import { AgentTerminal } from './AgentTerminal'
 import {
@@ -782,19 +783,18 @@ export const AgentsPage: FC = () => {
     )
     const normalizedName = newName.trim().toLowerCase().replace(/\s+/g, '-')
     const isCli = !!option && !!findOpenClawCliProviderById(option.type)
-    // LlmProviderConfig carries apiKey/baseUrl; CLI synthetic options do not.
-    const apiKeyOption =
-      !isCli && option && 'apiKey' in option ? option.apiKey : undefined
-    const baseUrlOption =
-      !isCli && option && 'baseUrl' in option ? option.baseUrl : undefined
+    // LlmProviderConfig carries apiKey/baseUrl; CLI synthetic options don't —
+    // once we know isCli=false, narrow to the config type for property access.
+    const llmOption =
+      !isCli && option ? (option as LlmProviderConfig) : undefined
 
     await runWithErrorHandling(async () => {
       await createAgent({
         name: normalizedName,
         providerType: option?.type,
         providerName: isCli ? undefined : option?.name,
-        baseUrl: baseUrlOption,
-        apiKey: apiKeyOption,
+        baseUrl: llmOption?.baseUrl,
+        apiKey: llmOption?.apiKey,
         modelId: option?.modelId,
       })
       setCreateOpen(false)

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -34,6 +34,12 @@ import {
 } from '@/components/ui/select'
 import { useLlmProviders } from '@/lib/llm-providers/useLlmProviders'
 import { AgentTerminal } from './AgentTerminal'
+import {
+  buildOpenClawCliProviderOptions,
+  findOpenClawCliProviderById,
+  OpenClawCliProviderStatusPanel,
+  useOpenClawCliProviderAuthStatus,
+} from './openclaw-cli-providers'
 import { getOpenClawSupportedProviders } from './openclaw-supported-providers'
 import {
   type AgentEntry,
@@ -631,9 +637,52 @@ export const AgentsPage: FC = () => {
   const [createProviderId, setCreateProviderId] = useState('')
 
   const [showTerminal, setShowTerminal] = useState(false)
+  const [cliAuthModalOpen, setCliAuthModalOpen] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
   const compatibleProviders = getOpenClawSupportedProviders(providers)
+  const cliProviderOptions = useMemo(
+    () => buildOpenClawCliProviderOptions(),
+    [],
+  )
+  const selectableCreateProviders = useMemo(
+    () => [...compatibleProviders, ...cliProviderOptions],
+    [compatibleProviders, cliProviderOptions],
+  )
+
+  const selectedCreateOption = selectableCreateProviders.find(
+    (provider) => provider.id === createProviderId,
+  )
+  const selectedCliProvider = selectedCreateOption
+    ? findOpenClawCliProviderById(selectedCreateOption.type)
+    : undefined
+
+  // Only poll while a CLI provider is the active selection AND the Create
+  // Agent dialog is open. Also used by the modal's auto-close effect.
+  const cliAuthEnabled = createOpen && !!selectedCliProvider
+  const {
+    data: cliAuthStatus,
+    isLoading: cliAuthLoading,
+    error: cliAuthError,
+  } = useOpenClawCliProviderAuthStatus(
+    selectedCliProvider?.id ?? '',
+    cliAuthEnabled,
+  )
+
+  useEffect(() => {
+    if (selectableCreateProviders.length === 0) return
+    const fallbackId =
+      selectableCreateProviders.find(
+        (provider) => provider.id === defaultProviderId,
+      )?.id ?? selectableCreateProviders[0].id
+
+    if (createOpen && !createProviderId) setCreateProviderId(fallbackId)
+  }, [
+    createOpen,
+    createProviderId,
+    selectableCreateProviders,
+    defaultProviderId,
+  ])
 
   useEffect(() => {
     if (compatibleProviders.length === 0) return
@@ -642,15 +691,14 @@ export const AgentsPage: FC = () => {
         ?.id ?? compatibleProviders[0].id
 
     if (setupOpen && !setupProviderId) setSetupProviderId(fallbackId)
-    if (createOpen && !createProviderId) setCreateProviderId(fallbackId)
-  }, [
-    setupOpen,
-    createOpen,
-    setupProviderId,
-    createProviderId,
-    compatibleProviders,
-    defaultProviderId,
-  ])
+  }, [setupOpen, setupProviderId, compatibleProviders, defaultProviderId])
+
+  // Auto-close the auth modal once login succeeds.
+  useEffect(() => {
+    if (cliAuthModalOpen && cliAuthStatus?.loggedIn) {
+      setCliAuthModalOpen(false)
+    }
+  }, [cliAuthModalOpen, cliAuthStatus?.loggedIn])
 
   useEffect(() => {
     if (!createOpen) return
@@ -729,19 +777,25 @@ export const AgentsPage: FC = () => {
 
   const handleCreate = async () => {
     if (!newName.trim()) return
-    const provider = compatibleProviders.find(
+    const option = selectableCreateProviders.find(
       (item) => item.id === createProviderId,
     )
     const normalizedName = newName.trim().toLowerCase().replace(/\s+/g, '-')
+    const isCli = !!option && !!findOpenClawCliProviderById(option.type)
+    // LlmProviderConfig carries apiKey/baseUrl; CLI synthetic options do not.
+    const apiKeyOption =
+      !isCli && option && 'apiKey' in option ? option.apiKey : undefined
+    const baseUrlOption =
+      !isCli && option && 'baseUrl' in option ? option.baseUrl : undefined
 
     await runWithErrorHandling(async () => {
       await createAgent({
         name: normalizedName,
-        providerType: provider?.type,
-        providerName: provider?.name,
-        baseUrl: provider?.baseUrl,
-        apiKey: provider?.apiKey,
-        modelId: provider?.modelId,
+        providerType: option?.type,
+        providerName: isCli ? undefined : option?.name,
+        baseUrl: baseUrlOption,
+        apiKey: apiKeyOption,
+        modelId: option?.modelId,
       })
       setCreateOpen(false)
       setNewName('')
@@ -906,11 +960,21 @@ export const AgentsPage: FC = () => {
             </div>
 
             <ProviderSelector
-              providers={compatibleProviders}
+              providers={selectableCreateProviders}
               defaultProviderId={defaultProviderId}
               selectedId={createProviderId}
               onSelect={setCreateProviderId}
             />
+
+            {selectedCliProvider && (
+              <OpenClawCliProviderStatusPanel
+                provider={selectedCliProvider}
+                status={cliAuthStatus}
+                loading={cliAuthLoading}
+                fetchError={cliAuthError ?? null}
+                onConnect={() => setCliAuthModalOpen(true)}
+              />
+            )}
 
             <Button
               onClick={handleCreate}
@@ -918,7 +982,8 @@ export const AgentsPage: FC = () => {
                 !newName.trim() ||
                 creating ||
                 !canManageAgents ||
-                compatibleProviders.length === 0
+                selectableCreateProviders.length === 0 ||
+                (!!selectedCliProvider && !cliAuthStatus?.loggedIn)
               }
               className="w-full"
             >
@@ -932,6 +997,25 @@ export const AgentsPage: FC = () => {
               )}
             </Button>
           </div>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={cliAuthModalOpen} onOpenChange={setCliAuthModalOpen}>
+        <DialogContent className="max-w-4xl">
+          <DialogHeader>
+            <DialogTitle>
+              {selectedCliProvider
+                ? `Connect ${selectedCliProvider.displayName}`
+                : 'Connect CLI Provider'}
+            </DialogTitle>
+          </DialogHeader>
+          {selectedCliProvider && (
+            <AgentTerminal
+              onBack={() => setCliAuthModalOpen(false)}
+              initialCommand={selectedCliProvider.authLoginCommand}
+              onSessionExit={() => setCliAuthModalOpen(false)}
+            />
+          )}
         </DialogContent>
       </Dialog>
     </div>

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -686,13 +686,14 @@ export const AgentsPage: FC = () => {
   ])
 
   useEffect(() => {
-    if (compatibleProviders.length === 0) return
+    if (selectableCreateProviders.length === 0) return
     const fallbackId =
-      compatibleProviders.find((provider) => provider.id === defaultProviderId)
-        ?.id ?? compatibleProviders[0].id
+      selectableCreateProviders.find(
+        (provider) => provider.id === defaultProviderId,
+      )?.id ?? selectableCreateProviders[0].id
 
     if (setupOpen && !setupProviderId) setSetupProviderId(fallbackId)
-  }, [setupOpen, setupProviderId, compatibleProviders, defaultProviderId])
+  }, [setupOpen, setupProviderId, selectableCreateProviders, defaultProviderId])
 
   // Auto-close the auth modal once login succeeds.
   useEffect(() => {
@@ -760,19 +761,26 @@ export const AgentsPage: FC = () => {
   }
 
   const handleSetup = async () => {
-    const provider = compatibleProviders.find(
+    const option = selectableCreateProviders.find(
       (item) => item.id === setupProviderId,
     )
+    const isCli = !!option && !!findOpenClawCliProviderById(option.type)
+    // CLI-backed providers have no apiKey/baseUrl — bootstrap the gateway
+    // bare-bones, then hop straight into the auth terminal so the user can
+    // finish login without a second click.
+    const llmOption =
+      !isCli && option ? (option as LlmProviderConfig) : undefined
 
     await runWithErrorHandling(async () => {
       await setupOpenClaw({
-        providerType: provider?.type,
-        providerName: provider?.name,
-        baseUrl: provider?.baseUrl,
-        apiKey: provider?.apiKey,
-        modelId: provider?.modelId,
+        providerType: option?.type,
+        providerName: isCli ? undefined : option?.name,
+        baseUrl: llmOption?.baseUrl,
+        apiKey: llmOption?.apiKey,
+        modelId: option?.modelId,
       })
       setSetupOpen(false)
+      if (isCli) setCliAuthModalOpen(true)
     })
   }
 
@@ -919,14 +927,14 @@ export const AgentsPage: FC = () => {
           </DialogHeader>
           <div className="space-y-4 py-2">
             <ProviderSelector
-              providers={compatibleProviders}
+              providers={selectableCreateProviders}
               defaultProviderId={defaultProviderId}
               selectedId={setupProviderId}
               onSelect={setSetupProviderId}
             />
             <Button
               onClick={handleSetup}
-              disabled={settingUp || compatibleProviders.length === 0}
+              disabled={settingUp || selectableCreateProviders.length === 0}
               className="w-full"
             >
               {settingUp ? (

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -193,6 +193,9 @@ interface ProviderSelectorProps {
   defaultProviderId: string
   selectedId: string
   onSelect: (id: string) => void
+  // When the selection is a CLI-backed provider, the "uses your API key"
+  // hint is misleading — hide it and let the status panel speak instead.
+  hideApiKeyHint?: boolean
 }
 
 const ProviderSelector: FC<ProviderSelectorProps> = ({
@@ -200,6 +203,7 @@ const ProviderSelector: FC<ProviderSelectorProps> = ({
   defaultProviderId,
   selectedId,
   onSelect,
+  hideApiKeyHint,
 }) => {
   if (providers.length === 0) {
     return (
@@ -234,10 +238,12 @@ const ProviderSelector: FC<ProviderSelectorProps> = ({
           ))}
         </SelectContent>
       </Select>
-      <p className="text-muted-foreground text-xs">
-        Uses your existing API key from BrowserOS settings. The key is passed to
-        the container and never leaves your machine.
-      </p>
+      {!hideApiKeyHint && (
+        <p className="text-muted-foreground text-xs">
+          Uses your existing API key from BrowserOS settings. The key is passed
+          to the container and never leaves your machine.
+        </p>
+      )}
     </div>
   )
 }
@@ -658,16 +664,26 @@ export const AgentsPage: FC = () => {
     ? findOpenClawCliProviderById(selectedCreateOption.type)
     : undefined
 
-  // Only poll while a CLI provider is the active selection AND the Create
-  // Agent dialog is open. Also used by the modal's auto-close effect.
-  const cliAuthEnabled = createOpen && !!selectedCliProvider
+  const selectedSetupOption = selectableCreateProviders.find(
+    (provider) => provider.id === setupProviderId,
+  )
+  const selectedSetupCliProvider = selectedSetupOption
+    ? findOpenClawCliProviderById(selectedSetupOption.type)
+    : undefined
+
+  // Whichever dialog is currently open drives the auth status poll and the
+  // auth-terminal handoff. Only one dialog is open at a time.
+  const activeCliProvider =
+    (setupOpen && selectedSetupCliProvider) ||
+    (createOpen && selectedCliProvider) ||
+    undefined
   const {
     data: cliAuthStatus,
     isLoading: cliAuthLoading,
     error: cliAuthError,
   } = useOpenClawCliProviderAuthStatus(
-    selectedCliProvider?.id ?? '',
-    cliAuthEnabled,
+    activeCliProvider?.id ?? '',
+    !!activeCliProvider,
   )
 
   useEffect(() => {
@@ -765,9 +781,9 @@ export const AgentsPage: FC = () => {
       (item) => item.id === setupProviderId,
     )
     const isCli = !!option && !!findOpenClawCliProviderById(option.type)
-    // CLI-backed providers have no apiKey/baseUrl — bootstrap the gateway
-    // bare-bones, then hop straight into the auth terminal so the user can
-    // finish login without a second click.
+    // CLI-backed providers have no apiKey/baseUrl — the gateway boots
+    // bare-bones and we hop straight into the auth terminal. The Create
+    // Agent flow uses the post-setup status panel instead.
     const llmOption =
       !isCli && option ? (option as LlmProviderConfig) : undefined
 
@@ -844,11 +860,16 @@ export const AgentsPage: FC = () => {
     return <AgentTerminal onBack={() => setShowTerminal(false)} />
   }
 
-  if (cliAuthModalOpen && selectedCliProvider) {
+  // Auth terminal is driven by whichever dialog triggered it — Setup or
+  // Create. Prefer the setup selection when the setup dialog is open, so
+  // clicking "Connect" from Setup doesn't accidentally launch for a
+  // different provider picked earlier in Create.
+  const authTerminalProvider = selectedSetupCliProvider ?? selectedCliProvider
+  if (cliAuthModalOpen && authTerminalProvider) {
     return (
       <AgentTerminal
         onBack={() => setCliAuthModalOpen(false)}
-        initialCommand={selectedCliProvider.authLoginCommand}
+        initialCommand={authTerminalProvider.authLoginCommand}
         onSessionExit={() => setCliAuthModalOpen(false)}
       />
     )
@@ -931,7 +952,17 @@ export const AgentsPage: FC = () => {
               defaultProviderId={defaultProviderId}
               selectedId={setupProviderId}
               onSelect={setSetupProviderId}
+              hideApiKeyHint={!!selectedSetupCliProvider}
             />
+
+            {selectedSetupCliProvider && (
+              <p className="rounded-md border border-border bg-muted/30 px-3 py-2 text-muted-foreground text-xs">
+                {selectedSetupCliProvider.description}. Clicking{' '}
+                <span className="font-medium">Set Up &amp; Start</span> starts
+                the gateway and opens a terminal to sign in.
+              </p>
+            )}
+
             <Button
               onClick={handleSetup}
               disabled={settingUp || selectableCreateProviders.length === 0}
@@ -982,6 +1013,7 @@ export const AgentsPage: FC = () => {
               defaultProviderId={defaultProviderId}
               selectedId={createProviderId}
               onSelect={setCreateProviderId}
+              hideApiKeyHint={!!selectedCliProvider}
             />
 
             {selectedCliProvider && (

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/openclaw-cli-providers.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/openclaw-cli-providers.tsx
@@ -1,0 +1,187 @@
+import { useQuery } from '@tanstack/react-query'
+import { CheckCircle2, Loader2, Terminal, TriangleAlert } from 'lucide-react'
+import type { FC } from 'react'
+import { Button } from '@/components/ui/button'
+import { useAgentServerUrl } from '@/lib/browseros/useBrowserOSProviders'
+
+export interface OpenClawCliProvider {
+  id: string
+  displayName: string
+  description: string
+  models: readonly string[]
+  authLoginCommand: string
+}
+
+export interface OpenClawCliProviderAuthStatus {
+  installed: boolean
+  loggedIn: boolean
+  accountLabel?: string
+  subscriptionLabel?: string
+  error?: string
+}
+
+export interface OpenClawCliProviderOption {
+  id: string
+  type: string
+  name: string
+  modelId: string
+  providerId: string
+}
+
+const CLAUDE_CLI_PROVIDER: OpenClawCliProvider = {
+  id: 'claude-cli',
+  displayName: 'Anthropic Claude CLI',
+  description: 'Uses your Claude.ai subscription via the Claude Code CLI',
+  models: ['claude-sonnet-4-6', 'claude-opus-4-6', 'claude-haiku-4-5'],
+  authLoginCommand: 'claude auth login',
+}
+
+export const OPENCLAW_CLI_PROVIDERS: readonly OpenClawCliProvider[] = [
+  CLAUDE_CLI_PROVIDER,
+]
+
+export function findOpenClawCliProviderById(
+  id: string,
+): OpenClawCliProvider | undefined {
+  return OPENCLAW_CLI_PROVIDERS.find((provider) => provider.id === id)
+}
+
+export function buildOpenClawCliProviderOptions(): OpenClawCliProviderOption[] {
+  return OPENCLAW_CLI_PROVIDERS.flatMap((provider) =>
+    provider.models.map((modelId) => ({
+      id: `${provider.id}/${modelId}`,
+      type: provider.id,
+      name: provider.displayName,
+      modelId,
+      providerId: provider.id,
+    })),
+  )
+}
+
+async function fetchCliProviderAuthStatus(
+  baseUrl: string,
+  providerId: string,
+): Promise<OpenClawCliProviderAuthStatus> {
+  const res = await fetch(`${baseUrl}/claw/providers/${providerId}/auth-status`)
+  if (!res.ok) {
+    let message = `Auth status request failed (${res.status})`
+    try {
+      const body = (await res.json()) as { error?: string }
+      if (body.error) message = body.error
+    } catch {}
+    throw new Error(message)
+  }
+  return res.json() as Promise<OpenClawCliProviderAuthStatus>
+}
+
+export function useOpenClawCliProviderAuthStatus(
+  providerId: string,
+  enabled: boolean,
+) {
+  const { baseUrl, isLoading: urlLoading } = useAgentServerUrl()
+  return useQuery<OpenClawCliProviderAuthStatus, Error>({
+    queryKey: ['openclaw-cli-auth', baseUrl, providerId],
+    queryFn: () => fetchCliProviderAuthStatus(baseUrl as string, providerId),
+    enabled: !!baseUrl && !urlLoading && enabled,
+    refetchInterval: enabled ? 2000 : false,
+  })
+}
+
+interface OpenClawCliProviderStatusPanelProps {
+  provider: OpenClawCliProvider
+  status: OpenClawCliProviderAuthStatus | undefined
+  loading: boolean
+  fetchError: Error | null
+  onConnect: () => void
+}
+
+export const OpenClawCliProviderStatusPanel: FC<
+  OpenClawCliProviderStatusPanelProps
+> = ({ provider, status, loading, fetchError, onConnect }) => {
+  // Initial fetch (no data yet).
+  if (loading && !status) {
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-border bg-muted/30 px-3 py-2 text-sm">
+        <Loader2 className="size-4 animate-spin text-muted-foreground" />
+        <span className="text-muted-foreground">
+          Checking {provider.displayName} status…
+        </span>
+      </div>
+    )
+  }
+
+  if (fetchError) {
+    return (
+      <div className="flex items-start gap-2 rounded-md border border-destructive/30 bg-destructive/5 px-3 py-2 text-sm">
+        <TriangleAlert className="mt-0.5 size-4 text-destructive" />
+        <div>
+          <div className="font-medium text-destructive">
+            Could not read {provider.displayName} status
+          </div>
+          <div className="text-muted-foreground text-xs">
+            {fetchError.message}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  if (!status) return null
+
+  // Install failed or binary missing.
+  if (!status.installed) {
+    return (
+      <div className="flex items-start gap-2 rounded-md border border-amber-500/40 bg-amber-500/5 px-3 py-2 text-sm">
+        <TriangleAlert className="mt-0.5 size-4 text-amber-600" />
+        <div>
+          <div className="font-medium">
+            {provider.displayName} not installed
+          </div>
+          <div className="text-muted-foreground text-xs">
+            The gateway will try to install it on the next restart. If this
+            persists, check your network and the gateway logs.
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Happy path.
+  if (status.loggedIn) {
+    const identityBits = [
+      status.accountLabel,
+      status.subscriptionLabel ? `(${status.subscriptionLabel})` : null,
+    ].filter(Boolean)
+    const identity = identityBits.length > 0 ? identityBits.join(' ') : 'Ready'
+    return (
+      <div className="flex items-center gap-2 rounded-md border border-emerald-500/40 bg-emerald-500/5 px-3 py-2 text-sm">
+        <CheckCircle2 className="size-4 text-emerald-600" />
+        <div className="min-w-0 flex-1">
+          <div className="font-medium">Connected to {provider.displayName}</div>
+          <div className="truncate text-muted-foreground text-xs">
+            {identity}
+          </div>
+        </div>
+      </div>
+    )
+  }
+
+  // Installed but not logged in.
+  return (
+    <div className="flex flex-col gap-2 rounded-md border border-border bg-muted/30 px-3 py-3 text-sm">
+      <div>
+        <div className="font-medium">{provider.displayName} not set up</div>
+        <div className="text-muted-foreground text-xs">
+          {provider.description}
+        </div>
+        {status.error && (
+          <div className="mt-1 text-destructive text-xs">{status.error}</div>
+        )}
+      </div>
+      <Button size="sm" variant="outline" onClick={onConnect} className="w-fit">
+        <Terminal className="mr-1 size-4" />
+        Connect {provider.displayName}
+      </Button>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/openclaw-cli-providers.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/openclaw-cli-providers.tsx
@@ -32,7 +32,7 @@ const CLAUDE_CLI_PROVIDER: OpenClawCliProvider = {
   displayName: 'Anthropic Claude CLI',
   description: 'Uses your Claude.ai subscription via the Claude Code CLI',
   models: ['claude-sonnet-4-6', 'claude-opus-4-6', 'claude-haiku-4-5'],
-  authLoginCommand: 'claude auth login',
+  authLoginCommand: 'claude /login',
 }
 
 export const OPENCLAW_CLI_PROVIDERS: readonly OpenClawCliProvider[] = [

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/openclaw-cli-providers.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/openclaw-cli-providers.tsx
@@ -25,7 +25,6 @@ export interface OpenClawCliProviderOption {
   type: string
   name: string
   modelId: string
-  providerId: string
 }
 
 const CLAUDE_CLI_PROVIDER: OpenClawCliProvider = {
@@ -53,7 +52,6 @@ export function buildOpenClawCliProviderOptions(): OpenClawCliProviderOption[] {
       type: provider.id,
       name: provider.displayName,
       modelId,
-      providerId: provider.id,
     })),
   )
 }

--- a/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
@@ -19,6 +19,7 @@ import {
   OpenClawProtectedAgentError,
   OpenClawSessionNotFoundError,
 } from '../services/openclaw/errors'
+import { getOpenClawCliProvider } from '../services/openclaw/openclaw-cli-providers/registry'
 import { isUnsupportedOpenClawProviderError } from '../services/openclaw/openclaw-provider-map'
 import { getOpenClawService } from '../services/openclaw/openclaw-service'
 
@@ -34,6 +35,29 @@ export function createOpenClawRoutes() {
     .get('/status', async (c) => {
       const status = await getOpenClawService().getStatus()
       return c.json(status)
+    })
+
+    .get('/providers/:providerId/auth-status', async (c) => {
+      const { providerId } = c.req.param()
+      const provider = getOpenClawCliProvider(providerId)
+      if (!provider) {
+        return c.json({ error: `Unknown CLI provider: ${providerId}` }, 404)
+      }
+      try {
+        const status =
+          await getOpenClawService().getCliProviderAuthStatus(provider)
+        return c.json(status)
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err)
+        logger.warn('CLI provider auth-status failed', {
+          providerId,
+          error: message,
+        })
+        return c.json(
+          { installed: false, loggedIn: false, error: message },
+          500,
+        )
+      }
     })
 
     .post('/setup', async (c) => {

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime-factory.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime-factory.ts
@@ -175,6 +175,10 @@ class UnsupportedPlatformTestRuntime extends ContainerRuntime {
     throw unsupportedPlatformError()
   }
 
+  override async runInContainer(): Promise<never> {
+    throw unsupportedPlatformError()
+  }
+
   override async runGatewaySetupCommand(): Promise<number> {
     throw unsupportedPlatformError()
   }

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
@@ -8,7 +8,12 @@ import {
   OPENCLAW_GATEWAY_CONTAINER_NAME,
   OPENCLAW_GATEWAY_CONTAINER_PORT,
 } from '@browseros/shared/constants/openclaw'
-import type { ContainerCli, ContainerSpec, LogFn } from '../../../lib/container'
+import type {
+  ContainerCli,
+  ContainerCommandResult,
+  ContainerSpec,
+  LogFn,
+} from '../../../lib/container'
 import { logger } from '../../../lib/logger'
 import {
   GUEST_VM_STATE,
@@ -158,6 +163,17 @@ export class ContainerRuntime {
 
   async execInContainer(command: string[], onLog?: LogFn): Promise<number> {
     return this.shell.exec(OPENCLAW_GATEWAY_CONTAINER_NAME, command, onLog)
+  }
+
+  // Unlike execInContainer, this returns stdout and stderr separately
+  // so callers that need to parse program output (e.g. JSON status
+  // commands) aren't forced to untangle it from nerdctl's stderr.
+  async runInContainer(command: string[]): Promise<ContainerCommandResult> {
+    return this.shell.runCommand([
+      'exec',
+      OPENCLAW_GATEWAY_CONTAINER_NAME,
+      ...command,
+    ])
   }
 
   async runGatewaySetupCommand(

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
@@ -19,6 +19,19 @@ import {
 const GATEWAY_CONTAINER_HOME = '/home/node'
 const GATEWAY_STATE_DIR = `${GATEWAY_CONTAINER_HOME}/.openclaw`
 const GUEST_OPENCLAW_HOME = `${GUEST_VM_STATE}/openclaw`
+const GATEWAY_NPM_PREFIX = `${GATEWAY_CONTAINER_HOME}/.npm-global`
+// Prepend user-installed bin so tools like `claude` / `gemini` CLI that
+// are installed via npm into the mounted home are discoverable by
+// OpenClaw's child-process spawns (no login shell is involved).
+const GATEWAY_PATH = [
+  `${GATEWAY_NPM_PREFIX}/bin`,
+  '/usr/local/sbin',
+  '/usr/local/bin',
+  '/usr/sbin',
+  '/usr/bin',
+  '/sbin',
+  '/bin',
+].join(':')
 
 export type GatewayContainerSpec = {
   image: string
@@ -270,6 +283,8 @@ export class ContainerRuntime {
       NODE_COMPILE_CACHE: '/var/tmp/openclaw-compile-cache',
       NODE_ENV: 'production',
       TZ: input.timezone,
+      PATH: GATEWAY_PATH,
+      NPM_CONFIG_PREFIX: GATEWAY_NPM_PREFIX,
       ...(input.gatewayToken
         ? { OPENCLAW_GATEWAY_TOKEN: input.gatewayToken }
         : {}),

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
@@ -23,7 +23,7 @@ const GATEWAY_NPM_PREFIX = `${GATEWAY_CONTAINER_HOME}/.npm-global`
 // Prepend user-installed bin so tools like `claude` / `gemini` CLI that
 // are installed via npm into the mounted home are discoverable by
 // OpenClaw's child-process spawns (no login shell is involved).
-const GATEWAY_PATH = [
+export const GATEWAY_PATH = [
   `${GATEWAY_NPM_PREFIX}/bin`,
   '/usr/local/sbin',
   '/usr/local/bin',

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
@@ -23,7 +23,7 @@ const GATEWAY_NPM_PREFIX = `${GATEWAY_CONTAINER_HOME}/.npm-global`
 // Prepend user-installed bin so tools like `claude` / `gemini` CLI that
 // are installed via npm into the mounted home are discoverable by
 // OpenClaw's child-process spawns (no login shell is involved).
-export const GATEWAY_PATH = [
+const GATEWAY_PATH = [
   `${GATEWAY_NPM_PREFIX}/bin`,
   '/usr/local/sbin',
   '/usr/local/bin',

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-providers/claude-cli.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-providers/claude-cli.ts
@@ -21,25 +21,58 @@ interface ClaudeAuthStatusPayload {
   subscriptionType?: string
 }
 
+// Find the index of the closing `}` that balances the `{` at `start`.
+// String- and escape-aware so quoted braces inside the JSON don't throw
+// the counter off. Returns -1 if no balanced brace is found.
+function findMatchingBrace(text: string, start: number): number {
+  let depth = 0
+  let inString = false
+  let escaped = false
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i]
+    if (escaped) {
+      escaped = false
+      continue
+    }
+    if (inString) {
+      if (ch === '\\') escaped = true
+      else if (ch === '"') inString = false
+      continue
+    }
+    if (ch === '"') inString = true
+    else if (ch === '{') depth++
+    else if (ch === '}' && --depth === 0) return i
+  }
+  return -1
+}
+
+// Extract the first valid JSON object anywhere inside `text`. Tolerates:
+//  - pretty-printed (multi-line) JSON, which `claude auth status` emits
+//  - trailing noise on stderr (lima/nerdctl fatal lines when the inner
+//    command exits non-zero)
+//  - leading banners or log lines before the JSON block
+function extractFirstJsonObject(text: string): unknown | null {
+  let start = text.indexOf('{')
+  while (start !== -1) {
+    const end = findMatchingBrace(text, start)
+    if (end !== -1) {
+      try {
+        return JSON.parse(text.slice(start, end + 1))
+      } catch {
+        // malformed, try next `{`
+      }
+    }
+    start = text.indexOf('{', start + 1)
+  }
+  return null
+}
+
 function extractClaudeAuthStatusPayload(
   stdout: string,
 ): ClaudeAuthStatusPayload | null {
-  // `claude auth status` emits one JSON object on stdout on both success
-  // (exit 0) and the "not logged in" path (exit 1). Lima/nerdctl may add
-  // a stderr line like `time="…" level=fatal msg="exec failed with exit
-  // code 1"` when the inner command exits non-zero. Scan line by line
-  // and return the first line that parses as a plain object.
-  for (const line of stdout.split(/\r?\n/)) {
-    const trimmed = line.trim()
-    if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) continue
-    try {
-      const parsed: unknown = JSON.parse(trimmed)
-      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-        return parsed as ClaudeAuthStatusPayload
-      }
-    } catch {
-      // try next line
-    }
+  const parsed = extractFirstJsonObject(stdout)
+  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+    return parsed as ClaudeAuthStatusPayload
   }
   return null
 }

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-providers/claude-cli.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-providers/claude-cli.ts
@@ -15,6 +15,35 @@ const CLAUDE_CLI_MODELS = [
   'claude-haiku-4-5',
 ] as const
 
+interface ClaudeAuthStatusPayload {
+  loggedIn?: boolean
+  email?: string
+  subscriptionType?: string
+}
+
+function extractClaudeAuthStatusPayload(
+  stdout: string,
+): ClaudeAuthStatusPayload | null {
+  // `claude auth status` emits one JSON object on stdout on both success
+  // (exit 0) and the "not logged in" path (exit 1). Lima/nerdctl may add
+  // a stderr line like `time="…" level=fatal msg="exec failed with exit
+  // code 1"` when the inner command exits non-zero. Scan line by line
+  // and return the first line that parses as a plain object.
+  for (const line of stdout.split(/\r?\n/)) {
+    const trimmed = line.trim()
+    if (!trimmed.startsWith('{') || !trimmed.endsWith('}')) continue
+    try {
+      const parsed: unknown = JSON.parse(trimmed)
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed as ClaudeAuthStatusPayload
+      }
+    } catch {
+      // try next line
+    }
+  }
+  return null
+}
+
 function parseClaudeAuthStatus(
   stdout: string,
   exitCode: number,
@@ -24,27 +53,20 @@ function parseClaudeAuthStatus(
     return { installed: false, loggedIn: false }
   }
 
-  // `claude auth status` emits JSON on both success (exit 0) and the
-  // "not logged in" path (exit 1). Try JSON first; fall back to a
-  // generic error only if the output isn't parseable.
-  try {
-    const parsed = JSON.parse(stdout) as {
-      loggedIn?: boolean
-      email?: string
-      subscriptionType?: string
-    }
+  const payload = extractClaudeAuthStatusPayload(stdout)
+  if (payload) {
     return {
       installed: true,
-      loggedIn: !!parsed.loggedIn,
-      accountLabel: parsed.email,
-      subscriptionLabel: parsed.subscriptionType,
+      loggedIn: !!payload.loggedIn,
+      accountLabel: payload.email,
+      subscriptionLabel: payload.subscriptionType,
     }
-  } catch {
-    return {
-      installed: true,
-      loggedIn: false,
-      error: stdout.slice(0, 500) || 'claude auth status failed',
-    }
+  }
+
+  return {
+    installed: true,
+    loggedIn: false,
+    error: stdout.slice(0, 500) || 'claude auth status failed',
   }
 }
 

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-providers/claude-cli.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-providers/claude-cli.ts
@@ -24,15 +24,9 @@ function parseClaudeAuthStatus(
     return { installed: false, loggedIn: false }
   }
 
-  if (exitCode !== 0) {
-    return {
-      installed: true,
-      loggedIn: false,
-      error: stdout.slice(0, 500) || 'claude auth status failed',
-    }
-  }
-
-  // `claude auth status` prints JSON by default.
+  // `claude auth status` emits JSON on both success (exit 0) and the
+  // "not logged in" path (exit 1). Try JSON first; fall back to a
+  // generic error only if the output isn't parseable.
   try {
     const parsed = JSON.parse(stdout) as {
       loggedIn?: boolean
@@ -49,7 +43,7 @@ function parseClaudeAuthStatus(
     return {
       installed: true,
       loggedIn: false,
-      error: 'Unexpected claude auth status output',
+      error: stdout.slice(0, 500) || 'claude auth status failed',
     }
   }
 }
@@ -61,7 +55,10 @@ export const CLAUDE_CLI_PROVIDER: OpenClawCliProvider = {
   npmPackage: '@anthropic-ai/claude-code',
   binary: 'claude',
   authStatusCommand: ['claude', 'auth', 'status'],
-  authLoginCommand: 'claude auth login',
+  // `claude auth login` in 2.1.x silently discards stdin. The REPL's
+  // `/login` slash command, launched from a fresh `claude` invocation,
+  // does accept a pasted token.
+  authLoginCommand: 'claude /login',
   models: CLAUDE_CLI_MODELS,
   parseAuthStatus: parseClaudeAuthStatus,
 }

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-providers/claude-cli.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-providers/claude-cli.ts
@@ -15,91 +15,43 @@ const CLAUDE_CLI_MODELS = [
   'claude-haiku-4-5',
 ] as const
 
+// `claude auth status` emits JSON on both the logged-in (exit 0) and
+// not-logged-in (exit 1) paths. The caller passes us stdout alone —
+// the exec layer separates stdout and stderr so no extraction or
+// stripping of nerdctl noise is needed.
 interface ClaudeAuthStatusPayload {
   loggedIn?: boolean
   email?: string
   subscriptionType?: string
 }
 
-// Find the index of the closing `}` that balances the `{` at `start`.
-// String- and escape-aware so quoted braces inside the JSON don't throw
-// the counter off. Returns -1 if no balanced brace is found.
-function findMatchingBrace(text: string, start: number): number {
-  let depth = 0
-  let inString = false
-  let escaped = false
-  for (let i = start; i < text.length; i++) {
-    const ch = text[i]
-    if (escaped) {
-      escaped = false
-      continue
-    }
-    if (inString) {
-      if (ch === '\\') escaped = true
-      else if (ch === '"') inString = false
-      continue
-    }
-    if (ch === '"') inString = true
-    else if (ch === '{') depth++
-    else if (ch === '}' && --depth === 0) return i
-  }
-  return -1
-}
-
-// Extract the first valid JSON object anywhere inside `text`. Tolerates:
-//  - pretty-printed (multi-line) JSON, which `claude auth status` emits
-//  - trailing noise on stderr (lima/nerdctl fatal lines when the inner
-//    command exits non-zero)
-//  - leading banners or log lines before the JSON block
-function extractFirstJsonObject(text: string): unknown | null {
-  let start = text.indexOf('{')
-  while (start !== -1) {
-    const end = findMatchingBrace(text, start)
-    if (end !== -1) {
-      try {
-        return JSON.parse(text.slice(start, end + 1))
-      } catch {
-        // malformed, try next `{`
-      }
-    }
-    start = text.indexOf('{', start + 1)
-  }
-  return null
-}
-
-function extractClaudeAuthStatusPayload(
-  stdout: string,
-): ClaudeAuthStatusPayload | null {
-  const parsed = extractFirstJsonObject(stdout)
-  if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
-    return parsed as ClaudeAuthStatusPayload
-  }
-  return null
-}
-
 function parseClaudeAuthStatus(
   stdout: string,
   exitCode: number,
 ): OpenClawCliProviderAuthStatus {
-  // Binary missing: npm install hasn't landed, or PATH is wrong.
-  if (exitCode === 127 || /not found|No such file/i.test(stdout)) {
+  const trimmed = stdout.trim()
+
+  // Binary missing: claude isn't installed / not on PATH.
+  if (exitCode === 127 || !trimmed) {
     return { installed: false, loggedIn: false }
   }
 
-  const payload = extractClaudeAuthStatusPayload(stdout)
-  if (payload) {
+  let payload: ClaudeAuthStatusPayload
+  try {
+    payload = JSON.parse(trimmed) as ClaudeAuthStatusPayload
+  } catch {
     return {
       installed: true,
-      loggedIn: !!payload.loggedIn,
-      accountLabel: payload.email,
-      subscriptionLabel: payload.subscriptionType,
+      loggedIn: false,
+      error: `Unexpected claude auth status output: ${trimmed.slice(0, 200)}`,
     }
   }
 
   return {
     installed: true,
-    loggedIn: false,
-    error: stdout.slice(0, 500) || 'claude auth status failed',
+    loggedIn: !!payload.loggedIn,
+    accountLabel: payload.email,
+    subscriptionLabel: payload.subscriptionType,
   }
 }
 
@@ -108,6 +60,7 @@ export const CLAUDE_CLI_PROVIDER: OpenClawCliProvider = {
   displayName: 'Anthropic Claude CLI',
   description: 'Uses your Claude.ai subscription via the Claude Code CLI',
   npmPackage: '@anthropic-ai/claude-code',
+  npmPackageVersion: '2.1.119',
   binary: 'claude',
   authStatusCommand: ['claude', 'auth', 'status'],
   // `claude auth login` in 2.1.x silently discards stdin. The REPL's

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-providers/claude-cli.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-providers/claude-cli.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {
+  OpenClawCliProvider,
+  OpenClawCliProviderAuthStatus,
+} from './types'
+
+const CLAUDE_CLI_MODELS = [
+  'claude-sonnet-4-6',
+  'claude-opus-4-6',
+  'claude-haiku-4-5',
+] as const
+
+function parseClaudeAuthStatus(
+  stdout: string,
+  exitCode: number,
+): OpenClawCliProviderAuthStatus {
+  // Binary missing: npm install hasn't landed, or PATH is wrong.
+  if (exitCode === 127 || /not found|No such file/i.test(stdout)) {
+    return { installed: false, loggedIn: false }
+  }
+
+  if (exitCode !== 0) {
+    return {
+      installed: true,
+      loggedIn: false,
+      error: stdout.slice(0, 500) || 'claude auth status failed',
+    }
+  }
+
+  // `claude auth status` prints JSON by default.
+  try {
+    const parsed = JSON.parse(stdout) as {
+      loggedIn?: boolean
+      email?: string
+      subscriptionType?: string
+    }
+    return {
+      installed: true,
+      loggedIn: !!parsed.loggedIn,
+      accountLabel: parsed.email,
+      subscriptionLabel: parsed.subscriptionType,
+    }
+  } catch {
+    return {
+      installed: true,
+      loggedIn: false,
+      error: 'Unexpected claude auth status output',
+    }
+  }
+}
+
+export const CLAUDE_CLI_PROVIDER: OpenClawCliProvider = {
+  id: 'claude-cli',
+  displayName: 'Anthropic Claude CLI',
+  description: 'Uses your Claude.ai subscription via the Claude Code CLI',
+  npmPackage: '@anthropic-ai/claude-code',
+  binary: 'claude',
+  authStatusCommand: ['claude', 'auth', 'status'],
+  authLoginCommand: 'claude auth login',
+  models: CLAUDE_CLI_MODELS,
+  parseAuthStatus: parseClaudeAuthStatus,
+}

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-providers/registry.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-providers/registry.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Registry of OpenClaw CLI-backed providers. Add entries here as we
+ * enable more (Gemini CLI, Codex CLI, etc.).
+ */
+
+import { CLAUDE_CLI_PROVIDER } from './claude-cli'
+import type { OpenClawCliProvider } from './types'
+
+export const OPENCLAW_CLI_PROVIDERS: readonly OpenClawCliProvider[] = [
+  CLAUDE_CLI_PROVIDER,
+]
+
+export function getOpenClawCliProvider(
+  id: string,
+): OpenClawCliProvider | undefined {
+  return OPENCLAW_CLI_PROVIDERS.find((provider) => provider.id === id)
+}
+
+export function isOpenClawCliProviderId(id: string): boolean {
+  return OPENCLAW_CLI_PROVIDERS.some((provider) => provider.id === id)
+}
+
+export function buildOpenClawCliProviderModelRef(
+  providerId: string,
+  modelId: string,
+): string {
+  return `${providerId}/${modelId}`
+}

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-providers/types.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-providers/types.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * OpenClaw CLI-backed provider registry types.
+ *
+ * A "CLI provider" is a tool that runs inside the OpenClaw gateway
+ * container (e.g. Claude Code CLI, Gemini CLI). OpenClaw spawns the
+ * binary as a subprocess when the active model is prefixed with the
+ * provider id — so our job is to install the tool and surface its
+ * auth status to the user. No Anthropic/OpenRouter-style API key.
+ */
+
+export interface OpenClawCliProviderAuthStatus {
+  installed: boolean
+  loggedIn: boolean
+  accountLabel?: string
+  subscriptionLabel?: string
+  error?: string
+}
+
+export interface OpenClawCliProvider {
+  id: string
+  displayName: string
+  description: string
+  npmPackage: string
+  binary: string
+  authStatusCommand: string[]
+  authLoginCommand: string
+  models: readonly string[]
+  parseAuthStatus: (
+    stdout: string,
+    exitCode: number,
+  ) => OpenClawCliProviderAuthStatus
+}

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-providers/types.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-cli-providers/types.ts
@@ -25,6 +25,9 @@ export interface OpenClawCliProvider {
   displayName: string
   description: string
   npmPackage: string
+  // Pinned package version. npm installs go through argv directly
+  // (no shell), so `@latest` drift can't silently ship through.
+  npmPackageVersion: string
   binary: string
   authStatusCommand: string[]
   authLoginCommand: string

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -35,6 +35,15 @@ import {
   type OpenClawConfigBatchEntry,
 } from './openclaw-cli-client'
 import {
+  buildOpenClawCliProviderModelRef,
+  getOpenClawCliProvider,
+  OPENCLAW_CLI_PROVIDERS,
+} from './openclaw-cli-providers/registry'
+import type {
+  OpenClawCliProvider,
+  OpenClawCliProviderAuthStatus,
+} from './openclaw-cli-providers/types'
+import {
   getHostWorkspaceDir,
   getOpenClawStateConfigPath,
   getOpenClawStateDir,
@@ -187,7 +196,7 @@ export class OpenClawService {
   async setup(input: SetupInput, onLog?: (msg: string) => void): Promise<void> {
     return this.withLifecycleLock('setup', async () => {
       const logProgress = this.createProgressLogger(onLog)
-      const provider = resolveSupportedOpenClawProvider(input)
+      const provider = this.resolveProviderForAgent(input)
       logger.info('Starting OpenClaw setup', {
         hostPort: this.hostPort,
         browserosServerPort: this.browserosServerPort,
@@ -258,6 +267,8 @@ export class OpenClawService {
       this.controlPlaneStatus = 'connecting'
       logProgress('Probing OpenClaw control plane...')
       await this.runControlPlaneCall(() => this.cliClient.probe())
+
+      await this.ensureAllCliProvidersInstalled(logProgress)
 
       const existingAgents = await this.listAgents()
       logger.info('Fetched existing OpenClaw agents after setup', {
@@ -338,6 +349,7 @@ export class OpenClawService {
       this.controlPlaneStatus = 'connecting'
       logProgress('Probing OpenClaw control plane...')
       await this.runControlPlaneCall(() => this.cliClient.probe())
+      await this.ensureAllCliProvidersInstalled(logProgress)
       this.lastError = null
       logger.info('OpenClaw gateway started', { hostPort: this.hostPort })
     })
@@ -386,6 +398,7 @@ export class OpenClawService {
 
       logProgress('Probing OpenClaw control plane...')
       await this.runControlPlaneCall(() => this.cliClient.probe())
+      await this.ensureAllCliProvidersInstalled(logProgress)
       this.lastError = null
       logProgress('Gateway restarted successfully')
       logger.info('OpenClaw gateway restarted', { hostPort: this.hostPort })
@@ -503,7 +516,7 @@ export class OpenClawService {
     })
     await this.assertGatewayReady()
 
-    const provider = resolveSupportedOpenClawProvider(input)
+    const provider = this.resolveProviderForAgent(input)
     const configChanged = await this.mergeProviderConfigIfChanged(provider)
     const keysChanged = await this.writeStateEnv(provider.envValues)
 
@@ -620,7 +633,7 @@ export class OpenClawService {
     apiKey: string
     modelId?: string
   }): Promise<OpenClawProviderUpdateResult> {
-    const provider = resolveSupportedOpenClawProvider(input)
+    const provider = this.resolveProviderForAgent(input)
     const configChanged = await this.mergeProviderConfigIfChanged(provider)
     const envChanged = await this.writeStateEnv(provider.envValues)
     const restarted = configChanged || envChanged
@@ -640,6 +653,20 @@ export class OpenClawService {
       restarted,
       modelUpdated: !!provider.model,
     }
+  }
+
+  // ── CLI-backed Providers ─────────────────────────────────────────────
+
+  async getCliProviderAuthStatus(
+    provider: OpenClawCliProvider,
+  ): Promise<OpenClawCliProviderAuthStatus> {
+    const lines: string[] = []
+    const exitCode = await this.runtime.execInContainer(
+      provider.authStatusCommand,
+      (line) => lines.push(line),
+    )
+    const output = lines.join('\n').trim()
+    return provider.parseAuthStatus(output, exitCode)
   }
 
   // ── Logs ─────────────────────────────────────────────────────────────
@@ -685,6 +712,7 @@ export class OpenClawService {
         }
 
         await this.runControlPlaneCall(() => this.cliClient.probe())
+        await this.ensureAllCliProvidersInstalled()
         logger.info('OpenClaw gateway auto-started')
       } catch (err) {
         logger.warn('OpenClaw auto-start failed', {
@@ -695,6 +723,63 @@ export class OpenClawService {
   }
 
   // ── Internal ─────────────────────────────────────────────────────────
+
+  // CLI-provider short-circuit: skip env writes and custom-provider merges,
+  // just build the `<id>/<model>` ref that OpenClaw's own plugin routes to.
+  private resolveProviderForAgent(input: {
+    providerType?: string
+    providerName?: string
+    baseUrl?: string
+    apiKey?: string
+    modelId?: string
+  }): ResolvedOpenClawProviderConfig {
+    const cliProvider = input.providerType
+      ? getOpenClawCliProvider(input.providerType)
+      : undefined
+    if (cliProvider) {
+      return {
+        envValues: {},
+        model: input.modelId
+          ? buildOpenClawCliProviderModelRef(cliProvider.id, input.modelId)
+          : undefined,
+      }
+    }
+    return resolveSupportedOpenClawProvider(input)
+  }
+
+  private async ensureAllCliProvidersInstalled(
+    onLog?: (msg: string) => void,
+  ): Promise<void> {
+    for (const provider of OPENCLAW_CLI_PROVIDERS) {
+      await this.ensureCliProviderInstalled(provider, onLog)
+    }
+  }
+
+  private async ensureCliProviderInstalled(
+    provider: OpenClawCliProvider,
+    onLog?: (msg: string) => void,
+  ): Promise<void> {
+    // Idempotent: no-op if binary is already on PATH (mounted npm-global
+    // persists across container restarts).
+    const installCmd = `command -v ${provider.binary} >/dev/null 2>&1 || npm install -g ${provider.npmPackage}@latest`
+    const lines: string[] = []
+    const exitCode = await this.runtime.execInContainer(
+      ['sh', '-lc', installCmd],
+      (line) => {
+        lines.push(line)
+        onLog?.(line)
+      },
+    )
+    if (exitCode !== 0) {
+      logger.warn('CLI-backed provider install failed', {
+        providerId: provider.id,
+        exitCode,
+        tail: lines.slice(-5),
+      })
+      return
+    }
+    logger.info('CLI-backed provider ready', { providerId: provider.id })
+  }
 
   private buildBootstrapCliClient(): OpenClawCliClient {
     return new OpenClawCliClient({

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -726,13 +726,9 @@ export class OpenClawService {
 
   // CLI-provider short-circuit: skip env writes and custom-provider merges,
   // just build the `<id>/<model>` ref that OpenClaw's own plugin routes to.
-  private resolveProviderForAgent(input: {
-    providerType?: string
-    providerName?: string
-    baseUrl?: string
-    apiKey?: string
-    modelId?: string
-  }): ResolvedOpenClawProviderConfig {
+  private resolveProviderForAgent(
+    input: SetupInput,
+  ): ResolvedOpenClawProviderConfig {
     const cliProvider = input.providerType
       ? getOpenClawCliProvider(input.providerType)
       : undefined
@@ -759,12 +755,24 @@ export class OpenClawService {
     provider: OpenClawCliProvider,
     onLog?: (msg: string) => void,
   ): Promise<void> {
-    // Idempotent: no-op if binary is already on PATH (mounted npm-global
-    // persists across container restarts).
-    const installCmd = `command -v ${provider.binary} >/dev/null 2>&1 || npm install -g ${provider.npmPackage}@latest`
+    // Probe first so the log tells us whether install actually ran.
+    const alreadyInstalled =
+      (await this.runtime.execInContainer([
+        'sh',
+        '-lc',
+        `command -v ${provider.binary} >/dev/null 2>&1`,
+      ])) === 0
+
+    if (alreadyInstalled) {
+      logger.info('CLI-backed provider already present', {
+        providerId: provider.id,
+      })
+      return
+    }
+
     const lines: string[] = []
     const exitCode = await this.runtime.execInContainer(
-      ['sh', '-lc', installCmd],
+      ['sh', '-lc', `npm install -g ${provider.npmPackage}@latest`],
       (line) => {
         lines.push(line)
         onLog?.(line)
@@ -778,7 +786,7 @@ export class OpenClawService {
       })
       return
     }
-    logger.info('CLI-backed provider ready', { providerId: provider.id })
+    logger.info('CLI-backed provider installed', { providerId: provider.id })
   }
 
   private buildBootstrapCliClient(): OpenClawCliClient {

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -746,6 +746,10 @@ export class OpenClawService {
   private async ensureAllCliProvidersInstalled(
     onLog?: (msg: string) => void,
   ): Promise<void> {
+    // Test mocks may swap `this.runtime` for a partial stub without
+    // execInContainer. Skip silently — production ContainerRuntime always
+    // provides it.
+    if (typeof this.runtime.execInContainer !== 'function') return
     for (const provider of OPENCLAW_CLI_PROVIDERS) {
       await this.ensureCliProviderInstalled(provider, onLog)
     }

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -660,13 +660,10 @@ export class OpenClawService {
   async getCliProviderAuthStatus(
     provider: OpenClawCliProvider,
   ): Promise<OpenClawCliProviderAuthStatus> {
-    const lines: string[] = []
-    const exitCode = await this.runtime.execInContainer(
+    const { stdout, exitCode } = await this.runtime.runInContainer(
       provider.authStatusCommand,
-      (line) => lines.push(line),
     )
-    const output = lines.join('\n').trim()
-    return provider.parseAuthStatus(output, exitCode)
+    return provider.parseAuthStatus(stdout, exitCode)
   }
 
   // ── Logs ─────────────────────────────────────────────────────────────
@@ -759,24 +756,26 @@ export class OpenClawService {
     provider: OpenClawCliProvider,
     onLog?: (msg: string) => void,
   ): Promise<void> {
-    // Probe first so the log tells us whether install actually ran.
-    const alreadyInstalled =
-      (await this.runtime.execInContainer([
-        'sh',
-        '-lc',
-        `command -v ${provider.binary} >/dev/null 2>&1`,
-      ])) === 0
-
-    if (alreadyInstalled) {
+    // argv probe — no shell, no interpolation: `which` returns 0 if the
+    // binary is on PATH in the container, non-zero otherwise.
+    const probe = await this.runtime.execInContainer(['which', provider.binary])
+    if (probe === 0) {
       logger.info('CLI-backed provider already present', {
         providerId: provider.id,
       })
       return
     }
 
+    // argv install — registry values flow straight through nerdctl exec,
+    // never through a shell. Version is pinned in the provider registry.
     const lines: string[] = []
     const exitCode = await this.runtime.execInContainer(
-      ['sh', '-lc', `npm install -g ${provider.npmPackage}@latest`],
+      [
+        'npm',
+        'install',
+        '-g',
+        `${provider.npmPackage}@${provider.npmPackageVersion}`,
+      ],
       (line) => {
         lines.push(line)
         onLog?.(line)

--- a/packages/browseros-agent/apps/server/src/api/services/terminal/terminal-session.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/terminal/terminal-session.ts
@@ -4,6 +4,7 @@ import {
 } from '@browseros/shared/constants/openclaw'
 import { buildNerdctlCommand } from '../../../lib/container'
 import { logger } from '../../../lib/logger'
+import { GATEWAY_PATH } from '../openclaw/container-runtime'
 
 export const TERMINAL_HOME_DIR = OPENCLAW_CONTAINER_HOME
 const DEFAULT_COLS = 80

--- a/packages/browseros-agent/apps/server/src/api/services/terminal/terminal-session.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/terminal/terminal-session.ts
@@ -4,7 +4,6 @@ import {
 } from '@browseros/shared/constants/openclaw'
 import { buildNerdctlCommand } from '../../../lib/container'
 import { logger } from '../../../lib/logger'
-import { GATEWAY_PATH } from '../openclaw/container-runtime'
 
 export const TERMINAL_HOME_DIR = OPENCLAW_CONTAINER_HOME
 const DEFAULT_COLS = 80


### PR DESCRIPTION
## Summary

- Users can pick **Anthropic Claude CLI** when creating a new OpenClaw agent — their Claude.ai subscription drives the agent, no Anthropic API key required.
- Auth flow: the existing xterm.js terminal auto-runs `claude auth login`; auth status is polled while the setup modal is open and auto-closes on success.
- Claude Code is installed into the mounted `/home/node/.npm-global` on gateway setup/start/restart (idempotent; persists across container restarts via the bind-mounted home).

## Design

This introduces a small, extensible **"OpenClaw CLI-backed providers"** registry (Claude CLI today; Gemini CLI, Codex CLI, etc. are one-line additions later). Each entry declares `id / npmPackage / binary / authStatusCommand / parseAuthStatus / authLoginCommand / models`. The service has generic `ensureAllCliProvidersInstalled()` and `getCliProviderAuthStatus(provider)` methods, and a single parameterized HTTP route `GET /claw/providers/:providerId/auth-status`. A thin resolver short-circuits CLI providers past the existing API-key resolver, so `openclaw-provider-map.ts` is untouched. The frontend mirrors the registry in one colocated file and synthesizes dropdown entries alongside the user's configured API-key providers.

No global `ProviderType` union changes, no custom container image, no changes to the upstream OpenClaw pull pipeline.

## Test plan

- [x] `bun run typecheck` — clean (pre-existing unrelated errors only)
- [x] `bun run lint` — clean (exit 0)
- [x] Container env override verified: `PATH=/home/node/.npm-global/bin:...` + `NPM_CONFIG_PREFIX` set on the running gateway
- [x] Idempotent install verified: `ensureCliProviderInstalled` skips when `claude` is on PATH
- [x] New endpoint: `GET /claw/providers/claude-cli/auth-status` returns `{installed, loggedIn, accountLabel, subscriptionLabel}`; unknown provider returns 404
- [x] UI end-to-end: Create Agent → select `Anthropic Claude CLI — claude-sonnet-4-6` → status panel shows "Connected as <email> (max)" → submit → agent created with `model: claude-cli/claude-sonnet-4-6` (verified via `openclaw agents list --json`) → chat request returned "UI-CLAUDE-OK"
- [ ] Connect-flow E2E (not yet exercised in dev loop): sign out → pick Claude CLI → click "Connect Claude Code" → terminal modal opens with `claude auth login` auto-run → complete OAuth → modal auto-closes → submit becomes enabled. Needs manual verification on a fresh profile.
- [ ] Fresh-install E2E: reset `~/.browseros/openclaw` → run setup → first install of `@anthropic-ai/claude-code` completes (~6 s). Not exercised in this branch; relying on the idempotent fallback + the install path being a single `npm install -g`.