### PR TITLE
feat: bundle Bun for Linux and Windows

### DIFF
--- a/packages/browseros-agent/apps/server/src/lib/agents/host-acp/bundled-bun.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/host-acp/bundled-bun.ts
@@ -8,6 +8,7 @@ import { accessSync, constants, statSync } from 'node:fs'
 import { join } from 'node:path'
 
 export const BUNDLED_BUN_RELATIVE_PATH = join('bin', 'third_party', 'bun')
+const WINDOWS_BUNDLED_BUN_RELATIVE_PATH = join('bin', 'third_party', 'bun.exe')
 
 /** Resolves the packaged Bun executable used to run ACP adapter packages. */
 export function resolveBundledBun(input: {
@@ -15,16 +16,29 @@ export function resolveBundledBun(input: {
   platform?: NodeJS.Platform
 }): string | null {
   const platform = input.platform ?? process.platform
-  if (platform !== 'darwin') return null
+  const relativePath = bundledBunRelativePath(platform)
+  if (!relativePath) return null
   const resourcesDir = input.resourcesDir?.trim()
   if (!resourcesDir) return null
 
-  const candidate = join(resourcesDir, BUNDLED_BUN_RELATIVE_PATH)
+  const candidate = join(resourcesDir, relativePath)
   try {
     if (!statSync(candidate).isFile()) return null
-    accessSync(candidate, constants.X_OK)
+    if (platform !== 'win32') {
+      accessSync(candidate, constants.X_OK)
+    }
     return candidate
   } catch {
     return null
   }
+}
+
+function bundledBunRelativePath(platform: NodeJS.Platform): string | null {
+  if (platform === 'darwin' || platform === 'linux') {
+    return BUNDLED_BUN_RELATIVE_PATH
+  }
+  if (platform === 'win32') {
+    return WINDOWS_BUNDLED_BUN_RELATIVE_PATH
+  }
+  return null
 }

--- a/packages/browseros-agent/apps/server/tests/lib/agents/bundled-bun.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/bundled-bun.test.ts
@@ -53,7 +53,7 @@ describe('bundled Bun helpers', () => {
     expect(resolveBundledBun({ resourcesDir, platform: 'win32' })).toBe(bunPath)
   })
 
-  it('ignores non-executable bundled Bun files', async () => {
+  it('ignores non-executable bundled Bun files on macOS', async () => {
     const resourcesDir = await mkdtemp(join(tmpdir(), 'browseros-bun-'))
     tempDirs.push(resourcesDir)
     const bunPath = join(resourcesDir, 'bin', 'third_party', 'bun')
@@ -62,6 +62,17 @@ describe('bundled Bun helpers', () => {
     await chmod(bunPath, 0o644)
 
     expect(resolveBundledBun({ resourcesDir, platform: 'darwin' })).toBeNull()
+  })
+
+  it('ignores non-executable bundled Bun files on Linux', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'browseros-bun-'))
+    tempDirs.push(resourcesDir)
+    const bunPath = join(resourcesDir, 'bin', 'third_party', 'bun')
+    await mkdir(dirname(bunPath), { recursive: true })
+    await writeFile(bunPath, '#!/bin/sh\n')
+    await chmod(bunPath, 0o644)
+
+    expect(resolveBundledBun({ resourcesDir, platform: 'linux' })).toBeNull()
   })
 
   it('ignores bundled Bun on unsupported platforms', async () => {

--- a/packages/browseros-agent/apps/server/tests/lib/agents/bundled-bun.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/bundled-bun.test.ts
@@ -32,6 +32,27 @@ describe('bundled Bun helpers', () => {
     )
   })
 
+  it('resolves the Linux bundled Bun executable', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'browseros-bun-'))
+    tempDirs.push(resourcesDir)
+    const bunPath = join(resourcesDir, 'bin', 'third_party', 'bun')
+    await mkdir(dirname(bunPath), { recursive: true })
+    await writeFile(bunPath, '#!/bin/sh\n')
+    await chmod(bunPath, 0o755)
+
+    expect(resolveBundledBun({ resourcesDir, platform: 'linux' })).toBe(bunPath)
+  })
+
+  it('resolves the Windows bundled Bun executable', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'browseros-bun-'))
+    tempDirs.push(resourcesDir)
+    const bunPath = join(resourcesDir, 'bin', 'third_party', 'bun.exe')
+    await mkdir(dirname(bunPath), { recursive: true })
+    await writeFile(bunPath, 'MZ')
+
+    expect(resolveBundledBun({ resourcesDir, platform: 'win32' })).toBe(bunPath)
+  })
+
   it('ignores non-executable bundled Bun files', async () => {
     const resourcesDir = await mkdtemp(join(tmpdir(), 'browseros-bun-'))
     tempDirs.push(resourcesDir)
@@ -43,13 +64,13 @@ describe('bundled Bun helpers', () => {
     expect(resolveBundledBun({ resourcesDir, platform: 'darwin' })).toBeNull()
   })
 
-  it('ignores bundled Bun on non-macOS platforms', async () => {
+  it('ignores bundled Bun on unsupported platforms', async () => {
     const resourcesDir = await mkdtemp(join(tmpdir(), 'browseros-bun-'))
     tempDirs.push(resourcesDir)
     const bunPath = join(resourcesDir, 'bin', 'third_party', 'bun')
     await mkdir(dirname(bunPath), { recursive: true })
     await writeFile(bunPath, '#!/bin/sh\n')
 
-    expect(resolveBundledBun({ resourcesDir, platform: 'linux' })).toBeNull()
+    expect(resolveBundledBun({ resourcesDir, platform: 'freebsd' })).toBeNull()
   })
 })

--- a/packages/browseros-agent/scripts/build/config/server-prod-resources.json
+++ b/packages/browseros-agent/scripts/build/config/server-prod-resources.json
@@ -65,6 +65,39 @@
       "executable": true
     },
     {
+      "name": "Bun - Linux ARM64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/bun/bun-linux-arm64"
+      },
+      "destination": "resources/bin/third_party/bun",
+      "os": ["linux"],
+      "arch": ["arm64"],
+      "executable": true
+    },
+    {
+      "name": "Bun - Linux x64 baseline",
+      "source": {
+        "type": "r2",
+        "key": "third_party/bun/bun-linux-x64-baseline"
+      },
+      "destination": "resources/bin/third_party/bun",
+      "os": ["linux"],
+      "arch": ["x64"],
+      "executable": true
+    },
+    {
+      "name": "Bun - Windows x64 baseline",
+      "source": {
+        "type": "r2",
+        "key": "third_party/bun/bun-windows-x64-baseline.exe"
+      },
+      "destination": "resources/bin/third_party/bun.exe",
+      "os": ["windows"],
+      "arch": ["x64"],
+      "executable": true
+    },
+    {
       "name": "BrowserOS VM Lima template",
       "source": {
         "type": "local",

--- a/packages/browseros-agent/scripts/build/server/stage.test.ts
+++ b/packages/browseros-agent/scripts/build/server/stage.test.ts
@@ -3,7 +3,7 @@ import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { S3Client } from '@aws-sdk/client-s3'
-import { loadManifest } from './manifest'
+import { getTargetRules, loadManifest } from './manifest'
 import { stageCompiledArtifact, stageTargetArtifact } from './stage'
 import type { BuildTarget, R2Config, ResourceRule } from './types'
 
@@ -121,6 +121,69 @@ describe('server artifact staging', () => {
     expect(await readFile(bunPath, 'utf8')).toBe('#!/bin/sh\n')
     expect((await stat(bunPath)).mode & 0o111).not.toBe(0)
   })
+
+  for (const { target, expectedKey, expectedRelativePath } of [
+    {
+      target: linuxArm64Target,
+      expectedKey: 'third_party/bun/bun-linux-arm64',
+      expectedRelativePath: 'bin/third_party/bun',
+    },
+    {
+      target: linuxX64Target,
+      expectedKey: 'third_party/bun/bun-linux-x64-baseline',
+      expectedRelativePath: 'bin/third_party/bun',
+    },
+    {
+      target: windowsX64Target,
+      expectedKey: 'third_party/bun/bun-windows-x64-baseline.exe',
+      expectedRelativePath: 'bin/third_party/bun.exe',
+    },
+  ]) {
+    it(`stages the platform Bun resource for ${target.id}`, async () => {
+      tempDir = await mkdtemp(join(tmpdir(), 'browseros-stage-test-'))
+      const sourceRoot = join(tempDir, 'source')
+      const distRoot = join(tempDir, 'dist')
+      const binaryPath = join(tempDir, target.serverBinaryName)
+      const requests: string[] = []
+      const payload = new TextEncoder().encode(`${target.id}-bun`)
+      await writeFile(binaryPath, 'server')
+
+      const rules = bunRulesForTarget(target)
+      expect(rules).toHaveLength(1)
+      expect(rules[0]?.source).toEqual({
+        type: 'r2',
+        key: expectedKey,
+      })
+
+      const artifact = await stageTargetArtifact(
+        distRoot,
+        binaryPath,
+        target,
+        rules,
+        sourceRoot,
+        {
+          send: async (command: unknown) => {
+            requests.push((command as { input: { Key: string } }).input.Key)
+            return {
+              Body: {
+                transformToByteArray: async () => payload,
+              },
+            }
+          },
+        } as unknown as S3Client,
+        fakeR2Config,
+        '0.0.0-test',
+      )
+
+      expect(requests).toEqual([`artifacts/vendor/${expectedKey}`])
+      expect(
+        await readFile(
+          join(artifact.resourcesDir, expectedRelativePath),
+          'utf8',
+        ),
+      ).toBe(`${target.id}-bun`)
+    })
+  }
 })
 
 const testTarget: BuildTarget = {
@@ -130,6 +193,42 @@ const testTarget: BuildTarget = {
   arch: 'arm64',
   bunTarget: 'bun-darwin-arm64',
   serverBinaryName: 'browseros-server',
+}
+
+const linuxArm64Target: BuildTarget = {
+  id: 'linux-arm64',
+  name: 'Linux ARM64',
+  os: 'linux',
+  arch: 'arm64',
+  bunTarget: 'bun-linux-arm64',
+  serverBinaryName: 'browseros_server',
+}
+
+const linuxX64Target: BuildTarget = {
+  id: 'linux-x64',
+  name: 'Linux x64',
+  os: 'linux',
+  arch: 'x64',
+  bunTarget: 'bun-linux-x64-baseline',
+  serverBinaryName: 'browseros_server',
+}
+
+const windowsX64Target: BuildTarget = {
+  id: 'windows-x64',
+  name: 'Windows x64',
+  os: 'windows',
+  arch: 'x64',
+  bunTarget: 'bun-windows-x64-baseline',
+  serverBinaryName: 'browseros_server.exe',
+}
+
+function bunRulesForTarget(target: BuildTarget): ResourceRule[] {
+  return getTargetRules(
+    loadManifest(join(import.meta.dir, '../config/server-prod-resources.json')),
+    target,
+  ).filter(
+    (rule) => rule.source.type === 'r2' && rule.name.startsWith('Bun - '),
+  )
 }
 
 const migrationRule: ResourceRule = {

--- a/packages/browseros/build/cli/storage.py
+++ b/packages/browseros/build/cli/storage.py
@@ -49,16 +49,42 @@ LIMA_ARCHES: Tuple[LimaArch, ...] = (
 
 
 @dataclass(frozen=True)
-class BunArch:
-    """Arch-pair: the suffix Bun uses upstream and the suffix we use in R2."""
+class BunTarget:
+    """Mapping from a Bun release asset to the R2 object staged into bundles."""
 
-    internal: str  # "arm64" | "x64" — how our R2 keys name it
-    upstream: str  # "darwin-aarch64" | "darwin-x64" — Bun's zip suffix
+    internal: str  # "darwin-arm64" | "linux-x64" — how manifests identify it
+    upstream: str  # "darwin-aarch64" | "linux-x64-baseline" — Bun's zip suffix
+    r2_name: str  # object basename under BUN_R2_PREFIX
+    binary_name: str = "bun"  # Windows zips contain bun.exe
 
 
-BUN_ARCHES: Tuple[BunArch, ...] = (
-    BunArch(internal="arm64", upstream="darwin-aarch64"),
-    BunArch(internal="x64", upstream="darwin-x64"),
+BUN_TARGETS: Tuple[BunTarget, ...] = (
+    BunTarget(
+        internal="darwin-arm64",
+        upstream="darwin-aarch64",
+        r2_name="bun-darwin-arm64",
+    ),
+    BunTarget(
+        internal="darwin-x64",
+        upstream="darwin-x64",
+        r2_name="bun-darwin-x64",
+    ),
+    BunTarget(
+        internal="linux-arm64",
+        upstream="linux-aarch64",
+        r2_name="bun-linux-arm64",
+    ),
+    BunTarget(
+        internal="linux-x64",
+        upstream="linux-x64-baseline",
+        r2_name="bun-linux-x64-baseline",
+    ),
+    BunTarget(
+        internal="windows-x64",
+        upstream="windows-x64-baseline",
+        r2_name="bun-windows-x64-baseline.exe",
+        binary_name="bun.exe",
+    ),
 )
 
 
@@ -154,7 +180,7 @@ def upload_bun(
         help="Download + verify only; skip R2 uploads.",
     ),
 ) -> None:
-    """Download Bun from an upstream GitHub release and push macOS binaries to R2."""
+    """Download Bun from an upstream GitHub release and push target binaries to R2."""
     if not BOTO3_AVAILABLE:
         log_error("boto3 not installed — run: pip install boto3")
         raise typer.Exit(1)
@@ -181,10 +207,10 @@ def upload_bun(
         zip_shas: Dict[str, str] = {}
 
         try:
-            for arch in BUN_ARCHES:
-                zip_sha, binary_sha, _ = _process_bun_arch(
+            for target in BUN_TARGETS:
+                zip_sha, binary_sha, _ = _process_bun_target(
                     tag,
-                    arch,
+                    target,
                     tmp_dir,
                     checksums,
                     client,
@@ -192,8 +218,8 @@ def upload_bun(
                     dry_run,
                     uploaded_keys,
                 )
-                zip_shas[arch.internal] = zip_sha
-                object_shas[arch.internal] = binary_sha
+                zip_shas[target.internal] = zip_sha
+                object_shas[target.internal] = binary_sha
 
             manifest = _build_bun_manifest(tag, zip_shas, object_shas)
             _upload_bun_manifest(client, env, manifest, tmp_dir, dry_run)
@@ -206,7 +232,7 @@ def upload_bun(
             log_error(f"Bun upload aborted: {exc}")
             raise typer.Exit(1)
 
-    log_success(f"Bun {tag} uploaded for {[a.internal for a in BUN_ARCHES]}")
+    log_success(f"Bun {tag} uploaded for {[t.internal for t in BUN_TARGETS]}")
 
 
 def _normalize_version_tag(version: str) -> str:
@@ -319,9 +345,9 @@ def _process_arch(
     return actual_sha, object_shas, r2_keys
 
 
-def _process_bun_arch(
+def _process_bun_target(
     tag: str,
-    arch: BunArch,
+    target: BunTarget,
     tmp_dir: Path,
     checksums: Dict[str, str],
     client: Any,
@@ -329,7 +355,7 @@ def _process_bun_arch(
     dry_run: bool,
     uploaded_keys: Optional[List[str]] = None,
 ) -> Tuple[str, str, str]:
-    zip_name = f"bun-{arch.upstream}.zip"
+    zip_name = f"bun-{target.upstream}.zip"
     expected_sha = checksums.get(zip_name)
     if not expected_sha:
         raise RuntimeError(
@@ -347,9 +373,9 @@ def _process_bun_arch(
             f"sha256 mismatch for {zip_name}: expected {expected_sha}, got {actual_sha}"
         )
 
-    local_path = tmp_dir / f"bun-darwin-{arch.internal}"
-    r2_key = f"{BUN_R2_PREFIX}/bun-darwin-{arch.internal}"
-    _extract_bun_file(zip_path, local_path)
+    local_path = tmp_dir / target.r2_name
+    r2_key = f"{BUN_R2_PREFIX}/{target.r2_name}"
+    _extract_bun_file(zip_path, local_path, target.binary_name)
     binary_sha = _sha256_file(local_path)
 
     if dry_run:
@@ -381,12 +407,12 @@ def _extract_lima_file(tarball_path: Path, logical_path: str, dest: Path) -> Non
     raise RuntimeError(f"{logical_path} not found in Lima tarball")
 
 
-def _extract_bun_file(zip_path: Path, dest: Path) -> None:
+def _extract_bun_file(zip_path: Path, dest: Path, binary_name: str = "bun") -> None:
     with zipfile.ZipFile(zip_path) as archive:
         for member in archive.infolist():
             if member.is_dir():
                 continue
-            if _logical_bun_path(member.filename) != "bun":
+            if _logical_bun_path(member.filename) != binary_name:
                 continue
             dest.parent.mkdir(parents=True, exist_ok=True)
             with archive.open(member) as src, open(dest, "wb") as out:

--- a/packages/browseros/build/cli/storage.py
+++ b/packages/browseros/build/cli/storage.py
@@ -420,7 +420,7 @@ def _extract_bun_file(zip_path: Path, dest: Path, binary_name: str = "bun") -> N
                     out.write(chunk)
             dest.chmod(0o755)
             return
-    raise RuntimeError("bun binary not found in Bun zip")
+    raise RuntimeError(f"{binary_name} not found in Bun zip")
 
 
 def _logical_lima_path(member_name: str) -> str:

--- a/packages/browseros/build/cli/storage_test.py
+++ b/packages/browseros/build/cli/storage_test.py
@@ -51,11 +51,16 @@ def _add_tar_file(
     tar.addfile(info, io.BytesIO(payload))
 
 
-def _build_bun_zip(payload: bytes) -> bytes:
+def _build_bun_zip(
+    payload: bytes,
+    *,
+    root_dir: str = "bun-darwin-aarch64",
+    binary_name: str = "bun",
+) -> bytes:
     """Return a Bun release zip with the upstream directory layout."""
     buffer = io.BytesIO()
     with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
-        archive.writestr("bun-darwin-aarch64/bun", payload)
+        archive.writestr(f"{root_dir}/{binary_name}", payload)
     return buffer.getvalue()
 
 
@@ -218,6 +223,33 @@ class ExtractBunFileTest(unittest.TestCase):
                 storage._extract_bun_file(zip_path, tmp_path / "bun")
 
 
+class BunTargetTest(unittest.TestCase):
+    def test_target_matrix_matches_server_build_targets(self) -> None:
+        self.assertEqual(
+            [
+                (target.internal, target.upstream, target.r2_name, target.binary_name)
+                for target in storage.BUN_TARGETS
+            ],
+            [
+                ("darwin-arm64", "darwin-aarch64", "bun-darwin-arm64", "bun"),
+                ("darwin-x64", "darwin-x64", "bun-darwin-x64", "bun"),
+                ("linux-arm64", "linux-aarch64", "bun-linux-arm64", "bun"),
+                (
+                    "linux-x64",
+                    "linux-x64-baseline",
+                    "bun-linux-x64-baseline",
+                    "bun",
+                ),
+                (
+                    "windows-x64",
+                    "windows-x64-baseline",
+                    "bun-windows-x64-baseline.exe",
+                    "bun.exe",
+                ),
+            ],
+        )
+
+
 class RollbackTest(unittest.TestCase):
     def test_rollback_deletes_all_keys(self) -> None:
         deleted: List[Tuple[str, str]] = []
@@ -260,12 +292,15 @@ class BuildManifestTest(unittest.TestCase):
     def test_bun_manifest_shape(self) -> None:
         manifest = storage._build_bun_manifest(
             "bun-v1.2.3",
-            {"arm64": "a" * 64, "x64": "b" * 64},
-            {"arm64": "c" * 64, "x64": "d" * 64},
+            {"darwin-arm64": "a" * 64, "linux-x64": "b" * 64},
+            {"darwin-arm64": "c" * 64, "linux-x64": "d" * 64},
         )
         self.assertEqual(manifest["bun_version"], "bun-v1.2.3")
-        self.assertEqual(manifest["zip_shas_upstream"]["arm64"], "a" * 64)
-        self.assertEqual(manifest["r2_object_shas"]["x64"], "d" * 64)
+        self.assertEqual(
+            manifest["zip_shas_upstream"]["darwin-arm64"],
+            "a" * 64,
+        )
+        self.assertEqual(manifest["r2_object_shas"]["linux-x64"], "d" * 64)
         self.assertIn("uploaded_at", manifest)
         self.assertIn("uploaded_by", manifest)
 
@@ -507,7 +542,7 @@ class ProcessArchTest(unittest.TestCase):
         self.assertEqual(uploads, [])
 
 
-class ProcessBunArchTest(unittest.TestCase):
+class ProcessBunTargetTest(unittest.TestCase):
     def setUp(self) -> None:
         self.bun_payload = b"bun-binary-" + b"z" * 200
         self.zip_bytes = _build_bun_zip(self.bun_payload)
@@ -539,9 +574,13 @@ class ProcessBunArchTest(unittest.TestCase):
                     storage, "upload_file_to_r2", side_effect=fake_upload
                 ),
             ):
-                zip_sha, binary_sha, r2_key = storage._process_bun_arch(
+                zip_sha, binary_sha, r2_key = storage._process_bun_target(
                     tag="bun-v1.2.3",
-                    arch=storage.BunArch(internal="arm64", upstream="darwin-aarch64"),
+                    target=storage.BunTarget(
+                        internal="darwin-arm64",
+                        upstream="darwin-aarch64",
+                        r2_name="bun-darwin-arm64",
+                    ),
                     tmp_dir=tmp_path,
                     checksums={"bun-darwin-aarch64.zip": self.expected_zip_sha},
                     client=mock.Mock(),
@@ -574,9 +613,13 @@ class ProcessBunArchTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             with mock.patch.object(storage, "_download", side_effect=fake_download):
-                storage._process_bun_arch(
+                storage._process_bun_target(
                     tag="bun-v1.2.3",
-                    arch=storage.BunArch(internal="arm64", upstream="darwin-aarch64"),
+                    target=storage.BunTarget(
+                        internal="darwin-arm64",
+                        upstream="darwin-aarch64",
+                        r2_name="bun-darwin-arm64",
+                    ),
                     tmp_dir=tmp_path,
                     checksums={"bun-darwin-aarch64.zip": self.expected_zip_sha},
                     client=None,
@@ -608,11 +651,12 @@ class ProcessBunArchTest(unittest.TestCase):
                 ),
             ):
                 with self.assertRaisesRegex(RuntimeError, "sha256 mismatch"):
-                    storage._process_bun_arch(
+                    storage._process_bun_target(
                         tag="bun-v1.2.3",
-                        arch=storage.BunArch(
-                            internal="arm64",
+                        target=storage.BunTarget(
+                            internal="darwin-arm64",
                             upstream="darwin-aarch64",
+                            r2_name="bun-darwin-arm64",
                         ),
                         tmp_dir=tmp_path,
                         checksums={"bun-darwin-aarch64.zip": "0" * 64},
@@ -642,9 +686,13 @@ class ProcessBunArchTest(unittest.TestCase):
                     storage, "upload_file_to_r2", side_effect=fake_upload
                 ),
             ):
-                _, _, r2_key = storage._process_bun_arch(
+                _, _, r2_key = storage._process_bun_target(
                     tag="bun-v1.2.3",
-                    arch=storage.BunArch(internal="arm64", upstream="darwin-aarch64"),
+                    target=storage.BunTarget(
+                        internal="darwin-arm64",
+                        upstream="darwin-aarch64",
+                        r2_name="bun-darwin-arm64",
+                    ),
                     tmp_dir=tmp_path,
                     checksums={"bun-darwin-aarch64.zip": self.expected_zip_sha},
                     client=None,
@@ -654,6 +702,69 @@ class ProcessBunArchTest(unittest.TestCase):
 
         self.assertEqual(uploads, [])
         self.assertEqual(r2_key, "artifacts/vendor/third_party/bun/bun-darwin-arm64")
+
+    def test_windows_target_extracts_exe_and_uploads_exe_key(self) -> None:
+        payload = b"bun-windows-exe-" + b"w" * 200
+        zip_bytes = _build_bun_zip(
+            payload,
+            root_dir="bun-windows-x64-baseline",
+            binary_name="bun.exe",
+        )
+        expected_zip_sha = hashlib.sha256(zip_bytes).hexdigest()
+        expected_bun_sha = hashlib.sha256(payload).hexdigest()
+        uploads: List[Tuple[str, str, bytes]] = []
+
+        def fake_download(_url: str, dest: Path, **_kwargs: Any) -> None:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_bytes(zip_bytes)
+
+        def fake_upload(
+            _client: Any, local_path: Path, r2_key: str, bucket: str
+        ) -> bool:
+            uploads.append((r2_key, bucket, local_path.read_bytes()))
+            return True
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            with (
+                mock.patch.object(storage, "_download", side_effect=fake_download),
+                mock.patch.object(
+                    storage,
+                    "upload_file_to_r2",
+                    side_effect=fake_upload,
+                ),
+            ):
+                zip_sha, binary_sha, r2_key = storage._process_bun_target(
+                    tag="bun-v1.2.3",
+                    target=storage.BunTarget(
+                        internal="windows-x64",
+                        upstream="windows-x64-baseline",
+                        r2_name="bun-windows-x64-baseline.exe",
+                        binary_name="bun.exe",
+                    ),
+                    tmp_dir=tmp_path,
+                    checksums={"bun-windows-x64-baseline.zip": expected_zip_sha},
+                    client=mock.Mock(),
+                    env=mock.Mock(r2_bucket="browseros"),
+                    dry_run=False,
+                )
+
+        self.assertEqual(zip_sha, expected_zip_sha)
+        self.assertEqual(binary_sha, expected_bun_sha)
+        self.assertEqual(
+            r2_key,
+            "artifacts/vendor/third_party/bun/bun-windows-x64-baseline.exe",
+        )
+        self.assertEqual(
+            uploads,
+            [
+                (
+                    "artifacts/vendor/third_party/bun/bun-windows-x64-baseline.exe",
+                    "browseros",
+                    payload,
+                )
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/packages/browseros/build/cli/storage_test.py
+++ b/packages/browseros/build/cli/storage_test.py
@@ -219,12 +219,26 @@ class ExtractBunFileTest(unittest.TestCase):
             with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as archive:
                 archive.writestr("bun-darwin-aarch64/README.md", b"missing")
 
-            with self.assertRaisesRegex(RuntimeError, "bun binary not found"):
+            with self.assertRaisesRegex(RuntimeError, "bun not found in Bun zip"):
                 storage._extract_bun_file(zip_path, tmp_path / "bun")
+
+    def test_raises_with_requested_binary_name_when_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            zip_path = tmp_path / "bun.zip"
+            with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as archive:
+                archive.writestr("bun-windows-x64-baseline/README.md", b"missing")
+
+            with self.assertRaisesRegex(RuntimeError, r"bun\.exe not found"):
+                storage._extract_bun_file(
+                    zip_path,
+                    tmp_path / "bun.exe",
+                    binary_name="bun.exe",
+                )
 
 
 class BunTargetTest(unittest.TestCase):
-    def test_target_matrix_matches_server_build_targets(self) -> None:
+    def test_bun_targets_have_expected_fields(self) -> None:
         self.assertEqual(
             [
                 (target.internal, target.upstream, target.r2_name, target.binary_name)


### PR DESCRIPTION
## Summary
- Adds Linux ARM64, Linux x64 baseline, and Windows x64 baseline Bun resources to the production server resource manifest.
- Extends the Bun R2 uploader to publish target-specific Bun binaries, including Windows bun.exe extraction.
- Allows bundled Bun resolution on Linux and Windows so ACP adapters can use the packaged runtime there too.

## Design
The Bun uploader now uses explicit target metadata instead of a macOS-only arch pair. The server manifest keeps one Bun resource per platform target so existing OS/arch filtering selects the correct R2 object, with Windows staging to bun.exe.

## Test plan
- [x] uv run python -m unittest build/cli/storage_test.py
- [x] uv run ruff check build/cli/storage.py build/cli/storage_test.py
- [x] uv run pyright build/cli/storage.py
- [x] bun test packages/browseros-agent/scripts/build/server/stage.test.ts packages/browseros-agent/apps/server/tests/lib/agents/bundled-bun.test.ts packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
- [x] bun run ./scripts/run-bun-test.ts ./scripts/build
- [x] bun run --filter @browseros/server typecheck
- [x] bunx biome check apps/server/src/lib/agents/host-acp/bundled-bun.ts apps/server/tests/lib/agents/bundled-bun.test.ts scripts/build/server/stage.test.ts scripts/build/config/server-prod-resources.json

Note: repo-wide `bun run lint` exits 0 but reports existing warnings outside the touched files.