### PR TITLE
fix(agent): align agent row cards

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentList.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentList.tsx
@@ -85,7 +85,7 @@ export const AgentList: FC<AgentListProps> = ({
   }
 
   return (
-    <div className="grid gap-3">
+    <div className="grid min-w-0 gap-3">
       {ordered.map((agent) => {
         const harness = harnessAgentLookup?.get(agent.agentId)
         const adapter: HarnessAgentAdapter | 'unknown' =

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentRowCard.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentRowCard.tsx
@@ -42,7 +42,7 @@ export const AgentRowCard: FC<AgentRowCardProps> = ({
         // visibly perturb neighbouring rows. Only the border tint
         // shifts on hover, and the rail's vertical rhythm stays
         // exactly the same in every state.
-        'group rounded-xl border bg-card p-4 shadow-sm transition-colors',
+        'group w-full min-w-0 rounded-xl border bg-card p-6 shadow-sm transition-colors',
         data.status === 'working'
           ? 'border-[var(--accent-orange)]/40'
           : data.status === 'error'
@@ -50,7 +50,7 @@ export const AgentRowCard: FC<AgentRowCardProps> = ({
             : 'border-border hover:border-[var(--accent-orange)]/30',
       )}
     >
-      <div className="flex items-start gap-4">
+      <div className="flex min-w-0 items-start gap-4">
         <AgentTile
           adapter={data.adapter}
           status={data.status}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-row/AgentLastMessage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-row/AgentLastMessage.tsx
@@ -24,12 +24,12 @@ export const AgentLastMessage: FC<AgentLastMessageProps> = ({ message }) => {
   }
   const preview = truncate(firstNonBlankLine(message), PREVIEW_CHARS)
   return (
-    <p className="mt-1.5 flex items-start gap-1.5 text-foreground/85 text-sm italic leading-snug">
+    <p className="mt-1.5 flex min-w-0 items-start gap-1.5 text-foreground/85 text-sm italic leading-snug">
       <Quote
         className="mt-1 size-3 shrink-0 text-muted-foreground/60"
         aria-hidden
       />
-      <span className="truncate">{preview}</span>
+      <span className="min-w-0 flex-1 truncate">{preview}</span>
     </p>
   )
 }


### PR DESCRIPTION
## Summary
- Keep agent rows constrained to the settings content column.
- Allow the agent row flex layout and last-message preview to shrink before truncating long prompts.
- Match the agent row card spacing with the adapter summary card.

## Screenshots / videos
Before:

<img width="1402" height="420" alt="截屏2026-05-28 16 34 43" src="https://github.com/user-attachments/assets/c76b6add-f0fe-4613-950d-3b73c3c7f00b" />

After:

<img width="865" height="372" alt="截屏2026-05-28 17 38 01" src="https://github.com/user-attachments/assets/92b19fe1-67e1-4b60-bd70-e8f26f1cc3f8" />

## Validation
- `bun test apps/agent/entrypoints/app/agents/agent-row/agent-row.helpers.test.ts apps/agent/entrypoints/app/agents/agents-list-order.test.ts apps/agent/entrypoints/app/agents/useAgents.test.ts`
- `bunx biome check apps/agent/entrypoints/app/agents/AgentList.tsx apps/agent/entrypoints/app/agents/AgentRowCard.tsx apps/agent/entrypoints/app/agents/agent-row/AgentLastMessage.tsx`
- `bun run --filter @browseros/agent --elide-lines=0 build:dev`