### PR TITLE
feat(agent): rich rail + header on /agents/:agentId chat

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
@@ -136,7 +136,7 @@ function AgentConversationController({
   }
 
   return (
-    <div className="flex min-h-0 flex-col overflow-hidden">
+    <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
       <ClawChat
         agentName={agentName}
         historyMessages={historyMessages}
@@ -296,7 +296,7 @@ export const AgentCommandConversation: FC<AgentCommandConversationProps> = ({
           onGoHome={() => navigate(backPath)}
         />
 
-        <div className="flex min-h-0 flex-col overflow-hidden">
+        <div className="flex h-full min-h-0 flex-col overflow-hidden">
           <ConversationHeader
             agent={harnessAgent ?? null}
             fallbackName={fallbackName}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
@@ -292,7 +292,7 @@ export const AgentCommandConversation: FC<AgentCommandConversationProps> = ({
         {/* Shared top band — the rail's "Agents" header and the chat
             header live on one row so they're aligned by construction. */}
         <div className="flex shrink-0 items-stretch border-border/50 border-b">
-          <div className="hidden w-[288px] shrink-0 items-center gap-3 border-border/50 border-r px-4 lg:flex">
+          <div className="hidden min-h-[84px] w-[288px] shrink-0 items-center gap-3 border-border/50 border-r px-4 lg:flex">
             <Button
               variant="ghost"
               size="icon"

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
@@ -1,5 +1,7 @@
+import { ArrowLeft } from 'lucide-react'
 import { type FC, useEffect, useMemo, useRef } from 'react'
 import { Navigate, useNavigate, useParams, useSearchParams } from 'react-router'
+import { Button } from '@/components/ui/button'
 import type {
   HarnessAgent,
   HarnessAgentAdapter,
@@ -286,39 +288,64 @@ export const AgentCommandConversation: FC<AgentCommandConversationProps> = ({
 
   return (
     <div className="absolute inset-0 overflow-hidden bg-background md:pl-[theme(spacing.14)]">
-      <div className="mx-auto grid h-full w-full max-w-[1480px] grid-rows-[minmax(0,1fr)] lg:grid-cols-[288px_minmax(0,1fr)]">
-        <AgentRail
-          agents={harnessAgents}
-          adapters={adapters}
-          activeAgentId={resolvedAgentId}
-          onSelectAgent={handleSelectHarnessAgent}
-          onPinToggle={(target, next) => handlePinToggle(target, next)}
-          onGoHome={() => navigate(backPath)}
-        />
+      <div className="mx-auto flex h-full w-full max-w-[1480px] flex-col">
+        {/* Shared top band — the rail's "Agents" header and the chat
+            header live on one row so they're aligned by construction. */}
+        <div className="flex shrink-0 items-stretch border-border/50 border-b">
+          <div className="hidden w-[288px] shrink-0 items-center gap-3 border-border/50 border-r px-4 lg:flex">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => navigate(backPath)}
+              className="size-8 rounded-xl"
+              title="Back to home"
+            >
+              <ArrowLeft className="size-4" />
+            </Button>
+            <div className="truncate font-semibold text-[15px] leading-5">
+              Agents
+            </div>
+          </div>
+          <div className="min-w-0 flex-1">
+            <ConversationHeader
+              agent={harnessAgent ?? null}
+              fallbackName={fallbackName}
+              fallbackAdapter={fallbackAdapter}
+              adapterHealth={adapterHealth}
+              backLabel={backLabel}
+              backTarget={isPageVariant ? 'page' : 'home'}
+              onGoHome={() => navigate(backPath)}
+              onPinToggle={(next) =>
+                handlePinToggle(harnessAgent ?? null, next)
+              }
+            />
+          </div>
+        </div>
 
-        <div className="flex h-full min-h-0 flex-col overflow-hidden">
-          <ConversationHeader
-            agent={harnessAgent ?? null}
-            fallbackName={fallbackName}
-            fallbackAdapter={fallbackAdapter}
-            adapterHealth={adapterHealth}
-            backLabel={backLabel}
-            backTarget={isPageVariant ? 'page' : 'home'}
-            onGoHome={() => navigate(backPath)}
-            onPinToggle={(next) => handlePinToggle(harnessAgent ?? null, next)}
+        {/* Body grid: rail list + chat. Both columns share the same
+            top edge (the band above) so headers can never drift. */}
+        <div className="grid min-h-0 flex-1 grid-rows-[minmax(0,1fr)] lg:grid-cols-[288px_minmax(0,1fr)]">
+          <AgentRail
+            agents={harnessAgents}
+            adapters={adapters}
+            activeAgentId={resolvedAgentId}
+            onSelectAgent={handleSelectHarnessAgent}
+            onPinToggle={(target, next) => handlePinToggle(target, next)}
           />
 
-          <AgentConversationController
-            key={resolvedAgentId}
-            agentId={resolvedAgentId}
-            agents={agents}
-            initialMessage={initialMessage}
-            onInitialMessageConsumed={() =>
-              setSearchParams({}, { replace: true })
-            }
-            agentPathPrefix={agentPathPrefix}
-            createAgentPath={createAgentPath}
-          />
+          <div className="flex h-full min-h-0 flex-col overflow-hidden">
+            <AgentConversationController
+              key={resolvedAgentId}
+              agentId={resolvedAgentId}
+              agents={agents}
+              initialMessage={initialMessage}
+              onInitialMessageConsumed={() =>
+                setSearchParams({}, { replace: true })
+              }
+              agentPathPrefix={agentPathPrefix}
+              createAgentPath={createAgentPath}
+            />
+          </div>
         </div>
       </div>
     </div>

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
@@ -286,7 +286,7 @@ export const AgentCommandConversation: FC<AgentCommandConversationProps> = ({
 
   return (
     <div className="absolute inset-0 overflow-hidden bg-background md:pl-[theme(spacing.14)]">
-      <div className="mx-auto grid h-full w-full max-w-[1480px] lg:grid-cols-[288px_minmax(0,1fr)]">
+      <div className="mx-auto grid h-full w-full max-w-[1480px] grid-rows-[minmax(0,1fr)] lg:grid-cols-[288px_minmax(0,1fr)]">
         <AgentRail
           agents={harnessAgents}
           adapters={adapters}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
@@ -1,20 +1,23 @@
-import { ArrowLeft, Bot, Home } from 'lucide-react'
 import { type FC, useEffect, useMemo, useRef } from 'react'
 import { Navigate, useNavigate, useParams, useSearchParams } from 'react-router'
-import { Button } from '@/components/ui/button'
+import type {
+  HarnessAgent,
+  HarnessAgentAdapter,
+} from '@/entrypoints/app/agents/agent-harness-types'
+import type { AgentAdapterHealth } from '@/entrypoints/app/agents/agent-row/agent-row.types'
 import {
   cancelHarnessTurn,
+  useAgentAdapters,
   useEnqueueHarnessMessage,
   useHarnessAgents,
   useRemoveHarnessQueuedMessage,
+  useUpdateHarnessAgent,
 } from '@/entrypoints/app/agents/useAgents'
-import {
-  type AgentEntry,
-  getModelDisplayName,
-} from '@/entrypoints/app/agents/useOpenClaw'
-import { cn } from '@/lib/utils'
+import type { AgentEntry } from '@/entrypoints/app/agents/useOpenClaw'
+import { AgentRail } from './AgentRail'
 import { useAgentCommandData } from './agent-command-layout'
 import { ClawChat } from './ClawChat'
+import { ConversationHeader } from './ConversationHeader'
 import { ConversationInput } from './ConversationInput'
 import {
   buildChatHistoryFromClawMessages,
@@ -24,162 +27,6 @@ import {
 import { QueuePanel } from './QueuePanel'
 import { useAgentConversation } from './useAgentConversation'
 import { useHarnessChatHistory } from './useHarnessChatHistory'
-
-function StatusBadge({ status }: { status: string }) {
-  return (
-    <div className="inline-flex items-center gap-2 rounded-full border border-border/60 bg-card px-3 py-1 text-[11px] text-muted-foreground uppercase tracking-[0.18em]">
-      <span
-        className={cn(
-          'size-1.5 rounded-full',
-          status === 'Working on your request'
-            ? 'bg-amber-500'
-            : status === 'Ready'
-              ? 'bg-emerald-500'
-              : status === 'Offline'
-                ? 'bg-muted-foreground/50'
-                : 'bg-[var(--accent-orange)]',
-        )}
-      />
-      <span>{status}</span>
-    </div>
-  )
-}
-
-function AgentIdentity({
-  name,
-  meta,
-  className,
-}: {
-  name: string
-  meta: string
-  className?: string
-}) {
-  return (
-    <div className={cn('min-w-0', className)}>
-      <div className="truncate font-semibold text-[15px] leading-5">{name}</div>
-      <div className="truncate text-muted-foreground text-xs leading-5">
-        {meta}
-      </div>
-    </div>
-  )
-}
-
-function ConversationHeader({
-  agentName,
-  agentMeta,
-  status,
-  backLabel,
-  backTarget,
-  onGoHome,
-}: {
-  agentName: string
-  agentMeta: string
-  status: string
-  backLabel: string
-  backTarget: 'home' | 'page'
-  onGoHome: () => void
-}) {
-  const BackIcon = backTarget === 'home' ? Home : ArrowLeft
-
-  return (
-    <div className="flex h-14 items-center justify-between gap-4 border-border/50 border-b px-5">
-      <div className="flex min-w-0 items-center gap-3">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onGoHome}
-          className="size-8 rounded-xl lg:hidden"
-          title={backLabel}
-        >
-          <BackIcon className="size-4" />
-        </Button>
-        <div className="flex size-8 shrink-0 items-center justify-center rounded-xl bg-muted text-muted-foreground">
-          <Bot className="size-4" />
-        </div>
-        <AgentIdentity name={agentName} meta={agentMeta} />
-      </div>
-
-      <StatusBadge status={status} />
-    </div>
-  )
-}
-
-function AgentRailHeader({ onGoHome }: { onGoHome: () => void }) {
-  return (
-    <div className="hidden h-14 items-center border-border/50 border-r border-b bg-background/70 px-4 lg:flex">
-      <div className="flex min-w-0 items-center gap-3">
-        <Button
-          variant="ghost"
-          size="icon"
-          onClick={onGoHome}
-          className="size-8 rounded-xl"
-          title="Back to home"
-        >
-          <ArrowLeft className="size-4" />
-        </Button>
-        <div className="truncate font-semibold text-[15px] leading-5">
-          Agents
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function AgentRailList({
-  activeAgentId,
-  agents,
-  onSelectAgent,
-}: {
-  activeAgentId: string
-  agents: AgentEntry[]
-  onSelectAgent: (entry: AgentEntry) => void
-}) {
-  return (
-    <aside className="hidden min-h-0 flex-col border-border/50 border-r bg-background/70 lg:flex">
-      <div className="styled-scrollbar min-h-0 flex-1 space-y-2 overflow-y-auto px-3 py-3">
-        {agents.map((entry) => {
-          const active = entry.agentId === activeAgentId
-          const modelName = getAgentEntryMeta(entry)
-
-          return (
-            <button
-              key={entry.agentId}
-              type="button"
-              onClick={() => onSelectAgent(entry)}
-              className={cn(
-                'w-full rounded-2xl border px-3 py-3 text-left transition-all',
-                active
-                  ? 'border-[var(--accent-orange)]/30 bg-[var(--accent-orange)]/8 shadow-sm'
-                  : 'border-transparent bg-transparent hover:border-border/60 hover:bg-card',
-              )}
-            >
-              <div className="flex items-center gap-3">
-                <div
-                  className={cn(
-                    'flex size-9 items-center justify-center rounded-xl',
-                    active
-                      ? 'bg-[var(--accent-orange)]/12 text-[var(--accent-orange)]'
-                      : 'bg-muted text-muted-foreground',
-                  )}
-                >
-                  <Bot className="size-4" />
-                </div>
-                <AgentIdentity name={entry.name} meta={modelName} />
-              </div>
-            </button>
-          )
-        })}
-      </div>
-    </aside>
-  )
-}
-
-function getAgentEntryMeta(agent: AgentEntry | undefined): string {
-  if (agent?.source === 'agent-harness') {
-    return getModelDisplayName(agent.model) ?? 'ACP agent'
-  }
-  return getModelDisplayName(agent?.model) ?? 'OpenClaw agent'
-}
 
 function AgentConversationController({
   agentId,
@@ -368,6 +215,22 @@ interface AgentCommandConversationProps {
   createAgentPath?: string
 }
 
+function inferAdapterFromEntry(
+  entry: AgentEntry | undefined,
+): HarnessAgentAdapter | 'unknown' {
+  if (!entry) return 'unknown'
+  if (entry.source === 'agent-harness') {
+    // Harness entries don't carry the adapter on AgentEntry; the rail
+    // / header read the harness record directly. This branch only runs
+    // before the harness query resolves, so 'unknown' is correct — the
+    // tile's bot fallback renders until data arrives.
+    return 'unknown'
+  }
+  // OpenClaw-only entries (no harness shadow) are deprecated in
+  // practice but the rail still tolerates them.
+  return 'openclaw'
+}
+
 export const AgentCommandConversation: FC<AgentCommandConversationProps> = ({
   variant = 'command',
   backPath = '/home',
@@ -378,60 +241,85 @@ export const AgentCommandConversation: FC<AgentCommandConversationProps> = ({
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
   const { agents } = useAgentCommandData()
+  const { harnessAgents } = useHarnessAgents()
+  const { adapters } = useAgentAdapters()
+  const updateAgent = useUpdateHarnessAgent()
+
   const shouldRedirectHome = !agentId
   const resolvedAgentId = agentId ?? ''
-  const agent = agents.find((entry) => entry.agentId === resolvedAgentId)
-  const agentName = agent?.name || resolvedAgentId || 'Agent'
-  const agentMeta = getAgentEntryMeta(agent)
+  const harnessAgent = harnessAgents.find(
+    (entry) => entry.id === resolvedAgentId,
+  )
+  const entry = agents.find((item) => item.agentId === resolvedAgentId)
+  const fallbackName = entry?.name || resolvedAgentId || 'Agent'
+  const fallbackAdapter = inferAdapterFromEntry(entry)
   const initialMessage = searchParams.get('q')
   const isPageVariant = variant === 'page'
   const backLabel = isPageVariant ? 'Back to agents' : 'Back to home'
+
+  const adapterHealth = useMemo<AgentAdapterHealth | null>(() => {
+    const adapterId = harnessAgent?.adapter
+    if (!adapterId) return null
+    const descriptor = adapters.find((item) => item.id === adapterId)
+    if (!descriptor?.health) return null
+    return {
+      healthy: descriptor.health.healthy,
+      reason: descriptor.health.reason,
+    }
+  }, [adapters, harnessAgent?.adapter])
 
   if (shouldRedirectHome) {
     return <Navigate to="/home" replace />
   }
 
-  const handleSelectAgent = (entry: AgentEntry) => {
-    navigate(`${agentPathPrefix}/${entry.agentId}`)
+  const handleSelectHarnessAgent = (target: HarnessAgent) => {
+    navigate(`${agentPathPrefix}/${target.id}`)
   }
 
-  // Every visible agent runs through the harness now, so per-agent
-  // runtime status doesn't gate chat the way OpenClaw's legacy
-  // gateway lifecycle did. Show "Ready" once the agent record is
-  // resolved from the rail, "Setup" otherwise.
-  const statusCopy = agent ? 'Ready' : 'Setup'
+  const handlePinToggle = (target: HarnessAgent | null, next: boolean) => {
+    if (!target) return
+    updateAgent.mutate({
+      agentId: target.id,
+      patch: { pinned: next },
+    })
+  }
 
   return (
     <div className="absolute inset-0 overflow-hidden bg-background md:pl-[theme(spacing.14)]">
-      <div className="mx-auto grid h-full w-full max-w-[1480px] lg:grid-cols-[288px_minmax(0,1fr)] lg:grid-rows-[3.5rem_minmax(0,1fr)]">
-        <AgentRailHeader onGoHome={() => navigate(backPath)} />
-
-        <ConversationHeader
-          agentName={agentName}
-          agentMeta={agentMeta}
-          status={statusCopy}
-          backLabel={backLabel}
-          backTarget={isPageVariant ? 'page' : 'home'}
+      <div className="mx-auto grid h-full w-full max-w-[1480px] lg:grid-cols-[288px_minmax(0,1fr)]">
+        <AgentRail
+          agents={harnessAgents}
+          adapters={adapters}
+          activeAgentId={resolvedAgentId}
+          onSelectAgent={handleSelectHarnessAgent}
+          onPinToggle={(target, next) => handlePinToggle(target, next)}
           onGoHome={() => navigate(backPath)}
         />
 
-        <AgentRailList
-          activeAgentId={resolvedAgentId}
-          agents={agents}
-          onSelectAgent={handleSelectAgent}
-        />
+        <div className="flex min-h-0 flex-col overflow-hidden">
+          <ConversationHeader
+            agent={harnessAgent ?? null}
+            fallbackName={fallbackName}
+            fallbackAdapter={fallbackAdapter}
+            adapterHealth={adapterHealth}
+            backLabel={backLabel}
+            backTarget={isPageVariant ? 'page' : 'home'}
+            onGoHome={() => navigate(backPath)}
+            onPinToggle={(next) => handlePinToggle(harnessAgent ?? null, next)}
+          />
 
-        <AgentConversationController
-          key={resolvedAgentId}
-          agentId={resolvedAgentId}
-          agents={agents}
-          initialMessage={initialMessage}
-          onInitialMessageConsumed={() =>
-            setSearchParams({}, { replace: true })
-          }
-          agentPathPrefix={agentPathPrefix}
-          createAgentPath={createAgentPath}
-        />
+          <AgentConversationController
+            key={resolvedAgentId}
+            agentId={resolvedAgentId}
+            agents={agents}
+            initialMessage={initialMessage}
+            onInitialMessageConsumed={() =>
+              setSearchParams({}, { replace: true })
+            }
+            agentPathPrefix={agentPathPrefix}
+            createAgentPath={createAgentPath}
+          />
+        </div>
       </div>
     </div>
   )

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
@@ -292,7 +292,7 @@ export const AgentCommandConversation: FC<AgentCommandConversationProps> = ({
         {/* Shared top band — the rail's "Agents" header and the chat
             header live on one row so they're aligned by construction. */}
         <div className="flex shrink-0 items-stretch border-border/50 border-b">
-          <div className="hidden min-h-[84px] w-[288px] shrink-0 items-center gap-3 border-border/50 border-r px-4 lg:flex">
+          <div className="hidden min-h-[60px] w-[288px] shrink-0 items-center gap-3 border-border/50 border-r px-4 lg:flex">
             <Button
               variant="ghost"
               size="icon"

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentRail.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentRail.tsx
@@ -1,0 +1,84 @@
+import { ArrowLeft } from 'lucide-react'
+import { type FC, useMemo } from 'react'
+import { Button } from '@/components/ui/button'
+import type {
+  HarnessAdapterDescriptor,
+  HarnessAgent,
+  HarnessAgentAdapter,
+} from '@/entrypoints/app/agents/agent-harness-types'
+import type { AgentAdapterHealth } from '@/entrypoints/app/agents/agent-row/agent-row.types'
+import { orderAgentsByPinThenRecency } from '@/entrypoints/app/agents/agents-list-order'
+import { AgentRailRow } from './AgentRailRow'
+
+interface AgentRailProps {
+  agents: HarnessAgent[]
+  adapters: HarnessAdapterDescriptor[]
+  activeAgentId: string
+  onSelectAgent: (agent: HarnessAgent) => void
+  onPinToggle: (agent: HarnessAgent, next: boolean) => void
+  onGoHome: () => void
+}
+
+/**
+ * Left sidebar on `/agents/:agentId`. Header strip with the back-button
+ * sits flush above the scrollable list. Sort uses the same pin-first →
+ * recency comparator the `/agents` page uses, not the `/home`
+ * active-first one — chat is index-shaped: shuffling rows every 5 s as
+ * turns transition would be jarring while the user is reading.
+ */
+export const AgentRail: FC<AgentRailProps> = ({
+  agents,
+  adapters,
+  activeAgentId,
+  onSelectAgent,
+  onPinToggle,
+  onGoHome,
+}) => {
+  const adapterHealth = useMemo(() => {
+    const map = new Map<HarnessAgentAdapter, AgentAdapterHealth>()
+    for (const adapter of adapters) {
+      if (adapter.health) {
+        map.set(adapter.id, {
+          healthy: adapter.health.healthy,
+          reason: adapter.health.reason,
+        })
+      }
+    }
+    return map
+  }, [adapters])
+
+  const ordered = useMemo(() => orderAgentsByPinThenRecency(agents), [agents])
+
+  return (
+    <aside className="hidden min-h-0 flex-col border-border/50 border-r bg-background/70 lg:flex">
+      <div className="flex h-14 shrink-0 items-center border-border/50 border-b px-4">
+        <div className="flex min-w-0 items-center gap-3">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={onGoHome}
+            className="size-8 rounded-xl"
+            title="Back to home"
+          >
+            <ArrowLeft className="size-4" />
+          </Button>
+          <div className="truncate font-semibold text-[15px] leading-5">
+            Agents
+          </div>
+        </div>
+      </div>
+      <div className="styled-scrollbar min-h-0 flex-1 space-y-1.5 overflow-y-auto px-3 py-3">
+        {ordered.map((agent) => (
+          <AgentRailRow
+            key={agent.id}
+            agent={agent}
+            active={agent.id === activeAgentId}
+            adapterHealth={adapterHealth.get(agent.adapter) ?? null}
+            onSelect={() => onSelectAgent(agent)}
+            onPinToggle={(next) => onPinToggle(agent, next)}
+          />
+        ))}
+      </div>
+    </aside>
+  )
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentRail.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentRail.tsx
@@ -1,6 +1,4 @@
-import { ArrowLeft } from 'lucide-react'
 import { type FC, useMemo } from 'react'
-import { Button } from '@/components/ui/button'
 import type {
   HarnessAdapterDescriptor,
   HarnessAgent,
@@ -16,15 +14,15 @@ interface AgentRailProps {
   activeAgentId: string
   onSelectAgent: (agent: HarnessAgent) => void
   onPinToggle: (agent: HarnessAgent, next: boolean) => void
-  onGoHome: () => void
 }
 
 /**
- * Left sidebar on `/agents/:agentId`. Header strip with the back-button
- * sits flush above the scrollable list. Sort uses the same pin-first →
- * recency comparator the `/agents` page uses, not the `/home`
- * active-first one — chat is index-shaped: shuffling rows every 5 s as
- * turns transition would be jarring while the user is reading.
+ * Left-column scrollable list of agents. The "Agents" label + back
+ * button live in the shared top band above (so the rail header and
+ * the chat header sit on a single aligned strip rather than as two
+ * separately-sized headers per column). Sort matches `/agents`:
+ * pinned-first → recency, so the rail doesn't reshuffle as turns
+ * transition every 5 s.
  */
 export const AgentRail: FC<AgentRailProps> = ({
   agents,
@@ -32,7 +30,6 @@ export const AgentRail: FC<AgentRailProps> = ({
   activeAgentId,
   onSelectAgent,
   onPinToggle,
-  onGoHome,
 }) => {
   const adapterHealth = useMemo(() => {
     const map = new Map<HarnessAgentAdapter, AgentAdapterHealth>()
@@ -51,22 +48,6 @@ export const AgentRail: FC<AgentRailProps> = ({
 
   return (
     <aside className="hidden min-h-0 flex-col border-border/50 border-r bg-background/70 lg:flex">
-      <div className="flex h-14 shrink-0 items-center border-border/50 border-b px-4">
-        <div className="flex min-w-0 items-center gap-3">
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={onGoHome}
-            className="size-8 rounded-xl"
-            title="Back to home"
-          >
-            <ArrowLeft className="size-4" />
-          </Button>
-          <div className="truncate font-semibold text-[15px] leading-5">
-            Agents
-          </div>
-        </div>
-      </div>
       <div className="styled-scrollbar min-h-0 flex-1 space-y-1.5 overflow-y-auto px-3 py-3">
         {ordered.map((agent) => (
           <AgentRailRow

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentRailRow.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentRailRow.tsx
@@ -1,0 +1,102 @@
+import type { FC } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { adapterLabel } from '@/entrypoints/app/agents/AdapterIcon'
+import type { HarnessAgent } from '@/entrypoints/app/agents/agent-harness-types'
+import { AgentSummaryChips } from '@/entrypoints/app/agents/agent-row/AgentSummaryChips'
+import { AgentTile } from '@/entrypoints/app/agents/agent-row/AgentTile'
+import type { AgentAdapterHealth } from '@/entrypoints/app/agents/agent-row/agent-row.types'
+import { PinToggle } from '@/entrypoints/app/agents/agent-row/PinToggle'
+import { cn } from '@/lib/utils'
+
+interface AgentRailRowProps {
+  agent: HarnessAgent
+  active: boolean
+  adapterHealth: AgentAdapterHealth | null
+  onSelect: () => void
+  onPinToggle: (next: boolean) => void
+}
+
+/**
+ * Compact rail row for the chat-screen sidebar. Slims `<AgentRowCard>`
+ * down to the essentials that fit a ~280 px rail: tile + name + status
+ * badge + pin star, with the adapter / model / reasoning chips on a
+ * second line. Token totals, sparkline, last-message preview all stay
+ * on the `/agents` page where rows are full-width.
+ */
+export const AgentRailRow: FC<AgentRailRowProps> = ({
+  agent,
+  active,
+  adapterHealth,
+  onSelect,
+  onPinToggle,
+}) => {
+  const status = agent.status ?? 'unknown'
+  const lastUsedAt = agent.lastUsedAt ?? null
+  const pinned = agent.pinned ?? false
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      className={cn(
+        'group w-full rounded-2xl border px-3 py-3 text-left transition-colors',
+        active
+          ? 'border-[var(--accent-orange)]/30 bg-[var(--accent-orange)]/8'
+          : 'border-transparent bg-transparent hover:border-border/60 hover:bg-card',
+      )}
+    >
+      <div className="flex min-w-0 items-start gap-3">
+        <AgentTile
+          adapter={agent.adapter}
+          status={status}
+          lastUsedAt={lastUsedAt}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-1.5">
+            <span className="truncate font-semibold text-[14px] leading-5">
+              {agent.name}
+            </span>
+            {status === 'working' && (
+              <Badge
+                variant="secondary"
+                className="h-5 bg-amber-50 px-1.5 text-[10px] text-amber-900 hover:bg-amber-50"
+              >
+                Working
+              </Badge>
+            )}
+            {status === 'asleep' && (
+              <Badge
+                variant="outline"
+                className="h-5 px-1.5 text-[10px] text-muted-foreground"
+              >
+                Asleep
+              </Badge>
+            )}
+            {status === 'error' && (
+              <Badge variant="destructive" className="h-5 px-1.5 text-[10px]">
+                Attention
+              </Badge>
+            )}
+            <div className="ml-auto">
+              <PinToggle pinned={pinned} onToggle={onPinToggle} />
+            </div>
+          </div>
+          <AgentSummaryChips
+            adapter={agent.adapter}
+            modelLabel={agent.modelId ?? null}
+            reasoningEffort={agent.reasoningEffort ?? null}
+            adapterHealth={adapterHealth}
+          />
+        </div>
+      </div>
+    </button>
+  )
+}
+
+/**
+ * Tooltip-only label helper kept exported in case the tile row needs to
+ * show "Codex agent" or similar in a future state. Inlined fallback for
+ * the rare `unknown` adapter rendering path.
+ */
+export function railRowAdapterLabel(agent: HarnessAgent): string {
+  return adapterLabel(agent.adapter)
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationHeader.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationHeader.tsx
@@ -5,7 +5,6 @@ import { Button } from '@/components/ui/button'
 import { formatRelativeTime } from '@/entrypoints/app/agents/agent-display.helpers'
 import type { HarnessAgent } from '@/entrypoints/app/agents/agent-harness-types'
 import { AgentSummaryChips } from '@/entrypoints/app/agents/agent-row/AgentSummaryChips'
-import { AgentTile } from '@/entrypoints/app/agents/agent-row/AgentTile'
 import { formatTokens } from '@/entrypoints/app/agents/agent-row/agent-row.helpers'
 import type { AgentAdapterHealth } from '@/entrypoints/app/agents/agent-row/agent-row.types'
 import { PinToggle } from '@/entrypoints/app/agents/agent-row/PinToggle'
@@ -52,7 +51,6 @@ export const ConversationHeader: FC<ConversationHeaderProps> = ({
   const lifetimeTotal = tokens
     ? tokens.cumulative.input + tokens.cumulative.output
     : 0
-  const cwd = agent?.cwd ?? null
 
   const metaParts: string[] = []
   if (lastUsedAt !== null) metaParts.push(formatRelativeTime(lastUsedAt))
@@ -62,21 +60,20 @@ export const ConversationHeader: FC<ConversationHeaderProps> = ({
   }
 
   return (
-    <div className="flex min-h-14 items-start justify-between gap-4 border-border/50 border-b px-5 py-2.5">
+    <div className="flex shrink-0 items-start justify-between gap-4 border-border/50 border-b px-5 py-3">
       <div className="flex min-w-0 items-start gap-3">
         <Button
           variant="ghost"
           size="icon"
           onClick={onGoHome}
-          className="mt-1 size-8 shrink-0 rounded-xl lg:hidden"
+          className="size-8 shrink-0 rounded-xl lg:hidden"
           title={backLabel}
         >
           <BackIcon className="size-4" />
         </Button>
-        <AgentTile adapter={adapter} status={status} lastUsedAt={lastUsedAt} />
-        <div className="group min-w-0 flex-1 pt-0.5">
-          <div className="flex items-center gap-1.5">
-            <span className="truncate font-semibold text-[15px] leading-5">
+        <div className="group min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="truncate font-semibold text-[15px] leading-6">
               {agent?.name || fallbackName}
             </span>
             {agent ? (
@@ -87,24 +84,16 @@ export const ConversationHeader: FC<ConversationHeaderProps> = ({
               hasActiveTurn={Boolean(agent?.activeTurnId)}
             />
           </div>
-          <div className="mt-0.5 flex items-center gap-2">
+          <div className="mt-1 flex items-center gap-2">
             <AgentSummaryChips
               adapter={adapter}
               modelLabel={agent?.modelId ?? null}
               reasoningEffort={agent?.reasoningEffort ?? null}
               adapterHealth={adapterHealth}
             />
-            {cwd ? (
-              <span
-                className="truncate text-muted-foreground text-xs"
-                title={cwd}
-              >
-                · {cwd}
-              </span>
-            ) : null}
           </div>
           {metaParts.length > 0 ? (
-            <div className="mt-0.5 flex items-center gap-2 text-[11px] text-muted-foreground">
+            <div className="mt-1 flex items-center gap-2 text-[11px] text-muted-foreground">
               <span className="truncate">{metaParts.join(' · ')}</span>
             </div>
           ) : null}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationHeader.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationHeader.tsx
@@ -60,7 +60,7 @@ export const ConversationHeader: FC<ConversationHeaderProps> = ({
   }
 
   return (
-    <div className="flex shrink-0 items-start justify-between gap-4 px-5 py-3">
+    <div className="flex min-h-[84px] shrink-0 items-start justify-between gap-4 px-5 py-3">
       <div className="flex min-w-0 items-start gap-3">
         <Button
           variant="ghost"
@@ -92,11 +92,11 @@ export const ConversationHeader: FC<ConversationHeaderProps> = ({
               adapterHealth={adapterHealth}
             />
           </div>
-          {metaParts.length > 0 ? (
-            <div className="mt-1 flex items-center gap-2 text-[11px] text-muted-foreground">
-              <span className="truncate">{metaParts.join(' · ')}</span>
-            </div>
-          ) : null}
+          <div className="mt-1 flex h-4 items-center gap-2 text-[11px] text-muted-foreground">
+            <span className="truncate">
+              {metaParts.length > 0 ? metaParts.join(' · ') : '\u00A0'}
+            </span>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationHeader.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationHeader.tsx
@@ -1,0 +1,188 @@
+import { ArrowLeft, Home } from 'lucide-react'
+import type { FC } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { formatRelativeTime } from '@/entrypoints/app/agents/agent-display.helpers'
+import type { HarnessAgent } from '@/entrypoints/app/agents/agent-harness-types'
+import { AgentSummaryChips } from '@/entrypoints/app/agents/agent-row/AgentSummaryChips'
+import { AgentTile } from '@/entrypoints/app/agents/agent-row/AgentTile'
+import { formatTokens } from '@/entrypoints/app/agents/agent-row/agent-row.helpers'
+import type { AgentAdapterHealth } from '@/entrypoints/app/agents/agent-row/agent-row.types'
+import { PinToggle } from '@/entrypoints/app/agents/agent-row/PinToggle'
+import type { AgentLiveness } from '@/entrypoints/app/agents/LivenessDot'
+import { cn } from '@/lib/utils'
+
+interface ConversationHeaderProps {
+  agent: HarnessAgent | null
+  fallbackName: string
+  fallbackAdapter: 'claude' | 'codex' | 'openclaw' | 'unknown'
+  adapterHealth: AgentAdapterHealth | null
+  backLabel: string
+  backTarget: 'home' | 'page'
+  onGoHome: () => void
+  onPinToggle: (next: boolean) => void
+}
+
+/**
+ * Strip above the chat. Mirrors the `/agents` row card's title row +
+ * summary chips so the user gets adapter health, pin state, and status
+ * at a glance — but adds the meta line (last used · lifetime tokens ·
+ * queued) that's specific to this surface.
+ *
+ * The mobile `lg:hidden` Back button is preserved so the small-screen
+ * collapse keeps a navigable header without a sidebar.
+ */
+export const ConversationHeader: FC<ConversationHeaderProps> = ({
+  agent,
+  fallbackName,
+  fallbackAdapter,
+  adapterHealth,
+  backLabel,
+  backTarget,
+  onGoHome,
+  onPinToggle,
+}) => {
+  const BackIcon = backTarget === 'home' ? Home : ArrowLeft
+  const adapter = agent?.adapter ?? fallbackAdapter
+  const status: AgentLiveness = agent?.status ?? 'unknown'
+  const lastUsedAt = agent?.lastUsedAt ?? null
+  const pinned = agent?.pinned ?? false
+  const queueCount = agent?.queue?.length ?? 0
+  const tokens = agent?.tokens ?? null
+  const lifetimeTotal = tokens
+    ? tokens.cumulative.input + tokens.cumulative.output
+    : 0
+  const cwd = agent?.cwd ?? null
+
+  const metaParts: string[] = []
+  if (lastUsedAt !== null) metaParts.push(formatRelativeTime(lastUsedAt))
+  if (lifetimeTotal > 0) metaParts.push(`${formatTokens(lifetimeTotal)} tokens`)
+  if (queueCount > 0) {
+    metaParts.push(queueCount === 1 ? '1 queued' : `${queueCount} queued`)
+  }
+
+  return (
+    <div className="flex min-h-14 items-start justify-between gap-4 border-border/50 border-b px-5 py-2.5">
+      <div className="flex min-w-0 items-start gap-3">
+        <Button
+          variant="ghost"
+          size="icon"
+          onClick={onGoHome}
+          className="mt-1 size-8 shrink-0 rounded-xl lg:hidden"
+          title={backLabel}
+        >
+          <BackIcon className="size-4" />
+        </Button>
+        <AgentTile adapter={adapter} status={status} lastUsedAt={lastUsedAt} />
+        <div className="group min-w-0 flex-1 pt-0.5">
+          <div className="flex items-center gap-1.5">
+            <span className="truncate font-semibold text-[15px] leading-5">
+              {agent?.name || fallbackName}
+            </span>
+            {agent ? (
+              <PinToggle pinned={pinned} onToggle={onPinToggle} />
+            ) : null}
+            <StatusPill
+              status={status}
+              hasActiveTurn={Boolean(agent?.activeTurnId)}
+            />
+          </div>
+          <div className="mt-0.5 flex items-center gap-2">
+            <AgentSummaryChips
+              adapter={adapter}
+              modelLabel={agent?.modelId ?? null}
+              reasoningEffort={agent?.reasoningEffort ?? null}
+              adapterHealth={adapterHealth}
+            />
+            {cwd ? (
+              <span
+                className="truncate text-muted-foreground text-xs"
+                title={cwd}
+              >
+                · {cwd}
+              </span>
+            ) : null}
+          </div>
+          {metaParts.length > 0 ? (
+            <div className="mt-0.5 flex items-center gap-2 text-[11px] text-muted-foreground">
+              <span className="truncate">{metaParts.join(' · ')}</span>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+interface StatusPillProps {
+  status: AgentLiveness
+  hasActiveTurn: boolean
+}
+
+/**
+ * Working / Asleep / Attention all get distinctive styling; idle keeps
+ * the legacy emerald `Ready` pill so the default state is visually
+ * calm. Defensive working: `idle + activeTurnId` falls through to the
+ * working pill since the server says a turn is in flight.
+ */
+const StatusPill: FC<StatusPillProps> = ({ status, hasActiveTurn }) => {
+  const effective: AgentLiveness =
+    status === 'idle' && hasActiveTurn ? 'working' : status
+
+  const base =
+    'inline-flex items-center gap-2 rounded-full border px-3 py-0.5 text-[11px] uppercase tracking-[0.18em]'
+
+  if (effective === 'working') {
+    return (
+      <Badge
+        variant="secondary"
+        className={cn(
+          base,
+          'border-amber-200 bg-amber-50 text-amber-900 hover:bg-amber-50',
+        )}
+      >
+        <span className="size-1.5 animate-pulse rounded-full bg-amber-500" />
+        Working
+      </Badge>
+    )
+  }
+  if (effective === 'asleep') {
+    return (
+      <Badge variant="outline" className={cn(base, 'text-muted-foreground')}>
+        <span className="size-1.5 rounded-full bg-muted-foreground/50" />
+        Asleep
+      </Badge>
+    )
+  }
+  if (effective === 'error') {
+    return (
+      <Badge
+        variant="destructive"
+        className={cn(base, 'border-destructive/30')}
+      >
+        <span className="size-1.5 rounded-full bg-destructive-foreground" />
+        Attention
+      </Badge>
+    )
+  }
+  if (effective === 'idle') {
+    return (
+      <Badge
+        variant="outline"
+        className={cn(
+          base,
+          'border-emerald-200 bg-emerald-50 text-emerald-900 hover:bg-emerald-50',
+        )}
+      >
+        <span className="size-1.5 rounded-full bg-emerald-500" />
+        Ready
+      </Badge>
+    )
+  }
+  return (
+    <Badge variant="outline" className={cn(base, 'text-muted-foreground')}>
+      <span className="size-1.5 rounded-full bg-muted-foreground/30" />
+      Setup
+    </Badge>
+  )
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationHeader.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationHeader.tsx
@@ -60,7 +60,7 @@ export const ConversationHeader: FC<ConversationHeaderProps> = ({
   }
 
   return (
-    <div className="flex shrink-0 items-start justify-between gap-4 border-border/50 border-b px-5 py-3">
+    <div className="flex shrink-0 items-start justify-between gap-4 px-5 py-3">
       <div className="flex min-w-0 items-start gap-3">
         <Button
           variant="ghost"

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationHeader.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationHeader.tsx
@@ -60,8 +60,8 @@ export const ConversationHeader: FC<ConversationHeaderProps> = ({
   }
 
   return (
-    <div className="flex min-h-[84px] shrink-0 items-start justify-between gap-4 px-5 py-3">
-      <div className="flex min-w-0 items-start gap-3">
+    <div className="flex min-h-[60px] shrink-0 items-center justify-between gap-4 px-5 py-2.5">
+      <div className="flex min-w-0 items-center gap-3">
         <Button
           variant="ghost"
           size="icon"
@@ -79,12 +79,8 @@ export const ConversationHeader: FC<ConversationHeaderProps> = ({
             {agent ? (
               <PinToggle pinned={pinned} onToggle={onPinToggle} />
             ) : null}
-            <StatusPill
-              status={status}
-              hasActiveTurn={Boolean(agent?.activeTurnId)}
-            />
           </div>
-          <div className="mt-1 flex items-center gap-2">
+          <div className="mt-0.5 flex items-center gap-2">
             <AgentSummaryChips
               adapter={adapter}
               modelLabel={agent?.modelId ?? null}
@@ -92,11 +88,17 @@ export const ConversationHeader: FC<ConversationHeaderProps> = ({
               adapterHealth={adapterHealth}
             />
           </div>
-          <div className="mt-1 flex h-4 items-center gap-2 text-[11px] text-muted-foreground">
-            <span className="truncate">
-              {metaParts.length > 0 ? metaParts.join(' · ') : '\u00A0'}
-            </span>
-          </div>
+        </div>
+      </div>
+      <div className="flex shrink-0 flex-col items-end gap-1">
+        <StatusPill
+          status={status}
+          hasActiveTurn={Boolean(agent?.activeTurnId)}
+        />
+        <div className="flex h-4 items-center text-[11px] text-muted-foreground">
+          <span className="truncate">
+            {metaParts.length > 0 ? metaParts.join(' · ') : '\u00A0'}
+          </span>
         </div>
       </div>
     </div>

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentList.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentList.tsx
@@ -11,6 +11,7 @@ import type {
   AgentAdapterHealth,
   AgentRowData,
 } from './agent-row/agent-row.types'
+import { compareAgentsByPinThenRecency } from './agents-list-order'
 import type { AgentListItem } from './agents-page-types'
 import type { AgentLiveness } from './LivenessDot'
 
@@ -56,31 +57,18 @@ export const AgentList: FC<AgentListProps> = ({
     return map
   }, [adapters])
 
-  // Sort: pinned rows first, then most recently used, then never-used
-  // agents in id-stable order. The gateway's `main` agent stays
-  // pinned-to-top when never touched so a fresh install has an
-  // obvious starting point.
   const ordered = useMemo(() => {
     const withMeta = agents.map((agent) => {
       const harness = harnessAgentLookup?.get(agent.agentId)
       return {
         agent,
+        id: agent.agentId,
         pinned: harness?.pinned ?? false,
         lastUsedAt: activity?.[agent.agentId]?.lastUsedAt ?? null,
       }
     })
     return withMeta
-      .sort((a, b) => {
-        if (a.pinned !== b.pinned) return a.pinned ? -1 : 1
-        const aSeed = a.agent.agentId === 'main' && a.lastUsedAt === null
-        const bSeed = b.agent.agentId === 'main' && b.lastUsedAt === null
-        if (aSeed && !bSeed) return -1
-        if (!aSeed && bSeed) return 1
-        const aValue = a.lastUsedAt ?? -Infinity
-        const bValue = b.lastUsedAt ?? -Infinity
-        if (aValue !== bValue) return bValue - aValue
-        return a.agent.agentId.localeCompare(b.agent.agentId)
-      })
+      .sort(compareAgentsByPinThenRecency)
       .map((entry) => entry.agent)
   }, [activity, agents, harnessAgentLookup])
 

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/agents-list-order.test.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/agents-list-order.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'bun:test'
+import type { HarnessAgent } from './agent-harness-types'
+import {
+  compareAgentsByPinThenRecency,
+  orderAgentsByPinThenRecency,
+} from './agents-list-order'
+
+function makeAgent(input: {
+  id: string
+  pinned?: boolean
+  lastUsedAt?: number | null
+}): HarnessAgent {
+  return {
+    id: input.id,
+    name: input.id,
+    adapter: 'codex',
+    permissionMode: 'approve-all',
+    sessionKey: 'session',
+    createdAt: 0,
+    updatedAt: 0,
+    pinned: input.pinned,
+    lastUsedAt: input.lastUsedAt,
+  }
+}
+
+describe('orderAgentsByPinThenRecency', () => {
+  it('floats pinned agents to the top regardless of recency', () => {
+    const result = orderAgentsByPinThenRecency([
+      makeAgent({ id: 'a', pinned: false, lastUsedAt: 1_000 }),
+      makeAgent({ id: 'b', pinned: true, lastUsedAt: 100 }),
+      makeAgent({ id: 'c', pinned: false, lastUsedAt: 500 }),
+    ])
+    expect(result.map((entry) => entry.id)).toEqual(['b', 'a', 'c'])
+  })
+
+  it('sorts by lastUsedAt desc within each pin group', () => {
+    const result = orderAgentsByPinThenRecency([
+      makeAgent({ id: 'older-pin', pinned: true, lastUsedAt: 100 }),
+      makeAgent({ id: 'newer-pin', pinned: true, lastUsedAt: 200 }),
+      makeAgent({ id: 'older', pinned: false, lastUsedAt: 50 }),
+      makeAgent({ id: 'newer', pinned: false, lastUsedAt: 80 }),
+    ])
+    expect(result.map((entry) => entry.id)).toEqual([
+      'newer-pin',
+      'older-pin',
+      'newer',
+      'older',
+    ])
+  })
+
+  it('seed-pins the gateway main agent above other never-used agents', () => {
+    const result = orderAgentsByPinThenRecency([
+      makeAgent({ id: 'aaa', pinned: false, lastUsedAt: null }),
+      makeAgent({ id: 'main', pinned: false, lastUsedAt: null }),
+      makeAgent({ id: 'zzz', pinned: false, lastUsedAt: null }),
+    ])
+    expect(result.map((entry) => entry.id)).toEqual(['main', 'aaa', 'zzz'])
+  })
+
+  it('drops the main seed-pin once the agent has been used', () => {
+    const result = orderAgentsByPinThenRecency([
+      makeAgent({ id: 'aaa', pinned: false, lastUsedAt: 999 }),
+      makeAgent({ id: 'main', pinned: false, lastUsedAt: 1 }),
+    ])
+    expect(result.map((entry) => entry.id)).toEqual(['aaa', 'main'])
+  })
+
+  it('puts never-used agents below recently-used ones', () => {
+    const result = orderAgentsByPinThenRecency([
+      makeAgent({ id: 'fresh', pinned: false, lastUsedAt: null }),
+      makeAgent({ id: 'used', pinned: false, lastUsedAt: 100 }),
+    ])
+    expect(result.map((entry) => entry.id)).toEqual(['used', 'fresh'])
+  })
+
+  it('id-stable tiebreaks two agents with identical lastUsedAt', () => {
+    const result = orderAgentsByPinThenRecency([
+      makeAgent({ id: 'b', pinned: false, lastUsedAt: 100 }),
+      makeAgent({ id: 'a', pinned: false, lastUsedAt: 100 }),
+    ])
+    expect(result.map((entry) => entry.id)).toEqual(['a', 'b'])
+  })
+})
+
+describe('compareAgentsByPinThenRecency', () => {
+  it('produces the same order as the harness-shape helper', () => {
+    const items = [
+      { id: 'older', pinned: false, lastUsedAt: 50 },
+      { id: 'newer', pinned: false, lastUsedAt: 80 },
+      { id: 'pinned', pinned: true, lastUsedAt: 1 },
+    ]
+    const sorted = [...items].sort(compareAgentsByPinThenRecency)
+    expect(sorted.map((item) => item.id)).toEqual(['pinned', 'newer', 'older'])
+  })
+
+  it('seeds the main agent above other never-used rows', () => {
+    const items = [
+      { id: 'zzz', pinned: false, lastUsedAt: null },
+      { id: 'main', pinned: false, lastUsedAt: null },
+    ]
+    const sorted = [...items].sort(compareAgentsByPinThenRecency)
+    expect(sorted.map((item) => item.id)).toEqual(['main', 'zzz'])
+  })
+})

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/agents-list-order.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/agents-list-order.ts
@@ -1,0 +1,59 @@
+import type { HarnessAgent } from './agent-harness-types'
+
+/**
+ * Stable ordering for index-shaped agent surfaces (the `/agents` rail
+ * and the chat-screen rail at `/agents/:agentId`). Pinned rows float
+ * to the top, then recency desc, with never-used agents falling to
+ * the bottom in id-stable order. The gateway's `main` agent gets
+ * seed-pinned to the top of the never-used group so a fresh install
+ * has an obvious starting point even before the user has used it.
+ *
+ * NOT the same rule as the home grid (`orderHomeAgents`): home is
+ * action-shaped — active-turn floats to the top — so users can
+ * resume what's running. The chat rail keeps recency stable so it
+ * doesn't reshuffle as turns transition every 5s.
+ */
+export function orderAgentsByPinThenRecency(
+  agents: HarnessAgent[],
+): HarnessAgent[] {
+  return [...agents].sort((a, b) => {
+    const aPinned = a.pinned ?? false
+    const bPinned = b.pinned ?? false
+    if (aPinned !== bPinned) return aPinned ? -1 : 1
+
+    const aSeed = a.id === 'main' && (a.lastUsedAt ?? null) === null
+    const bSeed = b.id === 'main' && (b.lastUsedAt ?? null) === null
+    if (aSeed && !bSeed) return -1
+    if (!aSeed && bSeed) return 1
+
+    const aValue = a.lastUsedAt ?? Number.NEGATIVE_INFINITY
+    const bValue = b.lastUsedAt ?? Number.NEGATIVE_INFINITY
+    if (aValue !== bValue) return bValue - aValue
+
+    return a.id.localeCompare(b.id)
+  })
+}
+
+/**
+ * Same comparator, but operates over arbitrary records that carry
+ * `pinned`, `lastUsedAt`, and an `id`-equivalent key. Used by the
+ * `/agents` `AgentList` which pivots `AgentListItem` + harness
+ * lookup into a sortable shape; both surfaces stay on identical
+ * sort semantics through this adapter.
+ */
+export function compareAgentsByPinThenRecency<
+  T extends { pinned: boolean; lastUsedAt: number | null; id: string },
+>(a: T, b: T): number {
+  if (a.pinned !== b.pinned) return a.pinned ? -1 : 1
+
+  const aSeed = a.id === 'main' && a.lastUsedAt === null
+  const bSeed = b.id === 'main' && b.lastUsedAt === null
+  if (aSeed && !bSeed) return -1
+  if (!aSeed && bSeed) return 1
+
+  const aValue = a.lastUsedAt ?? Number.NEGATIVE_INFINITY
+  const bValue = b.lastUsedAt ?? Number.NEGATIVE_INFINITY
+  if (aValue !== bValue) return bValue - aValue
+
+  return a.id.localeCompare(b.id)
+}


### PR DESCRIPTION
## Summary

Brings the chat screen at `/agents/:agentId` up to feature parity with the `/agents` rail and the `/home` Recent Agents grid. Both the left rail and the conversation header now consume the same `useHarnessAgents()` data and use the shared visual language for adapter glyph, liveness, pin, status, model details, and recency.

- **Rail row**: adapter glyph + liveness dot + name + pin star + status badge + adapter · model · reasoning subtitle. Sort: pinned-first → recency (matches `/agents`, not `/home`'s active-first — index-shaped surface, so reshuffling every 5 s is jarring).
- **Conversation header**: two-column layout — name + pin + adapter chips on the left, status pill stacked on top of last-used · tokens · queued meta on the right. Includes the Adapter Unavailable warning when the adapter binary is missing.
- **Shared top band**: rail's "Agents" + back-button and the chat header sit on a single horizontal strip spanning both columns, so the headers are aligned by construction and can't drift as the chat header gains/loses meta lines.
- **Anti-shift**: `min-h-[60px]` reserved on both halves of the band; meta line slot always renders so the harness data resolving doesn't trigger a layout shift.
- **Shared sort helper**: `orderAgentsByPinThenRecency` extracted from the inline sort in `/agents` `AgentList.tsx` into `agents-list-order.ts`. Both surfaces now use the same comparator.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bunx biome check` clean
- [x] `bun test` 70/70 pass (including 8 new tests for the sort helper)
- [ ] Visual: rail row hover / active / pin states for each adapter (Claude / Codex / OpenClaw / unknown)
- [ ] Visual: header status pill across Working / Asleep / Attention / Ready / Setup
- [ ] Visual: composer flush to the bottom of the chat panel on short conversations
- [ ] Visual: header doesn't shift when `useHarnessAgents()` poll resolves
- [ ] Visual: switching agents from the rail keeps the header stable and updates the conversation pane