### PR TITLE
chore: resolve all fallow findings without behavior changes

### DIFF
--- a/packages/browseros-agent/.fallowrc.json
+++ b/packages/browseros-agent/.fallowrc.json
@@ -20,7 +20,13 @@
     "tw-animate-css",
     "@tailwindcss/typography",
     "pino-pretty",
-    "@browseros/cdp-protocol"
+    "@browseros/cdp-protocol",
+    "@graphql-typed-document-node/core"
+  ],
+  "ignoreUnresolvedImports": [
+    "@/assets/**",
+    "@/generated/graphql/**",
+    "@/styles/global.css"
   ],
   "ignorePatterns": [
     "**/*.d.ts",

--- a/packages/browseros-agent/apps/agent/components/agents/AdapterIcon.tsx
+++ b/packages/browseros-agent/apps/agent/components/agents/AdapterIcon.tsx
@@ -7,7 +7,7 @@ import type { HarnessAgentAdapter } from '@/modules/agents/agent-harness-types'
  * Falls back to a generic bot when the adapter is unknown so future
  * adapters land without a code change at the call site.
  */
-interface AdapterIconProps {
+export interface AdapterIconProps {
   adapter: HarnessAgentAdapter | 'unknown'
   className?: string
 }

--- a/packages/browseros-agent/apps/agent/components/agents/LivenessDot.tsx
+++ b/packages/browseros-agent/apps/agent/components/agents/LivenessDot.tsx
@@ -9,7 +9,7 @@ import { cn } from '@/lib/utils'
 
 export type AgentLiveness = 'working' | 'idle' | 'asleep' | 'error' | 'unknown'
 
-interface LivenessDotProps {
+export interface LivenessDotProps {
   status: AgentLiveness
   /**
    * Optional human-friendly secondary line, e.g. "Idle for 4 min" or

--- a/packages/browseros-agent/apps/agent/components/agents/NewAgentDialog.tsx
+++ b/packages/browseros-agent/apps/agent/components/agents/NewAgentDialog.tsx
@@ -28,7 +28,7 @@ import type {
 } from '@/modules/agents/agents-page-types'
 import { ProviderSelector } from './ProviderSelector'
 
-interface NewAgentDialogProps {
+export interface NewAgentDialogProps {
   adapters: HarnessAdapterDescriptor[]
   createError: string | null
   createRuntime: CreateAgentRuntime

--- a/packages/browseros-agent/apps/agent/components/agents/ProviderSelector.tsx
+++ b/packages/browseros-agent/apps/agent/components/agents/ProviderSelector.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/components/ui/select'
 import type { ProviderOption } from '@/modules/agents/agents-page-types'
 
-interface ProviderSelectorProps {
+export interface ProviderSelectorProps {
   providers: ProviderOption[]
   defaultProviderId: string
   selectedId: string

--- a/packages/browseros-agent/apps/agent/components/agents/agent-row/AgentSummaryChips.tsx
+++ b/packages/browseros-agent/apps/agent/components/agents/agent-row/AgentSummaryChips.tsx
@@ -15,7 +15,7 @@ import type { HarnessAgentAdapter } from '@/modules/agents/agent-harness-types'
 import { adapterLabel } from '../AdapterIcon'
 import type { AgentAdapterHealth } from './agent-row.types'
 
-interface AgentSummaryChipsProps {
+export interface AgentSummaryChipsProps {
   adapter: HarnessAgentAdapter | 'unknown'
   modelLabel: string | null
   reasoningEffort: string | null

--- a/packages/browseros-agent/apps/agent/components/agents/agent-row/PinToggle.tsx
+++ b/packages/browseros-agent/apps/agent/components/agents/agent-row/PinToggle.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 
-interface PinToggleProps {
+export interface PinToggleProps {
   pinned: boolean
   onToggle: (next: boolean) => void
 }

--- a/packages/browseros-agent/apps/agent/components/chat/ChatProviderSelector.tsx
+++ b/packages/browseros-agent/apps/agent/components/chat/ChatProviderSelector.tsx
@@ -24,7 +24,7 @@ import {
 } from './ChatProviderSelector.helpers'
 import type { Provider } from './chatComponentTypes'
 
-interface ChatProviderSelectorProps {
+export interface ChatProviderSelectorProps {
   providers: Provider[]
   selectedProvider: Provider
   onSelectProvider: (provider: Provider) => void

--- a/packages/browseros-agent/apps/agent/components/credits/CreditBadge.tsx
+++ b/packages/browseros-agent/apps/agent/components/credits/CreditBadge.tsx
@@ -3,7 +3,7 @@ import type { FC } from 'react'
 import { getCreditTextColor } from '@/lib/credits/credit-colors'
 import { cn } from '@/lib/utils'
 
-interface CreditBadgeProps {
+export interface CreditBadgeProps {
   credits: number
   onClick?: () => void
 }

--- a/packages/browseros-agent/apps/agent/components/elements/AppSelector.tsx
+++ b/packages/browseros-agent/apps/agent/components/elements/AppSelector.tsx
@@ -27,7 +27,7 @@ import { useSubmitApiKey } from '@/modules/mcp/submit-api-key.hooks'
 import { useSyncRemoteIntegrations } from '@/modules/mcp/sync-remote-integrations.hooks'
 import { useGetUserMCPIntegrations } from '@/modules/mcp/user-integrations.hooks'
 
-interface AppSelectorProps {
+export interface AppSelectorProps {
   children: ReactNode
   side?: 'top' | 'bottom' | 'left' | 'right'
 }

--- a/packages/browseros-agent/apps/agent/components/elements/available-tabs.hooks.ts
+++ b/packages/browseros-agent/apps/agent/components/elements/available-tabs.hooks.ts
@@ -1,11 +1,11 @@
 import { useEffect, useMemo, useState } from 'react'
 
-interface UseAvailableTabsOptions {
+export interface UseAvailableTabsOptions {
   enabled: boolean
   filterText?: string
 }
 
-interface UseAvailableTabsResult {
+export interface UseAvailableTabsResult {
   tabs: chrome.tabs.Tab[]
   allTabs: chrome.tabs.Tab[]
   isLoading: boolean

--- a/packages/browseros-agent/apps/agent/components/elements/glowing-border.tsx
+++ b/packages/browseros-agent/apps/agent/components/elements/glowing-border.tsx
@@ -7,7 +7,7 @@ import {
 } from 'motion/react'
 import React, { type FC, type SVGProps, useRef } from 'react'
 
-interface GlowingBorderProps extends SVGProps<SVGSVGElement> {
+export interface GlowingBorderProps extends SVGProps<SVGSVGElement> {
   duration?: number
   rx?: string
   ry?: string

--- a/packages/browseros-agent/apps/agent/components/elements/pill-indicator.tsx
+++ b/packages/browseros-agent/apps/agent/components/elements/pill-indicator.tsx
@@ -1,7 +1,7 @@
 import type { FC } from 'react'
 import { cn } from '@/lib/utils'
 
-interface PillIndicatorProps {
+export interface PillIndicatorProps {
   text: string
   className?: string
 }

--- a/packages/browseros-agent/apps/agent/components/elements/tab-list-item.tsx
+++ b/packages/browseros-agent/apps/agent/components/elements/tab-list-item.tsx
@@ -2,7 +2,7 @@ import { Check, Globe } from 'lucide-react'
 import type { FC } from 'react'
 import { cn } from '@/lib/utils'
 
-interface TabListItemProps {
+export interface TabListItemProps {
   tab: chrome.tabs.Tab
   isSelected: boolean
   className?: string

--- a/packages/browseros-agent/apps/agent/components/elements/tab-picker-popover.tsx
+++ b/packages/browseros-agent/apps/agent/components/elements/tab-picker-popover.tsx
@@ -18,14 +18,14 @@ import {
 import { useAvailableTabs } from './available-tabs.hooks'
 import { TabListItem } from './tab-list-item'
 
-type PopoverSide = 'top' | 'bottom' | 'left' | 'right'
+export type PopoverSide = 'top' | 'bottom' | 'left' | 'right'
 
-interface TabPickerCommonProps {
+export interface TabPickerCommonProps {
   selectedTabs: chrome.tabs.Tab[]
   onToggleTab: (tab: chrome.tabs.Tab) => void
 }
 
-interface TabPickerMentionPopoverProps extends TabPickerCommonProps {
+export interface TabPickerMentionPopoverProps extends TabPickerCommonProps {
   variant: 'mention'
   isOpen: boolean
   filterText: string
@@ -34,13 +34,13 @@ interface TabPickerMentionPopoverProps extends TabPickerCommonProps {
   side?: PopoverSide
 }
 
-interface TabPickerSelectorPopoverProps
+export interface TabPickerSelectorPopoverProps
   extends PropsWithChildren<TabPickerCommonProps> {
   variant: 'selector'
   side?: PopoverSide
 }
 
-type TabPickerPopoverProps =
+export type TabPickerPopoverProps =
   | TabPickerMentionPopoverProps
   | TabPickerSelectorPopoverProps
 

--- a/packages/browseros-agent/apps/agent/components/elements/theme-toggle.tsx
+++ b/packages/browseros-agent/apps/agent/components/elements/theme-toggle.tsx
@@ -19,7 +19,7 @@ const themes: { value: Theme; icon: typeof Monitor; label: string }[] = [
   { value: 'dark', icon: Moon, label: 'Dark' },
 ]
 
-interface ThemeToggleProps {
+export interface ThemeToggleProps {
   hideLabel?: boolean
   iconClassName?: ClassNameValue
   className?: ClassNameValue

--- a/packages/browseros-agent/apps/agent/components/elements/workspace-selector.tsx
+++ b/packages/browseros-agent/apps/agent/components/elements/workspace-selector.tsx
@@ -19,7 +19,7 @@ import { cn } from '@/lib/utils'
 import type { WorkspaceFolder } from '@/lib/workspace/workspace-storage'
 import { useWorkspace } from '@/modules/workspace/workspace.hooks'
 
-interface WorkspaceSelectorProps {
+export interface WorkspaceSelectorProps {
   side?: 'top' | 'bottom' | 'left' | 'right'
 }
 

--- a/packages/browseros-agent/apps/agent/components/mcp/ApiKeyDialog.tsx
+++ b/packages/browseros-agent/apps/agent/components/mcp/ApiKeyDialog.tsx
@@ -29,7 +29,7 @@ const formSchema = z.object({
 
 type FormValues = z.infer<typeof formSchema>
 
-interface ApiKeyDialogProps {
+export interface ApiKeyDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   serverName: string

--- a/packages/browseros-agent/apps/agent/components/mcp/McpServerIcon.tsx
+++ b/packages/browseros-agent/apps/agent/components/mcp/McpServerIcon.tsx
@@ -93,7 +93,7 @@ const mcpIconMap: Record<string, string> = {
   Intercom: IntercomSvg,
 }
 
-interface McpServerIconProps {
+export interface McpServerIconProps {
   serverName: string
   size?: number
   className?: string

--- a/packages/browseros-agent/apps/agent/components/sidebar/AppSidebar.tsx
+++ b/packages/browseros-agent/apps/agent/components/sidebar/AppSidebar.tsx
@@ -4,7 +4,7 @@ import { SidebarBranding } from './SidebarBranding'
 import { SidebarNavigation } from './SidebarNavigation'
 import { SidebarUserFooter } from './SidebarUserFooter'
 
-interface AppSidebarProps {
+export interface AppSidebarProps {
   expanded?: boolean
   onOpenShortcuts?: () => void
 }

--- a/packages/browseros-agent/apps/agent/components/sidebar/SidebarBranding.tsx
+++ b/packages/browseros-agent/apps/agent/components/sidebar/SidebarBranding.tsx
@@ -17,7 +17,7 @@ import { useGraphqlQuery } from '@/modules/graphql/graphql-query.hooks'
 import { useWorkspace } from '@/modules/workspace/workspace.hooks'
 import { GetProfileByUserIdDocument } from '@/screens/profile/graphql/profileDocument'
 
-interface SidebarBrandingProps {
+export interface SidebarBrandingProps {
   expanded?: boolean
 }
 

--- a/packages/browseros-agent/apps/agent/components/sidebar/SidebarNavigation.tsx
+++ b/packages/browseros-agent/apps/agent/components/sidebar/SidebarNavigation.tsx
@@ -11,7 +11,7 @@ import { Feature } from '@/lib/browseros/capabilities'
 import { cn } from '@/lib/utils'
 import { useCapabilities } from '@/modules/browseros/capabilities.hooks'
 
-interface SidebarNavigationProps {
+export interface SidebarNavigationProps {
   expanded?: boolean
 }
 

--- a/packages/browseros-agent/apps/agent/components/sidebar/SidebarUserFooter.tsx
+++ b/packages/browseros-agent/apps/agent/components/sidebar/SidebarUserFooter.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
 
-interface SidebarUserFooterProps {
+export interface SidebarUserFooterProps {
   expanded?: boolean
   onOpenShortcuts?: () => void
 }

--- a/packages/browseros-agent/apps/agent/components/theme-provider.tsx
+++ b/packages/browseros-agent/apps/agent/components/theme-provider.tsx
@@ -1,7 +1,7 @@
 import { createContext, useContext, useEffect, useState } from 'react'
 import { type Theme, themeStorage } from '@/lib/theme/theme-storage'
 
-type ThemeProviderProps = {
+export type ThemeProviderProps = {
   children: React.ReactNode
   defaultTheme?: Theme
 }

--- a/packages/browseros-agent/apps/agent/lib/browseros/capabilities.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/capabilities.ts
@@ -140,7 +140,7 @@ export function resolveStaticFeatureSupport({
   return null
 }
 
-type CapabilitiesState = {
+export type CapabilitiesState = {
   browserOSVersion: number[] | null
   serverVersion: number[] | null
 }

--- a/packages/browseros-agent/apps/agent/lib/chat-actions/types.ts
+++ b/packages/browseros-agent/apps/agent/lib/chat-actions/types.ts
@@ -2,7 +2,7 @@
  * Base interface for all chat actions
  * @public
  */
-interface BaseChatAction {
+export interface BaseChatAction {
   id: string
   timestamp: number
 }

--- a/packages/browseros-agent/apps/agent/lib/conversations/formatConversationHistory.ts
+++ b/packages/browseros-agent/apps/agent/lib/conversations/formatConversationHistory.ts
@@ -3,7 +3,7 @@ import type { UIMessage } from 'ai'
 const MAX_MESSAGES = 10
 const MAX_MESSAGE_CHARS = 65536
 
-interface ConversationMessage {
+export interface ConversationMessage {
   role: 'user' | 'assistant'
   content: string
 }

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/client-oauth.ts
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/client-oauth.ts
@@ -14,7 +14,7 @@ export interface ClientAuthConfig {
   contentType: 'json' | 'form'
 }
 
-interface DeviceCodeData {
+export interface DeviceCodeData {
   device_code: string
   user_code: string
   verification_uri: string

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/providerIcons.tsx
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/providerIcons.tsx
@@ -41,7 +41,7 @@ const providerIconMap: Record<ProviderType, IconComponent | null> = {
   'acp-custom': null,
 }
 
-interface ProviderIconProps {
+export interface ProviderIconProps {
   type: ProviderType
   size?: number
   className?: string

--- a/packages/browseros-agent/apps/agent/lib/messaging/server/buildChatRequestBody.ts
+++ b/packages/browseros-agent/apps/agent/lib/messaging/server/buildChatRequestBody.ts
@@ -1,7 +1,7 @@
 import type { LlmProviderConfig } from '@/lib/llm-providers/types'
 import type { ChatMode } from '@/modules/chat/chat-types'
 
-interface ChatHistoryEntry {
+export interface ChatHistoryEntry {
   role: 'user' | 'assistant'
   content: string
 }
@@ -25,7 +25,7 @@ export interface ChatRequestBrowserContext {
   }[]
 }
 
-interface ChatRequestBodyParams {
+export interface ChatRequestBodyParams {
   conversationId: string
   provider: LlmProviderConfig
   message?: string

--- a/packages/browseros-agent/apps/agent/lib/schedules/getChatServerResponse.ts
+++ b/packages/browseros-agent/apps/agent/lib/schedules/getChatServerResponse.ts
@@ -17,13 +17,13 @@ import { personalizationStorage } from '../personalization/personalizationStorag
 import { scheduleSystemPrompt } from './scheduleSystemPrompt'
 import type { ToolCallExecution } from './scheduleTypes'
 
-interface ActiveTab {
+export interface ActiveTab {
   id?: number
   url?: string
   title?: string
 }
 
-interface ChatServerRequest {
+export interface ChatServerRequest {
   message: string
   mode?: ChatMode
   conversationId?: string
@@ -33,7 +33,7 @@ interface ChatServerRequest {
   providerId?: string
 }
 
-interface ChatServerResponse {
+export interface ChatServerResponse {
   text: string
   conversationId: string
   finalResult: string

--- a/packages/browseros-agent/apps/agent/modules/browseros/agent-server-url.hooks.ts
+++ b/packages/browseros-agent/apps/agent/modules/browseros/agent-server-url.hooks.ts
@@ -4,7 +4,7 @@ import { getAgentServerUrl } from '@/lib/browseros/helpers'
 const MAX_AGENT_SERVER_URL_ATTEMPTS = 3
 const AGENT_SERVER_URL_RETRY_DELAY_MS = 500
 
-type UseAgentServerUrlResult =
+export type UseAgentServerUrlResult =
   | { baseUrl: string; isLoading: false; error: null }
   | { baseUrl?: never; isLoading: true; error: null }
   | { baseUrl?: never; isLoading: false; error: Error }

--- a/packages/browseros-agent/apps/agent/modules/browseros/capabilities.hooks.ts
+++ b/packages/browseros-agent/apps/agent/modules/browseros/capabilities.hooks.ts
@@ -7,7 +7,7 @@ interface CapabilitiesState {
   supportedFeatures: Map<Feature, boolean>
 }
 
-interface UseCapabilitiesResult {
+export interface UseCapabilitiesResult {
   supports: (feature: Feature) => boolean
   isLoading: boolean
   browserOSVersion: string | null

--- a/packages/browseros-agent/apps/agent/modules/chat-actions/chat-actions.hooks.ts
+++ b/packages/browseros-agent/apps/agent/modules/chat-actions/chat-actions.hooks.ts
@@ -5,7 +5,7 @@ import { useChatSessionContext } from '@/modules/chat/chat-session-context'
 import type { ChatMode } from '@/modules/chat/chat-types'
 import { useVoiceInput } from '@/modules/voice/voice.hooks'
 
-interface ChatActionsConfig {
+export interface ChatActionsConfig {
   /** Analytics event names scoped to the origin */
   events: {
     modeChanged: string

--- a/packages/browseros-agent/apps/agent/modules/chat/chat-session-request.ts
+++ b/packages/browseros-agent/apps/agent/modules/chat/chat-session-request.ts
@@ -6,14 +6,14 @@ import {
   toLlmProviderConfig,
 } from './sidepanel-chat-targets'
 
-type LlmChatRequestBodyInput = Parameters<typeof buildChatRequestBody>[0]
+export type LlmChatRequestBodyInput = Parameters<typeof buildChatRequestBody>[0]
 
-type CommonSidepanelRequestInput = Omit<
+export type CommonSidepanelRequestInput = Omit<
   LlmChatRequestBodyInput,
   'provider' | 'message' | 'isScheduledTask'
 >
 
-interface BuildSidepanelPreparedSendMessagesRequestInput
+export interface BuildSidepanelPreparedSendMessagesRequestInput
   extends CommonSidepanelRequestInput {
   agentServerUrl: string
   target: SidepanelChatTarget | undefined

--- a/packages/browseros-agent/apps/agent/modules/chat/sidepanel-chat-targets.ts
+++ b/packages/browseros-agent/apps/agent/modules/chat/sidepanel-chat-targets.ts
@@ -41,28 +41,28 @@ export type SidepanelChatTargetSelection = Pick<
   'kind' | 'id'
 >
 
-interface BuildSidepanelChatTargetsInput {
+export interface BuildSidepanelChatTargetsInput {
   providers: LlmProviderConfig[]
   adapters: HarnessAdapterDescriptor[]
   agents?: HarnessAgent[]
   hermesAgentSupported?: boolean
 }
 
-interface ResolveSidepanelChatTargetInput {
+export interface ResolveSidepanelChatTargetInput {
   targets: SidepanelChatTarget[]
   defaultProviderId: string
   selection?: SidepanelChatTargetSelection | null
 }
 
-interface SidepanelChatTargetSelectionWriter {
+export interface SidepanelChatTargetSelectionWriter {
   setValue(value: SidepanelChatTargetSelection | null): Promise<void>
 }
 
-interface SidepanelChatTargetSelectionReader {
+export interface SidepanelChatTargetSelectionReader {
   getValue(): Promise<SidepanelChatTargetSelection | null>
 }
 
-interface SidepanelChatTargetSelectionWatcher {
+export interface SidepanelChatTargetSelectionWatcher {
   watch(
     callback: (selection: SidepanelChatTargetSelection | null) => void,
   ): () => void

--- a/packages/browseros-agent/apps/agent/modules/llm-providers/acp-probe.hooks.ts
+++ b/packages/browseros-agent/apps/agent/modules/llm-providers/acp-probe.hooks.ts
@@ -2,23 +2,23 @@ import { useQuery } from '@tanstack/react-query'
 import type { ProviderType } from '@/lib/llm-providers/types'
 import { useAgentServerUrl } from '@/modules/browseros/agent-server-url.hooks'
 
-export interface AcpProbeModel {
+interface AcpProbeModel {
   id: string
   name?: string
   description?: string
 }
 
-export interface AcpProbeReasoning {
+interface AcpProbeReasoning {
   values: string[]
   defaultValue?: string
 }
 
-export interface AcpProbeError {
+interface AcpProbeError {
   code: string
   message: string
 }
 
-export interface AcpProbeResult {
+interface AcpProbeResult {
   models: AcpProbeModel[]
   reasoning: AcpProbeReasoning | null
   supportsConfigOption: boolean

--- a/packages/browseros-agent/apps/agent/modules/llm-providers/oauth-provider-flow.hooks.ts
+++ b/packages/browseros-agent/apps/agent/modules/llm-providers/oauth-provider-flow.hooks.ts
@@ -26,7 +26,7 @@ export interface PendingDeviceCode {
   verificationUri: string
 }
 
-interface OAuthProviderFlowReturn {
+export interface OAuthProviderFlowReturn {
   status: { authenticated: boolean; email?: string } | null
   disconnect: () => Promise<void>
   startOAuthFlow: (agentServerUrl: string | undefined) => Promise<void>

--- a/packages/browseros-agent/apps/agent/modules/llm-providers/oauth-status.hooks.ts
+++ b/packages/browseros-agent/apps/agent/modules/llm-providers/oauth-status.hooks.ts
@@ -1,13 +1,13 @@
 import { useEffect, useRef, useState } from 'react'
 import { getAgentServerUrl } from '@/lib/browseros/helpers'
 
-interface OAuthStatus {
+export interface OAuthStatus {
   authenticated: boolean
   email?: string
   provider: string
 }
 
-interface UseOAuthStatusReturn {
+export interface UseOAuthStatusReturn {
   status: OAuthStatus | null
   isPolling: boolean
   startPolling: () => void

--- a/packages/browseros-agent/apps/agent/screens/agent-command/AgentChat.tsx
+++ b/packages/browseros-agent/apps/agent/screens/agent-command/AgentChat.tsx
@@ -11,7 +11,7 @@ import { AgentChatMessage } from './AgentChatMessage'
 import type { AgentChatMessage as AgentChatMessageModel } from './agent-chat-types'
 import { ConversationMessage } from './ConversationMessage'
 
-interface AgentChatProps {
+export interface AgentChatProps {
   agentName: string
   historyMessages: AgentChatMessageModel[]
   turns: AgentConversationTurn[]

--- a/packages/browseros-agent/apps/agent/screens/agent-command/AgentChatMessage.tsx
+++ b/packages/browseros-agent/apps/agent/screens/agent-command/AgentChatMessage.tsx
@@ -92,7 +92,7 @@ function ToolStatusIcon({ status }: { status: ToolCallPart['status'] }) {
   return <XCircle className="size-3.5 shrink-0 text-destructive" />
 }
 
-interface AgentChatMessageProps {
+export interface AgentChatMessageProps {
   message: AgentChatMessageType
 }
 

--- a/packages/browseros-agent/apps/agent/screens/agent-command/AgentCommandConversation.tsx
+++ b/packages/browseros-agent/apps/agent/screens/agent-command/AgentCommandConversation.tsx
@@ -239,7 +239,7 @@ function AgentConversationController({
   )
 }
 
-interface AgentCommandConversationProps {
+export interface AgentCommandConversationProps {
   variant?: 'command' | 'page'
   backPath?: string
   agentPathPrefix?: string

--- a/packages/browseros-agent/apps/agent/screens/agent-command/AgentCommandLayout.tsx
+++ b/packages/browseros-agent/apps/agent/screens/agent-command/AgentCommandLayout.tsx
@@ -3,7 +3,7 @@ import { Outlet, useOutletContext } from 'react-router'
 import type { AgentEntry } from '@/modules/agents/agent-harness-types'
 import { useHarnessAgents } from '@/modules/agents/agents.hooks'
 
-interface AgentCommandContextValue {
+export interface AgentCommandContextValue {
   agents: AgentEntry[]
   agentsLoading: boolean
 }

--- a/packages/browseros-agent/apps/agent/screens/agent-command/AgentRail.tsx
+++ b/packages/browseros-agent/apps/agent/screens/agent-command/AgentRail.tsx
@@ -8,7 +8,7 @@ import type {
 import { orderAgentsByPinThenRecency } from '@/modules/agents/agents-list-order'
 import { AgentRailRow } from './AgentRailRow'
 
-interface AgentRailProps {
+export interface AgentRailProps {
   agents: HarnessAgent[]
   adapters: HarnessAdapterDescriptor[]
   activeAgentId: string

--- a/packages/browseros-agent/apps/agent/screens/agent-command/AgentRailRow.tsx
+++ b/packages/browseros-agent/apps/agent/screens/agent-command/AgentRailRow.tsx
@@ -7,7 +7,7 @@ import { Badge } from '@/components/ui/badge'
 import { cn } from '@/lib/utils'
 import type { HarnessAgent } from '@/modules/agents/agent-harness-types'
 
-interface AgentRailRowProps {
+export interface AgentRailRowProps {
   agent: HarnessAgent
   active: boolean
   adapterHealth: AgentAdapterHealth | null

--- a/packages/browseros-agent/apps/agent/screens/agent-command/ConversationHeader.tsx
+++ b/packages/browseros-agent/apps/agent/screens/agent-command/ConversationHeader.tsx
@@ -11,7 +11,7 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import type { HarnessAgent } from '@/modules/agents/agent-harness-types'
 
-interface ConversationHeaderProps {
+export interface ConversationHeaderProps {
   agent: HarnessAgent | null
   fallbackName: string
   fallbackAdapter: 'claude' | 'codex' | 'hermes' | 'unknown'

--- a/packages/browseros-agent/apps/agent/screens/agent-command/ConversationInput.tsx
+++ b/packages/browseros-agent/apps/agent/screens/agent-command/ConversationInput.tsx
@@ -44,7 +44,7 @@ export interface ConversationInputSendInput {
   attachments: StagedAttachment[]
 }
 
-interface ConversationInputProps {
+export interface ConversationInputProps {
   onSend: (input: ConversationInputSendInput) => void
   /**
    * Merged provider/agent picker shown only on the `home` variant. Lets the

--- a/packages/browseros-agent/apps/agent/screens/agent-command/ConversationMessage.tsx
+++ b/packages/browseros-agent/apps/agent/screens/agent-command/ConversationMessage.tsx
@@ -23,7 +23,7 @@ import type {
   ToolEntry,
 } from '@/lib/agent-conversations/types'
 
-interface ConversationMessageProps {
+export interface ConversationMessageProps {
   turn: AgentConversationTurn
   streaming: boolean
 }

--- a/packages/browseros-agent/apps/agent/screens/agent-command/QueuePanel.tsx
+++ b/packages/browseros-agent/apps/agent/screens/agent-command/QueuePanel.tsx
@@ -21,7 +21,7 @@ import type {
   HarnessQueuedMessageAttachment,
 } from '@/modules/agents/agent-harness-types'
 
-interface QueuePanelProps {
+export interface QueuePanelProps {
   queue: HarnessQueuedMessage[]
   onRemove: (messageId: string) => void
 }

--- a/packages/browseros-agent/apps/agent/screens/agent-command/agent-conversation.hooks.ts
+++ b/packages/browseros-agent/apps/agent/screens/agent-command/agent-conversation.hooks.ts
@@ -27,7 +27,7 @@ interface SendInput {
   attachmentPreviews?: UserAttachmentPreview[]
 }
 
-interface UseAgentConversationOptions {
+export interface UseAgentConversationOptions {
   runtime?: 'agent-harness'
   sessionId?: string
   sessionKey?: string | null

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/CodingAgentCard.tsx
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/CodingAgentCard.tsx
@@ -11,7 +11,7 @@ import { Badge } from '../../components/ui/badge'
 import { Button } from '../../components/ui/button'
 import { cn } from '../../lib/utils'
 
-interface CodingAgentCardProps {
+export interface CodingAgentCardProps {
   agent: AgentListItem
   adapter: HarnessAgentAdapter | 'unknown'
   modelLabel: string | null

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/CodingAgentTemplateCard.tsx
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/CodingAgentTemplateCard.tsx
@@ -6,7 +6,7 @@ import type {
   HarnessAgentAdapter,
 } from '@/modules/agents/agent-harness-types'
 
-interface CodingAgentTemplateCardProps {
+export interface CodingAgentTemplateCardProps {
   adapter: HarnessAdapterDescriptor
   onCreate: (adapterId: HarnessAgentAdapter) => void
 }

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/CodingAgentsList.tsx
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/CodingAgentsList.tsx
@@ -6,7 +6,7 @@ import type { AgentListItem } from '@/modules/agents/agents-page-types'
 import { CodingAgentCard } from './CodingAgentCard'
 import type { CodingAgentsController } from './coding-agents.hooks'
 
-interface CodingAgentsListProps {
+export interface CodingAgentsListProps {
   controller: CodingAgentsController
   selectedAgentId: string | null
   onSelectAgent: (agentId: string) => void

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/ConfiguredProvidersList.tsx
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/ConfiguredProvidersList.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react'
 import type { LlmProviderConfig } from '@/lib/llm-providers/types'
 import { ProviderCard } from './ProviderCard'
 
-interface ConfiguredProvidersListProps {
+export interface ConfiguredProvidersListProps {
   providers: LlmProviderConfig[]
   selectedProviderId: string | null
   testingProviderId: string | null

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/DeviceCodeDialog.tsx
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/DeviceCodeDialog.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/components/ui/dialog'
 import type { PendingDeviceCode } from '@/modules/llm-providers/oauth-provider-flow.hooks'
 
-interface DeviceCodeDialogProps {
+export interface DeviceCodeDialogProps {
   deviceCode: PendingDeviceCode | null
   onClose: () => void
 }

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/IncompleteProviderCard.tsx
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/IncompleteProviderCard.tsx
@@ -17,7 +17,7 @@ export interface IncompleteProvider {
   region?: string | null
 }
 
-interface IncompleteProviderCardProps {
+export interface IncompleteProviderCardProps {
   provider: IncompleteProvider
   onAddKeys: () => void
   onDelete: () => void

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/IncompleteProvidersList.tsx
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/IncompleteProvidersList.tsx
@@ -5,7 +5,7 @@ import {
   IncompleteProviderCard,
 } from './IncompleteProviderCard'
 
-interface IncompleteProvidersListProps {
+export interface IncompleteProvidersListProps {
   providers: IncompleteProvider[]
   onAddKeys: (provider: IncompleteProvider) => void
   onDelete: (provider: IncompleteProvider) => void

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/LlmProvidersHeader.tsx
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/LlmProvidersHeader.tsx
@@ -19,7 +19,7 @@ import {
   encodeTargetValue,
 } from './default-chat-target.helpers'
 
-interface LlmProvidersHeaderProps {
+export interface LlmProvidersHeaderProps {
   providers: LlmProviderConfig[]
   agents: HarnessAgent[]
   selectedTarget: SidepanelChatTargetSelection

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/ProviderCard.tsx
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/ProviderCard.tsx
@@ -7,7 +7,7 @@ import { BrowserOSIcon, ProviderIcon } from '@/lib/llm-providers/providerIcons'
 import type { LlmProviderConfig } from '@/lib/llm-providers/types'
 import { cn } from '@/lib/utils'
 
-interface ProviderCardProps {
+export interface ProviderCardProps {
   provider: LlmProviderConfig
   isSelected: boolean
   isBuiltIn: boolean

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/ProviderTemplateCard.tsx
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/ProviderTemplateCard.tsx
@@ -4,7 +4,7 @@ import { ProviderIcon } from '@/lib/llm-providers/providerIcons'
 import type { ProviderTemplate } from '@/lib/llm-providers/providerTemplates'
 import { cn } from '@/lib/utils'
 
-interface ProviderTemplateCardProps {
+export interface ProviderTemplateCardProps {
   template: ProviderTemplate
   highlighted?: boolean
   onUseTemplate: (template: ProviderTemplate) => void

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/ProviderTemplatesSection.tsx
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/ProviderTemplatesSection.tsx
@@ -19,7 +19,7 @@ import { useCapabilities } from '@/modules/browseros/capabilities.hooks'
 import { CodingAgentTemplateCard } from './CodingAgentTemplateCard'
 import { ProviderTemplateCard } from './ProviderTemplateCard'
 
-interface ProviderTemplatesSectionProps {
+export interface ProviderTemplatesSectionProps {
   /** Coding-agent runtimes (Claude Code / Codex) shown first in the grid. */
   codingAdapters: HarnessAdapterDescriptor[]
   onCreateAgent: (adapterId: HarnessAgentAdapter) => void

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/coding-agents.hooks.ts
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/coding-agents.hooks.ts
@@ -21,7 +21,7 @@ import type { AgentListItem } from '@/modules/agents/agents-page-types'
 import { toHarnessListItem } from '@/modules/agents/agents-page-utils'
 import { clearSidepanelChatTargetSelectionForAgent } from '@/modules/chat/sidepanel-chat-targets'
 
-type AgentActivity = Record<
+export type AgentActivity = Record<
   string,
   { status: 'working' | 'idle' | 'asleep' | 'error'; lastUsedAt: number | null }
 >

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/default-chat-target.helpers.ts
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/default-chat-target.helpers.ts
@@ -4,7 +4,7 @@ import type { SidepanelChatTargetSelection } from '@/modules/chat/sidepanel-chat
 // resolves tsconfig `@/` aliases for erased type imports only, not values.
 import { resolveDefaultProviderId } from '../../lib/llm-providers/provider-selection'
 
-interface ResolveEffectiveDefaultTargetInput {
+export interface ResolveEffectiveDefaultTargetInput {
   providers: LlmProviderConfig[]
   agents: ReadonlyArray<{ id: string }>
   selection: SidepanelChatTargetSelection | null

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/default-chat-target.hooks.ts
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/default-chat-target.hooks.ts
@@ -9,7 +9,7 @@ import {
 } from '@/modules/chat/sidepanel-chat-targets'
 import { resolveEffectiveDefaultTarget } from './default-chat-target.helpers'
 
-interface UseDefaultChatTargetInput {
+export interface UseDefaultChatTargetInput {
   providers: LlmProviderConfig[]
   agents: ReadonlyArray<{ id: string }>
   defaultProviderId: string

--- a/packages/browseros-agent/apps/agent/screens/connect-mcp/AddCustomMCPDialog.tsx
+++ b/packages/browseros-agent/apps/agent/screens/connect-mcp/AddCustomMCPDialog.tsx
@@ -37,7 +37,7 @@ const formSchema = z.object({
 
 type FormValues = z.infer<typeof formSchema>
 
-interface AddCustomMCPDialogProps {
+export interface AddCustomMCPDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   onAddServer: (config: {

--- a/packages/browseros-agent/apps/agent/screens/connect-mcp/AddManagedMCPDialog.tsx
+++ b/packages/browseros-agent/apps/agent/screens/connect-mcp/AddManagedMCPDialog.tsx
@@ -11,12 +11,12 @@ import {
 } from '@/components/ui/dialog'
 import { Input } from '@/components/ui/input'
 
-interface UnauthenticatedServer {
+export interface UnauthenticatedServer {
   name: string
   description: string
 }
 
-interface AddManagedMCPDialogProps {
+export interface AddManagedMCPDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   serversList?: { name: string; description: string }[]

--- a/packages/browseros-agent/apps/agent/screens/connect-mcp/AvailableManagedServers.tsx
+++ b/packages/browseros-agent/apps/agent/screens/connect-mcp/AvailableManagedServers.tsx
@@ -8,7 +8,7 @@ import {
   CollapsibleTrigger,
 } from '@/components/ui/collapsible'
 
-interface AvailableManagedServersProps {
+export interface AvailableManagedServersProps {
   availableServers?: { name: string; description: string }[]
   onAddServer: (args: { name: string; description: string }) => void
   isLoading?: boolean

--- a/packages/browseros-agent/apps/agent/screens/jtbd-agent/SurveyChat.tsx
+++ b/packages/browseros-agent/apps/agent/screens/jtbd-agent/SurveyChat.tsx
@@ -8,7 +8,7 @@ import { useVoiceInput } from '@/modules/voice/voice.hooks'
 import type { Message } from './survey-chat.hooks'
 import { VoiceInputButton } from './VoiceInputButton'
 
-interface Props {
+export interface Props {
   messages: Message[]
   isStreaming: boolean
   onSendMessage: (text: string) => void

--- a/packages/browseros-agent/apps/agent/screens/jtbd-agent/SurveyPage.tsx
+++ b/packages/browseros-agent/apps/agent/screens/jtbd-agent/SurveyPage.tsx
@@ -7,7 +7,7 @@ import { Header } from './SurveyHeader'
 import { Welcome } from './SurveyWelcome'
 import { useChat } from './survey-chat.hooks'
 
-interface SurveyPageProps {
+export interface SurveyPageProps {
   maxTurns?: number
   experimentId?: string
 }

--- a/packages/browseros-agent/apps/agent/screens/jtbd-agent/SurveyWelcome.tsx
+++ b/packages/browseros-agent/apps/agent/screens/jtbd-agent/SurveyWelcome.tsx
@@ -2,7 +2,7 @@ import { Sparkles } from 'lucide-react'
 import type { FC } from 'react'
 import { Button } from '@/components/ui/button'
 
-interface Props {
+export interface Props {
   onStart: () => void
   isLoading?: boolean
 }

--- a/packages/browseros-agent/apps/agent/screens/jtbd-agent/VoiceInputButton.tsx
+++ b/packages/browseros-agent/apps/agent/screens/jtbd-agent/VoiceInputButton.tsx
@@ -2,7 +2,7 @@ import { Loader2, Mic, Square } from 'lucide-react'
 import type { FC } from 'react'
 import { Button } from '@/components/ui/button'
 
-interface Props {
+export interface Props {
   isRecording: boolean
   isTranscribing: boolean
   audioLevel: number

--- a/packages/browseros-agent/apps/agent/screens/llm-hub/AddHubProviderDialog.tsx
+++ b/packages/browseros-agent/apps/agent/screens/llm-hub/AddHubProviderDialog.tsx
@@ -49,7 +49,7 @@ const formSchema = z.object({
 
 type FormValues = z.infer<typeof formSchema>
 
-interface AddHubProviderDialogProps {
+export interface AddHubProviderDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   initialValues?: LlmHubProvider | null

--- a/packages/browseros-agent/apps/agent/screens/llm-hub/HubProviderRow.tsx
+++ b/packages/browseros-agent/apps/agent/screens/llm-hub/HubProviderRow.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react'
 import { Button } from '@/components/ui/button'
 import { getFaviconUrl, type LlmHubProvider } from './models'
 
-interface HubProviderRowProps {
+export interface HubProviderRowProps {
   provider: LlmHubProvider
   canDelete: boolean
   onEdit: () => void

--- a/packages/browseros-agent/apps/agent/screens/llm-hub/HubProvidersList.tsx
+++ b/packages/browseros-agent/apps/agent/screens/llm-hub/HubProvidersList.tsx
@@ -4,7 +4,7 @@ import { Button } from '@/components/ui/button'
 import { HubProviderRow } from './HubProviderRow'
 import type { LlmHubProvider } from './models'
 
-interface HubProvidersListProps {
+export interface HubProvidersListProps {
   providers: LlmHubProvider[]
   isLoading?: boolean
   onEditProvider: (index: number) => void

--- a/packages/browseros-agent/apps/agent/screens/mcp-settings/MCPServerHeader.tsx
+++ b/packages/browseros-agent/apps/agent/screens/mcp-settings/MCPServerHeader.tsx
@@ -14,7 +14,7 @@ import { track } from '@/lib/metrics/track'
 import { ServerPortEditor } from './ServerPortEditor'
 import { waitForServerHealth } from './server-health'
 
-interface MCPServerHeaderProps {
+export interface MCPServerHeaderProps {
   serverUrl: string | null
   isLoading: boolean
   error: string | null

--- a/packages/browseros-agent/apps/agent/screens/mcp-settings/MCPToolsSection.tsx
+++ b/packages/browseros-agent/apps/agent/screens/mcp-settings/MCPToolsSection.tsx
@@ -8,7 +8,7 @@ import {
 } from '@/components/ui/collapsible'
 import type { McpTool } from '@/lib/mcp/client'
 
-interface MCPToolsSectionProps {
+export interface MCPToolsSectionProps {
   tools: McpTool[]
   isLoading: boolean
   error: string | null

--- a/packages/browseros-agent/apps/agent/screens/mcp-settings/QuickSetupSection.tsx
+++ b/packages/browseros-agent/apps/agent/screens/mcp-settings/QuickSetupSection.tsx
@@ -3,7 +3,7 @@ import { type FC, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 
-interface QuickSetupSectionProps {
+export interface QuickSetupSectionProps {
   serverUrl: string | null
 }
 

--- a/packages/browseros-agent/apps/agent/screens/mcp-settings/ServerPortEditor.tsx
+++ b/packages/browseros-agent/apps/agent/screens/mcp-settings/ServerPortEditor.tsx
@@ -18,7 +18,7 @@ import { track } from '@/lib/metrics/track'
 import { waitForServerHealth } from './server-health'
 import { PROXY_PORT_MIN, parseProxyPort } from './server-port-editor.helpers'
 
-interface ServerPortEditorProps {
+export interface ServerPortEditorProps {
   onPortChanged?: () => void
 }
 

--- a/packages/browseros-agent/apps/agent/screens/newtab/index/SearchSuggestions.tsx
+++ b/packages/browseros-agent/apps/agent/screens/newtab/index/SearchSuggestions.tsx
@@ -5,10 +5,10 @@ import type { FC } from 'react'
 import { cn } from '@/lib/utils'
 import type { SuggestionItem, SuggestionSection } from './lib/suggestions/types'
 
-type GetMenuProps = ReturnType<typeof useCombobox>['getMenuProps']
-type GetItemProps = ReturnType<typeof useCombobox>['getItemProps']
+export type GetMenuProps = ReturnType<typeof useCombobox>['getMenuProps']
+export type GetItemProps = ReturnType<typeof useCombobox>['getItemProps']
 
-interface SearchSuggestionsProps {
+export interface SearchSuggestionsProps {
   getMenuProps: GetMenuProps
   getItemProps: GetItemProps
   sections: SuggestionSection[]

--- a/packages/browseros-agent/apps/agent/screens/newtab/index/ShortcutsDialog.tsx
+++ b/packages/browseros-agent/apps/agent/screens/newtab/index/ShortcutsDialog.tsx
@@ -9,7 +9,7 @@ import { Kbd, KbdGroup } from '@/components/ui/kbd'
 import { SHORTCUTS_LIST } from '@/lib/constants/shortcuts'
 import { useIsMac } from '@/lib/useIsMac'
 
-interface ShortcutsDialogProps {
+export interface ShortcutsDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
 }

--- a/packages/browseros-agent/apps/agent/screens/newtab/index/lib/search-suggestions/search-suggestions.hooks.ts
+++ b/packages/browseros-agent/apps/agent/screens/newtab/index/lib/search-suggestions/search-suggestions.hooks.ts
@@ -2,7 +2,7 @@ import { useEffect, useState } from 'react'
 import useSWR from 'swr'
 import { getSearchSuggestions } from './search-suggestions'
 
-interface UseSearchSuggestionsArgs {
+export interface UseSearchSuggestionsArgs {
   query: string
   debounceMs?: number
 }

--- a/packages/browseros-agent/apps/agent/screens/newtab/index/lib/search-suggestions/search-suggestions.ts
+++ b/packages/browseros-agent/apps/agent/screens/newtab/index/lib/search-suggestions/search-suggestions.ts
@@ -6,7 +6,10 @@ const getGoogleSuggestions = async (query: string): Promise<string[]> => {
   return data[1] || []
 }
 
-type SearchSuggestionsKey = readonly ['google-search-suggestions', string]
+export type SearchSuggestionsKey = readonly [
+  'google-search-suggestions',
+  string,
+]
 
 /**
  * Fetches new-tab search suggestions from the fixed Google provider.

--- a/packages/browseros-agent/apps/agent/screens/newtab/index/lib/suggestions/suggestions.hooks.ts
+++ b/packages/browseros-agent/apps/agent/screens/newtab/index/lib/suggestions/suggestions.hooks.ts
@@ -10,7 +10,7 @@ import type {
   SuggestionSection,
 } from './types'
 
-interface UseSuggestionsArgs {
+export interface UseSuggestionsArgs {
   query: string
   selectedTabs: chrome.tabs.Tab[]
 }

--- a/packages/browseros-agent/apps/agent/screens/newtab/index/lib/suggestions/types.ts
+++ b/packages/browseros-agent/apps/agent/screens/newtab/index/lib/suggestions/types.ts
@@ -8,7 +8,7 @@ export type SuggestionType = 'search' | 'ai-tab' | 'browseros'
 /**
  * @public
  */
-interface BaseSuggestionItem {
+export interface BaseSuggestionItem {
   id: string
 }
 

--- a/packages/browseros-agent/apps/agent/screens/newtab/layout/NewTabLayout.tsx
+++ b/packages/browseros-agent/apps/agent/screens/newtab/layout/NewTabLayout.tsx
@@ -4,7 +4,7 @@ import { ChatSessionProvider } from '@/modules/chat/chat-session-context'
 import { NewTabFocusGrid } from './NewTabFocusGrid'
 import { shouldHideFocusGrid, shouldUseChatSession } from './route-utils'
 
-interface NewTabLayoutProps {
+export interface NewTabLayoutProps {
   useChatSessionOnHome?: boolean
 }
 

--- a/packages/browseros-agent/apps/agent/screens/onboarding/features/BentoCard.tsx
+++ b/packages/browseros-agent/apps/agent/screens/onboarding/features/BentoCard.tsx
@@ -26,7 +26,7 @@ export interface Feature {
   gifUrl?: string
 }
 
-interface BentoCardProps {
+export interface BentoCardProps {
   feature: Feature
   mounted: boolean
   index: number

--- a/packages/browseros-agent/apps/agent/screens/onboarding/features/VideoFrame.tsx
+++ b/packages/browseros-agent/apps/agent/screens/onboarding/features/VideoFrame.tsx
@@ -1,7 +1,7 @@
 import type { FC, PropsWithChildren } from 'react'
 import { cn } from '@/lib/utils'
 
-interface VideoFrameProps {
+export interface VideoFrameProps {
   className?: string
   title?: string
 }

--- a/packages/browseros-agent/apps/agent/screens/onboarding/index/OnboardingHeader.tsx
+++ b/packages/browseros-agent/apps/agent/screens/onboarding/index/OnboardingHeader.tsx
@@ -3,7 +3,7 @@ import ProductLogoSvg from '@/assets/product_logo.svg'
 import { Button } from '@/components/ui/button'
 import { docsUrl, githubOrgUrl } from '@/lib/constants/productUrls'
 
-interface OnboardingHeaderProps {
+export interface OnboardingHeaderProps {
   isMounted: boolean
 }
 

--- a/packages/browseros-agent/apps/agent/screens/onboarding/steps/StepConnectApps.tsx
+++ b/packages/browseros-agent/apps/agent/screens/onboarding/steps/StepConnectApps.tsx
@@ -15,7 +15,7 @@ import { useAddManagedServer } from '@/modules/mcp/add-managed-server.hooks'
 import { useGetUserMCPIntegrations } from '@/modules/mcp/user-integrations.hooks'
 import { type StepDirection, StepTransition } from './StepTransition'
 
-interface StepConnectAppsProps {
+export interface StepConnectAppsProps {
   direction: StepDirection
   onContinue: () => void
 }

--- a/packages/browseros-agent/apps/agent/screens/onboarding/steps/StepOne.tsx
+++ b/packages/browseros-agent/apps/agent/screens/onboarding/steps/StepOne.tsx
@@ -37,7 +37,7 @@ import { personalizationStorage } from '@/lib/personalization/personalizationSto
 import { cn } from '@/lib/utils'
 import { type StepDirection, StepTransition } from './StepTransition'
 
-interface StepOneProps {
+export interface StepOneProps {
   direction: StepDirection
   onContinue: () => void
 }

--- a/packages/browseros-agent/apps/agent/screens/onboarding/steps/StepTransition.tsx
+++ b/packages/browseros-agent/apps/agent/screens/onboarding/steps/StepTransition.tsx
@@ -3,7 +3,7 @@ import type { FC, PropsWithChildren } from 'react'
 
 export type StepDirection = -1 | 1
 
-interface StepTransitionProps {
+export interface StepTransitionProps {
   direction: StepDirection
 }
 

--- a/packages/browseros-agent/apps/agent/screens/onboarding/steps/StepTwo.tsx
+++ b/packages/browseros-agent/apps/agent/screens/onboarding/steps/StepTwo.tsx
@@ -12,7 +12,7 @@ import { track } from '@/lib/metrics/track'
 import { authRedirectPathStorage } from '@/lib/onboarding/onboardingStorage'
 import { type StepDirection, StepTransition } from './StepTransition'
 
-interface StepTwoProps {
+export interface StepTwoProps {
   direction: StepDirection
   onContinue: () => void
 }

--- a/packages/browseros-agent/apps/agent/screens/scheduled-tasks/NewScheduledTaskDialog.tsx
+++ b/packages/browseros-agent/apps/agent/screens/scheduled-tasks/NewScheduledTaskDialog.tsx
@@ -86,7 +86,7 @@ const formSchema = z
 
 type FormValues = z.infer<typeof formSchema>
 
-interface NewScheduledTaskDialogProps {
+export interface NewScheduledTaskDialogProps {
   open: boolean
   onOpenChange: (open: boolean) => void
   initialValues?: ScheduledJob | null

--- a/packages/browseros-agent/apps/agent/screens/scheduled-tasks/ScheduledTaskCard.tsx
+++ b/packages/browseros-agent/apps/agent/screens/scheduled-tasks/ScheduledTaskCard.tsx
@@ -29,7 +29,7 @@ import type { ScheduledJob, ScheduledJobRun } from './types'
 dayjs.extend(relativeTime)
 dayjs.extend(duration)
 
-interface ScheduledTaskCardProps {
+export interface ScheduledTaskCardProps {
   job: ScheduledJob
   onEdit: () => void
   onDelete: () => void

--- a/packages/browseros-agent/apps/agent/screens/scheduled-tasks/ScheduledTaskResults.tsx
+++ b/packages/browseros-agent/apps/agent/screens/scheduled-tasks/ScheduledTaskResults.tsx
@@ -27,7 +27,7 @@ interface JobRunWithDetails extends ScheduledJobRun {
   job: ScheduledJob | undefined
 }
 
-interface ScheduledTaskResultsProps {
+export interface ScheduledTaskResultsProps {
   onViewRun: (run: ScheduledJobRun) => void
   onCancelRun: (runId: string) => void
   onRetryRun: (jobId: string) => void

--- a/packages/browseros-agent/apps/agent/screens/scheduled-tasks/ScheduledTasksHeader.tsx
+++ b/packages/browseros-agent/apps/agent/screens/scheduled-tasks/ScheduledTasksHeader.tsx
@@ -9,7 +9,7 @@ import {
 } from '@/components/ui/tooltip'
 import { scheduledTasksHelpUrl } from '@/lib/constants/productUrls'
 
-interface ScheduledTasksHeaderProps {
+export interface ScheduledTasksHeaderProps {
   onAddClick: () => void
 }
 

--- a/packages/browseros-agent/apps/agent/screens/scheduled-tasks/ScheduledTasksList.tsx
+++ b/packages/browseros-agent/apps/agent/screens/scheduled-tasks/ScheduledTasksList.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react'
 import { ScheduledTaskCard } from './ScheduledTaskCard'
 import type { ScheduledJob, ScheduledJobRun } from './types'
 
-interface ScheduledTasksListProps {
+export interface ScheduledTasksListProps {
   jobs: ScheduledJob[]
   onEdit: (job: ScheduledJob) => void
   onDelete: (jobId: string) => void

--- a/packages/browseros-agent/apps/agent/screens/sidepanel/history/components/ConversationGroup.tsx
+++ b/packages/browseros-agent/apps/agent/screens/sidepanel/history/components/ConversationGroup.tsx
@@ -2,7 +2,7 @@ import type { FC } from 'react'
 import { ConversationItem } from './ConversationItem'
 import type { HistoryConversation } from './types'
 
-interface ConversationGroupProps {
+export interface ConversationGroupProps {
   label: string
   conversations: HistoryConversation[]
   onDelete?: (id: string) => void

--- a/packages/browseros-agent/apps/agent/screens/sidepanel/history/components/ConversationItem.tsx
+++ b/packages/browseros-agent/apps/agent/screens/sidepanel/history/components/ConversationItem.tsx
@@ -17,7 +17,7 @@ import type { HistoryConversation } from './types'
 
 dayjs.extend(relativeTime)
 
-interface ConversationItemProps {
+export interface ConversationItemProps {
   conversation: HistoryConversation
   onDelete?: (id: string) => void
   isActive: boolean

--- a/packages/browseros-agent/apps/agent/screens/sidepanel/history/components/ConversationList.tsx
+++ b/packages/browseros-agent/apps/agent/screens/sidepanel/history/components/ConversationList.tsx
@@ -5,7 +5,7 @@ import { ConversationGroup } from './ConversationGroup'
 import type { GroupedConversations } from './types'
 import { TIME_GROUP_LABELS } from './utils'
 
-interface ConversationListProps {
+export interface ConversationListProps {
   groupedConversations: GroupedConversations
   activeConversationId: string
   onDelete?: (id: string) => void

--- a/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatAttachedTabs.tsx
+++ b/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatAttachedTabs.tsx
@@ -1,7 +1,7 @@
 import { Globe, X } from 'lucide-react'
 import type { FC } from 'react'
 
-interface ChatAttachedTabsProps {
+export interface ChatAttachedTabsProps {
   tabs: chrome.tabs.Tab[]
   onRemoveTab: (tabId?: number) => void
 }

--- a/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatEmptyState.tsx
+++ b/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatEmptyState.tsx
@@ -7,7 +7,7 @@ import {
   type ChatMode,
 } from '@/modules/chat/chat-types'
 
-interface ChatEmptyStateProps {
+export interface ChatEmptyStateProps {
   mode: ChatMode
   mounted: boolean
   onSuggestionClick: (suggestion: string) => void

--- a/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatError.tsx
+++ b/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatError.tsx
@@ -14,7 +14,7 @@ function pickRandomDirection(): string {
   return SURVEY_DIRECTIONS[Math.floor(Math.random() * SURVEY_DIRECTIONS.length)]
 }
 
-interface ChatErrorProps {
+export interface ChatErrorProps {
   error: Error
   onRetry?: () => void
   providerType?: string

--- a/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatFooter.tsx
+++ b/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatFooter.tsx
@@ -21,7 +21,7 @@ import { ChatInput, type ChatInputHandle } from './ChatInput'
 import { ChatModeToggle } from './ChatModeToggle'
 import { ChatSelectedText } from './ChatSelectedText'
 
-interface ChatFooterProps {
+export interface ChatFooterProps {
   mode: ChatMode
   onModeChange: (mode: ChatMode) => void
   input: string

--- a/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatHeader.tsx
+++ b/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatHeader.tsx
@@ -24,7 +24,7 @@ const CreditsBadgeWrapper: FC = () => {
   )
 }
 
-interface ChatHeaderProps {
+export interface ChatHeaderProps {
   selectedProvider: Provider
   providers: Provider[]
   onSelectProvider: (provider: Provider) => void

--- a/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatMessageActions.tsx
+++ b/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatMessageActions.tsx
@@ -15,7 +15,7 @@ import { Input } from '@/components/ui/input'
 import { SIDEPANEL_MESSAGE_COPIED_EVENT } from '@/lib/constants/analyticsEvents'
 import { track } from '@/lib/metrics/track'
 
-interface ChatMessageActionsProps {
+export interface ChatMessageActionsProps {
   messageId: string
   messageText: string
   liked: boolean

--- a/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatMessages.tsx
+++ b/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatMessages.tsx
@@ -25,7 +25,7 @@ import { ScheduleSuggestionCard } from './ScheduleSuggestionCard'
 import { ToolBatch } from './ToolBatch'
 import { UserActionMessage } from './UserActionMessage'
 
-interface ChatMessagesProps {
+export interface ChatMessagesProps {
   messages: UIMessage[]
   status: 'streaming' | 'submitted' | 'ready' | 'error'
   getActionForMessage?: (message: UIMessage) => ChatAction | undefined

--- a/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatModeToggle.tsx
+++ b/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatModeToggle.tsx
@@ -9,7 +9,7 @@ import {
 import { cn } from '@/lib/utils'
 import type { ChatMode } from '@/modules/chat/chat-types'
 
-interface ChatModeToggleProps {
+export interface ChatModeToggleProps {
   mode: ChatMode
   onModeChange: (mode: ChatMode) => void
 }

--- a/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatSelectedText.tsx
+++ b/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatSelectedText.tsx
@@ -4,7 +4,7 @@ import type { SelectedTextData } from '@/lib/selected-text/selectedTextStorage'
 
 const MAX_DISPLAY_LENGTH = 200
 
-interface ChatSelectedTextProps {
+export interface ChatSelectedTextProps {
   selectedText: SelectedTextData
   onDismiss: () => void
 }

--- a/packages/browseros-agent/apps/agent/screens/sidepanel/index/ConnectAppCard.tsx
+++ b/packages/browseros-agent/apps/agent/screens/sidepanel/index/ConnectAppCard.tsx
@@ -20,7 +20,7 @@ import type { NudgeData } from './getMessageSegments'
 
 type CardPhase = 'choosing' | 'oauth-pending' | 'resolved'
 
-interface ConnectAppCardProps {
+export interface ConnectAppCardProps {
   data: NudgeData
   isLastMessage: boolean
 }

--- a/packages/browseros-agent/apps/agent/screens/sidepanel/index/JtbdPopup.tsx
+++ b/packages/browseros-agent/apps/agent/screens/sidepanel/index/JtbdPopup.tsx
@@ -4,7 +4,7 @@ import { Message, MessageContent } from '@/components/ai-elements/message'
 import { Button } from '@/components/ui/button'
 import { Checkbox } from '@/components/ui/checkbox'
 
-interface JtbdPopupProps {
+export interface JtbdPopupProps {
   onTakeSurvey: (opts?: { dontShowAgain?: boolean }) => void
   onDismiss: (dontShowAgain: boolean) => void
   showDontShowAgain: boolean

--- a/packages/browseros-agent/apps/agent/screens/sidepanel/index/ScheduleSuggestionCard.tsx
+++ b/packages/browseros-agent/apps/agent/screens/sidepanel/index/ScheduleSuggestionCard.tsx
@@ -8,7 +8,7 @@ import {
 import { track } from '@/lib/metrics/track'
 import type { NudgeData } from './getMessageSegments'
 
-interface ScheduleSuggestionCardProps {
+export interface ScheduleSuggestionCardProps {
   data: NudgeData
   isLastMessage: boolean
 }

--- a/packages/browseros-agent/apps/agent/screens/sidepanel/index/ToolBatch.tsx
+++ b/packages/browseros-agent/apps/agent/screens/sidepanel/index/ToolBatch.tsx
@@ -19,7 +19,7 @@ import type {
   ToolInvocationState,
 } from './getMessageSegments'
 
-interface ToolBatchProps {
+export interface ToolBatchProps {
   tools: ToolInvocationInfo[]
   isLastBatch: boolean
   isLastMessage: boolean

--- a/packages/browseros-agent/apps/agent/screens/sidepanel/index/UserActionMessage.tsx
+++ b/packages/browseros-agent/apps/agent/screens/sidepanel/index/UserActionMessage.tsx
@@ -6,7 +6,7 @@ import type {
   ChatAction,
 } from '@/lib/chat-actions/types'
 
-interface UserActionMessageProps {
+export interface UserActionMessageProps {
   action: ChatAction
 }
 

--- a/packages/browseros-agent/apps/eval/scripts/generate-report.ts
+++ b/packages/browseros-agent/apps/eval/scripts/generate-report.ts
@@ -8,8 +8,10 @@ import { readRunMetricSummary } from '../src/reporting/task-metrics'
 export const DEFAULT_REPORT_MODEL = 'claude-opus-4-6'
 export const DEFAULT_REPORT_MAX_TURNS = 300
 
-type Env = Record<string, string | undefined>
-type ClaudeQuery = (input: unknown) => AsyncIterable<Record<string, unknown>>
+export type Env = Record<string, string | undefined>
+export type ClaudeQuery = (
+  input: unknown,
+) => AsyncIterable<Record<string, unknown>>
 
 export interface ReportAgentInvocation {
   inputDir: string
@@ -23,7 +25,7 @@ export interface GenerateEvalReportOptions {
   runAgent?: (invocation: ReportAgentInvocation) => Promise<void>
 }
 
-interface ClaudeReportAgentDeps {
+export interface ClaudeReportAgentDeps {
   query?: ClaudeQuery
   env?: Env
 }

--- a/packages/browseros-agent/apps/eval/src/capture/captcha-waiter.ts
+++ b/packages/browseros-agent/apps/eval/src/capture/captcha-waiter.ts
@@ -7,7 +7,7 @@ export interface CaptchaWaitResult {
   waitDurationMs: number
 }
 
-interface CaptchaWaiterConfig {
+export interface CaptchaWaiterConfig {
   waitTimeoutMs: number
   pollIntervalMs: number
 }

--- a/packages/browseros-agent/apps/eval/src/cli/commands/suite.ts
+++ b/packages/browseros-agent/apps/eval/src/cli/commands/suite.ts
@@ -10,7 +10,7 @@ import type { EvalSuite } from '../../suites/schema'
 import { type EvalConfig, EvalConfigSchema } from '../../types'
 import type { PublishTarget } from '../args'
 
-type Env = Record<string, string | undefined>
+export type Env = Record<string, string | undefined>
 
 export interface SuiteCommandOptions {
   configPath?: string

--- a/packages/browseros-agent/apps/eval/src/runs/task-run-pipeline.ts
+++ b/packages/browseros-agent/apps/eval/src/runs/task-run-pipeline.ts
@@ -39,7 +39,7 @@ class TaskExecutionError extends Error {
 // Task Executor
 // ============================================================================
 
-interface TaskRunPipelineDeps {
+export interface TaskRunPipelineDeps {
   onEvent?: (taskId: string, event: Record<string, unknown>) => void
 }
 
@@ -311,6 +311,8 @@ class TaskRunPipeline {
     }
   }
 }
+
+export type { TaskRunPipeline }
 
 // ============================================================================
 // Factory

--- a/packages/browseros-agent/apps/eval/src/suites/config-adapter.ts
+++ b/packages/browseros-agent/apps/eval/src/suites/config-adapter.ts
@@ -3,7 +3,7 @@ import { type EvalConfig, EvalConfigSchema } from '../types'
 import { type EvalVariant, resolveVariant } from './resolve-variant'
 import type { EvalSuite } from './schema'
 
-type Env = Record<string, string | undefined>
+export type Env = Record<string, string | undefined>
 
 export interface AdaptEvalConfigOptions {
   env?: Env

--- a/packages/browseros-agent/apps/eval/src/suites/resolve-variant.ts
+++ b/packages/browseros-agent/apps/eval/src/suites/resolve-variant.ts
@@ -1,4 +1,4 @@
-type Env = Record<string, string | undefined>
+export type Env = Record<string, string | undefined>
 
 export interface ResolveVariantOptions {
   variantId?: string

--- a/packages/browseros-agent/apps/eval/src/utils/config-validator.ts
+++ b/packages/browseros-agent/apps/eval/src/utils/config-validator.ts
@@ -1,7 +1,7 @@
 import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
 import { type EvalConfig, EvalConfigSchema } from '../types'
 
-interface ValidationResult {
+export interface ValidationResult {
   valid: boolean
   config?: EvalConfig
   errors: string[]

--- a/packages/browseros-agent/apps/server/src/agent/acp-instructions/index.ts
+++ b/packages/browseros-agent/apps/server/src/agent/acp-instructions/index.ts
@@ -4,16 +4,4 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-export {
-  type EnsureInstructionFileOptions,
-  type EnsureInstructionFileResult,
-  ensureWorkspaceInstructionFile,
-} from './ensureInstructionFile'
-export { instructionFilenameFor } from './filenames'
-export { promptHash } from './hash'
-export {
-  findManagedBlock,
-  type ManagedBlock,
-  renderManagedBlock,
-  spliceManagedBlock,
-} from './managedBlock'
+export { ensureWorkspaceInstructionFile } from './ensureInstructionFile'

--- a/packages/browseros-agent/apps/server/src/agent/compaction/content.ts
+++ b/packages/browseros-agent/apps/server/src/agent/compaction/content.ts
@@ -8,7 +8,7 @@ import type {
   UserModelMessage,
 } from 'ai'
 
-type ToolResultOutput = ToolResultPart['output']
+export type ToolResultOutput = ToolResultPart['output']
 type ToolResultContentPart = Extract<
   ToolResultOutput,
   { type: 'content' }

--- a/packages/browseros-agent/apps/server/src/api/services/klavis/strata-proxy.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/klavis/strata-proxy.ts
@@ -48,12 +48,12 @@ export interface KlavisProxyRef {
   handle: KlavisProxyHandle | null
 }
 
-interface ConnectDeps {
+export interface ConnectDeps {
   klavisClient: KlavisClient
   browserosId: string
 }
 
-interface BackgroundConnectOptions {
+export interface BackgroundConnectOptions {
   connect?: (deps: ConnectDeps) => Promise<KlavisProxyHandle>
   retryDelaysMs?: readonly number[]
 }

--- a/packages/browseros-agent/apps/server/src/api/services/screencast/screencast-manager.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/screencast/screencast-manager.ts
@@ -36,7 +36,7 @@ export type ScreencastOutboundMessage =
   | ScreencastFrameMessage
   | ScreencastStatusMessage
 
-type Subscriber = WSContext<unknown>
+export type Subscriber = WSContext<unknown>
 
 // At most one active screencast across the whole BrowserOS instance.
 // A new subscribe displaces the prior one — so frame events from

--- a/packages/browseros-agent/apps/server/src/api/utils/cors.ts
+++ b/packages/browseros-agent/apps/server/src/api/utils/cors.ts
@@ -7,7 +7,7 @@
 import type { cors } from 'hono/cors'
 import { logger } from '../../lib/logger'
 
-type CorsOptions = Parameters<typeof cors>[0]
+export type CorsOptions = Parameters<typeof cors>[0]
 
 const STATIC_ALLOWED_ORIGINS = new Set<string>([
   'chrome-extension://bflpfmnmnokmjhmgnolecpppdbdophmk',

--- a/packages/browseros-agent/apps/server/src/browser/backends/cdp.ts
+++ b/packages/browseros-agent/apps/server/src/browser/backends/cdp.ts
@@ -23,7 +23,7 @@ interface CdpVersion {
 const LOOPBACK_DISCOVERY_HOSTS = ['127.0.0.1', 'localhost', '[::1]'] as const
 type LoopbackDiscoveryHost = (typeof LOOPBACK_DISCOVERY_HOSTS)[number]
 
-interface CdpBackendConfig {
+export interface CdpBackendConfig {
   port: number
   exitOnReconnectFailure?: boolean
 }

--- a/packages/browseros-agent/apps/server/src/browser/core/input/keyboard.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/input/keyboard.ts
@@ -4,7 +4,7 @@ import type { ProtocolApi } from '@browseros/cdp-protocol/protocol-api'
 // Meta (Cmd) on macOS, Control on everything else.
 const PLATFORM_MODIFIER = platform() === 'darwin' ? 4 : 2
 
-interface KeyInfo {
+export interface KeyInfo {
   code: string
   keyCode: number | undefined
 }

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx-provider/buildBrowserOsSelfMcp.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx-provider/buildBrowserOsSelfMcp.ts
@@ -64,7 +64,3 @@ export function buildBrowserOsSelfMcpEntry(
     headers,
   }
 }
-
-export const __internal__ = {
-  BROWSEROS_SELF_MCP_NAME,
-}

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime.ts
@@ -53,7 +53,7 @@ import {
   loadLatestRuntimeState,
 } from './runtime-state'
 
-type AcpxRuntimeOptions = {
+export type AcpxRuntimeOptions = {
   cwd?: string
   browserosDir?: string
   resourcesDir?: string

--- a/packages/browseros-agent/apps/server/src/lib/agents/turns/active-turn-registry.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/turns/active-turn-registry.ts
@@ -29,12 +29,12 @@ export interface ActiveTurnInfo {
   prompt: string | null
 }
 
-interface Subscriber {
+export interface Subscriber {
   push(frame: TurnFrame): void
   end(): void
 }
 
-interface ActiveTurn {
+export interface ActiveTurn {
   turnId: string
   agentId: string
   sessionId: AgentSessionId

--- a/packages/browseros-agent/apps/server/src/tools/browser/framework.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/framework.ts
@@ -6,7 +6,7 @@ import {
   ToolResponse,
 } from '../response'
 
-type ToolInputSchema = ZodObject<ZodRawShape>
+export type ToolInputSchema = ZodObject<ZodRawShape>
 
 export interface ToolContext {
   session: BrowserSession

--- a/packages/browseros-agent/apps/server/src/tools/legacy/register.ts
+++ b/packages/browseros-agent/apps/server/src/tools/legacy/register.ts
@@ -22,7 +22,7 @@ type RegisterFn = (
   }>,
 ) => void
 
-interface LegacyToolDefaults {
+export interface LegacyToolDefaults {
   defaultWindowId?: number
   defaultTabGroupId?: string
 }

--- a/packages/browseros-agent/apps/server/src/tools/legacy/tool-registry.ts
+++ b/packages/browseros-agent/apps/server/src/tools/legacy/tool-registry.ts
@@ -26,6 +26,8 @@ class ToolRegistry {
   }
 }
 
+export type { ToolRegistry }
+
 export function createRegistry(tools: ToolDefinition[]): ToolRegistry {
   return new ToolRegistry(tools)
 }

--- a/packages/browseros-agent/apps/server/src/tools/response.ts
+++ b/packages/browseros-agent/apps/server/src/tools/response.ts
@@ -23,7 +23,7 @@ export interface ToolResult {
   structuredContent?: unknown
 }
 
-interface ToolResponseOptions {
+export interface ToolResponseOptions {
   postActionTimeoutMs?: number
 }
 

--- a/packages/browseros-agent/apps/server/tests/__fixtures__/browser-fixtures/app.ts
+++ b/packages/browseros-agent/apps/server/tests/__fixtures__/browser-fixtures/app.ts
@@ -55,7 +55,7 @@ export interface BrowserFixtureServer {
   stop(): Promise<void>
 }
 
-interface StartOptions {
+export interface StartOptions {
   port?: number
 }
 

--- a/packages/browseros-agent/apps/server/tests/__fixtures__/snapshot.ts
+++ b/packages/browseros-agent/apps/server/tests/__fixtures__/snapshot.ts
@@ -2,7 +2,7 @@
  * @license
  * Copyright 2025 BrowserOS
  */
-interface ScreenshotData {
+export interface ScreenshotData {
   html: string
 }
 

--- a/packages/browseros-agent/apps/server/tests/__helpers__/browser.ts
+++ b/packages/browseros-agent/apps/server/tests/__helpers__/browser.ts
@@ -21,7 +21,7 @@ export interface BrowserConfig {
   extraArgs: string[]
 }
 
-interface BrowserState {
+export interface BrowserState {
   process: ChildProcess
   userDataDir: string
   config: BrowserConfig

--- a/packages/browseros-agent/apps/server/tests/__helpers__/server.ts
+++ b/packages/browseros-agent/apps/server/tests/__helpers__/server.ts
@@ -19,7 +19,7 @@ export interface ServerConfig {
   extensionPort: number
 }
 
-interface ServerState {
+export interface ServerState {
   process: ChildProcess
   config: ServerConfig
 }

--- a/packages/browseros-agent/scripts/build/cli/upload.ts
+++ b/packages/browseros-agent/scripts/build/cli/upload.ts
@@ -45,7 +45,7 @@ export interface CliReleaseManifest {
   assets: Record<string, CliReleaseAsset>
 }
 
-interface CliArchiveMetadata {
+export interface CliArchiveMetadata {
   filename: string
   version: string
   os: string


### PR DESCRIPTION
## Summary
- Drives `bun run fallow` in `packages/browseros-agent/` from 234 reported issues (measured locally with codegen output present; count varies with untracked generated dirs) to **0**, with zero runtime-behavior change.
- 156 `private-type-leaks`: adds `export` to type declarations referenced by exported signatures (3 reveal rounds, 159 declarations / 136 files); `TaskRunPipeline` and `ToolRegistry` become `export type { … }` so the runtime export surface doesn't grow.
- Dead exports removed (grep-verified, 1:1 with fallow's baseline JSON): `acp-instructions` barrel trimmed to its single consumed re-export, importer-less `__internal__` aggregate deleted, four in-file-only probe interfaces un-exported.
- `.fallowrc.json`: `ignoreUnresolvedImports` for the 67 bundler-resolved specifiers (`@/assets/**`, `@/generated/graphql/**`, `@/styles/global.css` — targets fallow's own `ignorePatterns` hide from its graph) and `ignoreDependencies` for `@graphql-typed-document-node/core`, which is imported by graphql-codegen output under the ignored `generated/**` (same precedent as `@browseros/cdp-protocol`).

## Design
Config knobs over suppression comments (fallow's documented mechanisms for analyzer blind spots, not `ignorePatterns` widening), hand-deletions only where fallow + grep agree the export is dead, and a deterministic script driven by `fallow --format json` for the bulk type-visibility pass. An independent context-free review of the full range found no Critical/Important issues and re-verified the gates, including fallow=0 in a fresh-install worktree.

## Test plan
- [x] `bun run fallow` → ✓ 0 issues (1 pre-existing suppression, 0 stale)
- [x] `bun run typecheck` → exit 0 (all workspaces; requires `bun run codegen:agent` once in a fresh checkout, unchanged)
- [x] `bun run lint` → exit 0, exactly the 35 pre-existing warnings
- [x] `bun run test:main` → tools 232 pass / integration 10 pass / 0 fail (plus eval 91/91, acpx 42/42 run separately)

Note: `cd apps/agent && bun run test` can fail when a stale `.wxt/tsconfig.json` exists — pre-existing bun/WXT tsconfig interaction, present at the base commit and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)