### PR TITLE
Add GPT-5.5 support for ChatGPT Plus/Pro

### DIFF
--- a/docs/features/chatgpt-pro-oauth.mdx
+++ b/docs/features/chatgpt-pro-oauth.mdx
@@ -3,7 +3,7 @@ title: "ChatGPT Pro / Plus"
 description: "Use your ChatGPT subscription to power BrowserOS"
 ---
 
-Connect your ChatGPT Pro or Plus subscription to BrowserOS and access GPT-5 Codex, GPT-5.4, and the full lineup of OpenAI's most advanced models — with up to 400K context. No API keys needed.
+Connect your ChatGPT Pro or Plus subscription to BrowserOS and access GPT-5.5, GPT-5 Codex, GPT-5.4, and the full lineup of OpenAI's most advanced models — with up to 1.05M context. No API keys needed.
 
 ## Setup
 
@@ -25,6 +25,7 @@ Connect your ChatGPT Pro or Plus subscription to BrowserOS and access GPT-5 Code
 
 | Model | Context Window |
 |-------|---------------|
+| `gpt-5.5` | 1.05M |
 | `gpt-5.4` | 400K |
 | `gpt-5.3-codex` | 400K |
 | `gpt-5.2-codex` | 400K |

--- a/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/models.test.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/models.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'bun:test'
+import { getModelContextLength, getModelsForProvider } from './models'
+
+describe('ChatGPT Plus/Pro models', () => {
+  it('offers GPT-5.5 as the default first choice', () => {
+    const models = getModelsForProvider('chatgpt-pro')
+
+    expect(models[0]).toEqual({
+      modelId: 'gpt-5.5',
+      contextLength: 1050000,
+    })
+    expect(getModelContextLength('chatgpt-pro', 'gpt-5.5')).toBe(1050000)
+  })
+})

--- a/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/models.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/models.ts
@@ -17,6 +17,7 @@ const CUSTOM_PROVIDER_MODELS: Partial<Record<ProviderType, ModelInfo[]>> = {
   'openai-compatible': [],
   ollama: [],
   'chatgpt-pro': [
+    { modelId: 'gpt-5.5', contextLength: 1050000 },
     { modelId: 'gpt-5.4', contextLength: 400000 },
     { modelId: 'gpt-5.3-codex', contextLength: 400000 },
     { modelId: 'gpt-5.2-codex', contextLength: 400000 },

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/providerTemplates.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/providerTemplates.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'bun:test'
+import { providerTemplates } from './providerTemplates'
+
+describe('providerTemplates', () => {
+  it('uses GPT-5.5 for new ChatGPT Plus/Pro providers', () => {
+    const template = providerTemplates.find(
+      (provider) => provider.id === 'chatgpt-pro',
+    )
+
+    expect(template).toMatchObject({
+      defaultModelId: 'gpt-5.5',
+      contextWindow: 1050000,
+    })
+  })
+})

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/providerTemplates.ts
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/providerTemplates.ts
@@ -49,9 +49,9 @@ export const providerTemplates: ProviderTemplate[] = [
     id: 'chatgpt-pro',
     name: 'ChatGPT Plus/Pro',
     defaultBaseUrl: 'https://chatgpt.com/backend-api',
-    defaultModelId: 'gpt-5.3-codex',
+    defaultModelId: 'gpt-5.5',
     supportsImages: true,
-    contextWindow: 400000,
+    contextWindow: 1050000,
     setupGuideUrl: 'https://docs.browseros.com/features/chatgpt-pro-oauth',
   },
   {

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/config.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/config.ts
@@ -26,7 +26,7 @@ export async function resolveLLMConfig(
     return resolveOAuthConfig(config, browserosId, {
       providerId: 'chatgpt-pro',
       displayName: 'ChatGPT Plus/Pro',
-      defaultModel: 'gpt-5.3-codex',
+      defaultModel: 'gpt-5.5',
       useRefresh: true,
       extraFields: (tokens) => ({
         upstreamProvider: 'openai',

--- a/packages/browseros-agent/apps/server/tests/lib/clients/llm/config.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/clients/llm/config.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
+
+const tokenManager = {
+  refreshIfExpired: mock(async () => ({
+    accessToken: 'access-token',
+    refreshToken: 'refresh-token',
+    expiresAt: Date.now() + 3600_000,
+    accountId: 'account-id',
+  })),
+}
+
+mock.module('../../../../src/lib/clients/oauth', () => ({
+  getOAuthTokenManager: () => tokenManager,
+}))
+
+const { resolveLLMConfig } = await import(
+  '../../../../src/lib/clients/llm/config'
+)
+
+describe('resolveLLMConfig', () => {
+  beforeEach(() => {
+    tokenManager.refreshIfExpired.mockClear()
+  })
+
+  it('defaults ChatGPT Plus/Pro OAuth providers to GPT-5.5', async () => {
+    const resolved = await resolveLLMConfig(
+      { provider: LLM_PROVIDERS.CHATGPT_PRO },
+      'browseros-id',
+    )
+
+    expect(tokenManager.refreshIfExpired).toHaveBeenCalledWith('chatgpt-pro')
+    expect(resolved).toMatchObject({
+      provider: LLM_PROVIDERS.CHATGPT_PRO,
+      model: 'gpt-5.5',
+      apiKey: 'access-token',
+      upstreamProvider: 'openai',
+      accountId: 'account-id',
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- add `gpt-5.5` as the first/default ChatGPT Plus/Pro model
- update the ChatGPT Plus/Pro provider template and OAuth fallback default to `gpt-5.5`
- document GPT-5.5 and its 1.05M context window
- add focused tests for the model list, provider template, and server-side fallback

## Validation

- `bun test apps/agent/entrypoints/app/ai-settings/models.test.ts apps/agent/lib/llm-providers/providerTemplates.test.ts apps/server/tests/lib/clients/llm/config.test.ts`
- `bunx biome check apps/agent/entrypoints/app/ai-settings/models.ts apps/agent/entrypoints/app/ai-settings/models.test.ts apps/agent/lib/llm-providers/providerTemplates.ts apps/agent/lib/llm-providers/providerTemplates.test.ts apps/server/src/lib/clients/llm/config.ts apps/server/tests/lib/clients/llm/config.test.ts ../../docs/features/chatgpt-pro-oauth.mdx`
- `bun run --filter @browseros/server typecheck`
- `bun run codegen:agent`
- `bun run --filter @browseros/agent typecheck`

OpenAI currently lists `gpt-5.5` as the recommended flagship model for complex reasoning and coding, with model ID `gpt-5.5` and a 1,050,000 token context window.
