### PR TITLE
feat(agents): add Hermes ACP adapter

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationHeader.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationHeader.tsx
@@ -3,7 +3,10 @@ import type { FC } from 'react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { formatRelativeTime } from '@/entrypoints/app/agents/agent-display.helpers'
-import type { HarnessAgent } from '@/entrypoints/app/agents/agent-harness-types'
+import type {
+  HarnessAgent,
+  HarnessAgentAdapter,
+} from '@/entrypoints/app/agents/agent-harness-types'
 import { AgentSummaryChips } from '@/entrypoints/app/agents/agent-row/AgentSummaryChips'
 import { formatTokens } from '@/entrypoints/app/agents/agent-row/agent-row.helpers'
 import type { AgentAdapterHealth } from '@/entrypoints/app/agents/agent-row/agent-row.types'
@@ -14,7 +17,7 @@ import { cn } from '@/lib/utils'
 interface ConversationHeaderProps {
   agent: HarnessAgent | null
   fallbackName: string
-  fallbackAdapter: 'claude' | 'codex' | 'openclaw' | 'unknown'
+  fallbackAdapter: HarnessAgentAdapter | 'unknown'
   adapterHealth: AgentAdapterHealth | null
   backLabel: string
   backTarget: 'home' | 'page'

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AdapterIcon.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AdapterIcon.tsx
@@ -15,14 +15,13 @@ interface AdapterIconProps {
 export const AdapterIcon: FC<AdapterIconProps> = ({ adapter, className }) => {
   switch (adapter) {
     case 'claude':
-      // Claude Code — text-based agent, sparkles to evoke the "AI assistant" feel.
       return <Sparkles className={className} aria-label="Claude Code" />
     case 'codex':
-      // Codex — code-leaning, CPU mark.
       return <Cpu className={className} aria-label="Codex" />
     case 'openclaw':
-      // OpenClaw — bot/automation framing.
       return <Bot className={className} aria-label="OpenClaw" />
+    case 'hermes':
+      return <Bot className={className} aria-label="Hermes" />
     default:
       return <Bot className={className} aria-label="Agent" />
   }
@@ -36,6 +35,8 @@ export function adapterLabel(adapter: HarnessAgentAdapter | 'unknown'): string {
       return 'Codex'
     case 'openclaw':
       return 'OpenClaw'
+    case 'hermes':
+      return 'Hermes'
     default:
       return 'Agent'
   }

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentList.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentList.tsx
@@ -117,6 +117,7 @@ function inferAdapterFromLabel(label: string): HarnessAgentAdapter | 'unknown' {
   if (lower === 'claude code') return 'claude'
   if (lower === 'codex') return 'codex'
   if (lower === 'openclaw') return 'openclaw'
+  if (lower === 'hermes') return 'hermes'
   return 'unknown'
 }
 

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/NewAgentDialog.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/NewAgentDialog.tsx
@@ -23,6 +23,7 @@ import type {
   HarnessAgentAdapter,
 } from './agent-harness-types'
 import type { CreateAgentRuntime, ProviderOption } from './agents-page-types'
+import { getHermesCliInstallPrompt } from './hermes-install-prompt'
 import { ProviderSelector } from './OpenClawControls'
 import {
   type OpenClawCliProvider,
@@ -89,6 +90,15 @@ export const NewAgentDialog: FC<NewAgentDialogProps> = ({
 }) => {
   const selectedHarnessAdapter =
     adapters.find((adapter) => adapter.id === harnessAdapterId) ?? adapters[0]
+  const selectedCreateAdapter =
+    createRuntime === 'openclaw'
+      ? selectedHarnessAdapter
+      : (adapters.find((adapter) => adapter.id === createRuntime) ??
+        selectedHarnessAdapter)
+  const hermesInstallPrompt = getHermesCliInstallPrompt({
+    createRuntime,
+    selectedAdapter: selectedCreateAdapter,
+  })
   const isHarnessRuntime = createRuntime !== 'openclaw'
   const openClawBlocked = createRuntime === 'openclaw' && !canManageOpenClaw
   const cliBlocked =
@@ -100,6 +110,7 @@ export const NewAgentDialog: FC<NewAgentDialogProps> = ({
     !creating &&
     !openClawBlocked &&
     !cliBlocked &&
+    !hermesInstallPrompt &&
     (createRuntime === 'openclaw'
       ? providers.length > 0
       : Boolean(selectedHarnessAdapter))
@@ -199,6 +210,29 @@ export const NewAgentDialog: FC<NewAgentDialogProps> = ({
 
           {isHarnessRuntime ? (
             <>
+              {hermesInstallPrompt ? (
+                <Alert>
+                  <AlertCircle className="size-4" />
+                  <AlertTitle>{hermesInstallPrompt.title}</AlertTitle>
+                  <AlertDescription>
+                    <div className="grid gap-2">
+                      <p>{hermesInstallPrompt.description}</p>
+                      <code className="rounded bg-muted px-2 py-1 font-mono text-xs">
+                        {hermesInstallPrompt.installCommand}
+                      </code>
+                      <a
+                        href={hermesInstallPrompt.docsUrl}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="text-primary text-xs underline underline-offset-4"
+                      >
+                        Hermes ACP setup
+                      </a>
+                    </div>
+                  </AlertDescription>
+                </Alert>
+              ) : null}
+
               <div className="grid gap-2">
                 <Label htmlFor="harness-model">Model</Label>
                 <Select

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/NewAgentDialog.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/NewAgentDialog.tsx
@@ -143,7 +143,8 @@ export const NewAgentDialog: FC<NewAgentDialogProps> = ({
                 if (
                   value === 'openclaw' ||
                   value === 'claude' ||
-                  value === 'codex'
+                  value === 'codex' ||
+                  value === 'hermes'
                 ) {
                   onRuntimeChange(value)
                   if (value !== 'openclaw') onHarnessAdapterChange(value)

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/NewAgentDialog.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/NewAgentDialog.tsx
@@ -256,24 +256,26 @@ export const NewAgentDialog: FC<NewAgentDialogProps> = ({
                 </div>
               ) : null}
 
-              <div className="grid gap-2">
-                <Label htmlFor="harness-effort">Reasoning</Label>
-                <Select
-                  value={harnessReasoningEffort}
-                  onValueChange={onHarnessReasoningChange}
-                >
-                  <SelectTrigger id="harness-effort">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {harnessReasoningEfforts.map((effort) => (
-                      <SelectItem key={effort.id} value={effort.id}>
-                        {effort.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
+              {harnessReasoningEfforts.length > 1 ? (
+                <div className="grid gap-2">
+                  <Label htmlFor="harness-effort">Reasoning</Label>
+                  <Select
+                    value={harnessReasoningEffort}
+                    onValueChange={onHarnessReasoningChange}
+                  >
+                    <SelectTrigger id="harness-effort">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {harnessReasoningEfforts.map((effort) => (
+                        <SelectItem key={effort.id} value={effort.id}>
+                          {effort.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              ) : null}
             </>
           ) : null}
         </div>

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/NewAgentDialog.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/NewAgentDialog.tsx
@@ -99,6 +99,8 @@ export const NewAgentDialog: FC<NewAgentDialogProps> = ({
     createRuntime,
     selectedAdapter: selectedCreateAdapter,
   })
+  const harnessModels = selectedHarnessAdapter?.models ?? []
+  const harnessReasoningEfforts = selectedHarnessAdapter?.reasoningEfforts ?? []
   const isHarnessRuntime = createRuntime !== 'openclaw'
   const openClawBlocked = createRuntime === 'openclaw' && !canManageOpenClaw
   const cliBlocked =
@@ -233,24 +235,26 @@ export const NewAgentDialog: FC<NewAgentDialogProps> = ({
                 </Alert>
               ) : null}
 
-              <div className="grid gap-2">
-                <Label htmlFor="harness-model">Model</Label>
-                <Select
-                  value={harnessModelId}
-                  onValueChange={onHarnessModelChange}
-                >
-                  <SelectTrigger id="harness-model">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {(selectedHarnessAdapter?.models ?? []).map((model) => (
-                      <SelectItem key={model.id} value={model.id}>
-                        {model.label}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
+              {harnessModels.length > 0 ? (
+                <div className="grid gap-2">
+                  <Label htmlFor="harness-model">Model</Label>
+                  <Select
+                    value={harnessModelId}
+                    onValueChange={onHarnessModelChange}
+                  >
+                    <SelectTrigger id="harness-model">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {harnessModels.map((model) => (
+                        <SelectItem key={model.id} value={model.id}>
+                          {model.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              ) : null}
 
               <div className="grid gap-2">
                 <Label htmlFor="harness-effort">Reasoning</Label>
@@ -262,13 +266,11 @@ export const NewAgentDialog: FC<NewAgentDialogProps> = ({
                     <SelectValue />
                   </SelectTrigger>
                   <SelectContent>
-                    {(selectedHarnessAdapter?.reasoningEfforts ?? []).map(
-                      (effort) => (
-                        <SelectItem key={effort.id} value={effort.id}>
-                          {effort.label}
-                        </SelectItem>
-                      ),
-                    )}
+                    {harnessReasoningEfforts.map((effort) => (
+                      <SelectItem key={effort.id} value={effort.id}>
+                        {effort.label}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
               </div>

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-display.helpers.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-display.helpers.ts
@@ -56,7 +56,7 @@ export function canRename(_agent: AgentListItem): boolean {
  */
 export function workspaceLabel(agent: AgentListItem): string | null {
   if (!agent.detail) return null
-  if (/^(claude|codex|openclaw):main$/.test(agent.detail)) return null
+  if (/^(claude|codex|openclaw|hermes):main$/.test(agent.detail)) return null
   return agent.detail
 }
 

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-harness-types.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-harness-types.ts
@@ -1,6 +1,6 @@
 import type { AgentEntry } from './useOpenClaw'
 
-export type HarnessAgentAdapter = 'claude' | 'codex' | 'openclaw'
+export type HarnessAgentAdapter = 'claude' | 'codex' | 'openclaw' | 'hermes'
 
 export type AgentHarnessStreamEvent =
   | {

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/agents-page-actions.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/agents-page-actions.ts
@@ -140,6 +140,7 @@ export function createAgentPageActions(input: AgentPageActionInput) {
       openclaw: handleOpenClawCreate,
       claude: handleHarnessCreate,
       codex: handleHarnessCreate,
+      hermes: handleHarnessCreate,
     }
     void createByRuntime[input.createRuntime]()
   }

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/agents-page-utils.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/agents-page-utils.ts
@@ -38,7 +38,16 @@ export function getRecoveryDetail(status: OpenClawStatus): string | null {
 }
 
 export function formatHarnessAdapter(adapter: HarnessAgentAdapter): string {
-  return adapter === 'claude' ? 'Claude Code' : 'Codex'
+  switch (adapter) {
+    case 'claude':
+      return 'Claude Code'
+    case 'codex':
+      return 'Codex'
+    case 'openclaw':
+      return 'OpenClaw'
+    case 'hermes':
+      return 'Hermes'
+  }
 }
 
 export function toProviderOptions(

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/hermes-install-prompt.test.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/hermes-install-prompt.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  getHermesCliInstallPrompt,
+  HERMES_ACP_DOCS_URL,
+} from './hermes-install-prompt'
+
+describe('getHermesCliInstallPrompt', () => {
+  it('prompts for Hermes install when the Hermes adapter health is unhealthy', () => {
+    expect(
+      getHermesCliInstallPrompt({
+        createRuntime: 'hermes',
+        selectedAdapter: {
+          id: 'hermes',
+          name: 'Hermes',
+          defaultModelId: 'default',
+          defaultReasoningEffort: 'default',
+          modelControl: 'best-effort',
+          models: [],
+          reasoningEfforts: [],
+          health: {
+            healthy: false,
+            reason: 'hermes --version failed: command not found',
+            checkedAt: 1000,
+          },
+        },
+      }),
+    ).toEqual({
+      title: 'Hermes CLI not installed',
+      description:
+        'hermes --version failed: command not found. Install Hermes with the ACP extra, then make sure hermes is on PATH.',
+      docsUrl: HERMES_ACP_DOCS_URL,
+      installCommand: "pip install -e '.[acp]'",
+    })
+  })
+
+  it('does not prompt for healthy or non-Hermes adapter selections', () => {
+    const hermesDescriptor = {
+      id: 'hermes' as const,
+      name: 'Hermes',
+      defaultModelId: 'default',
+      defaultReasoningEffort: 'default',
+      modelControl: 'best-effort' as const,
+      models: [],
+      reasoningEfforts: [],
+      health: { healthy: true, checkedAt: 1000 },
+    }
+
+    expect(
+      getHermesCliInstallPrompt({
+        createRuntime: 'hermes',
+        selectedAdapter: hermesDescriptor,
+      }),
+    ).toBeNull()
+    expect(
+      getHermesCliInstallPrompt({
+        createRuntime: 'codex',
+        selectedAdapter: { ...hermesDescriptor, id: 'codex', name: 'Codex' },
+      }),
+    ).toBeNull()
+    expect(
+      getHermesCliInstallPrompt({
+        createRuntime: 'hermes',
+        selectedAdapter: null,
+      }),
+    ).toBeNull()
+    expect(
+      getHermesCliInstallPrompt({
+        createRuntime: 'hermes',
+        selectedAdapter: {
+          ...hermesDescriptor,
+          id: 'codex' as const,
+          name: 'Codex',
+          health: { healthy: false, checkedAt: 1000 },
+        },
+      }),
+    ).toBeNull()
+  })
+})

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/hermes-install-prompt.test.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/hermes-install-prompt.test.ts
@@ -19,7 +19,7 @@ describe('getHermesCliInstallPrompt', () => {
           reasoningEfforts: [],
           health: {
             healthy: false,
-            reason: 'hermes --version failed: command not found',
+            reason: 'hermes acp --help failed: command not found',
             checkedAt: 1000,
           },
         },
@@ -27,7 +27,7 @@ describe('getHermesCliInstallPrompt', () => {
     ).toEqual({
       title: 'Hermes CLI not installed',
       description:
-        'hermes --version failed: command not found. Install Hermes with the ACP extra, then make sure hermes is on PATH.',
+        'hermes acp --help failed: command not found. Install Hermes normally, then add the ACP extra and make sure hermes is on PATH.',
       docsUrl: HERMES_ACP_DOCS_URL,
       installCommand: "pip install -e '.[acp]'",
     })

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/hermes-install-prompt.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/hermes-install-prompt.ts
@@ -34,7 +34,7 @@ export function getHermesCliInstallPrompt(input: {
     title: 'Hermes CLI not installed',
     description: `${
       reason ? `${reason}. ` : ''
-    }Install Hermes with the ACP extra, then make sure hermes is on PATH.`,
+    }Install Hermes normally, then add the ACP extra and make sure hermes is on PATH.`,
     docsUrl: HERMES_ACP_DOCS_URL,
     installCommand: "pip install -e '.[acp]'",
   }

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/hermes-install-prompt.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/hermes-install-prompt.ts
@@ -1,0 +1,41 @@
+import type { HarnessAdapterDescriptor } from './agent-harness-types'
+import type { CreateAgentRuntime } from './agents-page-types'
+
+export const HERMES_ACP_DOCS_URL =
+  'https://hermes-agent.nousresearch.com/docs/user-guide/features/acp'
+
+export interface HermesCliInstallPrompt {
+  title: string
+  description: string
+  docsUrl: string
+  installCommand: string
+}
+
+/**
+ * Returns the blocking install prompt for host-local Hermes ACP.
+ * BrowserOS launches `hermes acp`, so a missing host CLI has to be
+ * resolved before we create the persisted agent record.
+ */
+export function getHermesCliInstallPrompt(input: {
+  createRuntime: CreateAgentRuntime
+  selectedAdapter: HarnessAdapterDescriptor | null | undefined
+}): HermesCliInstallPrompt | null {
+  const health = input.selectedAdapter?.health
+  if (
+    input.createRuntime !== 'hermes' ||
+    input.selectedAdapter?.id !== 'hermes' ||
+    health?.healthy !== false
+  ) {
+    return null
+  }
+
+  const reason = health.reason?.trim()
+  return {
+    title: 'Hermes CLI not installed',
+    description: `${
+      reason ? `${reason}. ` : ''
+    }Install Hermes with the ACP extra, then make sure hermes is on PATH.`,
+    docsUrl: HERMES_ACP_DOCS_URL,
+    installCommand: "pip install -e '.[acp]'",
+  }
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/useAgents.test.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/useAgents.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import { adapterLabel } from './AdapterIcon'
 import { buildAgentApiUrl } from './agent-api-url'
 import { mapHarnessAgentToEntry } from './agent-harness-types'
 
@@ -23,6 +24,34 @@ describe('mapHarnessAgentToEntry', () => {
       model: 'gpt-5.5',
       source: 'agent-harness',
     })
+  })
+
+  it('maps Hermes harness agents into chat-compatible entries', () => {
+    expect(
+      mapHarnessAgentToEntry({
+        id: 'agent-hermes',
+        name: 'Hermes bot',
+        adapter: 'hermes',
+        modelId: 'default',
+        reasoningEffort: 'default',
+        permissionMode: 'approve-all',
+        sessionKey: 'agent:agent-hermes:main',
+        createdAt: 1000,
+        updatedAt: 1000,
+      }),
+    ).toEqual({
+      agentId: 'agent-hermes',
+      name: 'Hermes bot',
+      workspace: 'hermes:main',
+      model: 'default',
+      source: 'agent-harness',
+    })
+  })
+})
+
+describe('adapterLabel', () => {
+  it('labels Hermes harness agents consistently', () => {
+    expect(adapterLabel('hermes')).toBe('Hermes')
   })
 })
 

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/sidepanel-chat-targets.test.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/sidepanel-chat-targets.test.ts
@@ -78,6 +78,15 @@ const adapters: HarnessAdapterDescriptor[] = [
       { id: 'high', label: 'High' },
     ],
   },
+  {
+    id: 'hermes',
+    name: 'Hermes',
+    defaultModelId: 'default',
+    defaultReasoningEffort: 'default',
+    modelControl: 'best-effort',
+    models: [],
+    reasoningEfforts: [{ id: 'default', label: 'Default', recommended: true }],
+  },
 ]
 
 const agents: HarnessAgent[] = [
@@ -103,6 +112,17 @@ const agents: HarnessAgent[] = [
     createdAt: timestamp,
     updatedAt: timestamp,
   },
+  {
+    id: 'agent-hermes',
+    name: 'Hermes Bot',
+    adapter: 'hermes',
+    modelId: 'default',
+    reasoningEffort: 'default',
+    permissionMode: 'approve-all',
+    sessionKey: 'agent:agent-hermes:main',
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  },
 ]
 
 describe('buildSidepanelChatTargets', () => {
@@ -114,6 +134,7 @@ describe('buildSidepanelChatTargets', () => {
       'anthropic-sonnet',
       'agent-codex',
       'agent-openclaw',
+      'agent-hermes',
     ])
   })
 
@@ -163,6 +184,39 @@ describe('buildSidepanelChatTargets', () => {
       recommended: true,
       reasoningEffort: 'medium',
       reasoningEffortLabel: 'Medium',
+    })
+  })
+
+  it('labels Hermes ACP targets from the adapter catalog', () => {
+    const targets = buildSidepanelChatTargets({ providers, adapters, agents })
+    const hermes = targets.find((target) => target.id === 'agent-hermes')
+
+    expect(hermes).toMatchObject({
+      kind: 'acp',
+      agentId: 'agent-hermes',
+      adapter: 'hermes',
+      adapterName: 'Hermes',
+      modelId: 'default',
+      modelLabel: 'default',
+      modelControl: 'best-effort',
+      reasoningEffort: 'default',
+      reasoningEffortLabel: 'Default',
+    })
+  })
+
+  it('uses the Hermes display name when catalog metadata is unavailable', () => {
+    const targets = buildSidepanelChatTargets({
+      providers,
+      adapters: adapters.filter((adapter) => adapter.id !== 'hermes'),
+      agents: agents.filter((agent) => agent.id === 'agent-hermes'),
+    })
+
+    expect(
+      targets.find((target) => target.id === 'agent-hermes'),
+    ).toMatchObject({
+      kind: 'acp',
+      adapter: 'hermes',
+      adapterName: 'Hermes',
     })
   })
 

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/sidepanel-chat-targets.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/sidepanel-chat-targets.ts
@@ -108,6 +108,7 @@ function formatAdapterName(adapter: HarnessAgentAdapter): string {
   if (adapter === 'claude') return 'Claude Code'
   if (adapter === 'codex') return 'Codex'
   if (adapter === 'openclaw') return 'OpenClaw'
+  if (adapter === 'hermes') return 'Hermes'
   return adapter
 }
 

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-agent-adapter.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-agent-adapter.ts
@@ -9,6 +9,7 @@ import type { OpenClawGatewayChatClient } from '../../api/services/openclaw/open
 import type { AgentDefinition } from './agent-types'
 import { prepareClaudeCodeContext } from './claude-code/prepare'
 import { prepareCodexContext } from './codex/prepare'
+import { prepareHermesContext } from './hermes/prepare'
 import {
   maybeHandleOpenClawTurn,
   prepareOpenClawContext,
@@ -58,6 +59,7 @@ const ADAPTERS: Record<AgentDefinition['adapter'], AcpxAgentAdapter> = {
     prepare: prepareOpenClawContext,
     maybeHandleTurn: maybeHandleOpenClawTurn,
   },
+  hermes: { prepare: prepareHermesContext },
 }
 
 export function getAcpxAgentAdapter(

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
@@ -740,6 +740,10 @@ function createBrowserosAgentRegistry(input: {
         )
       }
 
+      if (lower === 'hermes') {
+        return wrapCommandWithEnv(resolveHermesAcpCommand(), input.commandEnv)
+      }
+
       if (lower === 'claude' || lower === 'codex') {
         return wrapCommandWithEnv(registry.resolve(agentName), input.commandEnv)
       }
@@ -747,6 +751,15 @@ function createBrowserosAgentRegistry(input: {
       return registry.resolve(agentName)
     },
   }
+}
+
+/**
+ * Resolves the host-local Hermes ACP command acpx will spawn.
+ * The env override is intentionally a full command string so local
+ * development can point at an unpublished adapter without changing code.
+ */
+function resolveHermesAcpCommand(): string {
+  return process.env.BROWSEROS_HERMES_ACP_COMMAND?.trim() || 'hermes acp'
 }
 
 /**

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
@@ -755,15 +755,11 @@ function createBrowserosAgentRegistry(input: {
 
 /**
  * Resolves the host-local Hermes ACP command acpx will spawn.
- * The env override is intentionally a full command string so local
+ * HERMES_ACP_COMMAND is intentionally a full command string so local
  * development can point at an unpublished adapter without changing code.
  */
 function resolveHermesAcpCommand(): string {
-  return (
-    process.env.HERMES_ACP_COMMAND?.trim() ||
-    process.env.BROWSEROS_HERMES_ACP_COMMAND?.trim() ||
-    'hermes acp'
-  )
+  return process.env.HERMES_ACP_COMMAND?.trim() || 'hermes acp'
 }
 
 /**

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
@@ -759,7 +759,11 @@ function createBrowserosAgentRegistry(input: {
  * development can point at an unpublished adapter without changing code.
  */
 function resolveHermesAcpCommand(): string {
-  return process.env.BROWSEROS_HERMES_ACP_COMMAND?.trim() || 'hermes acp'
+  return (
+    process.env.HERMES_ACP_COMMAND?.trim() ||
+    process.env.BROWSEROS_HERMES_ACP_COMMAND?.trim() ||
+    'hermes acp'
+  )
 }
 
 /**

--- a/packages/browseros-agent/apps/server/src/lib/agents/adapter-health.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/adapter-health.ts
@@ -119,7 +119,7 @@ export class AdapterHealthChecker {
 const ADAPTER_HEALTH_COMMANDS: Partial<Record<AgentAdapter, string>> = {
   claude: 'claude --version',
   codex: 'codex --version',
-  hermes: 'hermes --version',
+  hermes: 'hermes acp --help',
 }
 
 function friendlyProbeFailure(adapter: AgentAdapter, raw: string): string {

--- a/packages/browseros-agent/apps/server/src/lib/agents/adapter-health.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/adapter-health.ts
@@ -23,6 +23,11 @@ interface CachedHealth extends AdapterHealth {
   expiresAt: number
 }
 
+type ExecCommand = (
+  command: string,
+  options: { timeout: number },
+) => Promise<unknown>
+
 /**
  * In-memory cache of adapter binary availability. Probed lazily on
  * first read and refreshed every `cacheTtlMs`. The probe is one
@@ -37,10 +42,19 @@ export class AdapterHealthChecker {
   private readonly cacheTtlMs: number
   private readonly probeTimeoutMs: number
   private readonly inflight = new Map<AgentAdapter, Promise<AdapterHealth>>()
+  private readonly execCommand: ExecCommand
 
-  constructor(options: { cacheTtlMs?: number; probeTimeoutMs?: number } = {}) {
+  constructor(
+    options: {
+      cacheTtlMs?: number
+      probeTimeoutMs?: number
+      execCommand?: ExecCommand
+    } = {},
+  ) {
     this.cacheTtlMs = options.cacheTtlMs ?? 5 * 60 * 1000
     this.probeTimeoutMs = options.probeTimeoutMs ?? 2_000
+    this.execCommand =
+      options.execCommand ?? ((command, options) => execAsync(command, options))
   }
 
   async getHealth(adapter: AgentAdapter): Promise<AdapterHealth> {
@@ -84,7 +98,7 @@ export class AdapterHealthChecker {
       }
     }
     try {
-      await execAsync(command, { timeout: this.probeTimeoutMs })
+      await this.execCommand(command, { timeout: this.probeTimeoutMs })
       return { healthy: true, checkedAt: Date.now() }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
@@ -105,6 +119,7 @@ export class AdapterHealthChecker {
 const ADAPTER_HEALTH_COMMANDS: Partial<Record<AgentAdapter, string>> = {
   claude: 'claude --version',
   codex: 'codex --version',
+  hermes: 'hermes --version',
 }
 
 function friendlyProbeFailure(adapter: AgentAdapter, raw: string): string {

--- a/packages/browseros-agent/apps/server/src/lib/agents/agent-catalog.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/agent-catalog.ts
@@ -84,6 +84,15 @@ export const AGENT_ADAPTER_CATALOG: AgentAdapterDescriptor[] = [
       { id: 'adaptive', label: 'Adaptive' },
     ],
   },
+  {
+    id: 'hermes',
+    name: 'Hermes',
+    defaultModelId: 'default',
+    defaultReasoningEffort: 'default',
+    modelControl: 'best-effort',
+    models: [],
+    reasoningEfforts: [{ id: 'default', label: 'Default', recommended: true }],
+  },
 ]
 
 export function getAgentAdapterDescriptor(
@@ -93,7 +102,12 @@ export function getAgentAdapterDescriptor(
 }
 
 export function isAgentAdapter(value: unknown): value is AgentAdapter {
-  return value === 'claude' || value === 'codex' || value === 'openclaw'
+  return (
+    value === 'claude' ||
+    value === 'codex' ||
+    value === 'openclaw' ||
+    value === 'hermes'
+  )
 }
 
 export function resolveDefaultModelId(adapter: AgentAdapter): string {

--- a/packages/browseros-agent/apps/server/src/lib/agents/agent-types.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/agent-types.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-export type AgentAdapter = 'claude' | 'codex' | 'openclaw'
+export type AgentAdapter = 'claude' | 'codex' | 'openclaw' | 'hermes'
 
 export type AgentPermissionMode = 'approve-all'
 

--- a/packages/browseros-agent/apps/server/src/lib/agents/hermes/prepare.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/hermes/prepare.ts
@@ -1,0 +1,27 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type {
+  PrepareAcpxAgentContextInput,
+  PreparedAcpxAgentContext,
+} from '../acpx-agent-adapter'
+import {
+  finishBrowserosManagedContext,
+  prepareBrowserosManagedContext,
+} from '../acpx-agent-common'
+
+/** Prepares Hermes ACP with BrowserOS agent home, skills, and MCP access. */
+export async function prepareHermesContext(
+  input: PrepareAcpxAgentContextInput,
+): Promise<PreparedAcpxAgentContext> {
+  const common = await prepareBrowserosManagedContext(input)
+  return finishBrowserosManagedContext({
+    ...common,
+    commandEnv: {
+      AGENT_HOME: common.paths.agentHome,
+    },
+  })
+}

--- a/packages/browseros-agent/apps/server/src/lib/db/schema/agents.ts
+++ b/packages/browseros-agent/apps/server/src/lib/db/schema/agents.ts
@@ -19,7 +19,7 @@ export const agentDefinitions = sqliteTable(
     id: text('id').primaryKey(),
     name: text('name').notNull(),
     adapter: text('adapter', {
-      enum: ['claude', 'codex', 'openclaw'],
+      enum: ['claude', 'codex', 'openclaw', 'hermes'],
     }).notNull(),
     modelId: text('model_id').notNull(),
     reasoningEffort: text('reasoning_effort').notNull(),

--- a/packages/browseros-agent/apps/server/tests/api/routes/agents.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/agents.test.ts
@@ -632,6 +632,42 @@ describe('createAgentRoutes', () => {
       error: `Name must be ${AGENT_HARNESS_LIMITS.AGENT_NAME_MAX_CHARS} characters or fewer`,
     })
   })
+
+  it('creates Hermes harness agents with default model and reasoning', async () => {
+    const agents: AgentDefinition[] = []
+    const route = createMountedRoutes(agents)
+
+    const response = await route.request('/agents', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: 'Hermes bot', adapter: 'hermes' }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      agent: {
+        name: 'Hermes bot',
+        adapter: 'hermes',
+      },
+    })
+  })
+
+  it('rejects invalid Hermes reasoning efforts', async () => {
+    const route = createMountedRoutes([])
+
+    const response = await route.request('/agents', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: 'Hermes bot',
+        adapter: 'hermes',
+        reasoningEffort: 'medium',
+      }),
+    })
+
+    expect(response.status).toBe(400)
+    expect(await response.json()).toEqual({ error: 'Invalid reasoningEffort' })
+  })
 })
 
 function createMountedRoutes(
@@ -696,7 +732,7 @@ function createFakeService(agents: AgentDefinition[]) {
     },
     async createAgent(input: {
       name: string
-      adapter: 'claude' | 'codex' | 'openclaw'
+      adapter: AgentDefinition['adapter']
       modelId?: string
       reasoningEffort?: string
     }) {

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-agent-adapter.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-agent-adapter.test.ts
@@ -84,6 +84,39 @@ describe('prepareAcpxAgentContext', () => {
     expect(prepared.runPrompt).toContain('AGENT_HOME=')
   })
 
+  it('prepares Hermes with BrowserOS memory, skills, BrowserOS MCP, and fingerprinted session', async () => {
+    const browserosDir = await mkdtemp(join(tmpdir(), 'browseros-adapters-'))
+    tempDirs.push(browserosDir)
+    const prepared = await prepareAcpxAgentContext({
+      browserosDir,
+      agent: makeAgent('hermes'),
+      sessionId: 'main',
+      sessionKey: 'agent:hermes-agent:main',
+      cwdOverride: null,
+      isSelectedCwd: false,
+      message: 'use hermes',
+    })
+
+    expect(prepared.commandEnv.AGENT_HOME).toContain('/hermes-agent/home')
+    expect(prepared.commandEnv).not.toHaveProperty('CODEX_HOME')
+    expect(prepared.useBrowserosMcp).toBe(true)
+    expect(prepared.openclawSessionKey).toBeNull()
+    expect(prepared.runtimeSessionKey).toMatch(
+      /^agent:hermes-agent:main:[a-f0-9]{16}$/,
+    )
+    expect(prepared.runPrompt).toContain('<browseros_acpx_runtime version=')
+    expect(prepared.runPrompt).toContain(
+      'Available skills: browseros, memory, soul',
+    )
+    expect(prepared.runPrompt).toContain('Current workspace cwd:')
+    expect(prepared.runPrompt).toContain(
+      '<user_request>\nuse hermes\n</user_request>',
+    )
+    expect(
+      await readFile(`${prepared.commandEnv.AGENT_HOME}/MEMORY.md`, 'utf8'),
+    ).toContain('# MEMORY.md')
+  })
+
   it('prepares OpenClaw without BrowserOS memory, host cwd, skills, or MCP', async () => {
     const browserosDir = await mkdtemp(join(tmpdir(), 'browseros-adapters-'))
     tempDirs.push(browserosDir)

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -936,6 +936,120 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
     expect(command).toContain('/runtime/codex-home')
   })
 
+  it('resolves Hermes to local ACP command with BrowserOS env', async () => {
+    const browserosDir = await mkdtemp(
+      join(tmpdir(), 'browseros-acpx-browseros-'),
+    )
+    const stateDir = await mkdtemp(join(tmpdir(), 'browseros-acpx-state-'))
+    tempDirs.push(browserosDir, stateDir)
+    const calls: Array<{ method: string; input: unknown }> = []
+    const runtime = new AcpxRuntime({
+      browserosDir,
+      stateDir,
+      runtimeFactory: (options) => {
+        calls.push({ method: 'createRuntime', input: options })
+        return createFakeAcpRuntime(calls)
+      },
+    })
+    const agent = makeAgent({ id: 'agent-1', adapter: 'hermes' })
+
+    await collectStream(
+      await runtime.send({
+        agent,
+        sessionId: 'main',
+        sessionKey: agent.sessionKey,
+        message: 'hi',
+        permissionMode: 'approve-all',
+      }),
+    )
+
+    expect(
+      calls.find((call) => call.method === 'ensureSession')?.input,
+    ).toMatchObject({
+      agent: 'hermes',
+    })
+    const command =
+      getCreateRuntimeOptions(calls).agentRegistry.resolve('hermes')
+    expect(command).toContain('env AGENT_HOME=')
+    expect(command).toContain('hermes acp')
+    expect(command).not.toContain('CODEX_HOME=')
+    expect(getCreateRuntimeOptions(calls).mcpServers).toMatchObject([
+      { name: 'browseros' },
+    ])
+  })
+
+  it('resolves Hermes with BROWSEROS_HERMES_ACP_COMMAND override', async () => {
+    const previous = process.env.BROWSEROS_HERMES_ACP_COMMAND
+    process.env.BROWSEROS_HERMES_ACP_COMMAND = 'python -m acp_adapter'
+    try {
+      const browserosDir = await mkdtemp(
+        join(tmpdir(), 'browseros-acpx-browseros-'),
+      )
+      const stateDir = await mkdtemp(join(tmpdir(), 'browseros-acpx-state-'))
+      tempDirs.push(browserosDir, stateDir)
+      const calls: Array<{ method: string; input: unknown }> = []
+      const runtime = new AcpxRuntime({
+        browserosDir,
+        stateDir,
+        runtimeFactory: (options) => {
+          calls.push({ method: 'createRuntime', input: options })
+          return createFakeAcpRuntime(calls)
+        },
+      })
+      const agent = makeAgent({ id: 'agent-1', adapter: 'hermes' })
+
+      await collectStream(
+        await runtime.send({
+          agent,
+          sessionId: 'main',
+          sessionKey: agent.sessionKey,
+          message: 'hi',
+          permissionMode: 'approve-all',
+        }),
+      )
+
+      const command =
+        getCreateRuntimeOptions(calls).agentRegistry.resolve('hermes')
+      expect(command).toContain('env AGENT_HOME=')
+      expect(command).toContain('python -m acp_adapter')
+      expect(command).not.toContain('hermes acp')
+    } finally {
+      if (previous === undefined) {
+        delete process.env.BROWSEROS_HERMES_ACP_COMMAND
+      } else {
+        process.env.BROWSEROS_HERMES_ACP_COMMAND = previous
+      }
+    }
+  })
+
+  it('continues Hermes turns with a best-effort model status when model is non-default', async () => {
+    const calls: Array<{ method: string; input: unknown }> = []
+    const runtime = new AcpxRuntime({
+      cwd: '/tmp/browseros-acpx-runtime',
+      stateDir: '/tmp/browseros-acpx-state',
+      runtimeFactory: () => createFakeAcpRuntime(calls),
+    })
+    const agent: AgentDefinition = {
+      ...makeAgent({ id: 'agent-1', adapter: 'hermes' }),
+      modelId: 'custom-hermes-model',
+    }
+
+    const events = await collectStream(
+      await runtime.send({
+        agent,
+        sessionId: 'main',
+        sessionKey: agent.sessionKey,
+        message: 'hello',
+        permissionMode: 'approve-all',
+      }),
+    )
+
+    expect(events[0]).toMatchObject({
+      type: 'status',
+      text: expect.stringContaining('Using adapter default'),
+    })
+  })
+
   it('does not reuse an Acpx runtime across different command identities', async () => {
     const browserosDir = await mkdtemp(
       join(tmpdir(), 'browseros-acpx-browseros-'),

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -978,9 +978,9 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
     ])
   })
 
-  it('resolves Hermes with BROWSEROS_HERMES_ACP_COMMAND override', async () => {
-    const previous = process.env.BROWSEROS_HERMES_ACP_COMMAND
-    process.env.BROWSEROS_HERMES_ACP_COMMAND = 'python -m acp_adapter'
+  it('resolves Hermes with HERMES_ACP_COMMAND override', async () => {
+    const previous = process.env.HERMES_ACP_COMMAND
+    process.env.HERMES_ACP_COMMAND = 'python -m acp_adapter'
     try {
       const browserosDir = await mkdtemp(
         join(tmpdir(), 'browseros-acpx-browseros-'),
@@ -1015,9 +1015,9 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
       expect(command).not.toContain('hermes acp')
     } finally {
       if (previous === undefined) {
-        delete process.env.BROWSEROS_HERMES_ACP_COMMAND
+        delete process.env.HERMES_ACP_COMMAND
       } else {
-        process.env.BROWSEROS_HERMES_ACP_COMMAND = previous
+        process.env.HERMES_ACP_COMMAND = previous
       }
     }
   })

--- a/packages/browseros-agent/apps/server/tests/lib/agents/adapter-health.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/adapter-health.test.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { AdapterHealthChecker } from '../../../src/lib/agents/adapter-health'
+
+describe('AdapterHealthChecker', () => {
+  it('probes Hermes with its local CLI version command', async () => {
+    const calls: Array<{ command: string; timeout: number }> = []
+    const checker = new AdapterHealthChecker({
+      probeTimeoutMs: 123,
+      execCommand: async (command, options) => {
+        calls.push({ command, timeout: options.timeout })
+      },
+    })
+
+    const health = await checker.getHealth('hermes')
+
+    expect(health.healthy).toBe(true)
+    expect(calls).toEqual([{ command: 'hermes --version', timeout: 123 }])
+  })
+
+  it('returns a friendly missing-command reason for Hermes', async () => {
+    const checker = new AdapterHealthChecker({
+      execCommand: async () => {
+        throw new Error('zsh: command not found: hermes')
+      },
+    })
+
+    const health = await checker.getHealth('hermes')
+
+    expect(health).toMatchObject({
+      healthy: false,
+      reason: 'hermes --version failed: command not found',
+    })
+  })
+
+  it('deduplicates inflight Hermes probes and caches the result', async () => {
+    let resolveProbe: (() => void) | null = null
+    let probeCount = 0
+    const checker = new AdapterHealthChecker({
+      cacheTtlMs: 10_000,
+      execCommand: async () => {
+        probeCount += 1
+        await new Promise<void>((resolve) => {
+          resolveProbe = resolve
+        })
+      },
+    })
+
+    const first = checker.getHealth('hermes')
+    const second = checker.getHealth('hermes')
+
+    expect(probeCount).toBe(1)
+    resolveProbe?.()
+    await Promise.all([first, second])
+    await checker.getHealth('hermes')
+
+    expect(probeCount).toBe(1)
+  })
+
+  it('does not probe OpenClaw through the host CLI health checker', async () => {
+    const checker = new AdapterHealthChecker({
+      execCommand: async () => {
+        throw new Error('unexpected probe')
+      },
+    })
+
+    const health = await checker.getHealth('openclaw')
+
+    expect(health.healthy).toBe(true)
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/lib/agents/adapter-health.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/adapter-health.test.ts
@@ -7,7 +7,7 @@ import { describe, expect, it } from 'bun:test'
 import { AdapterHealthChecker } from '../../../src/lib/agents/adapter-health'
 
 describe('AdapterHealthChecker', () => {
-  it('probes Hermes with its local CLI version command', async () => {
+  it('probes Hermes with its ACP subcommand', async () => {
     const calls: Array<{ command: string; timeout: number }> = []
     const checker = new AdapterHealthChecker({
       probeTimeoutMs: 123,
@@ -19,7 +19,7 @@ describe('AdapterHealthChecker', () => {
     const health = await checker.getHealth('hermes')
 
     expect(health.healthy).toBe(true)
-    expect(calls).toEqual([{ command: 'hermes --version', timeout: 123 }])
+    expect(calls).toEqual([{ command: 'hermes acp --help', timeout: 123 }])
   })
 
   it('returns a friendly missing-command reason for Hermes', async () => {
@@ -33,7 +33,7 @@ describe('AdapterHealthChecker', () => {
 
     expect(health).toMatchObject({
       healthy: false,
-      reason: 'hermes --version failed: command not found',
+      reason: 'hermes acp --help failed: command not found',
     })
   })
 

--- a/packages/browseros-agent/apps/server/tests/lib/agents/agent-catalog.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/agent-catalog.test.ts
@@ -7,16 +7,20 @@ import { describe, expect, it } from 'bun:test'
 import {
   AGENT_ADAPTER_CATALOG,
   getAgentAdapterDescriptor,
+  isAgentAdapter,
   isSupportedAgentModel,
   isSupportedReasoningEffort,
+  resolveDefaultModelId,
+  resolveDefaultReasoningEffort,
 } from '../../../src/lib/agents/agent-catalog'
 
 describe('AGENT_ADAPTER_CATALOG', () => {
-  it('exposes Claude, Codex, and OpenClaw adapters with model and effort options', () => {
+  it('exposes Claude, Codex, OpenClaw, and Hermes adapters with model and effort options', () => {
     expect(AGENT_ADAPTER_CATALOG.map((adapter) => adapter.id)).toEqual([
       'claude',
       'codex',
       'openclaw',
+      'hermes',
     ])
 
     expect(getAgentAdapterDescriptor('claude')).toMatchObject({
@@ -46,6 +50,15 @@ describe('AGENT_ADAPTER_CATALOG', () => {
     // gateway-side agent record and is sourced from the LlmProviderConfig.
     expect(getAgentAdapterDescriptor('openclaw')?.models).toEqual([])
 
+    expect(getAgentAdapterDescriptor('hermes')).toMatchObject({
+      id: 'hermes',
+      name: 'Hermes',
+      defaultModelId: 'default',
+      defaultReasoningEffort: 'default',
+      modelControl: 'best-effort',
+    })
+    expect(getAgentAdapterDescriptor('hermes')?.models).toEqual([])
+
     expect(isSupportedAgentModel('claude', 'haiku')).toBe(true)
     expect(isSupportedAgentModel('claude', 'claude-opus-4-7')).toBe(true)
     expect(isSupportedAgentModel('claude', 'claude-sonnet-4-6')).toBe(true)
@@ -58,10 +71,19 @@ describe('AGENT_ADAPTER_CATALOG', () => {
     expect(isSupportedAgentModel('openclaw', undefined)).toBe(true)
     expect(isSupportedAgentModel('openclaw', 'default')).toBe(true)
     expect(isSupportedAgentModel('openclaw', 'gpt-5.5')).toBe(false)
+    expect(isSupportedAgentModel('hermes', undefined)).toBe(true)
+    expect(isSupportedAgentModel('hermes', 'default')).toBe(true)
+    expect(isSupportedAgentModel('hermes', 'gpt-5.5')).toBe(false)
 
     expect(isSupportedReasoningEffort('codex', 'xhigh')).toBe(true)
     expect(isSupportedReasoningEffort('claude', 'banana')).toBe(false)
     expect(isSupportedReasoningEffort('openclaw', 'adaptive')).toBe(true)
     expect(isSupportedReasoningEffort('openclaw', 'xhigh')).toBe(false)
+    expect(isSupportedReasoningEffort('hermes', 'default')).toBe(true)
+    expect(isSupportedReasoningEffort('hermes', 'medium')).toBe(false)
+    expect(resolveDefaultModelId('hermes')).toBe('default')
+    expect(resolveDefaultReasoningEffort('hermes')).toBe('default')
+    expect(isAgentAdapter('hermes')).toBe(true)
+    expect(isAgentAdapter('not-real')).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary
- Add Hermes as a host-local ACP adapter in the server catalog, DB enum, ACPX prep, command resolver, and health probe.
- Launch Hermes via `hermes acp` with `HERMES_ACP_COMMAND` override support.
- Surface Hermes in the agent UI and block creation with an install prompt when the local CLI health probe fails.

## Verification
- `bun run --filter @browseros/server test:agent`
- `bun --env-file=apps/server/.env.development test apps/server/tests/lib/agents/agent-catalog.test.ts apps/server/tests/lib/agents/acpx-agent-adapter.test.ts apps/server/tests/lib/agents/acpx-runtime.test.ts apps/server/tests/lib/agents/adapter-health.test.ts apps/server/tests/api/routes/agents.test.ts`
- `bun run --filter @browseros/server typecheck`
- `bun run --filter @browseros/agent typecheck`
- `bun run --filter @browseros/agent test`
- `bunx biome check apps/server/src/lib/agents apps/server/tests/lib/agents apps/server/tests/api/routes apps/agent/entrypoints/app/agents apps/agent/entrypoints/app/agent-command apps/agent/entrypoints/sidepanel/index` (exits 0; existing warnings remain in active-turn/route-test files)

Hermes ACP docs referenced: https://hermes-agent.nousresearch.com/docs/user-guide/features/acp