### PR TITLE
chore(dev): add VM cache setup flow

### DIFF
--- a/packages/browseros-agent/README.md
+++ b/packages/browseros-agent/README.md
@@ -75,26 +75,20 @@ packages/
 
 ### Setup
 
-Requires [process-compose](https://github.com/F1bonacc1/process-compose):
-
-```bash
-brew install process-compose
-```
-
 ```bash
 # Copy environment files for each package
 cp apps/server/.env.example apps/server/.env.development
 cp apps/agent/.env.example apps/agent/.env.development
 cp apps/server/.env.production.example apps/server/.env.production
 
+# Install deps, generate agent code, and sync the VM cache
+bun run dev:setup
+
 # Start the full dev environment
-process-compose up
+bun run dev:watch
 ```
 
-The `process-compose up` command runs the following in order:
-1. `bun install` — installs dependencies
-2. `bun --cwd apps/agent codegen` — generates agent code
-3. `bun --cwd apps/server start` and `bun --cwd apps/agent dev` — starts server and agent in parallel
+`dev:watch` exits when the VM cache manifest is missing, but setup stays in `dev:setup`.
 
 ### Environment Variables
 

--- a/packages/browseros-agent/apps/server/README.md
+++ b/packages/browseros-agent/apps/server/README.md
@@ -142,7 +142,7 @@ cp .env.example .env.development
 bun run start
 ```
 
-See the [agent monorepo README](../../README.md) for full environment variable reference and `process-compose` setup.
+See the [agent monorepo README](../../README.md) for full environment variable reference and `dev:watch` setup.
 
 ### Testing
 

--- a/packages/browseros-agent/apps/server/src/lib/vm/errors.ts
+++ b/packages/browseros-agent/apps/server/src/lib/vm/errors.ts
@@ -47,8 +47,14 @@ export class ImageLoadError extends VmError {
 
 export class ManifestMissingError extends VmError {
   constructor(public readonly manifestPath: string) {
-    super(
-      `VM manifest is missing at ${manifestPath}; run bun run cache:sync before starting the server`,
-    )
+    super(manifestMissingMessage(manifestPath))
   }
+}
+
+function manifestMissingMessage(manifestPath: string): string {
+  const message = `VM manifest is missing at ${manifestPath}`
+  if (process.env.NODE_ENV === 'development') {
+    return `${message}; run bun run dev:setup before starting the server`
+  }
+  return message
 }

--- a/packages/browseros-agent/apps/server/tests/lib/vm/manifest.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/vm/manifest.test.ts
@@ -59,9 +59,8 @@ describe('VM manifest helpers', () => {
     await expect(readCachedManifest(root)).resolves.toEqual(manifest)
   })
 
-  it('throws ManifestMissingError with a cache-sync hint when cached manifest is absent', async () => {
+  it('throws ManifestMissingError when cached manifest is absent', async () => {
     await expect(readCachedManifest(root)).rejects.toThrow(ManifestMissingError)
-    await expect(readCachedManifest(root)).rejects.toThrow('bun run cache:sync')
   })
 
   it('returns null for a missing installed manifest', async () => {

--- a/packages/browseros-agent/package.json
+++ b/packages/browseros-agent/package.json
@@ -13,6 +13,7 @@
     "dev:watch": "./tools/dev/run.sh watch",
     "dev:watch:new": "./tools/dev/run.sh watch --new",
     "dev:manual": "./tools/dev/run.sh watch --manual",
+    "dev:setup": "./tools/dev/setup.sh",
     "test:env": "./tools/dev/run.sh test",
     "test:cleanup": "./tools/dev/run.sh cleanup",
     "start:server": "bun run --filter @browseros/server --elide-lines=0 start",

--- a/packages/browseros-agent/tools/dev/cmd/watch.go
+++ b/packages/browseros-agent/tools/dev/cmd/watch.go
@@ -39,6 +39,9 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	if err := ensureDevCachePresent(); err != nil {
+		return err
+	}
 
 	defaultPorts := proc.DefaultLocalPorts()
 	p := defaultPorts
@@ -103,16 +106,7 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	var wg sync.WaitGroup
 	var procs []*proc.ManagedProc
 
-	// Run agent codegen if generated files don't exist
 	agentDir := filepath.Join(root, "apps/agent")
-	if _, err := os.Stat(filepath.Join(agentDir, "generated/graphql")); os.IsNotExist(err) {
-		proc.LogMsg(proc.TagBuild, "Running agent codegen...")
-		if err := proc.RunBlocking(ctx, agentDir, proc.TagBuild,
-			"bun", "--env-file=.env.development", "graphql-codegen", "--config", "codegen.ts"); err != nil {
-			return fmt.Errorf("agent codegen failed: %w", err)
-		}
-		proc.LogMsg(proc.TagBuild, "agent codegen done")
-	}
 
 	if watchManual {
 		proc.LogMsg(proc.TagBuild, "Building agent (dev)...")
@@ -187,5 +181,17 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	}
 	wg.Wait()
 	proc.LogMsg(proc.TagInfo, "All processes stopped")
+	return nil
+}
+
+func ensureDevCachePresent() error {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	manifestPath := filepath.Join(home, ".browseros-dev", "cache", "vm", "manifest.json")
+	if _, err := os.Stat(manifestPath); os.IsNotExist(err) {
+		return fmt.Errorf("VM cache missing at %s; run bun run dev:setup once", manifestPath)
+	}
 	return nil
 }

--- a/packages/browseros-agent/tools/dev/setup.sh
+++ b/packages/browseros-agent/tools/dev/setup.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -euo pipefail
+
+DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$DIR/../.." && pwd)"
+
+cd "$ROOT"
+
+echo "[setup] Installing dependencies..."
+bun install --frozen-lockfile
+
+echo "[setup] Generating agent code..."
+bun run codegen:agent
+
+echo "[setup] Syncing VM cache..."
+NODE_ENV=development bun run --filter @browseros/build-tools cache:sync
+
+echo "[setup] Ready"


### PR DESCRIPTION
## Summary
- Adds `bun run dev:setup` to install deps, run agent codegen, and sync the development VM cache.
- Makes `dev:watch` exit early when `~/.browseros-dev/cache/vm/manifest.json` is missing instead of continuing to start services.
- Keeps production missing-manifest errors plain while development errors point to `bun run dev:setup`.

## Design
Setup remains in a simple shell script so future setup additions are easy to maintain. The Go dev watcher performs only a prerequisite check for the VM cache manifest before touching ports or launching processes.

## Test plan
- `go test ./...` from `packages/browseros-agent/tools/dev`
- `bash -n tools/dev/setup.sh`
- `bun test apps/server/tests/lib/vm/manifest.test.ts`
- Smoke-tested `./tools/dev/run.sh watch` with an empty temporary HOME and verified it exits before port cleanup.