### PR TITLE
fix(metrics): aggregate mcp.request + tool_executed into 30-min usage rollup

### DIFF
--- a/packages/browseros-agent/apps/server/src/lib/metrics.ts
+++ b/packages/browseros-agent/apps/server/src/lib/metrics.ts
@@ -10,6 +10,37 @@ import { INLINED_ENV } from '../env'
 const POSTHOG_API_KEY = INLINED_ENV.POSTHOG_API_KEY
 const EVENT_PREFIX = 'browseros.server.'
 
+/**
+ * The two events that previously fired per call and dwarfed every other
+ * event in volume (~87% of total on the worst day). They get rolled up
+ * into a single periodic `usage_rollup` event instead — see
+ * `RollupBuffer` below.
+ */
+const AGGREGATED_EVENT_MCP_REQUEST = 'mcp.request'
+const AGGREGATED_EVENT_TOOL_EXECUTED = 'tool_executed'
+
+/**
+ * Flush the rollup buffer every 30 minutes, wall-clock aligned so
+ * dashboards comparing instances see aligned buckets. Not configurable
+ * by design — one less knob to misconfigure in deployments. If a
+ * future need surfaces, change the constant and ship a release.
+ */
+const ROLLUP_INTERVAL_MS = 30 * 60 * 1000
+
+/**
+ * Defensive cap on `tool_executions_by_tool` cardinality. Realistic
+ * tool names are statically registered so this only matters if a
+ * future code path passes dynamic / user-supplied names through.
+ * Overflow names roll into `__other__`.
+ */
+const MAX_TOOL_NAME_KEYS = 200
+
+/** PostHog property keys can't safely contain dots — they collide with
+ *  nested-prop access syntax in HogQL. */
+function sanitizeToolName(name: string): string {
+  return name.replace(/\./g, '_').slice(0, 80)
+}
+
 export interface MetricsConfig {
   client_id?: string
   install_id?: string
@@ -19,9 +50,88 @@ export interface MetricsConfig {
   [key: string]: string | undefined
 }
 
+interface ToolExecCounters {
+  total: number
+  failed: number
+  by_source: Record<string, number>
+  by_tool: Record<string, number>
+}
+
+interface RollupBucket {
+  period_start_ts: string
+  mcp_requests: number
+  tool_executions: ToolExecCounters
+}
+
+class RollupBuffer {
+  private current: RollupBucket | null = null
+
+  recordMcpRequest(): void {
+    this.ensureCurrent().mcp_requests += 1
+  }
+
+  recordToolExecuted(props: {
+    tool_name?: string
+    source?: string
+    success?: boolean
+  }): void {
+    const counters = this.ensureCurrent().tool_executions
+    counters.total += 1
+    if (props.success === false) counters.failed += 1
+    const source = props.source ?? 'unknown'
+    counters.by_source[source] = (counters.by_source[source] ?? 0) + 1
+    if (props.tool_name) {
+      const name = sanitizeToolName(props.tool_name)
+      if (
+        counters.by_tool[name] !== undefined ||
+        Object.keys(counters.by_tool).length < MAX_TOOL_NAME_KEYS
+      ) {
+        counters.by_tool[name] = (counters.by_tool[name] ?? 0) + 1
+      } else {
+        counters.by_tool.__other__ = (counters.by_tool.__other__ ?? 0) + 1
+      }
+    }
+  }
+
+  /**
+   * Return the current bucket and reset internal state. Returns `null`
+   * when nothing was recorded since the last drain so callers can skip
+   * the emit and avoid billing for an empty interval.
+   */
+  drain(
+    periodEndTs: string,
+  ): (RollupBucket & { period_end_ts: string }) | null {
+    const bucket = this.current
+    this.current = null
+    if (!bucket) return null
+    if (bucket.mcp_requests === 0 && bucket.tool_executions.total === 0) {
+      return null
+    }
+    return { ...bucket, period_end_ts: periodEndTs }
+  }
+
+  private ensureCurrent(): RollupBucket {
+    if (!this.current) {
+      this.current = {
+        period_start_ts: new Date().toISOString(),
+        mcp_requests: 0,
+        tool_executions: {
+          total: 0,
+          failed: 0,
+          by_source: {},
+          by_tool: {},
+        },
+      }
+    }
+    return this.current
+  }
+}
+
 class MetricsService {
   private client: PostHog | null = null
   private config: MetricsConfig | null = null
+  private rollup = new RollupBuffer()
+  private flushTimer: ReturnType<typeof setTimeout> | null = null
 
   initialize(config: MetricsConfig): void {
     this.config = { ...this.config, ...config }
@@ -31,6 +141,8 @@ class MetricsService {
         host: EXTERNAL_URLS.POSTHOG_DEFAULT,
       })
     }
+
+    this.scheduleNextFlush()
   }
 
   isEnabled(): boolean {
@@ -46,6 +158,73 @@ class MetricsService {
       return
     }
 
+    // The two highest-volume events get aggregated. Every other event
+    // captures per call as it always has.
+    if (eventName === AGGREGATED_EVENT_MCP_REQUEST) {
+      this.rollup.recordMcpRequest()
+      return
+    }
+    if (eventName === AGGREGATED_EVENT_TOOL_EXECUTED) {
+      this.rollup.recordToolExecuted({
+        tool_name: properties.tool_name as string | undefined,
+        source: properties.source as string | undefined,
+        success: properties.success as boolean | undefined,
+      })
+      return
+    }
+
+    this.captureNow(eventName, properties)
+  }
+
+  async shutdown(): Promise<void> {
+    if (this.flushTimer) {
+      clearTimeout(this.flushTimer)
+      this.flushTimer = null
+    }
+    // Drain whatever's buffered into the PostHog SDK before asking it
+    // to flush its own send queue.
+    this.flushRollup()
+    if (this.client) {
+      await this.client.shutdown()
+      this.client = null
+    }
+  }
+
+  private scheduleNextFlush(): void {
+    if (this.flushTimer || !this.client) return
+    const now = Date.now()
+    const nextTs = Math.ceil(now / ROLLUP_INTERVAL_MS) * ROLLUP_INTERVAL_MS
+    const delay = Math.max(nextTs - now, 0)
+    this.flushTimer = setTimeout(() => {
+      this.flushTimer = null
+      this.flushRollup()
+      this.scheduleNextFlush()
+    }, delay)
+    // Don't keep the event loop alive just for telemetry.
+    this.flushTimer.unref?.()
+  }
+
+  private flushRollup(): void {
+    const bucket = this.rollup.drain(new Date().toISOString())
+    if (!bucket) return
+    this.captureNow('usage_rollup', {
+      interval_seconds: ROLLUP_INTERVAL_MS / 1000,
+      period_start_ts: bucket.period_start_ts,
+      period_end_ts: bucket.period_end_ts,
+      mcp_requests_count: bucket.mcp_requests,
+      tool_executions_count: bucket.tool_executions.total,
+      tool_executions_failed: bucket.tool_executions.failed,
+      tool_executions_by_source: bucket.tool_executions.by_source,
+      tool_executions_by_tool: bucket.tool_executions.by_tool,
+    })
+  }
+
+  private captureNow(
+    eventName: string,
+    properties: Record<string, unknown>,
+  ): void {
+    if (!this.client || !this.config) return
+
     const {
       client_id,
       install_id,
@@ -55,7 +234,13 @@ class MetricsService {
       ...defaultProperties
     } = this.config
 
-    const distinctId = client_id || install_id || 'anonymous'
+    // No identity ⇒ no event. The previous `'anonymous'` fallback let
+    // unconfigured instances funnel everything into one
+    // un-attributable bucket and inflate billing dramatically. Treat
+    // "no identity" as a configuration error to be surfaced at boot,
+    // not as a reason to emit useless events.
+    const distinctId = client_id || install_id
+    if (!distinctId) return
 
     this.client.capture({
       distinctId,
@@ -72,13 +257,14 @@ class MetricsService {
       },
     })
   }
-
-  async shutdown(): Promise<void> {
-    if (this.client) {
-      await this.client.shutdown()
-      this.client = null
-    }
-  }
 }
 
 export const metrics = new MetricsService()
+
+// Re-exported for tests; do not depend on these in product code.
+export const __internal__ = {
+  ROLLUP_INTERVAL_MS,
+  MAX_TOOL_NAME_KEYS,
+  sanitizeToolName,
+  RollupBuffer,
+}

--- a/packages/browseros-agent/apps/server/src/lib/metrics.ts
+++ b/packages/browseros-agent/apps/server/src/lib/metrics.ts
@@ -66,6 +66,8 @@ interface RollupBucket {
 class RollupBuffer {
   private current: RollupBucket | null = null
 
+  constructor(private readonly alignedNow: () => number = defaultAlignedNow) {}
+
   recordMcpRequest(): void {
     this.ensureCurrent().mcp_requests += 1
   }
@@ -112,8 +114,14 @@ class RollupBuffer {
 
   private ensureCurrent(): RollupBucket {
     if (!this.current) {
+      // Anchor period_start_ts to the aligned window boundary, not
+      // to the moment the first event arrived. The flush always fires
+      // on the boundary, so a lazy first-event timestamp would make
+      // interval_seconds, period_start_ts, and period_end_ts disagree
+      // about the window — and rate analyses computed as
+      // `count / interval_seconds` would be wrong.
       this.current = {
-        period_start_ts: new Date().toISOString(),
+        period_start_ts: new Date(this.alignedNow()).toISOString(),
         mcp_requests: 0,
         tool_executions: {
           total: 0,
@@ -125,6 +133,10 @@ class RollupBuffer {
     }
     return this.current
   }
+}
+
+function defaultAlignedNow(): number {
+  return Math.floor(Date.now() / ROLLUP_INTERVAL_MS) * ROLLUP_INTERVAL_MS
 }
 
 class MetricsService {
@@ -193,7 +205,11 @@ class MetricsService {
   private scheduleNextFlush(): void {
     if (this.flushTimer || !this.client) return
     const now = Date.now()
-    const nextTs = Math.ceil(now / ROLLUP_INTERVAL_MS) * ROLLUP_INTERVAL_MS
+    // floor + 1 (not ceil) so a tick that lands exactly on a boundary
+    // schedules to the *next* boundary instead of producing delay = 0
+    // and immediately re-entering the recursive schedule.
+    const nextTs =
+      (Math.floor(now / ROLLUP_INTERVAL_MS) + 1) * ROLLUP_INTERVAL_MS
     const delay = Math.max(nextTs - now, 0)
     this.flushTimer = setTimeout(() => {
       this.flushTimer = null

--- a/packages/browseros-agent/apps/server/src/main.ts
+++ b/packages/browseros-agent/apps/server/src/main.ts
@@ -172,6 +172,19 @@ export class Application {
 
     if (!metrics.isEnabled()) {
       logger.warn('Metrics disabled: missing POSTHOG_API_KEY')
+    } else if (
+      !this.config.instanceClientId &&
+      !this.config.instanceInstallId
+    ) {
+      // captureNow short-circuits when no identity is set, so emits
+      // will silently no-op until the deployment supplies one of these.
+      // Surface the cause so a misconfigured instance doesn't quietly
+      // produce zero analytics.
+      logger.warn(
+        'Metrics will skip events: no instance identity. ' +
+          'Set BROWSEROS_CLIENT_ID or BROWSEROS_INSTALL_ID (env) or ' +
+          'instance.client_id / instance.install_id (config) to opt in.',
+      )
     }
 
     if (!INLINED_ENV.SENTRY_DSN) {

--- a/packages/browseros-agent/apps/server/tests/lib/metrics.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/metrics.test.ts
@@ -1,0 +1,246 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+
+interface CaptureCall {
+  distinctId: string
+  event: string
+  properties: Record<string, unknown>
+}
+
+const captureCalls: CaptureCall[] = []
+
+class FakePostHog {
+  // biome-ignore lint/complexity/noUselessConstructor: matches the real PostHog(apiKey, opts) signature so `new PostHog(...)` from the module under test type-checks against the mock
+  constructor(_apiKey: string, _opts: { host: string }) {}
+  capture(call: CaptureCall): void {
+    captureCalls.push(call)
+  }
+  async shutdown(): Promise<void> {
+    return Promise.resolve()
+  }
+}
+
+mock.module('posthog-node', () => ({ PostHog: FakePostHog }))
+mock.module('../../src/env', () => ({
+  INLINED_ENV: { POSTHOG_API_KEY: 'test-key' },
+}))
+
+// Loaded after the module mocks so the metrics module picks them up.
+const metricsModule = await import('../../src/lib/metrics')
+const { metrics, __internal__ } = metricsModule
+const {
+  ROLLUP_INTERVAL_MS,
+  MAX_TOOL_NAME_KEYS,
+  sanitizeToolName,
+  RollupBuffer,
+} = __internal__
+
+beforeEach(() => {
+  captureCalls.length = 0
+  // Reset the singleton's internal state between tests by reinitializing.
+  // The service merges over its existing config so an empty config first
+  // drains, then a fresh identity primes the next test.
+  metrics.initialize({ client_id: '__reset__' })
+  metrics.initialize({ client_id: undefined, install_id: undefined })
+})
+
+describe('sanitizeToolName', () => {
+  it('replaces dots with underscores so HogQL prop access is safe', () => {
+    expect(sanitizeToolName('foo.bar.baz')).toBe('foo_bar_baz')
+  })
+
+  it('caps length so a pathological name cannot blow up the payload', () => {
+    const long = `${'x'.repeat(200)}`
+    expect(sanitizeToolName(long).length).toBe(80)
+  })
+})
+
+describe('RollupBuffer', () => {
+  it('returns null on drain when nothing was recorded', () => {
+    const buf = new RollupBuffer()
+    expect(buf.drain(new Date().toISOString())).toBeNull()
+  })
+
+  it('accumulates mcp_requests and tool_executions across calls', () => {
+    const buf = new RollupBuffer()
+    buf.recordMcpRequest()
+    buf.recordMcpRequest()
+    buf.recordToolExecuted({
+      tool_name: 'navigate_page',
+      source: 'chat',
+      success: true,
+    })
+    buf.recordToolExecuted({
+      tool_name: 'navigate_page',
+      source: 'chat',
+      success: false,
+    })
+    buf.recordToolExecuted({
+      tool_name: 'fill',
+      source: 'mcp',
+      success: true,
+    })
+
+    const bucket = buf.drain(new Date().toISOString())
+    expect(bucket).not.toBeNull()
+    if (!bucket) return
+    expect(bucket.mcp_requests).toBe(2)
+    expect(bucket.tool_executions.total).toBe(3)
+    expect(bucket.tool_executions.failed).toBe(1)
+    expect(bucket.tool_executions.by_tool).toEqual({
+      navigate_page: 2,
+      fill: 1,
+    })
+    expect(bucket.tool_executions.by_source).toEqual({ chat: 2, mcp: 1 })
+  })
+
+  it('resets internal state after drain so the next interval is clean', () => {
+    const buf = new RollupBuffer()
+    buf.recordMcpRequest()
+    buf.drain(new Date().toISOString())
+    expect(buf.drain(new Date().toISOString())).toBeNull()
+  })
+
+  it('rolls overflow tool names into __other__ once the cap is reached', () => {
+    const buf = new RollupBuffer()
+    for (let i = 0; i < MAX_TOOL_NAME_KEYS; i++) {
+      buf.recordToolExecuted({ tool_name: `tool_${i}`, source: 'chat' })
+    }
+    // The (cap + 1)th distinct name should land in __other__.
+    buf.recordToolExecuted({ tool_name: 'overflow_one', source: 'chat' })
+    buf.recordToolExecuted({ tool_name: 'overflow_two', source: 'chat' })
+    // A name already in the bucket continues to increment, even after the cap.
+    buf.recordToolExecuted({ tool_name: 'tool_0', source: 'chat' })
+
+    const bucket = buf.drain(new Date().toISOString())
+    if (!bucket) throw new Error('expected bucket')
+    expect(Object.keys(bucket.tool_executions.by_tool).length).toBe(
+      MAX_TOOL_NAME_KEYS + 1, // original cap + __other__
+    )
+    expect(bucket.tool_executions.by_tool.__other__).toBe(2)
+    expect(bucket.tool_executions.by_tool.tool_0).toBe(2)
+  })
+})
+
+describe('MetricsService — log dispatch', () => {
+  it('aggregates mcp.request without immediately capturing', () => {
+    metrics.initialize({ client_id: 'client-a' })
+    metrics.log('mcp.request', { scopeId: 'ephemeral' })
+    metrics.log('mcp.request')
+    metrics.log('mcp.request')
+    expect(captureCalls).toHaveLength(0)
+  })
+
+  it('aggregates tool_executed without immediately capturing', () => {
+    metrics.initialize({ client_id: 'client-a' })
+    metrics.log('tool_executed', {
+      tool_name: 'navigate_page',
+      source: 'chat',
+      success: true,
+    })
+    metrics.log('tool_executed', {
+      tool_name: 'fill',
+      source: 'mcp',
+      success: false,
+    })
+    expect(captureCalls).toHaveLength(0)
+  })
+
+  it('captures non-aggregated events immediately', () => {
+    metrics.initialize({ client_id: 'client-a' })
+    metrics.log('chat.request', { mode: 'agent' })
+    expect(captureCalls).toHaveLength(1)
+    expect(captureCalls[0]?.event).toBe('browseros.server.chat.request')
+    expect(captureCalls[0]?.distinctId).toBe('client-a')
+  })
+
+  it('skips emit entirely when no identity is configured', () => {
+    // No client_id, no install_id → captureNow should short-circuit.
+    metrics.initialize({})
+    metrics.log('chat.request', { mode: 'agent' })
+    expect(captureCalls).toHaveLength(0)
+  })
+
+  it('still aggregates noisy events even without identity, but flush emits nothing', async () => {
+    metrics.initialize({})
+    metrics.log('mcp.request')
+    metrics.log('tool_executed', { tool_name: 'fill', source: 'chat' })
+    // No way to reach flush from outside, but shutdown drains + skip-on-no-identity
+    // means the emit on the underlying captureNow is also skipped.
+    await metrics.shutdown()
+    expect(captureCalls).toHaveLength(0)
+  })
+})
+
+describe('MetricsService — flush + shutdown', () => {
+  it('emits a single usage_rollup on shutdown drain', async () => {
+    metrics.initialize({
+      client_id: 'client-a',
+      install_id: 'install-a',
+      browseros_version: '0.46.0.0',
+      server_version: '0.0.99',
+    })
+
+    metrics.log('mcp.request', { scopeId: 'ephemeral' })
+    metrics.log('mcp.request')
+    metrics.log('tool_executed', {
+      tool_name: 'navigate_page',
+      source: 'chat',
+      success: true,
+    })
+    metrics.log('tool_executed', {
+      tool_name: 'navigate_page',
+      source: 'chat',
+      success: false,
+    })
+    metrics.log('tool_executed', {
+      tool_name: 'fill',
+      source: 'mcp',
+      success: true,
+    })
+
+    await metrics.shutdown()
+
+    expect(captureCalls).toHaveLength(1)
+    const call = captureCalls[0]
+    if (!call) throw new Error('expected one capture call')
+    expect(call.event).toBe('browseros.server.usage_rollup')
+    expect(call.distinctId).toBe('client-a')
+    expect(call.properties.interval_seconds).toBe(ROLLUP_INTERVAL_MS / 1000)
+    expect(call.properties.mcp_requests_count).toBe(2)
+    expect(call.properties.tool_executions_count).toBe(3)
+    expect(call.properties.tool_executions_failed).toBe(1)
+    expect(call.properties.tool_executions_by_source).toEqual({
+      chat: 2,
+      mcp: 1,
+    })
+    expect(call.properties.tool_executions_by_tool).toEqual({
+      navigate_page: 2,
+      fill: 1,
+    })
+    expect(call.properties.browseros_version).toBe('0.46.0.0')
+    expect(call.properties.server_version).toBe('0.0.99')
+  })
+
+  it('emits nothing on shutdown when no activity was recorded', async () => {
+    metrics.initialize({ client_id: 'client-a' })
+    await metrics.shutdown()
+    expect(captureCalls).toHaveLength(0)
+  })
+
+  it('does not retain the dotted-name shape on aggregated tool names', async () => {
+    metrics.initialize({ client_id: 'client-a' })
+    metrics.log('tool_executed', { tool_name: 'foo.bar', source: 'chat' })
+    await metrics.shutdown()
+    const call = captureCalls[0]
+    if (!call) throw new Error('expected one capture call')
+    expect(
+      (call.properties.tool_executions_by_tool as Record<string, number>)
+        .foo_bar,
+    ).toBe(1)
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/lib/metrics.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/metrics.test.ts
@@ -39,11 +39,12 @@ const {
   RollupBuffer,
 } = __internal__
 
-beforeEach(() => {
+beforeEach(async () => {
+  // Drain whatever's left in the singleton RollupBuffer + PostHog
+  // client from a prior test so each test is hermetic. shutdown nulls
+  // the client; the initialize calls below re-create it.
+  await metrics.shutdown()
   captureCalls.length = 0
-  // Reset the singleton's internal state between tests by reinitializing.
-  // The service merges over its existing config so an empty config first
-  // drains, then a fresh identity primes the next test.
   metrics.initialize({ client_id: '__reset__' })
   metrics.initialize({ client_id: undefined, install_id: undefined })
 })

--- a/packages/browseros-agent/apps/server/tests/main.test.ts
+++ b/packages/browseros-agent/apps/server/tests/main.test.ts
@@ -14,6 +14,7 @@ const config = {
   executionDir: '/tmp/browseros-execution',
   mcpAllowRemote: false,
   aiSdkDevtoolsEnabled: false,
+  instanceClientId: 'client-test',
 }
 
 describe('Application.start', () => {
@@ -86,6 +87,20 @@ describe('Application.start', () => {
         process.env.BROWSEROS_DIR = originalBrowserosDir
       }
     }
+  })
+
+  it('warns at boot when metrics is enabled but no instance identity is configured', async () => {
+    const { Application, loggerWarn } = await setupApplicationTest()
+    const { instanceClientId: _unused, ...configWithoutIdentity } = config
+    const app = new Application(configWithoutIdentity)
+
+    await app.start()
+
+    const warnedAboutIdentity = loggerWarn.mock.calls.some(
+      (args) =>
+        typeof args[0] === 'string' && args[0].includes('no instance identity'),
+    )
+    expect(warnedAboutIdentity).toBe(true)
   })
 })
 


### PR DESCRIPTION
## Summary

- `metrics.log('mcp.request', …)` and `metrics.log('tool_executed', …)` are now buffered in-process instead of hitting PostHog per call.
- A new `browseros.server.usage_rollup` event flushes every 30 minutes (wall-clock aligned to `:00` and `:30`) with rolled-up counts and breakdowns. Empty buckets emit nothing.
- The 11 existing call sites for these two events don't change — aggregation happens inside `MetricsService.log`.
- Drops the `'anonymous'` `distinct_id` fallback so unconfigured instances no longer pool unattributable events into one bucket and inflate billing.

## Why

A volume audit traced ~87% of PostHog events on the worst day to these two event names, with a 14× jump over baseline in a 48-hour window. Per-call captures (`mcp.request` and `tool_executed`) had no per-call signal we use — `mcp.request` carries no `tool` / `server` / `method` properties on the noisy code path, and `tool_executed`'s `duration_ms` / `error_message` are observability noise already routed through Sentry and logs. The right fix is to stop firing per call.

On the worst-case caller observed in prod (~3 req/sec sustained polling), this drops PostHog billing from ~10,800 events/hour to **2 events/hour** during active intervals — ~5,400× reduction. For a typical user doing 100 tool calls in 30 minutes it's ~100× reduction. Other events (`chat.request`, `cli.command_executed`, `http_server.started`, etc.) keep their per-call shape because their volume was always fine.

## Shape of the rollup event

```json
{
  "event": "browseros.server.usage_rollup",
  "properties": {
    "interval_seconds": 1800,
    "period_start_ts": "2026-06-01T14:00:00.000Z",
    "period_end_ts":   "2026-06-01T14:30:00.000Z",
    "mcp_requests_count": 124,
    "tool_executions_count": 87,
    "tool_executions_failed": 3,
    "tool_executions_by_source": { \"chat\": 60, \"mcp\": 27 },
    "tool_executions_by_tool": {
      "navigate_page": 24, "fill": 18, "click": 15, "take_snapshot": 12,
      "scroll": 8, "press_key": 6, "get_dom": 4
    }
  }
}
```

`tool_executions_by_tool` keys are sanitized so PostHog property paths stay clean (dots → underscores, length capped at 80). The map itself is capped at 200 distinct keys per bucket; overflow rolls into `__other__`.

## Notes

- **Interval is hardcoded** at 30 minutes — one less knob to misconfigure across deployments. If staging or a future scale-up needs tighter feedback, change the `ROLLUP_INTERVAL_MS` constant and ship a release.
- The dropped `'anonymous'` fallback is a separate concern from the aggregation: it ensures that *other* unaggregated emit sites (`chat.request`, etc.) on unconfigured instances stop firing too. `main.ts` surfaces a clear `logger.warn` at boot when neither `BROWSEROS_CLIENT_ID` nor `BROWSEROS_INSTALL_ID` is set so a misconfigured deployment doesn't silently produce zero analytics.
- Tool name cardinality and length caps are defensive — current tool names are statically registered and well-behaved; the caps protect against future dynamic / user-supplied names.

## Manual Verification

- [x] \`bun test apps/server/tests/lib/metrics.test.ts\` — **14 pass, 0 fail**.
- [x] \`bun run --filter '@browseros/server' typecheck\` — clean.
- [x] \`bunx biome check apps/server/src/lib/metrics.ts apps/server/src/main.ts apps/server/tests/lib/metrics.test.ts\` — clean.
- [ ] **Staging rollout:** verify `usage_rollup` events appear on the staging PostHog project every 30 minutes when there's activity, and that `mcp.request` / `tool_executed` stop appearing. Spot-check `tool_executions_by_tool` and `tool_executions_by_source` for sensible breakdowns.
- [ ] **Prod rollout sequencing:** once a majority of active instances are on the new code, disable then delete the temporary PostHog ingestion-side block that's filtering anonymous `mcp.request` / `tool_executed` events.

## Test plan

The new `tests/lib/metrics.test.ts` covers:

- `mcp.request` and `tool_executed` go into the buffer instead of capturing immediately
- Other events still capture immediately
- Shutdown drain emits exactly one `usage_rollup` event with the right counts, `by_tool` map, `by_source` map, and instance metadata
- Empty buffer emits nothing
- No-identity short-circuits the underlying capture path
- Tool-name cardinality cap rolls overflow into `__other__`
- Dotted tool names are sanitized
- `RollupBuffer` resets after `drain`