### PR TITLE
fix(ci): restore PAT on actions/checkout for submodule fetch

### DIFF
--- a/.github/workflows/sync-internal-docs.yml
+++ b/.github/workflows/sync-internal-docs.yml
@@ -21,6 +21,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
+          token: ${{ secrets.INTERNAL_DOCS_SYNC_TOKEN }}
           submodules: true
           ref: dev
           fetch-depth: 50


### PR DESCRIPTION
## Summary
PR #897 dropped the explicit token on `actions/checkout`, which made it fall back to `GITHUB_TOKEN`. That token has no access to the private `internal-docs` repo, so the submodule clone failed with `repository 'https://github.com/browseros-ai/internal-docs.git/' not found`.

This restores `token: \${{ secrets.INTERNAL_DOCS_SYNC_TOKEN }}` on the checkout step.

## Why this still keeps the small-blast-radius shape
- PR ops (`gh pr create`, `gh pr merge`) keep using `GITHUB_TOKEN` via the `GH_TOKEN` env var on the run step.
- Only the git push of the bot branch uses the PAT (via the credential helper that checkout sets up). The PAT has Contents: Read and write, so the push works.
- The PAT does NOT need `Pull requests: Read and write` because PR ops go through `gh` with `GITHUB_TOKEN`.

## Test plan
- [ ] After merge, trigger `workflow_dispatch` on `Sync internal-docs submodule`. Expect: clone succeeds, "No internal-docs changes to sync." (the submodule pointer matches dev).