### PR TITLE
fix(browseros): address Chromium 148 review feedback

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_loader.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_loader.cc
@@ -56,7 +56,7 @@ index 0000000000000..70ad8710a39b7
 +}
 +
 +void BrowserOSExtensionLoader::StartLoading() {
-+  LOG(INFO) << "browseros: Extension loader starting";
++  VLOG(2) << "browseros: Extension loader starting";
 +
 +  installer_ = std::make_unique<BrowserOSExtensionInstaller>(profile_);
 +  maintainer_ = std::make_unique<BrowserOSExtensionMaintainer>(profile_);
@@ -68,7 +68,7 @@ index 0000000000000..70ad8710a39b7
 +}
 +
 +void BrowserOSExtensionLoader::OnInstallComplete(InstallResult result) {
-+  LOG(INFO) << "browseros: OnInstallComplete from_bundled="
++  VLOG(2) << "browseros: OnInstallComplete from_bundled="
 +            << result.from_bundled << " prefs=" << result.prefs.size()
 +            << " ids=" << result.extension_ids.size();
 +
@@ -95,7 +95,7 @@ index 0000000000000..70ad8710a39b7
 +    LOG(WARNING) << "browseros: Install returned empty prefs, "
 +                 << "reconstructing from installed extensions";
 +    prefs_to_load = ReconstructPrefsFromInstalledExtensions();
-+    LOG(INFO) << "browseros: Reconstructed prefs for "
++    VLOG(2) << "browseros: Reconstructed prefs for "
 +              << prefs_to_load.size() << " installed extensions";
 +  }
 +
@@ -129,7 +129,7 @@ index 0000000000000..70ad8710a39b7
 +                 update_url);
 +    prefs.Set(id, std::move(ext_pref));
 +
-+    LOG(INFO) << "browseros: Reconstructed pref for installed extension "
++    VLOG(2) << "browseros: Reconstructed pref for installed extension "
 +              << id << " v" << ext->version().GetString();
 +  }
 +
@@ -141,7 +141,7 @@ index 0000000000000..70ad8710a39b7
 +}
 +
 +void BrowserOSExtensionLoader::OnStartupComplete(bool from_bundled) {
-+  LOG(INFO) << "browseros: Startup complete (from_bundled=" << from_bundled
++  VLOG(2) << "browseros: Startup complete (from_bundled=" << from_bundled
 +            << ")";
 +
 +  if (from_bundled) {
@@ -178,7 +178,7 @@ index 0000000000000..70ad8710a39b7
 +    return;
 +  }
 +
-+  LOG(INFO) << "browseros: Installing " << extension_ids_.size()
++  VLOG(2) << "browseros: Installing " << extension_ids_.size()
 +            << " remote extensions immediately";
 +
 +  for (const std::string& id : extension_ids_) {
@@ -234,7 +234,7 @@ index 0000000000000..70ad8710a39b7
 +    return;
 +  }
 +
-+  LOG(INFO) << "browseros: Installing " << extension_ids_.size()
++  VLOG(2) << "browseros: Installing " << extension_ids_.size()
 +            << " bundled extensions immediately";
 +
 +  for (const std::string& id : extension_ids_) {
@@ -250,7 +250,7 @@ index 0000000000000..70ad8710a39b7
 +    base::FilePath crx_path = bundled_crx_base_path_.Append(
 +        base::FilePath::FromUTF8Unsafe(id + ".crx"));
 +
-+    LOG(INFO) << "browseros: Installing bundled " << id << " v" << it->second;
++    VLOG(2) << "browseros: Installing bundled " << id << " v" << it->second;
 +
 +    pending->AddFromExternalFile(
 +        id, extensions::mojom::ManifestLocation::kExternalComponent,

--- a/packages/browseros/chromium_patches/chrome/browser/extensions/api/side_panel/side_panel_service.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/extensions/api/side_panel/side_panel_service.cc
@@ -25,7 +25,7 @@ index 5474809d1dcd7..7e8967854ac29 100644
 +    int tab_id,
 +    bool include_incognito_information,
 +    std::optional<bool> desired_state) {
-+  LOG(INFO) << "browseros: BrowserosToggleSidePanelForTab called for tab_id="
++  VLOG(2) << "browseros: BrowserosToggleSidePanelForTab called for tab_id="
 +            << tab_id << ", extension=" << extension.id()
 +            << ", desired_state="
 +            << (desired_state.has_value()
@@ -60,7 +60,7 @@ index 5474809d1dcd7..7e8967854ac29 100644
 +    has_contextual_options = panels_iter->second.contains(tab_id);
 +  }
 +
-+  LOG(INFO) << "browseros: has_contextual_options=" << has_contextual_options
++  VLOG(2) << "browseros: has_contextual_options=" << has_contextual_options
 +            << " for tab_id=" << tab_id;
 +
 +  if (!has_contextual_options) {
@@ -75,7 +75,7 @@ index 5474809d1dcd7..7e8967854ac29 100644
 +          "setOptions() before toggling.");
 +    }
 +
-+    LOG(INFO) << "browseros: Auto-registering contextual panel for tab_id="
++    VLOG(2) << "browseros: Auto-registering contextual panel for tab_id="
 +              << tab_id << " with path=" << *default_options.path;
 +
 +    // Create contextual options for this tab.
@@ -95,12 +95,12 @@ index 5474809d1dcd7..7e8967854ac29 100644
 +  }
 +
 +  // Toggle the contextual panel.
-+  LOG(INFO) << "browseros: Calling ToggleContextualExtensionSidePanel for tab_id="
++  VLOG(2) << "browseros: Calling ToggleContextualExtensionSidePanel for tab_id="
 +            << tab_id;
 +  bool is_now_open = side_panel_util::ToggleContextualExtensionSidePanel(
 +      *browser_window, *web_contents, extension.id(), desired_state);
 +
-+  LOG(INFO) << "browseros: Toggle result: is_now_open=" << is_now_open
++  VLOG(2) << "browseros: Toggle result: is_now_open=" << is_now_open
 +            << " for tab_id=" << tab_id;
 +
 +  return is_now_open;
@@ -112,7 +112,7 @@ index 5474809d1dcd7..7e8967854ac29 100644
 +    content::BrowserContext* context,
 +    int tab_id,
 +    bool include_incognito_information) {
-+  LOG(INFO) << "browseros: BrowserosIsSidePanelOpenForTab called for tab_id="
++  VLOG(2) << "browseros: BrowserosIsSidePanelOpenForTab called for tab_id="
 +            << tab_id << ", extension=" << extension.id();
 +
 +  // Find the tab.
@@ -137,7 +137,7 @@ index 5474809d1dcd7..7e8967854ac29 100644
 +  // Check if panel is disabled - return false (not an error).
 +  api::side_panel::PanelOptions current_options = GetOptions(extension, tab_id);
 +  if (!current_options.enabled.value_or(true)) {
-+    LOG(INFO) << "browseros: Panel is disabled for tab_id=" << tab_id
++    VLOG(2) << "browseros: Panel is disabled for tab_id=" << tab_id
 +              << ", returning false";
 +    return false;
 +  }
@@ -145,7 +145,7 @@ index 5474809d1dcd7..7e8967854ac29 100644
 +  bool is_open = side_panel_util::IsContextualExtensionSidePanelOpen(
 +      browser_window, web_contents, extension.id());
 +
-+  LOG(INFO) << "browseros: IsOpen result: is_open=" << is_open
++  VLOG(2) << "browseros: IsOpen result: is_open=" << is_open
 +            << " for tab_id=" << tab_id;
 +
 +  return is_open;

--- a/packages/browseros/chromium_patches/chrome/browser/extensions/updater/extension_updater.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/extensions/updater/extension_updater.cc
@@ -2,7 +2,7 @@ diff --git a/chrome/browser/extensions/updater/extension_updater.cc b/chrome/bro
 index bd09a39459441..8860719396ce8 100644
 --- a/chrome/browser/extensions/updater/extension_updater.cc
 +++ b/chrome/browser/extensions/updater/extension_updater.cc
-@@ -562,6 +562,100 @@ void ExtensionUpdater::CheckNow(CheckParams params) {
+@@ -562,6 +562,103 @@ void ExtensionUpdater::CheckNow(CheckParams params) {
    }
  }
  
@@ -17,9 +17,12 @@ index bd09a39459441..8860719396ce8 100644
 +    return;
 +  }
 +
-+  CHECK(enabled_);
-+  CHECK(alive_);
-+  CHECK(pending_extension_manager_);
++  if (!enabled_ || !alive_ || !pending_extension_manager_) {
++    if (params.callback) {
++      std::move(params.callback).Run();
++    }
++    return;
++  }
 +
 +  if (params.ids.empty()) {
 +    if (params.callback) {

--- a/packages/browseros/chromium_patches/chrome/browser/ui/browser_actions.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/browser_actions.cc
@@ -100,7 +100,7 @@ index 8a43e7c2fcde5..95eff82226b48 100644
 +                }
 +
 +                int tab_id = extensions::ExtensionTabUtil::GetTabId(contents);
-+                LOG(INFO) << "browseros: Agent toolbar action for tab_id="
++                VLOG(2) << "browseros: Agent toolbar action for tab_id="
 +                          << tab_id;
 +
 +                extensions::SidePanelService* service =
@@ -119,7 +119,7 @@ index 8a43e7c2fcde5..95eff82226b48 100644
 +                  LOG(WARNING) << "browseros: Agent toggle failed: "
 +                               << result.error();
 +                } else {
-+                  LOG(INFO) << "browseros: Agent toggle result: "
++                  VLOG(2) << "browseros: Agent toggle result: "
 +                            << result.value();
 +                }
 +              },

--- a/packages/browseros/chromium_patches/chrome/browser/ui/browser_command_controller.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/browser_command_controller.cc
@@ -8,10 +8,10 @@ index 738696abf04fa..469b5cbcc0f8d 100644
  #include <algorithm>
 +#include <optional>
  #include <string>
-+#include <tuple>
  
  #include "base/check_deref.h"
  #include "base/command_line.h"
++#include "base/logging.h"
 @@ -23,11 +25,14 @@
  #include "build/build_config.h"
  #include "chrome/app/chrome_command_ids.h"
@@ -52,7 +52,7 @@ index 738696abf04fa..469b5cbcc0f8d 100644
  #include "extensions/browser/extension_registrar.h"
  #include "extensions/browser/extension_registry.h"
  #include "extensions/common/extension_urls.h"
-@@ -1089,6 +1098,71 @@ bool BrowserCommandController::ExecuteCommandWithDisposition(
+@@ -1089,6 +1098,74 @@ bool BrowserCommandController::ExecuteCommandWithDisposition(
        browser_->GetFeatures().side_panel_ui()->Show(
            SidePanelEntryId::kBookmarks, SidePanelOpenTrigger::kAppMenu);
        break;
@@ -76,11 +76,11 @@ index 738696abf04fa..469b5cbcc0f8d 100644
 +      if (base::FeatureList::IsEnabled(features::kClashOfGpts)) {
 +        ClashOfGptsCoordinator* coordinator =
 +            browser_->browser_window_features()->clash_of_gpts_coordinator();
-+        // If not showing properly, close and recreate
-+        if (!coordinator->IsShowing()) {
-+          coordinator->Close();
++        // Show() creates the window if needed and reactivates it if open.
++        // This command is open/activate, so do not close an existing panel.
++        if (coordinator) {
++          coordinator->Show();
 +        }
-+        coordinator->Show();
 +      }
 +      break;
 +    case IDC_TOGGLE_BROWSEROS_AGENT: {
@@ -114,10 +114,13 @@ index 738696abf04fa..469b5cbcc0f8d 100644
 +      extensions::SidePanelService* service =
 +          extensions::SidePanelService::Get(profile);
 +      if (service) {
-+        std::ignore = service->BrowserosToggleSidePanelForTab(
++        auto result = service->BrowserosToggleSidePanelForTab(
 +            *extension, profile, tab_id,
 +            /*include_incognito_information=*/true,
 +            /*desired_state=*/std::nullopt);
++        if (!result.has_value()) {
++          LOG(WARNING) << "browseros: Agent toggle failed: " << result.error();
++        }
 +      }
 +      break;
 +    }

--- a/packages/browseros/chromium_patches/chrome/browser/ui/extensions/settings_overridden_params_providers.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/extensions/settings_overridden_params_providers.cc
@@ -24,7 +24,7 @@ index 77281f600f64d..ef60366c81f3a 100644
  
 +  // Don't show the dialog for BrowserOS extensions
 +  if (browseros::IsBrowserOSExtension(extension->id())) {
-+    LOG(INFO) << "browseros: Skipping settings override dialog for BrowserOS extension "
++    VLOG(2) << "browseros: Skipping settings override dialog for BrowserOS extension "
 +              << extension->id();
 +    return std::nullopt;
 +  }

--- a/packages/browseros/chromium_patches/chrome/browser/ui/side_panel/side_panel_action_callback.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/side_panel/side_panel_action_callback.cc
@@ -38,7 +38,7 @@ index f81e396170a79..c4d7abeeac7a6 100644
 +  return base::BindRepeating(
 +      [](extensions::ExtensionId extension_id, BrowserWindowInterface* bwi,
 +         actions::ActionItem* item, actions::ActionInvocationContext context) {
-+        LOG(INFO) << "browseros: Toolbar action clicked for extension="
++        VLOG(2) << "browseros: Toolbar action clicked for extension="
 +                  << extension_id;
 +
 +        tabs::TabInterface* active_tab = bwi->GetActiveTabInterface();
@@ -54,7 +54,7 @@ index f81e396170a79..c4d7abeeac7a6 100644
 +        }
 +
 +        int tab_id = extensions::ExtensionTabUtil::GetTabId(active_contents);
-+        LOG(INFO) << "browseros: Active tab_id=" << tab_id;
++        VLOG(2) << "browseros: Active tab_id=" << tab_id;
 +
 +        Profile* profile =
 +            Profile::FromBrowserContext(active_contents->GetBrowserContext());
@@ -85,7 +85,7 @@ index f81e396170a79..c4d7abeeac7a6 100644
 +          return;
 +        }
 +
-+        LOG(INFO) << "browseros: Toggle result: " << result.value();
++        VLOG(2) << "browseros: Toggle result: " << result.value();
 +      },
 +      extension_id, bwi);
 +}

--- a/packages/browseros/chromium_patches/chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model.cc
@@ -44,7 +44,7 @@ index 0177d0e3bda7c..a38ae2b19fbd2 100644
 +  // it
    if (!pref_service_->GetBoolean(prefs::kPinnedChromeLabsMigrationComplete)) {
 -    UpdatePinnedState(kActionShowChromeLabs, true);
-+    // UpdatePinnedState(kActionShowChromeLabs, true);  // No longer auto-pin
++    // Mark complete without pinning Chrome Labs for new profiles.
      pref_service_->SetBoolean(prefs::kPinnedChromeLabsMigrationComplete, true);
    }
    if (features::HasTabSearchToolbarButton() &&


### PR DESCRIPTION
## Summary
- convert routine BrowserOS Chromium patch logs from LOG(INFO) to VLOG(2) while keeping warnings visible
- avoid closing Clash of GPTs before opening it, and log BrowserOS Agent toggle failures from the command path
- make pending extension immediate install return through callbacks instead of hard CHECK aborting
- remove the commented-out Chrome Labs pin call from the toolbar migration patch

## Validation
- git diff --check origin/dev..HEAD
- git apply --numstat on edited Chromium patch files
- artifact path check against generated resources/Sparkle/string outputs returned no matches

Build not run per user instruction; build was already verified externally.