### PR TITLE
fix: improve browseros-patch workspace feedback

### DIFF
--- a/packages/browseros/tools/patch/cmd/apply.go
+++ b/packages/browseros/tools/patch/cmd/apply.go
@@ -38,6 +38,7 @@ func init() {
 				ChangedRef: changed,
 				RangeEnd:   rangeEnd,
 				Filters:    filters,
+				Progress:   commandProgress(cmd),
 			})
 			if err != nil {
 				return err

--- a/packages/browseros/tools/patch/cmd/common.go
+++ b/packages/browseros/tools/patch/cmd/common.go
@@ -3,7 +3,9 @@ package cmd
 import (
 	"fmt"
 
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/engine"
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/repo"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/ui"
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/workspace"
 	"github.com/spf13/cobra"
 )
@@ -46,4 +48,14 @@ func ensureRepoConfigured(override string) error {
 	}
 	appState.Config.PatchesRepo = info.Root
 	return nil
+}
+
+// commandProgress routes long-running engine updates to stderr in human mode only.
+func commandProgress(cmd *cobra.Command) engine.Progress {
+	if jsonOut {
+		return nil
+	}
+	return engine.ProgressFunc(func(message string) {
+		fmt.Fprintf(cmd.ErrOrStderr(), "%s %s\n", ui.Muted("..."), message)
+	})
 }

--- a/packages/browseros/tools/patch/cmd/common_test.go
+++ b/packages/browseros/tools/patch/cmd/common_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestCommandProgressWritesHumanUpdatesToStderr(t *testing.T) {
+	oldJSONOut := jsonOut
+	t.Cleanup(func() {
+		jsonOut = oldJSONOut
+	})
+	jsonOut = false
+
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{}
+	cmd.SetErr(&stderr)
+
+	progress := commandProgress(cmd)
+	if progress == nil {
+		t.Fatalf("expected human progress reporter")
+	}
+	progress.Step("Applying 1 patch operation")
+
+	if !strings.Contains(stderr.String(), "Applying 1 patch operation") {
+		t.Fatalf("expected progress on stderr, got %q", stderr.String())
+	}
+}
+
+func TestCommandProgressDisabledForJSON(t *testing.T) {
+	oldJSONOut := jsonOut
+	t.Cleanup(func() {
+		jsonOut = oldJSONOut
+	})
+	jsonOut = true
+
+	if progress := commandProgress(&cobra.Command{}); progress != nil {
+		t.Fatalf("expected nil progress reporter in JSON mode")
+	}
+}

--- a/packages/browseros/tools/patch/cmd/continue.go
+++ b/packages/browseros/tools/patch/cmd/continue.go
@@ -20,7 +20,10 @@ func init() {
 			if err != nil {
 				return err
 			}
-			result, err := engine.Continue(cmd.Context(), ws)
+			result, err := engine.Continue(cmd.Context(), engine.ContinueOptions{
+				Workspace: ws,
+				Progress:  commandProgress(cmd),
+			})
 			if err != nil {
 				return err
 			}

--- a/packages/browseros/tools/patch/cmd/diff.go
+++ b/packages/browseros/tools/patch/cmd/diff.go
@@ -25,10 +25,11 @@ func init() {
 			if err != nil {
 				return err
 			}
-			if progress := commandProgress(cmd); progress != nil {
-				progress.Step("Inspecting workspace drift")
-			}
-			status, err := engine.InspectWorkspace(cmd.Context(), ws, info)
+			status, err := engine.InspectWorkspace(cmd.Context(), engine.InspectWorkspaceOptions{
+				Workspace: ws,
+				Repo:      info,
+				Progress:  commandProgress(cmd),
+			})
 			if err != nil {
 				return err
 			}

--- a/packages/browseros/tools/patch/cmd/diff.go
+++ b/packages/browseros/tools/patch/cmd/diff.go
@@ -25,6 +25,9 @@ func init() {
 			if err != nil {
 				return err
 			}
+			if progress := commandProgress(cmd); progress != nil {
+				progress.Step("Inspecting workspace drift")
+			}
 			status, err := engine.InspectWorkspace(cmd.Context(), ws, info)
 			if err != nil {
 				return err

--- a/packages/browseros/tools/patch/cmd/extract.go
+++ b/packages/browseros/tools/patch/cmd/extract.go
@@ -52,6 +52,7 @@ func init() {
 				Squash:     squash,
 				Base:       base,
 				Filters:    filters,
+				Progress:   commandProgress(cmd),
 			})
 			if err != nil {
 				return err

--- a/packages/browseros/tools/patch/cmd/list.go
+++ b/packages/browseros/tools/patch/cmd/list.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/engine"
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -13,7 +12,7 @@ func init() {
 		Use:         "list",
 		Aliases:     []string{"ls"},
 		Annotations: map[string]string{"group": "Workspace:"},
-		Short:       "List registered workspaces and their sync state",
+		Short:       "List registered workspaces",
 		Args:        cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(appState.Registry.Workspaces) == 0 {
@@ -21,27 +20,15 @@ func init() {
 					fmt.Println("No workspaces registered. Run `browseros-patch add <name> <path>`.")
 				})
 			}
-			info, err := repoInfo()
-			if err != nil {
-				return err
-			}
 			rows := make([][]string, 0, len(appState.Registry.Workspaces))
-			statuses := make([]*engine.WorkspaceStatus, 0, len(appState.Registry.Workspaces))
 			for _, ws := range appState.Registry.Workspaces {
-				status, err := engine.InspectWorkspace(cmd.Context(), ws, info)
-				if err != nil {
-					return err
-				}
-				statuses = append(statuses, status)
 				rows = append(rows, []string{
 					ws.Name,
-					status.SyncState,
-					fmt.Sprintf("%d/%d/%d", len(status.UpToDate), len(status.NeedsUpdate), len(status.Orphaned)),
 					ws.Path,
 				})
 			}
-			return renderResult(map[string]any{"workspaces": statuses}, func() {
-				fmt.Println(ui.RenderTable([]string{"NAME", "STATE", "PATCHES", "PATH"}, rows))
+			return renderResult(map[string]any{"workspaces": appState.Registry.Workspaces}, func() {
+				fmt.Println(ui.RenderTable([]string{"NAME", "PATH"}, rows))
 			})
 		},
 	}

--- a/packages/browseros/tools/patch/cmd/publish.go
+++ b/packages/browseros/tools/patch/cmd/publish.go
@@ -24,7 +24,12 @@ func init() {
 			if len(args) == 1 {
 				remote = args[0]
 			}
-			result, err := engine.Publish(cmd.Context(), info, remote, message)
+			result, err := engine.Publish(cmd.Context(), engine.PublishOptions{
+				Repo:     info,
+				Remote:   remote,
+				Message:  message,
+				Progress: commandProgress(cmd),
+			})
 			if err != nil {
 				return err
 			}

--- a/packages/browseros/tools/patch/cmd/skip.go
+++ b/packages/browseros/tools/patch/cmd/skip.go
@@ -20,7 +20,10 @@ func init() {
 			if err != nil {
 				return err
 			}
-			result, err := engine.Skip(cmd.Context(), ws)
+			result, err := engine.Skip(cmd.Context(), engine.SkipOptions{
+				Workspace: ws,
+				Progress:  commandProgress(cmd),
+			})
 			if err != nil {
 				return err
 			}

--- a/packages/browseros/tools/patch/cmd/status.go
+++ b/packages/browseros/tools/patch/cmd/status.go
@@ -24,10 +24,11 @@ func init() {
 			if err != nil {
 				return err
 			}
-			if progress := commandProgress(cmd); progress != nil {
-				progress.Step("Inspecting workspace drift")
-			}
-			status, err := engine.InspectWorkspace(cmd.Context(), ws, info)
+			status, err := engine.InspectWorkspace(cmd.Context(), engine.InspectWorkspaceOptions{
+				Workspace: ws,
+				Repo:      info,
+				Progress:  commandProgress(cmd),
+			})
 			if err != nil {
 				return err
 			}

--- a/packages/browseros/tools/patch/cmd/status.go
+++ b/packages/browseros/tools/patch/cmd/status.go
@@ -24,6 +24,9 @@ func init() {
 			if err != nil {
 				return err
 			}
+			if progress := commandProgress(cmd); progress != nil {
+				progress.Step("Inspecting workspace drift")
+			}
 			status, err := engine.InspectWorkspace(cmd.Context(), ws, info)
 			if err != nil {
 				return err

--- a/packages/browseros/tools/patch/cmd/sync.go
+++ b/packages/browseros/tools/patch/cmd/sync.go
@@ -31,6 +31,7 @@ func init() {
 				Repo:      info,
 				Remote:    remote,
 				Rebase:    rebase,
+				Progress:  commandProgress(cmd),
 			})
 			if err != nil {
 				return err

--- a/packages/browseros/tools/patch/internal/engine/apply.go
+++ b/packages/browseros/tools/patch/internal/engine/apply.go
@@ -23,6 +23,7 @@ type ApplyOptions struct {
 	RangeEnd   string
 	Filters    []string
 	Mode       string
+	Progress   Progress
 }
 
 type ApplyResult struct {
@@ -41,10 +42,12 @@ func Apply(ctx context.Context, opts ApplyOptions) (*ApplyResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	reportProgress(opts.Progress, "Inspecting workspace changes")
 	ops, orphaned, err := buildApplyOperations(ctx, opts)
 	if err != nil {
 		return nil, err
 	}
+	reportProgress(opts.Progress, "Applying %d patch %s", len(ops), plural(len(ops), "operation", "operations"))
 	result := &ApplyResult{
 		Workspace:  opts.Workspace.Name,
 		Mode:       applyMode(opts),
@@ -61,7 +64,7 @@ func Apply(ctx context.Context, opts ApplyOptions) (*ApplyResult, error) {
 		}
 		return result, nil
 	}
-	next, err := applyOperationRange(ctx, opts.Workspace, opts.Repo, ops, 0, nil, nil, result)
+	next, err := applyOperationRange(ctx, opts.Workspace, opts.Repo, ops, 0, nil, nil, result, opts.Progress)
 	if err != nil {
 		return nil, err
 	}
@@ -77,7 +80,14 @@ func Apply(ctx context.Context, opts ApplyOptions) (*ApplyResult, error) {
 	return result, nil
 }
 
-func Continue(ctx context.Context, ws workspace.Entry) (*ApplyResult, error) {
+type ContinueOptions struct {
+	Workspace workspace.Entry
+	Progress  Progress
+}
+
+// Continue resumes a saved patch application after the current conflict is resolved.
+func Continue(ctx context.Context, opts ContinueOptions) (*ApplyResult, error) {
+	ws := opts.Workspace
 	state, err := resolve.Load(ws.Path)
 	if err != nil {
 		return nil, err
@@ -102,7 +112,8 @@ func Continue(ctx context.Context, ws workspace.Entry) (*ApplyResult, error) {
 		Applied:    append([]string{}, state.Resolved...),
 		Conflicts:  nil,
 	}
-	next, err := applyOperationRange(ctx, ws, repoInfo, state.Operations, state.Current+1, state.Resolved, state.Skipped, result)
+	reportProgress(opts.Progress, "Continuing patch resolution")
+	next, err := applyOperationRange(ctx, ws, repoInfo, state.Operations, state.Current+1, state.Resolved, state.Skipped, result, opts.Progress)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +128,14 @@ func Continue(ctx context.Context, ws workspace.Entry) (*ApplyResult, error) {
 	return result, nil
 }
 
-func Skip(ctx context.Context, ws workspace.Entry) (*ApplyResult, error) {
+type SkipOptions struct {
+	Workspace workspace.Entry
+	Progress  Progress
+}
+
+// Skip records the current conflict as skipped and resumes the remaining patch operations.
+func Skip(ctx context.Context, opts SkipOptions) (*ApplyResult, error) {
+	ws := opts.Workspace
 	state, err := resolve.Load(ws.Path)
 	if err != nil {
 		return nil, err
@@ -138,7 +156,8 @@ func Skip(ctx context.Context, ws workspace.Entry) (*ApplyResult, error) {
 		RepoRev:    state.RepoRev,
 		Applied:    append([]string{}, state.Resolved...),
 	}
-	next, err := applyOperationRange(ctx, ws, repoInfo, state.Operations, state.Current+1, state.Resolved, state.Skipped, result)
+	reportProgress(opts.Progress, "Skipping current conflict")
+	next, err := applyOperationRange(ctx, ws, repoInfo, state.Operations, state.Current+1, state.Resolved, state.Skipped, result, opts.Progress)
 	if err != nil {
 		return nil, err
 	}
@@ -244,6 +263,7 @@ func applyOperationRange(
 	resolved []string,
 	skipped []string,
 	result *ApplyResult,
+	progress Progress,
 ) (int, error) {
 	repoSet, err := patch.LoadRepoPatchSet(repoInfo.PatchesDir, nil)
 	if err != nil {
@@ -251,6 +271,7 @@ func applyOperationRange(
 	}
 	for idx := start; idx < len(ops); idx++ {
 		op := ops[idx]
+		reportProgress(progress, "Applying %d/%d %s", idx+1, len(ops), op.ChromiumPath)
 		result.ResetPaths = append(result.ResetPaths, op.ChromiumPath)
 		if op.OldPath != "" {
 			if err := git.ResetPathToCommit(ctx, ws.Path, repoInfo.BaseCommit, op.OldPath); err != nil {

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -87,7 +88,7 @@ func TestPublishReturnsHelpfulErrorWhenNothingChanged(t *testing.T) {
 	if err != nil {
 		t.Fatalf("repo.Load: %v", err)
 	}
-	if _, err := Publish(ctx, repoInfo, "", ""); err == nil || !strings.Contains(err.Error(), "nothing to publish") {
+	if _, err := Publish(ctx, PublishOptions{Repo: repoInfo}); err == nil || !strings.Contains(err.Error(), "nothing to publish") {
 		t.Fatalf("expected helpful no-op error, got %v", err)
 	}
 }
@@ -108,6 +109,47 @@ func TestOperationsFromChangesNormalizesOldPath(t *testing.T) {
 	if ops[0].OldPath != "chrome/old.cc" {
 		t.Fatalf("unexpected old path: %q", ops[0].OldPath)
 	}
+}
+
+func TestApplyReportsPatchProgress(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser.cc"), "base\n")
+	runGit(t, workspacePath, "add", "chrome/browser.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser.cc"), "patched\n")
+	diff, err := git.DiffText(ctx, workspacePath, baseCommit, "--", "chrome/browser.cc")
+	if err != nil {
+		t.Fatalf("DiffText: %v", err)
+	}
+	runGit(t, workspacePath, "checkout", "--", "chrome/browser.cc")
+
+	repoRoot := initGitRepo(t)
+	writeFile(t, filepath.Join(repoRoot, "BASE_COMMIT"), baseCommit+"\n")
+	writeFile(t, filepath.Join(repoRoot, "chromium_patches", "chrome", "browser.cc"), diff)
+	runGit(t, repoRoot, "add", "BASE_COMMIT", "chromium_patches/chrome/browser.cc")
+	runGit(t, repoRoot, "commit", "-m", "patch repo init")
+	repoInfo, err := repo.Load(repoRoot)
+	if err != nil {
+		t.Fatalf("repo.Load: %v", err)
+	}
+
+	progress := &progressRecorder{}
+	_, err = Apply(ctx, ApplyOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+		Progress:  progress,
+	})
+	if err != nil {
+		t.Fatalf("Apply: %v", err)
+	}
+
+	progress.requireContains(t, "Inspecting workspace changes")
+	progress.requireContains(t, "Applying 1 patch operation")
+	progress.requireContains(t, "Applying 1/1 chrome/browser.cc")
+	assertFile(t, filepath.Join(workspacePath, "chrome", "browser.cc"), "patched\n")
 }
 
 func TestSyncClearsPendingStashAfterSuccessfulNonRebaseRun(t *testing.T) {
@@ -168,6 +210,47 @@ func TestSyncClearsPendingStashAfterSuccessfulNonRebaseRun(t *testing.T) {
 	}
 }
 
+func TestSyncReportsPatchRepoProgress(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser.cc"), "base\n")
+	runGit(t, workspacePath, "add", "chrome/browser.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	remoteRepo := t.TempDir()
+	runGit(t, remoteRepo, "init", "--bare")
+
+	repoRoot := initGitRepo(t)
+	if err := os.MkdirAll(filepath.Join(repoRoot, "chromium_patches"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	writeFile(t, filepath.Join(repoRoot, "BASE_COMMIT"), baseCommit+"\n")
+	runGit(t, repoRoot, "add", "BASE_COMMIT")
+	runGit(t, repoRoot, "commit", "-m", "patch repo init")
+	runGit(t, repoRoot, "remote", "add", "origin", remoteRepo)
+	runGit(t, repoRoot, "push", "-u", "origin", "HEAD")
+
+	repoInfo, err := repo.Load(repoRoot)
+	if err != nil {
+		t.Fatalf("repo.Load: %v", err)
+	}
+	progress := &progressRecorder{}
+	_, err = Sync(ctx, SyncOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+		Remote:    "origin",
+		Progress:  progress,
+	})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+
+	progress.requireContains(t, "Checking patch repo status")
+	progress.requireContains(t, "Pulling patch repo from origin/")
+	progress.requireContains(t, "Inspecting workspace drift")
+}
+
 func initGitRepo(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -175,6 +258,24 @@ func initGitRepo(t *testing.T) string {
 	runGit(t, dir, "config", "user.name", "Test User")
 	runGit(t, dir, "config", "user.email", "test@example.com")
 	return dir
+}
+
+type progressRecorder struct {
+	messages []string
+}
+
+func (p *progressRecorder) Step(message string) {
+	p.messages = append(p.messages, message)
+}
+
+func (p *progressRecorder) requireContains(t *testing.T, want string) {
+	t.Helper()
+	if slices.ContainsFunc(p.messages, func(message string) bool {
+		return strings.Contains(message, want)
+	}) {
+		return
+	}
+	t.Fatalf("progress missing %q in %#v", want, p.messages)
 }
 
 func runGit(t *testing.T, dir string, args ...string) {

--- a/packages/browseros/tools/patch/internal/engine/extract.go
+++ b/packages/browseros/tools/patch/internal/engine/extract.go
@@ -19,6 +19,7 @@ type ExtractOptions struct {
 	Squash     bool
 	Base       string
 	Filters    []string
+	Progress   Progress
 }
 
 type ExtractResult struct {
@@ -43,6 +44,7 @@ func Extract(ctx context.Context, opts ExtractOptions) (*ExtractResult, error) {
 	switch {
 	case opts.Commit != "":
 		mode = "commit"
+		reportProgress(opts.Progress, "Extracting patches from commit %s", opts.Commit)
 		set, err = patch.BuildCommitPatchSet(ctx, opts.Workspace.Path, opts.Commit, opts.Base, opts.Filters)
 		if err == nil {
 			if opts.Base != "" {
@@ -57,6 +59,7 @@ func Extract(ctx context.Context, opts ExtractOptions) (*ExtractResult, error) {
 		}
 	case opts.RangeStart != "" && opts.RangeEnd != "":
 		mode = "range"
+		reportProgress(opts.Progress, "Extracting patches from range %s..%s", opts.RangeStart, opts.RangeEnd)
 		set, err = patch.BuildRangePatchSet(ctx, opts.Workspace.Path, opts.RangeStart, opts.RangeEnd, opts.Base, opts.Squash, opts.Filters)
 		if err == nil {
 			if opts.Base != "" || opts.Squash {
@@ -71,6 +74,7 @@ func Extract(ctx context.Context, opts ExtractOptions) (*ExtractResult, error) {
 		}
 	default:
 		mode = "working-tree"
+		reportProgress(opts.Progress, "Extracting workspace changes")
 		set, err = patch.BuildWorkingTreePatchSet(ctx, opts.Workspace.Path, base, opts.Filters)
 		if err == nil && len(opts.Filters) > 0 {
 			scope = opts.Filters
@@ -79,6 +83,7 @@ func Extract(ctx context.Context, opts ExtractOptions) (*ExtractResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	reportProgress(opts.Progress, "Writing %d patch %s", len(set), plural(len(set), "file", "files"))
 	written, deleted, err := patch.WriteRepoPatchSet(opts.Repo.PatchesDir, set, scope)
 	if err != nil {
 		return nil, err

--- a/packages/browseros/tools/patch/internal/engine/progress.go
+++ b/packages/browseros/tools/patch/internal/engine/progress.go
@@ -1,0 +1,29 @@
+package engine
+
+import "fmt"
+
+// Progress receives concise updates for operations that can take noticeable time.
+type Progress interface {
+	Step(message string)
+}
+
+type ProgressFunc func(message string)
+
+// Step sends one progress message through f.
+func (f ProgressFunc) Step(message string) {
+	f(message)
+}
+
+func reportProgress(progress Progress, format string, args ...any) {
+	if progress == nil {
+		return
+	}
+	progress.Step(fmt.Sprintf(format, args...))
+}
+
+func plural(count int, singular string, pluralForm string) string {
+	if count == 1 {
+		return singular
+	}
+	return pluralForm
+}

--- a/packages/browseros/tools/patch/internal/engine/progress.go
+++ b/packages/browseros/tools/patch/internal/engine/progress.go
@@ -20,10 +20,3 @@ func reportProgress(progress Progress, format string, args ...any) {
 	}
 	progress.Step(fmt.Sprintf(format, args...))
 }
-
-func plural(count int, singular string, pluralForm string) string {
-	if count == 1 {
-		return singular
-	}
-	return pluralForm
-}

--- a/packages/browseros/tools/patch/internal/engine/publish.go
+++ b/packages/browseros/tools/patch/internal/engine/publish.go
@@ -14,32 +14,44 @@ type PublishResult struct {
 	Message string `json:"message"`
 }
 
-func Publish(ctx context.Context, repoInfo *repo.Info, remote string, message string) (*PublishResult, error) {
-	if remote == "" {
-		remote = "origin"
+type PublishOptions struct {
+	Repo     *repo.Info
+	Remote   string
+	Message  string
+	Progress Progress
+}
+
+// Publish commits chromium_patches changes and pushes them to the selected remote.
+func Publish(ctx context.Context, opts PublishOptions) (*PublishResult, error) {
+	if opts.Remote == "" {
+		opts.Remote = "origin"
 	}
-	if message == "" {
-		message = "chore: update chromium patches"
+	if opts.Message == "" {
+		opts.Message = "chore: update chromium patches"
 	}
-	dirty, err := git.IsDirtyPaths(ctx, repoInfo.Root, []string{"chromium_patches"})
+	reportProgress(opts.Progress, "Checking chromium_patches changes")
+	dirty, err := git.IsDirtyPaths(ctx, opts.Repo.Root, []string{"chromium_patches"})
 	if err != nil {
 		return nil, err
 	}
 	if !dirty {
 		return nil, fmt.Errorf("nothing to publish: chromium_patches has no uncommitted changes")
 	}
-	if err := git.AddPaths(ctx, repoInfo.Root, []string{"chromium_patches"}); err != nil {
+	reportProgress(opts.Progress, "Staging chromium_patches")
+	if err := git.AddPaths(ctx, opts.Repo.Root, []string{"chromium_patches"}); err != nil {
 		return nil, err
 	}
-	if err := git.Commit(ctx, repoInfo.Root, message); err != nil {
+	reportProgress(opts.Progress, "Committing chromium_patches")
+	if err := git.Commit(ctx, opts.Repo.Root, opts.Message); err != nil {
 		return nil, err
 	}
-	branch, err := git.CurrentBranch(ctx, repoInfo.Root)
+	branch, err := git.CurrentBranch(ctx, opts.Repo.Root)
 	if err != nil {
 		return nil, err
 	}
-	if err := git.Push(ctx, repoInfo.Root, remote, branch); err != nil {
+	reportProgress(opts.Progress, "Pushing patch repo to %s/%s", opts.Remote, branch)
+	if err := git.Push(ctx, opts.Repo.Root, opts.Remote, branch); err != nil {
 		return nil, err
 	}
-	return &PublishResult{Remote: remote, Branch: branch, Message: message}, nil
+	return &PublishResult{Remote: opts.Remote, Branch: branch, Message: opts.Message}, nil
 }

--- a/packages/browseros/tools/patch/internal/engine/status.go
+++ b/packages/browseros/tools/patch/internal/engine/status.go
@@ -25,31 +25,41 @@ type WorkspaceStatus struct {
 	SyncState      string          `json:"sync_state"`
 }
 
-func InspectWorkspace(ctx context.Context, ws workspace.Entry, repoInfo *repo.Info) (*WorkspaceStatus, error) {
-	head, err := git.HeadRev(ctx, repoInfo.Root)
+type InspectWorkspaceOptions struct {
+	Workspace workspace.Entry
+	Repo      *repo.Info
+	Progress  Progress
+}
+
+// InspectWorkspace compares a workspace against the patch repo and classifies drift.
+func InspectWorkspace(ctx context.Context, opts InspectWorkspaceOptions) (*WorkspaceStatus, error) {
+	reportProgress(opts.Progress, "Inspecting workspace drift")
+	head, err := git.HeadRev(ctx, opts.Repo.Root)
 	if err != nil {
 		return nil, err
 	}
-	state, err := workspace.LoadState(ws.Path)
+	state, err := workspace.LoadState(opts.Workspace.Path)
 	if err != nil {
 		return nil, err
 	}
-	repoSet, err := patch.LoadRepoPatchSet(repoInfo.PatchesDir, nil)
+	reportProgress(opts.Progress, "Loading repo patch set")
+	repoSet, err := patch.LoadRepoPatchSet(opts.Repo.PatchesDir, nil)
 	if err != nil {
 		return nil, err
 	}
-	localSet, err := patch.BuildWorkingTreePatchSet(ctx, ws.Path, repoInfo.BaseCommit, nil)
+	reportProgress(opts.Progress, "Building workspace patch set")
+	localSet, err := patch.BuildWorkingTreePatchSet(ctx, opts.Workspace.Path, opts.Repo.BaseCommit, nil)
 	if err != nil {
 		return nil, err
 	}
 	status := &WorkspaceStatus{
-		Workspace:      ws,
+		Workspace:      opts.Workspace,
 		RepoHead:       head,
-		BaseCommit:     repoInfo.BaseCommit,
+		BaseCommit:     opts.Repo.BaseCommit,
 		LastApplyRev:   state.LastApplyRev,
 		LastSyncRev:    state.LastSyncRev,
 		LastExtractRev: state.LastExtractRev,
-		ActiveResolve:  resolve.Exists(ws.Path),
+		ActiveResolve:  resolve.Exists(opts.Workspace.Path),
 	}
 	for _, delta := range patch.Compare(repoSet, localSet) {
 		switch delta.Kind {

--- a/packages/browseros/tools/patch/internal/engine/strings.go
+++ b/packages/browseros/tools/patch/internal/engine/strings.go
@@ -1,0 +1,8 @@
+package engine
+
+func plural(count int, singular string, pluralForm string) string {
+	if count == 1 {
+		return singular
+	}
+	return pluralForm
+}

--- a/packages/browseros/tools/patch/internal/engine/sync.go
+++ b/packages/browseros/tools/patch/internal/engine/sync.go
@@ -15,6 +15,7 @@ type SyncOptions struct {
 	Repo      *repo.Info
 	Remote    string
 	Rebase    bool
+	Progress  Progress
 }
 
 type SyncResult struct {
@@ -32,6 +33,7 @@ func Sync(ctx context.Context, opts SyncOptions) (*SyncResult, error) {
 	if opts.Remote == "" {
 		opts.Remote = "origin"
 	}
+	reportProgress(opts.Progress, "Checking patch repo status")
 	dirty, err := git.IsDirty(ctx, opts.Repo.Root)
 	if err != nil {
 		return nil, err
@@ -43,6 +45,7 @@ func Sync(ctx context.Context, opts SyncOptions) (*SyncResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	reportProgress(opts.Progress, "Pulling patch repo from %s/%s", opts.Remote, branch)
 	if err := git.PullRebase(ctx, opts.Repo.Root, opts.Remote, branch); err != nil {
 		return nil, err
 	}
@@ -60,6 +63,7 @@ func Sync(ctx context.Context, opts SyncOptions) (*SyncResult, error) {
 		RepoHead:  head,
 		Rebased:   opts.Rebase,
 	}
+	reportProgress(opts.Progress, "Inspecting workspace drift")
 	status, err := InspectWorkspace(ctx, opts.Workspace, opts.Repo)
 	if err != nil {
 		return nil, err
@@ -67,6 +71,7 @@ func Sync(ctx context.Context, opts SyncOptions) (*SyncResult, error) {
 	divergent := append([]string{}, status.NeedsUpdate...)
 	divergent = append(divergent, status.Orphaned...)
 	if len(divergent) > 0 {
+		reportProgress(opts.Progress, "Stashing %d divergent %s", len(divergent), plural(len(divergent), "file", "files"))
 		stashRef, err := git.StashPush(ctx, opts.Workspace.Path, "browseros-patch sync stash", true, divergent)
 		if err != nil {
 			return nil, err
@@ -84,6 +89,7 @@ func Sync(ctx context.Context, opts SyncOptions) (*SyncResult, error) {
 			Repo:      opts.Repo,
 			Reset:     true,
 			Mode:      "sync-reset",
+			Progress:  opts.Progress,
 		})
 		if err != nil {
 			return nil, err
@@ -102,6 +108,7 @@ func Sync(ctx context.Context, opts SyncOptions) (*SyncResult, error) {
 			ChangedRef: state.LastSyncRev,
 			RangeEnd:   head,
 			Mode:       "sync",
+			Progress:   opts.Progress,
 		})
 		if err != nil {
 			return nil, err
@@ -115,6 +122,7 @@ func Sync(ctx context.Context, opts SyncOptions) (*SyncResult, error) {
 		}
 	}
 	if opts.Rebase && result.StashRef != "" {
+		reportProgress(opts.Progress, "Restoring stashed local changes")
 		if err := git.StashPop(ctx, opts.Workspace.Path, result.StashRef); err != nil {
 			return nil, err
 		}

--- a/packages/browseros/tools/patch/internal/engine/sync.go
+++ b/packages/browseros/tools/patch/internal/engine/sync.go
@@ -63,8 +63,11 @@ func Sync(ctx context.Context, opts SyncOptions) (*SyncResult, error) {
 		RepoHead:  head,
 		Rebased:   opts.Rebase,
 	}
-	reportProgress(opts.Progress, "Inspecting workspace drift")
-	status, err := InspectWorkspace(ctx, opts.Workspace, opts.Repo)
+	status, err := InspectWorkspace(ctx, InspectWorkspaceOptions{
+		Workspace: opts.Workspace,
+		Repo:      opts.Repo,
+		Progress:  opts.Progress,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary
- Make `browseros-patch list` / `ls` a pure registry read that shows configured workspace names and paths without inspecting sync state.
- Add concise progress updates for long-running patch operations such as status, diff, apply, sync, extract, conflict continuation, and publish.
- Keep machine output clean by disabling progress logs when `--json` is used.

## Design
The change keeps registry inspection separate from workspace sync inspection: `list` reads only `workspaces.yaml`, while `status` and `diff` remain responsible for patch state. Long-running operations now use a small engine-level `Progress` callback that command handlers render to stderr in human mode, so engine logic stays testable and JSON output remains stdout-only.

## Compatibility note
`browseros-patch list --json` intentionally now returns registered workspace entries instead of workspace sync status objects. Use `browseros-patch status --json` when sync state is needed.

## Test plan
- `go test -count=1 ./...` from `packages/browseros/tools/patch`
- `go build ./...` from `packages/browseros/tools/patch`
- `git diff --check`
- Manual `browseros-patch list` / `--json list` against a stale invalid workspace config