### PR TITLE
fix(ci): narrow nightly server release target

### DIFF
--- a/.github/workflows/nightly-macos-build.yml
+++ b/.github/workflows/nightly-macos-build.yml
@@ -137,6 +137,8 @@ jobs:
     uses: ./.github/workflows/release-server.yml
     with:
       version: ${{ needs.resolve_inputs.outputs.server_version }}
+      targets: darwin-arm64
+      publish_github_release: false
     secrets: inherit
 
   build:

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -27,7 +27,14 @@ on:
         description: "Server build targets to publish to R2"
         required: false
         default: all
-        type: string
+        type: choice
+        options:
+          - all
+          - darwin-arm64
+          - darwin-x64
+          - linux-arm64
+          - linux-x64
+          - windows-x64
       publish_github_release:
         description: "Create or update the GitHub server release"
         required: false

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -7,12 +7,32 @@ on:
         description: "Release version (e.g. 0.0.97)"
         required: true
         type: string
+      targets:
+        description: "Server build targets to publish to R2"
+        required: false
+        default: all
+        type: string
+      publish_github_release:
+        description: "Create or update the GitHub server release"
+        required: false
+        default: true
+        type: boolean
   workflow_dispatch:
     inputs:
       version:
         description: "Release version (e.g. 0.0.97)"
         required: true
         type: string
+      targets:
+        description: "Server build targets to publish to R2"
+        required: false
+        default: all
+        type: string
+      publish_github_release:
+        description: "Create or update the GitHub server release"
+        required: false
+        default: true
+        type: boolean
 
 concurrency:
   group: release-server
@@ -80,6 +100,17 @@ jobs:
             exit 1
           fi
 
+      - name: Validate release options
+        env:
+          SERVER_RELEASE_TARGETS: ${{ inputs.targets }}
+          PUBLISH_GITHUB_RELEASE: ${{ inputs.publish_github_release }}
+        run: |
+          set -euo pipefail
+          if [ "$PUBLISH_GITHUB_RELEASE" = "true" ] && [ "$SERVER_RELEASE_TARGETS" != "all" ]; then
+            echo "::error::Set publish_github_release=false when releasing a subset of server targets."
+            exit 1
+          fi
+
       - name: Build and upload release artifacts
         env:
           BROWSEROS_CONFIG_URL: ${{ vars.BROWSEROS_CONFIG_URL || 'https://llm.browseros.com/api/browseros-server/config' }}
@@ -92,7 +123,9 @@ jobs:
           R2_UPLOAD_PREFIX: artifacts/server
           NODE_ENV: production
           LOG_LEVEL: info
-        run: bun run build:server
+          FORCE_COLOR: 1
+          SERVER_RELEASE_TARGETS: ${{ inputs.targets }}
+        run: bun scripts/build/server.ts --target="$SERVER_RELEASE_TARGETS"
 
       - name: Verify release artifacts
         run: |
@@ -106,6 +139,7 @@ jobs:
           printf 'Found release artifacts:\n%s\n' "${ZIP_FILES[@]}"
 
       - name: Generate release notes
+        if: ${{ inputs.publish_github_release }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PACKAGE_VERSION: ${{ steps.version.outputs.package_version }}
@@ -149,6 +183,7 @@ jobs:
         working-directory: ${{ github.workspace }}
 
       - name: Create GitHub release
+        if: ${{ inputs.publish_github_release }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PACKAGE_VERSION: ${{ steps.version.outputs.package_version }}


### PR DESCRIPTION
## Summary

- Add target selection to the reusable server release workflow while keeping full releases as the default.
- Make nightly macOS builds publish only the `darwin-arm64` server resource bundle before packaging.
- Skip GitHub server release creation for the nightly partial artifact upload so it does not publish partial release assets.

## Design

The linked scheduled run failed before the macOS builder started because `release-server.yml` called the all-target server build and hit the Windows executable metadata patch path without Wine. The macOS ARM64 packaging config only downloads `browseros-server-resources-darwin-arm64.zip`, so the nightly caller now asks the reusable workflow for that target only. Manual/full server releases still default to `targets: all` and `publish_github_release: true`.

## Test plan

- `gh run view 26739308048 --json name,event,status,conclusion,headBranch,headSha,createdAt,updatedAt,jobs`
- `gh run view 26739308048 --job 78799287074 --log-failed`
- `bun scripts/build/server.ts --target=darwin-arm64 --ci`
- `go run github.com/rhysd/actionlint/cmd/actionlint@latest -ignore 'label "browseros-builder" is unknown' .github/workflows/release-server.yml .github/workflows/nightly-macos-build.yml`
- `git diff --check`
