### PR TITLE
feat: bundle Bun for macOS ACP adapters

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/routes/agents.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/agents.ts
@@ -97,6 +97,7 @@ type AgentRouteDeps = {
   service?: AgentRouteService
   browser?: Pick<Browser, 'resolveTabIds'>
   browserosServerPort?: number
+  resourcesDir?: string
   /** Optional hook for harness-owned VM/container runtimes. */
   ensureVmRuntimeReady?: EnsureVmRuntimeReady
   /** Optional override; defaults to a fresh in-memory checker. */
@@ -119,6 +120,7 @@ export function createAgentRoutes(deps: AgentRouteDeps = {}) {
     deps.service ??
     new AgentHarnessService({
       browserosServerPort: deps.browserosServerPort,
+      resourcesDir: deps.resourcesDir,
       ensureVmRuntimeReady: deps.ensureVmRuntimeReady,
     })
   if (deps.onTurnLifecycle && service instanceof AgentHarnessService) {

--- a/packages/browseros-agent/apps/server/src/api/server.ts
+++ b/packages/browseros-agent/apps/server/src/api/server.ts
@@ -102,6 +102,7 @@ export async function createHttpServer(config: HttpServerConfig) {
       '/',
       createAgentRoutes({
         browserosServerPort: port,
+        resourcesDir,
         browser,
         ensureVmRuntimeReady: async (adapter) => {
           switch (adapter) {

--- a/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
@@ -138,6 +138,7 @@ export class AgentHarnessService {
       agentStore?: AgentStore
       runtime?: AgentRuntime
       browserosDir?: string
+      resourcesDir?: string
       browserosServerPort?: number
       ensureVmRuntimeReady?: EnsureVmRuntimeReady
       turnRegistry?: TurnRegistry
@@ -150,6 +151,7 @@ export class AgentHarnessService {
       deps.runtime ??
       new AcpxRuntime({
         browserosDir: this.browserosDir,
+        resourcesDir: deps.resourcesDir,
         browserosServerPort: deps.browserosServerPort,
       })
     this.ensureVmRuntimeReady = deps.ensureVmRuntimeReady ?? null

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime-context.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime-context.ts
@@ -255,7 +255,7 @@ async function sourceFileExists(path: string): Promise<boolean> {
   return true
 }
 
-function shellQuote(value: string): string {
+export function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`
 }
 

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
@@ -23,6 +23,7 @@ import { logger } from '../logger'
 import { prepareAcpxAgentContext } from './acpx-agent-adapter'
 import {
   resolveAgentRuntimePaths,
+  shellQuote,
   wrapCommandWithEnv,
 } from './acpx-runtime-context'
 import { loadLatestRuntimeState } from './acpx-runtime-state'
@@ -31,6 +32,7 @@ import type {
   AgentHistoryEntry,
   AgentHistoryToolCall,
 } from './agent-types'
+import { buildMacosAcpAdapterPath, resolveBundledBun } from './bundled-bun'
 import { getHermesRuntime } from './runtime'
 import type {
   AgentHistoryPage,
@@ -45,10 +47,15 @@ import type {
 const CLAUDE_ACP_ADAPTER_COMMAND =
   'npx -y @agentclientprotocol/claude-agent-acp@^0.31.0'
 const CODEX_ACP_ADAPTER_COMMAND = 'npx -y @zed-industries/codex-acp@^0.12.0'
+const CLAUDE_ACP_PACKAGE = '@agentclientprotocol/claude-agent-acp@^0.31.0'
+const CLAUDE_ACP_BIN = 'claude-agent-acp'
+const CODEX_ACP_PACKAGE = '@zed-industries/codex-acp@^0.12.0'
+const CODEX_ACP_BIN = 'codex-acp'
 
 type AcpxRuntimeOptions = {
   cwd?: string
   browserosDir?: string
+  resourcesDir?: string
   stateDir?: string
   browserosServerPort?: number
   runtimeFactory?: (options: AcpRuntimeOptions) => AcpxCoreRuntime
@@ -67,6 +74,7 @@ interface PreparedRuntimeContext {
 export class AcpxRuntime implements AgentRuntime {
   private readonly defaultCwd: string | null
   private readonly browserosDir: string
+  private readonly resourcesDir: string | null
   private readonly stateDir: string
   private readonly browserosServerPort: number
   private readonly runtimeFactory: (
@@ -78,6 +86,7 @@ export class AcpxRuntime implements AgentRuntime {
   constructor(options: AcpxRuntimeOptions = {}) {
     this.defaultCwd = options.cwd ?? null
     this.browserosDir = options.browserosDir ?? getBrowserosDir()
+    this.resourcesDir = options.resourcesDir ?? null
     this.stateDir =
       options.stateDir ??
       process.env.BROWSEROS_ACPX_STATE_DIR ??
@@ -245,6 +254,8 @@ export class AcpxRuntime implements AgentRuntime {
       sessionStore: this.sessionStore,
       agentRegistry: createBrowserosAgentRegistry({
         commandEnv: input.commandEnv,
+        resourcesDir: this.resourcesDir,
+        browserosDir: this.browserosDir,
       }),
       mcpServers: input.useBrowserosMcp
         ? createBrowserosMcpServers(this.browserosServerPort, mcpHost)
@@ -648,6 +659,8 @@ function createBrowserosMcpServers(
 
 function createBrowserosAgentRegistry(input: {
   commandEnv: Record<string, string>
+  resourcesDir: string | null
+  browserosDir: string
 }): AcpRuntimeOptions['agentRegistry'] {
   const registry = createAgentRegistry()
 
@@ -668,9 +681,15 @@ function createBrowserosAgentRegistry(input: {
       }
 
       if (lower === 'claude' || lower === 'codex') {
+        const launch = resolveBrowserosHostAcpAdapterCommand({
+          adapter: lower,
+          resourcesDir: input.resourcesDir,
+        })
         return wrapCommandWithEnv(
-          resolveBrowserosHostAcpAdapterCommand(lower),
-          input.commandEnv,
+          launch.command,
+          launch.addMacosAdapterEnv
+            ? withMacosAcpAdapterEnv(input.commandEnv, input.browserosDir)
+            : input.commandEnv,
         )
       }
 
@@ -681,17 +700,47 @@ function createBrowserosAgentRegistry(input: {
 
 /**
  * Resolve host-spawned Claude/Codex ACP adapters without asking acpx
- * to discover package bins. BrowserOS prefixes commands with `env`;
- * that hides acpx's built-in command from its package launcher, and
- * in Bun standalone builds that launcher may also see `$bunfs` paths
- * plus the compiled BrowserOS binary as `process.execPath`.
+ * to discover package bins. Packaged macOS builds prefer BrowserOS's
+ * bundled Bun so adapter package execution doesn't depend on host
+ * `npx` or the app launch environment.
  */
-function resolveBrowserosHostAcpAdapterCommand(
-  adapter: 'claude' | 'codex',
-): string {
-  return adapter === 'claude'
-    ? CLAUDE_ACP_ADAPTER_COMMAND
-    : CODEX_ACP_ADAPTER_COMMAND
+function resolveBrowserosHostAcpAdapterCommand(input: {
+  adapter: 'claude' | 'codex'
+  resourcesDir: string | null
+}): { command: string; addMacosAdapterEnv: boolean } {
+  const bun = resolveBundledBun({ resourcesDir: input.resourcesDir })
+  if (bun) {
+    const pkg =
+      input.adapter === 'claude' ? CLAUDE_ACP_PACKAGE : CODEX_ACP_PACKAGE
+    const bin = input.adapter === 'claude' ? CLAUDE_ACP_BIN : CODEX_ACP_BIN
+    return {
+      command: `${shellQuote(bun)} x --bun --silent --package ${pkg} ${bin}`,
+      addMacosAdapterEnv: true,
+    }
+  }
+
+  return {
+    command:
+      input.adapter === 'claude'
+        ? CLAUDE_ACP_ADAPTER_COMMAND
+        : CODEX_ACP_ADAPTER_COMMAND,
+    addMacosAdapterEnv: false,
+  }
+}
+
+/** Adds the minimum macOS env needed for bundled Bun and native CLI lookup. */
+function withMacosAcpAdapterEnv(
+  env: Record<string, string>,
+  browserosDir: string,
+): Record<string, string> {
+  return {
+    ...env,
+    BUN_INSTALL_CACHE_DIR: join(browserosDir, 'cache', 'bun-install'),
+    PATH: buildMacosAcpAdapterPath({
+      basePath: process.env.PATH,
+      home: process.env.HOME,
+    }),
+  }
 }
 
 async function applyRuntimeControls(

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
@@ -714,7 +714,7 @@ function resolveBrowserosHostAcpAdapterCommand(input: {
       input.adapter === 'claude' ? CLAUDE_ACP_PACKAGE : CODEX_ACP_PACKAGE
     const bin = input.adapter === 'claude' ? CLAUDE_ACP_BIN : CODEX_ACP_BIN
     return {
-      command: `${shellQuote(bun)} x --bun --silent --package ${pkg} ${bin}`,
+      command: `${shellQuote(bun)} x --bun --silent --package ${shellQuote(pkg)} ${shellQuote(bin)}`,
       addMacosAdapterEnv: true,
     }
   }
@@ -737,8 +737,8 @@ function withMacosAcpAdapterEnv(
     ...env,
     BUN_INSTALL_CACHE_DIR: join(browserosDir, 'cache', 'bun-install'),
     PATH: buildMacosAcpAdapterPath({
-      basePath: process.env.PATH,
-      home: process.env.HOME,
+      basePath: env.PATH ?? process.env.PATH,
+      home: env.HOME ?? process.env.HOME,
     }),
   }
 }

--- a/packages/browseros-agent/apps/server/src/lib/agents/bundled-bun.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/bundled-bun.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { existsSync, statSync } from 'node:fs'
+import { accessSync, constants, statSync } from 'node:fs'
 import { delimiter, join } from 'node:path'
 
 export const BUNDLED_BUN_RELATIVE_PATH = join('bin', 'third_party', 'bun')
@@ -14,15 +14,16 @@ export function resolveBundledBun(input: {
   resourcesDir?: string | null
   platform?: NodeJS.Platform
 }): string | null {
-  if (input.platform && input.platform !== 'darwin') return null
-  if (!input.platform && process.platform !== 'darwin') return null
+  const platform = input.platform ?? process.platform
+  if (platform !== 'darwin') return null
   const resourcesDir = input.resourcesDir?.trim()
   if (!resourcesDir) return null
 
   const candidate = join(resourcesDir, BUNDLED_BUN_RELATIVE_PATH)
   try {
-    if (!existsSync(candidate)) return null
-    return statSync(candidate).isFile() ? candidate : null
+    if (!statSync(candidate).isFile()) return null
+    accessSync(candidate, constants.X_OK)
+    return candidate
   } catch {
     return null
   }

--- a/packages/browseros-agent/apps/server/src/lib/agents/bundled-bun.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/bundled-bun.ts
@@ -1,0 +1,53 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { existsSync, statSync } from 'node:fs'
+import { delimiter, join } from 'node:path'
+
+export const BUNDLED_BUN_RELATIVE_PATH = join('bin', 'third_party', 'bun')
+
+/** Resolves the packaged Bun executable used to run ACP adapter packages. */
+export function resolveBundledBun(input: {
+  resourcesDir?: string | null
+  platform?: NodeJS.Platform
+}): string | null {
+  if (input.platform && input.platform !== 'darwin') return null
+  if (!input.platform && process.platform !== 'darwin') return null
+  const resourcesDir = input.resourcesDir?.trim()
+  if (!resourcesDir) return null
+
+  const candidate = join(resourcesDir, BUNDLED_BUN_RELATIVE_PATH)
+  try {
+    if (!existsSync(candidate)) return null
+    return statSync(candidate).isFile() ? candidate : null
+  } catch {
+    return null
+  }
+}
+
+/** Builds a macOS host PATH for GUI-launched adapter processes. */
+export function buildMacosAcpAdapterPath(input: {
+  basePath?: string
+  home?: string
+}): string {
+  const home = input.home?.trim()
+  const candidates = [
+    home ? join(home, '.local', 'bin') : '',
+    home ? join(home, '.bun', 'bin') : '',
+    '/opt/homebrew/bin',
+    '/usr/local/bin',
+    input.basePath ?? '',
+    '/usr/bin',
+    '/bin',
+    '/usr/sbin',
+    '/sbin',
+  ]
+
+  const parts = candidates.flatMap((value) =>
+    value.split(delimiter).filter(Boolean),
+  )
+  return [...new Set(parts)].join(delimiter)
+}

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -4,9 +4,9 @@
  */
 
 import { afterEach, describe, expect, it } from 'bun:test'
-import { mkdtemp, rm } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { dirname, join } from 'node:path'
 import type {
   AcpRuntimeEvent,
   AcpRuntimeHandle,
@@ -960,6 +960,54 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
     expect(command).toContain('npx -y @zed-industries/codex-acp')
   })
 
+  it('runs Claude and Codex ACP adapter packages through bundled Bun on macOS', async () => {
+    if (process.platform !== 'darwin') return
+    const browserosDir = await mkdtemp(
+      join(tmpdir(), 'browseros-acpx-browseros-'),
+    )
+    const stateDir = await mkdtemp(join(tmpdir(), 'browseros-acpx-state-'))
+    const resourcesDir = await mkdtemp(
+      join(tmpdir(), 'browseros-acpx-resources-'),
+    )
+    tempDirs.push(browserosDir, stateDir, resourcesDir)
+    const bunPath = await writeFakeBundledBun(resourcesDir)
+    const calls: Array<{ method: string; input: unknown }> = []
+    const runtime = new AcpxRuntime({
+      browserosDir,
+      resourcesDir,
+      stateDir,
+      runtimeFactory: (options) => {
+        calls.push({ method: 'createRuntime', input: options })
+        return createFakeAcpRuntime(calls)
+      },
+    })
+    const agent = makeAgent({ id: 'agent-1', adapter: 'codex' })
+
+    await collectStream(
+      await runtime.send({
+        agent,
+        sessionId: 'main',
+        sessionKey: agent.sessionKey,
+        message: 'hi',
+        permissionMode: 'approve-all',
+      }),
+    )
+
+    const registry = getCreateRuntimeOptions(calls).agentRegistry
+    const claudeCommand = registry.resolve('claude')
+    const codexCommand = registry.resolve('codex')
+    expect(claudeCommand).toContain(
+      `'${bunPath}' x --bun --silent --package @agentclientprotocol/claude-agent-acp@^0.31.0 claude-agent-acp`,
+    )
+    expect(codexCommand).toContain(
+      `'${bunPath}' x --bun --silent --package @zed-industries/codex-acp@^0.12.0 codex-acp`,
+    )
+    expect(codexCommand).toContain('BUN_INSTALL_CACHE_DIR=')
+    expect(codexCommand).toContain('PATH=')
+    expect(codexCommand).toContain('/opt/homebrew/bin')
+    expect(codexCommand).not.toContain('npx -y')
+  })
+
   it('resolves the Hermes adapter to a container `nerdctl exec hermes acp` command when a HermesContainerRuntime is registered', async () => {
     const browserosDir = await mkdtemp(
       join(tmpdir(), 'browseros-acpx-browseros-'),
@@ -1296,6 +1344,14 @@ async function createLatestRuntimeStateForTest(input: {
       updatedAt: 1234,
     },
   )
+}
+
+async function writeFakeBundledBun(resourcesDir: string): Promise<string> {
+  const bunPath = join(resourcesDir, 'bin', 'third_party', 'bun')
+  await mkdir(dirname(bunPath), { recursive: true })
+  await writeFile(bunPath, '#!/bin/sh\n')
+  await chmod(bunPath, 0o755)
+  return bunPath
 }
 
 function makeSessionRecord(input: {

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -31,6 +31,7 @@ import type { ManagedContainerDeps } from '../../../src/lib/container/managed'
 
 describe('AcpxRuntime', () => {
   const tempDirs: string[] = []
+  const macosIt = process.platform === 'darwin' ? it : it.skip
 
   afterEach(async () => {
     await Promise.all(
@@ -960,53 +961,55 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
     expect(command).toContain('npx -y @zed-industries/codex-acp')
   })
 
-  it('runs Claude and Codex ACP adapter packages through bundled Bun on macOS', async () => {
-    if (process.platform !== 'darwin') return
-    const browserosDir = await mkdtemp(
-      join(tmpdir(), 'browseros-acpx-browseros-'),
-    )
-    const stateDir = await mkdtemp(join(tmpdir(), 'browseros-acpx-state-'))
-    const resourcesDir = await mkdtemp(
-      join(tmpdir(), 'browseros-acpx-resources-'),
-    )
-    tempDirs.push(browserosDir, stateDir, resourcesDir)
-    const bunPath = await writeFakeBundledBun(resourcesDir)
-    const calls: Array<{ method: string; input: unknown }> = []
-    const runtime = new AcpxRuntime({
-      browserosDir,
-      resourcesDir,
-      stateDir,
-      runtimeFactory: (options) => {
-        calls.push({ method: 'createRuntime', input: options })
-        return createFakeAcpRuntime(calls)
-      },
-    })
-    const agent = makeAgent({ id: 'agent-1', adapter: 'codex' })
+  macosIt(
+    'runs Claude and Codex ACP adapter packages through bundled Bun on macOS',
+    async () => {
+      const browserosDir = await mkdtemp(
+        join(tmpdir(), 'browseros-acpx-browseros-'),
+      )
+      const stateDir = await mkdtemp(join(tmpdir(), 'browseros-acpx-state-'))
+      const resourcesDir = await mkdtemp(
+        join(tmpdir(), 'browseros-acpx-resources-'),
+      )
+      tempDirs.push(browserosDir, stateDir, resourcesDir)
+      const bunPath = await writeFakeBundledBun(resourcesDir)
+      const calls: Array<{ method: string; input: unknown }> = []
+      const runtime = new AcpxRuntime({
+        browserosDir,
+        resourcesDir,
+        stateDir,
+        runtimeFactory: (options) => {
+          calls.push({ method: 'createRuntime', input: options })
+          return createFakeAcpRuntime(calls)
+        },
+      })
+      const agent = makeAgent({ id: 'agent-1', adapter: 'codex' })
 
-    await collectStream(
-      await runtime.send({
-        agent,
-        sessionId: 'main',
-        sessionKey: agent.sessionKey,
-        message: 'hi',
-        permissionMode: 'approve-all',
-      }),
-    )
+      await collectStream(
+        await runtime.send({
+          agent,
+          sessionId: 'main',
+          sessionKey: agent.sessionKey,
+          message: 'hi',
+          permissionMode: 'approve-all',
+        }),
+      )
 
-    const registry = getCreateRuntimeOptions(calls).agentRegistry
-    const claudeCommand = registry.resolve('claude')
-    const codexCommand = registry.resolve('codex')
-    expect(claudeCommand).toContain(
-      `'${bunPath}' x --bun --silent --package @agentclientprotocol/claude-agent-acp@^0.31.0 claude-agent-acp`,
-    )
-    expect(codexCommand).toContain(
-      `'${bunPath}' x --bun --silent --package @zed-industries/codex-acp@^0.12.0 codex-acp`,
-    )
-    expect(codexCommand).toContain('BUN_INSTALL_CACHE_DIR=')
-    expect(codexCommand).toContain('PATH=')
-    expect(codexCommand).toContain('/opt/homebrew/bin')
-    expect(codexCommand).not.toContain('npx -y')
-  })
+      const registry = getCreateRuntimeOptions(calls).agentRegistry
+      const claudeCommand = registry.resolve('claude')
+      const codexCommand = registry.resolve('codex')
+      expect(claudeCommand).toContain(
+        `'${bunPath}' x --bun --silent --package '@agentclientprotocol/claude-agent-acp@^0.31.0' 'claude-agent-acp'`,
+      )
+      expect(codexCommand).toContain(
+        `'${bunPath}' x --bun --silent --package '@zed-industries/codex-acp@^0.12.0' 'codex-acp'`,
+      )
+      expect(codexCommand).toContain('BUN_INSTALL_CACHE_DIR=')
+      expect(codexCommand).toContain('PATH=')
+      expect(codexCommand).toContain('/opt/homebrew/bin')
+      expect(codexCommand).not.toContain('npx -y')
+    },
+  )
 
   it('resolves the Hermes adapter to a container `nerdctl exec hermes acp` command when a HermesContainerRuntime is registered', async () => {
     const browserosDir = await mkdtemp(

--- a/packages/browseros-agent/apps/server/tests/lib/agents/bundled-bun.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/bundled-bun.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import {
+  buildMacosAcpAdapterPath,
+  resolveBundledBun,
+} from '../../../src/lib/agents/bundled-bun'
+
+describe('bundled Bun helpers', () => {
+  const tempDirs: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true })),
+    )
+    tempDirs.length = 0
+  })
+
+  it('resolves the macOS bundled Bun executable', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'browseros-bun-'))
+    tempDirs.push(resourcesDir)
+    const bunPath = join(resourcesDir, 'bin', 'third_party', 'bun')
+    await mkdir(dirname(bunPath), { recursive: true })
+    await writeFile(bunPath, '#!/bin/sh\n')
+
+    expect(resolveBundledBun({ resourcesDir, platform: 'darwin' })).toBe(
+      bunPath,
+    )
+  })
+
+  it('ignores bundled Bun on non-macOS platforms', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'browseros-bun-'))
+    tempDirs.push(resourcesDir)
+    const bunPath = join(resourcesDir, 'bin', 'third_party', 'bun')
+    await mkdir(dirname(bunPath), { recursive: true })
+    await writeFile(bunPath, '#!/bin/sh\n')
+
+    expect(resolveBundledBun({ resourcesDir, platform: 'linux' })).toBeNull()
+  })
+
+  it('adds common macOS CLI install directories without duplicating PATH entries', () => {
+    expect(
+      buildMacosAcpAdapterPath({
+        basePath: '/usr/bin:/bin:/opt/homebrew/bin',
+        home: '/Users/dev',
+      }),
+    ).toBe(
+      '/Users/dev/.local/bin:/Users/dev/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin',
+    )
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/lib/agents/bundled-bun.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/bundled-bun.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { afterEach, describe, expect, it } from 'bun:test'
-import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import {
@@ -28,10 +28,22 @@ describe('bundled Bun helpers', () => {
     const bunPath = join(resourcesDir, 'bin', 'third_party', 'bun')
     await mkdir(dirname(bunPath), { recursive: true })
     await writeFile(bunPath, '#!/bin/sh\n')
+    await chmod(bunPath, 0o755)
 
     expect(resolveBundledBun({ resourcesDir, platform: 'darwin' })).toBe(
       bunPath,
     )
+  })
+
+  it('ignores non-executable bundled Bun files', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'browseros-bun-'))
+    tempDirs.push(resourcesDir)
+    const bunPath = join(resourcesDir, 'bin', 'third_party', 'bun')
+    await mkdir(dirname(bunPath), { recursive: true })
+    await writeFile(bunPath, '#!/bin/sh\n')
+    await chmod(bunPath, 0o644)
+
+    expect(resolveBundledBun({ resourcesDir, platform: 'darwin' })).toBeNull()
   })
 
   it('ignores bundled Bun on non-macOS platforms', async () => {

--- a/packages/browseros-agent/packages/build-tools/README.md
+++ b/packages/browseros-agent/packages/build-tools/README.md
@@ -53,6 +53,25 @@ artifacts/vendor/third_party/lima/lima-guestagent.Linux-x86_64.gz
 
 Server resource staging uses relative manifest keys such as `third_party/lima/limactl-darwin-arm64`; set `R2_DOWNLOAD_PREFIX=artifacts/vendor` in `apps/server/.env.production` so those keys resolve to the uploaded objects.
 
+## Upload bundled Bun runtime files
+
+BrowserOS also ships Bun for macOS server artifacts so ACP adapter packages can run without relying on host `npx`:
+
+```bash
+cd packages/browseros
+uv run browseros upload bun --version bun-v1.3.6 --dry-run
+uv run browseros upload bun --version bun-v1.3.6
+```
+
+The upload stores two R2 objects:
+
+```text
+artifacts/vendor/third_party/bun/bun-darwin-arm64
+artifacts/vendor/third_party/bun/bun-darwin-x64
+```
+
+Server resource staging uses relative manifest keys such as `third_party/bun/bun-darwin-arm64`; with `R2_DOWNLOAD_PREFIX=artifacts/vendor`, those keys resolve to the uploaded Bun binaries.
+
 The final server resource zip must contain real files, not a nested Lima runtime archive. Lima finds its runtime data by walking from `bin/limactl` to the sibling `share/lima` directory:
 
 ```text

--- a/packages/browseros-agent/scripts/build/config/server-prod-resources.json
+++ b/packages/browseros-agent/scripts/build/config/server-prod-resources.json
@@ -43,6 +43,28 @@
       "arch": ["x64"]
     },
     {
+      "name": "Bun - macOS ARM64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/bun/bun-darwin-arm64"
+      },
+      "destination": "resources/bin/third_party/bun",
+      "os": ["macos"],
+      "arch": ["arm64"],
+      "executable": true
+    },
+    {
+      "name": "Bun - macOS x64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/bun/bun-darwin-x64"
+      },
+      "destination": "resources/bin/third_party/bun",
+      "os": ["macos"],
+      "arch": ["x64"],
+      "executable": true
+    },
+    {
       "name": "BrowserOS VM Lima template",
       "source": {
         "type": "local",

--- a/packages/browseros-agent/scripts/build/server/stage.test.ts
+++ b/packages/browseros-agent/scripts/build/server/stage.test.ts
@@ -1,10 +1,11 @@
 import { afterEach, describe, expect, it } from 'bun:test'
-import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import type { S3Client } from '@aws-sdk/client-s3'
 import { loadManifest } from './manifest'
-import { stageCompiledArtifact } from './stage'
-import type { BuildTarget, ResourceRule } from './types'
+import { stageCompiledArtifact, stageTargetArtifact } from './stage'
+import type { BuildTarget, R2Config, ResourceRule } from './types'
 
 describe('server artifact staging', () => {
   let tempDir: string | null = null
@@ -90,6 +91,36 @@ describe('server artifact staging', () => {
       ),
     ).toBe('{"entries":[]}')
   })
+
+  it('downloads R2 executable resources and marks them executable', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'browseros-stage-test-'))
+    const sourceRoot = join(tempDir, 'source')
+    const distRoot = join(tempDir, 'dist')
+    const binaryPath = join(tempDir, 'browseros-server')
+    const payload = new TextEncoder().encode('#!/bin/sh\n')
+    await writeFile(binaryPath, 'server')
+
+    const artifact = await stageTargetArtifact(
+      distRoot,
+      binaryPath,
+      testTarget,
+      [bunRule],
+      sourceRoot,
+      {
+        send: async () => ({
+          Body: {
+            transformToByteArray: async () => payload,
+          },
+        }),
+      } as unknown as S3Client,
+      fakeR2Config,
+      '0.0.0-test',
+    )
+
+    const bunPath = join(artifact.resourcesDir, 'bin/third_party/bun')
+    expect(await readFile(bunPath, 'utf8')).toBe('#!/bin/sh\n')
+    expect((await stat(bunPath)).mode & 0o111).not.toBe(0)
+  })
 })
 
 const testTarget: BuildTarget = {
@@ -111,4 +142,25 @@ const migrationRule: ResourceRule = {
   recursive: true,
   os: ['macos'],
   arch: ['arm64', 'x64'],
+}
+
+const bunRule: ResourceRule = {
+  name: 'Bun - macOS ARM64',
+  source: {
+    type: 'r2',
+    key: 'third_party/bun/bun-darwin-arm64',
+  },
+  destination: 'resources/bin/third_party/bun',
+  os: ['macos'],
+  arch: ['arm64'],
+  executable: true,
+}
+
+const fakeR2Config: R2Config = {
+  accountId: 'test',
+  accessKeyId: 'test',
+  secretAccessKey: 'test',
+  bucket: 'browseros-test',
+  downloadPrefix: 'artifacts/vendor',
+  uploadPrefix: 'server/prod-resources',
 }

--- a/packages/browseros/build/cli/storage.py
+++ b/packages/browseros/build/cli/storage.py
@@ -26,10 +26,11 @@ from ..modules.storage.r2 import (
 LIMA_RELEASE_BASE = "https://github.com/lima-vm/lima/releases/download"
 LIMA_R2_PREFIX = "artifacts/vendor/third_party/lima"
 LIMA_MANIFEST_KEY = f"{LIMA_R2_PREFIX}/manifest.json"
-LIMA_HTTP_TIMEOUT_S = 60
+HTTP_TIMEOUT_S = 60
 BUN_RELEASE_BASE = "https://github.com/oven-sh/bun/releases/download"
 BUN_R2_PREFIX = "artifacts/vendor/third_party/bun"
 BUN_MANIFEST_KEY = f"{BUN_R2_PREFIX}/manifest.json"
+BUN_HTTP_TIMEOUT_S = 120
 
 
 @dataclass(frozen=True)
@@ -215,6 +216,8 @@ def _normalize_version_tag(version: str) -> str:
 def _normalize_bun_version_tag(version: str) -> str:
     if version.startswith("bun-v"):
         return version
+    if version.startswith("bun-"):
+        return f"bun-v{version[len('bun-') :]}"
     return f"bun-{_normalize_version_tag(version)}"
 
 
@@ -336,7 +339,7 @@ def _process_bun_arch(
     zip_path = tmp_dir / zip_name
     url = f"{BUN_RELEASE_BASE}/{tag}/{zip_name}"
     log_info(f"Downloading {url}")
-    _download(url, zip_path)
+    _download(url, zip_path, timeout=BUN_HTTP_TIMEOUT_S)
 
     actual_sha = _sha256_file(zip_path)
     if actual_sha != expected_sha:
@@ -480,7 +483,7 @@ def _rollback(client: Any, bucket: str, keys: List[str]) -> None:
 
 
 def _download(url: str, dest: Path, *, timeout: Optional[int] = None) -> None:
-    response = requests.get(url, stream=True, timeout=timeout or LIMA_HTTP_TIMEOUT_S)
+    response = requests.get(url, stream=True, timeout=timeout or HTTP_TIMEOUT_S)
     response.raise_for_status()
     dest.parent.mkdir(parents=True, exist_ok=True)
     with open(dest, "wb") as out:

--- a/packages/browseros/build/cli/storage.py
+++ b/packages/browseros/build/cli/storage.py
@@ -6,6 +6,7 @@ import json
 import os
 import tarfile
 import tempfile
+import zipfile
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -26,6 +27,9 @@ LIMA_RELEASE_BASE = "https://github.com/lima-vm/lima/releases/download"
 LIMA_R2_PREFIX = "artifacts/vendor/third_party/lima"
 LIMA_MANIFEST_KEY = f"{LIMA_R2_PREFIX}/manifest.json"
 LIMA_HTTP_TIMEOUT_S = 60
+BUN_RELEASE_BASE = "https://github.com/oven-sh/bun/releases/download"
+BUN_R2_PREFIX = "artifacts/vendor/third_party/bun"
+BUN_MANIFEST_KEY = f"{BUN_R2_PREFIX}/manifest.json"
 
 
 @dataclass(frozen=True)
@@ -40,6 +44,20 @@ class LimaArch:
 LIMA_ARCHES: Tuple[LimaArch, ...] = (
     LimaArch(internal="arm64", upstream="Darwin-arm64", linux_guest_arch="aarch64"),
     LimaArch(internal="x64", upstream="Darwin-x86_64", linux_guest_arch="x86_64"),
+)
+
+
+@dataclass(frozen=True)
+class BunArch:
+    """Arch-pair: the suffix Bun uses upstream and the suffix we use in R2."""
+
+    internal: str  # "arm64" | "x64" — how our R2 keys name it
+    upstream: str  # "darwin-aarch64" | "darwin-x64" — Bun's zip suffix
+
+
+BUN_ARCHES: Tuple[BunArch, ...] = (
+    BunArch(internal="arm64", upstream="darwin-aarch64"),
+    BunArch(internal="x64", upstream="darwin-x64"),
 )
 
 
@@ -111,7 +129,9 @@ def upload_lima(
         # roll back prior arch uploads so R2 never holds a mixed-version pair.
         except Exception as exc:
             if not dry_run and uploaded_keys:
-                log_warning(f"Upload failed — rolling back {len(uploaded_keys)} object(s)")
+                log_warning(
+                    f"Upload failed — rolling back {len(uploaded_keys)} object(s)"
+                )
                 _rollback(client, env.r2_bucket, uploaded_keys)
             log_error(f"Lima upload aborted: {exc}")
             raise typer.Exit(1)
@@ -119,13 +139,96 @@ def upload_lima(
     log_success(f"Lima {tag} uploaded for {[a.internal for a in LIMA_ARCHES]}")
 
 
+@app.command("bun")
+def upload_bun(
+    version: str = typer.Option(
+        ...,
+        "--version",
+        "-v",
+        help="Bun release tag, e.g. bun-v1.2.15",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Download + verify only; skip R2 uploads.",
+    ),
+) -> None:
+    """Download Bun from an upstream GitHub release and push macOS binaries to R2."""
+    if not BOTO3_AVAILABLE:
+        log_error("boto3 not installed — run: pip install boto3")
+        raise typer.Exit(1)
+
+    env = EnvConfig()
+    if not env.has_r2_config():
+        log_error(
+            "R2 configuration missing. Required: "
+            "R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY"
+        )
+        raise typer.Exit(1)
+
+    tag = _normalize_bun_version_tag(version)
+    client = None if dry_run else get_r2_client(env)
+    if not dry_run and client is None:
+        log_error("Failed to create R2 client")
+        raise typer.Exit(1)
+
+    with tempfile.TemporaryDirectory(prefix="bun-upload-") as tmp:
+        tmp_dir = Path(tmp)
+        checksums = _fetch_bun_checksums(tag, tmp_dir)
+        uploaded_keys: List[str] = []
+        object_shas: Dict[str, str] = {}
+        zip_shas: Dict[str, str] = {}
+
+        try:
+            for arch in BUN_ARCHES:
+                zip_sha, binary_sha, _ = _process_bun_arch(
+                    tag,
+                    arch,
+                    tmp_dir,
+                    checksums,
+                    client,
+                    env,
+                    dry_run,
+                    uploaded_keys,
+                )
+                zip_shas[arch.internal] = zip_sha
+                object_shas[arch.internal] = binary_sha
+
+            manifest = _build_bun_manifest(tag, zip_shas, object_shas)
+            _upload_bun_manifest(client, env, manifest, tmp_dir, dry_run)
+        except Exception as exc:
+            if not dry_run and uploaded_keys:
+                log_warning(
+                    f"Upload failed — rolling back {len(uploaded_keys)} object(s)"
+                )
+                _rollback(client, env.r2_bucket, uploaded_keys)
+            log_error(f"Bun upload aborted: {exc}")
+            raise typer.Exit(1)
+
+    log_success(f"Bun {tag} uploaded for {[a.internal for a in BUN_ARCHES]}")
+
+
 def _normalize_version_tag(version: str) -> str:
     return version if version.startswith("v") else f"v{version}"
+
+
+def _normalize_bun_version_tag(version: str) -> str:
+    if version.startswith("bun-v"):
+        return version
+    return f"bun-{_normalize_version_tag(version)}"
 
 
 def _fetch_checksums(tag: str, tmp_dir: Path) -> Dict[str, str]:
     url = f"{LIMA_RELEASE_BASE}/{tag}/SHA256SUMS"
     dest = tmp_dir / "SHA256SUMS"
+    log_info(f"Fetching {url}")
+    _download(url, dest)
+    return _parse_checksums(dest.read_text(encoding="utf-8"))
+
+
+def _fetch_bun_checksums(tag: str, tmp_dir: Path) -> Dict[str, str]:
+    url = f"{BUN_RELEASE_BASE}/{tag}/SHASUMS256.txt"
+    dest = tmp_dir / "SHASUMS256.txt"
     log_info(f"Fetching {url}")
     _download(url, dest)
     return _parse_checksums(dest.read_text(encoding="utf-8"))
@@ -213,6 +316,49 @@ def _process_arch(
     return actual_sha, object_shas, r2_keys
 
 
+def _process_bun_arch(
+    tag: str,
+    arch: BunArch,
+    tmp_dir: Path,
+    checksums: Dict[str, str],
+    client: Any,
+    env: EnvConfig,
+    dry_run: bool,
+    uploaded_keys: Optional[List[str]] = None,
+) -> Tuple[str, str, str]:
+    zip_name = f"bun-{arch.upstream}.zip"
+    expected_sha = checksums.get(zip_name)
+    if not expected_sha:
+        raise RuntimeError(
+            f"{zip_name} missing from SHASUMS256.txt (is the version tag correct?)"
+        )
+
+    zip_path = tmp_dir / zip_name
+    url = f"{BUN_RELEASE_BASE}/{tag}/{zip_name}"
+    log_info(f"Downloading {url}")
+    _download(url, zip_path)
+
+    actual_sha = _sha256_file(zip_path)
+    if actual_sha != expected_sha:
+        raise RuntimeError(
+            f"sha256 mismatch for {zip_name}: expected {expected_sha}, got {actual_sha}"
+        )
+
+    local_path = tmp_dir / f"bun-darwin-{arch.internal}"
+    r2_key = f"{BUN_R2_PREFIX}/bun-darwin-{arch.internal}"
+    _extract_bun_file(zip_path, local_path)
+    binary_sha = _sha256_file(local_path)
+
+    if dry_run:
+        log_info(f"[dry-run] skipped upload of {r2_key}")
+    elif not upload_file_to_r2(client, local_path, r2_key, env.r2_bucket):
+        raise RuntimeError(f"Failed to upload {r2_key}")
+    elif uploaded_keys is not None:
+        uploaded_keys.append(r2_key)
+
+    return actual_sha, binary_sha, r2_key
+
+
 def _extract_lima_file(tarball_path: Path, logical_path: str, dest: Path) -> None:
     with tarfile.open(tarball_path, "r:gz") as tar:
         for member in tar.getmembers():
@@ -232,9 +378,32 @@ def _extract_lima_file(tarball_path: Path, logical_path: str, dest: Path) -> Non
     raise RuntimeError(f"{logical_path} not found in Lima tarball")
 
 
+def _extract_bun_file(zip_path: Path, dest: Path) -> None:
+    with zipfile.ZipFile(zip_path) as archive:
+        for member in archive.infolist():
+            if member.is_dir():
+                continue
+            if _logical_bun_path(member.filename) != "bun":
+                continue
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            with archive.open(member) as src, open(dest, "wb") as out:
+                while chunk := src.read(1024 * 1024):
+                    out.write(chunk)
+            dest.chmod(0o755)
+            return
+    raise RuntimeError("bun binary not found in Bun zip")
+
+
 def _logical_lima_path(member_name: str) -> str:
     parts = Path(member_name.lstrip("./")).parts
     if len(parts) > 1 and parts[0].startswith("lima-"):
+        parts = parts[1:]
+    return "/".join(parts)
+
+
+def _logical_bun_path(member_name: str) -> str:
+    parts = Path(member_name.lstrip("./")).parts
+    if len(parts) > 1 and parts[0].startswith("bun-"):
         parts = parts[1:]
     return "/".join(parts)
 
@@ -255,6 +424,20 @@ def _build_manifest(
     }
 
 
+def _build_bun_manifest(
+    tag: str,
+    zip_shas: Dict[str, str],
+    object_shas: Dict[str, str],
+) -> Dict[str, Any]:
+    return {
+        "bun_version": tag,
+        "zip_shas_upstream": zip_shas,
+        "r2_object_shas": object_shas,
+        "uploaded_at": datetime.now(timezone.utc).isoformat(),
+        "uploaded_by": os.environ.get("GITHUB_ACTOR") or "local",
+    }
+
+
 def _upload_manifest(
     client: Any,
     env: EnvConfig,
@@ -263,14 +446,28 @@ def _upload_manifest(
     dry_run: bool,
 ) -> None:
     manifest_path = tmp_dir / "manifest.json"
-    manifest_path.write_text(
-        json.dumps(manifest, indent=2) + "\n", encoding="utf-8"
-    )
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
     if dry_run:
         log_info(f"[dry-run] manifest would be: {manifest}")
         return
     if not upload_file_to_r2(client, manifest_path, LIMA_MANIFEST_KEY, env.r2_bucket):
         raise RuntimeError(f"Failed to upload {LIMA_MANIFEST_KEY}")
+
+
+def _upload_bun_manifest(
+    client: Any,
+    env: EnvConfig,
+    manifest: Dict[str, Any],
+    tmp_dir: Path,
+    dry_run: bool,
+) -> None:
+    manifest_path = tmp_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    if dry_run:
+        log_info(f"[dry-run] manifest would be: {manifest}")
+        return
+    if not upload_file_to_r2(client, manifest_path, BUN_MANIFEST_KEY, env.r2_bucket):
+        raise RuntimeError(f"Failed to upload {BUN_MANIFEST_KEY}")
 
 
 def _rollback(client: Any, bucket: str, keys: List[str]) -> None:

--- a/packages/browseros/build/cli/storage_test.py
+++ b/packages/browseros/build/cli/storage_test.py
@@ -110,6 +110,12 @@ class NormalizeBunVersionTagTest(unittest.TestCase):
     def test_accepts_v_prefixed_semver(self) -> None:
         self.assertEqual(storage._normalize_bun_version_tag("v1.2.3"), "bun-v1.2.3")
 
+    def test_accepts_bun_prefixed_semver_without_v(self) -> None:
+        self.assertEqual(
+            storage._normalize_bun_version_tag("bun-1.2.3"),
+            "bun-v1.2.3",
+        )
+
 
 class ExtractLimaFileTest(unittest.TestCase):
     def test_extracts_limactl_binary(self) -> None:
@@ -556,6 +562,29 @@ class ProcessBunArchTest(unittest.TestCase):
                 )
             ],
         )
+
+    def test_uses_bun_download_timeout(self) -> None:
+        download_kwargs: List[Dict[str, Any]] = []
+
+        def fake_download(_url: str, dest: Path, **kwargs: Any) -> None:
+            download_kwargs.append(kwargs)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(self.zip_bytes)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            with mock.patch.object(storage, "_download", side_effect=fake_download):
+                storage._process_bun_arch(
+                    tag="bun-v1.2.3",
+                    arch=storage.BunArch(internal="arm64", upstream="darwin-aarch64"),
+                    tmp_dir=tmp_path,
+                    checksums={"bun-darwin-aarch64.zip": self.expected_zip_sha},
+                    client=None,
+                    env=mock.Mock(r2_bucket="browseros"),
+                    dry_run=True,
+                )
+
+        self.assertEqual(download_kwargs, [{"timeout": storage.BUN_HTTP_TIMEOUT_S}])
 
     def test_sha_mismatch_aborts_before_upload(self) -> None:
         uploads: List[Tuple[str, str]] = []

--- a/packages/browseros/build/cli/storage_test.py
+++ b/packages/browseros/build/cli/storage_test.py
@@ -6,6 +6,7 @@ import io
 import tarfile
 import tempfile
 import unittest
+import zipfile
 from pathlib import Path
 from typing import Any, Dict, List, Tuple
 from unittest import mock
@@ -50,6 +51,14 @@ def _add_tar_file(
     tar.addfile(info, io.BytesIO(payload))
 
 
+def _build_bun_zip(payload: bytes) -> bytes:
+    """Return a Bun release zip with the upstream directory layout."""
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("bun-darwin-aarch64/bun", payload)
+    return buffer.getvalue()
+
+
 class ParseChecksumsTest(unittest.TestCase):
     def test_parses_two_column_lines(self) -> None:
         contents = (
@@ -86,6 +95,20 @@ class NormalizeVersionTagTest(unittest.TestCase):
 
     def test_adds_v_prefix_when_missing(self) -> None:
         self.assertEqual(storage._normalize_version_tag("1.2.3"), "v1.2.3")
+
+
+class NormalizeBunVersionTagTest(unittest.TestCase):
+    def test_keeps_existing_bun_prefix(self) -> None:
+        self.assertEqual(
+            storage._normalize_bun_version_tag("bun-v1.2.3"),
+            "bun-v1.2.3",
+        )
+
+    def test_accepts_plain_semver(self) -> None:
+        self.assertEqual(storage._normalize_bun_version_tag("1.2.3"), "bun-v1.2.3")
+
+    def test_accepts_v_prefixed_semver(self) -> None:
+        self.assertEqual(storage._normalize_bun_version_tag("v1.2.3"), "bun-v1.2.3")
 
 
 class ExtractLimaFileTest(unittest.TestCase):
@@ -140,7 +163,9 @@ class ExtractLimaFileTest(unittest.TestCase):
             tarball_path.write_bytes(buffer.getvalue())
 
             with self.assertRaisesRegex(RuntimeError, "bin/limactl not found"):
-                storage._extract_lima_file(tarball_path, "bin/limactl", tmp_path / "out")
+                storage._extract_lima_file(
+                    tarball_path, "bin/limactl", tmp_path / "out"
+                )
 
     def test_raises_when_guest_agent_missing(self) -> None:
         tarball = _build_lima_tarball("1.2.3", b"limactl")
@@ -161,6 +186,32 @@ class ExtractLimaFileTest(unittest.TestCase):
                 )
 
 
+class ExtractBunFileTest(unittest.TestCase):
+    def test_extracts_bun_binary(self) -> None:
+        payload = b"bun-binary-" + b"b" * 100
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            zip_path = tmp_path / "bun.zip"
+            zip_path.write_bytes(_build_bun_zip(payload))
+            dest = tmp_path / "bun"
+
+            storage._extract_bun_file(zip_path, dest)
+
+            self.assertEqual(dest.read_bytes(), payload)
+            self.assertTrue(dest.stat().st_mode & 0o100, "should be executable")
+
+    def test_raises_when_bun_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            zip_path = tmp_path / "bun.zip"
+            with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as archive:
+                archive.writestr("bun-darwin-aarch64/README.md", b"missing")
+
+            with self.assertRaisesRegex(RuntimeError, "bun binary not found"):
+                storage._extract_bun_file(zip_path, tmp_path / "bun")
+
+
 class RollbackTest(unittest.TestCase):
     def test_rollback_deletes_all_keys(self) -> None:
         deleted: List[Tuple[str, str]] = []
@@ -170,7 +221,9 @@ class RollbackTest(unittest.TestCase):
                 deleted.append((kwargs["Bucket"], kwargs["Key"]))
 
         storage._rollback(FakeClient(), "browseros", ["a", "b", "c"])
-        self.assertEqual(deleted, [("browseros", "a"), ("browseros", "b"), ("browseros", "c")])
+        self.assertEqual(
+            deleted, [("browseros", "a"), ("browseros", "b"), ("browseros", "c")]
+        )
 
     def test_rollback_tolerates_delete_failures(self) -> None:
         class FakeClient:
@@ -195,6 +248,18 @@ class BuildManifestTest(unittest.TestCase):
         self.assertEqual(manifest["tarball_shas_upstream"]["arm64"], "a" * 64)
         self.assertEqual(manifest["r2_object_shas"]["x64"]["limactl"], "e" * 64)
         self.assertEqual(manifest["r2_object_shas"]["x64"]["guest_agent"], "f" * 64)
+        self.assertIn("uploaded_at", manifest)
+        self.assertIn("uploaded_by", manifest)
+
+    def test_bun_manifest_shape(self) -> None:
+        manifest = storage._build_bun_manifest(
+            "bun-v1.2.3",
+            {"arm64": "a" * 64, "x64": "b" * 64},
+            {"arm64": "c" * 64, "x64": "d" * 64},
+        )
+        self.assertEqual(manifest["bun_version"], "bun-v1.2.3")
+        self.assertEqual(manifest["zip_shas_upstream"]["arm64"], "a" * 64)
+        self.assertEqual(manifest["r2_object_shas"]["x64"], "d" * 64)
         self.assertIn("uploaded_at", manifest)
         self.assertIn("uploaded_by", manifest)
 
@@ -223,7 +288,9 @@ class ProcessArchTest(unittest.TestCase):
     def test_happy_path_uploads_and_returns_shas(self) -> None:
         uploads: List[Tuple[str, str, bytes]] = []
 
-        def fake_upload(_client: Any, local_path: Path, r2_key: str, bucket: str) -> bool:
+        def fake_upload(
+            _client: Any, local_path: Path, r2_key: str, bucket: str
+        ) -> bool:
             uploads.append((r2_key, bucket, local_path.read_bytes()))
             return True
 
@@ -231,8 +298,14 @@ class ProcessArchTest(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
-            with mock.patch.object(storage, "_download", side_effect=self._fake_download), \
-                 mock.patch.object(storage, "upload_file_to_r2", side_effect=fake_upload):
+            with (
+                mock.patch.object(
+                    storage, "_download", side_effect=self._fake_download
+                ),
+                mock.patch.object(
+                    storage, "upload_file_to_r2", side_effect=fake_upload
+                ),
+            ):
                 tarball_sha, object_shas, r2_keys = storage._process_arch(
                     tag="v1.2.3",
                     arch=storage.LimaArch(
@@ -276,14 +349,16 @@ class ProcessArchTest(unittest.TestCase):
                     "artifacts/vendor/third_party/lima/lima-guestagent.Linux-aarch64.gz",
                     "browseros",
                     self.guest_agent_payload,
-                )
+                ),
             ],
         )
 
     def test_sha_mismatch_aborts_before_upload(self) -> None:
         uploads: List[Tuple[str, str]] = []
 
-        def fake_upload(_client: Any, _local_path: Path, r2_key: str, bucket: str) -> bool:
+        def fake_upload(
+            _client: Any, _local_path: Path, r2_key: str, bucket: str
+        ) -> bool:
             uploads.append((r2_key, bucket))
             return True
 
@@ -291,8 +366,14 @@ class ProcessArchTest(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
-            with mock.patch.object(storage, "_download", side_effect=self._fake_download), \
-                 mock.patch.object(storage, "upload_file_to_r2", side_effect=fake_upload):
+            with (
+                mock.patch.object(
+                    storage, "_download", side_effect=self._fake_download
+                ),
+                mock.patch.object(
+                    storage, "upload_file_to_r2", side_effect=fake_upload
+                ),
+            ):
                 with self.assertRaisesRegex(RuntimeError, "sha256 mismatch"):
                     storage._process_arch(
                         tag="v1.2.3",
@@ -341,8 +422,14 @@ class ProcessArchTest(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
-            with mock.patch.object(storage, "_download", side_effect=self._fake_download), \
-                 mock.patch.object(storage, "upload_file_to_r2", side_effect=fake_upload):
+            with (
+                mock.patch.object(
+                    storage, "_download", side_effect=self._fake_download
+                ),
+                mock.patch.object(
+                    storage, "upload_file_to_r2", side_effect=fake_upload
+                ),
+            ):
                 _, _, r2_keys = storage._process_arch(
                     tag="v1.2.3",
                     arch=storage.LimaArch(
@@ -377,7 +464,9 @@ class ProcessArchTest(unittest.TestCase):
             dest.parent.mkdir(parents=True, exist_ok=True)
             dest.write_bytes(tarball_bytes)
 
-        def fake_upload(_client: Any, _local_path: Path, r2_key: str, bucket: str) -> bool:
+        def fake_upload(
+            _client: Any, _local_path: Path, r2_key: str, bucket: str
+        ) -> bool:
             uploads.append((r2_key, bucket))
             return True
 
@@ -385,8 +474,12 @@ class ProcessArchTest(unittest.TestCase):
 
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
-            with mock.patch.object(storage, "_download", side_effect=fake_download), \
-                 mock.patch.object(storage, "upload_file_to_r2", side_effect=fake_upload):
+            with (
+                mock.patch.object(storage, "_download", side_effect=fake_download),
+                mock.patch.object(
+                    storage, "upload_file_to_r2", side_effect=fake_upload
+                ),
+            ):
                 with self.assertRaisesRegex(
                     RuntimeError,
                     "share/lima/lima-guestagent.Linux-aarch64.gz not found",
@@ -399,15 +492,139 @@ class ProcessArchTest(unittest.TestCase):
                             linux_guest_arch="aarch64",
                         ),
                         tmp_dir=tmp_path,
-                        checksums={
-                            "lima-1.2.3-Darwin-arm64.tar.gz": expected_sha
-                        },
+                        checksums={"lima-1.2.3-Darwin-arm64.tar.gz": expected_sha},
                         client=mock.Mock(),
                         env=env,
                         dry_run=False,
                     )
 
         self.assertEqual(uploads, [])
+
+
+class ProcessBunArchTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.bun_payload = b"bun-binary-" + b"z" * 200
+        self.zip_bytes = _build_bun_zip(self.bun_payload)
+        self.expected_zip_sha = hashlib.sha256(self.zip_bytes).hexdigest()
+        self.expected_bun_sha = hashlib.sha256(self.bun_payload).hexdigest()
+
+    def _fake_download(self, _url: str, dest: Path, **_kwargs: Any) -> None:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(self.zip_bytes)
+
+    def test_happy_path_uploads_and_returns_shas(self) -> None:
+        uploads: List[Tuple[str, str, bytes]] = []
+
+        def fake_upload(
+            _client: Any, local_path: Path, r2_key: str, bucket: str
+        ) -> bool:
+            uploads.append((r2_key, bucket, local_path.read_bytes()))
+            return True
+
+        env = mock.Mock(r2_bucket="browseros")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            with (
+                mock.patch.object(
+                    storage, "_download", side_effect=self._fake_download
+                ),
+                mock.patch.object(
+                    storage, "upload_file_to_r2", side_effect=fake_upload
+                ),
+            ):
+                zip_sha, binary_sha, r2_key = storage._process_bun_arch(
+                    tag="bun-v1.2.3",
+                    arch=storage.BunArch(internal="arm64", upstream="darwin-aarch64"),
+                    tmp_dir=tmp_path,
+                    checksums={"bun-darwin-aarch64.zip": self.expected_zip_sha},
+                    client=mock.Mock(),
+                    env=env,
+                    dry_run=False,
+                )
+
+        self.assertEqual(zip_sha, self.expected_zip_sha)
+        self.assertEqual(binary_sha, self.expected_bun_sha)
+        self.assertEqual(r2_key, "artifacts/vendor/third_party/bun/bun-darwin-arm64")
+        self.assertEqual(
+            uploads,
+            [
+                (
+                    "artifacts/vendor/third_party/bun/bun-darwin-arm64",
+                    "browseros",
+                    self.bun_payload,
+                )
+            ],
+        )
+
+    def test_sha_mismatch_aborts_before_upload(self) -> None:
+        uploads: List[Tuple[str, str]] = []
+
+        def fake_upload(
+            _client: Any, _local_path: Path, r2_key: str, bucket: str
+        ) -> bool:
+            uploads.append((r2_key, bucket))
+            return True
+
+        env = mock.Mock(r2_bucket="browseros")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            with (
+                mock.patch.object(
+                    storage, "_download", side_effect=self._fake_download
+                ),
+                mock.patch.object(
+                    storage, "upload_file_to_r2", side_effect=fake_upload
+                ),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "sha256 mismatch"):
+                    storage._process_bun_arch(
+                        tag="bun-v1.2.3",
+                        arch=storage.BunArch(
+                            internal="arm64",
+                            upstream="darwin-aarch64",
+                        ),
+                        tmp_dir=tmp_path,
+                        checksums={"bun-darwin-aarch64.zip": "0" * 64},
+                        client=mock.Mock(),
+                        env=env,
+                        dry_run=False,
+                    )
+
+        self.assertEqual(uploads, [])
+
+    def test_dry_run_skips_upload(self) -> None:
+        uploads: List[Tuple[str, str]] = []
+
+        def fake_upload(*args: Any, **kwargs: Any) -> bool:
+            uploads.append(("called", ""))
+            return True
+
+        env = mock.Mock(r2_bucket="browseros")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            with (
+                mock.patch.object(
+                    storage, "_download", side_effect=self._fake_download
+                ),
+                mock.patch.object(
+                    storage, "upload_file_to_r2", side_effect=fake_upload
+                ),
+            ):
+                _, _, r2_key = storage._process_bun_arch(
+                    tag="bun-v1.2.3",
+                    arch=storage.BunArch(internal="arm64", upstream="darwin-aarch64"),
+                    tmp_dir=tmp_path,
+                    checksums={"bun-darwin-aarch64.zip": self.expected_zip_sha},
+                    client=None,
+                    env=env,
+                    dry_run=True,
+                )
+
+        self.assertEqual(uploads, [])
+        self.assertEqual(r2_key, "artifacts/vendor/third_party/bun/bun-darwin-arm64")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Bundle Bun into macOS server resources so packaged BrowserOS can launch ACP adapter packages without relying on host `npx`.
- Resolve Claude/Codex ACP adapters through bundled `bun x --bun --package ...` when the packaged Bun binary is present, with `npx` retained as the fallback.
- Add R2 upload tooling and tests for Bun resource staging, bundled Bun resolution, and ACP command generation.

## Design
The server build now stages a macOS Bun executable at `resources/bin/third_party/bun`. At runtime, ACPX receives an already-resolved shell command for Claude/Codex: bundled Bun runs the specific ACP package and binary, while BrowserOS injects a controlled cache dir and macOS CLI lookup PATH for the underlying native Claude/Codex CLIs. This keeps packaged production launches independent from GUI app PATH and host package-manager availability.

## Test plan
- `bun test scripts/build/server/stage.test.ts apps/server/tests/lib/agents/bundled-bun.test.ts apps/server/tests/lib/agents/acpx-runtime.test.ts`
- `uv run python -m unittest build.cli.storage_test`
- `bun run typecheck`
- Manual prod BrowserOS validation: tested Claude/Codex launch with the new server build.