### PR TITLE
fix: remove unsupported CDP window visibility tool

### DIFF
--- a/packages/browseros-agent/apps/server/src/browser/browser.ts
+++ b/packages/browseros-agent/apps/server/src/browser/browser.ts
@@ -1459,14 +1459,6 @@ export class Browser {
     await this.cdp.Browser.activateWindow({ windowId })
   }
 
-  async showWindow(windowId: number): Promise<void> {
-    await this.cdp.Browser.showWindow({ windowId })
-  }
-
-  async hideWindow(windowId: number): Promise<void> {
-    await this.cdp.Browser.hideWindow({ windowId })
-  }
-
   async showPage(
     page: number,
     opts?: { windowId?: number; index?: number; activate?: boolean },

--- a/packages/browseros-agent/apps/server/src/tools/registry.ts
+++ b/packages/browseros-agent/apps/server/src/tools/registry.ts
@@ -70,7 +70,6 @@ import {
   create_hidden_window,
   create_window,
   list_windows,
-  set_window_visibility,
 } from './windows'
 
 export const registry = createRegistry([
@@ -120,13 +119,12 @@ export const registry = createRegistry([
   save_screenshot,
   download_file,
 
-  // Windows (6)
+  // Windows (5)
   list_windows,
   create_window,
   create_hidden_window,
   close_window,
   activate_window,
-  set_window_visibility,
 
   // Bookmarks (6)
   get_bookmarks,

--- a/packages/browseros-agent/apps/server/src/tools/windows.ts
+++ b/packages/browseros-agent/apps/server/src/tools/windows.ts
@@ -126,37 +126,3 @@ export const activate_window = defineManagementTool({
     response.data({ action: 'activate_window', windowId: args.windowId })
   },
 })
-
-export const set_window_visibility = defineManagementTool({
-  name: 'set_window_visibility',
-  description:
-    'Show or hide an existing browser window. ' +
-    'Pass visible=true to make a hidden window visible, ' +
-    'visible=false to hide a visible one. Idempotent — calling with ' +
-    'the current state is a no-op. The windowId is stable across the ' +
-    'toggle; tabs are preserved.',
-  input: z.object({
-    windowId: z.number().describe('Window ID'),
-    visible: z.boolean().describe('Target visibility'),
-  }),
-  output: z.object({
-    action: z.literal('set_window_visibility'),
-    windowId: z.number(),
-    visible: z.boolean(),
-  }),
-  handler: async (args, ctx, response) => {
-    if (args.visible) {
-      await ctx.browser.showWindow(args.windowId)
-    } else {
-      await ctx.browser.hideWindow(args.windowId)
-    }
-    response.text(
-      `Window ${args.windowId} is now ${args.visible ? 'visible' : 'hidden'}`,
-    )
-    response.data({
-      action: 'set_window_visibility',
-      windowId: args.windowId,
-      visible: args.visible,
-    })
-  },
-})

--- a/packages/browseros-agent/apps/server/tests/agent/tool-approval.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/tool-approval.test.ts
@@ -30,4 +30,8 @@ describe('tool approval enforcement', () => {
 
     assert.deepStrictEqual(approvedToolNames.sort(), registry.names().sort())
   })
+
+  it('does not expose unsupported window visibility tools', () => {
+    assert.ok(!registry.names().includes('set_window_visibility'))
+  })
 })


### PR DESCRIPTION
## Summary

- Removes the `set_window_visibility` MCP tool because the refreshed CDP Browser bindings no longer expose `showWindow` or `hideWindow`.
- Drops the dead `Browser.showWindow` / `Browser.hideWindow` facade methods while preserving supported window and hidden-page tools.
- Adds registry coverage to prevent re-exposing the unsupported visibility tool.

## Design

The tool registry should only advertise actions backed by the current generated CDP API. This change removes the unsupported window visibility toggle path instead of bypassing the generated bindings or returning runtime unsupported errors. Hidden window creation and hidden-page workflows remain intact because `CreateWindowParams.hidden` is still supported.

## Test plan

- `cd apps/server && bun --env-file=.env.development test --preload=./tests/__helpers__/test-env.ts ./tests/agent/tool-approval.test.ts`
- `cd apps/server && bun run typecheck`
- `bunx biome check apps/server/src/tools/registry.ts apps/server/src/tools/windows.ts apps/server/src/browser/browser.ts apps/server/tests/agent/tool-approval.test.ts`
- `bun run typecheck`
