### PR TITLE
fix(dogfood): clarify init prompts

### DIFF
--- a/packages/browseros-agent/tools/dogfood/cmd/init.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/init.go
@@ -34,10 +34,15 @@ var initCmd = &cobra.Command{
 			cfg.RepoPath = cwd
 		}
 		reader := bufio.NewReader(os.Stdin)
-		cfg.RepoPath = prompt(reader, "Repo path", cfg.RepoPath)
-		cfg.BrowserOSAppPath = prompt(reader, "BrowserOS binary", cfg.BrowserOSAppPath)
+		out := cmd.OutOrStdout()
+		printRepoPathHelp(out)
+		cfg.RepoPath = prompt(out, reader, "Repo path", cfg.RepoPath)
+		cfg.BrowserOSAppPath = prompt(out, reader, "BrowserOS binary", cfg.BrowserOSAppPath)
 		profiles, _ := profile.ReadProfiles(cfg.SourceUserDataDir)
-		cfg.SourceProfileDir = chooseProfile(reader, profiles)
+		if len(profiles) > 0 {
+			printSourceProfileHelp(out)
+		}
+		cfg.SourceProfileDir = chooseProfile(out, reader, profiles)
 		cfg.Resolve()
 		if err := cfg.Validate(); err != nil {
 			return err
@@ -64,8 +69,19 @@ func printInitNextSteps(out io.Writer, path string) {
 	fmt.Fprintf(out, "  %s %s\n", labelStyle.Sprint("Background:"), commandStyle.Sprint("browseros-dogfood start-background"))
 }
 
-func prompt(r *bufio.Reader, label string, current string) string {
-	fmt.Printf("%s [%s]: ", labelStyle.Sprint(label), pathStyle.Sprint(current))
+func printRepoPathHelp(out io.Writer) {
+	fmt.Fprintln(out, "Repo path is the root BrowserOS repo clone for alpha dogfood.")
+	fmt.Fprintln(out, "Use a separate clone from your everyday dev checkout if you can.")
+	fmt.Fprintln(out, "Example: /Users/you/code/browseros-alpha, not packages/browseros-agent.")
+}
+
+func printSourceProfileHelp(out io.Writer) {
+	fmt.Fprintln(out, "Choose the installed BrowserOS profile you normally use.")
+	fmt.Fprintln(out, "  Dogfood copies it into a separate dev profile.")
+}
+
+func prompt(out io.Writer, r *bufio.Reader, label string, current string) string {
+	fmt.Fprintf(out, "%s [%s]: ", labelStyle.Sprint(label), pathStyle.Sprint(current))
 	line, _ := r.ReadString('\n')
 	line = strings.TrimSpace(line)
 	if line == "" {
@@ -75,20 +91,20 @@ func prompt(r *bufio.Reader, label string, current string) string {
 	return config.ExpandTilde(line, home)
 }
 
-func chooseProfile(r *bufio.Reader, profiles []profile.BrowserProfile) string {
+func chooseProfile(out io.Writer, r *bufio.Reader, profiles []profile.BrowserProfile) string {
 	if len(profiles) == 0 {
 		return "Default"
 	}
-	fmt.Printf("%s %d BrowserOS profiles:\n", labelStyle.Sprint("Found"), len(profiles))
+	fmt.Fprintf(out, "%s %d BrowserOS profiles:\n", labelStyle.Sprint("Found"), len(profiles))
 	for i, p := range profiles {
 		email := ""
 		if p.Email != "" {
 			email = " " + p.Email
 		}
-		fmt.Printf("  %s %s (%s)%s\n", commandStyle.Sprintf("%d.", i+1), p.Name, pathStyle.Sprint(p.Dir), email)
+		fmt.Fprintf(out, "  %s %s (%s)%s\n", commandStyle.Sprintf("%d.", i+1), p.Name, pathStyle.Sprint(p.Dir), email)
 	}
 	for {
-		fmt.Printf("%s [1]: ", labelStyle.Sprint("Select source profile"))
+		fmt.Fprintf(out, "%s [1]: ", labelStyle.Sprint("Select source profile"))
 		line, _ := r.ReadString('\n')
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -98,7 +114,7 @@ func chooseProfile(r *bufio.Reader, profiles []profile.BrowserProfile) string {
 		if err == nil && n >= 1 && n <= len(profiles) {
 			return profiles[n-1].Dir
 		}
-		fmt.Println(warnStyle.Sprint("Choose a listed number."))
+		fmt.Fprintln(out, warnStyle.Sprint("Choose a listed number."))
 	}
 }
 

--- a/packages/browseros-agent/tools/dogfood/cmd/init_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/init_test.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"bufio"
 	"bytes"
 	"strings"
 	"testing"
+
+	"browseros-dogfood/profile"
 )
 
 func TestPrintInitNextStepsShowsInlineAndBackgroundStart(t *testing.T) {
@@ -18,6 +21,79 @@ func TestPrintInitNextStepsShowsInlineAndBackgroundStart(t *testing.T) {
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("missing %q in\n%s", want, got)
+		}
+	}
+}
+
+func TestPrintRepoPathHelpExplainsOnlyRepoPath(t *testing.T) {
+	var out bytes.Buffer
+	printRepoPathHelp(&out)
+
+	got := stripANSI(out.String())
+	for _, want := range []string{
+		"Repo path is the root BrowserOS repo clone for alpha dogfood.",
+		"Use a separate clone from your everyday dev checkout if you can.",
+		"Example: /Users/you/code/browseros-alpha",
+		"not packages/browseros-agent",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "BrowserOS binary") {
+		t.Fatalf("repo path help should not explain BrowserOS binary:\n%s", got)
+	}
+}
+
+func TestPrintSourceProfileHelpExplainsProfileChoice(t *testing.T) {
+	var out bytes.Buffer
+	printSourceProfileHelp(&out)
+
+	got := stripANSI(out.String())
+	for _, want := range []string{
+		"Choose the installed BrowserOS profile you normally use.",
+		"Dogfood copies it into a separate dev profile.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in\n%s", want, got)
+		}
+	}
+}
+
+func TestPromptWritesPromptToOutputWriter(t *testing.T) {
+	var out bytes.Buffer
+	reader := bufio.NewReader(strings.NewReader("\n"))
+
+	got := prompt(&out, reader, "Repo path", "/tmp/browseros-alpha")
+
+	if got != "/tmp/browseros-alpha" {
+		t.Fatalf("prompt returned %q", got)
+	}
+	if want := "Repo path [/tmp/browseros-alpha]: "; !strings.Contains(stripANSI(out.String()), want) {
+		t.Fatalf("missing prompt %q in\n%s", want, out.String())
+	}
+}
+
+func TestChooseProfileWritesChoicesToOutputWriter(t *testing.T) {
+	var out bytes.Buffer
+	reader := bufio.NewReader(strings.NewReader("\n"))
+
+	got := chooseProfile(&out, reader, []profile.BrowserProfile{{
+		Name:  "Main",
+		Dir:   "Default",
+		Email: "you@example.com",
+	}})
+
+	if got != "Default" {
+		t.Fatalf("chooseProfile returned %q", got)
+	}
+	for _, want := range []string{
+		"Found 1 BrowserOS profiles:",
+		"1. Main (Default) you@example.com",
+		"Select source profile [1]: ",
+	} {
+		if !strings.Contains(stripANSI(out.String()), want) {
+			t.Fatalf("missing %q in\n%s", want, out.String())
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Adds lightweight inline guidance to browseros-dogfood init for repo path and source profile.
- Explains that repo path should be the root of a separate BrowserOS monorepo clone, not packages/browseros-agent.
- Clarifies that dogfood copies the selected installed BrowserOS profile into a separate dev profile.

## Design
The init flow now prints short help only next to the prompts that need it. BrowserOS binary keeps the existing default-only prompt, config behavior is unchanged, and interactive prompt output now uses Cobra's command output writer consistently for testability. The copy and prompt output behavior are covered by focused unit tests.

## Test plan
- go test ./...