### PR TITLE
docs: restructure CLAUDE guidance

### DIFF
--- a/packages/browseros-agent/CLAUDE.md
+++ b/packages/browseros-agent/CLAUDE.md
@@ -1,226 +1,36 @@
-# CLAUDE.md
+# BrowserOS Agent contributor ground rules
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+A Bun-workspaces monorepo for the BrowserOS MCP server, agent extension UI, CLI, eval harness, and shared packages.
 
-## Coding guidelines
+## Before you push
 
-- **Use extensionless imports.** Do not use `.js` extensions in TypeScript imports. Bun resolves `.ts` files automatically.
-  ```typescript
-  // ✅ Correct
-  import { foo } from './utils'
-  import type { Bar } from '../types'
-
-  // ❌ Wrong
-  import { foo } from './utils.js'
-  ```
-- Write minimal code comments. Only add comments for non-obvious logic, complex algorithms, or critical warnings. Skip comments for self-explanatory code, obvious function names, and simple operations.
-- Logger messages should not include `[prefix]` tags (e.g., `[Config]`, `[HTTP Server]`). Source tracking automatically adds file:line:function in development mode.
-- Avoid magic constants scattered in the codebase. Use `@browseros/shared` for all shared configuration:
-  - `@browseros/shared/constants/ports` - Port numbers (DEFAULT_PORTS, TEST_PORTS)
-  - `@browseros/shared/constants/timeouts` - Timeout values (TIMEOUTS)
-  - `@browseros/shared/constants/limits` - Rate limits, pagination, content limits (RATE_LIMITS, AGENT_LIMITS, etc.)
-  - `@browseros/shared/constants/urls` - External service URLs (EXTERNAL_URLS)
-  - `@browseros/shared/constants/paths` - File system paths (PATHS)
-  - `@browseros/shared/types/logger` - Logger interface types (LoggerInterface, LogLevel)
-
-## File Naming Convention
-
-Use **kebab-case** for all file and folder names:
-
-| Type | Convention | Example |
-|------|------------|---------|
-| Multi-word files | kebab-case | `gemini-agent.ts`, `mcp-context.ts` |
-| Single-word files | lowercase | `types.ts`, `browser.ts`, `index.ts` |
-| Test files | `.test.ts` suffix | `mcp-context.test.ts` |
-| Folders | kebab-case | `rate-limiter/`, `browser-tools/` |
-
-Classes remain PascalCase in code, but live in kebab-case files:
-```typescript
-// file: gemini-agent.ts
-export class GeminiAgent { ... }
-```
-
-## Project Overview
-
-**BrowserOS Server** - The automation engine inside BrowserOS. This MCP server powers the built-in AI agent and lets external tools like `claude-code` or `gemini-cli` control the browser. Starts automatically when BrowserOS launches.
-
-## Bun Preferences
-
-Default to using Bun instead of Node.js:
-
-- Use `bun <file>` instead of `node <file>`
-- Use `bun test` instead of `jest` or `vitest`
-- Use `bun install` instead of `npm install`
-- Use `bun run <script>` instead of `npm run <script>`
-- Bun automatically loads .env (no dotenv needed)
-
-## Common Commands
-
-```bash
-# Start server (development)
-bun run start                    # Loads .env.dev automatically
-
-# Testing
-bun run test                     # Run tool tests (requires BrowserOS running)
-bun run test:tools               # Same as above
-bun run test:integration         # Run integration tests
-bun run test:sdk                 # Run SDK tests
-
-# Run a single test file
-bun --env-file=.env.development test apps/server/tests/path/to/file.test.ts
-
-# Linting
-bun run lint                     # Check with Biome
-bun run lint:fix                 # Auto-fix with Biome
-
-# Type checking
-bun run typecheck                # TypeScript build check
-
-# Build
-bun run dev:server               # Build server for development
-bun run dev:ext                  # Build extension for development
-bun run dist:server              # Build server for production (all targets)
-bun run dist:ext                 # Build extension for production
-
-# Refresh models.dev data
-bun run generate:models          # Fetches latest from models.dev/api.json
-```
-
-## Architecture
-
-This is a monorepo with three packages in `apps/`:
-
-### Server (`apps/server`)
-The main MCP server that exposes browser automation tools via HTTP/SSE.
-
-**Entry point:** `apps/server/src/index.ts` → `apps/server/src/main.ts`
-
-**Key components:**
-- `src/tools/` - MCP tool definitions, split into:
-  - `cdp-based/` - Tools using Chrome DevTools Protocol (navigation, DOM interaction, network, console, emulation, input, etc.)
-- `src/common/` - Shared utilities (McpContext, PageCollector, browser connection, identity, db)
-- `src/agent/` - AI agent functionality (Gemini adapter, rate limiting, session management)
-- `src/http/` - Hono HTTP server with MCP, health, and provider routes
-
-**Tool types:**
-- CDP tools require a direct CDP connection (`--cdp-port`)
-
-### Shared (`packages/shared`)
-Shared constants, types, and configuration used across packages. Avoids magic numbers.
-
-**Structure:**
-- `src/constants/` - Configuration values (ports, timeouts, limits, urls, paths)
-- `src/types/` - Shared type definitions (logger)
-
-**Exports:** `@browseros/shared/constants/*`, `@browseros/shared/types/*`
-
-### Communication Flow
+There is no root `bun run check` script here. Run the real checks:
 
 ```
-AI Agent/MCP Client → HTTP Server (Hono) → Tool Handler
-                                              ↓
-                                   CDP → BrowserOS / Chrome APIs
+bun run lint
+bun run typecheck
+bun run test:main
 ```
 
-## Creating Packages
+For docs-only changes, also run `git diff --check`. For release/build changes, run the relevant `bun run build:*` command.
 
-When creating new packages in this monorepo:
+## Universal rules
 
-- **Location:** Packages go in `packages/`, apps go in `apps/`
-- **No index.ts:** Don't create or export an `index.ts` - it inflates the bundle with all exports
-- **Separate export files:** Keep exports in individual files (e.g., `logger.ts`, `ports.ts`)
-- **Import pattern:** `import { X } from "@my-package/name/logger"` - only imports what's needed
+- Use extensionless TypeScript imports: `./utils`, not `./utils.js`.
+- Use Bun: `bun <file>`, `bun test`, `bun install`, `bun run <script>`. Bun loads env files; do not add dotenv unless a script proves it needs one.
+- Use kebab-case for folders and multi-word non-component files; app-specific framework exceptions live in the app CLAUDE files.
+- Keep shared constants in `@browseros/shared` instead of scattering magic values:
+  - `@browseros/shared/constants/ports`
+  - `@browseros/shared/constants/timeouts`
+  - `@browseros/shared/constants/limits`
+  - `@browseros/shared/constants/urls`
+  - `@browseros/shared/constants/paths`
+  - `@browseros/shared/types/logger`
+- Logger messages should not include `[prefix]` tags; development logging already adds file, line, and function.
+- Keep comments minimal. Comment hidden constraints, subtle invariants, critical warnings, or surprising behavior; do not restate obvious code.
+- New packages go in `packages/`; apps go in `apps/`. Avoid package-wide `index.ts` barrels and expose narrow files with both `types` and `default` entries in `package.json`.
 
-**package.json exports:** Must include both `types` and `default` for TypeScript:
-```json
-"exports": {
-  "./constants/ports": {
-    "types": "./src/constants/ports.ts",
-    "default": "./src/constants/ports.ts"
-  },
-  "./types/logger": {
-    "types": "./src/types/logger.ts",
-    "default": "./src/types/logger.ts"
-  }
-}
-```
+## Where to look
 
-## Test Organization
-
-Tests are in `apps/server/tests/`:
-- `tools/` - Tool tests (require BrowserOS running with CDP), plus ACL scorer tests (standalone)
-- `browser/` - Browser backend tests
-- `agent/` - Agent tests (compaction, rate limiter)
-- `sdk/` - Agent SDK tests
-- `__helpers__/` - Test utilities and fixtures
-
-## Self-Testing UI Changes
-
-After making UI changes to the agent extension (`apps/agent/`), you can visually verify them using the CDP inspector script. This connects directly to the browser via Chrome DevTools Protocol and can inspect extension pages (side panel, new tab, etc.) that the agent's own tools cannot see.
-
-### Prerequisites
-
-The dev server must be running:
-```bash
-bun run dev:watch -- --new
-```
-Read the output to find the randomized CDP port, then:
-```bash
-export BROWSEROS_CDP_PORT=<port from output>
-```
-
-### Workflow
-
-1. **List all targets** to see what's available:
-   ```bash
-   bun scripts/dev/inspect-ui.ts targets
-   ```
-
-2. **Open the side panel** if it's not already open:
-   ```bash
-   bun scripts/dev/inspect-ui.ts open-sidepanel
-   ```
-
-3. **Take a screenshot** of the side panel:
-   ```bash
-   bun scripts/dev/inspect-ui.ts screenshot sidepanel /tmp/panel.png
-   ```
-   Then read `/tmp/panel.png` to view the result.
-
-4. **Get the accessibility tree** for structural verification:
-   ```bash
-   bun scripts/dev/inspect-ui.ts snapshot sidepanel
-   ```
-
-5. **Click an element** by its ID from the snapshot:
-   ```bash
-   bun scripts/dev/inspect-ui.ts click sidepanel 142
-   ```
-
-6. **Fill a text input** by its ID from the snapshot:
-   ```bash
-   bun scripts/dev/inspect-ui.ts fill sidepanel 85 "search query"
-   ```
-
-7. **Evaluate JavaScript** in the extension context:
-   ```bash
-   bun scripts/dev/inspect-ui.ts eval sidepanel "document.title"
-   ```
-
-### Interaction workflow
-
-The typical loop is: snapshot → identify element IDs → click/fill → screenshot to verify.
-Element IDs come from the `[number]` in snapshot output (these are `backendDOMNodeId` values).
-This uses the same element resolution as the server's MCP tools — no coordinate guessing.
-
-### Target selection
-
-The `<target>` argument can be:
-- An **index** from the `targets` output (e.g., `3`)
-- A **URL substring** (e.g., `sidepanel`, `newtab`, `chrome-extension://`)
-
-## Release gating — bundled-VM runtime migration (2026-Q2)
-
-Between the Lima server-prod-resources cutover (WS3) and the ContainerRuntime migration (WS6) landing, `resources/bin/third_party/` ships `limactl` instead of `podman`. The current OpenClaw runtime (`apps/server/src/api/services/openclaw/podman-runtime.ts`, `container-runtime.ts`) still invokes `podman`; it will fail to find the binary on builds cut from `dev`.
-
-Do **not** cut a release branch off `dev` during this window. Track WS6 progress before any release cut. See `specs/bundled-vm-runtime-spec.md` + `specs/workstreams.md` for context.
+- For server-specific guidance, see `apps/server/CLAUDE.md`.
+- For extension/agent UI specifics, see `apps/agent/CLAUDE.md`.

--- a/packages/browseros-agent/apps/agent/CLAUDE.md
+++ b/packages/browseros-agent/apps/agent/CLAUDE.md
@@ -1,177 +1,110 @@
-# CLAUDE.md
+# BrowserOS Agent UI contributor ground rules
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+The agent UI is a WXT React extension: side panel chat, app/settings pages, new tab, onboarding, background workers, and content scripts.
 
-## Coding guidelines
+## Before you push
 
-- Write minimal code comments. Only add comments for non-obvious logic, complex algorithms, or critical warnings. Skip comments for self-explanatory code, obvious function names, and simple operations.
+From the monorepo root:
 
-## File Naming Convention
+```
+bun run lint
+bun run typecheck
+bun run build:agent
+```
 
-| Type | Convention | Example |
-|------|------------|---------|
-| Folders | kebab-case | `ai-settings/`, `jtbd-popup/`, `llm-hub/` |
-| React components (.tsx) | PascalCase | `AISettingsPage.tsx`, `SurveyHeader.tsx` |
-| Hooks (.ts) | camelCase with `use` prefix | `useVoiceInput.ts`, `useMessageTree.ts` |
-| Non-component files (.ts) | lowercase | `types.ts`, `models.ts`, `storage.ts` |
+For focused agent UI work:
 
-## Project Overview
+```
+cd apps/agent && bun run typecheck
+cd apps/agent && bun run test
+cd apps/agent && bun run codegen
+```
 
-**BrowserOS Agent Chrome Extension** - This project contains the official chrome extension for BrowserOS Agent, enabling users to interact with the core functionalities of BrowserOS.
+## Project shape
 
-## Bun Preferences
+```
+apps/agent/
+|- entrypoints/
+|  |- sidepanel/     Chat UI
+|  |- app/           Settings, AI providers, agents, MCP, usage
+|  |- newtab/        BrowserOS new tab UI
+|  |- onboarding/    First-run flow
+|  |- background/    Extension background logic
+|  `- *.content*     Page/content integrations
+|- components/       Shared UI, including generated shadcn-style primitives
+|- generated/graphql GraphQL codegen output
+|- lib/              Auth, GraphQL, metrics, Sentry, BrowserOS clients, state
+|- schema/           Default GraphQL schema input
+`- wxt.config.ts     Manifest and WXT/Vite config
+```
 
-Default to using Bun instead of Node.js:
+## WXT and entrypoints
 
-- Use `bun <file>` instead of `node <file>`
-- Use `bun test` instead of `jest` or `vitest`
-- Use `bun install` instead of `npm install`
-- Use `bun run <script>` instead of `npm run <script>`
-- Bun automatically loads .env (no dotenv needed)
+- `wxt.config.ts` owns manifest shape, permissions, side panel/new tab/options wiring, extension ID, externally connectable hosts, and Vite plugins.
+- `entrypoints/sidepanel/main.tsx` is the side panel entry.
+- `entrypoints/app/main.tsx` is the extension app/settings entry.
+- `entrypoints/newtab/` owns the new tab experience.
+- `entrypoints/background/` owns background jobs and extension-level listeners.
+- Content entrypoints live under `entrypoints/*.content*`; keep page integration logic there, not in shared UI components.
 
-## Project Structure
+## UI conventions
 
-This project user wxt.dev as its framework for building chrome extension.
+- Folders are kebab-case. React component files are PascalCase. Hooks use a `use` prefix. Single-word utility/model files stay lowercase.
+- Avoid `useCallback` and `useMemo` unless they solve a measured or obvious render problem.
+- Use existing shadcn-style primitives from `components/ui/` for UI controls.
+- Capture runtime errors with Sentry, not `console.error`:
 
-The chrome extension manifest is created via default wxt.dev setup along with some custom configuration provided via `wxt.config.ts` file
-
-The key directories of the project are:
-- `entrypoints/newtab`: Contains the code for the new tab page of the extension.
-- `entrypoints/popup`: Contains the code for the popup that appears when the extension icon is clicked.
-- `entrypoints/onboarding`: Contains the onboarding flow for new users which is triggered on first install.
-
-## React Coding patterns
-
-- Avoid using useCallback and useMemo as much as possible - only add them if their presence is absolutely necessary
-- When writing a graphql document, create a /graphql directory under the current directory where the file is present and create a file to contain the document.
-  - For example: if you want to create grapqhl queries in @apps/agent/entrypoints/sidepanel/history/ChatHistory.tsx then write the graphql document in @apps/agent/entrypoints/sidepanel/history/graphql/chatHistoryDocument.ts 
-- Shadcn UI is setup in this project and always use shadcn components for the UI
-- When need to record errors, do not use console.error -> instead use the sentry service to capture errors:
-```ts
+```
 import { sentry } from '@/lib/sentry/sentry'
 
 sentry.captureException(error, {
-  extra: {
-    message: 'Failed to fetch graph data from the server',
-    codeId: workflow.codeId,
-  },
+  extra: { message: 'Failed to fetch graph data from the server' },
 })
 ```
 
-## GraphQL Client
+## GraphQL and codegen
 
-- The Graphql main schema file is in `@apps/agent/generated/graphql/schema.graphql` - this is the source of truth for constructing all graphql queries
+- Codegen input defaults to `schema/schema.graphql`; set `GRAPHQL_SCHEMA_PATH` when you need an external schema.
+- Generated files live in `generated/graphql/`; do not hand-edit them.
+- Put GraphQL documents in a local `graphql/` folder near the feature using them.
+- Import documents with `graphql` from `@/generated/graphql/gql`.
+- Use the existing helpers in `lib/graphql/`: `useGraphqlQuery`, `useGraphqlMutation`, `useGraphqlInfiniteQuery`, and `getQueryKeyFromDocument`.
+- After adding or changing a document, run:
 
-- The frontend uses React Query with `graphql-codegen` to interact with the backend GraphQL API. The types are generated and stored in `@apps/agent/generated/graphql`
-
-- When working with React Query and GraphQL, some important utilities are already created to make the interaction simpler:
-  - `@apps/agent/lib/graphql/useGraphqlInfiniteQuery.ts`
-  - `@apps/agent/lib/graphql/useGraphqlMutation.ts`
-  - `@apps/agent/lib/graphql/useGraphqlQuery.ts`
-  - `@apps/agent/lib/graphql/getQueryKeyFromDocument.ts`
-
-This is how a standard GraphQL query and mutation looks like:
-
-```ts
-import { graphql } from "~/graphql/gql";
-import { useGraphqlQuery } from "@/lib/graphql/useGraphqlQuery";
-import { useGraphqlMutation } from "@/lib/graphql/useGraphqlMutation";
-import { useSessionInfo } from '@/lib/auth/sessionStorage'
-import { getQueryKeyFromDocument } from "@/modules/graphql/getQueryKeyFromDocument";
-import { useQueryClient } from "@tanstack/react-query";
-
-export const GetProfileByUserIdDocument = graphql(`
-  query GetProfileByUserId($userId: String!) {
-    profileByUserId(userId: $userId) {
-      id
-      rowId
-      name
-      userId
-      meta
-      profilePictureUrl
-      linkedInUrl
-      updatedAt
-      createdAt
-      deletedAt
-    }
-  }
-`);
-
-const UpdateProfileIndustryDocument = graphql(`
-  mutation UpdateProfileIndustry($userId: String!, $meta: JSON) {
-    updateProfileByUserId(input: { userId: $userId, patch: { meta: $meta } }) {
-      profile {
-        id
-        rowId
-        meta
-      }
-    }
-  }
-`);
-
-  const { sessionInfo } = useSessionInfo()
-
-  const userId = sessionInfo.user?.id
-
-const queryClient = useQueryClient();
-
-const { data: profileData } = useGraphqlQuery(
-  GetProfileByUserIdDocument,
-  {
-    userId,
-  },
-  {
-    enabled: !!userId,
-  },
-);
-
-const updateProfileMutation = useGraphqlMutation(
-  UpdateProfileIndustryDocument,
-  {
-    onSuccess: () => {
-      queryClient.invalidateQueries({
-        queryKey: [getQueryKeyFromDocument(GetProfileByUserIdDocument)],
-      });
-    },
-  },
-);
+```
+cd apps/agent && bun run codegen
 ```
 
-To run codegen to generate graphql code after creating a query, you should run codegen using the command (since .env.development is necessary for codegen):
-```sh
-bun --env-file=.env.development run codegen
+## Analytics
+
+- Event constants live in `lib/constants/analyticsEvents.ts`.
+- Event constants use `SCREAMING_SNAKE_CASE` ending in `_EVENT`.
+- Add `/** @public */` above each exported event constant.
+- Event values follow `<area>.<entity>.<action>` such as `ui.message.like` or `settings.managed_mcp.added`.
+- Always call `track()` with an event constant; never pass raw event strings.
+
+## Self-testing UI changes
+
+Use the CDP inspector when changing extension UI. It can inspect extension pages that the agent tools cannot see.
+
+Start the dev environment and read the randomized CDP port:
+
+```
+bun run dev:watch -- --new
+export BROWSEROS_CDP_PORT=<port from output>
 ```
 
-## Analytics & Event Tracking
+Useful inspector commands:
 
-All user-facing events are tracked using a centralized pattern:
-
-- **Event constants** are defined in `lib/constants/analyticsEvents.ts`
-- **Tracking** is done via the `track()` utility from `lib/metrics/track.ts`
-
-**Event constant naming:**
-- Use `SCREAMING_SNAKE_CASE` ending with `_EVENT`
-- Add `/** @public */` JSDoc tag above each constant
-
-**Event value naming** follows the pattern `<area>.<entity>.<action>`:
-- `ui.*` - sidepanel/chat interactions (e.g. `ui.message.like`, `ui.conversation.reset`)
-- `settings.*` - settings page actions (e.g. `settings.scheduled_task.created`, `settings.managed_mcp.added`)
-- `newtab.*` - new tab page actions (e.g. `newtab.opened`, `newtab.ai.triggered`)
-- `sidepanel.*` - sidepanel-specific actions (e.g. `sidepanel.ai.triggered`)
-
-**Usage:**
-```ts
-import { MY_EVENT } from '@/lib/constants/analyticsEvents'
-import { track } from '@/lib/metrics/track'
-
-// Without properties
-track(MY_EVENT)
-
-// With properties
-track(MY_EVENT, {
-  mode,
-  provider_type: selectedLlmProvider?.type,
-})
+```
+bun scripts/dev/inspect-ui.ts targets
+bun scripts/dev/inspect-ui.ts open-sidepanel
+bun scripts/dev/inspect-ui.ts snapshot sidepanel
+bun scripts/dev/inspect-ui.ts screenshot sidepanel /tmp/panel.png
+bun scripts/dev/inspect-ui.ts click sidepanel <backendDOMNodeId>
+bun scripts/dev/inspect-ui.ts fill sidepanel <backendDOMNodeId> "search query"
+bun scripts/dev/inspect-ui.ts press_key sidepanel Enter
+bun scripts/dev/inspect-ui.ts eval sidepanel "document.title"
 ```
 
-Always use event constants from `analyticsEvents.ts` — never pass raw string event names to `track()`.
+The normal loop is `snapshot -> click/fill/press_key -> screenshot`. Element IDs are the `[number]` values from the snapshot output.

--- a/packages/browseros-agent/apps/server/CLAUDE.md
+++ b/packages/browseros-agent/apps/server/CLAUDE.md
@@ -1,0 +1,60 @@
+# BrowserOS Server contributor ground rules
+
+The Bun server is a Hono HTTP app that exposes MCP tools, drives BrowserOS through CDP, and runs the AI SDK agent loop.
+
+## Before you push
+
+From the monorepo root:
+
+```
+bun run lint
+bun run typecheck
+bun run test:main
+```
+
+For focused server work:
+
+```
+cd apps/server && bun run test:agent
+cd apps/server && bun run test:api
+cd apps/server && bun run test:browser
+cd apps/server && bun run test:tools
+```
+
+Tool, browser, and integration tests may require a running BrowserOS/CDP target. For local server artifact checks, prefer `bun run build:server:test`; use `bun scripts/build/server.ts --target=all --no-upload` when you need all targets without R2 upload.
+
+## Entry points
+
+- `src/index.ts` loads polyfills/config, creates `Application`, starts it, and maps startup failures to exit codes.
+- `src/main.ts` owns lifecycle: runtime setup, DB/identity/metrics init, CDP connection, browser wrapper, tool registry, HTTP startup, and shutdown.
+- `src/api/server.ts` composes Hono routes for `/health`, `/status`, `/chat`, `/mcp`, `/klavis`, `/agents`, `/screencast`, provider testing, prompt refinement, and shutdown.
+
+## Project shape
+
+```
+apps/server/
+|- src/
+|  |- api/          Hono routes, middleware, route services, HTTP utilities
+|  |- agent/        AI SDK agent loop, providers, sessions, MCP client setup
+|  |- browser/      Browser facade plus CDP-backed core connection/snapshot/input
+|  |- lib/          DB, identity, metrics, OAuth, runtime, clients, process helpers
+|  |- tools/        MCP tool registry and browser/filesystem/tool implementations
+|  |- index.ts      process entry
+|  `- main.ts       application lifecycle
+`- tests/           grouped by agent, api, browser, lib, tools
+```
+
+## Server conventions
+
+- HTTP routes use Hono. Add routes in `src/api/routes/` and compose them in `src/api/server.ts`.
+- MCP tool registration flows through `src/tools/registry.ts` and the tool implementation folders. Keep tool names, labels, schemas, and responses in sync.
+- CDP-backed browser behavior lives under `src/browser/` and `src/browser/core/`; tools should use that layer instead of speaking raw CDP when a local abstraction exists.
+- Agent behavior lives under `src/agent/` and uses the AI SDK provider/tool loop. External MCP clients are per-session and built through `mcp-builder.ts`.
+- CDP is required at runtime: pass `--cdp-port` or set `BROWSEROS_CDP_PORT`.
+- Tests live under `apps/server/tests/`; use the closest group runner before broad suites.
+
+## Release gate
+
+Server production resources must not package VM-only Lima resources. Keep `scripts/build/server/stage.test.ts` green: `scripts/build/config/server-prod-resources.json` should exclude `third_party/lima` and `resources/vm/` while still packaging Bun and DB migrations.
+
+If you change the BrowserOS VM template, keep `packages/build-tools/tests/vm-template.test.ts` green. The template is Lima/containerd-rootless based and must not depend on `podman`.


### PR DESCRIPTION
## Summary
- Split BrowserOS Agent contributor guidance into root, server, and agent UI CLAUDE layers.
- Kept root guidance short with universal rules, real before-push commands, and app-specific doc pointers.
- Moved server and extension specifics into `apps/server/CLAUDE.md` and `apps/agent/CLAUDE.md`, including current release-gate guidance and UI inspector workflow.

## Design
The root doc is now the universal contributor contract and delegates domain-specific guidance to app-level CLAUDE files. The server doc owns Hono/MCP/CDP/AI SDK guidance and server release-resource checks. The agent doc owns WXT entrypoints, GraphQL codegen, UI/error/analytics conventions, and CDP inspector self-testing.

## Test plan
- [x] `git diff --check origin/main..HEAD`
- [x] `bun run lint` (exits 0; existing unrelated warnings remain)
- [x] `bun run typecheck`
- [x] `bun run test:main`
- [x] local context-free review loop: one stale release-gate finding fixed, second review clean