### PR TITLE
feat(runtime): introduce AgentRuntime abstraction (types, interface, registry, abstract bases)

### DIFF
--- a/packages/browseros-agent/apps/server/src/lib/agents/runtime/agent-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/runtime/agent-runtime.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Top-level interface every adapter runtime implements. Two abstract
+ * subclasses (`ContainerAgentRuntime`, `HostProcessAgentRuntime`)
+ * cover the two kinds we ship today.
+ */
+
+import type {
+  ExecSpec,
+  RuntimeAction,
+  RuntimeCapability,
+  RuntimeDescriptor,
+  RuntimeStatusSnapshot,
+  StateListener,
+  Unsubscribe,
+} from './types'
+
+export interface AgentRuntime {
+  readonly descriptor: RuntimeDescriptor
+
+  // ── Status surface (Plane B feed) ────────────────────────────────
+  getStatusSnapshot(): RuntimeStatusSnapshot
+  subscribe(listener: StateListener): Unsubscribe
+  getCapabilities(): ReadonlyArray<RuntimeCapability>
+
+  // ── Action dispatch (Plane B control) ────────────────────────────
+  executeAction(
+    action: RuntimeAction,
+    options?: { onLog?: (msg: string) => void },
+  ): Promise<void>
+
+  // ── ACP plane integration ────────────────────────────────────────
+  /**
+   * Build the shell-command string acpx-core spawns to run `spec`
+   * against this runtime. For container kinds, this is the
+   * `limactl shell <vm> -- nerdctl exec -i …` chain; for host kinds,
+   * it's `env KEY=VAL <binary> <argv...>`.
+   */
+  buildExecArgv(spec: ExecSpec): string
+
+  // ── Filesystem ───────────────────────────────────────────────────
+  /** Per-agent home dir on host. Both kinds expose this; container
+   *  kinds also expose `toContainerPath` for in-container translation. */
+  getPerAgentHomeDir(agentId: string): string
+  toContainerPath?(hostPath: string): string
+  toHostPath?(containerPath: string): string
+}

--- a/packages/browseros-agent/apps/server/src/lib/agents/runtime/container-agent-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/runtime/container-agent-runtime.ts
@@ -1,0 +1,121 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Abstract base for container-backed agent runtimes (openclaw,
+ * hermes). Extends `ManagedContainer` so subclasses keep all the
+ * existing container plumbing (state machine, lifecycle lock, image
+ * load, mount roots, exec gating); adds the runtime-layer surface on
+ * top: descriptor, capability list, action dispatcher, status
+ * snapshot.
+ */
+
+import type {
+  ContainerDescriptor,
+  ContainerStatusSnapshot,
+} from '../../container/managed'
+import { ManagedContainer } from '../../container/managed'
+import type { AgentRuntime } from './agent-runtime'
+import { ActionNotSupportedError } from './errors'
+import type {
+  RuntimeAction,
+  RuntimeCapability,
+  StateListener,
+  Unsubscribe,
+} from './types'
+
+export abstract class ContainerAgentRuntime
+  extends ManagedContainer
+  implements AgentRuntime
+{
+  abstract override readonly descriptor: ContainerDescriptor & {
+    kind: 'container'
+  }
+  abstract getPerAgentHomeDir(agentId: string): string
+
+  /**
+   * Default capability list. Subclasses extend (e.g. OpenClaw adds
+   * `'gateway-control-plane'`) or filter (e.g. drop reset levels the
+   * subclass can't support yet).
+   */
+  getCapabilities(): ReadonlyArray<RuntimeCapability> {
+    return [
+      'install',
+      'start',
+      'stop',
+      'restart',
+      'reset-soft',
+      'reset-wipe-agent',
+      'reset-hard',
+      'logs',
+    ]
+  }
+
+  override getStatusSnapshot(): ContainerStatusSnapshot & {
+    isReady: boolean
+  } {
+    const state = this.getState()
+    return {
+      adapterId: this.descriptor.adapterId,
+      containerName: this.descriptor.containerName,
+      state,
+      isReady: state === 'running',
+      lastError: this.lastError,
+      lastErrorAt: this.lastErrorAt,
+    }
+  }
+
+  subscribe(listener: StateListener): Unsubscribe {
+    return this.subscribeState(() => listener(this.getStatusSnapshot()))
+  }
+
+  async executeAction(
+    action: RuntimeAction,
+    opts: { onLog?: (msg: string) => void } = {},
+  ): Promise<void> {
+    const required = actionToCapability(action)
+    if (!this.getCapabilities().includes(required)) {
+      throw new ActionNotSupportedError(
+        this.descriptor.adapterId,
+        action.type,
+        this.getCapabilities(),
+      )
+    }
+    switch (action.type) {
+      case 'install':
+        return this.install(opts)
+      case 'start':
+        return this.start(opts)
+      case 'stop':
+        return this.stop()
+      case 'restart':
+        return this.restart(opts)
+      case 'reset-soft':
+        return this.reset('soft', opts)
+      case 'reset-wipe-agent':
+        return this.reset('wipe-agent', { ...opts, agentId: action.agentId })
+      case 'reset-hard':
+        return this.reset('hard', opts)
+      default:
+        throw new ActionNotSupportedError(
+          this.descriptor.adapterId,
+          (action as { type: string }).type,
+          this.getCapabilities(),
+        )
+    }
+  }
+}
+
+/**
+ * Map an action variant to the capability key the gate checks. Kept
+ * outside the class so the dispatcher can guard before constructing
+ * any state.
+ */
+function actionToCapability(action: RuntimeAction): RuntimeCapability {
+  // The action.type strings happen to coincide with capability
+  // strings 1:1, so this is currently identity. Pulled out as a
+  // function so the gate can grow more nuanced (e.g. action-specific
+  // sub-capabilities) without re-flowing the dispatcher.
+  return action.type as RuntimeCapability
+}

--- a/packages/browseros-agent/apps/server/src/lib/agents/runtime/errors.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/runtime/errors.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+/**
+ * Thrown when `executeAction` is called with an action that the
+ * runtime's `getCapabilities()` doesn't list. The HTTP route layer
+ * maps this to 405; the UI gates affordances on capabilities so a
+ * well-behaved client should never trip this.
+ */
+export class ActionNotSupportedError extends Error {
+  constructor(
+    public readonly adapterId: string,
+    public readonly actionType: string,
+    public readonly capabilities: ReadonlyArray<string>,
+  ) {
+    super(
+      `Runtime "${adapterId}" does not support action "${actionType}" ` +
+        `(capabilities: ${capabilities.join(', ') || 'none'})`,
+    )
+    this.name = 'ActionNotSupportedError'
+  }
+}
+
+/**
+ * Higher-level "runtime is not ready to take a turn" error. Mirrors
+ * `ContainerNotReadyError` from the container layer but lives at the
+ * runtime layer so callers can differentiate "container abstraction
+ * says no" from "host CLI is missing" without reaching down two
+ * layers.
+ */
+export class RuntimeNotReadyError extends Error {
+  constructor(
+    public readonly adapterId: string,
+    public readonly state: string,
+    public readonly hint: string,
+  ) {
+    super(`Runtime "${adapterId}" is not ready (state=${state}): ${hint}`)
+    this.name = 'RuntimeNotReadyError'
+  }
+}

--- a/packages/browseros-agent/apps/server/src/lib/agents/runtime/host-process-agent-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/runtime/host-process-agent-runtime.ts
@@ -85,6 +85,13 @@ export abstract class HostProcessAgentRuntime implements AgentRuntime {
     action: RuntimeAction,
     _opts: { onLog?: (msg: string) => void } = {},
   ): Promise<void> {
+    if (!this.getCapabilities().includes(action.type as RuntimeCapability)) {
+      throw new ActionNotSupportedError(
+        this.descriptor.adapterId,
+        action.type,
+        this.getCapabilities(),
+      )
+    }
     switch (action.type) {
       case 'reinstall-cli':
         return this.handleReinstallCli()
@@ -121,7 +128,6 @@ export abstract class HostProcessAgentRuntime implements AgentRuntime {
     const cacheMs = this.deps.probeCacheMs ?? DEFAULT_PROBE_CACHE_MS
     const now = Date.now()
     if (!force && now - this.healthCheckedAt < cacheMs) return
-    this.healthCheckedAt = now
 
     const argv = this.deps.versionProbeArgs ?? [
       this.deps.binaryName,
@@ -129,6 +135,10 @@ export abstract class HostProcessAgentRuntime implements AgentRuntime {
     ]
     try {
       const result = await this.runProbe(argv, DEFAULT_PROBE_TIMEOUT_MS)
+      // Only stamp the cache once a definitive result lands. A spawn
+      // throw (binary missing, perm denied) leaves the timestamp
+      // untouched so the next call re-probes immediately.
+      this.healthCheckedAt = Date.now()
       if (result.exitCode === 0) {
         this.binaryVersion = result.stdout.trim() || null
         this.setState('cli_present')

--- a/packages/browseros-agent/apps/server/src/lib/agents/runtime/host-process-agent-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/runtime/host-process-agent-runtime.ts
@@ -1,0 +1,220 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Abstract base for host-process agent runtimes (claude, codex). The
+ * agent process runs from the user's host PATH — no container, no
+ * Lima. This class owns binary discovery, version probing with
+ * caching, and the smaller capability surface that host adapters
+ * support.
+ */
+
+import { logger } from '../../logger'
+import type { AgentRuntime } from './agent-runtime'
+import { ActionNotSupportedError } from './errors'
+import type {
+  ExecSpec,
+  RuntimeAction,
+  RuntimeCapability,
+  RuntimeDescriptor,
+  RuntimeState,
+  RuntimeStatusSnapshot,
+  StateListener,
+  Unsubscribe,
+} from './types'
+
+export interface HostProcessAgentRuntimeDeps {
+  /** Host PATH binary name to probe + spawn (e.g. 'claude', 'codex'). */
+  binaryName: string
+  /** Override the default `<binary> --version` probe argv. */
+  versionProbeArgs?: ReadonlyArray<string>
+  /** Cache window for probe results in ms. Default 5 minutes — same
+   *  as today's adapter-health.ts. */
+  probeCacheMs?: number
+  /** Test seam: spawn the probe via this fn instead of `Bun.$`. */
+  spawnProbe?: (
+    cmd: ReadonlyArray<string>,
+    timeoutMs: number,
+  ) => Promise<{ exitCode: number; stdout: string; stderr: string }>
+}
+
+const DEFAULT_PROBE_CACHE_MS = 5 * 60 * 1000
+const DEFAULT_PROBE_TIMEOUT_MS = 2_000
+
+export abstract class HostProcessAgentRuntime implements AgentRuntime {
+  abstract readonly descriptor: RuntimeDescriptor & { kind: 'host-process' }
+  abstract getPerAgentHomeDir(agentId: string): string
+
+  protected state: RuntimeState = 'cli_missing'
+  protected lastError: string | null = null
+  protected lastErrorAt: number | null = null
+  protected binaryVersion: string | null = null
+  private readonly listeners = new Set<StateListener>()
+  private healthCheckedAt = 0
+
+  constructor(protected readonly deps: HostProcessAgentRuntimeDeps) {}
+
+  // ── Status surface ───────────────────────────────────────────────
+
+  getStatusSnapshot(): RuntimeStatusSnapshot {
+    return {
+      adapterId: this.descriptor.adapterId,
+      state: this.state,
+      isReady: this.state === 'cli_present',
+      lastError: this.lastError,
+      lastErrorAt: this.lastErrorAt,
+      details: { binaryVersion: this.binaryVersion },
+    }
+  }
+
+  subscribe(listener: StateListener): Unsubscribe {
+    this.listeners.add(listener)
+    return () => {
+      this.listeners.delete(listener)
+    }
+  }
+
+  getCapabilities(): ReadonlyArray<RuntimeCapability> {
+    return ['reinstall-cli', 'check-auth']
+  }
+
+  // ── Action dispatch ──────────────────────────────────────────────
+
+  async executeAction(
+    action: RuntimeAction,
+    _opts: { onLog?: (msg: string) => void } = {},
+  ): Promise<void> {
+    switch (action.type) {
+      case 'reinstall-cli':
+        return this.handleReinstallCli()
+      case 'check-auth':
+        return this.checkAuth()
+      default:
+        throw new ActionNotSupportedError(
+          this.descriptor.adapterId,
+          action.type,
+          this.getCapabilities(),
+        )
+    }
+  }
+
+  // ── ACP plane integration ────────────────────────────────────────
+
+  buildExecArgv(spec: ExecSpec): string {
+    // Host binary lives on $PATH — no limactl chain. Compose
+    // `env KEY=val ... <argv...>` so adapters that inject env
+    // (AGENT_HOME, CODEX_HOME) get them on the spawned process.
+    const envParts = Object.entries(spec.env ?? {}).map(([k, v]) => `${k}=${v}`)
+    const prefix = envParts.length > 0 ? `env ${envParts.join(' ')} ` : ''
+    return `${prefix}${spec.argv.join(' ')}`
+  }
+
+  // ── Health probe ─────────────────────────────────────────────────
+
+  /**
+   * Probe `<binary> --version` (override via deps.versionProbeArgs).
+   * Cached for `probeCacheMs`. Updates state + binaryVersion +
+   * fires subscribers. Idempotent within the cache window.
+   */
+  async probeHealth(force = false): Promise<void> {
+    const cacheMs = this.deps.probeCacheMs ?? DEFAULT_PROBE_CACHE_MS
+    const now = Date.now()
+    if (!force && now - this.healthCheckedAt < cacheMs) return
+    this.healthCheckedAt = now
+
+    const argv = this.deps.versionProbeArgs ?? [
+      this.deps.binaryName,
+      '--version',
+    ]
+    try {
+      const result = await this.runProbe(argv, DEFAULT_PROBE_TIMEOUT_MS)
+      if (result.exitCode === 0) {
+        this.binaryVersion = result.stdout.trim() || null
+        this.setState('cli_present')
+      } else {
+        this.binaryVersion = null
+        this.setState(
+          'cli_unhealthy',
+          `${this.deps.binaryName} --version exited ${result.exitCode}: ${result.stderr.trim() || '(no stderr)'}`,
+        )
+      }
+    } catch (err) {
+      // Spawn failure (binary missing, permission denied) — distinct
+      // from a non-zero exit, so the UI can render different copy.
+      this.binaryVersion = null
+      this.setState(
+        'cli_missing',
+        err instanceof Error ? err.message : String(err),
+      )
+    }
+  }
+
+  // ── Subclass hooks ───────────────────────────────────────────────
+
+  /** Subclass override — claude reads ~/.claude/auth.json, codex
+   *  reads <CODEX_HOME>/auth.json, etc. Default is a no-op. */
+  protected async checkAuth(): Promise<void> {
+    return
+  }
+
+  /** Default reinstall-cli handler — throws an informative error
+   *  pointing at the upstream docs. Subclasses can override to
+   *  trigger an in-app installer. */
+  protected async handleReinstallCli(): Promise<void> {
+    throw new Error(
+      `${this.descriptor.displayName} CLI is not installed. ` +
+        `Install ${this.deps.binaryName} from the upstream docs and probe again.`,
+    )
+  }
+
+  // ── Internals ────────────────────────────────────────────────────
+
+  protected setState(next: RuntimeState, errorMessage?: string): void {
+    if (next === this.state && !errorMessage) return
+    this.state = next
+    if (errorMessage !== undefined) {
+      this.lastError = errorMessage
+      this.lastErrorAt = Date.now()
+    } else if (next === 'cli_present') {
+      this.lastError = null
+      this.lastErrorAt = null
+    }
+    const snapshot = this.getStatusSnapshot()
+    for (const listener of this.listeners) {
+      try {
+        listener(snapshot)
+      } catch (err) {
+        logger.warn('HostProcessAgentRuntime state listener threw', {
+          adapterId: this.descriptor.adapterId,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    }
+  }
+
+  private async runProbe(
+    cmd: ReadonlyArray<string>,
+    timeoutMs: number,
+  ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
+    if (this.deps.spawnProbe) return this.deps.spawnProbe(cmd, timeoutMs)
+    const proc = Bun.spawn(cmd as string[], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    const timer = setTimeout(() => {
+      try {
+        proc.kill()
+      } catch {
+        // best-effort
+      }
+    }, timeoutMs)
+    const [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ])
+    clearTimeout(timer)
+    return { exitCode, stdout, stderr }
+  }
+}

--- a/packages/browseros-agent/apps/server/src/lib/agents/runtime/index.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/runtime/index.ts
@@ -1,0 +1,24 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+export type { AgentRuntime } from './agent-runtime'
+export { ActionNotSupportedError, RuntimeNotReadyError } from './errors'
+export {
+  AgentRuntimeRegistry,
+  getAgentRuntimeRegistry,
+  resetAgentRuntimeRegistry,
+} from './registry'
+export type {
+  ExecSpec,
+  Platform,
+  RuntimeAction,
+  RuntimeCapability,
+  RuntimeDescriptor,
+  RuntimeState,
+  RuntimeStatusSnapshot,
+  StateListener,
+  Unsubscribe,
+} from './types'

--- a/packages/browseros-agent/apps/server/src/lib/agents/runtime/index.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/runtime/index.ts
@@ -5,7 +5,12 @@
  */
 
 export type { AgentRuntime } from './agent-runtime'
+export { ContainerAgentRuntime } from './container-agent-runtime'
 export { ActionNotSupportedError, RuntimeNotReadyError } from './errors'
+export {
+  HostProcessAgentRuntime,
+  type HostProcessAgentRuntimeDeps,
+} from './host-process-agent-runtime'
 export {
   AgentRuntimeRegistry,
   getAgentRuntimeRegistry,

--- a/packages/browseros-agent/apps/server/src/lib/agents/runtime/registry.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/runtime/registry.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { AgentRuntime } from './agent-runtime'
+
+export class AgentRuntimeRegistry {
+  private readonly runtimes = new Map<string, AgentRuntime>()
+
+  register(runtime: AgentRuntime): void {
+    const id = runtime.descriptor.adapterId
+    if (this.runtimes.has(id)) {
+      throw new Error(`Runtime for adapter "${id}" is already registered`)
+    }
+    this.runtimes.set(id, runtime)
+  }
+
+  get(adapterId: string): AgentRuntime | null {
+    return this.runtimes.get(adapterId) ?? null
+  }
+
+  list(): ReadonlyArray<AgentRuntime> {
+    return Array.from(this.runtimes.values())
+  }
+
+  unregister(adapterId: string): boolean {
+    return this.runtimes.delete(adapterId)
+  }
+}
+
+let globalRegistry: AgentRuntimeRegistry | null = null
+
+export function getAgentRuntimeRegistry(): AgentRuntimeRegistry {
+  if (!globalRegistry) globalRegistry = new AgentRuntimeRegistry()
+  return globalRegistry
+}
+
+/** Test-only — production code never calls this. */
+export function resetAgentRuntimeRegistry(): void {
+  globalRegistry = null
+}

--- a/packages/browseros-agent/apps/server/src/lib/agents/runtime/types.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/runtime/types.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Shared types for the AgentRuntime layer. Pure types — no behaviour
+ * lives here.
+ */
+
+import type { ExecSpec } from '../../container/managed'
+
+export type Platform = NodeJS.Platform
+
+export interface RuntimeDescriptor {
+  /** Stable id matching `agent.adapter` for harness lookups. */
+  adapterId: string
+  /** Human-readable label for UI. */
+  displayName: string
+  /** Discriminator for runtime kind. UI components route on this. */
+  kind: 'container' | 'host-process'
+  /** Platforms where this runtime is supported (today: ['darwin']
+   *  for container kinds; varies for host kinds). */
+  platforms: ReadonlyArray<Platform>
+}
+
+export type RuntimeState =
+  | 'unsupported_platform'
+  | 'errored'
+  // container-only
+  | 'not_installed'
+  | 'installing'
+  | 'installed'
+  | 'starting'
+  | 'running'
+  | 'stopped'
+  // host-only
+  | 'cli_missing'
+  | 'cli_present'
+  | 'cli_unhealthy'
+
+export interface RuntimeStatusSnapshot {
+  adapterId: string
+  state: RuntimeState
+  /** True iff the harness can spawn turns against this runtime now. */
+  isReady: boolean
+  lastError: string | null
+  lastErrorAt: number | null
+  /** Adapter-specific structured fields the UI may render. Keep keys
+   *  stable so the UI can opt into them. */
+  details?: Record<string, unknown>
+}
+
+export type RuntimeCapability =
+  | 'install'
+  | 'start'
+  | 'stop'
+  | 'restart'
+  | 'reset-soft'
+  | 'reset-wipe-agent'
+  | 'reset-hard'
+  | 'logs'
+  | 'terminal'
+  | 'reinstall-cli'
+  | 'check-auth'
+  | 'gateway-control-plane'
+  | 'agent-crud-via-runtime'
+
+/**
+ * Discriminated union of every action a runtime can be asked to
+ * perform. Required arguments live on the variant so callers can't
+ * forget them (e.g. `agentId` for `reset-wipe-agent`).
+ */
+export type RuntimeAction =
+  | { type: 'install' }
+  | { type: 'start' }
+  | { type: 'stop' }
+  | { type: 'restart' }
+  | { type: 'reset-soft' }
+  | { type: 'reset-wipe-agent'; agentId: string }
+  | { type: 'reset-hard' }
+  | { type: 'reinstall-cli' }
+  | { type: 'check-auth' }
+
+export type StateListener = (snapshot: RuntimeStatusSnapshot) => void
+export type Unsubscribe = () => void
+
+export type { ExecSpec }

--- a/packages/browseros-agent/apps/server/tests/lib/agents/runtime/container-agent-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/runtime/container-agent-runtime.test.ts
@@ -1,0 +1,188 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { describe, expect, it } from 'bun:test'
+import {
+  ActionNotSupportedError,
+  ContainerAgentRuntime,
+  type RuntimeCapability,
+  type RuntimeStatusSnapshot,
+} from '../../../../src/lib/agents/runtime'
+import type {
+  ManagedContainerDeps,
+  MountRoot,
+} from '../../../../src/lib/container/managed'
+import type { ContainerSpec } from '../../../../src/lib/container/types'
+
+interface Call {
+  kind: 'install' | 'start' | 'stop' | 'restart' | 'reset'
+  args?: unknown
+}
+
+class TestRuntime extends ContainerAgentRuntime {
+  readonly descriptor = {
+    adapterId: 'test',
+    displayName: 'Test',
+    kind: 'container' as const,
+    defaultImage: 'docker.io/test:latest',
+    containerName: 'test-container',
+    platforms: ['darwin' as NodeJS.Platform],
+  }
+
+  calls: Call[] = []
+  capabilities: ReadonlyArray<RuntimeCapability> | null = null
+
+  getPerAgentHomeDir(agentId: string): string {
+    return `/tmp/test/${agentId}`
+  }
+
+  override getCapabilities(): ReadonlyArray<RuntimeCapability> {
+    return this.capabilities ?? super.getCapabilities()
+  }
+
+  protected mountRoots(): readonly MountRoot[] {
+    return []
+  }
+
+  protected async buildContainerSpec(): Promise<ContainerSpec> {
+    return {
+      name: this.descriptor.containerName,
+      image: this.descriptor.defaultImage,
+    }
+  }
+
+  protected async readinessProbe(): Promise<boolean> {
+    return true
+  }
+
+  override async install(_opts: { onLog?: (m: string) => void } = {}) {
+    this.calls.push({ kind: 'install' })
+  }
+  override async start(_opts: { onLog?: (m: string) => void } = {}) {
+    this.calls.push({ kind: 'start' })
+  }
+  override async stop() {
+    this.calls.push({ kind: 'stop' })
+  }
+  override async restart(_opts: { onLog?: (m: string) => void } = {}) {
+    this.calls.push({ kind: 'restart' })
+  }
+  override async reset(level: 'soft' | 'wipe-agent' | 'hard', opts: unknown) {
+    this.calls.push({ kind: 'reset', args: { level, opts } })
+  }
+}
+
+function makeDeps(): ManagedContainerDeps {
+  return {
+    cli: {} as ManagedContainerDeps['cli'],
+    loader: {} as ManagedContainerDeps['loader'],
+    vm: {} as ManagedContainerDeps['vm'],
+    limactlPath: '/opt/homebrew/bin/limactl',
+    limaHome: '/tmp/lima',
+    vmName: 'browseros-vm',
+    lockDir: '/tmp/locks',
+  }
+}
+
+describe('ContainerAgentRuntime', () => {
+  it('default capabilities cover lifecycle + reset levels + logs', () => {
+    const r = new TestRuntime(makeDeps())
+    expect(r.getCapabilities()).toEqual([
+      'install',
+      'start',
+      'stop',
+      'restart',
+      'reset-soft',
+      'reset-wipe-agent',
+      'reset-hard',
+      'logs',
+    ])
+  })
+
+  it('getStatusSnapshot maps state, isReady, containerName', () => {
+    const r = new TestRuntime(makeDeps())
+    const snap = r.getStatusSnapshot()
+    expect(snap.adapterId).toBe('test')
+    expect(snap.containerName).toBe('test-container')
+    expect(snap.state).toBe('not_installed')
+    expect(snap.isReady).toBe(false)
+    expect(snap.lastError).toBeNull()
+  })
+
+  it('isReady is true only when state is running', () => {
+    const r = new TestRuntime(makeDeps())
+    // biome-ignore lint/complexity/useLiteralKeys: protected access
+    r['state'] = 'running'
+    expect(r.getStatusSnapshot().isReady).toBe(true)
+    // biome-ignore lint/complexity/useLiteralKeys: protected access
+    r['state'] = 'errored'
+    expect(r.getStatusSnapshot().isReady).toBe(false)
+  })
+
+  it('subscribe wires through subscribeState and emits a snapshot', () => {
+    const r = new TestRuntime(makeDeps())
+    const seen: RuntimeStatusSnapshot[] = []
+    const off = r.subscribe((s) => seen.push(s))
+    // biome-ignore lint/complexity/useLiteralKeys: protected access
+    r['setState']('starting')
+    // biome-ignore lint/complexity/useLiteralKeys: protected access
+    r['setState']('running')
+    off()
+    // biome-ignore lint/complexity/useLiteralKeys: protected access
+    r['setState']('stopped')
+    expect(seen.map((s) => s.state)).toEqual(['starting', 'running'])
+    expect(seen[1].isReady).toBe(true)
+  })
+
+  describe('executeAction dispatch', () => {
+    it('routes install/start/stop/restart to inherited methods', async () => {
+      const r = new TestRuntime(makeDeps())
+      await r.executeAction({ type: 'install' })
+      await r.executeAction({ type: 'start' })
+      await r.executeAction({ type: 'stop' })
+      await r.executeAction({ type: 'restart' })
+      expect(r.calls.map((c) => c.kind)).toEqual([
+        'install',
+        'start',
+        'stop',
+        'restart',
+      ])
+    })
+
+    it('routes reset variants with correct level + agentId', async () => {
+      const r = new TestRuntime(makeDeps())
+      await r.executeAction({ type: 'reset-soft' })
+      await r.executeAction({ type: 'reset-wipe-agent', agentId: 'agent-7' })
+      await r.executeAction({ type: 'reset-hard' })
+      const resets = r.calls.filter((c) => c.kind === 'reset')
+      expect(resets).toHaveLength(3)
+      expect((resets[0].args as { level: string }).level).toBe('soft')
+      expect(
+        (resets[1].args as { level: string; opts: { agentId: string } }).opts
+          .agentId,
+      ).toBe('agent-7')
+      expect((resets[2].args as { level: string }).level).toBe('hard')
+    })
+
+    it('throws ActionNotSupportedError when capability is filtered out', async () => {
+      const r = new TestRuntime(makeDeps())
+      r.capabilities = ['start', 'stop']
+      await expect(r.executeAction({ type: 'install' })).rejects.toBeInstanceOf(
+        ActionNotSupportedError,
+      )
+      expect(r.calls).toEqual([])
+    })
+
+    it('throws ActionNotSupportedError for host-only actions', async () => {
+      const r = new TestRuntime(makeDeps())
+      await expect(
+        r.executeAction({ type: 'reinstall-cli' }),
+      ).rejects.toBeInstanceOf(ActionNotSupportedError)
+      await expect(
+        r.executeAction({ type: 'check-auth' }),
+      ).rejects.toBeInstanceOf(ActionNotSupportedError)
+    })
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/lib/agents/runtime/host-process-agent-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/runtime/host-process-agent-runtime.test.ts
@@ -104,6 +104,22 @@ describe('HostProcessAgentRuntime', () => {
       expect(snap.lastError).toBe('ENOENT')
     })
 
+    it('does not stamp the cache when probe throws (lets next call retry)', async () => {
+      let attempt = 0
+      const spawnProbe = mock(async () => {
+        attempt += 1
+        if (attempt === 1) throw new Error('ENOENT')
+        return { exitCode: 0, stdout: 'ok', stderr: '' }
+      })
+      const r = makeRuntime({ spawnProbe, probeCacheMs: 60_000 })
+      await r.probeHealth()
+      // No force flag — should still re-probe because the first call
+      // failed and must not have advanced the cache.
+      await r.probeHealth()
+      expect(spawnProbe).toHaveBeenCalledTimes(2)
+      expect(r.getStatusSnapshot().state).toBe('cli_present')
+    })
+
     it('caches probe results within the cache window', async () => {
       const spawnProbe = mock(async () => ({
         exitCode: 0,
@@ -186,6 +202,22 @@ describe('HostProcessAgentRuntime', () => {
       await expect(
         r.executeAction({ type: 'reset-soft' }),
       ).rejects.toBeInstanceOf(ActionNotSupportedError)
+    })
+
+    it('gates on getCapabilities() — subclass-filtered actions throw', async () => {
+      class FilteredRuntime extends TestRuntime {
+        override getCapabilities() {
+          return ['check-auth' as const]
+        }
+      }
+      const r = new FilteredRuntime({ binaryName: 'fake-cli' })
+      await expect(
+        r.executeAction({ type: 'reinstall-cli' }),
+      ).rejects.toBeInstanceOf(ActionNotSupportedError)
+      expect(r.reinstallCalls).toBe(0)
+      // Whitelisted action still goes through.
+      await r.executeAction({ type: 'check-auth' })
+      expect(r.authCalls).toBe(1)
     })
 
     it('default handleReinstallCli throws if subclass does not override', async () => {

--- a/packages/browseros-agent/apps/server/tests/lib/agents/runtime/host-process-agent-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/runtime/host-process-agent-runtime.test.ts
@@ -1,0 +1,226 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { describe, expect, it, mock } from 'bun:test'
+import {
+  ActionNotSupportedError,
+  HostProcessAgentRuntime,
+  type HostProcessAgentRuntimeDeps,
+  type RuntimeStatusSnapshot,
+} from '../../../../src/lib/agents/runtime'
+
+class TestRuntime extends HostProcessAgentRuntime {
+  readonly descriptor = {
+    adapterId: 'host-test',
+    displayName: 'Host Test',
+    kind: 'host-process' as const,
+    platforms: ['darwin' as NodeJS.Platform],
+  }
+
+  reinstallCalls = 0
+  authCalls = 0
+
+  getPerAgentHomeDir(agentId: string): string {
+    return `/tmp/host-test/${agentId}`
+  }
+
+  protected override async handleReinstallCli(): Promise<void> {
+    this.reinstallCalls += 1
+  }
+
+  protected override async checkAuth(): Promise<void> {
+    this.authCalls += 1
+  }
+}
+
+function makeRuntime(
+  overrides: Partial<HostProcessAgentRuntimeDeps> = {},
+): TestRuntime {
+  return new TestRuntime({
+    binaryName: 'fake-cli',
+    spawnProbe: async () => ({ exitCode: 0, stdout: '1.2.3\n', stderr: '' }),
+    ...overrides,
+  })
+}
+
+describe('HostProcessAgentRuntime', () => {
+  it('starts in cli_missing state', () => {
+    const r = makeRuntime()
+    const snap = r.getStatusSnapshot()
+    expect(snap.state).toBe('cli_missing')
+    expect(snap.isReady).toBe(false)
+    expect(snap.details).toEqual({ binaryVersion: null })
+  })
+
+  it('default capabilities are reinstall-cli + check-auth', () => {
+    expect(makeRuntime().getCapabilities()).toEqual([
+      'reinstall-cli',
+      'check-auth',
+    ])
+  })
+
+  describe('probeHealth', () => {
+    it('transitions to cli_present on exit 0 and records version', async () => {
+      const spawnProbe = mock(async () => ({
+        exitCode: 0,
+        stdout: '1.2.3\n',
+        stderr: '',
+      }))
+      const r = makeRuntime({ spawnProbe })
+      await r.probeHealth()
+      const snap = r.getStatusSnapshot()
+      expect(snap.state).toBe('cli_present')
+      expect(snap.isReady).toBe(true)
+      expect(snap.details?.binaryVersion).toBe('1.2.3')
+      expect(spawnProbe).toHaveBeenCalledTimes(1)
+    })
+
+    it('transitions to cli_unhealthy on non-zero exit', async () => {
+      const r = makeRuntime({
+        spawnProbe: async () => ({
+          exitCode: 1,
+          stdout: '',
+          stderr: 'broken',
+        }),
+      })
+      await r.probeHealth()
+      const snap = r.getStatusSnapshot()
+      expect(snap.state).toBe('cli_unhealthy')
+      expect(snap.lastError).toMatch(/exited 1/)
+      expect(snap.lastError).toMatch(/broken/)
+    })
+
+    it('transitions to cli_missing when spawn throws', async () => {
+      const r = makeRuntime({
+        spawnProbe: async () => {
+          throw new Error('ENOENT')
+        },
+      })
+      await r.probeHealth()
+      const snap = r.getStatusSnapshot()
+      expect(snap.state).toBe('cli_missing')
+      expect(snap.lastError).toBe('ENOENT')
+    })
+
+    it('caches probe results within the cache window', async () => {
+      const spawnProbe = mock(async () => ({
+        exitCode: 0,
+        stdout: 'v',
+        stderr: '',
+      }))
+      const r = makeRuntime({ spawnProbe, probeCacheMs: 60_000 })
+      await r.probeHealth()
+      await r.probeHealth()
+      await r.probeHealth()
+      expect(spawnProbe).toHaveBeenCalledTimes(1)
+    })
+
+    it('force=true bypasses the cache', async () => {
+      const spawnProbe = mock(async () => ({
+        exitCode: 0,
+        stdout: 'v',
+        stderr: '',
+      }))
+      const r = makeRuntime({ spawnProbe, probeCacheMs: 60_000 })
+      await r.probeHealth()
+      await r.probeHealth(true)
+      expect(spawnProbe).toHaveBeenCalledTimes(2)
+    })
+
+    it('uses versionProbeArgs override when provided', async () => {
+      const spawnProbe = mock(async () => ({
+        exitCode: 0,
+        stdout: 'v',
+        stderr: '',
+      }))
+      const r = makeRuntime({
+        spawnProbe,
+        versionProbeArgs: ['custom-bin', '-V'],
+      })
+      await r.probeHealth()
+      expect(spawnProbe.mock.calls[0]?.[0]).toEqual(['custom-bin', '-V'])
+    })
+  })
+
+  describe('subscribe', () => {
+    it('fires listener on state changes only', async () => {
+      const seen: RuntimeStatusSnapshot[] = []
+      const r = makeRuntime()
+      r.subscribe((s) => seen.push(s))
+      await r.probeHealth()
+      await r.probeHealth(true)
+      // First probe: cli_missing → cli_present (one fire). Second
+      // probe: stays cli_present, no fire.
+      expect(seen.map((s) => s.state)).toEqual(['cli_present'])
+    })
+
+    it('unsubscribe stops further notifications', async () => {
+      const seen: RuntimeStatusSnapshot[] = []
+      const r = makeRuntime()
+      const off = r.subscribe((s) => seen.push(s))
+      off()
+      await r.probeHealth()
+      expect(seen).toEqual([])
+    })
+  })
+
+  describe('executeAction', () => {
+    it('routes reinstall-cli + check-auth to subclass hooks', async () => {
+      const r = makeRuntime()
+      await r.executeAction({ type: 'reinstall-cli' })
+      await r.executeAction({ type: 'check-auth' })
+      expect(r.reinstallCalls).toBe(1)
+      expect(r.authCalls).toBe(1)
+    })
+
+    it('throws ActionNotSupportedError for container-only actions', async () => {
+      const r = makeRuntime()
+      await expect(r.executeAction({ type: 'install' })).rejects.toBeInstanceOf(
+        ActionNotSupportedError,
+      )
+      await expect(r.executeAction({ type: 'start' })).rejects.toBeInstanceOf(
+        ActionNotSupportedError,
+      )
+      await expect(
+        r.executeAction({ type: 'reset-soft' }),
+      ).rejects.toBeInstanceOf(ActionNotSupportedError)
+    })
+
+    it('default handleReinstallCli throws if subclass does not override', async () => {
+      class BareRuntime extends HostProcessAgentRuntime {
+        readonly descriptor = {
+          adapterId: 'bare',
+          displayName: 'Bare',
+          kind: 'host-process' as const,
+          platforms: ['darwin' as NodeJS.Platform],
+        }
+        getPerAgentHomeDir() {
+          return '/tmp/bare'
+        }
+      }
+      const r = new BareRuntime({ binaryName: 'bare-cli' })
+      await expect(r.executeAction({ type: 'reinstall-cli' })).rejects.toThrow(
+        /not installed/,
+      )
+    })
+  })
+
+  describe('buildExecArgv', () => {
+    it('joins argv with no env prefix when env is empty', () => {
+      const r = makeRuntime()
+      const out = r.buildExecArgv({ argv: ['fake-cli', '--help'] })
+      expect(out).toBe('fake-cli --help')
+    })
+
+    it('emits an env prefix when env is set', () => {
+      const r = makeRuntime()
+      const out = r.buildExecArgv({
+        argv: ['fake-cli', 'run'],
+        env: { AGENT_HOME: '/tmp/h', LOG: '1' },
+      })
+      expect(out).toBe('env AGENT_HOME=/tmp/h LOG=1 fake-cli run')
+    })
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/lib/agents/runtime/registry.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/runtime/registry.test.ts
@@ -1,0 +1,90 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import {
+  type AgentRuntime,
+  AgentRuntimeRegistry,
+  getAgentRuntimeRegistry,
+  resetAgentRuntimeRegistry,
+} from '../../../../src/lib/agents/runtime'
+
+function makeFakeRuntime(adapterId: string): AgentRuntime {
+  return {
+    descriptor: {
+      adapterId,
+      displayName: adapterId,
+      kind: 'host-process',
+      platforms: ['darwin'],
+    },
+    getStatusSnapshot: () => ({
+      adapterId,
+      state: 'cli_missing',
+      isReady: false,
+      lastError: null,
+      lastErrorAt: null,
+    }),
+    subscribe: () => () => {},
+    getCapabilities: () => [],
+    executeAction: async () => {},
+    buildExecArgv: () => '',
+    getPerAgentHomeDir: () => `/tmp/${adapterId}`,
+  }
+}
+
+describe('AgentRuntimeRegistry', () => {
+  it('register + get + list round-trip', () => {
+    const registry = new AgentRuntimeRegistry()
+    const a = makeFakeRuntime('alpha')
+    const b = makeFakeRuntime('beta')
+
+    registry.register(a)
+    registry.register(b)
+
+    expect(registry.get('alpha')).toBe(a)
+    expect(registry.get('beta')).toBe(b)
+    expect(registry.list()).toEqual([a, b])
+  })
+
+  it('get returns null for unknown adapterId', () => {
+    const registry = new AgentRuntimeRegistry()
+    expect(registry.get('nope')).toBeNull()
+  })
+
+  it('register throws on duplicate adapterId', () => {
+    const registry = new AgentRuntimeRegistry()
+    registry.register(makeFakeRuntime('dup'))
+    expect(() => registry.register(makeFakeRuntime('dup'))).toThrow(
+      /already registered/,
+    )
+  })
+
+  it('unregister removes the entry and returns true', () => {
+    const registry = new AgentRuntimeRegistry()
+    registry.register(makeFakeRuntime('x'))
+    expect(registry.unregister('x')).toBe(true)
+    expect(registry.get('x')).toBeNull()
+    expect(registry.unregister('x')).toBe(false)
+  })
+
+  describe('singleton', () => {
+    afterEach(() => {
+      resetAgentRuntimeRegistry()
+    })
+
+    it('returns the same instance across calls', () => {
+      const a = getAgentRuntimeRegistry()
+      const b = getAgentRuntimeRegistry()
+      expect(a).toBe(b)
+    })
+
+    it('reset clears the singleton', () => {
+      const a = getAgentRuntimeRegistry()
+      resetAgentRuntimeRegistry()
+      const b = getAgentRuntimeRegistry()
+      expect(a).not.toBe(b)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Introduces a unified `AgentRuntime` layer that sits above the existing container abstraction and parallels it for host-process adapters (claude, codex). No adapter migrates yet — this is foundation only.

- `AgentRuntime` interface — descriptor, status snapshot, capability list, action dispatcher, exec-argv builder, per-agent home dir, optional path translation
- Discriminated `RuntimeAction` union (variant-required args like `agentId` for `reset-wipe-agent`)
- `RuntimeState` superset covering both container states (`not_installed`/`installing`/.../`running`/`stopped`/`errored`) and host-CLI states (`cli_missing`/`cli_present`/`cli_unhealthy`)
- `ContainerAgentRuntime` — abstract base extending `ManagedContainer`, default lifecycle + reset capabilities, dispatcher that gates on `getCapabilities()` and routes to inherited methods
- `HostProcessAgentRuntime` — abstract base for host-PATH binaries with cached `--version` probe, `cli_missing → cli_present/cli_unhealthy` transitions, env-prefixed exec argv, subclass hooks for `checkAuth` + `handleReinstallCli`
- `AgentRuntimeRegistry` — duplicate-guarded register/get/list/unregister + process singleton with test reset

## Test plan

- [x] `bun run typecheck` clean across server package
- [x] `biome check` clean on new sources + tests
- [x] `bun test tests/lib/agents/runtime/` — 29 cases covering capability defaults + filtering, status snapshot mapping, subscribe wiring, action dispatch (incl. `ActionNotSupportedError` for cross-kind actions), probe success/non-zero/spawn-error transitions, cache + force-bypass, registry round-trip + duplicate guard + singleton reset
- [x] Full server test sweep (`bun test`) — 1010 pass, 0 fail