### PR TITLE
Fix Windows install branding constants

### DIFF
--- a/packages/browseros/chromium_patches/chrome/install_static/chromium_install_modes.h
+++ b/packages/browseros/chromium_patches/chrome/install_static/chromium_install_modes.h
@@ -2,7 +2,9 @@ diff --git a/chrome/install_static/chromium_install_modes.h b/chrome/install_sta
 index ee62888f89705..7ec72d302bc4b 100644
 --- a/chrome/install_static/chromium_install_modes.h
 +++ b/chrome/install_static/chromium_install_modes.h
-@@ -21,7 +21,7 @@ inline constexpr wchar_t kCompanyPathName[] = L"";
+@@ -21,9 +21,9 @@ inline constexpr wchar_t kCompanyPathName[] = L"";
+-inline constexpr wchar_t kCompanyPathName[] = L"";
++inline constexpr wchar_t kCompanyPathName[] = L"BrowserOS";
  
  // The brand-specific product name to be included as a component of the install
  // and user data directory paths.
@@ -10,7 +12,8 @@ index ee62888f89705..7ec72d302bc4b 100644
 +inline constexpr wchar_t kProductPathName[] = L"BrowserOS";
  
  // The brand-specific safe browsing client name.
- inline constexpr char kSafeBrowsingName[] = "chromium";
+-inline constexpr char kSafeBrowsingName[] = "chromium";
++inline constexpr char kSafeBrowsingName[] = "browseros";
 @@ -44,48 +44,49 @@ inline constexpr auto kInstallModes = std::to_array<InstallConstants>({
              L"",  // Empty install_suffix for the primary install mode.
          .logo_suffix = L"",  // No logo suffix for the primary install mode.

--- a/packages/browseros/tests/test_install_modes_patch.py
+++ b/packages/browseros/tests/test_install_modes_patch.py
@@ -1,0 +1,23 @@
+import unittest
+from pathlib import Path
+
+
+PATCH_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "chromium_patches"
+    / "chrome"
+    / "install_static"
+    / "chromium_install_modes.h"
+)
+
+
+class InstallModesPatchTest(unittest.TestCase):
+    def test_install_identity_is_browseros(self) -> None:
+        content = PATCH_PATH.read_text(encoding="utf-8")
+        self.assertIn('kCompanyPathName[] = L"BrowserOS"', content)
+        self.assertIn('kProductPathName[] = L"BrowserOS"', content)
+        self.assertIn('kSafeBrowsingName[] = "browseros"', content)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- set BrowserOS company and safe browsing names in Windows install constants (fixes #765)
- add a unit test to guard install identity constants

## Testing
- python -m unittest discover -s packages/browseros/tests

PR generated with Copilot cloud agent using GPT-5.2-codex.

I could not test the fix myself because I could not compile, I don't have the required stack, but I reviewed the code change and the logic and the fix makes sense to me.

Please test beforehand to check if it works (if someone can make a build - maybe by triggering a gh action - I will gladly try !). 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Windows install identity to use BrowserOS branding. Ensures install paths and Safe Browsing client name are correct and adds a test to prevent regressions.

- **Bug Fixes**
  - Set `kCompanyPathName` and `kProductPathName` to "BrowserOS" and `kSafeBrowsingName` to "browseros" in `packages/browseros/chromium_patches/chrome/install_static/chromium_install_modes.h`.
  - Added `packages/browseros/tests/test_install_modes_patch.py` to assert the constants and guard future changes.

<sup>Written for commit c03ccd43a597e81bcafaa8c2230a7b77b4cb8f7f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

This specific bug is Windows-only. The constants we changed live under chrome/install_static (Windows install path/registry identity). macOS/Linux installs use different mechanisms and aren’t affected by these Windows install identity values.

Agent-Logs-Url: https://github.com/lrq3000/BrowserOS/sessions/aca7c90e-815e-41b0-b423-616b591ae881