### PR TITLE
docs(readme): add founder Twitter follow badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,14 @@
 <a href="https://cdn.browseros.com/download/BrowserOS.deb">
   <img src="https://img.shields.io/badge/Download-Debian-D70A53?style=flat&logo=debian&logoColor=white" alt="Download Debian package" />
 </a>
-<br />
+<br /><br />
+
+Built by [@ThatNithin](https://x.com/intent/user?screen_name=ThatNithin) and [@nv_sonti](https://x.com/intent/user?screen_name=nv_sonti) — follow along:
+
+[![Twitter Follow](https://img.shields.io/twitter/follow/ThatNithin?style=social)](https://x.com/intent/user?screen_name=ThatNithin)
+&emsp;&emsp;&emsp;
+[![Twitter Follow](https://img.shields.io/twitter/follow/nv_sonti?style=social)](https://x.com/intent/user?screen_name=nv_sonti)
+
 </div>
 
 BrowserOS is an open-source Chromium fork that runs AI agents natively. **The privacy-first alternative to ChatGPT Atlas, Perplexity Comet, and Dia.**


### PR DESCRIPTION
## Summary
- Add Twitter follow badges for founders @ThatNithin and @nv_sonti in the centered header section of the README, right below the download badges.

## Test plan
- [x] README renders correctly on GitHub
- [x] Links resolve to the correct Twitter/X profiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)