### PR TITLE
fix: restrict manual release workflows

### DIFF
--- a/.github/workflows/nightly-macos-build.yml
+++ b/.github/workflows/nightly-macos-build.yml
@@ -9,7 +9,7 @@ on:
       bump:
         description: Version bump level
         type: choice
-        default: offset+patch
+        default: offset+build
         options:
           - offset-only
           - offset+build
@@ -92,7 +92,7 @@ jobs:
             upload_to_r2="true"
           else
             target_ref="$DISPATCH_REF"
-            bump_mode="${DISPATCH_BUMP:-offset+patch}"
+            bump_mode="${DISPATCH_BUMP:-offset+build}"
             commit_version="${DISPATCH_COMMIT_VERSION:-false}"
             upload_to_r2="${DISPATCH_UPLOAD_TO_R2:-true}"
           fi

--- a/.github/workflows/nightly-macos-build.yml
+++ b/.github/workflows/nightly-macos-build.yml
@@ -9,7 +9,7 @@ on:
       bump:
         description: Version bump level
         type: choice
-        default: offset-only
+        default: offset+patch
         options:
           - offset-only
           - offset+build
@@ -34,7 +34,7 @@ concurrency:
 jobs:
   authorize_manual_dispatch:
     if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, macOS, ARM64, browseros-builder]
     environment: release-core
     steps:
       - run: echo "Manual dispatch approved through release-core."
@@ -92,7 +92,7 @@ jobs:
             upload_to_r2="true"
           else
             target_ref="$DISPATCH_REF"
-            bump_mode="${DISPATCH_BUMP:-offset-only}"
+            bump_mode="${DISPATCH_BUMP:-offset+patch}"
             commit_version="${DISPATCH_COMMIT_VERSION:-false}"
             upload_to_r2="${DISPATCH_UPLOAD_TO_R2:-true}"
           fi

--- a/.github/workflows/nightly-macos-build.yml
+++ b/.github/workflows/nightly-macos-build.yml
@@ -33,6 +33,9 @@ concurrency:
 
 jobs:
   build:
+    if: |
+      github.event_name == 'schedule' ||
+      contains(fromJSON('["shadowfax92","shivammittal274","DaniAkash","felarof99"]'), github.actor)
     runs-on: [self-hosted, macOS, ARM64, browseros-builder]
     timeout-minutes: 600
     env:

--- a/.github/workflows/nightly-macos-build.yml
+++ b/.github/workflows/nightly-macos-build.yml
@@ -32,10 +32,18 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  authorize_manual_dispatch:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    environment: release-core
+    steps:
+      - run: echo "Manual dispatch approved through release-core."
+
   build:
+    needs: authorize_manual_dispatch
     if: |
-      github.event_name == 'schedule' ||
-      contains(fromJSON('["shadowfax92","shivammittal274","DaniAkash","felarof99"]'), github.actor)
+      always() &&
+      (github.event_name == 'schedule' || needs.authorize_manual_dispatch.result == 'success')
     runs-on: [self-hosted, macOS, ARM64, browseros-builder]
     timeout-minutes: 600
     env:

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -14,7 +14,9 @@ concurrency:
 
 jobs:
   release:
-    if: github.ref == 'refs/heads/main'
+    if: |
+      github.ref == 'refs/heads/main' &&
+      contains(fromJSON('["shadowfax92","shivammittal274","DaniAkash","felarof99"]'), github.actor)
     runs-on: ubuntu-latest
     environment: release-core
     permissions:

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -14,9 +14,7 @@ concurrency:
 
 jobs:
   release:
-    if: |
-      github.ref == 'refs/heads/main' &&
-      contains(fromJSON('["shadowfax92","shivammittal274","DaniAkash","felarof99"]'), github.actor)
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: release-core
     permissions:

--- a/packages/browseros/build/docs/nightly-macos-ci.md
+++ b/packages/browseros/build/docs/nightly-macos-ci.md
@@ -90,8 +90,8 @@ Add these in GitHub repo settings under Actions variables:
 The workflow calls `build/scripts/bump_version.py`.
 
 - Nightly schedule: `offset+build`, commit and push enabled, R2 upload enabled
-- Manual dispatch default: `offset-only`, commit disabled, R2 upload enabled
-- Manual hotfix option: choose `offset+patch`
+- Manual dispatch default: `offset+patch`, commit disabled, R2 upload enabled
+- Manual nightly-style option: choose `offset+build`
 - Manual dry run option: choose `none`
 
 `BROWSEROS_BUILD_OFFSET` is the internal Chromium-build monotonic counter.

--- a/packages/browseros/build/docs/nightly-macos-ci.md
+++ b/packages/browseros/build/docs/nightly-macos-ci.md
@@ -90,8 +90,8 @@ Add these in GitHub repo settings under Actions variables:
 The workflow calls `build/scripts/bump_version.py`.
 
 - Nightly schedule: `offset+build`, commit and push enabled, R2 upload enabled
-- Manual dispatch default: `offset+patch`, commit disabled, R2 upload enabled
-- Manual nightly-style option: choose `offset+build`
+- Manual dispatch default: `offset+build`, commit disabled, R2 upload enabled
+- Manual hotfix option: choose `offset+patch`
 - Manual dry run option: choose `none`
 
 `BROWSEROS_BUILD_OFFSET` is the internal Chromium-build monotonic counter.

--- a/packages/browseros/build/docs/nightly-macos-ci.md
+++ b/packages/browseros/build/docs/nightly-macos-ci.md
@@ -117,6 +117,9 @@ branch in GitHub's native branch picker, then set inputs:
 - `commit_version`: commit and push the bumped version files
 - `upload_to_r2`: publish to R2/CDN after packaging, enabled by default
 
+Manual dispatch is restricted to the release-core maintainers. Scheduled nightly
+runs are not actor-gated.
+
 The DMG is always uploaded as a run artifact when packaging succeeds.
 
 ## Artifacts

--- a/packages/browseros/build/docs/nightly-macos-ci.md
+++ b/packages/browseros/build/docs/nightly-macos-ci.md
@@ -117,8 +117,8 @@ branch in GitHub's native branch picker, then set inputs:
 - `commit_version`: commit and push the bumped version files
 - `upload_to_r2`: publish to R2/CDN after packaging, enabled by default
 
-Manual dispatch is restricted to the release-core maintainers. Scheduled nightly
-runs are not actor-gated.
+Manual dispatch requires approval through the `release-core` environment.
+Scheduled nightly runs bypass that approval job and run automatically.
 
 The DMG is always uploaded as a run artifact when packaging succeeds.
 


### PR DESCRIPTION
## Summary
- add a `release-core` approval job for manual nightly macOS dispatches, running on the same self-hosted macOS runner labels as the build
- keep scheduled nightly runs automatic and on `offset+build`
- set manual dispatch default to `offset+build`, with full upload enabled by default
- document the nightly manual-dispatch approval and version defaults

## Verification
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'label "browseros-builder" is unknown' .github/workflows/nightly-macos-build.yml .github/workflows/release-server.yml`\n- `git diff --check -- .github/workflows/nightly-macos-build.yml packages/browseros/build/docs/nightly-macos-ci.md`\n\n## Runner setup\n- confirmed repo runner `felarof01studio` is online and labeled `self-hosted`, `macOS`, `ARM64`, `browseros-builder`