### PR TITLE
feat: add sidepanel ACP chat targets

### DIFF
--- a/packages/browseros-agent/apps/agent/components/chat/ChatProviderSelector.helpers.ts
+++ b/packages/browseros-agent/apps/agent/components/chat/ChatProviderSelector.helpers.ts
@@ -31,8 +31,8 @@ export function getProviderSearchValue(
     .join(' ')
 }
 
-export function getProviderSubtitle(provider: Provider): string | null {
-  if (provider.kind !== 'acp') return null
+export function getProviderSubtitle(provider: Provider): string | undefined {
+  if (provider.kind !== 'acp') return undefined
   return provider.modelControl === 'best-effort'
     ? 'ACP model · best effort'
     : 'ACP model'

--- a/packages/browseros-agent/apps/agent/components/chat/ChatProviderSelector.helpers.ts
+++ b/packages/browseros-agent/apps/agent/components/chat/ChatProviderSelector.helpers.ts
@@ -1,0 +1,39 @@
+import type { Provider } from './chatComponentTypes'
+
+export interface ProviderOptionGroup {
+  key: 'llm' | 'acp'
+  label: string
+  options: Provider[]
+}
+
+export function groupProviderOptions(
+  providers: Provider[],
+): ProviderOptionGroup[] {
+  const llm = providers.filter((provider) => provider.kind !== 'acp')
+  const acp = providers.filter((provider) => provider.kind === 'acp')
+
+  return [
+    ...(llm.length
+      ? [{ key: 'llm' as const, label: 'AI Providers', options: llm }]
+      : []),
+    ...(acp.length
+      ? [{ key: 'acp' as const, label: 'ACP Models', options: acp }]
+      : []),
+  ]
+}
+
+export function getProviderSearchValue(
+  provider: Provider,
+  groupLabel: string,
+): string {
+  return [provider.id, provider.name, provider.type, groupLabel]
+    .filter(Boolean)
+    .join(' ')
+}
+
+export function getProviderSubtitle(provider: Provider): string | null {
+  if (provider.kind !== 'acp') return null
+  return provider.modelControl === 'best-effort'
+    ? 'ACP model · best effort'
+    : 'ACP model'
+}

--- a/packages/browseros-agent/apps/agent/components/chat/ChatProviderSelector.test.tsx
+++ b/packages/browseros-agent/apps/agent/components/chat/ChatProviderSelector.test.tsx
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  getProviderSearchValue,
+  getProviderSubtitle,
+  groupProviderOptions,
+} from './ChatProviderSelector.helpers'
+import type { Provider } from './chatComponentTypes'
+
+const options: Provider[] = [
+  { kind: 'llm', id: 'browseros', name: 'BrowserOS', type: 'browseros' },
+  {
+    kind: 'llm',
+    id: 'anthropic-sonnet',
+    name: 'Anthropic Sonnet',
+    type: 'anthropic',
+  },
+  {
+    kind: 'acp',
+    id: 'acp:claude:haiku:medium',
+    name: 'Claude Code Haiku',
+    type: 'acp',
+    modelControl: 'best-effort',
+  },
+  {
+    kind: 'acp',
+    id: 'acp:codex:gpt-5.5:medium',
+    name: 'Codex GPT-5.5',
+    type: 'acp',
+    modelControl: 'runtime-supported',
+  },
+]
+
+describe('groupProviderOptions', () => {
+  it('groups normal providers separately from ACP models', () => {
+    expect(groupProviderOptions(options)).toEqual([
+      {
+        key: 'llm',
+        label: 'AI Providers',
+        options: [options[0], options[1]],
+      },
+      {
+        key: 'acp',
+        label: 'ACP Models',
+        options: [options[2], options[3]],
+      },
+    ])
+  })
+})
+
+describe('getProviderSearchValue', () => {
+  it('matches ACP group labels and item labels', () => {
+    expect(getProviderSearchValue(options[2], 'ACP Models')).toContain(
+      'ACP Models',
+    )
+    expect(getProviderSearchValue(options[2], 'ACP Models')).toContain(
+      'Claude Code Haiku',
+    )
+  })
+})
+
+describe('getProviderSubtitle', () => {
+  it('does not present best-effort ACP models as guaranteed routing', () => {
+    expect(getProviderSubtitle(options[2])).toBe('ACP model · best effort')
+    expect(getProviderSubtitle(options[3])).toBe('ACP model')
+    expect(getProviderSubtitle(options[0])).toBeNull()
+  })
+})

--- a/packages/browseros-agent/apps/agent/components/chat/ChatProviderSelector.test.tsx
+++ b/packages/browseros-agent/apps/agent/components/chat/ChatProviderSelector.test.tsx
@@ -62,6 +62,6 @@ describe('getProviderSubtitle', () => {
   it('does not present best-effort ACP models as guaranteed routing', () => {
     expect(getProviderSubtitle(options[2])).toBe('ACP model · best effort')
     expect(getProviderSubtitle(options[3])).toBe('ACP model')
-    expect(getProviderSubtitle(options[0])).toBeNull()
+    expect(getProviderSubtitle(options[0])).toBeUndefined()
   })
 })

--- a/packages/browseros-agent/apps/agent/components/chat/ChatProviderSelector.tsx
+++ b/packages/browseros-agent/apps/agent/components/chat/ChatProviderSelector.tsx
@@ -1,4 +1,4 @@
-import { Check, Plus } from 'lucide-react'
+import { Bot, Check, Plus } from 'lucide-react'
 import type { FC, PropsWithChildren } from 'react'
 import { useState } from 'react'
 import {
@@ -17,6 +17,11 @@ import {
 import { BrowserOSIcon, ProviderIcon } from '@/lib/llm-providers/providerIcons'
 import type { ProviderType } from '@/lib/llm-providers/types'
 import { cn } from '@/lib/utils'
+import {
+  getProviderSearchValue,
+  getProviderSubtitle,
+  groupProviderOptions,
+} from './ChatProviderSelector.helpers'
 import type { Provider } from './chatComponentTypes'
 
 interface ChatProviderSelectorProps {
@@ -29,54 +34,55 @@ export const ChatProviderSelector: FC<
   PropsWithChildren<ChatProviderSelectorProps>
 > = ({ children, providers, selectedProvider, onSelectProvider }) => {
   const [open, setOpen] = useState(false)
+  const groups = groupProviderOptions(providers)
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>{children}</PopoverTrigger>
-      <PopoverContent side="bottom" align="start" className="w-48 p-0">
+      <PopoverContent side="bottom" align="start" className="w-64 p-0">
         <Command>
-          <CommandInput placeholder="Search providers..." className="h-9" />
+          <CommandInput placeholder="Search models..." className="h-9" />
           <CommandList>
-            <div className="my-2 px-2 font-semibold text-muted-foreground text-xs uppercase tracking-wide">
-              AI Provider
-            </div>
             <CommandEmpty>No provider found</CommandEmpty>
-            <CommandGroup>
-              {providers.map((provider) => {
-                const isSelected = selectedProvider.id === provider.id
-                return (
-                  <CommandItem
-                    key={provider.id}
-                    value={`${provider.id} ${provider.name}`}
-                    onSelect={() => {
-                      onSelectProvider(provider)
-                      setOpen(false)
-                    }}
-                    className={cn(
-                      'flex w-full items-center gap-3 rounded-md p-2 transition-colors',
-                      isSelected && 'bg-[var(--accent-orange)]/10',
-                    )}
-                  >
-                    <span className="text-muted-foreground">
-                      {provider.type === 'browseros' ? (
-                        <BrowserOSIcon size={18} />
-                      ) : (
-                        <ProviderIcon
-                          type={provider.type as ProviderType}
-                          size={18}
-                        />
+            {groups.map((group) => (
+              <CommandGroup key={group.key} heading={group.label}>
+                {group.options.map((provider) => {
+                  const isSelected = selectedProvider.id === provider.id
+                  const subtitle = getProviderSubtitle(provider)
+                  return (
+                    <CommandItem
+                      key={provider.id}
+                      value={getProviderSearchValue(provider, group.label)}
+                      onSelect={() => {
+                        onSelectProvider(provider)
+                        setOpen(false)
+                      }}
+                      className={cn(
+                        'flex w-full items-center gap-3 rounded-md p-2 transition-colors',
+                        isSelected && 'bg-[var(--accent-orange)]/10',
                       )}
-                    </span>
-                    <span className="flex-1 text-left text-sm">
-                      {provider.name}
-                    </span>
-                    {isSelected && (
-                      <Check className="h-3.5 w-3.5 text-[var(--accent-orange)]" />
-                    )}
-                  </CommandItem>
-                )
-              })}
-            </CommandGroup>
+                    >
+                      <span className="text-muted-foreground">
+                        <ProviderOptionIcon provider={provider} />
+                      </span>
+                      <span className="min-w-0 flex-1 text-left">
+                        <span className="block truncate text-sm">
+                          {provider.name}
+                        </span>
+                        {subtitle && (
+                          <span className="block truncate text-muted-foreground text-xs">
+                            {subtitle}
+                          </span>
+                        )}
+                      </span>
+                      {isSelected && (
+                        <Check className="h-3.5 w-3.5 text-[var(--accent-orange)]" />
+                      )}
+                    </CommandItem>
+                  )
+                })}
+              </CommandGroup>
+            ))}
             <div className="border-border border-t p-1">
               <button
                 type="button"
@@ -95,4 +101,10 @@ export const ChatProviderSelector: FC<
       </PopoverContent>
     </Popover>
   )
+}
+
+function ProviderOptionIcon({ provider }: { provider: Provider }) {
+  if (provider.kind === 'acp') return <Bot size={18} />
+  if (provider.type === 'browseros') return <BrowserOSIcon size={18} />
+  return <ProviderIcon type={provider.type as ProviderType} size={18} />
 }

--- a/packages/browseros-agent/apps/agent/components/chat/chatComponentTypes.ts
+++ b/packages/browseros-agent/apps/agent/components/chat/chatComponentTypes.ts
@@ -6,6 +6,6 @@ export interface Provider {
   id: string
   name: string
   type: ChatProviderType
-  kind?: 'llm' | 'acp'
+  kind: 'llm' | 'acp'
   modelControl?: 'runtime-supported' | 'best-effort'
 }

--- a/packages/browseros-agent/apps/agent/components/chat/chatComponentTypes.ts
+++ b/packages/browseros-agent/apps/agent/components/chat/chatComponentTypes.ts
@@ -1,7 +1,10 @@
 import type { ProviderType } from '@/lib/llm-providers/types'
 
+export type ChatProviderType = ProviderType | 'acp'
+
 export interface Provider {
   id: string
   name: string
-  type: ProviderType
+  type: ChatProviderType
+  kind?: 'llm' | 'acp'
 }

--- a/packages/browseros-agent/apps/agent/components/chat/chatComponentTypes.ts
+++ b/packages/browseros-agent/apps/agent/components/chat/chatComponentTypes.ts
@@ -7,4 +7,5 @@ export interface Provider {
   name: string
   type: ChatProviderType
   kind?: 'llm' | 'acp'
+  modelControl?: 'runtime-supported' | 'best-effort'
 }

--- a/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/NewScheduledTaskDialog.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/NewScheduledTaskDialog.tsx
@@ -164,9 +164,17 @@ export const NewScheduledTaskDialog: FC<NewScheduledTaskDialogProps> = ({
   const resolvedProvider: Provider | null = (() => {
     const id = selectedProviderId ?? defaultProviderId
     const found = providers.find((p) => p.id === id)
-    if (found) return { id: found.id, name: found.name, type: found.type }
+    if (found) {
+      return {
+        kind: 'llm' as const,
+        id: found.id,
+        name: found.name,
+        type: found.type,
+      }
+    }
     if (providers[0])
       return {
+        kind: 'llm' as const,
         id: providers[0].id,
         name: providers[0].name,
         type: providers[0].type,
@@ -175,6 +183,7 @@ export const NewScheduledTaskDialog: FC<NewScheduledTaskDialogProps> = ({
   })()
 
   const providerOptions: Provider[] = providers.map((p) => ({
+    kind: 'llm',
     id: p.id,
     name: p.name,
     type: p.type,

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ChatHeader.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ChatHeader.tsx
@@ -1,4 +1,4 @@
-import { Github, History, Plus, SettingsIcon } from 'lucide-react'
+import { Bot, Github, History, Plus, SettingsIcon } from 'lucide-react'
 import type { FC } from 'react'
 import { Link, useLocation, useNavigate } from 'react-router'
 import { ChatProviderSelector } from '@/components/chat/ChatProviderSelector'
@@ -64,7 +64,9 @@ export const ChatHeader: FC<ChatHeaderProps> = ({
             className="group relative inline-flex cursor-pointer items-center gap-2 rounded-lg p-2 text-muted-foreground transition-colors hover:bg-muted/50 hover:text-foreground data-[state=open]:bg-accent"
             title="Change AI Provider"
           >
-            {selectedProvider.type === 'browseros' ? (
+            {selectedProvider.kind === 'acp' ? (
+              <Bot className="h-[18px] w-[18px]" />
+            ) : selectedProvider.type === 'browseros' ? (
               <BrowserOSIcon size={18} />
             ) : (
               <ProviderIcon

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/sidepanel-chat-targets.test.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/sidepanel-chat-targets.test.ts
@@ -158,7 +158,7 @@ describe('persistSidepanelChatTargetSelection', () => {
       },
     })
 
-    expect(savedSelection).toEqual({
+    expect(savedSelection as SidepanelChatTargetSelection | null).toEqual({
       kind: 'acp',
       id: 'acp:codex:gpt-5.5:medium',
     })

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/sidepanel-chat-targets.test.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/sidepanel-chat-targets.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it } from 'bun:test'
+import type { HarnessAdapterDescriptor } from '@/entrypoints/app/agents/agent-harness-types'
+import type { LlmProviderConfig } from '@/lib/llm-providers/types'
+import {
+  buildSidepanelChatTargets,
+  persistSidepanelChatTargetSelection,
+  resolveSidepanelChatTarget,
+  type SidepanelChatTargetSelection,
+  toLlmProviderConfig,
+} from './sidepanel-chat-targets'
+
+const timestamp = 1000
+
+const providers: LlmProviderConfig[] = [
+  {
+    id: 'browseros',
+    type: 'browseros',
+    name: 'BrowserOS',
+    baseUrl: 'https://api.browseros.com/v1',
+    modelId: 'browseros-auto',
+    supportsImages: true,
+    contextWindow: 200000,
+    temperature: 0.2,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  },
+  {
+    id: 'anthropic-sonnet',
+    type: 'anthropic',
+    name: 'Anthropic Sonnet',
+    modelId: 'claude-sonnet-4-6',
+    apiKey: 'sk-ant',
+    supportsImages: true,
+    contextWindow: 200000,
+    temperature: 0.2,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  },
+]
+
+const adapters: HarnessAdapterDescriptor[] = [
+  {
+    id: 'claude',
+    name: 'Claude Code',
+    defaultModelId: 'haiku',
+    defaultReasoningEffort: 'medium',
+    modelControl: 'best-effort',
+    models: [
+      { id: 'sonnet', label: 'Sonnet' },
+      { id: 'haiku', label: 'Haiku', recommended: true },
+    ],
+    reasoningEfforts: [
+      { id: 'medium', label: 'Medium', recommended: true },
+      { id: 'high', label: 'High' },
+    ],
+  },
+  {
+    id: 'codex',
+    name: 'Codex',
+    defaultModelId: 'gpt-5.5',
+    defaultReasoningEffort: 'medium',
+    modelControl: 'runtime-supported',
+    models: [{ id: 'gpt-5.5', label: 'GPT-5.5', recommended: true }],
+    reasoningEfforts: [{ id: 'medium', label: 'Medium', recommended: true }],
+  },
+]
+
+describe('buildSidepanelChatTargets', () => {
+  it('returns LLM targets plus one ACP target per adapter model', () => {
+    const targets = buildSidepanelChatTargets({ providers, adapters })
+
+    expect(targets.map((target) => target.id)).toEqual([
+      'browseros',
+      'anthropic-sonnet',
+      'acp:claude:sonnet:medium',
+      'acp:claude:haiku:medium',
+      'acp:codex:gpt-5.5:medium',
+    ])
+  })
+
+  it('preserves ACP model-control and recommendation metadata', () => {
+    const targets = buildSidepanelChatTargets({ providers, adapters })
+    const haiku = targets.find(
+      (target) => target.id === 'acp:claude:haiku:medium',
+    )
+
+    expect(haiku).toMatchObject({
+      kind: 'acp',
+      adapter: 'claude',
+      modelId: 'haiku',
+      modelControl: 'best-effort',
+      recommended: true,
+      reasoningEffort: 'medium',
+    })
+  })
+
+  it('still returns LLM targets when ACP adapters are unavailable', () => {
+    expect(buildSidepanelChatTargets({ providers, adapters: [] })).toEqual([
+      {
+        kind: 'llm',
+        id: 'browseros',
+        name: 'BrowserOS',
+        type: 'browseros',
+        provider: providers[0],
+      },
+      {
+        kind: 'llm',
+        id: 'anthropic-sonnet',
+        name: 'Anthropic Sonnet',
+        type: 'anthropic',
+        provider: providers[1],
+      },
+    ])
+  })
+})
+
+describe('resolveSidepanelChatTarget', () => {
+  it('resolves selected LLM targets back to their provider config', () => {
+    const targets = buildSidepanelChatTargets({ providers, adapters })
+    const resolved = resolveSidepanelChatTarget({
+      targets,
+      defaultProviderId: 'browseros',
+      selection: { kind: 'llm', id: 'anthropic-sonnet' },
+    })
+
+    expect(resolved?.kind).toBe('llm')
+    expect(toLlmProviderConfig(resolved)?.modelId).toBe('claude-sonnet-4-6')
+  })
+
+  it('falls back to the current default LLM provider when a persisted ACP target is stale', () => {
+    const targets = buildSidepanelChatTargets({ providers, adapters: [] })
+
+    expect(
+      resolveSidepanelChatTarget({
+        targets,
+        defaultProviderId: 'anthropic-sonnet',
+        selection: { kind: 'acp', id: 'acp:claude:haiku:medium' },
+      }),
+    ).toMatchObject({
+      kind: 'llm',
+      id: 'anthropic-sonnet',
+    })
+  })
+})
+
+describe('persistSidepanelChatTargetSelection', () => {
+  it('stores only target identity and does not mutate LLM provider arrays', async () => {
+    let savedSelection: SidepanelChatTargetSelection | null = null
+    const originalProviders = providers.map((provider) => ({ ...provider }))
+    const targets = buildSidepanelChatTargets({ providers, adapters })
+    const target = targets.find(
+      (candidate) => candidate.id === 'acp:codex:gpt-5.5:medium',
+    )
+
+    await persistSidepanelChatTargetSelection(target, {
+      setValue: async (value) => {
+        savedSelection = value
+      },
+    })
+
+    expect(savedSelection).toEqual({
+      kind: 'acp',
+      id: 'acp:codex:gpt-5.5:medium',
+    })
+    expect(providers).toEqual(originalProviders)
+  })
+})

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/sidepanel-chat-targets.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/sidepanel-chat-targets.ts
@@ -1,0 +1,167 @@
+import type {
+  HarnessAdapterDescriptor,
+  HarnessAgentAdapter,
+} from '@/entrypoints/app/agents/agent-harness-types'
+import type { LlmProviderConfig, ProviderType } from '@/lib/llm-providers/types'
+
+export type SidepanelTargetKind = 'llm' | 'acp'
+
+export type SidepanelChatTarget =
+  | {
+      kind: 'llm'
+      id: string
+      name: string
+      type: ProviderType
+      provider: LlmProviderConfig
+    }
+  | {
+      kind: 'acp'
+      id: string
+      name: string
+      type: 'acp'
+      adapter: HarnessAgentAdapter
+      adapterName: string
+      modelId: string
+      modelLabel: string
+      modelControl: HarnessAdapterDescriptor['modelControl']
+      recommended?: boolean
+      reasoningEffort: string
+      reasoningEffortLabel?: string
+    }
+
+export type SidepanelChatTargetSelection = Pick<
+  SidepanelChatTarget,
+  'kind' | 'id'
+>
+
+interface BuildSidepanelChatTargetsInput {
+  providers: LlmProviderConfig[]
+  adapters: HarnessAdapterDescriptor[]
+}
+
+interface ResolveSidepanelChatTargetInput {
+  targets: SidepanelChatTarget[]
+  defaultProviderId: string
+  selection?: SidepanelChatTargetSelection | null
+}
+
+interface SidepanelChatTargetSelectionWriter {
+  setValue(value: SidepanelChatTargetSelection | null): Promise<void>
+}
+
+interface SidepanelChatTargetSelectionReader {
+  getValue(): Promise<SidepanelChatTargetSelection | null>
+}
+
+type SidepanelChatTargetSelectionStore = SidepanelChatTargetSelectionReader &
+  SidepanelChatTargetSelectionWriter
+
+let sidepanelChatTargetSelectionStorage:
+  | SidepanelChatTargetSelectionStore
+  | undefined
+
+export function buildSidepanelChatTargets({
+  providers,
+  adapters,
+}: BuildSidepanelChatTargetsInput): SidepanelChatTarget[] {
+  return [
+    ...providers.map(toLlmTarget),
+    ...adapters.flatMap((adapter) =>
+      adapter.models.map((model) => {
+        const reasoning = adapter.reasoningEfforts.find(
+          (effort) => effort.id === adapter.defaultReasoningEffort,
+        )
+        const reasoningEffort =
+          reasoning?.id ?? adapter.defaultReasoningEffort ?? 'medium'
+        return {
+          kind: 'acp' as const,
+          id: buildAcpTargetId(adapter.id, model.id, reasoningEffort),
+          name: `${adapter.name} ${model.label}`,
+          type: 'acp' as const,
+          adapter: adapter.id,
+          adapterName: adapter.name,
+          modelId: model.id,
+          modelLabel: model.label,
+          modelControl: adapter.modelControl,
+          recommended: model.recommended,
+          reasoningEffort,
+          reasoningEffortLabel: reasoning?.label,
+        }
+      }),
+    ),
+  ]
+}
+
+export function resolveSidepanelChatTarget({
+  targets,
+  defaultProviderId,
+  selection,
+}: ResolveSidepanelChatTargetInput): SidepanelChatTarget | undefined {
+  if (selection) {
+    const selected = targets.find(
+      (target) => target.kind === selection.kind && target.id === selection.id,
+    )
+    if (selected) return selected
+  }
+
+  return (
+    targets.find(
+      (target) => target.kind === 'llm' && target.id === defaultProviderId,
+    ) ?? targets.find((target) => target.kind === 'llm')
+  )
+}
+
+export function toLlmProviderConfig(
+  target: SidepanelChatTarget | undefined,
+): LlmProviderConfig | undefined {
+  return target?.kind === 'llm' ? target.provider : undefined
+}
+
+export async function persistSidepanelChatTargetSelection(
+  target: SidepanelChatTarget | undefined,
+  store?: SidepanelChatTargetSelectionWriter,
+): Promise<void> {
+  const targetStore = store ?? (await getSidepanelChatTargetSelectionStorage())
+  await targetStore.setValue(
+    target ? { kind: target.kind, id: target.id } : null,
+  )
+}
+
+export async function loadSidepanelChatTargetSelection(
+  store?: SidepanelChatTargetSelectionReader,
+): Promise<SidepanelChatTargetSelection | null> {
+  const targetStore = store ?? (await getSidepanelChatTargetSelectionStorage())
+  return targetStore.getValue()
+}
+
+function toLlmTarget(provider: LlmProviderConfig): SidepanelChatTarget {
+  return {
+    kind: 'llm',
+    id: provider.id,
+    name: provider.name,
+    type: provider.type,
+    provider,
+  }
+}
+
+export function buildAcpTargetId(
+  adapter: HarnessAgentAdapter,
+  modelId: string,
+  reasoningEffort: string,
+): string {
+  return `acp:${adapter}:${modelId}:${reasoningEffort}`
+}
+
+async function getSidepanelChatTargetSelectionStorage(): Promise<SidepanelChatTargetSelectionStore> {
+  if (sidepanelChatTargetSelectionStorage) {
+    return sidepanelChatTargetSelectionStorage
+  }
+
+  const { storage } = await import('@wxt-dev/storage')
+  sidepanelChatTargetSelectionStorage =
+    storage.defineItem<SidepanelChatTargetSelection | null>(
+      'local:sidepanel-chat-target-selection',
+      { fallback: null },
+    )
+  return sidepanelChatTargetSelectionStorage
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatRefs.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatRefs.ts
@@ -1,9 +1,18 @@
-import { useEffect, useRef } from 'react'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import useDeepCompareEffect from 'use-deep-compare-effect'
+import { useAgentAdapters } from '@/entrypoints/app/agents/useAgents'
 import type { LlmProviderConfig } from '@/lib/llm-providers/types'
 import { useLlmProviders } from '@/lib/llm-providers/useLlmProviders'
 import { type McpServer, useMcpServers } from '@/lib/mcp/mcpServerStorage'
 import { usePersonalization } from '@/lib/personalization/personalizationStorage'
+import {
+  buildSidepanelChatTargets,
+  loadSidepanelChatTargetSelection,
+  persistSidepanelChatTargetSelection,
+  resolveSidepanelChatTarget,
+  type SidepanelChatTarget,
+  type SidepanelChatTargetSelection,
+} from './sidepanel-chat-targets'
 
 const constructMcpServers = (servers: McpServer[]) => {
   return servers
@@ -23,13 +32,50 @@ const constructCustomServers = (servers: McpServer[]) => {
 export const useChatRefs = () => {
   const { servers: mcpServers } = useMcpServers()
   const {
+    providers: llmProviders,
     selectedProvider: selectedLlmProvider,
+    setDefaultProvider,
     isLoading: isLoadingProviders,
   } = useLlmProviders()
+  const { adapters, loading: isLoadingAdapters } = useAgentAdapters()
   const { personalization } = usePersonalization()
+  const [targetSelection, setTargetSelection] =
+    useState<SidepanelChatTargetSelection | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    loadSidepanelChatTargetSelection().then((selection) => {
+      if (!cancelled) setTargetSelection(selection)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  const chatTargets = useMemo(
+    () =>
+      buildSidepanelChatTargets({
+        providers: llmProviders,
+        adapters,
+      }),
+    [llmProviders, adapters],
+  )
+
+  const selectedChatTarget = useMemo(
+    () =>
+      resolveSidepanelChatTarget({
+        targets: chatTargets,
+        defaultProviderId: selectedLlmProvider?.id ?? llmProviders[0]?.id ?? '',
+        selection: targetSelection,
+      }),
+    [chatTargets, llmProviders, selectedLlmProvider, targetSelection],
+  )
 
   const selectedLlmProviderRef = useRef<LlmProviderConfig | null>(
     selectedLlmProvider,
+  )
+  const selectedChatTargetRef = useRef<SidepanelChatTarget | undefined>(
+    selectedChatTarget,
   )
   const enabledMcpServersRef = useRef(constructMcpServers(mcpServers))
   const enabledCustomServersRef = useRef(constructCustomServers(mcpServers))
@@ -42,15 +88,34 @@ export const useChatRefs = () => {
   }, [selectedLlmProvider, mcpServers])
 
   useEffect(() => {
+    selectedChatTargetRef.current = selectedChatTarget
+  }, [selectedChatTarget])
+
+  useEffect(() => {
     personalizationRef.current = personalization
   }, [personalization])
 
+  const selectChatTarget = useCallback(
+    async (target: SidepanelChatTarget | undefined) => {
+      selectedChatTargetRef.current = target
+      setTargetSelection(target ? { kind: target.kind, id: target.id } : null)
+      await persistSidepanelChatTargetSelection(target)
+    },
+    [],
+  )
+
   return {
     selectedLlmProviderRef,
+    selectedChatTargetRef,
     enabledMcpServersRef,
     enabledCustomServersRef,
     personalizationRef,
+    llmProviders,
+    setDefaultProvider,
+    chatTargets,
+    selectedChatTarget,
+    selectChatTarget,
     selectedLlmProvider,
-    isLoadingProviders,
+    isLoadingProviders: isLoadingProviders || isLoadingAdapters,
   }
 }

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSession.test.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSession.test.ts
@@ -1,0 +1,153 @@
+import { describe, expect, it } from 'bun:test'
+import type { LlmProviderConfig } from '@/lib/llm-providers/types'
+import type { ChatMode } from './chatTypes'
+import type { SidepanelChatTarget } from './sidepanel-chat-targets'
+import { buildSidepanelPreparedSendMessagesRequest } from './useChatSessionRequest'
+
+const conversationId = '00000000-0000-4000-8000-000000000001'
+
+describe('buildSidepanelPreparedSendMessagesRequest', () => {
+  it('keeps LLM targets on the existing /chat request body', () => {
+    const request = buildSidepanelPreparedSendMessagesRequest({
+      agentServerUrl: 'http://127.0.0.1:5151',
+      target: llmTarget,
+      fallbackProvider,
+      message: 'Summarize this page',
+      ...commonRequestInput(),
+    })
+
+    expect(request.api).toBe('http://127.0.0.1:5151/chat')
+    expect(request.body).toMatchObject({
+      message: 'Summarize this page',
+      conversationId,
+      provider: 'browseros',
+      providerType: 'browseros',
+      providerName: 'BrowserOS',
+      model: 'gpt-5',
+      mode: 'agent',
+      browserContext: {
+        activeTab: { id: 10, url: 'https://example.com', title: 'Example' },
+        enabledMcpServers: ['slack'],
+      },
+      userSystemPrompt: 'Be concise',
+      userWorkingDir: '/tmp/work',
+      previousConversation: [{ role: 'assistant', content: 'Prior answer' }],
+      selectedText: 'selected text',
+      selectedTextSource: {
+        url: 'https://example.com',
+        title: 'Example',
+      },
+    })
+  })
+
+  it('sends ACP targets to the sidepanel ACP route with explicit target fields', () => {
+    const request = buildSidepanelPreparedSendMessagesRequest({
+      agentServerUrl: 'http://127.0.0.1:5151',
+      target: acpTarget,
+      fallbackProvider,
+      message: 'Inspect the current tab',
+      approvalResponses: [
+        { approvalId: 'approval-1', approved: true, reason: 'ok' },
+      ],
+      ...commonRequestInput(),
+    })
+
+    expect(request.api).toBe('http://127.0.0.1:5151/agents/sidepanel/chat')
+    expect(request.body).toEqual({
+      conversationId,
+      adapter: 'codex',
+      modelId: 'gpt-5.5',
+      reasoningEffort: 'medium',
+      message: 'Inspect the current tab',
+      browserContext: {
+        activeTab: { id: 10, url: 'https://example.com', title: 'Example' },
+        enabledMcpServers: ['slack'],
+      },
+      userSystemPrompt: 'Be concise',
+      userWorkingDir: '/tmp/work',
+      selectedText: 'selected text',
+      selectedTextSource: {
+        url: 'https://example.com',
+        title: 'Example',
+      },
+    })
+  })
+
+  it('keeps tool approval retry payloads scoped to LLM chat', () => {
+    const request = buildSidepanelPreparedSendMessagesRequest({
+      agentServerUrl: 'http://127.0.0.1:5151',
+      target: llmTarget,
+      fallbackProvider,
+      approvalResponses: [
+        { approvalId: 'approval-1', approved: false, reason: 'no' },
+      ],
+      ...commonRequestInput(),
+    })
+
+    expect(request.api).toBe('http://127.0.0.1:5151/chat')
+    expect(request.body).toMatchObject({
+      message: '',
+      toolApprovalResponses: [
+        { approvalId: 'approval-1', approved: false, reason: 'no' },
+      ],
+    })
+  })
+})
+
+function commonRequestInput() {
+  return {
+    conversationId,
+    mode: 'agent' as ChatMode,
+    browserContext: {
+      activeTab: { id: 10, url: 'https://example.com', title: 'Example' },
+      enabledMcpServers: ['slack'],
+    },
+    userSystemPrompt: 'Be concise',
+    userWorkingDir: '/tmp/work',
+    previousConversation: [
+      { role: 'assistant' as const, content: 'Prior answer' },
+    ],
+    declinedApps: ['gmail'],
+    aclRules: [{ id: 'rule-1', sitePattern: '*://*/*', enabled: true }],
+    selectedText: 'selected text',
+    selectedTextSource: {
+      url: 'https://example.com',
+      title: 'Example',
+    },
+    toolApprovalConfig: { categories: { navigation: true } },
+  }
+}
+
+const fallbackProvider: LlmProviderConfig = {
+  id: 'browseros',
+  type: 'browseros',
+  name: 'BrowserOS',
+  modelId: 'gpt-5',
+  supportsImages: true,
+  contextWindow: 128000,
+  temperature: 0.7,
+  createdAt: 1000,
+  updatedAt: 1000,
+}
+
+const llmTarget: SidepanelChatTarget = {
+  kind: 'llm',
+  id: fallbackProvider.id,
+  name: fallbackProvider.name,
+  type: fallbackProvider.type,
+  provider: fallbackProvider,
+}
+
+const acpTarget: SidepanelChatTarget = {
+  kind: 'acp',
+  id: 'acp:codex:gpt-5.5:medium',
+  name: 'Codex GPT-5.5',
+  type: 'acp',
+  adapter: 'codex',
+  adapterName: 'Codex',
+  modelId: 'gpt-5.5',
+  modelLabel: 'GPT-5.5',
+  modelControl: 'best-effort',
+  reasoningEffort: 'medium',
+  reasoningEffortLabel: 'Medium',
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -26,11 +26,9 @@ import { useInvalidateCredits } from '@/lib/credits/useCredits'
 import { declinedAppsStorage } from '@/lib/declined-apps/storage'
 import { useGraphqlQuery } from '@/lib/graphql/useGraphqlQuery'
 import { createDefaultBrowserOSProvider } from '@/lib/llm-providers/storage'
-import { useLlmProviders } from '@/lib/llm-providers/useLlmProviders'
-import {
-  type ApprovalResponseData,
-  buildChatRequestBody,
-  type ChatRequestBrowserContext,
+import type {
+  ApprovalResponseData,
+  ChatRequestBrowserContext,
 } from '@/lib/messaging/server/buildChatRequestBody'
 import { track } from '@/lib/metrics/track'
 import { searchActionsStorage } from '@/lib/search-actions/searchActionsStorage'
@@ -52,7 +50,12 @@ import {
 import { selectedWorkspaceStorage } from '@/lib/workspace/workspace-storage'
 import type { ChatMode } from './chatTypes'
 import { GetConversationWithMessagesDocument } from './graphql/chatSessionDocument'
+import { toLlmProviderConfig } from './sidepanel-chat-targets'
 import { useChatRefs } from './useChatRefs'
+import {
+  buildSidepanelPreparedSendMessagesRequest,
+  toProviderOption,
+} from './useChatSessionRequest'
 import { useExecutionHistoryTracker } from './useExecutionHistoryTracker'
 import { useNotifyActiveTab } from './useNotifyActiveTab'
 import { useRemoteConversationSave } from './useRemoteConversationSave'
@@ -186,15 +189,18 @@ const buildRequestBrowserContext = ({
 export const useChatSession = (options?: ChatSessionOptions) => {
   const {
     selectedLlmProviderRef,
+    selectedChatTargetRef,
     enabledMcpServersRef,
     enabledCustomServersRef,
     personalizationRef,
+    setDefaultProvider,
+    chatTargets,
+    selectedChatTarget,
+    selectChatTarget,
     selectedLlmProvider,
     isLoadingProviders,
   } = useChatRefs()
   const invalidateCredits = useInvalidateCredits()
-
-  const { providers: llmProviders, setDefaultProvider } = useLlmProviders()
 
   const {
     baseUrl: agentServerUrl,
@@ -218,11 +224,7 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     agentUrlRef.current = agentServerUrl
   }, [agentServerUrl])
 
-  const providers: Provider[] = llmProviders.map((p) => ({
-    id: p.id,
-    name: p.name,
-    type: p.type,
-  }))
+  const providers: Provider[] = chatTargets.map(toProviderOption)
 
   const [mode, setMode] = useState<ChatMode>('agent')
   const [textToAction, setTextToAction] = useState<Map<string, ChatAction>>(
@@ -324,15 +326,8 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     textToActionRef.current = textToAction
   }, [mode, textToAction])
 
-  const selectedProvider = selectedLlmProvider
-    ? {
-        id: selectedLlmProvider.id,
-        name: selectedLlmProvider.name,
-        type:
-          selectedLlmProvider.id === 'browseros'
-            ? ('browseros' as const)
-            : selectedLlmProvider.type,
-      }
+  const selectedProvider = selectedChatTarget
+    ? toProviderOption(selectedChatTarget)
     : providers[0]
 
   const {
@@ -346,7 +341,8 @@ export const useChatSession = (options?: ChatSessionOptions) => {
   } = useChat({
     transport: new DefaultChatTransport({
       prepareSendMessagesRequest: async ({ messages }) => {
-        const provider =
+        const target = selectedChatTargetRef.current
+        const fallbackProvider =
           selectedLlmProviderRef.current ?? createDefaultBrowserOSProvider()
         const activeTabsList = await chrome.tabs.query({
           active: true,
@@ -395,51 +391,46 @@ export const useChatSession = (options?: ChatSessionOptions) => {
           personalizationRef.current,
         )
 
-        const approvalResponses = extractApprovalResponses(messages)
+        const commonRequest = {
+          conversationId: conversationIdRef.current,
+          mode: currentMode,
+          browserContext: requestBrowserContext,
+          userSystemPrompt,
+          userWorkingDir: workingDirRef.current,
+          previousConversation,
+          declinedApps,
+          aclRules: enabledAclRules,
+          toolApprovalConfig: approvalConfig,
+        }
+
+        const approvalResponses =
+          target?.kind === 'acp' ? null : extractApprovalResponses(messages)
         if (approvalResponses) {
-          return {
-            api: `${agentUrlRef.current}/chat`,
-            body: buildChatRequestBody({
-              conversationId: conversationIdRef.current,
-              provider,
-              mode: currentMode,
-              browserContext: requestBrowserContext,
-              userSystemPrompt,
-              userWorkingDir: workingDirRef.current,
-              previousConversation,
-              declinedApps,
-              aclRules: enabledAclRules,
-              toolApprovalConfig: approvalConfig,
-              toolApprovalResponses: approvalResponses,
-            }),
-          }
+          return buildSidepanelPreparedSendMessagesRequest({
+            agentServerUrl: agentUrlRef.current ?? undefined,
+            target,
+            fallbackProvider,
+            ...commonRequest,
+            approvalResponses,
+          })
         }
 
         const message = getLastMessageText(messages)
 
-        const result = {
-          api: `${agentUrlRef.current}/chat`,
-          body: buildChatRequestBody({
-            message,
-            conversationId: conversationIdRef.current,
-            provider,
-            mode: currentMode,
-            browserContext: requestBrowserContext,
-            userSystemPrompt,
-            userWorkingDir: workingDirRef.current,
-            previousConversation,
-            declinedApps,
-            aclRules: enabledAclRules,
-            selectedText: activeTabSelection?.text,
-            selectedTextSource: activeTabSelection
-              ? {
-                  url: activeTabSelection.url,
-                  title: activeTabSelection.title,
-                }
-              : undefined,
-            toolApprovalConfig: approvalConfig,
-          }),
-        }
+        const result = buildSidepanelPreparedSendMessagesRequest({
+          agentServerUrl: agentUrlRef.current ?? undefined,
+          target,
+          fallbackProvider,
+          message,
+          ...commonRequest,
+          selectedText: activeTabSelection?.text,
+          selectedTextSource: activeTabSelection
+            ? {
+                url: activeTabSelection.url,
+                title: activeTabSelection.title,
+              }
+            : undefined,
+        })
 
         // Track which tab's selection was sent so we can clear it on success
         pendingSelectionTabKeyRef.current =
@@ -451,7 +442,7 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     sendAutomaticallyWhen: () => {
       if (approvalJustRespondedRef.current) {
         approvalJustRespondedRef.current = false
-        return true
+        return selectedChatTargetRef.current?.kind !== 'acp'
       }
       return false
     },
@@ -686,10 +677,15 @@ export const useChatSession = (options?: ChatSessionOptions) => {
   }, [dispatchMessage, isIntegrationsSynced])
 
   const sendMessage = (params: { text: string; action?: ChatAction }) => {
+    const target = selectedChatTargetRef.current
+    const llmTargetProvider = toLlmProviderConfig(target)
     track(MESSAGE_SENT_EVENT, {
       mode,
-      provider_type: selectedLlmProvider?.type,
-      model: selectedLlmProvider?.modelId,
+      provider_type: target?.kind === 'acp' ? 'acp' : llmTargetProvider?.type,
+      model:
+        target?.kind === 'acp'
+          ? target.modelId
+          : llmTargetProvider?.modelId || selectedLlmProvider?.modelId,
     })
 
     if (!isIntegrationsSyncedRef.current) {
@@ -741,14 +737,45 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     addToolApprovalResponse(params)
   }
 
+  const resetConversationState = () => {
+    stop()
+    void finishExecutionTask({ isAbort: true })
+    setConversationId(crypto.randomUUID())
+    setMessages([])
+    setTextToAction(new Map())
+    setLiked({})
+    setDisliked({})
+    setRestoredConversationId(null)
+    resetRemoteConversation()
+  }
+
   const handleSelectProvider = (provider: Provider) => {
-    const fullProvider = llmProviders.find((p) => p.id === provider.id)
+    const target = chatTargets.find(
+      (candidate) =>
+        candidate.id === provider.id &&
+        (provider.kind ? candidate.kind === provider.kind : true),
+    )
+    if (!target) return
+
+    const previousTarget = selectedChatTargetRef.current
     track(PROVIDER_SELECTED_EVENT, {
-      provider_id: provider.id,
-      provider_type: provider.type,
-      model_id: fullProvider?.modelId,
+      provider_id: target.id,
+      provider_type: target.kind === 'acp' ? 'acp' : target.type,
+      model_id:
+        target.kind === 'acp' ? target.modelId : target.provider.modelId,
     })
-    setDefaultProvider(provider.id)
+
+    void selectChatTarget(target)
+    if (target.kind === 'llm') setDefaultProvider(target.provider.id)
+
+    if (
+      previousTarget &&
+      (previousTarget.kind !== target.kind ||
+        previousTarget.id !== target.id) &&
+      messagesRef.current.length > 0
+    ) {
+      resetConversationState()
+    }
   }
 
   const getActionForMessage = (message: UIMessage) => {
@@ -762,15 +789,7 @@ export const useChatSession = (options?: ChatSessionOptions) => {
 
   const resetConversation = () => {
     track(CONVERSATION_RESET_EVENT, { message_count: messages.length })
-    stop()
-    void finishExecutionTask({ isAbort: true })
-    setConversationId(crypto.randomUUID())
-    setMessages([])
-    setTextToAction(new Map())
-    setLiked({})
-    setDisliked({})
-    setRestoredConversationId(null)
-    resetRemoteConversation()
+    resetConversationState()
   }
 
   const isRestoringConversation =

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -33,6 +33,7 @@ import type {
 import { track } from '@/lib/metrics/track'
 import { searchActionsStorage } from '@/lib/search-actions/searchActionsStorage'
 import { selectedTextStorage } from '@/lib/selected-text/selectedTextStorage'
+import { sentry } from '@/lib/sentry/sentry'
 import { stopAgentStorage } from '@/lib/stop-agent/stop-agent-storage'
 import {
   type ApprovalResponse,
@@ -752,8 +753,7 @@ export const useChatSession = (options?: ChatSessionOptions) => {
   const handleSelectProvider = (provider: Provider) => {
     const target = chatTargets.find(
       (candidate) =>
-        candidate.id === provider.id &&
-        (provider.kind ? candidate.kind === provider.kind : true),
+        candidate.id === provider.id && candidate.kind === provider.kind,
     )
     if (!target) return
 
@@ -765,7 +765,15 @@ export const useChatSession = (options?: ChatSessionOptions) => {
         target.kind === 'acp' ? target.modelId : target.provider.modelId,
     })
 
-    void selectChatTarget(target)
+    void selectChatTarget(target).catch((error) => {
+      sentry.captureException(error, {
+        extra: {
+          message: 'Failed to persist sidepanel chat target selection',
+          targetId: target.id,
+          targetKind: target.kind,
+        },
+      })
+    })
     if (target.kind === 'llm') setDefaultProvider(target.provider.id)
 
     if (

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSessionRequest.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSessionRequest.ts
@@ -1,0 +1,74 @@
+import type { Provider } from '../../../components/chat/chatComponentTypes'
+import type { LlmProviderConfig } from '../../../lib/llm-providers/types'
+import {
+  type ApprovalResponseData,
+  buildChatRequestBody,
+} from '../../../lib/messaging/server/buildChatRequestBody'
+import {
+  type SidepanelChatTarget,
+  toLlmProviderConfig,
+} from './sidepanel-chat-targets'
+
+type LlmChatRequestBodyInput = Parameters<typeof buildChatRequestBody>[0]
+
+type CommonSidepanelRequestInput = Omit<
+  LlmChatRequestBodyInput,
+  'provider' | 'message' | 'toolApprovalResponses' | 'isScheduledTask'
+>
+
+interface BuildSidepanelPreparedSendMessagesRequestInput
+  extends CommonSidepanelRequestInput {
+  agentServerUrl: string | undefined
+  target: SidepanelChatTarget | undefined
+  fallbackProvider: LlmProviderConfig
+  message?: string
+  approvalResponses?: ApprovalResponseData[] | null
+}
+
+export function buildSidepanelPreparedSendMessagesRequest({
+  agentServerUrl,
+  target,
+  fallbackProvider,
+  message,
+  approvalResponses,
+  ...common
+}: BuildSidepanelPreparedSendMessagesRequestInput) {
+  if (target?.kind === 'acp') {
+    return {
+      api: `${agentServerUrl}/agents/sidepanel/chat`,
+      body: {
+        conversationId: common.conversationId,
+        adapter: target.adapter,
+        modelId: target.modelId,
+        reasoningEffort: target.reasoningEffort,
+        message: message ?? '',
+        browserContext: common.browserContext,
+        userSystemPrompt: common.userSystemPrompt,
+        userWorkingDir: common.userWorkingDir,
+        selectedText: common.selectedText,
+        selectedTextSource: common.selectedTextSource,
+      },
+    }
+  }
+
+  const provider = toLlmProviderConfig(target) ?? fallbackProvider
+  return {
+    api: `${agentServerUrl}/chat`,
+    body: buildChatRequestBody({
+      ...common,
+      provider,
+      message,
+      toolApprovalResponses: approvalResponses ?? undefined,
+    }),
+  }
+}
+
+export function toProviderOption(target: SidepanelChatTarget): Provider {
+  return {
+    id: target.id,
+    name: target.name,
+    type: target.type,
+    kind: target.kind,
+    modelControl: target.kind === 'acp' ? target.modelControl : undefined,
+  }
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSessionRequest.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSessionRequest.ts
@@ -34,6 +34,8 @@ export function buildSidepanelPreparedSendMessagesRequest({
   ...common
 }: BuildSidepanelPreparedSendMessagesRequestInput) {
   if (target?.kind === 'acp') {
+    // ACP session history is owned by AcpxRuntime through sessionKey, so LLM-only
+    // resume and approval fields are intentionally not forwarded.
     return {
       api: `${agentServerUrl}/agents/sidepanel/chat`,
       body: {

--- a/packages/browseros-agent/apps/server/src/api/routes/agents.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/agents.ts
@@ -380,7 +380,7 @@ function readOptionalTrimmedString(
 }
 
 function isUuid(value: string): boolean {
-  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
     value,
   )
 }

--- a/packages/browseros-agent/apps/server/src/api/routes/agents.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/agents.ts
@@ -5,24 +5,40 @@
  */
 
 import { AGENT_HARNESS_LIMITS } from '@browseros/shared/constants/limits'
+import {
+  type BrowserContext,
+  BrowserContextSchema,
+} from '@browseros/shared/schemas/browser-context'
 import { type Context, Hono } from 'hono'
 import { stream } from 'hono/streaming'
+import { formatUserMessage } from '../../agent/format-message'
+import type { Browser } from '../../browser/browser'
+import { createAcpUIMessageStreamResponse } from '../../lib/agents/acp-ui-message-stream'
+import { AcpxRuntime } from '../../lib/agents/acpx-runtime'
 import {
   AGENT_ADAPTER_CATALOG,
+  getAgentAdapterDescriptor,
   isAgentAdapter,
   isSupportedAgentModel,
   isSupportedReasoningEffort,
+  resolveDefaultModelId,
+  resolveDefaultReasoningEffort,
 } from '../../lib/agents/agent-catalog'
 import type {
   AgentAdapter,
   AgentDefinition,
 } from '../../lib/agents/agent-types'
-import type { AgentHistoryPage, AgentStreamEvent } from '../../lib/agents/types'
+import type {
+  AgentHistoryPage,
+  AgentRuntime,
+  AgentStreamEvent,
+} from '../../lib/agents/types'
 import {
   AgentHarnessService,
   UnknownAgentError,
 } from '../services/agents/agent-harness-service'
 import type { Env } from '../types'
+import { resolveBrowserContextPageIds } from '../utils/resolve-browser-context-page-ids'
 
 type AgentRouteService = {
   listAgents(): Promise<AgentDefinition[]>
@@ -44,13 +60,29 @@ type AgentRouteService = {
 
 type AgentRouteDeps = {
   service?: AgentRouteService
+  runtime?: AgentRuntime
+  browser?: Pick<Browser, 'resolveTabIds'>
   browserosServerPort?: number
+}
+
+type SidepanelAcpChatRequest = {
+  conversationId: string
+  adapter: AgentAdapter
+  modelId: string
+  reasoningEffort: string
+  message: string
+  browserContext?: BrowserContext
+  selectedText?: string
+  selectedTextSource?: { url: string; title: string }
+  userSystemPrompt?: string
+  userWorkingDir?: string
 }
 
 export function createAgentRoutes(deps: AgentRouteDeps = {}) {
   const service =
     deps.service ??
     new AgentHarnessService({ browserosServerPort: deps.browserosServerPort })
+  let sidepanelRuntime = deps.runtime
 
   return new Hono<Env>()
     .get('/adapters', (c) => c.json({ adapters: AGENT_ADAPTER_CATALOG }))
@@ -60,6 +92,47 @@ export function createAgentRoutes(deps: AgentRouteDeps = {}) {
       if ('error' in parsed) return c.json({ error: parsed.error }, 400)
       try {
         return c.json({ agent: await service.createAgent(parsed) })
+      } catch (err) {
+        return handleAgentRouteError(c, err)
+      }
+    })
+    .post('/sidepanel/chat', async (c) => {
+      const parsed = await parseSidepanelAcpChatBody(c)
+      if ('error' in parsed) return c.json({ error: parsed.error }, 400)
+
+      let browserContext = parsed.browserContext
+      if (deps.browser) {
+        browserContext = await resolveBrowserContextPageIds(
+          deps.browser,
+          browserContext,
+        )
+      }
+
+      const userContent = formatUserMessage(
+        parsed.message,
+        browserContext,
+        parsed.selectedText,
+        parsed.selectedTextSource,
+      )
+      const message = parsed.userSystemPrompt?.trim()
+        ? `${parsed.userSystemPrompt.trim()}\n\n${userContent}`
+        : userContent
+      const agent = buildSidepanelAcpAgent(parsed)
+
+      try {
+        sidepanelRuntime ??= new AcpxRuntime({
+          browserosServerPort: deps.browserosServerPort,
+        })
+        const eventStream = await sidepanelRuntime.send({
+          agent,
+          sessionId: 'main',
+          sessionKey: agent.sessionKey,
+          message,
+          permissionMode: agent.permissionMode,
+          cwd: parsed.userWorkingDir,
+          signal: c.req.raw.signal,
+        })
+        return createAcpUIMessageStreamResponse(eventStream)
       } catch (err) {
         return handleAgentRouteError(c, err)
       }
@@ -187,6 +260,129 @@ async function parseChatBody(
   const message =
     typeof body.value.message === 'string' ? body.value.message.trim() : ''
   return message ? { message } : { error: 'Message is required' }
+}
+
+async function parseSidepanelAcpChatBody(
+  c: Context<Env>,
+): Promise<SidepanelAcpChatRequest | { error: string }> {
+  const body = await readJsonBody(c)
+  if ('error' in body) return body
+  const record = body.value
+
+  const conversationId = readOptionalTrimmedString(record, 'conversationId')
+  if (!conversationId || !isUuid(conversationId)) {
+    return { error: 'conversationId must be a UUID' }
+  }
+  if (!isAgentAdapter(record.adapter)) {
+    return { error: 'Invalid adapter' }
+  }
+
+  const modelId =
+    readOptionalTrimmedString(record, 'modelId') ??
+    resolveDefaultModelId(record.adapter)
+  const reasoningEffort =
+    readOptionalTrimmedString(record, 'reasoningEffort') ??
+    resolveDefaultReasoningEffort(record.adapter)
+
+  if (!isSupportedAgentModel(record.adapter, modelId)) {
+    return { error: 'Invalid modelId' }
+  }
+  if (!isSupportedReasoningEffort(record.adapter, reasoningEffort)) {
+    return { error: 'Invalid reasoningEffort' }
+  }
+
+  const message = readOptionalTrimmedString(record, 'message')
+  if (!message) return { error: 'Message is required' }
+
+  const browserContext = parseBrowserContext(record.browserContext)
+  if ('error' in browserContext) return browserContext
+
+  const selectedText = readOptionalString(record, 'selectedText')
+  const selectedTextSource = parseSelectedTextSource(record.selectedTextSource)
+  if ('error' in selectedTextSource) return selectedTextSource
+
+  return {
+    conversationId,
+    adapter: record.adapter,
+    modelId,
+    reasoningEffort,
+    message,
+    browserContext: browserContext.value,
+    selectedText,
+    selectedTextSource: selectedTextSource.value,
+    userSystemPrompt: readOptionalString(record, 'userSystemPrompt'),
+    userWorkingDir: readOptionalTrimmedString(record, 'userWorkingDir'),
+  }
+}
+
+function buildSidepanelAcpAgent(
+  request: SidepanelAcpChatRequest,
+): AgentDefinition {
+  const now = Date.now()
+  const descriptor = getAgentAdapterDescriptor(request.adapter)
+  const sessionKey = [
+    'sidepanel',
+    request.conversationId,
+    request.adapter,
+    request.modelId,
+    request.reasoningEffort,
+  ].join(':')
+
+  return {
+    id: `sidepanel:${request.conversationId}`,
+    name: descriptor?.name ?? request.adapter,
+    adapter: request.adapter,
+    modelId: request.modelId,
+    reasoningEffort: request.reasoningEffort,
+    permissionMode: 'approve-all',
+    sessionKey,
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function parseBrowserContext(
+  value: unknown,
+): { value?: BrowserContext } | { error: string } {
+  if (value === undefined) return { value: undefined }
+  const parsed = BrowserContextSchema.safeParse(value)
+  return parsed.success
+    ? { value: parsed.data }
+    : { error: 'Invalid browserContext' }
+}
+
+function parseSelectedTextSource(
+  value: unknown,
+): { value?: { url: string; title: string } } | { error: string } {
+  if (value === undefined) return { value: undefined }
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return { error: 'Invalid selectedTextSource' }
+  }
+  const record = value as Record<string, unknown>
+  return typeof record.url === 'string' && typeof record.title === 'string'
+    ? { value: { url: record.url, title: record.title } }
+    : { error: 'Invalid selectedTextSource' }
+}
+
+function readOptionalString(
+  record: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  return typeof record[key] === 'string' ? record[key] : undefined
+}
+
+function readOptionalTrimmedString(
+  record: Record<string, unknown>,
+  key: string,
+): string | undefined {
+  const value = readOptionalString(record, key)?.trim()
+  return value || undefined
+}
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
+    value,
+  )
 }
 
 async function readJsonBody(

--- a/packages/browseros-agent/apps/server/src/api/server.ts
+++ b/packages/browseros-agent/apps/server/src/api/server.ts
@@ -131,7 +131,7 @@ export async function createHttpServer(config: HttpServerConfig) {
 
   const agentRoutes = new Hono<Env>()
     .use('/*', requireTrustedAppOrigin())
-    .route('/', createAgentRoutes({ browserosServerPort: port }))
+    .route('/', createAgentRoutes({ browserosServerPort: port, browser }))
 
   const app = new Hono<Env>()
     .use('/*', cors(defaultCorsConfig))

--- a/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
@@ -19,6 +19,7 @@ import { logger } from '../../lib/logger'
 import type { ToolRegistry } from '../../tools/tool-registry'
 import type { KlavisProxyRef } from '../services/klavis/strata-proxy'
 import type { BrowserContext, ChatRequest } from '../types'
+import { resolveBrowserContextPageIds } from '../utils/resolve-browser-context-page-ids'
 
 export interface ChatServiceDeps {
   sessionStore: SessionStore
@@ -181,7 +182,10 @@ export class ChatService {
     if (!session) {
       isNewSession = true
       let hiddenPageId: number | undefined
-      let browserContext = await this.resolvePageIds(request.browserContext)
+      let browserContext = await resolveBrowserContextPageIds(
+        this.deps.browser,
+        request.browserContext,
+      )
       if (request.isScheduledTask) {
         try {
           hiddenPageId = await this.deps.browser.newPage('about:blank', {
@@ -290,11 +294,11 @@ export class ChatService {
       ? (session.browserContext ?? request.browserContext)
       : request.browserContext
     // Scheduled tasks already have correct internal pageIds from browser.newPage();
-    // calling resolvePageIds would pass those to resolveTabIds (which expects Chrome
-    // tab IDs), corrupting them back to undefined.
+    // resolving them again would pass those to resolveTabIds, which expects Chrome
+    // tab IDs.
     const resolvedMessageContext = request.isScheduledTask
       ? messageContext
-      : await this.resolvePageIds(messageContext)
+      : await resolveBrowserContextPageIds(this.deps.browser, messageContext)
     const userContent = formatUserMessage(
       request.message,
       resolvedMessageContext,
@@ -342,48 +346,6 @@ export class ChatService {
     return { deleted, sessionCount: this.deps.sessionStore.count() }
   }
 
-  // Browser context arrives with Chrome tab IDs, but tools expect internal page IDs.
-  // Resolve the mapping upfront so the agent's first navigation doesn't fail.
-  private async resolvePageIds(
-    browserContext?: BrowserContext,
-  ): Promise<BrowserContext | undefined> {
-    if (!browserContext) return undefined
-
-    const tabIdSet = new Set<number>()
-    if (browserContext.activeTab) tabIdSet.add(browserContext.activeTab.id)
-    if (browserContext.selectedTabs) {
-      for (const tab of browserContext.selectedTabs) tabIdSet.add(tab.id)
-    }
-    if (browserContext.tabs) {
-      for (const tab of browserContext.tabs) tabIdSet.add(tab.id)
-    }
-
-    if (tabIdSet.size === 0) return browserContext
-
-    const tabToPage = await this.deps.browser.resolveTabIds([...tabIdSet])
-
-    const addPageId = (tab: { id: number; url?: string; title?: string }) => {
-      const pageId = tabToPage.get(tab.id)
-      if (pageId === undefined) {
-        logger.warn('Could not resolve page ID for tab', { tabId: tab.id })
-      }
-      return { ...tab, pageId }
-    }
-
-    logger.debug('Resolved tab IDs to page IDs', {
-      mapping: Object.fromEntries(tabToPage),
-    })
-
-    return {
-      ...browserContext,
-      activeTab: browserContext.activeTab
-        ? addPageId(browserContext.activeTab)
-        : undefined,
-      selectedTabs: browserContext.selectedTabs?.map(addPageId),
-      tabs: browserContext.tabs?.map(addPageId),
-    }
-  }
-
   private closeHiddenPage(pageId: number, conversationId: string): void {
     this.deps.browser.closePage(pageId).catch((error) => {
       logger.warn('Failed to close hidden page', {
@@ -406,8 +368,14 @@ export class ChatService {
 
     const browserContext = agentConfig.isScheduledTask
       ? (session.browserContext ??
-        (await this.resolvePageIds(request.browserContext)))
-      : await this.resolvePageIds(request.browserContext)
+        (await resolveBrowserContextPageIds(
+          this.deps.browser,
+          request.browserContext,
+        )))
+      : await resolveBrowserContextPageIds(
+          this.deps.browser,
+          request.browserContext,
+        )
     const agent = await AiSdkAgent.create({
       resolvedConfig: agentConfig,
       browser: this.deps.browser,

--- a/packages/browseros-agent/apps/server/src/api/utils/resolve-browser-context-page-ids.ts
+++ b/packages/browseros-agent/apps/server/src/api/utils/resolve-browser-context-page-ids.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { BrowserContext } from '@browseros/shared/schemas/browser-context'
+import type { Browser } from '../../browser/browser'
+import { logger } from '../../lib/logger'
+
+export async function resolveBrowserContextPageIds(
+  browser: Pick<Browser, 'resolveTabIds'>,
+  browserContext?: BrowserContext,
+): Promise<BrowserContext | undefined> {
+  if (!browserContext) return undefined
+
+  const tabIdSet = new Set<number>()
+  if (browserContext.activeTab) tabIdSet.add(browserContext.activeTab.id)
+  if (browserContext.selectedTabs) {
+    for (const tab of browserContext.selectedTabs) tabIdSet.add(tab.id)
+  }
+  if (browserContext.tabs) {
+    for (const tab of browserContext.tabs) tabIdSet.add(tab.id)
+  }
+
+  if (tabIdSet.size === 0) return browserContext
+
+  const tabToPage = await browser.resolveTabIds([...tabIdSet])
+
+  const addPageId = (tab: { id: number; url?: string; title?: string }) => {
+    const pageId = tabToPage.get(tab.id)
+    if (pageId === undefined) {
+      logger.warn('Could not resolve page ID for tab', { tabId: tab.id })
+    }
+    return { ...tab, pageId }
+  }
+
+  logger.debug('Resolved tab IDs to page IDs', {
+    mapping: Object.fromEntries(tabToPage),
+  })
+
+  return {
+    ...browserContext,
+    activeTab: browserContext.activeTab
+      ? addPageId(browserContext.activeTab)
+      : undefined,
+    selectedTabs: browserContext.selectedTabs?.map(addPageId),
+    tabs: browserContext.tabs?.map(addPageId),
+  }
+}

--- a/packages/browseros-agent/apps/server/src/lib/agents/acp-ui-message-stream.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acp-ui-message-stream.ts
@@ -4,18 +4,20 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import {
-  createUIMessageStreamResponse,
-  type FinishReason,
-  type UIMessageChunk,
-  type UIMessageStreamResponseInit,
-} from 'ai'
+import type { FinishReason, UIMessageChunk } from 'ai'
 
 import type { AgentStreamEvent } from './types'
 
 const TEXT_PART_ID = 'acp-text'
 const REASONING_PART_ID = 'acp-reasoning'
 const STATUS_PART_ID = 'acp-status'
+const UI_MESSAGE_STREAM_HEADERS = {
+  'content-type': 'text/event-stream',
+  'cache-control': 'no-cache',
+  connection: 'keep-alive',
+  'x-vercel-ai-ui-message-stream': 'v1',
+  'x-accel-buffering': 'no',
+}
 
 interface AcpUIMessageStreamState {
   cancelled: boolean
@@ -59,11 +61,16 @@ export function createAcpUIMessageStream(
 
 export function createAcpUIMessageStreamResponse(
   events: ReadableStream<AgentStreamEvent>,
-  init?: UIMessageStreamResponseInit,
+  init?: ResponseInit,
 ): Response {
-  return createUIMessageStreamResponse({
+  const headers = new Headers(init?.headers)
+  for (const [key, value] of Object.entries(UI_MESSAGE_STREAM_HEADERS)) {
+    if (!headers.has(key)) headers.set(key, value)
+  }
+
+  return new Response(createSseStream(createAcpUIMessageStream(events)), {
     ...init,
-    stream: createAcpUIMessageStream(events),
+    headers,
   })
 }
 
@@ -293,6 +300,23 @@ function isCompletedToolStatus(status: string | undefined): boolean {
 
 function isFailedToolStatus(status: string | undefined): boolean {
   return status === 'failed' || status === 'error' || status === 'failure'
+}
+
+function createSseStream(
+  stream: ReadableStream<UIMessageChunk>,
+): ReadableStream<Uint8Array> {
+  return stream
+    .pipeThrough(
+      new TransformStream<UIMessageChunk, string>({
+        transform(chunk, controller) {
+          controller.enqueue(`data: ${JSON.stringify(chunk)}\n\n`)
+        },
+        flush(controller) {
+          controller.enqueue('data: [DONE]\n\n')
+        },
+      }),
+    )
+    .pipeThrough(new TextEncoderStream())
 }
 
 function errorToMessage(error: unknown): string {

--- a/packages/browseros-agent/apps/server/src/lib/agents/acp-ui-message-stream.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acp-ui-message-stream.ts
@@ -25,6 +25,10 @@ interface AcpUIMessageStreamState {
   finished: boolean
   textOpen: boolean
   reasoningOpen: boolean
+  textPartCount: number
+  reasoningPartCount: number
+  textPartId: string
+  reasoningPartId: string
   toolCallCount: number
   toolNames: Map<string, string>
   toolInputs: Set<string>
@@ -39,6 +43,10 @@ export function createAcpUIMessageStream(
     finished: false,
     textOpen: false,
     reasoningOpen: false,
+    textPartCount: 0,
+    reasoningPartCount: 0,
+    textPartId: TEXT_PART_ID,
+    reasoningPartId: REASONING_PART_ID,
     toolCallCount: 0,
     toolNames: new Map(),
     toolInputs: new Set(),
@@ -165,25 +173,21 @@ function enqueueTextDelta(
   state: AcpUIMessageStreamState,
 ): void {
   if (event.stream === 'thought') {
-    if (!state.reasoningOpen) {
-      controller.enqueue({ type: 'reasoning-start', id: REASONING_PART_ID })
-      state.reasoningOpen = true
-    }
+    if (state.textOpen) closeTextPart(controller, state)
+    if (!state.reasoningOpen) startReasoningPart(controller, state)
     controller.enqueue({
       type: 'reasoning-delta',
-      id: REASONING_PART_ID,
+      id: state.reasoningPartId,
       delta: event.text,
     })
     return
   }
 
-  if (!state.textOpen) {
-    controller.enqueue({ type: 'text-start', id: TEXT_PART_ID })
-    state.textOpen = true
-  }
+  if (state.reasoningOpen) closeReasoningPart(controller, state)
+  if (!state.textOpen) startTextPart(controller, state)
   controller.enqueue({
     type: 'text-delta',
-    id: TEXT_PART_ID,
+    id: state.textPartId,
     delta: event.text,
   })
 }
@@ -223,7 +227,7 @@ function enqueueToolCall(
     controller.enqueue({
       type: 'tool-output-error',
       toolCallId,
-      errorText: event.text || event.title,
+      errorText: event.text || event.title || 'Tool failed',
       dynamic: true,
     })
   }
@@ -260,15 +264,50 @@ function closeOpenParts(
   controller: ReadableStreamDefaultController<UIMessageChunk>,
   state: AcpUIMessageStreamState,
 ): void {
-  if (state.reasoningOpen) {
-    controller.enqueue({ type: 'reasoning-end', id: REASONING_PART_ID })
-    state.reasoningOpen = false
-  }
+  if (state.reasoningOpen) closeReasoningPart(controller, state)
+  if (state.textOpen) closeTextPart(controller, state)
+}
 
-  if (state.textOpen) {
-    controller.enqueue({ type: 'text-end', id: TEXT_PART_ID })
-    state.textOpen = false
-  }
+function startReasoningPart(
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  state: AcpUIMessageStreamState,
+): void {
+  state.reasoningPartCount += 1
+  state.reasoningPartId =
+    state.reasoningPartCount === 1
+      ? REASONING_PART_ID
+      : `${REASONING_PART_ID}-${state.reasoningPartCount}`
+  state.reasoningOpen = true
+  controller.enqueue({ type: 'reasoning-start', id: state.reasoningPartId })
+}
+
+function closeReasoningPart(
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  state: AcpUIMessageStreamState,
+): void {
+  controller.enqueue({ type: 'reasoning-end', id: state.reasoningPartId })
+  state.reasoningOpen = false
+}
+
+function startTextPart(
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  state: AcpUIMessageStreamState,
+): void {
+  state.textPartCount += 1
+  state.textPartId =
+    state.textPartCount === 1
+      ? TEXT_PART_ID
+      : `${TEXT_PART_ID}-${state.textPartCount}`
+  state.textOpen = true
+  controller.enqueue({ type: 'text-start', id: state.textPartId })
+}
+
+function closeTextPart(
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  state: AcpUIMessageStreamState,
+): void {
+  controller.enqueue({ type: 'text-end', id: state.textPartId })
+  state.textOpen = false
 }
 
 function closeController(

--- a/packages/browseros-agent/apps/server/src/lib/agents/acp-ui-message-stream.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acp-ui-message-stream.ts
@@ -1,0 +1,300 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {
+  createUIMessageStreamResponse,
+  type FinishReason,
+  type UIMessageChunk,
+  type UIMessageStreamResponseInit,
+} from 'ai'
+
+import type { AgentStreamEvent } from './types'
+
+const TEXT_PART_ID = 'acp-text'
+const REASONING_PART_ID = 'acp-reasoning'
+const STATUS_PART_ID = 'acp-status'
+
+interface AcpUIMessageStreamState {
+  cancelled: boolean
+  closed: boolean
+  finished: boolean
+  textOpen: boolean
+  reasoningOpen: boolean
+  toolCallCount: number
+  toolNames: Map<string, string>
+  toolInputs: Set<string>
+}
+
+export function createAcpUIMessageStream(
+  events: ReadableStream<AgentStreamEvent>,
+): ReadableStream<UIMessageChunk> {
+  const state: AcpUIMessageStreamState = {
+    cancelled: false,
+    closed: false,
+    finished: false,
+    textOpen: false,
+    reasoningOpen: false,
+    toolCallCount: 0,
+    toolNames: new Map(),
+    toolInputs: new Set(),
+  }
+  let reader: ReadableStreamDefaultReader<AgentStreamEvent> | undefined
+
+  return new ReadableStream<UIMessageChunk>({
+    start(controller) {
+      reader = events.getReader()
+      controller.enqueue({ type: 'start' })
+
+      void pumpAcpEvents(reader, controller, state)
+    },
+    async cancel(reason) {
+      state.cancelled = true
+      await reader?.cancel(reason)
+    },
+  })
+}
+
+export function createAcpUIMessageStreamResponse(
+  events: ReadableStream<AgentStreamEvent>,
+  init?: UIMessageStreamResponseInit,
+): Response {
+  return createUIMessageStreamResponse({
+    ...init,
+    stream: createAcpUIMessageStream(events),
+  })
+}
+
+export function mapAcpStopReasonToFinishReason(
+  stopReason: string | undefined,
+): FinishReason {
+  switch (stopReason) {
+    case undefined:
+    case 'end_turn':
+    case 'stop':
+    case 'stop_sequence':
+      return 'stop'
+    case 'max_tokens':
+    case 'max_output_tokens':
+      return 'length'
+    case 'tool_use':
+      return 'tool-calls'
+    case 'content_filter':
+      return 'content-filter'
+    case 'error':
+      return 'error'
+    case 'cancelled':
+      return 'other'
+    default:
+      return 'stop'
+  }
+}
+
+async function pumpAcpEvents(
+  reader: ReadableStreamDefaultReader<AgentStreamEvent>,
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  state: AcpUIMessageStreamState,
+): Promise<void> {
+  try {
+    for (;;) {
+      const { done, value } = await reader.read()
+      if (state.cancelled) return
+
+      if (done) {
+        finish(controller, state, 'stop')
+        return
+      }
+
+      handleAcpEvent(value, controller, state)
+      if (state.finished || state.closed) return
+    }
+  } catch (error) {
+    if (!state.cancelled) {
+      finishWithError(controller, state, errorToMessage(error))
+    }
+  } finally {
+    if (!state.cancelled) reader.releaseLock()
+  }
+}
+
+function handleAcpEvent(
+  event: AgentStreamEvent,
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  state: AcpUIMessageStreamState,
+): void {
+  switch (event.type) {
+    case 'text_delta':
+      enqueueTextDelta(event, controller, state)
+      return
+    case 'tool_call':
+      enqueueToolCall(event, controller, state)
+      return
+    case 'status':
+      controller.enqueue({
+        type: 'data-acp-status',
+        id: STATUS_PART_ID,
+        data: { text: event.text },
+        transient: true,
+      })
+      return
+    case 'done':
+      finish(
+        controller,
+        state,
+        mapAcpStopReasonToFinishReason(event.stopReason),
+      )
+      return
+    case 'error':
+      finishWithError(controller, state, event.message)
+      return
+  }
+}
+
+function enqueueTextDelta(
+  event: Extract<AgentStreamEvent, { type: 'text_delta' }>,
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  state: AcpUIMessageStreamState,
+): void {
+  if (event.stream === 'thought') {
+    if (!state.reasoningOpen) {
+      controller.enqueue({ type: 'reasoning-start', id: REASONING_PART_ID })
+      state.reasoningOpen = true
+    }
+    controller.enqueue({
+      type: 'reasoning-delta',
+      id: REASONING_PART_ID,
+      delta: event.text,
+    })
+    return
+  }
+
+  if (!state.textOpen) {
+    controller.enqueue({ type: 'text-start', id: TEXT_PART_ID })
+    state.textOpen = true
+  }
+  controller.enqueue({
+    type: 'text-delta',
+    id: TEXT_PART_ID,
+    delta: event.text,
+  })
+}
+
+function enqueueToolCall(
+  event: Extract<AgentStreamEvent, { type: 'tool_call' }>,
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  state: AcpUIMessageStreamState,
+): void {
+  const toolCallId = event.id ?? nextToolCallId(state)
+  const toolName =
+    state.toolNames.get(toolCallId) ??
+    normalizeToolName(event.title || event.rawType || 'acp_tool')
+
+  state.toolNames.set(toolCallId, toolName)
+
+  if (!state.toolInputs.has(toolCallId)) {
+    state.toolInputs.add(toolCallId)
+    controller.enqueue({
+      type: 'tool-input-available',
+      toolCallId,
+      toolName,
+      title: event.title,
+      input: { description: event.text },
+      dynamic: true,
+    })
+  }
+
+  if (isCompletedToolStatus(event.status)) {
+    controller.enqueue({
+      type: 'tool-output-available',
+      toolCallId,
+      output: { content: event.text },
+      dynamic: true,
+    })
+  } else if (isFailedToolStatus(event.status)) {
+    controller.enqueue({
+      type: 'tool-output-error',
+      toolCallId,
+      errorText: event.text || event.title,
+      dynamic: true,
+    })
+  }
+}
+
+function finish(
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  state: AcpUIMessageStreamState,
+  finishReason: FinishReason,
+): void {
+  if (state.cancelled || state.finished || state.closed) return
+
+  closeOpenParts(controller, state)
+  controller.enqueue({ type: 'finish', finishReason })
+  state.finished = true
+  closeController(controller, state)
+}
+
+function finishWithError(
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  state: AcpUIMessageStreamState,
+  errorText: string,
+): void {
+  if (state.cancelled || state.finished || state.closed) return
+
+  closeOpenParts(controller, state)
+  controller.enqueue({ type: 'error', errorText })
+  controller.enqueue({ type: 'finish', finishReason: 'error' })
+  state.finished = true
+  closeController(controller, state)
+}
+
+function closeOpenParts(
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  state: AcpUIMessageStreamState,
+): void {
+  if (state.reasoningOpen) {
+    controller.enqueue({ type: 'reasoning-end', id: REASONING_PART_ID })
+    state.reasoningOpen = false
+  }
+
+  if (state.textOpen) {
+    controller.enqueue({ type: 'text-end', id: TEXT_PART_ID })
+    state.textOpen = false
+  }
+}
+
+function closeController(
+  controller: ReadableStreamDefaultController<UIMessageChunk>,
+  state: AcpUIMessageStreamState,
+): void {
+  state.closed = true
+  controller.close()
+}
+
+function nextToolCallId(state: AcpUIMessageStreamState): string {
+  state.toolCallCount += 1
+  return `acp-tool-${state.toolCallCount}`
+}
+
+function normalizeToolName(value: string): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+
+  return normalized || 'acp_tool'
+}
+
+function isCompletedToolStatus(status: string | undefined): boolean {
+  return status === 'completed' || status === 'done' || status === 'success'
+}
+
+function isFailedToolStatus(status: string | undefined): boolean {
+  return status === 'failed' || status === 'error' || status === 'failure'
+}
+
+function errorToMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error)
+}

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
@@ -93,12 +93,13 @@ export class AcpxRuntime implements AgentRuntime {
   async send(
     input: AgentPromptInput,
   ): Promise<ReadableStream<AgentStreamEvent>> {
+    const cwd = input.cwd ?? this.cwd
     logger.info('Agent harness acpx send requested', {
       agentId: input.agent.id,
       adapter: input.agent.adapter,
       sessionId: input.sessionId,
       sessionKey: input.sessionKey,
-      cwd: this.cwd,
+      cwd,
       stateDir: this.stateDir,
       permissionMode: input.permissionMode,
       modelId: input.agent.modelId,
@@ -106,12 +107,12 @@ export class AcpxRuntime implements AgentRuntime {
       messageLength: input.message.length,
     })
     const runtime = this.getRuntime({
-      cwd: this.cwd,
+      cwd,
       permissionMode: input.permissionMode,
       nonInteractivePermissions: 'fail',
     })
 
-    return createAcpxEventStream(runtime, input, this.cwd)
+    return createAcpxEventStream(runtime, input, cwd)
   }
 
   private getRuntime(input: {

--- a/packages/browseros-agent/apps/server/src/lib/agents/types.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/types.ts
@@ -64,6 +64,7 @@ export interface AgentPromptInput {
   sessionKey: string
   message: string
   permissionMode: AgentPermissionMode
+  cwd?: string
   timeoutMs?: number
   signal?: AbortSignal
 }

--- a/packages/browseros-agent/apps/server/tests/api/routes/agents.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/agents.test.ts
@@ -8,7 +8,11 @@ import { AGENT_HARNESS_LIMITS } from '@browseros/shared/constants/limits'
 import { Hono } from 'hono'
 import { createAgentRoutes } from '../../../src/api/routes/agents'
 import type { AgentDefinition } from '../../../src/lib/agents/agent-types'
-import type { AgentStreamEvent } from '../../../src/lib/agents/types'
+import type {
+  AgentPromptInput,
+  AgentRuntime,
+  AgentStreamEvent,
+} from '../../../src/lib/agents/types'
 
 describe('createAgentRoutes', () => {
   it('creates and lists harness agents', async () => {
@@ -62,6 +66,58 @@ describe('createAgentRoutes', () => {
     expect(await response.text()).toContain('data: [DONE]')
   })
 
+  it('streams sidepanel ACP chat as an AI SDK UI message stream', async () => {
+    const conversationId = '00000000-0000-4000-8000-000000000001'
+    let sentInput: AgentPromptInput | undefined
+    const route = createMountedRoutes([], {
+      browser: {
+        async resolveTabIds(tabIds: number[]) {
+          return new Map(tabIds.map((tabId) => [tabId, tabId + 100]))
+        },
+      },
+      runtime: createFakeRuntime(async (input) => {
+        sentInput = input
+        return createAgentStream([
+          { type: 'text_delta', text: 'Hello', stream: 'output' },
+          { type: 'done', stopReason: 'end_turn' },
+        ])
+      }),
+    })
+
+    const response = await route.request('/agents/sidepanel/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        conversationId,
+        adapter: 'codex',
+        modelId: 'gpt-5.5',
+        reasoningEffort: 'medium',
+        message: 'hi',
+        userWorkingDir: '/tmp/work',
+        browserContext: {
+          activeTab: { id: 1, url: 'https://example.com', title: 'Example' },
+        },
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('Content-Type')).toContain('text/event-stream')
+    expect(await response.text()).toContain('"type":"text-delta"')
+    expect(sentInput?.agent).toMatchObject({
+      id: `sidepanel:${conversationId}`,
+      adapter: 'codex',
+      modelId: 'gpt-5.5',
+      reasoningEffort: 'medium',
+      permissionMode: 'approve-all',
+      sessionKey: `sidepanel:${conversationId}:codex:gpt-5.5:medium`,
+    })
+    expect(sentInput?.cwd).toBe('/tmp/work')
+    expect(sentInput?.message).toContain(
+      'Tab 1 (Page ID: 101) - "Example" (https://example.com)',
+    )
+    expect(sentInput?.message).toContain('<USER_QUERY>\nhi\n</USER_QUERY>')
+  })
+
   it('rejects overlong agent names', async () => {
     const route = createMountedRoutes([])
     const response = await route.request('/agents', {
@@ -80,10 +136,16 @@ describe('createAgentRoutes', () => {
   })
 })
 
-function createMountedRoutes(agents: AgentDefinition[]) {
+function createMountedRoutes(
+  agents: AgentDefinition[],
+  deps: {
+    runtime?: AgentRuntime
+    browser?: { resolveTabIds(tabIds: number[]): Promise<Map<number, number>> }
+  } = {},
+) {
   return new Hono().route(
     '/agents',
-    createAgentRoutes({ service: createFakeService(agents) }),
+    createAgentRoutes({ service: createFakeService(agents), ...deps }),
   )
 }
 
@@ -129,17 +191,42 @@ function createFakeService(agents: AgentDefinition[]) {
       }
     },
     async send() {
-      return new ReadableStream<AgentStreamEvent>({
-        start(controller) {
-          controller.enqueue({
-            type: 'text_delta',
-            text: 'Hello',
-            stream: 'output',
-          })
-          controller.enqueue({ type: 'done', stopReason: 'end_turn' })
-          controller.close()
+      return createAgentStream([
+        {
+          type: 'text_delta',
+          text: 'Hello',
+          stream: 'output',
         },
-      })
+        { type: 'done', stopReason: 'end_turn' },
+      ])
     },
   }
+}
+
+function createFakeRuntime(
+  send: (input: AgentPromptInput) => Promise<ReadableStream<AgentStreamEvent>>,
+): AgentRuntime {
+  return {
+    async status() {
+      return { state: 'ready' }
+    },
+    async listSessions(agent) {
+      return [{ agentId: agent.id, id: 'main', updatedAt: agent.updatedAt }]
+    },
+    async getHistory(input) {
+      return { agentId: input.agent.id, sessionId: 'main', items: [] }
+    },
+    send,
+  }
+}
+
+function createAgentStream(
+  events: AgentStreamEvent[],
+): ReadableStream<AgentStreamEvent> {
+  return new ReadableStream<AgentStreamEvent>({
+    start(controller) {
+      for (const event of events) controller.enqueue(event)
+      controller.close()
+    },
+  })
 }

--- a/packages/browseros-agent/apps/server/tests/api/routes/agents.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/agents.test.ts
@@ -69,6 +69,7 @@ describe('createAgentRoutes', () => {
   it('streams sidepanel ACP chat as an AI SDK UI message stream', async () => {
     const conversationId = '00000000-0000-4000-8000-000000000001'
     let sentInput: AgentPromptInput | undefined
+    const abortController = new AbortController()
     const route = createMountedRoutes([], {
       browser: {
         async resolveTabIds(tabIds: number[]) {
@@ -87,6 +88,7 @@ describe('createAgentRoutes', () => {
     const response = await route.request('/agents/sidepanel/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      signal: abortController.signal,
       body: JSON.stringify({
         conversationId,
         adapter: 'codex',
@@ -116,6 +118,37 @@ describe('createAgentRoutes', () => {
       'Tab 1 (Page ID: 101) - "Example" (https://example.com)',
     )
     expect(sentInput?.message).toContain('<USER_QUERY>\nhi\n</USER_QUERY>')
+    expect(sentInput?.signal).toBe(abortController.signal)
+
+    const list = await route.request('/agents')
+    expect(await list.json()).toEqual({ agents: [] })
+  })
+
+  it('rejects invalid sidepanel ACP chat requests', async () => {
+    const route = createMountedRoutes([])
+
+    for (const { patch, error } of [
+      {
+        patch: { conversationId: 'not-a-uuid' },
+        error: 'conversationId must be a UUID',
+      },
+      { patch: { adapter: 'openai' }, error: 'Invalid adapter' },
+      { patch: { modelId: 'unknown-model' }, error: 'Invalid modelId' },
+      { patch: { reasoningEffort: 'turbo' }, error: 'Invalid reasoningEffort' },
+      { patch: { message: '   ' }, error: 'Message is required' },
+    ]) {
+      const response = await route.request('/agents/sidepanel/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          ...validSidepanelAcpBody(),
+          ...patch,
+        }),
+      })
+
+      expect(response.status).toBe(400)
+      expect(await response.json()).toEqual({ error })
+    }
   })
 
   it('rejects overlong agent names', async () => {
@@ -200,6 +233,16 @@ function createFakeService(agents: AgentDefinition[]) {
         { type: 'done', stopReason: 'end_turn' },
       ])
     },
+  }
+}
+
+function validSidepanelAcpBody() {
+  return {
+    conversationId: '00000000-0000-4000-8000-000000000001',
+    adapter: 'codex',
+    modelId: 'gpt-5.5',
+    reasoningEffort: 'medium',
+    message: 'hi',
   }
 }
 

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acp-ui-message-stream.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acp-ui-message-stream.test.ts
@@ -46,6 +46,33 @@ describe('createAcpUIMessageStream', () => {
     ])
   })
 
+  it('closes and reopens text parts when ACP output and thoughts interleave', async () => {
+    const chunks = await collectChunks([
+      { type: 'text_delta', text: 'Thinking', stream: 'thought' },
+      { type: 'text_delta', text: 'Answer', stream: 'output' },
+      { type: 'text_delta', text: 'More thought', stream: 'thought' },
+      { type: 'done', stopReason: 'end_turn' },
+    ])
+
+    expect(chunks).toEqual([
+      { type: 'start' },
+      { type: 'reasoning-start', id: 'acp-reasoning' },
+      { type: 'reasoning-delta', id: 'acp-reasoning', delta: 'Thinking' },
+      { type: 'reasoning-end', id: 'acp-reasoning' },
+      { type: 'text-start', id: 'acp-text' },
+      { type: 'text-delta', id: 'acp-text', delta: 'Answer' },
+      { type: 'text-end', id: 'acp-text' },
+      { type: 'reasoning-start', id: 'acp-reasoning-2' },
+      {
+        type: 'reasoning-delta',
+        id: 'acp-reasoning-2',
+        delta: 'More thought',
+      },
+      { type: 'reasoning-end', id: 'acp-reasoning-2' },
+      { type: 'finish', finishReason: 'stop' },
+    ])
+  })
+
   it('maps ACP tool calls to AI SDK tool chunks', async () => {
     const chunks = await collectChunks([
       {
@@ -90,6 +117,26 @@ describe('createAcpUIMessageStream', () => {
       type: 'tool-output-error',
       toolCallId: 'tool-2',
       errorText: 'Tests failed',
+      dynamic: true,
+    })
+  })
+
+  it('uses a fallback error text for failed ACP tool calls without text', async () => {
+    const chunks = await collectChunks([
+      {
+        type: 'tool_call',
+        id: 'tool-1',
+        title: '',
+        text: '',
+        status: 'failed',
+      },
+      { type: 'done', stopReason: 'end_turn' },
+    ])
+
+    expect(chunks).toContainEqual({
+      type: 'tool-output-error',
+      toolCallId: 'tool-1',
+      errorText: 'Tool failed',
       dynamic: true,
     })
   })

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acp-ui-message-stream.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acp-ui-message-stream.test.ts
@@ -1,0 +1,165 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { describe, expect, it } from 'bun:test'
+import type { UIMessageChunk } from 'ai'
+import {
+  createAcpUIMessageStream,
+  mapAcpStopReasonToFinishReason,
+} from '../../../src/lib/agents/acp-ui-message-stream'
+import type { AgentStreamEvent } from '../../../src/lib/agents/types'
+
+describe('createAcpUIMessageStream', () => {
+  it('streams ACP output text into AI SDK text chunks', async () => {
+    const chunks = await collectChunks([
+      { type: 'text_delta', text: 'Hello', stream: 'output' },
+      { type: 'text_delta', text: ' world', stream: 'output' },
+      { type: 'done', stopReason: 'end_turn' },
+    ])
+
+    expect(chunks).toEqual([
+      { type: 'start' },
+      { type: 'text-start', id: 'acp-text' },
+      { type: 'text-delta', id: 'acp-text', delta: 'Hello' },
+      { type: 'text-delta', id: 'acp-text', delta: ' world' },
+      { type: 'text-end', id: 'acp-text' },
+      { type: 'finish', finishReason: 'stop' },
+    ])
+  })
+
+  it('streams ACP thought deltas into AI SDK reasoning chunks', async () => {
+    const chunks = await collectChunks([
+      { type: 'text_delta', text: 'Thinking', stream: 'thought' },
+      { type: 'text_delta', text: ' carefully', stream: 'thought' },
+      { type: 'done', stopReason: 'end_turn' },
+    ])
+
+    expect(chunks).toEqual([
+      { type: 'start' },
+      { type: 'reasoning-start', id: 'acp-reasoning' },
+      { type: 'reasoning-delta', id: 'acp-reasoning', delta: 'Thinking' },
+      { type: 'reasoning-delta', id: 'acp-reasoning', delta: ' carefully' },
+      { type: 'reasoning-end', id: 'acp-reasoning' },
+      { type: 'finish', finishReason: 'stop' },
+    ])
+  })
+
+  it('maps ACP tool calls to AI SDK tool chunks', async () => {
+    const chunks = await collectChunks([
+      {
+        type: 'tool_call',
+        id: 'tool-1',
+        title: 'Read file',
+        text: 'Reading package.json',
+        status: 'running',
+      },
+      {
+        type: 'tool_call',
+        id: 'tool-1',
+        title: 'Read file',
+        text: 'Read package.json',
+        status: 'completed',
+      },
+      {
+        type: 'tool_call',
+        id: 'tool-2',
+        title: 'Run tests',
+        text: 'Tests failed',
+        status: 'failed',
+      },
+      { type: 'done', stopReason: 'end_turn' },
+    ])
+
+    expect(chunks).toContainEqual({
+      type: 'tool-input-available',
+      toolCallId: 'tool-1',
+      toolName: 'read_file',
+      title: 'Read file',
+      input: { description: 'Reading package.json' },
+      dynamic: true,
+    })
+    expect(chunks).toContainEqual({
+      type: 'tool-output-available',
+      toolCallId: 'tool-1',
+      output: { content: 'Read package.json' },
+      dynamic: true,
+    })
+    expect(chunks).toContainEqual({
+      type: 'tool-output-error',
+      toolCallId: 'tool-2',
+      errorText: 'Tests failed',
+      dynamic: true,
+    })
+  })
+
+  it('keeps ACP status events transient', async () => {
+    const chunks = await collectChunks([
+      { type: 'status', text: 'Using adapter default' },
+      { type: 'done', stopReason: 'end_turn' },
+    ])
+
+    expect(chunks).toContainEqual({
+      type: 'data-acp-status',
+      id: 'acp-status',
+      data: { text: 'Using adapter default' },
+      transient: true,
+    })
+  })
+
+  it('emits an AI SDK error chunk and error finish for ACP errors', async () => {
+    const chunks = await collectChunks([
+      { type: 'text_delta', text: 'Partial', stream: 'output' },
+      { type: 'error', message: 'ACP failed', code: 'boom' },
+    ])
+
+    expect(chunks).toEqual([
+      { type: 'start' },
+      { type: 'text-start', id: 'acp-text' },
+      { type: 'text-delta', id: 'acp-text', delta: 'Partial' },
+      { type: 'text-end', id: 'acp-text' },
+      { type: 'error', errorText: 'ACP failed' },
+      { type: 'finish', finishReason: 'error' },
+    ])
+  })
+
+  it('cancels the ACP event reader when the UI stream is cancelled', async () => {
+    let cancelled = false
+    const acpEvents = new ReadableStream<AgentStreamEvent>({
+      cancel() {
+        cancelled = true
+      },
+    })
+    const reader = createAcpUIMessageStream(acpEvents).getReader()
+
+    await reader.read()
+    await reader.cancel('sidepanel stopped')
+
+    expect(cancelled).toBe(true)
+  })
+})
+
+describe('mapAcpStopReasonToFinishReason', () => {
+  it('maps known ACP stop reasons to AI SDK finish reasons', () => {
+    expect(mapAcpStopReasonToFinishReason('end_turn')).toBe('stop')
+    expect(mapAcpStopReasonToFinishReason('cancelled')).toBe('other')
+    expect(mapAcpStopReasonToFinishReason(undefined)).toBe('stop')
+  })
+})
+
+async function collectChunks(
+  events: AgentStreamEvent[],
+): Promise<UIMessageChunk[]> {
+  const stream = createAcpUIMessageStream(
+    new ReadableStream<AgentStreamEvent>({
+      start(controller) {
+        for (const event of events) controller.enqueue(event)
+        controller.close()
+      },
+    }),
+  )
+  const chunks: UIMessageChunk[] = []
+  for await (const chunk of stream) chunks.push(chunk)
+  return chunks
+}


### PR DESCRIPTION
## Summary
- Adds sidepanel chat targets so normal LLM providers and ACP-backed Claude Code/Codex models share one selector.
- Adds a sidepanel ACP chat route that converts ACP runtime events into AI SDK UI-message SSE for the existing sidepanel chat renderer.
- Routes sidepanel sends by selected target while preserving LLM /chat behavior and resetting active conversations on LLM/ACP target switches.

## Design
The sidepanel now resolves a selected chat target as either an LLM provider or an ACP model. LLM sends keep the existing /chat request body. ACP sends post explicit adapter/model/reasoning fields to /agents/sidepanel/chat, where the server creates a virtual conversation-scoped ACP agent, formats browser context consistently with /chat, and streams AI SDK UI-message chunks back to useChat.

## Test plan
- [x] bun run typecheck
- [x] bun run test:agent
- [x] bun ./tests/__helpers__/run-test-group.ts api (from apps/server)
- [x] bun --env-file=.env.development test --preload=./tests/__helpers__/test-env.ts ./tests/lib/agents/acp-ui-message-stream.test.ts (from apps/server)
- [x] Sidepanel CDP smoke test: selector opens, ACP options render, Codex GPT-5.5 selection updates header, no sidepanel JS errors
