### PR TITLE
fix: retry annotate on stale index.lock

### DIFF
--- a/packages/browseros/build/modules/annotate/annotate.py
+++ b/packages/browseros/build/modules/annotate/annotate.py
@@ -7,6 +7,7 @@ with the feature name and description.
 
 import yaml
 from pathlib import Path
+import subprocess
 from typing import List, Tuple, Optional, Dict
 
 from ..apply.utils import run_git_command
@@ -57,35 +58,40 @@ def _clear_git_index_lock(chromium_src: Path) -> bool:
     try:
         lock_path.unlink()
         return True
-    except OSError:
+    except OSError as e:
+        log_warning(f"   Failed to remove index.lock at {lock_path}: {e}")
         return False
 
 
 def _run_git_with_lock_retry(
     cmd: List[str], chromium_src: Path, max_retries: int = 1
-):
+) -> subprocess.CompletedProcess:
     """Run git command and retry once after removing an unexpected index lock."""
     result = run_git_command(cmd, cwd=chromium_src)
 
     if result.returncode == 0:
         return result
 
-    if not _is_git_index_lock_error(result.stderr or result.stdout):
+    if not _is_git_index_lock_error(result.stderr):
         return result
 
     for _ in range(max_retries):
-        if not _clear_git_index_lock(chromium_src):
-            return result
+        cleared_lock = _clear_git_index_lock(chromium_src)
+        if cleared_lock:
+            log_warning("   Git lock existed; removed stale index.lock and retrying")
 
-        log_warning("   Git lock existed; removed stale index.lock and retrying")
         result = run_git_command(cmd, cwd=chromium_src)
         if result.returncode == 0:
+            return result
+        if not _is_git_index_lock_error(result.stderr):
             return result
 
     return result
 
 
-def _format_git_error(cmd_result, action: str, target: str) -> str:
+def _format_git_error(
+    cmd_result: subprocess.CompletedProcess, action: str, target: str
+) -> str:
     """Build a compact git failure message for logging."""
     error = (cmd_result.stderr or cmd_result.stdout or "").strip()
     if not error:

--- a/packages/browseros/build/modules/annotate/annotate.py
+++ b/packages/browseros/build/modules/annotate/annotate.py
@@ -26,6 +26,73 @@ def load_features(features_file: Path) -> Dict:
         return {}
 
 
+def _git_index_lock_path(chromium_src: Path) -> Path:
+    """Resolve the git index lock path from git metadata when possible."""
+    result = run_git_command(
+        ["git", "rev-parse", "--git-path", "index.lock"],
+        cwd=chromium_src,
+    )
+    if result.returncode != 0:
+        return chromium_src / ".git" / "index.lock"
+
+    relative_path = (result.stdout or "").strip()
+    lock_path = Path(relative_path)
+    if not lock_path.is_absolute():
+        return chromium_src / lock_path
+    return lock_path
+
+
+def _is_git_index_lock_error(stderr: str) -> bool:
+    """Detect git errors caused by an existing index.lock file."""
+    normalized = (stderr or "").lower()
+    return "index.lock" in normalized and "file exists" in normalized
+
+
+def _clear_git_index_lock(chromium_src: Path) -> bool:
+    """Remove a stale git index lock file if it exists."""
+    lock_path = _git_index_lock_path(chromium_src)
+    if not lock_path.exists():
+        return False
+
+    try:
+        lock_path.unlink()
+        return True
+    except OSError:
+        return False
+
+
+def _run_git_with_lock_retry(
+    cmd: List[str], chromium_src: Path, max_retries: int = 1
+):
+    """Run git command and retry once after removing an unexpected index lock."""
+    result = run_git_command(cmd, cwd=chromium_src)
+
+    if result.returncode == 0:
+        return result
+
+    if not _is_git_index_lock_error(result.stderr or result.stdout):
+        return result
+
+    for _ in range(max_retries):
+        if not _clear_git_index_lock(chromium_src):
+            return result
+
+        log_warning("   Git lock existed; removed stale index.lock and retrying")
+        result = run_git_command(cmd, cwd=chromium_src)
+        if result.returncode == 0:
+            return result
+
+    return result
+
+
+def _format_git_error(cmd_result, action: str, target: str) -> str:
+    """Build a compact git failure message for logging."""
+    error = (cmd_result.stderr or cmd_result.stdout or "").strip()
+    if not error:
+        return f"Failed to {action}: {target}"
+    return f"Failed to {action} {target}: {error}"
+
+
 def get_modified_files(chromium_src: Path, files: List[str]) -> List[str]:
     """Get list of files that have modifications or are untracked.
 
@@ -68,27 +135,26 @@ def git_add_and_commit(
     Returns:
         True if commit was created successfully
     """
-    # Add all specified files
     for file_path in files:
-        result = run_git_command(
+        result = _run_git_with_lock_retry(
             ["git", "add", str(file_path)],
-            cwd=chromium_src,
+            chromium_src,
         )
         if result.returncode != 0:
-            log_error(f"Failed to add file: {file_path}")
+            log_error(_format_git_error(result, "add file", file_path))
             return False
 
     # Create commit
-    result = run_git_command(
+    result = _run_git_with_lock_retry(
         ["git", "commit", "-m", commit_message],
-        cwd=chromium_src,
+        chromium_src,
     )
 
     if result.returncode != 0:
         stderr = result.stderr or ""
         if "nothing to commit" in stderr or "nothing added to commit" in stderr:
             return False
-        log_error(f"Failed to commit: {stderr}")
+        log_error(_format_git_error(result, "create commit with message", f"`{commit_message}`"))
         return False
 
     return True


### PR DESCRIPTION
### Summary
- Add defensive handling for stale `.git/index.lock` during annotation commits.
- Retry `git add`/`git commit` in `packages/browseros/build/modules/annotate/annotate.py` when lock contention is detected.
- Keep existing error paths intact, so legitimate commit failures still surface with actionable messages.

### Design
The change adds a small lock-safe git execution path inside the annotate module: it checks for `git` lock errors, resolves/removes the lock file path from git metadata when present, and retries the command once before surfacing an error. This keeps annotate robust against stale lock leftovers during large, multi-feature feature-commits.

### Test plan
- `python -m py_compile packages/browseros/build/modules/annotate/annotate.py`
- `uv run ruff check packages/browseros/build/modules/annotate/annotate.py`
- `cd packages/browseros && uv run browseros dev --chromium-src /Users/shadowfax/ch1-src annotate`
- `cd packages/browseros && uv run browseros dev --chromium-src /Users/shadowfax/code/chromium-checkouts/chromium-1/src annotate`
