### PR TITLE
fix(dogfood): separate BrowserOS state root

### DIFF
--- a/packages/browseros-agent/tools/dogfood/README.md
+++ b/packages/browseros-agent/tools/dogfood/README.md
@@ -8,6 +8,7 @@ Internal BrowserOS dogfooding CLI for running the current checkout against a cop
 
 - Uses the BrowserOS repo path from config, then works from `packages/browseros-agent`.
 - Copies one installed BrowserOS profile into a separate dev profile under `~/.config/browseros-dogfood/profile`.
+- Runs the local server with BrowserOS state defaulting to `~/.browseros-dogfood`.
 - Writes `apps/server/.env.production` and `apps/cli/.env.production` from config.
 - Runs the existing `tools/dev/setup.sh` setup flow.
 - Builds the WXT dev extension.
@@ -73,6 +74,12 @@ The dev profile defaults to:
 
 ```text
 ~/.config/browseros-dogfood/profile
+```
+
+The BrowserOS server state root defaults to:
+
+```text
+~/.browseros-dogfood
 ```
 
 `init` also writes the generated production env files in the configured checkout.
@@ -218,6 +225,7 @@ Important fields:
 - `source_profile_dir`: installed profile directory to copy.
 - `dev_user_data_dir`: separate dev user-data dir. Defaults to `~/.config/browseros-dogfood/profile`.
 - `dev_profile_dir`: dev profile directory. Defaults to `Default`.
+- `browseros_dir`: separate BrowserOS server state root. Defaults to `~/.browseros-dogfood`.
 - `ports`: CDP, BrowserOS server, and extension ports.
 - `production_env`: values written to `apps/server/.env.production` and `apps/cli/.env.production`.
 

--- a/packages/browseros-agent/tools/dogfood/cmd/control.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/control.go
@@ -364,6 +364,7 @@ func formatStatus(data any) string {
 			intValue(ports["Extension"]),
 		)
 	}
+	writeStringField(&out, "BrowserOS dir", status["browseros_dir"])
 	writeStringField(&out, "Logs", status["log_path"])
 	return out.String()
 }

--- a/packages/browseros-agent/tools/dogfood/cmd/control_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/control_test.go
@@ -13,10 +13,11 @@ import (
 
 func TestFormatStatusDataUsesHumanReadableSummary(t *testing.T) {
 	got := formatStatus(map[string]any{
-		"state":    "running",
-		"pid":      float64(123),
-		"uptime":   "5s",
-		"log_path": "/tmp/browseros-dogfood/daemon.jsonl",
+		"state":         "running",
+		"pid":           float64(123),
+		"uptime":        "5s",
+		"log_path":      "/tmp/browseros-dogfood/daemon.jsonl",
+		"browseros_dir": "/tmp/browseros-dogfood",
 		"ports": map[string]any{
 			"CDP":       float64(9015),
 			"Server":    float64(9115),
@@ -28,6 +29,7 @@ func TestFormatStatusDataUsesHumanReadableSummary(t *testing.T) {
 		"PID: 123",
 		"Uptime: 5s",
 		"Ports: CDP=9015 Server=9115 Extension=9315",
+		"BrowserOS dir: /tmp/browseros-dogfood",
 		"Logs: /tmp/browseros-dogfood/daemon.jsonl",
 	} {
 		if !strings.Contains(got, want) {

--- a/packages/browseros-agent/tools/dogfood/cmd/daemon.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/daemon.go
@@ -229,23 +229,25 @@ type dogfoodDaemon struct {
 	opMu sync.Mutex
 	mu   sync.RWMutex
 
-	env       *environment
-	state     string
-	operation string
-	lastError string
-	ports     config.Ports
-	startedAt time.Time
-	headless  bool
+	env          *environment
+	state        string
+	operation    string
+	lastError    string
+	ports        config.Ports
+	startedAt    time.Time
+	headless     bool
+	browserOSDir string
 }
 
 type daemonStatus struct {
-	State     string       `json:"state"`
-	Operation string       `json:"operation,omitempty"`
-	LastError string       `json:"last_error,omitempty"`
-	PID       int          `json:"pid"`
-	Uptime    string       `json:"uptime"`
-	Ports     config.Ports `json:"ports"`
-	LogPath   string       `json:"log_path"`
+	State        string       `json:"state"`
+	Operation    string       `json:"operation,omitempty"`
+	LastError    string       `json:"last_error,omitempty"`
+	PID          int          `json:"pid"`
+	Uptime       string       `json:"uptime"`
+	Ports        config.Ports `json:"ports"`
+	BrowserOSDir string       `json:"browseros_dir"`
+	LogPath      string       `json:"log_path"`
 }
 
 type healthResponse struct {
@@ -280,14 +282,15 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	d := &dogfoodDaemon{
-		ctx:       ctx,
-		cancel:    cancel,
-		paths:     paths,
-		logWriter: logWriter,
-		state:     "starting",
-		startedAt: time.Now(),
-		headless:  daemonHeadless,
-		ports:     cfg.Ports,
+		ctx:          ctx,
+		cancel:       cancel,
+		paths:        paths,
+		logWriter:    logWriter,
+		state:        "starting",
+		startedAt:    time.Now(),
+		headless:     daemonHeadless,
+		ports:        cfg.Ports,
+		browserOSDir: cfg.BrowserOSDir,
 	}
 
 	server := ipc.NewServer(paths.Socket, d)
@@ -341,13 +344,14 @@ func (d *dogfoodDaemon) status() daemonStatus {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	return daemonStatus{
-		State:     d.state,
-		Operation: d.operation,
-		LastError: d.lastError,
-		PID:       os.Getpid(),
-		Uptime:    time.Since(d.startedAt).Round(time.Second).String(),
-		Ports:     d.ports,
-		LogPath:   d.paths.Log,
+		State:        d.state,
+		Operation:    d.operation,
+		LastError:    d.lastError,
+		PID:          os.Getpid(),
+		Uptime:       time.Since(d.startedAt).Round(time.Second).String(),
+		Ports:        d.ports,
+		BrowserOSDir: d.browserOSDir,
+		LogPath:      d.paths.Log,
 	}
 }
 

--- a/packages/browseros-agent/tools/dogfood/cmd/daemon_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/daemon_test.go
@@ -36,6 +36,20 @@ func TestDaemonArgsIncludeHeadlessWhenRequested(t *testing.T) {
 	}
 }
 
+func TestDaemonStatusIncludesBrowserOSDir(t *testing.T) {
+	d := &dogfoodDaemon{
+		state:        "running",
+		startedAt:    time.Now(),
+		browserOSDir: "/tmp/browseros-dogfood",
+	}
+
+	got := d.status()
+
+	if got.BrowserOSDir != "/tmp/browseros-dogfood" {
+		t.Fatalf("BrowserOS dir got %q", got.BrowserOSDir)
+	}
+}
+
 func TestLogLifecycleWritesDaemonRunlogEntry(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "daemon.jsonl")
 	writer, err := runlog.NewWriter(path)

--- a/packages/browseros-agent/tools/dogfood/cmd/start.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/start.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
@@ -238,14 +239,7 @@ func startEnvironment(parent context.Context, cfg config.Config, agentRoot strin
 		reportProgress(opts, "CDP not available, starting server anyway")
 		proc.LogMsg(proc.TagServer, proc.WarnColor.Sprint("CDP not available, starting server anyway"))
 	}
-	runtimeEnv := os.Environ()
-	runtimeEnv = append(runtimeEnv,
-		"NODE_ENV=development",
-		fmt.Sprintf("BROWSEROS_CDP_PORT=%d", cfg.Ports.CDP),
-		fmt.Sprintf("BROWSEROS_SERVER_PORT=%d", cfg.Ports.Server),
-		fmt.Sprintf("BROWSEROS_EXTENSION_PORT=%d", cfg.Ports.Extension),
-		fmt.Sprintf("VITE_BROWSEROS_SERVER_PORT=%d", cfg.Ports.Server),
-	)
+	runtimeEnv := serverRuntimeEnv(os.Environ(), cfg)
 	serverDir := filepath.Join(agentRoot, "apps/server")
 	reportProgress(opts, "starting server")
 	e.managed = append(e.managed, proc.StartManaged(ctx, &e.wg, proc.ProcConfig{
@@ -291,6 +285,24 @@ func serverCommand() []string {
 	return []string{"bun", "--env-file=.env.development", "src/index.ts"}
 }
 
+func serverRuntimeEnv(base []string, cfg config.Config) []string {
+	env := make([]string, 0, len(base)+6)
+	for _, entry := range base {
+		if strings.HasPrefix(entry, "BROWSEROS_DIR=") {
+			continue
+		}
+		env = append(env, entry)
+	}
+	return append(env,
+		"NODE_ENV=development",
+		fmt.Sprintf("BROWSEROS_DIR=%s", cfg.BrowserOSDir),
+		fmt.Sprintf("BROWSEROS_CDP_PORT=%d", cfg.Ports.CDP),
+		fmt.Sprintf("BROWSEROS_SERVER_PORT=%d", cfg.Ports.Server),
+		fmt.Sprintf("BROWSEROS_EXTENSION_PORT=%d", cfg.Ports.Extension),
+		fmt.Sprintf("VITE_BROWSEROS_SERVER_PORT=%d", cfg.Ports.Server),
+	)
+}
+
 func exists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
@@ -302,6 +314,7 @@ func printSummary(cfg config.Config, agentRoot string) {
 	proc.LogMsgf(proc.TagInfo, "Repo: %s", cfg.RepoPath)
 	proc.LogMsgf(proc.TagInfo, "Agent root: %s", agentRoot)
 	proc.LogMsgf(proc.TagInfo, "Profile: %s", cfg.DevUserDataDir)
+	proc.LogMsgf(proc.TagInfo, "BrowserOS dir: %s", cfg.BrowserOSDir)
 	proc.LogMsgf(proc.TagInfo, "Logs: %s", cfg.LogDir())
 	proc.LogMsgf(proc.TagInfo, "Ports: CDP=%d Server=%d Extension=%d", cfg.Ports.CDP, cfg.Ports.Server, cfg.Ports.Extension)
 	fmt.Println()

--- a/packages/browseros-agent/tools/dogfood/cmd/start_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/start_test.go
@@ -2,7 +2,10 @@ package cmd
 
 import (
 	"reflect"
+	"strings"
 	"testing"
+
+	"browseros-dogfood/config"
 )
 
 func TestServerCommandDoesNotWatchFiles(t *testing.T) {
@@ -25,4 +28,38 @@ func TestReportProgressInvokesConfiguredProgress(t *testing.T) {
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("progress got %#v want %#v", got, want)
 	}
+}
+
+func TestServerRuntimeEnvSetsBrowserOSDir(t *testing.T) {
+	got := serverRuntimeEnv([]string{"PATH=/bin"}, config.Config{
+		BrowserOSDir: "/tmp/browseros-dogfood",
+		Ports:        config.Ports{CDP: 9015, Server: 9115, Extension: 9315},
+	})
+
+	assertEnvContains(t, got, "BROWSEROS_DIR=/tmp/browseros-dogfood")
+}
+
+func TestServerRuntimeEnvOverridesInheritedBrowserOSDir(t *testing.T) {
+	got := serverRuntimeEnv([]string{
+		"BROWSEROS_DIR=/tmp/wrong",
+		"PATH=/bin",
+	}, config.Config{
+		BrowserOSDir: "/tmp/browseros-dogfood",
+		Ports:        config.Ports{CDP: 9015, Server: 9115, Extension: 9315},
+	})
+
+	if strings.Contains(strings.Join(got, "\n"), "BROWSEROS_DIR=/tmp/wrong") {
+		t.Fatalf("inherited BrowserOS dir was not overridden: %#v", got)
+	}
+	assertEnvContains(t, got, "BROWSEROS_DIR=/tmp/browseros-dogfood")
+}
+
+func assertEnvContains(t *testing.T, env []string, want string) {
+	t.Helper()
+	for _, entry := range env {
+		if entry == want {
+			return
+		}
+	}
+	t.Fatalf("env missing %q: %#v", want, env)
 }

--- a/packages/browseros-agent/tools/dogfood/config/config.go
+++ b/packages/browseros-agent/tools/dogfood/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	SourceProfileDir  string        `yaml:"source_profile_dir"`
 	DevUserDataDir    string        `yaml:"dev_user_data_dir"`
 	DevProfileDir     string        `yaml:"dev_profile_dir"`
+	BrowserOSDir      string        `yaml:"browseros_dir"`
 	Ports             Ports         `yaml:"ports"`
 	ProductionEnv     ProductionEnv `yaml:"production_env"`
 }
@@ -62,6 +63,7 @@ func Defaults(home string) Config {
 		SourceProfileDir:  "Default",
 		DevUserDataDir:    filepath.Join(DefaultConfigDir(home), "profile"),
 		DevProfileDir:     "Default",
+		BrowserOSDir:      filepath.Join(home, ".browseros-dogfood"),
 		Ports:             Ports{CDP: 9015, Server: 9115, Extension: 9315},
 		ProductionEnv:     DefaultProductionEnv(),
 	}
@@ -101,6 +103,7 @@ func (c *Config) Resolve() {
 	c.RepoPath = ExpandTilde(c.RepoPath, home)
 	c.SourceUserDataDir = ExpandTilde(c.SourceUserDataDir, home)
 	c.DevUserDataDir = ExpandTilde(c.DevUserDataDir, home)
+	c.BrowserOSDir = ExpandTilde(c.BrowserOSDir, home)
 	c.BrowserOSAppPath = ExpandTilde(c.BrowserOSAppPath, home)
 	if c.DevProfileDir == "" {
 		c.DevProfileDir = "Default"
@@ -149,6 +152,9 @@ func (c Config) Validate() error {
 	}
 	if c.DevUserDataDir == "" || c.DevProfileDir == "" {
 		return fmt.Errorf("dev_user_data_dir and dev_profile_dir are required")
+	}
+	if c.BrowserOSDir == "" {
+		return fmt.Errorf("browseros_dir is required")
 	}
 	if fspath.IsSameOrChild(c.DevUserDataDir, c.SourceUserDataDir) {
 		return fmt.Errorf("dev_user_data_dir must not equal or live inside source_user_data_dir")

--- a/packages/browseros-agent/tools/dogfood/config/config_test.go
+++ b/packages/browseros-agent/tools/dogfood/config/config_test.go
@@ -20,6 +20,9 @@ func TestDefaults(t *testing.T) {
 	if cfg.DevUserDataDir != filepath.Join(home, ".config/browseros-dogfood/profile") {
 		t.Fatalf("unexpected dev dir: %s", cfg.DevUserDataDir)
 	}
+	if cfg.BrowserOSDir != filepath.Join(home, ".browseros-dogfood") {
+		t.Fatalf("unexpected BrowserOS dir: %s", cfg.BrowserOSDir)
+	}
 	if cfg.LogDir() != filepath.Join(home, ".config/browseros-dogfood/profile/logs") {
 		t.Fatalf("unexpected log dir: %s", cfg.LogDir())
 	}
@@ -62,6 +65,7 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 		SourceProfileDir:  "Profile 25",
 		DevUserDataDir:    "/dev",
 		DevProfileDir:     "Default",
+		BrowserOSDir:      "/browseros-dogfood",
 		Ports:             Ports{CDP: 9015, Server: 9115, Extension: 9315},
 		ProductionEnv: ProductionEnv{
 			Server: map[string]string{"NODE_ENV": "production"},
@@ -81,6 +85,9 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 	}
 	if got.Ports.Server != 9115 {
 		t.Fatalf("server port mismatch: %d", got.Ports.Server)
+	}
+	if got.BrowserOSDir != cfg.BrowserOSDir {
+		t.Fatalf("BrowserOS dir mismatch: %q", got.BrowserOSDir)
 	}
 	if got.ProductionEnv.CLI["R2_BUCKET"] != "browseros" {
 		t.Fatalf("production env mismatch: %#v", got.ProductionEnv)
@@ -103,6 +110,7 @@ func TestValidateRejectsSourceInsideDev(t *testing.T) {
 		SourceProfileDir:  "Default",
 		DevUserDataDir:    "/tmp/source/dev",
 		DevProfileDir:     "Default",
+		BrowserOSDir:      "/tmp/browseros-dogfood",
 		Ports:             Ports{CDP: 9015, Server: 9115, Extension: 9315},
 	}
 	if err := cfg.Validate(); err == nil {
@@ -153,9 +161,39 @@ func TestValidateRepoShape(t *testing.T) {
 		SourceProfileDir:  "Default",
 		DevUserDataDir:    "/tmp/dev",
 		DevProfileDir:     "Default",
+		BrowserOSDir:      "/tmp/browseros-dogfood",
 		Ports:             Ports{CDP: 9015, Server: 9115, Extension: 9315},
 	}
 	if err := cfg.Validate(); err != nil {
 		t.Fatalf("validate: %v", err)
+	}
+}
+
+func TestResolveExpandsBrowserOSDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfg := Config{BrowserOSDir: "~/.browseros-dogfood"}
+
+	cfg.Resolve()
+
+	want := filepath.Join(home, ".browseros-dogfood")
+	if cfg.BrowserOSDir != want {
+		t.Fatalf("expanded BrowserOS dir got %q want %q", cfg.BrowserOSDir, want)
+	}
+}
+
+func TestValidateRequiresBrowserOSDir(t *testing.T) {
+	cfg := Config{
+		RepoPath:          t.TempDir(),
+		BrowserOSAppPath:  "/bin/sh",
+		SourceUserDataDir: "/tmp/source",
+		SourceProfileDir:  "Default",
+		DevUserDataDir:    "/tmp/dev",
+		DevProfileDir:     "Default",
+		Ports:             Ports{CDP: 9015, Server: 9115, Extension: 9315},
+	}
+
+	if err := cfg.Validate(); err == nil {
+		t.Fatal("expected missing BrowserOS dir to fail validation")
 	}
 }


### PR DESCRIPTION
**Summary**
- Adds a `browseros_dir` dogfood config field defaulting to `~/.browseros-dogfood`.
- Launches the dogfood server with `BROWSEROS_DIR` set from config so server, OpenClaw, VM cache, and Lima state stay separate from `.browseros` and `.browseros-dev`.
- Shows the BrowserOS dir in start/status output and documents the config field.

**Design**
Dogfood now uses the existing server `BROWSEROS_DIR` override instead of changing server defaults. The CLI owns the dogfood-specific state root, injects it into the server process environment, and strips any inherited `BROWSEROS_DIR` so the dogfood environment is deterministic while still allowing users to edit the generated config.

**Test plan**
- `cd packages/browseros-agent/tools/dogfood && go test ./...`