### PR TITLE
fix(ci): make nightly macOS sync resilient to a dirty builder tree

### DIFF
--- a/.github/workflows/nightly-macos-build.yml
+++ b/.github/workflows/nightly-macos-build.yml
@@ -129,7 +129,6 @@ jobs:
             git checkout -f "$TARGET_REF"
             git reset --hard "$TARGET_REF"
           fi
-          git clean -fd
 
       - name: Bump version
         id: bump

--- a/.github/workflows/nightly-macos-build.yml
+++ b/.github/workflows/nightly-macos-build.yml
@@ -117,11 +117,16 @@ jobs:
           set -euo pipefail
           cd "$BROWSEROS_REPO"
           git fetch origin --tags --prune
+          # Wipe any local edits before switching refs. The builder's working
+          # tree can carry stray modifications to tracked files, which would
+          # otherwise make the checkout below abort before reset --hard runs.
+          git reset --hard
+          git clean -fd
           if git show-ref --verify --quiet "refs/remotes/origin/$TARGET_REF"; then
             git checkout -B "$TARGET_REF" "origin/$TARGET_REF"
             git reset --hard "origin/$TARGET_REF"
           else
-            git checkout "$TARGET_REF"
+            git checkout -f "$TARGET_REF"
             git reset --hard "$TARGET_REF"
           fi
           git clean -fd


### PR DESCRIPTION
## Summary

- Nightly macOS build [run 26494928588](https://github.com/browseros-ai/BrowserOS/actions/runs/26494928588) failed at the **Sync build repo to target ref** step: `git checkout -B` aborted with *"Your local changes to the following files would be overwritten by checkout"* because the self-hosted builder's working tree had stray edits to tracked files (`.github/workflows/nightly-macos-build.yml`, `packages/browseros/build/docs/nightly-macos-ci.md`).
- The step ran `git checkout` **before** `git reset --hard` / `git clean -fd`, so the cleanup that was meant to discard those local edits never executed — `checkout` refuses to clobber modified tracked files and bailed first.
- Reorder so the tree is reset and cleaned **up front**; the checkout can no longer be blocked by a dirty tree.

## Design

The sync step's intent — as already documented in the nightly-build PRD ("`git fetch` + checkout + hard-reset the target ref; `git clean -fd`") — is to force the persistent build clone to match the target ref, discarding anything local. The original implementation deferred `reset --hard` / `clean -fd` until *after* the checkout, which is unreachable when the tree is dirty. This moves an unconditional `git reset --hard` + `git clean -fd` ahead of the branch logic and uses `git checkout -f` on the fallback (non-origin) path, so a dirty builder normalizes itself before any ref switch. No behavioral change on a clean tree.

## Test plan

- **Self-heal (primary):** the next scheduled nightly resets/cleans the builder tree before checkout, so the leftover edits that broke run 26494928588 are wiped and the sync succeeds — no manual cleanup on the Mac Mini.
- **On-demand:** `workflow_dispatch` this branch with `commit_version: false`, `upload_to_r2: false`; confirm the Sync step passes even with a dirty tree.
- **Local repro:** in a clone with a modified tracked file, run the new sequence (`reset --hard` → `clean -fd` → `checkout -B … origin/<ref>`) and confirm checkout no longer aborts.