### PR TITLE
fix(server): tighten CORS allowlist for the agent server

### DIFF
--- a/packages/browseros-agent/apps/server/.env.example
+++ b/packages/browseros-agent/apps/server/.env.example
@@ -13,6 +13,14 @@ BROWSEROS_VERSION=
 BROWSEROS_INSTALL_ID=
 BROWSEROS_CLIENT_ID=
 
+# Comma-separated allowlist of cross-origin callers permitted to
+# reach the agent server. The published BrowserOS extension origin
+# is added by the host application; dev / unsigned builds set this
+# to include their chrome-extension://<id> origin (and the WXT dev
+# server origin if relevant). Callers without an Origin header
+# (CLI, internal Node) are unaffected.
+BROWSEROS_TRUSTED_ORIGINS=
+
 # Graph service
 CODEGEN_SERVICE_URL=
 

--- a/packages/browseros-agent/apps/server/.env.example
+++ b/packages/browseros-agent/apps/server/.env.example
@@ -13,12 +13,6 @@ BROWSEROS_VERSION=
 BROWSEROS_INSTALL_ID=
 BROWSEROS_CLIENT_ID=
 
-# Comma-separated allowlist of cross-origin callers permitted to
-# reach the agent server. The published BrowserOS extension origin
-# is added by the host application; dev / unsigned builds set this
-# to include their chrome-extension://<id> origin (and the WXT dev
-# server origin if relevant). Callers without an Origin header
-# (CLI, internal Node) are unaffected.
 BROWSEROS_TRUSTED_ORIGINS=
 
 # Graph service

--- a/packages/browseros-agent/apps/server/src/api/middleware/require-trusted-origin.ts
+++ b/packages/browseros-agent/apps/server/src/api/middleware/require-trusted-origin.ts
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { MiddlewareHandler } from 'hono'
+import { isAllowedOrigin } from '../utils/cors'
+
+/**
+ * Reject requests whose `Origin` header is present and not in
+ * the trusted-origins allowlist.
+ *
+ * Hono's `cors()` middleware on its own only omits the
+ * response `Access-Control-Allow-Origin` header on a
+ * mismatch — by the time the browser blocks the read, the
+ * route handler has already executed. Routes that have side
+ * effects (running a tool, mutating state) need an active
+ * gate, not a response-side one. This middleware provides
+ * that.
+ *
+ * Permissive on missing `Origin`. The header is only present
+ * on browser-initiated cross-origin requests. CLI tools,
+ * internal Node clients, and some service-worker fetches
+ * legitimately omit it; rejecting those would break working
+ * integrations. Browser-initiated POST requests with bodies
+ * always carry `Origin` (the header is on the Forbidden
+ * Header List, so JS cannot suppress it), so the threat
+ * model is fully covered.
+ */
+export function requireTrustedOrigin(): MiddlewareHandler {
+  return async (c, next) => {
+    const origin = c.req.header('Origin')
+    if (origin !== undefined && !isAllowedOrigin(origin)) {
+      return c.json(
+        {
+          error: {
+            name: 'ForbiddenOrigin',
+            message: 'Origin not allowed',
+            code: 'FORBIDDEN_ORIGIN',
+            statusCode: 403,
+          },
+        },
+        403,
+      )
+    }
+    return next()
+  }
+}

--- a/packages/browseros-agent/apps/server/src/api/middleware/require-trusted-origin.ts
+++ b/packages/browseros-agent/apps/server/src/api/middleware/require-trusted-origin.ts
@@ -7,27 +7,6 @@
 import type { MiddlewareHandler } from 'hono'
 import { isAllowedOrigin } from '../utils/cors'
 
-/**
- * Reject requests whose `Origin` header is present and not in
- * the trusted-origins allowlist.
- *
- * Hono's `cors()` middleware on its own only omits the
- * response `Access-Control-Allow-Origin` header on a
- * mismatch — by the time the browser blocks the read, the
- * route handler has already executed. Routes that have side
- * effects (running a tool, mutating state) need an active
- * gate, not a response-side one. This middleware provides
- * that.
- *
- * Permissive on missing `Origin`. The header is only present
- * on browser-initiated cross-origin requests. CLI tools,
- * internal Node clients, and some service-worker fetches
- * legitimately omit it; rejecting those would break working
- * integrations. Browser-initiated POST requests with bodies
- * always carry `Origin` (the header is on the Forbidden
- * Header List, so JS cannot suppress it), so the threat
- * model is fully covered.
- */
 export function requireTrustedOrigin(): MiddlewareHandler {
   return async (c, next) => {
     const origin = c.req.header('Origin')

--- a/packages/browseros-agent/apps/server/src/api/server.ts
+++ b/packages/browseros-agent/apps/server/src/api/server.ts
@@ -20,6 +20,7 @@ import { initializeOAuth } from '../lib/clients/oauth'
 import { getDb } from '../lib/db'
 import { logger } from '../lib/logger'
 import { Sentry } from '../lib/sentry'
+import { requireTrustedOrigin } from './middleware/require-trusted-origin'
 import { createChatRoutes } from './routes/chat'
 import { createCreditsRoutes } from './routes/credits'
 import { createHealthRoute } from './routes/health'
@@ -103,6 +104,7 @@ export async function createHttpServer(config: HttpServerConfig) {
 
   const app = new Hono<Env>()
     .use('/*', cors(defaultCorsConfig))
+    .use('/*', requireTrustedOrigin())
     .route('/health', createHealthRoute({ browser }))
     .route(
       '/shutdown',

--- a/packages/browseros-agent/apps/server/src/api/utils/cors.ts
+++ b/packages/browseros-agent/apps/server/src/api/utils/cors.ts
@@ -8,36 +8,6 @@ import type { cors } from 'hono/cors'
 
 type CorsOptions = Parameters<typeof cors>[0]
 
-/**
- * Default CORS configuration for the HTTP server.
- *
- * The agent server binds to a localhost port and is reachable
- * from any tab running in the user's browser. With a wildcard
- * `Access-Control-Allow-Origin`, every page on the open
- * internet can issue cross-origin fetches and read responses.
- * Restrict to an explicit allowlist composed of:
- *
- *   1. The published BrowserOS extension origin (always
- *      allowed).
- *   2. Additional origins supplied via the
- *      `BROWSEROS_TRUSTED_ORIGINS` env var, comma-separated —
- *      used by dev (the WXT dev extension origin), unsigned
- *      builds, and internal alpha extensions.
- *
- * Reflecting any unknown origin is intentionally not done.
- * Callers without an `Origin` header (CLI tools, internal
- * Node clients) are unaffected — `cors()` only acts when an
- * `Origin` header is present, and the `requireTrustedOrigin`
- * middleware mirrors that behaviour at the reject side.
- */
-
-/**
- * Static, hard-coded allowlist for the published BrowserOS
- * extension. Pinned by extension id (a SHA-256 of the
- * extension's public key, stable across releases). Additional
- * origins (dev builds, alpha channels, the WXT dev server) can
- * be appended via `BROWSEROS_TRUSTED_ORIGINS`.
- */
 const STATIC_ALLOWED_ORIGINS = new Set<string>([
   'chrome-extension://bflpfmnmnokmjhmgnolecpppdbdophmk',
 ])
@@ -59,17 +29,10 @@ function getAllowedOrigins(): Set<string> {
   return cachedAllowedOrigins
 }
 
-/** Test-only: drop the cached set so tests can re-read env. */
 export function resetAllowedOriginsForTesting(): void {
   cachedAllowedOrigins = null
 }
 
-/**
- * Returns true when `origin` is in the allowlist. Case-
- * sensitive, exact match — origins are normalised by the
- * browser before they reach us, and `chrome-extension://` is
- * lowercase by spec.
- */
 export function isAllowedOrigin(origin: string): boolean {
   return getAllowedOrigins().has(origin)
 }

--- a/packages/browseros-agent/apps/server/src/api/utils/cors.ts
+++ b/packages/browseros-agent/apps/server/src/api/utils/cors.ts
@@ -10,10 +10,71 @@ type CorsOptions = Parameters<typeof cors>[0]
 
 /**
  * Default CORS configuration for the HTTP server.
- * Permissive since MCP endpoints are protected by localhost check.
+ *
+ * The agent server binds to a localhost port and is reachable
+ * from any tab running in the user's browser. With a wildcard
+ * `Access-Control-Allow-Origin`, every page on the open
+ * internet can issue cross-origin fetches and read responses.
+ * Restrict to an explicit allowlist composed of:
+ *
+ *   1. The published BrowserOS extension origin (always
+ *      allowed).
+ *   2. Additional origins supplied via the
+ *      `BROWSEROS_TRUSTED_ORIGINS` env var, comma-separated —
+ *      used by dev (the WXT dev extension origin), unsigned
+ *      builds, and internal alpha extensions.
+ *
+ * Reflecting any unknown origin is intentionally not done.
+ * Callers without an `Origin` header (CLI tools, internal
+ * Node clients) are unaffected — `cors()` only acts when an
+ * `Origin` header is present, and the `requireTrustedOrigin`
+ * middleware mirrors that behaviour at the reject side.
  */
+
+/**
+ * Static, hard-coded allowlist. Empty by default — every
+ * deployment supplies its trusted origins via env. This keeps
+ * the source agnostic of any specific build/extension id.
+ */
+const STATIC_ALLOWED_ORIGINS = new Set<string>()
+
+let cachedAllowedOrigins: Set<string> | null = null
+
+function buildAllowedOrigins(): Set<string> {
+  const fromEnv = (process.env.BROWSEROS_TRUSTED_ORIGINS ?? '')
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0)
+  return new Set([...STATIC_ALLOWED_ORIGINS, ...fromEnv])
+}
+
+function getAllowedOrigins(): Set<string> {
+  if (!cachedAllowedOrigins) {
+    cachedAllowedOrigins = buildAllowedOrigins()
+  }
+  return cachedAllowedOrigins
+}
+
+/** Test-only: drop the cached set so tests can re-read env. */
+export function resetAllowedOriginsForTesting(): void {
+  cachedAllowedOrigins = null
+}
+
+/**
+ * Returns true when `origin` is in the allowlist. Case-
+ * sensitive, exact match — origins are normalised by the
+ * browser before they reach us, and `chrome-extension://` is
+ * lowercase by spec.
+ */
+export function isAllowedOrigin(origin: string): boolean {
+  return getAllowedOrigins().has(origin)
+}
+
 export const defaultCorsConfig: CorsOptions = {
-  origin: (origin: string | undefined) => origin || '*',
+  origin: (origin: string | undefined) => {
+    if (origin && isAllowedOrigin(origin)) return origin
+    return null
+  },
   allowMethods: ['GET', 'POST', 'DELETE', 'OPTIONS'],
   allowHeaders: ['Content-Type', 'Authorization', 'Accept'],
   credentials: true,

--- a/packages/browseros-agent/apps/server/src/api/utils/cors.ts
+++ b/packages/browseros-agent/apps/server/src/api/utils/cors.ts
@@ -32,11 +32,15 @@ type CorsOptions = Parameters<typeof cors>[0]
  */
 
 /**
- * Static, hard-coded allowlist. Empty by default — every
- * deployment supplies its trusted origins via env. This keeps
- * the source agnostic of any specific build/extension id.
+ * Static, hard-coded allowlist for the published BrowserOS
+ * extension. Pinned by extension id (a SHA-256 of the
+ * extension's public key, stable across releases). Additional
+ * origins (dev builds, alpha channels, the WXT dev server) can
+ * be appended via `BROWSEROS_TRUSTED_ORIGINS`.
  */
-const STATIC_ALLOWED_ORIGINS = new Set<string>()
+const STATIC_ALLOWED_ORIGINS = new Set<string>([
+  'chrome-extension://bflpfmnmnokmjhmgnolecpppdbdophmk',
+])
 
 let cachedAllowedOrigins: Set<string> | null = null
 

--- a/packages/browseros-agent/apps/server/tests/api/middleware/require-trusted-origin.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/middleware/require-trusted-origin.test.ts
@@ -1,0 +1,87 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { Hono } from 'hono'
+import { requireTrustedOrigin } from '../../../src/api/middleware/require-trusted-origin'
+import { resetAllowedOriginsForTesting } from '../../../src/api/utils/cors'
+
+function buildApp() {
+  return new Hono()
+    .use('/*', requireTrustedOrigin())
+    .get('/probe', (c) => c.json({ ok: true }))
+    .post('/probe', (c) => c.json({ ok: true, method: 'POST' }))
+}
+
+describe('requireTrustedOrigin', () => {
+  const previousEnv = process.env.BROWSEROS_TRUSTED_ORIGINS
+
+  beforeEach(() => {
+    process.env.BROWSEROS_TRUSTED_ORIGINS = 'chrome-extension://allowed'
+    resetAllowedOriginsForTesting()
+  })
+  afterEach(() => {
+    process.env.BROWSEROS_TRUSTED_ORIGINS = previousEnv
+    resetAllowedOriginsForTesting()
+  })
+
+  it('passes when no Origin header is set', async () => {
+    const res = await buildApp().request('/probe')
+    expect(res.status).toBe(200)
+  })
+
+  it('passes when Origin matches the allowlist', async () => {
+    const res = await buildApp().request('/probe', {
+      headers: { Origin: 'chrome-extension://allowed' },
+    })
+    expect(res.status).toBe(200)
+  })
+
+  it('rejects with 403 when Origin is unknown', async () => {
+    const res = await buildApp().request('/probe', {
+      headers: { Origin: 'https://example.com' },
+    })
+    expect(res.status).toBe(403)
+    const body = (await res.json()) as { error?: { code?: string } }
+    expect(body.error?.code).toBe('FORBIDDEN_ORIGIN')
+  })
+
+  it('rejects with 403 when Origin is the literal "null"', async () => {
+    const res = await buildApp().request('/probe', {
+      headers: { Origin: 'null' },
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('rejects POST with disallowed Origin without invoking the route handler', async () => {
+    const app = new Hono()
+      .use('/*', requireTrustedOrigin())
+      .post('/probe', () => {
+        throw new Error('handler must not run')
+      })
+
+    const res = await app.request('/probe', {
+      method: 'POST',
+      headers: { Origin: 'https://example.com' },
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('rejects port mismatches even when host matches', async () => {
+    process.env.BROWSEROS_TRUSTED_ORIGINS = 'http://localhost:5173'
+    resetAllowedOriginsForTesting()
+    const res = await buildApp().request('/probe', {
+      headers: { Origin: 'http://localhost:5174' },
+    })
+    expect(res.status).toBe(403)
+  })
+
+  it('treats the allowlist as case-sensitive', async () => {
+    const res = await buildApp().request('/probe', {
+      headers: { Origin: 'CHROME-EXTENSION://allowed' },
+    })
+    expect(res.status).toBe(403)
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/api/utils/cors.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/utils/cors.test.ts
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import {
+  isAllowedOrigin,
+  resetAllowedOriginsForTesting,
+} from '../../../src/api/utils/cors'
+
+describe('isAllowedOrigin', () => {
+  const previousEnv = process.env.BROWSEROS_TRUSTED_ORIGINS
+
+  beforeEach(() => {
+    resetAllowedOriginsForTesting()
+  })
+  afterEach(() => {
+    process.env.BROWSEROS_TRUSTED_ORIGINS = previousEnv
+    resetAllowedOriginsForTesting()
+  })
+
+  it('rejects every origin when env is empty', () => {
+    process.env.BROWSEROS_TRUSTED_ORIGINS = ''
+    expect(isAllowedOrigin('https://example.com')).toBe(false)
+    expect(isAllowedOrigin('chrome-extension://anyid')).toBe(false)
+    expect(isAllowedOrigin('null')).toBe(false)
+  })
+
+  it('accepts a single origin from env', () => {
+    process.env.BROWSEROS_TRUSTED_ORIGINS = 'chrome-extension://abcdef'
+    expect(isAllowedOrigin('chrome-extension://abcdef')).toBe(true)
+    expect(isAllowedOrigin('chrome-extension://other')).toBe(false)
+  })
+
+  it('accepts multiple comma-separated origins and trims whitespace', () => {
+    process.env.BROWSEROS_TRUSTED_ORIGINS =
+      ' chrome-extension://abc , http://localhost:5173 '
+    expect(isAllowedOrigin('chrome-extension://abc')).toBe(true)
+    expect(isAllowedOrigin('http://localhost:5173')).toBe(true)
+    expect(isAllowedOrigin('http://localhost:5174')).toBe(false)
+  })
+
+  it('is case-sensitive on origin match', () => {
+    process.env.BROWSEROS_TRUSTED_ORIGINS = 'chrome-extension://abc'
+    expect(isAllowedOrigin('CHROME-EXTENSION://abc')).toBe(false)
+  })
+
+  it('treats port as part of the origin', () => {
+    process.env.BROWSEROS_TRUSTED_ORIGINS = 'http://localhost:5173'
+    expect(isAllowedOrigin('http://localhost:5173')).toBe(true)
+    expect(isAllowedOrigin('http://localhost:5174')).toBe(false)
+    expect(isAllowedOrigin('http://localhost')).toBe(false)
+  })
+
+  it('rejects the literal string "null" unless explicitly allowlisted', () => {
+    process.env.BROWSEROS_TRUSTED_ORIGINS = 'chrome-extension://abc'
+    expect(isAllowedOrigin('null')).toBe(false)
+  })
+
+  it('drops empty entries between commas', () => {
+    process.env.BROWSEROS_TRUSTED_ORIGINS = 'chrome-extension://abc,,, ,'
+    expect(isAllowedOrigin('chrome-extension://abc')).toBe(true)
+    expect(isAllowedOrigin('')).toBe(false)
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/api/utils/cors.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/utils/cors.test.ts
@@ -20,10 +20,17 @@ describe('isAllowedOrigin', () => {
     resetAllowedOriginsForTesting()
   })
 
-  it('rejects every origin when env is empty', () => {
+  it('accepts the pinned published extension origin even when env is empty', () => {
+    process.env.BROWSEROS_TRUSTED_ORIGINS = ''
+    expect(
+      isAllowedOrigin('chrome-extension://bflpfmnmnokmjhmgnolecpppdbdophmk'),
+    ).toBe(true)
+  })
+
+  it('rejects unknown origins when env is empty', () => {
     process.env.BROWSEROS_TRUSTED_ORIGINS = ''
     expect(isAllowedOrigin('https://example.com')).toBe(false)
-    expect(isAllowedOrigin('chrome-extension://anyid')).toBe(false)
+    expect(isAllowedOrigin('chrome-extension://someotherid')).toBe(false)
     expect(isAllowedOrigin('null')).toBe(false)
   })
 


### PR DESCRIPTION
Add a small `requireTrustedOrigin` middleware that actively rejects (403) any request whose `Origin` header is present and not in the allowlist. 