### PR TITLE
feat(agent): composer attachments + server-side outbound message queue

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
@@ -337,6 +337,7 @@ function AgentConversationController({
                   name: a.name,
                   dataUrl: a.dataUrl,
                 })),
+                history: chatHistory,
               })
             }}
             onCreateAgent={() => navigate(createAgentPath)}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
@@ -16,6 +16,7 @@ import {
 } from './claw-chat-types'
 import { useAgentConversation } from './useAgentConversation'
 import { useClawChatHistory } from './useClawChatHistory'
+import { useOutboundQueue } from './useOutboundQueue'
 
 function StatusBadge({ status }: { status: string }) {
   return (
@@ -223,8 +224,7 @@ function AgentConversationController({
       setStreamSessionKey(sessionKey)
     },
   })
-  const sendRef = useRef(send)
-  sendRef.current = send
+  const outboundQueue = useOutboundQueue({ send, streaming })
   onInitialMessageConsumedRef.current = onInitialMessageConsumed
 
   const disabled = status?.status !== 'running'
@@ -242,6 +242,9 @@ function AgentConversationController({
     : null
   const error = historyQuery.error ?? null
 
+  const enqueueRef = useRef(outboundQueue.enqueue)
+  enqueueRef.current = outboundQueue.enqueue
+
   useEffect(() => {
     const query = initialMessage?.trim()
     if (!initialMessageKey) {
@@ -249,20 +252,24 @@ function AgentConversationController({
       return
     }
 
+    // The initial-message handoff (home composer → conversation page via
+    // ?q=) goes through the outbound queue too, so it inherits the same
+    // single-flight serialization. We no longer need to gate on
+    // `streaming` — the queue worker drains as soon as the agent is
+    // free.
     if (
       !query ||
       initialMessageSentRef.current === initialMessageKey ||
       disabled ||
-      !historyReady ||
-      streaming
+      !historyReady
     ) {
       return
     }
 
     initialMessageSentRef.current = initialMessageKey
     onInitialMessageConsumedRef.current()
-    void sendRef.current(query)
-  }, [disabled, historyReady, initialMessage, initialMessageKey, streaming])
+    enqueueRef.current({ text: query })
+  }, [disabled, historyReady, initialMessage, initialMessageKey])
 
   const handleSelectAgent = (entry: AgentEntry) => {
     navigate(`${agentPathPrefix}/${entry.agentId}`)
@@ -295,7 +302,7 @@ function AgentConversationController({
             selectedAgentId={agentId}
             onSelectAgent={handleSelectAgent}
             onSend={(input) => {
-              void send({
+              outboundQueue.enqueue({
                 text: input.text,
                 attachments: input.attachments.map((a) => a.payload),
                 attachmentPreviews: input.attachments.map((a) => ({
@@ -312,6 +319,9 @@ function AgentConversationController({
             disabled={disabled}
             status={status?.status}
             placeholder={`Message ${agentName}...`}
+            outboundQueue={outboundQueue.queue}
+            onCancelQueued={outboundQueue.cancel}
+            onRetryQueued={outboundQueue.retry}
           />
         </div>
       </div>

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
@@ -217,15 +217,37 @@ function AgentConversationController({
   const resolvedSessionKey =
     streamSessionKey ?? historyQuery.data?.pages?.[0]?.sessionKey ?? null
 
-  const { turns, streaming, send } = useAgentConversation(agentId, {
+  const { turns, streaming } = useAgentConversation(agentId, {
     sessionKey: resolvedSessionKey,
     history: chatHistory,
     onSessionKeyChange: (sessionKey) => {
       setStreamSessionKey(sessionKey)
     },
   })
-  const outboundQueue = useOutboundQueue({ send, streaming })
+  const outboundQueue = useOutboundQueue({ agentId })
   onInitialMessageConsumedRef.current = onInitialMessageConsumed
+
+  // Refetch history whenever a server-dispatched queue item completes.
+  // The server worker streams the queued turn into OpenClaw directly, so
+  // the client never observes the live tokens — we only see the new
+  // assistant turn once the JSONL is updated. Watching the queue for
+  // any 'sending' item dropping out is the cleanest "turn finalized"
+  // signal we have without exposing per-turn SSE.
+  const previousSendingIdsRef = useRef<Set<string>>(new Set())
+  useEffect(() => {
+    const currentSending = new Set(
+      outboundQueue.queue
+        .filter((item) => item.status === 'sending')
+        .map((item) => item.id),
+    )
+    const dropped = [...previousSendingIdsRef.current].filter(
+      (id) => !currentSending.has(id),
+    )
+    previousSendingIdsRef.current = currentSending
+    if (dropped.length > 0) {
+      void historyQuery.refetch()
+    }
+  }, [outboundQueue.queue, historyQuery])
 
   const disabled = status?.status !== 'running'
   // Two-part gate: cover both "still fetching" AND "just got enabled but

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
@@ -224,7 +224,10 @@ function AgentConversationController({
       setStreamSessionKey(sessionKey)
     },
   })
-  const outboundQueue = useOutboundQueue({ agentId })
+  const outboundQueue = useOutboundQueue({
+    agentId,
+    sessionKey: resolvedSessionKey,
+  })
   onInitialMessageConsumedRef.current = onInitialMessageConsumed
 
   // Refetch history whenever a server-dispatched queue item completes.

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
@@ -294,8 +294,18 @@ function AgentConversationController({
             agents={agents}
             selectedAgentId={agentId}
             onSelectAgent={handleSelectAgent}
-            onSend={(text) => {
-              void send(text)
+            onSend={(input) => {
+              void send({
+                text: input.text,
+                attachments: input.attachments.map((a) => a.payload),
+                attachmentPreviews: input.attachments.map((a) => ({
+                  id: a.id,
+                  kind: a.kind,
+                  mediaType: a.mediaType,
+                  name: a.name,
+                  dataUrl: a.dataUrl,
+                })),
+              })
             }}
             onCreateAgent={() => navigate(createAgentPath)}
             streaming={streaming}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandHome.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandHome.tsx
@@ -155,9 +155,16 @@ export const AgentCommandHome: FC = () => {
     }
   }, [agents, selectedAgentId])
 
-  const handleSend = (text: string) => {
+  const handleSend = (input: { text: string }) => {
     if (!selectedAgentId) return
-    navigate(`/home/agents/${selectedAgentId}?q=${encodeURIComponent(text)}`)
+    // Home composer navigates to the conversation page with the prompt in
+    // the query string. Attachments are dropped at this boundary in v1 —
+    // the conversation page (where staging UX is most useful anyway) is
+    // where users can attach. A future iteration can stash staged files
+    // in chrome.storage.session and replay them on first mount there.
+    navigate(
+      `/home/agents/${selectedAgentId}?q=${encodeURIComponent(input.text)}`,
+    )
   }
 
   const handleSelectAgent = (agent: AgentEntry) => {

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ClawChatMessage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ClawChatMessage.tsx
@@ -4,6 +4,8 @@ import {
   Message,
   MessageAction,
   MessageActions,
+  MessageAttachment,
+  MessageAttachments,
   MessageContent,
   MessageResponse,
   MessageToolbar,
@@ -31,22 +33,27 @@ function formatCost(usd: number): string {
 }
 
 type ToolCallPart = Extract<ClawChatMessagePart, { type: 'tool-call' }>
+type AttachmentPart = Extract<ClawChatMessagePart, { type: 'attachment' }>
 
 interface RenderEntry {
-  kind: 'text' | 'reasoning' | 'meta' | 'task'
+  kind: 'text' | 'reasoning' | 'meta' | 'task' | 'attachments'
   partIndex: number
   part?: ClawChatMessagePart
   tools?: ToolCallPart[]
+  attachments?: AttachmentPart[]
 }
 
 /**
  * Build a render plan that groups all tool-call parts into a single Task
- * collapsible at their first appearance position. Other parts render in place.
+ * collapsible and all attachment parts into a single attachment strip at
+ * their respective first-appearance positions. Other parts render in place.
  */
 function buildRenderEntries(parts: ClawChatMessagePart[]): RenderEntry[] {
   const entries: RenderEntry[] = []
   const tools: ToolCallPart[] = []
+  const attachments: AttachmentPart[] = []
   let taskInserted = false
+  let attachmentsInserted = false
 
   parts.forEach((part, partIndex) => {
     if (part.type === 'tool-call') {
@@ -54,6 +61,12 @@ function buildRenderEntries(parts: ClawChatMessagePart[]): RenderEntry[] {
       if (!taskInserted) {
         entries.push({ kind: 'task', partIndex, tools })
         taskInserted = true
+      }
+    } else if (part.type === 'attachment') {
+      attachments.push(part)
+      if (!attachmentsInserted) {
+        entries.push({ kind: 'attachments', partIndex, attachments })
+        attachmentsInserted = true
       }
     } else if (part.type === 'text') {
       entries.push({ kind: 'text', partIndex, part })
@@ -106,6 +119,25 @@ export const ClawChatMessage: FC<ClawChatMessageProps> = ({ message }) => {
       <MessageContent className="max-w-full overflow-hidden group-[.is-assistant]:w-full group-[.is-user]:max-w-full">
         {entries.map((entry) => {
           const key = `${message.id}-entry-${entry.partIndex}`
+
+          if (entry.kind === 'attachments' && entry.attachments) {
+            return (
+              <MessageAttachments key={key}>
+                {entry.attachments.map((attachment, idx) => (
+                  <MessageAttachment
+                    // biome-ignore lint/suspicious/noArrayIndexKey: attachment order is stable within a finalized message
+                    key={`${attachment.kind}-${idx}`}
+                    data={{
+                      type: 'file',
+                      url: attachment.dataUrl ?? '',
+                      mediaType: attachment.mediaType,
+                      filename: attachment.name,
+                    }}
+                  />
+                ))}
+              </MessageAttachments>
+            )
+          }
 
           if (entry.kind === 'text' && entry.part?.type === 'text') {
             return (

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationInput.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationInput.tsx
@@ -1,4 +1,5 @@
 import {
+  AlertTriangle,
   ArrowRight,
   Bot,
   ChevronDown,
@@ -8,6 +9,7 @@ import {
   Loader2,
   Mic,
   Paperclip,
+  RefreshCw,
   Square,
   X,
 } from 'lucide-react'
@@ -36,6 +38,7 @@ import { cn } from '@/lib/utils'
 import { useVoiceInput } from '@/lib/voice/useVoiceInput'
 import { useWorkspace } from '@/lib/workspace/use-workspace'
 import { AgentSelector } from './AgentSelector'
+import type { OutboundMessage } from './useOutboundQueue'
 
 export interface ConversationInputSendInput {
   text: string
@@ -53,6 +56,15 @@ interface ConversationInputProps {
   status?: string
   placeholder?: string
   variant?: 'home' | 'conversation'
+  // Outbound queue: when present, the composer renders the queue strip
+  // above the textarea and lets the user keep sending while a previous
+  // turn is in flight. Optional so non-conversation variants (the home
+  // page) can opt out — the queue only makes sense in the conversation
+  // page where each enqueued message will eventually be delivered to the
+  // active agent.
+  outboundQueue?: OutboundMessage[]
+  onCancelQueued?: (id: string) => void
+  onRetryQueued?: (id: string) => void
 }
 
 function InputActionButton({
@@ -295,6 +307,9 @@ export const ConversationInput: FC<ConversationInputProps> = ({
   status,
   placeholder,
   variant = 'conversation',
+  outboundQueue,
+  onCancelQueued,
+  onRetryQueued,
 }) => {
   const [input, setInput] = useState('')
   const [selectedTabs, setSelectedTabs] = useState<chrome.tabs.Tab[]>([])
@@ -365,10 +380,15 @@ export const ConversationInput: FC<ConversationInputProps> = ({
   }
 
   const hasContent = input.trim().length > 0 || attachments.length > 0
+  const queueEnabled = outboundQueue !== undefined
 
   const handleSend = () => {
     const text = input.trim()
-    if (streaming || disabled || isStaging) return
+    // The outbound queue accepts new messages while streaming; legacy
+    // direct-send callers (e.g., the home composer) keep the original
+    // streaming-blocks-send semantic.
+    if (disabled || isStaging) return
+    if (!queueEnabled && streaming) return
     if (!text && attachments.length === 0) return
     onSend({ text, attachments })
     setInput('')
@@ -456,6 +476,13 @@ export const ConversationInput: FC<ConversationInputProps> = ({
             error={attachmentError}
           />
         ) : null}
+        {queueEnabled && outboundQueue && outboundQueue.length > 0 ? (
+          <OutboundQueueStrip
+            messages={outboundQueue}
+            onCancel={onCancelQueued}
+            onRetry={onRetryQueued}
+          />
+        ) : null}
         <div
           className={cn(
             'flex gap-3',
@@ -507,13 +534,18 @@ export const ConversationInput: FC<ConversationInputProps> = ({
           <InputActionButton
             disabled={
               !hasContent ||
-              streaming ||
               isStaging ||
               !!disabled ||
               voice.isRecording ||
-              voice.isTranscribing
+              voice.isTranscribing ||
+              // Only block on `streaming` for the legacy direct-send path
+              // (no queue). With the queue active the press always
+              // succeeds — it just enqueues instead of dispatching.
+              (!queueEnabled && streaming)
             }
             onClick={handleSend}
+            // Spinner stays the user-facing "agent is busy" hint; with the
+            // queue active we still spin while a turn is in flight.
             streaming={streaming}
           />
         </div>
@@ -541,6 +573,117 @@ export const ConversationInput: FC<ConversationInputProps> = ({
         ) : null}
       </section>
     </Shell>
+  )
+}
+
+function OutboundQueueStrip({
+  messages,
+  onCancel,
+  onRetry,
+}: {
+  messages: OutboundMessage[]
+  onCancel?: (id: string) => void
+  onRetry?: (id: string) => void
+}) {
+  return (
+    <div className="border-border/40 border-b px-4 pt-3 pb-2">
+      <ul className="flex flex-col gap-1">
+        {messages.map((message) => (
+          <OutboundQueueItem
+            key={message.id}
+            message={message}
+            onCancel={onCancel}
+            onRetry={onRetry}
+          />
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function OutboundQueueItem({
+  message,
+  onCancel,
+  onRetry,
+}: {
+  message: OutboundMessage
+  onCancel?: (id: string) => void
+  onRetry?: (id: string) => void
+}) {
+  const preview = message.text.trim() || '(attachments only)'
+  return (
+    <li className="flex items-center gap-2 rounded-md px-2 py-1 text-xs">
+      <OutboundQueueStatusIcon status={message.status} />
+      <span className="min-w-0 flex-1 truncate text-muted-foreground">
+        {preview}
+      </span>
+      {message.attachmentPreviews.length > 0 ? (
+        <span className="inline-flex items-center gap-1 text-muted-foreground/70">
+          <Paperclip className="size-3" />
+          <span className="tabular-nums">
+            {message.attachmentPreviews.length}
+          </span>
+        </span>
+      ) : null}
+      {message.status === 'queued' && onCancel ? (
+        <button
+          type="button"
+          onClick={() => onCancel(message.id)}
+          className="ml-1 inline-flex size-5 items-center justify-center rounded-full text-muted-foreground hover:bg-accent hover:text-foreground"
+          aria-label="Cancel queued message"
+          title="Cancel"
+        >
+          <X className="size-3" />
+        </button>
+      ) : null}
+      {message.status === 'failed' ? (
+        <span className="ml-1 inline-flex items-center gap-2 text-destructive">
+          <span className="max-w-[160px] truncate" title={message.error}>
+            {message.error ?? 'Failed'}
+          </span>
+          {onRetry ? (
+            <button
+              type="button"
+              onClick={() => onRetry(message.id)}
+              className="inline-flex size-5 items-center justify-center rounded-full hover:bg-accent hover:text-foreground"
+              aria-label="Retry failed message"
+              title="Retry"
+            >
+              <RefreshCw className="size-3" />
+            </button>
+          ) : null}
+          {onCancel ? (
+            <button
+              type="button"
+              onClick={() => onCancel(message.id)}
+              className="inline-flex size-5 items-center justify-center rounded-full hover:bg-accent hover:text-foreground"
+              aria-label="Discard failed message"
+              title="Discard"
+            >
+              <X className="size-3" />
+            </button>
+          ) : null}
+        </span>
+      ) : null}
+    </li>
+  )
+}
+
+function OutboundQueueStatusIcon({
+  status,
+}: {
+  status: OutboundMessage['status']
+}) {
+  if (status === 'sending') {
+    return (
+      <Loader2 className="size-3.5 shrink-0 animate-spin text-muted-foreground" />
+    )
+  }
+  if (status === 'failed') {
+    return <AlertTriangle className="size-3.5 shrink-0 text-destructive" />
+  }
+  return (
+    <span className="inline-block size-2 shrink-0 rounded-full bg-muted-foreground/40" />
   )
 }
 

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationInput.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationInput.tsx
@@ -2,13 +2,17 @@ import {
   ArrowRight,
   Bot,
   ChevronDown,
+  FileText,
   Folder,
   Layers,
   Loader2,
   Mic,
+  Paperclip,
   Square,
+  X,
 } from 'lucide-react'
 import {
+  type DragEvent,
   type FC,
   type ReactNode,
   useEffect,
@@ -24,6 +28,7 @@ import { Textarea } from '@/components/ui/textarea'
 import type { AgentEntry } from '@/entrypoints/app/agents/useOpenClaw'
 import { McpServerIcon } from '@/entrypoints/app/connect-mcp/McpServerIcon'
 import { useGetUserMCPIntegrations } from '@/entrypoints/app/connect-mcp/useGetUserMCPIntegrations'
+import { type StagedAttachment, stageAttachments } from '@/lib/attachments'
 import { Feature } from '@/lib/browseros/capabilities'
 import { useCapabilities } from '@/lib/browseros/useCapabilities'
 import { useMcpServers } from '@/lib/mcp/mcpServerStorage'
@@ -32,11 +37,16 @@ import { useVoiceInput } from '@/lib/voice/useVoiceInput'
 import { useWorkspace } from '@/lib/workspace/use-workspace'
 import { AgentSelector } from './AgentSelector'
 
+export interface ConversationInputSendInput {
+  text: string
+  attachments: StagedAttachment[]
+}
+
 interface ConversationInputProps {
   agents: AgentEntry[]
   selectedAgentId: string | null
   onSelectAgent: (agent: AgentEntry) => void
-  onSend: (text: string) => void
+  onSend: (input: ConversationInputSendInput) => void
   onCreateAgent?: () => void
   streaming: boolean
   disabled?: boolean
@@ -131,6 +141,8 @@ function ContextControls({
   onToggleTab,
   showAgentSelector,
   status,
+  onAttachClick,
+  attachDisabled,
 }: {
   agents: AgentEntry[]
   onCreateAgent?: () => void
@@ -140,6 +152,8 @@ function ContextControls({
   onToggleTab: (tab: chrome.tabs.Tab) => void
   showAgentSelector: boolean
   status?: string
+  onAttachClick: () => void
+  attachDisabled: boolean
 }) {
   const { supports } = useCapabilities()
   const { selectedFolder } = useWorkspace()
@@ -199,6 +213,20 @@ function ContextControls({
             <span>Tabs</span>
           </Button>
         </TabPickerPopover>
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={onAttachClick}
+          disabled={attachDisabled}
+          title="Attach files"
+          className={cn(
+            'flex items-center gap-2 rounded-lg px-3 py-1.5 font-medium text-sm transition-all',
+            'bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+          )}
+        >
+          <Paperclip className="h-4 w-4" />
+          <span>Attach</span>
+        </Button>
       </div>
 
       {supports(Feature.MANAGED_MCP_SUPPORT) ? (
@@ -271,12 +299,39 @@ export const ConversationInput: FC<ConversationInputProps> = ({
   const [input, setInput] = useState('')
   const [selectedTabs, setSelectedTabs] = useState<chrome.tabs.Tab[]>([])
   const [isExpandedDraft, setIsExpandedDraft] = useState(false)
+  const [attachments, setAttachments] = useState<StagedAttachment[]>([])
+  const [attachmentError, setAttachmentError] = useState<string | null>(null)
+  const [isStaging, setIsStaging] = useState(false)
+  const [isDragOver, setIsDragOver] = useState(false)
+  const fileInputRef = useRef<HTMLInputElement>(null)
   const voice = useVoiceInput()
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const selectedAgent = agents.find(
     (agent) => agent.agentId === selectedAgentId,
   )
   const isConversation = variant === 'conversation'
+
+  const stageFiles = async (files: File[]) => {
+    if (files.length === 0) return
+    setIsStaging(true)
+    setAttachmentError(null)
+    try {
+      const result = await stageAttachments(files, attachments.length)
+      if (result.staged.length > 0) {
+        setAttachments((prev) => [...prev, ...result.staged])
+      }
+      if (result.errors.length > 0) {
+        setAttachmentError(result.errors.map((e) => e.message).join(' \u2022 '))
+      }
+    } finally {
+      setIsStaging(false)
+    }
+  }
+
+  const removeAttachment = (id: string) => {
+    setAttachments((prev) => prev.filter((a) => a.id !== id))
+    setAttachmentError(null)
+  }
 
   useLayoutEffect(() => {
     const element = textareaRef.current
@@ -309,11 +364,66 @@ export const ConversationInput: FC<ConversationInputProps> = ({
     })
   }
 
+  const hasContent = input.trim().length > 0 || attachments.length > 0
+
   const handleSend = () => {
     const text = input.trim()
-    if (!text || streaming || disabled) return
-    onSend(text)
+    if (streaming || disabled || isStaging) return
+    if (!text && attachments.length === 0) return
+    onSend({ text, attachments })
     setInput('')
+    setAttachments([])
+    setAttachmentError(null)
+  }
+
+  const handlePaste = (event: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    const items = event.clipboardData?.items
+    if (!items) return
+    const files: File[] = []
+    for (const item of items) {
+      if (item.kind === 'file') {
+        const file = item.getAsFile()
+        if (file) files.push(file)
+      }
+    }
+    if (files.length > 0) {
+      event.preventDefault()
+      void stageFiles(files)
+    }
+  }
+
+  const handleDrop = (event: DragEvent<HTMLDivElement>) => {
+    event.preventDefault()
+    setIsDragOver(false)
+    const files = Array.from(event.dataTransfer?.files ?? [])
+    if (files.length > 0) {
+      void stageFiles(files)
+    }
+  }
+
+  const handleDragOver = (event: DragEvent<HTMLDivElement>) => {
+    if (!event.dataTransfer?.types.includes('Files')) return
+    event.preventDefault()
+    setIsDragOver(true)
+  }
+
+  const handleDragLeave = (event: DragEvent<HTMLDivElement>) => {
+    if (event.currentTarget.contains(event.relatedTarget as Node | null)) {
+      return
+    }
+    setIsDragOver(false)
+  }
+
+  const openFilePicker = () => {
+    fileInputRef.current?.click()
+  }
+
+  const handleFileInputChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+  ) => {
+    const files = Array.from(event.target.files ?? [])
+    event.target.value = ''
+    if (files.length > 0) void stageFiles(files)
   }
 
   const shell = variant === 'home' ? HomeShell : ConversationShell
@@ -321,79 +431,187 @@ export const ConversationInput: FC<ConversationInputProps> = ({
 
   return (
     <Shell>
-      <div
-        className={cn(
-          'flex gap-3',
-          variant === 'home' ? 'px-4 py-3' : 'px-4 py-3',
-          isExpandedDraft ? 'items-end' : 'items-center',
-        )}
+      <section
+        // Drag/drop on a region isn't a click affordance — wrap the
+        // composer in a labeled <section> so the a11y rule is satisfied
+        // without misrepresenting the surface as interactive.
+        aria-label="Message composer"
+        className={cn('relative', isDragOver && 'ring-2 ring-primary/60')}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onDrop={handleDrop}
       >
-        <BotInputIcon variant={variant} />
-        <div className="flex-1">
-          <Textarea
-            ref={textareaRef}
-            value={input}
-            onChange={(event) => setInput(event.currentTarget.value)}
-            onKeyDown={(event) => {
-              if (event.key === 'Enter' && !event.shiftKey) {
-                event.preventDefault()
-                handleSend()
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          accept="image/png,image/jpeg,image/webp,image/gif,text/*,application/json"
+          className="hidden"
+          onChange={handleFileInputChange}
+        />
+        {attachments.length > 0 || attachmentError ? (
+          <AttachmentStrip
+            attachments={attachments}
+            onRemove={removeAttachment}
+            error={attachmentError}
+          />
+        ) : null}
+        <div
+          className={cn(
+            'flex gap-3',
+            variant === 'home' ? 'px-4 py-3' : 'px-4 py-3',
+            isExpandedDraft ? 'items-end' : 'items-center',
+          )}
+        >
+          <BotInputIcon variant={variant} />
+          <div className="flex-1">
+            <Textarea
+              ref={textareaRef}
+              value={input}
+              onChange={(event) => setInput(event.currentTarget.value)}
+              onKeyDown={(event) => {
+                if (event.key === 'Enter' && !event.shiftKey) {
+                  event.preventDefault()
+                  handleSend()
+                }
+              }}
+              onPaste={handlePaste}
+              rows={1}
+              placeholder={
+                voice.isTranscribing
+                  ? 'Transcribing...'
+                  : (placeholder ??
+                    `Message ${selectedAgent?.name ?? 'agent'}...`)
               }
+              disabled={disabled || voice.isTranscribing}
+              className={cn(
+                'resize-none border-none bg-transparent px-0 text-[15px] shadow-none focus-visible:ring-0',
+                '[field-sizing:fixed]',
+                variant === 'home'
+                  ? 'min-h-[40px] py-2 leading-6'
+                  : 'min-h-[40px] py-2 leading-6',
+                'placeholder:text-muted-foreground/80',
+              )}
+            />
+          </div>
+          <VoiceButton
+            isRecording={voice.isRecording}
+            isTranscribing={voice.isTranscribing}
+            onStart={() => {
+              void voice.startRecording()
             }}
-            rows={1}
-            placeholder={
+            onStop={() => {
+              void voice.stopRecording()
+            }}
+          />
+          <InputActionButton
+            disabled={
+              !hasContent ||
+              streaming ||
+              isStaging ||
+              !!disabled ||
+              voice.isRecording ||
               voice.isTranscribing
-                ? 'Transcribing...'
-                : (placeholder ??
-                  `Message ${selectedAgent?.name ?? 'agent'}...`)
             }
-            disabled={disabled || voice.isTranscribing}
-            className={cn(
-              'resize-none border-none bg-transparent px-0 text-[15px] shadow-none focus-visible:ring-0',
-              '[field-sizing:fixed]',
-              variant === 'home'
-                ? 'min-h-[40px] py-2 leading-6'
-                : 'min-h-[40px] py-2 leading-6',
-              'placeholder:text-muted-foreground/80',
-            )}
+            onClick={handleSend}
+            streaming={streaming}
           />
         </div>
-        <VoiceButton
-          isRecording={voice.isRecording}
-          isTranscribing={voice.isTranscribing}
-          onStart={() => {
-            void voice.startRecording()
-          }}
-          onStop={() => {
-            void voice.stopRecording()
-          }}
+        {voice.error ? (
+          <div className="px-5 pb-2 text-destructive text-xs">
+            {voice.error}
+          </div>
+        ) : null}
+        <ContextControls
+          agents={agents}
+          onCreateAgent={onCreateAgent}
+          onSelectAgent={onSelectAgent}
+          selectedAgentId={selectedAgentId}
+          selectedTabs={selectedTabs}
+          onToggleTab={toggleTab}
+          showAgentSelector={variant === 'home'}
+          status={status}
+          onAttachClick={openFilePicker}
+          attachDisabled={attachments.length >= 10 || isStaging || !!disabled}
         />
-        <InputActionButton
-          disabled={
-            !input.trim() ||
-            streaming ||
-            !!disabled ||
-            voice.isRecording ||
-            voice.isTranscribing
-          }
-          onClick={handleSend}
-          streaming={streaming}
-        />
-      </div>
-      {voice.error ? (
-        <div className="px-5 pb-2 text-destructive text-xs">{voice.error}</div>
-      ) : null}
-      <ContextControls
-        agents={agents}
-        onCreateAgent={onCreateAgent}
-        onSelectAgent={onSelectAgent}
-        selectedAgentId={selectedAgentId}
-        selectedTabs={selectedTabs}
-        onToggleTab={toggleTab}
-        showAgentSelector={variant === 'home'}
-        status={status}
-      />
+        {isDragOver ? (
+          <div className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-[inherit] bg-background/80 font-medium text-foreground text-sm backdrop-blur-sm">
+            Drop files to attach
+          </div>
+        ) : null}
+      </section>
     </Shell>
+  )
+}
+
+function AttachmentStrip({
+  attachments,
+  onRemove,
+  error,
+}: {
+  attachments: StagedAttachment[]
+  onRemove: (id: string) => void
+  error: string | null
+}) {
+  return (
+    <div className="border-border/40 border-b px-4 pt-3 pb-2">
+      {attachments.length > 0 ? (
+        <div className="flex flex-wrap gap-2">
+          {attachments.map((attachment) => (
+            <AttachmentChip
+              key={attachment.id}
+              attachment={attachment}
+              onRemove={() => onRemove(attachment.id)}
+            />
+          ))}
+        </div>
+      ) : null}
+      {error ? (
+        <div className="mt-2 text-destructive text-xs">{error}</div>
+      ) : null}
+    </div>
+  )
+}
+
+function AttachmentChip({
+  attachment,
+  onRemove,
+}: {
+  attachment: StagedAttachment
+  onRemove: () => void
+}) {
+  if (attachment.kind === 'image' && attachment.dataUrl) {
+    return (
+      <div className="group relative size-16 overflow-hidden rounded-md border border-border/60">
+        <img
+          src={attachment.dataUrl}
+          alt={attachment.name}
+          className="size-full object-cover"
+        />
+        <button
+          type="button"
+          onClick={onRemove}
+          className="absolute top-1 right-1 inline-flex size-5 items-center justify-center rounded-full bg-background/80 text-muted-foreground opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100"
+          aria-label={`Remove ${attachment.name}`}
+        >
+          <X className="size-3" />
+        </button>
+      </div>
+    )
+  }
+  return (
+    <div className="group flex max-w-[220px] items-center gap-2 rounded-md border border-border/60 bg-background/60 px-2 py-1.5">
+      <FileText className="size-4 shrink-0 text-muted-foreground" />
+      <span className="truncate text-xs">{attachment.name}</span>
+      <button
+        type="button"
+        onClick={onRemove}
+        className="ml-1 inline-flex size-4 items-center justify-center text-muted-foreground hover:text-foreground"
+        aria-label={`Remove ${attachment.name}`}
+      >
+        <X className="size-3" />
+      </button>
+    </div>
   )
 }
 

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationMessage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationMessage.tsx
@@ -2,6 +2,8 @@ import { Bot, CheckCircle2, Loader2, Wrench, XCircle } from 'lucide-react'
 import { type FC, useMemo } from 'react'
 import {
   Message,
+  MessageAttachment,
+  MessageAttachments,
   MessageContent,
   MessageResponse,
 } from '@/components/ai-elements/message'
@@ -93,9 +95,26 @@ export const ConversationMessage: FC<ConversationMessageProps> = ({
     <div className="space-y-3">
       <Message from="user">
         <MessageContent>
-          <pre className="whitespace-pre-wrap font-sans text-sm">
-            {turn.userText}
-          </pre>
+          {turn.userAttachments && turn.userAttachments.length > 0 && (
+            <MessageAttachments>
+              {turn.userAttachments.map((attachment) => (
+                <MessageAttachment
+                  key={attachment.id}
+                  data={{
+                    type: 'file',
+                    url: attachment.dataUrl ?? '',
+                    mediaType: attachment.mediaType,
+                    filename: attachment.name,
+                  }}
+                />
+              ))}
+            </MessageAttachments>
+          )}
+          {turn.userText && (
+            <pre className="whitespace-pre-wrap font-sans text-sm">
+              {turn.userText}
+            </pre>
+          )}
         </MessageContent>
       </Message>
 

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/claw-chat-types.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/claw-chat-types.ts
@@ -34,6 +34,16 @@ export interface BrowserOSChatHistoryReasoning {
   durationMs?: number
 }
 
+export interface BrowserOSChatHistoryAttachment {
+  kind: 'image' | 'file'
+  mediaType: string
+  // Images carry a `data:` URL so we can render directly without any
+  // additional fetch; files (text/PDF) currently round-trip via inline
+  // text in the message body and do not populate this field in v1.
+  dataUrl?: string
+  name?: string
+}
+
 export interface BrowserOSChatHistoryItem {
   id: string
   role: ClawChatRole
@@ -47,6 +57,7 @@ export interface BrowserOSChatHistoryItem {
   tokensOut?: number
   toolCalls?: BrowserOSChatHistoryToolCall[]
   reasoning?: BrowserOSChatHistoryReasoning
+  attachments?: BrowserOSChatHistoryAttachment[]
 }
 
 export interface AgentHistoryPageResponse {
@@ -81,6 +92,13 @@ export type ClawChatMessagePart =
       error?: string
       durationMs?: number
     }
+  | {
+      type: 'attachment'
+      kind: 'image' | 'file'
+      mediaType: string
+      dataUrl?: string
+      name?: string
+    }
   | { type: 'meta'; label: string; value: string }
 
 export interface ClawChatMessage {
@@ -101,6 +119,21 @@ export function mapHistoryItemToClawMessage(
   item: BrowserOSChatHistoryItem,
 ): ClawChatMessage {
   const parts: ClawChatMessagePart[] = []
+
+  // Attachments first — they belong above the text in user messages and
+  // never appear on assistant messages today (assistant images come back
+  // through tool results, which render via the Task collapsible).
+  if (item.attachments && item.attachments.length > 0) {
+    for (const attachment of item.attachments) {
+      parts.push({
+        type: 'attachment',
+        kind: attachment.kind,
+        mediaType: attachment.mediaType,
+        dataUrl: attachment.dataUrl,
+        name: attachment.name,
+      })
+    }
+  }
 
   // Reasoning, then tool calls, then text — the chronological order the
   // agent produced them (think → act → answer).
@@ -135,7 +168,11 @@ export function mapHistoryItemToClawMessage(
     }
   }
 
-  parts.push({ type: 'text', text: item.text })
+  // Only emit a text part when there's actual content. User messages with
+  // only attachments and no caption shouldn't render an empty bubble.
+  if (item.text.trim().length > 0) {
+    parts.push({ type: 'text', text: item.text })
+  }
 
   return {
     id: item.id,

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useAgentConversation.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useAgentConversation.ts
@@ -7,9 +7,20 @@ import {
 import type {
   AgentConversationTurn,
   AssistantPart,
+  UserAttachmentPreview,
 } from '@/lib/agent-conversations/types'
+import type { ServerAttachmentPayload } from '@/lib/attachments'
 import { consumeSSEStream } from '@/lib/sse'
 import { buildToolLabel } from '@/lib/tool-labels'
+
+export interface SendInput {
+  text: string
+  attachments?: ServerAttachmentPayload[]
+  // Optional preview metadata used to render the optimistic user turn.
+  // Built by the composer at staging time; the server only sees the
+  // payload array.
+  attachmentPreviews?: UserAttachmentPreview[]
+}
 
 interface UseAgentConversationOptions {
   sessionKey?: string | null
@@ -171,12 +182,22 @@ export function useAgentConversation(
     }
   }
 
-  const send = async (text: string) => {
-    if (!text.trim() || streaming) return
+  const send = async (input: string | SendInput) => {
+    const normalized: SendInput =
+      typeof input === 'string' ? { text: input } : input
+    const trimmed = normalized.text.trim()
+    const attachments = normalized.attachments ?? []
+    if (streaming) return
+    if (!trimmed && attachments.length === 0) return
 
     const turn: AgentConversationTurn = {
       id: crypto.randomUUID(),
-      userText: text.trim(),
+      userText: trimmed,
+      userAttachments:
+        normalized.attachmentPreviews &&
+        normalized.attachmentPreviews.length > 0
+          ? normalized.attachmentPreviews
+          : undefined,
       parts: [],
       done: false,
       timestamp: Date.now(),
@@ -191,10 +212,11 @@ export function useAgentConversation(
     try {
       const response = await chatWithAgent(
         agentId,
-        text.trim(),
+        trimmed,
         sessionKeyRef.current || undefined,
         historyRef.current,
         abortController.signal,
+        attachments,
       )
       const responseSessionKey = response.headers.get('X-Session-Key')
       if (responseSessionKey) {

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useOutboundQueue.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useOutboundQueue.ts
@@ -227,6 +227,14 @@ export function useOutboundQueue(
           if (serverId) {
             previewMapRef.current.set(serverId, { localId, previews })
             previewMapRef.current.delete(localId)
+            // Drop the optimistic entry as soon as the server has
+            // acknowledged it. The server's enqueue broadcasts to SSE
+            // *before* the POST returns, so by the time we land here
+            // the snapshot already carries the canonical entry — the
+            // SSE-based ack path can race the POST response (snapshot
+            // arrives first, doesn't yet know the localId↔serverId
+            // mapping, can't prune), so we also prune here defensively.
+            setLocalItems((prev) => prev.filter((item) => item.id !== localId))
           }
         } catch (err) {
           previewMapRef.current.delete(localId)

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useOutboundQueue.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useOutboundQueue.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
+import type { OpenClawChatHistoryMessage } from '@/entrypoints/app/agents/useOpenClaw'
 import type { UserAttachmentPreview } from '@/lib/agent-conversations/types'
 import type { ServerAttachmentPayload } from '@/lib/attachments'
 import { useAgentServerUrl } from '@/lib/browseros/useBrowserOSProviders'
@@ -25,6 +26,12 @@ export interface OutboundQueueEnqueueInput {
   text: string
   attachments?: ServerAttachmentPayload[]
   attachmentPreviews?: UserAttachmentPreview[]
+  /**
+   * Prior chat turns to forward verbatim. Mirrors the direct chat path so
+   * queued sends never lose conversational context — the queue worker
+   * passes this through to OpenClaw as the message history.
+   */
+  history?: OpenClawChatHistoryMessage[]
 }
 
 export interface OutboundQueueApi {
@@ -89,13 +96,14 @@ export function useOutboundQueue(
   const [serverItems, setServerItems] = useState<OutboundMessage[]>([])
   const [localItems, setLocalItems] = useState<OutboundMessage[]>([])
 
-  // Keep the latest local previews keyed by the local id so when the
-  // server snapshot lands we can carry the data URLs forward onto the
-  // server-issued id (matched by message text + arrival order — best
-  // effort, fine for the chip strip).
-  const localPreviewsRef = useRef<
-    Array<{ text: string; previews: UserAttachmentPreview[] }>
-  >([])
+  // Map local previews onto server-issued ids. The POST response gives us
+  // the server id, and we keep a localId fallback for the brief window
+  // before that response lands. Keying by id (never by message text)
+  // avoids collisions when the user sends two messages with identical
+  // text back-to-back.
+  const previewMapRef = useRef<
+    Map<string, { localId: string; previews: UserAttachmentPreview[] }>
+  >(new Map())
 
   // Subscribe to per-agent queue stream.
   useEffect(() => {
@@ -111,25 +119,37 @@ export function useOutboundQueue(
       try {
         const parsed = JSON.parse(event.data) as { items: ServerQueuedItem[] }
         const next: OutboundMessage[] = parsed.items.map((item) => {
-          const matchedPreview = localPreviewsRef.current.find(
-            (entry) => entry.text === item.message,
-          )
+          const matched = previewMapRef.current.get(item.id)
           return {
             id: item.id,
             text: item.message,
             attachments: [],
-            attachmentPreviews: matchedPreview?.previews ?? [],
+            attachmentPreviews: matched?.previews ?? [],
             status: serverStatusToClient(item.status),
             error: item.error,
             createdAt: item.createdAt,
           }
         })
         setServerItems(next)
-        // Drop any optimistic entries whose text now appears in the
-        // server snapshot — the server has acknowledged them.
+        // Drop optimistic entries that the server has now acknowledged.
+        // We tracked their localId in the preview map alongside the
+        // server id, so when an item's server id appears in the snapshot
+        // its sibling localId is safe to evict.
+        const acknowledgedLocalIds = new Set<string>()
+        for (const item of next) {
+          const matched = previewMapRef.current.get(item.id)
+          if (matched) acknowledgedLocalIds.add(matched.localId)
+        }
         setLocalItems((prev) =>
-          prev.filter((local) => !next.some((s) => s.text === local.text)),
+          prev.filter((local) => !acknowledgedLocalIds.has(local.id)),
         )
+        // Prune preview entries whose server item is no longer in the
+        // snapshot — once the queue drains it we can free the data URLs.
+        const liveIds = new Set(next.map((item) => item.id))
+        for (const id of previewMapRef.current.keys()) {
+          if (id.startsWith(LOCAL_PREFIX)) continue
+          if (!liveIds.has(id)) previewMapRef.current.delete(id)
+        }
       } catch {
         // Malformed event — ignore; next snapshot will recover.
       }
@@ -162,12 +182,12 @@ export function useOutboundQueue(
         createdAt: Date.now(),
       }
       setLocalItems((prev) => [...prev, optimistic])
-      // Remember the previews so they can be re-attached when the server
-      // snapshot replaces the optimistic entry.
-      localPreviewsRef.current = [
-        ...localPreviewsRef.current,
-        { text: trimmed, previews },
-      ]
+      // Stage previews under the localId until the server responds with
+      // the real id. Once we have that id we re-key under it so SSE
+      // snapshots can match.
+      if (previews.length > 0) {
+        previewMapRef.current.set(localId, { localId, previews })
+      }
 
       void (async () => {
         try {
@@ -180,11 +200,13 @@ export function useOutboundQueue(
                 message: trimmed,
                 attachments: attachments.length > 0 ? attachments : undefined,
                 sessionKey: sessionKeyRef.current ?? undefined,
+                history: input.history,
               }),
             },
           )
           if (!response.ok) {
             const text = await response.text().catch(() => '')
+            previewMapRef.current.delete(localId)
             setLocalItems((prev) =>
               prev.map((item) =>
                 item.id === localId
@@ -197,8 +219,18 @@ export function useOutboundQueue(
                   : item,
               ),
             )
+            return
+          }
+          const payload = (await response.json().catch(() => null)) as {
+            id?: string
+          } | null
+          const serverId = payload?.id
+          if (serverId && previews.length > 0) {
+            previewMapRef.current.set(serverId, { localId, previews })
+            previewMapRef.current.delete(localId)
           }
         } catch (err) {
+          previewMapRef.current.delete(localId)
           setLocalItems((prev) =>
             prev.map((item) =>
               item.id === localId
@@ -222,6 +254,7 @@ export function useOutboundQueue(
   const cancel = useCallback(
     (id: string) => {
       if (id.startsWith(LOCAL_PREFIX)) {
+        previewMapRef.current.delete(id)
         setLocalItems((prev) => prev.filter((item) => item.id !== id))
         return
       }

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useOutboundQueue.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useOutboundQueue.ts
@@ -1,0 +1,154 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { UserAttachmentPreview } from '@/lib/agent-conversations/types'
+import type { ServerAttachmentPayload } from '@/lib/attachments'
+import type { SendInput } from './useAgentConversation'
+
+export type OutboundMessageStatus = 'queued' | 'sending' | 'failed'
+
+export interface OutboundMessage {
+  id: string
+  text: string
+  attachments: ServerAttachmentPayload[]
+  attachmentPreviews: UserAttachmentPreview[]
+  status: OutboundMessageStatus
+  error?: string
+  createdAt: number
+}
+
+export interface OutboundQueueEnqueueInput {
+  text: string
+  attachments?: ServerAttachmentPayload[]
+  attachmentPreviews?: UserAttachmentPreview[]
+}
+
+export interface OutboundQueueApi {
+  queue: OutboundMessage[]
+  enqueue(input: OutboundQueueEnqueueInput): void
+  cancel(id: string): void
+  retry(id: string): void
+}
+
+interface UseOutboundQueueOptions {
+  send: (input: SendInput) => Promise<void>
+  streaming: boolean
+}
+
+function makeId(): string {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID()
+  }
+  return `outbound-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+/**
+ * Client-side outbound queue for agent chat sends. Allows the user to keep
+ * typing while the agent is mid-turn — each enqueued message is delivered
+ * as soon as `streaming` flips false (i.e., the prior turn finished).
+ *
+ * The hook owns no scheduling timers; it reacts to `streaming` transitions
+ * and to enqueue calls. The worker is single-flight by design — only one
+ * message is dispatched at a time, in arrival order.
+ */
+export function useOutboundQueue(
+  options: UseOutboundQueueOptions,
+): OutboundQueueApi {
+  const { send, streaming } = options
+  const [queue, setQueue] = useState<OutboundMessage[]>([])
+  const sendRef = useRef(send)
+  sendRef.current = send
+
+  // Re-entrancy guard: while a queued item is mid-dispatch we don't want
+  // a streaming flip to kick off a second simultaneous dispatch.
+  const dispatchingRef = useRef(false)
+
+  const setStatus = useCallback(
+    (id: string, status: OutboundMessageStatus, error?: string) => {
+      setQueue((prev) =>
+        prev.map((m) =>
+          m.id === id
+            ? { ...m, status, error: status === 'failed' ? error : undefined }
+            : m,
+        ),
+      )
+    },
+    [],
+  )
+
+  const removeItem = useCallback((id: string) => {
+    setQueue((prev) => prev.filter((m) => m.id !== id))
+  }, [])
+
+  const enqueue = useCallback((input: OutboundQueueEnqueueInput) => {
+    const trimmed = input.text.trim()
+    const attachments = input.attachments ?? []
+    if (!trimmed && attachments.length === 0) return
+    const message: OutboundMessage = {
+      id: makeId(),
+      text: trimmed,
+      attachments,
+      attachmentPreviews: input.attachmentPreviews ?? [],
+      status: 'queued',
+      createdAt: Date.now(),
+    }
+    setQueue((prev) => [...prev, message])
+  }, [])
+
+  const cancel = useCallback((id: string) => {
+    setQueue((prev) => {
+      const target = prev.find((m) => m.id === id)
+      // Only allow cancelling items that haven't started sending yet.
+      // Sending items are owned by the SSE stream and need a separate
+      // abort path (deferred to v2).
+      if (!target || target.status === 'sending') return prev
+      return prev.filter((m) => m.id !== id)
+    })
+  }, [])
+
+  const retry = useCallback((id: string) => {
+    setQueue((prev) =>
+      prev.map((m) =>
+        m.id === id && m.status === 'failed'
+          ? { ...m, status: 'queued', error: undefined }
+          : m,
+      ),
+    )
+  }, [])
+
+  // Drain the queue whenever `streaming` is false and we have a head item
+  // in `queued`. The effect runs on every queue/streaming change but the
+  // dispatching ref keeps it single-flight.
+  useEffect(() => {
+    if (streaming) return
+    if (dispatchingRef.current) return
+    const head = queue.find((m) => m.status === 'queued')
+    if (!head) return
+
+    let cancelled = false
+    dispatchingRef.current = true
+    setStatus(head.id, 'sending')
+    ;(async () => {
+      try {
+        await sendRef.current({
+          text: head.text,
+          attachments: head.attachments,
+          attachmentPreviews: head.attachmentPreviews,
+        })
+        if (!cancelled) removeItem(head.id)
+      } catch (err) {
+        if (!cancelled) {
+          const message =
+            err instanceof Error ? err.message : 'Failed to send message'
+          setStatus(head.id, 'failed', message)
+        }
+      } finally {
+        dispatchingRef.current = false
+      }
+    })()
+
+    return () => {
+      cancelled = true
+    }
+  }, [queue, streaming, removeItem, setStatus])
+
+  return { queue, enqueue, cancel, retry }
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useOutboundQueue.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useOutboundQueue.ts
@@ -36,6 +36,13 @@ export interface OutboundQueueApi {
 
 interface UseOutboundQueueOptions {
   agentId: string | null | undefined
+  /**
+   * Current resolved sessionKey for the active conversation. The hook
+   * forwards it to the server on every enqueue so the queue worker
+   * targets the same OpenClaw session the user is actively viewing.
+   * Null means "no session yet" — the server will allocate one.
+   */
+  sessionKey?: string | null
 }
 
 interface ServerQueuedItem {
@@ -73,8 +80,12 @@ function makeLocalId(): string {
 export function useOutboundQueue(
   options: UseOutboundQueueOptions,
 ): OutboundQueueApi {
-  const { agentId } = options
+  const { agentId, sessionKey } = options
   const { baseUrl } = useAgentServerUrl()
+  // Keep the latest sessionKey in a ref so enqueue's closure always sees
+  // the freshest value without re-creating the callback on every change.
+  const sessionKeyRef = useRef<string | null | undefined>(sessionKey)
+  sessionKeyRef.current = sessionKey
   const [serverItems, setServerItems] = useState<OutboundMessage[]>([])
   const [localItems, setLocalItems] = useState<OutboundMessage[]>([])
 
@@ -168,6 +179,7 @@ export function useOutboundQueue(
               body: JSON.stringify({
                 message: trimmed,
                 attachments: attachments.length > 0 ? attachments : undefined,
+                sessionKey: sessionKeyRef.current ?? undefined,
               }),
             },
           )

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useOutboundQueue.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useOutboundQueue.ts
@@ -6,12 +6,6 @@ import { useAgentServerUrl } from '@/lib/browseros/useBrowserOSProviders'
 
 export type OutboundMessageStatus = 'queued' | 'sending' | 'failed'
 
-/**
- * The composer renders this shape. It mirrors the server's QueuedItemPublic
- * but adds local-only `attachmentPreviews` (data URLs) so chip thumbnails
- * keep rendering while a message is in flight to / on the server. Those
- * data URLs never leave the browser; the SSE feed only carries metadata.
- */
 export interface OutboundMessage {
   id: string
   text: string
@@ -26,11 +20,6 @@ export interface OutboundQueueEnqueueInput {
   text: string
   attachments?: ServerAttachmentPayload[]
   attachmentPreviews?: UserAttachmentPreview[]
-  /**
-   * Prior chat turns to forward verbatim. Mirrors the direct chat path so
-   * queued sends never lose conversational context — the queue worker
-   * passes this through to OpenClaw as the message history.
-   */
   history?: OpenClawChatHistoryMessage[]
 }
 
@@ -43,12 +32,6 @@ export interface OutboundQueueApi {
 
 interface UseOutboundQueueOptions {
   agentId: string | null | undefined
-  /**
-   * Current resolved sessionKey for the active conversation. The hook
-   * forwards it to the server on every enqueue so the queue worker
-   * targets the same OpenClaw session the user is actively viewing.
-   * Null means "no session yet" — the server will allocate one.
-   */
   sessionKey?: string | null
 }
 
@@ -65,13 +48,11 @@ interface ServerQueuedItem {
   createdAt: number
 }
 
-const LOCAL_PREFIX = 'local-'
-
-function makeLocalId(): string {
+function makeId(): string {
   if (typeof crypto !== 'undefined' && crypto.randomUUID) {
-    return `${LOCAL_PREFIX}${crypto.randomUUID()}`
+    return crypto.randomUUID()
   }
-  return `${LOCAL_PREFIX}${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
 }
 
 /**
@@ -79,41 +60,35 @@ function makeLocalId(): string {
  * projection of server state — closing the tab is safe because the queue
  * keeps draining server-side via the OutboundQueueService.
  *
- * The hook still exposes the same `{ queue, enqueue, cancel, retry }`
- * surface the composer expects. `enqueue` POSTs to /queue and shows an
- * optimistic local entry until the server's SSE snapshot reflects it
- * (then the optimistic entry is replaced).
+ * Single id-keyed list: the client generates the queue id and hands it
+ * to the server in the POST body, so the optimistic row and the SSE
+ * snapshot reconcile on the same key from frame zero — there is no
+ * window in which the message renders twice.
  */
 export function useOutboundQueue(
   options: UseOutboundQueueOptions,
 ): OutboundQueueApi {
   const { agentId, sessionKey } = options
   const { baseUrl } = useAgentServerUrl()
-  // Keep the latest sessionKey in a ref so enqueue's closure always sees
-  // the freshest value without re-creating the callback on every change.
   const sessionKeyRef = useRef<string | null | undefined>(sessionKey)
   sessionKeyRef.current = sessionKey
-  const [serverItems, setServerItems] = useState<OutboundMessage[]>([])
-  const [localItems, setLocalItems] = useState<OutboundMessage[]>([])
-  // Mirror serverItems into a ref so the POST-success branch can
-  // synchronously check whether the SSE snapshot has already landed
-  // for the new server id without depending on a stale closure.
-  const serverItemsRef = useRef<OutboundMessage[]>(serverItems)
-  serverItemsRef.current = serverItems
 
-  // Map local previews onto server-issued ids. The POST response gives us
-  // the server id, and we keep a localId fallback for the brief window
-  // before that response lands. Keying by id (never by message text)
-  // avoids collisions when the user sends two messages with identical
-  // text back-to-back.
-  const previewMapRef = useRef<
-    Map<string, { localId: string; previews: UserAttachmentPreview[] }>
-  >(new Map())
+  const [items, setItems] = useState<OutboundMessage[]>([])
+  // Track which ids the server has confirmed seeing in any SSE snapshot.
+  // We use this to know whether a missing-from-snapshot id is "drained
+  // by the server" (drop it) or "still in flight client-side" (keep
+  // showing the optimistic row).
+  const everSeenByServerRef = useRef<Set<string>>(new Set())
+  // Local-only attachment previews, keyed by queue id. Data URLs never
+  // leave the browser — the SSE feed only carries metadata, so we hold
+  // them here so the chip strip keeps rendering after server takeover.
+  const previewMapRef = useRef<Map<string, UserAttachmentPreview[]>>(new Map())
 
-  // Subscribe to per-agent queue stream.
   useEffect(() => {
     if (!baseUrl || !agentId) {
-      setServerItems([])
+      setItems([])
+      everSeenByServerRef.current = new Set()
+      previewMapRef.current = new Map()
       return
     }
     let cancelled = false
@@ -123,45 +98,39 @@ export function useOutboundQueue(
       if (cancelled) return
       try {
         const parsed = JSON.parse(event.data) as { items: ServerQueuedItem[] }
-        const next: OutboundMessage[] = parsed.items.map((item) => {
-          const matched = previewMapRef.current.get(item.id)
-          return {
+        const snapshotIds = new Set(parsed.items.map((item) => item.id))
+        for (const id of snapshotIds) everSeenByServerRef.current.add(id)
+
+        setItems((prev) => {
+          const next: OutboundMessage[] = parsed.items.map((item) => ({
             id: item.id,
             text: item.message,
             attachments: [],
-            attachmentPreviews: matched?.previews ?? [],
+            attachmentPreviews: previewMapRef.current.get(item.id) ?? [],
             status: serverStatusToClient(item.status),
             error: item.error,
             createdAt: item.createdAt,
-          }
+          }))
+          // Carry forward any optimistic / failed entries the server
+          // doesn't know about yet (POST in flight) or has finished
+          // dispatching but the client wants to keep visible (failed).
+          const carried = prev.filter((local) => {
+            if (snapshotIds.has(local.id)) return false
+            if (everSeenByServerRef.current.has(local.id)) {
+              // Server saw it before and it's gone now — drained.
+              previewMapRef.current.delete(local.id)
+              return false
+            }
+            return local.status !== 'failed' || Boolean(local.error)
+          })
+          return [...carried, ...next]
         })
-        setServerItems(next)
-        // Drop optimistic entries that the server has now acknowledged.
-        // We tracked their localId in the preview map alongside the
-        // server id, so when an item's server id appears in the snapshot
-        // its sibling localId is safe to evict.
-        const acknowledgedLocalIds = new Set<string>()
-        for (const item of next) {
-          const matched = previewMapRef.current.get(item.id)
-          if (matched) acknowledgedLocalIds.add(matched.localId)
-        }
-        setLocalItems((prev) =>
-          prev.filter((local) => !acknowledgedLocalIds.has(local.id)),
-        )
-        // Prune preview entries whose server item is no longer in the
-        // snapshot — once the queue drains it we can free the data URLs.
-        const liveIds = new Set(next.map((item) => item.id))
-        for (const id of previewMapRef.current.keys()) {
-          if (id.startsWith(LOCAL_PREFIX)) continue
-          if (!liveIds.has(id)) previewMapRef.current.delete(id)
-        }
       } catch {
         // Malformed event — ignore; next snapshot will recover.
       }
     }
     source.onerror = () => {
-      // Connection issues are transient (server restart, network blip).
-      // EventSource auto-reconnects; nothing to do here.
+      // Auto-reconnects; nothing to do here.
     }
     return () => {
       cancelled = true
@@ -176,22 +145,20 @@ export function useOutboundQueue(
       const attachments = input.attachments ?? []
       if (!trimmed && attachments.length === 0) return
 
-      const localId = makeLocalId()
+      const id = makeId()
       const previews = input.attachmentPreviews ?? []
-      const optimistic: OutboundMessage = {
-        id: localId,
-        text: trimmed,
-        attachments,
-        attachmentPreviews: previews,
-        status: 'queued',
-        createdAt: Date.now(),
-      }
-      setLocalItems((prev) => [...prev, optimistic])
-      // Always stage a map entry under the localId — even for text-only
-      // sends — so the SSE snapshot can match the optimistic entry to
-      // its server id and prune the duplicate. The previews array may
-      // be empty; what matters is the localId↔serverId link.
-      previewMapRef.current.set(localId, { localId, previews })
+      previewMapRef.current.set(id, previews)
+      setItems((prev) => [
+        ...prev,
+        {
+          id,
+          text: trimmed,
+          attachments,
+          attachmentPreviews: previews,
+          status: 'queued',
+          createdAt: Date.now(),
+        },
+      ])
 
       void (async () => {
         try {
@@ -201,6 +168,7 @@ export function useOutboundQueue(
               method: 'POST',
               headers: { 'Content-Type': 'application/json' },
               body: JSON.stringify({
+                id,
                 message: trimmed,
                 attachments: attachments.length > 0 ? attachments : undefined,
                 sessionKey: sessionKeyRef.current ?? undefined,
@@ -210,10 +178,10 @@ export function useOutboundQueue(
           )
           if (!response.ok) {
             const text = await response.text().catch(() => '')
-            previewMapRef.current.delete(localId)
-            setLocalItems((prev) =>
+            previewMapRef.current.delete(id)
+            setItems((prev) =>
               prev.map((item) =>
-                item.id === localId
+                item.id === id
                   ? {
                       ...item,
                       status: 'failed',
@@ -223,32 +191,16 @@ export function useOutboundQueue(
                   : item,
               ),
             )
-            return
-          }
-          const payload = (await response.json().catch(() => null)) as {
-            id?: string
-          } | null
-          const serverId = payload?.id
-          if (serverId) {
-            previewMapRef.current.set(serverId, { localId, previews })
-            previewMapRef.current.delete(localId)
-            // Only prune the optimistic entry now if the SSE snapshot
-            // has already arrived with this server id. Otherwise leave
-            // it visible — pruning here without a server entry to take
-            // its place causes a one-frame flicker where the message
-            // disappears entirely. The SSE handler now has the map
-            // populated and will dedupe as soon as the snapshot lands.
-            if (serverItemsRef.current.some((item) => item.id === serverId)) {
-              setLocalItems((prev) =>
-                prev.filter((item) => item.id !== localId),
-              )
-            }
           }
         } catch (err) {
-          previewMapRef.current.delete(localId)
-          setLocalItems((prev) =>
+          // Only mark as failed if the SSE snapshot hasn't already
+          // taken ownership of the entry (i.e. the request actually
+          // reached the server).
+          if (everSeenByServerRef.current.has(id)) return
+          previewMapRef.current.delete(id)
+          setItems((prev) =>
             prev.map((item) =>
-              item.id === localId
+              item.id === id
                 ? {
                     ...item,
                     status: 'failed',
@@ -268,9 +220,10 @@ export function useOutboundQueue(
 
   const cancel = useCallback(
     (id: string) => {
-      if (id.startsWith(LOCAL_PREFIX)) {
+      // If the server has never seen this id, just drop it locally.
+      if (!everSeenByServerRef.current.has(id)) {
         previewMapRef.current.delete(id)
-        setLocalItems((prev) => prev.filter((item) => item.id !== id))
+        setItems((prev) => prev.filter((item) => item.id !== id))
         return
       }
       if (!baseUrl || !agentId) return
@@ -284,11 +237,10 @@ export function useOutboundQueue(
 
   const retry = useCallback(
     (id: string) => {
-      if (id.startsWith(LOCAL_PREFIX)) {
-        // Optimistic local items don't have a server id yet — reset them
-        // to 'queued' so the user can press Send again. Caller is
-        // expected to re-enqueue manually for v1.
-        setLocalItems((prev) =>
+      if (!everSeenByServerRef.current.has(id)) {
+        // Optimistic-only entry, never made it to the server. Reset
+        // status so the user can press Send again.
+        setItems((prev) =>
           prev.map((item) =>
             item.id === id
               ? { ...item, status: 'queued', error: undefined }
@@ -306,12 +258,7 @@ export function useOutboundQueue(
     [baseUrl, agentId],
   )
 
-  // Order: local optimistic entries first (just-pressed), then server
-  // entries. When the SSE snapshot arrives, the local entry for the same
-  // text has already been pruned above, so this never duplicates.
-  const queue = [...localItems, ...serverItems]
-
-  return { queue, enqueue, cancel, retry }
+  return { queue: items, enqueue, cancel, retry }
 }
 
 function serverStatusToClient(

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useOutboundQueue.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useOutboundQueue.ts
@@ -95,6 +95,11 @@ export function useOutboundQueue(
   sessionKeyRef.current = sessionKey
   const [serverItems, setServerItems] = useState<OutboundMessage[]>([])
   const [localItems, setLocalItems] = useState<OutboundMessage[]>([])
+  // Mirror serverItems into a ref so the POST-success branch can
+  // synchronously check whether the SSE snapshot has already landed
+  // for the new server id without depending on a stale closure.
+  const serverItemsRef = useRef<OutboundMessage[]>(serverItems)
+  serverItemsRef.current = serverItems
 
   // Map local previews onto server-issued ids. The POST response gives us
   // the server id, and we keep a localId fallback for the brief window
@@ -227,14 +232,17 @@ export function useOutboundQueue(
           if (serverId) {
             previewMapRef.current.set(serverId, { localId, previews })
             previewMapRef.current.delete(localId)
-            // Drop the optimistic entry as soon as the server has
-            // acknowledged it. The server's enqueue broadcasts to SSE
-            // *before* the POST returns, so by the time we land here
-            // the snapshot already carries the canonical entry — the
-            // SSE-based ack path can race the POST response (snapshot
-            // arrives first, doesn't yet know the localId↔serverId
-            // mapping, can't prune), so we also prune here defensively.
-            setLocalItems((prev) => prev.filter((item) => item.id !== localId))
+            // Only prune the optimistic entry now if the SSE snapshot
+            // has already arrived with this server id. Otherwise leave
+            // it visible — pruning here without a server entry to take
+            // its place causes a one-frame flicker where the message
+            // disappears entirely. The SSE handler now has the map
+            // populated and will dedupe as soon as the snapshot lands.
+            if (serverItemsRef.current.some((item) => item.id === serverId)) {
+              setLocalItems((prev) =>
+                prev.filter((item) => item.id !== localId),
+              )
+            }
           }
         } catch (err) {
           previewMapRef.current.delete(localId)

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useOutboundQueue.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useOutboundQueue.ts
@@ -1,10 +1,16 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import type { UserAttachmentPreview } from '@/lib/agent-conversations/types'
 import type { ServerAttachmentPayload } from '@/lib/attachments'
-import type { SendInput } from './useAgentConversation'
+import { useAgentServerUrl } from '@/lib/browseros/useBrowserOSProviders'
 
 export type OutboundMessageStatus = 'queued' | 'sending' | 'failed'
 
+/**
+ * The composer renders this shape. It mirrors the server's QueuedItemPublic
+ * but adds local-only `attachmentPreviews` (data URLs) so chip thumbnails
+ * keep rendering while a message is in flight to / on the server. Those
+ * data URLs never leave the browser; the SSE feed only carries metadata.
+ */
 export interface OutboundMessage {
   id: string
   text: string
@@ -29,126 +35,229 @@ export interface OutboundQueueApi {
 }
 
 interface UseOutboundQueueOptions {
-  send: (input: SendInput) => Promise<void>
-  streaming: boolean
+  agentId: string | null | undefined
 }
 
-function makeId(): string {
+interface ServerQueuedItem {
+  id: string
+  status: 'queued' | 'dispatching' | 'failed'
+  message: string
+  attachmentsPreview: Array<{
+    kind: 'image' | 'file'
+    mediaType: string
+    name?: string
+  }>
+  error?: string
+  createdAt: number
+}
+
+const LOCAL_PREFIX = 'local-'
+
+function makeLocalId(): string {
   if (typeof crypto !== 'undefined' && crypto.randomUUID) {
-    return crypto.randomUUID()
+    return `${LOCAL_PREFIX}${crypto.randomUUID()}`
   }
-  return `outbound-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+  return `${LOCAL_PREFIX}${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
 }
 
 /**
- * Client-side outbound queue for agent chat sends. Allows the user to keep
- * typing while the agent is mid-turn — each enqueued message is delivered
- * as soon as `streaming` flips false (i.e., the prior turn finished).
+ * Server-backed outbound message queue. The browser is purely a
+ * projection of server state — closing the tab is safe because the queue
+ * keeps draining server-side via the OutboundQueueService.
  *
- * The hook owns no scheduling timers; it reacts to `streaming` transitions
- * and to enqueue calls. The worker is single-flight by design — only one
- * message is dispatched at a time, in arrival order.
+ * The hook still exposes the same `{ queue, enqueue, cancel, retry }`
+ * surface the composer expects. `enqueue` POSTs to /queue and shows an
+ * optimistic local entry until the server's SSE snapshot reflects it
+ * (then the optimistic entry is replaced).
  */
 export function useOutboundQueue(
   options: UseOutboundQueueOptions,
 ): OutboundQueueApi {
-  const { send, streaming } = options
-  const [queue, setQueue] = useState<OutboundMessage[]>([])
-  const sendRef = useRef(send)
-  sendRef.current = send
+  const { agentId } = options
+  const { baseUrl } = useAgentServerUrl()
+  const [serverItems, setServerItems] = useState<OutboundMessage[]>([])
+  const [localItems, setLocalItems] = useState<OutboundMessage[]>([])
 
-  // Re-entrancy guard: while a queued item is mid-dispatch we don't want
-  // a streaming flip to kick off a second simultaneous dispatch.
-  const dispatchingRef = useRef(false)
+  // Keep the latest local previews keyed by the local id so when the
+  // server snapshot lands we can carry the data URLs forward onto the
+  // server-issued id (matched by message text + arrival order — best
+  // effort, fine for the chip strip).
+  const localPreviewsRef = useRef<
+    Array<{ text: string; previews: UserAttachmentPreview[] }>
+  >([])
 
-  const setStatus = useCallback(
-    (id: string, status: OutboundMessageStatus, error?: string) => {
-      setQueue((prev) =>
-        prev.map((m) =>
-          m.id === id
-            ? { ...m, status, error: status === 'failed' ? error : undefined }
-            : m,
-        ),
-      )
-    },
-    [],
-  )
-
-  const removeItem = useCallback((id: string) => {
-    setQueue((prev) => prev.filter((m) => m.id !== id))
-  }, [])
-
-  const enqueue = useCallback((input: OutboundQueueEnqueueInput) => {
-    const trimmed = input.text.trim()
-    const attachments = input.attachments ?? []
-    if (!trimmed && attachments.length === 0) return
-    const message: OutboundMessage = {
-      id: makeId(),
-      text: trimmed,
-      attachments,
-      attachmentPreviews: input.attachmentPreviews ?? [],
-      status: 'queued',
-      createdAt: Date.now(),
-    }
-    setQueue((prev) => [...prev, message])
-  }, [])
-
-  const cancel = useCallback((id: string) => {
-    setQueue((prev) => {
-      const target = prev.find((m) => m.id === id)
-      // Only allow cancelling items that haven't started sending yet.
-      // Sending items are owned by the SSE stream and need a separate
-      // abort path (deferred to v2).
-      if (!target || target.status === 'sending') return prev
-      return prev.filter((m) => m.id !== id)
-    })
-  }, [])
-
-  const retry = useCallback((id: string) => {
-    setQueue((prev) =>
-      prev.map((m) =>
-        m.id === id && m.status === 'failed'
-          ? { ...m, status: 'queued', error: undefined }
-          : m,
-      ),
-    )
-  }, [])
-
-  // Drain the queue whenever `streaming` is false and we have a head item
-  // in `queued`. The effect runs on every queue/streaming change but the
-  // dispatching ref keeps it single-flight.
+  // Subscribe to per-agent queue stream.
   useEffect(() => {
-    if (streaming) return
-    if (dispatchingRef.current) return
-    const head = queue.find((m) => m.status === 'queued')
-    if (!head) return
-
+    if (!baseUrl || !agentId) {
+      setServerItems([])
+      return
+    }
     let cancelled = false
-    dispatchingRef.current = true
-    setStatus(head.id, 'sending')
-    ;(async () => {
+    const url = `${baseUrl}/claw/agents/${encodeURIComponent(agentId)}/queue/stream`
+    const source = new EventSource(url)
+    source.onmessage = (event) => {
+      if (cancelled) return
       try {
-        await sendRef.current({
-          text: head.text,
-          attachments: head.attachments,
-          attachmentPreviews: head.attachmentPreviews,
+        const parsed = JSON.parse(event.data) as { items: ServerQueuedItem[] }
+        const next: OutboundMessage[] = parsed.items.map((item) => {
+          const matchedPreview = localPreviewsRef.current.find(
+            (entry) => entry.text === item.message,
+          )
+          return {
+            id: item.id,
+            text: item.message,
+            attachments: [],
+            attachmentPreviews: matchedPreview?.previews ?? [],
+            status: serverStatusToClient(item.status),
+            error: item.error,
+            createdAt: item.createdAt,
+          }
         })
-        if (!cancelled) removeItem(head.id)
-      } catch (err) {
-        if (!cancelled) {
-          const message =
-            err instanceof Error ? err.message : 'Failed to send message'
-          setStatus(head.id, 'failed', message)
-        }
-      } finally {
-        dispatchingRef.current = false
+        setServerItems(next)
+        // Drop any optimistic entries whose text now appears in the
+        // server snapshot — the server has acknowledged them.
+        setLocalItems((prev) =>
+          prev.filter((local) => !next.some((s) => s.text === local.text)),
+        )
+      } catch {
+        // Malformed event — ignore; next snapshot will recover.
       }
-    })()
-
+    }
+    source.onerror = () => {
+      // Connection issues are transient (server restart, network blip).
+      // EventSource auto-reconnects; nothing to do here.
+    }
     return () => {
       cancelled = true
+      source.close()
     }
-  }, [queue, streaming, removeItem, setStatus])
+  }, [baseUrl, agentId])
+
+  const enqueue = useCallback(
+    (input: OutboundQueueEnqueueInput) => {
+      if (!baseUrl || !agentId) return
+      const trimmed = input.text.trim()
+      const attachments = input.attachments ?? []
+      if (!trimmed && attachments.length === 0) return
+
+      const localId = makeLocalId()
+      const previews = input.attachmentPreviews ?? []
+      const optimistic: OutboundMessage = {
+        id: localId,
+        text: trimmed,
+        attachments,
+        attachmentPreviews: previews,
+        status: 'queued',
+        createdAt: Date.now(),
+      }
+      setLocalItems((prev) => [...prev, optimistic])
+      // Remember the previews so they can be re-attached when the server
+      // snapshot replaces the optimistic entry.
+      localPreviewsRef.current = [
+        ...localPreviewsRef.current,
+        { text: trimmed, previews },
+      ]
+
+      void (async () => {
+        try {
+          const response = await fetch(
+            `${baseUrl}/claw/agents/${encodeURIComponent(agentId)}/queue`,
+            {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({
+                message: trimmed,
+                attachments: attachments.length > 0 ? attachments : undefined,
+              }),
+            },
+          )
+          if (!response.ok) {
+            const text = await response.text().catch(() => '')
+            setLocalItems((prev) =>
+              prev.map((item) =>
+                item.id === localId
+                  ? {
+                      ...item,
+                      status: 'failed',
+                      error:
+                        text || `Failed to enqueue (status ${response.status})`,
+                    }
+                  : item,
+              ),
+            )
+          }
+        } catch (err) {
+          setLocalItems((prev) =>
+            prev.map((item) =>
+              item.id === localId
+                ? {
+                    ...item,
+                    status: 'failed',
+                    error:
+                      err instanceof Error
+                        ? err.message
+                        : 'Failed to enqueue message',
+                  }
+                : item,
+            ),
+          )
+        }
+      })()
+    },
+    [baseUrl, agentId],
+  )
+
+  const cancel = useCallback(
+    (id: string) => {
+      if (id.startsWith(LOCAL_PREFIX)) {
+        setLocalItems((prev) => prev.filter((item) => item.id !== id))
+        return
+      }
+      if (!baseUrl || !agentId) return
+      void fetch(
+        `${baseUrl}/claw/agents/${encodeURIComponent(agentId)}/queue/${encodeURIComponent(id)}`,
+        { method: 'DELETE' },
+      ).catch(() => {})
+    },
+    [baseUrl, agentId],
+  )
+
+  const retry = useCallback(
+    (id: string) => {
+      if (id.startsWith(LOCAL_PREFIX)) {
+        // Optimistic local items don't have a server id yet — reset them
+        // to 'queued' so the user can press Send again. Caller is
+        // expected to re-enqueue manually for v1.
+        setLocalItems((prev) =>
+          prev.map((item) =>
+            item.id === id
+              ? { ...item, status: 'queued', error: undefined }
+              : item,
+          ),
+        )
+        return
+      }
+      if (!baseUrl || !agentId) return
+      void fetch(
+        `${baseUrl}/claw/agents/${encodeURIComponent(agentId)}/queue/${encodeURIComponent(id)}/retry`,
+        { method: 'POST' },
+      ).catch(() => {})
+    },
+    [baseUrl, agentId],
+  )
+
+  // Order: local optimistic entries first (just-pressed), then server
+  // entries. When the SSE snapshot arrives, the local entry for the same
+  // text has already been pruned above, so this never duplicates.
+  const queue = [...localItems, ...serverItems]
 
   return { queue, enqueue, cancel, retry }
+}
+
+function serverStatusToClient(
+  status: ServerQueuedItem['status'],
+): OutboundMessageStatus {
+  if (status === 'dispatching') return 'sending'
+  if (status === 'failed') return 'failed'
+  return 'queued'
 }

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useOutboundQueue.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useOutboundQueue.ts
@@ -182,12 +182,11 @@ export function useOutboundQueue(
         createdAt: Date.now(),
       }
       setLocalItems((prev) => [...prev, optimistic])
-      // Stage previews under the localId until the server responds with
-      // the real id. Once we have that id we re-key under it so SSE
-      // snapshots can match.
-      if (previews.length > 0) {
-        previewMapRef.current.set(localId, { localId, previews })
-      }
+      // Always stage a map entry under the localId — even for text-only
+      // sends — so the SSE snapshot can match the optimistic entry to
+      // its server id and prune the duplicate. The previews array may
+      // be empty; what matters is the localId↔serverId link.
+      previewMapRef.current.set(localId, { localId, previews })
 
       void (async () => {
         try {
@@ -225,7 +224,7 @@ export function useOutboundQueue(
             id?: string
           } | null
           const serverId = payload?.id
-          if (serverId && previews.length > 0) {
+          if (serverId) {
             previewMapRef.current.set(serverId, { localId, previews })
             previewMapRef.current.delete(localId)
           }

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/useOpenClaw.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/useOpenClaw.ts
@@ -317,12 +317,18 @@ export async function chatWithAgent(
   sessionKey?: string,
   history: OpenClawChatHistoryMessage[] = [],
   signal?: AbortSignal,
+  attachments?: ReadonlyArray<unknown>,
 ): Promise<Response> {
   const baseUrl = await getAgentServerUrl()
   return fetch(`${baseUrl}/claw/agents/${agentId}/chat`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ message, sessionKey, history }),
+    body: JSON.stringify({
+      message,
+      sessionKey,
+      history,
+      ...(attachments && attachments.length > 0 ? { attachments } : {}),
+    }),
     signal,
   })
 }

--- a/packages/browseros-agent/apps/agent/lib/agent-conversations/types.ts
+++ b/packages/browseros-agent/apps/agent/lib/agent-conversations/types.ts
@@ -28,9 +28,24 @@ export type AssistantPart =
   | AssistantThinkingPart
   | AssistantToolBatchPart
 
+/**
+ * Attachments rendered alongside the user's text on the optimistic turn
+ * — populated when the composer staged any images/files. The dataUrl is
+ * the same one the server received; we keep it in memory only for the
+ * lifetime of the live turn (history reload re-fetches via the JSONL).
+ */
+export interface UserAttachmentPreview {
+  id: string
+  kind: 'image' | 'file'
+  mediaType: string
+  name: string
+  dataUrl?: string
+}
+
 export interface AgentConversationTurn {
   id: string
   userText: string
+  userAttachments?: UserAttachmentPreview[]
   parts: AssistantPart[]
   done: boolean
   timestamp: number

--- a/packages/browseros-agent/apps/agent/lib/attachments.ts
+++ b/packages/browseros-agent/apps/agent/lib/attachments.ts
@@ -1,0 +1,369 @@
+/**
+ * Composer attachment helpers — validation, image compression, and the
+ * client-side payload shape sent to /agents/:id/chat.
+ *
+ * Image attachments travel as `data:` URLs (base64) so the gateway, which
+ * runs on 127.0.0.1 over Lima virtiofs, can ingest them as standard
+ * OpenAI-style content blocks. Non-image text-shaped files are read into
+ * memory and travel as their extracted text body — the server inlines
+ * them as a fenced `<attachment>` block on the user message.
+ */
+
+export const MAX_ATTACHMENTS_PER_MESSAGE = 10
+export const MAX_IMAGE_BYTES = 5 * 1024 * 1024 // 5 MB after compression
+export const MAX_FILE_TEXT_BYTES = 1 * 1024 * 1024 // 1 MB extracted text
+export const IMAGE_LONG_EDGE_CAP = 2048
+
+export const ALLOWED_IMAGE_MEDIA_TYPES = [
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'image/webp',
+  'image/gif',
+] as const
+
+export const ALLOWED_FILE_MEDIA_TYPE_PREFIXES = [
+  'text/',
+  'application/json',
+] as const
+
+export type ServerImageAttachment = {
+  kind: 'image'
+  mediaType: string
+  dataUrl: string
+  name?: string
+}
+
+export type ServerFileAttachment = {
+  kind: 'file'
+  mediaType: string
+  name: string
+  text: string
+}
+
+export type ServerAttachmentPayload =
+  | ServerImageAttachment
+  | ServerFileAttachment
+
+/** UI-side representation: what the composer needs to render a chip. */
+export interface StagedAttachment {
+  id: string
+  kind: 'image' | 'file'
+  mediaType: string
+  name: string
+  // Set for images so the chip thumbnail can render directly. For files
+  // we don't need a preview yet, but the field exists for v2 PDF previews.
+  dataUrl?: string
+  // Pre-computed payload for the server. Built once at staging time so
+  // re-renders don't re-encode large blobs.
+  payload: ServerAttachmentPayload
+}
+
+export type AttachmentValidationError =
+  | { code: 'too_many'; message: string }
+  | { code: 'unsupported_type'; message: string; mediaType: string }
+  | { code: 'too_large'; message: string }
+  | { code: 'read_failed'; message: string }
+
+export type StageAttachmentResult =
+  | { ok: true; attachment: StagedAttachment }
+  | { ok: false; error: AttachmentValidationError }
+
+function isImageMediaType(mediaType: string): boolean {
+  return (ALLOWED_IMAGE_MEDIA_TYPES as readonly string[]).includes(mediaType)
+}
+
+function isAllowedFileMediaType(mediaType: string): boolean {
+  return ALLOWED_FILE_MEDIA_TYPE_PREFIXES.some((prefix) =>
+    mediaType.startsWith(prefix),
+  )
+}
+
+/** Build a unique id without depending on `crypto.randomUUID` outside DOM. */
+function makeId(): string {
+  if (typeof crypto !== 'undefined' && crypto.randomUUID) {
+    return crypto.randomUUID()
+  }
+  return `att-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+}
+
+/**
+ * Read a `File` and produce the staged-attachment shape — validate type,
+ * compress if it's a large image, and pre-build the server payload.
+ */
+export async function stageAttachment(
+  file: File,
+): Promise<StageAttachmentResult> {
+  const mediaType = file.type || 'application/octet-stream'
+
+  if (isImageMediaType(mediaType)) {
+    try {
+      const compressed = await compressImageIfNeeded(file)
+      const dataUrl = await readAsDataUrl(compressed)
+      // Rough byte ceiling — `data:image/png;base64,...` doubles size with
+      // base64. Reject early so we never POST something the route will 400.
+      if (dataUrl.length > MAX_IMAGE_BYTES * 2) {
+        return {
+          ok: false,
+          error: {
+            code: 'too_large',
+            message: `Image "${file.name}" is too large (max ${humanBytes(
+              MAX_IMAGE_BYTES,
+            )}).`,
+          },
+        }
+      }
+      return {
+        ok: true,
+        attachment: {
+          id: makeId(),
+          kind: 'image',
+          mediaType,
+          name: file.name || 'image',
+          dataUrl,
+          payload: {
+            kind: 'image',
+            mediaType,
+            dataUrl,
+            name: file.name || undefined,
+          },
+        },
+      }
+    } catch (err) {
+      return {
+        ok: false,
+        error: {
+          code: 'read_failed',
+          message:
+            err instanceof Error
+              ? err.message
+              : `Failed to read image "${file.name}".`,
+        },
+      }
+    }
+  }
+
+  if (isAllowedFileMediaType(mediaType)) {
+    let text: string
+    try {
+      text = await file.text()
+    } catch (err) {
+      return {
+        ok: false,
+        error: {
+          code: 'read_failed',
+          message:
+            err instanceof Error
+              ? err.message
+              : `Failed to read file "${file.name}".`,
+        },
+      }
+    }
+    if (text.length > MAX_FILE_TEXT_BYTES) {
+      return {
+        ok: false,
+        error: {
+          code: 'too_large',
+          message: `File "${file.name}" is too large (max ${humanBytes(
+            MAX_FILE_TEXT_BYTES,
+          )}).`,
+        },
+      }
+    }
+    return {
+      ok: true,
+      attachment: {
+        id: makeId(),
+        kind: 'file',
+        mediaType,
+        name: file.name || 'attachment',
+        payload: {
+          kind: 'file',
+          mediaType,
+          name: file.name || 'attachment',
+          text,
+        },
+      },
+    }
+  }
+
+  return {
+    ok: false,
+    error: {
+      code: 'unsupported_type',
+      message: `Unsupported attachment type: ${mediaType || 'unknown'}`,
+      mediaType,
+    },
+  }
+}
+
+/**
+ * Stage multiple files at once, enforcing the per-message cap. The result
+ * partitions successful stages and any errors so the caller can show
+ * granular toasts.
+ */
+export async function stageAttachments(
+  files: File[],
+  alreadyStaged: number,
+): Promise<{
+  staged: StagedAttachment[]
+  errors: AttachmentValidationError[]
+}> {
+  const remainingSlots = Math.max(
+    0,
+    MAX_ATTACHMENTS_PER_MESSAGE - alreadyStaged,
+  )
+  const staged: StagedAttachment[] = []
+  const errors: AttachmentValidationError[] = []
+
+  if (remainingSlots === 0 && files.length > 0) {
+    errors.push({
+      code: 'too_many',
+      message: `At most ${MAX_ATTACHMENTS_PER_MESSAGE} attachments per message.`,
+    })
+    return { staged, errors }
+  }
+
+  const overflow = files.length - remainingSlots
+  if (overflow > 0) {
+    errors.push({
+      code: 'too_many',
+      message: `Only the first ${remainingSlots} of ${files.length} files were attached (max ${MAX_ATTACHMENTS_PER_MESSAGE}).`,
+    })
+  }
+
+  for (const file of files.slice(0, remainingSlots)) {
+    const result = await stageAttachment(file)
+    if (result.ok) {
+      staged.push(result.attachment)
+    } else {
+      errors.push(result.error)
+    }
+  }
+
+  return { staged, errors }
+}
+
+/**
+ * Resize images that are oversized to a sane long-edge cap. JPEG/WebP
+ * source files are re-encoded to JPEG; PNGs/GIFs that are already small
+ * are passed through untouched.
+ */
+export async function compressImageIfNeeded(file: File): Promise<Blob> {
+  // Cheap path: small files don't need any transform.
+  if (file.size <= 1.5 * 1024 * 1024) return file
+
+  const bitmap = await blobToImageBitmap(file)
+  const { width, height } = bitmap
+  const longEdge = Math.max(width, height)
+  if (longEdge <= IMAGE_LONG_EDGE_CAP && file.size <= MAX_IMAGE_BYTES) {
+    bitmap.close?.()
+    return file
+  }
+
+  const scale = Math.min(1, IMAGE_LONG_EDGE_CAP / longEdge)
+  const targetWidth = Math.max(1, Math.round(width * scale))
+  const targetHeight = Math.max(1, Math.round(height * scale))
+
+  const canvas =
+    typeof OffscreenCanvas !== 'undefined'
+      ? new OffscreenCanvas(targetWidth, targetHeight)
+      : Object.assign(document.createElement('canvas'), {
+          width: targetWidth,
+          height: targetHeight,
+        })
+
+  const ctx = canvas.getContext('2d') as
+    | CanvasRenderingContext2D
+    | OffscreenCanvasRenderingContext2D
+    | null
+  if (!ctx) {
+    bitmap.close?.()
+    return file
+  }
+  ctx.drawImage(bitmap, 0, 0, targetWidth, targetHeight)
+  bitmap.close?.()
+
+  const outputType = 'image/jpeg'
+  if (canvas instanceof HTMLCanvasElement) {
+    return await new Promise<Blob>((resolve, reject) => {
+      canvas.toBlob(
+        (blob) => {
+          if (blob) resolve(blob)
+          else reject(new Error('Image compression failed.'))
+        },
+        outputType,
+        0.85,
+      )
+    })
+  }
+  return await (canvas as OffscreenCanvas).convertToBlob({
+    type: outputType,
+    quality: 0.85,
+  })
+}
+
+async function blobToImageBitmap(blob: Blob): Promise<ImageBitmap> {
+  if (typeof createImageBitmap === 'function') {
+    return createImageBitmap(blob)
+  }
+  // Fallback: load via an Image element and use the canvas decode path.
+  const url = URL.createObjectURL(blob)
+  try {
+    const img = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const el = new Image()
+      el.onload = () => resolve(el)
+      el.onerror = () =>
+        reject(new Error('Failed to decode image for compression.'))
+      el.src = url
+    })
+    const canvas = document.createElement('canvas')
+    canvas.width = img.naturalWidth
+    canvas.height = img.naturalHeight
+    const ctx = canvas.getContext('2d')
+    if (!ctx) throw new Error('Canvas 2D context unavailable.')
+    ctx.drawImage(img, 0, 0)
+    const blobOut = await new Promise<Blob | null>((resolve) =>
+      canvas.toBlob(resolve, 'image/png'),
+    )
+    if (!blobOut) throw new Error('Canvas toBlob returned null.')
+    return await createImageBitmap(blobOut)
+  } finally {
+    URL.revokeObjectURL(url)
+  }
+}
+
+async function readAsDataUrl(blob: Blob): Promise<string> {
+  if ('arrayBuffer' in blob && typeof FileReader === 'undefined') {
+    const buffer = await blob.arrayBuffer()
+    const base64 = arrayBufferToBase64(buffer)
+    const type = blob.type || 'application/octet-stream'
+    return `data:${type};base64,${base64}`
+  }
+  return await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => resolve(reader.result as string)
+    reader.onerror = () =>
+      reject(reader.error ?? new Error('FileReader failed to read blob.'))
+    reader.readAsDataURL(blob)
+  })
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const bytes = new Uint8Array(buffer)
+  let binary = ''
+  const chunkSize = 0x8000
+  for (let i = 0; i < bytes.byteLength; i += chunkSize) {
+    binary += String.fromCharCode.apply(
+      null,
+      Array.from(bytes.subarray(i, Math.min(i + chunkSize, bytes.byteLength))),
+    )
+  }
+  return btoa(binary)
+}
+
+function humanBytes(bytes: number): string {
+  if (bytes >= 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(0)} MB`
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(0)} KB`
+  return `${bytes} B`
+}

--- a/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
@@ -665,6 +665,10 @@ export function createOpenClawRoutes() {
         sessionKey?: string
         history?: MonitoringChatTurn[]
         attachments?: unknown
+        // Optional client-provided id — when set, the queue uses it as
+        // the canonical item id so the browser's optimistic row and the
+        // SSE snapshot reconcile on the same key.
+        id?: string
       }>()
       const trimmedMessage = body.message?.trim() ?? ''
       const attachmentValidation = validateChatAttachments(body.attachments)
@@ -694,6 +698,7 @@ export function createOpenClawRoutes() {
 
       const item = getOutboundQueueService().enqueue({
         agentId: id,
+        id: typeof body.id === 'string' && body.id ? body.id : undefined,
         message: composedMessage,
         messageParts,
         sessionKey,

--- a/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
@@ -52,6 +52,9 @@ type ChatAttachment = ImageAttachment | FileAttachment
 
 const MAX_ATTACHMENTS = 10
 const MAX_IMAGE_BYTES = 5 * 1024 * 1024 // 5 MB after compression
+// data: URLs encode bytes as base64 (~4/3 inflation) plus a small media-type
+// prefix; cap the encoded string against that, not 2× the byte budget.
+const MAX_IMAGE_DATA_URL_LENGTH = Math.ceil(MAX_IMAGE_BYTES * (4 / 3)) + 100
 const MAX_FILE_TEXT_BYTES = 1 * 1024 * 1024 // 1 MB extracted text
 const ALLOWED_IMAGE_MEDIA_TYPES = new Set([
   'image/png',
@@ -101,7 +104,7 @@ function validateChatAttachments(input: unknown): {
           error: 'image attachment must include a data: URL',
         }
       }
-      if (dataUrl.length > MAX_IMAGE_BYTES * 2) {
+      if (dataUrl.length > MAX_IMAGE_DATA_URL_LENGTH) {
         return {
           attachments: null,
           error: `image exceeds ${MAX_IMAGE_BYTES} bytes`,

--- a/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
@@ -26,6 +26,8 @@ import {
   getOpenClawService,
   normalizeBrowserOSChatSessionKey,
 } from '../services/openclaw/openclaw-service'
+import type { QueuedItemPublic } from '../services/queue'
+import { getOutboundQueueService } from '../services/queue'
 
 /**
  * Inbound attachment shapes the chat route accepts. Images travel as
@@ -651,6 +653,105 @@ export function createOpenClawRoutes() {
         const message = err instanceof Error ? err.message : String(err)
         return c.json({ error: message }, 500)
       }
+    })
+
+    .post('/agents/:id/queue', async (c) => {
+      const { id } = c.req.param()
+      const body = await c.req.json<{
+        message: string
+        sessionKey?: string
+        history?: MonitoringChatTurn[]
+        attachments?: unknown
+      }>()
+      const trimmedMessage = body.message?.trim() ?? ''
+      const attachmentValidation = validateChatAttachments(body.attachments)
+      if (attachmentValidation.error) {
+        return c.json({ error: attachmentValidation.error }, 400)
+      }
+      const attachments = attachmentValidation.attachments ?? []
+      if (!trimmedMessage && attachments.length === 0) {
+        return c.json({ error: 'Message is required' }, 400)
+      }
+
+      const sessionKey = body.sessionKey
+        ? normalizeBrowserOSChatSessionKey(id, body.sessionKey)
+        : undefined
+      const history = Array.isArray(body.history)
+        ? body.history.filter((entry): entry is MonitoringChatTurn =>
+            Boolean(
+              entry &&
+                (entry.role === 'user' || entry.role === 'assistant') &&
+                typeof entry.content === 'string',
+            ),
+          )
+        : []
+
+      const { text: composedMessage, parts: messageParts } =
+        buildMessagePartsFromAttachments(trimmedMessage, attachments)
+
+      const item = getOutboundQueueService().enqueue({
+        agentId: id,
+        message: composedMessage,
+        messageParts,
+        sessionKey,
+        history,
+        attachmentsPreview: attachments.map((a) => ({
+          kind: a.kind,
+          mediaType: a.mediaType,
+          name: 'name' in a ? a.name : undefined,
+        })),
+      })
+      return c.json({ id: item.id }, 202)
+    })
+
+    .delete('/agents/:id/queue/:itemId', (c) => {
+      const { id, itemId } = c.req.param()
+      const result = getOutboundQueueService().cancel(id, itemId)
+      if (!result.ok) {
+        const code = result.reason === 'dispatching' ? 409 : 404
+        const message =
+          result.reason === 'dispatching'
+            ? 'Item is already dispatching'
+            : 'Item not found'
+        return c.json({ error: message }, code)
+      }
+      return c.json({ ok: true })
+    })
+
+    .post('/agents/:id/queue/:itemId/retry', (c) => {
+      const { id, itemId } = c.req.param()
+      const result = getOutboundQueueService().retry(id, itemId)
+      if (!result.ok) {
+        return c.json({ error: 'Item not found or not failed' }, 404)
+      }
+      return c.json({ ok: true })
+    })
+
+    .get('/agents/:id/queue/stream', (c) => {
+      const { id } = c.req.param()
+      c.header('Content-Type', 'text/event-stream')
+      c.header('Cache-Control', 'no-cache')
+      return stream(c, async (s) => {
+        const encoder = new TextEncoder()
+        const sendSnapshot = (items: QueuedItemPublic[]) => {
+          void s.write(encoder.encode(`data: ${JSON.stringify({ items })}\n\n`))
+        }
+        const unsubscribe = getOutboundQueueService().subscribe(
+          id,
+          sendSnapshot,
+        )
+        const heartbeat = setInterval(() => {
+          void s.write(encoder.encode(': keep-alive\n\n'))
+        }, 15_000)
+        try {
+          await new Promise<void>((resolve) => {
+            s.onAbort(() => resolve())
+          })
+        } finally {
+          clearInterval(heartbeat)
+          unsubscribe()
+        }
+      })
     })
 
     .get('/session/:key/history', async (c) => {

--- a/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
@@ -20,11 +20,166 @@ import {
   OpenClawSessionNotFoundError,
 } from '../services/openclaw/errors'
 import { getOpenClawCliProvider } from '../services/openclaw/openclaw-cli-providers/registry'
+import type { OpenClawChatContentPart } from '../services/openclaw/openclaw-http-client'
 import { isUnsupportedOpenClawProviderError } from '../services/openclaw/openclaw-provider-map'
 import {
   getOpenClawService,
   normalizeBrowserOSChatSessionKey,
 } from '../services/openclaw/openclaw-service'
+
+/**
+ * Inbound attachment shapes the chat route accepts. Images travel as
+ * data: URLs (the gateway is on 127.0.0.1 so we don't pay public-network
+ * cost for the base64 overhead). Files arrive with their text already
+ * extracted on the client — we just inline them as a fenced text part on
+ * the user message.
+ */
+type ImageAttachment = {
+  kind: 'image'
+  mediaType: string
+  dataUrl: string
+  name?: string
+}
+type FileAttachment = {
+  kind: 'file'
+  mediaType: string
+  name: string
+  text: string
+}
+type ChatAttachment = ImageAttachment | FileAttachment
+
+const MAX_ATTACHMENTS = 10
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024 // 5 MB after compression
+const MAX_FILE_TEXT_BYTES = 1 * 1024 * 1024 // 1 MB extracted text
+const ALLOWED_IMAGE_MEDIA_TYPES = new Set([
+  'image/png',
+  'image/jpeg',
+  'image/jpg',
+  'image/webp',
+  'image/gif',
+])
+const ALLOWED_FILE_MEDIA_TYPE_PREFIXES = ['text/', 'application/json']
+
+function validateChatAttachments(input: unknown): {
+  attachments: ChatAttachment[] | null
+  error: string | null
+} {
+  if (input === undefined || input === null) {
+    return { attachments: null, error: null }
+  }
+  if (!Array.isArray(input)) {
+    return { attachments: null, error: 'attachments must be an array' }
+  }
+  if (input.length > MAX_ATTACHMENTS) {
+    return {
+      attachments: null,
+      error: `at most ${MAX_ATTACHMENTS} attachments are allowed per message`,
+    }
+  }
+
+  const result: ChatAttachment[] = []
+  for (const raw of input) {
+    if (!raw || typeof raw !== 'object') {
+      return { attachments: null, error: 'invalid attachment entry' }
+    }
+    const entry = raw as Record<string, unknown>
+    if (entry.kind === 'image') {
+      const mediaType =
+        typeof entry.mediaType === 'string' ? entry.mediaType : ''
+      const dataUrl = typeof entry.dataUrl === 'string' ? entry.dataUrl : ''
+      if (!ALLOWED_IMAGE_MEDIA_TYPES.has(mediaType)) {
+        return {
+          attachments: null,
+          error: `unsupported image type: ${mediaType || 'unknown'}`,
+        }
+      }
+      if (!dataUrl.startsWith('data:')) {
+        return {
+          attachments: null,
+          error: 'image attachment must include a data: URL',
+        }
+      }
+      if (dataUrl.length > MAX_IMAGE_BYTES * 2) {
+        return {
+          attachments: null,
+          error: `image exceeds ${MAX_IMAGE_BYTES} bytes`,
+        }
+      }
+      result.push({
+        kind: 'image',
+        mediaType,
+        dataUrl,
+        name: typeof entry.name === 'string' ? entry.name : undefined,
+      })
+      continue
+    }
+    if (entry.kind === 'file') {
+      const mediaType =
+        typeof entry.mediaType === 'string' ? entry.mediaType : ''
+      const name = typeof entry.name === 'string' ? entry.name : ''
+      const text = typeof entry.text === 'string' ? entry.text : ''
+      const allowed = ALLOWED_FILE_MEDIA_TYPE_PREFIXES.some((prefix) =>
+        mediaType.startsWith(prefix),
+      )
+      if (!allowed) {
+        return {
+          attachments: null,
+          error: `unsupported file type: ${mediaType || 'unknown'}`,
+        }
+      }
+      if (!name) {
+        return {
+          attachments: null,
+          error: 'file attachment must include a name',
+        }
+      }
+      if (text.length > MAX_FILE_TEXT_BYTES) {
+        return {
+          attachments: null,
+          error: `file "${name}" exceeds ${MAX_FILE_TEXT_BYTES} bytes`,
+        }
+      }
+      result.push({ kind: 'file', mediaType, name, text })
+      continue
+    }
+    return {
+      attachments: null,
+      error: 'attachment kind must be "image" or "file"',
+    }
+  }
+  return { attachments: result, error: null }
+}
+
+function buildMessagePartsFromAttachments(
+  message: string,
+  attachments: ChatAttachment[],
+): { text: string; parts: OpenClawChatContentPart[] | undefined } {
+  const images = attachments.filter(
+    (a): a is ImageAttachment => a.kind === 'image',
+  )
+  const files = attachments.filter(
+    (a): a is FileAttachment => a.kind === 'file',
+  )
+
+  const fileBlocks = files
+    .map(
+      (f) => `<attachment name="${f.name}" mediaType="${f.mediaType}">
+${f.text}
+</attachment>`,
+    )
+    .join('\n\n')
+  const text = fileBlocks ? `${message}\n\n${fileBlocks}`.trim() : message
+
+  if (images.length === 0) {
+    return { text, parts: undefined }
+  }
+
+  const parts: OpenClawChatContentPart[] = [{ type: 'text', text }]
+  for (const image of images) {
+    parts.push({ type: 'image_url', image_url: { url: image.dataUrl } })
+  }
+  return { text, parts }
+}
 
 function getCreateAgentValidationError(body: { name?: string }): string | null {
   if (!body.name?.trim()) {
@@ -356,9 +511,17 @@ export function createOpenClawRoutes() {
         message: string
         sessionKey?: string
         history?: MonitoringChatTurn[]
+        attachments?: unknown
       }>()
 
-      if (!body.message?.trim()) {
+      const trimmedMessage = body.message?.trim() ?? ''
+      const attachmentValidation = validateChatAttachments(body.attachments)
+      if (attachmentValidation.error) {
+        return c.json({ error: attachmentValidation.error }, 400)
+      }
+      const attachments = attachmentValidation.attachments ?? []
+      // Either a non-empty text body or at least one attachment is required.
+      if (!trimmedMessage && attachments.length === 0) {
         return c.json({ error: 'Message is required' }, 400)
       }
 
@@ -375,19 +538,35 @@ export function createOpenClawRoutes() {
             ),
           )
         : []
-      if (getMonitoringService().getActiveSessionId(id)) {
+
+      // Replace the immediate 409 with a bounded wait so back-to-back user
+      // sends or a cron / hook turn that's still finishing don't reject the
+      // user-chat outright. The client-side outbound queue (Feature 2) keeps
+      // the per-agent send rate at 1, so this only kicks in for cross-source
+      // contention.
+      try {
+        await getMonitoringService().waitForSessionFree(id, {
+          timeoutMs: 30_000,
+        })
+      } catch (err) {
         return c.json(
           {
             error:
-              'A monitored chat session is already active for this agent. Wait for it to finish before starting another.',
+              err instanceof Error
+                ? err.message
+                : 'Agent is busy. Try again shortly.',
           },
-          409,
+          503,
         )
       }
+
+      const { text: composedMessage, parts: messageParts } =
+        buildMessagePartsFromAttachments(trimmedMessage, attachments)
+
       const monitoringContext = await getMonitoringService().startSession({
         agentId: id,
         sessionKey,
-        originalPrompt: body.message.trim(),
+        originalPrompt: composedMessage,
         chatHistory: history,
       })
 
@@ -395,8 +574,9 @@ export function createOpenClawRoutes() {
         const eventStream = await getOpenClawService().chatStream(
           id,
           sessionKey,
-          body.message,
+          composedMessage,
           history,
+          { messageParts },
         )
 
         c.header('Content-Type', 'text/event-stream')

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-http-client.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-http-client.ts
@@ -13,10 +13,27 @@ export interface OpenClawChatHistoryMessage {
   content: string
 }
 
+/**
+ * OpenAI-compatible content parts for multimodal user messages. OpenClaw's
+ * gateway accepts the standard `content: [{ type: 'text', ... }, { type:
+ * 'image_url', image_url: { url } }]` shape on /v1/chat/completions and
+ * routes it to whichever upstream provider the agent's model points at.
+ */
+export type OpenClawChatContentPart =
+  | { type: 'text'; text: string }
+  | {
+      type: 'image_url'
+      image_url: { url: string; detail?: 'auto' | 'low' | 'high' }
+    }
+
 export interface OpenClawChatRequest {
   agentId: string
   sessionKey: string
   message: string
+  // When present, sent as the user message's `content` array verbatim. The
+  // legacy string `message` is folded into a leading text part if no text
+  // part is present in `messageParts`.
+  messageParts?: OpenClawChatContentPart[]
   history?: OpenClawChatHistoryMessage[]
   signal?: AbortSignal
 }
@@ -117,6 +134,7 @@ export class OpenClawHttpClient {
 
   private async fetchChat(input: OpenClawChatRequest): Promise<Response> {
     const token = await this.getToken()
+    const userContent = buildUserContent(input)
     const response = await fetch(
       `http://127.0.0.1:${this.hostPort}/v1/chat/completions`,
       {
@@ -130,7 +148,7 @@ export class OpenClawHttpClient {
           stream: true,
           messages: [
             ...(input.history ?? []),
-            { role: 'user', content: input.message },
+            { role: 'user', content: userContent },
           ],
           user: `browseros:${input.agentId}:${input.sessionKey}`,
         }),
@@ -195,6 +213,30 @@ function buildHistoryPath(
 
 function resolveAgentModel(agentId: string): string {
   return agentId === 'main' ? 'openclaw' : `openclaw/${agentId}`
+}
+
+/**
+ * Build the OpenAI-compatible `content` payload for the trailing user
+ * message. When the caller supplies multimodal parts via `messageParts`,
+ * use them as-is, ensuring at least one text part is present (we fold the
+ * legacy `message` string in as a leading text part if not). Otherwise,
+ * fall back to a plain string `content` so simple text-only sends keep
+ * the same wire shape we've always sent.
+ */
+function buildUserContent(
+  input: OpenClawChatRequest,
+): string | OpenClawChatContentPart[] {
+  if (!input.messageParts || input.messageParts.length === 0) {
+    return input.message
+  }
+
+  const hasText = input.messageParts.some((p) => p.type === 'text')
+  if (hasText) return input.messageParts
+
+  const trimmed = input.message.trim()
+  if (!trimmed) return input.messageParts
+
+  return [{ type: 'text', text: input.message }, ...input.messageParts]
 }
 
 function createEventStream(

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-jsonl-reader.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-jsonl-reader.ts
@@ -20,6 +20,16 @@ interface PiContentBlock {
   id?: string
   name?: string
   arguments?: Record<string, unknown>
+  // OpenAI-shaped image blocks: { type: 'image_url', image_url: { url } }.
+  // The data: URL carries mediaType + base64 in one string.
+  image_url?: { url?: string; detail?: string }
+  // Anthropic-shaped image blocks: { type: 'image', source: { type:
+  // 'base64', media_type, data } } and the simpler { type: 'image', data }
+  // variant the gateway emits on tool results.
+  source?: { type?: string; media_type?: string; data?: string }
+  data?: string
+  media_type?: string
+  mediaType?: string
 }
 
 interface PiMessage {
@@ -68,6 +78,7 @@ type SessionsJson = Record<string, SessionsJsonEntry>
 
 export type ClawEventType =
   | 'user.message'
+  | 'user.attachment'
   | 'agent.message'
   | 'agent.thinking'
   | 'agent.tool_use'
@@ -75,6 +86,16 @@ export type ClawEventType =
   | 'session.model_change'
   | 'session.thinking_level_change'
   | 'session.compaction'
+
+export interface ClawAttachmentInfo {
+  kind: 'image' | 'file'
+  mediaType: string
+  // For images we always emit a data: URL so downstream consumers don't
+  // have to reconstruct it. `name` is best-effort (JSONL rarely carries
+  // a filename for inline image content blocks).
+  dataUrl?: string
+  name?: string
+}
 
 export interface ClawEvent {
   eventId: string
@@ -89,6 +110,7 @@ export interface ClawEvent {
   toolCallId?: string
   toolArguments?: Record<string, unknown>
   isError?: boolean
+  attachment?: ClawAttachmentInfo
 }
 
 export interface JsonlSessionEntry {
@@ -408,9 +430,7 @@ function mapMessageToEvents(
   createdAt: number,
 ): ClawEvent[] {
   if (msg.role === 'user') {
-    const text = extractText(msg.content)
-    if (!text) return []
-    return [{ eventId, type: 'user.message', content: text, createdAt }]
+    return mapUserMessage(msg, eventId, createdAt)
   }
 
   if (msg.role === 'assistant') {
@@ -433,6 +453,92 @@ function mapMessageToEvents(
   }
 
   return []
+}
+
+/**
+ * Build events for a user JSONL message. Each image content block becomes
+ * a separate `user.attachment` event ordered before the `user.message`
+ * text event so downstream accumulators (in jsonlEventsToHistoryItems)
+ * can flush attachments onto the message they arrived with.
+ */
+function mapUserMessage(
+  msg: PiMessage,
+  eventId: string,
+  createdAt: number,
+): ClawEvent[] {
+  const events: ClawEvent[] = []
+  const text = extractText(msg.content)
+
+  if (msg.content) {
+    let attachmentIdx = 0
+    for (const block of msg.content) {
+      const attachment = extractImageAttachment(block)
+      if (!attachment) continue
+      events.push({
+        eventId: `${eventId}:attachment:${attachmentIdx}`,
+        type: 'user.attachment',
+        content: attachment.dataUrl ?? '',
+        createdAt,
+        attachment,
+      })
+      attachmentIdx++
+    }
+  }
+
+  if (text) {
+    events.push({ eventId, type: 'user.message', content: text, createdAt })
+  } else if (events.length > 0) {
+    // User sent only attachments and no caption — synthesize an empty
+    // user.message so downstream pipelines that gate on user.message still
+    // see a turn boundary.
+    events.push({ eventId, type: 'user.message', content: '', createdAt })
+  }
+
+  return events
+}
+
+/**
+ * Extract a normalised image attachment from a single content block.
+ * Handles all three shapes the OpenClaw gateway round-trips:
+ *   - OpenAI: `{ type: 'image_url', image_url: { url } }` (data: URL)
+ *   - Anthropic: `{ type: 'image', source: { type: 'base64', media_type, data } }`
+ *   - Bare: `{ type: 'image', data: '<base64>' }` (used by tool-result outputs)
+ */
+function extractImageAttachment(
+  block: PiContentBlock,
+): ClawAttachmentInfo | null {
+  if (block.type === 'image_url') {
+    const url = block.image_url?.url
+    if (typeof url !== 'string' || !url.startsWith('data:')) return null
+    const mediaType =
+      url.slice(5, url.indexOf(';')).trim() || 'application/octet-stream'
+    return { kind: 'image', mediaType, dataUrl: url }
+  }
+
+  if (block.type === 'image') {
+    const sourceData = block.source?.data
+    const sourceMediaType =
+      block.source?.media_type ?? block.media_type ?? block.mediaType
+    const bareData = block.data
+    if (typeof sourceData === 'string' && typeof sourceMediaType === 'string') {
+      return {
+        kind: 'image',
+        mediaType: sourceMediaType,
+        dataUrl: `data:${sourceMediaType};base64,${sourceData}`,
+      }
+    }
+    if (typeof bareData === 'string') {
+      const mediaType =
+        typeof sourceMediaType === 'string' ? sourceMediaType : 'image/png'
+      return {
+        kind: 'image',
+        mediaType,
+        dataUrl: `data:${mediaType};base64,${bareData}`,
+      }
+    }
+  }
+
+  return null
 }
 
 function mapAssistantMessage(

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -1204,7 +1204,10 @@ export class OpenClawService {
     sessionKey: string,
     message: string,
     history: MonitoringChatTurn[] = [],
-    options: { messageParts?: OpenClawChatContentPart[] } = {},
+    options: {
+      messageParts?: OpenClawChatContentPart[]
+      signal?: AbortSignal
+    } = {},
   ): Promise<ReadableStream<OpenClawStreamEvent>> {
     await this.assertGatewayReady()
     const normalizedSessionKey = normalizeBrowserOSChatSessionKey(
@@ -1225,6 +1228,7 @@ export class OpenClawService {
         message,
         messageParts: options.messageParts,
         history,
+        signal: options.signal,
       }),
     )
   }

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -60,6 +60,7 @@ import {
   mergeEnvContent,
 } from './openclaw-env'
 import {
+  type OpenClawChatContentPart,
   OpenClawHttpClient,
   type OpenClawSessionHistory,
   type OpenClawSessionHistoryEvent,
@@ -185,6 +186,16 @@ export interface BrowserOSChatHistoryReasoning {
   durationMs?: number
 }
 
+export interface BrowserOSChatHistoryAttachment {
+  kind: 'image' | 'file'
+  mediaType: string
+  // Images carry the full data: URL so the client can render directly.
+  // Files (text / pdf / etc) currently round-trip via inline text in the
+  // message body and don't reach this field — kept on the type for v2.
+  dataUrl?: string
+  name?: string
+}
+
 export interface BrowserOSChatHistoryItem {
   id: string
   role: 'user' | 'assistant'
@@ -198,6 +209,7 @@ export interface BrowserOSChatHistoryItem {
   tokensOut?: number
   toolCalls?: BrowserOSChatHistoryToolCall[]
   reasoning?: BrowserOSChatHistoryReasoning
+  attachments?: BrowserOSChatHistoryAttachment[]
 }
 
 export interface BrowserOSOpenClawHistoryPageResponse {
@@ -294,7 +306,25 @@ function jsonlEventsToHistoryItems(
   let pendingReasoningTexts: string[] = []
   let pendingReasoningFirstAt: number | null = null
 
+  // Accumulate user-side attachments. The reader emits them as separate
+  // `user.attachment` events ordered immediately before the user.message
+  // they belong to (same JSONL line). We flush them onto the next user
+  // history item and reset the buffer alongside the per-turn buffers.
+  let pendingAttachments: BrowserOSChatHistoryAttachment[] = []
+
   for (const event of events) {
+    if (event.type === 'user.attachment') {
+      if (event.attachment) {
+        pendingAttachments.push({
+          kind: event.attachment.kind,
+          mediaType: event.attachment.mediaType,
+          dataUrl: event.attachment.dataUrl,
+          name: event.attachment.name,
+        })
+      }
+      continue
+    }
+
     if (event.type === 'agent.thinking') {
       const text = event.content.trim()
       if (text) pendingReasoningTexts.push(text)
@@ -351,7 +381,15 @@ function jsonlEventsToHistoryItems(
     }
 
     let text = event.content.trim()
-    if (!text) continue
+    // Allow user messages with no text body when attachments are present —
+    // the user can attach an image and rely on the model to describe it.
+    if (!text) {
+      if (event.type === 'user.message' && pendingAttachments.length > 0) {
+        // fall through; the empty text is acceptable when paired with media
+      } else {
+        continue
+      }
+    }
 
     // Filter assistant heartbeats
     if (event.type === 'agent.message' && text.startsWith('HEARTBEAT')) continue
@@ -382,6 +420,7 @@ function jsonlEventsToHistoryItems(
         pendingToolStarts.clear()
         pendingReasoningTexts = []
         pendingReasoningFirstAt = null
+        pendingAttachments = []
         continue
       }
       if (!text) continue
@@ -434,6 +473,12 @@ function jsonlEventsToHistoryItems(
       pendingToolStarts.clear()
       pendingReasoningTexts = []
       pendingReasoningFirstAt = null
+
+      // Flush accumulated attachments onto this user message.
+      if (pendingAttachments.length > 0) {
+        item.attachments = pendingAttachments
+        pendingAttachments = []
+      }
     }
 
     items.push(item)
@@ -1154,6 +1199,7 @@ export class OpenClawService {
     sessionKey: string,
     message: string,
     history: MonitoringChatTurn[] = [],
+    options: { messageParts?: OpenClawChatContentPart[] } = {},
   ): Promise<ReadableStream<OpenClawStreamEvent>> {
     await this.assertGatewayReady()
     const normalizedSessionKey = normalizeBrowserOSChatSessionKey(
@@ -1165,12 +1211,14 @@ export class OpenClawService {
       sessionKey: normalizedSessionKey,
       messageLength: message.length,
       historyLength: history.length,
+      contentPartCount: options.messageParts?.length ?? 0,
     })
     return this.runControlPlaneCall(() =>
       this.httpClient.streamChat({
         agentId,
         sessionKey: normalizedSessionKey,
         message,
+        messageParts: options.messageParts,
         history,
       }),
     )

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -643,6 +643,11 @@ export class OpenClawService {
     return this.clawSession.onStateChange(listener)
   }
 
+  /** Read the current ClawSession state for an agent (read-only snapshot). */
+  getAgentState(agentId: string): AgentSessionState {
+    return this.clawSession.getState(agentId)
+  }
+
   // ── Lifecycle ────────────────────────────────────────────────────────
 
   async setup(input: SetupInput, onLog?: (msg: string) => void): Promise<void> {

--- a/packages/browseros-agent/apps/server/src/api/services/queue/index.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/queue/index.ts
@@ -28,9 +28,17 @@ export function getOutboundQueueService(): OutboundQueueService {
       // which mirrors what the existing /chat route does.
       resolveExistingSessionKey: (agentId) =>
         openclaw.resolveAgentSession(agentId).sessionKey ?? null,
-      chatStream: ({ agentId, sessionKey, message, history, messageParts }) =>
+      chatStream: ({
+        agentId,
+        sessionKey,
+        message,
+        history,
+        messageParts,
+        signal,
+      }) =>
         openclaw.chatStream(agentId, sessionKey, message, history, {
           messageParts,
+          signal,
         }),
     })
   }

--- a/packages/browseros-agent/apps/server/src/api/services/queue/index.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/queue/index.ts
@@ -21,6 +21,13 @@ export function getOutboundQueueService(): OutboundQueueService {
     service = new OutboundQueueService({
       onAgentStatusChange: (listener) => openclaw.onAgentStatusChange(listener),
       getAgentState: (agentId) => openclaw.getAgentState(agentId),
+      // Resolve the agent's existing user-chat session for queued sends
+      // so we don't accidentally orphan the conversation by spawning a
+      // fresh session per queued message. Only the very first message
+      // for an agent (no prior session at all) falls back to a new key,
+      // which mirrors what the existing /chat route does.
+      resolveExistingSessionKey: (agentId) =>
+        openclaw.resolveAgentSession(agentId).sessionKey ?? null,
       chatStream: ({ agentId, sessionKey, message, history, messageParts }) =>
         openclaw.chatStream(agentId, sessionKey, message, history, {
           messageParts,

--- a/packages/browseros-agent/apps/server/src/api/services/queue/index.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/queue/index.ts
@@ -1,0 +1,46 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { getOpenClawService } from '../openclaw/openclaw-service'
+import { OutboundQueueService } from './outbound-queue-service'
+
+let service: OutboundQueueService | null = null
+
+/**
+ * Lazy singleton — built on first access so the OpenClaw service is
+ * already available. The queue subscribes to ClawSession state changes
+ * via OpenClawService.onAgentStatusChange and dispatches through
+ * OpenClawService.chatStream, so no extra wiring on the openclaw side.
+ */
+export function getOutboundQueueService(): OutboundQueueService {
+  if (!service) {
+    const openclaw = getOpenClawService()
+    service = new OutboundQueueService({
+      onAgentStatusChange: (listener) => openclaw.onAgentStatusChange(listener),
+      getAgentState: (agentId) => openclaw.getAgentState(agentId),
+      chatStream: ({ agentId, sessionKey, message, history, messageParts }) =>
+        openclaw.chatStream(agentId, sessionKey, message, history, {
+          messageParts,
+        }),
+    })
+  }
+  return service
+}
+
+/** Tear down the singleton — wired into server shutdown. */
+export function shutdownOutboundQueueService(): void {
+  if (service) {
+    service.shutdown()
+    service = null
+  }
+}
+
+export type {
+  QueuedItem,
+  QueuedItemAttachmentPreview,
+  QueuedItemPublic,
+  QueuedItemStatus,
+} from './outbound-queue-service'

--- a/packages/browseros-agent/apps/server/src/api/services/queue/outbound-queue-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/queue/outbound-queue-service.ts
@@ -102,14 +102,24 @@ export class OutboundQueueService {
     })
   }
 
-  enqueue(item: Omit<QueuedItem, 'id' | 'status' | 'createdAt'>): QueuedItem {
+  enqueue(
+    item: Omit<QueuedItem, 'id' | 'status' | 'createdAt'> & { id?: string },
+  ): QueuedItem {
+    // Caller-supplied ids let the browser keep its optimistic row and the
+    // server snapshot reconciled on a single key — without that, SSE
+    // can't dedupe the optimistic entry until the POST response lands
+    // and the client learns the server-generated UUID.
+    const list = this.queues.get(item.agentId) ?? []
+    const id =
+      item.id && !list.some((existing) => existing.id === item.id)
+        ? item.id
+        : randomUUID()
     const queued: QueuedItem = {
       ...item,
-      id: randomUUID(),
+      id,
       status: 'queued',
       createdAt: Date.now(),
     }
-    const list = this.queues.get(item.agentId) ?? []
     list.push(queued)
     this.queues.set(item.agentId, list)
     this.broadcast(item.agentId)

--- a/packages/browseros-agent/apps/server/src/api/services/queue/outbound-queue-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/queue/outbound-queue-service.ts
@@ -78,6 +78,13 @@ interface OutboundQueueServiceDeps {
   onAgentStatusChange(listener: SessionStateListener): () => void
   /** Read the current ClawSession state for an agent. */
   getAgentState(agentId: string): AgentSessionState
+  /**
+   * Look up the agent's existing user-chat sessionKey, if any. The worker
+   * uses this to keep queued sends on the same conversation thread —
+   * generating a fresh UUID per queued message would orphan the prior
+   * conversation by spawning a brand-new session each time.
+   */
+  resolveExistingSessionKey(agentId: string): string | null
   /** Send a chat — wraps OpenClawService.chatStream. */
   chatStream: ChatStreamFn
 }
@@ -191,9 +198,17 @@ export class OutboundQueueService {
     this.workerInflight.set(agentId, abort)
 
     try {
+      // Resolution order: explicit sessionKey on the queued item ➜
+      // the agent's existing user-chat session ➜ a fresh UUID for the
+      // first-ever message. This prevents the queue from inadvertently
+      // splintering an active conversation into a new session.
+      const targetSessionKey =
+        head.sessionKey ??
+        this.deps.resolveExistingSessionKey(agentId) ??
+        randomUUID()
       const stream = await this.deps.chatStream({
         agentId,
-        sessionKey: head.sessionKey ?? randomUUID(),
+        sessionKey: targetSessionKey,
         message: head.message,
         history: head.history,
         messageParts: head.messageParts,

--- a/packages/browseros-agent/apps/server/src/api/services/queue/outbound-queue-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/queue/outbound-queue-service.ts
@@ -1,0 +1,262 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Per-agent FIFO queue of outbound chat messages. The user submits a
+ * message via /claw/agents/:id/queue, the server holds it, and a worker
+ * dispatches it through the existing chatStream path the moment the
+ * agent's ClawSession status flips to idle.
+ *
+ * The queue lives in memory only — server restart loses pending items.
+ * Persistence is a follow-up; the deliberate v1 trade-off is keeping the
+ * dispatch reactive (single source of truth = ClawSession) and avoiding
+ * a parallel store that could drift from the agent's actual state.
+ */
+
+import { randomUUID } from 'node:crypto'
+import { logger } from '../../../lib/logger'
+import type {
+  AgentSessionState,
+  SessionStateListener,
+} from '../openclaw/claw-session'
+import type { OpenClawChatContentPart } from '../openclaw/openclaw-http-client'
+import type { OpenClawStreamEvent } from '../openclaw/openclaw-types'
+
+export type QueuedItemStatus = 'queued' | 'dispatching' | 'failed'
+
+export interface QueuedItemAttachmentPreview {
+  kind: 'image' | 'file'
+  mediaType: string
+  name?: string
+}
+
+export interface QueuedItem {
+  id: string
+  agentId: string
+  /** Plain text body — what we send through chatStream's `message` arg. */
+  message: string
+  /** Multimodal parts when attachments are present. */
+  messageParts?: OpenClawChatContentPart[]
+  /** Compact preview the SSE feed broadcasts; never includes data URLs. */
+  attachmentsPreview: QueuedItemAttachmentPreview[]
+  sessionKey?: string
+  history: Array<{ role: 'user' | 'assistant'; content: string }>
+  status: QueuedItemStatus
+  error?: string
+  createdAt: number
+  startedAt?: number
+}
+
+/** Public projection sent over the SSE feed — strips heavy fields. */
+export interface QueuedItemPublic {
+  id: string
+  status: QueuedItemStatus
+  message: string
+  attachmentsPreview: QueuedItemAttachmentPreview[]
+  error?: string
+  createdAt: number
+  startedAt?: number
+}
+
+interface QueueListener {
+  agentId: string
+  send(items: QueuedItemPublic[]): void
+}
+
+/** A "send" delegate — wraps OpenClawService.chatStream to avoid a hard dep. */
+export type ChatStreamFn = (input: {
+  agentId: string
+  sessionKey: string
+  message: string
+  history: QueuedItem['history']
+  messageParts?: OpenClawChatContentPart[]
+}) => Promise<ReadableStream<OpenClawStreamEvent>>
+
+interface OutboundQueueServiceDeps {
+  /** Subscribe to per-agent status transitions from the ClawSession SM. */
+  onAgentStatusChange(listener: SessionStateListener): () => void
+  /** Read the current ClawSession state for an agent. */
+  getAgentState(agentId: string): AgentSessionState
+  /** Send a chat — wraps OpenClawService.chatStream. */
+  chatStream: ChatStreamFn
+}
+
+export class OutboundQueueService {
+  private readonly queues = new Map<string, QueuedItem[]>()
+  private readonly listeners = new Set<QueueListener>()
+  private readonly workerInflight = new Map<string, AbortController>()
+  private unsubscribe: (() => void) | null = null
+
+  constructor(private readonly deps: OutboundQueueServiceDeps) {
+    this.unsubscribe = deps.onAgentStatusChange((agentId, state) => {
+      if (state.status === 'idle') void this.tryDispatch(agentId)
+    })
+  }
+
+  enqueue(item: Omit<QueuedItem, 'id' | 'status' | 'createdAt'>): QueuedItem {
+    const queued: QueuedItem = {
+      ...item,
+      id: randomUUID(),
+      status: 'queued',
+      createdAt: Date.now(),
+    }
+    const list = this.queues.get(item.agentId) ?? []
+    list.push(queued)
+    this.queues.set(item.agentId, list)
+    this.broadcast(item.agentId)
+    void this.tryDispatch(item.agentId)
+    return queued
+  }
+
+  cancel(
+    agentId: string,
+    itemId: string,
+  ): { ok: true } | { ok: false; reason: 'not_found' | 'dispatching' } {
+    const list = this.queues.get(agentId) ?? []
+    const idx = list.findIndex((i) => i.id === itemId)
+    if (idx < 0) return { ok: false, reason: 'not_found' }
+    const target = list[idx]
+    if (!target) return { ok: false, reason: 'not_found' }
+    if (target.status === 'dispatching') {
+      return { ok: false, reason: 'dispatching' }
+    }
+    list.splice(idx, 1)
+    this.queues.set(agentId, list)
+    this.broadcast(agentId)
+    return { ok: true }
+  }
+
+  retry(agentId: string, itemId: string): { ok: boolean } {
+    const list = this.queues.get(agentId) ?? []
+    const item = list.find((i) => i.id === itemId)
+    if (!item || item.status !== 'failed') return { ok: false }
+    item.status = 'queued'
+    item.error = undefined
+    this.broadcast(agentId)
+    void this.tryDispatch(agentId)
+    return { ok: true }
+  }
+
+  list(agentId: string): QueuedItemPublic[] {
+    const items = this.queues.get(agentId) ?? []
+    return items.map(toPublic)
+  }
+
+  /** Subscribe to per-agent queue state. Sends a snapshot immediately. */
+  subscribe(
+    agentId: string,
+    send: (items: QueuedItemPublic[]) => void,
+  ): () => void {
+    const listener: QueueListener = { agentId, send }
+    this.listeners.add(listener)
+    try {
+      send(this.list(agentId))
+    } catch {
+      // best effort
+    }
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  private broadcast(agentId: string): void {
+    const snapshot = this.list(agentId)
+    for (const listener of this.listeners) {
+      if (listener.agentId !== agentId) continue
+      try {
+        listener.send(snapshot)
+      } catch {
+        // ignore — broken listeners GC themselves on next subscribe attempt
+      }
+    }
+  }
+
+  private async tryDispatch(agentId: string): Promise<void> {
+    if (this.workerInflight.has(agentId)) return
+    const list = this.queues.get(agentId) ?? []
+    const head = list.find((i) => i.status === 'queued')
+    if (!head) return
+
+    // Don't fire if the agent isn't actually idle yet — even if the
+    // listener happened to call us early during a state transition.
+    const state = this.deps.getAgentState(agentId)
+    if (state.status === 'working') return
+
+    head.status = 'dispatching'
+    head.startedAt = Date.now()
+    this.broadcast(agentId)
+
+    const abort = new AbortController()
+    this.workerInflight.set(agentId, abort)
+
+    try {
+      const stream = await this.deps.chatStream({
+        agentId,
+        sessionKey: head.sessionKey ?? randomUUID(),
+        message: head.message,
+        history: head.history,
+        messageParts: head.messageParts,
+      })
+      // Drain the stream to completion so the gateway run finalizes
+      // properly (writes the JSONL turn, releases the run controller).
+      const reader = stream.getReader()
+      try {
+        while (true) {
+          if (abort.signal.aborted) break
+          const { done } = await reader.read()
+          if (done) break
+        }
+      } finally {
+        await reader.cancel().catch(() => {})
+      }
+      this.removeAndBroadcast(agentId, head.id)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      logger.warn('OutboundQueue dispatch failed', {
+        agentId,
+        itemId: head.id,
+        error: message,
+      })
+      head.status = 'failed'
+      head.error = message
+      this.broadcast(agentId)
+    } finally {
+      this.workerInflight.delete(agentId)
+    }
+
+    // If anything else is still queued and the agent's still idle, drain
+    // it now without waiting for the next state-change callback.
+    void this.tryDispatch(agentId)
+  }
+
+  private removeAndBroadcast(agentId: string, itemId: string): void {
+    const list = this.queues.get(agentId) ?? []
+    this.queues.set(
+      agentId,
+      list.filter((i) => i.id !== itemId),
+    )
+    this.broadcast(agentId)
+  }
+
+  shutdown(): void {
+    this.unsubscribe?.()
+    this.unsubscribe = null
+    for (const abort of this.workerInflight.values()) abort.abort()
+    this.workerInflight.clear()
+    this.listeners.clear()
+    this.queues.clear()
+  }
+}
+
+function toPublic(item: QueuedItem): QueuedItemPublic {
+  return {
+    id: item.id,
+    status: item.status,
+    message: item.message,
+    attachmentsPreview: item.attachmentsPreview,
+    error: item.error,
+    createdAt: item.createdAt,
+    startedAt: item.startedAt,
+  }
+}

--- a/packages/browseros-agent/apps/server/src/api/services/queue/outbound-queue-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/queue/outbound-queue-service.ts
@@ -71,6 +71,7 @@ export type ChatStreamFn = (input: {
   message: string
   history: QueuedItem['history']
   messageParts?: OpenClawChatContentPart[]
+  signal?: AbortSignal
 }) => Promise<ReadableStream<OpenClawStreamEvent>>
 
 interface OutboundQueueServiceDeps {
@@ -212,6 +213,7 @@ export class OutboundQueueService {
         message: head.message,
         history: head.history,
         messageParts: head.messageParts,
+        signal: abort.signal,
       })
       // Drain the stream to completion so the gateway run finalizes
       // properly (writes the JSONL turn, releases the run controller).

--- a/packages/browseros-agent/apps/server/src/main.ts
+++ b/packages/browseros-agent/apps/server/src/main.ts
@@ -18,6 +18,7 @@ import {
   configureVmRuntime,
   getOpenClawService,
 } from './api/services/openclaw/openclaw-service'
+import { shutdownOutboundQueueService } from './api/services/queue'
 import { CdpBackend } from './browser/backends/cdp'
 import { Browser } from './browser/browser'
 import type { ServerConfig } from './config'
@@ -144,6 +145,7 @@ export class Application {
   stop(reason?: string): void {
     logger.info('Shutting down server...', { reason })
     stopSkillSync()
+    shutdownOutboundQueueService()
     getOpenClawService()
       .shutdown()
       .catch(() => {})

--- a/packages/browseros-agent/apps/server/src/monitoring/service.ts
+++ b/packages/browseros-agent/apps/server/src/monitoring/service.ts
@@ -70,6 +70,56 @@ export class MonitoringService {
     return this.registry.getActive(agentId)
   }
 
+  /**
+   * Resolve when no monitoring session is active for `agentId`. Used by the
+   * chat route to gate user-chat sends behind any in-flight cron / hook turn
+   * without rejecting the client outright.
+   *
+   * Resolves immediately if the agent is already free. Otherwise registers
+   * a one-shot listener on the session-end event and resolves when it
+   * fires. Rejects with a TimeoutError-shaped Error after `timeoutMs`.
+   */
+  async waitForSessionFree(
+    agentId: string,
+    options: { timeoutMs?: number } = {},
+  ): Promise<void> {
+    if (!this.registry.getActive(agentId)) return
+
+    const timeoutMs = options.timeoutMs ?? 30_000
+
+    return new Promise<void>((resolve, reject) => {
+      let timer: ReturnType<typeof setTimeout> | null = null
+      let unsubscribe: (() => void) | null = null
+
+      const cleanup = () => {
+        if (timer) clearTimeout(timer)
+        unsubscribe?.()
+      }
+
+      timer = setTimeout(() => {
+        cleanup()
+        reject(
+          new Error(
+            `Timed out waiting for agent "${agentId}" to become free after ${timeoutMs}ms`,
+          ),
+        )
+      }, timeoutMs)
+
+      unsubscribe = this.registry.onSessionEnd(agentId, () => {
+        if (this.registry.getActive(agentId)) return
+        cleanup()
+        resolve()
+      })
+
+      // Re-check after listener registration to close a race where the
+      // session ended between the initial getActive() and the subscribe.
+      if (!this.registry.getActive(agentId)) {
+        cleanup()
+        resolve()
+      }
+    })
+  }
+
   resolveSessionForMcpRequest(
     explicitAgentId?: string,
   ): { agentId: string; monitoringSessionId: string } | undefined {

--- a/packages/browseros-agent/apps/server/src/monitoring/session-registry.ts
+++ b/packages/browseros-agent/apps/server/src/monitoring/session-registry.ts
@@ -5,10 +5,16 @@ interface ActiveMonitoringSession {
   source: MonitoringSessionContext['source']
 }
 
+type SessionEndListener = () => void
+
 export class MonitoringSessionRegistry {
   private readonly activeSessionsByAgent = new Map<
     string,
     ActiveMonitoringSession
+  >()
+  private readonly endListenersByAgent = new Map<
+    string,
+    Set<SessionEndListener>
   >()
 
   setActive(
@@ -17,6 +23,28 @@ export class MonitoringSessionRegistry {
     source: MonitoringSessionContext['source'],
   ): void {
     this.activeSessionsByAgent.set(agentId, { monitoringSessionId, source })
+  }
+
+  /**
+   * Subscribe to "session ended for this agent" events. The listener fires
+   * once per termination — `clearIfMatches` is the only place that drops an
+   * active session, so each clear notifies all current listeners. Returns an
+   * unsubscribe function. Used by `waitForSessionFree` to gate user-chat
+   * sends behind in-flight cron / hook turns without polling.
+   */
+  onSessionEnd(agentId: string, listener: SessionEndListener): () => void {
+    let listeners = this.endListenersByAgent.get(agentId)
+    if (!listeners) {
+      listeners = new Set()
+      this.endListenersByAgent.set(agentId, listeners)
+    }
+    listeners.add(listener)
+    return () => {
+      listeners?.delete(listener)
+      if (listeners && listeners.size === 0) {
+        this.endListenersByAgent.delete(agentId)
+      }
+    }
   }
 
   getActive(agentId: string): string | undefined {
@@ -64,5 +92,16 @@ export class MonitoringSessionRegistry {
       return
     }
     this.activeSessionsByAgent.delete(agentId)
+    const listeners = this.endListenersByAgent.get(agentId)
+    if (listeners) {
+      // Snapshot the set: listeners commonly unsubscribe themselves inside
+      // their own callback (one-shot waiters), which would mutate the live
+      // set mid-iteration.
+      for (const listener of [...listeners]) {
+        try {
+          listener()
+        } catch {}
+      }
+    }
   }
 }

--- a/packages/browseros-agent/apps/server/tests/api/routes/openclaw.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/openclaw.test.ts
@@ -16,6 +16,9 @@ describe('createOpenClawRoutes', () => {
     const actualOpenClawService = await import(
       '../../../src/api/services/openclaw/openclaw-service'
     )
+    const actualMonitoringService = await import(
+      '../../../src/monitoring/service'
+    )
     const chatStream = mock(
       async () =>
         new ReadableStream({
@@ -41,6 +44,24 @@ describe('createOpenClawRoutes', () => {
         }) as never,
     }))
 
+    mock.module('../../../src/monitoring/service', () => ({
+      ...actualMonitoringService,
+      getMonitoringService: () =>
+        ({
+          waitForSessionFree: async () => undefined,
+          startSession: async () => ({
+            monitoringSessionId: 'm-1',
+            agentId: 'research',
+            sessionKey: 'session-123',
+            originalPrompt: 'hi',
+            chatHistory: [],
+            startedAt: new Date().toISOString(),
+            source: 'openclaw-agent-chat' as const,
+          }),
+          finalizeSession: async () => undefined,
+        }) as never,
+    }))
+
     const { createOpenClawRoutes } = await import(
       '../../../src/api/routes/openclaw'
     )
@@ -59,7 +80,15 @@ describe('createOpenClawRoutes', () => {
     expect(response.status).toBe(200)
     expect(response.headers.get('Content-Type')).toContain('text/event-stream')
     expect(response.headers.get('X-Session-Key')).toBe('session-123')
-    expect(chatStream).toHaveBeenCalledWith('research', 'session-123', 'hi', [])
+    expect(chatStream).toHaveBeenCalledWith(
+      'research',
+      'session-123',
+      'hi',
+      [],
+      {
+        messageParts: undefined,
+      },
+    )
     expect(await response.text()).toBe(
       'data: {"type":"text-delta","data":{"text":"Hello"}}\n\n' +
         'data: {"type":"done","data":{"text":"Hello"}}\n\n' +
@@ -70,6 +99,9 @@ describe('createOpenClawRoutes', () => {
   it('passes prior chat history through to the OpenClaw chat stream', async () => {
     const actualOpenClawService = await import(
       '../../../src/api/services/openclaw/openclaw-service'
+    )
+    const actualMonitoringService = await import(
+      '../../../src/monitoring/service'
     )
     const chatStream = mock(
       async () =>
@@ -89,6 +121,24 @@ describe('createOpenClawRoutes', () => {
       getOpenClawService: () =>
         ({
           chatStream,
+        }) as never,
+    }))
+
+    mock.module('../../../src/monitoring/service', () => ({
+      ...actualMonitoringService,
+      getMonitoringService: () =>
+        ({
+          waitForSessionFree: async () => undefined,
+          startSession: async () => ({
+            monitoringSessionId: 'm-2',
+            agentId: 'research',
+            sessionKey: 'session-456',
+            originalPrompt: 'Summarize what is blocked',
+            chatHistory: [],
+            startedAt: new Date().toISOString(),
+            source: 'openclaw-agent-chat' as const,
+          }),
+          finalizeSession: async () => undefined,
         }) as never,
     }))
 
@@ -117,10 +167,11 @@ describe('createOpenClawRoutes', () => {
       'session-456',
       'Summarize what is blocked',
       history,
+      { messageParts: undefined },
     )
   })
 
-  it('rejects concurrent monitored chat requests for the same agent', async () => {
+  it('returns 503 when waitForSessionFree times out for a busy agent', async () => {
     const actualOpenClawService = await import(
       '../../../src/api/services/openclaw/openclaw-service'
     )
@@ -141,8 +192,11 @@ describe('createOpenClawRoutes', () => {
       ...actualMonitoringService,
       getMonitoringService: () =>
         ({
-          getActiveSessionId: (agentId: string) =>
-            agentId === 'research' ? 'existing-run' : undefined,
+          waitForSessionFree: async () => {
+            throw new Error(
+              'Timed out waiting for agent "research" to become free after 30000ms',
+            )
+          },
         }) as never,
     }))
 
@@ -160,11 +214,11 @@ describe('createOpenClawRoutes', () => {
       }),
     })
 
-    expect(response.status).toBe(409)
+    expect(response.status).toBe(503)
     expect(chatStream).not.toHaveBeenCalled()
     expect(await response.json()).toEqual({
       error:
-        'A monitored chat session is already active for this agent. Wait for it to finish before starting another.',
+        'Timed out waiting for agent "research" to become free after 30000ms',
     })
   })
 


### PR DESCRIPTION
## Summary

Two upgrades to the agent chat composer at `/home/agents/:agent-id` (and `/home`):

1. **File and image attachments** — drag-and-drop, paste, or pick images / text-shaped files alongside the message. They round-trip through OpenClaw as OpenAI-compatible content blocks and surface in the historical view via a new `attachments` field on history items.
2. **Server-owned outbound message queue** — users can keep sending messages while the agent is mid-turn. The queue lives on the BrowserOS server, drains the moment the agent's `ClawSession` flips to idle, and survives tab close. Closing the browser is now safe.

The two features compose: attachments work just as well from queued sends as from immediate sends.

## What's in it

### Attachments (commit `a5ba9388`)

**Server**
- Chat route (`/agents/:id/chat`) accepts `attachments[]` with mime / size / count caps (10 per message, 5 MB / image after compression, 1 MB / text file). Images travel as `data:` URLs in OpenAI `image_url` parts; text-shaped files inline as `<attachment>` blocks in the user message.
- HTTP client (`OpenClawHttpClient`) gains `OpenClawChatContentPart` and a `buildUserContent` helper that emits multimodal arrays when `messageParts` is supplied, falls back to legacy string content otherwise.
- JSONL reader picks up `image_url` (OpenAI), `image{source,data}` (Anthropic), and bare `{type:'image',data}` shapes on user messages, emits a new `user.attachment` event the history mapper accumulates onto the next user item.
- History items gain `attachments?: BrowserOSChatHistoryAttachment[]`.
- `MonitoringSessionRegistry` gains `onSessionEnd`; `MonitoringService.waitForSessionFree(agentId, { timeoutMs: 30_000 })` replaces the immediate `409 monitored chat session active` so cron / hook contention no longer rejects user-chat sends outright (returns `503` after 30 s if truly stuck).

**Client**
- New `lib/attachments.ts`: `stageAttachment` / `stageAttachments` / `compressImageIfNeeded` (canvas downscale to 2048 px long edge, JPEG 0.85 re-encode for >1.5 MB).
- `ConversationInput`: paperclip button, drag-and-drop overlay, clipboard paste, staged-attachment chip strip with image thumbnails / paperclip+name chips, drag overlay during dragover. Send button enables on text *or* attachments.
- `useAgentConversation.send` accepts a `SendInput` shape and forwards `attachments` plus optimistic `attachmentPreviews` for the live turn render.
- `ClawChatMessage` groups historical attachment parts into one `<MessageAttachments>` strip ordered before reasoning/tools/text. `ConversationMessage` does the same on user-side of live turns.

### Outbound message queue (commits `123ef21d` → `5f9b232b` → `14529be7`)

**Server-owned, in-memory FIFO per agent.**
- New `OutboundQueueService` (`apps/server/src/api/services/queue`). Subscribes to `ClawSession.onStateChange` via `OpenClawService.onAgentStatusChange`; dispatches through `OpenClawService.chatStream` so attachments / history / monitoring all behave identically to the existing chat route. The worker drains the SSE response server-side so the gateway run finalizes cleanly even with no client connected.
- Four routes under `/claw/agents/:id/queue`:
  - `POST   /queue` — enqueue, returns `202 { id }`
  - `DELETE /queue/:itemId` — cancel a queued item (409 if already dispatching)
  - `POST   /queue/:itemId/retry` — re-queue a failed item
  - `GET    /queue/stream` — SSE feed of per-agent queue state for live UI
- Validation reuses the chat route's `validateChatAttachments` + `buildMessagePartsFromAttachments`. Singleton wired in `main.ts`; shutdown on SIGTERM.
- `OpenClawService` gains `getAgentState(agentId)` for the worker's pre-dispatch sanity check.

**Client UI**
- `useOutboundQueue` is an SSE-backed projection over server state. Public API unchanged so the composer doesn't change.
- `enqueue` POSTs to `/queue` and shows an optimistic local entry until the server's SSE snapshot reflects it. Local-only entries get a `local-` id prefix so cancel can short-circuit them without hitting the server.
- Composer renders an `OutboundQueueStrip` above the staged-attachment strip with per-item status (queued / sending / failed), cancel for queued items, retry + discard for failed items.
- `AgentCommandConversation` watches the queue for `sending` items dropping out and refetches history so the new assistant turn shows up in the conversation view (server worker dispatches without exposing per-turn SSE; refetch is the cleanest "turn finalized" hook for v1).

**Critical bug fixed in `14529be7`** — the worker was generating fresh UUIDs as `sessionKey` when the queued item didn't carry one, orphaning the user's active conversation behind a brand-new "most recent" session entry. Now layered:
1. Client always sends `sessionKey: resolvedSessionKey` on enqueue.
2. Server worker resolves to the agent's existing user-chat session via `OpenClawService.resolveAgentSession` if no `sessionKey` is provided.
3. UUID fallback reserved for the very first message on a brand-new agent.

## Notable design choices

- **Why server-side queue rather than client-side.** Closing the tab discards a React-state queue silently. Server-side also gives sub-second drain latency (`ClawSession` event → dispatch) instead of waiting for the SSE `done` to propagate through React state.
- **No persistence in v1.** Server restart loses queue. Documented as a v2 follow-up. `chrome.storage.session` would still lose on browser quit; SQLite or similar is the proper fix when needed.
- **Dispatch via `/v1/chat/completions` not `chat.send` RPC.** OpenClaw's `chat.send` RPC is a richer primitive (native attachments, idempotency, in-flight detection) but switching means rewriting the SSE adapter. Reusing the existing `chatStream` keeps blast radius small.
- **Live token streaming on queued sends is intentionally absent.** The server worker drains the SSE internally; clients see the new turn after history refetch. Per-turn streaming is a v2 polish.

## Known limitations / open follow-ups

- **Image attachments require an OpenClaw vision provider.** OpenClaw's gateway runs all media through `applyMediaUnderstandingIfNeeded`, which routes images to a separately-configured provider (Anthropic, Google, Qwen, Groq, …). Without that configuration, the gateway silently drops the image part before reaching the conversation model. Our wire format is correct end-to-end (verified with a payload triage); the gateway just needs vision wiring on its end. Friendly 400 + Settings UI hint is a recommended follow-up.
- **Server restart loses the queue.** As above.
- **Per-turn live streaming for queued sends.** Currently the user sees the assistant turn after a history refetch.
- **True interject (Claude-Code style).** OpenClaw doesn't expose a "user nudge mid-tool-call" hook in this build. We confirmed via container introspection — `chat.inject` is for assistant-side messages, not user. Tracking upstream.

## Test plan

- [ ] Send a text message — works as before.
- [ ] Drag an image into the composer — chip appears, send goes through. (Note: image only round-trips to the model if OpenClaw has a vision provider configured.)
- [ ] Paste an image from clipboard — chip appears, send goes through.
- [ ] Attach 11 images — last one is rejected with a clear error.
- [ ] Attach a 6 MB image — rejected with a clear error.
- [ ] Send 3 messages in quick succession while agent is mid-turn — all 3 appear in queue strip; first dispatches; remaining drain in order as agent finishes each turn.
- [ ] Close the tab between dispatches, reopen — pending items still in strip (or already drained, depending on timing). JSONL shows all turns delivered.
- [ ] Cancel a queued item before it dispatches — disappears from strip, JSONL never sees it.
- [ ] Force a failure (e.g., kill the gateway mid-dispatch) — item shows `failed` with error; retry button re-queues it.
- [ ] Open two tabs on the same agent — enqueue in tab A, tab B sees it.
- [ ] Verify session continuity: send a queued message, then a regular send — both land on the same `sessionKey`. (Regression test for the orphan-session bug fixed in `14529be7`.)