### PR TITLE
feat(agent): add 'Continue in Chat' dropdown to scheduled task results

### DIFF
--- a/packages/browseros-agent/apps/agent/components/ai-elements/run-result-dialog.tsx
+++ b/packages/browseros-agent/apps/agent/components/ai-elements/run-result-dialog.tsx
@@ -72,7 +72,11 @@ export const RunResultDialog: FC<RunResultDialogProps> = ({
     if (!run?.result) return
     onOpenChange(false)
     track(SCHEDULED_TASK_CONTINUE_IN_CHAT_EVENT, { mode })
-    navigate(`/home/chat?q=${encodeURIComponent(run.result)}&mode=${mode}`)
+    const key = `scheduled-task-${run.id}`
+    sessionStorage.setItem(key, run.result)
+    navigate(
+      `/home/chat?q=${encodeURIComponent(key)}&mode=${mode}&source=scheduled-task`,
+    )
   }
 
   const handleCopy = async () => {

--- a/packages/browseros-agent/apps/agent/components/ai-elements/run-result-dialog.tsx
+++ b/packages/browseros-agent/apps/agent/components/ai-elements/run-result-dialog.tsx
@@ -2,15 +2,19 @@ import dayjs from 'dayjs'
 import duration from 'dayjs/plugin/duration'
 import {
   AlertCircle,
+  Bot,
   Check,
   CheckCircle2,
+  ChevronDown,
   Copy,
   Loader2,
+  MessageSquare,
   RotateCcw,
   Square,
   XCircle,
 } from 'lucide-react'
 import { type FC, useState } from 'react'
+import { useNavigate } from 'react-router'
 import { Button } from '@/components/ui/button'
 import {
   Dialog,
@@ -19,7 +23,15 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
 import { ScrollArea } from '@/components/ui/scroll-area'
+import { SCHEDULED_TASK_CONTINUE_IN_CHAT_EVENT } from '@/lib/constants/analyticsEvents'
+import { track } from '@/lib/metrics/track'
 import type { ScheduledJobRun } from '@/lib/schedules/scheduleTypes'
 import { MessageResponse } from './message'
 
@@ -54,6 +66,14 @@ export const RunResultDialog: FC<RunResultDialogProps> = ({
   onRetryRun,
 }) => {
   const [copied, setCopied] = useState(false)
+  const navigate = useNavigate()
+
+  const handleContinueInChat = (mode: 'chat' | 'agent') => {
+    if (!run?.result) return
+    onOpenChange(false)
+    track(SCHEDULED_TASK_CONTINUE_IN_CHAT_EVENT, { mode })
+    navigate(`/home/chat?q=${encodeURIComponent(run.result)}&mode=${mode}`)
+  }
 
   const handleCopy = async () => {
     if (!run?.result) return
@@ -141,6 +161,26 @@ export const RunResultDialog: FC<RunResultDialogProps> = ({
                 </>
               )}
             </Button>
+          )}
+          {run.result && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="outline">
+                  Continue in Chat
+                  <ChevronDown className="h-4 w-4" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end">
+                <DropdownMenuItem onClick={() => handleContinueInChat('chat')}>
+                  <MessageSquare className="h-4 w-4" />
+                  Chat
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => handleContinueInChat('agent')}>
+                  <Bot className="h-4 w-4" />
+                  Assistant
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
           )}
           <Button onClick={() => onOpenChange(false)}>Close</Button>
         </DialogFooter>

--- a/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTaskResultGroup.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTaskResultGroup.tsx
@@ -16,13 +16,9 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
-import type { ScheduledJob, ScheduledJobRun } from './types'
+import type { JobRunWithDetails, ScheduledJob } from './types'
 
 dayjs.extend(relativeTime)
-
-interface JobRunWithDetails extends ScheduledJobRun {
-  job: ScheduledJob | undefined
-}
 
 interface ScheduledTaskResultGroupProps {
   job: ScheduledJob

--- a/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTaskResultGroup.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTaskResultGroup.tsx
@@ -16,7 +16,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
-import type { JobRunWithDetails, ScheduledJob } from './types'
+import type { JobRunWithDetails, ScheduledJob, ScheduledJobRun } from './types'
 
 dayjs.extend(relativeTime)
 

--- a/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTaskResultGroup.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTaskResultGroup.tsx
@@ -1,0 +1,162 @@
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+import {
+  CheckCircle2,
+  ChevronDown,
+  Clock,
+  Loader2,
+  RotateCcw,
+  Square,
+  XCircle,
+} from 'lucide-react'
+import type { FC } from 'react'
+import { Button } from '@/components/ui/button'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import type { ScheduledJob, ScheduledJobRun } from './types'
+
+dayjs.extend(relativeTime)
+
+interface JobRunWithDetails extends ScheduledJobRun {
+  job: ScheduledJob | undefined
+}
+
+interface ScheduledTaskResultGroupProps {
+  job: ScheduledJob
+  runs: JobRunWithDetails[]
+  isOpen: boolean
+  onOpenChange: (open: boolean) => void
+  onViewRun: (run: ScheduledJobRun) => void
+  onCancelRun: (runId: string) => void
+  onRetryRun: (jobId: string) => void
+}
+
+const getStatusIcon = (status: JobRunWithDetails['status']) => {
+  switch (status) {
+    case 'completed':
+      return <CheckCircle2 className="h-4 w-4 text-green-500" />
+    case 'running':
+      return <Loader2 className="h-4 w-4 animate-spin text-accent-orange" />
+    case 'failed':
+      return <XCircle className="h-4 w-4 text-destructive" />
+  }
+}
+
+const formatTimestamp = (dateString: string) => dayjs(dateString).fromNow()
+
+export const ScheduledTaskResultGroup: FC<ScheduledTaskResultGroupProps> = ({
+  job,
+  runs,
+  isOpen,
+  onOpenChange,
+  onViewRun,
+  onCancelRun,
+  onRetryRun,
+}) => {
+  const latestRun = runs[0]
+  const latestTime = latestRun ? formatTimestamp(latestRun.startedAt) : ''
+  const runningCount = runs.filter((r) => r.status === 'running').length
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={onOpenChange}>
+      <CollapsibleTrigger asChild>
+        <Button
+          variant="ghost"
+          className="group flex h-auto w-full items-center justify-between rounded-xl border border-border/50 bg-card p-4 text-left transition-all hover:border-border"
+        >
+          <div className="flex items-center gap-3">
+            {latestRun ? getStatusIcon(latestRun.status) : null}
+            <div className="min-w-0 flex-1">
+              <div className="mb-1 flex items-center gap-2">
+                <span className="truncate font-medium text-foreground text-sm">
+                  {job.name}
+                </span>
+                {runningCount > 0 && (
+                  <span className="rounded-full bg-accent-orange/20 px-2 py-0.5 text-accent-orange text-xs">
+                    {runningCount} running
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-2 text-muted-foreground text-xs">
+                <span className="flex items-center gap-1">
+                  <Clock className="h-3 w-3" />
+                  {latestTime}
+                </span>
+                <span>•</span>
+                <span>
+                  {runs.length} {runs.length === 1 ? 'result' : 'results'}
+                </span>
+              </div>
+            </div>
+          </div>
+          <ChevronDown
+            className={`h-4 w-4 text-muted-foreground transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}
+          />
+        </Button>
+      </CollapsibleTrigger>
+
+      <CollapsibleContent className="fade-in-0 slide-in-from-top-2 animate-in pt-2 duration-200">
+        <div className="space-y-2 pl-4">
+          {runs.map((run) => (
+            <Button
+              key={run.id}
+              variant="ghost"
+              onClick={() => onViewRun(run)}
+              className="h-auto w-full justify-start rounded-lg border border-border/50 bg-background p-3 text-left transition-all hover:border-border"
+            >
+              <div className="flex w-full items-start gap-3">
+                {getStatusIcon(run.status)}
+                <div className="min-w-0 flex-1">
+                  <div className="mb-1 flex items-center gap-2">
+                    <span className="text-sm">
+                      {dayjs(run.startedAt).format('MMM D, h:mm A')}
+                    </span>
+                    <span className="flex items-center gap-1 text-muted-foreground text-xs">
+                      {formatTimestamp(run.startedAt)}
+                    </span>
+                  </div>
+                  {run.result && (
+                    <p className="line-clamp-2 text-ellipsis text-muted-foreground text-xs">
+                      {run.result}
+                    </p>
+                  )}
+                </div>
+                {run.status === 'running' && (
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onCancelRun(run.id)
+                    }}
+                    className="shrink-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                    aria-label="Cancel run"
+                  >
+                    <Square className="h-3.5 w-3.5" />
+                  </Button>
+                )}
+                {run.status === 'failed' && (
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={(e) => {
+                      e.stopPropagation()
+                      onRetryRun(run.jobId)
+                    }}
+                    className="shrink-0 text-muted-foreground hover:text-foreground"
+                    aria-label="Retry run"
+                  >
+                    <RotateCcw className="h-3.5 w-3.5" />
+                  </Button>
+                )}
+              </div>
+            </Button>
+          ))}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTaskResults.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTaskResults.tsx
@@ -1,17 +1,6 @@
-import dayjs from 'dayjs'
-import relativeTime from 'dayjs/plugin/relativeTime'
-import {
-  Calendar,
-  CheckCircle2,
-  Clock,
-  Loader2,
-  RotateCcw,
-  Square,
-  XCircle,
-} from 'lucide-react'
+import { Calendar } from 'lucide-react'
 import type { FC } from 'react'
-import { useMemo } from 'react'
-import { Button } from '@/components/ui/button'
+import { useMemo, useState } from 'react'
 import {
   useScheduledJobRuns,
   useScheduledJobs,
@@ -20,8 +9,7 @@ import type {
   ScheduledJob,
   ScheduledJobRun,
 } from '@/lib/schedules/scheduleTypes'
-
-dayjs.extend(relativeTime)
+import { ScheduledTaskResultGroup } from './ScheduledTaskResultGroup'
 
 interface JobRunWithDetails extends ScheduledJobRun {
   job: ScheduledJob | undefined
@@ -33,19 +21,6 @@ interface ScheduledTaskResultsProps {
   onRetryRun: (jobId: string) => void
 }
 
-const getStatusIcon = (status: JobRunWithDetails['status']) => {
-  switch (status) {
-    case 'completed':
-      return <CheckCircle2 className="h-4 w-4 text-green-500" />
-    case 'running':
-      return <Loader2 className="h-4 w-4 animate-spin text-accent-orange" />
-    case 'failed':
-      return <XCircle className="h-4 w-4 text-destructive" />
-  }
-}
-
-const formatTimestamp = (dateString: string) => dayjs(dateString).fromNow()
-
 export const ScheduledTaskResults: FC<ScheduledTaskResultsProps> = ({
   onViewRun,
   onCancelRun,
@@ -53,29 +28,45 @@ export const ScheduledTaskResults: FC<ScheduledTaskResultsProps> = ({
 }) => {
   const { jobRuns } = useScheduledJobRuns()
   const { jobs } = useScheduledJobs()
+  const [openGroupId, setOpenGroupId] = useState<string | null>(null)
 
-  const sortedRuns: JobRunWithDetails[] = useMemo(() => {
+  const groupedRuns = useMemo(() => {
     const enrichWithJob = (run: ScheduledJobRun): JobRunWithDetails => ({
       ...run,
       job: jobs.find((j) => j.id === run.jobId),
     })
 
-    const running = jobRuns
-      .filter((r) => r.status === 'running')
-      .map(enrichWithJob)
+    const runsByJob = new Map<string, JobRunWithDetails[]>()
 
-    const completedOrFailed = jobRuns
-      .filter((r) => r.status === 'completed' || r.status === 'failed')
-      .sort(
+    for (const run of jobRuns) {
+      const enriched = enrichWithJob(run)
+      const existing = runsByJob.get(run.jobId) ?? []
+      existing.push(enriched)
+      runsByJob.set(run.jobId, existing)
+    }
+
+    const groups: Array<{ job: ScheduledJob; runs: JobRunWithDetails[] }> = []
+
+    for (const [jobId, runs] of runsByJob) {
+      const job = jobs.find((j) => j.id === jobId)
+      if (!job) continue
+
+      const sorted = runs.sort(
         (a, b) =>
           new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
       )
-      .map(enrichWithJob)
 
-    return [...running, ...completedOrFailed]
+      groups.push({ job, runs: sorted })
+    }
+
+    return groups.sort((a, b) => {
+      const latestA = a.runs[0]?.startedAt ?? ''
+      const latestB = b.runs[0]?.startedAt ?? ''
+      return new Date(latestB).getTime() - new Date(latestA).getTime()
+    })
   }, [jobRuns, jobs])
 
-  if (!sortedRuns.length) {
+  if (!groupedRuns.length) {
     return (
       <div className="flex flex-col items-center justify-center gap-3 py-16 text-muted-foreground">
         <Calendar className="h-10 w-10 opacity-50" />
@@ -86,61 +77,17 @@ export const ScheduledTaskResults: FC<ScheduledTaskResultsProps> = ({
 
   return (
     <div className="space-y-2">
-      {sortedRuns.map((run) => (
-        <Button
-          key={run.id}
-          variant="ghost"
-          onClick={() => onViewRun(run)}
-          className="h-auto w-full justify-start rounded-xl border border-border/50 bg-card p-4 text-left transition-all hover:border-border"
-        >
-          <div className="flex w-full items-start gap-3">
-            {getStatusIcon(run.status)}
-            <div className="min-w-0 flex-1">
-              <div className="mb-1 flex items-center gap-2">
-                <span className="truncate font-medium text-foreground text-sm">
-                  {run.job?.name}
-                </span>
-                <span className="flex items-center gap-1 text-muted-foreground text-xs">
-                  <Clock className="h-3 w-3" />
-                  {formatTimestamp(run.startedAt)}
-                </span>
-              </div>
-              {run.result && (
-                <p className="line-clamp-2 text-ellipsis text-muted-foreground text-xs">
-                  {run.result}
-                </p>
-              )}
-            </div>
-            {run.status === 'running' && (
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onCancelRun(run.id)
-                }}
-                className="shrink-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
-                aria-label="Cancel run"
-              >
-                <Square className="h-3.5 w-3.5" />
-              </Button>
-            )}
-            {run.status === 'failed' && (
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                onClick={(e) => {
-                  e.stopPropagation()
-                  onRetryRun(run.jobId)
-                }}
-                className="shrink-0 text-muted-foreground hover:text-foreground"
-                aria-label="Retry run"
-              >
-                <RotateCcw className="h-3.5 w-3.5" />
-              </Button>
-            )}
-          </div>
-        </Button>
+      {groupedRuns.map(({ job, runs }) => (
+        <ScheduledTaskResultGroup
+          key={job.id}
+          job={job}
+          runs={runs}
+          isOpen={openGroupId === job.id}
+          onOpenChange={(open) => setOpenGroupId(open ? job.id : null)}
+          onViewRun={onViewRun}
+          onCancelRun={onCancelRun}
+          onRetryRun={onRetryRun}
+        />
       ))}
     </div>
   )

--- a/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTaskResults.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTaskResults.tsx
@@ -5,15 +5,9 @@ import {
   useScheduledJobRuns,
   useScheduledJobs,
 } from '@/lib/schedules/scheduleStorage'
-import type {
-  ScheduledJob,
-  ScheduledJobRun,
-} from '@/lib/schedules/scheduleTypes'
+import type { ScheduledJobRun } from '@/lib/schedules/scheduleTypes'
 import { ScheduledTaskResultGroup } from './ScheduledTaskResultGroup'
-
-interface JobRunWithDetails extends ScheduledJobRun {
-  job: ScheduledJob | undefined
-}
+import { groupRunsByJob } from './types'
 
 interface ScheduledTaskResultsProps {
   onViewRun: (run: ScheduledJobRun) => void
@@ -30,41 +24,10 @@ export const ScheduledTaskResults: FC<ScheduledTaskResultsProps> = ({
   const { jobs } = useScheduledJobs()
   const [openGroupId, setOpenGroupId] = useState<string | null>(null)
 
-  const groupedRuns = useMemo(() => {
-    const enrichWithJob = (run: ScheduledJobRun): JobRunWithDetails => ({
-      ...run,
-      job: jobs.find((j) => j.id === run.jobId),
-    })
-
-    const runsByJob = new Map<string, JobRunWithDetails[]>()
-
-    for (const run of jobRuns) {
-      const enriched = enrichWithJob(run)
-      const existing = runsByJob.get(run.jobId) ?? []
-      existing.push(enriched)
-      runsByJob.set(run.jobId, existing)
-    }
-
-    const groups: Array<{ job: ScheduledJob; runs: JobRunWithDetails[] }> = []
-
-    for (const [jobId, runs] of runsByJob) {
-      const job = jobs.find((j) => j.id === jobId)
-      if (!job) continue
-
-      const sorted = runs.sort(
-        (a, b) =>
-          new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
-      )
-
-      groups.push({ job, runs: sorted })
-    }
-
-    return groups.sort((a, b) => {
-      const latestA = a.runs[0]?.startedAt ?? ''
-      const latestB = b.runs[0]?.startedAt ?? ''
-      return new Date(latestB).getTime() - new Date(latestA).getTime()
-    })
-  }, [jobRuns, jobs])
+  const groupedRuns = useMemo(
+    () => groupRunsByJob(jobRuns, jobs),
+    [jobRuns, jobs],
+  )
 
   if (!groupedRuns.length) {
     return (

--- a/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/types.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/types.ts
@@ -11,3 +11,52 @@ export interface ScheduledTasksStorage {
   loadRuns(): Promise<ScheduledJobRun[]>
   saveRuns(runs: ScheduledJobRun[]): Promise<void>
 }
+
+export interface JobRunWithDetails extends ScheduledJobRun {
+  job: ScheduledJob
+}
+
+export interface JobGroup {
+  job: ScheduledJob
+  runs: JobRunWithDetails[]
+}
+
+export function groupRunsByJob(
+  jobRuns: ScheduledJobRun[],
+  jobs: ScheduledJob[],
+): JobGroup[] {
+  const runsByJob = new Map<string, JobRunWithDetails[]>()
+
+  for (const run of jobRuns) {
+    const job = jobs.find((j) => j.id === run.jobId) ?? {
+      id: run.jobId,
+      name: 'Unknown task',
+      query: '',
+      scheduleType: 'daily' as const,
+      enabled: false,
+      createdAt: '',
+      updatedAt: '',
+    }
+
+    const enriched = { ...run, job }
+    const existing = runsByJob.get(run.jobId) ?? []
+    existing.push(enriched)
+    runsByJob.set(run.jobId, existing)
+  }
+
+  const groups: JobGroup[] = []
+
+  for (const [, runs] of runsByJob) {
+    const sorted = runs.sort(
+      (a, b) =>
+        new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+    )
+    groups.push({ job: sorted[0].job, runs: sorted })
+  }
+
+  return groups.sort((a, b) => {
+    const latestA = a.runs[0]?.startedAt ?? ''
+    const latestB = b.runs[0]?.startedAt ?? ''
+    return new Date(latestB).getTime() - new Date(latestA).getTime()
+  })
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/types.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/types.ts
@@ -25,10 +25,11 @@ export function groupRunsByJob(
   jobRuns: ScheduledJobRun[],
   jobs: ScheduledJob[],
 ): JobGroup[] {
+  const jobsById = new Map(jobs.map((j) => [j.id, j]))
   const runsByJob = new Map<string, JobRunWithDetails[]>()
 
   for (const run of jobRuns) {
-    const job = jobs.find((j) => j.id === run.jobId) ?? {
+    const job = jobsById.get(run.jobId) ?? {
       id: run.jobId,
       name: 'Unknown task',
       query: '',

--- a/packages/browseros-agent/apps/agent/entrypoints/newtab/index/NewTabChat.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/newtab/index/NewTabChat.tsx
@@ -79,16 +79,26 @@ export const NewTabChat: FC = () => {
   // biome-ignore lint/correctness/useExhaustiveDependencies: must only run once on mount
   useEffect(() => {
     if (hasSentInitialRef.current) return
-    const query = searchParams.get('q')
+    const queryParam = searchParams.get('q')
     const chatMode = searchParams.get('mode')
     const tabIdsParam = searchParams.get('tabs')
-    if (!query) return
+    const source = searchParams.get('source')
+    if (!queryParam) return
 
     hasSentInitialRef.current = true
     if (chatMode === 'chat' || chatMode === 'agent') {
       setMode(chatMode)
     }
     setSearchParams({}, { replace: true })
+
+    const query =
+      source === 'scheduled-task'
+        ? (sessionStorage.getItem(queryParam) ?? queryParam)
+        : queryParam
+
+    if (source === 'scheduled-task') {
+      sessionStorage.removeItem(queryParam)
+    }
 
     const actionType = searchParams.get('actionType')
     const tabName = searchParams.get('tabName')

--- a/packages/browseros-agent/apps/agent/entrypoints/newtab/index/ScheduleResults.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/newtab/index/ScheduleResults.tsx
@@ -35,7 +35,7 @@ import {
   groupRunsByJob,
   type JobGroup,
   type JobRunWithDetails,
-} from '../app/scheduled-tasks/types'
+} from '../../app/scheduled-tasks/types'
 
 dayjs.extend(relativeTime)
 

--- a/packages/browseros-agent/apps/agent/entrypoints/newtab/index/ScheduleResults.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/newtab/index/ScheduleResults.tsx
@@ -42,6 +42,11 @@ interface JobRunWithDetails extends ScheduledJobRun {
   job: ScheduledJob | undefined
 }
 
+interface JobGroup {
+  job: ScheduledJob
+  runs: JobRunWithDetails[]
+}
+
 const MAX_DISPLAY_COUNT = 3
 const SCHEDULE_RESULTS_COLLAPSED_KEY = 'schedule-results-collapsed'
 
@@ -63,6 +68,7 @@ export const ScheduleResults: FC = () => {
     const stored = localStorage.getItem(SCHEDULE_RESULTS_COLLAPSED_KEY)
     return stored !== 'true'
   })
+  const [openGroupId, setOpenGroupId] = useState<string | null>(null)
   const [viewingRun, setViewingRun] = useState<JobRunWithDetails | null>(null)
 
   const handleOpenChange = (open: boolean) => {
@@ -75,30 +81,42 @@ export const ScheduleResults: FC = () => {
 
   const runningCount = jobRuns.filter((r) => r.status === 'running').length
 
-  const displayedRuns: JobRunWithDetails[] = useMemo(() => {
+  const groupedRuns: JobGroup[] = useMemo(() => {
     const enrichWithJob = (run: ScheduledJobRun): JobRunWithDetails => ({
       ...run,
       job: jobs.find((j) => j.id === run.jobId),
     })
 
-    const runningJobs = jobRuns
-      .filter((r) => r.status === 'running')
-      .map(enrichWithJob)
+    const runsByJob = new Map<string, JobRunWithDetails[]>()
 
-    if (runningJobs.length >= MAX_DISPLAY_COUNT) {
-      return runningJobs
+    for (const run of jobRuns) {
+      const enriched = enrichWithJob(run)
+      const existing = runsByJob.get(run.jobId) ?? []
+      existing.push(enriched)
+      runsByJob.set(run.jobId, existing)
     }
 
-    const completedOrFailed = jobRuns
-      .filter((r) => r.status === 'completed' || r.status === 'failed')
-      .sort(
+    const groups: JobGroup[] = []
+
+    for (const [jobId, runs] of runsByJob) {
+      const job = jobs.find((j) => j.id === jobId)
+      if (!job) continue
+
+      const sorted = runs.sort(
         (a, b) =>
           new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
       )
-      .slice(0, MAX_DISPLAY_COUNT - runningJobs.length)
-      .map(enrichWithJob)
 
-    return [...runningJobs, ...completedOrFailed]
+      groups.push({ job, runs: sorted })
+    }
+
+    return groups
+      .sort((a, b) => {
+        const latestA = a.runs[0]?.startedAt ?? ''
+        const latestB = b.runs[0]?.startedAt ?? ''
+        return new Date(latestB).getTime() - new Date(latestA).getTime()
+      })
+      .slice(0, MAX_DISPLAY_COUNT)
   }, [jobRuns, jobs])
 
   const viewRun = (run: JobRunWithDetails) => {
@@ -117,7 +135,7 @@ export const ScheduleResults: FC = () => {
     track(SCHEDULED_TASK_RETRIED_EVENT)
   }
 
-  if (!displayedRuns.length) return null
+  if (!groupedRuns.length) return null
 
   return (
     <Collapsible
@@ -148,62 +166,118 @@ export const ScheduleResults: FC = () => {
       </CollapsibleTrigger>
 
       <CollapsibleContent className="fade-in-0 slide-in-from-top-2 animate-in space-y-2 duration-200">
-        {displayedRuns.map((run) => (
-          <Button
-            key={run.id}
-            variant="ghost"
-            onClick={() => viewRun(run)}
-            className="h-auto w-full justify-start rounded-xl border border-border/50 bg-card p-4 text-left transition-all hover:border-border"
-          >
-            <div className="flex w-full items-start gap-3">
-              {getStatusIcon(run.status)}
-              <div className="min-w-0 flex-1">
-                <div className="mb-1 flex items-center gap-2">
-                  <span className="truncate font-medium text-foreground text-sm">
-                    {run.job?.name}
-                  </span>
-                  <span className="flex items-center gap-1 text-muted-foreground text-xs">
-                    <Clock className="h-3 w-3" />
-                    {formatTimestamp(run.startedAt)}
-                  </span>
+        {groupedRuns.map(({ job, runs }) => {
+          const latestRun = runs[0]
+          const latestTime = latestRun ? formatTimestamp(latestRun.startedAt) : ''
+          const groupRunningCount = runs.filter(
+            (r) => r.status === 'running',
+          ).length
+
+          return (
+            <Collapsible
+              key={job.id}
+              open={openGroupId === job.id}
+              onOpenChange={(open) => setOpenGroupId(open ? job.id : null)}
+            >
+              <CollapsibleTrigger asChild>
+                <Button
+                  variant="ghost"
+                  className="flex h-auto w-full items-center justify-between rounded-xl border border-border/50 bg-card p-4 text-left transition-all hover:border-border"
+                >
+                  <div className="flex items-center gap-3">
+                    {latestRun ? getStatusIcon(latestRun.status) : null}
+                    <div className="min-w-0 flex-1">
+                      <div className="mb-1 flex items-center gap-2">
+                        <span className="truncate font-medium text-foreground text-sm">
+                          {job.name}
+                        </span>
+                        {groupRunningCount > 0 && (
+                          <span className="rounded-full bg-accent-orange/20 px-2 py-0.5 text-accent-orange text-xs">
+                            {groupRunningCount} running
+                          </span>
+                        )}
+                      </div>
+                      <div className="flex items-center gap-2 text-muted-foreground text-xs">
+                        <span className="flex items-center gap-1">
+                          <Clock className="h-3 w-3" />
+                          {latestTime}
+                        </span>
+                        <span>•</span>
+                        <span>
+                          {runs.length}{' '}
+                          {runs.length === 1 ? 'result' : 'results'}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                  <ChevronDown
+                    className={`h-4 w-4 text-muted-foreground transition-transform duration-200 ${openGroupId === job.id ? 'rotate-180' : ''}`}
+                  />
+                </Button>
+              </CollapsibleTrigger>
+
+              <CollapsibleContent className="fade-in-0 slide-in-from-top-2 animate-in pt-2 duration-200">
+                <div className="space-y-2 pl-4">
+                  {runs.map((run) => (
+                    <Button
+                      key={run.id}
+                      variant="ghost"
+                      onClick={() => viewRun(run)}
+                      className="h-auto w-full justify-start rounded-lg border border-border/50 bg-background p-3 text-left transition-all hover:border-border"
+                    >
+                      <div className="flex w-full items-start gap-3">
+                        {getStatusIcon(run.status)}
+                        <div className="min-w-0 flex-1">
+                          <div className="mb-1 flex items-center gap-2">
+                            <span className="text-sm">
+                              {dayjs(run.startedAt).format('MMM D, h:mm A')}
+                            </span>
+                            <span className="flex items-center gap-1 text-muted-foreground text-xs">
+                              {formatTimestamp(run.startedAt)}
+                            </span>
+                          </div>
+                          {run.result && (
+                            <p className="line-clamp-2 text-ellipsis text-muted-foreground text-xs">
+                              {run.result}
+                            </p>
+                          )}
+                        </div>
+                        {run.status === 'running' && (
+                          <Button
+                            variant="ghost"
+                            size="icon-sm"
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              handleCancelRun(run.id)
+                            }}
+                            className="shrink-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                            aria-label="Cancel run"
+                          >
+                            <Square className="h-3.5 w-3.5" />
+                          </Button>
+                        )}
+                        {run.status === 'failed' && (
+                          <Button
+                            variant="ghost"
+                            size="icon-sm"
+                            onClick={(e) => {
+                              e.stopPropagation()
+                              handleRetryRun(run.jobId)
+                            }}
+                            className="shrink-0 text-muted-foreground hover:text-foreground"
+                            aria-label="Retry run"
+                          >
+                            <RotateCcw className="h-3.5 w-3.5" />
+                          </Button>
+                        )}
+                      </div>
+                    </Button>
+                  ))}
                 </div>
-                {run.result && (
-                  <p className="line-clamp-2 text-ellipsis text-muted-foreground text-xs">
-                    {run.result}
-                  </p>
-                )}
-              </div>
-              {run.status === 'running' && (
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    handleCancelRun(run.id)
-                  }}
-                  className="shrink-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
-                  aria-label="Cancel run"
-                >
-                  <Square className="h-3.5 w-3.5" />
-                </Button>
-              )}
-              {run.status === 'failed' && (
-                <Button
-                  variant="ghost"
-                  size="icon-sm"
-                  onClick={(e) => {
-                    e.stopPropagation()
-                    handleRetryRun(run.jobId)
-                  }}
-                  className="shrink-0 text-muted-foreground hover:text-foreground"
-                  aria-label="Retry run"
-                >
-                  <RotateCcw className="h-3.5 w-3.5" />
-                </Button>
-              )}
-            </div>
-          </Button>
-        ))}
+              </CollapsibleContent>
+            </Collapsible>
+          )
+        })}
         <Button variant="ghost" asChild className="w-full">
           {/* biome-ignore lint/a11y/useValidAnchor: click handler is passive */}
           <a

--- a/packages/browseros-agent/apps/agent/entrypoints/newtab/index/ScheduleResults.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/newtab/index/ScheduleResults.tsx
@@ -31,21 +31,13 @@ import {
   useScheduledJobRuns,
   useScheduledJobs,
 } from '@/lib/schedules/scheduleStorage'
-import type {
-  ScheduledJob,
-  ScheduledJobRun,
-} from '@/lib/schedules/scheduleTypes'
+import {
+  groupRunsByJob,
+  type JobGroup,
+  type JobRunWithDetails,
+} from '../app/scheduled-tasks/types'
 
 dayjs.extend(relativeTime)
-
-interface JobRunWithDetails extends ScheduledJobRun {
-  job: ScheduledJob | undefined
-}
-
-interface JobGroup {
-  job: ScheduledJob
-  runs: JobRunWithDetails[]
-}
 
 const MAX_DISPLAY_COUNT = 3
 const SCHEDULE_RESULTS_COLLAPSED_KEY = 'schedule-results-collapsed'
@@ -82,41 +74,22 @@ export const ScheduleResults: FC = () => {
   const runningCount = jobRuns.filter((r) => r.status === 'running').length
 
   const groupedRuns: JobGroup[] = useMemo(() => {
-    const enrichWithJob = (run: ScheduledJobRun): JobRunWithDetails => ({
-      ...run,
-      job: jobs.find((j) => j.id === run.jobId),
-    })
+    const allGroups = groupRunsByJob(jobRuns, jobs)
 
-    const runsByJob = new Map<string, JobRunWithDetails[]>()
+    const withRunning = allGroups.filter((g) =>
+      g.runs.some((r) => r.status === 'running'),
+    )
+    const withoutRunning = allGroups.filter(
+      (g) => !g.runs.some((r) => r.status === 'running'),
+    )
 
-    for (const run of jobRuns) {
-      const enriched = enrichWithJob(run)
-      const existing = runsByJob.get(run.jobId) ?? []
-      existing.push(enriched)
-      runsByJob.set(run.jobId, existing)
+    const result = [...withRunning]
+    for (const group of withoutRunning) {
+      if (result.length >= MAX_DISPLAY_COUNT) break
+      result.push(group)
     }
 
-    const groups: JobGroup[] = []
-
-    for (const [jobId, runs] of runsByJob) {
-      const job = jobs.find((j) => j.id === jobId)
-      if (!job) continue
-
-      const sorted = runs.sort(
-        (a, b) =>
-          new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
-      )
-
-      groups.push({ job, runs: sorted })
-    }
-
-    return groups
-      .sort((a, b) => {
-        const latestA = a.runs[0]?.startedAt ?? ''
-        const latestB = b.runs[0]?.startedAt ?? ''
-        return new Date(latestB).getTime() - new Date(latestA).getTime()
-      })
-      .slice(0, MAX_DISPLAY_COUNT)
+    return result
   }, [jobRuns, jobs])
 
   const viewRun = (run: JobRunWithDetails) => {
@@ -168,7 +141,9 @@ export const ScheduleResults: FC = () => {
       <CollapsibleContent className="fade-in-0 slide-in-from-top-2 animate-in space-y-2 duration-200">
         {groupedRuns.map(({ job, runs }) => {
           const latestRun = runs[0]
-          const latestTime = latestRun ? formatTimestamp(latestRun.startedAt) : ''
+          const latestTime = latestRun
+            ? formatTimestamp(latestRun.startedAt)
+            : ''
           const groupRunningCount = runs.filter(
             (r) => r.status === 'running',
           ).length

--- a/packages/browseros-agent/apps/agent/lib/constants/analyticsEvents.ts
+++ b/packages/browseros-agent/apps/agent/lib/constants/analyticsEvents.ts
@@ -217,6 +217,10 @@ export const SCHEDULED_TASK_CANCELLED_EVENT =
 export const SCHEDULED_TASK_RETRIED_EVENT = 'settings.scheduled_task.retried'
 
 /** @public */
+export const SCHEDULED_TASK_CONTINUE_IN_CHAT_EVENT =
+  'settings.scheduled_task.continue_in_chat'
+
+/** @public */
 export const JTBD_POPUP_DISMISSED_EVENT = 'ui.jtbd_popup.dismissed'
 
 /** @public */


### PR DESCRIPTION
## Summary

- Add "Continue in Chat" dropdown button to scheduled task result dialog
- Users can continue the conversation with task output in Chat or Assistant mode
- Fixes pre-existing import path bug in ScheduleResults.tsx

## Changes

### RunResultDialog.tsx
- Added DropdownMenu with two options: **Chat** and **Assistant**
- Chat navigates to `/home/chat?q=<result>&mode=chat`
- Assistant navigates to `/home/chat?q=<result>&mode=agent`
- Button only appears when `run.result` exists (same as Copy button)
- Uses existing shadcn DropdownMenu components
- Tracks usage via `SCHEDULED_TASK_CONTINUE_IN_CHAT_EVENT` analytics event

### ScheduleResults.tsx
- Fixed import path: `../app/scheduled-tasks/types` → `../../app/scheduled-tasks/types`
- This was a pre-existing bug that blocked the build

### analyticsEvents.ts
- Added `SCHEDULED_TASK_CONTINUE_IN_CHAT_EVENT` constant

## Motivation

When a scheduled task completes, users currently have no way to immediately act on the output. They must manually copy, open a new chat, and paste. This feature closes the loop — **run → review → act → repeat** — without leaving the browser.

## Mock UX

```
┌─────────────────────────────────┐
│  Scheduled Task: "Morning News" │
│  Completed at 09:00             │
│                                 │
│  [Latest headlines...]          │
│                                 │
│  [Copy]  [Continue in Chat ▼]  [Close]  │
│                   ├─ Chat       │
│                   └─ Assistant  │
└─────────────────────────────────┘
```
<img width="840" height="468" alt="Ekran Görüntüsü_20260508_123946" src="https://github.com/user-attachments/assets/85837e65-9840-4919-a077-0f6e5488e8a0" />


Closes #949