### PR TITLE
chore: update CDP protocol bindings

### DIFF
--- a/packages/browseros-agent/.env.example
+++ b/packages/browseros-agent/.env.example
@@ -1,0 +1,2 @@
+# CDP protocol codegen
+CDP_PROTOCOL_JSON=/path/to/chromium/src/out/Default_arm64/gen/third_party/blink/public/devtools_protocol/protocol.json

--- a/packages/browseros-agent/packages/cdp-protocol/README.md
+++ b/packages/browseros-agent/packages/cdp-protocol/README.md
@@ -62,6 +62,28 @@ src/generated/
 
 Types are auto-generated from the CDP protocol specification. The generated output lives in `src/generated/` and should not be edited manually.
 
+1. Build Chromium so the generated DevTools protocol JSON exists:
+
+   ```sh
+   autoninja -C out/Default_arm64 chrome
+   ```
+
+2. From this repository root, point `CDP_PROTOCOL_JSON` at Chromium's generated protocol file:
+
+   ```sh
+   CDP_PROTOCOL_JSON=/path/to/chromium/src/out/Default_arm64/gen/third_party/blink/public/devtools_protocol/protocol.json bun run gen:cdp
+   ```
+
+   You can also copy `.env.example` to `.env` and set `CDP_PROTOCOL_JSON` there; Bun loads `.env` automatically when running the codegen script.
+
+3. Review and commit all regenerated files:
+
+   ```sh
+   git status --short packages/cdp-protocol package.json scripts/codegen
+   ```
+
+   New CDP domains create new files under both `src/generated/domains/` and `src/generated/domain-apis/`. Make sure those files are tracked along with `packages/cdp-protocol/package.json`, `protocol-api.ts`, and `create-api.ts`.
+
 ## License
 
 [AGPL-3.0-or-later](../../../../LICENSE)

--- a/packages/browseros-agent/packages/cdp-protocol/package.json
+++ b/packages/browseros-agent/packages/cdp-protocol/package.json
@@ -342,6 +342,14 @@
       "types": "./src/generated/domain-apis/service-worker.ts",
       "default": "./src/generated/domain-apis/service-worker.ts"
     },
+    "./domains/smart-card-emulation": {
+      "types": "./src/generated/domains/smart-card-emulation.ts",
+      "default": "./src/generated/domains/smart-card-emulation.ts"
+    },
+    "./domain-apis/smart-card-emulation": {
+      "types": "./src/generated/domain-apis/smart-card-emulation.ts",
+      "default": "./src/generated/domain-apis/smart-card-emulation.ts"
+    },
     "./domains/storage": {
       "types": "./src/generated/domains/storage.ts",
       "default": "./src/generated/domains/storage.ts"

--- a/packages/browseros-agent/packages/cdp-protocol/src/generated/create-api.ts
+++ b/packages/browseros-agent/packages/cdp-protocol/src/generated/create-api.ts
@@ -69,6 +69,7 @@ export function createProtocolApi(send: RawSend, on: RawOn): ProtocolApi {
     Preload: createDomainProxy('Preload', send, on),
     Security: createDomainProxy('Security', send, on),
     ServiceWorker: createDomainProxy('ServiceWorker', send, on),
+    SmartCardEmulation: createDomainProxy('SmartCardEmulation', send, on),
     Storage: createDomainProxy('Storage', send, on),
     SystemInfo: createDomainProxy('SystemInfo', send, on),
     Target: createDomainProxy('Target', send, on),

--- a/packages/browseros-agent/packages/cdp-protocol/src/generated/domain-apis/browser.ts
+++ b/packages/browseros-agent/packages/cdp-protocol/src/generated/domain-apis/browser.ts
@@ -47,9 +47,6 @@ import type {
   GetWindowForTargetResult,
   GetWindowsResult,
   GrantPermissionsParams,
-  HideTabParams,
-  HideTabResult,
-  HideWindowParams,
   MoveTabGroupParams,
   MoveTabGroupResult,
   MoveTabParams,
@@ -65,7 +62,6 @@ import type {
   SetWindowBoundsParams,
   ShowTabParams,
   ShowTabResult,
-  ShowWindowParams,
   UnpinTabParams,
   UnpinTabResult,
   UpdateTabGroupParams,
@@ -80,8 +76,6 @@ export interface BrowserApi {
   createWindow(params?: CreateWindowParams): Promise<CreateWindowResult>
   closeWindow(params: CloseWindowParams): Promise<void>
   activateWindow(params: ActivateWindowParams): Promise<void>
-  showWindow(params: ShowWindowParams): Promise<void>
-  hideWindow(params: HideWindowParams): Promise<void>
   getTabs(params?: GetTabsParams): Promise<GetTabsResult>
   getActiveTab(params?: GetActiveTabParams): Promise<GetActiveTabResult>
   getTabInfo(params?: GetTabInfoParams): Promise<GetTabInfoResult>
@@ -93,7 +87,6 @@ export interface BrowserApi {
   pinTab(params?: PinTabParams): Promise<PinTabResult>
   unpinTab(params?: UnpinTabParams): Promise<UnpinTabResult>
   showTab(params?: ShowTabParams): Promise<ShowTabResult>
-  hideTab(params?: HideTabParams): Promise<HideTabResult>
   getTabGroups(params?: GetTabGroupsParams): Promise<GetTabGroupsResult>
   createTabGroup(params: CreateTabGroupParams): Promise<CreateTabGroupResult>
   updateTabGroup(params: UpdateTabGroupParams): Promise<UpdateTabGroupResult>

--- a/packages/browseros-agent/packages/cdp-protocol/src/generated/domain-apis/extensions.ts
+++ b/packages/browseros-agent/packages/cdp-protocol/src/generated/domain-apis/extensions.ts
@@ -8,12 +8,14 @@ import type {
   LoadUnpackedResult,
   RemoveStorageItemsParams,
   SetStorageItemsParams,
+  TriggerActionParams,
   UninstallParams,
 } from '../domains/extensions'
 
 export interface ExtensionsApi {
   // ── Commands ──
 
+  triggerAction(params: TriggerActionParams): Promise<void>
   loadUnpacked(params: LoadUnpackedParams): Promise<LoadUnpackedResult>
   uninstall(params: UninstallParams): Promise<void>
   getStorageItems(params: GetStorageItemsParams): Promise<GetStorageItemsResult>

--- a/packages/browseros-agent/packages/cdp-protocol/src/generated/domain-apis/overlay.ts
+++ b/packages/browseros-agent/packages/cdp-protocol/src/generated/domain-apis/overlay.ts
@@ -12,7 +12,9 @@ import type {
   HighlightQuadParams,
   HighlightRectParams,
   HighlightSourceOrderParams,
+  InspectedElementWindowRestoredEvent,
   InspectNodeRequestedEvent,
+  InspectPanelShowRequestedEvent,
   NodeHighlightRequestedEvent,
   ScreenshotRequestedEvent,
   SetInspectModeParams,
@@ -25,6 +27,7 @@ import type {
   SetShowGridOverlaysParams,
   SetShowHingeParams,
   SetShowHitTestBordersParams,
+  SetShowInspectedElementAnchorParams,
   SetShowIsolatedElementsParams,
   SetShowLayoutShiftRegionsParams,
   SetShowPaintRectsParams,
@@ -70,6 +73,9 @@ export interface OverlayApi {
   setShowContainerQueryOverlays(
     params: SetShowContainerQueryOverlaysParams,
   ): Promise<void>
+  setShowInspectedElementAnchor(
+    params: SetShowInspectedElementAnchorParams,
+  ): Promise<void>
   setShowPaintRects(params: SetShowPaintRectsParams): Promise<void>
   setShowLayoutShiftRegions(
     params: SetShowLayoutShiftRegionsParams,
@@ -101,6 +107,14 @@ export interface OverlayApi {
   on(
     event: 'screenshotRequested',
     handler: (params: ScreenshotRequestedEvent) => void,
+  ): () => void
+  on(
+    event: 'inspectPanelShowRequested',
+    handler: (params: InspectPanelShowRequestedEvent) => void,
+  ): () => void
+  on(
+    event: 'inspectedElementWindowRestored',
+    handler: (params: InspectedElementWindowRestoredEvent) => void,
   ): () => void
   on(event: 'inspectModeCanceled', handler: () => void): () => void
 }

--- a/packages/browseros-agent/packages/cdp-protocol/src/generated/domain-apis/smart-card-emulation.ts
+++ b/packages/browseros-agent/packages/cdp-protocol/src/generated/domain-apis/smart-card-emulation.ts
@@ -1,0 +1,112 @@
+// ── AUTO-GENERATED from CDP protocol. DO NOT EDIT. ──
+
+import type {
+  BeginTransactionRequestedEvent,
+  CancelRequestedEvent,
+  ConnectRequestedEvent,
+  ControlRequestedEvent,
+  DisconnectRequestedEvent,
+  EndTransactionRequestedEvent,
+  EstablishContextRequestedEvent,
+  GetAttribRequestedEvent,
+  GetStatusChangeRequestedEvent,
+  ListReadersRequestedEvent,
+  ReleaseContextRequestedEvent,
+  ReportBeginTransactionResultParams,
+  ReportConnectResultParams,
+  ReportDataResultParams,
+  ReportErrorParams,
+  ReportEstablishContextResultParams,
+  ReportGetStatusChangeResultParams,
+  ReportListReadersResultParams,
+  ReportPlainResultParams,
+  ReportReleaseContextResultParams,
+  ReportStatusResultParams,
+  SetAttribRequestedEvent,
+  StatusRequestedEvent,
+  TransmitRequestedEvent,
+} from '../domains/smart-card-emulation'
+
+export interface SmartCardEmulationApi {
+  // ── Commands ──
+
+  enable(): Promise<void>
+  disable(): Promise<void>
+  reportEstablishContextResult(
+    params: ReportEstablishContextResultParams,
+  ): Promise<void>
+  reportReleaseContextResult(
+    params: ReportReleaseContextResultParams,
+  ): Promise<void>
+  reportListReadersResult(params: ReportListReadersResultParams): Promise<void>
+  reportGetStatusChangeResult(
+    params: ReportGetStatusChangeResultParams,
+  ): Promise<void>
+  reportBeginTransactionResult(
+    params: ReportBeginTransactionResultParams,
+  ): Promise<void>
+  reportPlainResult(params: ReportPlainResultParams): Promise<void>
+  reportConnectResult(params: ReportConnectResultParams): Promise<void>
+  reportDataResult(params: ReportDataResultParams): Promise<void>
+  reportStatusResult(params: ReportStatusResultParams): Promise<void>
+  reportError(params: ReportErrorParams): Promise<void>
+
+  // ── Events ──
+
+  on(
+    event: 'establishContextRequested',
+    handler: (params: EstablishContextRequestedEvent) => void,
+  ): () => void
+  on(
+    event: 'releaseContextRequested',
+    handler: (params: ReleaseContextRequestedEvent) => void,
+  ): () => void
+  on(
+    event: 'listReadersRequested',
+    handler: (params: ListReadersRequestedEvent) => void,
+  ): () => void
+  on(
+    event: 'getStatusChangeRequested',
+    handler: (params: GetStatusChangeRequestedEvent) => void,
+  ): () => void
+  on(
+    event: 'cancelRequested',
+    handler: (params: CancelRequestedEvent) => void,
+  ): () => void
+  on(
+    event: 'connectRequested',
+    handler: (params: ConnectRequestedEvent) => void,
+  ): () => void
+  on(
+    event: 'disconnectRequested',
+    handler: (params: DisconnectRequestedEvent) => void,
+  ): () => void
+  on(
+    event: 'transmitRequested',
+    handler: (params: TransmitRequestedEvent) => void,
+  ): () => void
+  on(
+    event: 'controlRequested',
+    handler: (params: ControlRequestedEvent) => void,
+  ): () => void
+  on(
+    event: 'getAttribRequested',
+    handler: (params: GetAttribRequestedEvent) => void,
+  ): () => void
+  on(
+    event: 'setAttribRequested',
+    handler: (params: SetAttribRequestedEvent) => void,
+  ): () => void
+  on(
+    event: 'statusRequested',
+    handler: (params: StatusRequestedEvent) => void,
+  ): () => void
+  on(
+    event: 'beginTransactionRequested',
+    handler: (params: BeginTransactionRequestedEvent) => void,
+  ): () => void
+  on(
+    event: 'endTransactionRequested',
+    handler: (params: EndTransactionRequestedEvent) => void,
+  ): () => void
+}

--- a/packages/browseros-agent/packages/cdp-protocol/src/generated/domains/audits.ts
+++ b/packages/browseros-agent/packages/cdp-protocol/src/generated/domains/audits.ts
@@ -33,8 +33,6 @@ export type CookieExclusionReason =
   | 'ExcludeSameSiteNoneInsecure'
   | 'ExcludeSameSiteLax'
   | 'ExcludeSameSiteStrict'
-  | 'ExcludeInvalidSameParty'
-  | 'ExcludeSamePartyCrossPartyContext'
   | 'ExcludeDomainNonASCII'
   | 'ExcludeThirdPartyCookieBlockedInFirstPartySet'
   | 'ExcludeThirdPartyPhaseout'
@@ -286,6 +284,14 @@ export type UnencodedDigestError =
   | 'IncorrectDigestType'
   | 'IncorrectDigestLength'
 
+export type ConnectionAllowlistError =
+  | 'InvalidHeader'
+  | 'MoreThanOneList'
+  | 'ItemNotInnerList'
+  | 'InvalidAllowlistItemType'
+  | 'ReportingEndpointNotToken'
+  | 'InvalidUrlPattern'
+
 export interface AttributionReportingIssueDetails {
   violationType: AttributionReportingIssueType
   request?: AffectedRequest
@@ -320,6 +326,11 @@ export interface SRIMessageSignatureIssueDetails {
 
 export interface UnencodedDigestIssueDetails {
   error: UnencodedDigestError
+  request: AffectedRequest
+}
+
+export interface ConnectionAllowlistIssueDetails {
+  error: ConnectionAllowlistError
   request: AffectedRequest
 }
 
@@ -563,6 +574,7 @@ export type InspectorIssueCode =
   | 'ElementAccessibilityIssue'
   | 'SRIMessageSignatureIssue'
   | 'UnencodedDigestIssue'
+  | 'ConnectionAllowlistIssue'
   | 'UserReidentificationIssue'
   | 'PermissionElementIssue'
 
@@ -592,6 +604,7 @@ export interface InspectorIssueDetails {
   elementAccessibilityIssueDetails?: ElementAccessibilityIssueDetails
   sriMessageSignatureIssueDetails?: SRIMessageSignatureIssueDetails
   unencodedDigestIssueDetails?: UnencodedDigestIssueDetails
+  connectionAllowlistIssueDetails?: ConnectionAllowlistIssueDetails
   userReidentificationIssueDetails?: UserReidentificationIssueDetails
   permissionElementIssueDetails?: PermissionElementIssueDetails
 }

--- a/packages/browseros-agent/packages/cdp-protocol/src/generated/domains/browser.ts
+++ b/packages/browseros-agent/packages/cdp-protocol/src/generated/domains/browser.ts
@@ -166,14 +166,6 @@ export interface ActivateWindowParams {
   windowId: WindowID
 }
 
-export interface ShowWindowParams {
-  windowId: WindowID
-}
-
-export interface HideWindowParams {
-  windowId: WindowID
-}
-
 export interface GetTabsParams {
   windowId?: WindowID
   includeHidden?: boolean
@@ -206,7 +198,6 @@ export interface CreateTabParams {
   index?: number
   background?: boolean
   pinned?: boolean
-  hidden?: boolean
   browserContextId?: BrowserContextID
 }
 
@@ -271,15 +262,6 @@ export interface ShowTabParams {
 }
 
 export interface ShowTabResult {
-  tab: TabInfo
-}
-
-export interface HideTabParams {
-  targetId?: TargetID
-  tabId?: TabID
-}
-
-export interface HideTabResult {
   tab: TabInfo
 }
 

--- a/packages/browseros-agent/packages/cdp-protocol/src/generated/domains/extensions.ts
+++ b/packages/browseros-agent/packages/cdp-protocol/src/generated/domains/extensions.ts
@@ -6,8 +6,14 @@ export type StorageArea = 'session' | 'local' | 'sync' | 'managed'
 
 // ══ Commands ══
 
+export interface TriggerActionParams {
+  id: string
+  targetId: string
+}
+
 export interface LoadUnpackedParams {
   path: string
+  enableInIncognito?: boolean
 }
 
 export interface LoadUnpackedResult {

--- a/packages/browseros-agent/packages/cdp-protocol/src/generated/domains/network.ts
+++ b/packages/browseros-agent/packages/cdp-protocol/src/generated/domains/network.ts
@@ -214,21 +214,14 @@ export type CorsError =
   | 'PreflightInvalidAllowCredentials'
   | 'PreflightMissingAllowExternal'
   | 'PreflightInvalidAllowExternal'
-  | 'PreflightMissingAllowPrivateNetwork'
-  | 'PreflightInvalidAllowPrivateNetwork'
   | 'InvalidAllowMethodsPreflightResponse'
   | 'InvalidAllowHeadersPreflightResponse'
   | 'MethodDisallowedByPreflightResponse'
   | 'HeaderDisallowedByPreflightResponse'
   | 'RedirectContainsCredentials'
-  | 'InsecurePrivateNetwork'
-  | 'InvalidPrivateNetworkAccess'
-  | 'UnexpectedPrivateNetworkAccess'
+  | 'InsecureLocalNetwork'
+  | 'InvalidLocalNetworkAccess'
   | 'NoCorsRedirectModeNotFollow'
-  | 'PreflightMissingPrivateNetworkAccessId'
-  | 'PreflightMissingPrivateNetworkAccessName'
-  | 'PrivateNetworkAccessPermissionUnavailable'
-  | 'PrivateNetworkAccessPermissionDenied'
   | 'LocalNetworkAccessPermissionDenied'
 
 export interface CorsErrorStatus {
@@ -362,7 +355,6 @@ export interface Cookie {
   session: boolean
   sameSite?: CookieSameSite
   priority: CookiePriority
-  sameParty: boolean
   sourceScheme: CookieSourceScheme
   sourcePort: number
   partitionKey?: CookiePartitionKey
@@ -387,8 +379,6 @@ export type SetCookieBlockedReason =
   | 'SchemefulSameSiteStrict'
   | 'SchemefulSameSiteLax'
   | 'SchemefulSameSiteUnspecifiedTreatedAsLax'
-  | 'SamePartyFromCrossPartyContext'
-  | 'SamePartyConflictsWithOtherAttributes'
   | 'NameValuePairExceedsMaxSize'
   | 'DisallowedCharacter'
   | 'NoCookieContent'
@@ -408,7 +398,6 @@ export type CookieBlockedReason =
   | 'SchemefulSameSiteStrict'
   | 'SchemefulSameSiteLax'
   | 'SchemefulSameSiteUnspecifiedTreatedAsLax'
-  | 'SamePartyFromCrossPartyContext'
   | 'NameValuePairExceedsMaxSize'
   | 'PortMismatch'
   | 'SchemeMismatch'
@@ -456,7 +445,6 @@ export interface CookieParam {
   sameSite?: CookieSameSite
   expires?: TimeSinceEpoch
   priority?: CookiePriority
-  sameParty?: boolean
   sourceScheme?: CookieSourceScheme
   sourcePort?: number
   partitionKey?: CookiePartitionKey
@@ -572,7 +560,7 @@ export interface DirectUDPMessage {
   remotePort?: number
 }
 
-export type PrivateNetworkRequestPolicy =
+export type LocalNetworkAccessRequestPolicy =
   | 'Allow'
   | 'BlockFromInsecureToMorePrivate'
   | 'WarnFromInsecureToMorePrivate'
@@ -588,7 +576,7 @@ export interface ConnectTiming {
 export interface ClientSecurityState {
   initiatorIsSecureContext: boolean
   initiatorIPAddressSpace: IPAddressSpace
-  privateNetworkRequestPolicy: PrivateNetworkRequestPolicy
+  localNetworkAccessRequestPolicy: LocalNetworkAccessRequestPolicy
 }
 
 export type CrossOriginOpenerPolicyValue =
@@ -657,6 +645,17 @@ export interface ReportingApiEndpoint {
 export interface DeviceBoundSessionKey {
   site: string
   id: string
+}
+
+export interface DeviceBoundSessionWithUsage {
+  sessionKey: DeviceBoundSessionKey
+  usage:
+    | 'NotInScope'
+    | 'InScopeRefreshNotYetNeeded'
+    | 'InScopeRefreshNotAllowed'
+    | 'ProactiveRefreshNotPossible'
+    | 'ProactiveRefreshAttempted'
+    | 'Deferred'
 }
 
 export interface DeviceBoundSessionCookieCraving {
@@ -988,7 +987,6 @@ export interface SetCookieParams {
   sameSite?: CookieSameSite
   expires?: TimeSinceEpoch
   priority?: CookiePriority
-  sameParty?: boolean
   sourceScheme?: CookieSourceScheme
   sourcePort?: number
   partitionKey?: CookiePartitionKey
@@ -1313,6 +1311,7 @@ export interface RequestWillBeSentExtraInfoEvent {
   associatedCookies: AssociatedCookie[]
   headers: Headers
   connectTiming: ConnectTiming
+  deviceBoundSessionUsages?: DeviceBoundSessionWithUsage[]
   clientSecurityState?: ClientSecurityState
   siteHasCookieInOtherPartition?: boolean
   appliedNetworkConditionsId?: string

--- a/packages/browseros-agent/packages/cdp-protocol/src/generated/domains/overlay.ts
+++ b/packages/browseros-agent/packages/cdp-protocol/src/generated/domains/overlay.ts
@@ -148,6 +148,11 @@ export type InspectMode =
   | 'captureAreaScreenshot'
   | 'none'
 
+export interface InspectedElementAnchorConfig {
+  nodeId?: NodeId
+  backendNodeId?: BackendNodeId
+}
+
 // ══ Commands ══
 
 export interface GetHighlightObjectForTestParams {
@@ -251,6 +256,10 @@ export interface SetShowContainerQueryOverlaysParams {
   containerQueryHighlightConfigs: ContainerQueryHighlightConfig[]
 }
 
+export interface SetShowInspectedElementAnchorParams {
+  inspectedElementAnchorConfig: InspectedElementAnchorConfig
+}
+
 export interface SetShowPaintRectsParams {
   result: boolean
 }
@@ -299,4 +308,12 @@ export interface NodeHighlightRequestedEvent {
 
 export interface ScreenshotRequestedEvent {
   viewport: Viewport
+}
+
+export interface InspectPanelShowRequestedEvent {
+  backendNodeId: BackendNodeId
+}
+
+export interface InspectedElementWindowRestoredEvent {
+  backendNodeId: BackendNodeId
 }

--- a/packages/browseros-agent/packages/cdp-protocol/src/generated/domains/page.ts
+++ b/packages/browseros-agent/packages/cdp-protocol/src/generated/domains/page.ts
@@ -583,6 +583,7 @@ export type BackForwardCacheNotRestoredReason =
   | 'SharedWorkerMessage'
   | 'SharedWorkerWithNoActiveClient'
   | 'WebLocks'
+  | 'WebLocksContention'
   | 'WebHID'
   | 'WebBluetooth'
   | 'WebShare'

--- a/packages/browseros-agent/packages/cdp-protocol/src/generated/domains/smart-card-emulation.ts
+++ b/packages/browseros-agent/packages/cdp-protocol/src/generated/domains/smart-card-emulation.ts
@@ -1,0 +1,227 @@
+// ── AUTO-GENERATED from CDP protocol. DO NOT EDIT. ──
+
+// ══ Types ══
+
+export type ResultCode =
+  | 'success'
+  | 'removed-card'
+  | 'reset-card'
+  | 'unpowered-card'
+  | 'unresponsive-card'
+  | 'unsupported-card'
+  | 'reader-unavailable'
+  | 'sharing-violation'
+  | 'not-transacted'
+  | 'no-smartcard'
+  | 'proto-mismatch'
+  | 'system-cancelled'
+  | 'not-ready'
+  | 'cancelled'
+  | 'insufficient-buffer'
+  | 'invalid-handle'
+  | 'invalid-parameter'
+  | 'invalid-value'
+  | 'no-memory'
+  | 'timeout'
+  | 'unknown-reader'
+  | 'unsupported-feature'
+  | 'no-readers-available'
+  | 'service-stopped'
+  | 'no-service'
+  | 'comm-error'
+  | 'internal-error'
+  | 'server-too-busy'
+  | 'unexpected'
+  | 'shutdown'
+  | 'unknown-card'
+  | 'unknown'
+
+export type ShareMode = 'shared' | 'exclusive' | 'direct'
+
+export type Disposition =
+  | 'leave-card'
+  | 'reset-card'
+  | 'unpower-card'
+  | 'eject-card'
+
+export type ConnectionState =
+  | 'absent'
+  | 'present'
+  | 'swallowed'
+  | 'powered'
+  | 'negotiable'
+  | 'specific'
+
+export interface ReaderStateFlags {
+  unaware?: boolean
+  ignore?: boolean
+  changed?: boolean
+  unknown?: boolean
+  unavailable?: boolean
+  empty?: boolean
+  present?: boolean
+  exclusive?: boolean
+  inuse?: boolean
+  mute?: boolean
+  unpowered?: boolean
+}
+
+export interface ProtocolSet {
+  t0?: boolean
+  t1?: boolean
+  raw?: boolean
+}
+
+export type Protocol = 't0' | 't1' | 'raw'
+
+export interface ReaderStateIn {
+  reader: string
+  currentState: ReaderStateFlags
+  currentInsertionCount: number
+}
+
+export interface ReaderStateOut {
+  reader: string
+  eventState: ReaderStateFlags
+  eventCount: number
+  atr: string
+}
+
+// ══ Commands ══
+
+export interface ReportEstablishContextResultParams {
+  requestId: string
+  contextId: number
+}
+
+export interface ReportReleaseContextResultParams {
+  requestId: string
+}
+
+export interface ReportListReadersResultParams {
+  requestId: string
+  readers: string[]
+}
+
+export interface ReportGetStatusChangeResultParams {
+  requestId: string
+  readerStates: ReaderStateOut[]
+}
+
+export interface ReportBeginTransactionResultParams {
+  requestId: string
+  handle: number
+}
+
+export interface ReportPlainResultParams {
+  requestId: string
+}
+
+export interface ReportConnectResultParams {
+  requestId: string
+  handle: number
+  activeProtocol?: Protocol
+}
+
+export interface ReportDataResultParams {
+  requestId: string
+  data: string
+}
+
+export interface ReportStatusResultParams {
+  requestId: string
+  readerName: string
+  state: ConnectionState
+  atr: string
+  protocol?: Protocol
+}
+
+export interface ReportErrorParams {
+  requestId: string
+  resultCode: ResultCode
+}
+
+// ══ Events ══
+
+export interface EstablishContextRequestedEvent {
+  requestId: string
+}
+
+export interface ReleaseContextRequestedEvent {
+  requestId: string
+  contextId: number
+}
+
+export interface ListReadersRequestedEvent {
+  requestId: string
+  contextId: number
+}
+
+export interface GetStatusChangeRequestedEvent {
+  requestId: string
+  contextId: number
+  readerStates: ReaderStateIn[]
+  timeout?: number
+}
+
+export interface CancelRequestedEvent {
+  requestId: string
+  contextId: number
+}
+
+export interface ConnectRequestedEvent {
+  requestId: string
+  contextId: number
+  reader: string
+  shareMode: ShareMode
+  preferredProtocols: ProtocolSet
+}
+
+export interface DisconnectRequestedEvent {
+  requestId: string
+  handle: number
+  disposition: Disposition
+}
+
+export interface TransmitRequestedEvent {
+  requestId: string
+  handle: number
+  data: string
+  protocol?: Protocol
+}
+
+export interface ControlRequestedEvent {
+  requestId: string
+  handle: number
+  controlCode: number
+  data: string
+}
+
+export interface GetAttribRequestedEvent {
+  requestId: string
+  handle: number
+  attribId: number
+}
+
+export interface SetAttribRequestedEvent {
+  requestId: string
+  handle: number
+  attribId: number
+  data: string
+}
+
+export interface StatusRequestedEvent {
+  requestId: string
+  handle: number
+}
+
+export interface BeginTransactionRequestedEvent {
+  requestId: string
+  handle: number
+}
+
+export interface EndTransactionRequestedEvent {
+  requestId: string
+  handle: number
+  disposition: Disposition
+}

--- a/packages/browseros-agent/packages/cdp-protocol/src/generated/domains/target.ts
+++ b/packages/browseros-agent/packages/cdp-protocol/src/generated/domains/target.ts
@@ -101,6 +101,7 @@ export interface CreateTargetParams {
   background?: boolean
   forTab?: boolean
   hidden?: boolean
+  focus?: boolean
 }
 
 export interface CreateTargetResult {

--- a/packages/browseros-agent/packages/cdp-protocol/src/generated/protocol-api.ts
+++ b/packages/browseros-agent/packages/cdp-protocol/src/generated/protocol-api.ts
@@ -48,6 +48,7 @@ import type { RuntimeApi } from './domain-apis/runtime'
 import type { SchemaApi } from './domain-apis/schema'
 import type { SecurityApi } from './domain-apis/security'
 import type { ServiceWorkerApi } from './domain-apis/service-worker'
+import type { SmartCardEmulationApi } from './domain-apis/smart-card-emulation'
 import type { StorageApi } from './domain-apis/storage'
 import type { SystemInfoApi } from './domain-apis/system-info'
 import type { TargetApi } from './domain-apis/target'
@@ -99,6 +100,7 @@ export interface ProtocolApi {
   readonly Preload: PreloadApi
   readonly Security: SecurityApi
   readonly ServiceWorker: ServiceWorkerApi
+  readonly SmartCardEmulation: SmartCardEmulationApi
   readonly Storage: StorageApi
   readonly SystemInfo: SystemInfoApi
   readonly Target: TargetApi


### PR DESCRIPTION
## Summary
- regenerate CDP protocol bindings from Chromium's generated protocol.json
- add the missing SmartCardEmulation generated domain/API files referenced by the updated exports
- document the regeneration workflow and add a root .env.example for CDP_PROTOCOL_JSON

## Verification
- bun run --filter @browseros/cdp-protocol typecheck
- bunx biome check (exits 0; reports existing warnings outside this CDP change)