### PR TITLE
feat(agents): redesign the agent command center for multi-adapter use

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AdapterIcon.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AdapterIcon.tsx
@@ -1,0 +1,42 @@
+import { Bot, Cpu, Sparkles } from 'lucide-react'
+import type { FC } from 'react'
+import type { HarnessAgentAdapter } from './agent-harness-types'
+
+/**
+ * Single icon component for any adapter the agent rail can render.
+ * Falls back to a generic bot when the adapter is unknown so future
+ * adapters land without a code change at the call site.
+ */
+interface AdapterIconProps {
+  adapter: HarnessAgentAdapter | 'unknown'
+  className?: string
+}
+
+export const AdapterIcon: FC<AdapterIconProps> = ({ adapter, className }) => {
+  switch (adapter) {
+    case 'claude':
+      // Claude Code — text-based agent, sparkles to evoke the "AI assistant" feel.
+      return <Sparkles className={className} aria-label="Claude Code" />
+    case 'codex':
+      // Codex — code-leaning, CPU mark.
+      return <Cpu className={className} aria-label="Codex" />
+    case 'openclaw':
+      // OpenClaw — bot/automation framing.
+      return <Bot className={className} aria-label="OpenClaw" />
+    default:
+      return <Bot className={className} aria-label="Agent" />
+  }
+}
+
+export function adapterLabel(adapter: HarnessAgentAdapter | 'unknown'): string {
+  switch (adapter) {
+    case 'claude':
+      return 'Claude Code'
+    case 'codex':
+      return 'Codex'
+    case 'openclaw':
+      return 'OpenClaw'
+    default:
+      return 'Agent'
+  }
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentList.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentList.tsx
@@ -1,117 +1,108 @@
-import { Bot, Cpu, Loader2, MessageSquare, Plus, Trash2 } from 'lucide-react'
-import type { FC } from 'react'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import { Loader2 } from 'lucide-react'
+import { type FC, useMemo } from 'react'
+import { AgentRowCard } from './AgentRowCard'
+import { AgentsEmptyState } from './AgentsEmptyState'
+import type { HarnessAgent, HarnessAgentAdapter } from './agent-harness-types'
 import type { AgentListItem } from './agents-page-types'
+import type { AgentLiveness } from './LivenessDot'
 
 interface AgentListProps {
   agents: AgentListItem[]
+  /**
+   * Optional per-agent activity metadata. Keyed by `agentId`. Missing
+   * entries fall back to status='unknown' / lastUsedAt=null and the
+   * row renders an "unknown" dot. The server will populate this once
+   * the activity tracker ships; the page works without it.
+   */
+  activity?: Record<
+    string,
+    { status: AgentLiveness; lastUsedAt: number | null }
+  >
+  /**
+   * Lookup table from harness agent id → adapter + reasoning effort,
+   * sourced from `useHarnessAgents`. Lets the row card render the
+   * correct adapter icon and chips for harness agents (legacy
+   * /claw/agents entries fall back to inferring from `runtimeLabel`).
+   */
+  harnessAgentLookup?: Map<string, HarnessAgent>
   loading: boolean
   deletingAgentKey: string | null
-  onChatAgent: (agent: AgentListItem) => void
   onCreateAgent: () => void
   onDeleteAgent: (agent: AgentListItem) => void
 }
 
 export const AgentList: FC<AgentListProps> = ({
   agents,
+  activity,
+  harnessAgentLookup,
   loading,
   deletingAgentKey,
-  onChatAgent,
   onCreateAgent,
   onDeleteAgent,
 }) => {
+  // Sort by recency: most recently used first; never-used agents drop
+  // to the bottom in id-stable order so the list doesn't reshuffle on
+  // every refresh. The pinned exception is the gateway's `main` agent
+  // when it's never been touched — keep it at the top so a fresh
+  // install has an obvious starting point.
+  const ordered = useMemo(() => {
+    const withScore = agents.map((agent) => {
+      const lastUsedAt = activity?.[agent.agentId]?.lastUsedAt ?? null
+      return { agent, lastUsedAt }
+    })
+    return withScore
+      .sort((a, b) => {
+        const aPinned = a.agent.agentId === 'main' && a.lastUsedAt === null
+        const bPinned = b.agent.agentId === 'main' && b.lastUsedAt === null
+        if (aPinned && !bPinned) return -1
+        if (!aPinned && bPinned) return 1
+        const aValue = a.lastUsedAt ?? -Infinity
+        const bValue = b.lastUsedAt ?? -Infinity
+        if (aValue !== bValue) return bValue - aValue
+        return a.agent.agentId.localeCompare(b.agent.agentId)
+      })
+      .map((entry) => entry.agent)
+  }, [activity, agents])
+
   if (loading && agents.length === 0) {
     return (
-      <div className="flex h-36 items-center justify-center rounded-lg border border-border/70">
+      <div className="flex h-36 items-center justify-center rounded-xl border border-border border-dashed bg-card/50">
         <Loader2 className="size-5 animate-spin text-muted-foreground" />
       </div>
     )
   }
 
   if (agents.length === 0) {
-    return (
-      <Card>
-        <CardContent className="flex h-48 flex-col items-center justify-center gap-4 text-center">
-          <div className="flex size-10 items-center justify-center rounded-lg bg-muted text-muted-foreground">
-            <Bot className="size-5" />
-          </div>
-          <div className="space-y-1">
-            <h2 className="font-medium text-base">No agents</h2>
-            <p className="text-muted-foreground text-sm">
-              Create an OpenClaw, Claude Code, or Codex agent.
-            </p>
-          </div>
-          <Button variant="outline" onClick={onCreateAgent}>
-            <Plus className="mr-2 size-4" />
-            New Agent
-          </Button>
-        </CardContent>
-      </Card>
-    )
+    return <AgentsEmptyState onCreateAgent={onCreateAgent} />
   }
 
   return (
     <div className="grid gap-3">
-      {agents.map((agent) => (
-        <Card key={agent.key} className="rounded-lg border-border/70">
-          <CardHeader className="flex flex-row items-center justify-between gap-4 py-3">
-            <div className="flex min-w-0 items-center gap-3">
-              <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-muted-foreground">
-                {agent.source === 'openclaw' ? (
-                  <Cpu className="size-5" />
-                ) : (
-                  <Bot className="size-5" />
-                )}
-              </div>
-              <div className="min-w-0">
-                <CardTitle className="truncate text-base">
-                  {agent.name}
-                </CardTitle>
-                <div className="mt-1 flex flex-wrap items-center gap-2 text-muted-foreground text-xs">
-                  <Badge variant="outline" className="rounded-md">
-                    {agent.runtimeLabel}
-                  </Badge>
-                  <span>{agent.modelLabel}</span>
-                  <Badge variant="outline" className="rounded-md">
-                    main
-                  </Badge>
-                </div>
-                <p className="mt-1 truncate font-mono text-muted-foreground text-xs">
-                  {agent.detail}
-                </p>
-              </div>
-            </div>
-            <div className="flex shrink-0 items-center gap-1">
-              <Button
-                variant="ghost"
-                size="sm"
-                onClick={() => onChatAgent(agent)}
-                disabled={!agent.canChat}
-              >
-                <MessageSquare className="mr-1 size-4" />
-                Chat
-              </Button>
-              {agent.canDelete ? (
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  title="Delete agent"
-                  onClick={() => onDeleteAgent(agent)}
-                  disabled={deletingAgentKey === agent.key}
-                >
-                  {deletingAgentKey === agent.key ? (
-                    <Loader2 className="size-4 animate-spin" />
-                  ) : (
-                    <Trash2 className="size-4 text-destructive" />
-                  )}
-                </Button>
-              ) : null}
-            </div>
-          </CardHeader>
-        </Card>
-      ))}
+      {ordered.map((agent) => {
+        const harness = harnessAgentLookup?.get(agent.agentId)
+        const adapter: HarnessAgentAdapter | undefined =
+          harness?.adapter ?? inferAdapterFromLabel(agent.runtimeLabel)
+        return (
+          <AgentRowCard
+            key={agent.key}
+            agent={agent}
+            status={activity?.[agent.agentId]?.status}
+            lastUsedAt={activity?.[agent.agentId]?.lastUsedAt}
+            adapter={adapter}
+            reasoningEffort={harness?.reasoningEffort ?? null}
+            onDelete={onDeleteAgent}
+            deleting={deletingAgentKey === agent.key}
+          />
+        )
+      })}
     </div>
   )
+}
+
+function inferAdapterFromLabel(label: string): HarnessAgentAdapter | undefined {
+  const lower = label?.toLowerCase()
+  if (lower === 'claude code') return 'claude'
+  if (lower === 'codex') return 'codex'
+  if (lower === 'openclaw') return 'openclaw'
+  return undefined
 }

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentRowCard.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentRowCard.tsx
@@ -1,0 +1,270 @@
+import {
+  Copy,
+  Loader2,
+  MessageSquare,
+  MoreHorizontal,
+  Pencil,
+  RotateCcw,
+  Trash2,
+} from 'lucide-react'
+import type { FC } from 'react'
+import { useNavigate } from 'react-router'
+import { toast } from 'sonner'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { AdapterIcon, adapterLabel } from './AdapterIcon'
+import {
+  canDelete as canDeleteAgent,
+  canRename as canRenameAgent,
+  displayName,
+  formatRelativeTime,
+  workspaceLabel,
+} from './agent-display.helpers'
+import type { HarnessAgentAdapter } from './agent-harness-types'
+import type { AgentListItem } from './agents-page-types'
+import { type AgentLiveness, LivenessDot } from './LivenessDot'
+
+interface AgentRowCardProps {
+  agent: AgentListItem
+  /**
+   * Per-agent extras the listing surface provides on top of the
+   * minimal `AgentListItem` shape. `lastUsedAt` survives server
+   * restart (sourced from acpx session record); `status` is in-memory
+   * server-side.
+   */
+  status?: AgentLiveness
+  lastUsedAt?: number | null
+  /** Adapter the agent belongs to. Drives icon + label. */
+  adapter?: HarnessAgentAdapter
+  /** Reasoning effort chip (claude/codex/openclaw catalog). */
+  reasoningEffort?: string | null
+  /** Modeled directly off the inbound delete handler so the parent owns the dialog. */
+  onDelete: (agent: AgentListItem) => void
+  /** Whether THIS agent is mid-delete; renders a spinner in place of the trash icon. */
+  deleting?: boolean
+}
+
+export const AgentRowCard: FC<AgentRowCardProps> = ({
+  agent,
+  status = 'unknown',
+  lastUsedAt,
+  adapter,
+  reasoningEffort,
+  onDelete,
+  deleting,
+}) => {
+  const navigate = useNavigate()
+  const adapterId = adapter ?? inferAdapterFromListItem(agent)
+  const workspace = workspaceLabel(agent)
+  const lastUsedLabel = formatRelativeTime(lastUsedAt ?? null)
+  const allowDelete = canDeleteAgent(agent)
+  const allowRename = canRenameAgent(agent)
+
+  const handleChat = () => navigate(`/agents/${agent.agentId}`)
+  const handleCopyId = async () => {
+    try {
+      await navigator.clipboard.writeText(agent.agentId)
+      toast.success('Agent id copied')
+    } catch {
+      toast.error('Could not copy agent id')
+    }
+  }
+
+  return (
+    <div
+      className={cn(
+        'group rounded-xl border border-border bg-card p-4 shadow-sm transition-all',
+        'hover:border-[var(--accent-orange)]/50 hover:shadow-sm',
+      )}
+    >
+      <div className="flex items-start gap-4">
+        {/* Adapter tile + liveness dot in the corner. */}
+        <div className="relative shrink-0">
+          <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-muted text-muted-foreground">
+            <AdapterIcon adapter={adapterId} className="h-6 w-6" />
+          </div>
+          <LivenessDot
+            status={status}
+            detail={livenessDetail(status, lastUsedAt)}
+            className="absolute -right-0.5 -bottom-0.5"
+          />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="mb-1 flex items-center gap-2">
+            <span className="truncate font-semibold">{displayName(agent)}</span>
+            {status === 'working' && (
+              <Badge
+                variant="secondary"
+                className="bg-amber-50 text-amber-900 hover:bg-amber-50"
+              >
+                Working
+              </Badge>
+            )}
+            {status === 'asleep' && (
+              <Badge variant="outline" className="text-muted-foreground">
+                Asleep
+              </Badge>
+            )}
+            {status === 'error' && (
+              <Badge variant="destructive">Attention</Badge>
+            )}
+          </div>
+
+          <div className="mb-2 flex flex-wrap items-center gap-1.5 text-xs">
+            <Badge variant="secondary" className="font-normal">
+              {adapterLabel(adapterId)}
+            </Badge>
+            {agent.modelLabel && agent.modelLabel !== 'default' && (
+              <Badge variant="outline" className="font-normal">
+                {agent.modelLabel}
+              </Badge>
+            )}
+            {reasoningEffort && reasoningEffort !== 'medium' && (
+              <Badge variant="outline" className="font-normal">
+                {reasoningEffort}
+              </Badge>
+            )}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2 text-muted-foreground text-xs">
+            <span>Last used {lastUsedLabel}</span>
+            {workspace && (
+              <>
+                <span aria-hidden>•</span>
+                <span className="truncate font-mono" title={workspace}>
+                  {workspace}
+                </span>
+              </>
+            )}
+          </div>
+        </div>
+
+        <div className="flex shrink-0 items-center gap-2">
+          <Button variant="outline" size="sm" onClick={handleChat}>
+            <MessageSquare className="mr-1.5 h-3 w-3" />
+            Chat
+          </Button>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                aria-label={`More actions for ${displayName(agent)}`}
+                className="h-8 w-8"
+              >
+                <MoreHorizontal className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-44">
+              <DropdownMenuItem onSelect={() => void handleCopyId()}>
+                <Copy className="mr-2 h-3.5 w-3.5" />
+                Copy id
+              </DropdownMenuItem>
+              <RenameMenuItem disabled={!allowRename} />
+              <ResetHistoryMenuItem />
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                onSelect={() => onDelete(agent)}
+                disabled={!allowDelete || deleting}
+                className="text-destructive focus:text-destructive"
+              >
+                {deleting ? (
+                  <Loader2 className="mr-2 h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Trash2 className="mr-2 h-3.5 w-3.5" />
+                )}
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+const RenameMenuItem: FC<{ disabled: boolean }> = ({ disabled }) => {
+  const item = (
+    <DropdownMenuItem disabled className="text-muted-foreground">
+      <Pencil className="mr-2 h-3.5 w-3.5" />
+      Rename
+    </DropdownMenuItem>
+  )
+  if (!disabled) return item
+  // Disabled but with a hint so users know it's coming, not broken.
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="block w-full">{item}</span>
+        </TooltipTrigger>
+        <TooltipContent side="left" className="text-xs">
+          Rename coming soon
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+const ResetHistoryMenuItem: FC = () => {
+  const item = (
+    <DropdownMenuItem disabled className="text-muted-foreground">
+      <RotateCcw className="mr-2 h-3.5 w-3.5" />
+      Reset history
+    </DropdownMenuItem>
+  )
+  return (
+    <TooltipProvider delayDuration={300}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="block w-full">{item}</span>
+        </TooltipTrigger>
+        <TooltipContent side="left" className="text-xs">
+          Reset history coming soon
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}
+
+function inferAdapterFromListItem(
+  agent: AgentListItem,
+): HarnessAgentAdapter | 'unknown' {
+  const label = agent.runtimeLabel?.toLowerCase()
+  if (label?.includes('claude')) return 'claude'
+  if (label?.includes('codex')) return 'codex'
+  if (label?.includes('openclaw')) return 'openclaw'
+  return 'unknown'
+}
+
+function livenessDetail(
+  status: AgentLiveness,
+  lastUsedAt: number | null | undefined,
+): string | undefined {
+  if (lastUsedAt == null) return undefined
+  const diffMin = Math.floor((Date.now() - lastUsedAt) / 60_000)
+  if (status === 'idle') return `Idle for ${Math.max(0, diffMin)} min`
+  if (status === 'asleep') {
+    if (diffMin < 60) return `Asleep — quiet for ${diffMin} min`
+    const hr = Math.floor(diffMin / 60)
+    return `Asleep — quiet for ${hr} hr`
+  }
+  if (status === 'working') return 'Working on a turn'
+  if (status === 'error') return 'Attention — last turn failed'
+  return undefined
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsEmptyState.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsEmptyState.tsx
@@ -1,0 +1,32 @@
+import { Bot, Plus } from 'lucide-react'
+import type { FC } from 'react'
+import { Button } from '@/components/ui/button'
+
+interface AgentsEmptyStateProps {
+  onCreateAgent: () => void
+}
+
+export const AgentsEmptyState: FC<AgentsEmptyStateProps> = ({
+  onCreateAgent,
+}) => {
+  return (
+    <div className="rounded-xl border border-border border-dashed bg-card/50 p-12 text-center">
+      <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-xl bg-[var(--accent-orange)]/10">
+        <Bot className="h-6 w-6 text-[var(--accent-orange)]" />
+      </div>
+      <h3 className="mb-1 font-semibold">No agents yet</h3>
+      <p className="mx-auto mb-4 max-w-sm text-muted-foreground text-sm">
+        Spin up an OpenClaw, Claude Code, or Codex agent to chat with, schedule,
+        or run in the background.
+      </p>
+      <Button
+        onClick={onCreateAgent}
+        variant="outline"
+        className="border-[var(--accent-orange)] bg-[var(--accent-orange)]/10 text-[var(--accent-orange)] hover:bg-[var(--accent-orange)]/20 hover:text-[var(--accent-orange)]"
+      >
+        <Plus className="mr-1.5 h-4 w-4" />
+        Create your first agent
+      </Button>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsHeader.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsHeader.tsx
@@ -1,0 +1,41 @@
+import { Bot, Plus } from 'lucide-react'
+import type { FC } from 'react'
+import { Button } from '@/components/ui/button'
+
+interface AgentsHeaderProps {
+  onCreateAgent: () => void
+}
+
+/**
+ * Mirrors the visual shape of `SoulHeader` and `ScheduledTasksHeader`
+ * so the page reads as part of the same family. Loose lifecycle
+ * controls that used to sit next to the title moved into
+ * `GatewayStatusBar` — they're OpenClaw-specific and don't apply to
+ * Claude/Codex agents.
+ */
+export const AgentsHeader: FC<AgentsHeaderProps> = ({ onCreateAgent }) => {
+  return (
+    <div className="rounded-xl border border-border bg-card p-6 shadow-sm transition-all hover:shadow-md">
+      <div className="flex items-start gap-4">
+        <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-[var(--accent-orange)]/10">
+          <Bot className="h-6 w-6 text-[var(--accent-orange)]" />
+        </div>
+        <div className="flex-1">
+          <h2 className="mb-1 font-semibold text-xl">Agents</h2>
+          <p className="text-muted-foreground text-sm">
+            OpenClaw, Claude Code, and Codex agents — chat, schedule, and run
+            them in the background.
+          </p>
+        </div>
+        <Button
+          onClick={onCreateAgent}
+          className="border-[var(--accent-orange)] bg-[var(--accent-orange)]/10 text-[var(--accent-orange)] hover:bg-[var(--accent-orange)]/20 hover:text-[var(--accent-orange)]"
+          variant="outline"
+        >
+          <Plus className="mr-1.5 h-4 w-4" />
+          New Agent
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -158,15 +158,24 @@ export const AgentsPage: FC = () => {
     openClawAgentsEnabled,
     openClawAgents,
   )
-  const agentListItems = useMemo(
-    () => [
-      ...visibleOpenClawAgents.map((agent) =>
+  const agentListItems = useMemo(() => {
+    // Dual-created OpenClaw agents (and the backfilled `main`/orphans
+    // post Step 9) live in both `/claw/agents` and `/agents` under the
+    // same id. Prefer the harness entry — it carries adapter/model/
+    // reasoning/lastUsedAt/status that the chat path actually uses —
+    // and drop the legacy duplicate so the rail doesn't show every
+    // OpenClaw agent twice.
+    const harnessIds = new Set(harnessAgents.map((agent) => agent.id))
+    const dedupedOpenClawAgents = visibleOpenClawAgents.filter(
+      (agent) => !harnessIds.has(agent.agentId),
+    )
+    return [
+      ...dedupedOpenClawAgents.map((agent) =>
         toOpenClawListItem(agent, openClawManageable),
       ),
       ...harnessAgents.map(toHarnessListItem),
-    ],
-    [harnessAgents, openClawManageable, visibleOpenClawAgents],
-  )
+    ]
+  }, [harnessAgents, openClawManageable, visibleOpenClawAgents])
   // Lookup map so AgentList can render adapter chips, reasoning, etc.
   // Computed up here to keep all hooks above the early returns below.
   const harnessAgentLookup = useMemo(() => {

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -45,25 +45,27 @@ import {
   useDeleteHarnessAgent,
   useHarnessAgents,
 } from './useAgents'
-import {
-  useOpenClawAgents,
-  useOpenClawMutations,
-  useOpenClawStatus,
-} from './useOpenClaw'
+import { useOpenClawAgents, useOpenClawMutations } from './useOpenClaw'
 
 export const AgentsPage: FC = () => {
   const navigate = useNavigate()
-  const {
-    status,
-    loading: statusLoading,
-    error: statusError,
-  } = useOpenClawStatus()
   const { providers, defaultProviderId } = useLlmProviders()
   const {
     adapters,
     loading: adaptersLoading,
     error: adaptersError,
   } = useAgentAdapters()
+
+  // The harness listing now carries the gateway lifecycle snapshot
+  // alongside the agents — one polling source for everything the
+  // agents page renders. The legacy `/claw/status` poll is dead from
+  // this surface; the chat-panel layout still uses it for now.
+  const {
+    harnessAgents,
+    gateway: status,
+    loading: harnessAgentsLoading,
+    error: harnessAgentsError,
+  } = useHarnessAgents()
 
   const openClawAgentsEnabled =
     status?.status === 'running' && status.controlPlaneStatus === 'connected'
@@ -72,11 +74,6 @@ export const AgentsPage: FC = () => {
     loading: openClawAgentsLoading,
     error: openClawAgentsError,
   } = useOpenClawAgents(openClawAgentsEnabled)
-  const {
-    harnessAgents,
-    loading: harnessAgentsLoading,
-    error: harnessAgentsError,
-  } = useHarnessAgents()
   const createHarnessAgent = useCreateHarnessAgent()
   const deleteHarnessAgent = useDeleteHarnessAgent()
   const {
@@ -204,16 +201,13 @@ export const AgentsPage: FC = () => {
   const inlineError = getInlineError({
     lifecyclePending,
     pageError,
-    statusError,
     openClawAgentsError,
     adaptersError,
     harnessAgentsError,
   })
   const agentsLoading = getAgentsLoading({
-    statusLoading,
     adaptersLoading,
     harnessAgentsLoading,
-    openClawAgentsEnabled,
     openClawAgentsLoading,
   })
   const creatingAgent = creatingOpenClawAgent || createHarnessAgent.isPending
@@ -264,7 +258,9 @@ export const AgentsPage: FC = () => {
     )
   }
 
-  if (statusLoading && !status) {
+  // First-paint loader: until the harness listing has resolved at
+  // least once we don't know which adapters / agents to render.
+  if (harnessAgentsLoading && !status) {
     return (
       <div className="flex items-center justify-center py-20">
         <Loader2 className="size-6 animate-spin text-muted-foreground" />

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -57,14 +57,12 @@ export const AgentsPage: FC = () => {
     status,
     loading: statusLoading,
     error: statusError,
-    refetch: refetchStatus,
   } = useOpenClawStatus()
   const { providers, defaultProviderId } = useLlmProviders()
   const {
     adapters,
     loading: adaptersLoading,
     error: adaptersError,
-    refetch: refetchAdapters,
   } = useAgentAdapters()
 
   const openClawAgentsEnabled =
@@ -73,13 +71,11 @@ export const AgentsPage: FC = () => {
     agents: openClawAgents,
     loading: openClawAgentsLoading,
     error: openClawAgentsError,
-    refetch: refetchOpenClawAgents,
   } = useOpenClawAgents(openClawAgentsEnabled)
   const {
     harnessAgents,
     loading: harnessAgentsLoading,
     error: harnessAgentsError,
-    refetch: refetchHarnessAgents,
   } = useHarnessAgents()
   const createHarnessAgent = useCreateHarnessAgent()
   const deleteHarnessAgent = useDeleteHarnessAgent()
@@ -223,15 +219,6 @@ export const AgentsPage: FC = () => {
   const creatingAgent = creatingOpenClawAgent || createHarnessAgent.isPending
   const deletingAgent = deletingOpenClawAgent || deleteHarnessAgent.isPending
 
-  const refreshAll = async () => {
-    await Promise.all([
-      refetchStatus(),
-      refetchAdapters(),
-      refetchHarnessAgents(),
-      openClawAgentsEnabled ? refetchOpenClawAgents() : Promise.resolve(),
-    ])
-  }
-
   const handleHarnessAdapterChange = (adapter: HarnessAgentAdapter) => {
     const descriptor = adapters.find((entry) => entry.id === adapter)
     setHarnessAdapterId(adapter)
@@ -347,8 +334,11 @@ export const AgentsPage: FC = () => {
         {showGatewayStatusBar ? (
           <GatewayStatusBar
             status={status}
+            actionInProgress={actionInProgress}
             onOpenTerminal={() => setShowTerminal(true)}
-            onRefresh={() => void refreshAll()}
+            onRestart={() => {
+              void runWithPageErrorHandling(restartOpenClaw)
+            }}
           />
         ) : null}
 

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -3,8 +3,9 @@ import { type FC, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router'
 import { useLlmProviders } from '@/lib/llm-providers/useLlmProviders'
 import { AgentList } from './AgentList'
+import { AgentsHeader } from './AgentsHeader'
 import { AgentTerminal } from './AgentTerminal'
-import type { HarnessAgentAdapter } from './agent-harness-types'
+import type { HarnessAgent, HarnessAgentAdapter } from './agent-harness-types'
 import { createAgentPageActions } from './agents-page-actions'
 import {
   useDefaultAgentName,
@@ -29,9 +30,9 @@ import {
   toHarnessListItem,
   toOpenClawListItem,
 } from './agents-page-utils'
+import { GatewayStatusBar } from './GatewayStatusBar'
 import { NewAgentDialog } from './NewAgentDialog'
 import {
-  AgentsPageHeader,
   ControlPlaneAlert,
   GatewayStateCards,
   InlineErrorAlert,
@@ -87,7 +88,6 @@ export const AgentsPage: FC = () => {
     createAgent: createOpenClawAgent,
     deleteAgent: deleteOpenClawAgent,
     startOpenClaw,
-    stopOpenClaw,
     restartOpenClaw,
     reconnectOpenClaw,
     actionInProgress,
@@ -167,6 +167,13 @@ export const AgentsPage: FC = () => {
     ],
     [harnessAgents, openClawManageable, visibleOpenClawAgents],
   )
+  // Lookup map so AgentList can render adapter chips, reasoning, etc.
+  // Computed up here to keep all hooks above the early returns below.
+  const harnessAgentLookup = useMemo(() => {
+    const map = new Map<string, HarnessAgent>()
+    for (const agent of harnessAgents) map.set(agent.id, agent)
+    return map
+  }, [harnessAgents])
   const inlineError = getInlineError({
     lifecyclePending,
     pageError,
@@ -255,27 +262,18 @@ export const AgentsPage: FC = () => {
   const recoveryDetail = status ? getRecoveryDetail(status) : null
   const controlPlaneCopy = getControlPlaneCopyForStatus(status)
 
+  // Bar only makes sense when the gateway is meaningfully alive AND
+  // there's at least one OpenClaw agent in the merged list. Hide it
+  // for Claude/Codex-only setups so the page stays uncluttered.
+  const showGatewayStatusBar =
+    status?.status === 'running' &&
+    (visibleOpenClawAgents.length > 0 ||
+      harnessAgents.some((agent) => agent.adapter === 'openclaw'))
+
   return (
     <div className="min-h-full bg-background px-6 py-8">
-      <div className="mx-auto flex w-full max-w-5xl flex-col gap-6">
-        <AgentsPageHeader
-          actionInProgress={actionInProgress}
-          controlPlaneBusy={gatewayUiState.controlPlaneBusy}
-          reconnecting={reconnecting}
-          status={status}
-          onCreateAgent={() => setCreateOpen(true)}
-          onOpenTerminal={() => setShowTerminal(true)}
-          onReconnect={() => {
-            void runWithPageErrorHandling(reconnectOpenClaw)
-          }}
-          onRefresh={() => void refreshAll()}
-          onRestart={() => {
-            void runWithPageErrorHandling(restartOpenClaw)
-          }}
-          onStop={() => {
-            void runWithPageErrorHandling(stopOpenClaw)
-          }}
-        />
+      <div className="fade-in slide-in-from-bottom-5 mx-auto flex w-full max-w-5xl animate-in flex-col gap-6 duration-500">
+        <AgentsHeader onCreateAgent={() => setCreateOpen(true)} />
 
         {lifecycleBanner ? <LifecycleAlert message={lifecycleBanner} /> : null}
 
@@ -315,11 +313,19 @@ export const AgentsPage: FC = () => {
           }}
         />
 
+        {showGatewayStatusBar ? (
+          <GatewayStatusBar
+            status={status}
+            onOpenTerminal={() => setShowTerminal(true)}
+            onRefresh={() => void refreshAll()}
+          />
+        ) : null}
+
         <AgentList
           agents={agentListItems}
+          harnessAgentLookup={harnessAgentLookup}
           loading={agentsLoading}
           deletingAgentKey={deletingAgent ? deletingAgentKey : null}
-          onChatAgent={(agent) => navigate(`/agents/${agent.agentId}`)}
           onCreateAgent={() => setCreateOpen(true)}
           onDeleteAgent={(agent) => {
             void handleDelete(agent)

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentsPage.tsx
@@ -174,6 +174,28 @@ export const AgentsPage: FC = () => {
     for (const agent of harnessAgents) map.set(agent.id, agent)
     return map
   }, [harnessAgents])
+  // Activity map keyed by agentId. Sourced from the harness listing's
+  // server-side enrichment (`status` + `lastUsedAt`). Legacy gateway
+  // agents that don't have a harness record yet (rare post-backfill)
+  // simply miss from the map and render with the default `unknown`
+  // dot until reconciliation picks them up.
+  const agentActivity = useMemo(() => {
+    const map: Record<
+      string,
+      {
+        status: 'working' | 'idle' | 'asleep' | 'error'
+        lastUsedAt: number | null
+      }
+    > = {}
+    for (const agent of harnessAgents) {
+      if (!agent.status) continue
+      map[agent.id] = {
+        status: agent.status,
+        lastUsedAt: agent.lastUsedAt ?? null,
+      }
+    }
+    return map
+  }, [harnessAgents])
   const inlineError = getInlineError({
     lifecyclePending,
     pageError,
@@ -323,6 +345,7 @@ export const AgentsPage: FC = () => {
 
         <AgentList
           agents={agentListItems}
+          activity={agentActivity}
           harnessAgentLookup={harnessAgentLookup}
           loading={agentsLoading}
           deletingAgentKey={deletingAgent ? deletingAgentKey : null}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/GatewayStatusBar.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/GatewayStatusBar.tsx
@@ -21,16 +21,15 @@ interface GatewayStatusBarProps {
 }
 
 /**
- * Compact one-line status bar for the OpenClaw gateway. Lives between
- * the page header and the agent list when at least one OpenClaw agent
- * is in the picture; collapses to nothing when the user only has
- * Claude/Codex agents.
+ * Compact one-line status bar for the OpenClaw gateway. Renders the
+ * lifecycle pills (Running / Control plane connected) plus a Terminal
+ * escape hatch and a Restart Gateway action. Lives between the page
+ * header and the agent list when at least one OpenClaw agent is in
+ * the merged list; collapses to nothing for Claude/Codex-only setups.
  *
- * Carries the lifecycle pills + a Terminal escape hatch + a Restart
- * button. The agent listing itself auto-polls every 5s, so a manual
- * refresh isn't needed; restart is a real lifecycle action that the
- * old AgentsPageHeader exposed and is still useful when the gateway
- * gets wedged.
+ * Status is sourced from `GET /agents`'s `gateway` field — the agents
+ * page no longer polls `/claw/status` directly. One endpoint, one
+ * 5s interval, no duplicate state.
  */
 export const GatewayStatusBar: FC<GatewayStatusBarProps> = ({
   status,

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/GatewayStatusBar.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/GatewayStatusBar.tsx
@@ -1,0 +1,175 @@
+import { RefreshCw, Terminal } from 'lucide-react'
+import type { FC } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Separator } from '@/components/ui/separator'
+import { cn } from '@/lib/utils'
+import type { OpenClawStatus } from './useOpenClaw'
+
+interface GatewayStatusBarProps {
+  status: OpenClawStatus | null
+  onOpenTerminal: () => void
+  onRefresh: () => void
+}
+
+/**
+ * Compact one-line status bar for the OpenClaw gateway. Lives between
+ * the page header and the agent list when at least one OpenClaw agent
+ * is in the picture; collapses to nothing when the user only has
+ * Claude/Codex agents.
+ *
+ * Only renders the lifecycle pills + Terminal/Refresh affordances —
+ * the existing `GatewayStateCards` (start, restart, setup) keep their
+ * own slot below the list because they're action-heavy. This bar is
+ * for at-a-glance reassurance: "yes, the gateway is running and the
+ * control plane is connected."
+ */
+export const GatewayStatusBar: FC<GatewayStatusBarProps> = ({
+  status,
+  onOpenTerminal,
+  onRefresh,
+}) => {
+  if (!status) return null
+
+  const runningPill = pillForRuntimeStatus(status.status)
+  const controlPlanePill = pillForControlPlane(status.controlPlaneStatus)
+
+  return (
+    <div className="rounded-xl border border-border bg-card px-4 py-3 shadow-sm">
+      <div className="flex items-center gap-3 text-sm">
+        <span className="font-medium text-muted-foreground">
+          OpenClaw gateway
+        </span>
+        <Badge
+          variant={runningPill.variant}
+          className={cn('gap-1.5', runningPill.className)}
+        >
+          <span
+            className={cn(
+              'inline-block h-1.5 w-1.5 rounded-full',
+              runningPill.dot,
+            )}
+          />
+          {runningPill.label}
+        </Badge>
+        <Badge
+          variant={controlPlanePill.variant}
+          className={cn('gap-1.5', controlPlanePill.className)}
+        >
+          <span
+            className={cn(
+              'inline-block h-1.5 w-1.5 rounded-full',
+              controlPlanePill.dot,
+            )}
+          />
+          {controlPlanePill.label}
+        </Badge>
+        <Separator orientation="vertical" className="h-4" />
+        <Button variant="ghost" size="sm" onClick={onOpenTerminal}>
+          <Terminal className="mr-1.5 h-3.5 w-3.5" />
+          Terminal
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onRefresh}
+          aria-label="Refresh gateway status"
+          className="ml-auto h-8 w-8"
+        >
+          <RefreshCw className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+type PillKind = {
+  variant: 'default' | 'secondary' | 'outline' | 'destructive'
+  label: string
+  dot: string
+  className?: string
+}
+
+function pillForRuntimeStatus(status: OpenClawStatus['status']): PillKind {
+  switch (status) {
+    case 'running':
+      return {
+        variant: 'secondary',
+        label: 'Running',
+        dot: 'bg-emerald-500',
+        className: 'bg-emerald-50 text-emerald-900 hover:bg-emerald-50',
+      }
+    case 'starting':
+      return {
+        variant: 'secondary',
+        label: 'Starting',
+        dot: 'bg-amber-500 animate-pulse',
+        className: 'bg-amber-50 text-amber-900 hover:bg-amber-50',
+      }
+    case 'stopped':
+      return {
+        variant: 'outline',
+        label: 'Stopped',
+        dot: 'bg-muted-foreground/40',
+      }
+    case 'error':
+      return {
+        variant: 'destructive',
+        label: 'Error',
+        dot: 'bg-destructive-foreground',
+      }
+    default:
+      return {
+        variant: 'outline',
+        label: 'Unknown',
+        dot: 'bg-muted-foreground/40',
+      }
+  }
+}
+
+function pillForControlPlane(
+  status: OpenClawStatus['controlPlaneStatus'],
+): PillKind {
+  switch (status) {
+    case 'connected':
+      return {
+        variant: 'secondary',
+        label: 'Control plane connected',
+        dot: 'bg-emerald-500',
+        className: 'bg-emerald-50 text-emerald-900 hover:bg-emerald-50',
+      }
+    case 'connecting':
+      return {
+        variant: 'secondary',
+        label: 'Connecting',
+        dot: 'bg-amber-500 animate-pulse',
+        className: 'bg-amber-50 text-amber-900 hover:bg-amber-50',
+      }
+    case 'reconnecting':
+      return {
+        variant: 'secondary',
+        label: 'Reconnecting',
+        dot: 'bg-amber-500 animate-pulse',
+        className: 'bg-amber-50 text-amber-900 hover:bg-amber-50',
+      }
+    case 'recovering':
+      return {
+        variant: 'secondary',
+        label: 'Recovering',
+        dot: 'bg-amber-500 animate-pulse',
+        className: 'bg-amber-50 text-amber-900 hover:bg-amber-50',
+      }
+    case 'failed':
+      return {
+        variant: 'destructive',
+        label: 'Needs attention',
+        dot: 'bg-destructive-foreground',
+      }
+    default:
+      return {
+        variant: 'outline',
+        label: 'Disconnected',
+        dot: 'bg-muted-foreground/40',
+      }
+  }
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/GatewayStatusBar.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/GatewayStatusBar.tsx
@@ -1,15 +1,23 @@
-import { RefreshCw, Terminal } from 'lucide-react'
-import type { FC } from 'react'
+import { Loader2, RotateCcw, Terminal } from 'lucide-react'
+import type { FC, ReactNode } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { Separator } from '@/components/ui/separator'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 import type { OpenClawStatus } from './useOpenClaw'
 
 interface GatewayStatusBarProps {
   status: OpenClawStatus | null
+  /** Disabled while a gateway lifecycle mutation is mid-flight. */
+  actionInProgress: boolean
   onOpenTerminal: () => void
-  onRefresh: () => void
+  onRestart: () => void
 }
 
 /**
@@ -18,16 +26,17 @@ interface GatewayStatusBarProps {
  * is in the picture; collapses to nothing when the user only has
  * Claude/Codex agents.
  *
- * Only renders the lifecycle pills + Terminal/Refresh affordances —
- * the existing `GatewayStateCards` (start, restart, setup) keep their
- * own slot below the list because they're action-heavy. This bar is
- * for at-a-glance reassurance: "yes, the gateway is running and the
- * control plane is connected."
+ * Carries the lifecycle pills + a Terminal escape hatch + a Restart
+ * button. The agent listing itself auto-polls every 5s, so a manual
+ * refresh isn't needed; restart is a real lifecycle action that the
+ * old AgentsPageHeader exposed and is still useful when the gateway
+ * gets wedged.
  */
 export const GatewayStatusBar: FC<GatewayStatusBarProps> = ({
   status,
+  actionInProgress,
   onOpenTerminal,
-  onRefresh,
+  onRestart,
 }) => {
   if (!status) return null
 
@@ -65,23 +74,46 @@ export const GatewayStatusBar: FC<GatewayStatusBarProps> = ({
           {controlPlanePill.label}
         </Badge>
         <Separator orientation="vertical" className="h-4" />
-        <Button variant="ghost" size="sm" onClick={onOpenTerminal}>
-          <Terminal className="mr-1.5 h-3.5 w-3.5" />
-          Terminal
-        </Button>
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onRefresh}
-          aria-label="Refresh gateway status"
-          className="ml-auto h-8 w-8"
-        >
-          <RefreshCw className="h-4 w-4" />
-        </Button>
+        <WithTooltip label="Open a shell into the OpenClaw gateway container for raw CLI access (config edits, session inspection).">
+          <Button variant="ghost" size="sm" onClick={onOpenTerminal}>
+            <Terminal className="mr-1.5 h-3.5 w-3.5" />
+            Terminal
+          </Button>
+        </WithTooltip>
+        <WithTooltip label="Restart the OpenClaw gateway. Useful when the gateway is stuck or after editing provider config.">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onRestart}
+            disabled={actionInProgress}
+            className="ml-auto"
+          >
+            {actionInProgress ? (
+              <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <RotateCcw className="mr-1.5 h-3.5 w-3.5" />
+            )}
+            Restart Gateway
+          </Button>
+        </WithTooltip>
       </div>
     </div>
   )
 }
+
+const WithTooltip: FC<{ label: string; children: ReactNode }> = ({
+  label,
+  children,
+}) => (
+  <TooltipProvider delayDuration={250}>
+    <Tooltip>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent side="bottom" className="max-w-xs text-xs">
+        {label}
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+)
 
 type PillKind = {
   variant: 'default' | 'secondary' | 'outline' | 'destructive'

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/LivenessDot.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/LivenessDot.tsx
@@ -1,0 +1,83 @@
+import type { FC } from 'react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+export type AgentLiveness = 'working' | 'idle' | 'asleep' | 'error' | 'unknown'
+
+interface LivenessDotProps {
+  status: AgentLiveness
+  /**
+   * Optional human-friendly secondary line, e.g. "Idle for 4 min" or
+   * "Asleep — no activity for 22 min". When absent the tooltip just
+   * reads the status label.
+   */
+  detail?: string
+  className?: string
+}
+
+const VARIANT: Record<
+  AgentLiveness,
+  { dot: string; ring: string; label: string }
+> = {
+  working: {
+    // Animated amber pulse + soft halo so the eye catches an active
+    // agent in a long list without the dot screaming for attention.
+    dot: 'bg-amber-500 animate-pulse',
+    ring: 'ring-2 ring-amber-200',
+    label: 'Working on a turn',
+  },
+  idle: {
+    dot: 'bg-emerald-500',
+    ring: 'ring-2 ring-emerald-100',
+    label: 'Idle',
+  },
+  asleep: {
+    dot: 'bg-muted-foreground/40',
+    ring: 'ring-2 ring-muted',
+    label: 'Asleep',
+  },
+  error: {
+    dot: 'bg-destructive',
+    ring: 'ring-2 ring-destructive/30',
+    label: 'Attention',
+  },
+  unknown: {
+    dot: 'bg-muted-foreground/30',
+    ring: 'ring-2 ring-muted',
+    label: 'Status unknown',
+  },
+}
+
+export const LivenessDot: FC<LivenessDotProps> = ({
+  status,
+  detail,
+  className,
+}) => {
+  const variant = VARIANT[status]
+  return (
+    <TooltipProvider delayDuration={150}>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span
+            role="img"
+            aria-label={detail ?? variant.label}
+            className={cn(
+              'inline-block h-3 w-3 rounded-full',
+              variant.dot,
+              variant.ring,
+              className,
+            )}
+          />
+        </TooltipTrigger>
+        <TooltipContent side="right" className="text-xs">
+          {detail ?? variant.label}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  )
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-display.helpers.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-display.helpers.ts
@@ -1,0 +1,84 @@
+import type { AgentListItem } from './agents-page-types'
+
+/**
+ * Display rules for the redesigned agent rows. Pure helpers — no React,
+ * no API calls — so they're trivial to unit-test and the row card stays
+ * focused on layout.
+ */
+
+const UUID_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+const OC_UUID_PATTERN =
+  /^oc-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+
+/**
+ * The agent rail used to render whatever the gateway returned for `name`.
+ * Post-migration that's frequently the agent's UUID — readable to nobody.
+ * Prefer the explicit `name` when it differs meaningfully from the id;
+ * otherwise fall back to a short prefix users can recognize on second
+ * glance.
+ */
+export function displayName(agent: AgentListItem): string {
+  const name = agent.name?.trim()
+  const id = agent.agentId
+  if (!name || name === id) {
+    if (OC_UUID_PATTERN.test(id)) return id.slice(0, 11) // "oc-XXXXXXXX"
+    if (UUID_PATTERN.test(id)) return id.slice(0, 8)
+    return id
+  }
+  return name
+}
+
+export function canDelete(agent: AgentListItem): boolean {
+  // The gateway's protected `main` agent must not be deletable. The
+  // server enforces this too, but disabling the menu item avoids users
+  // hitting an opaque 400.
+  if (agent.agentId === 'main') return false
+  return agent.canDelete
+}
+
+/**
+ * Rename will be wired to a future `PATCH /agents/:id` endpoint. The
+ * legacy `/claw/agents` create flow named the agent on the gateway via
+ * the `name` field but the field isn't editable post-create today.
+ */
+export function canRename(_agent: AgentListItem): boolean {
+  return false
+}
+
+/**
+ * The detail line carries the agent's workspace path. The `detail`
+ * field on AgentListItem already holds it for OpenClaw entries
+ * (`/home/node/.openclaw/workspace-...`); for harness agents it's the
+ * synthetic `<adapter>:main` marker that's not informative — hide it.
+ */
+export function workspaceLabel(agent: AgentListItem): string | null {
+  if (!agent.detail) return null
+  if (/^(claude|codex|openclaw):main$/.test(agent.detail)) return null
+  return agent.detail
+}
+
+const ONE_MINUTE = 60_000
+const ONE_HOUR = 60 * ONE_MINUTE
+const ONE_DAY = 24 * ONE_HOUR
+
+/**
+ * Lightweight relative-time formatter. We don't want to drag in
+ * `dayjs/relativeTime` just for a few labels.
+ */
+export function formatRelativeTime(epochMs: number | null): string {
+  if (epochMs === null || !Number.isFinite(epochMs)) return 'never'
+  const diff = Math.max(0, Date.now() - epochMs)
+  if (diff < ONE_MINUTE) return 'just now'
+  if (diff < ONE_HOUR) {
+    const m = Math.floor(diff / ONE_MINUTE)
+    return `${m} min ago`
+  }
+  if (diff < ONE_DAY) {
+    const h = Math.floor(diff / ONE_HOUR)
+    return h === 1 ? '1 hr ago' : `${h} hr ago`
+  }
+  const d = Math.floor(diff / ONE_DAY)
+  return d === 1 ? '1 day ago' : `${d} days ago`
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-harness-types.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-harness-types.ts
@@ -33,6 +33,8 @@ export type AgentHarnessStreamEvent =
       code?: string
     }
 
+export type HarnessAgentLiveness = 'working' | 'idle' | 'asleep' | 'error'
+
 export interface HarnessAgent {
   id: string
   name: string
@@ -43,6 +45,17 @@ export interface HarnessAgent {
   sessionKey: string
   createdAt: number
   updatedAt: number
+  /**
+   * Server-derived liveness state. When the listing endpoint hasn't
+   * been enriched yet (older deployments) this is undefined and the UI
+   * falls back to `unknown`.
+   */
+  status?: HarnessAgentLiveness
+  /**
+   * Wall-clock ms of the last persisted turn. `null` for never-used
+   * agents. Drives the recency sort and the "Last used X min ago" copy.
+   */
+  lastUsedAt?: number | null
 }
 
 export interface HarnessAdapterDescriptor {

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/agents-page-utils.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/agents-page-utils.ts
@@ -138,24 +138,20 @@ export function getVisibleOpenClawAgents(
 }
 
 export function getAgentsLoading(input: {
-  statusLoading: boolean
   adaptersLoading: boolean
   harnessAgentsLoading: boolean
-  openClawAgentsEnabled: boolean
   openClawAgentsLoading: boolean
 }): boolean {
   return (
-    input.statusLoading ||
     input.adaptersLoading ||
     input.harnessAgentsLoading ||
-    (input.openClawAgentsEnabled && input.openClawAgentsLoading)
+    input.openClawAgentsLoading
   )
 }
 
 export function getInlineError(input: {
   lifecyclePending: boolean
   pageError: string | null
-  statusError: Error | null
   openClawAgentsError: Error | null
   adaptersError: Error | null
   harnessAgentsError: Error | null
@@ -163,7 +159,6 @@ export function getInlineError(input: {
   if (input.lifecyclePending) return null
   return (
     input.pageError ??
-    input.statusError?.message ??
     input.openClawAgentsError?.message ??
     input.adaptersError?.message ??
     input.harnessAgentsError?.message ??

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/useAgents.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/useAgents.ts
@@ -79,6 +79,12 @@ export function useHarnessAgents(enabled = true) {
       return data.agents ?? []
     },
     enabled: Boolean(baseUrl) && !urlLoading && enabled,
+    // Poll every 5s so the per-agent liveness state (working / idle /
+    // asleep / error) and last-used timestamps stay fresh without a
+    // websocket. `refetchIntervalInBackground: false` lets a hidden
+    // tab go quiet — react-query's default, made explicit.
+    refetchInterval: 5_000,
+    refetchIntervalInBackground: false,
   })
 
   return {

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/useAgents.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/useAgents.ts
@@ -10,6 +10,17 @@ import {
   type HarnessAgentHistoryPage,
   mapHarnessAgentToEntry,
 } from './agent-harness-types'
+import type { OpenClawStatus } from './useOpenClaw'
+
+/**
+ * Combined response shape of `GET /agents`. The page polls this once
+ * and consumes both fields, replacing the dedicated `/claw/status`
+ * poll the previous design carried.
+ */
+interface HarnessAgentsResponse {
+  agents: HarnessAgent[]
+  gateway: OpenClawStatus | null
+}
 
 export type { AgentHarnessStreamEvent }
 
@@ -69,14 +80,17 @@ export function useHarnessAgents(enabled = true) {
     error: urlError,
   } = useAgentServerUrl()
 
-  const query = useQuery<HarnessAgent[], Error>({
+  const query = useQuery<HarnessAgentsResponse, Error>({
     queryKey: [AGENT_QUERY_KEYS.agents, baseUrl],
     queryFn: async () => {
-      const data = await agentsFetch<{ agents: HarnessAgent[] }>(
+      const data = await agentsFetch<HarnessAgentsResponse>(
         baseUrl as string,
         '/',
       )
-      return data.agents ?? []
+      return {
+        agents: data.agents ?? [],
+        gateway: data.gateway ?? null,
+      }
     },
     enabled: Boolean(baseUrl) && !urlLoading && enabled,
     // Poll every 5s so the per-agent liveness state (working / idle /
@@ -88,8 +102,9 @@ export function useHarnessAgents(enabled = true) {
   })
 
   return {
-    agents: (query.data ?? []).map(mapHarnessAgentToEntry),
-    harnessAgents: query.data ?? [],
+    agents: (query.data?.agents ?? []).map(mapHarnessAgentToEntry),
+    harnessAgents: query.data?.agents ?? [],
+    gateway: query.data?.gateway ?? null,
     loading: query.isLoading || urlLoading,
     error: query.error ?? urlError,
     refetch: query.refetch,

--- a/packages/browseros-agent/apps/server/src/api/routes/agents.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/agents.ts
@@ -37,6 +37,7 @@ import type {
   AgentStreamEvent,
 } from '../../lib/agents/types'
 import {
+  type AgentDefinitionWithActivity,
   AgentHarnessService,
   type OpenClawProvisioner,
   OpenClawProvisionerUnavailableError,
@@ -48,6 +49,7 @@ import { resolveBrowserContextPageIds } from '../utils/resolve-browser-context-p
 
 type AgentRouteService = {
   listAgents(): Promise<AgentDefinition[]>
+  listAgentsWithActivity(): Promise<AgentDefinitionWithActivity[]>
   createAgent(input: {
     name: string
     adapter: AgentAdapter
@@ -121,7 +123,9 @@ export function createAgentRoutes(deps: AgentRouteDeps = {}) {
 
   return new Hono<Env>()
     .get('/adapters', (c) => c.json({ adapters: AGENT_ADAPTER_CATALOG }))
-    .get('/', async (c) => c.json({ agents: await service.listAgents() }))
+    .get('/', async (c) =>
+      c.json({ agents: await service.listAgentsWithActivity() }),
+    )
     .post('/', async (c) => {
       const parsed = await parseCreateAgentBody(c)
       if ('error' in parsed) return c.json({ error: parsed.error }, 400)

--- a/packages/browseros-agent/apps/server/src/api/routes/agents.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/agents.ts
@@ -39,6 +39,7 @@ import type {
 import {
   type AgentDefinitionWithActivity,
   AgentHarnessService,
+  type GatewayStatusSnapshot,
   type OpenClawProvisioner,
   OpenClawProvisionerUnavailableError,
   UnknownAgentError,
@@ -50,6 +51,7 @@ import { resolveBrowserContextPageIds } from '../utils/resolve-browser-context-p
 type AgentRouteService = {
   listAgents(): Promise<AgentDefinition[]>
   listAgentsWithActivity(): Promise<AgentDefinitionWithActivity[]>
+  getGatewayStatus(): Promise<GatewayStatusSnapshot | null>
   createAgent(input: {
     name: string
     adapter: AgentAdapter
@@ -123,9 +125,17 @@ export function createAgentRoutes(deps: AgentRouteDeps = {}) {
 
   return new Hono<Env>()
     .get('/adapters', (c) => c.json({ adapters: AGENT_ADAPTER_CATALOG }))
-    .get('/', async (c) =>
-      c.json({ agents: await service.listAgentsWithActivity() }),
-    )
+    .get('/', async (c) => {
+      // Single round-trip the agents page consumes: enriched agents
+      // (status + lastUsedAt) plus the gateway lifecycle snapshot the
+      // GatewayStatusBar / GatewayStateCards / ControlPlaneAlert used
+      // to fetch from `/claw/status`. Lets the page poll one endpoint.
+      const [agents, gateway] = await Promise.all([
+        service.listAgentsWithActivity(),
+        service.getGatewayStatus(),
+      ])
+      return c.json({ agents, gateway })
+    })
     .post('/', async (c) => {
       const parsed = await parseCreateAgentBody(c)
       if ('error' in parsed) return c.json({ error: parsed.error }, 400)

--- a/packages/browseros-agent/apps/server/src/api/server.ts
+++ b/packages/browseros-agent/apps/server/src/api/server.ts
@@ -160,6 +160,7 @@ export async function createHttpServer(config: HttpServerConfig) {
               model: agent.model,
             }))
           },
+          getStatus: () => getOpenClawService().getStatus(),
         },
       }),
     )

--- a/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
@@ -68,6 +68,45 @@ export interface OpenClawProvisioner {
   listAgents(): Promise<
     Array<{ agentId: string; name: string; model?: string }>
   >
+  /**
+   * Optional. When wired, the harness exposes the gateway lifecycle
+   * snapshot through `GET /agents` so the agents page can render
+   * Running / Control plane connected pills without a separate
+   * `/claw/status` poll. Returns the same shape as the legacy
+   * endpoint; `null` when the snapshot can't be fetched (e.g. the
+   * gateway is not configured at all).
+   */
+  getStatus?(): Promise<GatewayStatusSnapshot | null>
+}
+
+/**
+ * Mirrors the wire shape `/claw/status` returns. Carried through the
+ * harness so the agents page has one polling source for everything it
+ * renders. Field optionality matches the legacy response.
+ */
+export interface GatewayStatusSnapshot {
+  status: 'uninitialized' | 'starting' | 'running' | 'stopped' | 'error'
+  podmanAvailable: boolean
+  machineReady: boolean
+  port: number | null
+  agentCount: number
+  error: string | null
+  controlPlaneStatus:
+    | 'disconnected'
+    | 'connecting'
+    | 'connected'
+    | 'reconnecting'
+    | 'recovering'
+    | 'failed'
+  lastGatewayError: string | null
+  lastRecoveryReason:
+    | 'transient_disconnect'
+    | 'signature_expired'
+    | 'pairing_required'
+    | 'token_mismatch'
+    | 'container_not_ready'
+    | 'unknown'
+    | null
 }
 
 export class AgentHarnessService {
@@ -130,6 +169,25 @@ export class AgentHarnessService {
         lastUsedAt,
       }
     })
+  }
+
+  /**
+   * Read the gateway lifecycle snapshot through the wired provisioner.
+   * Returns null if no provisioner is configured or it doesn't expose
+   * `getStatus`; route-layer callers should treat that as "no gateway,
+   * skip rendering OpenClaw-only chrome." Errors get logged + swallowed
+   * so a transient gateway issue doesn't 500 the listing endpoint.
+   */
+  async getGatewayStatus(): Promise<GatewayStatusSnapshot | null> {
+    if (!this.openclawProvisioner?.getStatus) return null
+    try {
+      return await this.openclawProvisioner.getStatus()
+    } catch (err) {
+      logger.warn('Failed to fetch gateway status for /agents listing', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+      return null
+    }
   }
 
   /**

--- a/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
@@ -21,6 +21,25 @@ import type {
 import { logger } from '../../../lib/logger'
 import type { OpenClawGatewayChatClient } from '../openclaw/openclaw-gateway-chat-client'
 
+export type AgentLiveness = 'working' | 'idle' | 'asleep' | 'error'
+
+export interface AgentActivity {
+  status: AgentLiveness
+  /** Wall-clock ms; null when the agent has never been used. */
+  lastUsedAt: number | null
+}
+
+export interface AgentDefinitionWithActivity extends AgentDefinition {
+  status: AgentLiveness
+  lastUsedAt: number | null
+}
+
+/**
+ * `idle` downgrades to `asleep` after this many ms of no activity. Read at
+ * enrichment time; no timer cleanup necessary.
+ */
+const ASLEEP_THRESHOLD_MS = 15 * 60 * 1000
+
 /**
  * Provisions and tears down agent records on the OpenClaw gateway side.
  * OpenClaw agents are dual-tracked: the harness owns the user-facing
@@ -56,6 +75,14 @@ export class AgentHarnessService {
   private readonly runtime: AgentRuntime
   private readonly openclawProvisioner: OpenClawProvisioner | null
   private inFlightReconcile: Promise<void> | null = null
+  // In-memory liveness tracker. Lost on server restart (acceptable —
+  // `lastUsedAt` survives via the acpx session record's `lastUsedAt`,
+  // and an idle/asleep agent post-restart will read fine from the
+  // record's timestamp without ever flipping to `working`).
+  private readonly activity = new Map<
+    string,
+    { status: 'working' | 'error'; lastEventAt: number; lastError?: string }
+  >()
 
   constructor(
     deps: {
@@ -81,6 +108,81 @@ export class AgentHarnessService {
   async listAgents(): Promise<AgentDefinition[]> {
     await this.ensureGatewayReconciled()
     return this.agentStore.list()
+  }
+
+  /**
+   * Same shape as `listAgents()` but every record is enriched with the
+   * current liveness state and `lastUsedAt`. Liveness is read from the
+   * in-memory activity tracker — which only knows about turns that
+   * went through this process — falling back to a timestamp-derived
+   * `idle`/`asleep` from the acpx session record's `lastUsedAt`.
+   */
+  async listAgentsWithActivity(): Promise<AgentDefinitionWithActivity[]> {
+    const agents = await this.listAgents()
+    const lastUsedMap = await this.collectLastUsed(agents)
+    const now = Date.now()
+    return agents.map((agent) => {
+      const live = this.activity.get(agent.id)
+      const lastUsedAt = lastUsedMap.get(agent.id) ?? null
+      return {
+        ...agent,
+        status: deriveStatus(live, lastUsedAt, now),
+        lastUsedAt,
+      }
+    })
+  }
+
+  /**
+   * Read each agent's `lastUsedAt` from the acpx session record (the
+   * runtime exposes it through `getHistory` indirectly, but we don't
+   * need history items here — only the timestamp). Loads in parallel
+   * and tolerates per-agent failures (agents that have never had a
+   * turn won't have a record yet).
+   */
+  private async collectLastUsed(
+    agents: AgentDefinition[],
+  ): Promise<Map<string, number>> {
+    const out = new Map<string, number>()
+    await Promise.all(
+      agents.map(async (agent) => {
+        try {
+          const page = await this.runtime.getHistory({
+            agent,
+            sessionId: 'main',
+          })
+          const last = page.items.at(-1)?.createdAt
+          if (typeof last === 'number' && Number.isFinite(last)) {
+            out.set(agent.id, last)
+          }
+        } catch {
+          // No record yet — treat as never-used.
+        }
+      }),
+    )
+    return out
+  }
+
+  /** Mark `agentId` as actively running a turn. */
+  notifyTurnStarted(agentId: string): void {
+    this.activity.set(agentId, { status: 'working', lastEventAt: Date.now() })
+  }
+
+  /** Clear the working flag. `error` keeps the row badged as needing attention. */
+  notifyTurnEnded(
+    agentId: string,
+    outcome: { ok: boolean; error?: string } = { ok: true },
+  ): void {
+    if (!outcome.ok) {
+      this.activity.set(agentId, {
+        status: 'error',
+        lastEventAt: Date.now(),
+        lastError: outcome.error,
+      })
+      return
+    }
+    // Successful turn — drop the in-memory entry. Liveness will be
+    // derived from the session record's `lastUsedAt` on next read.
+    this.activity.delete(agentId)
   }
 
   private ensureGatewayReconciled(): Promise<void> {
@@ -236,14 +338,27 @@ export class AgentHarnessService {
     signal?: AbortSignal
   }): Promise<ReadableStream<AgentStreamEvent>> {
     const agent = await this.requireAgent(input.agentId)
-    return this.runtime.send({
-      agent,
-      sessionId: 'main',
-      sessionKey: agent.sessionKey,
-      message: input.message,
-      attachments: input.attachments,
-      permissionMode: agent.permissionMode,
-      signal: input.signal,
+    this.notifyTurnStarted(agent.id)
+    let stream: ReadableStream<AgentStreamEvent>
+    try {
+      stream = await this.runtime.send({
+        agent,
+        sessionId: 'main',
+        sessionKey: agent.sessionKey,
+        message: input.message,
+        attachments: input.attachments,
+        permissionMode: agent.permissionMode,
+        signal: input.signal,
+      })
+    } catch (err) {
+      this.notifyTurnEnded(agent.id, {
+        ok: false,
+        error: err instanceof Error ? err.message : String(err),
+      })
+      throw err
+    }
+    return wrapStreamWithLifecycle(stream, {
+      onComplete: (ok, error) => this.notifyTurnEnded(agent.id, { ok, error }),
     })
   }
 
@@ -254,6 +369,77 @@ export class AgentHarnessService {
     }
     return agent
   }
+}
+
+/**
+ * Pure derivation: in-memory activity tracker wins; otherwise we fall
+ * back to a timestamp-only judgment. Never-used agents resolve to
+ * `idle` so the UI doesn't render them as `asleep` (asleep implies
+ * "was active, went quiet").
+ */
+function deriveStatus(
+  live: { status: 'working' | 'error'; lastEventAt: number } | undefined,
+  lastUsedAt: number | null,
+  now: number,
+): AgentLiveness {
+  if (live?.status === 'working') return 'working'
+  if (live?.status === 'error') return 'error'
+  if (lastUsedAt == null) return 'idle'
+  return now - lastUsedAt > ASLEEP_THRESHOLD_MS ? 'asleep' : 'idle'
+}
+
+/**
+ * Tee an `AgentStreamEvent` stream so we can fire `onComplete` exactly
+ * once when it ends — whether by natural close, error event, or
+ * downstream cancellation. The wrapped stream is what the caller
+ * consumes; the lifecycle hook fires as a side-effect.
+ */
+function wrapStreamWithLifecycle(
+  upstream: ReadableStream<AgentStreamEvent>,
+  hooks: { onComplete: (ok: boolean, error?: string) => void },
+): ReadableStream<AgentStreamEvent> {
+  let settled = false
+  const settle = (ok: boolean, error?: string) => {
+    if (settled) return
+    settled = true
+    try {
+      hooks.onComplete(ok, error)
+    } catch (err) {
+      logger.warn('Agent harness lifecycle hook threw', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+  let lastError: string | undefined
+  return new ReadableStream<AgentStreamEvent>({
+    start(controller) {
+      const reader = upstream.getReader()
+      const pump = async () => {
+        try {
+          while (true) {
+            const { done, value } = await reader.read()
+            if (done) break
+            if (value.type === 'error') {
+              lastError = value.message
+              settle(false, lastError)
+            }
+            controller.enqueue(value)
+          }
+          settle(lastError === undefined, lastError)
+          controller.close()
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err)
+          settle(false, msg)
+          controller.error(err)
+        }
+      }
+      void pump()
+    },
+    cancel(reason) {
+      settle(false, typeof reason === 'string' ? reason : undefined)
+      void upstream.cancel(reason).catch(() => {})
+    },
+  })
 }
 
 export class UnknownAgentError extends Error {

--- a/packages/browseros-agent/apps/server/tests/api/routes/agents.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/agents.test.ts
@@ -121,7 +121,7 @@ describe('createAgentRoutes', () => {
     expect(sentInput?.signal).toBe(abortController.signal)
 
     const list = await route.request('/agents')
-    expect(await list.json()).toEqual({ agents: [] })
+    expect(await list.json()).toEqual({ agents: [], gateway: null })
   })
 
   it('rejects invalid sidepanel ACP chat requests', async () => {
@@ -186,6 +186,20 @@ function createFakeService(agents: AgentDefinition[]) {
   return {
     async listAgents() {
       return agents
+    },
+    async listAgentsWithActivity() {
+      // The route returns enriched agents in the listing response.
+      // Tests don't care about activity values; default to `idle`/null.
+      return agents.map((agent) => ({
+        ...agent,
+        status: 'idle' as const,
+        lastUsedAt: null,
+      }))
+    },
+    async getGatewayStatus() {
+      // No openclaw provisioner wired in tests → `null` mirrors what
+      // `AgentHarnessService.getGatewayStatus` does without one.
+      return null
     },
     async createAgent(input: {
       name: string

--- a/packages/browseros-agent/apps/server/tests/api/services/agents/agent-harness-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/agents/agent-harness-service.test.ts
@@ -336,6 +336,108 @@ describe('AgentHarnessService', () => {
     expect(listed).toHaveLength(1)
     expect(listed[0]?.id).toBe('agent-existing')
   })
+
+  it('marks an agent working while a turn streams and idle once it ends', async () => {
+    const agent: AgentDefinition = {
+      id: 'live-1',
+      name: 'live',
+      adapter: 'claude',
+      modelId: 'haiku',
+      reasoningEffort: 'medium',
+      permissionMode: 'approve-all',
+      sessionKey: 'agent:live-1:main',
+      createdAt: 1000,
+      updatedAt: 1000,
+    }
+    // Hold the upstream open until the test releases it so we can
+    // observe the "working" state between dispatch and stream end.
+    let releaseUpstream: () => void = () => {}
+    const upstreamHeld = new Promise<void>((resolve) => {
+      releaseUpstream = resolve
+    })
+    const runtime: AgentRuntime = {
+      async status() {
+        return { state: 'ready' }
+      },
+      async listSessions() {
+        return []
+      },
+      async getHistory() {
+        return { agentId: agent.id, sessionId: 'main', items: [] }
+      },
+      async send() {
+        return new ReadableStream<AgentStreamEvent>({
+          async start(controller) {
+            controller.enqueue({
+              type: 'text_delta',
+              text: 'hi',
+              stream: 'output',
+            })
+            await upstreamHeld
+            controller.enqueue({ type: 'done', stopReason: 'end_turn' })
+            controller.close()
+          },
+        })
+      },
+    }
+    const service = new AgentHarnessService({
+      agentStore: createAgentStore([agent]) as FileAgentStore,
+      runtime,
+    })
+
+    const stream = await service.send({ agentId: agent.id, message: 'hi' })
+    // Turn just kicked off — the activity tracker should report working.
+    let listed = await service.listAgentsWithActivity()
+    expect(listed[0]?.status).toBe('working')
+
+    // Release the upstream so the lifecycle hook fires `notifyTurnEnded`,
+    // then drain the consumer side.
+    releaseUpstream()
+    await collectStream(stream)
+    listed = await service.listAgentsWithActivity()
+    expect(listed[0]?.status).toBe('idle')
+  })
+
+  it('flips to error when a turn emits an error event', async () => {
+    const agent: AgentDefinition = {
+      id: 'err-1',
+      name: 'err',
+      adapter: 'claude',
+      modelId: 'haiku',
+      reasoningEffort: 'medium',
+      permissionMode: 'approve-all',
+      sessionKey: 'agent:err-1:main',
+      createdAt: 1000,
+      updatedAt: 1000,
+    }
+    const runtime: AgentRuntime = {
+      async status() {
+        return { state: 'ready' }
+      },
+      async listSessions() {
+        return []
+      },
+      async getHistory() {
+        return { agentId: agent.id, sessionId: 'main', items: [] }
+      },
+      async send() {
+        return new ReadableStream<AgentStreamEvent>({
+          start(controller) {
+            controller.enqueue({ type: 'error', message: 'boom' })
+            controller.close()
+          },
+        })
+      },
+    }
+    const service = new AgentHarnessService({
+      agentStore: createAgentStore([agent]) as FileAgentStore,
+      runtime,
+    })
+
+    await collectStream(await service.send({ agentId: agent.id, message: 'x' }))
+    const listed = await service.listAgentsWithActivity()
+    expect(listed[0]?.status).toBe('error')
+  })
 })
 
 function stubRuntime(): AgentRuntime {


### PR DESCRIPTION
## Summary

Reshapes \`#/agents\` so it reads as a sibling of \`/scheduled\` and \`/soul\` and works as a real command center for the multi-adapter world (OpenClaw, Claude Code, Codex). Net diff: **+1,225 / -136** across 14 files. Three things land together:

1. **Visual parity with the rest of the app.** Standard \`fade-in slide-in-from-bottom-5 animate-in space-y-6 duration-500\` page shell. New header card mirroring \`SoulHeader\`/\`ScheduledTasksHeader\` (accent bot tile, title, subtitle, "+ New Agent" button). New \`GatewayStatusBar\` consolidates the OpenClaw lifecycle pills + Terminal + Restart Gateway into a single labeled bar — only renders when the gateway is \`running\` and at least one OpenClaw agent is in the merged list. Empty-state card mirroring \`/scheduled\`'s dashed empty.

2. **Adapter-aware row card.** New \`AgentRowCard\` per agent: adapter tile (Claude Code / Codex / OpenClaw icons + label) with a corner liveness dot, name + status badge, adapter/model/reasoning chips, last-used relative time + truncated workspace path, primary "Chat" button, overflow menu (Copy id / Rename* / Reset history* / Delete). Rename and Reset are disabled with "coming soon" tooltips until the corresponding endpoints ship; Delete is hidden for the protected \`main\` agent. Display-name helper falls back gracefully to the truncated id for legacy \`oc-<uuid>\` titles.

3. **Real per-agent liveness.** Server-side \`AgentHarnessService\` keeps an in-memory activity tracker; \`send()\` wraps the runtime stream so the lifecycle hook fires exactly once on natural close, error event, downstream cancel, or thrown setup. New \`listAgentsWithActivity()\` enriches every agent with \`{status, lastUsedAt}\`; \`lastUsedAt\` is read from the acpx session record's last persisted item so it survives server restart even though the activity map doesn't. Status derivation: \`working\`/\`error\` win when present, otherwise timestamp-based — \`idle\` until 15 min of silence, then \`asleep\`. \`useHarnessAgents\` flips on a 5s \`refetchInterval\` (background-quiet) so the dots and last-used copy stay fresh. Sort is \`lastUsedAt\` desc with \`main\` pinned only while never used.

### Things that go away
- The loose top toolbar mixing page-level and OpenClaw-lifecycle controls (replaced by header card + gateway bar).
- The manual refresh icon — redundant once \`useHarnessAgents\` + \`useOpenClawStatus\` poll on the same cadence.
- The duplicate-agent rendering bug where every dual-created OpenClaw agent appeared twice (once from \`/claw/agents\`, once from \`/agents\`); now deduped on id with the harness entry winning.

### Things kept on purpose
- Terminal escape hatch in the gateway bar — power-user shell into the gateway container for raw \`openclaw\` CLI calls (config edits, session JSONL inspection).
- Restart Gateway button — was on the old header, useful when the gateway is wedged or after editing provider config; relocated into the gateway bar with a spinner while a lifecycle mutation is mid-flight.
- The legacy \`/claw/status\` polling — still drives the \`GatewayStateCards\` (Set Up / Start / Restart prompts when the gateway isn't running). Folding this into the new listing endpoint is captured as a follow-up.

## Test plan

- [x] \`bun run --filter @browseros/agent typecheck\` → exit 0
- [x] \`bun run --filter @browseros/server typecheck\` → exit 0
- [x] Server tests: 33 pass / 0 fail in \`tests/lib/agents\` + \`tests/api/services/agents\` (new coverage on the activity tracker: working state visible mid-stream, drops to idle on success, flips to error on error event)
- [x] Live curl on \`GET /agents\` confirms enriched \`{status, lastUsedAt}\` per agent
- [x] Live curl on the chat path confirms the wrapped stream still streams \`text_delta\` + \`done\` cleanly
- [ ] Manual smoke: open \`/agents\`, confirm visual parity with \`/scheduled\`/\`/soul\`
- [ ] Manual smoke: send a message → row's dot pulses amber while streaming, settles to green on done
- [ ] Manual smoke: agent that hasn't been used in >15 min shows the gray "Asleep" badge; chatting with it brings it back to idle and floats it to the top of the list
- [ ] Manual smoke: error path — provider mid-stream failure flips the dot red and shows the "Attention" badge
- [ ] Manual smoke: gateway bar Restart button restarts the gateway, button shows a spinner during the action, lifecycle pills update, regular agents come back online
- [ ] Manual smoke: gateway bar Terminal button still opens the in-extension shell
- [ ] Manual smoke: tooltips render on the Terminal and Restart Gateway buttons
- [ ] Manual smoke: \`main\` is pinned at the top of an empty rail; once it has a turn, sort order is purely by \`lastUsedAt\`
- [ ] Manual smoke: empty state renders when every agent is deleted; "Create your first agent" CTA opens the dialog
- [ ] Manual smoke: claude/codex/openclaw rows all render with distinguishable icons + chips and chat works for each