### PR TITLE
feat: release server before macos build

### DIFF
--- a/.github/workflows/nightly-macos-build.yml
+++ b/.github/workflows/nightly-macos-build.yml
@@ -52,6 +52,7 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           NIGHTLY_REF: ${{ vars.BROWSEROS_NIGHTLY_REF }}
+          NIGHTLY_RELEASE_SERVER: ${{ vars.BROWSEROS_NIGHTLY_RELEASE_SERVER }}
           DISPATCH_BUMP: ${{ inputs.bump }}
           DISPATCH_COMMIT_VERSION: ${{ inputs.commit_version }}
           DISPATCH_UPLOAD_TO_R2: ${{ inputs.upload_to_r2 }}
@@ -65,13 +66,26 @@ jobs:
             bump_mode="offset+build"
             commit_version="true"
             upload_to_r2="true"
-            release_server="true"
+            release_server="${NIGHTLY_RELEASE_SERVER:-auto}"
           else
             target_ref="$DISPATCH_REF"
             bump_mode="${DISPATCH_BUMP:-offset+build}"
             commit_version="${DISPATCH_COMMIT_VERSION:-false}"
             upload_to_r2="${DISPATCH_UPLOAD_TO_R2:-true}"
             release_server="${DISPATCH_RELEASE_SERVER:-true}"
+          fi
+
+          if [ "$release_server" = "auto" ]; then
+            if [ "$target_ref" = "$DEFAULT_BRANCH" ]; then
+              release_server="true"
+            else
+              release_server="false"
+            fi
+          fi
+
+          if [ "$release_server" != "true" ] && [ "$release_server" != "false" ]; then
+            echo "::error::release_server must be true, false, or auto (got $release_server)"
+            exit 1
           fi
 
           if [ "$release_server" = "true" ] && [ "$target_ref" != "$DEFAULT_BRANCH" ]; then

--- a/.github/workflows/nightly-macos-build.yml
+++ b/.github/workflows/nightly-macos-build.yml
@@ -23,6 +23,10 @@ on:
         description: Publish build to R2/CDN after packaging
         type: boolean
         default: true
+      release_server:
+        description: Build and upload server artifacts before packaging
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -32,6 +36,74 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
+  resolve_inputs:
+    runs-on: ubuntu-latest
+    outputs:
+      target_ref: ${{ steps.workflow_inputs.outputs.target_ref }}
+      bump_mode: ${{ steps.workflow_inputs.outputs.bump_mode }}
+      commit_version: ${{ steps.workflow_inputs.outputs.commit_version }}
+      upload_to_r2: ${{ steps.workflow_inputs.outputs.upload_to_r2 }}
+      release_server: ${{ steps.workflow_inputs.outputs.release_server }}
+      server_version: ${{ steps.server_version.outputs.server_version }}
+    steps:
+      - name: Resolve workflow inputs
+        id: workflow_inputs
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          NIGHTLY_REF: ${{ vars.BROWSEROS_NIGHTLY_REF }}
+          DISPATCH_BUMP: ${{ inputs.bump }}
+          DISPATCH_COMMIT_VERSION: ${{ inputs.commit_version }}
+          DISPATCH_UPLOAD_TO_R2: ${{ inputs.upload_to_r2 }}
+          DISPATCH_RELEASE_SERVER: ${{ inputs.release_server }}
+          DISPATCH_REF: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            target_ref="${NIGHTLY_REF:-$DEFAULT_BRANCH}"
+            bump_mode="offset+build"
+            commit_version="true"
+            upload_to_r2="true"
+            release_server="true"
+          else
+            target_ref="$DISPATCH_REF"
+            bump_mode="${DISPATCH_BUMP:-offset+build}"
+            commit_version="${DISPATCH_COMMIT_VERSION:-false}"
+            upload_to_r2="${DISPATCH_UPLOAD_TO_R2:-true}"
+            release_server="${DISPATCH_RELEASE_SERVER:-true}"
+          fi
+
+          if [ "$release_server" = "true" ] && [ "$target_ref" != "$DEFAULT_BRANCH" ]; then
+            echo "::error::Server release publishes to global R2 latest and is only allowed for $DEFAULT_BRANCH. Disable release_server for branch-only macOS builds."
+            exit 1
+          fi
+
+          {
+            echo "target_ref=$target_ref"
+            echo "bump_mode=$bump_mode"
+            echo "commit_version=$commit_version"
+            echo "upload_to_r2=$upload_to_r2"
+            echo "release_server=$release_server"
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.workflow_inputs.outputs.target_ref }}
+
+      - name: Read server package version
+        id: server_version
+        run: |
+          set -euo pipefail
+          python3 - <<'PY' >> "$GITHUB_OUTPUT"
+          import json
+          from pathlib import Path
+
+          package_json = Path("packages/browseros-agent/apps/server/package.json")
+          version = json.loads(package_json.read_text())["version"]
+          print(f"server_version={version}")
+          PY
+
   authorize_manual_dispatch:
     if: github.event_name == 'workflow_dispatch'
     runs-on: [self-hosted, macOS, ARM64, browseros-builder]
@@ -39,11 +111,27 @@ jobs:
     steps:
       - run: echo "Manual dispatch approved through release-core."
 
-  build:
-    needs: authorize_manual_dispatch
+  release_server:
+    needs: [authorize_manual_dispatch, resolve_inputs]
     if: |
       always() &&
+      needs.resolve_inputs.result == 'success' &&
+      needs.resolve_inputs.outputs.release_server == 'true' &&
       (github.event_name == 'schedule' || needs.authorize_manual_dispatch.result == 'success')
+    permissions:
+      contents: write
+    uses: ./.github/workflows/release-server.yml
+    with:
+      version: ${{ needs.resolve_inputs.outputs.server_version }}
+    secrets: inherit
+
+  build:
+    needs: [authorize_manual_dispatch, resolve_inputs, release_server]
+    if: |
+      always() &&
+      needs.resolve_inputs.result == 'success' &&
+      (github.event_name == 'schedule' || needs.authorize_manual_dispatch.result == 'success') &&
+      (needs.resolve_inputs.outputs.release_server != 'true' || needs.release_server.result == 'success')
     runs-on: [self-hosted, macOS, ARM64, browseros-builder]
     permissions:
       contents: write
@@ -52,17 +140,14 @@ jobs:
     env:
       BROWSEROS_REPO: ${{ vars.BROWSEROS_REPO_PATH }}
       CHROMIUM_SRC: ${{ vars.BROWSEROS_CHROMIUM_SRC }}
-      NIGHTLY_REF: ${{ vars.BROWSEROS_NIGHTLY_REF }}
     steps:
       - name: Resolve build inputs
         id: build_inputs
         env:
-          EVENT_NAME: ${{ github.event_name }}
-          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          DISPATCH_BUMP: ${{ inputs.bump }}
-          DISPATCH_COMMIT_VERSION: ${{ inputs.commit_version }}
-          DISPATCH_UPLOAD_TO_R2: ${{ inputs.upload_to_r2 }}
-          DISPATCH_REF: ${{ github.ref_name }}
+          TARGET_REF: ${{ needs.resolve_inputs.outputs.target_ref }}
+          BUMP_MODE: ${{ needs.resolve_inputs.outputs.bump_mode }}
+          COMMIT_VERSION: ${{ needs.resolve_inputs.outputs.commit_version }}
+          UPLOAD_TO_R2: ${{ needs.resolve_inputs.outputs.upload_to_r2 }}
         run: |
           set -euo pipefail
 
@@ -88,25 +173,13 @@ jobs:
             exit 1
           fi
 
-          if [ "$EVENT_NAME" = "schedule" ]; then
-            target_ref="${NIGHTLY_REF:-$DEFAULT_BRANCH}"
-            bump_mode="offset+build"
-            commit_version="true"
-            upload_to_r2="true"
-          else
-            target_ref="$DISPATCH_REF"
-            bump_mode="${DISPATCH_BUMP:-offset+build}"
-            commit_version="${DISPATCH_COMMIT_VERSION:-false}"
-            upload_to_r2="${DISPATCH_UPLOAD_TO_R2:-true}"
-          fi
-
           {
             echo "browseros_repo=$repo"
             echo "chromium_src=$chromium_src"
-            echo "target_ref=$target_ref"
-            echo "bump_mode=$bump_mode"
-            echo "commit_version=$commit_version"
-            echo "upload_to_r2=$upload_to_r2"
+            echo "target_ref=$TARGET_REF"
+            echo "bump_mode=$BUMP_MODE"
+            echo "commit_version=$COMMIT_VERSION"
+            echo "upload_to_r2=$UPLOAD_TO_R2"
           } >> "$GITHUB_OUTPUT"
 
       - name: Sync build repo to target ref

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -1,10 +1,16 @@
 name: Release BrowserOS Server
 
 on:
+  workflow_call:
+    inputs:
+      version:
+        description: "Release version (e.g. 0.0.97)"
+        required: true
+        type: string
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. 0.0.80)"
+        description: "Release version (e.g. 0.0.97)"
         required: true
         type: string
 
@@ -52,8 +58,21 @@ jobs:
             exit 1
           fi
 
-      - name: Build release artifacts
-        run: bun run build:server:ci
+      - name: Build and upload release artifacts
+        env:
+          BROWSEROS_CONFIG_URL: ${{ vars.BROWSEROS_CONFIG_URL || 'https://llm.browseros.com/api/browseros-server/config' }}
+          CODEGEN_SERVICE_URL: ${{ secrets.CODEGEN_SERVICE_URL || vars.CODEGEN_SERVICE_URL }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY || vars.POSTHOG_API_KEY }}
+          SENTRY_DSN: ${{ secrets.SENTRY_DSN || vars.SENTRY_DSN }}
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          R2_DOWNLOAD_PREFIX: artifacts/vendor
+          R2_UPLOAD_PREFIX: artifacts/server
+          NODE_ENV: production
+          LOG_LEVEL: info
+        run: bun run build:server
 
       - name: Verify release artifacts
         run: |

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -19,9 +19,19 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  release:
+  authorize_manual_dispatch:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     environment: release-core
+    steps:
+      - run: echo "Manual dispatch approved through release-core."
+
+  release:
+    needs: authorize_manual_dispatch
+    if: |
+      always() &&
+      (github.event_name != 'workflow_dispatch' || needs.authorize_manual_dispatch.result == 'success')
+    runs-on: ubuntu-latest
     permissions:
       contents: write
     timeout-minutes: 120

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -20,16 +20,27 @@ concurrency:
 
 jobs:
   release:
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: release-core
     permissions:
       contents: write
+    timeout-minutes: 120
     defaults:
       run:
         working-directory: packages/browseros-agent
 
     steps:
+      - name: Validate release ref
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
+        run: |
+          set -euo pipefail
+          expected_ref="refs/heads/$DEFAULT_BRANCH"
+          if [ "$GITHUB_REF" != "$expected_ref" ]; then
+            echo "::error::Server release is only allowed on $DEFAULT_BRANCH (got $GITHUB_REF)"
+            exit 1
+          fi
+
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
           - suite: server-api
             command: (cd apps/server && bun run test:api)
             junit_path: test-results/server-api.xml
-            needs_browser: false
+            needs_browser: true
           - suite: server-tools
             command: (cd apps/server && bun run test:tools)
             junit_path: test-results/server-tools.xml

--- a/packages/browseros-agent/apps/server/package.json
+++ b/packages/browseros-agent/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browseros/server",
-  "version": "0.0.96",
+  "version": "0.0.97",
   "description": "BrowserOS server",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -152,7 +152,7 @@
     },
     "apps/server": {
       "name": "@browseros/server",
-      "version": "0.0.96",
+      "version": "0.0.97",
       "bin": {
         "browseros-server": "./src/index.ts",
       },


### PR DESCRIPTION
## Summary
- Bump @browseros/server to 0.0.97.
- Make the server release workflow reusable and run the full production build/upload path to Cloudflare R2.
- Gate nightly macOS packaging on a successful server release so R2 latest is refreshed first.

## Design
The nightly workflow resolves the target ref and server package version, calls the reusable server release workflow before packaging, and only starts the macOS build after that upload succeeds. Manual branch builds must disable server release rather than publishing non-default-branch artifacts to global R2 latest.

## Test plan
- ruby YAML parse for nightly-macos-build.yml and release-server.yml
- actionlint for both changed workflows, ignoring the existing custom self-hosted runner label warning
- bun run --filter @browseros/server typecheck
- bun --env-file=apps/server/.env.development test apps/server/tests/build.test.ts
- bun run lint (exits 0; existing unrelated warnings remain)