### PR TITLE
fix(agent): add cloud sync sign-in disclosure

### DIFF
--- a/packages/browseros-agent/apps/agent/components/auth/CloudSyncDisclosure.tsx
+++ b/packages/browseros-agent/apps/agent/components/auth/CloudSyncDisclosure.tsx
@@ -1,0 +1,40 @@
+import { cloudSyncSignInLinks } from '@/lib/constants/productUrls'
+import { cn } from '@/lib/utils'
+
+interface CloudSyncDisclosureProps {
+  className?: string
+}
+
+export function CloudSyncDisclosure({ className }: CloudSyncDisclosureProps) {
+  const [termsLink, privacyLink, cloudSyncLink] = cloudSyncSignInLinks
+
+  return (
+    <p
+      className={cn(
+        'text-center text-muted-foreground text-xs leading-relaxed',
+        className,
+      )}
+    >
+      By signing in, you agree to the <DisclosureLink link={termsLink} /> and
+      acknowledge the <DisclosureLink link={privacyLink} />.{' '}
+      <DisclosureLink link={cloudSyncLink} />.
+    </p>
+  )
+}
+
+function DisclosureLink({
+  link,
+}: {
+  link: (typeof cloudSyncSignInLinks)[number]
+}) {
+  return (
+    <a
+      href={link.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="font-medium underline underline-offset-2 hover:text-foreground"
+    >
+      {link.label}
+    </a>
+  )
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/login/LoginPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/login/LoginPage.tsx
@@ -8,6 +8,7 @@ import {
 import type { FC } from 'react'
 import { useEffect, useState } from 'react'
 import { useNavigate } from 'react-router'
+import { CloudSyncDisclosure } from '@/components/auth/CloudSyncDisclosure'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import {
@@ -199,6 +200,8 @@ export const LoginPage: FC = () => {
           )}
           Continue with Google
         </Button>
+
+        <CloudSyncDisclosure />
       </CardContent>
     </Card>
   )

--- a/packages/browseros-agent/apps/agent/entrypoints/onboarding/steps/StepTwo.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/onboarding/steps/StepTwo.tsx
@@ -1,5 +1,6 @@
 import { AlertCircle, CheckCircle2, Loader2, Mail } from 'lucide-react'
 import { useState } from 'react'
+import { CloudSyncDisclosure } from '@/components/auth/CloudSyncDisclosure'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
@@ -198,6 +199,8 @@ export const StepTwo = ({ direction, onContinue }: StepTwoProps) => {
               Send Magic Link
             </Button>
           </form>
+
+          <CloudSyncDisclosure />
 
           <div className="text-center">
             <Button

--- a/packages/browseros-agent/apps/agent/lib/constants/productUrls.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/constants/productUrls.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  cloudSyncHelpUrl,
+  cloudSyncSignInLinks,
+  privacyPolicyUrl,
+  termsOfServiceUrl,
+} from './productUrls'
+
+describe('cloud sync sign-in links', () => {
+  it('points to the public legal and cloud sync documentation URLs', () => {
+    expect(termsOfServiceUrl).toBe('https://browseros.com/terms')
+    expect(privacyPolicyUrl).toBe('https://browseros.com/privacy')
+    expect(cloudSyncHelpUrl).toBe(
+      'https://docs.browseros.com/features/sync-to-cloud',
+    )
+  })
+
+  it('includes legal and cloud sync documentation links in display order', () => {
+    expect(cloudSyncSignInLinks).toEqual([
+      { label: 'Terms of Service', url: termsOfServiceUrl },
+      { label: 'Privacy Policy', url: privacyPolicyUrl },
+      { label: 'Learn more about cloud sync', url: cloudSyncHelpUrl },
+    ])
+  })
+})

--- a/packages/browseros-agent/apps/agent/lib/constants/productUrls.ts
+++ b/packages/browseros-agent/apps/agent/lib/constants/productUrls.ts
@@ -26,6 +26,26 @@ export const privacyPolicyUrl = 'https://browseros.com/privacy'
 /**
  * @public
  */
+export const termsOfServiceUrl = 'https://browseros.com/terms'
+
+/**
+ * @public
+ */
+export const cloudSyncHelpUrl =
+  'https://docs.browseros.com/features/sync-to-cloud'
+
+/**
+ * @public
+ */
+export const cloudSyncSignInLinks = [
+  { label: 'Terms of Service', url: termsOfServiceUrl },
+  { label: 'Privacy Policy', url: privacyPolicyUrl },
+  { label: 'Learn more about cloud sync', url: cloudSyncHelpUrl },
+] as const
+
+/**
+ * @public
+ */
 export const contributorsUrl =
   'https://github.com/browseros-ai/BrowserOS/graphs/contributors'
 


### PR DESCRIPTION
## Summary
- Add Terms of Service, Privacy Policy, and cloud sync docs links to BrowserOS sign-in surfaces.
- Share one CloudSyncDisclosure component between the login page and onboarding sign-in step.
- Add tests that pin the legal/docs URLs and display order.

## Test plan
- bun test apps/agent/lib/constants/productUrls.test.ts
- bun run --filter @browseros/agent typecheck
- bun run --filter @browseros/agent test
- bun run --filter @browseros/agent lint

Fixes #419
