### PR TITLE
fix: disable container VM warmup

### DIFF
--- a/packages/browseros-agent/apps/agent/lib/mcp/client.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/mcp/client.test.ts
@@ -3,6 +3,9 @@ import { createServer, type IncomingMessage, type Server } from 'node:http'
 import type { AddressInfo } from 'node:net'
 import { fetchMcpTools } from './client'
 
+const SCHEMA_COMPILATION_STACK_RE =
+  /node_modules[/\\](?:zod|@modelcontextprotocol[/\\]sdk)[/\\]/
+
 function readBody(req: IncomingMessage): Promise<string> {
   const chunks: Uint8Array[] = []
 
@@ -49,7 +52,7 @@ describe('fetchMcpTools', () => {
 
   it('lists tools without invoking Function-based schema compilation', async () => {
     const requests: string[] = []
-    let evalCalls = 0
+    const functionCallStacks: string[] = []
     let getRequests = 0
     let initialized = false
 
@@ -139,11 +142,11 @@ describe('fetchMcpTools', () => {
     try {
       globalThis.Function = new Proxy(originalFunction, {
         apply(target, thisArg, argArray) {
-          evalCalls += 1
+          functionCallStacks.push(new Error().stack ?? '')
           return Reflect.apply(target, thisArg, argArray)
         },
         construct(target, argArray, newTarget) {
-          evalCalls += 1
+          functionCallStacks.push(new Error().stack ?? '')
           return Reflect.construct(target, argArray, newTarget)
         },
       }) as unknown as FunctionConstructor
@@ -157,7 +160,11 @@ describe('fetchMcpTools', () => {
           description: 'List tabs',
         },
       ])
-      expect(evalCalls).toBe(0)
+      expect(
+        functionCallStacks.filter((stack) =>
+          SCHEMA_COMPILATION_STACK_RE.test(stack),
+        ),
+      ).toEqual([])
       expect(getRequests).toBe(1)
       expect(initialized).toBe(true)
       expect(requests).toEqual([

--- a/packages/browseros-agent/apps/agent/lib/mcp/client.ts
+++ b/packages/browseros-agent/apps/agent/lib/mcp/client.ts
@@ -1,107 +1,252 @@
-import type { ListToolsResult } from '@modelcontextprotocol/sdk/types.js'
-import * as z from 'zod/v4'
-
 /** @public */
 export interface McpTool {
   name: string
   description?: string
 }
 
+const JSONRPC_VERSION = '2.0'
+const MCP_PROTOCOL_VERSION = '2025-11-25'
 const MCP_CLIENT_INFO = {
   name: 'browseros-settings',
   version: '1.0.0',
 } as const
 
-type McpClientConstructor =
-  typeof import('@modelcontextprotocol/sdk/client/index.js').Client
-type McpListToolsResultSchema =
-  typeof import('@modelcontextprotocol/sdk/types.js').ListToolsResultSchema
-type McpTransportConstructor =
-  typeof import('@modelcontextprotocol/sdk/client/streamableHttp.js').StreamableHTTPClientTransport
-
-interface McpSdk {
-  Client: McpClientConstructor
-  ListToolsResultSchema: McpListToolsResultSchema
-  StreamableHTTPClientTransport: McpTransportConstructor
+interface JsonRpcError {
+  code: number
+  message: string
+  data?: unknown
 }
 
-let mcpSdkPromise: Promise<McpSdk> | undefined
+interface JsonRpcRequest {
+  jsonrpc: typeof JSONRPC_VERSION
+  id?: number
+  method: string
+  params?: unknown
+}
 
-async function loadMcpSdk(): Promise<McpSdk> {
-  if (!mcpSdkPromise) {
-    mcpSdkPromise = (async () => {
-      const previousJitless = z.config().jitless
+interface JsonRpcResponse<T> {
+  jsonrpc: typeof JSONRPC_VERSION
+  id: number
+  result?: T
+  error?: JsonRpcError
+}
 
-      // Zod v4 captures JIT settings when schemas are constructed, so this has
-      // to be set before the SDK modules create their schemas.
-      z.config({ jitless: true })
+interface McpRequestContext {
+  protocolVersion?: string
+  sessionId?: string
+}
 
-      try {
-        const [clientModule, transportModule, typesModule] = await Promise.all([
-          import('@modelcontextprotocol/sdk/client/index.js'),
-          import('@modelcontextprotocol/sdk/client/streamableHttp.js'),
-          import('@modelcontextprotocol/sdk/types.js'),
-        ])
+interface InitializeResult {
+  protocolVersion?: unknown
+}
 
-        return {
-          Client: clientModule.Client,
-          StreamableHTTPClientTransport:
-            transportModule.StreamableHTTPClientTransport,
-          ListToolsResultSchema: typesModule.ListToolsResultSchema,
-        }
-      } finally {
-        z.config({ jitless: previousJitless })
-      }
-    })()
+interface ListToolsResult {
+  nextCursor?: unknown
+  tools?: unknown
+}
+
+function buildMcpHeaders(
+  context: McpRequestContext,
+  accept: string,
+): Record<string, string> {
+  const headers: Record<string, string> = {
+    accept,
   }
 
-  return mcpSdkPromise
+  if (context.sessionId) {
+    headers['mcp-session-id'] = context.sessionId
+  }
+  if (context.protocolVersion) {
+    headers['mcp-protocol-version'] = context.protocolVersion
+  }
+
+  return headers
 }
 
-function normalizeTools(tools: ListToolsResult['tools']): McpTool[] {
-  return tools.map((tool) => ({
-    name: tool.name,
-    description: tool.description,
-  }))
+async function readErrorMessage(response: Response): Promise<string> {
+  const text = await response.text().catch(() => '')
+  return text || response.statusText || `HTTP ${response.status}`
 }
 
-async function listTools(
-  client: InstanceType<McpClientConstructor>,
-  listToolsResultSchema: McpListToolsResultSchema,
-): Promise<McpTool[]> {
+async function postJsonRpc<T>(
+  serverUrl: string,
+  message: JsonRpcRequest,
+  context: McpRequestContext,
+): Promise<{ result: T; sessionId?: string }> {
+  const response = await fetch(serverUrl, {
+    method: 'POST',
+    headers: {
+      ...buildMcpHeaders(context, 'application/json, text/event-stream'),
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(message),
+  })
+  const sessionId = response.headers.get('mcp-session-id') ?? context.sessionId
+
+  if (!response.ok) {
+    throw new Error(`MCP request failed: ${await readErrorMessage(response)}`)
+  }
+
+  const contentType = response.headers.get('content-type') ?? ''
+  if (!contentType.includes('application/json')) {
+    throw new Error(
+      `MCP request returned unsupported content type: ${contentType}`,
+    )
+  }
+
+  const body = (await response.json()) as JsonRpcResponse<T>
+  if (body.error) {
+    throw new Error(`MCP request failed: ${body.error.message}`)
+  }
+  if (!('result' in body)) {
+    throw new Error('MCP request returned no result')
+  }
+
+  return { result: body.result as T, sessionId }
+}
+
+async function postJsonRpcNotification(
+  serverUrl: string,
+  message: JsonRpcRequest,
+  context: McpRequestContext,
+): Promise<void> {
+  const response = await fetch(serverUrl, {
+    method: 'POST',
+    headers: {
+      ...buildMcpHeaders(context, 'application/json, text/event-stream'),
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(message),
+  })
+
+  if (!response.ok) {
+    throw new Error(
+      `MCP notification failed: ${await readErrorMessage(response)}`,
+    )
+  }
+
+  await response.body?.cancel()
+}
+
+async function openOptionalSseStream(
+  serverUrl: string,
+  context: McpRequestContext,
+): Promise<void> {
+  const response = await fetch(serverUrl, {
+    method: 'GET',
+    headers: buildMcpHeaders(context, 'text/event-stream'),
+  })
+
+  await response.body?.cancel()
+
+  if (response.status === 405) {
+    return
+  }
+  if (!response.ok) {
+    throw new Error(
+      `MCP SSE stream failed: ${await readErrorMessage(response)}`,
+    )
+  }
+}
+
+function normalizeTools(result: ListToolsResult): {
+  nextCursor?: string
+  tools: McpTool[]
+} {
+  if (!Array.isArray(result.tools)) {
+    throw new Error('MCP tools/list returned invalid tools')
+  }
+
+  const tools = result.tools.map((tool, index) => {
+    if (!tool || typeof tool !== 'object') {
+      throw new Error(`MCP tools/list returned invalid tool at index ${index}`)
+    }
+
+    const { name, description } = tool as {
+      description?: unknown
+      name?: unknown
+    }
+    if (typeof name !== 'string') {
+      throw new Error(`MCP tools/list returned unnamed tool at index ${index}`)
+    }
+
+    return {
+      name,
+      ...(typeof description === 'string' ? { description } : {}),
+    }
+  })
+
+  return {
+    tools,
+    ...(typeof result.nextCursor === 'string'
+      ? { nextCursor: result.nextCursor }
+      : {}),
+  }
+}
+
+/**
+ * Fetches available tools from the BrowserOS MCP server without importing the
+ * MCP SDK runtime, which can generate validators with `new Function` in tests
+ * and browser extension contexts.
+ * @public
+ */
+export async function fetchMcpTools(serverUrl: string): Promise<McpTool[]> {
+  let nextId = 1
+  const initialize = await postJsonRpc<InitializeResult>(
+    serverUrl,
+    {
+      jsonrpc: JSONRPC_VERSION,
+      id: nextId,
+      method: 'initialize',
+      params: {
+        protocolVersion: MCP_PROTOCOL_VERSION,
+        capabilities: {},
+        clientInfo: MCP_CLIENT_INFO,
+      },
+    },
+    {},
+  )
+
+  const protocolVersion = initialize.result.protocolVersion
+  if (typeof protocolVersion !== 'string') {
+    throw new Error('MCP initialize returned no protocol version')
+  }
+
+  const context: McpRequestContext = {
+    protocolVersion,
+    sessionId: initialize.sessionId,
+  }
+
+  await postJsonRpcNotification(
+    serverUrl,
+    {
+      jsonrpc: JSONRPC_VERSION,
+      method: 'notifications/initialized',
+    },
+    context,
+  )
+  await openOptionalSseStream(serverUrl, context)
+
   const tools: McpTool[] = []
   let cursor: string | undefined
 
   do {
-    const response: ListToolsResult = await client.request(
+    nextId += 1
+    const response = await postJsonRpc<ListToolsResult>(
+      serverUrl,
       {
+        jsonrpc: JSONRPC_VERSION,
+        id: nextId,
         method: 'tools/list',
         ...(cursor ? { params: { cursor } } : {}),
       },
-      listToolsResultSchema,
+      context,
     )
+    const page = normalizeTools(response.result)
 
-    tools.push(...normalizeTools(response.tools))
-    cursor = response.nextCursor
+    tools.push(...page.tools)
+    cursor = page.nextCursor
   } while (cursor)
 
   return tools
-}
-
-/**
- * Fetches available tools from an MCP server
- * @public
- */
-export async function fetchMcpTools(serverUrl: string): Promise<McpTool[]> {
-  const { Client, StreamableHTTPClientTransport, ListToolsResultSchema } =
-    await loadMcpSdk()
-  const client = new Client(MCP_CLIENT_INFO)
-  const transport = new StreamableHTTPClientTransport(new URL(serverUrl))
-
-  try {
-    await client.connect(transport)
-    return await listTools(client, ListToolsResultSchema)
-  } finally {
-    await client.close()
-  }
 }

--- a/packages/browseros-agent/apps/server/src/api/routes/agents.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/agents.ts
@@ -33,6 +33,7 @@ import type { AgentHistoryPage, AgentStreamEvent } from '../../lib/agents/types'
 import {
   type AgentDefinitionWithActivity,
   AgentHarnessService,
+  type EnsureVmRuntimeReady,
   HermesProviderConfigInvalidError,
   InvalidAgentUpdateError,
   MessageQueueFullError,
@@ -96,6 +97,8 @@ type AgentRouteDeps = {
   service?: AgentRouteService
   browser?: Pick<Browser, 'resolveTabIds'>
   browserosServerPort?: number
+  /** Optional hook for harness-owned VM/container runtimes. */
+  ensureVmRuntimeReady?: EnsureVmRuntimeReady
   /** Optional override; defaults to a fresh in-memory checker. */
   adapterHealth?: AdapterHealthChecker
   onTurnLifecycle?: import('../services/agents/agent-harness-service').TurnLifecycleListener
@@ -116,6 +119,7 @@ export function createAgentRoutes(deps: AgentRouteDeps = {}) {
     deps.service ??
     new AgentHarnessService({
       browserosServerPort: deps.browserosServerPort,
+      ensureVmRuntimeReady: deps.ensureVmRuntimeReady,
     })
   if (deps.onTurnLifecycle && service instanceof AgentHarnessService) {
     service.onTurnLifecycle(deps.onTurnLifecycle)

--- a/packages/browseros-agent/apps/server/src/api/server.ts
+++ b/packages/browseros-agent/apps/server/src/api/server.ts
@@ -16,6 +16,7 @@ import { cors } from 'hono/cors'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import { HttpAgentError } from '../agent/errors'
 import { INLINED_ENV } from '../env'
+import { ensureHermesRuntimeReady } from '../lib/agents/runtime'
 import { KlavisClient } from '../lib/clients/klavis/klavis-client'
 import { initializeOAuth, shutdownOAuth } from '../lib/clients/oauth'
 import { getDb } from '../lib/db'
@@ -102,6 +103,12 @@ export async function createHttpServer(config: HttpServerConfig) {
       createAgentRoutes({
         browserosServerPort: port,
         browser,
+        ensureVmRuntimeReady: async (adapter) => {
+          switch (adapter) {
+            case 'hermes':
+              await ensureHermesRuntimeReady({ resourcesDir })
+          }
+        },
       }),
     )
 

--- a/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
@@ -16,7 +16,10 @@ import type {
 } from '../../../lib/agents/agent-store'
 import type { AgentDefinition } from '../../../lib/agents/agent-types'
 import { DbAgentStore } from '../../../lib/agents/db-agent-store'
-import { writeHermesPerAgentProvider } from '../../../lib/agents/hermes/hermes-paths'
+import {
+  getHermesHarnessHostDir,
+  writeHermesPerAgentProvider,
+} from '../../../lib/agents/hermes/hermes-paths'
 import { getHermesProviderMapping } from '../../../lib/agents/hermes/hermes-provider-map'
 import {
   FileMessageQueue,
@@ -30,6 +33,7 @@ export {
   type QueuedMessageAttachment,
 } from '../../../lib/agents/message-queue'
 
+import { rm } from 'node:fs/promises'
 import { join } from 'node:path'
 import type {
   AgentHistoryPage,
@@ -102,10 +106,21 @@ export type TurnLifecycleListener = (
   event: TurnLifecycleEvent,
 ) => void
 
+export type HarnessManagedVmAdapter = Extract<
+  AgentDefinition['adapter'],
+  'hermes'
+>
+
+/** Starts harness-owned VM/container runtimes at the agent creation boundary. */
+export type EnsureVmRuntimeReady = (
+  adapter: HarnessManagedVmAdapter,
+) => Promise<void>
+
 export class AgentHarnessService {
   private readonly agentStore: AgentStore
   private readonly runtime: AgentRuntime
   private readonly browserosDir: string
+  private readonly ensureVmRuntimeReady: EnsureVmRuntimeReady | null
   private readonly turnRegistry: TurnRegistry
   private readonly messageQueue: FileMessageQueue
   private readonly turnLifecycleListeners = new Set<TurnLifecycleListener>()
@@ -124,6 +139,7 @@ export class AgentHarnessService {
       runtime?: AgentRuntime
       browserosDir?: string
       browserosServerPort?: number
+      ensureVmRuntimeReady?: EnsureVmRuntimeReady
       turnRegistry?: TurnRegistry
       messageQueue?: FileMessageQueue
     } = {},
@@ -136,6 +152,7 @@ export class AgentHarnessService {
         browserosDir: this.browserosDir,
         browserosServerPort: deps.browserosServerPort,
       })
+    this.ensureVmRuntimeReady = deps.ensureVmRuntimeReady ?? null
     this.turnRegistry = deps.turnRegistry ?? new TurnRegistry()
     this.messageQueue =
       deps.messageQueue ??
@@ -408,8 +425,20 @@ export class AgentHarnessService {
     if (agent.adapter === 'hermes') {
       try {
         await this.writeHermesPerAgentProvider(agent.id, input)
+        await this.ensureVmRuntimeReady?.(agent.adapter)
       } catch (err) {
         await this.agentStore.delete(agent.id).catch(() => {})
+        await this.deleteHermesPerAgentProvider(agent.id).catch(
+          (cleanupErr) => {
+            logger.warn('Failed to clean Hermes provider config', {
+              agentId: agent.id,
+              error:
+                cleanupErr instanceof Error
+                  ? cleanupErr.message
+                  : String(cleanupErr),
+            })
+          },
+        )
         throw err
       }
       return agent
@@ -444,6 +473,13 @@ export class AgentHarnessService {
       apiKey: (input.apiKey as string).trim(),
       modelId: (input.modelId as string).trim(),
       baseUrl: input.baseUrl?.trim() || mapping.defaultBaseUrl,
+    })
+  }
+
+  private async deleteHermesPerAgentProvider(agentId: string): Promise<void> {
+    await rm(join(getHermesHarnessHostDir(this.browserosDir), agentId), {
+      recursive: true,
+      force: true,
     })
   }
 

--- a/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
@@ -430,7 +430,7 @@ export class AgentHarnessService {
         await this.agentStore.delete(agent.id).catch(() => {})
         await this.deleteHermesPerAgentProvider(agent.id).catch(
           (cleanupErr) => {
-            logger.warn('Failed to clean Hermes provider config', {
+            logger.warn('Hermes provider config cleanup failed', {
               agentId: agent.id,
               error:
                 cleanupErr instanceof Error

--- a/packages/browseros-agent/apps/server/src/lib/agents/runtime/hermes-container-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/runtime/hermes-container-runtime.ts
@@ -255,16 +255,6 @@ export interface ConfigureHermesRuntimeOptions {
   browserosDir?: string
 }
 
-export type HermesRuntimeStartupPhase = 'configure' | 'install' | 'start'
-
-export interface StartHermesRuntimeBestEffortOptions
-  extends ConfigureHermesRuntimeOptions {
-  configureRuntime?: (
-    options: ConfigureHermesRuntimeOptions,
-  ) => HermesContainerRuntime | null
-  onError?: (phase: HermesRuntimeStartupPhase, error: unknown) => void
-}
-
 /**
  * Build a `HermesContainerRuntime` with production deps (bundled
  * limactl, BrowserOS state dirs, Lima VM runtime) and register it in
@@ -324,38 +314,6 @@ export function configureHermesRuntime(
 }
 
 /**
- * Startup wiring for the Hermes adapter. Kept beside the adapter runtime so
- * the server entry point does not need to know Hermes' install/start sequence.
- */
-export function startHermesRuntimeBestEffort(
-  options: StartHermesRuntimeBestEffortOptions = {},
-): HermesContainerRuntime | null {
-  const {
-    configureRuntime = configureHermesRuntime,
-    onError = logHermesStartupError,
-    ...configureOptions
-  } = options
-
-  let runtime: HermesContainerRuntime | null
-  try {
-    runtime = configureRuntime(configureOptions)
-  } catch (err) {
-    onError('configure', err)
-    return null
-  }
-
-  if (!runtime) return null
-
-  void runtime
-    .executeAction({ type: 'install' })
-    .catch((err) => onError('install', err))
-  void runtime
-    .executeAction({ type: 'start' })
-    .catch((err) => onError('start', err))
-  return runtime
-}
-
-/**
  * Configure and start Hermes on demand for the first Hermes agent.
  * Startup intentionally does not call this, because `start` can create
  * the shared BrowserOS VM; agent creation is the user intent boundary.
@@ -379,19 +337,4 @@ export async function ensureHermesRuntimeReady(
 export function getHermesRuntime(): HermesContainerRuntime | null {
   const r = getAgentRuntimeRegistry().get('hermes')
   return r instanceof HermesContainerRuntime ? r : null
-}
-
-function logHermesStartupError(
-  phase: HermesRuntimeStartupPhase,
-  error: unknown,
-): void {
-  const message =
-    phase === 'configure'
-      ? 'Hermes container configuration failed, continuing without it'
-      : phase === 'install'
-        ? 'Hermes prewarm failed'
-        : 'Hermes container start failed'
-  logger.warn(message, {
-    error: error instanceof Error ? error.message : String(error),
-  })
 }

--- a/packages/browseros-agent/apps/server/src/lib/agents/runtime/hermes-container-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/runtime/hermes-container-runtime.ts
@@ -47,6 +47,7 @@ import {
   getHermesHostStateDir,
 } from '../hermes/hermes-paths'
 import { ContainerAgentRuntime } from './container-agent-runtime'
+import { RuntimeNotReadyError } from './errors'
 import { getAgentRuntimeRegistry } from './registry'
 import type { ExecSpec } from './types'
 
@@ -351,6 +352,26 @@ export function startHermesRuntimeBestEffort(
   void runtime
     .executeAction({ type: 'start' })
     .catch((err) => onError('start', err))
+  return runtime
+}
+
+/**
+ * Configure and start Hermes on demand for the first Hermes agent.
+ * Startup intentionally does not call this, because `start` can create
+ * the shared BrowserOS VM; agent creation is the user intent boundary.
+ */
+export async function ensureHermesRuntimeReady(
+  options: ConfigureHermesRuntimeOptions = {},
+): Promise<HermesContainerRuntime> {
+  const runtime = getHermesRuntime() ?? configureHermesRuntime(options)
+  if (!runtime) {
+    throw new RuntimeNotReadyError(
+      'hermes',
+      'unavailable',
+      'Hermes container runtime is not available on this platform.',
+    )
+  }
+  await runtime.executeAction({ type: 'start' })
   return runtime
 }
 

--- a/packages/browseros-agent/apps/server/src/lib/agents/runtime/index.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/runtime/index.ts
@@ -26,6 +26,7 @@ export { ActionNotSupportedError, RuntimeNotReadyError } from './errors'
 export {
   type ConfigureHermesRuntimeOptions,
   configureHermesRuntime,
+  ensureHermesRuntimeReady,
   getHermesRuntime,
   HermesContainerRuntime,
   type HermesContainerRuntimeConfig,

--- a/packages/browseros-agent/apps/server/src/lib/agents/runtime/index.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/runtime/index.ts
@@ -31,8 +31,6 @@ export {
   HermesContainerRuntime,
   type HermesContainerRuntimeConfig,
   prepareHermesContext,
-  type StartHermesRuntimeBestEffortOptions,
-  startHermesRuntimeBestEffort,
 } from './hermes-container-runtime'
 export {
   HostProcessAgentRuntime,

--- a/packages/browseros-agent/apps/server/src/main.ts
+++ b/packages/browseros-agent/apps/server/src/main.ts
@@ -20,7 +20,6 @@ import {
   configureClaudeRuntime,
   configureCodexRuntime,
   getHermesRuntime,
-  startHermesRuntimeBestEffort,
 } from './lib/agents/runtime'
 import {
   cleanOldSessions,
@@ -52,7 +51,6 @@ export class Application {
       resourcesDir: path.resolve(this.config.resourcesDir),
     })
 
-    const resourcesDir = path.resolve(this.config.resourcesDir)
     configureClaudeRuntime()
     configureCodexRuntime()
     await this.initCoreServices()
@@ -117,8 +115,6 @@ export class Application {
     )
 
     this.logStartupSummary()
-
-    startHermesRuntimeBestEffort({ resourcesDir })
 
     metrics.log('http_server.started', { version: VERSION })
   }

--- a/packages/browseros-agent/apps/server/tests/api/services/agents/agent-harness-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/agents/agent-harness-service.test.ts
@@ -4,11 +4,14 @@
  */
 
 import { describe, expect, it } from 'bun:test'
-import { mkdtempSync, readFileSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync } from 'node:fs'
 import { rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { AgentHarnessService } from '../../../../src/api/services/agents/agent-harness-service'
+import {
+  AgentHarnessService,
+  type EnsureVmRuntimeReady,
+} from '../../../../src/api/services/agents/agent-harness-service'
 import type { AgentStore } from '../../../../src/lib/agents/agent-store'
 import type { AgentDefinition } from '../../../../src/lib/agents/agent-types'
 import type {
@@ -274,6 +277,55 @@ describe('AgentHarnessService', () => {
     })
   })
 
+  it('ensures the VM runtime when a Hermes agent is created', async () => {
+    const readinessCalls: string[] = []
+    await withHermesBrowserosDir(
+      async ({ service }) => {
+        await service.createAgent({
+          name: 'Hermes bot',
+          adapter: 'hermes',
+          providerType: 'openrouter',
+          apiKey: 'sk-or-v1-test-key',
+          modelId: 'anthropic/claude-haiku-4.5',
+        })
+
+        expect(readinessCalls).toEqual(['hermes'])
+      },
+      {
+        ensureVmRuntimeReady: async (adapter) => {
+          readinessCalls.push(adapter)
+        },
+      },
+    )
+  })
+
+  it('rolls back Hermes agent creation when runtime startup fails', async () => {
+    await withHermesBrowserosDir(
+      async ({ agents, browserosDir, service }) => {
+        await expect(
+          service.createAgent({
+            name: 'Broken Hermes',
+            adapter: 'hermes',
+            providerType: 'openrouter',
+            apiKey: 'sk-or-v1-test-key',
+            modelId: 'anthropic/claude-haiku-4.5',
+          }),
+        ).rejects.toThrow('hermes start failed')
+        expect(agents).toHaveLength(0)
+        expect(
+          existsSync(
+            join(browserosDir, 'vm', 'hermes', 'harness', 'agent-1'),
+          ),
+        ).toBe(false)
+      },
+      {
+        ensureVmRuntimeReady: async () => {
+          throw new Error('hermes start failed')
+        },
+      },
+    )
+  })
+
   it('rejects Hermes agent creation when apiKey is missing', async () => {
     await withHermesBrowserosDir(async ({ agents, service }) => {
       await expect(
@@ -407,6 +459,7 @@ async function withHermesBrowserosDir<T>(
     browserosDir: string
     service: AgentHarnessService
   }) => Promise<T>,
+  options: { ensureVmRuntimeReady?: EnsureVmRuntimeReady } = {},
 ): Promise<T> {
   const browserosDir = mkdtempSync(join(tmpdir(), 'browseros-hermes-test-'))
   const agents: AgentDefinition[] = []
@@ -414,6 +467,7 @@ async function withHermesBrowserosDir<T>(
     const service = new AgentHarnessService({
       agentStore: createAgentStore(agents) as AgentStore,
       browserosDir,
+      ensureVmRuntimeReady: options.ensureVmRuntimeReady,
       runtime: stubRuntime(),
     })
     return await run({ agents, browserosDir, service })

--- a/packages/browseros-agent/apps/server/tests/api/services/agents/agent-harness-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/agents/agent-harness-service.test.ts
@@ -311,12 +311,16 @@ describe('AgentHarnessService', () => {
             modelId: 'anthropic/claude-haiku-4.5',
           }),
         ).rejects.toThrow('hermes start failed')
+        const homeDir = join(
+          browserosDir,
+          'vm',
+          'hermes',
+          'harness',
+          'agent-1',
+          'home',
+        )
         expect(agents).toHaveLength(0)
-        expect(
-          existsSync(
-            join(browserosDir, 'vm', 'hermes', 'harness', 'agent-1'),
-          ),
-        ).toBe(false)
+        expect(existsSync(homeDir)).toBe(false)
       },
       {
         ensureVmRuntimeReady: async () => {

--- a/packages/browseros-agent/apps/server/tests/lib/agents/runtime/hermes-container-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/runtime/hermes-container-runtime.test.ts
@@ -20,9 +20,7 @@ import {
   getHermesRuntime,
   HermesContainerRuntime,
   resetAgentRuntimeRegistry,
-  startHermesRuntimeBestEffort,
 } from '../../../../src/lib/agents/runtime'
-import type { RuntimeAction } from '../../../../src/lib/agents/runtime/types'
 import type {
   ManagedContainerDeps,
   MountRoot,
@@ -250,79 +248,6 @@ describe('HermesContainerRuntime', () => {
       expect(() => configureHermesRuntime({ browserosDir })).toThrow(
         /already registered/,
       )
-    })
-  })
-
-  describe('startHermesRuntimeBestEffort', () => {
-    it('configures Hermes and schedules install + start actions', async () => {
-      const actions: RuntimeAction[] = []
-      const runtime = {
-        executeAction: async (action: RuntimeAction) => {
-          actions.push(action)
-        },
-      } as HermesContainerRuntime
-
-      const result = startHermesRuntimeBestEffort({
-        resourcesDir: '/Applications/BrowserOS.app/Contents/Resources',
-        configureRuntime: (options) => {
-          expect(options).toEqual({
-            resourcesDir: '/Applications/BrowserOS.app/Contents/Resources',
-          })
-          return runtime
-        },
-        onError: (phase, error) => {
-          throw new Error(`${phase}: ${String(error)}`)
-        },
-      })
-
-      expect(result).toBe(runtime)
-      expect(actions).toEqual([{ type: 'install' }, { type: 'start' }])
-    })
-
-    it('returns null when Hermes configuration throws', () => {
-      const errors: Array<{ phase: string; message: string }> = []
-
-      const result = startHermesRuntimeBestEffort({
-        configureRuntime: () => {
-          throw new Error('unsupported')
-        },
-        onError: (phase, error) => {
-          errors.push({
-            phase,
-            message: error instanceof Error ? error.message : String(error),
-          })
-        },
-      })
-
-      expect(result).toBeNull()
-      expect(errors).toEqual([{ phase: 'configure', message: 'unsupported' }])
-    })
-
-    it('reports install and start failures without throwing', async () => {
-      const errors: Array<{ phase: string; message: string }> = []
-      const runtime = {
-        executeAction: async (action: RuntimeAction) => {
-          throw new Error(`${action.type} failed`)
-        },
-      } as HermesContainerRuntime
-
-      const result = startHermesRuntimeBestEffort({
-        configureRuntime: () => runtime,
-        onError: (phase, error) => {
-          errors.push({
-            phase,
-            message: error instanceof Error ? error.message : String(error),
-          })
-        },
-      })
-
-      expect(result).toBe(runtime)
-      await Promise.resolve()
-      await Promise.resolve()
-      expect(errors).toEqual([
-        { phase: 'install', message: 'install failed' },
-        { phase: 'start', message: 'start failed' },
-      ])
     })
   })
 

--- a/packages/browseros-agent/apps/server/tests/lib/agents/runtime/hermes-container-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/runtime/hermes-container-runtime.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../../../../../../packages/shared/src/constants/hermes'
 import {
   configureHermesRuntime,
+  ensureHermesRuntimeReady,
   getAgentRuntimeRegistry,
   getHermesRuntime,
   HermesContainerRuntime,
@@ -322,6 +323,34 @@ describe('HermesContainerRuntime', () => {
         { phase: 'install', message: 'install failed' },
         { phase: 'start', message: 'start failed' },
       ])
+    })
+  })
+
+  describe('ensureHermesRuntimeReady', () => {
+    it('starts the registered Hermes runtime on demand', async () => {
+      const lockDir = mkTempDir()
+      const { deps } = makeDeps({ lockDir })
+      const runtime = new HermesContainerRuntime(deps, {
+        hermesHarnessHostDir: '/host/browseros/vm/hermes/harness',
+      })
+      getAgentRuntimeRegistry().register(runtime)
+
+      const result = await ensureHermesRuntimeReady()
+
+      expect(result).toBe(runtime)
+      expect(runtime.getState()).toBe('running')
+    })
+
+    it('throws a runtime-not-ready error when Hermes is unavailable', async () => {
+      const originalPlatform = process.platform
+      Object.defineProperty(process, 'platform', { value: 'linux' })
+      try {
+        await expect(ensureHermesRuntimeReady()).rejects.toThrow(
+          /Runtime "hermes" is not ready/,
+        )
+      } finally {
+        Object.defineProperty(process, 'platform', { value: originalPlatform })
+      }
     })
   })
 })

--- a/packages/browseros-agent/apps/server/tests/main.test.ts
+++ b/packages/browseros-agent/apps/server/tests/main.test.ts
@@ -49,6 +49,22 @@ describe('Application.start', () => {
     expect(loggerError).not.toHaveBeenCalled()
   })
 
+  it('does not start the Hermes runtime on startup', async () => {
+    const {
+      Application,
+      configureHermesRuntime,
+      createHttpServer,
+      hermesService,
+    } = await setupApplicationTest()
+    const app = new Application(config)
+
+    await app.start()
+
+    expect(createHttpServer).toHaveBeenCalledTimes(1)
+    expect(configureHermesRuntime).not.toHaveBeenCalled()
+    expect(hermesService.executeAction).not.toHaveBeenCalled()
+  })
+
   it('stores the database below the BrowserOS directory instead of the execution directory', async () => {
     const originalBrowserosDir = process.env.BROWSEROS_DIR
     process.env.BROWSEROS_DIR = '/tmp/browseros-dogfood'
@@ -134,9 +150,10 @@ async function setupApplicationTest() {
 
   const hermesExecuteAction = mock(async () => {})
   const fakeHermesRuntime = { executeAction: hermesExecuteAction } as never
-  spyOn(runtimeModule, 'configureHermesRuntime').mockImplementation(
-    () => fakeHermesRuntime,
-  )
+  const configureHermesRuntime = spyOn(
+    runtimeModule,
+    'configureHermesRuntime',
+  ).mockImplementation(() => fakeHermesRuntime)
   spyOn(runtimeModule, 'getHermesRuntime').mockImplementation(
     () => fakeHermesRuntime,
   )
@@ -157,6 +174,7 @@ async function setupApplicationTest() {
     loggerInfo,
     loggerWarn,
     initializeDb,
+    configureHermesRuntime,
     hermesService: { executeAction: hermesExecuteAction },
   }
 }

--- a/packages/browseros-agent/apps/server/tests/tools/dom.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/dom.test.ts
@@ -6,7 +6,10 @@ import { dirname, join } from 'node:path'
 import { get_dom, search_dom } from '../../src/tools/dom'
 import { close_page, new_page } from '../../src/tools/navigation'
 import { evaluate_script } from '../../src/tools/snapshot'
-import { withBrowser } from '../__helpers__/with-browser'
+import {
+  type WithBrowserContext,
+  withBrowser,
+} from '../__helpers__/with-browser'
 
 function textOf(result: {
   content: { type: string; text?: string }[]
@@ -77,13 +80,35 @@ function cleanupSavedDom(domPath: string): void {
   } catch {}
 }
 
+/** Opens the shared DOM fixture after its static form controls are queryable. */
+async function openRichPage(
+  execute: WithBrowserContext['execute'],
+): Promise<number> {
+  const newResult = await execute(new_page, { url: RICH_PAGE })
+  const pageId = pageIdOf(newResult)
+
+  for (let attempt = 0; attempt < 20; attempt++) {
+    const readyResult = await execute(evaluate_script, {
+      page: pageId,
+      expression:
+        "document.readyState !== 'loading' && Boolean(document.querySelector('#submit-btn[data-testid=\"login-submit\"]')) ? 'ready' : document.readyState",
+    })
+    if (!readyResult.isError && textOf(readyResult) === 'ready') {
+      return pageId
+    }
+    await Bun.sleep(50)
+  }
+
+  await execute(close_page, { page: pageId })
+  assert.fail('Rich DOM fixture did not become queryable')
+}
+
 // ── get_dom ──
 
 describe('get_dom', () => {
   it('returns full page HTML', async () => {
     await withBrowser(async ({ execute }) => {
-      const newResult = await execute(new_page, { url: RICH_PAGE })
-      const pageId = pageIdOf(newResult)
+      const pageId = await openRichPage(execute)
       let domPath: string | undefined
 
       try {
@@ -121,8 +146,7 @@ describe('get_dom', () => {
 
   it('scopes to a CSS selector', async () => {
     await withBrowser(async ({ execute }) => {
-      const newResult = await execute(new_page, { url: RICH_PAGE })
-      const pageId = pageIdOf(newResult)
+      const pageId = await openRichPage(execute)
       let domPath: string | undefined
 
       try {
@@ -158,8 +182,7 @@ describe('get_dom', () => {
 
   it('scopes to a nested CSS selector', async () => {
     await withBrowser(async ({ execute }) => {
-      const newResult = await execute(new_page, { url: RICH_PAGE })
-      const pageId = pageIdOf(newResult)
+      const pageId = await openRichPage(execute)
       let domPath: string | undefined
 
       try {
@@ -184,8 +207,7 @@ describe('get_dom', () => {
 
   it('returns error for non-matching selector', async () => {
     await withBrowser(async ({ execute }) => {
-      const newResult = await execute(new_page, { url: RICH_PAGE })
-      const pageId = pageIdOf(newResult)
+      const pageId = await openRichPage(execute)
 
       const result = await execute(get_dom, {
         page: pageId,
@@ -268,8 +290,7 @@ describe('get_dom', () => {
 
   it('preserves element attributes in output', async () => {
     await withBrowser(async ({ execute }) => {
-      const newResult = await execute(new_page, { url: RICH_PAGE })
-      const pageId = pageIdOf(newResult)
+      const pageId = await openRichPage(execute)
       let domPath: string | undefined
 
       try {
@@ -303,8 +324,7 @@ describe('get_dom', () => {
 describe('search_dom', () => {
   it('finds elements by plain text', async () => {
     await withBrowser(async ({ execute }) => {
-      const newResult = await execute(new_page, { url: RICH_PAGE })
-      const pageId = pageIdOf(newResult)
+      const pageId = await openRichPage(execute)
 
       const result = await execute(search_dom, {
         page: pageId,
@@ -331,8 +351,7 @@ describe('search_dom', () => {
 
   it('finds elements by CSS selector', async () => {
     await withBrowser(async ({ execute }) => {
-      const newResult = await execute(new_page, { url: RICH_PAGE })
-      const pageId = pageIdOf(newResult)
+      const pageId = await openRichPage(execute)
 
       const result = await execute(search_dom, {
         page: pageId,
@@ -353,8 +372,7 @@ describe('search_dom', () => {
 
   it('finds elements by XPath', async () => {
     await withBrowser(async ({ execute }) => {
-      const newResult = await execute(new_page, { url: RICH_PAGE })
-      const pageId = pageIdOf(newResult)
+      const pageId = await openRichPage(execute)
 
       const result = await execute(search_dom, {
         page: pageId,
@@ -371,8 +389,7 @@ describe('search_dom', () => {
 
   it('finds multiple elements with CSS class selector', async () => {
     await withBrowser(async ({ execute }) => {
-      const newResult = await execute(new_page, { url: RICH_PAGE })
-      const pageId = pageIdOf(newResult)
+      const pageId = await openRichPage(execute)
 
       const result = await execute(search_dom, {
         page: pageId,
@@ -388,8 +405,7 @@ describe('search_dom', () => {
 
   it('finds elements by ID selector', async () => {
     await withBrowser(async ({ execute }) => {
-      const newResult = await execute(new_page, { url: RICH_PAGE })
-      const pageId = pageIdOf(newResult)
+      const pageId = await openRichPage(execute)
 
       const result = await execute(search_dom, {
         page: pageId,
@@ -410,8 +426,7 @@ describe('search_dom', () => {
 
   it('returns no-match message for non-existent content', async () => {
     await withBrowser(async ({ execute }) => {
-      const newResult = await execute(new_page, { url: RICH_PAGE })
-      const pageId = pageIdOf(newResult)
+      const pageId = await openRichPage(execute)
 
       const result = await execute(search_dom, {
         page: pageId,
@@ -429,8 +444,7 @@ describe('search_dom', () => {
 
   it('respects limit parameter', async () => {
     await withBrowser(async ({ execute }) => {
-      const newResult = await execute(new_page, { url: RICH_PAGE })
-      const pageId = pageIdOf(newResult)
+      const pageId = await openRichPage(execute)
 
       const result = await execute(search_dom, {
         page: pageId,
@@ -459,8 +473,7 @@ describe('search_dom', () => {
 
   it('returns element attributes in search results', async () => {
     await withBrowser(async ({ execute }) => {
-      const newResult = await execute(new_page, { url: RICH_PAGE })
-      const pageId = pageIdOf(newResult)
+      const pageId = await openRichPage(execute)
 
       const result = await execute(search_dom, {
         page: pageId,
@@ -514,8 +527,7 @@ describe('search_dom', () => {
 
   it('finds elements using attribute selector', async () => {
     await withBrowser(async ({ execute }) => {
-      const newResult = await execute(new_page, { url: RICH_PAGE })
-      const pageId = pageIdOf(newResult)
+      const pageId = await openRichPage(execute)
 
       const result = await execute(search_dom, {
         page: pageId,
@@ -532,8 +544,7 @@ describe('search_dom', () => {
 
   it('finds text across multiple elements', async () => {
     await withBrowser(async ({ execute }) => {
-      const newResult = await execute(new_page, { url: RICH_PAGE })
-      const pageId = pageIdOf(newResult)
+      const pageId = await openRichPage(execute)
 
       const result = await execute(search_dom, {
         page: pageId,
@@ -554,8 +565,7 @@ describe('search_dom', () => {
 
   it('includes nodeId in search results for element reference', async () => {
     await withBrowser(async ({ execute }) => {
-      const newResult = await execute(new_page, { url: RICH_PAGE })
-      const pageId = pageIdOf(newResult)
+      const pageId = await openRichPage(execute)
 
       const result = await execute(search_dom, {
         page: pageId,


### PR DESCRIPTION
## Summary
- Stop server startup from starting the Hermes container runtime.
- Start Hermes lazily when a Hermes agent is created via the generic `ensureVmRuntimeReady` hook.
- Preserve `main`'s OpenClaw removal; this branch does not reintroduce OpenClaw server surfaces.
- Stabilize the DOM fixture wait and the MCP Function guard that were flaking in CI.

## Design
Startup now configures only the host-process runtimes. `createHttpServer` wires `ensureVmRuntimeReady`, and the harness invokes it after writing Hermes per-agent provider config. If runtime startup fails, the harness rolls back both the agent record and the Hermes provider files.

## Test plan
- `bun test apps/server/tests/main.test.ts apps/server/tests/api/services/agents/agent-harness-service.test.ts apps/server/tests/lib/agents/runtime/hermes-container-runtime.test.ts`
- `bun --env-file=apps/server/.env.development test apps/server/tests/tools/dom.test.ts`
- `bun test apps/agent/lib/mcp/client.test.ts`
- `bunx bun@1.3.14 test apps/agent/lib/mcp/client.test.ts`
- `bunx bun@1.3.14 run test` from `apps/agent`
- `bun run typecheck`
- `bunx biome check ...changed files...`