### PR TITLE
chore: document AI SDK DevTools workflow

### DIFF
--- a/packages/browseros-agent/apps/server/.env.example
+++ b/packages/browseros-agent/apps/server/.env.example
@@ -26,7 +26,7 @@ LOG_LEVEL=info
 # 1. Set BROWSEROS_AI_SDK_DEVTOOLS=true in apps/server/.env.development.
 # 2. Run `cd apps/server && bun run devtools` to open the viewer.
 #    From the monorepo root, `bun run devtools` opens the same viewer.
-# 3. Run `bun run start` and use the agent.
+# 3. In another apps/server terminal, run `bun run start` and use the agent.
 # 4. Confirm the `AI SDK DevTools middleware enabled` log line; captures need a v3 model.
 # BROWSEROS_AI_SDK_DEVTOOLS=true
 

--- a/packages/browseros-agent/apps/server/.env.example
+++ b/packages/browseros-agent/apps/server/.env.example
@@ -22,7 +22,12 @@ SENTRY_DSN=
 NODE_ENV=development
 LOG_LEVEL=info
 
-# Debug — captures every LLM call to .devtools/generations.json (view with `npx @ai-sdk/devtools`)
+# AI SDK DevTools
+# 1. Set BROWSEROS_AI_SDK_DEVTOOLS=true in apps/server/.env.development.
+# 2. Run `cd apps/server && bun run devtools` to open the viewer.
+#    From the monorepo root, `bun run devtools` opens the same viewer.
+# 3. Run `bun run start` and use the agent.
+# 4. Confirm the `AI SDK DevTools middleware enabled` log line; captures need a v3 model.
 # BROWSEROS_AI_SDK_DEVTOOLS=true
 
 # Testing

--- a/packages/browseros-agent/package.json
+++ b/packages/browseros-agent/package.json
@@ -13,6 +13,7 @@
     "dev:watch:new": "./tools/dev/run.sh watch --new",
     "dev:manual": "./tools/dev/run.sh watch --manual",
     "dev:stop": "pkill -f 'browseros-dev watch' ; pkill -f 'bun --watch' ; echo 'dev watch stopped'",
+    "devtools": "cd apps/server && bun run devtools",
     "dev:setup": "./tools/dev/run.sh setup",
     "dev:cleanup": "./tools/dev/run.sh cleanup --target dev",
     "dev:reset": "./tools/dev/run.sh reset --target dev",


### PR DESCRIPTION
## Summary
- Expands the AI SDK DevTools section in `packages/browseros-agent/apps/server/.env.example` into numbered setup steps.
- Adds a root `devtools` script in `packages/browseros-agent/package.json` that launches the viewer from `apps/server`.
- Clarifies that `bun run start` runs from an `apps/server` terminal and that captures need a v3 model.

## Design
The root script delegates with `cd apps/server && bun run devtools` so the DevTools viewer reads `.devtools/generations.json` relative to the same server package path that writes it. The env example remains the nearby source of truth for the required `BROWSEROS_AI_SDK_DEVTOOLS=true` toggle.

## Test plan
- [x] `bun pm pkg get scripts.devtools`
- [x] focused `rg` check for the numbered env-example steps
- [x] `git diff --check 27d83c002cc42d1740b9f759ed496ebbd8482a3c..HEAD`
- [x] `bun run typecheck`
- [x] `bun run lint` (exits 0; existing warnings remain)
- [x] local adversarial review pass 2: clean