### PR TITLE
fix: store server database under BrowserOS dir

### DIFF
--- a/packages/browseros-agent/apps/server/src/lib/browseros-dir.ts
+++ b/packages/browseros-agent/apps/server/src/lib/browseros-dir.ts
@@ -59,6 +59,11 @@ export function getCacheDir(): string {
   return join(getBrowserosDir(), PATHS.CACHE_DIR_NAME)
 }
 
+/** Returns the durable SQLite database path for local BrowserOS server state. */
+export function getDbPath(): string {
+  return join(getBrowserosDir(), 'db', 'browseros.sqlite')
+}
+
 export function getVmCacheDir(): string {
   return join(getCacheDir(), 'vm')
 }

--- a/packages/browseros-agent/apps/server/src/lib/browseros-dir.ts
+++ b/packages/browseros-agent/apps/server/src/lib/browseros-dir.ts
@@ -61,7 +61,7 @@ export function getCacheDir(): string {
 
 /** Returns the durable SQLite database path for local BrowserOS server state. */
 export function getDbPath(): string {
-  return join(getBrowserosDir(), 'db', 'browseros.sqlite')
+  return join(getBrowserosDir(), PATHS.DB_DIR_NAME, PATHS.DB_FILE_NAME)
 }
 
 export function getVmCacheDir(): string {

--- a/packages/browseros-agent/apps/server/src/main.ts
+++ b/packages/browseros-agent/apps/server/src/main.ts
@@ -24,6 +24,7 @@ import { INLINED_ENV } from './env'
 import {
   cleanOldSessions,
   ensureBrowserosDir,
+  getDbPath,
   removeServerConfigSync,
   writeServerConfig,
 } from './lib/browseros-dir'
@@ -179,9 +180,8 @@ export class Application {
     await migrateBuiltinSkills()
     await syncBuiltinSkills()
 
-    const dbPath = path.join(this.config.executionDir, 'db', 'browseros.sqlite')
     initializeDb({
-      dbPath,
+      dbPath: getDbPath(),
       resourcesDir: this.config.resourcesDir,
     })
 

--- a/packages/browseros-agent/apps/server/tests/browseros-dir.test.ts
+++ b/packages/browseros-agent/apps/server/tests/browseros-dir.test.ts
@@ -10,6 +10,7 @@ import { PATHS } from '@browseros/shared/constants/paths'
 import {
   getBrowserosDir,
   getCacheDir,
+  getDbPath,
   getVmCacheDir,
   logDevelopmentBrowserosDir,
 } from '../src/lib/browseros-dir'
@@ -88,6 +89,14 @@ describe('getBrowserosDir', () => {
     process.env.NODE_ENV = 'development'
 
     expect(getCacheDir()).toBe(join(homedir(), '.browseros-dev', 'cache'))
+  })
+
+  it('uses the BrowserOS directory for the sqlite database', () => {
+    process.env.NODE_ENV = 'development'
+
+    expect(getDbPath()).toBe(
+      join(homedir(), '.browseros-dev', 'db', 'browseros.sqlite'),
+    )
   })
 
   it('uses the standard cache directory outside development', () => {

--- a/packages/browseros-agent/apps/server/tests/browseros-dir.test.ts
+++ b/packages/browseros-agent/apps/server/tests/browseros-dir.test.ts
@@ -95,7 +95,25 @@ describe('getBrowserosDir', () => {
     process.env.NODE_ENV = 'development'
 
     expect(getDbPath()).toBe(
-      join(homedir(), '.browseros-dev', 'db', 'browseros.sqlite'),
+      join(
+        homedir(),
+        PATHS.DEV_BROWSEROS_DIR_NAME,
+        PATHS.DB_DIR_NAME,
+        PATHS.DB_FILE_NAME,
+      ),
+    )
+  })
+
+  it('uses the standard BrowserOS directory for the sqlite database outside development', () => {
+    process.env.NODE_ENV = 'test'
+
+    expect(getDbPath()).toBe(
+      join(
+        homedir(),
+        PATHS.BROWSEROS_DIR_NAME,
+        PATHS.DB_DIR_NAME,
+        PATHS.DB_FILE_NAME,
+      ),
     )
   })
 

--- a/packages/browseros-agent/apps/server/tests/main.test.ts
+++ b/packages/browseros-agent/apps/server/tests/main.test.ts
@@ -89,6 +89,29 @@ describe('Application.start', () => {
       error: 'registry offline',
     })
   })
+
+  it('stores the database below the BrowserOS directory instead of the execution directory', async () => {
+    const originalBrowserosDir = process.env.BROWSEROS_DIR
+    process.env.BROWSEROS_DIR = '/tmp/browseros-dogfood'
+
+    try {
+      const { Application, initializeDb } = await setupApplicationTest()
+      const app = new Application(config)
+
+      await app.start()
+
+      expect(initializeDb).toHaveBeenCalledWith({
+        dbPath: '/tmp/browseros-dogfood/db/browseros.sqlite',
+        resourcesDir: config.resourcesDir,
+      })
+    } finally {
+      if (originalBrowserosDir === undefined) {
+        delete process.env.BROWSEROS_DIR
+      } else {
+        process.env.BROWSEROS_DIR = originalBrowserosDir
+      }
+    }
+  })
 })
 
 async function setupApplicationTest() {
@@ -121,7 +144,7 @@ async function setupApplicationTest() {
   spyOn(browserosDir, 'writeServerConfig').mockImplementation(async () => {})
   spyOn(browserosDir, 'removeServerConfigSync').mockImplementation(() => {})
 
-  spyOn(dbModule, 'initializeDb').mockImplementation(
+  const initializeDb = spyOn(dbModule, 'initializeDb').mockImplementation(
     () =>
       ({
         path: '/tmp/browseros-execution/db/browseros.sqlite',
@@ -192,6 +215,7 @@ async function setupApplicationTest() {
     loggerError,
     loggerInfo,
     loggerWarn,
+    initializeDb,
     openClawService: { prewarm, tryAutoStart },
   }
 }

--- a/packages/browseros-agent/apps/server/tests/main.test.ts
+++ b/packages/browseros-agent/apps/server/tests/main.test.ts
@@ -147,7 +147,7 @@ async function setupApplicationTest() {
   const initializeDb = spyOn(dbModule, 'initializeDb').mockImplementation(
     () =>
       ({
-        path: '/tmp/browseros-execution/db/browseros.sqlite',
+        path: '/tmp/browseros-state/db/browseros.sqlite',
         migrationsDir: '/tmp/browseros-resources/db/migrations',
         sqlite: { close: () => {} },
         db: {},

--- a/packages/browseros-agent/packages/shared/src/constants/paths.ts
+++ b/packages/browseros-agent/packages/shared/src/constants/paths.ts
@@ -11,6 +11,8 @@ export const PATHS = {
   BROWSEROS_DIR_NAME: '.browseros',
   DEV_BROWSEROS_DIR_NAME: '.browseros-dev',
   CACHE_DIR_NAME: 'cache',
+  DB_DIR_NAME: 'db',
+  DB_FILE_NAME: 'browseros.sqlite',
   MEMORY_DIR_NAME: 'memory',
   SESSIONS_DIR_NAME: 'sessions',
   TOOL_OUTPUT_DIR_NAME: 'tool-output',


### PR DESCRIPTION
Summary
- Move the server SQLite database path out of executionDir and into the BrowserOS state directory.
- Centralize the database path in browseros-dir.ts so dogfood uses BROWSEROS_DIR, including ~/.browseros-dogfood.
- Add regression coverage for startup DB initialization and direct path resolution.

Design
Application startup now calls getDbPath() from browseros-dir.ts when initializing Drizzle SQLite. That keeps durable server DB state next to the rest of BrowserOS state while leaving resourcesDir responsible only for packaged migrations. DB directory and filename constants live in PATHS with the other filesystem path names.

Upgrade note
This intentionally does not migrate the old executionDir SQLite database. That DB was introduced during alpha and is disposable; avoiding migration keeps this fix focused on moving durable state to the correct BrowserOS directory.

Test plan
- bun --env-file=apps/server/.env.development test apps/server/tests/main.test.ts apps/server/tests/browseros-dir.test.ts
- bunx biome check --write packages/shared/src/constants/paths.ts apps/server/src/lib/browseros-dir.ts apps/server/tests/main.test.ts apps/server/tests/browseros-dir.test.ts
- bun run --filter @browseros/server typecheck
- bun run test:root from apps/server