### PR TITLE
fix(agent): wrap MCP tool names inside tool cards

### DIFF
--- a/packages/browseros-agent/apps/agent/screens/mcp-settings/MCPToolsSection.tsx
+++ b/packages/browseros-agent/apps/agent/screens/mcp-settings/MCPToolsSection.tsx
@@ -70,7 +70,7 @@ export const MCPToolsSection: FC<MCPToolsSectionProps> = ({
 
         <CollapsibleContent className="pt-4">
           {tools.length > 0 && (
-            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
               {tools.map((tool) => (
                 <div
                   key={tool.name}

--- a/packages/browseros-agent/apps/agent/screens/mcp-settings/MCPToolsSection.tsx
+++ b/packages/browseros-agent/apps/agent/screens/mcp-settings/MCPToolsSection.tsx
@@ -76,12 +76,14 @@ export const MCPToolsSection: FC<MCPToolsSectionProps> = ({
                   key={tool.name}
                   className="rounded-lg border border-border bg-background p-4 transition-all hover:border-[var(--accent-orange)]/50 hover:shadow-sm"
                 >
-                  <div className="mb-2 flex items-center gap-2">
-                    <Wrench className="h-4 w-4 text-[var(--accent-orange)]" />
-                    <span className="font-medium text-sm">{tool.name}</span>
+                  <div className="mb-2 flex items-start gap-2">
+                    <Wrench className="mt-0.5 h-4 w-4 shrink-0 text-[var(--accent-orange)]" />
+                    <span className="min-w-0 break-words font-medium text-sm">
+                      {tool.name}
+                    </span>
                   </div>
                   {tool.description && (
-                    <p className="line-clamp-2 text-muted-foreground text-xs">
+                    <p className="line-clamp-2 break-words text-muted-foreground text-xs">
                       {tool.description}
                     </p>
                   )}


### PR DESCRIPTION
## Summary
- Long snake_case MCP tool names (e.g. `discover_server_categories_in_actions`) and long description tokens overflowed past the card border in the MCP settings "Available Tools" grid.
- Tool names now wrap inside the card (`min-w-0` + `break-words` on the name, `shrink-0` + first-line anchoring for the wrench icon); descriptions wrap too and keep their 2-line clamp.
- The grid is pinned to `grid-cols-1` below `sm` so the single column stays constrained (`minmax(0, 1fr)`) even with pathological unbroken tokens.

## Design
The overflow came from the name `<span>` being a flex item: flex items default to `min-width: auto`, and snake_case names contain no soft break points, so the span refused to shrink and escaped the card. The fix follows the repo's established wrap idiom (`break-words` + flex `min-w-0`/`shrink-0`, as in `AgentChatMessage` and `queue`), keeps the markup and component API untouched, and moves the row to `items-start` with a 2px optical offset so the icon anchors to the first line of wrapped names while single-line cards render pixel-identical.

## Test plan
- [x] `bun run lint` · `bun run typecheck` · `bun run test:main` green
- [x] CDP visual check in the dev extension: all 17 tool cards report `scrollWidth <= clientWidth` (DOM probe), and `discover_server_categories_or_actions` wraps onto two lines inside its card (screenshot verified)

🤖 Generated with [Claude Code](https://claude.com/claude-code)