### PR TITLE
fix: preserve server artifact executable modes

### DIFF
--- a/packages/browseros/build/modules/storage/download.py
+++ b/packages/browseros/build/modules/storage/download.py
@@ -79,7 +79,8 @@ def _extract_artifact_files(
         dest_path = destination.joinpath(*relative_path.parts)
 
         try:
-            source_file = archive.open(archive_member, "r")
+            archive_info = archive.getinfo(archive_member)
+            source_file = archive.open(archive_info, "r")
         except KeyError as exc:
             raise RuntimeError(
                 f"Artifact archive is missing declared file: {archive_member}"
@@ -108,8 +109,7 @@ def _extract_artifact_files(
                 f"expected {expected_sha256}, got {actual_sha256}"
             )
 
-        if _should_mark_executable(relative_path):
-            dest_path.chmod(dest_path.stat().st_mode | 0o755)
+        _restore_zip_file_mode(dest_path, archive_info)
 
         extracted_paths.append(dest_path)
 
@@ -151,12 +151,22 @@ def _normalize_artifact_path(raw_path: Any) -> PurePosixPath:
     return relative_path
 
 
-def _should_mark_executable(relative_path: PurePosixPath) -> bool:
-    parts = relative_path.parts
-    if get_platform() == "windows":
-        return False
+def _restore_zip_file_mode(dest_path: Path, archive_info: zipfile.ZipInfo) -> None:
+    """Restore Unix permission bits from a validated artifact member.
 
-    return len(parts) >= 2 and parts[0] == "resources" and parts[1] == "bin"
+    Server artifact extraction streams files manually for checksum validation,
+    bypassing zipfile's normal mode handling. The agent builder already stages
+    per-target executable bits before zipping, so extraction should preserve
+    those bits instead of inferring executability from path names.
+    """
+    if get_platform() == "windows":
+        return
+
+    mode = (archive_info.external_attr >> 16) & 0o777
+    if mode == 0:
+        return
+
+    dest_path.chmod((dest_path.stat().st_mode & ~0o777) | mode)
 
 
 def _clear_destination(dest_path: Path) -> None:

--- a/packages/browseros/build/modules/storage/download.py
+++ b/packages/browseros/build/modules/storage/download.py
@@ -15,6 +15,7 @@ from ...common.context import Context
 from ...common.utils import (
     log_info,
     log_success,
+    log_warning,
     get_platform,
 )
 
@@ -164,6 +165,12 @@ def _restore_zip_file_mode(dest_path: Path, archive_info: zipfile.ZipInfo) -> No
 
     mode = (archive_info.external_attr >> 16) & 0o777
     if mode == 0:
+        parts = PurePosixPath(archive_info.filename).parts
+        if len(parts) >= 2 and parts[0] == "resources" and parts[1] == "bin":
+            log_warning(
+                "No Unix mode bits in zip entry "
+                f"{archive_info.filename}; leaving default permissions"
+            )
         return
 
     dest_path.chmod((dest_path.stat().st_mode & ~0o777) | mode)

--- a/packages/browseros/build/modules/storage/download_test.py
+++ b/packages/browseros/build/modules/storage/download_test.py
@@ -18,19 +18,32 @@ from build.modules.storage.download import (
 
 class ExtractArtifactZipTest(unittest.TestCase):
     def test_extracts_declared_files_and_writes_metadata(self) -> None:
-        files = {
+        executable_files = {
             "resources/bin/browseros_server": b"server-binary",
-            "resources/bin/third_party/bun": b"bun-binary",
-            "resources/bin/third_party/rg": b"rg-binary",
-            "resources/bin/third_party/podman/podman": b"podman-binary",
-            "resources/bin/third_party/podman/gvproxy": b"gvproxy-binary",
+            "resources/bin/third_party/lima/bin/limactl": b"limactl-binary",
+            "resources/bin/third_party/linux/helper": b"linux-helper",
         }
+        data_files = {
+            (
+                "resources/bin/third_party/lima/share/lima/"
+                "lima-guestagent.Linux-aarch64.gz"
+            ): b"guest-agent",
+            "resources/vm/browseros-vm.yaml": b"vm-template",
+        }
+        files = executable_files | data_files
 
         with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = Path(temp_dir)
             archive_path = temp_path / "artifact.zip"
             destination = temp_path / "output"
-            self._write_artifact_zip(archive_path, files)
+            self._write_artifact_zip(
+                archive_path,
+                files,
+                file_modes={
+                    relative_path: 0o755 for relative_path in executable_files
+                }
+                | {relative_path: 0o644 for relative_path in data_files},
+            )
 
             extracted_paths = extract_artifact_zip(archive_path, destination)
 
@@ -43,8 +56,16 @@ class ExtractArtifactZipTest(unittest.TestCase):
                 self.assertEqual(extracted_path.read_bytes(), content)
 
                 if os.name != "nt":
+                    mode = os.stat(extracted_path).st_mode
+                    if relative_path in data_files:
+                        self.assertFalse(
+                            mode & stat.S_IXUSR,
+                            f"{relative_path} should not be executable",
+                        )
+                        continue
+
                     self.assertTrue(
-                        os.stat(extracted_path).st_mode & stat.S_IXUSR,
+                        mode & stat.S_IXUSR,
                         f"{relative_path} should be executable",
                     )
 
@@ -119,13 +140,18 @@ class ExtractArtifactZipTest(unittest.TestCase):
         archive_path: Path,
         files: dict[str, bytes],
         metadata_override: dict | None = None,
+        file_modes: dict[str, int] | None = None,
     ) -> None:
         metadata = metadata_override or self._build_metadata(files)
 
         with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as archive:
             archive.writestr(ARTIFACT_METADATA_NAME, json.dumps(metadata))
             for relative_path, content in files.items():
-                archive.writestr(relative_path, content)
+                info = zipfile.ZipInfo(relative_path)
+                mode = (file_modes or {}).get(relative_path)
+                if mode is not None:
+                    info.external_attr = mode << 16
+                archive.writestr(info, content)
 
     def _build_metadata(self, files: dict[str, bytes]) -> dict:
         return {

--- a/packages/browseros/build/modules/storage/download_test.py
+++ b/packages/browseros/build/modules/storage/download_test.py
@@ -69,6 +69,28 @@ class ExtractArtifactZipTest(unittest.TestCase):
                         f"{relative_path} should be executable",
                     )
 
+    def test_extracts_zip_members_without_unix_modes(self) -> None:
+        files = {
+            "resources/bin/browseros_server": b"server-binary",
+        }
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            temp_path = Path(temp_dir)
+            archive_path = temp_path / "artifact.zip"
+            destination = temp_path / "output"
+            self._write_artifact_zip(archive_path, files)
+
+            extracted_paths = extract_artifact_zip(archive_path, destination)
+
+            self.assertEqual(len(extracted_paths), len(files))
+            extracted_path = destination / "resources/bin/browseros_server"
+            self.assertEqual(extracted_path.read_bytes(), b"server-binary")
+
+            if os.name != "nt":
+                mode = os.stat(extracted_path).st_mode
+                self.assertTrue(mode & stat.S_IRUSR)
+                self.assertFalse(mode & stat.S_IXUSR)
+
     def test_rejects_missing_declared_files(self) -> None:
         files = {
             "resources/bin/browseros_server": b"server-binary",


### PR DESCRIPTION
## Summary
- Preserve executable permissions from BrowserOS server artifact zips during validated extraction.
- Stop treating every file under resources/bin as executable, which caused Lima guest-agent .gz data files to be rejected by macOS OTA signing.
- Add regression coverage for executable binaries, a non-macOS executable helper, and non-executable resource data.

## Design
The extractor now streams each declared artifact member through checksum validation as before, but looks up the ZipInfo for that member and restores its Unix mode bits after writing. This keeps executable ownership with the producing package in packages/browseros-agent, where per-platform resources are staged, instead of inferring permissions from path names or macOS signing metadata.

## Test plan
- uv run python -m unittest discover build -p '*test.py'\n- git diff --check