### PR TITLE
feat: detect Claude and Codex readiness

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
@@ -271,10 +271,7 @@ export const AgentCommandConversation: FC<AgentCommandConversationProps> = ({
     if (!adapterId) return null
     const descriptor = adapters.find((item) => item.id === adapterId)
     if (!descriptor?.health) return null
-    return {
-      healthy: descriptor.health.healthy,
-      reason: descriptor.health.reason,
-    }
+    return descriptor.health
   }, [adapters, harnessAgent?.adapter])
 
   if (shouldRedirectHome) {

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentRail.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentRail.tsx
@@ -35,10 +35,7 @@ export const AgentRail: FC<AgentRailProps> = ({
     const map = new Map<HarnessAgentAdapter, AgentAdapterHealth>()
     for (const adapter of adapters) {
       if (adapter.health) {
-        map.set(adapter.id, {
-          healthy: adapter.health.healthy,
-          reason: adapter.health.reason,
-        })
+        map.set(adapter.id, adapter.health)
       }
     }
     return map

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentList.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/AgentList.tsx
@@ -48,10 +48,7 @@ export const AgentList: FC<AgentListProps> = ({
     const map = new Map<HarnessAgentAdapter, AgentAdapterHealth>()
     for (const adapter of adapters) {
       if (adapter.health) {
-        map.set(adapter.id, {
-          healthy: adapter.health.healthy,
-          reason: adapter.health.reason,
-        })
+        map.set(adapter.id, adapter.health)
       }
     }
     return map

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/adapter-health.test.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/adapter-health.test.ts
@@ -38,6 +38,13 @@ describe('adapter health helpers', () => {
         readiness: 'will-fetch-package',
       }),
     ).toBe('warning')
+    expect(
+      adapterHealthTone({
+        healthy: true,
+        checkedAt: 1,
+        readiness: 'diagnostic-warning',
+      }),
+    ).toBe('warning')
   })
 
   it('summarizes version and launch source when known', () => {

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/adapter-health.test.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/adapter-health.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  adapterHealthLabel,
+  adapterHealthMeta,
+  adapterHealthTone,
+} from './adapter-health'
+
+describe('adapter health helpers', () => {
+  it('labels actionable readiness states', () => {
+    expect(
+      adapterHealthLabel({
+        healthy: false,
+        checkedAt: 1,
+        readiness: 'needs-auth',
+      }),
+    ).toBe('Login needed')
+    expect(
+      adapterHealthLabel({
+        healthy: false,
+        checkedAt: 1,
+        readiness: 'will-fetch-package',
+      }),
+    ).toBe('Fetch on first run')
+  })
+
+  it('keeps install/auth blockers visually stronger than fetch warnings', () => {
+    expect(
+      adapterHealthTone({
+        healthy: false,
+        checkedAt: 1,
+        readiness: 'needs-install',
+      }),
+    ).toBe('danger')
+    expect(
+      adapterHealthTone({
+        healthy: false,
+        checkedAt: 1,
+        readiness: 'will-fetch-package',
+      }),
+    ).toBe('warning')
+  })
+
+  it('summarizes version and launch source when known', () => {
+    expect(
+      adapterHealthMeta({
+        healthy: true,
+        checkedAt: 1,
+        version: 'claude 1.2.3',
+        adapterLaunchSource: 'host-npx',
+      }),
+    ).toBe('claude 1.2.3 · npx')
+  })
+})

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/adapter-health.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/adapter-health.ts
@@ -1,0 +1,59 @@
+import type { HarnessAdapterHealth } from './agent-harness-types'
+
+export type AdapterHealthTone = 'ready' | 'warning' | 'danger'
+
+export function adapterHealthLabel(health: HarnessAdapterHealth): string {
+  switch (health.readiness) {
+    case 'ready':
+      return 'Ready'
+    case 'needs-auth':
+      return 'Login needed'
+    case 'needs-install':
+      return 'Install needed'
+    case 'will-fetch-package':
+      return 'Fetch on first run'
+    case 'diagnostic-warning':
+      return 'Check warning'
+    case 'unknown':
+      return 'Check failed'
+    default:
+      return health.healthy ? 'Ready' : 'Unavailable'
+  }
+}
+
+export function adapterHealthTone(
+  health: HarnessAdapterHealth,
+): AdapterHealthTone {
+  switch (health.readiness) {
+    case 'ready':
+      return 'ready'
+    case 'needs-install':
+    case 'needs-auth':
+      return 'danger'
+    default:
+      return health.healthy ? 'ready' : 'warning'
+  }
+}
+
+export function adapterHealthMeta(health: HarnessAdapterHealth): string | null {
+  const parts: string[] = []
+  if (health.version) parts.push(health.version)
+  const launch = launchSourceLabel(health.adapterLaunchSource)
+  if (launch) parts.push(launch)
+  return parts.length > 0 ? parts.join(' · ') : null
+}
+
+function launchSourceLabel(
+  source: HarnessAdapterHealth['adapterLaunchSource'],
+): string | null {
+  switch (source) {
+    case 'bundled-bun':
+      return 'bundled Bun'
+    case 'host-npx':
+      return 'npx'
+    case 'native-binary':
+      return 'native binary'
+    default:
+      return null
+  }
+}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/adapter-health.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/adapter-health.ts
@@ -30,6 +30,8 @@ export function adapterHealthTone(
     case 'needs-install':
     case 'needs-auth':
       return 'danger'
+    case 'diagnostic-warning':
+      return 'warning'
     default:
       return health.healthy ? 'ready' : 'warning'
   }
@@ -51,8 +53,6 @@ function launchSourceLabel(
       return 'bundled Bun'
     case 'host-npx':
       return 'npx'
-    case 'native-binary':
-      return 'native binary'
     default:
       return null
   }

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-harness-types.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-harness-types.ts
@@ -99,6 +99,23 @@ export interface HarnessAdapterHealth {
   healthy: boolean
   reason?: string
   checkedAt: number
+  readiness?:
+    | 'ready'
+    | 'needs-auth'
+    | 'needs-install'
+    | 'will-fetch-package'
+    | 'diagnostic-warning'
+    | 'unknown'
+  installState?:
+    | 'installed'
+    | 'npx-available'
+    | 'package-runner-available'
+    | 'not-installed'
+  nativeCliState?: 'present' | 'missing' | 'unknown'
+  authState?: 'authenticated' | 'unauthenticated' | 'not-applicable' | 'unknown'
+  version?: string
+  adapterLaunchSource?: 'native-binary' | 'bundled-bun' | 'host-npx' | 'none'
+  packageCacheState?: 'cached' | 'fetch-required' | 'unknown'
 }
 
 export interface HarnessAdapterDescriptor {

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-harness-types.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-harness-types.ts
@@ -114,7 +114,7 @@ export interface HarnessAdapterHealth {
   nativeCliState?: 'present' | 'missing' | 'unknown'
   authState?: 'authenticated' | 'unauthenticated' | 'not-applicable' | 'unknown'
   version?: string
-  adapterLaunchSource?: 'native-binary' | 'bundled-bun' | 'host-npx' | 'none'
+  adapterLaunchSource?: 'bundled-bun' | 'host-npx' | 'runtime' | 'none'
   packageCacheState?: 'cached' | 'fetch-required' | 'unknown'
 }
 

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-row/AgentSummaryChips.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-row/AgentSummaryChips.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/components/ui/hover-card'
 import { cn } from '@/lib/utils'
 import { adapterLabel } from '../AdapterIcon'
+import { adapterHealthLabel, adapterHealthTone } from '../adapter-health'
 import type { HarnessAgentAdapter } from '../agent-harness-types'
 import type { AgentAdapterHealth } from './agent-row.types'
 
@@ -33,6 +34,7 @@ export const AgentSummaryChips: FC<AgentSummaryChipsProps> = ({
   if (modelLabel) parts.push(modelLabel)
   if (reasoningEffort) parts.push(reasoningEffort)
   const unhealthy = adapterHealth?.healthy === false
+  const tone = adapterHealth ? adapterHealthTone(adapterHealth) : 'ready'
   return (
     <div
       className={cn(
@@ -49,12 +51,15 @@ export const AgentSummaryChips: FC<AgentSummaryChipsProps> = ({
               className="h-5 cursor-default gap-1 border-amber-500/40 bg-amber-50 px-1.5 text-amber-900 hover:bg-amber-50"
             >
               <TriangleAlert className="size-2.5" />
-              <span className="font-normal">Unavailable</span>
+              <span className="font-normal">
+                {adapterHealthLabel(adapterHealth)}
+              </span>
             </Badge>
           </HoverCardTrigger>
           <HoverCardContent side="right" className="w-72 text-sm">
             <div className="font-medium">
-              {adapterLabel(adapter)} CLI not available
+              {adapterLabel(adapter)}{' '}
+              {tone === 'danger' ? 'needs setup' : 'warning'}
             </div>
             <div className="mt-1 text-muted-foreground text-xs">
               {adapterHealth.reason ??

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-row/agent-row.types.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-row/agent-row.types.ts
@@ -1,4 +1,7 @@
-import type { HarnessAgentAdapter } from '../agent-harness-types'
+import type {
+  HarnessAdapterHealth,
+  HarnessAgentAdapter,
+} from '../agent-harness-types'
 import type { AgentListItem } from '../agents-page-types'
 import type { AgentLiveness } from '../LivenessDot'
 
@@ -11,10 +14,7 @@ export interface AgentTokenUsage {
   cumulative: { input: number; output: number }
 }
 
-export interface AgentAdapterHealth {
-  healthy: boolean
-  reason?: string
-}
+export type AgentAdapterHealth = HarnessAdapterHealth
 
 /**
  * Everything an `AgentRowCard` needs to render. Mirrors the shape

--- a/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/AdapterAgentsPane.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/AdapterAgentsPane.tsx
@@ -3,7 +3,13 @@ import { type FC, useEffect, useMemo, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { AdapterIcon, adapterLabel } from '@/entrypoints/app/agents/AdapterIcon'
 import { AgentList } from '@/entrypoints/app/agents/AgentList'
+import {
+  adapterHealthLabel,
+  adapterHealthMeta,
+  adapterHealthTone,
+} from '@/entrypoints/app/agents/adapter-health'
 import type {
+  HarnessAdapterHealth,
   HarnessAgent,
   HarnessAgentAdapter,
 } from '@/entrypoints/app/agents/agent-harness-types'
@@ -151,6 +157,9 @@ export const AdapterAgentsPane: FC<AdapterAgentsPaneProps> = ({
                 ? `Default model ${adapter.defaultModelId} · ${adapter.defaultReasoningEffort} reasoning`
                 : 'Runtime details load from the agent server.'}
             </p>
+            {adapter?.health ? (
+              <AdapterHealthMeta health={adapter.health} />
+            ) : null}
           </div>
           <Button
             onClick={() => setCreateOpen(true)}
@@ -227,26 +236,37 @@ export const AdapterAgentsPane: FC<AdapterAgentsPaneProps> = ({
 function AdapterHealthBadge({
   health,
 }: {
-  health: { healthy: boolean; reason?: string } | undefined
+  health: HarnessAdapterHealth | undefined
 }) {
   if (!health) return null
+  const tone = adapterHealthTone(health)
   return (
     <span
       className={cn(
         'inline-flex items-center gap-1.5 rounded-full px-2 py-0.5 font-medium text-xs',
-        health.healthy
-          ? 'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400'
-          : 'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+        tone === 'ready' &&
+          'bg-emerald-500/10 text-emerald-600 dark:text-emerald-400',
+        tone === 'warning' &&
+          'bg-amber-500/10 text-amber-600 dark:text-amber-400',
+        tone === 'danger' && 'bg-red-500/10 text-red-600 dark:text-red-400',
       )}
       title={health.reason}
     >
       <span
         className={cn(
           'size-1.5 rounded-full',
-          health.healthy ? 'bg-emerald-500' : 'bg-amber-500',
+          tone === 'ready' && 'bg-emerald-500',
+          tone === 'warning' && 'bg-amber-500',
+          tone === 'danger' && 'bg-red-500',
         )}
       />
-      {health.healthy ? 'Ready' : 'Unavailable'}
+      {adapterHealthLabel(health)}
     </span>
   )
+}
+
+function AdapterHealthMeta({ health }: { health: HarnessAdapterHealth }) {
+  const meta = adapterHealthMeta(health)
+  if (!meta) return null
+  return <p className="mt-1 text-muted-foreground text-xs">{meta}</p>
 }

--- a/packages/browseros-agent/apps/server/src/api/routes/agents.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/agents.ts
@@ -101,7 +101,7 @@ type AgentRouteDeps = {
   /** Optional hook for harness-owned VM/container runtimes. */
   ensureVmRuntimeReady?: EnsureVmRuntimeReady
   /** Optional override; defaults to a fresh in-memory checker. */
-  adapterHealth?: AdapterHealthChecker
+  adapterHealth?: Pick<AdapterHealthChecker, 'getHealth'>
   onTurnLifecycle?: import('../services/agents/agent-harness-service').TurnLifecycleListener
 }
 
@@ -128,7 +128,11 @@ export function createAgentRoutes(deps: AgentRouteDeps = {}) {
   }
   // One checker per route mount. Cached probes refresh every 5min;
   // tests can swap in an alternate via deps if needed.
-  const adapterHealth = deps.adapterHealth ?? new AdapterHealthChecker()
+  const adapterHealth =
+    deps.adapterHealth ??
+    new AdapterHealthChecker({
+      hostDetectionOptions: { resourcesDir: deps.resourcesDir },
+    })
 
   return new Hono<Env>()
     .get('/adapters', async (c) => {

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-runtime.ts
@@ -32,7 +32,8 @@ import type {
   AgentHistoryEntry,
   AgentHistoryToolCall,
 } from './agent-types'
-import { buildMacosAcpAdapterPath, resolveBundledBun } from './bundled-bun'
+import { resolveBundledBun } from './bundled-bun'
+import { HOST_ACP_ADAPTER_CONFIG } from './host-acp-adapter-config'
 import { getHermesRuntime } from './runtime'
 import type {
   AgentHistoryPage,
@@ -43,14 +44,6 @@ import type {
   AgentStatus,
   AgentStreamEvent,
 } from './types'
-
-const CLAUDE_ACP_ADAPTER_COMMAND =
-  'npx -y @agentclientprotocol/claude-agent-acp@^0.31.0'
-const CODEX_ACP_ADAPTER_COMMAND = 'npx -y @zed-industries/codex-acp@^0.12.0'
-const CLAUDE_ACP_PACKAGE = '@agentclientprotocol/claude-agent-acp@^0.31.0'
-const CLAUDE_ACP_BIN = 'claude-agent-acp'
-const CODEX_ACP_PACKAGE = '@zed-industries/codex-acp@^0.12.0'
-const CODEX_ACP_BIN = 'codex-acp'
 
 type AcpxRuntimeOptions = {
   cwd?: string
@@ -687,8 +680,8 @@ function createBrowserosAgentRegistry(input: {
         })
         return wrapCommandWithEnv(
           launch.command,
-          launch.addMacosAdapterEnv
-            ? withMacosAcpAdapterEnv(input.commandEnv, input.browserosDir)
+          launch.addBundledBunAdapterEnv
+            ? withBundledBunAcpAdapterEnv(input.commandEnv, input.browserosDir)
             : input.commandEnv,
         )
       }
@@ -707,39 +700,31 @@ function createBrowserosAgentRegistry(input: {
 function resolveBrowserosHostAcpAdapterCommand(input: {
   adapter: 'claude' | 'codex'
   resourcesDir: string | null
-}): { command: string; addMacosAdapterEnv: boolean } {
+}): { command: string; addBundledBunAdapterEnv: boolean } {
   const bun = resolveBundledBun({ resourcesDir: input.resourcesDir })
   if (bun) {
-    const pkg =
-      input.adapter === 'claude' ? CLAUDE_ACP_PACKAGE : CODEX_ACP_PACKAGE
-    const bin = input.adapter === 'claude' ? CLAUDE_ACP_BIN : CODEX_ACP_BIN
+    const config = HOST_ACP_ADAPTER_CONFIG[input.adapter]
     return {
-      command: `${shellQuote(bun)} x --bun --silent --package ${shellQuote(pkg)} ${shellQuote(bin)}`,
-      addMacosAdapterEnv: true,
+      command: `${shellQuote(bun)} x --bun --silent --package ${shellQuote(config.acpPackageSpec)} ${shellQuote(config.acpBin)}`,
+      addBundledBunAdapterEnv: true,
     }
   }
 
+  const config = HOST_ACP_ADAPTER_CONFIG[input.adapter]
   return {
-    command:
-      input.adapter === 'claude'
-        ? CLAUDE_ACP_ADAPTER_COMMAND
-        : CODEX_ACP_ADAPTER_COMMAND,
-    addMacosAdapterEnv: false,
+    command: config.acpCommand,
+    addBundledBunAdapterEnv: false,
   }
 }
 
-/** Adds the minimum macOS env needed for bundled Bun and native CLI lookup. */
-function withMacosAcpAdapterEnv(
+/** Adds the minimum env needed for BrowserOS-managed bundled Bun package installs. */
+function withBundledBunAcpAdapterEnv(
   env: Record<string, string>,
   browserosDir: string,
 ): Record<string, string> {
   return {
     ...env,
     BUN_INSTALL_CACHE_DIR: join(browserosDir, 'cache', 'bun-install'),
-    PATH: buildMacosAcpAdapterPath({
-      basePath: env.PATH ?? process.env.PATH,
-      home: env.HOME ?? process.env.HOME,
-    }),
   }
 }
 

--- a/packages/browseros-agent/apps/server/src/lib/agents/adapter-detection.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/adapter-detection.ts
@@ -4,9 +4,6 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { access, readdir } from 'node:fs/promises'
-import { homedir } from 'node:os'
-import { join } from 'node:path'
 import { resolveBundledBun } from './bundled-bun'
 import {
   HOST_ACP_ADAPTER_CONFIG,
@@ -18,6 +15,9 @@ import {
   resolveHostBinary,
   runHostCommand,
 } from './host-binary-resolver'
+import { probeNpxPackageCache } from './npx-package-cache'
+
+export { probeNpxPackageCache } from './npx-package-cache'
 
 export type AdapterReadiness =
   | 'ready'
@@ -40,9 +40,9 @@ export type AdapterAuthState =
   | 'not-applicable'
   | 'unknown'
 export type AdapterLaunchSource =
-  | 'native-binary'
   | 'bundled-bun'
   | 'host-npx'
+  | 'runtime'
   | 'none'
 export type PackageCacheState = 'cached' | 'fetch-required' | 'unknown'
 
@@ -67,7 +67,10 @@ export interface DetectHostAdapterOptions {
   now?: () => number
   resolveBinary?: (name: string) => Promise<ResolvedHostBinary | null>
   runCommand?: HostCommandRunner
-  probePackageCache?: (packageName: string) => Promise<boolean>
+  probePackageCache?: (
+    packageName: string,
+    versionRange?: string,
+  ) => Promise<boolean>
   resolveBundledBun?: typeof resolveBundledBun
 }
 
@@ -87,7 +90,10 @@ export async function detectHostAdapter(
   const resolveBinary =
     options.resolveBinary ??
     ((name: string) => resolveHostBinary(name, { env, platform, timeoutMs }))
-  const probePackageCache = options.probePackageCache ?? probeNpxPackageCache
+  const probePackageCache =
+    options.probePackageCache ??
+    ((packageName: string, versionRange?: string) =>
+      probeNpxPackageCache(packageName, { versionRange }))
   const resolveBun = options.resolveBundledBun ?? resolveBundledBun
 
   const [nativeCli, launch] = await Promise.all([
@@ -102,13 +108,17 @@ export async function detectHostAdapter(
     }),
   ])
 
-  const version = nativeCli
-    ? await probeVersion(nativeCli, runCommand, timeoutMs)
-    : undefined
-  const authState = nativeCli
-    ? await probeAuth(adapter, nativeCli, runCommand, timeoutMs)
-    : 'unknown'
   const nativeCliState: NativeCliState = nativeCli ? 'present' : 'missing'
+  let version: string | undefined
+  let authState: AdapterAuthState = 'unknown'
+  if (nativeCli) {
+    const probes = await Promise.all([
+      probeVersion(nativeCli, runCommand, timeoutMs),
+      probeAuth(adapter, nativeCli, runCommand, timeoutMs),
+    ])
+    version = probes[0]
+    authState = probes[1]
+  }
   const installState = determineInstallState({
     nativeCliState,
     adapterLaunchSource: launch.source,
@@ -135,44 +145,15 @@ export async function detectHostAdapter(
   }
 }
 
-export async function probeNpxPackageCache(
-  packageName: string,
-  options: { npxCacheDir?: string } = {},
-): Promise<boolean> {
-  const npxCacheDir = options.npxCacheDir ?? join(homedir(), '.npm', '_npx')
-  let entries: Array<{ isDirectory(): boolean; name: string }>
-  try {
-    entries = await readdir(npxCacheDir, { withFileTypes: true })
-  } catch {
-    return false
-  }
-
-  const packageParts = packageName.split('/').filter(Boolean)
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue
-    const candidate = join(
-      npxCacheDir,
-      entry.name,
-      'node_modules',
-      ...packageParts,
-      'package.json',
-    )
-    try {
-      await access(candidate)
-      return true
-    } catch {
-      // keep scanning
-    }
-  }
-  return false
-}
-
 async function detectAdapterLaunch(input: {
   adapter: HostAcpAdapter
   platform: NodeJS.Platform
   resourcesDir?: string | null
   resolveBinary: (name: string) => Promise<ResolvedHostBinary | null>
-  probePackageCache: (packageName: string) => Promise<boolean>
+  probePackageCache: (
+    packageName: string,
+    versionRange?: string,
+  ) => Promise<boolean>
   resolveBundledBun: typeof resolveBundledBun
 }): Promise<{
   source: AdapterLaunchSource
@@ -189,8 +170,10 @@ async function detectAdapterLaunch(input: {
   const npx = await input.resolveBinary('npx').catch(() => null)
   if (!npx) return { source: 'none', packageCacheState: 'unknown' }
 
-  const packageName = HOST_ACP_ADAPTER_CONFIG[input.adapter].acpPackageName
-  const cached = await input.probePackageCache(packageName).catch(() => false)
+  const config = HOST_ACP_ADAPTER_CONFIG[input.adapter]
+  const cached = await input
+    .probePackageCache(config.acpPackageName, config.acpPackageVersionRange)
+    .catch(() => false)
   return {
     source: 'host-npx',
     packageCacheState: cached ? 'cached' : 'fetch-required',
@@ -226,9 +209,10 @@ async function probeAuth(
     return result.exitCode === 0 ? 'authenticated' : 'unauthenticated'
   }
 
+  const timeoutPerCodexAuthProbe = splitTimeoutForCodexFallback(timeoutMs)
   const status = await runCommand(binary.path, ['login', 'status'], {
     env: binary.env,
-    timeoutMs,
+    timeoutMs: timeoutPerCodexAuthProbe,
   }).catch(() => null)
   if (status) {
     if (status.exitCode === 0) return 'authenticated'
@@ -237,7 +221,7 @@ async function probeAuth(
 
   const doctor = await runCommand(binary.path, ['doctor'], {
     env: binary.env,
-    timeoutMs,
+    timeoutMs: timeoutPerCodexAuthProbe,
   }).catch(() => null)
   if (!doctor) return 'unknown'
   const output = `${doctor.stdout}\n${doctor.stderr}`.toLowerCase()
@@ -249,6 +233,10 @@ async function probeAuth(
     return 'unauthenticated'
   }
   return doctor.exitCode === 0 ? 'authenticated' : 'unknown'
+}
+
+function splitTimeoutForCodexFallback(timeoutMs: number): number {
+  return Math.max(1, Math.floor(timeoutMs / 2))
 }
 
 function isUnsupportedCodexStatus(result: {
@@ -291,6 +279,7 @@ function determineReadiness(input: {
   if (input.launch.packageCacheState === 'fetch-required') {
     return 'will-fetch-package'
   }
+  if (input.authState === 'unknown') return 'diagnostic-warning'
   return 'ready'
 }
 
@@ -306,6 +295,8 @@ function reasonFor(input: {
       return `${input.displayName} adapter cannot launch because neither bundled Bun nor npx is available.`
     case 'will-fetch-package':
       return `${input.displayName} adapter package will be downloaded on first use.`
+    case 'diagnostic-warning':
+      return `${input.displayName} can launch, but authentication could not be verified.`
     case 'unknown':
       return `${input.displayName} readiness could not be checked.`
     default:

--- a/packages/browseros-agent/apps/server/src/lib/agents/adapter-detection.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/adapter-detection.ts
@@ -1,0 +1,314 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { access, readdir } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { resolveBundledBun } from './bundled-bun'
+import {
+  HOST_ACP_ADAPTER_CONFIG,
+  type HostAcpAdapter,
+} from './host-acp-adapter-config'
+import {
+  type HostCommandRunner,
+  type ResolvedHostBinary,
+  resolveHostBinary,
+  runHostCommand,
+} from './host-binary-resolver'
+
+export type AdapterReadiness =
+  | 'ready'
+  | 'needs-auth'
+  | 'needs-install'
+  | 'will-fetch-package'
+  | 'diagnostic-warning'
+  | 'unknown'
+
+export type AdapterInstallState =
+  | 'installed'
+  | 'npx-available'
+  | 'package-runner-available'
+  | 'not-installed'
+
+export type NativeCliState = 'present' | 'missing' | 'unknown'
+export type AdapterAuthState =
+  | 'authenticated'
+  | 'unauthenticated'
+  | 'not-applicable'
+  | 'unknown'
+export type AdapterLaunchSource =
+  | 'native-binary'
+  | 'bundled-bun'
+  | 'host-npx'
+  | 'none'
+export type PackageCacheState = 'cached' | 'fetch-required' | 'unknown'
+
+export interface AdapterHealth {
+  healthy: boolean
+  reason?: string
+  checkedAt: number
+  readiness: AdapterReadiness
+  installState: AdapterInstallState
+  nativeCliState: NativeCliState
+  authState: AdapterAuthState
+  version?: string
+  adapterLaunchSource: AdapterLaunchSource
+  packageCacheState: PackageCacheState
+}
+
+export interface DetectHostAdapterOptions {
+  env?: NodeJS.ProcessEnv
+  platform?: NodeJS.Platform
+  resourcesDir?: string | null
+  timeoutMs?: number
+  now?: () => number
+  resolveBinary?: (name: string) => Promise<ResolvedHostBinary | null>
+  runCommand?: HostCommandRunner
+  probePackageCache?: (packageName: string) => Promise<boolean>
+  resolveBundledBun?: typeof resolveBundledBun
+}
+
+const DEFAULT_PROBE_TIMEOUT_MS = 3_000
+
+/** Detects whether a host ACP adapter can be launched, versioned, and authenticated. */
+export async function detectHostAdapter(
+  adapter: HostAcpAdapter,
+  options: DetectHostAdapterOptions = {},
+): Promise<AdapterHealth> {
+  const config = HOST_ACP_ADAPTER_CONFIG[adapter]
+  const platform = options.platform ?? process.platform
+  const env = options.env ?? process.env
+  const timeoutMs = options.timeoutMs ?? DEFAULT_PROBE_TIMEOUT_MS
+  const now = options.now ?? Date.now
+  const runCommand = options.runCommand ?? runHostCommand
+  const resolveBinary =
+    options.resolveBinary ??
+    ((name: string) => resolveHostBinary(name, { env, platform, timeoutMs }))
+  const probePackageCache = options.probePackageCache ?? probeNpxPackageCache
+  const resolveBun = options.resolveBundledBun ?? resolveBundledBun
+
+  const [nativeCli, launch] = await Promise.all([
+    resolveBinary(config.nativeBinary).catch(() => null),
+    detectAdapterLaunch({
+      adapter,
+      platform,
+      resourcesDir: options.resourcesDir,
+      resolveBinary,
+      probePackageCache,
+      resolveBundledBun: resolveBun,
+    }),
+  ])
+
+  const version = nativeCli
+    ? await probeVersion(nativeCli, runCommand, timeoutMs)
+    : undefined
+  const authState = nativeCli
+    ? await probeAuth(adapter, nativeCli, runCommand, timeoutMs)
+    : 'unknown'
+  const nativeCliState: NativeCliState = nativeCli ? 'present' : 'missing'
+  const installState = determineInstallState({
+    nativeCliState,
+    adapterLaunchSource: launch.source,
+    packageCacheState: launch.packageCacheState,
+  })
+  const readiness = determineReadiness({ authState, launch })
+  const reason = reasonFor({
+    displayName: config.displayName,
+    readiness,
+    authState,
+  })
+
+  return {
+    healthy: readiness === 'ready' || readiness === 'diagnostic-warning',
+    ...(reason ? { reason } : {}),
+    checkedAt: now(),
+    readiness,
+    installState,
+    nativeCliState,
+    authState,
+    ...(version ? { version } : {}),
+    adapterLaunchSource: launch.source,
+    packageCacheState: launch.packageCacheState,
+  }
+}
+
+export async function probeNpxPackageCache(
+  packageName: string,
+  options: { npxCacheDir?: string } = {},
+): Promise<boolean> {
+  const npxCacheDir = options.npxCacheDir ?? join(homedir(), '.npm', '_npx')
+  let entries: Array<{ isDirectory(): boolean; name: string }>
+  try {
+    entries = await readdir(npxCacheDir, { withFileTypes: true })
+  } catch {
+    return false
+  }
+
+  const packageParts = packageName.split('/').filter(Boolean)
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    const candidate = join(
+      npxCacheDir,
+      entry.name,
+      'node_modules',
+      ...packageParts,
+      'package.json',
+    )
+    try {
+      await access(candidate)
+      return true
+    } catch {
+      // keep scanning
+    }
+  }
+  return false
+}
+
+async function detectAdapterLaunch(input: {
+  adapter: HostAcpAdapter
+  platform: NodeJS.Platform
+  resourcesDir?: string | null
+  resolveBinary: (name: string) => Promise<ResolvedHostBinary | null>
+  probePackageCache: (packageName: string) => Promise<boolean>
+  resolveBundledBun: typeof resolveBundledBun
+}): Promise<{
+  source: AdapterLaunchSource
+  packageCacheState: PackageCacheState
+}> {
+  const bundledBun = input.resolveBundledBun({
+    resourcesDir: input.resourcesDir,
+    platform: input.platform,
+  })
+  if (bundledBun) {
+    return { source: 'bundled-bun', packageCacheState: 'unknown' }
+  }
+
+  const npx = await input.resolveBinary('npx').catch(() => null)
+  if (!npx) return { source: 'none', packageCacheState: 'unknown' }
+
+  const packageName = HOST_ACP_ADAPTER_CONFIG[input.adapter].acpPackageName
+  const cached = await input.probePackageCache(packageName).catch(() => false)
+  return {
+    source: 'host-npx',
+    packageCacheState: cached ? 'cached' : 'fetch-required',
+  }
+}
+
+async function probeVersion(
+  binary: ResolvedHostBinary,
+  runCommand: HostCommandRunner,
+  timeoutMs: number,
+): Promise<string | undefined> {
+  const result = await runCommand(binary.path, ['--version'], {
+    env: binary.env,
+    timeoutMs,
+  }).catch(() => null)
+  if (!result || result.exitCode !== 0) return undefined
+  const firstLine = result.stdout.trim().split(/\r?\n/)[0]?.trim()
+  return firstLine || undefined
+}
+
+async function probeAuth(
+  adapter: HostAcpAdapter,
+  binary: ResolvedHostBinary,
+  runCommand: HostCommandRunner,
+  timeoutMs: number,
+): Promise<AdapterAuthState> {
+  if (adapter === 'claude') {
+    const result = await runCommand(binary.path, ['auth', 'status'], {
+      env: binary.env,
+      timeoutMs,
+    }).catch(() => null)
+    if (!result) return 'unknown'
+    return result.exitCode === 0 ? 'authenticated' : 'unauthenticated'
+  }
+
+  const status = await runCommand(binary.path, ['login', 'status'], {
+    env: binary.env,
+    timeoutMs,
+  }).catch(() => null)
+  if (status) {
+    if (status.exitCode === 0) return 'authenticated'
+    if (!isUnsupportedCodexStatus(status)) return 'unauthenticated'
+  }
+
+  const doctor = await runCommand(binary.path, ['doctor'], {
+    env: binary.env,
+    timeoutMs,
+  }).catch(() => null)
+  if (!doctor) return 'unknown'
+  const output = `${doctor.stdout}\n${doctor.stderr}`.toLowerCase()
+  if (
+    output.includes('not authenticated') ||
+    output.includes('not logged in') ||
+    output.includes('no authentication')
+  ) {
+    return 'unauthenticated'
+  }
+  return doctor.exitCode === 0 ? 'authenticated' : 'unknown'
+}
+
+function isUnsupportedCodexStatus(result: {
+  stdout: string
+  stderr: string
+}): boolean {
+  const output = `${result.stdout}\n${result.stderr}`.toLowerCase()
+  return (
+    output.includes('unrecognized') ||
+    output.includes('unknown command') ||
+    output.includes('unexpected argument') ||
+    output.includes('invalid subcommand')
+  )
+}
+
+function determineInstallState(input: {
+  nativeCliState: NativeCliState
+  adapterLaunchSource: AdapterLaunchSource
+  packageCacheState: PackageCacheState
+}): AdapterInstallState {
+  if (
+    input.nativeCliState === 'present' ||
+    input.packageCacheState === 'cached'
+  ) {
+    return 'installed'
+  }
+  if (input.adapterLaunchSource === 'host-npx') return 'npx-available'
+  if (input.adapterLaunchSource === 'bundled-bun') {
+    return 'package-runner-available'
+  }
+  return 'not-installed'
+}
+
+function determineReadiness(input: {
+  authState: AdapterAuthState
+  launch: { source: AdapterLaunchSource; packageCacheState: PackageCacheState }
+}): AdapterReadiness {
+  if (input.launch.source === 'none') return 'needs-install'
+  if (input.authState === 'unauthenticated') return 'needs-auth'
+  if (input.launch.packageCacheState === 'fetch-required') {
+    return 'will-fetch-package'
+  }
+  return 'ready'
+}
+
+function reasonFor(input: {
+  displayName: string
+  readiness: AdapterReadiness
+  authState: AdapterAuthState
+}): string | undefined {
+  switch (input.readiness) {
+    case 'needs-auth':
+      return `${input.displayName} is installed but is not authenticated.`
+    case 'needs-install':
+      return `${input.displayName} adapter cannot launch because neither bundled Bun nor npx is available.`
+    case 'will-fetch-package':
+      return `${input.displayName} adapter package will be downloaded on first use.`
+    case 'unknown':
+      return `${input.displayName} readiness could not be checked.`
+    default:
+      return undefined
+  }
+}

--- a/packages/browseros-agent/apps/server/src/lib/agents/adapter-health.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/adapter-health.ts
@@ -4,21 +4,19 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import {
+  type AdapterHealth,
+  type DetectHostAdapterOptions,
+  detectHostAdapter,
+} from './adapter-detection'
 import type { AgentAdapter } from './agent-types'
+import { isHostAcpAdapter } from './host-acp-adapter-config'
 import {
   type AgentRuntime,
   type AgentRuntimeRegistry,
   getAgentRuntimeRegistry,
   HostProcessAgentRuntime,
 } from './runtime'
-
-export interface AdapterHealth {
-  healthy: boolean
-  /** Human-readable explanation when unhealthy; absent on success. */
-  reason?: string
-  /** Wall-clock ms when this probe completed. */
-  checkedAt: number
-}
 
 /**
  * Reports adapter readiness for the `/adapters` route. Reads from the
@@ -29,18 +27,38 @@ export interface AdapterHealth {
  */
 export class AdapterHealthChecker {
   private readonly registry: AgentRuntimeRegistry
+  private readonly detectHostAdapter: typeof detectHostAdapter
+  private readonly hostDetectionOptions: DetectHostAdapterOptions
 
-  constructor(options: { registry?: AgentRuntimeRegistry } = {}) {
+  constructor(
+    options: {
+      registry?: AgentRuntimeRegistry
+      detectHostAdapter?: typeof detectHostAdapter
+      hostDetectionOptions?: DetectHostAdapterOptions
+    } = {},
+  ) {
     this.registry = options.registry ?? getAgentRuntimeRegistry()
+    this.detectHostAdapter = options.detectHostAdapter ?? detectHostAdapter
+    this.hostDetectionOptions = options.hostDetectionOptions ?? {}
   }
 
   async getHealth(adapter: AgentAdapter): Promise<AdapterHealth> {
+    if (isHostAcpAdapter(adapter)) {
+      return this.detectHostAdapter(adapter, this.hostDetectionOptions)
+    }
+
     const runtime = this.registry.get(adapter)
     if (!runtime) {
       return {
         healthy: false,
         reason: `No runtime registered for "${adapter}"`,
         checkedAt: Date.now(),
+        readiness: 'needs-install',
+        installState: 'not-installed',
+        nativeCliState: 'unknown',
+        authState: 'unknown',
+        adapterLaunchSource: 'none',
+        packageCacheState: 'unknown',
       }
     }
     if (runtime instanceof HostProcessAgentRuntime) await runtime.probeHealth()
@@ -57,5 +75,11 @@ function runtimeSnapshotToHealth(runtime: AgentRuntime): AdapterHealth {
     // regardless of health state. lastErrorAt is the fallback for
     // runtimes that don't emit probedAt yet (containers).
     checkedAt: snap.probedAt ?? snap.lastErrorAt ?? Date.now(),
+    readiness: snap.isReady ? 'ready' : 'unknown',
+    installState: snap.isReady ? 'installed' : 'not-installed',
+    nativeCliState: 'unknown',
+    authState: 'unknown',
+    adapterLaunchSource: 'none',
+    packageCacheState: 'unknown',
   }
 }

--- a/packages/browseros-agent/apps/server/src/lib/agents/adapter-health.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/adapter-health.ts
@@ -78,8 +78,8 @@ function runtimeSnapshotToHealth(runtime: AgentRuntime): AdapterHealth {
     readiness: snap.isReady ? 'ready' : 'unknown',
     installState: snap.isReady ? 'installed' : 'not-installed',
     nativeCliState: 'unknown',
-    authState: 'unknown',
-    adapterLaunchSource: 'none',
+    authState: snap.isReady ? 'not-applicable' : 'unknown',
+    adapterLaunchSource: snap.isReady ? 'runtime' : 'none',
     packageCacheState: 'unknown',
   }
 }

--- a/packages/browseros-agent/apps/server/src/lib/agents/bundled-bun.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/bundled-bun.ts
@@ -5,7 +5,7 @@
  */
 
 import { accessSync, constants, statSync } from 'node:fs'
-import { delimiter, join } from 'node:path'
+import { join } from 'node:path'
 
 export const BUNDLED_BUN_RELATIVE_PATH = join('bin', 'third_party', 'bun')
 
@@ -27,28 +27,4 @@ export function resolveBundledBun(input: {
   } catch {
     return null
   }
-}
-
-/** Builds a macOS host PATH for GUI-launched adapter processes. */
-export function buildMacosAcpAdapterPath(input: {
-  basePath?: string
-  home?: string
-}): string {
-  const home = input.home?.trim()
-  const candidates = [
-    home ? join(home, '.local', 'bin') : '',
-    home ? join(home, '.bun', 'bin') : '',
-    '/opt/homebrew/bin',
-    '/usr/local/bin',
-    input.basePath ?? '',
-    '/usr/bin',
-    '/bin',
-    '/usr/sbin',
-    '/sbin',
-  ]
-
-  const parts = candidates.flatMap((value) =>
-    value.split(delimiter).filter(Boolean),
-  )
-  return [...new Set(parts)].join(delimiter)
 }

--- a/packages/browseros-agent/apps/server/src/lib/agents/host-acp-adapter-config.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/host-acp-adapter-config.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+export type HostAcpAdapter = 'claude' | 'codex'
+
+export const HOST_ACP_ADAPTER_CONFIG = {
+  claude: {
+    displayName: 'Claude Code',
+    nativeBinary: 'claude',
+    acpCommand: 'npx -y @agentclientprotocol/claude-agent-acp@^0.31.0',
+    acpPackageSpec: '@agentclientprotocol/claude-agent-acp@^0.31.0',
+    acpPackageName: '@agentclientprotocol/claude-agent-acp',
+    acpBin: 'claude-agent-acp',
+  },
+  codex: {
+    displayName: 'Codex',
+    nativeBinary: 'codex',
+    acpCommand: 'npx -y @zed-industries/codex-acp@^0.12.0',
+    acpPackageSpec: '@zed-industries/codex-acp@^0.12.0',
+    acpPackageName: '@zed-industries/codex-acp',
+    acpBin: 'codex-acp',
+  },
+} as const satisfies Record<
+  HostAcpAdapter,
+  {
+    displayName: string
+    nativeBinary: string
+    acpCommand: string
+    acpPackageSpec: string
+    acpPackageName: string
+    acpBin: string
+  }
+>
+
+export function isHostAcpAdapter(value: string): value is HostAcpAdapter {
+  return value === 'claude' || value === 'codex'
+}

--- a/packages/browseros-agent/apps/server/src/lib/agents/host-acp-adapter-config.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/host-acp-adapter-config.ts
@@ -13,6 +13,7 @@ export const HOST_ACP_ADAPTER_CONFIG = {
     acpCommand: 'npx -y @agentclientprotocol/claude-agent-acp@^0.31.0',
     acpPackageSpec: '@agentclientprotocol/claude-agent-acp@^0.31.0',
     acpPackageName: '@agentclientprotocol/claude-agent-acp',
+    acpPackageVersionRange: '^0.31.0',
     acpBin: 'claude-agent-acp',
   },
   codex: {
@@ -21,6 +22,7 @@ export const HOST_ACP_ADAPTER_CONFIG = {
     acpCommand: 'npx -y @zed-industries/codex-acp@^0.12.0',
     acpPackageSpec: '@zed-industries/codex-acp@^0.12.0',
     acpPackageName: '@zed-industries/codex-acp',
+    acpPackageVersionRange: '^0.12.0',
     acpBin: 'codex-acp',
   },
 } as const satisfies Record<
@@ -31,6 +33,7 @@ export const HOST_ACP_ADAPTER_CONFIG = {
     acpCommand: string
     acpPackageSpec: string
     acpPackageName: string
+    acpPackageVersionRange: string
     acpBin: string
   }
 >

--- a/packages/browseros-agent/apps/server/src/lib/agents/host-binary-resolver.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/host-binary-resolver.ts
@@ -1,0 +1,212 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { posix, win32 } from 'node:path'
+
+export interface HostCommandResult {
+  exitCode: number
+  stdout: string
+  stderr: string
+}
+
+export interface HostCommandOptions {
+  env?: NodeJS.ProcessEnv
+  timeoutMs?: number
+}
+
+export type HostCommandRunner = (
+  cmd: string,
+  args: string[],
+  options: HostCommandOptions,
+) => Promise<HostCommandResult>
+
+export interface ResolvedHostBinary {
+  path: string
+  env: NodeJS.ProcessEnv
+}
+
+export interface ResolveHostBinaryOptions {
+  env?: NodeJS.ProcessEnv
+  platform?: NodeJS.Platform
+  timeoutMs?: number
+  runCommand?: HostCommandRunner
+}
+
+const DEFAULT_LOOKUP_TIMEOUT_MS = 3_000
+const SAFE_BINARY_NAME = /^[A-Za-z0-9._-]+(?:\.(?:cmd|exe|bat))?$/
+
+/** Resolves a host command through the user's OS lookup path without hardcoded install directories. */
+export async function resolveHostBinary(
+  name: string,
+  options: ResolveHostBinaryOptions = {},
+): Promise<ResolvedHostBinary | null> {
+  assertSafeBinaryName(name)
+  const platform = options.platform ?? process.platform
+  const env = options.env ?? process.env
+  const timeoutMs = options.timeoutMs ?? DEFAULT_LOOKUP_TIMEOUT_MS
+  const runCommand = options.runCommand ?? runHostCommand
+
+  const resolvedPath =
+    platform === 'win32'
+      ? await resolveWindowsBinary(name, env, timeoutMs, runCommand)
+      : await resolveUnixBinary(name, env, timeoutMs, runCommand)
+
+  if (!resolvedPath) return null
+  return {
+    path: resolvedPath,
+    env: buildResolvedBinaryEnv({ binaryPath: resolvedPath, env, platform }),
+  }
+}
+
+/** Builds child process env so npm/node shims can find their shebang interpreter. */
+export function buildResolvedBinaryEnv(input: {
+  binaryPath: string
+  env?: NodeJS.ProcessEnv
+  platform?: NodeJS.Platform
+}): NodeJS.ProcessEnv {
+  const platform = input.platform ?? process.platform
+  const env = { ...(input.env ?? process.env) }
+  const key = pathEnvKey(env, platform)
+  const delimiter = pathDelimiter(platform)
+  const dir =
+    platform === 'win32'
+      ? win32.dirname(input.binaryPath)
+      : posix.dirname(input.binaryPath)
+  const existing = env[key] ?? ''
+  const parts = existing.split(delimiter).filter(Boolean)
+  env[key] = parts.includes(dir)
+    ? existing
+    : [dir, ...parts].filter(Boolean).join(delimiter)
+  return env
+}
+
+export async function runHostCommand(
+  cmd: string,
+  args: string[],
+  options: HostCommandOptions = {},
+): Promise<HostCommandResult> {
+  const proc = Bun.spawn([cmd, ...args], {
+    stdin: 'ignore',
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: options.env,
+  })
+  let timedOut = false
+  const timer =
+    options.timeoutMs && options.timeoutMs > 0
+      ? setTimeout(() => {
+          timedOut = true
+          try {
+            proc.kill()
+          } catch {
+            // best effort
+          }
+        }, options.timeoutMs)
+      : null
+
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  if (timer) clearTimeout(timer)
+  if (timedOut)
+    throw new Error(`Command timed out after ${options.timeoutMs}ms`)
+  return { exitCode, stdout, stderr }
+}
+
+async function resolveUnixBinary(
+  name: string,
+  env: NodeJS.ProcessEnv,
+  timeoutMs: number,
+  runCommand: HostCommandRunner,
+): Promise<string | null> {
+  const shell = env.SHELL?.trim()
+  if (shell) {
+    const viaLoginShell = await lookupWithCommand(
+      shell,
+      ['-lic', `command -v ${name}`],
+      env,
+      timeoutMs,
+      runCommand,
+    )
+    if (viaLoginShell) return viaLoginShell
+  }
+
+  return lookupWithCommand(
+    'sh',
+    ['-lc', `command -v ${name}`],
+    env,
+    timeoutMs,
+    runCommand,
+  )
+}
+
+async function resolveWindowsBinary(
+  name: string,
+  env: NodeJS.ProcessEnv,
+  timeoutMs: number,
+  runCommand: HostCommandRunner,
+): Promise<string | null> {
+  const viaWhere = await lookupWithCommand(
+    'where.exe',
+    [name],
+    env,
+    timeoutMs,
+    runCommand,
+  )
+  if (viaWhere) return viaWhere
+
+  return lookupWithCommand(
+    'powershell.exe',
+    [
+      '-NoProfile',
+      '-NonInteractive',
+      '-Command',
+      `(Get-Command -CommandType Application ${name} -ErrorAction SilentlyContinue).Source`,
+    ],
+    env,
+    timeoutMs,
+    runCommand,
+  )
+}
+
+async function lookupWithCommand(
+  cmd: string,
+  args: string[],
+  env: NodeJS.ProcessEnv,
+  timeoutMs: number,
+  runCommand: HostCommandRunner,
+): Promise<string | null> {
+  const result = await runCommand(cmd, args, { env, timeoutMs }).catch(
+    () => null,
+  )
+  if (!result || result.exitCode !== 0) return null
+  return firstOutputPath(result.stdout)
+}
+
+function firstOutputPath(stdout: string): string | null {
+  const line = stdout
+    .split(/\r?\n/)
+    .map((part) => part.trim())
+    .find(Boolean)
+  return line && line.length > 0 ? line : null
+}
+
+function assertSafeBinaryName(name: string): void {
+  if (!SAFE_BINARY_NAME.test(name)) {
+    throw new Error(`Unsafe binary name: ${name}`)
+  }
+}
+
+function pathDelimiter(platform: NodeJS.Platform): string {
+  return platform === 'win32' ? ';' : ':'
+}
+
+function pathEnvKey(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): string {
+  if (platform !== 'win32') return 'PATH'
+  return Object.keys(env).find((key) => key.toLowerCase() === 'path') ?? 'Path'
+}

--- a/packages/browseros-agent/apps/server/src/lib/agents/npx-package-cache.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/npx-package-cache.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { readdir, readFile } from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+
+/** Checks whether npm's npx cache already holds the configured ACP package range. */
+export async function probeNpxPackageCache(
+  packageName: string,
+  options: { npxCacheDir?: string; versionRange?: string } = {},
+): Promise<boolean> {
+  const npxCacheDir = options.npxCacheDir ?? join(homedir(), '.npm', '_npx')
+  let entries: Array<{ isDirectory(): boolean; name: string }>
+  try {
+    entries = await readdir(npxCacheDir, { withFileTypes: true })
+  } catch {
+    return false
+  }
+
+  const packageParts = packageName.split('/').filter(Boolean)
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue
+    const candidate = join(
+      npxCacheDir,
+      entry.name,
+      'node_modules',
+      ...packageParts,
+      'package.json',
+    )
+    try {
+      const packageJson = await readFile(candidate, 'utf8')
+      if (cachedPackageMatches(packageJson, options.versionRange)) return true
+    } catch {
+      // keep scanning
+    }
+  }
+  return false
+}
+
+function cachedPackageMatches(
+  packageJson: string,
+  versionRange?: string,
+): boolean {
+  if (!versionRange) return true
+
+  let version: unknown
+  try {
+    version = (JSON.parse(packageJson) as { version?: unknown }).version
+  } catch {
+    return false
+  }
+  return typeof version === 'string' && versionSatisfies(version, versionRange)
+}
+
+function versionSatisfies(version: string, range: string): boolean {
+  const trimmedRange = range.trim()
+  if (!trimmedRange) return true
+
+  const candidate = parseSemver(version)
+  if (!candidate) return false
+
+  if (trimmedRange.startsWith('^')) {
+    const base = parseSemver(trimmedRange.slice(1))
+    if (!base) return false
+    return (
+      compareSemver(candidate, base) >= 0 &&
+      compareSemver(candidate, caretUpperBound(base)) < 0
+    )
+  }
+
+  const exact = parseSemver(trimmedRange)
+  return !!exact && compareSemver(candidate, exact) === 0
+}
+
+function parseSemver(
+  value: string,
+): { major: number; minor: number; patch: number } | null {
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:[-+].*)?$/.exec(value.trim())
+  if (!match) return null
+  return {
+    major: Number(match[1]),
+    minor: Number(match[2]),
+    patch: Number(match[3]),
+  }
+}
+
+function compareSemver(
+  left: { major: number; minor: number; patch: number },
+  right: { major: number; minor: number; patch: number },
+): number {
+  return (
+    left.major - right.major ||
+    left.minor - right.minor ||
+    left.patch - right.patch
+  )
+}
+
+function caretUpperBound(version: {
+  major: number
+  minor: number
+  patch: number
+}): { major: number; minor: number; patch: number } {
+  if (version.major > 0) {
+    return { major: version.major + 1, minor: 0, patch: 0 }
+  }
+  if (version.minor > 0) {
+    return { major: 0, minor: version.minor + 1, patch: 0 }
+  }
+  return { major: 0, minor: 0, patch: version.patch + 1 }
+}

--- a/packages/browseros-agent/apps/server/src/lib/agents/runtime/host-process-agent-runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/runtime/host-process-agent-runtime.ts
@@ -11,7 +11,10 @@
  */
 
 import { logger } from '../../logger'
-import { buildMacosAcpAdapterPath } from '../bundled-bun'
+import {
+  type ResolvedHostBinary,
+  resolveHostBinary,
+} from '../host-binary-resolver'
 import type { AgentRuntime } from './agent-runtime'
 import { ActionNotSupportedError } from './errors'
 import type {
@@ -38,40 +41,18 @@ export interface HostProcessAgentRuntimeDeps {
     cmd: ReadonlyArray<string>,
     timeoutMs: number,
   ) => Promise<{ exitCode: number; stdout: string; stderr: string }>
+  /** Test seam: resolve the command before spawning the real probe. */
+  resolveBinary?: (
+    name: string,
+    timeoutMs: number,
+    env: NodeJS.ProcessEnv,
+  ) => Promise<ResolvedHostBinary | null>
   /** Environment overrides for the version probe subprocess. */
   probeEnv?: NodeJS.ProcessEnv
 }
 
 const DEFAULT_PROBE_CACHE_MS = 5 * 60 * 1000
 const DEFAULT_PROBE_TIMEOUT_MS = 2_000
-
-/**
- * Builds the environment used for host CLI version probes. macOS probes get
- * the same GUI-safe PATH used by ACP adapter launches; explicit overrides
- * layer on top without disabling that PATH enrichment.
- */
-export function buildHostProcessProbeEnv(
-  input: {
-    env?: NodeJS.ProcessEnv
-    platform?: NodeJS.Platform
-    overrides?: NodeJS.ProcessEnv
-  } = {},
-): NodeJS.ProcessEnv | undefined {
-  const platform = input.platform ?? process.platform
-  const env = input.env ?? process.env
-  const baseEnv =
-    platform === 'darwin'
-      ? {
-          ...env,
-          PATH: buildMacosAcpAdapterPath({
-            basePath: env.PATH,
-            home: env.HOME,
-          }),
-        }
-      : undefined
-  if (!input.overrides) return baseEnv
-  return { ...(baseEnv ?? env), ...input.overrides }
-}
 
 export abstract class HostProcessAgentRuntime implements AgentRuntime {
   abstract readonly descriptor: RuntimeDescriptor & { kind: 'host-process' }
@@ -249,11 +230,18 @@ export abstract class HostProcessAgentRuntime implements AgentRuntime {
     timeoutMs: number,
   ): Promise<{ exitCode: number; stdout: string; stderr: string }> {
     if (this.deps.spawnProbe) return this.deps.spawnProbe(cmd, timeoutMs)
-    const env = buildHostProcessProbeEnv({ overrides: this.deps.probeEnv })
-    const proc = Bun.spawn(cmd as string[], {
+    const binaryName = cmd[0]
+    if (!binaryName) throw new Error('Host probe command is empty')
+    const env = { ...process.env, ...(this.deps.probeEnv ?? {}) }
+    const resolved =
+      (await this.deps.resolveBinary?.(binaryName, timeoutMs, env)) ??
+      (await resolveHostBinary(binaryName, { env, timeoutMs }))
+    if (!resolved) throw new Error(`${binaryName} not found on host PATH`)
+
+    const proc = Bun.spawn([resolved.path, ...cmd.slice(1)] as string[], {
       stdout: 'pipe',
       stderr: 'pipe',
-      env,
+      env: resolved.env,
     })
     const timer = setTimeout(() => {
       try {

--- a/packages/browseros-agent/apps/server/src/lib/agents/runtime/index.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/runtime/index.ts
@@ -33,7 +33,6 @@ export {
   prepareHermesContext,
 } from './hermes-container-runtime'
 export {
-  buildHostProcessProbeEnv,
   HostProcessAgentRuntime,
   type HostProcessAgentRuntimeDeps,
 } from './host-process-agent-runtime'

--- a/packages/browseros-agent/apps/server/tests/api/routes/agents.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/agents.test.ts
@@ -15,6 +15,64 @@ import type { AgentDefinition } from '../../../src/lib/agents/agent-types'
 import type { AgentStreamEvent } from '../../../src/lib/agents/types'
 
 describe('createAgentRoutes', () => {
+  it('returns enriched adapter health from /adapters', async () => {
+    const route = new Hono().route(
+      '/agents',
+      createAgentRoutes({
+        service: createFakeService([]),
+        adapterHealth: {
+          async getHealth(adapter) {
+            return {
+              healthy: adapter === 'claude',
+              checkedAt: 1234,
+              readiness: adapter === 'claude' ? 'ready' : 'needs-auth',
+              installState: 'installed',
+              nativeCliState: 'present',
+              authState:
+                adapter === 'claude' ? 'authenticated' : 'unauthenticated',
+              version: adapter === 'claude' ? 'claude 1.2.3' : undefined,
+              adapterLaunchSource: 'host-npx',
+              packageCacheState: 'cached',
+              ...(adapter === 'claude'
+                ? {}
+                : { reason: 'Codex is installed but is not authenticated.' }),
+            }
+          },
+        },
+      }),
+    )
+
+    const response = await route.request('/agents/adapters')
+    expect(response.status).toBe(200)
+    const body = await response.json()
+    expect(body.adapters).toContainEqual(
+      expect.objectContaining({
+        id: 'claude',
+        health: expect.objectContaining({
+          healthy: true,
+          readiness: 'ready',
+          installState: 'installed',
+          nativeCliState: 'present',
+          authState: 'authenticated',
+          version: 'claude 1.2.3',
+          adapterLaunchSource: 'host-npx',
+          packageCacheState: 'cached',
+          checkedAt: 1234,
+        }),
+      }),
+    )
+    expect(body.adapters).toContainEqual(
+      expect.objectContaining({
+        id: 'codex',
+        health: expect.objectContaining({
+          healthy: false,
+          readiness: 'needs-auth',
+          reason: 'Codex is installed but is not authenticated.',
+        }),
+      }),
+    )
+  })
+
   it('creates and lists harness agents', async () => {
     const agents: AgentDefinition[] = []
     const route = createMountedRoutes(agents)

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -1005,8 +1005,7 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
         `'${bunPath}' x --bun --silent --package '@zed-industries/codex-acp@^0.12.0' 'codex-acp'`,
       )
       expect(codexCommand).toContain('BUN_INSTALL_CACHE_DIR=')
-      expect(codexCommand).toContain('PATH=')
-      expect(codexCommand).toContain('/opt/homebrew/bin')
+      expect(codexCommand).not.toContain('PATH=')
       expect(codexCommand).not.toContain('npx -y')
     },
   )

--- a/packages/browseros-agent/apps/server/tests/lib/agents/adapter-detection.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/adapter-detection.test.ts
@@ -1,0 +1,206 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import {
+  detectHostAdapter,
+  probeNpxPackageCache,
+} from '../../../src/lib/agents/adapter-detection'
+
+describe('adapter detection', () => {
+  it('reports ready when the adapter package is cached and auth probe succeeds', async () => {
+    const result = await detectHostAdapter('claude', {
+      now: () => 1234,
+      resolveBinary: async (name) => {
+        if (name === 'claude') {
+          return {
+            path: '/Users/dev/.local/bin/claude',
+            env: { PATH: '/Users/dev/.local/bin:/usr/bin' },
+          }
+        }
+        if (name === 'npx') {
+          return {
+            path: '/opt/node/bin/npx',
+            env: { PATH: '/opt/node/bin:/usr/bin' },
+          }
+        }
+        return null
+      },
+      runCommand: async (cmd, args) => {
+        if (cmd === '/Users/dev/.local/bin/claude' && args[0] === '--version') {
+          return { exitCode: 0, stdout: 'claude 1.2.3\n', stderr: '' }
+        }
+        if (
+          cmd === '/Users/dev/.local/bin/claude' &&
+          args.join(' ') === 'auth status'
+        ) {
+          return { exitCode: 0, stdout: 'authenticated\n', stderr: '' }
+        }
+        throw new Error(`unexpected command ${cmd} ${args.join(' ')}`)
+      },
+      probePackageCache: async () => true,
+    })
+
+    expect(result).toMatchObject({
+      healthy: true,
+      readiness: 'ready',
+      installState: 'installed',
+      nativeCliState: 'present',
+      authState: 'authenticated',
+      adapterLaunchSource: 'host-npx',
+      packageCacheState: 'cached',
+      version: 'claude 1.2.3',
+      checkedAt: 1234,
+    })
+  })
+
+  it('surfaces auth blockers separately from install state', async () => {
+    const result = await detectHostAdapter('claude', {
+      now: () => 1234,
+      resolveBinary: async (name) =>
+        name === 'claude'
+          ? { path: '/bin/claude', env: { PATH: '/bin' } }
+          : { path: '/bin/npx', env: { PATH: '/bin' } },
+      runCommand: async (_cmd, args) =>
+        args[0] === '--version'
+          ? { exitCode: 0, stdout: 'claude 1.2.3\n', stderr: '' }
+          : { exitCode: 1, stdout: '', stderr: 'not logged in' },
+      probePackageCache: async () => true,
+    })
+
+    expect(result).toMatchObject({
+      healthy: false,
+      readiness: 'needs-auth',
+      installState: 'installed',
+      nativeCliState: 'present',
+      authState: 'unauthenticated',
+      reason: 'Claude Code is installed but is not authenticated.',
+    })
+  })
+
+  it('reports fetchable npx packages without pretending the native CLI is present', async () => {
+    const result = await detectHostAdapter('codex', {
+      now: () => 1234,
+      resolveBinary: async (name) =>
+        name === 'npx' ? { path: '/bin/npx', env: { PATH: '/bin' } } : null,
+      runCommand: async () => {
+        throw new Error('should not run native probes without a native CLI')
+      },
+      probePackageCache: async () => false,
+    })
+
+    expect(result).toMatchObject({
+      healthy: false,
+      readiness: 'will-fetch-package',
+      installState: 'npx-available',
+      nativeCliState: 'missing',
+      authState: 'unknown',
+      adapterLaunchSource: 'host-npx',
+      packageCacheState: 'fetch-required',
+    })
+  })
+
+  it('detects bundled Bun as a package runner without host npx', async () => {
+    const result = await detectHostAdapter('codex', {
+      now: () => 1234,
+      platform: 'darwin',
+      resourcesDir: '/Applications/BrowserOS.app/Contents/Resources',
+      resolveBundledBun: () =>
+        '/Applications/BrowserOS.app/Contents/Resources/bin/third_party/bun',
+      resolveBinary: async () => null,
+      runCommand: async () => {
+        throw new Error('should not run native probes without a native CLI')
+      },
+      probePackageCache: async () => false,
+    })
+
+    expect(result).toMatchObject({
+      healthy: true,
+      readiness: 'ready',
+      installState: 'package-runner-available',
+      nativeCliState: 'missing',
+      authState: 'unknown',
+      adapterLaunchSource: 'bundled-bun',
+      packageCacheState: 'unknown',
+    })
+  })
+})
+
+describe('probeNpxPackageCache', () => {
+  const tempDirs: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true })),
+    )
+    tempDirs.length = 0
+  })
+
+  it('finds cached scoped npx packages without matching nested dependencies', async () => {
+    const npmCacheDir = await mkdtemp(join(tmpdir(), 'browseros-npx-cache-'))
+    tempDirs.push(npmCacheDir)
+    await mkdir(
+      join(
+        npmCacheDir,
+        '_npx',
+        'hit',
+        'node_modules',
+        '@zed-industries',
+        'codex-acp',
+      ),
+      { recursive: true },
+    )
+    await mkdir(
+      join(
+        npmCacheDir,
+        '_npx',
+        'miss',
+        'node_modules',
+        '@zed-industries',
+        'nested',
+        'node_modules',
+        '@zed-industries',
+        'codex-acp',
+      ),
+      { recursive: true },
+    )
+    await writeFile(
+      join(
+        npmCacheDir,
+        '_npx',
+        'hit',
+        'node_modules',
+        '@zed-industries',
+        'codex-acp',
+        'package.json',
+      ),
+      '{}',
+    )
+    await writeFile(
+      join(
+        npmCacheDir,
+        '_npx',
+        'miss',
+        'node_modules',
+        '@zed-industries',
+        'nested',
+        'node_modules',
+        '@zed-industries',
+        'codex-acp',
+        'package.json',
+      ),
+      '{}',
+    )
+
+    await expect(
+      probeNpxPackageCache('@zed-industries/codex-acp', {
+        npxCacheDir: join(npmCacheDir, '_npx'),
+      }),
+    ).resolves.toBe(true)
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/lib/agents/adapter-detection.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/adapter-detection.test.ts
@@ -43,7 +43,11 @@ describe('adapter detection', () => {
         }
         throw new Error(`unexpected command ${cmd} ${args.join(' ')}`)
       },
-      probePackageCache: async () => true,
+      probePackageCache: async (packageName, versionRange) => {
+        expect(packageName).toBe('@agentclientprotocol/claude-agent-acp')
+        expect(versionRange).toBe('^0.31.0')
+        return true
+      },
     })
 
     expect(result).toMatchObject({
@@ -105,6 +109,29 @@ describe('adapter detection', () => {
     })
   })
 
+  it('warns when the adapter package is cached but native auth cannot be verified', async () => {
+    const result = await detectHostAdapter('codex', {
+      now: () => 1234,
+      resolveBinary: async (name) =>
+        name === 'npx' ? { path: '/bin/npx', env: { PATH: '/bin' } } : null,
+      runCommand: async () => {
+        throw new Error('should not run native probes without a native CLI')
+      },
+      probePackageCache: async () => true,
+    })
+
+    expect(result).toMatchObject({
+      healthy: true,
+      readiness: 'diagnostic-warning',
+      installState: 'installed',
+      nativeCliState: 'missing',
+      authState: 'unknown',
+      adapterLaunchSource: 'host-npx',
+      packageCacheState: 'cached',
+      reason: 'Codex can launch, but authentication could not be verified.',
+    })
+  })
+
   it('detects bundled Bun as a package runner without host npx', async () => {
     const result = await detectHostAdapter('codex', {
       now: () => 1234,
@@ -121,12 +148,80 @@ describe('adapter detection', () => {
 
     expect(result).toMatchObject({
       healthy: true,
-      readiness: 'ready',
+      readiness: 'diagnostic-warning',
       installState: 'package-runner-available',
       nativeCliState: 'missing',
       authState: 'unknown',
       adapterLaunchSource: 'bundled-bun',
       packageCacheState: 'unknown',
+      reason: 'Codex can launch, but authentication could not be verified.',
+    })
+  })
+
+  it('uses codex doctor when login status is not supported', async () => {
+    const calls: Array<{ args: string[]; timeoutMs: number | undefined }> = []
+
+    const result = await detectHostAdapter('codex', {
+      now: () => 1234,
+      timeoutMs: 3000,
+      resolveBinary: async (name) => {
+        if (name === 'codex') {
+          return { path: '/bin/codex', env: { PATH: '/bin' } }
+        }
+        if (name === 'npx') {
+          return { path: '/bin/npx', env: { PATH: '/bin' } }
+        }
+        return null
+      },
+      runCommand: async (_cmd, args, options) => {
+        calls.push({ args, timeoutMs: options.timeoutMs })
+        if (args[0] === '--version') {
+          return { exitCode: 0, stdout: 'codex-cli 0.135.0\n', stderr: '' }
+        }
+        if (args.join(' ') === 'login status') {
+          return { exitCode: 2, stdout: '', stderr: 'unrecognized command' }
+        }
+        if (args[0] === 'doctor') {
+          return { exitCode: 0, stdout: 'Auth: authenticated\n', stderr: '' }
+        }
+        throw new Error(`unexpected command ${args.join(' ')}`)
+      },
+      probePackageCache: async () => true,
+    })
+
+    expect(result).toMatchObject({
+      healthy: true,
+      readiness: 'ready',
+      authState: 'authenticated',
+      version: 'codex-cli 0.135.0',
+    })
+    expect(calls).toContainEqual({ args: ['login', 'status'], timeoutMs: 1500 })
+    expect(calls).toContainEqual({ args: ['doctor'], timeoutMs: 1500 })
+  })
+
+  it('warns when native auth probing fails', async () => {
+    const result = await detectHostAdapter('claude', {
+      now: () => 1234,
+      resolveBinary: async (name) =>
+        name === 'claude'
+          ? { path: '/bin/claude', env: { PATH: '/bin' } }
+          : { path: '/bin/npx', env: { PATH: '/bin' } },
+      runCommand: async (_cmd, args) => {
+        if (args[0] === '--version') {
+          return { exitCode: 0, stdout: 'claude 1.2.3\n', stderr: '' }
+        }
+        throw new Error('auth probe failed')
+      },
+      probePackageCache: async () => true,
+    })
+
+    expect(result).toMatchObject({
+      healthy: true,
+      readiness: 'diagnostic-warning',
+      nativeCliState: 'present',
+      authState: 'unknown',
+      reason:
+        'Claude Code can launch, but authentication could not be verified.',
     })
   })
 })
@@ -141,7 +236,7 @@ describe('probeNpxPackageCache', () => {
     tempDirs.length = 0
   })
 
-  it('finds cached scoped npx packages without matching nested dependencies', async () => {
+  it('finds cached scoped npx packages that match the requested range', async () => {
     const npmCacheDir = await mkdtemp(join(tmpdir(), 'browseros-npx-cache-'))
     tempDirs.push(npmCacheDir)
     await mkdir(
@@ -179,7 +274,7 @@ describe('probeNpxPackageCache', () => {
         'codex-acp',
         'package.json',
       ),
-      '{}',
+      '{"version":"0.12.1"}',
     )
     await writeFile(
       join(
@@ -194,13 +289,49 @@ describe('probeNpxPackageCache', () => {
         'codex-acp',
         'package.json',
       ),
-      '{}',
+      '{"version":"0.12.1"}',
     )
 
     await expect(
       probeNpxPackageCache('@zed-industries/codex-acp', {
         npxCacheDir: join(npmCacheDir, '_npx'),
+        versionRange: '^0.12.0',
       }),
     ).resolves.toBe(true)
+  })
+
+  it('ignores cached npx packages outside the requested range', async () => {
+    const npmCacheDir = await mkdtemp(join(tmpdir(), 'browseros-npx-cache-'))
+    tempDirs.push(npmCacheDir)
+    await mkdir(
+      join(
+        npmCacheDir,
+        '_npx',
+        'stale',
+        'node_modules',
+        '@zed-industries',
+        'codex-acp',
+      ),
+      { recursive: true },
+    )
+    await writeFile(
+      join(
+        npmCacheDir,
+        '_npx',
+        'stale',
+        'node_modules',
+        '@zed-industries',
+        'codex-acp',
+        'package.json',
+      ),
+      '{"version":"0.11.9"}',
+    )
+
+    await expect(
+      probeNpxPackageCache('@zed-industries/codex-acp', {
+        npxCacheDir: join(npmCacheDir, '_npx'),
+        versionRange: '^0.12.0',
+      }),
+    ).resolves.toBe(false)
   })
 })

--- a/packages/browseros-agent/apps/server/tests/lib/agents/adapter-health.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/adapter-health.test.ts
@@ -1,0 +1,58 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { AdapterHealthChecker } from '../../../src/lib/agents/adapter-health'
+import {
+  type AgentRuntime,
+  AgentRuntimeRegistry,
+  type RuntimeStatusSnapshot,
+} from '../../../src/lib/agents/runtime'
+
+describe('AdapterHealthChecker', () => {
+  it('reports healthy non-host runtimes as runtime-backed', async () => {
+    const registry = new AgentRuntimeRegistry()
+    registry.register(
+      createFakeRuntime({
+        adapterId: 'hermes',
+        state: 'running',
+        isReady: true,
+        lastError: null,
+        lastErrorAt: null,
+        probedAt: 1234,
+      }),
+    )
+
+    const health = await new AdapterHealthChecker({ registry }).getHealth(
+      'hermes',
+    )
+
+    expect(health).toMatchObject({
+      healthy: true,
+      checkedAt: 1234,
+      readiness: 'ready',
+      installState: 'installed',
+      authState: 'not-applicable',
+      adapterLaunchSource: 'runtime',
+    })
+  })
+})
+
+function createFakeRuntime(snapshot: RuntimeStatusSnapshot): AgentRuntime {
+  return {
+    descriptor: {
+      adapterId: snapshot.adapterId,
+      displayName: 'Hermes',
+      kind: 'container',
+      platforms: ['darwin'],
+    },
+    getStatusSnapshot: () => snapshot,
+    subscribe: () => () => {},
+    getCapabilities: () => [],
+    executeAction: async () => {},
+    buildExecArgv: () => '',
+    getPerAgentHomeDir: () => '/tmp/browseros-agent',
+  }
+}

--- a/packages/browseros-agent/apps/server/tests/lib/agents/bundled-bun.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/bundled-bun.test.ts
@@ -7,10 +7,7 @@ import { afterEach, describe, expect, it } from 'bun:test'
 import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
-import {
-  buildMacosAcpAdapterPath,
-  resolveBundledBun,
-} from '../../../src/lib/agents/bundled-bun'
+import { resolveBundledBun } from '../../../src/lib/agents/bundled-bun'
 
 describe('bundled Bun helpers', () => {
   const tempDirs: string[] = []
@@ -54,16 +51,5 @@ describe('bundled Bun helpers', () => {
     await writeFile(bunPath, '#!/bin/sh\n')
 
     expect(resolveBundledBun({ resourcesDir, platform: 'linux' })).toBeNull()
-  })
-
-  it('adds common macOS CLI install directories without duplicating PATH entries', () => {
-    expect(
-      buildMacosAcpAdapterPath({
-        basePath: '/usr/bin:/bin:/opt/homebrew/bin',
-        home: '/Users/dev',
-      }),
-    ).toBe(
-      '/Users/dev/.local/bin:/Users/dev/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin',
-    )
   })
 })

--- a/packages/browseros-agent/apps/server/tests/lib/agents/host-binary-resolver.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/host-binary-resolver.test.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { describe, expect, it, mock } from 'bun:test'
+import {
+  buildResolvedBinaryEnv,
+  resolveHostBinary,
+} from '../../../src/lib/agents/host-binary-resolver'
+
+describe('host binary resolver', () => {
+  it('resolves Unix binaries through the user login shell first', async () => {
+    const runCommand = mock(async () => ({
+      exitCode: 0,
+      stdout: '/Users/dev/.local/bin/claude\n',
+      stderr: '',
+    }))
+
+    const result = await resolveHostBinary('claude', {
+      env: { SHELL: '/bin/zsh', PATH: '/usr/bin:/bin' },
+      platform: 'darwin',
+      runCommand,
+    })
+
+    expect(result?.path).toBe('/Users/dev/.local/bin/claude')
+    expect(runCommand).toHaveBeenCalledWith(
+      '/bin/zsh',
+      ['-lic', 'command -v claude'],
+      expect.objectContaining({
+        env: { SHELL: '/bin/zsh', PATH: '/usr/bin:/bin' },
+      }),
+    )
+  })
+
+  it('falls back to sh lookup on Unix when the login shell misses', async () => {
+    const runCommand = mock(async (cmd: string) =>
+      cmd === '/bin/fish'
+        ? { exitCode: 1, stdout: '', stderr: 'not found' }
+        : { exitCode: 0, stdout: '/usr/local/bin/codex\n', stderr: '' },
+    )
+
+    const result = await resolveHostBinary('codex', {
+      env: { SHELL: '/bin/fish', PATH: '/usr/bin:/bin' },
+      platform: 'linux',
+      runCommand,
+    })
+
+    expect(result?.path).toBe('/usr/local/bin/codex')
+    expect(runCommand.mock.calls.map((call) => call[0])).toEqual([
+      '/bin/fish',
+      'sh',
+    ])
+  })
+
+  it('uses Windows-native lookup on win32', async () => {
+    const runCommand = mock(async () => ({
+      exitCode: 0,
+      stdout: 'C:\\Users\\dev\\AppData\\Roaming\\npm\\codex.cmd\r\n',
+      stderr: '',
+    }))
+
+    const result = await resolveHostBinary('codex', {
+      env: { Path: 'C:\\Windows\\System32' },
+      platform: 'win32',
+      runCommand,
+    })
+
+    expect(result?.path).toBe(
+      'C:\\Users\\dev\\AppData\\Roaming\\npm\\codex.cmd',
+    )
+    expect(runCommand).toHaveBeenCalledWith(
+      'where.exe',
+      ['codex'],
+      expect.objectContaining({ env: { Path: 'C:\\Windows\\System32' } }),
+    )
+  })
+
+  it('prepends the resolved binary directory to child PATH for shims', () => {
+    expect(
+      buildResolvedBinaryEnv({
+        binaryPath: 'C:\\Users\\dev\\AppData\\Roaming\\npm\\codex.cmd',
+        env: { Path: 'C:\\Windows\\System32' },
+        platform: 'win32',
+      }),
+    ).toEqual({
+      Path: 'C:\\Users\\dev\\AppData\\Roaming\\npm;C:\\Windows\\System32',
+    })
+
+    expect(
+      buildResolvedBinaryEnv({
+        binaryPath: '/Users/dev/.local/share/fnm/node/bin/codex',
+        env: { PATH: '/usr/bin:/bin' },
+        platform: 'darwin',
+      }),
+    ).toEqual({
+      PATH: '/Users/dev/.local/share/fnm/node/bin:/usr/bin:/bin',
+    })
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/lib/agents/runtime/host-process-agent-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/runtime/host-process-agent-runtime.test.ts
@@ -6,10 +6,9 @@
 import { describe, expect, it, mock } from 'bun:test'
 import { chmod, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { delimiter, join } from 'node:path'
+import { join } from 'node:path'
 import {
   ActionNotSupportedError,
-  buildHostProcessProbeEnv,
   HostProcessAgentRuntime,
   type HostProcessAgentRuntimeDeps,
   type RuntimeStatusSnapshot,
@@ -201,71 +200,28 @@ describe('HostProcessAgentRuntime', () => {
       const dir = await mkdtemp(join(tmpdir(), 'host-probe-'))
       try {
         const bin = join(dir, 'fake-cli')
-        await writeFile(bin, '#!/bin/sh\necho from-probe-env\n')
+        await writeFile(bin, '#!/bin/sh\necho "$PATH"\n')
         await chmod(bin, 0o755)
+        let resolverEnv: NodeJS.ProcessEnv | null = null
         const r = new TestRuntime({
           binaryName: 'fake-cli',
-          probeEnv: { PATH: dir },
+          probeEnv: { PATH: '/custom/bin' },
+          resolveBinary: async (_name, _timeoutMs, env) => {
+            resolverEnv = env
+            return {
+              path: bin,
+              env: { PATH: `${dir}:/custom/bin` },
+            }
+          },
         })
         await r.probeHealth()
         const snap = r.getStatusSnapshot()
         expect(snap.state).toBe('cli_present')
-        expect(snap.details?.binaryVersion).toBe('from-probe-env')
+        expect(snap.details?.binaryVersion).toBe(`${dir}:/custom/bin`)
+        expect(resolverEnv?.PATH).toBe('/custom/bin')
       } finally {
         await rm(dir, { recursive: true, force: true })
       }
-    })
-
-    it('builds a macOS GUI-safe probe PATH', () => {
-      const env = buildHostProcessProbeEnv({
-        env: { HOME: '/Users/tester', PATH: '/base/bin' },
-        platform: 'darwin',
-      })
-      expect(env?.PATH.split(delimiter).slice(0, 5)).toEqual([
-        '/Users/tester/.local/bin',
-        '/Users/tester/.bun/bin',
-        '/opt/homebrew/bin',
-        '/usr/local/bin',
-        '/base/bin',
-      ])
-    })
-
-    it('keeps macOS PATH enrichment as the probeEnv base', () => {
-      const env = buildHostProcessProbeEnv({
-        env: { HOME: '/Users/tester', PATH: '/base/bin' },
-        platform: 'darwin',
-        overrides: { DEBUG_PROBE: '1' },
-      })
-      expect(env?.DEBUG_PROBE).toBe('1')
-      expect(env?.PATH?.split(delimiter).slice(0, 5)).toEqual([
-        '/Users/tester/.local/bin',
-        '/Users/tester/.bun/bin',
-        '/opt/homebrew/bin',
-        '/usr/local/bin',
-        '/base/bin',
-      ])
-    })
-
-    it('layers probeEnv over process env on non-macOS', () => {
-      const env = buildHostProcessProbeEnv({
-        env: { HOME: '/home/tester', PATH: '/base/bin' },
-        platform: 'linux',
-        overrides: { DEBUG_PROBE: '1' },
-      })
-      expect(env).toEqual({
-        HOME: '/home/tester',
-        PATH: '/base/bin',
-        DEBUG_PROBE: '1',
-      })
-    })
-
-    it('leaves non-macOS probe env unchanged', () => {
-      expect(
-        buildHostProcessProbeEnv({
-          env: { HOME: '/home/tester', PATH: '/base/bin' },
-          platform: 'linux',
-        }),
-      ).toBeUndefined()
     })
   })
 


### PR DESCRIPTION
## Summary
- Adds a host adapter detector for Claude Code and Codex that reports launch source, native CLI state, auth state, version, and npx/Bun package cache state.
- Replaces hardcoded GUI PATH candidate lists with an agent-company-style host binary resolver using login-shell lookup on Unix and Windows-native lookup on win32.
- Extends /agents/adapters and the settings UI with actionable readiness states like Ready, Login needed, Install needed, and Fetch on first run.

## Design
Detection is now separate from runtime health: Claude/Codex go through a dedicated detector, while Hermes still maps runtime snapshots. The detector shares ACP adapter package constants with runtime launch code, resolves host binaries before spawning, and only prepends the resolved binary directory for child process execution so npm/node shims can find their interpreter without hardcoded install paths.

## Test plan
- [x] bun --env-file=apps/server/.env.development test apps/server/tests/lib/agents/host-binary-resolver.test.ts apps/server/tests/lib/agents/adapter-detection.test.ts apps/server/tests/lib/agents/bundled-bun.test.ts apps/server/tests/lib/agents/runtime/host-process-agent-runtime.test.ts apps/server/tests/lib/agents/acpx-runtime.test.ts apps/server/tests/api/routes/agents.test.ts apps/agent/entrypoints/app/agents/adapter-health.test.ts
- [x] bunx biome check
- [x] bun run --filter @browseros/server typecheck
- [x] bun run --filter @browseros/agent typecheck
- [x] bun run --filter @browseros/server test:lib
- [x] bun run --filter @browseros/server test:api
- [x] bun run --filter @browseros/agent test apps/agent/entrypoints/app/agents/adapter-health.test.ts apps/agent/entrypoints/app/agent-command/home-agent-card.helpers.test.ts apps/agent/entrypoints/app/agents/useAgents.test.ts
- [x] Manual /agents/adapters route inspection showed Claude and Codex ready with native CLI present, authenticated auth, host-npx launch source, and cached adapter packages on this machine.