### PR TITLE
fix: use CDP frame tree for observer URL reads

### DIFF
--- a/packages/browseros-agent/apps/server/src/browser/core/observer/observer.test.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/observer/observer.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from 'bun:test'
+import type { ProtocolApi } from '@browseros/cdp-protocol/protocol-api'
+import type { PageManager, PageSession } from '../pages'
+import type { FrameRegistry } from './frames'
+import { Observer } from './observer'
+
+type HarnessOptions = {
+  frameTreeUrl?: string
+  frameTreeError?: Error
+  refreshedUrl?: string
+  refreshError?: Error
+}
+
+function createObserverHarness(opts: HarnessOptions = {}) {
+  const runtimeExpressions: string[] = []
+  let frameTreeCalls = 0
+  let refreshCalls = 0
+
+  const session = {
+    Page: {
+      getFrameTree: async () => {
+        frameTreeCalls++
+        if (opts.frameTreeError) throw opts.frameTreeError
+        return {
+          frameTree: {
+            frame: {
+              id: 'main',
+              loaderId: 'loader',
+              url: opts.frameTreeUrl ?? 'https://frame.example/',
+              domainAndRegistry: '',
+              securityOrigin: '',
+              mimeType: 'text/html',
+              secureContextType: 'Secure',
+              crossOriginIsolatedContextType: 'NotIsolated',
+              gatedAPIFeatures: [],
+            },
+          },
+        }
+      },
+    },
+    Runtime: {
+      evaluate: async ({ expression }: { expression: string }) => {
+        runtimeExpressions.push(expression)
+        if (expression === 'location.href') {
+          return { result: { value: 'https://runtime.example/' } }
+        }
+        return { result: { value: [] } }
+      },
+    },
+    Accessibility: {
+      getFullAXTree: async () => ({
+        nodes: [
+          {
+            nodeId: 'root',
+            role: { type: 'role', value: 'RootWebArea' },
+            childIds: ['button'],
+          },
+          {
+            nodeId: 'button',
+            role: { type: 'role', value: 'button' },
+            name: { type: 'computedString', value: 'Save' },
+            backendDOMNodeId: 42,
+          },
+        ],
+      }),
+    },
+  } as unknown as ProtocolApi
+
+  const pages = {
+    getSession: async (): Promise<PageSession> => ({
+      targetId: 'target-1',
+      session,
+      url: 'https://cached.example/',
+    }),
+    refresh: async () => {
+      refreshCalls++
+      if (opts.refreshError) throw opts.refreshError
+      if (opts.refreshedUrl === undefined) return undefined
+      return { url: opts.refreshedUrl }
+    },
+  } as unknown as PageManager
+
+  const frames = {
+    resolveFrameTarget: () => ({ session, axParams: {} }),
+  } as unknown as FrameRegistry
+
+  return {
+    observer: new Observer(pages, frames, 1),
+    get frameTreeCalls() {
+      return frameTreeCalls
+    },
+    get refreshCalls() {
+      return refreshCalls
+    },
+    runtimeExpressions,
+  }
+}
+
+describe('Observer URL lookup', () => {
+  test('reads the main-frame URL through Page.getFrameTree without location.href evaluation', async () => {
+    const harness = createObserverHarness({
+      frameTreeUrl: 'https://frame.example/path',
+      refreshedUrl: 'https://registry.example/',
+    })
+
+    const snapshot = await harness.observer.snapshot()
+
+    expect(snapshot.url).toBe('https://frame.example/path')
+    expect(harness.frameTreeCalls).toBe(2)
+    expect(harness.refreshCalls).toBe(0)
+    expect(harness.runtimeExpressions).not.toContain('location.href')
+  })
+
+  test('falls back to the refreshed tab registry URL when frame tree URL lookup fails', async () => {
+    const harness = createObserverHarness({
+      frameTreeError: new Error('detached target'),
+      refreshedUrl: 'https://registry.example/current',
+    })
+
+    const snapshot = await harness.observer.snapshot()
+
+    expect(snapshot.url).toBe('https://registry.example/current')
+    expect(harness.frameTreeCalls).toBe(2)
+    expect(harness.refreshCalls).toBe(2)
+    expect(harness.runtimeExpressions).not.toContain('location.href')
+  })
+
+  test('returns unknown when frame tree and tab registry fallbacks both fail', async () => {
+    const harness = createObserverHarness({
+      frameTreeError: new Error('detached target'),
+      refreshError: new Error('registry unavailable'),
+    })
+
+    const snapshot = await harness.observer.snapshot()
+
+    expect(snapshot.url).toBe('unknown')
+    expect(harness.frameTreeCalls).toBe(2)
+    expect(harness.refreshCalls).toBe(2)
+    expect(harness.runtimeExpressions).not.toContain('location.href')
+  })
+})

--- a/packages/browseros-agent/apps/server/src/browser/core/observer/observer.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/observer/observer.ts
@@ -133,17 +133,15 @@ export class Observer {
   }
 }
 
-/** Reads the live document URL, falling back to the tab registry during context teardown. */
+/** Reads the live main-frame URL, falling back to the tab registry during teardown. */
 async function readCurrentUrl(
   session: ProtocolApi,
   fallback: () => Promise<string | undefined>,
 ): Promise<string> {
   try {
-    const result = await session.Runtime.evaluate({
-      expression: 'location.href',
-      returnByValue: true,
-    })
-    if (typeof result.result?.value === 'string') return result.result.value
+    const result = await session.Page.getFrameTree()
+    const url = result.frameTree.frame.url
+    if (url) return url
   } catch {}
   try {
     return (await fallback()) || 'unknown'

--- a/packages/browseros-agent/apps/server/src/browser/core/observer/observer.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/observer/observer.ts
@@ -140,8 +140,8 @@ async function readCurrentUrl(
 ): Promise<string> {
   try {
     const result = await session.Page.getFrameTree()
-    const url = result.frameTree.frame.url
-    if (url) return url
+    const frame = result.frameTree.frame
+    if (frame.url) return `${frame.url}${frame.urlFragment ?? ''}`
   } catch {}
   try {
     return (await fallback()) || 'unknown'

--- a/packages/browseros-agent/apps/server/tests/browser/core/observer.test.ts
+++ b/packages/browseros-agent/apps/server/tests/browser/core/observer.test.ts
@@ -1,11 +1,12 @@
 import { describe, expect, test } from 'bun:test'
 import type { ProtocolApi } from '@browseros/cdp-protocol/protocol-api'
-import type { PageManager, PageSession } from '../pages'
-import type { FrameRegistry } from './frames'
-import { Observer } from './observer'
+import type { FrameRegistry } from '../../../src/browser/core/observer/frames'
+import { Observer } from '../../../src/browser/core/observer/observer'
+import type { PageManager, PageSession } from '../../../src/browser/core/pages'
 
 type HarnessOptions = {
   frameTreeUrl?: string
+  frameTreeFragment?: string
   frameTreeError?: Error
   refreshedUrl?: string
   refreshError?: Error
@@ -27,6 +28,7 @@ function createObserverHarness(opts: HarnessOptions = {}) {
               id: 'main',
               loaderId: 'loader',
               url: opts.frameTreeUrl ?? 'https://frame.example/',
+              urlFragment: opts.frameTreeFragment,
               domainAndRegistry: '',
               securityOrigin: '',
               mimeType: 'text/html',
@@ -108,6 +110,18 @@ describe('Observer URL lookup', () => {
     expect(snapshot.url).toBe('https://frame.example/path')
     expect(harness.frameTreeCalls).toBe(2)
     expect(harness.refreshCalls).toBe(0)
+    expect(harness.runtimeExpressions).not.toContain('location.href')
+  })
+
+  test('preserves URL fragments from frame tree metadata', async () => {
+    const harness = createObserverHarness({
+      frameTreeUrl: 'https://frame.example/path',
+      frameTreeFragment: '#section',
+    })
+
+    const snapshot = await harness.observer.snapshot()
+
+    expect(snapshot.url).toBe('https://frame.example/path#section')
     expect(harness.runtimeExpressions).not.toContain('location.href')
   })
 


### PR DESCRIPTION
## Summary
- Replace observer URL reads from `Runtime.evaluate('location.href')` with `Page.getFrameTree()` main-frame metadata.
- Preserve URL fragments via `frame.urlFragment` and retain registry/`unknown` fallback behavior.
- Add focused observer regression tests under the server browser test group.

## Design
`readCurrentUrl` stays private to the observer and now reads the live main-frame URL from CDP frame metadata, recombining `frame.url` with `frame.urlFragment` before falling back to `PageManager.refresh(pageId)?.url` and then `unknown` during teardown.

## Test plan
- [x] `bun --env-file=apps/server/.env.development test --preload=./apps/server/tests/__helpers__/test-env.ts apps/server/tests/browser/core/observer.test.ts`
- [x] `cd apps/server && bun run test:browser`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test:main`