### PR TITLE
fix(browseros): align Browser protocol whitelist with Chromium 148

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/devtools/inspector_protocol_config.json
+++ b/packages/browseros/chromium_patches/chrome/browser/devtools/inspector_protocol_config.json
@@ -7,7 +7,7 @@ index 31b73283d26ea..0c44982bde0a7 100644
              {
                  "domain": "Browser",
 -                "include": [ "getWindowForTarget", "getWindowBounds", "setWindowBounds", "setContentsSize", "close", "setDockTile", "executeBrowserCommand", "addPrivacySandboxEnrollmentOverride" ],
-+                "include": [ "getWindowForTarget", "getTabForTarget", "getTargetForTab", "getWindowBounds", "setWindowBounds", "setContentsSize", "close", "setDockTile", "executeBrowserCommand", "addPrivacySandboxEnrollmentOverride", "getWindows", "getActiveWindow", "createWindow", "closeWindow", "activateWindow", "showWindow", "hideWindow", "getTabs", "getActiveTab", "getTabInfo", "createTab", "closeTab", "activateTab", "moveTab", "duplicateTab", "pinTab", "unpinTab", "showTab", "hideTab", "getTabGroups", "createTabGroup", "updateTabGroup", "closeTabGroup", "addTabsToGroup", "removeTabsFromGroup", "moveTabGroup" ],
++                "include": [ "getWindowForTarget", "getTabForTarget", "getTargetForTab", "getWindowBounds", "setWindowBounds", "setContentsSize", "close", "setDockTile", "executeBrowserCommand", "addPrivacySandboxEnrollmentOverride", "getWindows", "getActiveWindow", "createWindow", "closeWindow", "activateWindow", "setWindowVisibility", "getTabs", "getActiveTab", "getTabInfo", "createTab", "closeTab", "activateTab", "moveTab", "duplicateTab", "pinTab", "unpinTab", "showTab", "getTabGroups", "createTabGroup", "updateTabGroup", "closeTabGroup", "addTabsToGroup", "removeTabsFromGroup", "moveTabGroup" ],
                  "include_events": []
              },
 +            {


### PR DESCRIPTION
## Summary
- replace stale Browser protocol command whitelist entries from Chromium 148 sync with current `setWindowVisibility`
- remove stale `hideTab` from the generated protocol allowlist

## Root Cause
`add50556 chore(browseros): sync Chromium 148 patches (#947)` added stale Browser protocol command names (`showWindow`, `hideWindow`, `hideTab`) to `inspector_protocol_config.json`. Chromium 148 now exposes `setWindowVisibility`, so the generated `protocol::Browser::Backend` omitted `SetWindowVisibility` while `BrowserHandler` still marked it `override`, breaking compilation.

## Verification
- `autoninja -C out/Default_arm64 chrome/browser/devtools:protocol_generated_sources`
- `autoninja -C out/Default_arm64 obj/chrome/browser/devtools/devtools/browser_handler.o`
- `autoninja -C out/Default_arm64 chrome`
- `uv run browseros build --config build/config/release.macos.yaml --chromium-src ~/code/chromium-release/src/`

Release build completed successfully and uploaded arm64, x64, and universal DMGs for 0.46.0.