### PR TITLE
fix(agent): composer mic always switches to voice mode

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/newtab-2/Composer.tsx
+++ b/packages/browseros-agent/apps/agent/entrypoints/newtab-2/Composer.tsx
@@ -44,7 +44,6 @@ export const Composer: FC<ComposerProps> = ({
     submit,
     triggerVoice,
     placeholder: ctxPlaceholder,
-    chatActive,
   } = useComposer()
 
   const inputRef = useRef<HTMLInputElement>(null)
@@ -72,10 +71,6 @@ export const Composer: FC<ComposerProps> = ({
   const handleMicToggle = () => {
     if (voice.isRecording) {
       void voice.stopRecording()
-      return
-    }
-    if (chatActive) {
-      void voice.startRecording()
       return
     }
     triggerVoice()


### PR DESCRIPTION
## Summary

On the /newtab-2/chat surface the composer's mic button never reached the voice orb. It shortcircuited to in-place \`voice.startRecording()\` whenever AgentChat was mounted, so the only way to hit voice mode was the small header mic icon. This PR removes that branch.

The composer mic now behaves the same on both surfaces:
- Launcher: \`triggerVoice()\` falls through to the provider's navigate path → \`/newtab-2/chat?mode=voice\`, recording starts in parallel with the route change.
- Chat: \`triggerVoice()\` invokes ChatScreen's registered \`onSwitchToVoice\` → \`switchTo('voice')\` flips \`?mode=voice\` and starts recording.

## Round-trip UX

No extra work needed for the "voice complete, composer comes back with state intact" UX — the architecture already supports it:

- Composer is hoisted above the route swap, so it never unmounts. \`value\`, attached tabs, attached files all persist.
- \`voice\` lives in ComposerProvider, so the MediaStream survives mode changes.
- The existing transcript \`useEffect\` appends new text to \`value\` with a space separator when recording stops.

When the founder hits VoiceMode's "Switch to text" (or the X) button, \`switchTo('text')\` stops recording → Whisper returns the transcript → it lands on the composer's existing value. The composer slides back in with everything intact plus the new transcript.

## Test plan

- [ ] On /newtab-2 (launcher), click mic → navigates to /newtab-2/chat?mode=voice, orb materialises, recording begins.
- [ ] On /newtab-2/chat (text mode), type some text, attach a tab, click mic → URL flips to ?mode=voice in place, composer fades, orb materialises, recording begins.
- [ ] In voice mode, hit "Switch to text" → composer fades back in at the bottom with the original typed text + attached tab + transcript appended.
- [ ] In voice mode, hit X → returns to launcher, composer centered, same content preserved.