### PR TITLE
chore: add internal-docs submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule ".internal-docs"]
+	path = .internal-docs
+	url = git@github.com:browseros-ai/internal-docs.git
+	branch = main


### PR DESCRIPTION
## Summary

Activates the internal-docs system that landed in #894 by adding the submodule pointer.

- Mounts `browseros-ai/internal-docs` at `.internal-docs/`, tracking `main`.
- Submodule URL is SSH; HTTPS-token override documented in PR #894 for users without SSH.

## Effect

After this lands:

- `/document-internal` and `/ask-internal` skills become functional for team members who have run `git submodule update --init .internal-docs`.
- `.github/workflows/sync-internal-docs.yml` (added in #894) starts doing real work on its 4-hourly cron — it currently skips because of its `.gitmodules` guard.

## Remaining manual prereqs (NOT in this PR)

The sync workflow will fail every 4 hours until these are done:

1. Create the `browseros-bot` GitHub account (or reuse) — grant write to `browseros-ai/BrowserOS`, read to `browseros-ai/internal-docs`.
2. Generate a fine-grained PAT for the bot. Add as `INTERNAL_DOCS_SYNC_TOKEN` in OSS repo Actions secrets.
3. Mark the bot as a bypass actor on the `dev` branch protection ruleset (so it can push the chore commit directly without going through PR review).
4. Send the team this snippet (Slack `#engineering` pinned message):
   ```
   # Run once after pulling latest dev:
   git submodule update --init .internal-docs
   ```

## Test plan

- [ ] After landing, run the sync workflow manually via `workflow_dispatch` once the bot is set up. Verify it either reports "No internal-docs changes to sync." (if `internal-docs/main` hasn't moved) or pushes a chore commit cleanly.
- [ ] Run `/document-internal` from a feature branch — verify it can clone internal-docs, draft a 1-pager, and open a PR back.
- [ ] Run `/ask-internal "<some question>"` — verify it greps internal-docs + code and synthesizes an answer.
- [ ] OSS contributor (no internal-docs access) clones BrowserOS — verify no error.