### PR TITLE
fix(build): update bundled CLI signing metadata

### DIFF
--- a/packages/browseros/build/common/server_binaries.py
+++ b/packages/browseros/build/common/server_binaries.py
@@ -32,7 +32,6 @@ MACOS_SERVER_BINARIES: Dict[str, SignSpec] = {
     "codex": SignSpec("codex", "runtime"),
     "claude": SignSpec("claude", "runtime"),
     "rg": SignSpec("rg", "runtime"),
-    "limactl": SignSpec("limactl", "runtime", "lima-vz-entitlements.plist"),
 }
 
 
@@ -44,7 +43,7 @@ WINDOWS_SERVER_BINARIES: List[str] = [
 
 
 def macos_sign_spec_for(binary_path: Path) -> Optional[SignSpec]:
-    """Look up sign metadata by file stem (e.g., ``limactl``)."""
+    """Look up sign metadata by file stem, such as ``codex`` or ``claude``."""
     return MACOS_SERVER_BINARIES.get(binary_path.stem)
 
 

--- a/packages/browseros/build/common/server_binaries_test.py
+++ b/packages/browseros/build/common/server_binaries_test.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Tests for the shared server-binary sign table."""
 
-import plistlib
 import unittest
 from pathlib import Path
 
@@ -29,22 +28,10 @@ class MacosServerBinariesTest(unittest.TestCase):
             self.assertTrue(plist.exists(), f"{stem}: entitlements {plist} missing")
 
     def test_macos_sign_spec_for_resolves_by_stem(self):
-        spec = macos_sign_spec_for(Path("/x/limactl"))
+        spec = macos_sign_spec_for(Path("/x/codex"))
         assert spec is not None
-        self.assertEqual(spec.identifier_suffix, "limactl")
+        self.assertEqual(spec.identifier_suffix, "codex")
         self.assertIsNone(macos_sign_spec_for(Path("/x/not_a_known_binary")))
-
-    def test_limactl_uses_vz_entitlement(self):
-        spec = macos_sign_spec_for(Path("/x/limactl"))
-        assert spec is not None
-        self.assertEqual(spec.entitlements, "lima-vz-entitlements.plist")
-
-        entitlements_name = spec.entitlements
-        assert entitlements_name is not None
-        entitlements = plistlib.loads(
-            (ENTITLEMENTS_DIR / entitlements_name).read_bytes()
-        )
-        self.assertIs(entitlements.get("com.apple.security.virtualization"), True)
 
     def test_agent_cli_entries_use_plain_hardened_runtime(self):
         for binary in ["codex", "claude"]:
@@ -54,12 +41,19 @@ class MacosServerBinariesTest(unittest.TestCase):
             self.assertEqual(spec.options, "runtime")
             self.assertIsNone(spec.entitlements)
 
-    def test_matches_lima_bundle_layout(self):
+    def test_lima_is_not_registered_for_signing(self):
         keys = set(MACOS_SERVER_BINARIES.keys())
-        self.assertIn("limactl", keys)
-        forbidden = {"podman", "gvproxy", "vfkit", "krunkit", "podman-mac-helper"}
+        forbidden = {
+            "limactl",
+            "podman",
+            "gvproxy",
+            "vfkit",
+            "krunkit",
+            "podman-mac-helper",
+        }
         leftover = forbidden & keys
-        self.assertFalse(leftover, f"podman-era entries still present: {leftover}")
+        self.assertFalse(leftover, f"stale VM entries still present: {leftover}")
+        self.assertIsNone(macos_sign_spec_for(Path("/x/third_party/lima/bin/limactl")))
 
 
 class WindowsServerBinariesTest(unittest.TestCase):

--- a/packages/browseros/build/modules/ota/common.py
+++ b/packages/browseros/build/modules/ota/common.py
@@ -238,9 +238,9 @@ def generate_server_appcast(
 def create_server_bundle_zip(resources_dir: Path, output_zip: Path) -> bool:
     """Zip an extracted ``resources/`` tree into a Sparkle payload.
 
-    Produces entries like ``resources/bin/browseros_server``,
-    ``resources/bin/third_party/lima/limactl`` — mirroring what the agent
-    build staged and what the Chromium build bakes into the installed app.
+    Produces entries like ``resources/bin/browseros_server`` and
+    ``resources/bin/third_party/codex`` — mirroring what the agent build
+    staged and what the Chromium build bakes into the installed app.
     File modes are preserved by ``ZipFile.write`` so executable bits survive.
     """
     if not resources_dir.is_dir():

--- a/packages/browseros/build/modules/sign/macos.py
+++ b/packages/browseros/build/modules/sign/macos.py
@@ -279,7 +279,12 @@ def find_components_to_sign(
     browseros_server_dir = join_paths(app_path, "Contents", "Resources", "BrowserOSServer")
     if browseros_server_dir.exists():
         for item in browseros_server_dir.rglob("*"):
-            if item.is_file() and not item.suffix and os.access(item, os.X_OK):
+            if (
+                item.is_file()
+                and not item.suffix
+                and os.access(item, os.X_OK)
+                and get_browseros_server_binary_info(item) is not None
+            ):
                 components["executables"].append(item)
 
     return components

--- a/packages/browseros/build/modules/sign/macos_test.py
+++ b/packages/browseros/build/modules/sign/macos_test.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Tests for macOS app signing discovery."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from .macos import find_components_to_sign
+
+
+def _write_exec(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("#!/bin/sh\n")
+    path.chmod(path.stat().st_mode | 0o755)
+
+
+class MacOSSignDiscoveryTest(unittest.TestCase):
+    def test_discovers_registered_server_binaries_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            app_path = Path(tmp) / "BrowserOS.app"
+            server_bin = (
+                app_path
+                / "Contents"
+                / "Resources"
+                / "BrowserOSServer"
+                / "default"
+                / "resources"
+                / "bin"
+            )
+            _write_exec(server_bin / "browseros_server")
+            _write_exec(server_bin / "third_party" / "codex")
+            _write_exec(server_bin / "third_party" / "claude")
+            _write_exec(server_bin / "third_party" / "lima" / "bin" / "limactl")
+
+            executables = set(find_components_to_sign(app_path)["executables"])
+
+            self.assertIn(server_bin / "browseros_server", executables)
+            self.assertIn(server_bin / "third_party" / "codex", executables)
+            self.assertIn(server_bin / "third_party" / "claude", executables)
+            self.assertNotIn(
+                server_bin / "third_party" / "lima" / "bin" / "limactl",
+                executables,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/modules/sign/macos_test.py
+++ b/packages/browseros/build/modules/sign/macos_test.py
@@ -28,6 +28,7 @@ class MacOSSignDiscoveryTest(unittest.TestCase):
                 / "bin"
             )
             _write_exec(server_bin / "browseros_server")
+            _write_exec(server_bin / "third_party" / "rg")
             _write_exec(server_bin / "third_party" / "codex")
             _write_exec(server_bin / "third_party" / "claude")
             _write_exec(server_bin / "third_party" / "lima" / "bin" / "limactl")
@@ -35,6 +36,7 @@ class MacOSSignDiscoveryTest(unittest.TestCase):
             executables = set(find_components_to_sign(app_path)["executables"])
 
             self.assertIn(server_bin / "browseros_server", executables)
+            self.assertIn(server_bin / "third_party" / "rg", executables)
             self.assertIn(server_bin / "third_party" / "codex", executables)
             self.assertIn(server_bin / "third_party" / "claude", executables)
             self.assertNotIn(

--- a/packages/browseros/resources/entitlements/lima-vz-entitlements.plist
+++ b/packages/browseros/resources/entitlements/lima-vz-entitlements.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-  <key>com.apple.security.virtualization</key>
-  <true/>
-</dict>
-</plist>


### PR DESCRIPTION
**Summary**
- Keep the bundled Codex and Claude Code CLI binaries registered for macOS and Windows signing.
- Remove stale limactl signing metadata now that Lima is unshipped.
- Prevent macOS app signing discovery from signing unregistered BrowserOSServer executables.

**Design**
The shared BrowserOS Server signing table remains the single source of truth for both the Chromium-build signing path and OTA signing. macOS app signing now filters BrowserOSServer executables through that table, so registered binaries such as `codex` and `claude` are signed while stale VM binaries such as `limactl` are ignored.

**Test plan**
- `python -m unittest discover -s build -p "*test.py"`
- `python -m unittest build.modules.sign.macos_test`
- `git diff --check`