### PR TITLE
fix(server): hide browser-context scaffolding in the new-tab agent chat

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/agents/agent-harness-service.ts
@@ -4,7 +4,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { AcpxRuntime } from '../../../lib/agents/acpx/runtime'
+import {
+  AcpxRuntime,
+  unwrapBrowserosAcpUserMessage,
+} from '../../../lib/agents/acpx/runtime'
 import type { AgentDefinition } from '../../../lib/agents/agent-types'
 import {
   getHermesHarnessHostDir,
@@ -595,7 +598,14 @@ export class AgentHarnessService {
     sessionId: 'main' = 'main',
   ): ActiveTurnInfo | null {
     const turn = this.turnRegistry.getActiveFor(agentId, sessionId)
-    return turn ? this.turnRegistry.describe(turn.turnId) : null
+    if (!turn) return null
+    const info = this.turnRegistry.describe(turn.turnId)
+    if (!info?.prompt) return info
+    // Chat UIs that attach to an in-flight turn render this prompt as the
+    // user bubble (new-tab agent view). Strip the browser-context /
+    // <USER_QUERY> scaffolding so it shows only the user's question —
+    // same read-time unwrap getHistory applies.
+    return { ...info, prompt: unwrapBrowserosAcpUserMessage(info.prompt) }
   }
 
   /**

--- a/packages/browseros-agent/apps/server/tests/api/services/agents/agent-harness-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/agents/agent-harness-service.test.ts
@@ -14,6 +14,7 @@ import {
 } from '../../../../src/api/services/agents/agent-harness-service'
 import type { AgentDefinition } from '../../../../src/lib/agents/agent-types'
 import type { AgentStore } from '../../../../src/lib/agents/storage/agent-store'
+import { TurnRegistry } from '../../../../src/lib/agents/turns/active-turn-registry'
 import type {
   AgentRuntime,
   AgentStreamEvent,
@@ -455,7 +456,55 @@ describe('AgentHarnessService', () => {
       expect(agents).toHaveLength(0)
     })
   })
+
+  it('strips browser-context scaffolding from the active-turn prompt', () => {
+    const { registry, service } = serviceWithRegistry()
+    registry.register('agent-1', 'main', {
+      prompt: [
+        '## Browser Context',
+        '**Window ID:** 1995357486',
+        '**Active Tab:** Tab 1995357512 (Page ID: 3) - "BrowserOS" (chrome://newtab/)',
+        '',
+        '---',
+        '',
+        '<USER_QUERY>',
+        'Open amazon.com in current tab and add sensodyne toothpaste to cart',
+        '</USER_QUERY>',
+      ].join('\n'),
+    })
+
+    expect(service.getActiveTurn('agent-1')?.prompt).toBe(
+      'Open amazon.com in current tab and add sensodyne toothpaste to cart',
+    )
+  })
+
+  it('passes a null active-turn prompt through unchanged', () => {
+    const { registry, service } = serviceWithRegistry()
+    registry.register('agent-1', 'main', { prompt: null })
+
+    expect(service.getActiveTurn('agent-1')?.prompt).toBeNull()
+  })
+
+  it('leaves an already-clean active-turn prompt unchanged', () => {
+    const { registry, service } = serviceWithRegistry()
+    registry.register('agent-1', 'main', { prompt: 'plain question' })
+
+    expect(service.getActiveTurn('agent-1')?.prompt).toBe('plain question')
+  })
 })
+
+function serviceWithRegistry(): {
+  registry: TurnRegistry
+  service: AgentHarnessService
+} {
+  const registry = new TurnRegistry()
+  const service = new AgentHarnessService({
+    agentStore: createAgentStore([]) as AgentStore,
+    runtime: stubRuntime(),
+    turnRegistry: registry,
+  })
+  return { registry, service }
+}
 
 async function withHermesBrowserosDir<T>(
   run: (input: {


### PR DESCRIPTION
## Summary
- The new-tab **Agents** chat leaked the `## Browser Context … <USER_QUERY>…</USER_QUERY>` prompt scaffolding in the user-message bubble, while the side panel showed only the clean query (see before/after below).
- **Root cause:** the new-tab view renders the active turn's `prompt` (from `GET /chat/active`). For side-panel-initiated turns that stored prompt is the wrapped `formatUserMessage` output, and `getActiveTurn` returned it verbatim — the one read path that didn't strip.
- **Fix:** `getActiveTurn` now unwraps the prompt on read via the canonical `unwrapBrowserosAcpUserMessage`, the same read-time strip `getHistory` and `extractLastUserMessage` already apply.

## Design
Read-time normalization in `AgentHarnessService.getActiveTurn`, mirroring how `getHistory` de-scaffolds on read. The generic `TurnRegistry` keeps storing the faithful prompt (no layering violation), and the canonical unwrap helper is reused with zero duplicated logic. The change touches only the `/chat/active` read boundary — never the prompt sent to the LLM, and not the already-correct history/listing paths. A `null` prompt passes through unchanged, and the helper is idempotent so already-clean (new-tab-initiated) prompts are untouched.

## Test plan
- New unit tests in `agent-harness-service.test.ts`:
  - a wrapped `## Browser Context … <USER_QUERY>` prompt surfaces via `getActiveTurn` as the clean inner query;
  - a `null` prompt passes through;
  - an already-clean prompt is unchanged (idempotence).
- `bun test` across service + acpx-runtime + agents-route suites: **66/66 pass**.
- `bunx biome check` clean; `tsc --noEmit` exit 0.
- Manual: start a turn from the side panel, then open the same agent in the new-tab Agents page — the user bubble now shows only the typed query, matching the side panel.

## Out of scope
- Prompts prefixed with a non-empty `userSystemPrompt` (pre-existing limitation shared with `getHistory`; the `^## Browser Context` anchor won't match behind a prefix).
- Whether new-tab-initiated turns receive browser context (separate product concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
