### PR TITLE
feat(server): plant CLAUDE.md / AGENTS.md in ACP workspaces

### DIFF
--- a/packages/browseros-agent/apps/agent/lib/messaging/server/buildChatRequestBody.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/messaging/server/buildChatRequestBody.test.ts
@@ -45,4 +45,42 @@ describe('buildChatRequestBody', () => {
     expect(body.userSystemPrompt).toBe('Stay in the current tab.')
     expect(body.declinedApps).toEqual(['gmail'])
   })
+
+  it('forwards the provider id so the server can scope per-provider state', () => {
+    const body = buildChatRequestBody({
+      conversationId: '6ff46e3b-e45a-40a4-9157-ca520e800f43',
+      provider: { ...provider, id: 'uuid-opus-high' },
+    })
+    expect(body.providerId).toBe('uuid-opus-high')
+  })
+
+  it('forwards every ACP field so the chat path can reach a custom agent', () => {
+    const acpProvider: LlmProviderConfig = {
+      ...provider,
+      id: 'uuid-claude-opus',
+      type: 'claude-code',
+      name: 'Claude Opus',
+      acpAgentId: 'claude',
+      acpCommand: undefined,
+      acpFixedWorkspacePath: '/home/user/agents/claude-opus',
+    }
+    const body = buildChatRequestBody({
+      conversationId: '6ff46e3b-e45a-40a4-9157-ca520e800f43',
+      provider: acpProvider,
+    })
+    expect(body.providerId).toBe('uuid-claude-opus')
+    expect(body.acpAgentId).toBe('claude')
+    expect(body.acpCommand).toBeUndefined()
+    expect(body.acpFixedWorkspacePath).toBe('/home/user/agents/claude-opus')
+  })
+
+  it('leaves ACP fields undefined for non-ACP providers', () => {
+    const body = buildChatRequestBody({
+      conversationId: '6ff46e3b-e45a-40a4-9157-ca520e800f43',
+      provider,
+    })
+    expect(body.acpAgentId).toBeUndefined()
+    expect(body.acpCommand).toBeUndefined()
+    expect(body.acpFixedWorkspacePath).toBeUndefined()
+  })
 })

--- a/packages/browseros-agent/apps/agent/lib/messaging/server/buildChatRequestBody.ts
+++ b/packages/browseros-agent/apps/agent/lib/messaging/server/buildChatRequestBody.ts
@@ -61,6 +61,7 @@ export const buildChatRequestBody = ({
 }: ChatRequestBodyParams) => ({
   message,
   provider: provider.type,
+  providerId: provider.id,
   providerType: provider.type,
   providerName: provider.name,
   apiKey: provider.apiKey,
@@ -77,6 +78,13 @@ export const buildChatRequestBody = ({
   sessionToken: provider.sessionToken,
   reasoningEffort: provider.reasoningEffort,
   reasoningSummary: provider.reasoningSummary,
+  // ACP-backed providers (claude-code, codex, acp-custom) need their
+  // own fields to reach the server; otherwise every provider config of
+  // a given type would share one workspace and the user-supplied
+  // workspace path would be silently dropped.
+  acpAgentId: provider.acpAgentId,
+  acpCommand: provider.acpCommand,
+  acpFixedWorkspacePath: provider.acpFixedWorkspacePath,
   browserContext,
   userSystemPrompt,
   userWorkingDir,

--- a/packages/browseros-agent/apps/server/src/agent/acp-instructions/ensureInstructionFile.ts
+++ b/packages/browseros-agent/apps/server/src/agent/acp-instructions/ensureInstructionFile.ts
@@ -8,7 +8,6 @@
  * when a new conversation starts; subsequent turns short-circuit.
  */
 
-import { rename, writeFile } from 'node:fs/promises'
 import { dirname, join } from 'node:path'
 import { type BuildSystemPromptOptions, buildSystemPrompt } from '../prompt'
 import { instructionFilenameFor } from './filenames'
@@ -75,9 +74,10 @@ async function defaultWriteFileAtomic(
   path: string,
   contents: string,
 ): Promise<void> {
+  const fs = await import('node:fs/promises')
   const tmp = join(dirname(path), `.${path.split('/').pop()}.browseros-tmp`)
-  await writeFile(tmp, contents, 'utf8')
-  await rename(tmp, path)
+  await fs.writeFile(tmp, contents, 'utf8')
+  await fs.rename(tmp, path)
 }
 
 export async function ensureWorkspaceInstructionFile(

--- a/packages/browseros-agent/apps/server/src/agent/acp-instructions/ensureInstructionFile.ts
+++ b/packages/browseros-agent/apps/server/src/agent/acp-instructions/ensureInstructionFile.ts
@@ -50,13 +50,18 @@ const fileLocks = new Map<string, FileLock>()
 function withFileLock<T>(path: string, fn: () => Promise<T>): Promise<T> {
   const prev = fileLocks.get(path) ?? Promise.resolve()
   const next = prev.then(fn, fn)
-  fileLocks.set(
-    path,
-    next.then(
-      () => undefined,
-      () => undefined,
-    ),
+  const tail: FileLock = next.then(
+    () => undefined,
+    () => undefined,
   )
+  fileLocks.set(path, tail)
+  // Drop the entry once the chain settles so the Map cannot grow
+  // without bound across long-running processes. The identity check
+  // makes sure a newer queued call that overwrote our tail keeps its
+  // entry; we only clear when nobody else is waiting on this path.
+  tail.then(() => {
+    if (fileLocks.get(path) === tail) fileLocks.delete(path)
+  })
   return next
 }
 

--- a/packages/browseros-agent/apps/server/src/agent/acp-instructions/ensureInstructionFile.ts
+++ b/packages/browseros-agent/apps/server/src/agent/acp-instructions/ensureInstructionFile.ts
@@ -1,0 +1,134 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Plants and refreshes the BrowserOS-managed instruction file inside
+ * an ACP agent's workspace. Called from `createAcpLanguageModel`
+ * when a new conversation starts; subsequent turns short-circuit.
+ */
+
+import { rename, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { type BuildSystemPromptOptions, buildSystemPrompt } from '../prompt'
+import { instructionFilenameFor } from './filenames'
+import { promptHash } from './hash'
+import {
+  findManagedBlock,
+  renderManagedBlock,
+  spliceManagedBlock,
+} from './managedBlock'
+
+export interface EnsureInstructionFileOptions {
+  workspacePath: string
+  providerType: string
+  promptOptions: BuildSystemPromptOptions
+  isNewConversation: boolean
+  /**
+   * Filesystem read injected so tests can stub without mocking
+   * `node:fs/promises` at the module level (which leaks across files
+   * in bun's shared test process). Production callers leave it unset.
+   */
+  readFile?: (path: string) => Promise<string | null>
+  /**
+   * Atomic write injected for the same reason. Default writes to a
+   * `.browseros-tmp` sibling and renames into place.
+   */
+  writeFileAtomic?: (path: string, contents: string) => Promise<void>
+}
+
+export type EnsureInstructionFileResult =
+  | { action: 'skipped-not-new-conversation' }
+  | { action: 'skipped-up-to-date'; filename: string; path: string }
+  | { action: 'created'; filename: string; path: string }
+  | { action: 'updated'; filename: string; path: string }
+  | { action: 'appended'; filename: string; path: string }
+  | { action: 'failed'; filename: string; path: string; error: Error }
+
+type FileLock = Promise<unknown>
+const fileLocks = new Map<string, FileLock>()
+
+function withFileLock<T>(path: string, fn: () => Promise<T>): Promise<T> {
+  const prev = fileLocks.get(path) ?? Promise.resolve()
+  const next = prev.then(fn, fn)
+  fileLocks.set(
+    path,
+    next.then(
+      () => undefined,
+      () => undefined,
+    ),
+  )
+  return next
+}
+
+async function defaultReadFile(path: string): Promise<string | null> {
+  const fs = await import('node:fs/promises')
+  try {
+    return await fs.readFile(path, 'utf8')
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw err
+  }
+}
+
+async function defaultWriteFileAtomic(
+  path: string,
+  contents: string,
+): Promise<void> {
+  const tmp = join(dirname(path), `.${path.split('/').pop()}.browseros-tmp`)
+  await writeFile(tmp, contents, 'utf8')
+  await rename(tmp, path)
+}
+
+export async function ensureWorkspaceInstructionFile(
+  opts: EnsureInstructionFileOptions,
+): Promise<EnsureInstructionFileResult> {
+  if (!opts.isNewConversation) {
+    return { action: 'skipped-not-new-conversation' }
+  }
+
+  const filename = instructionFilenameFor(opts.providerType)
+  const path = join(opts.workspacePath, filename)
+  const readFile = opts.readFile ?? defaultReadFile
+  const writeFileAtomic = opts.writeFileAtomic ?? defaultWriteFileAtomic
+
+  return withFileLock(path, async () => {
+    try {
+      const prompt = buildSystemPrompt(opts.promptOptions)
+      const hash = promptHash(prompt)
+      const nextBlock = renderManagedBlock(prompt, hash)
+
+      const existing = await readFile(path)
+      if (existing === null) {
+        await writeFileAtomic(path, `${nextBlock}\n`)
+        return { action: 'created', filename, path }
+      }
+
+      const block = findManagedBlock(existing)
+      if (block === null) {
+        const separator = existing.endsWith('\n\n')
+          ? ''
+          : existing.endsWith('\n')
+            ? '\n'
+            : '\n\n'
+        await writeFileAtomic(path, `${existing}${separator}${nextBlock}\n`)
+        return { action: 'appended', filename, path }
+      }
+
+      if (block.storedHash === hash) {
+        return { action: 'skipped-up-to-date', filename, path }
+      }
+
+      const next = spliceManagedBlock(existing, block, nextBlock)
+      await writeFileAtomic(path, next)
+      return { action: 'updated', filename, path }
+    } catch (err) {
+      return {
+        action: 'failed',
+        filename,
+        path,
+        error: err instanceof Error ? err : new Error(String(err)),
+      }
+    }
+  })
+}

--- a/packages/browseros-agent/apps/server/src/agent/acp-instructions/filenames.ts
+++ b/packages/browseros-agent/apps/server/src/agent/acp-instructions/filenames.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
+
+/**
+ * Picks the workspace-rooted markdown file that the spawned ACP agent
+ * reads at session start. Claude Code reads `CLAUDE.md`; everything
+ * else (Codex, custom ACP agents) follows the OpenAI / Codex CLI
+ * `AGENTS.md` convention which has become the de-facto fallback.
+ */
+export function instructionFilenameFor(providerType: string): string {
+  if (providerType === LLM_PROVIDERS.CLAUDE_CODE) return 'CLAUDE.md'
+  return 'AGENTS.md'
+}

--- a/packages/browseros-agent/apps/server/src/agent/acp-instructions/hash.ts
+++ b/packages/browseros-agent/apps/server/src/agent/acp-instructions/hash.ts
@@ -1,0 +1,18 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createHash } from 'node:crypto'
+
+/**
+ * Short sha256 prefix used as the version anchor for the managed
+ * instruction block. 12 hex chars is 48 bits of entropy, which is
+ * collision-resistant at the cardinality we deal with (a few rendered
+ * prompts per user install) and small enough to stay readable in the
+ * marker line.
+ */
+export function promptHash(rendered: string): string {
+  return createHash('sha256').update(rendered).digest('hex').slice(0, 12)
+}

--- a/packages/browseros-agent/apps/server/src/agent/acp-instructions/index.ts
+++ b/packages/browseros-agent/apps/server/src/agent/acp-instructions/index.ts
@@ -1,0 +1,19 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+export {
+  type EnsureInstructionFileOptions,
+  type EnsureInstructionFileResult,
+  ensureWorkspaceInstructionFile,
+} from './ensureInstructionFile'
+export { instructionFilenameFor } from './filenames'
+export { promptHash } from './hash'
+export {
+  findManagedBlock,
+  type ManagedBlock,
+  renderManagedBlock,
+  spliceManagedBlock,
+} from './managedBlock'

--- a/packages/browseros-agent/apps/server/src/agent/acp-instructions/managedBlock.ts
+++ b/packages/browseros-agent/apps/server/src/agent/acp-instructions/managedBlock.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Renders, parses, and splices the BrowserOS-managed block inside the
+ * ACP workspace instruction file (CLAUDE.md / AGENTS.md). Everything
+ * outside the BEGIN/END markers is user-authored content and never
+ * touched.
+ */
+
+const BEGIN = '<!-- BROWSEROS:BEGIN -->'
+const END = '<!-- BROWSEROS:END -->'
+const HASH_LINE_RE = /<!-- BROWSEROS:HASH=([0-9a-f]+) -->/
+
+/**
+ * Location of the managed block inside a source file plus the hash
+ * value embedded in it. `startIndex` points at the BEGIN marker;
+ * `endIndex` points immediately after the END marker so a splice
+ * call only needs `source.slice(0, startIndex) + next +
+ * source.slice(endIndex)`.
+ */
+export interface ManagedBlock {
+  startIndex: number
+  endIndex: number
+  storedHash: string | null
+}
+
+export function findManagedBlock(source: string): ManagedBlock | null {
+  const startIndex = source.indexOf(BEGIN)
+  if (startIndex === -1) return null
+  const endMarkerIndex = source.indexOf(END, startIndex + BEGIN.length)
+  if (endMarkerIndex === -1) return null
+  const inside = source.slice(startIndex + BEGIN.length, endMarkerIndex)
+  const hashMatch = HASH_LINE_RE.exec(inside)
+  return {
+    startIndex,
+    endIndex: endMarkerIndex + END.length,
+    storedHash: hashMatch ? hashMatch[1] : null,
+  }
+}
+
+export function renderManagedBlock(prompt: string, hash: string): string {
+  return [
+    BEGIN,
+    '<!-- This block is managed by BrowserOS. Do not edit inside the markers. -->',
+    `<!-- BROWSEROS:HASH=${hash} -->`,
+    '',
+    prompt,
+    '',
+    END,
+  ].join('\n')
+}
+
+export function spliceManagedBlock(
+  source: string,
+  block: ManagedBlock,
+  next: string,
+): string {
+  return source.slice(0, block.startIndex) + next + source.slice(block.endIndex)
+}

--- a/packages/browseros-agent/apps/server/src/agent/prompt.ts
+++ b/packages/browseros-agent/apps/server/src/agent/prompt.ts
@@ -155,6 +155,20 @@ You have a session workspace for reading, writing, and executing files. See the 
 }
 
 // -----------------------------------------------------------------------------
+// section: acp-tool-namespace (only rendered when acpMode is true)
+// -----------------------------------------------------------------------------
+
+function getAcpToolNamespace(
+  _exclude: Set<string>,
+  options?: BuildSystemPromptOptions,
+): string {
+  if (!options?.acpMode) return ''
+  return `<acp_tool_namespace>
+You are running through BrowserOS as an ACP-powered agent. The browser tools listed in capabilities reach you over MCP as \`mcp.browseros.<name>\`, so \`navigate\` is \`mcp.browseros.navigate\`, \`act\` is \`mcp.browseros.act\`, \`snapshot\` is \`mcp.browseros.snapshot\`, and so on. Your workspace filesystem is a separate surface from the browser tabs; editing files in the workspace does not change web page content, and reading pages over the browser tools does not touch your workspace. Prefer the BrowserOS MCP tools over your own built-in file, shell, or fetch tools for any browser or web task.
+</acp_tool_namespace>`
+}
+
+// -----------------------------------------------------------------------------
 // section: execution
 // -----------------------------------------------------------------------------
 
@@ -610,6 +624,7 @@ const promptSections: Record<string, PromptSectionFn> = {
   'role-and-mode': getRoleAndMode,
   security: getSecurity,
   capabilities: getCapabilities,
+  'acp-tool-namespace': getAcpToolNamespace,
   execution: getExecution,
   'tool-selection': (
     _exclude: Set<string>,
@@ -639,6 +654,13 @@ export interface BuildSystemPromptOptions {
   declinedApps?: string[]
   /** Where the chat session originates from — determines navigation behavior. */
   origin?: 'sidepanel' | 'newtab'
+  /**
+   * Render the ACP-only tool-namespace addendum. Set to true when the
+   * prompt is being written into a CLAUDE.md / AGENTS.md workspace file
+   * for an ACP-backed agent; leave unset for the cloud LLM tool-loop
+   * path so the section stays out of those prompts.
+   */
+  acpMode?: boolean
 }
 
 export function buildSystemPrompt(options?: BuildSystemPromptOptions): string {

--- a/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
+++ b/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
@@ -35,8 +35,25 @@ const BUILT_IN_ACP_AGENT_BY_PROVIDER: Record<string, string> = {
   [LLM_PROVIDERS.CODEX]: 'codex',
 }
 
-function defaultAcpWorkspacePath(providerId: string): string {
-  return join(getBrowserosDir(), 'workspaces', providerId)
+/**
+ * Per-provider workspace path so two providers of the same TYPE (e.g.
+ * Claude Opus High and Claude Sonnet Medium) get isolated working
+ * directories instead of stomping on each other's files. The provider
+ * type still anchors the top-level folder so the user can browse
+ * `workspaces/claude-code/` to see all their Claude Code provider
+ * records at a glance.
+ *
+ * `providerId` is optional for backwards compatibility with chat
+ * requests from older clients that did not forward the saved
+ * `LlmProviderConfig.id` to the server; those still land on the legacy
+ * shared path. New requests always carry it.
+ */
+function defaultAcpWorkspacePath(
+  providerType: string,
+  providerId: string | undefined,
+): string {
+  const base = join(getBrowserosDir(), 'workspaces', providerType)
+  return providerId ? join(base, providerId) : base
 }
 
 /**
@@ -70,7 +87,8 @@ async function createAcpLanguageModel(
 ): Promise<LanguageModelWithCleanup> {
   const agentId = resolveAcpAgentId(config)
   const workspacePath = expandHomeToken(
-    config.acpFixedWorkspacePath ?? defaultAcpWorkspacePath(config.provider),
+    config.acpFixedWorkspacePath ??
+      defaultAcpWorkspacePath(config.provider, config.providerId),
   )
   await mkdir(workspacePath, { recursive: true }).catch((err: unknown) => {
     logger.warn('Failed to ensure ACP workspace exists; spawn may fail', {

--- a/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
+++ b/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
@@ -22,7 +22,10 @@ import { createCodexFetch } from '../lib/clients/oauth/codex-fetch'
 import { createCopilotFetch } from '../lib/clients/oauth/copilot-fetch'
 import { logger } from '../lib/logger'
 import { createOpenRouterCompatibleFetch } from '../lib/openrouter-fetch'
+import { ensureWorkspaceInstructionFile } from './acp-instructions'
 import { ACP_PROVIDER_TYPES, isAcpProvider } from './acp-providers'
+import type { BuildSystemPromptOptions } from './prompt'
+import { readSoulPrompt } from './soul-prompt'
 import type { ResolvedAgentConfig } from './types'
 
 export { isAcpProvider }
@@ -75,6 +78,38 @@ async function createAcpLanguageModel(
       error: err instanceof Error ? err.message : String(err),
     })
   })
+
+  // Plant or refresh the ACP workspace instruction file (CLAUDE.md /
+  // AGENTS.md) on conversation start. Subsequent turns short-circuit
+  // inside the helper. Failures are logged but never thrown so a bad
+  // write does not break the chat.
+  const promptOptions: BuildSystemPromptOptions = {
+    workspaceDir: workspacePath,
+    userSystemPrompt: config.userSystemPrompt,
+    chatMode: config.chatMode,
+    isScheduledTask: config.isScheduledTask,
+    soulContent: await readSoulPrompt(),
+    declinedApps: config.declinedApps,
+    origin: config.origin,
+    acpMode: true,
+  }
+  const ensureResult = await ensureWorkspaceInstructionFile({
+    workspacePath,
+    providerType: config.provider,
+    promptOptions,
+    isNewConversation: config.isNewConversation ?? false,
+  })
+  logger.info('ACP workspace instruction file lifecycle', {
+    conversationId: config.conversationId,
+    providerType: config.provider,
+    workspacePath,
+    action: ensureResult.action,
+    ...('filename' in ensureResult ? { filename: ensureResult.filename } : {}),
+    ...(ensureResult.action === 'failed'
+      ? { error: ensureResult.error.message }
+      : {}),
+  })
+
   const agentRegistryOverrides: Record<string, string> = {}
   if (config.provider === LLM_PROVIDERS.ACP_CUSTOM && config.acpCommand) {
     agentRegistryOverrides[agentId] = config.acpCommand

--- a/packages/browseros-agent/apps/server/src/agent/types.ts
+++ b/packages/browseros-agent/apps/server/src/agent/types.ts
@@ -66,4 +66,9 @@ export interface ResolvedAgentConfig {
    *  servers in browserContext. Only consumed by the ACP factory
    *  branch; model-backed factories ignore it. */
   acpMcpServers?: McpServerSpec[]
+
+  /** True iff this is the first turn of the conversation (no session
+   *  cached in the SessionStore). Drives the ACP workspace
+   *  instruction file refresh so subsequent turns do zero fs work. */
+  isNewConversation?: boolean
 }

--- a/packages/browseros-agent/apps/server/src/agent/types.ts
+++ b/packages/browseros-agent/apps/server/src/agent/types.ts
@@ -22,6 +22,13 @@ export interface ProviderConfig {
 export interface ResolvedAgentConfig {
   conversationId: string
   provider: LLMProvider
+  /**
+   * Unique `LlmProviderConfig.id` this request references. Forwarded
+   * from the chat request so the ACP factory can scope the default
+   * workspace path per provider record instead of per provider TYPE
+   * (otherwise every Claude Code provider would share one cwd).
+   */
+  providerId?: string
   model: string
   apiKey?: string
   baseUrl?: string

--- a/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
@@ -46,6 +46,14 @@ export class ChatService {
 
     const llmConfig = await resolveLLMConfig(request, this.deps.browserosId)
 
+    // Look up the session first so we can stamp isNewConversation onto
+    // agentConfig before it flows down into the ACP factory (which uses
+    // the flag to decide whether to refresh the workspace instruction
+    // file). The original isNewSession flag below stays as-is for the
+    // rest of the chat-service logic.
+    let session = sessionStore.get(request.conversationId)
+    const isFirstTurn = !session
+
     const agentConfig: ResolvedAgentConfig = {
       conversationId: request.conversationId,
       provider: llmConfig.provider,
@@ -82,9 +90,9 @@ export class ChatService {
             customMcpServers: request.browserContext?.customMcpServers,
           })
         : undefined,
+      isNewConversation: isFirstTurn,
     }
 
-    let session = sessionStore.get(request.conversationId)
     let isNewSession = false
     const contextChanges: string[] = []
 

--- a/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
@@ -57,6 +57,7 @@ export class ChatService {
     const agentConfig: ResolvedAgentConfig = {
       conversationId: request.conversationId,
       provider: llmConfig.provider,
+      providerId: llmConfig.providerId,
       model: llmConfig.model,
       apiKey: llmConfig.apiKey,
       baseUrl: llmConfig.baseUrl,

--- a/packages/browseros-agent/apps/server/tests/agent/acp-instructions/ensureInstructionFile.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/acp-instructions/ensureInstructionFile.test.ts
@@ -1,0 +1,219 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { beforeEach, describe, expect, it } from 'bun:test'
+import { ensureWorkspaceInstructionFile } from '../../../src/agent/acp-instructions/ensureInstructionFile'
+import { promptHash } from '../../../src/agent/acp-instructions/hash'
+import {
+  findManagedBlock,
+  renderManagedBlock,
+} from '../../../src/agent/acp-instructions/managedBlock'
+import { buildSystemPrompt } from '../../../src/agent/prompt'
+
+interface FakeFs {
+  files: Map<string, string>
+  reads: string[]
+  writes: Array<{ path: string; contents: string }>
+  readFile: (path: string) => Promise<string | null>
+  writeFileAtomic: (path: string, contents: string) => Promise<void>
+}
+
+function makeFakeFs(): FakeFs {
+  const files = new Map<string, string>()
+  const reads: string[] = []
+  const writes: Array<{ path: string; contents: string }> = []
+  return {
+    files,
+    reads,
+    writes,
+    readFile: async (path) => {
+      reads.push(path)
+      return files.has(path) ? (files.get(path) as string) : null
+    },
+    writeFileAtomic: async (path, contents) => {
+      writes.push({ path, contents })
+      files.set(path, contents)
+    },
+  }
+}
+
+let fs: FakeFs
+
+beforeEach(() => {
+  fs = makeFakeFs()
+})
+
+const baseOpts = {
+  workspacePath: '/tmp/ws',
+  providerType: 'claude-code',
+  promptOptions: { workspaceDir: '/tmp/ws' },
+  isNewConversation: true,
+}
+
+describe('ensureWorkspaceInstructionFile', () => {
+  it('writes a fresh CLAUDE.md when the workspace has no file yet', async () => {
+    const result = await ensureWorkspaceInstructionFile({
+      ...baseOpts,
+      readFile: fs.readFile,
+      writeFileAtomic: fs.writeFileAtomic,
+    })
+
+    expect(result.action).toBe('created')
+    expect(fs.writes).toHaveLength(1)
+    expect(fs.writes[0].path).toBe('/tmp/ws/CLAUDE.md')
+    const block = findManagedBlock(fs.writes[0].contents)
+    expect(block).not.toBeNull()
+    const expectedHash = promptHash(buildSystemPrompt(baseOpts.promptOptions))
+    expect(block?.storedHash).toBe(expectedHash)
+  })
+
+  it('uses AGENTS.md for codex', async () => {
+    const result = await ensureWorkspaceInstructionFile({
+      ...baseOpts,
+      providerType: 'codex',
+      readFile: fs.readFile,
+      writeFileAtomic: fs.writeFileAtomic,
+    })
+
+    expect(result.action).toBe('created')
+    expect(fs.writes[0].path).toBe('/tmp/ws/AGENTS.md')
+  })
+
+  it('uses AGENTS.md for acp-custom', async () => {
+    const result = await ensureWorkspaceInstructionFile({
+      ...baseOpts,
+      providerType: 'acp-custom',
+      readFile: fs.readFile,
+      writeFileAtomic: fs.writeFileAtomic,
+    })
+
+    expect(result.action).toBe('created')
+    expect(fs.writes[0].path).toBe('/tmp/ws/AGENTS.md')
+  })
+
+  it('appends to a user-authored file when no managed block exists', async () => {
+    const userContent = '# My workspace notes\n\nthese are mine.\n'
+    fs.files.set('/tmp/ws/CLAUDE.md', userContent)
+
+    const result = await ensureWorkspaceInstructionFile({
+      ...baseOpts,
+      readFile: fs.readFile,
+      writeFileAtomic: fs.writeFileAtomic,
+    })
+
+    expect(result.action).toBe('appended')
+    expect(fs.writes).toHaveLength(1)
+    const written = fs.writes[0].contents
+    expect(written.startsWith(userContent)).toBe(true)
+    expect(findManagedBlock(written)).not.toBeNull()
+  })
+
+  it('skips writing when the existing managed hash matches the rendered prompt', async () => {
+    const prompt = buildSystemPrompt(baseOpts.promptOptions)
+    const hash = promptHash(prompt)
+    const existing = `${renderManagedBlock(prompt, hash)}\n`
+    fs.files.set('/tmp/ws/CLAUDE.md', existing)
+
+    const result = await ensureWorkspaceInstructionFile({
+      ...baseOpts,
+      readFile: fs.readFile,
+      writeFileAtomic: fs.writeFileAtomic,
+    })
+
+    expect(result.action).toBe('skipped-up-to-date')
+    expect(fs.writes).toHaveLength(0)
+  })
+
+  it('replaces the managed block when the stored hash differs and keeps surrounding bytes', async () => {
+    const userTop = '# my workspace notes\n\n'
+    const oldBlock = renderManagedBlock('old prompt body', 'deadbeef0000')
+    const userBottom = '\n\n## addendum\nuser content.\n'
+    fs.files.set('/tmp/ws/CLAUDE.md', userTop + oldBlock + userBottom)
+
+    const result = await ensureWorkspaceInstructionFile({
+      ...baseOpts,
+      readFile: fs.readFile,
+      writeFileAtomic: fs.writeFileAtomic,
+    })
+
+    expect(result.action).toBe('updated')
+    const written = fs.writes[0].contents
+    expect(written.startsWith(userTop)).toBe(true)
+    expect(written.endsWith(userBottom)).toBe(true)
+    expect(written).not.toContain('old prompt body')
+    expect(written).not.toContain('deadbeef0000')
+    const expectedHash = promptHash(buildSystemPrompt(baseOpts.promptOptions))
+    expect(written).toContain(`<!-- BROWSEROS:HASH=${expectedHash} -->`)
+  })
+
+  it('does not even read the file when isNewConversation is false', async () => {
+    const result = await ensureWorkspaceInstructionFile({
+      ...baseOpts,
+      isNewConversation: false,
+      readFile: fs.readFile,
+      writeFileAtomic: fs.writeFileAtomic,
+    })
+
+    expect(result.action).toBe('skipped-not-new-conversation')
+    expect(fs.reads).toHaveLength(0)
+    expect(fs.writes).toHaveLength(0)
+  })
+
+  it('serializes concurrent ensure calls against the same path', async () => {
+    const writeOrder: number[] = []
+    let inFlight = 0
+    let maxInFlight = 0
+    const slowWrite = async (path: string, contents: string) => {
+      inFlight++
+      maxInFlight = Math.max(maxInFlight, inFlight)
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      writeOrder.push(contents.length)
+      fs.files.set(path, contents)
+      inFlight--
+    }
+
+    const promises = [
+      ensureWorkspaceInstructionFile({
+        ...baseOpts,
+        readFile: fs.readFile,
+        writeFileAtomic: slowWrite,
+      }),
+      ensureWorkspaceInstructionFile({
+        ...baseOpts,
+        readFile: fs.readFile,
+        writeFileAtomic: slowWrite,
+      }),
+      ensureWorkspaceInstructionFile({
+        ...baseOpts,
+        readFile: fs.readFile,
+        writeFileAtomic: slowWrite,
+      }),
+    ]
+    const results = await Promise.all(promises)
+
+    expect(maxInFlight).toBe(1)
+    // First call creates the file; the next two see the managed block
+    // they just wrote and short-circuit to skipped-up-to-date.
+    expect(results[0].action).toBe('created')
+    expect(results[1].action).toBe('skipped-up-to-date')
+    expect(results[2].action).toBe('skipped-up-to-date')
+    expect(writeOrder).toHaveLength(1)
+  })
+
+  it('returns a failed result instead of throwing when the write blows up', async () => {
+    const result = await ensureWorkspaceInstructionFile({
+      ...baseOpts,
+      readFile: fs.readFile,
+      writeFileAtomic: async () => {
+        throw new Error('disk full')
+      },
+    })
+
+    expect(result.action).toBe('failed')
+    if (result.action === 'failed') {
+      expect(result.error.message).toBe('disk full')
+    }
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/agent/acp-instructions/managedBlock.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/acp-instructions/managedBlock.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { describe, expect, it } from 'bun:test'
+import {
+  findManagedBlock,
+  renderManagedBlock,
+  spliceManagedBlock,
+} from '../../../src/agent/acp-instructions/managedBlock'
+
+describe('renderManagedBlock', () => {
+  it('emits the begin notice, hash line, prompt body, and end marker in order', () => {
+    const rendered = renderManagedBlock('hello agent', 'deadbeef1234')
+    const lines = rendered.split('\n')
+    expect(lines[0]).toBe('<!-- BROWSEROS:BEGIN -->')
+    expect(lines[1]).toBe(
+      '<!-- This block is managed by BrowserOS. Do not edit inside the markers. -->',
+    )
+    expect(lines[2]).toBe('<!-- BROWSEROS:HASH=deadbeef1234 -->')
+    expect(lines[3]).toBe('')
+    expect(lines[4]).toBe('hello agent')
+    expect(lines[5]).toBe('')
+    expect(lines[6]).toBe('<!-- BROWSEROS:END -->')
+  })
+
+  it('preserves embedded newlines inside the prompt body verbatim', () => {
+    const multi = 'first\n\nsecond\nthird'
+    const rendered = renderManagedBlock(multi, 'abc123')
+    expect(rendered).toContain('\n\nfirst\n\nsecond\nthird\n\n')
+  })
+})
+
+describe('findManagedBlock', () => {
+  it('returns null when no BEGIN marker is present', () => {
+    expect(findManagedBlock('# user notes\n\nnothing managed here.')).toBeNull()
+  })
+
+  it('returns null when BEGIN is present but END is missing', () => {
+    const truncated = '<!-- BROWSEROS:BEGIN -->\nhash and body never closed'
+    expect(findManagedBlock(truncated)).toBeNull()
+  })
+
+  it('parses startIndex, endIndex, and the hash when both markers are present', () => {
+    const source =
+      'preface\n' +
+      '<!-- BROWSEROS:BEGIN -->\n' +
+      '<!-- BROWSEROS:HASH=abc123def456 -->\n' +
+      '\nbody\n\n' +
+      '<!-- BROWSEROS:END -->\n' +
+      'trailing user notes'
+    const block = findManagedBlock(source)
+    expect(block).not.toBeNull()
+    expect(block?.storedHash).toBe('abc123def456')
+    expect(source.slice(block!.startIndex, block!.endIndex)).toContain(
+      '<!-- BROWSEROS:BEGIN -->',
+    )
+    expect(source.slice(block!.startIndex, block!.endIndex)).toContain(
+      '<!-- BROWSEROS:END -->',
+    )
+  })
+
+  it('returns storedHash null when the hash line is malformed', () => {
+    const source =
+      '<!-- BROWSEROS:BEGIN -->\n' +
+      '<!-- malformed hash row -->\n' +
+      'body\n' +
+      '<!-- BROWSEROS:END -->'
+    const block = findManagedBlock(source)
+    expect(block).not.toBeNull()
+    expect(block?.storedHash).toBeNull()
+  })
+
+  it('only matches the first BEGIN+END pair when several are present', () => {
+    const source =
+      '<!-- BROWSEROS:BEGIN -->\n' +
+      '<!-- BROWSEROS:HASH=aaaaaaaaaaaa -->\n' +
+      'first body\n' +
+      '<!-- BROWSEROS:END -->\n' +
+      '<!-- BROWSEROS:BEGIN -->\n' +
+      '<!-- BROWSEROS:HASH=bbbbbbbbbbbb -->\n' +
+      'second body\n' +
+      '<!-- BROWSEROS:END -->'
+    const block = findManagedBlock(source)
+    expect(block?.storedHash).toBe('aaaaaaaaaaaa')
+  })
+})
+
+describe('spliceManagedBlock', () => {
+  it('replaces only the marker range and keeps everything outside byte-identical', () => {
+    const userTop = '# my workspace notes\n\nthis is mine.\n\n'
+    const oldBlock =
+      '<!-- BROWSEROS:BEGIN -->\n' +
+      '<!-- BROWSEROS:HASH=oldhash -->\n' +
+      '\nold body\n\n' +
+      '<!-- BROWSEROS:END -->'
+    const userBottom = '\n\n## addendum from me\nmore content.\n'
+    const source = userTop + oldBlock + userBottom
+
+    const block = findManagedBlock(source)!
+    const fresh = renderManagedBlock('new body', 'newhash')
+    const next = spliceManagedBlock(source, block, fresh)
+
+    expect(next.startsWith(userTop)).toBe(true)
+    expect(next.endsWith(userBottom)).toBe(true)
+    expect(next).toContain('<!-- BROWSEROS:HASH=newhash -->')
+    expect(next).not.toContain('oldhash')
+    expect(next).not.toContain('old body')
+    expect(next).toContain('new body')
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/agent/prompt.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/prompt.test.ts
@@ -1004,6 +1004,49 @@ describe('nudges', () => {
 })
 
 // ---------------------------------------------------------------------------
+// 16. ACP TOOL NAMESPACE
+//
+// Why: ACP-powered agents read this prompt out of CLAUDE.md / AGENTS.md and
+// see browser tools prefixed with `mcp.browseros.*` rather than the bare
+// names the rest of the prompt uses. The addendum resolves the naming
+// mismatch, draws the line between workspace files and browser tabs, and
+// steers the agent toward BrowserOS MCP tools for browser work over its
+// own native filesystem / shell tools. The cloud LLM tool-loop path must
+// never render this section.
+// ---------------------------------------------------------------------------
+describe('acp tool namespace section', () => {
+  it('is absent when acpMode is unset', () => {
+    const prompt = buildRegular()
+    expect(prompt).not.toContain('<acp_tool_namespace>')
+    expect(prompt).not.toContain('mcp.browseros.<name>')
+  })
+
+  it('is absent when acpMode is false', () => {
+    const prompt = buildRegular({ acpMode: false })
+    expect(prompt).not.toContain('<acp_tool_namespace>')
+  })
+
+  it('renders once when acpMode is true', () => {
+    const prompt = buildRegular({ acpMode: true })
+    const matches = prompt.match(/<acp_tool_namespace>/g) ?? []
+    expect(matches).toHaveLength(1)
+    expect(prompt).toContain('mcp.browseros.<name>')
+    expect(prompt).toContain('mcp.browseros.navigate')
+    expect(prompt).toContain('workspace filesystem is a separate surface')
+  })
+
+  it('sits between </capabilities> and <execution> so naming is clarified before the tool tables', () => {
+    const prompt = buildRegular({ acpMode: true })
+    const capsEnd = prompt.indexOf('</capabilities>')
+    const namespaceStart = prompt.indexOf('<acp_tool_namespace>')
+    const executionStart = prompt.indexOf('<execution>')
+    expect(capsEnd).toBeGreaterThan(-1)
+    expect(namespaceStart).toBeGreaterThan(capsEnd)
+    expect(executionStart).toBeGreaterThan(namespaceStart)
+  })
+})
+
+// ---------------------------------------------------------------------------
 // 15. NEW-TAB ORIGIN
 //
 // Why: When the user chats from the new-tab page, the active tab IS the chat

--- a/packages/browseros-agent/apps/server/tests/agent/provider-factory-acp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/provider-factory-acp.test.ts
@@ -118,18 +118,58 @@ describe('createLanguageModel — ACP providers', () => {
     expect(lastBuildArgs?.workspacePath).toBe('/tmp/some-cwd')
   })
 
-  it('falls back to getBrowserosDir()/workspaces/<provider-id> when no path is set', async () => {
+  it('falls back to getBrowserosDir()/workspaces/<type> when no path or providerId is set', async () => {
     await createLanguageModel(baseConfig() as never)
     expect(lastBuildArgs?.workspacePath).toBe(
       join(homedir(), '.browseros-test', 'workspaces', 'claude-code'),
     )
   })
 
+  it('nests under workspaces/<type>/<providerId> when providerId is supplied', async () => {
+    await createLanguageModel({
+      ...baseConfig(),
+      providerId: 'opus-high-uuid-1',
+    } as never)
+    expect(lastBuildArgs?.workspacePath).toBe(
+      join(
+        homedir(),
+        '.browseros-test',
+        'workspaces',
+        'claude-code',
+        'opus-high-uuid-1',
+      ),
+    )
+  })
+
+  it('isolates two providers of the same type into different directories', async () => {
+    await createLanguageModel({
+      ...baseConfig(),
+      providerId: 'opus-high',
+    } as never)
+    const opusPath = lastBuildArgs?.workspacePath
+    await createLanguageModel({
+      ...baseConfig(),
+      providerId: 'sonnet-medium',
+    } as never)
+    expect(opusPath).not.toBe(lastBuildArgs?.workspacePath)
+    expect(opusPath).toContain('claude-code/opus-high')
+    expect(lastBuildArgs?.workspacePath).toContain('claude-code/sonnet-medium')
+  })
+
   it('mkdir -ps the workspace before handing it to buildAcpxProvider', async () => {
-    await createLanguageModel(baseConfig() as never)
+    await createLanguageModel({
+      ...baseConfig(),
+      providerId: 'opus-high-uuid-1',
+    } as never)
     expect(mkdirCalls).toHaveLength(1)
     expect(mkdirCalls[0]?.path).toBe(
-      join(homedir(), '.browseros-test', 'workspaces', 'claude-code'),
+      join(
+        homedir(),
+        '.browseros-test',
+        'workspaces',
+        'claude-code',
+        'opus-high-uuid-1',
+      ),
     )
     expect(mkdirCalls[0]?.opts).toEqual({ recursive: true })
   })

--- a/packages/browseros-agent/apps/server/tests/agent/provider-factory-acp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/provider-factory-acp.test.ts
@@ -27,6 +27,7 @@ mock.module('node:fs/promises', () => ({
 
 mock.module('../../src/lib/browseros-dir', () => ({
   getBrowserosDir: () => join(homedir(), '.browseros-test'),
+  getSoulPath: () => join(homedir(), '.browseros-test', 'SOUL.md'),
 }))
 
 mock.module('../../src/lib/agents/acpx-provider/buildAcpxProvider', () => ({

--- a/packages/browseros-agent/packages/shared/src/schemas/llm.ts
+++ b/packages/browseros-agent/packages/shared/src/schemas/llm.ts
@@ -83,6 +83,7 @@ export type LLMProvider = z.infer<typeof LLMProviderSchema>
  */
 export const LLMConfigSchema: z.ZodObject<{
   provider: typeof LLMProviderSchema
+  providerId: z.ZodOptional<z.ZodString>
   model: z.ZodOptional<z.ZodString>
   apiKey: z.ZodOptional<z.ZodString>
   baseUrl: z.ZodOptional<z.ZodString>
@@ -100,6 +101,11 @@ export const LLMConfigSchema: z.ZodObject<{
   acpFixedWorkspacePath: z.ZodOptional<z.ZodString>
 }> = z.object({
   provider: LLMProviderSchema,
+  // The unique LlmProviderConfig.id this request points at. Used by the
+  // ACP factory to scope the default workspace path so two providers of
+  // the same type (e.g. Claude Opus High vs Claude Sonnet Medium) get
+  // their own isolated working directory instead of sharing one.
+  providerId: z.string().optional(),
   model: z.string().optional(),
   apiKey: z.string().optional(),
   baseUrl: z.string().optional(),


### PR DESCRIPTION
## Summary

- ACP-powered providers (claude-code, codex, acp-custom) cannot receive a per-turn `system` field over the wire; coding agents instead read instructions from a workspace-rooted markdown file (`CLAUDE.md` for Claude Code, `AGENTS.md` for everything else following the Codex CLI convention).
- This branch makes the BrowserOS server own that file. On the first turn of a new conversation, `createAcpLanguageModel` renders the system prompt, hashes it, and writes (or refreshes) a sentinel-marked managed block inside the agent's workspace. Subsequent turns short-circuit before any filesystem work.
- A new ACP-only `acp-tool-namespace` section in the system prompt resolves a real failure mode the existing prompt had on ACP agents: the agents see browser tools prefixed as `mcp.browseros.*` rather than the bare names the rest of the prompt uses, and they have their own native filesystem tools that operate on the workspace (separate surface from browser tabs).

## What is in the diff

| Area | Change |
|---|---|
| `apps/server/src/agent/acp-instructions/` | New module: filename lookup (claude-code → `CLAUDE.md`, others → `AGENTS.md`), 12-char sha256 prompt-hash, managed-block render + parse + splice, three-case orchestrator (`ensureWorkspaceInstructionFile`) with per-path async lock, atomic write, injectable fs for tests. |
| `apps/server/src/agent/prompt.ts` | New `acpMode: boolean` option on `BuildSystemPromptOptions` and a new `acp-tool-namespace` section that renders only when `acpMode === true`. Slotted between `capabilities` and `execution` so the prefix clarification lands before the agent reaches the tool-selection tables. |
| `apps/server/src/agent/types.ts` + `apps/server/src/api/services/chat-service.ts` | `isNewConversation` plumbed onto `ResolvedAgentConfig` from the existing session-store lookup. |
| `apps/server/src/agent/provider-factory.ts` | Wires `ensureWorkspaceInstructionFile` into `createAcpLanguageModel` right after the `mkdir -p workspacePath`. The full result is logged at `info`; failures are caught and logged but never thrown so a bad write cannot break the chat. |

## Managed-block format

```
<!-- BROWSEROS:BEGIN -->
<!-- This block is managed by BrowserOS. Do not edit inside the markers. -->
<!-- BROWSEROS:HASH=8f3c1e9a4b2d -->

<rendered system prompt content>

<!-- BROWSEROS:END -->
```

The 12-char sha256 prefix of the rendered prompt drives the refresh decision: if the file's stored hash matches the freshly-rendered one, the write is skipped; otherwise only the bytes between BEGIN and END change and user-authored content outside the markers stays byte-identical. Files without markers (user-authored CLAUDE.md / AGENTS.md from before BrowserOS was installed) get an appended managed block at the end, leaving the user content intact.

## Test plan

- [x] `bun run test:agent` (server-agent group) — 278 / 278 pass, including new `tests/agent/acp-instructions/{managedBlock,ensureInstructionFile}.test.ts` covering marker render / parse / splice, all three orchestrator branches (created, appended, updated), `skipped-up-to-date` hash match, `skipped-not-new-conversation` short-circuit, concurrent-call serialisation, and catch-and-report failure path.
- [x] `bun run test:api` (server-api group) — 121 / 121 pass.
- [x] `bun run test:lib` (server-lib group) — 218 / 218 pass.
- [x] `bun test` (agent app) — 149 / 149 pass.
- [x] `bunx tsc --noEmit` for both `apps/server` and `apps/agent` — clean.
- [x] `tests/agent/prompt.test.ts` extended with four cases pinning the new section: absent when `acpMode` unset or false, present once when true, and ordered between `</capabilities>` and `<execution>`.

## Manual smoke

After loading the extension and creating a Claude Code provider in `/settings/ai`:

1. Start a brand-new conversation. Check the workspace directory; `CLAUDE.md` should exist with the managed-block markers and the current prompt hash.
2. Edit the file outside the markers (add a custom note above or below). Send another message; the file is left alone (subsequent turns short-circuit).
3. Bump the dynamic prompt context (e.g. connect a new MCP app) and start another new conversation. The hash changes; the managed block updates in place, the custom note outside the markers survives.
4. Repeat with a Codex provider; the file is named `AGENTS.md` and follows the same lifecycle.