### PR TITLE
chore: add fallow dead-code workflow

### DIFF
--- a/packages/browseros-agent/.fallowrc.json
+++ b/packages/browseros-agent/.fallowrc.json
@@ -8,7 +8,8 @@
     "apps/agent/entrypoints/content.ts",
     "apps/agent/entrypoints/auth.content/index.ts",
     "apps/agent/entrypoints/glow.content/index.ts",
-    "apps/agent/entrypoints/selection.content.ts"
+    "apps/agent/entrypoints/selection.content.ts",
+    "scripts/run-bun-test.ts"
   ],
   "ignorePatterns": [
     "**/*.d.ts",

--- a/packages/browseros-agent/.fallowrc.json
+++ b/packages/browseros-agent/.fallowrc.json
@@ -1,0 +1,75 @@
+{
+  "$schema": "https://raw.githubusercontent.com/fallow-rs/fallow/main/schema.json",
+  "entry": [
+    "apps/server/src/index.ts",
+    "apps/agent/entrypoints/app/main.tsx",
+    "apps/agent/entrypoints/sidepanel/main.tsx",
+    "apps/agent/entrypoints/background/index.ts",
+    "apps/agent/entrypoints/content.ts",
+    "apps/agent/entrypoints/auth.content/index.ts",
+    "apps/agent/entrypoints/glow.content/index.ts",
+    "apps/agent/entrypoints/selection.content.ts"
+  ],
+  "ignorePatterns": [
+    "**/*.d.ts",
+    "**/dist/**",
+    "**/node_modules/**",
+    "**/*.css",
+    "**/.wxt/**",
+    "**/.output/**",
+    "**/coverage/**",
+    "**/tmp/**",
+    "apps/cli/**",
+    "apps/agent/assets/**",
+    "apps/agent/generated/**",
+    "apps/eval/data/**",
+    "apps/server/src/lib/db/migrations/**",
+    "packages/cdp-protocol/src/generated/**",
+    ".agents/skills/**",
+    ".claude/skills/**"
+  ],
+  "rules": {
+    "unused-files": "warn",
+    "unused-exports": "warn",
+    "unused-types": "warn",
+    "unused-dependencies": "warn",
+    "unused-dev-dependencies": "warn",
+    "unused-optional-dependencies": "warn",
+    "unused-enum-members": "warn",
+    "private-type-leaks": "warn",
+    "unresolved-imports": "warn",
+    "unlisted-dependencies": "warn",
+    "circular-dependencies": "warn",
+    "unused-class-members": "off",
+    "duplicate-exports": "off"
+  },
+  "overrides": [
+    {
+      "files": [
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "**/*.spec.ts",
+        "**/*.spec.tsx",
+        "**/tests/**",
+        "**/*.config.ts",
+        "**/codegen.ts"
+      ],
+      "rules": {
+        "unused-exports": "off",
+        "unused-files": "off"
+      }
+    },
+    {
+      "files": [
+        "apps/agent/components/ui/**",
+        "apps/agent/components/ai-elements/**"
+      ],
+      "rules": {
+        "unused-exports": "off",
+        "unused-files": "off",
+        "unused-types": "off",
+        "private-type-leaks": "off"
+      }
+    }
+  ]
+}

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -13,6 +13,7 @@
         "@typescript/native-preview": "^7.0.0-dev.20260319.1",
         "commander": "^14.0.1",
         "dotenv": "^17.2.3",
+        "fallow": "^2.85.0",
         "globals": "^16.4.0",
         "lefthook": "^2.0.12",
         "picocolors": "^1.1.1",
@@ -662,6 +663,22 @@
     "@eslint/compat": ["@eslint/compat@2.0.1", "", { "dependencies": { "@eslint/core": "^1.0.1" }, "peerDependencies": { "eslint": "^8.40 || 9" }, "optionalPeers": ["eslint"] }, "sha512-yl/JsgplclzuvGFNqwNYV4XNPhP3l62ZOP9w/47atNAdmDtIFCx6X7CSk/SlWUuBGkT4Et/5+UD+WyvX2iiIWA=="],
 
     "@eslint/core": ["@eslint/core@1.0.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-r18fEAj9uCk+VjzGt2thsbOmychS+4kxI14spVNibUO2vqKX7obOG+ymZljAwuPZl+S3clPGwCwTDtrdqTiY6Q=="],
+
+    "@fallow-cli/darwin-arm64": ["@fallow-cli/darwin-arm64@2.85.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-GmV5+f6TqhQWraymXN2L4JNRPjJ3N2i9KvAzAnQsonipCCDJ7Y1QbBMCvwzLSM5e3tKXC8hRgcc5pUnwInuocg=="],
+
+    "@fallow-cli/darwin-x64": ["@fallow-cli/darwin-x64@2.85.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-P7dtW5WIQgN4RhhsnuLWf8hr8ySbZEPP2lBmIzCMmXZcK7uBwS3tVy4tDmY6SjQ0BmuN0e1IJRwD66BzTjh7Tg=="],
+
+    "@fallow-cli/linux-arm64-gnu": ["@fallow-cli/linux-arm64-gnu@2.85.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-8WWgP+3a9bzTLzq6hu7jqcWwTqdcJMK2iq/rLV+Trz/mzY11dmIdsplJQdr1T8Pjq2s2P/Os4Des3SeST0dQeQ=="],
+
+    "@fallow-cli/linux-arm64-musl": ["@fallow-cli/linux-arm64-musl@2.85.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-ZeJE5nxwvgPlbDgrjUdiMkV12s/h6e2ZGMUFiBoFGObNbHewkHA6HocfKVSWp81VX1XEiWK0Gt1aI7Zcp+REJQ=="],
+
+    "@fallow-cli/linux-x64-gnu": ["@fallow-cli/linux-x64-gnu@2.85.0", "", { "os": "linux", "cpu": "x64" }, "sha512-COeXmkc4jQxkG9GbbOm5Y/tuR87nu5Q4oAk8hwx568btN0Bhzdu/H2bTUOMb7xBD65JnsTOG4XijwTNR1dkz2w=="],
+
+    "@fallow-cli/linux-x64-musl": ["@fallow-cli/linux-x64-musl@2.85.0", "", { "os": "linux", "cpu": "x64" }, "sha512-OSj/uwUAUTxHnpIemM8Vgvl8eQh1sRSGnYMIMASsghedFhG6yc+MnB8P/PND7Tfa2H4fFqsqTDsjOl1VmHEV2A=="],
+
+    "@fallow-cli/win32-arm64-msvc": ["@fallow-cli/win32-arm64-msvc@2.85.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-VQDmyXdVttaxuGeiEsqdhtnRg40uMfI2IPK2GXdiC9NgvabMWGDsgWlotSwUJ8pSi2ktIuLMuld0VIYCbk8oPw=="],
+
+    "@fallow-cli/win32-x64-msvc": ["@fallow-cli/win32-x64-msvc@2.85.0", "", { "os": "win32", "cpu": "x64" }, "sha512-T/rhJ4KBa87hrhrY8upUVQ+oc9kGRWyVWxx84DHeElq5foNgxEut43LgrbzuP3ErIeSuA+GGnLZsGhrGiMTCUw=="],
 
     "@fastify/busboy": ["@fastify/busboy@3.2.0", "", {}, "sha512-m9FVDXU3GT2ITSe0UaMA5rU3QkfC/UXtCU8y0gSN/GugTqtVldOBWIB5V6V3sbmenVZUIpU6f+mPEO2+m5iTaA=="],
 
@@ -2522,6 +2539,8 @@
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
 
     "extract-zip": ["extract-zip@2.0.1", "", { "dependencies": { "debug": "^4.1.1", "get-stream": "^5.1.0", "yauzl": "^2.10.0" }, "optionalDependencies": { "@types/yauzl": "^2.9.1" }, "bin": { "extract-zip": "cli.js" } }, "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg=="],
+
+    "fallow": ["fallow@2.85.0", "", { "dependencies": { "detect-libc": "2.1.2" }, "optionalDependencies": { "@fallow-cli/darwin-arm64": "2.85.0", "@fallow-cli/darwin-x64": "2.85.0", "@fallow-cli/linux-arm64-gnu": "2.85.0", "@fallow-cli/linux-arm64-musl": "2.85.0", "@fallow-cli/linux-x64-gnu": "2.85.0", "@fallow-cli/linux-x64-musl": "2.85.0", "@fallow-cli/win32-arm64-msvc": "2.85.0", "@fallow-cli/win32-x64-msvc": "2.85.0" }, "bin": { "fallow": "bin/fallow", "fallow-lsp": "bin/fallow-lsp", "fallow-mcp": "bin/fallow-mcp" } }, "sha512-R8Obl32b2LYyNtUYYtCgMXlDKlRqjcR8obVw+UhAi9pj1Zk4BIfbjy1tiEUlD7e1KkU5uC+CvrMFL+Ke73qarw=="],
 
     "fast-copy": ["fast-copy@4.0.2", "", {}, "sha512-ybA6PDXIXOXivLJK/z9e+Otk7ve13I4ckBvGO5I2RRmBU1gMHLVDJYEuJYhGwez7YNlYji2M2DvVU+a9mSFDlw=="],
 

--- a/packages/browseros-agent/package.json
+++ b/packages/browseros-agent/package.json
@@ -40,6 +40,7 @@
     "test:main": "bun run ./scripts/run-test-suite.ts main",
     "typecheck": "bun run --filter '*' typecheck",
     "lint": "bunx biome check",
+    "fallow": "fallow check",
     "lint:fix": "bunx biome check --write --unsafe",
     "gen:cdp": "bun scripts/codegen/cdp-protocol.ts",
     "generate:models": "bun scripts/generate-models.ts"
@@ -60,6 +61,7 @@
     "@typescript/native-preview": "^7.0.0-dev.20260319.1",
     "commander": "^14.0.1",
     "dotenv": "^17.2.3",
+    "fallow": "^2.85.0",
     "globals": "^16.4.0",
     "lefthook": "^2.0.12",
     "picocolors": "^1.1.1",


### PR DESCRIPTION
## Summary
- Adds a root `.fallowrc.json` with the fallow schema, repo-specific entrypoints, and generated/non-source ignore patterns.
- Wires fallow into the root workflow with a `fallow` script and a root dev dependency.
- Keeps current repo findings warning-level so the command is usable before a cleanup baseline is established.

## Design
The config uses the BrowserOS server entrypoint, the real WXT extension roots under `apps/agent/entrypoints`, and the root test runner script that fallow cannot infer through workspace `../../scripts/...` package scripts. Agent-company desktop boundaries were intentionally not copied because this repo has a different server/extension/eval layout.

## Test plan
- [x] `bun -e 'const fs=require("fs"); const c=JSON.parse(fs.readFileSync(".fallowrc.json","utf8")); for (const entry of c.entry) { if (!fs.existsSync(entry)) { console.error(`missing entry: ${entry}`); process.exitCode=1; } } console.log(`${c.entry.length} entries ok`);'`
- [x] `bunx biome check .fallowrc.json package.json`
- [x] `bun install --frozen-lockfile`
- [x] `bun run fallow -- --summary --no-cache`
- [x] local codex review loop: 2 rounds, clean after fixing `scripts/run-bun-test.ts` entry