### PR TITLE
fix: bound VM agent cache smoke test

### DIFF
--- a/.github/workflows/publish-vm-agent-cache.yml
+++ b/.github/workflows/publish-vm-agent-cache.yml
@@ -112,9 +112,14 @@ jobs:
             echo "missing ${{ matrix.arch }} tarball artifact for ${AGENT}" >&2
             exit 1
           fi
+          checksum="${tarball}.sha256"
+          if [ ! -f "$checksum" ]; then
+            echo "missing checksum sidecar: $checksum" >&2
+            exit 1
+          fi
           echo "smoke-testing $tarball"
-          ls -lh "$tarball" "${tarball}.sha256"
-          (cd "$(dirname "$tarball")" && sha256sum -c "$(basename "$tarball").sha256")
+          ls -lh "$tarball" "$checksum"
+          (cd "$(dirname "$tarball")" && sha256sum -c "$(basename "$checksum")")
           timeout --verbose --kill-after=30s 8m bun run smoke:tarball -- --agent "$AGENT" --arch "${{ matrix.arch }}" --tarball "$tarball"
 
   publish:

--- a/.github/workflows/publish-vm-agent-cache.yml
+++ b/.github/workflows/publish-vm-agent-cache.yml
@@ -101,6 +101,7 @@ jobs:
       - working-directory: packages/browseros-agent
         run: bun install --frozen-lockfile
       - name: Smoke test tarball
+        timeout-minutes: 10
         working-directory: ${{ env.PKG_DIR }}
         env:
           AGENT: ${{ inputs.agent || 'openclaw' }}
@@ -111,7 +112,10 @@ jobs:
             echo "missing ${{ matrix.arch }} tarball artifact for ${AGENT}" >&2
             exit 1
           fi
-          bun run smoke:tarball -- --agent "$AGENT" --arch "${{ matrix.arch }}" --tarball "$tarball"
+          echo "smoke-testing $tarball"
+          ls -lh "$tarball" "${tarball}.sha256"
+          (cd "$(dirname "$tarball")" && sha256sum -c "$(basename "$tarball").sha256")
+          timeout --verbose --kill-after=30s 8m bun run smoke:tarball -- --agent "$AGENT" --arch "${{ matrix.arch }}" --tarball "$tarball"
 
   publish:
     needs: [build, smoke]


### PR DESCRIPTION
## Summary
- Add a 10-minute GitHub Actions guard around the VM agent cache smoke step.
- Log and checksum-verify the downloaded tarball before invoking podman smoke.
- Wrap the Bun smoke command in an 8-minute GNU timeout so arm64 podman hangs fail instead of leaving the workflow in progress.

## Design
The build matrix and arm64 validation stay intact. The workflow now bounds only the smoke command that was observed hanging, while preserving enough artifact diagnostics to distinguish bad downloads from a stuck podman smoke process.

## Test plan
- ruby -ryaml -e 'YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/publish-vm-agent-cache.yml
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/publish-vm-agent-cache.yml
- git diff --check
- bun run --filter @browseros/build-tools typecheck
- bun run --filter @browseros/build-tools test