### PR TITLE
feat(server): add upload browser MCP tool using CDP DOM.setFileInputF…

### DIFF
--- a/packages/browseros-agent/apps/server/src/browser/core/input/input.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/input/input.ts
@@ -262,6 +262,10 @@ export class Input {
         backendNodeId,
       }),
     )
+    await this.withPageSessionRetry((session) =>
+      callOnElement(session, backendNodeId,
+        'function(){this.dispatchEvent(new Event("change",{bubbles:true}));return true}'),
+    )
   }
 
   /**

--- a/packages/browseros-agent/apps/server/src/browser/core/input/input.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/input/input.ts
@@ -264,6 +264,15 @@ export class Input {
     )
   }
 
+  /**
+   * Upload files to a file input element identified by ref.
+   * Resolves the ref to backendNodeId and calls DOM.setFileInputFiles.
+   */
+  async upload(ref: string, files: string[]): Promise<void> {
+    const { backendNodeId } = await this.observer.resolveRef(ref)
+    await this.uploadFile(backendNodeId, files)
+  }
+
   async handleDialog(accept: boolean, promptText?: string): Promise<void> {
     await this.withPageSessionRetry((session) =>
       session.Page.handleJavaScriptDialog({

--- a/packages/browseros-agent/apps/server/src/tools/browser/registry.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/registry.ts
@@ -8,6 +8,7 @@ import { run } from './run'
 import { screenshot } from './screenshot'
 import { snapshot } from './snapshot'
 import { tabs } from './tabs'
+import { upload } from './upload'
 import { wait } from './wait'
 
 /** The complete browser tool surface, in a sensible discovery order. */
@@ -17,6 +18,7 @@ export const BROWSER_TOOLS: readonly ToolDefinition[] = [
   snapshot,
   diff,
   act,
+  upload,
   read,
   grep,
   screenshot,

--- a/packages/browseros-agent/apps/server/src/tools/browser/upload.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/upload.ts
@@ -1,0 +1,52 @@
+import { z } from 'zod'
+import {
+  defineTool,
+  textResult,
+  type ToolResult,
+} from './framework'
+
+/**
+ * Upload files to a file input element (<input type="file">) using CDP DOM.setFileInputFiles.
+ * This bypasses the native file picker dialog, enabling automated file uploads.
+ *
+ * Usage:
+ *  1. Take a snapshot to get the ref of the <input type="file"> element.
+ *  2. Call this tool with the ref and an array of file paths.
+ *  3. The files must be accessible to the Chromium browser process.
+ */
+export const upload = defineTool({
+  name: 'upload',
+  description:
+    'Upload files to a file input element without opening the file picker dialog. ' +
+    'Takes a ref (from snapshot) pointing to an <input type="file"> element and an array of file paths. ' +
+    'The files will be set on the input, after which you can click the submit button to upload. ' +
+    'Requires that the file paths are accessible to the browser process.',
+  input: z.object({
+    page: z.number().int().describe('The page id from tabs.'),
+    ref: z
+      .string()
+      .describe(
+        'The ref of the file input element (from snapshot). ' +
+          'Must point to an <input type="file"> element.',
+      ),
+    files: z
+      .array(z.string())
+      .describe(
+        'Array of file paths to upload. ' +
+          'Paths must be accessible to the Chromium browser process. ' +
+          'Supports multiple files for <input multiple>.',
+      ),
+  }),
+  annotations: {
+    readOnlyHint: false,
+    destructiveHint: false,
+    openWorldHint: false,
+  },
+  handler: async (args, ctx): Promise<ToolResult> => {
+    await ctx.session.input(args.page).upload(args.ref, args.files)
+    const fileList = args.files.map((f) => `"${f}"`).join(', ')
+    return textResult(
+      `ok (upload) · set ${args.files.length} file(s): ${fileList}`,
+    )
+  },
+})


### PR DESCRIPTION
…iles

Add a new 'upload' browser tool that sets files on <input type=file> elements via CDP DOM.setFileInputFiles, bypassing the system file picker dialog that blocks browser automation.

Changes:
- Input.upload(ref, files): ref-based wrapper resolving ref to backendNodeId before calling the existing Input.uploadFile() (input.ts)
- tools/browser/upload.ts: new MCP tool exposing upload(ref, files) with Zod schema validation
- registry.ts: register upload in BROWSER_TOOLS (11 tools now)