### PR TITLE
fix: align host adapter availability probe

### DIFF
--- a/packages/browseros-agent/apps/server/src/lib/agents/runtime/host-process-agent-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/runtime/host-process-agent-runtime.ts
@@ -45,19 +45,32 @@ export interface HostProcessAgentRuntimeDeps {
 const DEFAULT_PROBE_CACHE_MS = 5 * 60 * 1000
 const DEFAULT_PROBE_TIMEOUT_MS = 2_000
 
+/**
+ * Builds the environment used for host CLI version probes. macOS probes get
+ * the same GUI-safe PATH used by ACP adapter launches; explicit overrides
+ * layer on top without disabling that PATH enrichment.
+ */
 export function buildHostProcessProbeEnv(
-  input: { env?: NodeJS.ProcessEnv; platform?: NodeJS.Platform } = {},
+  input: {
+    env?: NodeJS.ProcessEnv
+    platform?: NodeJS.Platform
+    overrides?: NodeJS.ProcessEnv
+  } = {},
 ): NodeJS.ProcessEnv | undefined {
   const platform = input.platform ?? process.platform
-  if (platform !== 'darwin') return undefined
   const env = input.env ?? process.env
-  return {
-    ...env,
-    PATH: buildMacosAcpAdapterPath({
-      basePath: env.PATH,
-      home: env.HOME,
-    }),
-  }
+  const baseEnv =
+    platform === 'darwin'
+      ? {
+          ...env,
+          PATH: buildMacosAcpAdapterPath({
+            basePath: env.PATH,
+            home: env.HOME,
+          }),
+        }
+      : undefined
+  if (!input.overrides) return baseEnv
+  return { ...(baseEnv ?? env), ...input.overrides }
 }
 
 export abstract class HostProcessAgentRuntime implements AgentRuntime {
@@ -236,9 +249,7 @@ export abstract class HostProcessAgentRuntime implements AgentRuntime {
     timeoutMs: number,
   ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
     if (this.deps.spawnProbe) return this.deps.spawnProbe(cmd, timeoutMs)
-    const env = this.deps.probeEnv
-      ? { ...process.env, ...this.deps.probeEnv }
-      : buildHostProcessProbeEnv()
+    const env = buildHostProcessProbeEnv({ overrides: this.deps.probeEnv })
     const proc = Bun.spawn(cmd as string[], {
       stdout: 'pipe',
       stderr: 'pipe',

--- a/packages/browseros-agent/apps/server/src/lib/agents/runtime/host-process-agent-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/runtime/host-process-agent-runtime.ts
@@ -11,6 +11,7 @@
  */
 
 import { logger } from '../../logger'
+import { buildMacosAcpAdapterPath } from '../bundled-bun'
 import type { AgentRuntime } from './agent-runtime'
 import { ActionNotSupportedError } from './errors'
 import type {
@@ -37,10 +38,27 @@ export interface HostProcessAgentRuntimeDeps {
     cmd: ReadonlyArray<string>,
     timeoutMs: number,
   ) => Promise<{ exitCode: number; stdout: string; stderr: string }>
+  /** Environment overrides for the version probe subprocess. */
+  probeEnv?: NodeJS.ProcessEnv
 }
 
 const DEFAULT_PROBE_CACHE_MS = 5 * 60 * 1000
 const DEFAULT_PROBE_TIMEOUT_MS = 2_000
+
+export function buildHostProcessProbeEnv(
+  input: { env?: NodeJS.ProcessEnv; platform?: NodeJS.Platform } = {},
+): NodeJS.ProcessEnv | undefined {
+  const platform = input.platform ?? process.platform
+  if (platform !== 'darwin') return undefined
+  const env = input.env ?? process.env
+  return {
+    ...env,
+    PATH: buildMacosAcpAdapterPath({
+      basePath: env.PATH,
+      home: env.HOME,
+    }),
+  }
+}
 
 export abstract class HostProcessAgentRuntime implements AgentRuntime {
   abstract readonly descriptor: RuntimeDescriptor & { kind: 'host-process' }
@@ -218,9 +236,13 @@ export abstract class HostProcessAgentRuntime implements AgentRuntime {
     timeoutMs: number,
   ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
     if (this.deps.spawnProbe) return this.deps.spawnProbe(cmd, timeoutMs)
+    const env = this.deps.probeEnv
+      ? { ...process.env, ...this.deps.probeEnv }
+      : buildHostProcessProbeEnv()
     const proc = Bun.spawn(cmd as string[], {
       stdout: 'pipe',
       stderr: 'pipe',
+      env,
     })
     const timer = setTimeout(() => {
       try {

--- a/packages/browseros-agent/apps/server/src/lib/agents/runtime/index.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/runtime/index.ts
@@ -33,6 +33,7 @@ export {
   prepareHermesContext,
 } from './hermes-container-runtime'
 export {
+  buildHostProcessProbeEnv,
   HostProcessAgentRuntime,
   type HostProcessAgentRuntimeDeps,
 } from './host-process-agent-runtime'

--- a/packages/browseros-agent/apps/server/tests/lib/agents/runtime/host-process-agent-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/runtime/host-process-agent-runtime.test.ts
@@ -230,6 +230,35 @@ describe('HostProcessAgentRuntime', () => {
       ])
     })
 
+    it('keeps macOS PATH enrichment as the probeEnv base', () => {
+      const env = buildHostProcessProbeEnv({
+        env: { HOME: '/Users/tester', PATH: '/base/bin' },
+        platform: 'darwin',
+        overrides: { DEBUG_PROBE: '1' },
+      })
+      expect(env?.DEBUG_PROBE).toBe('1')
+      expect(env?.PATH?.split(delimiter).slice(0, 5)).toEqual([
+        '/Users/tester/.local/bin',
+        '/Users/tester/.bun/bin',
+        '/opt/homebrew/bin',
+        '/usr/local/bin',
+        '/base/bin',
+      ])
+    })
+
+    it('layers probeEnv over process env on non-macOS', () => {
+      const env = buildHostProcessProbeEnv({
+        env: { HOME: '/home/tester', PATH: '/base/bin' },
+        platform: 'linux',
+        overrides: { DEBUG_PROBE: '1' },
+      })
+      expect(env).toEqual({
+        HOME: '/home/tester',
+        PATH: '/base/bin',
+        DEBUG_PROBE: '1',
+      })
+    })
+
     it('leaves non-macOS probe env unchanged', () => {
       expect(
         buildHostProcessProbeEnv({

--- a/packages/browseros-agent/apps/server/tests/lib/agents/runtime/host-process-agent-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/runtime/host-process-agent-runtime.test.ts
@@ -4,8 +4,12 @@
  */
 
 import { describe, expect, it, mock } from 'bun:test'
+import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { delimiter, join } from 'node:path'
 import {
   ActionNotSupportedError,
+  buildHostProcessProbeEnv,
   HostProcessAgentRuntime,
   type HostProcessAgentRuntimeDeps,
   type RuntimeStatusSnapshot,
@@ -191,6 +195,48 @@ describe('HostProcessAgentRuntime', () => {
       })
       await r.probeHealth()
       expect(spawnProbe.mock.calls[0]?.[0]).toEqual(['custom-bin', '-V'])
+    })
+
+    it('passes probeEnv overrides to the spawned version probe', async () => {
+      const dir = await mkdtemp(join(tmpdir(), 'host-probe-'))
+      try {
+        const bin = join(dir, 'fake-cli')
+        await writeFile(bin, '#!/bin/sh\necho from-probe-env\n')
+        await chmod(bin, 0o755)
+        const r = new TestRuntime({
+          binaryName: 'fake-cli',
+          probeEnv: { PATH: dir },
+        })
+        await r.probeHealth()
+        const snap = r.getStatusSnapshot()
+        expect(snap.state).toBe('cli_present')
+        expect(snap.details?.binaryVersion).toBe('from-probe-env')
+      } finally {
+        await rm(dir, { recursive: true, force: true })
+      }
+    })
+
+    it('builds a macOS GUI-safe probe PATH', () => {
+      const env = buildHostProcessProbeEnv({
+        env: { HOME: '/Users/tester', PATH: '/base/bin' },
+        platform: 'darwin',
+      })
+      expect(env?.PATH.split(delimiter).slice(0, 5)).toEqual([
+        '/Users/tester/.local/bin',
+        '/Users/tester/.bun/bin',
+        '/opt/homebrew/bin',
+        '/usr/local/bin',
+        '/base/bin',
+      ])
+    })
+
+    it('leaves non-macOS probe env unchanged', () => {
+      expect(
+        buildHostProcessProbeEnv({
+          env: { HOME: '/home/tester', PATH: '/base/bin' },
+          platform: 'linux',
+        }),
+      ).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
## Summary
- Align host adapter health checks with the macOS PATH used when Claude/Codex turns actually run.
- Prevent Recent Agents from showing adapter-level "Unavailable" when the CLI is discoverable through BrowserOS' GUI-safe PATH.
- Add focused coverage for probe environment overrides and macOS PATH construction.

## Design
Host-process adapter health still flows through the existing /adapters endpoint and runtime snapshots. The change only updates the probe subprocess environment: on macOS it now builds the same GUI-safe PATH used by ACP adapter launches, while non-macOS behavior stays unchanged. Tests cover both the environment override seam and platform-specific PATH behavior.

## Test plan
- bun --env-file=apps/server/.env.development test apps/server/tests/lib/agents/runtime/host-process-agent-runtime.test.ts
- bun run --filter @browseros/server typecheck
- bunx biome check apps/server/src/lib/agents/runtime/host-process-agent-runtime.ts apps/server/src/lib/agents/runtime/index.ts apps/server/tests/lib/agents/runtime/host-process-agent-runtime.test.ts