### PR TITLE
Fix Codex MCP setup command

### DIFF
--- a/docs/features/use-with-claude-code.mdx
+++ b/docs/features/use-with-claude-code.mdx
@@ -85,8 +85,8 @@ Wondering how BrowserOS MCP compares to Chrome DevTools MCP or other browser aut
   <Tab title="Codex">
     Add BrowserOS to OpenAI Codex CLI:
     ```bash
-    codex mcp add browseros <mcp_url> --transport http
-    # Example: codex mcp add browseros http://127.0.0.1:9239/mcp --transport http
+    codex mcp add browseros --url <mcp_url>
+    # Example: codex mcp add browseros --url http://127.0.0.1:9239/mcp
     ```
   </Tab>
   <Tab title="OpenClaw">

--- a/packages/browseros-agent/apps/agent/entrypoints/app/mcp-settings/QuickSetupSection.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/mcp-settings/QuickSetupSection.tsx
@@ -34,7 +34,7 @@ const clients: ClientConfig[] = [
     id: 'codex',
     name: 'Codex',
     type: 'command',
-    getSnippet: (url) => `codex mcp add browseros ${url}`,
+    getSnippet: (url) => `codex mcp add browseros --url ${url}`,
   },
   {
     id: 'claude-desktop',


### PR DESCRIPTION
## Summary
- update the in-app MCP Quick Setup Codex command to use `codex mcp add browseros --url <url>`
- update the matching Codex CLI docs example to use `--url` instead of the stale transport syntax

## Verification
- `git diff --check`
- Could not run `bunx biome check` because `bunx` is not installed in this environment