### PR TITLE
fix(build): stop shipping stale universal app in macOS nightly

### DIFF
--- a/packages/browseros/build/common/context.py
+++ b/packages/browseros/build/common/context.py
@@ -439,26 +439,15 @@ class Context:
     def get_app_path(self) -> Path:
         """Get built app path
 
-        For universal builds, checks if out/Default_universal/BrowserOS.app exists
-        and returns that instead of the architecture-specific path.
-
-        This allows downstream modules (sign, package) to work on the universal
-        binary after UniversalBuildModule has run.
-
-        Note: If _fixed_app_path is set, returns that directly (used by
-        UniversalBuildModule to prevent auto-detection during arch-specific ops).
+        Resolves strictly from this context's own out_dir (or _fixed_app_path
+        when set, as UniversalBuildModule does). Never probes other out dirs:
+        a stale out/Default_universal app must not hijack arch-specific
+        builds' sign/package stages. Universal flows resolve here too, since
+        architecture="universal" already derives out_dir=out/Default_universal.
         """
         # If fixed path is set (for arch-specific operations), use it directly
         if self._fixed_app_path:
             return self._fixed_app_path
-
-        # Check for universal binary first (macOS only)
-        if IS_MACOS():
-            universal_app = join_paths(
-                self.chromium_src, "out/Default_universal", self.BROWSEROS_APP_NAME
-            )
-            if universal_app.exists():
-                return universal_app
 
         # For debug builds, check if the app has a different name
         if self.build_type == "debug" and IS_MACOS():

--- a/packages/browseros/build/common/context.py
+++ b/packages/browseros/build/common/context.py
@@ -210,8 +210,8 @@ class Context:
     # New code should use ctx.artifacts (ArtifactRegistry) instead
     artifacts: Dict[str, List[Path]] = field(default_factory=dict)
 
-    # Fixed app path - used by UniversalBuildModule to prevent auto-detection
-    # When set, get_app_path() returns this directly instead of auto-detecting
+    # When set, get_app_path() returns this directly — UniversalBuildModule
+    # pins per-arch and universal app paths through it.
     _fixed_app_path: Optional[Path] = None
 
     # New sub-components (initialized in __post_init__)

--- a/packages/browseros/build/common/context_test.py
+++ b/packages/browseros/build/common/context_test.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Tests for Context app path resolution."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from .context import Context
+
+
+class GetAppPathTest(unittest.TestCase):
+    def test_arch_build_ignores_stale_universal_app(self):
+        # Regression: a leftover out/Default_universal app must never hijack
+        # an arch-specific build's sign/package stages.
+        with tempfile.TemporaryDirectory() as tmp:
+            chromium_src = Path(tmp)
+            ctx = Context(
+                chromium_src=chromium_src,
+                architecture="arm64",
+                build_type="release",
+            )
+
+            stale_universal = (
+                chromium_src / "out" / "Default_universal" / ctx.BROWSEROS_APP_NAME
+            )
+            stale_universal.mkdir(parents=True)
+
+            fresh_arm64 = chromium_src / ctx.out_dir / ctx.BROWSEROS_APP_NAME
+            fresh_arm64.mkdir(parents=True, exist_ok=True)
+
+            self.assertEqual(ctx.get_app_path(), fresh_arm64)
+
+    def test_universal_architecture_resolves_universal_out_dir(self):
+        ctx = Context(
+            chromium_src=Path("/nonexistent-src"),
+            architecture="universal",
+            build_type="release",
+        )
+
+        expected = (
+            Path("/nonexistent-src") / ctx.out_dir / ctx.BROWSEROS_APP_NAME
+        )
+        self.assertTrue(str(ctx.out_dir).endswith("Default_universal"))
+        self.assertEqual(ctx.get_app_path(), expected)
+
+    def test_fixed_app_path_short_circuits_resolution(self):
+        ctx = Context(
+            chromium_src=Path("/nonexistent-src"),
+            architecture="arm64",
+            build_type="release",
+        )
+        pinned = Path("/pinned") / ctx.BROWSEROS_APP_NAME
+        ctx._fixed_app_path = pinned
+
+        self.assertEqual(ctx.get_app_path(), pinned)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/modules/compile/universal.py
+++ b/packages/browseros/build/modules/compile/universal.py
@@ -263,9 +263,7 @@ class UniversalBuildModule(CommandModule):
             architecture=arch,
             build_type=base_ctx.build_type,
         )
-        # Set fixed app path to prevent universal auto-detection in get_app_path()
-        # This is critical: after arm64 is built, get_app_path() would otherwise
-        # try to detect the universal dir for x64 context
+        # Pin the app path for this arch's context
         ctx._fixed_app_path = (
             ctx.chromium_src / f"out/Default_{arch}" / ctx.BROWSEROS_APP_NAME
         )

--- a/packages/browseros/build/modules/sign/macos.py
+++ b/packages/browseros/build/modules/sign/macos.py
@@ -40,6 +40,8 @@ SERVER_RESOURCES_SOURCE_REL = Path("chrome/browser/browseros/server/resources")
 SERVER_RESOURCES_BUNDLE_REL = Path(
     "Contents/Resources/BrowserOSServer/default/resources"
 )
+# Finder droppings in the staged tree must not fail the nightly sign.
+SERVER_RESOURCES_JUNK_FILES = {".DS_Store"}
 
 
 def verify_server_resources_bundle(app_path: Path, chromium_src: Path) -> List[str]:
@@ -64,7 +66,7 @@ def verify_server_resources_bundle(app_path: Path, chromium_src: Path) -> List[s
     problems: List[str] = []
     source_rels = []
     for source_file in sorted(source_root.rglob("*")):
-        if not source_file.is_file():
+        if not source_file.is_file() or source_file.name in SERVER_RESOURCES_JUNK_FILES:
             continue
         rel = source_file.relative_to(source_root)
         source_rels.append(rel)
@@ -78,7 +80,10 @@ def verify_server_resources_bundle(app_path: Path, chromium_src: Path) -> List[s
     if bundle_root.is_dir():
         staged = set(source_rels)
         for bundle_file in sorted(bundle_root.rglob("*")):
-            if not bundle_file.is_file():
+            if (
+                not bundle_file.is_file()
+                or bundle_file.name in SERVER_RESOURCES_JUNK_FILES
+            ):
                 continue
             rel = bundle_file.relative_to(bundle_root)
             if rel not in staged:

--- a/packages/browseros/build/modules/sign/macos.py
+++ b/packages/browseros/build/modules/sign/macos.py
@@ -52,6 +52,10 @@ def verify_server_resources_bundle(app_path: Path, chromium_src: Path) -> List[s
     staged under chrome/browser/browseros/server/resources must exist in the
     bundle with executable bits intact. Returns problem strings; empty = OK.
     Bundle-only extras and a missing source tree (sign-only flows) just warn.
+
+    Deliberately compares paths + exec bits only, never content/size: universal
+    bundles hold lipo-fat binaries whose bytes differ from the thin staged
+    tree, so same-name content staleness is out of this guard's reach.
     """
     source_root = chromium_src / SERVER_RESOURCES_SOURCE_REL
     bundle_root = app_path / SERVER_RESOURCES_BUNDLE_REL
@@ -64,12 +68,12 @@ def verify_server_resources_bundle(app_path: Path, chromium_src: Path) -> List[s
         return []
 
     problems: List[str] = []
-    source_rels = []
+    staged = set()
     for source_file in sorted(source_root.rglob("*")):
         if not source_file.is_file() or source_file.name in SERVER_RESOURCES_JUNK_FILES:
             continue
         rel = source_file.relative_to(source_root)
-        source_rels.append(rel)
+        staged.add(rel)
         bundle_file = bundle_root / rel
         if not bundle_file.is_file():
             problems.append(f"missing from app bundle: {rel.as_posix()}")
@@ -78,7 +82,6 @@ def verify_server_resources_bundle(app_path: Path, chromium_src: Path) -> List[s
             problems.append(f"lost executable bit in app bundle: {rel.as_posix()}")
 
     if bundle_root.is_dir():
-        staged = set(source_rels)
         for bundle_file in sorted(bundle_root.rglob("*")):
             if (
                 not bundle_file.is_file()

--- a/packages/browseros/build/modules/sign/macos.py
+++ b/packages/browseros/build/modules/sign/macos.py
@@ -36,6 +36,60 @@ def get_browseros_server_binary_info(component_path: Path) -> Optional[Dict[str,
     return info
 
 
+SERVER_RESOURCES_SOURCE_REL = Path("chrome/browser/browseros/server/resources")
+SERVER_RESOURCES_BUNDLE_REL = Path(
+    "Contents/Resources/BrowserOSServer/default/resources"
+)
+
+
+def verify_server_resources_bundle(app_path: Path, chromium_src: Path) -> List[str]:
+    """Check the app bundle ships exactly what the build staged for the server.
+
+    Guards against signing/packaging a stale or incomplete bundle (a leftover
+    out/Default_universal app once shipped for two weeks unnoticed): every file
+    staged under chrome/browser/browseros/server/resources must exist in the
+    bundle with executable bits intact. Returns problem strings; empty = OK.
+    Bundle-only extras and a missing source tree (sign-only flows) just warn.
+    """
+    source_root = chromium_src / SERVER_RESOURCES_SOURCE_REL
+    bundle_root = app_path / SERVER_RESOURCES_BUNDLE_REL
+
+    if not source_root.is_dir():
+        log_warning(
+            f"Staged server resources not found at {source_root} - "
+            "skipping bundle verification"
+        )
+        return []
+
+    problems: List[str] = []
+    source_rels = []
+    for source_file in sorted(source_root.rglob("*")):
+        if not source_file.is_file():
+            continue
+        rel = source_file.relative_to(source_root)
+        source_rels.append(rel)
+        bundle_file = bundle_root / rel
+        if not bundle_file.is_file():
+            problems.append(f"missing from app bundle: {rel.as_posix()}")
+            continue
+        if os.access(source_file, os.X_OK) and not os.access(bundle_file, os.X_OK):
+            problems.append(f"lost executable bit in app bundle: {rel.as_posix()}")
+
+    if bundle_root.is_dir():
+        staged = set(source_rels)
+        for bundle_file in sorted(bundle_root.rglob("*")):
+            if not bundle_file.is_file():
+                continue
+            rel = bundle_file.relative_to(bundle_root)
+            if rel not in staged:
+                log_warning(
+                    f"App bundle has server file not in staged resources "
+                    f"(stale?): {rel.as_posix()}"
+                )
+
+    return problems
+
+
 def run_command(
     cmd: List[str],
     cwd: Optional[Path] = None,
@@ -101,6 +155,7 @@ class MacOSSignModule(CommandModule):
         app_path = ctx.get_app_path()
         env_ok, env_vars = check_environment(ctx.env)
 
+        self._verify_server_resources(app_path, ctx)
         self._clear_extended_attributes(app_path)
         self._sign_all_components(app_path, env_vars["certificate_name"], ctx)
         self._verify_signature(app_path)
@@ -108,6 +163,14 @@ class MacOSSignModule(CommandModule):
 
         ctx.artifact_registry.add("signed_app", app_path)
         log_success("Application signed and notarized successfully")
+
+    def _verify_server_resources(self, app_path: Path, ctx: Context) -> None:
+        problems = verify_server_resources_bundle(app_path, ctx.chromium_src)
+        if problems:
+            raise RuntimeError(
+                "App bundle does not match staged server resources "
+                "(signing a stale build?):\n  " + "\n  ".join(problems)
+            )
 
     def _clear_extended_attributes(self, app_path: Path) -> None:
         log_info("🧹 Clearing extended attributes...")
@@ -782,6 +845,16 @@ def sign_app(ctx: Context, create_dmg: bool = True) -> bool:
     # Verify app exists
     if not app_path.exists():
         log_error(f"App not found at: {app_path}")
+        return False
+
+    problems = verify_server_resources_bundle(app_path, ctx.chromium_src)
+    if problems:
+        log_error(
+            "App bundle does not match staged server resources "
+            "(signing a stale build?):"
+        )
+        for problem in problems:
+            log_error(f"  {problem}")
         return False
 
     try:

--- a/packages/browseros/build/modules/sign/macos_test.py
+++ b/packages/browseros/build/modules/sign/macos_test.py
@@ -5,7 +5,15 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from .macos import find_components_to_sign, verify_server_resources_bundle
+import yaml
+
+from ...common.context import Context
+from .macos import (
+    SERVER_RESOURCES_SOURCE_REL,
+    MacOSSignModule,
+    find_components_to_sign,
+    verify_server_resources_bundle,
+)
 
 
 def _write_exec(path: Path) -> None:
@@ -122,6 +130,81 @@ class VerifyServerResourcesBundleTest(unittest.TestCase):
             self.assertEqual(
                 verify_server_resources_bundle(app_path, chromium_src), []
             )
+
+    def test_junk_files_in_source_are_ignored(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            chromium_src, app_path, source_root, bundle_root = self._setup(tmp)
+            _write_exec(source_root / "bin" / "browseros_server")
+            _write_file(source_root / "bin" / ".DS_Store", "junk")
+            _write_exec(bundle_root / "bin" / "browseros_server")
+
+            self.assertEqual(
+                verify_server_resources_bundle(app_path, chromium_src), []
+            )
+
+    def test_source_rel_matches_copy_resources_destination(self):
+        # The guard reads the staging dir that copy_resources.yaml writes; if
+        # that destination moves, the guard must not silently degrade to the
+        # skip branch.
+        config_path = (
+            Path(__file__).resolve().parents[2] / "config" / "copy_resources.yaml"
+        )
+        config = yaml.safe_load(config_path.read_text())
+        destinations = {
+            op["destination"]
+            for op in config["copy_operations"]
+            if op["name"].startswith("BrowserOS Server Resources")
+        }
+
+        self.assertEqual(destinations, {SERVER_RESOURCES_SOURCE_REL.as_posix()})
+
+
+class SignModuleGuardWiringTest(unittest.TestCase):
+    def test_execute_path_raises_on_stale_bundle(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            chromium_src = Path(tmp) / "src"
+            app_path = Path(tmp) / "out" / "BrowserOS.app"
+            source_root = (
+                chromium_src / "chrome" / "browser" / "browseros" / "server" / "resources"
+            )
+            _write_exec(source_root / "bin" / "third_party" / "codex")
+
+            ctx = Context(
+                chromium_src=chromium_src,
+                architecture="arm64",
+                build_type="release",
+            )
+
+            with self.assertRaises(RuntimeError) as raised:
+                MacOSSignModule()._verify_server_resources(app_path, ctx)
+
+            self.assertIn("bin/third_party/codex", str(raised.exception))
+
+    def test_execute_path_accepts_matching_bundle(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            chromium_src = Path(tmp) / "src"
+            app_path = Path(tmp) / "out" / "BrowserOS.app"
+            source_root = (
+                chromium_src / "chrome" / "browser" / "browseros" / "server" / "resources"
+            )
+            bundle_root = (
+                app_path
+                / "Contents"
+                / "Resources"
+                / "BrowserOSServer"
+                / "default"
+                / "resources"
+            )
+            _write_exec(source_root / "bin" / "third_party" / "codex")
+            _write_exec(bundle_root / "bin" / "third_party" / "codex")
+
+            ctx = Context(
+                chromium_src=chromium_src,
+                architecture="arm64",
+                build_type="release",
+            )
+
+            MacOSSignModule()._verify_server_resources(app_path, ctx)
 
 
 if __name__ == "__main__":

--- a/packages/browseros/build/modules/sign/macos_test.py
+++ b/packages/browseros/build/modules/sign/macos_test.py
@@ -160,7 +160,7 @@ class VerifyServerResourcesBundleTest(unittest.TestCase):
 
 
 class SignModuleGuardWiringTest(unittest.TestCase):
-    def test_execute_path_raises_on_stale_bundle(self):
+    def test_module_guard_raises_on_stale_bundle(self):
         with tempfile.TemporaryDirectory() as tmp:
             chromium_src = Path(tmp) / "src"
             app_path = Path(tmp) / "out" / "BrowserOS.app"
@@ -180,7 +180,7 @@ class SignModuleGuardWiringTest(unittest.TestCase):
 
             self.assertIn("bin/third_party/codex", str(raised.exception))
 
-    def test_execute_path_accepts_matching_bundle(self):
+    def test_module_guard_accepts_matching_bundle(self):
         with tempfile.TemporaryDirectory() as tmp:
             chromium_src = Path(tmp) / "src"
             app_path = Path(tmp) / "out" / "BrowserOS.app"

--- a/packages/browseros/build/modules/sign/macos_test.py
+++ b/packages/browseros/build/modules/sign/macos_test.py
@@ -5,13 +5,18 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from .macos import find_components_to_sign
+from .macos import find_components_to_sign, verify_server_resources_bundle
 
 
 def _write_exec(path: Path) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text("#!/bin/sh\n")
     path.chmod(path.stat().st_mode | 0o755)
+
+
+def _write_file(path: Path, content: str = "data\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
 
 
 class MacOSSignDiscoveryTest(unittest.TestCase):
@@ -42,6 +47,80 @@ class MacOSSignDiscoveryTest(unittest.TestCase):
             self.assertNotIn(
                 server_bin / "third_party" / "lima" / "bin" / "limactl",
                 executables,
+            )
+
+
+class VerifyServerResourcesBundleTest(unittest.TestCase):
+    def _setup(self, tmp: str) -> tuple[Path, Path, Path, Path]:
+        chromium_src = Path(tmp) / "src"
+        app_path = Path(tmp) / "out" / "BrowserOS.app"
+        source_root = chromium_src / "chrome" / "browser" / "browseros" / "server" / "resources"
+        bundle_root = (
+            app_path
+            / "Contents"
+            / "Resources"
+            / "BrowserOSServer"
+            / "default"
+            / "resources"
+        )
+        return chromium_src, app_path, source_root, bundle_root
+
+    def test_reports_files_missing_from_bundle(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            chromium_src, app_path, source_root, bundle_root = self._setup(tmp)
+            _write_exec(source_root / "bin" / "browseros_server")
+            _write_exec(source_root / "bin" / "third_party" / "codex")
+            _write_exec(bundle_root / "bin" / "browseros_server")
+
+            problems = verify_server_resources_bundle(app_path, chromium_src)
+
+            self.assertEqual(len(problems), 1)
+            self.assertIn("bin/third_party/codex", problems[0])
+
+    def test_reports_lost_executable_bit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            chromium_src, app_path, source_root, bundle_root = self._setup(tmp)
+            _write_exec(source_root / "bin" / "third_party" / "claude")
+            _write_file(bundle_root / "bin" / "third_party" / "claude", "#!/bin/sh\n")
+
+            problems = verify_server_resources_bundle(app_path, chromium_src)
+
+            self.assertEqual(len(problems), 1)
+            self.assertIn("bin/third_party/claude", problems[0])
+            self.assertIn("executable", problems[0])
+
+    def test_passes_when_bundle_matches_source(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            chromium_src, app_path, source_root, bundle_root = self._setup(tmp)
+            _write_exec(source_root / "bin" / "browseros_server")
+            _write_exec(source_root / "bin" / "third_party" / "codex")
+            _write_file(source_root / "db" / "migrations" / "0000_init.sql")
+            _write_exec(bundle_root / "bin" / "browseros_server")
+            _write_exec(bundle_root / "bin" / "third_party" / "codex")
+            _write_file(bundle_root / "db" / "migrations" / "0000_init.sql")
+
+            self.assertEqual(
+                verify_server_resources_bundle(app_path, chromium_src), []
+            )
+
+    def test_skips_when_source_dir_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            chromium_src, app_path, _, bundle_root = self._setup(tmp)
+            _write_exec(bundle_root / "bin" / "browseros_server")
+
+            self.assertEqual(
+                verify_server_resources_bundle(app_path, chromium_src), []
+            )
+
+    def test_bundle_only_extras_are_not_failures(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            chromium_src, app_path, source_root, bundle_root = self._setup(tmp)
+            _write_exec(source_root / "bin" / "browseros_server")
+            _write_exec(bundle_root / "bin" / "browseros_server")
+            _write_exec(bundle_root / "bin" / "third_party" / "lima" / "limactl")
+
+            self.assertEqual(
+                verify_server_resources_bundle(app_path, chromium_src), []
             )
 
 


### PR DESCRIPTION
## Summary
- The nightly macOS DMG has been a re-signed **May 27 universal app** for ~2 weeks: `Context.get_app_path()` preferred `out/Default_universal/BrowserOS.app` whenever it existed, so the arm64-only nightly signed/packaged a stale leftover instead of the app it just built. That's why the Codex/Claude CLIs bundled in cf2a9feb (#1093) never appeared in releases — verified by mounting the June 9 nightly DMG: fat x86_64+arm64 binaries, stale `third_party/lima/`, no codex/claude, Chromium build number dating it to build-offset 146 (May 27). The agent→R2→artifact-zip pipeline is fully correct (the R2 zip contains all binaries, `rwxr-xr-x`).
- Fix: `get_app_path()` now resolves strictly from the context's own `out_dir` (or `_fixed_app_path`). The universal pipeline never relied on the removed auto-detect — `UniversalBuildModule` pins `_fixed_app_path` for every context, and `architecture: universal` configs already derive `out_dir = out/Default_universal`.
- Guard: signing now verifies the bundle's `BrowserOSServer/default/resources` matches the staged tree (`chrome/browser/browseros/server/resources`) — missing files or lost exec bits fail the build **before notarization**; bundle-only extras and `.DS_Store` warn/skip. Wired into both `MacOSSignModule.execute()` (also covers `UniversalBuildModule`, which bypasses `validate()`) and legacy `sign_app()`.

## Design
Two independent changes in `packages/browseros/build/`: (1) delete the universal-first probe in `common/context.py` so app-path resolution is single-sourced from `out_dir`; (2) add `verify_server_resources_bundle()` in `modules/sign/macos.py` comparing paths + executable bits only — deliberately not content/size, since universal bundles hold lipo-fat binaries that legitimately differ from the thin staged tree. The guard converts this entire silent-stale failure class into a loud pre-notarization stop.

## Test plan
- [x] `uv run python -m unittest` over all `packages/browseros` test modules — 109 pass (13 new: stale-universal regression, universal/out_dir + `_fixed_app_path` resolution, guard missing-file/exec-bit/match/skip/extras/junk, module wiring raise, source-rel pinned to `copy_resources.yaml`)
- [x] `ruff` + `pyright` clean on touched files
- [ ] After merge: next nightly DMG contains `Contents/Resources/BrowserOSServer/default/resources/bin/third_party/{codex,claude}` signed as `com.browseros.codex`/`com.browseros.claude`

## Follow-ups (not in this PR)
- Ops: delete the stale `out/Default_universal/` on the builder (inert after this fix; frees disk).
- CI gap (pre-existing): no workflow runs `packages/browseros` Python tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)