### PR TITLE
feat(release): auto-bump server version each nightly build

### DIFF
--- a/.github/workflows/nightly-macos-build.yml
+++ b/.github/workflows/nightly-macos-build.yml
@@ -137,6 +137,7 @@ jobs:
     uses: ./.github/workflows/release-server.yml
     with:
       version: ${{ needs.resolve_inputs.outputs.server_version }}
+      apply_bump: ${{ needs.resolve_inputs.outputs.bump_mode != 'none' }}
       targets: darwin-arm64
       publish_github_release: false
     secrets: inherit
@@ -231,20 +232,43 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Built version: $version"
 
+      - name: Apply server version bump
+        if: ${{ needs.resolve_inputs.outputs.release_server == 'true' && needs.release_server.outputs.server_version != '' }}
+        env:
+          BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
+          SERVER_VERSION: ${{ needs.release_server.outputs.server_version }}
+        run: |
+          set -euo pipefail
+          cd "$BROWSEROS_REPO/packages/browseros"
+          uv run python build/scripts/bump_server_version.py --set "$SERVER_VERSION"
+          echo "Applied server version $SERVER_VERSION to the build working tree"
+
       - name: Commit version bump via pull request
         if: ${{ steps.build_inputs.outputs.commit_version == 'true' }}
         env:
           BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
           TARGET_REF: ${{ steps.build_inputs.outputs.target_ref }}
           VERSION: ${{ steps.bump.outputs.version }}
+          RELEASE_SERVER: ${{ needs.resolve_inputs.outputs.release_server }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail
           cd "$BROWSEROS_REPO"
-          git add packages/browseros/resources/BROWSEROS_VERSION \
+          version_files=(
+            packages/browseros/resources/BROWSEROS_VERSION
             packages/browseros/build/config/BROWSEROS_BUILD_OFFSET
+          )
+          # When the server was released this run, fold its bumped version into the
+          # same PR so the browser and server versions land together.
+          if [ "$RELEASE_SERVER" = "true" ]; then
+            version_files+=(
+              packages/browseros-agent/apps/server/package.json
+              packages/browseros-agent/bun.lock
+            )
+          fi
+          git add "${version_files[@]}"
           if git diff --cached --quiet; then
             echo "No version changes to commit."
             exit 0

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -29,7 +29,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version (e.g. 0.0.97)"
+        description: "Release version (e.g. 0.0.97). Ignored when apply_bump is true."
         required: true
         type: string
       apply_bump:

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -4,9 +4,14 @@ on:
   workflow_call:
     inputs:
       version:
-        description: "Release version (e.g. 0.0.97)"
-        required: true
+        description: "Release version (e.g. 0.0.97). Ignored when apply_bump is true."
+        required: false
         type: string
+      apply_bump:
+        description: "Patch-bump the server version in-place before building; the caller commits it."
+        required: false
+        default: false
+        type: boolean
       targets:
         description: "Server build targets to publish to R2"
         required: false
@@ -17,12 +22,21 @@ on:
         required: false
         default: true
         type: boolean
+    outputs:
+      server_version:
+        description: "The server version that was built and uploaded."
+        value: ${{ jobs.release.outputs.server_version }}
   workflow_dispatch:
     inputs:
       version:
         description: "Release version (e.g. 0.0.97)"
         required: true
         type: string
+      apply_bump:
+        description: "Patch-bump the server version in-place before building (not committed by this workflow)."
+        required: false
+        default: false
+        type: boolean
       targets:
         description: "Server build targets to publish to R2"
         required: false
@@ -59,6 +73,8 @@ jobs:
       always() &&
       (github.event_name != 'workflow_dispatch' || needs.authorize_manual_dispatch.result == 'success')
     runs-on: ubuntu-latest
+    outputs:
+      server_version: ${{ steps.version.outputs.package_version }}
     permissions:
       contents: write
     timeout-minutes: 120
@@ -93,19 +109,32 @@ jobs:
       - name: Prepare production env file
         run: cp apps/server/.env.production.example apps/server/.env.production
 
-      - name: Validate version
+      - name: Resolve server version
         id: version
         env:
+          APPLY_BUMP: ${{ inputs.apply_bump }}
           REQUESTED_VERSION: ${{ inputs.version }}
+          PUBLISH_GITHUB_RELEASE: ${{ inputs.publish_github_release }}
         run: |
-          PACKAGE_VERSION=$(node -p "require('./apps/server/package.json').version")
-          echo "package_version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
-          echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
-
-          if [ "$PACKAGE_VERSION" != "$REQUESTED_VERSION" ]; then
-            echo "Requested version $REQUESTED_VERSION does not match apps/server/package.json ($PACKAGE_VERSION)"
+          set -euo pipefail
+          if [ "$APPLY_BUMP" = "true" ] && [ "$PUBLISH_GITHUB_RELEASE" = "true" ]; then
+            echo "::error::apply_bump cannot be combined with publish_github_release (the bump is committed by the calling workflow, so a tag/release would point at a commit without it)."
             exit 1
           fi
+
+          if [ "$APPLY_BUMP" = "true" ]; then
+            PACKAGE_VERSION="$(python3 "$GITHUB_WORKSPACE/packages/browseros/build/scripts/bump_server_version.py" --agent-root .)"
+            echo "Bumped server version in-place to $PACKAGE_VERSION"
+          else
+            PACKAGE_VERSION=$(node -p "require('./apps/server/package.json').version")
+            if [ -n "$REQUESTED_VERSION" ] && [ "$PACKAGE_VERSION" != "$REQUESTED_VERSION" ]; then
+              echo "::error::Requested version $REQUESTED_VERSION does not match apps/server/package.json ($PACKAGE_VERSION)"
+              exit 1
+            fi
+          fi
+
+          echo "package_version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "release_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Validate release options
         env:

--- a/packages/browseros/build/scripts/bump_server_version.py
+++ b/packages/browseros/build/scripts/bump_server_version.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Bump the @browseros/server version in package.json + bun.lock, print the result.
+
+Used by the nightly release flow: release-server.yml bumps in-place before building,
+and the macOS build job applies the same version (--set) so the bump rides in the
+existing browser-version PR. Mirrors build/scripts/bump_version.py for the browser.
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+from typing import Sequence
+
+# Anchor on the workspace package's own name so the single version line that follows
+# is matched in BOTH package.json and bun.lock; \s* spans the newline + indentation.
+_VERSION_RE = re.compile(
+    r'("name":\s*"@browseros/server",\s*"version":\s*")(\d+\.\d+\.\d+)(")'
+)
+
+
+def _replace_version(text: str, new_version: str) -> str:
+    """Rewrite the single @browseros/server version occurrence, or fail loudly."""
+    updated, count = _VERSION_RE.subn(
+        lambda match: f"{match.group(1)}{new_version}{match.group(3)}", text
+    )
+    if count != 1:
+        raise ValueError(
+            f"Expected exactly one @browseros/server version entry, found {count}"
+        )
+    return updated
+
+
+def _current_version(package_json_text: str) -> str:
+    match = _VERSION_RE.search(package_json_text)
+    if match is None:
+        raise ValueError("Could not find @browseros/server version in package.json")
+    return match.group(2)
+
+
+def _next_patch(version: str) -> str:
+    parts = version.split(".")
+    if len(parts) != 3 or not all(part.isdigit() for part in parts):
+        raise ValueError(f"Unsupported server version (expected MAJOR.MINOR.PATCH): {version}")
+    major, minor, patch = (int(part) for part in parts)
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def bump_server_version(agent_root: Path, set_version: str | None = None) -> str:
+    """Set (or patch-bump) the server version in package.json + bun.lock; return it."""
+    package_json = agent_root / "apps" / "server" / "package.json"
+    bun_lock = agent_root / "bun.lock"
+
+    new_version = set_version or _next_patch(_current_version(package_json.read_text()))
+
+    for path in (package_json, bun_lock):
+        text = path.read_text()
+        updated = _replace_version(text, new_version)
+        if updated != text:
+            path.write_text(updated)
+
+    return new_version
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI for GitHub Actions: bump (or --set) the server version and print it."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--set", dest="set_version", default=None)
+    parser.add_argument(
+        "--agent-root",
+        default=str(Path(__file__).resolve().parents[3] / "browseros-agent"),
+    )
+    args = parser.parse_args(argv)
+
+    print(bump_server_version(Path(args.agent_root), args.set_version))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/browseros/build/scripts/bump_server_version_test.py
+++ b/packages/browseros/build/scripts/bump_server_version_test.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Tests for the BrowserOS server version bump script."""
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT_PATH = Path(__file__).with_name("bump_server_version.py")
+
+PACKAGE_JSON = "\n".join(
+    [
+        "{",
+        '  "name": "@browseros/server",',
+        '  "version": "0.0.98",',
+        '  "description": "BrowserOS server",',
+        '  "scripts": {',
+        '    "build": "bun ../../scripts/build/server.ts --target=all"',
+        "  }",
+        "}",
+        "",
+    ]
+)
+
+# bun.lock is JSONC-ish (trailing commas); the script regex-edits, never parses it.
+BUN_LOCK = "\n".join(
+    [
+        "{",
+        '  "lockfileVersion": 1,',
+        '  "workspaces": {',
+        '    "apps/server": {',
+        '      "name": "@browseros/server",',
+        '      "version": "0.0.98",',
+        '      "bin": {',
+        '        "browseros-server": "./src/index.ts",',
+        "      },",
+        "    },",
+        "  },",
+        "}",
+        "",
+    ]
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("bump_server_version", SCRIPT_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not load {SCRIPT_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class BumpServerVersionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.module = _load_module()
+        self.tmp = tempfile.TemporaryDirectory()
+        self.root = Path(self.tmp.name)
+        (self.root / "apps" / "server").mkdir(parents=True)
+        self.pkg = self.root / "apps" / "server" / "package.json"
+        self.lock = self.root / "bun.lock"
+        self.pkg.write_text(PACKAGE_JSON)
+        self.lock.write_text(BUN_LOCK)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_default_bumps_patch_in_both_files(self) -> None:
+        version = self.module.bump_server_version(self.root)
+
+        self.assertEqual(version, "0.0.99")
+        self.assertIn('"version": "0.0.99",', self.pkg.read_text())
+        self.assertIn('"version": "0.0.99",', self.lock.read_text())
+        self.assertNotIn("0.0.98", self.pkg.read_text())
+        self.assertNotIn("0.0.98", self.lock.read_text())
+
+    def test_set_writes_exact_version(self) -> None:
+        version = self.module.bump_server_version(self.root, set_version="1.2.3")
+
+        self.assertEqual(version, "1.2.3")
+        self.assertIn('"version": "1.2.3",', self.pkg.read_text())
+        self.assertIn('"version": "1.2.3",', self.lock.read_text())
+
+    def test_patch_rolls_into_three_digits(self) -> None:
+        self.pkg.write_text(PACKAGE_JSON.replace("0.0.98", "0.0.99"))
+        self.lock.write_text(BUN_LOCK.replace("0.0.98", "0.0.99"))
+
+        version = self.module.bump_server_version(self.root)
+
+        self.assertEqual(version, "0.0.100")
+        self.assertIn('"version": "0.0.100",', self.pkg.read_text())
+        self.assertIn('"version": "0.0.100",', self.lock.read_text())
+
+    def test_only_version_line_changes_in_package_json(self) -> None:
+        before = self.pkg.read_text()
+        self.module.bump_server_version(self.root)
+        after = self.pkg.read_text()
+
+        diff = [
+            (b, a)
+            for b, a in zip(before.splitlines(), after.splitlines())
+            if b != a
+        ]
+        self.assertEqual(len(before.splitlines()), len(after.splitlines()))
+        self.assertEqual(diff, [('  "version": "0.0.98",', '  "version": "0.0.99",')])
+
+    def test_missing_server_block_raises(self) -> None:
+        self.lock.write_text('{\n  "lockfileVersion": 1\n}\n')
+
+        with self.assertRaisesRegex(ValueError, "exactly one"):
+            self.module.bump_server_version(self.root)
+
+    def test_set_is_idempotent(self) -> None:
+        self.module.bump_server_version(self.root, set_version="0.0.99")
+        version = self.module.bump_server_version(self.root, set_version="0.0.99")
+
+        self.assertEqual(version, "0.0.99")
+        self.assertIn('"version": "0.0.99",', self.pkg.read_text())
+        self.assertIn('"version": "0.0.99",', self.lock.read_text())
+
+    def test_main_prints_new_version(self) -> None:
+        import io
+        from contextlib import redirect_stdout
+
+        buffer = io.StringIO()
+        with redirect_stdout(buffer):
+            rc = self.module.main(["--agent-root", str(self.root)])
+
+        self.assertEqual(rc, 0)
+        self.assertEqual(buffer.getvalue().strip(), "0.0.99")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- The nightly macOS build now **auto-increments the server version (patch++) before building the server**, so each nightly publishes a new, traceable server version to R2 instead of overwriting the current one.
- Mirrors the existing browser-version auto-bump; the server bump is **folded into the same "build vX" version PR** (one PR carries both browser + server versions).
- Follow-up to #1128 (which set the `0.0.98` baseline). The pipeline reads the server version from `apps/server/package.json`, so the bump is the new source of truth each night.

## Design
`release-server.yml` gains an `apply_bump` input (default `false`, so manual dispatch is unchanged). The bump must be **in-place**: a reusable-workflow checkout is pinned to the parent nightly's start SHA, so a mid-run commit would be invisible. So when `apply_bump=true`, the release job runs `bump_server_version.py` to write the next patch into `package.json` + `bun.lock`, builds/uploads **that** version (`latest/` + `<version>/`), and exposes it via `outputs.server_version`.

The `build` job then applies that exact version (`--set`, no recompute) to its local clone and stages `package.json` + `bun.lock` into the existing version-bump PR — so the committed version always equals the uploaded one, even across the two machines. `apply_bump` is gated on `bump_mode != 'none'`, and a guard forbids `apply_bump` + `publish_github_release`.

The bump script is Python (the mac builder runs `uv`/`python3`, not `bun` for scripts) and mirrors `bump_version.py`. One regex anchored on `"name": "@browseros/server"` edits the single version line in both files (asserts exactly one match → minimal diff, no JSON reformatting).

Note: the browser build already pulls `artifacts/server/latest/…` verbatim every nightly, so "latest gets pulled in" already worked — this change adds **unique per-version artifacts + a traceable incrementing version**.

## Test plan
- [x] `bump_server_version_test.py` (7 tests): patch bump, `--set`, multi-digit rollover (`0.0.99→0.0.100`), single-line-only diff, exactly-one-match raise, idempotent set, CLI prints version
- [x] Regex validated against the **real** `package.json` + `bun.lock` (one match each; idempotent `--set` = clean no-op)
- [x] Existing `bump_version_test.py` still passes (no regression)
- [x] `actionlint` clean on both workflows (apart from a pre-existing custom-runner-label false positive)
- [ ] Observe the next scheduled nightly: server version increments, one PR carries both bumps, `artifacts/server/<new>/…` appears