### PR TITLE
feat(openclaw): aggregate sub-session history into agent main session

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/server.ts
+++ b/packages/browseros-agent/apps/server/src/api/server.ts
@@ -46,6 +46,7 @@ import {
   connectKlavisInBackground,
   type KlavisProxyRef,
 } from './services/klavis/strata-proxy'
+import { convertOpenClawHistoryToAgentHistory } from './services/openclaw/history-mapper'
 import { OpenClawGatewayChatClient } from './services/openclaw/openclaw-gateway-chat-client'
 import { getOpenClawService } from './services/openclaw/openclaw-service'
 import type { Env, HttpServerConfig } from './types'
@@ -159,6 +160,15 @@ export async function createHttpServer(config: HttpServerConfig) {
             }))
           },
           getStatus: () => getOpenClawService().getStatus(),
+          getAgentHistory: async (agentId) => {
+            // Aggregated across the agent's main + every sub-session
+            // (cron / hook / channel) so autonomous turns surface in
+            // the chat panel alongside user-initiated ones.
+            const raw = await getOpenClawService().getSessionHistory(
+              `agent:${agentId}:main`,
+            )
+            return convertOpenClawHistoryToAgentHistory(agentId, raw)
+          },
         },
       }),
     )

--- a/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
@@ -120,6 +120,15 @@ export interface OpenClawProvisioner {
    * gateway is not configured at all).
    */
   getStatus?(): Promise<GatewayStatusSnapshot | null>
+  /**
+   * Optional. When wired, the harness uses this for `getHistory` on
+   * openclaw-adapter agents so the chat panel sees autonomous
+   * (cron / hook / channel) turns alongside user-typed turns. Without
+   * this, history reads come from AcpxRuntime's local session record
+   * which only contains user-initiated turns — autonomous activity
+   * fires correctly but stays invisible to the panel.
+   */
+  getAgentHistory?(agentId: string): Promise<AgentHistoryPage>
 }
 
 /**
@@ -599,6 +608,16 @@ export class AgentHarnessService {
 
   async getHistory(agentId: string): Promise<AgentHistoryPage> {
     const agent = await this.requireAgent(agentId)
+    // OpenClaw agents persist conversation in the gateway, not in the
+    // AcpxRuntime's local session record. Reading the local record
+    // would miss autonomous (cron / hook / channel) turns. Route
+    // through the provisioner so the panel sees the full history.
+    if (
+      agent.adapter === 'openclaw' &&
+      this.openclawProvisioner?.getAgentHistory
+    ) {
+      return this.openclawProvisioner.getAgentHistory(agentId)
+    }
     return this.runtime.getHistory({ agent, sessionId: 'main' })
   }
 

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/history-mapper.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/history-mapper.ts
@@ -43,6 +43,7 @@ const BROWSEROS_SYSTEM_REMINDER_BLOCK =
   /\n*<system-reminder>[\s\S]*?<\/system-reminder>\s*$/
 const QUEUED_MARKER_LINE =
   /^\[Queued user message that arrived while the previous turn was still active\]\s*$/m
+const SUBAGENT_CONTEXT_PREFIX = /^\[Subagent Context\][\s\S]*$/
 
 /**
  * Strip OpenClaw + BrowserOS scaffolding from a "user" message before
@@ -59,6 +60,11 @@ const QUEUED_MARKER_LINE =
  *     `[Queued user message that arrived while the previous turn was
  *     still active]`. We split on those markers and clean each chunk
  *     independently, then re-join the non-empty results.
+ *   - Subagent context prefix: when an agent invokes a nested subagent,
+ *     OpenClaw seeds the subagent's session with `[Subagent Context]
+ *     You are running as a subagent (depth N/M). ...` followed by
+ *     internal task framing. The actual task lives in the system prompt;
+ *     this user message is pure scaffolding and gets dropped entirely.
  *
  * For each, we extract just the user-facing text. Non-matching messages
  * fall through unchanged so any future pattern we don't recognize stays
@@ -85,6 +91,12 @@ export function cleanHistoryUserText(raw: string): string {
 function cleanSingleUserMessage(raw: string): string {
   const trimmed = raw.trim()
   if (!trimmed) return ''
+  // Subagent context seed: pure scaffolding, drop entirely. The real
+  // task lives in the subagent's system prompt; the user-message body
+  // is just framing the model never produced.
+  if (SUBAGENT_CONTEXT_PREFIX.test(trimmed)) {
+    return ''
+  }
   const cronMatch = CRON_PROMPT_PREFIX_PATTERN.exec(trimmed)
   if (cronMatch) {
     const payload = cronMatch[2] ?? ''
@@ -155,10 +167,14 @@ export function convertOpenClawHistoryToAgentHistory(
     const reasoningText = collectThinking(blocks).trim()
     const toolCallEntries = collectToolCalls(blocks, pendingByToolCallId)
 
-    // Skip entries that would render as completely empty cards. A turn
-    // that is *only* tool calls still has value — the user sees what
-    // tools the agent reached for — so don't filter those.
-    if (!text && !reasoningText && toolCallEntries.length === 0) continue
+    // Skip empty entries. Two cases:
+    //   - User: cleaner returned empty after stripping scaffolding (e.g.
+    //     dropped Subagent Context message). No bubble to render.
+    //   - Assistant: model returned only thinking blocks (common with
+    //     MiniMax `thinking: minimal` for trivial prompts) and no text
+    //     or tools. The empty bubble + dangling reasoning collapsible
+    //     reads as broken UI; cleaner to drop the turn entirely.
+    if (!text && toolCallEntries.length === 0) continue
 
     const entry: AgentHistoryEntry = {
       id: message.messageId ?? nextId(),

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/history-mapper.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/history-mapper.ts
@@ -1,0 +1,211 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Converts an aggregated OpenClaw session history (rich content blocks
+ * across the agent's main + sub-sessions) into the flat AgentHistoryPage
+ * shape the chat panel consumes.
+ *
+ * Input: OpenClawSessionHistory.messages — each message has `content`
+ *   that is either a string OR an array of typed blocks
+ *   ({type: 'text'|'thinking'|'toolCall'|'toolResult'}). The HTTP endpoint
+ *   returns the array form even though the type definition says string.
+ *
+ * Output: AgentHistoryEntry[] — flat text per entry, separate `reasoning`
+ *   and `toolCalls` fields the UI renders as collapsible sections.
+ *
+ * Tool result pairing: `toolCall` blocks emit on assistant messages;
+ * the matching `toolResult` arrives in a later message (typically with
+ * role 'tool' or 'toolResult'). We pair them by `toolCallId` so the
+ * resulting AgentHistoryToolCall has both input and output.
+ */
+
+import type {
+  AgentHistoryEntry,
+  AgentHistoryToolCall,
+} from '../../../lib/agents/agent-types'
+import type { AgentHistoryPage } from '../../../lib/agents/types'
+import type {
+  OpenClawSessionHistory,
+  OpenClawSessionHistoryMessage,
+} from './openclaw-http-client'
+
+type RichBlock =
+  | { type: 'text'; text?: string }
+  | { type: 'thinking'; thinking?: string; text?: string }
+  | {
+      type: 'toolCall'
+      id?: string
+      toolCallId?: string
+      name?: string
+      arguments?: unknown
+    }
+  | {
+      type: 'toolResult'
+      toolCallId?: string
+      content?: unknown
+      isError?: boolean
+    }
+  | { type: string; [key: string]: unknown }
+
+// We hold the AgentHistoryToolCall reference itself in `pending` so a
+// later `toolResult` block mutates the same object that was already
+// pushed onto the assistant entry's `toolCalls` array.
+type PendingToolCall = AgentHistoryToolCall
+
+export function convertOpenClawHistoryToAgentHistory(
+  agentId: string,
+  raw: OpenClawSessionHistory,
+): AgentHistoryPage {
+  const items: AgentHistoryEntry[] = []
+  // Resolved tool calls keyed by toolCallId — used to attach `output`
+  // back to the assistant entry that issued the call once the tool
+  // result arrives in a subsequent message.
+  const pendingByToolCallId = new Map<string, PendingToolCall>()
+
+  let entryCounter = 0
+  const nextId = () => `${agentId}:hist:${entryCounter++}`
+
+  for (const message of raw.messages) {
+    const blocks = normalizeBlocks(message)
+    const role = normalizeRole(message.role)
+
+    if (!role) {
+      // 'system' / 'tool' messages aren't shown as their own chat entries;
+      // tool results get folded into the assistant entry they complete.
+      if (message.role === 'tool') {
+        applyToolResults(blocks, pendingByToolCallId)
+      }
+      continue
+    }
+
+    const text = collectText(blocks).trim()
+    const reasoningText = collectThinking(blocks).trim()
+    const toolCallEntries = collectToolCalls(blocks, pendingByToolCallId)
+
+    // Skip entries that would render as completely empty cards. A turn
+    // that is *only* tool calls still has value — the user sees what
+    // tools the agent reached for — so don't filter those.
+    if (!text && !reasoningText && toolCallEntries.length === 0) continue
+
+    const entry: AgentHistoryEntry = {
+      id: message.messageId ?? nextId(),
+      agentId,
+      sessionId: 'main',
+      role,
+      text,
+      createdAt: message.timestamp ?? 0,
+    }
+    if (reasoningText) {
+      entry.reasoning = { text: reasoningText }
+    }
+    if (toolCallEntries.length > 0) {
+      entry.toolCalls = toolCallEntries
+    }
+
+    items.push(entry)
+  }
+
+  return {
+    agentId,
+    sessionId: 'main',
+    items,
+  }
+}
+
+function normalizeBlocks(message: OpenClawSessionHistoryMessage): RichBlock[] {
+  const content = (message as { content: unknown }).content
+  if (typeof content === 'string') {
+    return content ? [{ type: 'text', text: content }] : []
+  }
+  if (Array.isArray(content)) {
+    return content as RichBlock[]
+  }
+  return []
+}
+
+function normalizeRole(
+  role: OpenClawSessionHistoryMessage['role'],
+): 'user' | 'assistant' | null {
+  if (role === 'user' || role === 'assistant') return role
+  return null
+}
+
+function collectText(blocks: RichBlock[]): string {
+  const parts: string[] = []
+  for (const block of blocks) {
+    if (block.type === 'text' && typeof block.text === 'string') {
+      parts.push(block.text)
+    }
+  }
+  return parts.join('\n')
+}
+
+function collectThinking(blocks: RichBlock[]): string {
+  const parts: string[] = []
+  for (const block of blocks) {
+    if (block.type === 'thinking') {
+      const value =
+        typeof block.thinking === 'string'
+          ? block.thinking
+          : typeof block.text === 'string'
+            ? block.text
+            : ''
+      if (value) parts.push(value)
+    }
+  }
+  return parts.join('\n\n')
+}
+
+function collectToolCalls(
+  blocks: RichBlock[],
+  pending: Map<string, PendingToolCall>,
+): AgentHistoryToolCall[] {
+  const out: AgentHistoryToolCall[] = []
+  for (const block of blocks) {
+    if (block.type !== 'toolCall') continue
+    const callId =
+      typeof block.toolCallId === 'string'
+        ? block.toolCallId
+        : typeof block.id === 'string'
+          ? block.id
+          : undefined
+    if (!callId) continue
+    const toolName = typeof block.name === 'string' ? block.name : 'unknown'
+    const entry: AgentHistoryToolCall = {
+      toolCallId: callId,
+      toolName,
+      status: 'completed',
+      input: block.arguments,
+    }
+    out.push(entry)
+    // Hold the same reference so a later toolResult mutates the entry
+    // already pushed onto the assistant's toolCalls array.
+    pending.set(callId, entry)
+  }
+  return out
+}
+
+function applyToolResults(
+  blocks: RichBlock[],
+  pending: Map<string, PendingToolCall>,
+): void {
+  for (const block of blocks) {
+    if (block.type !== 'toolResult') continue
+    const callId =
+      typeof block.toolCallId === 'string' ? block.toolCallId : undefined
+    if (!callId) continue
+    const entry = pending.get(callId)
+    if (!entry) continue
+    if (block.isError) {
+      entry.status = 'failed'
+      entry.error =
+        typeof block.content === 'string'
+          ? block.content
+          : JSON.stringify(block.content)
+    } else {
+      entry.output = block.content
+    }
+  }
+}

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/history-mapper.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/history-mapper.ts
@@ -31,6 +31,50 @@ import type {
   OpenClawSessionHistoryMessage,
 } from './openclaw-http-client'
 
+const CRON_PROMPT_PREFIX_PATTERN =
+  /^\[cron:[0-9a-f-]+ ([^\]]+)\]\s*([\s\S]*?)\n*Current time:[^\n]*(?:\n[\s\S]*)?$/
+const CRON_DELIVERY_TRAILER =
+  /\n*Use the message tool if you need to notify the user directly[\s\S]*$/
+const BROWSEROS_WORKING_DIR_PREFIX = /^\[Working directory:[^\]]*\]\n+/
+const BROWSEROS_ROLE_BLOCK = /<role>[\s\S]*?<\/role>\n+/
+const BROWSEROS_USER_REQUEST_BLOCK =
+  /<user_request>\n?([\s\S]*?)\n?<\/user_request>/
+const BROWSEROS_SYSTEM_REMINDER_BLOCK =
+  /\n*<system-reminder>[\s\S]*?<\/system-reminder>\s*$/
+
+/**
+ * Strip OpenClaw + BrowserOS scaffolding from a "user" message before
+ * showing it in the chat panel. The raw prompts contain:
+ *
+ *   - OpenClaw cron payload prefix:
+ *       `[cron:<uuid> <name>] <payload>\nCurrent time: ...\nUse the
+ *       message tool if you need to notify the user directly...`
+ *   - BrowserOS ACP prefix:
+ *       `[Working directory: ...]\n\n<role>...</role>\n\n<user_request>
+ *       <actual user text>\n</user_request>\n\n<system-reminder>...</system-reminder>`
+ *
+ * For each, we extract just the user-facing text. Non-matching messages
+ * fall through unchanged so any future pattern we don't recognize stays
+ * visible rather than getting silently dropped.
+ */
+export function cleanHistoryUserText(raw: string): string {
+  if (!raw) return raw
+  const cronMatch = CRON_PROMPT_PREFIX_PATTERN.exec(raw)
+  if (cronMatch) {
+    const payload = cronMatch[2] ?? ''
+    return payload.replace(CRON_DELIVERY_TRAILER, '').trim()
+  }
+  let text = raw
+  text = text.replace(BROWSEROS_WORKING_DIR_PREFIX, '')
+  text = text.replace(BROWSEROS_ROLE_BLOCK, '')
+  text = text.replace(BROWSEROS_SYSTEM_REMINDER_BLOCK, '')
+  const userReq = BROWSEROS_USER_REQUEST_BLOCK.exec(text)
+  if (userReq) {
+    return (userReq[1] ?? '').trim()
+  }
+  return text.trim()
+}
+
 type RichBlock =
   | { type: 'text'; text?: string }
   | { type: 'thinking'; thinking?: string; text?: string }
@@ -80,7 +124,8 @@ export function convertOpenClawHistoryToAgentHistory(
       continue
     }
 
-    const text = collectText(blocks).trim()
+    const rawText = collectText(blocks).trim()
+    const text = role === 'user' ? cleanHistoryUserText(rawText) : rawText
     const reasoningText = collectThinking(blocks).trim()
     const toolCallEntries = collectToolCalls(blocks, pendingByToolCallId)
 

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/history-mapper.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/history-mapper.ts
@@ -41,6 +41,8 @@ const BROWSEROS_USER_REQUEST_BLOCK =
   /<user_request>\n?([\s\S]*?)\n?<\/user_request>/
 const BROWSEROS_SYSTEM_REMINDER_BLOCK =
   /\n*<system-reminder>[\s\S]*?<\/system-reminder>\s*$/
+const QUEUED_MARKER_LINE =
+  /^\[Queued user message that arrived while the previous turn was still active\]\s*$/m
 
 /**
  * Strip OpenClaw + BrowserOS scaffolding from a "user" message before
@@ -52,6 +54,11 @@ const BROWSEROS_SYSTEM_REMINDER_BLOCK =
  *   - BrowserOS ACP prefix:
  *       `[Working directory: ...]\n\n<role>...</role>\n\n<user_request>
  *       <actual user text>\n</user_request>\n\n<system-reminder>...</system-reminder>`
+ *   - Queued-marker concatenation: when multiple prompts queue while a
+ *     turn is active, BrowserOS joins them with the marker line
+ *     `[Queued user message that arrived while the previous turn was
+ *     still active]`. We split on those markers and clean each chunk
+ *     independently, then re-join the non-empty results.
  *
  * For each, we extract just the user-facing text. Non-matching messages
  * fall through unchanged so any future pattern we don't recognize stays
@@ -59,12 +66,31 @@ const BROWSEROS_SYSTEM_REMINDER_BLOCK =
  */
 export function cleanHistoryUserText(raw: string): string {
   if (!raw) return raw
-  const cronMatch = CRON_PROMPT_PREFIX_PATTERN.exec(raw)
+  // Queued-marker case: this is structurally a multi-message blob, so
+  // split first and recurse into each chunk. We keep the join character
+  // narrow (single newline) so e.g. five cron payloads render as five
+  // visually-separate lines rather than one wall of text.
+  if (QUEUED_MARKER_LINE.test(raw)) {
+    const chunks = raw
+      .split(
+        /^\[Queued user message that arrived while the previous turn was still active\]\s*$/m,
+      )
+      .map((chunk) => cleanSingleUserMessage(chunk))
+      .filter((chunk) => chunk.length > 0)
+    return chunks.join('\n')
+  }
+  return cleanSingleUserMessage(raw)
+}
+
+function cleanSingleUserMessage(raw: string): string {
+  const trimmed = raw.trim()
+  if (!trimmed) return ''
+  const cronMatch = CRON_PROMPT_PREFIX_PATTERN.exec(trimmed)
   if (cronMatch) {
     const payload = cronMatch[2] ?? ''
     return payload.replace(CRON_DELIVERY_TRAILER, '').trim()
   }
-  let text = raw
+  let text = trimmed
   text = text.replace(BROWSEROS_WORKING_DIR_PREFIX, '')
   text = text.replace(BROWSEROS_ROLE_BLOCK, '')
   text = text.replace(BROWSEROS_SYSTEM_REMINDER_BLOCK, '')

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-http-client.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-http-client.ts
@@ -44,6 +44,17 @@ export interface OpenClawSessionHistoryMessage {
   messageId?: string
   messageSeq?: number
   timestamp?: number
+  /**
+   * Origin of this message when the response merges multiple sessions.
+   * Absent on single-session responses for backward compatibility.
+   */
+  source?: 'main' | 'cron' | 'hook' | 'channel' | 'other'
+  /**
+   * The session key this message originated from. Differs from the
+   * top-level `sessionKey` when sub-sessions (e.g. cron runs) are merged
+   * into a parent agent's main-session response.
+   */
+  subSessionKey?: string
 }
 
 export interface OpenClawSessionHistory {

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-http-client.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-http-client.ts
@@ -45,6 +45,13 @@ export interface OpenClawSessionHistoryMessage {
   messageSeq?: number
   timestamp?: number
   /**
+   * OpenClaw extension envelope. The gateway records the per-session
+   * monotonic sequence on `__openclaw.seq` rather than the top-level
+   * `messageSeq` field, so cursor logic reads from here. `id` is the
+   * gateway's stable message id.
+   */
+  __openclaw?: { id?: string; seq?: number }
+  /**
    * Origin of this message when the response merges multiple sessions.
    * Absent on single-session responses for backward compatibility.
    */

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -40,6 +40,7 @@ import {
   type OpenClawAgentRecord,
   OpenClawCliClient,
   type OpenClawConfigBatchEntry,
+  type OpenClawSessionEntry,
 } from './openclaw-cli-client'
 import {
   buildOpenClawCliProviderModelRef,
@@ -61,6 +62,7 @@ import {
   OpenClawHttpClient,
   type OpenClawSessionHistory,
   type OpenClawSessionHistoryEvent,
+  type OpenClawSessionHistoryMessage,
 } from './openclaw-http-client'
 import { OpenClawObserver } from './openclaw-observer'
 import {
@@ -232,6 +234,57 @@ export function normalizeBrowserOSChatSessionKey(
 
 function getOpenClawBrowserOSSessionPrefix(agentId: string): string {
   return `agent:${agentId}:openai-user:browseros:${agentId}:`
+}
+
+const MAIN_SESSION_KEY_PATTERN = /^agent:([^:]+):main$/
+
+/**
+ * Extract the agent id from a main-session key (e.g. `agent:research:main`
+ * → `research`). Returns null when the key isn't a top-level main session,
+ * which signals the caller to use the per-session fetch path.
+ */
+function extractAgentIdFromMainSessionKey(sessionKey: string): string | null {
+  const match = MAIN_SESSION_KEY_PATTERN.exec(sessionKey)
+  return match?.[1] ?? null
+}
+
+/**
+ * Classify a session key by its source. The pattern is `agent:<id>:<kind>:...`;
+ * the third segment identifies how the session was started.
+ */
+function parseSessionSource(
+  sessionKey: string,
+): NonNullable<OpenClawSessionHistoryMessage['source']> {
+  const parts = sessionKey.split(':')
+  if (parts[0] !== 'agent' || parts.length < 3) return 'other'
+  switch (parts[2]) {
+    case 'main':
+      return 'main'
+    case 'cron':
+      return 'cron'
+    case 'hook':
+      return 'hook'
+    case 'channel':
+      return 'channel'
+    default:
+      return 'other'
+  }
+}
+
+/**
+ * Stable chronological order across sessions. Falls back to `messageSeq`
+ * when timestamps tie or are missing, preserving intra-session order.
+ */
+function compareMessageOrder(
+  a: OpenClawSessionHistoryMessage,
+  b: OpenClawSessionHistoryMessage,
+): number {
+  const aTs = a.timestamp ?? 0
+  const bTs = b.timestamp ?? 0
+  if (aTs !== bTs) return aTs - bTs
+  const aSeq = a.messageSeq ?? 0
+  const bSeq = b.messageSeq ?? 0
+  return aSeq - bSeq
 }
 
 export interface AgentOverview {
@@ -794,9 +847,99 @@ export class OpenClawService {
     input: { limit?: number; cursor?: string; signal?: AbortSignal } = {},
   ): Promise<OpenClawSessionHistory> {
     await this.assertGatewayReady()
-    return this.runControlPlaneCall(() =>
-      this.httpClient.getSessionHistory(sessionKey, input),
+    return this.runControlPlaneCall(async () => {
+      const agentId = extractAgentIdFromMainSessionKey(sessionKey)
+      if (!agentId) {
+        return this.httpClient.getSessionHistory(sessionKey, input)
+      }
+      return this.fetchAggregatedAgentHistory(sessionKey, agentId, input)
+    })
+  }
+
+  /**
+   * Aggregates the agent's main session and every sub-session (cron,
+   * hook, channel) into a single chronological response. The main
+   * session's own messages are included; each sub-session's messages
+   * are tagged with `source` and `subSessionKey` so the UI can
+   * distinguish autonomous turns from user-driven turns.
+   *
+   * Sub-session fetches that fail are logged and dropped — partial
+   * timelines are preferable to a hard failure that hides the main
+   * session.
+   */
+  private async fetchAggregatedAgentHistory(
+    mainSessionKey: string,
+    agentId: string,
+    input: { limit?: number; cursor?: string; signal?: AbortSignal },
+  ): Promise<OpenClawSessionHistory> {
+    const sessions = await this.cliClient
+      .listSessions(agentId)
+      .catch((err): OpenClawSessionEntry[] => {
+        logger.warn(
+          'Failed to list OpenClaw sub-sessions; falling back to main only',
+          { agentId, error: err instanceof Error ? err.message : String(err) },
+        )
+        return []
+      })
+
+    const targetKeys = new Set<string>([mainSessionKey])
+    for (const entry of sessions) {
+      if (entry.key?.startsWith(`agent:${agentId}:`)) {
+        targetKeys.add(entry.key)
+      }
+    }
+
+    const fetchedHistories = await Promise.all(
+      Array.from(targetKeys).map(async (key) => {
+        try {
+          const history = await this.httpClient.getSessionHistory(key, {
+            // Per-session limit — applied again post-merge below.
+            limit: input.limit,
+            signal: input.signal,
+          })
+          return { key, history }
+        } catch (err) {
+          logger.warn('Failed to fetch OpenClaw sub-session history', {
+            sessionKey: key,
+            error: err instanceof Error ? err.message : String(err),
+          })
+          return null
+        }
+      }),
     )
+
+    const merged: OpenClawSessionHistoryMessage[] = []
+    let truncated = false
+    for (const result of fetchedHistories) {
+      if (!result) continue
+      const source = parseSessionSource(result.key)
+      const isMain = result.key === mainSessionKey
+      for (const msg of result.history.messages) {
+        merged.push({
+          ...msg,
+          source,
+          // Annotate sub-session origin so the UI can render section
+          // markers without re-parsing the key.
+          ...(isMain ? {} : { subSessionKey: result.key }),
+        })
+      }
+      if (result.history.truncated) truncated = true
+    }
+
+    merged.sort(compareMessageOrder)
+
+    const limited =
+      typeof input.limit === 'number' && input.limit > 0
+        ? merged.slice(-input.limit)
+        : merged
+
+    return {
+      sessionKey: mainSessionKey,
+      messages: limited,
+      cursor: null,
+      hasMore: false,
+      truncated: truncated || limited.length < merged.length,
+    }
   }
 
   async streamSessionHistory(

--- a/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/openclaw/openclaw-service.ts
@@ -272,7 +272,23 @@ function parseSessionSource(
 }
 
 /**
- * Stable chronological order across sessions. Falls back to `messageSeq`
+ * Per-session monotonic sequence. Gateway encodes it inside the
+ * `__openclaw` extension envelope; the legacy top-level `messageSeq`
+ * field exists in the type but is rarely populated.
+ */
+function resolveMessageSeq(msg: OpenClawSessionHistoryMessage): number | null {
+  const fromEnvelope = msg.__openclaw?.seq
+  if (typeof fromEnvelope === 'number' && Number.isFinite(fromEnvelope)) {
+    return fromEnvelope
+  }
+  if (typeof msg.messageSeq === 'number' && Number.isFinite(msg.messageSeq)) {
+    return msg.messageSeq
+  }
+  return null
+}
+
+/**
+ * Stable chronological order across sessions. Falls back to seq
  * when timestamps tie or are missing, preserving intra-session order.
  */
 function compareMessageOrder(
@@ -282,9 +298,40 @@ function compareMessageOrder(
   const aTs = a.timestamp ?? 0
   const bTs = b.timestamp ?? 0
   if (aTs !== bTs) return aTs - bTs
-  const aSeq = a.messageSeq ?? 0
-  const bSeq = b.messageSeq ?? 0
-  return aSeq - bSeq
+  return (resolveMessageSeq(a) ?? 0) - (resolveMessageSeq(b) ?? 0)
+}
+
+/**
+ * Compound cursor for the aggregated history endpoint. Maps each
+ * session key to either:
+ *   - a `messageSeq` to fetch BEFORE on the next page (more historical),
+ *   - or `null` meaning the session is exhausted and should be skipped.
+ *
+ * Encoded as base64url JSON for URL-safe transport in `?cursor=`.
+ */
+type CompoundCursor = Record<string, number | null>
+
+function decodeCompoundCursor(encoded: string | undefined): CompoundCursor {
+  if (!encoded) return {}
+  try {
+    const json = Buffer.from(encoded, 'base64url').toString('utf8')
+    const parsed = JSON.parse(json)
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      const out: CompoundCursor = {}
+      for (const [k, v] of Object.entries(parsed)) {
+        if (typeof v === 'number' || v === null) out[k] = v
+      }
+      return out
+    }
+  } catch {
+    // Malformed cursors are treated as "first page" — preferable to
+    // erroring out the entire history fetch on a bad client cursor.
+  }
+  return {}
+}
+
+function encodeCompoundCursor(cursor: CompoundCursor): string {
+  return Buffer.from(JSON.stringify(cursor), 'utf8').toString('base64url')
 }
 
 export interface AgentOverview {
@@ -863,6 +910,14 @@ export class OpenClawService {
    * are tagged with `source` and `subSessionKey` so the UI can
    * distinguish autonomous turns from user-driven turns.
    *
+   * Pagination uses a compound cursor that encodes a per-session seq
+   * for each session in scope (`{<sessionKey>: seq | null}`). Each page
+   * fetches each non-exhausted session with its own per-session cursor,
+   * merges messages across sessions by timestamp, slices to `limit`,
+   * and emits a fresh compound cursor reflecting where each session
+   * should resume on the next page. A session with `null` in the
+   * cursor is exhausted and skipped.
+   *
    * Sub-session fetches that fail are logged and dropped — partial
    * timelines are preferable to a hard failure that hides the main
    * session.
@@ -872,6 +927,7 @@ export class OpenClawService {
     agentId: string,
     input: { limit?: number; cursor?: string; signal?: AbortSignal },
   ): Promise<OpenClawSessionHistory> {
+    const compoundIn = decodeCompoundCursor(input.cursor)
     const sessions = await this.cliClient
       .listSessions(agentId)
       .catch((err): OpenClawSessionEntry[] => {
@@ -882,6 +938,9 @@ export class OpenClawService {
         return []
       })
 
+    // Build the candidate set from the agent's session directory plus
+    // the main key (which may not appear in `sessions.list` if the file
+    // hasn't been written yet for a fresh agent).
     const targetKeys = new Set<string>([mainSessionKey])
     for (const entry of sessions) {
       if (entry.key?.startsWith(`agent:${agentId}:`)) {
@@ -889,12 +948,23 @@ export class OpenClawService {
       }
     }
 
+    // Only fetch sessions that aren't exhausted by the inbound cursor.
+    // A session with `null` in the cursor is fully read; skip it on
+    // subsequent pages.
+    const activeKeys = Array.from(targetKeys).filter(
+      (k) => compoundIn[k] !== null,
+    )
+
     const fetchedHistories = await Promise.all(
-      Array.from(targetKeys).map(async (key) => {
+      activeKeys.map(async (key) => {
+        const sessionCursor = compoundIn[key]
         try {
           const history = await this.httpClient.getSessionHistory(key, {
-            // Per-session limit — applied again post-merge below.
             limit: input.limit,
+            cursor:
+              typeof sessionCursor === 'number'
+                ? String(sessionCursor)
+                : undefined,
             signal: input.signal,
           })
           return { key, history }
@@ -908,7 +978,8 @@ export class OpenClawService {
       }),
     )
 
-    const merged: OpenClawSessionHistoryMessage[] = []
+    type Annotated = OpenClawSessionHistoryMessage & { __sessionKey: string }
+    const merged: Annotated[] = []
     let truncated = false
     for (const result of fetchedHistories) {
       if (!result) continue
@@ -918,9 +989,8 @@ export class OpenClawService {
         merged.push({
           ...msg,
           source,
-          // Annotate sub-session origin so the UI can render section
-          // markers without re-parsing the key.
           ...(isMain ? {} : { subSessionKey: result.key }),
+          __sessionKey: result.key,
         })
       }
       if (result.history.truncated) truncated = true
@@ -928,16 +998,49 @@ export class OpenClawService {
 
     merged.sort(compareMessageOrder)
 
+    // The merged window contains the latest portion fetched. We emit
+    // up to `limit` messages from the END (newest), and compute the
+    // resume position for each session as the seq of the EARLIEST
+    // emitted message that came from that session.
     const limited =
       typeof input.limit === 'number' && input.limit > 0
         ? merged.slice(-input.limit)
         : merged
 
+    const compoundOut: CompoundCursor = {}
+    // Carry forward exhausted sessions so subsequent pages keep skipping them.
+    for (const key of Array.from(targetKeys)) {
+      if (compoundIn[key] === null) {
+        compoundOut[key] = null
+      }
+    }
+    for (const result of fetchedHistories) {
+      if (!result) continue
+      const key = result.key
+      const earliestEmitted = limited.find((m) => m.__sessionKey === key)
+      const sessionFetchHasMore = Boolean(result.history.hasMore)
+      const droppedFromMerge =
+        result.history.messages.length >
+        limited.filter((m) => m.__sessionKey === key).length
+      const sessionHasMore = sessionFetchHasMore || droppedFromMerge
+      if (!sessionHasMore) {
+        compoundOut[key] = null
+        continue
+      }
+      const seq = earliestEmitted ? resolveMessageSeq(earliestEmitted) : null
+      compoundOut[key] = seq
+    }
+
+    const hasMore = Object.values(compoundOut).some(
+      (v) => typeof v === 'number',
+    )
+    const messages = limited.map(({ __sessionKey: _drop, ...rest }) => rest)
+
     return {
       sessionKey: mainSessionKey,
-      messages: limited,
-      cursor: null,
-      hasMore: false,
+      messages,
+      cursor: hasMore ? encodeCompoundCursor(compoundOut) : null,
+      hasMore,
       truncated: truncated || limited.length < merged.length,
     }
   }

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/history-mapper.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/history-mapper.test.ts
@@ -1,0 +1,168 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { describe, expect, it } from 'bun:test'
+import {
+  cleanHistoryUserText,
+  convertOpenClawHistoryToAgentHistory,
+} from '../../../../src/api/services/openclaw/history-mapper'
+import type { OpenClawSessionHistory } from '../../../../src/api/services/openclaw/openclaw-http-client'
+
+describe('cleanHistoryUserText', () => {
+  it('extracts the cron payload and drops the trailer', () => {
+    const raw =
+      '[cron:681df8ba-85e0-404e-a6ea-891d0f5068af hello-8] Print hello\n' +
+      'Current time: Tuesday, May 5th, 2026 - 2:26 AM (Asia/Calcutta) / 2026-05-04 20:56 UTC\n\n' +
+      'Use the message tool if you need to notify the user directly with an explicit target. ' +
+      'If you do not send directly, your final plain-text reply will be delivered automatically.'
+    expect(cleanHistoryUserText(raw)).toBe('Print hello')
+  })
+
+  it('extracts a multiline cron payload and drops the trailer', () => {
+    const raw =
+      '[cron:abcd1234-0000-0000-0000-000000000000 weather] Tell me the weather in Tokyo\n' +
+      'and report back briefly.\n' +
+      'Current time: Tuesday, May 5th, 2026 - 2:26 AM (Asia/Calcutta) / 2026-05-04 20:56 UTC\n\n' +
+      'Use the message tool if you need to notify the user directly with an explicit target.'
+    expect(cleanHistoryUserText(raw)).toBe(
+      'Tell me the weather in Tokyo\nand report back briefly.',
+    )
+  })
+
+  it('unwraps the BrowserOS ACP user_request envelope', () => {
+    const raw =
+      '[Working directory: /tmp/workspace]\n\n' +
+      '<role>\nYou are BrowserOS - a browser agent...\n</role>\n\n' +
+      '<user_request>\nhey\n</user_request>'
+    expect(cleanHistoryUserText(raw)).toBe('hey')
+  })
+
+  it('strips a trailing system-reminder block', () => {
+    const raw =
+      '[Working directory: /tmp/workspace]\n\n' +
+      '<role>\nYou are BrowserOS\n</role>\n\n' +
+      '<user_request>\nopen google.com\n</user_request>\n\n' +
+      '<system-reminder>\nA reminder the user never typed.\n</system-reminder>'
+    expect(cleanHistoryUserText(raw)).toBe('open google.com')
+  })
+
+  it('preserves messages that match no known scaffolding', () => {
+    expect(cleanHistoryUserText('hello there')).toBe('hello there')
+    expect(cleanHistoryUserText('multi\nline\nuser text')).toBe(
+      'multi\nline\nuser text',
+    )
+  })
+
+  it('returns empty string unchanged', () => {
+    expect(cleanHistoryUserText('')).toBe('')
+  })
+})
+
+describe('convertOpenClawHistoryToAgentHistory', () => {
+  it('strips cron scaffolding from user messages while preserving assistant text', () => {
+    const raw: OpenClawSessionHistory = {
+      sessionKey: 'agent:demo:main',
+      messages: [
+        {
+          role: 'user',
+          content: '' as never,
+          // The HTTP endpoint actually returns content as an array of typed
+          // blocks at runtime; the type is `string` for backward-compat.
+          // Cast via `unknown` to reflect runtime.
+          ...({
+            content: [
+              {
+                type: 'text',
+                text:
+                  '[cron:abc-123 hello-1] Print hello\n' +
+                  'Current time: 2026-05-05 16:00 UTC\n\n' +
+                  'Use the message tool if you need to notify the user directly with an explicit target.',
+              },
+            ],
+          } as unknown as { content: never }),
+          timestamp: 1000,
+        },
+        {
+          role: 'assistant',
+          content: '' as never,
+          ...({
+            content: [{ type: 'text', text: 'hello' }],
+          } as unknown as { content: never }),
+          timestamp: 1001,
+        },
+      ],
+    }
+
+    const out = convertOpenClawHistoryToAgentHistory('demo', raw)
+    expect(out.items.map((i) => ({ role: i.role, text: i.text }))).toEqual([
+      { role: 'user', text: 'Print hello' },
+      { role: 'assistant', text: 'hello' },
+    ])
+  })
+
+  it('attaches assistant reasoning and pairs tool call output across messages', () => {
+    const raw: OpenClawSessionHistory = {
+      sessionKey: 'agent:demo:main',
+      messages: [
+        {
+          role: 'user',
+          content: '' as never,
+          ...({
+            content: [{ type: 'text', text: 'navigate to example.com' }],
+          } as unknown as { content: never }),
+          timestamp: 1000,
+        },
+        {
+          role: 'assistant',
+          content: '' as never,
+          ...({
+            content: [
+              {
+                type: 'thinking',
+                thinking: 'I should call the navigate tool.',
+              },
+              {
+                type: 'toolCall',
+                id: 'call-1',
+                name: 'navigate',
+                arguments: { url: 'https://example.com' },
+              },
+            ],
+          } as unknown as { content: never }),
+          timestamp: 1001,
+        },
+        {
+          role: 'tool',
+          content: '' as never,
+          ...({
+            content: [
+              {
+                type: 'toolResult',
+                toolCallId: 'call-1',
+                content: 'navigated',
+              },
+            ],
+          } as unknown as { content: never }),
+          timestamp: 1002,
+        },
+      ],
+    }
+
+    const out = convertOpenClawHistoryToAgentHistory('demo', raw)
+    // 'tool' role messages are folded into the prior assistant entry, not surfaced
+    expect(out.items.map((i) => i.role)).toEqual(['user', 'assistant'])
+    const assistant = out.items[1]
+    expect(assistant.reasoning?.text).toBe('I should call the navigate tool.')
+    expect(assistant.toolCalls).toEqual([
+      {
+        toolCallId: 'call-1',
+        toolName: 'navigate',
+        status: 'completed',
+        input: { url: 'https://example.com' },
+        output: 'navigated',
+      },
+    ])
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/history-mapper.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/history-mapper.test.ts
@@ -48,6 +48,32 @@ describe('cleanHistoryUserText', () => {
     expect(cleanHistoryUserText(raw)).toBe('open google.com')
   })
 
+  it('splits queued-marker concatenations and cleans each chunk', () => {
+    // When multiple prompts queue up while a turn is active, BrowserOS
+    // joins them with the queued-marker line. Each chunk between markers
+    // is its own message that should be cleaned independently.
+    const raw =
+      '[Queued user message that arrived while the previous turn was still active]\n' +
+      "[cron:aaaa hello-job-1] print('hello')\n" +
+      'Current time: 2026-05-05 16:00 UTC\n\n' +
+      'Use the message tool if you need to notify the user directly with an explicit target.\n' +
+      '[Queued user message that arrived while the previous turn was still active]\n' +
+      "[cron:bbbb hello-job-2] print('world')\n" +
+      'Current time: 2026-05-05 16:01 UTC\n\n' +
+      'Use the message tool if you need to notify the user directly with an explicit target.'
+    expect(cleanHistoryUserText(raw)).toBe("print('hello')\nprint('world')")
+  })
+
+  it('drops empty chunks left by leading queued marker', () => {
+    // The blob often opens with a marker (no content before it). Empty
+    // chunks should be dropped so we don't emit a leading newline.
+    const raw =
+      '[Queued user message that arrived while the previous turn was still active]\n' +
+      '[cron:aaaa job] payload-only\n' +
+      'Current time: now'
+    expect(cleanHistoryUserText(raw)).toBe('payload-only')
+  })
+
   it('preserves messages that match no known scaffolding', () => {
     expect(cleanHistoryUserText('hello there')).toBe('hello there')
     expect(cleanHistoryUserText('multi\nline\nuser text')).toBe(

--- a/packages/browseros-agent/apps/server/tests/api/services/openclaw/history-mapper.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/openclaw/history-mapper.test.ts
@@ -64,6 +64,19 @@ describe('cleanHistoryUserText', () => {
     expect(cleanHistoryUserText(raw)).toBe("print('hello')\nprint('world')")
   })
 
+  it('drops a Subagent Context message entirely', () => {
+    // OpenClaw seeds a nested subagent's session with a "Subagent
+    // Context" prefix that's pure scaffolding. The actual task lives in
+    // the system prompt, so the user message body is meaningless to
+    // surface. cleanHistoryUserText returns empty; the converter then
+    // skips the entry so it doesn't render an empty bubble.
+    const raw =
+      '[Subagent Context] You are running as a subagent (depth 1/1). ' +
+      'Results auto-announce to your requester; do not busy-poll for status.\n\n' +
+      'Begin. Your assigned task is in the system prompt under **Your Role**.'
+    expect(cleanHistoryUserText(raw)).toBe('')
+  })
+
   it('drops empty chunks left by leading queued marker', () => {
     // The blob often opens with a marker (no content before it). Empty
     // chunks should be dropped so we don't emit a leading newline.
@@ -125,6 +138,77 @@ describe('convertOpenClawHistoryToAgentHistory', () => {
     expect(out.items.map((i) => ({ role: i.role, text: i.text }))).toEqual([
       { role: 'user', text: 'Print hello' },
       { role: 'assistant', text: 'hello' },
+    ])
+  })
+
+  it('drops assistant turns that have only reasoning (no text, no tools)', () => {
+    // MiniMax with thinking:minimal often returns only `thinking` blocks
+    // for trivial prompts ("Print hello"). The empty text bubble with a
+    // dangling reasoning collapsible reads as broken UI; cleaner to skip.
+    const raw: OpenClawSessionHistory = {
+      sessionKey: 'agent:demo:main',
+      messages: [
+        {
+          role: 'user',
+          content: '' as never,
+          ...({
+            content: [{ type: 'text', text: 'hi' }],
+          } as unknown as { content: never }),
+          timestamp: 1000,
+        },
+        {
+          role: 'assistant',
+          content: '' as never,
+          ...({
+            content: [
+              {
+                type: 'thinking',
+                thinking: 'I should respond with a greeting.',
+              },
+            ],
+          } as unknown as { content: never }),
+          timestamp: 1001,
+        },
+      ],
+    }
+    const out = convertOpenClawHistoryToAgentHistory('demo', raw)
+    expect(out.items.map((i) => ({ role: i.role, text: i.text }))).toEqual([
+      { role: 'user', text: 'hi' },
+    ])
+  })
+
+  it('drops Subagent Context user messages entirely (no empty bubble)', () => {
+    const raw: OpenClawSessionHistory = {
+      sessionKey: 'agent:demo:main',
+      messages: [
+        {
+          role: 'user',
+          content: '' as never,
+          ...({
+            content: [
+              {
+                type: 'text',
+                text:
+                  '[Subagent Context] You are running as a subagent (depth 1/1).\n\n' +
+                  'Begin. Your assigned task is in the system prompt.',
+              },
+            ],
+          } as unknown as { content: never }),
+          timestamp: 1000,
+        },
+        {
+          role: 'assistant',
+          content: '' as never,
+          ...({
+            content: [{ type: 'text', text: 'real reply' }],
+          } as unknown as { content: never }),
+          timestamp: 1001,
+        },
+      ],
+    }
+    const out = convertOpenClawHistoryToAgentHistory('demo', raw)
+    expect(out.items.map((i) => ({ role: i.role, text: i.text }))).toEqual([
+      { role: 'assistant', text: 'real reply' },
     ])
   })
 


### PR DESCRIPTION
## Problem

Autonomous OpenClaw runs (cron, hook, channel) execute and persist on disk, but the BrowserOS chat panel never sees them. Each run gets its own ephemeral session file under the parent agent's directory:

\`\`\`
/home/node/.openclaw/agents/<agentId>/sessions/<runId>.jsonl
\`\`\`

The panel queries \`agent:<agentId>:main\` and gets back only that one file. The hellos a user scheduled earlier today fired correctly but were invisible.

## Change

When \`getSessionHistory\` is called with a main-session key (\`^agent:[^:]+:main$\`), enumerate every session under that agent via the existing \`sessions.list\` gateway RPC and merge their messages into one chronological response.

Each merged message gets:

- \`source\`: \`main\` | \`cron\` | \`hook\` | \`channel\` | \`other\` (parsed from the third segment of the session key)
- \`subSessionKey\`: only when the message originates outside the main session, so the UI can group / render section markers without re-parsing

Single-session keys (anything not matching the main pattern) still take the existing per-session HTTP path, so callers asking for a specific sub-session key keep working untouched.

## Why no agent-collision risk

\`sessions.list({ agentId })\` is **filesystem-scoped**, not pattern-matched. Confirmed in \`browseros-ai/openclaw\` at \`src/config/sessions/combined-store-gateway.ts:90\`:

\`\`\`ts
const targets = requestedAgentId
  ? resolveAgentSessionStoreTargetsSync(cfg, requestedAgentId)  // only this agent's dir
  : resolveAllAgentSessionStoreTargetsSync(cfg);
\`\`\`

Each agent has its own directory. Querying \`research\` cannot return a \`writer\` session.

## Behavior choices

- **Sub-session fetch failures** → log + drop. Partial timeline preferable to hiding the main session entirely.
- **\`limit\`** → applied post-merge across the unified timeline (single global limit, not per-sub-session).
- **Streaming variant** (\`Accept: text/event-stream\`) → unchanged for v1; aggregation only on the JSON path.
- **No new endpoint** → modified the existing \`/claw/session/:key/history\` route; no new query flag.
- **Wire shape** → backward compatible. Existing callers just see \`source\` / \`subSessionKey\` as new optional fields on each message; old clients ignoring them keep working.

## Files

| File | Change |
|---|---|
| \`openclaw-service.ts\` | New \`fetchAggregatedAgentHistory\` branch in \`getSessionHistory\`; helpers \`extractAgentIdFromMainSessionKey\`, \`parseSessionSource\`, \`compareMessageOrder\` |
| \`openclaw-http-client.ts\` | Add optional \`source\` and \`subSessionKey\` fields on \`OpenClawSessionHistoryMessage\` |

## Stats

\`\`\`
openclaw-http-client.ts | 11 ++
openclaw-service.ts     | 147 ++++++++++++++++++-
2 files changed, 156 insertions(+), 2 deletions(-)
\`\`\`

## Validation

- \`bun run typecheck\` clean
- \`bunx biome check\` clean
- \`bun test apps/server/tests/api/services/openclaw/openclaw-service.test.ts apps/server/tests/api/routes/openclaw.test.ts\` — **44 pass / 0 fail**

## Test plan

- [ ] Schedule cron jobs in an OpenClaw agent (with delivery: announce or sessionTarget targeting main)
- [ ] Wait for cron runs to fire
- [ ] Reload the chat panel
- [ ] Confirm: cron-spawned messages appear inline with main session messages, ordered by timestamp, tagged with \`source: 'cron'\`
- [ ] Confirm: a single sub-session fetch failure (e.g. corrupt JSONL) doesn't break the response — main session still loads
- [ ] Confirm: \`getSessionHistory\` for a non-main key (e.g. \`agent:X:cron:...\`) still returns just that session

## Notes

Independent of the cleanup PRs (#934, #935, #936). Branched off \`dev\` directly. No conflicts expected.

Reference design: design doc at https://gist.github.com/shivammittal274/b7c200c8845096e750ac3d060c1f3f69