### PR TITLE
feat(agent): calm composer + redesigned hero

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandHome.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandHome.tsx
@@ -164,7 +164,7 @@ export const AgentCommandHome: FC = () => {
               <div className="space-y-3">
                 <h1 className="font-semibold text-[clamp(2.25rem,4.5vw,3.5rem)] leading-[1.08] tracking-[-0.025em] [text-wrap:balance]">
                   What should your agent{' '}
-                  <span className="font-medium text-muted-foreground italic">
+                  <span className="font-medium text-[var(--accent-orange)] italic">
                     work on
                   </span>{' '}
                   next?

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandHome.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandHome.tsx
@@ -162,12 +162,16 @@ export const AgentCommandHome: FC = () => {
           <>
             <div className="flex flex-col items-center gap-5 pt-[max(10vh,24px)] text-center">
               <div className="space-y-3">
-                <h1 className="font-semibold text-[clamp(2rem,4vw,3.25rem)] leading-tight tracking-tight">
-                  What should your agent work on next?
+                <h1 className="font-semibold text-[clamp(2.25rem,4.5vw,3.5rem)] leading-[1.08] tracking-[-0.025em] [text-wrap:balance]">
+                  What should your agent{' '}
+                  <span className="font-medium text-muted-foreground italic">
+                    work on
+                  </span>{' '}
+                  next?
                 </h1>
-                <p className="mx-auto max-w-2xl text-muted-foreground text-sm leading-6">
-                  Start with a task, continue a thread, or switch to another
-                  agent without leaving the new tab.
+                <p className="mx-auto max-w-2xl text-muted-foreground text-sm leading-6 [text-wrap:pretty]">
+                  Start a task, continue a thread, or hand off to a different
+                  agent — all without leaving this tab.
                 </p>
               </div>
 

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentSelector.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentSelector.tsx
@@ -27,6 +27,14 @@ interface AgentSelectorProps {
   onSelectAgent: (agent: AgentEntry) => void
   onCreateAgent?: () => void
   status?: string
+  /**
+   * `'pill'` renders the filled-pill variant used by the calm
+   * composer on `/home` — bordered, slightly elevated background,
+   * mono agent name, used as the visual anchor on the left of the
+   * footer chip row. Default `'ghost'` keeps the existing flat
+   * shadcn ghost-button trigger used by the chat surface.
+   */
+  triggerVariant?: 'ghost' | 'pill'
 }
 
 function getStatusDot(status?: string) {
@@ -42,31 +50,49 @@ export const AgentSelector: FC<AgentSelectorProps> = ({
   onSelectAgent,
   onCreateAgent,
   status,
+  triggerVariant = 'ghost',
 }) => {
   const [open, setOpen] = useState(false)
   const selectedAgent = agents.find(
     (agent) => agent.agentId === selectedAgentId,
   )
 
+  const triggerNode =
+    triggerVariant === 'pill' ? (
+      <button
+        type="button"
+        className={cn(
+          'inline-flex h-6 max-w-[180px] items-center gap-1.5 rounded-full border border-border bg-accent/40 pr-2 pl-2.5 text-[11.5px] text-foreground transition-colors',
+          'hover:border-border hover:bg-accent/70 data-[state=open]:border-border data-[state=open]:bg-accent/70',
+        )}
+      >
+        <span className={cn('size-1.5 rounded-full', getStatusDot(status))} />
+        <span className="truncate font-medium font-mono text-[11.5px] tracking-[-0.01em]">
+          {selectedAgent?.name ?? 'Select agent'}
+        </span>
+        <ChevronDown className="size-3 shrink-0 text-muted-foreground" />
+      </button>
+    ) : (
+      <Button
+        variant="ghost"
+        className={cn(
+          'flex items-center gap-2 rounded-lg px-3 py-1.5 font-medium text-sm transition-all',
+          'bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground',
+          'data-[state=open]:bg-accent',
+        )}
+      >
+        <Bot className="h-4 w-4" />
+        <span className={cn('size-2 rounded-full', getStatusDot(status))} />
+        <span className="max-w-32 truncate">
+          {selectedAgent?.name ?? 'Select agent'}
+        </span>
+        <ChevronDown className="h-3 w-3" />
+      </Button>
+    )
+
   return (
     <Popover open={open} onOpenChange={setOpen}>
-      <PopoverTrigger asChild>
-        <Button
-          variant="ghost"
-          className={cn(
-            'flex items-center gap-2 rounded-lg px-3 py-1.5 font-medium text-sm transition-all',
-            'bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground',
-            'data-[state=open]:bg-accent',
-          )}
-        >
-          <Bot className="h-4 w-4" />
-          <span className={cn('size-2 rounded-full', getStatusDot(status))} />
-          <span className="max-w-32 truncate">
-            {selectedAgent?.name ?? 'Select agent'}
-          </span>
-          <ChevronDown className="h-3 w-3" />
-        </Button>
-      </PopoverTrigger>
+      <PopoverTrigger asChild>{triggerNode}</PopoverTrigger>
       <PopoverContent side="bottom" align="start" className="w-72 p-0">
         <Command>
           <CommandInput placeholder="Search agents..." className="h-9" />

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationInput.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationInput.tsx
@@ -704,7 +704,7 @@ export const ConversationInput: FC<ConversationInputProps> = ({
               }
               disabled={disabled || voice.isTranscribing}
               className={cn(
-                'resize-none border-none bg-transparent px-0 text-[15px] shadow-none focus-visible:ring-0',
+                'resize-none border-none bg-transparent px-0 text-[15px] shadow-none focus-visible:ring-0 dark:bg-transparent',
                 '[field-sizing:fixed]',
                 variant === 'home'
                   ? 'min-h-[40px] py-2 leading-6'

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationInput.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationInput.tsx
@@ -164,6 +164,168 @@ function VoiceButton({
   )
 }
 
+/**
+ * Calm-composer footer used by `variant="home"`. Pill-shaped chips on
+ * an internal dashed divider, with a right-aligned keyboard hint.
+ * The chat-screen composer keeps the original `ContextControls`
+ * layout — no shared structure beyond the props pass-through.
+ */
+function HomeContextControls({
+  agents,
+  onCreateAgent,
+  onSelectAgent,
+  selectedAgentId,
+  selectedTabs,
+  onToggleTab,
+  showAgentSelector,
+  status,
+  onAttachClick,
+  attachDisabled,
+  attachmentsEnabled,
+}: {
+  agents: AgentEntry[]
+  onCreateAgent?: () => void
+  onSelectAgent: (agent: AgentEntry) => void
+  selectedAgentId: string | null
+  selectedTabs: chrome.tabs.Tab[]
+  onToggleTab: (tab: chrome.tabs.Tab) => void
+  showAgentSelector: boolean
+  status?: string
+  onAttachClick: () => void
+  attachDisabled: boolean
+  attachmentsEnabled: boolean
+}) {
+  const { supports } = useCapabilities()
+  const { selectedFolder } = useWorkspace()
+  const { servers: mcpServers } = useMcpServers()
+  const { data: userMCPIntegrations } = useGetUserMCPIntegrations()
+
+  const connectedManagedServers = mcpServers.filter((server) => {
+    if (server.type !== 'managed' || !server.managedServerName) return false
+    return userMCPIntegrations?.integrations?.find(
+      (integration) => integration.name === server.managedServerName,
+    )?.is_authenticated
+  })
+
+  const showApps = supports(Feature.MANAGED_MCP_SUPPORT)
+  const showWorkspace = supports(Feature.WORKSPACE_FOLDER_SUPPORT)
+
+  return (
+    <div className="mx-3 flex items-center gap-1 border-border/60 border-t border-dashed py-2">
+      {showAgentSelector ? (
+        <>
+          <AgentSelector
+            agents={agents}
+            selectedAgentId={selectedAgentId}
+            onSelectAgent={onSelectAgent}
+            onCreateAgent={onCreateAgent}
+            status={status}
+            triggerVariant="pill"
+          />
+          <span
+            aria-hidden="true"
+            className="mx-1 inline-block h-3.5 w-px shrink-0 bg-border"
+          />
+        </>
+      ) : null}
+      {showWorkspace ? (
+        <WorkspaceSelector>
+          <button
+            type="button"
+            className="inline-flex h-6 items-center gap-1.5 rounded-full px-2.5 text-[11.5px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground"
+          >
+            <Folder className="size-3" />
+            <span>Workspace</span>
+            <span className="font-mono text-[10.5px] text-muted-foreground/70">
+              {selectedFolder?.name ?? 'none'}
+            </span>
+          </button>
+        </WorkspaceSelector>
+      ) : null}
+      <TabPickerPopover
+        variant="selector"
+        selectedTabs={selectedTabs}
+        onToggleTab={onToggleTab}
+      >
+        <button
+          type="button"
+          className={cn(
+            'inline-flex h-6 items-center gap-1.5 rounded-full px-2.5 text-[11.5px] transition-colors data-[state=open]:bg-accent data-[state=open]:text-foreground',
+            selectedTabs.length > 0
+              ? 'bg-[var(--accent-orange)] text-white hover:bg-[var(--accent-orange)]/90'
+              : 'text-muted-foreground hover:bg-accent hover:text-foreground',
+          )}
+        >
+          <Layers className="size-3" />
+          <span>Tabs</span>
+          <span
+            className={cn(
+              'font-mono text-[10.5px]',
+              selectedTabs.length > 0
+                ? 'text-white/80'
+                : 'text-muted-foreground/70',
+            )}
+          >
+            {selectedTabs.length}
+          </span>
+        </button>
+      </TabPickerPopover>
+      <button
+        type="button"
+        onClick={onAttachClick}
+        disabled={attachDisabled || !attachmentsEnabled}
+        title="Attach files"
+        className="inline-flex h-6 items-center gap-1.5 rounded-full px-2.5 text-[11.5px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        <Paperclip className="size-3" />
+        <span>Attach</span>
+      </button>
+      {showApps ? (
+        <AppSelector side="bottom">
+          <button
+            type="button"
+            className="inline-flex h-6 items-center gap-1.5 rounded-full px-2.5 text-[11.5px] text-muted-foreground transition-colors hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground"
+          >
+            {connectedManagedServers.length > 0 ? (
+              <span className="flex items-center -space-x-1.5">
+                {connectedManagedServers.slice(0, 4).map((server) => (
+                  <span
+                    key={server.id}
+                    className="rounded-full ring-2 ring-card"
+                  >
+                    <McpServerIcon
+                      serverName={server.managedServerName ?? ''}
+                      size={12}
+                    />
+                  </span>
+                ))}
+              </span>
+            ) : (
+              <FileText className="size-3" />
+            )}
+            <span>Apps</span>
+            <ChevronDown className="size-3" />
+          </button>
+        </AppSelector>
+      ) : null}
+      <div className="ml-auto inline-flex shrink-0 items-center gap-1.5 text-[11px] text-muted-foreground/70">
+        <kbd className="inline-flex h-4 min-w-4 items-center justify-center rounded border border-border bg-accent/30 px-1 font-mono text-[10px] text-muted-foreground">
+          ↵
+        </kbd>
+        <span>to run</span>
+        <span className="text-muted-foreground/40">·</span>
+        <kbd className="inline-flex h-4 min-w-4 items-center justify-center rounded border border-border bg-accent/30 px-1 font-mono text-[10px] text-muted-foreground">
+          ⇧
+        </kbd>
+        <kbd className="inline-flex h-4 min-w-4 items-center justify-center rounded border border-border bg-accent/30 px-1 font-mono text-[10px] text-muted-foreground">
+          ↵
+        </kbd>
+        <span>new line</span>
+      </div>
+    </div>
+  )
+}
+
 function ContextControls({
   agents,
   onCreateAgent,
@@ -304,7 +466,7 @@ function ContextControls({
 
 function HomeShell({ children }: { children: ReactNode }) {
   return (
-    <div className="overflow-hidden rounded-[1.55rem] border border-border/60 bg-card/95 shadow-sm">
+    <div className="overflow-hidden rounded-[1.55rem] border border-border/60 bg-card/95 shadow-sm transition-[border-color,box-shadow] duration-150 focus-within:border-[var(--accent-orange)]/40 focus-within:shadow-[0_0_0_4px_color-mix(in_oklch,var(--accent-orange)_15%,transparent),0_1px_2px_rgba(15,23,42,0.04)]">
       {children}
     </div>
   )
@@ -583,19 +745,35 @@ export const ConversationInput: FC<ConversationInputProps> = ({
             {voice.error}
           </div>
         ) : null}
-        <ContextControls
-          agents={agents}
-          onCreateAgent={onCreateAgent}
-          onSelectAgent={onSelectAgent}
-          selectedAgentId={selectedAgentId}
-          selectedTabs={selectedTabs}
-          onToggleTab={toggleTab}
-          showAgentSelector={variant === 'home'}
-          status={status}
-          onAttachClick={openFilePicker}
-          attachDisabled={attachments.length >= 10 || isStaging || !!disabled}
-          attachmentsEnabled={attachmentsEnabled}
-        />
+        {variant === 'home' ? (
+          <HomeContextControls
+            agents={agents}
+            onCreateAgent={onCreateAgent}
+            onSelectAgent={onSelectAgent}
+            selectedAgentId={selectedAgentId}
+            selectedTabs={selectedTabs}
+            onToggleTab={toggleTab}
+            showAgentSelector={true}
+            status={status}
+            onAttachClick={openFilePicker}
+            attachDisabled={attachments.length >= 10 || isStaging || !!disabled}
+            attachmentsEnabled={attachmentsEnabled}
+          />
+        ) : (
+          <ContextControls
+            agents={agents}
+            onCreateAgent={onCreateAgent}
+            onSelectAgent={onSelectAgent}
+            selectedAgentId={selectedAgentId}
+            selectedTabs={selectedTabs}
+            onToggleTab={toggleTab}
+            showAgentSelector={false}
+            status={status}
+            onAttachClick={openFilePicker}
+            attachDisabled={attachments.length >= 10 || isStaging || !!disabled}
+            attachmentsEnabled={attachmentsEnabled}
+          />
+        )}
         {isDragOver ? (
           <div className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-[inherit] bg-background/80 font-medium text-foreground text-sm backdrop-blur-sm">
             Drop files to attach

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationInput.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationInput.tsx
@@ -165,12 +165,15 @@ function VoiceButton({
 }
 
 /**
- * Calm-composer footer used by `variant="home"`. Pill-shaped chips on
- * an internal dashed divider, with a right-aligned keyboard hint.
- * The chat-screen composer keeps the original `ContextControls`
- * layout — no shared structure beyond the props pass-through.
+ * Calm-composer footer shared by both `/home` (`variant="home"`) and
+ * the chat surface at `/agents/:agentId` (`variant="conversation"`).
+ * Pill-shaped chips on an internal dashed divider, with a right-
+ * aligned keyboard hint. The agent selector is conditional via
+ * `showAgentSelector`: home shows it as a filled pill on the left,
+ * the chat surface hides it (the agent is locked once you're in the
+ * conversation).
  */
-function HomeContextControls({
+function CalmContextControls({
   agents,
   onCreateAgent,
   onSelectAgent,
@@ -326,144 +329,6 @@ function HomeContextControls({
   )
 }
 
-function ContextControls({
-  agents,
-  onCreateAgent,
-  onSelectAgent,
-  selectedAgentId,
-  selectedTabs,
-  onToggleTab,
-  showAgentSelector,
-  status,
-  onAttachClick,
-  attachDisabled,
-  attachmentsEnabled,
-}: {
-  agents: AgentEntry[]
-  onCreateAgent?: () => void
-  onSelectAgent: (agent: AgentEntry) => void
-  selectedAgentId: string | null
-  selectedTabs: chrome.tabs.Tab[]
-  onToggleTab: (tab: chrome.tabs.Tab) => void
-  showAgentSelector: boolean
-  status?: string
-  onAttachClick: () => void
-  attachDisabled: boolean
-  attachmentsEnabled: boolean
-}) {
-  const { supports } = useCapabilities()
-  const { selectedFolder } = useWorkspace()
-  const { servers: mcpServers } = useMcpServers()
-  const { data: userMCPIntegrations } = useGetUserMCPIntegrations()
-
-  const connectedManagedServers = mcpServers.filter((server) => {
-    if (server.type !== 'managed' || !server.managedServerName) return false
-    return userMCPIntegrations?.integrations?.find(
-      (integration) => integration.name === server.managedServerName,
-    )?.is_authenticated
-  })
-
-  return (
-    <div className="flex items-center justify-between border-border/40 border-t px-4 py-2.5">
-      <div className="flex items-center gap-1">
-        {showAgentSelector ? (
-          <AgentSelector
-            agents={agents}
-            selectedAgentId={selectedAgentId}
-            onSelectAgent={onSelectAgent}
-            onCreateAgent={onCreateAgent}
-            status={status}
-          />
-        ) : null}
-        {supports(Feature.WORKSPACE_FOLDER_SUPPORT) ? (
-          <WorkspaceSelector>
-            <Button
-              variant="ghost"
-              className={cn(
-                'flex items-center gap-2 rounded-lg px-3 py-1.5 font-medium text-sm transition-all',
-                'bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground',
-                'data-[state=open]:bg-accent',
-              )}
-            >
-              <Folder className="h-4 w-4" />
-              <span>{selectedFolder?.name || 'Add workspace'}</span>
-              <ChevronDown className="h-3 w-3" />
-            </Button>
-          </WorkspaceSelector>
-        ) : null}
-        <TabPickerPopover
-          variant="selector"
-          selectedTabs={selectedTabs}
-          onToggleTab={onToggleTab}
-        >
-          <Button
-            className={cn(
-              'flex items-center gap-2 rounded-lg px-3 py-1.5 font-medium text-sm transition-all',
-              selectedTabs.length > 0
-                ? 'bg-[var(--accent-orange)]! text-white shadow-sm'
-                : 'bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground',
-              'data-[state=open]:bg-accent',
-            )}
-          >
-            <Layers className="h-4 w-4" />
-            <span>Tabs</span>
-          </Button>
-        </TabPickerPopover>
-        <Button
-          type="button"
-          variant="ghost"
-          onClick={onAttachClick}
-          disabled={attachDisabled || !attachmentsEnabled}
-          title="Attach files"
-          className={cn(
-            'flex items-center gap-2 rounded-lg px-3 py-1.5 font-medium text-sm transition-all',
-            'bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground',
-          )}
-        >
-          <Paperclip className="h-4 w-4" />
-          <span>Attach</span>
-        </Button>
-      </div>
-
-      {supports(Feature.MANAGED_MCP_SUPPORT) ? (
-        <div className="ml-auto flex items-center gap-1.5">
-          <AppSelector side="bottom">
-            <Button
-              variant="ghost"
-              className={cn(
-                'flex items-center gap-2 rounded-lg px-3 py-1.5 font-medium text-sm transition-all',
-                'bg-transparent text-muted-foreground hover:bg-accent hover:text-accent-foreground',
-                'data-[state=open]:bg-accent',
-              )}
-            >
-              <div className="flex items-center -space-x-1.5">
-                {connectedManagedServers.slice(0, 4).map((server) => (
-                  <div
-                    key={server.id}
-                    className="rounded-full ring-2 ring-card"
-                  >
-                    <McpServerIcon
-                      serverName={server.managedServerName ?? ''}
-                      size={16}
-                    />
-                  </div>
-                ))}
-              </div>
-              {connectedManagedServers.length > 4 ? (
-                <span className="text-xs">
-                  +{connectedManagedServers.length - 4}
-                </span>
-              ) : null}
-              <span>Apps</span>
-              <ChevronDown className="h-3 w-3" />
-            </Button>
-          </AppSelector>
-        </div>
-      ) : null}
-    </div>
-  )
-}
-
 function HomeShell({ children }: { children: ReactNode }) {
   return (
     <div className="overflow-hidden rounded-[1.55rem] border border-border/60 bg-card/95 shadow-sm transition-[border-color,box-shadow] duration-150 focus-within:border-[var(--accent-orange)]/40 focus-within:shadow-[0_0_0_4px_color-mix(in_oklch,var(--accent-orange)_15%,transparent),0_1px_2px_rgba(15,23,42,0.04)]">
@@ -474,7 +339,7 @@ function HomeShell({ children }: { children: ReactNode }) {
 
 function ConversationShell({ children }: { children: ReactNode }) {
   return (
-    <div className="overflow-hidden rounded-[1.35rem] border border-border/50 bg-background/95 shadow-[0_10px_30px_rgba(15,23,42,0.06)] backdrop-blur-md">
+    <div className="overflow-hidden rounded-[1.35rem] border border-border/50 bg-background/95 shadow-[0_10px_30px_rgba(15,23,42,0.06)] backdrop-blur-md transition-[border-color,box-shadow] duration-150 focus-within:border-[var(--accent-orange)]/40 focus-within:shadow-[0_0_0_4px_color-mix(in_oklch,var(--accent-orange)_15%,transparent),0_10px_30px_rgba(15,23,42,0.06)]">
       {children}
     </div>
   )
@@ -745,35 +610,19 @@ export const ConversationInput: FC<ConversationInputProps> = ({
             {voice.error}
           </div>
         ) : null}
-        {variant === 'home' ? (
-          <HomeContextControls
-            agents={agents}
-            onCreateAgent={onCreateAgent}
-            onSelectAgent={onSelectAgent}
-            selectedAgentId={selectedAgentId}
-            selectedTabs={selectedTabs}
-            onToggleTab={toggleTab}
-            showAgentSelector={true}
-            status={status}
-            onAttachClick={openFilePicker}
-            attachDisabled={attachments.length >= 10 || isStaging || !!disabled}
-            attachmentsEnabled={attachmentsEnabled}
-          />
-        ) : (
-          <ContextControls
-            agents={agents}
-            onCreateAgent={onCreateAgent}
-            onSelectAgent={onSelectAgent}
-            selectedAgentId={selectedAgentId}
-            selectedTabs={selectedTabs}
-            onToggleTab={toggleTab}
-            showAgentSelector={false}
-            status={status}
-            onAttachClick={openFilePicker}
-            attachDisabled={attachments.length >= 10 || isStaging || !!disabled}
-            attachmentsEnabled={attachmentsEnabled}
-          />
-        )}
+        <CalmContextControls
+          agents={agents}
+          onCreateAgent={onCreateAgent}
+          onSelectAgent={onSelectAgent}
+          selectedAgentId={selectedAgentId}
+          selectedTabs={selectedTabs}
+          onToggleTab={toggleTab}
+          showAgentSelector={variant === 'home'}
+          status={status}
+          onAttachClick={openFilePicker}
+          attachDisabled={attachments.length >= 10 || isStaging || !!disabled}
+          attachmentsEnabled={attachmentsEnabled}
+        />
         {isDragOver ? (
           <div className="pointer-events-none absolute inset-0 flex items-center justify-center rounded-[inherit] bg-background/80 font-medium text-foreground text-sm backdrop-blur-sm">
             Drop files to attach


### PR DESCRIPTION
## Summary

Adopts the Variant A "calm composer" aesthetic across both home (\`/home\`) and the chat surface (\`/agents/:agentId\`), with a redesigned hero on home. shadcn primitives and existing CSS variables are unchanged; the only logic addition is a \`triggerVariant\` prop on \`<AgentSelector>\` so the home composer can render a filled-pill trigger.

## What changed

**Hero (home)**
- Larger display title (\`clamp(2.25rem, 4.5vw, 3.5rem)\` / weight 600 / tracking -0.025em / balanced wrap)
- Italic accent-orange span around \"work on\" — small typographic accent

**Composer (both surfaces)**
- Internal **dashed divider** between the typing area and the footer chip row
- Footer chips: 24px pill-shaped (\`rounded-full\`), ghost on idle, muted-bg on hover
- Workspace + Tabs chips show muted trailing values inline (\`Workspace none\`, \`Tabs 0\`)
- Right-aligned keyboard hint (\`↵ to run · ⇧↵ new line\`) using \`<kbd>\` with existing accent/border tokens
- Soft accent-orange \`focus-within\` ring on the outer shell

**Composer differences between surfaces**
- **Home** renders the agent selector as a filled pill on the left (\`triggerVariant=\"pill\"\`) followed by a 1px vertical divider — the agent is selectable here.
- **Chat** hides the agent selector entirely (the agent is locked once you're in the conversation) and keeps its existing Stop button between the textarea and voice mic.

**Cleanup**
- Renamed \`HomeContextControls\` → \`CalmContextControls\` (shared by both surfaces).
- Deleted the legacy \`ContextControls\` function (~140 LOC) — single source of truth.

## Bug fix bundled in

The shadcn \`<Textarea>\` base ships \`dark:bg-input/30\` baked into its default class list, which surfaces as a slightly-lighter rectangle inside the calm composer shell on dark mode. Fixed by adding \`dark:bg-transparent\` to the override so the textarea background stays inherited from the composer card in both themes.

## What did NOT change

- All composer logic, send pipeline, attachment flow (PR 930), voice, dropdowns, agent picker behaviour
- Routing, URL handling, the home → chat handoff (registry from PR 930)
- shadcn primitives where they are (\`<Button>\`, dropdowns, popovers, command). New raw \`<button>\` pills only where shadcn's standard sizes don't match the calm aesthetic (24px tall \`rounded-full\`).
- Any CSS variables or theme tokens

## Out of scope (future PRs)

- Variant A eyebrow strip (\`New task · Routing to <agent>\`)
- TRY suggestion chips below the composer
- Recent agents → Variant A's quiet rows
- Activity log section

## Test plan

- [x] \`bun run typecheck\` clean
- [x] \`bunx biome check\` clean
- [x] \`bun test\` 76/76 pass (no logic touched)
- [ ] Manual: /home loads with the new hero + composer; italic accent-orange \"work on\" span renders
- [ ] Manual: focus the textarea on /home → outer shell shows the soft accent-orange ring
- [ ] Manual: dark mode — textarea background sits flush with the card; no lighter rectangle
- [ ] Manual: agent pill click on /home opens the agent selector
- [ ] Manual: navigate to /agents/<id> → chat composer uses the same calm pill footer (without the agent pill); Stop button still surfaces while streaming
- [ ] Manual: Workspace / Tabs / Attach / Apps still trigger their existing flows on both surfaces
- [ ] Manual: paste a screenshot at /home → chip strip appears above textarea, send → chat receives both (PR 930 flow preserved)