### PR TITLE
fix(eval): switch weekly evals from Fireworks to OpenRouter

### DIFF
--- a/packages/browseros-agent/apps/eval/configs/agisdk-real-smoke.json
+++ b/packages/browseros-agent/apps/eval/configs/agisdk-real-smoke.json
@@ -2,9 +2,9 @@
   "agent": {
     "type": "single",
     "provider": "openai-compatible",
-    "model": "accounts/fireworks/models/kimi-k2p5",
-    "apiKey": "FIREWORKS_API_KEY",
-    "baseUrl": "https://api.fireworks.ai/inference/v1",
+    "model": "moonshotai/kimi-k2.5",
+    "apiKey": "OPENROUTER_API_KEY",
+    "baseUrl": "https://openrouter.ai/api/v1",
     "supportsImages": true
   },
   "dataset": "../data/agisdk-real.jsonl",

--- a/packages/browseros-agent/apps/eval/configs/browseros-agent-weekly.json
+++ b/packages/browseros-agent/apps/eval/configs/browseros-agent-weekly.json
@@ -2,9 +2,9 @@
   "agent": {
     "type": "single",
     "provider": "openai-compatible",
-    "model": "accounts/fireworks/models/kimi-k2p5",
-    "apiKey": "FIREWORKS_API_KEY",
-    "baseUrl": "https://api.fireworks.ai/inference/v1",
+    "model": "moonshotai/kimi-k2.5",
+    "apiKey": "OPENROUTER_API_KEY",
+    "baseUrl": "https://openrouter.ai/api/v1",
     "supportsImages": true
   },
   "dataset": "../data/webbench-2of4-50.jsonl",

--- a/packages/browseros-agent/apps/eval/configs/infinity-hard-50.json
+++ b/packages/browseros-agent/apps/eval/configs/infinity-hard-50.json
@@ -2,9 +2,9 @@
   "agent": {
     "type": "single",
     "provider": "openai-compatible",
-    "model": "accounts/fireworks/models/kimi-k2p5",
-    "apiKey": "FIREWORKS_API_KEY",
-    "baseUrl": "https://api.fireworks.ai/inference/v1",
+    "model": "moonshotai/kimi-k2.5",
+    "apiKey": "OPENROUTER_API_KEY",
+    "baseUrl": "https://openrouter.ai/api/v1",
     "supportsImages": true
   },
   "dataset": "../data/webarena-infinity-hard-50.jsonl",


### PR DESCRIPTION
## Summary

Switch the three weekly eval configs from Fireworks to OpenRouter to escape the Fireworks 503 "service overloaded" rate-limits that ate 42-46% of the 2026-04-23 weekly run.

## Why

On 2026-04-23, AGISDK (52 tasks) and Infinity (50 tasks) ran concurrently with 10 workers each — ~20 concurrent kimi-k2p5 streams hit Fireworks for ~35 minutes. Result: 20/52 AGISDK tasks errored, 23/50 Infinity tasks errored, all with the same message:

> `AI_RetryError: Failed after 3 attempts. Last error: Request didn't generate first token before the given deadline, the service is overloaded`

This was the dominant failure mode — about half of the 30% headline pass rate is infra noise.

## What

Three config files swap from Fireworks to OpenRouter (same model weights — Moonshot Kimi K2.5):
- `browseros-agent-weekly.json`
- `agisdk-real-smoke.json`
- `infinity-hard-50.json`

```diff
-    "model": "accounts/fireworks/models/kimi-k2p5",
-    "apiKey": "FIREWORKS_API_KEY",
-    "baseUrl": "https://api.fireworks.ai/inference/v1",
+    "model": "moonshotai/kimi-k2.5",
+    "apiKey": "OPENROUTER_API_KEY",
+    "baseUrl": "https://openrouter.ai/api/v1",
```

`moonshotai/kimi-k2.5` on OpenRouter is the same weights, same 262K context. OpenRouter fronts multiple providers and falls back across them, so a single provider being overloaded doesn't kill the request.

## Out of scope (kept on Fireworks)

- `browseros-oe-agent-weekly.json` (orchestrator-executor variant)
- `browseros-oe-clado-weekly.json` (orchestrator-executor with Clado executor)
- `test_webvoyager.json` (manual dev test)

These can switch later if desired.

## GH Actions / secrets

`OPENROUTER_API_KEY` is already in repo secrets (added 2026-04-09) and already wired into `.github/workflows/eval-weekly.yml:70`. No infra changes needed.

## Test plan

- [x] All 3 modified configs are valid JSON
- [x] No `FIREWORKS` / `kimi-k2p5` strings remain in the modified configs
- [x] OPENROUTER_API_KEY confirmed present in repo secrets via `gh secret list`
- [x] OPENROUTER_API_KEY confirmed plumbed into eval-weekly.yml
- [ ] Trigger AGISDK smoke run on this branch and confirm zero "service overloaded" errors