### PR TITLE
fix(dogfood): colorize cli output

### DIFF
--- a/packages/browseros-agent/tools/dogfood/cmd/config.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/config.go
@@ -16,8 +16,9 @@ func init() {
 }
 
 var configCmd = &cobra.Command{
-	Use:   "config",
-	Short: "Manage browseros-dogfood config",
+	Use:     "config",
+	Short:   "Manage browseros-dogfood config",
+	GroupID: groupSetup,
 }
 
 var configEditCmd = &cobra.Command{

--- a/packages/browseros-agent/tools/dogfood/cmd/init.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/init.go
@@ -20,8 +20,9 @@ func init() {
 }
 
 var initCmd = &cobra.Command{
-	Use:   "init",
-	Short: "Create or update browseros-dogfood config",
+	Use:     "init",
+	Short:   "Create or update browseros-dogfood config",
+	GroupID: groupSetup,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		home, err := os.UserHomeDir()
 		if err != nil {
@@ -50,13 +51,13 @@ var initCmd = &cobra.Command{
 		if err := pipeline.WriteProductionEnvFiles(cfg.AgentRoot(), cfg); err != nil {
 			return err
 		}
-		fmt.Printf("Config written: %s\nRun: browseros-dogfood start\n", path)
+		fmt.Printf("%s %s\n%s %s\n", successStyle.Sprint("Config written:"), pathStyle.Sprint(path), labelStyle.Sprint("Run:"), commandStyle.Sprint("browseros-dogfood start"))
 		return nil
 	},
 }
 
 func prompt(r *bufio.Reader, label string, current string) string {
-	fmt.Printf("%s [%s]: ", label, current)
+	fmt.Printf("%s [%s]: ", labelStyle.Sprint(label), pathStyle.Sprint(current))
 	line, _ := r.ReadString('\n')
 	line = strings.TrimSpace(line)
 	if line == "" {
@@ -70,16 +71,16 @@ func chooseProfile(r *bufio.Reader, profiles []profile.BrowserProfile) string {
 	if len(profiles) == 0 {
 		return "Default"
 	}
-	fmt.Printf("Found %d BrowserOS profiles:\n", len(profiles))
+	fmt.Printf("%s %d BrowserOS profiles:\n", labelStyle.Sprint("Found"), len(profiles))
 	for i, p := range profiles {
 		email := ""
 		if p.Email != "" {
 			email = " " + p.Email
 		}
-		fmt.Printf("  %d. %s (%s)%s\n", i+1, p.Name, p.Dir, email)
+		fmt.Printf("  %s %s (%s)%s\n", commandStyle.Sprintf("%d.", i+1), p.Name, pathStyle.Sprint(p.Dir), email)
 	}
 	for {
-		fmt.Print("Select source profile [1]: ")
+		fmt.Printf("%s [1]: ", labelStyle.Sprint("Select source profile"))
 		line, _ := r.ReadString('\n')
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -89,7 +90,7 @@ func chooseProfile(r *bufio.Reader, profiles []profile.BrowserProfile) string {
 		if err == nil && n >= 1 && n <= len(profiles) {
 			return profiles[n-1].Dir
 		}
-		fmt.Println("Choose a listed number.")
+		fmt.Println(warnStyle.Sprint("Choose a listed number."))
 	}
 }
 

--- a/packages/browseros-agent/tools/dogfood/cmd/logs.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/logs.go
@@ -15,8 +15,9 @@ func init() {
 }
 
 var logsCmd = &cobra.Command{
-	Use:   "logs",
-	Short: "Print browseros-dogfood log files",
+	Use:     "logs",
+	Short:   "Print browseros-dogfood log files",
+	GroupID: groupInspect,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg, err := loadConfigWithoutValidation()
 		if err != nil {
@@ -28,17 +29,17 @@ var logsCmd = &cobra.Command{
 
 func printLogs(out io.Writer, cfg config.Config) error {
 	logDir := cfg.LogDir()
-	fmt.Fprintf(out, "Log directory: %s\n", logDir)
+	fmt.Fprintf(out, "%s %s\n", labelStyle.Sprint("Log directory:"), pathStyle.Sprint(logDir))
 	files, err := proc.ListLogFiles(logDir)
 	if err != nil {
 		return err
 	}
 	if len(files) == 0 {
-		fmt.Fprintln(out, "No log files found.")
+		fmt.Fprintln(out, dimStyle.Sprint("No log files found."))
 		return nil
 	}
 	for _, file := range files {
-		fmt.Fprintf(out, "%s (%d bytes, modified %s)\n", file.Path, file.Size, file.ModTime.Format("2006-01-02 15:04:05"))
+		fmt.Fprintf(out, "%s %s\n", pathStyle.Sprint(file.Path), dimStyle.Sprintf("(%d bytes, modified %s)", file.Size, file.ModTime.Format("2006-01-02 15:04:05")))
 	}
 	return nil
 }

--- a/packages/browseros-agent/tools/dogfood/cmd/logs_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/logs_test.go
@@ -11,9 +11,6 @@ import (
 )
 
 func TestPrintLogsShowsDirectoryAndFiles(t *testing.T) {
-	restore := forceColor(t)
-	defer restore()
-
 	devDir := t.TempDir()
 	cfg := config.Config{DevUserDataDir: devDir}
 	logDir := cfg.LogDir()
@@ -31,9 +28,9 @@ func TestPrintLogsShowsDirectoryAndFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := out.String()
+	got := stripANSI(out.String())
 	for _, want := range []string{
-		"\x1b[1mLog directory:\x1b[22m \x1b[36m" + logDir + "\x1b[0m",
+		"Log directory: " + logDir,
 		filepath.Join(logDir, "chromium.log"),
 		filepath.Join(logDir, "server.log"),
 	} {
@@ -44,9 +41,6 @@ func TestPrintLogsShowsDirectoryAndFiles(t *testing.T) {
 }
 
 func TestPrintLogsHandlesMissingDirectory(t *testing.T) {
-	restore := forceColor(t)
-	defer restore()
-
 	cfg := config.Config{DevUserDataDir: t.TempDir()}
 
 	var out bytes.Buffer
@@ -54,8 +48,8 @@ func TestPrintLogsHandlesMissingDirectory(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := out.String()
-	if !strings.Contains(got, "\x1b[2mNo log files found.\x1b[22m") {
+	got := stripANSI(out.String())
+	if !strings.Contains(got, "No log files found.") {
 		t.Fatalf("unexpected output:\n%s", got)
 	}
 }

--- a/packages/browseros-agent/tools/dogfood/cmd/logs_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/logs_test.go
@@ -11,6 +11,9 @@ import (
 )
 
 func TestPrintLogsShowsDirectoryAndFiles(t *testing.T) {
+	restore := forceColor(t)
+	defer restore()
+
 	devDir := t.TempDir()
 	cfg := config.Config{DevUserDataDir: devDir}
 	logDir := cfg.LogDir()
@@ -30,7 +33,7 @@ func TestPrintLogsShowsDirectoryAndFiles(t *testing.T) {
 
 	got := out.String()
 	for _, want := range []string{
-		"Log directory: " + logDir,
+		"\x1b[1mLog directory:\x1b[22m \x1b[36m" + logDir + "\x1b[0m",
 		filepath.Join(logDir, "chromium.log"),
 		filepath.Join(logDir, "server.log"),
 	} {
@@ -41,6 +44,9 @@ func TestPrintLogsShowsDirectoryAndFiles(t *testing.T) {
 }
 
 func TestPrintLogsHandlesMissingDirectory(t *testing.T) {
+	restore := forceColor(t)
+	defer restore()
+
 	cfg := config.Config{DevUserDataDir: t.TempDir()}
 
 	var out bytes.Buffer
@@ -49,7 +55,7 @@ func TestPrintLogsHandlesMissingDirectory(t *testing.T) {
 	}
 
 	got := out.String()
-	if !strings.Contains(got, "No log files found.") {
+	if !strings.Contains(got, "\x1b[2mNo log files found.\x1b[22m") {
 		t.Fatalf("unexpected output:\n%s", got)
 	}
 }

--- a/packages/browseros-agent/tools/dogfood/cmd/pull.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/pull.go
@@ -16,8 +16,9 @@ func init() {
 }
 
 var pullCmd = &cobra.Command{
-	Use:   "pull",
-	Short: "Refresh the configured BrowserOS checkout",
+	Use:     "pull",
+	Short:   "Refresh the configured BrowserOS checkout",
+	GroupID: groupRun,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg, err := loadConfig()
 		if err != nil {
@@ -29,7 +30,7 @@ var pullCmd = &cobra.Command{
 		}
 		branch := pipeline.Branch(cfg.RepoPath, runner)
 		head, _ := pipeline.Head(cfg.RepoPath, runner)
-		fmt.Printf("Repo: %s %s %s\n", cfg.RepoPath, branch, head)
+		fmt.Printf("%s %s %s %s\n", labelStyle.Sprint("Repo:"), pathStyle.Sprint(cfg.RepoPath), commandStyle.Sprint(branch), dimStyle.Sprint(head))
 		dirty, err := pipeline.Dirty(cfg.RepoPath, runner)
 		if err != nil {
 			return err
@@ -41,7 +42,7 @@ var pullCmd = &cobra.Command{
 			return err
 		}
 		newHead, _ := pipeline.Head(cfg.RepoPath, runner)
-		fmt.Printf("Updated to %s\n", newHead)
+		fmt.Printf("%s %s\n", successStyle.Sprint("Updated to"), commandStyle.Sprint(newHead))
 		return nil
 	},
 }

--- a/packages/browseros-agent/tools/dogfood/cmd/refresh_profile.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/refresh_profile.go
@@ -14,8 +14,9 @@ func init() {
 }
 
 var refreshProfileCmd = &cobra.Command{
-	Use:   "refresh-profile",
-	Short: "Copy the configured BrowserOS profile into the browseros-dogfood dev profile",
+	Use:     "refresh-profile",
+	Short:   "Copy the configured BrowserOS profile into the browseros-dogfood dev profile",
+	GroupID: groupRun,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg, err := loadConfig()
 		if err != nil {
@@ -29,7 +30,7 @@ var refreshProfileCmd = &cobra.Command{
 		}); err != nil {
 			return err
 		}
-		fmt.Printf("Profile refreshed: %s\n", cfg.DevUserDataDir)
+		fmt.Printf("%s %s\n", successStyle.Sprint("Profile refreshed:"), pathStyle.Sprint(cfg.DevUserDataDir))
 		return nil
 	},
 }

--- a/packages/browseros-agent/tools/dogfood/cmd/root.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/root.go
@@ -42,7 +42,7 @@ func init() {
 		&cobra.Group{ID: groupSetup, Title: "Setup:"},
 		&cobra.Group{ID: groupRun, Title: "Run:"},
 		&cobra.Group{ID: groupInspect, Title: "Inspect:"},
-		&cobra.Group{ID: groupOther, Title: "Other:"},
+		&cobra.Group{ID: groupOther, Title: groupOtherTitle},
 	)
 	rootCmd.SetHelpCommandGroupID(groupOther)
 	rootCmd.SetUsageTemplate(usageTemplate)

--- a/packages/browseros-agent/tools/dogfood/cmd/root.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/root.go
@@ -16,6 +16,38 @@ var rootCmd = &cobra.Command{
 	SilenceErrors:     true,
 }
 
+const usageTemplate = `{{helpHeader "Usage:"}}{{if .Runnable}}
+  {{.UseLine}}{{end}}{{if .HasAvailableSubCommands}}
+  {{.CommandPath}} [command]{{end}}{{if .HasExample}}
+
+{{helpHeader "Examples:"}}
+{{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+{{groupedHelp .}}{{end}}{{if .HasAvailableLocalFlags}}
+
+{{helpHeader "Flags:"}}
+{{.LocalFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableInheritedFlags}}
+
+{{helpHeader "Global Flags:"}}
+{{.InheritedFlags.FlagUsages | trimTrailingWhitespaces}}{{end}}{{if .HasAvailableSubCommands}}
+
+{{helpHint (printf "Use \"%s [command] --help\" for more information." .CommandPath)}}{{end}}
+`
+
+func init() {
+	cobra.AddTemplateFunc("helpHeader", helpHeader)
+	cobra.AddTemplateFunc("helpHint", helpHint)
+	cobra.AddTemplateFunc("groupedHelp", groupedHelp)
+
+	rootCmd.AddGroup(
+		&cobra.Group{ID: groupSetup, Title: "Setup:"},
+		&cobra.Group{ID: groupRun, Title: "Run:"},
+		&cobra.Group{ID: groupInspect, Title: "Inspect:"},
+		&cobra.Group{ID: groupOther, Title: "Other:"},
+	)
+	rootCmd.SetHelpCommandGroupID(groupOther)
+	rootCmd.SetUsageTemplate(usageTemplate)
+}
+
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)

--- a/packages/browseros-agent/tools/dogfood/cmd/root_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/root_test.go
@@ -1,23 +1,25 @@
 package cmd
 
 import (
+	"regexp"
 	"strings"
 	"testing"
 
-	"github.com/fatih/color"
+	"github.com/spf13/cobra"
 )
 
-func TestRootUsageUsesColorAndCommandGroups(t *testing.T) {
-	restore := forceColor(t)
-	defer restore()
+var testANSIPattern = regexp.MustCompile(`\x1b\[[0-9;]*m`)
 
-	usage := rootCmd.UsageString()
-
+func TestRootUsageUsesCommandGroups(t *testing.T) {
+	usage := stripANSI(rootCmd.UsageString())
 	for _, want := range []string{
-		"\x1b[1;36mUsage:\x1b[22;0m",
-		"\x1b[1;36mRun:\x1b[22;0m",
-		"\x1b[92mstart          \x1b[0m Start BrowserOS dogfooding environment",
-		"\x1b[2mUse \"browseros-dogfood [command] --help\" for more information.\x1b[22m",
+		"Usage:",
+		"Setup:",
+		"Run:",
+		"Inspect:",
+		"start",
+		"Start BrowserOS dogfooding environment",
+		"Use \"browseros-dogfood [command] --help\" for more information.",
 	} {
 		if !strings.Contains(usage, want) {
 			t.Fatalf("missing %q in\n%s", want, usage)
@@ -25,28 +27,32 @@ func TestRootUsageUsesColorAndCommandGroups(t *testing.T) {
 	}
 }
 
-func forceColor(t *testing.T) func() {
-	t.Helper()
+func TestGroupedHelpUsesOneOtherSectionForUngroupedCommands(t *testing.T) {
+	cmd := &cobra.Command{Use: "test"}
+	cmd.AddGroup(&cobra.Group{ID: groupOther, Title: groupOtherTitle})
+	cmd.AddCommand(&cobra.Command{
+		Use:   "orphan",
+		Short: "Ungrouped command",
+		Run:   func(cmd *cobra.Command, args []string) {},
+	})
+	cmd.AddCommand(&cobra.Command{
+		Use:     "help",
+		Short:   "Help about any command",
+		GroupID: groupOther,
+		Run:     func(cmd *cobra.Command, args []string) {},
+	})
 
-	original := color.NoColor
-	color.NoColor = false
-	styles := []*color.Color{
-		headerStyle,
-		commandStyle,
-		hintStyle,
-		successStyle,
-		warnStyle,
-		labelStyle,
-		pathStyle,
-		dimStyle,
+	help := stripANSI(groupedHelp(cmd))
+	if got := strings.Count(help, "Other:"); got != 1 {
+		t.Fatalf("Other section count got %d want 1 in\n%s", got, help)
 	}
-	for _, style := range styles {
-		style.EnableColor()
-	}
-	return func() {
-		color.NoColor = original
-		for _, style := range styles {
-			style.DisableColor()
+	for _, want := range []string{"orphan", "Ungrouped command", "help", "Help about any command"} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("missing %q in\n%s", want, help)
 		}
 	}
+}
+
+func stripANSI(s string) string {
+	return testANSIPattern.ReplaceAllString(s, "")
 }

--- a/packages/browseros-agent/tools/dogfood/cmd/root_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/root_test.go
@@ -1,0 +1,52 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/fatih/color"
+)
+
+func TestRootUsageUsesColorAndCommandGroups(t *testing.T) {
+	restore := forceColor(t)
+	defer restore()
+
+	usage := rootCmd.UsageString()
+
+	for _, want := range []string{
+		"\x1b[1;36mUsage:\x1b[22;0m",
+		"\x1b[1;36mRun:\x1b[22;0m",
+		"\x1b[92mstart          \x1b[0m Start BrowserOS dogfooding environment",
+		"\x1b[2mUse \"browseros-dogfood [command] --help\" for more information.\x1b[22m",
+	} {
+		if !strings.Contains(usage, want) {
+			t.Fatalf("missing %q in\n%s", want, usage)
+		}
+	}
+}
+
+func forceColor(t *testing.T) func() {
+	t.Helper()
+
+	original := color.NoColor
+	color.NoColor = false
+	styles := []*color.Color{
+		headerStyle,
+		commandStyle,
+		hintStyle,
+		successStyle,
+		warnStyle,
+		labelStyle,
+		pathStyle,
+		dimStyle,
+	}
+	for _, style := range styles {
+		style.EnableColor()
+	}
+	return func() {
+		color.NoColor = original
+		for _, style := range styles {
+			style.DisableColor()
+		}
+	}
+}

--- a/packages/browseros-agent/tools/dogfood/cmd/start.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/start.go
@@ -34,8 +34,9 @@ func init() {
 }
 
 var startCmd = &cobra.Command{
-	Use:   "start",
-	Short: "Start BrowserOS dogfooding environment",
+	Use:     "start",
+	Short:   "Start BrowserOS dogfooding environment",
+	GroupID: groupRun,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg, err := loadConfig()
 		if err != nil {
@@ -44,7 +45,7 @@ var startCmd = &cobra.Command{
 		agentRoot := cfg.AgentRoot()
 		runner := pipeline.ExecRunner{}
 		if dirty, err := pipeline.Dirty(cfg.RepoPath, runner); err == nil && dirty {
-			fmt.Fprintln(os.Stderr, "warning: checkout has uncommitted changes; start will use current files")
+			fmt.Fprintln(os.Stderr, warnStyle.Sprint("warning: checkout has uncommitted changes; start will use current files"))
 		}
 		if startRefreshProfile || !exists(cfg.DevUserDataDir) {
 			if err := profile.Import(profile.ImportConfig{

--- a/packages/browseros-agent/tools/dogfood/cmd/style.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/style.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+const (
+	groupSetup   = "setup"
+	groupRun     = "run"
+	groupInspect = "inspect"
+	groupOther   = "other"
+)
+
+var (
+	headerStyle  = color.New(color.Bold, color.FgCyan)
+	commandStyle = color.New(color.FgHiGreen)
+	hintStyle    = color.New(color.Faint)
+	successStyle = color.New(color.FgGreen, color.Bold)
+	warnStyle    = color.New(color.FgYellow, color.Bold)
+	labelStyle   = color.New(color.Bold)
+	pathStyle    = color.New(color.FgCyan)
+	dimStyle     = color.New(color.Faint)
+)
+
+func helpHeader(s string) string {
+	return headerStyle.Sprint(s)
+}
+
+func helpHint(s string) string {
+	return hintStyle.Sprint(s)
+}
+
+func groupedHelp(cmd *cobra.Command) string {
+	var b strings.Builder
+	cmds := cmd.Commands()
+
+	for _, group := range cmd.Groups() {
+		lines := commandLines(cmds, group.ID)
+		if len(lines) == 0 {
+			continue
+		}
+		b.WriteString("\n" + helpHeader(group.Title) + "\n")
+		for _, line := range lines {
+			b.WriteString(line)
+		}
+	}
+
+	lines := commandLines(cmds, "")
+	if len(lines) > 0 {
+		b.WriteString("\n" + helpHeader("Other:") + "\n")
+		for _, line := range lines {
+			b.WriteString(line)
+		}
+	}
+	return strings.TrimRight(b.String(), "\n")
+}
+
+func commandLines(cmds []*cobra.Command, groupID string) []string {
+	lines := []string{}
+	for _, c := range cmds {
+		if c.GroupID != groupID || (!c.IsAvailableCommand() && c.Name() != "help") {
+			continue
+		}
+		name := commandStyle.Sprint(fmt.Sprintf("%-*s", c.NamePadding(), c.Name()))
+		lines = append(lines, fmt.Sprintf("  %s %s\n", name, c.Short))
+	}
+	return lines
+}

--- a/packages/browseros-agent/tools/dogfood/cmd/style.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/style.go
@@ -9,16 +9,17 @@ import (
 )
 
 const (
-	groupSetup   = "setup"
-	groupRun     = "run"
-	groupInspect = "inspect"
-	groupOther   = "other"
+	groupSetup      = "setup"
+	groupRun        = "run"
+	groupInspect    = "inspect"
+	groupOther      = "other"
+	groupOtherTitle = "Other:"
+	helpCommandName = "help"
 )
 
 var (
 	headerStyle  = color.New(color.Bold, color.FgCyan)
 	commandStyle = color.New(color.FgHiGreen)
-	hintStyle    = color.New(color.Faint)
 	successStyle = color.New(color.FgGreen, color.Bold)
 	warnStyle    = color.New(color.FgYellow, color.Bold)
 	labelStyle   = color.New(color.Bold)
@@ -31,27 +32,23 @@ func helpHeader(s string) string {
 }
 
 func helpHint(s string) string {
-	return hintStyle.Sprint(s)
+	return dimStyle.Sprint(s)
 }
 
 func groupedHelp(cmd *cobra.Command) string {
 	var b strings.Builder
 	cmds := cmd.Commands()
+	groups := cmd.Groups()
+	if len(groups) == 0 {
+		groups = []*cobra.Group{{ID: groupOther, Title: groupOtherTitle}}
+	}
 
-	for _, group := range cmd.Groups() {
+	for _, group := range groups {
 		lines := commandLines(cmds, group.ID)
 		if len(lines) == 0 {
 			continue
 		}
 		b.WriteString("\n" + helpHeader(group.Title) + "\n")
-		for _, line := range lines {
-			b.WriteString(line)
-		}
-	}
-
-	lines := commandLines(cmds, "")
-	if len(lines) > 0 {
-		b.WriteString("\n" + helpHeader("Other:") + "\n")
 		for _, line := range lines {
 			b.WriteString(line)
 		}
@@ -62,7 +59,11 @@ func groupedHelp(cmd *cobra.Command) string {
 func commandLines(cmds []*cobra.Command, groupID string) []string {
 	lines := []string{}
 	for _, c := range cmds {
-		if c.GroupID != groupID || (!c.IsAvailableCommand() && c.Name() != "help") {
+		commandGroupID := c.GroupID
+		if commandGroupID == "" {
+			commandGroupID = groupOther
+		}
+		if commandGroupID != groupID || (!c.IsAvailableCommand() && c.Name() != helpCommandName) {
 			continue
 		}
 		name := commandStyle.Sprint(fmt.Sprintf("%-*s", c.NamePadding(), c.Name()))


### PR DESCRIPTION
## Summary
- Adds a small shared style layer for `browseros-dogfood` terminal output.
- Groups and colorizes Cobra help so commands are easier to scan.
- Highlights user-facing status lines for logs, init, pull, refresh-profile, and dirty-check warnings.

## Design
This keeps the change scoped to the renamed Go/Cobra CLI under `tools/dogfood/cmd`, reusing the existing `fatih/color` dependency and mirroring the lightweight help-template approach used by `tk`. Runtime process logs remain tagged as before; only command help and direct CLI status messages get cleaner color treatment.

## Test plan
- `cd packages/browseros-agent/tools/dogfood && go test -count=1 ./...`
- `cd packages/browseros-agent/tools/dogfood && make build`
- `git diff --check`
- Rendered `browseros-dogfood --help` in a TTY with color enabled.