### PR TITLE
docs(dogfood): simplify alpha workflow readme

### DIFF
--- a/packages/browseros-agent/tools/dogfood/README.md
+++ b/packages/browseros-agent/tools/dogfood/README.md
@@ -4,18 +4,15 @@ Internal BrowserOS dogfooding CLI for running the current checkout against a cop
 
 ## What It Does
 
-`browseros-dogfood` starts a local BrowserOS dogfooding environment:
+`browseros-dogfood` makes it easy for the team to alpha test the latest dev branch with the smallest possible effort.
 
-- Uses the BrowserOS repo path from config, then works from `packages/browseros-agent`.
-- Copies one installed BrowserOS profile into a separate dev profile under `~/.config/browseros-dogfood/profile`.
-- Runs the local server with BrowserOS state defaulting to `~/.browseros-dogfood`.
-- Writes `apps/server/.env.production` and `apps/cli/.env.production` from config.
-- Runs the existing `tools/dev/setup.sh` setup flow.
-- Builds the WXT dev extension.
-- Launches `/Applications/BrowserOS.app` with the dev profile, the local extension, and the built-in server disabled.
-- Starts the local Bun server from `apps/server`.
+High level:
 
-It does not auto-pull on `start`. Use `browseros-dogfood pull` when you want to refresh the checkout.
+- You point it at a BrowserOS repo clone used for alpha dogfooding.
+- It imports your normal BrowserOS profile into a separate dev profile.
+- It keeps BrowserOS state under `~/.browseros-dogfood`, separate from your normal app state.
+- It builds the local extension, starts the local server, and launches the installed BrowserOS app against them.
+- It does not auto-pull on `start`; you choose when to update the checkout.
 
 ## Requirements
 
@@ -23,26 +20,18 @@ It does not auto-pull on `start`. Use `browseros-dogfood pull` when you want to 
 - Go.
 - Bun.
 - BrowserOS installed at `/Applications/BrowserOS.app`.
-- A BrowserOS monorepo checkout, for example `~/code/browseros-project/browseros-test`.
-- `~/bin` or your chosen install directory on `PATH`.
+- A separate BrowserOS monorepo checkout for alpha dogfood.
 
 ## Install
 
 From the BrowserOS monorepo root:
 
 ```bash
-cd packages/browseros-agent
-bun run install:browseros-dogfood
-```
-
-This builds `tools/dogfood/browseros-dogfood` and installs it to `~/bin/browseros-dogfood`.
-
-To install somewhere else:
-
-```bash
 cd packages/browseros-agent/tools/dogfood
-make install PREFIX=/usr/local/bin
+make install
 ```
+
+This installs `browseros-dogfood` globally on your machine.
 
 Check the binary:
 
@@ -60,178 +49,63 @@ browseros-dogfood init
 
 `init` asks for:
 
-- `Repo path`: the BrowserOS monorepo root, not `packages/browseros-agent`.
+- `Repo path`: the full path to the root BrowserOS git repo clone.
 - `BrowserOS binary`: defaults to `/Applications/BrowserOS.app/Contents/MacOS/BrowserOS`.
-- `Source profile`: selected from the installed BrowserOS profiles in `~/Library/Application Support/BrowserOS`.
+- `Source profile`: your main installed BrowserOS profile.
 
-Config is written to:
+Use a separate clone for the repo path. This clone is what `browseros-dogfood` uses to run alpha dogfood builds, so ideally it is not the same checkout you use for actual dev work. Give the full root repo path, for example `/Users/you/code/browseros-alpha`.
 
-```text
-~/.config/browseros-dogfood/config.yaml
-```
+If you have multiple BrowserOS profiles, `init` reads them and shows their real names. Pick your main profile, the one with your data, so alpha dogfood starts with the right imported profile.
 
-The dev profile defaults to:
-
-```text
-~/.config/browseros-dogfood/profile
-```
-
-The BrowserOS server state root defaults to:
-
-```text
-~/.browseros-dogfood
-```
-
-`init` also writes the generated production env files in the configured checkout.
-
-## Start
+## Daily Use
 
 ```bash
 browseros-dogfood start
 ```
 
-`start` runs inline. It holds the browseros-dogfood runtime lock until you press `Ctrl+C`, so
-another inline or background environment cannot start at the same time.
+`start` is sync: it runs in your terminal. Press `Ctrl+C` to cancel and stop BrowserOS and the local server.
 
-Each start:
+For async mode:
 
-- Warns if the configured checkout has uncommitted changes.
-- Imports the BrowserOS profile if the dev profile does not exist.
-- Rewrites production env files from config.
-- Auto-increments busy ports and saves the resolved values back to config.
-- Runs `tools/dev/setup.sh`.
-- Builds the WXT extension.
-- Starts BrowserOS and the local Bun server.
-- Tees BrowserOS and server output to log files under the copied profile.
+```bash
+browseros-dogfood start-background
+```
 
-Use this when you want to refresh the copied profile before launching:
+`start-background` keeps running after the command returns. Use the CLI to manage it:
+
+```bash
+browseros-dogfood status
+browseros-dogfood pull
+browseros-dogfood restart
+browseros-dogfood restart --pull
+browseros-dogfood logs
+browseros-dogfood logs tail
+browseros-dogfood stop
+```
+
+- `pull` updates the configured repo for the next sync start.
+- `restart --pull` updates the configured repo, rebuilds, and restarts when new changes land upstream.
+- `logs` prints log file paths; `logs tail` follows background dogfood, BrowserOS, and server logs.
+- `start` and `start-background` use the same lock, so only one dogfood environment runs at a time.
+
+## State And Profile Safety
+
+`browseros-dogfood` keeps alpha dogfood separate from normal BrowserOS:
+
+- BrowserOS state, including the local server state and VM data, lives under `~/.browseros-dogfood`.
+- The imported dev profile lives under `~/.config/browseros-dogfood/profile`.
+- Your installed BrowserOS profile is only used as the source import. It is not where alpha dogfood runs.
+
+To re-import your main profile:
 
 ```bash
 browseros-dogfood start --refresh-profile
 ```
 
-Use this for a headless launch:
-
-```bash
-browseros-dogfood start --headless
-```
-
-Stop the environment with `Ctrl+C`.
-
-## Logs
-
-`browseros-dogfood start` writes process logs to:
-
-```text
-~/.config/browseros-dogfood/profile/logs
-```
-
-The current files are:
-
-- `chromium.log`: BrowserOS/Chromium stdout and stderr.
-- `server.log`: local Bun server stdout and stderr.
-
-When either file is older than one day at startup, `browseros-dogfood` rotates it to
-`<name>.old` before writing a fresh log.
-
-To print the log directory and file paths:
-
-```bash
-browseros-dogfood logs
-```
-
-## Background Mode
-
-```bash
-browseros-dogfood start-background
-```
-
-`start-background` starts the same BrowserOS dogfooding environment under a
-user-level background daemon, streams startup progress, waits for the local
-server `/health` endpoint to report a CDP-connected BrowserOS, and then returns.
-It does not install a root daemon or configure login startup.
-
-The inline and background modes share one OS file lock. If either mode is already
-running, a second `browseros-dogfood start` or `browseros-dogfood start-background`
-exits with an error. Crash recovery is automatic: when the owning process exits,
-macOS releases the lock; the next start cleans up stale socket and state files.
-
-Background control commands:
-
-```bash
-browseros-dogfood status
-browseros-dogfood stop
-browseros-dogfood restart
-browseros-dogfood restart --pull
-browseros-dogfood restart --pull --force
-browseros-dogfood logs tail
-browseros-dogfood logs tail --filter daemon
-browseros-dogfood logs tail --filter chromium
-browseros-dogfood logs tail --filter server
-```
-
-- `status` shows daemon state, PID, uptime, ports, and the structured log path.
-- `stop` stops the background daemon and its BrowserOS/server child processes.
-- `restart` rebuilds from the current checkout, then restarts BrowserOS and the server.
-- `restart --pull` refuses dirty checkouts, runs `git pull --ff-only`, rebuilds, and restarts.
-- `restart --pull --force` is destructive: it runs `git fetch --prune`, resets hard
-  to the configured upstream branch, rebuilds, and restarts.
-- `logs tail` follows grouped daemon/chromium/server logs from the background daemon.
-
-Pressing Ctrl-C while `start-background` or `restart` is streaming startup logs
-detaches from the monitor. It does not stop the daemon.
-
-If no background daemon is running, control commands tell you to start one with:
-
-```bash
-browseros-dogfood start-background
-```
-
-## Update The Checkout
-
-`browseros-dogfood start` intentionally does not pull. To update the configured repo:
-
-```bash
-browseros-dogfood pull
-```
-
-If the checkout has uncommitted changes, `pull` fails. To pull anyway:
-
-```bash
-browseros-dogfood pull --force
-```
-
-## Refresh The Copied Profile
-
-To overwrite the dev profile from the selected installed BrowserOS profile:
-
-```bash
-browseros-dogfood refresh-profile
-```
-
-This removes and recreates `dev_user_data_dir`. It refuses to run if the dev user-data dir is the real BrowserOS user-data dir or lives inside it.
-
-## Edit Config
+## Config
 
 ```bash
 browseros-dogfood config edit
 ```
 
-Important fields:
-
-- `repo_path`: BrowserOS monorepo root.
-- `browseros_app_path`: BrowserOS executable to launch.
-- `source_user_data_dir`: installed BrowserOS user-data dir. Defaults to `~/Library/Application Support/BrowserOS`.
-- `source_profile_dir`: installed profile directory to copy.
-- `dev_user_data_dir`: separate dev user-data dir. Defaults to `~/.config/browseros-dogfood/profile`.
-- `dev_profile_dir`: dev profile directory. Defaults to `Default`.
-- `browseros_dir`: separate BrowserOS server state root. Defaults to `~/.browseros-dogfood`.
-- `ports`: CDP, BrowserOS server, and extension ports.
-- `production_env`: values written to `apps/server/.env.production` and `apps/cli/.env.production`.
-
-## Safety Notes
-
-- Do not point `dev_user_data_dir` at the real BrowserOS profile.
-- `browseros-dogfood` does not pass `--use-mock-keychain`; copied login data relies on the installed signed app path.
-- Default ports are CDP `9015`, server `9115`, and extension `9315`.
-- Browser launch passes `--browseros-mcp-port`, `--browseros-server-port`, and `--browseros-proxy-port` to tolerate current switch differences.
+Config lives at `~/.config/browseros-dogfood/config.yaml`. Most people should only need to edit it when changing the alpha repo clone, ports, or env values.


### PR DESCRIPTION
**Summary**
- Reframes the dogfood README around the alpha-testing goal: stay on latest dev with low setup effort.
- Replaces the long command reference with the core setup and daily-use commands for start, background mode, updates, and logs.
- Clarifies that dogfood uses a separate root repo clone, imported dev profile, and `~/.browseros-dogfood` state so the normal BrowserOS profile is not used for alpha runs.

**Design**
The README now prioritizes the alpha dogfood workflow over implementation detail. It keeps only the context a team member needs to install, initialize, run, update, inspect logs, and understand profile/state isolation, while leaving lower-level command details to CLI help.

**Test plan**
- `git diff --check -- tools/dogfood/README.md`
