### PR TITLE
feat: add window visibility change

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/devtools/inspector_protocol_config.json
+++ b/packages/browseros/chromium_patches/chrome/browser/devtools/inspector_protocol_config.json
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/devtools/inspector_protocol_config.json b/chrome/browser/devtools/inspector_protocol_config.json
-index df7ff4a10c045..a631474f81c5d 100644
+index 84e36364a0850..6b2e552a0a055 100644
 --- a/chrome/browser/devtools/inspector_protocol_config.json
 +++ b/chrome/browser/devtools/inspector_protocol_config.json
 @@ -14,9 +14,20 @@
@@ -7,7 +7,7 @@ index df7ff4a10c045..a631474f81c5d 100644
              {
                  "domain": "Browser",
 -                "include": [ "getWindowForTarget", "getWindowBounds", "setWindowBounds", "setContentsSize", "close", "setDockTile", "executeBrowserCommand", "addPrivacySandboxEnrollmentOverride" ],
-+                "include": [ "getWindowForTarget", "getTabForTarget", "getTargetForTab", "getWindowBounds", "setWindowBounds", "setContentsSize", "close", "setDockTile", "executeBrowserCommand", "addPrivacySandboxEnrollmentOverride", "getWindows", "getActiveWindow", "createWindow", "closeWindow", "activateWindow", "showWindow", "hideWindow", "getTabs", "getActiveTab", "getTabInfo", "createTab", "closeTab", "activateTab", "moveTab", "duplicateTab", "pinTab", "unpinTab", "showTab", "hideTab", "getTabGroups", "createTabGroup", "updateTabGroup", "closeTabGroup", "addTabsToGroup", "removeTabsFromGroup", "moveTabGroup" ],
++                "include": [ "getWindowForTarget", "getTabForTarget", "getTargetForTab", "getWindowBounds", "setWindowBounds", "setContentsSize", "close", "setDockTile", "executeBrowserCommand", "addPrivacySandboxEnrollmentOverride", "getWindows", "getActiveWindow", "createWindow", "closeWindow", "activateWindow", "setWindowVisibility", "getTabs", "getActiveTab", "getTabInfo", "createTab", "closeTab", "activateTab", "moveTab", "duplicateTab", "pinTab", "unpinTab", "showTab", "getTabGroups", "createTabGroup", "updateTabGroup", "closeTabGroup", "addTabsToGroup", "removeTabsFromGroup", "moveTabGroup" ],
                  "include_events": []
              },
 +            {

--- a/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler.cc
@@ -229,7 +229,7 @@ index 30bd52d09c3fc..5ef348c475174 100644
 +                                    bool hidden,
 +                                    bool activate) {
 +  if (hidden) {
-+    window->Show();
++    window->ShowInactive();
 +    return;
 +  }
 +  if (activate) {

--- a/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler.cc
@@ -1,8 +1,14 @@
 diff --git a/chrome/browser/devtools/protocol/browser_handler.cc b/chrome/browser/devtools/protocol/browser_handler.cc
-index 30bd52d09c3fc..66746cef3fe0e 100644
+index 30bd52d09c3fc..1515fd382c2b7 100644
 --- a/chrome/browser/devtools/protocol/browser_handler.cc
 +++ b/chrome/browser/devtools/protocol/browser_handler.cc
-@@ -8,19 +8,32 @@
+@@ -4,23 +4,38 @@
+ 
+ #include "chrome/browser/devtools/protocol/browser_handler.h"
+ 
++#include <numeric>
+ #include <set>
++#include <variant>
  #include <vector>
  
  #include "base/functional/bind.h"
@@ -35,7 +41,7 @@ index 30bd52d09c3fc..66746cef3fe0e 100644
  #include "content/public/browser/browser_task_traits.h"
  #include "content/public/browser/browser_thread.h"
  #include "content/public/browser/devtools_agent_host.h"
-@@ -30,10 +43,32 @@
+@@ -30,10 +45,32 @@
  #include "ui/gfx/image/image.h"
  #include "ui/gfx/image/image_png_rep.h"
  
@@ -68,7 +74,7 @@ index 30bd52d09c3fc..66746cef3fe0e 100644
  BrowserWindow* GetBrowserWindow(int window_id) {
    BrowserWindow* result = nullptr;
    ForEachCurrentBrowserWindowInterfaceOrderedByActivation(
-@@ -72,12 +107,394 @@ std::unique_ptr<protocol::Browser::Bounds> GetBrowserWindowBounds(
+@@ -72,12 +109,461 @@ std::unique_ptr<protocol::Browser::Bounds> GetBrowserWindowBounds(
        .Build();
  }
  
@@ -210,6 +216,73 @@ index 30bd52d09c3fc..66746cef3fe0e 100644
 +  }
 +
 +  return info;
++}
++
++std::vector<int> GetAllTabIndices(TabStripModel* tab_strip) {
++  std::vector<int> indices(tab_strip->count());
++  std::iota(indices.begin(), indices.end(), 0);
++  return indices;
++}
++
++void ShowBrowserWindowForVisibility(BrowserWindow* window,
++                                    bool hidden,
++                                    bool activate) {
++  if (hidden) {
++    window->Show();
++    return;
++  }
++  if (activate) {
++    window->Show();
++    window->Activate();
++    return;
++  }
++  window->ShowInactive();
++}
++
++// Moves every tab and tab collection from one Browser to another while
++// preserving tab strip structure that would be lost by raw WebContents moves.
++void MoveAllTabsToReplacementWindow(Browser* source, Browser* target) {
++  TabStripModel* source_model = source->tab_strip_model();
++  TabStripModel* target_model = target->tab_strip_model();
++  std::vector<int> tab_indices = GetAllTabIndices(source_model);
++  if (tab_indices.empty()) {
++    return;
++  }
++
++  const tabs::TabInterface* active_tab = source_model->GetActiveTab();
++  for (auto& tab_or_collection :
++       source_model->DetachTabsAndCollectionsForInsertion(tab_indices)) {
++    if (auto tab =
++            std::get_if<std::unique_ptr<DetachedTab>>(&tab_or_collection)) {
++      const bool active = active_tab == tab->get()->tab.get();
++      const bool pinned = tab->get()->was_pinned_at_time_of_removal;
++      const int add_types = (active ? AddTabTypes::ADD_ACTIVE : 0) |
++                            (pinned ? AddTabTypes::ADD_PINNED : 0);
++      target_model->InsertDetachedTabAt(target_model->count(),
++                                        std::move(tab->get()->tab), add_types);
++      continue;
++    }
++
++    auto collection =
++        std::get_if<std::unique_ptr<DetachedTabCollection>>(&tab_or_collection);
++    if (std::holds_alternative<std::unique_ptr<tabs::TabGroupTabCollection>>(
++            collection->get()->collection_)) {
++      target_model->InsertDetachedTabGroupAt(std::move(*collection),
++                                             target_model->count());
++    } else {
++      const bool pinned = collection->get()->pinned_;
++      target_model->InsertDetachedSplitTabAt(
++          std::move(*collection),
++          pinned ? target_model->IndexOfFirstNonPinnedTab()
++                 : target_model->count(),
++          pinned);
++    }
++  }
++}
++
++gfx::Rect GetReplacementInitialBounds(ui::BaseWindow* window) {
++  return window->IsMinimized() ? window->GetRestoredBounds()
++                               : window->GetBounds();
 +}
 +
 +struct TabLookupResult {
@@ -464,7 +537,7 @@ index 30bd52d09c3fc..66746cef3fe0e 100644
    if (dispatcher)
      protocol::Browser::Dispatcher::wire(dispatcher, this);
  }
-@@ -120,6 +537,65 @@ Response BrowserHandler::GetWindowForTarget(
+@@ -120,6 +606,65 @@ Response BrowserHandler::GetWindowForTarget(
    return Response::Success();
  }
  
@@ -530,7 +603,7 @@ index 30bd52d09c3fc..66746cef3fe0e 100644
  Response BrowserHandler::GetWindowBounds(
      int window_id,
      std::unique_ptr<protocol::Browser::Bounds>* out_bounds) {
-@@ -297,3 +773,749 @@ protocol::Response BrowserHandler::AddPrivacySandboxEnrollmentOverride(
+@@ -297,3 +842,808 @@ protocol::Response BrowserHandler::AddPrivacySandboxEnrollmentOverride(
        net::SchemefulSite(url_to_add));
    return Response::Success();
  }
@@ -634,6 +707,64 @@ index 30bd52d09c3fc..66746cef3fe0e 100644
 +    return Response::ServerError("Browser window not found");
 +  }
 +  bwi->GetWindow()->Activate();
++  return Response::Success();
++}
++
++Response BrowserHandler::SetWindowVisibility(
++    int window_id,
++    bool visible,
++    std::optional<bool> activate,
++    std::unique_ptr<protocol::Browser::WindowInfo>* out_window,
++    bool* out_replaced,
++    int* out_previous_window_id) {
++  BrowserWindowInterface* source_bwi = GetBrowserWindowInterface(window_id);
++  if (!source_bwi) {
++    return Response::ServerError("Browser window not found");
++  }
++
++  const bool target_hidden = !visible;
++  Browser* source_browser = source_bwi->GetBrowserForMigrationOnly();
++  const bool source_hidden = source_browser->is_hidden();
++  *out_previous_window_id = window_id;
++
++  if (source_hidden == target_hidden) {
++    if (visible && activate.value_or(false)) {
++      source_bwi->GetWindow()->Activate();
++    }
++    *out_replaced = false;
++    *out_window = BuildWindowInfo(source_bwi, source_hidden);
++    return Response::Success();
++  }
++
++  if (target_hidden && !HiddenWindowsSupportedOnThisPlatform()) {
++    return Response::ServerError(
++        "Hidden windows are not yet supported on this platform. "
++        "Use X11 (XDG_SESSION_TYPE=x11), macOS, or Windows.");
++  }
++
++  Browser::CreateParams params(source_bwi->GetType(), source_bwi->GetProfile(),
++                               true);
++  params.hidden = target_hidden;
++  params.initial_bounds = GetReplacementInitialBounds(source_bwi->GetWindow());
++
++  Browser* replacement_browser = Browser::Create(params);
++  BrowserWindowInterface* replacement_bwi =
++      GetBrowserWindowInterface(replacement_browser->session_id().id());
++  if (!replacement_bwi) {
++    return Response::ServerError("Failed to create replacement window");
++  }
++
++  base::WeakPtr<Browser> source_weak = source_browser->AsWeakPtr();
++  MoveAllTabsToReplacementWindow(source_browser, replacement_browser);
++  if (source_weak) {
++    source_weak->window()->Close();
++  }
++
++  ShowBrowserWindowForVisibility(replacement_browser->window(), target_hidden,
++                                 activate.value_or(false));
++
++  *out_replaced = true;
++  *out_window = BuildWindowInfo(replacement_bwi, target_hidden);
 +  return Response::Success();
 +}
 +
@@ -776,7 +907,9 @@ index 30bd52d09c3fc..66746cef3fe0e 100644
 +    new_index = tab_strip->SetTabPinned(new_index, true);
 +  }
 +
-+  *out_tab = BuildTabInfo(new_wc, bwi, new_index, false);
++  *out_tab =
++      BuildTabInfo(new_wc, bwi, new_index,
++                   bwi->GetBrowserForMigrationOnly()->is_hidden());
 +  return Response::Success();
 +}
 +
@@ -1279,4 +1412,3 @@ index 30bd52d09c3fc..66746cef3fe0e 100644
 +  *out_group = BuildTabGroupInfo(target_bwi, new_gid);
 +  return Response::Success();
 +}
-+

--- a/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler.cc
@@ -1,8 +1,8 @@
 diff --git a/chrome/browser/devtools/protocol/browser_handler.cc b/chrome/browser/devtools/protocol/browser_handler.cc
-index 30bd52d09c3fc..1515fd382c2b7 100644
+index 30bd52d09c3fc..5ef348c475174 100644
 --- a/chrome/browser/devtools/protocol/browser_handler.cc
 +++ b/chrome/browser/devtools/protocol/browser_handler.cc
-@@ -4,23 +4,38 @@
+@@ -4,23 +4,39 @@
  
  #include "chrome/browser/devtools/protocol/browser_handler.h"
  
@@ -11,6 +11,7 @@ index 30bd52d09c3fc..1515fd382c2b7 100644
 +#include <variant>
  #include <vector>
  
++#include "base/check.h"
  #include "base/functional/bind.h"
 +#include "base/memory/raw_ptr.h"
  #include "base/memory/ref_counted_memory.h"
@@ -41,7 +42,7 @@ index 30bd52d09c3fc..1515fd382c2b7 100644
  #include "content/public/browser/browser_task_traits.h"
  #include "content/public/browser/browser_thread.h"
  #include "content/public/browser/devtools_agent_host.h"
-@@ -30,10 +45,32 @@
+@@ -30,10 +46,32 @@
  #include "ui/gfx/image/image.h"
  #include "ui/gfx/image/image_png_rep.h"
  
@@ -74,7 +75,7 @@ index 30bd52d09c3fc..1515fd382c2b7 100644
  BrowserWindow* GetBrowserWindow(int window_id) {
    BrowserWindow* result = nullptr;
    ForEachCurrentBrowserWindowInterfaceOrderedByActivation(
-@@ -72,12 +109,461 @@ std::unique_ptr<protocol::Browser::Bounds> GetBrowserWindowBounds(
+@@ -72,12 +110,468 @@ std::unique_ptr<protocol::Browser::Bounds> GetBrowserWindowBounds(
        .Build();
  }
  
@@ -265,6 +266,7 @@ index 30bd52d09c3fc..1515fd382c2b7 100644
 +
 +    auto collection =
 +        std::get_if<std::unique_ptr<DetachedTabCollection>>(&tab_or_collection);
++    CHECK(collection);
 +    if (std::holds_alternative<std::unique_ptr<tabs::TabGroupTabCollection>>(
 +            collection->get()->collection_)) {
 +      target_model->InsertDetachedTabGroupAt(std::move(*collection),
@@ -277,6 +279,12 @@ index 30bd52d09c3fc..1515fd382c2b7 100644
 +                 : target_model->count(),
 +          pinned);
 +    }
++  }
++
++  const int active_index = target_model->GetIndexOfTab(active_tab);
++  if (target_model->ContainsIndex(active_index) &&
++      target_model->GetActiveTab() != active_tab) {
++    target_model->ActivateTabAt(active_index);
 +  }
 +}
 +
@@ -537,7 +545,7 @@ index 30bd52d09c3fc..1515fd382c2b7 100644
    if (dispatcher)
      protocol::Browser::Dispatcher::wire(dispatcher, this);
  }
-@@ -120,6 +606,65 @@ Response BrowserHandler::GetWindowForTarget(
+@@ -120,6 +614,65 @@ Response BrowserHandler::GetWindowForTarget(
    return Response::Success();
  }
  
@@ -603,7 +611,7 @@ index 30bd52d09c3fc..1515fd382c2b7 100644
  Response BrowserHandler::GetWindowBounds(
      int window_id,
      std::unique_ptr<protocol::Browser::Bounds>* out_bounds) {
-@@ -297,3 +842,808 @@ protocol::Response BrowserHandler::AddPrivacySandboxEnrollmentOverride(
+@@ -297,3 +850,810 @@ protocol::Response BrowserHandler::AddPrivacySandboxEnrollmentOverride(
        net::SchemefulSite(url_to_add));
    return Response::Success();
  }
@@ -751,6 +759,7 @@ index 30bd52d09c3fc..1515fd382c2b7 100644
 +  BrowserWindowInterface* replacement_bwi =
 +      GetBrowserWindowInterface(replacement_browser->session_id().id());
 +  if (!replacement_bwi) {
++    replacement_browser->window()->Close();
 +    return Response::ServerError("Failed to create replacement window");
 +  }
 +
@@ -843,7 +852,8 @@ index 30bd52d09c3fc..1515fd382c2b7 100644
 +    content::WebContents* active_wc = tab_strip->GetActiveWebContents();
 +    if (active_wc) {
 +      int index = tab_strip->GetIndexOfWebContents(active_wc);
-+      *out_tab = BuildTabInfo(active_wc, bwi, index, false);
++      const bool is_hidden = bwi->GetBrowserForMigrationOnly()->is_hidden();
++      *out_tab = BuildTabInfo(active_wc, bwi, index, is_hidden);
 +    }
 +  }
 +  return Response::Success();

--- a/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler.h
+++ b/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler.h
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/devtools/protocol/browser_handler.h b/chrome/browser/devtools/protocol/browser_handler.h
-index e1424aa52cbf6..412380c066d63 100644
+index e1424aa52cbf6..aa49d245cc034 100644
 --- a/chrome/browser/devtools/protocol/browser_handler.h
 +++ b/chrome/browser/devtools/protocol/browser_handler.h
 @@ -5,9 +5,17 @@
@@ -35,7 +35,7 @@ index e1424aa52cbf6..412380c066d63 100644
    protocol::Response GetWindowBounds(
        int window_id,
        std::unique_ptr<protocol::Browser::Bounds>* out_bounds) override;
-@@ -41,6 +57,101 @@ class BrowserHandler : public protocol::Browser::Backend {
+@@ -41,6 +57,108 @@ class BrowserHandler : public protocol::Browser::Backend {
    protocol::Response AddPrivacySandboxEnrollmentOverride(
        const std::string& in_url) override;
  
@@ -54,6 +54,13 @@ index e1424aa52cbf6..412380c066d63 100644
 +      std::unique_ptr<protocol::Browser::WindowInfo>* out_window) override;
 +  protocol::Response CloseWindow(int window_id) override;
 +  protocol::Response ActivateWindow(int window_id) override;
++  protocol::Response SetWindowVisibility(
++      int window_id,
++      bool visible,
++      std::optional<bool> activate,
++      std::unique_ptr<protocol::Browser::WindowInfo>* out_window,
++      bool* out_replaced,
++      int* out_previous_window_id) override;
 +
 +  // Tab management
 +  protocol::Response GetTabs(

--- a/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler_android.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler_android.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/devtools/protocol/browser_handler_android.cc b/chrome/browser/devtools/protocol/browser_handler_android.cc
-index 82199c6e2e93b..628cc138aa267 100644
+index 82199c6e2e93b..7978474dda89b 100644
 --- a/chrome/browser/devtools/protocol/browser_handler_android.cc
 +++ b/chrome/browser/devtools/protocol/browser_handler_android.cc
 @@ -11,6 +11,7 @@
@@ -70,7 +70,7 @@ index 82199c6e2e93b..628cc138aa267 100644
  Response BrowserHandlerAndroid::GetWindowBounds(
      int window_id,
      std::unique_ptr<protocol::Browser::Bounds>* out_bounds) {
-@@ -92,3 +146,184 @@ protocol::Response BrowserHandlerAndroid::AddPrivacySandboxEnrollmentOverride(
+@@ -92,3 +146,178 @@ protocol::Response BrowserHandlerAndroid::AddPrivacySandboxEnrollmentOverride(
      const std::string& in_url) {
    return Response::MethodNotFound(kNotImplemented);
  }
@@ -106,11 +106,13 @@ index 82199c6e2e93b..628cc138aa267 100644
 +  return Response::MethodNotFound(kNotImplemented);
 +}
 +
-+Response BrowserHandlerAndroid::ShowWindow(int window_id) {
-+  return Response::MethodNotFound(kNotImplemented);
-+}
-+
-+Response BrowserHandlerAndroid::HideWindow(int window_id) {
++Response BrowserHandlerAndroid::SetWindowVisibility(
++    int window_id,
++    bool visible,
++    std::optional<bool> activate,
++    std::unique_ptr<protocol::Browser::WindowInfo>* out_window,
++    bool* out_replaced,
++    int* out_previous_window_id) {
 +  return Response::MethodNotFound(kNotImplemented);
 +}
 +
@@ -142,7 +144,6 @@ index 82199c6e2e93b..628cc138aa267 100644
 +    std::optional<int> index,
 +    std::optional<bool> background,
 +    std::optional<bool> pinned,
-+    std::optional<bool> hidden,
 +    std::optional<std::string> browser_context_id,
 +    std::unique_ptr<protocol::Browser::TabInfo>* out_tab) {
 +  return Response::MethodNotFound(kNotImplemented);
@@ -196,13 +197,6 @@ index 82199c6e2e93b..628cc138aa267 100644
 +    std::optional<int> window_id,
 +    std::optional<int> index,
 +    std::optional<bool> activate,
-+    std::unique_ptr<protocol::Browser::TabInfo>* out_tab) {
-+  return Response::MethodNotFound(kNotImplemented);
-+}
-+
-+Response BrowserHandlerAndroid::HideTab(
-+    std::optional<std::string> target_id,
-+    std::optional<int> tab_id,
 +    std::unique_ptr<protocol::Browser::TabInfo>* out_tab) {
 +  return Response::MethodNotFound(kNotImplemented);
 +}

--- a/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler_android.h
+++ b/packages/browseros/chromium_patches/chrome/browser/devtools/protocol/browser_handler_android.h
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/devtools/protocol/browser_handler_android.h b/chrome/browser/devtools/protocol/browser_handler_android.h
-index a80686d439110..52b7344ac56a9 100644
+index a80686d439110..b35c043695542 100644
 --- a/chrome/browser/devtools/protocol/browser_handler_android.h
 +++ b/chrome/browser/devtools/protocol/browser_handler_android.h
 @@ -22,6 +22,14 @@ class BrowserHandlerAndroid : public protocol::Browser::Backend {
@@ -36,8 +36,13 @@ index a80686d439110..52b7344ac56a9 100644
 +      std::unique_ptr<protocol::Browser::WindowInfo>* out_window) override;
 +  protocol::Response CloseWindow(int window_id) override;
 +  protocol::Response ActivateWindow(int window_id) override;
-+  protocol::Response ShowWindow(int window_id) override;
-+  protocol::Response HideWindow(int window_id) override;
++  protocol::Response SetWindowVisibility(
++      int window_id,
++      bool visible,
++      std::optional<bool> activate,
++      std::unique_ptr<protocol::Browser::WindowInfo>* out_window,
++      bool* out_replaced,
++      int* out_previous_window_id) override;
 +
 +  // Tab management
 +  protocol::Response GetTabs(
@@ -58,7 +63,6 @@ index a80686d439110..52b7344ac56a9 100644
 +      std::optional<int> index,
 +      std::optional<bool> background,
 +      std::optional<bool> pinned,
-+      std::optional<bool> hidden,
 +      std::optional<std::string> browser_context_id,
 +      std::unique_ptr<protocol::Browser::TabInfo>* out_tab) override;
 +  protocol::Response CloseTab(std::optional<std::string> target_id,
@@ -89,10 +93,6 @@ index a80686d439110..52b7344ac56a9 100644
 +      std::optional<int> window_id,
 +      std::optional<int> index,
 +      std::optional<bool> activate,
-+      std::unique_ptr<protocol::Browser::TabInfo>* out_tab) override;
-+  protocol::Response HideTab(
-+      std::optional<std::string> target_id,
-+      std::optional<int> tab_id,
 +      std::unique_ptr<protocol::Browser::TabInfo>* out_tab) override;
 +
 +  // Tab group management

--- a/packages/browseros/chromium_patches/third_party/blink/public/devtools_protocol/domains/Browser.pdl
+++ b/packages/browseros/chromium_patches/third_party/blink/public/devtools_protocol/domains/Browser.pdl
@@ -1,5 +1,5 @@
 diff --git a/third_party/blink/public/devtools_protocol/domains/Browser.pdl b/third_party/blink/public/devtools_protocol/domains/Browser.pdl
-index 6015a94554c21..412e5b8bc22cb 100644
+index 6015a94554c21..43dd32ff0983d 100644
 --- a/third_party/blink/public/devtools_protocol/domains/Browser.pdl
 +++ b/third_party/blink/public/devtools_protocol/domains/Browser.pdl
 @@ -8,6 +8,16 @@
@@ -19,7 +19,7 @@ index 6015a94554c21..412e5b8bc22cb 100644
  
    # The state of the browser window.
    experimental type WindowState extends string
-@@ -31,6 +41,222 @@ domain Browser
+@@ -31,6 +41,224 @@ domain Browser
        # The window state. Default to normal.
        optional WindowState windowState
  
@@ -107,6 +107,8 @@ index 6015a94554c21..412e5b8bc22cb 100644
 +  experimental command getTabs
 +    parameters
 +      optional WindowID windowId
++      # Only affects all-window enumeration. When windowId is provided, tabs
++      # from that specific window are returned even if the window is hidden.
 +      optional boolean includeHidden
 +    returns
 +      array of TabInfo tabs
@@ -242,7 +244,7 @@ index 6015a94554c21..412e5b8bc22cb 100644
    experimental type PermissionType extends string
      enum
        ar
-@@ -294,6 +520,28 @@ domain Browser
+@@ -294,6 +522,28 @@ domain Browser
        # position and size are returned.
        Bounds bounds
  

--- a/packages/browseros/chromium_patches/third_party/blink/public/devtools_protocol/domains/Browser.pdl
+++ b/packages/browseros/chromium_patches/third_party/blink/public/devtools_protocol/domains/Browser.pdl
@@ -1,5 +1,5 @@
 diff --git a/third_party/blink/public/devtools_protocol/domains/Browser.pdl b/third_party/blink/public/devtools_protocol/domains/Browser.pdl
-index 6015a94554c21..0d94b009929f8 100644
+index 6015a94554c21..412e5b8bc22cb 100644
 --- a/third_party/blink/public/devtools_protocol/domains/Browser.pdl
 +++ b/third_party/blink/public/devtools_protocol/domains/Browser.pdl
 @@ -8,6 +8,16 @@
@@ -19,7 +19,7 @@ index 6015a94554c21..0d94b009929f8 100644
  
    # The state of the browser window.
    experimental type WindowState extends string
-@@ -31,6 +41,212 @@ domain Browser
+@@ -31,6 +41,222 @@ domain Browser
        # The window state. Default to normal.
        optional WindowState windowState
  
@@ -89,6 +89,16 @@ index 6015a94554c21..0d94b009929f8 100644
 +  experimental command activateWindow
 +    parameters
 +      WindowID windowId
++
++  experimental command setWindowVisibility
++    parameters
++      WindowID windowId
++      boolean visible
++      optional boolean activate
++    returns
++      WindowInfo window
++      boolean replaced
++      WindowID previousWindowId
 +
 +  # --- Tab Management ---
 +  # Commands that operate on a single tab accept both targetId and tabId.
@@ -232,7 +242,7 @@ index 6015a94554c21..0d94b009929f8 100644
    experimental type PermissionType extends string
      enum
        ar
-@@ -294,6 +510,28 @@ domain Browser
+@@ -294,6 +520,28 @@ domain Browser
        # position and size are returned.
        Bounds bounds
  


### PR DESCRIPTION
## Summary
- Add `Browser.setWindowVisibility` so CDP callers can hide or reveal an existing browser window through one unified command.
- Add Browser-domain window, tab, and tab-group management helpers used by the visibility flow, including window/tab lookup, create/close/activate/move/duplicate/pin/show operations, and tab group CRUD/move operations.
- Update protocol config, Browser.pdl, and Android stubs so the desktop and generated backend surfaces stay aligned.

## Design
Hidden state is modeled as a Browser creation parameter. Changing visibility recreates the Browser with the requested hidden mode, migrates the full tab-strip structure into the replacement window, closes the source window, and returns replacement metadata including the previous window id. The migration preserves pinned tabs, active tab selection, tab groups, and split collections. Hidden-window requests are guarded to platforms with supporting widget plumbing: macOS, Windows, and Linux X11.

## Review feedback
- Closed the replacement-browser failure-path leak.
- Added an explicit invariant check before dereferencing detached tab collections.
- Preserved active tab metadata across migration and hidden-state reporting in `getActiveTab`.
- Documented `includeHidden` behavior when `windowId` is provided.
- Avoided focus-stealing initialization for hidden replacement windows.

## Test plan
- `git diff --check`
- `autoninja -C out/Default_arm64 chrome` — blocked locally because `out/Default_arm64` does not exist in this worktree.