### PR TITLE
fix: gate Hermes behind alpha capability

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandHome.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/agent-command/AgentCommandHome.tsx
@@ -20,7 +20,9 @@ import {
   resolveSidepanelChatTarget,
 } from '@/entrypoints/sidepanel/index/sidepanel-chat-targets'
 import { toProviderOption } from '@/entrypoints/sidepanel/index/useChatSessionRequest'
-import { isAdapterHidden } from '@/lib/chat/adapter-visibility'
+import { Feature } from '@/lib/browseros/capabilities'
+import { useCapabilities } from '@/lib/browseros/useCapabilities'
+import { visibleHarnessAgents } from '@/lib/chat/adapter-visibility'
 import { useLlmProviders } from '@/lib/llm-providers/useLlmProviders'
 import { AgentCardDock } from './AgentCardDock'
 import {
@@ -85,6 +87,8 @@ export const AgentCommandHome: FC = () => {
   } = useLlmProviders()
   const { harnessAgents } = useHarnessAgents()
   const { adapters } = useAgentAdapters()
+  const { supports } = useCapabilities()
+  const hermesAgentSupported = supports(Feature.HERMES_AGENT_SUPPORT)
   const [selectedProvider, setSelectedProvider] = useState<Provider | null>(
     null,
   )
@@ -95,8 +99,9 @@ export const AgentCommandHome: FC = () => {
         providers: llmProviders,
         adapters,
         agents: harnessAgents,
+        hermesAgentSupported,
       }),
-    [llmProviders, adapters, harnessAgents],
+    [llmProviders, adapters, harnessAgents, hermesAgentSupported],
   )
   const providerOptions = useMemo(
     () => targets.map(toProviderOption),
@@ -129,11 +134,12 @@ export const AgentCommandHome: FC = () => {
   // has agents under (the most recent visible one), not a hardcoded adapter —
   // otherwise a Codex-only user would land on an empty Claude pane.
   const manageAgentsPath = useMemo(() => {
-    const adapter = orderedAgents.find(
-      (agent) => !isAdapterHidden(agent.adapter),
-    )?.adapter
+    const adapter = visibleHarnessAgents(
+      orderedAgents,
+      hermesAgentSupported,
+    ).at(0)?.adapter
     return adapter ? `/settings/ai?section=${adapter}` : '/settings/ai'
-  }, [orderedAgents])
+  }, [orderedAgents, hermesAgentSupported])
 
   const handleSend = async (input: ConversationInputSendInput) => {
     if (!selectedProvider) return

--- a/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/AISettingsPage.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/app/ai-settings/AISettingsPage.tsx
@@ -2,6 +2,8 @@ import type { FC, ReactNode } from 'react'
 import { useSearchParams } from 'react-router'
 import { AdapterIcon, adapterLabel } from '@/entrypoints/app/agents/AdapterIcon'
 import { useAgentAdapters } from '@/entrypoints/app/agents/useAgents'
+import { Feature } from '@/lib/browseros/capabilities'
+import { useCapabilities } from '@/lib/browseros/useCapabilities'
 import { visibleAdapters } from '@/lib/chat/adapter-visibility'
 import { BrowserOSIcon } from '@/lib/llm-providers/providerIcons'
 import { cn } from '@/lib/utils'
@@ -26,9 +28,11 @@ interface SectionItem {
  */
 export const AISettingsPage: FC = () => {
   const [searchParams, setSearchParams] = useSearchParams()
+  const { supports } = useCapabilities()
   const { adapters } = useAgentAdapters()
+  const hermesAgentSupported = supports(Feature.HERMES_AGENT_SUPPORT)
 
-  const shownAdapters = visibleAdapters(adapters)
+  const shownAdapters = visibleAdapters(adapters, hermesAgentSupported)
   const activeSection = resolveAiSettingsSection(
     searchParams.get('section'),
     shownAdapters.map((adapter) => adapter.id),

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/sidepanel-chat-targets.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/sidepanel-chat-targets.ts
@@ -6,7 +6,7 @@ import type {
 import type { LlmProviderConfig, ProviderType } from '@/lib/llm-providers/types'
 // Relative (not `@/`) so this module stays loadable under `bun test`, which
 // resolves tsconfig `@/` aliases for erased type imports only, not values.
-import { isAdapterHidden } from '../../../lib/chat/adapter-visibility'
+import { visibleHarnessAgents } from '../../../lib/chat/adapter-visibility'
 
 export type SidepanelTargetKind = 'llm' | 'acp'
 
@@ -43,6 +43,7 @@ interface BuildSidepanelChatTargetsInput {
   providers: LlmProviderConfig[]
   adapters: HarnessAdapterDescriptor[]
   agents?: HarnessAgent[]
+  hermesAgentSupported?: boolean
 }
 
 interface ResolveSidepanelChatTargetInput {
@@ -70,12 +71,13 @@ export function buildSidepanelChatTargets({
   providers,
   adapters,
   agents = [],
+  hermesAgentSupported = false,
 }: BuildSidepanelChatTargetsInput): SidepanelChatTarget[] {
   return [
     ...providers.map(toLlmTarget),
-    ...agents
-      .filter((agent) => !isAdapterHidden(agent.adapter))
-      .map((agent) => toAcpTargetForAgent(agent, adapters)),
+    ...visibleHarnessAgents(agents, hermesAgentSupported).map((agent) =>
+      toAcpTargetForAgent(agent, adapters),
+    ),
   ]
 }
 

--- a/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatRefs.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/sidepanel/index/useChatRefs.ts
@@ -4,6 +4,8 @@ import {
   useAgentAdapters,
   useHarnessAgents,
 } from '@/entrypoints/app/agents/useAgents'
+import { Feature } from '@/lib/browseros/capabilities'
+import { useCapabilities } from '@/lib/browseros/useCapabilities'
 import type { LlmProviderConfig } from '@/lib/llm-providers/types'
 import { useLlmProviders } from '@/lib/llm-providers/useLlmProviders'
 import { type McpServer, useMcpServers } from '@/lib/mcp/mcpServerStorage'
@@ -42,6 +44,8 @@ export const useChatRefs = () => {
   } = useLlmProviders()
   const { adapters, loading: isLoadingAdapters } = useAgentAdapters()
   const { harnessAgents, loading: isLoadingAgents } = useHarnessAgents()
+  const { supports } = useCapabilities()
+  const hermesAgentSupported = supports(Feature.HERMES_AGENT_SUPPORT)
   const { personalization } = usePersonalization()
   const [targetSelection, setTargetSelection] =
     useState<SidepanelChatTargetSelection | null>(null)
@@ -62,8 +66,9 @@ export const useChatRefs = () => {
         providers: llmProviders,
         adapters,
         agents: harnessAgents,
+        hermesAgentSupported,
       }),
-    [llmProviders, adapters, harnessAgents],
+    [llmProviders, adapters, harnessAgents, hermesAgentSupported],
   )
 
   const selectedChatTarget = useMemo(

--- a/packages/browseros-agent/apps/agent/lib/browseros/capabilities.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/capabilities.test.ts
@@ -63,3 +63,14 @@ describe('checkFeatureSupport — AGENT_HARNESS_SUPPORT', () => {
     expect(at([0, 47, 0, 0])).toBe(true)
   })
 })
+
+describe('checkFeatureSupport — HERMES_AGENT_SUPPORT', () => {
+  it('has no version dependency once the static alpha gate allows it', () => {
+    expect(
+      checkFeatureSupport(
+        { browserOSVersion: null, serverVersion: null },
+        Feature.HERMES_AGENT_SUPPORT,
+      ),
+    ).toBe(true)
+  })
+})

--- a/packages/browseros-agent/apps/agent/lib/browseros/capabilities.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/capabilities.ts
@@ -50,6 +50,8 @@ export enum Feature {
   CREDITS_SUPPORT = 'CREDITS_SUPPORT',
   // Claude Code / Codex agent-harness adapters in the unified picker + settings
   AGENT_HARNESS_SUPPORT = 'AGENT_HARNESS_SUPPORT',
+  // VM-backed Hermes agent adapter
+  HERMES_AGENT_SUPPORT = 'HERMES_AGENT_SUPPORT',
 }
 
 /**
@@ -79,6 +81,7 @@ const FEATURE_CONFIG: { [K in Feature]: FeatureConfig } = {
   [Feature.QWEN_CODE_SUPPORT]: { minServerVersion: '0.0.77' },
   [Feature.CREDITS_SUPPORT]: { minServerVersion: '0.0.78' },
   [Feature.AGENT_HARNESS_SUPPORT]: { minBrowserOSVersion: '0.46.0.0' },
+  [Feature.HERMES_AGENT_SUPPORT]: { requiresAlphaFlag: true },
 }
 
 function parseVersion(version: string): number[] {

--- a/packages/browseros-agent/apps/agent/lib/chat/adapter-visibility.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/chat/adapter-visibility.test.ts
@@ -49,29 +49,44 @@ function makeProvider(id: string): LlmProviderConfig {
 }
 
 describe('isAdapterHidden', () => {
-  it('hides hermes', () => {
-    expect(isAdapterHidden('hermes')).toBe(true)
+  it('hides hermes when the alpha capability is disabled', () => {
+    expect(isAdapterHidden('hermes', false)).toBe(true)
   })
 
-  it('shows claude and codex', () => {
-    expect(isAdapterHidden('claude')).toBe(false)
-    expect(isAdapterHidden('codex')).toBe(false)
+  it('shows hermes when the alpha capability is enabled', () => {
+    expect(isAdapterHidden('hermes', true)).toBe(false)
+  })
+
+  it('shows claude and codex regardless of the Hermes capability', () => {
+    expect(isAdapterHidden('claude', false)).toBe(false)
+    expect(isAdapterHidden('codex', false)).toBe(false)
   })
 })
 
 describe('visibleAdapters', () => {
-  it('drops hermes descriptors and preserves the order of the rest', () => {
-    const result = visibleAdapters([
-      makeAdapter('claude'),
-      makeAdapter('hermes'),
-      makeAdapter('codex'),
-    ])
+  const adapters = [
+    makeAdapter('claude'),
+    makeAdapter('hermes'),
+    makeAdapter('codex'),
+  ]
+
+  it('drops hermes descriptors when the alpha capability is disabled', () => {
+    const result = visibleAdapters(adapters, false)
     expect(result.map((adapter) => adapter.id)).toEqual(['claude', 'codex'])
+  })
+
+  it('keeps hermes descriptors when the alpha capability is enabled', () => {
+    const result = visibleAdapters(adapters, true)
+    expect(result.map((adapter) => adapter.id)).toEqual([
+      'claude',
+      'hermes',
+      'codex',
+    ])
   })
 })
 
 describe('buildSidepanelChatTargets adapter visibility', () => {
-  it('omits acp targets for hermes-backed agents but keeps claude/codex', () => {
+  it('omits acp targets for hermes-backed agents when alpha is disabled', () => {
     const targets = buildSidepanelChatTargets({
       providers: [],
       adapters: [
@@ -84,12 +99,35 @@ describe('buildSidepanelChatTargets adapter visibility', () => {
         makeAgent('b', 'hermes'),
         makeAgent('c', 'codex'),
       ],
+      hermesAgentSupported: false,
     })
     expect(
       targets
         .filter((target) => target.kind === 'acp')
         .map((target) => target.id),
     ).toEqual(['a', 'c'])
+  })
+
+  it('keeps acp targets for hermes-backed agents when alpha is enabled', () => {
+    const targets = buildSidepanelChatTargets({
+      providers: [],
+      adapters: [
+        makeAdapter('claude'),
+        makeAdapter('codex'),
+        makeAdapter('hermes'),
+      ],
+      agents: [
+        makeAgent('a', 'claude'),
+        makeAgent('b', 'hermes'),
+        makeAgent('c', 'codex'),
+      ],
+      hermesAgentSupported: true,
+    })
+    expect(
+      targets
+        .filter((target) => target.kind === 'acp')
+        .map((target) => target.id),
+    ).toEqual(['a', 'b', 'c'])
   })
 
   it('keeps one llm target per provider', () => {

--- a/packages/browseros-agent/apps/agent/lib/chat/adapter-visibility.ts
+++ b/packages/browseros-agent/apps/agent/lib/chat/adapter-visibility.ts
@@ -4,20 +4,29 @@ import type {
 } from '@/entrypoints/app/agents/agent-harness-types'
 
 /**
- * Single source of truth for which harness adapters are exposed in the UI.
- * Hermes is hidden today (kept in the backend/types). Re-enabling it later
- * is a one-line change here, and every picker / settings list / create
- * dialog inherits the result.
+ * UI visibility gate for VM-backed adapters. Hermes stays in backend
+ * catalog/types, but the product exposes it only through an alpha capability.
  */
-const HIDDEN_ADAPTERS: ReadonlySet<HarnessAgentAdapter> =
-  new Set<HarnessAgentAdapter>(['hermes'])
-
-export function isAdapterHidden(adapter: HarnessAgentAdapter): boolean {
-  return HIDDEN_ADAPTERS.has(adapter)
+export function isAdapterHidden(
+  adapter: HarnessAgentAdapter,
+  hermesAgentSupported: boolean,
+): boolean {
+  return adapter === 'hermes' && !hermesAgentSupported
 }
 
 export function visibleAdapters(
   adapters: HarnessAdapterDescriptor[],
+  hermesAgentSupported: boolean,
 ): HarnessAdapterDescriptor[] {
-  return adapters.filter((adapter) => !isAdapterHidden(adapter.id))
+  return adapters.filter(
+    (adapter) => !isAdapterHidden(adapter.id, hermesAgentSupported),
+  )
+}
+
+export function visibleHarnessAgents<
+  T extends { adapter: HarnessAgentAdapter },
+>(agents: T[], hermesAgentSupported: boolean): T[] {
+  return agents.filter(
+    (agent) => !isAdapterHidden(agent.adapter, hermesAgentSupported),
+  )
 }

--- a/packages/browseros-agent/apps/server/src/api/server.ts
+++ b/packages/browseros-agent/apps/server/src/api/server.ts
@@ -106,6 +106,7 @@ export async function createHttpServer(config: HttpServerConfig) {
         resourcesDir,
         browser,
         ensureVmRuntimeReady: async (adapter) => {
+          if (process.env.NODE_ENV === 'production') return
           switch (adapter) {
             case 'hermes':
               await ensureHermesRuntimeReady({ resourcesDir })

--- a/packages/browseros-agent/apps/server/tests/api/routes/agents.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/agents.test.ts
@@ -71,6 +71,11 @@ describe('createAgentRoutes', () => {
         }),
       }),
     )
+    expect(
+      body.adapters.map(
+        (adapter: { id: AgentDefinition['adapter'] }) => adapter.id,
+      ),
+    ).toContain('hermes')
   })
 
   it('creates and lists harness agents', async () => {

--- a/packages/browseros-agent/scripts/build/config/server-prod-resources.json
+++ b/packages/browseros-agent/scripts/build/config/server-prod-resources.json
@@ -1,48 +1,6 @@
 {
   "resources": [
     {
-      "name": "Lima limactl - macOS ARM64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/lima/limactl-darwin-arm64"
-      },
-      "destination": "resources/bin/third_party/lima/bin/limactl",
-      "os": ["macos"],
-      "arch": ["arm64"],
-      "executable": true
-    },
-    {
-      "name": "Lima guest agent - Linux ARM64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/lima/lima-guestagent.Linux-aarch64.gz"
-      },
-      "destination": "resources/bin/third_party/lima/share/lima/lima-guestagent.Linux-aarch64.gz",
-      "os": ["macos"],
-      "arch": ["arm64"]
-    },
-    {
-      "name": "Lima limactl - macOS x64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/lima/limactl-darwin-x64"
-      },
-      "destination": "resources/bin/third_party/lima/bin/limactl",
-      "os": ["macos"],
-      "arch": ["x64"],
-      "executable": true
-    },
-    {
-      "name": "Lima guest agent - Linux x64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/lima/lima-guestagent.Linux-x86_64.gz"
-      },
-      "destination": "resources/bin/third_party/lima/share/lima/lima-guestagent.Linux-x86_64.gz",
-      "os": ["macos"],
-      "arch": ["x64"]
-    },
-    {
       "name": "Bun - macOS ARM64",
       "source": {
         "type": "r2",
@@ -96,16 +54,6 @@
       "os": ["windows"],
       "arch": ["x64"],
       "executable": true
-    },
-    {
-      "name": "BrowserOS VM Lima template",
-      "source": {
-        "type": "local",
-        "path": "packages/build-tools/template/browseros-vm.yaml"
-      },
-      "destination": "resources/vm/browseros-vm.yaml",
-      "os": ["macos"],
-      "arch": ["arm64", "x64"]
     },
     {
       "name": "Drizzle migrations",

--- a/packages/browseros-agent/scripts/build/server/stage.test.ts
+++ b/packages/browseros-agent/scripts/build/server/stage.test.ts
@@ -184,6 +184,23 @@ describe('server artifact staging', () => {
       ).toBe(`${target.id}-bun`)
     })
   }
+
+  it('does not package VM-only resources in the production manifest', () => {
+    const manifest = loadManifest(
+      'scripts/build/config/server-prod-resources.json',
+    )
+    const destinations = manifest.resources.map((rule) => rule.destination)
+
+    expect(
+      destinations.filter(
+        (destination) =>
+          destination.includes('third_party/lima') ||
+          destination.startsWith('resources/vm/'),
+      ),
+    ).toEqual([])
+    expect(destinations).toContain('resources/bin/third_party/bun')
+    expect(destinations).toContain('resources/db/migrations')
+  })
 })
 
 const testTarget: BuildTarget = {


### PR DESCRIPTION
## Summary
- Remove Lima/VM resources from production server resource staging so prod artifacts do not ship `limactl`, Lima guest agents, or VM templates.
- Add `Feature.HERMES_AGENT_SUPPORT` as an alpha-gated capability and use it to hide/show Hermes in agent picker/settings surfaces.
- Keep Hermes backend catalog/runtime codepaths intact for alpha/dev; production VM readiness is a no-op so prod cannot try to start a non-shipped VM runtime.

## Rework
The first pass added server-side adapter availability filtering. This rework removes that extra availability layer and makes Hermes exposure a frontend capability decision, matching the existing alpha feature model.

## Test plan
- `bunx biome check <changed files>`
- `bun --env-file=apps/agent/.env.development test apps/agent/lib/browseros/capabilities.test.ts apps/agent/lib/chat/adapter-visibility.test.ts apps/agent/entrypoints/sidepanel/index/sidepanel-chat-targets.test.ts apps/agent/entrypoints/app/ai-settings/ai-settings-sections.test.ts`
- `bun --env-file=.env.development test apps/server/tests/api/routes/agents.test.ts scripts/build/server/stage.test.ts`
- `bun run typecheck`
- `bun run lint` exits 0 with existing repo-wide warnings
- `bun run build:server:ci`
- Verified generated `dist/prod/server/browseros-server-resources-*.zip` archives contain no `third_party/lima`, `resources/vm`, or `limactl` entries

Known local unrelated failure:
- `bun run --filter @browseros/server test:tools` -> 227 pass, 2 fail in `tests/tools/navigation.test.ts`:
  - `navigation tools > show_page errors on an already-visible page`
  - `navigation tools > move_page moves a tab to a different window`
