### PR TITLE
feat(mcp): X-BrowserOS-Default-Window-Id header + set_window_visibility tool

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
@@ -28,6 +28,12 @@ interface McpRouteDeps {
   klavisRef?: KlavisProxyRef
 }
 
+function parseOptionalNumber(value: string | undefined): number | undefined {
+  if (value === undefined) return undefined
+  const n = Number(value)
+  return Number.isFinite(n) ? n : undefined
+}
+
 export function createMcpRoutes(deps: McpRouteDeps) {
   const app = new Hono<Env>()
 
@@ -58,12 +64,20 @@ export function createMcpRoutes(deps: McpRouteDeps) {
         ? monitoringService.createObserver(monitoringSessionId, agentId)
         : undefined
 
+    // Lets the host pin every browser tool call in this request to a
+    // specific window. register-mcp.ts injects this into args.windowId
+    // for any tool whose zod input schema has a windowId field.
+    const defaultWindowId = parseOptionalNumber(
+      c.req.header('X-BrowserOS-Default-Window-Id'),
+    )
+
     // Per-request server + transport: no shared state, no race conditions,
     // no ID collisions. Required by MCP SDK 1.26.0+ security fix (GHSA-345p-7cg4-v4c7).
     const mcpServer = createMcpServer({
       ...deps,
       aclRules,
       observer,
+      defaultWindowId,
     })
     const transport = new StreamableHTTPTransport({
       sessionIdGenerator: undefined,

--- a/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
@@ -31,7 +31,10 @@ interface McpRouteDeps {
 function parseOptionalNumber(value: string | undefined): number | undefined {
   if (value === undefined) return undefined
   const n = Number(value)
-  return Number.isFinite(n) ? n : undefined
+  // CDP window ids are integers; `Number.isFinite('1.5')` would be true
+  // and silently route to a non-integer that CDP rejects with an opaque
+  // protocol error. Require an integer at the parse boundary.
+  return Number.isInteger(n) ? n : undefined
 }
 
 export function createMcpRoutes(deps: McpRouteDeps) {

--- a/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-server.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-server.ts
@@ -26,6 +26,13 @@ export interface McpServiceDeps {
   aclRules?: AclRule[]
   klavisRef?: KlavisProxyRef
   observer?: ToolExecutionObserver
+  // Per-request default windowId from the X-BrowserOS-Default-Window-Id
+  // header. When set, tool handlers inject this into args.windowId for
+  // any tool whose zod input schema has a `windowId` field and whose
+  // caller-supplied args didn't include one. Lets a host application
+  // bind every browser tool call to a specific window without the
+  // agent needing to be aware of it.
+  defaultWindowId?: number
 }
 
 export function createMcpServer(deps: McpServiceDeps): McpServer {
@@ -51,6 +58,7 @@ export function createMcpServer(deps: McpServiceDeps): McpServer {
     },
     aclRules: deps.aclRules,
     observer: deps.observer,
+    defaultWindowId: deps.defaultWindowId,
   })
 
   // Register Klavis proxy tools (if connected via background init)

--- a/packages/browseros-agent/apps/server/src/api/services/mcp/register-mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/mcp/register-mcp.ts
@@ -1,23 +1,56 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
+import { z } from 'zod'
 import { logger } from '../../../lib/logger'
 import { metrics } from '../../../lib/metrics'
 import {
   buildMonitoringToolOutput,
   type ToolExecutionObserver,
 } from '../../../monitoring/observer'
-import { executeTool, type ToolContext } from '../../../tools/framework'
+import {
+  executeTool,
+  type ToolContext,
+  type ToolDefinition,
+} from '../../../tools/framework'
 import type { ToolRegistry } from '../../../tools/tool-registry'
+
+// True when the tool's zod input schema is a ZodObject with a `windowId`
+// field. Schema-driven so any future tool that takes a windowId
+// participates automatically — no per-tool allowlist.
+function inputHasWindowIdField(tool: ToolDefinition): boolean {
+  const input = tool.input
+  if (!(input instanceof z.ZodObject)) return false
+  return 'windowId' in (input as z.AnyZodObject).shape
+}
 
 export function registerTools(
   mcpServer: McpServer,
   registry: ToolRegistry,
-  ctx: ToolContext & { observer?: ToolExecutionObserver },
+  ctx: ToolContext & {
+    observer?: ToolExecutionObserver
+    // Default windowId from X-BrowserOS-Default-Window-Id. When set,
+    // tool calls without an explicit args.windowId have this value
+    // injected — provided the tool's schema actually accepts one.
+    defaultWindowId?: number
+  },
 ): void {
   for (const tool of registry.all()) {
+    const acceptsWindowId = inputHasWindowIdField(tool)
     const handler = async (
       args: Record<string, unknown>,
       extra: { signal: AbortSignal },
     ) => {
+      // Inject the per-request default windowId only when (a) the host
+      // supplied one via header, (b) the tool actually accepts a
+      // windowId, and (c) the caller didn't explicitly set one. The
+      // explicit-set check means an agent that *did* pick a windowId on
+      // purpose still wins — we only fill the gap.
+      if (
+        ctx.defaultWindowId !== undefined &&
+        acceptsWindowId &&
+        args.windowId === undefined
+      ) {
+        args.windowId = ctx.defaultWindowId
+      }
       const startTime = performance.now()
       const toolCallId = crypto.randomUUID()
 

--- a/packages/browseros-agent/apps/server/src/browser/browser.ts
+++ b/packages/browseros-agent/apps/server/src/browser/browser.ts
@@ -1459,6 +1459,14 @@ export class Browser {
     await this.cdp.Browser.activateWindow({ windowId })
   }
 
+  async showWindow(windowId: number): Promise<void> {
+    await this.cdp.Browser.showWindow({ windowId })
+  }
+
+  async hideWindow(windowId: number): Promise<void> {
+    await this.cdp.Browser.hideWindow({ windowId })
+  }
+
   async showPage(
     page: number,
     opts?: { windowId?: number; index?: number; activate?: boolean },

--- a/packages/browseros-agent/apps/server/src/tools/registry.ts
+++ b/packages/browseros-agent/apps/server/src/tools/registry.ts
@@ -70,6 +70,7 @@ import {
   create_hidden_window,
   create_window,
   list_windows,
+  set_window_visibility,
 } from './windows'
 
 export const registry = createRegistry([
@@ -119,12 +120,13 @@ export const registry = createRegistry([
   save_screenshot,
   download_file,
 
-  // Windows (5)
+  // Windows (6)
   list_windows,
   create_window,
   create_hidden_window,
   close_window,
   activate_window,
+  set_window_visibility,
 
   // Bookmarks (6)
   get_bookmarks,

--- a/packages/browseros-agent/apps/server/src/tools/windows.ts
+++ b/packages/browseros-agent/apps/server/src/tools/windows.ts
@@ -126,3 +126,37 @@ export const activate_window = defineManagementTool({
     response.data({ action: 'activate_window', windowId: args.windowId })
   },
 })
+
+export const set_window_visibility = defineManagementTool({
+  name: 'set_window_visibility',
+  description:
+    'Show or hide an existing browser window. ' +
+    'Pass visible=true to make a hidden window visible, ' +
+    'visible=false to hide a visible one. Idempotent — calling with ' +
+    'the current state is a no-op. The windowId is stable across the ' +
+    'toggle; tabs are preserved.',
+  input: z.object({
+    windowId: z.number().describe('Window ID'),
+    visible: z.boolean().describe('Target visibility'),
+  }),
+  output: z.object({
+    action: z.literal('set_window_visibility'),
+    windowId: z.number(),
+    visible: z.boolean(),
+  }),
+  handler: async (args, ctx, response) => {
+    if (args.visible) {
+      await ctx.browser.showWindow(args.windowId)
+    } else {
+      await ctx.browser.hideWindow(args.windowId)
+    }
+    response.text(
+      `Window ${args.windowId} is now ${args.visible ? 'visible' : 'hidden'}`,
+    )
+    response.data({
+      action: 'set_window_visibility',
+      windowId: args.windowId,
+      visible: args.visible,
+    })
+  },
+})


### PR DESCRIPTION
## Summary

Two additions for host applications that want to deterministically bind every browser tool call in an MCP session to a specific window.

- **Header `X-BrowserOS-Default-Window-Id`** — honored in `register-mcp.ts`. Before `executeTool` runs, the handler wrap reads the tool's zod input schema; if it has a `windowId` field and `args.windowId` is undefined, the header value is injected. Schema-driven — covers `new_page`, `new_hidden_page`, `show_page`, `move_page` today and any future tool with a `windowId` field with no per-tool allowlist. The agent's explicit `args.windowId` still wins when set (intentional, lets multi-window batch work continue).
- **`set_window_visibility {windowId, visible}` tool** — symmetric show/hide on an existing window, delegating to `cdp.Browser.showWindow` / `hideWindow`. Idempotent. Preserves the windowId and tabs.

The C++ side of `Browser.showWindow` / `hideWindow` isn't wired in the binary yet (`is_hidden_` is `const` and there's no handler in `BrowserHandler` for them; only declared in the `inspector_protocol_config.json` include list + generated client types). The tool returns the runtime error verbatim so callers can degrade gracefully; once the Chromium patch lands, the tool starts working with no changes here.

## Companion PR

[agent-company#TBD](https://github.com/browseros-ai/agent-company) uses this header to per-`(employee, thread)` bind windows and exposes a visibility toggle in the chat header.

## Test plan

- [x] `bun run dev:watch:new` boots; `set_window_visibility` appears in `tools/list` (61 tools registered).
- [x] `tools/call new_page` with `X-BrowserOS-Default-Window-Id: <id>` header and no `windowId` in args → page lands in `<id>`. Verified via follow-up `list_pages`.
- [x] `tools/call set_window_visibility` returns the expected runtime error from missing CDP wire-up — no crash, error text propagated to client.
- [x] Agent's explicit `args.windowId` is **not** overridden by the header.
- [x] Tools without `windowId` in their schema are untouched by the injection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)