### PR TITLE
fix(agent): resolve Claude and Codex ACP commands

### DIFF
--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
@@ -48,6 +48,10 @@ import type {
 
 export type { OpenclawGatewayAccessor } from './openclaw/acp-command'
 
+const CLAUDE_ACP_ADAPTER_COMMAND =
+  'npx -y @agentclientprotocol/claude-agent-acp@^0.31.0'
+const CODEX_ACP_ADAPTER_COMMAND = 'npx -y @zed-industries/codex-acp@^0.12.0'
+
 type AcpxRuntimeOptions = {
   cwd?: string
   browserosDir?: string
@@ -706,20 +710,31 @@ function createBrowserosAgentRegistry(input: {
         return wrapCommandWithEnv('hermes acp', input.commandEnv)
       }
 
-      // claude + codex resolve through acpx-core's built-in registry
-      // because the canonical command is an npx wrapper around the
-      // upstream ACP-adapter package (e.g. `npx @zed-industries/codex-acp`),
-      // and the package version range lives inside acpx-core. The
-      // ClaudeRuntime / CodexRuntime registrations still drive health
-      // probing and per-turn prep; only the spawn command source-of-
-      // truth stays in acpx-core.
       if (lower === 'claude' || lower === 'codex') {
-        return wrapCommandWithEnv(registry.resolve(agentName), input.commandEnv)
+        return wrapCommandWithEnv(
+          resolveBrowserosHostAcpAdapterCommand(lower),
+          input.commandEnv,
+        )
       }
 
       return registry.resolve(agentName)
     },
   }
+}
+
+/**
+ * Resolve host-spawned Claude/Codex ACP adapters without asking acpx
+ * to discover package bins. BrowserOS prefixes commands with `env`;
+ * that hides acpx's built-in command from its package launcher, and
+ * in Bun standalone builds that launcher may also see `$bunfs` paths
+ * plus the compiled BrowserOS binary as `process.execPath`.
+ */
+function resolveBrowserosHostAcpAdapterCommand(
+  adapter: 'claude' | 'codex',
+): string {
+  return adapter === 'claude'
+    ? CLAUDE_ACP_ADAPTER_COMMAND
+    : CODEX_ACP_ADAPTER_COMMAND
 }
 
 async function applyRuntimeControls(

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -965,7 +965,7 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
     expect(command).toContain('/runtime/codex-home')
     // Spawn must go through acpx-core's npx wrapper for the official
     // codex-acp package, not a bare `codex` binary.
-    expect(command).toContain('codex-acp')
+    expect(command).toContain('npx -y @zed-industries/codex-acp')
   })
 
   it('resolves the Hermes adapter to a container `nerdctl exec hermes acp` command when a HermesContainerRuntime is registered', async () => {


### PR DESCRIPTION
## Summary
- Resolve Claude and Codex ACP adapter commands from BrowserOS instead of acpx package-bin discovery.
- Use noninteractive `npx -y` for the Codex ACP adapter so production launches do not prompt or hang.
- Add regression coverage for Codex command resolution with BrowserOS runtime env injection.

## Design
BrowserOS now owns the host-spawned Claude/Codex ACP adapter command strings before applying the per-runtime environment wrapper. This avoids acpx package-bin discovery paths that are brittle in Bun standalone executables, where embedded bundle paths and the compiled server binary can appear as runtime resolution anchors.

## Test plan
- `bun test ./tests/lib/agents/acpx-runtime.test.ts`
- `bun scripts/build/server.ts --target=darwin-arm64 --ci`