### PR TITLE
fix(agent): keep ChatSessionProvider mounted across /home/* navigations

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/App.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/App.tsx
@@ -87,7 +87,7 @@ export const App: FC = () => {
           {/* Home routes */}
           <Route
             path="home"
-            element={<NewTabLayout useChatSessionOnHome={!alphaEnabled} />}
+            element={<NewTabLayout />}
           >
             {alphaEnabled ? (
               <>

--- a/packages/browseros-agent/apps/agent/entrypoints/newtab/layout/NewTabLayout.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/newtab/layout/NewTabLayout.tsx
@@ -2,21 +2,11 @@ import type { FC } from 'react'
 import { Outlet, useLocation } from 'react-router'
 import { ChatSessionProvider } from '@/entrypoints/sidepanel/layout/ChatSessionContext'
 import { NewTabFocusGrid } from './NewTabFocusGrid'
-import { shouldHideFocusGrid, shouldUseChatSession } from './route-utils'
+import { shouldHideFocusGrid } from './route-utils'
 
-interface NewTabLayoutProps {
-  useChatSessionOnHome?: boolean
-}
-
-export const NewTabLayout: FC<NewTabLayoutProps> = ({
-  useChatSessionOnHome = false,
-}) => {
+export const NewTabLayout: FC = () => {
   const location = useLocation()
   const hideGrid = shouldHideFocusGrid(location.pathname)
-  const useChatSession = shouldUseChatSession(
-    location.pathname,
-    useChatSessionOnHome,
-  )
   const content = (
     <>
       {!hideGrid && <NewTabFocusGrid />}
@@ -24,7 +14,9 @@ export const NewTabLayout: FC<NewTabLayoutProps> = ({
     </>
   )
 
-  if (!useChatSession) return content
-
-  return <ChatSessionProvider origin="newtab">{content}</ChatSessionProvider>
+  return (
+    <ChatSessionProvider origin="newtab">
+      {content}
+    </ChatSessionProvider>
+  )
 }

--- a/packages/browseros-agent/apps/agent/entrypoints/newtab/layout/route-utils.test.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/newtab/layout/route-utils.test.ts
@@ -3,19 +3,14 @@ import {
   isAgentCommandPath,
   isAgentConversationPath,
   shouldHideFocusGrid,
-  shouldUseChatSession,
 } from './route-utils'
 
 describe('route-utils', () => {
-  it('treats command center routes as non-chat-session paths', () => {
+  it('correctly identifies agent command center routes', () => {
     expect(isAgentCommandPath('/home')).toBe(true)
     expect(isAgentCommandPath('/home/agents/main')).toBe(true)
     expect(isAgentConversationPath('/home')).toBe(false)
     expect(isAgentConversationPath('/home/agents/main')).toBe(true)
-    expect(shouldUseChatSession('/home')).toBe(false)
-    expect(shouldUseChatSession('/home', true)).toBe(true)
-    expect(shouldUseChatSession('/home/agents/main')).toBe(false)
-    expect(shouldUseChatSession('/home/chat')).toBe(true)
   })
 
   it('hides the focus grid on full-screen routes', () => {

--- a/packages/browseros-agent/apps/agent/entrypoints/newtab/layout/route-utils.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/newtab/layout/route-utils.ts
@@ -19,12 +19,3 @@ export function shouldHideFocusGrid(pathname: string): boolean {
     HIDE_FOCUS_GRID_PATHS.has(pathname) || isAgentConversationPath(pathname)
   )
 }
-
-export function shouldUseChatSession(
-  pathname: string,
-  useChatSessionOnHome = false,
-): boolean {
-  return (
-    pathname === '/home/chat' || (useChatSessionOnHome && pathname === '/home')
-  )
-}


### PR DESCRIPTION
## Summary

Closes #927

`ChatSessionProvider` was conditionally mounted — only rendered when `shouldUseChatSession()` returned `true` (i.e. only on `/home/chat`). Any navigation away from that route unmounted the provider and destroyed the in-memory `useChat` message state. Returning to chat started a fresh session with no history.

- `ChatSessionProvider` now unconditionally wraps all `/home/*` routes
- Removes the dead `shouldUseChatSession` helper function
- Removes the `useChatSessionOnHome` prop from `NewTabLayout`
- Removes associated tests for the removed function

## Test plan

- [ ] Open the newtab chat at `/home/chat`, send a message
- [ ] Navigate to another sub-route (e.g. `/home/skills`, `/home/memory`)
- [ ] Navigate back to `/home/chat` — previous messages should still be visible
- [ ] Verify fresh session still starts on first load (no prior messages on new tab open)
- [ ] Confirm no TypeScript errors (`bun run typecheck`)
