### PR TITLE
fix(server): add .passthrough() to MCP tool output schemas

### DIFF
--- a/packages/browseros-agent/apps/server/src/tools/bookmarks.ts
+++ b/packages/browseros-agent/apps/server/src/tools/bookmarks.ts
@@ -12,7 +12,7 @@ const bookmarkNodeSchema = z.object({
   index: z.number().optional(),
   dateAdded: z.number(),
   dateLastUsed: z.number().optional(),
-})
+}).passthrough()
 
 function formatBookmarkTree(nodes: BookmarkNode[]): string {
   const lines: string[] = []

--- a/packages/browseros-agent/apps/server/src/tools/console.ts
+++ b/packages/browseros-agent/apps/server/src/tools/console.ts
@@ -44,7 +44,7 @@ export const get_console_logs = defineObservationTool({
         url: z.string().optional(),
         lineNumber: z.number().optional(),
         timestamp: z.number(),
-      }),
+      }).passthrough(),
     ),
     totalCount: z.number(),
     returnedCount: z.number(),

--- a/packages/browseros-agent/apps/server/src/tools/history.ts
+++ b/packages/browseros-agent/apps/server/src/tools/history.ts
@@ -9,7 +9,7 @@ const historyItemSchema = z.object({
   lastVisitTime: z.number(),
   visitCount: z.number().optional(),
   typedCount: z.number().optional(),
-})
+}).passthrough()
 
 export const search_history = defineManagementTool({
   name: 'search_history',

--- a/packages/browseros-agent/apps/server/src/tools/navigation.ts
+++ b/packages/browseros-agent/apps/server/src/tools/navigation.ts
@@ -17,7 +17,7 @@ const pageInfoSchema = z.object({
   windowId: z.number().optional(),
   index: z.number().optional(),
   groupId: z.string().optional(),
-})
+}).passthrough()
 
 export const get_active_page = defineNavigationTool({
   name: 'get_active_page',

--- a/packages/browseros-agent/apps/server/src/tools/tab-groups.ts
+++ b/packages/browseros-agent/apps/server/src/tools/tab-groups.ts
@@ -21,7 +21,7 @@ const tabGroupWithPageIdsSchema = z.object({
   color: z.string(),
   collapsed: z.boolean(),
   pageIds: z.array(z.number()),
-})
+}).passthrough()
 
 export const list_tab_groups = defineManagementTool({
   name: 'list_tab_groups',

--- a/packages/browseros-agent/apps/server/src/tools/windows.ts
+++ b/packages/browseros-agent/apps/server/src/tools/windows.ts
@@ -20,12 +20,13 @@ const windowInfoSchema = z.object({
     windowState: z
       .enum(['normal', 'minimized', 'maximized', 'fullscreen'])
       .optional(),
-  }),
+  }).passthrough(),
   isActive: z.boolean(),
   isVisible: z.boolean(),
   tabCount: z.number(),
   activeTabId: z.number().optional(),
-})
+  incognito: z.boolean().optional(),
+}).passthrough()
 
 export const list_windows = defineManagementTool({
   name: 'list_windows',

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_updater.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_updater.cc
@@ -203,11 +203,6 @@ index 0000000000000..9050130727fc8
 +  std::string stdout_output;
 +  std::string stderr_output;
 +
-+  base::LaunchOptions options;
-+#if BUILDFLAG(IS_WIN)
-+  options.start_hidden = true;
-+#endif
-+
 +  // GetAppOutputWithExitCode runs the process and captures output
 +  bool success = base::GetAppOutputAndError(cmd, &stdout_output);
 +

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/process_controller_impl.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/process_controller_impl.cc
@@ -142,6 +142,12 @@ index 0000000000000..d1bb340ae3d86
 +  options.start_hidden = true;
 +#endif
 +
+++#if BUILDFLAG(IS_WIN)
+++  options.environment[L"BROWSEROS_DIR"] = config.paths.execution.value();
+++#else
+++  options.environment["BROWSEROS_DIR"] = config.paths.execution.value();
+++#endif
+++
 +  // Launch the process (blocking I/O)
 +  result.process = base::LaunchProcess(cmd, options);
 +  return result;


### PR DESCRIPTION
## Summary

Closes #929

Chrome APIs return extra fields alongside the known fields in their responses. Zod's default strict mode rejects unknown fields, causing MCP tool failures whenever Chrome returns an unexpected key.

**Root cause:** Zod objects without `.passthrough()` strip (or in structured-output mode, reject) extra keys. Chrome's tab, window, bookmark, history, tab-group, and console APIs all return fields beyond what the schemas declared.

**Changes:**
- `navigation.ts` — `.passthrough()` on `pageInfoSchema` (affects `get_active_page`, `list_pages`, `show_page`, `move_page`)
- `windows.ts` — `.passthrough()` on `windowInfoSchema` + inner `bounds` object; adds missing `incognito` field
- `tab-groups.ts` — `.passthrough()` on `tabGroupWithPageIdsSchema`
- `bookmarks.ts` — `.passthrough()` on `bookmarkNodeSchema`
- `history.ts` — `.passthrough()` on `historyItemSchema`
- `console.ts` — `.passthrough()` on console entry schema
- `browseros_server_updater.cc` — removes misplaced `LaunchOptions` block (belonged in `process_controller_impl.cc`)
- `process_controller_impl.cc` — injects `BROWSEROS_DIR` env var into launched server process (cross-platform)

## Test plan

- [ ] `list_windows` returns results including incognito windows without schema error
- [ ] `list_pages` / `get_active_page` work when Chrome returns extra tab fields
- [ ] `list_tab_groups` returns results without validation failure
- [ ] `get_bookmarks` / `search_bookmarks` work with Chrome's extra bookmark fields
- [ ] `search_history` / `get_recent_history` work correctly
- [ ] `get_console_logs` returns entries without schema rejection
