### PR TITLE
feat: add window visibility tool

### DIFF
--- a/packages/browseros-agent/apps/server/src/browser/browser.ts
+++ b/packages/browseros-agent/apps/server/src/browser/browser.ts
@@ -62,6 +62,12 @@ export interface WindowInfo {
   activeTabId?: number
 }
 
+export interface SetWindowVisibilityResult {
+  window: WindowInfo
+  replaced: boolean
+  previousWindowId: number
+}
+
 interface TabInfo {
   tabId: number
   targetId: string
@@ -1457,6 +1463,27 @@ export class Browser {
 
   async activateWindow(windowId: number): Promise<void> {
     await this.cdp.Browser.activateWindow({ windowId })
+  }
+
+  /**
+   * Changes a window between hidden and visible states and refreshes cached page metadata.
+   * BrowserOS may replace the underlying window, so callers must use the returned window ID.
+   */
+  async setWindowVisibility(
+    windowId: number,
+    opts: { visible: boolean; activate?: boolean },
+  ): Promise<SetWindowVisibilityResult> {
+    const result = await this.cdp.Browser.setWindowVisibility({
+      windowId,
+      visible: opts.visible,
+      ...(opts.activate !== undefined && { activate: opts.activate }),
+    })
+    await this.listPages()
+    return {
+      window: result.window as WindowInfo,
+      replaced: result.replaced,
+      previousWindowId: result.previousWindowId,
+    }
   }
 
   async showPage(

--- a/packages/browseros-agent/apps/server/src/browser/browser.ts
+++ b/packages/browseros-agent/apps/server/src/browser/browser.ts
@@ -1466,7 +1466,7 @@ export class Browser {
   }
 
   /**
-   * Changes a window between hidden and visible states and refreshes cached page metadata.
+   * Changes a window between hidden and visible states.
    * BrowserOS may replace the underlying window, so callers must use the returned window ID.
    */
   async setWindowVisibility(
@@ -1478,7 +1478,6 @@ export class Browser {
       visible: opts.visible,
       ...(opts.activate !== undefined && { activate: opts.activate }),
     })
-    await this.listPages()
     return {
       window: result.window as WindowInfo,
       replaced: result.replaced,

--- a/packages/browseros-agent/apps/server/src/tools/registry.ts
+++ b/packages/browseros-agent/apps/server/src/tools/registry.ts
@@ -70,6 +70,7 @@ import {
   create_hidden_window,
   create_window,
   list_windows,
+  set_window_visibility,
 } from './windows'
 
 export const registry = createRegistry([
@@ -119,12 +120,13 @@ export const registry = createRegistry([
   save_screenshot,
   download_file,
 
-  // Windows (5)
+  // Windows (6)
   list_windows,
   create_window,
   create_hidden_window,
   close_window,
   activate_window,
+  set_window_visibility,
 
   // Bookmarks (6)
   get_bookmarks,

--- a/packages/browseros-agent/apps/server/src/tools/windows.ts
+++ b/packages/browseros-agent/apps/server/src/tools/windows.ts
@@ -137,7 +137,9 @@ export const set_window_visibility = defineManagementTool({
     activate: z
       .boolean()
       .optional()
-      .describe('Activate (focus) the window after showing it'),
+      .describe(
+        'Activate (focus) the window after making it visible. Has no effect when visible is false.',
+      ),
   }),
   output: z.object({
     action: z.literal('set_window_visibility'),

--- a/packages/browseros-agent/apps/server/src/tools/windows.ts
+++ b/packages/browseros-agent/apps/server/src/tools/windows.ts
@@ -126,3 +126,43 @@ export const activate_window = defineManagementTool({
     response.data({ action: 'activate_window', windowId: args.windowId })
   },
 })
+
+export const set_window_visibility = defineManagementTool({
+  name: 'set_window_visibility',
+  description:
+    'Set a browser window visible or hidden. Returns the new window ID because BrowserOS may replace the window during the transition.',
+  input: z.object({
+    windowId: z.number().describe('Window ID to show or hide'),
+    visible: z.boolean().describe('Set true to show, false to hide'),
+    activate: z
+      .boolean()
+      .optional()
+      .describe('Activate (focus) the window after showing it'),
+  }),
+  output: z.object({
+    action: z.literal('set_window_visibility'),
+    previousWindowId: z.number(),
+    newWindowId: z.number(),
+    replaced: z.boolean(),
+    window: windowInfoSchema,
+  }),
+  handler: async (args, ctx, response) => {
+    const result = await ctx.browser.setWindowVisibility(args.windowId, {
+      visible: args.visible,
+      activate: args.activate,
+    })
+    const newWindowId = result.window.windowId
+    const state = result.window.isVisible ? 'visible' : 'hidden'
+    response.text(
+      `Set window ${args.windowId} ${state}. New window ID: ${newWindowId}`,
+    )
+    response.data({
+      action: 'set_window_visibility',
+      previousWindowId: result.previousWindowId,
+      newWindowId,
+      replaced: result.replaced,
+      window: result.window,
+    })
+    response.includePages()
+  },
+})

--- a/packages/browseros-agent/apps/server/tests/agent/tool-approval.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/tool-approval.test.ts
@@ -31,7 +31,7 @@ describe('tool approval enforcement', () => {
     assert.deepStrictEqual(approvedToolNames.sort(), registry.names().sort())
   })
 
-  it('exposes window visibility as browser management', () => {
+  it('exposes window visibility as data-modification', () => {
     const tool = registry.get('set_window_visibility')
 
     assert.ok(tool, 'Expected set_window_visibility to be registered')

--- a/packages/browseros-agent/apps/server/tests/agent/tool-approval.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/tool-approval.test.ts
@@ -31,7 +31,10 @@ describe('tool approval enforcement', () => {
     assert.deepStrictEqual(approvedToolNames.sort(), registry.names().sort())
   })
 
-  it('does not expose unsupported window visibility tools', () => {
-    assert.ok(!registry.names().includes('set_window_visibility'))
+  it('exposes window visibility as browser management', () => {
+    const tool = registry.get('set_window_visibility')
+
+    assert.ok(tool, 'Expected set_window_visibility to be registered')
+    assert.strictEqual(tool.approvalCategory, 'data-modification')
   })
 })

--- a/packages/browseros-agent/apps/server/tests/tools/windows.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/windows.test.ts
@@ -1,11 +1,14 @@
 import { describe, it } from 'bun:test'
 import assert from 'node:assert'
+import type { Browser } from '../../src/browser/browser'
+import { executeTool } from '../../src/tools/framework'
 import {
   activate_window,
   close_window,
   create_hidden_window,
   create_window,
   list_windows,
+  set_window_visibility,
 } from '../../src/tools/windows'
 import { withBrowser } from '../__helpers__/with-browser'
 
@@ -21,6 +24,19 @@ function textOf(result: {
 function structuredOf<T>(result: { structuredContent?: unknown }): T {
   assert.ok(result.structuredContent, 'Expected structuredContent')
   return result.structuredContent as T
+}
+
+function fakeWindow(
+  overrides: Partial<{ windowId: number; isVisible: boolean }>,
+) {
+  return {
+    windowId: overrides.windowId ?? 1,
+    windowType: 'normal' as const,
+    bounds: {},
+    isActive: false,
+    isVisible: overrides.isVisible ?? true,
+    tabCount: 0,
+  }
 }
 
 describe('window tools', () => {
@@ -105,4 +121,52 @@ describe('window tools', () => {
       assert.ok(!closeResult.isError, textOf(closeResult))
     })
   }, 60_000)
+
+  it('set_window_visibility returns replacement metadata and the new window ID', async () => {
+    const calls: Array<{
+      windowId: number
+      opts: { visible: boolean; activate?: boolean }
+    }> = []
+    const browser = {
+      setWindowVisibility: async (
+        windowId: number,
+        opts: { visible: boolean; activate?: boolean },
+      ) => {
+        calls.push({ windowId, opts })
+        return {
+          previousWindowId: windowId,
+          replaced: true,
+          window: fakeWindow({ windowId: 42, isVisible: true }),
+        }
+      },
+      listPages: async () => [],
+    } as unknown as Browser
+
+    const result = await executeTool(
+      set_window_visibility,
+      { windowId: 7, visible: true, activate: false },
+      { browser, directories: { workingDir: process.cwd() } },
+      AbortSignal.timeout(30_000),
+    )
+
+    assert.ok(!result.isError, textOf(result))
+    assert.ok(textOf(result).includes('New window ID: 42'))
+    assert.deepStrictEqual(calls, [
+      { windowId: 7, opts: { visible: true, activate: false } },
+    ])
+    const data = structuredOf<{
+      action: string
+      previousWindowId: number
+      newWindowId: number
+      replaced: boolean
+      window: { windowId: number; isVisible: boolean }
+    }>(result)
+
+    assert.strictEqual(data.action, 'set_window_visibility')
+    assert.strictEqual(data.previousWindowId, 7)
+    assert.strictEqual(data.newWindowId, 42)
+    assert.strictEqual(data.newWindowId, data.window.windowId)
+    assert.strictEqual(data.replaced, true)
+    assert.strictEqual(data.window.isVisible, true)
+  })
 })

--- a/packages/browseros-agent/packages/cdp-protocol/src/generated/domain-apis/browser.ts
+++ b/packages/browseros-agent/packages/cdp-protocol/src/generated/domain-apis/browser.ts
@@ -60,6 +60,8 @@ import type {
   SetDownloadBehaviorParams,
   SetPermissionParams,
   SetWindowBoundsParams,
+  SetWindowVisibilityParams,
+  SetWindowVisibilityResult,
   ShowTabParams,
   ShowTabResult,
   UnpinTabParams,
@@ -76,6 +78,9 @@ export interface BrowserApi {
   createWindow(params?: CreateWindowParams): Promise<CreateWindowResult>
   closeWindow(params: CloseWindowParams): Promise<void>
   activateWindow(params: ActivateWindowParams): Promise<void>
+  setWindowVisibility(
+    params: SetWindowVisibilityParams,
+  ): Promise<SetWindowVisibilityResult>
   getTabs(params?: GetTabsParams): Promise<GetTabsResult>
   getActiveTab(params?: GetActiveTabParams): Promise<GetActiveTabResult>
   getTabInfo(params?: GetTabInfoParams): Promise<GetTabInfoResult>

--- a/packages/browseros-agent/packages/cdp-protocol/src/generated/domains/browser.ts
+++ b/packages/browseros-agent/packages/cdp-protocol/src/generated/domains/browser.ts
@@ -166,6 +166,18 @@ export interface ActivateWindowParams {
   windowId: WindowID
 }
 
+export interface SetWindowVisibilityParams {
+  windowId: WindowID
+  visible: boolean
+  activate?: boolean
+}
+
+export interface SetWindowVisibilityResult {
+  window: WindowInfo
+  replaced: boolean
+  previousWindowId: WindowID
+}
+
 export interface GetTabsParams {
   windowId?: WindowID
   includeHidden?: boolean


### PR DESCRIPTION
## Summary

- Adds a `set_window_visibility` browser-management tool that accepts `windowId`, `visible`, and optional `activate`.
- Wraps the new generated `Browser.setWindowVisibility` CDP command in the server Browser abstraction.
- Returns `newWindowId`, `previousWindowId`, `replaced`, and the returned window info so callers do not have to infer replacement behavior.

## Design

The implementation follows the existing window tool path: tools call `ctx.browser`, the Browser wrapper delegates to generated CDP protocol APIs, and `registry.ts` exposes the tool under Browser Management. Runtime replacement semantics are preserved from the protocol result and surfaced at the top level as `newWindowId`.

## Test plan

- `bun --env-file=.env.development test apps/server/tests/tools/windows.test.ts`
- `bun --env-file=.env.development test apps/server/tests/agent/tool-approval.test.ts`
- `bun run --filter @browseros/server typecheck`
- `bunx biome check apps/server/src/browser/browser.ts apps/server/src/tools/windows.ts apps/server/src/tools/registry.ts apps/server/tests/tools/windows.test.ts apps/server/tests/agent/tool-approval.test.ts`
- `bun run --filter @browseros/server test:all`

## Note

The current test BrowserOS binary still responds with `Browser.setWindowVisibility wasn't found`, so the new runtime behavior is covered at the tool layer with a fake Browser object until the BrowserOS binary includes the new CDP command.
