### PR TITLE
fix: handle browser diff URL changes

### DIFF
--- a/packages/browseros-agent/apps/server/src/browser/core/observer/observer.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/observer/observer.ts
@@ -10,6 +10,7 @@ import type { FrameRegistry } from './frames'
 import { type ResolvedElement, resolveRefEntry } from './resolve'
 
 const MAX_FRAME_DEPTH = 5
+const MAX_STABLE_CAPTURE_ATTEMPTS = 3
 
 export interface SnapshotResult {
   text: string
@@ -61,13 +62,17 @@ export class Observer {
 
   private async capture(): Promise<SnapshotResult> {
     const pageSession = await this.pages.getSession(this.pageId)
-    const refs = new RefMap()
-    const text = await this.captureFrame(undefined, refs, 0, new Set())
-    const url = await readCurrentUrl(pageSession.session, async () => {
-      const refreshed = await this.pages.refresh(this.pageId)
-      return refreshed?.url
-    })
-    return { text, refs, url }
+    let latest: SnapshotResult | undefined
+    for (let attempt = 0; attempt < MAX_STABLE_CAPTURE_ATTEMPTS; attempt++) {
+      const beforeUrl = await this.readCurrentUrl(pageSession.session)
+      const refs = new RefMap()
+      const text = await this.captureFrame(undefined, refs, 0, new Set())
+      const afterUrl = await this.readCurrentUrl(pageSession.session)
+      latest = { text, refs, url: afterUrl }
+      if (!knownUrlsDiffer(beforeUrl, afterUrl)) return latest
+    }
+    if (!latest) throw new Error('Unable to capture page snapshot.')
+    return latest
   }
 
   /** Render a frame, then splice each child iframe's rendered tree under its `- iframe` line. */
@@ -121,6 +126,13 @@ export class Observer {
     this.baseline = { text: result.text, url: result.url }
     this.refs = result.refs
   }
+
+  private async readCurrentUrl(session: ProtocolApi): Promise<string> {
+    return readCurrentUrl(session, async () => {
+      const refreshed = await this.pages.refresh(this.pageId)
+      return refreshed?.url
+    })
+  }
 }
 
 /** Reads the live document URL, falling back to the tab registry during context teardown. */
@@ -140,6 +152,12 @@ async function readCurrentUrl(
   } catch {
     return 'unknown'
   }
+}
+
+function knownUrlsDiffer(beforeUrl: string, afterUrl: string): boolean {
+  return (
+    beforeUrl !== 'unknown' && afterUrl !== 'unknown' && beforeUrl !== afterUrl
+  )
 }
 
 /** Resolve an iframe element to the frameId of its embedded document. */

--- a/packages/browseros-agent/apps/server/src/browser/core/observer/observer.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/observer/observer.ts
@@ -63,7 +63,10 @@ export class Observer {
     const pageSession = await this.pages.getSession(this.pageId)
     const refs = new RefMap()
     const text = await this.captureFrame(undefined, refs, 0, new Set())
-    const url = await readCurrentUrl(pageSession.session, pageSession.url)
+    const url = await readCurrentUrl(pageSession.session, async () => {
+      const refreshed = await this.pages.refresh(this.pageId)
+      return refreshed?.url
+    })
     return { text, refs, url }
   }
 
@@ -123,7 +126,7 @@ export class Observer {
 /** Reads the live document URL, falling back to the tab registry during context teardown. */
 async function readCurrentUrl(
   session: ProtocolApi,
-  fallback: string,
+  fallback: () => Promise<string | undefined>,
 ): Promise<string> {
   try {
     const result = await session.Runtime.evaluate({
@@ -132,7 +135,11 @@ async function readCurrentUrl(
     })
     if (typeof result.result?.value === 'string') return result.result.value
   } catch {}
-  return fallback || 'unknown'
+  try {
+    return (await fallback()) || 'unknown'
+  } catch {
+    return 'unknown'
+  }
 }
 
 /** Resolve an iframe element to the frameId of its embedded document. */

--- a/packages/browseros-agent/apps/server/src/browser/core/observer/observer.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/observer/observer.ts
@@ -1,7 +1,7 @@
 import type { ProtocolApi } from '@browseros/cdp-protocol/protocol-api'
 import type { FrameId } from '../connection'
 import type { PageManager } from '../pages'
-import { diffSnapshots, type SnapshotDiff } from '../snapshot/diff'
+import { diffSnapshotObservations, type SnapshotDiff } from '../snapshot/diff'
 import { RefMap } from '../snapshot/refs'
 import { renderSnapshot } from '../snapshot/render'
 import { fetchAxTree } from './ax-tree'
@@ -14,15 +14,12 @@ const MAX_FRAME_DEPTH = 5
 export interface SnapshotResult {
   text: string
   refs: RefMap
+  url: string
 }
 
-/**
- * Per-page observation. Renders the accessibility tree (stitched across iframes into one tree
- * with a single global ref namespace) and diffs successive observations against a stored
- * baseline. Holds the last RefMap so refs can be resolved through the right frame session.
- */
+/** Per-page snapshot, ref, and diff state for one BrowserOS page id. */
 export class Observer {
-  private baseline = ''
+  private baseline?: { text: string; url: string }
   private refs = new RefMap()
 
   constructor(
@@ -41,7 +38,7 @@ export class Observer {
     const before = this.baseline
     const result = await this.capture()
     this.commit(result)
-    return diffSnapshots(before, result.text)
+    return diffSnapshotObservations(before, result)
   }
 
   get lastRefs(): RefMap {
@@ -63,11 +60,11 @@ export class Observer {
   }
 
   private async capture(): Promise<SnapshotResult> {
-    // Ensure the page session is attached + registered with the frame tracker.
-    await this.pages.getSession(this.pageId)
+    const pageSession = await this.pages.getSession(this.pageId)
     const refs = new RefMap()
     const text = await this.captureFrame(undefined, refs, 0, new Set())
-    return { text, refs }
+    const url = await readCurrentUrl(pageSession.session, pageSession.url)
+    return { text, refs, url }
   }
 
   /** Render a frame, then splice each child iframe's rendered tree under its `- iframe` line. */
@@ -118,9 +115,24 @@ export class Observer {
   }
 
   private commit(result: SnapshotResult): void {
-    this.baseline = result.text
+    this.baseline = { text: result.text, url: result.url }
     this.refs = result.refs
   }
+}
+
+/** Reads the live document URL, falling back to the tab registry during context teardown. */
+async function readCurrentUrl(
+  session: ProtocolApi,
+  fallback: string,
+): Promise<string> {
+  try {
+    const result = await session.Runtime.evaluate({
+      expression: 'location.href',
+      returnByValue: true,
+    })
+    if (typeof result.result?.value === 'string') return result.result.value
+  } catch {}
+  return fallback || 'unknown'
 }
 
 /** Resolve an iframe element to the frameId of its embedded document. */

--- a/packages/browseros-agent/apps/server/src/browser/core/observer/observer.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/observer/observer.ts
@@ -62,17 +62,15 @@ export class Observer {
 
   private async capture(): Promise<SnapshotResult> {
     const pageSession = await this.pages.getSession(this.pageId)
-    let latest: SnapshotResult | undefined
     for (let attempt = 0; attempt < MAX_STABLE_CAPTURE_ATTEMPTS; attempt++) {
       const beforeUrl = await this.readCurrentUrl(pageSession.session)
       const refs = new RefMap()
       const text = await this.captureFrame(undefined, refs, 0, new Set())
       const afterUrl = await this.readCurrentUrl(pageSession.session)
-      latest = { text, refs, url: afterUrl }
-      if (!knownUrlsDiffer(beforeUrl, afterUrl)) return latest
+      if (!knownUrlsDiffer(beforeUrl, afterUrl))
+        return { text, refs, url: afterUrl }
     }
-    if (!latest) throw new Error('Unable to capture page snapshot.')
-    return latest
+    throw new Error('Page URL changed during snapshot capture; retry.')
   }
 
   /** Render a frame, then splice each child iframe's rendered tree under its `- iframe` line. */

--- a/packages/browseros-agent/apps/server/src/browser/core/snapshot/diff.test.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/snapshot/diff.test.ts
@@ -87,4 +87,21 @@ describe('diffSnapshots', () => {
     expect(d.text).toContain('-   button "Old"')
     expect(d.text).toContain('+   button "New"')
   })
+
+  test('same-url diffs preserve the current url for callers', () => {
+    const d = diffSnapshotObservations(
+      {
+        text: '- main\n  - button "Save" [ref=e1]',
+        url: 'https://example.com/form',
+      },
+      {
+        text: '- main\n  - button "Saved" [ref=e1]',
+        url: 'https://example.com/form',
+      },
+    )
+
+    expect(d.changed).toBe(true)
+    expect(d.urlChanged).toBeUndefined()
+    expect(d.afterUrl).toBe('https://example.com/form')
+  })
 })

--- a/packages/browseros-agent/apps/server/src/browser/core/snapshot/diff.test.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/snapshot/diff.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test'
-import { diffSnapshots } from './diff'
+import { diffSnapshotObservations, diffSnapshots } from './diff'
 
 describe('diffSnapshots', () => {
   test('identical snapshots short-circuit to no change', () => {
@@ -48,7 +48,43 @@ describe('diffSnapshots', () => {
     expect(d.text).toContain('- item 0')
     expect(d.text).toContain('+ item ZERO')
     expect(d.text).toContain('+ item LAST')
-    // The unchanged middle (e.g. item 15) is elided.
     expect(d.text).not.toContain('item 15')
+  })
+
+  test('url changes return the full current snapshot instead of a line diff', () => {
+    const before = {
+      text: '- main\n  - button "Old page" [ref=e1]',
+      url: 'https://example.com/old',
+    }
+    const after = {
+      text: '- main\n  - heading "New page"',
+      url: 'https://example.com/new',
+    }
+
+    const d = diffSnapshotObservations(before, after)
+
+    expect(d).toMatchObject({
+      text: after.text,
+      added: 0,
+      removed: 0,
+      changed: true,
+      urlChanged: true,
+      beforeUrl: before.url,
+      afterUrl: after.url,
+    })
+  })
+
+  test('unknown urls keep existing line-diff behavior', () => {
+    const d = diffSnapshotObservations(
+      { text: '- main\n  - button "Old"', url: 'unknown' },
+      { text: '- main\n  - button "New"', url: 'https://example.com/new' },
+    )
+
+    expect(d.changed).toBe(true)
+    expect(d.urlChanged).toBeUndefined()
+    expect(d.added).toBe(1)
+    expect(d.removed).toBe(1)
+    expect(d.text).toContain('-   button "Old"')
+    expect(d.text).toContain('+   button "New"')
   })
 })

--- a/packages/browseros-agent/apps/server/src/browser/core/snapshot/diff.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/snapshot/diff.ts
@@ -78,7 +78,9 @@ export function diffSnapshotObservations(
     }
   }
 
-  return diffSnapshots(before?.text ?? '', after.text, opts)
+  const diff = diffSnapshots(before?.text ?? '', after.text, opts)
+  if (isKnownUrl(afterUrl)) return { ...diff, afterUrl }
+  return diff
 }
 
 function isKnownUrl(url: string | undefined): url is string {

--- a/packages/browseros-agent/apps/server/src/browser/core/snapshot/diff.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/snapshot/diff.ts
@@ -6,10 +6,18 @@ export interface SnapshotDiff {
   added: number
   removed: number
   changed: boolean
+  urlChanged?: true
+  beforeUrl?: string
+  afterUrl?: string
 }
 
 export interface DiffOptions {
   contextRadius?: number
+}
+
+export interface SnapshotObservation {
+  text: string
+  url?: string
 }
 
 interface TaggedLine {
@@ -48,6 +56,33 @@ export function diffSnapshots(
     removed,
     changed: true,
   }
+}
+
+/** Compares successive page observations, returning the full snapshot when navigation changed the URL. */
+export function diffSnapshotObservations(
+  before: SnapshotObservation | undefined,
+  after: SnapshotObservation,
+  opts: DiffOptions = {},
+): SnapshotDiff {
+  const beforeUrl = before?.url
+  const afterUrl = after.url
+  if (isKnownUrl(beforeUrl) && isKnownUrl(afterUrl) && beforeUrl !== afterUrl) {
+    return {
+      text: after.text,
+      added: 0,
+      removed: 0,
+      changed: true,
+      urlChanged: true,
+      beforeUrl,
+      afterUrl,
+    }
+  }
+
+  return diffSnapshots(before?.text ?? '', after.text, opts)
+}
+
+function isKnownUrl(url: string | undefined): url is string {
+  return url !== undefined && url !== '' && url !== 'unknown'
 }
 
 function splitLines(value: string): string[] {

--- a/packages/browseros-agent/apps/server/src/tools/browser/act.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/act.ts
@@ -67,7 +67,7 @@ export const act = defineTool({
     const origin =
       diff.afterUrl ?? ctx.session.pages.getInfo(args.page)?.url ?? 'unknown'
     const body = diff.urlChanged
-      ? `page URL changed from ${diff.beforeUrl} to ${diff.afterUrl}; returning full current snapshot instead of a diff:\n${wrapUntrusted(diff.text || '(empty page)', origin)}`
+      ? `page URL changed; returning full current snapshot instead of a diff:\n${wrapUntrusted(diff.text || '(empty page)', origin)}`
       : diff.changed
         ? `page changed:\n${wrapUntrusted(diff.text, origin)}`
         : 'no visible change'

--- a/packages/browseros-agent/apps/server/src/tools/browser/act.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/act.ts
@@ -64,14 +64,25 @@ export const act = defineTool({
     if (err) return err
 
     const diff = await ctx.session.observe(args.page).diff()
-    const origin = ctx.session.pages.getInfo(args.page)?.url ?? 'unknown'
-    const body = diff.changed
-      ? `page changed:\n${wrapUntrusted(diff.text, origin)}`
-      : 'no visible change'
-    return textResult(`ok (${args.kind}) · ${body}`, {
+    const origin =
+      diff.afterUrl ?? ctx.session.pages.getInfo(args.page)?.url ?? 'unknown'
+    const body = diff.urlChanged
+      ? `page URL changed from ${diff.beforeUrl} to ${diff.afterUrl}; returning full current snapshot instead of a diff:\n${wrapUntrusted(diff.text || '(empty page)', origin)}`
+      : diff.changed
+        ? `page changed:\n${wrapUntrusted(diff.text, origin)}`
+        : 'no visible change'
+    const structured: Record<string, unknown> = {
       kind: args.kind,
       changed: diff.changed,
-    })
+    }
+    if (diff.urlChanged) {
+      Object.assign(structured, {
+        urlChanged: true,
+        beforeUrl: diff.beforeUrl,
+        afterUrl: diff.afterUrl,
+      })
+    }
+    return textResult(`ok (${args.kind}) · ${body}`, structured)
   },
 })
 

--- a/packages/browseros-agent/apps/server/src/tools/browser/diff.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/diff.ts
@@ -15,7 +15,7 @@ export const diff = defineTool({
       d.afterUrl ?? ctx.session.pages.getInfo(args.page)?.url ?? 'unknown'
     if (d.urlChanged) {
       return textResult(
-        `URL changed from ${d.beforeUrl} to ${d.afterUrl}; returning full current snapshot instead of a diff:\n${wrapUntrusted(d.text || '(empty page)', origin)}`,
+        `URL changed; returning full current snapshot instead of a diff:\n${wrapUntrusted(d.text || '(empty page)', origin)}`,
         {
           added: d.added,
           removed: d.removed,

--- a/packages/browseros-agent/apps/server/src/tools/browser/diff.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/diff.ts
@@ -11,7 +11,20 @@ export const diff = defineTool({
   handler: async (args, ctx) => {
     const d = await ctx.session.observe(args.page).diff()
     if (!d.changed) return textResult('no change since last snapshot')
-    const origin = ctx.session.pages.getInfo(args.page)?.url ?? 'unknown'
+    const origin =
+      d.afterUrl ?? ctx.session.pages.getInfo(args.page)?.url ?? 'unknown'
+    if (d.urlChanged) {
+      return textResult(
+        `URL changed from ${d.beforeUrl} to ${d.afterUrl}; returning full current snapshot instead of a diff:\n${wrapUntrusted(d.text || '(empty page)', origin)}`,
+        {
+          added: d.added,
+          removed: d.removed,
+          urlChanged: true,
+          beforeUrl: d.beforeUrl,
+          afterUrl: d.afterUrl,
+        },
+      )
+    }
     return textResult(wrapUntrusted(d.text, origin), {
       added: d.added,
       removed: d.removed,

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -218,6 +218,43 @@ describe('registerBrowserTools', () => {
     ])
   })
 
+  it('wraps same-url diffs with the observed current URL', async () => {
+    const fake = createFakeServer()
+    const session = {
+      observe: () => ({
+        diff: async () => ({
+          changed: true,
+          text: '+   button "Saved" [ref=e1]\n1 added, 0 removed',
+          added: 1,
+          removed: 0,
+          afterUrl: 'https://example.com/current',
+        }),
+      }),
+      pages: {
+        getInfo: () => ({ url: 'https://example.com/stale' }),
+      },
+    } as unknown as BrowserSession
+
+    registerBrowserTools(fake.server as never, session)
+
+    const result = await fake.handlers.get('diff')?.({ page: 1 })
+
+    expect(result?.isError).toBeFalsy()
+    expect(result?.structuredContent).toEqual({ added: 1, removed: 0 })
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('origin=https://example.com/current'),
+      }),
+    ])
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.not.stringContaining('origin=https://example.com/stale'),
+      }),
+    ])
+  })
+
   it('returns a full snapshot when act readback sees a URL change', async () => {
     const fake = createFakeServer()
     const calls: string[] = []

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -193,9 +193,7 @@ describe('registerBrowserTools', () => {
     expect(result?.content).toEqual([
       expect.objectContaining({
         type: 'text',
-        text: expect.stringContaining(
-          'URL changed from https://example.com/old to https://example.com/new',
-        ),
+        text: expect.stringContaining('URL changed;'),
       }),
     ])
     expect(result?.content).toEqual([
@@ -218,6 +216,74 @@ describe('registerBrowserTools', () => {
         text: expect.stringContaining('- heading "New page"'),
       }),
     ])
+  })
+
+  it('returns a full snapshot when act readback sees a URL change', async () => {
+    const fake = createFakeServer()
+    const calls: string[] = []
+    const session = {
+      input: () => ({
+        click: async () => calls.push('click'),
+      }),
+      observe: () => ({
+        diff: async () => ({
+          changed: true,
+          text: '- main\n  - heading "Destination"',
+          added: 0,
+          removed: 0,
+          urlChanged: true,
+          beforeUrl: 'https://example.com/start',
+          afterUrl: 'https://example.com/destination',
+        }),
+      }),
+      pages: {
+        getInfo: () => ({ url: 'https://example.com/destination' }),
+      },
+    } as unknown as BrowserSession
+
+    registerBrowserTools(fake.server as never, session)
+
+    const result = await fake.handlers.get('act')?.({
+      page: 1,
+      kind: 'click',
+      ref: 'e1',
+    })
+
+    expect(result?.isError).toBeFalsy()
+    expect(result?.structuredContent).toEqual({
+      kind: 'click',
+      changed: true,
+      urlChanged: true,
+      beforeUrl: 'https://example.com/start',
+      afterUrl: 'https://example.com/destination',
+    })
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('page URL changed;'),
+      }),
+    ])
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining(
+          'returning full current snapshot instead of a diff',
+        ),
+      }),
+    ])
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('[UNTRUSTED_PAGE_CONTENT'),
+      }),
+    ])
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('- heading "Destination"'),
+      }),
+    ])
+    expect(calls).toEqual(['click'])
   })
 
   it('caps page-context JavaScript timeouts', async () => {

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -159,6 +159,67 @@ describe('registerBrowserTools', () => {
     )
   })
 
+  it('returns a full snapshot when diff sees a URL change', async () => {
+    const fake = createFakeServer()
+    const session = {
+      observe: () => ({
+        diff: async () => ({
+          changed: true,
+          text: '- main\n  - heading "New page"',
+          added: 0,
+          removed: 0,
+          urlChanged: true,
+          beforeUrl: 'https://example.com/old',
+          afterUrl: 'https://example.com/new',
+        }),
+      }),
+      pages: {
+        getInfo: () => ({ url: 'https://example.com/new' }),
+      },
+    } as unknown as BrowserSession
+
+    registerBrowserTools(fake.server as never, session)
+
+    const result = await fake.handlers.get('diff')?.({ page: 1 })
+
+    expect(result?.isError).toBeFalsy()
+    expect(result?.structuredContent).toEqual({
+      added: 0,
+      removed: 0,
+      urlChanged: true,
+      beforeUrl: 'https://example.com/old',
+      afterUrl: 'https://example.com/new',
+    })
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining(
+          'URL changed from https://example.com/old to https://example.com/new',
+        ),
+      }),
+    ])
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining(
+          'returning full current snapshot instead of a diff',
+        ),
+      }),
+    ])
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('[UNTRUSTED_PAGE_CONTENT'),
+      }),
+    ])
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('- heading "New page"'),
+      }),
+    ])
+  })
+
   it('caps page-context JavaScript timeouts', async () => {
     const fake = createFakeServer()
     const evaluateCalls: Array<Record<string, unknown>> = []


### PR DESCRIPTION
## Summary
- Track the URL with each browser snapshot observation and return the full current snapshot when the URL changed instead of emitting a misleading line diff.
- Keep URL-change responses inside the existing untrusted page-content wrapper, with generic trusted prose and URL-change metadata.
- Stabilize snapshot capture around URL reads so navigation during capture asks the caller to retry instead of committing an incoherent baseline.

## Design
The observer now owns URL-aware snapshot baselines, and the pure snapshot diff layer compares observations before line-diffing. Tool renderers preserve existing result conventions while handling the URL-change branch explicitly for both `diff` and `act`.

## Test plan
- [x] `bun test apps/server/src/browser/core/snapshot/diff.test.ts apps/server/tests/tools/browser/register.test.ts`
- [x] `bun run lint` (exits 0; existing warnings remain outside this change)
- [x] `bun run typecheck`
- [x] `bun run test:main`
