### PR TITLE
feat(server): ManagedContainer abstraction — Hermes readiness gate + ACP layering fix

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
@@ -629,7 +629,7 @@ export class AgentHarnessService {
       envVarName: mapping.envVarName,
       apiKey: (input.apiKey as string).trim(),
       modelId: (input.modelId as string).trim(),
-      baseUrl: input.baseUrl?.trim() || undefined,
+      baseUrl: input.baseUrl?.trim() || mapping.defaultBaseUrl,
     })
   }
 

--- a/packages/browseros-agent/apps/server/src/api/services/hermes/hermes-container.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/hermes/hermes-container.ts
@@ -47,15 +47,22 @@ export interface HermesContainerServiceConfig {
 }
 
 /**
- * Structural type returned by `getAccessor()` so the ACP runtime can
- * build its `nerdctl exec` command without a hard dep on this module.
- * Wire-compatible with what `acpx-runtime.ts` expects today.
+ * Structural type returned by `getAccessor()` so the ACP runtime
+ * can build its `nerdctl exec` command without a hard dep on this
+ * module. Mirrors `HermesGatewayAccessor` in `acpx-runtime.ts`;
+ * `buildExecArgv` delegates to the underlying
+ * `ManagedContainer.buildExecArgv` so the limactl/nerdctl argv
+ * chain has exactly one owner.
  */
 export interface HermesAccessor {
   getContainerName(): string
   getLimaHomeDir(): string
   getLimactlPath(): string
   getVmName(): string
+  buildExecArgv(spec: {
+    argv: readonly [string, ...string[]]
+    env?: Record<string, string>
+  }): string
 }
 
 export class HermesContainerService {
@@ -145,7 +152,10 @@ export class HermesContainerService {
   /**
    * Live-getters used by AcpxRuntime to spawn `hermes acp` inside
    * the container. Kept structural so the ACP runtime doesn't need
-   * to import this module.
+   * to import this module. `buildExecArgv` delegates to the
+   * underlying `HermesContainer` so the limactl/nerdctl argv chain
+   * has exactly one owner; the four legacy getters are kept for
+   * tests and any caller still constructing the chain by hand.
    */
   getAccessor(): HermesAccessor {
     return {
@@ -153,6 +163,10 @@ export class HermesContainerService {
       getLimaHomeDir: () => this.limaHome,
       getLimactlPath: () => this.limactlPath,
       getVmName: () => VM_NAME,
+      buildExecArgv: (spec) => {
+        const container = this.requireContainer()
+        return container.buildExecArgv(spec)
+      },
     }
   }
 

--- a/packages/browseros-agent/apps/server/src/api/services/hermes/hermes-container.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/hermes/hermes-container.ts
@@ -3,41 +3,40 @@
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
- * Lifecycle service for the Hermes ACPX adapter container. Hermes runs
- * in the same Lima VM as OpenClaw — image is pulled into containerd, an
- * idle container is kept up so the harness can `nerdctl exec hermes acp`
- * per turn. Much smaller than OpenClawService: no gateway, no token, no
- * agent CRUD via container — the harness owns all of that.
+ * Singleton wrapper around `HermesContainer` (the `ManagedContainer`
+ * subclass living in `lib/container/managed/`). Preserves the
+ * existing `HermesContainerService` public surface — `prewarm`,
+ * `start`, `stop`, `restart`, `shutdown`, `getAccessor`, `configure`
+ * — so the existing callers (`main.ts`, `server.ts`,
+ * `agent-harness-service`) compile unchanged in this PR.
+ *
+ * The wrapper is a temporary bridge: in a follow-up PR the
+ * singleton vends the `HermesContainer` directly, the accessor
+ * collapses, and `configure` becomes the constructor option of a
+ * fresh instance instead of a mutating call. Goal here is minimal
+ * blast-radius for the primitives + abstract base introduction.
  */
 
-import { mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
 import {
-  HERMES_CONTAINER_HARNESS_DIR,
   HERMES_CONTAINER_NAME,
   HERMES_IMAGE,
 } from '@browseros/shared/constants/hermes'
 import { getBrowserosDir } from '../../../lib/browseros-dir'
 import {
   ContainerCli,
-  type ContainerSpec,
+  HermesContainer,
   ImageLoader,
 } from '../../../lib/container'
 import { logger } from '../../../lib/logger'
-import { withProcessLock } from '../../../lib/process-lock'
 import {
-  GUEST_VM_STATE,
   getLimaHomeDir,
   resolveBundledLimactl,
   resolveBundledLimaTemplate,
   VM_NAME,
   VmRuntime,
 } from '../../../lib/vm'
-import { ContainerNameInUseError } from '../../../lib/vm/errors'
 import { getHermesHarnessHostDir, getHermesHostStateDir } from './hermes-paths'
-
-const CREATE_CONTAINER_MAX_ATTEMPTS = 3
-const NAME_RELEASE_WAIT_MS = 10_000
 
 const UNSUPPORTED_PLATFORM_MESSAGE =
   'browseros-vm currently supports macOS only; see the Linux/Windows tracking issue'
@@ -47,6 +46,11 @@ export interface HermesContainerServiceConfig {
   browserosDir?: string
 }
 
+/**
+ * Structural type returned by `getAccessor()` so the ACP runtime can
+ * build its `nerdctl exec` command without a hard dep on this module.
+ * Wire-compatible with what `acpx-runtime.ts` expects today.
+ */
 export interface HermesAccessor {
   getContainerName(): string
   getLimaHomeDir(): string
@@ -55,16 +59,13 @@ export interface HermesAccessor {
 }
 
 export class HermesContainerService {
-  private vm: VmRuntime | null = null
-  private shell: ContainerCli | null = null
-  private loader: ImageLoader | null = null
+  private container: HermesContainer | null = null
   private limactlPath: string
   private limaHome: string
   private resourcesDir: string | null
   private browserosDir: string
   private readonly hermesStateDir: string
   private readonly platform: NodeJS.Platform
-  private lifecycleLock: Promise<void> = Promise.resolve()
 
   constructor(config: HermesContainerServiceConfig = {}) {
     this.resourcesDir = config.resourcesDir ?? null
@@ -73,7 +74,7 @@ export class HermesContainerService {
     this.platform = process.platform
     this.limactlPath = this.resolveLimactlPath()
     this.limaHome = getLimaHomeDir(this.browserosDir)
-    this.initRuntimes()
+    this.initContainer()
   }
 
   configure(config: HermesContainerServiceConfig): void {
@@ -95,11 +96,11 @@ export class HermesContainerService {
     if (runtimeChanged) {
       this.limactlPath = this.resolveLimactlPath()
       this.limaHome = getLimaHomeDir(this.browserosDir)
-      this.initRuntimes()
+      this.initContainer()
     }
   }
 
-  /** Warm the VM and Hermes image so first-use spawns avoid registry work. */
+  /** Warm the VM and Hermes image so first-use spawns avoid pulls. */
   async prewarm(onLog?: (msg: string) => void): Promise<void> {
     if (!this.isSupportedPlatform()) {
       logger.warn('Hermes prewarm skipped: unsupported platform', {
@@ -107,26 +108,10 @@ export class HermesContainerService {
       })
       return
     }
-    return this.withLifecycleLock('prewarm', async () => {
-      const logProgress = (message: string) => {
-        logger.info(message)
-        onLog?.(message)
-      }
-      logProgress('Hermes prewarm: ensuring BrowserOS VM is ready')
-      await this.requireVm().ensureReady()
-      logProgress(`Hermes prewarm: ensuring image ${HERMES_IMAGE} is available`)
-      await this.requireLoader().ensureImageLoaded(HERMES_IMAGE)
-      logProgress('Hermes prewarm: ready')
-    })
+    await this.requireContainer().install({ onLog })
   }
 
-  /**
-   * Start a long-running idle container with the harness dir bind-
-   * mounted. The container's default ENTRYPOINT (`hermes acp`) is
-   * overridden with `tini -- sleep infinity` so the container stays
-   * up; the AcpxRuntime spawns `hermes acp` per turn via `nerdctl
-   * exec` and pipes its stdio back through limactl/SSH.
-   */
+  /** Bring the long-running idle container up. */
   async start(onLog?: (msg: string) => void): Promise<void> {
     if (!this.isSupportedPlatform()) {
       logger.warn('Hermes start skipped: unsupported platform', {
@@ -134,43 +119,12 @@ export class HermesContainerService {
       })
       return
     }
-    return this.withLifecycleLock('start', async () => {
-      const logProgress = (msg: string) => {
-        logger.info(msg)
-        onLog?.(msg)
-      }
-      await this.requireVm().ensureReady(logProgress)
-      await this.requireLoader().ensureImageLoaded(HERMES_IMAGE, logProgress)
-
-      // Make sure the host-side harness root exists so the bind-mount
-      // doesn't error on a missing source path. Per-agent home dirs
-      // get created lazily by prepareHermesContext.
-      await mkdir(getHermesHarnessHostDir(this.browserosDir), {
-        recursive: true,
-      })
-
-      logProgress('Hermes: starting idle container...')
-      const container = await this.buildContainerSpec()
-      await this.createContainerWithNameReconcile(container, logProgress)
-      await this.requireShell().startContainer(container.name, logProgress)
-      logProgress(
-        `Hermes container running: ${HERMES_CONTAINER_NAME} (image ${HERMES_IMAGE})`,
-      )
-    })
+    await this.requireContainer().start({ onLog })
   }
 
   async stop(): Promise<void> {
     if (!this.isSupportedPlatform()) return
-    return this.withLifecycleLock('stop', async () => {
-      logger.info('Stopping Hermes container', {
-        container: HERMES_CONTAINER_NAME,
-      })
-      await this.requireShell().removeContainer(
-        HERMES_CONTAINER_NAME,
-        { force: true },
-        undefined,
-      )
-    })
+    await this.requireContainer().stop()
   }
 
   async restart(onLog?: (msg: string) => void): Promise<void> {
@@ -178,24 +132,20 @@ export class HermesContainerService {
     await this.start(onLog)
   }
 
+  /** Best-effort container removal at server shutdown. */
   async shutdown(): Promise<void> {
     if (!this.isSupportedPlatform()) return
     try {
-      await this.requireShell().removeContainer(
-        HERMES_CONTAINER_NAME,
-        { force: true },
-        undefined,
-      )
+      await this.requireContainer().stop()
     } catch {
       // best effort
     }
   }
 
   /**
-   * Live-getters used by AcpxRuntime to spawn `hermes acp` inside the
-   * container. Returned shape matches `HermesGatewayAccessor` in
-   * acpx-runtime — kept structural here so the type wiring works without
-   * a circular import.
+   * Live-getters used by AcpxRuntime to spawn `hermes acp` inside
+   * the container. Kept structural so the ACP runtime doesn't need
+   * to import this module.
    */
   getAccessor(): HermesAccessor {
     return {
@@ -206,7 +156,17 @@ export class HermesContainerService {
     }
   }
 
-  // ── Internal ─────────────────────────────────────────────────────────
+  /**
+   * Hand the underlying `HermesContainer` out so callers that have
+   * been ported to the new abstraction can use its richer surface
+   * (`buildExecArgv`, state subscriptions, path translation).
+   * Returns `null` on unsupported platforms.
+   */
+  getContainer(): HermesContainer | null {
+    return this.container
+  }
+
+  // ── Internal ─────────────────────────────────────────────────────
 
   private isSupportedPlatform(): boolean {
     return this.platform === 'darwin'
@@ -219,14 +179,12 @@ export class HermesContainerService {
       : 'limactl'
   }
 
-  private initRuntimes(): void {
+  private initContainer(): void {
     if (!this.isSupportedPlatform()) {
-      this.vm = null
-      this.shell = null
-      this.loader = null
+      this.container = null
       return
     }
-    this.vm = new VmRuntime({
+    const vm = new VmRuntime({
       limactlPath: this.limactlPath,
       limaHome: this.limaHome,
       templatePath: this.resourcesDir
@@ -234,125 +192,32 @@ export class HermesContainerService {
         : undefined,
       browserosRoot: this.browserosDir,
     })
-    this.shell = new ContainerCli({
+    const cli = new ContainerCli({
       limactlPath: this.limactlPath,
       limaHome: this.limaHome,
       vmName: VM_NAME,
     })
-    this.loader = new ImageLoader(this.shell)
-  }
-
-  private requireVm(): VmRuntime {
-    if (!this.vm) throw unsupportedPlatformError()
-    return this.vm
-  }
-
-  private requireShell(): ContainerCli {
-    if (!this.shell) throw unsupportedPlatformError()
-    return this.shell
-  }
-
-  private requireLoader(): ImageLoader {
-    if (!this.loader) throw unsupportedPlatformError()
-    return this.loader
-  }
-
-  private async buildContainerSpec(): Promise<ContainerSpec> {
-    const guestHarnessDir = `${GUEST_VM_STATE}/hermes/harness`
-    const gateway = await this.requireVm().getDefaultGateway()
-    return {
-      name: HERMES_CONTAINER_NAME,
-      image: HERMES_IMAGE,
-      restart: 'unless-stopped',
-      env: {
-        PYTHONUNBUFFERED: '1',
+    const loader = new ImageLoader(cli)
+    this.container = new HermesContainer(
+      {
+        cli,
+        loader,
+        vm,
+        limactlPath: this.limactlPath,
+        limaHome: this.limaHome,
+        vmName: VM_NAME,
+        lockDir: join(this.hermesStateDir, '.locks'),
       },
-      // Make `host.containers.internal` resolve to the VM's gateway so
-      // hermes inside the container can reach the BrowserOS HTTP server
-      // running on the host (where the BrowserOS MCP /mcp lives). Mirrors
-      // OpenClaw's container-runtime.ts gatewayContainer setup.
-      addHosts: [`host.containers.internal:${gateway}`],
-      mounts: [
-        // Host harness root lives under <browserosDir>/vm/hermes/harness
-        // so it's reachable inside the Lima VM via the existing vm/
-        // mount; container sees it at /data/agents/harness.
-        { source: guestHarnessDir, target: HERMES_CONTAINER_HARNESS_DIR },
-      ],
-      // Override the upstream image's `hermes acp` ENTRYPOINT — we want
-      // a long-lived container that we `nerdctl exec` into per turn,
-      // not one that tries to speak ACP at startup.
-      // Bypass tini and use /bin/sh directly: tini 0.19.0 in the upstream
-      // image getopt-parses any `-x` token (even after the PROGRAM), so
-      // `tini /bin/sh -c "..."` errors with `invalid option -- 'c'`. We
-      // don't need tini reaping zombies for an idle sleeper anyway.
-      entrypoint: '/bin/sh',
-      command: ['-c', 'exec sleep infinity'],
-    }
+      {
+        hermesHarnessHostDir: getHermesHarnessHostDir(this.browserosDir),
+      },
+    )
+    logger.debug('HermesContainer initialised', { image: HERMES_IMAGE })
   }
 
-  /**
-   * Create the fixed-name Hermes container, reconciling stale nerdctl
-   * name ownership. Mirrors the OpenClaw service's reconcile loop.
-   */
-  private async createContainerWithNameReconcile(
-    container: ContainerSpec,
-    onLog?: (msg: string) => void,
-  ): Promise<void> {
-    let attempt = 1
-    const shell = this.requireShell()
-    while (true) {
-      await this.removeContainerAndWait(container.name)
-      try {
-        await shell.createContainer(container, onLog)
-        return
-      } catch (err) {
-        if (
-          !(err instanceof ContainerNameInUseError) ||
-          attempt >= CREATE_CONTAINER_MAX_ATTEMPTS
-        ) {
-          throw err
-        }
-        logger.warn('Hermes container name still in use; retrying create', {
-          containerName: container.name,
-          attempt,
-          maxAttempts: CREATE_CONTAINER_MAX_ATTEMPTS,
-        })
-        attempt++
-      }
-    }
-  }
-
-  private async removeContainerAndWait(containerName: string): Promise<void> {
-    const shell = this.requireShell()
-    await shell.removeContainer(containerName, { force: true }, undefined)
-    await shell.waitForContainerNameRelease(containerName, {
-      timeoutMs: NAME_RELEASE_WAIT_MS,
-      intervalMs: 100,
-    })
-  }
-
-  private async withLifecycleLock<T>(
-    operation: string,
-    fn: () => Promise<T>,
-  ): Promise<T> {
-    const previous = this.lifecycleLock
-    let release!: () => void
-    this.lifecycleLock = new Promise<void>((resolve) => {
-      release = resolve
-    })
-    await previous.catch(() => undefined)
-    try {
-      return await withProcessLock(
-        'hermes-lifecycle',
-        { lockDir: join(this.hermesStateDir, '.locks') },
-        async () => {
-          logger.debug('Hermes lifecycle operation started', { operation })
-          return await fn()
-        },
-      )
-    } finally {
-      release()
-    }
+  private requireContainer(): HermesContainer {
+    if (!this.container) throw unsupportedPlatformError()
+    return this.container
   }
 }
 

--- a/packages/browseros-agent/apps/server/src/api/services/hermes/hermes-paths.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/hermes/hermes-paths.ts
@@ -72,6 +72,15 @@ export async function writeHermesPerAgentProvider(input: {
   })
   await mkdir(home, { recursive: true })
 
+  // Hermes' `provider: custom` requires a `base_url` — without one the
+  // model loader rejects with `unknown provider 'custom'`. Callers that
+  // use a named Hermes provider (e.g. anthropic, openrouter) can omit
+  // baseUrl and Hermes resolves the URL itself.
+  if (input.providerId === 'custom' && !input.baseUrl) {
+    throw new Error(
+      'Hermes provider "custom" requires base_url; set HermesProviderMapping.defaultBaseUrl or supply input.baseUrl',
+    )
+  }
   const yamlLines = [
     'model:',
     `  default: ${JSON.stringify(input.modelId)}`,

--- a/packages/browseros-agent/apps/server/src/api/services/hermes/hermes-provider-map.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/hermes/hermes-provider-map.ts
@@ -27,8 +27,14 @@ export interface HermesProviderMapping {
   hermesProvider: string
   /** Env var Hermes reads the API key from (written into per-agent `.env`). */
   envVarName: string
-  /** True when Hermes needs an explicit `model.base_url` to reach the API. */
+  /** True when the harness must require an explicit baseUrl from input. */
   requiresBaseUrl: boolean
+  /**
+   * Used when `hermesProvider === 'custom'` and the input has no
+   * baseUrl — Hermes treats `provider: custom` as "call this URL
+   * directly", so `base_url` must always end up in config.yaml.
+   */
+  defaultBaseUrl?: string
 }
 
 const HERMES_PROVIDER_MAP: Record<
@@ -40,21 +46,24 @@ const HERMES_PROVIDER_MAP: Record<
     envVarName: 'ANTHROPIC_API_KEY',
     requiresBaseUrl: false,
   },
+  // Hermes (v2026.4.x) has no provider key named `"openai"`. Per the
+  // upstream docs, `provider: custom` + `base_url` is the canonical
+  // shape for any OpenAI-compatible endpoint with an API key — Hermes
+  // skips provider lookup and calls the URL directly. Used for both
+  // pure OpenAI (default base URL) and openai-compatible (caller URL).
   openai: {
-    hermesProvider: 'openai',
+    hermesProvider: 'custom',
     envVarName: 'OPENAI_API_KEY',
     requiresBaseUrl: false,
+    defaultBaseUrl: 'https://api.openai.com/v1',
   },
   openrouter: {
     hermesProvider: 'openrouter',
     envVarName: 'OPENROUTER_API_KEY',
     requiresBaseUrl: false,
   },
-  // BrowserOS' "openai-compatible" type is anything that speaks the OpenAI
-  // wire format on a custom base URL (Together, Groq, etc.). Hermes routes
-  // these through its `openai` provider with `base_url` set.
   'openai-compatible': {
-    hermesProvider: 'openai',
+    hermesProvider: 'custom',
     envVarName: 'OPENAI_API_KEY',
     requiresBaseUrl: true,
   },

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
@@ -62,10 +62,16 @@ export interface OpenclawGatewayAccessor {
 }
 
 /**
- * Live-getter access to the Hermes container runtime info. Required
- * when spawning the hermes ACP adapter inside its long-running idle
+ * Live-getter access to the Hermes container runtime. Required when
+ * spawning the hermes ACP adapter inside its long-running idle
  * container; absent only in tests / dev fallback (where the harness
- * still falls back to a host-process `hermes acp` spawn).
+ * falls back to a host-process `hermes acp` spawn).
+ *
+ * `buildExecArgv` is the new single source of truth for the
+ * `env LIMA_HOME=… limactl shell <vm> -- nerdctl exec -i …` chain.
+ * The pre-existing four getters stay so callers that build the
+ * argv themselves (legacy paths, tests) continue to work; the ACP
+ * runtime now goes through `buildExecArgv` exclusively.
  */
 export interface HermesGatewayAccessor {
   /** Container name e.g. browseros-hermes-hermes-agent-1. */
@@ -76,6 +82,15 @@ export interface HermesGatewayAccessor {
   getLimactlPath(): string
   /** VM name registered in LIMA_HOME (e.g. browseros-vm). */
   getVmName(): string
+  /**
+   * Build the shell-command string acpx-core will spawn to run
+   * `argv` inside the Hermes container. Owned by the underlying
+   * `ManagedContainer`. Pure builder; no state side effects.
+   */
+  buildExecArgv(spec: {
+    argv: readonly [string, ...string[]]
+    env?: Record<string, string>
+  }): string
 }
 
 type AcpxRuntimeOptions = {
@@ -761,62 +776,31 @@ function createBrowserosAgentRegistry(input: {
 
 /**
  * Builds the command string acpx will spawn for a `hermes` adapter.
- * Runs `hermes acp` inside the long-running Hermes container via the
- * bundled `limactl shell <vm> -- nerdctl exec -i ...` chain so the
- * upstream image's `hermes` binary is reused; BrowserOS does not
- * require a host-side hermes install.
+ * Runs `hermes acp` inside the long-running Hermes container via
+ * the bundled `limactl shell <vm> -- nerdctl exec -i ...` chain.
  *
- * HERMES_HOME inside the container points at the per-agent home
- * directory (translated from the host-side path by prepareHermesContext)
- * so each BrowserOS agent stays isolated.
+ * The argv chain itself is built by the gateway accessor's
+ * `buildExecArgv` (delegates to `ManagedContainer.buildExecArgv`)
+ * so this function stays out of the limactl/nerdctl business. The
+ * single command env merger here adds `PYTHONUNBUFFERED=1` (sticky
+ * on the container, re-added for safety) on top of caller-supplied
+ * env (typically `HERMES_HOME`, a /data/... path set by
+ * `prepareHermesContext`).
  *
- * Stdio: with `limactl shell -- nerdctl exec`, hermes' stdio inside the
- * container is a real pipe(2), and bytes flow back through limactl/SSH
- * to the harness. The Bun↔Python socketpair workaround that the
- * Phase A host-process spawn needed (`bash -c "... | tee /dev/null"`) is
- * unnecessary here because the multiple pipe→socket conversions
- * naturally absorb the issue.
+ * The upstream nousresearch/hermes-agent image installs hermes
+ * into `/opt/hermes/.venv/bin/hermes` (note the leading dot). PATH
+ * isn't set up for arbitrary `nerdctl exec` calls because we
+ * override the entrypoint to keep the container idle, so the
+ * absolute path is used here.
  */
 function resolveHermesAcpCommand(
   gateway: HermesGatewayAccessor,
   commandEnv: Record<string, string>,
 ): string {
-  const limactl = gateway.getLimactlPath()
-  const vm = gateway.getVmName()
-  const container = gateway.getContainerName()
-  const limaHome = gateway.getLimaHomeDir()
-
-  // Build `nerdctl exec -i -e <K=V> ... <container> hermes acp`. The
-  // commandEnv typically carries HERMES_HOME (a /data/... path inside
-  // the container set by prepareHermesContext); pass each value through
-  // `-e` so hermes sees them, even though the env itself was set on the
-  // host process. PYTHONUNBUFFERED is sticky on the container; we
-  // re-add it here for safety.
-  const argv = [
-    'env',
-    `LIMA_HOME=${limaHome}`,
-    limactl,
-    'shell',
-    '--workdir',
-    '/',
-    vm,
-    '--',
-    'nerdctl',
-    'exec',
-    '-i',
-    '-e',
-    'PYTHONUNBUFFERED=1',
-  ]
-  for (const [key, value] of Object.entries(commandEnv)) {
-    argv.push('-e', `${key}=${value}`)
-  }
-  // The upstream nousresearch/hermes-agent image installs hermes into
-  // /opt/hermes/.venv/bin (note the leading dot). It's not on PATH for
-  // arbitrary `nerdctl exec` calls — the image's own entrypoint script
-  // sets the PATH but we override the entrypoint to keep the container
-  // idle, so we use the absolute path here.
-  argv.push(container, '/opt/hermes/.venv/bin/hermes', 'acp')
-  return argv.join(' ')
+  return gateway.buildExecArgv({
+    argv: ['/opt/hermes/.venv/bin/hermes', 'acp'],
+    env: { PYTHONUNBUFFERED: '1', ...commandEnv },
+  })
 }
 
 /**

--- a/packages/browseros-agent/apps/server/src/lib/container/container-cli.ts
+++ b/packages/browseros-agent/apps/server/src/lib/container/container-cli.ts
@@ -8,6 +8,7 @@ import {
   ContainerCliError,
   ContainerNameInUseError,
   ContainerNameReleaseTimeoutError,
+  ContainerNotRunningError,
 } from '../vm/errors'
 import { LimaCli } from '../vm/lima-cli'
 import type {
@@ -17,6 +18,7 @@ import type {
   MountSpec,
   PortMapping,
   WaitForContainerNameReleaseOptions,
+  WaitForContainerRunningOptions,
 } from './types'
 
 export function buildNerdctlCommand(args: string[]): string[] {
@@ -115,6 +117,36 @@ export class ContainerCli {
     }
     if (isNoSuchContainer(result.stderr)) return null
     throw this.commandError(args, result)
+  }
+
+  /**
+   * Poll `nerdctl container inspect` until the container reports
+   * `running: true`. Used by the managed-container layer between
+   * `nerdctl create + start` and "container is ready for `exec`" so
+   * the harness never spawns a turn against a half-started container.
+   *
+   * Distinct from `waitForContainerNameRelease`, which waits for the
+   * container to disappear after `rm`. Defaults are sized for a
+   * cold-start: 30 s budget at 500 ms cadence (60 polls). Caller can
+   * tighten for tests via `opts`.
+   */
+  async waitForContainerRunning(
+    name: string,
+    opts: WaitForContainerRunningOptions = {},
+  ): Promise<void> {
+    const timeoutMs = opts.timeoutMs ?? 30_000
+    const intervalMs = opts.intervalMs ?? 500
+    const startedAt = Date.now()
+
+    while (Date.now() - startedAt <= timeoutMs) {
+      const info = await this.inspectContainer(name)
+      if (info?.running === true) return
+      const remainingMs = timeoutMs - (Date.now() - startedAt)
+      if (remainingMs <= 0) break
+      await Bun.sleep(Math.min(intervalMs, remainingMs))
+    }
+
+    throw new ContainerNotRunningError(name, timeoutMs)
   }
 
   /** Wait for containerd/nerdctl to stop resolving a container name after rm. */

--- a/packages/browseros-agent/apps/server/src/lib/container/index.ts
+++ b/packages/browseros-agent/apps/server/src/lib/container/index.ts
@@ -6,4 +6,5 @@
 
 export * from './container-cli'
 export * from './image-loader'
+export * from './managed'
 export * from './types'

--- a/packages/browseros-agent/apps/server/src/lib/container/managed/errors.ts
+++ b/packages/browseros-agent/apps/server/src/lib/container/managed/errors.ts
@@ -1,0 +1,71 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ContainerState } from './types'
+
+/**
+ * Thrown by `ManagedContainer.execProcess` / `execOneShot` when the
+ * container isn't in `running` state and can't be made ready in time
+ * (or shouldn't be — `errored` and `not_installed` are terminal until
+ * the user takes action). The harness route layer catches this and
+ * surfaces a structured error frame on the chat SSE so the UI can
+ * render an actionable banner instead of a silent broken turn.
+ *
+ * `reason` discriminates so the UI can pick the right next-action:
+ * - `not_installed` → "Set up containers"
+ * - `installing` / `starting` → "Container is starting, please wait"
+ * - `stopped` → "Start container"
+ * - `errored` → "Reset container"
+ * - `timeout` → "Container is taking too long, try again"
+ */
+export class ContainerNotReadyError extends Error {
+  constructor(
+    public readonly state: ContainerState,
+    public readonly containerId: string,
+    public readonly reason:
+      | 'not_installed'
+      | 'installing'
+      | 'starting'
+      | 'stopped'
+      | 'errored'
+      | 'timeout',
+    public readonly hint: string,
+    public readonly lastError?: string | null,
+  ) {
+    super(
+      `Container "${containerId}" is not ready (state=${state}, reason=${reason}): ${hint}` +
+        (lastError ? ` — last error: ${lastError}` : ''),
+    )
+    this.name = 'ContainerNotReadyError'
+  }
+}
+
+/** Thrown when a `reset(level)` arrives with a level that the
+ *  current `ManagedContainer` implementation doesn't support yet
+ *  (e.g. `'hard'` requires a `VmService` that hasn't shipped). */
+export class ResetNotSupportedError extends Error {
+  constructor(
+    public readonly level: string,
+    message = `reset(${level}) is not supported in this build`,
+  ) {
+    super(message)
+    this.name = 'ResetNotSupportedError'
+  }
+}
+
+/** Thrown by `toContainerPath` / `toHostPath` when the input path
+ *  doesn't sit under any declared mount root. */
+export class PathOutsideMountsError extends Error {
+  constructor(
+    public readonly path: string,
+    public readonly direction: 'host->container' | 'container->host',
+  ) {
+    super(
+      `Path "${path}" is not inside any declared mount root for direction ${direction}`,
+    )
+    this.name = 'PathOutsideMountsError'
+  }
+}

--- a/packages/browseros-agent/apps/server/src/lib/container/managed/hermes-container.ts
+++ b/packages/browseros-agent/apps/server/src/lib/container/managed/hermes-container.ts
@@ -1,0 +1,120 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Hermes-specific subclass of `ManagedContainer`. Provides image,
+ * container spec, readiness probe, and mount roots — all the
+ * adapter-specific bits. The base class handles state, lifecycle,
+ * and the gated execute family.
+ *
+ * Lives under `lib/container/managed/` (not `api/services/hermes/`)
+ * so it has no dependency on the harness layer. The wrapper at
+ * `api/services/hermes/hermes-container.ts` glues this into the
+ * existing service singleton + accessor surface so callers like
+ * `main.ts` / `server.ts` don't need to change in this PR.
+ */
+
+import {
+  HERMES_CONTAINER_HARNESS_DIR,
+  HERMES_CONTAINER_NAME,
+  HERMES_IMAGE,
+} from '@browseros/shared/constants/hermes'
+import { GUEST_VM_STATE } from '../../vm'
+import type { ContainerSpec } from '../types'
+import { ManagedContainer } from './managed-container'
+import type { ContainerDescriptor, MountRoot } from './types'
+
+export interface HermesContainerConfig {
+  /** Host-side directory where Hermes per-agent home dirs live. */
+  hermesHarnessHostDir: string
+}
+
+export class HermesContainer extends ManagedContainer {
+  readonly descriptor: ContainerDescriptor = {
+    adapterId: 'hermes',
+    displayName: 'Hermes',
+    defaultImage: HERMES_IMAGE,
+    containerName: HERMES_CONTAINER_NAME,
+    platforms: ['darwin'],
+    // Hermes has no HTTP probe; we exec `hermes --version` instead
+    // (see `readinessProbe` below). Generous timeout because the
+    // first exec inside a freshly-started container can be slow.
+    readinessProbe: { timeoutMs: 30_000, intervalMs: 500 },
+  }
+
+  // Stored separately because Phase 1 wires the wrapper through
+  // `ManagedContainerDeps`; later phases will make this a
+  // first-class config option.
+  private readonly hermesConfig: HermesContainerConfig
+
+  constructor(
+    deps: ConstructorParameters<typeof ManagedContainer>[0],
+    config: HermesContainerConfig,
+  ) {
+    super(deps)
+    this.hermesConfig = config
+  }
+
+  protected mountRoots(): readonly MountRoot[] {
+    return [
+      {
+        hostPath: this.hermesConfig.hermesHarnessHostDir,
+        containerPath: HERMES_CONTAINER_HARNESS_DIR,
+        kind: 'shared',
+      },
+    ]
+  }
+
+  protected async buildContainerSpec(): Promise<ContainerSpec> {
+    // The bind-mount source is an in-VM path, not the host path —
+    // Lima's bundled mount already exposes <browserosDir>/vm/ to the
+    // VM at GUEST_VM_STATE, so nerdctl sees the harness dir at
+    // `${GUEST_VM_STATE}/hermes/harness`. mountRoots() above declares
+    // the *logical* host↔container mapping for path-translation use.
+    const guestHarnessDir = `${GUEST_VM_STATE}/hermes/harness`
+    const gateway = await this.deps.vm.getDefaultGateway()
+    return {
+      name: HERMES_CONTAINER_NAME,
+      image: HERMES_IMAGE,
+      restart: 'unless-stopped',
+      env: { PYTHONUNBUFFERED: '1' },
+      // host.containers.internal → VM gateway so hermes inside the
+      // container can reach the BrowserOS HTTP server running on the
+      // host (BrowserOS MCP /mcp).
+      addHosts: [`host.containers.internal:${gateway}`],
+      mounts: [
+        { source: guestHarnessDir, target: HERMES_CONTAINER_HARNESS_DIR },
+      ],
+      // Override the upstream image's `hermes acp` ENTRYPOINT — we
+      // want a long-lived idle container that we `nerdctl exec` into
+      // per turn. Bypass tini (0.19.0 getopt-parses `-x` even after
+      // the PROGRAM, so `tini /bin/sh -c "…"` errors).
+      entrypoint: '/bin/sh',
+      command: ['-c', 'exec sleep infinity'],
+    }
+  }
+
+  /**
+   * Container-running is already checked by the base via
+   * `cli.waitForContainerRunning` before this runs. Here we add an
+   * exec-based liveness check: `hermes --version` exits 0. Catches
+   * the failure mode where the container daemon thinks it's running
+   * but the embedded Python venv is broken or the binary is missing.
+   *
+   * This must NOT go through `execProcess` — that would deadlock on
+   * the state gate (we're in `starting`, not `running`). Use the
+   * lower-level `cli.exec` directly.
+   */
+  protected async readinessProbe(): Promise<boolean> {
+    try {
+      const exitCode = await this.deps.cli.exec(this.descriptor.containerName, [
+        '/opt/hermes/.venv/bin/hermes',
+        '--version',
+      ])
+      return exitCode === 0
+    } catch {
+      return false
+    }
+  }
+}

--- a/packages/browseros-agent/apps/server/src/lib/container/managed/hermes-container.ts
+++ b/packages/browseros-agent/apps/server/src/lib/container/managed/hermes-container.ts
@@ -43,9 +43,6 @@ export class HermesContainer extends ManagedContainer {
     readinessProbe: { timeoutMs: 30_000, intervalMs: 500 },
   }
 
-  // Stored separately because Phase 1 wires the wrapper through
-  // `ManagedContainerDeps`; later phases will make this a
-  // first-class config option.
   private readonly hermesConfig: HermesContainerConfig
 
   constructor(

--- a/packages/browseros-agent/apps/server/src/lib/container/managed/index.ts
+++ b/packages/browseros-agent/apps/server/src/lib/container/managed/index.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+export {
+  ContainerNotReadyError,
+  PathOutsideMountsError,
+  ResetNotSupportedError,
+} from './errors'
+export {
+  ManagedContainer,
+  type ManagedContainerDeps,
+  type StateListener,
+  type Unsubscribe,
+} from './managed-container'
+export type {
+  ContainerDescriptor,
+  ContainerState,
+  ContainerStatusSnapshot,
+  ExecResult,
+  ExecSpec,
+  MountRoot,
+  Platform,
+  ResetLevel,
+  ResetOptions,
+} from './types'
+export { TRANSIENT_STATES } from './types'

--- a/packages/browseros-agent/apps/server/src/lib/container/managed/index.ts
+++ b/packages/browseros-agent/apps/server/src/lib/container/managed/index.ts
@@ -10,6 +10,10 @@ export {
   ResetNotSupportedError,
 } from './errors'
 export {
+  HermesContainer,
+  type HermesContainerConfig,
+} from './hermes-container'
+export {
   ManagedContainer,
   type ManagedContainerDeps,
   type StateListener,

--- a/packages/browseros-agent/apps/server/src/lib/container/managed/managed-container.ts
+++ b/packages/browseros-agent/apps/server/src/lib/container/managed/managed-container.ts
@@ -283,10 +283,9 @@ export abstract class ManagedContainer {
    * `execGateTimeoutMs` (default 60s). Returns Bun's spawned process
    * — caller owns stdio piping and `exit`.
    *
-   * NOTE: Phase 1 implementation is minimal — sufficient for the
-   * `execOneShot` convenience and for tests that need to verify the
-   * gating semantics. The ACP runtime continues to use
-   * `buildExecArgv` directly because acpx-core does its own spawn.
+   * The ACP runtime continues to use `buildExecArgv` directly
+   * because acpx-core does its own spawn; this entry point exists
+   * for `execOneShot` and for callers that want to own stdio.
    */
   async execProcess(
     spec: ExecSpec,

--- a/packages/browseros-agent/apps/server/src/lib/container/managed/managed-container.ts
+++ b/packages/browseros-agent/apps/server/src/lib/container/managed/managed-container.ts
@@ -1,0 +1,530 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Abstract base for every container-backed agent adapter. Owns the
+ * state machine, lifecycle lock, and the gated `execute*` family.
+ * Subclasses provide image / spec / readiness probe / mount roots —
+ * see `./types.ts` for the contract.
+ *
+ * Layering: this lives at the container-orchestration boundary.
+ * Anything above (harness, ACP runtime, HTTP routes, UI) talks to
+ * the abstraction; anything below (`ContainerCli`, `VmRuntime`,
+ * `ImageLoader`) is plumbed through the constructor. The ACP layer
+ * never imports `limactl`, `LIMA_HOME`, or container names again —
+ * `buildExecArgv` is the single owner of that string.
+ */
+
+import { logger } from '../../logger'
+import { withProcessLock } from '../../process-lock'
+import type { VmRuntime } from '../../vm/vm-runtime'
+import type { ContainerCli } from '../container-cli'
+import type { ImageLoader } from '../image-loader'
+import type { ContainerSpec } from '../types'
+import {
+  ContainerNotReadyError,
+  PathOutsideMountsError,
+  ResetNotSupportedError,
+} from './errors'
+import type {
+  ContainerDescriptor,
+  ContainerState,
+  ContainerStatusSnapshot,
+  ExecResult,
+  ExecSpec,
+  MountRoot,
+  ResetLevel,
+  ResetOptions,
+} from './types'
+
+export interface ManagedContainerDeps {
+  cli: ContainerCli
+  loader: ImageLoader
+  vm: VmRuntime
+  /** Absolute path to the bundled `limactl`. */
+  limactlPath: string
+  /** `LIMA_HOME` env value to scope limactl to BrowserOS's VM dir. */
+  limaHome: string
+  /** Lima VM name (today: a single shared VM). */
+  vmName: string
+  /** Process-lock dir for serialising lifecycle ops across processes. */
+  lockDir: string
+}
+
+export type StateListener = (state: ContainerState) => void
+export type Unsubscribe = () => void
+
+/** Default budget for `execProcess` / `execOneShot` to wait through
+ *  a `starting` state. After this, throws `ContainerNotReadyError`
+ *  with `reason: 'timeout'`. */
+const DEFAULT_EXEC_GATE_TIMEOUT_MS = 60_000
+
+export abstract class ManagedContainer {
+  // ── Subclass contract ───────────────────────────────────────────
+  abstract readonly descriptor: ContainerDescriptor
+  protected abstract buildContainerSpec(): Promise<ContainerSpec>
+  protected abstract readinessProbe(): Promise<boolean>
+  protected abstract mountRoots(): readonly MountRoot[]
+
+  // ── State ───────────────────────────────────────────────────────
+  protected state: ContainerState = 'not_installed'
+  protected lastError: string | null = null
+  protected lastErrorAt: number | null = null
+  private listeners = new Set<StateListener>()
+
+  // Promise chain so concurrent lifecycle calls serialise within this
+  // process. Cross-process serialisation lives in `withProcessLock`
+  // below. Same pattern as today's HermesContainerService.
+  private lifecycleLock: Promise<void> = Promise.resolve()
+
+  constructor(protected readonly deps: ManagedContainerDeps) {}
+
+  // ── State surface ───────────────────────────────────────────────
+
+  getState(): ContainerState {
+    return this.state
+  }
+
+  /** Returns an unsubscribe handle. Listeners fire on every transition. */
+  subscribeState(listener: StateListener): Unsubscribe {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  getStatusSnapshot(): ContainerStatusSnapshot {
+    return {
+      adapterId: this.descriptor.adapterId,
+      containerName: this.descriptor.containerName,
+      state: this.state,
+      lastError: this.lastError,
+      lastErrorAt: this.lastErrorAt,
+    }
+  }
+
+  protected setState(next: ContainerState, errorMessage?: string): void {
+    if (next === this.state && !errorMessage) return
+    const prev = this.state
+    this.state = next
+    if (errorMessage !== undefined) {
+      this.lastError = errorMessage
+      this.lastErrorAt = Date.now()
+    } else if (next === 'running') {
+      // Successful reach to running clears the last error.
+      this.lastError = null
+      this.lastErrorAt = null
+    }
+    logger.debug('ManagedContainer state transition', {
+      adapterId: this.descriptor.adapterId,
+      from: prev,
+      to: next,
+      error: errorMessage,
+    })
+    for (const listener of this.listeners) {
+      try {
+        listener(next)
+      } catch (err) {
+        // Listener bugs must not derail the state machine.
+        logger.warn('ManagedContainer state listener threw', {
+          adapterId: this.descriptor.adapterId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
+  }
+
+  // ── Lifecycle ───────────────────────────────────────────────────
+
+  /**
+   * Pull the image into the VM's containerd store. Idempotent — if
+   * the image is already present, transitions through `installing →
+   * installed` immediately.
+   */
+  async install(opts: { onLog?: (msg: string) => void } = {}): Promise<void> {
+    return this.withLifecycleLock('install', async () => {
+      if (this.state === 'running' || this.state === 'starting') return
+      this.setState('installing')
+      try {
+        await this.deps.loader.ensureImageLoaded(
+          this.descriptor.defaultImage,
+          opts.onLog,
+        )
+        this.setState('installed')
+      } catch (err) {
+        this.setState(
+          'errored',
+          err instanceof Error ? err.message : String(err),
+        )
+        throw err
+      }
+    })
+  }
+
+  /**
+   * Bring the container to `running`. Encapsulates: ensure VM ready,
+   * ensure image, recreate container from current spec, start it,
+   * wait for the daemon to report `running`, run the readiness
+   * probe. Each phase transitions state so subscribers see progress.
+   */
+  async start(opts: { onLog?: (msg: string) => void } = {}): Promise<void> {
+    return this.withLifecycleLock('start', async () => {
+      if (this.state === 'running') return
+      const log = (msg: string) => {
+        logger.info(msg, { adapterId: this.descriptor.adapterId })
+        opts.onLog?.(msg)
+      }
+      try {
+        await this.deps.vm.ensureReady(log)
+        this.setState('installing')
+        await this.deps.loader.ensureImageLoaded(
+          this.descriptor.defaultImage,
+          log,
+        )
+        this.setState('starting')
+        const spec = await this.buildContainerSpec()
+        // Always recreate so spec changes take effect on restart. The
+        // existing container (if any) is force-removed first.
+        await this.deps.cli.removeContainer(spec.name, { force: true })
+        await this.deps.cli.waitForContainerNameRelease(spec.name, {
+          timeoutMs: 10_000,
+          intervalMs: 100,
+        })
+        await this.deps.cli.createContainer(spec, log)
+        await this.deps.cli.startContainer(spec.name, log)
+        const probeOpts = this.descriptor.readinessProbe
+        await this.deps.cli.waitForContainerRunning(spec.name, {
+          timeoutMs: probeOpts?.timeoutMs ?? 30_000,
+          intervalMs: probeOpts?.intervalMs ?? 500,
+        })
+        // Run the subclass-defined probe — usually a `--version` exec
+        // or HTTP /readyz call. Failing this is errored, not stopped.
+        const probeOk = await this.readinessProbe()
+        if (!probeOk) {
+          this.setState(
+            'errored',
+            'Readiness probe failed after container reached running state',
+          )
+          throw new Error(`${this.descriptor.adapterId} readiness probe failed`)
+        }
+        this.setState('running')
+      } catch (err) {
+        if (this.state !== 'errored') {
+          this.setState(
+            'errored',
+            err instanceof Error ? err.message : String(err),
+          )
+        }
+        throw err
+      }
+    })
+  }
+
+  /** Stop and remove the container. Image and per-agent data preserved. */
+  async stop(): Promise<void> {
+    return this.withLifecycleLock('stop', async () => {
+      try {
+        await this.deps.cli.removeContainer(this.descriptor.containerName, {
+          force: true,
+        })
+        // Stop is forward-friendly even from `errored` — the user is
+        // explicitly asking for a clean state.
+        this.setState('stopped')
+      } catch (err) {
+        // A stop failure is mostly cosmetic; we still want stopped to
+        // be the user's reality. Log and recover.
+        logger.warn('ManagedContainer stop failed', {
+          adapterId: this.descriptor.adapterId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+        this.setState('stopped')
+      }
+    })
+  }
+
+  async restart(opts: { onLog?: (msg: string) => void } = {}): Promise<void> {
+    await this.stop()
+    await this.start(opts)
+  }
+
+  /**
+   * Reset is intentionally a stub here — it pins the API shape so the
+   * follow-up PR can land without revving the abstract class. The
+   * follow-up will implement `'soft'` (= restart), `'wipe-agent'`
+   * (= soft + `rm -rf` per-agent home dir), and `'hard'` (delegated
+   * to a `VmService` that hasn't shipped yet).
+   */
+  async reset(level: ResetLevel, _opts: ResetOptions = {}): Promise<void> {
+    throw new ResetNotSupportedError(
+      level,
+      `reset(${level}) is not implemented yet — wired in a follow-up PR`,
+    )
+  }
+
+  // ── Execute family ──────────────────────────────────────────────
+
+  /**
+   * Build the shell-command string acpx-core would spawn for an
+   * `ExecSpec`. Pure builder; does NOT gate on state. Callers that
+   * need state gating (i.e. anyone other than acpx-core which has
+   * its own scheduling) should use `execProcess` / `execOneShot`.
+   *
+   * Returned string is intended for `sh -c …` consumption — see
+   * `acpx-runtime.ts` for the historical context.
+   */
+  buildExecArgv(spec: ExecSpec): string {
+    return this.buildExecArgvArray(spec).join(' ')
+  }
+
+  /**
+   * Spawn a long-lived child process inside the container, gated on
+   * `state === 'running'`. Waits through `starting` up to
+   * `execGateTimeoutMs` (default 60s). Returns Bun's spawned process
+   * — caller owns stdio piping and `exit`.
+   *
+   * NOTE: Phase 1 implementation is minimal — sufficient for the
+   * `execOneShot` convenience and for tests that need to verify the
+   * gating semantics. The ACP runtime continues to use
+   * `buildExecArgv` directly because acpx-core does its own spawn.
+   */
+  async execProcess(
+    spec: ExecSpec,
+    opts: { execGateTimeoutMs?: number } = {},
+  ): Promise<Bun.Subprocess<'pipe', 'pipe', 'pipe'>> {
+    await this.waitForRunning(
+      opts.execGateTimeoutMs ?? DEFAULT_EXEC_GATE_TIMEOUT_MS,
+    )
+    const argv = this.buildExecArgvArray(spec)
+    return Bun.spawn(argv, {
+      stdin: 'pipe',
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+  }
+
+  /**
+   * Convenience wrapper for short-lived commands the harness or
+   * control-panel might need (cleanup, version checks, diagnostics).
+   * Buffers stdio and returns once the process exits.
+   */
+  async execOneShot(
+    spec: ExecSpec,
+    opts: { execGateTimeoutMs?: number; processTimeoutMs?: number } = {},
+  ): Promise<ExecResult> {
+    const proc = await this.execProcess(spec, {
+      execGateTimeoutMs: opts.execGateTimeoutMs,
+    })
+    if (opts.processTimeoutMs !== undefined) {
+      const timer = setTimeout(() => {
+        try {
+          proc.kill()
+        } catch {
+          // best-effort
+        }
+      }, opts.processTimeoutMs)
+      proc.exited.finally(() => clearTimeout(timer))
+    }
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+    return { exitCode, stdout, stderr }
+  }
+
+  // ── Filesystem ──────────────────────────────────────────────────
+
+  /**
+   * Translate a host path under one of the declared mount roots into
+   * the path the container sees. Throws `PathOutsideMountsError` for
+   * paths that don't sit under any mount.
+   */
+  toContainerPath(hostPath: string): string {
+    const normalized = normalizePath(hostPath)
+    for (const mount of this.mountRoots()) {
+      const root = normalizePath(mount.hostPath)
+      if (isPathInside(root, normalized)) {
+        const suffix = normalized.slice(root.length)
+        return joinContainerPath(mount.containerPath, suffix)
+      }
+    }
+    throw new PathOutsideMountsError(hostPath, 'host->container')
+  }
+
+  /** Inverse of `toContainerPath`. */
+  toHostPath(containerPath: string): string {
+    const normalized = normalizePath(containerPath)
+    for (const mount of this.mountRoots()) {
+      const root = normalizePath(mount.containerPath)
+      if (isPathInside(root, normalized)) {
+        const suffix = normalized.slice(root.length)
+        return joinContainerPath(mount.hostPath, suffix)
+      }
+    }
+    throw new PathOutsideMountsError(containerPath, 'container->host')
+  }
+
+  // ── Internals ───────────────────────────────────────────────────
+
+  /**
+   * Build the argv array we'd hand to `Bun.spawn` to run `spec`
+   * inside the container. Pure — no state side effects. Single
+   * source of truth for the limactl/nerdctl chain so the ACP layer
+   * never has to know about it (closes the §4.1 leak from the
+   * audit).
+   */
+  private buildExecArgvArray(spec: ExecSpec): string[] {
+    const argv = [
+      'env',
+      `LIMA_HOME=${this.deps.limaHome}`,
+      this.deps.limactlPath,
+      'shell',
+      '--workdir',
+      '/',
+      this.deps.vmName,
+      '--',
+      'nerdctl',
+      'exec',
+      '-i',
+    ]
+    for (const [key, value] of Object.entries(spec.env ?? {})) {
+      argv.push('-e', `${key}=${value}`)
+    }
+    argv.push(this.descriptor.containerName, ...spec.argv)
+    return argv
+  }
+
+  /**
+   * Resolve once the container is `running`, or throw a typed
+   * `ContainerNotReadyError`. `installing` / `starting` callers wait
+   * up to `timeoutMs`. `not_installed` / `stopped` / `errored` reject
+   * immediately — caller is expected to call `install()` / `start()`
+   * / `reset()` first. Used by `execProcess`.
+   */
+  protected async waitForRunning(timeoutMs: number): Promise<void> {
+    if (this.state === 'running') return
+    if (this.state === 'not_installed') {
+      throw new ContainerNotReadyError(
+        this.state,
+        this.descriptor.containerName,
+        'not_installed',
+        'Container image has not been pulled. Call install() first.',
+        this.lastError,
+      )
+    }
+    if (this.state === 'stopped') {
+      throw new ContainerNotReadyError(
+        this.state,
+        this.descriptor.containerName,
+        'stopped',
+        'Container is stopped. Call start() first.',
+        this.lastError,
+      )
+    }
+    if (this.state === 'errored') {
+      throw new ContainerNotReadyError(
+        this.state,
+        this.descriptor.containerName,
+        'errored',
+        'Container has hit a terminal error. Reset to recover.',
+        this.lastError,
+      )
+    }
+
+    // 'installing' or 'starting' — wait for either 'running' or
+    // 'errored', whichever comes first, with a timeout.
+    return new Promise<void>((resolve, reject) => {
+      let settled = false
+      const timer = setTimeout(() => {
+        if (settled) return
+        settled = true
+        unsubscribe()
+        reject(
+          new ContainerNotReadyError(
+            this.state,
+            this.descriptor.containerName,
+            'timeout',
+            `Timed out after ${timeoutMs}ms waiting for container to reach running state.`,
+            this.lastError,
+          ),
+        )
+      }, timeoutMs)
+      const unsubscribe = this.subscribeState((s) => {
+        if (settled) return
+        if (s === 'running') {
+          settled = true
+          clearTimeout(timer)
+          unsubscribe()
+          resolve()
+        } else if (s === 'errored') {
+          settled = true
+          clearTimeout(timer)
+          unsubscribe()
+          reject(
+            new ContainerNotReadyError(
+              'errored',
+              this.descriptor.containerName,
+              'errored',
+              'Container hit a terminal error while we were waiting.',
+              this.lastError,
+            ),
+          )
+        }
+      })
+    })
+  }
+
+  /**
+   * Serialise lifecycle operations both within this process (via the
+   * promise chain) and across processes (via file-lock). Mirrors the
+   * pattern in today's HermesContainerService / OpenClawService.
+   */
+  private async withLifecycleLock<T>(
+    operation: string,
+    fn: () => Promise<T>,
+  ): Promise<T> {
+    const previous = this.lifecycleLock
+    let release!: () => void
+    this.lifecycleLock = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    await previous.catch(() => undefined)
+    try {
+      return await withProcessLock(
+        `${this.descriptor.adapterId}-lifecycle`,
+        { lockDir: this.deps.lockDir },
+        async () => {
+          logger.debug('ManagedContainer lifecycle op started', {
+            adapterId: this.descriptor.adapterId,
+            operation,
+          })
+          return await fn()
+        },
+      )
+    } finally {
+      release()
+    }
+  }
+}
+
+// ── Path helpers (kept private to this module) ──────────────────────
+
+function normalizePath(p: string): string {
+  // Strip trailing slashes, collapse repeats. Leave leading slash
+  // alone so absolute paths stay absolute.
+  let out = p.replace(/\/+/g, '/')
+  if (out.length > 1 && out.endsWith('/')) out = out.slice(0, -1)
+  return out
+}
+
+function isPathInside(root: string, candidate: string): boolean {
+  if (candidate === root) return true
+  return candidate.startsWith(`${root}/`)
+}
+
+function joinContainerPath(base: string, suffix: string): string {
+  if (!suffix) return base
+  if (suffix.startsWith('/')) return `${base}${suffix}`
+  return `${base}/${suffix}`
+}

--- a/packages/browseros-agent/apps/server/src/lib/container/managed/managed-container.ts
+++ b/packages/browseros-agent/apps/server/src/lib/container/managed/managed-container.ts
@@ -145,8 +145,14 @@ export abstract class ManagedContainer {
   async install(opts: { onLog?: (msg: string) => void } = {}): Promise<void> {
     return this.withLifecycleLock('install', async () => {
       if (this.state === 'running' || this.state === 'starting') return
-      this.setState('installing')
       try {
+        // Image ops run inside the Lima VM, so the VM has to be up
+        // before nerdctl can pull. On cold boot this method is the
+        // first lifecycle call to win the lock, so the ensure has to
+        // happen here too — `start()` having its own ensure is not
+        // enough.
+        await this.deps.vm.ensureReady(opts.onLog)
+        this.setState('installing')
         await this.deps.loader.ensureImageLoaded(
           this.descriptor.defaultImage,
           opts.onLog,

--- a/packages/browseros-agent/apps/server/src/lib/container/managed/types.ts
+++ b/packages/browseros-agent/apps/server/src/lib/container/managed/types.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Types shared by the abstract `ManagedContainer` base and its
+ * subclasses. Kept in their own file so the base class file can stay
+ * focused on behaviour.
+ */
+
+/** Subset of `NodeJS.Platform` — kept loose so a future Linux add
+ *  doesn't require touching the abstraction. */
+export type Platform = NodeJS.Platform
+
+/** State the container is in, viewed from the harness's perspective. */
+export type ContainerState =
+  | 'not_installed'
+  | 'installing'
+  | 'installed'
+  | 'starting'
+  | 'running'
+  | 'stopped'
+  | 'errored'
+
+/** Subset of the state machine that callers should treat as "may
+ *  resolve to running on its own with time" — `execProcess` and
+ *  friends wait through these. Callers checking `isReady()` use this. */
+export const TRANSIENT_STATES: ReadonlySet<ContainerState> = new Set([
+  'installing',
+  'starting',
+])
+
+export interface ContainerDescriptor {
+  /** Stable id matching `agent.adapter` for harness lookups. */
+  adapterId: string
+  /** Human-readable label for UI. */
+  displayName: string
+  /** Image ref to pull on `install()`. */
+  defaultImage: string
+  /** Fixed container name inside the VM. */
+  containerName: string
+  /** Platforms where this container is supported (today: ['darwin']). */
+  platforms: ReadonlyArray<Platform>
+  /** Optional probe tuning. */
+  readinessProbe?: {
+    timeoutMs?: number
+    intervalMs?: number
+  }
+}
+
+/**
+ * Mount root the container exposes. `kind` is informational —
+ * `'shared'` mounts are bind-mounted once and used by every agent;
+ * `'per-agent'` mounts are bind-mounted per agent and the harness's
+ * agent-delete flow is expected to clean them up. Both are
+ * containment-checked by `toContainerPath` / `toHostPath`.
+ */
+export interface MountRoot {
+  hostPath: string
+  containerPath: string
+  kind: 'shared' | 'per-agent'
+}
+
+export interface ContainerStatusSnapshot {
+  adapterId: string
+  containerName: string
+  state: ContainerState
+  lastError: string | null
+  lastErrorAt: number | null
+}
+
+/** What the caller wants to run inside the container. */
+export interface ExecSpec {
+  /** Argv inside the container — first element is the executable. */
+  argv: readonly [string, ...string[]]
+  env?: Record<string, string>
+}
+
+export interface ExecResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+/** Reset granularity — see the architecture doc / team brief. */
+export type ResetLevel = 'soft' | 'wipe-agent' | 'hard'
+
+export interface ResetOptions {
+  /** Required for `level === 'wipe-agent'` — agent id whose home dir
+   *  should be removed. Ignored for soft/hard. */
+  agentId?: string
+  onLog?: (msg: string) => void
+}

--- a/packages/browseros-agent/apps/server/src/lib/container/types.ts
+++ b/packages/browseros-agent/apps/server/src/lib/container/types.ts
@@ -59,6 +59,11 @@ export interface WaitForContainerNameReleaseOptions {
   intervalMs?: number
 }
 
+export interface WaitForContainerRunningOptions {
+  timeoutMs?: number
+  intervalMs?: number
+}
+
 export interface LogLine {
   stream: 'stdout' | 'stderr'
   line: string

--- a/packages/browseros-agent/apps/server/src/lib/vm/errors.ts
+++ b/packages/browseros-agent/apps/server/src/lib/vm/errors.ts
@@ -63,6 +63,25 @@ export class ContainerNameReleaseTimeoutError extends VmError {
   }
 }
 
+/**
+ * Container's process never reached `running` state within the
+ * timeout window. Distinct from `ContainerNameReleaseTimeoutError`
+ * (which is about deletion). Thrown by
+ * `ContainerCli.waitForContainerRunning` and surfaced by the
+ * managed-container layer when a `start()` finishes the create+start
+ * commands but the container hasn't actually come up.
+ */
+export class ContainerNotRunningError extends VmError {
+  constructor(
+    public readonly containerName: string,
+    public readonly timeoutMs: number,
+  ) {
+    super(
+      `Timed out waiting ${timeoutMs}ms for container "${containerName}" to reach running state`,
+    )
+  }
+}
+
 export class ImageLoadError extends VmError {
   constructor(
     public readonly imageRef: string,

--- a/packages/browseros-agent/apps/server/tests/api/services/agents/agent-harness-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/agents/agent-harness-service.test.ts
@@ -531,7 +531,7 @@ describe('AgentHarnessService', () => {
     expect(agents).toHaveLength(0)
   })
 
-  it('writes Hermes per-agent base_url for openai-compatible providers (mapped to Hermes openai key)', async () => {
+  it('writes provider:custom + base_url for openai-compatible providers', async () => {
     const agents: AgentDefinition[] = []
     const browserosDir = mkdtempSync(join(tmpdir(), 'browseros-hermes-test-'))
     const service = new AgentHarnessService({
@@ -559,12 +559,47 @@ describe('AgentHarnessService', () => {
     )
     const yaml = readFileSync(join(homeDir, 'config.yaml'), 'utf8')
     const env = readFileSync(join(homeDir, '.env'), 'utf8')
-    // BrowserOS' openai-compatible type routes through Hermes' `openai`
-    // provider with base_url set.
-    expect(yaml).toContain('"openai"')
+    // Hermes has no provider key called "openai" — the canonical shape
+    // for any OpenAI-compatible endpoint is `provider: custom` with
+    // `base_url` set. Hermes then short-circuits provider lookup and
+    // calls the URL directly using OPENAI_API_KEY.
+    expect(yaml).toContain('"custom"')
     expect(yaml).toContain('"my-model"')
     expect(yaml).toContain('"https://api.example.com/v1"')
     expect(env).toContain('OPENAI_API_KEY=sk-test')
+  })
+
+  it('falls back to OpenAI default base_url for the openai provider type', async () => {
+    const agents: AgentDefinition[] = []
+    const browserosDir = mkdtempSync(join(tmpdir(), 'browseros-hermes-test-'))
+    const service = new AgentHarnessService({
+      agentStore: createAgentStore(agents) as AgentStore,
+      runtime: stubRuntime(),
+      browserosDir,
+    })
+
+    const agent = await service.createAgent({
+      name: 'OpenAI Hermes',
+      adapter: 'hermes',
+      providerType: 'openai',
+      apiKey: 'sk-openai-test',
+      modelId: 'gpt-4o-mini',
+      // No baseUrl supplied — provider:custom still requires one,
+      // so the mapping's defaultBaseUrl must take over.
+    })
+
+    const homeDir = join(
+      browserosDir,
+      'vm',
+      'hermes',
+      'harness',
+      agent.id,
+      'home',
+    )
+    const yaml = readFileSync(join(homeDir, 'config.yaml'), 'utf8')
+    expect(yaml).toContain('"custom"')
+    expect(yaml).toContain('"gpt-4o-mini"')
+    expect(yaml).toContain('"https://api.openai.com/v1"')
   })
 
   it('rejects openai-compatible Hermes agent creation when baseUrl is missing', async () => {

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -970,6 +970,28 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
         getLimaHomeDir: () => '/Users/dev/.browseros-dev/lima',
         getLimactlPath: () => '/opt/homebrew/bin/limactl',
         getVmName: () => 'browseros-vm',
+        // Mirrors ManagedContainer.buildExecArgv — kept inline so the
+        // test doesn't depend on the production class wiring.
+        buildExecArgv: (spec) => {
+          const argv = [
+            'env',
+            'LIMA_HOME=/Users/dev/.browseros-dev/lima',
+            '/opt/homebrew/bin/limactl',
+            'shell',
+            '--workdir',
+            '/',
+            'browseros-vm',
+            '--',
+            'nerdctl',
+            'exec',
+            '-i',
+          ]
+          for (const [key, value] of Object.entries(spec.env ?? {})) {
+            argv.push('-e', `${key}=${value}`)
+          }
+          argv.push('browseros-hermes-hermes-agent-1', ...spec.argv)
+          return argv.join(' ')
+        },
       },
       runtimeFactory: (options) => {
         calls.push({ method: 'createRuntime', input: options })

--- a/packages/browseros-agent/apps/server/tests/lib/container/managed/hermes-container.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/container/managed/hermes-container.test.ts
@@ -1,0 +1,193 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtempSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  HERMES_CONTAINER_HARNESS_DIR,
+  HERMES_CONTAINER_NAME,
+  HERMES_IMAGE,
+} from '../../../../../../packages/shared/src/constants/hermes'
+import {
+  HermesContainer,
+  type ManagedContainerDeps,
+} from '../../../../src/lib/container/managed'
+import type {
+  ContainerInfo,
+  ContainerSpec,
+} from '../../../../src/lib/container/types'
+
+interface FakeCli {
+  inspectContainer: (name: string) => Promise<ContainerInfo | null>
+  removeContainer: (name: string, opts?: { force?: boolean }) => Promise<void>
+  waitForContainerNameRelease: () => Promise<void>
+  createContainer: (spec: ContainerSpec) => Promise<void>
+  startContainer: (name: string) => Promise<void>
+  waitForContainerRunning: (name: string) => Promise<void>
+  exec: (name: string, cmd: string[]) => Promise<number>
+}
+
+function makeDeps(opts: {
+  lockDir: string
+  exec?: (name: string, cmd: string[]) => Promise<number>
+}): {
+  deps: ManagedContainerDeps
+  getCapturedSpec: () => ContainerSpec | null
+} {
+  let capturedSpec: ContainerSpec | null = null
+  const fakeCli = {
+    inspectContainer: async (): Promise<ContainerInfo | null> => ({
+      id: 'cid',
+      name: HERMES_CONTAINER_NAME,
+      image: HERMES_IMAGE,
+      status: 'running',
+      running: true,
+    }),
+    removeContainer: async () => {},
+    waitForContainerNameRelease: async () => {},
+    createContainer: async (spec: ContainerSpec) => {
+      capturedSpec = spec
+    },
+    startContainer: async () => {},
+    waitForContainerRunning: async () => {},
+    exec: opts.exec ?? (async () => 0),
+  } satisfies FakeCli
+  const fakeLoader = {
+    ensureImageLoaded: async () => {},
+  }
+  const fakeVm = {
+    ensureReady: async () => {},
+    getDefaultGateway: async () => '192.168.5.2',
+  }
+  const deps: ManagedContainerDeps = {
+    cli: fakeCli as unknown as ManagedContainerDeps['cli'],
+    loader: fakeLoader as unknown as ManagedContainerDeps['loader'],
+    vm: fakeVm as unknown as ManagedContainerDeps['vm'],
+    limactlPath: '/opt/homebrew/bin/limactl',
+    limaHome: '/Users/dev/.browseros/lima',
+    vmName: 'browseros-vm',
+    lockDir: opts.lockDir,
+  }
+  return { deps, getCapturedSpec: () => capturedSpec }
+}
+
+describe('HermesContainer', () => {
+  const tempDirs: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true })),
+    )
+    tempDirs.length = 0
+  })
+
+  function mkTempDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'hermes-container-test-'))
+    tempDirs.push(dir)
+    return dir
+  }
+
+  it('declares the canonical Hermes descriptor', () => {
+    const lockDir = mkTempDir()
+    const { deps } = makeDeps({ lockDir })
+    const c = new HermesContainer(deps, {
+      hermesHarnessHostDir: '/host/hermes/harness',
+    })
+
+    expect(c.descriptor.adapterId).toBe('hermes')
+    expect(c.descriptor.containerName).toBe(HERMES_CONTAINER_NAME)
+    expect(c.descriptor.defaultImage).toBe(HERMES_IMAGE)
+    expect(c.descriptor.platforms).toContain('darwin')
+  })
+
+  it('start() reaches running and runs hermes --version probe', async () => {
+    const lockDir = mkTempDir()
+    let probeCmd: string[] | null = null
+    const { deps } = makeDeps({
+      lockDir,
+      exec: async (_name, cmd) => {
+        probeCmd = cmd
+        return 0
+      },
+    })
+    const c = new HermesContainer(deps, {
+      hermesHarnessHostDir: '/host/hermes/harness',
+    })
+
+    await c.start()
+
+    expect(c.getState()).toBe('running')
+    expect(probeCmd).toEqual(['/opt/hermes/.venv/bin/hermes', '--version'])
+  })
+
+  it('start() lands errored when probe exits non-zero', async () => {
+    const lockDir = mkTempDir()
+    const { deps } = makeDeps({
+      lockDir,
+      exec: async () => 1,
+    })
+    const c = new HermesContainer(deps, {
+      hermesHarnessHostDir: '/host/hermes/harness',
+    })
+
+    await expect(c.start()).rejects.toThrow(/probe failed/i)
+    expect(c.getState()).toBe('errored')
+  })
+
+  it('builds a ContainerSpec with idle entrypoint + harness mount + add-host', async () => {
+    const lockDir = mkTempDir()
+    const { deps, getCapturedSpec } = makeDeps({ lockDir })
+    const c = new HermesContainer(deps, {
+      hermesHarnessHostDir: '/host/hermes/harness',
+    })
+
+    await c.start()
+
+    const spec = getCapturedSpec()
+    if (!spec) throw new Error('createContainer was never called')
+    expect(spec.entrypoint).toBe('/bin/sh')
+    expect(spec.command).toEqual(['-c', 'exec sleep infinity'])
+    expect(spec.addHosts).toContain('host.containers.internal:192.168.5.2')
+    const harnessMount = spec.mounts?.find(
+      (m) => m.target === HERMES_CONTAINER_HARNESS_DIR,
+    )
+    if (!harnessMount) throw new Error('harness mount missing')
+    expect(harnessMount.source).toBe('/mnt/browseros/vm/hermes/harness')
+  })
+
+  it('toContainerPath maps host harness dir to /data/agents/harness', () => {
+    const lockDir = mkTempDir()
+    const { deps } = makeDeps({ lockDir })
+    const c = new HermesContainer(deps, {
+      hermesHarnessHostDir: '/host/hermes/harness',
+    })
+
+    expect(c.toContainerPath('/host/hermes/harness/agent-01/home/x.txt')).toBe(
+      `${HERMES_CONTAINER_HARNESS_DIR}/agent-01/home/x.txt`,
+    )
+  })
+
+  it('buildExecArgv produces the canonical Hermes ACP spawn string', () => {
+    const lockDir = mkTempDir()
+    const { deps } = makeDeps({ lockDir })
+    const c = new HermesContainer(deps, {
+      hermesHarnessHostDir: '/host/hermes/harness',
+    })
+
+    const out = c.buildExecArgv({
+      argv: ['/opt/hermes/.venv/bin/hermes', 'acp'],
+      env: { HERMES_HOME: '/data/agents/harness/a/home' },
+    })
+    expect(out).toContain('LIMA_HOME=/Users/dev/.browseros/lima')
+    expect(out).toContain('shell --workdir / browseros-vm --')
+    expect(out).toContain('nerdctl exec -i')
+    expect(out).toContain(HERMES_CONTAINER_NAME)
+    expect(out).toContain('/opt/hermes/.venv/bin/hermes acp')
+    expect(out).toContain('-e HERMES_HOME=/data/agents/harness/a/home')
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/lib/container/managed/managed-container.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/container/managed/managed-container.test.ts
@@ -318,7 +318,7 @@ describe('ManagedContainer', () => {
   })
 
   describe('reset', () => {
-    it('throws ResetNotSupportedError for every level (Phase 1 stub)', async () => {
+    it('throws ResetNotSupportedError for every level', async () => {
       const lockDir = mkTempDir()
       const deps = makeFakeDeps({ lockDir })
       const c = new TestContainer(deps)

--- a/packages/browseros-agent/apps/server/tests/lib/container/managed/managed-container.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/container/managed/managed-container.test.ts
@@ -1,0 +1,390 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtempSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  ContainerNotReadyError,
+  type ContainerState,
+  ManagedContainer,
+  type ManagedContainerDeps,
+  type MountRoot,
+  PathOutsideMountsError,
+  ResetNotSupportedError,
+} from '../../../../src/lib/container/managed'
+import type {
+  ContainerInfo,
+  ContainerSpec,
+} from '../../../../src/lib/container/types'
+
+interface FakeCli {
+  inspectContainer: (name: string) => Promise<ContainerInfo | null>
+  removeContainer: (name: string, opts?: { force?: boolean }) => Promise<void>
+  waitForContainerNameRelease: () => Promise<void>
+  createContainer: (spec: ContainerSpec) => Promise<void>
+  startContainer: (name: string) => Promise<void>
+  waitForContainerRunning: (name: string) => Promise<void>
+  exec: (name: string, cmd: string[]) => Promise<number>
+}
+
+interface FakeLoader {
+  ensureImageLoaded: (ref: string) => Promise<void>
+}
+
+interface FakeVm {
+  ensureReady: () => Promise<void>
+  getDefaultGateway: () => Promise<string>
+}
+
+class TestContainer extends ManagedContainer {
+  readonly descriptor = {
+    adapterId: 'test',
+    displayName: 'Test',
+    defaultImage: 'docker.io/test:latest',
+    containerName: 'test-container',
+    platforms: ['darwin' as NodeJS.Platform],
+  }
+
+  probeOutcome: boolean | Error = true
+  probeCalls = 0
+
+  protected mountRoots(): readonly MountRoot[] {
+    return [
+      {
+        hostPath: '/host/root',
+        containerPath: '/data/root',
+        kind: 'shared',
+      },
+    ]
+  }
+
+  protected async buildContainerSpec(): Promise<ContainerSpec> {
+    return {
+      name: this.descriptor.containerName,
+      image: this.descriptor.defaultImage,
+      env: { FOO: 'bar' },
+    }
+  }
+
+  protected async readinessProbe(): Promise<boolean> {
+    this.probeCalls += 1
+    if (this.probeOutcome instanceof Error) throw this.probeOutcome
+    return this.probeOutcome
+  }
+
+  // Expose the protected helper for one specific test.
+  triggerErrored(message: string) {
+    // biome-ignore lint/complexity/useLiteralKeys: protected method access for tests
+    this['setState']('errored', message)
+  }
+}
+
+function makeFakeDeps(opts: { lockDir: string }): ManagedContainerDeps & {
+  fakeCli: FakeCli
+  fakeLoader: FakeLoader
+  fakeVm: FakeVm
+} {
+  const fakeCli: FakeCli = {
+    inspectContainer: async () => ({
+      id: 'cid',
+      name: 'test-container',
+      image: 'docker.io/test:latest',
+      status: 'running',
+      running: true,
+    }),
+    removeContainer: async () => {},
+    waitForContainerNameRelease: async () => {},
+    createContainer: async () => {},
+    startContainer: async () => {},
+    waitForContainerRunning: async () => {},
+    exec: async () => 0,
+  }
+  const fakeLoader: FakeLoader = {
+    ensureImageLoaded: async () => {},
+  }
+  const fakeVm: FakeVm = {
+    ensureReady: async () => {},
+    getDefaultGateway: async () => '192.168.5.2',
+  }
+  return {
+    cli: fakeCli as unknown as ManagedContainerDeps['cli'],
+    loader: fakeLoader as unknown as ManagedContainerDeps['loader'],
+    vm: fakeVm as unknown as ManagedContainerDeps['vm'],
+    limactlPath: '/opt/homebrew/bin/limactl',
+    limaHome: '/Users/dev/.browseros/lima',
+    vmName: 'browseros-vm',
+    lockDir: opts.lockDir,
+    fakeCli,
+    fakeLoader,
+    fakeVm,
+  }
+}
+
+describe('ManagedContainer', () => {
+  const tempDirs: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true })),
+    )
+    tempDirs.length = 0
+  })
+
+  function mkTempDir(): string {
+    const dir = mkdtempSync(join(tmpdir(), 'managed-container-test-'))
+    tempDirs.push(dir)
+    return dir
+  }
+
+  describe('state machine', () => {
+    it('transitions through start() to running', async () => {
+      const lockDir = mkTempDir()
+      const deps = makeFakeDeps({ lockDir })
+      const c = new TestContainer(deps)
+      const transitions: ContainerState[] = []
+      c.subscribeState((s) => transitions.push(s))
+
+      expect(c.getState()).toBe('not_installed')
+      await c.start()
+
+      expect(c.getState()).toBe('running')
+      // installing → starting → running (the base goes through these
+      // phases on every start).
+      expect(transitions).toEqual(['installing', 'starting', 'running'])
+    })
+
+    it('lands in errored when readiness probe returns false', async () => {
+      const lockDir = mkTempDir()
+      const deps = makeFakeDeps({ lockDir })
+      const c = new TestContainer(deps)
+      c.probeOutcome = false
+
+      await expect(c.start()).rejects.toThrow(/probe failed/i)
+      expect(c.getState()).toBe('errored')
+      expect(c.getStatusSnapshot().lastError).toMatch(/probe failed/i)
+    })
+
+    it('stop() force-transitions to stopped even from errored', async () => {
+      const lockDir = mkTempDir()
+      const deps = makeFakeDeps({ lockDir })
+      const c = new TestContainer(deps)
+      c.probeOutcome = false
+      await expect(c.start()).rejects.toThrow()
+      expect(c.getState()).toBe('errored')
+
+      await c.stop()
+      expect(c.getState()).toBe('stopped')
+    })
+  })
+
+  describe('execProcess gating', () => {
+    it('rejects with ContainerNotReadyError when not_installed', async () => {
+      const lockDir = mkTempDir()
+      const deps = makeFakeDeps({ lockDir })
+      const c = new TestContainer(deps)
+
+      await expect(
+        c.execProcess({ argv: ['/bin/echo', 'hi'] }),
+      ).rejects.toBeInstanceOf(ContainerNotReadyError)
+
+      try {
+        await c.execProcess({ argv: ['/bin/echo', 'hi'] })
+      } catch (err) {
+        if (err instanceof ContainerNotReadyError) {
+          expect(err.reason).toBe('not_installed')
+          expect(err.state).toBe('not_installed')
+          expect(err.containerId).toBe('test-container')
+        }
+      }
+    })
+
+    it('rejects with reason=errored when in errored state', async () => {
+      const lockDir = mkTempDir()
+      const deps = makeFakeDeps({ lockDir })
+      const c = new TestContainer(deps)
+      c.triggerErrored('probe boom')
+
+      try {
+        await c.execProcess({ argv: ['/bin/echo', 'hi'] })
+        throw new Error('unreachable')
+      } catch (err) {
+        expect(err).toBeInstanceOf(ContainerNotReadyError)
+        if (err instanceof ContainerNotReadyError) {
+          expect(err.reason).toBe('errored')
+          expect(err.lastError).toBe('probe boom')
+        }
+      }
+    })
+
+    it('waits through starting and resolves when running', async () => {
+      const lockDir = mkTempDir()
+      const deps = makeFakeDeps({ lockDir })
+      const c = new TestContainer(deps)
+      // Skip directly to a starting state without running the start
+      // pipeline, then flip to running asynchronously.
+      // biome-ignore lint/complexity/useLiteralKeys: test reaches into protected
+      c['setState']('starting')
+      // Ensure execProcess waits, not resolves immediately.
+      const execPromise = c.execProcess(
+        {
+          argv: ['/bin/echo', 'hi'],
+          env: { FOO: 'bar' },
+        },
+        { execGateTimeoutMs: 1_000 },
+      )
+      // Flip to running on next tick — execProcess should resolve.
+      setTimeout(() => {
+        // biome-ignore lint/complexity/useLiteralKeys: test reaches into protected
+        c['setState']('running')
+      }, 10)
+      const proc = await execPromise
+      proc.kill()
+      // Bun spawned a real process — it will exit quickly. Drain so
+      // the test doesn't leak resources.
+      await proc.exited.catch(() => undefined)
+    })
+
+    it('rejects with reason=timeout when starting never resolves', async () => {
+      const lockDir = mkTempDir()
+      const deps = makeFakeDeps({ lockDir })
+      const c = new TestContainer(deps)
+      // biome-ignore lint/complexity/useLiteralKeys: test reaches into protected
+      c['setState']('starting')
+
+      try {
+        await c.execProcess(
+          { argv: ['/bin/echo', 'hi'] },
+          { execGateTimeoutMs: 50 },
+        )
+        throw new Error('unreachable')
+      } catch (err) {
+        expect(err).toBeInstanceOf(ContainerNotReadyError)
+        if (err instanceof ContainerNotReadyError) {
+          expect(err.reason).toBe('timeout')
+        }
+      }
+    })
+  })
+
+  describe('buildExecArgv', () => {
+    it('produces the canonical limactl/nerdctl chain', () => {
+      const lockDir = mkTempDir()
+      const deps = makeFakeDeps({ lockDir })
+      const c = new TestContainer(deps)
+
+      const out = c.buildExecArgv({
+        argv: ['/opt/hermes/.venv/bin/hermes', 'acp'],
+        env: { HERMES_HOME: '/data/agents/harness/a/home' },
+      })
+
+      // Single source of truth for the chain — pin the exact string
+      // so future edits are explicit.
+      expect(out).toBe(
+        [
+          'env',
+          'LIMA_HOME=/Users/dev/.browseros/lima',
+          '/opt/homebrew/bin/limactl',
+          'shell',
+          '--workdir',
+          '/',
+          'browseros-vm',
+          '--',
+          'nerdctl',
+          'exec',
+          '-i',
+          '-e',
+          'HERMES_HOME=/data/agents/harness/a/home',
+          'test-container',
+          '/opt/hermes/.venv/bin/hermes',
+          'acp',
+        ].join(' '),
+      )
+    })
+
+    it('omits -e flags when env is empty', () => {
+      const lockDir = mkTempDir()
+      const deps = makeFakeDeps({ lockDir })
+      const c = new TestContainer(deps)
+
+      const out = c.buildExecArgv({ argv: ['/bin/version'] })
+      expect(out).not.toContain('-e ')
+      expect(out).toContain('test-container /bin/version')
+    })
+  })
+
+  describe('reset', () => {
+    it('throws ResetNotSupportedError for every level (Phase 1 stub)', async () => {
+      const lockDir = mkTempDir()
+      const deps = makeFakeDeps({ lockDir })
+      const c = new TestContainer(deps)
+
+      await expect(c.reset('soft')).rejects.toBeInstanceOf(
+        ResetNotSupportedError,
+      )
+      await expect(c.reset('wipe-agent')).rejects.toBeInstanceOf(
+        ResetNotSupportedError,
+      )
+      await expect(c.reset('hard')).rejects.toBeInstanceOf(
+        ResetNotSupportedError,
+      )
+    })
+  })
+
+  describe('path translation', () => {
+    it('round-trips host ↔ container paths under a declared mount', () => {
+      const lockDir = mkTempDir()
+      const deps = makeFakeDeps({ lockDir })
+      const c = new TestContainer(deps)
+
+      const host = '/host/root/agents/a/home/file.txt'
+      const inContainer = c.toContainerPath(host)
+      expect(inContainer).toBe('/data/root/agents/a/home/file.txt')
+      expect(c.toHostPath(inContainer)).toBe(host)
+    })
+
+    it('rejects host paths outside any declared mount', () => {
+      const lockDir = mkTempDir()
+      const deps = makeFakeDeps({ lockDir })
+      const c = new TestContainer(deps)
+
+      expect(() => c.toContainerPath('/etc/passwd')).toThrow(
+        PathOutsideMountsError,
+      )
+      expect(() => c.toHostPath('/proc/cpuinfo')).toThrow(
+        PathOutsideMountsError,
+      )
+    })
+
+    it('translates the mount root itself (no suffix)', () => {
+      const lockDir = mkTempDir()
+      const deps = makeFakeDeps({ lockDir })
+      const c = new TestContainer(deps)
+
+      expect(c.toContainerPath('/host/root')).toBe('/data/root')
+      expect(c.toHostPath('/data/root')).toBe('/host/root')
+    })
+  })
+
+  describe('subscribeState', () => {
+    it('fires every transition and stops after unsubscribe', async () => {
+      const lockDir = mkTempDir()
+      const deps = makeFakeDeps({ lockDir })
+      const c = new TestContainer(deps)
+      const transitions: ContainerState[] = []
+      const unsubscribe = c.subscribeState((s) => transitions.push(s))
+
+      await c.start()
+      expect(transitions.at(-1)).toBe('running')
+
+      unsubscribe()
+      await c.stop()
+      // No new transitions recorded after unsubscribe.
+      expect(transitions.at(-1)).toBe('running')
+    })
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/lib/container/managed/managed-container.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/container/managed/managed-container.test.ts
@@ -180,6 +180,24 @@ describe('ManagedContainer', () => {
       await c.stop()
       expect(c.getState()).toBe('stopped')
     })
+
+    it('install() calls vm.ensureReady before loader.ensureImageLoaded (cold-boot regression)', async () => {
+      const lockDir = mkTempDir()
+      const deps = makeFakeDeps({ lockDir })
+      const calls: string[] = []
+      deps.fakeVm.ensureReady = async () => {
+        calls.push('vm.ensureReady')
+      }
+      deps.fakeLoader.ensureImageLoaded = async () => {
+        calls.push('loader.ensureImageLoaded')
+      }
+      const c = new TestContainer(deps)
+
+      await c.install()
+
+      expect(calls).toEqual(['vm.ensureReady', 'loader.ensureImageLoaded'])
+      expect(c.getState()).toBe('installed')
+    })
   })
 
   describe('execProcess gating', () => {


### PR DESCRIPTION
## Summary

- Introduces `ManagedContainer` (`lib/container/managed/`) — an abstract base every container-backed agent adapter implements. Owns a 7-state machine (`not_installed | installing | installed | starting | running | stopped | errored`), the lifecycle lock (per-process promise chain + cross-process file lock), the gated `execute*` family, and a host↔container path translator. Subclasses provide only the genuinely adapter-specific bits — image, container spec, readiness probe, mount roots.
- Migrates Hermes onto the new base via `HermesContainer`. The existing `HermesContainerService` becomes a thin wrapper preserving its public API (`prewarm` / `start` / `stop` / `restart` / `shutdown` / `getAccessor`) so `main.ts`, `server.ts`, and the harness compile unchanged. OpenClaw stays on its existing service in this PR — its migration opens a much larger surface (gateway, control plane, agent CRUD via container) and is best as a separate change.
- Fixes the silent-first-turn-failure on Hermes. `start()` now waits for `nerdctl inspect.running === true` AND runs a `hermes --version` probe before transitioning the state machine to `running`. Subsequent ACP turns gate on the container actually being ready instead of just on `nerdctl create + start` having returned.
- ACP runtime stops hand-rolling the `env LIMA_HOME=… limactl shell <vm> -- nerdctl exec -i …` argv chain. \`resolveHermesAcpCommand\` collapses to a 3-line call to \`gateway.buildExecArgv()\` — \`HermesGatewayAccessor\` gains one method (\`buildExecArgv\`) which the wrapper delegates to the underlying \`HermesContainer\`. The runtime no longer imports \`limactl\`, \`LIMA_HOME\`, or container names for the Hermes path.
- New container-layer primitive \`ContainerCli.waitForContainerRunning\` plus typed \`ContainerNotRunningError\` and \`ContainerNotReadyError\`. The \`execute*\` family throws \`ContainerNotReadyError\` with a \`reason\` discriminator (\`'not_installed' | 'installing' | 'starting' | 'stopped' | 'errored' | 'timeout'\`) so the harness route layer can surface actionable error frames on the chat SSE instead of silent broken turns.

## Out of scope (deferred to follow-ups)

- OpenClaw migration onto \`ManagedContainer\`.
- A single VM service that owns \`limactl\` lifecycle and coalesces concurrent \`ensureReady()\` calls — eliminates the parallel-start race on cold boot by construction.
- Uniform \`/containers/<adapter>/*\` HTTP route surface (status, lifecycle, logs, dashboard SSE).
- Shared control-panel UI for both adapters + first-time-install progress surface.
- \`reset(level)\` body — base method is on the API but throws \`ResetNotSupportedError\`, so a follow-up wires soft / wipe-agent / hard without revving the abstract class.
- Image-pull progress events (image-loader currently forwards raw \`nerdctl pull\` log lines; structured progress is a separate change).

## Test plan

- [x] \`bun run typecheck\` clean in \`apps/server\`
- [x] \`bun test tests/lib/container/managed/\` — 20 new cases pass (14 covering the abstract base: state transitions, exec gating with all four \`reason\` codes, \`buildExecArgv\` snapshot, \`reset\` stub, path round-trip + \`PathOutsideMountsError\`, \`subscribeState\`. 6 covering the Hermes subclass: descriptor, happy-path \`start\`, probe-fails-→-errored, container spec composition, path translation, exec-argv snapshot.)
- [x] \`bun test tests/api tests/lib\` — 320 existing cases still pass. One pre-existing flake (\`ContainerCli > waits until a container name is no longer resolvable\`) passes solo and flakes only under parallel test load on dev — last touched well before this branch.
- [ ] Cold-boot a Hermes agent and send the first chat before the container is ready → harness surfaces \`ContainerNotReadyError\` with \`reason: 'starting' | 'timeout'\` instead of silently emitting an empty \`done\` SSE frame.
- [ ] Existing Hermes happy-path turn (container already running, file produced) — no behaviour change.
- [ ] Switching to a Codex / Claude agent — no changes; OpenClaw path untouched.