### PR TITLE
ci: make build-agent workflow manual-only

### DIFF
--- a/.github/workflows/build-agent.yml
+++ b/.github/workflows/build-agent.yml
@@ -13,10 +13,6 @@ on:
         required: false
         default: false
         type: boolean
-  pull_request:
-    paths:
-      - "packages/browseros-agent/packages/build-tools/**"
-      - ".github/workflows/build-agent.yml"
 
 env:
   BUN_VERSION: "1.3.6"


### PR DESCRIPTION
## Summary
- Remove the `pull_request` trigger from the `build-agent` GitHub Actions workflow.
- Keep `workflow_dispatch` inputs intact so agent builds can still be run manually.

## Design
This keeps the existing build, smoke, and publish jobs unchanged, but limits invocation to explicit manual dispatches. That avoids running the agent container build workflow automatically on every matching PR while preserving the manual triage path.

## Test plan
- Ran `git diff --check`.
- Reviewed the workflow diff to confirm only the PR trigger block was removed.