### PR TITLE
fix(dogfood): copy extension state into dev profile

### DIFF
--- a/packages/browseros-agent/tools/dogfood/README.md
+++ b/packages/browseros-agent/tools/dogfood/README.md
@@ -95,12 +95,16 @@ browseros-dogfood stop
 - BrowserOS state, including the local server state and VM data, lives under `~/.browseros-dogfood`.
 - The imported dev profile lives under `~/.config/browseros-dogfood/profile`.
 - Your installed BrowserOS profile is only used as the source import. It is not where alpha dogfood runs.
+- Installed extensions, extension-specific settings/state, and extension-owned IndexedDB data are copied so dogfood sessions keep extension setup close to your normal profile.
+- Cache and broad site storage directories are not copied.
 
 To re-import your main profile:
 
 ```bash
 browseros-dogfood start --refresh-profile
 ```
+
+If BrowserOS appears to be using the source profile during import, the CLI asks you to quit BrowserOS and press Enter before copying. You can type `continue` if the lock files are stale and you want to import anyway.
 
 ## Config
 

--- a/packages/browseros-agent/tools/dogfood/cmd/refresh_profile.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/refresh_profile.go
@@ -1,7 +1,9 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
+	"os"
 
 	"browseros-dogfood/config"
 	"browseros-dogfood/profile"
@@ -20,6 +22,9 @@ var refreshProfileCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		cfg, err := loadConfig()
 		if err != nil {
+			return err
+		}
+		if err := promptIfSourceProfileInUse(cmd.OutOrStdout(), bufio.NewReader(os.Stdin), cfg, true); err != nil {
 			return err
 		}
 		if err := profile.Import(profile.ImportConfig{

--- a/packages/browseros-agent/tools/dogfood/cmd/refresh_profile.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/refresh_profile.go
@@ -2,11 +2,13 @@ package cmd
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"os"
 
 	"browseros-dogfood/config"
 	"browseros-dogfood/profile"
+	dogfoodruntime "browseros-dogfood/runtime"
 
 	"github.com/spf13/cobra"
 )
@@ -24,6 +26,18 @@ var refreshProfileCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		paths, err := defaultRunPaths()
+		if err != nil {
+			return err
+		}
+		lock, err := acquireRefreshProfileLock(paths)
+		if err != nil {
+			return err
+		}
+		defer lock.Close()
+		if err := ensureDevProfileNotInUse(cfg); err != nil {
+			return err
+		}
 		if err := promptIfSourceProfileInUse(cmd.OutOrStdout(), bufio.NewReader(os.Stdin), cfg, true); err != nil {
 			return err
 		}
@@ -38,6 +52,43 @@ var refreshProfileCmd = &cobra.Command{
 		fmt.Printf("%s %s\n", successStyle.Sprint("Profile refreshed:"), pathStyle.Sprint(cfg.DevUserDataDir))
 		return nil
 	},
+}
+
+func acquireRefreshProfileLock(paths runPaths) (*dogfoodruntime.Lock, error) {
+	lock, err := dogfoodruntime.AcquireLock(paths.Lock)
+	if err == nil {
+		if cleanupErr := dogfoodruntime.CleanupStaleRunFiles(paths.State); cleanupErr != nil {
+			lock.Close()
+			return nil, cleanupErr
+		}
+		return lock, nil
+	}
+	if errors.Is(err, dogfoodruntime.ErrAlreadyRunning) {
+		return nil, refreshProfileRunningError(paths)
+	}
+	return nil, err
+}
+
+func refreshProfileRunningError(paths runPaths) error {
+	state, err := dogfoodruntime.ReadRunState(paths.State)
+	if err == nil {
+		if state.Mode == "background" {
+			return fmt.Errorf("cannot refresh profile while browseros-dogfood background daemon is running (pid %d); run `browseros-dogfood stop` first", state.PID)
+		}
+		return fmt.Errorf("cannot refresh profile while browseros-dogfood is running in foreground mode (pid %d); stop it first", state.PID)
+	}
+	return fmt.Errorf("cannot refresh profile while browseros-dogfood is running; run `browseros-dogfood stop` first")
+}
+
+func ensureDevProfileNotInUse(cfg config.Config) error {
+	inUse, err := profile.HasSingletons(cfg.DevUserDataDir)
+	if err != nil {
+		return err
+	}
+	if inUse {
+		return fmt.Errorf("cannot refresh profile because the dogfood dev profile is in use at %s; run `browseros-dogfood stop` first", cfg.DevUserDataDir)
+	}
+	return nil
 }
 
 func loadConfig() (config.Config, error) {

--- a/packages/browseros-agent/tools/dogfood/cmd/refresh_profile_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/refresh_profile_test.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"browseros-dogfood/config"
+	dogfoodruntime "browseros-dogfood/runtime"
+)
+
+func TestAcquireRefreshProfileLockReportsStopCommandWhenRunning(t *testing.T) {
+	paths := newRunPaths(filepath.Join(t.TempDir(), "config.yaml"))
+	lock, err := dogfoodruntime.AcquireLock(paths.Lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lock.Close()
+	if err := dogfoodruntime.WriteRunState(paths.State, dogfoodruntime.RunState{
+		PID:  12345,
+		Mode: "background",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = acquireRefreshProfileLock(paths)
+
+	if err == nil {
+		t.Fatal("expected refresh profile lock error")
+	}
+	for _, want := range []string{"cannot refresh profile", "browseros-dogfood stop", "12345"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error missing %q: %v", want, err)
+		}
+	}
+}
+
+func TestEnsureDevProfileNotInUseReportsStopCommand(t *testing.T) {
+	devUserDataDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(devUserDataDir, "SingletonLock"), []byte("lock"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ensureDevProfileNotInUse(config.Config{DevUserDataDir: devUserDataDir})
+
+	if err == nil {
+		t.Fatal("expected dev profile in-use error")
+	}
+	for _, want := range []string{"cannot refresh profile", "browseros-dogfood stop", devUserDataDir} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error missing %q: %v", want, err)
+		}
+	}
+}

--- a/packages/browseros-agent/tools/dogfood/cmd/source_profile.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/source_profile.go
@@ -39,11 +39,11 @@ func confirmSourceProfileImportWithChecker(out io.Writer, r *bufio.Reader, hasSi
 		fmt.Fprintln(out, warnStyle.Sprint("BrowserOS appears to be using the source profile."))
 		fmt.Fprintf(out, "%s ", labelStyle.Sprint("Quit BrowserOS, then press Enter to retry, or type \"continue\" to import anyway:"))
 		line, err := r.ReadString('\n')
-		if err != nil {
-			return err
-		}
 		if strings.EqualFold(strings.TrimSpace(line), "continue") {
 			return nil
+		}
+		if err != nil {
+			return err
 		}
 	}
 }

--- a/packages/browseros-agent/tools/dogfood/cmd/source_profile.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/source_profile.go
@@ -1,0 +1,49 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"strings"
+
+	"browseros-dogfood/config"
+	"browseros-dogfood/profile"
+)
+
+func promptIfSourceProfileInUse(out io.Writer, r *bufio.Reader, cfg config.Config, refreshProfile bool) error {
+	if !profileImportNeeded(cfg, refreshProfile) {
+		return nil
+	}
+	return confirmSourceProfileImport(out, r, cfg.SourceUserDataDir)
+}
+
+func profileImportNeeded(cfg config.Config, refreshProfile bool) bool {
+	return refreshProfile || !exists(cfg.DevUserDataDir)
+}
+
+func confirmSourceProfileImport(out io.Writer, r *bufio.Reader, sourceUserDataDir string) error {
+	return confirmSourceProfileImportWithChecker(out, r, func() (bool, error) {
+		return profile.HasSingletons(sourceUserDataDir)
+	})
+}
+
+func confirmSourceProfileImportWithChecker(out io.Writer, r *bufio.Reader, hasSingletons func() (bool, error)) error {
+	for {
+		active, err := hasSingletons()
+		if err != nil {
+			return err
+		}
+		if !active {
+			return nil
+		}
+		fmt.Fprintln(out, warnStyle.Sprint("BrowserOS appears to be using the source profile."))
+		fmt.Fprintf(out, "%s ", labelStyle.Sprint("Quit BrowserOS, then press Enter to retry, or type \"continue\" to import anyway:"))
+		line, err := r.ReadString('\n')
+		if err != nil {
+			return err
+		}
+		if strings.EqualFold(strings.TrimSpace(line), "continue") {
+			return nil
+		}
+	}
+}

--- a/packages/browseros-agent/tools/dogfood/cmd/source_profile_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/source_profile_test.go
@@ -56,3 +56,15 @@ func TestConfirmSourceProfileImportCanContinuePastStaleLock(t *testing.T) {
 		t.Fatalf("missing continue escape hatch: %q", out.String())
 	}
 }
+
+func TestConfirmSourceProfileImportCanContinueWithoutTrailingNewline(t *testing.T) {
+	var out bytes.Buffer
+	err := confirmSourceProfileImportWithChecker(
+		&out,
+		bufio.NewReader(strings.NewReader("continue")),
+		func() (bool, error) { return true, nil },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/packages/browseros-agent/tools/dogfood/cmd/source_profile_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/source_profile_test.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestConfirmSourceProfileImportReturnsWithoutPromptWhenUnlocked(t *testing.T) {
+	var out bytes.Buffer
+	err := confirmSourceProfileImportWithChecker(
+		&out,
+		bufio.NewReader(strings.NewReader("")),
+		func() (bool, error) { return false, nil },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if out.String() != "" {
+		t.Fatalf("unexpected prompt: %q", out.String())
+	}
+}
+
+func TestConfirmSourceProfileImportRetriesAfterUserQuitsBrowserOS(t *testing.T) {
+	var out bytes.Buffer
+	checks := []bool{true, false}
+	err := confirmSourceProfileImportWithChecker(
+		&out,
+		bufio.NewReader(strings.NewReader("\n")),
+		func() (bool, error) {
+			next := checks[0]
+			checks = checks[1:]
+			return next, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "Quit BrowserOS") {
+		t.Fatalf("missing quit prompt: %q", out.String())
+	}
+}
+
+func TestConfirmSourceProfileImportCanContinuePastStaleLock(t *testing.T) {
+	var out bytes.Buffer
+	err := confirmSourceProfileImportWithChecker(
+		&out,
+		bufio.NewReader(strings.NewReader("continue\n")),
+		func() (bool, error) { return true, nil },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "continue") {
+		t.Fatalf("missing continue escape hatch: %q", out.String())
+	}
+}

--- a/packages/browseros-agent/tools/dogfood/cmd/start.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/start.go
@@ -178,7 +178,7 @@ func buildAndStartEnvironment(ctx context.Context, cfg config.Config, opts envir
 }
 
 func prepareEnvironment(cfg *config.Config, agentRoot string, opts environmentOptions) error {
-	if opts.RefreshProfile || !exists(cfg.DevUserDataDir) {
+	if profileImportNeeded(*cfg, opts.RefreshProfile) {
 		if err := profile.Import(profile.ImportConfig{
 			SourceUserDataDir: cfg.SourceUserDataDir,
 			SourceProfileDir:  cfg.SourceProfileDir,

--- a/packages/browseros-agent/tools/dogfood/cmd/start.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/start.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
 	"errors"
 	"fmt"
@@ -50,6 +51,9 @@ var startCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		if err := promptIfSourceProfileInUse(cmd.OutOrStdout(), bufio.NewReader(os.Stdin), cfg, startRefreshProfile); err != nil {
+			return err
+		}
 		paths, err := defaultRunPaths()
 		if err != nil {
 			return err
@@ -74,7 +78,11 @@ var startBackgroundCmd = &cobra.Command{
 	Short:   "Start BrowserOS dogfooding environment in the background",
 	GroupID: groupRun,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if _, err := loadConfig(); err != nil {
+		cfg, err := loadConfig()
+		if err != nil {
+			return err
+		}
+		if err := promptIfSourceProfileInUse(cmd.OutOrStdout(), bufio.NewReader(os.Stdin), cfg, startBackgroundRefreshProfile); err != nil {
 			return err
 		}
 		paths, err := defaultRunPaths()

--- a/packages/browseros-agent/tools/dogfood/profile/import.go
+++ b/packages/browseros-agent/tools/dogfood/profile/import.go
@@ -40,6 +40,8 @@ var profileGlobAllowlist = []string{
 	filepath.Join("IndexedDB", "chrome-extension_*"),
 }
 
+var warningOutput io.Writer = os.Stderr
+
 func Import(cfg ImportConfig) error {
 	if cfg.SourceUserDataDir == "" || cfg.SourceProfileDir == "" || cfg.DevUserDataDir == "" || cfg.DevProfileDir == "" {
 		return fmt.Errorf("source and dev profile paths are required")
@@ -186,6 +188,7 @@ func patchPreferences(path string) error {
 	}
 	var prefs map[string]any
 	if err := json.Unmarshal(data, &prefs); err != nil {
+		warnPatchSkipped(path, err)
 		return nil
 	}
 	profile, ok := prefs["profile"].(map[string]any)
@@ -212,6 +215,7 @@ func patchLocalState(path string, sourceProfileDir string, devProfileDir string)
 	}
 	var state map[string]any
 	if err := json.Unmarshal(data, &state); err != nil {
+		warnPatchSkipped(path, err)
 		return nil
 	}
 	profile := ensureObject(state, "profile")
@@ -227,6 +231,10 @@ func patchLocalState(path string, sourceProfileDir string, devProfileDir string)
 		return err
 	}
 	return os.WriteFile(path, out, 0644)
+}
+
+func warnPatchSkipped(path string, err error) {
+	fmt.Fprintf(warningOutput, "warning: could not patch %s: invalid JSON: %v\n", path, err)
 }
 
 func ensureObject(parent map[string]any, key string) map[string]any {

--- a/packages/browseros-agent/tools/dogfood/profile/import.go
+++ b/packages/browseros-agent/tools/dogfood/profile/import.go
@@ -19,7 +19,13 @@ type ImportConfig struct {
 
 var profileAllowlist = []string{
 	"Extensions",
+	"Extension State",
+	"Extension Rules",
+	"DNR Extension Rules",
+	"Extension Scripts",
 	"Local Extension Settings",
+	"Sync Extension Settings",
+	"Managed Extension Settings",
 	"Login Data",
 	"Login Data For Account",
 	"Cookies",
@@ -28,6 +34,10 @@ var profileAllowlist = []string{
 	"Preferences",
 	"Web Data",
 	"History",
+}
+
+var profileGlobAllowlist = []string{
+	filepath.Join("IndexedDB", "chrome-extension_*"),
 }
 
 func Import(cfg ImportConfig) error {
@@ -62,6 +72,11 @@ func Import(cfg ImportConfig) error {
 			return err
 		}
 	}
+	for _, pattern := range profileGlobAllowlist {
+		if err := copyGlob(sourceProfile, devProfile, pattern); err != nil {
+			return err
+		}
+	}
 	if err := patchPreferences(filepath.Join(devProfile, "Preferences")); err != nil {
 		return err
 	}
@@ -81,6 +96,14 @@ func CleanupSingletons(userDataDir string) error {
 	return nil
 }
 
+func HasSingletons(userDataDir string) (bool, error) {
+	entries, err := filepath.Glob(filepath.Join(userDataDir, "Singleton*"))
+	if err != nil {
+		return false, err
+	}
+	return len(entries) > 0, nil
+}
+
 func copyIfExists(src string, dst string) error {
 	info, err := os.Stat(src)
 	if os.IsNotExist(err) {
@@ -93,6 +116,23 @@ func copyIfExists(src string, dst string) error {
 		return copyDir(src, dst)
 	}
 	return copyFile(src, dst, info.Mode())
+}
+
+func copyGlob(srcRoot string, dstRoot string, pattern string) error {
+	matches, err := filepath.Glob(filepath.Join(srcRoot, pattern))
+	if err != nil {
+		return err
+	}
+	for _, src := range matches {
+		rel, err := filepath.Rel(srcRoot, src)
+		if err != nil {
+			return err
+		}
+		if err := copyIfExists(src, filepath.Join(dstRoot, rel)); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func copyDir(src string, dst string) error {

--- a/packages/browseros-agent/tools/dogfood/profile/import_test.go
+++ b/packages/browseros-agent/tools/dogfood/profile/import_test.go
@@ -1,9 +1,11 @@
 package profile
 
 import (
+	"bytes"
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -137,6 +139,48 @@ func TestHasSingletonsDetectsProfileLockFiles(t *testing.T) {
 	}
 	if !hasSingletons {
 		t.Fatal("expected singleton files")
+	}
+}
+
+func TestHasSingletonsReturnsFalseForMissingDir(t *testing.T) {
+	hasSingletons, err := HasSingletons(filepath.Join(t.TempDir(), "missing"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if hasSingletons {
+		t.Fatal("expected no singleton files")
+	}
+}
+
+func TestPatchPreferencesWarnsOnInvalidJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Preferences")
+	mustWrite(t, path, "{")
+	var out bytes.Buffer
+	old := warningOutput
+	warningOutput = &out
+	defer func() { warningOutput = old }()
+
+	if err := patchPreferences(path); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "could not patch") || !strings.Contains(out.String(), path) {
+		t.Fatalf("missing warning, got %q", out.String())
+	}
+}
+
+func TestPatchLocalStateWarnsOnInvalidJSON(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "Local State")
+	mustWrite(t, path, "{")
+	var out bytes.Buffer
+	old := warningOutput
+	warningOutput = &out
+	defer func() { warningOutput = old }()
+
+	if err := patchLocalState(path, "Default", "Default"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "could not patch") || !strings.Contains(out.String(), path) {
+		t.Fatalf("missing warning, got %q", out.String())
 	}
 }
 

--- a/packages/browseros-agent/tools/dogfood/profile/import_test.go
+++ b/packages/browseros-agent/tools/dogfood/profile/import_test.go
@@ -30,6 +30,14 @@ func TestImportCopiesAllowlistAndLocalState(t *testing.T) {
 	mustWrite(t, filepath.Join(sourceProfile, "Preferences"), `{"profile":{"exit_type":"Crashed","exited_cleanly":false}}`)
 	mustWrite(t, filepath.Join(sourceProfile, "Cache/junk"), "cache")
 	mustWrite(t, filepath.Join(sourceProfile, "Extensions/ext/manifest.json"), "{}")
+	mustWrite(t, filepath.Join(sourceProfile, "Extension State/LOG"), "state")
+	mustWrite(t, filepath.Join(sourceProfile, "Extension Rules/rules.json"), "{}")
+	mustWrite(t, filepath.Join(sourceProfile, "DNR Extension Rules/ruleset"), "dnr")
+	mustWrite(t, filepath.Join(sourceProfile, "Extension Scripts/script.js"), "script")
+	mustWrite(t, filepath.Join(sourceProfile, "Sync Extension Settings/ext/000001.log"), "sync")
+	mustWrite(t, filepath.Join(sourceProfile, "Managed Extension Settings/ext/000001.log"), "managed")
+	mustWrite(t, filepath.Join(sourceProfile, "IndexedDB/chrome-extension_abcdef_0.indexeddb.leveldb/LOG"), "extension-indexeddb")
+	mustWrite(t, filepath.Join(sourceProfile, "IndexedDB/https_example.com_0.indexeddb.leveldb/LOG"), "site-indexeddb")
 
 	err := Import(ImportConfig{
 		SourceUserDataDir: sourceUser,
@@ -45,6 +53,14 @@ func TestImportCopiesAllowlistAndLocalState(t *testing.T) {
 	assertFile(t, filepath.Join(devUser, "Default", "Bookmarks"), "bookmarks")
 	assertMissing(t, filepath.Join(devUser, "Default", "Cache"))
 	assertFileExists(t, filepath.Join(devUser, "Default", "Extensions/ext/manifest.json"))
+	assertFile(t, filepath.Join(devUser, "Default", "Extension State/LOG"), "state")
+	assertFile(t, filepath.Join(devUser, "Default", "Extension Rules/rules.json"), "{}")
+	assertFile(t, filepath.Join(devUser, "Default", "DNR Extension Rules/ruleset"), "dnr")
+	assertFile(t, filepath.Join(devUser, "Default", "Extension Scripts/script.js"), "script")
+	assertFile(t, filepath.Join(devUser, "Default", "Sync Extension Settings/ext/000001.log"), "sync")
+	assertFile(t, filepath.Join(devUser, "Default", "Managed Extension Settings/ext/000001.log"), "managed")
+	assertFile(t, filepath.Join(devUser, "Default", "IndexedDB/chrome-extension_abcdef_0.indexeddb.leveldb/LOG"), "extension-indexeddb")
+	assertMissing(t, filepath.Join(devUser, "Default", "IndexedDB/https_example.com_0.indexeddb.leveldb"))
 	prefs, err := os.ReadFile(filepath.Join(devUser, "Default", "Preferences"))
 	if err != nil {
 		t.Fatal(err)
@@ -109,6 +125,19 @@ func TestCleanupSingletons(t *testing.T) {
 	}
 	assertMissing(t, filepath.Join(dir, "SingletonLock"))
 	assertMissing(t, filepath.Join(dir, "SingletonCookie"))
+}
+
+func TestHasSingletonsDetectsProfileLockFiles(t *testing.T) {
+	dir := t.TempDir()
+	mustWrite(t, filepath.Join(dir, "SingletonLock"), "lock")
+
+	hasSingletons, err := HasSingletons(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !hasSingletons {
+		t.Fatal("expected singleton files")
+	}
 }
 
 func assertStringList(t *testing.T, got any, want []string) {


### PR DESCRIPTION
## Summary
- Copy extension-specific profile state into the dogfood dev profile, including extension state/rules/scripts and sync/managed extension settings.
- Copy only extension-owned IndexedDB entries (`IndexedDB/chrome-extension_*`) so extension login data has a better chance of carrying over without importing broad site storage.
- Prompt before importing when the source BrowserOS profile appears to be in use, with a `continue` escape hatch for stale lock files.

## Design
The importer keeps the existing allowlist model and extends it with explicit extension state directories plus a targeted glob allowlist for extension IndexedDB origins. The import path stays non-interactive; command handlers decide whether an import is about to happen and prompt if the source profile has Chromium singleton lock files.

## Test plan
- `cd packages/browseros-agent/tools/dogfood && go test -count=1 ./...`
- `git diff --check origin/dev...HEAD`