### PR TITLE
fix(dogfood): use alpha dock icon

### DIFF
--- a/packages/browseros-agent/tools/dogfood/README.md
+++ b/packages/browseros-agent/tools/dogfood/README.md
@@ -11,7 +11,7 @@ High level:
 - You point it at a BrowserOS repo clone used for alpha dogfooding.
 - It imports your normal BrowserOS profile into a separate dev profile.
 - It keeps BrowserOS state under `~/.browseros-dogfood`, separate from your normal app state.
-- It builds the local extension, starts the local server, and launches the installed BrowserOS app against them.
+- It builds the local extension, starts the local server, and launches the installed BrowserOS app with the alpha Dock icon against them.
 - It does not auto-pull on `start`; you choose when to update the checkout.
 
 ## Requirements
@@ -109,3 +109,5 @@ browseros-dogfood config edit
 ```
 
 Config lives at `~/.config/browseros-dogfood/config.yaml`. Most people should only need to edit it when changing the alpha repo clone, ports, or env values.
+
+Browser launch passes `--browseros-dock-icon=alpha` so dogfood sessions are visually distinct in the Dock.

--- a/packages/browseros-agent/tools/dogfood/browser/args.go
+++ b/packages/browseros-agent/tools/dogfood/browser/args.go
@@ -24,6 +24,7 @@ func BuildArgs(cfg ArgsConfig) []string {
 		"--show-component-extension-options",
 		"--disable-browseros-server",
 		"--disable-browseros-extensions",
+		"--browseros-dock-icon=alpha",
 		"--enable-logging=stderr",
 		fmt.Sprintf("--remote-debugging-port=%d", cfg.Ports.CDP),
 		// Keep all server aliases until installed BrowserOS apps converge on one switch.

--- a/packages/browseros-agent/tools/dogfood/browser/args_test.go
+++ b/packages/browseros-agent/tools/dogfood/browser/args_test.go
@@ -26,6 +26,7 @@ func TestBuildArgs(t *testing.T) {
 		"--profile-directory=Default",
 		"--disable-browseros-server",
 		"--disable-browseros-extensions",
+		"--browseros-dock-icon=alpha",
 		"--enable-logging=stderr",
 		"--load-extension=/repo/packages/browseros-agent/apps/agent/dist/chrome-mv3-dev",
 		"chrome://newtab",


### PR DESCRIPTION
## Summary
- Pass `--browseros-dock-icon=alpha` whenever `browseros-dogfood` launches BrowserOS.
- Cover the launch argument in `browser.BuildArgs` tests.
- Document that dogfood sessions use the alpha Dock icon so they are visually distinct.

## Design
The dogfood launcher hard-codes the alpha Dock icon category in its existing BrowserOS argument builder, alongside the other dogfood-only launch switches. This keeps the behavior automatic for both foreground and background dogfood starts without adding user config or changing process orchestration.

## Test plan
- `git diff --check`
- `go test -count=1 ./...` from `packages/browseros-agent/tools/dogfood`
