### PR TITLE
fix: improve browseros-patch CLI ergonomics

### DIFF
--- a/packages/browseros/tools/patch/cmd/add.go
+++ b/packages/browseros/tools/patch/cmd/add.go
@@ -12,8 +12,8 @@ func init() {
 	command := &cobra.Command{
 		Use:         "add <name> <path>",
 		Aliases:     []string{"register"},
-		Annotations: map[string]string{"group": "Workspace:"},
-		Short:       "Register a Chromium checkout as a workspace",
+		Annotations: map[string]string{"group": "Chromium Checkouts:"},
+		Short:       "Register a named Chromium checkout",
 		Args:        cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := ensureRepoConfigured(patchesRepo); err != nil {
@@ -30,7 +30,7 @@ func init() {
 				"workspace":    entry,
 				"patches_repo": appState.Config.PatchesRepo,
 			}, func() {
-				fmt.Println(ui.Success("Registered workspace"))
+				fmt.Println(ui.Success("Registered Chromium checkout"))
 				fmt.Printf("%s  %s\n", ui.Muted("name:"), entry.Name)
 				fmt.Printf("%s  %s\n", ui.Muted("path:"), entry.Path)
 				fmt.Printf("%s  %s\n", ui.Muted("repo:"), appState.Config.PatchesRepo)

--- a/packages/browseros/tools/patch/cmd/apply.go
+++ b/packages/browseros/tools/patch/cmd/apply.go
@@ -14,14 +14,14 @@ func init() {
 	var changed string
 	var rangeEnd string
 	command := &cobra.Command{
-		Use:         "apply [workspace] [-- files...]",
+		Use:         "apply [checkout] [-- files...]",
 		Annotations: map[string]string{"group": "Core:"},
-		Short:       "Apply repo patches to a workspace",
+		Short:       "Apply repo patches to a checkout",
 		Args:        cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			positional, filters := splitWorkspaceAndFilters(cmd, args)
 			if len(positional) > 1 {
-				return fmt.Errorf("expected at most one workspace name")
+				return fmt.Errorf("expected at most one checkout name")
 			}
 			ws, err := resolveWorkspace(cmd, positional, src)
 			if err != nil {

--- a/packages/browseros/tools/patch/cmd/apply.go
+++ b/packages/browseros/tools/patch/cmd/apply.go
@@ -17,7 +17,10 @@ func init() {
 		Use:         "apply [checkout] [-- files...]",
 		Annotations: map[string]string{"group": "Core:"},
 		Short:       "Apply repo patches to a checkout",
-		Args:        cobra.ArbitraryArgs,
+		Example: `  browseros-patch apply ch1
+  browseros-patch apply ch1 -- chrome/browser/browser.cc
+  browseros-patch apply --src /path/to/chromium/src`,
+		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			positional, filters := splitWorkspaceAndFilters(cmd, args)
 			if len(positional) > 1 {
@@ -58,7 +61,7 @@ func init() {
 			})
 		},
 	}
-	command.Flags().StringVar(&src, "src", "", "Chromium checkout path to operate on directly")
+	command.Flags().StringVar(&src, "src", "", srcFlagUsage)
 	command.Flags().BoolVar(&reset, "reset", false, "Reset patched files to BASE_COMMIT before applying")
 	command.Flags().StringVar(&changed, "changed", "", "Apply only patches changed in the given repo commit")
 	command.Flags().StringVar(&rangeEnd, "range-end", "", "End revision when using --changed as a range start")

--- a/packages/browseros/tools/patch/cmd/apply.go
+++ b/packages/browseros/tools/patch/cmd/apply.go
@@ -23,7 +23,7 @@ func init() {
 			if len(positional) > 1 {
 				return fmt.Errorf("expected at most one workspace name")
 			}
-			ws, err := resolveWorkspace(positional, src)
+			ws, err := resolveWorkspace(cmd, positional, src)
 			if err != nil {
 				return err
 			}

--- a/packages/browseros/tools/patch/cmd/common.go
+++ b/packages/browseros/tools/patch/cmd/common.go
@@ -14,12 +14,16 @@ func repoInfo() (*repo.Info, error) {
 	return appState.RepoInfo()
 }
 
-func resolveWorkspace(positional []string, src string) (workspace.Entry, error) {
+func resolveWorkspace(cmd *cobra.Command, positional []string, src string) (workspace.Entry, error) {
 	name := ""
 	if len(positional) > 0 {
 		name = positional[0]
 	}
-	return appState.ResolveWorkspace(name, src)
+	commandPath := ""
+	if cmd != nil {
+		commandPath = cmd.CommandPath()
+	}
+	return workspace.ResolveForCommand(appState.Registry, name, appState.CWD, src, commandPath)
 }
 
 func splitWorkspaceAndFilters(cmd *cobra.Command, args []string) ([]string, []string) {

--- a/packages/browseros/tools/patch/cmd/common.go
+++ b/packages/browseros/tools/patch/cmd/common.go
@@ -36,6 +36,24 @@ func splitWorkspaceAndFilters(cmd *cobra.Command, args []string) ([]string, []st
 	return args[:atDash], args[atDash:]
 }
 
+// llmTxtGuide returns a stable plain-text operating guide for coding agents.
+func llmTxtGuide() string {
+	return `browseros-patch quick reference for coding agents
+
+Terms:
+- patch repo: BrowserOS packages/browseros repo containing chromium_patches/.
+- Chromium checkout: local Chromium src tree registered with a checkout name like ch1.
+- checkout name: registry alias used by commands, for example ch1.
+- --src: operate on a Chromium checkout path directly without registry lookup.
+
+Rules:
+- Checkout commands work from anywhere when passed a checkout name: browseros-patch diff ch1.
+- browseros-patch list reads only registered Chromium checkouts; it does not inspect sync state.
+- Use browseros-patch status ch1 or browseros-patch diff ch1 before mutating.
+- Mutating commands: browseros-patch sync ch1, browseros-patch apply ch1, browseros-patch extract ch1.
+`
+}
+
 func ensureRepoConfigured(override string) error {
 	if override == "" && appState.Config.PatchesRepo != "" {
 		return nil

--- a/packages/browseros/tools/patch/cmd/common.go
+++ b/packages/browseros/tools/patch/cmd/common.go
@@ -10,6 +10,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const srcFlagUsage = "Chromium checkout path to operate on directly without registry lookup"
+
 func repoInfo() (*repo.Info, error) {
 	return appState.RepoInfo()
 }

--- a/packages/browseros/tools/patch/cmd/common_test.go
+++ b/packages/browseros/tools/patch/cmd/common_test.go
@@ -73,3 +73,49 @@ func TestResolveWorkspaceErrorUsesCurrentCommandExample(t *testing.T) {
 		t.Fatalf("expected command-specific example, got:\n%s", err)
 	}
 }
+
+func TestPublicHelpUsesCheckoutTerminology(t *testing.T) {
+	help := rootCmd.Short + groupedHelp(rootCmd)
+	for _, want := range []string{
+		"Chromium checkouts",
+		"Chromium Checkouts:",
+	} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("expected help to contain %q, got:\n%s", want, help)
+		}
+	}
+	for _, forbidden := range []string{
+		"Workspace-centric",
+		"Workspace:",
+		" workspace",
+		" workspaces",
+	} {
+		if strings.Contains(help, forbidden) {
+			t.Fatalf("expected help not to contain %q, got:\n%s", forbidden, help)
+		}
+	}
+}
+
+func TestCheckoutCommandUsageTerminology(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		use  string
+	}{
+		{name: "diff", use: "diff [checkout]"},
+		{name: "status", use: "status [checkout]"},
+		{name: "apply", use: "apply [checkout] [-- files...]"},
+		{name: "sync", use: "sync [checkout]"},
+		{name: "extract", use: "extract [checkout] [--range <start> <end>] [-- files...]"},
+	} {
+		cmd, _, err := rootCmd.Find([]string{tc.name})
+		if err != nil {
+			t.Fatalf("find %s: %v", tc.name, err)
+		}
+		if cmd.Use != tc.use {
+			t.Fatalf("%s use = %q, want %q", tc.name, cmd.Use, tc.use)
+		}
+		if strings.Contains(strings.ToLower(cmd.Short), "workspace") {
+			t.Fatalf("%s short should use checkout terminology: %q", tc.name, cmd.Short)
+		}
+	}
+}

--- a/packages/browseros/tools/patch/cmd/common_test.go
+++ b/packages/browseros/tools/patch/cmd/common_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"io"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -179,5 +180,89 @@ func TestSrcFlagExplainsDirectCheckoutPath(t *testing.T) {
 		if !strings.Contains(flag.Usage, "without registry lookup") {
 			t.Fatalf("%s --src usage should explain registry bypass, got %q", name, flag.Usage)
 		}
+	}
+}
+
+func TestLLMTxtGuideContent(t *testing.T) {
+	text := llmTxtGuide()
+	for _, want := range []string{
+		"patch repo",
+		"chromium_patches/",
+		"Chromium checkout",
+		"checkout name",
+		"--src",
+		"browseros-patch diff ch1",
+		"browseros-patch list",
+		"browseros-patch status ch1",
+		"browseros-patch sync ch1",
+		"browseros-patch apply ch1",
+		"browseros-patch extract ch1",
+		"list reads only registered Chromium checkouts",
+		"does not inspect sync state",
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("expected llm txt to contain %q, got:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "\x1b[") {
+		t.Fatalf("llm txt should be uncolored, got:\n%s", text)
+	}
+}
+
+func TestRootLLMTxtPrintsWithoutLoadingApp(t *testing.T) {
+	oldAppState := appState
+	oldLLMTxt := llmTxt
+	t.Cleanup(func() {
+		appState = oldAppState
+		llmTxt = oldLLMTxt
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+
+	appState = nil
+	llmTxt = false
+	var stdout bytes.Buffer
+	rootCmd.SetArgs([]string{"--llm-txt"})
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(io.Discard)
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute --llm-txt: %v", err)
+	}
+	if appState != nil {
+		t.Fatalf("--llm-txt should not load app state")
+	}
+	if !strings.Contains(stdout.String(), "browseros-patch diff ch1") {
+		t.Fatalf("expected llm txt output, got:\n%s", stdout.String())
+	}
+}
+
+func TestLLMTxtRejectedWithSubcommand(t *testing.T) {
+	oldAppState := appState
+	oldLLMTxt := llmTxt
+	t.Cleanup(func() {
+		appState = oldAppState
+		llmTxt = oldLLMTxt
+		rootCmd.SetArgs(nil)
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+	})
+
+	appState = nil
+	llmTxt = false
+	rootCmd.SetArgs([]string{"diff", "--llm-txt"})
+	rootCmd.SetOut(io.Discard)
+	rootCmd.SetErr(io.Discard)
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("expected --llm-txt subcommand error")
+	}
+	if !strings.Contains(err.Error(), "--llm-txt is only valid without a subcommand") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if appState != nil {
+		t.Fatalf("--llm-txt subcommand error should not load app state")
 	}
 }

--- a/packages/browseros/tools/patch/cmd/common_test.go
+++ b/packages/browseros/tools/patch/cmd/common_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"io"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -72,6 +73,70 @@ func TestResolveWorkspaceErrorUsesCurrentCommandExample(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), `browseros-patch diff ch1`) {
 		t.Fatalf("expected command-specific example, got:\n%s", err)
+	}
+}
+
+func TestResolveWorkspaceNamedCheckoutIgnoresCWD(t *testing.T) {
+	oldAppState := appState
+	t.Cleanup(func() {
+		appState = oldAppState
+	})
+
+	root := t.TempDir()
+	registered := filepath.Join(root, "chromium-src")
+	outside := filepath.Join(root, "outside")
+	appState = &app.App{
+		CWD: outside,
+		Registry: &workspace.Registry{Version: 1, Workspaces: []workspace.Entry{
+			{Name: "ch1", Path: registered},
+		}},
+	}
+
+	rootCmd := &cobra.Command{Use: "browseros-patch"}
+	diffCmd := &cobra.Command{Use: "diff"}
+	rootCmd.AddCommand(diffCmd)
+
+	ws, err := resolveWorkspace(diffCmd, []string{"ch1"}, "")
+	if err != nil {
+		t.Fatalf("resolve named checkout: %v", err)
+	}
+	if ws.Path != registered {
+		t.Fatalf("resolved path = %q, want %q", ws.Path, registered)
+	}
+}
+
+func TestListReadsOnlyRegistry(t *testing.T) {
+	oldAppState := appState
+	oldJSONOut := jsonOut
+	t.Cleanup(func() {
+		appState = oldAppState
+		jsonOut = oldJSONOut
+	})
+
+	missingCheckout := filepath.Join(t.TempDir(), "missing-src")
+	appState = &app.App{
+		Registry: &workspace.Registry{Version: 1, Workspaces: []workspace.Entry{
+			{Name: "ch1", Path: missingCheckout},
+		}},
+	}
+	jsonOut = false
+
+	listCmd, _, err := rootCmd.Find([]string{"list"})
+	if err != nil {
+		t.Fatalf("find list: %v", err)
+	}
+
+	var runErr error
+	output := captureStdout(t, func() {
+		runErr = listCmd.RunE(listCmd, nil)
+	})
+	if runErr != nil {
+		t.Fatalf("list should not inspect checkout path: %v", runErr)
+	}
+	for _, want := range []string{"ch1", missingCheckout} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected list output to contain %q, got:\n%s", want, output)
+		}
 	}
 }
 
@@ -265,4 +330,30 @@ func TestLLMTxtRejectedWithSubcommand(t *testing.T) {
 	if appState != nil {
 		t.Fatalf("--llm-txt subcommand error should not load app state")
 	}
+}
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	oldStdout := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+	os.Stdout = writer
+	defer func() {
+		os.Stdout = oldStdout
+	}()
+
+	fn()
+	os.Stdout = oldStdout
+
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close stdout writer: %v", err)
+	}
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	return string(output)
 }

--- a/packages/browseros/tools/patch/cmd/common_test.go
+++ b/packages/browseros/tools/patch/cmd/common_test.go
@@ -119,3 +119,65 @@ func TestCheckoutCommandUsageTerminology(t *testing.T) {
 		}
 	}
 }
+
+func TestRootHelpExplainsPatchRepoAndCheckoutModel(t *testing.T) {
+	for _, want := range []string{
+		"patch repo",
+		"chromium_patches/",
+		"Chromium checkout",
+		"ch1",
+	} {
+		if !strings.Contains(rootCmd.Long, want) {
+			t.Fatalf("expected root long help to contain %q, got:\n%s", want, rootCmd.Long)
+		}
+	}
+
+	for _, want := range []string{
+		"browseros-patch add ch1 /path/to/chromium/src",
+		"browseros-patch list",
+		"browseros-patch diff ch1",
+		"browseros-patch sync ch1",
+		"browseros-patch extract ch1",
+	} {
+		if !strings.Contains(rootCmd.Example, want) {
+			t.Fatalf("expected root examples to contain %q, got:\n%s", want, rootCmd.Example)
+		}
+	}
+}
+
+func TestCheckoutCommandExamplesUseNamedCheckout(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		example string
+	}{
+		{name: "diff", example: "browseros-patch diff ch1"},
+		{name: "status", example: "browseros-patch status ch1"},
+		{name: "apply", example: "browseros-patch apply ch1"},
+		{name: "sync", example: "browseros-patch sync ch1"},
+		{name: "extract", example: "browseros-patch extract ch1"},
+	} {
+		cmd, _, err := rootCmd.Find([]string{tc.name})
+		if err != nil {
+			t.Fatalf("find %s: %v", tc.name, err)
+		}
+		if !strings.Contains(cmd.Example, tc.example) {
+			t.Fatalf("expected %s examples to contain %q, got:\n%s", tc.name, tc.example, cmd.Example)
+		}
+	}
+}
+
+func TestSrcFlagExplainsDirectCheckoutPath(t *testing.T) {
+	for _, name := range []string{"diff", "status", "apply", "sync", "extract"} {
+		cmd, _, err := rootCmd.Find([]string{name})
+		if err != nil {
+			t.Fatalf("find %s: %v", name, err)
+		}
+		flag := cmd.Flags().Lookup("src")
+		if flag == nil {
+			t.Fatalf("%s missing --src flag", name)
+		}
+		if !strings.Contains(flag.Usage, "without registry lookup") {
+			t.Fatalf("%s --src usage should explain registry bypass, got %q", name, flag.Usage)
+		}
+	}
+}

--- a/packages/browseros/tools/patch/cmd/common_test.go
+++ b/packages/browseros/tools/patch/cmd/common_test.go
@@ -324,11 +324,31 @@ func TestLLMTxtRejectedWithSubcommand(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected --llm-txt subcommand error")
 	}
-	if !strings.Contains(err.Error(), "--llm-txt is only valid without a subcommand") {
+	if !strings.Contains(err.Error(), "unknown flag: --llm-txt") {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if appState != nil {
 		t.Fatalf("--llm-txt subcommand error should not load app state")
+	}
+}
+
+func TestLLMTxtNotShownInSubcommandHelp(t *testing.T) {
+	diffCmd, _, err := rootCmd.Find([]string{"diff"})
+	if err != nil {
+		t.Fatalf("find diff: %v", err)
+	}
+
+	var help bytes.Buffer
+	diffCmd.SetOut(&help)
+	t.Cleanup(func() {
+		diffCmd.SetOut(nil)
+	})
+
+	if err := diffCmd.Help(); err != nil {
+		t.Fatalf("diff help: %v", err)
+	}
+	if strings.Contains(help.String(), "--llm-txt") {
+		t.Fatalf("subcommand help should not include root-only --llm-txt, got:\n%s", help.String())
 	}
 }
 

--- a/packages/browseros/tools/patch/cmd/common_test.go
+++ b/packages/browseros/tools/patch/cmd/common_test.go
@@ -2,9 +2,12 @@ package cmd
 
 import (
 	"bytes"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/app"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/workspace"
 	"github.com/spf13/cobra"
 )
 
@@ -39,5 +42,34 @@ func TestCommandProgressDisabledForJSON(t *testing.T) {
 
 	if progress := commandProgress(&cobra.Command{}); progress != nil {
 		t.Fatalf("expected nil progress reporter in JSON mode")
+	}
+}
+
+func TestResolveWorkspaceErrorUsesCurrentCommandExample(t *testing.T) {
+	oldAppState := appState
+	t.Cleanup(func() {
+		appState = oldAppState
+	})
+
+	root := t.TempDir()
+	registered := filepath.Join(root, "chromium-src")
+	outside := filepath.Join(root, "outside")
+	appState = &app.App{
+		CWD: outside,
+		Registry: &workspace.Registry{Version: 1, Workspaces: []workspace.Entry{
+			{Name: "ch1", Path: registered},
+		}},
+	}
+
+	rootCmd := &cobra.Command{Use: "browseros-patch"}
+	diffCmd := &cobra.Command{Use: "diff"}
+	rootCmd.AddCommand(diffCmd)
+
+	_, err := resolveWorkspace(diffCmd, nil, "")
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+	if !strings.Contains(err.Error(), `browseros-patch diff ch1`) {
+		t.Fatalf("expected command-specific example, got:\n%s", err)
 	}
 }

--- a/packages/browseros/tools/patch/cmd/diff.go
+++ b/packages/browseros/tools/patch/cmd/diff.go
@@ -15,7 +15,9 @@ func init() {
 		Use:         "diff [checkout]",
 		Annotations: map[string]string{"group": "Core:"},
 		Short:       "Preview patch differences for a checkout",
-		Args:        cobra.MaximumNArgs(1),
+		Example: `  browseros-patch diff ch1
+  browseros-patch diff --src /path/to/chromium/src`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ws, err := resolveWorkspace(cmd, args, src)
 			if err != nil {
@@ -41,7 +43,7 @@ func init() {
 			})
 		},
 	}
-	command.Flags().StringVar(&src, "src", "", "Chromium checkout path to operate on directly")
+	command.Flags().StringVar(&src, "src", "", srcFlagUsage)
 	rootCmd.AddCommand(command)
 }
 

--- a/packages/browseros/tools/patch/cmd/diff.go
+++ b/packages/browseros/tools/patch/cmd/diff.go
@@ -12,9 +12,9 @@ import (
 func init() {
 	var src string
 	command := &cobra.Command{
-		Use:         "diff [workspace]",
+		Use:         "diff [checkout]",
 		Annotations: map[string]string{"group": "Core:"},
-		Short:       "Preview patch differences for a workspace",
+		Short:       "Preview patch differences for a checkout",
 		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ws, err := resolveWorkspace(cmd, args, src)

--- a/packages/browseros/tools/patch/cmd/diff.go
+++ b/packages/browseros/tools/patch/cmd/diff.go
@@ -17,7 +17,7 @@ func init() {
 		Short:       "Preview patch differences for a workspace",
 		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ws, err := resolveWorkspace(args, src)
+			ws, err := resolveWorkspace(cmd, args, src)
 			if err != nil {
 				return err
 			}

--- a/packages/browseros/tools/patch/cmd/extract.go
+++ b/packages/browseros/tools/patch/cmd/extract.go
@@ -18,7 +18,10 @@ func init() {
 		Use:         "extract [checkout] [--range <start> <end>] [-- files...]",
 		Annotations: map[string]string{"group": "Core:"},
 		Short:       "Extract checkout changes back to chromium_patches",
-		Args:        cobra.ArbitraryArgs,
+		Example: `  browseros-patch extract ch1
+  browseros-patch extract ch1 --range HEAD~2 HEAD
+  browseros-patch extract --src /path/to/chromium/src`,
+		Args: cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			positional, filters := splitWorkspaceAndFilters(cmd, args)
 			workspaceArgs := positional
@@ -65,7 +68,7 @@ func init() {
 			})
 		},
 	}
-	command.Flags().StringVar(&src, "src", "", "Chromium checkout path to operate on directly")
+	command.Flags().StringVar(&src, "src", "", srcFlagUsage)
 	command.Flags().StringVar(&commit, "commit", "", "Extract from a single commit")
 	command.Flags().BoolVar(&rangeMode, "range", false, "Extract from a commit range")
 	command.Flags().BoolVar(&squash, "squash", false, "Squash a range into a cumulative diff")

--- a/packages/browseros/tools/patch/cmd/extract.go
+++ b/packages/browseros/tools/patch/cmd/extract.go
@@ -35,7 +35,7 @@ func init() {
 			if len(workspaceArgs) > 1 {
 				return fmt.Errorf("expected at most one workspace name")
 			}
-			ws, err := resolveWorkspace(workspaceArgs, src)
+			ws, err := resolveWorkspace(cmd, workspaceArgs, src)
 			if err != nil {
 				return err
 			}

--- a/packages/browseros/tools/patch/cmd/extract.go
+++ b/packages/browseros/tools/patch/cmd/extract.go
@@ -15,9 +15,9 @@ func init() {
 	var squash bool
 	var base string
 	command := &cobra.Command{
-		Use:         "extract [workspace] [--range <start> <end>] [-- files...]",
+		Use:         "extract [checkout] [--range <start> <end>] [-- files...]",
 		Annotations: map[string]string{"group": "Core:"},
-		Short:       "Extract workspace changes back to chromium_patches",
+		Short:       "Extract checkout changes back to chromium_patches",
 		Args:        cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			positional, filters := splitWorkspaceAndFilters(cmd, args)
@@ -26,14 +26,14 @@ func init() {
 			rangeEnd := ""
 			if rangeMode {
 				if len(positional) < 2 || len(positional) > 3 {
-					return fmt.Errorf(`range mode expects "browseros-patch extract [workspace] --range <start> <end>"`)
+					return fmt.Errorf(`range mode expects "browseros-patch extract [checkout] --range <start> <end>"`)
 				}
 				rangeStart = positional[len(positional)-2]
 				rangeEnd = positional[len(positional)-1]
 				workspaceArgs = positional[:len(positional)-2]
 			}
 			if len(workspaceArgs) > 1 {
-				return fmt.Errorf("expected at most one workspace name")
+				return fmt.Errorf("expected at most one checkout name")
 			}
 			ws, err := resolveWorkspace(cmd, workspaceArgs, src)
 			if err != nil {

--- a/packages/browseros/tools/patch/cmd/list.go
+++ b/packages/browseros/tools/patch/cmd/list.go
@@ -11,13 +11,13 @@ func init() {
 	command := &cobra.Command{
 		Use:         "list",
 		Aliases:     []string{"ls"},
-		Annotations: map[string]string{"group": "Workspace:"},
-		Short:       "List registered workspaces",
+		Annotations: map[string]string{"group": "Chromium Checkouts:"},
+		Short:       "List registered Chromium checkouts",
 		Args:        cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(appState.Registry.Workspaces) == 0 {
 				return renderResult(map[string]any{"workspaces": []any{}}, func() {
-					fmt.Println("No workspaces registered. Run `browseros-patch add <name> <path>`.")
+					fmt.Println("No Chromium checkouts registered. Run `browseros-patch add <name> <path>`.")
 				})
 			}
 			rows := make([][]string, 0, len(appState.Registry.Workspaces))

--- a/packages/browseros/tools/patch/cmd/list.go
+++ b/packages/browseros/tools/patch/cmd/list.go
@@ -13,6 +13,7 @@ func init() {
 		Aliases:     []string{"ls"},
 		Annotations: map[string]string{"group": "Chromium Checkouts:"},
 		Short:       "List registered Chromium checkouts",
+		Example:     `  browseros-patch list`,
 		Args:        cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(appState.Registry.Workspaces) == 0 {

--- a/packages/browseros/tools/patch/cmd/remove.go
+++ b/packages/browseros/tools/patch/cmd/remove.go
@@ -11,8 +11,8 @@ func init() {
 	command := &cobra.Command{
 		Use:         "remove <name>",
 		Aliases:     []string{"rm"},
-		Annotations: map[string]string{"group": "Workspace:"},
-		Short:       "Unregister a workspace",
+		Annotations: map[string]string{"group": "Chromium Checkouts:"},
+		Short:       "Unregister a Chromium checkout",
 		Args:        cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			entry, err := appState.Registry.Remove(args[0])
@@ -23,7 +23,7 @@ func init() {
 				return err
 			}
 			return renderResult(map[string]any{"workspace": entry}, func() {
-				fmt.Println(ui.Success("Removed workspace"))
+				fmt.Println(ui.Success("Removed Chromium checkout"))
 				fmt.Printf("%s  %s\n", ui.Muted("name:"), entry.Name)
 				fmt.Printf("%s  %s\n", ui.Muted("path:"), entry.Path)
 			})

--- a/packages/browseros/tools/patch/cmd/root.go
+++ b/packages/browseros/tools/patch/cmd/root.go
@@ -128,7 +128,7 @@ func init() {
 	cobra.AddTemplateFunc("groupedHelp", groupedHelp)
 	rootCmd.SetUsageTemplate(usageTemplate)
 	rootCmd.PersistentFlags().BoolVar(&jsonOut, "json", false, "Emit JSON output")
-	rootCmd.PersistentFlags().BoolVar(&llmTxt, "llm-txt", false, "Print concise plain-text guidance for coding agents")
+	rootCmd.Flags().BoolVar(&llmTxt, "llm-txt", false, "Print concise plain-text guidance for coding agents")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 }

--- a/packages/browseros/tools/patch/cmd/root.go
+++ b/packages/browseros/tools/patch/cmd/root.go
@@ -20,7 +20,7 @@ var (
 )
 
 var groupOrder = []string{
-	"Workspace:",
+	"Chromium Checkouts:",
 	"Core:",
 	"Conflict:",
 	"Remote:",
@@ -85,7 +85,7 @@ const usageTemplate = `{{helpHeader "Usage:"}}{{if .Runnable}}
 
 var rootCmd = &cobra.Command{
 	Use:           "browseros-patch",
-	Short:         "Workspace-centric BrowserOS patch tooling for Chromium checkouts",
+	Short:         "BrowserOS patch tooling for Chromium checkouts",
 	Version:       Version,
 	SilenceUsage:  true,
 	SilenceErrors: true,

--- a/packages/browseros/tools/patch/cmd/root.go
+++ b/packages/browseros/tools/patch/cmd/root.go
@@ -84,8 +84,18 @@ const usageTemplate = `{{helpHeader "Usage:"}}{{if .Runnable}}
 `
 
 var rootCmd = &cobra.Command{
-	Use:           "browseros-patch",
-	Short:         "BrowserOS patch tooling for Chromium checkouts",
+	Use:   "browseros-patch",
+	Short: "BrowserOS patch tooling for Chromium checkouts",
+	Long: `browseros-patch moves changes between two places:
+  patch repo: the BrowserOS repo containing chromium_patches/
+  Chromium checkout: a named local Chromium src tree, such as ch1
+
+Pass a checkout name to run from anywhere, for example "browseros-patch diff ch1".`,
+	Example: `  browseros-patch add ch1 /path/to/chromium/src
+  browseros-patch list
+  browseros-patch diff ch1
+  browseros-patch sync ch1
+  browseros-patch extract ch1`,
 	Version:       Version,
 	SilenceUsage:  true,
 	SilenceErrors: true,

--- a/packages/browseros/tools/patch/cmd/root.go
+++ b/packages/browseros/tools/patch/cmd/root.go
@@ -16,6 +16,7 @@ var Version = "dev"
 var (
 	jsonOut  bool
 	verbose  bool
+	llmTxt   bool
 	appState *app.App
 )
 
@@ -100,11 +101,21 @@ Pass a checkout name to run from anywhere, for example "browseros-patch diff ch1
 	SilenceUsage:  true,
 	SilenceErrors: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		if llmTxt {
+			if cmd.Parent() != nil {
+				return fmt.Errorf("--llm-txt is only valid without a subcommand")
+			}
+			return nil
+		}
 		var err error
 		appState, err = app.Load(jsonOut, verbose, "")
 		return err
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if llmTxt {
+			fmt.Fprint(cmd.OutOrStdout(), llmTxtGuide())
+			return nil
+		}
 		return cmd.Help()
 	},
 }
@@ -117,6 +128,7 @@ func init() {
 	cobra.AddTemplateFunc("groupedHelp", groupedHelp)
 	rootCmd.SetUsageTemplate(usageTemplate)
 	rootCmd.PersistentFlags().BoolVar(&jsonOut, "json", false, "Emit JSON output")
+	rootCmd.PersistentFlags().BoolVar(&llmTxt, "llm-txt", false, "Print concise plain-text guidance for coding agents")
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 }

--- a/packages/browseros/tools/patch/cmd/status.go
+++ b/packages/browseros/tools/patch/cmd/status.go
@@ -14,7 +14,9 @@ func init() {
 		Use:         "status [checkout]",
 		Annotations: map[string]string{"group": "Core:"},
 		Short:       "Show checkout sync state",
-		Args:        cobra.MaximumNArgs(1),
+		Example: `  browseros-patch status ch1
+  browseros-patch status --src /path/to/chromium/src`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ws, err := resolveWorkspace(cmd, args, src)
 			if err != nil {
@@ -44,6 +46,6 @@ func init() {
 			})
 		},
 	}
-	command.Flags().StringVar(&src, "src", "", "Chromium checkout path to operate on directly")
+	command.Flags().StringVar(&src, "src", "", srcFlagUsage)
 	rootCmd.AddCommand(command)
 }

--- a/packages/browseros/tools/patch/cmd/status.go
+++ b/packages/browseros/tools/patch/cmd/status.go
@@ -11,9 +11,9 @@ import (
 func init() {
 	var src string
 	command := &cobra.Command{
-		Use:         "status [workspace]",
+		Use:         "status [checkout]",
 		Annotations: map[string]string{"group": "Core:"},
-		Short:       "Show workspace sync state",
+		Short:       "Show checkout sync state",
 		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ws, err := resolveWorkspace(cmd, args, src)

--- a/packages/browseros/tools/patch/cmd/status.go
+++ b/packages/browseros/tools/patch/cmd/status.go
@@ -16,7 +16,7 @@ func init() {
 		Short:       "Show workspace sync state",
 		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ws, err := resolveWorkspace(args, src)
+			ws, err := resolveWorkspace(cmd, args, src)
 			if err != nil {
 				return err
 			}

--- a/packages/browseros/tools/patch/cmd/sync.go
+++ b/packages/browseros/tools/patch/cmd/sync.go
@@ -13,9 +13,9 @@ func init() {
 	var rebase bool
 	var remote string
 	command := &cobra.Command{
-		Use:         "sync [workspace]",
+		Use:         "sync [checkout]",
 		Annotations: map[string]string{"group": "Core:"},
-		Short:       "Sync a workspace with the latest patch repo state",
+		Short:       "Sync a checkout with the latest patch repo state",
 		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ws, err := resolveWorkspace(cmd, args, src)

--- a/packages/browseros/tools/patch/cmd/sync.go
+++ b/packages/browseros/tools/patch/cmd/sync.go
@@ -18,7 +18,7 @@ func init() {
 		Short:       "Sync a workspace with the latest patch repo state",
 		Args:        cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ws, err := resolveWorkspace(args, src)
+			ws, err := resolveWorkspace(cmd, args, src)
 			if err != nil {
 				return err
 			}

--- a/packages/browseros/tools/patch/cmd/sync.go
+++ b/packages/browseros/tools/patch/cmd/sync.go
@@ -16,7 +16,9 @@ func init() {
 		Use:         "sync [checkout]",
 		Annotations: map[string]string{"group": "Core:"},
 		Short:       "Sync a checkout with the latest patch repo state",
-		Args:        cobra.MaximumNArgs(1),
+		Example: `  browseros-patch sync ch1
+  browseros-patch sync --src /path/to/chromium/src`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ws, err := resolveWorkspace(cmd, args, src)
 			if err != nil {
@@ -52,7 +54,7 @@ func init() {
 			})
 		},
 	}
-	command.Flags().StringVar(&src, "src", "", "Chromium checkout path to operate on directly")
+	command.Flags().StringVar(&src, "src", "", srcFlagUsage)
 	command.Flags().BoolVar(&rebase, "rebase", false, "Re-apply stashed local changes after syncing")
 	command.Flags().StringVar(&remote, "remote", "origin", "Remote to pull from")
 	rootCmd.AddCommand(command)

--- a/packages/browseros/tools/patch/internal/resolve/resolve.go
+++ b/packages/browseros/tools/patch/internal/resolve/resolve.go
@@ -86,7 +86,7 @@ func FindActive(reg *workspace.Registry, cwd string) (workspace.Entry, error) {
 	case 1:
 		return active[0], nil
 	default:
-		return workspace.Entry{}, fmt.Errorf("multiple workspaces have active conflicts; run from inside the target workspace")
+		return workspace.Entry{}, fmt.Errorf("multiple Chromium checkouts have active conflicts; run from inside the target checkout")
 	}
 }
 

--- a/packages/browseros/tools/patch/internal/workspace/detect.go
+++ b/packages/browseros/tools/patch/internal/workspace/detect.go
@@ -81,8 +81,5 @@ func namedCheckoutExample(reg *Registry, commandPath string) string {
 	if commandPath == "" {
 		commandPath = "browseros-patch diff"
 	}
-	if len(reg.Workspaces) == 0 {
-		return commandPath + " <checkout>"
-	}
 	return commandPath + " " + reg.Workspaces[0].Name
 }

--- a/packages/browseros/tools/patch/internal/workspace/detect.go
+++ b/packages/browseros/tools/patch/internal/workspace/detect.go
@@ -1,14 +1,22 @@
 package workspace
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
 )
 
+// Detect finds the registered Chromium checkout that contains cwd.
 func Detect(reg *Registry, cwd string) (Entry, error) {
+	return DetectForCommand(reg, cwd, "browseros-patch diff")
+}
+
+// DetectForCommand finds the checkout for cwd and includes a command-specific
+// named-checkout example when cwd is not registered.
+func DetectForCommand(reg *Registry, cwd string, commandPath string) (Entry, error) {
 	if len(reg.Workspaces) == 0 {
-		return Entry{}, fmt.Errorf("no workspaces registered yet")
+		return Entry{}, fmt.Errorf(`no Chromium checkouts registered; run "browseros-patch add <name> <path>"`)
 	}
 	abs, err := filepath.Abs(cwd)
 	if err != nil {
@@ -27,14 +35,19 @@ func Detect(reg *Registry, cwd string) (Entry, error) {
 		}
 	}
 	if bestLen == -1 {
-		return Entry{}, fmt.Errorf(
-			`not inside a registered workspace; run "browseros-patch list" to inspect workspaces or pass one by name`,
-		)
+		return Entry{}, errors.New(detectErrorMessage(reg, clean, commandPath))
 	}
 	return best, nil
 }
 
+// Resolve resolves a checkout from --src, an explicit name, or cwd detection.
 func Resolve(reg *Registry, name string, cwd string, src string) (Entry, error) {
+	return ResolveForCommand(reg, name, cwd, src, "browseros-patch diff")
+}
+
+// ResolveForCommand resolves a checkout and tailors cwd detection errors for a
+// specific command such as "browseros-patch diff".
+func ResolveForCommand(reg *Registry, name string, cwd string, src string, commandPath string) (Entry, error) {
 	if src != "" {
 		path, err := NormalizeWorkspacePath(src)
 		if err != nil {
@@ -45,5 +58,31 @@ func Resolve(reg *Registry, name string, cwd string, src string) (Entry, error) 
 	if name != "" {
 		return reg.Get(name)
 	}
-	return Detect(reg, cwd)
+	return DetectForCommand(reg, cwd, commandPath)
+}
+
+func detectErrorMessage(reg *Registry, cleanCWD string, commandPath string) string {
+	var builder strings.Builder
+	builder.WriteString("not inside a registered Chromium checkout\n")
+	builder.WriteString("cwd: " + cleanCWD + "\n")
+	if resolved, err := filepath.EvalSymlinks(cleanCWD); err == nil && resolved != cleanCWD {
+		builder.WriteString("resolved cwd: " + resolved + "\n")
+	}
+	builder.WriteString("registered checkouts:\n")
+	for _, ws := range reg.Workspaces {
+		builder.WriteString(fmt.Sprintf("  %s  %s\n", ws.Name, ws.Path))
+	}
+	builder.WriteString("try: " + namedCheckoutExample(reg, commandPath))
+	return strings.TrimRight(builder.String(), "\n")
+}
+
+func namedCheckoutExample(reg *Registry, commandPath string) string {
+	commandPath = strings.TrimSpace(commandPath)
+	if commandPath == "" {
+		commandPath = "browseros-patch diff"
+	}
+	if len(reg.Workspaces) == 0 {
+		return commandPath + " <checkout>"
+	}
+	return commandPath + " " + reg.Workspaces[0].Name
 }

--- a/packages/browseros/tools/patch/internal/workspace/registry.go
+++ b/packages/browseros/tools/patch/internal/workspace/registry.go
@@ -65,10 +65,10 @@ func NormalizeWorkspacePath(raw string) (string, error) {
 		return "", err
 	}
 	if !info.IsDir() {
-		return "", fmt.Errorf("workspace path is not a directory: %s", clean)
+		return "", fmt.Errorf("checkout path is not a directory: %s", clean)
 	}
 	if _, err := os.Stat(filepath.Join(clean, ".git")); err != nil {
-		return "", fmt.Errorf("workspace is not a git checkout: %s", clean)
+		return "", fmt.Errorf("checkout is not a git checkout: %s", clean)
 	}
 	return clean, nil
 }
@@ -79,7 +79,7 @@ func (r *Registry) Get(name string) (Entry, error) {
 			return ws, nil
 		}
 	}
-	return Entry{}, fmt.Errorf("workspace %q not found", name)
+	return Entry{}, fmt.Errorf("checkout %q not found", name)
 }
 
 func (r *Registry) Add(name string, path string) (Entry, error) {
@@ -90,9 +90,9 @@ func (r *Registry) Add(name string, path string) (Entry, error) {
 	for _, ws := range r.Workspaces {
 		switch {
 		case ws.Name == name:
-			return Entry{}, fmt.Errorf("workspace %q already exists", name)
+			return Entry{}, fmt.Errorf("checkout %q already exists", name)
 		case ws.Path == normalized:
-			return Entry{}, fmt.Errorf("workspace path already registered as %q", ws.Name)
+			return Entry{}, fmt.Errorf("checkout path already registered as %q", ws.Name)
 		}
 	}
 	entry := Entry{Name: name, Path: normalized, AddedAt: time.Now().UTC()}
@@ -117,5 +117,5 @@ func (r *Registry) Remove(name string) (Entry, error) {
 		r.Workspaces = append(r.Workspaces[:idx], r.Workspaces[idx+1:]...)
 		return ws, nil
 	}
-	return Entry{}, fmt.Errorf("workspace %q not found", name)
+	return Entry{}, fmt.Errorf("checkout %q not found", name)
 }

--- a/packages/browseros/tools/patch/internal/workspace/workspace_test.go
+++ b/packages/browseros/tools/patch/internal/workspace/workspace_test.go
@@ -140,3 +140,23 @@ func TestDetectOutsideRegisteredCheckoutErrorShowsResolvedCWD(t *testing.T) {
 		}
 	}
 }
+
+func TestRegistryErrorsUseCheckoutTerminology(t *testing.T) {
+	file := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(file, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	if _, err := NormalizeWorkspacePath(file); err == nil {
+		t.Fatalf("expected not-directory error")
+	} else if !strings.Contains(err.Error(), "checkout path is not a directory") {
+		t.Fatalf("expected checkout terminology, got %q", err)
+	}
+
+	reg := &Registry{Version: 1}
+	if _, err := reg.Get("missing"); err == nil {
+		t.Fatalf("expected missing checkout error")
+	} else if !strings.Contains(err.Error(), `checkout "missing" not found`) {
+		t.Fatalf("expected checkout terminology, got %q", err)
+	}
+}

--- a/packages/browseros/tools/patch/internal/workspace/workspace_test.go
+++ b/packages/browseros/tools/patch/internal/workspace/workspace_test.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -51,5 +52,91 @@ func TestRegistryDetectsLongestMatchingWorkspace(t *testing.T) {
 	}
 	if ws.Name != "child" {
 		t.Fatalf("expected child workspace, got %q", ws.Name)
+	}
+}
+
+func TestDetectNoRegisteredCheckoutsError(t *testing.T) {
+	_, err := Detect(&Registry{Version: 1}, t.TempDir())
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	message := err.Error()
+	for _, want := range []string{
+		"no Chromium checkouts registered",
+		`browseros-patch add <name> <path>`,
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("expected error to contain %q, got:\n%s", want, message)
+		}
+	}
+}
+
+func TestDetectOutsideRegisteredCheckoutError(t *testing.T) {
+	root := t.TempDir()
+	registered := filepath.Join(root, "chromium-src")
+	outside := filepath.Join(root, "other")
+	for _, dir := range []string{registered, outside} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+
+	reg := &Registry{Version: 1, Workspaces: []Entry{{Name: "ch1", Path: registered}}}
+	_, err := Detect(reg, outside)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	message := err.Error()
+	for _, want := range []string{
+		"not inside a registered Chromium checkout",
+		"cwd: " + outside,
+		"registered checkouts:",
+		"ch1",
+		registered,
+		`browseros-patch diff ch1`,
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("expected error to contain %q, got:\n%s", want, message)
+		}
+	}
+	if strings.Contains(message, "sync state") {
+		t.Fatalf("error should not imply list computes sync state:\n%s", message)
+	}
+}
+
+func TestDetectOutsideRegisteredCheckoutErrorShowsResolvedCWD(t *testing.T) {
+	root := t.TempDir()
+	registered := filepath.Join(root, "chromium-src")
+	realOutside := filepath.Join(root, "real-outside")
+	linkOutside := filepath.Join(root, "link-outside")
+	for _, dir := range []string{registered, realOutside} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+	}
+	if err := os.Symlink(realOutside, linkOutside); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	resolvedOutside, err := filepath.EvalSymlinks(realOutside)
+	if err != nil {
+		t.Fatalf("eval symlinks: %v", err)
+	}
+
+	reg := &Registry{Version: 1, Workspaces: []Entry{{Name: "ch1", Path: registered}}}
+	_, err = Detect(reg, linkOutside)
+	if err == nil {
+		t.Fatalf("expected error")
+	}
+
+	message := err.Error()
+	for _, want := range []string{
+		"cwd: " + linkOutside,
+		"resolved cwd: " + resolvedOutside,
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("expected error to contain %q, got:\n%s", want, message)
+		}
 	}
 }


### PR DESCRIPTION
## Summary
- Clarifies browseros-patch around patch repos and named Chromium checkouts.
- Makes checkout detection errors actionable with cwd, resolved cwd, registered checkouts, and named command examples.
- Adds concise command examples and `--llm-txt` guidance for coding agents.

## Design
This keeps the existing registry and patch engine behavior intact. User-facing copy now says Chromium checkout, named checkout commands work from anywhere through the existing resolver, and `--llm-txt` prints a static plain-text quick reference before app state is loaded.

## Test plan
- [x] `go test -count=1 ./...` from `packages/browseros/tools/patch`
- [x] `go vet ./...` from `packages/browseros/tools/patch`
- [x] Inspected `go run . --help`, `diff --help`, `status --help`, `apply --help`, `sync --help`, `extract --help`
- [x] Inspected `go run . --llm-txt`