### PR TITLE
feat(agent): add delete and clear history for scheduled task runs

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTaskResults.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTaskResults.tsx
@@ -8,6 +8,7 @@ import {
   RotateCcw,
   Square,
   XCircle,
+  Trash2,
 } from 'lucide-react'
 import type { FC } from 'react'
 import { useMemo } from 'react'
@@ -31,6 +32,8 @@ interface ScheduledTaskResultsProps {
   onViewRun: (run: ScheduledJobRun) => void
   onCancelRun: (runId: string) => void
   onRetryRun: (jobId: string) => void
+  onDeleteRun: (runId: string) => void
+  onClearRuns: () => void
 }
 
 const getStatusIcon = (status: JobRunWithDetails['status']) => {
@@ -50,6 +53,8 @@ export const ScheduledTaskResults: FC<ScheduledTaskResultsProps> = ({
   onViewRun,
   onCancelRun,
   onRetryRun,
+  onDeleteRun,
+  onClearRuns,
 }) => {
   const { jobRuns } = useScheduledJobRuns()
   const { jobs } = useScheduledJobs()
@@ -85,63 +90,90 @@ export const ScheduledTaskResults: FC<ScheduledTaskResultsProps> = ({
   }
 
   return (
-    <div className="space-y-2">
-      {sortedRuns.map((run) => (
+    <div className="space-y-4">
+      <div className="flex justify-end">
         <Button
-          key={run.id}
-          variant="ghost"
-          onClick={() => onViewRun(run)}
-          className="h-auto w-full justify-start rounded-xl border border-border/50 bg-card p-4 text-left transition-all hover:border-border"
+          variant="outline"
+          size="sm"
+          onClick={onClearRuns}
+          className="flex items-center gap-2"
         >
-          <div className="flex w-full items-start gap-3">
-            {getStatusIcon(run.status)}
-            <div className="min-w-0 flex-1">
-              <div className="mb-1 flex items-center gap-2">
-                <span className="truncate font-medium text-foreground text-sm">
-                  {run.job?.name}
-                </span>
-                <span className="flex items-center gap-1 text-muted-foreground text-xs">
-                  <Clock className="h-3 w-3" />
-                  {formatTimestamp(run.startedAt)}
-                </span>
+          <Trash2 className="h-4 w-4" />
+          Clear All History
+        </Button>
+      </div>
+      <div className="space-y-2">
+        {sortedRuns.map((run) => (
+          <Button
+            key={run.id}
+            variant="ghost"
+            onClick={() => onViewRun(run)}
+            className="h-auto w-full justify-start rounded-xl border border-border/50 bg-card p-4 text-left transition-all hover:border-border"
+          >
+            <div className="flex w-full items-start gap-3">
+              {getStatusIcon(run.status)}
+              <div className="min-w-0 flex-1">
+                <div className="mb-1 flex items-center gap-2">
+                  <span className="truncate font-medium text-foreground text-sm">
+                    {run.job?.name}
+                  </span>
+                  <span className="flex items-center gap-1 text-muted-foreground text-xs">
+                    <Clock className="h-3 w-3" />
+                    {formatTimestamp(run.startedAt)}
+                  </span>
+                </div>
+                {run.result && (
+                  <p className="line-clamp-2 text-ellipsis text-muted-foreground text-xs">
+                    {run.result}
+                  </p>
+                )}
               </div>
-              {run.result && (
-                <p className="line-clamp-2 text-ellipsis text-muted-foreground text-xs">
-                  {run.result}
-                </p>
+              {run.status === 'running' && (
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onCancelRun(run.id)
+                  }}
+                  className="shrink-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                  aria-label="Cancel run"
+                >
+                  <Square className="h-3.5 w-3.5" />
+                </Button>
+              )}
+              {run.status === 'failed' && (
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onRetryRun(run.jobId)
+                  }}
+                  className="shrink-0 text-muted-foreground hover:text-foreground"
+                  aria-label="Retry run"
+                >
+                  <RotateCcw className="h-3.5 w-3.5" />
+                </Button>
+              )}
+              {run.status !== 'running' && (
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    onDeleteRun(run.id)
+                  }}
+                  className="shrink-0 text-muted-foreground hover:text-destructive"
+                  aria-label="Delete run"
+                >
+                  <Trash2 className="h-3.5 w-3.5" />
+                </Button>
               )}
             </div>
-            {run.status === 'running' && (
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onCancelRun(run.id)
-                }}
-                className="shrink-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
-                aria-label="Cancel run"
-              >
-                <Square className="h-3.5 w-3.5" />
-              </Button>
-            )}
-            {run.status === 'failed' && (
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onRetryRun(run.jobId)
-                }}
-                className="shrink-0 text-muted-foreground hover:text-foreground"
-                aria-label="Retry run"
-              >
-                <RotateCcw className="h-3.5 w-3.5" />
-              </Button>
-            )}
-          </div>
-        </Button>
-      ))}
+          </Button>
+        ))}
+      </div>
     </div>
   )
 }

--- a/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTasksPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTasksPage.tsx
@@ -18,6 +18,8 @@ import {
   SCHEDULED_TASK_DELETED_EVENT,
   SCHEDULED_TASK_EDITED_EVENT,
   SCHEDULED_TASK_RETRIED_EVENT,
+  SCHEDULED_TASK_RUN_DELETED_EVENT,
+  SCHEDULED_TASK_RUNS_CLEARED_EVENT,
   SCHEDULED_TASK_TESTED_EVENT,
   SCHEDULED_TASK_TOGGLED_EVENT,
   SCHEDULED_TASK_VIEW_RESULTS_EVENT,
@@ -42,13 +44,14 @@ import type { ScheduledJob } from './types'
 export const ScheduledTasksPage: FC = () => {
   const { jobs, addJob, editJob, toggleJob, removeJob, runJob } =
     useScheduledJobs()
-  const { jobRuns, cancelJobRun } = useScheduledJobRuns()
+  const { jobRuns, cancelJobRun, removeJobRun, clearJobRuns } = useScheduledJobRuns()
 
   const [activeTab, setActiveTab] = useState<string | null>(null)
   const [isDialogOpen, setIsDialogOpen] = useState(false)
   const [editingJob, setEditingJob] = useState<ScheduledJob | null>(null)
   const [deleteJobId, setDeleteJobId] = useState<string | null>(null)
   const [viewingRunId, setViewingRunId] = useState<string | null>(null)
+  const [clearAllRunsConfirm, setClearAllRunsConfirm] = useState(false)
   const viewingRun = viewingRunId
     ? (jobRuns.find((r) => r.id === viewingRunId) ?? null)
     : null
@@ -149,6 +152,21 @@ export const ScheduledTasksPage: FC = () => {
     track(SCHEDULED_TASK_VIEW_RESULTS_EVENT)
   }
 
+  const handleDeleteRun = async (runId: string) => {
+    await removeJobRun(runId)
+    track(SCHEDULED_TASK_RUN_DELETED_EVENT)
+  }
+
+  const handleClearRuns = () => {
+    setClearAllRunsConfirm(true)
+  }
+
+  const confirmClearRuns = async () => {
+    await clearJobRuns()
+    track(SCHEDULED_TASK_RUNS_CLEARED_EVENT)
+    setClearAllRunsConfirm(false)
+  }
+
   useEffect(() => {
     scheduledJobRunStorage.getValue().then((runs) => {
       setActiveTab(runs && runs.length > 0 ? 'results' : 'tasks')
@@ -175,6 +193,8 @@ export const ScheduledTasksPage: FC = () => {
               onViewRun={handleViewRun}
               onCancelRun={handleCancelRun}
               onRetryRun={handleRetryRun}
+              onDeleteRun={handleDeleteRun}
+              onClearRuns={handleClearRuns}
             />
           </TabsContent>
 
@@ -234,6 +254,27 @@ export const ScheduledTasksPage: FC = () => {
             <AlertDialogCancel>Cancel</AlertDialogCancel>
             <AlertDialogAction onClick={confirmDelete}>
               Delete
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <AlertDialog
+        open={clearAllRunsConfirm}
+        onOpenChange={(open) => !open && setClearAllRunsConfirm(false)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Clear All Run History</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will permanently delete all scheduled task run history. This
+              action cannot be undone.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={confirmClearRuns}>
+              Clear All
             </AlertDialogAction>
           </AlertDialogFooter>
         </AlertDialogContent>

--- a/packages/browseros-agent/apps/agent/lib/constants/analyticsEvents.ts
+++ b/packages/browseros-agent/apps/agent/lib/constants/analyticsEvents.ts
@@ -217,6 +217,14 @@ export const SCHEDULED_TASK_CANCELLED_EVENT =
 export const SCHEDULED_TASK_RETRIED_EVENT = 'settings.scheduled_task.retried'
 
 /** @public */
+export const SCHEDULED_TASK_RUN_DELETED_EVENT =
+  'settings.scheduled_task.run_deleted'
+
+/** @public */
+export const SCHEDULED_TASK_RUNS_CLEARED_EVENT =
+  'settings.scheduled_task.runs_cleared'
+
+/** @public */
 export const JTBD_POPUP_DISMISSED_EVENT = 'ui.jtbd_popup.dismissed'
 
 /** @public */

--- a/packages/browseros-agent/apps/agent/lib/schedules/scheduleStorage.ts
+++ b/packages/browseros-agent/apps/agent/lib/schedules/scheduleStorage.ts
@@ -144,6 +144,10 @@ export function useScheduledJobRuns() {
     await scheduledJobRunStorage.setValue(current.filter((r) => r.id !== id))
   }
 
+  const clearJobRuns = async () => {
+    await scheduledJobRunStorage.setValue([])
+  }
+
   const editJobRun = async (
     id: string,
     updates: Partial<Omit<ScheduledJobRun, 'id'>>,
@@ -158,7 +162,7 @@ export function useScheduledJobRuns() {
     return sendScheduleMessage('cancelScheduledJobRun', { runId })
   }
 
-  return { jobRuns, addJobRun, removeJobRun, editJobRun, cancelJobRun }
+  return { jobRuns, addJobRun, removeJobRun, clearJobRuns, editJobRun, cancelJobRun }
 }
 
 export async function syncScheduledJobs(): Promise<void> {


### PR DESCRIPTION
## Summary

Closes #926

- Adds a **Trash2 delete button** on each completed/failed run in the Scheduled Tasks results list — running tasks cannot be deleted
- Adds a **Clear All History** button at the top of the results panel
- Wires `onDeleteRun` / `onClearRuns` callbacks from `ScheduledTasksPage` → `ScheduledTaskResults`
- Adds `clearJobRuns()` to `useScheduledJobRuns` hook (sets `scheduledJobRunStorage` to `[]`)
- Adds `SCHEDULED_TASK_RUN_DELETED_EVENT` and `SCHEDULED_TASK_RUNS_CLEARED_EVENT` analytics events

## Test plan

- [ ] Create a scheduled task and run it manually a few times
- [ ] Verify delete (Trash2) button appears on completed/failed runs but NOT on running runs
- [ ] Click delete on a single run → run disappears, others remain
- [ ] Refresh page → deleted run does not reappear (removed from storage)
- [ ] Click **Clear All History** → all runs removed, results tab shows empty state
- [ ] Refresh page → no runs visible
