### PR TITLE
feat(agent): run the extension UI as a plain web page for e2e testing

### DIFF
--- a/packages/browseros-agent/apps/agent/package.json
+++ b/packages/browseros-agent/apps/agent/package.json
@@ -6,6 +6,9 @@
   "type": "module",
   "scripts": {
     "dev": "test -d generated/graphql || bun run codegen; mkdir -p /tmp/browseros-dev; bun --env-file=.env.development wxt",
+    "web": "bun run web:prepare; bun --env-file=.env.development vite --config web/vite.config.ts",
+    "web:build": "bun run web:prepare; vite build --config web/vite.config.ts",
+    "web:prepare": "test -d generated/graphql || bun run codegen; test -f .wxt/tsconfig.json || bun --env-file=.env.development wxt prepare",
     "build": "bun run codegen && wxt build",
     "build:dev": "bun --env-file=.env.development wxt build --mode development",
     "zip": "wxt zip",
@@ -114,10 +117,13 @@
     "@types/dagre": "^0.7.53",
     "@types/react": "^19.1.12",
     "@types/react-dom": "^19.1.9",
+    "@vitejs/plugin-react": "^5.1.2",
+    "@webext-core/fake-browser": "^1.3.4",
     "@wxt-dev/module-react": "^1.1.5",
     "lefthook": "^2.0.3",
     "tailwindcss": "^4.1.17",
     "typescript": "^5.9.2",
+    "vite": "^7.3.1",
     "wxt": "^0.20.18"
   },
   "trustedDependencies": [

--- a/packages/browseros-agent/apps/agent/styles/global.css
+++ b/packages/browseros-agent/apps/agent/styles/global.css
@@ -3,6 +3,15 @@
 @import "tailwind-scrollbar-hide/v4";
 @plugin "@tailwindcss/typography";
 
+/* Explicit Tailwind content sources. Needed so the web/ test harness — which
+   serves this CSS from a different Vite root (web/) — still detects utility
+   classes used across the app. No-op for the extension build, where these
+   dirs are already auto-detected from the app root. */
+@source "../entrypoints";
+@source "../components";
+@source "../hooks";
+@source "../lib";
+
 @custom-variant dark (&:is(.dark *));
 
 /* Geist Sans Variable Font */

--- a/packages/browseros-agent/apps/agent/web/README.md
+++ b/packages/browseros-agent/apps/agent/web/README.md
@@ -1,0 +1,61 @@
+# Web Harness — run the agent UI as a plain web page
+
+Runs the **exact** agent UI (`entrypoints/app`) as an ordinary web page on
+`http://localhost:5300`, connected to the **real** local `apps/server`. No
+extension load, no mocked agent — so it's a true integration target you can drive
+with an e2e tool.
+
+## How it works
+
+| Layer | Real or faked | Notes |
+|-------|---------------|-------|
+| React UI, transport (HTTP/SSE), agent loop, model, tools, operated browser | **Real** | Same code + server as production |
+| `chrome.storage` / `tabs` / `runtime` | Faked (in-memory, `@webext-core/fake-browser`) | Just so the app boots in a tab |
+| `chrome.browserOS` | Stub — **except** the MCP server port, which is real | Port comes from `VITE_BROWSEROS_MCP_PORT`; the rest are no-ops |
+
+The app derives its server URL from `chrome.browserOS.getPref('browseros.server.mcp_port')`
+(`lib/browseros/helpers.ts`). The shim returns the real port there, so the page hits
+the real server with **zero changes to app code**. No server change is needed: the
+server already trusts any `http://localhost:*` origin (`isTrustedAppOrigin`).
+
+Files:
+- `vite.config.ts` — standalone Vite server (port 5300) for `entrypoints/app`.
+- `shim.ts` — installs `fakeBrowser` as `globalThis.chrome`/`browser` + BrowserOS/sidePanel stubs.
+- `browseros-stub.ts` — localStorage-backed pref store (real port; provider config persists) + no-op browser-control methods.
+- `main.tsx` / `index.html` — thin web entry that loads the shim, then the real app bootstrap.
+- `e2e/chat.e2e.sh` — example `agent-browser` driver.
+
+## Run it
+
+```bash
+# 1. Start the real stack (BrowserOS + server). Note the MCP port it prints.
+bun run dev:watch
+
+# 2. Serve the web harness (from apps/agent). Pass the real port if not 9100.
+cd apps/agent
+VITE_BROWSEROS_MCP_PORT=<port> bun run web
+# → open http://localhost:5300
+```
+
+`import.meta.env.DEV` is `true` under `vite`, so all capability features are enabled
+and the UI renders without a login. For a chat to actually reply, configure an LLM
+provider/agent (same as normal dev) — you can do this in the web UI; provider prefs
+persist in `localStorage`.
+
+## Drive it (e2e)
+
+```bash
+# with the harness open and agent-browser installed:
+INPUT_REF=@e12 SEND_REF=@e15 bash web/e2e/chat.e2e.sh "go to example.com and tell me the title"
+```
+
+`agent-browser` is a real-browser CLI over CDP (it has a `-p browseros` provider). It
+opens the page, types, clicks, and reads rendered output — the e2e *driver*. (It is not
+the in-page `chrome.*` shim; that's `fakeBrowser` + the BrowserOS stub.)
+
+## Scope / limits (v1)
+
+- Browser-control `browserOS` calls (snapshot/click/screenshot) are no-ops on the page —
+  fine, because the agent's tools run server-side over the server's own CDP connection.
+- Content scripts, the background worker, scheduling, and the side panel are not part of
+  the web page; the core chat path doesn't need them.

--- a/packages/browseros-agent/apps/agent/web/browseros-stub.ts
+++ b/packages/browseros-agent/apps/agent/web/browseros-stub.ts
@@ -4,8 +4,15 @@
 
 const STORAGE_KEY = 'browseros:web-harness:prefs'
 const MCP_PORT_PREF = 'browseros.server.mcp_port'
+const DEFAULT_MCP_PORT = 9100
 
 type PrefObject = { key: string; type: string; value: unknown }
+
+// Resolve the real server port from the build env, tolerating unset/empty/NaN.
+function resolveMcpPort(): number {
+  const parsed = Number(import.meta.env.VITE_BROWSEROS_MCP_PORT)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : DEFAULT_MCP_PORT
+}
 
 function prefType(value: unknown): string {
   if (typeof value === 'number') return 'number'
@@ -29,9 +36,7 @@ class PrefStore {
     this.values = this.load()
     // seed the server port so getAgentServerUrl() resolves to the real server
     if (this.values[MCP_PORT_PREF] == null) {
-      this.values[MCP_PORT_PREF] = Number(
-        import.meta.env.VITE_BROWSEROS_MCP_PORT ?? 9100,
-      )
+      this.values[MCP_PORT_PREF] = resolveMcpPort()
       this.persist()
     }
   }

--- a/packages/browseros-agent/apps/agent/web/browseros-stub.ts
+++ b/packages/browseros-agent/apps/agent/web/browseros-stub.ts
@@ -1,0 +1,117 @@
+// In-memory + localStorage-backed stub for the custom `chrome.browserOS` API.
+// The agent UI talks to the real server, so the only call that must be truthful
+// is getPref('browseros.server.mcp_port') — everything else is a benign no-op.
+
+const STORAGE_KEY = 'browseros:web-harness:prefs'
+const MCP_PORT_PREF = 'browseros.server.mcp_port'
+
+type PrefObject = { key: string; type: string; value: unknown }
+
+function prefType(value: unknown): string {
+  if (typeof value === 'number') return 'number'
+  if (typeof value === 'boolean') return 'boolean'
+  if (typeof value === 'string') return 'string'
+  if (value == null) return 'none'
+  return 'dict'
+}
+
+// Calls the last argument if it is a callback, passing the given default result.
+// BrowserOS methods are callback-last across all their overloads.
+function respond(args: unknown[], result?: unknown): void {
+  const cb = args[args.length - 1]
+  if (typeof cb === 'function') (cb as (r: unknown) => void)(result)
+}
+
+class PrefStore {
+  private values: Record<string, unknown>
+
+  constructor() {
+    this.values = this.load()
+    // seed the server port so getAgentServerUrl() resolves to the real server
+    if (this.values[MCP_PORT_PREF] == null) {
+      this.values[MCP_PORT_PREF] = Number(
+        import.meta.env.VITE_BROWSEROS_MCP_PORT ?? 9100,
+      )
+      this.persist()
+    }
+  }
+
+  get(name: string): PrefObject {
+    const value = this.values[name]
+    return { key: name, type: prefType(value), value }
+  }
+
+  set(name: string, value: unknown): void {
+    this.values[name] = value
+    this.persist()
+  }
+
+  all(): PrefObject[] {
+    return Object.keys(this.values).map((key) => this.get(key))
+  }
+
+  private load(): Record<string, unknown> {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY)
+      return raw ? JSON.parse(raw) : {}
+    } catch {
+      return {}
+    }
+  }
+
+  private persist(): void {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(this.values))
+    } catch {
+      // ignore quota / unavailable storage
+    }
+  }
+}
+
+export function installBrowserOSStub(target: typeof chrome): void {
+  const store = new PrefStore()
+  const browserOS = {
+    // prefs — backed by a real (localStorage) store so provider config persists
+    getPref: (name: string, cb: (p: PrefObject) => void) => cb(store.get(name)),
+    setPref: (name: string, value: unknown, ...rest: unknown[]) => {
+      store.set(name, value)
+      respond(rest, true)
+    },
+    getAllPrefs: (cb: (p: PrefObject[]) => void) => cb(store.all()),
+    // versions — any string works; capabilities enables all features in dev anyway
+    getVersionNumber: (cb: (v: string) => void) => cb('140.0.0'),
+    getBrowserosVersionNumber: (cb: (v: string) => void) => cb('1.0.0'),
+    logMetric: (...a: unknown[]) => respond(a),
+    // browser-control methods — unused on the web page (tools run server-side);
+    // still invoke their callback so the adapter's typeof guards pass cleanly.
+    getPageLoadStatus: (...a: unknown[]) =>
+      respond(a, {
+        isResourcesLoading: false,
+        isDOMContentLoaded: true,
+        isPageComplete: true,
+      }),
+    getAccessibilityTree: (...a: unknown[]) =>
+      respond(a, { rootId: 0, nodes: {} }),
+    getInteractiveSnapshot: (...a: unknown[]) =>
+      respond(a, {
+        snapshotId: 0,
+        timestamp: 0,
+        elements: [],
+        processingTimeMs: 0,
+      }),
+    getSnapshot: (...a: unknown[]) => respond(a, { items: [] }),
+    captureScreenshot: (...a: unknown[]) => respond(a, ''),
+    click: (...a: unknown[]) => respond(a),
+    inputText: (...a: unknown[]) => respond(a),
+    clear: (...a: unknown[]) => respond(a),
+    scrollUp: (...a: unknown[]) => respond(a),
+    scrollDown: (...a: unknown[]) => respond(a),
+    scrollToNode: (...a: unknown[]) => respond(a, true),
+    sendKeys: (...a: unknown[]) => respond(a),
+    executeJavaScript: (...a: unknown[]) => respond(a, null),
+    clickCoordinates: (...a: unknown[]) => respond(a),
+    typeAtCoordinates: (...a: unknown[]) => respond(a),
+    choosePath: (...a: unknown[]) => respond(a, null),
+  }
+  ;(target as unknown as { browserOS: unknown }).browserOS = browserOS
+}

--- a/packages/browseros-agent/apps/agent/web/browseros-stub.ts
+++ b/packages/browseros-agent/apps/agent/web/browseros-stub.ts
@@ -34,11 +34,11 @@ class PrefStore {
 
   constructor() {
     this.values = this.load()
-    // seed the server port so getAgentServerUrl() resolves to the real server
-    if (this.values[MCP_PORT_PREF] == null) {
-      this.values[MCP_PORT_PREF] = resolveMcpPort()
-      this.persist()
-    }
+    // The server port is harness config, not user data — the env var always wins
+    // so a changed VITE_BROWSEROS_MCP_PORT takes effect even across reloads where
+    // an older port was persisted. Other prefs (e.g. providers) still persist.
+    this.values[MCP_PORT_PREF] = resolveMcpPort()
+    this.persist()
   }
 
   get(name: string): PrefObject {

--- a/packages/browseros-agent/apps/agent/web/e2e/chat.e2e.sh
+++ b/packages/browseros-agent/apps/agent/web/e2e/chat.e2e.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Example end-to-end drive of the web harness using the `agent-browser` CLI.
+#
+# Prereqs (see web/README.md):
+#   1. The real stack is running:  bun run dev:watch        (BrowserOS + server)
+#   2. The web harness is served:  cd apps/agent && bun run web   (http://localhost:5300)
+#   3. `agent-browser` is installed and its BrowserOS provider is reachable.
+#   4. At least one LLM provider/agent is configured (for a real reply).
+#
+# This is a starting point, not a strict assertion suite — adjust refs/selectors
+# to the current UI. `snapshot -i` prints @e refs; plug the right ones below.
+set -euo pipefail
+
+URL="${WEB_HARNESS_URL:-http://localhost:5300/#/home}"
+PROMPT="${1:-What is the title of example.com?}"
+P=(-p browseros) # use the BrowserOS provider
+
+echo "→ opening web harness: $URL"
+agent-browser "${P[@]}" tab new "$URL"
+agent-browser "${P[@]}" wait --load networkidle
+
+echo "→ snapshot (find the chat input + send button refs):"
+agent-browser "${P[@]}" snapshot -i
+
+# Replace @eINPUT / @eSEND with the refs printed above.
+: "${INPUT_REF:=@eINPUT}"
+: "${SEND_REF:=@eSEND}"
+
+echo "→ typing prompt into $INPUT_REF and sending via $SEND_REF"
+agent-browser "${P[@]}" fill "$INPUT_REF" "$PROMPT"
+agent-browser "${P[@]}" click "$SEND_REF"
+
+echo "→ waiting for the streamed reply to render"
+agent-browser "${P[@]}" wait --timeout 60000
+
+echo "→ captured page text (assert on this):"
+agent-browser "${P[@]}" eval "document.body.innerText" | tail -40

--- a/packages/browseros-agent/apps/agent/web/index.html
+++ b/packages/browseros-agent/apps/agent/web/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>BrowserOS Agent (Web Harness)</title>
+        <!-- No inline theme script here (the app's index.html has one): it would
+             run before the chrome shim is installed. ThemeProvider applies the
+             theme on mount instead. -->
+    </head>
+    <body class="bg-background h-screen w-screen">
+        <div id="root"></div>
+        <script type="module" src="./main.tsx"></script>
+    </body>
+</html>

--- a/packages/browseros-agent/apps/agent/web/main.tsx
+++ b/packages/browseros-agent/apps/agent/web/main.tsx
@@ -1,0 +1,6 @@
+// Install the chrome/browser shim BEFORE the real app bootstrap evaluates — app
+// modules touch chrome.* at import time (sentry, posthog, the BrowserOS adapter).
+// ES module evaluation is depth-first in source order, so './shim' fully runs
+// before '@/entrypoints/app/main' is evaluated.
+import './shim'
+import '@/entrypoints/app/main'

--- a/packages/browseros-agent/apps/agent/web/shim.ts
+++ b/packages/browseros-agent/apps/agent/web/shim.ts
@@ -1,0 +1,37 @@
+// Installs a fake `chrome`/`browser` global so the extension UI can boot as a
+// plain web page. `@webext-core/fake-browser` provides in-memory storage/tabs/
+// runtime; we add the custom BrowserOS + sidePanel surfaces on top.
+import { fakeBrowser } from '@webext-core/fake-browser'
+import { installBrowserOSStub } from './browseros-stub'
+
+// fake-browser keeps runtime.lastError set to a truthy { message: '' }. The
+// BrowserOS adapter treats any truthy lastError as a failure, so expose it as
+// undefined (no error) instead.
+try {
+  Object.defineProperty(fakeBrowser.runtime, 'lastError', {
+    get: () => undefined,
+    configurable: true,
+  })
+} catch {
+  ;(fakeBrowser.runtime as { lastError?: unknown }).lastError = undefined
+}
+
+// The app reads chrome.runtime.getManifest().version at startup (sentry, posthog).
+fakeBrowser.runtime.getManifest = () =>
+  ({
+    version: '0.0.0-web',
+    manifest_version: 3,
+    name: 'BrowserOS Assistant (web harness)',
+  }) as chrome.runtime.Manifest
+
+const chromeShim = fakeBrowser as unknown as typeof chrome
+installBrowserOSStub(chromeShim)
+// custom chrome.sidePanel.browseros* helpers used by the side-panel toggle util
+;(chromeShim as unknown as { sidePanel: unknown }).sidePanel = {
+  setOptions: () => Promise.resolve(),
+  browserosIsOpen: (cb: (open: boolean) => void) => cb(false),
+  browserosToggle: () => {},
+}
+
+;(globalThis as { chrome?: typeof chrome }).chrome = chromeShim
+;(globalThis as { browser?: unknown }).browser = fakeBrowser

--- a/packages/browseros-agent/apps/agent/web/vite.config.ts
+++ b/packages/browseros-agent/apps/agent/web/vite.config.ts
@@ -1,0 +1,27 @@
+import { resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import tailwindcss from '@tailwindcss/vite'
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'vite'
+
+// web/ → apps/agent (the real app root) → packages/shared/src
+const webDir = fileURLToPath(new URL('.', import.meta.url))
+const agentRoot = resolve(webDir, '..')
+const sharedSrc = resolve(agentRoot, '../../packages/shared/src')
+
+export default defineConfig({
+  root: webDir, // serve web/index.html
+  envDir: agentRoot, // load apps/agent/.env.development (VITE_PUBLIC_*)
+  server: { port: 5300, strictPort: true },
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: [
+      // WXT's #imports virtual module — only `storage` is imported from it
+      { find: '#imports', replacement: '@wxt-dev/storage' },
+      // mirror the WXT/tsconfig path aliases (@/* and ~/* → app root)
+      { find: /^@browseros\/shared\/(.*)$/, replacement: `${sharedSrc}/$1` },
+      { find: /^@\/(.*)$/, replacement: `${agentRoot}/$1` },
+      { find: /^~\/(.*)$/, replacement: `${agentRoot}/$1` },
+    ],
+  },
+})

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -119,10 +119,13 @@
         "@types/dagre": "^0.7.53",
         "@types/react": "^19.1.12",
         "@types/react-dom": "^19.1.9",
+        "@vitejs/plugin-react": "^5.1.2",
+        "@webext-core/fake-browser": "^1.3.4",
         "@wxt-dev/module-react": "^1.1.5",
         "lefthook": "^2.0.3",
         "tailwindcss": "^4.1.17",
         "typescript": "^5.9.2",
+        "vite": "^7.3.1",
         "wxt": "^0.20.18",
       },
     },
@@ -152,7 +155,7 @@
     },
     "apps/server": {
       "name": "@browseros/server",
-      "version": "0.0.94",
+      "version": "0.0.95",
       "bin": {
         "browseros-server": "./src/index.ts",
       },
@@ -2124,7 +2127,7 @@
 
     "chrome-devtools-frontend": ["chrome-devtools-frontend@1.0.1577886", "", {}, "sha512-B9hY3o/0RuVCDWNYh9YnkEbRrPUMCY+NaOgBxvZRzGvqbGSMNckkVSdO67SwWR8bm4fo/qplXbUj0cSr229V6w=="],
 
-    "chrome-devtools-mcp": ["chrome-devtools-mcp@1.0.1", "", { "bin": { "chrome-devtools-mcp": "build/src/bin/chrome-devtools-mcp.js", "chrome-devtools": "build/src/bin/chrome-devtools.js" } }, "sha512-h80dfsji5fHKoHce4fESVHHpx0jw18TyULDevLEpEsAFl92oy7DSR2l7gbRjGgRWETrtAENgT+7xotBv+7dkxg=="],
+    "chrome-devtools-mcp": ["chrome-devtools-mcp@1.1.1", "", { "bin": { "chrome-devtools-mcp": "build/src/bin/chrome-devtools-mcp.js", "chrome-devtools": "build/src/bin/chrome-devtools.js" } }, "sha512-Fs/ASXAkQqvYCbJjHIx/pnShjyIoZoPxdg4J3wjaA9FLkRb2ngGnisu2AGcBIXdw5qrPkOuV/cOlGOonpsE1qw=="],
 
     "chrome-launcher": ["chrome-launcher@1.2.0", "", { "dependencies": { "@types/node": "*", "escape-string-regexp": "^4.0.0", "is-wsl": "^2.2.0", "lighthouse-logger": "^2.0.1" }, "bin": { "print-chrome-path": "bin/print-chrome-path.cjs" } }, "sha512-JbuGuBNss258bvGil7FT4HKdC3SC2K7UAEUqiPy3ACS3Yxo3hAW6bvFpCu2HsIJLgTqxgEX6BkujvzZfLpUD0Q=="],
 
@@ -3106,7 +3109,7 @@
 
     "lowercase-keys": ["lowercase-keys@3.0.0", "", {}, "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ=="],
 
-    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "lucide-react": ["lucide-react@0.562.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-82hOAu7y0dbVuFfmO4bYF1XEwYk/mEbM5E+b1jgci/udUBEE/R7LF5Ip0CCEmXe8AybRM8L+04eP+LGZeDvkiw=="],
 
@@ -4368,8 +4371,6 @@
 
     "@babel/core/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
-    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
-
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "@better-auth/core/zod": ["zod@4.3.5", "", {}, "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g=="],
@@ -4946,6 +4947,8 @@
 
     "hoist-non-react-statics/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
+    "hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
     "html-to-text/htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
@@ -4967,6 +4970,8 @@
     "katex/commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
     "leva/zustand": ["zustand@3.7.2", "", { "peerDependencies": { "react": ">=16.8" }, "optionalPeers": ["react"] }, "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA=="],
+
+    "lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "magicast/@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
 
@@ -5023,6 +5028,8 @@
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
 
     "parse5/entities": ["entities@6.0.1", "", {}, "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g=="],
+
+    "path-scurry/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "pino/pino-abstract-transport": ["pino-abstract-transport@2.0.0", "", { "dependencies": { "split2": "^4.0.0" } }, "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw=="],
 
@@ -5149,8 +5156,6 @@
     "@aws-crypto/util/@aws-sdk/types/@smithy/types": ["@smithy/types@4.12.0", "", { "dependencies": { "tslib": "^2.6.2" } }, "sha512-9YcuJVTOBDjg9LWo23Qp0lTQ3D7fQsQtwle0jVfpbUHy9qBwCEgKuVH4FqFB3VYu0nwdHKiEMA+oXz7oV8X1kw=="],
 
     "@aws-crypto/util/@smithy/util-utf8/@smithy/util-buffer-from": ["@smithy/util-buffer-from@2.2.0", "", { "dependencies": { "@smithy/is-array-buffer": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA=="],
-
-    "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "@browseros/agent/@types/bun/bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 


### PR DESCRIPTION
## Summary
- Adds `apps/agent/web/` — a standalone Vite server (`localhost:5300`) that runs the **existing** extension UI (`entrypoints/app`) as a plain web page, no `chrome-extension://` load.
- Connects to the **real** `apps/server` over the production HTTP/SSE path — a true integration target (real UI + transport + agent loop + tools), with only boot-time `chrome.*` plumbing faked.
- Drivable by `agent-browser` for e2e; example script (`web/e2e/chat.e2e.sh`) + runbook (`web/README.md`) included.

## Design
The UI boots via a shim (`web/shim.ts`) that installs `@webext-core/fake-browser` as `globalThis.chrome`/`browser` (in-memory storage/tabs/runtime) plus a thin `chrome.browserOS` stub (`web/browseros-stub.ts`). The stub's only truthful call is `getPref('browseros.server.mcp_port')`, returning the real server port from `VITE_BROWSEROS_MCP_PORT` — so the app's existing `getAgentServerUrl()` resolution targets the real server with **zero app-code changes**. No server change was needed: `isTrustedAppOrigin` already trusts any `http://localhost:*` origin and CORS is permissive. `import.meta.env.DEV` (true under Vite) enables all capability features, so the UI renders without login. Production `entrypoints/app/*` are untouched; `web` scripts auto-run `codegen` + `wxt prepare` so the standalone build reuses WXT's exact TS setup.

## Test plan
- [ ] `bun run dev:watch` (real BrowserOS + server; note the MCP port)
- [ ] `cd apps/agent && VITE_BROWSEROS_MCP_PORT=<port> bun run web` → open http://localhost:5300 → agent UI renders
- [ ] Configure an LLM provider in the web UI, send a chat, confirm a streamed reply from the real server
- [ ] Drive `web/e2e/chat.e2e.sh` with `agent-browser` (fill refs from `snapshot -i`)

Verified locally: `vite build` passes; runtime boot via `agent-browser` mounts React and renders the real UI; `getPref(mcp_port)`→9100, `runtime.lastError`→undefined, `getManifest().version`→`0.0.0-web`; biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)