### PR TITLE
feat(build): add BROWSEROS_SKIP_R2_DOWNLOAD escape hatch for external builds

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,39 @@ python build/build.py --config build/config/release.windows.yaml --chromium-src 
 
 The build typically takes 1-3 hours on modern hardware (M4 Max, Ryzen 9, etc.).
 
+### Building Without R2 Credentials (External Contributors)
+
+The browser build's `download_resources` step pulls pre-built `browseros_server`
+binaries from a private Cloudflare R2 bucket. External contributors don't have
+those credentials, and historically the build failed at validation with:
+
+```
+R2 configuration not set. Required env vars: R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY
+```
+
+You can skip this step by setting `BROWSEROS_SKIP_R2_DOWNLOAD=1`:
+
+```bash
+# macOS / Linux
+export BROWSEROS_SKIP_R2_DOWNLOAD=1
+python build/build.py --config build/config/debug.macos.yaml --chromium-src /path/to/chromium/src --build
+
+# Windows (PowerShell)
+$env:BROWSEROS_SKIP_R2_DOWNLOAD = "1"
+python build/build.py --config build/config/debug.windows.yaml --chromium-src C:\path\to\chromium\src --build
+```
+
+**What this does:** the `download_resources` module short-circuits with a
+warning and the build proceeds with whatever is already cached locally under
+`resources/binaries/browseros_server/`.
+
+**Caveat:** subsequent steps that copy server binaries into the Chromium tree
+(see `build/config/copy_resources.yaml`) will produce a partial build if that
+cache is empty. This flag is intended for contributors working on **Chromium
+patches, the build system, or the agent extension** — areas that don't depend
+on the bundled server binary. If you need a working server binary too, please
+reach out on Discord.
+
 **For detailed instructions, see [Browser Build Guide](docs/BUILD.md).**
 
 ## Making Your First Contribution

--- a/packages/browseros/build/common/env.py
+++ b/packages/browseros/build/common/env.py
@@ -266,6 +266,18 @@ class EnvConfig:
             self.r2_account_id and self.r2_access_key_id and self.r2_secret_access_key
         )
 
+    @property
+    def skip_r2_download(self) -> bool:
+        """Whether to skip the R2 resource download step.
+
+        External contributors without R2 credentials can set
+        BROWSEROS_SKIP_R2_DOWNLOAD=1 to bypass downloading the browseros_server
+        resource bundles. The build will proceed with whatever is already
+        cached locally under resources/binaries/browseros_server/.
+        """
+        value = os.environ.get("BROWSEROS_SKIP_R2_DOWNLOAD", "")
+        return value.strip().lower() in ("1", "true", "yes", "on")
+
     def has_sparkle_key(self) -> bool:
         """Check if Sparkle private key is available"""
         return bool(self.sparkle_private_key)

--- a/packages/browseros/build/modules/storage/download.py
+++ b/packages/browseros/build/modules/storage/download.py
@@ -15,6 +15,7 @@ from ...common.context import Context
 from ...common.utils import (
     log_info,
     log_success,
+    log_warning,
     get_platform,
 )
 
@@ -187,6 +188,12 @@ class DownloadResourcesModule(CommandModule):
     description = "Download resources from Cloudflare R2"
 
     def validate(self, context: Context) -> None:
+        if context.env.skip_r2_download:
+            # External contributors without R2 access opt in via
+            # BROWSEROS_SKIP_R2_DOWNLOAD=1. Don't gate on boto3 or R2 creds here;
+            # execute() will log and return early.
+            return
+
         if not BOTO3_AVAILABLE:
             raise ValidationError(
                 "boto3 library not installed - run: pip install boto3"
@@ -195,7 +202,9 @@ class DownloadResourcesModule(CommandModule):
         if not context.env.has_r2_config():
             raise ValidationError(
                 "R2 configuration not set. Required env vars: "
-                "R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY"
+                "R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY. "
+                "External contributors without R2 access can set "
+                "BROWSEROS_SKIP_R2_DOWNLOAD=1 to skip this step."
             )
 
         config_path = context.get_download_resources_config()
@@ -205,6 +214,16 @@ class DownloadResourcesModule(CommandModule):
             )
 
     def execute(self, context: Context) -> None:
+        if context.env.skip_r2_download:
+            log_warning(
+                "Skipping R2 resource download (BROWSEROS_SKIP_R2_DOWNLOAD is set).\n"
+                "  Build will proceed with whatever is already cached under\n"
+                "  resources/binaries/browseros_server/. Subsequent steps that\n"
+                "  copy server binaries into the Chromium tree may fail or\n"
+                "  produce a partial build if the cache is empty."
+            )
+            return
+
         log_info("\nDownloading resources from R2...")
 
         config_path = context.get_download_resources_config()

--- a/packages/browseros/build/modules/storage/download_test.py
+++ b/packages/browseros/build/modules/storage/download_test.py
@@ -9,9 +9,12 @@ import tempfile
 import unittest
 import zipfile
 from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
 
 from build.modules.storage.download import (
     ARTIFACT_METADATA_NAME,
+    DownloadResourcesModule,
     extract_artifact_zip,
 )
 
@@ -141,6 +144,52 @@ class ExtractArtifactZipTest(unittest.TestCase):
                 for relative_path, content in files.items()
             ],
         }
+
+
+class SkipR2DownloadTest(unittest.TestCase):
+    """Verify BROWSEROS_SKIP_R2_DOWNLOAD bypasses validation and execution.
+
+    External contributors without R2 credentials need a way to run the build
+    pipeline without failing at the download step.
+    """
+
+    def _make_context(self, *, skip: bool) -> SimpleNamespace:
+        env = SimpleNamespace(
+            skip_r2_download=skip,
+            has_r2_config=lambda: False,
+        )
+        return SimpleNamespace(env=env)
+
+    def test_validate_skips_all_checks_when_flag_set(self) -> None:
+        module = DownloadResourcesModule()
+        context = self._make_context(skip=True)
+
+        # Must not raise even though R2 config is missing.
+        module.validate(context)
+
+    def test_validate_still_requires_r2_when_flag_unset(self) -> None:
+        from build.common.module import ValidationError
+
+        module = DownloadResourcesModule()
+        context = self._make_context(skip=False)
+
+        with self.assertRaises(ValidationError):
+            module.validate(context)
+
+    def test_execute_returns_early_when_flag_set(self) -> None:
+        module = DownloadResourcesModule()
+        context = self._make_context(skip=True)
+
+        # Mock log_warning to avoid console encoding issues on Windows hosts
+        # and to assert the user sees a clear notice.
+        with mock.patch(
+            "build.modules.storage.download.log_warning"
+        ) as log_warning, mock.patch(
+            "build.modules.storage.download.get_r2_client"
+        ) as get_client:
+            module.execute(context)
+            log_warning.assert_called_once()
+            get_client.assert_not_called()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Closes #792

The `download_resources` build module hard-failed validation when R2 credentials were missing, blocking external contributors from running a local Chromium build. The maintainer noted in #792 that the R2 bucket is for internal build infra and not actually required for a local build — but until now there was no documented or supported way to skip it.

This PR adds a documented escape hatch: set `BROWSEROS_SKIP_R2_DOWNLOAD=1` and the `download_resources` step short-circuits cleanly.

## Changes

**Code**

- `packages/browseros/build/common/env.py` — adds `EnvConfig.skip_r2_download` property. Reads `BROWSEROS_SKIP_R2_DOWNLOAD` and accepts `1` / `true` / `yes` / `on` (case-insensitive, trimmed).
- `packages/browseros/build/modules/storage/download.py`
  - `validate()` returns early when the flag is set, bypassing both the `boto3` import check and the R2 config check.
  - `execute()` logs a clear `log_warning` and returns before any R2 call.
  - The existing `"R2 configuration not set"` ValidationError now points users at the new flag, so contributors who hit the error see the workaround immediately.

**Tests** — `packages/browseros/build/modules/storage/download_test.py`

- `test_validate_skips_all_checks_when_flag_set` — validates with `has_r2_config()` returning `False`, must not raise.
- `test_validate_still_requires_r2_when_flag_unset` — flag off, missing creds → still raises `ValidationError` (no regression).
- `test_execute_returns_early_when_flag_set` — asserts `get_r2_client` is never invoked and a warning is emitted. `log_warning` is mocked so the test is portable across hosts whose console encoding can't render the warning emoji (e.g. Windows CP1252).

**Docs** — `CONTRIBUTING.md` gets a new "Building Without R2 Credentials (External Contributors)" section under Browser Development with POSIX + PowerShell examples and an explicit caveat that `copy_resources` may still need a populated `resources/binaries/browseros_server/` cache for a full build.

## Test plan

- [x] `python -m unittest build.modules.storage.download_test -v` — all 7 tests pass (4 existing + 3 new)
- [x] `EnvConfig.skip_r2_download` smoke test across 9 input values (`1`, `true`, `TRUE`, `yes`, `on`, `0`, `false`, `""`, `"  1  "`) — all produce expected booleans
- [ ] On a clean fork with no R2 creds in `.env`: `BROWSEROS_SKIP_R2_DOWNLOAD=1 python build/build.py --config build/config/debug.<os>.yaml --chromium-src ... --build` should reach the configure/build steps without failing at `download_resources`
- [ ] Without the flag, missing R2 creds should still fail validation with the improved error message that mentions the flag
