### PR TITLE
fix: use system nerdctl in Lima runtime

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/container-runtime.ts
@@ -8,12 +8,11 @@ import {
   OPENCLAW_GATEWAY_CONTAINER_NAME,
   OPENCLAW_GATEWAY_CONTAINER_PORT,
 } from '@browseros/shared/constants/openclaw'
-import type { ContainerCli, ContainerSpec } from '../../../lib/container'
+import type { ContainerCli, ContainerSpec, LogFn } from '../../../lib/container'
 import { logger } from '../../../lib/logger'
 import {
   GUEST_VM_STATE,
   hostPathToGuest,
-  type LogFn,
   type VmRuntime,
 } from '../../../lib/vm'
 
@@ -98,9 +97,9 @@ export class ContainerRuntime {
 
   async getGatewayLogs(tail = 50): Promise<string[]> {
     const lines: string[] = []
-    await this.vm.runCommand(
-      ['nerdctl', 'logs', '-n', String(tail), OPENCLAW_GATEWAY_CONTAINER_NAME],
-      { onOutput: (line) => lines.push(line) },
+    await this.shell.runCommand(
+      ['logs', '-n', String(tail), OPENCLAW_GATEWAY_CONTAINER_NAME],
+      (line) => lines.push(line),
     )
     return lines
   }
@@ -154,14 +153,11 @@ export class ContainerRuntime {
     onLog?: LogFn,
   ): Promise<number> {
     const setupContainerName = `${OPENCLAW_GATEWAY_CONTAINER_NAME}-setup`
-    await this.vm.runCommand(['nerdctl', 'rm', '-f', setupContainerName], {
-      onOutput: onLog,
-    })
+    await this.shell.removeContainer(setupContainerName, { force: true }, onLog)
     await this.loader.ensureImageLoaded(spec.image, onLog)
     const setupArgs = command[0] === 'node' ? command.slice(1) : command
-    const createExitCode = await this.vm.runCommand(
+    const createResult = await this.shell.runCommand(
       [
-        'nerdctl',
         'create',
         '--name',
         setupContainerName,
@@ -170,24 +166,29 @@ export class ContainerRuntime {
         'node',
         ...setupArgs,
       ],
-      { onOutput: onLog },
+      onLog,
     )
-    if (createExitCode !== 0) {
-      await this.vm.runCommand(['nerdctl', 'rm', '-f', setupContainerName], {
-        onOutput: onLog,
-      })
-      return createExitCode
+    if (createResult.exitCode !== 0) {
+      await this.shell.removeContainer(
+        setupContainerName,
+        { force: true },
+        onLog,
+      )
+      return createResult.exitCode
     }
 
     try {
-      return await this.vm.runCommand(
-        ['nerdctl', 'start', '-a', setupContainerName],
-        { onOutput: onLog },
+      const startResult = await this.shell.runCommand(
+        ['start', '-a', setupContainerName],
+        onLog,
       )
+      return startResult.exitCode
     } finally {
-      await this.vm.runCommand(['nerdctl', 'rm', '-f', setupContainerName], {
-        onOutput: onLog,
-      })
+      await this.shell.removeContainer(
+        setupContainerName,
+        { force: true },
+        onLog,
+      )
     }
   }
 
@@ -196,17 +197,11 @@ export class ContainerRuntime {
   }
 
   private async removeGatewayContainer(onLog?: LogFn): Promise<void> {
-    if (onLog) {
-      await this.shell.removeContainer(
-        OPENCLAW_GATEWAY_CONTAINER_NAME,
-        { force: true },
-        onLog,
-      )
-      return
-    }
-    await this.shell.removeContainer(OPENCLAW_GATEWAY_CONTAINER_NAME, {
-      force: true,
-    })
+    await this.shell.removeContainer(
+      OPENCLAW_GATEWAY_CONTAINER_NAME,
+      { force: true },
+      onLog,
+    )
   }
 
   private async buildGatewayContainerSpec(

--- a/packages/browseros-agent/apps/server/src/api/services/terminal/terminal-session.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/terminal/terminal-session.ts
@@ -2,6 +2,7 @@ import {
   OPENCLAW_CONTAINER_HOME,
   OPENCLAW_TERMINAL_SHELL,
 } from '@browseros/shared/constants/openclaw'
+import { buildSystemNerdctlCommand } from '../../../lib/container'
 import { logger } from '../../../lib/logger'
 
 export const TERMINAL_HOME_DIR = OPENCLAW_CONTAINER_HOME
@@ -36,13 +37,14 @@ export function buildTerminalExecCommand(
     'shell',
     vmName,
     '--',
-    'nerdctl',
-    'exec',
-    '-it',
-    '-w',
-    workingDir,
-    containerName,
-    OPENCLAW_TERMINAL_SHELL,
+    ...buildSystemNerdctlCommand([
+      'exec',
+      '-it',
+      '-w',
+      workingDir,
+      containerName,
+      OPENCLAW_TERMINAL_SHELL,
+    ]),
   ]
 }
 

--- a/packages/browseros-agent/apps/server/src/lib/container/container-cli.ts
+++ b/packages/browseros-agent/apps/server/src/lib/container/container-cli.ts
@@ -8,6 +8,10 @@ import { ContainerCliError } from '../vm/errors'
 import { LimaCli } from '../vm/lima-cli'
 import type { ContainerSpec, LogFn, MountSpec, PortMapping } from './types'
 
+export function buildSystemNerdctlCommand(args: string[]): string[] {
+  return ['sudo', 'nerdctl', ...args]
+}
+
 export interface ContainerCliConfig {
   limactlPath: string
   limaHome: string
@@ -15,7 +19,7 @@ export interface ContainerCliConfig {
   sshPath?: string
 }
 
-interface CommandResult {
+export interface ContainerCommandResult {
   exitCode: number
   stdout: string
   stderr: string
@@ -33,7 +37,7 @@ export class ContainerCli {
   }
 
   async imageExists(ref: string): Promise<boolean> {
-    const result = await this.run(['image', 'inspect', ref])
+    const result = await this.runCommand(['image', 'inspect', ref])
     return result.exitCode === 0
   }
 
@@ -55,7 +59,7 @@ export class ContainerCli {
   }
 
   async stopContainer(name: string, onLog?: LogFn): Promise<void> {
-    const result = await this.run(['stop', name], onLog)
+    const result = await this.runCommand(['stop', name], onLog)
     if (result.exitCode === 0 || isNoSuchContainer(result.stderr)) return
     throw this.commandError(['stop', name], result)
   }
@@ -68,13 +72,13 @@ export class ContainerCli {
     const args = ['rm']
     if (opts?.force) args.push('-f')
     args.push(name)
-    const result = await this.run(args, onLog)
+    const result = await this.runCommand(args, onLog)
     if (result.exitCode === 0 || isNoSuchContainer(result.stderr)) return
     throw this.commandError(args, result)
   }
 
   async exec(name: string, cmd: string[], onLog?: LogFn): Promise<number> {
-    const result = await this.run(['exec', name, ...cmd], onLog)
+    const result = await this.runCommand(['exec', name, ...cmd], onLog)
     return result.exitCode
   }
 
@@ -91,7 +95,7 @@ export class ContainerCli {
   tailLogs(name: string, onLine: LogFn): () => void {
     const proc = this.lima.spawnShell(
       this.cfg.vmName,
-      ['nerdctl', 'logs', '-f', '-n', '0', name],
+      buildSystemNerdctlCommand(['logs', '-f', '-n', '0', name]),
       { onStdout: onLine, onStderr: onLine },
     )
 
@@ -103,21 +107,15 @@ export class ContainerCli {
     }
   }
 
-  private async runRequired(
+  async runCommand(
     args: string[],
     onLog?: LogFn,
-  ): Promise<CommandResult> {
-    const result = await this.run(args, onLog)
-    if (result.exitCode === 0) return result
-    throw this.commandError(args, result)
-  }
-
-  private async run(args: string[], onLog?: LogFn): Promise<CommandResult> {
+  ): Promise<ContainerCommandResult> {
     const stdoutLines: string[] = []
     const stderrLines: string[] = []
     const exitCode = await this.lima.shell(
       this.cfg.vmName,
-      ['nerdctl', ...args],
+      buildSystemNerdctlCommand(args),
       {
         onStdout: (line) => {
           stdoutLines.push(line)
@@ -137,9 +135,18 @@ export class ContainerCli {
     }
   }
 
+  private async runRequired(
+    args: string[],
+    onLog?: LogFn,
+  ): Promise<ContainerCommandResult> {
+    const result = await this.runCommand(args, onLog)
+    if (result.exitCode === 0) return result
+    throw this.commandError(args, result)
+  }
+
   private commandError(
     args: string[],
-    result: CommandResult,
+    result: ContainerCommandResult,
   ): ContainerCliError {
     return new ContainerCliError(
       `nerdctl ${args.join(' ')}`,

--- a/packages/browseros-agent/apps/server/src/lib/vm/vm-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/vm/vm-runtime.ts
@@ -145,29 +145,6 @@ export class VmRuntime {
     })
   }
 
-  async listRunningContainers(): Promise<string[]> {
-    const lines: string[] = []
-    await this.runCommand(['nerdctl', 'ps', '--format', '{{.Names}}'], {
-      onOutput: (line) => lines.push(line),
-    })
-    return lines.map((line) => line.trim()).filter(Boolean)
-  }
-
-  tailContainerLogs(containerName: string, onLine: LogFn): () => void {
-    const proc = this.cli.spawnShell(
-      VM_NAME,
-      ['nerdctl', 'logs', '-f', '-n', '0', containerName],
-      { onStdout: onLine, onStderr: onLine },
-    )
-
-    let stopped = false
-    return () => {
-      if (stopped) return
-      stopped = true
-      proc.kill()
-    }
-  }
-
   async reset(_reason: string): Promise<never> {
     throw notImplemented('VmRuntime.reset')
   }

--- a/packages/browseros-agent/apps/server/tests/api/routes/terminal-protocol.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/terminal-protocol.test.ts
@@ -64,6 +64,7 @@ describe('terminal protocol', () => {
       'shell',
       'browseros-vm',
       '--',
+      'sudo',
       'nerdctl',
       'exec',
       '-it',

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/container-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/container-runtime.test.ts
@@ -32,6 +32,7 @@ describe('ContainerRuntime', () => {
     expect(deps.shell.removeContainer).toHaveBeenCalledWith(
       OPENCLAW_GATEWAY_CONTAINER_NAME,
       { force: true },
+      undefined,
     )
     expect(deps.loader.ensureImageLoaded).toHaveBeenCalledWith(
       defaultSpec.image,
@@ -96,9 +97,8 @@ describe('ContainerRuntime', () => {
       defaultSpec,
     )
 
-    expect(deps.vm.runCommand).toHaveBeenCalledWith(
+    expect(deps.shell.runCommand).toHaveBeenCalledWith(
       expect.arrayContaining([
-        'nerdctl',
         'create',
         '--name',
         `${OPENCLAW_GATEWAY_CONTAINER_NAME}-setup`,
@@ -109,15 +109,16 @@ describe('ContainerRuntime', () => {
         '--add-host',
         'host.containers.internal:192.168.5.2',
       ]),
-      expect.any(Object),
+      undefined,
     )
-    expect(deps.vm.runCommand).toHaveBeenCalledWith(
-      ['nerdctl', 'start', '-a', `${OPENCLAW_GATEWAY_CONTAINER_NAME}-setup`],
-      expect.any(Object),
+    expect(deps.shell.runCommand).toHaveBeenCalledWith(
+      ['start', '-a', `${OPENCLAW_GATEWAY_CONTAINER_NAME}-setup`],
+      undefined,
     )
-    expect(deps.vm.runCommand).toHaveBeenCalledWith(
-      ['nerdctl', 'rm', '-f', `${OPENCLAW_GATEWAY_CONTAINER_NAME}-setup`],
-      expect.any(Object),
+    expect(deps.shell.removeContainer).toHaveBeenCalledWith(
+      `${OPENCLAW_GATEWAY_CONTAINER_NAME}-setup`,
+      { force: true },
+      undefined,
     )
   })
 
@@ -138,9 +139,9 @@ describe('ContainerRuntime', () => {
       OPENCLAW_GATEWAY_CONTAINER_NAME,
       expect.any(Function),
     )
-    expect(deps.vm.runCommand).toHaveBeenCalledWith(
-      ['nerdctl', 'logs', '-n', '10', OPENCLAW_GATEWAY_CONTAINER_NAME],
-      expect.any(Object),
+    expect(deps.shell.runCommand).toHaveBeenCalledWith(
+      ['logs', '-n', '10', OPENCLAW_GATEWAY_CONTAINER_NAME],
+      expect.any(Function),
     )
     expect(logs).toEqual(['log line'])
   })
@@ -153,15 +154,6 @@ function createDeps() {
       getDefaultGateway: mock(async () => '192.168.5.2'),
       stopVm: mock(async () => {}),
       isReady: mock(async () => true),
-      runCommand: mock(
-        async (
-          _args: string[],
-          opts?: { onOutput?: (line: string) => void },
-        ) => {
-          opts?.onOutput?.('log line')
-          return 0
-        },
-      ),
     },
     shell: {
       createContainer: mock(async () => {}),
@@ -169,6 +161,12 @@ function createDeps() {
       stopContainer: mock(async () => {}),
       removeContainer: mock(async () => {}),
       exec: mock(async () => 0),
+      runCommand: mock(
+        async (_args: string[], onLog?: (line: string) => void) => {
+          onLog?.('log line')
+          return { exitCode: 0, stdout: 'log line\n', stderr: '' }
+        },
+      ),
       tailLogs: mock(() => () => {}),
     },
     loader: {

--- a/packages/browseros-agent/apps/server/tests/integration/vm-smoke.test.ts
+++ b/packages/browseros-agent/apps/server/tests/integration/vm-smoke.test.ts
@@ -68,12 +68,12 @@ describe('BrowserOS VM live smoke', () => {
       await runtime.ensureReady()
       expect((await stat(getContainerdSocketPath(root))).isSocket()).toBe(true)
       const nerdctlInfoOutput: string[] = []
-      const nerdctlInfoExit = await runtime.runCommand(['nerdctl', 'info'], {
-        onOutput: (line) => nerdctlInfoOutput.push(line),
-      })
-      if (nerdctlInfoExit !== 0) {
+      const nerdctlInfo = await cli.runCommand(['info'], (line) =>
+        nerdctlInfoOutput.push(line),
+      )
+      if (nerdctlInfo.exitCode !== 0) {
         throw new Error(
-          `nerdctl info failed with exit ${nerdctlInfoExit}:\n${nerdctlInfoOutput.join('\n')}`,
+          `nerdctl info failed with exit ${nerdctlInfo.exitCode}:\n${nerdctlInfoOutput.join('\n')}`,
         )
       }
 

--- a/packages/browseros-agent/apps/server/tests/lib/container/container-cli.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/container/container-cli.test.ts
@@ -31,7 +31,7 @@ describe('ContainerCli', () => {
 
     const sshConfig = sshConfigPath(tempDir)
     await expect(readFile(logPath, 'utf8')).resolves.toContain(
-      `${sshPrefix(sshConfig)} 'nerdctl' 'image' 'inspect' 'openclaw:v1'`,
+      `${sshPrefix(sshConfig)} 'sudo' 'nerdctl' 'image' 'inspect' 'openclaw:v1'`,
     )
   })
 
@@ -72,7 +72,7 @@ describe('ContainerCli', () => {
       cli.loadImage('/mnt/browseros/cache/images/openclaw.tar.gz'),
     ).resolves.toEqual(['openclaw:v1'])
     await expect(readFile(logPath, 'utf8')).resolves.toContain(
-      `${sshPrefix(sshConfigPath(tempDir))} 'nerdctl' 'load' '-i' '/mnt/browseros/cache/images/openclaw.tar.gz'`,
+      `${sshPrefix(sshConfigPath(tempDir))} 'sudo' 'nerdctl' 'load' '-i' '/mnt/browseros/cache/images/openclaw.tar.gz'`,
     )
   })
 
@@ -106,7 +106,7 @@ describe('ContainerCli', () => {
 
     await expect(readFile(logPath, 'utf8')).resolves.toContain(
       [
-        `${sshPrefix(sshConfigPath(tempDir))} 'nerdctl' 'create'`,
+        `${sshPrefix(sshConfigPath(tempDir))} 'sudo' 'nerdctl' 'create'`,
         "'--name' 'gateway'",
         "'--restart' 'unless-stopped'",
         "'-p' '127.0.0.1:18789:18789'",
@@ -138,14 +138,18 @@ describe('ContainerCli', () => {
     ])
 
     const log = await readFile(logPath, 'utf8')
-    expect(log).toContain("lima-browseros-vm 'nerdctl' 'start' 'gateway'")
-    expect(log).toContain("lima-browseros-vm 'nerdctl' 'stop' 'gateway'")
-    expect(log).toContain("lima-browseros-vm 'nerdctl' 'rm' '-f' 'gateway'")
     expect(log).toContain(
-      "lima-browseros-vm 'nerdctl' 'exec' 'gateway' 'node' '--version'",
+      "lima-browseros-vm 'sudo' 'nerdctl' 'start' 'gateway'",
+    )
+    expect(log).toContain("lima-browseros-vm 'sudo' 'nerdctl' 'stop' 'gateway'")
+    expect(log).toContain(
+      "lima-browseros-vm 'sudo' 'nerdctl' 'rm' '-f' 'gateway'",
     )
     expect(log).toContain(
-      "lima-browseros-vm 'nerdctl' 'ps' '--format' '{{.Names}}'",
+      "lima-browseros-vm 'sudo' 'nerdctl' 'exec' 'gateway' 'node' '--version'",
+    )
+    expect(log).toContain(
+      "lima-browseros-vm 'sudo' 'nerdctl' 'ps' '--format' '{{.Names}}'",
     )
   })
 
@@ -172,7 +176,7 @@ describe('ContainerCli', () => {
 
     expect(lines).toEqual(['line'])
     await expect(readFile(logPath, 'utf8')).resolves.toContain(
-      `${sshPrefix(sshConfigPath(tempDir))} 'nerdctl' 'logs' '-f' '-n' '0' 'gateway'`,
+      `${sshPrefix(sshConfigPath(tempDir))} 'sudo' 'nerdctl' 'logs' '-f' '-n' '0' 'gateway'`,
     )
   })
 })

--- a/packages/browseros-agent/apps/server/tests/lib/vm/vm-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/vm/vm-runtime.test.ts
@@ -333,8 +333,8 @@ describe('VmRuntime', () => {
     expect(resetCalled).toBe(false)
   })
 
-  it('delegates runCommand and listRunningContainers through ssh', async () => {
-    const sshPath = await fakeSsh({ stdout: 'gateway\nworker\n' }, logPath)
+  it('delegates runCommand through ssh', async () => {
+    const sshPath = await fakeSsh({}, logPath)
     const sshConfig = join(limaHome, VM_NAME, 'ssh.config')
     await mkdir(join(limaHome, VM_NAME), { recursive: true })
     await writeFile(sshConfig, '')
@@ -346,17 +346,10 @@ describe('VmRuntime', () => {
     })
 
     await expect(runtime.runCommand(['nerdctl', 'version'])).resolves.toBe(0)
-    await expect(runtime.listRunningContainers()).resolves.toEqual([
-      'gateway',
-      'worker',
-    ])
 
     const log = await readFile(logPath, 'utf8')
     expect(log).toContain(
       `ARGS:-F ${sshConfig} lima-${VM_NAME} 'nerdctl' 'version'`,
-    )
-    expect(log).toContain(
-      `ARGS:-F ${sshConfig} lima-${VM_NAME} 'nerdctl' 'ps' '--format' '{{.Names}}'`,
     )
   })
 
@@ -383,31 +376,6 @@ describe('VmRuntime', () => {
 
     const log = await readFile(logPath, 'utf8')
     expect(log.match(/'ip' '-4' 'route' 'show' 'default'/g)).toHaveLength(1)
-  })
-
-  it('returns a stop handle for tailing container logs', async () => {
-    const sshPath = await fakeSsh({ stdout: 'line\n' }, logPath)
-    const sshConfig = join(limaHome, VM_NAME, 'ssh.config')
-    await mkdir(join(limaHome, VM_NAME), { recursive: true })
-    await writeFile(sshConfig, '')
-    const runtime = new VmRuntime({
-      limactlPath: 'unused',
-      limaHome,
-      sshPath,
-      browserosRoot: root,
-    })
-    const lines: string[] = []
-
-    const stop = runtime.tailContainerLogs('gateway', (line) =>
-      lines.push(line),
-    )
-    await Bun.sleep(20)
-    stop()
-
-    expect(lines).toEqual(['line'])
-    await expect(readFile(logPath, 'utf8')).resolves.toContain(
-      `ARGS:-F ${sshConfig} lima-${VM_NAME} 'nerdctl' 'logs' '-f' '-n' '0' 'gateway'`,
-    )
   })
 })
 

--- a/packages/browseros-agent/packages/build-tools/template/browseros-vm.yaml
+++ b/packages/browseros-agent/packages/build-tools/template/browseros-vm.yaml
@@ -43,7 +43,7 @@ probes:
 - script: |
     #!/bin/bash
     set -eux -o pipefail
-    if ! timeout 60s bash -c 'until nerdctl info >/dev/null 2>&1; do sleep 2; done'; then
+    if ! timeout 60s bash -c 'until sudo nerdctl info >/dev/null 2>&1; do sleep 2; done'; then
       echo >&2 "nerdctl is not ready after 60s"
       exit 1
     fi

--- a/packages/browseros-agent/packages/build-tools/tests/vm-template.test.ts
+++ b/packages/browseros-agent/packages/build-tools/tests/vm-template.test.ts
@@ -16,7 +16,7 @@ describe('browseros-vm Lima template', () => {
     expect(yaml).toContain('containerd:')
     expect(yaml).toContain('system: true')
     expect(yaml).toContain('user: false')
-    expect(yaml).toContain('until nerdctl info >/dev/null 2>&1')
+    expect(yaml).toContain('until sudo nerdctl info >/dev/null 2>&1')
     expect(yaml).toContain('runtime:containerd')
     expect(yaml).toContain('guestSocket: "/var/run/containerd/containerd.sock"')
     expect(yaml).toContain('hostSocket: "{{.Dir}}/sock/containerd.sock"')


### PR DESCRIPTION
## Summary
- Fixes OpenClaw setup failures where bare `nerdctl` targeted rootless containerd inside the Lima VM.
- Keeps system-containerd invocation policy in `apps/server/src/lib/container` via `ContainerCli`, instead of duplicating `sudo nerdctl` in OpenClaw runtime code.
- Updates unit, integration, terminal, and VM template coverage to assert the system-containerd command path.

## Design
The Lima template intentionally provisions system containerd with `containerd.user: false`, so container operations must use `sudo nerdctl` rather than bare user-mode `nerdctl`. `ContainerCli` now owns that command construction and exposes `runCommand()` for low-level container operations that do not need a higher-level helper. `ContainerRuntime` no longer carries a nerdctl prefix, and `VmRuntime` stays scoped to VM lifecycle and generic shell execution.

## Test plan
- `bun test apps/server/tests/lib/container/container-cli.test.ts apps/server/tests/lib/vm/vm-runtime.test.ts apps/server/tests/api/services/openclaw/container-runtime.test.ts apps/server/tests/api/routes/terminal-protocol.test.ts packages/build-tools/tests/vm-template.test.ts`
- `bun run --filter @browseros/server typecheck`
- Manually verified in the live VM that bare `nerdctl info` reproduces the rootless-containerd failure, `sudo nerdctl info` succeeds, and `sudo nerdctl load -i /mnt/browseros/cache/images/openclaw-2026.4.12-arm64.tar.gz` loads `ghcr.io/openclaw/openclaw:2026.4.12`.
