### PR TITLE
fix: version-gate Claude Code/Codex agents to BrowserOS 0.46.0.0

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/useAgents.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/useAgents.ts
@@ -43,7 +43,7 @@ export async function agentsFetch<T>(
 }
 
 export function useAgentAdapters(enabled = true) {
-  const { supports } = useCapabilities()
+  const { supports, isLoading: capabilitiesLoading } = useCapabilities()
   const agentsSupported = supports(Feature.AGENT_HARNESS_SUPPORT)
   const {
     baseUrl,
@@ -65,14 +65,16 @@ export function useAgentAdapters(enabled = true) {
 
   return {
     adapters: agentsSupported ? (query.data ?? []) : [],
-    loading: agentsSupported && (query.isLoading || urlLoading),
-    error: query.error ?? urlError,
+    loading:
+      capabilitiesLoading ||
+      (agentsSupported && (query.isLoading || urlLoading)),
+    error: agentsSupported ? (query.error ?? urlError) : null,
     refetch: query.refetch,
   }
 }
 
 export function useHarnessAgents(enabled = true) {
-  const { supports } = useCapabilities()
+  const { supports, isLoading: capabilitiesLoading } = useCapabilities()
   const agentsSupported = supports(Feature.AGENT_HARNESS_SUPPORT)
   const {
     baseUrl,
@@ -105,8 +107,10 @@ export function useHarnessAgents(enabled = true) {
       ? (query.data?.agents ?? []).map(mapHarnessAgentToEntry)
       : [],
     harnessAgents: agentsSupported ? (query.data?.agents ?? []) : [],
-    loading: agentsSupported && (query.isLoading || urlLoading),
-    error: query.error ?? urlError,
+    loading:
+      capabilitiesLoading ||
+      (agentsSupported && (query.isLoading || urlLoading)),
+    error: agentsSupported ? (query.error ?? urlError) : null,
     refetch: query.refetch,
   }
 }

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/useAgents.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/useAgents.ts
@@ -1,6 +1,8 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query'
+import { Feature } from '@/lib/browseros/capabilities'
 import { getAgentServerUrl } from '@/lib/browseros/helpers'
 import { useAgentServerUrl } from '@/lib/browseros/useBrowserOSProviders'
+import { useCapabilities } from '@/lib/browseros/useCapabilities'
 import { buildAgentApiUrl } from './agent-api-url'
 import {
   type AgentHarnessStreamEvent,
@@ -41,6 +43,8 @@ export async function agentsFetch<T>(
 }
 
 export function useAgentAdapters(enabled = true) {
+  const { supports } = useCapabilities()
+  const agentsSupported = supports(Feature.AGENT_HARNESS_SUPPORT)
   const {
     baseUrl,
     isLoading: urlLoading,
@@ -56,18 +60,20 @@ export function useAgentAdapters(enabled = true) {
       )
       return data.adapters ?? []
     },
-    enabled: Boolean(baseUrl) && !urlLoading && enabled,
+    enabled: Boolean(baseUrl) && !urlLoading && enabled && agentsSupported,
   })
 
   return {
-    adapters: query.data ?? [],
-    loading: query.isLoading || urlLoading,
+    adapters: agentsSupported ? (query.data ?? []) : [],
+    loading: agentsSupported && (query.isLoading || urlLoading),
     error: query.error ?? urlError,
     refetch: query.refetch,
   }
 }
 
 export function useHarnessAgents(enabled = true) {
+  const { supports } = useCapabilities()
+  const agentsSupported = supports(Feature.AGENT_HARNESS_SUPPORT)
   const {
     baseUrl,
     isLoading: urlLoading,
@@ -85,7 +91,7 @@ export function useHarnessAgents(enabled = true) {
         agents: data.agents ?? [],
       }
     },
-    enabled: Boolean(baseUrl) && !urlLoading && enabled,
+    enabled: Boolean(baseUrl) && !urlLoading && enabled && agentsSupported,
     // Poll every 5s so the per-agent liveness state (working / idle /
     // asleep / error) and last-used timestamps stay fresh without a
     // websocket. `refetchIntervalInBackground: false` lets a hidden
@@ -95,9 +101,11 @@ export function useHarnessAgents(enabled = true) {
   })
 
   return {
-    agents: (query.data?.agents ?? []).map(mapHarnessAgentToEntry),
-    harnessAgents: query.data?.agents ?? [],
-    loading: query.isLoading || urlLoading,
+    agents: agentsSupported
+      ? (query.data?.agents ?? []).map(mapHarnessAgentToEntry)
+      : [],
+    harnessAgents: agentsSupported ? (query.data?.agents ?? []) : [],
+    loading: agentsSupported && (query.isLoading || urlLoading),
     error: query.error ?? urlError,
     refetch: query.refetch,
   }

--- a/packages/browseros-agent/apps/agent/lib/browseros/capabilities.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/capabilities.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'bun:test'
-import { resolveStaticFeatureSupport } from './capabilities'
+import {
+  checkFeatureSupport,
+  Feature,
+  resolveStaticFeatureSupport,
+} from './capabilities'
 
 describe('resolveStaticFeatureSupport', () => {
   it('enables alpha-gated features automatically in development', () => {
@@ -38,5 +42,24 @@ describe('resolveStaticFeatureSupport', () => {
         alphaFeaturesEnabled: false,
       }),
     ).toBeNull()
+  })
+})
+
+describe('checkFeatureSupport — AGENT_HARNESS_SUPPORT', () => {
+  const at = (browserOSVersion: number[] | null) =>
+    checkFeatureSupport(
+      { browserOSVersion, serverVersion: null },
+      Feature.AGENT_HARNESS_SUPPORT,
+    )
+
+  it('hides harness agents below BrowserOS 0.46.0.0 or when version is unknown', () => {
+    expect(at([0, 45, 9, 9])).toBe(false)
+    expect(at([0, 45, 0, 0])).toBe(false)
+    expect(at(null)).toBe(false)
+  })
+
+  it('shows harness agents at or above BrowserOS 0.46.0.0', () => {
+    expect(at([0, 46, 0, 0])).toBe(true)
+    expect(at([0, 47, 0, 0])).toBe(true)
   })
 })

--- a/packages/browseros-agent/apps/agent/lib/browseros/capabilities.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/capabilities.ts
@@ -192,6 +192,8 @@ function ensureInitialized(): Promise<CapabilitiesState> {
   return initPromise
 }
 
+// Exported for unit tests: resolves a feature's version gate directly,
+// bypassing the dev-mode/static short-circuit in `supports`.
 export function checkFeatureSupport(
   state: CapabilitiesState,
   feature: Feature,

--- a/packages/browseros-agent/apps/agent/lib/browseros/capabilities.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/capabilities.ts
@@ -50,6 +50,8 @@ export enum Feature {
   QWEN_CODE_SUPPORT = 'QWEN_CODE_SUPPORT',
   // Credit-based usage tracking
   CREDITS_SUPPORT = 'CREDITS_SUPPORT',
+  // Claude Code / Codex agent-harness adapters in the unified picker + settings
+  AGENT_HARNESS_SUPPORT = 'AGENT_HARNESS_SUPPORT',
 }
 
 /**
@@ -79,6 +81,7 @@ const FEATURE_CONFIG: { [K in Feature]: FeatureConfig } = {
   [Feature.GITHUB_COPILOT_SUPPORT]: { minServerVersion: '0.0.77' },
   [Feature.QWEN_CODE_SUPPORT]: { minServerVersion: '0.0.77' },
   [Feature.CREDITS_SUPPORT]: { minServerVersion: '0.0.78' },
+  [Feature.AGENT_HARNESS_SUPPORT]: { minBrowserOSVersion: '0.46.0.0' },
 }
 
 function parseVersion(version: string): number[] {
@@ -189,7 +192,7 @@ function ensureInitialized(): Promise<CapabilitiesState> {
   return initPromise
 }
 
-function checkFeatureSupport(
+export function checkFeatureSupport(
   state: CapabilitiesState,
   feature: Feature,
 ): boolean {


### PR DESCRIPTION
## Summary
- The unified picker (#1065) surfaced the agent-harness adapters (**Claude Code**, **Codex**) on every BrowserOS version the auto-updating extension runs on — but the harness/ACP backend that runs them only ships in **BrowserOS 0.46.0.0+**. On older builds the agents appeared but could not run.
- Adds `Feature.AGENT_HARNESS_SUPPORT` (`minBrowserOSVersion: 0.46.0.0`) and gates the two data hooks that feed every surface: `useAgentAdapters` (AI & Agents settings tabs) and `useHarnessAgents` (picker ACP targets).
- When unsupported, both hooks disable their query and return empty — so the home + sidepanel pickers, the settings tabs, and the recent-agents dock all hide the agents, with **no requests** to harness endpoints that may not exist on older BrowserOS.

## Design
The gate is applied at the single data-source choke point. `useAgentAdapters` and `useHarnessAgents` (`apps/agent/entrypoints/app/agents/useAgents.ts`) are the only readers of the harness `/adapters` and agents-list endpoints, and every UI surface reads through them. Each hook consults `useCapabilities()`; when `AGENT_HARNESS_SUPPORT` is unsupported it sets react-query `enabled: false` and returns `[]` (non-loading).

The picker builds ACP entries from `agents` and the settings tabs from `adapters`, so gating both hooks covers both axes. The pure helpers (`adapter-visibility.ts`, `buildSidepanelChatTargets`) stay untouched and pure. Dev mode and BrowserOS ≥ 0.46.0.0 are unchanged. ChatGPT / GitHub Copilot LLM providers are out of scope (already gated by their own server-version features).

## Test plan
- `bun run typecheck` — all workspaces green (the TS mapped type `{ [K in Feature]: FeatureConfig }` enforces the new config entry at compile time).
- `bun test apps/agent/lib/browseros/capabilities.test.ts` — new gate-boundary test: hidden below `0.46.0.0` and when the version is unknown, shown at/above.
- `bun test apps/agent/entrypoints/sidepanel/index/sidepanel-chat-targets.test.ts apps/agent/lib/chat/adapter-visibility.test.ts` — pure-function tests unchanged (no regressions).
- `bunx biome check` — clean.
