### PR TITLE
fix: clean limactl entitlement test

### DIFF
--- a/packages/browseros/build/common/server_binaries.py
+++ b/packages/browseros/build/common/server_binaries.py
@@ -30,7 +30,7 @@ MACOS_SERVER_BINARIES: Dict[str, SignSpec] = {
     ),
     "bun": SignSpec("bun", "runtime", "browseros-executable-entitlements.plist"),
     "rg": SignSpec("rg", "runtime"),
-    "limactl": SignSpec("limactl", "runtime"),
+    "limactl": SignSpec("limactl", "runtime", "lima-vz-entitlements.plist"),
 }
 
 

--- a/packages/browseros/build/common/server_binaries_test.py
+++ b/packages/browseros/build/common/server_binaries_test.py
@@ -35,12 +35,11 @@ class MacosServerBinariesTest(unittest.TestCase):
         self.assertIsNone(macos_sign_spec_for(Path("/x/not_a_known_binary")))
 
     def test_limactl_uses_vz_entitlement(self):
+        entitlements_name = "lima-vz-entitlements.plist"
         spec = macos_sign_spec_for(Path("/x/limactl"))
         assert spec is not None
-        self.assertEqual(spec.entitlements, "lima-vz-entitlements.plist")
+        self.assertEqual(spec.entitlements, entitlements_name)
 
-        entitlements_name = spec.entitlements
-        assert entitlements_name is not None
         entitlements = plistlib.loads((ENTITLEMENTS_DIR / entitlements_name).read_bytes())
         self.assertIs(entitlements.get("com.apple.security.virtualization"), True)
 

--- a/packages/browseros/build/common/server_binaries_test.py
+++ b/packages/browseros/build/common/server_binaries_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Tests for the shared server-binary sign table."""
 
+import plistlib
 import unittest
 from pathlib import Path
 
@@ -32,6 +33,16 @@ class MacosServerBinariesTest(unittest.TestCase):
         assert spec is not None
         self.assertEqual(spec.identifier_suffix, "limactl")
         self.assertIsNone(macos_sign_spec_for(Path("/x/not_a_known_binary")))
+
+    def test_limactl_uses_vz_entitlement(self):
+        spec = macos_sign_spec_for(Path("/x/limactl"))
+        assert spec is not None
+        self.assertEqual(spec.entitlements, "lima-vz-entitlements.plist")
+
+        entitlements_name = spec.entitlements
+        assert entitlements_name is not None
+        entitlements = plistlib.loads((ENTITLEMENTS_DIR / entitlements_name).read_bytes())
+        self.assertIs(entitlements.get("com.apple.security.virtualization"), True)
 
     def test_matches_lima_bundle_layout(self):
         keys = set(MACOS_SERVER_BINARIES.keys())

--- a/packages/browseros/resources/entitlements/lima-vz-entitlements.plist
+++ b/packages/browseros/resources/entitlements/lima-vz-entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>com.apple.security.virtualization</key>
+  <true/>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- Removes the redundant optional null-guard from the `limactl` entitlement regression test.
- Keeps pyright green by using an explicit expected entitlement filename constant.

## Design
PR #822 was squash-merged before this review-nit cleanup commit landed on the branch. This follow-up carries only the test cleanup requested by the AI review; the production signing fix is already merged in #822.

## Test plan
- [x] `cd packages/browseros && uv run python -m unittest build.common.server_binaries_test`
- [x] `cd packages/browseros && uv run python -m unittest discover -s build -p '*_test.py'`
- [x] `cd packages/browseros && uv run ruff check build/common/server_binaries.py build/common/server_binaries_test.py`
- [x] `cd packages/browseros && uv run pyright build/common/server_binaries.py build/common/server_binaries_test.py`
- [x] `git diff --check`
