### PR TITLE
fix(agents): connect OpenClaw ACP inside gateway container

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/server.ts
+++ b/packages/browseros-agent/apps/server/src/api/server.ts
@@ -138,7 +138,6 @@ export async function createHttpServer(config: HttpServerConfig) {
         browserosServerPort: port,
         browser,
         openclawGateway: {
-          getPort: () => getOpenClawService().getPort(),
           getGatewayToken: () => getOpenClawService().getGatewayToken(),
           getContainerName: () => OPENCLAW_GATEWAY_CONTAINER_NAME,
           getLimaHomeDir: () => getLimaHomeDir(),

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
@@ -6,6 +6,7 @@
 
 import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
+import { OPENCLAW_GATEWAY_CONTAINER_PORT } from '@browseros/shared/constants/openclaw'
 import { DEFAULT_PORTS } from '@browseros/shared/constants/ports'
 import {
   type AcpRuntimeEvent,
@@ -45,13 +46,10 @@ import type {
  * when spawning the openclaw ACP adapter inside the gateway container.
  *
  * Fields are getters (not snapshot values) so the harness picks up the
- * current port/token at spawn time — port can change after a gateway
- * restart, token can rotate.
+ * current token and VM/container paths at spawn time.
  */
 export interface OpenclawGatewayAccessor {
-  /** Host port the gateway is currently bound to (e.g. 18789). */
-  getPort(): number
-  /** Current gateway auth token. Passed via OPENCLAW_GATEWAY_TOKEN env. */
+  /** Current gateway auth token. Passed to `openclaw acp --token`. */
   getGatewayToken(): string
   /** Container name e.g. browseros-openclaw-openclaw-gateway-1. */
   getContainerName(): string
@@ -730,10 +728,8 @@ function createBrowserosAgentRegistry(
  * already installed alongside the gateway is reused; BrowserOS does
  * not require a host-side openclaw install.
  *
- * Auth: the gateway token is injected as the OPENCLAW_GATEWAY_TOKEN
- * env var on the container exec, which the openclaw CLI honors per
- * its documented env-var precedence. This avoids the `--token` flag
- * showing the secret in `ps aux`.
+ * Auth: `openclaw acp --url ...` deliberately does not reuse implicit
+ * env/config credentials, so pass the gateway token explicitly.
  *
  * Banner output: OPENCLAW_HIDE_BANNER and OPENCLAW_SUPPRESS_NOTES
  * suppress non-JSON-RPC chatter on stdout that would otherwise corrupt
@@ -743,12 +739,12 @@ function resolveOpenclawAcpCommand(
   gateway: OpenclawGatewayAccessor,
   sessionKey: string | null,
 ): string {
-  const port = gateway.getPort()
   const token = gateway.getGatewayToken()
   const limactl = gateway.getLimactlPath()
   const vm = gateway.getVmName()
   const container = gateway.getContainerName()
   const limaHome = gateway.getLimaHomeDir()
+  const gatewayUrlInsideContainer = `ws://127.0.0.1:${OPENCLAW_GATEWAY_CONTAINER_PORT}`
 
   // `--session <key>` routes the bridge's newSession requests to the
   // matching gateway agent. acpx does not pass sessionKey through ACP
@@ -789,13 +785,13 @@ function resolveOpenclawAcpCommand(
     'OPENCLAW_HIDE_BANNER=1',
     '-e',
     'OPENCLAW_SUPPRESS_NOTES=1',
-    '-e',
-    `OPENCLAW_GATEWAY_TOKEN=${token}`,
     container,
     'openclaw',
     'acp',
     '--url',
-    `ws://127.0.0.1:${port}`,
+    gatewayUrlInsideContainer,
+    '--token',
+    token,
   ]
   if (bridgeSessionKey) {
     argv.push('--session', bridgeSessionKey)

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -478,7 +478,6 @@ open &lt;example.com&gt;
       cwd: '/tmp/browseros-acpx-runtime',
       stateDir: '/tmp/browseros-acpx-state',
       openclawGateway: {
-        getPort: () => 18789,
         getGatewayToken: () => 'test-token-abc',
         getContainerName: () => 'browseros-openclaw-openclaw-gateway-1',
         getLimaHomeDir: () => '/Users/dev/.browseros-dev/lima',
@@ -515,9 +514,11 @@ open &lt;example.com&gt;
     expect(command).toContain('env LIMA_HOME=/Users/dev/.browseros-dev/lima')
     expect(command).toContain('/opt/homebrew/bin/limactl shell browseros-vm --')
     expect(command).toContain(
-      'nerdctl exec -i -e OPENCLAW_HIDE_BANNER=1 -e OPENCLAW_SUPPRESS_NOTES=1 -e OPENCLAW_GATEWAY_TOKEN=test-token-abc browseros-openclaw-openclaw-gateway-1',
+      'nerdctl exec -i -e OPENCLAW_HIDE_BANNER=1 -e OPENCLAW_SUPPRESS_NOTES=1 browseros-openclaw-openclaw-gateway-1',
     )
-    expect(command).toContain('openclaw acp --url ws://127.0.0.1:18789')
+    expect(command).toContain(
+      'openclaw acp --url ws://127.0.0.1:18789 --token test-token-abc',
+    )
     // sessionKey routing: the bridge needs --session <key> to map newSession
     // requests to the matching gateway agent (acpx does not forward
     // sessionKey via ACP newSession params).
@@ -535,7 +536,6 @@ open &lt;example.com&gt;
       cwd: '/tmp/browseros-acpx-runtime',
       stateDir: '/tmp/browseros-acpx-state',
       openclawGateway: {
-        getPort: () => 18789,
         getGatewayToken: () => 'test-token-abc',
         getContainerName: () => 'browseros-openclaw-openclaw-gateway-1',
         getLimaHomeDir: () => '/Users/dev/.browseros-dev/lima',


### PR DESCRIPTION
## Summary
- Fix OpenClaw ACP startup when the gateway host port differs from the container port.
- Run the in-container ACP bridge against the gateway container's fixed loopback port.
- Pass the gateway token explicitly to `openclaw acp --token` because `--url` does not reuse implicit credentials.

## Design
`openclaw acp` is spawned via `limactl shell ... nerdctl exec`, so its `127.0.0.1` is the gateway container, not the macOS host. The ACP command now uses `OPENCLAW_GATEWAY_CONTAINER_PORT` for the WebSocket URL and keeps host-mapped ports limited to host-side gateway clients/status. The OpenClaw gateway accessor no longer exposes a host port to the ACP spawn path.

## Test plan
- `bun test apps/server/tests/lib/agents/acpx-runtime.test.ts`
- `bunx biome check apps/server/src/lib/agents/acpx-runtime.ts apps/server/src/api/server.ts apps/server/tests/lib/agents/acpx-runtime.test.ts`
- `bun run --filter @browseros/server typecheck`
- Live dogfood validation: `POST /agents/claw-main/chat` returns `text_delta: ok` and `done` instead of ACP initialize/auth failure.