### PR TITLE
feat(agent): add reset controls for sessions and memory

### DIFF
--- a/packages/browseros-agent/apps/agent/components/sidebar/SettingsSidebar.tsx
+++ b/packages/browseros-agent/apps/agent/components/sidebar/SettingsSidebar.tsx
@@ -81,6 +81,11 @@ const primarySettingsSections: NavSection[] = [
         feature: Feature.CUSTOMIZATION_SUPPORT,
       },
       {
+        name: 'Reset Data',
+        to: '/settings/reset-data',
+        icon: RotateCcw,
+      },
+      {
         name: 'Tool Approvals',
         to: '/settings/approvals',
         icon: ShieldCheck,

--- a/packages/browseros-agent/apps/agent/entrypoints/app/App.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/App.tsx
@@ -30,6 +30,7 @@ import { MagicLinkCallback } from './login/MagicLinkCallback'
 import { MCPSettingsPage } from './mcp-settings/MCPSettingsPage'
 import { MemoryPage } from './memory/MemoryPage'
 import { ProfilePage } from './profile/ProfilePage'
+import { ResetDataPage } from './reset-data/ResetDataPage'
 import { ScheduledTasksPage } from './scheduled-tasks/ScheduledTasksPage'
 import { SearchProviderPage } from './search-provider/SearchProviderPage'
 import { SkillsPage } from './skills/SkillsPage'
@@ -143,6 +144,7 @@ export const App: FC = () => {
             <Route path="chat" element={<LlmHubPage />} />
             <Route path="mcp" element={<MCPSettingsPage />} />
             <Route path="customization" element={<CustomizationPage />} />
+            <Route path="reset-data" element={<ResetDataPage />} />
             <Route path="search" element={<SearchProviderPage />} />
             <Route path="survey" element={<SurveyPage {...surveyParams} />} />
             <Route path="usage" element={<UsagePage />} />

--- a/packages/browseros-agent/apps/agent/entrypoints/app/memory/useMemoryContent.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/memory/useMemoryContent.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useAgentServerUrl } from '@/lib/browseros/useBrowserOSProviders'
 
+export const MEMORY_QUERY_KEY = 'memory'
+
 async function fetchMemory(baseUrl: string): Promise<string> {
   const response = await fetch(`${baseUrl}/memory`)
   if (!response.ok) throw new Error(`HTTP ${response.status}`)
@@ -30,7 +32,7 @@ export function useMemoryContent() {
   const queryClient = useQueryClient()
 
   const { data, isLoading, error, refetch } = useQuery<string, Error>({
-    queryKey: ['memory', baseUrl],
+    queryKey: [MEMORY_QUERY_KEY, baseUrl],
     queryFn: () => fetchMemory(baseUrl as string),
     enabled: !!baseUrl && !urlLoading,
   })
@@ -38,7 +40,7 @@ export function useMemoryContent() {
   const saveMutation = useMutation({
     mutationFn: (content: string) => saveMemory(baseUrl as string, content),
     onSuccess: (_data, content) => {
-      queryClient.setQueryData(['memory', baseUrl], content)
+      queryClient.setQueryData([MEMORY_QUERY_KEY, baseUrl], content)
     },
   })
 

--- a/packages/browseros-agent/apps/agent/entrypoints/app/reset-data/ResetDataPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/reset-data/ResetDataPage.tsx
@@ -1,0 +1,180 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query'
+import { Brain, FileText, Loader2, RotateCcw } from 'lucide-react'
+import { type FC, type ReactNode, useState } from 'react'
+import { toast } from 'sonner'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { Button } from '@/components/ui/button'
+import { useAgentServerUrl } from '@/lib/browseros/useBrowserOSProviders'
+import { MEMORY_QUERY_KEY } from '../memory/useMemoryContent'
+import { SOUL_QUERY_KEY } from '../soul/useSoulContent'
+
+type ResetTarget = 'memory' | 'soul'
+
+type ResetAction = {
+  target: ResetTarget
+  title: string
+  description: string
+  buttonLabel: string
+  icon: ReactNode
+}
+
+async function deleteServerResource(
+  baseUrl: string,
+  resource: ResetTarget,
+): Promise<void> {
+  const response = await fetch(`${baseUrl}/${resource}`, { method: 'DELETE' })
+  if (!response.ok) throw new Error(`HTTP ${response.status}`)
+}
+
+export const ResetDataPage: FC = () => {
+  const {
+    baseUrl,
+    isLoading: isUrlLoading,
+    error: urlError,
+  } = useAgentServerUrl()
+  const queryClient = useQueryClient()
+  const [pendingAction, setPendingAction] = useState<ResetAction | null>(null)
+
+  const resetMutation = useMutation({
+    mutationFn: async (target: ResetTarget) => {
+      if (!baseUrl) throw new Error('BrowserOS server URL is unavailable')
+      await deleteServerResource(baseUrl, target)
+      return target
+    },
+    onSuccess: async (target) => {
+      if (target === 'memory') {
+        queryClient.setQueryData([MEMORY_QUERY_KEY, baseUrl], '')
+      }
+      await queryClient.invalidateQueries({
+        queryKey: target === 'memory' ? [MEMORY_QUERY_KEY] : [SOUL_QUERY_KEY],
+      })
+      toast.success(target === 'memory' ? 'Memory reset' : 'SOUL.md reset')
+    },
+    onError: (_error, target) => {
+      toast.error(
+        target === 'memory'
+          ? 'Failed to reset memory'
+          : 'Failed to reset SOUL.md',
+      )
+    },
+  })
+
+  const actions: ResetAction[] = [
+    {
+      target: 'memory',
+      title: 'Reset memory?',
+      description:
+        'This deletes CORE.md and daily memory files. This cannot be undone.',
+      buttonLabel: 'Reset memory',
+      icon: <Brain className="h-4 w-4 text-muted-foreground" />,
+    },
+    {
+      target: 'soul',
+      title: 'Reset SOUL.md?',
+      description:
+        'This replaces SOUL.md with the default template. This cannot be undone.',
+      buttonLabel: 'Reset SOUL.md',
+      icon: <FileText className="h-4 w-4 text-muted-foreground" />,
+    },
+  ]
+
+  const isBusy = isUrlLoading || resetMutation.isPending
+  const disabled = isBusy || Boolean(urlError) || !baseUrl
+
+  const handleConfirm = () => {
+    if (!pendingAction) return
+    resetMutation.mutate(pendingAction.target)
+    setPendingAction(null)
+  }
+
+  return (
+    <div className="mx-auto w-full max-w-3xl space-y-6 p-6">
+      <div>
+        <div className="mb-2 flex items-center gap-2 text-muted-foreground">
+          <RotateCcw className="h-4 w-4" />
+          <span className="font-medium text-xs uppercase tracking-wider">
+            Reset
+          </span>
+        </div>
+        <h1 className="font-semibold text-2xl">Reset Data</h1>
+      </div>
+
+      {urlError ? (
+        <div className="rounded-lg border border-destructive/50 bg-destructive/5 p-4">
+          <p className="text-destructive text-sm">
+            BrowserOS server is unavailable.
+          </p>
+        </div>
+      ) : null}
+
+      <div className="space-y-3">
+        {actions.map((action) => (
+          <div
+            key={action.target}
+            className="flex flex-col gap-3 rounded-lg border bg-card p-4 shadow-sm sm:flex-row sm:items-center sm:justify-between"
+          >
+            <div className="flex min-w-0 items-center gap-3">
+              {action.icon}
+              <div className="min-w-0">
+                <h2 className="font-medium text-sm">{action.buttonLabel}</h2>
+                <p className="mt-1 text-muted-foreground text-xs">
+                  {action.description}
+                </p>
+              </div>
+            </div>
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              className="shrink-0"
+              disabled={disabled}
+              onClick={() => setPendingAction(action)}
+            >
+              {resetMutation.isPending &&
+              resetMutation.variables === action.target ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <RotateCcw className="h-3.5 w-3.5" />
+              )}
+              {action.buttonLabel}
+            </Button>
+          </div>
+        ))}
+      </div>
+
+      <AlertDialog
+        open={Boolean(pendingAction)}
+        onOpenChange={(open) => {
+          if (!open) setPendingAction(null)
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{pendingAction?.title}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {pendingAction?.description}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirm}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              {pendingAction?.buttonLabel}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/history/ChatHistory.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/history/ChatHistory.tsx
@@ -2,7 +2,8 @@ import { keepPreviousData, useQueryClient } from '@tanstack/react-query'
 import type { UIMessage } from 'ai'
 import { Loader2 } from 'lucide-react'
 import type { FC } from 'react'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
+import { toast } from 'sonner'
 import { useSessionInfo } from '@/lib/auth/sessionStorage'
 import { useConversations } from '@/lib/conversations/conversationStorage'
 import { GetProfileIdByUserIdDocument } from '@/lib/conversations/graphql/uploadConversationDocument'
@@ -21,8 +22,11 @@ import {
 import { LocalChatHistory } from './local/LocalChatHistory'
 
 const RemoteChatHistory: FC<{ userId: string }> = ({ userId }) => {
-  const { conversationId: activeConversationId } = useChatSessionContext()
+  const { conversationId: activeConversationId, resetConversation } =
+    useChatSessionContext()
+  const { clearConversations } = useConversations()
   const queryClient = useQueryClient()
+  const [isClearingAll, setIsClearingAll] = useState(false)
 
   const { data: profileData } = useGraphqlQuery(GetProfileIdByUserIdDocument, {
     userId,
@@ -68,6 +72,50 @@ const RemoteChatHistory: FC<{ userId: string }> = ({ userId }) => {
     deleteConversationMutation.mutate({ rowId: id })
   }
 
+  const getAllRemoteConversationIds = async () => {
+    let pages = graphqlData?.pages ?? []
+    let hasMore = Boolean(
+      pages.at(-1)?.conversations?.pageInfo.hasNextPage ?? hasNextPage,
+    )
+
+    while (hasMore) {
+      const result = await fetchNextPage()
+      pages = result.data?.pages ?? pages
+      hasMore = Boolean(pages.at(-1)?.conversations?.pageInfo.hasNextPage)
+    }
+
+    return pages.flatMap((page) =>
+      (page.conversations?.nodes ?? [])
+        .filter((node): node is NonNullable<typeof node> => node !== null)
+        .map((node) => node.rowId),
+    )
+  }
+
+  const handleClearAll = async () => {
+    setIsClearingAll(true)
+    try {
+      const ids = [...new Set(await getAllRemoteConversationIds())]
+      for (let i = 0; i < ids.length; i += 10) {
+        const batch = ids.slice(i, i + 10)
+        await Promise.all(
+          batch.map((rowId) =>
+            deleteConversationMutation.mutateAsync({ rowId }),
+          ),
+        )
+      }
+      await clearConversations()
+      resetConversation()
+      await queryClient.invalidateQueries({
+        queryKey: [getQueryKeyFromDocument(GetConversationsForHistoryDocument)],
+      })
+      toast.success('Chat sessions cleared')
+    } catch {
+      toast.error('Failed to clear chat sessions')
+    } finally {
+      setIsClearingAll(false)
+    }
+  }
+
   const conversations = useMemo<HistoryConversation[]>(() => {
     if (!graphqlData?.pages) return []
 
@@ -110,6 +158,8 @@ const RemoteChatHistory: FC<{ userId: string }> = ({ userId }) => {
       groupedConversations={groupedConversations}
       activeConversationId={activeConversationId}
       onDelete={handleDelete}
+      onClearAll={handleClearAll}
+      isClearingAll={isClearingAll || deleteConversationMutation.isPending}
       hasNextPage={hasNextPage}
       isFetchingNextPage={isFetchingNextPage}
       onLoadMore={fetchNextPage}
@@ -121,8 +171,6 @@ const RemoteChatHistory: FC<{ userId: string }> = ({ userId }) => {
 export const ChatHistory: FC = () => {
   const { sessionInfo } = useSessionInfo()
   const userId = sessionInfo.user?.id
-  // needed to initiate remote-sync
-  useConversations()
 
   if (userId) {
     return <RemoteChatHistory userId={userId} />

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/history/components/ConversationList.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/history/components/ConversationList.tsx
@@ -1,6 +1,16 @@
-import { Loader2, MessageSquare } from 'lucide-react'
-import { type FC, useEffect, useRef } from 'react'
+import { Loader2, MessageSquare, Trash2 } from 'lucide-react'
+import { type FC, useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router'
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
 import { ConversationGroup } from './ConversationGroup'
 import type { GroupedConversations } from './types'
 import { TIME_GROUP_LABELS } from './utils'
@@ -13,6 +23,8 @@ interface ConversationListProps {
   isFetchingNextPage?: boolean
   onLoadMore?: () => void
   isRefreshing?: boolean
+  onClearAll?: () => void
+  isClearingAll?: boolean
 }
 
 export const ConversationList: FC<ConversationListProps> = ({
@@ -23,8 +35,11 @@ export const ConversationList: FC<ConversationListProps> = ({
   isFetchingNextPage,
   onLoadMore,
   isRefreshing,
+  onClearAll,
+  isClearingAll,
 }) => {
   const loadMoreRef = useRef<HTMLDivElement>(null)
+  const [showClearAllDialog, setShowClearAllDialog] = useState(false)
 
   useEffect(() => {
     if (!hasNextPage || !onLoadMore) return
@@ -56,65 +71,118 @@ export const ConversationList: FC<ConversationListProps> = ({
     groupedConversations.thisMonth.length > 0 ||
     groupedConversations.older.length > 0
 
-  return (
-    <main className="mt-4 flex h-full flex-1 flex-col space-y-4 overflow-y-auto">
-      <div className="w-full p-3">
-        {isRefreshing && (
-          <div className="flex items-center justify-center gap-2 pb-3 text-muted-foreground text-xs">
-            <Loader2 className="h-3 w-3 animate-spin" />
-            <span>Fetching latest conversations</span>
-          </div>
-        )}
-        {!hasConversations ? (
-          <div className="flex flex-col items-center justify-center py-12 text-center">
-            <MessageSquare className="mb-3 h-10 w-10 text-muted-foreground/50" />
-            <p className="text-muted-foreground text-sm">
-              No conversations yet
-            </p>
-            <Link to="/" className="mt-2 text-primary text-sm hover:underline">
-              Start a new chat
-            </Link>
-          </div>
-        ) : (
-          <>
-            <ConversationGroup
-              label={TIME_GROUP_LABELS.today}
-              conversations={groupedConversations.today}
-              onDelete={onDelete}
-              activeConversationId={activeConversationId}
-            />
-            <ConversationGroup
-              label={TIME_GROUP_LABELS.thisWeek}
-              conversations={groupedConversations.thisWeek}
-              onDelete={onDelete}
-              activeConversationId={activeConversationId}
-            />
-            <ConversationGroup
-              label={TIME_GROUP_LABELS.thisMonth}
-              conversations={groupedConversations.thisMonth}
-              onDelete={onDelete}
-              activeConversationId={activeConversationId}
-            />
-            <ConversationGroup
-              label={TIME_GROUP_LABELS.older}
-              conversations={groupedConversations.older}
-              onDelete={onDelete}
-              activeConversationId={activeConversationId}
-            />
+  const handleConfirmClearAll = () => {
+    onClearAll?.()
+    setShowClearAllDialog(false)
+  }
 
-            {hasNextPage && (
-              <div
-                ref={loadMoreRef}
-                className="flex items-center justify-center py-4"
+  return (
+    <>
+      <main className="mt-4 flex h-full flex-1 flex-col space-y-4 overflow-y-auto">
+        <div className="w-full p-3">
+          <div className="mb-3 flex items-center justify-between gap-3 px-1">
+            <h2 className="font-semibold text-sm">Chat history</h2>
+            {onClearAll && hasConversations && (
+              <button
+                type="button"
+                onClick={() => setShowClearAllDialog(true)}
+                disabled={isClearingAll}
+                className="inline-flex h-8 shrink-0 items-center gap-1.5 rounded-md px-2.5 font-medium text-muted-foreground text-xs transition-colors hover:bg-destructive/10 hover:text-destructive disabled:pointer-events-none disabled:opacity-50"
+                title="Clear sessions"
               >
-                {isFetchingNextPage && (
-                  <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                {isClearingAll ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <Trash2 className="h-3.5 w-3.5" />
                 )}
-              </div>
+                Clear sessions
+              </button>
             )}
-          </>
-        )}
-      </div>
-    </main>
+          </div>
+
+          {isRefreshing && (
+            <div className="flex items-center justify-center gap-2 pb-3 text-muted-foreground text-xs">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              <span>Fetching latest conversations</span>
+            </div>
+          )}
+          {!hasConversations ? (
+            <div className="flex flex-col items-center justify-center py-12 text-center">
+              <MessageSquare className="mb-3 h-10 w-10 text-muted-foreground/50" />
+              <p className="text-muted-foreground text-sm">
+                No conversations yet
+              </p>
+              <Link
+                to="/"
+                className="mt-2 text-primary text-sm hover:underline"
+              >
+                Start a new chat
+              </Link>
+            </div>
+          ) : (
+            <>
+              <ConversationGroup
+                label={TIME_GROUP_LABELS.today}
+                conversations={groupedConversations.today}
+                onDelete={onDelete}
+                activeConversationId={activeConversationId}
+              />
+              <ConversationGroup
+                label={TIME_GROUP_LABELS.thisWeek}
+                conversations={groupedConversations.thisWeek}
+                onDelete={onDelete}
+                activeConversationId={activeConversationId}
+              />
+              <ConversationGroup
+                label={TIME_GROUP_LABELS.thisMonth}
+                conversations={groupedConversations.thisMonth}
+                onDelete={onDelete}
+                activeConversationId={activeConversationId}
+              />
+              <ConversationGroup
+                label={TIME_GROUP_LABELS.older}
+                conversations={groupedConversations.older}
+                onDelete={onDelete}
+                activeConversationId={activeConversationId}
+              />
+
+              {hasNextPage && (
+                <div
+                  ref={loadMoreRef}
+                  className="flex items-center justify-center py-4"
+                >
+                  {isFetchingNextPage && (
+                    <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+                  )}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </main>
+
+      <AlertDialog
+        open={showClearAllDialog}
+        onOpenChange={setShowClearAllDialog}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Clear all sessions?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This action permanently deletes every chat session in history.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={handleConfirmClearAll}
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+            >
+              Clear sessions
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
   )
 }

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/history/local/LocalChatHistory.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/history/local/LocalChatHistory.tsx
@@ -1,5 +1,6 @@
 import type { FC } from 'react'
 import { useMemo } from 'react'
+import { toast } from 'sonner'
 import { useConversations } from '@/lib/conversations/conversationStorage'
 import { useChatSessionContext } from '../../layout/ChatSessionContext'
 import { ConversationList } from '../components/ConversationList'
@@ -7,9 +8,13 @@ import type { HistoryConversation } from '../components/types'
 import { extractLastUserMessage, groupConversations } from '../components/utils'
 
 export const LocalChatHistory: FC = () => {
-  const { conversations: localConversations, removeConversation } =
-    useConversations()
-  const { conversationId: activeConversationId } = useChatSessionContext()
+  const {
+    conversations: localConversations,
+    removeConversation,
+    clearConversations,
+  } = useConversations()
+  const { conversationId: activeConversationId, resetConversation } =
+    useChatSessionContext()
 
   const conversations = useMemo<HistoryConversation[]>(() => {
     return localConversations.map((conv) => ({
@@ -24,11 +29,22 @@ export const LocalChatHistory: FC = () => {
     [conversations],
   )
 
+  const handleClearAll = async () => {
+    try {
+      await clearConversations()
+      resetConversation()
+      toast.success('Chat sessions cleared')
+    } catch {
+      toast.error('Failed to clear chat sessions')
+    }
+  }
+
   return (
     <ConversationList
       groupedConversations={groupedConversations}
       activeConversationId={activeConversationId}
       onDelete={removeConversation}
+      onClearAll={handleClearAll}
     />
   )
 }

--- a/packages/browseros-agent/apps/agent/lib/conversations/conversationStorage.ts
+++ b/packages/browseros-agent/apps/agent/lib/conversations/conversationStorage.ts
@@ -2,7 +2,10 @@ import { storage } from '@wxt-dev/storage'
 import type { UIMessage } from 'ai'
 import { useEffect, useState } from 'react'
 import { useSessionInfo } from '../auth/sessionStorage'
-import { removeConversationExecutionHistory } from '../execution-history/storage'
+import {
+  clearConversationExecutionHistory,
+  removeConversationExecutionHistory,
+} from '../execution-history/storage'
 import { uploadConversationsToGraphql } from './uploadConversationsToGraphql'
 
 const MAX_CONVERSATIONS = 50
@@ -44,6 +47,11 @@ export function useConversations() {
     const current = (await conversationStorage.getValue()) ?? []
     await conversationStorage.setValue(current.filter((c) => c.id !== id))
     await removeConversationExecutionHistory(id)
+  }
+
+  const clearConversations = async () => {
+    await conversationStorage.setValue([])
+    await clearConversationExecutionHistory()
   }
 
   const saveConversation = async (id: string, messages: UIMessage[]) => {
@@ -90,6 +98,7 @@ export function useConversations() {
   return {
     conversations,
     removeConversation,
+    clearConversations,
     saveConversation,
     getConversation,
   }

--- a/packages/browseros-agent/apps/agent/lib/execution-history/storage.ts
+++ b/packages/browseros-agent/apps/agent/lib/execution-history/storage.ts
@@ -82,6 +82,10 @@ export async function removeConversationExecutionHistory(
   await executionHistoryStorage.setValue(rest)
 }
 
+export async function clearConversationExecutionHistory(): Promise<void> {
+  await executionHistoryStorage.setValue({})
+}
+
 export async function removeConversationExecutionTask(args: {
   conversationId: string
   taskId: string

--- a/packages/browseros-agent/apps/server/src/api/routes/memory.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/memory.ts
@@ -1,4 +1,4 @@
-import { mkdir } from 'node:fs/promises'
+import { mkdir, rm } from 'node:fs/promises'
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { z } from 'zod'
@@ -24,6 +24,11 @@ export function createMemoryRoutes() {
       const { content } = c.req.valid('json')
       await mkdir(getMemoryDir(), { recursive: true })
       await Bun.write(getCoreMemoryPath(), content)
+      return c.json({ success: true })
+    })
+    .delete('/', async (c) => {
+      await rm(getMemoryDir(), { recursive: true, force: true })
+      await mkdir(getMemoryDir(), { recursive: true })
       return c.json({ success: true })
     })
 }

--- a/packages/browseros-agent/apps/server/src/api/routes/soul.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/soul.ts
@@ -1,7 +1,7 @@
 import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { z } from 'zod'
-import { readSoul, writeSoul } from '../../lib/soul'
+import { readSoul, resetSoulTemplate, writeSoul } from '../../lib/soul'
 
 const WriteSoulSchema = z.object({
   content: z.string(),
@@ -16,6 +16,10 @@ export function createSoulRoutes() {
     .put('/', zValidator('json', WriteSoulSchema), async (c) => {
       const { content } = c.req.valid('json')
       const result = await writeSoul(content)
+      return c.json(result)
+    })
+    .delete('/', async (c) => {
+      const result = await resetSoulTemplate()
       return c.json(result)
     })
 }

--- a/packages/browseros-agent/apps/server/src/lib/soul.ts
+++ b/packages/browseros-agent/apps/server/src/lib/soul.ts
@@ -1,7 +1,7 @@
 import { PATHS } from '@browseros/shared/constants/paths'
 import { getSoulPath } from './browseros-dir'
 
-const SOUL_TEMPLATE = `# SOUL.md — Who You Are
+export const SOUL_TEMPLATE = `# SOUL.md — Who You Are
 _You're not a chatbot. You're becoming someone._
 
 ## Core Truths
@@ -48,6 +48,10 @@ export async function writeSoul(content: string): Promise<WriteSoulResult> {
     linesDropped: dropped.length,
     droppedContent: dropped.join('\n'),
   }
+}
+
+export async function resetSoulTemplate(): Promise<WriteSoulResult> {
+  return writeSoul(SOUL_TEMPLATE)
 }
 
 export async function seedSoulTemplate(): Promise<void> {

--- a/packages/browseros-agent/apps/server/tests/api/routes/memory-soul-reset.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/memory-soul-reset.test.ts
@@ -1,0 +1,64 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { beforeEach, describe, it } from 'bun:test'
+import assert from 'node:assert'
+import { existsSync, mkdtempSync } from 'node:fs'
+import { mkdir, readFile, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+
+import { createMemoryRoutes } from '../../../src/api/routes/memory'
+import { createSoulRoutes } from '../../../src/api/routes/soul'
+import {
+  getCoreMemoryPath,
+  getMemoryDir,
+  getSoulPath,
+} from '../../../src/lib/browseros-dir'
+
+describe('memory and soul reset routes', () => {
+  beforeEach(() => {
+    process.env.BROWSEROS_DIR = mkdtempSync(
+      join(tmpdir(), 'browseros-reset-routes-'),
+    )
+  })
+
+  it('deletes all memory files and leaves the memory directory usable', async () => {
+    await mkdir(getMemoryDir(), { recursive: true })
+    await writeFile(getCoreMemoryPath(), 'core facts')
+    await writeFile(join(getMemoryDir(), '2026-05-09.md'), 'daily notes')
+
+    const route = createMemoryRoutes()
+    const response = await route.request('/', { method: 'DELETE' })
+
+    assert.strictEqual(response.status, 200)
+    assert.deepStrictEqual(await response.json(), { success: true })
+    assert.strictEqual(existsSync(getMemoryDir()), true)
+    assert.strictEqual(existsSync(getCoreMemoryPath()), false)
+    assert.strictEqual(existsSync(join(getMemoryDir(), '2026-05-09.md')), false)
+
+    const getResponse = await route.request('/')
+    assert.deepStrictEqual(await getResponse.json(), { content: '' })
+  })
+
+  it('resets SOUL.md to the default template', async () => {
+    await mkdir(dirname(getSoulPath()), { recursive: true })
+    await writeFile(getSoulPath(), '# Custom soul\nBe different.')
+
+    const route = createSoulRoutes()
+    const response = await route.request('/', { method: 'DELETE' })
+
+    assert.strictEqual(response.status, 200)
+    const body = await response.json()
+    assert.strictEqual(body.truncated, false)
+    assert.ok(body.linesWritten > 0)
+
+    const content = await readFile(getSoulPath(), 'utf8')
+    assert.ok(
+      content.includes("You're not a chatbot. You're becoming someone."),
+    )
+    assert.ok(!content.includes('Custom soul'))
+  })
+})


### PR DESCRIPTION
Fixes #418

Verification:
- Passed: bunx biome check on changed files
- Passed: git diff --check origin/dev...HEAD
- Local blocked: bun --env-file=.env.development test ./tests/api/routes/memory-soul-reset.test.ts cannot resolve @hono/zod-validator from an origin/dev route import in this refinery worktree.
- Local blocked: server bun run typecheck cannot find tsc; tracked as bosmain-woi.
- Local blocked: agent bun run typecheck cannot find wxt; tracked as bosmain-090.