### PR TITLE
feat: bundle Codex and Claude Code CLIs

### DIFF
--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime.ts
@@ -26,6 +26,7 @@ import type {
   AgentHistoryToolCall,
 } from '../agent-types'
 import { resolveBundledBun } from '../host-acp/bundled-bun'
+import { withBundledNativeBinaryPath } from '../host-acp/bundled-native-binary'
 import { HOST_ACP_ADAPTER_CONFIG } from '../host-acp/config'
 import { getHermesRuntime } from '../runtime'
 import type {
@@ -678,11 +679,15 @@ function createBrowserosAgentRegistry(input: {
           adapter: lower,
           resourcesDir: input.resourcesDir,
         })
+        const commandEnv = withBundledNativeBinaryPath({
+          env: input.commandEnv,
+          resourcesDir: input.resourcesDir,
+        })
         return wrapCommandWithEnv(
           launch.command,
           launch.addBundledBunAdapterEnv
-            ? withBundledBunAcpAdapterEnv(input.commandEnv, input.browserosDir)
-            : input.commandEnv,
+            ? withBundledBunAcpAdapterEnv(commandEnv, input.browserosDir)
+            : commandEnv,
         )
       }
 

--- a/packages/browseros-agent/apps/server/src/lib/agents/host-acp/bundled-native-binary.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/host-acp/bundled-native-binary.ts
@@ -1,0 +1,100 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { accessSync, constants, statSync } from 'node:fs'
+import { join } from 'node:path'
+import {
+  buildResolvedBinaryEnv,
+  type ResolvedHostBinary,
+} from './binary-resolver'
+import type { HostAcpAdapter } from './config'
+
+export const BUNDLED_NATIVE_CLI_DIR_RELATIVE_PATH = join('bin', 'third_party')
+
+/** Resolves BrowserOS-packaged Claude/Codex binaries before falling back to host PATH. */
+export function resolveBundledNativeBinary(input: {
+  adapter: HostAcpAdapter
+  resourcesDir?: string | null
+  env?: NodeJS.ProcessEnv
+  platform?: NodeJS.Platform
+}): ResolvedHostBinary | null {
+  const resourcesDir = input.resourcesDir?.trim()
+  if (!resourcesDir) return null
+
+  const platform = input.platform ?? process.platform
+  const candidate = join(
+    resourcesDir,
+    BUNDLED_NATIVE_CLI_DIR_RELATIVE_PATH,
+    bundledBinaryName(input.adapter, platform),
+  )
+  if (!isUsableBundledBinary(candidate, platform)) return null
+
+  return {
+    path: candidate,
+    env: buildResolvedBinaryEnv({
+      binaryPath: candidate,
+      env: input.env,
+      platform,
+    }),
+  }
+}
+
+/** Prepends BrowserOS's packaged CLI directory so ACP packages spawn bundled CLIs first. */
+export function withBundledNativeBinaryPath(input: {
+  resourcesDir?: string | null
+  env: Record<string, string>
+  platform?: NodeJS.Platform
+}): Record<string, string> {
+  const resourcesDir = input.resourcesDir?.trim()
+  if (!resourcesDir) return { ...input.env }
+
+  const dir = join(resourcesDir, BUNDLED_NATIVE_CLI_DIR_RELATIVE_PATH)
+  try {
+    if (!statSync(dir).isDirectory()) return { ...input.env }
+  } catch {
+    return { ...input.env }
+  }
+
+  const platform = input.platform ?? process.platform
+  const env = { ...input.env }
+  const key = pathEnvKey(env, platform)
+  const delimiter = platform === 'win32' ? ';' : ':'
+  const existing = env[key] ?? ''
+  const parts = existing
+    .split(delimiter)
+    .filter(Boolean)
+    .filter((part) => part !== dir)
+  env[key] = [dir, ...parts].join(delimiter)
+  return env
+}
+
+function bundledBinaryName(
+  adapter: HostAcpAdapter,
+  platform: NodeJS.Platform,
+): string {
+  return platform === 'win32' ? `${adapter}.exe` : adapter
+}
+
+function isUsableBundledBinary(
+  path: string,
+  platform: NodeJS.Platform,
+): boolean {
+  try {
+    if (!statSync(path).isFile()) return false
+    if (platform !== 'win32') accessSync(path, constants.X_OK)
+    return true
+  } catch {
+    return false
+  }
+}
+
+function pathEnvKey(
+  env: Record<string, string | undefined>,
+  platform: NodeJS.Platform,
+): string {
+  if (platform !== 'win32') return 'PATH'
+  return Object.keys(env).find((key) => key.toLowerCase() === 'path') ?? 'Path'
+}

--- a/packages/browseros-agent/apps/server/src/lib/agents/host-acp/detection.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/host-acp/detection.ts
@@ -11,6 +11,7 @@ import {
   runHostCommand,
 } from './binary-resolver'
 import { resolveBundledBun } from './bundled-bun'
+import { resolveBundledNativeBinary } from './bundled-native-binary'
 import { HOST_ACP_ADAPTER_CONFIG, type HostAcpAdapter } from './config'
 import { probeNpxPackageCache } from './npx-package-cache'
 
@@ -69,6 +70,7 @@ export interface DetectHostAdapterOptions {
     versionRange?: string,
   ) => Promise<boolean>
   resolveBundledBun?: typeof resolveBundledBun
+  resolveBundledNativeBinary?: typeof resolveBundledNativeBinary
 }
 
 const DEFAULT_PROBE_TIMEOUT_MS = 3_000
@@ -92,9 +94,17 @@ export async function detectHostAdapter(
     ((packageName: string, versionRange?: string) =>
       probeNpxPackageCache(packageName, { versionRange }))
   const resolveBun = options.resolveBundledBun ?? resolveBundledBun
+  const resolveBundledNative =
+    options.resolveBundledNativeBinary ?? resolveBundledNativeBinary
 
   const [nativeCli, launch] = await Promise.all([
-    resolveBinary(config.nativeBinary).catch(() => null),
+    (async () =>
+      resolveBundledNative({
+        adapter,
+        resourcesDir: options.resourcesDir,
+        env,
+        platform,
+      }) ?? (await resolveBinary(config.nativeBinary)))().catch(() => null),
     detectAdapterLaunch({
       adapter,
       platform,

--- a/packages/browseros-agent/apps/server/src/lib/agents/host-acp/detection.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/host-acp/detection.ts
@@ -98,13 +98,15 @@ export async function detectHostAdapter(
     options.resolveBundledNativeBinary ?? resolveBundledNativeBinary
 
   const [nativeCli, launch] = await Promise.all([
-    (async () =>
-      resolveBundledNative({
-        adapter,
-        resourcesDir: options.resourcesDir,
-        env,
-        platform,
-      }) ?? (await resolveBinary(config.nativeBinary)))().catch(() => null),
+    resolveNativeCli({
+      adapter,
+      nativeBinary: config.nativeBinary,
+      resourcesDir: options.resourcesDir,
+      env,
+      platform,
+      resolveBinary,
+      resolveBundledNativeBinary: resolveBundledNative,
+    }).catch(() => null),
     detectAdapterLaunch({
       adapter,
       platform,
@@ -150,6 +152,26 @@ export async function detectHostAdapter(
     adapterLaunchSource: launch.source,
     packageCacheState: launch.packageCacheState,
   }
+}
+
+/** Resolves BrowserOS-packaged native CLIs before consulting the user's host PATH. */
+async function resolveNativeCli(input: {
+  adapter: HostAcpAdapter
+  nativeBinary: string
+  resourcesDir?: string | null
+  env: NodeJS.ProcessEnv
+  platform: NodeJS.Platform
+  resolveBinary: (name: string) => Promise<ResolvedHostBinary | null>
+  resolveBundledNativeBinary: typeof resolveBundledNativeBinary
+}): Promise<ResolvedHostBinary | null> {
+  const bundled = input.resolveBundledNativeBinary({
+    adapter: input.adapter,
+    resourcesDir: input.resourcesDir,
+    env: input.env,
+    platform: input.platform,
+  })
+  if (bundled) return bundled
+  return input.resolveBinary(input.nativeBinary)
 }
 
 async function detectAdapterLaunch(input: {
@@ -299,7 +321,7 @@ function reasonFor(input: {
     case 'needs-auth':
       return `${input.displayName} is installed but is not authenticated.`
     case 'needs-install':
-      return `${input.displayName} adapter cannot launch because neither bundled Bun nor npx is available.`
+      return `${input.displayName} adapter package cannot launch because neither bundled Bun nor npx is available.`
     case 'will-fetch-package':
       return `${input.displayName} adapter package will be downloaded on first use.`
     case 'diagnostic-warning':

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -961,6 +961,47 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
     expect(command).toContain('npx -y @zed-industries/codex-acp')
   })
 
+  it('prepends the bundled native CLI directory to host ACP adapter commands', async () => {
+    const browserosDir = await mkdtemp(
+      join(tmpdir(), 'browseros-acpx-browseros-'),
+    )
+    const stateDir = await mkdtemp(join(tmpdir(), 'browseros-acpx-state-'))
+    const resourcesDir = await mkdtemp(
+      join(tmpdir(), 'browseros-acpx-resources-'),
+    )
+    tempDirs.push(browserosDir, stateDir, resourcesDir)
+    const bundledDir = join(resourcesDir, 'bin', 'third_party')
+    await mkdir(bundledDir, { recursive: true })
+    const calls: Array<{ method: string; input: unknown }> = []
+    const runtime = new AcpxRuntime({
+      browserosDir,
+      resourcesDir,
+      stateDir,
+      runtimeFactory: (options) => {
+        calls.push({ method: 'createRuntime', input: options })
+        return createFakeAcpRuntime(calls)
+      },
+    })
+    const agent = makeAgent({ id: 'agent-1', adapter: 'codex' })
+
+    await collectStream(
+      await runtime.send({
+        agent,
+        sessionId: 'main',
+        sessionKey: agent.sessionKey,
+        message: 'hi',
+        permissionMode: 'approve-all',
+      }),
+    )
+
+    const registry = getCreateRuntimeOptions(calls).agentRegistry
+    const pathEnvKey = process.platform === 'win32' ? 'Path' : 'PATH'
+    expect(registry.resolve('claude')).toContain(
+      `${pathEnvKey}='${bundledDir}'`,
+    )
+    expect(registry.resolve('codex')).toContain(`${pathEnvKey}='${bundledDir}'`)
+  })
+
   macosIt(
     'runs Claude and Codex ACP adapter packages through bundled Bun on macOS',
     async () => {
@@ -1005,7 +1046,7 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
         `'${bunPath}' x --bun --silent --package '@zed-industries/codex-acp@^0.12.0' 'codex-acp'`,
       )
       expect(codexCommand).toContain('BUN_INSTALL_CACHE_DIR=')
-      expect(codexCommand).not.toContain('PATH=')
+      expect(codexCommand).toContain(`PATH='${dirname(bunPath)}'`)
       expect(codexCommand).not.toContain('npx -y')
     },
   )

--- a/packages/browseros-agent/apps/server/tests/lib/agents/adapter-detection.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/adapter-detection.test.ts
@@ -158,6 +158,75 @@ describe('adapter detection', () => {
     })
   })
 
+  it('uses bundled native CLIs before host PATH for version and auth probes', async () => {
+    const resourcesDir = '/Applications/BrowserOS.app/Contents/Resources'
+    const bundledDir = join(resourcesDir, 'bin', 'third_party')
+    const bundledCodex = join(bundledDir, 'codex')
+    const hostResolveCalls: string[] = []
+    const commandCalls: Array<{
+      cmd: string
+      args: string[]
+      pathEnv: string | undefined
+    }> = []
+
+    const result = await detectHostAdapter('codex', {
+      now: () => 1234,
+      platform: 'darwin',
+      resourcesDir,
+      resolveBundledBun: () => join(bundledDir, 'bun'),
+      resolveBundledNativeBinary: ({ adapter, env, platform }) => {
+        expect(adapter).toBe('codex')
+        expect(platform).toBe('darwin')
+        expect(env?.PATH).toBe('/usr/bin')
+        return {
+          path: bundledCodex,
+          env: { PATH: `${bundledDir}:/usr/bin` },
+        }
+      },
+      env: { PATH: '/usr/bin' },
+      resolveBinary: async (name) => {
+        hostResolveCalls.push(name)
+        return null
+      },
+      runCommand: async (cmd, args, options) => {
+        commandCalls.push({ cmd, args, pathEnv: options.env?.PATH })
+        if (args[0] === '--version') {
+          return { exitCode: 0, stdout: 'codex-cli 0.136.0\n', stderr: '' }
+        }
+        if (args.join(' ') === 'login status') {
+          return { exitCode: 0, stdout: 'authenticated\n', stderr: '' }
+        }
+        throw new Error(`unexpected command ${cmd} ${args.join(' ')}`)
+      },
+      probePackageCache: async () => false,
+    })
+
+    expect(result).toMatchObject({
+      healthy: true,
+      readiness: 'ready',
+      installState: 'installed',
+      nativeCliState: 'present',
+      authState: 'authenticated',
+      adapterLaunchSource: 'bundled-bun',
+      packageCacheState: 'unknown',
+      version: 'codex-cli 0.136.0',
+      checkedAt: 1234,
+    })
+    expect(hostResolveCalls).toEqual([])
+    expect(commandCalls).toEqual([
+      {
+        cmd: bundledCodex,
+        args: ['--version'],
+        pathEnv: `${bundledDir}:/usr/bin`,
+      },
+      {
+        cmd: bundledCodex,
+        args: ['login', 'status'],
+        pathEnv: `${bundledDir}:/usr/bin`,
+      },
+    ])
+  })
+
   it('uses codex doctor when login status is not supported', async () => {
     const calls: Array<{ args: string[]; timeoutMs: number | undefined }> = []
 

--- a/packages/browseros-agent/apps/server/tests/lib/agents/adapter-detection.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/adapter-detection.test.ts
@@ -227,6 +227,46 @@ describe('adapter detection', () => {
     ])
   })
 
+  it('reports missing package runner separately from bundled native CLI presence', async () => {
+    const resourcesDir = '/opt/BrowserOS/resources'
+    const bundledDir = join(resourcesDir, 'bin', 'third_party')
+    const bundledCodex = join(bundledDir, 'codex')
+
+    const result = await detectHostAdapter('codex', {
+      now: () => 1234,
+      platform: 'linux',
+      resourcesDir,
+      resolveBundledNativeBinary: () => ({
+        path: bundledCodex,
+        env: { PATH: `${bundledDir}:/usr/bin` },
+      }),
+      resolveBundledBun: () => null,
+      resolveBinary: async () => null,
+      runCommand: async (_cmd, args) => {
+        if (args[0] === '--version') {
+          return { exitCode: 0, stdout: 'codex-cli 0.136.0\n', stderr: '' }
+        }
+        if (args.join(' ') === 'login status') {
+          return { exitCode: 0, stdout: 'authenticated\n', stderr: '' }
+        }
+        throw new Error(`unexpected command ${args.join(' ')}`)
+      },
+      probePackageCache: async () => false,
+    })
+
+    expect(result).toMatchObject({
+      healthy: false,
+      readiness: 'needs-install',
+      installState: 'installed',
+      nativeCliState: 'present',
+      authState: 'authenticated',
+      adapterLaunchSource: 'none',
+      packageCacheState: 'unknown',
+      reason:
+        'Codex adapter package cannot launch because neither bundled Bun nor npx is available.',
+    })
+  })
+
   it('uses codex doctor when login status is not supported', async () => {
     const calls: Array<{ args: string[]; timeoutMs: number | undefined }> = []
 

--- a/packages/browseros-agent/apps/server/tests/lib/agents/bundled-native-binary.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/bundled-native-binary.test.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import { chmod, mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import {
+  resolveBundledNativeBinary,
+  withBundledNativeBinaryPath,
+} from '../../../src/lib/agents/host-acp/bundled-native-binary'
+
+describe('bundled native binary helpers', () => {
+  const tempDirs: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true })),
+    )
+    tempDirs.length = 0
+  })
+
+  it('resolves executable Unix bundled binaries and prepends their directory', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'browseros-native-cli-'))
+    tempDirs.push(resourcesDir)
+    const codexPath = join(resourcesDir, 'bin', 'third_party', 'codex')
+    await mkdir(dirname(codexPath), { recursive: true })
+    await writeFile(codexPath, '#!/bin/sh\n')
+    await chmod(codexPath, 0o755)
+
+    expect(
+      resolveBundledNativeBinary({
+        adapter: 'codex',
+        resourcesDir,
+        env: { PATH: '/usr/bin' },
+        platform: 'linux',
+      }),
+    ).toEqual({
+      path: codexPath,
+      env: {
+        PATH: `${dirname(codexPath)}:/usr/bin`,
+      },
+    })
+  })
+
+  it('ignores non-executable Unix bundled binaries', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'browseros-native-cli-'))
+    tempDirs.push(resourcesDir)
+    const claudePath = join(resourcesDir, 'bin', 'third_party', 'claude')
+    await mkdir(dirname(claudePath), { recursive: true })
+    await writeFile(claudePath, '#!/bin/sh\n')
+    await chmod(claudePath, 0o644)
+
+    expect(
+      resolveBundledNativeBinary({
+        adapter: 'claude',
+        resourcesDir,
+        platform: 'darwin',
+      }),
+    ).toBeNull()
+  })
+
+  it('resolves Windows bundled binaries without executable bits', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'browseros-native-cli-'))
+    tempDirs.push(resourcesDir)
+    const claudePath = join(resourcesDir, 'bin', 'third_party', 'claude.exe')
+    await mkdir(dirname(claudePath), { recursive: true })
+    await writeFile(claudePath, 'MZ')
+
+    expect(
+      resolveBundledNativeBinary({
+        adapter: 'claude',
+        resourcesDir,
+        env: { Path: 'C:\\Windows\\System32' },
+        platform: 'win32',
+      }),
+    ).toEqual({
+      path: claudePath,
+      env: {
+        Path: `${dirname(claudePath)};C:\\Windows\\System32`,
+      },
+    })
+  })
+
+  it('prepends the bundled CLI directory once for ACP adapter commands', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'browseros-native-cli-'))
+    tempDirs.push(resourcesDir)
+    const bundledDir = join(resourcesDir, 'bin', 'third_party')
+    await mkdir(bundledDir, { recursive: true })
+
+    expect(
+      withBundledNativeBinaryPath({
+        resourcesDir,
+        env: { PATH: `/opt/bin:${bundledDir}` },
+        platform: 'linux',
+      }),
+    ).toEqual({
+      PATH: `${bundledDir}:/opt/bin`,
+    })
+
+    expect(
+      withBundledNativeBinaryPath({
+        resourcesDir,
+        env: { PATH: '/opt/bin' },
+        platform: 'linux',
+      }),
+    ).toEqual({
+      PATH: `${bundledDir}:/opt/bin`,
+    })
+  })
+})

--- a/packages/browseros-agent/scripts/build/config/server-prod-resources.json
+++ b/packages/browseros-agent/scripts/build/config/server-prod-resources.json
@@ -56,6 +56,116 @@
       "executable": true
     },
     {
+      "name": "Codex - macOS ARM64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/codex/codex-darwin-arm64"
+      },
+      "destination": "resources/bin/third_party/codex",
+      "os": ["macos"],
+      "arch": ["arm64"],
+      "executable": true
+    },
+    {
+      "name": "Claude Code - macOS ARM64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/claude-code/claude-darwin-arm64"
+      },
+      "destination": "resources/bin/third_party/claude",
+      "os": ["macos"],
+      "arch": ["arm64"],
+      "executable": true
+    },
+    {
+      "name": "Codex - macOS x64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/codex/codex-darwin-x64"
+      },
+      "destination": "resources/bin/third_party/codex",
+      "os": ["macos"],
+      "arch": ["x64"],
+      "executable": true
+    },
+    {
+      "name": "Claude Code - macOS x64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/claude-code/claude-darwin-x64"
+      },
+      "destination": "resources/bin/third_party/claude",
+      "os": ["macos"],
+      "arch": ["x64"],
+      "executable": true
+    },
+    {
+      "name": "Codex - Linux ARM64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/codex/codex-linux-arm64"
+      },
+      "destination": "resources/bin/third_party/codex",
+      "os": ["linux"],
+      "arch": ["arm64"],
+      "executable": true
+    },
+    {
+      "name": "Claude Code - Linux ARM64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/claude-code/claude-linux-arm64"
+      },
+      "destination": "resources/bin/third_party/claude",
+      "os": ["linux"],
+      "arch": ["arm64"],
+      "executable": true
+    },
+    {
+      "name": "Codex - Linux x64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/codex/codex-linux-x64"
+      },
+      "destination": "resources/bin/third_party/codex",
+      "os": ["linux"],
+      "arch": ["x64"],
+      "executable": true
+    },
+    {
+      "name": "Claude Code - Linux x64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/claude-code/claude-linux-x64"
+      },
+      "destination": "resources/bin/third_party/claude",
+      "os": ["linux"],
+      "arch": ["x64"],
+      "executable": true
+    },
+    {
+      "name": "Codex - Windows x64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/codex/codex-windows-x64.exe"
+      },
+      "destination": "resources/bin/third_party/codex.exe",
+      "os": ["windows"],
+      "arch": ["x64"],
+      "executable": true
+    },
+    {
+      "name": "Claude Code - Windows x64",
+      "source": {
+        "type": "r2",
+        "key": "third_party/claude-code/claude-windows-x64.exe"
+      },
+      "destination": "resources/bin/third_party/claude.exe",
+      "os": ["windows"],
+      "arch": ["x64"],
+      "executable": true
+    },
+    {
       "name": "Drizzle migrations",
       "source": {
         "type": "local",

--- a/packages/browseros-agent/scripts/build/server/stage.test.ts
+++ b/packages/browseros-agent/scripts/build/server/stage.test.ts
@@ -201,6 +201,123 @@ describe('server artifact staging', () => {
     expect(destinations).toContain('resources/bin/third_party/bun')
     expect(destinations).toContain('resources/db/migrations')
   })
+
+  it('downloads bundled agent CLIs for Linux targets and marks them executable', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'browseros-stage-test-'))
+    const sourceRoot = join(tempDir, 'source')
+    const distRoot = join(tempDir, 'dist')
+    const binaryPath = join(tempDir, 'browseros-server')
+    await writeFile(binaryPath, 'server')
+
+    const artifact = await stageTargetArtifact(
+      distRoot,
+      binaryPath,
+      linuxArm64Target,
+      [codexLinuxArm64Rule, claudeLinuxArm64Rule],
+      sourceRoot,
+      fakeObjectClient({
+        'artifacts/vendor/third_party/codex/codex-linux-arm64':
+          '#!/bin/sh\ncodex\n',
+        'artifacts/vendor/third_party/claude-code/claude-linux-arm64':
+          '#!/bin/sh\nclaude\n',
+      }),
+      fakeR2Config,
+      '0.0.0-test',
+    )
+
+    const codexPath = join(artifact.resourcesDir, 'bin/third_party/codex')
+    const claudePath = join(artifact.resourcesDir, 'bin/third_party/claude')
+    expect(await readFile(codexPath, 'utf8')).toBe('#!/bin/sh\ncodex\n')
+    expect(await readFile(claudePath, 'utf8')).toBe('#!/bin/sh\nclaude\n')
+    expect((await stat(codexPath)).mode & 0o111).not.toBe(0)
+    expect((await stat(claudePath)).mode & 0o111).not.toBe(0)
+  })
+
+  it('downloads bundled agent CLIs for Windows targets without chmod', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'browseros-stage-test-'))
+    const sourceRoot = join(tempDir, 'source')
+    const distRoot = join(tempDir, 'dist')
+    const binaryPath = join(tempDir, 'browseros-server.exe')
+    await writeFile(binaryPath, 'server')
+
+    const artifact = await stageTargetArtifact(
+      distRoot,
+      binaryPath,
+      windowsX64Target,
+      [codexWindowsX64Rule, claudeWindowsX64Rule],
+      sourceRoot,
+      fakeObjectClient({
+        'artifacts/vendor/third_party/codex/codex-windows-x64.exe': 'codex.exe',
+        'artifacts/vendor/third_party/claude-code/claude-windows-x64.exe':
+          'claude.exe',
+      }),
+      fakeR2Config,
+      '0.0.0-test',
+    )
+
+    const codexPath = join(artifact.resourcesDir, 'bin/third_party/codex.exe')
+    const claudePath = join(artifact.resourcesDir, 'bin/third_party/claude.exe')
+    expect(await readFile(codexPath, 'utf8')).toBe('codex.exe')
+    expect(await readFile(claudePath, 'utf8')).toBe('claude.exe')
+    expect((await stat(codexPath)).mode & 0o111).toBe(0)
+    expect((await stat(claudePath)).mode & 0o111).toBe(0)
+  })
+
+  it('loads target-filtered bundled CLI rules from the production manifest', () => {
+    const manifest = loadManifest(
+      'scripts/build/config/server-prod-resources.json',
+    )
+    const linuxRules = getTargetRules(manifest, linuxArm64Target)
+    const windowsRules = getTargetRules(manifest, windowsX64Target)
+
+    expect(linuxRules).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'Codex - Linux ARM64',
+          source: {
+            type: 'r2',
+            key: 'third_party/codex/codex-linux-arm64',
+          },
+          destination: 'resources/bin/third_party/codex',
+          executable: true,
+        }),
+        expect.objectContaining({
+          name: 'Claude Code - Linux ARM64',
+          source: {
+            type: 'r2',
+            key: 'third_party/claude-code/claude-linux-arm64',
+          },
+          destination: 'resources/bin/third_party/claude',
+          executable: true,
+        }),
+      ]),
+    )
+    expect(windowsRules).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          name: 'Codex - Windows x64',
+          source: {
+            type: 'r2',
+            key: 'third_party/codex/codex-windows-x64.exe',
+          },
+          destination: 'resources/bin/third_party/codex.exe',
+          executable: true,
+        }),
+        expect.objectContaining({
+          name: 'Claude Code - Windows x64',
+          source: {
+            type: 'r2',
+            key: 'third_party/claude-code/claude-windows-x64.exe',
+          },
+          destination: 'resources/bin/third_party/claude.exe',
+          executable: true,
+        }),
+      ]),
+    )
+    expect(linuxRules.find((rule) => rule.name === 'Codex - Windows x64')).toBe(
+      undefined,
+    )
+  })
 })
 
 const testTarget: BuildTarget = {
@@ -272,6 +389,54 @@ const bunRule: ResourceRule = {
   executable: true,
 }
 
+const codexLinuxArm64Rule: ResourceRule = {
+  name: 'Codex - Linux ARM64',
+  source: {
+    type: 'r2',
+    key: 'third_party/codex/codex-linux-arm64',
+  },
+  destination: 'resources/bin/third_party/codex',
+  os: ['linux'],
+  arch: ['arm64'],
+  executable: true,
+}
+
+const claudeLinuxArm64Rule: ResourceRule = {
+  name: 'Claude Code - Linux ARM64',
+  source: {
+    type: 'r2',
+    key: 'third_party/claude-code/claude-linux-arm64',
+  },
+  destination: 'resources/bin/third_party/claude',
+  os: ['linux'],
+  arch: ['arm64'],
+  executable: true,
+}
+
+const codexWindowsX64Rule: ResourceRule = {
+  name: 'Codex - Windows x64',
+  source: {
+    type: 'r2',
+    key: 'third_party/codex/codex-windows-x64.exe',
+  },
+  destination: 'resources/bin/third_party/codex.exe',
+  os: ['windows'],
+  arch: ['x64'],
+  executable: true,
+}
+
+const claudeWindowsX64Rule: ResourceRule = {
+  name: 'Claude Code - Windows x64',
+  source: {
+    type: 'r2',
+    key: 'third_party/claude-code/claude-windows-x64.exe',
+  },
+  destination: 'resources/bin/third_party/claude.exe',
+  os: ['windows'],
+  arch: ['x64'],
+  executable: true,
+}
+
 const fakeR2Config: R2Config = {
   accountId: 'test',
   accessKeyId: 'test',
@@ -279,4 +444,21 @@ const fakeR2Config: R2Config = {
   bucket: 'browseros-test',
   downloadPrefix: 'artifacts/vendor',
   uploadPrefix: 'server/prod-resources',
+}
+
+function fakeObjectClient(objects: Record<string, string>): S3Client {
+  return {
+    send: async (command: { input?: { Key?: string } }) => {
+      const key = command.input?.Key
+      const payload = key ? objects[key] : undefined
+      if (payload === undefined) {
+        throw new Error(`Unexpected R2 object: ${String(key)}`)
+      }
+      return {
+        Body: {
+          transformToByteArray: async () => new TextEncoder().encode(payload),
+        },
+      }
+    },
+  } as unknown as S3Client
 }

--- a/packages/browseros/build/cli/storage.py
+++ b/packages/browseros/build/cli/storage.py
@@ -31,6 +31,16 @@ BUN_RELEASE_BASE = "https://github.com/oven-sh/bun/releases/download"
 BUN_R2_PREFIX = "artifacts/vendor/third_party/bun"
 BUN_MANIFEST_KEY = f"{BUN_R2_PREFIX}/manifest.json"
 BUN_HTTP_TIMEOUT_S = 120
+CODEX_RELEASE_BASE = "https://github.com/openai/codex/releases/download"
+CODEX_DEFAULT_TAG = "rust-v0.136.0"
+CODEX_R2_PREFIX = "artifacts/vendor/third_party/codex"
+CODEX_MANIFEST_KEY = f"{CODEX_R2_PREFIX}/manifest.json"
+CODEX_HTTP_TIMEOUT_S = 120
+CLAUDE_CODE_RELEASE_BASE = "https://downloads.claude.ai/claude-code-releases"
+CLAUDE_CODE_DEFAULT_VERSION = "2.1.159"
+CLAUDE_CODE_R2_PREFIX = "artifacts/vendor/third_party/claude-code"
+CLAUDE_CODE_MANIFEST_KEY = f"{CLAUDE_CODE_R2_PREFIX}/manifest.json"
+CLAUDE_CODE_HTTP_TIMEOUT_S = 300
 
 
 @dataclass(frozen=True)
@@ -85,6 +95,61 @@ BUN_TARGETS: Tuple[BunTarget, ...] = (
         r2_name="bun-windows-x64-baseline.exe",
         binary_name="bun.exe",
     ),
+)
+
+
+@dataclass(frozen=True)
+class CodexPlatform:
+    """BrowserOS target plus the upstream Codex package coordinates."""
+
+    target: str
+    upstream: str
+    entrypoint: str
+
+
+CODEX_PLATFORMS: Tuple[CodexPlatform, ...] = (
+    CodexPlatform(
+        target="darwin-arm64",
+        upstream="aarch64-apple-darwin",
+        entrypoint="bin/codex",
+    ),
+    CodexPlatform(
+        target="darwin-x64",
+        upstream="x86_64-apple-darwin",
+        entrypoint="bin/codex",
+    ),
+    CodexPlatform(
+        target="linux-arm64",
+        upstream="aarch64-unknown-linux-musl",
+        entrypoint="bin/codex",
+    ),
+    CodexPlatform(
+        target="linux-x64",
+        upstream="x86_64-unknown-linux-musl",
+        entrypoint="bin/codex",
+    ),
+    CodexPlatform(
+        target="windows-x64",
+        upstream="x86_64-pc-windows-msvc",
+        entrypoint="bin/codex.exe",
+    ),
+)
+
+
+@dataclass(frozen=True)
+class ClaudeCodePlatform:
+    """BrowserOS target plus the upstream Claude Code platform name."""
+
+    target: str
+    upstream: str
+
+
+CLAUDE_CODE_PLATFORMS: Tuple[ClaudeCodePlatform, ...] = (
+    ClaudeCodePlatform(target="darwin-arm64", upstream="darwin-arm64"),
+    ClaudeCodePlatform(target="darwin-x64", upstream="darwin-x64"),
+    ClaudeCodePlatform(target="linux-arm64", upstream="linux-arm64"),
+    ClaudeCodePlatform(target="linux-x64", upstream="linux-x64"),
+    ClaudeCodePlatform(target="windows-x64", upstream="win32-x64"),
 )
 
 
@@ -235,6 +300,120 @@ def upload_bun(
     log_success(f"Bun {tag} uploaded for {[t.internal for t in BUN_TARGETS]}")
 
 
+@app.command("codex")
+def upload_codex(
+    version: str = typer.Option(
+        CODEX_DEFAULT_TAG,
+        "--version",
+        "-v",
+        help="Codex release tag, e.g. rust-v0.136.0",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Download + verify only; skip R2 uploads.",
+    ),
+) -> None:
+    """Download Codex release packages and push normalized native binaries to R2."""
+    tag = _normalize_codex_release_tag(version)
+    env, client = _prepare_upload_client(dry_run)
+
+    with tempfile.TemporaryDirectory(prefix="codex-upload-") as tmp:
+        tmp_dir = Path(tmp)
+        checksums = _fetch_codex_package_checksums(tag, tmp_dir)
+        uploaded_keys: List[str] = []
+        package_shas: Dict[str, str] = {}
+        object_shas: Dict[str, str] = {}
+
+        try:
+            for platform in CODEX_PLATFORMS:
+                package_sha, binary_sha, _ = _process_codex_platform(
+                    tag,
+                    platform,
+                    tmp_dir,
+                    checksums,
+                    client,
+                    env,
+                    dry_run,
+                    uploaded_keys,
+                )
+                package_shas[platform.target] = package_sha
+                object_shas[platform.target] = binary_sha
+
+            manifest = _build_codex_manifest(tag, package_shas, object_shas)
+            _upload_codex_manifest(client, env, manifest, tmp_dir, dry_run)
+        except Exception as exc:
+            if not dry_run and uploaded_keys:
+                log_warning(
+                    f"Upload failed — rolling back {len(uploaded_keys)} object(s)"
+                )
+                _rollback(client, env.r2_bucket, uploaded_keys)
+            log_error(f"Codex upload aborted: {exc}")
+            raise typer.Exit(1)
+
+    log_success(f"Codex {tag} uploaded for {[p.target for p in CODEX_PLATFORMS]}")
+
+
+@app.command("claude-code")
+def upload_claude_code(
+    version: str = typer.Option(
+        CLAUDE_CODE_DEFAULT_VERSION,
+        "--version",
+        "-v",
+        help="Claude Code release version, e.g. 2.1.159",
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Download + verify only; skip R2 uploads.",
+    ),
+) -> None:
+    """Download Claude Code release binaries and push normalized objects to R2."""
+    version = version.strip()
+    env, client = _prepare_upload_client(dry_run)
+
+    with tempfile.TemporaryDirectory(prefix="claude-code-upload-") as tmp:
+        tmp_dir = Path(tmp)
+        manifest = _fetch_claude_code_manifest(version, tmp_dir)
+        uploaded_keys: List[str] = []
+        object_shas: Dict[str, str] = {}
+        platform_info: Dict[str, Dict[str, str]] = {}
+
+        try:
+            for platform in CLAUDE_CODE_PLATFORMS:
+                binary_sha, _ = _process_claude_code_platform(
+                    version,
+                    platform,
+                    manifest,
+                    tmp_dir,
+                    client,
+                    env,
+                    dry_run,
+                    uploaded_keys,
+                )
+                object_shas[platform.target] = binary_sha
+                platform_info[platform.target] = _claude_code_manifest_info(
+                    manifest, platform
+                )
+
+            upload_manifest = _build_claude_code_manifest(
+                version, object_shas, platform_info
+            )
+            _upload_claude_code_manifest(client, env, upload_manifest, tmp_dir, dry_run)
+        except Exception as exc:
+            if not dry_run and uploaded_keys:
+                log_warning(
+                    f"Upload failed — rolling back {len(uploaded_keys)} object(s)"
+                )
+                _rollback(client, env.r2_bucket, uploaded_keys)
+            log_error(f"Claude Code upload aborted: {exc}")
+            raise typer.Exit(1)
+
+    log_success(
+        f"Claude Code {version} uploaded for {[p.target for p in CLAUDE_CODE_PLATFORMS]}"
+    )
+
+
 def _normalize_version_tag(version: str) -> str:
     return version if version.startswith("v") else f"v{version}"
 
@@ -245,6 +424,40 @@ def _normalize_bun_version_tag(version: str) -> str:
     if version.startswith("bun-"):
         return f"bun-v{version[len('bun-') :]}"
     return f"bun-{_normalize_version_tag(version)}"
+
+
+def _normalize_codex_release_tag(version: str) -> str:
+    if version.startswith("rust-v"):
+        return version
+    if version.startswith("rust-"):
+        suffix = version[len("rust-") :]
+        return f"rust-{_normalize_version_tag(suffix)}"
+    return f"rust-{_normalize_version_tag(version)}"
+
+
+def _codex_cli_version(tag: str) -> str:
+    return tag[len("rust-v") :] if tag.startswith("rust-v") else tag
+
+
+def _prepare_upload_client(dry_run: bool) -> Tuple[EnvConfig, Any]:
+    """Create the R2 client for real uploads while keeping dry-runs local."""
+    env = EnvConfig()
+    if dry_run:
+        return env, None
+    if not BOTO3_AVAILABLE:
+        log_error("boto3 not installed — run: pip install boto3")
+        raise typer.Exit(1)
+    if not env.has_r2_config():
+        log_error(
+            "R2 configuration missing. Required: "
+            "R2_ACCOUNT_ID, R2_ACCESS_KEY_ID, R2_SECRET_ACCESS_KEY"
+        )
+        raise typer.Exit(1)
+    client = get_r2_client(env)
+    if client is None:
+        log_error("Failed to create R2 client")
+        raise typer.Exit(1)
+    return env, client
 
 
 def _fetch_checksums(tag: str, tmp_dir: Path) -> Dict[str, str]:
@@ -261,6 +474,25 @@ def _fetch_bun_checksums(tag: str, tmp_dir: Path) -> Dict[str, str]:
     log_info(f"Fetching {url}")
     _download(url, dest)
     return _parse_checksums(dest.read_text(encoding="utf-8"))
+
+
+def _fetch_codex_package_checksums(tag: str, tmp_dir: Path) -> Dict[str, str]:
+    url = f"{CODEX_RELEASE_BASE}/{tag}/codex-package_SHA256SUMS"
+    dest = tmp_dir / "codex-package_SHA256SUMS"
+    log_info(f"Fetching {url}")
+    _download(url, dest)
+    return _parse_checksums(dest.read_text(encoding="utf-8"))
+
+
+def _fetch_claude_code_manifest(version: str, tmp_dir: Path) -> Dict[str, Any]:
+    url = f"{CLAUDE_CODE_RELEASE_BASE}/{version}/manifest.json"
+    dest = tmp_dir / "claude-code-manifest.json"
+    log_info(f"Fetching {url}")
+    _download(url, dest, timeout=CLAUDE_CODE_HTTP_TIMEOUT_S)
+    manifest = json.loads(dest.read_text(encoding="utf-8"))
+    if not isinstance(manifest, dict):
+        raise RuntimeError("Claude Code manifest must be a JSON object")
+    return manifest
 
 
 def _parse_checksums(contents: str) -> Dict[str, str]:
@@ -388,6 +620,100 @@ def _process_bun_target(
     return actual_sha, binary_sha, r2_key
 
 
+def _process_codex_platform(
+    tag: str,
+    platform: CodexPlatform,
+    tmp_dir: Path,
+    checksums: Dict[str, str],
+    client: Any,
+    env: EnvConfig,
+    dry_run: bool,
+    uploaded_keys: Optional[List[str]] = None,
+) -> Tuple[str, str, str]:
+    package_name = f"codex-package-{platform.upstream}.tar.gz"
+    expected_sha = checksums.get(package_name)
+    if not expected_sha:
+        raise RuntimeError(
+            f"{package_name} missing from codex-package_SHA256SUMS "
+            "(is the version tag correct?)"
+        )
+
+    package_path = tmp_dir / package_name
+    url = f"{CODEX_RELEASE_BASE}/{tag}/{package_name}"
+    log_info(f"Downloading {url}")
+    _download(url, package_path, timeout=CODEX_HTTP_TIMEOUT_S)
+
+    actual_sha = _sha256_file(package_path)
+    if actual_sha != expected_sha:
+        raise RuntimeError(
+            f"sha256 mismatch for {package_name}: expected {expected_sha}, got {actual_sha}"
+        )
+
+    local_path = tmp_dir / _platform_binary_object_name("codex", platform.target)
+    r2_key = (
+        f"{CODEX_R2_PREFIX}/{_platform_binary_object_name('codex', platform.target)}"
+    )
+    _extract_codex_file(package_path, local_path)
+    binary_sha = _sha256_file(local_path)
+
+    if dry_run:
+        log_info(f"[dry-run] skipped upload of {r2_key}")
+    elif not upload_file_to_r2(client, local_path, r2_key, env.r2_bucket):
+        raise RuntimeError(f"Failed to upload {r2_key}")
+    elif uploaded_keys is not None:
+        uploaded_keys.append(r2_key)
+
+    return actual_sha, binary_sha, r2_key
+
+
+def _process_claude_code_platform(
+    version: str,
+    platform: ClaudeCodePlatform,
+    manifest: Dict[str, Any],
+    tmp_dir: Path,
+    client: Any,
+    env: EnvConfig,
+    dry_run: bool,
+    uploaded_keys: Optional[List[str]] = None,
+) -> Tuple[str, str]:
+    entry = _claude_code_manifest_entry(manifest, platform)
+    binary_name = entry["binary"]
+    expected_sha = entry["checksum"]
+    expected_size = entry["size"]
+
+    local_path = tmp_dir / f"{platform.upstream}-{binary_name}"
+    url = f"{CLAUDE_CODE_RELEASE_BASE}/{version}/{platform.upstream}/{binary_name}"
+    log_info(f"Downloading {url}")
+    _download(url, local_path, timeout=CLAUDE_CODE_HTTP_TIMEOUT_S)
+
+    actual_size = local_path.stat().st_size
+    if actual_size != expected_size:
+        raise RuntimeError(
+            f"size mismatch for Claude Code {platform.upstream}: "
+            f"expected {expected_size}, got {actual_size}"
+        )
+
+    actual_sha = _sha256_file(local_path)
+    if actual_sha != expected_sha:
+        raise RuntimeError(
+            f"sha256 mismatch for Claude Code {platform.upstream}: "
+            f"expected {expected_sha}, got {actual_sha}"
+        )
+
+    if not binary_name.endswith(".exe"):
+        local_path.chmod(0o755)
+
+    r2_key = f"{CLAUDE_CODE_R2_PREFIX}/{_platform_binary_object_name('claude', platform.target)}"
+    if dry_run:
+        log_info(f"[dry-run] skipped upload of {r2_key}")
+    elif not upload_file_to_r2(client, local_path, r2_key, env.r2_bucket):
+        raise RuntimeError(f"Failed to upload {r2_key}")
+    elif uploaded_keys is not None:
+        uploaded_keys.append(r2_key)
+
+    return actual_sha, r2_key
+
+
 def _extract_lima_file(tarball_path: Path, logical_path: str, dest: Path) -> None:
     with tarfile.open(tarball_path, "r:gz") as tar:
         for member in tar.getmembers():
@@ -423,6 +749,28 @@ def _extract_bun_file(zip_path: Path, dest: Path, binary_name: str = "bun") -> N
     raise RuntimeError(f"{binary_name} not found in Bun zip")
 
 
+def _extract_codex_file(package_path: Path, dest: Path) -> None:
+    """Extract the entrypoint declared by Codex's package metadata."""
+    with tarfile.open(package_path, "r:gz") as tar:
+        members = tar.getmembers()
+        entrypoint = _read_codex_package_entrypoint(tar, members)
+        for member in members:
+            if not member.isfile():
+                continue
+            if _logical_archive_path(member.name) != entrypoint:
+                continue
+            extracted = tar.extractfile(member)
+            if extracted is None:
+                raise RuntimeError(f"{member.name} is not a regular file")
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            with extracted as src, open(dest, "wb") as out:
+                while chunk := src.read(1024 * 1024):
+                    out.write(chunk)
+            dest.chmod(0o755)
+            return
+    raise RuntimeError(f"Codex entrypoint {entrypoint} not found in package")
+
+
 def _logical_lima_path(member_name: str) -> str:
     parts = Path(member_name.lstrip("./")).parts
     if len(parts) > 1 and parts[0].startswith("lima-"):
@@ -435,6 +783,80 @@ def _logical_bun_path(member_name: str) -> str:
     if len(parts) > 1 and parts[0].startswith("bun-"):
         parts = parts[1:]
     return "/".join(parts)
+
+
+def _logical_archive_path(member_name: str) -> str:
+    return "/".join(Path(member_name.lstrip("./")).parts)
+
+
+def _read_codex_package_entrypoint(
+    tar: tarfile.TarFile,
+    members: List[tarfile.TarInfo],
+) -> str:
+    for member in members:
+        if not member.isfile():
+            continue
+        if _logical_archive_path(member.name) != "codex-package.json":
+            continue
+        extracted = tar.extractfile(member)
+        if extracted is None:
+            raise RuntimeError("codex-package.json is not a regular file")
+        with extracted as src:
+            metadata = json.loads(src.read().decode("utf-8"))
+        entrypoint = metadata.get("entrypoint") if isinstance(metadata, dict) else None
+        if not isinstance(entrypoint, str) or not entrypoint:
+            raise RuntimeError("Codex package metadata is missing entrypoint")
+        return entrypoint
+    raise RuntimeError("codex-package.json not found in Codex package")
+
+
+def _platform_binary_object_name(binary_stem: str, target: str) -> str:
+    suffix = ".exe" if target.startswith("windows-") else ""
+    return f"{binary_stem}-{target}{suffix}"
+
+
+def _claude_code_manifest_entry(
+    manifest: Dict[str, Any],
+    platform: ClaudeCodePlatform,
+) -> Dict[str, Any]:
+    platforms = manifest.get("platforms")
+    if not isinstance(platforms, dict):
+        raise RuntimeError("Claude Code manifest is missing platforms")
+    entry = platforms.get(platform.upstream)
+    if not isinstance(entry, dict):
+        raise RuntimeError(f"{platform.upstream} missing from Claude Code manifest")
+    binary = entry.get("binary")
+    checksum = entry.get("checksum")
+    size = entry.get("size")
+    if not isinstance(binary, str) or not binary:
+        raise RuntimeError(
+            f"Claude Code manifest has invalid binary for {platform.upstream}"
+        )
+    if not _is_sha256(checksum):
+        raise RuntimeError(
+            f"Claude Code manifest has invalid checksum for {platform.upstream}"
+        )
+    if not isinstance(size, int) or size < 0:
+        raise RuntimeError(
+            f"Claude Code manifest has invalid size for {platform.upstream}"
+        )
+    return {"binary": binary, "checksum": checksum, "size": size}
+
+
+def _claude_code_manifest_info(
+    manifest: Dict[str, Any],
+    platform: ClaudeCodePlatform,
+) -> Dict[str, str]:
+    entry = _claude_code_manifest_entry(manifest, platform)
+    return {"platform": platform.upstream, "binary": entry["binary"]}
+
+
+def _is_sha256(value: Any) -> bool:
+    return (
+        isinstance(value, str)
+        and len(value) == 64
+        and all(c in "0123456789abcdef" for c in value.lower())
+    )
 
 
 def _build_manifest(
@@ -462,6 +884,36 @@ def _build_bun_manifest(
         "bun_version": tag,
         "zip_shas_upstream": zip_shas,
         "r2_object_shas": object_shas,
+        "uploaded_at": datetime.now(timezone.utc).isoformat(),
+        "uploaded_by": os.environ.get("GITHUB_ACTOR") or "local",
+    }
+
+
+def _build_codex_manifest(
+    tag: str,
+    package_shas: Dict[str, str],
+    object_shas: Dict[str, str],
+) -> Dict[str, Any]:
+    return {
+        "codex_release_tag": tag,
+        "codex_cli_version": _codex_cli_version(tag),
+        "package_shas_upstream": package_shas,
+        "r2_object_shas": object_shas,
+        "uploaded_at": datetime.now(timezone.utc).isoformat(),
+        "uploaded_by": os.environ.get("GITHUB_ACTOR") or "local",
+    }
+
+
+def _build_claude_code_manifest(
+    version: str,
+    binary_shas: Dict[str, str],
+    platform_info: Dict[str, Dict[str, str]],
+) -> Dict[str, Any]:
+    return {
+        "claude_code_version": version,
+        "binary_shas_upstream": binary_shas,
+        "r2_object_shas": binary_shas,
+        "platforms": platform_info,
         "uploaded_at": datetime.now(timezone.utc).isoformat(),
         "uploaded_by": os.environ.get("GITHUB_ACTOR") or "local",
     }
@@ -497,6 +949,40 @@ def _upload_bun_manifest(
         return
     if not upload_file_to_r2(client, manifest_path, BUN_MANIFEST_KEY, env.r2_bucket):
         raise RuntimeError(f"Failed to upload {BUN_MANIFEST_KEY}")
+
+
+def _upload_codex_manifest(
+    client: Any,
+    env: EnvConfig,
+    manifest: Dict[str, Any],
+    tmp_dir: Path,
+    dry_run: bool,
+) -> None:
+    manifest_path = tmp_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    if dry_run:
+        log_info(f"[dry-run] manifest would be: {manifest}")
+        return
+    if not upload_file_to_r2(client, manifest_path, CODEX_MANIFEST_KEY, env.r2_bucket):
+        raise RuntimeError(f"Failed to upload {CODEX_MANIFEST_KEY}")
+
+
+def _upload_claude_code_manifest(
+    client: Any,
+    env: EnvConfig,
+    manifest: Dict[str, Any],
+    tmp_dir: Path,
+    dry_run: bool,
+) -> None:
+    manifest_path = tmp_dir / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    if dry_run:
+        log_info(f"[dry-run] manifest would be: {manifest}")
+        return
+    if not upload_file_to_r2(
+        client, manifest_path, CLAUDE_CODE_MANIFEST_KEY, env.r2_bucket
+    ):
+        raise RuntimeError(f"Failed to upload {CLAUDE_CODE_MANIFEST_KEY}")
 
 
 def _rollback(client: Any, bucket: str, keys: List[str]) -> None:

--- a/packages/browseros/build/cli/storage.py
+++ b/packages/browseros/build/cli/storage.py
@@ -104,34 +104,28 @@ class CodexPlatform:
 
     target: str
     upstream: str
-    entrypoint: str
 
 
 CODEX_PLATFORMS: Tuple[CodexPlatform, ...] = (
     CodexPlatform(
         target="darwin-arm64",
         upstream="aarch64-apple-darwin",
-        entrypoint="bin/codex",
     ),
     CodexPlatform(
         target="darwin-x64",
         upstream="x86_64-apple-darwin",
-        entrypoint="bin/codex",
     ),
     CodexPlatform(
         target="linux-arm64",
         upstream="aarch64-unknown-linux-musl",
-        entrypoint="bin/codex",
     ),
     CodexPlatform(
         target="linux-x64",
         upstream="x86_64-unknown-linux-musl",
-        entrypoint="bin/codex",
     ),
     CodexPlatform(
         target="windows-x64",
         upstream="x86_64-pc-windows-msvc",
-        entrypoint="bin/codex.exe",
     ),
 )
 
@@ -744,7 +738,8 @@ def _extract_bun_file(zip_path: Path, dest: Path, binary_name: str = "bun") -> N
             with archive.open(member) as src, open(dest, "wb") as out:
                 while chunk := src.read(1024 * 1024):
                     out.write(chunk)
-            dest.chmod(0o755)
+            if not binary_name.endswith(".exe"):
+                dest.chmod(0o755)
             return
     raise RuntimeError(f"{binary_name} not found in Bun zip")
 
@@ -766,7 +761,8 @@ def _extract_codex_file(package_path: Path, dest: Path) -> None:
             with extracted as src, open(dest, "wb") as out:
                 while chunk := src.read(1024 * 1024):
                     out.write(chunk)
-            dest.chmod(0o755)
+            if not entrypoint.endswith(".exe"):
+                dest.chmod(0o755)
             return
     raise RuntimeError(f"Codex entrypoint {entrypoint} not found in package")
 
@@ -911,9 +907,9 @@ def _build_claude_code_manifest(
 ) -> Dict[str, Any]:
     return {
         "claude_code_version": version,
-        "binary_shas_upstream": binary_shas,
-        "r2_object_shas": binary_shas,
-        "platforms": platform_info,
+        "binary_shas_upstream": dict(binary_shas),
+        "r2_object_shas": dict(binary_shas),
+        "platforms": {target: dict(info) for target, info in platform_info.items()},
         "uploaded_at": datetime.now(timezone.utc).isoformat(),
         "uploaded_by": os.environ.get("GITHUB_ACTOR") or "local",
     }

--- a/packages/browseros/build/cli/storage_test.py
+++ b/packages/browseros/build/cli/storage_test.py
@@ -3,6 +3,7 @@
 
 import hashlib
 import io
+import json
 import tarfile
 import tempfile
 import unittest
@@ -61,6 +62,23 @@ def _build_bun_zip(
     buffer = io.BytesIO()
     with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
         archive.writestr(f"{root_dir}/{binary_name}", payload)
+    return buffer.getvalue()
+
+
+def _build_codex_package(
+    entrypoint: str,
+    payload: bytes,
+    actual_entrypoint: str | None = None,
+) -> bytes:
+    """Return a Codex package archive with package metadata and entrypoint."""
+    buffer = io.BytesIO()
+    with tarfile.open(fileobj=buffer, mode="w:gz") as tar:
+        _add_tar_file(
+            tar,
+            "codex-package.json",
+            json.dumps({"entrypoint": entrypoint}).encode("utf-8"),
+        )
+        _add_tar_file(tar, actual_entrypoint or entrypoint, payload, mode=0o755)
     return buffer.getvalue()
 
 
@@ -315,6 +333,37 @@ class BuildManifestTest(unittest.TestCase):
             "a" * 64,
         )
         self.assertEqual(manifest["r2_object_shas"]["linux-x64"], "d" * 64)
+        self.assertIn("uploaded_at", manifest)
+        self.assertIn("uploaded_by", manifest)
+
+    def test_codex_manifest_shape(self) -> None:
+        manifest = storage._build_codex_manifest(
+            "rust-v0.136.0",
+            {"darwin-arm64": "a" * 64, "windows-x64": "b" * 64},
+            {"darwin-arm64": "c" * 64, "windows-x64": "d" * 64},
+        )
+        self.assertEqual(manifest["codex_release_tag"], "rust-v0.136.0")
+        self.assertEqual(manifest["codex_cli_version"], "0.136.0")
+        self.assertEqual(manifest["package_shas_upstream"]["darwin-arm64"], "a" * 64)
+        self.assertEqual(manifest["r2_object_shas"]["windows-x64"], "d" * 64)
+        self.assertIn("uploaded_at", manifest)
+        self.assertIn("uploaded_by", manifest)
+
+    def test_claude_code_manifest_shape(self) -> None:
+        manifest = storage._build_claude_code_manifest(
+            "2.1.159",
+            {"darwin-arm64": "5" * 64, "windows-x64": "6" * 64},
+            {
+                "darwin-arm64": {"platform": "darwin-arm64", "binary": "claude"},
+                "windows-x64": {"platform": "win32-x64", "binary": "claude.exe"},
+            },
+        )
+        self.assertEqual(manifest["claude_code_version"], "2.1.159")
+        self.assertEqual(manifest["binary_shas_upstream"]["darwin-arm64"], "5" * 64)
+        self.assertEqual(
+            manifest["platforms"]["windows-x64"],
+            {"platform": "win32-x64", "binary": "claude.exe"},
+        )
         self.assertIn("uploaded_at", manifest)
         self.assertIn("uploaded_by", manifest)
 
@@ -778,6 +827,391 @@ class ProcessBunTargetTest(unittest.TestCase):
                     payload,
                 )
             ],
+        )
+
+
+class ExtractCodexFileTest(unittest.TestCase):
+    def test_extracts_declared_entrypoint(self) -> None:
+        payload = b"codex-binary-" + b"c" * 100
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            package_path = tmp_path / "codex.tar.gz"
+            package_path.write_bytes(_build_codex_package("bin/codex", payload))
+            dest = tmp_path / "codex"
+
+            storage._extract_codex_file(package_path, dest)
+
+            self.assertEqual(dest.read_bytes(), payload)
+            self.assertTrue(dest.stat().st_mode & 0o100, "should be executable")
+
+    def test_raises_when_declared_entrypoint_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            package_path = tmp_path / "codex.tar.gz"
+            package_path.write_bytes(
+                _build_codex_package("bin/missing", b"payload", "bin/codex")
+            )
+
+            with self.assertRaisesRegex(RuntimeError, "Codex entrypoint .* not found"):
+                storage._extract_codex_file(package_path, tmp_path / "codex")
+
+
+class ProcessCodexPlatformTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.codex_payload = b"codex-binary-" + b"x" * 200
+        self.package_bytes = _build_codex_package("bin/codex", self.codex_payload)
+        self.expected_package_sha = hashlib.sha256(self.package_bytes).hexdigest()
+        self.expected_codex_sha = hashlib.sha256(self.codex_payload).hexdigest()
+
+    def _fake_download(self, _url: str, dest: Path, **_kwargs: Any) -> None:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(self.package_bytes)
+
+    def test_happy_path_uploads_and_returns_shas(self) -> None:
+        uploads: List[Tuple[str, str, bytes]] = []
+
+        def fake_upload(
+            _client: Any, local_path: Path, r2_key: str, bucket: str
+        ) -> bool:
+            uploads.append((r2_key, bucket, local_path.read_bytes()))
+            return True
+
+        env = mock.Mock(r2_bucket="browseros")
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            with (
+                mock.patch.object(
+                    storage, "_download", side_effect=self._fake_download
+                ),
+                mock.patch.object(
+                    storage, "upload_file_to_r2", side_effect=fake_upload
+                ),
+            ):
+                package_sha, binary_sha, r2_key = storage._process_codex_platform(
+                    tag="rust-v0.136.0",
+                    platform=storage.CodexPlatform(
+                        target="darwin-arm64",
+                        upstream="aarch64-apple-darwin",
+                        entrypoint="bin/codex",
+                    ),
+                    tmp_dir=tmp_path,
+                    checksums={
+                        "codex-package-aarch64-apple-darwin.tar.gz": self.expected_package_sha
+                    },
+                    client=mock.Mock(),
+                    env=env,
+                    dry_run=False,
+                )
+
+        self.assertEqual(package_sha, self.expected_package_sha)
+        self.assertEqual(binary_sha, self.expected_codex_sha)
+        self.assertEqual(
+            r2_key, "artifacts/vendor/third_party/codex/codex-darwin-arm64"
+        )
+        self.assertEqual(
+            uploads,
+            [
+                (
+                    "artifacts/vendor/third_party/codex/codex-darwin-arm64",
+                    "browseros",
+                    self.codex_payload,
+                )
+            ],
+        )
+
+    def test_sha_mismatch_aborts_before_upload(self) -> None:
+        uploads: List[Tuple[str, str]] = []
+
+        def fake_upload(
+            _client: Any, _local_path: Path, r2_key: str, bucket: str
+        ) -> bool:
+            uploads.append((r2_key, bucket))
+            return True
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            with (
+                mock.patch.object(
+                    storage, "_download", side_effect=self._fake_download
+                ),
+                mock.patch.object(
+                    storage, "upload_file_to_r2", side_effect=fake_upload
+                ),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "sha256 mismatch"):
+                    storage._process_codex_platform(
+                        tag="rust-v0.136.0",
+                        platform=storage.CodexPlatform(
+                            target="darwin-arm64",
+                            upstream="aarch64-apple-darwin",
+                            entrypoint="bin/codex",
+                        ),
+                        tmp_dir=tmp_path,
+                        checksums={
+                            "codex-package-aarch64-apple-darwin.tar.gz": "0" * 64
+                        },
+                        client=mock.Mock(),
+                        env=mock.Mock(r2_bucket="browseros"),
+                        dry_run=False,
+                    )
+
+        self.assertEqual(uploads, [])
+
+    def test_dry_run_skips_upload(self) -> None:
+        uploads: List[Tuple[str, str]] = []
+
+        def fake_upload(*args: Any, **kwargs: Any) -> bool:
+            uploads.append(("called", ""))
+            return True
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            with (
+                mock.patch.object(
+                    storage, "_download", side_effect=self._fake_download
+                ),
+                mock.patch.object(
+                    storage, "upload_file_to_r2", side_effect=fake_upload
+                ),
+            ):
+                _, _, r2_key = storage._process_codex_platform(
+                    tag="rust-v0.136.0",
+                    platform=storage.CodexPlatform(
+                        target="windows-x64",
+                        upstream="x86_64-pc-windows-msvc",
+                        entrypoint="bin/codex.exe",
+                    ),
+                    tmp_dir=tmp_path,
+                    checksums={
+                        "codex-package-x86_64-pc-windows-msvc.tar.gz": self.expected_package_sha
+                    },
+                    client=None,
+                    env=mock.Mock(r2_bucket="browseros"),
+                    dry_run=True,
+                )
+
+        self.assertEqual(uploads, [])
+        self.assertEqual(
+            r2_key, "artifacts/vendor/third_party/codex/codex-windows-x64.exe"
+        )
+
+
+class ProcessClaudeCodePlatformTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.claude_payload = b"claude-binary-" + b"y" * 200
+        self.expected_binary_sha = hashlib.sha256(self.claude_payload).hexdigest()
+        self.manifest = {
+            "platforms": {
+                "darwin-arm64": {
+                    "binary": "claude",
+                    "checksum": self.expected_binary_sha,
+                    "size": len(self.claude_payload),
+                },
+                "win32-x64": {
+                    "binary": "claude.exe",
+                    "checksum": self.expected_binary_sha,
+                    "size": len(self.claude_payload),
+                },
+            }
+        }
+
+    def _fake_download(self, _url: str, dest: Path, **_kwargs: Any) -> None:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(self.claude_payload)
+
+    def test_happy_path_uploads_and_returns_shas(self) -> None:
+        uploads: List[Tuple[str, str, bytes]] = []
+
+        def fake_upload(
+            _client: Any, local_path: Path, r2_key: str, bucket: str
+        ) -> bool:
+            uploads.append((r2_key, bucket, local_path.read_bytes()))
+            return True
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            with (
+                mock.patch.object(
+                    storage, "_download", side_effect=self._fake_download
+                ),
+                mock.patch.object(
+                    storage, "upload_file_to_r2", side_effect=fake_upload
+                ),
+            ):
+                binary_sha, r2_key = storage._process_claude_code_platform(
+                    version="2.1.159",
+                    platform=storage.ClaudeCodePlatform(
+                        target="darwin-arm64",
+                        upstream="darwin-arm64",
+                    ),
+                    manifest=self.manifest,
+                    tmp_dir=tmp_path,
+                    client=mock.Mock(),
+                    env=mock.Mock(r2_bucket="browseros"),
+                    dry_run=False,
+                )
+
+        self.assertEqual(binary_sha, self.expected_binary_sha)
+        self.assertEqual(
+            r2_key,
+            "artifacts/vendor/third_party/claude-code/claude-darwin-arm64",
+        )
+        self.assertEqual(
+            uploads,
+            [
+                (
+                    "artifacts/vendor/third_party/claude-code/claude-darwin-arm64",
+                    "browseros",
+                    self.claude_payload,
+                )
+            ],
+        )
+
+    def test_size_mismatch_aborts_before_upload(self) -> None:
+        uploads: List[Tuple[str, str]] = []
+        bad_manifest = {
+            "platforms": {
+                "darwin-arm64": {
+                    "binary": "claude",
+                    "checksum": self.expected_binary_sha,
+                    "size": len(self.claude_payload) + 1,
+                }
+            }
+        }
+
+        def fake_upload(
+            _client: Any, _local_path: Path, r2_key: str, bucket: str
+        ) -> bool:
+            uploads.append((r2_key, bucket))
+            return True
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            with (
+                mock.patch.object(
+                    storage, "_download", side_effect=self._fake_download
+                ),
+                mock.patch.object(
+                    storage, "upload_file_to_r2", side_effect=fake_upload
+                ),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "size mismatch"):
+                    storage._process_claude_code_platform(
+                        version="2.1.159",
+                        platform=storage.ClaudeCodePlatform(
+                            target="darwin-arm64",
+                            upstream="darwin-arm64",
+                        ),
+                        manifest=bad_manifest,
+                        tmp_dir=tmp_path,
+                        client=mock.Mock(),
+                        env=mock.Mock(r2_bucket="browseros"),
+                        dry_run=False,
+                    )
+
+        self.assertEqual(uploads, [])
+
+    def test_missing_manifest_platform_aborts(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(
+                RuntimeError, "missing from Claude Code manifest"
+            ):
+                storage._process_claude_code_platform(
+                    version="2.1.159",
+                    platform=storage.ClaudeCodePlatform(
+                        target="linux-x64",
+                        upstream="linux-x64",
+                    ),
+                    manifest=self.manifest,
+                    tmp_dir=Path(tmp),
+                    client=mock.Mock(),
+                    env=mock.Mock(r2_bucket="browseros"),
+                    dry_run=False,
+                )
+
+    def test_dry_run_skips_upload_and_uses_manifest_binary_name(self) -> None:
+        uploads: List[Tuple[str, str]] = []
+
+        def fake_upload(*args: Any, **kwargs: Any) -> bool:
+            uploads.append(("called", ""))
+            return True
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            with (
+                mock.patch.object(
+                    storage, "_download", side_effect=self._fake_download
+                ),
+                mock.patch.object(
+                    storage, "upload_file_to_r2", side_effect=fake_upload
+                ),
+            ):
+                _, r2_key = storage._process_claude_code_platform(
+                    version="2.1.159",
+                    platform=storage.ClaudeCodePlatform(
+                        target="windows-x64",
+                        upstream="win32-x64",
+                    ),
+                    manifest=self.manifest,
+                    tmp_dir=tmp_path,
+                    client=None,
+                    env=mock.Mock(r2_bucket="browseros"),
+                    dry_run=True,
+                )
+
+        self.assertEqual(uploads, [])
+        self.assertEqual(
+            r2_key,
+            "artifacts/vendor/third_party/claude-code/claude-windows-x64.exe",
+        )
+
+
+class UploadVendorRollbackTest(unittest.TestCase):
+    def test_codex_upload_rolls_back_objects_uploaded_before_failure(self) -> None:
+        client = mock.Mock()
+        env = mock.Mock(
+            r2_bucket="browseros", has_r2_config=mock.Mock(return_value=True)
+        )
+        calls = 0
+
+        def fake_process(
+            tag: str,
+            platform: Any,
+            tmp_dir: Path,
+            checksums: Dict[str, str],
+            client_arg: Any,
+            env_arg: Any,
+            dry_run: bool,
+            uploaded_keys: List[str],
+        ) -> Tuple[str, str, str]:
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                key = "artifacts/vendor/third_party/codex/codex-darwin-arm64"
+                uploaded_keys.append(key)
+                return "a" * 64, "b" * 64, key
+            raise RuntimeError("boom")
+
+        with (
+            mock.patch.object(storage, "BOTO3_AVAILABLE", True),
+            mock.patch.object(storage, "EnvConfig", return_value=env),
+            mock.patch.object(storage, "get_r2_client", return_value=client),
+            mock.patch.object(
+                storage, "_fetch_codex_package_checksums", return_value={}
+            ),
+            mock.patch.object(
+                storage, "_process_codex_platform", side_effect=fake_process
+            ),
+        ):
+            with self.assertRaises(Exception) as exc:
+                storage.upload_codex(version="rust-v0.136.0", dry_run=False)
+
+        self.assertEqual(exc.exception.exit_code, 1)
+        client.delete_object.assert_called_once_with(
+            Bucket="browseros",
+            Key="artifacts/vendor/third_party/codex/codex-darwin-arm64",
         )
 
 

--- a/packages/browseros/build/cli/storage_test.py
+++ b/packages/browseros/build/cli/storage_test.py
@@ -254,6 +254,26 @@ class ExtractBunFileTest(unittest.TestCase):
                     binary_name="bun.exe",
                 )
 
+    def test_windows_exe_is_not_marked_executable(self) -> None:
+        payload = b"bun-windows-exe-" + b"b" * 100
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            zip_path = tmp_path / "bun.zip"
+            zip_path.write_bytes(
+                _build_bun_zip(
+                    payload,
+                    root_dir="bun-windows-x64-baseline",
+                    binary_name="bun.exe",
+                )
+            )
+            dest = tmp_path / "bun.exe"
+
+            storage._extract_bun_file(zip_path, dest, binary_name="bun.exe")
+
+            self.assertEqual(dest.read_bytes(), payload)
+            self.assertFalse(dest.stat().st_mode & 0o100, "should not be executable")
+
 
 class BunTargetTest(unittest.TestCase):
     def test_bun_targets_have_expected_fields(self) -> None:
@@ -363,6 +383,10 @@ class BuildManifestTest(unittest.TestCase):
         self.assertEqual(
             manifest["platforms"]["windows-x64"],
             {"platform": "win32-x64", "binary": "claude.exe"},
+        )
+        self.assertIsNot(
+            manifest["binary_shas_upstream"],
+            manifest["r2_object_shas"],
         )
         self.assertIn("uploaded_at", manifest)
         self.assertIn("uploaded_by", manifest)
@@ -887,6 +911,20 @@ class ExtractCodexFileTest(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "Codex entrypoint .* not found"):
                 storage._extract_codex_file(package_path, tmp_path / "codex")
 
+    def test_windows_entrypoint_is_not_marked_executable(self) -> None:
+        payload = b"codex-windows-exe-" + b"c" * 100
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            package_path = tmp_path / "codex.tar.gz"
+            package_path.write_bytes(_build_codex_package("bin/codex.exe", payload))
+            dest = tmp_path / "codex.exe"
+
+            storage._extract_codex_file(package_path, dest)
+
+            self.assertEqual(dest.read_bytes(), payload)
+            self.assertFalse(dest.stat().st_mode & 0o100, "should not be executable")
+
 
 class ProcessCodexPlatformTest(unittest.TestCase):
     def setUp(self) -> None:
@@ -925,7 +963,6 @@ class ProcessCodexPlatformTest(unittest.TestCase):
                     platform=storage.CodexPlatform(
                         target="darwin-arm64",
                         upstream="aarch64-apple-darwin",
-                        entrypoint="bin/codex",
                     ),
                     tmp_dir=tmp_path,
                     checksums={
@@ -977,7 +1014,6 @@ class ProcessCodexPlatformTest(unittest.TestCase):
                         platform=storage.CodexPlatform(
                             target="darwin-arm64",
                             upstream="aarch64-apple-darwin",
-                            entrypoint="bin/codex",
                         ),
                         tmp_dir=tmp_path,
                         checksums={
@@ -1012,7 +1048,6 @@ class ProcessCodexPlatformTest(unittest.TestCase):
                     platform=storage.CodexPlatform(
                         target="windows-x64",
                         upstream="x86_64-pc-windows-msvc",
-                        entrypoint="bin/codex.exe",
                     ),
                     tmp_dir=tmp_path,
                     checksums={

--- a/packages/browseros/build/cli/storage_test.py
+++ b/packages/browseros/build/cli/storage_test.py
@@ -368,6 +368,37 @@ class BuildManifestTest(unittest.TestCase):
         self.assertIn("uploaded_by", manifest)
 
 
+class PackagedAgentCliContractTest(unittest.TestCase):
+    def test_server_resource_keys_match_storage_upload_keys(self) -> None:
+        manifest_path = (
+            Path(__file__).resolve().parents[3]
+            / "browseros-agent"
+            / "scripts"
+            / "build"
+            / "config"
+            / "server-prod-resources.json"
+        )
+        manifest = json.loads(manifest_path.read_text())
+        actual_keys = {
+            f"artifacts/vendor/{resource['source']['key']}"
+            for resource in manifest["resources"]
+            if resource["source"]["type"] == "r2"
+            and (
+                resource["source"]["key"].startswith("third_party/codex/")
+                or resource["source"]["key"].startswith("third_party/claude-code/")
+            )
+        }
+        expected_keys = {
+            f"{storage.CODEX_R2_PREFIX}/{storage._platform_binary_object_name('codex', platform.target)}"
+            for platform in storage.CODEX_PLATFORMS
+        } | {
+            f"{storage.CLAUDE_CODE_R2_PREFIX}/{storage._platform_binary_object_name('claude', platform.target)}"
+            for platform in storage.CLAUDE_CODE_PLATFORMS
+        }
+
+        self.assertEqual(actual_keys, expected_keys)
+
+
 class ProcessArchTest(unittest.TestCase):
     """Covers download + sha verify + extract + upload in one pass."""
 

--- a/packages/browseros/build/common/server_binaries.py
+++ b/packages/browseros/build/common/server_binaries.py
@@ -29,6 +29,8 @@ MACOS_SERVER_BINARIES: Dict[str, SignSpec] = {
         "browseros_server", "runtime", "browseros-executable-entitlements.plist"
     ),
     "bun": SignSpec("bun", "runtime", "browseros-executable-entitlements.plist"),
+    "codex": SignSpec("codex", "runtime"),
+    "claude": SignSpec("claude", "runtime"),
     "rg": SignSpec("rg", "runtime"),
     "limactl": SignSpec("limactl", "runtime", "lima-vz-entitlements.plist"),
 }
@@ -36,6 +38,8 @@ MACOS_SERVER_BINARIES: Dict[str, SignSpec] = {
 
 WINDOWS_SERVER_BINARIES: List[str] = [
     "browseros_server.exe",
+    "third_party/codex.exe",
+    "third_party/claude.exe",
 ]
 
 

--- a/packages/browseros/build/common/server_binaries_test.py
+++ b/packages/browseros/build/common/server_binaries_test.py
@@ -41,8 +41,18 @@ class MacosServerBinariesTest(unittest.TestCase):
 
         entitlements_name = spec.entitlements
         assert entitlements_name is not None
-        entitlements = plistlib.loads((ENTITLEMENTS_DIR / entitlements_name).read_bytes())
+        entitlements = plistlib.loads(
+            (ENTITLEMENTS_DIR / entitlements_name).read_bytes()
+        )
         self.assertIs(entitlements.get("com.apple.security.virtualization"), True)
+
+    def test_agent_cli_entries_use_plain_hardened_runtime(self):
+        for binary in ["codex", "claude"]:
+            spec = macos_sign_spec_for(Path(f"/x/{binary}"))
+            assert spec is not None
+            self.assertEqual(spec.identifier_suffix, binary)
+            self.assertEqual(spec.options, "runtime")
+            self.assertIsNone(spec.entitlements)
 
     def test_matches_lima_bundle_layout(self):
         keys = set(MACOS_SERVER_BINARIES.keys())
@@ -64,6 +74,10 @@ class WindowsServerBinariesTest(unittest.TestCase):
                 rel == "browseros_server.exe" or rel.startswith("third_party/"),
                 f"{rel} outside expected layout",
             )
+
+    def test_windows_includes_agent_cli_entries(self):
+        self.assertIn("third_party/codex.exe", WINDOWS_SERVER_BINARIES)
+        self.assertIn("third_party/claude.exe", WINDOWS_SERVER_BINARIES)
 
     def test_expected_windows_binary_paths_joins_root(self):
         root = Path("/tmp/fake/resources/bin")


### PR DESCRIPTION
## Summary
- add R2 upload commands for Codex rust-v0.136.0 and Claude Code 2.1.159 across macOS, Linux, and Windows targets
- stage packaged Codex/Claude binaries into server resources and register them for macOS/Windows signing
- prefer packaged native CLIs for health probes and ACP adapter subprocesses while preserving existing bundled Bun support
- add cross-contract coverage so storage uploader keys match the production server resource manifest

## Verification
- cd packages/browseros && python -m unittest build.cli.storage_test build.common.server_binaries_test
- cd packages/browseros-agent && bun test scripts/build/server/stage.test.ts apps/server/tests/lib/agents/bundled-bun.test.ts apps/server/tests/lib/agents/bundled-native-binary.test.ts apps/server/tests/lib/agents/adapter-detection.test.ts apps/server/tests/lib/agents/acpx-runtime.test.ts
- cd packages/browseros-agent && bun run typecheck
- cd packages/browseros-agent && bunx biome check apps/server/src/lib/agents/host-acp/bundled-bun.ts apps/server/tests/lib/agents/bundled-bun.test.ts scripts/build/config/server-prod-resources.json scripts/build/server/stage.test.ts apps/server/src/lib/agents/host-acp/bundled-native-binary.ts apps/server/src/lib/agents/host-acp/detection.ts apps/server/src/lib/agents/acpx/runtime.ts apps/server/tests/lib/agents/bundled-native-binary.test.ts apps/server/tests/lib/agents/adapter-detection.test.ts apps/server/tests/lib/agents/acpx-runtime.test.ts
- cd packages/browseros && python -m black --check build/cli/storage.py build/cli/storage_test.py build/common/server_binaries.py build/common/server_binaries_test.py