### PR TITLE
fix(ci): restore internal-docs sync PR merging

### DIFF
--- a/.github/workflows/sync-internal-docs.yml
+++ b/.github/workflows/sync-internal-docs.yml
@@ -86,6 +86,18 @@ jobs:
           trap - ERR
 
           if ! gh pr merge "$PR_URL" --squash --delete-branch; then
-            echo "Immediate merge failed; enabling auto-merge for pending merge requirements."
+            PR_STATE=$(gh pr view "$PR_URL" --json mergeStateStatus,statusCheckRollup)
+            MERGE_STATE=$(jq -r '.mergeStateStatus' <<<"$PR_STATE")
+            FAILED_CHECKS=$(jq '[.statusCheckRollup[] | select(
+              (.__typename == "CheckRun" and ((.conclusion // "") | test("^(FAILURE|CANCELLED|TIMED_OUT|ACTION_REQUIRED)$"))) or
+              (.__typename == "StatusContext" and ((.state // "") | test("^(FAILURE|ERROR)$")))
+            )] | length' <<<"$PR_STATE")
+
+            if [ "$MERGE_STATE" = "DIRTY" ] || [ "$FAILED_CHECKS" -gt 0 ]; then
+              echo "Immediate merge failed and PR is not auto-mergeable (mergeStateStatus=$MERGE_STATE, failedChecks=$FAILED_CHECKS). Leaving PR open."
+              exit 1
+            fi
+
+            echo "Immediate merge failed with mergeStateStatus=$MERGE_STATE and no failed checks; enabling auto-merge."
             gh pr merge "$PR_URL" --auto --squash --delete-branch
           fi

--- a/.github/workflows/sync-internal-docs.yml
+++ b/.github/workflows/sync-internal-docs.yml
@@ -82,11 +82,10 @@ jobs:
             --head "$BRANCH" \
             --title "chore: sync internal-docs submodule" \
             --body "Automated bump of the \`.internal-docs\` submodule pointer. Auto-merging.")
+          CLEANUP_BRANCH=0
+          trap - ERR
 
           if ! gh pr merge "$PR_URL" --squash --delete-branch; then
             echo "Immediate merge failed; enabling auto-merge for pending merge requirements."
             gh pr merge "$PR_URL" --auto --squash --delete-branch
           fi
-
-          CLEANUP_BRANCH=0
-          trap - ERR

--- a/.github/workflows/sync-internal-docs.yml
+++ b/.github/workflows/sync-internal-docs.yml
@@ -5,13 +5,16 @@ on:
     - cron: '0 */4 * * *'
   workflow_dispatch:
 
+concurrency:
+  group: sync-internal-docs
+  cancel-in-progress: false
+
 jobs:
   sync:
     name: Bump internal-docs submodule pointer on dev
     runs-on: ubuntu-latest
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
     steps:
       - name: Rewrite SSH submodule URL to HTTPS-with-token
         env:
@@ -28,13 +31,24 @@ jobs:
 
       - name: Open auto-merge PR if internal-docs has new commits
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.INTERNAL_DOCS_SYNC_TOKEN }}
         run: |
-          set -e
+          set -euo pipefail
 
           # Skip if submodule not yet configured (handoff window before someone adds it)
           if ! git config --file .gitmodules --get-regexp '^submodule\..internal-docs\.path$' >/dev/null 2>&1; then
             echo "internal-docs submodule not yet configured in .gitmodules. Skipping."
+            exit 0
+          fi
+
+          EXISTING_PR_URL=$(gh pr list \
+            --base dev \
+            --state open \
+            --json headRefName,url \
+            --jq '[.[] | select(.headRefName | startswith("bot/sync-internal-docs-")) | .url][0] // ""')
+
+          if [ -n "$EXISTING_PR_URL" ]; then
+            echo "An internal-docs sync PR is already open: $EXISTING_PR_URL"
             exit 0
           fi
 
@@ -51,7 +65,17 @@ jobs:
           git checkout -b "$BRANCH"
           git add .internal-docs
           git commit -m "chore: sync internal-docs submodule"
+
+          CLEANUP_BRANCH=0
+          cleanup_branch() {
+            if [ "$CLEANUP_BRANCH" = "1" ]; then
+              git push origin --delete "$BRANCH" >/dev/null 2>&1 || true
+            fi
+          }
+          trap cleanup_branch ERR
+
           git push -u origin "$BRANCH"
+          CLEANUP_BRANCH=1
 
           PR_URL=$(gh pr create \
             --base dev \
@@ -59,4 +83,10 @@ jobs:
             --title "chore: sync internal-docs submodule" \
             --body "Automated bump of the \`.internal-docs\` submodule pointer. Auto-merging.")
 
-          gh pr merge "$PR_URL" --auto --squash --delete-branch
+          if ! gh pr merge "$PR_URL" --squash --delete-branch; then
+            echo "Immediate merge failed; enabling auto-merge for pending merge requirements."
+            gh pr merge "$PR_URL" --auto --squash --delete-branch
+          fi
+
+          CLEANUP_BRANCH=0
+          trap - ERR


### PR DESCRIPTION
## Summary
- Fixes the internal-docs sync workflow so clean PRs merge immediately instead of failing while trying to enable auto-merge.
- Uses `INTERNAL_DOCS_SYNC_TOKEN` for checkout, branch pushes, PR creation, and merge operations so PRs are authored by the sync identity instead of `github-actions[bot]`.
- Adds duplicate-run/duplicate-PR guards and cleans up pushed bot branches if later PR or merge steps fail.

## Design
The workflow keeps the existing submodule bump shape, but makes the merge path match GitHub's behavior: call `gh pr merge --squash --delete-branch` first for already-clean PRs, then fall back to `--auto` only when merge requirements are still pending. It also serializes sync runs, checks for an existing open sync PR before creating another one, and limits the default `GITHUB_TOKEN` to read-only because the PAT is now the single write credential used by checkout and `gh`.

## Test plan
- `ruby` invariant check for expected workflow behavior
- `ruby` YAML parse for `.github/workflows/sync-internal-docs.yml`
- extracted embedded Bash with `bash -n`
- `git diff --check -- .github/workflows/sync-internal-docs.yml`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/sync-internal-docs.yml`
- live `gh pr list --jq` check for the duplicate-PR selector