### PR TITLE
fix: use Node 24 GitHub actions

### DIFF
--- a/.github/workflows/publish-vm-agent-cache.yml
+++ b/.github/workflows/publish-vm-agent-cache.yml
@@ -29,7 +29,7 @@ jobs:
   check:
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
@@ -52,7 +52,7 @@ jobs:
             runner: ubuntu-24.04
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
@@ -68,7 +68,7 @@ jobs:
           AGENT: ${{ inputs.agent || 'openclaw' }}
           OUT: ${{ github.workspace }}/dist/images
         run: bun run build:tarball -- --agent "$AGENT" --arch "${{ matrix.arch }}" --output-dir "$OUT"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: tarball-${{ inputs.agent || 'openclaw' }}-${{ matrix.arch }}
           path: dist/images/
@@ -86,11 +86,11 @@ jobs:
             runner: ubuntu-24.04
     runs-on: ${{ matrix.runner }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: tarball-${{ inputs.agent || 'openclaw' }}-${{ matrix.arch }}
           path: dist/images
@@ -131,11 +131,11 @@ jobs:
       group: r2-manifest-publish
       cancel-in-progress: false
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ env.BUN_VERSION }}
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           pattern: tarball-*
           path: dist/images


### PR DESCRIPTION
## Summary
- Bump publish-vm-agent-cache workflow actions off Node 20-backed versions.
- Use actions/checkout@v6, actions/upload-artifact@v7, and actions/download-artifact@v8.
- Keep existing workflow behavior and artifact inputs unchanged.

## Test plan
- ruby -ryaml -e 'YAML.load_file(ARGV.fetch(0)); puts "yaml ok"' .github/workflows/publish-vm-agent-cache.yml
- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/publish-vm-agent-cache.yml
- git diff --check
- Verified action metadata uses node24 and supports the workflow inputs