### PR TITLE
feat: add nightly macOS build workflow

### DIFF
--- a/.github/workflows/nightly-macos-build.yml
+++ b/.github/workflows/nightly-macos-build.yml
@@ -22,7 +22,7 @@ on:
       upload_to_r2:
         description: Publish build to R2/CDN after packaging
         type: boolean
-        default: false
+        default: true
 
 permissions:
   contents: read
@@ -83,7 +83,7 @@ jobs:
             target_ref="$DISPATCH_REF"
             bump_mode="${DISPATCH_BUMP:-offset-only}"
             commit_version="${DISPATCH_COMMIT_VERSION:-false}"
-            upload_to_r2="${DISPATCH_UPLOAD_TO_R2:-false}"
+            upload_to_r2="${DISPATCH_UPLOAD_TO_R2:-true}"
           fi
 
           {

--- a/.github/workflows/nightly-macos-build.yml
+++ b/.github/workflows/nightly-macos-build.yml
@@ -159,12 +159,12 @@ jobs:
 
       - name: Upload DMG artifact
         if: ${{ always() && steps.bump.outputs.version != '' }}
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: BrowserOS_v${{ steps.bump.outputs.version }}_arm64
           path: ${{ steps.build_inputs.outputs.browseros_repo }}/packages/browseros/releases/${{ steps.bump.outputs.version }}/*.dmg
           retention-days: 14
-          if-no-files-found: error
+          if-no-files-found: warn
 
       - name: Slack failure ping
         if: ${{ failure() }}

--- a/.github/workflows/nightly-macos-build.yml
+++ b/.github/workflows/nightly-macos-build.yml
@@ -1,0 +1,210 @@
+name: Nightly macOS Build
+
+on:
+  schedule:
+    # About 10 PM US Pacific during daylight saving time. GitHub cron is UTC.
+    - cron: "0 5 * * *"
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: Version bump level
+        type: choice
+        default: offset-only
+        options:
+          - offset-only
+          - offset+build
+          - offset+patch
+          - none
+      commit_version:
+        description: Commit and push the version bump to the built branch
+        type: boolean
+        default: false
+      upload_to_r2:
+        description: Publish build to R2/CDN after packaging
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-build
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: [self-hosted, macOS, ARM64, browseros-builder]
+    timeout-minutes: 600
+    env:
+      BROWSEROS_REPO: ${{ vars.BROWSEROS_REPO_PATH }}
+      CHROMIUM_SRC: ${{ vars.BROWSEROS_CHROMIUM_SRC }}
+      NIGHTLY_REF: ${{ vars.BROWSEROS_NIGHTLY_REF }}
+    steps:
+      - name: Resolve build inputs
+        id: build_inputs
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          DISPATCH_BUMP: ${{ inputs.bump }}
+          DISPATCH_COMMIT_VERSION: ${{ inputs.commit_version }}
+          DISPATCH_UPLOAD_TO_R2: ${{ inputs.upload_to_r2 }}
+          DISPATCH_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          repo="${BROWSEROS_REPO:-}"
+          chromium_src="${CHROMIUM_SRC:-}"
+          if [ -z "$repo" ]; then
+            echo "::error::Set repository variable BROWSEROS_REPO_PATH"
+            exit 1
+          fi
+          if [ -z "$chromium_src" ]; then
+            echo "::error::Set repository variable BROWSEROS_CHROMIUM_SRC"
+            exit 1
+          fi
+
+          repo="${repo/#\~/$HOME}"
+          chromium_src="${chromium_src/#\~/$HOME}"
+          if [ ! -d "$repo/.git" ]; then
+            echo "::error::BROWSEROS_REPO_PATH does not point to a git checkout: $repo"
+            exit 1
+          fi
+          if [ ! -d "$chromium_src" ]; then
+            echo "::error::BROWSEROS_CHROMIUM_SRC does not exist: $chromium_src"
+            exit 1
+          fi
+
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            target_ref="${NIGHTLY_REF:-$DEFAULT_BRANCH}"
+            bump_mode="offset+build"
+            commit_version="true"
+            upload_to_r2="true"
+          else
+            target_ref="$DISPATCH_REF"
+            bump_mode="${DISPATCH_BUMP:-offset-only}"
+            commit_version="${DISPATCH_COMMIT_VERSION:-false}"
+            upload_to_r2="${DISPATCH_UPLOAD_TO_R2:-false}"
+          fi
+
+          {
+            echo "browseros_repo=$repo"
+            echo "chromium_src=$chromium_src"
+            echo "target_ref=$target_ref"
+            echo "bump_mode=$bump_mode"
+            echo "commit_version=$commit_version"
+            echo "upload_to_r2=$upload_to_r2"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Sync build repo to target ref
+        env:
+          BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
+          TARGET_REF: ${{ steps.build_inputs.outputs.target_ref }}
+        run: |
+          set -euo pipefail
+          cd "$BROWSEROS_REPO"
+          git fetch origin --tags --prune
+          if git show-ref --verify --quiet "refs/remotes/origin/$TARGET_REF"; then
+            git checkout -B "$TARGET_REF" "origin/$TARGET_REF"
+            git reset --hard "origin/$TARGET_REF"
+          else
+            git checkout "$TARGET_REF"
+            git reset --hard "$TARGET_REF"
+          fi
+          git clean -fd
+
+      - name: Bump version
+        id: bump
+        env:
+          BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
+          BUMP_MODE: ${{ steps.build_inputs.outputs.bump_mode }}
+        run: |
+          set -euo pipefail
+          cd "$BROWSEROS_REPO/packages/browseros"
+          version="$(uv run python build/scripts/bump_version.py --mode "$BUMP_MODE")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Built version: $version"
+
+      - name: Commit and push version bump
+        if: ${{ steps.build_inputs.outputs.commit_version == 'true' }}
+        env:
+          BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
+          TARGET_REF: ${{ steps.build_inputs.outputs.target_ref }}
+          VERSION: ${{ steps.bump.outputs.version }}
+        run: |
+          set -euo pipefail
+          cd "$BROWSEROS_REPO"
+          git add packages/browseros/resources/BROWSEROS_VERSION \
+            packages/browseros/build/config/BROWSEROS_BUILD_OFFSET
+          if git diff --cached --quiet; then
+            echo "No version changes to commit."
+            exit 0
+          fi
+          git -c user.name="BrowserOS CI" -c user.email="ci@browseros.com" \
+            commit -m "chore(release): build v$VERSION [skip ci]"
+          git push origin "HEAD:$TARGET_REF"
+
+      - name: Build BrowserOS (macOS arm64)
+        env:
+          BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
+          CHROMIUM_SRC: ${{ steps.build_inputs.outputs.chromium_src }}
+          UPLOAD_TO_R2: ${{ steps.build_inputs.outputs.upload_to_r2 }}
+        run: |
+          set -euo pipefail
+          cd "$BROWSEROS_REPO/packages/browseros"
+          config="build/config/release.macos.arm64.yaml"
+          if [ "$UPLOAD_TO_R2" != "true" ]; then
+            config="build/config/release.macos.arm64.noupload.yaml"
+          fi
+          uv run browseros build --config "$config" --chromium-src "$CHROMIUM_SRC"
+
+      - name: Upload DMG artifact
+        if: ${{ always() && steps.bump.outputs.version != '' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: BrowserOS_v${{ steps.bump.outputs.version }}_arm64
+          path: ${{ steps.build_inputs.outputs.browseros_repo }}/packages/browseros/releases/${{ steps.bump.outputs.version }}/*.dmg
+          retention-days: 14
+          if-no-files-found: error
+
+      - name: Slack failure ping
+        if: ${{ failure() }}
+        env:
+          BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
+          TARGET_REF: ${{ steps.build_inputs.outputs.target_ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          hook="$(
+            python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          env_file = Path(os.environ["BROWSEROS_REPO"]) / "packages/browseros/.env"
+          if not env_file.exists():
+              raise SystemExit(0)
+          for line in env_file.read_text().splitlines():
+              if line.startswith("SLACK_WEBHOOK_URL="):
+                  print(line.split("=", 1)[1].strip().strip("'\""))
+                  break
+          PY
+          )"
+          if [ -z "$hook" ]; then
+            exit 0
+          fi
+          python3 - <<'PY' > /tmp/browseros-nightly-slack-payload.json
+          import json
+          import os
+
+          print(
+              json.dumps(
+                  {
+                      "text": (
+                          ":x: Nightly macOS build failed on "
+                          f"`{os.environ['TARGET_REF']}` - {os.environ['RUN_URL']}"
+                      )
+                  }
+              )
+          )
+          PY
+          curl -fsS -X POST -H "Content-type: application/json" \
+            --data @/tmp/browseros-nightly-slack-payload.json "$hook" || true

--- a/packages/browseros/build/config/release.macos.arm64.noupload.yaml
+++ b/packages/browseros/build/config/release.macos.arm64.noupload.yaml
@@ -1,0 +1,51 @@
+# BrowserOS macOS Release Build Configuration (arm64 only, no R2 upload)
+#
+# Single-architecture arm64 release build. This is the nightly/manual CI variant
+# for artifact-only branch builds where publishing to R2/CDN is not desired.
+#
+# Environment Variables:
+#   Use !env tag to reference environment variables:
+#     Example: chromium_src: !env CHROMIUM_SRC
+
+build:
+  type: release
+  architecture: arm64
+
+gn_flags:
+  file: build/config/gn/flags.macos.release.gn
+
+# Explicit module execution order
+modules:
+  # Phase 1: Setup
+  - clean
+  - git_setup
+  - sparkle_setup
+
+  # Phase 2: Patches & Resources
+  - download_resources
+  - resources
+  - bundled_extensions
+  - chromium_replace
+  - string_replaces
+  - series_patches
+  - patches
+
+  # Phase 3: Build
+  - configure
+  - compile
+
+  # Phase 4: Sign & Package
+  - sign_macos
+  - package_macos
+
+# Required environment variables
+# Note: CHROMIUM_SRC can be provided via --chromium-src CLI flag, YAML config, or env var
+required_envs:
+  - MACOS_CERTIFICATE_NAME
+  - PROD_MACOS_NOTARIZATION_APPLE_ID
+  - PROD_MACOS_NOTARIZATION_TEAM_ID
+  - PROD_MACOS_NOTARIZATION_PWD
+
+# Notification settings
+notifications:
+  slack: true

--- a/packages/browseros/build/docs/nightly-macos-ci.md
+++ b/packages/browseros/build/docs/nightly-macos-ci.md
@@ -13,13 +13,14 @@ Nightly runs execute this command from the persistent build repo clone:
 uv run browseros build --config build/config/release.macos.arm64.yaml --chromium-src "$CHROMIUM_SRC"
 ```
 
-Manual runs default to artifact-only builds:
+Manual runs default to the same publishing config:
 
 ```bash
-uv run browseros build --config build/config/release.macos.arm64.noupload.yaml --chromium-src "$CHROMIUM_SRC"
+uv run browseros build --config build/config/release.macos.arm64.yaml --chromium-src "$CHROMIUM_SRC"
 ```
 
-Set `upload_to_r2=true` in the manual dispatch form to use the publishing config.
+Set `upload_to_r2=false` in the manual dispatch form to run an artifact-only
+build without publishing to R2.
 
 ## One-Time Runner Setup
 
@@ -89,7 +90,7 @@ Add these in GitHub repo settings under Actions variables:
 The workflow calls `build/scripts/bump_version.py`.
 
 - Nightly schedule: `offset+build`, commit and push enabled, R2 upload enabled
-- Manual dispatch default: `offset-only`, commit disabled, R2 upload disabled
+- Manual dispatch default: `offset-only`, commit disabled, R2 upload enabled
 - Manual hotfix option: choose `offset+patch`
 - Manual dry run option: choose `none`
 
@@ -114,7 +115,7 @@ branch in GitHub's native branch picker, then set inputs:
 
 - `bump`: `offset-only`, `offset+build`, `offset+patch`, or `none`
 - `commit_version`: commit and push the bumped version files
-- `upload_to_r2`: publish to R2/CDN after packaging
+- `upload_to_r2`: publish to R2/CDN after packaging, enabled by default
 
 The DMG is always uploaded as a run artifact when packaging succeeds.
 
@@ -146,8 +147,8 @@ confirm `MACOS_KEYCHAIN_PASSWORD` is present in `packages/browseros/.env`.
 `uv`, `gclient`, `gn`, or `autoninja` not found: update `~/actions-runner/.path`
 and restart the runner service.
 
-No R2 upload on a manual run: manual runs default to artifact-only builds. Re-run
-with `upload_to_r2=true`.
+Artifact-only manual run: set `upload_to_r2=false` to package the DMG without
+publishing it to R2.
 
 No version commit: check `commit_version`, the selected bump mode, and the
 persistent clone's push credentials.

--- a/packages/browseros/build/docs/nightly-macos-ci.md
+++ b/packages/browseros/build/docs/nightly-macos-ci.md
@@ -65,8 +65,8 @@ Keep the runner current enough to run the action majors used by the workflow.
 
 The Mac Mini must already have:
 
-- Build repo clone, for example `/Users/shadowfax/code/browseros-release`
-- Chromium checkout, for example `/Users/shadowfax/code/chromium-release/src`
+- Build repo clone, for example `/Users/<user>/code/browseros-release`
+- Chromium checkout, for example `/Users/<user>/code/chromium-release/src`
 - `uv`, depot_tools, Xcode Command Line Tools, and signing/notarization tooling
 - `packages/browseros/.env` with signing, notarization, R2, and Slack values
 - `MACOS_KEYCHAIN_PASSWORD` in `.env` so the build can unlock the keychain
@@ -80,8 +80,8 @@ Add these in GitHub repo settings under Actions variables:
 
 | Variable | Example | Notes |
 | --- | --- | --- |
-| `BROWSEROS_REPO_PATH` | `/Users/shadowfax/code/browseros-release` | Persistent build repo clone. Use an absolute path. |
-| `BROWSEROS_CHROMIUM_SRC` | `/Users/shadowfax/code/chromium-release/src` | Chromium `src` checkout. Use an absolute path. |
+| `BROWSEROS_REPO_PATH` | `/Users/<user>/code/browseros-release` | Persistent build repo clone. Use an absolute path. |
+| `BROWSEROS_CHROMIUM_SRC` | `/Users/<user>/code/chromium-release/src` | Chromium `src` checkout. Use an absolute path. |
 | `BROWSEROS_NIGHTLY_REF` | `main` | Optional; falls back to the repo default branch. |
 
 ## Version Policy

--- a/packages/browseros/build/docs/nightly-macos-ci.md
+++ b/packages/browseros/build/docs/nightly-macos-ci.md
@@ -1,0 +1,156 @@
+# Nightly macOS CI
+
+This workflow builds signed BrowserOS macOS arm64 DMGs on the dedicated Mac Mini.
+It runs nightly, can be triggered manually from any branch, bumps build versions,
+uploads the DMG to the Actions run, and leaves build lifecycle Slack updates to
+the existing BrowserOS build notifier.
+
+## What It Builds
+
+Nightly runs execute this command from the persistent build repo clone:
+
+```bash
+uv run browseros build --config build/config/release.macos.arm64.yaml --chromium-src "$CHROMIUM_SRC"
+```
+
+Manual runs default to artifact-only builds:
+
+```bash
+uv run browseros build --config build/config/release.macos.arm64.noupload.yaml --chromium-src "$CHROMIUM_SRC"
+```
+
+Set `upload_to_r2=true` in the manual dispatch form to use the publishing config.
+
+## One-Time Runner Setup
+
+Register the Mac Mini as a repo-scoped self-hosted runner with the custom
+`browseros-builder` label:
+
+```bash
+mkdir -p ~/actions-runner
+cd ~/actions-runner
+
+./config.sh --url https://github.com/<owner>/<repo> --token <REGISTRATION_TOKEN> \
+  --labels browseros-builder --name mac-mini-builder --work _work
+```
+
+The workflow targets:
+
+```yaml
+runs-on: [self-hosted, macOS, ARM64, browseros-builder]
+```
+
+Run the service in the logged-in GUI user session, not as a boot-time daemon.
+Codesign and `xcrun notarytool` need access to the user's login keychain; daemon
+or SSH-only sessions commonly fail with `User interaction not allowed`.
+
+```bash
+./svc.sh install
+./svc.sh start
+```
+
+If the runner is launched by `launchd`, inject the build toolchain into the
+runner PATH and restart the service:
+
+```bash
+printf '%s\n' "$HOME/code/depot_tools:/opt/homebrew/bin:/usr/local/bin:$PATH" \
+  > ~/actions-runner/.path
+./svc.sh stop
+./svc.sh start
+```
+
+Keep the runner current enough to run the action majors used by the workflow.
+
+## Machine Prerequisites
+
+The Mac Mini must already have:
+
+- Build repo clone, for example `/Users/shadowfax/code/browseros-release`
+- Chromium checkout, for example `/Users/shadowfax/code/chromium-release/src`
+- `uv`, depot_tools, Xcode Command Line Tools, and signing/notarization tooling
+- `packages/browseros/.env` with signing, notarization, R2, and Slack values
+- `MACOS_KEYCHAIN_PASSWORD` in `.env` so the build can unlock the keychain
+
+Do not copy signing, notarization, R2, or Slack secrets into GitHub Actions.
+The workflow reuses the machine-local `.env`.
+
+## Repository Variables
+
+Add these in GitHub repo settings under Actions variables:
+
+| Variable | Example | Notes |
+| --- | --- | --- |
+| `BROWSEROS_REPO_PATH` | `/Users/shadowfax/code/browseros-release` | Persistent build repo clone. Use an absolute path. |
+| `BROWSEROS_CHROMIUM_SRC` | `/Users/shadowfax/code/chromium-release/src` | Chromium `src` checkout. Use an absolute path. |
+| `BROWSEROS_NIGHTLY_REF` | `main` | Optional; falls back to the repo default branch. |
+
+## Version Policy
+
+The workflow calls `build/scripts/bump_version.py`.
+
+- Nightly schedule: `offset+build`, commit and push enabled, R2 upload enabled
+- Manual dispatch default: `offset-only`, commit disabled, R2 upload disabled
+- Manual hotfix option: choose `offset+patch`
+- Manual dry run option: choose `none`
+
+`BROWSEROS_BUILD_OFFSET` is the internal Chromium-build monotonic counter.
+`BROWSEROS_BUILD` advances the public nightly semantic version. `BROWSEROS_PATCH`
+is reserved for manual hotfix-style builds because setting both build and patch
+nonzero produces a four-part version.
+
+Nightly version commits use:
+
+```text
+chore(release): build v<VERSION> [skip ci]
+```
+
+The persistent clone must already have push credentials for the target branch.
+The workflow's `GITHUB_TOKEN` is read-only.
+
+## Manual Branch Build
+
+Open Actions, choose `Nightly macOS Build`, click `Run workflow`, select the
+branch in GitHub's native branch picker, then set inputs:
+
+- `bump`: `offset-only`, `offset+build`, `offset+patch`, or `none`
+- `commit_version`: commit and push the bumped version files
+- `upload_to_r2`: publish to R2/CDN after packaging
+
+The DMG is always uploaded as a run artifact when packaging succeeds.
+
+## Artifacts
+
+The build writes:
+
+```text
+packages/browseros/releases/<version>/BrowserOS_v<version>_arm64.dmg
+```
+
+The workflow uploads matching DMGs as `BrowserOS_v<version>_arm64` with
+14-day retention.
+
+## Slack
+
+The build already posts pipeline start, phase start/done, success, failure,
+package-created, and upload-complete messages when `SLACK_WEBHOOK_URL` is
+present in `.env`.
+
+The workflow only adds a CI-level failure ping for failures that happen before
+or around the build invocation, such as missing runner variables or sync errors.
+
+## Troubleshooting
+
+`User interaction not allowed`: run the runner as the logged-in GUI user and
+confirm `MACOS_KEYCHAIN_PASSWORD` is present in `packages/browseros/.env`.
+
+`uv`, `gclient`, `gn`, or `autoninja` not found: update `~/actions-runner/.path`
+and restart the runner service.
+
+No R2 upload on a manual run: manual runs default to artifact-only builds. Re-run
+with `upload_to_r2=true`.
+
+No version commit: check `commit_version`, the selected bump mode, and the
+persistent clone's push credentials.
+
+Long runtime: the release pipeline resets the Chromium tree and wipes
+`out/Default_arm64`, so multi-hour runs are expected.

--- a/packages/browseros/build/scripts/bump_version.py
+++ b/packages/browseros/build/scripts/bump_version.py
@@ -55,14 +55,19 @@ def bump_version(package_root: Path, mode: str) -> str:
     next_version_text = version_text
     if mode == "offset+build":
         next_version_text = _bump_version_key(version_text, "BROWSEROS_BUILD")
+        next_version_text = _replace_int_setting(
+            next_version_text,
+            "BROWSEROS_PATCH",
+            0,
+        )
     elif mode == "offset+patch":
         next_version_text = _bump_version_key(version_text, "BROWSEROS_PATCH")
 
     version = _semantic_version(next_version_text)
-    if offset is not None:
-        offset_file.write_text(f"{offset + 1}\n")
     if next_version_text != version_text:
         version_file.write_text(next_version_text)
+    if offset is not None:
+        offset_file.write_text(f"{offset + 1}\n")
     return version
 
 

--- a/packages/browseros/build/scripts/bump_version.py
+++ b/packages/browseros/build/scripts/bump_version.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Bump BrowserOS version files for CI and print the resulting version."""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Sequence
+
+
+BUMP_MODES = ("none", "offset-only", "offset+build", "offset+patch")
+
+
+def _read_int_setting(text: str, key: str) -> int:
+    match = re.search(rf"^{re.escape(key)}=(\d+)$", text, re.MULTILINE)
+    if match is None:
+        raise ValueError(f"Missing {key}")
+    return int(match.group(1))
+
+
+def _replace_int_setting(text: str, key: str, value: int) -> str:
+    pattern = re.compile(rf"^({re.escape(key)}=)(\d+)$", re.MULTILINE)
+    updated, count = pattern.subn(lambda match: f"{match.group(1)}{value}", text)
+    if count != 1:
+        raise ValueError(f"Expected exactly one {key} entry")
+    return updated
+
+
+def _semantic_version(version_text: str) -> str:
+    major = _read_int_setting(version_text, "BROWSEROS_MAJOR")
+    minor = _read_int_setting(version_text, "BROWSEROS_MINOR")
+    build = _read_int_setting(version_text, "BROWSEROS_BUILD")
+    patch = _read_int_setting(version_text, "BROWSEROS_PATCH")
+    if patch != 0:
+        return f"{major}.{minor}.{build}.{patch}"
+    if build != 0:
+        return f"{major}.{minor}.{build}"
+    return f"{major}.{minor}.0"
+
+
+def _bump_version_key(version_text: str, key: str) -> str:
+    current = _read_int_setting(version_text, key)
+    return _replace_int_setting(version_text, key, current + 1)
+
+
+def bump_version(package_root: Path, mode: str) -> str:
+    """Apply the requested CI version bump and return BrowserOS semantic version."""
+    if mode not in BUMP_MODES:
+        raise ValueError(f"Unsupported bump mode: {mode}")
+
+    offset_file = package_root / "build" / "config" / "BROWSEROS_BUILD_OFFSET"
+    version_file = package_root / "resources" / "BROWSEROS_VERSION"
+    offset = int(offset_file.read_text().strip()) if mode != "none" else None
+    version_text = version_file.read_text()
+    next_version_text = version_text
+    if mode == "offset+build":
+        next_version_text = _bump_version_key(version_text, "BROWSEROS_BUILD")
+    elif mode == "offset+patch":
+        next_version_text = _bump_version_key(version_text, "BROWSEROS_PATCH")
+
+    version = _semantic_version(next_version_text)
+    if offset is not None:
+        offset_file.write_text(f"{offset + 1}\n")
+    if next_version_text != version_text:
+        version_file.write_text(next_version_text)
+    return version
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Parse CLI arguments for GitHub Actions and print the bumped version."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", default="offset+build", choices=BUMP_MODES)
+    args = parser.parse_args(argv)
+
+    package_root = Path(__file__).resolve().parents[2]
+    print(bump_version(package_root, args.mode))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/browseros/build/scripts/bump_version_test.py
+++ b/packages/browseros/build/scripts/bump_version_test.py
@@ -52,6 +52,26 @@ class BumpVersionTest(unittest.TestCase):
         self.assertIn("BROWSEROS_BUILD=1\n", self.version_file.read_text())
         self.assertIn("BROWSEROS_PATCH=0\n", self.version_file.read_text())
 
+    def test_offset_and_build_resets_stale_patch(self) -> None:
+        self.version_file.write_text(
+            "\n".join(
+                [
+                    "BROWSEROS_MAJOR=0",
+                    "BROWSEROS_MINOR=46",
+                    "BROWSEROS_BUILD=2",
+                    "BROWSEROS_PATCH=1",
+                    "",
+                ]
+            )
+        )
+
+        version = self.module.bump_version(self.root, "offset+build")
+
+        self.assertEqual(version, "0.46.3")
+        self.assertEqual(self.offset_file.read_text(), "147\n")
+        self.assertIn("BROWSEROS_BUILD=3\n", self.version_file.read_text())
+        self.assertIn("BROWSEROS_PATCH=0\n", self.version_file.read_text())
+
     def test_offset_only_preserves_semantic_version(self) -> None:
         version = self.module.bump_version(self.root, "offset-only")
 
@@ -90,6 +110,17 @@ class BumpVersionTest(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, "Missing BROWSEROS_BUILD"):
             self.module.bump_version(self.root, "offset+build")
+
+        self.assertEqual(self.offset_file.read_text(), "146\n")
+
+    def test_version_write_failure_does_not_write_offset(self) -> None:
+        self.version_file.chmod(0o400)
+
+        try:
+            with self.assertRaises(OSError):
+                self.module.bump_version(self.root, "offset+build")
+        finally:
+            self.version_file.chmod(0o600)
 
         self.assertEqual(self.offset_file.read_text(), "146\n")
 

--- a/packages/browseros/build/scripts/bump_version_test.py
+++ b/packages/browseros/build/scripts/bump_version_test.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Tests for the BrowserOS CI version bump script."""
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("bump_version.py")
+
+
+def _load_bump_version_module():
+    spec = importlib.util.spec_from_file_location("bump_version", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class BumpVersionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.module = _load_bump_version_module()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        (self.root / "build" / "config").mkdir(parents=True)
+        (self.root / "resources").mkdir()
+        self.offset_file = self.root / "build" / "config" / "BROWSEROS_BUILD_OFFSET"
+        self.version_file = self.root / "resources" / "BROWSEROS_VERSION"
+        self.offset_file.write_text("146\n")
+        self.version_file.write_text(
+            "\n".join(
+                [
+                    "BROWSEROS_MAJOR=0",
+                    "BROWSEROS_MINOR=46",
+                    "BROWSEROS_BUILD=0",
+                    "BROWSEROS_PATCH=0",
+                    "",
+                ]
+            )
+        )
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_offset_and_build_bumps_internal_and_semantic_versions(self) -> None:
+        version = self.module.bump_version(self.root, "offset+build")
+
+        self.assertEqual(version, "0.46.1")
+        self.assertEqual(self.offset_file.read_text(), "147\n")
+        self.assertIn("BROWSEROS_BUILD=1\n", self.version_file.read_text())
+        self.assertIn("BROWSEROS_PATCH=0\n", self.version_file.read_text())
+
+    def test_offset_only_preserves_semantic_version(self) -> None:
+        version = self.module.bump_version(self.root, "offset-only")
+
+        self.assertEqual(version, "0.46.0")
+        self.assertEqual(self.offset_file.read_text(), "147\n")
+        self.assertIn("BROWSEROS_BUILD=0\n", self.version_file.read_text())
+
+    def test_offset_and_patch_outputs_four_part_version(self) -> None:
+        self.version_file.write_text(
+            "\n".join(
+                [
+                    "BROWSEROS_MAJOR=0",
+                    "BROWSEROS_MINOR=46",
+                    "BROWSEROS_BUILD=2",
+                    "BROWSEROS_PATCH=0",
+                    "",
+                ]
+            )
+        )
+
+        version = self.module.bump_version(self.root, "offset+patch")
+
+        self.assertEqual(version, "0.46.2.1")
+        self.assertEqual(self.offset_file.read_text(), "147\n")
+        self.assertIn("BROWSEROS_PATCH=1\n", self.version_file.read_text())
+
+    def test_none_only_reads_current_version(self) -> None:
+        version = self.module.bump_version(self.root, "none")
+
+        self.assertEqual(version, "0.46.0")
+        self.assertEqual(self.offset_file.read_text(), "146\n")
+        self.assertIn("BROWSEROS_BUILD=0\n", self.version_file.read_text())
+
+    def test_malformed_version_does_not_write_offset(self) -> None:
+        self.version_file.write_text("BROWSEROS_MAJOR=0\n")
+
+        with self.assertRaisesRegex(ValueError, "Missing BROWSEROS_BUILD"):
+            self.module.bump_version(self.root, "offset+build")
+
+        self.assertEqual(self.offset_file.read_text(), "146\n")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds a self-hosted GitHub Actions workflow for nightly BrowserOS macOS arm64 builds on the dedicated Mac Mini.
- Supports manual branch builds, version bump modes, DMG artifact upload, and optional R2 publishing.
- Adds a stdlib-only version bump script, no-upload release config, and ops documentation for runner/keychain/PATH setup.

## Design
The workflow follows the selected thin self-hosted runner approach: it operates on the persistent build repo clone configured by repository variables, syncs it to the target ref, bumps BrowserOS version files, optionally commits the bump, runs the existing `uv run browseros build` command against the configured Chromium checkout, and uploads the resulting DMG as an Actions artifact. Secrets remain in the machine-local `.env`; the workflow only adds a CI-level Slack failure ping for failures outside the build notifier lifecycle.

## Test plan
- `uv run ruff check build/scripts/bump_version.py build/scripts/bump_version_test.py`
- `uv run pyright build/scripts/bump_version.py build/scripts/bump_version_test.py`
- `uv run python -m unittest discover -s build -p '*_test.py'`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'label "browseros-builder" is unknown' .github/workflows/nightly-macos-build.yml`
- `git diff --check` for the feature files

Notes: full-package `ruff check .` and `pyright` currently fail on existing unrelated package issues outside this change.
