### PR TITLE
fix: address balpha CLI dogfooding feedback

### DIFF
--- a/packages/browseros-agent/tools/alpha/Makefile
+++ b/packages/browseros-agent/tools/alpha/Makefile
@@ -2,11 +2,15 @@ BINARY := balpha
 SOURCES := $(shell find . -name '*.go') go.mod go.sum
 PREFIX ?= $(HOME)/bin
 
+all: build
+
+build: $(BINARY)
+
 $(BINARY): $(SOURCES)
 	@echo "[build] Compiling $(BINARY)..."
 	@go build -o $(BINARY) .
 
-.PHONY: install test clean
+.PHONY: all build install test clean
 
 install: $(BINARY)
 	@mkdir -p $(PREFIX)

--- a/packages/browseros-agent/tools/alpha/cmd/start.go
+++ b/packages/browseros-agent/tools/alpha/cmd/start.go
@@ -119,7 +119,7 @@ func runEnvironment(cfg config.Config, agentRoot string) error {
 		Dir:     serverDir,
 		Env:     env,
 		Restart: true,
-		Cmd:     []string{"bun", "--watch", "--env-file=.env.development", "src/index.ts"},
+		Cmd:     serverCommand(),
 	}))
 	printSummary(cfg, agentRoot)
 
@@ -155,6 +155,10 @@ func runEnvironment(cfg config.Config, agentRoot string) error {
 		}
 	}
 	return nil
+}
+
+func serverCommand() []string {
+	return []string{"bun", "--env-file=.env.development", "src/index.ts"}
 }
 
 func exists(path string) bool {

--- a/packages/browseros-agent/tools/alpha/cmd/start_test.go
+++ b/packages/browseros-agent/tools/alpha/cmd/start_test.go
@@ -1,0 +1,14 @@
+package cmd
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestServerCommandDoesNotWatchFiles(t *testing.T) {
+	got := serverCommand()
+	want := []string{"bun", "--env-file=.env.development", "src/index.ts"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("server command got %#v want %#v", got, want)
+	}
+}

--- a/packages/browseros-agent/tools/alpha/config/config.go
+++ b/packages/browseros-agent/tools/alpha/config/config.go
@@ -195,7 +195,7 @@ func DefaultProductionEnv() ProductionEnv {
 			"R2_DOWNLOAD_PREFIX":              "artifacts/vendor",
 			"R2_UPLOAD_PREFIX":                "artifacts/server",
 			"NODE_ENV":                        "production",
-			"LOG_LEVEL":                       "info",
+			"LOG_LEVEL":                       "debug",
 		},
 		CLI: map[string]string{
 			"POSTHOG_API_KEY":      "",
@@ -203,7 +203,7 @@ func DefaultProductionEnv() ProductionEnv {
 			"R2_ACCESS_KEY_ID":     "",
 			"R2_SECRET_ACCESS_KEY": "",
 			"R2_BUCKET":            "browseros",
-			"R2_UPLOAD_PREFIX":     "cli",
+			"R2_UPLOAD_PREFIX":     "",
 		},
 	}
 }

--- a/packages/browseros-agent/tools/alpha/config/config_test.go
+++ b/packages/browseros-agent/tools/alpha/config/config_test.go
@@ -29,8 +29,14 @@ func TestDefaults(t *testing.T) {
 	if cfg.ProductionEnv.Server["BROWSEROS_CONFIG_URL"] == "" {
 		t.Fatalf("missing server production env defaults: %#v", cfg.ProductionEnv.Server)
 	}
+	if cfg.ProductionEnv.Server["LOG_LEVEL"] != "debug" {
+		t.Fatalf("server log level got %q want debug", cfg.ProductionEnv.Server["LOG_LEVEL"])
+	}
 	if cfg.ProductionEnv.CLI["R2_BUCKET"] != "browseros" {
 		t.Fatalf("missing cli production env defaults: %#v", cfg.ProductionEnv.CLI)
+	}
+	if cfg.ProductionEnv.CLI["R2_UPLOAD_PREFIX"] != "" {
+		t.Fatalf("cli upload prefix got %q want empty", cfg.ProductionEnv.CLI["R2_UPLOAD_PREFIX"])
 	}
 }
 

--- a/packages/browseros-agent/tools/alpha/pipeline/env_test.go
+++ b/packages/browseros-agent/tools/alpha/pipeline/env_test.go
@@ -15,11 +15,11 @@ func TestWriteProductionEnvFiles(t *testing.T) {
 		ProductionEnv: config.ProductionEnv{
 			Server: map[string]string{
 				"NODE_ENV":  "production",
-				"LOG_LEVEL": "info",
+				"LOG_LEVEL": "debug",
 			},
 			CLI: map[string]string{
 				"R2_BUCKET":        "browseros",
-				"R2_UPLOAD_PREFIX": "cli",
+				"R2_UPLOAD_PREFIX": "",
 			},
 		},
 	}
@@ -29,11 +29,11 @@ func TestWriteProductionEnvFiles(t *testing.T) {
 	assertMode(t, filepath.Join(root, "apps/server/.env.production"), 0600)
 	assertMode(t, filepath.Join(root, "apps/cli/.env.production"), 0600)
 	assertContains(t, filepath.Join(root, "apps/server/.env.production"), "BROWSEROS_CONFIG_URL=https://llm.browseros.com/api/browseros-server/config\n")
-	assertContains(t, filepath.Join(root, "apps/server/.env.production"), "LOG_LEVEL=info\n")
+	assertContains(t, filepath.Join(root, "apps/server/.env.production"), "LOG_LEVEL=debug\n")
 	assertContains(t, filepath.Join(root, "apps/server/.env.production"), "NODE_ENV=production\n")
 	assertContains(t, filepath.Join(root, "apps/cli/.env.production"), "POSTHOG_API_KEY=\n")
 	assertContains(t, filepath.Join(root, "apps/cli/.env.production"), "R2_BUCKET=browseros\n")
-	assertContains(t, filepath.Join(root, "apps/cli/.env.production"), "R2_UPLOAD_PREFIX=cli\n")
+	assertContains(t, filepath.Join(root, "apps/cli/.env.production"), "R2_UPLOAD_PREFIX=\n")
 }
 
 func TestWriteEnvFileQuotesUnsafeValues(t *testing.T) {


### PR DESCRIPTION
**Summary**
- Stop the balpha-managed server from running Bun in watch mode, so file changes do not implicitly refresh the process.
- Default server production logs to debug and leave the CLI R2 upload prefix empty.
- Add explicit Makefile build/all targets and cover the server command/env defaults with tests.

**Design**
This keeps the dogfooding CLI behavior explicit and scoped: `balpha start` still launches the managed server process with restart-on-exit, but the server command no longer asks Bun to watch the filesystem. Production env defaults are updated in the central config defaults so generated env files stay consistent. The Makefile keeps `./balpha` as the local build artifact and makes that flow addressable through `make` or `make build`.

**Test plan**
- `make test` from `tools/alpha`
- `make clean && make` from `tools/alpha`
- `test -x ./balpha && ./balpha --help` from `tools/alpha`
- `git diff --check`