### PR TITLE
fix: stop passing native permission flags to ACP adapters

### DIFF
--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
@@ -205,7 +205,6 @@ export class AcpxRuntime implements AgentRuntime {
       cwd: input.cwd,
       sessionStore: this.sessionStore,
       agentRegistry: createBrowserosAgentRegistry(
-        input.permissionMode,
         this.openclawGateway,
         input.openclawSessionKey,
       ),
@@ -680,7 +679,6 @@ function createBrowserosMcpServers(
 }
 
 function createBrowserosAgentRegistry(
-  permissionMode: AcpRuntimeOptions['permissionMode'],
   openclawGateway: OpenclawGatewayAccessor | null,
   openclawSessionKey: string | null,
 ): AcpRuntimeOptions['agentRegistry'] {
@@ -705,20 +703,7 @@ function createBrowserosAgentRegistry(
         return resolveOpenclawAcpCommand(openclawGateway, openclawSessionKey)
       }
 
-      const command = registry.resolve(agentName)
-      if (permissionMode !== 'approve-all') return command
-
-      switch (lower) {
-        case 'claude':
-          return appendCommandArg(command, '--dangerously-skip-permissions')
-        case 'codex':
-          return appendCommandArg(
-            command,
-            '--dangerously-bypass-approvals-and-sandbox',
-          )
-        default:
-          return command
-      }
+      return registry.resolve(agentName)
     },
   }
 }
@@ -797,10 +782,6 @@ function resolveOpenclawAcpCommand(
     argv.push('--session', bridgeSessionKey)
   }
   return argv.join(' ')
-}
-
-function appendCommandArg(command: string, arg: string): string {
-  return command.split(/\s+/).includes(arg) ? command : `${command} ${arg}`
 }
 
 function buildBrowserosAcpPrompt(message: string): string {

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -433,7 +433,7 @@ open &lt;example.com&gt;
     expect(text).not.toContain('</user_request><role>')
   })
 
-  it('launches ACP adapters with BrowserOS permission bypass flags', async () => {
+  it('does not pass native CLI permission flags to ACP adapters', async () => {
     const calls: Array<{ method: string; input: unknown }> = []
     const runtime = new AcpxRuntime({
       cwd: '/tmp/browseros-acpx-runtime',
@@ -464,10 +464,10 @@ open &lt;example.com&gt;
     )
 
     const runtimeOptions = calls[0]?.input as AcpRuntimeOptions
-    expect(runtimeOptions.agentRegistry.resolve('claude')).toContain(
+    expect(runtimeOptions.agentRegistry.resolve('claude')).not.toContain(
       '--dangerously-skip-permissions',
     )
-    expect(runtimeOptions.agentRegistry.resolve('codex')).toContain(
+    expect(runtimeOptions.agentRegistry.resolve('codex')).not.toContain(
       '--dangerously-bypass-approvals-and-sandbox',
     )
   })


### PR DESCRIPTION
## Summary
- Stop appending native Claude/Codex CLI permission flags to ACP adapter commands.
- Keep ACPx adapter resolution intact for Claude/Codex while preserving the OpenClaw registry override.
- Add regression coverage that ACP adapter commands do not receive native CLI permission flags.

## Design
The BrowserOS registry now only special-cases OpenClaw, whose ACP bridge must be spawned inside the bundled gateway container. Claude and Codex resolve through ACPx's built-in registry without command mutation. Claude approve-all behavior remains handled through the existing ACP session mode call to `bypassPermissions`, while Codex no longer receives the unsupported `--dangerously-bypass-approvals-and-sandbox` flag that caused `codex-acp` initialization to exit early.

## Test plan
- `bun test apps/server/tests/lib/agents/acpx-runtime.test.ts`
- `bunx biome check apps/server/src/lib/agents/acpx-runtime.ts apps/server/tests/lib/agents/acpx-runtime.test.ts`
- `bun run --filter @browseros/server typecheck`
- `git diff --check`