### PR TITLE
fix(server): support Gemini computer use requests

### DIFF
--- a/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
+++ b/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
@@ -9,6 +9,7 @@ import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
 import { createOpenRouter } from '@openrouter/ai-sdk-provider'
 import type { LanguageModel } from 'ai'
 import { createBrowserOSFetch } from '../lib/browseros-fetch'
+import { createGeminiComputerUseFetch } from '../lib/clients/llm/gemini-computer-use-fetch'
 import {
   createMockBrowserOSLanguageModel,
   shouldUseMockBrowserOSLLM,
@@ -41,7 +42,12 @@ function createGoogleFactory(
   config: ResolvedAgentConfig,
 ): (modelId: string) => unknown {
   if (!config.apiKey) throw new Error('Google provider requires apiKey')
-  return createGoogleGenerativeAI({ apiKey: config.apiKey })
+  const fetch = createGeminiComputerUseFetch(config.model)
+  return createGoogleGenerativeAI({
+    apiKey: config.apiKey,
+    ...(config.baseUrl && { baseURL: config.baseUrl }),
+    ...(fetch && { fetch }),
+  })
 }
 
 function createOpenRouterFactory(

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/gemini-computer-use-fetch.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/gemini-computer-use-fetch.ts
@@ -1,0 +1,68 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+const GEMINI_COMPUTER_USE_MODEL_PATTERN = /computer-use/i
+
+const GEMINI_COMPUTER_USE_TOOL = {
+  computerUse: {
+    environment: 'ENVIRONMENT_BROWSER',
+  },
+} as const
+
+type JsonObject = Record<string, unknown>
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+}
+
+function hasComputerUseTool(tool: unknown): boolean {
+  return isJsonObject(tool) && 'computerUse' in tool
+}
+
+export function isGeminiComputerUseModel(modelId: string): boolean {
+  return GEMINI_COMPUTER_USE_MODEL_PATTERN.test(modelId)
+}
+
+export function addGeminiComputerUseTool(body: unknown): unknown {
+  if (!isJsonObject(body)) return body
+
+  const existingTools = Array.isArray(body.tools) ? body.tools : []
+  if (existingTools.some(hasComputerUseTool)) return body
+
+  return {
+    ...body,
+    tools: [GEMINI_COMPUTER_USE_TOOL, ...existingTools],
+  }
+}
+
+function injectComputerUseToolIntoBody(body: BodyInit | null | undefined) {
+  if (typeof body !== 'string') return body
+
+  try {
+    return JSON.stringify(addGeminiComputerUseTool(JSON.parse(body)))
+  } catch {
+    return body
+  }
+}
+
+export function createGeminiComputerUseFetch(
+  modelId: string,
+): typeof globalThis.fetch | undefined {
+  if (!isGeminiComputerUseModel(modelId)) return undefined
+
+  const fetchWithComputerUse = (async (input, init) => {
+    return globalThis.fetch(input, {
+      ...init,
+      body: injectComputerUseToolIntoBody(init?.body),
+    })
+  }) as typeof globalThis.fetch
+
+  fetchWithComputerUse.preconnect = globalThis.fetch.preconnect.bind(
+    globalThis.fetch,
+  )
+
+  return fetchWithComputerUse
+}

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/provider.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/provider.ts
@@ -21,6 +21,7 @@ import { logger } from '../../logger'
 import { createOpenRouterCompatibleFetch } from '../../openrouter-fetch'
 import { createCodexFetch } from '../oauth/codex-fetch'
 import { createCopilotFetch } from '../oauth/copilot-fetch'
+import { createGeminiComputerUseFetch } from './gemini-computer-use-fetch'
 import {
   createMockBrowserOSLanguageModel,
   shouldUseMockBrowserOSLLM,
@@ -41,7 +42,12 @@ function createOpenAIModel(config: ResolvedLLMConfig): LanguageModel {
 
 function createGoogleModel(config: ResolvedLLMConfig): LanguageModel {
   if (!config.apiKey) throw new Error('Google provider requires apiKey')
-  return createGoogleGenerativeAI({ apiKey: config.apiKey })(config.model)
+  const fetch = createGeminiComputerUseFetch(config.model)
+  return createGoogleGenerativeAI({
+    apiKey: config.apiKey,
+    ...(config.baseUrl && { baseURL: config.baseUrl }),
+    ...(fetch && { fetch }),
+  })(config.model)
 }
 
 function createOpenRouterModel(config: ResolvedLLMConfig): LanguageModel {

--- a/packages/browseros-agent/apps/server/tests/agent/gemini-computer-use-provider.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/gemini-computer-use-provider.test.ts
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'bun:test'
+import assert from 'node:assert'
+import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
+import { generateText, type LanguageModel } from 'ai'
+
+import { createLanguageModel } from '../../src/agent/provider-factory'
+import {
+  addGeminiComputerUseTool,
+  isGeminiComputerUseModel,
+} from '../../src/lib/clients/llm/gemini-computer-use-fetch'
+import { createLLMProvider } from '../../src/lib/clients/llm/provider'
+
+const COMPUTER_USE_MODEL = 'gemini-2.5-computer-use-preview-10-2025'
+
+async function captureGoogleRequest(model: LanguageModel) {
+  const originalFetch = globalThis.fetch
+  let capturedInput: RequestInfo | URL | undefined
+  let capturedBody: unknown
+
+  globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+    capturedInput = input
+    capturedBody = JSON.parse(String(init?.body))
+
+    return new Response(
+      JSON.stringify({
+        candidates: [
+          {
+            content: { parts: [{ text: 'ok' }] },
+            finishReason: 'STOP',
+          },
+        ],
+        usageMetadata: {
+          promptTokenCount: 1,
+          candidatesTokenCount: 1,
+          totalTokenCount: 2,
+        },
+      }),
+      {
+        headers: { 'content-type': 'application/json' },
+      },
+    )
+  }) as typeof fetch
+
+  try {
+    await generateText({
+      model,
+      messages: [{ role: 'user', content: 'Hello' }],
+    })
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+
+  assert.ok(capturedInput)
+  assert.ok(capturedBody)
+  return {
+    url: String(capturedInput),
+    body: capturedBody as { tools?: unknown[] },
+  }
+}
+
+describe('Gemini Computer Use provider requests', () => {
+  it('detects Gemini Computer Use model ids', () => {
+    expect(isGeminiComputerUseModel(COMPUTER_USE_MODEL)).toBe(true)
+    expect(isGeminiComputerUseModel('gemini-2.5-pro')).toBe(false)
+  })
+
+  it('adds Computer Use while preserving function declarations', () => {
+    const body = addGeminiComputerUseTool({
+      tools: [
+        {
+          functionDeclarations: [
+            {
+              name: 'custom_action',
+              description: 'Custom action',
+              parameters: { type: 'object' },
+            },
+          ],
+        },
+      ],
+    }) as { tools: unknown[] }
+
+    expect(body.tools).toEqual([
+      {
+        computerUse: {
+          environment: 'ENVIRONMENT_BROWSER',
+        },
+      },
+      {
+        functionDeclarations: [
+          {
+            name: 'custom_action',
+            description: 'Custom action',
+            parameters: { type: 'object' },
+          },
+        ],
+      },
+    ])
+  })
+
+  it('injects Computer Use for agent provider factory requests', async () => {
+    const model = createLanguageModel({
+      conversationId: 'test-conversation',
+      provider: LLM_PROVIDERS.GOOGLE,
+      model: COMPUTER_USE_MODEL,
+      apiKey: 'test-key',
+      baseUrl: 'https://proxy.example.test/v1beta',
+    })
+
+    const request = await captureGoogleRequest(model)
+
+    expect(request.url).toBe(
+      `https://proxy.example.test/v1beta/models/${COMPUTER_USE_MODEL}:generateContent`,
+    )
+    expect(request.body.tools?.[0]).toEqual({
+      computerUse: {
+        environment: 'ENVIRONMENT_BROWSER',
+      },
+    })
+  })
+
+  it('injects Computer Use for lightweight LLM provider requests', async () => {
+    const model = createLLMProvider({
+      provider: LLM_PROVIDERS.GOOGLE,
+      model: COMPUTER_USE_MODEL,
+      apiKey: 'test-key',
+    })
+
+    const request = await captureGoogleRequest(model)
+
+    expect(request.body.tools?.[0]).toEqual({
+      computerUse: {
+        environment: 'ENVIRONMENT_BROWSER',
+      },
+    })
+  })
+
+  it('leaves regular Gemini model requests unchanged', async () => {
+    const model = createLanguageModel({
+      conversationId: 'test-conversation',
+      provider: LLM_PROVIDERS.GOOGLE,
+      model: 'gemini-2.5-pro',
+      apiKey: 'test-key',
+    })
+
+    const request = await captureGoogleRequest(model)
+
+    expect(request.body.tools).toBeUndefined()
+  })
+})


### PR DESCRIPTION
Fixes #148

Verification:
- Passed: bunx biome check apps/server/src/agent/provider-factory.ts apps/server/src/lib/clients/llm/gemini-computer-use-fetch.ts apps/server/src/lib/clients/llm/provider.ts apps/server/tests/agent/gemini-computer-use-provider.test.ts
- Passed: git diff --check origin/dev...HEAD
- Local blocked: bun --env-file=.env.development test ./tests/agent/gemini-computer-use-provider.test.ts cannot resolve @browseros/shared/schemas/llm in this refinery worktree; related local workspace resolution is tracked as bosmain-bjx.
- Local blocked: server bun run typecheck cannot find tsc; tracked as bosmain-woi.
- Local blocked: bun scripts/build/server.ts --target=darwin-arm64 --ci cannot resolve @smithy/core/endpoints; tracked as bosmain-vbu.