### PR TITLE
feat(split-tabs): add top-bottom split panes

### DIFF
--- a/packages/browseros/chromium_patches/chrome/app/generated_resources.grd
+++ b/packages/browseros/chromium_patches/chrome/app/generated_resources.grd
@@ -28,3 +28,29 @@ index 33c0b42d826b5..1e258157b8033 100644
          <!-- TODO(thestig) Should this be Linux only? Add #ifdefs to external_process_importer_client.cc -->
          <message name="IDS_IMPORT_FROM_ICEWEASEL" desc="browser combo box: Iceweasel">
            Iceweasel
+@@ -12234,6 +12246,12 @@ Check your passwords anytime in <ph name="GOOGLE_PASSWORD_MANAGER">$1<ex>Google
+         <message name="IDS_PIN_SPLIT_TAB_TOGGLE" desc="Pins the split tabs button to the toolbar when toggled on.">
+           Open in split view
+         </message>
++        <message name="IDS_SPLIT_TAB_CREATE_LEFT_RIGHT" desc="The label for a toolbar button context menu item that creates a left/right split view.">
++          Split left/right
++        </message>
++        <message name="IDS_SPLIT_TAB_CREATE_TOP_BOTTOM" desc="The label for a toolbar button context menu item that creates a top/bottom split view.">
++          Split top/bottom
++        </message>
+         <message name="IDS_SPLIT_TAB_REVERSE_VIEWS" desc="The label for a menu item that swaps the inactive split tab to the other side when clicked.">
+           Reverse views
+         </message>
+@@ -12275,6 +12293,12 @@ Check your passwords anytime in <ph name="GOOGLE_PASSWORD_MANAGER">$1<ex>Google
+         <message name="IDS_PIN_SPLIT_TAB_TOGGLE" desc="In title case: pins the split tabs button to the toolbar when toggled on.">
+           Open In Split View
+         </message>
++        <message name="IDS_SPLIT_TAB_CREATE_LEFT_RIGHT" desc="In title case: the label for a toolbar button context menu item that creates a left/right split view.">
++          Split Left/Right
++        </message>
++        <message name="IDS_SPLIT_TAB_CREATE_TOP_BOTTOM" desc="In title case: the label for a toolbar button context menu item that creates a top/bottom split view.">
++          Split Top/Bottom
++        </message>
+         <message name="IDS_SPLIT_TAB_REVERSE_VIEWS" desc="In title case: the label for a menu item that swaps the inactive split tab to the other side when clicked.">
+           Reverse Views
+         </message>

--- a/packages/browseros/chromium_patches/chrome/browser/ui/browser_commands.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/browser_commands.cc
@@ -10,6 +10,27 @@ index cd7f650386e23..3ad70515264a1 100644
  #include "chrome/common/chrome_features.h"
  #include "chrome/common/content_restriction.h"
  #include "chrome/common/pref_names.h"
+@@ -1479,7 +1480,8 @@ void GroupTab(BrowserWindowInterface* browser) {
+ }
+ 
+ void NewSplitTab(BrowserWindowInterface* browser,
+-                 split_tabs::SplitTabCreatedSource source) {
++                 split_tabs::SplitTabCreatedSource source,
++                 split_tabs::SplitTabLayout layout) {
+   TabStripModel* const tab_strip_model = browser->GetTabStripModel();
+   const int active_index = tab_strip_model->active_index();
+   // In Incognito mode, we can't show the regular Split View NTP so default to
+@@ -1491,8 +1493,8 @@ void NewSplitTab(BrowserWindowInterface* browser,
+       GURL(new_tab_url), active_index + 1, true,
+       tab_strip_model->GetTabGroupForTab(active_index),
+       tab_strip_model->IsTabPinned(active_index));
+-  tab_strip_model->AddToNewSplit({active_index},
+-                                 split_tabs::SplitTabVisualData(), source);
++  split_tabs::SplitTabVisualData visual_data(layout);
++  tab_strip_model->AddToNewSplit({active_index}, visual_data, source);
+ }
+ 
+ void AddNewTabToGroup(BrowserWindowInterface* browser) {
 @@ -2528,7 +2529,20 @@ bool IsDebuggerAttachedToCurrentTab(BrowserWindowInterface* browser) {
  void CopyURL(BrowserWindowInterface* browser,
               content::WebContents* web_contents) {

--- a/packages/browseros/chromium_patches/chrome/browser/ui/browser_commands.h
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/browser_commands.h
@@ -1,0 +1,25 @@
+diff --git a/chrome/browser/ui/browser_commands.h b/chrome/browser/ui/browser_commands.h
+index 9a4b59415da4d..32e2bd6d3b645 100644
+--- a/chrome/browser/ui/browser_commands.h
++++ b/chrome/browser/ui/browser_commands.h
+@@ -20,6 +20,7 @@
+ #include "chrome/browser/ui/tabs/tab_strip_model_delegate.h"
+ #include "chrome/browser/ui/tabs/tab_strip_user_gesture_details.h"
+ #include "components/split_tabs/split_tab_id.h"
++#include "components/split_tabs/split_tab_visual_data.h"
+ #include "content/public/common/page_zoom.h"
+ #include "printing/buildflags/buildflags.h"
+ #include "ui/base/window_open_disposition.h"
+@@ -169,8 +170,10 @@ void MoveGroupToExistingWindow(BrowserWindowInterface* source,
+ void MuteSite(BrowserWindowInterface* browser);
+ void PinTab(BrowserWindowInterface* browser);
+ void GroupTab(BrowserWindowInterface* browser);
+-void NewSplitTab(BrowserWindowInterface* browser,
+-                 split_tabs::SplitTabCreatedSource source);
++void NewSplitTab(
++    BrowserWindowInterface* browser,
++    split_tabs::SplitTabCreatedSource source,
++    split_tabs::SplitTabLayout layout = split_tabs::SplitTabLayout::kVertical);
+ 
+ // Tab group commands
+ // These values are persisted to logs. Entries should not be renumbered

--- a/packages/browseros/chromium_patches/chrome/browser/ui/views/frame/browser_view.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/views/frame/browser_view.cc
@@ -1,0 +1,42 @@
+diff --git a/chrome/browser/ui/views/frame/browser_view.cc b/chrome/browser/ui/views/frame/browser_view.cc
+index a29e3f73ef39b..f274ce83a1160 100644
+--- a/chrome/browser/ui/views/frame/browser_view.cc
++++ b/chrome/browser/ui/views/frame/browser_view.cc
+@@ -3595,10 +3595,11 @@ void BrowserView::OnSplitTabChanged(const SplitTabChange& change) {
+           browser_->tab_strip_model()->GetActiveTab();
+ 
+       if (active_tab->GetSplit() == change.split_id) {
+-        if (change.GetVisualsChange()->new_visual_data().split_ratio() !=
+-            change.GetVisualsChange()->old_visual_data().split_ratio()) {
+-          multi_contents_view_->UpdateSplitRatio(
+-              change.GetVisualsChange()->new_visual_data().split_ratio());
++        if (change.GetVisualsChange()->new_visual_data() !=
++            change.GetVisualsChange()->old_visual_data()) {
++          multi_contents_view_->UpdateSplitVisualData(
++              change.GetVisualsChange()->new_visual_data().split_ratio(),
++              change.GetVisualsChange()->new_visual_data().split_layout());
+         }
+       }
+       break;
+@@ -4437,8 +4438,9 @@ void BrowserView::ShowSplitView(bool focus_active_view) {
+   const int relative_active_position = active_index - first_split_tab_index;
+   multi_contents_view_->SetActiveIndex(relative_active_position);
+ 
+-  multi_contents_view_->UpdateSplitRatio(
+-      split_data->visual_data()->split_ratio());
++  multi_contents_view_->UpdateSplitVisualData(
++      split_data->visual_data()->split_ratio(),
++      split_data->visual_data()->split_layout());
+ 
+   // Set focus to the active contents avoid reentrency when setting the web
+   // contents within MultiContentsView. See crbug.com/458189541 and
+@@ -5503,7 +5505,8 @@ bool BrowserView::MaybeUpdateSplitView(content::WebContents* contents) {
+     split_tabs::SplitTabData* split_data =
+         browser_->tab_strip_model()->GetSplitData(new_tab->GetSplit().value());
+     multi_contents_view_->ShowSplitView(
+-        split_data->visual_data()->split_ratio());
++        split_data->visual_data()->split_ratio(),
++        split_data->visual_data()->split_layout());
+   } else if (current_state != updated_state) {
+     multi_contents_view_->CloseSplitView();
+   } else {

--- a/packages/browseros/chromium_patches/chrome/browser/ui/views/frame/multi_contents_resize_area.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/views/frame/multi_contents_resize_area.cc
@@ -1,0 +1,198 @@
+diff --git a/chrome/browser/ui/views/frame/multi_contents_resize_area.cc b/chrome/browser/ui/views/frame/multi_contents_resize_area.cc
+index 72347969217f6..d7cf9d21f61ac 100644
+--- a/chrome/browser/ui/views/frame/multi_contents_resize_area.cc
++++ b/chrome/browser/ui/views/frame/multi_contents_resize_area.cc
+@@ -11,11 +11,13 @@
+ #include "chrome/browser/ui/views/frame/multi_contents_view.h"
+ #include "chrome/grit/generated_resources.h"
+ #include "ui/accessibility/mojom/ax_node_data.mojom.h"
++#include "ui/base/cursor/cursor.h"
+ #include "ui/base/l10n/l10n_util.h"
+ #include "ui/base/metadata/metadata_impl_macros.h"
+ #include "ui/color/color_provider.h"
+ #include "ui/compositor/layer.h"
+ #include "ui/compositor/layer_type.h"
++#include "ui/gfx/geometry/point.h"
+ #include "ui/gfx/geometry/size.h"
+ #include "ui/views/accessibility/view_accessibility.h"
+ #include "ui/views/background.h"
+@@ -57,6 +59,15 @@ MultiContentsResizeHandle::MultiContentsResizeHandle() {
+       kColorSidePanelHoverResizeAreaHandle, kHandleCornerRadius));
+ }
+ 
++void MultiContentsResizeHandle::SetSplitLayout(
++    split_tabs::SplitTabLayout split_layout) {
++  if (split_layout == split_tabs::SplitTabLayout::kHorizontal) {
++    SetPreferredSize(gfx::Size(kHandleHeight, kHandleWidth));
++  } else {
++    SetPreferredSize(gfx::Size(kHandleWidth, kHandleHeight));
++  }
++}
++
+ void MultiContentsResizeHandle::UpdateVisibility() {
+   layer()->SetVisible(parent()->GetVisible() &&
+                       (HasFocus() || parent()->IsMouseHovered()));
+@@ -91,31 +102,131 @@ MultiContentsResizeArea::MultiContentsResizeArea(
+   resize_handle_ = AddChildView(std::make_unique<MultiContentsResizeHandle>());
+ 
+   SetProperty(views::kElementIdentifierKey, kMultiContentsResizeAreaElementId);
+-  SetPreferredSize(gfx::Size(kHandleWidth + kHandlePadding, kHandleHeight));
++  SetSplitLayout(split_tabs::SplitTabLayout::kVertical);
++}
++
++void MultiContentsResizeArea::SetSplitLayout(
++    split_tabs::SplitTabLayout split_layout) {
++  split_layout_ = split_layout;
++  auto* layout_manager = static_cast<views::FlexLayout*>(GetLayoutManager());
++  if (IsHorizontalSplit()) {
++    layout_manager->SetOrientation(views::LayoutOrientation::kHorizontal);
++    SetPreferredSize(gfx::Size(kHandleHeight, kHandleWidth + kHandlePadding));
++  } else {
++    layout_manager->SetOrientation(views::LayoutOrientation::kVertical);
++    SetPreferredSize(gfx::Size(kHandleWidth + kHandlePadding, kHandleHeight));
++  }
++  resize_handle_->SetSplitLayout(split_layout_);
++  InvalidateLayout();
++}
++
++ui::Cursor MultiContentsResizeArea::GetCursor(const ui::MouseEvent& event) {
++  if (!GetEnabled()) {
++    return ui::Cursor();
++  }
++
++  if (IsHorizontalSplit()) {
++    return ui::Cursor(ui::mojom::CursorType::kNorthSouthResize);
++  }
++  return ResizeArea::GetCursor(event);
+ }
+ 
+ void MultiContentsResizeArea::OnGestureEvent(ui::GestureEvent* event) {
+   // If the gesture event was a double tap and was not part of a resizing event,
+   // swap the contents views.
+-  if (!is_resizing() && event->type() == ui::EventType::kGestureTap &&
++  if (!IsResizeInProgress() && event->type() == ui::EventType::kGestureTap &&
+       event->details().tap_count() == 2) {
+     multi_contents_view_->OnSwap();
+   }
++
++  if (IsHorizontalSplit()) {
++    if (event->type() == ui::EventType::kGestureTapDown) {
++      SetInitialResizePosition(event->y());
++      event->SetHandled();
++    } else if (event->type() == ui::EventType::kGestureScrollBegin ||
++               event->type() == ui::EventType::kGestureScrollUpdate) {
++      ReportResizeAmount(event->y(), false);
++      event->SetHandled();
++    } else if (event->type() == ui::EventType::kGestureEnd) {
++      if (is_resizing_horizontally_) {
++        ReportResizeAmount(event->y(), true);
++      }
++      event->SetHandled();
++    }
++    return;
++  }
++
+   ResizeArea::OnGestureEvent(event);
+ }
+ 
++bool MultiContentsResizeArea::OnMousePressed(const ui::MouseEvent& event) {
++  if (!IsHorizontalSplit()) {
++    return ResizeArea::OnMousePressed(event);
++  }
++
++  if (!event.IsOnlyLeftMouseButton()) {
++    return false;
++  }
++
++  SetInitialResizePosition(event.y());
++  return true;
++}
++
++bool MultiContentsResizeArea::OnMouseDragged(const ui::MouseEvent& event) {
++  if (!IsHorizontalSplit()) {
++    return ResizeArea::OnMouseDragged(event);
++  }
++
++  if (!event.IsLeftMouseButton()) {
++    return false;
++  }
++
++  ReportResizeAmount(event.y(), false);
++  return true;
++}
++
+ void MultiContentsResizeArea::OnMouseReleased(const ui::MouseEvent& event) {
+   // If the mouse event was a left double click and was not part of a resizing
+   // event, swap the contents views.
+-  if (!is_resizing() && event.IsOnlyLeftMouseButton() &&
++  if (!IsResizeInProgress() && event.IsOnlyLeftMouseButton() &&
+       event.GetClickCount() == 2) {
+     multi_contents_view_->OnSwap();
+   }
++
++  if (IsHorizontalSplit()) {
++    if (is_resizing_horizontally_) {
++      ReportResizeAmount(event.y(), true);
++    }
++    return;
++  }
++
+   ResizeArea::OnMouseReleased(event);
+ }
+ 
++void MultiContentsResizeArea::OnMouseCaptureLost() {
++  if (!IsHorizontalSplit()) {
++    ResizeArea::OnMouseCaptureLost();
++    return;
++  }
++
++  ReportResizeAmount(initial_resize_position_, true);
++}
++
+ bool MultiContentsResizeArea::OnKeyPressed(const ui::KeyEvent& event) {
+   int resize_amount = 0;
++  if (IsHorizontalSplit()) {
++    if (event.key_code() == ui::VKEY_UP) {
++      resize_amount = -kResizeIncrement;
++    } else if (event.key_code() == ui::VKEY_DOWN) {
++      resize_amount = kResizeIncrement;
++    } else {
++      return false;
++    }
++
++    multi_contents_view_->OnResize(resize_amount, true);
++    return true;
++  }
++
+   if (event.key_code() == ui::VKEY_LEFT) {
+     resize_amount = base::i18n::IsRTL() ? kResizeIncrement : -kResizeIncrement;
+   } else if (event.key_code() == ui::VKEY_RIGHT) {
+@@ -162,5 +273,28 @@ void MultiContentsResizeArea::SetVisible(bool visible) {
+   resize_handle_->UpdateVisibility();
+ }
+ 
++bool MultiContentsResizeArea::IsHorizontalSplit() const {
++  return split_layout_ == split_tabs::SplitTabLayout::kHorizontal;
++}
++
++bool MultiContentsResizeArea::IsResizeInProgress() {
++  return IsHorizontalSplit() ? is_resizing_horizontally_ : is_resizing();
++}
++
++void MultiContentsResizeArea::SetInitialResizePosition(int event_position) {
++  gfx::Point point(0, event_position);
++  View::ConvertPointToScreen(this, &point);
++  initial_resize_position_ = point.y();
++}
++
++void MultiContentsResizeArea::ReportResizeAmount(int resize_amount,
++                                                 bool last_update) {
++  gfx::Point point(0, resize_amount);
++  View::ConvertPointToScreen(this, &point);
++  resize_amount = point.y() - initial_resize_position_;
++  is_resizing_horizontally_ = !last_update;
++  multi_contents_view_->OnResize(resize_amount, last_update);
++}
++
+ BEGIN_METADATA(MultiContentsResizeArea)
+ END_METADATA

--- a/packages/browseros/chromium_patches/chrome/browser/ui/views/frame/multi_contents_resize_area.h
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/views/frame/multi_contents_resize_area.h
@@ -1,0 +1,53 @@
+diff --git a/chrome/browser/ui/views/frame/multi_contents_resize_area.h b/chrome/browser/ui/views/frame/multi_contents_resize_area.h
+index c34534ee850b1..1d782e658c6ed 100644
+--- a/chrome/browser/ui/views/frame/multi_contents_resize_area.h
++++ b/chrome/browser/ui/views/frame/multi_contents_resize_area.h
+@@ -6,6 +6,8 @@
+ #define CHROME_BROWSER_UI_VIEWS_FRAME_MULTI_CONTENTS_RESIZE_AREA_H_
+ 
+ #include "base/memory/raw_ptr.h"
++#include "components/split_tabs/split_tab_visual_data.h"
++#include "ui/base/cursor/cursor.h"
+ #include "ui/base/interaction/element_identifier.h"
+ #include "ui/views/controls/resize_area.h"
+ #include "ui/views/focus/focus_manager.h"
+@@ -24,6 +26,7 @@ class MultiContentsResizeHandle : public views::View,
+ 
+   MultiContentsResizeHandle();
+ 
++  void SetSplitLayout(split_tabs::SplitTabLayout split_layout);
+   void UpdateVisibility();
+ 
+   // views::View:
+@@ -44,15 +47,31 @@ class MultiContentsResizeArea : public views::ResizeArea {
+ 
+   explicit MultiContentsResizeArea(MultiContentsView* multi_contents_view);
+ 
++  void SetSplitLayout(split_tabs::SplitTabLayout split_layout);
++
+   // views::ResizeArea:
++  ui::Cursor GetCursor(const ui::MouseEvent& event) override;
+   void OnGestureEvent(ui::GestureEvent* event) override;
++  bool OnMousePressed(const ui::MouseEvent& event) override;
++  bool OnMouseDragged(const ui::MouseEvent& event) override;
+   void OnMouseReleased(const ui::MouseEvent& event) override;
++  void OnMouseCaptureLost() override;
+   bool OnKeyPressed(const ui::KeyEvent& event) override;
+   void OnMouseMoved(const ui::MouseEvent& event) override;
+   void OnMouseExited(const ui::MouseEvent& event) override;
+   void SetVisible(bool visible) override;
+ 
+  private:
++  bool IsHorizontalSplit() const;
++  bool IsResizeInProgress();
++  void SetInitialResizePosition(int event_position);
++  void ReportResizeAmount(int resize_amount, bool last_update);
++
++  split_tabs::SplitTabLayout split_layout_ =
++      split_tabs::SplitTabLayout::kVertical;
++  bool is_resizing_horizontally_ = false;
++  int initial_resize_position_ = 0;
++
+   raw_ptr<MultiContentsView> multi_contents_view_;
+   raw_ptr<MultiContentsResizeHandle> resize_handle_;
+ };

--- a/packages/browseros/chromium_patches/chrome/browser/ui/views/frame/multi_contents_view.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/views/frame/multi_contents_view.cc
@@ -1,0 +1,333 @@
+diff --git a/chrome/browser/ui/views/frame/multi_contents_view.cc b/chrome/browser/ui/views/frame/multi_contents_view.cc
+index aaec9ccc448c9..2731a0a40c00b 100644
+--- a/chrome/browser/ui/views/frame/multi_contents_view.cc
++++ b/chrome/browser/ui/views/frame/multi_contents_view.cc
+@@ -37,6 +37,7 @@
+ #include "chrome/common/pref_names.h"
+ #include "chrome/common/webui_url_constants.h"
+ #include "components/prefs/pref_service.h"
++#include "components/split_tabs/split_tab_visual_data.h"
+ #include "content/public/browser/web_contents.h"
+ #include "content/public/common/url_constants.h"
+ #include "ui/base/metadata/metadata_impl_macros.h"
+@@ -65,12 +66,7 @@ void MultiContentsView::ContentsSeparators::Reset() {
+ MultiContentsView::MultiContentsView(
+     BrowserView* browser_view,
+     std::unique_ptr<MultiContentsViewDelegate> delegate)
+-    : browser_view_(browser_view),
+-      delegate_(std::move(delegate)),
+-      start_contents_view_inset_(
+-          gfx::Insets(kSplitViewContentInset).set_top(0).set_right(0)),
+-      end_contents_view_inset_(
+-          gfx::Insets(kSplitViewContentInset).set_top(0).set_left(0)) {
++    : browser_view_(browser_view), delegate_(std::move(delegate)) {
+   SetLayoutManager(std::make_unique<views::DelegatingLayoutManager>(this));
+   SetProperty(views::kElementIdentifierKey, kMultiContentsViewElementId);
+ 
+@@ -119,6 +115,7 @@ MultiContentsView::MultiContentsView(
+           kColorToolbarContentAreaSeparator));
+   contents_separators_.corner_separator->SetProperty(
+       views::kElementIdentifierKey, kContentsSeparatorTopCornerElementId);
++  UpdateContentsViewInsets();
+ 
+   for (auto* contents_container_view : contents_container_views_) {
+     auto& view_map = container_focusable_map_[contents_container_view];
+@@ -246,20 +243,15 @@ void MultiContentsView::SetWebContentsAtIndex(
+   }
+ }
+ 
+-void MultiContentsView::ShowSplitView(double ratio) {
++void MultiContentsView::ShowSplitView(double ratio,
++                                      split_tabs::SplitTabLayout split_layout) {
++  UpdateSplitVisualData(ratio, split_layout);
+   if (!contents_container_views_[1]->GetVisible()) {
+-    // If split view is not visible, set the `start_ratio_` and update the view
+-    // visibility.
+-    start_ratio_ = ratio;
++    // If split view is not visible, update the view visibility.
+     contents_container_views_[1]->SetVisible(true);
+     resize_area_->SetVisible(true);
+     UpdateContentsBorderAndOverlay();
+-  } else if (start_ratio_ != ratio) {
+-    // If the split view is visible but ratio is changed, update the split
+-    // ratio.
+-    UpdateSplitRatio(ratio);
+   }
+-  // Split view is visible and ratio is not changed, do nothing.
+ }
+ 
+ void MultiContentsView::CloseSplitView() {
+@@ -305,11 +297,29 @@ void MultiContentsView::SetActiveIndex(int index) {
+ }
+ 
+ void MultiContentsView::UpdateSplitRatio(double ratio) {
+-  if (start_ratio_ == ratio) {
++  UpdateSplitVisualData(ratio, split_layout_);
++}
++
++void MultiContentsView::UpdateSplitVisualData(
++    double ratio,
++    split_tabs::SplitTabLayout split_layout) {
++  bool needs_layout = false;
++  if (split_layout_ != split_layout) {
++    split_layout_ = split_layout;
++    resize_area_->SetSplitLayout(split_layout_);
++    UpdateContentsViewInsets();
++    needs_layout = true;
++  }
++
++  if (start_ratio_ != ratio) {
++    start_ratio_ = ratio;
++    needs_layout = true;
++  }
++
++  if (!needs_layout) {
+     return;
+   }
+ 
+-  start_ratio_ = ratio;
+   InvalidateLayout();
+ }
+ 
+@@ -347,24 +357,36 @@ std::vector<views::View*> MultiContentsView::GetAccessiblePanes() {
+ }
+ 
+ void MultiContentsView::OnResize(int resize_amount, bool done_resizing) {
+-  if (!initial_start_width_on_resize_.has_value()) {
+-    initial_start_width_on_resize_ =
+-        std::make_optional(contents_container_views_[0]->size().width());
+-  }
+-  double total_width = contents_container_views_[0]->size().width() +
+-                       contents_container_views_[0]->GetInsets().width() +
+-                       contents_container_views_[1]->size().width() +
+-                       contents_container_views_[1]->GetInsets().width();
+-  double end_width = (initial_start_width_on_resize_.value() +
+-                      contents_container_views_[0]->GetInsets().width() +
+-                      static_cast<double>(resize_amount));
+-
+-  // If end_width is within the snap point widths, update to the snap point.
++  const bool is_horizontal_split =
++      split_layout_ == split_tabs::SplitTabLayout::kHorizontal;
++  if (!initial_start_size_on_resize_.has_value()) {
++    initial_start_size_on_resize_ = std::make_optional(
++        is_horizontal_split ? contents_container_views_[0]->size().height()
++                            : contents_container_views_[0]->size().width());
++  }
++  const double total_size =
++      (is_horizontal_split ? contents_container_views_[0]->size().height()
++                           : contents_container_views_[0]->size().width()) +
++      (is_horizontal_split
++           ? contents_container_views_[0]->GetInsets().height()
++           : contents_container_views_[0]->GetInsets().width()) +
++      (is_horizontal_split ? contents_container_views_[1]->size().height()
++                           : contents_container_views_[1]->size().width()) +
++      (is_horizontal_split ? contents_container_views_[1]->GetInsets().height()
++                           : contents_container_views_[1]->GetInsets().width());
++  const double start_size =
++      initial_start_size_on_resize_.value() +
++      (is_horizontal_split
++           ? contents_container_views_[0]->GetInsets().height()
++           : contents_container_views_[0]->GetInsets().width()) +
++      static_cast<double>(resize_amount);
++
++  // If start_size is within the snap point sizes, update to the snap point.
+   delegate_->ResizeWebContents(
+-      CalculateRatioWithSnapPoints(end_width, total_width), done_resizing);
++      CalculateRatioWithSnapPoints(start_size, total_size), done_resizing);
+ 
+   if (done_resizing) {
+-    initial_start_width_on_resize_ = std::nullopt;
++    initial_start_size_on_resize_ = std::nullopt;
+   }
+ }
+ 
+@@ -464,15 +486,30 @@ views::ProposedLayout MultiContentsView::CalculateProposedLayout(
+   available_space =
+       CalculateSeparatorLayouts(available_space, layouts.child_layouts);
+ 
+-  ViewWidths widths = GetViewWidths(available_space);
+-
+-  gfx::Rect start_rect(available_space.origin(),
+-                       gfx::Size(widths.start_width, available_space.height()));
+-  gfx::Rect resize_rect(
+-      start_rect.top_right(),
+-      gfx::Size(widths.resize_width, available_space.height()));
+-  gfx::Rect end_rect(resize_rect.top_right(),
+-                     gfx::Size(widths.end_width, available_space.height()));
++  ViewSizes sizes = GetViewSizes(available_space);
++
++  gfx::Rect start_rect;
++  gfx::Rect resize_rect;
++  gfx::Rect end_rect;
++  if (split_layout_ == split_tabs::SplitTabLayout::kHorizontal) {
++    start_rect =
++        gfx::Rect(available_space.origin(),
++                  gfx::Size(available_space.width(), sizes.start_size));
++    resize_rect =
++        gfx::Rect(gfx::Point(available_space.x(), start_rect.bottom()),
++                  gfx::Size(available_space.width(), sizes.resize_size));
++    end_rect = gfx::Rect(gfx::Point(available_space.x(), resize_rect.bottom()),
++                         gfx::Size(available_space.width(), sizes.end_size));
++  } else {
++    start_rect =
++        gfx::Rect(available_space.origin(),
++                  gfx::Size(sizes.start_size, available_space.height()));
++    resize_rect =
++        gfx::Rect(start_rect.top_right(),
++                  gfx::Size(sizes.resize_size, available_space.height()));
++    end_rect = gfx::Rect(resize_rect.top_right(),
++                         gfx::Size(sizes.end_size, available_space.height()));
++  }
+ 
+   if (IsInSplitView()) {
+     start_rect.Inset(start_contents_view_inset_);
+@@ -605,61 +642,89 @@ gfx::Rect MultiContentsView::CalculateSeparatorLayouts(
+                    height - separator_height);
+ }
+ 
+-MultiContentsView::ViewWidths MultiContentsView::GetViewWidths(
++MultiContentsView::ViewSizes MultiContentsView::GetViewSizes(
+     gfx::Rect available_space) const {
+-  ViewWidths widths;
++  ViewSizes sizes;
++  const bool is_horizontal_split =
++      split_layout_ == split_tabs::SplitTabLayout::kHorizontal;
++  const int available_size =
++      is_horizontal_split ? available_space.height() : available_space.width();
+   if (IsInSplitView()) {
+     CHECK(contents_container_views_[0]->GetVisible() &&
+           contents_container_views_[1]->GetVisible());
+-    widths.resize_width = resize_area_->GetPreferredSize().width();
+-    widths.start_width =
+-        start_ratio_ * (available_space.width() - widths.resize_width);
+-    widths.end_width =
+-        available_space.width() - widths.start_width - widths.resize_width;
++    sizes.resize_size = is_horizontal_split
++                            ? resize_area_->GetPreferredSize().height()
++                            : resize_area_->GetPreferredSize().width();
++    sizes.start_size = start_ratio_ * (available_size - sizes.resize_size);
++    sizes.end_size = available_size - sizes.start_size - sizes.resize_size;
+   } else {
+     CHECK(!contents_container_views_[1]->GetVisible());
+-    widths.start_width = available_space.width();
++    sizes.start_size = available_size;
+   }
+-  return ClampToMinWidth(available_space, widths);
++  return ClampToMinViewSize(available_space, sizes);
+ }
+ 
+-MultiContentsView::ViewWidths MultiContentsView::ClampToMinWidth(
++MultiContentsView::ViewSizes MultiContentsView::ClampToMinViewSize(
+     gfx::Rect available_space,
+-    ViewWidths widths) const {
++    ViewSizes sizes) const {
+   if (!IsInSplitView()) {
+     // Don't clamp if in a single-view state, where other views should be 0
+-    // width.
+-    return widths;
++    // size.
++    return sizes;
+   }
+ 
+-  const int min_width = GetMinViewWidth(available_space);
+-  if (widths.start_width < min_width) {
+-    const double diff = min_width - widths.start_width;
+-    widths.start_width += diff;
+-    widths.end_width -= diff;
+-  } else if (widths.end_width < min_width) {
+-    const double diff = min_width - widths.end_width;
+-    widths.end_width += diff;
+-    widths.start_width -= diff;
++  const int min_size = GetMinViewSize(available_space);
++  if (sizes.start_size < min_size) {
++    const double diff = min_size - sizes.start_size;
++    sizes.start_size += diff;
++    sizes.end_size -= diff;
++  } else if (sizes.end_size < min_size) {
++    const double diff = min_size - sizes.end_size;
++    sizes.end_size += diff;
++    sizes.start_size -= diff;
+   }
+-  return widths;
++  return sizes;
+ }
+ 
+-int MultiContentsView::GetMinViewWidth(gfx::Rect available_space) const {
++int MultiContentsView::GetMinViewSize(gfx::Rect available_space) const {
+   CHECK(IsInSplitView());
+ 
+-  // The minimum width for a content view in a split should be the lesser of
++  // The minimum size for a content view in a split should be the lesser of
+   // kMinWebContentsWidth, and kMinWebContentsWidthPercentage as a percentage of
+-  // the MultiContentsView's available width with a lower bound of
++  // the MultiContentsView's available split axis size with a lower bound of
+   // kConstrainedMinWebContentsWidth.
+-  const int min_percentage =
+-      kMinWebContentsWidthPercentage * available_space.width();
++  const int available_size =
++      split_layout_ == split_tabs::SplitTabLayout::kHorizontal
++          ? available_space.height()
++          : available_space.width();
++  const int min_percentage = kMinWebContentsWidthPercentage * available_size;
+   const int min_fixed_value =
+       min_contents_width_for_testing_.value_or(kMinWebContentsWidth);
+   return std::min(min_fixed_value,
+                   std::max(kConstrainedMinWebContentsWidth, min_percentage));
+ }
+ 
++void MultiContentsView::UpdateContentsViewInsets() {
++  const int top_inset =
++      contents_separators_.should_show_top ? 0 : kSplitViewContentInset;
++  const int leading_inset =
++      contents_separators_.should_show_leading ? 0 : kSplitViewContentInset;
++  const int trailing_inset =
++      contents_separators_.should_show_trailing ? 0 : kSplitViewContentInset;
++
++  if (split_layout_ == split_tabs::SplitTabLayout::kHorizontal) {
++    start_contents_view_inset_ =
++        gfx::Insets::TLBR(top_inset, leading_inset, 0, trailing_inset);
++    end_contents_view_inset_ = gfx::Insets::TLBR(
++        0, leading_inset, kSplitViewContentInset, trailing_inset);
++  } else {
++    start_contents_view_inset_ =
++        gfx::Insets::TLBR(top_inset, leading_inset, kSplitViewContentInset, 0);
++    end_contents_view_inset_ =
++        gfx::Insets::TLBR(top_inset, 0, kSplitViewContentInset, trailing_inset);
++  }
++}
++
+ void MultiContentsView::UpdateContentsBorderAndOverlay() {
+   for (auto* contents_container_view : contents_container_views_) {
+     const bool is_active =
+@@ -709,10 +774,7 @@ void MultiContentsView::SetShouldShowTopSeparator(bool should_show) {
+     return;
+   }
+   contents_separators_.should_show_top = should_show;
+-  start_contents_view_inset_.set_top(
+-      should_show ? 0 : MultiContentsView::kSplitViewContentInset);
+-  end_contents_view_inset_.set_top(
+-      should_show ? 0 : MultiContentsView::kSplitViewContentInset);
++  UpdateContentsViewInsets();
+ 
+   // This can be called during BrowserView layout, so protect against creating a
+   // layout loop.
+@@ -724,8 +786,7 @@ void MultiContentsView::SetShouldShowLeadingSeparator(bool should_show) {
+     return;
+   }
+   contents_separators_.should_show_leading = should_show;
+-  start_contents_view_inset_.set_left(
+-      should_show ? 0 : MultiContentsView::kSplitViewContentInset);
++  UpdateContentsViewInsets();
+ 
+   // This can be called during BrowserView layout, so protect against creating a
+   // layout loop.
+@@ -737,8 +798,7 @@ void MultiContentsView::SetShouldShowTrailingSeparator(bool should_show) {
+     return;
+   }
+   contents_separators_.should_show_trailing = should_show;
+-  end_contents_view_inset_.set_right(
+-      should_show ? 0 : MultiContentsView::kSplitViewContentInset);
++  UpdateContentsViewInsets();
+ 
+   // This can be called during BrowserView layout, so protect against creating a
+   // layout loop.

--- a/packages/browseros/chromium_patches/chrome/browser/ui/views/frame/multi_contents_view.h
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/views/frame/multi_contents_view.h
@@ -1,0 +1,107 @@
+diff --git a/chrome/browser/ui/views/frame/multi_contents_view.h b/chrome/browser/ui/views/frame/multi_contents_view.h
+index e24b980a8fb42..b9fe34148edba 100644
+--- a/chrome/browser/ui/views/frame/multi_contents_view.h
++++ b/chrome/browser/ui/views/frame/multi_contents_view.h
+@@ -16,6 +16,7 @@
+ #include "chrome/browser/ui/ui_features.h"
+ #include "chrome/browser/ui/views/frame/contents_container_view.h"
+ #include "components/prefs/pref_change_registrar.h"
++#include "components/split_tabs/split_tab_visual_data.h"
+ #include "ui/base/interaction/element_identifier.h"
+ #include "ui/base/metadata/metadata_header_macros.h"
+ #include "ui/views/controls/resize_area_delegate.h"
+@@ -56,10 +57,10 @@ class MultiContentsView
+  public:
+   using FocusableViewMap = base::flat_map<std::string, views::View*>;
+ 
+-  struct ViewWidths {
+-    double start_width = 0;
+-    double resize_width = 0;
+-    double end_width = 0;
++  struct ViewSizes {
++    double start_size = 0;
++    double resize_size = 0;
++    double end_size = 0;
+   };
+ 
+   static constexpr int kSplitViewContentInset = 8;
+@@ -90,7 +91,7 @@ class MultiContentsView
+   // Show the split view without set any WebContents and update the size of
+   // contents views based on `ratio`, this is used to prepare the layout and
+   // prevent a re-layout of WebContents.
+-  void ShowSplitView(double ratio);
++  void ShowSplitView(double ratio, split_tabs::SplitTabLayout split_layout);
+ 
+   // Preserves the active WebContents and hides the second ContentsContainerView
+   // and resize handle.
+@@ -108,6 +109,8 @@ class MultiContentsView
+ 
+   // Updates the size of the contents views based on |ratio|.
+   void UpdateSplitRatio(double ratio);
++  void UpdateSplitVisualData(double ratio,
++                             split_tabs::SplitTabLayout split_layout);
+   double GetSplitRatio() const { return start_ratio_; }
+ 
+   // SplitTabHighlightController::Delegate:
+@@ -147,7 +150,7 @@ class MultiContentsView
+ 
+   // If the split view is being resized.
+   bool IsSplitResizing() const {
+-    return initial_start_width_on_resize_.has_value();
++    return initial_start_size_on_resize_.has_value();
+   }
+ 
+   // Returns accessible panes to be used in BrowserView to create the order of
+@@ -252,17 +255,20 @@ class MultiContentsView
+   void OnReadAnythingOverlayFocused(ContentsContainerView* container,
+                                     views::WebView* web_view);
+ 
+-  ViewWidths GetViewWidths(gfx::Rect available_space) const;
++  ViewSizes GetViewSizes(gfx::Rect available_space) const;
+ 
+   // Clamps to the minimum of kMinWebContentsWidth or
+-  // kMinWebContentsWidthPercentage multiplied by the available width. This
+-  // allows for some flexibility when it comes to particularly narrow windows.
+-  ViewWidths ClampToMinWidth(gfx::Rect available_space,
+-                             ViewWidths widths) const;
++  // kMinWebContentsWidthPercentage multiplied by the available split axis size.
++  // This allows for some flexibility when it comes to particularly narrow or
++  // short windows.
++  ViewSizes ClampToMinViewSize(gfx::Rect available_space,
++                               ViewSizes sizes) const;
+ 
+-  // Returns the minimum width for a single view within the `MultiContentsView`.
++  // Returns the minimum size for a single view within the `MultiContentsView`.
+   // Returns 0 if not in a split view.
+-  int GetMinViewWidth(gfx::Rect available_space) const;
++  int GetMinViewSize(gfx::Rect available_space) const;
++
++  void UpdateContentsViewInsets();
+ 
+   void UpdateContentsBorderAndOverlay();
+ 
+@@ -299,16 +305,20 @@ class MultiContentsView
+   // The index in contents_views_ of the active contents view.
+   int active_index_ = 0;
+ 
+-  // Current ratio of |contents_views_|'s first ContentsContainerView's width /
+-  // overall contents view width.
++  // Current ratio of |contents_views_|'s first ContentsContainerView's size /
++  // overall contents view size along the active split axis.
+   double start_ratio_ = 0.5;
+ 
+   // See `SetTargetContentBounds()`.
+   std::optional<TargetContentBounds> target_content_bounds_;
+ 
+-  // Width of `start_contents_.contents_view_` when a resize action began.
++  split_tabs::SplitTabLayout split_layout_ =
++      split_tabs::SplitTabLayout::kVertical;
++
++  // Size of `start_contents_.contents_view_` along the active split axis when a
++  // resize action began.
+   // Nullopt if not currently resizing.
+-  std::optional<double> initial_start_width_on_resize_;
++  std::optional<double> initial_start_size_on_resize_;
+ 
+   // Insets of the start and end contents view when in split view
+   gfx::Insets start_contents_view_inset_;

--- a/packages/browseros/chromium_patches/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button_menu_model.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button_menu_model.cc
@@ -1,0 +1,154 @@
+diff --git a/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button_menu_model.cc b/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button_menu_model.cc
+index d8a69c7965a46..82d85cc4e5cae 100644
+--- a/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button_menu_model.cc
++++ b/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button_menu_model.cc
+@@ -15,18 +15,22 @@
+ #include "chrome/browser/profiles/profile.h"
+ #include "chrome/browser/ui/actions/chrome_action_id.h"
+ #include "chrome/browser/ui/browser_actions.h"
++#include "chrome/browser/ui/browser_commands.h"
+ #include "chrome/browser/ui/browser_element_identifiers.h"
+ #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
+ #include "chrome/browser/ui/customize_chrome/side_panel_controller.h"
+ #include "chrome/browser/ui/tabs/public/tab_features.h"
++#include "chrome/browser/ui/tabs/split_tab_metrics.h"
+ #include "chrome/browser/ui/tabs/tab_strip_model.h"
+ #include "chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model.h"
+ #include "chrome/common/pref_names.h"
++#include "chrome/grit/generated_resources.h"
+ #include "components/prefs/pref_service.h"
+ #include "components/tabs/public/tab_interface.h"
+ #include "ui/actions/action_id.h"
+ #include "ui/actions/actions.h"
+ #include "ui/base/interaction/element_identifier.h"
++#include "ui/base/l10n/l10n_util.h"
+ #include "ui/menus/simple_menu_model.h"
+ 
+ DEFINE_ELEMENT_IDENTIFIER_VALUE(kPinnedActionToolbarUnpinElementId);
+@@ -84,6 +88,10 @@ ui::MenuModel::ItemType PinnedActionToolbarButtonMenuModel::GetTypeAt(
+     return items_[index].type;
+   }
+ 
++  if (items_[index].kind == ItemKind::kSplitTabCreate) {
++    return items_[index].type;
++  }
++
+   return GetActionItemFor(items_[index].action_id)->GetChecked()
+              ? TYPE_CHECK
+              : items_[index].type;
+@@ -104,6 +112,10 @@ std::u16string PinnedActionToolbarButtonMenuModel::GetLabelAt(
+     return std::u16string();
+   }
+ 
++  if (items_[index].kind == ItemKind::kSplitTabCreate) {
++    return l10n_util::GetStringUTF16(items_[index].string_id);
++  }
++
+   return std::u16string(GetActionItemFor(items_[index].action_id)->GetText());
+ }
+ 
+@@ -121,6 +133,9 @@ bool PinnedActionToolbarButtonMenuModel::IsItemCheckedAt(size_t index) const {
+   if (GetTypeAt(index) == TYPE_SEPARATOR) {
+     return false;
+   }
++  if (items_[index].kind == ItemKind::kSplitTabCreate) {
++    return false;
++  }
+ 
+   return GetActionItemFor(items_[index].action_id)->GetChecked();
+ }
+@@ -134,6 +149,9 @@ ui::ImageModel PinnedActionToolbarButtonMenuModel::GetIconAt(
+   if (GetTypeAt(index) == TYPE_SEPARATOR) {
+     return ui::ImageModel();
+   }
++  if (items_[index].kind == ItemKind::kSplitTabCreate) {
++    return ui::ImageModel();
++  }
+ 
+   const ui::ImageModel& image =
+       GetActionItemFor(items_[index].action_id)->GetImage();
+@@ -156,6 +174,9 @@ bool PinnedActionToolbarButtonMenuModel::IsEnabledAt(size_t index) const {
+   if (GetTypeAt(index) == TYPE_SEPARATOR) {
+     return true;
+   }
++  if (items_[index].kind == ItemKind::kSplitTabCreate) {
++    return CanCreateSplitTab();
++  }
+   if (items_[index].action_id == kActionPinActionToToolbar ||
+       items_[index].action_id == kActionUnpinActionFromToolbar) {
+     const bool is_pinnable = IsPinnable();
+@@ -176,7 +197,14 @@ bool PinnedActionToolbarButtonMenuModel::IsEnabledAt(size_t index) const {
+ }
+ 
+ bool PinnedActionToolbarButtonMenuModel::IsVisibleAt(size_t index) const {
++  if (items_[index].kind == ItemKind::kSplitTabCreate) {
++    return CanCreateSplitTab();
++  }
+   if (GetTypeAt(index) == TYPE_SEPARATOR) {
++    if (action_id_ == kActionSplitTab && index > 0 &&
++        items_[index - 1].kind == ItemKind::kSplitTabCreate) {
++      return CanCreateSplitTab();
++    }
+     return true;
+   }
+   const bool is_pinned = IsPinned();
+@@ -201,6 +229,13 @@ void PinnedActionToolbarButtonMenuModel::ActivatedAt(size_t index) {
+ void PinnedActionToolbarButtonMenuModel::ActivatedAt(size_t index,
+                                                      int event_flags) {
+   DCHECK(GetTypeAt(index) != TYPE_SEPARATOR);
++  if (items_[index].kind == ItemKind::kSplitTabCreate) {
++    chrome::NewSplitTab(browser_,
++                        split_tabs::SplitTabCreatedSource::kToolbarButton,
++                        items_[index].split_tab_layout);
++    return;
++  }
++
+   auto action_id = items_[index].action_id;
+   if (action_id == kActionPinActionToToolbar ||
+       action_id == kActionUnpinActionFromToolbar) {
+@@ -230,12 +265,28 @@ PinnedActionToolbarButtonMenuModel::Item::Item(
+     ItemType type,
+     std::optional<ui::ElementIdentifier> unique_id)
+     : action_id(action_id), type(type), unique_id(unique_id) {}
+-PinnedActionToolbarButtonMenuModel::Item::Item(ItemType type) : type(type) {}
++PinnedActionToolbarButtonMenuModel::Item::Item(
++    int string_id,
++    split_tabs::SplitTabLayout split_tab_layout)
++    : kind(ItemKind::kSplitTabCreate),
++      string_id(string_id),
++      split_tab_layout(split_tab_layout) {}
++PinnedActionToolbarButtonMenuModel::Item::Item(ItemType type)
++    : type(type), kind(ItemKind::kSeparator) {}
+ PinnedActionToolbarButtonMenuModel::Item&
+ PinnedActionToolbarButtonMenuModel::Item::operator=(Item&&) = default;
+ PinnedActionToolbarButtonMenuModel::Item::~Item() = default;
+ 
+ void PinnedActionToolbarButtonMenuModel::AddActionSpecificItems() {
++  if (action_id_ == kActionSplitTab) {
++    items_.emplace_back(IDS_SPLIT_TAB_CREATE_LEFT_RIGHT,
++                        split_tabs::SplitTabLayout::kVertical);
++    items_.emplace_back(IDS_SPLIT_TAB_CREATE_TOP_BOTTOM,
++                        split_tabs::SplitTabLayout::kHorizontal);
++    items_.emplace_back(TYPE_SEPARATOR);
++    return;
++  }
++
+   if (!IsPinStateManagedByPrefs(action_id_)) {
+     // If the action has child actions add those first followed by a separator.
+     actions::ActionItem* action_item = GetActionItemFor(action_id_);
+@@ -252,6 +303,15 @@ void PinnedActionToolbarButtonMenuModel::AddActionSpecificItems() {
+   }
+ }
+ 
++bool PinnedActionToolbarButtonMenuModel::CanCreateSplitTab() const {
++  TabStripModel* const tab_strip_model = browser_->GetTabStripModel();
++  if (!tab_strip_model) {
++    return false;
++  }
++  tabs::TabInterface* const active_tab = tab_strip_model->GetActiveTab();
++  return active_tab && !active_tab->IsSplit();
++}
++
+ actions::ActionItem* PinnedActionToolbarButtonMenuModel::GetActionItemFor(
+     actions::ActionId id) const {
+   return actions::ActionManager::Get().FindAction(

--- a/packages/browseros/chromium_patches/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button_menu_model.h
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button_menu_model.h
@@ -1,0 +1,45 @@
+diff --git a/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button_menu_model.h b/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button_menu_model.h
+index 2e4d96e3d69ab..9e3bde9501ab9 100644
+--- a/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button_menu_model.h
++++ b/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button_menu_model.h
+@@ -11,6 +11,7 @@
+ #include "base/memory/raw_ptr.h"
+ #include "base/memory/weak_ptr.h"
+ #include "base/time/time.h"
++#include "components/split_tabs/split_tab_visual_data.h"
+ #include "ui/actions/actions.h"
+ #include "ui/base/models/menu_model.h"
+ #include "ui/views/view_class_properties.h"
+@@ -62,11 +63,14 @@ class PinnedActionToolbarButtonMenuModel final : public ui::MenuModel {
+   actions::ActionId GetActionIdAtForTesting(size_t index);
+ 
+  private:
++  enum class ItemKind { kAction, kSeparator, kSplitTabCreate };
++
+   struct Item {
+     Item(Item&&);
+     Item(actions::ActionId action_id,
+          ItemType type,
+          std::optional<ui::ElementIdentifier> unique_id = std::nullopt);
++    Item(int string_id, split_tabs::SplitTabLayout split_tab_layout);
+     explicit Item(ItemType type);
+     Item& operator=(Item&&);
+     ~Item();
+@@ -74,11 +78,17 @@ class PinnedActionToolbarButtonMenuModel final : public ui::MenuModel {
+     actions::ActionId action_id = 0;
+     ItemType type = TYPE_COMMAND;
+     std::optional<ui::ElementIdentifier> unique_id;
++    ItemKind kind = ItemKind::kAction;
++    int string_id = 0;
++    split_tabs::SplitTabLayout split_tab_layout =
++        split_tabs::SplitTabLayout::kVertical;
+   };
+ 
+   // Adds menu items specific to the action item to the menu.
+   void AddActionSpecificItems();
+ 
++  bool CanCreateSplitTab() const;
++
+   actions::ActionItem* GetActionItemFor(actions::ActionId id) const;
+ 
+   // Returns true if the toolbar button can be pinned and false otherwise.

--- a/packages/browseros/chromium_patches/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button_menu_model_browsertest.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button_menu_model_browsertest.cc
@@ -1,0 +1,87 @@
+diff --git a/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button_menu_model_browsertest.cc b/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button_menu_model_browsertest.cc
+index f03e5448c7f3c..e7948cf559bf7 100644
+--- a/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button_menu_model_browsertest.cc
++++ b/chrome/browser/ui/views/toolbar/pinned_action_toolbar_button_menu_model_browsertest.cc
+@@ -6,12 +6,19 @@
+ 
+ #include <string>
+ 
++#include "chrome/browser/ui/actions/chrome_action_id.h"
+ #include "chrome/browser/ui/browser.h"
+ #include "chrome/browser/ui/browser_actions.h"
++#include "chrome/browser/ui/browser_commands.h"
++#include "chrome/browser/ui/tabs/split_tab_metrics.h"
++#include "chrome/grit/generated_resources.h"
+ #include "chrome/test/base/in_process_browser_test.h"
++#include "components/split_tabs/split_tab_visual_data.h"
++#include "components/tabs/public/split_tab_data.h"
+ #include "components/vector_icons/vector_icons.h"
+ #include "content/public/test/browser_test.h"
+ #include "ui/actions/actions.h"
++#include "ui/base/l10n/l10n_util.h"
+ #include "ui/base/models/menu_model.h"
+ #include "ui/menus/simple_menu_model.h"
+ 
+@@ -96,3 +103,62 @@ IN_PROC_BROWSER_TEST_F(PinnedActionToolbarButtonMenuModelBrowserTest,
+   EXPECT_TRUE(menu_model.IsEnabledAt(2));
+   EXPECT_TRUE(menu_model.IsVisibleAt(2));
+ }
++
++IN_PROC_BROWSER_TEST_F(PinnedActionToolbarButtonMenuModelBrowserTest,
++                       SplitTabCreateItems) {
++  PinnedActionToolbarButtonMenuModel menu_model(browser(), kActionSplitTab);
++
++  ASSERT_EQ(6u, menu_model.GetItemCount());
++  EXPECT_EQ(l10n_util::GetStringUTF16(IDS_SPLIT_TAB_CREATE_LEFT_RIGHT),
++            menu_model.GetLabelAt(0));
++  EXPECT_EQ(l10n_util::GetStringUTF16(IDS_SPLIT_TAB_CREATE_TOP_BOTTOM),
++            menu_model.GetLabelAt(1));
++  EXPECT_TRUE(menu_model.IsVisibleAt(0));
++  EXPECT_TRUE(menu_model.IsVisibleAt(1));
++  EXPECT_TRUE(menu_model.IsVisibleAt(2));
++}
++
++IN_PROC_BROWSER_TEST_F(PinnedActionToolbarButtonMenuModelBrowserTest,
++                       SplitTabCreateItemsHiddenWhenActiveTabIsSplit) {
++  chrome::NewSplitTab(browser(),
++                      split_tabs::SplitTabCreatedSource::kToolbarButton);
++  PinnedActionToolbarButtonMenuModel menu_model(browser(), kActionSplitTab);
++
++  ASSERT_EQ(6u, menu_model.GetItemCount());
++  EXPECT_FALSE(menu_model.IsVisibleAt(0));
++  EXPECT_FALSE(menu_model.IsVisibleAt(1));
++  EXPECT_FALSE(menu_model.IsVisibleAt(2));
++}
++
++IN_PROC_BROWSER_TEST_F(PinnedActionToolbarButtonMenuModelBrowserTest,
++                       SplitTabCreateLeftRightCreatesVerticalSplit) {
++  PinnedActionToolbarButtonMenuModel menu_model(browser(), kActionSplitTab);
++
++  menu_model.ActivatedAt(0);
++
++  auto split_id = browser()->tab_strip_model()->GetActiveTab()->GetSplit();
++  ASSERT_TRUE(split_id.has_value());
++  split_tabs::SplitTabVisualData* visual_data =
++      browser()
++          ->tab_strip_model()
++          ->GetSplitData(split_id.value())
++          ->visual_data();
++  EXPECT_EQ(split_tabs::SplitTabLayout::kVertical, visual_data->split_layout());
++}
++
++IN_PROC_BROWSER_TEST_F(PinnedActionToolbarButtonMenuModelBrowserTest,
++                       SplitTabCreateTopBottomCreatesHorizontalSplit) {
++  PinnedActionToolbarButtonMenuModel menu_model(browser(), kActionSplitTab);
++
++  menu_model.ActivatedAt(1);
++
++  auto split_id = browser()->tab_strip_model()->GetActiveTab()->GetSplit();
++  ASSERT_TRUE(split_id.has_value());
++  split_tabs::SplitTabVisualData* visual_data =
++      browser()
++          ->tab_strip_model()
++          ->GetSplitData(split_id.value())
++          ->visual_data();
++  EXPECT_EQ(split_tabs::SplitTabLayout::kHorizontal,
++            visual_data->split_layout());
++}


### PR DESCRIPTION
## Summary

Adds top/bottom split creation from the split tabs toolbar button context menu.

- Keeps the existing toolbar left-click behavior unchanged.
- Adds context menu options for left/right and top/bottom split creation.
- Adds browser test coverage for the toolbar context menu flow.

## Design

This PR adds a layout parameter to the toolbar split creation path and passes it through to the split view UI.

The top/bottom option uses `SplitTabLayout::kHorizontal`, which MultiContentsView uses to lay out panes vertically and resize them by height ratio. Existing default split
creation paths continue to use the current left/right layout.

## Test plan

- Built BrowserOS locally with full `autoninja`.
- Manually verified top/bottom split creation from the toolbar button context menu.
- Manually verified focus switching and divider resizing for top/bottom panes.

Related to: https://github.com/browseros-ai/BrowserOS/issues/928

https://github.com/user-attachments/assets/d8f25b6b-5229-44e0-b0ca-d0a8d31830ec

