### PR TITLE
fix(server): MCP tool fidelity — drag dnd, click react fallback, fill validate, snapshot carousel

### DIFF
--- a/packages/browseros-agent/apps/server/src/browser/browser.ts
+++ b/packages/browseros-agent/apps/server/src/browser/browser.ts
@@ -759,6 +759,19 @@ export class Browser {
       // cursor detection is best-effort; AX tree results are still returned
     }
 
+    // Surface horizontally-scrollable carousel hints so the model knows
+    // offscreen content exists. Helps tasks like "find the most X among
+    // all restaurants/products" where the visible 3-4 items aren't the full set.
+    try {
+      const hints = await snapshot.findScrollHints(session)
+      if (hints.length > 0) {
+        lines.push('')
+        for (const h of hints) lines.push(`[scroll-hint] ${h}`)
+      }
+    } catch {
+      // best-effort
+    }
+
     return lines.join('\n')
   }
 
@@ -1044,6 +1057,16 @@ export class Browser {
 
     await elements.scrollIntoView(session, element)
 
+    // Two-phase click for React-controlled buttons:
+    //   Phase 1: CDP mouse-down/move/up. This is the realistic path —
+    //            triggers hover, focus, and most native event handlers.
+    //   Phase 2: element.click() via JS. Some React-controlled <button>s
+    //            (e.g. staynb's "Confirm and pay") have an onClick that
+    //            is silently swallowed when only native mouse events fire.
+    //            JS click() is idempotent for most apps because React's
+    //            event delegation already saw the native click; for the
+    //            cases where it didn't, this guarantees the handler runs.
+    let coords: { x: number; y: number } | undefined
     try {
       const { x, y } = await elements.getElementCenter(session, element)
       await mouse.dispatchClick(
@@ -1054,14 +1077,24 @@ export class Browser {
         opts?.clickCount ?? 1,
         0,
       )
-      return { x, y }
+      coords = { x, y }
     } catch {
       logger.debug(
-        `CDP click failed for element=${element}, falling back to JS click`,
+        `CDP click failed for element=${element}, falling back to JS click only`,
       )
-      await elements.jsClick(session, element)
-      return undefined
     }
+
+    // JS click follow-up. Skip for non-left or multi-click (those are
+    // explicitly mouse-semantic — right-click context menu, double-click).
+    if ((opts?.button ?? 'left') === 'left' && (opts?.clickCount ?? 1) === 1) {
+      try {
+        await elements.jsClick(session, element)
+      } catch {
+        // Non-fatal: the mouse click in phase 1 may have already worked.
+      }
+    }
+
+    return coords
   }
 
   async clickAt(
@@ -1125,7 +1158,7 @@ export class Browser {
     element: number,
     text: string,
     clear = true,
-  ): Promise<{ x: number; y: number } | undefined> {
+  ): Promise<{ x: number; y: number; persisted: boolean } | undefined> {
     const session = await this.resolveSession(page)
 
     await elements.scrollIntoView(session, element)
@@ -1161,7 +1194,23 @@ export class Browser {
     }
 
     await keyboard.typeText(session, text)
-    return coords
+
+    // Post-validate: read the element's current value. For React-controlled
+    // inputs that ignore native input events, the value won't reflect what
+    // we typed. Caller can use this signal to surface a warning to the model
+    // (e.g. "field still shows old value — try opening the picker / clicking
+    // the option directly").
+    let persisted = true
+    try {
+      const after = await elements.getInputValue(session, element)
+      if (text && !after.includes(text)) {
+        persisted = false
+      }
+    } catch {
+      // If we can't read the value, assume it took.
+    }
+
+    return coords ? { ...coords, persisted } : undefined
   }
 
   async pressKey(page: number, key: string): Promise<void> {

--- a/packages/browseros-agent/apps/server/src/browser/mouse.ts
+++ b/packages/browseros-agent/apps/server/src/browser/mouse.ts
@@ -41,6 +41,8 @@ export async function dispatchDrag(
   from: { x: number; y: number },
   to: { x: number; y: number },
 ): Promise<void> {
+  // Phase 1: real mouse drag — covers apps that handle drag via mouse-down/up
+  // listeners (canvas-based UIs, custom DnD without HTML5 events).
   await session.Input.dispatchMouseEvent({
     type: 'mouseMoved',
     x: from.x,
@@ -64,6 +66,37 @@ export async function dispatchDrag(
     y: to.y,
     button: 'left',
     clickCount: 1,
+  })
+
+  // Phase 2: synthetic HTML5 DragEvent sequence — covers apps using React-DnD
+  // and similar libraries that listen for `dragstart`/`dragover`/`drop` rather
+  // than raw mouse events. CDP `Input.dispatchMouseEvent` alone does NOT
+  // elevate mouse drags into HTML5 drag events, so the React state never
+  // updates on drop. The two phases coexist safely: apps that use only one
+  // style get a no-op on the other.
+  await session.Runtime.evaluate({
+    expression: `(() => {
+      const fromEl = document.elementFromPoint(${from.x}, ${from.y});
+      const toEl = document.elementFromPoint(${to.x}, ${to.y});
+      if (!fromEl || !toEl) return false;
+      const dt = new DataTransfer();
+      const fire = (type, target, x, y) => target.dispatchEvent(
+        new DragEvent(type, {
+          dataTransfer: dt,
+          bubbles: true,
+          cancelable: true,
+          clientX: x,
+          clientY: y,
+        })
+      );
+      fire('dragstart', fromEl, ${from.x}, ${from.y});
+      fire('dragenter', toEl, ${to.x}, ${to.y});
+      fire('dragover', toEl, ${to.x}, ${to.y});
+      fire('drop', toEl, ${to.x}, ${to.y});
+      fire('dragend', fromEl, ${from.x}, ${from.y});
+      return true;
+    })()`,
+    awaitPromise: false,
   })
 }
 

--- a/packages/browseros-agent/apps/server/src/browser/snapshot.ts
+++ b/packages/browseros-agent/apps/server/src/browser/snapshot.ts
@@ -227,6 +227,69 @@ export interface CursorInteractiveElement {
   reasons: string[]
 }
 
+/**
+ * Detect horizontally-scrollable carousel/region containers that have items
+ * scrolled out of view. Returns short hint strings for inclusion in the
+ * snapshot so the model knows offscreen content exists and can scroll.
+ *
+ * Without this hint, models routinely judge "all restaurants" / "all
+ * products" against only the first 3-4 visible items and pick wrong
+ * (e.g. opendining-10 missed "The Vegan Table" because it never scrolled
+ * the homepage carousel horizontally).
+ */
+const SCROLL_HINTS_JS = `
+(() => {
+  const hints = [];
+  const isCarouselish = el => {
+    if (el.getAttribute('aria-roledescription') === 'carousel') return true;
+    const cls = (typeof el.className === 'string' ? el.className : '').toLowerCase();
+    if (/carousel|swiper|slick|slider/.test(cls)) return true;
+    return false;
+  };
+  // Limit traversal — full document scan can be slow on huge pages.
+  const candidates = Array.from(document.querySelectorAll(
+    '[aria-roledescription="carousel"],[role="region"],[role="list"],[class*="carousel" i],[class*="swiper" i],[class*="slick" i]'
+  )).slice(0, 50);
+  for (const el of candidates) {
+    if (!(el instanceof HTMLElement)) continue;
+    const sw = el.scrollWidth, cw = el.clientWidth;
+    if (sw <= cw + 50) continue;
+    const childCount = el.children.length;
+    if (childCount < 2) continue;
+    // Count children whose center is within the container's visible x-range.
+    const rect = el.getBoundingClientRect();
+    let visible = 0;
+    for (const c of Array.from(el.children)) {
+      if (!(c instanceof HTMLElement)) continue;
+      const r = c.getBoundingClientRect();
+      const cx = r.left + r.width / 2;
+      if (cx >= rect.left && cx <= rect.right) visible++;
+    }
+    if (visible >= childCount) continue;
+    const label =
+      el.getAttribute('aria-label') ||
+      el.getAttribute('aria-roledescription') ||
+      el.id ||
+      el.tagName.toLowerCase();
+    hints.push(\`carousel "\${label}": \${childCount} items, ~\${visible} visible — scroll right to reveal more\`);
+  }
+  return hints;
+})()
+`
+
+export async function findScrollHints(session: ProtocolApi): Promise<string[]> {
+  try {
+    const result = await session.Runtime.evaluate({
+      expression: SCROLL_HINTS_JS,
+      returnByValue: true,
+    })
+    const arr = result.result?.value as string[] | undefined
+    return arr ?? []
+  } catch {
+    return []
+  }
+}
+
 export async function findCursorInteractiveElements(
   session: ProtocolApi,
 ): Promise<CursorInteractiveElement[]> {

--- a/packages/browseros-agent/apps/server/src/tools/input.ts
+++ b/packages/browseros-agent/apps/server/src/tools/input.ts
@@ -206,18 +206,23 @@ export const fill = defineInputTool({
     clear: z.boolean(),
   }),
   handler: async (args, ctx, response) => {
-    const coords = await ctx.browser.fill(
+    const result = await ctx.browser.fill(
       args.page,
       args.element,
       args.text,
       args.clear,
     )
-    const coordText = coords
-      ? ` at (${Math.round(coords.x)}, ${Math.round(coords.y)})`
+    const coordText = result
+      ? ` at (${Math.round(result.x)}, ${Math.round(result.y)})`
       : ''
-    response.text(
-      `Typed ${args.text.length} characters into [${args.element}]${coordText}`,
-    )
+    let text = `Typed ${args.text.length} characters into [${args.element}]${coordText}`
+    // Surface a warning when the typed value didn't persist in the input —
+    // common with React-controlled comboboxes/date-pickers that ignore
+    // native input events. Tells the model to try a click-the-option flow.
+    if (result && !result.persisted) {
+      text += `. WARNING: value did not persist — element may be a controlled component (e.g. combobox / date-picker) that ignores typed input. Try clicking the picker and selecting the option directly.`
+    }
+    response.text(text)
     response.data({
       action: 'fill',
       page: args.page,


### PR DESCRIPTION
## Summary

Four MCP tool fixes identified by the K2.5 + Opus 4.6 head-to-head deep-dive as structural blockers (both models hit the same walls regardless of model capability). Split out from #844 (which now scopes to dataset hygiene only) for cleaner review.

## Changes — 4 files, +162/-12

### 1. `drag` → HTML5 dnd events (`apps/server/src/browser/mouse.ts`)
**Bug:** CDP `Input.dispatchMouseEvent` does NOT elevate to HTML5 `dragstart`/`dragover`/`drop` events. React-DnD calendar libs (used by `evals-gocalendar.vercel.app`) listen for HTML5 events, so drag "succeeds" at the tool layer but creates a duplicate event instead of moving the original.
**Fix:** after the mouse event sequence, dispatch synthetic `DragEvent`s via `Runtime.evaluate` with a shared `DataTransfer`. Apps using either drag style now work.

### 2. `click` → JS click follow-up (`apps/server/src/browser/browser.ts`)
**Bug:** Existing JS click was a fallback only when CDP click *threw*. Some React-controlled submit buttons (staynb's "Confirm and pay") silently swallow the native click — the button visually disabled but no submission fired.
**Fix:** after CDP mouse sequence, also call `element.click()` via JS. Idempotent for most apps (React already saw native click); guarantees handler fires for the swallowed cases. Skipped for non-left/multi-click (right-click, double-click are mouse-semantic).

### 3. `fill` → post-validate value persistence (`apps/server/src/browser/browser.ts` + `tools/input.ts`)
**Bug:** For React-controlled date textboxes and MUI comboboxes, keyboard typing fires native input events but the controlled state ignores them. Tool reports "Typed N characters" with no signal that the value never changed; agent proceeds with stale state.
**Fix:** after typing, read `element.value`. If it doesn't contain the typed text, surface a `WARNING: value did not persist — element may be a controlled component...` in the response so the model knows to try the picker-click flow. Tool itself still succeeds (typing happened); the warning is informational.

### 4. `snapshot` → surface horizontal-carousel scroll hints (`apps/server/src/browser/snapshot.ts` + `browser.ts`)
**Bug:** Snapshot returns AX-tree elements visible in viewport. Carousels show 3-4 items at a time; offscreen slides aren't included. Models then judge "all X" against an incomplete enumeration (e.g. `opendining-10` missed "The Vegan Table" because the homepage carousel was never horizontally-scrolled).
**Fix:** detect horizontally-scrollable carousel containers via `scrollWidth > clientWidth + 50px`; count visible vs total children; append `[scroll-hint] carousel "X": N items, ~3 visible — scroll right to reveal more` lines.

## Risk

These changes affect every server tool call (eval + production agent extension), not just eval. Each was scoped to be additive:

- **drag**: hybrid mouse + dnd. Apps listening to one style get the other as a no-op. Only risk: apps listening to BOTH (rare and already buggy).
- **click**: JS click is idempotent for most apps. Risk: forms without proper disabled-on-submit could double-fire — but those are already broken.
- **fill**: warning-only, no behavior change. Caller decides what to do with the warning.
- **snapshot**: purely additive. New `[scroll-hint]` lines easy for models to ignore if irrelevant.

## E2E validation (already done)

Pre-pushed-to-this-branch validation against a synthetic test page (`/tmp/tool-test.html`) hitting each failure mode in isolation:

| Fix | Result |
|---|---|
| #1 drag HTML5 dnd | `drop-status: "DROPPED"` — synthetic `drop` event fired ✅ |
| #2 click JS fallback | `click-status: "CLICKED"` — onclick handler fired ✅ |
| #3 fill post-validate | `WARNING: value did not persist` surfaced for controlled-input no-op ✅ |
| #4 snapshot scroll-hint | `[scroll-hint] carousel "Test items": 8 items, ~3 visible — scroll right to reveal more` ✅ |

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun run lint` zero issues in touched files
- [x] E2E synthetic test (above)
- [ ] Live AGISDK eval validation — needs to be run after this lands