### PR TITLE
test(build): mock chromium checkout fixture + build-module tests

### DIFF
--- a/packages/browseros/build/common/resolver_test.py
+++ b/packages/browseros/build/common/resolver_test.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Tests for config/pipeline resolution against a mock chromium checkout."""
+
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from .resolver import resolve_config, resolve_pipeline
+from .testing import MockChromium
+
+
+class ResolveConfigConfigModeTest(unittest.TestCase):
+    def test_missing_chromium_src_raises(self):
+        with self.assertRaises(ValueError) as err:
+            resolve_config(cli_args={}, yaml_config={"build": {}})
+        self.assertIn("chromium_src required", str(err.exception))
+
+    def test_nonexistent_chromium_src_raises(self):
+        yaml_config = {"build": {"chromium_src": "/nonexistent/chromium/src"}}
+        with self.assertRaises(ValueError) as err:
+            resolve_config(cli_args={}, yaml_config=yaml_config)
+        self.assertIn("does not exist", str(err.exception))
+
+    def test_arch_list_yields_one_context_per_arch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            m = MockChromium(Path(tmp))
+            yaml_config = {
+                "build": {
+                    "chromium_src": str(m.src),
+                    "architecture": ["x64", "arm64"],
+                    "type": "release",
+                }
+            }
+            contexts = resolve_config(cli_args={}, yaml_config=yaml_config)
+            self.assertEqual([c.architecture for c in contexts], ["x64", "arm64"])
+            self.assertEqual({c.build_type for c in contexts}, {"release"})
+            self.assertEqual({c.chromium_src for c in contexts}, {m.src})
+
+    def test_invalid_arch_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            m = MockChromium(Path(tmp))
+            yaml_config = {
+                "build": {"chromium_src": str(m.src), "architecture": "mips"}
+            }
+            with self.assertRaises(ValueError) as err:
+                resolve_config(cli_args={}, yaml_config=yaml_config)
+            self.assertIn("invalid architecture", str(err.exception))
+
+    def test_cli_overrides_yaml(self):
+        with (
+            tempfile.TemporaryDirectory() as yaml_tmp,
+            tempfile.TemporaryDirectory() as cli_tmp,
+        ):
+            yaml_checkout = MockChromium(Path(yaml_tmp))
+            cli_checkout = MockChromium(Path(cli_tmp))
+            yaml_config = {
+                "build": {
+                    "chromium_src": str(yaml_checkout.src),
+                    "architecture": "x64",
+                    "type": "debug",
+                }
+            }
+            cli_args = {
+                "chromium_src": str(cli_checkout.src),
+                "arch": "arm64",
+                "build_type": "release",
+            }
+            contexts = resolve_config(cli_args=cli_args, yaml_config=yaml_config)
+            self.assertEqual(len(contexts), 1)
+            self.assertEqual(contexts[0].chromium_src, cli_checkout.src)
+            self.assertEqual(contexts[0].architecture, "arm64")
+            self.assertEqual(contexts[0].build_type, "release")
+
+    def test_build_type_defaults_to_debug(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            m = MockChromium(Path(tmp))
+            yaml_config = {
+                "build": {"chromium_src": str(m.src), "architecture": "x64"}
+            }
+            contexts = resolve_config(cli_args={}, yaml_config=yaml_config)
+            self.assertEqual(contexts[0].build_type, "debug")
+
+
+class ResolveConfigDirectModeTest(unittest.TestCase):
+    def test_missing_chromium_src_everywhere_raises(self):
+        env = {k: v for k, v in os.environ.items() if k not in ("CHROMIUM_SRC", "ARCH")}
+        with mock.patch.dict(os.environ, env, clear=True):
+            with self.assertRaises(ValueError) as err:
+                resolve_config(cli_args={}, yaml_config=None)
+        self.assertIn("chromium_src required", str(err.exception))
+
+    def test_cli_chromium_src_and_arch_resolve(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            m = MockChromium(Path(tmp))
+            cli_args = {
+                "chromium_src": str(m.src),
+                "arch": "arm64",
+                "build_type": "release",
+            }
+            contexts = resolve_config(cli_args=cli_args, yaml_config=None)
+            self.assertEqual(len(contexts), 1)
+            self.assertEqual(contexts[0].chromium_src, m.src)
+            self.assertEqual(contexts[0].architecture, "arm64")
+            self.assertEqual(contexts[0].build_type, "release")
+
+    def test_env_chromium_src_used_when_no_cli(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            m = MockChromium(Path(tmp))
+            with mock.patch.dict(
+                os.environ, {"CHROMIUM_SRC": str(m.src), "ARCH": "x64"}
+            ):
+                contexts = resolve_config(cli_args={}, yaml_config=None)
+            self.assertEqual(contexts[0].chromium_src, m.src)
+            self.assertEqual(contexts[0].architecture, "x64")
+            self.assertEqual(contexts[0].build_type, "debug")
+
+    def test_invalid_arch_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            m = MockChromium(Path(tmp))
+            cli_args = {"chromium_src": str(m.src), "arch": "sparc"}
+            with self.assertRaises(ValueError) as err:
+                resolve_config(cli_args=cli_args, yaml_config=None)
+            self.assertIn("invalid architecture", str(err.exception))
+
+
+class ResolvePipelineTest(unittest.TestCase):
+    def test_config_mode_requires_modules(self):
+        with self.assertRaises(ValueError) as err:
+            resolve_pipeline(cli_args={}, yaml_config={"build": {}})
+        self.assertIn("modules required", str(err.exception))
+
+    def test_config_mode_returns_yaml_modules(self):
+        yaml_config = {"modules": ["clean", "configure", "compile"]}
+        pipeline = resolve_pipeline(cli_args={}, yaml_config=yaml_config)
+        self.assertEqual(pipeline, ["clean", "configure", "compile"])
+
+    def test_direct_mode_requires_modules_or_flags(self):
+        with self.assertRaises(ValueError) as err:
+            resolve_pipeline(cli_args={}, yaml_config=None)
+        self.assertIn("No pipeline specified", str(err.exception))
+
+    def test_direct_mode_rejects_modules_and_flags_together(self):
+        cli_args = {"modules": "clean", "build": True}
+        with self.assertRaises(ValueError) as err:
+            resolve_pipeline(cli_args=cli_args, yaml_config=None)
+        self.assertIn("Cannot use both", str(err.exception))
+
+    def test_direct_mode_parses_modules_string(self):
+        pipeline = resolve_pipeline(
+            cli_args={"modules": "clean, compile ,sign_macos"}, yaml_config=None
+        )
+        self.assertEqual(pipeline, ["clean", "compile", "sign_macos"])
+
+    def test_direct_mode_expands_phase_flags_in_execution_order(self):
+        execution_order = [
+            ("setup", ["clean", "git_setup"]),
+            ("prep", ["patches"]),
+            ("build", ["configure", "compile"]),
+        ]
+        cli_args = {"setup": True, "build": True}
+        pipeline = resolve_pipeline(
+            cli_args=cli_args, yaml_config=None, execution_order=execution_order
+        )
+        self.assertEqual(pipeline, ["clean", "git_setup", "configure", "compile"])
+
+    def test_direct_mode_phase_flags_require_execution_order(self):
+        with self.assertRaises(ValueError) as err:
+            resolve_pipeline(cli_args={"setup": True}, yaml_config=None)
+        self.assertIn("execution_order required", str(err.exception))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/common/testing.py
+++ b/packages/browseros/build/common/testing.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+"""Test fixtures that fake the two directory trees the build system operates on.
+
+MockChromium builds a minimal gclient checkout (the multi-GB tree at e.g.
+~/code/chromium-1, reduced to the marker files build modules actually touch),
+and MockBrowserOSRoot builds a minimal packages/browseros root. Tests compose
+the pieces they need instead of depending on a real Chromium checkout.
+
+Only for use from *_test.py files.
+"""
+
+import subprocess
+from pathlib import Path
+from typing import Dict, Optional
+
+import yaml
+
+from .context import Context
+
+DEFAULT_CHROMIUM_VERSION = "137.0.7151.69"
+DEFAULT_BUILD_OFFSET = "80"
+
+# Realistic-enough sample for branding string replacement tests: contains the
+# brand terms string_replaces.py rewrites and the "Google Play" exception it
+# must preserve.
+_BRANDING_SAMPLE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Copyright 2024 The Chromium Authors. All rights reserved. -->
+<grit>
+  <message name="IDS_PRODUCT_NAME">Google Chrome</message>
+  <message name="IDS_SHORT_NAME">Chromium</message>
+  <message name="IDS_PLAY">Get it on Google Play</message>
+</grit>
+"""
+
+
+def _write_version_file(path: Path, version: str, prefix: str = "") -> None:
+    """Write a chromium-style KEY=VALUE version file from 'MAJOR.MINOR.BUILD.PATCH'."""
+    major, minor, build, patch = version.split(".")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        f"{prefix}MAJOR={major}\n"
+        f"{prefix}MINOR={minor}\n"
+        f"{prefix}BUILD={build}\n"
+        f"{prefix}PATCH={patch}\n"
+    )
+
+
+class MockChromium:
+    """Minimal fake of a Chromium gclient checkout.
+
+    The constructor writes only the cheap baseline markers (.gclient, the
+    src/ dir with chrome/VERSION and BUILD.gn); everything else is opt-in so
+    each test pays for exactly the tree it needs.
+    """
+
+    def __init__(self, root: Path, chromium_version: str = DEFAULT_CHROMIUM_VERSION):
+        self.root = root
+        self.chromium_version = chromium_version
+        self.src = root / "src"
+
+        self.src.mkdir(parents=True, exist_ok=True)
+        (root / ".gclient").write_text(
+            'solutions = [\n'
+            '  {\n'
+            '    "name": "src",\n'
+            '    "url": "https://chromium.googlesource.com/chromium/src.git",\n'
+            '    "managed": False,\n'
+            '    "custom_deps": {},\n'
+            '    "custom_vars": {},\n'
+            '  },\n'
+            ']\n'
+        )
+        _write_version_file(self.src / "chrome" / "VERSION", chromium_version)
+        (self.src / "BUILD.gn").write_text("# mock chromium root build file\n")
+
+    def add_file(self, relative_path: str, content: str = "") -> Path:
+        """Create a file under src/ (parents included) and return its path."""
+        path = self.src / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        return path
+
+    def with_out_dir(self, arch: str, args_gn: Optional[str] = None) -> Path:
+        """Create out/Default_{arch}/, optionally with an args.gn file."""
+        out_dir = self.src / "out" / f"Default_{arch}"
+        out_dir.mkdir(parents=True, exist_ok=True)
+        if args_gn is not None:
+            (out_dir / "args.gn").write_text(args_gn)
+        return out_dir
+
+    def with_branding_files(self) -> None:
+        """Create the two grd/grdp files string_replaces.py rewrites."""
+        self.add_file("chrome/app/chromium_strings.grd", _BRANDING_SAMPLE)
+        self.add_file("chrome/app/settings_chromium_strings.grdp", _BRANDING_SAMPLE)
+
+    def with_sparkle(self) -> Path:
+        """Create the third_party/sparkle directory marker."""
+        sparkle = self.src / "third_party" / "sparkle"
+        sparkle.mkdir(parents=True, exist_ok=True)
+        return sparkle
+
+    def with_pkg_dmg(self) -> Path:
+        """Create the chrome/installer/mac/pkg-dmg tool marker."""
+        return self.add_file("chrome/installer/mac/pkg-dmg", "#!/bin/sh\n")
+
+    def with_git(self) -> "MockChromium":
+        """Turn src/ into a real git repo with an initial commit.
+
+        Identity and signing are configured repo-locally so commits succeed
+        regardless of the machine's global git config.
+        """
+        self._git("init", "-q", "-b", "main")
+        self._git("config", "user.email", "tests@browseros.invalid")
+        self._git("config", "user.name", "BrowserOS Build Tests")
+        self._git("config", "commit.gpgsign", "false")
+        self.commit_all("initial mock checkout")
+        return self
+
+    def commit_all(self, message: str, allow_empty: bool = False) -> str:
+        """Stage everything, commit, and return the commit hash."""
+        self._git("add", "-A")
+        commit_cmd = ["commit", "-q", "-m", message]
+        if allow_empty:
+            commit_cmd.append("--allow-empty")
+        self._git(*commit_cmd)
+        return self._git("rev-parse", "HEAD").stdout.strip()
+
+    def _git(self, *args: str) -> subprocess.CompletedProcess:
+        result = subprocess.run(
+            ["git", *args], cwd=self.src, capture_output=True, text=True
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"git {' '.join(args)} failed in mock checkout: {result.stderr}"
+            )
+        return result
+
+
+class MockBrowserOSRoot:
+    """Minimal fake of the packages/browseros root (ctx.root_dir).
+
+    The constructor writes the version files Context.__post_init__ reads;
+    patches, replacement files, and config files are opt-in.
+    """
+
+    def __init__(
+        self,
+        root: Path,
+        chromium_version: str = DEFAULT_CHROMIUM_VERSION,
+        build_offset: str = DEFAULT_BUILD_OFFSET,
+        browseros_version: str = "0.31.0.0",
+    ):
+        self.root = root
+        root.mkdir(parents=True, exist_ok=True)
+
+        _write_version_file(root / "CHROMIUM_VERSION", chromium_version)
+
+        offset_file = root / "build" / "config" / "BROWSEROS_BUILD_OFFSET"
+        offset_file.parent.mkdir(parents=True, exist_ok=True)
+        offset_file.write_text(f"{build_offset}\n")
+
+        _write_version_file(
+            root / "resources" / "BROWSEROS_VERSION",
+            browseros_version,
+            prefix="BROWSEROS_",
+        )
+
+    def add_patch(self, relative_path: str, content: str) -> Path:
+        """Create a patch file under chromium_patches/ and return its path."""
+        path = self.root / "chromium_patches" / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        return path
+
+    def add_replacement_file(self, relative_path: str, content: str) -> Path:
+        """Create a replacement file under chromium_files/ and return its path."""
+        path = self.root / "chromium_files" / relative_path
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        return path
+
+    def write_features_yaml(self, features: Dict) -> Path:
+        """Write build/features.yaml wrapping the given features mapping."""
+        path = self.root / "build" / "features.yaml"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            yaml.safe_dump(
+                {"version": "1.0", "features": features},
+                f,
+                sort_keys=False,
+                default_flow_style=False,
+            )
+        return path
+
+    def write_copy_config(self, config: Dict) -> Path:
+        """Write build/config/copy_resources.yaml with the given mapping."""
+        path = self.root / "build" / "config" / "copy_resources.yaml"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        with open(path, "w") as f:
+            yaml.safe_dump(config, f, sort_keys=False, default_flow_style=False)
+        return path
+
+    def write_gn_flags(self, platform: str, build_type: str, content: str) -> Path:
+        """Write build/config/gn/flags.{platform}.{build_type}.gn."""
+        path = self.root / "build" / "config" / "gn" / f"flags.{platform}.{build_type}.gn"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content)
+        return path
+
+
+def make_context(
+    chromium: MockChromium,
+    root: MockBrowserOSRoot,
+    architecture: str = "x64",
+    build_type: str = "release",
+) -> Context:
+    """Build a real Context wired to the mock trees.
+
+    Returns an actual Context (not a stub), so version loading and path
+    derivation in __post_init__ run against the mock files.
+    """
+    return Context(
+        root_dir=root.root,
+        chromium_src=chromium.src,
+        architecture=architecture,
+        build_type=build_type,
+    )

--- a/packages/browseros/build/common/testing.py
+++ b/packages/browseros/build/common/testing.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Test fixtures that fake the two directory trees the build system operates on.
 
-MockChromium builds a minimal gclient checkout (the multi-GB tree at e.g.
-~/code/chromium-1, reduced to the marker files build modules actually touch),
-and MockBrowserOSRoot builds a minimal packages/browseros root. Tests compose
+MockChromium builds a minimal gclient checkout (a real one is multi-GB; this
+keeps only the marker files build modules actually touch), and
+MockBrowserOSRoot builds a minimal packages/browseros root. Tests compose
 the pieces they need instead of depending on a real Chromium checkout.
 
 Only for use from *_test.py files.

--- a/packages/browseros/build/common/testing_test.py
+++ b/packages/browseros/build/common/testing_test.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Tests for the mock chromium checkout fixture."""
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from .testing import MockBrowserOSRoot, MockChromium, make_context
+
+
+class MockChromiumTest(unittest.TestCase):
+    def test_baseline_markers_created(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            m = MockChromium(Path(tmp))
+
+            gclient = Path(tmp) / ".gclient"
+            self.assertTrue(gclient.exists())
+            self.assertIn("solutions", gclient.read_text())
+            self.assertIn('"src"', gclient.read_text())
+
+            version_file = m.src / "chrome" / "VERSION"
+            self.assertTrue(version_file.exists())
+            version = dict(
+                line.split("=") for line in version_file.read_text().strip().split("\n")
+            )
+            self.assertEqual(version["MAJOR"], "137")
+            self.assertEqual(version["MINOR"], "0")
+            self.assertEqual(version["BUILD"], "7151")
+            self.assertEqual(version["PATCH"], "69")
+
+            self.assertTrue((m.src / "BUILD.gn").exists())
+
+    def test_src_is_under_gclient_root(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            m = MockChromium(Path(tmp))
+            self.assertEqual(m.src, Path(tmp) / "src")
+            self.assertEqual(m.src.parent / ".gclient", Path(tmp) / ".gclient")
+
+    def test_add_file_creates_parents_and_content(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            m = MockChromium(Path(tmp))
+            written = m.add_file("chrome/browser/foo/bar.cc", "int x = 1;\n")
+            self.assertEqual(written, m.src / "chrome" / "browser" / "foo" / "bar.cc")
+            self.assertEqual(written.read_text(), "int x = 1;\n")
+
+    def test_with_out_dir_creates_arch_dir_and_args_gn(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            m = MockChromium(Path(tmp))
+            out = m.with_out_dir("arm64", args_gn='is_debug = false\n')
+            self.assertEqual(out, m.src / "out" / "Default_arm64")
+            self.assertTrue(out.is_dir())
+            self.assertEqual((out / "args.gn").read_text(), "is_debug = false\n")
+
+    def test_with_out_dir_without_args_gn(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            m = MockChromium(Path(tmp))
+            out = m.with_out_dir("x64")
+            self.assertTrue(out.is_dir())
+            self.assertFalse((out / "args.gn").exists())
+
+    def test_with_git_creates_repo_with_initial_commit(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            m = MockChromium(Path(tmp)).with_git()
+            self.assertTrue((m.src / ".git").is_dir())
+            head = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=m.src,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(head.returncode, 0, head.stderr)
+            self.assertEqual(len(head.stdout.strip()), 40)
+
+    def test_commit_all_returns_hash_listing_added_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            m = MockChromium(Path(tmp)).with_git()
+            m.add_file("chrome/new_file.txt", "hello\n")
+            commit = m.commit_all("add new file")
+            self.assertEqual(len(commit), 40)
+
+            shown = subprocess.run(
+                ["git", "diff-tree", "--no-commit-id", "--name-only", "-r", commit],
+                cwd=m.src,
+                capture_output=True,
+                text=True,
+            )
+            self.assertIn("chrome/new_file.txt", shown.stdout)
+
+    def test_commit_all_allow_empty(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            m = MockChromium(Path(tmp)).with_git()
+            commit = m.commit_all("empty", allow_empty=True)
+            self.assertEqual(len(commit), 40)
+
+    def test_with_sparkle_and_pkg_dmg_markers(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            m = MockChromium(Path(tmp))
+            sparkle = m.with_sparkle()
+            pkg_dmg = m.with_pkg_dmg()
+            self.assertEqual(sparkle, m.src / "third_party" / "sparkle")
+            self.assertTrue(sparkle.is_dir())
+            self.assertEqual(
+                pkg_dmg, m.src / "chrome" / "installer" / "mac" / "pkg-dmg"
+            )
+            self.assertTrue(pkg_dmg.is_file())
+
+    def test_with_branding_files_contains_replaceable_strings(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            m = MockChromium(Path(tmp))
+            m.with_branding_files()
+            grd = m.src / "chrome" / "app" / "chromium_strings.grd"
+            grdp = m.src / "chrome" / "app" / "settings_chromium_strings.grdp"
+            self.assertTrue(grd.exists())
+            self.assertTrue(grdp.exists())
+            self.assertIn("Google Chrome", grd.read_text())
+            self.assertIn("Chromium", grd.read_text())
+
+
+class MockBrowserOSRootTest(unittest.TestCase):
+    def test_version_files_written(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            r = MockBrowserOSRoot(Path(tmp))
+            self.assertIn("MAJOR=137", (r.root / "CHROMIUM_VERSION").read_text())
+            self.assertEqual(
+                (r.root / "build" / "config" / "BROWSEROS_BUILD_OFFSET")
+                .read_text()
+                .strip(),
+                "80",
+            )
+            browseros_version = (
+                r.root / "resources" / "BROWSEROS_VERSION"
+            ).read_text()
+            self.assertIn("BROWSEROS_MAJOR=0", browseros_version)
+            self.assertIn("BROWSEROS_MINOR=31", browseros_version)
+
+    def test_add_patch_and_replacement_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            r = MockBrowserOSRoot(Path(tmp))
+            patch = r.add_patch("chrome/foo.cc.patch", "--- a/x\n")
+            repl = r.add_replacement_file("chrome/bar.h", "// custom\n")
+            self.assertEqual(patch, r.root / "chromium_patches" / "chrome" / "foo.cc.patch")
+            self.assertEqual(patch.read_text(), "--- a/x\n")
+            self.assertEqual(repl, r.root / "chromium_files" / "chrome" / "bar.h")
+            self.assertEqual(repl.read_text(), "// custom\n")
+
+    def test_write_features_yaml_roundtrip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            r = MockBrowserOSRoot(Path(tmp))
+            features = {
+                "llm-chat": {
+                    "description": "feat: LLM chat",
+                    "files": ["chrome/a.cc"],
+                }
+            }
+            path = r.write_features_yaml(features)
+            self.assertEqual(path, r.root / "build" / "features.yaml")
+            loaded = yaml.safe_load(path.read_text())
+            self.assertEqual(loaded["features"], features)
+
+    def test_write_copy_config_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            r = MockBrowserOSRoot(Path(tmp))
+            path = r.write_copy_config({"copy_operations": []})
+            self.assertEqual(path, r.root / "build" / "config" / "copy_resources.yaml")
+            self.assertEqual(yaml.safe_load(path.read_text()), {"copy_operations": []})
+
+    def test_write_gn_flags_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            r = MockBrowserOSRoot(Path(tmp))
+            path = r.write_gn_flags("macos", "release", "is_debug = false\n")
+            self.assertEqual(
+                path,
+                r.root / "build" / "config" / "gn" / "flags.macos.release.gn",
+            )
+            self.assertEqual(path.read_text(), "is_debug = false\n")
+
+
+class MakeContextTest(unittest.TestCase):
+    def test_context_loads_versions_from_mocks(self):
+        with (
+            tempfile.TemporaryDirectory() as chromium_tmp,
+            tempfile.TemporaryDirectory() as root_tmp,
+        ):
+            m = MockChromium(Path(chromium_tmp))
+            r = MockBrowserOSRoot(Path(root_tmp))
+            ctx = make_context(m, r, architecture="x64", build_type="release")
+
+            self.assertEqual(ctx.chromium_src, m.src)
+            self.assertEqual(ctx.root_dir, r.root)
+            self.assertEqual(ctx.architecture, "x64")
+            self.assertEqual(ctx.build_type, "release")
+            self.assertEqual(ctx.chromium_version, "137.0.7151.69")
+            # BUILD 7151 + offset 80 = 7231
+            self.assertEqual(ctx.browseros_chromium_version, "137.0.7231.69")
+            self.assertEqual(ctx.semantic_version, "0.31.0")
+            self.assertEqual(
+                ctx.get_features_yaml_path(), r.root / "build" / "features.yaml"
+            )
+            self.assertEqual(
+                ctx.get_patches_dir(), r.root / "chromium_patches"
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/modules/annotate/annotate_test.py
+++ b/packages/browseros/build/modules/annotate/annotate_test.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""Tests for feature-based commit annotation against a mock git checkout."""
+
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from .annotate import (
+    _is_git_index_lock_error,
+    annotate_features,
+    get_modified_files,
+    git_add_and_commit,
+    load_features,
+)
+from ...common.testing import MockBrowserOSRoot, MockChromium, make_context
+
+
+class IsGitIndexLockErrorTest(unittest.TestCase):
+    def test_detects_lock_error(self):
+        stderr = (
+            "fatal: Unable to create '/repo/.git/index.lock': File exists.\n"
+            "Another git process seems to be running"
+        )
+        self.assertTrue(_is_git_index_lock_error(stderr))
+
+    def test_is_case_insensitive(self):
+        self.assertTrue(
+            _is_git_index_lock_error("INDEX.LOCK trouble: FILE EXISTS")
+        )
+
+    def test_other_errors_not_detected(self):
+        self.assertFalse(_is_git_index_lock_error("fatal: not a git repository"))
+        self.assertFalse(_is_git_index_lock_error(""))
+        self.assertFalse(_is_git_index_lock_error(None))
+
+
+class LoadFeaturesTest(unittest.TestCase):
+    def test_missing_file_returns_empty(self):
+        self.assertEqual(load_features(Path("/nonexistent/features.yaml")), {})
+
+    def test_loads_features_mapping(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = MockBrowserOSRoot(Path(tmp))
+            path = root.write_features_yaml(
+                {"llm-chat": {"description": "feat: chat", "files": ["a.cc"]}}
+            )
+            features = load_features(path)
+            self.assertEqual(features["llm-chat"]["files"], ["a.cc"])
+
+
+class GetModifiedFilesTest(unittest.TestCase):
+    def test_detects_modified_and_untracked_only(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            chromium = MockChromium(Path(tmp))
+            chromium.add_file("chrome/dirty.cc", "v1")
+            chromium.add_file("chrome/clean.cc", "v1")
+            chromium.with_git()
+
+            chromium.add_file("chrome/dirty.cc", "v2")
+            chromium.add_file("chrome/untracked.cc", "new")
+
+            modified = get_modified_files(
+                chromium.src,
+                [
+                    "chrome/dirty.cc",
+                    "chrome/clean.cc",
+                    "chrome/untracked.cc",
+                    "chrome/nonexistent.cc",
+                ],
+            )
+
+            self.assertEqual(
+                modified, ["chrome/dirty.cc", "chrome/untracked.cc"]
+            )
+
+
+class GitAddAndCommitTest(unittest.TestCase):
+    def test_commits_listed_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            chromium = MockChromium(Path(tmp))
+            chromium.add_file("chrome/dirty.cc", "v1")
+            chromium.with_git()
+            chromium.add_file("chrome/dirty.cc", "v2")
+
+            self.assertTrue(
+                git_add_and_commit(chromium.src, ["chrome/dirty.cc"], "feat: dirty")
+            )
+
+            subject = subprocess.run(
+                ["git", "log", "-1", "--format=%s"],
+                cwd=chromium.src,
+                capture_output=True,
+                text=True,
+            ).stdout.strip()
+            self.assertEqual(subject, "feat: dirty")
+
+    def test_clean_tree_returns_false(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            chromium = MockChromium(Path(tmp))
+            chromium.add_file("chrome/clean.cc", "v1")
+            chromium.with_git()
+
+            self.assertFalse(
+                git_add_and_commit(chromium.src, ["chrome/clean.cc"], "feat: noop")
+            )
+
+
+class AnnotateFeaturesTest(unittest.TestCase):
+    def setUp(self):
+        self._chromium_tmp = tempfile.TemporaryDirectory()
+        self._root_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._chromium_tmp.cleanup)
+        self.addCleanup(self._root_tmp.cleanup)
+        self.chromium = MockChromium(Path(self._chromium_tmp.name))
+        self.chromium.add_file("chrome/feature_a.cc", "v1")
+        self.chromium.add_file("chrome/feature_b.cc", "v1")
+        self.chromium.with_git()
+        self.root = MockBrowserOSRoot(Path(self._root_tmp.name))
+        self.ctx = make_context(self.chromium, self.root)
+
+    def _last_commit_subject(self) -> str:
+        return subprocess.run(
+            ["git", "log", "-1", "--format=%s"],
+            cwd=self.chromium.src,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+
+    def test_missing_features_yaml_returns_zero(self):
+        self.assertEqual(annotate_features(self.ctx), (0, 0))
+
+    def test_commits_feature_with_modified_files(self):
+        self.chromium.add_file("chrome/feature_a.cc", "v2")
+        self.root.write_features_yaml(
+            {
+                "feature-a": {
+                    "description": "feat: feature A",
+                    "files": ["chrome/feature_a.cc"],
+                }
+            }
+        )
+
+        commits, skipped = annotate_features(self.ctx)
+
+        self.assertEqual((commits, skipped), (1, 0))
+        self.assertEqual(self._last_commit_subject(), "feat: feature A")
+
+    def test_clean_feature_is_skipped(self):
+        self.root.write_features_yaml(
+            {
+                "feature-b": {
+                    "description": "feat: feature B",
+                    "files": ["chrome/feature_b.cc"],
+                }
+            }
+        )
+
+        self.assertEqual(annotate_features(self.ctx), (0, 1))
+
+    def test_feature_without_files_is_skipped(self):
+        self.root.write_features_yaml(
+            {"empty-feature": {"description": "feat: empty", "files": []}}
+        )
+
+        self.assertEqual(annotate_features(self.ctx), (0, 1))
+
+    def test_unknown_feature_filter_returns_zero(self):
+        self.root.write_features_yaml(
+            {
+                "feature-a": {
+                    "description": "feat: feature A",
+                    "files": ["chrome/feature_a.cc"],
+                }
+            }
+        )
+
+        self.assertEqual(
+            annotate_features(self.ctx, feature_filter="nope"), (0, 0)
+        )
+
+    def test_feature_filter_limits_to_one_feature(self):
+        self.chromium.add_file("chrome/feature_a.cc", "v2")
+        self.chromium.add_file("chrome/feature_b.cc", "v2")
+        self.root.write_features_yaml(
+            {
+                "feature-a": {
+                    "description": "feat: feature A",
+                    "files": ["chrome/feature_a.cc"],
+                },
+                "feature-b": {
+                    "description": "feat: feature B",
+                    "files": ["chrome/feature_b.cc"],
+                },
+            }
+        )
+
+        commits, skipped = annotate_features(self.ctx, feature_filter="feature-a")
+
+        self.assertEqual((commits, skipped), (1, 0))
+        self.assertEqual(self._last_commit_subject(), "feat: feature A")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/modules/annotate/annotate_test.py
+++ b/packages/browseros/build/modules/annotate/annotate_test.py
@@ -5,6 +5,7 @@ import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from typing import cast
 
 from .annotate import (
     _is_git_index_lock_error,
@@ -32,7 +33,9 @@ class IsGitIndexLockErrorTest(unittest.TestCase):
     def test_other_errors_not_detected(self):
         self.assertFalse(_is_git_index_lock_error("fatal: not a git repository"))
         self.assertFalse(_is_git_index_lock_error(""))
-        self.assertFalse(_is_git_index_lock_error(None))
+        # CompletedProcess.stderr can be None when output isn't captured;
+        # the guard must tolerate it even though the annotation says str.
+        self.assertFalse(_is_git_index_lock_error(cast(str, None)))
 
 
 class LoadFeaturesTest(unittest.TestCase):

--- a/packages/browseros/build/modules/apply/apply_all_test.py
+++ b/packages/browseros/build/modules/apply/apply_all_test.py
@@ -53,7 +53,7 @@ class ApplyAllPatchesTest(unittest.TestCase):
         applied, failed = apply_all_patches(self.ctx)
 
         self.assertEqual(applied, 1)
-        self.assertEqual([str(f) for f in failed], ["chrome/broken.txt.patch"])
+        self.assertEqual(failed, [Path("chrome/broken.txt.patch")])
 
     def test_dry_run_does_not_modify_files(self):
         self.chromium.add_file("chrome/feature.txt", ORIGINAL)

--- a/packages/browseros/build/modules/apply/apply_all_test.py
+++ b/packages/browseros/build/modules/apply/apply_all_test.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Tests for apply_all_patches against a mock checkout and patches dir."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from .apply_all import apply_all_patches
+from .common_test import BAD_PATCH, GOOD_PATCH, NEW_FILE_PATCH, ORIGINAL, PATCHED
+from ...common.testing import MockBrowserOSRoot, MockChromium, make_context
+
+
+class ApplyAllPatchesTest(unittest.TestCase):
+    def setUp(self):
+        self._chromium_tmp = tempfile.TemporaryDirectory()
+        self._root_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._chromium_tmp.cleanup)
+        self.addCleanup(self._root_tmp.cleanup)
+        self.chromium = MockChromium(Path(self._chromium_tmp.name))
+        self.root = MockBrowserOSRoot(Path(self._root_tmp.name))
+        self.ctx = make_context(self.chromium, self.root)
+
+    def test_missing_patches_dir_returns_zero(self):
+        self.assertEqual(apply_all_patches(self.ctx), (0, []))
+
+    def test_empty_patches_dir_returns_zero(self):
+        (self.root.root / "chromium_patches").mkdir()
+        self.assertEqual(apply_all_patches(self.ctx), (0, []))
+
+    def test_applies_nested_patches(self):
+        self.chromium.add_file("chrome/feature.txt", ORIGINAL)
+        self.chromium.with_git()
+        self.root.add_patch("chrome/feature.txt.patch", GOOD_PATCH)
+        self.root.add_patch("chrome/sub/created.txt.patch", NEW_FILE_PATCH)
+
+        applied, failed = apply_all_patches(self.ctx)
+
+        self.assertEqual(applied, 2)
+        self.assertEqual(failed, [])
+        self.assertEqual(
+            (self.chromium.src / "chrome" / "feature.txt").read_text(), PATCHED
+        )
+        self.assertEqual(
+            (self.chromium.src / "chrome" / "created.txt").read_text(), "created\n"
+        )
+
+    def test_failed_patch_is_reported_and_others_still_apply(self):
+        self.chromium.add_file("chrome/feature.txt", ORIGINAL)
+        self.chromium.with_git()
+        self.root.add_patch("chrome/feature.txt.patch", GOOD_PATCH)
+        self.root.add_patch("chrome/broken.txt.patch", BAD_PATCH)
+
+        applied, failed = apply_all_patches(self.ctx)
+
+        self.assertEqual(applied, 1)
+        self.assertEqual([str(f) for f in failed], ["chrome/broken.txt.patch"])
+
+    def test_dry_run_does_not_modify_files(self):
+        self.chromium.add_file("chrome/feature.txt", ORIGINAL)
+        self.chromium.with_git()
+        self.root.add_patch("chrome/feature.txt.patch", GOOD_PATCH)
+
+        applied, failed = apply_all_patches(self.ctx, dry_run=True)
+
+        self.assertEqual(applied, 1)
+        self.assertEqual(failed, [])
+        self.assertEqual(
+            (self.chromium.src / "chrome" / "feature.txt").read_text(), ORIGINAL
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/modules/apply/common_test.py
+++ b/packages/browseros/build/modules/apply/common_test.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Tests for core patch application logic against a mock git checkout."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from .common import apply_single_patch, find_patch_files, process_patch_list
+from ...common.testing import MockChromium
+
+ORIGINAL = "line one\nline two\nline three\n"
+
+GOOD_PATCH = """\
+--- a/chrome/feature.txt
++++ b/chrome/feature.txt
+@@ -1,3 +1,3 @@
+ line one
+-line two
++line 2!
+ line three
+"""
+
+PATCHED = "line one\nline 2!\nline three\n"
+
+# Context lines that don't exist in the target file, so application fails.
+BAD_PATCH = """\
+--- a/chrome/feature.txt
++++ b/chrome/feature.txt
+@@ -1,3 +1,3 @@
+ alpha
+-beta
++gamma
+ delta
+"""
+
+NEW_FILE_PATCH = """\
+--- /dev/null
++++ b/chrome/created.txt
+@@ -0,0 +1 @@
++created
+"""
+
+
+class FindPatchFilesTest(unittest.TestCase):
+    def test_missing_dir_returns_empty(self):
+        self.assertEqual(find_patch_files(Path("/nonexistent/patches")), [])
+
+    def test_filters_markers_and_dotfiles_and_sorts(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            patches = Path(tmp)
+            (patches / "sub").mkdir()
+            (patches / "b.patch").write_text("x")
+            (patches / "sub" / "a.patch").write_text("x")
+            (patches / "gone.patch.deleted").write_text("x")
+            (patches / "image.patch.binary").write_text("x")
+            (patches / "moved.patch.rename").write_text("x")
+            (patches / ".hidden").write_text("x")
+
+            found = find_patch_files(patches)
+
+            self.assertEqual(
+                found, [patches / "b.patch", patches / "sub" / "a.patch"]
+            )
+
+
+class ApplySinglePatchTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.chromium = MockChromium(Path(self._tmp.name))
+        self.chromium.add_file("chrome/feature.txt", ORIGINAL)
+        self.chromium.with_git()
+
+    def _write_patch(self, content: str) -> Path:
+        patch = Path(self._tmp.name) / "test.patch"
+        patch.write_text(content)
+        return patch
+
+    def test_good_patch_applies_and_modifies_file(self):
+        patch = self._write_patch(GOOD_PATCH)
+
+        success, error = apply_single_patch(patch, self.chromium.src)
+
+        self.assertTrue(success)
+        self.assertIsNone(error)
+        self.assertEqual(
+            (self.chromium.src / "chrome" / "feature.txt").read_text(), PATCHED
+        )
+
+    def test_bad_patch_fails_and_leaves_file_unchanged(self):
+        patch = self._write_patch(BAD_PATCH)
+
+        success, error = apply_single_patch(patch, self.chromium.src)
+
+        self.assertFalse(success)
+        self.assertTrue(error)
+        self.assertEqual(
+            (self.chromium.src / "chrome" / "feature.txt").read_text(), ORIGINAL
+        )
+
+    def test_dry_run_checks_without_modifying(self):
+        patch = self._write_patch(GOOD_PATCH)
+
+        success, error = apply_single_patch(patch, self.chromium.src, dry_run=True)
+
+        self.assertTrue(success)
+        self.assertIsNone(error)
+        self.assertEqual(
+            (self.chromium.src / "chrome" / "feature.txt").read_text(), ORIGINAL
+        )
+
+    def test_dry_run_reports_failing_patch(self):
+        patch = self._write_patch(BAD_PATCH)
+
+        success, _ = apply_single_patch(patch, self.chromium.src, dry_run=True)
+
+        self.assertFalse(success)
+
+    def test_patch_can_create_new_file(self):
+        patch = self._write_patch(NEW_FILE_PATCH)
+
+        success, _ = apply_single_patch(patch, self.chromium.src)
+
+        self.assertTrue(success)
+        self.assertEqual(
+            (self.chromium.src / "chrome" / "created.txt").read_text(), "created\n"
+        )
+
+
+class ProcessPatchListTest(unittest.TestCase):
+    def test_counts_applied_and_failed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            chromium = MockChromium(Path(tmp))
+            chromium.add_file("chrome/feature.txt", ORIGINAL)
+            chromium.with_git()
+
+            patches_dir = Path(tmp) / "patches"
+            patches_dir.mkdir()
+            good = patches_dir / "good.patch"
+            good.write_text(GOOD_PATCH)
+            missing = patches_dir / "missing.patch"
+
+            applied, failed = process_patch_list(
+                [(good, "good.patch"), (missing, "missing.patch")],
+                chromium.src,
+                patches_dir,
+            )
+
+            self.assertEqual(applied, 1)
+            self.assertEqual(failed, ["missing.patch"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/modules/feature/feature_test.py
+++ b/packages/browseros/build/modules/feature/feature_test.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Tests for feature-to-file mapping against a mock git checkout."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+import yaml
+
+from .feature import add_or_update_feature
+from ...common.testing import MockBrowserOSRoot, MockChromium, make_context
+
+
+class AddOrUpdateFeatureTest(unittest.TestCase):
+    def setUp(self):
+        self._chromium_tmp = tempfile.TemporaryDirectory()
+        self._root_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._chromium_tmp.cleanup)
+        self.addCleanup(self._root_tmp.cleanup)
+        self.chromium = MockChromium(Path(self._chromium_tmp.name)).with_git()
+        self.root = MockBrowserOSRoot(Path(self._root_tmp.name))
+        self.ctx = make_context(self.chromium, self.root)
+
+    def _load_features(self) -> dict:
+        path = self.ctx.get_features_yaml_path()
+        return yaml.safe_load(path.read_text())["features"]
+
+    def test_invalid_name_rejected_without_writing(self):
+        success, error = add_or_update_feature(
+            self.ctx, "Bad Name", "HEAD", "feat: x"
+        )
+        self.assertFalse(success)
+        self.assertIn("spaces", error)
+        self.assertFalse(self.ctx.get_features_yaml_path().exists())
+
+    def test_invalid_description_rejected_without_writing(self):
+        success, error = add_or_update_feature(
+            self.ctx, "llm-chat", "HEAD", "adds chat"
+        )
+        self.assertFalse(success)
+        self.assertIn("must start with", error)
+        self.assertFalse(self.ctx.get_features_yaml_path().exists())
+
+    def test_commit_with_no_changes_rejected(self):
+        commit = self.chromium.commit_all("empty", allow_empty=True)
+        success, error = add_or_update_feature(
+            self.ctx, "llm-chat", commit, "feat: chat"
+        )
+        self.assertFalse(success)
+        self.assertIn("No changed files", error)
+
+    def test_creates_new_feature_with_sorted_files(self):
+        self.chromium.add_file("chrome/browser/b_second.cc", "b")
+        self.chromium.add_file("chrome/browser/a_first.cc", "a")
+        commit = self.chromium.commit_all("add chat files")
+
+        success, error = add_or_update_feature(
+            self.ctx, "llm-chat", commit, "feat: LLM chat"
+        )
+
+        self.assertTrue(success, error)
+        features = self._load_features()
+        self.assertEqual(
+            features["llm-chat"]["files"],
+            ["chrome/browser/a_first.cc", "chrome/browser/b_second.cc"],
+        )
+        self.assertEqual(features["llm-chat"]["description"], "feat: LLM chat")
+
+    def test_updates_existing_feature_by_merging_files(self):
+        self.chromium.add_file("chrome/browser/a_first.cc", "a")
+        first = self.chromium.commit_all("first")
+        add_or_update_feature(self.ctx, "llm-chat", first, "feat: LLM chat")
+
+        self.chromium.add_file("chrome/browser/a_first.cc", "a modified")
+        self.chromium.add_file("chrome/browser/c_third.cc", "c")
+        second = self.chromium.commit_all("second")
+
+        success, error = add_or_update_feature(
+            self.ctx, "llm-chat", second, "feat: LLM chat v2"
+        )
+
+        self.assertTrue(success, error)
+        features = self._load_features()
+        self.assertEqual(
+            features["llm-chat"]["files"],
+            ["chrome/browser/a_first.cc", "chrome/browser/c_third.cc"],
+        )
+        self.assertEqual(features["llm-chat"]["description"], "feat: LLM chat v2")
+
+    def test_other_features_preserved_on_update(self):
+        self.chromium.add_file("chrome/browser/a.cc", "a")
+        first = self.chromium.commit_all("first")
+        add_or_update_feature(self.ctx, "feature-one", first, "feat: one")
+
+        self.chromium.add_file("chrome/browser/b.cc", "b")
+        second = self.chromium.commit_all("second")
+        add_or_update_feature(self.ctx, "feature-two", second, "feat: two")
+
+        features = self._load_features()
+        self.assertEqual(features["feature-one"]["files"], ["chrome/browser/a.cc"])
+        self.assertEqual(features["feature-two"]["files"], ["chrome/browser/b.cc"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/modules/feature/validation_test.py
+++ b/packages/browseros/build/modules/feature/validation_test.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Tests for feature name and description validation."""
+
+import unittest
+
+from .validation import validate_description, validate_feature_name
+
+
+class ValidateFeatureNameTest(unittest.TestCase):
+    def test_accepts_kebab_and_snake_names(self):
+        for name in ("llm-chat", "a1_b", "feature2", "x"):
+            valid, error = validate_feature_name(name)
+            self.assertTrue(valid, f"{name!r} should be valid: {error}")
+            self.assertEqual(error, "")
+
+    def test_rejects_empty(self):
+        valid, error = validate_feature_name("")
+        self.assertFalse(valid)
+        self.assertIn("empty", error)
+
+    def test_rejects_spaces(self):
+        valid, error = validate_feature_name("llm chat")
+        self.assertFalse(valid)
+        self.assertIn("spaces", error)
+
+    def test_rejects_colon(self):
+        valid, error = validate_feature_name("feat:llm")
+        self.assertFalse(valid)
+        self.assertIn(":", error)
+
+    def test_rejects_uppercase(self):
+        valid, error = validate_feature_name("LLM-Chat")
+        self.assertFalse(valid)
+        self.assertIn("lowercase", error)
+
+    def test_rejects_leading_hyphen(self):
+        valid, _ = validate_feature_name("-leading")
+        self.assertFalse(valid)
+
+
+class ValidateDescriptionTest(unittest.TestCase):
+    def test_accepts_all_valid_prefixes(self):
+        for prefix in ("feat:", "fix:", "build:", "chore:", "series:"):
+            valid, error = validate_description(f"{prefix} something")
+            self.assertTrue(valid, f"{prefix} should be valid: {error}")
+
+    def test_rejects_empty(self):
+        valid, error = validate_description("   ")
+        self.assertFalse(valid)
+        self.assertIn("empty", error)
+
+    def test_rejects_missing_prefix(self):
+        valid, error = validate_description("adds LLM chat")
+        self.assertFalse(valid)
+        self.assertIn("must start with", error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/modules/patches/patches_test.py
+++ b/packages/browseros/build/modules/patches/patches_test.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Tests for the patches build module."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest import mock
+
+from . import patches
+from ..apply import apply_all
+from ...common.context import Context
+from ...common.module import ValidationError
+from ...common.testing import MockBrowserOSRoot, MockChromium, make_context
+
+
+class PatchesModuleValidateTest(unittest.TestCase):
+    def test_missing_git_raises_validation_error(self):
+        ctx = cast(Context, SimpleNamespace())
+        with mock.patch.object(patches.shutil, "which", return_value=None):
+            with self.assertRaises(ValidationError):
+                patches.PatchesModule().validate(ctx)
+
+    def test_missing_patches_dir_raises_validation_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = cast(
+                Context,
+                SimpleNamespace(get_patches_dir=lambda: Path(tmp) / "missing"),
+            )
+            with self.assertRaises(ValidationError):
+                patches.PatchesModule().validate(ctx)
+
+    def test_existing_patches_dir_passes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = cast(
+                Context, SimpleNamespace(get_patches_dir=lambda: Path(tmp))
+            )
+            patches.PatchesModule().validate(ctx)
+
+
+class ApplyPatchesImplTest(unittest.TestCase):
+    def _ctx(self) -> Context:
+        chromium_tmp = tempfile.TemporaryDirectory()
+        root_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(chromium_tmp.cleanup)
+        self.addCleanup(root_tmp.cleanup)
+        return make_context(
+            MockChromium(Path(chromium_tmp.name)),
+            MockBrowserOSRoot(Path(root_tmp.name)),
+        )
+
+    def test_failures_raise_runtime_error_in_non_interactive_mode(self):
+        ctx = self._ctx()
+        with mock.patch.object(
+            apply_all, "apply_all_patches", return_value=(1, ["broken.patch"])
+        ):
+            with self.assertRaises(RuntimeError) as err:
+                patches.apply_patches_impl(ctx, interactive=False)
+        self.assertIn("1 patches", str(err.exception))
+
+    def test_success_returns_true(self):
+        ctx = self._ctx()
+        with mock.patch.object(
+            apply_all, "apply_all_patches", return_value=(3, [])
+        ) as apply_mock:
+            self.assertTrue(patches.apply_patches_impl(ctx, interactive=False))
+        apply_mock.assert_called_once_with(
+            build_ctx=ctx, dry_run=False, interactive=False
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/modules/resources/chromium_replace_test.py
+++ b/packages/browseros/build/modules/resources/chromium_replace_test.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Tests for chromium file replacement against a mock checkout."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+from .chromium_replace import ChromiumReplaceModule, replace_chromium_files_impl
+from ...common.context import Context
+from ...common.module import ValidationError
+from ...common.testing import MockBrowserOSRoot, MockChromium, make_context
+
+
+class ReplaceChromiumFilesTest(unittest.TestCase):
+    def _make(self, build_type: str):
+        chromium_tmp = tempfile.TemporaryDirectory()
+        root_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(chromium_tmp.cleanup)
+        self.addCleanup(root_tmp.cleanup)
+        chromium = MockChromium(Path(chromium_tmp.name))
+        root = MockBrowserOSRoot(Path(root_tmp.name))
+        ctx = make_context(chromium, root, build_type=build_type)
+        return chromium, root, ctx
+
+    def test_missing_chromium_files_dir_is_noop(self):
+        _, _, ctx = self._make("release")
+        self.assertTrue(replace_chromium_files_impl(ctx))
+
+    def test_generic_file_replaces_existing_destination(self):
+        chromium, root, ctx = self._make("release")
+        chromium.add_file("chrome/common/branding.h", "// original\n")
+        root.add_replacement_file("chrome/common/branding.h", "// custom\n")
+
+        self.assertTrue(replace_chromium_files_impl(ctx))
+
+        self.assertEqual(
+            (chromium.src / "chrome" / "common" / "branding.h").read_text(),
+            "// custom\n",
+        )
+
+    def test_missing_destination_raises(self):
+        _, root, ctx = self._make("release")
+        root.add_replacement_file("chrome/common/not_in_chromium.h", "// custom\n")
+
+        with self.assertRaises(FileNotFoundError):
+            replace_chromium_files_impl(ctx)
+
+    def test_build_type_variant_replaces_when_matching(self):
+        chromium, root, ctx = self._make("release")
+        chromium.add_file("chrome/common/flags.cc", "// original\n")
+        root.add_replacement_file("chrome/common/flags.cc.release", "// release\n")
+
+        self.assertTrue(replace_chromium_files_impl(ctx))
+
+        self.assertEqual(
+            (chromium.src / "chrome" / "common" / "flags.cc").read_text(),
+            "// release\n",
+        )
+
+    def test_build_type_variant_skipped_when_not_matching(self):
+        chromium, root, ctx = self._make("debug")
+        chromium.add_file("chrome/common/flags.cc", "// original\n")
+        root.add_replacement_file("chrome/common/flags.cc.release", "// release\n")
+
+        self.assertTrue(replace_chromium_files_impl(ctx))
+
+        self.assertEqual(
+            (chromium.src / "chrome" / "common" / "flags.cc").read_text(),
+            "// original\n",
+        )
+
+    def test_variant_wins_over_generic_for_matching_build_type(self):
+        chromium, root, ctx = self._make("release")
+        chromium.add_file("chrome/common/mixed.cc", "// original\n")
+        root.add_replacement_file("chrome/common/mixed.cc", "// generic\n")
+        root.add_replacement_file("chrome/common/mixed.cc.release", "// release\n")
+
+        self.assertTrue(replace_chromium_files_impl(ctx))
+
+        self.assertEqual(
+            (chromium.src / "chrome" / "common" / "mixed.cc").read_text(),
+            "// release\n",
+        )
+
+
+class ChromiumReplaceModuleValidateTest(unittest.TestCase):
+    def test_missing_chromium_src_raises_validation_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = cast(
+                Context, SimpleNamespace(chromium_src=Path(tmp) / "missing")
+            )
+            with self.assertRaises(ValidationError):
+                ChromiumReplaceModule().validate(ctx)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/modules/resources/resources_test.py
+++ b/packages/browseros/build/modules/resources/resources_test.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Tests for copy_resources against a mock chromium checkout."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+from .resources import ResourcesModule, copy_resources_impl
+from ...common.context import Context
+from ...common.module import ValidationError
+from ...common.testing import MockBrowserOSRoot, MockChromium, make_context
+from ...common.utils import get_platform
+
+
+class CopyResourcesTest(unittest.TestCase):
+    def setUp(self):
+        self._chromium_tmp = tempfile.TemporaryDirectory()
+        self._root_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._chromium_tmp.cleanup)
+        self.addCleanup(self._root_tmp.cleanup)
+        self.chromium = MockChromium(Path(self._chromium_tmp.name))
+        self.root = MockBrowserOSRoot(Path(self._root_tmp.name))
+        self.ctx = make_context(
+            self.chromium, self.root, architecture="x64", build_type="release"
+        )
+
+    def test_missing_config_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            copy_resources_impl(self.ctx)
+
+    def test_config_without_operations_is_noop(self):
+        self.root.write_copy_config({"something_else": True})
+        self.assertTrue(copy_resources_impl(self.ctx))
+
+    def test_directory_operation_copies_tree(self):
+        src_dir = self.root.root / "resources" / "icons"
+        (src_dir / "nested").mkdir(parents=True)
+        (src_dir / "app.png").write_text("png-bytes")
+        (src_dir / "nested" / "small.png").write_text("small-bytes")
+        self.root.write_copy_config(
+            {
+                "copy_operations": [
+                    {
+                        "name": "Icons",
+                        "source": "resources/icons",
+                        "destination": "chrome/app/theme/browseros",
+                        "type": "directory",
+                    }
+                ]
+            }
+        )
+
+        self.assertTrue(copy_resources_impl(self.ctx))
+
+        dest = self.chromium.src / "chrome" / "app" / "theme" / "browseros"
+        self.assertEqual((dest / "app.png").read_text(), "png-bytes")
+        self.assertEqual((dest / "nested" / "small.png").read_text(), "small-bytes")
+
+    def test_file_operation_copies_and_creates_parents(self):
+        (self.root.root / "resources").mkdir(exist_ok=True)
+        (self.root.root / "resources" / "logo.icns").write_text("icns")
+        self.root.write_copy_config(
+            {
+                "copy_operations": [
+                    {
+                        "name": "Logo",
+                        "source": "resources/logo.icns",
+                        "destination": "chrome/app/theme/logo.icns",
+                        "type": "file",
+                    }
+                ]
+            }
+        )
+
+        self.assertTrue(copy_resources_impl(self.ctx))
+
+        dest = self.chromium.src / "chrome" / "app" / "theme" / "logo.icns"
+        self.assertEqual(dest.read_text(), "icns")
+
+    def test_files_operation_copies_glob_matches(self):
+        ext_dir = self.root.root / "resources" / "ext"
+        ext_dir.mkdir(parents=True)
+        (ext_dir / "a.js").write_text("a")
+        (ext_dir / "b.js").write_text("b")
+        (ext_dir / "ignore.txt").write_text("x")
+        self.root.write_copy_config(
+            {
+                "copy_operations": [
+                    {
+                        "name": "Scripts",
+                        "source": "resources/ext/*.js",
+                        "destination": "chrome/browser/resources/browseros",
+                        "type": "files",
+                    }
+                ]
+            }
+        )
+
+        self.assertTrue(copy_resources_impl(self.ctx))
+
+        dest = self.chromium.src / "chrome" / "browser" / "resources" / "browseros"
+        self.assertEqual((dest / "a.js").read_text(), "a")
+        self.assertEqual((dest / "b.js").read_text(), "b")
+        self.assertFalse((dest / "ignore.txt").exists())
+
+    def test_condition_mismatches_skip_operation(self):
+        (self.root.root / "resources").mkdir(exist_ok=True)
+        (self.root.root / "resources" / "skipped.txt").write_text("x")
+        self.root.write_copy_config(
+            {
+                "copy_operations": [
+                    {
+                        "name": "Wrong build type",
+                        "source": "resources/skipped.txt",
+                        "destination": "chrome/one.txt",
+                        "type": "file",
+                        "build_type": "debug",
+                    },
+                    {
+                        "name": "Wrong os",
+                        "source": "resources/skipped.txt",
+                        "destination": "chrome/two.txt",
+                        "type": "file",
+                        "os": ["never-os"],
+                    },
+                    {
+                        "name": "Wrong arch",
+                        "source": "resources/skipped.txt",
+                        "destination": "chrome/three.txt",
+                        "type": "file",
+                        "arch": ["arm64"],
+                    },
+                ]
+            }
+        )
+
+        self.assertTrue(copy_resources_impl(self.ctx))
+
+        self.assertFalse((self.chromium.src / "chrome" / "one.txt").exists())
+        self.assertFalse((self.chromium.src / "chrome" / "two.txt").exists())
+        self.assertFalse((self.chromium.src / "chrome" / "three.txt").exists())
+
+    def test_matching_conditions_run_operation(self):
+        (self.root.root / "resources").mkdir(exist_ok=True)
+        (self.root.root / "resources" / "kept.txt").write_text("kept")
+        self.root.write_copy_config(
+            {
+                "copy_operations": [
+                    {
+                        "name": "Matches everything",
+                        "source": "resources/kept.txt",
+                        "destination": "chrome/kept.txt",
+                        "type": "file",
+                        "build_type": "release",
+                        "os": [get_platform()],
+                        "arch": ["x64"],
+                    }
+                ]
+            }
+        )
+
+        self.assertTrue(copy_resources_impl(self.ctx))
+
+        self.assertEqual(
+            (self.chromium.src / "chrome" / "kept.txt").read_text(), "kept"
+        )
+
+    def test_missing_source_is_tolerated(self):
+        self.root.write_copy_config(
+            {
+                "copy_operations": [
+                    {
+                        "name": "Ghost",
+                        "source": "resources/missing-dir",
+                        "destination": "chrome/ghost",
+                        "type": "directory",
+                    }
+                ]
+            }
+        )
+
+        self.assertTrue(copy_resources_impl(self.ctx))
+
+        self.assertFalse((self.chromium.src / "chrome" / "ghost").exists())
+
+
+class ResourcesModuleValidateTest(unittest.TestCase):
+    def test_missing_copy_config_raises_validation_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = cast(
+                Context,
+                SimpleNamespace(
+                    get_copy_resources_config=lambda: Path(tmp) / "missing.yaml"
+                ),
+            )
+            with self.assertRaises(ValidationError):
+                ResourcesModule().validate(ctx)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/modules/resources/string_replaces_test.py
+++ b/packages/browseros/build/modules/resources/string_replaces_test.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Tests for branding string replacements against a mock checkout."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+
+from .string_replaces import StringReplacesModule, apply_string_replacements_impl
+from ...common.context import Context
+from ...common.module import ValidationError
+from ...common.testing import MockBrowserOSRoot, MockChromium, make_context
+
+
+class ApplyStringReplacementsTest(unittest.TestCase):
+    def setUp(self):
+        self._chromium_tmp = tempfile.TemporaryDirectory()
+        self._root_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._chromium_tmp.cleanup)
+        self.addCleanup(self._root_tmp.cleanup)
+        self.chromium = MockChromium(Path(self._chromium_tmp.name))
+        self.root = MockBrowserOSRoot(Path(self._root_tmp.name))
+        self.ctx = make_context(self.chromium, self.root)
+
+    def test_rebrands_target_files(self):
+        self.chromium.with_branding_files()
+
+        self.assertTrue(apply_string_replacements_impl(self.ctx))
+
+        content = (
+            self.chromium.src / "chrome" / "app" / "chromium_strings.grd"
+        ).read_text()
+        self.assertNotIn("Google Chrome", content)
+        self.assertNotIn("Chromium", content)
+        self.assertIn("BrowserOS", content)
+        self.assertIn("The BrowserOS Authors. All rights reserved.", content)
+
+    def test_google_play_is_preserved(self):
+        self.chromium.with_branding_files()
+
+        self.assertTrue(apply_string_replacements_impl(self.ctx))
+
+        content = (
+            self.chromium.src / "chrome" / "app" / "chromium_strings.grd"
+        ).read_text()
+        self.assertIn("Google Play", content)
+        self.assertNotIn("BrowserOS Play", content)
+
+    def test_both_target_files_are_processed(self):
+        self.chromium.with_branding_files()
+
+        self.assertTrue(apply_string_replacements_impl(self.ctx))
+
+        grdp = (
+            self.chromium.src / "chrome" / "app" / "settings_chromium_strings.grdp"
+        ).read_text()
+        self.assertNotIn("Google Chrome", grdp)
+        self.assertIn("BrowserOS", grdp)
+
+    def test_missing_target_file_is_tolerated(self):
+        self.chromium.add_file(
+            "chrome/app/chromium_strings.grd", "<grit>Google Chrome</grit>\n"
+        )
+        # settings_chromium_strings.grdp intentionally absent
+
+        self.assertTrue(apply_string_replacements_impl(self.ctx))
+
+        content = (
+            self.chromium.src / "chrome" / "app" / "chromium_strings.grd"
+        ).read_text()
+        self.assertIn("BrowserOS", content)
+
+    def test_all_targets_missing_still_succeeds(self):
+        self.assertTrue(apply_string_replacements_impl(self.ctx))
+
+    def test_non_target_files_untouched(self):
+        self.chromium.with_branding_files()
+        other = self.chromium.add_file(
+            "chrome/app/google_chrome_strings.grd", "<grit>Chromium</grit>\n"
+        )
+
+        self.assertTrue(apply_string_replacements_impl(self.ctx))
+
+        self.assertEqual(other.read_text(), "<grit>Chromium</grit>\n")
+
+
+class StringReplacesModuleValidateTest(unittest.TestCase):
+    def test_missing_chromium_src_raises_validation_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            ctx = cast(
+                Context, SimpleNamespace(chromium_src=Path(tmp) / "missing")
+            )
+            with self.assertRaises(ValidationError):
+                StringReplacesModule().validate(ctx)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/modules/setup/clean_test.py
+++ b/packages/browseros/build/modules/setup/clean_test.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""Tests for the clean module against a mock checkout."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from . import clean
+from ...common.context import Context
+from ...common.module import ValidationError
+from ...common.testing import MockBrowserOSRoot, MockChromium, make_context
+
+
+class CleanValidateTest(unittest.TestCase):
+    def test_missing_chromium_src_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = MockBrowserOSRoot(Path(tmp) / "root")
+            ctx = Context(
+                root_dir=root.root,
+                chromium_src=Path(tmp) / "missing-src",
+                architecture="x64",
+                build_type="release",
+            )
+            with self.assertRaises(ValidationError):
+                clean.CleanModule().validate(ctx)
+
+
+class CleanExecuteTest(unittest.TestCase):
+    def test_removes_out_dir_and_sparkle_and_resets_git(self):
+        with (
+            tempfile.TemporaryDirectory() as chromium_tmp,
+            tempfile.TemporaryDirectory() as root_tmp,
+        ):
+            chromium = MockChromium(Path(chromium_tmp))
+            ctx = make_context(
+                chromium, MockBrowserOSRoot(Path(root_tmp)), architecture="x64"
+            )
+            out_dir = chromium.with_out_dir("x64", args_gn="is_debug = false\n")
+            sparkle = chromium.with_sparkle()
+
+            with mock.patch.object(clean, "run_command") as run_cmd:
+                clean.CleanModule().execute(ctx)
+
+            self.assertFalse(out_dir.exists())
+            self.assertFalse(sparkle.exists())
+
+            git_commands = [call.args[0] for call in run_cmd.call_args_list]
+            self.assertEqual(
+                git_commands[0], ["git", "reset", "--hard", "HEAD"]
+            )
+            self.assertTrue(
+                all(cmd[0] == "git" for cmd in git_commands),
+                f"expected only git commands, got: {git_commands}",
+            )
+            for call in run_cmd.call_args_list:
+                self.assertEqual(call.kwargs["cwd"], ctx.chromium_src)
+
+    def test_missing_out_dir_is_tolerated(self):
+        with (
+            tempfile.TemporaryDirectory() as chromium_tmp,
+            tempfile.TemporaryDirectory() as root_tmp,
+        ):
+            chromium = MockChromium(Path(chromium_tmp))
+            ctx = make_context(chromium, MockBrowserOSRoot(Path(root_tmp)))
+
+            with mock.patch.object(clean, "run_command"):
+                clean.CleanModule().execute(ctx)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/modules/setup/configure_test.py
+++ b/packages/browseros/build/modules/setup/configure_test.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Tests for the GN configure module against a mock checkout."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from . import configure
+from ...common.context import Context
+from ...common.module import ValidationError
+from ...common.testing import MockBrowserOSRoot, MockChromium, make_context
+from ...common.utils import get_platform
+
+
+class ConfigureValidateTest(unittest.TestCase):
+    def test_missing_chromium_src_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = MockBrowserOSRoot(Path(tmp) / "root")
+            ctx = Context(
+                root_dir=root.root,
+                chromium_src=Path(tmp) / "missing-src",
+                architecture="x64",
+                build_type="release",
+            )
+            with self.assertRaises(ValidationError):
+                configure.ConfigureModule().validate(ctx)
+
+    def test_missing_gn_flags_file_raises(self):
+        with (
+            tempfile.TemporaryDirectory() as chromium_tmp,
+            tempfile.TemporaryDirectory() as root_tmp,
+        ):
+            ctx = make_context(
+                MockChromium(Path(chromium_tmp)),
+                MockBrowserOSRoot(Path(root_tmp)),
+                build_type="release",
+            )
+            with self.assertRaises(ValidationError):
+                configure.ConfigureModule().validate(ctx)
+
+    def test_passes_with_existing_flags_file(self):
+        with (
+            tempfile.TemporaryDirectory() as chromium_tmp,
+            tempfile.TemporaryDirectory() as root_tmp,
+        ):
+            root = MockBrowserOSRoot(Path(root_tmp))
+            root.write_gn_flags(get_platform(), "release", "is_debug = false\n")
+            ctx = make_context(
+                MockChromium(Path(chromium_tmp)), root, build_type="release"
+            )
+            configure.ConfigureModule().validate(ctx)
+
+
+class ConfigureExecuteTest(unittest.TestCase):
+    def _execute(self, build_type: str, architecture: str = "x64"):
+        chromium_tmp = tempfile.TemporaryDirectory()
+        root_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(chromium_tmp.cleanup)
+        self.addCleanup(root_tmp.cleanup)
+
+        chromium = MockChromium(Path(chromium_tmp.name))
+        root = MockBrowserOSRoot(Path(root_tmp.name))
+        root.write_gn_flags(get_platform(), build_type, "is_official_build = true\n")
+        ctx = make_context(
+            chromium, root, architecture=architecture, build_type=build_type
+        )
+
+        with (
+            mock.patch.object(configure, "run_command") as run_cmd,
+            mock.patch.object(configure, "IS_LINUX", return_value=False),
+            mock.patch.object(configure, "IS_WINDOWS", return_value=False),
+        ):
+            configure.ConfigureModule().execute(ctx)
+
+        return ctx, chromium, run_cmd
+
+    def test_writes_args_gn_with_target_cpu(self):
+        ctx, chromium, _ = self._execute("release", architecture="arm64")
+
+        args_gn = chromium.src / ctx.out_dir / "args.gn"
+        self.assertTrue(args_gn.exists())
+        self.assertEqual(
+            args_gn.read_text(),
+            'is_official_build = true\n\ntarget_cpu = "arm64"\n',
+        )
+
+    def test_release_build_fails_on_unused_args(self):
+        ctx, _, run_cmd = self._execute("release")
+
+        run_cmd.assert_called_once()
+        self.assertEqual(
+            run_cmd.call_args.args[0],
+            ["gn", "gen", ctx.out_dir, "--fail-on-unused-args"],
+        )
+        self.assertEqual(run_cmd.call_args.kwargs["cwd"], ctx.chromium_src)
+
+    def test_debug_build_omits_fail_on_unused_args(self):
+        ctx, _, run_cmd = self._execute("debug")
+
+        self.assertEqual(run_cmd.call_args.args[0], ["gn", "gen", ctx.out_dir])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/modules/setup/git_test.py
+++ b/packages/browseros/build/modules/setup/git_test.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Tests for the git setup module's gclient handling against a mock checkout."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from .git import GitSetupModule
+from ...common.context import Context
+from ...common.module import ValidationError
+from ...common.testing import MockBrowserOSRoot, MockChromium, make_context
+
+
+class GitSetupValidateTest(unittest.TestCase):
+    def test_missing_chromium_src_raises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = MockBrowserOSRoot(Path(tmp) / "root")
+            ctx = Context(
+                root_dir=root.root,
+                chromium_src=Path(tmp) / "missing-src",
+                architecture="x64",
+                build_type="release",
+            )
+            with self.assertRaises(ValidationError):
+                GitSetupModule().validate(ctx)
+
+    def test_missing_chromium_version_raises(self):
+        with (
+            tempfile.TemporaryDirectory() as chromium_tmp,
+            tempfile.TemporaryDirectory() as root_tmp,
+        ):
+            root = MockBrowserOSRoot(Path(root_tmp))
+            (root.root / "CHROMIUM_VERSION").unlink()
+            ctx = make_context(MockChromium(Path(chromium_tmp)), root)
+            self.assertEqual(ctx.chromium_version, "")
+            with self.assertRaises(ValidationError):
+                GitSetupModule().validate(ctx)
+
+    def test_passes_with_src_and_version(self):
+        with (
+            tempfile.TemporaryDirectory() as chromium_tmp,
+            tempfile.TemporaryDirectory() as root_tmp,
+        ):
+            ctx = make_context(
+                MockChromium(Path(chromium_tmp)),
+                MockBrowserOSRoot(Path(root_tmp)),
+            )
+            GitSetupModule().validate(ctx)
+
+
+class EnsureGclientTargetCpusTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self._root_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.addCleanup(self._root_tmp.cleanup)
+        self.chromium = MockChromium(Path(self._tmp.name))
+        self.ctx = make_context(
+            self.chromium, MockBrowserOSRoot(Path(self._root_tmp.name))
+        )
+        self.gclient = self.chromium.root / ".gclient"
+        self.module = GitSetupModule()
+
+    def test_missing_gclient_is_tolerated(self):
+        self.gclient.unlink()
+
+        self.module._ensure_gclient_target_cpus(self.ctx, ["x64", "arm64"])
+
+        self.assertFalse(self.gclient.exists())
+
+    def test_appends_target_cpus_when_absent(self):
+        self.module._ensure_gclient_target_cpus(self.ctx, ["x64", "arm64"])
+
+        content = self.gclient.read_text()
+        self.assertIn("target_cpus = ['x64', 'arm64']", content)
+        self.assertIn("solutions = [", content)
+
+    def test_merges_missing_archs_into_existing_list(self):
+        self.gclient.write_text(
+            self.gclient.read_text() + "\ntarget_cpus = ['x64']\n"
+        )
+
+        self.module._ensure_gclient_target_cpus(self.ctx, ["x64", "arm64"])
+
+        content = self.gclient.read_text()
+        self.assertIn("target_cpus = ['arm64', 'x64']", content)
+        self.assertNotIn("target_cpus = ['x64']\n", content)
+
+    def test_complete_list_leaves_file_unchanged(self):
+        self.gclient.write_text(
+            self.gclient.read_text() + "\ntarget_cpus = ['arm64', 'x64']\n"
+        )
+        before = self.gclient.read_text()
+
+        self.module._ensure_gclient_target_cpus(self.ctx, ["x64", "arm64"])
+
+        self.assertEqual(self.gclient.read_text(), before)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `build/common/testing.py`: a reusable mock-chromium-checkout fixture (`MockChromium` for the gclient root + `src/` tree, `MockBrowserOSRoot` for the packages/browseros root, `make_context` wiring a real `Context` to both) so build modules can be unit-tested without a multi-GB real Chromium checkout.
- Adds 14 colocated `_test.py` files covering previously untested modules: resolver, resources (copy / chromium-replace / branding string replacements), apply + patches, feature + annotate, and setup (configure / gclient target_cpus / clean) — 119 new tests, 245 total.
- Real `git init` repos (in temp dirs) back the patch/annotate/feature tests for fidelity; expensive tools (gn, gclient, git reset) stay behind `mock.patch.object(module, "run_command")`, matching existing test conventions.

## Design
Builder-object fixture: constructors write only the cheap baseline markers (`.gclient`, `src/chrome/VERSION`, `BUILD.gn`; version files for the root), and everything else is opt-in (`add_file`, `with_out_dir`, `with_git`, `with_branding_files`, `add_patch`, `write_features_yaml`, …) so each test pays for exactly the tree it needs. All stdlib `unittest`, package-relative imports, no network, no real-checkout references.

## Test plan
- [x] `cd packages/browseros && uv run python -m unittest build.cli.storage_test build.common.context_test build.common.resolver_test build.common.server_binaries_test build.common.testing_test build.modules.annotate.annotate_test build.modules.apply.apply_all_test build.modules.apply.common_test build.modules.compile.standard_test build.modules.extract.extract_base_default_test build.modules.feature.feature_test build.modules.feature.validation_test build.modules.ota.bundle_test build.modules.package.linux_test build.modules.package.windows_test build.modules.patches.patches_test build.modules.resources.chromium_replace_test build.modules.resources.resources_test build.modules.resources.string_replaces_test build.modules.setup.clean_test build.modules.setup.configure_test build.modules.setup.git_test build.modules.sign.macos_test build.modules.storage.download_test build.modules.storage.upload_test build.scripts.bump_server_version_test build.scripts.bump_version_test` → 245 tests OK (126 pre-existing + 119 new)
- [x] `uv run ruff check` clean on all new files; `uv run pyright` clean on all new files

🤖 Generated with [Claude Code](https://claude.com/claude-code)