### PR TITLE
fix(server): preserve cached windowId for hidden tabs in listPages

### DIFF
--- a/packages/browseros-agent/apps/server/src/browser/browser.ts
+++ b/packages/browseros-agent/apps/server/src/browser/browser.ts
@@ -190,7 +190,11 @@ export class Browser {
           info.loadProgress = tab.loadProgress
           info.isPinned = tab.isPinned
           info.isHidden = tab.isHidden
-          info.windowId = tab.windowId
+          // CDP omits windowId for hidden tabs, so preserve the
+          // value we cached when the tab was created via newPage —
+          // otherwise downstream filters (e.g. the tab picker
+          // scoped to a thread's hidden window) lose every entry.
+          info.windowId = tab.windowId ?? info.windowId
           info.index = tab.index
           info.groupId = tab.groupId
           found = true


### PR DESCRIPTION
## Summary

- CDP's `getTabs` omits `windowId` for hidden tabs. In `listPages`, the update branch was overwriting `info.windowId` with that undefined value, wiping the correct windowId that `newPage` had cached when the tab was created via `new_page(windowId=X)`.
- Downstream callers that filter pages by window — agent-company's `@`-tab picker, third-party clients grouping pages per window — lost every hidden entry as a result.
- `newPage` already sets `info.windowId` correctly at creation (line 372 `windowId: tabInfo.windowId ?? windowId`). Fix is to stop clobbering it in the refresh path: fall back to the cached value when CDP gives us nothing.

## Repro (before fix)

```
1. create_hidden_window           → windowId=W
2. new_hidden_page(windowId=W)    → pageId=P, info.windowId=W (cached) ✓
3. list_pages                     → page P returned with windowId: undefined ✗
```

## After fix

```
3. list_pages                     → page P returned with windowId: W ✓
```

Verified live: a hidden page created via `new_hidden_page(windowId=…)` now retains its windowId across subsequent `list_pages` calls.

## Test plan

- [x] Probe: `create_hidden_window` → `new_hidden_page(windowId=W)` → `list_pages` returns `windowId: W` on the hidden page
- [x] Verified visible-window pages still report windowId correctly (no regression)
- [x] Verified the agent-company `@`-tab picker (browseros-ai/agent-company#66) shows hidden-window tabs after this fix

## Scope

One line of code, plus a comment explaining why. No behavior change for any tab that already had a valid `windowId` from CDP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)