### PR TITLE
fix(openclaw): wire LlmProvider.supportsImages through to OpenClaw model config

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -794,6 +794,7 @@ export const AgentsPage: FC = () => {
         baseUrl: llmOption?.baseUrl,
         apiKey: llmOption?.apiKey,
         modelId: option?.modelId,
+        supportsImages: llmOption?.supportsImages,
       })
       setSetupOpen(false)
       if (isCli) setCliAuthModalOpen(true)
@@ -820,6 +821,7 @@ export const AgentsPage: FC = () => {
         baseUrl: llmOption?.baseUrl,
         apiKey: llmOption?.apiKey,
         modelId: option?.modelId,
+        supportsImages: llmOption?.supportsImages,
       })
       setCreateOpen(false)
       setNewName('')

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/useOpenClaw.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/useOpenClaw.ts
@@ -41,6 +41,7 @@ export interface OpenClawAgentMutationInput {
   baseUrl?: string
   apiKey?: string
   modelId?: string
+  supportsImages?: boolean
 }
 
 export interface OpenClawSetupInput {
@@ -49,6 +50,10 @@ export interface OpenClawSetupInput {
   baseUrl?: string
   apiKey?: string
   modelId?: string
+  // Mirrors LlmProviderConfig.supportsImages — pass-through so the gateway
+  // can declare the model's input modalities correctly when persisting the
+  // custom-provider config.
+  supportsImages?: boolean
 }
 
 export function getModelDisplayName(model: unknown): string | undefined {

--- a/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/openclaw.ts
@@ -240,6 +240,7 @@ export function createOpenClawRoutes() {
         baseUrl?: string
         apiKey?: string
         modelId?: string
+        supportsImages?: boolean
       }>()
 
       try {
@@ -249,6 +250,7 @@ export function createOpenClawRoutes() {
           hasBaseUrl: !!body.baseUrl,
           hasModel: !!body.modelId,
           hasApiKey: !!body.apiKey,
+          supportsImages: !!body.supportsImages,
         })
         const logs: string[] = []
         await getOpenClawService().setup(body, (msg) => logs.push(msg))
@@ -350,6 +352,7 @@ export function createOpenClawRoutes() {
         baseUrl?: string
         apiKey?: string
         modelId?: string
+        supportsImages?: boolean
       }>()
       const validationError = getCreateAgentValidationError(body)
       if (validationError) {
@@ -364,6 +367,7 @@ export function createOpenClawRoutes() {
           baseUrl: body.baseUrl,
           apiKey: body.apiKey,
           modelId: body.modelId,
+          supportsImages: body.supportsImages,
         })
         return c.json({ agent }, 201)
       } catch (err) {

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-provider-map.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-provider-map.ts
@@ -114,6 +114,12 @@ export function resolveSupportedOpenClawProvider(input: {
   baseUrl?: string
   apiKey?: string
   modelId?: string
+  // Honors the agent UI's "Supports Image" flag on the LlmProvider record
+  // (apps/agent/lib/llm-providers/types.ts). When true, the custom-provider
+  // model entry advertises `input: ['text', 'image']` so OpenClaw forwards
+  // image content parts to the model. When undefined/false, OpenClaw's
+  // default `input: ['text']` is preserved and image content is stripped.
+  supportsImages?: boolean
 }): ResolvedOpenClawProviderConfig {
   if (!input.providerType) {
     return { envValues: {} }
@@ -135,6 +141,9 @@ export function resolveSupportedOpenClawProvider(input: {
 
   const providerId = deriveOpenClawProviderId(input)
   const apiKeyEnvVar = deriveOpenClawApiKeyEnvVar(providerId)
+  const modelInput: ('text' | 'image')[] = input.supportsImages
+    ? ['text', 'image']
+    : ['text']
 
   return {
     envValues: input.apiKey ? { [apiKeyEnvVar]: input.apiKey } : {},
@@ -148,7 +157,13 @@ export function resolveSupportedOpenClawProvider(input: {
         apiKey: `\${${apiKeyEnvVar}}`,
         ...(input.modelId
           ? {
-              models: [{ id: input.modelId, name: input.modelId }],
+              models: [
+                {
+                  id: input.modelId,
+                  name: input.modelId,
+                  input: modelInput,
+                },
+              ],
             }
           : {}),
       },

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -128,6 +128,11 @@ export interface SetupInput {
   baseUrl?: string
   apiKey?: string
   modelId?: string
+  // The agent UI's "Supports Image" flag (LlmProviderConfig.supportsImages).
+  // Pass-through to provider-map so custom OpenAI-compat providers can
+  // advertise `input: ['text', 'image']` on their model entries when the
+  // user asserted vision support.
+  supportsImages?: boolean
 }
 
 export interface OpenClawProviderUpdateResult {
@@ -959,6 +964,7 @@ export class OpenClawService {
     baseUrl?: string
     apiKey?: string
     modelId?: string
+    supportsImages?: boolean
   }): Promise<OpenClawAgentEntry> {
     const { name } = input
     if (!AGENT_NAME_PATTERN.test(name)) {
@@ -972,6 +978,7 @@ export class OpenClawService {
       hasBaseUrl: !!input.baseUrl,
       hasModel: !!input.modelId,
       hasApiKey: !!input.apiKey,
+      supportsImages: !!input.supportsImages,
     })
     await this.assertGatewayReady()
 
@@ -1734,6 +1741,16 @@ export class OpenClawService {
       {
         path: 'agents.defaults.memorySearch.enabled',
         value: false,
+      },
+      {
+        // Enable OpenClaw's image-understanding pipeline so models that
+        // declare `input: ['text', 'image']` actually receive image bytes
+        // instead of having them stripped at the gateway. Without this,
+        // image_url content parts are silently dropped even if the model
+        // and provider both support vision. Per-model `input` still gates
+        // which models see images — this just turns the global pipeline on.
+        path: 'tools.media.image.enabled',
+        value: true,
       },
     ]
 

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/openclaw-service.test.ts
@@ -556,6 +556,10 @@ describe('OpenClawService', () => {
           path: 'gateway.http.endpoints.chatCompletions.enabled',
           value: true,
         },
+        {
+          path: 'tools.media.image.enabled',
+          value: true,
+        },
       ]),
     )
     expect(validateConfig).toHaveBeenCalled()
@@ -1270,6 +1274,7 @@ describe('OpenClawService', () => {
       providerType: 'moonshot',
     })
 
+    // Without supportsImages → emit text-only `input` per OpenClaw schema.
     expect(
       resolveSupportedOpenClawProvider({
         providerType: 'openai-compatible',
@@ -1294,6 +1299,41 @@ describe('OpenClawService', () => {
             {
               id: 'accounts/fireworks/models/kimi-k2p5',
               name: 'accounts/fireworks/models/kimi-k2p5',
+              input: ['text'],
+            },
+          ],
+        },
+      },
+    })
+
+    // With supportsImages → emit ['text', 'image'] so OpenClaw forwards
+    // image content parts to the model instead of stripping them.
+    expect(
+      resolveSupportedOpenClawProvider({
+        providerType: 'openai-compatible',
+        providerName: 'Kimi K2.5',
+        baseUrl: 'https://api.fireworks.ai/inference/v1',
+        apiKey: 'custom-key',
+        modelId: 'accounts/fireworks/models/kimi-k2p5',
+        supportsImages: true,
+      }),
+    ).toEqual({
+      envValues: {
+        KIMI_K2_5_API_KEY: 'custom-key',
+      },
+      model: 'kimi-k2-5/accounts/fireworks/models/kimi-k2p5',
+      customProvider: {
+        providerId: 'kimi-k2-5',
+        apiKeyEnvVar: 'KIMI_K2_5_API_KEY',
+        config: {
+          api: 'openai-completions',
+          baseUrl: 'https://api.fireworks.ai/inference/v1',
+          apiKey: `\${KIMI_K2_5_API_KEY}`,
+          models: [
+            {
+              id: 'accounts/fireworks/models/kimi-k2p5',
+              name: 'accounts/fireworks/models/kimi-k2p5',
+              input: ['text', 'image'],
             },
           ],
         },


### PR DESCRIPTION
## Summary

When BrowserOS sets up a custom OpenAI-compat provider on the gateway, the agent UI's "Supports Image" flag (`LlmProviderConfig.supportsImages` from `/settings/ai`) was being dropped. The persisted model entry under `models.providers.<id>.models[]` ended up with no `input` field, OpenClaw defaulted it to `["text"]`, and `image_url` content parts were silently stripped before the model saw them — even for vision-capable providers like Kimi K2.5 / Fireworks.

This was caught while building the ACP bridge spike: a control test against `POST /v1/chat/completions` directly worked once the model entry was manually patched to `input: ["text", "image"]` and `tools.media.image.enabled` was flipped on. This commit makes that the default behavior on bootstrap.

### What changed

- **`OpenClawSetupInput` / `OpenClawAgentMutationInput`** (agent and server) accept `supportsImages?: boolean`.
- **`AgentsPage.tsx`** — both `handleSetup` and `handleCreate` forward `llmOption?.supportsImages` from the selected `LlmProviderConfig`.
- **`/setup` and `/agents` routes** accept and log the new field.
- **`provider-map.resolveSupportedOpenClawProvider`** emits `input: ['text', 'image']` on the model entry when the flag is truthy; otherwise emits an explicit `['text']` (avoids relying on OpenClaw's implicit default).
- **`applyBrowserosConfig()`** adds `tools.media.image.enabled = true` to the bootstrap batch so the gateway's image-understanding pipeline is wired up. Per-model `input` still gates which models actually see images.

### Out of scope

- **Existing custom-provider configs are not auto-migrated.** The `supportsImages` intent isn't recoverable from the persisted server config alone (the source of truth is the LlmProvider record on the agent side). Existing users restore image support either by re-running setup or by editing `models.providers.<id>.models[*].input` manually.
- **ACP `image` content blocks remain dropped** by the OpenClaw bridge — that's a separate bridge bug that BrowserOS cannot fix on its own. This commit only restores image support on the OpenAI-compat HTTP path.

## Test plan

- [x] `bun run --filter @browseros/server typecheck` → exit 0
- [x] `openclaw-service.test.ts` — 37/38 pass (the single failure is a pre-existing port-rotation flake on `dev`, unrelated)
- [x] `openclaw.test.ts` (routes) — 13/13 pass
- [x] Lefthook hooks (biome-check, file-length, conventional commit) all pass
- [ ] Manual repro check: fresh setup with a vision-capable Kimi/Fireworks provider, send a screenshot via chat, verify the model can describe it
- [ ] Verify `LIMA_HOME=~/.browseros-dev/lima limactl shell browseros-vm -- nerdctl exec browseros-openclaw-openclaw-gateway-1 openclaw config get models.providers.<id>.models` shows `input: ['text', 'image']`
- [ ] Verify `... openclaw config get tools.media` returns `{ "image": { "enabled": true } }`