### PR TITLE
feat(agent): add dynamic RTL language support to chat components

### DIFF
--- a/packages/browseros-agent/apps/agent/components/ai-elements/message.tsx
+++ b/packages/browseros-agent/apps/agent/components/ai-elements/message.tsx
@@ -56,7 +56,7 @@ export const MessageContent = ({
 }: MessageContentProps) => (
   <div
     className={cn(
-      'is-user:dark flex w-fit flex-col gap-2 overflow-hidden text-sm',
+      'is-user:dark flex w-fit flex-col gap-2 overflow-hidden text-start text-sm',
       'group-[.is-user]:ml-auto group-[.is-user]:rounded-lg group-[.is-user]:bg-secondary group-[.is-user]:px-4 group-[.is-user]:py-3 group-[.is-user]:text-foreground',
       'group-[.is-assistant]:text-foreground',
       className,
@@ -347,7 +347,7 @@ export const MessageResponse = memo(
   ({ className, ...props }: MessageResponseProps) => (
     <Streamdown
       className={cn(
-        'size-full [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_[data-streamdown="code-block"]]:w-[calc(100vw-64px)]! [&_[data-streamdown="table-wrapper"]]:w-[calc(100vw-64px)]!',
+        'size-full [unicode-bidi:plaintext] [&>*:first-child]:mt-0 [&>*:last-child]:mb-0 [&_*]:text-start [&_[data-streamdown="code-block"]]:w-[calc(100vw-64px)]! [&_[data-streamdown="table-wrapper"]]:w-[calc(100vw-64px)]!',
         className,
       )}
       shikiTheme={themes}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationInput.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationInput.tsx
@@ -571,6 +571,7 @@ export const ConversationInput: FC<ConversationInputProps> = ({
               }}
               onPaste={handlePaste}
               rows={1}
+              dir="auto"
               placeholder={
                 voice.isTranscribing
                   ? 'Transcribing...'
@@ -579,7 +580,7 @@ export const ConversationInput: FC<ConversationInputProps> = ({
               }
               disabled={disabled || voice.isTranscribing}
               className={cn(
-                'resize-none border-none bg-transparent px-0 text-[15px] shadow-none focus-visible:ring-0 dark:bg-transparent',
+                'resize-none border-none bg-transparent px-0 text-start text-[15px] shadow-none focus-visible:ring-0 dark:bg-transparent',
                 '[field-sizing:fixed]',
                 variant === 'home'
                   ? 'min-h-[40px] py-2 leading-6'

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationMessage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationMessage.tsx
@@ -111,7 +111,10 @@ export const ConversationMessage: FC<ConversationMessageProps> = ({
             </MessageAttachments>
           )}
           {turn.userText && (
-            <pre className="whitespace-pre-wrap font-sans text-sm">
+            <pre
+              className="whitespace-pre-wrap text-start font-sans text-sm"
+              dir="auto"
+            >
               {turn.userText}
             </pre>
           )}

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ChatInput.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ChatInput.tsx
@@ -361,8 +361,9 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
         ) : (
           <textarea
             ref={textareaRef}
+            dir="auto"
             className={cn(
-              'field-sizing-content max-h-60 min-h-[42px] flex-1 resize-none overflow-hidden rounded-2xl border border-border/50 bg-muted/50 px-4 py-2.5 text-sm outline-none transition-colors placeholder:text-muted-foreground/70 hover:border-border focus:border-[var(--accent-orange)]',
+              'field-sizing-content max-h-60 min-h-[42px] flex-1 resize-none overflow-hidden rounded-2xl border border-border/50 bg-muted/50 px-4 py-2.5 text-start text-sm outline-none transition-colors placeholder:text-muted-foreground/70 hover:border-border focus:border-[var(--accent-orange)]',
               voice ? 'pr-[4.5rem]' : 'pr-11',
             )}
             value={input}


### PR DESCRIPTION
# Comprehensive RTL Language Support in Chat UI

This pull request implements dynamic Right-to-Left (RTL) language rendering support (Arabic, Hebrew, Farsi, etc.) across the Chat UI, covering both the full-page Dashboard/Command Chat and the Sidebar Extension Panel Chat.

---

## 🛠️ Changes Included

### 1. Unified Message Alignment (User & Assistant)
- **[message.tsx](file:///packages/browseros-agent/apps/agent/components/ai-elements/message.tsx)**:
  - Added `text-start` to the base `<MessageContent>` wrapper to ensure dynamic directionality is preserved for user bubbles.
  - Applied CSS standard classes `[unicode-bidi:plaintext]` and `[&_*]:text-start` selectors to `<Streamdown>`. Every paragraph in assistant responses aligns dynamically to the right for RTL and left LTR, while keeping code blocks LTR.

### 2. Sidebar Chat Input & Composer
- **[ChatInput.tsx](file:///packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/ChatInput.tsx)**:
  - Added `dir="auto"` and `text-start` to the sidebar `<textarea>` input composer.

### 3. Dashboard Chat Input & Composer
- **[ConversationInput.tsx](file:///packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationInput.tsx)**:
  - Added `dir="auto"` and `text-start` to the dashboard `<Textarea>` composer.

### 4. Dashboard User Message pre-block
- **[ConversationMessage.tsx](file:///packages/browseros-agent/apps/agent/entrypoints/app/agent-command/ConversationMessage.tsx)**:
  - Applied `dir="auto"` and `text-start` to user prompt `<pre>` rendering.

---

## 🧪 Verification & Build Status
- **TypeScript Verification**: `bun run typecheck` passed successfully!
- **Asset Bundling**: `bun run build:agent:dev` successfully compiled extension dev assets.
- **Biome Check**: Cleanly formatted and auto-sorted Tailwind classes to pass all repository validation checks.
