### PR TITLE
fix(agents): hide BrowserOS ACP envelope from chat history payloads (TKT-774)

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
@@ -311,17 +311,49 @@ export class ChatService {
       contextChanges.length > 0
         ? `${contextChanges.map((c) => `[Context: ${c}]`).join('\n')}\n\n`
         : ''
-    session.agent.appendUserMessage(contextPrefix + userContent)
+
+    // Persist the *raw* user text in session.agent.messages so it
+    // round-trips clean to the client's useChat state and to any
+    // future history reload. The wrapped form (browser context +
+    // <selected_text> + <USER_QUERY>) is built as a transient prompt
+    // copy below — the LLM sees it, the user-visible state never
+    // does.
+    session.agent.appendUserMessage(request.message)
+    const promptUserText = contextPrefix + userContent
+    const wrappedUserMessageId =
+      session.agent.messages[session.agent.messages.length - 1]?.id
+
+    const promptUiMessages = filterValidMessages(session.agent.messages).map(
+      (msg) =>
+        msg.id === wrappedUserMessageId && msg.role === 'user'
+          ? {
+              ...msg,
+              parts: [{ type: 'text' as const, text: promptUserText }],
+            }
+          : msg,
+    )
 
     return createAgentUIStreamResponse({
       agent: session.agent.toolLoopAgent,
-      uiMessages: filterValidMessages(session.agent.messages),
+      uiMessages: promptUiMessages,
       abortSignal,
       onFinish: async ({ messages }: { messages: UIMessage[] }) => {
-        session.agent.messages = filterValidMessages(messages)
+        // The agent loop returns `messages` containing the prompt-
+        // wrapped user text. Restore the raw form before persisting
+        // so subsequent turns see the clean text and the client's
+        // local UIMessage matches what was originally typed.
+        const restored = messages.map((msg) =>
+          msg.id === wrappedUserMessageId && msg.role === 'user'
+            ? {
+                ...msg,
+                parts: [{ type: 'text' as const, text: request.message }],
+              }
+            : msg,
+        )
+        session.agent.messages = filterValidMessages(restored)
         logger.info('Agent execution complete', {
           conversationId: request.conversationId,
-          totalMessages: messages.length,
+          totalMessages: restored.length,
         })
 
         if (session?.hiddenPageId) {

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
@@ -588,11 +588,18 @@ export function unwrapBrowserosAcpUserMessage(raw: string): string {
   if (!raw) return raw
   let text = raw
 
+  // Order matters: the outer envelope is added AFTER
+  // `escapePromptTagText` runs over the inner formatUserMessage
+  // payload (see buildBrowserosAcpPrompt). So once the outer
+  // <role>…</role>+<user_request>…</user_request> tags are stripped,
+  // the inner content is still entity-escaped (`&lt;USER_QUERY&gt;`
+  // not `<USER_QUERY>`). We decode entities BEFORE the inner-envelope
+  // strips so their anchors actually match.
   text = stripOuterRoleEnvelope(text)
+  text = decodeBasicEntities(text)
   text = stripBrowserContextHeader(text)
   text = stripSelectedTextBlock(text)
   text = unwrapUserQuery(text)
-  text = decodeBasicEntities(text)
 
   return text.trim()
 }

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
@@ -558,13 +558,46 @@ function mapToolUseToHistoryToolCall(
 }
 
 function userContentToText(content: AcpxUserContent): string {
-  if ('Text' in content) return unwrapBrowserosAcpPrompt(content.Text)
+  if ('Text' in content) return unwrapBrowserosAcpUserMessage(content.Text)
   if ('Mention' in content) return content.Mention.content
   if ('Image' in content) return content.Image.source ? '[image]' : ''
   return ''
 }
 
-function unwrapBrowserosAcpPrompt(value: string): string {
+/**
+ * Strip the BrowserOS ACP envelopes from a user-message text so HTTP
+ * consumers (history endpoint, listing's `lastUserMessage`) see only
+ * the user's actual question. Two layers are added on the wire today:
+ *
+ *   1. <role>…</role>\n\n<user_request>…</user_request> from
+ *      `buildBrowserosAcpPrompt` (outer).
+ *   2. ## Browser Context + <selected_text> + <USER_QUERY> from
+ *      `apps/server/src/agent/format-message.ts` (inner).
+ *
+ * Each step is independently defensive — anchors that don't match are
+ * skipped — so partially-wrapped text (older persisted records,
+ * messages without a selection, future schema drift) gets best-
+ * effort cleaning without throwing. The function is idempotent;
+ * applying it to already-clean text is a no-op.
+ *
+ * TODO: drop this once acpx/runtime exposes a real system-prompt
+ * surface so we can stop persisting the role block on every user
+ * message. Tracked in the server architecture audit.
+ */
+export function unwrapBrowserosAcpUserMessage(raw: string): string {
+  if (!raw) return raw
+  let text = raw
+
+  text = stripOuterRoleEnvelope(text)
+  text = stripBrowserContextHeader(text)
+  text = stripSelectedTextBlock(text)
+  text = unwrapUserQuery(text)
+  text = decodeBasicEntities(text)
+
+  return text.trim()
+}
+
+function stripOuterRoleEnvelope(value: string): string {
   const prefix = `${BROWSEROS_ACP_AGENT_INSTRUCTIONS}
 
 <user_request>
@@ -572,12 +605,41 @@ function unwrapBrowserosAcpPrompt(value: string): string {
   const suffix = `
 </user_request>`
   if (!value.startsWith(prefix) || !value.endsWith(suffix)) return value
-
-  // TODO: nikhil: remove this once acpx/runtime exposes system prompt support.
-  return unescapePromptTagText(value.slice(prefix.length, -suffix.length))
+  return value.slice(prefix.length, -suffix.length)
 }
 
-function unescapePromptTagText(value: string): string {
+function stripBrowserContextHeader(value: string): string {
+  // The `## Browser Context` block (when present) ends with the
+  // `\n\n---\n\n` separator emitted by `formatBrowserContext`.
+  // Anchored at the start of the string; non-greedy match through
+  // the body; one removal.
+  const match = value.match(/^## Browser Context\n[\s\S]*?\n\n---\n\n/)
+  return match ? value.slice(match[0].length) : value
+}
+
+function stripSelectedTextBlock(value: string): string {
+  // Optional `<selected_text [attrs]>…</selected_text>\n\n` block
+  // emitted by `formatUserMessage` when the user has a selection.
+  return value.replace(
+    /<selected_text(?:[^>]*)>\n[\s\S]*?\n<\/selected_text>\n\n/,
+    '',
+  )
+}
+
+function unwrapUserQuery(value: string): string {
+  // `formatUserMessage` always wraps the user's typed text in
+  // `<USER_QUERY>\n…\n</USER_QUERY>` — even when no browser context
+  // or selection is present.
+  const match = value.match(/^<USER_QUERY>\n([\s\S]*?)\n<\/USER_QUERY>$/)
+  return match ? match[1] : value
+}
+
+function decodeBasicEntities(value: string): string {
+  // Reverse the three escapes the server applied via
+  // `escapePromptTagText` so user-typed XML-like content (e.g.
+  // `<USER_QUERY>` typed literally) renders as the user typed it.
+  // Decode `&amp;` last to avoid double-decoding sequences like
+  // `&amp;lt;` → `&lt;` → `<`.
   return value
     .replace(/&lt;/g, '<')
     .replace(/&gt;/g, '>')

--- a/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
@@ -298,7 +298,9 @@ describe('ChatService Klavis session rebuilds', () => {
     const firstAgent = createFakeAgent()
     const secondAgent = createFakeAgent()
     agentToReturn = firstAgent
+    let lastPromptUiMessages: MockMessage[] | undefined
     streamResponseHandler = async ({ onFinish, uiMessages }) => {
+      lastPromptUiMessages = uiMessages
       await onFinish({ messages: uiMessages ?? [] })
       return new Response('ok')
     }
@@ -348,13 +350,24 @@ describe('ChatService Klavis session rebuilds', () => {
 
     expect(createAgentSpy.mock.calls.length - createCallsBefore).toBe(2)
     expect(firstAgent.dispose).toHaveBeenCalledTimes(1)
+
+    // Persisted form stays the raw user text — TKT-774. The Klavis
+    // context-change notice and the formatted user envelope go only
+    // into the transient prompt copy fed to the LLM.
     expect(secondAgent.messages).toHaveLength(2)
-    const rebuiltMessage = secondAgent.messages[1]?.parts[0]?.text ?? ''
-    expect(rebuiltMessage).toContain(
+    const persistedRebuiltMessage =
+      secondAgent.messages[1]?.parts[0]?.text ?? ''
+    expect(persistedRebuiltMessage).toBe('check integrations again')
+
+    // Prompt copy (what the agent loop actually saw) carries the
+    // context-change prefix so the model knows about the new tools.
+    const promptRebuiltMessage =
+      lastPromptUiMessages?.at(-1)?.parts[0]?.text ?? ''
+    expect(promptRebuiltMessage).toContain(
       'Klavis app integration tools are now available for the following connected apps: slack.',
     )
-    expect(rebuiltMessage).not.toContain('klavis:pending')
-    expect(rebuiltMessage).not.toContain('klavis:connected')
+    expect(promptRebuiltMessage).not.toContain('klavis:pending')
+    expect(promptRebuiltMessage).not.toContain('klavis:connected')
   })
 
   it('does not rebuild a session with no enabled managed apps when Klavis connects', async () => {

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -15,7 +15,11 @@ import type {
   AcpRuntime as AcpxCoreRuntime,
 } from 'acpx/runtime'
 import { createRuntimeStore } from 'acpx/runtime'
-import { AcpxRuntime } from '../../../src/lib/agents/acpx-runtime'
+import { formatUserMessage } from '../../../src/agent/format-message'
+import {
+  AcpxRuntime,
+  unwrapBrowserosAcpUserMessage,
+} from '../../../src/lib/agents/acpx-runtime'
 import type { AgentDefinition } from '../../../src/lib/agents/agent-types'
 import type { AgentStreamEvent } from '../../../src/lib/agents/types'
 
@@ -303,6 +307,230 @@ open &lt;example.com&gt;
         createdAt: Date.parse(timestamp),
       },
     ])
+  })
+
+  it('strips the inner formatUserMessage envelope from history payloads', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'browseros-acpx-runtime-'))
+    const stateDir = await mkdtemp(join(tmpdir(), 'browseros-acpx-state-'))
+    tempDirs.push(cwd, stateDir)
+    const timestamp = '2026-04-29T20:00:00.000Z'
+    const agent: AgentDefinition = {
+      id: 'agent-1',
+      name: 'Browser bot',
+      adapter: 'codex',
+      permissionMode: 'approve-all',
+      sessionKey: 'agent:agent-1:main',
+      createdAt: 1000,
+      updatedAt: 1000,
+    }
+    // Wrapped form persisted to the session record: outer
+    // <role>…</role>\n\n<user_request>…</user_request> from
+    // buildBrowserosAcpPrompt + inner ## Browser Context +
+    // <selected_text> + <USER_QUERY> from formatUserMessage.
+    const wrapped = `<role>
+You are BrowserOS - a browser agent with full control of a Chromium browser through the BrowserOS MCP server.
+
+Use the BrowserOS MCP server for all browser tasks, including browsing the web, interacting with pages, inspecting browser state, and managing tabs, windows, bookmarks, and history.
+</role>
+
+<user_request>
+## Browser Context
+**Active Tab:** Tab 1 (Page ID: 101) - "Example" (https://example.com)
+
+---
+
+<selected_text (from "Example" — https://example.com)>
+quoted selection
+</selected_text>
+
+<USER_QUERY>
+summarise this
+</USER_QUERY>
+</user_request>`
+    const record: AcpSessionRecord = {
+      schema: 'acpx.session.v1',
+      acpxRecordId: agent.sessionKey,
+      acpSessionId: 'sid-1',
+      agentSessionId: 'inner-1',
+      agentCommand: 'codex --acp',
+      cwd,
+      name: agent.sessionKey,
+      createdAt: timestamp,
+      lastUsedAt: timestamp,
+      lastSeq: 0,
+      eventLog: {
+        active_path: '',
+        segment_count: 0,
+        max_segment_bytes: 0,
+        max_segments: 0,
+      },
+      closed: false,
+      messages: [
+        {
+          User: {
+            id: 'user-1',
+            content: [{ Text: wrapped }],
+          },
+        },
+      ],
+      updated_at: timestamp,
+      cumulative_token_usage: {},
+      request_token_usage: {},
+      acpx: {},
+    }
+    await createRuntimeStore({ stateDir }).save(record)
+
+    const history = await new AcpxRuntime({ cwd, stateDir }).getHistory({
+      agent,
+      sessionId: 'main',
+    })
+
+    expect(history.items[0]?.text).toBe('summarise this')
+  })
+
+  describe('unwrapBrowserosAcpUserMessage', () => {
+    it('returns clean text for input that has no envelope', () => {
+      expect(unwrapBrowserosAcpUserMessage('hello')).toBe('hello')
+    })
+
+    it('handles empty input', () => {
+      expect(unwrapBrowserosAcpUserMessage('')).toBe('')
+    })
+
+    it('strips a fully wrapped message and decodes escapes', () => {
+      const wrapped = `<role>
+You are BrowserOS - a browser agent with full control of a Chromium browser through the BrowserOS MCP server.
+
+Use the BrowserOS MCP server for all browser tasks, including browsing the web, interacting with pages, inspecting browser state, and managing tabs, windows, bookmarks, and history.
+</role>
+
+<user_request>
+## Browser Context
+**Active Tab:** Tab 1 (Page ID: 101) - "Example" (https://example.com)
+
+---
+
+<USER_QUERY>
+look at &lt;example&gt;
+</USER_QUERY>
+</user_request>`
+      expect(unwrapBrowserosAcpUserMessage(wrapped)).toBe('look at <example>')
+    })
+
+    it('strips the inner envelope when only the inner wrapper is present', () => {
+      const innerOnly = `## Browser Context
+**Active Tab:** Tab 1
+
+---
+
+<USER_QUERY>
+just inner
+</USER_QUERY>`
+      expect(unwrapBrowserosAcpUserMessage(innerOnly)).toBe('just inner')
+    })
+
+    it('strips the outer envelope when only the outer wrapper is present', () => {
+      const outerOnly = `<role>
+You are BrowserOS - a browser agent with full control of a Chromium browser through the BrowserOS MCP server.
+
+Use the BrowserOS MCP server for all browser tasks, including browsing the web, interacting with pages, inspecting browser state, and managing tabs, windows, bookmarks, and history.
+</role>
+
+<user_request>
+just outer
+</user_request>`
+      expect(unwrapBrowserosAcpUserMessage(outerOnly)).toBe('just outer')
+    })
+
+    it('removes a selected_text block with attribute string', () => {
+      const wrapped = `<role>
+You are BrowserOS - a browser agent with full control of a Chromium browser through the BrowserOS MCP server.
+
+Use the BrowserOS MCP server for all browser tasks, including browsing the web, interacting with pages, inspecting browser state, and managing tabs, windows, bookmarks, and history.
+</role>
+
+<user_request>
+<selected_text (from "Title" — https://example.com)>
+selection body
+</selected_text>
+
+<USER_QUERY>
+question with selection
+</USER_QUERY>
+</user_request>`
+      expect(unwrapBrowserosAcpUserMessage(wrapped)).toBe(
+        'question with selection',
+      )
+    })
+
+    it('is idempotent — applying twice equals applying once', () => {
+      const wrapped = `<role>
+You are BrowserOS - a browser agent with full control of a Chromium browser through the BrowserOS MCP server.
+
+Use the BrowserOS MCP server for all browser tasks, including browsing the web, interacting with pages, inspecting browser state, and managing tabs, windows, bookmarks, and history.
+</role>
+
+<user_request>
+## Browser Context
+ctx
+
+---
+
+<USER_QUERY>
+hello
+</USER_QUERY>
+</user_request>`
+      const once = unwrapBrowserosAcpUserMessage(wrapped)
+      const twice = unwrapBrowserosAcpUserMessage(once)
+      expect(twice).toBe(once)
+      expect(twice).toBe('hello')
+    })
+
+    it('round-trips formatUserMessage output back to the user typed text', () => {
+      const userText = 'fix the OAuth redirect after login'
+      const formatted = formatUserMessage(userText, {
+        activeTab: {
+          id: 1,
+          url: 'https://example.com',
+          title: 'Example',
+        },
+      })
+      // Mirror what acpx-runtime.ts's buildBrowserosAcpPrompt does on
+      // the wire: wrap with <role>…</role> + <user_request>…</user_request>.
+      // Constants are duplicated here so the test pins the exact
+      // serialised shape rather than the helper that produces it.
+      const ROLE = `<role>
+You are BrowserOS - a browser agent with full control of a Chromium browser through the BrowserOS MCP server.
+
+Use the BrowserOS MCP server for all browser tasks, including browsing the web, interacting with pages, inspecting browser state, and managing tabs, windows, bookmarks, and history.
+</role>`
+      const wrapped = `${ROLE}
+
+<user_request>
+${formatted}
+</user_request>`
+      expect(unwrapBrowserosAcpUserMessage(wrapped)).toBe(userText)
+    })
+
+    it('preserves user-typed angle-brackets via the entity decode', () => {
+      // Server escapes `<` `>` `&` inside the user text via
+      // `escapePromptTagText` to keep the wire serialisation
+      // parseable. The unwrap reverses those escapes.
+      const wrapped = `<role>
+You are BrowserOS - a browser agent with full control of a Chromium browser through the BrowserOS MCP server.
+
+Use the BrowserOS MCP server for all browser tasks, including browsing the web, interacting with pages, inspecting browser state, and managing tabs, windows, bookmarks, and history.
+</role>
+
+<user_request>
+<USER_QUERY>
+the user typed &lt;USER_QUERY&gt;foo&lt;/USER_QUERY&gt; literally
+</USER_QUERY>
+</user_request>`
+      expect(unwrapBrowserosAcpUserMessage(wrapped)).toBe(
+        'the user typed <USER_QUERY>foo</USER_QUERY> literally',
+      )
+    })
   })
 
   it('continues the turn when runtime config control is unavailable', async () => {

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -323,10 +323,11 @@ open &lt;example.com&gt;
       createdAt: 1000,
       updatedAt: 1000,
     }
-    // Wrapped form persisted to the session record: outer
-    // <role>…</role>\n\n<user_request>…</user_request> from
-    // buildBrowserosAcpPrompt + inner ## Browser Context +
-    // <selected_text> + <USER_QUERY> from formatUserMessage.
+    // Wrapped form persisted to the session record. Note that the
+    // inner formatUserMessage envelope's tags (`<selected_text>`,
+    // `<USER_QUERY>`) are escaped to `&lt;…&gt;` because
+    // `buildBrowserosAcpPrompt` runs `escapePromptTagText` over the
+    // entire payload before adding the outer envelope.
     const wrapped = `<role>
 You are BrowserOS - a browser agent with full control of a Chromium browser through the BrowserOS MCP server.
 
@@ -339,13 +340,13 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
 
 ---
 
-<selected_text (from "Example" — https://example.com)>
+&lt;selected_text (from "Example" — https://example.com)&gt;
 quoted selection
-</selected_text>
+&lt;/selected_text&gt;
 
-<USER_QUERY>
+&lt;USER_QUERY&gt;
 summarise this
-</USER_QUERY>
+&lt;/USER_QUERY&gt;
 </user_request>`
     const record: AcpSessionRecord = {
       schema: 'acpx.session.v1',
@@ -398,6 +399,8 @@ summarise this
     })
 
     it('strips a fully wrapped message and decodes escapes', () => {
+      // On-wire form: `escapePromptTagText` escapes the inner tags
+      // before the outer envelope is added.
       const wrapped = `<role>
 You are BrowserOS - a browser agent with full control of a Chromium browser through the BrowserOS MCP server.
 
@@ -410,14 +413,17 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
 
 ---
 
-<USER_QUERY>
-look at &lt;example&gt;
-</USER_QUERY>
+&lt;USER_QUERY&gt;
+look at example
+&lt;/USER_QUERY&gt;
 </user_request>`
-      expect(unwrapBrowserosAcpUserMessage(wrapped)).toBe('look at <example>')
+      expect(unwrapBrowserosAcpUserMessage(wrapped)).toBe('look at example')
     })
 
     it('strips the inner envelope when only the inner wrapper is present', () => {
+      // Plain (un-escaped) inner-envelope-only input — covers the
+      // hypothetical case where some future code path stores the
+      // unwrapped-outer form directly.
       const innerOnly = `## Browser Context
 **Active Tab:** Tab 1
 
@@ -450,13 +456,13 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
 </role>
 
 <user_request>
-<selected_text (from "Title" — https://example.com)>
+&lt;selected_text (from "Title" — https://example.com)&gt;
 selection body
-</selected_text>
+&lt;/selected_text&gt;
 
-<USER_QUERY>
+&lt;USER_QUERY&gt;
 question with selection
-</USER_QUERY>
+&lt;/USER_QUERY&gt;
 </user_request>`
       expect(unwrapBrowserosAcpUserMessage(wrapped)).toBe(
         'question with selection',
@@ -476,9 +482,9 @@ ctx
 
 ---
 
-<USER_QUERY>
+&lt;USER_QUERY&gt;
 hello
-</USER_QUERY>
+&lt;/USER_QUERY&gt;
 </user_request>`
       const once = unwrapBrowserosAcpUserMessage(wrapped)
       const twice = unwrapBrowserosAcpUserMessage(once)
@@ -495,10 +501,14 @@ hello
           title: 'Example',
         },
       })
-      // Mirror what acpx-runtime.ts's buildBrowserosAcpPrompt does on
-      // the wire: wrap with <role>…</role> + <user_request>…</user_request>.
-      // Constants are duplicated here so the test pins the exact
-      // serialised shape rather than the helper that produces it.
+      // Mirror what acpx-runtime.ts's buildBrowserosAcpPrompt does
+      // on the wire: escape the inner payload (so its tags survive
+      // round-trip serialisation) and then wrap with <role>…</role>
+      // + <user_request>…</user_request>. Constants/escape rules
+      // are duplicated here so the test pins the exact serialised
+      // shape rather than the helpers that produce it.
+      const escapeForPrompt = (value: string) =>
+        value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;')
       const ROLE = `<role>
 You are BrowserOS - a browser agent with full control of a Chromium browser through the BrowserOS MCP server.
 
@@ -507,15 +517,17 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
       const wrapped = `${ROLE}
 
 <user_request>
-${formatted}
+${escapeForPrompt(formatted)}
 </user_request>`
       expect(unwrapBrowserosAcpUserMessage(wrapped)).toBe(userText)
     })
 
     it('preserves user-typed angle-brackets via the entity decode', () => {
-      // Server escapes `<` `>` `&` inside the user text via
-      // `escapePromptTagText` to keep the wire serialisation
-      // parseable. The unwrap reverses those escapes.
+      // `escapePromptTagText` escapes every `<` and `>` in the
+      // payload — including the inner envelope's own tags AND any
+      // user-typed tag-like content. The on-wire form below is what
+      // a user typing `<USER_QUERY>foo</USER_QUERY>` literally
+      // produces after formatUserMessage + buildBrowserosAcpPrompt.
       const wrapped = `<role>
 You are BrowserOS - a browser agent with full control of a Chromium browser through the BrowserOS MCP server.
 
@@ -523,12 +535,12 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
 </role>
 
 <user_request>
-<USER_QUERY>
-the user typed &lt;USER_QUERY&gt;foo&lt;/USER_QUERY&gt; literally
-</USER_QUERY>
+&lt;USER_QUERY&gt;
+&lt;USER_QUERY&gt;foo&lt;/USER_QUERY&gt;
+&lt;/USER_QUERY&gt;
 </user_request>`
       expect(unwrapBrowserosAcpUserMessage(wrapped)).toBe(
-        'the user typed <USER_QUERY>foo</USER_QUERY> literally',
+        '<USER_QUERY>foo</USER_QUERY>',
       )
     })
   })


### PR DESCRIPTION
## Summary

The user-message text persisted on the wire carried two nested envelopes — the outer \`<role>You are BrowserOS…</role>\` + \`<user_request>…</user_request>\` block from the ACP prompt builder, and the inner \`## Browser Context\` + \`<selected_text>\` + \`<USER_QUERY>\` block from the user-message formatter. A prior fix unwrapped only the outer envelope on history reads, so the user bubble in the agent rail still rendered the inner envelope, and the LLM chat-service path leaked the wrapper all the way back to the sidepanel client through AI SDK's stream sync — the symptom was a user bubble like \`<USER_QUERY> how's the day today… </USER_QUERY>\` in the sidepanel.

Two surgical fixes, both server-only:

1. **ACP path** — replace the existing \`unwrapBrowserosAcpPrompt\` helper with a comprehensive \`unwrapBrowserosAcpUserMessage\` that strips both layers and decodes the \`&lt;\`/\`&gt;\`/\`&amp;\` escapes the prompt builder applies. Each step is independently defensive (anchors that don't match are skipped) so the helper is idempotent and tolerates partial / older / future-shape envelopes. Applied at the message-mapper used by both \`GET /agents/:id/sessions/main/history\` and the listing's \`lastUserMessage\` field, so every consumer of the harness's HTTP API automatically sees clean text without having to re-implement the strip.

2. **LLM \`/chat\` path** — split the persisted user message from the prompt-time copy. The agent's session-stored user message is now the **raw** user text; a transient prompt copy with the wrapped form (browser context + \`<selected_text>\` + \`<USER_QUERY>\` + any mid-conversation context-change notice) is built only for the model call. \`onFinish\` restores the raw form before persisting, so the user-visible message and any future history reads see only the user's typed text.

### Why server-side, not client-side

- One source of truth — the envelope is a transport artifact added by the prompt builders. Returning it through the API leaks implementation detail across a documented HTTP boundary; every external client (admin tools, scheduled-task previews, future surfaces) would otherwise have to re-implement the same strip.
- \`lastUserMessage\` is already server-derived; fixing it once at the source covers every surface that consumes it.
- Matches the prior fix's pattern (unwrap is already in the message mapper) — natural extension rather than a parallel client-side helper.
- The agent app's local state doesn't actually hold wrapped text in steady state; whatever shows up wrong in the UI traces back to a server-stamped path.

## Test plan

- [x] Server typecheck clean.
- [x] Server lib suite: 122/122 pass (includes the new \`unwrapBrowserosAcpUserMessage\` test set: full-wrap, only-outer, only-inner, selected_text-with-attribute-string, idempotency, literal-tag round-trip, plus an integration test that round-trips the real \`formatUserMessage\` output — pins the writer/reader contract end-to-end).
- [x] Server api suite: 161/161 pass (existing \`ChatService Klavis session rebuilds\` test updated to match the new behaviour: persisted user message is the raw text, prompt copy passed to the agent carries the context-change notice).
- [ ] Manual: hit \`GET /agents/:id/sessions/main/history\` for an agent with prior turns; confirm user-message \`text\` fields contain only the user's typed question (no \`<role>\`, no \`<USER_QUERY>\`, no \`## Browser Context\`).
- [ ] Manual: send a message in the sidepanel against a BrowserOS LLM provider; confirm the user bubble renders the typed text, not the wrapped form.
- [ ] Manual: open the agent rail at \`/agents/:id\` for a session that previously stored wrapped messages; confirm the chat history shows clean user-side text.

## Notes

- The architectural follow-up (move BrowserOS instructions into a real ACP system-prompt + send browser context as a structured attachment) is out of scope here — this is the read-side fix while the long-term refactor is pending.
- The agent rail's existing client-side \`<USER_QUERY>\` skip in \`firstNonBlankLine\` becomes dead defence-in-depth after this lands; recommend leaving it (two lines, idempotent against clean text, gives a margin if a future envelope variant slips past).