### PR TITLE
fix(newtab): prevent null/chat navigation when search message is empty

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/newtab/index/NewTab.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/newtab/index/NewTab.tsx
@@ -306,13 +306,19 @@ export const NewTab = () => {
       const selectedItem = flatItems[highlightedIndex]
       runSelectedAction(selectedItem)
     } else {
-      executeDefaultAction()
+      // FIX: Only execute default action if inputValue has content
+      if (inputValue && inputValue.trim() !== '') {
+        executeDefaultAction()
+      }
     }
   }
 
   const executeDefaultAction = () => {
     const selectedItem = flatItems[0]
-    runSelectedAction(selectedItem)
+    // FIX: Only run action if selectedItem exists
+    if (selectedItem) {
+      runSelectedAction(selectedItem)
+    }
   }
 
   const startInlineChat = (
@@ -320,6 +326,12 @@ export const NewTab = () => {
     chatMode: 'chat' | 'agent',
     aiTab?: { name: string; description: string },
   ) => {
+    // FIX: Validate message is not null/undefined/empty
+    if (!message || message.trim() === '') {
+      console.warn('startInlineChat: message is empty, using default')
+      message = 'Help'
+    }
+    
     track(NEWTAB_CHAT_STARTED_EVENT, {
       mode: chatMode,
       tabs_count: selectedTabs.length,
@@ -329,7 +341,8 @@ export const NewTab = () => {
       .filter((id): id is number => id !== undefined)
     reset()
     setSelectedTabs([])
-    const params = new URLSearchParams({ q: message, mode: chatMode })
+    // FIX: Ensure message is a valid string for URLSearchParams
+    const params = new URLSearchParams({ q: String(message), mode: chatMode })
     if (tabIds.length > 0) {
       params.set('tabs', tabIds.join(','))
     }
@@ -386,6 +399,11 @@ export const NewTab = () => {
           mode: item.mode,
           tabs_count: selectedTabs.length,
         })
+        // FIX: Validate item.message before using it
+        if (!item.message) {
+          console.warn('runSelectedAction: browseros item has no message')
+          return
+        }
         if (supportsInlineChat) {
           startInlineChat(item.message, item.mode)
         } else {


### PR DESCRIPTION
When the search field on the new tab page is submitted with an empty or null message, URLSearchParams coerces null to the string 'null', causing navigation to /null/chat and a ERR_FILE_NOT_FOUND error.

Add validation in 4 locations:
- startInlineChat(): guard against null/empty messages
- handleSend(): only execute default action when inputValue has content
- executeDefaultAction(): only run action if selectedItem exists
- runSelectedAction(): validate browseros item has a message before use

Fixes #775