### PR TITLE
fix(agent): sandbox filesystem tool paths

### DIFF
--- a/packages/browseros-agent/apps/server/src/tools/filesystem/bash.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/bash.ts
@@ -1,9 +1,9 @@
-import { resolve } from 'node:path'
 import { tool } from 'ai'
 import { z } from 'zod'
 import {
   DEFAULT_BASH_TIMEOUT,
   executeWithMetrics,
+  resolveWorkspaceRoot,
   toModelOutput,
   truncateTail,
 } from './utils'
@@ -30,7 +30,7 @@ export function createBashTool(cwd: string) {
       executeWithMetrics(TOOL_NAME, async () => {
         const [shell, flag] = getShellArgs()
         const timeoutMs = (params.timeout || DEFAULT_BASH_TIMEOUT) * 1000
-        const resolvedCwd = resolve(cwd)
+        const resolvedCwd = await resolveWorkspaceRoot(cwd)
 
         const proc = Bun.spawn([shell, flag, params.command], {
           cwd: resolvedCwd,

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/edit.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/edit.ts
@@ -1,11 +1,11 @@
 import { readFile, writeFile } from 'node:fs/promises'
-import { resolve } from 'node:path'
 import { tool } from 'ai'
 import { z } from 'zod'
 import {
   detectLineEnding,
   executeWithMetrics,
   normalizeToLF,
+  resolveWorkspacePath,
   restoreLineEndings,
   stripBom,
   toModelOutput,
@@ -77,15 +77,13 @@ export function createEditTool(cwd: string) {
     description:
       'Make a targeted edit to a file by replacing an exact string match. The old_string must match exactly one location in the file. If exact match fails, a whitespace-tolerant match is attempted.',
     inputSchema: z.object({
-      path: z
-        .string()
-        .describe('File path (relative to working directory or absolute)'),
+      path: z.string().describe('File path within the working directory'),
       old_string: z.string().describe('Exact text to find in the file'),
       new_string: z.string().describe('Replacement text'),
     }),
     execute: (params) =>
       executeWithMetrics(TOOL_NAME, async () => {
-        const resolved = resolve(cwd, params.path)
+        const resolved = await resolveWorkspacePath(cwd, params.path)
         const raw = await readFile(resolved, 'utf-8')
 
         const { content: noBom, hasBom } = stripBom(raw)

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/find.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/find.ts
@@ -1,9 +1,10 @@
-import { resolve } from 'node:path'
 import { tool } from 'ai'
 import { z } from 'zod'
 import {
   DEFAULT_FIND_LIMIT,
   executeWithMetrics,
+  resolveWorkspacePath,
+  resolveWorkspaceRoot,
   toModelOutput,
   walkFiles,
 } from './utils'
@@ -23,7 +24,7 @@ export function createFindTool(cwd: string) {
       path: z
         .string()
         .optional()
-        .describe('Directory to search (default: working directory)'),
+        .describe('Directory within the working directory'),
       limit: z
         .number()
         .optional()
@@ -31,7 +32,8 @@ export function createFindTool(cwd: string) {
     }),
     execute: (params) =>
       executeWithMetrics(TOOL_NAME, async () => {
-        const searchPath = resolve(cwd, params.path || '.')
+        const searchPath = await resolveWorkspacePath(cwd, params.path || '.')
+        const workspaceRoot = await resolveWorkspaceRoot(cwd)
         const limit = params.limit || DEFAULT_FIND_LIMIT
 
         let effectivePattern = params.pattern
@@ -45,7 +47,11 @@ export function createFindTool(cwd: string) {
         const glob = new Bun.Glob(effectivePattern)
         const matches: string[] = []
 
-        for await (const relPath of walkFiles(searchPath, searchPath)) {
+        for await (const relPath of walkFiles(
+          searchPath,
+          searchPath,
+          workspaceRoot,
+        )) {
           if (glob.match(relPath)) {
             matches.push(relPath)
             if (matches.length >= limit) break

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/grep.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/grep.ts
@@ -1,5 +1,5 @@
 import { readFile, stat } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
+import { join } from 'node:path'
 import { tool } from 'ai'
 import { z } from 'zod'
 import {
@@ -8,6 +8,8 @@ import {
   GREP_MAX_LINE_LENGTH,
   isBinaryPath,
   MAX_GREP_FILE_SIZE,
+  resolveWorkspacePath,
+  resolveWorkspaceRoot,
   toModelOutput,
   truncateLine,
   walkFiles,
@@ -98,7 +100,7 @@ export function createGrepTool(cwd: string) {
       path: z
         .string()
         .optional()
-        .describe('Directory or file to search (default: working directory)'),
+        .describe('Directory or file within the working directory'),
       glob: z
         .string()
         .optional()
@@ -120,7 +122,8 @@ export function createGrepTool(cwd: string) {
     execute: (params) =>
       // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: grep tool has many output mode and filtering branches
       executeWithMetrics(TOOL_NAME, async () => {
-        const searchPath = resolve(cwd, params.path || '.')
+        const searchPath = await resolveWorkspacePath(cwd, params.path || '.')
+        const workspaceRoot = await resolveWorkspaceRoot(cwd)
         const limit = params.limit || DEFAULT_GREP_LIMIT
         const context = params.context || 0
 
@@ -173,7 +176,11 @@ export function createGrepTool(cwd: string) {
           allMatches.push(...fileMatches)
           totalMatchCount = fileMatches.filter((m) => m.isMatch).length
         } else {
-          for await (const relPath of walkFiles(searchPath, searchPath)) {
+          for await (const relPath of walkFiles(
+            searchPath,
+            searchPath,
+            workspaceRoot,
+          )) {
             if (isBinaryPath(relPath)) continue
             if (globMatcher && !globMatcher.match(relPath)) continue
 

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/ls.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/ls.ts
@@ -1,8 +1,13 @@
 import { readdir, stat } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
+import { join } from 'node:path'
 import { tool } from 'ai'
 import { z } from 'zod'
-import { DEFAULT_LS_LIMIT, executeWithMetrics, toModelOutput } from './utils'
+import {
+  DEFAULT_LS_LIMIT,
+  executeWithMetrics,
+  resolveWorkspacePath,
+  toModelOutput,
+} from './utils'
 
 const TOOL_NAME = 'filesystem_ls'
 
@@ -20,7 +25,7 @@ export function createLsTool(cwd: string) {
       path: z
         .string()
         .optional()
-        .describe('Directory path (default: working directory)'),
+        .describe('Directory path within the working directory'),
       limit: z
         .number()
         .optional()
@@ -28,7 +33,7 @@ export function createLsTool(cwd: string) {
     }),
     execute: (params) =>
       executeWithMetrics(TOOL_NAME, async () => {
-        const resolved = resolve(cwd, params.path || '.')
+        const resolved = await resolveWorkspacePath(cwd, params.path || '.')
         const limit = params.limit || DEFAULT_LS_LIMIT
         const entries = await readdir(resolved, { withFileTypes: true })
 

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/read.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/read.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises'
-import { extname, resolve } from 'node:path'
+import { extname } from 'node:path'
 import { tool } from 'ai'
 import { z } from 'zod'
 import {
@@ -9,6 +9,7 @@ import {
   IMAGE_MIME_TYPES,
   MAX_READ_CHARS,
   MAX_READ_LINES,
+  resolveWorkspacePath,
   toModelOutput,
 } from './utils'
 
@@ -99,9 +100,7 @@ export function createReadTool(cwd: string) {
   return tool({
     description: `Read a file from the filesystem. Returns text content with line numbers, or image data for image files. Text reads are limited to ${MAX_READ_LINES} lines and ${MAX_READ_CHARS} characters per call. Use offset and limit to paginate through large files.`,
     inputSchema: z.object({
-      path: z
-        .string()
-        .describe('File path (relative to working directory or absolute)'),
+      path: z.string().describe('File path within the working directory'),
       offset: z
         .number()
         .optional()
@@ -115,7 +114,7 @@ export function createReadTool(cwd: string) {
     }),
     execute: (params) =>
       executeWithMetrics(TOOL_NAME, async () => {
-        const resolved = resolve(cwd, params.path)
+        const resolved = await resolveWorkspacePath(cwd, params.path)
         const ext = extname(resolved).toLowerCase()
 
         if (IMAGE_EXTENSIONS.has(ext)) {

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/utils.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/utils.ts
@@ -1,6 +1,6 @@
 import type { Dirent } from 'node:fs'
-import { readdir } from 'node:fs/promises'
-import { join, relative } from 'node:path'
+import { lstat, readdir, realpath } from 'node:fs/promises'
+import { dirname, isAbsolute, join, relative, resolve } from 'node:path'
 import { TOOL_LIMITS } from '@browseros/shared/constants/limits'
 import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
@@ -27,6 +27,66 @@ export interface TruncationResult {
   truncated: boolean
   totalLines: number
   keptLines: number
+}
+
+export const WORKSPACE_PATH_ERROR = 'Path is outside the allowed workspace.'
+
+function isInsideOrEqual(root: string, path: string): boolean {
+  const rel = relative(root, path)
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel))
+}
+
+async function pathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path)
+    return true
+  } catch {
+    return false
+  }
+}
+
+async function nearestExistingPath(path: string): Promise<string> {
+  let current = path
+  while (!(await pathExists(current))) {
+    const parent = dirname(current)
+    if (parent === current) return current
+    current = parent
+  }
+  return current
+}
+
+export async function resolveWorkspaceRoot(cwd: string): Promise<string> {
+  return realpath(resolve(cwd))
+}
+
+export async function resolveWorkspacePath(
+  cwd: string,
+  userPath: string,
+): Promise<string> {
+  const workspacePath = resolve(cwd)
+  const workspaceRoot = await resolveWorkspaceRoot(cwd)
+  const requestedPath = resolve(workspacePath, userPath || '.')
+
+  if (
+    !isInsideOrEqual(workspacePath, requestedPath) &&
+    !isInsideOrEqual(workspaceRoot, requestedPath)
+  ) {
+    throw new Error(WORKSPACE_PATH_ERROR)
+  }
+
+  const existingPath = await nearestExistingPath(requestedPath)
+  let realExistingPath: string
+  try {
+    realExistingPath = await realpath(existingPath)
+  } catch {
+    throw new Error(WORKSPACE_PATH_ERROR)
+  }
+
+  if (!isInsideOrEqual(workspaceRoot, realExistingPath)) {
+    throw new Error(WORKSPACE_PATH_ERROR)
+  }
+
+  return requestedPath
 }
 
 export function truncateHead(
@@ -204,9 +264,10 @@ export const IMAGE_MIME_TYPES: Record<string, string> = {
   '.ico': 'image/x-icon',
 }
 
-export async function* walkFiles(
+async function* walkFilesWithinBoundary(
   dir: string,
   baseDir: string,
+  boundaryRoot: string,
 ): AsyncGenerator<string> {
   let entries: Dirent[]
   try {
@@ -219,11 +280,34 @@ export async function* walkFiles(
     const fullPath = join(dir, entry.name as string)
     if (entry.isDirectory()) {
       if (IGNORED_DIRS.has(entry.name as string)) continue
-      yield* walkFiles(fullPath, baseDir)
+      yield* walkFilesWithinBoundary(fullPath, baseDir, boundaryRoot)
     } else if (entry.isFile() || entry.isSymbolicLink()) {
+      if (entry.isSymbolicLink()) {
+        let target: string
+        try {
+          target = await realpath(fullPath)
+        } catch {
+          continue
+        }
+        if (!isInsideOrEqual(boundaryRoot, target)) continue
+      }
       yield relative(baseDir, fullPath)
     }
   }
+}
+
+export async function* walkFiles(
+  dir: string,
+  baseDir: string,
+  boundaryDir = baseDir,
+): AsyncGenerator<string> {
+  let boundaryRoot: string
+  try {
+    boundaryRoot = await realpath(boundaryDir)
+  } catch {
+    return
+  }
+  yield* walkFilesWithinBoundary(dir, baseDir, boundaryRoot)
 }
 
 export function toModelOutput({

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/write.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/write.ts
@@ -1,8 +1,12 @@
 import { mkdir, writeFile } from 'node:fs/promises'
-import { dirname, resolve } from 'node:path'
+import { dirname } from 'node:path'
 import { tool } from 'ai'
 import { z } from 'zod'
-import { executeWithMetrics, toModelOutput } from './utils'
+import {
+  executeWithMetrics,
+  resolveWorkspacePath,
+  toModelOutput,
+} from './utils'
 
 const TOOL_NAME = 'filesystem_write'
 
@@ -11,15 +15,14 @@ export function createWriteTool(cwd: string) {
     description:
       "Create or overwrite a file. Automatically creates parent directories if they don't exist. Use this to create new files or completely replace file contents.",
     inputSchema: z.object({
-      path: z
-        .string()
-        .describe('File path (relative to working directory or absolute)'),
+      path: z.string().describe('File path within the working directory'),
       content: z.string().describe('Complete file content to write'),
     }),
     execute: (params) =>
       executeWithMetrics(TOOL_NAME, async () => {
-        const resolved = resolve(cwd, params.path)
+        const resolved = await resolveWorkspacePath(cwd, params.path)
         await mkdir(dirname(resolved), { recursive: true })
+        await resolveWorkspacePath(cwd, dirname(resolved))
         await writeFile(resolved, params.content, 'utf-8')
         const bytes = Buffer.byteLength(params.content, 'utf-8')
         return { text: `Wrote ${bytes} bytes to ${params.path}` }

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/edit.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/edit.test.ts
@@ -1,19 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createEditTool } from '../../../src/tools/filesystem/edit'
 import type { FilesystemToolResult } from '../../../src/tools/filesystem/utils'
+import { WORKSPACE_PATH_ERROR } from '../../../src/tools/filesystem/utils'
 
 let tmpDir: string
+let outsideDir: string
 let exec: (params: Record<string, unknown>) => Promise<FilesystemToolResult>
 
 beforeEach(async () => {
-  tmpDir = join(
-    tmpdir(),
-    `fs-edit-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-  )
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  tmpDir = join(tmpdir(), `fs-edit-test-${suffix}`)
+  outsideDir = join(tmpdir(), `fs-edit-outside-${suffix}`)
   await mkdir(tmpDir, { recursive: true })
+  await mkdir(outsideDir, { recursive: true })
   const tool = createEditTool(tmpDir)
   // biome-ignore lint/suspicious/noExplicitAny: test helper
   exec = (params) => (tool as any).execute(params)
@@ -21,6 +23,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await rm(tmpDir, { recursive: true, force: true })
+  await rm(outsideDir, { recursive: true, force: true })
 })
 
 describe('filesystem_edit', () => {
@@ -82,6 +85,33 @@ describe('filesystem_edit', () => {
       new_string: 'y',
     })
     expect(result.isError).toBe(true)
+  })
+
+  it('rejects parent traversal outside the workspace', async () => {
+    const result = await exec({
+      path: '../escaped.ts',
+      old_string: 'x',
+      new_string: 'y',
+    })
+
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain(WORKSPACE_PATH_ERROR)
+  })
+
+  it('rejects editing symlinked files outside the workspace', async () => {
+    const outsideFile = join(outsideDir, 'secret.ts')
+    await writeFile(outsideFile, 'const secret = true')
+    await symlink(outsideFile, join(tmpDir, 'secret-link.ts'))
+
+    const result = await exec({
+      path: 'secret-link.ts',
+      old_string: 'true',
+      new_string: 'false',
+    })
+
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain(WORKSPACE_PATH_ERROR)
+    expect(await readFile(outsideFile, 'utf-8')).toBe('const secret = true')
   })
 
   it('performs fuzzy match when whitespace differs', async () => {

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/find.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/find.test.ts
@@ -1,19 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createFindTool } from '../../../src/tools/filesystem/find'
 import type { FilesystemToolResult } from '../../../src/tools/filesystem/utils'
+import { WORKSPACE_PATH_ERROR } from '../../../src/tools/filesystem/utils'
 
 let tmpDir: string
+let outsideDir: string
 let exec: (params: Record<string, unknown>) => Promise<FilesystemToolResult>
 
 beforeEach(async () => {
-  tmpDir = join(
-    tmpdir(),
-    `fs-find-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-  )
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  tmpDir = join(tmpdir(), `fs-find-test-${suffix}`)
+  outsideDir = join(tmpdir(), `fs-find-outside-${suffix}`)
   await mkdir(tmpDir, { recursive: true })
+  await mkdir(outsideDir, { recursive: true })
   const tool = createFindTool(tmpDir)
   // biome-ignore lint/suspicious/noExplicitAny: test helper
   exec = (params) => (tool as any).execute(params)
@@ -21,6 +23,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await rm(tmpDir, { recursive: true, force: true })
+  await rm(outsideDir, { recursive: true, force: true })
 })
 
 async function createFileTree() {
@@ -93,6 +96,13 @@ describe('filesystem_find', () => {
     expect(result.text).toContain('modal.tsx')
   })
 
+  it('rejects paths outside the workspace', async () => {
+    const result = await exec({ pattern: '*', path: outsideDir })
+
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain(WORKSPACE_PATH_ERROR)
+  })
+
   it('skips node_modules', async () => {
     await mkdir(join(tmpDir, 'node_modules', 'pkg'), { recursive: true })
     await writeFile(join(tmpDir, 'node_modules', 'pkg', 'index.js'), '')
@@ -133,5 +143,16 @@ describe('filesystem_find', () => {
     await createFileTree()
     const result = await exec({ pattern: '*.json' })
     expect(result.text).toContain('package.json')
+  })
+
+  it('does not return symlinked files outside the workspace', async () => {
+    await writeFile(join(outsideDir, 'secret.txt'), 'secret')
+    await writeFile(join(tmpDir, 'visible.txt'), '')
+    await symlink(join(outsideDir, 'secret.txt'), join(tmpDir, 'secret.txt'))
+
+    const result = await exec({ pattern: '*.txt' })
+
+    expect(result.text).toContain('visible.txt')
+    expect(result.text).not.toContain('secret.txt')
   })
 })

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/grep.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/grep.test.ts
@@ -1,19 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createGrepTool } from '../../../src/tools/filesystem/grep'
 import type { FilesystemToolResult } from '../../../src/tools/filesystem/utils'
+import { WORKSPACE_PATH_ERROR } from '../../../src/tools/filesystem/utils'
 
 let tmpDir: string
+let outsideDir: string
 let exec: (params: Record<string, unknown>) => Promise<FilesystemToolResult>
 
 beforeEach(async () => {
-  tmpDir = join(
-    tmpdir(),
-    `fs-grep-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-  )
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  tmpDir = join(tmpdir(), `fs-grep-test-${suffix}`)
+  outsideDir = join(tmpdir(), `fs-grep-outside-${suffix}`)
   await mkdir(tmpDir, { recursive: true })
+  await mkdir(outsideDir, { recursive: true })
   const tool = createGrepTool(tmpDir)
   // biome-ignore lint/suspicious/noExplicitAny: test helper
   exec = (params) => (tool as any).execute(params)
@@ -21,6 +23,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await rm(tmpDir, { recursive: true, force: true })
+  await rm(outsideDir, { recursive: true, force: true })
 })
 
 async function createTestFiles() {
@@ -138,6 +141,39 @@ describe('filesystem_grep', () => {
     const result = await exec({ pattern: 'beta', path: 'single.txt' })
     expect(result.text).toContain('beta')
     expect(result.text).not.toContain('alpha')
+  })
+
+  it('rejects paths outside the workspace', async () => {
+    await writeFile(join(outsideDir, 'secret.txt'), 'secret')
+
+    const result = await exec({ pattern: 'secret', path: outsideDir })
+
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain(WORKSPACE_PATH_ERROR)
+  })
+
+  it('rejects direct symlinked files outside the workspace', async () => {
+    const outsideFile = join(outsideDir, 'secret.txt')
+    await writeFile(outsideFile, 'secret')
+    await symlink(outsideFile, join(tmpDir, 'secret-link.txt'))
+
+    const result = await exec({ pattern: 'secret', path: 'secret-link.txt' })
+
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain(WORKSPACE_PATH_ERROR)
+  })
+
+  it('skips symlinked files outside the workspace during recursive search', async () => {
+    const outsideFile = join(outsideDir, 'secret.txt')
+    await writeFile(outsideFile, 'secret')
+    await writeFile(join(tmpDir, 'visible.txt'), 'secret')
+    await symlink(outsideFile, join(tmpDir, 'secret-link.txt'))
+
+    const result = await exec({ pattern: 'secret' })
+
+    expect(result.isError).toBeUndefined()
+    expect(result.text).toContain('visible.txt')
+    expect(result.text).not.toContain('secret-link.txt')
   })
 
   it('handles regex special characters', async () => {

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/ls.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/ls.test.ts
@@ -1,19 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createLsTool } from '../../../src/tools/filesystem/ls'
 import type { FilesystemToolResult } from '../../../src/tools/filesystem/utils'
+import { WORKSPACE_PATH_ERROR } from '../../../src/tools/filesystem/utils'
 
 let tmpDir: string
+let outsideDir: string
 let exec: (params: Record<string, unknown>) => Promise<FilesystemToolResult>
 
 beforeEach(async () => {
-  tmpDir = join(
-    tmpdir(),
-    `fs-ls-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-  )
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  tmpDir = join(tmpdir(), `fs-ls-test-${suffix}`)
+  outsideDir = join(tmpdir(), `fs-ls-outside-${suffix}`)
   await mkdir(tmpDir, { recursive: true })
+  await mkdir(outsideDir, { recursive: true })
   const tool = createLsTool(tmpDir)
   // biome-ignore lint/suspicious/noExplicitAny: test helper
   exec = (params) => (tool as any).execute(params)
@@ -21,6 +23,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await rm(tmpDir, { recursive: true, force: true })
+  await rm(outsideDir, { recursive: true, force: true })
 })
 
 describe('filesystem_ls', () => {
@@ -100,9 +103,28 @@ describe('filesystem_ls', () => {
     expect(result.text).toContain('MB')
   })
 
-  it('handles absolute path', async () => {
+  it('handles absolute paths inside the workspace', async () => {
     await writeFile(join(tmpDir, 'abs.txt'), 'data')
     const result = await exec({ path: tmpDir })
     expect(result.text).toContain('abs.txt')
+  })
+
+  it('rejects absolute paths outside the workspace', async () => {
+    await writeFile(join(outsideDir, 'secret.txt'), 'secret')
+
+    const result = await exec({ path: outsideDir })
+
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain(WORKSPACE_PATH_ERROR)
+  })
+
+  it('rejects symlinked directories outside the workspace', async () => {
+    await writeFile(join(outsideDir, 'secret.txt'), 'secret')
+    await symlink(outsideDir, join(tmpDir, 'external-dir'), 'dir')
+
+    const result = await exec({ path: 'external-dir' })
+
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain(WORKSPACE_PATH_ERROR)
   })
 })

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/read.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/read.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { createReadTool } from '../../../src/tools/filesystem/read'
@@ -7,17 +7,19 @@ import type { FilesystemToolResult } from '../../../src/tools/filesystem/utils'
 import {
   MAX_READ_CHARS,
   MAX_READ_LINES,
+  WORKSPACE_PATH_ERROR,
 } from '../../../src/tools/filesystem/utils'
 
 let tmpDir: string
+let outsideDir: string
 let exec: (params: Record<string, unknown>) => Promise<FilesystemToolResult>
 
 beforeEach(async () => {
-  tmpDir = join(
-    tmpdir(),
-    `fs-read-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-  )
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  tmpDir = join(tmpdir(), `fs-read-test-${suffix}`)
+  outsideDir = join(tmpdir(), `fs-read-outside-${suffix}`)
   await mkdir(tmpDir, { recursive: true })
+  await mkdir(outsideDir, { recursive: true })
   const tool = createReadTool(tmpDir)
   // biome-ignore lint/suspicious/noExplicitAny: test helper
   exec = (params) => (tool as any).execute(params)
@@ -25,6 +27,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await rm(tmpDir, { recursive: true, force: true })
+  await rm(outsideDir, { recursive: true, force: true })
 })
 
 describe('filesystem_read', () => {
@@ -101,11 +104,38 @@ describe('filesystem_read', () => {
     expect(result.text).toContain('nested content')
   })
 
-  it('handles absolute paths', async () => {
+  it('handles absolute paths inside the workspace', async () => {
     const absPath = join(tmpDir, 'abs.txt')
     await writeFile(absPath, 'absolute')
     const result = await exec({ path: absPath })
     expect(result.text).toContain('absolute')
+  })
+
+  it('rejects parent traversal outside the workspace', async () => {
+    const result = await exec({ path: '../secret.txt' })
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain(WORKSPACE_PATH_ERROR)
+  })
+
+  it('rejects absolute paths outside the workspace', async () => {
+    const outsideFile = join(outsideDir, 'secret.txt')
+    await writeFile(outsideFile, 'secret')
+
+    const result = await exec({ path: outsideFile })
+
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain(WORKSPACE_PATH_ERROR)
+  })
+
+  it('rejects symlinked files outside the workspace', async () => {
+    const outsideFile = join(outsideDir, 'secret.txt')
+    await writeFile(outsideFile, 'secret')
+    await symlink(outsideFile, join(tmpDir, 'secret-link.txt'))
+
+    const result = await exec({ path: 'secret-link.txt' })
+
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain(WORKSPACE_PATH_ERROR)
   })
 
   it('errors when a read would exceed the line limit', async () => {

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/utils.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/utils.test.ts
@@ -1,16 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, realpath, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   detectLineEnding,
   isBinaryPath,
   normalizeToLF,
+  resolveWorkspacePath,
+  resolveWorkspaceRoot,
   restoreLineEndings,
   stripBom,
   truncateHead,
   truncateLine,
   truncateTail,
+  WORKSPACE_PATH_ERROR,
   walkFiles,
 } from '../../../src/tools/filesystem/utils'
 
@@ -163,19 +166,105 @@ describe('isBinaryPath', () => {
   })
 })
 
-describe('walkFiles', () => {
+describe('resolveWorkspacePath', () => {
   let tmpDir: string
+  let outsideDir: string
 
   beforeEach(async () => {
-    tmpDir = join(
-      tmpdir(),
-      `fs-walk-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-    )
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+    tmpDir = join(tmpdir(), `fs-path-test-${suffix}`)
+    outsideDir = join(tmpdir(), `fs-path-outside-${suffix}`)
     await mkdir(tmpDir, { recursive: true })
+    await mkdir(outsideDir, { recursive: true })
   })
 
   afterEach(async () => {
     await rm(tmpDir, { recursive: true, force: true })
+    await rm(outsideDir, { recursive: true, force: true })
+  })
+
+  it('resolves relative paths inside the workspace', async () => {
+    await writeFile(join(tmpDir, 'inside.txt'), 'ok')
+
+    const resolved = await resolveWorkspacePath(tmpDir, 'inside.txt')
+
+    expect(resolved).toBe(join(tmpDir, 'inside.txt'))
+  })
+
+  it('allows absolute paths inside the workspace', async () => {
+    const filePath = join(tmpDir, 'absolute.txt')
+    await writeFile(filePath, 'ok')
+
+    const resolved = await resolveWorkspacePath(tmpDir, filePath)
+
+    expect(resolved).toBe(filePath)
+  })
+
+  it('rejects parent traversal outside the workspace', async () => {
+    await expect(
+      resolveWorkspacePath(tmpDir, '../outside.txt'),
+    ).rejects.toThrow(WORKSPACE_PATH_ERROR)
+  })
+
+  it('rejects absolute paths outside the workspace', async () => {
+    const filePath = join(outsideDir, 'secret.txt')
+    await writeFile(filePath, 'secret')
+
+    await expect(resolveWorkspacePath(tmpDir, filePath)).rejects.toThrow(
+      WORKSPACE_PATH_ERROR,
+    )
+  })
+
+  it('rejects symlinked files outside the workspace', async () => {
+    const filePath = join(outsideDir, 'secret.txt')
+    await writeFile(filePath, 'secret')
+    await symlink(filePath, join(tmpDir, 'secret-link.txt'))
+
+    await expect(
+      resolveWorkspacePath(tmpDir, 'secret-link.txt'),
+    ).rejects.toThrow(WORKSPACE_PATH_ERROR)
+  })
+
+  it('rejects symlinked directories outside the workspace', async () => {
+    await symlink(outsideDir, join(tmpDir, 'external-dir'), 'dir')
+
+    await expect(
+      resolveWorkspacePath(tmpDir, 'external-dir/new.txt'),
+    ).rejects.toThrow(WORKSPACE_PATH_ERROR)
+  })
+
+  it('allows symlinked files that stay inside the workspace', async () => {
+    const filePath = join(tmpDir, 'target.txt')
+    await writeFile(filePath, 'ok')
+    await symlink(filePath, join(tmpDir, 'target-link.txt'))
+
+    const resolved = await resolveWorkspacePath(tmpDir, 'target-link.txt')
+
+    expect(resolved).toBe(join(tmpDir, 'target-link.txt'))
+  })
+
+  it('resolves the workspace root through symlinks', async () => {
+    const root = await resolveWorkspaceRoot(tmpDir)
+
+    expect(root).toBe(await realpath(tmpDir))
+  })
+})
+
+describe('walkFiles', () => {
+  let tmpDir: string
+  let outsideDir: string
+
+  beforeEach(async () => {
+    const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+    tmpDir = join(tmpdir(), `fs-walk-test-${suffix}`)
+    outsideDir = join(tmpdir(), `fs-walk-outside-${suffix}`)
+    await mkdir(tmpDir, { recursive: true })
+    await mkdir(outsideDir, { recursive: true })
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+    await rm(outsideDir, { recursive: true, force: true })
   })
 
   it('walks files recursively', async () => {
@@ -233,5 +322,20 @@ describe('walkFiles', () => {
       files.push(f)
     }
     expect(files.length).toBe(0)
+  })
+
+  it('skips symlinks that resolve outside the boundary', async () => {
+    const outsideFile = join(outsideDir, 'secret.txt')
+    await writeFile(outsideFile, 'secret')
+    await symlink(outsideFile, join(tmpDir, 'secret-link.txt'))
+    await writeFile(join(tmpDir, 'visible.txt'), '')
+
+    const files: string[] = []
+    for await (const f of walkFiles(tmpDir, tmpDir, tmpDir)) {
+      files.push(f)
+    }
+
+    expect(files).toContain('visible.txt')
+    expect(files).not.toContain('secret-link.txt')
   })
 })

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/write.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/write.test.ts
@@ -1,19 +1,21 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdir, readFile, rm, stat } from 'node:fs/promises'
+import { mkdir, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { FilesystemToolResult } from '../../../src/tools/filesystem/utils'
+import { WORKSPACE_PATH_ERROR } from '../../../src/tools/filesystem/utils'
 import { createWriteTool } from '../../../src/tools/filesystem/write'
 
 let tmpDir: string
+let outsideDir: string
 let exec: (params: Record<string, unknown>) => Promise<FilesystemToolResult>
 
 beforeEach(async () => {
-  tmpDir = join(
-    tmpdir(),
-    `fs-write-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
-  )
+  const suffix = `${Date.now()}-${Math.random().toString(36).slice(2)}`
+  tmpDir = join(tmpdir(), `fs-write-test-${suffix}`)
+  outsideDir = join(tmpdir(), `fs-write-outside-${suffix}`)
   await mkdir(tmpDir, { recursive: true })
+  await mkdir(outsideDir, { recursive: true })
   const tool = createWriteTool(tmpDir)
   // biome-ignore lint/suspicious/noExplicitAny: test helper
   exec = (params) => (tool as any).execute(params)
@@ -21,6 +23,7 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await rm(tmpDir, { recursive: true, force: true })
+  await rm(outsideDir, { recursive: true, force: true })
 })
 
 describe('filesystem_write', () => {
@@ -76,12 +79,59 @@ describe('filesystem_write', () => {
     expect(written).toBe(content)
   })
 
-  it('handles absolute paths', async () => {
+  it('handles absolute paths inside the workspace', async () => {
     const absPath = join(tmpDir, 'absolute.txt')
     const result = await exec({ path: absPath, content: 'abs content' })
     expect(result.isError).toBeUndefined()
 
     const content = await readFile(absPath, 'utf-8')
     expect(content).toBe('abs content')
+  })
+
+  it('rejects parent traversal outside the workspace', async () => {
+    const result = await exec({
+      path: '../escaped.txt',
+      content: 'should not write',
+    })
+
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain(WORKSPACE_PATH_ERROR)
+  })
+
+  it('rejects absolute paths outside the workspace', async () => {
+    const result = await exec({
+      path: join(outsideDir, 'secret.txt'),
+      content: 'should not write',
+    })
+
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain(WORKSPACE_PATH_ERROR)
+  })
+
+  it('rejects writes through symlinked directories outside the workspace', async () => {
+    await symlink(outsideDir, join(tmpDir, 'external-dir'), 'dir')
+
+    const result = await exec({
+      path: 'external-dir/secret.txt',
+      content: 'should not write',
+    })
+
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain(WORKSPACE_PATH_ERROR)
+  })
+
+  it('rejects overwriting symlinked files outside the workspace', async () => {
+    const outsideFile = join(outsideDir, 'secret.txt')
+    await writeFile(outsideFile, 'original')
+    await symlink(outsideFile, join(tmpDir, 'secret-link.txt'))
+
+    const result = await exec({
+      path: 'secret-link.txt',
+      content: 'changed',
+    })
+
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain(WORKSPACE_PATH_ERROR)
+    expect(await readFile(outsideFile, 'utf-8')).toBe('original')
   })
 })


### PR DESCRIPTION
## Summary

Adds workspace boundary enforcement for BrowserOS filesystem tools so agent-accessible file operations cannot escape the configured workspace through parent traversal, outside absolute paths, or symlink escapes.

## Changes

- Add shared workspace path validation for filesystem tools.
- Reject paths outside the tool workspace.
- Block symlink escapes using realpath checks.
- Validate write parent directories before writing.
- Harden recursive find/grep walks against escaped symlinks.
- Update filesystem tool path descriptions.
- Add tests for traversal, absolute outside paths, symlinked files/directories, and mutation safety.

## Testing

- `bun run --filter @browseros/server test:tools:filesystem` passed: 135 tests
- `bun run --filter @browseros/server typecheck` passed
- Biome check on changed files passed
- `git diff --check` passed