### PR TITLE
feat(eval): AGI SDK dashboard with token capture, per-criterion drilldown

### DIFF
--- a/packages/browseros-agent/apps/eval/src/agents/claude-code/index.ts
+++ b/packages/browseros-agent/apps/eval/src/agents/claude-code/index.ts
@@ -2,6 +2,7 @@ import { writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 import { DEFAULT_TIMEOUT_MS } from '../../constants'
 import type { ClaudeCodeAgentConfig, UIMessageStreamEvent } from '../../types'
+import { extractDatasetMetadata } from '../../utils/dataset-metadata'
 import { withEvalTimeout } from '../../utils/with-eval-timeout'
 import type { AgentContext, AgentEvaluator, AgentResult } from '../types'
 import {
@@ -100,6 +101,8 @@ export class ClaudeCodeEvaluator implements AgentEvaluator {
 
     const endTime = Date.now()
     const finalAnswer = parser.getLastText() ?? capture.getLastAssistantText()
+    const tokenUsage = parser.getTokenUsage()
+    const datasetMetadata = extractDatasetMetadata(task.metadata)
     const metadata = {
       query_id: task.query_id,
       dataset: task.dataset,
@@ -118,6 +121,8 @@ export class ClaudeCodeEvaluator implements AgentEvaluator {
         model: agentConfig.model,
       },
       grader_results: {},
+      ...(tokenUsage ? { token_usage: tokenUsage } : {}),
+      ...(datasetMetadata ? { task_metadata: datasetMetadata } : {}),
     }
 
     await capture.trajectorySaver.saveMetadata(metadata)

--- a/packages/browseros-agent/apps/eval/src/agents/claude-code/stream-parser.ts
+++ b/packages/browseros-agent/apps/eval/src/agents/claude-code/stream-parser.ts
@@ -1,11 +1,13 @@
 import { randomUUID } from 'node:crypto'
-import type { UIMessageStreamEvent } from '../../types'
+import type { TokenUsage, UIMessageStreamEvent } from '../../types'
 
 type JsonObject = Record<string, unknown>
 
 export class ClaudeCodeStreamParser {
   private lastText: string | null = null
   private toolCallCount = 0
+  private summedUsage: TokenUsage = emptyUsage()
+  private resultUsage: TokenUsage | null = null
 
   pushLine(line: string): UIMessageStreamEvent[] {
     const trimmed = line.trim()
@@ -26,8 +28,10 @@ export class ClaudeCodeStreamParser {
     if (parsed.type === 'user') {
       return this.parseUserMessage(parsed)
     }
-    if (parsed.type === 'result' && typeof parsed.result === 'string') {
-      this.lastText = parsed.result
+    if (parsed.type === 'result') {
+      if (typeof parsed.result === 'string') this.lastText = parsed.result
+      const usage = extractUsage(parsed.usage)
+      if (usage) this.resultUsage = usage
     }
 
     return []
@@ -41,9 +45,20 @@ export class ClaudeCodeStreamParser {
     return this.toolCallCount
   }
 
+  /** Final token consumption for the run. Prefers the SDK's aggregate (`result.usage`)
+   * when present, otherwise falls back to summing per-message usage. */
+  getTokenUsage(): TokenUsage | null {
+    if (this.resultUsage) return this.resultUsage
+    return hasAnyUsage(this.summedUsage) ? this.summedUsage : null
+  }
+
   private parseAssistantMessage(message: JsonObject): UIMessageStreamEvent[] {
     const content = contentBlocks(message)
     const events: UIMessageStreamEvent[] = []
+
+    const inner = isObject(message.message) ? message.message : message
+    const usage = extractUsage(inner.usage)
+    if (usage) addUsage(this.summedUsage, usage)
 
     for (const block of content) {
       if (block.type === 'text' && typeof block.text === 'string') {
@@ -139,4 +154,56 @@ function stringifyToolContent(content: unknown): string {
   } catch {
     return String(normalized)
   }
+}
+
+function emptyUsage(): TokenUsage {
+  return {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_tokens: 0,
+    cache_creation_tokens: 0,
+  }
+}
+
+function hasAnyUsage(usage: TokenUsage): boolean {
+  return (
+    usage.input_tokens > 0 ||
+    usage.output_tokens > 0 ||
+    usage.cache_read_tokens > 0 ||
+    usage.cache_creation_tokens > 0
+  )
+}
+
+function addUsage(target: TokenUsage, addition: TokenUsage): void {
+  target.input_tokens += addition.input_tokens
+  target.output_tokens += addition.output_tokens
+  target.cache_read_tokens += addition.cache_read_tokens
+  target.cache_creation_tokens += addition.cache_creation_tokens
+}
+
+function readNumber(source: JsonObject, ...keys: string[]): number {
+  for (const key of keys) {
+    const value = source[key]
+    if (typeof value === 'number' && Number.isFinite(value)) return value
+  }
+  return 0
+}
+
+function extractUsage(raw: unknown): TokenUsage | null {
+  if (!isObject(raw)) return null
+  const usage: TokenUsage = {
+    input_tokens: readNumber(raw, 'input_tokens', 'inputTokens'),
+    output_tokens: readNumber(raw, 'output_tokens', 'outputTokens'),
+    cache_read_tokens: readNumber(
+      raw,
+      'cache_read_input_tokens',
+      'cacheReadInputTokens',
+    ),
+    cache_creation_tokens: readNumber(
+      raw,
+      'cache_creation_input_tokens',
+      'cacheCreationInputTokens',
+    ),
+  }
+  return hasAnyUsage(usage) ? usage : null
 }

--- a/packages/browseros-agent/apps/eval/src/agents/single-agent.ts
+++ b/packages/browseros-agent/apps/eval/src/agents/single-agent.ts
@@ -81,6 +81,12 @@ export class SingleAgentEvaluator implements AgentEvaluator {
 
     let agent: AiSdkAgent | null = null
     const tokenUsage: TokenUsage = emptyTokenUsage()
+    // Screenshots are taken in onToolCallFinish (per tool call). Track them by
+    // toolCallId so we can stamp the matching tool-output event in messages.jsonl
+    // with `screenshot: N` — this is what lets the viewer sync the agent stream
+    // to the currently displayed screenshot.
+    const screenshotByToolCallId = new Map<string, number>()
+    let currentToolCallId: string | null = null
 
     try {
       agent = await AiSdkAgent.create({
@@ -104,6 +110,7 @@ export class SingleAgentEvaluator implements AgentEvaluator {
             abortSignal: signal,
 
             experimental_onToolCallStart: ({ toolCall }) => {
+              currentToolCallId = toolCall.toolCallId
               const input = toolCall.input as
                 | Record<string, unknown>
                 | undefined
@@ -123,6 +130,9 @@ export class SingleAgentEvaluator implements AgentEvaluator {
                 const screenshotNum = await capture.screenshot.capture(
                   capture.getActivePageId(),
                 )
+                if (currentToolCallId) {
+                  screenshotByToolCallId.set(currentToolCallId, screenshotNum)
+                }
                 capture.emitEvent(task.query_id, {
                   type: 'screenshot-captured',
                   screenshot: screenshotNum,
@@ -155,8 +165,18 @@ export class SingleAgentEvaluator implements AgentEvaluator {
                     toolCallId: tr.toolCallId,
                     output: tr.output,
                   } as any
-                  await capture.messageLogger.logStreamEvent(outputEvent)
-                  capture.emitEvent(task.query_id, outputEvent)
+                  const screenshot = screenshotByToolCallId.get(tr.toolCallId)
+                  await capture.messageLogger.logStreamEvent(
+                    outputEvent,
+                    screenshot,
+                  )
+                  capture.emitEvent(task.query_id, {
+                    ...outputEvent,
+                    ...(screenshot !== undefined && { screenshot }),
+                  })
+                  if (screenshot !== undefined) {
+                    screenshotByToolCallId.delete(tr.toolCallId)
+                  }
                 }
               }
 

--- a/packages/browseros-agent/apps/eval/src/agents/single-agent.ts
+++ b/packages/browseros-agent/apps/eval/src/agents/single-agent.ts
@@ -9,8 +9,14 @@ import { CdpBackend } from '@browseros/server/browser/backends/cdp'
 import { registry } from '@browseros/server/tools/registry'
 import { CaptchaWaiter } from '../capture/captcha-waiter'
 import { DEFAULT_TIMEOUT_MS } from '../constants'
-import type { TaskMetadata } from '../types'
+import type { TaskMetadata, TokenUsage } from '../types'
+import { extractDatasetMetadata } from '../utils/dataset-metadata'
 import { resolveProviderConfig } from '../utils/resolve-provider-config'
+import {
+  addTokenUsageFromAiSdkStep,
+  emptyTokenUsage,
+  hasAnyTokenUsage,
+} from '../utils/token-usage'
 import { withEvalTimeout } from '../utils/with-eval-timeout'
 import type { AgentContext, AgentEvaluator, AgentResult } from './types'
 
@@ -74,6 +80,7 @@ export class SingleAgentEvaluator implements AgentEvaluator {
       : null
 
     let agent: AiSdkAgent | null = null
+    const tokenUsage: TokenUsage = emptyTokenUsage()
 
     try {
       agent = await AiSdkAgent.create({
@@ -125,7 +132,9 @@ export class SingleAgentEvaluator implements AgentEvaluator {
               }
             },
 
-            onStepFinish: async ({ toolCalls, toolResults, text }) => {
+            onStepFinish: async (step) => {
+              const { toolCalls, toolResults, text } = step
+              addTokenUsageFromAiSdkStep(tokenUsage, step)
               if (toolCalls) {
                 for (const tc of toolCalls) {
                   const inputEvent = {
@@ -173,6 +182,7 @@ export class SingleAgentEvaluator implements AgentEvaluator {
       )
 
       const endTime = Date.now()
+      const datasetMetadata = extractDatasetMetadata(task.metadata)
 
       const metadata: TaskMetadata = {
         query_id: task.query_id,
@@ -191,6 +201,8 @@ export class SingleAgentEvaluator implements AgentEvaluator {
           model: agentConfig.model,
         },
         grader_results: {},
+        ...(hasAnyTokenUsage(tokenUsage) ? { token_usage: tokenUsage } : {}),
+        ...(datasetMetadata ? { task_metadata: datasetMetadata } : {}),
       }
 
       await capture.trajectorySaver.saveMetadata(metadata)

--- a/packages/browseros-agent/apps/eval/src/dashboard/viewer.html
+++ b/packages/browseros-agent/apps/eval/src/dashboard/viewer.html
@@ -598,6 +598,350 @@
   ::-webkit-scrollbar-thumb { background: #30363d; border-radius: 3px; }
   ::-webkit-scrollbar-thumb:hover { background: #484f58; }
 
+  /* ── Tabs ────────────────────────────────────────────────────── */
+  .tabs {
+    background: #161b22;
+    border-bottom: 1px solid #30363d;
+    padding: 0 24px;
+    display: flex;
+    gap: 4px;
+    flex-shrink: 0;
+  }
+  .tab-btn {
+    background: transparent;
+    border: none;
+    border-bottom: 2px solid transparent;
+    color: #8b949e;
+    padding: 10px 16px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    font-family: inherit;
+    transition: color 0.12s, border-color 0.12s;
+  }
+  .tab-btn:hover { color: #e6edf3; }
+  .tab-btn.active {
+    color: #58a6ff;
+    border-bottom-color: #58a6ff;
+  }
+  .tab-content { display: none; flex: 1; flex-direction: column; overflow: hidden; }
+  .tab-content.active { display: flex; }
+
+  /* ── Overview tab ────────────────────────────────────────────── */
+  .overview-scroll {
+    flex: 1;
+    overflow-y: auto;
+    padding: 24px 28px;
+    background: #0d1117;
+  }
+  .overview-section { margin-bottom: 28px; }
+  .overview-section h2 {
+    font-size: 11px;
+    font-weight: 700;
+    color: #8b949e;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    margin-bottom: 12px;
+  }
+  .ov-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 12px;
+    margin-bottom: 28px;
+  }
+  .ov-card {
+    background: #161b22;
+    border: 1px solid #30363d;
+    border-radius: 8px;
+    padding: 14px 16px;
+  }
+  .ov-card-label {
+    font-size: 10px;
+    color: #6e7681;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 700;
+    margin-bottom: 6px;
+  }
+  .ov-card-value {
+    font-size: 22px;
+    color: #e6edf3;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+  }
+  .ov-card-sub {
+    font-size: 11px;
+    color: #8b949e;
+    margin-top: 4px;
+  }
+  .ov-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 12px;
+  }
+  .ov-table th, .ov-table td {
+    text-align: left;
+    padding: 8px 10px;
+    border-bottom: 1px solid #21262d;
+  }
+  .ov-table th {
+    font-size: 10px;
+    color: #6e7681;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 700;
+    background: #161b22;
+    cursor: pointer;
+    user-select: none;
+  }
+  .ov-table th.sortable:hover { color: #e6edf3; }
+  .ov-table th .sort-ind { color: #58a6ff; margin-left: 4px; }
+  .ov-table td { color: #e6edf3; font-variant-numeric: tabular-nums; }
+  .ov-table tr:hover td { background: #161b22; }
+  .ov-rate-bar {
+    display: inline-block;
+    width: 80px;
+    height: 6px;
+    background: #21262d;
+    border-radius: 999px;
+    overflow: hidden;
+    vertical-align: middle;
+    margin-right: 8px;
+  }
+  .ov-rate-fill {
+    height: 100%;
+    background: #3fb950;
+    border-radius: 999px;
+  }
+  .ov-rate-fill.med { background: #f0883e; }
+  .ov-rate-fill.low { background: #f85149; }
+  .ov-diff-cards {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 12px;
+  }
+  .ov-matrix {
+    display: grid;
+    gap: 6px;
+    margin-top: 8px;
+  }
+  .ov-matrix-row {
+    display: grid;
+    grid-template-columns: 110px repeat(3, 1fr);
+    gap: 6px;
+    align-items: center;
+  }
+  .ov-matrix-row.header > div {
+    font-size: 10px;
+    color: #6e7681;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 700;
+    text-align: center;
+  }
+  .ov-matrix-row.header > div:first-child { text-align: left; }
+  .ov-matrix-name {
+    font-size: 12px;
+    color: #e6edf3;
+    font-weight: 600;
+  }
+  .ov-matrix-cell {
+    background: #161b22;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    padding: 10px 8px;
+    text-align: center;
+    font-size: 12px;
+    font-weight: 700;
+    font-variant-numeric: tabular-nums;
+    color: #e6edf3;
+  }
+  .ov-matrix-cell.pass-high { background: rgba(63, 185, 80, 0.15); border-color: rgba(63, 185, 80, 0.35); color: #3fb950; }
+  .ov-matrix-cell.pass-mid { background: rgba(240, 136, 62, 0.12); border-color: rgba(240, 136, 62, 0.3); color: #f0883e; }
+  .ov-matrix-cell.pass-low { background: rgba(248, 81, 73, 0.12); border-color: rgba(248, 81, 73, 0.3); color: #f85149; }
+  .ov-matrix-cell.empty { color: #484f58; background: transparent; border-style: dashed; }
+  .ov-tool-bar {
+    display: inline-block;
+    height: 6px;
+    background: #58a6ff;
+    border-radius: 999px;
+    vertical-align: middle;
+    margin-right: 6px;
+  }
+  .ov-tool-err {
+    background: rgba(248, 81, 73, 0.18);
+    color: #f85149;
+    padding: 2px 6px;
+    border-radius: 4px;
+    font-weight: 600;
+    font-size: 11px;
+  }
+  .ov-donut {
+    display: flex;
+    gap: 24px;
+    align-items: center;
+  }
+  .ov-donut-legend { display: flex; flex-direction: column; gap: 6px; font-size: 12px; color: #e6edf3; }
+  .ov-donut-legend .dot { display: inline-block; width: 10px; height: 10px; border-radius: 50%; margin-right: 8px; vertical-align: middle; }
+
+  /* ── Tasks tab additions ─────────────────────────────────────── */
+  .task-meta-chips {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+    margin-top: 4px;
+  }
+  .task-meta-chip {
+    background: rgba(88, 166, 255, 0.1);
+    color: #58a6ff;
+    border: 1px solid rgba(88, 166, 255, 0.25);
+    border-radius: 999px;
+    padding: 2px 8px;
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: capitalize;
+  }
+  .task-meta-chip.diff-easy { background: rgba(63, 185, 80, 0.12); color: #3fb950; border-color: rgba(63, 185, 80, 0.3); }
+  .task-meta-chip.diff-medium { background: rgba(240, 136, 62, 0.12); color: #f0883e; border-color: rgba(240, 136, 62, 0.3); }
+  .task-meta-chip.diff-hard { background: rgba(248, 81, 73, 0.12); color: #f85149; border-color: rgba(248, 81, 73, 0.3); }
+
+  .criterion-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    margin-top: 8px;
+    max-height: 240px;
+    overflow-y: auto;
+  }
+  .criterion-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 8px;
+    padding: 6px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    background: #0d1117;
+    border: 1px solid #21262d;
+  }
+  .criterion-row.passed { border-color: rgba(63, 185, 80, 0.25); }
+  .criterion-row.failed { border-color: rgba(248, 81, 73, 0.25); background: rgba(248, 81, 73, 0.04); }
+  .criterion-mark { width: 14px; text-align: center; font-weight: 700; flex-shrink: 0; }
+  .criterion-row.passed .criterion-mark { color: #3fb950; }
+  .criterion-row.failed .criterion-mark { color: #f85149; }
+  .criterion-body { flex: 1; color: #e6edf3; line-height: 1.45; word-break: break-word; }
+  .criterion-detail {
+    color: #8b949e;
+    font-family: 'SF Mono', SFMono-Regular, Consolas, monospace;
+    font-size: 11px;
+    line-height: 1.5;
+    margin-top: 4px;
+  }
+  .criterion-diff {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 4px 10px;
+    margin-top: 4px;
+    font-family: 'SF Mono', SFMono-Regular, Consolas, monospace;
+    font-size: 10px;
+  }
+  .criterion-diff .k { color: #6e7681; }
+  .criterion-diff .v { color: #e6edf3; word-break: break-word; }
+  .criterion-soft { display: inline-block; background: rgba(240, 136, 62, 0.18); color: #f0883e; padding: 1px 6px; border-radius: 4px; font-size: 9px; font-weight: 700; margin-left: 6px; }
+
+  .finish-state-panel {
+    margin-top: 12px;
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    background: #0d1117;
+  }
+  .finish-state-toggle {
+    width: 100%;
+    background: transparent;
+    border: none;
+    color: #8b949e;
+    text-align: left;
+    padding: 8px 12px;
+    font-size: 11px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    cursor: pointer;
+    font-family: inherit;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+  }
+  .finish-state-toggle:hover { color: #e6edf3; }
+  .finish-state-body {
+    display: none;
+    padding: 10px 12px;
+    border-top: 1px solid #21262d;
+    max-height: 320px;
+    overflow: auto;
+    font-family: 'SF Mono', SFMono-Regular, Consolas, monospace;
+    font-size: 11px;
+    color: #8b949e;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+  .finish-state-panel.open .finish-state-body { display: block; }
+
+  .stream-controls {
+    display: flex;
+    gap: 6px;
+    padding: 8px 12px;
+    border-bottom: 1px solid #21262d;
+    background: #0d1117;
+    flex-wrap: wrap;
+    align-items: center;
+  }
+  .stream-controls input {
+    flex: 1;
+    min-width: 120px;
+    background: #0d1117;
+    border: 1px solid #30363d;
+    color: #e6edf3;
+    padding: 5px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    font-family: inherit;
+  }
+  .stream-chip {
+    background: #161b22;
+    border: 1px solid #30363d;
+    color: #8b949e;
+    padding: 3px 8px;
+    border-radius: 999px;
+    font-size: 10px;
+    font-weight: 600;
+    cursor: pointer;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+  .stream-chip.active {
+    background: #1c2333;
+    border-color: #58a6ff;
+    color: #58a6ff;
+  }
+  .stream-card.step-active { box-shadow: 0 0 0 1px #58a6ff; }
+
+  /* ── Report tab ──────────────────────────────────────────────── */
+  .report-frame {
+    flex: 1;
+    border: none;
+    width: 100%;
+    background: #fff;
+  }
+  .report-empty {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #6e7681;
+    font-size: 14px;
+    background: #0d1117;
+  }
+
   /* ── Responsive ──────────────────────────────────────────────── */
   @media (max-width: 1200px) {
     .right-panel { width: 300px; min-width: 300px; }
@@ -612,41 +956,69 @@
   <div class="header-sep"></div>
   <span class="header-run" id="header-run"></span>
   <span class="header-date" id="header-date"></span>
-  <a class="header-report" id="header-report" target="_blank" rel="noopener" style="display: none;">Run Report</a>
+  <a class="header-report" id="header-report" target="_blank" rel="noopener" style="display: none;">Open Report</a>
   <div class="header-stats" id="header-stats"></div>
 </div>
 
-<div class="layout" id="layout">
-  <!-- Left sidebar -->
-  <div class="sidebar" id="sidebar">
-    <div class="sidebar-stats" id="sidebar-stats"></div>
-    <div class="sidebar-metrics" id="sidebar-metrics"></div>
-    <div class="sidebar-filter">
-      <input type="text" id="filter-input" placeholder="Search tasks..." autocomplete="off" spellcheck="false" />
-    </div>
-    <div class="task-list" id="task-list"></div>
-  </div>
+<nav class="tabs" id="tabs">
+  <button type="button" class="tab-btn active" data-tab="overview">Overview</button>
+  <button type="button" class="tab-btn" data-tab="tasks">Tasks</button>
+  <button type="button" class="tab-btn" data-tab="report">Report</button>
+</nav>
 
-  <!-- Center: screenshot viewer -->
-  <div class="center-panel" id="center-panel">
-    <div class="placeholder" id="empty-state">
-      <div class="ph-icon">&#128270;</div>
-      <div class="ph-text">Select a task from the sidebar to view screenshots and agent activity</div>
-    </div>
-  </div>
-
-  <!-- Right panel: agent stream -->
-  <div class="right-panel" id="right-panel" style="display: none;">
-    <div class="stream-header">
-      Agent Stream
-      <span class="msg-count" id="stream-count"></span>
-    </div>
-    <div class="stream-body" id="stream-body"></div>
+<!-- Overview tab -->
+<div class="tab-content active" id="tab-overview">
+  <div class="overview-scroll" id="overview-scroll">
+    <div class="placeholder"><div class="ph-text" style="color:#6e7681;">Loading overview...</div></div>
   </div>
 </div>
 
-<!-- Detail bar (shown when a task is selected) -->
-<div class="detail-bar" id="detail-bar" style="display: none;"></div>
+<!-- Tasks tab (the original 3-pane viewer) -->
+<div class="tab-content" id="tab-tasks">
+  <div class="layout" id="layout">
+    <!-- Left sidebar -->
+    <div class="sidebar" id="sidebar">
+      <div class="sidebar-stats" id="sidebar-stats"></div>
+      <div class="sidebar-metrics" id="sidebar-metrics"></div>
+      <div class="sidebar-filter">
+        <input type="text" id="filter-input" placeholder="Search tasks..." autocomplete="off" spellcheck="false" />
+      </div>
+      <div class="task-list" id="task-list"></div>
+    </div>
+
+    <!-- Center: screenshot viewer -->
+    <div class="center-panel" id="center-panel">
+      <div class="placeholder" id="empty-state">
+        <div class="ph-icon">&#128270;</div>
+        <div class="ph-text">Select a task from the sidebar to view screenshots and agent activity</div>
+      </div>
+    </div>
+
+    <!-- Right panel: agent stream -->
+    <div class="right-panel" id="right-panel" style="display: none;">
+      <div class="stream-header">
+        Agent Stream
+        <span class="msg-count" id="stream-count"></span>
+      </div>
+      <div class="stream-controls" id="stream-controls" style="display: none;">
+        <input type="text" id="stream-search" placeholder="Search messages..." autocomplete="off" spellcheck="false" />
+        <button type="button" class="stream-chip active" data-stream-filter="all">All</button>
+        <button type="button" class="stream-chip" data-stream-filter="tool">Tools</button>
+        <button type="button" class="stream-chip" data-stream-filter="error">Errors</button>
+        <button type="button" class="stream-chip" data-stream-filter="reasoning">Reasoning</button>
+      </div>
+      <div class="stream-body" id="stream-body"></div>
+    </div>
+  </div>
+
+  <!-- Detail bar (shown when a task is selected) -->
+  <div class="detail-bar" id="detail-bar" style="display: none;"></div>
+</div>
+
+<!-- Report tab -->
+<div class="tab-content" id="tab-report">
+  <div class="report-empty" id="report-empty">Loading report...</div>
+</div>
 
 <script>
 (() => {
@@ -669,6 +1041,8 @@
   let totalSteps = 0;
   let autoplayTimer = null;
   let isPlaying = false;
+  let streamFilter = 'all';
+  let streamSearch = '';
   const basePath = `runs/${runId}`;
 
   // ── Fetch manifest ────────────────────────────────────────────
@@ -681,11 +1055,50 @@
       manifest = data;
       renderHeader();
       renderSidebar();
+      renderOverview();
+      setupTabs();
       autoSelectFromHash();
     })
     .catch((err) => {
       showFatalError(`Failed to load manifest<br><code>${esc(err.message)}</code>`);
     });
+
+  // ── Tab switching ─────────────────────────────────────────────
+  let activeTab = 'overview';
+  let reportLoaded = false;
+
+  function setupTabs() {
+    document.querySelectorAll('.tab-btn').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        showTab(btn.getAttribute('data-tab'));
+      });
+    });
+
+    // Honor initial hash: #tasks/<queryId> opens Tasks tab; #report opens Report tab
+    const hash = window.location.hash.replace('#', '');
+    if (hash.startsWith('tasks') || hash.length > 0 && !['overview', 'report'].includes(hash)) {
+      showTab('tasks');
+    } else if (hash === 'report') {
+      showTab('report');
+    } else {
+      showTab('overview');
+    }
+  }
+
+  function showTab(name) {
+    if (!['overview', 'tasks', 'report'].includes(name)) name = 'overview';
+    activeTab = name;
+    document.querySelectorAll('.tab-btn').forEach((btn) => {
+      btn.classList.toggle('active', btn.getAttribute('data-tab') === name);
+    });
+    document.querySelectorAll('.tab-content').forEach((el) => {
+      el.classList.toggle('active', el.id === `tab-${name}`);
+    });
+    if (name === 'report' && !reportLoaded) {
+      renderReport();
+      reportLoaded = true;
+    }
+  }
 
   // ── Header rendering ──────────────────────────────────────────
   function renderHeader() {
@@ -744,8 +1157,8 @@
       '<span>' + stats.total + ' total</span>' +
       '<span class="s-pass">' + stats.passed + ' pass</span>' +
       '<span class="s-fail">' + stats.failed + ' fail</span>' +
-      (stats.avgSteps !== null ? '<span>' + fmtCompact(stats.avgSteps) + ' steps/task</span>' : '') +
-      (stats.avgToolCalls !== null ? '<span>' + fmtCompact(stats.avgToolCalls) + ' tools/task</span>' : '');
+      (stats.avgSteps !== null ? `<span>${fmtCompact(stats.avgSteps)} steps/task</span>` : '') +
+      (stats.avgToolCalls !== null ? `<span>${fmtCompact(stats.avgToolCalls)} tools/task</span>` : '');
 
     renderSidebarMetrics(tasks, stats);
 
@@ -830,6 +1243,325 @@
     });
   }
 
+  // ── Overview tab ─────────────────────────────────────────────
+  function renderOverview() {
+    const root = document.getElementById('overview-scroll');
+    const tasks = manifest.tasks || [];
+    if (tasks.length === 0) {
+      root.innerHTML = '<div class="placeholder"><div class="ph-text" style="color:#6e7681;">No tasks in this run.</div></div>';
+      return;
+    }
+
+    const stats = computeStats(tasks);
+    const runMetrics = manifest.metrics || {};
+    const passPct = stats.total > 0 ? Math.round((stats.passed / stats.total) * 100) : 0;
+
+    // Headline cards
+    const tokens = runMetrics.tokenUsage;
+    const avgInputOut = tokens?.avg
+      ? Math.round(tokens.avg.input_tokens + tokens.avg.output_tokens)
+      : null;
+    const totalInputOut = tokens?.total
+      ? Math.round(tokens.total.input_tokens + tokens.total.output_tokens)
+      : null;
+
+    const cardsHtml =
+      '<div class="ov-cards">' +
+        ovCard('Pass rate', `${passPct}%`, `${stats.passed} / ${stats.total}`) +
+        ovCard('Avg duration', stats.avgDurationMs !== null ? fmtDuration(stats.avgDurationMs) : '–', `${stats.total} tasks`) +
+        ovCard('Avg tools / task', stats.avgToolCalls !== null ? fmtCompact(stats.avgToolCalls) : '–', stats.totalToolErrors > 0 ? `${stats.totalToolErrors} errors total` : '') +
+        ovCard('Avg tokens / task', avgInputOut !== null ? fmtTokens(avgInputOut) : '–', totalInputOut !== null ? `${fmtTokens(totalInputOut)} total` : 'not captured') +
+      '</div>';
+
+    const websiteHtml = renderWebsiteSection(tasks);
+    const difficultyHtml = renderDifficultySection(tasks);
+    const matrixHtml = renderWebsiteDifficultyMatrix(tasks);
+    const toolHtml = renderToolUsageSection(runMetrics);
+    const tokenHtml = renderTokenSection(runMetrics, tasks);
+    const terminationHtml = renderTerminationSection(tasks);
+
+    root.innerHTML = cardsHtml + websiteHtml + difficultyHtml + matrixHtml + toolHtml + tokenHtml + terminationHtml;
+
+    // Wire website-row click → switch to tasks tab and filter
+    root.querySelectorAll('[data-website-jump]').forEach((row) => {
+      row.style.cursor = 'pointer';
+      row.addEventListener('click', () => {
+        const website = row.getAttribute('data-website-jump');
+        showTab('tasks');
+        const input = document.getElementById('filter-input');
+        if (input) {
+          input.value = website;
+          renderTaskList(website);
+        }
+      });
+    });
+  }
+
+  function ovCard(label, value, sub) {
+    return (
+      '<div class="ov-card">' +
+        `<div class="ov-card-label">${esc(label)}</div>` +
+        `<div class="ov-card-value">${esc(value)}</div>` +
+        (sub ? `<div class="ov-card-sub">${esc(sub)}</div>` : '') +
+      '</div>'
+    );
+  }
+
+  function renderWebsiteSection(tasks) {
+    const groups = groupBy(tasks, (t) => (t.taskMetadata?.website) || 'unknown');
+    const rows = Object.entries(groups)
+      .map(([website, list]) => {
+        const passed = list.filter((t) => resolveStatus(t) === 'pass').length;
+        const total = list.length;
+        const rate = total > 0 ? passed / total : 0;
+        return { website, total, passed, failed: total - passed, rate };
+      })
+      .sort((a, b) => b.rate - a.rate || b.total - a.total);
+
+    if (rows.length === 1 && rows[0].website === 'unknown') return '';
+
+    const tbody = rows.map((r) => {
+      const pct = Math.round(r.rate * 100);
+      const cls = r.rate >= 0.7 ? '' : r.rate >= 0.4 ? 'med' : 'low';
+      return (
+        `<tr data-website-jump="${escAttr(r.website)}">` +
+          `<td>${esc(r.website)}</td>` +
+          `<td>${r.total}</td>` +
+          `<td><span style="color:#3fb950;">${r.passed}</span></td>` +
+          `<td><span style="color:${r.failed > 0 ? '#f85149' : '#6e7681'};">${r.failed}</span></td>` +
+          `<td><span class="ov-rate-bar"><span class="ov-rate-fill ${cls}" style="width:${pct}%"></span></span><span style="color:#8b949e;">${pct}%</span></td>` +
+        '</tr>'
+      );
+    }).join('');
+
+    return (
+      '<div class="overview-section">' +
+        '<h2>Pass rate by website</h2>' +
+        '<table class="ov-table">' +
+          '<thead><tr><th>Website</th><th>Tasks</th><th>Passed</th><th>Failed</th><th>Pass rate</th></tr></thead>' +
+          `<tbody>${tbody}</tbody>` +
+        '</table>' +
+      '</div>'
+    );
+  }
+
+  function renderDifficultySection(tasks) {
+    const buckets = ['easy', 'medium', 'hard'];
+    const groups = {};
+    let hasAny = false;
+    for (const t of tasks) {
+      const d = (t.taskMetadata?.difficulty) ? String(t.taskMetadata.difficulty).toLowerCase() : null;
+      if (!d) continue;
+      hasAny = true;
+      if (!groups[d]) groups[d] = [];
+      groups[d].push(t);
+    }
+    if (!hasAny) return '';
+
+    const orderedKeys = [...buckets.filter((k) => groups[k]), ...Object.keys(groups).filter((k) => !buckets.includes(k))];
+    const cardsHtml = orderedKeys.map((d) => {
+      const list = groups[d];
+      const passed = list.filter((t) => resolveStatus(t) === 'pass').length;
+      const total = list.length;
+      const pct = total > 0 ? Math.round((passed / total) * 100) : 0;
+      return ovCard(d, `${pct}%`, `${passed} / ${total} passed`);
+    }).join('');
+
+    return (
+      '<div class="overview-section">' +
+        '<h2>Pass rate by difficulty</h2>' +
+        `<div class="ov-diff-cards">${cardsHtml}</div>` +
+      '</div>'
+    );
+  }
+
+  function renderWebsiteDifficultyMatrix(tasks) {
+    const buckets = ['easy', 'medium', 'hard'];
+    const websites = Array.from(new Set(
+      tasks
+        .map((t) => t.taskMetadata?.website)
+        .filter(Boolean)
+    )).sort();
+    if (websites.length === 0) return '';
+
+    const header = (
+      '<div class="ov-matrix-row header">' +
+        '<div>Website</div>' +
+        buckets.map((b) => `<div>${esc(b)}</div>`).join('') +
+      '</div>'
+    );
+
+    const rows = websites.map((site) => {
+      const cells = buckets.map((b) => {
+        const list = tasks.filter((t) =>
+          (t.taskMetadata?.website) === site &&
+          ((t.taskMetadata && String(t.taskMetadata.difficulty || '').toLowerCase()) === b)
+        );
+        if (list.length === 0) return '<div class="ov-matrix-cell empty">—</div>';
+        const passed = list.filter((t) => resolveStatus(t) === 'pass').length;
+        const rate = passed / list.length;
+        const cls = rate >= 0.7 ? 'pass-high' : rate >= 0.4 ? 'pass-mid' : 'pass-low';
+        return `<div class="ov-matrix-cell ${cls}">${passed}/${list.length}</div>`;
+      }).join('');
+      return (
+        '<div class="ov-matrix-row">' +
+          `<div class="ov-matrix-name">${esc(site)}</div>` +
+          cells +
+        '</div>'
+      );
+    }).join('');
+
+    return (
+      '<div class="overview-section">' +
+        '<h2>Website &times; difficulty</h2>' +
+        `<div class="ov-matrix">${header}${rows}</div>` +
+      '</div>'
+    );
+  }
+
+  function renderToolUsageSection(runMetrics) {
+    const perTool = runMetrics.perTool || {};
+    const entries = Object.entries(perTool)
+      .map(([name, stats]) => ({ name, ...stats }))
+      .sort((a, b) => b.calls - a.calls)
+      .slice(0, 20);
+    if (entries.length === 0) return '';
+
+    const maxCalls = Math.max(...entries.map((e) => e.calls), 1);
+    const tbody = entries.map((e) => {
+      const errPct = e.calls > 0 ? (e.errors / e.calls) * 100 : 0;
+      const errCellHtml = e.errors > 0
+        ? `<span class="ov-tool-err">${e.errors}</span> <span style="color:#6e7681;">(${errPct.toFixed(1)}%)</span>`
+        : '<span style="color:#6e7681;">0</span>';
+      const barWidth = Math.max(2, Math.round((e.calls / maxCalls) * 100));
+      return (
+        '<tr>' +
+          `<td><span style="font-family:'SF Mono',monospace;color:#e6edf3;">${esc(e.name)}</span></td>` +
+          `<td><span class="ov-tool-bar" style="width:${barWidth}px"></span>${e.calls}</td>` +
+          `<td>${fmtCompact(e.avgCalls || 0)}</td>` +
+          `<td>${errCellHtml}</td>` +
+        '</tr>'
+      );
+    }).join('');
+
+    return (
+      '<div class="overview-section">' +
+        '<h2>Tool usage</h2>' +
+        '<table class="ov-table">' +
+          '<thead><tr><th>Tool</th><th>Total calls</th><th>Avg / task</th><th>Errors</th></tr></thead>' +
+          `<tbody>${tbody}</tbody>` +
+        '</table>' +
+      '</div>'
+    );
+  }
+
+  function renderTokenSection(runMetrics, tasks) {
+    const tokens = runMetrics.tokenUsage;
+    if (!tokens || !tokens.total) {
+      return (
+        '<div class="overview-section">' +
+          '<h2>Token usage</h2>' +
+          '<div class="ov-card-sub" style="font-size:12px;">No token data captured for this run.</div>' +
+        '</div>'
+      );
+    }
+    const total = tokens.total;
+    const avg = tokens.avg || total;
+    const totalAll = total.input_tokens + total.output_tokens;
+
+    // Find the task that consumed the most input+output tokens
+    let maxTask = null;
+    let maxTotal = 0;
+    for (const t of tasks) {
+      const u = t.metrics?.tokenUsage;
+      if (!u) continue;
+      const sum = (u.input_tokens || 0) + (u.output_tokens || 0);
+      if (sum > maxTotal) { maxTotal = sum; maxTask = t; }
+    }
+
+    const cards =
+      '<div class="ov-cards">' +
+        ovCard('Avg input + output', fmtTokens(Math.round(avg.input_tokens + avg.output_tokens)), `input ${fmtTokens(Math.round(avg.input_tokens))} · output ${fmtTokens(Math.round(avg.output_tokens))}`) +
+        ovCard('Total input + output', fmtTokens(totalAll), `${fmtTokens(total.input_tokens)} in · ${fmtTokens(total.output_tokens)} out`) +
+        ovCard('Cache reads', fmtTokens(total.cache_read_tokens), total.cache_creation_tokens > 0 ? `${fmtTokens(total.cache_creation_tokens)} created` : '') +
+        ovCard('Max task', maxTask ? fmtTokens(maxTotal) : '–', maxTask ? maxTask.queryId : '') +
+      '</div>';
+
+    return (
+      '<div class="overview-section">' +
+        '<h2>Token usage</h2>' +
+        cards +
+      '</div>'
+    );
+  }
+
+  function renderTerminationSection(tasks) {
+    const groups = groupBy(
+      tasks,
+      (t) => (t.metrics?.terminationReason) || t.status || 'unknown',
+    );
+    const legend = Object.entries(groups)
+      .sort((a, b) => b[1].length - a[1].length)
+      .map(([reason, list]) => {
+        const color = terminationColor(reason);
+        return (
+          `<div><span class="dot" style="background:${color}"></span>` +
+          `<span style="color:#e6edf3;">${esc(reason)}</span>` +
+          `<span style="color:#6e7681; margin-left:8px;">${list.length}</span></div>`
+        );
+      }).join('');
+
+    return (
+      '<div class="overview-section">' +
+        '<h2>Termination reasons</h2>' +
+        `<div class="ov-donut-legend">${legend}</div>` +
+      '</div>'
+    );
+  }
+
+  function terminationColor(reason) {
+    switch (reason) {
+      case 'completed': return '#3fb950';
+      case 'max_steps': return '#f0883e';
+      case 'timeout': return '#d29922';
+      case 'error': return '#f85149';
+      case 'pass': return '#3fb950';
+      case 'fail':
+      case 'failed': return '#f85149';
+      default: return '#8b949e';
+    }
+  }
+
+  function groupBy(items, keyFn) {
+    const out = {};
+    for (const item of items) {
+      const key = keyFn(item);
+      if (!key) continue;
+      if (!out[key]) out[key] = [];
+      out[key].push(item);
+    }
+    return out;
+  }
+
+  function fmtTokens(n) {
+    const num = Number(n);
+    if (!Number.isFinite(num) || num === 0) return '0';
+    if (num < 1000) return String(Math.round(num));
+    if (num < 1000000) return `${(num / 1000).toFixed(num >= 10000 ? 0 : 1)}k`;
+    return `${(num / 1000000).toFixed(num >= 10000000 ? 0 : 1)}M`;
+  }
+
+  // ── Report tab ────────────────────────────────────────────────
+  function renderReport() {
+    const container = document.getElementById('tab-report');
+    const url = reportUrl(manifest);
+    if (!url) {
+      container.innerHTML = '<div class="report-empty">No report.html was generated for this run.</div>';
+      return;
+    }
+    container.innerHTML = `<iframe class="report-frame" src="${escAttr(url)}" title="Run report" sandbox="allow-same-origin allow-scripts allow-popups"></iframe>`;
+  }
+
   // Test harness note: these ASCII section markers are used by r2-viewer-compat.test.ts.
   // -- Artifact path resolution
   function taskKey(task) {
@@ -904,6 +1636,8 @@
     // Update URL hash for deep linking
     history.replaceState(null, '', `?run=${runId}#${task.queryId}`);
 
+    if (activeTab !== 'tasks') showTab('tasks');
+
     // Re-render sidebar to update active state
     const filterVal = document.getElementById('filter-input').value;
     renderTaskList(filterVal);
@@ -914,6 +1648,7 @@
     loadTaskMetadata(task);
 
     document.getElementById('right-panel').style.display = '';
+    document.getElementById('stream-controls').style.display = '';
     document.getElementById('detail-bar').style.display = '';
   }
 
@@ -987,6 +1722,7 @@
     }
 
     updateControls();
+    syncStreamToStep(n);
   }
 
   function updateControls() {
@@ -1046,10 +1782,20 @@
     const bar = document.getElementById('detail-bar');
     let html = '';
 
-    // Query
+    // Query + metadata chips
     html += '<div class="db-section query-section">';
     html += '<span class="db-label">Query</span>';
     html += `<span class="db-value">${esc(task.query || 'No query')}</span>`;
+    const meta = task.taskMetadata || {};
+    const chips = [];
+    if (meta.website) chips.push(`<span class="task-meta-chip">${esc(meta.website)}</span>`);
+    if (meta.difficulty) {
+      const cls = `task-meta-chip diff-${String(meta.difficulty).toLowerCase()}`;
+      chips.push(`<span class="${cls}">${esc(meta.difficulty)}</span>`);
+    }
+    if (meta.challenge_type) chips.push(`<span class="task-meta-chip">${esc(meta.challenge_type)}</span>`);
+    if (meta.similar_to) chips.push(`<span class="task-meta-chip">similar to ${esc(meta.similar_to)}</span>`);
+    if (chips.length > 0) html += `<div class="task-meta-chips">${chips.join('')}</div>`;
     html += '</div>';
 
     // Start URL
@@ -1088,6 +1834,16 @@
       html += '</div>';
     }
 
+    // Token badge
+    const tokenUsage = task.metrics?.tokenUsage;
+    if (tokenUsage) {
+      const inOut = (tokenUsage.input_tokens || 0) + (tokenUsage.output_tokens || 0);
+      html += '<div class="db-section">';
+      html += '<span class="db-label">Tokens</span>';
+      html += `<span class="db-value" title="${tokenUsage.input_tokens} in · ${tokenUsage.output_tokens} out · ${tokenUsage.cache_read_tokens} cached">${fmtTokens(inOut)}</span>`;
+      html += '</div>';
+    }
+
     const reportLink = reportUrl(manifest, task);
     if (reportLink) {
       html += '<div class="db-section">';
@@ -1119,6 +1875,41 @@
       html += '</div>';
     }
 
+    // Per-criterion checklist (AGI SDK)
+    if (Array.isArray(task.perCriterion) && task.perCriterion.length > 0) {
+      const passed = task.perCriterion.filter((c) => c.passed).length;
+      const softened = task.perCriterion.filter((c) => c.softened).length;
+      html += '<div class="db-section" style="flex-basis: 100%;">';
+      html += '<span class="db-label">Criteria';
+      html += ` <span style="font-weight:400;text-transform:none;letter-spacing:0;color:#8b949e;">${passed} / ${task.perCriterion.length} passed`;
+      if (softened > 0) html += ` · ${softened} soft`;
+      html += '</span></span>';
+      html += '<div class="criterion-list">';
+      task.perCriterion.forEach((c) => {
+        const cls = c.passed ? 'passed' : 'failed';
+        const mark = c.passed ? '✓' : '✗';
+        const detail = renderCriterionDetail(c);
+        const softTag = c.softened ? '<span class="criterion-soft">SOFT</span>' : '';
+        html += `<div class="criterion-row ${cls}">`;
+        html += `<div class="criterion-mark">${mark}</div>`;
+        html += `<div class="criterion-body">${detail.summary}${softTag}${detail.body}</div>`;
+        html += '</div>';
+      });
+      html += '</div>';
+      html += '</div>';
+    }
+
+    // Finish-state inspector
+    const finishPath = task.paths?.finishState;
+    if (finishPath) {
+      html += '<div class="db-section" style="flex-basis: 100%;">';
+      html += `<div class="finish-state-panel" id="finish-state-panel">`;
+      html += `<button type="button" class="finish-state-toggle" id="finish-state-toggle"><span>Finish-state snapshot</span><span>+</span></button>`;
+      html += `<div class="finish-state-body" id="finish-state-body">Click to load...</div>`;
+      html += '</div>';
+      html += '</div>';
+    }
+
     bar.innerHTML = html;
 
     // Wire up grader pill clicks to show reasoning
@@ -1139,6 +1930,51 @@
         reasoningEl.classList.add('visible');
       });
     });
+
+    // Wire up finish-state toggle
+    const fsToggle = document.getElementById('finish-state-toggle');
+    if (fsToggle) {
+      let fsLoaded = false;
+      fsToggle.addEventListener('click', () => {
+        const panel = document.getElementById('finish-state-panel');
+        const body = document.getElementById('finish-state-body');
+        const isOpen = panel.classList.toggle('open');
+        if (!isOpen) return;
+        if (fsLoaded) return;
+        fsLoaded = true;
+        const url = `${basePath}/${finishPath}`;
+        body.textContent = 'Loading...';
+        fetch(url)
+          .then((res) => { if (!res.ok) throw new Error(`HTTP ${res.status}`); return res.json(); })
+          .then((data) => { body.textContent = JSON.stringify(data, null, 2); })
+          .catch((err) => { body.textContent = `Failed to load: ${err.message}`; });
+      });
+    }
+  }
+
+  function renderCriterionDetail(c) {
+    const detail = c.detail;
+    if (detail && typeof detail === 'object' && (detail.actual_value !== undefined || detail.expected_value !== undefined)) {
+      const expected = stringifyShort(detail.expected_value);
+      const actual = stringifyShort(detail.actual_value);
+      const key = detail.field || detail.key || detail.name || '';
+      const summary = key ? `<strong style="color:#e6edf3;">${esc(String(key))}</strong>` : '';
+      const body =
+        '<div class="criterion-diff">' +
+          '<span class="k">expected</span><span class="v">' + esc(expected) + '</span>' +
+          '<span class="k">actual</span><span class="v">' + esc(actual) + '</span>' +
+        '</div>';
+      return { summary, body };
+    }
+    const text = typeof detail === 'string' ? detail : (detail == null ? '' : JSON.stringify(detail));
+    return { summary: '', body: text ? `<div class="criterion-detail">${esc(text)}</div>` : '' };
+  }
+
+  function stringifyShort(v) {
+    if (v === undefined) return '(undefined)';
+    if (v === null) return 'null';
+    if (typeof v === 'string') return v;
+    try { return JSON.stringify(v); } catch { return String(v); }
   }
 
   // ── Agent stream (right panel) ─────────────────────────────────
@@ -1173,23 +2009,27 @@
     const countEl = document.getElementById('stream-count');
     body.innerHTML = '';
 
-    // Process events into display cards
+    // Process events into display cards, tracking which step each card belongs to.
+    // A `screenshot: N` field on an event means "this card produced screenshot N";
+    // subsequent cards then belong to step N+1 until the next screenshot.
     const cards = [];
     let textBuffer = '';
+    let cardStep = 1;
 
     function flushText() {
       if (textBuffer.trim()) {
-        cards.push({ type: 'reasoning', content: textBuffer.trim() });
+        cards.push({ type: 'reasoning', content: textBuffer.trim(), step: cardStep });
       }
       textBuffer = '';
     }
 
     events.forEach((evt) => {
       const eventType = evt.type || evt.event || '';
+      const evtScreenshot = typeof evt.screenshot === 'number' ? evt.screenshot : undefined;
 
       if (eventType === 'user') {
         flushText();
-        cards.push({ type: 'user-query', content: evt.content || '' });
+        cards.push({ type: 'user-query', content: evt.content || '', step: cardStep });
       } else if (eventType === 'text-delta' || eventType === 'text_delta') {
         textBuffer += (evt.delta || evt.text || evt.content || '');
       } else if (eventType === 'tool-input-available' || eventType === 'tool_use') {
@@ -1197,26 +2037,34 @@
         cards.push({
           type: 'tool-call',
           name: evt.toolName || evt.name || evt.tool || 'unknown',
-          args: evt.input || evt.args || evt.arguments || null
+          args: evt.input || evt.args || evt.arguments || null,
+          step: cardStep,
         });
       } else if (eventType === 'tool-output-available' || eventType === 'tool_result') {
         flushText();
+        const step = evtScreenshot !== undefined ? evtScreenshot : cardStep;
         cards.push({
           type: 'tool-output',
-          content: evt.output || evt.content || evt.result || ''
+          content: evt.output || evt.content || evt.result || '',
+          step,
         });
+        if (evtScreenshot !== undefined) cardStep = evtScreenshot + 1;
       } else if (eventType === 'tool-output-error' || eventType === 'tool-input-error' || eventType === 'error') {
         flushText();
+        const step = evtScreenshot !== undefined ? evtScreenshot : cardStep;
         cards.push({
           type: 'tool-error',
-          content: evt.error || evt.message || evt.content || 'Unknown error'
+          content: evt.error || evt.message || evt.content || 'Unknown error',
+          step,
         });
+        if (evtScreenshot !== undefined) cardStep = evtScreenshot + 1;
       } else if (eventType === 'content_block_start' && evt.content_block && evt.content_block.type === 'tool_use') {
         flushText();
         cards.push({
           type: 'tool-call',
           name: evt.content_block.name || 'unknown',
-          args: null
+          args: null,
+          step: cardStep,
         });
       }
     });
@@ -1233,6 +2081,8 @@
     cards.forEach((card) => {
       const el = document.createElement('div');
       el.className = 'stream-card';
+      el.setAttribute('data-step', String(card.step || 0));
+      el.setAttribute('data-kind', card.type);
 
       if (card.type === 'user-query') {
         el.classList.add('reasoning');
@@ -1303,9 +2153,69 @@
       body.appendChild(el);
     });
 
+    applyStreamFilters();
+    syncStreamToStep(currentStep);
+
     // Auto-scroll to bottom
     body.scrollTop = body.scrollHeight;
   }
+
+  function applyStreamFilters() {
+    const body = document.getElementById('stream-body');
+    if (!body) return;
+    const search = (streamSearch || '').toLowerCase();
+    const cards = body.querySelectorAll('.stream-card');
+    cards.forEach((el) => {
+      const kind = el.getAttribute('data-kind') || '';
+      let match = true;
+      if (streamFilter === 'tool') {
+        match = (kind === 'tool-call' || kind === 'tool-output');
+      } else if (streamFilter === 'error') {
+        match = (kind === 'tool-error');
+      } else if (streamFilter === 'reasoning') {
+        match = (kind === 'reasoning' || kind === 'user-query');
+      }
+      if (match && search) {
+        match = (el.textContent || '').toLowerCase().indexOf(search) !== -1;
+      }
+      el.style.display = match ? '' : 'none';
+    });
+  }
+
+  function syncStreamToStep(step) {
+    const body = document.getElementById('stream-body');
+    if (!body) return;
+    const cards = body.querySelectorAll('.stream-card');
+    let firstActive = null;
+    cards.forEach((el) => {
+      const s = parseInt(el.getAttribute('data-step') || '0', 10);
+      const isActive = s === step;
+      el.classList.toggle('step-active', isActive);
+      if (isActive && !firstActive) firstActive = el;
+    });
+    if (firstActive) firstActive.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+  }
+
+  // Wire stream filter chips + search (idempotent — fine to call on every load)
+  function wireStreamControls() {
+    document.querySelectorAll('[data-stream-filter]').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        streamFilter = btn.getAttribute('data-stream-filter');
+        document.querySelectorAll('[data-stream-filter]').forEach((b) => {
+          b.classList.toggle('active', b === btn);
+        });
+        applyStreamFilters();
+      });
+    });
+    const searchInput = document.getElementById('stream-search');
+    if (searchInput) {
+      searchInput.addEventListener('input', () => {
+        streamSearch = searchInput.value;
+        applyStreamFilters();
+      });
+    }
+  }
+  wireStreamControls();
 
   // ── Load task metadata for rich grader details ──────────────────
   function loadTaskMetadata(task) {

--- a/packages/browseros-agent/apps/eval/src/dashboard/viewer.html
+++ b/packages/browseros-agent/apps/eval/src/dashboard/viewer.html
@@ -813,6 +813,21 @@
     max-height: 240px;
     overflow-y: auto;
   }
+  .criterion-list.collapsed { display: none; }
+  .criterion-toggle {
+    cursor: pointer;
+    user-select: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+  }
+  .criterion-toggle .chevron {
+    display: inline-block;
+    transition: transform 0.15s;
+    color: #6e7681;
+    font-size: 9px;
+  }
+  .criterion-toggle.open .chevron { transform: rotate(90deg); }
   .criterion-row {
     display: flex;
     align-items: flex-start;
@@ -1875,16 +1890,20 @@
       html += '</div>';
     }
 
-    // Per-criterion checklist (AGI SDK)
+    // Per-criterion checklist (AGI SDK) — collapsible, defaults to collapsed
     if (Array.isArray(task.perCriterion) && task.perCriterion.length > 0) {
       const passed = task.perCriterion.filter((c) => c.passed).length;
       const softened = task.perCriterion.filter((c) => c.softened).length;
+      const failed = task.perCriterion.length - passed;
       html += '<div class="db-section" style="flex-basis: 100%;">';
-      html += '<span class="db-label">Criteria';
+      html += '<span class="db-label criterion-toggle" id="criterion-toggle">';
+      html += '<span class="chevron">&#9656;</span>';
+      html += 'Criteria';
       html += ` <span style="font-weight:400;text-transform:none;letter-spacing:0;color:#8b949e;">${passed} / ${task.perCriterion.length} passed`;
+      if (failed > 0) html += ` · <span style="color:#f85149;">${failed} failed</span>`;
       if (softened > 0) html += ` · ${softened} soft`;
       html += '</span></span>';
-      html += '<div class="criterion-list">';
+      html += '<div class="criterion-list collapsed" id="criterion-list">';
       task.perCriterion.forEach((c) => {
         const cls = c.passed ? 'passed' : 'failed';
         const mark = c.passed ? '✓' : '✗';
@@ -1948,6 +1967,16 @@
           .then((res) => { if (!res.ok) throw new Error(`HTTP ${res.status}`); return res.json(); })
           .then((data) => { body.textContent = JSON.stringify(data, null, 2); })
           .catch((err) => { body.textContent = `Failed to load: ${err.message}`; });
+      });
+    }
+
+    // Wire up criterion checklist toggle
+    const critToggle = document.getElementById('criterion-toggle');
+    const critList = document.getElementById('criterion-list');
+    if (critToggle && critList) {
+      critToggle.addEventListener('click', () => {
+        const isOpen = critToggle.classList.toggle('open');
+        critList.classList.toggle('collapsed', !isOpen);
       });
     }
   }

--- a/packages/browseros-agent/apps/eval/src/publishing/r2-publisher.ts
+++ b/packages/browseros-agent/apps/eval/src/publishing/r2-publisher.ts
@@ -6,8 +6,10 @@ import {
   S3Client,
 } from '@aws-sdk/client-s3'
 import { readTaskMetrics } from '../reporting/task-metrics'
+import type { TaskDatasetMetadata } from '../types'
 import {
   buildViewerManifest,
+  type ViewerCriterion,
   type ViewerManifestTaskInput,
 } from '../viewer/viewer-manifest'
 import type {
@@ -173,6 +175,33 @@ async function collectRunRootFiles(runDir: string): Promise<UploadJob[]> {
     })
 }
 
+function extractPerCriterion(
+  meta: Record<string, unknown>,
+): ViewerCriterion[] | undefined {
+  const graders = meta.grader_results as
+    | Record<string, { details?: { per_criterion?: unknown } }>
+    | undefined
+  const list = graders?.agisdk_state_diff?.details?.per_criterion
+  if (!Array.isArray(list) || list.length === 0) return undefined
+
+  const out: ViewerCriterion[] = []
+  for (const entry of list) {
+    if (entry && typeof entry === 'object') {
+      const e = entry as {
+        passed?: unknown
+        softened?: unknown
+        detail?: unknown
+      }
+      out.push({
+        passed: e.passed === true,
+        ...(e.softened === true ? { softened: true } : {}),
+        detail: e.detail,
+      })
+    }
+  }
+  return out
+}
+
 function statusFromMetadata(meta: Record<string, unknown>): string {
   return meta.termination_reason === 'completed'
     ? 'completed'
@@ -304,6 +333,9 @@ export class R2Publisher {
         })
       }
 
+      const taskMetadata = meta.task_metadata as TaskDatasetMetadata | undefined
+      const perCriterion = extractPerCriterion(meta)
+      const finalAnswer = meta.final_answer
       manifestTasks.push({
         queryId: (meta.query_id as string | undefined) || taskId,
         artifactId: taskId,
@@ -317,6 +349,11 @@ export class R2Publisher {
           (meta.grader_results as ViewerManifestTaskInput['graderResults']) ||
           {},
         metrics: await readTaskMetrics(taskPath, meta, screenshotCount),
+        ...(taskMetadata ? { taskMetadata } : {}),
+        ...(perCriterion ? { perCriterion } : {}),
+        ...(typeof finalAnswer === 'string' || finalAnswer === null
+          ? { finalAnswer: finalAnswer as string | null }
+          : {}),
       })
     }
 

--- a/packages/browseros-agent/apps/eval/src/reporting/task-metrics.ts
+++ b/packages/browseros-agent/apps/eval/src/reporting/task-metrics.ts
@@ -1,5 +1,21 @@
 import { readdir, readFile, stat } from 'node:fs/promises'
 import { join } from 'node:path'
+import type { TokenUsage } from '../types'
+
+export interface PerToolCounts {
+  calls: number
+  errors: number
+}
+
+export interface PerToolRunStats extends PerToolCounts {
+  avgCalls: number
+}
+
+export interface CriterionSummary {
+  total: number
+  passed: number
+  softened: number
+}
 
 export interface EvalTaskMetrics {
   durationMs: number
@@ -7,6 +23,10 @@ export interface EvalTaskMetrics {
   screenshots: number
   toolCalls: number
   toolErrors: number
+  perTool: Record<string, PerToolCounts>
+  tokenUsage?: TokenUsage
+  criteria?: CriterionSummary
+  terminationReason?: string
 }
 
 export interface EvalRunMetrics {
@@ -19,6 +39,17 @@ export interface EvalRunMetrics {
   avgToolCalls: number
   totalToolErrors: number
   avgToolErrors: number
+  perTool: Record<string, PerToolRunStats>
+  tokenUsage?: {
+    total: TokenUsage
+    avg: TokenUsage
+    maxInputOutputTotal?: number
+  }
+  criteria?: {
+    totalCriteria: number
+    passedCriteria: number
+    softenedCriteria: number
+  }
 }
 
 export interface EvalTaskMetricSummary {
@@ -39,59 +70,237 @@ interface TaskDirEntry {
   taskPath: string
 }
 
+/** Strip the MCP transport prefix so different agent backends report the same tool. */
+export function normalizeToolName(rawName: string): string {
+  if (rawName.startsWith('mcp__browseros__')) {
+    return rawName.slice('mcp__browseros__'.length)
+  }
+  if (rawName.startsWith('mcp__')) {
+    const parts = rawName.split('__')
+    return parts[parts.length - 1] ?? rawName
+  }
+  return rawName
+}
+
 function numberValue(value: unknown): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : 0
 }
 
-export function countMessageMetrics(messagesJsonl: string): {
+interface MessageMetrics {
   toolCalls: number
   toolErrors: number
-} {
+  perTool: Record<string, PerToolCounts>
+}
+
+export function countMessageMetrics(messagesJsonl: string): MessageMetrics {
   let toolCalls = 0
   let toolErrors = 0
+  const perTool: Record<string, PerToolCounts> = {}
+  const toolNameById = new Map<string, string>()
+
+  function bump(name: string, field: keyof PerToolCounts): void {
+    const normalized = normalizeToolName(name)
+    if (!perTool[normalized]) perTool[normalized] = { calls: 0, errors: 0 }
+    perTool[normalized][field]++
+  }
 
   for (const line of messagesJsonl.split('\n')) {
     const trimmed = line.trim()
     if (!trimmed) continue
     try {
-      const event = JSON.parse(trimmed) as { type?: unknown }
-      if (event.type === 'tool-input-available') toolCalls++
-      if (event.type === 'tool-output-error') toolErrors++
+      const event = JSON.parse(trimmed) as {
+        type?: unknown
+        toolName?: unknown
+        toolCallId?: unknown
+      }
+      if (event.type === 'tool-input-available') {
+        toolCalls++
+        const name =
+          typeof event.toolName === 'string' ? event.toolName : 'unknown'
+        if (typeof event.toolCallId === 'string') {
+          toolNameById.set(event.toolCallId, name)
+        }
+        bump(name, 'calls')
+      } else if (event.type === 'tool-output-error') {
+        toolErrors++
+        const name =
+          (typeof event.toolCallId === 'string'
+            ? toolNameById.get(event.toolCallId)
+            : undefined) ?? 'unknown'
+        bump(name, 'errors')
+      }
     } catch {
       // Ignore malformed telemetry lines; the raw artifact is still uploaded.
     }
   }
 
-  return { toolCalls, toolErrors }
+  return { toolCalls, toolErrors, perTool }
+}
+
+function extractTokenUsage(
+  metadata: Record<string, unknown>,
+): TokenUsage | undefined {
+  const raw = metadata.token_usage
+  if (!raw || typeof raw !== 'object') return undefined
+  const obj = raw as Record<string, unknown>
+  const usage: TokenUsage = {
+    input_tokens: numberValue(obj.input_tokens),
+    output_tokens: numberValue(obj.output_tokens),
+    cache_read_tokens: numberValue(obj.cache_read_tokens),
+    cache_creation_tokens: numberValue(obj.cache_creation_tokens),
+  }
+  const total =
+    usage.input_tokens +
+    usage.output_tokens +
+    usage.cache_read_tokens +
+    usage.cache_creation_tokens
+  return total > 0 ? usage : undefined
+}
+
+function extractCriterionSummary(
+  metadata: Record<string, unknown>,
+): CriterionSummary | undefined {
+  const graders = metadata.grader_results as
+    | Record<string, { details?: { per_criterion?: unknown } }>
+    | undefined
+  if (!graders) return undefined
+  const agisdk = graders.agisdk_state_diff
+  const list = agisdk?.details?.per_criterion
+  if (!Array.isArray(list) || list.length === 0) return undefined
+
+  let passed = 0
+  let softened = 0
+  for (const entry of list) {
+    if (entry && typeof entry === 'object') {
+      const e = entry as { passed?: unknown; softened?: unknown }
+      if (e.passed === true) passed++
+      if (e.softened === true) softened++
+    }
+  }
+  return { total: list.length, passed, softened }
 }
 
 export function buildTaskMetrics(
   metadata: Record<string, unknown>,
-  messageMetrics: { toolCalls: number; toolErrors: number },
+  messageMetrics: MessageMetrics,
   screenshotCount = 0,
 ): EvalTaskMetrics {
   const screenshots = numberValue(metadata.screenshot_count) || screenshotCount
+  const tokenUsage = extractTokenUsage(metadata)
+  const criteria = extractCriterionSummary(metadata)
+  const terminationReason =
+    typeof metadata.termination_reason === 'string'
+      ? metadata.termination_reason
+      : undefined
   return {
     durationMs: numberValue(metadata.total_duration_ms),
     steps: numberValue(metadata.total_steps) || screenshots,
     screenshots,
     toolCalls: messageMetrics.toolCalls,
     toolErrors: messageMetrics.toolErrors,
+    perTool: messageMetrics.perTool,
+    ...(tokenUsage ? { tokenUsage } : {}),
+    ...(criteria ? { criteria } : {}),
+    ...(terminationReason ? { terminationReason } : {}),
+  }
+}
+
+function emptyUsage(): TokenUsage {
+  return {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_tokens: 0,
+    cache_creation_tokens: 0,
+  }
+}
+
+function sumUsage(into: TokenUsage, addition: TokenUsage): void {
+  into.input_tokens += addition.input_tokens
+  into.output_tokens += addition.output_tokens
+  into.cache_read_tokens += addition.cache_read_tokens
+  into.cache_creation_tokens += addition.cache_creation_tokens
+}
+
+function divUsage(usage: TokenUsage, count: number): TokenUsage {
+  if (count <= 0) return emptyUsage()
+  return {
+    input_tokens: usage.input_tokens / count,
+    output_tokens: usage.output_tokens / count,
+    cache_read_tokens: usage.cache_read_tokens / count,
+    cache_creation_tokens: usage.cache_creation_tokens / count,
   }
 }
 
 export function buildRunMetrics(metrics: EvalTaskMetrics[]): EvalRunMetrics {
   const taskCount = metrics.length
-  const totalDurationMs = metrics.reduce((sum, metric) => {
-    return sum + metric.durationMs
-  }, 0)
+  const totalDurationMs = metrics.reduce(
+    (sum, metric) => sum + metric.durationMs,
+    0,
+  )
   const totalSteps = metrics.reduce((sum, metric) => sum + metric.steps, 0)
-  const totalToolCalls = metrics.reduce((sum, metric) => {
-    return sum + metric.toolCalls
-  }, 0)
-  const totalToolErrors = metrics.reduce((sum, metric) => {
-    return sum + metric.toolErrors
-  }, 0)
+  const totalToolCalls = metrics.reduce(
+    (sum, metric) => sum + metric.toolCalls,
+    0,
+  )
+  const totalToolErrors = metrics.reduce(
+    (sum, metric) => sum + metric.toolErrors,
+    0,
+  )
+
+  // Aggregate per-tool counts across all tasks
+  const perToolTotals: Record<string, PerToolCounts> = {}
+  for (const m of metrics) {
+    for (const [tool, counts] of Object.entries(m.perTool ?? {})) {
+      if (!perToolTotals[tool]) perToolTotals[tool] = { calls: 0, errors: 0 }
+      perToolTotals[tool].calls += counts.calls
+      perToolTotals[tool].errors += counts.errors
+    }
+  }
+  const perTool: Record<string, PerToolRunStats> = {}
+  for (const [tool, counts] of Object.entries(perToolTotals)) {
+    perTool[tool] = {
+      ...counts,
+      avgCalls: taskCount > 0 ? counts.calls / taskCount : 0,
+    }
+  }
+
+  // Aggregate token usage
+  let tokenUsage: EvalRunMetrics['tokenUsage']
+  const withTokens = metrics.filter(
+    (m): m is EvalTaskMetrics & { tokenUsage: TokenUsage } =>
+      m.tokenUsage !== undefined,
+  )
+  if (withTokens.length > 0) {
+    const total = emptyUsage()
+    let maxInputOutputTotal = 0
+    for (const m of withTokens) {
+      sumUsage(total, m.tokenUsage)
+      const t = m.tokenUsage.input_tokens + m.tokenUsage.output_tokens
+      if (t > maxInputOutputTotal) maxInputOutputTotal = t
+    }
+    tokenUsage = {
+      total,
+      avg: divUsage(total, withTokens.length),
+      maxInputOutputTotal,
+    }
+  }
+
+  // Aggregate criteria
+  let criteria: EvalRunMetrics['criteria']
+  const withCriteria = metrics.filter((m) => m.criteria !== undefined)
+  if (withCriteria.length > 0) {
+    let totalCriteria = 0
+    let passedCriteria = 0
+    let softenedCriteria = 0
+    for (const m of withCriteria) {
+      const c = m.criteria
+      if (!c) continue
+      totalCriteria += c.total
+      passedCriteria += c.passed
+      softenedCriteria += c.softened
+    }
+    criteria = { totalCriteria, passedCriteria, softenedCriteria }
+  }
 
   return {
     taskCount,
@@ -103,6 +312,9 @@ export function buildRunMetrics(metrics: EvalTaskMetrics[]): EvalRunMetrics {
     avgToolCalls: taskCount > 0 ? totalToolCalls / taskCount : 0,
     totalToolErrors,
     avgToolErrors: taskCount > 0 ? totalToolErrors / taskCount : 0,
+    perTool,
+    ...(tokenUsage ? { tokenUsage } : {}),
+    ...(criteria ? { criteria } : {}),
   }
 }
 
@@ -113,7 +325,13 @@ export async function readTaskMetrics(
 ): Promise<EvalTaskMetrics> {
   const messages = await readFile(join(taskPath, 'messages.jsonl'), 'utf-8')
     .then(countMessageMetrics)
-    .catch(() => ({ toolCalls: 0, toolErrors: 0 }))
+    .catch(
+      (): MessageMetrics => ({
+        toolCalls: 0,
+        toolErrors: 0,
+        perTool: {},
+      }),
+    )
   return buildTaskMetrics(metadata, messages, screenshotCount)
 }
 

--- a/packages/browseros-agent/apps/eval/src/types/index.ts
+++ b/packages/browseros-agent/apps/eval/src/types/index.ts
@@ -49,8 +49,12 @@ export {
   AgentResultSchema,
   type GraderResult,
   GraderResultSchema,
+  type TaskDatasetMetadata,
+  TaskDatasetMetadataSchema,
   type TaskMetadata,
   TaskMetadataSchema,
+  type TokenUsage,
+  TokenUsageSchema,
 } from './result'
 // Task types
 export {

--- a/packages/browseros-agent/apps/eval/src/types/result.ts
+++ b/packages/browseros-agent/apps/eval/src/types/result.ts
@@ -18,6 +18,24 @@ const AgentConfigMetaSchema = z
   })
   .passthrough()
 
+// LLM token consumption for the task (summed across all LLM calls)
+export const TokenUsageSchema = z.object({
+  input_tokens: z.number(),
+  output_tokens: z.number(),
+  cache_read_tokens: z.number(),
+  cache_creation_tokens: z.number(),
+})
+
+// Dataset-derived metadata passed through to the task (AGI SDK fields, etc.)
+export const TaskDatasetMetadataSchema = z
+  .object({
+    website: z.string().optional(),
+    difficulty: z.string().optional(),
+    challenge_type: z.string().optional(),
+    similar_to: z.string().optional(),
+  })
+  .passthrough()
+
 // Task metadata (output)
 export const TaskMetadataSchema = z.object({
   query_id: z.string(),
@@ -35,6 +53,8 @@ export const TaskMetadataSchema = z.object({
   device_pixel_ratio: z.number().optional(),
   agent_config: AgentConfigMetaSchema,
   grader_results: z.record(GraderResultSchema),
+  token_usage: TokenUsageSchema.optional(),
+  task_metadata: TaskDatasetMetadataSchema.optional(),
 })
 
 // Agent result
@@ -48,3 +68,5 @@ export const AgentResultSchema = z.object({
 export type GraderResult = z.infer<typeof GraderResultSchema>
 export type TaskMetadata = z.infer<typeof TaskMetadataSchema>
 export type AgentResult = z.infer<typeof AgentResultSchema>
+export type TokenUsage = z.infer<typeof TokenUsageSchema>
+export type TaskDatasetMetadata = z.infer<typeof TaskDatasetMetadataSchema>

--- a/packages/browseros-agent/apps/eval/src/utils/dataset-metadata.ts
+++ b/packages/browseros-agent/apps/eval/src/utils/dataset-metadata.ts
@@ -1,0 +1,34 @@
+import type { TaskDatasetMetadata, TaskInputMetadata } from '../types'
+
+/** Extract dataset-derived metadata (website/difficulty/challenge_type/similar_to)
+ * that we want to surface in the viewer. AGI SDK puts these under
+ * `metadata.additional`; the website also lives at `metadata.website`. */
+export function extractDatasetMetadata(
+  input: TaskInputMetadata | undefined,
+): TaskDatasetMetadata | undefined {
+  if (!input) return undefined
+
+  const additional = input.additional ?? {}
+  const result: TaskDatasetMetadata = {}
+
+  const website = pickString(input.website, additional.website)
+  if (website) result.website = website
+
+  const difficulty = pickString(additional.difficulty)
+  if (difficulty) result.difficulty = difficulty
+
+  const challengeType = pickString(additional.challenge_type)
+  if (challengeType) result.challenge_type = challengeType
+
+  const similarTo = pickString(additional.similar_to)
+  if (similarTo) result.similar_to = similarTo
+
+  return Object.keys(result).length > 0 ? result : undefined
+}
+
+function pickString(...candidates: unknown[]): string | undefined {
+  for (const value of candidates) {
+    if (typeof value === 'string' && value.length > 0) return value
+  }
+  return undefined
+}

--- a/packages/browseros-agent/apps/eval/src/utils/token-usage.ts
+++ b/packages/browseros-agent/apps/eval/src/utils/token-usage.ts
@@ -1,0 +1,69 @@
+import type { TokenUsage } from '../types'
+
+export function emptyTokenUsage(): TokenUsage {
+  return {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_tokens: 0,
+    cache_creation_tokens: 0,
+  }
+}
+
+export function hasAnyTokenUsage(usage: TokenUsage): boolean {
+  return (
+    usage.input_tokens > 0 ||
+    usage.output_tokens > 0 ||
+    usage.cache_read_tokens > 0 ||
+    usage.cache_creation_tokens > 0
+  )
+}
+
+/** Add usage from a Vercel AI SDK step (onStepFinish/result.usage) into the
+ * running task total. Field names changed across AI SDK versions, so we read
+ * both snake_case and camelCase variants defensively. */
+export function addTokenUsageFromAiSdkStep(
+  target: TokenUsage,
+  step: { usage?: unknown } | null | undefined,
+): void {
+  const usage = step?.usage
+  if (!usage || typeof usage !== 'object') return
+  const raw = usage as Record<string, unknown>
+
+  target.input_tokens += readNumber(
+    raw,
+    'inputTokens',
+    'input_tokens',
+    'promptTokens',
+    'prompt_tokens',
+  )
+  target.output_tokens += readNumber(
+    raw,
+    'outputTokens',
+    'output_tokens',
+    'completionTokens',
+    'completion_tokens',
+  )
+  target.cache_read_tokens += readNumber(
+    raw,
+    'cacheReadInputTokens',
+    'cache_read_input_tokens',
+    'cachedInputTokens',
+    'cached_input_tokens',
+  )
+  target.cache_creation_tokens += readNumber(
+    raw,
+    'cacheCreationInputTokens',
+    'cache_creation_input_tokens',
+  )
+}
+
+function readNumber(
+  source: Record<string, unknown>,
+  ...keys: string[]
+): number {
+  for (const key of keys) {
+    const value = source[key]
+    if (typeof value === 'number' && Number.isFinite(value)) return value
+  }
+  return 0
+}

--- a/packages/browseros-agent/apps/eval/src/viewer/viewer-manifest.ts
+++ b/packages/browseros-agent/apps/eval/src/viewer/viewer-manifest.ts
@@ -3,9 +3,17 @@ import {
   type EvalRunMetrics,
   type EvalTaskMetrics,
 } from '../reporting/task-metrics'
-import type { GraderResult } from '../types'
+import type { GraderResult, TaskDatasetMetadata } from '../types'
 
-export const VIEWER_MANIFEST_SCHEMA_VERSION = 2
+export const VIEWER_MANIFEST_SCHEMA_VERSION = 3
+
+/** Per-criterion entry surfaced from the agisdk_state_diff grader. */
+export interface ViewerCriterion {
+  passed: boolean
+  softened?: boolean
+  /** Free-form string from the grader, OR a structured `{ actual_value, expected_value }` object. */
+  detail: unknown
+}
 
 export interface ViewerManifestTaskPaths {
   attempt: string
@@ -15,6 +23,7 @@ export interface ViewerManifestTaskPaths {
   grades: string
   screenshots: string
   graderArtifacts: string
+  finishState?: string
 }
 
 export interface ViewerManifestTaskInput {
@@ -27,6 +36,9 @@ export interface ViewerManifestTaskInput {
   screenshotCount: number
   metrics?: EvalTaskMetrics
   graderResults: Record<string, GraderResult>
+  taskMetadata?: TaskDatasetMetadata
+  perCriterion?: ViewerCriterion[]
+  finalAnswer?: string | null
 }
 
 export interface ViewerManifestTask
@@ -70,6 +82,18 @@ function taskPaths(queryId: string): ViewerManifestTaskPaths {
     grades: `tasks/${queryId}/grades.json`,
     screenshots: `tasks/${queryId}/screenshots`,
     graderArtifacts: `tasks/${queryId}/grader-artifacts`,
+    finishState: `tasks/${queryId}/grader-artifacts/agisdk_state_diff/finish-state.json`,
+  }
+}
+
+function defaultMetrics(screenshotCount: number): EvalTaskMetrics {
+  return {
+    durationMs: 0,
+    steps: screenshotCount,
+    screenshots: screenshotCount,
+    toolCalls: 0,
+    toolErrors: 0,
+    perTool: {},
   }
 }
 
@@ -82,11 +106,8 @@ export function buildViewerManifest(
     const metrics =
       publicTask.metrics ??
       ({
+        ...defaultMetrics(publicTask.screenshotCount),
         durationMs: publicTask.durationMs,
-        steps: publicTask.screenshotCount,
-        screenshots: publicTask.screenshotCount,
-        toolCalls: 0,
-        toolErrors: 0,
       } satisfies EvalTaskMetrics)
 
     return {

--- a/packages/browseros-agent/apps/eval/tests/agents/claude-code-stream-parser.test.ts
+++ b/packages/browseros-agent/apps/eval/tests/agents/claude-code-stream-parser.test.ts
@@ -90,6 +90,72 @@ describe('ClaudeCodeStreamParser', () => {
     expect(parser.getLastText()).toBe('Final answer')
   })
 
+  it('returns null token usage when no usage data is seen', () => {
+    const parser = new ClaudeCodeStreamParser()
+    parser.pushLine(
+      JSON.stringify({
+        type: 'assistant',
+        message: { content: [{ type: 'text', text: 'hi' }] },
+      }),
+    )
+    expect(parser.getTokenUsage()).toBeNull()
+  })
+
+  it('accumulates per-assistant usage and prefers the result-message aggregate', () => {
+    const parser = new ClaudeCodeStreamParser()
+    parser.pushLine(
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [{ type: 'text', text: 'step 1' }],
+          usage: {
+            input_tokens: 100,
+            output_tokens: 25,
+            cache_read_input_tokens: 500,
+            cache_creation_input_tokens: 10,
+          },
+        },
+      }),
+    )
+    parser.pushLine(
+      JSON.stringify({
+        type: 'assistant',
+        message: {
+          content: [{ type: 'text', text: 'step 2' }],
+          usage: { input_tokens: 50, output_tokens: 30 },
+        },
+      }),
+    )
+    // No result usage → falls back to the running sum
+    expect(parser.getTokenUsage()).toEqual({
+      input_tokens: 150,
+      output_tokens: 55,
+      cache_read_tokens: 500,
+      cache_creation_tokens: 10,
+    })
+
+    // Result-line usage overrides the sum
+    parser.pushLine(
+      JSON.stringify({
+        type: 'result',
+        subtype: 'success',
+        result: 'done',
+        usage: {
+          input_tokens: 200,
+          output_tokens: 60,
+          cache_read_input_tokens: 1000,
+          cache_creation_input_tokens: 25,
+        },
+      }),
+    )
+    expect(parser.getTokenUsage()).toEqual({
+      input_tokens: 200,
+      output_tokens: 60,
+      cache_read_tokens: 1000,
+      cache_creation_tokens: 25,
+    })
+  })
+
   it('identifies BrowserOS MCP tools that should trigger screenshots', () => {
     expect(
       shouldCaptureScreenshotForTool('mcp__browseros__navigate_page'),

--- a/packages/browseros-agent/apps/eval/tests/publishing/r2-publisher.test.ts
+++ b/packages/browseros-agent/apps/eval/tests/publishing/r2-publisher.test.ts
@@ -134,7 +134,7 @@ describe('R2Publisher', () => {
       ).toString('utf-8'),
     )
     expect(manifest).toMatchObject({
-      schemaVersion: 2,
+      schemaVersion: 3,
       runId,
       uploadedAt: '2026-04-29T12:00:00.000Z',
       agentConfig: { type: 'single', model: 'kimi' },
@@ -313,7 +313,7 @@ describe('R2Publisher', () => {
     expect(keys).toContain(`runs/${runId}/task-1/metadata.json`)
     expect(keys).toContain(`runs/${runId}/tasks/task-1/metadata.json`)
     expect(manifest).toMatchObject({
-      schemaVersion: 2,
+      schemaVersion: 3,
       tasks: [
         {
           queryId: 'task-1',

--- a/packages/browseros-agent/apps/eval/tests/viewer/viewer-manifest.test.ts
+++ b/packages/browseros-agent/apps/eval/tests/viewer/viewer-manifest.test.ts
@@ -25,6 +25,7 @@ describe('buildViewerManifest', () => {
             screenshots: 42,
             toolCalls: 19,
             toolErrors: 2,
+            perTool: { click: { calls: 12, errors: 1 } },
           },
           graderResults: {
             agisdk_state_diff: {
@@ -39,7 +40,7 @@ describe('buildViewerManifest', () => {
     })
 
     const publishManifest: R2RunManifest = manifest
-    expect(publishManifest.schemaVersion).toBe(2)
+    expect(publishManifest.schemaVersion).toBe(3)
     expect(manifest.reportPath).toBe('report.html')
     expect(manifest.tasks[0].paths.messages).toBe(
       'tasks/agisdk-dashdish-4/messages.jsonl',
@@ -64,6 +65,7 @@ describe('buildViewerManifest', () => {
       screenshots: 42,
       toolCalls: 19,
       toolErrors: 2,
+      perTool: { click: { calls: 12, errors: 1 } },
     })
     expect(manifest.tasks[0].graderResults.agisdk_state_diff.details).toEqual({
       missing: ['checkout item'],
@@ -87,7 +89,7 @@ describe('buildViewerManifest', () => {
     })
 
     expect(manifest).toMatchObject({
-      schemaVersion: 2,
+      schemaVersion: 3,
       runId: 'run-2',
       uploadedAt: '2026-04-29T06:00:00.000Z',
       tasks: [
@@ -102,6 +104,8 @@ describe('buildViewerManifest', () => {
             grades: 'tasks/task-with-minimal-fields/grades.json',
             screenshots: 'tasks/task-with-minimal-fields/screenshots',
             graderArtifacts: 'tasks/task-with-minimal-fields/grader-artifacts',
+            finishState:
+              'tasks/task-with-minimal-fields/grader-artifacts/agisdk_state_diff/finish-state.json',
           },
         },
       ],


### PR DESCRIPTION
## Summary

Restructures the eval viewer for the AGI SDK suite into three tabs (**Overview / Tasks / Report**) and surfaces signals that were already on disk but never aggregated — token usage, per-criterion grader detail, dataset metadata, and per-tool stats.

### What you'll see in the viewer

- **Overview tab**: pass-rate / avg-duration / avg-tools / avg-tokens headline cards · pass-rate by website table · by difficulty cards · website × difficulty matrix · tool usage table with error rates · token usage breakdown · termination reasons.
- **Tasks tab** (existing 3-pane viewer + additions):
  - Task metadata chips above query (`DashDish · hard · action · similar to Doordash`).
  - Per-criterion checklist with `expected` vs `actual` diffs and `SOFT` badges for softened passes.
  - Finish-state inspector — collapsible JSON view of the AGI SDK `/finish` env_state.
  - Step-synchronized agent stream — clicking screenshot N highlights matching events.
  - Filter chips (All / Tools / Errors / Reasoning) + message search.
  - Token badge with input/output/cache breakdown tooltip.
- **Report tab**: embeds the existing AI-generated `report.html` inline as a sandboxed iframe.

### Under the hood

**Capture (no new infrastructure — uses data the SDKs already return):**
- Claude Code stream parser extracts `usage` from each `assistant` message and the final `result` line, preferring the SDK's aggregate when present.
- The tool-loop path (used by `"agent.type": "single"` which the AGI SDK suite runs) accumulates `usage` defensively across AI SDK field-name variants via a shared helper.
- Dataset fields (`website`, `difficulty`, `challenge_type`, `similar_to`) propagated from the task input metadata into `metadata.json`.

**Metrics + manifest:**
- `task-metrics.ts` emits per-tool call/error counts with `mcp__browseros__` prefix normalization, per-criterion totals from the AGI SDK grader, and aggregated token usage at the run level.
- Viewer manifest bumped to **schema v3** with `taskMetadata`, `perCriterion`, `tokenUsage`, `paths.finishState`, and `finalAnswer` per task.

### Out of scope

Cost ($ amounts), `compare.html`, a Runs/cross-run tab (already covered by the weekly report), performance grader specifics, orchestrator-executor token capture, per-step URL capture.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bunx biome check` clean (0 errors on touched files)
- [x] 27 unit tests pass — added 2 new tests for token usage extraction (per-message accumulation + result aggregate override); updated viewer manifest tests for schema v3 + new fields.
- [x] Verified live by building a v3 manifest from a real AGI SDK run, serving locally, and inspecting all three tabs via headless Chrome — Overview headline cards / website matrix / tool usage table, Tasks tab metadata chips + per-criterion checklist with mixed `{actual_value, expected_value}` and string detail shapes + SOFT badge rendering, Report tab graceful empty-state.
- [ ] Trigger Weekly Eval workflow against `configs/suites/agisdk-real.json` to verify end-to-end capture in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)