### PR TITLE
fix: make R2 uploads retryable

### DIFF
--- a/packages/browseros-agent/packages/build-tools/scripts/common/r2.ts
+++ b/packages/browseros-agent/packages/build-tools/scripts/common/r2.ts
@@ -74,14 +74,18 @@ export async function putFile(
     return
   }
 
-  await client.send(
-    new PutObjectCommand({
-      Bucket: bucket,
-      Key: key,
-      Body: createReadStream(filePath),
-      ContentLength: size,
-      ContentType: contentType,
-    }),
+  await sendWithRetry(
+    () =>
+      client.send(
+        new PutObjectCommand({
+          Bucket: bucket,
+          Key: key,
+          Body: createReadStream(filePath),
+          ContentLength: size,
+          ContentType: contentType,
+        }),
+      ),
+    opts,
   )
 }
 

--- a/packages/browseros-agent/packages/build-tools/scripts/common/r2.ts
+++ b/packages/browseros-agent/packages/build-tools/scripts/common/r2.ts
@@ -1,10 +1,28 @@
 import { createReadStream } from 'node:fs'
 import { stat } from 'node:fs/promises'
+import { setTimeout as sleep } from 'node:timers/promises'
 import {
+  AbortMultipartUploadCommand,
+  type CompletedPart,
+  CompleteMultipartUploadCommand,
+  CreateMultipartUploadCommand,
   GetObjectCommand,
   PutObjectCommand,
   S3Client,
+  UploadPartCommand,
 } from '@aws-sdk/client-s3'
+
+const MIN_MULTIPART_PART_SIZE_BYTES = 5 * 1024 * 1024
+const DEFAULT_MULTIPART_THRESHOLD_BYTES = 64 * 1024 * 1024
+const DEFAULT_MULTIPART_PART_SIZE_BYTES = 64 * 1024 * 1024
+const DEFAULT_UPLOAD_ATTEMPTS = 3
+
+export interface PutFileOptions {
+  multipartThresholdBytes?: number
+  partSizeBytes?: number
+  maxAttempts?: number
+  retryDelayMs?: number
+}
 
 function required(name: string): string {
   const value = process.env[name]?.trim()
@@ -31,14 +49,31 @@ export function getCdnBase(): string {
   return process.env.R2_PUBLIC_BASE_URL?.trim() ?? 'https://cdn.browseros.com'
 }
 
+/** Uploads a file to R2, using multipart uploads for large artifacts so failed parts can be retried. */
 export async function putFile(
   client: S3Client,
   bucket: string,
   key: string,
   filePath: string,
   contentType: string,
+  opts: PutFileOptions = {},
 ): Promise<void> {
   const { size } = await stat(filePath)
+  const multipartThresholdBytes =
+    opts.multipartThresholdBytes ?? DEFAULT_MULTIPART_THRESHOLD_BYTES
+  if (size > 0 && size >= multipartThresholdBytes) {
+    await putFileMultipart(
+      client,
+      bucket,
+      key,
+      filePath,
+      contentType,
+      size,
+      opts,
+    )
+    return
+  }
+
   await client.send(
     new PutObjectCommand({
       Bucket: bucket,
@@ -48,6 +83,101 @@ export async function putFile(
       ContentType: contentType,
     }),
   )
+}
+
+/** Uploads large files as multipart objects with fresh streams for each retried part. */
+async function putFileMultipart(
+  client: S3Client,
+  bucket: string,
+  key: string,
+  filePath: string,
+  contentType: string,
+  size: number,
+  opts: PutFileOptions,
+): Promise<void> {
+  const partSizeBytes = opts.partSizeBytes ?? DEFAULT_MULTIPART_PART_SIZE_BYTES
+  if (partSizeBytes < MIN_MULTIPART_PART_SIZE_BYTES) {
+    throw new Error(
+      `multipart part size must be at least ${MIN_MULTIPART_PART_SIZE_BYTES} bytes`,
+    )
+  }
+
+  const { UploadId } = await client.send(
+    new CreateMultipartUploadCommand({
+      Bucket: bucket,
+      Key: key,
+      ContentType: contentType,
+    }),
+  )
+  if (!UploadId) {
+    throw new Error(`missing multipart upload id for ${bucket}/${key}`)
+  }
+
+  const parts: CompletedPart[] = []
+  try {
+    for (let start = 0, partNumber = 1; start < size; start += partSizeBytes) {
+      const end = Math.min(start + partSizeBytes, size) - 1
+      const contentLength = end - start + 1
+      const result = await sendWithRetry(
+        () =>
+          client.send(
+            new UploadPartCommand({
+              Bucket: bucket,
+              Key: key,
+              UploadId,
+              PartNumber: partNumber,
+              Body: createReadStream(filePath, { start, end }),
+              ContentLength: contentLength,
+            }),
+          ),
+        opts,
+      )
+      if (!result.ETag) {
+        throw new Error(`missing ETag for ${bucket}/${key} part ${partNumber}`)
+      }
+      parts.push({ ETag: result.ETag, PartNumber: partNumber })
+      partNumber += 1
+    }
+
+    await client.send(
+      new CompleteMultipartUploadCommand({
+        Bucket: bucket,
+        Key: key,
+        UploadId,
+        MultipartUpload: { Parts: parts },
+      }),
+    )
+  } catch (error) {
+    await client
+      .send(
+        new AbortMultipartUploadCommand({ Bucket: bucket, Key: key, UploadId }),
+      )
+      .catch(() => {})
+    throw error
+  }
+}
+
+/** Retries part uploads by rerunning the command factory, which recreates consumed request bodies. */
+async function sendWithRetry<T>(
+  send: () => Promise<T>,
+  opts: PutFileOptions,
+): Promise<T> {
+  const maxAttempts = opts.maxAttempts ?? DEFAULT_UPLOAD_ATTEMPTS
+  const retryDelayMs = opts.retryDelayMs ?? 1000
+  let lastError: unknown
+  if (maxAttempts < 1) throw new Error('maxAttempts must be at least 1')
+
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    try {
+      return await send()
+    } catch (error) {
+      lastError = error
+      if (attempt === maxAttempts) break
+      if (retryDelayMs > 0) await sleep(retryDelayMs * attempt)
+    }
+  }
+
+  throw lastError
 }
 
 export async function putBody(

--- a/packages/browseros-agent/packages/build-tools/tests/r2.test.ts
+++ b/packages/browseros-agent/packages/build-tools/tests/r2.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import type { S3Client } from '@aws-sdk/client-s3'
+import { putFile } from '../scripts/common/r2'
+
+class FakeS3Client {
+  commands: Array<{ name: string; input: Record<string, unknown> }> = []
+  failedFirstPart = false
+
+  async send(command: { input: Record<string, unknown> }): Promise<unknown> {
+    const name = command.constructor.name
+    this.commands.push({ name, input: command.input })
+    if (name === 'CreateMultipartUploadCommand') return { UploadId: 'upload-1' }
+    if (name === 'UploadPartCommand') {
+      const partNumber = command.input.PartNumber
+      if (partNumber === 1 && !this.failedFirstPart) {
+        this.failedFirstPart = true
+        throw new Error('socket reset')
+      }
+      return { ETag: `etag-${partNumber}` }
+    }
+    return {}
+  }
+}
+
+describe('putFile', () => {
+  let dir: string | null = null
+
+  afterEach(async () => {
+    if (!dir) return
+    await rm(dir, { recursive: true, force: true })
+    dir = null
+  })
+
+  it('retries failed multipart parts with a fresh file stream', async () => {
+    dir = await mkdtemp(path.join(tmpdir(), 'browseros-r2-upload-'))
+    const filePath = path.join(dir, 'large.tar.gz')
+    await writeFile(filePath, new Uint8Array(6 * 1024 * 1024))
+    const client = new FakeS3Client()
+
+    await putFile(
+      client as unknown as S3Client,
+      'bucket',
+      'vm/images/large.tar.gz',
+      filePath,
+      'application/gzip',
+      {
+        multipartThresholdBytes: 1,
+        partSizeBytes: 5 * 1024 * 1024,
+        retryDelayMs: 0,
+      },
+    )
+
+    const uploadParts = client.commands.filter(
+      ({ name }) => name === 'UploadPartCommand',
+    )
+    expect(uploadParts.map(({ input }) => input.PartNumber)).toEqual([1, 1, 2])
+    expect(uploadParts[0].input.Body).not.toBe(uploadParts[1].input.Body)
+    expect(
+      client.commands.find(
+        ({ name }) => name === 'CompleteMultipartUploadCommand',
+      )?.input.MultipartUpload,
+    ).toEqual({
+      Parts: [
+        { ETag: 'etag-1', PartNumber: 1 },
+        { ETag: 'etag-2', PartNumber: 2 },
+      ],
+    })
+  })
+})

--- a/packages/browseros-agent/packages/build-tools/tests/r2.test.ts
+++ b/packages/browseros-agent/packages/build-tools/tests/r2.test.ts
@@ -8,10 +8,15 @@ import { putFile } from '../scripts/common/r2'
 class FakeS3Client {
   commands: Array<{ name: string; input: Record<string, unknown> }> = []
   failedFirstPart = false
+  failedPutObject = false
 
   async send(command: { input: Record<string, unknown> }): Promise<unknown> {
     const name = command.constructor.name
     this.commands.push({ name, input: command.input })
+    if (name === 'PutObjectCommand' && !this.failedPutObject) {
+      this.failedPutObject = true
+      throw new Error('socket reset')
+    }
     if (name === 'CreateMultipartUploadCommand') return { UploadId: 'upload-1' }
     if (name === 'UploadPartCommand') {
       const partNumber = command.input.PartNumber
@@ -68,5 +73,27 @@ describe('putFile', () => {
         { ETag: 'etag-2', PartNumber: 2 },
       ],
     })
+  })
+
+  it('retries failed put-object uploads with a fresh file stream', async () => {
+    dir = await mkdtemp(path.join(tmpdir(), 'browseros-r2-upload-'))
+    const filePath = path.join(dir, 'small.tar.gz')
+    await writeFile(filePath, 'small tarball')
+    const client = new FakeS3Client()
+
+    await putFile(
+      client as unknown as S3Client,
+      'bucket',
+      'vm/images/small.tar.gz',
+      filePath,
+      'application/gzip',
+      { retryDelayMs: 0 },
+    )
+
+    const putObjects = client.commands.filter(
+      ({ name }) => name === 'PutObjectCommand',
+    )
+    expect(putObjects).toHaveLength(2)
+    expect(putObjects[0].input.Body).not.toBe(putObjects[1].input.Body)
   })
 })


### PR DESCRIPTION
## Summary
- Switch large R2 file uploads to S3-compatible multipart upload.
- Retry failed multipart parts by recreating the file stream for each attempt, avoiding consumed-stream retry failures.
- Abort incomplete multipart uploads on failure.

## Background
The failed publish run had all R2 secrets present, but the first ~700MB tarball upload failed with ECONNRESET. The AWS SDK reported it as a non-retryable streaming request because the PutObject body was a consumed createReadStream.

## Test plan
- bun test tests/r2.test.ts
- bun run --filter @browseros/build-tools typecheck
- bun run --filter @browseros/build-tools test