### PR TITLE
feat(server): launch ACP adapters via the bundled Bun instead of npx

### DIFF
--- a/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
+++ b/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
@@ -12,6 +12,7 @@ import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
 import { createOpenRouter } from '@openrouter/ai-sdk-provider'
 import type { LanguageModel } from 'ai'
 import { buildAcpxProvider } from '../lib/agents/acpx-provider/buildAcpxProvider'
+import { resolveAcpSpawnCommand } from '../lib/agents/host-acp/launcher'
 import { getBrowserosDir } from '../lib/browseros-dir'
 import { createBrowserOSFetch } from '../lib/browseros-fetch'
 import {
@@ -129,6 +130,20 @@ async function createAcpLanguageModel(
   })
 
   const agentRegistryOverrides: Record<string, string> = {}
+  // Pre-seed the built-in adapters with the bundled-Bun launcher so the
+  // spawned child does not depend on `npx` being on the user's PATH.
+  // We only override when the launcher resolved the bundled binary;
+  // host-npx-fallback would only restate acpx's own registry command,
+  // so we let acpx resolve it directly in that case.
+  for (const builtIn of ['claude', 'codex'] as const) {
+    const launcher = resolveAcpSpawnCommand({
+      agentType: builtIn,
+      resourcesDir: config.resourcesDir,
+    })
+    if (launcher?.source === 'bundled-bun') {
+      agentRegistryOverrides[builtIn] = launcher.command
+    }
+  }
   if (config.provider === LLM_PROVIDERS.ACP_CUSTOM && config.acpCommand) {
     agentRegistryOverrides[agentId] = config.acpCommand
   }

--- a/packages/browseros-agent/apps/server/src/agent/types.ts
+++ b/packages/browseros-agent/apps/server/src/agent/types.ts
@@ -78,4 +78,9 @@ export interface ResolvedAgentConfig {
    *  cached in the SessionStore). Drives the ACP workspace
    *  instruction file refresh so subsequent turns do zero fs work. */
   isNewConversation?: boolean
+
+  /** BrowserOS resources directory. Threaded from HttpServerConfig
+   *  into the ACP factory so the bundled-Bun launcher at
+   *  <resourcesDir>/bin/third_party/bun can be located. */
+  resourcesDir?: string | null
 }

--- a/packages/browseros-agent/apps/server/src/api/routes/acpx-probe.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/acpx-probe.ts
@@ -30,16 +30,17 @@ const probeRequestSchema = z
   })
 
 export function createAcpxProbeRoutes(
-  options: { probe?: ProbeAcpAgentFn } = {},
+  options: { probe?: ProbeAcpAgentFn; resourcesDir?: string | null } = {},
 ) {
   const probe = options.probe ?? probeAcpAgent
+  const resourcesDir = options.resourcesDir
   return new Hono().post(
     '/',
     zValidator('json', probeRequestSchema),
     async (c) => {
       const body = c.req.valid('json')
       try {
-        const result = await probe(body)
+        const result = await probe({ ...body, resourcesDir })
         return c.json(result, 200)
       } catch (err) {
         // Probe errors from inside acp-probe (spawn_failed, initialize_timeout,

--- a/packages/browseros-agent/apps/server/src/api/routes/acpx-probe.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/acpx-probe.ts
@@ -23,7 +23,7 @@ const probeRequestSchema = z
     agentId: z.string().optional(),
     command: z.string().optional(),
     cwd: z.string().optional(),
-    timeoutMs: z.number().int().min(1_000).max(60_000).optional(),
+    timeoutMs: z.number().int().min(1_000).max(120_000).optional(),
   })
   .refine((v) => Boolean(v.agentId || v.command), {
     message: 'Either agentId or command is required',

--- a/packages/browseros-agent/apps/server/src/api/routes/chat.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/chat.ts
@@ -20,6 +20,10 @@ interface ChatRouteDeps {
   /** Port the BrowserOS server bound to. Threaded to ACP providers so
    *  the spawned agent can dial back into the local /mcp route. */
   serverPort: number
+  /** BrowserOS resources directory. Threaded to ACP providers so the
+   *  bundled-Bun launcher under <resourcesDir>/bin/third_party/bun
+   *  can be located for built-in adapters (claude / codex). */
+  resourcesDir?: string | null
 }
 
 export function createChatRoutes(deps: ChatRouteDeps) {
@@ -34,6 +38,7 @@ export function createChatRoutes(deps: ChatRouteDeps) {
     browserosId,
     aiSdkDevtoolsEnabled: deps.aiSdkDevtoolsEnabled,
     serverPort: deps.serverPort,
+    resourcesDir: deps.resourcesDir,
   })
 
   return new Hono()

--- a/packages/browseros-agent/apps/server/src/api/routes/provider.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/provider.ts
@@ -14,6 +14,7 @@ import { AgentLLMConfigSchema } from '../types'
 
 interface ProviderRouteDeps {
   browserosId?: string
+  resourcesDir?: string | null
 }
 
 export function createProviderRoutes(deps: ProviderRouteDeps = {}) {
@@ -29,13 +30,16 @@ export function createProviderRoutes(deps: ProviderRouteDeps = {}) {
       })
 
       const result = isAcpProvider(config.provider)
-        ? await testAcpProvider({
-            provider: config.provider,
-            model: config.model,
-            acpAgentId: config.acpAgentId,
-            acpCommand: config.acpCommand,
-            acpFixedWorkspacePath: config.acpFixedWorkspacePath,
-          })
+        ? await testAcpProvider(
+            {
+              provider: config.provider,
+              model: config.model,
+              acpAgentId: config.acpAgentId,
+              acpCommand: config.acpCommand,
+              acpFixedWorkspacePath: config.acpFixedWorkspacePath,
+            },
+            { resourcesDir: deps.resourcesDir },
+          )
         : await testProviderConnection(config, deps.browserosId)
 
       logger.info('Provider test result', {

--- a/packages/browseros-agent/apps/server/src/api/server.ts
+++ b/packages/browseros-agent/apps/server/src/api/server.ts
@@ -123,8 +123,11 @@ export async function createHttpServer(config: HttpServerConfig) {
       }),
     )
     .route('/status', createStatusRoute({ browser }))
-    .route('/test-provider', createProviderRoutes({ browserosId }))
-    .route('/acpx/probe', createAcpxProbeRoutes())
+    .route(
+      '/test-provider',
+      createProviderRoutes({ browserosId, resourcesDir }),
+    )
+    .route('/acpx/probe', createAcpxProbeRoutes({ resourcesDir }))
     .route('/refine-prompt', createRefinePromptRoutes({ browserosId }))
     .route(
       '/oauth',
@@ -163,6 +166,7 @@ export async function createHttpServer(config: HttpServerConfig) {
         klavisRef,
         aiSdkDevtoolsEnabled: config.aiSdkDevtoolsEnabled,
         serverPort: port,
+        resourcesDir,
       }),
     )
     .route('/screencast', createScreencastRoute({ browser }))

--- a/packages/browseros-agent/apps/server/src/api/services/acpx-probe/probeAgent.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/acpx-probe/probeAgent.ts
@@ -5,12 +5,23 @@
  */
 
 import { type AgentProbeResult, probeAgent as runProbe } from 'acp-probe'
+import { resolveAcpSpawnCommand } from '../../../lib/agents/host-acp/launcher'
+import { logger } from '../../../lib/logger'
 
 export interface ServerAcpxProbeInput {
   agentId?: string
   command?: string
   cwd?: string
   timeoutMs?: number
+  /**
+   * BrowserOS resources directory. When set, the probe prefers the
+   * bundled Bun launcher at <resourcesDir>/bin/third_party/bun for
+   * built-in agents so end-user installs without Node still resolve
+   * the spawn correctly. Production callers thread this from the
+   * HttpServerConfig.
+   */
+  resourcesDir?: string | null
+  platform?: NodeJS.Platform
 }
 
 export interface ServerAcpxProbeModel {
@@ -39,7 +50,12 @@ export interface ServerAcpxProbeResult {
   error?: ServerAcpxProbeError
 }
 
-const DEFAULT_PROBE_TIMEOUT_MS = 10_000
+// 30s mirrors acp-probe's library default. The bottleneck on cold
+// cache is the npm tarball fetch + extract for the adapter package,
+// which the bundled-bun launcher does not eliminate; the spawn part
+// is fast either way. Env override (clamped to 1-60s) lets a CI
+// scenario tighten it.
+const DEFAULT_PROBE_TIMEOUT_MS = 30_000
 
 function resolveTimeout(requested?: number): number {
   const envValue = Number(process.env.BROWSEROS_ACPX_PROBE_TIMEOUT_MS)
@@ -56,9 +72,33 @@ export async function probeAcpAgent(
     throw new Error('Either agentId or command is required')
   }
   const timeoutMs = resolveTimeout(input.timeoutMs)
+
+  // Built-in agent ids (claude, codex) get rewritten to an explicit
+  // command when the bundled-Bun launcher resolves. When the launcher
+  // would fall back to `npx -y …` we deliberately leave the agentId
+  // alone so acpx's built-in registry produces the same command via
+  // its own code path; this keeps callers that have not threaded
+  // resourcesDir yet on the exact pre-existing behaviour.
+  let agentId = input.agentId
+  let command = input.command
+  if (!command && agentId) {
+    const launcher = resolveAcpSpawnCommand({
+      agentType: agentId,
+      resourcesDir: input.resourcesDir,
+      platform: input.platform,
+    })
+    if (launcher?.source === 'bundled-bun') {
+      command = launcher.command
+      agentId = undefined
+      logger.debug('ACP probe using bundled-bun launcher', {
+        originalAgentId: input.agentId,
+      })
+    }
+  }
+
   const result = await runProbe({
-    agent: input.agentId,
-    command: input.command,
+    agent: agentId,
+    command,
     cwd: input.cwd,
     authPolicy: 'skip',
     timeoutMs,

--- a/packages/browseros-agent/apps/server/src/api/services/acpx-probe/probeAgent.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/acpx-probe/probeAgent.ts
@@ -50,16 +50,21 @@ export interface ServerAcpxProbeResult {
   error?: ServerAcpxProbeError
 }
 
-// 30s mirrors acp-probe's library default. The bottleneck on cold
-// cache is the npm tarball fetch + extract for the adapter package,
-// which the bundled-bun launcher does not eliminate; the spawn part
-// is fast either way. Env override (clamped to 1-60s) lets a CI
-// scenario tighten it.
-const DEFAULT_PROBE_TIMEOUT_MS = 30_000
+// 120s gives the cold-cache tarball fetch + extract enough headroom on
+// slow networks (corp VPN, antivirus scanning extracted files) without
+// stranding the user behind a smaller deadline. Warm-cache spawns still
+// return in well under a second so the ceiling is invisible in steady
+// state. Env override is clamped to [1s, 120s] for the same reason.
+const DEFAULT_PROBE_TIMEOUT_MS = 120_000
+const MAX_PROBE_TIMEOUT_MS = 120_000
 
 function resolveTimeout(requested?: number): number {
   const envValue = Number(process.env.BROWSEROS_ACPX_PROBE_TIMEOUT_MS)
-  if (Number.isFinite(envValue) && envValue >= 1_000 && envValue <= 60_000) {
+  if (
+    Number.isFinite(envValue) &&
+    envValue >= 1_000 &&
+    envValue <= MAX_PROBE_TIMEOUT_MS
+  ) {
     return envValue
   }
   return requested ?? DEFAULT_PROBE_TIMEOUT_MS

--- a/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
@@ -33,6 +33,10 @@ export interface ChatServiceDeps {
   /** Port the BrowserOS server bound to. Forwarded into the ACP MCP
    *  bridge so the spawned agent can dial back into /mcp. */
   serverPort: number
+  /** BrowserOS resources directory. Threaded into ACP-backed config
+   *  resolutions so the bundled-Bun launcher under
+   *  <resourcesDir>/bin/third_party/bun can be located. */
+  resourcesDir?: string | null
 }
 
 export class ChatService {
@@ -92,6 +96,7 @@ export class ChatService {
           })
         : undefined,
       isNewConversation: isFirstTurn,
+      resourcesDir: this.deps.resourcesDir,
     }
 
     let isNewSession = false

--- a/packages/browseros-agent/apps/server/src/lib/agents/host-acp/launcher.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/host-acp/launcher.ts
@@ -1,0 +1,70 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Constructs the spawn command for a built-in ACP adapter (claude /
+ * codex). Prefers the BrowserOS-shipped Bun at
+ * <resourcesDir>/bin/third_party/bun so end-user installs without Node
+ * still have a working launcher; falls back to the existing
+ * `npx -y …` command when the bundled binary is unavailable
+ * (development configurations, third_party not shipped, platforms
+ * outside darwin / linux / win32).
+ */
+
+import { resolveBundledBun } from './bundled-bun'
+import {
+  HOST_ACP_ADAPTER_CONFIG,
+  type HostAcpAdapter,
+  hasAcpPackageConfig,
+} from './config'
+
+export type AcpLauncherSource = 'bundled-bun' | 'host-npx-fallback'
+
+export interface AcpLauncherResolution {
+  command: string
+  source: AcpLauncherSource
+}
+
+export interface ResolveAcpSpawnCommandInput {
+  agentType: string
+  resourcesDir?: string | null
+  platform?: NodeJS.Platform
+  /** Injected for tests; production callers leave it unset. */
+  resolveBundledBun?: typeof resolveBundledBun
+}
+
+/**
+ * Build the spawn command for a built-in ACP agent.
+ *
+ * Returns null when:
+ *   - the agent type is not a known built-in (e.g. acp-custom; caller
+ *     uses the user-supplied command instead), OR
+ *   - the registry entry has no package spec (hermes today, which
+ *     spawns from a host CLI).
+ */
+export function resolveAcpSpawnCommand(
+  input: ResolveAcpSpawnCommandInput,
+): AcpLauncherResolution | null {
+  if (!(input.agentType in HOST_ACP_ADAPTER_CONFIG)) return null
+  const config = HOST_ACP_ADAPTER_CONFIG[input.agentType as HostAcpAdapter]
+  if (!hasAcpPackageConfig(config)) return null
+
+  const resolve = input.resolveBundledBun ?? resolveBundledBun
+  const bunPath = resolve({
+    resourcesDir: input.resourcesDir,
+    platform: input.platform,
+  })
+  if (bunPath) {
+    // `bun x <pkg>@<range>` mirrors `npx -y <pkg>@<range>`. Quote the
+    // bun path because the BrowserOS resources directory can include
+    // spaces (on macOS the resources sit inside the .app bundle which
+    // can include "Application Support" or similar). acpx's splitArgv
+    // honours both single and double quotes.
+    return {
+      command: `"${bunPath}" x ${config.acpPackageSpec}`,
+      source: 'bundled-bun',
+    }
+  }
+  return { command: config.acpCommand, source: 'host-npx-fallback' }
+}

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/test-acp-provider.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/test-acp-provider.ts
@@ -55,7 +55,10 @@ function humanizeProbeError(code: string, fallback: string): string {
 
 export async function testAcpProvider(
   input: TestAcpProviderInput,
-  options: { probe?: ProbeAcpAgentFn } = {},
+  options: {
+    probe?: ProbeAcpAgentFn
+    resourcesDir?: string | null
+  } = {},
 ): Promise<ProviderTestResult> {
   const probe = options.probe ?? probeAcpAgent
   const startTime = performance.now()
@@ -79,6 +82,7 @@ export async function testAcpProvider(
     agentId,
     command: input.acpCommand,
     cwd: input.acpFixedWorkspacePath,
+    resourcesDir: options.resourcesDir,
   })
   const responseTime = Math.round(performance.now() - startTime)
   if (probeResult.error) {

--- a/packages/browseros-agent/apps/server/tests/agent/provider-factory-acp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/provider-factory-acp.test.ts
@@ -105,9 +105,68 @@ describe('createLanguageModel — ACP providers', () => {
     })
   })
 
-  it('leaves agentRegistryOverrides empty for built-in agents', async () => {
+  it('leaves agentRegistryOverrides empty for built-in agents without a bundled bun', async () => {
+    // baseConfig() has no resourcesDir so the launcher cannot resolve
+    // the bundled Bun and falls back to acpx's own npx command, which
+    // means we deliberately do NOT pre-seed the registry override.
     await createLanguageModel(baseConfig() as never)
     expect(lastBuildArgs?.agentRegistryOverrides).toEqual({})
+  })
+
+  it('pre-seeds the bundled-Bun launcher for claude and codex when resourcesDir points at a real bundled bun', async () => {
+    // Sync `node:fs` because `node:fs/promises` is partial-mocked at
+    // the top of this file. We need real disk IO to make the launcher's
+    // resolveBundledBun.statSync find a real file.
+    const fs = await import('node:fs')
+    const os = await import('node:os')
+    const path = await import('node:path')
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bos-pf-acp-'))
+    const binDir = path.join(tmpRoot, 'bin', 'third_party')
+    fs.mkdirSync(binDir, { recursive: true })
+    const bunPath = path.join(binDir, 'bun')
+    fs.writeFileSync(bunPath, '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+
+    await createLanguageModel({
+      ...baseConfig(),
+      resourcesDir: tmpRoot,
+    } as never)
+    const overrides = lastBuildArgs?.agentRegistryOverrides as
+      | Record<string, string>
+      | undefined
+    expect(overrides?.claude).toContain(bunPath)
+    expect(overrides?.claude).toContain('@agentclientprotocol/claude-agent-acp')
+    expect(overrides?.codex).toContain(bunPath)
+    expect(overrides?.codex).toContain('@zed-industries/codex-acp')
+
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('still honours acp-custom user command alongside the built-in pre-seeds', async () => {
+    const fs = await import('node:fs')
+    const os = await import('node:os')
+    const path = await import('node:path')
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bos-pf-acp-'))
+    const binDir = path.join(tmpRoot, 'bin', 'third_party')
+    fs.mkdirSync(binDir, { recursive: true })
+    fs.writeFileSync(path.join(binDir, 'bun'), '#!/bin/sh\nexit 0\n', {
+      mode: 0o755,
+    })
+
+    await createLanguageModel({
+      ...baseConfig(),
+      provider: 'acp-custom',
+      acpAgentId: 'my-agent',
+      acpCommand: 'my-bin acp',
+      resourcesDir: tmpRoot,
+    } as never)
+    const overrides = lastBuildArgs?.agentRegistryOverrides as
+      | Record<string, string>
+      | undefined
+    expect(overrides?.['my-agent']).toBe('my-bin acp')
+    expect(overrides?.claude).toContain('@agentclientprotocol/claude-agent-acp')
+    expect(overrides?.codex).toContain('@zed-industries/codex-acp')
+
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
   })
 
   it('uses the user-supplied workspace path verbatim', async () => {

--- a/packages/browseros-agent/apps/server/tests/api/services/acpx-probe/probeAgent.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/acpx-probe/probeAgent.test.ts
@@ -88,10 +88,10 @@ describe('probeAcpAgent — input shape', () => {
     expect(lastCall?.cwd).toBe('/tmp/x')
   })
 
-  it('defaults the timeout to 10 seconds', async () => {
+  it('defaults the timeout to 30 seconds', async () => {
     nextResult = baseProbeResult()
     await probeAcpAgent({ agentId: 'claude' })
-    expect(lastCall?.timeoutMs).toBe(10_000)
+    expect(lastCall?.timeoutMs).toBe(30_000)
   })
 
   it('honours an explicit timeoutMs', async () => {
@@ -111,7 +111,65 @@ describe('probeAcpAgent — input shape', () => {
     process.env.BROWSEROS_ACPX_PROBE_TIMEOUT_MS = '999'
     nextResult = baseProbeResult()
     await probeAcpAgent({ agentId: 'claude' })
-    expect(lastCall?.timeoutMs).toBe(10_000)
+    expect(lastCall?.timeoutMs).toBe(30_000)
+  })
+})
+
+describe('probeAcpAgent — bundled-Bun launcher swap', () => {
+  it('rewrites a claude agentId to the bundled-Bun command when the binary exists', async () => {
+    // Mock the bundled-bun resolver to return a fake path. The
+    // probe calls resolveAcpSpawnCommand internally with the
+    // resourcesDir we threaded through; we point it at a stub
+    // implementation via the launcher's resolveBundledBun param
+    // path. Since the probe does not expose that injection,
+    // simulate the same outcome by passing a resourcesDir that
+    // makes the real resolveBundledBun succeed: write a fake bun
+    // into tmpdir/bin/third_party.
+    // Sync fs because some sibling test files partial-mock
+    // `node:fs/promises`. Using the sync API sidesteps that pollution.
+    const fs = await import('node:fs')
+    const os = await import('node:os')
+    const path = await import('node:path')
+    const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'bos-launcher-'))
+    const binDir = path.join(tmpRoot, 'bin', 'third_party')
+    fs.mkdirSync(binDir, { recursive: true })
+    const bunPath = path.join(binDir, 'bun')
+    fs.writeFileSync(bunPath, '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+
+    nextResult = baseProbeResult()
+    await probeAcpAgent({ agentId: 'claude', resourcesDir: tmpRoot })
+    expect(lastCall?.agent).toBeUndefined()
+    expect(lastCall?.command).toContain(bunPath)
+    expect(lastCall?.command).toContain('@agentclientprotocol/claude-agent-acp')
+
+    fs.rmSync(tmpRoot, { recursive: true, force: true })
+  })
+
+  it('leaves agentId in place when no resourcesDir is supplied so acpx resolves the npx command', async () => {
+    nextResult = baseProbeResult()
+    await probeAcpAgent({ agentId: 'claude' })
+    expect(lastCall?.agent).toBe('claude')
+    expect(lastCall?.command).toBeUndefined()
+  })
+
+  it('leaves agentId in place when the bundled bun binary is missing under resourcesDir', async () => {
+    nextResult = baseProbeResult()
+    await probeAcpAgent({
+      agentId: 'codex',
+      resourcesDir: '/nonexistent/path/that/has/no/bundled/bun',
+    })
+    expect(lastCall?.agent).toBe('codex')
+    expect(lastCall?.command).toBeUndefined()
+  })
+
+  it('passes through an explicit command unchanged regardless of resourcesDir', async () => {
+    nextResult = baseProbeResult()
+    await probeAcpAgent({
+      command: 'my-custom-binary acp',
+      resourcesDir: '/some/path',
+    })
+    expect(lastCall?.command).toBe('my-custom-binary acp')
+    expect(lastCall?.agent).toBeUndefined()
   })
 })
 

--- a/packages/browseros-agent/apps/server/tests/api/services/acpx-probe/probeAgent.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/acpx-probe/probeAgent.test.ts
@@ -88,10 +88,10 @@ describe('probeAcpAgent — input shape', () => {
     expect(lastCall?.cwd).toBe('/tmp/x')
   })
 
-  it('defaults the timeout to 30 seconds', async () => {
+  it('defaults the timeout to 120 seconds', async () => {
     nextResult = baseProbeResult()
     await probeAcpAgent({ agentId: 'claude' })
-    expect(lastCall?.timeoutMs).toBe(30_000)
+    expect(lastCall?.timeoutMs).toBe(120_000)
   })
 
   it('honours an explicit timeoutMs', async () => {
@@ -100,18 +100,25 @@ describe('probeAcpAgent — input shape', () => {
     expect(lastCall?.timeoutMs).toBe(5_000)
   })
 
-  it('honours BROWSEROS_ACPX_PROBE_TIMEOUT_MS when in the [1000, 60000] range', async () => {
-    process.env.BROWSEROS_ACPX_PROBE_TIMEOUT_MS = '20000'
+  it('honours BROWSEROS_ACPX_PROBE_TIMEOUT_MS when in the [1000, 120000] range', async () => {
+    process.env.BROWSEROS_ACPX_PROBE_TIMEOUT_MS = '90000'
     nextResult = baseProbeResult()
     await probeAcpAgent({ agentId: 'claude' })
-    expect(lastCall?.timeoutMs).toBe(20_000)
+    expect(lastCall?.timeoutMs).toBe(90_000)
   })
 
-  it('ignores BROWSEROS_ACPX_PROBE_TIMEOUT_MS when out of range', async () => {
+  it('ignores BROWSEROS_ACPX_PROBE_TIMEOUT_MS when below the floor', async () => {
     process.env.BROWSEROS_ACPX_PROBE_TIMEOUT_MS = '999'
     nextResult = baseProbeResult()
     await probeAcpAgent({ agentId: 'claude' })
-    expect(lastCall?.timeoutMs).toBe(30_000)
+    expect(lastCall?.timeoutMs).toBe(120_000)
+  })
+
+  it('ignores BROWSEROS_ACPX_PROBE_TIMEOUT_MS when above the ceiling', async () => {
+    process.env.BROWSEROS_ACPX_PROBE_TIMEOUT_MS = '300000'
+    nextResult = baseProbeResult()
+    await probeAcpAgent({ agentId: 'claude' })
+    expect(lastCall?.timeoutMs).toBe(120_000)
   })
 })
 

--- a/packages/browseros-agent/apps/server/tests/lib/agents/host-acp/launcher.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/host-acp/launcher.test.ts
@@ -1,0 +1,93 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { HOST_ACP_ADAPTER_CONFIG } from '../../../../src/lib/agents/host-acp/config'
+import { resolveAcpSpawnCommand } from '../../../../src/lib/agents/host-acp/launcher'
+
+const FAKE_BUN_PATH = '/Volumes/BrowserOS/bin/third_party/bun'
+
+const stubBunPresent: typeof import('../../../../src/lib/agents/host-acp/bundled-bun').resolveBundledBun =
+  () => FAKE_BUN_PATH
+
+const stubBunMissing: typeof import('../../../../src/lib/agents/host-acp/bundled-bun').resolveBundledBun =
+  () => null
+
+describe('resolveAcpSpawnCommand', () => {
+  it('returns the bundled-bun launcher for claude when the binary exists', () => {
+    const out = resolveAcpSpawnCommand({
+      agentType: 'claude',
+      resourcesDir: '/fake/resources',
+      resolveBundledBun: stubBunPresent,
+    })
+    expect(out).not.toBeNull()
+    expect(out?.source).toBe('bundled-bun')
+    expect(out?.command).toBe(
+      `"${FAKE_BUN_PATH}" x ${HOST_ACP_ADAPTER_CONFIG.claude.acpPackageSpec}`,
+    )
+  })
+
+  it('returns the bundled-bun launcher for codex when the binary exists', () => {
+    const out = resolveAcpSpawnCommand({
+      agentType: 'codex',
+      resourcesDir: '/fake/resources',
+      resolveBundledBun: stubBunPresent,
+    })
+    expect(out?.source).toBe('bundled-bun')
+    expect(out?.command).toBe(
+      `"${FAKE_BUN_PATH}" x ${HOST_ACP_ADAPTER_CONFIG.codex.acpPackageSpec}`,
+    )
+  })
+
+  it('falls back to the host npx command when the bundled binary is missing', () => {
+    const out = resolveAcpSpawnCommand({
+      agentType: 'claude',
+      resourcesDir: '/fake/resources',
+      resolveBundledBun: stubBunMissing,
+    })
+    expect(out?.source).toBe('host-npx-fallback')
+    expect(out?.command).toBe(HOST_ACP_ADAPTER_CONFIG.claude.acpCommand)
+  })
+
+  it('returns null for acp-custom so the caller uses the user-supplied command', () => {
+    const out = resolveAcpSpawnCommand({
+      agentType: 'acp-custom',
+      resourcesDir: '/fake/resources',
+      resolveBundledBun: stubBunPresent,
+    })
+    expect(out).toBeNull()
+  })
+
+  it('returns null for hermes since it has no acp package spec', () => {
+    const out = resolveAcpSpawnCommand({
+      agentType: 'hermes',
+      resourcesDir: '/fake/resources',
+      resolveBundledBun: stubBunPresent,
+    })
+    expect(out).toBeNull()
+  })
+
+  it('returns null for an unknown agent type', () => {
+    const out = resolveAcpSpawnCommand({
+      agentType: 'gemini',
+      resourcesDir: '/fake/resources',
+      resolveBundledBun: stubBunPresent,
+    })
+    expect(out).toBeNull()
+  })
+
+  it('double-quotes the bundled bun path so paths with spaces survive', () => {
+    const bunWithSpaces =
+      '/Applications/BrowserOS.app/Contents/bin/third_party/bun'
+    const out = resolveAcpSpawnCommand({
+      agentType: 'claude',
+      resourcesDir: '/Applications/BrowserOS.app/Contents/Resources',
+      resolveBundledBun: () => bunWithSpaces,
+    })
+    expect(out?.command).toBe(
+      `"${bunWithSpaces}" x ${HOST_ACP_ADAPTER_CONFIG.claude.acpPackageSpec}`,
+    )
+  })
+})


### PR DESCRIPTION
## Summary

- acpx's built-in agent registry resolves `claude` and `codex` to `npx -y @agentclientprotocol/claude-agent-acp@^0.31.0` and `npx -y @zed-industries/codex-acp@^0.12.0` respectively. A BrowserOS install on a machine without Node has Bun but no `npx`, so every probe and chat turn fails before the adapter package resolves.
- BrowserOS already ships Bun under `<resourcesDir>/bin/third_party/bun` and there is an existing `resolveBundledBun` helper that locates it. This PR adds a thin launcher on top (`resolveAcpSpawnCommand`) that builds a `"<bundledBunPath>" x <pkgSpec>` command and pre-seeds it into:
  1. **Probe path** (`probeAcpAgent`) - for built-in agent ids, swaps `{ agentId }` to `{ command }` so `acp-probe` skips acpx's registry and spawns the bundled launcher directly.
  2. **Chat path** (`createAcpLanguageModel`) - writes the same command into `agentRegistryOverrides` so the spawned chat child uses the same launcher.
- Both paths only swap when the launcher actually resolved to `bundled-bun`. When the bundled binary is missing (dev configs, `resourcesDir` not threaded, platforms outside darwin/linux/win32) we leave the existing behaviour untouched so acpx's own registry produces the same `npx -y …` command via its own code path.
- `DEFAULT_PROBE_TIMEOUT_MS` bumps from 10s to 30s to match `acp-probe`'s library default. Even with the bundled launcher, the adapter package still has to fetch from npm on cold cache.

## What is in the diff

| Area | Change |
|---|---|
| `apps/server/src/lib/agents/host-acp/launcher.ts` (new) | `resolveAcpSpawnCommand({ agentType, resourcesDir, platform })` returns `{ command, source: 'bundled-bun' | 'host-npx-fallback' } | null`. Reuses `HOST_ACP_ADAPTER_CONFIG.acpPackageSpec` so the version range stays single-sourced. |
| `apps/server/src/api/services/acpx-probe/probeAgent.ts` | Accepts `resourcesDir` + `platform`; swaps `agentId` to `command` when the launcher resolves; default timeout 10s -> 30s. |
| `apps/server/src/agent/provider-factory.ts` | Pre-seeds `agentRegistryOverrides.claude` and `.codex` from the launcher (only when `source === 'bundled-bun'`). `acp-custom` user command continues to win. |
| Route + service layers (`acpx-probe`, `provider`, `chat-service`, `chat`, `api/server`) | Thread `resourcesDir` from `HttpServerConfig` -> `ChatServiceDeps` -> `ResolvedAgentConfig` and into the route options that wrap the probe + test-provider. |

## Behaviour matrix

| Scenario | Probe agent / command on the wire | Chat path agentRegistryOverrides |
|---|---|---|
| Installed BrowserOS, bundled bun present | `command: "<bunPath>" x …` | `{ claude: "…", codex: "…" }` |
| Dev config, `resourcesDir` not threaded | `agent: 'claude'` (acpx resolves npx) | `{}` (acpx resolves npx) |
| `resourcesDir` set but `third_party/bun` missing | `agent: 'claude'` (same as above) | `{}` (same as above) |
| `acp-custom` provider | User's typed command, unchanged | `{ [acpAgentId]: acpCommand }` (plus the bundled claude/codex overrides when available) |
| `hermes` adapter | `agent: 'hermes'` (no acpPackageSpec, launcher returns null) | unchanged |

## Test plan

- [x] `bun run test:agent` (server-agent group) - 282 / 282 pass. New cases in `provider-factory-acp.test.ts` exercise the launcher pre-seed against a real tmpdir bundled bun for both `claude` + `codex`, assert acp-custom continues to win alongside the pre-seeds, and assert the `{}` case for legacy callers without `resourcesDir`.
- [x] `bun run test:api` (server-api group) - 125 / 125 pass. New `probeAgent.test.ts` cases pin the agentId-to-command rewrite against a real tmpdir bundled bun, the agentId-stays-untouched paths (no `resourcesDir`, `resourcesDir` with no bundled bun), and the explicit-command passthrough.
- [x] `bun run test:lib` (server-lib group) - 225 / 225 pass. New `tests/lib/agents/host-acp/launcher.test.ts` covers all six branches: claude + codex with bundled bun, claude with no bundled bun, acp-custom + hermes + unknown returning null, paths-with-spaces double-quoting.
- [x] `bunx tsc --noEmit` (server) - clean.

## Manual smoke

Once the bundled Bun is staged into `<resourcesDir>/bin/third_party/bun`:

1. Remove Node from `PATH` (`PATH="/usr/bin:/bin"`).
2. Click Test on a Claude Code or Codex provider. Probe spawn fires through the bundled bun; first call has up to 30s headroom for the cold-cache tarball fetch, warm cache is sub-second.
3. Send a chat message against either provider. Same launcher fires; the spawned child runs entirely off the bundled Bun even though `npx` is unreachable.