### PR TITLE
fix: resize BrowserOS VM resources

### DIFF
--- a/packages/browseros-agent/packages/build-tools/template/browseros-vm.yaml
+++ b/packages/browseros-agent/packages/build-tools/template/browseros-vm.yaml
@@ -3,9 +3,9 @@
 minimumLimaVersion: 2.0.0
 
 vmType: vz
-cpus: 2
-memory: 2GiB
-disk: 30GiB
+cpus: 4
+memory: 4GiB
+disk: 20GiB
 
 images:
 - location: "https://cloud-images.ubuntu.com/minimal/releases/noble/release-20260415/ubuntu-24.04-minimal-cloudimg-arm64.img"


### PR DESCRIPTION
## Summary
- Increase the BrowserOS Lima VM CPU allocation from 2 to 4.
- Increase VM memory from 2GiB to 4GiB.
- Reduce the VM disk allocation from 30GiB to 20GiB.

## Design
Updates the Lima VM template defaults in `packages/build-tools/template/browseros-vm.yaml` so new BrowserOS VM instances use the requested resource sizing directly from the consumed template.

## Test plan
- `git diff --check`
- Verified `packages/build-tools/template/browseros-vm.yaml` contains `cpus: 4`, `memory: 4GiB`, and `disk: 20GiB`.