### PR TITLE
feat: route agent sessions by conversation

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/App.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/App.tsx
@@ -92,6 +92,10 @@ export const App: FC = () => {
                     path="agents/:agentId"
                     element={<AgentCommandConversation />}
                   />
+                  <Route
+                    path="agents/:agentId/sessions/:sessionId"
+                    element={<AgentCommandConversation />}
+                  />
                 </Route>
                 <Route path="chat" element={<NewTabChat />} />
                 <Route path="personalize" element={<Personalize />} />

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandConversation.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeft } from 'lucide-react'
+import { ArrowLeft, Plus } from 'lucide-react'
 import { type FC, useEffect, useMemo, useRef } from 'react'
 import { Navigate, useNavigate, useParams, useSearchParams } from 'react-router'
 import { Button } from '@/components/ui/button'
@@ -34,11 +34,13 @@ import { useHarnessChatHistory } from './useHarnessChatHistory'
 
 function AgentConversationController({
   agentId,
+  sessionId,
   initialMessage,
   onInitialMessageConsumed,
   agents,
 }: {
   agentId: string
+  sessionId: string
   initialMessage: string | null
   onInitialMessageConsumed: () => void
   agents: AgentEntry[]
@@ -47,7 +49,11 @@ function AgentConversationController({
   const onInitialMessageConsumedRef = useRef(onInitialMessageConsumed)
   const agent = agents.find((entry) => entry.agentId === agentId)
   const agentName = agent?.name || agentId || 'Agent'
-  const harnessHistoryQuery = useHarnessChatHistory(agentId, Boolean(agent))
+  const harnessHistoryQuery = useHarnessChatHistory(
+    agentId,
+    sessionId,
+    Boolean(agent),
+  )
 
   const historyMessages = useMemo(
     () =>
@@ -66,11 +72,14 @@ function AgentConversationController({
   // keeps cross-tab queue state in sync without a second poll.
   const { harnessAgents } = useHarnessAgents()
   const harnessAgent = harnessAgents.find((entry) => entry.id === agentId)
-  const queue = harnessAgent?.queue ?? []
+  const queue = (harnessAgent?.queue ?? []).filter(
+    (entry) => (entry.sessionId ?? 'main') === sessionId,
+  )
   const activeTurnId = harnessAgent?.activeTurnId ?? null
 
   const { turns, streaming, send } = useAgentConversation(agentId, {
     runtime: 'agent-harness',
+    sessionId,
     sessionKey: null,
     history: chatHistory,
     activeTurnId,
@@ -84,6 +93,7 @@ function AgentConversationController({
 
   const handleStop = () => {
     void cancelHarnessTurn(agentId, {
+      sessionId,
       turnId: activeTurnId ?? undefined,
       reason: 'user pressed stop',
     })
@@ -98,7 +108,7 @@ function AgentConversationController({
   const historyReady =
     harnessHistoryQuery.isFetched || harnessHistoryQuery.isError
   const initialMessageKey = initialMessage
-    ? `${agentId}:${initialMessage}`
+    ? `${agentId}:${sessionId}:${initialMessage}`
     : null
   const error = harnessHistoryQuery.error ?? null
 
@@ -113,7 +123,7 @@ function AgentConversationController({
     // present and is the text-only fallback path; the registry wins
     // when both exist because it carries the binary attachments
     // alongside the text.
-    const pending = consumePendingInitialMessage(agentId)
+    const pending = consumePendingInitialMessage(agentId, sessionId)
     if (pending) {
       // Mark the dedup ref so the text-only branch below doesn't
       // re-fire on the same render.
@@ -151,7 +161,14 @@ function AgentConversationController({
     initialMessageSentRef.current = initialMessageKey
     onInitialMessageConsumedRef.current()
     void sendRef.current({ text: query })
-  }, [agentId, disabled, historyReady, initialMessage, initialMessageKey])
+  }, [
+    agentId,
+    disabled,
+    historyReady,
+    initialMessage,
+    initialMessageKey,
+    sessionId,
+  ])
 
   return (
     <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
@@ -198,6 +215,7 @@ function AgentConversationController({
               if (streaming || activeTurnId) {
                 enqueueMessage.mutate({
                   agentId,
+                  sessionId,
                   message: input.text,
                   attachments,
                 })
@@ -246,16 +264,20 @@ export const AgentCommandConversation: FC<AgentCommandConversationProps> = ({
   backPath = '/home',
   agentPathPrefix = '/home/agents',
 }) => {
-  const { agentId } = useParams<{ agentId: string }>()
+  const { agentId, sessionId } = useParams<{
+    agentId: string
+    sessionId?: string
+  }>()
   const [searchParams, setSearchParams] = useSearchParams()
   const navigate = useNavigate()
   const { agents } = useAgentCommandData()
-  const { harnessAgents } = useHarnessAgents()
+  const { harnessAgents, loading: harnessAgentsLoading } = useHarnessAgents()
   const { adapters } = useAgentAdapters()
   const updateAgent = useUpdateHarnessAgent()
 
   const shouldRedirectHome = !agentId
   const resolvedAgentId = agentId ?? ''
+  const resolvedSessionId = sessionId ?? ''
   const harnessAgent = harnessAgents.find(
     (entry) => entry.id === resolvedAgentId,
   )
@@ -278,8 +300,27 @@ export const AgentCommandConversation: FC<AgentCommandConversationProps> = ({
     return <Navigate to="/home" replace />
   }
 
+  if (!resolvedSessionId) {
+    if (harnessAgentsLoading) return null
+    const targetSessionId = harnessAgent?.latestSessionId ?? crypto.randomUUID()
+    const query = initialMessage
+      ? `?q=${encodeURIComponent(initialMessage)}`
+      : ''
+    return (
+      <Navigate
+        to={`${agentPathPrefix}/${resolvedAgentId}/sessions/${targetSessionId}${query}`}
+        replace
+      />
+    )
+  }
+
+  const openAgentSession = (target: HarnessAgent) => {
+    const targetSessionId = target.latestSessionId ?? crypto.randomUUID()
+    navigate(`${agentPathPrefix}/${target.id}/sessions/${targetSessionId}`)
+  }
+
   const handleSelectHarnessAgent = (target: HarnessAgent) => {
-    navigate(`${agentPathPrefix}/${target.id}`)
+    openAgentSession(target)
   }
 
   const handlePinToggle = (target: HarnessAgent | null, next: boolean) => {
@@ -322,6 +363,21 @@ export const AgentCommandConversation: FC<AgentCommandConversationProps> = ({
               onPinToggle={(next) =>
                 handlePinToggle(harnessAgent ?? null, next)
               }
+              headerExtra={
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  onClick={() =>
+                    navigate(
+                      `${agentPathPrefix}/${resolvedAgentId}/sessions/${crypto.randomUUID()}`,
+                    )
+                  }
+                  className="size-8 rounded-xl"
+                  title="New conversation"
+                >
+                  <Plus className="size-4" />
+                </Button>
+              }
             />
           </div>
         </div>
@@ -343,8 +399,9 @@ export const AgentCommandConversation: FC<AgentCommandConversationProps> = ({
 
           <div className="flex h-full min-h-0 flex-col overflow-hidden">
             <AgentConversationController
-              key={resolvedAgentId}
+              key={`${resolvedAgentId}:${resolvedSessionId}`}
               agentId={resolvedAgentId}
+              sessionId={resolvedSessionId}
               agents={agents}
               initialMessage={initialMessage}
               onInitialMessageConsumed={() => {

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandHome.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandHome.tsx
@@ -143,15 +143,21 @@ export const AgentCommandHome: FC = () => {
 
   const handleSend = async (input: ConversationInputSendInput) => {
     if (!selectedProvider) return
-    const route = routeHomeSend(selectedProvider, input.text)
+    const agentSessionId =
+      selectedProvider.kind === 'acp' ? crypto.randomUUID() : undefined
+    const route = routeHomeSend(selectedProvider, input.text, {
+      agentSessionId,
+    })
     if (!route) return
     if (route.kind === 'acp') {
+      if (!agentSessionId) return
       // Stash text + attachments in the in-memory registry. Text also travels
       // in `?q=` so a hard refresh / shareable URL still works for text-only
       // prompts; attachments are registry-only (a multi-MB dataUrl can't ride
       // a URL param). The chat screen prefers the registry when both exist.
       setPendingInitialMessage({
         agentId: route.agentId,
+        sessionId: agentSessionId,
         text: input.text,
         attachments: input.attachments,
         createdAt: Date.now(),
@@ -216,7 +222,13 @@ export const AgentCommandHome: FC = () => {
               agents={orderedAgents}
               adapters={adapters}
               onOpenAgents={() => navigate(manageAgentsPath)}
-              onSelectAgent={(agentId) => navigate(`/home/agents/${agentId}`)}
+              onSelectAgent={(agentId) => {
+                const agent = orderedAgents.find(
+                  (entry) => entry.id === agentId,
+                )
+                const sessionId = agent?.latestSessionId ?? crypto.randomUUID()
+                navigate(`/home/agents/${agentId}/sessions/${sessionId}`)
+              }}
             />
           </>
         ) : null}

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/harness-history-mapper.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/harness-history-mapper.ts
@@ -34,7 +34,7 @@ export function mapHarnessHistoryPage(
       text: item.text,
       timestamp: item.createdAt,
       messageSeq: index + 1,
-      sessionKey: 'main',
+      sessionKey: page.sessionId,
       source: 'user-chat',
       ...(item.reasoning ? { reasoning: item.reasoning } : {}),
       ...(toolCalls && toolCalls.length > 0 ? { toolCalls } : {}),
@@ -47,11 +47,11 @@ export function mapHarnessHistoryPage(
 
   return {
     agentId: page.agentId,
-    sessionKey: 'main',
+    sessionKey: page.sessionId,
     session: {
-      key: 'main',
+      key: page.sessionId,
       updatedAt,
-      sessionId: 'main',
+      sessionId: page.sessionId,
       agentId: page.agentId,
       kind: 'agent-harness',
       source: 'user-chat',

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/home-compose.helpers.test.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/home-compose.helpers.test.ts
@@ -26,10 +26,14 @@ describe('routeHomeSend', () => {
   })
 
   it('routes a named agent to its harness conversation', () => {
-    expect(routeHomeSend(acp, 'do a thing')).toEqual({
+    expect(
+      routeHomeSend(acp, 'do a thing', {
+        agentSessionId: '00000000-0000-4000-8000-000000000001',
+      }),
+    ).toEqual({
       kind: 'acp',
       agentId: 'agent-1',
-      path: '/home/agents/agent-1?q=do%20a%20thing',
+      path: '/home/agents/agent-1/sessions/00000000-0000-4000-8000-000000000001?q=do%20a%20thing',
     })
   })
 
@@ -50,6 +54,14 @@ describe('routeHomeSend', () => {
       type: 'acp',
       kind: 'acp',
     }
-    expect(routeHomeSend(acpNoId, 'hello')).toBeNull()
+    expect(
+      routeHomeSend(acpNoId, 'hello', {
+        agentSessionId: '00000000-0000-4000-8000-000000000001',
+      }),
+    ).toBeNull()
+  })
+
+  it('returns null for an acp target without a session id', () => {
+    expect(routeHomeSend(acp, 'hello')).toBeNull()
   })
 })

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/home-compose.helpers.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/home-compose.helpers.ts
@@ -14,6 +14,7 @@ export type HomeSendRoute =
 export function routeHomeSend(
   provider: Provider,
   text: string,
+  options: { agentSessionId?: string } = {},
 ): HomeSendRoute | null {
   const query = text.trim()
   if (!query) return null
@@ -21,11 +22,11 @@ export function routeHomeSend(
   if (provider.kind === 'acp') {
     // A malformed acp target (missing agentId) must not silently misroute to
     // the LLM chat with the agent id treated as a provider id — fail visibly.
-    if (!provider.agentId) return null
+    if (!provider.agentId || !options.agentSessionId) return null
     return {
       kind: 'acp',
       agentId: provider.agentId,
-      path: `/home/agents/${provider.agentId}?q=${encoded}`,
+      path: `/home/agents/${provider.agentId}/sessions/${options.agentSessionId}?q=${encoded}`,
     }
   }
   return {

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/pending-initial-message.test.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/pending-initial-message.test.ts
@@ -25,21 +25,23 @@ function makeAttachment(id: string): StagedAttachment {
 afterEach(() => {
   // Drain any leftover pending entry so tests don't leak into each
   // other (the module-scope state survives across `it` blocks).
-  consumePendingInitialMessage('drain')
+  consumePendingInitialMessage('drain', 'session-drain')
   // If still set, clear by consuming with the matching id.
   const leftover = peekPendingInitialMessage()
-  if (leftover) consumePendingInitialMessage(leftover.agentId)
+  if (leftover)
+    consumePendingInitialMessage(leftover.agentId, leftover.sessionId)
 })
 
 describe('pending-initial-message', () => {
   it('consume returns the payload set for the same agentId', () => {
     setPendingInitialMessage({
       agentId: 'agent-a',
+      sessionId: 'session-a',
       text: 'hello',
       attachments: [makeAttachment('one')],
       createdAt: Date.now(),
     })
-    const result = consumePendingInitialMessage('agent-a')
+    const result = consumePendingInitialMessage('agent-a', 'session-a')
     expect(result?.text).toBe('hello')
     expect(result?.attachments).toHaveLength(1)
     expect(result?.attachments[0]?.id).toBe('one')
@@ -48,51 +50,57 @@ describe('pending-initial-message', () => {
   it('consume is destructive — second call returns null', () => {
     setPendingInitialMessage({
       agentId: 'agent-a',
+      sessionId: 'session-a',
       text: 'hello',
       attachments: [],
       createdAt: Date.now(),
     })
-    expect(consumePendingInitialMessage('agent-a')).not.toBeNull()
-    expect(consumePendingInitialMessage('agent-a')).toBeNull()
+    expect(consumePendingInitialMessage('agent-a', 'session-a')).not.toBeNull()
+    expect(consumePendingInitialMessage('agent-a', 'session-a')).toBeNull()
   })
 
-  it('consume returns null and preserves entry when agentId differs', () => {
+  it('consume returns null and preserves entry when agentId or sessionId differs', () => {
     setPendingInitialMessage({
       agentId: 'agent-a',
+      sessionId: 'session-a',
       text: 'hello',
       attachments: [],
       createdAt: Date.now(),
     })
-    expect(consumePendingInitialMessage('agent-b')).toBeNull()
+    expect(consumePendingInitialMessage('agent-b', 'session-a')).toBeNull()
+    expect(consumePendingInitialMessage('agent-a', 'session-b')).toBeNull()
     expect(peekPendingInitialMessage()?.agentId).toBe('agent-a')
-    expect(consumePendingInitialMessage('agent-a')).not.toBeNull()
+    expect(consumePendingInitialMessage('agent-a', 'session-a')).not.toBeNull()
   })
 
   it('returns null for entries older than the TTL', () => {
     setPendingInitialMessage({
       agentId: 'agent-a',
+      sessionId: 'session-a',
       text: 'old',
       attachments: [],
       createdAt: Date.now() - 11_000, // older than 10 s TTL
     })
-    expect(consumePendingInitialMessage('agent-a')).toBeNull()
+    expect(consumePendingInitialMessage('agent-a', 'session-a')).toBeNull()
   })
 
   it('replaces a previous pending entry when set is called again', () => {
     setPendingInitialMessage({
       agentId: 'agent-a',
+      sessionId: 'session-a',
       text: 'first',
       attachments: [],
       createdAt: Date.now(),
     })
     setPendingInitialMessage({
       agentId: 'agent-b',
+      sessionId: 'session-b',
       text: 'second',
       attachments: [makeAttachment('two')],
       createdAt: Date.now(),
     })
-    expect(consumePendingInitialMessage('agent-a')).toBeNull()
-    const result = consumePendingInitialMessage('agent-b')
+    expect(consumePendingInitialMessage('agent-a', 'session-a')).toBeNull()
+    const result = consumePendingInitialMessage('agent-b', 'session-b')
     expect(result?.text).toBe('second')
     expect(result?.attachments[0]?.id).toBe('two')
   })
@@ -100,6 +108,18 @@ describe('pending-initial-message', () => {
   it('no-ops when set is called with empty agentId', () => {
     setPendingInitialMessage({
       agentId: '',
+      sessionId: 'session-a',
+      text: 'oops',
+      attachments: [],
+      createdAt: Date.now(),
+    })
+    expect(peekPendingInitialMessage()).toBeNull()
+  })
+
+  it('no-ops when set is called with empty sessionId', () => {
+    setPendingInitialMessage({
+      agentId: 'agent-a',
+      sessionId: '',
       text: 'oops',
       attachments: [],
       createdAt: Date.now(),

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/pending-initial-message.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/pending-initial-message.ts
@@ -2,8 +2,8 @@ import type { StagedAttachment } from '@/lib/attachments'
 
 /**
  * Same-tab in-memory handoff between the `/home` composer and the
- * chat screen at `/home/agents/:agentId`. URL search params (`?q=`)
- * carry the text fine, but cannot carry binary attachments — a multi-
+ * chat screen at `/home/agents/:agentId/sessions/:sessionId`. URL search
+ * params (`?q=`) carry the text fine, but cannot carry binary attachments — a multi-
  * megabyte image dataUrl would explode URL length limits and round-
  * trip badly. This module is the rich-data side channel for the same
  * navigation: the composer writes here, the chat screen reads here on
@@ -19,6 +19,7 @@ import type { StagedAttachment } from '@/lib/attachments'
 
 export interface PendingInitialMessage {
   agentId: string
+  sessionId: string
   text: string
   attachments: StagedAttachment[]
   createdAt: number
@@ -47,7 +48,7 @@ export function setPendingInitialMessage(payload: PendingInitialMessage): void {
   // Defensive: the home composer should never call this without an
   // agent selected. If it somehow does, no-op rather than holding a
   // payload we can't route.
-  if (!payload.agentId) return
+  if (!payload.agentId || !payload.sessionId) return
   clearPending()
   pending = payload
   pendingTimer = setTimeout(clearPending, PENDING_TTL_MS)
@@ -60,9 +61,11 @@ export function setPendingInitialMessage(payload: PendingInitialMessage): void {
  */
 export function consumePendingInitialMessage(
   agentId: string,
+  sessionId: string,
 ): PendingInitialMessage | null {
   if (!pending) return null
   if (pending.agentId !== agentId) return null
+  if (pending.sessionId !== sessionId) return null
   if (Date.now() - pending.createdAt >= PENDING_TTL_MS) {
     clearPending()
     return null

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useAgentConversation.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useAgentConversation.ts
@@ -29,6 +29,7 @@ export interface SendInput {
 
 interface UseAgentConversationOptions {
   runtime?: 'agent-harness'
+  sessionId?: string
   sessionKey?: string | null
   history?: AgentChatHistoryMessage[]
   onComplete?: () => void
@@ -57,6 +58,7 @@ export function useAgentConversation(
   const streamAbortRef = useRef<AbortController | null>(null)
   const onCompleteRef = useRef(options.onComplete)
   const onSessionKeyChangeRef = useRef(options.onSessionKeyChange)
+  const sessionIdRef = useRef(options.sessionId ?? 'main')
   // Per-turn resume bookkeeping. `turnId` is captured from the response
   // header; `lastSeq` advances with every SSE event so a reconnect can
   // resume via Last-Event-ID.
@@ -66,6 +68,10 @@ export function useAgentConversation(
   useEffect(() => {
     sessionKeyRef.current = options.sessionKey ?? ''
   }, [options.sessionKey])
+
+  useEffect(() => {
+    sessionIdRef.current = options.sessionId ?? 'main'
+  }, [options.sessionId])
 
   useEffect(() => {
     historyRef.current = options.history ?? []
@@ -243,7 +249,10 @@ export function useAgentConversation(
       // Stop button drops out mid-turn while events keep arriving.
       let weStartedStream = false
       try {
-        const active = await fetchActiveHarnessTurn(agentId)
+        const active = await fetchActiveHarnessTurn(
+          agentId,
+          sessionIdRef.current,
+        )
         if (cancelled || !active || active.status !== 'running') return
         if (streamAbortRef.current) return // someone else already owns the stream
 
@@ -272,6 +281,7 @@ export function useAgentConversation(
         weStartedStream = true
 
         const response = await attachToHarnessTurn(agentId, {
+          sessionId: sessionIdRef.current,
           turnId: active.turnId,
           signal: abortController.signal,
         })
@@ -327,12 +337,12 @@ export function useAgentConversation(
     attachments: ServerAttachmentPayload[],
     signal: AbortSignal,
   ): Promise<Response> => {
-    const initial = await chatWithHarnessAgent(
-      targetAgentId,
-      text,
+    const sessionId = sessionIdRef.current
+    const initial = await chatWithHarnessAgent(targetAgentId, text, {
+      sessionId,
       signal,
       attachments,
-    )
+    })
     if (initial.status !== 409) return initial
     // 409 means the server already has an active turn for this agent
     // (a previous tab kicked one off and we're a fresh mount that
@@ -340,6 +350,7 @@ export function useAgentConversation(
     const body = (await initial.json()) as { turnId?: string }
     if (!body.turnId) return initial
     return attachToHarnessTurn(targetAgentId, {
+      sessionId,
       turnId: body.turnId,
       signal,
     })
@@ -446,6 +457,7 @@ export function useAgentConversation(
     streamAbortRef.current = null
     try {
       await cancelHarnessTurn(agentId, {
+        sessionId: sessionIdRef.current,
         turnId,
         reason: 'user pressed stop',
       })

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useHarnessChatHistory.test.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useHarnessChatHistory.test.ts
@@ -52,4 +52,17 @@ describe('mapHarnessHistoryPage', () => {
       },
     ])
   })
+
+  it('preserves non-main harness session ids', () => {
+    const sessionId = '00000000-0000-4000-8000-000000000001'
+    const page = mapHarnessHistoryPage({
+      agentId: 'agent-1',
+      sessionId,
+      items: [],
+    })
+
+    expect(page.sessionKey).toBe(sessionId)
+    expect(page.session?.key).toBe(sessionId)
+    expect(page.session?.sessionId).toBe(sessionId)
+  })
 })

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useHarnessChatHistory.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/useHarnessChatHistory.ts
@@ -6,7 +6,11 @@ import { mapHarnessHistoryPage } from './harness-history-mapper'
 
 const HISTORY_QUERY_KEY = 'harness-agent-history'
 
-export function useHarnessChatHistory(agentId: string, enabled = true) {
+export function useHarnessChatHistory(
+  agentId: string,
+  sessionId = 'main',
+  enabled = true,
+) {
   const {
     baseUrl,
     isLoading: urlLoading,
@@ -14,9 +18,11 @@ export function useHarnessChatHistory(agentId: string, enabled = true) {
   } = useAgentServerUrl()
 
   const query = useQuery<AgentHistoryPageResponse, Error>({
-    queryKey: [HISTORY_QUERY_KEY, baseUrl, agentId, 'main'],
+    queryKey: [HISTORY_QUERY_KEY, baseUrl, agentId, sessionId],
     queryFn: async () => {
-      return mapHarnessHistoryPage(await fetchHarnessAgentHistory(agentId))
+      return mapHarnessHistoryPage(
+        await fetchHarnessAgentHistory(agentId, sessionId),
+      )
     },
     enabled: Boolean(baseUrl) && !urlLoading && enabled && Boolean(agentId),
   })

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-harness-types.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-harness-types.ts
@@ -77,6 +77,8 @@ export interface HarnessAgent {
   failedByDay?: number[]
   lastError?: string | null
   lastErrorAt?: number | null
+  /** Latest persisted conversation session for this agent. */
+  latestSessionId?: string | null
   /** When non-null, an in-flight turn this row can be resumed from. */
   activeTurnId?: string | null
   /** Persistent FIFO queue of messages waiting for this agent. */
@@ -91,6 +93,7 @@ export interface HarnessQueuedMessageAttachment {
 export interface HarnessQueuedMessage {
   id: string
   createdAt: number
+  sessionId?: string
   message: string
   attachments?: ReadonlyArray<HarnessQueuedMessageAttachment>
 }

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-harness-types.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/agent-harness-types.ts
@@ -164,7 +164,7 @@ export interface HarnessHistoryToolCall {
 export interface HarnessHistoryEntry {
   id: string
   agentId: string
-  sessionId: 'main'
+  sessionId: string
   role: 'user' | 'assistant'
   text: string
   createdAt: number
@@ -174,7 +174,7 @@ export interface HarnessHistoryEntry {
 
 export interface HarnessAgentHistoryPage {
   agentId: string
-  sessionId: 'main'
+  sessionId: string
   items: HarnessHistoryEntry[]
 }
 

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/useAgents.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/useAgents.ts
@@ -219,21 +219,38 @@ export function useDeleteHarnessAgent() {
   })
 }
 
+function buildSessionChatPath(
+  baseUrl: string,
+  agentId: string,
+  sessionId: string,
+): string {
+  const encodedAgent = encodeURIComponent(agentId)
+  if (sessionId === 'main') return `${baseUrl}/agents/${encodedAgent}/chat`
+  return `${baseUrl}/agents/${encodedAgent}/sessions/${encodeURIComponent(sessionId)}/chat`
+}
+
 export async function chatWithHarnessAgent(
   agentId: string,
   message: string,
-  signal?: AbortSignal,
-  attachments?: ReadonlyArray<unknown>,
+  options: {
+    sessionId?: string
+    signal?: AbortSignal
+    attachments?: ReadonlyArray<unknown>
+  } = {},
 ): Promise<Response> {
   const baseUrl = await getAgentServerUrl()
-  return fetch(`${baseUrl}/agents/${encodeURIComponent(agentId)}/chat`, {
+  const sessionId = options.sessionId ?? 'main'
+  const path = buildSessionChatPath(baseUrl, agentId, sessionId)
+  return fetch(path, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({
       message,
-      ...(attachments && attachments.length > 0 ? { attachments } : {}),
+      ...(options.attachments && options.attachments.length > 0
+        ? { attachments: options.attachments }
+        : {}),
     }),
-    signal,
+    signal: options.signal,
   })
 }
 
@@ -245,11 +262,17 @@ export async function chatWithHarnessAgent(
  */
 export async function attachToHarnessTurn(
   agentId: string,
-  options: { turnId?: string; lastSeq?: number; signal?: AbortSignal } = {},
+  options: {
+    sessionId?: string
+    turnId?: string
+    lastSeq?: number
+    signal?: AbortSignal
+  } = {},
 ): Promise<Response> {
   const baseUrl = await getAgentServerUrl()
+  const sessionId = options.sessionId ?? 'main'
   const url = new URL(
-    `${baseUrl}/agents/${encodeURIComponent(agentId)}/chat/stream`,
+    `${buildSessionChatPath(baseUrl, agentId, sessionId)}/stream`,
   )
   if (options.turnId) url.searchParams.set('turnId', options.turnId)
   const headers: Record<string, string> = {}
@@ -277,10 +300,11 @@ export interface HarnessActiveTurnInfo {
  */
 export async function fetchActiveHarnessTurn(
   agentId: string,
+  sessionId = 'main',
 ): Promise<HarnessActiveTurnInfo | null> {
   const baseUrl = await getAgentServerUrl()
   const response = await fetch(
-    `${baseUrl}/agents/${encodeURIComponent(agentId)}/chat/active`,
+    `${buildSessionChatPath(baseUrl, agentId, sessionId)}/active`,
   )
   if (!response.ok) return null
   const body = (await response.json()) as {
@@ -296,11 +320,11 @@ export async function fetchActiveHarnessTurn(
  */
 export async function cancelHarnessTurn(
   agentId: string,
-  options: { turnId?: string; reason?: string } = {},
+  options: { sessionId?: string; turnId?: string; reason?: string } = {},
 ): Promise<{ cancelled: boolean }> {
   const baseUrl = await getAgentServerUrl()
   const response = await fetch(
-    `${baseUrl}/agents/${encodeURIComponent(agentId)}/chat/cancel`,
+    `${buildSessionChatPath(baseUrl, agentId, options.sessionId ?? 'main')}/cancel`,
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -326,6 +350,7 @@ export async function fetchHarnessAgentHistory(
 }
 
 export interface EnqueueMessageInput {
+  sessionId?: string
   message: string
   attachments?: ReadonlyArray<unknown>
 }
@@ -335,19 +360,22 @@ export async function enqueueHarnessMessage(
   input: EnqueueMessageInput,
 ): Promise<HarnessQueuedMessage> {
   const baseUrl = await getAgentServerUrl()
-  const response = await fetch(
-    `${baseUrl}/agents/${encodeURIComponent(agentId)}/queue`,
-    {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        message: input.message,
-        ...(input.attachments && input.attachments.length > 0
-          ? { attachments: input.attachments }
-          : {}),
-      }),
-    },
-  )
+  const sessionId = input.sessionId ?? 'main'
+  const path =
+    sessionId === 'main'
+      ? `${baseUrl}/agents/${encodeURIComponent(agentId)}/queue`
+      : `${baseUrl}/agents/${encodeURIComponent(agentId)}/sessions/${encodeURIComponent(sessionId)}/queue`
+  const response = await fetch(path, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      sessionId: input.sessionId,
+      message: input.message,
+      ...(input.attachments && input.attachments.length > 0
+        ? { attachments: input.attachments }
+        : {}),
+    }),
+  })
   if (!response.ok) {
     let message = `Request failed with status ${response.status}`
     try {
@@ -395,6 +423,7 @@ export function useEnqueueHarnessMessage() {
       const optimistic: HarnessQueuedMessage = {
         id: `optimistic-${Math.random().toString(36).slice(2, 10)}`,
         createdAt: Date.now(),
+        sessionId: input.sessionId,
         message: input.message,
       }
       queryClient.setQueryData<HarnessAgentsResponse>(queryKey, {

--- a/packages/browseros-agent/apps/agent/entrypoints/app/agents/useAgents.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agents/useAgents.ts
@@ -262,7 +262,7 @@ export async function attachToHarnessTurn(
 export interface HarnessActiveTurnInfo {
   turnId: string
   agentId: string
-  sessionId: 'main'
+  sessionId: string
   status: 'running' | 'done' | 'error' | 'cancelled'
   lastSeq: number
   startedAt: number
@@ -316,11 +316,12 @@ export async function cancelHarnessTurn(
 
 export async function fetchHarnessAgentHistory(
   agentId: string,
+  sessionId = 'main',
 ): Promise<HarnessAgentHistoryPage> {
   const baseUrl = await getAgentServerUrl()
   return agentsFetch<HarnessAgentHistoryPage>(
     baseUrl,
-    `/${encodeURIComponent(agentId)}/sessions/main/history`,
+    `/${encodeURIComponent(agentId)}/sessions/${encodeURIComponent(sessionId)}/history`,
   )
 }
 

--- a/packages/browseros-agent/apps/agent/entrypoints/newtab/layout/NewTabLayout.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/newtab/layout/NewTabLayout.tsx
@@ -26,9 +26,5 @@ export const NewTabLayout: FC<NewTabLayoutProps> = ({
 
   if (!useChatSession) return content
 
-  return (
-    <ChatSessionProvider origin="newtab" agentSessionStrategy="main">
-      {content}
-    </ChatSessionProvider>
-  )
+  return <ChatSessionProvider origin="newtab">{content}</ChatSessionProvider>
 }

--- a/packages/browseros-agent/apps/agent/entrypoints/newtab/layout/NewTabLayout.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/newtab/layout/NewTabLayout.tsx
@@ -26,5 +26,9 @@ export const NewTabLayout: FC<NewTabLayoutProps> = ({
 
   if (!useChatSession) return content
 
-  return <ChatSessionProvider origin="newtab">{content}</ChatSessionProvider>
+  return (
+    <ChatSessionProvider origin="newtab" agentSessionStrategy="main">
+      {content}
+    </ChatSessionProvider>
+  )
 }

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSession.test.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSession.test.ts
@@ -54,6 +54,7 @@ describe('buildSidepanelPreparedSendMessagesRequest', () => {
     )
     expect(request.body).toEqual({
       conversationId,
+      agentSessionId: conversationId,
       message: 'Inspect the current tab',
       browserContext: {
         activeTab: { id: 10, url: 'https://example.com', title: 'Example' },
@@ -66,6 +67,23 @@ describe('buildSidepanelPreparedSendMessagesRequest', () => {
         url: 'https://example.com',
         title: 'Example',
       },
+    })
+  })
+
+  it('can send created-agent targets through the main agent session', () => {
+    const request = buildSidepanelPreparedSendMessagesRequest({
+      agentServerUrl: 'http://127.0.0.1:5151',
+      target: acpTarget,
+      fallbackProvider,
+      agentSessionId: 'main',
+      message: 'Inspect from new tab',
+      ...commonRequestInput(),
+    })
+
+    expect(request.body).toMatchObject({
+      conversationId,
+      agentSessionId: 'main',
+      message: 'Inspect from new tab',
     })
   })
 

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -89,7 +89,7 @@ export type AgentSessionStrategy = 'conversation' | 'main'
 
 export interface ChatSessionOptions {
   origin?: ChatOrigin
-  /** ACP agent session id source. Defaults to `main` on new tab, conversation id elsewhere. */
+  /** ACP agent session id source. Defaults to the conversation id. */
   agentSessionStrategy?: AgentSessionStrategy
   /** When false, messages are queued until integrations finish syncing. */
   isIntegrationsSynced?: boolean
@@ -354,8 +354,7 @@ export const useChatSession = (options?: ChatSessionOptions) => {
           personalizationRef.current,
         )
         const agentSessionStrategy =
-          options?.agentSessionStrategy ??
-          (options?.origin === 'newtab' ? 'main' : 'conversation')
+          options?.agentSessionStrategy ?? 'conversation'
         const agentSessionId =
           agentSessionStrategy === 'main' ? 'main' : conversationIdRef.current
 

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSession.ts
@@ -85,9 +85,12 @@ export const getResponseAndQueryFromMessageId = (
 }
 
 export type ChatOrigin = 'sidepanel' | 'newtab'
+export type AgentSessionStrategy = 'conversation' | 'main'
 
 export interface ChatSessionOptions {
   origin?: ChatOrigin
+  /** ACP agent session id source. Defaults to `main` on new tab, conversation id elsewhere. */
+  agentSessionStrategy?: AgentSessionStrategy
   /** When false, messages are queued until integrations finish syncing. */
   isIntegrationsSynced?: boolean
 }
@@ -350,9 +353,15 @@ export const useChatSession = (options?: ChatSessionOptions) => {
           options?.origin,
           personalizationRef.current,
         )
+        const agentSessionStrategy =
+          options?.agentSessionStrategy ??
+          (options?.origin === 'newtab' ? 'main' : 'conversation')
+        const agentSessionId =
+          agentSessionStrategy === 'main' ? 'main' : conversationIdRef.current
 
         const commonRequest = {
           conversationId: conversationIdRef.current,
+          agentSessionId,
           mode: currentMode,
           browserContext: requestBrowserContext,
           userSystemPrompt,

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSessionRequest.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatSessionRequest.ts
@@ -18,6 +18,7 @@ interface BuildSidepanelPreparedSendMessagesRequestInput
   agentServerUrl: string
   target: SidepanelChatTarget | undefined
   fallbackProvider: LlmProviderConfig
+  agentSessionId?: string
   message?: string
 }
 
@@ -25,6 +26,7 @@ export function buildSidepanelPreparedSendMessagesRequest({
   agentServerUrl,
   target,
   fallbackProvider,
+  agentSessionId,
   message,
   ...common
 }: BuildSidepanelPreparedSendMessagesRequestInput) {
@@ -33,6 +35,7 @@ export function buildSidepanelPreparedSendMessagesRequest({
       api: `${agentServerUrl}/agents/${encodeURIComponent(target.agentId)}/sidepanel/chat`,
       body: {
         conversationId: common.conversationId,
+        agentSessionId: agentSessionId ?? common.conversationId,
         message: message ?? '',
         browserContext: common.browserContext,
         userSystemPrompt: common.userSystemPrompt,

--- a/packages/browseros-agent/apps/server/src/api/routes/agents.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/agents.ts
@@ -21,9 +21,11 @@ import {
   isSupportedReasoningEffort,
 } from '../../lib/agents/adapters/catalog'
 import { AdapterHealthChecker } from '../../lib/agents/adapters/health'
-import type {
-  AgentAdapter,
-  AgentDefinition,
+import {
+  type AgentAdapter,
+  type AgentDefinition,
+  type AgentSessionId,
+  MAIN_AGENT_SESSION_ID,
 } from '../../lib/agents/agent-types'
 import type {
   ActiveTurnInfo,
@@ -64,9 +66,13 @@ type AgentRouteService = {
     agentId: string,
     patch: { name?: string; pinned?: boolean },
   ): Promise<AgentDefinition | null>
-  getHistory(agentId: string): Promise<AgentHistoryPage>
+  getHistory(
+    agentId: string,
+    sessionId?: AgentSessionId,
+  ): Promise<AgentHistoryPage>
   startTurn(input: {
     agentId: string
+    sessionId?: AgentSessionId
     message: string
     attachments?: ReadonlyArray<{ mediaType: string; data: string }>
     cwd?: string
@@ -75,9 +81,13 @@ type AgentRouteService = {
     turnId: string
     lastSeq?: number
   }): ReadableStream<TurnFrame> | null
-  getActiveTurn(agentId: string, sessionId?: 'main'): ActiveTurnInfo | null
+  getActiveTurn(
+    agentId: string,
+    sessionId?: AgentSessionId,
+  ): ActiveTurnInfo | null
   cancelTurn(input: {
     agentId: string
+    sessionId?: AgentSessionId
     turnId?: string
     reason?: string
   }): boolean
@@ -107,6 +117,7 @@ type AgentRouteDeps = {
 
 type SidepanelAgentChatRequest = {
   conversationId: string
+  agentSessionId: AgentSessionId
   message: string
   browserContext?: BrowserContext
   selectedText?: string
@@ -188,6 +199,7 @@ export function createAgentRoutes(deps: AgentRouteDeps = {}) {
         try {
           started = await service.startTurn({
             agentId: agent.id,
+            sessionId: parsed.agentSessionId,
             message,
             cwd: parsed.userWorkingDir,
           })
@@ -211,6 +223,7 @@ export function createAgentRoutes(deps: AgentRouteDeps = {}) {
           didRequestCancel = true
           service.cancelTurn({
             agentId: agent.id,
+            sessionId: parsed.agentSessionId,
             turnId: started.turnId,
             reason: 'sidepanel stream cancelled',
           })
@@ -229,7 +242,7 @@ export function createAgentRoutes(deps: AgentRouteDeps = {}) {
 
         return createAcpUIMessageStreamResponse(events, {
           headers: {
-            'X-Session-Id': 'main',
+            'X-Session-Id': parsed.agentSessionId,
             'X-Turn-Id': started.turnId,
           },
         })
@@ -269,9 +282,15 @@ export function createAgentRoutes(deps: AgentRouteDeps = {}) {
         return handleAgentRouteError(c, err)
       }
     })
-    .get('/:agentId/sessions/main/history', async (c) => {
+    .get('/:agentId/sessions/:sessionId/history', async (c) => {
+      const sessionId = c.req.param('sessionId')
+      if (!isAgentSessionId(sessionId)) {
+        return c.json({ error: 'sessionId must be "main" or a UUID' }, 400)
+      }
       try {
-        return c.json(await service.getHistory(c.req.param('agentId')))
+        return c.json(
+          await service.getHistory(c.req.param('agentId'), sessionId),
+        )
       } catch (err) {
         return handleAgentRouteError(c, err)
       }
@@ -310,7 +329,7 @@ export function createAgentRoutes(deps: AgentRouteDeps = {}) {
     })
     .get('/:agentId/chat/active', (c) => {
       const agentId = c.req.param('agentId')
-      const info = service.getActiveTurn(agentId, 'main')
+      const info = service.getActiveTurn(agentId, MAIN_AGENT_SESSION_ID)
       return c.json({ active: info })
     })
     .get('/:agentId/chat/stream', (c) => {
@@ -318,7 +337,8 @@ export function createAgentRoutes(deps: AgentRouteDeps = {}) {
       const url = new URL(c.req.url)
       const queryTurnId = url.searchParams.get('turnId')?.trim() || undefined
       const turnId =
-        queryTurnId ?? service.getActiveTurn(agentId, 'main')?.turnId
+        queryTurnId ??
+        service.getActiveTurn(agentId, MAIN_AGENT_SESSION_ID)?.turnId
       if (!turnId) {
         return c.json({ error: 'No active turn for this agent' }, 404)
       }
@@ -445,7 +465,7 @@ function streamTurnFrames(
 ) {
   c.header('Content-Type', 'text/event-stream')
   c.header('Cache-Control', 'no-cache')
-  c.header('X-Session-Id', 'main')
+  c.header('X-Session-Id', MAIN_AGENT_SESSION_ID)
   c.header('X-Turn-Id', options.turnId)
 
   return stream(c, async (s) => {
@@ -673,6 +693,12 @@ async function parseSidepanelAgentChatBody(
     return { error: 'conversationId must be a UUID' }
   }
 
+  const agentSessionId =
+    readOptionalTrimmedString(record, 'agentSessionId') ?? conversationId
+  if (!isAgentSessionId(agentSessionId)) {
+    return { error: 'agentSessionId must be "main" or a UUID' }
+  }
+
   const message = readOptionalTrimmedString(record, 'message')
   if (!message) return { error: 'Message is required' }
 
@@ -685,6 +711,7 @@ async function parseSidepanelAgentChatBody(
 
   return {
     conversationId,
+    agentSessionId,
     message,
     browserContext: browserContext.value,
     selectedText,
@@ -736,6 +763,10 @@ function isUuid(value: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(
     value,
   )
+}
+
+function isAgentSessionId(value: string): value is AgentSessionId {
+  return value === MAIN_AGENT_SESSION_ID || isUuid(value)
 }
 
 async function readJsonBody(

--- a/packages/browseros-agent/apps/server/src/api/routes/agents.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/agents.ts
@@ -93,6 +93,7 @@ type AgentRouteService = {
   }): boolean
   enqueueMessage(input: {
     agentId: string
+    sessionId?: AgentSessionId
     message: string
     attachments?: ReadonlyArray<{ mediaType: string; data: string }>
   }): Promise<QueuedMessage>
@@ -300,31 +301,22 @@ export function createAgentRoutes(deps: AgentRouteDeps = {}) {
       const parsed = await parseChatBody(c)
       if ('error' in parsed) return c.json({ error: parsed.error }, 400)
 
-      let started: { turnId: string; frames: ReadableStream<TurnFrame> }
-      try {
-        started = await service.startTurn({
-          agentId,
-          message: parsed.message,
-          attachments: parsed.attachments,
-          cwd: parsed.cwd,
-        })
-      } catch (err) {
-        if (err instanceof TurnAlreadyActiveError) {
-          // Caller can attach via GET /chat/stream?turnId=… instead.
-          return c.json(
-            {
-              error: 'Turn already active',
-              turnId: err.turnId,
-              attachUrl: `/agents/${agentId}/chat/stream?turnId=${err.turnId}`,
-            },
-            409,
-          )
-        }
-        return handleAgentRouteError(c, err)
-      }
+      return startChatTurnResponse(c, service, {
+        agentId,
+        sessionId: MAIN_AGENT_SESSION_ID,
+        parsed,
+      })
+    })
+    .post('/:agentId/sessions/:sessionId/chat', async (c) => {
+      const sessionId = parseSessionIdParam(c)
+      if ('error' in sessionId) return c.json({ error: sessionId.error }, 400)
+      const parsed = await parseChatBody(c)
+      if ('error' in parsed) return c.json({ error: parsed.error }, 400)
 
-      return streamTurnFrames(c, started.frames, {
-        turnId: started.turnId,
+      return startChatTurnResponse(c, service, {
+        agentId: c.req.param('agentId'),
+        sessionId: sessionId.value,
+        parsed,
       })
     })
     .get('/:agentId/chat/active', (c) => {
@@ -332,26 +324,29 @@ export function createAgentRoutes(deps: AgentRouteDeps = {}) {
       const info = service.getActiveTurn(agentId, MAIN_AGENT_SESSION_ID)
       return c.json({ active: info })
     })
+    .get('/:agentId/sessions/:sessionId/chat/active', (c) => {
+      const sessionId = parseSessionIdParam(c)
+      if ('error' in sessionId) return c.json({ error: sessionId.error }, 400)
+      const info = service.getActiveTurn(
+        c.req.param('agentId'),
+        sessionId.value,
+      )
+      return c.json({ active: info })
+    })
     .get('/:agentId/chat/stream', (c) => {
       const agentId = c.req.param('agentId')
-      const url = new URL(c.req.url)
-      const queryTurnId = url.searchParams.get('turnId')?.trim() || undefined
-      const turnId =
-        queryTurnId ??
-        service.getActiveTurn(agentId, MAIN_AGENT_SESSION_ID)?.turnId
-      if (!turnId) {
-        return c.json({ error: 'No active turn for this agent' }, 404)
-      }
-      const lastEventId =
-        c.req.header('Last-Event-ID') ??
-        url.searchParams.get('lastSeq') ??
-        undefined
-      const lastSeq = parseLastSeq(lastEventId)
-      const frames = service.attachTurn({ turnId, lastSeq })
-      if (!frames) {
-        return c.json({ error: 'Unknown turn' }, 404)
-      }
-      return streamTurnFrames(c, frames, { turnId })
+      return streamExistingTurn(c, service, {
+        agentId,
+        sessionId: MAIN_AGENT_SESSION_ID,
+      })
+    })
+    .get('/:agentId/sessions/:sessionId/chat/stream', (c) => {
+      const sessionId = parseSessionIdParam(c)
+      if ('error' in sessionId) return c.json({ error: sessionId.error }, 400)
+      return streamExistingTurn(c, service, {
+        agentId: c.req.param('agentId'),
+        sessionId: sessionId.value,
+      })
     })
     .post('/:agentId/chat/cancel', async (c) => {
       const agentId = c.req.param('agentId')
@@ -365,6 +360,26 @@ export function createAgentRoutes(deps: AgentRouteDeps = {}) {
           ? body.value.reason
           : undefined
       const cancelled = service.cancelTurn({ agentId, turnId, reason })
+      return c.json({ cancelled })
+    })
+    .post('/:agentId/sessions/:sessionId/chat/cancel', async (c) => {
+      const sessionId = parseSessionIdParam(c)
+      if ('error' in sessionId) return c.json({ error: sessionId.error }, 400)
+      const body = await readJsonBody(c)
+      const turnId =
+        'value' in body && typeof body.value.turnId === 'string'
+          ? body.value.turnId.trim() || undefined
+          : undefined
+      const reason =
+        'value' in body && typeof body.value.reason === 'string'
+          ? body.value.reason
+          : undefined
+      const cancelled = service.cancelTurn({
+        agentId: c.req.param('agentId'),
+        sessionId: sessionId.value,
+        turnId,
+        reason,
+      })
       return c.json({ cancelled })
     })
     .get('/:agentId/queue', async (c) => {
@@ -381,6 +396,24 @@ export function createAgentRoutes(deps: AgentRouteDeps = {}) {
       try {
         const queued = await service.enqueueMessage({
           agentId: c.req.param('agentId'),
+          sessionId: parsed.sessionId,
+          message: parsed.message,
+          attachments: parsed.attachments,
+        })
+        return c.json({ queued })
+      } catch (err) {
+        return handleAgentRouteError(c, err)
+      }
+    })
+    .post('/:agentId/sessions/:sessionId/queue', async (c) => {
+      const sessionId = parseSessionIdParam(c)
+      if ('error' in sessionId) return c.json({ error: sessionId.error }, 400)
+      const parsed = await parseEnqueueBody(c)
+      if ('error' in parsed) return c.json({ error: parsed.error }, 400)
+      try {
+        const queued = await service.enqueueMessage({
+          agentId: c.req.param('agentId'),
+          sessionId: sessionId.value,
           message: parsed.message,
           attachments: parsed.attachments,
         })
@@ -448,6 +481,80 @@ function turnFramesToAgentEvents(
   })
 }
 
+type ParsedChatBody = {
+  message: string
+  attachments: InboundImageAttachment[]
+  cwd?: string
+}
+
+async function startChatTurnResponse(
+  c: Context<Env>,
+  service: AgentRouteService,
+  input: {
+    agentId: string
+    sessionId: AgentSessionId
+    parsed: ParsedChatBody
+  },
+) {
+  let started: { turnId: string; frames: ReadableStream<TurnFrame> }
+  try {
+    started = await service.startTurn({
+      agentId: input.agentId,
+      sessionId: input.sessionId,
+      message: input.parsed.message,
+      attachments: input.parsed.attachments,
+      cwd: input.parsed.cwd,
+    })
+  } catch (err) {
+    if (err instanceof TurnAlreadyActiveError) {
+      return c.json(
+        {
+          error: 'Turn already active',
+          turnId: err.turnId,
+          attachUrl: `/agents/${input.agentId}/sessions/${input.sessionId}/chat/stream?turnId=${err.turnId}`,
+        },
+        409,
+      )
+    }
+    return handleAgentRouteError(c, err)
+  }
+
+  return streamTurnFrames(c, started.frames, {
+    sessionId: input.sessionId,
+    turnId: started.turnId,
+  })
+}
+
+function streamExistingTurn(
+  c: Context<Env>,
+  service: AgentRouteService,
+  input: {
+    agentId: string
+    sessionId: AgentSessionId
+  },
+) {
+  const url = new URL(c.req.url)
+  const queryTurnId = url.searchParams.get('turnId')?.trim() || undefined
+  const turnId =
+    queryTurnId ?? service.getActiveTurn(input.agentId, input.sessionId)?.turnId
+  if (!turnId) {
+    return c.json({ error: 'No active turn for this agent session' }, 404)
+  }
+  const lastEventId =
+    c.req.header('Last-Event-ID') ??
+    url.searchParams.get('lastSeq') ??
+    undefined
+  const lastSeq = parseLastSeq(lastEventId)
+  const frames = service.attachTurn({ turnId, lastSeq })
+  if (!frames) {
+    return c.json({ error: 'Unknown turn' }, 404)
+  }
+  return streamTurnFrames(c, frames, {
+    sessionId: input.sessionId,
+    turnId,
+  })
+}
+
 /**
  * Pipe a TurnFrame stream as Server-Sent Events. Each frame becomes:
  *
@@ -461,11 +568,11 @@ function turnFramesToAgentEvents(
 function streamTurnFrames(
   c: Context<Env>,
   frames: ReadableStream<TurnFrame>,
-  options: { turnId: string },
+  options: { sessionId: AgentSessionId; turnId: string },
 ) {
   c.header('Content-Type', 'text/event-stream')
   c.header('Cache-Control', 'no-cache')
-  c.header('X-Session-Id', MAIN_AGENT_SESSION_ID)
+  c.header('X-Session-Id', options.sessionId)
   c.header('X-Turn-Id', options.turnId)
 
   return stream(c, async (s) => {
@@ -604,33 +711,45 @@ const ALLOWED_IMAGE_MEDIA_TYPES = new Set([
  * message text size so a runaway client can't fill the queue file
  * with multi-megabyte payloads.
  */
-async function parseEnqueueBody(
-  c: Context<Env>,
-): Promise<
-  { message: string; attachments: InboundImageAttachment[] } | { error: string }
+async function parseEnqueueBody(c: Context<Env>): Promise<
+  | {
+      sessionId?: AgentSessionId
+      message: string
+      attachments: InboundImageAttachment[]
+    }
+  | { error: string }
 > {
-  const parsed = await parseChatBody(c)
+  const body = await readJsonBody(c)
+  if ('error' in body) return body
+  const parsed = parseChatBodyRecord(body.value)
   if ('error' in parsed) return parsed
   if (parsed.message.length > AGENT_HARNESS_LIMITS.QUEUE_MESSAGE_MAX_BYTES) {
     return {
       error: `Message exceeds ${AGENT_HARNESS_LIMITS.QUEUE_MESSAGE_MAX_BYTES} bytes`,
     }
   }
-  return parsed
+  const sessionId = readOptionalTrimmedString(body.value, 'sessionId')
+  if (sessionId && !isAgentSessionId(sessionId)) {
+    return { error: 'sessionId must be "main" or a UUID' }
+  }
+  return { ...parsed, sessionId }
 }
 
 async function parseChatBody(
   c: Context<Env>,
-): Promise<
-  | { message: string; attachments: InboundImageAttachment[]; cwd?: string }
-  | { error: string }
-> {
+): Promise<ParsedChatBody | { error: string }> {
   const body = await readJsonBody(c)
   if ('error' in body) return body
+  return parseChatBodyRecord(body.value)
+}
+
+function parseChatBodyRecord(
+  record: Record<string, unknown>,
+): ParsedChatBody | { error: string } {
   const message =
-    typeof body.value.message === 'string' ? body.value.message.trim() : ''
-  const attachmentsRaw = Array.isArray(body.value.attachments)
-    ? body.value.attachments
+    typeof record.message === 'string' ? record.message.trim() : ''
+  const attachmentsRaw = Array.isArray(record.attachments)
+    ? record.attachments
     : []
   if (attachmentsRaw.length > MAX_CHAT_ATTACHMENTS) {
     return {
@@ -676,8 +795,8 @@ async function parseChatBody(
     message,
     attachments,
     cwd:
-      readOptionalTrimmedString(body.value, 'cwd') ??
-      readOptionalTrimmedString(body.value, 'userWorkingDir'),
+      readOptionalTrimmedString(record, 'cwd') ??
+      readOptionalTrimmedString(record, 'userWorkingDir'),
   }
 }
 
@@ -767,6 +886,15 @@ function isUuid(value: string): boolean {
 
 function isAgentSessionId(value: string): value is AgentSessionId {
   return value === MAIN_AGENT_SESSION_ID || isUuid(value)
+}
+
+function parseSessionIdParam(
+  c: Context<Env>,
+): { value: AgentSessionId } | { error: string } {
+  const sessionId = c.req.param('sessionId')
+  return isAgentSessionId(sessionId)
+    ? { value: sessionId }
+    : { error: 'sessionId must be "main" or a UUID' }
 }
 
 async function readJsonBody(

--- a/packages/browseros-agent/apps/server/src/api/routes/agents.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/agents.ts
@@ -210,7 +210,11 @@ export function createAgentRoutes(deps: AgentRouteDeps = {}) {
               {
                 error: 'Turn already active',
                 turnId: err.turnId,
-                attachUrl: `/agents/${agent.id}/chat/stream?turnId=${err.turnId}`,
+                attachUrl: buildChatStreamAttachUrl({
+                  agentId: agent.id,
+                  sessionId: parsed.agentSessionId,
+                  turnId: err.turnId,
+                }),
               },
               409,
             )
@@ -511,7 +515,11 @@ async function startChatTurnResponse(
         {
           error: 'Turn already active',
           turnId: err.turnId,
-          attachUrl: `/agents/${input.agentId}/sessions/${input.sessionId}/chat/stream?turnId=${err.turnId}`,
+          attachUrl: buildChatStreamAttachUrl({
+            agentId: input.agentId,
+            sessionId: input.sessionId,
+            turnId: err.turnId,
+          }),
         },
         409,
       )
@@ -523,6 +531,23 @@ async function startChatTurnResponse(
     sessionId: input.sessionId,
     turnId: started.turnId,
   })
+}
+
+/**
+ * Builds the stream URL clients attach to after a 409, keeping the legacy
+ * main-session route while using scoped routes for sidepanel conversations.
+ */
+function buildChatStreamAttachUrl(input: {
+  agentId: string
+  sessionId: AgentSessionId
+  turnId: string
+}): string {
+  const agentId = encodeURIComponent(input.agentId)
+  const turnId = encodeURIComponent(input.turnId)
+  if (input.sessionId === MAIN_AGENT_SESSION_ID) {
+    return `/agents/${agentId}/chat/stream?turnId=${turnId}`
+  }
+  return `/agents/${agentId}/sessions/${encodeURIComponent(input.sessionId)}/chat/stream?turnId=${turnId}`
 }
 
 function streamExistingTurn(

--- a/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
@@ -60,6 +60,7 @@ export interface AgentActivity {
 }
 
 type SessionActivity = {
+  sessionId: AgentSessionId
   status: 'working' | 'error'
   lastEventAt: number
   lastError?: string
@@ -84,6 +85,8 @@ export interface AgentDefinitionWithActivity extends AgentDefinition {
   /** Last error message when status === 'error'; null otherwise. */
   lastError: string | null
   lastErrorAt: number | null
+  /** Most recent persisted session for this agent; null until first use. */
+  latestSessionId: AgentSessionId | null
   /** When non-null, an in-flight turn this row can be resumed from. */
   activeTurnId: string | null
   /** Persistent FIFO queue of messages waiting to run for this agent. */
@@ -219,18 +222,30 @@ export class AgentHarnessService {
     ])
     const now = Date.now()
     return agents.map((agent) => {
-      const live = this.activity.get(
-        activityKey(agent.id, MAIN_AGENT_SESSION_ID),
-      )
       const snapshot = snapshots.get(agent.id) ?? null
-      const lastUsedAt = snapshot?.lastUsedAt ?? null
-      const activeTurn = this.turnRegistry.getActiveFor(agent.id, 'main')
+      const liveLatest = this.getLatestActivity(agent.id)
+      const liveWins =
+        liveLatest != null &&
+        (!snapshot?.lastUsedAt || liveLatest.lastEventAt >= snapshot.lastUsedAt)
+      const latestSessionId = liveWins
+        ? liveLatest.sessionId
+        : (snapshot?.sessionId ?? null)
+      const live = latestSessionId
+        ? this.activity.get(activityKey(agent.id, latestSessionId))
+        : liveLatest
+      const lastUsedAt = liveWins
+        ? liveLatest.lastEventAt
+        : (snapshot?.lastUsedAt ?? null)
+      const activeTurn = latestSessionId
+        ? this.turnRegistry.getActiveFor(agent.id, latestSessionId)
+        : null
       return {
         ...agent,
         pinned: agent.pinned ?? false,
         status: deriveStatus(live, lastUsedAt, now),
         lastUsedAt,
-        lastUserMessage: snapshot?.lastUserMessage ?? null,
+        lastUserMessage:
+          activeTurn?.prompt ?? snapshot?.lastUserMessage ?? null,
         cwd: snapshot?.cwd ?? null,
         tokens: snapshot?.tokens ?? null,
         turnsByDay: ZERO_BUCKETS(),
@@ -238,6 +253,7 @@ export class AgentHarnessService {
         lastError: live?.status === 'error' ? (live.lastError ?? null) : null,
         lastErrorAt:
           live?.status === 'error' ? (live.lastEventAt ?? null) : null,
+        latestSessionId,
         activeTurnId: activeTurn?.turnId ?? null,
         queue: queueSnapshot[agent.id] ?? [],
       }
@@ -270,19 +286,45 @@ export class AgentHarnessService {
   private async fetchRowSnapshot(
     agent: AgentDefinition,
   ): Promise<AgentRowSnapshot | null> {
+    if (typeof this.runtime.getLatestRowSnapshot === 'function') {
+      return this.runtime.getLatestRowSnapshot(agent)
+    }
     if (typeof this.runtime.getRowSnapshot === 'function') {
-      return this.runtime.getRowSnapshot({ agent, sessionId: 'main' })
+      const snapshot = await this.runtime.getRowSnapshot({
+        agent,
+        sessionId: MAIN_AGENT_SESSION_ID,
+      })
+      return snapshot
+        ? {
+            ...snapshot,
+            sessionId: snapshot.sessionId ?? MAIN_AGENT_SESSION_ID,
+          }
+        : null
     }
     // Legacy fallback: derive only `lastUsedAt` from the history page.
-    const page = await this.runtime.getHistory({ agent, sessionId: 'main' })
+    const page = await this.runtime.getHistory({
+      agent,
+      sessionId: MAIN_AGENT_SESSION_ID,
+    })
     const last = page.items.at(-1)?.createdAt
     if (typeof last !== 'number' || !Number.isFinite(last)) return null
     return {
+      sessionId: MAIN_AGENT_SESSION_ID,
       cwd: null,
       lastUsedAt: last,
       lastUserMessage: null,
       tokens: null,
     }
+  }
+
+  private getLatestActivity(agentId: string): SessionActivity | undefined {
+    const prefix = `${agentId}\u0000`
+    let latest: SessionActivity | undefined
+    for (const [key, entry] of this.activity.entries()) {
+      if (!key.startsWith(prefix)) continue
+      if (!latest || entry.lastEventAt > latest.lastEventAt) latest = entry
+    }
+    return latest
   }
 
   /**
@@ -324,6 +366,7 @@ export class AgentHarnessService {
     sessionId: AgentSessionId = MAIN_AGENT_SESSION_ID,
   ): void {
     this.activity.set(activityKey(agentId, sessionId), {
+      sessionId,
       status: 'working',
       lastEventAt: Date.now(),
     })
@@ -338,6 +381,7 @@ export class AgentHarnessService {
     const key = activityKey(agentId, sessionId)
     if (!outcome.ok) {
       this.activity.set(key, {
+        sessionId,
         status: 'error',
         lastEventAt: Date.now(),
         lastError: outcome.error,
@@ -347,6 +391,7 @@ export class AgentHarnessService {
       // remaining running turn.
       if (this.turnRegistry.getActiveFor(agentId, sessionId)) {
         this.activity.set(key, {
+          sessionId,
           status: 'working',
           lastEventAt: Date.now(),
         })
@@ -371,17 +416,19 @@ export class AgentHarnessService {
   private async maybeStartNextFromQueue(agentId: string): Promise<void> {
     const next = await this.messageQueue.popOldest(agentId)
     if (!next) return
+    const sessionId = next.sessionId ?? MAIN_AGENT_SESSION_ID
     // Race guard: a turn may have started between `popOldest` and now
     // (e.g. the user typed and clicked Send directly between cancel
     // and the drain). Put the message back at the head and let the
     // next turn-end retry.
-    if (this.turnRegistry.getActiveFor(agentId, 'main')) {
+    if (this.turnRegistry.getActiveFor(agentId, sessionId)) {
       await this.messageQueue.pushFront(agentId, next)
       return
     }
     try {
       await this.startTurn({
         agentId,
+        sessionId,
         message: next.message,
         attachments: next.attachments,
       })
@@ -413,11 +460,13 @@ export class AgentHarnessService {
    */
   async enqueueMessage(input: {
     agentId: string
+    sessionId?: AgentSessionId
     message: string
     attachments?: ReadonlyArray<QueuedMessageAttachment>
   }): Promise<QueuedMessage> {
     const agent = await this.requireAgent(input.agentId)
     const queued = await this.messageQueue.append(agent.id, {
+      sessionId: input.sessionId,
       message: input.message,
       attachments: input.attachments,
     })
@@ -425,7 +474,12 @@ export class AgentHarnessService {
     // time (e.g. the user enqueued during the brief window between
     // turns), pop it back off and start it directly. Avoids the
     // queue sitting idle while the agent is also idle.
-    if (!this.turnRegistry.getActiveFor(agent.id, 'main')) {
+    if (
+      !this.turnRegistry.getActiveFor(
+        agent.id,
+        input.sessionId ?? MAIN_AGENT_SESSION_ID,
+      )
+    ) {
       void this.maybeStartNextFromQueue(agent.id)
     }
     return queued

--- a/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
@@ -8,7 +8,11 @@ import {
   AcpxRuntime,
   unwrapBrowserosAcpUserMessage,
 } from '../../../lib/agents/acpx/runtime'
-import type { AgentDefinition } from '../../../lib/agents/agent-types'
+import {
+  type AgentDefinition,
+  type AgentSessionId,
+  MAIN_AGENT_SESSION_ID,
+} from '../../../lib/agents/agent-types'
 import {
   getHermesHarnessHostDir,
   writeHermesPerAgentProvider,
@@ -322,9 +326,16 @@ export class AgentHarnessService {
         lastError: outcome.error,
       })
     } else {
-      // Successful turn — drop the in-memory entry. Liveness will be
-      // derived from the session record's `lastUsedAt` on next read.
-      this.activity.delete(agentId)
+      // Successful turn — clear working only when no other session is still
+      // running for this agent.
+      if (this.turnRegistry.hasActiveForAgent(agentId)) {
+        this.activity.set(agentId, {
+          status: 'working',
+          lastEventAt: Date.now(),
+        })
+      } else {
+        this.activity.delete(agentId)
+      }
     }
     // The queue drain runs on every turn-end (success or failure) so
     // a queued message is the next thing to run. Fire-and-forget; any
@@ -527,9 +538,12 @@ export class AgentHarnessService {
     return this.agentStore.get(agentId)
   }
 
-  async getHistory(agentId: string): Promise<AgentHistoryPage> {
+  async getHistory(
+    agentId: string,
+    sessionId: AgentSessionId = MAIN_AGENT_SESSION_ID,
+  ): Promise<AgentHistoryPage> {
     const agent = await this.requireAgent(agentId)
-    return this.runtime.getHistory({ agent, sessionId: 'main' })
+    return this.runtime.getHistory({ agent, sessionId })
   }
 
   /**
@@ -542,18 +556,20 @@ export class AgentHarnessService {
    */
   async startTurn(input: {
     agentId: string
+    sessionId?: AgentSessionId
     message: string
     attachments?: ReadonlyArray<{ mediaType: string; data: string }>
     cwd?: string
   }): Promise<{ turnId: string; frames: ReadableStream<TurnFrame> }> {
     const agent = await this.requireAgent(input.agentId)
+    const sessionId = input.sessionId ?? MAIN_AGENT_SESSION_ID
 
-    const existing = this.turnRegistry.getActiveFor(agent.id, 'main')
+    const existing = this.turnRegistry.getActiveFor(agent.id, sessionId)
     if (existing) {
       throw new TurnAlreadyActiveError(agent.id, existing.turnId)
     }
 
-    const turn = this.turnRegistry.register(agent.id, 'main', {
+    const turn = this.turnRegistry.register(agent.id, sessionId, {
       prompt: input.message,
     })
     this.notifyTurnStarted(agent.id)
@@ -595,7 +611,7 @@ export class AgentHarnessService {
    */
   getActiveTurn(
     agentId: string,
-    sessionId: 'main' = 'main',
+    sessionId: AgentSessionId = MAIN_AGENT_SESSION_ID,
   ): ActiveTurnInfo | null {
     const turn = this.turnRegistry.getActiveFor(agentId, sessionId)
     if (!turn) return null
@@ -615,12 +631,16 @@ export class AgentHarnessService {
    */
   cancelTurn(input: {
     agentId: string
+    sessionId?: AgentSessionId
     turnId?: string
     reason?: string
   }): boolean {
     const turnId =
       input.turnId ??
-      this.turnRegistry.getActiveFor(input.agentId, 'main')?.turnId
+      this.turnRegistry.getActiveFor(
+        input.agentId,
+        input.sessionId ?? MAIN_AGENT_SESSION_ID,
+      )?.turnId
     if (!turnId) return false
     return this.turnRegistry.cancel(turnId, input.reason)
   }
@@ -634,6 +654,7 @@ export class AgentHarnessService {
    */
   async send(input: {
     agentId: string
+    sessionId?: AgentSessionId
     message: string
     attachments?: ReadonlyArray<{ mediaType: string; data: string }>
     cwd?: string
@@ -658,6 +679,7 @@ export class AgentHarnessService {
     turnId: string,
     agent: AgentDefinition,
     input: {
+      sessionId?: AgentSessionId
       message: string
       attachments?: ReadonlyArray<{ mediaType: string; data: string }>
       cwd?: string
@@ -665,12 +687,13 @@ export class AgentHarnessService {
   ): Promise<void> {
     const turn = this.turnRegistry.get(turnId)
     if (!turn) return
+    const sessionId = turn.sessionId
     let lastErrorMessage: string | undefined
 
     try {
       const upstream = await this.runtime.send({
         agent,
-        sessionId: 'main',
+        sessionId,
         sessionKey: agent.sessionKey,
         message: input.message,
         attachments: input.attachments,

--- a/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
@@ -750,7 +750,6 @@ export class AgentHarnessService {
     turnId: string,
     agent: AgentDefinition,
     input: {
-      sessionId?: AgentSessionId
       message: string
       attachments?: ReadonlyArray<{ mediaType: string; data: string }>
       cwd?: string

--- a/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
@@ -59,6 +59,12 @@ export interface AgentActivity {
   lastUsedAt: number | null
 }
 
+type SessionActivity = {
+  status: 'working' | 'error'
+  lastEventAt: number
+  lastError?: string
+}
+
 export interface AgentDefinitionWithActivity extends AgentDefinition {
   status: AgentLiveness
   lastUsedAt: number | null
@@ -93,6 +99,10 @@ const ZERO_BUCKETS = (): number[] =>
  * enrichment time; no timer cleanup necessary.
  */
 const ASLEEP_THRESHOLD_MS = 15 * 60 * 1000
+
+function activityKey(agentId: string, sessionId: AgentSessionId): string {
+  return `${agentId}\u0000${sessionId}`
+}
 
 /**
  * Per-turn event the harness emits to subscribers. Lets services that
@@ -135,10 +145,7 @@ export class AgentHarnessService {
   // `lastUsedAt` survives via the acpx session record's `lastUsedAt`,
   // and an idle/asleep agent post-restart will read fine from the
   // record's timestamp without ever flipping to `working`).
-  private readonly activity = new Map<
-    string,
-    { status: 'working' | 'error'; lastEventAt: number; lastError?: string }
-  >()
+  private readonly activity = new Map<string, SessionActivity>()
 
   constructor(
     deps: {
@@ -212,7 +219,9 @@ export class AgentHarnessService {
     ])
     const now = Date.now()
     return agents.map((agent) => {
-      const live = this.activity.get(agent.id)
+      const live = this.activity.get(
+        activityKey(agent.id, MAIN_AGENT_SESSION_ID),
+      )
       const snapshot = snapshots.get(agent.id) ?? null
       const lastUsedAt = snapshot?.lastUsedAt ?? null
       const activeTurn = this.turnRegistry.getActiveFor(agent.id, 'main')
@@ -309,32 +318,40 @@ export class AgentHarnessService {
     }
   }
 
-  /** Mark `agentId` as actively running a turn. */
-  notifyTurnStarted(agentId: string): void {
-    this.activity.set(agentId, { status: 'working', lastEventAt: Date.now() })
+  /** Mark an agent session as actively running a turn. */
+  notifyTurnStarted(
+    agentId: string,
+    sessionId: AgentSessionId = MAIN_AGENT_SESSION_ID,
+  ): void {
+    this.activity.set(activityKey(agentId, sessionId), {
+      status: 'working',
+      lastEventAt: Date.now(),
+    })
   }
 
-  /** Clear the working flag. `error` keeps the row badged as needing attention. */
+  /** Clear the session working flag. `error` keeps that session badged as needing attention. */
   notifyTurnEnded(
     agentId: string,
+    sessionId: AgentSessionId = MAIN_AGENT_SESSION_ID,
     outcome: { ok: boolean; error?: string } = { ok: true },
   ): void {
+    const key = activityKey(agentId, sessionId)
     if (!outcome.ok) {
-      this.activity.set(agentId, {
+      this.activity.set(key, {
         status: 'error',
         lastEventAt: Date.now(),
         lastError: outcome.error,
       })
     } else {
-      // Successful turn — clear working only when no other session is still
-      // running for this agent.
-      if (this.turnRegistry.hasActiveForAgent(agentId)) {
-        this.activity.set(agentId, {
+      // Successful turn — clear working only when this same session has no
+      // remaining running turn.
+      if (this.turnRegistry.getActiveFor(agentId, sessionId)) {
+        this.activity.set(key, {
           status: 'working',
           lastEventAt: Date.now(),
         })
       } else {
-        this.activity.delete(agentId)
+        this.activity.delete(key)
       }
     }
     // The queue drain runs on every turn-end (success or failure) so
@@ -572,7 +589,7 @@ export class AgentHarnessService {
     const turn = this.turnRegistry.register(agent.id, sessionId, {
       prompt: input.message,
     })
-    this.notifyTurnStarted(agent.id)
+    this.notifyTurnStarted(agent.id, sessionId)
     this.emitTurnLifecycle(agent, { type: 'turn_started' })
 
     // Kick off the runtime call in the background. The per-turn
@@ -745,7 +762,7 @@ export class AgentHarnessService {
         })
       }
     } finally {
-      this.notifyTurnEnded(agent.id, {
+      this.notifyTurnEnded(agent.id, sessionId, {
         ok: lastErrorMessage === undefined,
         error: lastErrorMessage,
       })

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx/agent-adapter.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx/agent-adapter.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import type { AgentDefinition } from '../agent-types'
+import type { AgentDefinition, AgentSessionId } from '../agent-types'
 import {
   prepareClaudeCodeContext,
   prepareCodexContext,
@@ -31,7 +31,7 @@ export interface PreparedAcpxAgentContext {
 export interface PrepareAcpxAgentContextInput {
   browserosDir: string
   agent: AgentDefinition
-  sessionId: 'main'
+  sessionId: AgentSessionId
   sessionKey: string
   cwdOverride: string | null
   isSelectedCwd: boolean

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx/agent-common.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx/agent-common.ts
@@ -37,6 +37,7 @@ export async function prepareBrowserosManagedContext(
   const paths = resolveAgentRuntimePaths({
     browserosDir: input.browserosDir,
     agentId: input.agent.id,
+    sessionId: input.sessionId,
     cwd: input.cwdOverride,
   })
   await ensureUsableCwd(paths.effectiveCwd, !input.isSelectedCwd)
@@ -70,13 +71,17 @@ export async function finishBrowserosManagedContext(input: {
     skillIdentity: input.skillNames.join(','),
     commandIdentity,
   })
-  await saveLatestRuntimeState(input.paths.runtimeStatePath, {
+  const latest = {
     sessionId: input.input.sessionId,
     runtimeSessionKey,
     cwd: input.paths.effectiveCwd,
     agentHome: input.paths.agentHome,
     updatedAt: Date.now(),
-  })
+  }
+  await Promise.all([
+    saveLatestRuntimeState(input.paths.runtimeSessionStatePath, latest),
+    saveLatestRuntimeState(input.paths.runtimeStatePath, latest),
+  ])
   return {
     cwd: input.paths.effectiveCwd,
     runtimeSessionKey,

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime-context.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime-context.ts
@@ -18,7 +18,11 @@ import {
 } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { basename, dirname, join, resolve } from 'node:path'
-import type { AgentDefinition } from '../agent-types'
+import {
+  type AgentDefinition,
+  type AgentSessionId,
+  MAIN_AGENT_SESSION_ID,
+} from '../agent-types'
 import {
   MEMORY_TEMPLATE,
   RUNTIME_SKILLS,
@@ -33,7 +37,10 @@ export interface AgentRuntimePaths {
   agentHome: string
   defaultWorkspaceCwd: string
   effectiveCwd: string
+  /** Agent-level latest activity pointer used for row summaries. */
   runtimeStatePath: string
+  /** Session-level latest pointer used for exact history/resume lookups. */
+  runtimeSessionStatePath: string
   runtimeSkillsDir: string
   runtimeRoot: string
   codexHome: string
@@ -43,10 +50,12 @@ export function resolveAgentRuntimePaths(input: {
   browserosDir: string
   agentId: string
   cwd?: string | null
+  sessionId?: AgentSessionId
 }): AgentRuntimePaths {
   const harnessDir = join(input.browserosDir, 'agents', 'harness')
   const defaultWorkspaceCwd = join(harnessDir, 'workspace')
   const runtimeRoot = join(harnessDir, input.agentId, 'runtime')
+  const sessionFile = `${encodeURIComponent(input.sessionId ?? MAIN_AGENT_SESSION_ID)}.json`
   return {
     browserosDir: input.browserosDir,
     harnessDir,
@@ -57,6 +66,12 @@ export function resolveAgentRuntimePaths(input: {
       harnessDir,
       'runtime-state',
       `${input.agentId}.json`,
+    ),
+    runtimeSessionStatePath: join(
+      harnessDir,
+      'runtime-state',
+      input.agentId,
+      sessionFile,
     ),
     runtimeSkillsDir: join(harnessDir, 'runtime-skills'),
     runtimeRoot,

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime-state.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime-state.ts
@@ -7,9 +7,10 @@
 import { createHash } from 'node:crypto'
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
+import type { AgentSessionId } from './agent-types'
 
 export interface LatestRuntimeState {
-  sessionId: 'main'
+  sessionId: AgentSessionId
   runtimeSessionKey: string
   cwd: string
   agentHome: string
@@ -53,7 +54,7 @@ export async function saveLatestRuntimeState(
 
 export function deriveRuntimeSessionKey(input: {
   agentId: string
-  sessionId: 'main'
+  sessionId: AgentSessionId
   adapter: string
   cwd: string
   agentHome: string
@@ -72,7 +73,8 @@ function isLatestRuntimeState(value: unknown): value is LatestRuntimeState {
   if (!value || typeof value !== 'object') return false
   const record = value as Record<string, unknown>
   return (
-    record.sessionId === 'main' &&
+    typeof record.sessionId === 'string' &&
+    record.sessionId.length > 0 &&
     typeof record.runtimeSessionKey === 'string' &&
     typeof record.cwd === 'string' &&
     typeof record.agentHome === 'string' &&

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime-state.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime-state.ts
@@ -7,7 +7,7 @@
 import { createHash } from 'node:crypto'
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
-import type { AgentSessionId } from './agent-types'
+import type { AgentSessionId } from '../agent-types'
 
 export interface LatestRuntimeState {
   sessionId: AgentSessionId

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime.ts
@@ -132,7 +132,23 @@ export class AcpxRuntime implements AgentRuntime {
   }): Promise<AgentRowSnapshot | null> {
     const record = await this.loadSessionRecord(input.agent, input.sessionId)
     if (!record) return null
+    return this.createRowSnapshot(record, input.sessionId)
+  }
+
+  async getLatestRowSnapshot(
+    agent: AgentPromptInput['agent'],
+  ): Promise<AgentRowSnapshot | null> {
+    const latest = await this.loadLatestAgentSessionRecord(agent)
+    if (!latest) return null
+    return this.createRowSnapshot(latest.record, latest.sessionId)
+  }
+
+  private createRowSnapshot(
+    record: AcpSessionRecord,
+    sessionId: AgentSessionId,
+  ): AgentRowSnapshot {
     return {
+      sessionId,
       cwd: record.cwd ?? null,
       lastUsedAt: parseRecordTimestamp(record) || null,
       lastUserMessage: extractLastUserMessage(record),
@@ -217,6 +233,35 @@ export class AcpxRuntime implements AgentRuntime {
       if (latestRecord) return latestRecord
     }
     return (await this.sessionStore.load(agent.sessionKey)) ?? null
+  }
+
+  private async loadLatestAgentSessionRecord(
+    agent: AgentPromptInput['agent'],
+  ): Promise<{ sessionId: AgentSessionId; record: AcpSessionRecord } | null> {
+    const paths = resolveAgentRuntimePaths({
+      browserosDir: this.browserosDir,
+      agentId: agent.id,
+    })
+    const latestForAgent = await loadLatestRuntimeState(paths.runtimeStatePath)
+    if (latestForAgent) {
+      const latestRecord = await this.sessionStore.load(
+        latestForAgent.runtimeSessionKey,
+      )
+      if (latestRecord) {
+        return {
+          sessionId: latestForAgent.sessionId,
+          record: latestRecord,
+        }
+      }
+    }
+
+    const mainRecord = await this.loadSessionRecord(
+      agent,
+      MAIN_AGENT_SESSION_ID,
+    )
+    return mainRecord
+      ? { sessionId: MAIN_AGENT_SESSION_ID, record: mainRecord }
+      : null
   }
 
   private async prepareRuntimeContext(

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime.ts
@@ -45,7 +45,10 @@ import {
   shellQuote,
   wrapCommandWithEnv,
 } from './runtime-context'
-import { loadLatestRuntimeState } from './runtime-state'
+import {
+  type LatestRuntimeState,
+  loadLatestRuntimeState,
+} from './runtime-state'
 
 type AcpxRuntimeOptions = {
   cwd?: string
@@ -207,6 +210,7 @@ export class AcpxRuntime implements AgentRuntime {
   private async loadSessionRecord(
     agent: AgentPromptInput['agent'],
     sessionId: AgentSessionId,
+    latestForAgentHint?: LatestRuntimeState | null,
   ): Promise<AcpSessionRecord | null> {
     const paths = resolveAgentRuntimePaths({
       browserosDir: this.browserosDir,
@@ -225,7 +229,10 @@ export class AcpxRuntime implements AgentRuntime {
 
     if (sessionId !== MAIN_AGENT_SESSION_ID) return null
 
-    const latestForAgent = await loadLatestRuntimeState(paths.runtimeStatePath)
+    const latestForAgent =
+      latestForAgentHint === undefined
+        ? await loadLatestRuntimeState(paths.runtimeStatePath)
+        : latestForAgentHint
     if (latestForAgent?.sessionId === MAIN_AGENT_SESSION_ID) {
       const latestRecord = await this.sessionStore.load(
         latestForAgent.runtimeSessionKey,
@@ -258,6 +265,7 @@ export class AcpxRuntime implements AgentRuntime {
     const mainRecord = await this.loadSessionRecord(
       agent,
       MAIN_AGENT_SESSION_ID,
+      latestForAgent,
     )
     return mainRecord
       ? { sessionId: MAIN_AGENT_SESSION_ID, record: mainRecord }

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime.ts
@@ -219,23 +219,6 @@ export class AcpxRuntime implements AgentRuntime {
     return (await this.sessionStore.load(agent.sessionKey)) ?? null
   }
 
-  private async loadLatestAgentSessionRecord(
-    agent: AgentPromptInput['agent'],
-  ): Promise<AcpSessionRecord | null> {
-    const paths = resolveAgentRuntimePaths({
-      browserosDir: this.browserosDir,
-      agentId: agent.id,
-    })
-    const latestForAgent = await loadLatestRuntimeState(paths.runtimeStatePath)
-    if (latestForAgent) {
-      const latestRecord = await this.sessionStore.load(
-        latestForAgent.runtimeSessionKey,
-      )
-      if (latestRecord) return latestRecord
-    }
-    return this.loadSessionRecord(agent, MAIN_AGENT_SESSION_ID)
-  }
-
   private async prepareRuntimeContext(
     input: AgentPromptInput,
     cwdOverride: string | null,

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime.ts
@@ -20,10 +20,12 @@ import {
 } from 'acpx/runtime'
 import { getBrowserosDir } from '../../browseros-dir'
 import { logger } from '../../logger'
-import type {
-  AgentDefinition,
-  AgentHistoryEntry,
-  AgentHistoryToolCall,
+import {
+  type AgentDefinition,
+  type AgentHistoryEntry,
+  type AgentHistoryToolCall,
+  type AgentSessionId,
+  MAIN_AGENT_SESSION_ID,
 } from '../agent-types'
 import { resolveBundledBun } from '../host-acp/bundled-bun'
 import { HOST_ACP_ADAPTER_CONFIG } from '../host-acp/config'
@@ -97,14 +99,20 @@ export class AcpxRuntime implements AgentRuntime {
   async listSessions(
     input: AgentPromptInput['agent'],
   ): Promise<AgentSession[]> {
-    return [{ agentId: input.id, id: 'main', updatedAt: input.updatedAt }]
+    return [
+      {
+        agentId: input.id,
+        id: MAIN_AGENT_SESSION_ID,
+        updatedAt: input.updatedAt,
+      },
+    ]
   }
 
   async getHistory(input: {
     agent: AgentPromptInput['agent']
-    sessionId: 'main'
+    sessionId: AgentSessionId
   }): Promise<AgentHistoryPage> {
-    const record = await this.loadLatestSessionRecord(input.agent)
+    const record = await this.loadSessionRecord(input.agent, input.sessionId)
     if (!record) {
       return { agentId: input.agent.id, sessionId: input.sessionId, items: [] }
     }
@@ -120,9 +128,9 @@ export class AcpxRuntime implements AgentRuntime {
    */
   async getRowSnapshot(input: {
     agent: AgentPromptInput['agent']
-    sessionId: 'main'
+    sessionId: AgentSessionId
   }): Promise<AgentRowSnapshot | null> {
-    const record = await this.loadLatestSessionRecord(input.agent)
+    const record = await this.loadSessionRecord(input.agent, input.sessionId)
     if (!record) return null
     return {
       cwd: record.cwd ?? null,
@@ -180,21 +188,52 @@ export class AcpxRuntime implements AgentRuntime {
     })
   }
 
-  private async loadLatestSessionRecord(
+  private async loadSessionRecord(
+    agent: AgentPromptInput['agent'],
+    sessionId: AgentSessionId,
+  ): Promise<AcpSessionRecord | null> {
+    const paths = resolveAgentRuntimePaths({
+      browserosDir: this.browserosDir,
+      agentId: agent.id,
+      sessionId,
+    })
+    const latestForSession = await loadLatestRuntimeState(
+      paths.runtimeSessionStatePath,
+    )
+    if (latestForSession) {
+      const latestRecord = await this.sessionStore.load(
+        latestForSession.runtimeSessionKey,
+      )
+      if (latestRecord) return latestRecord
+    }
+
+    if (sessionId !== MAIN_AGENT_SESSION_ID) return null
+
+    const latestForAgent = await loadLatestRuntimeState(paths.runtimeStatePath)
+    if (latestForAgent?.sessionId === MAIN_AGENT_SESSION_ID) {
+      const latestRecord = await this.sessionStore.load(
+        latestForAgent.runtimeSessionKey,
+      )
+      if (latestRecord) return latestRecord
+    }
+    return (await this.sessionStore.load(agent.sessionKey)) ?? null
+  }
+
+  private async loadLatestAgentSessionRecord(
     agent: AgentPromptInput['agent'],
   ): Promise<AcpSessionRecord | null> {
     const paths = resolveAgentRuntimePaths({
       browserosDir: this.browserosDir,
       agentId: agent.id,
     })
-    const latest = await loadLatestRuntimeState(paths.runtimeStatePath)
-    if (latest) {
+    const latestForAgent = await loadLatestRuntimeState(paths.runtimeStatePath)
+    if (latestForAgent) {
       const latestRecord = await this.sessionStore.load(
-        latest.runtimeSessionKey,
+        latestForAgent.runtimeSessionKey,
       )
       if (latestRecord) return latestRecord
     }
-    return (await this.sessionStore.load(agent.sessionKey)) ?? null
+    return this.loadSessionRecord(agent, MAIN_AGENT_SESSION_ID)
   }
 
   private async prepareRuntimeContext(
@@ -286,7 +325,7 @@ type AcpxToolResult = AcpxAgentMessage['tool_results'][string]
 
 function mapAcpxSessionRecordToHistory(
   agent: AgentDefinition,
-  sessionId: 'main',
+  sessionId: AgentSessionId,
   record: AcpSessionRecord,
 ): AgentHistoryPage {
   const createdAt = parseRecordTimestamp(record)
@@ -336,7 +375,7 @@ function mapAcpxSessionRecordToHistory(
 function mapAgentMessageToHistoryEntry(input: {
   id: string
   agentId: string
-  sessionId: 'main'
+  sessionId: AgentSessionId
   createdAt: number
   message: AcpxAgentMessage
 }): AgentHistoryEntry | null {

--- a/packages/browseros-agent/apps/server/src/lib/agents/agent-types.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/agent-types.ts
@@ -8,6 +8,9 @@ export type AgentAdapter = 'claude' | 'codex' | 'hermes'
 
 export type AgentPermissionMode = 'approve-all'
 
+export const MAIN_AGENT_SESSION_ID = 'main'
+export type AgentSessionId = string
+
 export interface AgentDefinition {
   id: string
   name: string
@@ -58,7 +61,7 @@ export interface AgentHistoryToolCall {
 export interface AgentHistoryEntry {
   id: string
   agentId: string
-  sessionId: 'main'
+  sessionId: AgentSessionId
   role: 'user' | 'assistant'
   text: string
   createdAt: number

--- a/packages/browseros-agent/apps/server/src/lib/agents/storage/message-queue.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/storage/message-queue.ts
@@ -10,6 +10,7 @@ import { dirname, join } from 'node:path'
 import { AGENT_HARNESS_LIMITS } from '@browseros/shared/constants/limits'
 import { getBrowserosDir } from '../../browseros-dir'
 import { logger } from '../../logger'
+import type { AgentSessionId } from '../agent-types'
 
 export interface QueuedMessageAttachment {
   mediaType: string
@@ -19,6 +20,7 @@ export interface QueuedMessageAttachment {
 export interface QueuedMessage {
   id: string
   createdAt: number
+  sessionId?: AgentSessionId
   message: string
   attachments?: ReadonlyArray<QueuedMessageAttachment>
 }
@@ -80,6 +82,7 @@ export class FileMessageQueue {
   async append(
     agentId: string,
     input: {
+      sessionId?: AgentSessionId
       message: string
       attachments?: ReadonlyArray<QueuedMessageAttachment>
     },
@@ -93,6 +96,7 @@ export class FileMessageQueue {
       const queued: QueuedMessage = {
         id: randomUUID(),
         createdAt: Date.now(),
+        sessionId: input.sessionId,
         message: input.message,
         attachments: input.attachments,
       }

--- a/packages/browseros-agent/apps/server/src/lib/agents/turns/active-turn-registry.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/turns/active-turn-registry.ts
@@ -6,6 +6,7 @@
 
 import { randomUUID } from 'node:crypto'
 import { logger } from '../../logger'
+import { type AgentSessionId, MAIN_AGENT_SESSION_ID } from '../agent-types'
 import type { AgentStreamEvent } from '../types'
 
 export type TurnStatus = 'running' | 'done' | 'error' | 'cancelled'
@@ -19,7 +20,7 @@ export interface TurnFrame {
 export interface ActiveTurnInfo {
   turnId: string
   agentId: string
-  sessionId: 'main'
+  sessionId: AgentSessionId
   status: TurnStatus
   lastSeq: number
   startedAt: number
@@ -36,7 +37,7 @@ interface Subscriber {
 interface ActiveTurn {
   turnId: string
   agentId: string
-  sessionId: 'main'
+  sessionId: AgentSessionId
   status: TurnStatus
   buffer: RingBuffer
   subscribers: Set<Subscriber>
@@ -142,7 +143,7 @@ export class TurnRegistry {
    */
   register(
     agentId: string,
-    sessionId: 'main' = 'main',
+    sessionId: AgentSessionId = MAIN_AGENT_SESSION_ID,
     options: { prompt?: string | null } = {},
   ): ActiveTurn {
     const turn: ActiveTurn = {
@@ -171,7 +172,7 @@ export class TurnRegistry {
    */
   getActiveFor(
     agentId: string,
-    sessionId: 'main' = 'main',
+    sessionId: AgentSessionId = MAIN_AGENT_SESSION_ID,
   ): ActiveTurn | undefined {
     for (const turn of this.turns.values()) {
       if (

--- a/packages/browseros-agent/apps/server/src/lib/agents/turns/active-turn-registry.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/turns/active-turn-registry.ts
@@ -186,6 +186,14 @@ export class TurnRegistry {
     return undefined
   }
 
+  /** True when any session for the agent still has a running turn. */
+  hasActiveForAgent(agentId: string): boolean {
+    for (const turn of this.turns.values()) {
+      if (turn.status === 'running' && turn.agentId === agentId) return true
+    }
+    return false
+  }
+
   describe(turnId: string): ActiveTurnInfo | null {
     const turn = this.turns.get(turnId)
     if (!turn) return null

--- a/packages/browseros-agent/apps/server/src/lib/agents/turns/active-turn-registry.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/turns/active-turn-registry.ts
@@ -186,14 +186,6 @@ export class TurnRegistry {
     return undefined
   }
 
-  /** True when any session for the agent still has a running turn. */
-  hasActiveForAgent(agentId: string): boolean {
-    for (const turn of this.turns.values()) {
-      if (turn.status === 'running' && turn.agentId === agentId) return true
-    }
-    return false
-  }
-
   describe(turnId: string): ActiveTurnInfo | null {
     const turn = this.turns.get(turnId)
     if (!turn) return null

--- a/packages/browseros-agent/apps/server/src/lib/agents/types.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/types.ts
@@ -8,6 +8,7 @@ import type {
   AgentDefinition,
   AgentHistoryEntry,
   AgentPermissionMode,
+  AgentSessionId,
 } from './agent-types'
 
 export interface AgentStatus {
@@ -17,13 +18,13 @@ export interface AgentStatus {
 
 export interface AgentSession {
   agentId: string
-  id: 'main'
+  id: AgentSessionId
   updatedAt: number
 }
 
 export interface AgentHistoryPage {
   agentId: string
-  sessionId: 'main'
+  sessionId: AgentSessionId
   items: AgentHistoryEntry[]
 }
 
@@ -69,7 +70,7 @@ export interface AgentInlineImage {
 
 export interface AgentPromptInput {
   agent: AgentDefinition
-  sessionId: 'main'
+  sessionId: AgentSessionId
   sessionKey: string
   message: string
   attachments?: ReadonlyArray<AgentInlineImage>
@@ -106,12 +107,12 @@ export interface AgentRuntime {
   listSessions(agent: AgentDefinition): Promise<AgentSession[]>
   getHistory(input: {
     agent: AgentDefinition
-    sessionId: 'main'
+    sessionId: AgentSessionId
   }): Promise<AgentHistoryPage>
   send(input: AgentPromptInput): Promise<ReadableStream<AgentStreamEvent>>
   cancel?(input: {
     agent: AgentDefinition
-    sessionId: 'main'
+    sessionId: AgentSessionId
     reason?: string
   }): Promise<void>
   /**
@@ -121,6 +122,6 @@ export interface AgentRuntime {
    */
   getRowSnapshot?(input: {
     agent: AgentDefinition
-    sessionId: 'main'
+    sessionId: AgentSessionId
   }): Promise<AgentRowSnapshot | null>
 }

--- a/packages/browseros-agent/apps/server/src/lib/agents/types.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/types.ts
@@ -87,6 +87,8 @@ export interface AgentPromptInput {
  * user message). Returned `null` when the agent has no record yet.
  */
 export interface AgentRowSnapshot {
+  /** Session this row snapshot was read from. Omitted by legacy test fakes. */
+  sessionId?: AgentSessionId
   cwd: string | null
   lastUsedAt: number | null
   lastUserMessage: string | null
@@ -124,4 +126,7 @@ export interface AgentRuntime {
     agent: AgentDefinition
     sessionId: AgentSessionId
   }): Promise<AgentRowSnapshot | null>
+  getLatestRowSnapshot?(
+    agent: AgentDefinition,
+  ): Promise<AgentRowSnapshot | null>
 }

--- a/packages/browseros-agent/apps/server/tests/api/routes/agents.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/agents.test.ts
@@ -7,7 +7,11 @@ import { describe, expect, it } from 'bun:test'
 import { AGENT_HARNESS_LIMITS } from '@browseros/shared/constants/limits'
 import { Hono } from 'hono'
 import { createAgentRoutes } from '../../../src/api/routes/agents'
-import type { AgentDefinition } from '../../../src/lib/agents/agent-types'
+import {
+  type AgentDefinition,
+  type AgentSessionId,
+  MAIN_AGENT_SESSION_ID,
+} from '../../../src/lib/agents/agent-types'
 import {
   type ActiveTurnInfo,
   TurnRegistry,
@@ -158,6 +162,33 @@ describe('createAgentRoutes', () => {
     expect(service._lastStartTurnInput).toMatchObject({
       agentId: 'agent-1',
       cwd: '/tmp/workspace',
+    })
+  })
+
+  it('reads history for the requested agent session', async () => {
+    const sessionId = '00000000-0000-4000-8000-000000000001'
+    const route = createMountedRoutes([
+      {
+        id: 'agent-1',
+        name: 'Review bot',
+        adapter: 'codex',
+        modelId: 'gpt-5.5',
+        reasoningEffort: 'medium',
+        permissionMode: 'approve-all',
+        sessionKey: 'agent:agent-1:main',
+        createdAt: 1000,
+        updatedAt: 1000,
+      },
+    ])
+
+    const response = await route.request(
+      `/agents/agent-1/sessions/${sessionId}/history`,
+    )
+
+    expect(response.status).toBe(200)
+    expect(await response.json()).toMatchObject({
+      agentId: 'agent-1',
+      sessionId,
     })
   })
 
@@ -345,12 +376,14 @@ describe('createAgentRoutes', () => {
         },
       }),
     )
+    const conversationId = '00000000-0000-4000-8000-000000000001'
 
     const response = await route.request('/agents/agent-1/sidepanel/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({
         ...validCreatedAgentSidepanelBody(),
+        conversationId,
         adapter: 'codex',
         modelId: 'ignored-client-model',
         reasoningEffort: 'ignored-client-effort',
@@ -370,9 +403,11 @@ describe('createAgentRoutes', () => {
     expect(response.status).toBe(200)
     expect(response.headers.get('Content-Type')).toContain('text/event-stream')
     expect(response.headers.get('x-vercel-ai-ui-message-stream')).toBe('v1')
+    expect(response.headers.get('X-Session-Id')).toBe(conversationId)
     expect(await response.text()).toContain('"type":"text-delta"')
     expect(service._lastStartTurnInput).toMatchObject({
       agentId: 'agent-1',
+      sessionId: conversationId,
       cwd: '/tmp/work',
     })
     expect(service._lastStartTurnInput?.message).toContain('Always be concise.')
@@ -392,6 +427,39 @@ describe('createAgentRoutes', () => {
     const list = await route.request('/agents')
     expect(await list.json()).toMatchObject({
       agents: [{ id: 'agent-1', adapter: 'codex', modelId: 'gpt-5.5' }],
+    })
+  })
+
+  it('lets created-agent sidepanel chat explicitly use the main session', async () => {
+    const agent: AgentDefinition = {
+      id: 'agent-1',
+      name: 'Review bot',
+      adapter: 'codex',
+      modelId: 'gpt-5.5',
+      reasoningEffort: 'medium',
+      permissionMode: 'approve-all',
+      sessionKey: 'agent:agent-1:main',
+      createdAt: 1000,
+      updatedAt: 1000,
+    }
+    const service = createFakeService([agent])
+    const route = new Hono().route('/agents', createAgentRoutes({ service }))
+
+    const response = await route.request('/agents/agent-1/sidepanel/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...validCreatedAgentSidepanelBody(),
+        agentSessionId: MAIN_AGENT_SESSION_ID,
+      }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('X-Session-Id')).toBe(MAIN_AGENT_SESSION_ID)
+    await response.text()
+    expect(service._lastStartTurnInput).toMatchObject({
+      agentId: 'agent-1',
+      sessionId: MAIN_AGENT_SESSION_ID,
     })
   })
 
@@ -421,6 +489,10 @@ describe('createAgentRoutes', () => {
       {
         patch: { conversationId: 'not-a-uuid' },
         error: 'conversationId must be a UUID',
+      },
+      {
+        patch: { agentSessionId: 'not-a-session' },
+        error: 'agentSessionId must be "main" or a UUID',
       },
       { patch: { message: '   ' }, error: 'Message is required' },
       {
@@ -523,6 +595,65 @@ describe('createAgentRoutes', () => {
 
     blocking._unblock()
     await (await first).text()
+  })
+
+  it('allows concurrent created-agent sidepanel turns in different sessions', async () => {
+    const agent: AgentDefinition = {
+      id: 'agent-1',
+      name: 'Review bot',
+      adapter: 'codex',
+      modelId: 'gpt-5.5',
+      reasoningEffort: 'medium',
+      permissionMode: 'approve-all',
+      sessionKey: 'agent:agent-1:main',
+      createdAt: 1000,
+      updatedAt: 1000,
+    }
+    const blocking = createBlockingFakeService([agent])
+    const route = new Hono().route(
+      '/agents',
+      createAgentRoutes({ service: blocking }),
+    )
+
+    const firstSessionId = '00000000-0000-4000-8000-000000000001'
+    const secondSessionId = '00000000-0000-4000-8000-000000000002'
+    const first = route.request('/agents/agent-1/sidepanel/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...validCreatedAgentSidepanelBody(),
+        conversationId: firstSessionId,
+      }),
+    })
+    await new Promise((r) => setTimeout(r, 5))
+
+    const second = await route.request('/agents/agent-1/sidepanel/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...validCreatedAgentSidepanelBody(),
+        conversationId: secondSessionId,
+      }),
+    })
+
+    expect(second.status).toBe(200)
+    expect(second.headers.get('X-Session-Id')).toBe(secondSessionId)
+
+    const duplicate = await route.request('/agents/agent-1/sidepanel/chat', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...validCreatedAgentSidepanelBody(),
+        conversationId: firstSessionId,
+      }),
+    })
+    expect(duplicate.status).toBe(409)
+
+    blocking._unblock()
+    const firstResponse = await first
+    expect(firstResponse.headers.get('X-Session-Id')).toBe(firstSessionId)
+    await firstResponse.text()
+    await second.text()
   })
 
   it('does not expose the legacy virtual sidepanel ACP chat route', async () => {
@@ -724,7 +855,12 @@ function createFakeService(agents: AgentDefinition[]) {
     { type: 'done', stopReason: 'end_turn' },
   ]
   let lastStartTurnInput:
-    | { agentId: string; message?: string; cwd?: string }
+    | {
+        agentId: string
+        sessionId?: AgentSessionId
+        message?: string
+        cwd?: string
+      }
     | undefined
   const queues = new Map<
     string,
@@ -796,15 +932,19 @@ function createFakeService(agents: AgentDefinition[]) {
       agents[index] = next
       return next
     },
-    async getHistory(agentId: string) {
+    async getHistory(
+      agentId: string,
+      sessionId: AgentSessionId = MAIN_AGENT_SESSION_ID,
+    ) {
       return {
         agentId,
-        sessionId: 'main' as const,
+        sessionId,
         items: [],
       }
     },
     async startTurn(input: {
       agentId: string
+      sessionId?: AgentSessionId
       message?: string
       cwd?: string
     }) {
@@ -815,7 +955,10 @@ function createFakeService(agents: AgentDefinition[]) {
         throw new UnknownAgentError(input.agentId)
       }
       lastStartTurnInput = input
-      const turn = registry.register(input.agentId, 'main')
+      const turn = registry.register(
+        input.agentId,
+        input.sessionId ?? MAIN_AGENT_SESSION_ID,
+      )
       const frames = registry.subscribe(turn.turnId, { fromSeq: -1 })
       if (!frames) throw new Error('registered turn was not subscribable')
       // Push the canned events asynchronously so subscribers actually
@@ -828,13 +971,25 @@ function createFakeService(agents: AgentDefinition[]) {
     attachTurn(input: { turnId: string; lastSeq?: number }) {
       return registry.subscribe(input.turnId, { fromSeq: input.lastSeq ?? -1 })
     },
-    getActiveTurn(agentId: string): ActiveTurnInfo | null {
-      const t = registry.getActiveFor(agentId, 'main')
+    getActiveTurn(
+      agentId: string,
+      sessionId: AgentSessionId = MAIN_AGENT_SESSION_ID,
+    ): ActiveTurnInfo | null {
+      const t = registry.getActiveFor(agentId, sessionId)
       return t ? registry.describe(t.turnId) : null
     },
-    cancelTurn(input: { agentId: string; turnId?: string; reason?: string }) {
+    cancelTurn(input: {
+      agentId: string
+      sessionId?: AgentSessionId
+      turnId?: string
+      reason?: string
+    }) {
       const turnId =
-        input.turnId ?? registry.getActiveFor(input.agentId, 'main')?.turnId
+        input.turnId ??
+        registry.getActiveFor(
+          input.agentId,
+          input.sessionId ?? MAIN_AGENT_SESSION_ID,
+        )?.turnId
       if (!turnId) return false
       return registry.cancel(turnId, input.reason)
     },
@@ -928,18 +1083,22 @@ function createBlockingFakeService(agents: AgentDefinition[]) {
     async updateAgent() {
       return null
     },
-    async getHistory(agentId: string) {
-      return { agentId, sessionId: 'main' as const, items: [] }
+    async getHistory(
+      agentId: string,
+      sessionId: AgentSessionId = MAIN_AGENT_SESSION_ID,
+    ) {
+      return { agentId, sessionId, items: [] }
     },
-    async startTurn(input: { agentId: string }) {
-      const existing = registry.getActiveFor(input.agentId, 'main')
+    async startTurn(input: { agentId: string; sessionId?: AgentSessionId }) {
+      const sessionId = input.sessionId ?? MAIN_AGENT_SESSION_ID
+      const existing = registry.getActiveFor(input.agentId, sessionId)
       if (existing) {
         const { TurnAlreadyActiveError } = await import(
           '../../../src/api/services/agents/agent-harness-service'
         )
         throw new TurnAlreadyActiveError(input.agentId, existing.turnId)
       }
-      const turn = registry.register(input.agentId, 'main')
+      const turn = registry.register(input.agentId, sessionId)
       const frames = registry.subscribe(turn.turnId, { fromSeq: -1 })
       if (!frames) throw new Error('registered turn was not subscribable')
       void (async () => {
@@ -951,14 +1110,26 @@ function createBlockingFakeService(agents: AgentDefinition[]) {
     attachTurn(input: { turnId: string; lastSeq?: number }) {
       return registry.subscribe(input.turnId, { fromSeq: input.lastSeq ?? -1 })
     },
-    getActiveTurn(agentId: string): ActiveTurnInfo | null {
-      const t = registry.getActiveFor(agentId, 'main')
+    getActiveTurn(
+      agentId: string,
+      sessionId: AgentSessionId = MAIN_AGENT_SESSION_ID,
+    ): ActiveTurnInfo | null {
+      const t = registry.getActiveFor(agentId, sessionId)
       return t ? registry.describe(t.turnId) : null
     },
-    cancelTurn(input: { agentId: string; turnId?: string; reason?: string }) {
+    cancelTurn(input: {
+      agentId: string
+      sessionId?: AgentSessionId
+      turnId?: string
+      reason?: string
+    }) {
       cancelCalls.push({ agentId: input.agentId, reason: input.reason })
       const turnId =
-        input.turnId ?? registry.getActiveFor(input.agentId, 'main')?.turnId
+        input.turnId ??
+        registry.getActiveFor(
+          input.agentId,
+          input.sessionId ?? MAIN_AGENT_SESSION_ID,
+        )?.turnId
       if (!turnId) return false
       return registry.cancel(turnId, input.reason)
     },

--- a/packages/browseros-agent/apps/server/tests/api/routes/agents.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/agents.test.ts
@@ -137,6 +137,41 @@ describe('createAgentRoutes', () => {
     expect(body).toContain('data: [DONE]')
   })
 
+  it('streams chat for a requested agent session', async () => {
+    const sessionId = '00000000-0000-4000-8000-000000000001'
+    const agent: AgentDefinition = {
+      id: 'agent-1',
+      name: 'Review bot',
+      adapter: 'codex',
+      modelId: 'gpt-5.5',
+      reasoningEffort: 'medium',
+      permissionMode: 'approve-all',
+      sessionKey: 'agent:agent-1:main',
+      createdAt: 1000,
+      updatedAt: 1000,
+    }
+    const service = createFakeService([agent])
+    const route = new Hono().route('/agents', createAgentRoutes({ service }))
+
+    const response = await route.request(
+      `/agents/agent-1/sessions/${sessionId}/chat`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: 'hi' }),
+      },
+    )
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get('X-Session-Id')).toBe(sessionId)
+    expect(response.headers.get('X-Turn-Id')).toBeTruthy()
+    await response.text()
+    expect(service._lastStartTurnInput).toMatchObject({
+      agentId: 'agent-1',
+      sessionId,
+    })
+  })
+
   it('passes selected cwd from generic agent chat requests', async () => {
     const agent: AgentDefinition = {
       id: 'agent-1',
@@ -290,6 +325,53 @@ describe('createAgentRoutes', () => {
     expect(attachBody).toContain('"type":"text_delta"')
     expect(attachBody).toContain('data: [DONE]')
 
+    await (await first).text()
+  })
+
+  it('reports and attaches active turns for a requested session', async () => {
+    const sessionId = '00000000-0000-4000-8000-000000000001'
+    const agent: AgentDefinition = {
+      id: 'agent-1',
+      name: 'Review bot',
+      adapter: 'codex',
+      modelId: 'gpt-5.5',
+      reasoningEffort: 'medium',
+      permissionMode: 'approve-all',
+      sessionKey: 'agent:agent-1:main',
+      createdAt: 1000,
+      updatedAt: 1000,
+    }
+    const blocking = createBlockingFakeService([agent])
+    const route = new Hono().route(
+      '/agents',
+      createAgentRoutes({ service: blocking }),
+    )
+
+    const first = route.request(`/agents/agent-1/sessions/${sessionId}/chat`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: 'hi' }),
+    })
+    await new Promise((r) => setTimeout(r, 5))
+
+    const active = await route.request(
+      `/agents/agent-1/sessions/${sessionId}/chat/active`,
+    )
+    const activeBody = await active.json()
+    expect(activeBody.active).toMatchObject({
+      agentId: 'agent-1',
+      sessionId,
+      status: 'running',
+    })
+
+    const attachPromise = route.request(
+      `/agents/agent-1/sessions/${sessionId}/chat/stream?turnId=${activeBody.active.turnId}`,
+    )
+    blocking._unblock()
+    const attach = await attachPromise
+    expect(attach.status).toBe(200)
+    expect(attach.headers.get('X-Session-Id')).toBe(sessionId)
+    expect(await attach.text()).toContain('data: [DONE]')
     await (await first).text()
   })
 
@@ -780,6 +862,36 @@ describe('createAgentRoutes', () => {
     expect(removeMissing.status).toBe(404)
   })
 
+  it('queues messages for a requested agent session', async () => {
+    const sessionId = '00000000-0000-4000-8000-000000000001'
+    const agent: AgentDefinition = {
+      id: 'agent-1',
+      name: 'Review bot',
+      adapter: 'codex',
+      modelId: 'gpt-5.5',
+      reasoningEffort: 'medium',
+      permissionMode: 'approve-all',
+      sessionKey: 'agent:agent-1:main',
+      createdAt: 1000,
+      updatedAt: 1000,
+    }
+    const route = createMountedRoutes([agent])
+
+    const enqueue = await route.request(
+      `/agents/agent-1/sessions/${sessionId}/queue`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: 'follow up' }),
+      },
+    )
+
+    expect(enqueue.status).toBe(200)
+    expect(await enqueue.json()).toMatchObject({
+      queued: { sessionId, message: 'follow up' },
+    })
+  })
+
   it('rejects empty queue messages and unknown agents', async () => {
     const route = createMountedRoutes([
       {
@@ -867,6 +979,7 @@ function createFakeService(agents: AgentDefinition[]) {
     Array<{
       id: string
       createdAt: number
+      sessionId?: AgentSessionId
       message: string
       attachments?: ReadonlyArray<{ mediaType: string; data: string }>
     }>
@@ -886,6 +999,16 @@ function createFakeService(agents: AgentDefinition[]) {
         ...agent,
         status: 'idle' as const,
         lastUsedAt: null,
+        lastUserMessage: null,
+        cwd: null,
+        tokens: null,
+        turnsByDay: [],
+        failedByDay: [],
+        lastError: null,
+        lastErrorAt: null,
+        latestSessionId: null,
+        activeTurnId: null,
+        queue: queues.get(agent.id) ?? [],
       }))
     },
     async createAgent(input: {
@@ -995,6 +1118,7 @@ function createFakeService(agents: AgentDefinition[]) {
     },
     async enqueueMessage(input: {
       agentId: string
+      sessionId?: AgentSessionId
       message: string
       attachments?: ReadonlyArray<{ mediaType: string; data: string }>
     }) {
@@ -1007,6 +1131,7 @@ function createFakeService(agents: AgentDefinition[]) {
       const queued = {
         id: `q-${Math.random().toString(36).slice(2, 10)}`,
         createdAt: Date.now(),
+        sessionId: input.sessionId,
         message: input.message,
         attachments: input.attachments,
       }
@@ -1069,6 +1194,16 @@ function createBlockingFakeService(agents: AgentDefinition[]) {
         ...agent,
         status: 'idle' as const,
         lastUsedAt: null,
+        lastUserMessage: null,
+        cwd: null,
+        tokens: null,
+        turnsByDay: [],
+        failedByDay: [],
+        lastError: null,
+        lastErrorAt: null,
+        latestSessionId: null,
+        activeTurnId: null,
+        queue: [],
       }))
     },
     async createAgent() {

--- a/packages/browseros-agent/apps/server/tests/api/routes/agents.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/agents.test.ts
@@ -254,9 +254,7 @@ describe('createAgentRoutes', () => {
       body: JSON.stringify({ message: 'hi' }),
     })
 
-    // Yield so the first request reaches startTurn before the second
-    // arrives.
-    await new Promise((r) => setTimeout(r, 5))
+    await blocking._waitForStarted()
 
     const second = await blockingRoute.request('/agents/agent-1/chat', {
       method: 'POST',
@@ -267,7 +265,9 @@ describe('createAgentRoutes', () => {
     const body = await second.json()
     expect(body).toMatchObject({ error: 'Turn already active' })
     expect(typeof body.turnId).toBe('string')
-    expect(body.attachUrl).toContain(`turnId=${body.turnId}`)
+    expect(body.attachUrl).toBe(
+      `/agents/agent-1/chat/stream?turnId=${body.turnId}`,
+    )
 
     // Unblock and drain the first.
     blocking._unblock()
@@ -301,7 +301,7 @@ describe('createAgentRoutes', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ message: 'hi' }),
     })
-    await new Promise((r) => setTimeout(r, 5))
+    await blocking._waitForStarted()
 
     const active = await blockingRoute.request('/agents/agent-1/chat/active')
     expect(active.status).toBe(200)
@@ -352,7 +352,7 @@ describe('createAgentRoutes', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ message: 'hi' }),
     })
-    await new Promise((r) => setTimeout(r, 5))
+    await blocking._waitForStarted()
 
     const active = await route.request(
       `/agents/agent-1/sessions/${sessionId}/chat/active`,
@@ -398,7 +398,7 @@ describe('createAgentRoutes', () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ message: 'hi' }),
     })
-    await new Promise((r) => setTimeout(r, 5))
+    await blocking._waitForStarted()
 
     const cancel = await blockingRoute.request('/agents/agent-1/chat/cancel', {
       method: 'POST',
@@ -656,24 +656,27 @@ describe('createAgentRoutes', () => {
       createAgentRoutes({ service: blocking }),
     )
 
+    const requestBody = validCreatedAgentSidepanelBody()
     const first = route.request('/agents/agent-1/sidepanel/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(validCreatedAgentSidepanelBody()),
+      body: JSON.stringify(requestBody),
     })
-    await new Promise((r) => setTimeout(r, 5))
+    await blocking._waitForStarted()
 
     const second = await route.request('/agents/agent-1/sidepanel/chat', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(validCreatedAgentSidepanelBody()),
+      body: JSON.stringify(requestBody),
     })
 
     expect(second.status).toBe(409)
     const body = await second.json()
     expect(body).toMatchObject({ error: 'Turn already active' })
     expect(typeof body.turnId).toBe('string')
-    expect(body.attachUrl).toContain(`turnId=${body.turnId}`)
+    expect(body.attachUrl).toBe(
+      `/agents/agent-1/sessions/${requestBody.conversationId}/chat/stream?turnId=${body.turnId}`,
+    )
 
     blocking._unblock()
     await (await first).text()
@@ -707,7 +710,7 @@ describe('createAgentRoutes', () => {
         conversationId: firstSessionId,
       }),
     })
-    await new Promise((r) => setTimeout(r, 5))
+    await blocking._waitForStarted()
 
     const second = await route.request('/agents/agent-1/sidepanel/chat', {
       method: 'POST',
@@ -730,6 +733,10 @@ describe('createAgentRoutes', () => {
       }),
     })
     expect(duplicate.status).toBe(409)
+    const duplicateBody = await duplicate.json()
+    expect(duplicateBody.attachUrl).toBe(
+      `/agents/agent-1/sessions/${firstSessionId}/chat/stream?turnId=${duplicateBody.turnId}`,
+    )
 
     blocking._unblock()
     const firstResponse = await first
@@ -1180,10 +1187,28 @@ function createBlockingFakeService(agents: AgentDefinition[]) {
     { type: 'done', stopReason: 'end_turn' },
   ]
   let unblock: () => void = () => {}
+  let startedCount = 0
   const cancelCalls: Array<{ agentId: string; reason?: string }> = []
+  const startedWaiters: Array<{ count: number; resolve: () => void }> = []
   const gate = new Promise<void>((resolve) => {
     unblock = resolve
   })
+  const notifyStarted = () => {
+    startedCount += 1
+    for (let index = startedWaiters.length - 1; index >= 0; index -= 1) {
+      const waiter = startedWaiters[index]
+      if (waiter && startedCount >= waiter.count) {
+        startedWaiters.splice(index, 1)
+        waiter.resolve()
+      }
+    }
+  }
+  const waitForStarted = (count = 1) =>
+    startedCount >= count
+      ? Promise.resolve()
+      : new Promise<void>((resolve) => {
+          startedWaiters.push({ count, resolve })
+        })
 
   return {
     async listAgents() {
@@ -1234,6 +1259,7 @@ function createBlockingFakeService(agents: AgentDefinition[]) {
         throw new TurnAlreadyActiveError(input.agentId, existing.turnId)
       }
       const turn = registry.register(input.agentId, sessionId)
+      notifyStarted()
       const frames = registry.subscribe(turn.turnId, { fromSeq: -1 })
       if (!frames) throw new Error('registered turn was not subscribable')
       void (async () => {
@@ -1278,6 +1304,7 @@ function createBlockingFakeService(agents: AgentDefinition[]) {
       return []
     },
     _unblock: () => unblock(),
+    _waitForStarted: waitForStarted,
     _cancelCalls: cancelCalls,
   }
 }

--- a/packages/browseros-agent/apps/server/tests/api/services/agents/agent-harness-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/agents/agent-harness-service.test.ts
@@ -12,13 +12,15 @@ import {
   AgentHarnessService,
   type EnsureVmRuntimeReady,
 } from '../../../../src/api/services/agents/agent-harness-service'
-import type { TurnFrame } from '../../../../src/lib/agents/turns/active-turn-registry'
 import type {
   AgentDefinition,
   AgentSessionId,
 } from '../../../../src/lib/agents/agent-types'
 import type { AgentStore } from '../../../../src/lib/agents/storage/agent-store'
-import { TurnRegistry } from '../../../../src/lib/agents/turns/active-turn-registry'
+import {
+  type TurnFrame,
+  TurnRegistry,
+} from '../../../../src/lib/agents/turns/active-turn-registry'
 import type {
   AgentRuntime,
   AgentStreamEvent,
@@ -295,7 +297,7 @@ describe('AgentHarnessService', () => {
     expect(listed[0]?.status).toBe('error')
   })
 
-  it('does not show sidepanel session errors on the main activity row', async () => {
+  it('shows latest sidepanel session errors on the activity row', async () => {
     const sessionId = '00000000-0000-4000-8000-000000000001'
     const agent: AgentDefinition = {
       id: 'agent-1',
@@ -343,8 +345,58 @@ describe('AgentHarnessService', () => {
     })
     await collectFrameStream(turn.frames)
     const listed = await service.listAgentsWithActivity()
-    expect(listed[0]?.status).toBe('idle')
-    expect(listed[0]?.lastError).toBeNull()
+    expect(listed[0]?.status).toBe('error')
+    expect(listed[0]?.latestSessionId).toBe(sessionId)
+    expect(listed[0]?.lastError).toBe('sidepanel failed')
+  })
+
+  it('prefers newer live activity over an older persisted row snapshot', async () => {
+    const sessionId = '00000000-0000-4000-8000-000000000001'
+    const agent: AgentDefinition = {
+      id: 'agent-1',
+      name: 'Review bot',
+      adapter: 'codex',
+      modelId: 'gpt-5.5',
+      reasoningEffort: 'medium',
+      permissionMode: 'approve-all',
+      sessionKey: 'agent:agent-1:main',
+      createdAt: 1000,
+      updatedAt: 1000,
+    }
+    const held = createHeldRuntime()
+    const runtime: AgentRuntime = {
+      ...held.runtime,
+      async getLatestRowSnapshot() {
+        return {
+          sessionId: 'main',
+          cwd: null,
+          lastUsedAt: 1,
+          lastUserMessage: 'old main prompt',
+          tokens: null,
+        }
+      },
+    }
+    const service = new AgentHarnessService({
+      agentStore: createAgentStore([agent]) as AgentStore,
+      runtime,
+    })
+
+    const turn = await service.startTurn({
+      agentId: agent.id,
+      sessionId,
+      message: 'new sidepanel prompt',
+    })
+    const frames = collectFrameStream(turn.frames)
+    const listed = await service.listAgentsWithActivity()
+
+    expect(listed[0]?.status).toBe('working')
+    expect(listed[0]?.latestSessionId).toBe(sessionId)
+    expect(listed[0]?.activeTurnId).toBe(turn.turnId)
+    expect(listed[0]?.lastUserMessage).toBe('new sidepanel prompt')
+    expect(listed[0]?.lastUsedAt).toBeGreaterThan(1)
+
+    held.release(sessionId)
+    await frames
   })
 
   it('runs concurrent turns for different sessions and blocks duplicates per session', async () => {
@@ -392,12 +444,55 @@ describe('AgentHarnessService', () => {
     held.release('main')
     await collectFrameStream(main.frames)
     let listed = await service.listAgentsWithActivity()
-    expect(listed[0]?.status).toBe('idle')
+    expect(listed[0]?.status).toBe('working')
+    expect(listed[0]?.latestSessionId).toBe(sessionId)
 
     held.release(sessionId)
     await collectFrameStream(sidepanel.frames)
     listed = await service.listAgentsWithActivity()
     expect(listed[0]?.status).toBe('idle')
+  })
+
+  it('drains queued messages into the queued session', async () => {
+    const sessionId = '00000000-0000-4000-8000-000000000001'
+    const agent: AgentDefinition = {
+      id: 'agent-1',
+      name: 'Review bot',
+      adapter: 'codex',
+      modelId: 'gpt-5.5',
+      reasoningEffort: 'medium',
+      permissionMode: 'approve-all',
+      sessionKey: 'agent:agent-1:main',
+      createdAt: 1000,
+      updatedAt: 1000,
+    }
+    const held = createHeldRuntime()
+    const service = new AgentHarnessService({
+      agentStore: createAgentStore([agent]) as AgentStore,
+      runtime: held.runtime,
+    })
+
+    const first = await service.startTurn({
+      agentId: agent.id,
+      sessionId,
+      message: 'first',
+    })
+    const queued = await service.enqueueMessage({
+      agentId: agent.id,
+      sessionId,
+      message: 'second',
+    })
+
+    expect(queued.sessionId).toBe(sessionId)
+    held.release(sessionId)
+    await collectFrameStream(first.frames)
+    await waitFor(() => held.inputs.length === 2)
+
+    expect(held.inputs.map((input) => input.sessionId)).toEqual([
+      sessionId,
+      sessionId,
+    ])
+    held.release(sessionId)
   })
 
   it('writes a per-agent Hermes config.yaml + .env when adapter=hermes and provider config complete', async () => {
@@ -832,4 +927,17 @@ async function collectFrameStream(
     reader.releaseLock()
   }
   return frames
+}
+
+async function waitFor(
+  predicate: () => boolean,
+  timeoutMs = 500,
+): Promise<void> {
+  const started = Date.now()
+  while (!predicate()) {
+    if (Date.now() - started > timeoutMs) {
+      throw new Error('Timed out waiting for condition')
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5))
+  }
 }

--- a/packages/browseros-agent/apps/server/tests/api/services/agents/agent-harness-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/agents/agent-harness-service.test.ts
@@ -12,7 +12,11 @@ import {
   AgentHarnessService,
   type EnsureVmRuntimeReady,
 } from '../../../../src/api/services/agents/agent-harness-service'
-import type { AgentDefinition } from '../../../../src/lib/agents/agent-types'
+import type { TurnFrame } from '../../../../src/lib/agents/turns/active-turn-registry'
+import type {
+  AgentDefinition,
+  AgentSessionId,
+} from '../../../../src/lib/agents/agent-types'
 import type { AgentStore } from '../../../../src/lib/agents/storage/agent-store'
 import { TurnRegistry } from '../../../../src/lib/agents/turns/active-turn-registry'
 import type {
@@ -150,6 +154,45 @@ describe('AgentHarnessService', () => {
     })
   })
 
+  it('reads history from a requested session id', async () => {
+    const sessionId = '00000000-0000-4000-8000-000000000001'
+    const agent: AgentDefinition = {
+      id: 'agent-1',
+      name: 'Review bot',
+      adapter: 'codex',
+      modelId: 'gpt-5.5',
+      reasoningEffort: 'medium',
+      permissionMode: 'approve-all',
+      sessionKey: 'agent:agent-1:main',
+      createdAt: 1000,
+      updatedAt: 1000,
+    }
+    const runtimeInputs: unknown[] = []
+    const runtime: AgentRuntime = {
+      async status() {
+        return { state: 'ready' }
+      },
+      async listSessions() {
+        return []
+      },
+      async getHistory(input) {
+        runtimeInputs.push(input)
+        return { agentId: agent.id, sessionId: input.sessionId, items: [] }
+      },
+      async send() {
+        return new ReadableStream<AgentStreamEvent>()
+      },
+    }
+    const service = new AgentHarnessService({
+      agentStore: createAgentStore([agent]) as AgentStore,
+      runtime,
+    })
+
+    await service.getHistory(agent.id, sessionId)
+
+    expect(runtimeInputs).toEqual([{ agent, sessionId }])
+  })
+
   it('marks an agent working while a turn streams and idle once it ends', async () => {
     const agent: AgentDefinition = {
       id: 'live-1',
@@ -250,6 +293,59 @@ describe('AgentHarnessService', () => {
     await collectStream(await service.send({ agentId: agent.id, message: 'x' }))
     const listed = await service.listAgentsWithActivity()
     expect(listed[0]?.status).toBe('error')
+  })
+
+  it('runs concurrent turns for different sessions and blocks duplicates per session', async () => {
+    const sessionId = '00000000-0000-4000-8000-000000000001'
+    const agent: AgentDefinition = {
+      id: 'agent-1',
+      name: 'Review bot',
+      adapter: 'codex',
+      modelId: 'gpt-5.5',
+      reasoningEffort: 'medium',
+      permissionMode: 'approve-all',
+      sessionKey: 'agent:agent-1:main',
+      createdAt: 1000,
+      updatedAt: 1000,
+    }
+    const held = createHeldRuntime()
+    const service = new AgentHarnessService({
+      agentStore: createAgentStore([agent]) as AgentStore,
+      runtime: held.runtime,
+    })
+
+    const main = await service.startTurn({
+      agentId: agent.id,
+      sessionId: 'main',
+      message: 'main turn',
+    })
+    const sidepanel = await service.startTurn({
+      agentId: agent.id,
+      sessionId,
+      message: 'sidepanel turn',
+    })
+
+    expect(held.inputs.map((input) => input.sessionId)).toEqual([
+      'main',
+      sessionId,
+    ])
+    await expect(
+      service.startTurn({
+        agentId: agent.id,
+        sessionId,
+        message: 'duplicate',
+      }),
+    ).rejects.toThrow('already has an active turn')
+
+    held.release('main')
+    await collectFrameStream(main.frames)
+    let listed = await service.listAgentsWithActivity()
+    expect(listed[0]?.status).toBe('working')
+
+    held.release(sessionId)
+    await collectFrameStream(sidepanel.frames)
+    listed = await service.listAgentsWithActivity()
+    expect(listed[0]?.status).toBe('idle')
   })
 
   it('writes a per-agent Hermes config.yaml + .env when adapter=hermes and provider config complete', async () => {
@@ -546,6 +642,57 @@ function stubRuntime(): AgentRuntime {
   }
 }
 
+function createHeldRuntime(): {
+  runtime: AgentRuntime
+  inputs: Array<Parameters<AgentRuntime['send']>[0]>
+  release(sessionId: AgentSessionId): void
+} {
+  const inputs: Array<Parameters<AgentRuntime['send']>[0]> = []
+  const releases = new Map<AgentSessionId, () => void>()
+  return {
+    inputs,
+    release(sessionId) {
+      const release = releases.get(sessionId)
+      if (!release) throw new Error(`No held stream for ${sessionId}`)
+      release()
+      releases.delete(sessionId)
+    },
+    runtime: {
+      async status() {
+        return { state: 'ready' }
+      },
+      async listSessions() {
+        return []
+      },
+      async getHistory(input) {
+        return {
+          agentId: input.agent.id,
+          sessionId: input.sessionId,
+          items: [],
+        }
+      },
+      async send(input) {
+        inputs.push(input)
+        const gate = new Promise<void>((resolve) => {
+          releases.set(input.sessionId, resolve)
+        })
+        return new ReadableStream<AgentStreamEvent>({
+          async start(controller) {
+            controller.enqueue({
+              type: 'text_delta',
+              text: `started ${input.sessionId}`,
+              stream: 'output',
+            })
+            await gate
+            controller.enqueue({ type: 'done', stopReason: 'end_turn' })
+            controller.close()
+          },
+        })
+      },
+    },
+  }
+}
+
 function createAgentStore(agents: AgentDefinition[]) {
   return {
     async list() {
@@ -616,4 +763,21 @@ async function collectStream(
     reader.releaseLock()
   }
   return events
+}
+
+async function collectFrameStream(
+  stream: ReadableStream<TurnFrame>,
+): Promise<TurnFrame[]> {
+  const reader = stream.getReader()
+  const frames: TurnFrame[] = []
+  try {
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      frames.push(value)
+    }
+  } finally {
+    reader.releaseLock()
+  }
+  return frames
 }

--- a/packages/browseros-agent/apps/server/tests/api/services/agents/agent-harness-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/agents/agent-harness-service.test.ts
@@ -295,6 +295,58 @@ describe('AgentHarnessService', () => {
     expect(listed[0]?.status).toBe('error')
   })
 
+  it('does not show sidepanel session errors on the main activity row', async () => {
+    const sessionId = '00000000-0000-4000-8000-000000000001'
+    const agent: AgentDefinition = {
+      id: 'agent-1',
+      name: 'Review bot',
+      adapter: 'codex',
+      modelId: 'gpt-5.5',
+      reasoningEffort: 'medium',
+      permissionMode: 'approve-all',
+      sessionKey: 'agent:agent-1:main',
+      createdAt: 1000,
+      updatedAt: 1000,
+    }
+    const runtime: AgentRuntime = {
+      async status() {
+        return { state: 'ready' }
+      },
+      async listSessions() {
+        return []
+      },
+      async getHistory(input) {
+        return {
+          agentId: input.agent.id,
+          sessionId: input.sessionId,
+          items: [],
+        }
+      },
+      async send() {
+        return new ReadableStream<AgentStreamEvent>({
+          start(controller) {
+            controller.enqueue({ type: 'error', message: 'sidepanel failed' })
+            controller.close()
+          },
+        })
+      },
+    }
+    const service = new AgentHarnessService({
+      agentStore: createAgentStore([agent]) as AgentStore,
+      runtime,
+    })
+
+    const turn = await service.startTurn({
+      agentId: agent.id,
+      sessionId,
+      message: 'sidepanel turn',
+    })
+    await collectFrameStream(turn.frames)
+    const listed = await service.listAgentsWithActivity()
+    expect(listed[0]?.status).toBe('idle')
+    expect(listed[0]?.lastError).toBeNull()
+  })
+
   it('runs concurrent turns for different sessions and blocks duplicates per session', async () => {
     const sessionId = '00000000-0000-4000-8000-000000000001'
     const agent: AgentDefinition = {
@@ -340,7 +392,7 @@ describe('AgentHarnessService', () => {
     held.release('main')
     await collectFrameStream(main.frames)
     let listed = await service.listAgentsWithActivity()
-    expect(listed[0]?.status).toBe('working')
+    expect(listed[0]?.status).toBe('idle')
 
     held.release(sessionId)
     await collectFrameStream(sidepanel.frames)

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-agent-adapter.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-agent-adapter.test.ts
@@ -8,6 +8,8 @@ import { mkdtemp, readFile, rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { prepareAcpxAgentContext } from '../../../src/lib/agents/acpx/agent-adapter'
+import { resolveAgentRuntimePaths } from '../../../src/lib/agents/acpx/runtime-context'
+import { loadLatestRuntimeState } from '../../../src/lib/agents/acpx/runtime-state'
 import type { AgentDefinition } from '../../../src/lib/agents/agent-types'
 
 describe('prepareAcpxAgentContext', () => {
@@ -80,6 +82,43 @@ describe('prepareAcpxAgentContext', () => {
     expect(prepared.commandEnv).not.toHaveProperty('CLAUDE_CONFIG_DIR')
     expect(prepared.useBrowserosMcp).toBe(true)
     expect(prepared.runPrompt).toContain('AGENT_HOME=')
+  })
+
+  it('prepares a UUID session with separate runtime-state files', async () => {
+    const browserosDir = await mkdtemp(join(tmpdir(), 'browseros-adapters-'))
+    tempDirs.push(browserosDir)
+    const sessionId = '00000000-0000-4000-8000-000000000001'
+
+    const prepared = await prepareAcpxAgentContext({
+      browserosDir,
+      agent: makeAgent('claude'),
+      sessionId,
+      sessionKey: 'agent:claude-agent:main',
+      cwdOverride: null,
+      isSelectedCwd: false,
+      message: 'hi',
+    })
+    const paths = resolveAgentRuntimePaths({
+      browserosDir,
+      agentId: 'claude-agent',
+      sessionId,
+    })
+
+    expect(prepared.runtimeSessionKey).toMatch(
+      /^agent:claude-agent:00000000-0000-4000-8000-000000000001:[a-f0-9]{16}$/,
+    )
+    expect(await loadLatestRuntimeState(paths.runtimeSessionStatePath)).toEqual(
+      expect.objectContaining({
+        sessionId,
+        runtimeSessionKey: prepared.runtimeSessionKey,
+      }),
+    )
+    expect(await loadLatestRuntimeState(paths.runtimeStatePath)).toEqual(
+      expect.objectContaining({
+        sessionId,
+        runtimeSessionKey: prepared.runtimeSessionKey,
+      }),
+    )
   })
 
   it('prepares Hermes with HERMES_HOME pointing at the in-container agent home (translated from the host path)', async () => {

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime-context.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime-context.test.ts
@@ -52,6 +52,16 @@ describe('acpx runtime context helpers', () => {
     expect(paths.runtimeStatePath).toBe(
       join(browserosDir, 'agents', 'harness', 'runtime-state', 'agent-1.json'),
     )
+    expect(paths.runtimeSessionStatePath).toBe(
+      join(
+        browserosDir,
+        'agents',
+        'harness',
+        'runtime-state',
+        'agent-1',
+        'main.json',
+      ),
+    )
     expect(paths.runtimeSkillsDir).toBe(
       join(browserosDir, 'agents', 'harness', 'runtime-skills'),
     )
@@ -82,6 +92,31 @@ describe('acpx runtime context helpers', () => {
     })
 
     expect(paths.effectiveCwd).toBe(selected)
+  })
+
+  it('resolves a stable runtime-state path for UUID sessions', async () => {
+    const browserosDir = await mkdtemp(join(tmpdir(), 'browseros-context-'))
+    tempDirs.push(browserosDir)
+
+    const paths = resolveAgentRuntimePaths({
+      browserosDir,
+      agentId: 'agent-1',
+      sessionId: '00000000-0000-4000-8000-000000000001',
+    })
+
+    expect(paths.runtimeStatePath).toBe(
+      join(browserosDir, 'agents', 'harness', 'runtime-state', 'agent-1.json'),
+    )
+    expect(paths.runtimeSessionStatePath).toBe(
+      join(
+        browserosDir,
+        'agents',
+        'harness',
+        'runtime-state',
+        'agent-1',
+        '00000000-0000-4000-8000-000000000001.json',
+      ),
+    )
   })
 
   it('seeds agent home and does not overwrite edited files', async () => {

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime-state.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime-state.test.ts
@@ -77,4 +77,56 @@ describe('acpx runtime state', () => {
       deriveRuntimeSessionKey({ ...base, skillIdentity: 'skills-v2' }),
     ).not.toBe(first)
   })
+
+  it('derives stable session keys for UUID sessions', () => {
+    const sessionId = '00000000-0000-4000-8000-000000000001'
+    const base = {
+      agentId: 'agent-1',
+      sessionId,
+      adapter: 'codex',
+      cwd: '/tmp/work',
+      agentHome: '/tmp/agent-home',
+      promptVersion: 'v1',
+      skillIdentity: 'skills-v1',
+      commandIdentity: 'codex-home-v1',
+    }
+
+    const first = deriveRuntimeSessionKey(base)
+
+    expect(first).toMatch(
+      /^agent:agent-1:00000000-0000-4000-8000-000000000001:[a-f0-9]{16}$/,
+    )
+    expect(deriveRuntimeSessionKey(base)).toBe(first)
+    expect(deriveRuntimeSessionKey({ ...base, sessionId: 'main' })).not.toBe(
+      first,
+    )
+  })
+
+  it('saves and loads latest runtime state for a UUID session', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'browseros-runtime-state-'))
+    tempDirs.push(dir)
+    const filePath = join(
+      dir,
+      'agent-1',
+      '00000000-0000-4000-8000-000000000001.json',
+    )
+
+    await saveLatestRuntimeState(filePath, {
+      sessionId: '00000000-0000-4000-8000-000000000001',
+      runtimeSessionKey:
+        'agent:agent-1:00000000-0000-4000-8000-000000000001:abc',
+      cwd: '/tmp/work',
+      agentHome: '/tmp/agent-home',
+      updatedAt: 1234,
+    })
+
+    expect(await loadLatestRuntimeState(filePath)).toEqual({
+      sessionId: '00000000-0000-4000-8000-000000000001',
+      runtimeSessionKey:
+        'agent:agent-1:00000000-0000-4000-8000-000000000001:abc',
+      cwd: '/tmp/work',
+      agentHome: '/tmp/agent-home',
+      updatedAt: 1234,
+    })
+  })
 })

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -407,6 +407,15 @@ describe('AcpxRuntime', () => {
     })
 
     expect(snapshot?.lastUserMessage).toBe('main message')
+    expect(snapshot?.sessionId).toBe('main')
+
+    const latestSnapshot = await new AcpxRuntime({
+      browserosDir,
+      stateDir,
+    }).getLatestRowSnapshot(agent)
+
+    expect(latestSnapshot?.sessionId).toBe(sidepanelSession)
+    expect(latestSnapshot?.lastUserMessage).toBe('latest sidepanel message')
   })
 
   it('maps persisted acpx session records into rich history entries', async () => {

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -20,6 +20,8 @@ import {
   AcpxRuntime,
   unwrapBrowserosAcpUserMessage,
 } from '../../../src/lib/agents/acpx/runtime'
+import { resolveAgentRuntimePaths } from '../../../src/lib/agents/acpx/runtime-context'
+import { saveLatestRuntimeState } from '../../../src/lib/agents/acpx/runtime-state'
 import type { AgentDefinition } from '../../../src/lib/agents/agent-types'
 import {
   getAgentRuntimeRegistry,
@@ -266,6 +268,130 @@ describe('AcpxRuntime', () => {
     })
 
     expect(history.items.at(0)?.text).toBe('hello from latest')
+  })
+
+  it('loads main history from the main session even after another session is latest', async () => {
+    const browserosDir = await mkdtemp(
+      join(tmpdir(), 'browseros-acpx-browseros-'),
+    )
+    const stateDir = await mkdtemp(join(tmpdir(), 'browseros-acpx-state-'))
+    tempDirs.push(browserosDir, stateDir)
+    const sessionStore = createRuntimeStore({ stateDir })
+    const agent = makeAgent({ id: 'agent-1', adapter: 'codex' })
+    const sidepanelSession = '00000000-0000-4000-8000-000000000001'
+    const mainRuntimeSessionKey = 'agent:agent-1:main:abc123abc123abcd'
+    const sidepanelRuntimeSessionKey = `agent:agent-1:${sidepanelSession}:def456def456def0`
+    await createLatestRuntimeStateForTest({
+      browserosDir,
+      agentId: agent.id,
+      sessionId: 'main',
+      runtimeSessionKey: mainRuntimeSessionKey,
+      updateAgentLatest: false,
+    })
+    await createLatestRuntimeStateForTest({
+      browserosDir,
+      agentId: agent.id,
+      sessionId: sidepanelSession,
+      runtimeSessionKey: sidepanelRuntimeSessionKey,
+      updateAgentLatest: true,
+    })
+    await sessionStore.save(
+      makeSessionRecord({
+        key: mainRuntimeSessionKey,
+        cwd: join(browserosDir, 'agents', 'harness', 'workspace'),
+        userText: 'main conversation',
+      }),
+    )
+    await sessionStore.save(
+      makeSessionRecord({
+        key: sidepanelRuntimeSessionKey,
+        cwd: join(browserosDir, 'agents', 'harness', 'workspace'),
+        userText: 'sidepanel conversation',
+      }),
+    )
+
+    const history = await new AcpxRuntime({
+      browserosDir,
+      stateDir,
+    }).getHistory({
+      agent,
+      sessionId: 'main',
+    })
+
+    expect(history.items.at(0)?.text).toBe('main conversation')
+  })
+
+  it('loads history for a UUID session from that session state', async () => {
+    const browserosDir = await mkdtemp(
+      join(tmpdir(), 'browseros-acpx-browseros-'),
+    )
+    const stateDir = await mkdtemp(join(tmpdir(), 'browseros-acpx-state-'))
+    tempDirs.push(browserosDir, stateDir)
+    const sessionStore = createRuntimeStore({ stateDir })
+    const agent = makeAgent({ id: 'agent-1', adapter: 'codex' })
+    const sessionId = '00000000-0000-4000-8000-000000000001'
+    const runtimeSessionKey = `agent:agent-1:${sessionId}:abc123abc123abcd`
+    await createLatestRuntimeStateForTest({
+      browserosDir,
+      agentId: agent.id,
+      sessionId,
+      runtimeSessionKey,
+    })
+    await sessionStore.save(
+      makeSessionRecord({
+        key: runtimeSessionKey,
+        cwd: join(browserosDir, 'agents', 'harness', 'workspace'),
+        userText: 'uuid conversation',
+      }),
+    )
+
+    const history = await new AcpxRuntime({
+      browserosDir,
+      stateDir,
+    }).getHistory({
+      agent,
+      sessionId,
+    })
+
+    expect(history.sessionId).toBe(sessionId)
+    expect(history.items.at(0)?.sessionId).toBe(sessionId)
+    expect(history.items.at(0)?.text).toBe('uuid conversation')
+  })
+
+  it('reads row snapshots from latest agent activity across sessions', async () => {
+    const browserosDir = await mkdtemp(
+      join(tmpdir(), 'browseros-acpx-browseros-'),
+    )
+    const stateDir = await mkdtemp(join(tmpdir(), 'browseros-acpx-state-'))
+    tempDirs.push(browserosDir, stateDir)
+    const sessionStore = createRuntimeStore({ stateDir })
+    const agent = makeAgent({ id: 'agent-1', adapter: 'codex' })
+    const sidepanelSession = '00000000-0000-4000-8000-000000000001'
+    const sidepanelRuntimeSessionKey = `agent:agent-1:${sidepanelSession}:def456def456def0`
+    await createLatestRuntimeStateForTest({
+      browserosDir,
+      agentId: agent.id,
+      sessionId: sidepanelSession,
+      runtimeSessionKey: sidepanelRuntimeSessionKey,
+      updateAgentLatest: true,
+    })
+    await sessionStore.save(
+      makeSessionRecord({
+        key: sidepanelRuntimeSessionKey,
+        cwd: join(browserosDir, 'agents', 'harness', 'workspace'),
+        userText: 'latest sidepanel message',
+      }),
+    )
+
+    const snapshot = await new AcpxRuntime({
+      browserosDir,
+      stateDir,
+    }).getRowSnapshot({
+      agent,
+      sessionId: 'main',
+    })
+
+    expect(snapshot?.lastUserMessage).toBe('latest sidepanel message')
   })
 
   it('maps persisted acpx session records into rich history entries', async () => {
@@ -1319,33 +1445,32 @@ function makeAgent(input: {
 async function createLatestRuntimeStateForTest(input: {
   browserosDir: string
   agentId: string
+  sessionId?: string
   runtimeSessionKey: string
+  updateAgentLatest?: boolean
 }) {
-  const { saveLatestRuntimeState } = await import(
-    '../../../src/lib/agents/acpx/runtime-state'
-  )
-  await saveLatestRuntimeState(
-    join(
+  const paths = resolveAgentRuntimePaths({
+    browserosDir: input.browserosDir,
+    agentId: input.agentId,
+    sessionId: input.sessionId ?? 'main',
+  })
+  const latest = {
+    sessionId: input.sessionId ?? 'main',
+    runtimeSessionKey: input.runtimeSessionKey,
+    cwd: join(input.browserosDir, 'agents', 'harness', 'workspace'),
+    agentHome: join(
       input.browserosDir,
       'agents',
       'harness',
-      'runtime-state',
-      `${input.agentId}.json`,
+      input.agentId,
+      'home',
     ),
-    {
-      sessionId: 'main',
-      runtimeSessionKey: input.runtimeSessionKey,
-      cwd: join(input.browserosDir, 'agents', 'harness', 'workspace'),
-      agentHome: join(
-        input.browserosDir,
-        'agents',
-        'harness',
-        input.agentId,
-        'home',
-      ),
-      updatedAt: 1234,
-    },
-  )
+    updatedAt: 1234,
+  }
+  await saveLatestRuntimeState(paths.runtimeSessionStatePath, latest)
+  if (input.updateAgentLatest ?? true) {
+    await saveLatestRuntimeState(paths.runtimeStatePath, latest)
+  }
 }
 
 async function writeFakeBundledBun(resourcesDir: string): Promise<string> {

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -358,7 +358,7 @@ describe('AcpxRuntime', () => {
     expect(history.items.at(0)?.text).toBe('uuid conversation')
   })
 
-  it('reads row snapshots from latest agent activity across sessions', async () => {
+  it('reads row snapshots from the requested session only', async () => {
     const browserosDir = await mkdtemp(
       join(tmpdir(), 'browseros-acpx-browseros-'),
     )
@@ -367,7 +367,15 @@ describe('AcpxRuntime', () => {
     const sessionStore = createRuntimeStore({ stateDir })
     const agent = makeAgent({ id: 'agent-1', adapter: 'codex' })
     const sidepanelSession = '00000000-0000-4000-8000-000000000001'
+    const mainRuntimeSessionKey = 'agent:agent-1:main:abc123abc123abcd'
     const sidepanelRuntimeSessionKey = `agent:agent-1:${sidepanelSession}:def456def456def0`
+    await createLatestRuntimeStateForTest({
+      browserosDir,
+      agentId: agent.id,
+      sessionId: 'main',
+      runtimeSessionKey: mainRuntimeSessionKey,
+      updateAgentLatest: false,
+    })
     await createLatestRuntimeStateForTest({
       browserosDir,
       agentId: agent.id,
@@ -375,6 +383,13 @@ describe('AcpxRuntime', () => {
       runtimeSessionKey: sidepanelRuntimeSessionKey,
       updateAgentLatest: true,
     })
+    await sessionStore.save(
+      makeSessionRecord({
+        key: mainRuntimeSessionKey,
+        cwd: join(browserosDir, 'agents', 'harness', 'workspace'),
+        userText: 'main message',
+      }),
+    )
     await sessionStore.save(
       makeSessionRecord({
         key: sidepanelRuntimeSessionKey,
@@ -391,7 +406,7 @@ describe('AcpxRuntime', () => {
       sessionId: 'main',
     })
 
-    expect(snapshot?.lastUserMessage).toBe('latest sidepanel message')
+    expect(snapshot?.lastUserMessage).toBe('main message')
   })
 
   it('maps persisted acpx session records into rich history entries', async () => {

--- a/packages/browseros-agent/apps/server/tests/lib/agents/active-turn-registry.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/active-turn-registry.test.ts
@@ -160,6 +160,31 @@ describe('TurnRegistry', () => {
     expect(registry.getActiveFor('agent-1')).toBeUndefined()
   })
 
+  it('tracks separate active turns for the same agent in different sessions', () => {
+    const registry = makeRegistry()
+    const sidepanelSession = '00000000-0000-4000-8000-000000000001'
+
+    const mainTurn = registry.register('agent-1', 'main')
+    const sidepanelTurn = registry.register('agent-1', sidepanelSession)
+
+    expect(registry.getActiveFor('agent-1', 'main')?.turnId).toBe(
+      mainTurn.turnId,
+    )
+    expect(registry.getActiveFor('agent-1', sidepanelSession)?.turnId).toBe(
+      sidepanelTurn.turnId,
+    )
+
+    registry.pushEvent(mainTurn.turnId, {
+      type: 'done',
+      stopReason: 'end_turn',
+    })
+
+    expect(registry.getActiveFor('agent-1', 'main')).toBeUndefined()
+    expect(registry.getActiveFor('agent-1', sidepanelSession)?.turnId).toBe(
+      sidepanelTurn.turnId,
+    )
+  })
+
   it('evicts terminal turns past the retain window via sweep', () => {
     const registry = makeRegistry({ retainAfterDoneMs: 1 })
     const turn = registry.register('agent-1')

--- a/packages/browseros-agent/apps/server/tests/lib/agents/message-queue.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/message-queue.test.ts
@@ -38,6 +38,15 @@ describe('FileMessageQueue', () => {
     ])
   })
 
+  it('persists the target session id with queued messages', async () => {
+    const sessionId = '00000000-0000-4000-8000-000000000001'
+    await queue.append('a', { sessionId, message: 'one' })
+
+    expect(await queue.list('a')).toEqual([
+      expect.objectContaining({ sessionId, message: 'one' }),
+    ])
+  })
+
   it('returns null when popping an empty queue', async () => {
     expect(await queue.popOldest('a')).toBeNull()
   })


### PR DESCRIPTION
## Summary

- Reworked New Tab agent UX so there is no product-level `main` conversation default.
- Added canonical full-page agent routes at `/home/agents/:agentId/sessions/:sessionId`; old `/home/agents/:agentId` redirects to the latest session or a fresh UUID.
- Home recent-agent cards now resume `latestSessionId`, while the Home composer starts ACP sends in a fresh UUID session.
- Added a full-page chat header plus button to start a new conversation for the same agent.
- Added session-specific server chat/active/stream/cancel/queue routes while keeping old `main` routes as compatibility fallbacks.
- Queued messages now retain `sessionId` and drain back into that session.

## Rework

The previous approach forced New Tab into `main`, which solved leakage but created the wrong UX. This rework treats every full-page agent chat as session-addressed: resume the latest real session by default, and use the plus button when the user wants a new session.

## Test plan

- `bun run --filter @browseros/server test:api`
- `bun run --filter @browseros/server test:lib`
- `bun run --filter @browseros/agent test`
- `bun run --filter @browseros/server typecheck`
- `bun run --filter @browseros/agent typecheck`
- `git diff --name-only | sed 's#^packages/browseros-agent/##' | xargs bunx biome check`
- `git diff --check`