### PR TITLE
fix: open nightly version bumps via PR

### DIFF
--- a/.github/workflows/nightly-macos-build.yml
+++ b/.github/workflows/nightly-macos-build.yml
@@ -145,6 +145,7 @@ jobs:
           TARGET_REF: ${{ steps.build_inputs.outputs.target_ref }}
           VERSION: ${{ steps.bump.outputs.version }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
@@ -169,6 +170,7 @@ jobs:
           fi
 
           pr_url="$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
             --base "$TARGET_REF" \
             --head "$branch" \
             --state open \
@@ -176,6 +178,7 @@ jobs:
             --jq '.[0].url // ""')"
           if [ -z "$pr_url" ]; then
             pr_body="$(mktemp)"
+            trap 'rm -f "$pr_body"' EXIT
             cat > "$pr_body" <<EOF
           Automated nightly macOS version bump for v$VERSION.
 
@@ -183,6 +186,7 @@ jobs:
           Target ref: $TARGET_REF
           EOF
             pr_url="$(gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
               --base "$TARGET_REF" \
               --head "$branch" \
               --title "chore(release): build v$VERSION" \
@@ -191,6 +195,7 @@ jobs:
 
           echo "Version bump PR: $pr_url"
           if gh pr merge "$pr_url" \
+            --repo "$GITHUB_REPOSITORY" \
             --squash \
             --delete-branch \
             --subject "chore(release): build v$VERSION [skip ci]" \
@@ -198,16 +203,21 @@ jobs:
             exit 0
           fi
 
-          merge_state="$(gh pr view "$pr_url" --json mergeStateStatus --jq '.mergeStateStatus // "UNKNOWN"')"
+          merge_state="$(gh pr view "$pr_url" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json mergeStateStatus \
+            --jq '.mergeStateStatus // "UNKNOWN"' || echo "UNKNOWN")"
           failed_checks="$(gh pr view "$pr_url" \
+            --repo "$GITHUB_REPOSITORY" \
             --json statusCheckRollup \
-            --jq '[.statusCheckRollup[]? | select((.__typename == "CheckRun" and ((.conclusion // "") == "FAILURE" or (.conclusion // "") == "CANCELLED" or (.conclusion // "") == "TIMED_OUT" or (.conclusion // "") == "ACTION_REQUIRED")) or (.__typename == "StatusContext" and ((.state // "") == "FAILURE" or (.state // "") == "ERROR")))] | length')"
+            --jq '[.statusCheckRollup[]? | select((.__typename == "CheckRun" and ((.conclusion // "") == "FAILURE" or (.conclusion // "") == "CANCELLED" or (.conclusion // "") == "TIMED_OUT" or (.conclusion // "") == "ACTION_REQUIRED")) or (.__typename == "StatusContext" and ((.state // "") == "FAILURE" or (.state // "") == "ERROR")))] | length' || echo "0")"
           if [ "$merge_state" = "DIRTY" ] || [ "$failed_checks" -gt 0 ]; then
             echo "::warning::Leaving version bump PR open (mergeStateStatus=$merge_state, failedChecks=$failed_checks): $pr_url"
             exit 0
           fi
 
           if gh pr merge "$pr_url" \
+            --repo "$GITHUB_REPOSITORY" \
             --auto \
             --squash \
             --delete-branch \

--- a/.github/workflows/nightly-macos-build.yml
+++ b/.github/workflows/nightly-macos-build.yml
@@ -45,6 +45,9 @@ jobs:
       always() &&
       (github.event_name == 'schedule' || needs.authorize_manual_dispatch.result == 'success')
     runs-on: [self-hosted, macOS, ARM64, browseros-builder]
+    permissions:
+      contents: write
+      pull-requests: write
     timeout-minutes: 600
     env:
       BROWSEROS_REPO: ${{ vars.BROWSEROS_REPO_PATH }}
@@ -135,12 +138,14 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Built version: $version"
 
-      - name: Commit and push version bump
+      - name: Commit version bump via pull request
         if: ${{ steps.build_inputs.outputs.commit_version == 'true' }}
         env:
           BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
           TARGET_REF: ${{ steps.build_inputs.outputs.target_ref }}
           VERSION: ${{ steps.bump.outputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           cd "$BROWSEROS_REPO"
@@ -152,7 +157,66 @@ jobs:
           fi
           git -c user.name="BrowserOS CI" -c user.email="ci@browseros.com" \
             commit -m "chore(release): build v$VERSION [skip ci]"
-          git push origin "HEAD:$TARGET_REF"
+
+          safe_target_ref="${TARGET_REF//[^A-Za-z0-9._-]/-}"
+          branch="bot/nightly-macos-version-${safe_target_ref}-v${VERSION}"
+          expected_sha="$(git ls-remote --heads origin "$branch" | awk '{print $1}')"
+          if [ -n "$expected_sha" ]; then
+            git push --force-with-lease="refs/heads/$branch:$expected_sha" \
+              origin "HEAD:refs/heads/$branch"
+          else
+            git push origin "HEAD:refs/heads/$branch"
+          fi
+
+          pr_url="$(gh pr list \
+            --base "$TARGET_REF" \
+            --head "$branch" \
+            --state open \
+            --json url \
+            --jq '.[0].url // ""')"
+          if [ -z "$pr_url" ]; then
+            pr_body="$(mktemp)"
+            cat > "$pr_body" <<EOF
+          Automated nightly macOS version bump for v$VERSION.
+
+          Source run: $RUN_URL
+          Target ref: $TARGET_REF
+          EOF
+            pr_url="$(gh pr create \
+              --base "$TARGET_REF" \
+              --head "$branch" \
+              --title "chore(release): build v$VERSION" \
+              --body-file "$pr_body")"
+          fi
+
+          echo "Version bump PR: $pr_url"
+          if gh pr merge "$pr_url" \
+            --squash \
+            --delete-branch \
+            --subject "chore(release): build v$VERSION [skip ci]" \
+            --body "Automated nightly macOS version bump."; then
+            exit 0
+          fi
+
+          merge_state="$(gh pr view "$pr_url" --json mergeStateStatus --jq '.mergeStateStatus // "UNKNOWN"')"
+          failed_checks="$(gh pr view "$pr_url" \
+            --json statusCheckRollup \
+            --jq '[.statusCheckRollup[]? | select((.__typename == "CheckRun" and ((.conclusion // "") == "FAILURE" or (.conclusion // "") == "CANCELLED" or (.conclusion // "") == "TIMED_OUT" or (.conclusion // "") == "ACTION_REQUIRED")) or (.__typename == "StatusContext" and ((.state // "") == "FAILURE" or (.state // "") == "ERROR")))] | length')"
+          if [ "$merge_state" = "DIRTY" ] || [ "$failed_checks" -gt 0 ]; then
+            echo "::warning::Leaving version bump PR open (mergeStateStatus=$merge_state, failedChecks=$failed_checks): $pr_url"
+            exit 0
+          fi
+
+          if gh pr merge "$pr_url" \
+            --auto \
+            --squash \
+            --delete-branch \
+            --subject "chore(release): build v$VERSION [skip ci]" \
+            --body "Automated nightly macOS version bump."; then
+            echo "Enabled auto-merge for version bump PR: $pr_url"
+          else
+            echo "::warning::Could not merge or enable auto-merge for version bump PR; leaving it open: $pr_url"
+          fi
 
       - name: Build BrowserOS (macOS arm64)
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ packages/browseros/build/tools/
 # AI SDK DevTools traces
 .devtools/
 .omc/
+.llm/

--- a/packages/browseros/build/docs/nightly-macos-ci.md
+++ b/packages/browseros/build/docs/nightly-macos-ci.md
@@ -68,7 +68,7 @@ The Mac Mini must already have:
 
 - Build repo clone, for example `/Users/<user>/code/browseros-release`
 - Chromium checkout, for example `/Users/<user>/code/chromium-release/src`
-- `uv`, depot_tools, Xcode Command Line Tools, and signing/notarization tooling
+- `uv`, `gh`, depot_tools, Xcode Command Line Tools, and signing/notarization tooling
 - `packages/browseros/.env` with signing, notarization, R2, and Slack values
 - `MACOS_KEYCHAIN_PASSWORD` in `.env` so the build can unlock the keychain
 
@@ -105,8 +105,12 @@ Nightly version commits use:
 chore(release): build v<VERSION> [skip ci]
 ```
 
-The persistent clone must already have push credentials for the target branch.
-The workflow's `GITHUB_TOKEN` is read-only.
+Version commits are pushed to a `bot/nightly-macos-version-*` branch and opened
+as pull requests against the target branch. The workflow tries an immediate
+squash merge, then auto-merge, and leaves the PR open if GitHub will not merge it
+yet. The persistent clone must already have credentials that can push bot
+branches. The workflow's `GITHUB_TOKEN` has `contents: write` and
+`pull-requests: write` for the build job so it can create and merge those PRs.
 
 ## Manual Branch Build
 
@@ -153,8 +157,9 @@ and restart the runner service.
 Artifact-only manual run: set `upload_to_r2=false` to package the DMG without
 publishing it to R2.
 
-No version commit: check `commit_version`, the selected bump mode, and the
-persistent clone's push credentials.
+No version commit: check `commit_version`, the selected bump mode, the
+persistent clone's branch push credentials, and any open
+`bot/nightly-macos-version-*` PR.
 
 Long runtime: the release pipeline resets the Chromium tree and wipes
 `out/Default_arm64`, so multi-hour runs are expected.


### PR DESCRIPTION
## Summary
- Replaces direct nightly version pushes to protected branches with a bot-branch pull request flow.
- Attempts immediate squash merge, then auto-merge, and leaves the PR open without blocking the build if GitHub will not merge it.
- Updates the nightly macOS CI runbook with the `gh` prerequisite and new version-bump behavior.

## Design
The workflow still commits the generated version files in the persistent Mac build checkout so the build uses the bumped version immediately. It pushes that commit to a deterministic `bot/nightly-macos-version-*` branch, opens or reuses a PR against the target ref, and follows the existing repo pattern of immediate merge with auto-merge/open-PR fallback.

## Test plan
- `yq -e` parse check for the changed workflow step and job permissions.
- Extracted the PR-flow shell block with `yq` and ran `bash -n`.
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'label "browseros-builder" is unknown' .github/workflows/nightly-macos-build.yml`\n- `uv run python -m unittest build/scripts/bump_version_test.py`