### PR TITLE
fix: upload Lima resources under vendor prefix

### DIFF
--- a/packages/browseros/build/cli/storage.py
+++ b/packages/browseros/build/cli/storage.py
@@ -23,7 +23,7 @@ from ..modules.storage.r2 import (
 )
 
 LIMA_RELEASE_BASE = "https://github.com/lima-vm/lima/releases/download"
-LIMA_R2_PREFIX = "third_party/lima"
+LIMA_R2_PREFIX = "artifacts/vendor/third_party/lima"
 LIMA_MANIFEST_KEY = f"{LIMA_R2_PREFIX}/manifest.json"
 LIMA_HTTP_TIMEOUT_S = 60
 

--- a/packages/browseros/build/cli/storage_test.py
+++ b/packages/browseros/build/cli/storage_test.py
@@ -168,8 +168,18 @@ class ProcessArchTest(unittest.TestCase):
 
         self.assertEqual(tarball_sha, self.expected_tarball_sha)
         self.assertEqual(object_sha, self.expected_object_sha)
-        self.assertEqual(r2_key, "third_party/lima/limactl-darwin-arm64")
-        self.assertEqual(uploads, [("third_party/lima/limactl-darwin-arm64", "browseros")])
+        self.assertEqual(
+            r2_key, "artifacts/vendor/third_party/lima/limactl-darwin-arm64"
+        )
+        self.assertEqual(
+            uploads,
+            [
+                (
+                    "artifacts/vendor/third_party/lima/limactl-darwin-arm64",
+                    "browseros",
+                )
+            ],
+        )
 
     def test_sha_mismatch_aborts_before_upload(self) -> None:
         uploads: List[Tuple[str, str]] = []
@@ -239,7 +249,9 @@ class ProcessArchTest(unittest.TestCase):
                 )
 
         self.assertEqual(uploads, [])
-        self.assertEqual(r2_key, "third_party/lima/limactl-darwin-arm64")
+        self.assertEqual(
+            r2_key, "artifacts/vendor/third_party/lima/limactl-darwin-arm64"
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Summary**
- Fix Lima uploader keys so server production builds can download bundled limactl from the configured vendor prefix.
- Update Lima uploader tests to assert the prefixed R2 paths for upload and dry-run flows.
- Re-uploaded Lima v2.1.1 resources to `artifacts/vendor/third_party/lima/...`.

**Design**
The server artifact build resolves manifest resource keys beneath `R2_DOWNLOAD_PREFIX`, which is set to `artifacts/vendor` for production server resources. The Lima upload command now writes directly to that same prefixed namespace, matching the existing server build contract without changing the server manifest or download logic.

**Test plan**
- `uv run python -m unittest build.cli.storage_test`
- `bun scripts/build/server.ts --target=darwin-arm64 --no-upload`
- `bun scripts/build/server.ts --target=darwin-x64 --no-upload`