### PR TITLE
test(agent): tighten Claude ACP command assertion

### DIFF
--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -926,9 +926,9 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
     expect(command).toContain('env AGENT_HOME=')
     expect(command).not.toContain('CLAUDE_CONFIG_DIR=')
     expect(command).not.toContain('CODEX_HOME=')
-    // Spawn must go through acpx-core's npx wrapper for the official
+    // Spawn must go through BrowserOS's own npx command for the official
     // claude-agent-acp package, not a bare `claude` binary.
-    expect(command).toContain('claude-agent-acp')
+    expect(command).toContain('npx -y @agentclientprotocol/claude-agent-acp')
   })
 
   it('injects AGENT_HOME and CODEX_HOME into Codex ACP command resolution', async () => {
@@ -963,7 +963,7 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
     expect(command).toContain('env AGENT_HOME=')
     expect(command).toContain('CODEX_HOME=')
     expect(command).toContain('/runtime/codex-home')
-    // Spawn must go through acpx-core's npx wrapper for the official
+    // Spawn must go through BrowserOS's own npx command for the official
     // codex-acp package, not a bare `codex` binary.
     expect(command).toContain('npx -y @zed-industries/codex-acp')
   })


### PR DESCRIPTION
## Summary
- Follow up on Claude and Greptile review feedback from #1020.
- Tighten the Claude ACP command assertion to require the same `npx -y` command prefix as Codex.
- Update stale test comments so they describe BrowserOS-owned adapter command resolution.

## Design
This is a test-only follow-up. The production fix in #1020 was already squash-merged before review triage completed, so this PR applies the accepted review nit directly on top of `dev`.

## Test plan
- `bun test ./tests/lib/agents/acpx-runtime.test.ts`
- `bun test ./tests/lib/agents/acpx-runtime.test.ts -t "injects AGENT_HOME without CLAUDE_CONFIG_DIR"`