### PR TITLE
fix: package bundled Lima guest agent

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/newtab/layout/route-utils.test.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/newtab/layout/route-utils.test.ts
@@ -18,8 +18,8 @@ describe('route-utils', () => {
     expect(shouldUseChatSession('/home/chat')).toBe(true)
   })
 
-  it('keeps the focus grid on home while hiding it on dedicated full-screen routes', () => {
-    expect(shouldHideFocusGrid('/home')).toBe(false)
+  it('hides the focus grid on full-screen routes', () => {
+    expect(shouldHideFocusGrid('/home')).toBe(true)
     expect(shouldHideFocusGrid('/home/agents/main')).toBe(true)
     expect(shouldHideFocusGrid('/home/chat')).toBe(true)
     expect(shouldHideFocusGrid('/home/skills')).toBe(true)

--- a/packages/browseros-agent/apps/agent/entrypoints/newtab/layout/route-utils.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/newtab/layout/route-utils.ts
@@ -1,4 +1,5 @@
 const HIDE_FOCUS_GRID_PATHS = new Set([
+  '/home',
   '/home/soul',
   '/home/memory',
   '/home/skills',

--- a/packages/browseros-agent/apps/agent/entrypoints/newtab/layout/route-utils.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/newtab/layout/route-utils.ts
@@ -1,5 +1,4 @@
 const HIDE_FOCUS_GRID_PATHS = new Set([
-  '/home',
   '/home/soul',
   '/home/memory',
   '/home/skills',

--- a/packages/browseros-agent/apps/server/src/lib/vm/paths.ts
+++ b/packages/browseros-agent/apps/server/src/lib/vm/paths.ts
@@ -96,16 +96,45 @@ export function decompressedDiskPath(
   )
 }
 
-export function resolveBundledLimactl(resourcesDir: string): string {
+export function resolveBundledLimactl(
+  resourcesDir: string,
+  hostArch: Arch = detectArch(),
+): string {
   if (usesHostVmTools()) return resolveHostLimactl()
 
-  const candidate = join(resourcesDir, 'bin', 'third_party', 'lima', 'limactl')
+  const limaRoot = resolveBundledLimaRoot(resourcesDir)
+  const candidate = join(limaRoot, 'bin', 'limactl')
   if (!existsSync(candidate)) {
     throw new Error(
       `bundled limactl not found at ${candidate}; see the build-tools README and run bun run cache:sync`,
     )
   }
+  assertBundledLimaGuestAgent(limaRoot, hostArch)
   return candidate
+}
+
+function resolveBundledLimaRoot(resourcesDir: string): string {
+  return join(resourcesDir, 'bin', 'third_party', 'lima')
+}
+
+function nativeLinuxGuestAgentName(arch: Arch): string {
+  return arch === 'arm64'
+    ? 'lima-guestagent.Linux-aarch64.gz'
+    : 'lima-guestagent.Linux-x86_64.gz'
+}
+
+function assertBundledLimaGuestAgent(limaRoot: string, hostArch: Arch): void {
+  const guestAgent = join(
+    limaRoot,
+    'share',
+    'lima',
+    nativeLinuxGuestAgentName(hostArch),
+  )
+  if (!existsSync(guestAgent)) {
+    throw new Error(
+      `bundled Lima guest agent not found at ${guestAgent}; upload Lima runtime files and refresh server resources`,
+    )
+  }
 }
 
 function resolveHostLimactl(): string {

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/container-runtime-factory.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/container-runtime-factory.test.ts
@@ -20,14 +20,26 @@ describe('container-runtime factory', () => {
   beforeEach(async () => {
     root = await mkdtemp('/tmp/openclaw-runtime-factory-')
     resourcesDir = join(root, 'resources')
-    await mkdir(join(resourcesDir, 'bin', 'third_party', 'lima'), {
-      recursive: true,
-    })
-    await mkdir(join(resourcesDir, 'vm'), { recursive: true })
-    await writeFile(
-      join(resourcesDir, 'bin', 'third_party', 'lima', 'limactl'),
-      '#!/bin/sh\n',
+    const limaRoot = join(resourcesDir, 'bin', 'third_party', 'lima')
+    const limactlPath = join(limaRoot, 'bin', 'limactl')
+    const armGuestAgentPath = join(
+      limaRoot,
+      'share',
+      'lima',
+      'lima-guestagent.Linux-aarch64.gz',
     )
+    const x64GuestAgentPath = join(
+      limaRoot,
+      'share',
+      'lima',
+      'lima-guestagent.Linux-x86_64.gz',
+    )
+    await mkdir(dirname(limactlPath), { recursive: true })
+    await mkdir(dirname(armGuestAgentPath), { recursive: true })
+    await mkdir(join(resourcesDir, 'vm'), { recursive: true })
+    await writeFile(limactlPath, '#!/bin/sh\n')
+    await writeFile(armGuestAgentPath, 'guest-agent\n')
+    await writeFile(x64GuestAgentPath, 'guest-agent\n')
     await writeFile(
       join(resourcesDir, 'vm', 'browseros-vm.yaml'),
       'mounts: []\n',

--- a/packages/browseros-agent/apps/server/tests/lib/vm/paths.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/vm/paths.test.ts
@@ -123,13 +123,92 @@ describe('VM paths', () => {
       'bin',
       'third_party',
       'lima',
+      'bin',
+      'limactl',
+    )
+    const armGuestAgentPath = join(
+      resourcesDir,
+      'bin',
+      'third_party',
+      'lima',
+      'share',
+      'lima',
+      'lima-guestagent.Linux-aarch64.gz',
+    )
+    const x64GuestAgentPath = join(
+      resourcesDir,
+      'bin',
+      'third_party',
+      'lima',
+      'share',
+      'lima',
+      'lima-guestagent.Linux-x86_64.gz',
+    )
+    await mkdir(dirname(limactlPath), { recursive: true })
+    await mkdir(dirname(armGuestAgentPath), { recursive: true })
+    await writeFile(limactlPath, '#!/bin/sh\n')
+    await writeFile(armGuestAgentPath, 'guest-agent\n')
+    await writeFile(x64GuestAgentPath, 'guest-agent\n')
+
+    try {
+      expect(resolveBundledLimactl(resourcesDir)).toBe(limactlPath)
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+
+  it('validates the x64 bundled Lima guest agent path', async () => {
+    process.env.NODE_ENV = 'production'
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'limactl-x64-resources-'))
+    const limactlPath = join(
+      resourcesDir,
+      'bin',
+      'third_party',
+      'lima',
+      'bin',
+      'limactl',
+    )
+    const guestAgentPath = join(
+      resourcesDir,
+      'bin',
+      'third_party',
+      'lima',
+      'share',
+      'lima',
+      'lima-guestagent.Linux-x86_64.gz',
+    )
+    await mkdir(dirname(limactlPath), { recursive: true })
+    await mkdir(dirname(guestAgentPath), { recursive: true })
+    await writeFile(limactlPath, '#!/bin/sh\n')
+    await writeFile(guestAgentPath, 'guest-agent\n')
+
+    try {
+      expect(resolveBundledLimactl(resourcesDir, 'x64')).toBe(limactlPath)
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+
+  it('throws with a runtime packaging hint when the bundled Lima guest agent is missing', async () => {
+    process.env.NODE_ENV = 'production'
+    const resourcesDir = await mkdtemp(
+      join(tmpdir(), 'missing-lima-guest-agent-'),
+    )
+    const limactlPath = join(
+      resourcesDir,
+      'bin',
+      'third_party',
+      'lima',
+      'bin',
       'limactl',
     )
     await mkdir(dirname(limactlPath), { recursive: true })
     await writeFile(limactlPath, '#!/bin/sh\n')
 
     try {
-      expect(resolveBundledLimactl(resourcesDir)).toBe(limactlPath)
+      expect(() => resolveBundledLimactl(resourcesDir)).toThrow(
+        'bundled Lima guest agent not found',
+      )
     } finally {
       await rm(resourcesDir, { recursive: true, force: true })
     }

--- a/packages/browseros-agent/packages/build-tools/README.md
+++ b/packages/browseros-agent/packages/build-tools/README.md
@@ -54,6 +54,8 @@ artifacts/vendor/third_party/lima/limactl-darwin-x64
 artifacts/vendor/third_party/lima/lima-guestagent.Linux-x86_64.gz
 ```
 
+Server resource staging uses relative manifest keys such as `third_party/lima/limactl-darwin-arm64`; set `R2_DOWNLOAD_PREFIX=artifacts/vendor` in `apps/server/.env.production` so those keys resolve to the uploaded objects.
+
 The final server resource zip must contain real files, not a nested Lima runtime archive. Lima finds its runtime data by walking from `bin/limactl` to the sibling `share/lima` directory:
 
 ```text

--- a/packages/browseros-agent/packages/build-tools/README.md
+++ b/packages/browseros-agent/packages/build-tools/README.md
@@ -35,6 +35,56 @@ limactl shell browseros-vm-dev nerdctl load -i "$(ls dist/images/openclaw-*-arm6
 limactl delete --force browseros-vm-dev
 ```
 
+## Upload bundled Lima runtime files
+
+BrowserOS ships the Lima files needed by production server artifacts. Upload them from the upstream Lima release tarballs:
+
+```bash
+cd packages/browseros
+uv run browseros upload lima --version v2.1.1 --dry-run
+uv run browseros upload lima --version v2.1.1
+```
+
+The upload stores four R2 objects:
+
+```text
+artifacts/vendor/third_party/lima/limactl-darwin-arm64
+artifacts/vendor/third_party/lima/lima-guestagent.Linux-aarch64.gz
+artifacts/vendor/third_party/lima/limactl-darwin-x64
+artifacts/vendor/third_party/lima/lima-guestagent.Linux-x86_64.gz
+```
+
+The final server resource zip must contain real files, not a nested Lima runtime archive. Lima finds its runtime data by walking from `bin/limactl` to the sibling `share/lima` directory:
+
+```text
+resources/bin/third_party/lima/bin/limactl
+resources/bin/third_party/lima/share/lima/lima-guestagent.Linux-aarch64.gz
+resources/bin/third_party/lima/share/lima/lima-guestagent.Linux-x86_64.gz
+```
+
+`lima-additional-guestagents` is not required for BrowserOS native macOS artifacts. The core Darwin release tarballs already contain the native Linux guest agents used by our VM.
+
+Build a server resource artifact and smoke test the bundled prefix:
+
+```bash
+cd ../browseros-agent
+bun run build:server:test
+
+TMP_PREFIX="$(mktemp -d /tmp/browseros-lima-prefix.XXXXXX)"
+TMP_HOME="$(mktemp -d /tmp/browseros-lima-home.XXXXXX)"
+RESOURCES_DIR="dist/prod/server/darwin-arm64/resources"
+
+mkdir -p "$TMP_PREFIX/bin" "$TMP_PREFIX/share/lima"
+cp "$RESOURCES_DIR/bin/third_party/lima/bin/limactl" "$TMP_PREFIX/bin/limactl"
+cp "$RESOURCES_DIR/bin/third_party/lima/share/lima/lima-guestagent.Linux-aarch64.gz" "$TMP_PREFIX/share/lima/"
+
+LIMA_HOME="$TMP_HOME" "$TMP_PREFIX/bin/limactl" create --tty=false --name=browseros-smoke \
+  packages/build-tools/template/browseros-vm.yaml
+LIMA_HOME="$TMP_HOME" "$TMP_PREFIX/bin/limactl" delete --force browseros-smoke
+
+rm -rf "$TMP_PREFIX" "$TMP_HOME"
+```
+
 ## Build an agent tarball
 
 The BrowserOS VM uses containerd + nerdctl. This host-side tarball builder still requires `podman` to pull and save OCI archives for release packaging.

--- a/packages/browseros-agent/scripts/build/config/server-prod-resources.json
+++ b/packages/browseros-agent/scripts/build/config/server-prod-resources.json
@@ -6,10 +6,20 @@
         "type": "r2",
         "key": "third_party/lima/limactl-darwin-arm64"
       },
-      "destination": "resources/bin/third_party/lima/limactl",
+      "destination": "resources/bin/third_party/lima/bin/limactl",
       "os": ["macos"],
       "arch": ["arm64"],
       "executable": true
+    },
+    {
+      "name": "Lima guest agent - Linux ARM64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/lima/lima-guestagent.Linux-aarch64.gz"
+      },
+      "destination": "resources/bin/third_party/lima/share/lima/lima-guestagent.Linux-aarch64.gz",
+      "os": ["macos"],
+      "arch": ["arm64"]
     },
     {
       "name": "Lima limactl - macOS x64",
@@ -17,10 +27,20 @@
         "type": "r2",
         "key": "third_party/lima/limactl-darwin-x64"
       },
-      "destination": "resources/bin/third_party/lima/limactl",
+      "destination": "resources/bin/third_party/lima/bin/limactl",
       "os": ["macos"],
       "arch": ["x64"],
       "executable": true
+    },
+    {
+      "name": "Lima guest agent - Linux x64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/lima/lima-guestagent.Linux-x86_64.gz"
+      },
+      "destination": "resources/bin/third_party/lima/share/lima/lima-guestagent.Linux-x86_64.gz",
+      "os": ["macos"],
+      "arch": ["x64"]
     },
     {
       "name": "BrowserOS VM Lima template",

--- a/packages/browseros/build/cli/storage.py
+++ b/packages/browseros/build/cli/storage.py
@@ -34,11 +34,12 @@ class LimaArch:
 
     internal: str  # "arm64" | "x64" — how our R2 keys name it
     upstream: str  # "Darwin-arm64" | "Darwin-x86_64" — Lima's tarball suffix
+    linux_guest_arch: str  # "aarch64" | "x86_64" — Lima guest agent arch
 
 
 LIMA_ARCHES: Tuple[LimaArch, ...] = (
-    LimaArch(internal="arm64", upstream="Darwin-arm64"),
-    LimaArch(internal="x64", upstream="Darwin-x86_64"),
+    LimaArch(internal="arm64", upstream="Darwin-arm64", linux_guest_arch="aarch64"),
+    LimaArch(internal="x64", upstream="Darwin-x86_64", linux_guest_arch="x86_64"),
 )
 
 
@@ -86,18 +87,23 @@ def upload_lima(
         tmp_dir = Path(tmp)
         checksums = _fetch_checksums(tag, tmp_dir)
         uploaded_keys: List[str] = []
-        object_shas: Dict[str, str] = {}
+        object_shas: Dict[str, Dict[str, str]] = {}
         tarball_shas: Dict[str, str] = {}
 
         try:
             for arch in LIMA_ARCHES:
-                tarball_sha, object_sha, r2_key = _process_arch(
-                    tag, arch, tmp_dir, checksums, client, env, dry_run
+                tarball_sha, arch_object_shas, _ = _process_arch(
+                    tag,
+                    arch,
+                    tmp_dir,
+                    checksums,
+                    client,
+                    env,
+                    dry_run,
+                    uploaded_keys,
                 )
                 tarball_shas[arch.internal] = tarball_sha
-                object_shas[arch.internal] = object_sha
-                if not dry_run:
-                    uploaded_keys.append(r2_key)
+                object_shas[arch.internal] = arch_object_shas
 
             manifest = _build_manifest(tag, tarball_shas, object_shas)
             _upload_manifest(client, env, manifest, tmp_dir, dry_run)
@@ -150,7 +156,8 @@ def _process_arch(
     client: Any,
     env: EnvConfig,
     dry_run: bool,
-) -> Tuple[str, str, str]:
+    uploaded_keys: Optional[List[str]] = None,
+) -> Tuple[str, Dict[str, str], List[str]]:
     version_num = tag.lstrip("v")
     tarball_name = f"lima-{version_num}-{arch.upstream}.tar.gz"
     expected_sha = checksums.get(tarball_name)
@@ -171,47 +178,75 @@ def _process_arch(
             f"expected {expected_sha}, got {actual_sha}"
         )
 
-    limactl_path = tmp_dir / f"limactl-darwin-{arch.internal}"
-    _extract_limactl(tarball_path, limactl_path)
-    object_sha = _sha256_file(limactl_path)
+    guest_agent_name = f"lima-guestagent.Linux-{arch.linux_guest_arch}.gz"
+    runtime_files = [
+        (
+            "limactl",
+            "bin/limactl",
+            tmp_dir / f"limactl-darwin-{arch.internal}",
+            f"{LIMA_R2_PREFIX}/limactl-darwin-{arch.internal}",
+        ),
+        (
+            "guest_agent",
+            f"share/lima/{guest_agent_name}",
+            tmp_dir / guest_agent_name,
+            f"{LIMA_R2_PREFIX}/{guest_agent_name}",
+        ),
+    ]
 
-    r2_key = f"{LIMA_R2_PREFIX}/limactl-darwin-{arch.internal}"
-    if dry_run:
-        log_info(f"[dry-run] skipped upload of {r2_key}")
-    else:
-        if not upload_file_to_r2(client, limactl_path, r2_key, env.r2_bucket):
+    object_shas: Dict[str, str] = {}
+    r2_keys: List[str] = []
+    for name, logical_path, local_path, r2_key in runtime_files:
+        _extract_lima_file(tarball_path, logical_path, local_path)
+        object_shas[name] = _sha256_file(local_path)
+        r2_keys.append(r2_key)
+
+    for _, _, local_path, r2_key in runtime_files:
+        if dry_run:
+            log_info(f"[dry-run] skipped upload of {r2_key}")
+            continue
+        if not upload_file_to_r2(client, local_path, r2_key, env.r2_bucket):
             raise RuntimeError(f"Failed to upload {r2_key}")
+        if uploaded_keys is not None:
+            uploaded_keys.append(r2_key)
 
-    return actual_sha, object_sha, r2_key
+    return actual_sha, object_shas, r2_keys
 
 
 def _extract_limactl(tarball_path: Path, dest: Path) -> None:
-    """Extract the single `bin/limactl` entry to dest."""
+    _extract_lima_file(tarball_path, "bin/limactl", dest)
+
+
+def _extract_lima_file(tarball_path: Path, logical_path: str, dest: Path) -> None:
     with tarfile.open(tarball_path, "r:gz") as tar:
-        member = _find_limactl_member(tar)
-        extracted = tar.extractfile(member)
-        if extracted is None:
-            raise RuntimeError(f"{member.name} is not a regular file")
-        with extracted as src, open(dest, "wb") as out:
-            while chunk := src.read(1024 * 1024):
-                out.write(chunk)
-    dest.chmod(0o755)
+        for member in tar.getmembers():
+            if not member.isfile():
+                continue
+            if _logical_lima_path(member.name) != logical_path:
+                continue
+            extracted = tar.extractfile(member)
+            if extracted is None:
+                raise RuntimeError(f"{member.name} is not a regular file")
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            with extracted as src, open(dest, "wb") as out:
+                while chunk := src.read(1024 * 1024):
+                    out.write(chunk)
+            dest.chmod(member.mode & 0o777)
+            return
+    raise RuntimeError(f"{logical_path} not found in Lima tarball")
 
 
-def _find_limactl_member(tar: tarfile.TarFile) -> tarfile.TarInfo:
-    for member in tar.getmembers():
-        if not member.isfile():
-            continue
-        parts = Path(member.name).parts
-        if len(parts) >= 2 and parts[-2:] == ("bin", "limactl"):
-            return member
-    raise RuntimeError("bin/limactl not found in Lima tarball")
+def _logical_lima_path(member_name: str) -> str:
+    parts = Path(member_name.lstrip("./")).parts
+    if len(parts) > 1 and parts[0].startswith("lima-"):
+        parts = parts[1:]
+    return "/".join(parts)
 
 
 def _build_manifest(
     tag: str,
     tarball_shas: Dict[str, str],
-    object_shas: Dict[str, str],
+    object_shas: Dict[str, Dict[str, str]],
 ) -> Dict[str, Any]:
     return {
         "lima_version": tag,

--- a/packages/browseros/build/cli/storage.py
+++ b/packages/browseros/build/cli/storage.py
@@ -213,10 +213,6 @@ def _process_arch(
     return actual_sha, object_shas, r2_keys
 
 
-def _extract_limactl(tarball_path: Path, dest: Path) -> None:
-    _extract_lima_file(tarball_path, "bin/limactl", dest)
-
-
 def _extract_lima_file(tarball_path: Path, logical_path: str, dest: Path) -> None:
     with tarfile.open(tarball_path, "r:gz") as tar:
         for member in tar.getmembers():

--- a/packages/browseros/build/cli/storage_test.py
+++ b/packages/browseros/build/cli/storage_test.py
@@ -7,21 +7,47 @@ import tarfile
 import tempfile
 import unittest
 from pathlib import Path
-from typing import Any, List, Tuple
+from typing import Any, Dict, List, Tuple
 from unittest import mock
 
 from build.cli import storage
 
 
-def _build_lima_tarball(version: str, payload: bytes) -> bytes:
-    """Return a gzipped tar containing `lima-<v>/bin/limactl` with `payload`."""
+def _build_lima_tarball(
+    version: str,
+    limactl_payload: bytes,
+    guest_agents: Dict[str, bytes] | None = None,
+) -> bytes:
+    """Return a gzipped Lima release tarball with selected runtime files."""
     buffer = io.BytesIO()
     with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
-        info = tarfile.TarInfo(name=f"lima-{version}/bin/limactl")
-        info.size = len(payload)
-        info.mode = 0o755
-        tar.addfile(info, io.BytesIO(payload))
+        _add_tar_file(
+            tar,
+            f"lima-{version}/bin/limactl",
+            limactl_payload,
+            mode=0o755,
+        )
+        for guest_arch, payload in (guest_agents or {}).items():
+            _add_tar_file(
+                tar,
+                f"lima-{version}/share/lima/lima-guestagent.Linux-{guest_arch}.gz",
+                payload,
+                mode=0o644,
+            )
     return buffer.getvalue()
+
+
+def _add_tar_file(
+    tar: tarfile.TarFile,
+    name: str,
+    payload: bytes,
+    *,
+    mode: int = 0o644,
+) -> None:
+    info = tarfile.TarInfo(name=name)
+    info.size = len(payload)
+    info.mode = mode
+    tar.addfile(info, io.BytesIO(payload))
 
 
 class ParseChecksumsTest(unittest.TestCase):
@@ -62,7 +88,7 @@ class NormalizeVersionTagTest(unittest.TestCase):
         self.assertEqual(storage._normalize_version_tag("1.2.3"), "v1.2.3")
 
 
-class ExtractLimactlTest(unittest.TestCase):
+class ExtractLimaFileTest(unittest.TestCase):
     def test_extracts_limactl_binary(self) -> None:
         payload = b"limactl-bytes-" + b"x" * 100
         tarball = _build_lima_tarball("1.2.3", payload)
@@ -73,10 +99,33 @@ class ExtractLimactlTest(unittest.TestCase):
             tarball_path.write_bytes(tarball)
             dest = tmp_path / "limactl"
 
-            storage._extract_limactl(tarball_path, dest)
+            storage._extract_lima_file(tarball_path, "bin/limactl", dest)
 
             self.assertEqual(dest.read_bytes(), payload)
             self.assertTrue(dest.stat().st_mode & 0o100, "should be executable")
+
+    def test_extracts_native_guest_agent(self) -> None:
+        payload = b"guest-agent-bytes-" + b"g" * 100
+        tarball = _build_lima_tarball(
+            "1.2.3",
+            b"limactl",
+            guest_agents={"aarch64": payload},
+        )
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            tarball_path = tmp_path / "lima.tar.gz"
+            tarball_path.write_bytes(tarball)
+            dest = tmp_path / "lima-guestagent.Linux-aarch64.gz"
+
+            storage._extract_lima_file(
+                tarball_path,
+                "share/lima/lima-guestagent.Linux-aarch64.gz",
+                dest,
+            )
+
+            self.assertEqual(dest.read_bytes(), payload)
+            self.assertFalse(dest.stat().st_mode & 0o100, "should not be executable")
 
     def test_raises_when_limactl_missing(self) -> None:
         buffer = io.BytesIO()
@@ -91,7 +140,25 @@ class ExtractLimactlTest(unittest.TestCase):
             tarball_path.write_bytes(buffer.getvalue())
 
             with self.assertRaisesRegex(RuntimeError, "bin/limactl not found"):
-                storage._extract_limactl(tarball_path, tmp_path / "out")
+                storage._extract_lima_file(tarball_path, "bin/limactl", tmp_path / "out")
+
+    def test_raises_when_guest_agent_missing(self) -> None:
+        tarball = _build_lima_tarball("1.2.3", b"limactl")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            tarball_path = tmp_path / "lima.tar.gz"
+            tarball_path.write_bytes(tarball)
+
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "share/lima/lima-guestagent.Linux-aarch64.gz not found",
+            ):
+                storage._extract_lima_file(
+                    tarball_path,
+                    "share/lima/lima-guestagent.Linux-aarch64.gz",
+                    tmp_path / "guest-agent",
+                )
 
 
 class RollbackTest(unittest.TestCase):
@@ -119,11 +186,15 @@ class BuildManifestTest(unittest.TestCase):
         manifest = storage._build_manifest(
             "v1.2.3",
             {"arm64": "a" * 64, "x64": "b" * 64},
-            {"arm64": "c" * 64, "x64": "d" * 64},
+            {
+                "arm64": {"limactl": "c" * 64, "guest_agent": "d" * 64},
+                "x64": {"limactl": "e" * 64, "guest_agent": "f" * 64},
+            },
         )
         self.assertEqual(manifest["lima_version"], "v1.2.3")
         self.assertEqual(manifest["tarball_shas_upstream"]["arm64"], "a" * 64)
-        self.assertEqual(manifest["r2_object_shas"]["x64"], "d" * 64)
+        self.assertEqual(manifest["r2_object_shas"]["x64"]["limactl"], "e" * 64)
+        self.assertEqual(manifest["r2_object_shas"]["x64"]["guest_agent"], "f" * 64)
         self.assertIn("uploaded_at", manifest)
         self.assertIn("uploaded_by", manifest)
 
@@ -132,20 +203,28 @@ class ProcessArchTest(unittest.TestCase):
     """Covers download + sha verify + extract + upload in one pass."""
 
     def setUp(self) -> None:
-        self.payload = b"limactl-binary-" + b"z" * 200
-        self.tarball_bytes = _build_lima_tarball("1.2.3", self.payload)
+        self.limactl_payload = b"limactl-binary-" + b"z" * 200
+        self.guest_agent_payload = b"guest-agent-" + b"y" * 200
+        self.tarball_bytes = _build_lima_tarball(
+            "1.2.3",
+            self.limactl_payload,
+            guest_agents={"aarch64": self.guest_agent_payload},
+        )
         self.expected_tarball_sha = hashlib.sha256(self.tarball_bytes).hexdigest()
-        self.expected_object_sha = hashlib.sha256(self.payload).hexdigest()
+        self.expected_limactl_sha = hashlib.sha256(self.limactl_payload).hexdigest()
+        self.expected_guest_agent_sha = hashlib.sha256(
+            self.guest_agent_payload
+        ).hexdigest()
 
     def _fake_download(self, _url: str, dest: Path, **_kwargs: Any) -> None:
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(self.tarball_bytes)
 
     def test_happy_path_uploads_and_returns_shas(self) -> None:
-        uploads: List[Tuple[str, str]] = []
+        uploads: List[Tuple[str, str, bytes]] = []
 
-        def fake_upload(_client: Any, _local_path: Path, r2_key: str, bucket: str) -> bool:
-            uploads.append((r2_key, bucket))
+        def fake_upload(_client: Any, local_path: Path, r2_key: str, bucket: str) -> bool:
+            uploads.append((r2_key, bucket, local_path.read_bytes()))
             return True
 
         env = mock.Mock(r2_bucket="browseros")
@@ -154,9 +233,13 @@ class ProcessArchTest(unittest.TestCase):
             tmp_path = Path(tmp)
             with mock.patch.object(storage, "_download", side_effect=self._fake_download), \
                  mock.patch.object(storage, "upload_file_to_r2", side_effect=fake_upload):
-                tarball_sha, object_sha, r2_key = storage._process_arch(
+                tarball_sha, object_shas, r2_keys = storage._process_arch(
                     tag="v1.2.3",
-                    arch=storage.LimaArch(internal="arm64", upstream="Darwin-arm64"),
+                    arch=storage.LimaArch(
+                        internal="arm64",
+                        upstream="Darwin-arm64",
+                        linux_guest_arch="aarch64",
+                    ),
                     tmp_dir=tmp_path,
                     checksums={
                         "lima-1.2.3-Darwin-arm64.tar.gz": self.expected_tarball_sha
@@ -167,9 +250,19 @@ class ProcessArchTest(unittest.TestCase):
                 )
 
         self.assertEqual(tarball_sha, self.expected_tarball_sha)
-        self.assertEqual(object_sha, self.expected_object_sha)
         self.assertEqual(
-            r2_key, "artifacts/vendor/third_party/lima/limactl-darwin-arm64"
+            object_shas,
+            {
+                "limactl": self.expected_limactl_sha,
+                "guest_agent": self.expected_guest_agent_sha,
+            },
+        )
+        self.assertEqual(
+            r2_keys,
+            [
+                "artifacts/vendor/third_party/lima/limactl-darwin-arm64",
+                "artifacts/vendor/third_party/lima/lima-guestagent.Linux-aarch64.gz",
+            ],
         )
         self.assertEqual(
             uploads,
@@ -177,6 +270,12 @@ class ProcessArchTest(unittest.TestCase):
                 (
                     "artifacts/vendor/third_party/lima/limactl-darwin-arm64",
                     "browseros",
+                    self.limactl_payload,
+                ),
+                (
+                    "artifacts/vendor/third_party/lima/lima-guestagent.Linux-aarch64.gz",
+                    "browseros",
+                    self.guest_agent_payload,
                 )
             ],
         )
@@ -197,7 +296,11 @@ class ProcessArchTest(unittest.TestCase):
                 with self.assertRaisesRegex(RuntimeError, "sha256 mismatch"):
                     storage._process_arch(
                         tag="v1.2.3",
-                        arch=storage.LimaArch(internal="arm64", upstream="Darwin-arm64"),
+                        arch=storage.LimaArch(
+                            internal="arm64",
+                            upstream="Darwin-arm64",
+                            linux_guest_arch="aarch64",
+                        ),
                         tmp_dir=tmp_path,
                         checksums={"lima-1.2.3-Darwin-arm64.tar.gz": "0" * 64},
                         client=mock.Mock(),
@@ -215,7 +318,11 @@ class ProcessArchTest(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "missing from SHA256SUMS"):
                 storage._process_arch(
                     tag="v1.2.3",
-                    arch=storage.LimaArch(internal="arm64", upstream="Darwin-arm64"),
+                    arch=storage.LimaArch(
+                        internal="arm64",
+                        upstream="Darwin-arm64",
+                        linux_guest_arch="aarch64",
+                    ),
                     tmp_dir=tmp_path,
                     checksums={},
                     client=mock.Mock(),
@@ -236,9 +343,13 @@ class ProcessArchTest(unittest.TestCase):
             tmp_path = Path(tmp)
             with mock.patch.object(storage, "_download", side_effect=self._fake_download), \
                  mock.patch.object(storage, "upload_file_to_r2", side_effect=fake_upload):
-                _, _, r2_key = storage._process_arch(
+                _, _, r2_keys = storage._process_arch(
                     tag="v1.2.3",
-                    arch=storage.LimaArch(internal="arm64", upstream="Darwin-arm64"),
+                    arch=storage.LimaArch(
+                        internal="arm64",
+                        upstream="Darwin-arm64",
+                        linux_guest_arch="aarch64",
+                    ),
                     tmp_dir=tmp_path,
                     checksums={
                         "lima-1.2.3-Darwin-arm64.tar.gz": self.expected_tarball_sha
@@ -250,8 +361,53 @@ class ProcessArchTest(unittest.TestCase):
 
         self.assertEqual(uploads, [])
         self.assertEqual(
-            r2_key, "artifacts/vendor/third_party/lima/limactl-darwin-arm64"
+            r2_keys,
+            [
+                "artifacts/vendor/third_party/lima/limactl-darwin-arm64",
+                "artifacts/vendor/third_party/lima/lima-guestagent.Linux-aarch64.gz",
+            ],
         )
+
+    def test_missing_guest_agent_aborts_before_upload(self) -> None:
+        tarball_bytes = _build_lima_tarball("1.2.3", self.limactl_payload)
+        expected_sha = hashlib.sha256(tarball_bytes).hexdigest()
+        uploads: List[Tuple[str, str]] = []
+
+        def fake_download(_url: str, dest: Path, **_kwargs: Any) -> None:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(tarball_bytes)
+
+        def fake_upload(_client: Any, _local_path: Path, r2_key: str, bucket: str) -> bool:
+            uploads.append((r2_key, bucket))
+            return True
+
+        env = mock.Mock(r2_bucket="browseros")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            with mock.patch.object(storage, "_download", side_effect=fake_download), \
+                 mock.patch.object(storage, "upload_file_to_r2", side_effect=fake_upload):
+                with self.assertRaisesRegex(
+                    RuntimeError,
+                    "share/lima/lima-guestagent.Linux-aarch64.gz not found",
+                ):
+                    storage._process_arch(
+                        tag="v1.2.3",
+                        arch=storage.LimaArch(
+                            internal="arm64",
+                            upstream="Darwin-arm64",
+                            linux_guest_arch="aarch64",
+                        ),
+                        tmp_dir=tmp_path,
+                        checksums={
+                            "lima-1.2.3-Darwin-arm64.tar.gz": expected_sha
+                        },
+                        client=mock.Mock(),
+                        env=env,
+                        dry_run=False,
+                    )
+
+        self.assertEqual(uploads, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Uploads native Lima guest-agent files alongside limactl and records per-file R2 shas in the Lima manifest.
- Stages Lima resources into a self-contained `<prefix>/bin` plus `<prefix>/share/lima` layout in server resource zips.
- Validates the bundled guest-agent path before launching the BrowserOS VM and documents the upload/smoke flow.

## Design
The build upload keeps Lima resources as individual R2 files rather than a nested runtime archive. Server resource staging places `limactl` and the native Linux guest agent in the same prefix shape Lima expects, so production users do not need Homebrew Lima or `lima-additional-guestagents` installed.

## Test plan
- [x] `cd packages/browseros && uv run python -m unittest build/cli/storage_test.py`
- [x] `cd packages/browseros && uv run ruff check build/cli/storage.py build/cli/storage_test.py`
- [x] `cd packages/browseros-agent && bun run ./scripts/run-bun-test.ts ./apps/server/tests/lib/vm/paths.test.ts`
- [x] `cd packages/browseros-agent && bun run ./scripts/run-bun-test.ts ./apps/server/tests/api/services/openclaw/container-runtime-factory.test.ts`
- [x] `cd packages/browseros-agent && bun run ./scripts/run-bun-test.ts ./apps/agent/entrypoints/newtab/layout/route-utils.test.ts`
- [x] `cd packages/browseros-agent && bun run test:all`
- [x] `cd packages/browseros-agent && bun run lint` (exits 0; existing warnings remain)
- [x] `cd packages/browseros-agent && bun run typecheck`
- [x] `cd packages/browseros-agent && bun run build:server:test`
- [x] Built-prefix `limactl create --tty=false --name=browseros-smoke packages/build-tools/template/browseros-vm.yaml`