### PR TITLE
fix(agent): guard runMissedJobs daily branch from premature execution

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/background/scheduledJobRuns.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/background/scheduledJobRuns.ts
@@ -175,9 +175,12 @@ export const scheduledJobRuns = async () => {
 
         if (job.scheduleType === 'daily' && job.scheduleTime) {
           const [hours, minutes] = job.scheduleTime.split(':').map(Number)
+          if (!Number.isFinite(hours) || !Number.isFinite(minutes)) continue
           const scheduledToday = new Date()
           scheduledToday.setHours(hours, minutes, 0, 0)
           if (now < scheduledToday.getTime()) continue
+          const createdAt = new Date(job.createdAt).getTime()
+          if (createdAt > scheduledToday.getTime()) continue
         }
 
         if (


### PR DESCRIPTION
## Summary

- The daily branch of `runMissedJobs` was missing the `createdAt` gate that the hourly/minutes branch right below it already had, so a brand-new daily task fires on the next startup instead of waiting for tomorrow's alarm.
- Also add a `Number.isFinite` check for the parsed hours/minutes, so malformed `scheduleTime` strings (`"abc"`, `""`, `"9"`) skip instead of falling through with a NaN gate.

## Design

The daily check at `scheduledJobRuns.ts:176-181` only asked "has the scheduled HH:MM passed today?". For a job created today at 17:30 with `scheduleTime: "09:00"`, that's true, so the gate fell through and the task ran immediately, even though `createAlarmFromJob` correctly scheduled the first alarm for tomorrow 09:00. The hourly/minutes branch right below (lines 183-193) already gates on `createdAt`; mirroring that here closes the daily case.

The `Number.isFinite` guard handles `scheduleTime` strings that don't parse cleanly. Without it, `setHours(NaN, NaN, ...)` yields an invalid Date and the gate always falls through, so a job with a malformed schedule fires on every alarm tick. Reachable via `apps/server/src/tools/nudges.ts`, which accepts any string for `scheduleTime`.

## Test plan

Daily-gate logic in Node, with the fix applied:

```
$ node -e '
function dailyGate(scheduleTime, jobCreatedAtIso, now) {
    const [hours, minutes] = scheduleTime.split(":").map(Number);
    if (!Number.isFinite(hours) || !Number.isFinite(minutes)) return true;
    const scheduledToday = new Date(now);
    scheduledToday.setHours(hours, minutes, 0, 0);
    if (now < scheduledToday.getTime()) return true;
    const createdAt = new Date(jobCreatedAtIso).getTime();
    if (createdAt > scheduledToday.getTime()) return true;
    return false;
}
const now = new Date("2026-05-17T18:00:00+02:00").getTime();
const createdToday = new Date("2026-05-17T17:30:00+02:00").toISOString();
const createdYesterday = new Date("2026-05-16T10:00:00+02:00").toISOString();
console.log("brand-new, scheduleTime 09:00:", dailyGate("09:00", createdToday, now) ? "skip (correct)" : "FIRES");
console.log("missed run from yesterday:", dailyGate("09:00", createdYesterday, now) ? "skip" : "FIRES (correct, intentional)");
console.log("malformed scheduleTime abc:", dailyGate("abc", createdYesterday, now) ? "skip (correct)" : "FIRES");
'
brand-new, scheduleTime 09:00: skip (correct)
missed run from yesterday: FIRES (correct, intentional)
malformed scheduleTime abc: skip (correct)
```

Legitimate missed runs (job created before today's scheduled time, browser was closed across it) still fire as intended.

Fixes #1018
