### PR TITLE
docs(agent): add frontend/React engineering conventions to CLAUDE.md

### DIFF
--- a/packages/browseros-agent/apps/agent/CLAUDE.md
+++ b/packages/browseros-agent/apps/agent/CLAUDE.md
@@ -51,7 +51,8 @@ apps/agent/
 
 - Folders are kebab-case. React component files are PascalCase. Hooks use a `use` prefix. Single-word utility/model files stay lowercase.
 - Avoid `useCallback` and `useMemo` unless they solve a measured or obvious render problem.
-- Use existing shadcn-style primitives from `components/ui/` for UI controls.
+- Build UI from the shadcn-style primitives in `components/ui/` and the AI Elements in `components/ai-elements/`. Both are generated and exempt from fallow (`.fallowrc.json`); treat them as generated output and don't hand-edit them for feature work.
+- Feature UI lives in `components/<feature>/` or colocated with its entrypoint — keep `components/ui/` and `components/ai-elements/` for the generated primitives only.
 - Capture runtime errors with Sentry, not `console.error`:
 
 ```
@@ -61,6 +62,15 @@ sentry.captureException(error, {
   extra: { message: 'Failed to fetch graph data from the server' },
 })
 ```
+
+## Server state and data fetching
+
+All server state goes through **TanStack Query** (`@tanstack/react-query`) — don't fetch with `useEffect` + `useState`, and don't call the network from a component body. There are two lanes:
+
+- **GraphQL (BrowserOS API)** — the default for app data. Colocated `graphql()` documents + the `lib/graphql/` helpers; see *GraphQL and codegen* below.
+- **Local REST (agent harness, credits)** — endpoints on the dynamic agent server (`getAgentServerUrl()`) wrap a small `fetch` in `useQuery`/`useMutation`. Reference: `entrypoints/app/agents/useAgents.ts`, `lib/credits/useCredits.ts`.
+
+Either lane: keep query keys in one place — derive GraphQL keys with `getQueryKeyFromDocument(Document)`, give REST hooks a `*_QUERY_KEYS` const — and invalidate through that, never a hand-written string literal (`BrowserOsAiPane.tsx` invalidates via `getQueryKeyFromDocument(...)`). For instant-feeling mutations, do optimistic updates with `onMutate` -> `cancelQueries` + `getQueryData` + `setQueryData`, rolling back in `onError` — worked example: `useUpdateHarnessAgent` in `entrypoints/app/agents/useAgents.ts`.
 
 ## GraphQL and codegen
 
@@ -74,6 +84,28 @@ sentry.captureException(error, {
 ```
 cd apps/agent && bun run codegen
 ```
+
+## Forms
+
+Every form uses `react-hook-form` for state and submission plus a single `zod` schema for validation, bridged by `@hookform/resolvers/zod` — no `useState`-per-field. The UI is the shadcn `Form` set (`Form`, `FormField`, `FormItem`, `FormLabel`, `FormControl`, `FormMessage`) from `@/components/ui/form`. The schema is the source of truth: derive `FormValues` with `z.infer`, pass `zodResolver(schema)` to `useForm`, and surface per-field errors through `<FormMessage />` instead of rolling your own error state.
+
+- Import `z` from `zod/v3`, not `zod`. The package ships zod 4, but `@hookform/resolvers` and this Form pattern target the v3 API; `zod/v3` is the compat entry the existing forms use.
+- Reference: `entrypoints/app/connect-mcp/AddCustomMCPDialog.tsx` (also `ai-settings/NewProviderDialog.tsx`, `scheduled-tasks/NewScheduledTaskDialog.tsx`).
+
+## Routing
+
+Each page entrypoint owns a `react-router` v7 `HashRouter` with one central route table — `entrypoints/app/App.tsx` for the app/settings pages, `entrypoints/sidepanel/App.tsx` for the side panel. Add a page by registering a `<Route>` there and colocating the screen under `entrypoints/<area>/<feature>/`; express redirects and back-compat paths as `<Navigate replace>` entries in the same table.
+
+## Dates and times
+
+`dayjs` is the one date library (already a dependency) — use it for parsing, comparison, and formatting; prefer it over ad-hoc `Date`/`Intl` math, and don't add a second date lib. There is no central date module: keep a reusable formatter in the owning feature's helper file (e.g. `entrypoints/sidepanel/history/components/utils.ts`, `entrypoints/app/agents/agent-display.helpers.ts`) rather than re-deriving the same bucketing inline.
+
+## Module boundaries and formatting
+
+- Run `bun run fallow` before pushing. It flags unused files/exports, circular dependencies, and private-type leaks (`.fallowrc.json`); `generated/**`, `components/ui/**`, and `components/ai-elements/**` are exempt.
+- Colocate a feature's pieces with the entrypoint that owns them — its `graphql/` documents, `*.helpers.ts`, and `*.test.ts` sit next to it. Only genuinely shared code goes in `lib/` or `components/`, imported via the `@/` alias.
+- Biome owns formatting and import order — run `bun run lint:fix` rather than hand-formatting.
+- Comments: default to none and explain *why*, not *what*; see `packages/browseros-agent/CLAUDE.md` for the full rule.
 
 ## Analytics
 
@@ -108,3 +140,7 @@ bun scripts/dev/inspect-ui.ts eval sidepanel "document.title"
 ```
 
 The normal loop is `snapshot -> click/fill/press_key -> screenshot`. Element IDs are the `[number]` values from the snapshot output.
+
+## When in doubt, read a sibling
+
+Most features are a vertical slice you can copy. The AI settings slice is the GraphQL template end to end: `entrypoints/app/ai-settings/graphql/aiSettingsDocument.ts` (documents) -> consumed via `lib/graphql` hooks in `ai-settings/BrowserOsAiPane.tsx` -> `ai-settings/NewProviderDialog.tsx` (the `zod` + shadcn `Form` dialog). For the REST lane plus optimistic mutations, `entrypoints/app/agents/useAgents.ts` is the worked example.

--- a/packages/browseros-agent/apps/agent/CLAUDE.md
+++ b/packages/browseros-agent/apps/agent/CLAUDE.md
@@ -51,7 +51,7 @@ apps/agent/
 
 - Folders are kebab-case. React component files are PascalCase. Hooks use a `use` prefix. Single-word utility/model files stay lowercase.
 - Avoid `useCallback` and `useMemo` unless they solve a measured or obvious render problem.
-- Build UI from the shadcn-style primitives in `components/ui/` and the AI Elements in `components/ai-elements/`. Both are generated and exempt from fallow (`.fallowrc.json`); treat them as generated output and don't hand-edit them for feature work.
+- Build UI from the shadcn-style primitives in `components/ui/` and the AI Elements in `components/ai-elements/`. Both are generated — fallow skips its unused/leak checks for them (`.fallowrc.json`) — so treat them as generated output and don't hand-edit them for feature work.
 - Feature UI lives in `components/<feature>/` or colocated with its entrypoint — keep `components/ui/` and `components/ai-elements/` for the generated primitives only.
 - Capture runtime errors with Sentry, not `console.error`:
 
@@ -68,9 +68,9 @@ sentry.captureException(error, {
 All server state goes through **TanStack Query** (`@tanstack/react-query`) — don't fetch with `useEffect` + `useState`, and don't call the network from a component body. There are two lanes:
 
 - **GraphQL (BrowserOS API)** — the default for app data. Colocated `graphql()` documents + the `lib/graphql/` helpers; see *GraphQL and codegen* below.
-- **Local REST (agent harness, credits)** — endpoints on the dynamic agent server (`getAgentServerUrl()`) wrap a small `fetch` in `useQuery`/`useMutation`. Reference: `entrypoints/app/agents/useAgents.ts`, `lib/credits/useCredits.ts`.
+- **Local REST (agent harness, credits)** — endpoints on the dynamic agent server wrap a small `fetch` in `useQuery`/`useMutation`. Reference: `entrypoints/app/agents/useAgents.ts`, `lib/credits/useCredits.ts`.
 
-Either lane: keep query keys in one place — derive GraphQL keys with `getQueryKeyFromDocument(Document)`, give REST hooks a `*_QUERY_KEYS` const — and invalidate through that, never a hand-written string literal (`BrowserOsAiPane.tsx` invalidates via `getQueryKeyFromDocument(...)`). For instant-feeling mutations, do optimistic updates with `onMutate` -> `cancelQueries` + `getQueryData` + `setQueryData`, rolling back in `onError` — worked example: `useUpdateHarnessAgent` in `entrypoints/app/agents/useAgents.ts`.
+Either lane: keep query keys in one place — derive GraphQL keys with `getQueryKeyFromDocument(Document)`, give REST hooks a module-level query-key const (e.g. `AGENT_QUERY_KEYS`) — and invalidate through that, never a hand-written string literal (`BrowserOsAiPane.tsx` invalidates via `getQueryKeyFromDocument(...)`). For instant-feeling mutations, do optimistic updates with `onMutate` -> `cancelQueries` + `getQueryData` + `setQueryData`, rolling back in `onError` — worked example: `useUpdateHarnessAgent` in `entrypoints/app/agents/useAgents.ts`.
 
 ## GraphQL and codegen
 
@@ -89,7 +89,7 @@ cd apps/agent && bun run codegen
 
 Every form uses `react-hook-form` for state and submission plus a single `zod` schema for validation, bridged by `@hookform/resolvers/zod` — no `useState`-per-field. The UI is the shadcn `Form` set (`Form`, `FormField`, `FormItem`, `FormLabel`, `FormControl`, `FormMessage`) from `@/components/ui/form`. The schema is the source of truth: derive `FormValues` with `z.infer`, pass `zodResolver(schema)` to `useForm`, and surface per-field errors through `<FormMessage />` instead of rolling your own error state.
 
-- Import `z` from `zod/v3`, not `zod`. The package ships zod 4, but `@hookform/resolvers` and this Form pattern target the v3 API; `zod/v3` is the compat entry the existing forms use.
+- Import `z` from `zod/v3`, not `zod`. The package ships zod 4, which exposes a `zod/v3` compatibility entry; every existing form standardizes on it, so match them.
 - Reference: `entrypoints/app/connect-mcp/AddCustomMCPDialog.tsx` (also `ai-settings/NewProviderDialog.tsx`, `scheduled-tasks/NewScheduledTaskDialog.tsx`).
 
 ## Routing
@@ -98,11 +98,11 @@ Each page entrypoint owns a `react-router` v7 `HashRouter` with one central rout
 
 ## Dates and times
 
-`dayjs` is the one date library (already a dependency) — use it for parsing, comparison, and formatting; prefer it over ad-hoc `Date`/`Intl` math, and don't add a second date lib. There is no central date module: keep a reusable formatter in the owning feature's helper file (e.g. `entrypoints/sidepanel/history/components/utils.ts`, `entrypoints/app/agents/agent-display.helpers.ts`) rather than re-deriving the same bucketing inline.
+`dayjs` is the one date library (already a dependency) — use it for parsing, comparison, and formatting; prefer it over ad-hoc `Date`/`Intl` math, and don't add a second date lib. There is no central date module: keep a reusable formatter in the owning feature's helper file (e.g. `entrypoints/sidepanel/history/components/utils.ts`) rather than re-deriving the same bucketing inline.
 
 ## Module boundaries and formatting
 
-- Run `bun run fallow` before pushing. It flags unused files/exports, circular dependencies, and private-type leaks (`.fallowrc.json`); `generated/**`, `components/ui/**`, and `components/ai-elements/**` are exempt.
+- From the monorepo root, run `bun run fallow` before pushing. It flags unused files/exports, circular dependencies, and private-type leaks (`.fallowrc.json`); `generated/**` is ignored, and fallow skips its unused/leak checks for `components/ui/**` and `components/ai-elements/**`.
 - Colocate a feature's pieces with the entrypoint that owns them — its `graphql/` documents, `*.helpers.ts`, and `*.test.ts` sit next to it. Only genuinely shared code goes in `lib/` or `components/`, imported via the `@/` alias.
 - Biome owns formatting and import order — run `bun run lint:fix` rather than hand-formatting.
 - Comments: default to none and explain *why*, not *what*; see `packages/browseros-agent/CLAUDE.md` for the full rule.


### PR DESCRIPTION
## Summary
- Adds frontend/React writing conventions to `apps/agent/CLAUDE.md`, modeled on a sibling repo's well-structured doc but rewritten to match **this** repo's real stack and cited to existing files.
- New sections: **Server state and data fetching** (TanStack Query, two lanes), **Forms**, **Routing**, **Dates and times**, **Module boundaries and formatting**, a generated-folders rule folded into **UI conventions**, and a closing **When in doubt, read a sibling**.
- Accuracy-first: documents the actual stack — WXT + React 19, GraphQL (`lib/graphql` helpers + colocated `graphql()` docs) **and** a local-REST lane (`useAgents.ts`, `useCredits.ts`), `react-hook-form` + `@hookform/resolvers/zod` + `zod/v3` + shadcn `<Form>`, `react-router` v7 `HashRouter`, `dayjs`, Biome + fallow.

## Design
The sibling source described a different stack (Electron + Hono RPC + react-query-kit + a central `lib/dateTime` + fallow import-direction "zones"). Rather than port it verbatim, I investigated this repo first and wrote conventions that are true here — e.g. there is **no** `lib/dateTime.ts` (dayjs is used inline), `fallow` checks unused/circular/private-type-leaks (not zones), and raw `fetch` wrapped in react-query is a legitimate second data lane. Additions are pointer-first (real `path` references over long code dumps) and slot into the existing doc's flat `##`/bullet tone, per researched CLAUDE.md best practices (lean, one topic per header, defer style to the linter). Every cited path was verified to exist and every behavioral claim checked against the code via two adversarial review passes.

## Test plan
- [x] `git diff --check` clean (docs-only change)
- [x] `bunx biome check` green (Markdown is lint-neutral)
- [x] All 13 cited file paths verified to exist
- [x] Claims cross-checked against `.fallowrc.json`, `biome.json`, `apps/agent/package.json`, and the cited source files
- [ ] Reviewer sanity-check that the conventions match how you'd want new `apps/agent` code written