### PR TITLE
feat: add ACPX agent runtime adapters

### DIFF
--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-agent-adapter.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-agent-adapter.ts
@@ -1,0 +1,76 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { createRuntimeStore } from 'acpx/runtime'
+import type { OpenClawGatewayChatClient } from '../../api/services/openclaw/openclaw-gateway-chat-client'
+import type { AgentDefinition } from './agent-types'
+import { prepareClaudeCodeContext } from './claude-code/prepare'
+import { prepareCodexContext } from './codex/prepare'
+import {
+  maybeHandleOpenClawTurn,
+  prepareOpenClawContext,
+} from './openclaw/prepare'
+import type { AgentPromptInput, AgentStreamEvent } from './types'
+
+export interface PreparedAcpxAgentContext {
+  cwd: string
+  runtimeSessionKey: string
+  runPrompt: string
+  commandEnv: Record<string, string>
+  commandIdentity: string
+  useBrowserosMcp: boolean
+  openclawSessionKey: string | null
+}
+
+export interface PrepareAcpxAgentContextInput {
+  browserosDir: string
+  agent: AgentDefinition
+  sessionId: 'main'
+  sessionKey: string
+  cwdOverride: string | null
+  isSelectedCwd: boolean
+  message: string
+}
+
+export interface AcpxAdapterTurnInput {
+  prompt: AgentPromptInput
+  prepared: PreparedAcpxAgentContext
+  sessionStore: ReturnType<typeof createRuntimeStore>
+  openclawGatewayChat: OpenClawGatewayChatClient | null
+}
+
+export interface AcpxAgentAdapter {
+  id: AgentDefinition['adapter']
+  prepare(
+    input: PrepareAcpxAgentContextInput,
+  ): Promise<PreparedAcpxAgentContext>
+  maybeHandleTurn?(
+    input: AcpxAdapterTurnInput,
+  ): Promise<ReadableStream<AgentStreamEvent> | null>
+}
+
+const ADAPTERS: Record<AgentDefinition['adapter'], AcpxAgentAdapter> = {
+  claude: { id: 'claude', prepare: prepareClaudeCodeContext },
+  codex: { id: 'codex', prepare: prepareCodexContext },
+  openclaw: {
+    id: 'openclaw',
+    prepare: prepareOpenClawContext,
+    maybeHandleTurn: maybeHandleOpenClawTurn,
+  },
+}
+
+export function getAcpxAgentAdapter(
+  adapter: AgentDefinition['adapter'],
+): AcpxAgentAdapter {
+  return ADAPTERS[adapter]
+}
+
+/** Prepares adapter-specific filesystem, prompt, env, and session identity for one ACPX turn. */
+export async function prepareAcpxAgentContext(
+  input: PrepareAcpxAgentContextInput,
+): Promise<PreparedAcpxAgentContext> {
+  return getAcpxAgentAdapter(input.agent.adapter).prepare(input)
+}

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-agent-adapter.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-agent-adapter.ts
@@ -43,7 +43,6 @@ export interface AcpxAdapterTurnInput {
 }
 
 export interface AcpxAgentAdapter {
-  id: AgentDefinition['adapter']
   prepare(
     input: PrepareAcpxAgentContextInput,
   ): Promise<PreparedAcpxAgentContext>
@@ -53,10 +52,9 @@ export interface AcpxAgentAdapter {
 }
 
 const ADAPTERS: Record<AgentDefinition['adapter'], AcpxAgentAdapter> = {
-  claude: { id: 'claude', prepare: prepareClaudeCodeContext },
-  codex: { id: 'codex', prepare: prepareCodexContext },
+  claude: { prepare: prepareClaudeCodeContext },
+  codex: { prepare: prepareCodexContext },
   openclaw: {
-    id: 'openclaw',
     prepare: prepareOpenClawContext,
     maybeHandleTurn: maybeHandleOpenClawTurn,
   },

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-agent-common.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-agent-common.ts
@@ -1,0 +1,95 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {
+  PrepareAcpxAgentContextInput,
+  PreparedAcpxAgentContext,
+} from './acpx-agent-adapter'
+import type { AgentRuntimePaths } from './acpx-runtime-context'
+import {
+  BROWSEROS_ACPX_OPERATING_PROMPT_VERSION,
+  buildAcpxRuntimePromptPrefix,
+  buildBrowserosAcpPrompt,
+  ensureAgentHome,
+  ensureRuntimeSkills,
+  ensureUsableCwd,
+  resolveAgentRuntimePaths,
+} from './acpx-runtime-context'
+import {
+  deriveRuntimeSessionKey,
+  saveLatestRuntimeState,
+} from './acpx-runtime-state'
+
+export interface BrowserosManagedContext {
+  input: PrepareAcpxAgentContextInput
+  paths: AgentRuntimePaths
+  skillNames: string[]
+  promptPrefix: string
+}
+
+/** Builds the common BrowserOS-managed home, skills, cwd, and prompt prefix for Claude/Codex. */
+export async function prepareBrowserosManagedContext(
+  input: PrepareAcpxAgentContextInput,
+): Promise<BrowserosManagedContext> {
+  const paths = resolveAgentRuntimePaths({
+    browserosDir: input.browserosDir,
+    agentId: input.agent.id,
+    cwd: input.cwdOverride,
+  })
+  await ensureUsableCwd(paths.effectiveCwd, !input.isSelectedCwd)
+  await ensureAgentHome(paths)
+  const skillNames = await ensureRuntimeSkills(paths.runtimeSkillsDir)
+  const promptPrefix = buildAcpxRuntimePromptPrefix({
+    agent: input.agent,
+    paths,
+    skillNames,
+  })
+  return { input, paths, skillNames, promptPrefix }
+}
+
+/** Finalizes BrowserOS-managed prep into the uniform adapter context consumed by AcpxRuntime. */
+export async function finishBrowserosManagedContext(input: {
+  input: PrepareAcpxAgentContextInput
+  paths: AgentRuntimePaths
+  skillNames: string[]
+  promptPrefix: string
+  commandEnv: Record<string, string>
+}): Promise<PreparedAcpxAgentContext> {
+  const commandIdentity = stableCommandIdentity(input.commandEnv)
+  const runtimeSessionKey = deriveRuntimeSessionKey({
+    agentId: input.input.agent.id,
+    sessionId: input.input.sessionId,
+    adapter: input.input.agent.adapter,
+    cwd: input.paths.effectiveCwd,
+    agentHome: input.paths.agentHome,
+    promptVersion: BROWSEROS_ACPX_OPERATING_PROMPT_VERSION,
+    skillIdentity: input.skillNames.join(','),
+    commandIdentity,
+  })
+  await saveLatestRuntimeState(input.paths.runtimeStatePath, {
+    sessionId: input.input.sessionId,
+    runtimeSessionKey,
+    cwd: input.paths.effectiveCwd,
+    agentHome: input.paths.agentHome,
+    updatedAt: Date.now(),
+  })
+  return {
+    cwd: input.paths.effectiveCwd,
+    runtimeSessionKey,
+    runPrompt: buildBrowserosAcpPrompt(input.promptPrefix, input.input.message),
+    commandEnv: input.commandEnv,
+    commandIdentity,
+    useBrowserosMcp: true,
+    openclawSessionKey: null,
+  }
+}
+
+export function stableCommandIdentity(env: Record<string, string>): string {
+  return Object.entries(env)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n')
+}

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime-context.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime-context.ts
@@ -144,7 +144,7 @@ export async function materializeClaudeConfig(input: {
   }
 }
 
-/** Builds the stable BrowserOS operating instructions prepended to ACP turns. */
+/** Builds stable BrowserOS-managed instructions for Claude/Codex ACP turns. */
 export function buildAcpxRuntimePromptPrefix(input: {
   agent: AgentDefinition
   paths: AgentRuntimePaths

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime-context.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime-context.ts
@@ -35,7 +35,9 @@ export interface AgentRuntimePaths {
   effectiveCwd: string
   runtimeStatePath: string
   runtimeSkillsDir: string
+  runtimeRoot: string
   codexHome: string
+  claudeConfigDir: string
 }
 
 export function resolveAgentRuntimePaths(input: {
@@ -45,6 +47,7 @@ export function resolveAgentRuntimePaths(input: {
 }): AgentRuntimePaths {
   const harnessDir = join(input.browserosDir, 'agents', 'harness')
   const defaultWorkspaceCwd = join(harnessDir, 'workspace')
+  const runtimeRoot = join(harnessDir, input.agentId, 'runtime')
   return {
     browserosDir: input.browserosDir,
     harnessDir,
@@ -57,7 +60,9 @@ export function resolveAgentRuntimePaths(input: {
       `${input.agentId}.json`,
     ),
     runtimeSkillsDir: join(harnessDir, 'runtime-skills'),
-    codexHome: join(harnessDir, input.agentId, 'runtime', 'codex-home'),
+    runtimeRoot,
+    codexHome: join(runtimeRoot, 'codex-home'),
+    claudeConfigDir: join(runtimeRoot, 'claude-config'),
   }
 }
 
@@ -110,6 +115,35 @@ export async function materializeCodexHome(input: {
   }
 }
 
+const CLAUDE_CONFIG_SEED_FILES = [
+  '.credentials.json',
+  'credentials.json',
+  'settings.json',
+  'settings.local.json',
+  'CLAUDE.md',
+] as const
+
+/** Prepares the Claude config dir that the ACP adapter will see through CLAUDE_CONFIG_DIR. */
+export async function materializeClaudeConfig(input: {
+  paths: AgentRuntimePaths
+  sourceClaudeConfigDir?: string
+}): Promise<void> {
+  await mkdir(input.paths.claudeConfigDir, { recursive: true })
+  const source =
+    input.sourceClaudeConfigDir ??
+    process.env.CLAUDE_CONFIG_DIR?.trim() ??
+    join(homedir(), '.claude')
+  for (const file of CLAUDE_CONFIG_SEED_FILES) {
+    const sourcePath = join(source, file)
+    const targetPath = join(input.paths.claudeConfigDir, file)
+    if (file.includes('credentials')) {
+      await symlinkIfPresent(sourcePath, targetPath)
+    } else {
+      await copyIfPresent(sourcePath, targetPath)
+    }
+  }
+}
+
 /** Builds the stable BrowserOS operating instructions prepended to ACP turns. */
 export function buildAcpxRuntimePromptPrefix(input: {
   agent: AgentDefinition
@@ -134,6 +168,12 @@ BrowserOS has made runtime skills available for this ACPX session.
 Skill root: ${input.paths.runtimeSkillsDir}
 Available skills: ${input.skillNames.join(', ')}
 When a task calls for one of these skills, read its SKILL.md from that root and follow it.
+
+When the user asks you to remember, save feedback, store a preference, or update memory in this BrowserOS ACPX context, use the BrowserOS memory skill.
+Write BrowserOS memory only under AGENT_HOME:
+- AGENT_HOME/MEMORY.md for durable promoted preferences and operating patterns.
+- AGENT_HOME/memory/YYYY-MM-DD.md for daily notes and candidate memories.
+Do not use native Claude project memory, native CLI memory, or workspace files for BrowserOS memory.
 </browseros_acpx_runtime>`
 }
 
@@ -207,7 +247,7 @@ async function sourceFileExists(path: string): Promise<boolean> {
     throw err
   }
   if (!info.isFile()) {
-    throw new Error(`Expected Codex source file to be a file: ${path}`)
+    throw new Error(`Expected source file to be a file: ${path}`)
   }
   return true
 }

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime-context.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime-context.ts
@@ -37,7 +37,6 @@ export interface AgentRuntimePaths {
   runtimeSkillsDir: string
   runtimeRoot: string
   codexHome: string
-  claudeConfigDir: string
 }
 
 export function resolveAgentRuntimePaths(input: {
@@ -62,7 +61,6 @@ export function resolveAgentRuntimePaths(input: {
     runtimeSkillsDir: join(harnessDir, 'runtime-skills'),
     runtimeRoot,
     codexHome: join(runtimeRoot, 'codex-home'),
-    claudeConfigDir: join(runtimeRoot, 'claude-config'),
   }
 }
 
@@ -112,35 +110,6 @@ export async function materializeCodexHome(input: {
         'utf8',
       ),
     )
-  }
-}
-
-const CLAUDE_CONFIG_SEED_FILES = [
-  '.credentials.json',
-  'credentials.json',
-  'settings.json',
-  'settings.local.json',
-  'CLAUDE.md',
-] as const
-
-/** Prepares the Claude config dir that the ACP adapter will see through CLAUDE_CONFIG_DIR. */
-export async function materializeClaudeConfig(input: {
-  paths: AgentRuntimePaths
-  sourceClaudeConfigDir?: string
-}): Promise<void> {
-  await mkdir(input.paths.claudeConfigDir, { recursive: true })
-  const source =
-    input.sourceClaudeConfigDir ??
-    process.env.CLAUDE_CONFIG_DIR?.trim() ??
-    join(homedir(), '.claude')
-  for (const file of CLAUDE_CONFIG_SEED_FILES) {
-    const sourcePath = join(source, file)
-    const targetPath = join(input.paths.claudeConfigDir, file)
-    if (file.includes('credentials')) {
-      await symlinkIfPresent(sourcePath, targetPath)
-    } else {
-      await copyIfPresent(sourcePath, targetPath)
-    }
   }
 }
 

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime-context.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime-context.ts
@@ -188,6 +188,40 @@ export function wrapCommandWithEnv(
   return prefix ? `env ${prefix} ${command}` : command
 }
 
+/** Ensures the runtime cwd exists, creating only the managed default workspace. */
+export async function ensureUsableCwd(
+  cwd: string,
+  isDefaultWorkspace: boolean,
+): Promise<void> {
+  if (isDefaultWorkspace) {
+    await mkdir(cwd, { recursive: true })
+    return
+  }
+  let info: Stats
+  try {
+    info = await stat(cwd)
+  } catch (err) {
+    if (isNotFoundError(err)) {
+      throw new Error(`Selected workspace does not exist: ${cwd}`)
+    }
+    throw err
+  }
+  if (!info.isDirectory()) {
+    throw new Error(`Selected workspace is not a directory: ${cwd}`)
+  }
+}
+
+export function buildBrowserosAcpPrompt(
+  prefix: string,
+  message: string,
+): string {
+  return `${prefix}
+
+<user_request>
+${escapePromptTagText(message)}
+</user_request>`
+}
+
 async function writeFileIfMissing(
   path: string,
   content: string,
@@ -254,6 +288,13 @@ async function sourceFileExists(path: string): Promise<boolean> {
 
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`
+}
+
+function escapePromptTagText(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
 }
 
 function isNotFoundError(err: unknown): boolean {

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime-templates.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime-templates.ts
@@ -114,6 +114,11 @@ Do not store memory files in the project workspace.
 
 ## Write
 
+- When the user explicitly asks you to remember, save feedback, store a preference, or update memory, use this skill.
+- Write BrowserOS memory only under $AGENT_HOME.
+- Use $AGENT_HOME/MEMORY.md for durable promoted preferences and operating patterns.
+- Use $AGENT_HOME/memory/YYYY-MM-DD.md for daily notes and candidate memories.
+- Do not use native Claude project memory, native CLI memory, or workspace files for BrowserOS memory.
 - Put observations and task breadcrumbs in today's daily note first.
 - Promote only stable patterns into MEMORY.md.
 - Do not promote one-off facts, raw transcripts, temporary state, secrets, or credentials.

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
@@ -4,7 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
 import { OPENCLAW_GATEWAY_CONTAINER_PORT } from '@browseros/shared/constants/openclaw'
 import { DEFAULT_PORTS } from '@browseros/shared/constants/ports'
@@ -20,16 +19,14 @@ import {
   createAgentRegistry,
   createRuntimeStore,
 } from 'acpx/runtime'
-import type {
-  OpenAIChatMessage,
-  OpenAIContentPart,
-  OpenClawGatewayChatClient,
-} from '../../api/services/openclaw/openclaw-gateway-chat-client'
+import type { OpenClawGatewayChatClient } from '../../api/services/openclaw/openclaw-gateway-chat-client'
 import { getBrowserosDir } from '../browseros-dir'
 import { logger } from '../logger'
-import { prepareAcpxAgentContext } from './acpx-agent-adapter'
 import {
-  buildBrowserosAcpPrompt,
+  getAcpxAgentAdapter,
+  prepareAcpxAgentContext,
+} from './acpx-agent-adapter'
+import {
   resolveAgentRuntimePaths,
   wrapCommandWithEnv,
 } from './acpx-runtime-context'
@@ -208,19 +205,23 @@ export class AcpxRuntime implements AgentRuntime {
       imageAttachmentCount: imageAttachments.length,
     })
 
-    // Image carve-out for OpenClaw: the openclaw `acp` bridge silently
-    // drops ACP `image` content blocks, so the model never sees the
-    // attachment. Divert image-bearing turns to the gateway's HTTP
-    // /v1/chat/completions endpoint (which accepts OpenAI-style
-    // `image_url` parts) and pipe its SSE back through the same
-    // AgentStreamEvent shape callers already consume.
-    if (
-      input.agent.adapter === 'openclaw' &&
-      imageAttachments.length > 0 &&
-      this.openclawGatewayChat
-    ) {
-      return this.sendOpenclawViaGateway(input, imageAttachments, cwd)
-    }
+    const adapter = getAcpxAgentAdapter(input.agent.adapter)
+    const adapterStream =
+      (await adapter.maybeHandleTurn?.({
+        prompt: input,
+        prepared: {
+          cwd: prepared.cwd,
+          runtimeSessionKey: prepared.runtimeSessionKey,
+          runPrompt: prepared.runPrompt,
+          commandEnv: prepared.agentCommandEnv,
+          commandIdentity: prepared.commandIdentity,
+          useBrowserosMcp: prepared.useBrowserosMcp,
+          openclawSessionKey: prepared.openclawSessionKey,
+        },
+        sessionStore: this.sessionStore,
+        openclawGatewayChat: this.openclawGatewayChat,
+      })) ?? null
+    if (adapterStream) return adapterStream
 
     const runtime = this.getRuntime({
       cwd,
@@ -327,191 +328,6 @@ export class AcpxRuntime implements AgentRuntime {
     })
     return runtime
   }
-
-  /**
-   * Drives an OpenClaw turn that includes image attachments through the
-   * gateway HTTP endpoint, which translates OpenAI-style `image_url`
-   * content parts into provider-native multimodal calls. Streams back
-   * `AgentStreamEvent` so the chat panel renders identically to ACP
-   * turns. On natural completion, appends a synthetic user+assistant
-   * pair to the acpx session record so the turn shows up in
-   * `getHistory()` after a reload.
-   *
-   * Persistence is best-effort: when no session record exists yet (e.g.
-   * the very first turn for a fresh agent is image-only), the live
-   * stream still works but the turn is absent from history on reload.
-   * Subsequent text turns through ACP create/update the record normally.
-   */
-  private async sendOpenclawViaGateway(
-    input: AgentPromptInput,
-    imageAttachments: ReadonlyArray<{ mediaType: string; data: string }>,
-    cwd: string,
-  ): Promise<ReadableStream<AgentStreamEvent>> {
-    if (!this.openclawGatewayChat) {
-      throw new Error(
-        'OpenClaw gateway chat client is not wired into AcpxRuntime',
-      )
-    }
-
-    const existingRecord = await this.sessionStore.load(input.sessionKey)
-    const priorMessages = existingRecord
-      ? recordToOpenAIMessages(existingRecord)
-      : []
-    const userContent: OpenAIContentPart[] = [
-      {
-        type: 'text',
-        text: buildBrowserosAcpPrompt(
-          BROWSEROS_ACP_AGENT_INSTRUCTIONS,
-          input.message,
-        ),
-      },
-      ...imageAttachments.map(
-        (a): OpenAIContentPart => ({
-          type: 'image_url',
-          image_url: { url: `data:${a.mediaType};base64,${a.data}` },
-        }),
-      ),
-    ]
-    const messages: OpenAIChatMessage[] = [
-      ...priorMessages,
-      { role: 'user', content: userContent },
-    ]
-
-    logger.info('Agent harness gateway image turn dispatched', {
-      agentId: input.agent.id,
-      sessionKey: input.sessionKey,
-      cwd,
-      priorMessageCount: priorMessages.length,
-      imageAttachmentCount: imageAttachments.length,
-    })
-
-    const upstream = await this.openclawGatewayChat.streamTurn({
-      agentId: input.agent.id,
-      sessionKey: input.sessionKey,
-      messages,
-      signal: input.signal,
-    })
-
-    const sessionStore = this.sessionStore
-    const sessionKey = input.sessionKey
-    const userMessageText = input.message
-    let accumulated = ''
-
-    return new ReadableStream<AgentStreamEvent>({
-      start: (controller) => {
-        const reader = upstream.getReader()
-        const persist = async () => {
-          if (!existingRecord || !accumulated) return
-          try {
-            await persistGatewayTurn(
-              sessionStore,
-              sessionKey,
-              userMessageText,
-              imageAttachments,
-              accumulated,
-            )
-          } catch (err) {
-            logger.warn(
-              'Failed to persist gateway image turn to acpx session record',
-              {
-                sessionKey,
-                error: err instanceof Error ? err.message : String(err),
-              },
-            )
-          }
-        }
-        ;(async () => {
-          try {
-            while (true) {
-              const { done, value } = await reader.read()
-              if (done) break
-              if (value.type === 'text_delta') accumulated += value.text
-              controller.enqueue(value)
-            }
-            await persist()
-            controller.close()
-          } catch (err) {
-            controller.enqueue({
-              type: 'error',
-              message: err instanceof Error ? err.message : String(err),
-            })
-            controller.close()
-          }
-        })().catch(() => {})
-      },
-      cancel: () => {
-        // Best-effort: cancel propagation to the gateway is its own
-        // upstream issue (see plan), but at least drop our reader so
-        // the OpenAI SSE parse loop exits.
-      },
-    })
-  }
-}
-
-async function persistGatewayTurn(
-  sessionStore: ReturnType<typeof createRuntimeStore>,
-  sessionKey: string,
-  userMessageText: string,
-  imageAttachments: ReadonlyArray<{ mediaType: string; data: string }>,
-  assistantText: string,
-): Promise<void> {
-  const record = await sessionStore.load(sessionKey)
-  if (!record) return
-  const userContent: AcpxUserContent[] = [
-    {
-      Text: buildBrowserosAcpPrompt(
-        BROWSEROS_ACP_AGENT_INSTRUCTIONS,
-        userMessageText,
-      ),
-    } as AcpxUserContent,
-  ]
-  for (const _image of imageAttachments) {
-    // The history mapper's `userContentToText` reads `Image.source` and
-    // emits `[image]` for any non-empty value — we just need a truthy
-    // marker so the placeholder renders. We don't store the base64 in
-    // the record (it's already in the gateway's transcript and would
-    // bloat the JSON file).
-    userContent.push({ Image: { source: 'base64' } } as AcpxUserContent)
-  }
-  // The acpx persistence layer requires User messages to carry an `id`
-  // and Agent messages to carry a `tool_results` object — without them
-  // the record fails to round-trip through `parseSessionRecord` on next
-  // load. See acpx/dist/prompt-turn-... `isUserMessage`/`isAgentMessage`.
-  const turnId = randomUUID()
-  const updated = {
-    ...record,
-    messages: [
-      ...record.messages,
-      { User: { id: `user-${turnId}`, content: userContent } },
-      { Agent: { content: [{ Text: assistantText }], tool_results: {} } },
-    ],
-    lastUsedAt: new Date().toISOString(),
-  } as AcpSessionRecord
-  await sessionStore.save(updated)
-}
-
-function recordToOpenAIMessages(record: AcpSessionRecord): OpenAIChatMessage[] {
-  const messages: OpenAIChatMessage[] = []
-  for (const message of record.messages) {
-    if (message === 'Resume') continue
-    if ('User' in message) {
-      const text = message.User.content
-        .map(userContentToText)
-        .filter(Boolean)
-        .join('\n\n')
-        .trim()
-      if (text) messages.push({ role: 'user', content: text })
-      continue
-    }
-    if ('Agent' in message) {
-      const text = message.Agent.content
-        .map((part) => ('Text' in part ? part.Text : ''))
-        .join('')
-        .trim()
-      if (text) messages.push({ role: 'assistant', content: text })
-    }
-  }
-  return messages
 }
 
 type AcpxSessionMessage = AcpSessionRecord['messages'][number]

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
@@ -5,8 +5,6 @@
  */
 
 import { randomUUID } from 'node:crypto'
-import type { Stats } from 'node:fs'
-import { mkdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import { OPENCLAW_GATEWAY_CONTAINER_PORT } from '@browseros/shared/constants/openclaw'
 import { DEFAULT_PORTS } from '@browseros/shared/constants/ports'
@@ -29,21 +27,13 @@ import type {
 } from '../../api/services/openclaw/openclaw-gateway-chat-client'
 import { getBrowserosDir } from '../browseros-dir'
 import { logger } from '../logger'
-import type { AgentRuntimePaths } from './acpx-runtime-context'
+import { prepareAcpxAgentContext } from './acpx-agent-adapter'
 import {
-  BROWSEROS_ACPX_OPERATING_PROMPT_VERSION,
-  buildAcpxRuntimePromptPrefix,
-  ensureAgentHome,
-  ensureRuntimeSkills,
-  materializeCodexHome,
+  buildBrowserosAcpPrompt,
   resolveAgentRuntimePaths,
   wrapCommandWithEnv,
 } from './acpx-runtime-context'
-import {
-  deriveRuntimeSessionKey,
-  loadLatestRuntimeState,
-  saveLatestRuntimeState,
-} from './acpx-runtime-state'
+import { loadLatestRuntimeState } from './acpx-runtime-state'
 import type {
   AgentDefinition,
   AgentHistoryEntry,
@@ -107,6 +97,8 @@ interface PreparedRuntimeContext {
   runPrompt: string
   agentCommandEnv: Record<string, string>
   commandIdentity: string
+  useBrowserosMcp: boolean
+  openclawSessionKey: string | null
 }
 
 const BROWSEROS_ACP_AGENT_INSTRUCTIONS = `<role>
@@ -194,16 +186,11 @@ export class AcpxRuntime implements AgentRuntime {
   async send(
     input: AgentPromptInput,
   ): Promise<ReadableStream<AgentStreamEvent>> {
-    const prepared =
-      input.agent.adapter === 'openclaw'
-        ? null
-        : await this.prepareRuntimeContext(input, input.cwd ?? this.defaultCwd)
-    const cwd =
-      prepared?.cwd ??
-      (await this.resolveNonManagedCwd(
-        input.cwd ?? this.defaultCwd,
-        !!input.cwd,
-      ))
+    const prepared = await this.prepareRuntimeContext(
+      input,
+      input.cwd ?? this.defaultCwd,
+    )
+    const cwd = prepared.cwd
     const imageAttachments = (input.attachments ?? []).filter((a) =>
       a.mediaType.startsWith('image/'),
     )
@@ -239,24 +226,16 @@ export class AcpxRuntime implements AgentRuntime {
       cwd,
       permissionMode: input.permissionMode,
       nonInteractivePermissions: 'fail',
-      commandEnv: prepared?.agentCommandEnv ?? {},
-      commandIdentity: prepared?.commandIdentity ?? 'openclaw',
-      // OpenClaw agents need their gateway sessionKey baked into the
-      // spawn command (acpx does not forward sessionKey to newSession);
-      // claude/codex don't, and including it would split their cache.
-      openclawSessionKey:
-        input.agent.adapter === 'openclaw' ? input.sessionKey : null,
+      commandEnv: prepared.agentCommandEnv,
+      commandIdentity: prepared.commandIdentity,
+      useBrowserosMcp: prepared.useBrowserosMcp,
+      openclawSessionKey: prepared.openclawSessionKey,
     })
 
     return createAcpxEventStream(runtime, input, {
       cwd,
-      runtimeSessionKey: prepared?.runtimeSessionKey ?? input.sessionKey,
-      runPrompt:
-        prepared?.runPrompt ??
-        buildBrowserosAcpPrompt(
-          BROWSEROS_ACP_AGENT_INSTRUCTIONS,
-          input.message,
-        ),
+      runtimeSessionKey: prepared.runtimeSessionKey,
+      runPrompt: prepared.runPrompt,
     })
   }
 
@@ -277,64 +256,27 @@ export class AcpxRuntime implements AgentRuntime {
     return (await this.sessionStore.load(agent.sessionKey)) ?? null
   }
 
-  private async resolveNonManagedCwd(
-    cwdOverride: string | null,
-    isSelectedCwd: boolean,
-  ): Promise<string> {
-    const paths = resolveAgentRuntimePaths({
-      browserosDir: this.browserosDir,
-      agentId: 'openclaw',
-      cwd: cwdOverride,
-    })
-    await ensureUsableCwd(paths.effectiveCwd, !isSelectedCwd)
-    return paths.effectiveCwd
-  }
-
   private async prepareRuntimeContext(
     input: AgentPromptInput,
     cwdOverride: string | null,
   ): Promise<PreparedRuntimeContext> {
-    const paths = resolveAgentRuntimePaths({
+    const prepared = await prepareAcpxAgentContext({
       browserosDir: this.browserosDir,
-      agentId: input.agent.id,
-      cwd: cwdOverride,
-    })
-    await ensureUsableCwd(paths.effectiveCwd, !input.cwd)
-    await ensureAgentHome(paths)
-    const skillNames = await ensureRuntimeSkills(paths.runtimeSkillsDir)
-    if (input.agent.adapter === 'codex') {
-      await materializeCodexHome({ paths, skillNames })
-    }
-    const promptPrefix = buildAcpxRuntimePromptPrefix({
       agent: input.agent,
-      paths,
-      skillNames,
-    })
-    const agentCommandEnv = buildAgentCommandEnv(input.agent, paths)
-    const commandIdentity = stableCommandIdentity(agentCommandEnv)
-    const runtimeSessionKey = deriveRuntimeSessionKey({
-      agentId: input.agent.id,
       sessionId: input.sessionId,
-      adapter: input.agent.adapter,
-      cwd: paths.effectiveCwd,
-      agentHome: paths.agentHome,
-      promptVersion: BROWSEROS_ACPX_OPERATING_PROMPT_VERSION,
-      skillIdentity: skillNames.join(','),
-      commandIdentity,
-    })
-    await saveLatestRuntimeState(paths.runtimeStatePath, {
-      sessionId: input.sessionId,
-      runtimeSessionKey,
-      cwd: paths.effectiveCwd,
-      agentHome: paths.agentHome,
-      updatedAt: Date.now(),
+      sessionKey: input.sessionKey,
+      cwdOverride,
+      isSelectedCwd: !!input.cwd,
+      message: input.message,
     })
     return {
-      cwd: paths.effectiveCwd,
-      runtimeSessionKey,
-      runPrompt: buildBrowserosAcpPrompt(promptPrefix, input.message),
-      agentCommandEnv,
-      commandIdentity,
+      cwd: prepared.cwd,
+      runtimeSessionKey: prepared.runtimeSessionKey,
+      runPrompt: prepared.runPrompt,
+      agentCommandEnv: prepared.commandEnv,
+      commandIdentity: prepared.commandIdentity,
+      useBrowserosMcp: prepared.useBrowserosMcp,
+      openclawSessionKey: prepared.openclawSessionKey,
     }
   }
 
@@ -344,6 +286,7 @@ export class AcpxRuntime implements AgentRuntime {
     nonInteractivePermissions: AcpRuntimeOptions['nonInteractivePermissions']
     commandEnv: Record<string, string>
     commandIdentity: string
+    useBrowserosMcp: boolean
     openclawSessionKey: string | null
   }): AcpxCoreRuntime {
     const key = JSON.stringify({
@@ -351,16 +294,12 @@ export class AcpxRuntime implements AgentRuntime {
       permissionMode: input.permissionMode,
       nonInteractivePermissions: input.nonInteractivePermissions,
       commandIdentity: input.commandIdentity,
+      useBrowserosMcp: input.useBrowserosMcp,
       openclawSessionKey: input.openclawSessionKey,
     })
     const existing = this.runtimes.get(key)
     if (existing) return existing
 
-    // OpenClaw exposes its provider tools through the gateway, not through
-    // ACP-side MCP servers. Forwarding the BrowserOS HTTP MCP to its bridge
-    // makes newSession fail because openclaw rejects unsupported transports.
-    // Claude/codex still need the BrowserOS MCP for browser tooling.
-    const isOpenclaw = input.openclawSessionKey !== null
     const runtime = this.runtimeFactory({
       cwd: input.cwd,
       sessionStore: this.sessionStore,
@@ -369,9 +308,9 @@ export class AcpxRuntime implements AgentRuntime {
         openclawSessionKey: input.openclawSessionKey,
         commandEnv: input.commandEnv,
       }),
-      mcpServers: isOpenclaw
-        ? []
-        : createBrowserosMcpServers(this.browserosServerPort),
+      mcpServers: input.useBrowserosMcp
+        ? createBrowserosMcpServers(this.browserosServerPort)
+        : [],
       permissionMode: input.permissionMode,
       nonInteractivePermissions: input.nonInteractivePermissions,
     })
@@ -383,6 +322,7 @@ export class AcpxRuntime implements AgentRuntime {
       nonInteractivePermissions: input.nonInteractivePermissions,
       browserosServerPort: this.browserosServerPort,
       commandIdentity: input.commandIdentity,
+      useBrowserosMcp: input.useBrowserosMcp,
       openclawSessionKey: input.openclawSessionKey,
     })
     return runtime
@@ -1067,77 +1007,6 @@ function resolveOpenclawAcpCommand(
     argv.push('--session', bridgeSessionKey)
   }
   return argv.join(' ')
-}
-
-async function ensureUsableCwd(
-  cwd: string,
-  isDefaultWorkspace: boolean,
-): Promise<void> {
-  if (isDefaultWorkspace) {
-    await mkdir(cwd, { recursive: true })
-    return
-  }
-  let info: Stats
-  try {
-    info = await stat(cwd)
-  } catch (err) {
-    if (isNotFoundError(err)) {
-      throw new Error(`Selected workspace does not exist: ${cwd}`)
-    }
-    throw err
-  }
-  if (!info.isDirectory()) {
-    throw new Error(`Selected workspace is not a directory: ${cwd}`)
-  }
-}
-
-function isNotFoundError(err: unknown): boolean {
-  return (
-    typeof err === 'object' &&
-    err !== null &&
-    'code' in err &&
-    err.code === 'ENOENT'
-  )
-}
-
-function buildAgentCommandEnv(
-  agent: AgentDefinition,
-  paths: AgentRuntimePaths,
-): Record<string, string> {
-  if (agent.adapter === 'codex') {
-    return {
-      AGENT_HOME: paths.agentHome,
-      CODEX_HOME: paths.codexHome,
-    }
-  }
-  if (agent.adapter === 'claude') {
-    return {
-      AGENT_HOME: paths.agentHome,
-    }
-  }
-  return {}
-}
-
-function stableCommandIdentity(env: Record<string, string>): string {
-  return Object.entries(env)
-    .sort(([left], [right]) => left.localeCompare(right))
-    .map(([key, value]) => `${key}=${value}`)
-    .join('\n')
-}
-
-function buildBrowserosAcpPrompt(prefix: string, message: string): string {
-  return `${prefix}
-
-<user_request>
-${escapePromptTagText(message)}
-</user_request>`
-}
-
-function escapePromptTagText(value: string): string {
-  return value
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
 }
 
 async function applyRuntimeControls(

--- a/packages/browseros-agent/apps/server/src/lib/agents/claude-code/prepare.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/claude-code/prepare.ts
@@ -12,19 +12,16 @@ import {
   finishBrowserosManagedContext,
   prepareBrowserosManagedContext,
 } from '../acpx-agent-common'
-import { materializeClaudeConfig } from '../acpx-runtime-context'
 
-/** Prepares Claude Code with a contained config dir and BrowserOS agent home. */
+/** Prepares Claude Code with BrowserOS agent home while preserving host Claude auth. */
 export async function prepareClaudeCodeContext(
   input: PrepareAcpxAgentContextInput,
 ): Promise<PreparedAcpxAgentContext> {
   const common = await prepareBrowserosManagedContext(input)
-  await materializeClaudeConfig({ paths: common.paths })
   return finishBrowserosManagedContext({
     ...common,
     commandEnv: {
       AGENT_HOME: common.paths.agentHome,
-      CLAUDE_CONFIG_DIR: common.paths.claudeConfigDir,
     },
   })
 }

--- a/packages/browseros-agent/apps/server/src/lib/agents/claude-code/prepare.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/claude-code/prepare.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {
+  PrepareAcpxAgentContextInput,
+  PreparedAcpxAgentContext,
+} from '../acpx-agent-adapter'
+import {
+  finishBrowserosManagedContext,
+  prepareBrowserosManagedContext,
+} from '../acpx-agent-common'
+import { materializeClaudeConfig } from '../acpx-runtime-context'
+
+/** Prepares Claude Code with a contained config dir and BrowserOS agent home. */
+export async function prepareClaudeCodeContext(
+  input: PrepareAcpxAgentContextInput,
+): Promise<PreparedAcpxAgentContext> {
+  const common = await prepareBrowserosManagedContext(input)
+  await materializeClaudeConfig({ paths: common.paths })
+  return finishBrowserosManagedContext({
+    ...common,
+    commandEnv: {
+      AGENT_HOME: common.paths.agentHome,
+      CLAUDE_CONFIG_DIR: common.paths.claudeConfigDir,
+    },
+  })
+}

--- a/packages/browseros-agent/apps/server/src/lib/agents/codex/prepare.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/codex/prepare.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {
+  PrepareAcpxAgentContextInput,
+  PreparedAcpxAgentContext,
+} from '../acpx-agent-adapter'
+import {
+  finishBrowserosManagedContext,
+  prepareBrowserosManagedContext,
+} from '../acpx-agent-common'
+import { materializeCodexHome } from '../acpx-runtime-context'
+
+/** Prepares Codex with a contained CODEX_HOME and BrowserOS agent home. */
+export async function prepareCodexContext(
+  input: PrepareAcpxAgentContextInput,
+): Promise<PreparedAcpxAgentContext> {
+  const common = await prepareBrowserosManagedContext(input)
+  await materializeCodexHome({
+    paths: common.paths,
+    skillNames: common.skillNames,
+  })
+  return finishBrowserosManagedContext({
+    ...common,
+    commandEnv: {
+      AGENT_HOME: common.paths.agentHome,
+      CODEX_HOME: common.paths.codexHome,
+    },
+  })
+}

--- a/packages/browseros-agent/apps/server/src/lib/agents/openclaw/image-turn.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/openclaw/image-turn.ts
@@ -1,0 +1,14 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { AcpxAdapterTurnInput } from '../acpx-agent-adapter'
+import type { AgentStreamEvent } from '../types'
+
+export async function maybeHandleOpenClawTurn(
+  _input: AcpxAdapterTurnInput,
+): Promise<ReadableStream<AgentStreamEvent> | null> {
+  return null
+}

--- a/packages/browseros-agent/apps/server/src/lib/agents/openclaw/image-turn.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/openclaw/image-turn.ts
@@ -4,11 +4,218 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { randomUUID } from 'node:crypto'
+import type { AcpSessionRecord, createRuntimeStore } from 'acpx/runtime'
+import type {
+  OpenAIChatMessage,
+  OpenAIContentPart,
+} from '../../../api/services/openclaw/openclaw-gateway-chat-client'
+import { logger } from '../../logger'
 import type { AcpxAdapterTurnInput } from '../acpx-agent-adapter'
 import type { AgentStreamEvent } from '../types'
 
+type ImageAttachment = Readonly<{ mediaType: string; data: string }>
+
 export async function maybeHandleOpenClawTurn(
-  _input: AcpxAdapterTurnInput,
+  input: AcpxAdapterTurnInput,
 ): Promise<ReadableStream<AgentStreamEvent> | null> {
-  return null
+  const imageAttachments = (input.prompt.attachments ?? []).filter((a) =>
+    a.mediaType.startsWith('image/'),
+  )
+  if (imageAttachments.length === 0 || !input.openclawGatewayChat) {
+    return null
+  }
+  return sendOpenclawViaGateway({
+    prompt: input.prompt,
+    sessionStore: input.sessionStore,
+    openclawGatewayChat: input.openclawGatewayChat,
+    imageAttachments,
+    cwd: input.prepared.cwd,
+    runPrompt: input.prepared.runPrompt,
+  })
+}
+
+/** Handles OpenClaw image turns through the gateway HTTP chat endpoint. */
+async function sendOpenclawViaGateway(input: {
+  prompt: AcpxAdapterTurnInput['prompt']
+  sessionStore: AcpxAdapterTurnInput['sessionStore']
+  openclawGatewayChat: NonNullable<AcpxAdapterTurnInput['openclawGatewayChat']>
+  imageAttachments: ReadonlyArray<ImageAttachment>
+  cwd: string
+  runPrompt: string
+}): Promise<ReadableStream<AgentStreamEvent>> {
+  const existingRecord = await input.sessionStore.load(input.prompt.sessionKey)
+  const priorMessages = existingRecord
+    ? recordToOpenAIMessages(existingRecord)
+    : []
+  const userContent: OpenAIContentPart[] = [
+    {
+      type: 'text',
+      text: input.runPrompt,
+    },
+    ...input.imageAttachments.map(
+      (a): OpenAIContentPart => ({
+        type: 'image_url',
+        image_url: { url: `data:${a.mediaType};base64,${a.data}` },
+      }),
+    ),
+  ]
+  const messages: OpenAIChatMessage[] = [
+    ...priorMessages,
+    { role: 'user', content: userContent },
+  ]
+
+  logger.info('Agent harness gateway image turn dispatched', {
+    agentId: input.prompt.agent.id,
+    sessionKey: input.prompt.sessionKey,
+    cwd: input.cwd,
+    priorMessageCount: priorMessages.length,
+    imageAttachmentCount: input.imageAttachments.length,
+  })
+
+  const upstream = await input.openclawGatewayChat.streamTurn({
+    agentId: input.prompt.agent.id,
+    sessionKey: input.prompt.sessionKey,
+    messages,
+    signal: input.prompt.signal,
+  })
+
+  const sessionStore = input.sessionStore
+  const sessionKey = input.prompt.sessionKey
+  const userMessageText = input.prompt.message
+  const imageAttachments = input.imageAttachments
+  let accumulated = ''
+
+  return new ReadableStream<AgentStreamEvent>({
+    start: (controller) => {
+      const reader = upstream.getReader()
+      const persist = async () => {
+        if (!existingRecord || !accumulated) return
+        try {
+          await persistGatewayTurn(
+            sessionStore,
+            sessionKey,
+            userMessageText,
+            imageAttachments,
+            accumulated,
+          )
+        } catch (err) {
+          logger.warn(
+            'Failed to persist gateway image turn to acpx session record',
+            {
+              sessionKey,
+              error: err instanceof Error ? err.message : String(err),
+            },
+          )
+        }
+      }
+      ;(async () => {
+        try {
+          while (true) {
+            const { done, value } = await reader.read()
+            if (done) break
+            if (value.type === 'text_delta') accumulated += value.text
+            controller.enqueue(value)
+          }
+          await persist()
+          controller.close()
+        } catch (err) {
+          controller.enqueue({
+            type: 'error',
+            message: err instanceof Error ? err.message : String(err),
+          })
+          controller.close()
+        }
+      })().catch(() => {})
+    },
+    cancel: () => {
+      // Best-effort: cancel propagation to the gateway is tracked separately.
+    },
+  })
+}
+
+async function persistGatewayTurn(
+  sessionStore: ReturnType<typeof createRuntimeStore>,
+  sessionKey: string,
+  userMessageText: string,
+  imageAttachments: ReadonlyArray<ImageAttachment>,
+  assistantText: string,
+): Promise<void> {
+  const record = await sessionStore.load(sessionKey)
+  if (!record) return
+  const userContent: AcpxUserContent[] = [
+    { Text: userMessageText } as AcpxUserContent,
+  ]
+  for (const _image of imageAttachments) {
+    userContent.push({ Image: { source: 'base64' } } as AcpxUserContent)
+  }
+  const turnId = randomUUID()
+  const updated = {
+    ...record,
+    messages: [
+      ...record.messages,
+      { User: { id: `user-${turnId}`, content: userContent } },
+      { Agent: { content: [{ Text: assistantText }], tool_results: {} } },
+    ],
+    lastUsedAt: new Date().toISOString(),
+  } as AcpSessionRecord
+  await sessionStore.save(updated)
+}
+
+function recordToOpenAIMessages(record: AcpSessionRecord): OpenAIChatMessage[] {
+  const messages: OpenAIChatMessage[] = []
+  for (const message of record.messages) {
+    if (message === 'Resume') continue
+    if ('User' in message) {
+      const text = message.User.content
+        .map(userContentToText)
+        .filter(Boolean)
+        .join('\n\n')
+        .trim()
+      if (text) messages.push({ role: 'user', content: text })
+      continue
+    }
+    if ('Agent' in message) {
+      const text = message.Agent.content
+        .map((part) => ('Text' in part ? part.Text : ''))
+        .join('')
+        .trim()
+      if (text) messages.push({ role: 'assistant', content: text })
+    }
+  }
+  return messages
+}
+
+type AcpxSessionMessage = AcpSessionRecord['messages'][number]
+type AcpxUserContent = Extract<
+  Exclude<AcpxSessionMessage, 'Resume'>,
+  { User: unknown }
+>['User']['content'][number]
+
+function userContentToText(content: AcpxUserContent): string {
+  if ('Text' in content) return unwrapPromptText(content.Text)
+  if ('Mention' in content) return content.Mention.content
+  if ('Image' in content) return content.Image.source ? '[image]' : ''
+  return ''
+}
+
+function unwrapPromptText(raw: string): string {
+  return decodeBasicEntities(
+    raw
+      .replace(
+        /^<browseros_acpx_runtime\b[\s\S]*?<\/browseros_acpx_runtime>\n\n<user_request>\n([\s\S]*?)\n<\/user_request>$/,
+        '$1',
+      )
+      .replace(
+        /^<role>[\s\S]*?<\/role>\n\n<user_request>\n([\s\S]*?)\n<\/user_request>$/,
+        '$1',
+      ),
+  ).trim()
+}
+
+function decodeBasicEntities(value: string): string {
+  return value
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
 }

--- a/packages/browseros-agent/apps/server/src/lib/agents/openclaw/image-turn.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/openclaw/image-turn.ts
@@ -200,17 +200,15 @@ function userContentToText(content: AcpxUserContent): string {
 }
 
 function unwrapPromptText(raw: string): string {
-  return decodeBasicEntities(
-    raw
-      .replace(
-        /^<browseros_acpx_runtime\b[\s\S]*?<\/browseros_acpx_runtime>\n\n<user_request>\n([\s\S]*?)\n<\/user_request>$/,
-        '$1',
-      )
-      .replace(
-        /^<role>[\s\S]*?<\/role>\n\n<user_request>\n([\s\S]*?)\n<\/user_request>$/,
-        '$1',
-      ),
-  ).trim()
+  const runtimeMatch = raw.match(
+    /^<browseros_acpx_runtime\b[\s\S]*?<\/browseros_acpx_runtime>\n\n<user_request>\n([\s\S]*?)\n<\/user_request>$/,
+  )
+  if (runtimeMatch) return decodeBasicEntities(runtimeMatch[1]).trim()
+  const roleMatch = raw.match(
+    /^<role>[\s\S]*?<\/role>\n\n<user_request>\n([\s\S]*?)\n<\/user_request>$/,
+  )
+  if (roleMatch) return decodeBasicEntities(roleMatch[1]).trim()
+  return raw.trim()
 }
 
 function decodeBasicEntities(value: string): string {

--- a/packages/browseros-agent/apps/server/src/lib/agents/openclaw/prepare.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/openclaw/prepare.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {
+  PrepareAcpxAgentContextInput,
+  PreparedAcpxAgentContext,
+} from '../acpx-agent-adapter'
+import {
+  buildBrowserosAcpPrompt,
+  ensureUsableCwd,
+  resolveAgentRuntimePaths,
+} from '../acpx-runtime-context'
+
+export { maybeHandleOpenClawTurn } from './image-turn'
+
+const OPENCLAW_BROWSEROS_ACP_INSTRUCTIONS =
+  '<role>You are running inside BrowserOS through the OpenClaw ACP adapter. Use your OpenClaw identity, memory, and browser tools.</role>'
+
+/** Prepares OpenClaw without BrowserOS SOUL/MEMORY or BrowserOS MCP. */
+export async function prepareOpenClawContext(
+  input: PrepareAcpxAgentContextInput,
+): Promise<PreparedAcpxAgentContext> {
+  const paths = resolveAgentRuntimePaths({
+    browserosDir: input.browserosDir,
+    agentId: input.agent.id,
+    cwd: input.cwdOverride,
+  })
+  await ensureUsableCwd(paths.effectiveCwd, !input.isSelectedCwd)
+  return {
+    cwd: paths.effectiveCwd,
+    runtimeSessionKey: input.sessionKey,
+    runPrompt: buildBrowserosAcpPrompt(
+      OPENCLAW_BROWSEROS_ACP_INSTRUCTIONS,
+      input.message,
+    ),
+    commandEnv: {},
+    commandIdentity: 'openclaw',
+    useBrowserosMcp: false,
+    openclawSessionKey: input.sessionKey,
+  }
+}

--- a/packages/browseros-agent/apps/server/src/lib/agents/openclaw/prepare.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/openclaw/prepare.ts
@@ -19,16 +19,18 @@ export { maybeHandleOpenClawTurn } from './image-turn'
 const OPENCLAW_BROWSEROS_ACP_INSTRUCTIONS =
   '<role>You are running inside BrowserOS through the OpenClaw ACP adapter. Use your OpenClaw identity, memory, and browser tools.</role>'
 
-/** Prepares OpenClaw without BrowserOS SOUL/MEMORY or BrowserOS MCP. */
+/**
+ * Prepares OpenClaw without BrowserOS SOUL/MEMORY or BrowserOS MCP.
+ * OpenClaw runs inside the gateway VM/container, so a selected host cwd is not visible there.
+ */
 export async function prepareOpenClawContext(
   input: PrepareAcpxAgentContextInput,
 ): Promise<PreparedAcpxAgentContext> {
   const paths = resolveAgentRuntimePaths({
     browserosDir: input.browserosDir,
     agentId: input.agent.id,
-    cwd: input.cwdOverride,
   })
-  await ensureUsableCwd(paths.effectiveCwd, !input.isSelectedCwd)
+  await ensureUsableCwd(paths.effectiveCwd, true)
   return {
     cwd: paths.effectiveCwd,
     runtimeSessionKey: input.sessionKey,

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-agent-adapter.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-agent-adapter.test.ts
@@ -1,0 +1,109 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { prepareAcpxAgentContext } from '../../../src/lib/agents/acpx-agent-adapter'
+import type { AgentDefinition } from '../../../src/lib/agents/agent-types'
+
+describe('prepareAcpxAgentContext', () => {
+  const tempDirs: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true })),
+    )
+    tempDirs.length = 0
+  })
+
+  function makeAgent(adapter: AgentDefinition['adapter']): AgentDefinition {
+    return {
+      id: `${adapter}-agent`,
+      name: `${adapter} agent`,
+      adapter,
+      permissionMode: 'approve-all',
+      sessionKey: `agent:${adapter}-agent:main`,
+      createdAt: 1000,
+      updatedAt: 1000,
+    }
+  }
+
+  it('prepares Claude with BrowserOS memory, Claude config, BrowserOS MCP, and fingerprinted session', async () => {
+    const browserosDir = await mkdtemp(join(tmpdir(), 'browseros-adapters-'))
+    tempDirs.push(browserosDir)
+    const prepared = await prepareAcpxAgentContext({
+      browserosDir,
+      agent: makeAgent('claude'),
+      sessionId: 'main',
+      sessionKey: 'agent:claude-agent:main',
+      cwdOverride: null,
+      isSelectedCwd: false,
+      message: 'remember this',
+    })
+
+    expect(prepared.commandEnv.AGENT_HOME).toContain('/claude-agent/home')
+    expect(prepared.commandEnv.CLAUDE_CONFIG_DIR).toContain(
+      '/claude-agent/runtime/claude-config',
+    )
+    expect(prepared.commandEnv).not.toHaveProperty('CODEX_HOME')
+    expect(prepared.useBrowserosMcp).toBe(true)
+    expect(prepared.openclawSessionKey).toBeNull()
+    expect(prepared.runtimeSessionKey).toMatch(
+      /^agent:claude-agent:main:[a-f0-9]{16}$/,
+    )
+    expect(prepared.runPrompt).toContain(
+      'Available skills: browseros, memory, soul',
+    )
+    expect(
+      await readFile(`${prepared.commandEnv.AGENT_HOME}/MEMORY.md`, 'utf8'),
+    ).toContain('# MEMORY.md')
+  })
+
+  it('prepares Codex with CODEX_HOME and BrowserOS MCP', async () => {
+    const browserosDir = await mkdtemp(join(tmpdir(), 'browseros-adapters-'))
+    tempDirs.push(browserosDir)
+    const prepared = await prepareAcpxAgentContext({
+      browserosDir,
+      agent: makeAgent('codex'),
+      sessionId: 'main',
+      sessionKey: 'agent:codex-agent:main',
+      cwdOverride: null,
+      isSelectedCwd: false,
+      message: 'hi',
+    })
+
+    expect(prepared.commandEnv.AGENT_HOME).toContain('/codex-agent/home')
+    expect(prepared.commandEnv.CODEX_HOME).toContain(
+      '/codex-agent/runtime/codex-home',
+    )
+    expect(prepared.commandEnv).not.toHaveProperty('CLAUDE_CONFIG_DIR')
+    expect(prepared.useBrowserosMcp).toBe(true)
+    expect(prepared.openclawSessionKey).toBeNull()
+    expect(prepared.runPrompt).toContain('AGENT_HOME=')
+  })
+
+  it('prepares OpenClaw without BrowserOS memory, skills, or MCP', async () => {
+    const browserosDir = await mkdtemp(join(tmpdir(), 'browseros-adapters-'))
+    tempDirs.push(browserosDir)
+    const prepared = await prepareAcpxAgentContext({
+      browserosDir,
+      agent: makeAgent('openclaw'),
+      sessionId: 'main',
+      sessionKey: 'agent:openclaw-agent:main',
+      cwdOverride: null,
+      isSelectedCwd: false,
+      message: 'browse',
+    })
+
+    expect(prepared.commandEnv).toEqual({})
+    expect(prepared.useBrowserosMcp).toBe(false)
+    expect(prepared.openclawSessionKey).toBe('agent:openclaw-agent:main')
+    expect(prepared.runtimeSessionKey).toBe('agent:openclaw-agent:main')
+    expect(prepared.runPrompt).not.toContain('SOUL.md stores')
+    expect(prepared.runPrompt).not.toContain('Available skills:')
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-agent-adapter.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-agent-adapter.test.ts
@@ -32,7 +32,7 @@ describe('prepareAcpxAgentContext', () => {
     }
   }
 
-  it('prepares Claude with BrowserOS memory, Claude config, BrowserOS MCP, and fingerprinted session', async () => {
+  it('prepares Claude with BrowserOS memory, host auth, BrowserOS MCP, and fingerprinted session', async () => {
     const browserosDir = await mkdtemp(join(tmpdir(), 'browseros-adapters-'))
     tempDirs.push(browserosDir)
     const prepared = await prepareAcpxAgentContext({
@@ -46,9 +46,7 @@ describe('prepareAcpxAgentContext', () => {
     })
 
     expect(prepared.commandEnv.AGENT_HOME).toContain('/claude-agent/home')
-    expect(prepared.commandEnv.CLAUDE_CONFIG_DIR).toContain(
-      '/claude-agent/runtime/claude-config',
-    )
+    expect(prepared.commandEnv).not.toHaveProperty('CLAUDE_CONFIG_DIR')
     expect(prepared.commandEnv).not.toHaveProperty('CODEX_HOME')
     expect(prepared.useBrowserosMcp).toBe(true)
     expect(prepared.openclawSessionKey).toBeNull()

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-agent-adapter.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-agent-adapter.test.ts
@@ -86,24 +86,30 @@ describe('prepareAcpxAgentContext', () => {
     expect(prepared.runPrompt).toContain('AGENT_HOME=')
   })
 
-  it('prepares OpenClaw without BrowserOS memory, skills, or MCP', async () => {
+  it('prepares OpenClaw without BrowserOS memory, host cwd, skills, or MCP', async () => {
     const browserosDir = await mkdtemp(join(tmpdir(), 'browseros-adapters-'))
     tempDirs.push(browserosDir)
+    const ignoredSelectedCwd = join(browserosDir, 'missing-selected-workspace')
     const prepared = await prepareAcpxAgentContext({
       browserosDir,
       agent: makeAgent('openclaw'),
       sessionId: 'main',
       sessionKey: 'agent:openclaw-agent:main',
-      cwdOverride: null,
-      isSelectedCwd: false,
+      cwdOverride: ignoredSelectedCwd,
+      isSelectedCwd: true,
       message: 'browse',
     })
 
+    expect(prepared.cwd).toBe(
+      join(browserosDir, 'agents', 'harness', 'workspace'),
+    )
     expect(prepared.commandEnv).toEqual({})
     expect(prepared.useBrowserosMcp).toBe(false)
     expect(prepared.openclawSessionKey).toBe('agent:openclaw-agent:main')
     expect(prepared.runtimeSessionKey).toBe('agent:openclaw-agent:main')
     expect(prepared.runPrompt).not.toContain('SOUL.md stores')
+    expect(prepared.runPrompt).not.toContain('BrowserOS memory skill')
+    expect(prepared.runPrompt).not.toContain('AGENT_HOME/MEMORY.md')
     expect(prepared.runPrompt).not.toContain('Available skills:')
   })
 })

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime-context.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime-context.test.ts
@@ -19,7 +19,6 @@ import {
   buildAcpxRuntimePromptPrefix,
   ensureAgentHome,
   ensureRuntimeSkills,
-  materializeClaudeConfig,
   materializeCodexHome,
   resolveAgentRuntimePaths,
   wrapCommandWithEnv,
@@ -67,16 +66,6 @@ describe('acpx runtime context helpers', () => {
         'agent-1',
         'runtime',
         'codex-home',
-      ),
-    )
-    expect(paths.claudeConfigDir).toBe(
-      join(
-        browserosDir,
-        'agents',
-        'harness',
-        'agent-1',
-        'runtime',
-        'claude-config',
       ),
     )
   })
@@ -226,54 +215,6 @@ describe('acpx runtime context helpers', () => {
     await expect(
       materializeCodexHome({ paths, skillNames: skills, sourceCodexHome }),
     ).rejects.toThrow(/config\.toml/)
-  })
-
-  it('materializes Claude config with seed files without touching BrowserOS memory format', async () => {
-    const browserosDir = await mkdtemp(join(tmpdir(), 'browseros-context-'))
-    const sourceClaudeConfigDir = await mkdtemp(
-      join(tmpdir(), 'browseros-claude-src-'),
-    )
-    tempDirs.push(browserosDir, sourceClaudeConfigDir)
-    await writeFile(
-      join(sourceClaudeConfigDir, '.credentials.json'),
-      '{"token":"ok"}\n',
-    )
-    await writeFile(
-      join(sourceClaudeConfigDir, 'settings.json'),
-      '{"theme":"dark"}\n',
-    )
-    const paths = resolveAgentRuntimePaths({
-      browserosDir,
-      agentId: 'agent-1',
-    })
-
-    await ensureAgentHome(paths)
-    await materializeClaudeConfig({ paths, sourceClaudeConfigDir })
-
-    const credentials = await lstat(
-      join(paths.claudeConfigDir, '.credentials.json'),
-    )
-    expect(credentials.isSymbolicLink()).toBe(true)
-    expect(
-      await readFile(join(paths.claudeConfigDir, 'settings.json'), 'utf8'),
-    ).toBe('{"theme":"dark"}\n')
-    expect(
-      await readFile(join(paths.agentHome, 'MEMORY.md'), 'utf8'),
-    ).toContain('# MEMORY.md - What Persists')
-  })
-
-  it('rejects non-file Claude seed sources instead of silently skipping config', async () => {
-    const browserosDir = await mkdtemp(join(tmpdir(), 'browseros-context-'))
-    const sourceClaudeConfigDir = await mkdtemp(
-      join(tmpdir(), 'browseros-claude-src-'),
-    )
-    tempDirs.push(browserosDir, sourceClaudeConfigDir)
-    await mkdir(join(sourceClaudeConfigDir, 'settings.json'))
-    const paths = resolveAgentRuntimePaths({ browserosDir, agentId: 'agent-1' })
-
-    await expect(
-      materializeClaudeConfig({ paths, sourceClaudeConfigDir }),
-    ).rejects.toThrow(/settings\.json/)
   })
 
   it('wraps commands with shell-quoted env vars', () => {

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime-context.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime-context.test.ts
@@ -19,6 +19,7 @@ import {
   buildAcpxRuntimePromptPrefix,
   ensureAgentHome,
   ensureRuntimeSkills,
+  materializeClaudeConfig,
   materializeCodexHome,
   resolveAgentRuntimePaths,
   wrapCommandWithEnv,
@@ -55,6 +56,9 @@ describe('acpx runtime context helpers', () => {
     expect(paths.runtimeSkillsDir).toBe(
       join(browserosDir, 'agents', 'harness', 'runtime-skills'),
     )
+    expect(paths.runtimeRoot).toBe(
+      join(browserosDir, 'agents', 'harness', 'agent-1', 'runtime'),
+    )
     expect(paths.codexHome).toBe(
       join(
         browserosDir,
@@ -63,6 +67,16 @@ describe('acpx runtime context helpers', () => {
         'agent-1',
         'runtime',
         'codex-home',
+      ),
+    )
+    expect(paths.claudeConfigDir).toBe(
+      join(
+        browserosDir,
+        'agents',
+        'harness',
+        'agent-1',
+        'runtime',
+        'claude-config',
       ),
     )
   })
@@ -214,6 +228,54 @@ describe('acpx runtime context helpers', () => {
     ).rejects.toThrow(/config\.toml/)
   })
 
+  it('materializes Claude config with seed files without touching BrowserOS memory format', async () => {
+    const browserosDir = await mkdtemp(join(tmpdir(), 'browseros-context-'))
+    const sourceClaudeConfigDir = await mkdtemp(
+      join(tmpdir(), 'browseros-claude-src-'),
+    )
+    tempDirs.push(browserosDir, sourceClaudeConfigDir)
+    await writeFile(
+      join(sourceClaudeConfigDir, '.credentials.json'),
+      '{"token":"ok"}\n',
+    )
+    await writeFile(
+      join(sourceClaudeConfigDir, 'settings.json'),
+      '{"theme":"dark"}\n',
+    )
+    const paths = resolveAgentRuntimePaths({
+      browserosDir,
+      agentId: 'agent-1',
+    })
+
+    await ensureAgentHome(paths)
+    await materializeClaudeConfig({ paths, sourceClaudeConfigDir })
+
+    const credentials = await lstat(
+      join(paths.claudeConfigDir, '.credentials.json'),
+    )
+    expect(credentials.isSymbolicLink()).toBe(true)
+    expect(
+      await readFile(join(paths.claudeConfigDir, 'settings.json'), 'utf8'),
+    ).toBe('{"theme":"dark"}\n')
+    expect(
+      await readFile(join(paths.agentHome, 'MEMORY.md'), 'utf8'),
+    ).toContain('# MEMORY.md - What Persists')
+  })
+
+  it('rejects non-file Claude seed sources instead of silently skipping config', async () => {
+    const browserosDir = await mkdtemp(join(tmpdir(), 'browseros-context-'))
+    const sourceClaudeConfigDir = await mkdtemp(
+      join(tmpdir(), 'browseros-claude-src-'),
+    )
+    tempDirs.push(browserosDir, sourceClaudeConfigDir)
+    await mkdir(join(sourceClaudeConfigDir, 'settings.json'))
+    const paths = resolveAgentRuntimePaths({ browserosDir, agentId: 'agent-1' })
+
+    await expect(
+      materializeClaudeConfig({ paths, sourceClaudeConfigDir }),
+    ).rejects.toThrow(/settings\.json/)
+  })
+
   it('wraps commands with shell-quoted env vars', () => {
     expect(
       wrapCommandWithEnv('npx @zed-industries/codex-acp', {
@@ -256,5 +318,34 @@ describe('acpx runtime context helpers', () => {
       'Skill root: /tmp/browseros/agents/harness/runtime-skills',
     )
     expect(prompt).toContain('Available skills: browseros, memory, soul')
+  })
+
+  it('routes explicit memory requests to BrowserOS AGENT_HOME files', () => {
+    const agent: AgentDefinition = {
+      id: 'agent-1',
+      name: 'Researcher',
+      adapter: 'claude',
+      permissionMode: 'approve-all',
+      sessionKey: 'agent:agent-1:main',
+      createdAt: 1000,
+      updatedAt: 1000,
+    }
+    const paths = resolveAgentRuntimePaths({
+      browserosDir: '/tmp/browseros',
+      agentId: agent.id,
+      cwd: '/tmp/workspace',
+    })
+
+    const prompt = buildAcpxRuntimePromptPrefix({
+      agent,
+      paths,
+      skillNames: ['browseros', 'memory', 'soul'],
+    })
+
+    expect(prompt).toContain('When the user asks you to remember')
+    expect(prompt).toContain('use the BrowserOS memory skill')
+    expect(prompt).toContain('AGENT_HOME/MEMORY.md')
+    expect(prompt).toContain('AGENT_HOME/memory/YYYY-MM-DD.md')
+    expect(prompt).toContain('Do not use native Claude project memory')
   })
 })

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -868,7 +868,7 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
     )
   })
 
-  it('injects AGENT_HOME into Claude ACP command resolution', async () => {
+  it('injects AGENT_HOME without CLAUDE_CONFIG_DIR into Claude ACP command resolution', async () => {
     const browserosDir = await mkdtemp(
       join(tmpdir(), 'browseros-acpx-browseros-'),
     )
@@ -898,9 +898,8 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
     const command =
       getCreateRuntimeOptions(calls).agentRegistry.resolve('claude')
     expect(command).toContain('env AGENT_HOME=')
-    expect(command).toContain('CLAUDE_CONFIG_DIR=')
+    expect(command).not.toContain('CLAUDE_CONFIG_DIR=')
     expect(command).not.toContain('CODEX_HOME=')
-    expect(command).toContain('/runtime/claude-config')
   })
 
   it('injects AGENT_HOME and CODEX_HOME into Codex ACP command resolution', async () => {

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -1263,7 +1263,15 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
         max_segments: 0,
       },
       closed: false,
-      messages: [],
+      messages: [
+        {
+          User: {
+            id: 'prior-user',
+            content: [{ Text: 'literal &amp; &lt;tag&gt;' } as never],
+          },
+        },
+        { Agent: { content: [{ Text: 'Prior answer.' }], tool_results: {} } },
+      ],
       updated_at: seedTimestamp,
       cumulative_token_usage: {},
       request_token_usage: {},
@@ -1339,6 +1347,10 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
       }>
     }
     expect(gatewayInput.agentId).toBe('img-bot')
+    expect(gatewayInput.messages[0]).toEqual({
+      role: 'user',
+      content: 'literal &amp; &lt;tag&gt;',
+    })
     expect(gatewayInput.messages.at(-1)?.role).toBe('user')
     const userContent = gatewayInput.messages.at(-1)?.content
     expect(Array.isArray(userContent)).toBe(true)
@@ -1353,7 +1365,7 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
       agent,
       sessionId: 'main',
     })
-    expect(history.items.map((item) => item.role)).toEqual([
+    expect(history.items.slice(-2).map((item) => item.role)).toEqual([
       'user',
       'assistant',
     ])

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -1288,13 +1288,15 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
         })
       },
     } as never
+    const calls: Array<{ method: string; input: unknown }> = []
     const runtime = new AcpxRuntime({
       cwd,
       stateDir,
       openclawGatewayChat,
       // Provide a runtime factory that would fail loudly if reached —
       // image turns must NOT fall through to the ACP path.
-      runtimeFactory: () => {
+      runtimeFactory: (options) => {
+        calls.push({ method: 'createRuntime', input: options })
         throw new Error('ACP path should not be reached for image turns')
       },
     })
@@ -1325,6 +1327,9 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
       { type: 'done', stopReason: 'end_turn' },
     ])
     expect(gatewayCalls).toHaveLength(1)
+    expect(
+      calls.filter((call) => call.method === 'createRuntime'),
+    ).toHaveLength(0)
     const gatewayInput = gatewayCalls[0]?.input as {
       agentId: string
       sessionKey: string

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -898,7 +898,9 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
     const command =
       getCreateRuntimeOptions(calls).agentRegistry.resolve('claude')
     expect(command).toContain('env AGENT_HOME=')
+    expect(command).toContain('CLAUDE_CONFIG_DIR=')
     expect(command).not.toContain('CODEX_HOME=')
+    expect(command).toContain('/runtime/claude-config')
   })
 
   it('injects AGENT_HOME and CODEX_HOME into Codex ACP command resolution', async () => {


### PR DESCRIPTION
## Summary
- Adds a typed ACPX agent adapter registry so Claude Code, Codex, and OpenClaw each own their runtime preparation.
- Gives Claude and Codex managed BrowserOS agent homes, runtime skills, and isolated CLI homes/config while keeping OpenClaw on its own memory and tool model.
- Moves OpenClaw image-turn diversion into the OpenClaw adapter hook instead of keeping that logic in the shared runtime.

## Design
`AcpxRuntime` now orchestrates streaming, runtime caching, history mapping, and shared ACP execution while delegating per-agent setup through `prepareAcpxAgentContext()`. BrowserOS-managed adapters use shared helpers for cwd validation, AGENT_HOME seeding, runtime skills, prompt construction, command env, and runtime-state fingerprints. OpenClaw prepares through the same adapter path but opts out of BrowserOS MCP and BrowserOS SOUL/MEMORY, with its gateway image diversion implemented in `openclaw/image-turn.ts`.

## Test plan
- `bun --env-file=apps/server/.env.development test apps/server/tests/lib/agents/acpx-agent-adapter.test.ts apps/server/tests/lib/agents/acpx-runtime-context.test.ts apps/server/tests/lib/agents/acpx-runtime.test.ts`
- `bun run --filter @browseros/server typecheck`