### PR TITLE
feat(server): write cdp_port to server.json for auto-discovery

### DIFF
--- a/packages/browseros-agent/apps/server/src/main.ts
+++ b/packages/browseros-agent/apps/server/src/main.ts
@@ -95,6 +95,7 @@ export class Application {
     try {
       await writeServerConfig({
         server_port: this.config.serverPort,
+        cdp_port: this.config.cdpPort ?? undefined,
         url: `http://127.0.0.1:${this.config.serverPort}`,
         server_version: VERSION,
         browseros_version: this.config.instanceBrowserosVersion,

--- a/packages/browseros-agent/packages/shared/src/types/server-config.ts
+++ b/packages/browseros-agent/packages/shared/src/types/server-config.ts
@@ -9,6 +9,7 @@
 
 export interface ServerDiscoveryConfig {
   server_port: number
+  cdp_port?: number
   url: string
   server_version: string
   browseros_version?: string


### PR DESCRIPTION
## Summary
- Adds optional `cdp_port` to the `~/.browseros/server.json` discovery file written on server startup, alongside the existing `server_port`.
- Lets external tools (CLI, agents) auto-discover the CDP WebSocket port instead of only the HTTP server port.

## Design
`ServerDiscoveryConfig` gains an optional `cdp_port?: number`. In `main.ts`, the startup `writeServerConfig()` call now passes `cdp_port: this.config.cdpPort ?? undefined`. The CDP port is optional in config (`cdpPort: portSchema.nullable()`, set only via `--cdp-port` / `BROWSEROS_CDP_PORT`), so when absent the key is omitted from the JSON entirely rather than written as `null`.

## Test plan
- `bun run typecheck` passes across all packages.
- Start the server with `--cdp-port <port>` and confirm `~/.browseros/server.json` contains `cdp_port`.
- Start without a CDP port and confirm the key is omitted.