### PR TITLE
test: cover terminal limactl resolver errors

### DIFF
--- a/packages/browseros-agent/apps/server/tests/api/routes/terminal.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/terminal.test.ts
@@ -56,4 +56,40 @@ describe('createTerminalSocketEvents', () => {
     )
     expect(close).not.toHaveBeenCalled()
   })
+
+  it('sends an error and closes when the limactl resolver throws', async () => {
+    const close = mock(() => {})
+    const send = mock(() => {})
+    const createTerminalSession = mock(() => {
+      throw new Error('should not start a session')
+    })
+    const actualTerminalSession = await import(
+      '../../../src/api/services/terminal/terminal-session'
+    )
+
+    mock.module('../../../src/api/services/terminal/terminal-session', () => ({
+      ...actualTerminalSession,
+      createTerminalSession,
+    }))
+
+    const { createTerminalSocketEvents } = await import(
+      '../../../src/api/routes/terminal'
+    )
+    const events = createTerminalSocketEvents({
+      containerName: 'gateway',
+      limaHome: '/tmp/lima',
+      limactlPath: () => {
+        throw new Error('limactl not found')
+      },
+      vmName: 'browseros-vm',
+    })
+
+    events.onOpen(new Event('open'), { send, close })
+
+    expect(createTerminalSession).not.toHaveBeenCalled()
+    expect(send).toHaveBeenCalledWith(
+      JSON.stringify({ type: 'error', message: 'limactl not found' }),
+    )
+    expect(close).toHaveBeenCalledTimes(1)
+  })
 })


### PR DESCRIPTION
**Summary**
- Adds regression coverage for the terminal websocket path when lazy `limactl` resolution fails.
- Verifies the socket sends an error and closes without attempting to start a terminal session.

**Design**
This PR is intentionally narrow: it reapplies the review follow-up from the already-merged CI fix on top of current `origin/dev`, which contains PR #853 as a squash commit. The new branch contains one commit and one test-only file change.

**Test plan**
- `cd packages/browseros-agent/apps/server && bun run test:api`
- `cd packages/browseros-agent/apps/server && bun run typecheck`
- `cd packages/browseros-agent/apps/server && bunx biome check tests/api/routes/terminal.test.ts`
- `git diff --check origin/dev..HEAD`