### PR TITLE
feat(openclaw): HTTP session history endpoint (JSON + SSE)

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
@@ -349,8 +349,9 @@ export function createOpenClawRoutes() {
       const key = c.req.param('key')
       const limitRaw = c.req.query('limit')
       const cursor = c.req.query('cursor')
-      const limit =
-        limitRaw !== undefined ? Number.parseInt(limitRaw, 10) : undefined
+      const limitParsed =
+        limitRaw !== undefined ? Number.parseInt(limitRaw, 10) : Number.NaN
+      const limit = Number.isFinite(limitParsed) ? limitParsed : undefined
       const wantsStream = (c.req.header('accept') ?? '').includes(
         'text/event-stream',
       )

--- a/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
@@ -19,6 +19,7 @@ import {
   OpenClawAgentNotFoundError,
   OpenClawInvalidAgentNameError,
   OpenClawProtectedAgentError,
+  OpenClawSessionNotFoundError,
 } from '../services/openclaw/errors'
 import { isUnsupportedOpenClawProviderError } from '../services/openclaw/openclaw-provider-map'
 import { getOpenClawService } from '../services/openclaw/openclaw-service'
@@ -338,6 +339,60 @@ export function createOpenClawRoutes() {
         })
         if (isUnsupportedOpenClawProviderError(err)) {
           return c.json({ error: err.message }, 400)
+        }
+        const message = err instanceof Error ? err.message : String(err)
+        return c.json({ error: message }, 500)
+      }
+    })
+
+    .get('/session/:key/history', async (c) => {
+      const key = c.req.param('key')
+      const limitRaw = c.req.query('limit')
+      const cursor = c.req.query('cursor')
+      const limit =
+        limitRaw !== undefined ? Number.parseInt(limitRaw, 10) : undefined
+      const wantsStream = (c.req.header('accept') ?? '').includes(
+        'text/event-stream',
+      )
+
+      try {
+        if (!wantsStream) {
+          const history = await getOpenClawService().getSessionHistory(key, {
+            limit,
+            cursor,
+          })
+          return c.json(history)
+        }
+
+        const eventStream = await getOpenClawService().streamSessionHistory(
+          key,
+          { limit, cursor, signal: c.req.raw.signal },
+        )
+
+        c.header('Content-Type', 'text/event-stream')
+        c.header('Cache-Control', 'no-cache')
+        c.header('X-Session-Key', key)
+
+        return stream(c, async (s) => {
+          const reader = eventStream.getReader()
+          const encoder = new TextEncoder()
+          try {
+            while (true) {
+              const { done, value } = await reader.read()
+              if (done) break
+              await s.write(
+                encoder.encode(
+                  `event: ${value.type}\ndata: ${JSON.stringify(value.data)}\n\n`,
+                ),
+              )
+            }
+          } finally {
+            await reader.cancel()
+          }
+        })
+      } catch (err) {
+        if (err instanceof OpenClawSessionNotFoundError) {
+          return c.json({ error: err.message }, 404)
         }
         const message = err instanceof Error ? err.message : String(err)
         return c.json({ error: message }, 500)

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/errors.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/errors.ts
@@ -27,3 +27,10 @@ export class OpenClawProtectedAgentError extends Error {
     this.name = 'OpenClawProtectedAgentError'
   }
 }
+
+export class OpenClawSessionNotFoundError extends Error {
+  constructor(public readonly sessionKey: string) {
+    super(`OpenClaw session not found: ${sessionKey}`)
+    this.name = 'OpenClawSessionNotFoundError'
+  }
+}

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-http-client.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-http-client.ts
@@ -20,6 +20,48 @@ export interface OpenClawChatRequest {
   signal?: AbortSignal
 }
 
+export interface OpenClawSessionHistoryMessage {
+  role: 'user' | 'assistant' | 'system' | 'tool'
+  content: string
+  messageId?: string
+  messageSeq?: number
+  timestamp?: number
+}
+
+export interface OpenClawSessionHistory {
+  sessionKey: string
+  messages: OpenClawSessionHistoryMessage[]
+  cursor?: string | null
+  hasMore?: boolean
+  truncated?: boolean
+}
+
+export interface OpenClawSessionHistoryInput {
+  limit?: number
+  cursor?: string
+  signal?: AbortSignal
+}
+
+export type OpenClawSessionHistoryEvent =
+  | { type: 'history'; data: OpenClawSessionHistory }
+  | {
+      type: 'message'
+      data: {
+        sessionKey: string
+        message: OpenClawSessionHistoryMessage
+        messageId?: string
+        messageSeq: number
+      }
+    }
+  | { type: 'error'; data: { message: string } }
+
+export class OpenClawSessionNotFoundError extends Error {
+  constructor(public readonly sessionKey: string) {
+    super(`OpenClaw session not found: ${sessionKey}`)
+    this.name = 'OpenClawSessionNotFoundError'
+  }
+}
+
 export class OpenClawHttpClient {
   constructor(
     private readonly hostPort: number,
@@ -37,6 +79,28 @@ export class OpenClawHttpClient {
     }
 
     return createEventStream(body, input.signal)
+  }
+
+  async getSessionHistory(
+    sessionKey: string,
+    input: OpenClawSessionHistoryInput = {},
+  ): Promise<OpenClawSessionHistory> {
+    const response = await this.fetchSessionHistory(sessionKey, input, {})
+    return (await response.json()) as OpenClawSessionHistory
+  }
+
+  async streamSessionHistory(
+    sessionKey: string,
+    input: OpenClawSessionHistoryInput = {},
+  ): Promise<ReadableStream<OpenClawSessionHistoryEvent>> {
+    const response = await this.fetchSessionHistory(sessionKey, input, {
+      Accept: 'text/event-stream',
+    })
+    const body = response.body
+    if (!body) {
+      throw new Error('OpenClaw session history stream had no body')
+    }
+    return createHistoryEventStream(body, input.signal)
   }
 
   private async fetchChat(input: OpenClawChatRequest): Promise<Response> {
@@ -71,6 +135,50 @@ export class OpenClawHttpClient {
       detail || `OpenClaw chat failed with status ${response.status}`,
     )
   }
+
+  private async fetchSessionHistory(
+    sessionKey: string,
+    input: OpenClawSessionHistoryInput,
+    extraHeaders: Record<string, string>,
+  ): Promise<Response> {
+    const token = await this.getToken()
+    const response = await fetch(
+      `http://127.0.0.1:${this.hostPort}${buildHistoryPath(sessionKey, input)}`,
+      {
+        method: 'GET',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          ...extraHeaders,
+        },
+        signal: input.signal,
+      },
+    )
+
+    if (response.status === 404) {
+      throw new OpenClawSessionNotFoundError(sessionKey)
+    }
+    if (!response.ok) {
+      const detail = await response.text()
+      throw new Error(
+        detail ||
+          `OpenClaw session history failed with status ${response.status}`,
+      )
+    }
+    return response
+  }
+}
+
+function buildHistoryPath(
+  sessionKey: string,
+  input: OpenClawSessionHistoryInput,
+): string {
+  const qs = new URLSearchParams()
+  if (input.limit !== undefined) qs.set('limit', String(input.limit))
+  if (input.cursor !== undefined) qs.set('cursor', input.cursor)
+  const suffix = qs.toString()
+  return `/sessions/${encodeURIComponent(sessionKey)}/history${
+    suffix ? `?${suffix}` : ''
+  }`
 }
 
 function resolveAgentModel(agentId: string): string {
@@ -261,4 +369,105 @@ function parseChunk(data: string): Record<string, unknown> | null {
   } catch {
     return null
   }
+}
+
+function createHistoryEventStream(
+  body: ReadableStream<Uint8Array>,
+  signal?: AbortSignal,
+): ReadableStream<OpenClawSessionHistoryEvent> {
+  return new ReadableStream<OpenClawSessionHistoryEvent>({
+    start(controller) {
+      void pumpHistoryEvents(body, controller, signal)
+    },
+  })
+}
+
+async function pumpHistoryEvents(
+  body: ReadableStream<Uint8Array>,
+  controller: ReadableStreamDefaultController<OpenClawSessionHistoryEvent>,
+  signal?: AbortSignal,
+): Promise<void> {
+  const reader = body.getReader()
+  const decoder = new TextDecoder()
+  let closed = false
+  const close = () => {
+    if (closed) return
+    closed = true
+    controller.close()
+  }
+  const parser = createParser({
+    onEvent(message) {
+      if (closed) return
+      const event = toHistoryEvent(message)
+      if (!event) return
+      controller.enqueue(event)
+      if (event.type === 'error') close()
+    },
+  })
+
+  const onAbort = () => {
+    void reader.cancel().catch(() => {})
+    close()
+  }
+  signal?.addEventListener('abort', onAbort, { once: true })
+
+  try {
+    while (true) {
+      if (signal?.aborted) {
+        await reader.cancel()
+        close()
+        return
+      }
+      const { done, value } = await reader.read()
+      if (done) break
+      parser.feed(decoder.decode(value, { stream: true }))
+    }
+  } catch (error) {
+    if (!closed) {
+      controller.enqueue({
+        type: 'error',
+        data: {
+          message: error instanceof Error ? error.message : String(error),
+        },
+      })
+      close()
+    }
+  } finally {
+    signal?.removeEventListener('abort', onAbort)
+    close()
+    reader.releaseLock()
+  }
+}
+
+function toHistoryEvent(
+  message: EventSourceMessage,
+): OpenClawSessionHistoryEvent | null {
+  if (!message.event) return null
+  const payload = parseChunk(message.data)
+  if (!payload) return null
+  if (message.event === 'history') {
+    return {
+      type: 'history',
+      data: payload as unknown as OpenClawSessionHistory,
+    }
+  }
+  if (message.event === 'message') {
+    return {
+      type: 'message',
+      data: payload as unknown as {
+        sessionKey: string
+        message: OpenClawSessionHistoryMessage
+        messageId?: string
+        messageSeq: number
+      },
+    }
+  }
+  if (message.event === 'error') {
+    const errMessage =
+      typeof payload.message === 'string'
+        ? payload.message
+        : 'OpenClaw session history stream error'
+    return { type: 'error', data: { message: errMessage } }
+  }
+  return null
 }

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-http-client.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-http-client.ts
@@ -20,7 +20,7 @@ export interface OpenClawChatRequest {
   signal?: AbortSignal
 }
 
-export class OpenClawHttpChatClient {
+export class OpenClawHttpClient {
   constructor(
     private readonly hostPort: number,
     private readonly getToken: () => Promise<string>,

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-http-client.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-http-client.ts
@@ -5,6 +5,7 @@
  */
 
 import { createParser, type EventSourceMessage } from 'eventsource-parser'
+import { OpenClawSessionNotFoundError } from './errors'
 import type { OpenClawStreamEvent } from './openclaw-types'
 
 export interface OpenClawChatHistoryMessage {
@@ -54,13 +55,6 @@ export type OpenClawSessionHistoryEvent =
       }
     }
   | { type: 'error'; data: { message: string } }
-
-export class OpenClawSessionNotFoundError extends Error {
-  constructor(public readonly sessionKey: string) {
-    super(`OpenClaw session not found: ${sessionKey}`)
-    this.name = 'OpenClawSessionNotFoundError'
-  }
-}
 
 export class OpenClawHttpClient {
   constructor(

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -40,7 +40,11 @@ import {
   getOpenClawStateEnvPath,
   mergeEnvContent,
 } from './openclaw-env'
-import { OpenClawHttpClient } from './openclaw-http-client'
+import {
+  OpenClawHttpClient,
+  type OpenClawSessionHistory,
+  type OpenClawSessionHistoryEvent,
+} from './openclaw-http-client'
 import {
   type ResolvedOpenClawProviderConfig,
   resolveSupportedOpenClawProvider,
@@ -595,6 +599,28 @@ export class OpenClawService {
         message,
         history,
       }),
+    )
+  }
+
+  // ── Session History (HTTP) ───────────────────────────────────────────
+
+  async getSessionHistory(
+    sessionKey: string,
+    input: { limit?: number; cursor?: string; signal?: AbortSignal } = {},
+  ): Promise<OpenClawSessionHistory> {
+    await this.assertGatewayReady()
+    return this.runControlPlaneCall(() =>
+      this.httpClient.getSessionHistory(sessionKey, input),
+    )
+  }
+
+  async streamSessionHistory(
+    sessionKey: string,
+    input: { limit?: number; cursor?: string; signal?: AbortSignal } = {},
+  ): Promise<ReadableStream<OpenClawSessionHistoryEvent>> {
+    await this.assertGatewayReady()
+    return this.runControlPlaneCall(() =>
+      this.httpClient.streamSessionHistory(sessionKey, input),
     )
   }
 

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -40,7 +40,7 @@ import {
   getOpenClawStateEnvPath,
   mergeEnvContent,
 } from './openclaw-env'
-import { OpenClawHttpChatClient } from './openclaw-http-chat-client'
+import { OpenClawHttpClient } from './openclaw-http-client'
 import {
   type ResolvedOpenClawProviderConfig,
   resolveSupportedOpenClawProvider,
@@ -119,7 +119,7 @@ export class OpenClawService {
   private runtime: ContainerRuntime
   private cliClient: OpenClawCliClient
   private bootstrapCliClient: OpenClawCliClient
-  private chatClient: OpenClawHttpChatClient
+  private httpClient: OpenClawHttpClient
   private openclawDir: string
   private hostPort = OPENCLAW_GATEWAY_CONTAINER_PORT
   private token: string
@@ -139,7 +139,7 @@ export class OpenClawService {
     this.token = crypto.randomUUID()
     this.cliClient = new OpenClawCliClient(this.runtime)
     this.bootstrapCliClient = this.buildBootstrapCliClient()
-    this.chatClient = new OpenClawHttpChatClient(
+    this.httpClient = new OpenClawHttpClient(
       this.hostPort,
       async () => this.token,
     )
@@ -589,7 +589,7 @@ export class OpenClawService {
       historyLength: history.length,
     })
     return this.runControlPlaneCall(() =>
-      this.chatClient.streamChat({
+      this.httpClient.streamChat({
         agentId,
         sessionKey,
         message,
@@ -745,7 +745,7 @@ export class OpenClawService {
   private setPort(hostPort: number): void {
     if (hostPort === this.hostPort) return
     this.hostPort = hostPort
-    this.chatClient = new OpenClawHttpChatClient(
+    this.httpClient = new OpenClawHttpClient(
       this.hostPort,
       async () => this.token,
     )

--- a/packages/browseros-agent/apps/server/tests/api/routes/openclaw.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/openclaw.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it, mock } from 'bun:test'
 import { chmodSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { OpenClawSessionNotFoundError } from '../../../src/api/services/openclaw/errors'
 import { UnsupportedOpenClawProviderError } from '../../../src/api/services/openclaw/openclaw-provider-map'
 
 describe('createOpenClawRoutes', () => {
@@ -433,5 +434,125 @@ describe('createOpenClawRoutes', () => {
       apiKey: 'sk-test',
       modelId: 'gpt-5.4-mini',
     })
+  })
+
+  it('returns JSON history from the session history route and forwards query params', async () => {
+    const actualOpenClawService = await import(
+      '../../../src/api/services/openclaw/openclaw-service'
+    )
+    const getSessionHistory = mock(async () => ({
+      sessionKey: 'agent:main:main',
+      messages: [{ role: 'user', content: 'hi', messageSeq: 1 }],
+      cursor: null,
+      hasMore: false,
+    }))
+
+    mock.module('../../../src/api/services/openclaw/openclaw-service', () => ({
+      ...actualOpenClawService,
+      getOpenClawService: () => ({ getSessionHistory }) as never,
+    }))
+
+    const { createOpenClawRoutes } = await import(
+      '../../../src/api/routes/openclaw'
+    )
+    const route = createOpenClawRoutes()
+
+    const response = await route.request(
+      '/session/agent%3Amain%3Amain/history?limit=25&cursor=next',
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toContain('application/json')
+    expect(getSessionHistory).toHaveBeenCalledWith('agent:main:main', {
+      limit: 25,
+      cursor: 'next',
+    })
+    expect(await response.json()).toEqual({
+      sessionKey: 'agent:main:main',
+      messages: [{ role: 'user', content: 'hi', messageSeq: 1 }],
+      cursor: null,
+      hasMore: false,
+    })
+  })
+
+  it('returns 404 when the service reports a missing session', async () => {
+    const actualOpenClawService = await import(
+      '../../../src/api/services/openclaw/openclaw-service'
+    )
+    const getSessionHistory = mock(async () => {
+      throw new OpenClawSessionNotFoundError('missing')
+    })
+
+    mock.module('../../../src/api/services/openclaw/openclaw-service', () => ({
+      ...actualOpenClawService,
+      getOpenClawService: () => ({ getSessionHistory }) as never,
+    }))
+
+    const { createOpenClawRoutes } = await import(
+      '../../../src/api/routes/openclaw'
+    )
+    const route = createOpenClawRoutes()
+
+    const response = await route.request('/session/missing/history')
+
+    expect(response.status).toBe(404)
+    expect(await response.json()).toEqual({
+      error: 'OpenClaw session not found: missing',
+    })
+  })
+
+  it('streams named SSE frames when Accept: text/event-stream', async () => {
+    const actualOpenClawService = await import(
+      '../../../src/api/services/openclaw/openclaw-service'
+    )
+    const streamSessionHistory = mock(
+      async () =>
+        new ReadableStream({
+          start(controller) {
+            controller.enqueue({
+              type: 'history',
+              data: {
+                sessionKey: 'k',
+                messages: [],
+                cursor: null,
+                hasMore: false,
+              },
+            })
+            controller.enqueue({
+              type: 'message',
+              data: {
+                sessionKey: 'k',
+                messageSeq: 2,
+                message: { role: 'assistant', content: 'hi', messageSeq: 2 },
+              },
+            })
+            controller.close()
+          },
+        }),
+    )
+
+    mock.module('../../../src/api/services/openclaw/openclaw-service', () => ({
+      ...actualOpenClawService,
+      getOpenClawService: () => ({ streamSessionHistory }) as never,
+    }))
+
+    const { createOpenClawRoutes } = await import(
+      '../../../src/api/routes/openclaw'
+    )
+    const route = createOpenClawRoutes()
+
+    const response = await route.request('/session/k/history', {
+      headers: { Accept: 'text/event-stream' },
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toContain('text/event-stream')
+    expect(response.headers.get('X-Session-Key')).toBe('k')
+    expect(streamSessionHistory).toHaveBeenCalledTimes(1)
+    expect(streamSessionHistory.mock.calls[0]?.[0]).toBe('k')
+    expect(await response.text()).toBe(
+      'event: history\ndata: {"sessionKey":"k","messages":[],"cursor":null,"hasMore":false}\n\n' +
+        'event: message\ndata: {"sessionKey":"k","messageSeq":2,"message":{"role":"assistant","content":"hi","messageSeq":2}}\n\n',
+    )
   })
 })

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-http-client.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-http-client.test.ts
@@ -4,10 +4,8 @@
  */
 
 import { afterEach, describe, expect, it, mock } from 'bun:test'
-import {
-  OpenClawHttpClient,
-  OpenClawSessionNotFoundError,
-} from '../../../../src/api/services/openclaw/openclaw-http-client'
+import { OpenClawSessionNotFoundError } from '../../../../src/api/services/openclaw/errors'
+import { OpenClawHttpClient } from '../../../../src/api/services/openclaw/openclaw-http-client'
 
 describe('OpenClawHttpClient', () => {
   const originalFetch = globalThis.fetch

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-http-client.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-http-client.test.ts
@@ -4,9 +4,9 @@
  */
 
 import { afterEach, describe, expect, it, mock } from 'bun:test'
-import { OpenClawHttpChatClient } from '../../../../src/api/services/openclaw/openclaw-http-chat-client'
+import { OpenClawHttpClient } from '../../../../src/api/services/openclaw/openclaw-http-client'
 
-describe('OpenClawHttpChatClient', () => {
+describe('OpenClawHttpClient', () => {
   const originalFetch = globalThis.fetch
 
   afterEach(() => {
@@ -47,10 +47,7 @@ describe('OpenClawHttpChatClient', () => {
       ),
     )
     globalThis.fetch = fetchMock as typeof globalThis.fetch
-    const client = new OpenClawHttpChatClient(
-      18789,
-      async () => 'gateway-token',
-    )
+    const client = new OpenClawHttpClient(18789, async () => 'gateway-token')
 
     const stream = await client.streamChat({
       agentId: 'research',
@@ -103,10 +100,7 @@ describe('OpenClawHttpChatClient', () => {
       ),
     )
     globalThis.fetch = fetchMock as typeof globalThis.fetch
-    const client = new OpenClawHttpChatClient(
-      18789,
-      async () => 'gateway-token',
-    )
+    const client = new OpenClawHttpClient(18789, async () => 'gateway-token')
 
     await client.streamChat({
       agentId: 'main',
@@ -124,10 +118,7 @@ describe('OpenClawHttpChatClient', () => {
     globalThis.fetch = mock(() =>
       Promise.resolve(new Response('Unauthorized', { status: 401 })),
     ) as typeof globalThis.fetch
-    const client = new OpenClawHttpChatClient(
-      18789,
-      async () => 'gateway-token',
-    )
+    const client = new OpenClawHttpClient(18789, async () => 'gateway-token')
 
     await expect(
       client.streamChat({
@@ -161,10 +152,7 @@ describe('OpenClawHttpChatClient', () => {
         ),
       ),
     ) as typeof globalThis.fetch
-    const client = new OpenClawHttpChatClient(
-      18789,
-      async () => 'gateway-token',
-    )
+    const client = new OpenClawHttpClient(18789, async () => 'gateway-token')
 
     const stream = await client.streamChat({
       agentId: 'main',
@@ -207,10 +195,7 @@ describe('OpenClawHttpChatClient', () => {
       ),
     )
     globalThis.fetch = fetchMock as typeof globalThis.fetch
-    const client = new OpenClawHttpChatClient(
-      18789,
-      async () => 'gateway-token',
-    )
+    const client = new OpenClawHttpClient(18789, async () => 'gateway-token')
 
     const stream = await client.streamChat({
       agentId: 'research',

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-http-client.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-http-client.test.ts
@@ -4,7 +4,10 @@
  */
 
 import { afterEach, describe, expect, it, mock } from 'bun:test'
-import { OpenClawHttpClient } from '../../../../src/api/services/openclaw/openclaw-http-client'
+import {
+  OpenClawHttpClient,
+  OpenClawSessionNotFoundError,
+} from '../../../../src/api/services/openclaw/openclaw-http-client'
 
 describe('OpenClawHttpClient', () => {
   const originalFetch = globalThis.fetch
@@ -210,6 +213,256 @@ describe('OpenClawHttpClient', () => {
         data: { message: 'Failed to parse OpenClaw chat stream chunk' },
       },
     ])
+  })
+
+  describe('getSessionHistory', () => {
+    it('sends GET with bearer auth and forwards limit/cursor as query params', async () => {
+      const fetchMock = mock(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              sessionKey: 'agent:main:main',
+              messages: [
+                { role: 'user', content: 'hi', messageSeq: 1 },
+                { role: 'assistant', content: 'hello', messageSeq: 2 },
+              ],
+              cursor: null,
+              hasMore: false,
+            }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          ),
+        ),
+      )
+      globalThis.fetch = fetchMock as typeof globalThis.fetch
+      const client = new OpenClawHttpClient(18789, async () => 'gateway-token')
+
+      const result = await client.getSessionHistory('agent:main:main', {
+        limit: 50,
+        cursor: 'abc',
+      })
+
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(
+        'http://127.0.0.1:18789/sessions/agent%3Amain%3Amain/history?limit=50&cursor=abc',
+      )
+      expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+        method: 'GET',
+        headers: { Authorization: 'Bearer gateway-token' },
+      })
+      expect(result).toEqual({
+        sessionKey: 'agent:main:main',
+        messages: [
+          { role: 'user', content: 'hi', messageSeq: 1 },
+          { role: 'assistant', content: 'hello', messageSeq: 2 },
+        ],
+        cursor: null,
+        hasMore: false,
+      })
+    })
+
+    it('omits limit and cursor from the query when undefined', async () => {
+      const fetchMock = mock(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ sessionKey: 'k', messages: [] }), {
+            status: 200,
+          }),
+        ),
+      )
+      globalThis.fetch = fetchMock as typeof globalThis.fetch
+      const client = new OpenClawHttpClient(18789, async () => 'gateway-token')
+
+      await client.getSessionHistory('k')
+
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(
+        'http://127.0.0.1:18789/sessions/k/history',
+      )
+    })
+
+    it('throws OpenClawSessionNotFoundError on 404', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(new Response('not found', { status: 404 })),
+      ) as typeof globalThis.fetch
+      const client = new OpenClawHttpClient(18789, async () => 'gateway-token')
+
+      await expect(
+        client.getSessionHistory('missing-key'),
+      ).rejects.toBeInstanceOf(OpenClawSessionNotFoundError)
+    })
+
+    it('surfaces the response body on other non-2xx responses', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(new Response('boom', { status: 500 })),
+      ) as typeof globalThis.fetch
+      const client = new OpenClawHttpClient(18789, async () => 'gateway-token')
+
+      await expect(client.getSessionHistory('k')).rejects.toThrow('boom')
+    })
+
+    it('propagates the abort signal to fetch', async () => {
+      const fetchMock = mock(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ sessionKey: 'k', messages: [] }), {
+            status: 200,
+          }),
+        ),
+      )
+      globalThis.fetch = fetchMock as typeof globalThis.fetch
+      const controller = new AbortController()
+      const client = new OpenClawHttpClient(18789, async () => 'gateway-token')
+
+      await client.getSessionHistory('k', { signal: controller.signal })
+
+      expect(fetchMock.mock.calls[0]?.[1]?.signal).toBe(controller.signal)
+    })
+  })
+
+  describe('streamSessionHistory', () => {
+    it('parses named history/message SSE events into typed events', async () => {
+      const fetchMock = mock(() =>
+        Promise.resolve(
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                const encoder = new TextEncoder()
+                controller.enqueue(
+                  encoder.encode(
+                    'event: history\ndata: {"sessionKey":"k","messages":[{"role":"user","content":"hi","messageSeq":1}],"cursor":null,"hasMore":false}\n\n',
+                  ),
+                )
+                controller.enqueue(
+                  encoder.encode(
+                    'event: message\ndata: {"sessionKey":"k","messageSeq":2,"message":{"role":"assistant","content":"hey","messageSeq":2}}\n\n',
+                  ),
+                )
+                controller.close()
+              },
+            }),
+            {
+              status: 200,
+              headers: { 'Content-Type': 'text/event-stream' },
+            },
+          ),
+        ),
+      )
+      globalThis.fetch = fetchMock as typeof globalThis.fetch
+      const client = new OpenClawHttpClient(18789, async () => 'gateway-token')
+
+      const stream = await client.streamSessionHistory('k', { limit: 20 })
+
+      const events = await readEvents(stream)
+      expect(fetchMock.mock.calls[0]?.[0]).toBe(
+        'http://127.0.0.1:18789/sessions/k/history?limit=20',
+      )
+      expect(fetchMock.mock.calls[0]?.[1]).toMatchObject({
+        method: 'GET',
+        headers: {
+          Accept: 'text/event-stream',
+          Authorization: 'Bearer gateway-token',
+        },
+      })
+      expect(events).toEqual([
+        {
+          type: 'history',
+          data: {
+            sessionKey: 'k',
+            messages: [{ role: 'user', content: 'hi', messageSeq: 1 }],
+            cursor: null,
+            hasMore: false,
+          },
+        },
+        {
+          type: 'message',
+          data: {
+            sessionKey: 'k',
+            messageSeq: 2,
+            message: { role: 'assistant', content: 'hey', messageSeq: 2 },
+          },
+        },
+      ])
+    })
+
+    it('forwards upstream error frames and closes', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          new Response(
+            new ReadableStream({
+              start(controller) {
+                const encoder = new TextEncoder()
+                controller.enqueue(
+                  encoder.encode(
+                    'event: error\ndata: {"message":"upstream exploded"}\n\n',
+                  ),
+                )
+                controller.close()
+              },
+            }),
+            { status: 200 },
+          ),
+        ),
+      ) as typeof globalThis.fetch
+      const client = new OpenClawHttpClient(18789, async () => 'gateway-token')
+
+      const stream = await client.streamSessionHistory('k')
+
+      await expect(readEvents(stream)).resolves.toEqual([
+        { type: 'error', data: { message: 'upstream exploded' } },
+      ])
+    })
+
+    it('throws OpenClawSessionNotFoundError on 404', async () => {
+      globalThis.fetch = mock(() =>
+        Promise.resolve(new Response('not found', { status: 404 })),
+      ) as typeof globalThis.fetch
+      const client = new OpenClawHttpClient(18789, async () => 'gateway-token')
+
+      await expect(client.streamSessionHistory('k')).rejects.toBeInstanceOf(
+        OpenClawSessionNotFoundError,
+      )
+    })
+
+    it('closes when the abort signal fires mid-stream', async () => {
+      const ac = new AbortController()
+      globalThis.fetch = mock(() =>
+        Promise.resolve(
+          new Response(
+            new ReadableStream({
+              async start(controller) {
+                const encoder = new TextEncoder()
+                controller.enqueue(
+                  encoder.encode(
+                    'event: history\ndata: {"sessionKey":"k","messages":[]}\n\n',
+                  ),
+                )
+                // Keep the stream open; abort should close it from our side.
+                await new Promise((resolve) => {
+                  ac.signal.addEventListener(
+                    'abort',
+                    () => resolve(undefined),
+                    {
+                      once: true,
+                    },
+                  )
+                })
+                controller.close()
+              },
+            }),
+            { status: 200 },
+          ),
+        ),
+      ) as typeof globalThis.fetch
+      const client = new OpenClawHttpClient(18789, async () => 'gateway-token')
+
+      const stream = await client.streamSessionHistory('k', {
+        signal: ac.signal,
+      })
+      const reader = stream.getReader()
+      const first = await reader.read()
+      expect(first.done).toBe(false)
+      expect(first.value).toMatchObject({ type: 'history' })
+
+      ac.abort()
+      const next = await reader.read()
+      expect(next.done).toBe(true)
+    })
   })
 })
 


### PR DESCRIPTION
## Summary

- Adds `getSessionHistory` (JSON) and `streamSessionHistory` (SSE) to the OpenClaw HTTP client. Both target `GET /sessions/<key>/history` on the loopback gateway and reuse the bearer-token auth already used by `streamChat`.
- Exposes the new methods through the OpenClaw service and a new `GET /claw/session/:key/history` route. Route returns JSON by default; upgrades to SSE when the client sends `Accept: text/event-stream`.
- Renames `OpenClawHttpChatClient` → `OpenClawHttpClient` (file, class, and the service's `chatClient` → `httpClient` field) since the client now handles more than chat.

## Design

The session-history endpoints mirror the existing `streamChat` pattern rather than introducing a separate client or new auth story. A shared private `fetchSessionHistory` helper handles the URL build, bearer header, 404 → `OpenClawSessionNotFoundError`, and non-2xx → `Error(body)`. SSE uses `eventsource-parser` to map named gateway frames (`event: history`, `event: message`, `event: error`) into a typed `OpenClawSessionHistoryEvent` union. The route propagates `c.req.raw.signal` so client disconnects cancel the upstream fetch. `OpenClawSessionNotFoundError` lives in `errors.ts` alongside the other OpenClaw error classes so routes can import it from one place.

Explicitly **out of scope** for this PR (deferred from `2026-04-23-openclaw-http-fast-path.md`): the `gateway.auth.mode=none` flip and the separate loopback-admin HTTP client for `probe()` / `listAgents()`. This PR is a narrow slice that adds session history on the same client with the same auth pattern.

## Test plan

- [x] `bun --env-file=.env.development test apps/server/tests/api/services/openclaw/openclaw-http-client.test.ts` — 14 pass (5 existing chat + 9 new history).
- [x] `bun --env-file=.env.development test apps/server/tests/api/routes/openclaw.test.ts` — 15 pass (12 existing + 3 new: JSON+query, 404, SSE framing).
- [x] `bun --env-file=.env.development test apps/server/tests/api/` — 146 pass, 0 fail.
- [x] `bun run typecheck` — clean across the workspace.
- [ ] Manual smoke against a running BrowserOS stack: `curl http://127.0.0.1:$BROWSEROS_PORT/claw/session/<key>/history?limit=20`, and with `-H 'Accept: text/event-stream'`.