### PR TITLE
feat(dev): add guided cleanup and reset commands

### DIFF
--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -16,7 +16,6 @@
         "globals": "^16.4.0",
         "lefthook": "^2.0.12",
         "picocolors": "^1.1.1",
-        "rimraf": "^6.0.1",
         "typedoc": "^0.28.15",
         "typescript": "^5.9.2",
       },
@@ -2675,7 +2674,7 @@
 
     "giscus": ["giscus@1.6.0", "", { "dependencies": { "lit": "^3.2.1" } }, "sha512-Zrsi8r4t1LVW950keaWcsURuZUQwUaMKjvJgTCY125vkW6OiEBkatE7ScJDbpqKHdZwb///7FVC21SE3iFK3PQ=="],
 
-    "glob": ["glob@13.0.0", "", { "dependencies": { "minimatch": "^10.1.1", "minipass": "^7.1.2", "path-scurry": "^2.0.0" } }, "sha512-tvZgpqk6fz4BaNZ66ZsRaZnbHvP/jG3uKJvAZOwEVUL4RTA5nJeeLYfyN9/VA8NX/V3IBG+hkeuGpKjvELkVhA=="],
+    "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
 
     "glob-parent": ["glob-parent@5.1.2", "", { "dependencies": { "is-glob": "^4.0.1" } }, "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow=="],
 
@@ -3109,7 +3108,7 @@
 
     "lowercase-keys": ["lowercase-keys@3.0.0", "", {}, "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ=="],
 
-    "lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
+    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
 
@@ -3485,7 +3484,7 @@
 
     "path-root-regex": ["path-root-regex@0.1.2", "", {}, "sha512-4GlJ6rZDhQZFE0DPVKh0e9jmZ5egZfxTkp7bcRDuPlJXbAwhxcl2dINPUAsjLdejqaLsCeg8axcLjIbvBjN4pQ=="],
 
-    "path-scurry": ["path-scurry@2.0.1", "", { "dependencies": { "lru-cache": "^11.0.0", "minipass": "^7.1.2" } }, "sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA=="],
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
 
     "path-to-regexp": ["path-to-regexp@8.3.0", "", {}, "sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA=="],
 
@@ -3845,7 +3844,7 @@
 
     "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
 
-    "rimraf": ["rimraf@6.1.2", "", { "dependencies": { "glob": "^13.0.0", "package-json-from-dist": "^1.0.1" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-cFCkPslJv7BAXJsYlK1dZsbP8/ZNLkCAQ0bi1hf5EKX2QHegmDFEFA6QhuYJlk7UDdc+02JjO80YSOrWPpw06g=="],
+    "rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
 
     "roarr": ["roarr@2.15.4", "", { "dependencies": { "boolean": "^3.0.1", "detect-node": "^2.0.4", "globalthis": "^1.0.1", "json-stringify-safe": "^5.0.1", "semver-compare": "^1.0.0", "sprintf-js": "^1.1.2" } }, "sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A=="],
 
@@ -4425,8 +4424,6 @@
 
     "@google/gemini-cli-core/@opentelemetry/exporter-logs-otlp-http": ["@opentelemetry/exporter-logs-otlp-http@0.203.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.203.0", "@opentelemetry/core": "2.0.1", "@opentelemetry/otlp-exporter-base": "0.203.0", "@opentelemetry/otlp-transformer": "0.203.0", "@opentelemetry/sdk-logs": "0.203.0" }, "peerDependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-s0hys1ljqlMTbXx2XiplmMJg9wG570Z5lH7wMvrZX6lcODI56sG4HL03jklF63tBeyNwK2RV1/ntXGo3HgG4Qw=="],
 
-    "@google/gemini-cli-core/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
-
     "@google/gemini-cli-core/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "@google/gemini-cli-core/marked": ["marked@15.0.12", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA=="],
@@ -4803,8 +4800,6 @@
 
     "@sentry/bundler-plugin-core/dotenv": ["dotenv@16.6.1", "", {}, "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow=="],
 
-    "@sentry/bundler-plugin-core/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
-
     "@sentry/bundler-plugin-core/magic-string": ["magic-string@0.30.8", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" } }, "sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ=="],
 
     "@sentry/node/@opentelemetry/core": ["@opentelemetry/core@2.4.0", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-KtcyFHssTn5ZgDu6SXmUznS80OFs/wN7y6MyFRRcKU6TOw8hNcGxKvt8hsdaLJfhzUszNSjURetq5Qpkad14Gw=="],
@@ -4929,8 +4924,6 @@
 
     "giget/nypm": ["nypm@0.6.4", "", { "dependencies": { "citty": "^0.2.0", "pathe": "^2.0.3", "tinyexec": "^1.0.2" }, "bin": { "nypm": "dist/cli.mjs" } }, "sha512-1TvCKjZyyklN+JJj2TS3P4uSQEInrM/HkkuSXsEzm1ApPgBffOn8gFguNnZf07r/1X6vlryfIqMUkJKQMzlZiw=="],
 
-    "glob/minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
-
     "global-agent/serialize-error": ["serialize-error@7.0.1", "", { "dependencies": { "type-fest": "^0.13.1" } }, "sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw=="],
 
     "global-directory/ini": ["ini@4.1.1", "", {}, "sha512-QQnnxNyfvmHFIsj7gkPcYymR8Jdw/o7mp5ZFihxn6h8Ci6fh3Dx4E1gPjpQEpIuPo9XVNY/ZUwh4BPMjGyL01g=="],
@@ -4950,8 +4943,6 @@
     "gray-matter/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "hoist-non-react-statics/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
-
-    "hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "html-to-text/htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
 
@@ -5369,8 +5360,6 @@
 
     "@google/gemini-cli-core/@opentelemetry/exporter-logs-otlp-http/@opentelemetry/sdk-logs": ["@opentelemetry/sdk-logs@0.203.0", "", { "dependencies": { "@opentelemetry/api-logs": "0.203.0", "@opentelemetry/core": "2.0.1", "@opentelemetry/resources": "2.0.1" }, "peerDependencies": { "@opentelemetry/api": ">=1.4.0 <1.10.0" } }, "sha512-vM2+rPq0Vi3nYA5akQD2f3QwossDnTDLvKbea6u/A2NZ3XDkPxMfo/PNrDoXhDUD/0pPo2CdH5ce/thn9K0kLw=="],
 
-    "@google/gemini-cli-core/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
-
     "@google/gemini-cli-core/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "@google/gemini-cli-core/open/wsl-utils": ["wsl-utils@0.1.0", "", { "dependencies": { "is-wsl": "^3.1.0" } }, "sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw=="],
@@ -5547,8 +5536,6 @@
 
     "@prisma/instrumentation/@opentelemetry/instrumentation/require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
 
-    "@sentry/bundler-plugin-core/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
-
     "@sentry/node/@opentelemetry/instrumentation/@opentelemetry/api-logs": ["@opentelemetry/api-logs@0.210.0", "", { "dependencies": { "@opentelemetry/api": "^1.3.0" } }, "sha512-CMtLxp+lYDriveZejpBND/2TmadrrhUfChyxzmkFtHaMDdSKfP59MAYyA0ICBvEBdm3iXwLcaj/8Ic/pnGw9Yg=="],
 
     "@sentry/node/@opentelemetry/instrumentation/require-in-the-middle": ["require-in-the-middle@8.0.1", "", { "dependencies": { "debug": "^4.3.5", "module-details-from-path": "^1.0.3" } }, "sha512-QT7FVMXfWOYFbeRBF6nu+I6tr2Tf3u0q8RIEjNob/heKY/nh7drD/k7eeMFmSQgnTtCzLDcCu/XEnpW2wk4xCQ=="],
@@ -5582,8 +5569,6 @@
     "gaxios/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "giget/nypm/citty": ["citty@0.2.0", "", {}, "sha512-8csy5IBFI2ex2hTVpaHN2j+LNE199AgiI7y4dMintrr8i0lQiFn+0AWMZrWdHKIgMOer65f8IThysYhoReqjWA=="],
-
-    "glob/minimatch/brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
 
     "global-agent/serialize-error/type-fest": ["type-fest@0.13.1", "", {}, "sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg=="],
 
@@ -5779,23 +5764,15 @@
 
     "@google/gemini-cli-core/@opentelemetry/exporter-logs-otlp-http/@opentelemetry/sdk-logs/@opentelemetry/resources": ["@opentelemetry/resources@2.0.1", "", { "dependencies": { "@opentelemetry/core": "2.0.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-dZOB3R6zvBwDKnHDTB4X1xtMArB/d324VsbiPkX/Yu0Q8T2xceRthoIVFhJdvgVM2QhGVUyX9tzwiNxGtoBJUw=="],
 
-    "@google/gemini-cli-core/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
     "@google/genai/google-auth-library/gaxios/https-proxy-agent": ["https-proxy-agent@7.0.6", "", { "dependencies": { "agent-base": "^7.1.2", "debug": "4" } }, "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw=="],
 
     "@google/genai/google-auth-library/gaxios/node-fetch": ["node-fetch@3.3.2", "", { "dependencies": { "data-uri-to-buffer": "^4.0.0", "fetch-blob": "^3.1.4", "formdata-polyfill": "^4.0.10" } }, "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA=="],
 
-    "@google/genai/google-auth-library/gaxios/rimraf": ["rimraf@5.0.10", "", { "dependencies": { "glob": "^10.3.7" }, "bin": { "rimraf": "dist/esm/bin.mjs" } }, "sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ=="],
-
     "@inquirer/core/wrap-ansi/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
-
-    "@sentry/bundler-plugin-core/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "@types/request/form-data/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
     "fx-runner/which/is-absolute/is-relative": ["is-relative@0.1.3", "", {}, "sha512-wBOr+rNM4gkAZqoLRJI4myw5WzzIdQosFAAbnvfXP5z1LyzgAI3ivOKehC5KfqlQJZoihVhirgtCBj378Eg8GA=="],
-
-    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
     "graphql-config/@graphql-tools/url-loader/@graphql-tools/executor-graphql-ws/@graphql-tools/executor-common": ["@graphql-tools/executor-common@0.0.6", "", { "dependencies": { "@envelop/core": "^5.3.0", "@graphql-tools/utils": "^10.9.1" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-JAH/R1zf77CSkpYATIJw+eOJwsbWocdDjY+avY7G+P5HCXxwQjAjWVkJI1QJBQYjPQDVxwf1fmTZlIN3VOadow=="],
 
@@ -5849,8 +5826,6 @@
 
     "@google/genai/google-auth-library/gaxios/https-proxy-agent/agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "@google/genai/google-auth-library/gaxios/rimraf/glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
-
     "graphql-config/@graphql-tools/url-loader/@graphql-tools/wrap/@graphql-tools/delegate/@graphql-tools/batch-execute": ["@graphql-tools/batch-execute@9.0.19", "", { "dependencies": { "@graphql-tools/utils": "^10.9.1", "@whatwg-node/promise-helpers": "^1.3.0", "dataloader": "^2.2.3", "tslib": "^2.8.1" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-VGamgY4PLzSx48IHPoblRw0oTaBa7S26RpZXt0Y4NN90ytoE0LutlpB2484RbkfcTjv9wa64QD474+YP1kEgGA=="],
 
     "publish-browser-extension/listr2/cli-truncate/slice-ansi/ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
@@ -5862,9 +5837,5 @@
     "@browseros/build-tools/@aws-sdk/client-s3/@aws-sdk/core/@aws-sdk/xml-builder/fast-xml-parser/fast-xml-builder": ["fast-xml-builder@1.1.4", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg=="],
 
     "@browseros/eval/@aws-sdk/client-s3/@aws-sdk/core/@aws-sdk/xml-builder/fast-xml-parser/fast-xml-builder": ["fast-xml-builder@1.1.4", "", { "dependencies": { "path-expression-matcher": "^1.1.3" } }, "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg=="],
-
-    "@google/genai/google-auth-library/gaxios/rimraf/glob/path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
-
-    "@google/genai/google-auth-library/gaxios/rimraf/glob/path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
   }
 }

--- a/packages/browseros-agent/package.json
+++ b/packages/browseros-agent/package.json
@@ -13,9 +13,11 @@
     "dev:watch:new": "./tools/dev/run.sh watch --new",
     "dev:manual": "./tools/dev/run.sh watch --manual",
     "dev:setup": "./tools/dev/setup.sh",
+    "dev:cleanup": "./tools/dev/run.sh cleanup",
+    "dev:reset": "./tools/dev/run.sh reset",
     "install:browseros-dogfood": "make -C tools/dogfood install",
     "test:env": "./tools/dev/run.sh test",
-    "test:cleanup": "./tools/dev/run.sh cleanup",
+    "test:cleanup": "./tools/dev/run.sh cleanup --quick --yes",
     "start:server": "bun run --filter @browseros/server --elide-lines=0 start",
     "start:agent": "bun run --filter @browseros/agent dev",
     "build": "bun run build:server && bun run build:agent",
@@ -34,8 +36,7 @@
     "lint": "bunx biome check",
     "lint:fix": "bunx biome check --write --unsafe",
     "gen:cdp": "bun scripts/codegen/cdp-protocol.ts",
-    "generate:models": "bun scripts/generate-models.ts",
-    "clean": "rimraf dist"
+    "generate:models": "bun scripts/generate-models.ts"
   },
   "repository": "browseros-ai/BrowserOS-server",
   "author": "BrowserOS",
@@ -56,7 +57,6 @@
     "globals": "^16.4.0",
     "lefthook": "^2.0.12",
     "picocolors": "^1.1.1",
-    "rimraf": "^6.0.1",
     "typedoc": "^0.28.15",
     "typescript": "^5.9.2"
   },

--- a/packages/browseros-agent/tools/dev/cmd/cleanup.go
+++ b/packages/browseros-agent/tools/dev/cmd/cleanup.go
@@ -26,6 +26,11 @@ var (
 	cleanupYes   bool
 )
 
+type safeCleanupOptions struct {
+	ports bool
+	temps bool
+}
+
 func init() {
 	cleanupCmd.Flags().BoolVar(&cleanupPorts, "ports", false, "Only kill port processes")
 	cleanupCmd.Flags().BoolVar(&cleanupTemps, "temps", false, "Only remove temp directories")
@@ -51,15 +56,15 @@ func runCleanup(cmd *cobra.Command, args []string) error {
 			return nil
 		}
 	}
-	return runSafeCleanup(out)
+	return runSafeCleanup(out, safeCleanupOptions{
+		ports: !cleanupTemps || cleanupPorts,
+		temps: !cleanupPorts || cleanupTemps,
+	})
 }
 
 // runSafeCleanup is shared by cleanup and reset before any destructive repair steps.
-func runSafeCleanup(out io.Writer) error {
-	doPorts := !cleanupTemps || cleanupPorts
-	doTemps := !cleanupPorts || cleanupTemps
-
-	if doPorts {
+func runSafeCleanup(out io.Writer, opts safeCleanupOptions) error {
+	if opts.ports {
 		ports := proc.DefaultLocalPorts()
 		stopped, err := proc.StopAllWatchProcesses(3 * time.Second)
 		if err != nil {
@@ -82,7 +87,7 @@ func runSafeCleanup(out io.Writer) error {
 		fmt.Fprintln(out, successStyle.Sprint("Ports cleared."))
 	}
 
-	if doTemps {
+	if opts.temps {
 		n := proc.CleanupTempDirs("browseros-test-", "browseros-dev-")
 		if n > 0 {
 			fmt.Fprintf(out, "%s removed %d temp directories\n", successStyle.Sprint("Removed:"), n)

--- a/packages/browseros-agent/tools/dev/cmd/cleanup.go
+++ b/packages/browseros-agent/tools/dev/cmd/cleanup.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"bufio"
 	"fmt"
+	"io"
+	"os"
 	"time"
 
 	"browseros-dev/proc"
@@ -12,44 +15,83 @@ import (
 var cleanupCmd = &cobra.Command{
 	Use:   "cleanup",
 	Short: "Kill port processes and remove orphaned temp directories",
-	Long:  "Kills processes on dev/test ports and removes orphaned browseros-* temp directories.",
+	Long:  "Stops old dev watch processes, clears dev/test ports, and removes orphaned browseros-* temp directories.",
 	RunE:  runCleanup,
 }
 
 var (
 	cleanupPorts bool
 	cleanupTemps bool
+	cleanupQuick bool
+	cleanupYes   bool
 )
 
 func init() {
 	cleanupCmd.Flags().BoolVar(&cleanupPorts, "ports", false, "Only kill port processes")
 	cleanupCmd.Flags().BoolVar(&cleanupTemps, "temps", false, "Only remove temp directories")
+	cleanupCmd.Flags().BoolVar(&cleanupQuick, "quick", false, "Run safe cleanup only")
+	cleanupCmd.Flags().BoolVar(&cleanupYes, "yes", false, "Answer yes to the safe cleanup prompt")
 	rootCmd.AddCommand(cleanupCmd)
 }
 
+// runCleanup performs the non-destructive daily cleanup path for local dev.
 func runCleanup(cmd *cobra.Command, args []string) error {
+	out := cmd.OutOrStdout()
+	if !cleanupYes && !cleanupQuick {
+		ok, err := confirmYesNo(out, bufio.NewReader(os.Stdin), resetPrompt{
+			Title:  "Run safe cleanup?",
+			Body:   "Stops old dev watch processes, clears dev ports, and removes temporary /tmp browser profiles. This does not touch ~/.browseros-dev, Lima, containers, images, or saved dev data.",
+			Action: "Run safe cleanup",
+		})
+		if err != nil {
+			return err
+		}
+		if !ok {
+			fmt.Fprintln(out, dimStyle.Sprint("Skipped."))
+			return nil
+		}
+	}
+	return runSafeCleanup(out)
+}
+
+// runSafeCleanup is shared by cleanup and reset before any destructive repair steps.
+func runSafeCleanup(out io.Writer) error {
 	doPorts := !cleanupTemps || cleanupPorts
 	doTemps := !cleanupPorts || cleanupTemps
 
 	if doPorts {
 		ports := proc.DefaultLocalPorts()
-		proc.LogMsgf(proc.TagInfo, "Killing processes on ports %d, %d, %d...", ports.CDP, ports.Server, ports.Extension)
+		stopped, err := proc.StopAllWatchProcesses(3 * time.Second)
+		if err != nil {
+			return err
+		}
+		if stopped > 0 {
+			fmt.Fprintf(out, "%s stopped %d old dev watch process group(s)\n", successStyle.Sprint("Stopped:"), stopped)
+		}
+		killedBrowsers, err := proc.KillBrowserProcessesForDevProfiles(3 * time.Second)
+		if err != nil {
+			return err
+		}
+		if killedBrowsers > 0 {
+			fmt.Fprintf(out, "%s stopped %d BrowserOS dev/test profile process(es)\n", successStyle.Sprint("Stopped:"), killedBrowsers)
+		}
+		fmt.Fprintf(out, "%s ports %d, %d, %d\n", labelStyle.Sprint("Clearing:"), ports.CDP, ports.Server, ports.Extension)
 		if err := proc.KillPortsAndWait(ports, 3*time.Second); err != nil {
 			return err
 		}
-		proc.LogMsg(proc.TagInfo, "Ports cleared")
+		fmt.Fprintln(out, successStyle.Sprint("Ports cleared."))
 	}
 
 	if doTemps {
 		n := proc.CleanupTempDirs("browseros-test-", "browseros-dev-")
 		if n > 0 {
-			proc.LogMsgf(proc.TagInfo, "Removed %d temp directories", n)
+			fmt.Fprintf(out, "%s removed %d temp directories\n", successStyle.Sprint("Removed:"), n)
 		} else {
-			proc.LogMsg(proc.TagInfo, "No orphaned temp directories found")
+			fmt.Fprintln(out, dimStyle.Sprint("No orphaned temp directories found."))
 		}
 	}
 
-	fmt.Println()
-	proc.LogMsg(proc.TagInfo, "Cleanup complete")
+	fmt.Fprintln(out)
+	fmt.Fprintln(out, successStyle.Sprint("Cleanup complete."))
 	return nil
 }

--- a/packages/browseros-agent/tools/dev/cmd/cleanup_test.go
+++ b/packages/browseros-agent/tools/dev/cmd/cleanup_test.go
@@ -1,0 +1,134 @@
+package cmd
+
+import (
+	"bufio"
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestConfirmYesNoDefaultsNoAndExplainsAction(t *testing.T) {
+	var out bytes.Buffer
+	prompt := resetPrompt{
+		Title:  "Stop VM?",
+		Body:   "This shuts down browseros-vm. Data stays on disk.",
+		Action: "Stop browseros-vm",
+	}
+
+	ok, err := confirmYesNo(&out, bufio.NewReader(strings.NewReader("\n")), prompt)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if ok {
+		t.Fatal("expected empty answer to default to no")
+	}
+	text := out.String()
+	for _, want := range []string{
+		"Stop VM?",
+		"This shuts down browseros-vm. Data stays on disk.",
+		"Stop browseros-vm",
+		"[y/N]",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing %q in prompt:\n%s", want, text)
+		}
+	}
+}
+
+func TestConfirmTypedRequiresExactToken(t *testing.T) {
+	var out bytes.Buffer
+	ok, err := confirmTyped(
+		&out,
+		bufio.NewReader(strings.NewReader("delete\nDELETE\n")),
+		"Delete dev profile?",
+		"This removes ~/.browseros-dev.",
+		"DELETE",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !ok {
+		t.Fatal("expected exact token to confirm")
+	}
+
+	text := out.String()
+	if !strings.Contains(text, "Type DELETE to continue") {
+		t.Fatalf("missing typed confirmation instruction:\n%s", text)
+	}
+	if !strings.Contains(text, "Confirmation did not match") {
+		t.Fatalf("missing retry warning:\n%s", text)
+	}
+}
+
+func TestResetOverviewTellsUserToUseSmallestReset(t *testing.T) {
+	var out bytes.Buffer
+	printResetOverview(&out, devPaths{Root: "/Users/me/.browseros-dev"})
+
+	text := out.String()
+	for _, want := range []string{
+		"BrowserOS dev reset",
+		"Pick the smallest reset",
+		"/Users/me/.browseros-dev",
+		"Stop VM",
+		"Delete VM",
+		"Remove OpenClaw container",
+		"Remove OpenClaw image",
+		"Delete dev profile",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("missing %q in overview:\n%s", want, text)
+		}
+	}
+}
+
+func TestParseLimaListOutputAcceptsSingleObject(t *testing.T) {
+	entries, err := parseLimaListOutput([]byte(`{"name":"browseros-vm","status":"Running"}`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 || entries[0].Name != "browseros-vm" || entries[0].Status != "Running" {
+		t.Fatalf("unexpected entries: %#v", entries)
+	}
+}
+
+func TestParseLimaListOutputAcceptsJSONLines(t *testing.T) {
+	entries, err := parseLimaListOutput([]byte("{\"name\":\"one\",\"status\":\"Stopped\"}\n{\"name\":\"browseros-vm\",\"status\":\"Running\"}\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 || entries[1].Name != "browseros-vm" || entries[1].Status != "Running" {
+		t.Fatalf("unexpected entries: %#v", entries)
+	}
+}
+
+func TestValidateDevProfileRootRejectsUnsafePaths(t *testing.T) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, path := range []string{"/", home} {
+		if err := validateDevProfileRootForDeletion(path); err == nil {
+			t.Fatalf("expected %s to be rejected", path)
+		}
+	}
+}
+
+func TestLimactlShellArgsUseGuestWorkdir(t *testing.T) {
+	args := limactlShellArgs("sh", "-lc", "true")
+	want := []string{"shell", "--workdir", "/", "browseros-vm", "--", "sh", "-lc", "true"}
+	if strings.Join(args, "\x00") != strings.Join(want, "\x00") {
+		t.Fatalf("expected %#v, got %#v", want, args)
+	}
+}
+
+func TestParsePodmanMachineList(t *testing.T) {
+	machines, err := parsePodmanMachineList([]byte(`[{"Name":"podman-machine-default","Running":true}]`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(machines) != 1 || machines[0].Name != "podman-machine-default" || !machines[0].Running {
+		t.Fatalf("unexpected machines: %#v", machines)
+	}
+}

--- a/packages/browseros-agent/tools/dev/cmd/cleanup_test.go
+++ b/packages/browseros-agent/tools/dev/cmd/cleanup_test.go
@@ -108,7 +108,7 @@ func TestValidateDevProfileRootRejectsUnsafePaths(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	for _, path := range []string{"/", home} {
+	for _, path := range []string{"/", home, "/etc"} {
 		if err := validateDevProfileRootForDeletion(path); err == nil {
 			t.Fatalf("expected %s to be rejected", path)
 		}

--- a/packages/browseros-agent/tools/dev/cmd/reset.go
+++ b/packages/browseros-agent/tools/dev/cmd/reset.go
@@ -71,7 +71,7 @@ func runReset(cmd *cobra.Command, args []string) error {
 	}); err != nil {
 		return err
 	} else if ok {
-		if err := runSafeCleanup(out); err != nil {
+		if err := runSafeCleanup(out, safeCleanupOptions{ports: true, temps: true}); err != nil {
 			return err
 		}
 	}
@@ -113,7 +113,7 @@ func runReset(cmd *cobra.Command, args []string) error {
 		}); err != nil {
 			return err
 		} else if ok {
-			if err := runLimactl(limactlPath, paths.LimaHome, "stop", limaVMName); err != nil {
+			if err := runLimactl(out, limactlPath, paths.LimaHome, "stop", limaVMName); err != nil {
 				return err
 			}
 			fmt.Fprintln(out, successStyle.Sprint("VM stopped."))
@@ -130,7 +130,7 @@ func runReset(cmd *cobra.Command, args []string) error {
 	}); err != nil {
 		return err
 	} else if ok {
-		if err := runLimactl(limactlPath, paths.LimaHome, "delete", "--force", limaVMName); err != nil {
+		if err := runLimactl(out, limactlPath, paths.LimaHome, "delete", "--force", limaVMName); err != nil {
 			return err
 		}
 		fmt.Fprintln(out, successStyle.Sprint("VM deleted."))
@@ -222,7 +222,7 @@ func maybeResetOpenClaw(out io.Writer, reader *bufio.Reader, limactlPath string,
 			openClawContainerName,
 			openClawSetupContainer,
 		)
-		if err := runInVM(limactlPath, limaHome, "sh", "-lc", script); err != nil {
+		if err := runInVM(out, limactlPath, limaHome, "sh", "-lc", script); err != nil {
 			return err
 		}
 		fmt.Fprintln(out, successStyle.Sprint("OpenClaw containers removed if present."))
@@ -236,7 +236,7 @@ func maybeResetOpenClaw(out io.Writer, reader *bufio.Reader, limactlPath string,
 		return err
 	} else if ok {
 		script := fmt.Sprintf("nerdctl image rm %s >/dev/null 2>&1 || true", openClawImage)
-		if err := runInVM(limactlPath, limaHome, "sh", "-lc", script); err != nil {
+		if err := runInVM(out, limactlPath, limaHome, "sh", "-lc", script); err != nil {
 			return err
 		}
 		fmt.Fprintln(out, successStyle.Sprint("OpenClaw image removed if present."))
@@ -291,7 +291,8 @@ func maybeResetLegacyPodman(out io.Writer, reader *bufio.Reader) error {
 	fmt.Fprintln(out, dimStyle.Sprint("Future reset flows can add more legacy cleanup checks here."))
 	fmt.Fprintln(out)
 
-	for _, machine := range machines {
+	for i := range machines {
+		machine := machines[i]
 		if machine.Running {
 			if ok, err := confirmYesNo(out, reader, resetPrompt{
 				Title:  "Stop legacy Podman machine?",
@@ -300,11 +301,11 @@ func maybeResetLegacyPodman(out io.Writer, reader *bufio.Reader) error {
 			}); err != nil {
 				return err
 			} else if ok {
-				if err := runCommand(podmanPath, "machine", "stop", machine.Name); err != nil {
+				if err := runCommand(out, podmanPath, "machine", "stop", machine.Name); err != nil {
 					return err
 				}
 				fmt.Fprintf(out, "%s %s\n", successStyle.Sprint("Stopped:"), commandStyle.Sprint(machine.Name))
-				machine.Running = false
+				machines[i].Running = false
 			}
 		}
 
@@ -315,7 +316,7 @@ func maybeResetLegacyPodman(out io.Writer, reader *bufio.Reader) error {
 		}); err != nil {
 			return err
 		} else if ok {
-			if err := runCommand(podmanPath, "machine", "rm", "--force", machine.Name); err != nil {
+			if err := runCommand(out, podmanPath, "machine", "rm", "--force", machine.Name); err != nil {
 				return err
 			}
 			fmt.Fprintf(out, "%s %s\n", successStyle.Sprint("Deleted:"), commandStyle.Sprint(machine.Name))
@@ -363,7 +364,18 @@ func validateDevProfileRootForDeletion(root string) error {
 	if cleanRoot == cleanHome {
 		return fmt.Errorf("refusing to delete home directory %s", cleanRoot)
 	}
+	if !isPathInside(cleanRoot, cleanHome) {
+		return fmt.Errorf("refusing to delete path outside home directory: %s", cleanRoot)
+	}
 	return nil
+}
+
+func isPathInside(path string, parent string) bool {
+	rel, err := filepath.Rel(parent, path)
+	if err != nil {
+		return false
+	}
+	return rel != "." && rel != "" && !strings.HasPrefix(rel, "..") && !filepath.IsAbs(rel)
 }
 
 func findVM(limactlPath string, limaHome string) (*limaListEntry, error) {
@@ -414,16 +426,16 @@ func parseLimaListOutput(output []byte) ([]limaListEntry, error) {
 	return entries, nil
 }
 
-func runLimactl(limactlPath string, limaHome string, args ...string) error {
+func runLimactl(out io.Writer, limactlPath string, limaHome string, args ...string) error {
 	cmd := limactlCommand(limactlPath, limaHome, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = out
+	cmd.Stderr = out
 	return cmd.Run()
 }
 
-func runInVM(limactlPath string, limaHome string, args ...string) error {
+func runInVM(out io.Writer, limactlPath string, limaHome string, args ...string) error {
 	shellArgs := limactlShellArgs(args...)
-	return runLimactl(limactlPath, limaHome, shellArgs...)
+	return runLimactl(out, limactlPath, limaHome, shellArgs...)
 }
 
 func limactlShellArgs(args ...string) []string {
@@ -436,9 +448,9 @@ func limactlCommand(limactlPath string, limaHome string, args ...string) *exec.C
 	return cmd
 }
 
-func runCommand(path string, args ...string) error {
+func runCommand(out io.Writer, path string, args ...string) error {
 	cmd := exec.Command(path, args...)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = out
+	cmd.Stderr = out
 	return cmd.Run()
 }

--- a/packages/browseros-agent/tools/dev/cmd/reset.go
+++ b/packages/browseros-agent/tools/dev/cmd/reset.go
@@ -1,0 +1,444 @@
+package cmd
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	devDirName             = ".browseros-dev"
+	limaVMName             = "browseros-vm"
+	openClawImage          = "ghcr.io/openclaw/openclaw:2026.4.12"
+	openClawContainerName  = "browseros-openclaw-openclaw-gateway-1"
+	openClawSetupContainer = openClawContainerName + "-setup"
+)
+
+var resetCmd = &cobra.Command{
+	Use:   "reset",
+	Short: "Guide destructive BrowserOS dev profile and VM resets",
+	Long:  "Walks through safe cleanup, VM shutdown/deletion, OpenClaw container/image removal, and full ~/.browseros-dev reset.",
+	RunE:  runReset,
+}
+
+type devPaths struct {
+	Root     string
+	LimaHome string
+}
+
+type resetPrompt struct {
+	Title  string
+	Body   string
+	Action string
+}
+
+type limaListEntry struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+}
+
+type podmanMachineEntry struct {
+	Name    string `json:"Name"`
+	Running bool   `json:"Running"`
+}
+
+func init() {
+	rootCmd.AddCommand(resetCmd)
+}
+
+// runReset walks developers through escalating reset options without hiding the blast radius.
+func runReset(cmd *cobra.Command, args []string) error {
+	out := cmd.OutOrStdout()
+	reader := bufio.NewReader(os.Stdin)
+	paths, err := resolveDevPaths()
+	if err != nil {
+		return err
+	}
+
+	printResetOverview(out, paths)
+
+	if ok, err := confirmYesNo(out, reader, resetPrompt{
+		Title:  "Run safe cleanup first?",
+		Body:   "This stops old dev watch processes, clears dev ports, and removes temporary /tmp browser profiles. It does not touch saved dev data.",
+		Action: "Run safe cleanup",
+	}); err != nil {
+		return err
+	} else if ok {
+		if err := runSafeCleanup(out); err != nil {
+			return err
+		}
+	}
+
+	limactlPath, err := exec.LookPath("limactl")
+	if err != nil {
+		fmt.Fprintf(out, "%s Lima CLI not found; VM and OpenClaw reset steps are unavailable. Install with %s.\n", warnStyle.Sprint("Skipping:"), commandStyle.Sprint("brew install lima"))
+		if err := maybeResetLegacyPodman(out, reader); err != nil {
+			return err
+		}
+		return maybeDeleteDevProfile(out, reader, paths)
+	}
+
+	vm, err := findVM(limactlPath, paths.LimaHome)
+	if err != nil {
+		fmt.Fprintf(out, "%s could not inspect Lima VMs: %v\n", warnStyle.Sprint("Warning:"), err)
+		if err := maybeResetLegacyPodman(out, reader); err != nil {
+			return err
+		}
+		return maybeDeleteDevProfile(out, reader, paths)
+	}
+	if vm == nil {
+		fmt.Fprintf(out, "%s %s was not found in %s.\n", dimStyle.Sprint("Not found:"), limaVMName, pathStyle.Sprint(paths.LimaHome))
+		if err := maybeResetLegacyPodman(out, reader); err != nil {
+			return err
+		}
+		return maybeDeleteDevProfile(out, reader, paths)
+	}
+
+	fmt.Fprintf(out, "%s %s %s\n", labelStyle.Sprint("Found VM:"), commandStyle.Sprint(vm.Name), dimStyle.Sprintf("(%s)", vm.Status))
+	if strings.EqualFold(vm.Status, "Running") {
+		if err := maybeResetOpenClaw(out, reader, limactlPath, paths.LimaHome); err != nil {
+			return err
+		}
+		if ok, err := confirmYesNo(out, reader, resetPrompt{
+			Title:  "Stop VM?",
+			Body:   "This shuts down browseros-vm. The VM, containers, images, and profile data stay on disk.",
+			Action: "Stop browseros-vm",
+		}); err != nil {
+			return err
+		} else if ok {
+			if err := runLimactl(limactlPath, paths.LimaHome, "stop", limaVMName); err != nil {
+				return err
+			}
+			fmt.Fprintln(out, successStyle.Sprint("VM stopped."))
+			vm.Status = "Stopped"
+		}
+	} else {
+		fmt.Fprintln(out, dimStyle.Sprint("OpenClaw container/image reset needs the VM running; skipping those steps."))
+	}
+
+	if ok, err := confirmYesNo(out, reader, resetPrompt{
+		Title:  "Delete VM?",
+		Body:   "This deletes the Lima VM and its container store. ~/.browseros-dev remains. OpenClaw will be pulled again next time.",
+		Action: "Delete browseros-vm",
+	}); err != nil {
+		return err
+	} else if ok {
+		if err := runLimactl(limactlPath, paths.LimaHome, "delete", "--force", limaVMName); err != nil {
+			return err
+		}
+		fmt.Fprintln(out, successStyle.Sprint("VM deleted."))
+	}
+
+	if err := maybeResetLegacyPodman(out, reader); err != nil {
+		return err
+	}
+
+	return maybeDeleteDevProfile(out, reader, paths)
+}
+
+func resolveDevPaths() (devPaths, error) {
+	if override := strings.TrimSpace(os.Getenv("BROWSEROS_DIR")); override != "" {
+		root, err := filepath.Abs(override)
+		if err != nil {
+			return devPaths{}, err
+		}
+		return devPaths{Root: root, LimaHome: filepath.Join(root, "lima")}, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return devPaths{}, err
+	}
+	root := filepath.Join(home, devDirName)
+	return devPaths{Root: root, LimaHome: filepath.Join(root, "lima")}, nil
+}
+
+func printResetOverview(out io.Writer, paths devPaths) {
+	fmt.Fprintln(out, headerStyle.Sprint("BrowserOS dev reset"))
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "This can reset parts of %s. Pick the smallest reset that matches the problem.\n", pathStyle.Sprint(paths.Root))
+	fmt.Fprintln(out)
+	fmt.Fprintf(out, "  %s %s\n", labelStyle.Sprint("Stop VM:"), dimStyle.Sprint("Shuts down browseros-vm. Keeps data."))
+	fmt.Fprintf(out, "  %s %s\n", labelStyle.Sprint("Delete VM:"), dimStyle.Sprint("Removes Lima/container state. Keeps the dev profile."))
+	fmt.Fprintf(out, "  %s %s\n", labelStyle.Sprint("Remove OpenClaw container:"), dimStyle.Sprint("Keeps the downloaded OpenClaw image."))
+	fmt.Fprintf(out, "  %s %s\n", labelStyle.Sprint("Remove OpenClaw image:"), dimStyle.Sprint("Next startup pulls it again."))
+	fmt.Fprintf(out, "  %s %s\n", warnStyle.Sprint("Delete dev profile:"), dimStyle.Sprint("Deletes the dev profile root and dev-local BrowserOS data."))
+	fmt.Fprintln(out)
+}
+
+func confirmYesNo(out io.Writer, r *bufio.Reader, prompt resetPrompt) (bool, error) {
+	fmt.Fprintln(out, labelStyle.Sprint(prompt.Title))
+	fmt.Fprintln(out, prompt.Body)
+	if prompt.Action != "" {
+		fmt.Fprintf(out, "%s %s\n", labelStyle.Sprint("Action:"), commandStyle.Sprint(prompt.Action))
+	}
+	fmt.Fprint(out, labelStyle.Sprint("Continue?")+" [y/N]: ")
+	line, err := r.ReadString('\n')
+	if err != nil && len(line) == 0 {
+		return false, err
+	}
+	line = strings.TrimSpace(strings.ToLower(line))
+	fmt.Fprintln(out)
+	return line == "y" || line == "yes", nil
+}
+
+func confirmTyped(out io.Writer, r *bufio.Reader, title string, body string, token string) (bool, error) {
+	fmt.Fprintln(out, warnStyle.Sprint(title))
+	fmt.Fprintln(out, body)
+	for {
+		fmt.Fprintf(out, "%s %s %s: ", labelStyle.Sprint("Type"), commandStyle.Sprint(token), labelStyle.Sprint("to continue"))
+		line, err := r.ReadString('\n')
+		if err != nil && len(line) == 0 {
+			return false, err
+		}
+		if strings.TrimSpace(line) == token {
+			fmt.Fprintln(out)
+			return true, nil
+		}
+		if strings.TrimSpace(line) == "" {
+			fmt.Fprintln(out)
+			return false, nil
+		}
+		fmt.Fprintln(out, warnStyle.Sprint("Confirmation did not match. Press Enter to skip or try again."))
+	}
+}
+
+func maybeResetOpenClaw(out io.Writer, reader *bufio.Reader, limactlPath string, limaHome string) error {
+	if ok, err := confirmYesNo(out, reader, resetPrompt{
+		Title:  "Remove OpenClaw container?",
+		Body:   "This removes the current gateway/setup containers. The downloaded OpenClaw image stays in the VM.",
+		Action: "nerdctl rm -f " + openClawContainerName + " " + openClawSetupContainer,
+	}); err != nil {
+		return err
+	} else if ok {
+		script := fmt.Sprintf(
+			"nerdctl rm -f %s %s >/dev/null 2>&1 || true",
+			openClawContainerName,
+			openClawSetupContainer,
+		)
+		if err := runInVM(limactlPath, limaHome, "sh", "-lc", script); err != nil {
+			return err
+		}
+		fmt.Fprintln(out, successStyle.Sprint("OpenClaw containers removed if present."))
+	}
+
+	if ok, err := confirmYesNo(out, reader, resetPrompt{
+		Title:  "Remove OpenClaw image?",
+		Body:   "This deletes ghcr.io/openclaw/openclaw:2026.4.12 from the VM. Next startup pulls it again.",
+		Action: "nerdctl image rm " + openClawImage,
+	}); err != nil {
+		return err
+	} else if ok {
+		script := fmt.Sprintf("nerdctl image rm %s >/dev/null 2>&1 || true", openClawImage)
+		if err := runInVM(limactlPath, limaHome, "sh", "-lc", script); err != nil {
+			return err
+		}
+		fmt.Fprintln(out, successStyle.Sprint("OpenClaw image removed if present."))
+	}
+	return nil
+}
+
+func maybeDeleteDevProfile(out io.Writer, reader *bufio.Reader, paths devPaths) error {
+	ok, err := confirmTyped(
+		out,
+		reader,
+		"Delete dev profile?",
+		fmt.Sprintf("This deletes %s. It removes BrowserOS dev data plus VM/OpenClaw state.", pathStyle.Sprint(paths.Root)),
+		"DELETE",
+	)
+	if err != nil || !ok {
+		return err
+	}
+	if err := validateDevProfileRootForDeletion(paths.Root); err != nil {
+		return err
+	}
+	if err := os.RemoveAll(paths.Root); err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "%s %s\n", successStyle.Sprint("Deleted:"), pathStyle.Sprint(paths.Root))
+	return nil
+}
+
+func maybeResetLegacyPodman(out io.Writer, reader *bufio.Reader) error {
+	podmanPath, err := exec.LookPath("podman")
+	if err != nil {
+		return nil
+	}
+	machines, err := listPodmanMachines(podmanPath)
+	if err != nil {
+		fmt.Fprintf(out, "%s could not inspect legacy Podman machines: %v\n", warnStyle.Sprint("Warning:"), err)
+		return nil
+	}
+	if len(machines) == 0 {
+		return nil
+	}
+
+	fmt.Fprintln(out, headerStyle.Sprint("Legacy Podman VM cleanup"))
+	fmt.Fprintln(out, "BrowserOS used Podman before the Lima VM runtime. These machines are legacy for this dev flow.")
+	for _, machine := range machines {
+		state := "Stopped"
+		if machine.Running {
+			state = "Running"
+		}
+		fmt.Fprintf(out, "  %s %s\n", commandStyle.Sprint(machine.Name), dimStyle.Sprintf("(%s)", state))
+	}
+	fmt.Fprintln(out, dimStyle.Sprint("Future reset flows can add more legacy cleanup checks here."))
+	fmt.Fprintln(out)
+
+	for _, machine := range machines {
+		if machine.Running {
+			if ok, err := confirmYesNo(out, reader, resetPrompt{
+				Title:  "Stop legacy Podman machine?",
+				Body:   fmt.Sprintf("This stops legacy Podman machine %s. It does not delete the machine.", machine.Name),
+				Action: "podman machine stop " + machine.Name,
+			}); err != nil {
+				return err
+			} else if ok {
+				if err := runCommand(podmanPath, "machine", "stop", machine.Name); err != nil {
+					return err
+				}
+				fmt.Fprintf(out, "%s %s\n", successStyle.Sprint("Stopped:"), commandStyle.Sprint(machine.Name))
+				machine.Running = false
+			}
+		}
+
+		if ok, err := confirmYesNo(out, reader, resetPrompt{
+			Title:  "Delete legacy Podman machine?",
+			Body:   fmt.Sprintf("This deletes legacy Podman machine %s. Use this when cleaning up the old VM runtime.", machine.Name),
+			Action: "podman machine rm --force " + machine.Name,
+		}); err != nil {
+			return err
+		} else if ok {
+			if err := runCommand(podmanPath, "machine", "rm", "--force", machine.Name); err != nil {
+				return err
+			}
+			fmt.Fprintf(out, "%s %s\n", successStyle.Sprint("Deleted:"), commandStyle.Sprint(machine.Name))
+		}
+	}
+	return nil
+}
+
+func listPodmanMachines(podmanPath string) ([]podmanMachineEntry, error) {
+	cmd := exec.Command(podmanPath, "machine", "ls", "--format", "json")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	return parsePodmanMachineList(output)
+}
+
+func parsePodmanMachineList(output []byte) ([]podmanMachineEntry, error) {
+	if strings.TrimSpace(string(output)) == "" {
+		return nil, nil
+	}
+	var machines []podmanMachineEntry
+	if err := json.Unmarshal(output, &machines); err != nil {
+		return nil, err
+	}
+	return machines, nil
+}
+
+func validateDevProfileRootForDeletion(root string) error {
+	cleanRoot, err := filepath.Abs(root)
+	if err != nil {
+		return err
+	}
+	if cleanRoot == string(filepath.Separator) {
+		return fmt.Errorf("refusing to delete filesystem root")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return err
+	}
+	cleanHome, err := filepath.Abs(home)
+	if err != nil {
+		return err
+	}
+	if cleanRoot == cleanHome {
+		return fmt.Errorf("refusing to delete home directory %s", cleanRoot)
+	}
+	return nil
+}
+
+func findVM(limactlPath string, limaHome string) (*limaListEntry, error) {
+	cmd := limactlCommand(limactlPath, limaHome, "list", "--format", "json")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+	entries, err := parseLimaListOutput(output)
+	if err != nil {
+		return nil, err
+	}
+	for i := range entries {
+		if entries[i].Name == limaVMName {
+			return &entries[i], nil
+		}
+	}
+	return nil, nil
+}
+
+func parseLimaListOutput(output []byte) ([]limaListEntry, error) {
+	trimmed := strings.TrimSpace(string(output))
+	if trimmed == "" {
+		return nil, nil
+	}
+
+	var entries []limaListEntry
+	if err := json.Unmarshal([]byte(trimmed), &entries); err == nil {
+		return entries, nil
+	}
+
+	var single limaListEntry
+	if err := json.Unmarshal([]byte(trimmed), &single); err == nil {
+		return []limaListEntry{single}, nil
+	}
+
+	for _, line := range strings.Split(trimmed, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var entry limaListEntry
+		if err := json.Unmarshal([]byte(line), &entry); err != nil {
+			return nil, err
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}
+
+func runLimactl(limactlPath string, limaHome string, args ...string) error {
+	cmd := limactlCommand(limactlPath, limaHome, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func runInVM(limactlPath string, limaHome string, args ...string) error {
+	shellArgs := limactlShellArgs(args...)
+	return runLimactl(limactlPath, limaHome, shellArgs...)
+}
+
+func limactlShellArgs(args ...string) []string {
+	return append([]string{"shell", "--workdir", "/", limaVMName, "--"}, args...)
+}
+
+func limactlCommand(limactlPath string, limaHome string, args ...string) *exec.Cmd {
+	cmd := exec.Command(limactlPath, args...)
+	cmd.Env = append(os.Environ(), "LIMA_HOME="+limaHome)
+	return cmd
+}
+
+func runCommand(path string, args ...string) error {
+	cmd := exec.Command(path, args...)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/packages/browseros-agent/tools/dev/cmd/style.go
+++ b/packages/browseros-agent/tools/dev/cmd/style.go
@@ -1,0 +1,13 @@
+package cmd
+
+import "github.com/fatih/color"
+
+var (
+	headerStyle  = color.New(color.Bold, color.FgCyan)
+	commandStyle = color.New(color.FgHiGreen)
+	successStyle = color.New(color.FgGreen, color.Bold)
+	warnStyle    = color.New(color.FgYellow, color.Bold)
+	labelStyle   = color.New(color.Bold)
+	pathStyle    = color.New(color.FgCyan)
+	dimStyle     = color.New(color.Faint)
+)

--- a/packages/browseros-agent/tools/dev/proc/process.go
+++ b/packages/browseros-agent/tools/dev/proc/process.go
@@ -7,7 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
 	"syscall"
 	"time"
 )
@@ -120,6 +124,85 @@ func DefaultWatchRunBaseDir() (string, error) {
 	return filepath.Join(home, ".browseros-dev", "runs"), nil
 }
 
+// StopAllWatchProcesses terminates every recorded dev watch run.
+func StopAllWatchProcesses(timeout time.Duration) (int, error) {
+	baseDir, err := DefaultWatchRunBaseDir()
+	if err != nil {
+		return 0, err
+	}
+	return StopAllWatchProcessesInDir(baseDir, timeout)
+}
+
+// StopAllWatchProcessesInDir is StopAllWatchProcesses with an explicit state directory for tests.
+func StopAllWatchProcessesInDir(baseDir string, timeout time.Duration) (int, error) {
+	pgids, err := liveWatchRunPGIDs(baseDir)
+	if err != nil {
+		return 0, err
+	}
+	if len(pgids) == 0 {
+		return 0, nil
+	}
+
+	for _, pgid := range pgids {
+		if err := signalProcessGroup(pgid, syscall.SIGTERM); err != nil {
+			return 0, err
+		}
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		remaining := livePGIDs(pgids)
+		if len(remaining) == 0 {
+			return len(pgids), nil
+		}
+		if time.Now().After(deadline) {
+			for _, pgid := range remaining {
+				if err := signalProcessGroup(pgid, syscall.SIGKILL); err != nil {
+					return 0, err
+				}
+			}
+			return len(pgids), nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
+// KillBrowserProcessesForDevProfiles kills BrowserOS instances using temporary dev/test profiles.
+func KillBrowserProcessesForDevProfiles(timeout time.Duration) (int, error) {
+	pids, err := currentBrowserProfilePIDs()
+	if err != nil {
+		return 0, err
+	}
+	if len(pids) == 0 {
+		return 0, nil
+	}
+	for _, pid := range pids {
+		if err := signalProcess(pid, syscall.SIGTERM); err != nil {
+			return 0, err
+		}
+	}
+
+	deadline := time.Now().Add(timeout)
+	for {
+		remaining, err := currentBrowserProfilePIDs()
+		if err != nil {
+			return 0, err
+		}
+		if len(remaining) == 0 {
+			return len(pids), nil
+		}
+		if time.Now().After(deadline) {
+			for _, pid := range remaining {
+				if err := signalProcess(pid, syscall.SIGKILL); err != nil {
+					return 0, err
+				}
+			}
+			return len(pids), nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
 func (l *WatchRunLock) Close() error {
 	if l == nil || l.file == nil {
 		return nil
@@ -168,6 +251,82 @@ func readWatchRunStateWithRetry(path string, timeout time.Duration) (WatchRunSta
 		}
 		time.Sleep(50 * time.Millisecond)
 	}
+}
+
+func liveWatchRunPGIDs(baseDir string) ([]int, error) {
+	statePaths, err := filepath.Glob(filepath.Join(baseDir, "watch-*.json"))
+	if err != nil {
+		return nil, err
+	}
+	seen := map[int]struct{}{}
+	for _, statePath := range statePaths {
+		state, err := ReadWatchRunState(statePath)
+		if err != nil || state.PGID <= 0 || !processGroupLive(state.PGID) {
+			continue
+		}
+		seen[state.PGID] = struct{}{}
+	}
+	pgids := make([]int, 0, len(seen))
+	for pgid := range seen {
+		pgids = append(pgids, pgid)
+	}
+	sort.Ints(pgids)
+	return pgids, nil
+}
+
+func livePGIDs(pgids []int) []int {
+	remaining := make([]int, 0, len(pgids))
+	for _, pgid := range pgids {
+		if processGroupLive(pgid) {
+			remaining = append(remaining, pgid)
+		}
+	}
+	return remaining
+}
+
+func processGroupLive(pgid int) bool {
+	if pgid <= 0 {
+		return false
+	}
+	err := syscall.Kill(-pgid, 0)
+	return err == nil || err == syscall.EPERM
+}
+
+func currentBrowserProfilePIDs() ([]int, error) {
+	output, err := exec.Command("ps", "-axo", "pid=,pgid=,command=").Output()
+	if err != nil {
+		return nil, fmt.Errorf("listing processes: %w", err)
+	}
+	return browserProfilePIDsFromPS(string(output)), nil
+}
+
+func browserProfilePIDsFromPS(output string) []int {
+	var pids []int
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil {
+			continue
+		}
+		command := strings.Join(fields[2:], " ")
+		if isDevBrowserProcess(command) {
+			pids = append(pids, pid)
+		}
+	}
+	sort.Ints(pids)
+	return pids
+}
+
+func isDevBrowserProcess(command string) bool {
+	if !strings.Contains(command, "BrowserOS.app/Contents/MacOS/BrowserOS") {
+		return false
+	}
+	return strings.Contains(command, "--user-data-dir=/tmp/browseros-dev") ||
+		strings.Contains(command, "browseros-dev-") ||
+		strings.Contains(command, "browseros-test-")
 }
 
 func watchRunPaths(baseDir string, identity WatchRunIdentity) watchRunPathsResult {
@@ -276,6 +435,16 @@ func signalProcessGroup(pgid int, signal syscall.Signal) error {
 	}
 	if err := syscall.Kill(-pgid, signal); err != nil && err != syscall.ESRCH {
 		return fmt.Errorf("signaling process group %d: %w", pgid, err)
+	}
+	return nil
+}
+
+func signalProcess(pid int, signal syscall.Signal) error {
+	if pid <= 0 {
+		return fmt.Errorf("invalid process %d", pid)
+	}
+	if err := syscall.Kill(pid, signal); err != nil && err != syscall.ESRCH {
+		return fmt.Errorf("signaling process %d: %w", pid, err)
 	}
 	return nil
 }

--- a/packages/browseros-agent/tools/dev/proc/process_test.go
+++ b/packages/browseros-agent/tools/dev/proc/process_test.go
@@ -42,6 +42,22 @@ func TestWatchRunPathsStableAndDistinct(t *testing.T) {
 	}
 }
 
+func TestBrowserProfilePIDsFromPSSelectsOnlyDevAndTestProfiles(t *testing.T) {
+	output := `
+  111  111 /Applications/BrowserOS.app/Contents/MacOS/BrowserOS --user-data-dir=/tmp/browseros-dev
+  222  222 /Applications/BrowserOS.app/Contents/MacOS/BrowserOS --user-data-dir=/tmp/browseros-dev-abcd
+  333  333 /Applications/BrowserOS.app/Contents/MacOS/BrowserOS --user-data-dir=/var/folders/x/browseros-test-abcd
+  444  444 /Applications/BrowserOS.app/Contents/MacOS/BrowserOS --user-data-dir=/Users/me/Library/Application Support/BrowserOS
+  555  555 rg browseros-test-
+`
+
+	pids := browserProfilePIDsFromPS(output)
+
+	if len(pids) != 3 || pids[0] != 111 || pids[1] != 222 || pids[2] != 333 {
+		t.Fatalf("expected dev/test browser pids, got %#v", pids)
+	}
+}
+
 func TestAcquireWatchRunLockWritesStateAndReleases(t *testing.T) {
 	baseDir := t.TempDir()
 	identity := WatchRunIdentity{


### PR DESCRIPTION
**Summary**
- Add `bun run dev:cleanup` for safe daily cleanup of stale dev watch supervisors, BrowserOS dev/test profile processes, ports, and temp profiles.
- Add `bun run dev:reset` as a guided, colored reset flow for Lima VM/OpenClaw state, full `~/.browseros-dev` deletion, and legacy Podman machine cleanup.
- Remove the unused root `clean` script and direct `rimraf` dependency while keeping `test:cleanup` noninteractive via `cleanup --quick --yes`.

**Design**
The dev CLI now separates non-destructive cleanup from destructive reset. `cleanup` explains its limited scope and only touches transient dev/test processes, ports, and temp profiles. `reset` walks through escalating actions with concise yes/no prompts, typed confirmation for deleting the dev profile, Lima `LIMA_HOME` scoping, `limactl shell --workdir /` for guest commands, and a clearly labeled legacy Podman section for older VM state.

**Test plan**
- `go test ./...` from `packages/browseros-agent/tools/dev`
- `bun install --frozen-lockfile`
- `bun run dev:cleanup --help`
- `bun run dev:reset --help`
- Manual smoke test of `dev:cleanup` and `dev:reset` prompts, including Lima/OpenClaw reset and legacy Podman detection
