### PR TITLE
feat(agent): /home composer parity with image attachments

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
@@ -26,6 +26,7 @@ import {
   filterTurnsPersistedInHistory,
   flattenHistoryPages,
 } from './claw-chat-types'
+import { consumePendingInitialMessage } from './pending-initial-message'
 import { QueuePanel } from './QueuePanel'
 import { useAgentConversation } from './useAgentConversation'
 import { useHarnessChatHistory } from './useHarnessChatHistory'
@@ -113,25 +114,49 @@ function AgentConversationController({
   sendRef.current = send
 
   useEffect(() => {
+    if (disabled || !historyReady) return
+
+    // Registry-first: when the user submitted at /home with
+    // attachments, the rich payload is here. URL `?q=` may also be
+    // present and is the text-only fallback path; the registry wins
+    // when both exist because it carries the binary attachments
+    // alongside the text.
+    const pending = consumePendingInitialMessage(agentId)
+    if (pending) {
+      // Mark the dedup ref so the text-only branch below doesn't
+      // re-fire on the same render.
+      if (initialMessageKey) {
+        initialMessageSentRef.current = initialMessageKey
+      }
+      onInitialMessageConsumedRef.current()
+      void sendRef.current({
+        text: pending.text,
+        attachments: pending.attachments.map((a) => a.payload),
+        attachmentPreviews: pending.attachments.map((a) => ({
+          id: a.id,
+          kind: a.kind,
+          mediaType: a.mediaType,
+          name: a.name,
+          dataUrl: a.dataUrl,
+        })),
+      })
+      return
+    }
+
     const query = initialMessage?.trim()
     if (!initialMessageKey) {
       initialMessageSentRef.current = null
       return
     }
 
-    if (
-      !query ||
-      initialMessageSentRef.current === initialMessageKey ||
-      disabled ||
-      !historyReady
-    ) {
+    if (!query || initialMessageSentRef.current === initialMessageKey) {
       return
     }
 
     initialMessageSentRef.current = initialMessageKey
     onInitialMessageConsumedRef.current()
     void sendRef.current({ text: query })
-  }, [disabled, historyReady, initialMessage, initialMessageKey])
+  }, [agentId, disabled, historyReady, initialMessage, initialMessageKey])
 
   const handleSelectAgent = (entry: AgentEntry) => {
     navigate(`${agentPathPrefix}/${entry.agentId}`)

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
@@ -145,6 +145,9 @@ function AgentConversationController({
 
     const query = initialMessage?.trim()
     if (!initialMessageKey) {
+      // Reset is safe even on the post-registry-fire re-run: consume
+      // is destructive, so the registry is already drained — there's
+      // nothing left for a third run to re-send.
       initialMessageSentRef.current = null
       return
     }

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandHome.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandHome.tsx
@@ -18,8 +18,12 @@ import { SignInHint } from '@/entrypoints/newtab/index/SignInHint'
 import { useActiveHint } from '@/entrypoints/newtab/index/useActiveHint'
 import { AgentCardDock } from './AgentCardDock'
 import { useAgentCommandData } from './agent-command-layout'
-import { ConversationInput } from './ConversationInput'
+import {
+  ConversationInput,
+  type ConversationInputSendInput,
+} from './ConversationInput'
 import { orderHomeAgents } from './home-agent-card.helpers'
+import { setPendingInitialMessage } from './pending-initial-message'
 
 function EmptyAgentsState({ onOpenAgents }: { onOpenAgents: () => void }) {
   return (
@@ -116,8 +120,19 @@ export const AgentCommandHome: FC = () => {
     }
   }, [legacyAgents, selectedAgentId])
 
-  const handleSend = (input: { text: string }) => {
+  const handleSend = (input: ConversationInputSendInput) => {
     if (!selectedAgentId) return
+    // Stash text + attachments in the in-memory registry. Text also
+    // travels in `?q=` so a hard refresh / shareable URL still works
+    // for text-only prompts; attachments are registry-only because a
+    // multi-megabyte dataUrl can't ride a URL search param. The chat
+    // screen prefers the registry when both are present.
+    setPendingInitialMessage({
+      agentId: selectedAgentId,
+      text: input.text,
+      attachments: input.attachments,
+      createdAt: Date.now(),
+    })
     navigate(
       `/home/agents/${selectedAgentId}?q=${encodeURIComponent(input.text)}`,
     )
@@ -167,7 +182,7 @@ export const AgentCommandHome: FC = () => {
                   streaming={false}
                   disabled={!selectedAgentReady}
                   status={selectedAgentStatus}
-                  attachmentsEnabled={false}
+                  attachmentsEnabled={true}
                   placeholder={
                     selectedAgentReady
                       ? `Ask ${selectedAgentName} to handle a task...`

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/pending-initial-message.test.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/pending-initial-message.test.ts
@@ -1,0 +1,109 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import type { StagedAttachment } from '@/lib/attachments'
+import {
+  consumePendingInitialMessage,
+  peekPendingInitialMessage,
+  setPendingInitialMessage,
+} from './pending-initial-message'
+
+function makeAttachment(id: string): StagedAttachment {
+  return {
+    id,
+    kind: 'image',
+    mediaType: 'image/png',
+    name: `${id}.png`,
+    dataUrl: `data:image/png;base64,${id}`,
+    payload: {
+      kind: 'image',
+      mediaType: 'image/png',
+      name: `${id}.png`,
+      dataUrl: `data:image/png;base64,${id}`,
+    },
+  }
+}
+
+afterEach(() => {
+  // Drain any leftover pending entry so tests don't leak into each
+  // other (the module-scope state survives across `it` blocks).
+  consumePendingInitialMessage('drain')
+  // If still set, clear by consuming with the matching id.
+  const leftover = peekPendingInitialMessage()
+  if (leftover) consumePendingInitialMessage(leftover.agentId)
+})
+
+describe('pending-initial-message', () => {
+  it('consume returns the payload set for the same agentId', () => {
+    setPendingInitialMessage({
+      agentId: 'agent-a',
+      text: 'hello',
+      attachments: [makeAttachment('one')],
+      createdAt: Date.now(),
+    })
+    const result = consumePendingInitialMessage('agent-a')
+    expect(result?.text).toBe('hello')
+    expect(result?.attachments).toHaveLength(1)
+    expect(result?.attachments[0]?.id).toBe('one')
+  })
+
+  it('consume is destructive — second call returns null', () => {
+    setPendingInitialMessage({
+      agentId: 'agent-a',
+      text: 'hello',
+      attachments: [],
+      createdAt: Date.now(),
+    })
+    expect(consumePendingInitialMessage('agent-a')).not.toBeNull()
+    expect(consumePendingInitialMessage('agent-a')).toBeNull()
+  })
+
+  it('consume returns null and preserves entry when agentId differs', () => {
+    setPendingInitialMessage({
+      agentId: 'agent-a',
+      text: 'hello',
+      attachments: [],
+      createdAt: Date.now(),
+    })
+    expect(consumePendingInitialMessage('agent-b')).toBeNull()
+    expect(peekPendingInitialMessage()?.agentId).toBe('agent-a')
+    expect(consumePendingInitialMessage('agent-a')).not.toBeNull()
+  })
+
+  it('returns null for entries older than the TTL', () => {
+    setPendingInitialMessage({
+      agentId: 'agent-a',
+      text: 'old',
+      attachments: [],
+      createdAt: Date.now() - 11_000, // older than 10 s TTL
+    })
+    expect(consumePendingInitialMessage('agent-a')).toBeNull()
+  })
+
+  it('replaces a previous pending entry when set is called again', () => {
+    setPendingInitialMessage({
+      agentId: 'agent-a',
+      text: 'first',
+      attachments: [],
+      createdAt: Date.now(),
+    })
+    setPendingInitialMessage({
+      agentId: 'agent-b',
+      text: 'second',
+      attachments: [makeAttachment('two')],
+      createdAt: Date.now(),
+    })
+    expect(consumePendingInitialMessage('agent-a')).toBeNull()
+    const result = consumePendingInitialMessage('agent-b')
+    expect(result?.text).toBe('second')
+    expect(result?.attachments[0]?.id).toBe('two')
+  })
+
+  it('no-ops when set is called with empty agentId', () => {
+    setPendingInitialMessage({
+      agentId: '',
+      text: 'oops',
+      attachments: [],
+      createdAt: Date.now(),
+    })
+    expect(peekPendingInitialMessage()).toBeNull()
+  })
+})

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/pending-initial-message.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/pending-initial-message.ts
@@ -1,0 +1,81 @@
+import type { StagedAttachment } from '@/lib/attachments'
+
+/**
+ * Same-tab in-memory handoff between the `/home` composer and the
+ * chat screen at `/home/agents/:agentId`. URL search params (`?q=`)
+ * carry the text fine, but cannot carry binary attachments — a multi-
+ * megabyte image dataUrl would explode URL length limits and round-
+ * trip badly. This module is the rich-data side channel for the same
+ * navigation: the composer writes here, the chat screen reads here on
+ * mount.
+ *
+ * Intentionally module-scope. Same render tree, same tab — no need
+ * for sessionStorage (which would force JSON-serialising the dataUrls
+ * and re-parsing on the read side). Cross-tab handoff is out of
+ * scope: the user typing at home in tab A and switching to tab B's
+ * chat would surface an empty registry there, which is the correct
+ * behaviour.
+ */
+
+export interface PendingInitialMessage {
+  agentId: string
+  text: string
+  attachments: StagedAttachment[]
+  createdAt: number
+}
+
+/**
+ * 10s TTL on the entry. A stale entry from a back-button journey
+ * shouldn't fire on a future visit; if real-world latency makes 10s
+ * too tight under slow harness boot, bump but never make it
+ * indefinite.
+ */
+const PENDING_TTL_MS = 10_000
+
+let pending: PendingInitialMessage | null = null
+let pendingTimer: ReturnType<typeof setTimeout> | null = null
+
+function clearPending(): void {
+  pending = null
+  if (pendingTimer !== null) {
+    clearTimeout(pendingTimer)
+    pendingTimer = null
+  }
+}
+
+export function setPendingInitialMessage(payload: PendingInitialMessage): void {
+  // Defensive: the home composer should never call this without an
+  // agent selected. If it somehow does, no-op rather than holding a
+  // payload we can't route.
+  if (!payload.agentId) return
+  clearPending()
+  pending = payload
+  pendingTimer = setTimeout(clearPending, PENDING_TTL_MS)
+}
+
+/**
+ * Destructive read. Returns the entry only if `agentId` matches and
+ * the entry is fresh; clears the entry on success so Strict-Mode
+ * double-invokes can't double-send.
+ */
+export function consumePendingInitialMessage(
+  agentId: string,
+): PendingInitialMessage | null {
+  if (!pending) return null
+  if (pending.agentId !== agentId) return null
+  if (Date.now() - pending.createdAt >= PENDING_TTL_MS) {
+    clearPending()
+    return null
+  }
+  const entry = pending
+  clearPending()
+  return entry
+}
+
+/**
+ * Non-mutating read for tests. Production code should never need this
+ * — use `consume` and own the lifecycle.
+ */
+export function peekPendingInitialMessage(): PendingInitialMessage | null {
+  return pending
+}


### PR DESCRIPTION
## Summary

Brings the `/home` composer up to behavioural parity with the chat-screen composer at `/agents/:agentId`, with image attachments surviving the home → chat navigation end-to-end.

The same `<ConversationInput>` component already powered both surfaces, but `/home` passed `attachmentsEnabled={false}` and the handoff to the chat screen was a URL search param `?q=<text>` — fine for text, physically unable to carry a 5 MB image dataUrl. Pasting a screenshot at `/home` did nothing.

## Approach

Add a small in-memory registry (`pending-initial-message.ts`) as the rich-data side channel for the same navigation:

- **Home composer** writes `{ agentId, text, attachments, createdAt }` before `navigate()`, and continues to put the text in `?q=` so shareable text-only URLs still work.
- **Chat screen** consumes the registry first on mount; if hit, replays through the existing harness `send()` path with attachments + previews. If miss, falls back to the existing text-only `?q=` reader (unchanged behaviour for direct deep-links).
- Module-scope singleton (same tab, same render tree). 10s TTL. Destructive consume — Strict-Mode double-invokes can't double-send. Cross-tab handoff is intentionally out of scope.
- Registry wins when both `?q=` and registry are present (text travels in both channels; the registry's the only one that has the binary blobs).

`<ConversationInput>` already supports attachments fully (paste, drag-drop, file picker, validation, preview thumbnails) — the home composer just needed the flag flipped and a place to park the staged attachments before navigation. `AttachmentStrip` renders unconditionally based on `attachments.length`, so the chip UI works in both `home` and `conversation` variants without any layout work.

## Files

- **NEW** `pending-initial-message.ts` — set/consume/peek for the in-memory handoff (38 LOC).
- **NEW** `pending-initial-message.test.ts` — 6 tests covering: same-agent set+consume, destructive consume, cross-agent isolation, TTL expiry, replacement on second set, empty-agentId no-op.
- **MODIFY** `AgentCommandHome.tsx` — flip `attachmentsEnabled={true}`, expand `handleSend` to take `ConversationInputSendInput`, write to registry before navigating.
- **MODIFY** `AgentCommandConversation.tsx` — read registry alongside the `?q=` reader; replay with attachments + previews when registry hits; mark dedup ref so the text-only branch doesn't double-fire.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bunx biome check` clean
- [x] `bun test` 76/76 pass (including 6 new tests on the registry)
- [ ] Manual: paste a screenshot at `/home`, send → chat opens with the image inline + agent processes both
- [ ] Manual: drag-drop a PNG at `/home`, same result
- [ ] Manual: text-only prompt at `/home` → existing behaviour preserved
- [ ] Manual: deep-link `/home/agents/<id>?q=hello` directly (no registry entry) → text-only fallback fires
- [ ] Manual: type + paste image at home, click back, wait 10+ seconds, return to chat → registry expired, no zombie message