### PR TITLE
feat: use dev dock icon for dev launches

### DIFF
--- a/packages/browseros-agent/apps/agent/web-ext.config.ts
+++ b/packages/browseros-agent/apps/agent/web-ext.config.ts
@@ -8,6 +8,7 @@ const chromiumArgs = [
   '--show-component-extension-options',
   '--disable-browseros-server',
   '--disable-browseros-extensions',
+  '--browseros-dock-icon=dev',
 ]
 
 if (env.BROWSEROS_CDP_PORT) {

--- a/packages/browseros-agent/apps/server/tests/__helpers__/browser.ts
+++ b/packages/browseros-agent/apps/server/tests/__helpers__/browser.ts
@@ -98,6 +98,7 @@ export async function spawnBrowser(
       // Match the supported dev/eval launch path and keep legacy BrowserOS
       // extensions from trying to talk to the removed controller bridge.
       '--disable-browseros-extensions',
+      '--browseros-dock-icon=dev',
       '--enable-logging=stderr',
       ...(config.headless ? ['--headless=new'] : []),
       ...config.extraArgs,

--- a/packages/browseros-agent/apps/server/tests/browser-launch-args.test.ts
+++ b/packages/browseros-agent/apps/server/tests/browser-launch-args.test.ts
@@ -1,0 +1,92 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from 'node:fs'
+import { createServer } from 'node:http'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { killBrowser, spawnBrowser } from './__helpers__/browser'
+
+async function waitForFile(path: string): Promise<void> {
+  for (let attempt = 0; attempt < 50; attempt++) {
+    if (existsSync(path)) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10))
+  }
+  throw new Error(`timed out waiting for ${path}`)
+}
+
+describe('spawnBrowser', () => {
+  afterEach(async () => {
+    await killBrowser()
+  })
+
+  it('uses the dev dock icon for server test browsers', async () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'browseros-launch-args-'))
+    const argsPath = join(tempDir, 'args.txt')
+    const binaryPath = join(tempDir, 'browseros-fake')
+    await Bun.write(
+      binaryPath,
+      [
+        '#!/bin/sh',
+        'args_file="$BROWSEROS_TEST_ARGS_FILE.tmp"',
+        ': > "$args_file"',
+        'for arg in "$@"; do',
+        '  printf "%s\\n" "$arg" >> "$args_file"',
+        'done',
+        'mv "$args_file" "$BROWSEROS_TEST_ARGS_FILE"',
+        'sleep 60',
+      ].join('\n'),
+    )
+    chmodSync(binaryPath, 0o755)
+
+    const cdpServer = createServer((_request, response) => {
+      response.writeHead(200, { 'content-type': 'application/json' })
+      response.end('{"Browser":"BrowserOS"}')
+    })
+    await new Promise<void>((resolve) => cdpServer.listen(0, resolve))
+    const address = cdpServer.address()
+    if (!address || typeof address === 'string') {
+      throw new Error('failed to allocate CDP test port')
+    }
+
+    const originalArgsFile = process.env.BROWSEROS_TEST_ARGS_FILE
+    process.env.BROWSEROS_TEST_ARGS_FILE = argsPath
+    try {
+      await spawnBrowser({
+        cdpPort: address.port,
+        serverPort: address.port + 1,
+        extensionPort: address.port + 2,
+        binaryPath,
+        userDataDir: mkdtempSync(join(tmpdir(), 'browseros-test-')),
+        headless: false,
+        extraArgs: [],
+      })
+
+      await waitForFile(argsPath)
+      const args = readFileSync(argsPath, 'utf8').split('\n')
+      expect(args).toContain('--browseros-dock-icon=dev')
+    } finally {
+      if (originalArgsFile === undefined) {
+        delete process.env.BROWSEROS_TEST_ARGS_FILE
+      } else {
+        process.env.BROWSEROS_TEST_ARGS_FILE = originalArgsFile
+      }
+      await killBrowser()
+      await new Promise<void>((resolve, reject) => {
+        cdpServer.close((error) => (error ? reject(error) : resolve()))
+      })
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/browseros-agent/tools/dev/browser/args.go
+++ b/packages/browseros-agent/tools/dev/browser/args.go
@@ -28,6 +28,7 @@ func BuildArgs(cfg ArgsConfig) []string {
 		"--use-mock-keychain",
 		"--show-component-extension-options",
 		"--disable-browseros-server",
+		"--browseros-dock-icon=dev",
 	)
 
 	if cfg.LoadDevExtensions {

--- a/packages/browseros-agent/tools/dev/browser/args_test.go
+++ b/packages/browseros-agent/tools/dev/browser/args_test.go
@@ -1,0 +1,21 @@
+package browser
+
+import (
+	"strings"
+	"testing"
+
+	"browseros-dev/proc"
+)
+
+func TestBuildArgsUsesDevDockIcon(t *testing.T) {
+	args := BuildArgs(ArgsConfig{
+		Root:              "/repo/packages/browseros-agent",
+		Ports:             proc.Ports{CDP: 9005, Server: 9105, Extension: 9305},
+		UserDataDir:       "/tmp/browseros-dev",
+		LoadDevExtensions: true,
+	})
+	joined := strings.Join(args, "\n")
+	if !strings.Contains(joined, "--browseros-dock-icon=dev") {
+		t.Fatalf("missing dev dock icon arg in\n%s", joined)
+	}
+}


### PR DESCRIPTION
**Summary**
- Pass `--browseros-dock-icon=dev` through the WXT dev launch path used by `bun run dev:watch`.
- Pass the same dev dock icon through `tools/dev` browser launches and server test BrowserOS launches.
- Add focused regression coverage for the Go dev arg builder and server test browser launch args.

**Design**
The change keeps the existing launch surfaces intact and adds the `dev` dock icon switch where BrowserOS arguments are already assembled: WXT web-ext config, the Go `tools/dev` browser arg builder, and the server test browser helper. This matches the existing dogfood alpha icon approach while keeping dev/test sessions visually distinct from alpha and normal BrowserOS.

**Test plan**
- `go test -count=1 ./...` from `packages/browseros-agent/tools/dev`
- `bun --env-file=.env.development test ./tests/browser-launch-args.test.ts` from `packages/browseros-agent/apps/server`
- `bunx biome check apps/agent/web-ext.config.ts apps/server/tests/__helpers__/browser.ts apps/server/tests/browser-launch-args.test.ts`
- `bun --env-file=apps/agent/.env.development -e "import config from './apps/agent/web-ext.config.ts'; console.log(config.chromiumArgs.includes('--browseros-dock-icon=dev'))"`
- `git diff --check`