### PR TITLE
feat(agent): inject active page context into side chat prompts

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -395,6 +395,7 @@ export const useChatSession = (options?: ChatSessionOptions) => {
         const commonRequest = {
           conversationId: conversationIdRef.current,
           mode: currentMode,
+          origin: options?.origin ?? 'sidepanel',
           browserContext: requestBrowserContext,
           userSystemPrompt,
           userWorkingDir: workingDirRef.current,

--- a/packages/browseros-agent/apps/agent/lib/messaging/server/buildChatRequestBody.ts
+++ b/packages/browseros-agent/apps/agent/lib/messaging/server/buildChatRequestBody.ts
@@ -38,6 +38,7 @@ interface ChatRequestBodyParams {
   provider: LlmProviderConfig
   message?: string
   mode?: ChatMode
+  origin?: 'sidepanel' | 'newtab'
   browserContext?: ChatRequestBrowserContext
   userSystemPrompt?: string
   userWorkingDir?: string
@@ -69,6 +70,7 @@ export const buildChatRequestBody = ({
   provider,
   message = '',
   mode,
+  origin,
   browserContext,
   userSystemPrompt,
   userWorkingDir,
@@ -91,6 +93,7 @@ export const buildChatRequestBody = ({
   conversationId,
   model: provider.modelId ?? 'default',
   mode,
+  origin,
   contextWindowSize: provider.contextWindow,
   temperature: provider.temperature,
   resourceName: provider.resourceName,

--- a/packages/browseros-agent/apps/server/src/agent/format-message.ts
+++ b/packages/browseros-agent/apps/server/src/agent/format-message.ts
@@ -41,9 +41,43 @@ export function formatBrowserContext(browserContext?: BrowserContext): string {
 /** Strip XML-like tags that match our prompt delimiters to prevent injection. */
 function sanitizeForPrompt(s: string): string {
   return s.replace(
-    /<\/?(?:selected_text|USER_QUERY|page_context|AGENT_PROMPT|soul|memory_and_identity|security|workspace)[^>]*>/gi,
+    /<\/?(?:selected_text|current_page_context|page_content|USER_QUERY|page_context|AGENT_PROMPT|soul|memory_and_identity|security|workspace)[^>]*>/gi,
     '',
   )
+}
+
+export interface PageContextContent {
+  pageId: number
+  url?: string
+  title?: string
+  content: string
+  truncated?: boolean
+}
+
+function formatPageContextBlock(pages?: PageContextContent[]): string {
+  if (!pages?.length) return ''
+
+  const blocks = pages
+    .filter((page) => page.content.trim())
+    .map((page) => {
+      const title = page.title
+        ? sanitizeForPrompt(page.title).replace(/"/g, "'")
+        : ''
+      const url = page.url ? sanitizeForPrompt(page.url) : ''
+      const attrs = [
+        `page_id="${page.pageId}"`,
+        title ? `title="${title}"` : '',
+        url ? `url="${url}"` : '',
+        page.truncated ? 'truncated="true"' : '',
+      ]
+        .filter(Boolean)
+        .join(' ')
+
+      return `<page_content ${attrs}>\n${sanitizeForPrompt(page.content)}\n</page_content>`
+    })
+
+  if (blocks.length === 0) return ''
+  return `<current_page_context>\n${blocks.join('\n\n')}\n</current_page_context>\n\n`
 }
 
 export function formatUserMessage(
@@ -51,8 +85,10 @@ export function formatUserMessage(
   browserContext?: BrowserContext,
   selectedText?: string,
   selectedTextSource?: { url: string; title: string },
+  pageContext?: PageContextContent[],
 ): string {
   const contextPrefix = formatBrowserContext(browserContext)
+  const pageContextBlock = formatPageContextBlock(pageContext)
 
   let selectedTextBlock = ''
   if (selectedText) {
@@ -67,5 +103,5 @@ export function formatUserMessage(
     selectedTextBlock = `<selected_text${source}>\n${sanitizedText}\n</selected_text>\n\n`
   }
 
-  return `${contextPrefix}${selectedTextBlock}<USER_QUERY>\n${message}\n</USER_QUERY>`
+  return `${contextPrefix}${pageContextBlock}${selectedTextBlock}<USER_QUERY>\n${message}\n</USER_QUERY>`
 }

--- a/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
@@ -4,9 +4,13 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { CONTENT_LIMITS } from '@browseros/shared/constants/limits'
 import { createAgentUIStreamResponse, type UIMessage } from 'ai'
 import { AiSdkAgent } from '../../agent/ai-sdk-agent'
-import { formatUserMessage } from '../../agent/format-message'
+import {
+  formatUserMessage,
+  type PageContextContent,
+} from '../../agent/format-message'
 import {
   filterValidMessages,
   sanitizeMessagesForToolset,
@@ -299,11 +303,17 @@ export class ChatService {
     const resolvedMessageContext = request.isScheduledTask
       ? messageContext
       : await resolveBrowserContextPageIds(this.deps.browser, messageContext)
+    const pageContext = await this.resolvePageContext({
+      browserContext: resolvedMessageContext,
+      origin: request.origin,
+      isScheduledTask: request.isScheduledTask,
+    })
     const userContent = formatUserMessage(
       request.message,
       resolvedMessageContext,
       request.selectedText,
       request.selectedTextSource,
+      pageContext,
     )
 
     // Prepend tool-change context when session was rebuilt mid-conversation
@@ -492,5 +502,69 @@ export class ChatService {
           : 'klavis:pending'
         : null
     return [klavisState, ...managed, ...custom].filter(Boolean).join(',')
+  }
+
+  private async resolvePageContext(input: {
+    browserContext?: BrowserContext
+    origin?: 'sidepanel' | 'newtab'
+    isScheduledTask?: boolean
+  }): Promise<PageContextContent[] | undefined> {
+    if (input.isScheduledTask) return undefined
+
+    const tabs = this.getPageContextTabs(input.browserContext, input.origin)
+    if (tabs.length === 0) return undefined
+
+    const maxChars = CONTENT_LIMITS.BODY_CONTEXT_SIZE
+    const perPageLimit = Math.max(1000, Math.floor(maxChars / tabs.length))
+    const pageContexts: PageContextContent[] = []
+
+    for (const tab of tabs) {
+      if (tab.pageId === undefined) continue
+      try {
+        const content = await this.deps.browser.contentAsMarkdown(tab.pageId, {
+          includeLinks: true,
+          includeImages: false,
+        })
+        const trimmed = content.trim()
+        if (!trimmed) continue
+        pageContexts.push({
+          pageId: tab.pageId,
+          url: tab.url,
+          title: tab.title,
+          content: trimmed.slice(0, perPageLimit),
+          truncated: trimmed.length > perPageLimit,
+        })
+      } catch (error) {
+        logger.warn('Failed to read page context for side chat', {
+          pageId: tab.pageId,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      }
+    }
+
+    return pageContexts.length > 0 ? pageContexts : undefined
+  }
+
+  private getPageContextTabs(
+    browserContext?: BrowserContext,
+    origin?: 'sidepanel' | 'newtab',
+  ): Array<NonNullable<BrowserContext['activeTab']>> {
+    const tabs: Array<NonNullable<BrowserContext['activeTab']>> = []
+    const seenPageIds = new Set<number>()
+    const addTab = (tab?: NonNullable<BrowserContext['activeTab']>) => {
+      if (!tab?.pageId || seenPageIds.has(tab.pageId)) return
+      seenPageIds.add(tab.pageId)
+      tabs.push(tab)
+    }
+
+    if (origin !== 'newtab') {
+      addTab(browserContext?.activeTab)
+    }
+
+    for (const tab of browserContext?.selectedTabs ?? []) {
+      addTab(tab)
+    }
+
+    return tabs
   }
 }

--- a/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
@@ -293,6 +293,159 @@ describe('ChatService scheduled task hidden page lifecycle', () => {
   })
 })
 
+describe('ChatService page context prompt injection', () => {
+  it('adds the active tab markdown to the transient sidepanel prompt only', async () => {
+    const fakeAgent = createFakeAgent()
+    agentToReturn = fakeAgent
+    let lastPromptUiMessages: MockMessage[] | undefined
+    streamResponseHandler = async ({ onFinish, uiMessages }) => {
+      lastPromptUiMessages = uiMessages
+      await onFinish({ messages: uiMessages ?? [] })
+      return new Response('ok')
+    }
+
+    const browser = {
+      resolveTabIds: mock(
+        async (tabIds: number[]) =>
+          new Map(tabIds.map((tabId) => [tabId, tabId + 100])),
+      ),
+      contentAsMarkdown: mock(async () => '# Example\nVisible page text'),
+      closePage: mock(async () => {}),
+    }
+    const service = new ChatService({
+      sessionStore: createSessionStore() as never,
+      klavisRef: { handle: null },
+      browser: browser as never,
+      registry: {} as never,
+    })
+
+    await service.processMessage(
+      {
+        conversationId: crypto.randomUUID(),
+        message: 'What is on this page?',
+        isScheduledTask: false,
+        mode: 'agent',
+        origin: 'sidepanel',
+        browserContext: {
+          activeTab: {
+            id: 3,
+            url: 'https://example.com/article',
+            title: 'Example Article',
+          },
+        },
+      } as never,
+      new AbortController().signal,
+    )
+
+    expect(browser.contentAsMarkdown).toHaveBeenCalledWith(103, {
+      includeLinks: true,
+      includeImages: false,
+    })
+    const promptMessage = lastPromptUiMessages?.at(-1)?.parts[0]?.text ?? ''
+    expect(promptMessage).toContain('<current_page_context>')
+    expect(promptMessage).toContain(
+      '<page_content page_id="103" title="Example Article" url="https://example.com/article">',
+    )
+    expect(promptMessage).toContain('# Example\nVisible page text')
+    expect(promptMessage).toContain('<USER_QUERY>\nWhat is on this page?')
+    expect(fakeAgent.messages.at(-1)?.parts[0]?.text).toBe(
+      'What is on this page?',
+    )
+  })
+
+  it('does not inject the active tab page body for newtab-origin chat', async () => {
+    const fakeAgent = createFakeAgent()
+    agentToReturn = fakeAgent
+    let lastPromptUiMessages: MockMessage[] | undefined
+    streamResponseHandler = async ({ onFinish, uiMessages }) => {
+      lastPromptUiMessages = uiMessages
+      await onFinish({ messages: uiMessages ?? [] })
+      return new Response('ok')
+    }
+
+    const browser = {
+      resolveTabIds: mock(
+        async (tabIds: number[]) =>
+          new Map(tabIds.map((tabId) => [tabId, tabId + 200])),
+      ),
+      contentAsMarkdown: mock(async () => 'This should not be read'),
+      closePage: mock(async () => {}),
+    }
+    const service = new ChatService({
+      sessionStore: createSessionStore() as never,
+      klavisRef: { handle: null },
+      browser: browser as never,
+      registry: {} as never,
+    })
+
+    await service.processMessage(
+      {
+        conversationId: crypto.randomUUID(),
+        message: 'Summarize my current tab',
+        isScheduledTask: false,
+        mode: 'agent',
+        origin: 'newtab',
+        browserContext: {
+          activeTab: {
+            id: 5,
+            url: 'https://example.com/private',
+            title: 'Private Tab',
+          },
+        },
+      } as never,
+      new AbortController().signal,
+    )
+
+    expect(browser.contentAsMarkdown).not.toHaveBeenCalled()
+    const promptMessage = lastPromptUiMessages?.at(-1)?.parts[0]?.text ?? ''
+    expect(promptMessage).not.toContain('<current_page_context>')
+    expect(promptMessage).toContain('<USER_QUERY>\nSummarize my current tab')
+  })
+
+  it('skips page body injection for scheduled tasks', async () => {
+    const fakeAgent = createFakeAgent()
+    agentToReturn = fakeAgent
+    streamResponseHandler = async ({ onFinish, uiMessages }) => {
+      await onFinish({ messages: uiMessages ?? [] })
+      return new Response('ok')
+    }
+
+    const browser = {
+      newPage: mock(async () => 91),
+      listPages: mock(async () => [{ pageId: 91, windowId: 12 }]),
+      closePage: mock(async () => {}),
+      resolveTabIds: mock(async () => new Map<number, number>()),
+      contentAsMarkdown: mock(async () => 'Scheduled page body'),
+    }
+    const service = new ChatService({
+      sessionStore: createSessionStore() as never,
+      klavisRef: { handle: null },
+      browser: browser as never,
+      registry: {} as never,
+    })
+
+    await service.processMessage(
+      {
+        conversationId: crypto.randomUUID(),
+        message: 'Run later',
+        isScheduledTask: true,
+        mode: 'agent',
+        origin: 'sidepanel',
+        browserContext: {
+          activeTab: {
+            id: 3,
+            url: 'https://example.com',
+            title: 'Example',
+          },
+        },
+      } as never,
+      new AbortController().signal,
+    )
+
+    expect(browser.contentAsMarkdown).not.toHaveBeenCalled()
+  })
+})
+
 describe('ChatService Klavis session rebuilds', () => {
   it('rebuilds a managed-app session when the shared Klavis handle appears', async () => {
     const firstAgent = createFakeAgent()
@@ -311,6 +464,7 @@ describe('ChatService Klavis session rebuilds', () => {
         async (tabIds: number[]) =>
           new Map(tabIds.map((tabId) => [tabId, tabId + 100])),
       ),
+      contentAsMarkdown: mock(async () => ''),
       closePage: mock(async () => {}),
     }
     const sessionStore = createSessionStore()
@@ -385,6 +539,7 @@ describe('ChatService Klavis session rebuilds', () => {
         async (tabIds: number[]) =>
           new Map(tabIds.map((tabId) => [tabId, tabId + 200])),
       ),
+      contentAsMarkdown: mock(async () => ''),
       closePage: mock(async () => {}),
     }
     const sessionStore = createSessionStore()


### PR DESCRIPTION
Addresses the feature request #904 Add Google AI Mode as a Side Chat Option

This implements the maintainer-suggested direction for the Google AI Mode side chat request, instead of embedding another provider web panel, BrowserOS side chat now passes current-tab page context into the provider prompt so any configured provider can answer in context.

## Changes

- Reads active/selected tab page content as markdown on the server side
- Injects page content into the transient LLM prompt only
- Preserves the raw user message in chat history
- Skips active-tab body injection for newtab-origin chat and scheduled tasks
- Adds tests for sidepanel page context, newtab behavior, and scheduled task behavior

## Testing

- `bun --env-file=apps/server/.env.development test apps/server/tests/api/services/chat-service.test.ts`
- `bun run typecheck` in `apps/server`
- `bun run typecheck` in `apps/agent`

## Screenshots

After changes: BrowserOS Assistant answering from the active page context. Side chat can receive current-tab context and, when needed, use browser/search actions to gather missing context.

<img width="1919" height="1020" alt="Screenshot 2026-05-03 021058" src="https://github.com/user-attachments/assets/3275cf94-2d0a-41a5-94e8-c22ac9e0dd23" />
<img width="1919" height="1013" alt="Screenshot 2026-05-03 021138" src="https://github.com/user-attachments/assets/bc4cb4ad-0d2f-4863-81ca-ab1eaf637593" />
<img width="1910" height="1001" alt="Screenshot 2026-05-03 013919" src="https://github.com/user-attachments/assets/ffbf8ed3-14ae-45ab-8e0b-e58c69f57bb5" />
<img width="1919" height="1007" alt="Screenshot 2026-05-03 015141" src="https://github.com/user-attachments/assets/f2ec9b79-4b65-4f81-afd5-67cb131fbd09" />
