### PR TITLE
fix(agent): make coding-agent rows selectable in AI settings

### DIFF
--- a/packages/browseros-agent/apps/agent/modules/chat/sidepanel-chat-targets.test.ts
+++ b/packages/browseros-agent/apps/agent/modules/chat/sidepanel-chat-targets.test.ts
@@ -6,10 +6,13 @@ import type {
 } from '@/modules/agents/agent-harness-types'
 import {
   buildSidepanelChatTargets,
+  clearSidepanelChatTargetSelectionForAgent,
   persistSidepanelChatTargetSelection,
   resolveSidepanelChatTarget,
   type SidepanelChatTargetSelection,
+  saveSidepanelChatTargetSelection,
   toLlmProviderConfig,
+  watchSidepanelChatTargetSelection,
 } from './sidepanel-chat-targets'
 
 const timestamp = 1000
@@ -269,5 +272,101 @@ describe('persistSidepanelChatTargetSelection', () => {
       id: 'agent-codex',
     })
     expect(providers).toEqual(originalProviders)
+  })
+
+  it('persists null when no target is selected', async () => {
+    const store = createSelectionStore({ kind: 'acp', id: 'agent-codex' })
+
+    await persistSidepanelChatTargetSelection(undefined, store)
+
+    expect(await store.getValue()).toBeNull()
+  })
+})
+
+function createSelectionStore(
+  initial: SidepanelChatTargetSelection | null = null,
+) {
+  let value = initial
+  const watchers = new Set<
+    (selection: SidepanelChatTargetSelection | null) => void
+  >()
+  return {
+    getValue: async () => value,
+    setValue: async (next: SidepanelChatTargetSelection | null) => {
+      value = next
+      for (const watcher of watchers) watcher(next)
+    },
+    watch: (
+      callback: (selection: SidepanelChatTargetSelection | null) => void,
+    ) => {
+      watchers.add(callback)
+      return () => {
+        watchers.delete(callback)
+      }
+    },
+  }
+}
+
+describe('saveSidepanelChatTargetSelection', () => {
+  it('writes the selection identity to the store', async () => {
+    const store = createSelectionStore()
+
+    await saveSidepanelChatTargetSelection(
+      { kind: 'acp', id: 'agent-codex' },
+      store,
+    )
+
+    expect(await store.getValue()).toEqual({ kind: 'acp', id: 'agent-codex' })
+  })
+
+  it('clears the stored selection with null', async () => {
+    const store = createSelectionStore({ kind: 'llm', id: 'browseros' })
+
+    await saveSidepanelChatTargetSelection(null, store)
+
+    expect(await store.getValue()).toBeNull()
+  })
+})
+
+describe('clearSidepanelChatTargetSelectionForAgent', () => {
+  it('clears the selection pointing at the deleted agent', async () => {
+    const store = createSelectionStore({ kind: 'acp', id: 'agent-codex' })
+
+    await clearSidepanelChatTargetSelectionForAgent('agent-codex', store)
+
+    expect(await store.getValue()).toBeNull()
+  })
+
+  it('keeps a selection for a different agent', async () => {
+    const store = createSelectionStore({ kind: 'acp', id: 'agent-other' })
+
+    await clearSidepanelChatTargetSelectionForAgent('agent-codex', store)
+
+    expect(await store.getValue()).toEqual({ kind: 'acp', id: 'agent-other' })
+  })
+
+  it('keeps an LLM selection even when ids collide', async () => {
+    const store = createSelectionStore({ kind: 'llm', id: 'agent-codex' })
+
+    await clearSidepanelChatTargetSelectionForAgent('agent-codex', store)
+
+    expect(await store.getValue()).toEqual({ kind: 'llm', id: 'agent-codex' })
+  })
+})
+
+describe('watchSidepanelChatTargetSelection', () => {
+  it('notifies on selection changes until unsubscribed', async () => {
+    const store = createSelectionStore()
+    const seen: Array<SidepanelChatTargetSelection | null> = []
+
+    const unsubscribe = watchSidepanelChatTargetSelection(
+      (selection) => seen.push(selection),
+      store,
+    )
+    await store.setValue({ kind: 'acp', id: 'agent-codex' })
+    unsubscribe()
+    await store.setValue(null)
+
+    expect(seen).toEqual([{ kind: 'acp', id: 'agent-codex' }])
   })
 })

--- a/packages/browseros-agent/apps/agent/modules/chat/sidepanel-chat-targets.ts
+++ b/packages/browseros-agent/apps/agent/modules/chat/sidepanel-chat-targets.ts
@@ -202,10 +202,15 @@ export function watchSidepanelChatTargetSelection(
 
   let cancelled = false
   let unwatch: (() => void) | undefined
-  getSidepanelChatTargetSelectionStorage().then((targetStore) => {
-    if (cancelled) return
-    unwatch = targetStore.watch(callback)
-  })
+  getSidepanelChatTargetSelectionStorage()
+    .then((targetStore) => {
+      if (cancelled) return
+      unwatch = targetStore.watch(callback)
+    })
+    // Failed storage import leaves the watch inert; this module stays
+    // sentry-free for bun-test loadability, and the load path surfaces the
+    // same failure to callers, who report it.
+    .catch(() => undefined)
   return () => {
     cancelled = true
     unwatch?.()

--- a/packages/browseros-agent/apps/agent/modules/chat/sidepanel-chat-targets.ts
+++ b/packages/browseros-agent/apps/agent/modules/chat/sidepanel-chat-targets.ts
@@ -62,8 +62,15 @@ interface SidepanelChatTargetSelectionReader {
   getValue(): Promise<SidepanelChatTargetSelection | null>
 }
 
+interface SidepanelChatTargetSelectionWatcher {
+  watch(
+    callback: (selection: SidepanelChatTargetSelection | null) => void,
+  ): () => void
+}
+
 type SidepanelChatTargetSelectionStore = SidepanelChatTargetSelectionReader &
-  SidepanelChatTargetSelectionWriter
+  SidepanelChatTargetSelectionWriter &
+  SidepanelChatTargetSelectionWatcher
 
 let sidepanelChatTargetSelectionStorage:
   | SidepanelChatTargetSelectionStore
@@ -154,10 +161,55 @@ export async function persistSidepanelChatTargetSelection(
   target: SidepanelChatTarget | undefined,
   store?: SidepanelChatTargetSelectionWriter,
 ): Promise<void> {
-  const targetStore = store ?? (await getSidepanelChatTargetSelectionStorage())
-  await targetStore.setValue(
+  await saveSidepanelChatTargetSelection(
     target ? { kind: target.kind, id: target.id } : null,
+    store,
   )
+}
+
+/** Writes a selection identity (or null to clear) without needing a full target. */
+export async function saveSidepanelChatTargetSelection(
+  selection: SidepanelChatTargetSelection | null,
+  store?: SidepanelChatTargetSelectionWriter,
+): Promise<void> {
+  const targetStore = store ?? (await getSidepanelChatTargetSelectionStorage())
+  await targetStore.setValue(selection)
+}
+
+/** Clears the persisted selection only when it points at the given agent. */
+export async function clearSidepanelChatTargetSelectionForAgent(
+  agentId: string,
+  store?: SidepanelChatTargetSelectionReader &
+    SidepanelChatTargetSelectionWriter,
+): Promise<void> {
+  const targetStore = store ?? (await getSidepanelChatTargetSelectionStorage())
+  const selection = await targetStore.getValue()
+  if (selection?.kind === 'acp' && selection.id === agentId) {
+    await targetStore.setValue(null)
+  }
+}
+
+/**
+ * Subscribes to selection changes. The production store loads lazily, so the
+ * subscription may attach a tick later; the returned unsubscribe is always
+ * synchronous and safe to call before attachment completes.
+ */
+export function watchSidepanelChatTargetSelection(
+  callback: (selection: SidepanelChatTargetSelection | null) => void,
+  store?: SidepanelChatTargetSelectionWatcher,
+): () => void {
+  if (store) return store.watch(callback)
+
+  let cancelled = false
+  let unwatch: (() => void) | undefined
+  getSidepanelChatTargetSelectionStorage().then((targetStore) => {
+    if (cancelled) return
+    unwatch = targetStore.watch(callback)
+  })
+  return () => {
+    cancelled = true
+    unwatch?.()
+  }
 }
 
 export async function loadSidepanelChatTargetSelection(

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/BrowserOsAiPane.tsx
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/BrowserOsAiPane.tsx
@@ -42,6 +42,7 @@ import { CodingAgentsManager } from './CodingAgentsManager'
 import { ConfiguredProvidersList } from './ConfiguredProvidersList'
 import { useCodingAgents } from './coding-agents.hooks'
 import { DeviceCodeDialog } from './DeviceCodeDialog'
+import { useDefaultChatTarget } from './default-chat-target.hooks'
 import {
   DeleteRemoteLlmProviderDocument,
   GetRemoteLlmProvidersDocument,
@@ -109,6 +110,17 @@ export const BrowserOsAiPane: FC = () => {
   const { sessionInfo } = useSessionInfo()
   const queryClient = useQueryClient()
   const coding = useCodingAgents()
+  const defaultTarget = useDefaultChatTarget({
+    providers,
+    agents: coding.agents,
+    defaultProviderId,
+    setDefaultProvider,
+  })
+  const { effectiveTarget } = defaultTarget
+  const selectedProviderId =
+    effectiveTarget.kind === 'llm' ? effectiveTarget.id : null
+  const selectedAgentId =
+    effectiveTarget.kind === 'acp' ? effectiveTarget.id : null
 
   const userId = sessionInfo.user?.id
 
@@ -298,10 +310,6 @@ export const BrowserOsAiPane: FC = () => {
     await saveProvider(provider)
   }
 
-  const handleSelectProvider = (providerId: string) => {
-    setDefaultProvider(providerId)
-  }
-
   const handleTestProvider = async (provider: LlmProviderConfig) => {
     if (!agentServerUrl) {
       toast.error('Test Failed', {
@@ -357,8 +365,9 @@ export const BrowserOsAiPane: FC = () => {
     <div className="fade-in slide-in-from-bottom-5 animate-in space-y-6 duration-500">
       <LlmProvidersHeader
         providers={providers}
-        defaultProviderId={defaultProviderId}
-        onDefaultProviderChange={setDefaultProvider}
+        agents={coding.agents}
+        selectedTarget={effectiveTarget}
+        onSelectTarget={defaultTarget.selectTarget}
         onAddProvider={handleAddProvider}
       />
 
@@ -372,15 +381,19 @@ export const BrowserOsAiPane: FC = () => {
 
       <ConfiguredProvidersList
         providers={providers}
-        selectedProviderId={defaultProviderId}
+        selectedProviderId={selectedProviderId}
         testingProviderId={testingProviderId}
-        onSelectProvider={handleSelectProvider}
+        onSelectProvider={defaultTarget.selectProvider}
         onTestProvider={handleTestProvider}
         onEditProvider={handleEditProvider}
         onDeleteProvider={handleDeleteProvider}
       />
 
-      <CodingAgentsList controller={coding} />
+      <CodingAgentsList
+        controller={coding}
+        selectedAgentId={selectedAgentId}
+        onSelectAgent={defaultTarget.selectAgent}
+      />
 
       <IncompleteProvidersList
         providers={incompleteProviders}

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/CodingAgentCard.test.tsx
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/CodingAgentCard.test.tsx
@@ -108,6 +108,7 @@ describe('CodingAgentCard', () => {
     expect(html).toContain('id="agent-codex-1"')
     expect(html).not.toContain('checked')
     expect(html).not.toContain('DEFAULT')
+    expect(html).not.toContain('shadow-md')
   })
 
   it('renders the checked radio, DEFAULT badge, and selected styling when selected', () => {
@@ -115,6 +116,6 @@ describe('CodingAgentCard', () => {
 
     expect(html).toContain('checked')
     expect(html).toContain('DEFAULT')
-    expect(html).toContain('border-[var(--accent-orange)]')
+    expect(html).toContain('bg-[var(--accent-orange)]/5 shadow-md')
   })
 })

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/CodingAgentCard.test.tsx
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/CodingAgentCard.test.tsx
@@ -8,7 +8,9 @@ type CodingAgentCardProps = {
   adapter: 'codex'
   modelLabel: string | null
   reasoningEffort: string | null
+  isSelected: boolean
   deleting: boolean
+  onSelect: () => void
   onDelete: (agent: AgentListItem) => void
 }
 
@@ -30,6 +32,11 @@ mock.module('@/components/ui/button', () => ({
     ...props
   }: MockButtonProps) =>
     createElement('button', { type: 'button', ...props }, children),
+}))
+
+mock.module('@/components/ui/badge', () => ({
+  Badge: ({ children }: { children?: unknown }) =>
+    createElement('span', null, children as never),
 }))
 
 let CodingAgentCard: FC<CodingAgentCardProps>
@@ -57,7 +64,9 @@ function renderCard(props: Partial<CodingAgentCardProps> = {}) {
       adapter: 'codex',
       modelLabel: 'gpt-5.5',
       reasoningEffort: 'medium',
+      isSelected: false,
       deleting: false,
+      onSelect: () => {},
       onDelete: () => {},
       ...props,
     }),
@@ -89,5 +98,23 @@ describe('CodingAgentCard', () => {
 
     expect(html).toContain('disabled=""')
     expect(html).toContain('animate-spin')
+  })
+
+  it('renders an unselected default-provider radio row', () => {
+    const html = renderCard()
+
+    expect(html).toContain('<label')
+    expect(html).toContain('name="default-provider"')
+    expect(html).toContain('id="agent-codex-1"')
+    expect(html).not.toContain('checked')
+    expect(html).not.toContain('DEFAULT')
+  })
+
+  it('renders the checked radio, DEFAULT badge, and selected styling when selected', () => {
+    const html = renderCard({ isSelected: true })
+
+    expect(html).toContain('checked')
+    expect(html).toContain('DEFAULT')
+    expect(html).toContain('border-[var(--accent-orange)]')
   })
 })

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/CodingAgentCard.tsx
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/CodingAgentCard.tsx
@@ -1,4 +1,4 @@
-import { Loader2, Trash2 } from 'lucide-react'
+import { Check, Loader2, Trash2 } from 'lucide-react'
 import type { FC } from 'react'
 import type { HarnessAgentAdapter } from '@/modules/agents/agent-harness-types'
 import type { AgentListItem } from '@/modules/agents/agents-page-types'
@@ -7,6 +7,7 @@ import {
   canDelete as canDeleteAgent,
   displayName,
 } from '../../components/agents/agent-display.helpers'
+import { Badge } from '../../components/ui/badge'
 import { Button } from '../../components/ui/button'
 import { cn } from '../../lib/utils'
 
@@ -15,17 +16,25 @@ interface CodingAgentCardProps {
   adapter: HarnessAgentAdapter | 'unknown'
   modelLabel: string | null
   reasoningEffort: string | null
+  isSelected: boolean
   deleting: boolean
+  onSelect: () => void
   onDelete: (agent: AgentListItem) => void
 }
 
-/** Provider-style row for coding agents in the AI settings pane. */
+/**
+ * Provider-style row for coding agents in the AI settings pane. Participates
+ * in the same `default-provider` radio group as `ProviderCard` so providers
+ * and agents form one exclusive default-target choice.
+ */
 export const CodingAgentCard: FC<CodingAgentCardProps> = ({
   agent,
   adapter,
   modelLabel,
   reasoningEffort,
+  isSelected,
   deleting,
+  onSelect,
   onDelete,
 }) => {
   const name = displayName(agent)
@@ -33,24 +42,50 @@ export const CodingAgentCard: FC<CodingAgentCardProps> = ({
     .filter((part): part is string => Boolean(part))
     .join(' · ')
   const allowDelete = canDeleteAgent(agent)
+  const inputId = `agent-${agent.agentId}`
 
   return (
-    <div
+    <label
+      htmlFor={inputId}
       className={cn(
-        'group flex w-full items-center gap-4 rounded-xl border p-4 text-left transition-all',
-        'border-border bg-card hover:border-[var(--accent-orange)]/50 hover:shadow-sm',
+        'group flex w-full cursor-pointer items-center gap-4 rounded-xl border p-4 text-left transition-all',
+        isSelected
+          ? 'border-[var(--accent-orange)] bg-[var(--accent-orange)]/5 shadow-md'
+          : 'border-border bg-card hover:border-[var(--accent-orange)]/50 hover:shadow-sm',
       )}
     >
-      <div
-        aria-hidden="true"
-        className="flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 border-border transition-all"
+      <input
+        type="radio"
+        id={inputId}
+        name="default-provider"
+        className="sr-only"
+        checked={isSelected}
+        onChange={() => onSelect()}
       />
+      <div
+        className={cn(
+          'flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-all',
+          isSelected
+            ? 'border-[var(--accent-orange)] bg-[var(--accent-orange)]'
+            : 'border-border',
+        )}
+      >
+        {isSelected && <Check className="h-3 w-3 text-white" />}
+      </div>
       <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-[var(--accent-orange)]/10 text-[var(--accent-orange)]">
         <AdapterIcon adapter={adapter} className="h-6 w-6" />
       </div>
       <div className="min-w-0 flex-1">
         <div className="mb-1 flex items-center gap-2">
           <span className="truncate font-semibold">{name}</span>
+          {isSelected && (
+            <Badge
+              variant="secondary"
+              className="rounded bg-[var(--accent-orange)]/10 text-[var(--accent-orange)]"
+            >
+              DEFAULT
+            </Badge>
+          )}
         </div>
         <p className="truncate text-muted-foreground text-sm">{metadata}</p>
       </div>
@@ -70,6 +105,6 @@ export const CodingAgentCard: FC<CodingAgentCardProps> = ({
           )}
         </Button>
       </div>
-    </div>
+    </label>
   )
 }

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/CodingAgentsList.tsx
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/CodingAgentsList.tsx
@@ -8,10 +8,16 @@ import type { CodingAgentsController } from './coding-agents.hooks'
 
 interface CodingAgentsListProps {
   controller: CodingAgentsController
+  selectedAgentId: string | null
+  onSelectAgent: (agentId: string) => void
 }
 
 /** Provider-list placement for Claude Code / Codex agents in AI settings. */
-export const CodingAgentsList: FC<CodingAgentsListProps> = ({ controller }) => {
+export const CodingAgentsList: FC<CodingAgentsListProps> = ({
+  controller,
+  selectedAgentId,
+  onSelectAgent,
+}) => {
   const {
     listItems,
     activity,
@@ -56,7 +62,9 @@ export const CodingAgentsList: FC<CodingAgentsListProps> = ({ controller }) => {
             adapter={adapter}
             modelLabel={deriveModelLabel(agent, harness?.modelId)}
             reasoningEffort={harness?.reasoningEffort ?? null}
+            isSelected={selectedAgentId === agent.agentId}
             deleting={deleteIsPending && deletingAgentKey === agent.key}
+            onSelect={() => onSelectAgent(agent.agentId)}
             onDelete={(item) => {
               void handleDelete(item)
             }}

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/ConfiguredProvidersList.tsx
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/ConfiguredProvidersList.tsx
@@ -4,7 +4,7 @@ import { ProviderCard } from './ProviderCard'
 
 interface ConfiguredProvidersListProps {
   providers: LlmProviderConfig[]
-  selectedProviderId: string
+  selectedProviderId: string | null
   testingProviderId: string | null
   onSelectProvider: (providerId: string) => void
   onTestProvider: (provider: LlmProviderConfig) => void

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/LlmProvidersHeader.tsx
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/LlmProvidersHeader.tsx
@@ -5,26 +5,37 @@ import { Button } from '@/components/ui/button'
 import {
   Select,
   SelectContent,
+  SelectGroup,
   SelectItem,
+  SelectLabel,
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
 import type { LlmProviderConfig } from '@/lib/llm-providers/types'
+import type { HarnessAgent } from '@/modules/agents/agent-harness-types'
+import type { SidepanelChatTargetSelection } from '@/modules/chat/sidepanel-chat-targets'
+import {
+  decodeTargetValue,
+  encodeTargetValue,
+} from './default-chat-target.helpers'
 
 interface LlmProvidersHeaderProps {
   providers: LlmProviderConfig[]
-  defaultProviderId: string
-  onDefaultProviderChange: (providerId: string) => void
+  agents: HarnessAgent[]
+  selectedTarget: SidepanelChatTargetSelection
+  onSelectTarget: (selection: SidepanelChatTargetSelection) => void
   onAddProvider: () => void
 }
 
 /**
- * Header section for LLM providers with default provider selector and add button
+ * Header section for LLM providers with the default-target selector (LLM
+ * providers and coding agents) and add button.
  */
 export const LlmProvidersHeader: FC<LlmProvidersHeaderProps> = ({
   providers,
-  defaultProviderId,
-  onDefaultProviderChange,
+  agents,
+  selectedTarget,
+  onSelectTarget,
   onAddProvider,
 }) => {
   return (
@@ -47,8 +58,11 @@ export const LlmProvidersHeader: FC<LlmProvidersHeaderProps> = ({
               Default Provider:
             </label>
             <Select
-              value={defaultProviderId}
-              onValueChange={onDefaultProviderChange}
+              value={encodeTargetValue(selectedTarget)}
+              onValueChange={(value) => {
+                const selection = decodeTargetValue(value)
+                if (selection) onSelectTarget(selection)
+              }}
             >
               <SelectTrigger
                 id="provider-picker"
@@ -57,11 +71,33 @@ export const LlmProvidersHeader: FC<LlmProvidersHeaderProps> = ({
                 <SelectValue placeholder="Select a provider" />
               </SelectTrigger>
               <SelectContent>
-                {providers.map((provider) => (
-                  <SelectItem key={provider.id} value={provider.id}>
-                    {provider.name}
-                  </SelectItem>
-                ))}
+                <SelectGroup>
+                  <SelectLabel>LLM providers</SelectLabel>
+                  {providers.map((provider) => (
+                    <SelectItem
+                      key={provider.id}
+                      value={encodeTargetValue({
+                        kind: 'llm',
+                        id: provider.id,
+                      })}
+                    >
+                      {provider.name}
+                    </SelectItem>
+                  ))}
+                </SelectGroup>
+                {agents.length > 0 && (
+                  <SelectGroup>
+                    <SelectLabel>Coding agents</SelectLabel>
+                    {agents.map((agent) => (
+                      <SelectItem
+                        key={agent.id}
+                        value={encodeTargetValue({ kind: 'acp', id: agent.id })}
+                      >
+                        {agent.name}
+                      </SelectItem>
+                    ))}
+                  </SelectGroup>
+                )}
               </SelectContent>
             </Select>
             <Button

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/LlmProvidersHeader.tsx
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/LlmProvidersHeader.tsx
@@ -47,7 +47,7 @@ export const LlmProvidersHeader: FC<LlmProvidersHeaderProps> = ({
         <div className="flex-1">
           <h2 className="mb-1 font-semibold text-xl">LLM Providers</h2>
           <p className="mb-6 text-muted-foreground text-sm">
-            Add your provider and choose the default LLM
+            Add your provider and choose the default for new chats
           </p>
 
           <div className="flex flex-col items-start gap-4 sm:flex-row sm:items-center">

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/coding-agents.hooks.ts
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/coding-agents.hooks.ts
@@ -4,6 +4,7 @@ import {
   AGENT_DELETED_EVENT,
 } from '@/lib/constants/analyticsEvents'
 import { track } from '@/lib/metrics/track'
+import { sentry } from '@/lib/sentry/sentry'
 import type {
   HarnessAdapterDescriptor,
   HarnessAgent,
@@ -18,6 +19,7 @@ import {
 import { useDefaultAgentName } from '@/modules/agents/agents-page.hooks'
 import type { AgentListItem } from '@/modules/agents/agents-page-types'
 import { toHarnessListItem } from '@/modules/agents/agents-page-utils'
+import { clearSidepanelChatTargetSelectionForAgent } from '@/modules/chat/sidepanel-chat-targets'
 
 type AgentActivity = Record<
   string,
@@ -167,6 +169,17 @@ export function useCodingAgents(): CodingAgentsController {
         runtime: item.source,
         agent_id: item.agentId,
       })
+      // Storage cleanup must not surface as a delete failure — the agent is gone.
+      await clearSidepanelChatTargetSelectionForAgent(item.agentId).catch(
+        (error) => {
+          sentry.captureException(error, {
+            extra: {
+              message: 'Failed to clear chat-target selection after delete',
+              agentId: item.agentId,
+            },
+          })
+        },
+      )
     } catch (err) {
       setPageError(err instanceof Error ? err.message : String(err))
     } finally {

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/default-chat-target.helpers.test.ts
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/default-chat-target.helpers.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'bun:test'
+import type { LlmProviderConfig } from '@/lib/llm-providers/types'
+import {
+  decodeTargetValue,
+  encodeTargetValue,
+  resolveEffectiveDefaultTarget,
+} from './default-chat-target.helpers'
+
+const timestamp = 1000
+
+const providers: LlmProviderConfig[] = [
+  {
+    id: 'browseros',
+    type: 'browseros',
+    name: 'BrowserOS',
+    baseUrl: 'https://api.browseros.com/v1',
+    modelId: 'browseros-auto',
+    supportsImages: true,
+    contextWindow: 200000,
+    temperature: 0.2,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  },
+  {
+    id: 'anthropic-sonnet',
+    type: 'anthropic',
+    name: 'Anthropic Sonnet',
+    modelId: 'claude-sonnet-4-6',
+    apiKey: 'sk-ant',
+    supportsImages: true,
+    contextWindow: 200000,
+    temperature: 0.2,
+    createdAt: timestamp,
+    updatedAt: timestamp,
+  },
+]
+
+const agents = [{ id: 'agent-cc-1' }, { id: 'agent-codex-1' }]
+
+describe('resolveEffectiveDefaultTarget', () => {
+  it('returns the acp selection when the agent exists', () => {
+    expect(
+      resolveEffectiveDefaultTarget({
+        providers,
+        agents,
+        selection: { kind: 'acp', id: 'agent-cc-1' },
+        defaultProviderId: 'browseros',
+      }),
+    ).toEqual({ kind: 'acp', id: 'agent-cc-1' })
+  })
+
+  it('falls back to the default provider when the acp selection is stale', () => {
+    expect(
+      resolveEffectiveDefaultTarget({
+        providers,
+        agents,
+        selection: { kind: 'acp', id: 'agent-deleted' },
+        defaultProviderId: 'anthropic-sonnet',
+      }),
+    ).toEqual({ kind: 'llm', id: 'anthropic-sonnet' })
+  })
+
+  it('returns the llm selection when the provider exists', () => {
+    expect(
+      resolveEffectiveDefaultTarget({
+        providers,
+        agents,
+        selection: { kind: 'llm', id: 'anthropic-sonnet' },
+        defaultProviderId: 'browseros',
+      }),
+    ).toEqual({ kind: 'llm', id: 'anthropic-sonnet' })
+  })
+
+  it('falls back to the default provider when the llm selection is stale', () => {
+    expect(
+      resolveEffectiveDefaultTarget({
+        providers,
+        agents,
+        selection: { kind: 'llm', id: 'provider-deleted' },
+        defaultProviderId: 'browseros',
+      }),
+    ).toEqual({ kind: 'llm', id: 'browseros' })
+  })
+
+  it('resolves a null selection to the default provider', () => {
+    expect(
+      resolveEffectiveDefaultTarget({
+        providers,
+        agents,
+        selection: null,
+        defaultProviderId: 'anthropic-sonnet',
+      }),
+    ).toEqual({ kind: 'llm', id: 'anthropic-sonnet' })
+  })
+
+  it('repairs a stale default provider id to the first provider', () => {
+    expect(
+      resolveEffectiveDefaultTarget({
+        providers,
+        agents,
+        selection: null,
+        defaultProviderId: 'provider-deleted',
+      }),
+    ).toEqual({ kind: 'llm', id: 'browseros' })
+  })
+})
+
+describe('encodeTargetValue / decodeTargetValue', () => {
+  it('round-trips llm and acp selections', () => {
+    expect(
+      decodeTargetValue(encodeTargetValue({ kind: 'llm', id: 'browseros' })),
+    ).toEqual({ kind: 'llm', id: 'browseros' })
+    expect(
+      decodeTargetValue(encodeTargetValue({ kind: 'acp', id: 'agent-cc-1' })),
+    ).toEqual({ kind: 'acp', id: 'agent-cc-1' })
+  })
+
+  it('preserves ids that contain separators', () => {
+    expect(
+      decodeTargetValue(
+        encodeTargetValue({ kind: 'acp', id: 'acp:codex:gpt-5.5' }),
+      ),
+    ).toEqual({ kind: 'acp', id: 'acp:codex:gpt-5.5' })
+  })
+
+  it('returns null for malformed values', () => {
+    expect(decodeTargetValue('')).toBeNull()
+    expect(decodeTargetValue('bogus')).toBeNull()
+    expect(decodeTargetValue('http:provider')).toBeNull()
+    expect(decodeTargetValue('llm:')).toBeNull()
+  })
+})

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/default-chat-target.helpers.ts
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/default-chat-target.helpers.ts
@@ -1,0 +1,60 @@
+import type { LlmProviderConfig } from '@/lib/llm-providers/types'
+import type { SidepanelChatTargetSelection } from '@/modules/chat/sidepanel-chat-targets'
+// Relative (not `@/`) so this module stays loadable under `bun test`, which
+// resolves tsconfig `@/` aliases for erased type imports only, not values.
+import { resolveDefaultProviderId } from '../../lib/llm-providers/provider-selection'
+
+interface ResolveEffectiveDefaultTargetInput {
+  providers: LlmProviderConfig[]
+  agents: ReadonlyArray<{ id: string }>
+  selection: SidepanelChatTargetSelection | null
+  defaultProviderId: string
+}
+
+/**
+ * Resolves which single row (LLM provider or coding agent) the AI-settings
+ * pane shows as selected: the persisted chat-target selection when it still
+ * points at an existing row, otherwise the resolved default provider —
+ * mirroring `resolveSidepanelChatTarget`'s fallback.
+ */
+export function resolveEffectiveDefaultTarget({
+  providers,
+  agents,
+  selection,
+  defaultProviderId,
+}: ResolveEffectiveDefaultTargetInput): SidepanelChatTargetSelection {
+  if (
+    selection?.kind === 'acp' &&
+    agents.some((agent) => agent.id === selection.id)
+  ) {
+    return { kind: 'acp', id: selection.id }
+  }
+  if (
+    selection?.kind === 'llm' &&
+    providers.some((provider) => provider.id === selection.id)
+  ) {
+    return { kind: 'llm', id: selection.id }
+  }
+  return {
+    kind: 'llm',
+    id: resolveDefaultProviderId(providers, defaultProviderId),
+  }
+}
+
+/** Encodes a selection as a Select item value; ids may themselves contain ':'. */
+export function encodeTargetValue(
+  selection: SidepanelChatTargetSelection,
+): string {
+  return `${selection.kind}:${selection.id}`
+}
+
+export function decodeTargetValue(
+  value: string,
+): SidepanelChatTargetSelection | null {
+  const separatorIndex = value.indexOf(':')
+  if (separatorIndex === -1) return null
+  const kind = value.slice(0, separatorIndex)
+  const id = value.slice(separatorIndex + 1)
+  if ((kind !== 'llm' && kind !== 'acp') || !id) return null
+  return { kind, id }
+}

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/default-chat-target.hooks.ts
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/default-chat-target.hooks.ts
@@ -1,0 +1,101 @@
+import { useEffect, useState } from 'react'
+import type { LlmProviderConfig } from '@/lib/llm-providers/types'
+import { sentry } from '@/lib/sentry/sentry'
+import {
+  loadSidepanelChatTargetSelection,
+  type SidepanelChatTargetSelection,
+  saveSidepanelChatTargetSelection,
+  watchSidepanelChatTargetSelection,
+} from '@/modules/chat/sidepanel-chat-targets'
+import { resolveEffectiveDefaultTarget } from './default-chat-target.helpers'
+
+interface UseDefaultChatTargetInput {
+  providers: LlmProviderConfig[]
+  agents: ReadonlyArray<{ id: string }>
+  defaultProviderId: string
+  setDefaultProvider: (providerId: string) => Promise<void>
+}
+
+export interface DefaultChatTargetController {
+  effectiveTarget: SidepanelChatTargetSelection
+  selectProvider: (providerId: string) => void
+  selectAgent: (agentId: string) => void
+  selectTarget: (selection: SidepanelChatTargetSelection) => void
+}
+
+/**
+ * Selection state for the AI-settings pane's unified default-target radio
+ * group. Reads and writes the same persisted selection the sidepanel resolves
+ * (`local:sidepanel-chat-target-selection`), so picking a row here changes
+ * what new chats use everywhere. Selecting a provider also updates the
+ * default-provider id, mirroring the sidepanel's select semantics.
+ */
+export function useDefaultChatTarget({
+  providers,
+  agents,
+  defaultProviderId,
+  setDefaultProvider,
+}: UseDefaultChatTargetInput): DefaultChatTargetController {
+  const [selection, setSelection] =
+    useState<SidepanelChatTargetSelection | null>(null)
+
+  useEffect(() => {
+    let cancelled = false
+    loadSidepanelChatTargetSelection().then((stored) => {
+      if (!cancelled) setSelection(stored)
+    })
+    const unwatch = watchSidepanelChatTargetSelection((stored) => {
+      setSelection(stored)
+    })
+    return () => {
+      cancelled = true
+      unwatch()
+    }
+  }, [])
+
+  const persistSelection = (next: SidepanelChatTargetSelection) => {
+    setSelection(next)
+    saveSidepanelChatTargetSelection(next).catch((error) => {
+      sentry.captureException(error, {
+        extra: {
+          message: 'Failed to persist default chat-target selection',
+          targetId: next.id,
+          targetKind: next.kind,
+        },
+      })
+    })
+  }
+
+  const selectProvider = (providerId: string) => {
+    setDefaultProvider(providerId).catch((error) => {
+      sentry.captureException(error, {
+        extra: {
+          message: 'Failed to persist default provider id',
+          providerId,
+        },
+      })
+    })
+    persistSelection({ kind: 'llm', id: providerId })
+  }
+
+  const selectAgent = (agentId: string) => {
+    persistSelection({ kind: 'acp', id: agentId })
+  }
+
+  const selectTarget = (next: SidepanelChatTargetSelection) => {
+    if (next.kind === 'llm') {
+      selectProvider(next.id)
+    } else {
+      selectAgent(next.id)
+    }
+  }
+
+  const effectiveTarget = resolveEffectiveDefaultTarget({
+    providers,
+    agents,
+    selection,
+    defaultProviderId,
+  })
+
+  return { effectiveTarget, selectProvider, selectAgent, selectTarget }
+}

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/default-chat-target.hooks.ts
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/default-chat-target.hooks.ts
@@ -41,9 +41,15 @@ export function useDefaultChatTarget({
 
   useEffect(() => {
     let cancelled = false
-    loadSidepanelChatTargetSelection().then((stored) => {
-      if (!cancelled) setSelection(stored)
-    })
+    loadSidepanelChatTargetSelection()
+      .then((stored) => {
+        if (!cancelled) setSelection(stored)
+      })
+      .catch((error) => {
+        sentry.captureException(error, {
+          extra: { message: 'Failed to load default chat-target selection' },
+        })
+      })
     const unwatch = watchSidepanelChatTargetSelection((stored) => {
       setSelection(stored)
     })


### PR DESCRIPTION
## Summary
- Coding-agent rows (Claude Code / Codex, e.g. `cc-1`) in Settings > AI & Agents rendered a radio circle but could not be selected; only LLM provider rows worked. Agent rows are now selectable with the same label + sr-only-radio pattern as `ProviderCard`, in one exclusive `default-provider` radio group.
- Selection is wired to the existing cross-surface chat-target storage (`local:sidepanel-chat-target-selection`): picking an agent persists `{kind:'acp', id}` so new sidepanel/new-tab chats use it; picking a provider persists `{kind:'llm', id}` and sets the default provider, mirroring the sidepanel's select semantics.
- The header "Default Provider" select now lists both groups (LLM providers / Coding agents); deleting an agent clears a selection that pointed at it, and the pane watches the storage so external changes reflect live.

## Design
Rather than inventing a parallel "default agent" concept, the settings pane reuses the selection the chat surfaces already resolve with provider fallback (`modules/chat/sidepanel-chat-targets.ts`). New storage primitives (save/clear/watch, lazy-import pattern preserved for bun-test loadability) feed a pure resolver (`resolveEffectiveDefaultTarget`: acp selection wins when the agent exists, llm selection when the provider exists, else the resolved default provider) and a thin `useDefaultChatTarget` hook that the pane, provider list, agent list, and grouped header select all share — exactly one row shows selected.

## Test plan
- [x] `cd apps/agent && bun run test` — 132 pass (new: selection storage primitives, effective-target resolution + encode/decode, CodingAgentCard selected/unselected rendering)
- [x] `bun run lint` / `bun run typecheck` / `bun run test:main` / `bun run build:agent` — green
- [ ] Manual: Settings > AI & Agents — click the cc-1 row → radio fills + DEFAULT badge moves; new sidepanel chat targets Claude Code; selecting BrowserOS switches back

🤖 Generated with [Claude Code](https://claude.com/claude-code)