### PR TITLE
feat(agent): enrich chat UI with tool activity, reasoning duration, and cost

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
@@ -236,9 +236,16 @@ function AgentConversationController({
   onInitialMessageConsumedRef.current = onInitialMessageConsumed
 
   const disabled = status?.status !== 'running'
+  // Stay in the loading state until BOTH queries have actually fetched.
+  // historyQuery.isLoading is only true on the very first request — after
+  // session resolution there's a brief render frame where the history query
+  // hasn't been triggered yet (enabled just flipped to true). Gating on
+  // isFetched closes that window so we never render with empty history.
   const isInitialLoading =
     sessionQuery.isLoading ||
-    (Boolean(resolvedSessionKey) && historyQuery.isLoading)
+    (Boolean(resolvedSessionKey) &&
+      !historyQuery.isFetched &&
+      !historyQuery.isError)
   const historyReady =
     !resolvedSessionKey || historyQuery.isFetched || historyQuery.isError
   const initialMessageKey = initialMessage

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
@@ -1,4 +1,3 @@
-import { useQueryClient } from '@tanstack/react-query'
 import { ArrowLeft, Bot, Home } from 'lucide-react'
 import { type FC, useEffect, useMemo, useRef, useState } from 'react'
 import { Navigate, useNavigate, useParams, useSearchParams } from 'react-router'
@@ -16,11 +15,7 @@ import {
   flattenHistoryPages,
 } from './claw-chat-types'
 import { useAgentConversation } from './useAgentConversation'
-import {
-  CLAW_CHAT_QUERY_KEYS,
-  useClawAgentSession,
-  useClawChatHistory,
-} from './useClawChatHistory'
+import { useClawChatHistory } from './useClawChatHistory'
 
 function StatusBadge({ status }: { status: string }) {
   return (
@@ -196,20 +191,18 @@ function AgentConversationController({
   agentPathPrefix: string
   createAgentPath: string
 }) {
-  const queryClient = useQueryClient()
   const navigate = useNavigate()
   const initialMessageSentRef = useRef<string | null>(null)
   const onInitialMessageConsumedRef = useRef(onInitialMessageConsumed)
   const [streamSessionKey, setStreamSessionKey] = useState<string | null>(null)
   const agent = agents.find((entry) => entry.agentId === agentId)
   const agentName = agent?.name || agentId || 'Agent'
-  const sessionQuery = useClawAgentSession(agentId)
-  const resolvedSessionKey =
-    streamSessionKey ?? sessionQuery.data?.sessionKey ?? null
+  // Single source of truth: the history endpoint resolves the session itself
+  // when sessionKey is null. Once a chat creates a new session, streamSessionKey
+  // overrides it and the history queryKey rotates to refetch for that session.
   const historyQuery = useClawChatHistory({
     agentId,
-    sessionKey: resolvedSessionKey,
-    enabled: Boolean(resolvedSessionKey),
+    sessionKey: streamSessionKey,
   })
 
   const historyMessages = useMemo(
@@ -220,15 +213,14 @@ function AgentConversationController({
     () => buildChatHistoryFromClawMessages(historyMessages),
     [historyMessages],
   )
+  const resolvedSessionKey =
+    streamSessionKey ?? historyQuery.data?.pages?.[0]?.sessionKey ?? null
 
   const { turns, streaming, send } = useAgentConversation(agentId, {
     sessionKey: resolvedSessionKey,
     history: chatHistory,
     onSessionKeyChange: (sessionKey) => {
       setStreamSessionKey(sessionKey)
-      void queryClient.invalidateQueries({
-        queryKey: [CLAW_CHAT_QUERY_KEYS.session],
-      })
     },
   })
   const sendRef = useRef(send)
@@ -236,22 +228,19 @@ function AgentConversationController({
   onInitialMessageConsumedRef.current = onInitialMessageConsumed
 
   const disabled = status?.status !== 'running'
-  // Stay in the loading state until BOTH queries have actually fetched.
-  // historyQuery.isLoading is only true on the very first request — after
-  // session resolution there's a brief render frame where the history query
-  // hasn't been triggered yet (enabled just flipped to true). Gating on
-  // isFetched closes that window so we never render with empty history.
+  // Two-part gate: cover both "still fetching" AND "just got enabled but
+  // hasn't started fetching yet". When `enabled` flips true (baseUrl
+  // resolves), there's a render frame where React Query reports
+  // isLoading=false but hasn't run the queryFn yet — `isFetched` is still
+  // false. Without this we render EmptyState during that one frame.
   const isInitialLoading =
-    sessionQuery.isLoading ||
-    (Boolean(resolvedSessionKey) &&
-      !historyQuery.isFetched &&
-      !historyQuery.isError)
-  const historyReady =
-    !resolvedSessionKey || historyQuery.isFetched || historyQuery.isError
+    historyQuery.isLoading || (!historyQuery.isFetched && !historyQuery.isError)
+
+  const historyReady = historyQuery.isFetched || historyQuery.isError
   const initialMessageKey = initialMessage
     ? `${agentId}:${initialMessage}`
     : null
-  const error = sessionQuery.error ?? historyQuery.error ?? null
+  const error = historyQuery.error ?? null
 
   useEffect(() => {
     const query = initialMessage?.trim()
@@ -264,7 +253,6 @@ function AgentConversationController({
       !query ||
       initialMessageSentRef.current === initialMessageKey ||
       disabled ||
-      sessionQuery.isLoading ||
       !historyReady ||
       streaming
     ) {
@@ -274,14 +262,7 @@ function AgentConversationController({
     initialMessageSentRef.current = initialMessageKey
     onInitialMessageConsumedRef.current()
     void sendRef.current(query)
-  }, [
-    disabled,
-    historyReady,
-    initialMessage,
-    initialMessageKey,
-    sessionQuery.isLoading,
-    streaming,
-  ])
+  }, [disabled, historyReady, initialMessage, initialMessageKey, streaming])
 
   const handleSelectAgent = (entry: AgentEntry) => {
     navigate(`${agentPathPrefix}/${entry.agentId}`)
@@ -302,7 +283,6 @@ function AgentConversationController({
           void historyQuery.fetchNextPage()
         }}
         onRetry={() => {
-          void sessionQuery.refetch()
           void historyQuery.refetch()
         }}
       />

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ClawChatMessage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ClawChatMessage.tsx
@@ -16,11 +16,6 @@ import {
 import { cn } from '@/lib/utils'
 import type { ClawChatMessage as ClawChatMessageType } from './claw-chat-types'
 
-function formatTokenCount(tokens: number): string {
-  if (tokens < 1000) return String(tokens)
-  return `${(tokens / 1000).toFixed(1)}K`
-}
-
 function formatCost(usd: number): string {
   if (usd < 0.005) return `$${usd.toFixed(4)}`
   return `$${usd.toFixed(2)}`
@@ -39,10 +34,6 @@ export const ClawChatMessage: FC<ClawChatMessageProps> = ({ message }) => {
   const handleCopy = useCallback(() => {
     if (messageText) navigator.clipboard.writeText(messageText)
   }, [messageText])
-
-  const hasCostData =
-    message.role === 'assistant' &&
-    (message.costUsd || message.tokensIn || message.tokensOut)
 
   return (
     <Message
@@ -113,25 +104,17 @@ export const ClawChatMessage: FC<ClawChatMessageProps> = ({ message }) => {
           }
         })}
 
-        {messageText ? (
-          <MessageToolbar className="opacity-0 transition-opacity group-hover:opacity-100">
+        {message.role === 'assistant' && messageText ? (
+          <MessageToolbar>
             <MessageActions>
               <MessageAction tooltip="Copy" onClick={handleCopy}>
                 <Copy className="size-3.5" />
               </MessageAction>
             </MessageActions>
-            {hasCostData ? (
-              <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground/50 tabular-nums">
-                {message.tokensIn != null && message.tokensOut != null ? (
-                  <span>
-                    {formatTokenCount(message.tokensIn)} →{' '}
-                    {formatTokenCount(message.tokensOut)}
-                  </span>
-                ) : null}
-                {message.costUsd ? (
-                  <span>{formatCost(message.costUsd)}</span>
-                ) : null}
-              </div>
+            {message.costUsd ? (
+              <span className="text-[11px] text-muted-foreground/50 tabular-nums">
+                {formatCost(message.costUsd)}
+              </span>
             ) : null}
           </MessageToolbar>
         ) : null}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ClawChatMessage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ClawChatMessage.tsx
@@ -156,7 +156,14 @@ export const ClawChatMessage: FC<ClawChatMessageProps> = ({ message }) => {
                       className="flex items-center gap-2"
                     >
                       <ToolStatusIcon status={tool.status} />
-                      <span className="font-mono text-xs">{tool.name}</span>
+                      <span className="text-foreground text-xs">
+                        {tool.label}
+                      </span>
+                      {tool.subject ? (
+                        <span className="ml-1.5 truncate text-muted-foreground/70 text-xs">
+                          · {tool.subject}
+                        </span>
+                      ) : null}
                       {tool.error ? (
                         <span className="ml-2 truncate text-destructive text-xs">
                           {tool.error}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ClawChatMessage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ClawChatMessage.tsx
@@ -111,6 +111,13 @@ export const ClawChatMessage: FC<ClawChatMessageProps> = ({ message }) => {
             return (
               <MessageResponse
                 key={key}
+                // Historical messages are finalized — render immediately.
+                // Streamdown's default "streaming" mode uses an idle-callback
+                // debounce (300ms / 500ms idle) that paints empty content
+                // first, which made history flash blank tool collapsibles
+                // before text on every load.
+                mode="static"
+                parseIncompleteMarkdown={false}
                 className={cn(
                   'max-w-full overflow-hidden break-words',
                   '[&_[data-streamdown="code-block"]]:!w-full [&_[data-streamdown="code-block"]]:!max-w-full [&_[data-streamdown="code-block"]]:overflow-x-auto',

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ClawChatMessage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ClawChatMessage.tsx
@@ -1,5 +1,5 @@
-import { CheckCircle2, Copy, Loader2, XCircle } from 'lucide-react'
-import { type FC, useCallback } from 'react'
+import { CheckCircle2, Copy, Loader2, Wrench, XCircle } from 'lucide-react'
+import { type FC, useCallback, useMemo } from 'react'
 import {
   Message,
   MessageAction,
@@ -13,12 +13,70 @@ import {
   ReasoningContent,
   ReasoningTrigger,
 } from '@/components/ai-elements/reasoning'
+import {
+  Task,
+  TaskContent,
+  TaskItem,
+  TaskTrigger,
+} from '@/components/ai-elements/task'
 import { cn } from '@/lib/utils'
-import type { ClawChatMessage as ClawChatMessageType } from './claw-chat-types'
+import type {
+  ClawChatMessagePart,
+  ClawChatMessage as ClawChatMessageType,
+} from './claw-chat-types'
 
 function formatCost(usd: number): string {
   if (usd < 0.005) return `$${usd.toFixed(4)}`
   return `$${usd.toFixed(2)}`
+}
+
+type ToolCallPart = Extract<ClawChatMessagePart, { type: 'tool-call' }>
+
+interface RenderEntry {
+  kind: 'text' | 'reasoning' | 'meta' | 'task'
+  partIndex: number
+  part?: ClawChatMessagePart
+  tools?: ToolCallPart[]
+}
+
+/**
+ * Build a render plan that groups all tool-call parts into a single Task
+ * collapsible at their first appearance position. Other parts render in place.
+ */
+function buildRenderEntries(parts: ClawChatMessagePart[]): RenderEntry[] {
+  const entries: RenderEntry[] = []
+  const tools: ToolCallPart[] = []
+  let taskInserted = false
+
+  parts.forEach((part, partIndex) => {
+    if (part.type === 'tool-call') {
+      tools.push(part)
+      if (!taskInserted) {
+        entries.push({ kind: 'task', partIndex, tools })
+        taskInserted = true
+      }
+    } else if (part.type === 'text') {
+      entries.push({ kind: 'text', partIndex, part })
+    } else if (part.type === 'reasoning') {
+      entries.push({ kind: 'reasoning', partIndex, part })
+    } else if (part.type === 'meta') {
+      entries.push({ kind: 'meta', partIndex, part })
+    }
+  })
+
+  return entries
+}
+
+function ToolStatusIcon({ status }: { status: ToolCallPart['status'] }) {
+  if (status === 'running' || status === 'pending') {
+    return (
+      <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
+    )
+  }
+  if (status === 'completed') {
+    return <CheckCircle2 className="size-3.5 shrink-0 text-green-500" />
+  }
+  return <XCircle className="size-3.5 shrink-0 text-destructive" />
 }
 
 interface ClawChatMessageProps {
@@ -35,73 +93,83 @@ export const ClawChatMessage: FC<ClawChatMessageProps> = ({ message }) => {
     if (messageText) navigator.clipboard.writeText(messageText)
   }, [messageText])
 
+  const entries = useMemo(
+    () => buildRenderEntries(message.parts),
+    [message.parts],
+  )
+
   return (
     <Message
       from={message.role}
       className="max-w-full group-[.is-user]:max-w-[80%]"
     >
       <MessageContent className="max-w-full overflow-hidden group-[.is-assistant]:w-full group-[.is-user]:max-w-full">
-        {message.parts.map((part, index) => {
-          const key = `${message.id}-part-${index}`
+        {entries.map((entry) => {
+          const key = `${message.id}-entry-${entry.partIndex}`
 
-          switch (part.type) {
-            case 'text':
-              return (
-                <MessageResponse
-                  key={key}
-                  className={cn(
-                    'max-w-full overflow-hidden break-words',
-                    '[&_[data-streamdown="code-block"]]:!w-full [&_[data-streamdown="code-block"]]:!max-w-full [&_[data-streamdown="code-block"]]:overflow-x-auto',
-                    '[&_[data-streamdown="table-wrapper"]]:!w-full [&_[data-streamdown="table-wrapper"]]:!max-w-full [&_[data-streamdown="table-wrapper"]]:overflow-x-auto',
-                    '[&_table]:w-max [&_table]:min-w-full',
-                  )}
-                >
-                  {part.text}
-                </MessageResponse>
-              )
-
-            case 'reasoning':
-              return (
-                <Reasoning key={key} className="w-full" defaultOpen={false}>
-                  <ReasoningTrigger />
-                  <ReasoningContent>{part.text}</ReasoningContent>
-                </Reasoning>
-              )
-
-            case 'tool-call':
-              return (
-                <div
-                  key={key}
-                  className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
-                >
-                  {part.status === 'running' || part.status === 'pending' ? (
-                    <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
-                  ) : null}
-                  {part.status === 'completed' ? (
-                    <CheckCircle2 className="size-3.5 text-green-500" />
-                  ) : null}
-                  {part.status === 'failed' ? (
-                    <XCircle className="size-3.5 text-destructive" />
-                  ) : null}
-                  <span className="font-mono text-xs">{part.name}</span>
-                  {part.error ? (
-                    <span className="ml-auto text-destructive text-xs">
-                      {part.error}
-                    </span>
-                  ) : null}
-                </div>
-              )
-
-            case 'meta':
-              return (
-                <div key={key} className="text-muted-foreground text-xs">
-                  {part.label}: {part.value}
-                </div>
-              )
-
-            default:
-              return null
+          if (entry.kind === 'text' && entry.part?.type === 'text') {
+            return (
+              <MessageResponse
+                key={key}
+                className={cn(
+                  'max-w-full overflow-hidden break-words',
+                  '[&_[data-streamdown="code-block"]]:!w-full [&_[data-streamdown="code-block"]]:!max-w-full [&_[data-streamdown="code-block"]]:overflow-x-auto',
+                  '[&_[data-streamdown="table-wrapper"]]:!w-full [&_[data-streamdown="table-wrapper"]]:!max-w-full [&_[data-streamdown="table-wrapper"]]:overflow-x-auto',
+                  '[&_table]:w-max [&_table]:min-w-full',
+                )}
+              >
+                {entry.part.text}
+              </MessageResponse>
+            )
           }
+
+          if (entry.kind === 'reasoning' && entry.part?.type === 'reasoning') {
+            return (
+              <Reasoning key={key} className="w-full" defaultOpen={false}>
+                <ReasoningTrigger />
+                <ReasoningContent>{entry.part.text}</ReasoningContent>
+              </Reasoning>
+            )
+          }
+
+          if (entry.kind === 'meta' && entry.part?.type === 'meta') {
+            return (
+              <div key={key} className="text-muted-foreground text-xs">
+                {entry.part.label}: {entry.part.value}
+              </div>
+            )
+          }
+
+          if (entry.kind === 'task' && entry.tools) {
+            const tools = entry.tools
+            const errorCount = tools.filter((t) => t.status === 'failed').length
+            const taskTitle = `Agent activity (${tools.length} ${tools.length === 1 ? 'action' : 'actions'}${errorCount > 0 ? `, ${errorCount} failed` : ''})`
+
+            return (
+              <Task key={key} defaultOpen={false}>
+                <TaskTrigger title={taskTitle} TriggerIcon={Wrench} />
+                <TaskContent>
+                  {tools.map((tool, idx) => (
+                    <TaskItem
+                      // biome-ignore lint/suspicious/noArrayIndexKey: tool order is stable within a finalized historical message
+                      key={`${tool.name}-${tool.status}-${idx}`}
+                      className="flex items-center gap-2"
+                    >
+                      <ToolStatusIcon status={tool.status} />
+                      <span className="font-mono text-xs">{tool.name}</span>
+                      {tool.error ? (
+                        <span className="ml-auto truncate text-destructive text-xs">
+                          {tool.error}
+                        </span>
+                      ) : null}
+                    </TaskItem>
+                  ))}
+                </TaskContent>
+              </Task>
+            )
+          }
+
+          return null
         })}
 
         {message.role === 'assistant' && messageText ? (

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ClawChatMessage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ClawChatMessage.tsx
@@ -1,9 +1,12 @@
-import { CheckCircle2, Loader2, XCircle } from 'lucide-react'
-import type { FC } from 'react'
+import { CheckCircle2, Copy, Loader2, XCircle } from 'lucide-react'
+import { type FC, useCallback } from 'react'
 import {
   Message,
+  MessageAction,
+  MessageActions,
   MessageContent,
   MessageResponse,
+  MessageToolbar,
 } from '@/components/ai-elements/message'
 import {
   Reasoning,
@@ -13,78 +16,126 @@ import {
 import { cn } from '@/lib/utils'
 import type { ClawChatMessage as ClawChatMessageType } from './claw-chat-types'
 
+function formatTokenCount(tokens: number): string {
+  if (tokens < 1000) return String(tokens)
+  return `${(tokens / 1000).toFixed(1)}K`
+}
+
+function formatCost(usd: number): string {
+  if (usd < 0.005) return `$${usd.toFixed(4)}`
+  return `$${usd.toFixed(2)}`
+}
+
 interface ClawChatMessageProps {
   message: ClawChatMessageType
 }
 
-export const ClawChatMessage: FC<ClawChatMessageProps> = ({ message }) => (
-  <Message
-    from={message.role}
-    className="max-w-full group-[.is-user]:max-w-[80%]"
-  >
-    <MessageContent className="max-w-full overflow-hidden group-[.is-assistant]:w-full group-[.is-user]:max-w-full">
-      {message.parts.map((part, index) => {
-        const key = `${message.id}-part-${index}`
+export const ClawChatMessage: FC<ClawChatMessageProps> = ({ message }) => {
+  const messageText = message.parts
+    .filter((p) => p.type === 'text')
+    .map((p) => p.text)
+    .join('\n')
 
-        switch (part.type) {
-          case 'text':
-            return (
-              <MessageResponse
-                key={key}
-                className={cn(
-                  'max-w-full overflow-hidden break-words',
-                  '[&_[data-streamdown="code-block"]]:!w-full [&_[data-streamdown="code-block"]]:!max-w-full [&_[data-streamdown="code-block"]]:overflow-x-auto',
-                  '[&_[data-streamdown="table-wrapper"]]:!w-full [&_[data-streamdown="table-wrapper"]]:!max-w-full [&_[data-streamdown="table-wrapper"]]:overflow-x-auto',
-                  '[&_table]:w-max [&_table]:min-w-full',
-                )}
-              >
-                {part.text}
-              </MessageResponse>
-            )
+  const handleCopy = useCallback(() => {
+    if (messageText) navigator.clipboard.writeText(messageText)
+  }, [messageText])
 
-          case 'reasoning':
-            return (
-              <Reasoning key={key} className="w-full" defaultOpen={false}>
-                <ReasoningTrigger />
-                <ReasoningContent>{part.text}</ReasoningContent>
-              </Reasoning>
-            )
+  const hasCostData =
+    message.role === 'assistant' &&
+    (message.costUsd || message.tokensIn || message.tokensOut)
 
-          case 'tool-call':
-            return (
-              <div
-                key={key}
-                className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
-              >
-                {part.status === 'running' || part.status === 'pending' ? (
-                  <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
-                ) : null}
-                {part.status === 'completed' ? (
-                  <CheckCircle2 className="size-3.5 text-green-500" />
-                ) : null}
-                {part.status === 'failed' ? (
-                  <XCircle className="size-3.5 text-destructive" />
-                ) : null}
-                <span className="font-mono text-xs">{part.name}</span>
-                {part.error ? (
-                  <span className="ml-auto text-destructive text-xs">
-                    {part.error}
+  return (
+    <Message
+      from={message.role}
+      className="max-w-full group-[.is-user]:max-w-[80%]"
+    >
+      <MessageContent className="max-w-full overflow-hidden group-[.is-assistant]:w-full group-[.is-user]:max-w-full">
+        {message.parts.map((part, index) => {
+          const key = `${message.id}-part-${index}`
+
+          switch (part.type) {
+            case 'text':
+              return (
+                <MessageResponse
+                  key={key}
+                  className={cn(
+                    'max-w-full overflow-hidden break-words',
+                    '[&_[data-streamdown="code-block"]]:!w-full [&_[data-streamdown="code-block"]]:!max-w-full [&_[data-streamdown="code-block"]]:overflow-x-auto',
+                    '[&_[data-streamdown="table-wrapper"]]:!w-full [&_[data-streamdown="table-wrapper"]]:!max-w-full [&_[data-streamdown="table-wrapper"]]:overflow-x-auto',
+                    '[&_table]:w-max [&_table]:min-w-full',
+                  )}
+                >
+                  {part.text}
+                </MessageResponse>
+              )
+
+            case 'reasoning':
+              return (
+                <Reasoning key={key} className="w-full" defaultOpen={false}>
+                  <ReasoningTrigger />
+                  <ReasoningContent>{part.text}</ReasoningContent>
+                </Reasoning>
+              )
+
+            case 'tool-call':
+              return (
+                <div
+                  key={key}
+                  className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
+                >
+                  {part.status === 'running' || part.status === 'pending' ? (
+                    <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
+                  ) : null}
+                  {part.status === 'completed' ? (
+                    <CheckCircle2 className="size-3.5 text-green-500" />
+                  ) : null}
+                  {part.status === 'failed' ? (
+                    <XCircle className="size-3.5 text-destructive" />
+                  ) : null}
+                  <span className="font-mono text-xs">{part.name}</span>
+                  {part.error ? (
+                    <span className="ml-auto text-destructive text-xs">
+                      {part.error}
+                    </span>
+                  ) : null}
+                </div>
+              )
+
+            case 'meta':
+              return (
+                <div key={key} className="text-muted-foreground text-xs">
+                  {part.label}: {part.value}
+                </div>
+              )
+
+            default:
+              return null
+          }
+        })}
+
+        {messageText ? (
+          <MessageToolbar className="opacity-0 transition-opacity group-hover:opacity-100">
+            <MessageActions>
+              <MessageAction tooltip="Copy" onClick={handleCopy}>
+                <Copy className="size-3.5" />
+              </MessageAction>
+            </MessageActions>
+            {hasCostData ? (
+              <div className="flex items-center gap-1.5 text-[11px] text-muted-foreground/50 tabular-nums">
+                {message.tokensIn != null && message.tokensOut != null ? (
+                  <span>
+                    {formatTokenCount(message.tokensIn)} →{' '}
+                    {formatTokenCount(message.tokensOut)}
                   </span>
                 ) : null}
+                {message.costUsd ? (
+                  <span>{formatCost(message.costUsd)}</span>
+                ) : null}
               </div>
-            )
-
-          case 'meta':
-            return (
-              <div key={key} className="text-muted-foreground text-xs">
-                {part.label}: {part.value}
-              </div>
-            )
-
-          default:
-            return null
-        }
-      })}
-    </MessageContent>
-  </Message>
-)
+            ) : null}
+          </MessageToolbar>
+        ) : null}
+      </MessageContent>
+    </Message>
+  )
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ClawChatMessage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ClawChatMessage.tsx
@@ -132,7 +132,12 @@ export const ClawChatMessage: FC<ClawChatMessageProps> = ({ message }) => {
 
           if (entry.kind === 'reasoning' && entry.part?.type === 'reasoning') {
             return (
-              <Reasoning key={key} className="w-full" defaultOpen={false}>
+              <Reasoning
+                key={key}
+                className="w-full"
+                defaultOpen={false}
+                duration={entry.part.duration}
+              >
                 <ReasoningTrigger />
                 <ReasoningContent>{entry.part.text}</ReasoningContent>
               </Reasoning>

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ClawChatMessage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ClawChatMessage.tsx
@@ -158,8 +158,13 @@ export const ClawChatMessage: FC<ClawChatMessageProps> = ({ message }) => {
                       <ToolStatusIcon status={tool.status} />
                       <span className="font-mono text-xs">{tool.name}</span>
                       {tool.error ? (
-                        <span className="ml-auto truncate text-destructive text-xs">
+                        <span className="ml-2 truncate text-destructive text-xs">
                           {tool.error}
+                        </span>
+                      ) : null}
+                      {tool.durationMs != null ? (
+                        <span className="ml-auto text-muted-foreground/60 text-xs tabular-nums">
+                          {(tool.durationMs / 1000).toFixed(1)}s
                         </span>
                       ) : null}
                     </TaskItem>

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationMessage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationMessage.tsx
@@ -1,5 +1,5 @@
-import { Bot, CheckCircle2, Loader2, XCircle } from 'lucide-react'
-import type { FC } from 'react'
+import { Bot, CheckCircle2, Loader2, Wrench, XCircle } from 'lucide-react'
+import { type FC, useMemo } from 'react'
 import {
   Message,
   MessageContent,
@@ -10,96 +10,167 @@ import {
   ReasoningContent,
   ReasoningTrigger,
 } from '@/components/ai-elements/reasoning'
-import type { AgentConversationTurn } from '@/lib/agent-conversations/types'
+import {
+  Task,
+  TaskContent,
+  TaskItem,
+  TaskTrigger,
+} from '@/components/ai-elements/task'
+import type {
+  AgentConversationTurn,
+  ToolEntry,
+} from '@/lib/agent-conversations/types'
 
 interface ConversationMessageProps {
   turn: AgentConversationTurn
   streaming: boolean
 }
 
+interface RenderEntry {
+  kind: 'thinking' | 'text' | 'task'
+  partIndex: number
+  text?: string
+  done?: boolean
+  tools?: ToolEntry[]
+}
+
+/**
+ * Build the render plan for an assistant turn:
+ * - thinking and text parts render in place
+ * - all tool-batch parts collapse into a single Task entry at their first
+ *   appearance position, with tools listed in arrival order
+ */
+function buildRenderEntries(turn: AgentConversationTurn): RenderEntry[] {
+  const entries: RenderEntry[] = []
+  const aggregatedTools: ToolEntry[] = []
+  let taskInserted = false
+
+  turn.parts.forEach((part, partIndex) => {
+    if (part.kind === 'thinking') {
+      entries.push({
+        kind: 'thinking',
+        partIndex,
+        text: part.text,
+        done: part.done,
+      })
+    } else if (part.kind === 'text') {
+      entries.push({ kind: 'text', partIndex, text: part.text })
+    } else if (part.kind === 'tool-batch') {
+      aggregatedTools.push(...part.tools)
+      if (!taskInserted) {
+        entries.push({
+          kind: 'task',
+          partIndex,
+          tools: aggregatedTools,
+        })
+        taskInserted = true
+      }
+    }
+  })
+
+  return entries
+}
+
+function ToolStatusIcon({ status }: { status: ToolEntry['status'] }) {
+  if (status === 'running') {
+    return (
+      <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
+    )
+  }
+  if (status === 'completed') {
+    return <CheckCircle2 className="size-3.5 shrink-0 text-green-500" />
+  }
+  return <XCircle className="size-3.5 shrink-0 text-destructive" />
+}
+
 export const ConversationMessage: FC<ConversationMessageProps> = ({
   turn,
   streaming,
-}) => (
-  <div className="space-y-3">
-    <Message from="user">
-      <MessageContent>
-        <pre className="whitespace-pre-wrap font-sans text-sm">
-          {turn.userText}
-        </pre>
-      </MessageContent>
-    </Message>
+}) => {
+  const entries = useMemo(() => buildRenderEntries(turn), [turn])
 
-    {turn.parts.length > 0 && (
-      <Message from="assistant">
+  return (
+    <div className="space-y-3">
+      <Message from="user">
         <MessageContent>
-          {turn.parts.map((part, i) => {
-            const key = `${turn.id}-part-${i}`
+          <pre className="whitespace-pre-wrap font-sans text-sm">
+            {turn.userText}
+          </pre>
+        </MessageContent>
+      </Message>
 
-            switch (part.kind) {
-              case 'thinking':
+      {entries.length > 0 && (
+        <Message from="assistant">
+          <MessageContent>
+            {entries.map((entry) => {
+              const key = `${turn.id}-entry-${entry.partIndex}`
+
+              if (entry.kind === 'thinking') {
                 return (
                   <Reasoning
                     key={key}
                     className="w-full"
-                    isStreaming={!part.done}
-                    defaultOpen={!part.done}
+                    isStreaming={!entry.done}
+                    defaultOpen={!entry.done}
                   >
                     <ReasoningTrigger />
-                    <ReasoningContent>{part.text}</ReasoningContent>
+                    <ReasoningContent>{entry.text ?? ''}</ReasoningContent>
                   </Reasoning>
                 )
+              }
 
-              case 'tool-batch':
+              if (entry.kind === 'text') {
                 return (
-                  <div key={key} className="w-full space-y-1">
-                    {part.tools.map((tool) => (
-                      <div
+                  <MessageResponse key={key}>
+                    {entry.text ?? ''}
+                  </MessageResponse>
+                )
+              }
+
+              const tools = entry.tools ?? []
+              const allDone = tools.every((t) => t.status !== 'running')
+              const taskTitle = allDone
+                ? `Agent activity (${tools.length} ${tools.length === 1 ? 'action' : 'actions'})`
+                : `Working… (${tools.length} ${tools.length === 1 ? 'action' : 'actions'})`
+
+              return (
+                <Task key={key} defaultOpen={!turn.done}>
+                  <TaskTrigger title={taskTitle} TriggerIcon={Wrench} />
+                  <TaskContent>
+                    {tools.map((tool) => (
+                      <TaskItem
                         key={tool.id}
-                        className="flex items-center gap-2 rounded-md border px-3 py-2 text-sm"
+                        className="flex items-center gap-2"
                       >
-                        {tool.status === 'running' && (
-                          <Loader2 className="size-3.5 animate-spin text-muted-foreground" />
-                        )}
-                        {tool.status === 'completed' && (
-                          <CheckCircle2 className="size-3.5 text-green-500" />
-                        )}
-                        {tool.status === 'error' && (
-                          <XCircle className="size-3.5 text-destructive" />
-                        )}
+                        <ToolStatusIcon status={tool.status} />
                         <span className="font-mono text-xs">{tool.name}</span>
                         {tool.durationMs != null && (
-                          <span className="ml-auto text-muted-foreground text-xs">
+                          <span className="ml-auto text-muted-foreground/60 text-xs tabular-nums">
                             {(tool.durationMs / 1000).toFixed(1)}s
                           </span>
                         )}
-                      </div>
+                      </TaskItem>
                     ))}
-                  </div>
-                )
+                  </TaskContent>
+                </Task>
+              )
+            })}
+          </MessageContent>
+        </Message>
+      )}
 
-              case 'text':
-                return <MessageResponse key={key}>{part.text}</MessageResponse>
-
-              default:
-                return null
-            }
-          })}
-        </MessageContent>
-      </Message>
-    )}
-
-    {!turn.done && turn.parts.length === 0 && streaming && (
-      <div className="flex gap-2">
-        <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-[var(--accent-orange)] text-white">
-          <Bot className="size-3.5" />
+      {!turn.done && turn.parts.length === 0 && streaming && (
+        <div className="flex gap-2">
+          <div className="flex size-7 shrink-0 items-center justify-center rounded-full bg-[var(--accent-orange)] text-white">
+            <Bot className="size-3.5" />
+          </div>
+          <div className="flex items-center gap-1 rounded-xl rounded-tl-none border border-border/50 bg-card px-3 py-2.5 shadow-sm">
+            <span className="size-1.5 animate-bounce rounded-full bg-[var(--accent-orange)] [animation-delay:-0.3s]" />
+            <span className="size-1.5 animate-bounce rounded-full bg-[var(--accent-orange)] [animation-delay:-0.15s]" />
+            <span className="size-1.5 animate-bounce rounded-full bg-[var(--accent-orange)]" />
+          </div>
         </div>
-        <div className="flex items-center gap-1 rounded-xl rounded-tl-none border border-border/50 bg-card px-3 py-2.5 shadow-sm">
-          <span className="size-1.5 animate-bounce rounded-full bg-[var(--accent-orange)] [animation-delay:-0.3s]" />
-          <span className="size-1.5 animate-bounce rounded-full bg-[var(--accent-orange)] [animation-delay:-0.15s]" />
-          <span className="size-1.5 animate-bounce rounded-full bg-[var(--accent-orange)]" />
-        </div>
-      </div>
-    )}
-  </div>
-)
+      )}
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationMessage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationMessage.tsx
@@ -143,7 +143,14 @@ export const ConversationMessage: FC<ConversationMessageProps> = ({
                         className="flex items-center gap-2"
                       >
                         <ToolStatusIcon status={tool.status} />
-                        <span className="font-mono text-xs">{tool.name}</span>
+                        <span className="text-foreground text-xs">
+                          {tool.label}
+                        </span>
+                        {tool.subject ? (
+                          <span className="ml-1.5 truncate text-muted-foreground/70 text-xs">
+                            · {tool.subject}
+                          </span>
+                        ) : null}
                         {tool.durationMs != null && (
                           <span className="ml-auto text-muted-foreground/60 text-xs tabular-nums">
                             {(tool.durationMs / 1000).toFixed(1)}s

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/claw-chat-types.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/claw-chat-types.ts
@@ -32,6 +32,9 @@ export interface BrowserOSChatHistoryItem {
   messageSeq: number
   sessionKey: string
   source: ClawChatSource
+  costUsd?: number
+  tokensIn?: number
+  tokensOut?: number
 }
 
 export interface AgentHistoryPageResponse {
@@ -74,6 +77,9 @@ export interface ClawChatMessage {
   messageSeq?: number
   status?: ClawChatMessageStatus
   parts: ClawChatMessagePart[]
+  costUsd?: number
+  tokensIn?: number
+  tokensOut?: number
 }
 
 export function mapHistoryItemToClawMessage(
@@ -88,6 +94,9 @@ export function mapHistoryItemToClawMessage(
     messageSeq: item.messageSeq,
     status: 'historical',
     parts: [{ type: 'text', text: item.text }],
+    costUsd: item.costUsd,
+    tokensIn: item.tokensIn,
+    tokensOut: item.tokensOut,
   }
 }
 

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/claw-chat-types.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/claw-chat-types.ts
@@ -27,6 +27,8 @@ export interface AgentSessionResponse {
 export interface BrowserOSChatHistoryToolCall {
   toolCallId?: string
   toolName: string
+  label: string
+  subject?: string
   status: 'completed' | 'failed'
   input?: Record<string, unknown>
   output?: string
@@ -72,6 +74,8 @@ export type ClawChatMessagePart =
   | {
       type: 'tool-call'
       name: string
+      label: string
+      subject?: string
       status: 'pending' | 'running' | 'completed' | 'failed'
       input?: unknown
       output?: unknown
@@ -106,6 +110,8 @@ export function mapHistoryItemToClawMessage(
       parts.push({
         type: 'tool-call',
         name: tc.toolName,
+        label: tc.label,
+        subject: tc.subject,
         status: tc.status,
         input: tc.input,
         output: tc.output,

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/claw-chat-types.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/claw-chat-types.ts
@@ -112,13 +112,17 @@ export function mapHistoryItemToClawMessage(
   // Reasoning, then tool calls, then text — the chronological order the
   // agent produced them (think → act → answer).
   if (item.reasoning && item.reasoning.text.trim().length > 0) {
+    // 0ms means thinking and the final answer were emitted in the same JSONL
+    // line (no tool calls between them) — there's no real elapsed wall-clock,
+    // so fall through to the "Thinking" trigger instead of "Thought for 0
+    // seconds" / streaming shimmer. Real multi-line turns floor at 1s.
+    const durationMs = item.reasoning.durationMs ?? 0
+    const duration =
+      durationMs > 0 ? Math.max(1, Math.round(durationMs / 1000)) : undefined
     parts.push({
       type: 'reasoning',
       text: item.reasoning.text,
-      duration:
-        item.reasoning.durationMs != null
-          ? Math.round(item.reasoning.durationMs / 1000)
-          : undefined,
+      duration,
     })
   }
 

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/claw-chat-types.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/claw-chat-types.ts
@@ -36,6 +36,11 @@ export interface BrowserOSChatHistoryToolCall {
   durationMs?: number
 }
 
+export interface BrowserOSChatHistoryReasoning {
+  text: string
+  durationMs?: number
+}
+
 export interface BrowserOSChatHistoryItem {
   id: string
   role: ClawChatRole
@@ -48,6 +53,7 @@ export interface BrowserOSChatHistoryItem {
   tokensIn?: number
   tokensOut?: number
   toolCalls?: BrowserOSChatHistoryToolCall[]
+  reasoning?: BrowserOSChatHistoryReasoning
 }
 
 export interface AgentHistoryPageResponse {
@@ -103,8 +109,19 @@ export function mapHistoryItemToClawMessage(
 ): ClawChatMessage {
   const parts: ClawChatMessagePart[] = []
 
-  // Tool calls render BEFORE the text response — that's the order the
-  // agent produced them (call tools, then write the final answer).
+  // Reasoning, then tool calls, then text — the chronological order the
+  // agent produced them (think → act → answer).
+  if (item.reasoning && item.reasoning.text.trim().length > 0) {
+    parts.push({
+      type: 'reasoning',
+      text: item.reasoning.text,
+      duration:
+        item.reasoning.durationMs != null
+          ? Math.round(item.reasoning.durationMs / 1000)
+          : undefined,
+    })
+  }
+
   if (item.toolCalls && item.toolCalls.length > 0) {
     for (const tc of item.toolCalls) {
       parts.push({

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/claw-chat-types.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/claw-chat-types.ts
@@ -17,13 +17,6 @@ export interface BrowserOSOpenClawSession {
   modelProvider?: string
 }
 
-export interface AgentSessionResponse {
-  agentId: string
-  exists: boolean
-  sessionKey: string | null
-  session: BrowserOSOpenClawSession | null
-}
-
 export interface BrowserOSChatHistoryToolCall {
   toolCallId?: string
   toolName: string

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/claw-chat-types.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/claw-chat-types.ts
@@ -24,6 +24,16 @@ export interface AgentSessionResponse {
   session: BrowserOSOpenClawSession | null
 }
 
+export interface BrowserOSChatHistoryToolCall {
+  toolCallId?: string
+  toolName: string
+  status: 'completed' | 'failed'
+  input?: Record<string, unknown>
+  output?: string
+  error?: string
+  durationMs?: number
+}
+
 export interface BrowserOSChatHistoryItem {
   id: string
   role: ClawChatRole
@@ -35,6 +45,7 @@ export interface BrowserOSChatHistoryItem {
   costUsd?: number
   tokensIn?: number
   tokensOut?: number
+  toolCalls?: BrowserOSChatHistoryToolCall[]
 }
 
 export interface AgentHistoryPageResponse {
@@ -65,6 +76,7 @@ export type ClawChatMessagePart =
       input?: unknown
       output?: unknown
       error?: string
+      durationMs?: number
     }
   | { type: 'meta'; label: string; value: string }
 
@@ -85,6 +97,26 @@ export interface ClawChatMessage {
 export function mapHistoryItemToClawMessage(
   item: BrowserOSChatHistoryItem,
 ): ClawChatMessage {
+  const parts: ClawChatMessagePart[] = []
+
+  // Tool calls render BEFORE the text response — that's the order the
+  // agent produced them (call tools, then write the final answer).
+  if (item.toolCalls && item.toolCalls.length > 0) {
+    for (const tc of item.toolCalls) {
+      parts.push({
+        type: 'tool-call',
+        name: tc.toolName,
+        status: tc.status,
+        input: tc.input,
+        output: tc.output,
+        error: tc.error,
+        durationMs: tc.durationMs,
+      })
+    }
+  }
+
+  parts.push({ type: 'text', text: item.text })
+
   return {
     id: item.id,
     role: item.role,
@@ -93,7 +125,7 @@ export function mapHistoryItemToClawMessage(
     source: item.source,
     messageSeq: item.messageSeq,
     status: 'historical',
-    parts: [{ type: 'text', text: item.text }],
+    parts,
     costUsd: item.costUsd,
     tokensIn: item.tokensIn,
     tokensOut: item.tokensOut,

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useAgentConversation.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useAgentConversation.ts
@@ -9,6 +9,7 @@ import type {
   AssistantPart,
 } from '@/lib/agent-conversations/types'
 import { consumeSSEStream } from '@/lib/sse'
+import { buildToolLabel } from '@/lib/tool-labels'
 
 interface UseAgentConversationOptions {
   sessionKey?: string | null
@@ -92,9 +93,14 @@ export function useAgentConversation(
       }
 
       case 'tool-start': {
+        const rawName = (event.data.toolName as string) ?? 'unknown'
+        const args = event.data.args as Record<string, unknown> | undefined
+        const { label, subject } = buildToolLabel(rawName, args)
         const tool = {
           id: (event.data.toolCallId as string) ?? crypto.randomUUID(),
-          name: (event.data.toolName as string) ?? 'unknown',
+          name: rawName,
+          label,
+          subject,
           status: 'running' as const,
         }
         updateCurrentTurnParts((parts) => {

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useClawChatHistory.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useClawChatHistory.ts
@@ -1,14 +1,8 @@
-import { useInfiniteQuery, useQuery } from '@tanstack/react-query'
+import { useInfiniteQuery } from '@tanstack/react-query'
 import { useAgentServerUrl } from '@/lib/browseros/useBrowserOSProviders'
-import type {
-  AgentHistoryPageResponse,
-  AgentSessionResponse,
-} from './claw-chat-types'
+import type { AgentHistoryPageResponse } from './claw-chat-types'
 
-export const CLAW_CHAT_QUERY_KEYS = {
-  session: 'claw-agent-session',
-  history: 'claw-agent-history',
-} as const
+const HISTORY_QUERY_KEY = 'claw-agent-history'
 
 async function fetchClawJson<T>(url: string): Promise<T> {
   const response = await fetch(url)
@@ -27,29 +21,6 @@ async function fetchClawJson<T>(url: string): Promise<T> {
 
 function buildClawUrl(baseUrl: string, path: string): URL {
   return new URL(`/claw${path}`, baseUrl)
-}
-
-export function useClawAgentSession(agentId: string) {
-  const {
-    baseUrl,
-    isLoading: urlLoading,
-    error: urlError,
-  } = useAgentServerUrl()
-
-  const query = useQuery<AgentSessionResponse, Error>({
-    queryKey: [CLAW_CHAT_QUERY_KEYS.session, baseUrl, agentId],
-    queryFn: () => {
-      const url = buildClawUrl(baseUrl as string, `/agents/${agentId}/session`)
-      return fetchClawJson<AgentSessionResponse>(url.toString())
-    },
-    enabled: Boolean(baseUrl) && !urlLoading && Boolean(agentId),
-  })
-
-  return {
-    ...query,
-    error: query.error ?? urlError,
-    isLoading: query.isLoading || urlLoading,
-  }
 }
 
 export function useClawChatHistory({
@@ -72,7 +43,7 @@ export function useClawChatHistory({
   } = useAgentServerUrl()
 
   const query = useInfiniteQuery<AgentHistoryPageResponse, Error>({
-    queryKey: [CLAW_CHAT_QUERY_KEYS.history, baseUrl, agentId, sessionKey],
+    queryKey: [HISTORY_QUERY_KEY, baseUrl, agentId, sessionKey],
     initialPageParam: undefined as string | undefined,
     queryFn: async ({ pageParam }) => {
       const url = buildClawUrl(baseUrl as string, `/agents/${agentId}/history`)

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useClawChatHistory.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useClawChatHistory.ts
@@ -55,12 +55,14 @@ export function useClawAgentSession(agentId: string) {
 export function useClawChatHistory({
   agentId,
   sessionKey,
-  enabled,
+  enabled = true,
   limit = 50,
 }: {
   agentId: string
+  // null lets the server resolve the most recent user-chat session for the
+  // agent — avoids an extra /session round-trip and the race that came with it.
   sessionKey: string | null
-  enabled: boolean
+  enabled?: boolean
   limit?: number
 }) {
   const {
@@ -72,7 +74,7 @@ export function useClawChatHistory({
   const query = useInfiniteQuery<AgentHistoryPageResponse, Error>({
     queryKey: [CLAW_CHAT_QUERY_KEYS.history, baseUrl, agentId, sessionKey],
     initialPageParam: undefined as string | undefined,
-    queryFn: ({ pageParam }) => {
+    queryFn: async ({ pageParam }) => {
       const url = buildClawUrl(baseUrl as string, `/agents/${agentId}/history`)
       url.searchParams.set('limit', String(limit))
 
@@ -87,12 +89,7 @@ export function useClawChatHistory({
     },
     getNextPageParam: (lastPage) =>
       lastPage.page.hasMore ? lastPage.page.cursor : undefined,
-    enabled:
-      enabled &&
-      Boolean(baseUrl) &&
-      !urlLoading &&
-      Boolean(agentId) &&
-      Boolean(sessionKey),
+    enabled: enabled && Boolean(baseUrl) && !urlLoading && Boolean(agentId),
   })
 
   return {

--- a/packages/browseros-agent/apps/agent/lib/agent-conversations/types.ts
+++ b/packages/browseros-agent/apps/agent/lib/agent-conversations/types.ts
@@ -12,6 +12,8 @@ export interface AssistantThinkingPart {
 export interface ToolEntry {
   id: string
   name: string
+  label: string
+  subject?: string
   status: 'running' | 'completed' | 'error'
   durationMs?: number
 }

--- a/packages/browseros-agent/apps/agent/lib/tool-labels.ts
+++ b/packages/browseros-agent/apps/agent/lib/tool-labels.ts
@@ -230,18 +230,11 @@ const SUBJECT_EXTRACTORS: Record<string, SubjectExtractor> = {
     return typeof page === 'number' ? `tab ${page}` : asString(page)
   },
 
-  // Page reads — show which page, if specified
-  take_snapshot: (i) =>
-    typeof i.page === 'number' ? `tab ${i.page}` : undefined,
-  take_enhanced_snapshot: (i) =>
-    typeof i.page === 'number' ? `tab ${i.page}` : undefined,
-  get_page_content: (i) =>
-    typeof i.page === 'number' ? `tab ${i.page}` : undefined,
-  get_page_links: (i) =>
-    typeof i.page === 'number' ? `tab ${i.page}` : undefined,
-  get_dom: (i) => (typeof i.page === 'number' ? `tab ${i.page}` : undefined),
-  take_screenshot: (i) =>
-    typeof i.page === 'number' ? `tab ${i.page}` : undefined,
+  // Page reads (take_snapshot, take_enhanced_snapshot, get_page_content,
+  // get_page_links, get_dom, take_screenshot) intentionally omit a
+  // subject — the only argument is a numeric page ID that's internal
+  // to the agent and meaningless to the user ("tab 4" tells them nothing).
+  // The verb alone communicates what happened.
 
   // External actions via Strata
   execute_action: (i) => {

--- a/packages/browseros-agent/apps/agent/lib/tool-labels.ts
+++ b/packages/browseros-agent/apps/agent/lib/tool-labels.ts
@@ -1,0 +1,332 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Maps raw tool names + arguments to human-readable activity labels for
+ * the chat UI activity view. The MCP ToolRegistry is the source of truth
+ * for tool *existence*; this file is the editorial layer that turns
+ * snake_case identifiers into agent-speak verbs.
+ */
+
+const VERB_OVERRIDES: Record<string, string> = {
+  // Navigation
+  navigate_page: 'Navigated to',
+  new_page: 'Opened tab',
+  new_hidden_page: 'Opened tab',
+  show_page: 'Showed tab',
+  close_page: 'Closed tab',
+  list_pages: 'Listed open tabs',
+  get_active_page: 'Got active tab',
+  move_page: 'Moved tab',
+  group_tabs: 'Grouped tabs',
+
+  // Page reading
+  take_snapshot: 'Captured page snapshot',
+  take_enhanced_snapshot: 'Captured detailed snapshot',
+  get_page_content: 'Read page content',
+  get_page_links: 'Extracted page links',
+  get_dom: 'Read page DOM',
+  search_dom: 'Searched page DOM',
+  take_screenshot: 'Took screenshot',
+
+  // Input
+  click: 'Clicked',
+  click_at: 'Clicked at coordinates',
+  hover: 'Hovered',
+  hover_at: 'Hovered at coordinates',
+  type_at: 'Typed at coordinates',
+  drag_at: 'Dragged',
+  focus: 'Focused element',
+  fill: 'Filled field',
+  clear: 'Cleared field',
+  check: 'Checked box',
+  uncheck: 'Unchecked box',
+  press_key: 'Pressed key',
+  upload_file: 'Uploaded file',
+
+  // Console / scripts
+  evaluate_script: 'Ran script',
+  get_console_logs: 'Read console logs',
+
+  // History / bookmarks
+  search_history: 'Searched history',
+  get_recent_history: 'Read recent history',
+  delete_history_url: 'Deleted history entry',
+  delete_history_range: 'Deleted history range',
+  get_bookmarks: 'Listed bookmarks',
+  create_bookmark: 'Created bookmark',
+  remove_bookmark: 'Removed bookmark',
+  update_bookmark: 'Updated bookmark',
+  move_bookmark: 'Moved bookmark',
+  search_bookmarks: 'Searched bookmarks',
+
+  // Filesystem (sandboxed)
+  read_file: 'Read file',
+  write_file: 'Wrote file',
+  find_files: 'Searched files',
+
+  // Memory
+  read_soul: 'Read soul memory',
+  read_core: 'Read core memory',
+  write_memory: 'Wrote memory',
+  search_memory: 'Searched memory',
+  update_soul: 'Updated soul memory',
+  update_core: 'Updated core memory',
+
+  // Web
+  web_search: 'Searched the web',
+  web_fetch: 'Fetched URL',
+
+  // Klavis / external apps (Strata)
+  connector_mcp_servers: 'Listed connected apps',
+  discover_server_categories_or_actions: 'Browsed available actions',
+  get_category_actions: 'Listed actions',
+  get_action_details: 'Looked up action',
+  execute_action: 'Ran external action',
+  search_documentation: 'Searched docs',
+  handle_auth_failure: 'Handled auth issue',
+
+  // Suggestions
+  suggest_schedule: 'Suggested schedule',
+  suggest_app_connection: 'Suggested app connect',
+
+  // BrowserOS info
+  browseros_info: 'Read BrowserOS info',
+
+  // Windows
+  list_windows: 'Listed windows',
+  focus_window: 'Focused window',
+  close_window: 'Closed window',
+  create_window: 'Created window',
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function stringField(
+  input: Record<string, unknown>,
+  ...keys: string[]
+): string | undefined {
+  for (const k of keys) {
+    const v = asString(input[k])
+    if (v) return v
+  }
+  return undefined
+}
+
+function truncate(text: string | undefined, max: number): string | undefined {
+  if (!text) return undefined
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text
+}
+
+function quote(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  return `"${truncate(value, 60)}"`
+}
+
+function basename(path: string | undefined): string | undefined {
+  if (!path) return undefined
+  const parts = path.split(/[/\\]/).filter(Boolean)
+  return parts[parts.length - 1] ?? path
+}
+
+function formatUrl(value: unknown): string | undefined {
+  const url = asString(value)
+  if (!url) return undefined
+  try {
+    const parsed = new URL(url)
+    const host = parsed.host
+    const path = parsed.pathname === '/' ? '' : parsed.pathname
+    const display = path && path.length > 0 ? `${host}${path}` : host
+    return truncate(display, 60)
+  } catch {
+    return truncate(url, 60)
+  }
+}
+
+function coords(x: unknown, y: unknown): string | undefined {
+  if (typeof x === 'number' && typeof y === 'number') {
+    return `${Math.round(x)}, ${Math.round(y)}`
+  }
+  return undefined
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Subject extractors
+// ──────────────────────────────────────────────────────────────────────
+
+type SubjectExtractor = (input: Record<string, unknown>) => string | undefined
+
+const SUBJECT_EXTRACTORS: Record<string, SubjectExtractor> = {
+  // URL-bearing tools
+  new_page: (i) => formatUrl(i.url),
+  new_hidden_page: (i) => formatUrl(i.url),
+  navigate_page: (i) => {
+    const action = asString(i.action)
+    if (action === 'back') return 'back'
+    if (action === 'forward') return 'forward'
+    if (action === 'reload') return 'reload'
+    return formatUrl(i.url)
+  },
+  web_fetch: (i) => formatUrl(i.url),
+
+  // Search queries
+  web_search: (i) => quote(stringField(i, 'query', 'q')),
+  search_history: (i) => quote(stringField(i, 'query', 'text')),
+  search_bookmarks: (i) => quote(stringField(i, 'query', 'text')),
+  search_memory: (i) => quote(stringField(i, 'query', 'q')),
+  search_dom: (i) => quote(stringField(i, 'query', 'selector')),
+  search_documentation: (i) => quote(stringField(i, 'query', 'q')),
+  find_files: (i) => quote(stringField(i, 'pattern', 'query')),
+
+  // Element interactions
+  click: (i) => stringField(i, 'element'),
+  hover: (i) => stringField(i, 'element'),
+  focus: (i) => stringField(i, 'element'),
+  clear: (i) => stringField(i, 'element'),
+  check: (i) => stringField(i, 'element'),
+  uncheck: (i) => stringField(i, 'element'),
+  fill: (i) => {
+    const target = stringField(i, 'element')
+    const text = stringField(i, 'text')
+    if (target && text) return `${target}: ${truncate(text, 40)}`
+    return target ?? truncate(text, 40)
+  },
+  press_key: (i) => stringField(i, 'key'),
+
+  // Coordinate-based input
+  click_at: (i) => coords(i.x, i.y),
+  hover_at: (i) => coords(i.x, i.y),
+  type_at: (i) => {
+    const at = coords(i.x, i.y)
+    const text = stringField(i, 'text')
+    if (at && text) return `${at}: ${truncate(text, 40)}`
+    return at ?? truncate(text, 40)
+  },
+  drag_at: (i) => {
+    const from = coords(i.fromX, i.fromY)
+    const to = coords(i.toX, i.toY)
+    if (from && to) return `${from} → ${to}`
+    return from ?? to
+  },
+
+  // Tab management
+  show_page: (i) => {
+    const page = i.page
+    return typeof page === 'number' ? `tab ${page}` : asString(page)
+  },
+  close_page: (i) => {
+    const page = i.page
+    return typeof page === 'number' ? `tab ${page}` : asString(page)
+  },
+  move_page: (i) => {
+    const page = i.page
+    return typeof page === 'number' ? `tab ${page}` : asString(page)
+  },
+
+  // Page reads — show which page, if specified
+  take_snapshot: (i) =>
+    typeof i.page === 'number' ? `tab ${i.page}` : undefined,
+  take_enhanced_snapshot: (i) =>
+    typeof i.page === 'number' ? `tab ${i.page}` : undefined,
+  get_page_content: (i) =>
+    typeof i.page === 'number' ? `tab ${i.page}` : undefined,
+  get_page_links: (i) =>
+    typeof i.page === 'number' ? `tab ${i.page}` : undefined,
+  get_dom: (i) => (typeof i.page === 'number' ? `tab ${i.page}` : undefined),
+  take_screenshot: (i) =>
+    typeof i.page === 'number' ? `tab ${i.page}` : undefined,
+
+  // External actions via Strata
+  execute_action: (i) => {
+    const server = stringField(i, 'server_name')
+    const action = stringField(i, 'action_name')
+    if (server && action) return `${server} · ${action}`
+    return action ?? server
+  },
+  get_category_actions: (i) => stringField(i, 'category_name', 'server_name'),
+  get_action_details: (i) => stringField(i, 'action_name'),
+  discover_server_categories_or_actions: (i) =>
+    stringField(i, 'server_name', 'category_name'),
+  connector_mcp_servers: (i) => stringField(i, 'server_name'),
+
+  // Filesystem
+  read_file: (i) => basename(stringField(i, 'path')),
+  write_file: (i) => basename(stringField(i, 'path')),
+
+  // Memory writes — show first chars of content
+  write_memory: (i) => truncate(stringField(i, 'content', 'text'), 40),
+  update_soul: (i) => truncate(stringField(i, 'content'), 40),
+  update_core: (i) => truncate(stringField(i, 'content'), 40),
+
+  // Bookmarks
+  create_bookmark: (i) => stringField(i, 'title') ?? formatUrl(i.url),
+  remove_bookmark: (i) => stringField(i, 'id', 'title'),
+  update_bookmark: (i) => stringField(i, 'id', 'title'),
+  move_bookmark: (i) => stringField(i, 'id', 'title'),
+
+  // History
+  delete_history_url: (i) => formatUrl(i.url),
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Public API
+// ──────────────────────────────────────────────────────────────────────
+
+export interface ToolLabelResult {
+  label: string
+  subject?: string
+}
+
+/**
+ * Strip MCP namespace prefixes (e.g. "browseros__", "mcp_") to find the
+ * canonical tool name used in the override maps.
+ */
+function canonicalName(rawName: string): string {
+  return rawName.replace(/^browseros__/, '').replace(/^mcp_/, '')
+}
+
+/**
+ * Convert a snake_case tool name into Sentence-case English as a fallback
+ * when no curated override exists.
+ */
+function humanizeToolName(rawName: string): string {
+  const stripped = canonicalName(rawName)
+  const words = stripped.split(/[_-]/).filter((w) => w.length > 0)
+  if (words.length === 0) return rawName
+  const first = words[0]!
+  return [
+    first.charAt(0).toUpperCase() + first.slice(1),
+    ...words.slice(1),
+  ].join(' ')
+}
+
+/**
+ * Build a human-readable label and subject string for a tool call,
+ * suitable for rendering in the chat activity view.
+ */
+export function buildToolLabel(
+  rawName: string,
+  input?: Record<string, unknown>,
+): ToolLabelResult {
+  const canonical = canonicalName(rawName)
+  const label =
+    VERB_OVERRIDES[canonical] ??
+    VERB_OVERRIDES[rawName] ??
+    humanizeToolName(rawName)
+
+  const extractor = Object.hasOwn(SUBJECT_EXTRACTORS, canonical)
+    ? SUBJECT_EXTRACTORS[canonical]
+    : Object.hasOwn(SUBJECT_EXTRACTORS, rawName)
+      ? SUBJECT_EXTRACTORS[rawName]
+      : undefined
+  const subject = extractor && input ? extractor(input) : undefined
+
+  return { label, subject }
+}

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-jsonl-reader.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-jsonl-reader.ts
@@ -14,6 +14,9 @@ import { resolve } from 'node:path'
 interface PiContentBlock {
   type: string
   text?: string
+  // OpenClaw stores reasoning blocks as { type: 'thinking', thinking: '...' }
+  // — the prose lives on a `thinking` field, not `text`.
+  thinking?: string
   id?: string
   name?: string
   arguments?: Record<string, unknown>
@@ -444,18 +447,20 @@ function mapAssistantMessage(
     let thinkingIdx = 0
     let toolIdx = 0
     for (const block of msg.content) {
-      if (
-        block.type === 'thinking' &&
-        typeof block.text === 'string' &&
-        block.text.length > 0
-      ) {
-        events.push({
-          eventId: `${eventId}:thinking:${thinkingIdx}`,
-          type: 'agent.thinking',
-          content: block.text,
-          createdAt,
-        })
-        thinkingIdx++
+      if (block.type === 'thinking') {
+        const thinkingText =
+          (typeof block.thinking === 'string' && block.thinking) ||
+          (typeof block.text === 'string' && block.text) ||
+          ''
+        if (thinkingText.length > 0) {
+          events.push({
+            eventId: `${eventId}:thinking:${thinkingIdx}`,
+            type: 'agent.thinking',
+            content: thinkingText,
+            createdAt,
+          })
+          thinkingIdx++
+        }
       }
       if (block.type === 'toolCall' && block.name) {
         events.push({

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -180,6 +180,11 @@ export interface BrowserOSChatHistoryToolCall {
   durationMs?: number
 }
 
+export interface BrowserOSChatHistoryReasoning {
+  text: string
+  durationMs?: number
+}
+
 export interface BrowserOSChatHistoryItem {
   id: string
   role: 'user' | 'assistant'
@@ -192,6 +197,7 @@ export interface BrowserOSChatHistoryItem {
   tokensIn?: number
   tokensOut?: number
   toolCalls?: BrowserOSChatHistoryToolCall[]
+  reasoning?: BrowserOSChatHistoryReasoning
 }
 
 export interface BrowserOSOpenClawHistoryPageResponse {
@@ -281,7 +287,23 @@ function jsonlEventsToHistoryItems(
   let pendingToolCalls: BrowserOSChatHistoryToolCall[] = []
   const pendingToolStarts = new Map<string, ClawEvent>()
 
+  // Accumulate thinking blocks across the turn — there can be multiple
+  // (e.g., think → tool → think → tool → answer). We collapse them into
+  // a single Reasoning block per assistant message so the UI shows one
+  // collapsible per turn, with duration = first thinking → final answer.
+  let pendingReasoningTexts: string[] = []
+  let pendingReasoningFirstAt: number | null = null
+
   for (const event of events) {
+    if (event.type === 'agent.thinking') {
+      const text = event.content.trim()
+      if (text) pendingReasoningTexts.push(text)
+      if (pendingReasoningFirstAt == null) {
+        pendingReasoningFirstAt = event.createdAt
+      }
+      continue
+    }
+
     if (event.type === 'agent.tool_use') {
       if (event.toolCallId) {
         pendingToolStarts.set(event.toolCallId, event)
@@ -385,11 +407,31 @@ function jsonlEventsToHistoryItems(
         pendingToolCalls = []
         pendingToolStarts.clear()
       }
+
+      // Attach accumulated thinking. Duration is from the first thinking
+      // event to the final answer — the wall-clock time the user waited
+      // through the model's reasoning loop.
+      if (pendingReasoningTexts.length > 0) {
+        const reasoning: BrowserOSChatHistoryReasoning = {
+          text: pendingReasoningTexts.join('\n\n'),
+        }
+        if (pendingReasoningFirstAt != null) {
+          reasoning.durationMs = Math.max(
+            0,
+            event.createdAt - pendingReasoningFirstAt,
+          )
+        }
+        item.reasoning = reasoning
+        pendingReasoningTexts = []
+        pendingReasoningFirstAt = null
+      }
     } else if (event.type === 'user.message') {
-      // User messages reset the tool-call buffer — anything pending was
+      // User messages reset all per-turn buffers — anything pending was
       // part of an earlier turn that had no final assistant message.
       pendingToolCalls = []
       pendingToolStarts.clear()
+      pendingReasoningTexts = []
+      pendingReasoningFirstAt = null
     }
 
     items.push(item)

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -18,6 +18,7 @@ import { DEFAULT_PORTS } from '@browseros/shared/constants/ports'
 import { getOpenClawDir } from '../../../lib/browseros-dir'
 import { logger } from '../../../lib/logger'
 import type { MonitoringChatTurn } from '../../../monitoring/types'
+import { buildToolLabel } from '../../../tools/tool-label-registry'
 import {
   type AgentLiveStatus,
   type AgentSessionState,
@@ -170,6 +171,8 @@ export interface BrowserOSOpenClawAgentSessionResponse {
 export interface BrowserOSChatHistoryToolCall {
   toolCallId?: string
   toolName: string
+  label: string
+  subject?: string
   status: 'completed' | 'failed'
   input?: Record<string, unknown>
   output?: string
@@ -285,9 +288,13 @@ function jsonlEventsToHistoryItems(
       }
       // Keep order — record the tool call now with status pending; we'll
       // patch the result/error/duration when the matching tool_result arrives.
+      const rawName = event.toolName ?? event.content
+      const { label, subject } = buildToolLabel(rawName, event.toolArguments)
       pendingToolCalls.push({
         toolCallId: event.toolCallId,
-        toolName: event.toolName ?? event.content,
+        toolName: rawName,
+        label,
+        subject,
         status: 'completed', // optimistic; downgraded if a failed result arrives
         input: event.toolArguments,
       })

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -175,6 +175,9 @@ export interface BrowserOSChatHistoryItem {
   messageSeq: number
   sessionKey: string
   source: OpenClawSessionSource
+  costUsd?: number
+  tokensIn?: number
+  tokensOut?: number
 }
 
 export interface BrowserOSOpenClawHistoryPageResponse {
@@ -294,7 +297,7 @@ function jsonlEventsToHistoryItems(
       if (!text) continue
     }
 
-    items.push({
+    const item: BrowserOSChatHistoryItem = {
       id: `${sessionKey}:${seq}`,
       role: event.type === 'user.message' ? 'user' : 'assistant',
       text,
@@ -302,7 +305,16 @@ function jsonlEventsToHistoryItems(
       messageSeq: seq,
       sessionKey,
       source,
-    })
+    }
+
+    // Pass through per-turn cost and token data for assistant messages
+    if (event.type === 'agent.message') {
+      if (event.costUsd) item.costUsd = event.costUsd
+      if (event.tokensIn) item.tokensIn = event.tokensIn
+      if (event.tokensOut) item.tokensOut = event.tokensOut
+    }
+
+    items.push(item)
     seq++
   }
 

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -167,6 +167,16 @@ export interface BrowserOSOpenClawAgentSessionResponse {
   session: BrowserOSOpenClawSession | null
 }
 
+export interface BrowserOSChatHistoryToolCall {
+  toolCallId?: string
+  toolName: string
+  status: 'completed' | 'failed'
+  input?: Record<string, unknown>
+  output?: string
+  error?: string
+  durationMs?: number
+}
+
 export interface BrowserOSChatHistoryItem {
   id: string
   role: 'user' | 'assistant'
@@ -178,6 +188,7 @@ export interface BrowserOSChatHistoryItem {
   costUsd?: number
   tokensIn?: number
   tokensOut?: number
+  toolCalls?: BrowserOSChatHistoryToolCall[]
 }
 
 export interface BrowserOSOpenClawHistoryPageResponse {
@@ -260,7 +271,52 @@ function jsonlEventsToHistoryItems(
   const items: BrowserOSChatHistoryItem[] = []
   let seq = 0
 
+  // Accumulate tool calls between text messages. The agent emits
+  // tool_use → tool_result pairs interspersed with assistant text. We
+  // pair them by toolCallId and attach the resulting list to the next
+  // assistant message (the one that follows the tool sequence).
+  let pendingToolCalls: BrowserOSChatHistoryToolCall[] = []
+  const pendingToolStarts = new Map<string, ClawEvent>()
+
   for (const event of events) {
+    if (event.type === 'agent.tool_use') {
+      if (event.toolCallId) {
+        pendingToolStarts.set(event.toolCallId, event)
+      }
+      // Keep order — record the tool call now with status pending; we'll
+      // patch the result/error/duration when the matching tool_result arrives.
+      pendingToolCalls.push({
+        toolCallId: event.toolCallId,
+        toolName: event.toolName ?? event.content,
+        status: 'completed', // optimistic; downgraded if a failed result arrives
+        input: event.toolArguments,
+      })
+      continue
+    }
+
+    if (event.type === 'agent.tool_result') {
+      // Find the matching tool_use entry by toolCallId and patch it
+      const match = pendingToolCalls.find(
+        (t) => t.toolCallId && t.toolCallId === event.toolCallId,
+      )
+      if (match) {
+        if (event.isError) {
+          match.status = 'failed'
+          match.error = event.content
+        } else {
+          match.output = event.content
+        }
+        const start = event.toolCallId
+          ? pendingToolStarts.get(event.toolCallId)
+          : undefined
+        if (start) {
+          match.durationMs = Math.max(0, event.createdAt - start.createdAt)
+          if (event.toolCallId) pendingToolStarts.delete(event.toolCallId)
+        }
+      }
+      continue
+    }
+
     if (event.type !== 'user.message' && event.type !== 'agent.message') {
       continue
     }
@@ -292,6 +348,9 @@ function jsonlEventsToHistoryItems(
           .trim()
           .replace(/^User:\s*/i, '')
       } else {
+        // Reset pending tool calls — they belong to a discarded turn
+        pendingToolCalls = []
+        pendingToolStarts.clear()
         continue
       }
       if (!text) continue
@@ -307,11 +366,23 @@ function jsonlEventsToHistoryItems(
       source,
     }
 
-    // Pass through per-turn cost and token data for assistant messages
     if (event.type === 'agent.message') {
+      // Pass through per-turn cost and token data
       if (event.costUsd) item.costUsd = event.costUsd
       if (event.tokensIn) item.tokensIn = event.tokensIn
       if (event.tokensOut) item.tokensOut = event.tokensOut
+
+      // Attach any tool calls that happened before this assistant message
+      if (pendingToolCalls.length > 0) {
+        item.toolCalls = pendingToolCalls
+        pendingToolCalls = []
+        pendingToolStarts.clear()
+      }
+    } else if (event.type === 'user.message') {
+      // User messages reset the tool-call buffer — anything pending was
+      // part of an earlier turn that had no final assistant message.
+      pendingToolCalls = []
+      pendingToolStarts.clear()
     }
 
     items.push(item)

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -377,9 +377,11 @@ function jsonlEventsToHistoryItems(
           .trim()
           .replace(/^User:\s*/i, '')
       } else {
-        // Reset pending tool calls — they belong to a discarded turn
+        // Reset all per-turn buffers — they belong to a discarded turn
         pendingToolCalls = []
         pendingToolStarts.clear()
+        pendingReasoningTexts = []
+        pendingReasoningFirstAt = null
         continue
       }
       if (!text) continue

--- a/packages/browseros-agent/apps/server/src/tools/tool-label-registry.ts
+++ b/packages/browseros-agent/apps/server/src/tools/tool-label-registry.ts
@@ -230,18 +230,11 @@ const SUBJECT_EXTRACTORS: Record<string, SubjectExtractor> = {
     return typeof page === 'number' ? `tab ${page}` : asString(page)
   },
 
-  // Page reads — show which page, if specified
-  take_snapshot: (i) =>
-    typeof i.page === 'number' ? `tab ${i.page}` : undefined,
-  take_enhanced_snapshot: (i) =>
-    typeof i.page === 'number' ? `tab ${i.page}` : undefined,
-  get_page_content: (i) =>
-    typeof i.page === 'number' ? `tab ${i.page}` : undefined,
-  get_page_links: (i) =>
-    typeof i.page === 'number' ? `tab ${i.page}` : undefined,
-  get_dom: (i) => (typeof i.page === 'number' ? `tab ${i.page}` : undefined),
-  take_screenshot: (i) =>
-    typeof i.page === 'number' ? `tab ${i.page}` : undefined,
+  // Page reads (take_snapshot, take_enhanced_snapshot, get_page_content,
+  // get_page_links, get_dom, take_screenshot) intentionally omit a
+  // subject — the only argument is a numeric page ID that's internal
+  // to the agent and meaningless to the user ("tab 4" tells them nothing).
+  // The verb alone communicates what happened.
 
   // External actions via Strata
   execute_action: (i) => {

--- a/packages/browseros-agent/apps/server/src/tools/tool-label-registry.ts
+++ b/packages/browseros-agent/apps/server/src/tools/tool-label-registry.ts
@@ -1,0 +1,332 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Maps raw tool names + arguments to human-readable activity labels for
+ * the chat UI activity view. The MCP ToolRegistry is the source of truth
+ * for tool *existence*; this file is the editorial layer that turns
+ * snake_case identifiers into agent-speak verbs.
+ */
+
+const VERB_OVERRIDES: Record<string, string> = {
+  // Navigation
+  navigate_page: 'Navigated to',
+  new_page: 'Opened tab',
+  new_hidden_page: 'Opened tab',
+  show_page: 'Showed tab',
+  close_page: 'Closed tab',
+  list_pages: 'Listed open tabs',
+  get_active_page: 'Got active tab',
+  move_page: 'Moved tab',
+  group_tabs: 'Grouped tabs',
+
+  // Page reading
+  take_snapshot: 'Captured page snapshot',
+  take_enhanced_snapshot: 'Captured detailed snapshot',
+  get_page_content: 'Read page content',
+  get_page_links: 'Extracted page links',
+  get_dom: 'Read page DOM',
+  search_dom: 'Searched page DOM',
+  take_screenshot: 'Took screenshot',
+
+  // Input
+  click: 'Clicked',
+  click_at: 'Clicked at coordinates',
+  hover: 'Hovered',
+  hover_at: 'Hovered at coordinates',
+  type_at: 'Typed at coordinates',
+  drag_at: 'Dragged',
+  focus: 'Focused element',
+  fill: 'Filled field',
+  clear: 'Cleared field',
+  check: 'Checked box',
+  uncheck: 'Unchecked box',
+  press_key: 'Pressed key',
+  upload_file: 'Uploaded file',
+
+  // Console / scripts
+  evaluate_script: 'Ran script',
+  get_console_logs: 'Read console logs',
+
+  // History / bookmarks
+  search_history: 'Searched history',
+  get_recent_history: 'Read recent history',
+  delete_history_url: 'Deleted history entry',
+  delete_history_range: 'Deleted history range',
+  get_bookmarks: 'Listed bookmarks',
+  create_bookmark: 'Created bookmark',
+  remove_bookmark: 'Removed bookmark',
+  update_bookmark: 'Updated bookmark',
+  move_bookmark: 'Moved bookmark',
+  search_bookmarks: 'Searched bookmarks',
+
+  // Filesystem (sandboxed)
+  read_file: 'Read file',
+  write_file: 'Wrote file',
+  find_files: 'Searched files',
+
+  // Memory
+  read_soul: 'Read soul memory',
+  read_core: 'Read core memory',
+  write_memory: 'Wrote memory',
+  search_memory: 'Searched memory',
+  update_soul: 'Updated soul memory',
+  update_core: 'Updated core memory',
+
+  // Web
+  web_search: 'Searched the web',
+  web_fetch: 'Fetched URL',
+
+  // Klavis / external apps (Strata)
+  connector_mcp_servers: 'Listed connected apps',
+  discover_server_categories_or_actions: 'Browsed available actions',
+  get_category_actions: 'Listed actions',
+  get_action_details: 'Looked up action',
+  execute_action: 'Ran external action',
+  search_documentation: 'Searched docs',
+  handle_auth_failure: 'Handled auth issue',
+
+  // Suggestions
+  suggest_schedule: 'Suggested schedule',
+  suggest_app_connection: 'Suggested app connect',
+
+  // BrowserOS info
+  browseros_info: 'Read BrowserOS info',
+
+  // Windows
+  list_windows: 'Listed windows',
+  focus_window: 'Focused window',
+  close_window: 'Closed window',
+  create_window: 'Created window',
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────
+
+function asString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}
+
+function stringField(
+  input: Record<string, unknown>,
+  ...keys: string[]
+): string | undefined {
+  for (const k of keys) {
+    const v = asString(input[k])
+    if (v) return v
+  }
+  return undefined
+}
+
+function truncate(text: string | undefined, max: number): string | undefined {
+  if (!text) return undefined
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text
+}
+
+function quote(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  return `"${truncate(value, 60)}"`
+}
+
+function basename(path: string | undefined): string | undefined {
+  if (!path) return undefined
+  const parts = path.split(/[/\\]/).filter(Boolean)
+  return parts[parts.length - 1] ?? path
+}
+
+function formatUrl(value: unknown): string | undefined {
+  const url = asString(value)
+  if (!url) return undefined
+  try {
+    const parsed = new URL(url)
+    const host = parsed.host
+    const path = parsed.pathname === '/' ? '' : parsed.pathname
+    const display = path && path.length > 0 ? `${host}${path}` : host
+    return truncate(display, 60)
+  } catch {
+    return truncate(url, 60)
+  }
+}
+
+function coords(x: unknown, y: unknown): string | undefined {
+  if (typeof x === 'number' && typeof y === 'number') {
+    return `${Math.round(x)}, ${Math.round(y)}`
+  }
+  return undefined
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Subject extractors
+// ──────────────────────────────────────────────────────────────────────
+
+type SubjectExtractor = (input: Record<string, unknown>) => string | undefined
+
+const SUBJECT_EXTRACTORS: Record<string, SubjectExtractor> = {
+  // URL-bearing tools
+  new_page: (i) => formatUrl(i.url),
+  new_hidden_page: (i) => formatUrl(i.url),
+  navigate_page: (i) => {
+    const action = asString(i.action)
+    if (action === 'back') return 'back'
+    if (action === 'forward') return 'forward'
+    if (action === 'reload') return 'reload'
+    return formatUrl(i.url)
+  },
+  web_fetch: (i) => formatUrl(i.url),
+
+  // Search queries
+  web_search: (i) => quote(stringField(i, 'query', 'q')),
+  search_history: (i) => quote(stringField(i, 'query', 'text')),
+  search_bookmarks: (i) => quote(stringField(i, 'query', 'text')),
+  search_memory: (i) => quote(stringField(i, 'query', 'q')),
+  search_dom: (i) => quote(stringField(i, 'query', 'selector')),
+  search_documentation: (i) => quote(stringField(i, 'query', 'q')),
+  find_files: (i) => quote(stringField(i, 'pattern', 'query')),
+
+  // Element interactions
+  click: (i) => stringField(i, 'element'),
+  hover: (i) => stringField(i, 'element'),
+  focus: (i) => stringField(i, 'element'),
+  clear: (i) => stringField(i, 'element'),
+  check: (i) => stringField(i, 'element'),
+  uncheck: (i) => stringField(i, 'element'),
+  fill: (i) => {
+    const target = stringField(i, 'element')
+    const text = stringField(i, 'text')
+    if (target && text) return `${target}: ${truncate(text, 40)}`
+    return target ?? truncate(text, 40)
+  },
+  press_key: (i) => stringField(i, 'key'),
+
+  // Coordinate-based input
+  click_at: (i) => coords(i.x, i.y),
+  hover_at: (i) => coords(i.x, i.y),
+  type_at: (i) => {
+    const at = coords(i.x, i.y)
+    const text = stringField(i, 'text')
+    if (at && text) return `${at}: ${truncate(text, 40)}`
+    return at ?? truncate(text, 40)
+  },
+  drag_at: (i) => {
+    const from = coords(i.fromX, i.fromY)
+    const to = coords(i.toX, i.toY)
+    if (from && to) return `${from} → ${to}`
+    return from ?? to
+  },
+
+  // Tab management
+  show_page: (i) => {
+    const page = i.page
+    return typeof page === 'number' ? `tab ${page}` : asString(page)
+  },
+  close_page: (i) => {
+    const page = i.page
+    return typeof page === 'number' ? `tab ${page}` : asString(page)
+  },
+  move_page: (i) => {
+    const page = i.page
+    return typeof page === 'number' ? `tab ${page}` : asString(page)
+  },
+
+  // Page reads — show which page, if specified
+  take_snapshot: (i) =>
+    typeof i.page === 'number' ? `tab ${i.page}` : undefined,
+  take_enhanced_snapshot: (i) =>
+    typeof i.page === 'number' ? `tab ${i.page}` : undefined,
+  get_page_content: (i) =>
+    typeof i.page === 'number' ? `tab ${i.page}` : undefined,
+  get_page_links: (i) =>
+    typeof i.page === 'number' ? `tab ${i.page}` : undefined,
+  get_dom: (i) => (typeof i.page === 'number' ? `tab ${i.page}` : undefined),
+  take_screenshot: (i) =>
+    typeof i.page === 'number' ? `tab ${i.page}` : undefined,
+
+  // External actions via Strata
+  execute_action: (i) => {
+    const server = stringField(i, 'server_name')
+    const action = stringField(i, 'action_name')
+    if (server && action) return `${server} · ${action}`
+    return action ?? server
+  },
+  get_category_actions: (i) => stringField(i, 'category_name', 'server_name'),
+  get_action_details: (i) => stringField(i, 'action_name'),
+  discover_server_categories_or_actions: (i) =>
+    stringField(i, 'server_name', 'category_name'),
+  connector_mcp_servers: (i) => stringField(i, 'server_name'),
+
+  // Filesystem
+  read_file: (i) => basename(stringField(i, 'path')),
+  write_file: (i) => basename(stringField(i, 'path')),
+
+  // Memory writes — show first chars of content
+  write_memory: (i) => truncate(stringField(i, 'content', 'text'), 40),
+  update_soul: (i) => truncate(stringField(i, 'content'), 40),
+  update_core: (i) => truncate(stringField(i, 'content'), 40),
+
+  // Bookmarks
+  create_bookmark: (i) => stringField(i, 'title') ?? formatUrl(i.url),
+  remove_bookmark: (i) => stringField(i, 'id', 'title'),
+  update_bookmark: (i) => stringField(i, 'id', 'title'),
+  move_bookmark: (i) => stringField(i, 'id', 'title'),
+
+  // History
+  delete_history_url: (i) => formatUrl(i.url),
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Public API
+// ──────────────────────────────────────────────────────────────────────
+
+export interface ToolLabelResult {
+  label: string
+  subject?: string
+}
+
+/**
+ * Strip MCP namespace prefixes (e.g. "browseros__", "mcp_") to find the
+ * canonical tool name used in the override maps.
+ */
+function canonicalName(rawName: string): string {
+  return rawName.replace(/^browseros__/, '').replace(/^mcp_/, '')
+}
+
+/**
+ * Convert a snake_case tool name into Sentence-case English as a fallback
+ * when no curated override exists.
+ */
+function humanizeToolName(rawName: string): string {
+  const stripped = canonicalName(rawName)
+  const words = stripped.split(/[_-]/).filter((w) => w.length > 0)
+  if (words.length === 0) return rawName
+  const first = words[0]!
+  return [
+    first.charAt(0).toUpperCase() + first.slice(1),
+    ...words.slice(1),
+  ].join(' ')
+}
+
+/**
+ * Build a human-readable label and subject string for a tool call,
+ * suitable for rendering in the chat activity view.
+ */
+export function buildToolLabel(
+  rawName: string,
+  input?: Record<string, unknown>,
+): ToolLabelResult {
+  const canonical = canonicalName(rawName)
+  const label =
+    VERB_OVERRIDES[canonical] ??
+    VERB_OVERRIDES[rawName] ??
+    humanizeToolName(rawName)
+
+  const extractor = Object.hasOwn(SUBJECT_EXTRACTORS, canonical)
+    ? SUBJECT_EXTRACTORS[canonical]
+    : Object.hasOwn(SUBJECT_EXTRACTORS, rawName)
+      ? SUBJECT_EXTRACTORS[rawName]
+      : undefined
+  const subject = extractor && input ? extractor(input) : undefined
+
+  return { label, subject }
+}


### PR DESCRIPTION
## Summary

Brings the agent extension's chat view in line with the rest of the UI: every assistant turn now shows what the agent actually did, how long it thought, what the request cost, and a way to copy the answer.

## What's new

**Tool activity per turn**
- All tool calls inside an assistant turn collapse into a single `<Task>` collapsible — `Agent activity (N actions)` — instead of one collapsible per call.
- Each row is rendered as a human verb sourced from a shared tool-label registry (e.g. `Opened tab · news.ycombinator.com`, `Read page`, `Searched the web`) with status icon, optional subject, and elapsed time.
- The `tool-output` SSE event is now wired through so live streaming turns mutate their pending tool entries with output/error/duration as results arrive.

**Reasoning with duration**
- Historical assistant turns surface a single `<Reasoning>` collapsible per turn. Server accumulates `agent.thinking` blocks per turn from the JSONL and attaches them to the closing `agent.message` with `durationMs = first thinking → final answer`.
- Fixed a JSONL field-name mismatch (OpenClaw stores reasoning text on `block.thinking`, not `block.text`) that was silently dropping every thinking block at the parser layer.
- Trigger renders ``Thought for N seconds`` for multi-line turns; falls back to the static `Thinking` label when think + answer share a single JSONL line (sub-second).

**Per-message toolbar**
- Assistant messages get a `<MessageToolbar>` with a Copy button and the per-turn cost (rendered in tabular nums, only when data exists).
- Server passes `costUsd`, `tokensIn`, `tokensOut` from `agent.message` events through the history items so the toolbar can render without a separate request.

**Initial render fixes**
- Gate `isInitialLoading` on `historyQuery.isFetched` so the loading state stays through the render frame where the query just got enabled but hasn't started fetching yet — eliminates the empty-conversation flash.
- Pass `mode=\"static\"` + `parseIncompleteMarkdown={false}` to Streamdown for finalized historical messages so completed text paints in the same frame as the surrounding chrome (the default streaming mode debounces by ~300–500ms via `requestIdleCallback`, which is wrong for already-complete content).
- Collapsed the redundant `/agents/:id/session` round-trip into the existing `/history` endpoint (server resolves the most recent user-chat session itself when no `sessionKey` is provided).

## Files

**Server**
- \`apps/server/src/api/services/openclaw/openclaw-service.ts\` — extend history items with cost/tokens/tool-call/reasoning fields; accumulate thinking per turn; build labels via tool-label registry.
- \`apps/server/src/api/services/openclaw/openclaw-jsonl-reader.ts\` — read \`block.thinking\` (with \`block.text\` fallback) so reasoning blocks reach the pipeline.
- \`apps/server/src/tools/tool-label-registry.ts\` — new shared registry mapping tool names to verb + subject extractors.

**Client**
- \`apps/agent/entrypoints/app/agent-command/ClawChatMessage.tsx\` — single Task per turn, MessageToolbar, Reasoning with duration, Streamdown static mode.
- \`apps/agent/entrypoints/app/agent-command/ConversationMessage.tsx\` — same Task pattern for live streaming turns; consumes \`tool-output\` SSE events.
- \`apps/agent/entrypoints/app/agent-command/claw-chat-types.ts\` — types mirror the server; map history items into reasoning → tools → text part order.
- \`apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx\` — single-query flow keyed off the history endpoint; tightened loading gate.
- \`apps/agent/entrypoints/app/agent-command/useClawChatHistory.ts\` — accept \`sessionKey: null\` and let the server resolve.
- \`apps/agent/entrypoints/app/agent-command/useAgentConversation.ts\` — handle \`tool-output\` events; build labels for live tool starts.
- \`apps/agent/lib/tool-labels.ts\` — client mirror of the server-side registry for live SSE.

## Test plan
- [ ] Open an agent with existing history → messages render in one frame (no LoadingState → blank flash → text fade-in)
- [ ] Assistant turns with tool calls show one \`Agent activity (N actions)\` collapsible; expanding lists each tool with verb, status, subject, and duration
- [ ] Assistant turns that involved real thinking show \`Thought for N seconds\`; sub-second turns show \`Thinking\`
- [ ] Toolbar shows Copy + cost (e.g. \`\$0.0042\`) on assistant messages only; not on user messages
- [ ] Live streaming: tool rows update from running → completed/failed; output appears once \`tool-output\` arrives
- [ ] Sending a new chat creates a session if none exists; existing session continues without a refetch flicker