### PR TITLE
feat: add dogfood branch tracking

### DIFF
--- a/packages/browseros-agent/tools/dogfood/README.md
+++ b/packages/browseros-agent/tools/dogfood/README.md
@@ -9,6 +9,7 @@ Internal BrowserOS dogfooding CLI for running the current checkout against a cop
 High level:
 
 - You point it at a BrowserOS repo clone used for alpha dogfooding.
+- It tracks a configured branch for that clone and switches to it before builds and update commands.
 - It imports your normal BrowserOS profile into a separate dev profile.
 - It keeps BrowserOS state under `~/.browseros-dogfood`, separate from your normal app state.
 - It builds the local extension, starts the local server, and launches the installed BrowserOS app with the alpha Dock icon against them.
@@ -50,6 +51,7 @@ browseros-dogfood init
 `init` asks for:
 
 - `Repo path`: the full path to the root BrowserOS git repo clone.
+- `Branch`: the branch dogfood should track. It defaults to the selected repo's current branch, or `main`.
 - `BrowserOS binary`: defaults to `/Applications/BrowserOS.app/Contents/MacOS/BrowserOS`.
 - `Source profile`: your main installed BrowserOS profile.
 
@@ -83,8 +85,9 @@ browseros-dogfood logs tail
 browseros-dogfood stop
 ```
 
-- `pull` updates the configured repo for the next sync start.
-- `restart --pull` updates the configured repo, rebuilds, and restarts when new changes land upstream.
+- `start` switches a clean checkout to the configured branch before building. It still does not pull.
+- `pull` switches to the configured branch and updates the configured repo for the next sync start.
+- `restart --pull` switches to the configured branch, updates the configured repo, rebuilds, and restarts when new changes land upstream.
 - `logs` prints log file paths; `logs tail` follows background dogfood, BrowserOS, and server logs.
 - `start` and `start-background` use the same lock, so only one dogfood environment runs at a time.
 
@@ -112,6 +115,6 @@ If BrowserOS appears to be using the source profile during import, the CLI asks 
 browseros-dogfood config edit
 ```
 
-Config lives at `~/.config/browseros-dogfood/config.yaml`. Most people should only need to edit it when changing the alpha repo clone, ports, or env values.
+Config lives at `~/.config/browseros-dogfood/config.yaml`. Most people should only need to edit it when changing the alpha repo clone, tracked branch, ports, or env values.
 
 Browser launch passes `--browseros-dock-icon=alpha` so dogfood sessions are visually distinct in the Dock.

--- a/packages/browseros-agent/tools/dogfood/cmd/daemon.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/daemon.go
@@ -380,14 +380,10 @@ func (d *dogfoodDaemon) scheduleRestart(pull bool, force bool) error {
 				return err
 			}
 			runner := pipeline.ExecRunner{}
-			if force {
-				if err := pipeline.Fetch(d.ctx, cfg.RepoPath, runner); err != nil {
-					return err
-				}
-				if err := pipeline.ResetHardToUpstream(d.ctx, cfg.RepoPath, runner); err != nil {
-					return err
-				}
-			} else if err := pipeline.Pull(d.ctx, cfg.RepoPath, runner); err != nil {
+			if err := updateConfiguredRepo(d.ctx, cfg, runner, repoUpdateOptions{
+				Force:           force,
+				ResetToUpstream: force,
+			}); err != nil {
 				return err
 			}
 		}

--- a/packages/browseros-agent/tools/dogfood/cmd/daemon.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/daemon.go
@@ -359,20 +359,6 @@ func (d *dogfoodDaemon) scheduleRestart(pull bool, force bool) error {
 	if force && !pull {
 		return fmt.Errorf("--force requires --pull")
 	}
-	if pull && !force {
-		cfg, err := loadConfig()
-		if err != nil {
-			return err
-		}
-		runner := pipeline.ExecRunner{}
-		dirty, err := pipeline.Dirty(cfg.RepoPath, runner)
-		if err != nil {
-			return err
-		}
-		if dirty {
-			return fmt.Errorf("checkout has uncommitted changes; commit or stash them, or use --force to reset to upstream")
-		}
-	}
 	return d.scheduleOperation("restarting", func() error {
 		if pull {
 			cfg, err := loadConfig()

--- a/packages/browseros-agent/tools/dogfood/cmd/init.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/init.go
@@ -37,6 +37,11 @@ var initCmd = &cobra.Command{
 		out := cmd.OutOrStdout()
 		printRepoPathHelp(out)
 		cfg.RepoPath = prompt(out, reader, "Repo path", cfg.RepoPath)
+		if branch := pipeline.Branch(cfg.RepoPath, pipeline.ExecRunner{}); branch != "" {
+			cfg.Branch = branch
+		}
+		printBranchHelp(out)
+		cfg.Branch = promptValue(out, reader, "Branch", cfg.Branch)
 		cfg.BrowserOSAppPath = prompt(out, reader, "BrowserOS binary", cfg.BrowserOSAppPath)
 		profiles, _ := profile.ReadProfiles(cfg.SourceUserDataDir)
 		if len(profiles) > 0 {
@@ -75,6 +80,10 @@ func printRepoPathHelp(out io.Writer) {
 	fmt.Fprintln(out, "Example: /Users/you/code/browseros-alpha, not packages/browseros-agent.")
 }
 
+func printBranchHelp(out io.Writer) {
+	fmt.Fprintln(out, "Branch is the BrowserOS branch dogfood should track during pull/restart --pull.")
+}
+
 func printSourceProfileHelp(out io.Writer) {
 	fmt.Fprintln(out, "Choose the installed BrowserOS profile you normally use.")
 	fmt.Fprintln(out, "  Dogfood copies it into a separate dev profile.")
@@ -89,6 +98,16 @@ func prompt(out io.Writer, r *bufio.Reader, label string, current string) string
 	}
 	home, _ := os.UserHomeDir()
 	return config.ExpandTilde(line, home)
+}
+
+func promptValue(out io.Writer, r *bufio.Reader, label string, current string) string {
+	fmt.Fprintf(out, "%s [%s]: ", labelStyle.Sprint(label), commandStyle.Sprint(current))
+	line, _ := r.ReadString('\n')
+	line = strings.TrimSpace(line)
+	if line == "" {
+		return current
+	}
+	return line
 }
 
 func chooseProfile(out io.Writer, r *bufio.Reader, profiles []profile.BrowserProfile) string {

--- a/packages/browseros-agent/tools/dogfood/cmd/pull.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/pull.go
@@ -31,18 +31,12 @@ var pullCmd = &cobra.Command{
 		branch := pipeline.Branch(cfg.RepoPath, runner)
 		head, _ := pipeline.Head(cfg.RepoPath, runner)
 		fmt.Printf("%s %s %s %s\n", labelStyle.Sprint("Repo:"), pathStyle.Sprint(cfg.RepoPath), commandStyle.Sprint(branch), dimStyle.Sprint(head))
-		dirty, err := pipeline.Dirty(cfg.RepoPath, runner)
-		if err != nil {
+		if err := updateConfiguredRepo(cmd.Context(), cfg, runner, repoUpdateOptions{Force: pullForce}); err != nil {
 			return err
 		}
-		if dirty && !pullForce {
-			return fmt.Errorf("checkout has uncommitted changes; commit/stash them or use --force")
-		}
-		if err := pipeline.Pull(cmd.Context(), cfg.RepoPath, runner); err != nil {
-			return err
-		}
+		newBranch := pipeline.Branch(cfg.RepoPath, runner)
 		newHead, _ := pipeline.Head(cfg.RepoPath, runner)
-		fmt.Printf("%s %s\n", successStyle.Sprint("Updated to"), commandStyle.Sprint(newHead))
+		fmt.Printf("%s %s %s\n", successStyle.Sprint("Updated to"), commandStyle.Sprint(newBranch), commandStyle.Sprint(newHead))
 		return nil
 	},
 }

--- a/packages/browseros-agent/tools/dogfood/cmd/pull_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/pull_test.go
@@ -1,0 +1,92 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"browseros-dogfood/config"
+)
+
+func TestUpdateConfiguredRepoSwitchesToConfiguredBranchBeforePull(t *testing.T) {
+	r := &recordingRunner{output: map[string]string{
+		"git status --porcelain":    "",
+		"git branch --show-current": "feature\n",
+	}}
+	cfg := config.Config{RepoPath: "/repo", Branch: "dogfood"}
+
+	if err := updateConfiguredRepo(context.Background(), cfg, r, repoUpdateOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"git status --porcelain",
+		"git fetch --prune",
+		"git branch --show-current",
+		"git switch dogfood",
+		"git pull --ff-only",
+	}
+	if got := strings.Join(r.commands, "\n"); got != strings.Join(want, "\n") {
+		t.Fatalf("commands got:\n%s\nwant:\n%s", got, strings.Join(want, "\n"))
+	}
+}
+
+func TestUpdateConfiguredRepoRejectsDirtyCheckoutBeforeSwitch(t *testing.T) {
+	r := &recordingRunner{output: map[string]string{
+		"git status --porcelain": " M file.go\n",
+	}}
+	cfg := config.Config{RepoPath: "/repo", Branch: "dogfood"}
+
+	err := updateConfiguredRepo(context.Background(), cfg, r, repoUpdateOptions{})
+
+	if err == nil || !strings.Contains(err.Error(), "checkout has uncommitted changes") {
+		t.Fatalf("error got %v", err)
+	}
+	if len(r.commands) != 1 || r.commands[0] != "git status --porcelain" {
+		t.Fatalf("commands got %#v", r.commands)
+	}
+}
+
+func TestUpdateConfiguredRepoFetchesSwitchesAndResetsWhenRequested(t *testing.T) {
+	r := &recordingRunner{output: map[string]string{
+		"git branch --show-current": "feature\n",
+	}}
+	cfg := config.Config{RepoPath: "/repo", Branch: "dogfood"}
+
+	if err := updateConfiguredRepo(context.Background(), cfg, r, repoUpdateOptions{Force: true, ResetToUpstream: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{
+		"git fetch --prune",
+		"git branch --show-current",
+		"git switch dogfood",
+		"git reset --hard @{upstream}",
+	}
+	if got := strings.Join(r.commands, "\n"); got != strings.Join(want, "\n") {
+		t.Fatalf("commands got:\n%s\nwant:\n%s", got, strings.Join(want, "\n"))
+	}
+}
+
+type recordingRunner struct {
+	commands []string
+	output   map[string]string
+	err      error
+}
+
+func (r *recordingRunner) Run(ctx context.Context, dir string, args ...string) error {
+	r.commands = append(r.commands, strings.Join(args, " "))
+	return r.err
+}
+
+func (r *recordingRunner) OutputRun(dir string, args ...string) (string, error) {
+	r.commands = append(r.commands, strings.Join(args, " "))
+	if r.err != nil {
+		return "", r.err
+	}
+	if r.output == nil {
+		return "", errors.New("missing output")
+	}
+	return r.output[strings.Join(args, " ")], nil
+}

--- a/packages/browseros-agent/tools/dogfood/cmd/pull_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/pull_test.go
@@ -61,7 +61,7 @@ func TestUpdateConfiguredRepoFetchesSwitchesAndResetsWhenRequested(t *testing.T)
 	want := []string{
 		"git fetch --prune",
 		"git branch --show-current",
-		"git switch dogfood",
+		"git switch --force dogfood",
 		"git reset --hard @{upstream}",
 	}
 	if got := strings.Join(r.commands, "\n"); got != strings.Join(want, "\n") {
@@ -70,23 +70,29 @@ func TestUpdateConfiguredRepoFetchesSwitchesAndResetsWhenRequested(t *testing.T)
 }
 
 type recordingRunner struct {
-	commands []string
-	output   map[string]string
-	err      error
+	commands      []string
+	output        map[string]string
+	err           error
+	commandErrors map[string]error
 }
 
 func (r *recordingRunner) Run(ctx context.Context, dir string, args ...string) error {
-	r.commands = append(r.commands, strings.Join(args, " "))
+	cmd := strings.Join(args, " ")
+	r.commands = append(r.commands, cmd)
+	if err := r.commandErrors[cmd]; err != nil {
+		return err
+	}
 	return r.err
 }
 
 func (r *recordingRunner) OutputRun(dir string, args ...string) (string, error) {
-	r.commands = append(r.commands, strings.Join(args, " "))
+	cmd := strings.Join(args, " ")
+	r.commands = append(r.commands, cmd)
 	if r.err != nil {
 		return "", r.err
 	}
 	if r.output == nil {
 		return "", errors.New("missing output")
 	}
-	return r.output[strings.Join(args, " ")], nil
+	return r.output[cmd], nil
 }

--- a/packages/browseros-agent/tools/dogfood/cmd/repo_update.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/repo_update.go
@@ -1,0 +1,40 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+
+	"browseros-dogfood/config"
+	"browseros-dogfood/pipeline"
+)
+
+type repoUpdateOptions struct {
+	Force           bool
+	ResetToUpstream bool
+}
+
+// updateConfiguredRepo refreshes the dogfood checkout and first moves it to the configured branch.
+func updateConfiguredRepo(ctx context.Context, cfg config.Config, runner pipeline.Runner, opts repoUpdateOptions) error {
+	if runner == nil {
+		runner = pipeline.ExecRunner{}
+	}
+	if !opts.Force {
+		dirty, err := pipeline.Dirty(cfg.RepoPath, runner)
+		if err != nil {
+			return err
+		}
+		if dirty {
+			return fmt.Errorf("checkout has uncommitted changes; commit/stash them or use --force")
+		}
+	}
+	if err := pipeline.Fetch(ctx, cfg.RepoPath, runner); err != nil {
+		return err
+	}
+	if err := pipeline.EnsureBranch(ctx, cfg.RepoPath, cfg.Branch, runner); err != nil {
+		return err
+	}
+	if opts.ResetToUpstream {
+		return pipeline.ResetHardToUpstream(ctx, cfg.RepoPath, runner)
+	}
+	return pipeline.Pull(ctx, cfg.RepoPath, runner)
+}

--- a/packages/browseros-agent/tools/dogfood/cmd/repo_update.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/repo_update.go
@@ -30,7 +30,7 @@ func updateConfiguredRepo(ctx context.Context, cfg config.Config, runner pipelin
 	if err := pipeline.Fetch(ctx, cfg.RepoPath, runner); err != nil {
 		return err
 	}
-	if err := pipeline.EnsureBranch(ctx, cfg.RepoPath, cfg.Branch, runner); err != nil {
+	if err := pipeline.EnsureBranch(ctx, cfg.RepoPath, cfg.Branch, runner, opts.Force); err != nil {
 		return err
 	}
 	if opts.ResetToUpstream {

--- a/packages/browseros-agent/tools/dogfood/cmd/start.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/start.go
@@ -163,7 +163,9 @@ func buildAndStartEnvironment(ctx context.Context, cfg config.Config, opts envir
 	}
 	agentRoot := cfg.AgentRoot()
 	reportProgress(opts, "checking repo")
-	if dirty, err := pipeline.Dirty(cfg.RepoPath, opts.Runner); err == nil && dirty {
+	if dirty, err := prepareStartCheckout(ctx, cfg, opts.Runner); err != nil {
+		return nil, err
+	} else if dirty {
 		fmt.Fprintln(os.Stderr, warnStyle.Sprint("warning: checkout has uncommitted changes; start will use current files"))
 	}
 	reportProgress(opts, "preparing profile")
@@ -175,6 +177,22 @@ func buildAndStartEnvironment(ctx context.Context, cfg config.Config, opts envir
 		return nil, err
 	}
 	return startEnvironment(ctx, cfg, agentRoot, opts)
+}
+
+// prepareStartCheckout ensures start builds the configured branch without discarding local edits.
+func prepareStartCheckout(ctx context.Context, cfg config.Config, runner pipeline.Runner) (bool, error) {
+	dirty, err := pipeline.Dirty(cfg.RepoPath, runner)
+	if err != nil {
+		return false, err
+	}
+	if !dirty {
+		return false, pipeline.EnsureBranch(ctx, cfg.RepoPath, cfg.Branch, runner)
+	}
+	current := pipeline.Branch(cfg.RepoPath, runner)
+	if current != cfg.Branch {
+		return true, fmt.Errorf("checkout has uncommitted changes on %s; cannot switch to configured branch %s", current, cfg.Branch)
+	}
+	return true, nil
 }
 
 func prepareEnvironment(cfg *config.Config, agentRoot string, opts environmentOptions) error {

--- a/packages/browseros-agent/tools/dogfood/cmd/start.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/start.go
@@ -186,7 +186,10 @@ func prepareStartCheckout(ctx context.Context, cfg config.Config, runner pipelin
 		return false, err
 	}
 	if !dirty {
-		return false, pipeline.EnsureBranch(ctx, cfg.RepoPath, cfg.Branch, runner)
+		if err := pipeline.EnsureBranch(ctx, cfg.RepoPath, cfg.Branch, runner, false); err != nil {
+			return false, fmt.Errorf("switch to configured branch %s failed; run `browseros-dogfood pull` first if the branch is not available locally: %w", cfg.Branch, err)
+		}
+		return false, nil
 	}
 	current := pipeline.Branch(cfg.RepoPath, runner)
 	if current != cfg.Branch {

--- a/packages/browseros-agent/tools/dogfood/cmd/start_branch_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/start_branch_test.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"browseros-dogfood/config"
+)
+
+func TestPrepareStartCheckoutSwitchesCleanCheckoutToConfiguredBranch(t *testing.T) {
+	r := &recordingRunner{output: map[string]string{
+		"git status --porcelain":    "",
+		"git branch --show-current": "feature\n",
+	}}
+	cfg := config.Config{RepoPath: "/repo", Branch: "dogfood"}
+
+	dirty, err := prepareStartCheckout(context.Background(), cfg, r)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dirty {
+		t.Fatal("clean checkout reported dirty")
+	}
+	want := []string{
+		"git status --porcelain",
+		"git branch --show-current",
+		"git switch dogfood",
+	}
+	if got := strings.Join(r.commands, "\n"); got != strings.Join(want, "\n") {
+		t.Fatalf("commands got:\n%s\nwant:\n%s", got, strings.Join(want, "\n"))
+	}
+}
+
+func TestPrepareStartCheckoutAllowsDirtyCheckoutOnConfiguredBranch(t *testing.T) {
+	r := &recordingRunner{output: map[string]string{
+		"git status --porcelain":    " M file.go\n",
+		"git branch --show-current": "dogfood\n",
+	}}
+	cfg := config.Config{RepoPath: "/repo", Branch: "dogfood"}
+
+	dirty, err := prepareStartCheckout(context.Background(), cfg, r)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !dirty {
+		t.Fatal("dirty checkout reported clean")
+	}
+	want := []string{"git status --porcelain", "git branch --show-current"}
+	if got := strings.Join(r.commands, "\n"); got != strings.Join(want, "\n") {
+		t.Fatalf("commands got:\n%s\nwant:\n%s", got, strings.Join(want, "\n"))
+	}
+}
+
+func TestPrepareStartCheckoutRejectsDirtyCheckoutOnDifferentBranch(t *testing.T) {
+	r := &recordingRunner{output: map[string]string{
+		"git status --porcelain":    " M file.go\n",
+		"git branch --show-current": "feature\n",
+	}}
+	cfg := config.Config{RepoPath: "/repo", Branch: "dogfood"}
+
+	_, err := prepareStartCheckout(context.Background(), cfg, r)
+
+	if err == nil || !strings.Contains(err.Error(), "cannot switch to configured branch dogfood") {
+		t.Fatalf("error got %v", err)
+	}
+}

--- a/packages/browseros-agent/tools/dogfood/cmd/start_branch_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/start_branch_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -54,6 +55,27 @@ func TestPrepareStartCheckoutAllowsDirtyCheckoutOnConfiguredBranch(t *testing.T)
 	}
 }
 
+func TestPrepareStartCheckoutSkipsSwitchWhenCleanCheckoutAlreadyOnConfiguredBranch(t *testing.T) {
+	r := &recordingRunner{output: map[string]string{
+		"git status --porcelain":    "",
+		"git branch --show-current": "dogfood\n",
+	}}
+	cfg := config.Config{RepoPath: "/repo", Branch: "dogfood"}
+
+	dirty, err := prepareStartCheckout(context.Background(), cfg, r)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dirty {
+		t.Fatal("clean checkout reported dirty")
+	}
+	want := []string{"git status --porcelain", "git branch --show-current"}
+	if got := strings.Join(r.commands, "\n"); got != strings.Join(want, "\n") {
+		t.Fatalf("commands got:\n%s\nwant:\n%s", got, strings.Join(want, "\n"))
+	}
+}
+
 func TestPrepareStartCheckoutRejectsDirtyCheckoutOnDifferentBranch(t *testing.T) {
 	r := &recordingRunner{output: map[string]string{
 		"git status --porcelain":    " M file.go\n",
@@ -64,6 +86,25 @@ func TestPrepareStartCheckoutRejectsDirtyCheckoutOnDifferentBranch(t *testing.T)
 	_, err := prepareStartCheckout(context.Background(), cfg, r)
 
 	if err == nil || !strings.Contains(err.Error(), "cannot switch to configured branch dogfood") {
+		t.Fatalf("error got %v", err)
+	}
+}
+
+func TestPrepareStartCheckoutWrapsCleanSwitchFailure(t *testing.T) {
+	r := &recordingRunner{
+		output: map[string]string{
+			"git status --porcelain":    "",
+			"git branch --show-current": "feature\n",
+		},
+		commandErrors: map[string]error{
+			"git switch dogfood": errors.New("fatal: invalid reference: dogfood"),
+		},
+	}
+	cfg := config.Config{RepoPath: "/repo", Branch: "dogfood"}
+
+	_, err := prepareStartCheckout(context.Background(), cfg, r)
+
+	if err == nil || !strings.Contains(err.Error(), "run `browseros-dogfood pull` first") {
 		t.Fatalf("error got %v", err)
 	}
 }

--- a/packages/browseros-agent/tools/dogfood/config/config.go
+++ b/packages/browseros-agent/tools/dogfood/config/config.go
@@ -31,6 +31,7 @@ type Config struct {
 	DevUserDataDir    string        `yaml:"dev_user_data_dir"`
 	DevProfileDir     string        `yaml:"dev_profile_dir"`
 	BrowserOSDir      string        `yaml:"browseros_dir"`
+	Branch            string        `yaml:"branch"`
 	Ports             Ports         `yaml:"ports"`
 	ProductionEnv     ProductionEnv `yaml:"production_env"`
 }
@@ -40,6 +41,7 @@ type packageJSON struct {
 }
 
 const LogDirName = "logs"
+const DefaultBranch = "main"
 
 func Path() (string, error) {
 	home, err := os.UserHomeDir()
@@ -64,6 +66,7 @@ func Defaults(home string) Config {
 		DevUserDataDir:    filepath.Join(DefaultConfigDir(home), "profile"),
 		DevProfileDir:     "Default",
 		BrowserOSDir:      filepath.Join(home, ".browseros-dogfood"),
+		Branch:            DefaultBranch,
 		Ports:             Ports{CDP: 9015, Server: 9115, Extension: 9315},
 		ProductionEnv:     DefaultProductionEnv(),
 	}
@@ -105,6 +108,10 @@ func (c *Config) Resolve() {
 	c.DevUserDataDir = ExpandTilde(c.DevUserDataDir, home)
 	c.BrowserOSDir = ExpandTilde(c.BrowserOSDir, home)
 	c.BrowserOSAppPath = ExpandTilde(c.BrowserOSAppPath, home)
+	c.Branch = strings.TrimSpace(c.Branch)
+	if c.Branch == "" {
+		c.Branch = DefaultBranch
+	}
 	if c.DevProfileDir == "" {
 		c.DevProfileDir = "Default"
 	}

--- a/packages/browseros-agent/tools/dogfood/config/config_test.go
+++ b/packages/browseros-agent/tools/dogfood/config/config_test.go
@@ -23,6 +23,9 @@ func TestDefaults(t *testing.T) {
 	if cfg.BrowserOSDir != filepath.Join(home, ".browseros-dogfood") {
 		t.Fatalf("unexpected BrowserOS dir: %s", cfg.BrowserOSDir)
 	}
+	if cfg.Branch != "main" {
+		t.Fatalf("unexpected branch: %s", cfg.Branch)
+	}
 	if cfg.LogDir() != filepath.Join(home, ".config/browseros-dogfood/profile/logs") {
 		t.Fatalf("unexpected log dir: %s", cfg.LogDir())
 	}
@@ -66,6 +69,7 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 		DevUserDataDir:    "/dev",
 		DevProfileDir:     "Default",
 		BrowserOSDir:      "/browseros-dogfood",
+		Branch:            "dogfood",
 		Ports:             Ports{CDP: 9015, Server: 9115, Extension: 9315},
 		ProductionEnv: ProductionEnv{
 			Server: map[string]string{"NODE_ENV": "production"},
@@ -89,8 +93,21 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 	if got.BrowserOSDir != cfg.BrowserOSDir {
 		t.Fatalf("BrowserOS dir mismatch: %q", got.BrowserOSDir)
 	}
+	if got.Branch != cfg.Branch {
+		t.Fatalf("branch mismatch: %q", got.Branch)
+	}
 	if got.ProductionEnv.CLI["R2_BUCKET"] != "browseros" {
 		t.Fatalf("production env mismatch: %#v", got.ProductionEnv)
+	}
+}
+
+func TestResolveDefaultsBranch(t *testing.T) {
+	cfg := Config{}
+
+	cfg.Resolve()
+
+	if cfg.Branch != "main" {
+		t.Fatalf("branch got %q want main", cfg.Branch)
 	}
 }
 

--- a/packages/browseros-agent/tools/dogfood/pipeline/git.go
+++ b/packages/browseros-agent/tools/dogfood/pipeline/git.go
@@ -30,6 +30,22 @@ func ResetHardToUpstream(ctx context.Context, repoPath string, r Runner) error {
 	return r.Run(ctx, repoPath, "git", "reset", "--hard", "@{upstream}")
 }
 
+// EnsureBranch moves the configured dogfood checkout onto its target branch before update work runs.
+func EnsureBranch(ctx context.Context, repoPath string, branch string, r Runner) error {
+	branch = strings.TrimSpace(branch)
+	if branch == "" {
+		return nil
+	}
+	current, err := CurrentBranch(repoPath, r)
+	if err != nil {
+		return err
+	}
+	if current == branch {
+		return nil
+	}
+	return r.Run(ctx, repoPath, "git", "switch", branch)
+}
+
 func Head(repoPath string, r Runner) (string, error) {
 	out, err := r.OutputRun(repoPath, "git", "rev-parse", "--short", "HEAD")
 	if err != nil {
@@ -38,10 +54,18 @@ func Head(repoPath string, r Runner) (string, error) {
 	return strings.TrimSpace(out), nil
 }
 
-func Branch(repoPath string, r Runner) string {
+func CurrentBranch(repoPath string, r Runner) (string, error) {
 	out, err := r.OutputRun(repoPath, "git", "branch", "--show-current")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func Branch(repoPath string, r Runner) string {
+	out, err := CurrentBranch(repoPath, r)
 	if err != nil {
 		return ""
 	}
-	return strings.TrimSpace(out)
+	return out
 }

--- a/packages/browseros-agent/tools/dogfood/pipeline/git.go
+++ b/packages/browseros-agent/tools/dogfood/pipeline/git.go
@@ -31,7 +31,7 @@ func ResetHardToUpstream(ctx context.Context, repoPath string, r Runner) error {
 }
 
 // EnsureBranch moves the configured dogfood checkout onto its target branch before update work runs.
-func EnsureBranch(ctx context.Context, repoPath string, branch string, r Runner) error {
+func EnsureBranch(ctx context.Context, repoPath string, branch string, r Runner, force bool) error {
 	branch = strings.TrimSpace(branch)
 	if branch == "" {
 		return nil
@@ -42,6 +42,9 @@ func EnsureBranch(ctx context.Context, repoPath string, branch string, r Runner)
 	}
 	if current == branch {
 		return nil
+	}
+	if force {
+		return r.Run(ctx, repoPath, "git", "switch", "--force", branch)
 	}
 	return r.Run(ctx, repoPath, "git", "switch", branch)
 }

--- a/packages/browseros-agent/tools/dogfood/pipeline/git_test.go
+++ b/packages/browseros-agent/tools/dogfood/pipeline/git_test.go
@@ -48,6 +48,37 @@ func TestResetHardToUpstream(t *testing.T) {
 	}
 }
 
+func TestEnsureBranchSwitchesWhenCurrentBranchDiffers(t *testing.T) {
+	r := &FakeRunner{Output: map[string]string{
+		"git branch --show-current": "feature\n",
+	}}
+
+	if err := EnsureBranch(context.Background(), "/repo", "dogfood", r); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"git branch --show-current", "git switch dogfood"}
+	for i := range want {
+		if r.Commands[i] != want[i] {
+			t.Fatalf("command %d got %q want %q", i, r.Commands[i], want[i])
+		}
+	}
+}
+
+func TestEnsureBranchSkipsSwitchWhenAlreadyOnBranch(t *testing.T) {
+	r := &FakeRunner{Output: map[string]string{
+		"git branch --show-current": "dogfood\n",
+	}}
+
+	if err := EnsureBranch(context.Background(), "/repo", "dogfood", r); err != nil {
+		t.Fatal(err)
+	}
+
+	if len(r.Commands) != 1 || r.Commands[0] != "git branch --show-current" {
+		t.Fatalf("commands got %#v", r.Commands)
+	}
+}
+
 type FakeRunner struct {
 	Commands []string
 	Output   map[string]string

--- a/packages/browseros-agent/tools/dogfood/pipeline/git_test.go
+++ b/packages/browseros-agent/tools/dogfood/pipeline/git_test.go
@@ -53,7 +53,7 @@ func TestEnsureBranchSwitchesWhenCurrentBranchDiffers(t *testing.T) {
 		"git branch --show-current": "feature\n",
 	}}
 
-	if err := EnsureBranch(context.Background(), "/repo", "dogfood", r); err != nil {
+	if err := EnsureBranch(context.Background(), "/repo", "dogfood", r, false); err != nil {
 		t.Fatal(err)
 	}
 
@@ -70,12 +70,29 @@ func TestEnsureBranchSkipsSwitchWhenAlreadyOnBranch(t *testing.T) {
 		"git branch --show-current": "dogfood\n",
 	}}
 
-	if err := EnsureBranch(context.Background(), "/repo", "dogfood", r); err != nil {
+	if err := EnsureBranch(context.Background(), "/repo", "dogfood", r, false); err != nil {
 		t.Fatal(err)
 	}
 
 	if len(r.Commands) != 1 || r.Commands[0] != "git branch --show-current" {
 		t.Fatalf("commands got %#v", r.Commands)
+	}
+}
+
+func TestEnsureBranchForceSwitchesWhenRequested(t *testing.T) {
+	r := &FakeRunner{Output: map[string]string{
+		"git branch --show-current": "feature\n",
+	}}
+
+	if err := EnsureBranch(context.Background(), "/repo", "dogfood", r, true); err != nil {
+		t.Fatal(err)
+	}
+
+	want := []string{"git branch --show-current", "git switch --force dogfood"}
+	for i := range want {
+		if r.Commands[i] != want[i] {
+			t.Fatalf("command %d got %q want %q", i, r.Commands[i], want[i])
+		}
 	}
 }
 


### PR DESCRIPTION
**Summary**
- Add a `branch` setting to `browseros-dogfood` config with a `main` fallback.
- Make `init` default the branch prompt from the selected repo checkout.
- Switch clean dogfood checkouts to the configured branch before `start`, `pull`, and `restart --pull` update paths.

**Design**
The implementation keeps branch behavior inside the dogfood config, command, and git pipeline boundaries. `pipeline.EnsureBranch` handles the low-level `git switch` decision, `prepareStartCheckout` enforces the configured branch before builds without discarding local edits, and `updateConfiguredRepo` centralizes branch-aware update behavior for pull and background restart flows.

**Test plan**
- `go test -count=1 ./...` from `packages/browseros-agent/tools/dogfood`
- `git diff --check -- tools/dogfood`