### PR TITLE
fix(agent): offset sidebar content to prevent overlap on narrow viewports

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/layout/SidebarLayout.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/layout/SidebarLayout.tsx
@@ -85,7 +85,8 @@ export const SidebarLayout: FC = () => {
 
   return (
     <RpcClientProvider>
-      <div className="relative min-h-screen bg-background">
+      {/* pl-14 offsets all content by the collapsed sidebar width (w-14 = 56px) so it never sits under the rail */}
+      <div className="relative min-h-screen bg-background pl-14">
         {/* Sidebar - fixed overlay */}
         {/* biome-ignore lint/a11y/noStaticElementInteractions: hover interactions needed */}
         <div
@@ -96,13 +97,12 @@ export const SidebarLayout: FC = () => {
           <AppSidebar expanded={sidebarOpen} onOpenShortcuts={openShortcuts} />
         </div>
 
-        {/* Main content — offset by the collapsed sidebar width so content never sits under it */}
         {location.pathname === '/home/chat' ? (
-          <main className="relative h-dvh overflow-hidden pl-14">
+          <main className="relative h-dvh overflow-hidden">
             <Outlet />
           </main>
         ) : (
-          <main className="min-h-screen overflow-y-auto pl-14">
+          <main className="min-h-screen overflow-y-auto">
             <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
               <Outlet />
             </div>

--- a/packages/browseros-agent/apps/agent/entrypoints/app/layout/SidebarLayout.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/layout/SidebarLayout.tsx
@@ -96,13 +96,13 @@ export const SidebarLayout: FC = () => {
           <AppSidebar expanded={sidebarOpen} onOpenShortcuts={openShortcuts} />
         </div>
 
-        {/* Main content - full width, centered */}
+        {/* Main content — offset by the collapsed sidebar width so content never sits under it */}
         {location.pathname === '/home/chat' ? (
-          <main className="relative h-dvh overflow-hidden">
+          <main className="relative h-dvh overflow-hidden pl-14">
             <Outlet />
           </main>
         ) : (
-          <main className="min-h-screen overflow-y-auto">
+          <main className="min-h-screen overflow-y-auto pl-14">
             <div className="mx-auto max-w-4xl px-4 py-8 sm:px-6 lg:px-8">
               <Outlet />
             </div>


### PR DESCRIPTION
## Summary

- The fixed overlay sidebar (`w-14` collapsed / `w-64` expanded) had no corresponding left-offset on the main content area, so on viewports narrower than ~1300px the expanded sidebar visually overlapped the left edge of the centered `max-w-4xl` content.
- Added `pl-14` (56px — the collapsed sidebar width) to both `<main>` branches in `SidebarLayout` so content is always offset to the right of the sidebar rail.
- The chat route (`/home/chat`) gets the same fix since it shares the same layout wrapper.

## Design

`SidebarLayout` uses a `fixed inset-y-0 left-0 z-40` overlay for the sidebar. The main content used `mx-auto max-w-4xl` which centers on the full viewport — on a 1280px window the left edge of the content sits at ~192px while the expanded sidebar is 256px wide, causing 64px of overlap. Adding `pl-14` to `<main>` permanently offsets the content by the collapsed sidebar width (56px), so the sidebar never covers the content at rest, and any hover-expanded overlap is a shallow modal overlay on a small area rather than a jarring content shift.

## Test plan

- [ ] Open the Agents page (`/agents`) and verify content starts visibly to the right of the sidebar icon rail
- [ ] Hover over the sidebar — it should expand over the content without the content jumping
- [ ] Check the Home and Scheduled Tasks pages for the same alignment
- [ ] Verify the `/home/chat` full-height layout is not broken
🤖 Generated with [Claude Code](https://claude.com/claude-code)