### PR TITLE
chore(release): bump server to v0.0.98 for clean R2 publish

### DIFF
--- a/packages/browseros-agent/apps/server/package.json
+++ b/packages/browseros-agent/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browseros/server",
-  "version": "0.0.97",
+  "version": "0.0.98",
   "description": "BrowserOS server",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -152,7 +152,7 @@
     },
     "apps/server": {
       "name": "@browseros/server",
-      "version": "0.0.97",
+      "version": "0.0.98",
       "bin": {
         "browseros-server": "./src/index.ts",
       },


### PR DESCRIPTION
## Summary
- Bump `@browseros/server` version `0.0.97 → 0.0.98` so the next release publishes a **new** versioned artifact to Cloudflare R2 instead of overwriting the already-published `0.0.97`.
- Updated `apps/server/package.json` and `bun.lock` in lockstep (matching the canonical bump shape of prior commit `2403c0d9`).

## Design
The release pipeline treats `apps/server/package.json#version` as the single source of truth: `nightly-macos-build.yml` reads it and passes it to `release-server.yml`, which re-reads the same file and fails the build if they disagree. `scripts/build/server/{config.ts,archive.ts}` read the same field and derive the R2 object keys — `artifacts/server/latest/…` (always overwritten) and `artifacts/server/<version>/…`. Bumping the one field is therefore sufficient and complete: a re-run at `0.0.97` would mutate the published `0.0.97/` objects, whereas `0.0.98` creates a fresh versioned key and cleanly repoints `latest/`.

The `"…(e.g. 0.0.97)"` strings in `release-server.yml` are input description doc-text, not functional defaults, so they are intentionally left untouched.

## Test plan
- [x] `apps/server/package.json` and `bun.lock` both read `0.0.98` (no `0.0.97` remaining)
- [x] `bun install --frozen-lockfile` → "no changes" (lockfile consistent)
- [x] `bun run typecheck` → green
- [x] `bun test scripts/build/server/stage.test.ts` → 11 pass
- [x] Adversarial review (2 rounds) → clean
- [ ] Confirm release-gating precondition (CLAUDE.md bundled-VM/WS6) is satisfied before an actual publish