### PR TITLE
Fix sidepanel chat context-limit recovery

### DIFF
--- a/packages/browseros-agent/apps/server/README.md
+++ b/packages/browseros-agent/apps/server/README.md
@@ -74,13 +74,17 @@ The agent loop uses the [Vercel AI SDK](https://sdk.vercel.ai) to orchestrate mu
 
 - **Multi-provider support** — OpenAI, Anthropic, Google, Azure, Bedrock, OpenRouter, Ollama, LM Studio, and any OpenAI-compatible endpoint
 - **Session management** — conversations persist in a local SQLite database
-- **Context overflow handling** — automatic message compaction when context windows fill up
+- **Context overflow handling** — automatic message compaction when context windows fill up, including sidepanel chat recovery after provider context-limit errors
 - **MCP client** — connects to external MCP servers for additional tool access (40+ app integrations)
 - **Tool adapter** — bridges MCP tool definitions to AI SDK tool format
 
 ### Provider Factory
 
 The provider factory (`src/agent/provider-factory.ts`) creates AI SDK providers from runtime configuration, supporting hot-swapping between providers without restart.
+
+### Sidepanel Chat Context Recovery
+
+If a provider returns a context-limit error during a sidepanel chat turn, BrowserOS compacts older chat history into a structured `<continuation_context>` note, rebuilds the session, and retries once instead of making the user restart the chat. When the error arrives after partial assistant output, BrowserOS preserves the visible progress and suppresses the duplicate retry start event.
 
 ## Directory Structure
 

--- a/packages/browseros-agent/apps/server/src/agent/chat-continuation.ts
+++ b/packages/browseros-agent/apps/server/src/agent/chat-continuation.ts
@@ -1,0 +1,223 @@
+import type { UIMessage } from 'ai'
+
+const RECENT_EXACT_MESSAGES = 6
+const SUMMARY_MESSAGE_MAX_CHARS = 1_200
+const SUMMARY_TOTAL_MAX_CHARS = 32_000
+const RECENT_MESSAGE_MAX_CHARS = 2_500
+const TOOL_PAYLOAD_MAX_CHARS = 1_000
+
+export interface ChatContinuationResult {
+  messages: UIMessage[]
+  compactedMessageCount: number
+}
+
+export function buildChatContinuationMessages(input: {
+  messages: UIMessage[]
+  latestUserMessageId?: string
+  reason?: string
+}): ChatContinuationResult {
+  const messages = input.messages.filter((message) =>
+    uiMessageToTranscriptText(message).trim(),
+  )
+  const latestUserIndex = findLatestUserIndex(
+    messages,
+    input.latestUserMessageId,
+  )
+
+  if (latestUserIndex === -1) {
+    return { messages, compactedMessageCount: 0 }
+  }
+
+  const latestUser = textOnlyMessage(messages[latestUserIndex], {
+    maxChars: Number.POSITIVE_INFINITY,
+  })
+  const prior = messages.slice(0, latestUserIndex)
+  const recentCount = Math.min(RECENT_EXACT_MESSAGES, prior.length)
+  const older = prior.slice(0, prior.length - recentCount)
+  const recent = prior.slice(prior.length - recentCount)
+
+  const continuationNote: UIMessage = {
+    id: crypto.randomUUID(),
+    role: 'user',
+    parts: [
+      {
+        type: 'text',
+        text: [
+          '<continuation_context>',
+          'BrowserOS compacted earlier sidepanel chat history after the provider reported that the input exceeded the model context window.',
+          input.reason
+            ? `Provider signal: ${truncateText(input.reason, 500)}`
+            : '',
+          '',
+          'Summary of compacted older history:',
+          formatSummary(older),
+          '',
+          'Recent exact turns:',
+          formatRecent(recent),
+          '',
+          'Use this continuation note as memory of the prior conversation. Keep working from this state without asking the user to restart or repeat context.',
+          '</continuation_context>',
+        ]
+          .filter((line) => line !== '')
+          .join('\n'),
+      },
+    ],
+  }
+
+  return {
+    messages: [
+      continuationNote,
+      ...recent.map((message) =>
+        textOnlyMessage(message, { maxChars: RECENT_MESSAGE_MAX_CHARS }),
+      ),
+      latestUser,
+    ],
+    compactedMessageCount: prior.length,
+  }
+}
+
+function findLatestUserIndex(
+  messages: UIMessage[],
+  latestUserMessageId?: string,
+): number {
+  if (latestUserMessageId) {
+    const byId = messages.findIndex(
+      (message) =>
+        message.id === latestUserMessageId && message.role === 'user',
+    )
+    if (byId !== -1) return byId
+  }
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === 'user') return i
+  }
+  return -1
+}
+
+function textOnlyMessage(
+  message: UIMessage,
+  options: { maxChars: number },
+): UIMessage {
+  return {
+    id: message.id,
+    role: message.role,
+    parts: [
+      {
+        type: 'text',
+        text: truncateText(
+          uiMessageToTranscriptText(message),
+          options.maxChars,
+        ),
+      },
+    ],
+  }
+}
+
+function formatSummary(messages: UIMessage[]): string {
+  if (messages.length === 0) {
+    return '- No older text was available to summarize.'
+  }
+
+  const lines: string[] = []
+  let totalChars = 0
+  for (const [index, message] of messages.entries()) {
+    const text = singleLine(uiMessageToTranscriptText(message))
+    if (!text) continue
+
+    const line = `- ${roleLabel(message.role)}: ${truncateText(
+      text,
+      SUMMARY_MESSAGE_MAX_CHARS,
+    )}`
+    if (
+      totalChars + line.length > SUMMARY_TOTAL_MAX_CHARS &&
+      lines.length > 0
+    ) {
+      lines.push(
+        `- [omitted ${messages.length - index} compacted messages to keep the continuation note bounded]`,
+      )
+      break
+    }
+    lines.push(line)
+    totalChars += line.length + 1
+  }
+
+  return lines.length > 0
+    ? lines.join('\n')
+    : '- No older text was available to summarize.'
+}
+
+function formatRecent(messages: UIMessage[]): string {
+  if (messages.length === 0) return '- No recent exact turns were available.'
+  return messages
+    .map((message) => {
+      const text = truncateText(
+        uiMessageToTranscriptText(message),
+        RECENT_MESSAGE_MAX_CHARS,
+      )
+      return `[${roleLabel(message.role)}]\n${text}`
+    })
+    .join('\n\n')
+}
+
+function uiMessageToTranscriptText(message: UIMessage): string {
+  return message.parts.map(partToText).filter(Boolean).join('\n').trim()
+}
+
+function partToText(part: UIMessage['parts'][number]): string {
+  if (part.type === 'text') return part.text
+  if (part.type === 'reasoning') return `Reasoning: ${part.text}`
+  if (part.type === 'source-url') return `Source: ${part.url}`
+  if (part.type === 'source-document') return `Source document: ${part.title}`
+  if (part.type === 'file') return `[file: ${part.mediaType}]`
+  if (part.type === 'dynamic-tool') {
+    return toolPartToText('dynamic-tool', part)
+  }
+  if (part.type.startsWith('tool-')) {
+    return toolPartToText(part.type.slice(5), part)
+  }
+  if (part.type.startsWith('data-')) return ''
+  return `[${part.type}]`
+}
+
+function toolPartToText(toolName: string, part: unknown): string {
+  const value = part as {
+    state?: string
+    input?: unknown
+    output?: unknown
+    errorText?: string
+  }
+  const lines = [`Tool ${toolName}${value.state ? ` (${value.state})` : ''}`]
+  if (value.input !== undefined) {
+    lines.push(
+      `input: ${truncateText(safeJson(value.input), TOOL_PAYLOAD_MAX_CHARS)}`,
+    )
+  }
+  if (value.output !== undefined) {
+    lines.push(
+      `output: ${truncateText(safeJson(value.output), TOOL_PAYLOAD_MAX_CHARS)}`,
+    )
+  }
+  if (value.errorText) lines.push(`error: ${value.errorText}`)
+  return lines.join('\n')
+}
+
+function roleLabel(role: UIMessage['role']): string {
+  return role === 'user' ? 'User' : 'Assistant'
+}
+
+function truncateText(value: string, maxChars: number): string {
+  if (value.length <= maxChars) return value
+  return `${value.slice(0, maxChars)}\n[truncated ${value.length - maxChars} characters]`
+}
+
+function singleLine(value: string): string {
+  return value.replace(/\s+/g, ' ').trim()
+}
+
+function safeJson(value: unknown): string {
+  if (typeof value === 'string') return value
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}

--- a/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
@@ -4,8 +4,14 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { createAgentUIStreamResponse, type UIMessage } from 'ai'
+import {
+  createAgentUIStream,
+  createUIMessageStreamResponse,
+  type UIMessage,
+  type UIMessageChunk,
+} from 'ai'
 import { AiSdkAgent } from '../../agent/ai-sdk-agent'
+import { buildChatContinuationMessages } from '../../agent/chat-continuation'
 import { formatUserMessage } from '../../agent/format-message'
 import {
   filterValidMessages,
@@ -15,6 +21,10 @@ import type { AgentSession, SessionStore } from '../../agent/session-store'
 import type { ResolvedAgentConfig } from '../../agent/types'
 import type { Browser } from '../../browser/browser'
 import { resolveLLMConfig } from '../../lib/clients/llm/config'
+import {
+  isContextLimitError,
+  stringifyError,
+} from '../../lib/context-limit-error'
 import { logger } from '../../lib/logger'
 import type { ToolRegistry } from '../../tools/tool-registry'
 import type { KlavisProxyRef } from '../services/klavis/strata-proxy'
@@ -33,6 +43,7 @@ export interface ChatServiceDeps {
 export class ChatService {
   constructor(private deps: ChatServiceDeps) {}
 
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: this method orchestrates chat session lifecycle, context changes, and stream recovery; split only with a dedicated service refactor.
   async processMessage(
     request: ChatRequest,
     abortSignal: AbortSignal,
@@ -248,8 +259,10 @@ export class ChatService {
       })
     }
 
+    let activeSession = session
+
     const messageContext = request.isScheduledTask
-      ? (session.browserContext ?? request.browserContext)
+      ? (activeSession.browserContext ?? request.browserContext)
       : request.browserContext
     // Scheduled tasks already have correct internal pageIds from browser.newPage();
     // resolving them again would pass those to resolveTabIds, which expects Chrome
@@ -276,50 +289,62 @@ export class ChatService {
     // <selected_text> + <USER_QUERY>) is built as a transient prompt
     // copy below — the LLM sees it, the user-visible state never
     // does.
-    session.agent.appendUserMessage(request.message)
+    activeSession.agent.appendUserMessage(request.message)
     const promptUserText = contextPrefix + userContent
     const wrappedUserMessageId =
-      session.agent.messages[session.agent.messages.length - 1]?.id
+      activeSession.agent.messages[activeSession.agent.messages.length - 1]?.id
 
-    const promptUiMessages = filterValidMessages(session.agent.messages).map(
-      (msg) =>
+    const buildPromptUiMessages = () =>
+      filterValidMessages(activeSession.agent.messages).map((msg) =>
         msg.id === wrappedUserMessageId && msg.role === 'user'
           ? {
               ...msg,
               parts: [{ type: 'text' as const, text: promptUserText }],
             }
           : msg,
-    )
+      )
 
-    return createAgentUIStreamResponse({
-      agent: session.agent.toolLoopAgent,
-      uiMessages: promptUiMessages,
-      abortSignal,
-      onFinish: async ({ messages }: { messages: UIMessage[] }) => {
-        // The agent loop returns `messages` containing the prompt-
-        // wrapped user text. Restore the raw form before persisting
-        // so subsequent turns see the clean text and the client's
-        // local UIMessage matches what was originally typed.
-        const restored = messages.map((msg) =>
-          msg.id === wrappedUserMessageId && msg.role === 'user'
-            ? {
-                ...msg,
-                parts: [{ type: 'text' as const, text: request.message }],
-              }
-            : msg,
-        )
-        session.agent.messages = filterValidMessages(restored)
-        logger.info('Agent execution complete', {
-          conversationId: request.conversationId,
-          totalMessages: restored.length,
-        })
+    const persistFinishedMessages = async ({
+      messages,
+    }: {
+      messages: UIMessage[]
+    }) => {
+      // The agent loop returns `messages` containing the prompt-
+      // wrapped user text. Restore the raw form before persisting
+      // so subsequent turns see the clean text and the client's
+      // local UIMessage matches what was originally typed.
+      const restored = messages.map((msg) =>
+        msg.id === wrappedUserMessageId && msg.role === 'user'
+          ? {
+              ...msg,
+              parts: [{ type: 'text' as const, text: request.message }],
+            }
+          : msg,
+      )
+      activeSession.agent.messages = filterValidMessages(restored)
+      logger.info('Agent execution complete', {
+        conversationId: request.conversationId,
+        totalMessages: restored.length,
+      })
 
-        if (session?.hiddenPageId) {
-          const pageId = session.hiddenPageId
-          session.hiddenPageId = undefined
-          this.closeHiddenPage(pageId, request.conversationId)
-        }
+      if (activeSession.hiddenPageId) {
+        const pageId = activeSession.hiddenPageId
+        activeSession.hiddenPageId = undefined
+        this.closeHiddenPage(pageId, request.conversationId)
+      }
+    }
+
+    return this.createRecoveringAgentUIStreamResponse({
+      request,
+      agentConfig,
+      mcpServerKey,
+      getSession: () => activeSession,
+      setSession: (nextSession) => {
+        activeSession = nextSession
       },
+      getPromptUiMessages: buildPromptUiMessages,
+      abortSignal,
+      onFinish: persistFinishedMessages,
     })
   }
 
@@ -390,6 +415,216 @@ export class ChatService {
     return newSession
   }
 
+  private createRecoveringAgentUIStreamResponse(input: {
+    request: ChatRequest
+    agentConfig: ResolvedAgentConfig
+    mcpServerKey: string
+    getSession: () => AgentSession
+    setSession: (session: AgentSession) => void
+    getPromptUiMessages: () => UIMessage[]
+    abortSignal: AbortSignal
+    onFinish(args: { messages: UIMessage[] }): Promise<void>
+  }): Response {
+    let retriedForContextLimit = false
+
+    const stream = new ReadableStream<UIMessageChunk>({
+      start: async (controller) => {
+        const enqueue = (chunk: UIMessageChunk) => {
+          try {
+            controller.enqueue(chunk)
+          } catch {}
+        }
+
+        const runAttempt = async (
+          options: { suppressStartChunk?: boolean } = {},
+        ): Promise<void> => {
+          const session = input.getSession()
+          const agentStream = await createAgentUIStream({
+            agent: session.agent.toolLoopAgent,
+            uiMessages: input.getPromptUiMessages(),
+            abortSignal: input.abortSignal,
+            onFinish: input.onFinish,
+          })
+
+          await this.pipeAttemptWithContextRecovery({
+            input,
+            source: agentStream,
+            enqueue,
+            shouldRetry: () => !retriedForContextLimit,
+            markRetried: () => {
+              retriedForContextLimit = true
+            },
+            suppressStartChunk: options.suppressStartChunk ?? false,
+            runRetry: runAttempt,
+          })
+        }
+
+        try {
+          await runAttempt()
+        } catch (error) {
+          if (!retriedForContextLimit && isContextLimitError(error)) {
+            retriedForContextLimit = true
+            const retryPrepared = await this.prepareContextLimitRetry(
+              input,
+              error,
+            )
+            if (retryPrepared) {
+              await runAttempt()
+              controller.close()
+              return
+            }
+          }
+          enqueue({ type: 'error', errorText: stringifyError(error) })
+        } finally {
+          try {
+            controller.close()
+          } catch {}
+        }
+      },
+    })
+
+    return createUIMessageStreamResponse({ stream })
+  }
+
+  private async pipeAttemptWithContextRecovery(input: {
+    input: {
+      request: ChatRequest
+      agentConfig: ResolvedAgentConfig
+      mcpServerKey: string
+      getSession: () => AgentSession
+      setSession: (session: AgentSession) => void
+      getPromptUiMessages: () => UIMessage[]
+      abortSignal: AbortSignal
+      onFinish(args: { messages: UIMessage[] }): Promise<void>
+    }
+    source: ReadableStream<UIMessageChunk>
+    enqueue(chunk: UIMessageChunk): void
+    shouldRetry(): boolean
+    markRetried(): void
+    suppressStartChunk: boolean
+    runRetry(options?: { suppressStartChunk?: boolean }): Promise<void>
+  }): Promise<void> {
+    const buffered: UIMessageChunk[] = []
+    let flushed = false
+
+    const flush = () => {
+      if (flushed) return
+      flushed = true
+      for (const bufferedChunk of buffered) {
+        input.enqueue(bufferedChunk)
+      }
+      buffered.length = 0
+    }
+
+    const reader = input.source.getReader()
+    try {
+      while (true) {
+        const { done, value } = await reader.read()
+        if (done) break
+
+        if (input.suppressStartChunk && value.type === 'start') {
+          continue
+        }
+
+        if (
+          value.type === 'error' &&
+          input.shouldRetry() &&
+          isContextLimitError(value.errorText)
+        ) {
+          input.markRetried()
+          const retryPrepared = await this.prepareContextLimitRetry(
+            input.input,
+            value.errorText,
+          )
+          if (retryPrepared) {
+            await reader.cancel().catch(() => {})
+            await input.runRetry({ suppressStartChunk: flushed })
+            return
+          }
+        }
+
+        if (!flushed) {
+          buffered.push(value)
+          if (isMeaningfulStreamChunk(value)) flush()
+          continue
+        }
+
+        input.enqueue(value)
+      }
+    } finally {
+      reader.releaseLock()
+    }
+
+    flush()
+  }
+
+  private async prepareContextLimitRetry(
+    input: {
+      request: ChatRequest
+      agentConfig: ResolvedAgentConfig
+      mcpServerKey: string
+      getSession: () => AgentSession
+      setSession: (session: AgentSession) => void
+    },
+    error: unknown,
+  ): Promise<boolean> {
+    const session = input.getSession()
+    const continuation = buildChatContinuationMessages({
+      messages: session.agent.messages,
+      latestUserMessageId: session.agent.messages.at(-1)?.id,
+      reason: stringifyError(error),
+    })
+
+    if (continuation.compactedMessageCount === 0) {
+      logger.warn(
+        'Context limit retry skipped; no older chat history to compact',
+        {
+          conversationId: input.request.conversationId,
+        },
+      )
+      return false
+    }
+
+    logger.info(
+      'Context limit reached; compacting sidepanel chat and retrying',
+      {
+        conversationId: input.request.conversationId,
+        compactedMessageCount: continuation.compactedMessageCount,
+        retainedMessageCount: continuation.messages.length,
+      },
+    )
+
+    const rebuilt = await this.rebuildSessionWithMessages(
+      session,
+      input.request,
+      input.agentConfig,
+      input.mcpServerKey,
+      continuation.messages,
+    )
+    input.setSession(rebuilt)
+    return true
+  }
+
+  private async rebuildSessionWithMessages(
+    session: AgentSession,
+    request: ChatRequest,
+    agentConfig: ResolvedAgentConfig,
+    mcpServerKey: string,
+    messages: UIMessage[],
+  ): Promise<AgentSession> {
+    const rebuilt = await this.rebuildSession(
+      session,
+      request,
+      agentConfig,
+      mcpServerKey,
+    )
+    rebuilt.agent.messages = sanitizeMessagesForToolset(
+      messages,
+      rebuilt.agent.toolNames,
+    )
+    return rebuilt
+  }
+
   private buildMcpServerKey(browserContext?: BrowserContext): string {
     const managed = browserContext?.enabledMcpServers?.slice().sort() ?? []
     const custom =
@@ -401,5 +636,22 @@ export class ChatService {
           : 'klavis:pending'
         : null
     return [klavisState, ...managed, ...custom].filter(Boolean).join(',')
+  }
+}
+
+function isMeaningfulStreamChunk(chunk: UIMessageChunk): boolean {
+  switch (chunk.type) {
+    case 'start':
+    case 'start-step':
+    case 'text-start':
+    case 'text-end':
+    case 'reasoning-start':
+    case 'reasoning-end':
+    case 'finish-step':
+    case 'finish':
+    case 'message-metadata':
+      return false
+    default:
+      return chunk.type !== 'error'
   }
 }

--- a/packages/browseros-agent/apps/server/src/lib/context-limit-error.ts
+++ b/packages/browseros-agent/apps/server/src/lib/context-limit-error.ts
@@ -1,0 +1,27 @@
+export function isContextLimitError(value: unknown): boolean {
+  const haystack = stringifyError(value).toLowerCase()
+  return (
+    /context[_ -]?length[_ -]?exceeded/.test(haystack) ||
+    /maximum context length/.test(haystack) ||
+    /max(?:imum)? context/.test(haystack) ||
+    /context window/.test(haystack) ||
+    /too many tokens/.test(haystack) ||
+    /input (?:is )?too (?:large|long)/.test(haystack) ||
+    /token limit/.test(haystack) ||
+    /exceeds? [\w\s-]*tokens/.test(haystack)
+  )
+}
+
+export function stringifyError(value: unknown): string {
+  if (value instanceof Error) {
+    const cause =
+      'cause' in value && value.cause ? ` ${stringifyError(value.cause)}` : ''
+    return `${value.name} ${value.message} ${value.stack ?? ''}${cause}`
+  }
+  if (typeof value === 'string') return value
+  try {
+    return JSON.stringify(value)
+  } catch {
+    return String(value)
+  }
+}

--- a/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
@@ -24,10 +24,20 @@ interface StreamResponseOptions {
   onFinish(args: { messages: MockMessage[] }): Promise<void>
 }
 
+type MockStreamChunk =
+  | { type: 'start' }
+  | { type: 'start-step' }
+  | { type: 'text-start'; id: string }
+  | { type: 'text-delta'; id: string; delta: string }
+  | { type: 'text-end'; id: string }
+  | { type: 'finish' }
+  | { type: 'error'; errorText: string }
+
 let agentToReturn: MockAgent | undefined
 let streamResponseHandler:
-  | ((options: StreamResponseOptions) => Promise<Response>)
+  | ((options: StreamResponseOptions) => Promise<MockStreamChunk[] | undefined>)
   | undefined
+let drainedStreamChunks: MockStreamChunk[] = []
 
 const createAgentSpy = mock(async (config: unknown) => {
   if (!agentToReturn) {
@@ -36,12 +46,41 @@ const createAgentSpy = mock(async (config: unknown) => {
   return agentToReturn
 })
 
+const createAgentUIStreamSpy = mock(async (options: StreamResponseOptions) => {
+  if (!streamResponseHandler) {
+    throw new Error('No stream response handler configured')
+  }
+  const chunks = await streamResponseHandler(options)
+  return new ReadableStream({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk)
+      }
+      controller.close()
+    },
+  })
+})
+
+const createUIMessageStreamResponseSpy = mock(
+  async ({ stream }: { stream: ReadableStream<MockStreamChunk> }) => {
+    drainedStreamChunks = []
+    const reader = stream.getReader()
+    while (true) {
+      const { done, value } = await reader.read()
+      if (done) break
+      drainedStreamChunks.push(value)
+    }
+    return new Response('ok')
+  },
+)
+
 const createAgentUIStreamResponseSpy = mock(
   async (options: StreamResponseOptions) => {
     if (!streamResponseHandler) {
       throw new Error('No stream response handler configured')
     }
-    return await streamResponseHandler(options)
+    await streamResponseHandler(options)
+    return new Response('ok')
   },
 )
 
@@ -52,6 +91,8 @@ const resolveLLMConfigSpy = mock(async () => ({
 }))
 
 mock.module('ai', () => ({
+  createAgentUIStream: createAgentUIStreamSpy,
+  createUIMessageStreamResponse: createUIMessageStreamResponseSpy,
   createAgentUIStreamResponse: createAgentUIStreamResponseSpy,
 }))
 
@@ -123,7 +164,7 @@ describe('ChatService scheduled task hidden page lifecycle', () => {
     agentToReturn = fakeAgent
     streamResponseHandler = async ({ onFinish, uiMessages }) => {
       await onFinish({ messages: uiMessages ?? fakeAgent.messages })
-      return new Response('ok')
+      return []
     }
 
     const browser = {
@@ -232,7 +273,7 @@ describe('ChatService scheduled task hidden page lifecycle', () => {
     agentToReturn = fakeAgent
     streamResponseHandler = async ({ onFinish, uiMessages }) => {
       await onFinish({ messages: uiMessages ?? fakeAgent.messages })
-      return new Response('ok')
+      return []
     }
 
     const browser = {
@@ -300,7 +341,7 @@ describe('ChatService Klavis session rebuilds', () => {
     streamResponseHandler = async ({ onFinish, uiMessages }) => {
       lastPromptUiMessages = uiMessages
       await onFinish({ messages: uiMessages ?? [] })
-      return new Response('ok')
+      return []
     }
 
     const klavisRef = { handle: null as object | null }
@@ -374,7 +415,7 @@ describe('ChatService Klavis session rebuilds', () => {
     agentToReturn = firstAgent
     streamResponseHandler = async ({ onFinish, uiMessages }) => {
       await onFinish({ messages: uiMessages ?? [] })
-      return new Response('ok')
+      return []
     }
 
     const klavisRef = { handle: null as object | null }
@@ -422,5 +463,234 @@ describe('ChatService Klavis session rebuilds', () => {
     expect(createAgentSpy.mock.calls.length - createCallsBefore).toBe(1)
     expect(firstAgent.dispose).not.toHaveBeenCalled()
     expect(firstAgent.messages).toHaveLength(2)
+  })
+})
+
+describe('ChatService context-limit recovery', () => {
+  it('compacts sidepanel chat history, rebuilds the session, and retries once', async () => {
+    const firstAgent = createFakeAgent()
+    const secondAgent = createFakeAgent()
+    agentToReturn = firstAgent
+
+    let streamCallCount = 0
+    let retryPromptMessages: MockMessage[] | undefined
+    streamResponseHandler = async ({ onFinish, uiMessages }) => {
+      streamCallCount++
+      if (streamCallCount === 1) {
+        agentToReturn = secondAgent
+        return [
+          { type: 'start' },
+          { type: 'start-step' },
+          {
+            type: 'error',
+            errorText:
+              'Your input exceeds the context window of this model. Please adjust your input and try again.',
+          },
+        ]
+      }
+
+      retryPromptMessages = uiMessages
+      await onFinish({
+        messages: [
+          ...(uiMessages ?? []),
+          {
+            id: 'assistant-final',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'Recovered response.' }],
+          },
+        ],
+      })
+      return [
+        { type: 'start' },
+        { type: 'start-step' },
+        { type: 'text-start', id: 'text-1' },
+        { type: 'text-delta', id: 'text-1', delta: 'Recovered response.' },
+        { type: 'text-end', id: 'text-1' },
+        { type: 'finish' },
+      ]
+    }
+
+    const browser = {
+      resolveTabIds: mock(
+        async (tabIds: number[]) =>
+          new Map(tabIds.map((tabId) => [tabId, tabId + 300])),
+      ),
+      closePage: mock(async () => {}),
+    }
+    const sessionStore = createSessionStore()
+    const service = new ChatService({
+      sessionStore: sessionStore as never,
+      klavisRef: { handle: null },
+      browser: browser as never,
+      registry: {} as never,
+    })
+    const createCallsBefore = createAgentSpy.mock.calls.length
+
+    const previousConversation = Array.from({ length: 8 }, (_, index) => ({
+      role: index % 2 === 0 ? ('user' as const) : ('assistant' as const),
+      content: `prior message ${index}`,
+    }))
+
+    await service.processMessage(
+      {
+        conversationId: crypto.randomUUID(),
+        message: 'continue the research',
+        previousConversation,
+        isScheduledTask: false,
+        mode: 'agent',
+        origin: 'sidepanel',
+        browserContext: {
+          activeTab: {
+            id: 3,
+            url: 'https://example.com',
+            title: 'Example',
+          },
+        },
+      } as never,
+      new AbortController().signal,
+    )
+
+    expect(streamCallCount).toBe(2)
+    expect(createAgentSpy.mock.calls.length - createCallsBefore).toBe(2)
+    expect(firstAgent.dispose).toHaveBeenCalledTimes(1)
+    expect(
+      drainedStreamChunks.some((chunk) => chunk.type === 'error'),
+    ).toBeFalse()
+
+    const retryTexts =
+      retryPromptMessages?.map((message) => message.parts[0]?.text ?? '') ?? []
+    expect(retryTexts[0]).toContain('<continuation_context>')
+    expect(retryTexts[0]).toContain('provider reported')
+    expect(retryTexts.at(-1)).toContain('<USER_QUERY>')
+    expect(retryTexts.at(-1)).toContain('continue the research')
+
+    const persistedTexts = secondAgent.messages.map(
+      (message) => message.parts[0]?.text ?? '',
+    )
+    expect(persistedTexts[0]).toContain('<continuation_context>')
+    expect(persistedTexts).toContain('continue the research')
+    expect(persistedTexts).toContain('Recovered response.')
+  })
+
+  it('retries a context-limit failure after partial assistant output', async () => {
+    const firstAgent = createFakeAgent()
+    const secondAgent = createFakeAgent()
+    agentToReturn = firstAgent
+
+    let streamCallCount = 0
+    let retryPromptMessages: MockMessage[] | undefined
+    streamResponseHandler = async ({ onFinish, uiMessages }) => {
+      streamCallCount++
+      if (streamCallCount === 1) {
+        agentToReturn = secondAgent
+        return [
+          { type: 'start' },
+          { type: 'start-step' },
+          { type: 'text-start', id: 'text-1' },
+          {
+            type: 'text-delta',
+            id: 'text-1',
+            delta: 'I found some sources.',
+          },
+          { type: 'text-end', id: 'text-1' },
+          {
+            type: 'error',
+            errorText:
+              'Your input exceeds the context window of this model. Please adjust your input and try again.',
+          },
+        ]
+      }
+
+      retryPromptMessages = uiMessages
+      await onFinish({
+        messages: [
+          ...(uiMessages ?? []),
+          {
+            id: 'assistant-final',
+            role: 'assistant',
+            parts: [{ type: 'text', text: 'Recovered continuation.' }],
+          },
+        ],
+      })
+      return [
+        { type: 'start' },
+        { type: 'start-step' },
+        { type: 'text-start', id: 'text-2' },
+        {
+          type: 'text-delta',
+          id: 'text-2',
+          delta: 'Recovered continuation.',
+        },
+        { type: 'text-end', id: 'text-2' },
+        { type: 'finish' },
+      ]
+    }
+
+    const browser = {
+      resolveTabIds: mock(
+        async (tabIds: number[]) =>
+          new Map(tabIds.map((tabId) => [tabId, tabId + 400])),
+      ),
+      closePage: mock(async () => {}),
+    }
+    const sessionStore = createSessionStore()
+    const service = new ChatService({
+      sessionStore: sessionStore as never,
+      klavisRef: { handle: null },
+      browser: browser as never,
+      registry: {} as never,
+    })
+    const createCallsBefore = createAgentSpy.mock.calls.length
+
+    const previousConversation = Array.from({ length: 8 }, (_, index) => ({
+      role: index % 2 === 0 ? ('user' as const) : ('assistant' as const),
+      content: `prior message ${index}`,
+    }))
+
+    await service.processMessage(
+      {
+        conversationId: crypto.randomUUID(),
+        message: 'keep checking those forum sources',
+        previousConversation,
+        isScheduledTask: false,
+        mode: 'agent',
+        origin: 'sidepanel',
+        browserContext: {
+          activeTab: {
+            id: 3,
+            url: 'https://example.com',
+            title: 'Example',
+          },
+        },
+      } as never,
+      new AbortController().signal,
+    )
+
+    expect(streamCallCount).toBe(2)
+    expect(createAgentSpy.mock.calls.length - createCallsBefore).toBe(2)
+    expect(firstAgent.dispose).toHaveBeenCalledTimes(1)
+    expect(
+      drainedStreamChunks.some((chunk) => chunk.type === 'error'),
+    ).toBeFalse()
+    expect(
+      drainedStreamChunks.filter((chunk) => chunk.type === 'start'),
+    ).toHaveLength(1)
+    expect(
+      drainedStreamChunks
+        .filter((chunk) => chunk.type === 'text-delta')
+        .map((chunk) => chunk.delta),
+    ).toEqual(['I found some sources.', 'Recovered continuation.'])
+
+    const retryTexts =
+      retryPromptMessages?.map((message) => message.parts[0]?.text ?? '') ?? []
+    expect(retryTexts[0]).toContain('<continuation_context>')
+    expect(retryTexts.at(-1)).toContain('keep checking those forum sources')
+
+    const persistedTexts = secondAgent.messages.map(
+      (message) => message.parts[0]?.text ?? '',
+    )
+    expect(persistedTexts[0]).toContain('<continuation_context>')
+    expect(persistedTexts).toContain('keep checking those forum sources')
+    expect(persistedTexts).toContain('Recovered continuation.')
   })
 })


### PR DESCRIPTION
## Summary
- detect provider context-limit errors from sidepanel chat streams and thrown stream setup errors
- compact prior sidepanel chat history into a structured continuation note, rebuild the session, and retry once
- preserve already-visible assistant progress on mid-stream recovery while suppressing the duplicate retry start event
- add regression coverage for pre-output and partial-output context-limit failures

## Tests
- `bun --env-file=.env.development test --preload=./tests/__helpers__/test-env.ts ./tests/api/services/chat-service.test.ts`
- `bun run typecheck`
- `bun run test:api`
- `git diff --check`