### PR TITLE
feat(agents): background-resilient chat — turns survive tab disconnect

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useAgentConversation.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useAgentConversation.ts
@@ -1,7 +1,10 @@
 import { useEffect, useRef, useState } from 'react'
 import {
   type AgentHarnessStreamEvent,
+  attachToHarnessTurn,
+  cancelHarnessTurn,
   chatWithHarnessAgent,
+  fetchActiveHarnessTurn,
 } from '@/entrypoints/app/agents/useAgents'
 import type { OpenClawChatHistoryMessage } from '@/entrypoints/app/agents/useOpenClaw'
 import type {
@@ -48,6 +51,11 @@ export function useAgentConversation(
   const streamAbortRef = useRef<AbortController | null>(null)
   const onCompleteRef = useRef(options.onComplete)
   const onSessionKeyChangeRef = useRef(options.onSessionKeyChange)
+  // Per-turn resume bookkeeping. `turnId` is captured from the response
+  // header; `lastSeq` advances with every SSE event so a reconnect can
+  // resume via Last-Event-ID.
+  const turnIdRef = useRef<string | null>(null)
+  const lastSeqRef = useRef<number | null>(null)
 
   useEffect(() => {
     sessionKeyRef.current = options.sessionKey ?? ''
@@ -70,6 +78,12 @@ export function useAgentConversation(
       streamAbortRef.current?.abort()
     }
   }, [])
+
+  // Indirection for the resume effect below: lets it call the latest
+  // event handler without re-subscribing on every render.
+  const processEventRef = useRef<(event: AgentHarnessStreamEvent) => void>(
+    () => {},
+  )
 
   const updateCurrentTurnParts = (
     updater: (parts: AssistantPart[]) => AssistantPart[],
@@ -195,6 +209,79 @@ export function useAgentConversation(
         break
     }
   }
+  processEventRef.current = processAgentHarnessStreamEvent
+
+  // On mount (and whenever the agent changes), check whether the
+  // server has an in-flight turn for this agent and reattach to it.
+  // This is what makes the chat resilient across tab close/reopen,
+  // refresh, and navigation: the runtime call kept running on the
+  // server while we were away. Effect only depends on `agentId` —
+  // the event handler is read off a ref so this doesn't re-subscribe
+  // every render.
+  useEffect(() => {
+    let cancelled = false
+    const abortController = new AbortController()
+
+    const attemptResume = async () => {
+      try {
+        const active = await fetchActiveHarnessTurn(agentId)
+        if (cancelled || !active || active.status !== 'running') return
+        if (streamAbortRef.current) return // a fresh send already in flight
+
+        // Stage a placeholder turn so the streamed events have a row
+        // to render into. We don't have the user message text on
+        // resume; the assistant turn is what we're catching up on.
+        setTurns((prev) => [
+          ...prev,
+          {
+            id: crypto.randomUUID(),
+            userText: '',
+            parts: [],
+            done: false,
+            timestamp: active.startedAt,
+          },
+        ])
+        textAccRef.current = ''
+        thinkAccRef.current = ''
+        turnIdRef.current = active.turnId
+        lastSeqRef.current = null
+        streamAbortRef.current = abortController
+        setStreaming(true)
+
+        const response = await attachToHarnessTurn(agentId, {
+          turnId: active.turnId,
+          signal: abortController.signal,
+        })
+        if (!response.ok) return
+        await consumeSSEStream<AgentHarnessStreamEvent>(
+          response,
+          (event, meta) => {
+            if (typeof meta.seq === 'number') lastSeqRef.current = meta.seq
+            processEventRef.current(event)
+          },
+          abortController.signal,
+        )
+      } catch {
+        // Resume is best-effort; transient errors fall back to the
+        // user starting a new turn manually.
+      } finally {
+        if (!cancelled) {
+          if (streamAbortRef.current === abortController) {
+            streamAbortRef.current = null
+          }
+          turnIdRef.current = null
+          lastSeqRef.current = null
+          setStreaming(false)
+        }
+      }
+    }
+
+    void attemptResume()
+    return () => {
+      cancelled = true
+      abortController.abort()
+    }
+  }, [agentId])
 
   const send = async (input: string | SendInput) => {
     const normalized: SendInput =
@@ -224,18 +311,36 @@ export function useAgentConversation(
     streamAbortRef.current = abortController
 
     try {
-      const response = await chatWithHarnessAgent(
+      let response = await chatWithHarnessAgent(
         agentId,
         trimmed,
         abortController.signal,
         attachments,
       )
+      // 409 means the server already has an active turn for this
+      // agent (e.g. a previous tab kicked one off and we're a fresh
+      // mount that missed the resume window). Attach to it instead of
+      // double-sending.
+      if (response.status === 409) {
+        const body = (await response.json()) as { turnId?: string }
+        if (body.turnId) {
+          response = await attachToHarnessTurn(agentId, {
+            turnId: body.turnId,
+            signal: abortController.signal,
+          })
+        }
+      }
       const responseSessionKey =
         response.headers.get('X-Session-Key') ??
         response.headers.get('X-Session-Id')
       if (responseSessionKey) {
         sessionKeyRef.current = responseSessionKey
         onSessionKeyChangeRef.current?.(responseSessionKey)
+      }
+      const responseTurnId = response.headers.get('X-Turn-Id')
+      if (responseTurnId) {
+        turnIdRef.current = responseTurnId
+        lastSeqRef.current = null
       }
       if (!response.ok) {
         const err = await response.text()
@@ -247,7 +352,10 @@ export function useAgentConversation(
       }
       await consumeSSEStream<AgentHarnessStreamEvent>(
         response,
-        processAgentHarnessStreamEvent,
+        (event, meta) => {
+          if (typeof meta.seq === 'number') lastSeqRef.current = meta.seq
+          processAgentHarnessStreamEvent(event)
+        },
         abortController.signal,
       )
     } catch (err) {
@@ -261,14 +369,35 @@ export function useAgentConversation(
       if (streamAbortRef.current === abortController) {
         streamAbortRef.current = null
       }
+      turnIdRef.current = null
+      lastSeqRef.current = null
       onCompleteRef.current?.()
       setStreaming(false)
     }
   }
 
-  const resetConversation = () => {
+  /**
+   * Stop button. The fetch abort only detaches *this* SSE subscriber
+   * now — the underlying turn would otherwise keep running on the
+   * server. So we explicitly cancel via the new endpoint, then unwind
+   * the local stream.
+   */
+  const stop = async () => {
+    const turnId = turnIdRef.current ?? undefined
     streamAbortRef.current?.abort()
     streamAbortRef.current = null
+    try {
+      await cancelHarnessTurn(agentId, {
+        turnId,
+        reason: 'user pressed stop',
+      })
+    } catch {
+      // Best-effort — UI already aborted.
+    }
+  }
+
+  const resetConversation = () => {
+    void stop()
     setTurns([])
     setStreaming(false)
   }
@@ -278,6 +407,7 @@ export function useAgentConversation(
     streaming,
     sessionKey: sessionKeyRef.current,
     send,
+    stop,
     resetConversation,
   }
 }

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/useAgents.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/useAgents.ts
@@ -176,6 +176,81 @@ export async function chatWithHarnessAgent(
   })
 }
 
+/**
+ * Subscribe to an existing turn (the server's `ActiveTurnRegistry`
+ * decoupled the turn lifecycle from POST /chat). `lastSeq` lets the
+ * client resume after a disconnect — the server replays buffered
+ * frames with seq > lastSeq, then tails new ones.
+ */
+export async function attachToHarnessTurn(
+  agentId: string,
+  options: { turnId?: string; lastSeq?: number; signal?: AbortSignal } = {},
+): Promise<Response> {
+  const baseUrl = await getAgentServerUrl()
+  const url = new URL(
+    `${baseUrl}/agents/${encodeURIComponent(agentId)}/chat/stream`,
+  )
+  if (options.turnId) url.searchParams.set('turnId', options.turnId)
+  const headers: Record<string, string> = {}
+  if (typeof options.lastSeq === 'number') {
+    headers['Last-Event-ID'] = String(options.lastSeq)
+  }
+  return fetch(url.toString(), { signal: options.signal, headers })
+}
+
+export interface HarnessActiveTurnInfo {
+  turnId: string
+  agentId: string
+  sessionId: 'main'
+  status: 'running' | 'done' | 'error' | 'cancelled'
+  lastSeq: number
+  startedAt: number
+  endedAt?: number
+}
+
+/**
+ * Discover an in-flight turn for an agent. Used on chat mount so the
+ * UI reattaches instead of starting a new turn after a tab/refresh.
+ */
+export async function fetchActiveHarnessTurn(
+  agentId: string,
+): Promise<HarnessActiveTurnInfo | null> {
+  const baseUrl = await getAgentServerUrl()
+  const response = await fetch(
+    `${baseUrl}/agents/${encodeURIComponent(agentId)}/chat/active`,
+  )
+  if (!response.ok) return null
+  const body = (await response.json()) as {
+    active: HarnessActiveTurnInfo | null
+  }
+  return body.active
+}
+
+/**
+ * Stop button. Hits the explicit cancel endpoint instead of just
+ * aborting the fetch (which now only detaches *this* subscriber from
+ * the buffer; the underlying turn would otherwise keep running).
+ */
+export async function cancelHarnessTurn(
+  agentId: string,
+  options: { turnId?: string; reason?: string } = {},
+): Promise<{ cancelled: boolean }> {
+  const baseUrl = await getAgentServerUrl()
+  const response = await fetch(
+    `${baseUrl}/agents/${encodeURIComponent(agentId)}/chat/cancel`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...(options.turnId ? { turnId: options.turnId } : {}),
+        ...(options.reason ? { reason: options.reason } : {}),
+      }),
+    },
+  )
+  if (!response.ok) return { cancelled: false }
+  return (await response.json()) as { cancelled: boolean }
+}
+
 export async function fetchHarnessAgentHistory(
   agentId: string,
 ): Promise<HarnessAgentHistoryPage> {

--- a/packages/browseros-agent/apps/agent/lib/sse.ts
+++ b/packages/browseros-agent/apps/agent/lib/sse.ts
@@ -2,29 +2,75 @@ function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === 'AbortError'
 }
 
+export interface ParsedSSEEvent<T> {
+  data: T
+  /** Numeric `id:` line on the same SSE event, if any. */
+  seq?: number
+}
+
 export function parseSSELines<T>(buffer: string): {
-  events: T[]
+  events: ParsedSSEEvent<T>[]
   remainder: string
 } {
+  // SSE events are separated by blank lines. Buffer lines until we hit
+  // a blank, then assemble each event. Lines we recognise: `id: <n>`
+  // and `data: <payload>`. Everything else is ignored.
+  const events: ParsedSSEEvent<T>[] = []
   const lines = buffer.split('\n')
-  const remainder = lines.pop() ?? ''
-  const events: T[] = []
-
-  for (const line of lines) {
-    if (!line.startsWith('data: ')) continue
-    const payload = line.slice(6)
-    if (payload === '[DONE]') continue
-    try {
-      events.push(JSON.parse(payload) as T)
-    } catch {}
+  // Find the last blank-line boundary; everything after it is the
+  // remainder (next event partially received).
+  let lastBoundary = -1
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (lines[i] === '') {
+      lastBoundary = i
+      break
+    }
   }
+  const completeLines = lastBoundary >= 0 ? lines.slice(0, lastBoundary) : []
+  const remainder =
+    lastBoundary >= 0 ? lines.slice(lastBoundary + 1).join('\n') : buffer
+
+  let currentSeq: number | undefined
+  let currentData: string | null = null
+  const flush = () => {
+    if (currentData != null && currentData !== '[DONE]') {
+      try {
+        events.push({
+          data: JSON.parse(currentData) as T,
+          seq: currentSeq,
+        })
+      } catch {
+        // ignore
+      }
+    }
+    currentSeq = undefined
+    currentData = null
+  }
+
+  for (const line of completeLines) {
+    if (line === '') {
+      flush()
+      continue
+    }
+    if (line.startsWith('id: ')) {
+      const n = Number.parseInt(line.slice(4).trim(), 10)
+      if (Number.isFinite(n)) currentSeq = n
+      continue
+    }
+    if (line.startsWith('data: ')) {
+      currentData = line.slice(6)
+    }
+  }
+  // Catch a complete trailing event with no terminating blank line —
+  // shouldn't happen in well-formed SSE, but be tolerant.
+  flush()
 
   return { events, remainder }
 }
 
 export async function consumeSSEStream<T>(
   response: Response,
-  onEvent: (event: T) => void,
+  onEvent: (event: T, meta: { seq?: number }) => void,
   signal?: AbortSignal,
 ): Promise<void> {
   const reader = response.body?.getReader()
@@ -49,7 +95,7 @@ export async function consumeSSEStream<T>(
       buffer = remainder
 
       for (const event of events) {
-        onEvent(event)
+        onEvent(event.data, { seq: event.seq })
       }
     }
   } catch (error) {
@@ -64,7 +110,7 @@ export async function consumeSSEStream<T>(
     if (buffer) {
       const { events } = parseSSELines<T>(buffer)
       for (const event of events) {
-        onEvent(event)
+        onEvent(event.data, { seq: event.seq })
       }
     }
   }

--- a/packages/browseros-agent/apps/server/src/api/routes/agents.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/agents.ts
@@ -18,6 +18,10 @@ import {
   AcpxRuntime,
   type OpenclawGatewayAccessor,
 } from '../../lib/agents/acpx-runtime'
+import type {
+  ActiveTurnInfo,
+  TurnFrame,
+} from '../../lib/agents/active-turn-registry'
 import {
   AGENT_ADAPTER_CATALOG,
   getAgentAdapterDescriptor,
@@ -42,6 +46,7 @@ import {
   type GatewayStatusSnapshot,
   type OpenClawProvisioner,
   OpenClawProvisionerUnavailableError,
+  TurnAlreadyActiveError,
   UnknownAgentError,
 } from '../services/agents/agent-harness-service'
 import type { OpenClawGatewayChatClient } from '../services/openclaw/openclaw-gateway-chat-client'
@@ -66,6 +71,26 @@ type AgentRouteService = {
   getAgent(agentId: string): Promise<AgentDefinition | null>
   deleteAgent(agentId: string): Promise<boolean>
   getHistory(agentId: string): Promise<AgentHistoryPage>
+  startTurn(input: {
+    agentId: string
+    message: string
+    attachments?: ReadonlyArray<{ mediaType: string; data: string }>
+  }): Promise<{ turnId: string; frames: ReadableStream<TurnFrame> }>
+  attachTurn(input: {
+    turnId: string
+    lastSeq?: number
+  }): ReadableStream<TurnFrame> | null
+  getActiveTurn(agentId: string, sessionId?: 'main'): ActiveTurnInfo | null
+  cancelTurn(input: {
+    agentId: string
+    turnId?: string
+    reason?: string
+  }): boolean
+  /**
+   * Legacy wrapper used by the sidepanel ACP route and any external
+   * callers that want a flat AgentStreamEvent stream. Internally goes
+   * through the registry.
+   */
   send(input: {
     agentId: string
     message: string
@@ -217,43 +242,127 @@ export function createAgentRoutes(deps: AgentRouteDeps = {}) {
       const parsed = await parseChatBody(c)
       if ('error' in parsed) return c.json({ error: parsed.error }, 400)
 
-      let eventStream: ReadableStream<AgentStreamEvent>
+      let started: { turnId: string; frames: ReadableStream<TurnFrame> }
       try {
-        eventStream = await service.send({
+        started = await service.startTurn({
           agentId,
           message: parsed.message,
           attachments: parsed.attachments,
-          signal: c.req.raw.signal,
         })
       } catch (err) {
+        if (err instanceof TurnAlreadyActiveError) {
+          // Caller can attach via GET /chat/stream?turnId=… instead.
+          return c.json(
+            {
+              error: 'Turn already active',
+              turnId: err.turnId,
+              attachUrl: `/agents/${agentId}/chat/stream?turnId=${err.turnId}`,
+            },
+            409,
+          )
+        }
         return handleAgentRouteError(c, err)
       }
 
-      c.header('Content-Type', 'text/event-stream')
-      c.header('Cache-Control', 'no-cache')
-      c.header('X-Session-Id', 'main')
-
-      return stream(c, async (s) => {
-        const reader = eventStream.getReader()
-        const encoder = new TextEncoder()
-        let completed = false
-        try {
-          while (true) {
-            const { done, value } = await reader.read()
-            if (done) break
-            await s.write(encoder.encode(`data: ${JSON.stringify(value)}\n\n`))
-          }
-          await s.write(encoder.encode('data: [DONE]\n\n'))
-          completed = true
-        } finally {
-          if (completed) {
-            reader.releaseLock()
-          } else {
-            await reader.cancel('BrowserOS HTTP stream ended').catch(() => {})
-          }
-        }
+      return streamTurnFrames(c, started.frames, {
+        turnId: started.turnId,
       })
     })
+    .get('/:agentId/chat/active', (c) => {
+      const agentId = c.req.param('agentId')
+      const info = service.getActiveTurn(agentId, 'main')
+      return c.json({ active: info })
+    })
+    .get('/:agentId/chat/stream', (c) => {
+      const agentId = c.req.param('agentId')
+      const url = new URL(c.req.url)
+      const queryTurnId = url.searchParams.get('turnId')?.trim() || undefined
+      const turnId =
+        queryTurnId ?? service.getActiveTurn(agentId, 'main')?.turnId
+      if (!turnId) {
+        return c.json({ error: 'No active turn for this agent' }, 404)
+      }
+      const lastEventId =
+        c.req.header('Last-Event-ID') ??
+        url.searchParams.get('lastSeq') ??
+        undefined
+      const lastSeq = parseLastSeq(lastEventId)
+      const frames = service.attachTurn({ turnId, lastSeq })
+      if (!frames) {
+        return c.json({ error: 'Unknown turn' }, 404)
+      }
+      return streamTurnFrames(c, frames, { turnId })
+    })
+    .post('/:agentId/chat/cancel', async (c) => {
+      const agentId = c.req.param('agentId')
+      const body = await readJsonBody(c)
+      const turnId =
+        'value' in body && typeof body.value.turnId === 'string'
+          ? body.value.turnId.trim() || undefined
+          : undefined
+      const reason =
+        'value' in body && typeof body.value.reason === 'string'
+          ? body.value.reason
+          : undefined
+      const cancelled = service.cancelTurn({ agentId, turnId, reason })
+      return c.json({ cancelled })
+    })
+}
+
+/**
+ * Pipe a TurnFrame stream as Server-Sent Events. Each frame becomes:
+ *
+ *   id: <seq>
+ *   data: <event JSON>
+ *
+ * followed by a final `data: [DONE]` after the upstream closes.
+ * Cancelling the response (caller disconnect) detaches *this*
+ * subscriber; the underlying turn keeps running in the background.
+ */
+function streamTurnFrames(
+  c: Context<Env>,
+  frames: ReadableStream<TurnFrame>,
+  options: { turnId: string },
+) {
+  c.header('Content-Type', 'text/event-stream')
+  c.header('Cache-Control', 'no-cache')
+  c.header('X-Session-Id', 'main')
+  c.header('X-Turn-Id', options.turnId)
+
+  return stream(c, async (s) => {
+    const reader = frames.getReader()
+    const encoder = new TextEncoder()
+    let completed = false
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+        await s.write(
+          encoder.encode(
+            `id: ${value.seq}\ndata: ${JSON.stringify(value.event)}\n\n`,
+          ),
+        )
+      }
+      await s.write(encoder.encode('data: [DONE]\n\n'))
+      completed = true
+    } finally {
+      if (completed) {
+        reader.releaseLock()
+      } else {
+        // Caller went away mid-stream. Cancel only this subscription —
+        // the registry's underlying turn keeps running.
+        await reader.cancel('client disconnected').catch(() => {})
+      }
+    }
+  })
+}
+
+function parseLastSeq(value: string | undefined): number | undefined {
+  if (value == null) return undefined
+  const trimmed = value.trim()
+  if (trimmed === '') return undefined
+  const n = Number.parseInt(trimmed, 10)
+  return Number.isFinite(n) ? n : undefined
 }
 
 async function parseCreateAgentBody(c: Context<Env>): Promise<

--- a/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
@@ -8,6 +8,11 @@ import {
   AcpxRuntime,
   type OpenclawGatewayAccessor,
 } from '../../../lib/agents/acpx-runtime'
+import {
+  type ActiveTurnInfo,
+  type TurnFrame,
+  TurnRegistry,
+} from '../../../lib/agents/active-turn-registry'
 import type { AgentDefinition } from '../../../lib/agents/agent-types'
 import {
   type CreateAgentInput,
@@ -113,6 +118,7 @@ export class AgentHarnessService {
   private readonly agentStore: FileAgentStore
   private readonly runtime: AgentRuntime
   private readonly openclawProvisioner: OpenClawProvisioner | null
+  private readonly turnRegistry: TurnRegistry
   private inFlightReconcile: Promise<void> | null = null
   // In-memory liveness tracker. Lost on server restart (acceptable —
   // `lastUsedAt` survives via the acpx session record's `lastUsedAt`,
@@ -131,6 +137,7 @@ export class AgentHarnessService {
       openclawGateway?: OpenclawGatewayAccessor
       openclawGatewayChat?: OpenClawGatewayChatClient
       openclawProvisioner?: OpenClawProvisioner
+      turnRegistry?: TurnRegistry
     } = {},
   ) {
     this.agentStore = deps.agentStore ?? new FileAgentStore()
@@ -142,6 +149,7 @@ export class AgentHarnessService {
         openclawGatewayChat: deps.openclawGatewayChat,
       })
     this.openclawProvisioner = deps.openclawProvisioner ?? null
+    this.turnRegistry = deps.turnRegistry ?? new TurnRegistry()
   }
 
   async listAgents(): Promise<AgentDefinition[]> {
@@ -389,35 +397,185 @@ export class AgentHarnessService {
     return this.runtime.getHistory({ agent, sessionId: 'main' })
   }
 
+  /**
+   * Kick off a new agent turn that survives the caller's HTTP lifetime.
+   * Events are pushed into a per-turn buffer; the returned `frames`
+   * stream is a *subscription* (replays from seq 0). Closing the stream
+   * just unsubscribes; the turn keeps running until terminal or
+   * cancelled. Throws `TurnAlreadyActiveError` if the agent is already
+   * mid-turn — the route layer maps that to 409.
+   */
+  async startTurn(input: {
+    agentId: string
+    message: string
+    attachments?: ReadonlyArray<{ mediaType: string; data: string }>
+  }): Promise<{ turnId: string; frames: ReadableStream<TurnFrame> }> {
+    const agent = await this.requireAgent(input.agentId)
+
+    const existing = this.turnRegistry.getActiveFor(agent.id, 'main')
+    if (existing) {
+      throw new TurnAlreadyActiveError(agent.id, existing.turnId)
+    }
+
+    const turn = this.turnRegistry.register(agent.id, 'main')
+    this.notifyTurnStarted(agent.id)
+
+    // Kick off the runtime call in the background. The per-turn
+    // AbortController — NOT the HTTP request signal — is what cancels
+    // the runtime call. This is the core decoupling that lets turns
+    // outlive their initiating HTTP request.
+    void this.runDetachedTurn(turn.turnId, agent, input)
+
+    const frames = this.turnRegistry.subscribe(turn.turnId, { fromSeq: -1 })
+    if (!frames) {
+      // Should be impossible — register just put it in the registry —
+      // but keep the type narrow.
+      throw new Error('Turn registration race')
+    }
+    return { turnId: turn.turnId, frames }
+  }
+
+  /**
+   * Attach to an existing turn. Resumes by replaying buffered frames
+   * with seq > `lastSeq`, then tails new ones. Returns null if the
+   * turn is unknown (e.g. never existed, or its retain window expired).
+   */
+  attachTurn(input: {
+    turnId: string
+    lastSeq?: number
+  }): ReadableStream<TurnFrame> | null {
+    return this.turnRegistry.subscribe(input.turnId, {
+      fromSeq: input.lastSeq ?? -1,
+    })
+  }
+
+  /**
+   * Active turn for the (agentId, sessionId) pair, if any. Used by the
+   * UI on mount to discover an in-flight turn it should attach to
+   * instead of starting a new one.
+   */
+  getActiveTurn(
+    agentId: string,
+    sessionId: 'main' = 'main',
+  ): ActiveTurnInfo | null {
+    const turn = this.turnRegistry.getActiveFor(agentId, sessionId)
+    return turn ? this.turnRegistry.describe(turn.turnId) : null
+  }
+
+  /**
+   * Cancel an active turn. Idempotent — returns true on the first
+   * successful cancel, false if the turn doesn't exist or already
+   * finished.
+   */
+  cancelTurn(input: {
+    agentId: string
+    turnId?: string
+    reason?: string
+  }): boolean {
+    const turnId =
+      input.turnId ??
+      this.turnRegistry.getActiveFor(input.agentId, 'main')?.turnId
+    if (!turnId) return false
+    return this.turnRegistry.cancel(turnId, input.reason)
+  }
+
+  /**
+   * Back-compat wrapper for the old `send` signature. Returns a stream
+   * of `AgentStreamEvent` (not `TurnFrame`), so legacy callers/tests
+   * keep working. Internally goes through the registry so liveness and
+   * resilience semantics still apply. Drops `signal` — turns now own
+   * their own AbortController.
+   */
   async send(input: {
     agentId: string
     message: string
     attachments?: ReadonlyArray<{ mediaType: string; data: string }>
     signal?: AbortSignal
   }): Promise<ReadableStream<AgentStreamEvent>> {
-    const agent = await this.requireAgent(input.agentId)
-    this.notifyTurnStarted(agent.id)
-    let stream: ReadableStream<AgentStreamEvent>
+    const { frames } = await this.startTurn(input)
+    return frames.pipeThrough(
+      new TransformStream<TurnFrame, AgentStreamEvent>({
+        transform(frame, controller) {
+          controller.enqueue(frame.event)
+        },
+      }),
+    )
+  }
+
+  /**
+   * Background pump: drives the runtime call, fans events into the
+   * registry, and retires the turn on terminal/error/cancel. Never
+   * throws to its caller — all failures land as `error` frames.
+   */
+  private async runDetachedTurn(
+    turnId: string,
+    agent: AgentDefinition,
+    input: {
+      message: string
+      attachments?: ReadonlyArray<{ mediaType: string; data: string }>
+    },
+  ): Promise<void> {
+    const turn = this.turnRegistry.get(turnId)
+    if (!turn) return
+    let lastErrorMessage: string | undefined
     try {
-      stream = await this.runtime.send({
+      const upstream = await this.runtime.send({
         agent,
         sessionId: 'main',
         sessionKey: agent.sessionKey,
         message: input.message,
         attachments: input.attachments,
         permissionMode: agent.permissionMode,
-        signal: input.signal,
+        signal: turn.abortController.signal,
       })
+      const reader = upstream.getReader()
+      try {
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+          if (value.type === 'error') lastErrorMessage = value.message
+          this.turnRegistry.pushEvent(turnId, value)
+        }
+      } finally {
+        try {
+          reader.releaseLock()
+        } catch {
+          // ignore
+        }
+      }
+      // Synthesize a terminal `done` if the upstream finished without
+      // emitting one (defensive — runtime is supposed to, but our
+      // resilience contract requires every subscriber to see a
+      // terminal frame).
+      const refreshed = this.turnRegistry.get(turnId)
+      if (refreshed?.status === 'running') {
+        if (lastErrorMessage !== undefined) {
+          this.turnRegistry.pushEvent(turnId, {
+            type: 'error',
+            message: lastErrorMessage,
+          })
+        } else {
+          this.turnRegistry.pushEvent(turnId, {
+            type: 'done',
+            stopReason: 'end_turn',
+          })
+        }
+      }
     } catch (err) {
+      lastErrorMessage = err instanceof Error ? err.message : String(err)
+      const refreshed = this.turnRegistry.get(turnId)
+      if (refreshed?.status === 'running') {
+        this.turnRegistry.pushEvent(turnId, {
+          type: 'error',
+          message: lastErrorMessage,
+        })
+      }
+    } finally {
       this.notifyTurnEnded(agent.id, {
-        ok: false,
-        error: err instanceof Error ? err.message : String(err),
+        ok: lastErrorMessage === undefined,
+        error: lastErrorMessage,
       })
-      throw err
     }
-    return wrapStreamWithLifecycle(stream, {
-      onComplete: (ok, error) => this.notifyTurnEnded(agent.id, { ok, error }),
-    })
   }
 
   private async requireAgent(agentId: string): Promise<AgentDefinition> {
@@ -446,60 +604,6 @@ function deriveStatus(
   return now - lastUsedAt > ASLEEP_THRESHOLD_MS ? 'asleep' : 'idle'
 }
 
-/**
- * Tee an `AgentStreamEvent` stream so we can fire `onComplete` exactly
- * once when it ends — whether by natural close, error event, or
- * downstream cancellation. The wrapped stream is what the caller
- * consumes; the lifecycle hook fires as a side-effect.
- */
-function wrapStreamWithLifecycle(
-  upstream: ReadableStream<AgentStreamEvent>,
-  hooks: { onComplete: (ok: boolean, error?: string) => void },
-): ReadableStream<AgentStreamEvent> {
-  let settled = false
-  const settle = (ok: boolean, error?: string) => {
-    if (settled) return
-    settled = true
-    try {
-      hooks.onComplete(ok, error)
-    } catch (err) {
-      logger.warn('Agent harness lifecycle hook threw', {
-        error: err instanceof Error ? err.message : String(err),
-      })
-    }
-  }
-  let lastError: string | undefined
-  return new ReadableStream<AgentStreamEvent>({
-    start(controller) {
-      const reader = upstream.getReader()
-      const pump = async () => {
-        try {
-          while (true) {
-            const { done, value } = await reader.read()
-            if (done) break
-            if (value.type === 'error') {
-              lastError = value.message
-              settle(false, lastError)
-            }
-            controller.enqueue(value)
-          }
-          settle(lastError === undefined, lastError)
-          controller.close()
-        } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err)
-          settle(false, msg)
-          controller.error(err)
-        }
-      }
-      void pump()
-    },
-    cancel(reason) {
-      settle(false, typeof reason === 'string' ? reason : undefined)
-      void upstream.cancel(reason).catch(() => {})
-    },
-  })
-}
-
 export class UnknownAgentError extends Error {
   constructor(readonly agentId: string) {
     super(`Unknown agent: ${agentId}`)
@@ -517,5 +621,20 @@ export class OpenClawProvisionerUnavailableError extends Error {
   constructor() {
     super('OpenClaw gateway provisioner is not wired into AgentHarnessService')
     this.name = 'OpenClawProvisionerUnavailableError'
+  }
+}
+
+/**
+ * Thrown when `startTurn` is called for an agent that already has an
+ * in-flight turn. The route layer maps this to 409 + the existing
+ * `turnId` so the client can attach instead.
+ */
+export class TurnAlreadyActiveError extends Error {
+  constructor(
+    readonly agentId: string,
+    readonly turnId: string,
+  ) {
+    super(`Agent ${agentId} already has an active turn (${turnId})`)
+    this.name = 'TurnAlreadyActiveError'
   }
 }

--- a/packages/browseros-agent/apps/server/src/lib/agents/active-turn-registry.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/active-turn-registry.ts
@@ -1,0 +1,411 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { randomUUID } from 'node:crypto'
+import { logger } from '../logger'
+import type { AgentStreamEvent } from './types'
+
+export type TurnStatus = 'running' | 'done' | 'error' | 'cancelled'
+
+export interface TurnFrame {
+  seq: number
+  event: AgentStreamEvent
+  createdAt: number
+}
+
+export interface ActiveTurnInfo {
+  turnId: string
+  agentId: string
+  sessionId: 'main'
+  status: TurnStatus
+  lastSeq: number
+  startedAt: number
+  endedAt?: number
+}
+
+interface Subscriber {
+  push(frame: TurnFrame): void
+  end(): void
+}
+
+interface ActiveTurn {
+  turnId: string
+  agentId: string
+  sessionId: 'main'
+  status: TurnStatus
+  buffer: RingBuffer
+  subscribers: Set<Subscriber>
+  /** Per-turn AbortController. Aborting cancels the runtime call. */
+  abortController: AbortController
+  startedAt: number
+  endedAt?: number
+  retainUntil?: number
+}
+
+const DEFAULT_BUFFER_CAPACITY = 5000
+const DEFAULT_RETAIN_AFTER_DONE_MS = 5 * 60 * 1000
+const DEFAULT_SWEEP_INTERVAL_MS = 60 * 1000
+
+/**
+ * Append-only ring buffer keyed by monotonic `seq`. When capacity is
+ * exceeded the oldest frame is dropped (drop-oldest policy) and the
+ * `truncated` flag is set so subscribers resuming from a now-evicted seq
+ * know to refetch history. The terminal frame (`done`/`error`) is held
+ * separately so it's never evicted by overflow.
+ */
+export class RingBuffer {
+  private readonly frames: TurnFrame[] = []
+  private readonly capacity: number
+  private nextSeq = 0
+  private terminal: TurnFrame | null = null
+  truncated = false
+
+  constructor(capacity: number = DEFAULT_BUFFER_CAPACITY) {
+    this.capacity = capacity
+  }
+
+  push(event: AgentStreamEvent): TurnFrame {
+    const frame: TurnFrame = {
+      seq: this.nextSeq++,
+      event,
+      createdAt: Date.now(),
+    }
+    if (event.type === 'done' || event.type === 'error') {
+      this.terminal = frame
+    }
+    this.frames.push(frame)
+    if (this.frames.length > this.capacity) {
+      this.frames.shift()
+      this.truncated = true
+    }
+    return frame
+  }
+
+  /** Frames with seq > fromSeq, plus the terminal frame if not already in the slice. */
+  slice(fromSeq: number): TurnFrame[] {
+    const live = this.frames.filter((f) => f.seq > fromSeq)
+    if (this.terminal && !live.some((f) => f.seq === this.terminal!.seq)) {
+      // Terminal might have been evicted by overflow; re-attach it so
+      // subscribers always see a terminal if one exists.
+      if (this.terminal.seq > fromSeq) live.push(this.terminal)
+    }
+    return live
+  }
+
+  get lastSeq(): number {
+    return this.nextSeq - 1
+  }
+
+  get length(): number {
+    return this.frames.length
+  }
+}
+
+/**
+ * Per-process registry of in-flight agent turns. Decouples the turn
+ * lifecycle from any single SSE response: turns keep running when the
+ * caller disconnects, and reconnects can replay buffered events to
+ * catch up.
+ *
+ * Lifecycle:
+ *   register → run pump that pushes frames → complete/cancel → retain
+ *   for `retainAfterDoneMs` so a brief reconnect can still attach →
+ *   sweep evicts after retain window.
+ */
+export class TurnRegistry {
+  private readonly turns = new Map<string, ActiveTurn>()
+  private readonly retainAfterDoneMs: number
+  private readonly sweepIntervalMs: number
+  private sweepTimer: ReturnType<typeof setInterval> | null = null
+
+  constructor(
+    options: {
+      retainAfterDoneMs?: number
+      sweepIntervalMs?: number
+    } = {},
+  ) {
+    this.retainAfterDoneMs =
+      options.retainAfterDoneMs ?? DEFAULT_RETAIN_AFTER_DONE_MS
+    this.sweepIntervalMs = options.sweepIntervalMs ?? DEFAULT_SWEEP_INTERVAL_MS
+  }
+
+  /**
+   * Register a new turn. The caller is responsible for kicking off the
+   * runtime call and pumping its events into `pushEvent` until done.
+   */
+  register(agentId: string, sessionId: 'main' = 'main'): ActiveTurn {
+    const turn: ActiveTurn = {
+      turnId: randomUUID(),
+      agentId,
+      sessionId,
+      status: 'running',
+      buffer: new RingBuffer(),
+      subscribers: new Set(),
+      abortController: new AbortController(),
+      startedAt: Date.now(),
+    }
+    this.turns.set(turn.turnId, turn)
+    this.ensureSweeper()
+    return turn
+  }
+
+  get(turnId: string): ActiveTurn | undefined {
+    return this.turns.get(turnId)
+  }
+
+  /**
+   * Active (running) turn for the (agentId, sessionId) pair, if any.
+   * Used by route layer for collision detection on POST /chat.
+   */
+  getActiveFor(
+    agentId: string,
+    sessionId: 'main' = 'main',
+  ): ActiveTurn | undefined {
+    for (const turn of this.turns.values()) {
+      if (
+        turn.status === 'running' &&
+        turn.agentId === agentId &&
+        turn.sessionId === sessionId
+      ) {
+        return turn
+      }
+    }
+    return undefined
+  }
+
+  describe(turnId: string): ActiveTurnInfo | null {
+    const turn = this.turns.get(turnId)
+    if (!turn) return null
+    return {
+      turnId: turn.turnId,
+      agentId: turn.agentId,
+      sessionId: turn.sessionId,
+      status: turn.status,
+      lastSeq: turn.buffer.lastSeq,
+      startedAt: turn.startedAt,
+      endedAt: turn.endedAt,
+    }
+  }
+
+  /**
+   * Push an event into the turn's buffer and fan out to live
+   * subscribers. Terminal events transition status and start the
+   * retention window.
+   */
+  pushEvent(turnId: string, event: AgentStreamEvent): TurnFrame | null {
+    const turn = this.turns.get(turnId)
+    if (!turn) return null
+    if (turn.status !== 'running') return null
+    const frame = turn.buffer.push(event)
+    for (const sub of turn.subscribers) {
+      try {
+        sub.push(frame)
+      } catch (err) {
+        logger.warn('Subscriber push threw; dropping subscriber', {
+          turnId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+        turn.subscribers.delete(sub)
+      }
+    }
+    if (event.type === 'done') {
+      this.markTerminal(turn, 'done')
+    } else if (event.type === 'error') {
+      this.markTerminal(turn, 'error')
+    }
+    return frame
+  }
+
+  /**
+   * Mark a still-running turn as cancelled and signal its
+   * AbortController so the runtime call unwinds. Idempotent.
+   */
+  cancel(turnId: string, reason?: string): boolean {
+    const turn = this.turns.get(turnId)
+    if (!turn) return false
+    if (turn.status !== 'running') return false
+    try {
+      turn.abortController.abort(reason ?? 'cancelled')
+    } catch {
+      // AbortController.abort can throw on Node typing edge cases when
+      // signal is already aborted; harmless.
+    }
+    // We synthesize a terminal `done` with stopReason=cancelled so any
+    // subscribers see a clean end. The runtime cancel may also produce
+    // an error event later, but the buffer ignores additional pushes
+    // once status flips off `running`.
+    this.pushSynthetic(turn, {
+      type: 'done',
+      stopReason: 'cancelled',
+      text: reason,
+    })
+    this.markTerminal(turn, 'cancelled')
+    return true
+  }
+
+  /**
+   * Subscribe to a turn from `fromSeq` (exclusive). Returns a
+   * ReadableStream of TurnFrames that completes when the turn does.
+   * Cancelling the stream just unregisters the subscriber — the turn
+   * keeps running.
+   */
+  subscribe(
+    turnId: string,
+    options: { fromSeq?: number; signal?: AbortSignal } = {},
+  ): ReadableStream<TurnFrame> | null {
+    const turn = this.turns.get(turnId)
+    if (!turn) return null
+    const fromSeq = options.fromSeq ?? -1
+
+    let queueResolve: ((frame: TurnFrame | null) => void) | null = null
+    const pendingFrames: TurnFrame[] = []
+
+    const subscriber: Subscriber = {
+      push(frame) {
+        if (queueResolve) {
+          const r = queueResolve
+          queueResolve = null
+          r(frame)
+        } else {
+          pendingFrames.push(frame)
+        }
+      },
+      end() {
+        if (queueResolve) {
+          const r = queueResolve
+          queueResolve = null
+          r(null)
+        }
+      },
+    }
+
+    return new ReadableStream<TurnFrame>({
+      start: (controller) => {
+        // Replay buffered frames first.
+        for (const frame of turn.buffer.slice(fromSeq)) {
+          controller.enqueue(frame)
+        }
+        // If the turn already finished, close immediately.
+        if (turn.status !== 'running') {
+          controller.close()
+          return
+        }
+        turn.subscribers.add(subscriber)
+        if (options.signal) {
+          if (options.signal.aborted) {
+            turn.subscribers.delete(subscriber)
+            controller.close()
+            return
+          }
+          options.signal.addEventListener(
+            'abort',
+            () => {
+              turn.subscribers.delete(subscriber)
+              try {
+                controller.close()
+              } catch {
+                // Already closed — fine.
+              }
+            },
+            { once: true },
+          )
+        }
+        const pump = async () => {
+          try {
+            while (true) {
+              while (pendingFrames.length > 0) {
+                controller.enqueue(pendingFrames.shift()!)
+              }
+              if (turn.status !== 'running' && pendingFrames.length === 0) {
+                break
+              }
+              const next = await new Promise<TurnFrame | null>((resolve) => {
+                queueResolve = resolve
+              })
+              if (next === null) break
+              controller.enqueue(next)
+            }
+            controller.close()
+          } catch (err) {
+            try {
+              controller.error(err)
+            } catch {
+              // Already errored — fine.
+            }
+          } finally {
+            turn.subscribers.delete(subscriber)
+          }
+        }
+        void pump()
+      },
+      cancel: () => {
+        turn.subscribers.delete(subscriber)
+        subscriber.end()
+      },
+    })
+  }
+
+  /**
+   * Periodic eviction of turns that have been terminal past
+   * `retainAfterDoneMs`. Lazy — only runs while the registry has
+   * entries.
+   */
+  sweep(now: number = Date.now()): void {
+    for (const [turnId, turn] of this.turns) {
+      if (turn.status === 'running') continue
+      if (turn.retainUntil != null && now >= turn.retainUntil) {
+        this.turns.delete(turnId)
+      }
+    }
+    if (this.turns.size === 0 && this.sweepTimer) {
+      clearInterval(this.sweepTimer)
+      this.sweepTimer = null
+    }
+  }
+
+  /** For tests. */
+  size(): number {
+    return this.turns.size
+  }
+
+  /** For tests / shutdown. Stops the sweep timer; does not clear turns. */
+  stopSweeper(): void {
+    if (this.sweepTimer) {
+      clearInterval(this.sweepTimer)
+      this.sweepTimer = null
+    }
+  }
+
+  private markTerminal(turn: ActiveTurn, status: TurnStatus): void {
+    if (turn.status !== 'running') return
+    turn.status = status
+    turn.endedAt = Date.now()
+    turn.retainUntil = turn.endedAt + this.retainAfterDoneMs
+    for (const sub of turn.subscribers) sub.end()
+    turn.subscribers.clear()
+  }
+
+  private pushSynthetic(turn: ActiveTurn, event: AgentStreamEvent): void {
+    if (turn.status !== 'running') return
+    const frame = turn.buffer.push(event)
+    for (const sub of turn.subscribers) {
+      try {
+        sub.push(frame)
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  private ensureSweeper(): void {
+    if (this.sweepTimer) return
+    this.sweepTimer = setInterval(() => this.sweep(), this.sweepIntervalMs)
+    // Don't keep the process alive on the timer alone.
+    if (typeof this.sweepTimer === 'object' && 'unref' in this.sweepTimer) {
+      this.sweepTimer.unref()
+    }
+  }
+}

--- a/packages/browseros-agent/apps/server/tests/api/routes/agents.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/agents.test.ts
@@ -7,6 +7,10 @@ import { describe, expect, it } from 'bun:test'
 import { AGENT_HARNESS_LIMITS } from '@browseros/shared/constants/limits'
 import { Hono } from 'hono'
 import { createAgentRoutes } from '../../../src/api/routes/agents'
+import {
+  type ActiveTurnInfo,
+  TurnRegistry,
+} from '../../../src/lib/agents/active-turn-registry'
 import type { AgentDefinition } from '../../../src/lib/agents/agent-types'
 import type {
   AgentPromptInput,
@@ -63,7 +67,171 @@ describe('createAgentRoutes', () => {
 
     expect(response.status).toBe(200)
     expect(response.headers.get('X-Session-Id')).toBe('main')
-    expect(await response.text()).toContain('data: [DONE]')
+    expect(response.headers.get('X-Turn-Id')).toBeTruthy()
+    const body = await response.text()
+    // Frames now carry per-event seq ids so reconnects can resume.
+    expect(body).toMatch(/^id: 0\ndata: /m)
+    expect(body).toContain('data: [DONE]')
+  })
+
+  it('returns 409 when starting a turn while one is active', async () => {
+    const agent: AgentDefinition = {
+      id: 'agent-1',
+      name: 'Review bot',
+      adapter: 'codex',
+      modelId: 'gpt-5.5',
+      reasoningEffort: 'medium',
+      permissionMode: 'approve-all',
+      sessionKey: 'agent:agent-1:main',
+      createdAt: 1000,
+      updatedAt: 1000,
+    }
+    const route = createMountedRoutes([agent])
+
+    // Block the runtime so the first turn stays "running".
+    const blocking = createBlockingFakeService([agent])
+    const blockingRoute = new Hono().route(
+      '/agents',
+      createAgentRoutes({ service: blocking }),
+    )
+
+    const first = blockingRoute.request('/agents/agent-1/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: 'hi' }),
+    })
+
+    // Yield so the first request reaches startTurn before the second
+    // arrives.
+    await new Promise((r) => setTimeout(r, 5))
+
+    const second = await blockingRoute.request('/agents/agent-1/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: 'again' }),
+    })
+    expect(second.status).toBe(409)
+    const body = await second.json()
+    expect(body).toMatchObject({ error: 'Turn already active' })
+    expect(typeof body.turnId).toBe('string')
+    expect(body.attachUrl).toContain(`turnId=${body.turnId}`)
+
+    // Unblock and drain the first.
+    blocking._unblock()
+    const firstResponse = await first
+    await firstResponse.text()
+    void route // keep type
+  })
+
+  it('reports the active turn via /chat/active and lets a client attach', async () => {
+    const agent: AgentDefinition = {
+      id: 'agent-1',
+      name: 'Review bot',
+      adapter: 'codex',
+      modelId: 'gpt-5.5',
+      reasoningEffort: 'medium',
+      permissionMode: 'approve-all',
+      sessionKey: 'agent:agent-1:main',
+      createdAt: 1000,
+      updatedAt: 1000,
+    }
+    const blocking = createBlockingFakeService([agent])
+    const blockingRoute = new Hono().route(
+      '/agents',
+      createAgentRoutes({ service: blocking }),
+    )
+
+    // Kick off the first turn but don't read its body — that's the
+    // "tab disconnected mid-turn" case.
+    const first = blockingRoute.request('/agents/agent-1/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: 'hi' }),
+    })
+    await new Promise((r) => setTimeout(r, 5))
+
+    const active = await blockingRoute.request('/agents/agent-1/chat/active')
+    expect(active.status).toBe(200)
+    const activeBody = await active.json()
+    expect(activeBody.active).toMatchObject({
+      agentId: 'agent-1',
+      sessionId: 'main',
+      status: 'running',
+    })
+
+    // Reattach as a fresh subscriber. Should get all buffered frames
+    // when the runtime drains.
+    const attachPromise = blockingRoute.request(
+      `/agents/agent-1/chat/stream?turnId=${activeBody.active.turnId}`,
+    )
+    blocking._unblock()
+    const attach = await attachPromise
+    expect(attach.status).toBe(200)
+    expect(attach.headers.get('X-Turn-Id')).toBe(activeBody.active.turnId)
+    const attachBody = await attach.text()
+    expect(attachBody).toContain('"type":"text_delta"')
+    expect(attachBody).toContain('data: [DONE]')
+
+    await (await first).text()
+  })
+
+  it('cancels an active turn via /chat/cancel', async () => {
+    const agent: AgentDefinition = {
+      id: 'agent-1',
+      name: 'Review bot',
+      adapter: 'codex',
+      modelId: 'gpt-5.5',
+      reasoningEffort: 'medium',
+      permissionMode: 'approve-all',
+      sessionKey: 'agent:agent-1:main',
+      createdAt: 1000,
+      updatedAt: 1000,
+    }
+    const blocking = createBlockingFakeService([agent])
+    const blockingRoute = new Hono().route(
+      '/agents',
+      createAgentRoutes({ service: blocking }),
+    )
+
+    const first = blockingRoute.request('/agents/agent-1/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: 'hi' }),
+    })
+    await new Promise((r) => setTimeout(r, 5))
+
+    const cancel = await blockingRoute.request('/agents/agent-1/chat/cancel', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ reason: 'user pressed stop' }),
+    })
+    expect(cancel.status).toBe(200)
+    expect(await cancel.json()).toEqual({ cancelled: true })
+
+    const text = await (await first).text()
+    expect(text).toContain('"stopReason":"cancelled"')
+
+    blocking._unblock()
+  })
+
+  it('returns 404 when attaching to an unknown turn', async () => {
+    const route = createMountedRoutes([
+      {
+        id: 'agent-1',
+        name: 'Review bot',
+        adapter: 'codex',
+        modelId: 'gpt-5.5',
+        reasoningEffort: 'medium',
+        permissionMode: 'approve-all',
+        sessionKey: 'agent:agent-1:main',
+        createdAt: 1000,
+        updatedAt: 1000,
+      },
+    ])
+    const response = await route.request(
+      '/agents/agent-1/chat/stream?turnId=nope',
+    )
+    expect(response.status).toBe(404)
   })
 
   it('streams sidepanel ACP chat as an AI SDK UI message stream', async () => {
@@ -183,6 +351,20 @@ function createMountedRoutes(
 }
 
 function createFakeService(agents: AgentDefinition[]) {
+  // Per-test in-memory turn registry. The service-side fakes go through
+  // it for the same reason real code does: keeps turn lifecycle decoupled
+  // from the HTTP response, so reconnect/cancel/active-turn tests work
+  // against the same primitives prod uses.
+  const registry = new TurnRegistry({
+    retainAfterDoneMs: 60_000,
+    sweepIntervalMs: 60_000,
+  })
+
+  const fakeEvents: AgentStreamEvent[] = [
+    { type: 'text_delta', text: 'Hello', stream: 'output' },
+    { type: 'done', stopReason: 'end_turn' },
+  ]
+
   return {
     async listAgents() {
       return agents
@@ -237,16 +419,36 @@ function createFakeService(agents: AgentDefinition[]) {
         items: [],
       }
     },
-    async send() {
-      return createAgentStream([
-        {
-          type: 'text_delta',
-          text: 'Hello',
-          stream: 'output',
-        },
-        { type: 'done', stopReason: 'end_turn' },
-      ])
+    async startTurn(input: { agentId: string }) {
+      const turn = registry.register(input.agentId, 'main')
+      const frames = registry.subscribe(turn.turnId, { fromSeq: -1 })!
+      // Push the canned events asynchronously so subscribers actually
+      // receive them through the stream, mirroring real runtime fan-out.
+      queueMicrotask(() => {
+        for (const event of fakeEvents) registry.pushEvent(turn.turnId, event)
+      })
+      return { turnId: turn.turnId, frames }
     },
+    attachTurn(input: { turnId: string; lastSeq?: number }) {
+      return registry.subscribe(input.turnId, { fromSeq: input.lastSeq ?? -1 })
+    },
+    getActiveTurn(agentId: string): ActiveTurnInfo | null {
+      const t = registry.getActiveFor(agentId, 'main')
+      return t ? registry.describe(t.turnId) : null
+    },
+    cancelTurn(input: { agentId: string; turnId?: string; reason?: string }) {
+      const turnId =
+        input.turnId ?? registry.getActiveFor(input.agentId, 'main')?.turnId
+      if (!turnId) return false
+      return registry.cancel(turnId, input.reason)
+    },
+    async send() {
+      // Legacy shape, used by the sidepanel route only. Returns a flat
+      // AgentStreamEvent stream.
+      return createAgentStream(fakeEvents)
+    },
+    /** Test-only: lets tests await turn completion deterministically. */
+    _registry: registry,
   }
 }
 
@@ -286,4 +488,85 @@ function createAgentStream(
       controller.close()
     },
   })
+}
+
+/**
+ * Variant of `createFakeService` whose turn doesn't push frames until
+ * `_unblock()` is called. Used by tests that need to observe the
+ * "running" state — collisions, /chat/active discovery, cancel.
+ */
+function createBlockingFakeService(agents: AgentDefinition[]) {
+  const registry = new TurnRegistry({
+    retainAfterDoneMs: 60_000,
+    sweepIntervalMs: 60_000,
+  })
+  const events: AgentStreamEvent[] = [
+    { type: 'text_delta', text: 'Hello', stream: 'output' },
+    { type: 'done', stopReason: 'end_turn' },
+  ]
+  let unblock: () => void = () => {}
+  const gate = new Promise<void>((resolve) => {
+    unblock = resolve
+  })
+
+  return {
+    async listAgents() {
+      return agents
+    },
+    async listAgentsWithActivity() {
+      return agents.map((agent) => ({
+        ...agent,
+        status: 'idle' as const,
+        lastUsedAt: null,
+      }))
+    },
+    async getGatewayStatus() {
+      return null
+    },
+    async createAgent() {
+      throw new Error('not used in this test')
+    },
+    async getAgent(agentId: string) {
+      return agents.find((a) => a.id === agentId) ?? null
+    },
+    async deleteAgent() {
+      return false
+    },
+    async getHistory(agentId: string) {
+      return { agentId, sessionId: 'main' as const, items: [] }
+    },
+    async startTurn(input: { agentId: string }) {
+      const existing = registry.getActiveFor(input.agentId, 'main')
+      if (existing) {
+        const { TurnAlreadyActiveError } = await import(
+          '../../../src/api/services/agents/agent-harness-service'
+        )
+        throw new TurnAlreadyActiveError(input.agentId, existing.turnId)
+      }
+      const turn = registry.register(input.agentId, 'main')
+      const frames = registry.subscribe(turn.turnId, { fromSeq: -1 })!
+      void (async () => {
+        await gate
+        for (const event of events) registry.pushEvent(turn.turnId, event)
+      })()
+      return { turnId: turn.turnId, frames }
+    },
+    attachTurn(input: { turnId: string; lastSeq?: number }) {
+      return registry.subscribe(input.turnId, { fromSeq: input.lastSeq ?? -1 })
+    },
+    getActiveTurn(agentId: string): ActiveTurnInfo | null {
+      const t = registry.getActiveFor(agentId, 'main')
+      return t ? registry.describe(t.turnId) : null
+    },
+    cancelTurn(input: { agentId: string; turnId?: string; reason?: string }) {
+      const turnId =
+        input.turnId ?? registry.getActiveFor(input.agentId, 'main')?.turnId
+      if (!turnId) return false
+      return registry.cancel(turnId, input.reason)
+    },
+    async send() {
+      return createAgentStream(events)
+    },
+    _unblock: () => unblock(),
+  }
 }

--- a/packages/browseros-agent/apps/server/tests/lib/agents/active-turn-registry.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/active-turn-registry.test.ts
@@ -1,0 +1,179 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import {
+  RingBuffer,
+  type TurnFrame,
+  TurnRegistry,
+} from '../../../src/lib/agents/active-turn-registry'
+
+const registries: TurnRegistry[] = []
+afterEach(() => {
+  for (const r of registries.splice(0)) r.stopSweeper()
+})
+
+function makeRegistry(opts?: ConstructorParameters<typeof TurnRegistry>[0]) {
+  const r = new TurnRegistry({
+    retainAfterDoneMs: 1000,
+    sweepIntervalMs: 60_000,
+    ...(opts ?? {}),
+  })
+  registries.push(r)
+  return r
+}
+
+async function collect(
+  stream: ReadableStream<TurnFrame>,
+): Promise<TurnFrame[]> {
+  const reader = stream.getReader()
+  const out: TurnFrame[] = []
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+    out.push(value)
+  }
+  return out
+}
+
+describe('RingBuffer', () => {
+  it('assigns monotonic seq starting at 0', () => {
+    const buf = new RingBuffer(10)
+    const a = buf.push({ type: 'text_delta', text: 'a', stream: 'output' })
+    const b = buf.push({ type: 'text_delta', text: 'b', stream: 'output' })
+    expect(a.seq).toBe(0)
+    expect(b.seq).toBe(1)
+    expect(buf.lastSeq).toBe(1)
+  })
+
+  it('drops oldest on overflow and sets truncated', () => {
+    const buf = new RingBuffer(2)
+    buf.push({ type: 'text_delta', text: 'a', stream: 'output' })
+    buf.push({ type: 'text_delta', text: 'b', stream: 'output' })
+    buf.push({ type: 'text_delta', text: 'c', stream: 'output' })
+    expect(buf.length).toBe(2)
+    expect(buf.truncated).toBe(true)
+  })
+
+  it('preserves the terminal frame even after eviction', () => {
+    const buf = new RingBuffer(2)
+    buf.push({ type: 'text_delta', text: 'a', stream: 'output' })
+    buf.push({ type: 'done', stopReason: 'end_turn' })
+    buf.push({ type: 'text_delta', text: 'late', stream: 'output' })
+    // Done frame had seq=1; the slice from -1 must still expose it.
+    const frames = buf.slice(-1)
+    const seqs = frames.map((f) => f.seq)
+    expect(seqs).toContain(1)
+  })
+
+  it('slice returns only frames newer than fromSeq', () => {
+    const buf = new RingBuffer(10)
+    for (let i = 0; i < 5; i++) {
+      buf.push({ type: 'text_delta', text: String(i), stream: 'output' })
+    }
+    const after2 = buf.slice(2).map((f) => f.seq)
+    expect(after2).toEqual([3, 4])
+  })
+})
+
+describe('TurnRegistry', () => {
+  it('replays buffered frames to late subscribers', async () => {
+    const registry = makeRegistry()
+    const turn = registry.register('agent-1')
+    registry.pushEvent(turn.turnId, {
+      type: 'text_delta',
+      text: 'one',
+      stream: 'output',
+    })
+    registry.pushEvent(turn.turnId, {
+      type: 'text_delta',
+      text: 'two',
+      stream: 'output',
+    })
+
+    const stream = registry.subscribe(turn.turnId, { fromSeq: -1 })!
+    // Push more after subscribe — both buffered and live frames should
+    // arrive in order.
+    registry.pushEvent(turn.turnId, {
+      type: 'text_delta',
+      text: 'three',
+      stream: 'output',
+    })
+    registry.pushEvent(turn.turnId, { type: 'done', stopReason: 'end_turn' })
+
+    const frames = await collect(stream)
+    const texts = frames.map((f) =>
+      f.event.type === 'text_delta' ? f.event.text : f.event.type,
+    )
+    expect(texts).toEqual(['one', 'two', 'three', 'done'])
+    expect(frames.map((f) => f.seq)).toEqual([0, 1, 2, 3])
+  })
+
+  it('skips already-seen frames when subscriber resumes from lastSeq', async () => {
+    const registry = makeRegistry()
+    const turn = registry.register('agent-1')
+    for (let i = 0; i < 4; i++) {
+      registry.pushEvent(turn.turnId, {
+        type: 'text_delta',
+        text: String(i),
+        stream: 'output',
+      })
+    }
+    registry.pushEvent(turn.turnId, { type: 'done', stopReason: 'end_turn' })
+
+    const stream = registry.subscribe(turn.turnId, { fromSeq: 2 })!
+    const frames = await collect(stream)
+    expect(frames.map((f) => f.seq)).toEqual([3, 4])
+  })
+
+  it('marks status `cancelled` and emits a synthetic terminal on cancel', async () => {
+    const registry = makeRegistry()
+    const turn = registry.register('agent-1')
+    const stream = registry.subscribe(turn.turnId, { fromSeq: -1 })!
+
+    registry.pushEvent(turn.turnId, {
+      type: 'text_delta',
+      text: 'partial',
+      stream: 'output',
+    })
+    registry.cancel(turn.turnId, 'user pressed stop')
+
+    const frames = await collect(stream)
+    const last = frames.at(-1)
+    expect(last?.event.type).toBe('done')
+    expect(last?.event.type === 'done' ? last.event.stopReason : null).toBe(
+      'cancelled',
+    )
+
+    expect(registry.describe(turn.turnId)?.status).toBe('cancelled')
+    expect(turn.abortController.signal.aborted).toBe(true)
+  })
+
+  it('reports the active turn for an agent', () => {
+    const registry = makeRegistry()
+    expect(registry.getActiveFor('agent-1')).toBeUndefined()
+    const turn = registry.register('agent-1')
+    expect(registry.getActiveFor('agent-1')?.turnId).toBe(turn.turnId)
+    registry.pushEvent(turn.turnId, { type: 'done', stopReason: 'end_turn' })
+    expect(registry.getActiveFor('agent-1')).toBeUndefined()
+  })
+
+  it('evicts terminal turns past the retain window via sweep', () => {
+    const registry = makeRegistry({ retainAfterDoneMs: 1 })
+    const turn = registry.register('agent-1')
+    registry.pushEvent(turn.turnId, { type: 'done', stopReason: 'end_turn' })
+    expect(registry.size()).toBe(1)
+    // Advance fake "now" past the retain window.
+    registry.sweep(Date.now() + 10)
+    expect(registry.size()).toBe(0)
+  })
+
+  it('returns null for unknown turns', () => {
+    const registry = makeRegistry()
+    expect(registry.subscribe('nope')).toBeNull()
+    expect(registry.describe('nope')).toBeNull()
+    expect(registry.cancel('nope')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Summary

- New `ActiveTurnRegistry` decouples each agent turn's lifecycle from the SSE response that initiated it, so chat tabs that close, refresh, or navigate away no longer cancel an in-flight turn.
- New endpoints: `GET /agents/:id/chat/active` (discover an in-flight turn on mount), `GET /agents/:id/chat/stream` (subscribe / resume via `Last-Event-ID`), `POST /agents/:id/chat/cancel` (explicit Stop). `POST /chat` now returns `409 + attachUrl` when the agent already has a running turn.
- The chat hook captures `X-Turn-Id`, tracks `lastSeq` from per-event SSE `id:` lines, reattaches on mount when `/chat/active` reports a running turn, and routes Stop through the cancel endpoint. Streaming UX on the happy path is unchanged.

## Why this matters

Previously, closing the chat tab — or even a brief network blip — fired the request's AbortSignal into the runtime and killed the in-flight turn. The user came back to a half-rendered message and had to retry. The runtime call now uses the registry's per-turn AbortController instead of the HTTP request signal: the turn keeps running on the server, buffered events fan out to whoever is currently subscribed, and reconnects pick up via `Last-Event-ID`.

## What changes for users

| Scenario | Before | After |
|---|---|---|
| Stream a message to completion | Works | Identical |
| Switch tabs / refresh mid-turn | Turn cancelled, half-rendered output | Reattaches, replays buffered events, message completes |
| Press Stop | SSE close cancels by accident | Explicit `/chat/cancel` |
| Send while a turn is running | Silent queue/double-send | Server returns 409, UI attaches to the existing turn |

## Test plan

- [x] `bun test` for the registry: ring buffer overflow + truncated flag, terminal-frame preservation, replay from arbitrary `lastSeq`, cancel emits synthetic terminal, retain-window sweep.
- [x] `bun test` for the routes: chat emits per-event seq + `X-Turn-Id`, 409 collision returns `attachUrl`, `/chat/active` reports running turn, `/chat/stream?turnId=…` replays buffered events, `/chat/cancel` flips the turn to `cancelled` with a synthetic `done`, 404 on unknown turn.
- [x] Server typecheck, agent typecheck, agent lint, full server `test:api` (142) + `test:lib` (118), agent `bun test` (42).
- [ ] Manual: open chat, send a long-running message, close the tab mid-turn, reopen — message resumes and completes.
- [ ] Manual: send a message, press Stop — server-side turn cancels and any reattaching subscriber sees the cancellation terminal.
- [ ] Manual: open chat in two tabs on the same agent — both render the same stream in sync.

## Notes

- Server-restart resilience is out of scope. The retain window after a turn ends is 5 minutes; bounded buffer is 5000 frames with drop-oldest (terminal frame held in a separate slot).
- Sidepanel ACP route (`POST /agents/sidepanel/chat`) still uses the legacy stateless flow — it doesn't have a persistent agent identity.
- The openclaw bridge cancel-propagation gotcha is unchanged here; tracked separately.