### PR TITLE
feat: configurable request timeout for Ollama and LM Studio providers

### DIFF
--- a/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
+++ b/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
@@ -23,6 +23,30 @@ type ProviderFactory = (
   config: ResolvedAgentConfig,
 ) => (modelId: string) => unknown
 
+function createRequestTimeoutFetch(
+  requestTimeoutMs?: number,
+): typeof globalThis.fetch | undefined {
+  if (
+    !requestTimeoutMs ||
+    requestTimeoutMs <= 0 ||
+    !Number.isFinite(requestTimeoutMs)
+  ) {
+    return undefined
+  }
+
+  return async (input, init) => {
+    const timeoutSignal = AbortSignal.timeout(requestTimeoutMs)
+    const signal = init?.signal
+      ? AbortSignal.any([init.signal, timeoutSignal])
+      : timeoutSignal
+
+    return globalThis.fetch(input, {
+      ...init,
+      signal,
+    })
+  }
+}
+
 function createAnthropicFactory(
   config: ResolvedAgentConfig,
 ): (modelId: string) => unknown {
@@ -71,10 +95,12 @@ function createLMStudioFactory(
   config: ResolvedAgentConfig,
 ): (modelId: string) => unknown {
   if (!config.baseUrl) throw new Error('LMStudio provider requires baseUrl')
+  const timeoutFetch = createRequestTimeoutFetch(config.requestTimeoutMs)
   return createOpenAICompatible({
     name: 'lmstudio',
     baseURL: config.baseUrl,
     ...(config.apiKey && { apiKey: config.apiKey }),
+    ...(timeoutFetch && { fetch: timeoutFetch }),
   })
 }
 
@@ -82,10 +108,12 @@ function createOllamaFactory(
   config: ResolvedAgentConfig,
 ): (modelId: string) => unknown {
   if (!config.baseUrl) throw new Error('Ollama provider requires baseUrl')
+  const timeoutFetch = createRequestTimeoutFetch(config.requestTimeoutMs)
   return createOpenAICompatible({
     name: 'ollama',
     baseURL: config.baseUrl,
     ...(config.apiKey && { apiKey: config.apiKey }),
+    ...(timeoutFetch && { fetch: timeoutFetch }),
   })
 }
 

--- a/packages/browseros-agent/apps/server/src/agent/types.ts
+++ b/packages/browseros-agent/apps/server/src/agent/types.ts
@@ -34,6 +34,8 @@ export interface ResolvedAgentConfig {
   reasoningEffort?: string
   reasoningSummary?: string
   contextWindowSize?: number
+  /** Request timeout in milliseconds for providers that support per-request fetch configuration. */
+  requestTimeoutMs?: number
   userSystemPrompt?: string
   workingDir?: string
   /** Whether the model supports image inputs (vision). Defaults to true. */

--- a/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
@@ -65,6 +65,7 @@ export class ChatService {
       origin: request.origin,
       declinedApps: request.declinedApps,
       browserosId: this.deps.browserosId,
+      requestTimeoutMs: request.requestTimeoutMs,
     }
 
     let session = sessionStore.get(request.conversationId)

--- a/packages/browseros-agent/apps/server/src/api/types.ts
+++ b/packages/browseros-agent/apps/server/src/api/types.ts
@@ -38,6 +38,9 @@ export const ChatRequestSchema = AgentLLMConfigSchema.extend({
   conversationId: z.string().uuid(),
   message: z.string().optional().default(''),
   contextWindowSize: z.number().optional(),
+  // Per-request override for HTTP timeout against Ollama / LM Studio
+  // providers (closes #938). 0 / negative / undefined disables the timeout.
+  requestTimeoutMs: z.number().int().nonnegative().optional(),
   browserContext: BrowserContextSchema.optional(),
   userSystemPrompt: z.string().optional(),
   isScheduledTask: z.boolean().optional().default(false),

--- a/packages/browseros-agent/apps/server/tests/agent/provider-factory.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/provider-factory.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it, mock } from 'bun:test'
+
+import type { ResolvedAgentConfig } from '../../src/agent/types'
+
+const LLM_PROVIDERS = {
+  ANTHROPIC: 'anthropic',
+  OPENAI: 'openai',
+  GOOGLE: 'google',
+  OPENROUTER: 'openrouter',
+  AZURE: 'azure',
+  OLLAMA: 'ollama',
+  LMSTUDIO: 'lmstudio',
+  BEDROCK: 'bedrock',
+  BROWSEROS: 'browseros',
+  OPENAI_COMPATIBLE: 'openai-compatible',
+  MOONSHOT: 'moonshot',
+  CHATGPT_PRO: 'chatgpt-pro',
+  GITHUB_COPILOT: 'github-copilot',
+  QWEN_CODE: 'qwen-code',
+} as const
+
+type OpenAICompatibleOptions = {
+  name: string
+  baseURL: string
+  apiKey?: string
+  fetch?: typeof globalThis.fetch
+}
+
+const openAICompatibleOptions: OpenAICompatibleOptions[] = []
+const createProviderFactory = () =>
+  mock((options: unknown) =>
+    mock((modelId: string) => ({
+      modelId,
+      options,
+    })),
+  )
+
+mock.module('@browseros/shared/schemas/llm', () => ({
+  LLM_PROVIDERS,
+}))
+
+mock.module('@browseros/shared/constants/urls', () => ({
+  EXTERNAL_URLS: {
+    QWEN_CODE_API: 'https://qwen.example.test',
+    GITHUB_COPILOT_API: 'https://copilot.example.test',
+  },
+}))
+
+mock.module('@ai-sdk/amazon-bedrock', () => ({
+  createAmazonBedrock: createProviderFactory(),
+}))
+
+mock.module('@ai-sdk/anthropic', () => ({
+  createAnthropic: createProviderFactory(),
+}))
+
+mock.module('@ai-sdk/azure', () => ({
+  createAzure: createProviderFactory(),
+}))
+
+mock.module('@ai-sdk/google', () => ({
+  createGoogleGenerativeAI: createProviderFactory(),
+}))
+
+mock.module('@ai-sdk/openai', () => ({
+  createOpenAI: mock((options: unknown) => ({
+    ...createProviderFactory()(options),
+    responses: createProviderFactory()(options),
+  })),
+}))
+
+mock.module('@ai-sdk/openai-compatible', () => ({
+  createOpenAICompatible: mock((options: OpenAICompatibleOptions) => {
+    openAICompatibleOptions.push(options)
+    return mock((modelId: string) => ({
+      modelId,
+      options,
+    }))
+  }),
+}))
+
+mock.module('@openrouter/ai-sdk-provider', () => ({
+  createOpenRouter: createProviderFactory(),
+}))
+
+mock.module('../../src/lib/browseros-fetch', () => ({
+  createBrowserOSFetch: () => globalThis.fetch,
+}))
+
+mock.module('../../src/lib/clients/llm/mock-language-model', () => ({
+  createMockBrowserOSLanguageModel: mock(() => ({})),
+  shouldUseMockBrowserOSLLM: mock(() => false),
+}))
+
+mock.module('../../src/lib/clients/oauth/codex-fetch', () => ({
+  createCodexFetch: () => globalThis.fetch,
+}))
+
+mock.module('../../src/lib/clients/oauth/copilot-fetch', () => ({
+  createCopilotFetch: () => globalThis.fetch,
+}))
+
+mock.module('../../src/lib/logger', () => ({
+  logger: {
+    debug: mock(() => {}),
+  },
+}))
+
+mock.module('../../src/lib/openrouter-fetch', () => ({
+  createOpenRouterCompatibleFetch: () => globalThis.fetch,
+}))
+
+const { createLanguageModel } = await import('../../src/agent/provider-factory')
+
+function createConfig(
+  provider: ResolvedAgentConfig['provider'],
+  requestTimeoutMs?: number,
+): ResolvedAgentConfig {
+  return {
+    conversationId: crypto.randomUUID(),
+    provider,
+    model: 'local-model',
+    baseUrl: 'http://localhost:11434/v1',
+    requestTimeoutMs,
+  }
+}
+
+async function withFetch<T>(
+  fetchImpl: typeof globalThis.fetch,
+  callback: () => Promise<T>,
+): Promise<T> {
+  const originalFetch = globalThis.fetch
+  globalThis.fetch = fetchImpl
+  try {
+    return await callback()
+  } finally {
+    globalThis.fetch = originalFetch
+  }
+}
+
+function getLastOpenAICompatibleOptions(): OpenAICompatibleOptions {
+  const options = openAICompatibleOptions.at(-1)
+  if (!options) throw new Error('Expected createOpenAICompatible to be called')
+  return options
+}
+
+describe('createLanguageModel local provider request timeouts', () => {
+  it('does not pass a fetch override when timeout is unset', () => {
+    createLanguageModel(createConfig(LLM_PROVIDERS.OLLAMA))
+
+    expect(getLastOpenAICompatibleOptions().fetch).toBeUndefined()
+  })
+
+  it('does not pass a fetch override when timeout is zero or negative', () => {
+    createLanguageModel(createConfig(LLM_PROVIDERS.OLLAMA, 0))
+    expect(getLastOpenAICompatibleOptions().fetch).toBeUndefined()
+
+    createLanguageModel(createConfig(LLM_PROVIDERS.LMSTUDIO, -1))
+    expect(getLastOpenAICompatibleOptions().fetch).toBeUndefined()
+  })
+
+  it.each([
+    [LLM_PROVIDERS.OLLAMA, 'ollama'],
+    [LLM_PROVIDERS.LMSTUDIO, 'lmstudio'],
+  ] as const)(
+    'passes through fast %s requests before the timeout',
+    async (provider, providerName) => {
+      createLanguageModel(createConfig(provider, 100))
+      const timeoutFetch = getLastOpenAICompatibleOptions().fetch
+
+      expect(timeoutFetch).toBeDefined()
+      await withFetch(
+        mock(async (_input, init) => {
+          expect(init?.signal).toBeDefined()
+          expect(init?.signal?.aborted).toBe(false)
+          return new Response(providerName)
+        }) as typeof globalThis.fetch,
+        async () => {
+          const response = await timeoutFetch?.('http://localhost/v1/chat')
+          expect(await response?.text()).toBe(providerName)
+        },
+      )
+    },
+  )
+
+  it.each([
+    [LLM_PROVIDERS.OLLAMA],
+    [LLM_PROVIDERS.LMSTUDIO],
+  ] as const)('aborts slow %s requests after the timeout', async (provider) => {
+    createLanguageModel(createConfig(provider, 10))
+    const timeoutFetch = getLastOpenAICompatibleOptions().fetch
+
+    expect(timeoutFetch).toBeDefined()
+    await withFetch(
+      mock(
+        async (
+          _input: RequestInfo | URL,
+          init?: RequestInit,
+        ): Promise<Response> => {
+          await new Promise((resolve, reject) => {
+            init?.signal?.addEventListener(
+              'abort',
+              () => reject(init.signal?.reason),
+              { once: true },
+            )
+          })
+          return new Response('unexpected')
+        },
+      ) as typeof globalThis.fetch,
+      async () => {
+        await expect(timeoutFetch?.('http://localhost/v1/chat')).rejects.toThrow(
+          /abort|timed out/i,
+        )
+      },
+    )
+  })
+})


### PR DESCRIPTION
## Summary

feat: configurable request timeout for Ollama and LM Studio providers

Closes #938

---
AI was used for assistance.