### PR TITLE
feat: add support for NVIDIA NIM provider in LLM system

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,5 @@
 {
   "terminal.integrated.tabs.title": "${sequence} ${process}",
-  "terminal.integrated.tabs.description": "${cwd}"
+  "terminal.integrated.tabs.description": "${cwd}",
+  "snyk.advanced.autoSelectOrganization": true
 }

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/providerIcons.tsx
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/providerIcons.tsx
@@ -36,6 +36,7 @@ const providerIconMap: Record<ProviderType, IconComponent | null> = {
   'chatgpt-pro': OpenAI,
   'github-copilot': Github,
   'qwen-code': Qwen,
+  'nvidia-nim': Bot,
 }
 
 interface ProviderIconProps {

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/providerTemplates.ts
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/providerTemplates.ts
@@ -73,6 +73,16 @@ export const providerTemplates: ProviderTemplate[] = [
     setupGuideUrl: 'https://docs.browseros.com/features/qwen-code-oauth',
   },
   {
+    id: 'nvidia-nim',
+    name: 'NVIDIA NIM',
+    defaultBaseUrl: 'https://integrate.api.nvidia.com/v1',
+    defaultModelId: 'nvidia/llama-3.1-nemotron-nano-8b-instruct',
+    supportsImages: true,
+    contextWindow: 128000,
+    apiKeyUrl: 'https://build.nvidia.com/settings/api-keys',
+    setupGuideUrl: 'https://docs.nvidia.com/nim/',
+  },
+  {
     id: 'moonshot',
     name: 'Moonshot AI',
     defaultBaseUrl: 'https://api.moonshot.ai/v1',
@@ -161,6 +171,7 @@ export const providerTypeOptions: { value: ProviderType; label: string }[] = [
   { value: 'lmstudio', label: 'LM Studio' },
   { value: 'bedrock', label: 'AWS Bedrock' },
   { value: 'browseros', label: 'BrowserOS' },
+  { value: 'nvidia-nim', label: 'NVIDIA NIM' },
 ]
 
 /**
@@ -192,6 +203,7 @@ export const DEFAULT_BASE_URLS: Record<ProviderType, string> = {
   lmstudio: 'http://localhost:1234/v1',
   bedrock: '',
   browseros: '',
+  'nvidia-nim': 'https://integrate.api.nvidia.com/v1',
 }
 
 /**

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/types.ts
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/types.ts
@@ -17,6 +17,7 @@ export type ProviderType =
   | 'chatgpt-pro'
   | 'github-copilot'
   | 'qwen-code'
+  | 'nvidia-nim'
 
 /**
  * LLM Provider configuration

--- a/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
+++ b/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
@@ -179,6 +179,17 @@ function createQwenCodeFactory(
   })
 }
 
+function createNvidiaNimFactory(
+  config: ResolvedAgentConfig,
+): (modelId: string) => unknown {
+  if (!config.apiKey) throw new Error('NVIDIA NIM requires apiKey')
+  return createOpenAICompatible({
+    name: 'nvidia-nim',
+    baseURL: EXTERNAL_URLS.NVIDIA_NIM_API,
+    apiKey: config.apiKey,
+  })
+}
+
 function createGitHubCopilotFactory(
   config: ResolvedAgentConfig,
 ): (modelId: string) => unknown {
@@ -218,6 +229,7 @@ const PROVIDER_FACTORIES: Record<string, ProviderFactory> = {
   [LLM_PROVIDERS.CHATGPT_PRO]: createChatGPTProFactory,
   [LLM_PROVIDERS.GITHUB_COPILOT]: createGitHubCopilotFactory,
   [LLM_PROVIDERS.QWEN_CODE]: createQwenCodeFactory,
+  [LLM_PROVIDERS.NVIDIA_NIM]: createNvidiaNimFactory,
 }
 
 export function createLanguageModel(

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/provider.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/provider.ts
@@ -161,6 +161,15 @@ function createQwenCodeModel(config: ResolvedLLMConfig): LanguageModel {
   })(config.model)
 }
 
+function createNvidiaNimModel(config: ResolvedLLMConfig): LanguageModel {
+  if (!config.apiKey) throw new Error('NVIDIA NIM requires apiKey')
+  return createOpenAICompatible({
+    name: 'nvidia-nim',
+    baseURL: EXTERNAL_URLS.NVIDIA_NIM_API,
+    apiKey: config.apiKey,
+  })(config.model)
+}
+
 function createGitHubCopilotModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.apiKey)
     throw new Error('GitHub Copilot requires OAuth authentication')
@@ -196,6 +205,7 @@ const PROVIDER_FACTORIES: Record<string, ProviderFactory> = {
   [LLM_PROVIDERS.CHATGPT_PRO]: createChatGPTProModel,
   [LLM_PROVIDERS.GITHUB_COPILOT]: createGitHubCopilotModel,
   [LLM_PROVIDERS.QWEN_CODE]: createQwenCodeModel,
+  [LLM_PROVIDERS.NVIDIA_NIM]: createNvidiaNimModel,
 }
 
 export function createLLMProvider(config: ResolvedLLMConfig): LanguageModel {

--- a/packages/browseros-agent/packages/shared/src/constants/urls.ts
+++ b/packages/browseros-agent/packages/shared/src/constants/urls.ts
@@ -21,4 +21,5 @@ export const EXTERNAL_URLS = {
   QWEN_DEVICE_CODE: 'https://chat.qwen.ai/api/v1/oauth2/device/code',
   QWEN_OAUTH_TOKEN: 'https://chat.qwen.ai/api/v1/oauth2/token',
   QWEN_CODE_API: 'https://portal.qwen.ai/v1',
+  NVIDIA_NIM_API: 'https://integrate.api.nvidia.com/v1',
 } as const

--- a/packages/browseros-agent/packages/shared/src/schemas/llm.ts
+++ b/packages/browseros-agent/packages/shared/src/schemas/llm.ts
@@ -27,6 +27,7 @@ export const LLM_PROVIDERS = {
   CHATGPT_PRO: 'chatgpt-pro',
   GITHUB_COPILOT: 'github-copilot',
   QWEN_CODE: 'qwen-code',
+  NVIDIA_NIM: 'nvidia-nim',
 } as const
 
 /**
@@ -48,6 +49,7 @@ export const LLMProviderSchema: z.ZodEnum<
     'chatgpt-pro',
     'github-copilot',
     'qwen-code',
+    'nvidia-nim',
   ]
 > = z.enum([
   LLM_PROVIDERS.ANTHROPIC,
@@ -64,6 +66,7 @@ export const LLMProviderSchema: z.ZodEnum<
   LLM_PROVIDERS.CHATGPT_PRO,
   LLM_PROVIDERS.GITHUB_COPILOT,
   LLM_PROVIDERS.QWEN_CODE,
+  LLM_PROVIDERS.NVIDIA_NIM,
 ])
 
 export type LLMProvider = z.infer<typeof LLMProviderSchema>


### PR DESCRIPTION
Add NVIDIA NIM AI API Support
Summary
Adds support for NVIDIA NIM (NVIDIA Inference Microservices) as a new LLM provider in BrowserOS.
Changes
Files modified:
- packages/shared/src/schemas/llm.ts - Added nvidia-nim provider constant and schema
- packages/shared/src/constants/urls.ts - Added NVIDIA NIM API endpoint
- apps/agent/lib/llm-providers/types.ts - Added nvidia-nim to ProviderType
- apps/agent/lib/llm-providers/providerTemplates.ts - Added NVIDIA NIM template
- apps/agent/lib/llm-providers/providerIcons.tsx - Added icon mapping
- apps/server/src/lib/clients/llm/provider.ts - Added provider factory
- apps/server/src/agent/provider-factory.ts - Added agent factory
Usage
- Default Base URL: https://integrate.api.nvidia.com/v1
- Default Model: nvidia/llama-3.1-nemotron-nano-8b-instruct
- API Keys: Get at https://build.nvidia.com/settings/api-keys
- Docs: https://docs.nvidia.com/nim/
Notes
- Uses OpenAI-compatible API (via @ai-sdk/openai-compatible)
- Free tier: 1,000 inference credits on signup (40 RPM rate limit)
- Supports 100+ models including Nemotron, Kimi, MiniMax, GLM