### PR TITLE
feat: add browser tool post-action responses

### DIFF
--- a/packages/browseros-agent/apps/server/src/tools/browser/framework.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/framework.ts
@@ -1,5 +1,10 @@
 import type { TypeOf, ZodObject, ZodRawShape } from 'zod'
 import type { BrowserSession } from '../../browser/core/session'
+import {
+  type ContentItem,
+  type ToolResult as ResponseToolResult,
+  ToolResponse,
+} from '../response'
 
 type ToolInputSchema = ZodObject<ZodRawShape>
 
@@ -10,22 +15,8 @@ export interface ToolContext {
   signal?: AbortSignal
 }
 
-export interface TextBlock {
-  type: 'text'
-  text: string
-}
-export interface ImageBlock {
-  type: 'image'
-  data: string
-  mimeType: string
-}
-export type ContentBlock = TextBlock | ImageBlock
-
-export interface ToolResult {
-  content: ContentBlock[]
-  structuredContent?: unknown
-  isError?: boolean
-}
+export type ContentBlock = ContentItem
+export type ToolResult = ResponseToolResult
 
 export interface ToolAnnotations {
   readOnlyHint?: boolean
@@ -41,7 +32,8 @@ export interface ToolDefinition {
   handler: (
     args: Record<string, unknown>,
     ctx: ToolContext,
-  ) => Promise<ToolResult>
+    response: ToolResponse,
+  ) => Promise<ToolResult | undefined>
 }
 
 export function defineTool<S extends ToolInputSchema>(def: {
@@ -49,7 +41,11 @@ export function defineTool<S extends ToolInputSchema>(def: {
   description: string
   input: S
   annotations?: ToolAnnotations
-  handler: (args: TypeOf<S>, ctx: ToolContext) => Promise<ToolResult>
+  handler: (
+    args: TypeOf<S>,
+    ctx: ToolContext,
+    response: ToolResponse,
+  ) => Promise<ToolResult | undefined>
 }): ToolDefinition {
   return def as unknown as ToolDefinition
 }
@@ -150,17 +146,37 @@ export async function executeTool(
     return errorResult(`Invalid arguments for ${def.name}: ${detail}`)
   }
 
+  const response = new ToolResponse()
   try {
     const result = await abortable(
-      def.handler(parsed.data as Record<string, unknown>, ctx),
+      def.handler(parsed.data as Record<string, unknown>, ctx, response),
       ctx.signal,
     )
+    if (result) response.appendResult(result)
     throwIfAborted(ctx.signal)
-    return result
   } catch (err) {
     if (ctx.signal?.aborted || isAbortError(err)) throw err
-    return errorResult(
+    response.error(
       `${def.name} failed: ${err instanceof Error ? err.message : String(err)}`,
     )
   }
+
+  throwIfAborted(ctx.signal)
+  const result = await abortable(
+    response.buildForSession(ctx.session),
+    ctx.signal,
+  )
+  throwIfAborted(ctx.signal)
+
+  const pageId = (parsed.data as Record<string, unknown>).page
+  if (typeof pageId === 'number') {
+    const tabId = (
+      ctx.session.pages as { getTabId?: (pageId: number) => number | undefined }
+    ).getTabId?.(pageId)
+    if (tabId !== undefined) {
+      result.metadata = { ...result.metadata, tabId }
+    }
+  }
+
+  return result
 }

--- a/packages/browseros-agent/apps/server/src/tools/browser/navigate.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/navigate.ts
@@ -29,7 +29,9 @@ export const navigate = defineTool({
         break
     }
 
-    const origin = ctx.session.pages.getInfo(args.page)?.url ?? 'unknown'
+    const refreshed = await ctx.session.pages.refresh(args.page)
+    const origin =
+      refreshed?.url ?? ctx.session.pages.getInfo(args.page)?.url ?? 'unknown'
     response.text(`navigated (${args.action}) -> ${origin}`)
     response.data({ page: args.page, url: origin })
     response.includeSnapshot(args.page)

--- a/packages/browseros-agent/apps/server/src/tools/browser/navigate.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/navigate.ts
@@ -1,6 +1,5 @@
 import { z } from 'zod'
-import { defineTool, errorResult, textResult } from './framework'
-import { wrapUntrusted } from './trust-boundary'
+import { defineTool, errorResult } from './framework'
 
 export const navigate = defineTool({
   name: 'navigate',
@@ -11,7 +10,7 @@ export const navigate = defineTool({
     action: z.enum(['url', 'back', 'forward', 'reload']).default('url'),
     url: z.string().optional().describe('Required when action is "url".'),
   }),
-  handler: async (args, ctx) => {
+  handler: async (args, ctx, response) => {
     const nav = ctx.session.nav(args.page)
     switch (args.action) {
       case 'url':
@@ -30,11 +29,10 @@ export const navigate = defineTool({
         break
     }
 
-    const { text } = await ctx.session.observe(args.page).snapshot()
     const origin = ctx.session.pages.getInfo(args.page)?.url ?? 'unknown'
-    return textResult(
-      `navigated (${args.action}) -> ${origin}\n${wrapUntrusted(text || '(empty page)', origin)}`,
-      { page: args.page, url: origin },
-    )
+    response.text(`navigated (${args.action}) -> ${origin}`)
+    response.data({ page: args.page, url: origin })
+    response.includeSnapshot(args.page)
+    return undefined
   },
 })

--- a/packages/browseros-agent/apps/server/src/tools/response.ts
+++ b/packages/browseros-agent/apps/server/src/tools/response.ts
@@ -1,5 +1,7 @@
 import { TIMEOUTS } from '@browseros/shared/constants/timeouts'
 import type { Browser } from '../browser/browser'
+import type { BrowserSession } from '../browser/core/session'
+import { wrapUntrusted } from './browser/trust-boundary'
 
 export type ContentItem =
   | { type: 'text'; text: string }
@@ -18,7 +20,7 @@ export interface ToolResult {
   content: ContentItem[]
   isError?: boolean
   metadata?: ToolResultMetadata
-  structuredContent?: Record<string, unknown>
+  structuredContent?: unknown
 }
 
 interface ToolResponseOptions {
@@ -28,7 +30,7 @@ interface ToolResponseOptions {
 export class ToolResponse {
   private content: ContentItem[] = []
   private hasError = false
-  private structured: Record<string, unknown> = {}
+  private structured: unknown
   private postActions: PostAction[] = []
   private postActionTimeoutMs: number
 
@@ -53,11 +55,27 @@ export class ToolResponse {
   data(key: string, value: unknown): void
   data(obj: Record<string, unknown>): void
   data(keyOrObj: string | Record<string, unknown>, value?: unknown): void {
+    const current = isRecord(this.structured) ? this.structured : {}
     if (typeof keyOrObj === 'string') {
-      this.structured[keyOrObj] = value
+      current[keyOrObj] = value
+      this.structured = current
       return
     }
-    Object.assign(this.structured, keyOrObj)
+    Object.assign(current, keyOrObj)
+    this.structured = current
+  }
+
+  /** Merges a returned ToolResult into this response during incremental tool migration. */
+  appendResult(result: ToolResult): void {
+    this.content.push(...result.content)
+    if (result.isError) this.hasError = true
+    if ('structuredContent' in result) {
+      if (isRecord(result.structuredContent)) {
+        this.data(result.structuredContent)
+      } else {
+        this.structured = result.structuredContent
+      }
+    }
   }
 
   includeSnapshot(page: number): void {
@@ -107,6 +125,47 @@ export class ToolResponse {
     }
   }
 
+  private async runSessionPostAction(
+    action: PostAction,
+    session: BrowserSession,
+  ): Promise<void> {
+    switch (action.type) {
+      case 'snapshot': {
+        const { text } = await session.observe(action.page).snapshot()
+        const origin = session.pages.getInfo(action.page)?.url ?? 'unknown'
+        this.text(
+          `[Page ${action.page} snapshot]\n${wrapUntrusted(text || '(empty page)', origin)}`,
+        )
+        return
+      }
+      case 'screenshot': {
+        const { session: pageSession } = await session.pages.getSession(
+          action.page,
+        )
+        const result = await pageSession.Page.captureScreenshot({
+          format: 'png',
+          captureBeyondViewport: false,
+        })
+        this.text(`[Page ${action.page} screenshot]`)
+        this.image(result.data, 'image/png')
+        return
+      }
+      case 'pages': {
+        const pages = await session.pages.list()
+        if (pages.length === 0) {
+          this.text('[Open pages] None')
+        } else {
+          const lines = pages.map(
+            (p) =>
+              `  ${p.pageId}. ${p.title || '(untitled)'} — ${p.url}${p.isActive ? ' [ACTIVE]' : ''}`,
+          )
+          this.text(`[Open pages]\n${lines.join('\n')}`)
+        }
+        return
+      }
+    }
+  }
+
   private async withTimeout<T>(task: Promise<T>): Promise<T> {
     let timeoutId: ReturnType<typeof setTimeout> | undefined
     try {
@@ -138,12 +197,33 @@ export class ToolResponse {
     return this.toResult()
   }
 
+  /** Builds a compact browser-tool result after running BrowserSession post-actions. */
+  async buildForSession(session: BrowserSession): Promise<ToolResult> {
+    if (this.postActions.length > 0) {
+      this.text('\n--- Additional context (auto-included) ---')
+    }
+
+    for (const action of this.postActions) {
+      try {
+        await this.withTimeout(this.runSessionPostAction(action, session))
+      } catch {
+        // Post-action failure doesn't fail the tool
+      }
+    }
+    return this.toResult()
+  }
+
   toResult(): ToolResult {
-    const hasStructured = Object.keys(this.structured).length > 0
     return {
       content: this.content,
       ...(this.hasError && { isError: true }),
-      ...(hasStructured && { structuredContent: this.structured }),
+      ...(this.structured !== undefined && {
+        structuredContent: this.structured,
+      }),
     }
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }

--- a/packages/browseros-agent/apps/server/tests/tools/browser/framework.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/framework.test.ts
@@ -120,6 +120,7 @@ describe('browser tool framework post-actions', () => {
   it('attaches navigate snapshots through the shared post-action path', async () => {
     const fake = createFakeServer()
     const calls: string[] = []
+    let currentUrl = 'https://example.com/before'
     const session = {
       nav: () => ({
         goto: async (url: string) => calls.push(`goto:${url}`),
@@ -133,7 +134,12 @@ describe('browser tool framework post-actions', () => {
       pages: {
         getInfo: () => {
           calls.push('getInfo')
-          return { url: 'https://example.com/after' }
+          return { url: currentUrl }
+        },
+        refresh: async () => {
+          calls.push('refresh')
+          currentUrl = 'https://example.com/after'
+          return { url: currentUrl }
         },
         getTabId: () => undefined,
       },
@@ -155,11 +161,12 @@ describe('browser tool framework post-actions', () => {
     })
     expect(calls).toEqual([
       'goto:https://example.com/before',
-      'getInfo',
+      'refresh',
       'snapshot:9',
       'getInfo',
     ])
     expect(text).toContain('navigated (url) -> https://example.com/after')
+    expect(text).toContain('origin=https://example.com/after')
     expect(text.indexOf('navigated (url)')).toBeLessThan(
       text.indexOf('--- Additional context'),
     )

--- a/packages/browseros-agent/apps/server/tests/tools/browser/framework.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/framework.test.ts
@@ -1,0 +1,199 @@
+import { describe, expect, it } from 'bun:test'
+import { z } from 'zod'
+import type { BrowserSession } from '../../../src/browser/core/session'
+import {
+  defineTool,
+  errorResult,
+  executeTool,
+} from '../../../src/tools/browser/framework'
+import { registerBrowserTools } from '../../../src/tools/browser/register'
+
+type RegisteredHandler = (args: Record<string, unknown>) => Promise<{
+  content: unknown
+  isError?: boolean
+  structuredContent?: unknown
+}>
+
+function createFakeServer() {
+  const handlers = new Map<string, RegisteredHandler>()
+
+  return {
+    handlers,
+    server: {
+      registerTool(
+        name: string,
+        _config: { description: string; inputSchema?: unknown },
+        handler: RegisteredHandler,
+      ) {
+        handlers.set(name, handler)
+      },
+    },
+  }
+}
+
+function textOf(result: { content?: unknown }): string {
+  if (!Array.isArray(result.content)) return ''
+  return result.content
+    .filter(
+      (item): item is { type: 'text'; text: string } =>
+        typeof item === 'object' &&
+        item !== null &&
+        'type' in item &&
+        item.type === 'text' &&
+        'text' in item &&
+        typeof item.text === 'string',
+    )
+    .map((item) => item.text)
+    .join('\n')
+}
+
+describe('browser tool framework post-actions', () => {
+  it('runs compact ToolResponse post-actions after the handler', async () => {
+    const events: string[] = []
+    const postActionTool = defineTool({
+      name: 'post_action_test',
+      description: 'Test post-action execution.',
+      input: z.object({ page: z.number().int() }),
+      handler: async (args, _ctx, response) => {
+        events.push('handler')
+        response.text('handler output')
+        response.data({ page: args.page, url: 'https://example.com/post' })
+        response.includeSnapshot(args.page)
+      },
+    })
+    const session = {
+      observe: (page: number) => ({
+        snapshot: async () => {
+          events.push(`snapshot:${page}`)
+          return { text: '- button "Submit" [ref=e1]' }
+        },
+      }),
+      pages: {
+        getInfo: () => ({ url: 'https://example.com/post' }),
+        getTabId: () => 1234,
+      },
+    } as unknown as BrowserSession
+
+    const result = await executeTool(postActionTool, { page: 7 }, { session })
+    const text = textOf(result)
+
+    expect(events).toEqual(['handler', 'snapshot:7'])
+    expect(result.isError).toBeFalsy()
+    expect(result.structuredContent).toEqual({
+      page: 7,
+      url: 'https://example.com/post',
+    })
+    expect(result.metadata).toEqual({ tabId: 1234 })
+    expect(text.indexOf('handler output')).toBeLessThan(
+      text.indexOf('--- Additional context'),
+    )
+    expect(text).toContain('[Page 7 snapshot]')
+    expect(text).toContain('[UNTRUSTED_PAGE_CONTENT')
+    expect(text).toContain('- button "Submit" [ref=e1]')
+    expect(text).toContain('[END_UNTRUSTED_PAGE_CONTENT')
+  })
+
+  it('keeps compact error results from running undeclared post-actions', async () => {
+    const errorTool = defineTool({
+      name: 'error_test',
+      description: 'Test error result handling.',
+      input: z.object({ page: z.number().int() }),
+      handler: async () => errorResult('error_test: nope'),
+    })
+    const session = {
+      observe: () => ({
+        snapshot: async () => {
+          throw new Error('snapshot should not run')
+        },
+      }),
+      pages: {
+        getTabId: () => undefined,
+      },
+    } as unknown as BrowserSession
+
+    const result = await executeTool(errorTool, { page: 2 }, { session })
+
+    expect(result.isError).toBe(true)
+    expect(textOf(result)).toBe('error_test: nope')
+  })
+
+  it('attaches navigate snapshots through the shared post-action path', async () => {
+    const fake = createFakeServer()
+    const calls: string[] = []
+    const session = {
+      nav: () => ({
+        goto: async (url: string) => calls.push(`goto:${url}`),
+      }),
+      observe: (page: number) => ({
+        snapshot: async () => {
+          calls.push(`snapshot:${page}`)
+          return { text: '- heading "Arrived" [ref=e1]' }
+        },
+      }),
+      pages: {
+        getInfo: () => {
+          calls.push('getInfo')
+          return { url: 'https://example.com/after' }
+        },
+        getTabId: () => undefined,
+      },
+    } as unknown as BrowserSession
+
+    registerBrowserTools(fake.server as never, session)
+
+    const result = await fake.handlers.get('navigate')?.({
+      page: 9,
+      action: 'url',
+      url: 'https://example.com/before',
+    })
+    const text = textOf(result ?? {})
+
+    expect(result?.isError).toBeFalsy()
+    expect(result?.structuredContent).toEqual({
+      page: 9,
+      url: 'https://example.com/after',
+    })
+    expect(calls).toEqual([
+      'goto:https://example.com/before',
+      'getInfo',
+      'snapshot:9',
+      'getInfo',
+    ])
+    expect(text).toContain('navigated (url) -> https://example.com/after')
+    expect(text.indexOf('navigated (url)')).toBeLessThan(
+      text.indexOf('--- Additional context'),
+    )
+    expect(text).toContain('[Page 9 snapshot]')
+    expect(text).toContain('[UNTRUSTED_PAGE_CONTENT')
+    expect(text).toContain('- heading "Arrived" [ref=e1]')
+  })
+
+  it('does not snapshot navigate validation errors', async () => {
+    const fake = createFakeServer()
+    const calls: string[] = []
+    const session = {
+      nav: () => ({
+        goto: async () => calls.push('goto'),
+      }),
+      observe: () => ({
+        snapshot: async () => calls.push('snapshot'),
+      }),
+      pages: {
+        getTabId: () => undefined,
+      },
+    } as unknown as BrowserSession
+
+    registerBrowserTools(fake.server as never, session)
+
+    const result = await fake.handlers.get('navigate')?.({
+      page: 9,
+      action: 'url',
+    })
+
+    expect(result?.isError).toBe(true)
+    expect(result?.content).toEqual([
+      { type: 'text', text: 'navigate: url is required for action="url".' },
+    ])
+    expect(calls).toEqual([])
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -296,6 +296,7 @@ describe('registerBrowserTools', () => {
       input: () => input,
       pages: {
         getInfo: () => ({ url: 'https://example.com' }),
+        refresh: async () => ({ url: 'https://example.com' }),
         getSession: async () => ({
           session: {
             Runtime: {


### PR DESCRIPTION
## Summary
- Reuses `ToolResponse` as the compact browser-tool response accumulator so handlers can write text/error/structured data and attach shared post-actions.
- Adds BrowserSession-backed post-action execution for snapshots/screenshots/pages, with snapshot content wrapped in the existing untrusted-content boundary.
- Moves `navigate` snapshot attachment out of the handler and into the shared post-action path, refreshing page metadata before reporting URL/origin.

## Design
The compact browser framework now creates a `ToolResponse`, passes it into handlers, merges returned `ToolResult`s for incremental compatibility, runs `buildForSession(...)` after the handler, and then attaches page-to-tab metadata when available. `navigate` is the first migrated handler: it only performs navigation, records response text/data, and requests `includeSnapshot(page)`.

## Test plan
- [x] `cd apps/server && bun test tests/tools/browser/framework.test.ts tests/tools/browser/register.test.ts`
- [x] `bunx biome check apps/server/src/tools/response.ts apps/server/src/tools/browser/framework.ts apps/server/src/tools/browser/navigate.ts apps/server/tests/tools/browser/framework.test.ts apps/server/tests/tools/browser/register.test.ts`
- [x] `bun run lint` (exits 0 with existing warnings outside this diff)
- [x] `bun run typecheck`
- [x] `bun run test:main`
- [x] context-free local review: one stale-URL finding fixed, clean rerun