### PR TITLE
feat: spill large snapshots to temp files

### DIFF
--- a/packages/browseros-agent/apps/server/src/tools/browser/snapshot.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/snapshot.ts
@@ -1,6 +1,14 @@
 import { z } from 'zod'
 import { defineTool, textResult } from './framework'
+import { writeTempToolOutputFile } from './output-file'
 import { wrapUntrusted } from './trust-boundary'
+
+const LARGE_SNAPSHOT_WORD_THRESHOLD = 5_000
+
+function countWords(text: string): number {
+  const trimmed = text.trim()
+  return trimmed ? trimmed.split(/\s+/).length : 0
+}
 
 export const snapshot = defineTool({
   name: 'snapshot',
@@ -13,7 +21,33 @@ export const snapshot = defineTool({
   handler: async (args, ctx) => {
     const { text } = await ctx.session.observe(args.page).snapshot()
     const origin = ctx.session.pages.getInfo(args.page)?.url ?? 'unknown'
-    return textResult(wrapUntrusted(text || '(empty page)', origin), {
+    const snapshotText = text || '(empty page)'
+    const wordCount = countWords(text)
+    const wrappedSnapshot = wrapUntrusted(snapshotText, origin)
+
+    if (wordCount > LARGE_SNAPSHOT_WORD_THRESHOLD) {
+      const path = await writeTempToolOutputFile({
+        toolName: 'snapshot',
+        extension: 'md',
+        content: wrappedSnapshot,
+      })
+
+      return textResult(
+        [
+          `Large snapshot (${wordCount} words, ${wrappedSnapshot.length} chars) saved to: ${path}`,
+          'Read the file for the full snapshot and refs.',
+        ].join('\n'),
+        {
+          page: args.page,
+          path,
+          contentLength: wrappedSnapshot.length,
+          wordCount,
+          writtenToFile: true,
+        },
+      )
+    }
+
+    return textResult(wrappedSnapshot, {
       page: args.page,
     })
   },

--- a/packages/browseros-agent/apps/server/src/tools/browser/snapshot.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/snapshot.ts
@@ -4,6 +4,7 @@ import { writeTempToolOutputFile } from './output-file'
 import { wrapUntrusted } from './trust-boundary'
 
 const LARGE_SNAPSHOT_WORD_THRESHOLD = 5_000
+const LARGE_SNAPSHOT_CHAR_THRESHOLD = 50_000
 
 function countWords(text: string): number {
   const trimmed = text.trim()
@@ -24,8 +25,12 @@ export const snapshot = defineTool({
     const snapshotText = text || '(empty page)'
     const wordCount = countWords(text)
     const wrappedSnapshot = wrapUntrusted(snapshotText, origin)
+    const contentLength = wrappedSnapshot.length
 
-    if (wordCount > LARGE_SNAPSHOT_WORD_THRESHOLD) {
+    if (
+      wordCount > LARGE_SNAPSHOT_WORD_THRESHOLD ||
+      snapshotText.length > LARGE_SNAPSHOT_CHAR_THRESHOLD
+    ) {
       const path = await writeTempToolOutputFile({
         toolName: 'snapshot',
         extension: 'md',
@@ -34,13 +39,13 @@ export const snapshot = defineTool({
 
       return textResult(
         [
-          `Large snapshot (${wordCount} words, ${wrappedSnapshot.length} chars) saved to: ${path}`,
+          `Large snapshot (${wordCount} words, ${contentLength} chars) saved to: ${path}`,
           'Read the file for the full snapshot and refs.',
         ].join('\n'),
         {
           page: args.page,
           path,
-          contentLength: wrappedSnapshot.length,
+          contentLength,
           wordCount,
           writtenToFile: true,
         },

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -1,4 +1,7 @@
 import { describe, expect, it } from 'bun:test'
+import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
 import { TOOL_LIMITS } from '@browseros/shared/constants/limits'
 import { z } from 'zod'
 import { CHAT_MODE_ALLOWED_TOOLS } from '../../../src/agent/chat-mode'
@@ -228,6 +231,106 @@ describe('registerBrowserTools', () => {
         }),
       ]),
     )
+  })
+
+  it('keeps small snapshots inline with the existing structured content', async () => {
+    const fake = createFakeServer()
+    const session = {
+      observe: () => ({
+        snapshot: async () => ({ text: '- button "Save" [ref=e1]' }),
+      }),
+      pages: {
+        getInfo: () => ({ url: 'https://example.com/small' }),
+      },
+    } as unknown as BrowserSession
+
+    registerBrowserTools(fake.server as never, session)
+
+    const result = await fake.handlers.get('snapshot')?.({ page: 2 })
+
+    expect(result?.isError).toBeFalsy()
+    expect(result?.structuredContent).toEqual({ page: 2 })
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('[UNTRUSTED_PAGE_CONTENT'),
+      }),
+    ])
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('- button "Save" [ref=e1]'),
+      }),
+    ])
+    expect(JSON.stringify(result?.structuredContent)).not.toContain('path')
+  })
+
+  it('writes very large snapshots to a markdown temp file', async () => {
+    const fake = createFakeServer()
+    const largeSnapshot = Array.from(
+      { length: 5001 },
+      (_, i) => `node-${i}`,
+    ).join(' ')
+    const session = {
+      observe: () => ({
+        snapshot: async () => ({ text: largeSnapshot }),
+      }),
+      pages: {
+        getInfo: () => ({ url: 'https://example.com/large' }),
+      },
+    } as unknown as BrowserSession
+    let savedPath: string | undefined
+
+    registerBrowserTools(fake.server as never, session)
+
+    try {
+      const result = await fake.handlers.get('snapshot')?.({ page: 4 })
+
+      expect(result?.isError).toBeFalsy()
+      const data = result?.structuredContent as
+        | {
+            page: number
+            path: string
+            contentLength: number
+            wordCount: number
+            writtenToFile: boolean
+          }
+        | undefined
+      expect(data).toMatchObject({
+        page: 4,
+        wordCount: 5001,
+        writtenToFile: true,
+      })
+      savedPath = data?.path
+      expect(savedPath).toBeTruthy()
+      expect(savedPath?.endsWith('.md')).toBe(true)
+      expect(dirname(savedPath ?? '')).toStartWith(
+        join(tmpdir(), 'browseros-browser-tool-'),
+      )
+      expect(result?.content).toEqual([
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining('Large snapshot'),
+        }),
+      ])
+      expect(result?.content).toEqual([
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining(savedPath ?? ''),
+        }),
+      ])
+      expect(existsSync(savedPath ?? '')).toBe(true)
+
+      const savedContent = readFileSync(savedPath ?? '', 'utf8')
+      expect(savedContent).toContain('[UNTRUSTED_PAGE_CONTENT')
+      expect(savedContent).toContain('[END_UNTRUSTED_PAGE_CONTENT')
+      expect(savedContent).toContain('node-0')
+      expect(savedContent).toContain('node-5000')
+      expect(data?.contentLength).toBe(savedContent.length)
+    } finally {
+      if (savedPath)
+        rmSync(dirname(savedPath), { recursive: true, force: true })
+    }
   })
 
   it('returns read errors for page-side exceptions', async () => {

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -333,6 +333,50 @@ describe('registerBrowserTools', () => {
     }
   })
 
+  it('writes very long unbroken snapshots to a markdown temp file', async () => {
+    const fake = createFakeServer()
+    const largeSnapshot = 'x'.repeat(50_001)
+    const session = {
+      observe: () => ({
+        snapshot: async () => ({ text: largeSnapshot }),
+      }),
+      pages: {
+        getInfo: () => ({ url: 'https://example.com/long-token' }),
+      },
+    } as unknown as BrowserSession
+    let savedPath: string | undefined
+
+    registerBrowserTools(fake.server as never, session)
+
+    try {
+      const result = await fake.handlers.get('snapshot')?.({ page: 5 })
+      const data = result?.structuredContent as
+        | {
+            path: string
+            wordCount: number
+            writtenToFile: boolean
+          }
+        | undefined
+
+      expect(result?.isError).toBeFalsy()
+      expect(data).toMatchObject({
+        wordCount: 1,
+        writtenToFile: true,
+      })
+      savedPath = data?.path
+      expect(result?.content).toEqual([
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining(savedPath ?? ''),
+        }),
+      ])
+      expect(readFileSync(savedPath ?? '', 'utf8')).toContain(largeSnapshot)
+    } finally {
+      if (savedPath)
+        rmSync(dirname(savedPath), { recursive: true, force: true })
+    }
+  })
+
   it('returns read errors for page-side exceptions', async () => {
     const fake = createFakeServer()
     const session = {


### PR DESCRIPTION
## Summary
- Write very large active browser snapshots to markdown temp files instead of returning full snapshot text inline.
- Preserve small snapshot behavior and trust-boundary wrapping; saved files contain the full wrapped snapshot.
- Return structured metadata for large snapshots: page, path, contentLength, wordCount, and writtenToFile.

## Design
The active snapshot tool keeps the existing observe/origin/wrap/textResult flow. It branches only when the raw snapshot exceeds 5000 words or a conservative 50000-character fallback, then writes the wrapped content with writeTempToolOutputFile and returns a concise file-path message.

## Test plan
- [x] cd apps/server && bun test tests/tools/browser/register.test.ts
- [x] bun run lint
- [x] bun run typecheck
- [x] bun run test:main

Note: lint exits 0 with existing warnings outside this change.