### PR TITLE
feat(agent): continue scheduled task results in chat

### DIFF
--- a/packages/browseros-agent/apps/agent/components/ai-elements/run-result-dialog.tsx
+++ b/packages/browseros-agent/apps/agent/components/ai-elements/run-result-dialog.tsx
@@ -6,6 +6,7 @@ import {
   CheckCircle2,
   Copy,
   Loader2,
+  MessageSquareText,
   RotateCcw,
   Square,
   XCircle,
@@ -31,6 +32,7 @@ interface RunResultDialogProps {
   onOpenChange: (open: boolean) => void
   onCancelRun?: (runId: string) => void
   onRetryRun?: (jobId: string) => void
+  onContinueInChat?: (run: ScheduledJobRun) => void
 }
 
 const formatDateTime = (dateStr: string) =>
@@ -52,6 +54,7 @@ export const RunResultDialog: FC<RunResultDialogProps> = ({
   onOpenChange,
   onCancelRun,
   onRetryRun,
+  onContinueInChat,
 }) => {
   const [copied, setCopied] = useState(false)
 
@@ -140,6 +143,18 @@ export const RunResultDialog: FC<RunResultDialogProps> = ({
                   Copy
                 </>
               )}
+            </Button>
+          )}
+          {run.result && onContinueInChat && (
+            <Button
+              variant="outline"
+              onClick={() => {
+                onContinueInChat(run)
+                onOpenChange(false)
+              }}
+            >
+              <MessageSquareText className="h-4 w-4" />
+              Continue in Chat
             </Button>
           )}
           <Button onClick={() => onOpenChange(false)}>Close</Button>

--- a/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTasksPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/scheduled-tasks/ScheduledTasksPage.tsx
@@ -1,5 +1,5 @@
 import { type FC, useEffect, useRef, useState } from 'react'
-import { useSearchParams } from 'react-router'
+import { useNavigate, useSearchParams } from 'react-router'
 import { RunResultDialog } from '@/components/ai-elements/run-result-dialog'
 import {
   AlertDialog,
@@ -40,6 +40,7 @@ import type { ScheduledJob } from './types'
  * @public
  */
 export const ScheduledTasksPage: FC = () => {
+  const navigate = useNavigate()
   const { jobs, addJob, editJob, toggleJob, removeJob, runJob } =
     useScheduledJobs()
   const { jobRuns, cancelJobRun } = useScheduledJobRuns()
@@ -149,6 +150,15 @@ export const ScheduledTasksPage: FC = () => {
     track(SCHEDULED_TASK_VIEW_RESULTS_EVENT)
   }
 
+  const handleContinueInChat = (run: ScheduledJobRun) => {
+    const params = new URLSearchParams({
+      scheduledRunId: run.id,
+      mode: 'chat',
+    })
+    setViewingRunId(null)
+    navigate(`/home/chat?${params.toString()}`)
+  }
+
   useEffect(() => {
     scheduledJobRunStorage.getValue().then((runs) => {
       setActiveTab(runs && runs.length > 0 ? 'results' : 'tasks')
@@ -216,6 +226,7 @@ export const ScheduledTasksPage: FC = () => {
           handleRetryRun(jobId)
           setViewingRunId(null)
         }}
+        onContinueInChat={handleContinueInChat}
       />
 
       <AlertDialog

--- a/packages/browseros-agent/apps/agent/entrypoints/newtab/index/NewTabChat.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/newtab/index/NewTabChat.tsx
@@ -46,6 +46,7 @@ export const NewTabChat: FC = () => {
     isRestoringConversation,
     providers,
     selectedProvider,
+    scheduledTaskContext,
     handleSelectProvider,
     resetConversation,
     input,
@@ -82,13 +83,24 @@ export const NewTabChat: FC = () => {
     const query = searchParams.get('q')
     const chatMode = searchParams.get('mode')
     const tabIdsParam = searchParams.get('tabs')
-    if (!query) return
-
-    hasSentInitialRef.current = true
     if (chatMode === 'chat' || chatMode === 'agent') {
       setMode(chatMode)
     }
-    setSearchParams({}, { replace: true })
+    if (!query) return
+
+    hasSentInitialRef.current = true
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev)
+        next.delete('q')
+        next.delete('tabs')
+        next.delete('actionType')
+        next.delete('tabName')
+        next.delete('tabDescription')
+        return next
+      },
+      { replace: true },
+    )
 
     const actionType = searchParams.get('actionType')
     const tabName = searchParams.get('tabName')
@@ -177,6 +189,17 @@ export const NewTabChat: FC = () => {
         )}
         {chatError && (
           <ChatError error={chatError} providerType={selectedProvider?.type} />
+        )}
+        {scheduledTaskContext.status === 'ready' && (
+          <div className="rounded-lg border border-border bg-muted/45 px-3 py-2 text-muted-foreground text-sm">
+            Scheduled task result loaded: {scheduledTaskContext.jobName}
+          </div>
+        )}
+        {scheduledTaskContext.status === 'error' && (
+          <ChatError
+            error={scheduledTaskContext.error}
+            providerType={selectedProvider?.type}
+          />
         )}
       </main>
 

--- a/packages/browseros-agent/apps/agent/entrypoints/newtab/index/ScheduleResults.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/newtab/index/ScheduleResults.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react'
 import type { FC } from 'react'
 import { useMemo, useState } from 'react'
+import { useNavigate } from 'react-router'
 import { RunResultDialog } from '@/components/ai-elements/run-result-dialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -59,6 +60,7 @@ const getStatusIcon = (status: JobRunWithDetails['status']) => {
 const formatTimestamp = (dateString: string) => dayjs(dateString).fromNow()
 
 export const ScheduleResults: FC = () => {
+  const navigate = useNavigate()
   const [isOpen, setIsOpen] = useState(() => {
     const stored = localStorage.getItem(SCHEDULE_RESULTS_COLLAPSED_KEY)
     return stored !== 'true'
@@ -104,6 +106,15 @@ export const ScheduleResults: FC = () => {
   const viewRun = (run: JobRunWithDetails) => {
     track(SCHEDULED_TASK_VIEW_RESULTS_IN_NEWTAB_EVENT)
     setViewingRun(run)
+  }
+
+  const handleContinueInChat = (run: ScheduledJobRun) => {
+    const params = new URLSearchParams({
+      scheduledRunId: run.id,
+      mode: 'chat',
+    })
+    setViewingRun(null)
+    navigate(`/home/chat?${params.toString()}`)
   }
 
   const handleCancelRun = async (runId: string) => {
@@ -221,6 +232,7 @@ export const ScheduleResults: FC = () => {
         onOpenChange={(open) => !open && setViewingRun(null)}
         onCancelRun={handleCancelRun}
         onRetryRun={handleRetryRun}
+        onContinueInChat={handleContinueInChat}
       />
     </Collapsible>
   )

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -205,6 +205,35 @@ const buildRequestBrowserContext = ({
   return Object.keys(browserContext).length ? browserContext : undefined
 }
 
+type ScheduledTaskContextLoadResult =
+  | { context: string; jobName: string }
+  | { error: string }
+
+const loadScheduledTaskContextForRun = async (
+  runId: string,
+): Promise<ScheduledTaskContextLoadResult> => {
+  const [runs, jobs] = await Promise.all([
+    scheduledJobRunStorage.getValue(),
+    scheduledJobStorage.getValue(),
+  ])
+
+  const run = (runs ?? []).find((item) => item.id === runId)
+  if (!run) {
+    return { error: 'Scheduled task result was not found.' }
+  }
+
+  const job = (jobs ?? []).find((item) => item.id === run.jobId)
+  const context = buildScheduledTaskResultChatContext({ run, job })
+  if (!context) {
+    return { error: 'Scheduled task result has no output.' }
+  }
+
+  return {
+    context,
+    jobName: job?.name?.trim() || 'Scheduled Task',
+  }
+}
+
 export const useChatSession = (options?: ChatSessionOptions) => {
   const {
     selectedLlmProviderRef,
@@ -262,38 +291,23 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     })
 
     const loadScheduledTaskContext = async () => {
-      const [runs, jobs] = await Promise.all([
-        scheduledJobRunStorage.getValue(),
-        scheduledJobStorage.getValue(),
-      ])
+      const result = await loadScheduledTaskContextForRun(scheduledRunIdParam)
       if (cancelled) return
 
-      const run = (runs ?? []).find((item) => item.id === scheduledRunIdParam)
-      if (!run) {
+      if ('error' in result) {
         setScheduledTaskContext({
           status: 'error',
           runId: scheduledRunIdParam,
-          error: 'Scheduled task result was not found.',
+          error: result.error,
         })
         return
       }
 
-      const job = (jobs ?? []).find((item) => item.id === run.jobId)
-      const context = buildScheduledTaskResultChatContext({ run, job })
-      if (!context) {
-        setScheduledTaskContext({
-          status: 'error',
-          runId: scheduledRunIdParam,
-          error: 'Scheduled task result has no output.',
-        })
-        return
-      }
-
-      scheduledTaskContextRef.current = context
+      scheduledTaskContextRef.current = result.context
       setScheduledTaskContext({
         status: 'ready',
         runId: scheduledRunIdParam,
-        jobName: job?.name?.trim() || 'Scheduled Task',
+        jobName: result.jobName,
       })
     }
 
@@ -473,10 +487,31 @@ export const useChatSession = (options?: ChatSessionOptions) => {
             : history.map((m) => `${m.role}: ${m.content}`).join('\n')
           : undefined
 
+        let scheduledTaskContextForRequest = scheduledTaskContextRef.current
+        if (!scheduledTaskContextForRequest && scheduledRunIdParam) {
+          const result =
+            await loadScheduledTaskContextForRun(scheduledRunIdParam)
+          if ('error' in result) {
+            setScheduledTaskContext({
+              status: 'error',
+              runId: scheduledRunIdParam,
+              error: result.error,
+            })
+          } else {
+            scheduledTaskContextForRequest = result.context
+            scheduledTaskContextRef.current = result.context
+            setScheduledTaskContext({
+              status: 'ready',
+              runId: scheduledRunIdParam,
+              jobName: result.jobName,
+            })
+          }
+        }
+
         const userSystemPrompt = getUserSystemPrompt(
           options?.origin,
           personalizationRef.current,
-          scheduledTaskContextRef.current,
+          scheduledTaskContextForRequest,
         )
 
         const commonRequest = {

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -31,6 +31,11 @@ import type {
   ChatRequestBrowserContext,
 } from '@/lib/messaging/server/buildChatRequestBody'
 import { track } from '@/lib/metrics/track'
+import { buildScheduledTaskResultChatContext } from '@/lib/schedules/scheduledChatContext'
+import {
+  scheduledJobRunStorage,
+  scheduledJobStorage,
+} from '@/lib/schedules/scheduleStorage'
 import { searchActionsStorage } from '@/lib/search-actions/searchActionsStorage'
 import { selectedTextStorage } from '@/lib/selected-text/selectedTextStorage'
 import { sentry } from '@/lib/sentry/sentry'
@@ -132,15 +137,28 @@ export interface ChatSessionOptions {
   isIntegrationsSynced?: boolean
 }
 
+export type ScheduledTaskContextState =
+  | { status: 'idle' }
+  | { status: 'loading'; runId: string }
+  | { status: 'ready'; runId: string; jobName: string }
+  | { status: 'error'; runId: string; error: string }
+
 const NEWTAB_SYSTEM_PROMPT = `IMPORTANT: The user is chatting from the New Tab page. When performing browser actions, ALWAYS open content in a NEW TAB rather than navigating the current tab. The user's new tab page should remain accessible.`
 
 const getUserSystemPrompt = (
   origin: ChatOrigin | undefined,
   personalization: string,
-) =>
-  origin === 'newtab'
-    ? [personalization, NEWTAB_SYSTEM_PROMPT].filter(Boolean).join('\n\n')
-    : personalization
+  scheduledTaskContext?: string | null,
+) => {
+  const parts = [personalization]
+  if (origin === 'newtab') {
+    parts.push(NEWTAB_SYSTEM_PROMPT)
+  }
+  if (scheduledTaskContext) {
+    parts.push(scheduledTaskContext)
+  }
+  return parts.filter(Boolean).join('\n\n')
+}
 
 const buildRequestBrowserContext = ({
   activeTab,
@@ -218,12 +236,80 @@ export const useChatSession = (options?: ChatSessionOptions) => {
   } = useRemoteConversationSave()
   const [searchParams, setSearchParams] = useSearchParams()
   const conversationIdParam = searchParams.get('conversationId')
+  const scheduledRunIdParam = searchParams.get('scheduledRunId')
 
   const agentUrlRef = useRef(agentServerUrl)
+  const scheduledTaskContextRef = useRef<string | null>(null)
+  const [scheduledTaskContext, setScheduledTaskContext] =
+    useState<ScheduledTaskContextState>({ status: 'idle' })
 
   useEffect(() => {
     agentUrlRef.current = agentServerUrl
   }, [agentServerUrl])
+
+  useEffect(() => {
+    if (!scheduledRunIdParam) {
+      scheduledTaskContextRef.current = null
+      setScheduledTaskContext({ status: 'idle' })
+      return
+    }
+
+    let cancelled = false
+    scheduledTaskContextRef.current = null
+    setScheduledTaskContext({
+      status: 'loading',
+      runId: scheduledRunIdParam,
+    })
+
+    const loadScheduledTaskContext = async () => {
+      const [runs, jobs] = await Promise.all([
+        scheduledJobRunStorage.getValue(),
+        scheduledJobStorage.getValue(),
+      ])
+      if (cancelled) return
+
+      const run = (runs ?? []).find((item) => item.id === scheduledRunIdParam)
+      if (!run) {
+        setScheduledTaskContext({
+          status: 'error',
+          runId: scheduledRunIdParam,
+          error: 'Scheduled task result was not found.',
+        })
+        return
+      }
+
+      const job = (jobs ?? []).find((item) => item.id === run.jobId)
+      const context = buildScheduledTaskResultChatContext({ run, job })
+      if (!context) {
+        setScheduledTaskContext({
+          status: 'error',
+          runId: scheduledRunIdParam,
+          error: 'Scheduled task result has no output.',
+        })
+        return
+      }
+
+      scheduledTaskContextRef.current = context
+      setScheduledTaskContext({
+        status: 'ready',
+        runId: scheduledRunIdParam,
+        jobName: job?.name?.trim() || 'Scheduled Task',
+      })
+    }
+
+    loadScheduledTaskContext().catch((error) => {
+      if (cancelled) return
+      setScheduledTaskContext({
+        status: 'error',
+        runId: scheduledRunIdParam,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    })
+
+    return () => {
+      cancelled = true
+    }
+  }, [scheduledRunIdParam])
 
   const providers: Provider[] = chatTargets.map(toProviderOption)
 
@@ -390,6 +476,7 @@ export const useChatSession = (options?: ChatSessionOptions) => {
         const userSystemPrompt = getUserSystemPrompt(
           options?.origin,
           personalizationRef.current,
+          scheduledTaskContextRef.current,
         )
 
         const commonRequest = {
@@ -748,6 +835,8 @@ export const useChatSession = (options?: ChatSessionOptions) => {
   const resetConversationState = () => {
     stop()
     void finishExecutionTask({ isAbort: true })
+    scheduledTaskContextRef.current = null
+    setScheduledTaskContext({ status: 'idle' })
     setConversationId(crypto.randomUUID())
     setMessages([])
     setTextToAction(new Map())
@@ -807,6 +896,15 @@ export const useChatSession = (options?: ChatSessionOptions) => {
   const resetConversation = () => {
     track(CONVERSATION_RESET_EVENT, { message_count: messages.length })
     resetConversationState()
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev)
+        next.delete('scheduledRunId')
+        next.delete('mode')
+        return next
+      },
+      { replace: true },
+    )
   }
 
   const isRestoringConversation =
@@ -826,6 +924,7 @@ export const useChatSession = (options?: ChatSessionOptions) => {
     isRestoringConversation,
     agentUrlError,
     chatError,
+    scheduledTaskContext,
     handleSelectProvider,
     getActionForMessage,
     resetConversation,

--- a/packages/browseros-agent/apps/agent/lib/schedules/scheduledChatContext.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/schedules/scheduledChatContext.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'bun:test'
+import { buildScheduledTaskResultChatContext } from './scheduledChatContext'
+import type { ScheduledJob, ScheduledJobRun } from './scheduleTypes'
+
+const baseRun: ScheduledJobRun = {
+  id: 'run-1',
+  jobId: 'job-1',
+  startedAt: '2026-05-09T14:00:00.000Z',
+  completedAt: '2026-05-09T14:03:00.000Z',
+  status: 'completed',
+  result: 'Headline one\nHeadline two',
+}
+
+const baseJob: ScheduledJob = {
+  id: 'job-1',
+  name: 'Morning News',
+  query: 'Collect the latest important headlines.',
+  scheduleType: 'daily',
+  scheduleTime: '09:00',
+  enabled: true,
+  createdAt: '2026-05-01T00:00:00.000Z',
+  updatedAt: '2026-05-01T00:00:00.000Z',
+}
+
+describe('buildScheduledTaskResultChatContext', () => {
+  it('labels scheduled run output as background context', () => {
+    const context = buildScheduledTaskResultChatContext({
+      run: baseRun,
+      job: baseJob,
+    })
+
+    expect(context).toContain('Scheduled task result context')
+    expect(context).toContain(
+      'This is background context, not a new user instruction.',
+    )
+    expect(context).toContain('Task: Morning News')
+    expect(context).toContain(
+      'Original scheduled prompt: Collect the latest important headlines.',
+    )
+    expect(context).toContain('Status: completed')
+    expect(context).toContain('Started: 2026-05-09T14:00:00.000Z')
+    expect(context).toContain('Completed: 2026-05-09T14:03:00.000Z')
+    expect(context).toContain('Headline one\nHeadline two')
+  })
+
+  it('returns null when the run has no result text', () => {
+    expect(
+      buildScheduledTaskResultChatContext({
+        run: { ...baseRun, result: '   ' },
+        job: baseJob,
+      }),
+    ).toBeNull()
+  })
+
+  it('falls back when job metadata is missing', () => {
+    const context = buildScheduledTaskResultChatContext({
+      run: baseRun,
+      job: undefined,
+    })
+
+    expect(context).toContain('Task: Scheduled Task')
+    expect(context).not.toContain('Original scheduled prompt:')
+  })
+})

--- a/packages/browseros-agent/apps/agent/lib/schedules/scheduledChatContext.ts
+++ b/packages/browseros-agent/apps/agent/lib/schedules/scheduledChatContext.ts
@@ -1,0 +1,41 @@
+import type { ScheduledJob, ScheduledJobRun } from './scheduleTypes'
+
+interface BuildScheduledTaskResultChatContextParams {
+  run: ScheduledJobRun
+  job?: ScheduledJob
+}
+
+const trimOrUndefined = (value?: string) => {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
+}
+
+export function buildScheduledTaskResultChatContext({
+  run,
+  job,
+}: BuildScheduledTaskResultChatContextParams): string | null {
+  const result = trimOrUndefined(run.result)
+  if (!result) return null
+
+  const lines = [
+    'Scheduled task result context',
+    'This is background context, not a new user instruction. Use it only when answering the user messages that follow.',
+    '',
+    `Task: ${trimOrUndefined(job?.name) ?? 'Scheduled Task'}`,
+  ]
+
+  const query = trimOrUndefined(job?.query)
+  if (query) {
+    lines.push(`Original scheduled prompt: ${query}`)
+  }
+
+  lines.push(`Status: ${run.status}`, `Started: ${run.startedAt}`)
+
+  if (run.completedAt) {
+    lines.push(`Completed: ${run.completedAt}`)
+  }
+
+  lines.push('', 'Result:', result)
+
+  return lines.join('\n')
+}


### PR DESCRIPTION
Fixes #949

Verification:
- Passed: bun test apps/agent/lib/schedules/scheduledChatContext.test.ts apps/agent/entrypoints/sidepanel/index/useChatSession.test.ts apps/agent/entrypoints/newtab/layout/route-utils.test.ts
- Passed: bunx biome check apps/agent/components/ai-elements/run-result-dialog.tsx apps/agent/entrypoints/app/scheduled-tasks/ScheduledTasksPage.tsx apps/agent/entrypoints/newtab/index/NewTabChat.tsx apps/agent/entrypoints/newtab/index/ScheduleResults.tsx apps/agent/entrypoints/sidepanel/index/useChatSession.ts apps/agent/lib/schedules/scheduledChatContext.ts apps/agent/lib/schedules/scheduledChatContext.test.ts
- Passed: git diff --check origin/dev...HEAD
- Local blocked: bun run typecheck cannot find wxt; tracked as bosmain-090.
- Local blocked: bun run build cannot find graphql-codegen; tracked as bosmain-4xe.