### PR TITLE
fix: run release ref guard from workspace

### DIFF
--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -41,6 +41,7 @@ jobs:
 
     steps:
       - name: Validate release ref
+        working-directory: ${{ github.workspace }}
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
         run: |


### PR DESCRIPTION
## Summary
- Run the pre-checkout release ref guard from github.workspace instead of the job default package directory.
- Keep the release build steps in packages/browseros-agent after checkout.

## Root cause
The linked nightly run failed before checkout because release-server.yml has a job-level working-directory of packages/browseros-agent. The new Validate release ref step runs before actions/checkout, so the runner could not start bash in a directory that did not exist yet.

## Test plan
- ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f); puts "ok #{f}" }' .github/workflows/release-server.yml\n- go run github.com/rhysd/actionlint/cmd/actionlint@latest .github/workflows/release-server.yml