### PR TITLE
fix(build): cap Windows autoninja parallelism to stop clang-cl OOM

### DIFF
--- a/packages/browseros/build/modules/compile/standard.py
+++ b/packages/browseros/build/modules/compile/standard.py
@@ -83,7 +83,7 @@ def compute_ninja_jobs(env: Optional[Mapping[str, str]] = None) -> Optional[int]
     if cpus:
         jobs = min(jobs, cpus)
     log_info(
-        f"Ninja parallelism: -j {jobs} (capped by {total_gb:.0f} GB RAM / "
+        f"Ninja parallelism: -j {jobs} (capped by {int(total_gb)} GB RAM / "
         f"{GB_PER_COMPILE_JOB} GB per job; override with BROWSEROS_NINJA_JOBS)"
     )
     return jobs

--- a/packages/browseros/build/modules/compile/standard.py
+++ b/packages/browseros/build/modules/compile/standard.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python3
 """Standard single-architecture build module for BrowserOS"""
 
+import os
+import sys
 import tempfile
 import shutil
 from pathlib import Path
+from typing import Mapping, Optional
 from ...common.module import CommandModule, ValidationError
 from ...common.context import Context
 from ...common.utils import (
@@ -14,6 +17,76 @@ from ...common.utils import (
     join_paths,
     IS_WINDOWS,
 )
+
+GB_PER_COMPILE_JOB = 4
+
+
+def _windows_total_memory_gb() -> Optional[float]:
+    """Total physical RAM in GB via GlobalMemoryStatusEx; None when unavailable."""
+    if sys.platform != "win32":
+        return None
+    try:
+        import ctypes
+
+        class MEMORYSTATUSEX(ctypes.Structure):
+            _fields_ = [
+                ("dwLength", ctypes.c_uint32),
+                ("dwMemoryLoad", ctypes.c_uint32),
+                ("ullTotalPhys", ctypes.c_uint64),
+                ("ullAvailPhys", ctypes.c_uint64),
+                ("ullTotalPageFile", ctypes.c_uint64),
+                ("ullAvailPageFile", ctypes.c_uint64),
+                ("ullTotalVirtual", ctypes.c_uint64),
+                ("ullAvailVirtual", ctypes.c_uint64),
+                ("ullAvailExtendedVirtual", ctypes.c_uint64),
+            ]
+
+        status = MEMORYSTATUSEX()
+        status.dwLength = ctypes.sizeof(MEMORYSTATUSEX)
+        if not ctypes.windll.kernel32.GlobalMemoryStatusEx(ctypes.byref(status)):
+            return None
+        return status.ullTotalPhys / (1024**3)
+    except Exception:
+        return None
+
+
+def compute_ninja_jobs(env: Optional[Mapping[str, str]] = None) -> Optional[int]:
+    """Resolve the -j value: env override, else Windows RAM cap, else None (autoninja default)."""
+    if env is None:
+        env = os.environ
+
+    override = env.get("BROWSEROS_NINJA_JOBS")
+    if override is not None:
+        try:
+            jobs = int(override)
+        except ValueError:
+            jobs = 0
+        if jobs > 0:
+            log_info(f"Ninja parallelism: -j {jobs} (BROWSEROS_NINJA_JOBS override)")
+            return jobs
+        log_warning(f"Ignoring invalid BROWSEROS_NINJA_JOBS={override!r}")
+
+    if not IS_WINDOWS():
+        return None
+
+    total_gb = _windows_total_memory_gb()
+    if total_gb is None:
+        log_warning(
+            "Could not query physical memory; using autoninja default parallelism"
+        )
+        return None
+
+    # Windows has no overcommit: official+ThinLTO clang-cl jobs peak ~4 GB each,
+    # and one-job-per-core exhausts commit (LLVM ERROR: out of memory).
+    jobs = max(1, int(total_gb) // GB_PER_COMPILE_JOB)
+    cpus = os.cpu_count()
+    if cpus:
+        jobs = min(jobs, cpus)
+    log_info(
+        f"Ninja parallelism: -j {jobs} (capped by {total_gb:.0f} GB RAM / "
+        f"{GB_PER_COMPILE_JOB} GB per job; override with BROWSEROS_NINJA_JOBS)"
+    )
+    return jobs
 
 
 class CompileModule(CommandModule):

--- a/packages/browseros/build/modules/compile/standard.py
+++ b/packages/browseros/build/modules/compile/standard.py
@@ -6,7 +6,7 @@ import sys
 import tempfile
 import shutil
 from pathlib import Path
-from typing import Mapping, Optional
+from typing import List, Mapping, Optional
 from ...common.module import CommandModule, ValidationError
 from ...common.context import Context
 from ...common.utils import (
@@ -89,6 +89,17 @@ def compute_ninja_jobs(env: Optional[Mapping[str, str]] = None) -> Optional[int]
     return jobs
 
 
+def autoninja_command(
+    out_dir: str, targets: List[str], env: Optional[Mapping[str, str]] = None
+) -> List[str]:
+    """Assemble the autoninja argv with the resolved -j parallelism applied."""
+    cmd = ["autoninja.bat" if IS_WINDOWS() else "autoninja", "-C", out_dir]
+    jobs = compute_ninja_jobs(env)
+    if jobs is not None:
+        cmd += ["-j", str(jobs)]
+    return cmd + list(targets)
+
+
 class CompileModule(CommandModule):
     produces = ["built_app"]
     requires = []
@@ -110,10 +121,10 @@ class CompileModule(CommandModule):
 
         self._create_version_file(ctx)
 
-        autoninja_cmd = "autoninja.bat" if IS_WINDOWS() else "autoninja"
-        log_info("Using default autoninja parallelism")
-
-        run_command([autoninja_cmd, "-C", ctx.out_dir, "chrome", "chromedriver"], cwd=ctx.chromium_src)
+        run_command(
+            autoninja_command(ctx.out_dir, ["chrome", "chromedriver"]),
+            cwd=ctx.chromium_src,
+        )
 
         app_path = ctx.get_chromium_app_path()
         new_path = ctx.get_app_path()
@@ -148,8 +159,7 @@ def build_target(ctx: Context, target: str) -> bool:
     """Build a specific target (e.g., mini_installer)"""
     log_info(f"\n🔨 Building target: {target}")
 
-    autoninja_cmd = "autoninja.bat" if IS_WINDOWS() else "autoninja"
-    run_command([autoninja_cmd, "-C", ctx.out_dir, target], cwd=ctx.chromium_src)
+    run_command(autoninja_command(ctx.out_dir, [target]), cwd=ctx.chromium_src)
 
     log_success(f"Target {target} built successfully")
     return True

--- a/packages/browseros/build/modules/compile/standard.py
+++ b/packages/browseros/build/modules/compile/standard.py
@@ -97,6 +97,8 @@ def autoninja_command(
     jobs = compute_ninja_jobs(env)
     if jobs is not None:
         cmd += ["-j", str(jobs)]
+    else:
+        log_info("Ninja parallelism: autoninja default")
     return cmd + list(targets)
 
 

--- a/packages/browseros/build/modules/compile/standard_test.py
+++ b/packages/browseros/build/modules/compile/standard_test.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Tests for memory-aware ninja parallelism in the compile module."""
+
+import unittest
+from unittest import mock
+
+from . import standard
+
+
+class ComputeNinjaJobsTest(unittest.TestCase):
+    def test_env_override_wins_on_any_platform(self):
+        with mock.patch.object(standard, "IS_WINDOWS", return_value=False):
+            jobs = standard.compute_ninja_jobs({"BROWSEROS_NINJA_JOBS": "24"})
+        self.assertEqual(jobs, 24)
+
+    def test_invalid_override_is_ignored(self):
+        for bad in ("abc", "0", "-3", ""):
+            with mock.patch.object(standard, "IS_WINDOWS", return_value=False):
+                jobs = standard.compute_ninja_jobs({"BROWSEROS_NINJA_JOBS": bad})
+            self.assertIsNone(jobs, f"override {bad!r} should be ignored")
+
+    def test_non_windows_without_override_keeps_default(self):
+        with mock.patch.object(standard, "IS_WINDOWS", return_value=False):
+            self.assertIsNone(standard.compute_ninja_jobs({}))
+
+    def test_windows_caps_jobs_by_physical_memory(self):
+        with (
+            mock.patch.object(standard, "IS_WINDOWS", return_value=True),
+            mock.patch.object(
+                standard, "_windows_total_memory_gb", return_value=64.0
+            ),
+            mock.patch("os.cpu_count", return_value=32),
+        ):
+            self.assertEqual(standard.compute_ninja_jobs({}), 16)
+
+    def test_windows_clamps_to_cpu_count(self):
+        with (
+            mock.patch.object(standard, "IS_WINDOWS", return_value=True),
+            mock.patch.object(
+                standard, "_windows_total_memory_gb", return_value=256.0
+            ),
+            mock.patch("os.cpu_count", return_value=16),
+        ):
+            self.assertEqual(standard.compute_ninja_jobs({}), 16)
+
+    def test_windows_never_returns_less_than_one_job(self):
+        with (
+            mock.patch.object(standard, "IS_WINDOWS", return_value=True),
+            mock.patch.object(standard, "_windows_total_memory_gb", return_value=2.0),
+            mock.patch("os.cpu_count", return_value=8),
+        ):
+            self.assertEqual(standard.compute_ninja_jobs({}), 1)
+
+    def test_windows_memory_probe_failure_falls_back_to_default(self):
+        with (
+            mock.patch.object(standard, "IS_WINDOWS", return_value=True),
+            mock.patch.object(standard, "_windows_total_memory_gb", return_value=None),
+            mock.patch("os.cpu_count", return_value=32),
+        ):
+            self.assertIsNone(standard.compute_ninja_jobs({}))
+
+    def test_windows_unknown_cpu_count_uses_memory_value(self):
+        with (
+            mock.patch.object(standard, "IS_WINDOWS", return_value=True),
+            mock.patch.object(
+                standard, "_windows_total_memory_gb", return_value=64.0
+            ),
+            mock.patch("os.cpu_count", return_value=None),
+        ):
+            self.assertEqual(standard.compute_ninja_jobs({}), 16)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/modules/compile/standard_test.py
+++ b/packages/browseros/build/modules/compile/standard_test.py
@@ -27,6 +27,15 @@ class ComputeNinjaJobsTest(unittest.TestCase):
         with mock.patch.object(standard, "IS_WINDOWS", return_value=False):
             self.assertIsNone(standard.compute_ninja_jobs({}))
 
+    def test_valid_override_on_windows_skips_memory_probe(self):
+        with (
+            mock.patch.object(standard, "IS_WINDOWS", return_value=True),
+            mock.patch.object(standard, "_windows_total_memory_gb") as probe,
+        ):
+            jobs = standard.compute_ninja_jobs({"BROWSEROS_NINJA_JOBS": "24"})
+        self.assertEqual(jobs, 24)
+        probe.assert_not_called()
+
     def test_invalid_override_on_windows_falls_through_to_memory_cap(self):
         with (
             mock.patch.object(standard, "IS_WINDOWS", return_value=True),

--- a/packages/browseros/build/modules/compile/standard_test.py
+++ b/packages/browseros/build/modules/compile/standard_test.py
@@ -2,9 +2,13 @@
 """Tests for memory-aware ninja parallelism in the compile module."""
 
 import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
 from unittest import mock
 
 from . import standard
+from ...common.context import Context
 
 
 class ComputeNinjaJobsTest(unittest.TestCase):
@@ -68,6 +72,89 @@ class ComputeNinjaJobsTest(unittest.TestCase):
             mock.patch("os.cpu_count", return_value=None),
         ):
             self.assertEqual(standard.compute_ninja_jobs({}), 16)
+
+
+class AutoninjaCommandTest(unittest.TestCase):
+    def test_override_inserts_jobs_flag_before_targets(self):
+        with mock.patch.object(standard, "IS_WINDOWS", return_value=False):
+            cmd = standard.autoninja_command(
+                "out/Default_x64",
+                ["chrome", "chromedriver"],
+                {"BROWSEROS_NINJA_JOBS": "24"},
+            )
+        self.assertEqual(
+            cmd,
+            [
+                "autoninja",
+                "-C",
+                "out/Default_x64",
+                "-j",
+                "24",
+                "chrome",
+                "chromedriver",
+            ],
+        )
+
+    def test_default_parallelism_has_no_jobs_flag(self):
+        with mock.patch.object(standard, "IS_WINDOWS", return_value=False):
+            cmd = standard.autoninja_command("out/Default_arm64", ["chrome"], {})
+        self.assertEqual(cmd, ["autoninja", "-C", "out/Default_arm64", "chrome"])
+
+    def test_windows_uses_bat_and_memory_capped_jobs(self):
+        with (
+            mock.patch.object(standard, "IS_WINDOWS", return_value=True),
+            mock.patch.object(
+                standard, "_windows_total_memory_gb", return_value=64.0
+            ),
+            mock.patch("os.cpu_count", return_value=32),
+        ):
+            cmd = standard.autoninja_command("out/Default_x64", ["chrome"], {})
+        self.assertEqual(
+            cmd,
+            ["autoninja.bat", "-C", "out/Default_x64", "-j", "16", "chrome"],
+        )
+
+
+class BuildTargetTest(unittest.TestCase):
+    def test_build_target_uses_shared_argv_builder(self):
+        ctx = cast(
+            Context,
+            SimpleNamespace(
+                out_dir="out/Default_x64", chromium_src=Path("/tmp/chromium-src")
+            ),
+        )
+        with (
+            mock.patch.object(standard, "run_command") as run_cmd,
+            mock.patch.object(standard, "IS_WINDOWS", return_value=False),
+            mock.patch.dict("os.environ", {}, clear=True),
+        ):
+            standard.build_target(ctx, "mini_installer")
+        run_cmd.assert_called_once()
+        self.assertEqual(
+            run_cmd.call_args.args[0],
+            ["autoninja", "-C", "out/Default_x64", "mini_installer"],
+        )
+        self.assertEqual(run_cmd.call_args.kwargs["cwd"], ctx.chromium_src)
+
+    def test_build_target_respects_jobs_override(self):
+        ctx = cast(
+            Context,
+            SimpleNamespace(
+                out_dir="out/Default_x64", chromium_src=Path("/tmp/chromium-src")
+            ),
+        )
+        with (
+            mock.patch.object(standard, "run_command") as run_cmd,
+            mock.patch.object(standard, "IS_WINDOWS", return_value=False),
+            mock.patch.dict(
+                "os.environ", {"BROWSEROS_NINJA_JOBS": "8"}, clear=True
+            ),
+        ):
+            standard.build_target(ctx, "mini_installer")
+        self.assertEqual(
+            run_cmd.call_args.args[0],
+            ["autoninja", "-C", "out/Default_x64", "-j", "8", "mini_installer"],
+        )
 
 
 if __name__ == "__main__":

--- a/packages/browseros/build/modules/compile/standard_test.py
+++ b/packages/browseros/build/modules/compile/standard_test.py
@@ -27,12 +27,19 @@ class ComputeNinjaJobsTest(unittest.TestCase):
         with mock.patch.object(standard, "IS_WINDOWS", return_value=False):
             self.assertIsNone(standard.compute_ninja_jobs({}))
 
+    def test_invalid_override_on_windows_falls_through_to_memory_cap(self):
+        with (
+            mock.patch.object(standard, "IS_WINDOWS", return_value=True),
+            mock.patch.object(standard, "_windows_total_memory_gb", return_value=64.0),
+            mock.patch("os.cpu_count", return_value=32),
+        ):
+            jobs = standard.compute_ninja_jobs({"BROWSEROS_NINJA_JOBS": "abc"})
+        self.assertEqual(jobs, 16)
+
     def test_windows_caps_jobs_by_physical_memory(self):
         with (
             mock.patch.object(standard, "IS_WINDOWS", return_value=True),
-            mock.patch.object(
-                standard, "_windows_total_memory_gb", return_value=64.0
-            ),
+            mock.patch.object(standard, "_windows_total_memory_gb", return_value=64.0),
             mock.patch("os.cpu_count", return_value=32),
         ):
             self.assertEqual(standard.compute_ninja_jobs({}), 16)
@@ -40,9 +47,7 @@ class ComputeNinjaJobsTest(unittest.TestCase):
     def test_windows_clamps_to_cpu_count(self):
         with (
             mock.patch.object(standard, "IS_WINDOWS", return_value=True),
-            mock.patch.object(
-                standard, "_windows_total_memory_gb", return_value=256.0
-            ),
+            mock.patch.object(standard, "_windows_total_memory_gb", return_value=256.0),
             mock.patch("os.cpu_count", return_value=16),
         ):
             self.assertEqual(standard.compute_ninja_jobs({}), 16)
@@ -66,9 +71,7 @@ class ComputeNinjaJobsTest(unittest.TestCase):
     def test_windows_unknown_cpu_count_uses_memory_value(self):
         with (
             mock.patch.object(standard, "IS_WINDOWS", return_value=True),
-            mock.patch.object(
-                standard, "_windows_total_memory_gb", return_value=64.0
-            ),
+            mock.patch.object(standard, "_windows_total_memory_gb", return_value=64.0),
             mock.patch("os.cpu_count", return_value=None),
         ):
             self.assertEqual(standard.compute_ninja_jobs({}), 16)
@@ -103,9 +106,7 @@ class AutoninjaCommandTest(unittest.TestCase):
     def test_windows_uses_bat_and_memory_capped_jobs(self):
         with (
             mock.patch.object(standard, "IS_WINDOWS", return_value=True),
-            mock.patch.object(
-                standard, "_windows_total_memory_gb", return_value=64.0
-            ),
+            mock.patch.object(standard, "_windows_total_memory_gb", return_value=64.0),
             mock.patch("os.cpu_count", return_value=32),
         ):
             cmd = standard.autoninja_command("out/Default_x64", ["chrome"], {})
@@ -113,6 +114,26 @@ class AutoninjaCommandTest(unittest.TestCase):
             cmd,
             ["autoninja.bat", "-C", "out/Default_x64", "-j", "16", "chrome"],
         )
+
+
+class CompileModuleExecuteTest(unittest.TestCase):
+    def test_execute_builds_chrome_via_shared_argv_builder(self):
+        ctx = mock.Mock()
+        ctx.out_dir = "out/Default_x64"
+        ctx.chromium_src = Path("/tmp/chromium-src")
+        with (
+            mock.patch.object(standard, "run_command") as run_cmd,
+            mock.patch.object(standard, "IS_WINDOWS", return_value=False),
+            mock.patch.object(standard.CompileModule, "_create_version_file"),
+            mock.patch.dict("os.environ", {}, clear=True),
+        ):
+            standard.CompileModule().execute(ctx)
+        run_cmd.assert_called_once()
+        self.assertEqual(
+            run_cmd.call_args.args[0],
+            ["autoninja", "-C", "out/Default_x64", "chrome", "chromedriver"],
+        )
+        self.assertEqual(run_cmd.call_args.kwargs["cwd"], ctx.chromium_src)
 
 
 class BuildTargetTest(unittest.TestCase):
@@ -146,9 +167,7 @@ class BuildTargetTest(unittest.TestCase):
         with (
             mock.patch.object(standard, "run_command") as run_cmd,
             mock.patch.object(standard, "IS_WINDOWS", return_value=False),
-            mock.patch.dict(
-                "os.environ", {"BROWSEROS_NINJA_JOBS": "8"}, clear=True
-            ),
+            mock.patch.dict("os.environ", {"BROWSEROS_NINJA_JOBS": "8"}, clear=True),
         ):
             standard.build_target(ctx, "mini_installer")
         self.assertEqual(

--- a/packages/browseros/build/modules/package/windows.py
+++ b/packages/browseros/build/modules/package/windows.py
@@ -49,7 +49,7 @@ class WindowsPackageModule(CommandModule):
         notifier = get_notifier()
         notifier.notify(
             "📦 Package Created",
-            f"Windows packages created successfully",
+            "Windows packages created successfully",
             {
                 "Artifacts": f"{installer_path.name}, {zip_path.name}",
                 "Version": ctx.semantic_version,
@@ -118,17 +118,9 @@ def build_mini_installer(ctx: Context) -> bool:
 
     # Build mini_installer using autoninja
     try:
-        # Use autoninja.bat on Windows
-        autoninja_cmd = "autoninja.bat" if IS_WINDOWS else "autoninja"
+        from ..compile.standard import autoninja_command
 
-        # Build the mini_installer target
-        cmd = [
-            autoninja_cmd,
-            "-C",
-            ctx.out_dir,  # Use relative path like in compile.py
-            "setup",
-            "mini_installer",
-        ]
+        cmd = autoninja_command(ctx.out_dir, ["setup", "mini_installer"])
 
         # Change to chromium_src directory before running (like compile.py does)
         import os

--- a/packages/browseros/build/modules/package/windows.py
+++ b/packages/browseros/build/modules/package/windows.py
@@ -17,6 +17,7 @@ from ...common.utils import (
     IS_WINDOWS,
 )
 from ...common.notify import get_notifier, COLOR_GREEN
+from ..compile.standard import autoninja_command
 
 
 class WindowsPackageModule(CommandModule):
@@ -118,8 +119,6 @@ def build_mini_installer(ctx: Context) -> bool:
 
     # Build mini_installer using autoninja
     try:
-        from ..compile.standard import autoninja_command
-
         cmd = autoninja_command(ctx.out_dir, ["setup", "mini_installer"])
 
         # Change to chromium_src directory before running (like compile.py does)

--- a/packages/browseros/build/modules/package/windows_test.py
+++ b/packages/browseros/build/modules/package/windows_test.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python3
+"""Tests for the Windows packaging module's autoninja routing."""
+
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest import mock
+
+from . import windows
+from ..compile import standard
+from ...common.context import Context
+
+
+class BuildMiniInstallerTest(unittest.TestCase):
+    def test_routes_through_shared_argv_builder_with_override(self):
+        ctx = cast(
+            Context,
+            SimpleNamespace(
+                out_dir="out/Default_x64", chromium_src=Path("/tmp/chromium-src")
+            ),
+        )
+        with (
+            mock.patch.object(windows, "run_command") as run_cmd,
+            mock.patch.object(standard, "IS_WINDOWS", return_value=False),
+            mock.patch("os.chdir"),
+            mock.patch("os.getcwd", return_value="/anywhere"),
+            mock.patch.dict("os.environ", {"BROWSEROS_NINJA_JOBS": "8"}, clear=True),
+        ):
+            result = windows.build_mini_installer(ctx)
+        run_cmd.assert_called_once_with(
+            ["autoninja", "-C", "out/Default_x64", "-j", "8", "setup", "mini_installer"]
+        )
+        # Artifacts were never produced (run_command is mocked), so it reports failure.
+        self.assertFalse(result)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Windows official builds were dying mid-run with `LLVM ERROR: out of memory` (clang-cl frontend crash, exception 0xC000001D) — autoninja's default one-job-per-core parallelism exhausts Windows commit memory under official+ThinLTO compile loads (~2-4 GB per clang-cl on mojom-heavy TUs).
- On Windows, all three autoninja call sites (`CompileModule.execute`, `build_target`, packaging's `build_mini_installer`) now pass `-j N` where `N = clamp(total_physical_RAM_GB // 4, 1, logical_cpu_count)`; RAM is read via stdlib `ctypes`/`GlobalMemoryStatusEx` (no new deps).
- `BROWSEROS_NINJA_JOBS=<n>` overrides the heuristic on any platform (invalid values warned and ignored); macOS/Linux behavior without the override is byte-identical to before (no `-j`); probe failure falls back to today's behavior with a warning — the heuristic can never break a build.

## Design
A shared `autoninja_command(out_dir, targets, env)` builder in `compile/standard.py` resolves parallelism through `compute_ninja_jobs()` (override → Windows RAM cap → autoninja default) and assembles the argv for every call site, so future call sites can't drift back to uncapped invocations. The decision and its source are logged for build-log auditability. Capping by physical RAM (not commit limit) is deliberate: pagefile size is admin-managed and volatile, and thrashing into it makes builds crawl anyway. `int()` truncation of reported RAM keeps one job of safety margin on firmware-reserved memory — Windows has no overcommit, and an OOM at step 36k/57k costs hours. Incidentally fixes a latent `if IS_WINDOWS` (missing parens, always-truthy) bug in the packaging module's old inline argv.

## Test plan
- [x] 16 new unit tests (`compile/standard_test.py`, `package/windows_test.py`): override valid/invalid on both platforms, RAM-cap math, CPU/floor clamping, probe-failure fallback, unknown CPU count, and argv routing for all three call sites
- [x] Full build-package suite: 114 tests green; ruff, pyright (repo config), and black clean on touched files
- [ ] On the Windows build host: re-run the official build; expect log line `Ninja parallelism: -j <N> (capped by <RAM> GB RAM / 4 GB per job; ...)` and no clang-cl OOM. If more parallelism is wanted, set `BROWSEROS_NINJA_JOBS`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)