### PR TITLE
chore: remove server graph placeholder

### DIFF
--- a/packages/browseros-agent/apps/server/graph/.gitignore
+++ b/packages/browseros-agent/apps/server/graph/.gitignore
@@ -1,2 +1,0 @@
-*
-!.gitignore


### PR DESCRIPTION
## Summary
- Remove the tracked `apps/server/graph/.gitignore` placeholder so `apps/server/graph` is no longer part of the repository.
- Confirm there are no ignored local payloads or live references to the removed path.

## Design
This is a cleanup-only change: delete the tracked placeholder file instead of preserving the removed path with a parent ignore rule. Git then drops the empty directory naturally.

## Test plan
- `rg -n "apps/server/graph|server/graph|graph/" .gitignore apps/server/.gitignore apps/server scripts tools package.json README.md docs --glob "!node_modules/**" --glob "!third_party/**" --glob "!dist/**"`
- `bun run typecheck`
- `bun run lint`
- `bun run --filter @browseros/server test:root`