### PR TITLE
fix: hide BrowserOS ACP wrapper in history

### DIFF
--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
@@ -274,10 +274,30 @@ function mapToolUseToHistoryToolCall(
 }
 
 function userContentToText(content: AcpxUserContent): string {
-  if ('Text' in content) return content.Text
+  if ('Text' in content) return unwrapBrowserosAcpPrompt(content.Text)
   if ('Mention' in content) return content.Mention.content
   if ('Image' in content) return content.Image.source ? '[image]' : ''
   return ''
+}
+
+function unwrapBrowserosAcpPrompt(value: string): string {
+  const prefix = `${BROWSEROS_ACP_AGENT_INSTRUCTIONS}
+
+<user_request>
+`
+  const suffix = `
+</user_request>`
+  if (!value.startsWith(prefix) || !value.endsWith(suffix)) return value
+
+  // TODO: nikhil: remove this once acpx/runtime exposes system prompt support.
+  return unescapePromptTagText(value.slice(prefix.length, -suffix.length))
+}
+
+function unescapePromptTagText(value: string): string {
+  return value
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
 }
 
 function toolResultValue(result: AcpxToolResult): unknown {

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -229,6 +229,82 @@ describe('AcpxRuntime', () => {
     })
   })
 
+  it('shows only the user request for persisted BrowserOS-wrapped prompts', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'browseros-acpx-runtime-'))
+    const stateDir = await mkdtemp(join(tmpdir(), 'browseros-acpx-state-'))
+    tempDirs.push(cwd, stateDir)
+    const timestamp = '2026-04-28T20:00:00.000Z'
+    const agent: AgentDefinition = {
+      id: 'agent-1',
+      name: 'Browser bot',
+      adapter: 'codex',
+      permissionMode: 'approve-all',
+      sessionKey: 'agent:agent-1:main',
+      createdAt: 1000,
+      updatedAt: 1000,
+    }
+    const record: AcpSessionRecord = {
+      schema: 'acpx.session.v1',
+      acpxRecordId: agent.sessionKey,
+      acpSessionId: 'sid-1',
+      agentSessionId: 'inner-1',
+      agentCommand: 'codex --acp',
+      cwd,
+      name: agent.sessionKey,
+      createdAt: timestamp,
+      lastUsedAt: timestamp,
+      lastSeq: 0,
+      eventLog: {
+        active_path: '',
+        segment_count: 0,
+        max_segment_bytes: 0,
+        max_segments: 0,
+      },
+      closed: false,
+      messages: [
+        {
+          User: {
+            id: 'user-1',
+            content: [
+              {
+                Text: `<role>
+You are BrowserOS - a browser agent with full control of a Chromium browser through the BrowserOS MCP server.
+
+Use the BrowserOS MCP server for all browser tasks, including browsing the web, interacting with pages, inspecting browser state, and managing tabs, windows, bookmarks, and history.
+</role>
+
+<user_request>
+open &lt;example.com&gt;
+</user_request>`,
+              },
+            ],
+          },
+        },
+      ],
+      updated_at: timestamp,
+      cumulative_token_usage: {},
+      request_token_usage: {},
+      acpx: {},
+    }
+    await createRuntimeStore({ stateDir }).save(record)
+
+    const history = await new AcpxRuntime({ cwd, stateDir }).getHistory({
+      agent,
+      sessionId: 'main',
+    })
+
+    expect(history.items).toEqual([
+      {
+        id: 'agent:agent-1:main:0',
+        agentId: 'agent-1',
+        sessionId: 'main',
+        role: 'user',
+        text: 'open <example.com>',
+        createdAt: Date.parse(timestamp),
+      },
+    ])
+  })
+
   it('continues the turn when runtime config control is unavailable', async () => {
     const calls: Array<{ method: string; input: unknown }> = []
     const runtime = new AcpxRuntime({


### PR DESCRIPTION
## Summary
- Hide BrowserOS ACP wrapper instructions from persisted user-message history.
- Render only the original user request while preserving the wrapped prompt sent to acpx/runtime.
- Add regression coverage for escaped user requests inside the wrapper.

## Design
The fix stays in the BrowserOS acpx history mapping layer: persisted text content is unwrapped only when it exactly matches the BrowserOS ACP prompt wrapper, then XML entities from the wrapped user request are decoded for display. Runtime prompt submission is unchanged until acpx/runtime exposes system prompt support.

## Test plan
- `bun test apps/server/tests/lib/agents/acpx-runtime.test.ts`
- `bun run --filter @browseros/server typecheck`