### PR TITLE
feat(agent): add process MCP custom servers

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/connect-mcp/AddCustomMCPDialog.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/connect-mcp/AddCustomMCPDialog.tsx
@@ -27,24 +27,111 @@ import {
   FormMessage,
 } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
 
-const formSchema = z.object({
-  name: z.string().min(1, 'Server name is required'),
-  url: z.string().url('Please enter a valid URL'),
-  description: z.string().optional(),
-})
+const ARGUMENTS_TEXT = '-y\nanythingllm-mcp-server@2.0.0'
+const ENV_TEXT =
+  'ANYTHINGLLM_BASE_URL=http://localhost:3001\nANYTHINGLLM_API_KEY='
+
+const isValidUrl = (value: string) => {
+  try {
+    new URL(value)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const parseArgsText = (value?: string) =>
+  value
+    ?.split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean) ?? []
+
+const parseEnvText = (value?: string): Record<string, string> | undefined => {
+  const env: Record<string, string> = {}
+  for (const rawLine of value?.split('\n') ?? []) {
+    const line = rawLine.trim()
+    if (!line) continue
+    const separatorIndex = line.indexOf('=')
+    if (separatorIndex <= 0) return undefined
+    const key = line.slice(0, separatorIndex).trim()
+    if (!/^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) return undefined
+    env[key] = line.slice(separatorIndex + 1)
+  }
+  return Object.keys(env).length ? env : undefined
+}
+
+const formSchema = z
+  .object({
+    name: z.string().min(1, 'Server name is required'),
+    type: z.enum(['http', 'process']),
+    url: z.string().optional(),
+    command: z.string().optional(),
+    argsText: z.string().optional(),
+    envText: z.string().optional(),
+    cwd: z.string().optional(),
+    description: z.string().optional(),
+  })
+  .superRefine((values, ctx) => {
+    if (values.type === 'http') {
+      if (!values.url?.trim() || !isValidUrl(values.url.trim())) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['url'],
+          message: 'Please enter a valid URL',
+        })
+      }
+      return
+    }
+
+    if (!values.command?.trim()) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['command'],
+        message: 'Command is required',
+      })
+    }
+
+    if (values.envText?.trim() && parseEnvText(values.envText) === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['envText'],
+        message: 'Use KEY=value lines',
+      })
+    }
+  })
 
 type FormValues = z.infer<typeof formSchema>
+
+type CustomMcpConfig =
+  | {
+      name: string
+      type: 'http'
+      url: string
+      description: string
+    }
+  | {
+      name: string
+      type: 'process'
+      command: string
+      args?: string[]
+      env?: Record<string, string>
+      cwd?: string
+      description: string
+    }
 
 interface AddCustomMCPDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
-  onAddServer: (config: {
-    name: string
-    url: string
-    description: string
-  }) => void
+  onAddServer: (config: CustomMcpConfig) => void
 }
 
 export const AddCustomMCPDialog: FC<AddCustomMCPDialogProps> = ({
@@ -56,10 +143,16 @@ export const AddCustomMCPDialog: FC<AddCustomMCPDialogProps> = ({
     resolver: zodResolver(formSchema),
     defaultValues: {
       name: '',
+      type: 'http',
       url: '',
+      command: '',
+      argsText: '',
+      envText: '',
+      cwd: '',
       description: '',
     },
   })
+  const connectionType = form.watch('type')
 
   const handleOpenChange = (isOpen: boolean) => {
     if (!isOpen) {
@@ -69,18 +162,45 @@ export const AddCustomMCPDialog: FC<AddCustomMCPDialogProps> = ({
   }
 
   const onSubmit = (values: FormValues) => {
-    onAddServer({
-      name: values.name,
-      url: values.url,
-      description: values.description ?? '',
-    })
+    if (values.type === 'process') {
+      const args = parseArgsText(values.argsText)
+      onAddServer({
+        name: values.name,
+        type: 'process',
+        command: values.command?.trim() ?? '',
+        args: args.length ? args : undefined,
+        env: parseEnvText(values.envText),
+        cwd: values.cwd?.trim() || undefined,
+        description: values.description ?? '',
+      })
+    } else {
+      onAddServer({
+        name: values.name,
+        type: 'http',
+        url: values.url?.trim() ?? '',
+        description: values.description ?? '',
+      })
+    }
     form.reset()
     onOpenChange(false)
   }
 
+  const applyAnythingLlmPreset = () => {
+    form.reset({
+      name: 'AnythingLLM',
+      type: 'process',
+      url: '',
+      command: 'npx',
+      argsText: ARGUMENTS_TEXT,
+      envText: ENV_TEXT,
+      cwd: '',
+      description: 'Local AnythingLLM MCP agent',
+    })
+  }
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-w-md">
+      <DialogContent className="max-h-[90vh] max-w-lg overflow-y-auto">
         <DialogHeader>
           <DialogTitle>Add Custom App</DialogTitle>
           <DialogDescription>
@@ -90,6 +210,23 @@ export const AddCustomMCPDialog: FC<AddCustomMCPDialogProps> = ({
 
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+            <div className="flex items-center justify-between gap-3 rounded-md border border-[var(--accent-orange)]/30 bg-[var(--accent-orange)]/5 px-3 py-2">
+              <div>
+                <p className="font-medium text-sm">AnythingLLM</p>
+                <p className="text-muted-foreground text-xs">
+                  Local stdio server via npx
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={applyAnythingLlmPreset}
+              >
+                Use preset
+              </Button>
+            </div>
+
             <FormField
               control={form.control}
               name="name"
@@ -106,22 +243,116 @@ export const AddCustomMCPDialog: FC<AddCustomMCPDialogProps> = ({
 
             <FormField
               control={form.control}
-              name="url"
+              name="type"
               render={({ field }) => (
                 <FormItem>
-                  <FormLabel>MCP Server URL</FormLabel>
-                  <FormDescription>(only supports HTTP)</FormDescription>
-                  <FormControl>
-                    <Input
-                      type="url"
-                      placeholder="http://mcp.example.com"
-                      {...field}
-                    />
-                  </FormControl>
+                  <FormLabel>Connection Type</FormLabel>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormControl>
+                      <SelectTrigger className="w-full">
+                        <SelectValue />
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      <SelectItem value="http">HTTP URL</SelectItem>
+                      <SelectItem value="process">Local Process</SelectItem>
+                    </SelectContent>
+                  </Select>
                   <FormMessage />
                 </FormItem>
               )}
             />
+
+            {connectionType === 'http' ? (
+              <FormField
+                control={form.control}
+                name="url"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>MCP Server URL</FormLabel>
+                    <FormDescription>Streamable HTTP or SSE</FormDescription>
+                    <FormControl>
+                      <Input
+                        type="url"
+                        placeholder="http://mcp.example.com/mcp"
+                        {...field}
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            ) : (
+              <>
+                <FormField
+                  control={form.control}
+                  name="command"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Command</FormLabel>
+                      <FormControl>
+                        <Input placeholder="npx" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="argsText"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Arguments</FormLabel>
+                      <FormDescription>One argument per line</FormDescription>
+                      <FormControl>
+                        <Textarea
+                          placeholder={'-y\nanythingllm-mcp-server@2.0.0'}
+                          rows={3}
+                          className="resize-none font-mono text-xs"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="envText"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Environment</FormLabel>
+                      <FormDescription>KEY=value lines</FormDescription>
+                      <FormControl>
+                        <Textarea
+                          placeholder={ENV_TEXT}
+                          rows={4}
+                          className="resize-none font-mono text-xs"
+                          {...field}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+
+                <FormField
+                  control={form.control}
+                  name="cwd"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormLabel>Working Directory (Optional)</FormLabel>
+                      <FormControl>
+                        <Input placeholder="C:\\Users\\you" {...field} />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </>
+            )}
 
             <FormField
               control={form.control}
@@ -145,19 +376,12 @@ export const AddCustomMCPDialog: FC<AddCustomMCPDialogProps> = ({
             <Collapsible>
               <CollapsibleTrigger className="group flex w-full cursor-pointer items-center gap-2 rounded-md border border-[var(--accent-orange)]/30 bg-[var(--accent-orange)]/5 px-3 py-2 text-left text-sm transition-colors hover:bg-[var(--accent-orange)]/10">
                 <Lightbulb className="h-4 w-4 shrink-0 text-[var(--accent-orange)]" />
-                <span className="flex-1 font-medium">
-                  How do I find the URL?
-                </span>
+                <span className="flex-1 font-medium">Connection details</span>
                 <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 group-data-[state=open]:rotate-90" />
               </CollapsibleTrigger>
               <CollapsibleContent className="mt-2 rounded-md border border-[var(--accent-orange)]/30 bg-[var(--accent-orange)]/5 px-3 py-2 text-muted-foreground text-sm">
-                Many apps like Notion, Slack, or Stripe offer an MCP server you
-                can run locally. Check the app's docs for an MCP setup guide —
-                you'll get a URL (usually starting with{' '}
-                <code className="inline rounded bg-muted px-1 text-xs">
-                  http://
-                </code>
-                ) to paste here.
+                MCP apps usually provide either a URL or a local command with
+                arguments and environment variables.
               </CollapsibleContent>
             </Collapsible>
 

--- a/packages/browseros-agent/apps/agent/entrypoints/app/connect-mcp/ConnectMCP.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/connect-mcp/ConnectMCP.tsx
@@ -169,7 +169,12 @@ export const ConnectMCP: FC = () => {
 
   const addCustomServer = (config: {
     name: string
-    url: string
+    type: 'http' | 'process'
+    url?: string
+    command?: string
+    args?: string[]
+    env?: Record<string, string>
+    cwd?: string
     description: string
   }) => {
     addServer({
@@ -177,7 +182,12 @@ export const ConnectMCP: FC = () => {
       displayName: config.name,
       type: 'custom',
       config: {
+        type: config.type,
         url: config.url,
+        command: config.command,
+        args: config.args,
+        env: config.env,
+        cwd: config.cwd,
         description: config.description,
       },
     })
@@ -259,7 +269,7 @@ export const ConnectMCP: FC = () => {
               >
                 <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--accent-orange)]/10">
                   <McpServerIcon
-                    serverName={server.managedServerName ?? ''}
+                    serverName={server.managedServerName ?? server.displayName}
                     size={20}
                     className="text-[var(--accent-orange)]"
                   />
@@ -280,7 +290,8 @@ export const ConnectMCP: FC = () => {
                   <p className="text-muted-foreground text-sm">
                     {server.managedServerDescription ||
                       server.config?.description ||
-                      server.config?.url}
+                      server.config?.url ||
+                      server.config?.command}
                   </p>
                 </div>
                 {server.type === 'managed' &&

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatRefs.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatRefs.ts
@@ -6,6 +6,7 @@ import {
 } from '@/entrypoints/app/agents/useAgents'
 import type { LlmProviderConfig } from '@/lib/llm-providers/types'
 import { useLlmProviders } from '@/lib/llm-providers/useLlmProviders'
+import { buildChatCustomMcpServers } from '@/lib/mcp/customMcpServerPayload'
 import { type McpServer, useMcpServers } from '@/lib/mcp/mcpServerStorage'
 import { usePersonalization } from '@/lib/personalization/personalizationStorage'
 import {
@@ -24,12 +25,7 @@ const constructMcpServers = (servers: McpServer[]) => {
 }
 
 const constructCustomServers = (servers: McpServer[]) => {
-  return servers
-    .filter((eachServer) => eachServer.type === 'custom')
-    .map((each) => ({
-      name: each.displayName,
-      url: each.config?.url,
-    }))
+  return buildChatCustomMcpServers(servers)
 }
 
 export const useChatRefs = () => {

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -151,10 +151,7 @@ const buildRequestBrowserContext = ({
   activeTab?: chrome.tabs.Tab
   action?: ChatAction
   enabledMcpServers: Array<string | undefined>
-  customMcpServers: {
-    name: string
-    url?: string
-  }[]
+  customMcpServers: NonNullable<ChatRequestBrowserContext['customMcpServers']>
 }): ChatRequestBrowserContext | undefined => {
   const browserContext: ChatRequestBrowserContext = {}
 

--- a/packages/browseros-agent/apps/agent/lib/mcp/customMcpServerPayload.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/mcp/customMcpServerPayload.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'bun:test'
+import { buildChatCustomMcpServers } from './customMcpServerPayload'
+
+describe('buildChatCustomMcpServers', () => {
+  it('keeps existing URL-only custom MCP servers backward compatible', () => {
+    const servers = buildChatCustomMcpServers([
+      {
+        id: 'custom-http',
+        displayName: 'Custom HTTP',
+        type: 'custom',
+        config: {
+          url: 'http://127.0.0.1:19002/mcp',
+        },
+      },
+    ])
+
+    expect(servers).toEqual([
+      {
+        name: 'Custom HTTP',
+        type: 'http',
+        url: 'http://127.0.0.1:19002/mcp',
+        headers: undefined,
+      },
+    ])
+  })
+
+  it('maps process MCP servers into chat browser context', () => {
+    const servers = buildChatCustomMcpServers([
+      {
+        id: 'anythingllm',
+        displayName: 'AnythingLLM',
+        type: 'custom',
+        config: {
+          type: 'process',
+          command: 'npx',
+          args: ['-y', 'anythingllm-mcp-server@2.0.0'],
+          env: {
+            ANYTHINGLLM_BASE_URL: 'http://localhost:3001',
+            ANYTHINGLLM_API_KEY: 'test-key',
+          },
+        },
+      },
+    ])
+
+    expect(servers).toEqual([
+      {
+        name: 'AnythingLLM',
+        type: 'process',
+        command: 'npx',
+        args: ['-y', 'anythingllm-mcp-server@2.0.0'],
+        env: {
+          ANYTHINGLLM_BASE_URL: 'http://localhost:3001',
+          ANYTHINGLLM_API_KEY: 'test-key',
+        },
+        cwd: undefined,
+      },
+    ])
+  })
+})

--- a/packages/browseros-agent/apps/agent/lib/mcp/customMcpServerPayload.ts
+++ b/packages/browseros-agent/apps/agent/lib/mcp/customMcpServerPayload.ts
@@ -1,0 +1,48 @@
+import type { McpServer } from './mcpServerStorage'
+
+export interface ChatCustomMcpServer {
+  name: string
+  type?: 'http' | 'process'
+  url?: string
+  headers?: Record<string, string>
+  command?: string
+  args?: string[]
+  env?: Record<string, string>
+  cwd?: string
+}
+
+export const toChatCustomMcpServer = (
+  server: McpServer,
+): ChatCustomMcpServer | null => {
+  if (server.type !== 'custom') return null
+
+  const type =
+    server.config?.type ?? (server.config?.command ? 'process' : 'http')
+  if (type === 'process') {
+    if (!server.config?.command) return null
+    return {
+      name: server.displayName,
+      type: 'process',
+      command: server.config.command,
+      args: server.config.args,
+      env: server.config.env,
+      cwd: server.config.cwd,
+    }
+  }
+
+  if (!server.config?.url) return null
+  return {
+    name: server.displayName,
+    type: 'http',
+    url: server.config.url,
+    headers: server.config.headers,
+  }
+}
+
+export const buildChatCustomMcpServers = (
+  servers: McpServer[],
+): ChatCustomMcpServer[] =>
+  servers.flatMap((server) => {
+    const custom = toChatCustomMcpServer(server)
+    return custom ? [custom] : []
+  })

--- a/packages/browseros-agent/apps/agent/lib/mcp/mcpServerStorage.ts
+++ b/packages/browseros-agent/apps/agent/lib/mcp/mcpServerStorage.ts
@@ -11,7 +11,13 @@ export interface McpServer {
   managedServerName?: string
   managedServerDescription?: string
   config?: {
+    type?: 'http' | 'process'
     url?: string
+    headers?: Record<string, string>
+    command?: string
+    args?: string[]
+    env?: Record<string, string>
+    cwd?: string
     description?: string
   }
 }

--- a/packages/browseros-agent/apps/agent/lib/messaging/server/buildChatRequestBody.ts
+++ b/packages/browseros-agent/apps/agent/lib/messaging/server/buildChatRequestBody.ts
@@ -29,7 +29,13 @@ export interface ChatRequestBrowserContext {
   enabledMcpServers?: string[]
   customMcpServers?: {
     name: string
+    type?: 'http' | 'process'
     url?: string
+    headers?: Record<string, string>
+    command?: string
+    args?: string[]
+    env?: Record<string, string>
+    cwd?: string
   }[]
 }
 

--- a/packages/browseros-agent/apps/agent/lib/schedules/getChatServerResponse.ts
+++ b/packages/browseros-agent/apps/agent/lib/schedules/getChatServerResponse.ts
@@ -7,6 +7,7 @@ import {
   providersStorage,
 } from '@/lib/llm-providers/storage'
 import type { LlmProviderConfig } from '@/lib/llm-providers/types'
+import { buildChatCustomMcpServers } from '@/lib/mcp/customMcpServerPayload'
 import { mcpServerStorage } from '@/lib/mcp/mcpServerStorage'
 import { buildChatRequestBody } from '@/lib/messaging/server/buildChatRequestBody'
 import { personalizationStorage } from '../personalization/personalizationStorage'
@@ -102,10 +103,7 @@ export async function getChatServerResponse(
     .filter((s) => s.type === 'managed')
     .map((s) => s.managedServerName)
     .filter((name): name is string => !!name)
-  const customMcpServers = mcpServers
-    .filter((s) => s.type === 'custom' && !!s.config?.url)
-    // biome-ignore lint/style/noNonNullAssertion: filter guarantees url exists
-    .map((s) => ({ name: s.displayName, url: s.config!.url }))
+  const customMcpServers = buildChatCustomMcpServers(mcpServers)
 
   const response = await fetch(`${agentServerUrl}/chat`, {
     method: 'POST',

--- a/packages/browseros-agent/apps/server/src/agent/mcp-builder.ts
+++ b/packages/browseros-agent/apps/server/src/agent/mcp-builder.ts
@@ -1,6 +1,7 @@
 import { createMCPClient } from '@ai-sdk/mcp'
 import { TIMEOUTS } from '@browseros/shared/constants/timeouts'
 import type { BrowserContext } from '@browseros/shared/schemas/browser-context'
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js'
 import type { ToolSet } from 'ai'
 import { logger } from '../lib/logger'
 import {
@@ -8,12 +9,24 @@ import {
   type McpTransportType,
 } from '../lib/mcp-transport-detect'
 
-export interface McpServerSpec {
+export interface HttpMcpServerSpec {
   name: string
+  type: 'http'
   url: string
   transport: McpTransportType
   headers?: Record<string, string>
 }
+
+export interface ProcessMcpServerSpec {
+  name: string
+  type: 'process'
+  command: string
+  args?: string[]
+  env?: Record<string, string>
+  cwd?: string
+}
+
+export type McpServerSpec = HttpMcpServerSpec | ProcessMcpServerSpec
 
 export interface McpServerSpecDeps {
   browserContext?: BrowserContext
@@ -34,19 +47,85 @@ export async function buildMcpServerSpecs(
   // User-provided custom MCP servers
   if (deps.browserContext?.customMcpServers?.length) {
     const servers = deps.browserContext.customMcpServers
+    const httpServers: Array<{
+      name: string
+      url: string
+      headers?: Record<string, string>
+    }> = []
+
+    for (const server of servers) {
+      const name = `custom-${server.name}`
+      const type = server.type ?? (server.command ? 'process' : 'http')
+
+      if (type === 'process') {
+        if (!server.command) {
+          logger.warn('Skipping process MCP server without command', { name })
+          continue
+        }
+        specs.push({
+          name,
+          type: 'process',
+          command: server.command,
+          args: server.args,
+          env: server.env,
+          cwd: server.cwd,
+        })
+        continue
+      }
+
+      if (!server.url) {
+        logger.warn('Skipping HTTP MCP server without URL', { name })
+        continue
+      }
+      httpServers.push({
+        name,
+        url: server.url,
+        headers: server.headers,
+      })
+    }
+
     const transports = await Promise.all(
-      servers.map((s) => detectMcpTransport(s.url)),
+      httpServers.map((s) => detectMcpTransport(s.url)),
     )
-    for (let i = 0; i < servers.length; i++) {
+    for (let i = 0; i < httpServers.length; i++) {
       specs.push({
-        name: `custom-${servers[i].name}`,
-        url: servers[i].url,
+        name: httpServers[i].name,
+        type: 'http',
+        url: httpServers[i].url,
         transport: transports[i],
+        headers: httpServers[i].headers,
       })
     }
   }
 
   return specs
+}
+
+function resolveProcessCommand(command: string): string {
+  if (process.platform === 'win32' && command.toLowerCase() === 'npx') {
+    return 'npx.cmd'
+  }
+  return command
+}
+
+function getMcpLogContext(spec: McpServerSpec) {
+  if (spec.type === 'process') {
+    return {
+      name: spec.name,
+      type: spec.type,
+      command: resolveProcessCommand(spec.command),
+      args: spec.args,
+      cwd: spec.cwd,
+      envKeys: Object.keys(spec.env ?? {}).sort(),
+    }
+  }
+
+  return {
+    name: spec.name,
+    type: spec.type,
+    url: spec.url,
+    transport: spec.transport,
+  }
 }
 
 // Connect a single MCP client with timeout protection
@@ -57,10 +136,24 @@ async function connectMcpClient(
   try {
     const client = await Promise.race([
       createMCPClient({
-        transport: {
-          type: spec.transport === 'sse' ? 'sse' : 'http',
-          url: spec.url,
-          headers: spec.headers,
+        transport:
+          spec.type === 'process'
+            ? new StdioClientTransport({
+                command: resolveProcessCommand(spec.command),
+                args: spec.args,
+                env: spec.env,
+                cwd: spec.cwd,
+              })
+            : {
+                type: spec.transport === 'sse' ? 'sse' : 'http',
+                url: spec.url,
+                headers: spec.headers,
+              },
+        onUncaughtError(error) {
+          logger.warn('Uncaught MCP client error', {
+            ...getMcpLogContext(spec),
+            error: error instanceof Error ? error.message : String(error),
+          })
         },
       }),
       new Promise<never>((_, reject) =>
@@ -88,8 +181,7 @@ async function connectMcpClient(
     return { client, tools: clientTools }
   } catch (error) {
     logger.warn('Failed to connect MCP client, skipping', {
-      name: spec.name,
-      url: spec.url,
+      ...getMcpLogContext(spec),
       error: error instanceof Error ? error.message : String(error),
     })
     return null

--- a/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { createHash } from 'node:crypto'
 import { createAgentUIStreamResponse, type UIMessage } from 'ai'
 import { AiSdkAgent } from '../../agent/ai-sdk-agent'
 import { formatUserMessage } from '../../agent/format-message'
@@ -484,7 +485,28 @@ export class ChatService {
   private buildMcpServerKey(browserContext?: BrowserContext): string {
     const managed = browserContext?.enabledMcpServers?.slice().sort() ?? []
     const custom =
-      browserContext?.customMcpServers?.map((s) => s.url).sort() ?? []
+      browserContext?.customMcpServers
+        ?.map((server) => {
+          const type = server.type ?? (server.command ? 'process' : 'http')
+          if (type === 'process') {
+            const envHash = server.env
+              ? createHash('sha256')
+                  .update(JSON.stringify(Object.entries(server.env).sort()))
+                  .digest('hex')
+                  .slice(0, 12)
+              : ''
+            return [
+              'process',
+              server.name,
+              server.command,
+              server.args?.join('\0'),
+              server.cwd,
+              envHash,
+            ].join(':')
+          }
+          return ['http', server.name, server.url].join(':')
+        })
+        .sort() ?? []
     const klavisState =
       managed.length > 0
         ? this.deps.klavisRef?.handle

--- a/packages/browseros-agent/apps/server/tests/agent/mcp-builder.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/mcp-builder.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'bun:test'
+import { BrowserContextSchema } from '@browseros/shared/schemas/browser-context'
+import { buildMcpServerSpecs } from '../../src/agent/mcp-builder'
+
+describe('MCP builder custom process servers', () => {
+  it('accepts stdio process MCP servers in browser context', () => {
+    const parsed = BrowserContextSchema.safeParse({
+      customMcpServers: [
+        {
+          name: 'AnythingLLM',
+          type: 'process',
+          command: 'npx',
+          args: ['-y', 'anythingllm-mcp-server@2.0.0'],
+          env: {
+            ANYTHINGLLM_BASE_URL: 'http://localhost:3001',
+            ANYTHINGLLM_API_KEY: 'test-key',
+          },
+        },
+      ],
+    })
+
+    expect(parsed.success).toBe(true)
+  })
+
+  it('rejects process MCP servers without a command', () => {
+    const parsed = BrowserContextSchema.safeParse({
+      customMcpServers: [
+        {
+          name: 'AnythingLLM',
+          type: 'process',
+          env: {
+            ANYTHINGLLM_BASE_URL: 'http://localhost:3001',
+          },
+        },
+      ],
+    })
+
+    expect(parsed.success).toBe(false)
+  })
+
+  it('builds process MCP specs without probing HTTP transport', async () => {
+    const specs = await buildMcpServerSpecs({
+      browserContext: {
+        customMcpServers: [
+          {
+            name: 'AnythingLLM',
+            type: 'process',
+            command: 'npx',
+            args: ['-y', 'anythingllm-mcp-server@2.0.0'],
+            env: {
+              ANYTHINGLLM_BASE_URL: 'http://localhost:3001',
+              ANYTHINGLLM_API_KEY: 'test-key',
+            },
+            cwd: '/tmp',
+          },
+        ],
+      },
+    })
+
+    expect(specs).toEqual([
+      {
+        name: 'custom-AnythingLLM',
+        type: 'process',
+        command: 'npx',
+        args: ['-y', 'anythingllm-mcp-server@2.0.0'],
+        env: {
+          ANYTHINGLLM_BASE_URL: 'http://localhost:3001',
+          ANYTHINGLLM_API_KEY: 'test-key',
+        },
+        cwd: '/tmp',
+      },
+    ])
+  })
+})

--- a/packages/browseros-agent/packages/shared/src/schemas/browser-context.ts
+++ b/packages/browseros-agent/packages/shared/src/schemas/browser-context.ts
@@ -29,13 +29,38 @@ export type Tab = z.infer<typeof TabSchema>
 /**
  * Custom MCP server configuration schema
  */
-export const CustomMcpServerSchema: z.ZodObject<{
-  name: z.ZodString
-  url: z.ZodString
-}> = z.object({
-  name: z.string(),
-  url: z.string().url(),
-})
+export const CustomMcpServerTypeSchema = z.enum(['http', 'process'])
+
+export const CustomMcpServerSchema = z
+  .object({
+    name: z.string(),
+    type: CustomMcpServerTypeSchema.optional(),
+    url: z.string().url().optional(),
+    headers: z.record(z.string()).optional(),
+    command: z.string().min(1).optional(),
+    args: z.array(z.string()).optional(),
+    env: z.record(z.string()).optional(),
+    cwd: z.string().min(1).optional(),
+  })
+  .superRefine((server, ctx) => {
+    const type = server.type ?? (server.command ? 'process' : 'http')
+
+    if (type === 'http' && !server.url) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['url'],
+        message: 'HTTP MCP servers require a URL',
+      })
+    }
+
+    if (type === 'process' && !server.command) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['command'],
+        message: 'Process MCP servers require a command',
+      })
+    }
+  })
 
 export type CustomMcpServer = z.infer<typeof CustomMcpServerSchema>
 


### PR DESCRIPTION
## Summary
- Add process-based custom MCP server specs alongside existing URL-only custom MCP entries.
- Add an AnythingLLM preset with env var support for launching the official MCP server.
- Carry custom MCP process specs through browser context and build stdio MCP clients on the server.

Fixes #281

## Test plan
- `git diff --check origin/dev...HEAD`
- `bun --env-file=apps/server/.env.development test apps/agent/lib/mcp/customMcpServerPayload.test.ts apps/server/tests/agent/mcp-builder.test.ts` (agent tests passed locally; server test blocked locally by existing @browseros/shared workspace resolution issue tracked in bosmain-bjx)
- `bunx biome check` on touched files
- `bun run typecheck` from `packages/browseros-agent/apps/server` (blocked locally by existing tsc resolution issue tracked in bosmain-woi)
- `bun run typecheck` from `packages/browseros-agent/apps/agent` (blocked locally by existing wxt script resolution issue tracked in bosmain-090)
- `bun run build` from `packages/browseros-agent/apps/agent` (blocked locally by existing graphql-codegen script resolution issue tracked in bosmain-4xe)