### PR TITLE
fix: hide Hub button by default

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/customization/ToolbarSettingsCard.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/customization/ToolbarSettingsCard.tsx
@@ -8,7 +8,7 @@ import { BROWSEROS_PREFS } from '@/lib/browseros/prefs'
 
 export const ToolbarSettingsCard: FC = () => {
   const [showLlmChat, setShowLlmChat] = useState(true)
-  const [showLlmHub, setShowLlmHub] = useState(true)
+  const [showLlmHub, setShowLlmHub] = useState(false)
   const [showToolbarLabels, setShowToolbarLabels] = useState(true)
   const [verticalTabsEnabled, setVerticalTabsEnabled] = useState(true)
   const [supportsVerticalTabs, setSupportsVerticalTabs] = useState(false)
@@ -24,7 +24,7 @@ export const ToolbarSettingsCard: FC = () => {
           adapter.getPref(BROWSEROS_PREFS.SHOW_TOOLBAR_LABELS),
         ])
         setShowLlmChat(chatPref?.value !== false)
-        setShowLlmHub(hubPref?.value !== false)
+        setShowLlmHub(hubPref?.value === true)
         setShowToolbarLabels(labelsPref?.value !== false)
 
         const hasVerticalTabsSupport = await Capabilities.supports(

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.cc
@@ -21,7 +21,7 @@ index 0000000000000..c191fb3963968
 +void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
 +  // Toolbar visibility prefs
 +  registry->RegisterBooleanPref(prefs::kShowLLMChat, true);
-+  registry->RegisterBooleanPref(prefs::kShowLLMHub, true);
++  registry->RegisterBooleanPref(prefs::kShowLLMHub, false);
 +  registry->RegisterBooleanPref(prefs::kShowToolbarLabels, true);
 +
 +  // Vertical tabs pref

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.h
@@ -26,7 +26,7 @@ index 0000000000000..a94b14e0664ca
 +// Boolean: Show LLM Chat in toolbar (default: true)
 +inline constexpr char kShowLLMChat[] = "browseros.show_llm_chat";
 +
-+// Boolean: Show LLM Hub in toolbar (default: true)
++// Boolean: Show LLM Hub in toolbar (default: false)
 +inline constexpr char kShowLLMHub[] = "browseros.show_llm_hub";
 +
 +// Boolean: Show labels on BrowserOS toolbar actions (default: true)


### PR DESCRIPTION
## Summary

- Hide the Hub toolbar button by default when `browseros.show_llm_hub` has no explicit user value.
- Preserve existing explicit user choices for the Hub visibility pref.
- Align the BrowserOS customization UI switch with the new off-by-default behavior.

## Design

Keep the existing `browseros.show_llm_hub` pref key, change the Chromium registered default to `false`, and update the agent settings fallback so missing pref values render as off. This avoids a migration and keeps explicit stored true/false values authoritative.

## Test plan

- `bun run --filter @browseros/agent lint`
- `bun run --filter @browseros/agent typecheck`
- `bun run --filter @browseros/agent test`
- `git diff --check`
- `autoninja -C out/Default_arm64 chrome` attempted; unavailable in this Grove worktree because `out/Default_arm64` does not exist.