### PR TITLE
feat(patch-cli): churn-free extract + pull/rebase-style sync for browseros-patch

### DIFF
--- a/packages/browseros/tools/patch/.gitignore
+++ b/packages/browseros/tools/patch/.gitignore
@@ -1,0 +1,2 @@
+browseros-patch
+bpatch

--- a/packages/browseros/tools/patch/Makefile
+++ b/packages/browseros/tools/patch/Makefile
@@ -19,11 +19,12 @@ ifneq ($(shell uname -s),Darwin)
 else
 	codesign --force --sign - $(PREFIX)/$(BINARY)
 endif
-	@echo "Installed $(BINARY) to $(PREFIX)/$(BINARY)"
+	ln -sf $(PREFIX)/$(BINARY) $(PREFIX)/bpatch
+	@echo "Installed $(BINARY) to $(PREFIX)/$(BINARY) (alias: bpatch)"
 
 uninstall:
-	rm -f $(PREFIX)/$(BINARY)
-	@echo "Removed $(PREFIX)/$(BINARY)"
+	rm -f $(PREFIX)/$(BINARY) $(PREFIX)/bpatch
+	@echo "Removed $(PREFIX)/$(BINARY) and $(PREFIX)/bpatch"
 
 test:
 	go test ./...

--- a/packages/browseros/tools/patch/cmd/apply.go
+++ b/packages/browseros/tools/patch/cmd/apply.go
@@ -46,7 +46,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return renderResult(result, func() {
+			if err := renderResult(result, func() {
 				fmt.Println(ui.Title(fmt.Sprintf("Applied patches to %s", ws.Name)))
 				fmt.Printf("%s  %s\n", ui.Muted("mode:"), result.Mode)
 				fmt.Printf("%s  %d\n", ui.Muted("applied:"), len(result.Applied))
@@ -58,7 +58,10 @@ func init() {
 					}
 					fmt.Println(ui.Hint(`Run "browseros-patch continue" after fixing the current conflict.`))
 				}
-			})
+			}); err != nil {
+				return err
+			}
+			return conflictPauseError(len(result.Conflicts) > 0)
 		},
 	}
 	command.Flags().StringVar(&src, "src", "", srcFlagUsage)

--- a/packages/browseros/tools/patch/cmd/common.go
+++ b/packages/browseros/tools/patch/cmd/common.go
@@ -123,7 +123,7 @@ func printStashOutcome(result *engine.ApplyResult) {
 		for _, file := range result.StashConflictFiles {
 			fmt.Printf("  %s\n", file)
 		}
-		fmt.Println(ui.Hint(`Resolve the conflict markers, then run "git stash drop" in the checkout.`))
+		fmt.Println(ui.Hint(`Resolve the conflicted files (markers, or restored content for delete conflicts), then "git stash drop" in the checkout.`))
 	}
 }
 

--- a/packages/browseros/tools/patch/cmd/common.go
+++ b/packages/browseros/tools/patch/cmd/common.go
@@ -74,6 +74,21 @@ func ensureRepoConfigured(override string) error {
 	return nil
 }
 
+// printStashOutcome reports what happened to a pending sync stash once the
+// conflict loop completes.
+func printStashOutcome(result *engine.ApplyResult) {
+	switch {
+	case result.StashRestored:
+		fmt.Println(ui.Success("Local changes rebased on top of the new patches."))
+	case result.StashConflict:
+		fmt.Println(ui.Warning("Local changes conflict with the new patches"))
+		for _, file := range result.StashConflictFiles {
+			fmt.Printf("  %s\n", file)
+		}
+		fmt.Println(ui.Hint(`Resolve the conflict markers, then run "git stash drop" in the checkout.`))
+	}
+}
+
 // commandProgress routes long-running engine updates to stderr in human mode only.
 func commandProgress(cmd *cobra.Command) engine.Progress {
 	if jsonOut {

--- a/packages/browseros/tools/patch/cmd/common.go
+++ b/packages/browseros/tools/patch/cmd/common.go
@@ -43,7 +43,8 @@ func llmTxtGuide() string {
 	return `browseros-patch quick reference for coding agents
 
 Terms:
-- patch repo: BrowserOS packages/browseros repo containing chromium_patches/.
+- patch repo: BrowserOS packages/browseros repo containing chromium_patches/ and BASE_COMMIT.
+- BASE_COMMIT: the Chromium commit every patch is diffed against (file at the patch repo root).
 - Chromium checkout: local Chromium src tree registered with a checkout name like ch1.
 - checkout name: registry alias used by commands, for example ch1.
 - --src: operate on a Chromium checkout path directly without registry lookup.
@@ -52,7 +53,42 @@ Rules:
 - Checkout commands work from anywhere when passed a checkout name: browseros-patch diff ch1.
 - browseros-patch list reads only registered Chromium checkouts; it does not inspect sync state.
 - Use browseros-patch status ch1 or browseros-patch diff ch1 before mutating.
-- Mutating commands: browseros-patch sync ch1, browseros-patch apply ch1, browseros-patch extract ch1.
+- Mutating commands: browseros-patch sync ch1 (alias: pull), browseros-patch apply ch1, browseros-patch extract ch1.
+- Every command accepts --json for machine-readable output and never prompts.
+
+Exit codes:
+- 0 = success, nothing pending.
+- 1 = error (bad input, git failure).
+- 2 = paused on a conflict; read the JSON conflict list, fix, then continue.
+
+Status fields (browseros-patch status ch1 --json):
+- needs_apply: patches in the repo not present in the checkout -> run apply or sync.
+- needs_update: checkout changes missing from the patch repo -> run extract.
+- orphaned: checkout files not represented in the patch set (untracked junk is pre-filtered).
+- pending_stash: sync parked local changes in a stash and has not restored them yet.
+
+Daily flow (pull latest patches, keep local work):
+1. browseros-patch sync ch1            # pull patch repo, apply, rebase local changes
+2. exit 2 with conflicts -> fix the file, browseros-patch continue (or browseros-patch skip / browseros-patch abort)
+3. exit 2 with stash_conflict -> resolve the conflict markers, then "git stash drop" in the checkout
+
+Capture flow (turn checkout changes into patches):
+1. browseros-patch extract ch1 --dry-run   # preview created/updated/deleted/unchanged
+2. browseros-patch extract ch1             # write; unchanged patches are never rewritten
+3. browseros-patch publish -m "chore: sync patches"   # commit + push chromium_patches
+
+Chromium upgrade loop (move patches to a new Chromium base):
+1. gclient sync the checkout to the new Chromium revision.
+2. Update the BASE_COMMIT file in the patch repo to that revision.
+3. browseros-patch apply ch1 --json    # exit 2 -> the JSON lists the conflicted file and reject path
+4. Fix the conflicted file in the checkout, then browseros-patch continue.
+   Repeat until exit 0. Use browseros-patch skip to defer one patch, browseros-patch abort to roll back.
+5. Build/verify, then browseros-patch extract ch1 and browseros-patch publish.
+
+Extraction hygiene:
+- Untracked junk (.llm/, *.log, *.rej, *.orig, .DS_Store, .browseros-patch/) is ignored automatically.
+- Add project-specific patterns to .browseros-patchignore at the patch repo root.
+- One-off: browseros-patch extract ch1 --exclude "scratch/".
 `
 }
 

--- a/packages/browseros/tools/patch/cmd/common.go
+++ b/packages/browseros/tools/patch/cmd/common.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"os"
 
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/engine"
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/repo"
@@ -89,12 +91,57 @@ func printStashOutcome(result *engine.ApplyResult) {
 	}
 }
 
+// cliProgress renders engine progress on stderr: a self-overwriting single
+// line on a TTY, plain "... message" lines otherwise.
+type cliProgress struct {
+	w      io.Writer
+	tty    bool
+	active bool
+}
+
+// activeProgress lets renderResult clear a pending ephemeral line before
+// printing results (package-global like jsonOut/appState).
+var activeProgress *cliProgress
+
+func (p *cliProgress) Step(message string) {
+	if p == nil {
+		return
+	}
+	if p.tty {
+		fmt.Fprintf(p.w, "\r\x1b[2K%s %s", ui.Muted("..."), message)
+		p.active = true
+		return
+	}
+	fmt.Fprintf(p.w, "%s %s\n", ui.Muted("..."), message)
+}
+
+// Finish clears the in-place progress line so the next write starts clean.
+func (p *cliProgress) Finish() {
+	if p == nil || !p.active {
+		return
+	}
+	fmt.Fprint(p.w, "\r\x1b[2K")
+	p.active = false
+}
+
+func isTerminal(w io.Writer) bool {
+	file, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
+}
+
 // commandProgress routes long-running engine updates to stderr in human mode only.
 func commandProgress(cmd *cobra.Command) engine.Progress {
 	if jsonOut {
 		return nil
 	}
-	return engine.ProgressFunc(func(message string) {
-		fmt.Fprintf(cmd.ErrOrStderr(), "%s %s\n", ui.Muted("..."), message)
-	})
+	stderr := cmd.ErrOrStderr()
+	activeProgress = &cliProgress{w: stderr, tty: isTerminal(stderr)}
+	return activeProgress
 }

--- a/packages/browseros/tools/patch/cmd/common_test.go
+++ b/packages/browseros/tools/patch/cmd/common_test.go
@@ -312,6 +312,21 @@ func TestLLMTxtGuideContent(t *testing.T) {
 		"browseros-patch extract ch1",
 		"list reads only registered Chromium checkouts",
 		"does not inspect sync state",
+		// agent playbook
+		"Exit codes",
+		"0 = success",
+		"1 = error",
+		"2 = paused on a conflict",
+		"browseros-patch continue",
+		"browseros-patch skip",
+		"browseros-patch abort",
+		"browseros-patch extract ch1 --dry-run",
+		".browseros-patchignore",
+		"BASE_COMMIT",
+		"browseros-patch publish",
+		"pull",
+		"Chromium upgrade loop",
+		"--json",
 	} {
 		if !strings.Contains(text, want) {
 			t.Fatalf("expected llm txt to contain %q, got:\n%s", want, text)

--- a/packages/browseros/tools/patch/cmd/common_test.go
+++ b/packages/browseros/tools/patch/cmd/common_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -44,6 +45,23 @@ func TestCommandProgressDisabledForJSON(t *testing.T) {
 
 	if progress := commandProgress(&cobra.Command{}); progress != nil {
 		t.Fatalf("expected nil progress reporter in JSON mode")
+	}
+}
+
+func TestConflictPauseErrorClassification(t *testing.T) {
+	if err := conflictPauseError(false); err != nil {
+		t.Fatalf("clean result must exit 0, got %v", err)
+	}
+	err := conflictPauseError(true)
+	if err == nil {
+		t.Fatalf("paused result must return the exit sentinel")
+	}
+	var exitErr *exitCodeError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected exitCodeError, got %T", err)
+	}
+	if exitErr.code != 2 {
+		t.Fatalf("conflict pause exit code = %d, want 2", exitErr.code)
 	}
 }
 

--- a/packages/browseros/tools/patch/cmd/common_test.go
+++ b/packages/browseros/tools/patch/cmd/common_test.go
@@ -48,6 +48,36 @@ func TestCommandProgressDisabledForJSON(t *testing.T) {
 	}
 }
 
+func TestCLIProgressTTYRewritesSingleLine(t *testing.T) {
+	var buf bytes.Buffer
+	progress := &cliProgress{w: &buf, tty: true}
+	progress.Step("Applying 1/342 chrome/a.cc")
+	progress.Step("Applying 2/342 chrome/b.cc")
+
+	output := buf.String()
+	if strings.Contains(output, "\n") {
+		t.Fatalf("tty progress must not emit newlines between steps, got %q", output)
+	}
+	if strings.Count(output, "\r") < 2 {
+		t.Fatalf("tty progress should rewrite the line per step, got %q", output)
+	}
+	if !strings.Contains(output, "Applying 2/342 chrome/b.cc") {
+		t.Fatalf("expected latest step in output, got %q", output)
+	}
+
+	progress.Finish()
+	if !strings.HasSuffix(buf.String(), "\x1b[2K") {
+		t.Fatalf("Finish should clear the pending line, got %q", buf.String())
+	}
+	progress.Finish() // idempotent
+}
+
+func TestCLIProgressNilSafe(t *testing.T) {
+	var progress *cliProgress
+	progress.Step("ignored")
+	progress.Finish()
+}
+
 func TestConflictPauseErrorClassification(t *testing.T) {
 	if err := conflictPauseError(false); err != nil {
 		t.Fatalf("clean result must exit 0, got %v", err)

--- a/packages/browseros/tools/patch/cmd/continue.go
+++ b/packages/browseros/tools/patch/cmd/continue.go
@@ -27,7 +27,7 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return renderResult(result, func() {
+			if err := renderResult(result, func() {
 				fmt.Println(ui.Success(fmt.Sprintf("Advanced conflict resolution for %s", ws.Name)))
 				if len(result.Conflicts) > 0 {
 					fmt.Println(ui.Warning("Next conflict"))
@@ -35,7 +35,11 @@ func init() {
 						fmt.Printf("  %s\n", conflict.ChromiumPath)
 					}
 				}
-			})
+				printStashOutcome(result)
+			}); err != nil {
+				return err
+			}
+			return conflictPauseError(len(result.Conflicts) > 0 || result.StashConflict)
 		},
 	}
 	rootCmd.AddCommand(command)

--- a/packages/browseros/tools/patch/cmd/extract.go
+++ b/packages/browseros/tools/patch/cmd/extract.go
@@ -14,6 +14,8 @@ func init() {
 	var rangeMode bool
 	var squash bool
 	var base string
+	var dryRun bool
+	var excludes []string
 	command := &cobra.Command{
 		Use:         "extract [checkout] [--range <start> <end>] [-- files...]",
 		Annotations: map[string]string{"group": "Core:"},
@@ -55,16 +57,31 @@ func init() {
 				Squash:     squash,
 				Base:       base,
 				Filters:    filters,
+				Excludes:   excludes,
+				DryRun:     dryRun,
 				Progress:   commandProgress(cmd),
 			})
 			if err != nil {
 				return err
 			}
 			return renderResult(result, func() {
-				fmt.Println(ui.Title(fmt.Sprintf("Extracted patches from %s", ws.Name)))
+				title := fmt.Sprintf("Extracted patches from %s", ws.Name)
+				if result.DryRun {
+					title = fmt.Sprintf("Extract preview for %s (dry run)", ws.Name)
+				}
+				fmt.Println(ui.Title(title))
 				fmt.Printf("%s  %s\n", ui.Muted("mode:"), result.Mode)
-				fmt.Printf("%s  %d\n", ui.Muted("written:"), len(result.Written))
+				fmt.Printf("%s  %d (%d new, %d updated)\n", ui.Muted("written:"), len(result.Written), len(result.Created), len(result.Updated))
+				fmt.Printf("%s  %d\n", ui.Muted("unchanged:"), len(result.Unchanged))
 				fmt.Printf("%s  %d\n", ui.Muted("deleted:"), len(result.Deleted))
+				if result.DryRun {
+					printGroup("Would create", result.Created)
+					printGroup("Would update", result.Updated)
+					printGroup("Would delete", result.Deleted)
+				}
+				if len(result.Written) == 0 && len(result.Deleted) == 0 && !result.DryRun {
+					fmt.Println(ui.Hint("Patch repo already matches this checkout — nothing rewritten."))
+				}
 			})
 		},
 	}
@@ -73,5 +90,7 @@ func init() {
 	command.Flags().BoolVar(&rangeMode, "range", false, "Extract from a commit range")
 	command.Flags().BoolVar(&squash, "squash", false, "Squash a range into a cumulative diff")
 	command.Flags().StringVar(&base, "base", "", "Override BASE_COMMIT for extraction")
+	command.Flags().BoolVar(&dryRun, "dry-run", false, "Preview what would be written without touching the patch repo")
+	command.Flags().StringArrayVar(&excludes, "exclude", nil, "Extra ignore pattern for untracked files (repeatable)")
 	rootCmd.AddCommand(command)
 }

--- a/packages/browseros/tools/patch/cmd/extract.go
+++ b/packages/browseros/tools/patch/cmd/extract.go
@@ -91,6 +91,6 @@ func init() {
 	command.Flags().BoolVar(&squash, "squash", false, "Squash a range into a cumulative diff")
 	command.Flags().StringVar(&base, "base", "", "Override BASE_COMMIT for extraction")
 	command.Flags().BoolVar(&dryRun, "dry-run", false, "Preview what would be written without touching the patch repo")
-	command.Flags().StringArrayVar(&excludes, "exclude", nil, "Extra ignore pattern for untracked files (repeatable)")
+	command.Flags().StringArrayVar(&excludes, "exclude", nil, "Extra ignore pattern for untracked files; also removes previously extracted patches matching it (repeatable)")
 	rootCmd.AddCommand(command)
 }

--- a/packages/browseros/tools/patch/cmd/root.go
+++ b/packages/browseros/tools/patch/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -133,8 +134,35 @@ func init() {
 	rootCmd.CompletionOptions.DisableDefaultCmd = true
 }
 
+// exitCodeError carries a specific process exit code; Execute exits with it
+// silently because the command already rendered its result.
+type exitCodeError struct {
+	code int
+}
+
+func (e *exitCodeError) Error() string {
+	return fmt.Sprintf("exit status %d", e.code)
+}
+
+// errConflictPause is the exit-2 sentinel for operations that paused on a
+// conflict and need a human or agent before continuing.
+var errConflictPause = &exitCodeError{code: 2}
+
+// conflictPauseError converts "did this operation pause on conflicts?" into
+// the sentinel returned after rendering.
+func conflictPauseError(paused bool) error {
+	if paused {
+		return errConflictPause
+	}
+	return nil
+}
+
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
+		var exitErr *exitCodeError
+		if errors.As(err, &exitErr) {
+			os.Exit(exitErr.code)
+		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}

--- a/packages/browseros/tools/patch/cmd/root.go
+++ b/packages/browseros/tools/patch/cmd/root.go
@@ -159,6 +159,7 @@ func conflictPauseError(paused bool) error {
 
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
+		activeProgress.Finish()
 		var exitErr *exitCodeError
 		if errors.As(err, &exitErr) {
 			os.Exit(exitErr.code)

--- a/packages/browseros/tools/patch/cmd/root.go
+++ b/packages/browseros/tools/patch/cmd/root.go
@@ -169,6 +169,7 @@ func Execute() {
 }
 
 func renderResult(data any, human func()) error {
+	activeProgress.Finish()
 	if jsonOut {
 		encoder := json.NewEncoder(os.Stdout)
 		encoder.SetIndent("", "  ")

--- a/packages/browseros/tools/patch/cmd/skip.go
+++ b/packages/browseros/tools/patch/cmd/skip.go
@@ -27,9 +27,19 @@ func init() {
 			if err != nil {
 				return err
 			}
-			return renderResult(result, func() {
+			if err := renderResult(result, func() {
 				fmt.Println(ui.Warning(fmt.Sprintf("Skipped current conflict in %s", ws.Name)))
-			})
+				if len(result.Conflicts) > 0 {
+					fmt.Println(ui.Warning("Next conflict"))
+					for _, conflict := range result.Conflicts {
+						fmt.Printf("  %s\n", conflict.ChromiumPath)
+					}
+				}
+				printStashOutcome(result)
+			}); err != nil {
+				return err
+			}
+			return conflictPauseError(len(result.Conflicts) > 0 || result.StashConflict)
 		},
 	}
 	rootCmd.AddCommand(command)

--- a/packages/browseros/tools/patch/cmd/status.go
+++ b/packages/browseros/tools/patch/cmd/status.go
@@ -2,22 +2,44 @@ package cmd
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/engine"
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/ui"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/workspace"
 	"github.com/spf13/cobra"
 )
 
+// syncStateHints turns the terse sync_state enum into a one-line explanation
+// for humans; JSON values stay untouched for agents.
+var syncStateHints = map[string]string{
+	"never-synced":  "registered, but no sync has been recorded by this tool yet — apply/extract may still have happened (see last apply/extract)",
+	"needs-sync":    "the patch repo moved since the last sync of this checkout",
+	"drifted":       "the patch repo has patches this checkout is missing",
+	"local-changes": "this checkout has changes the patch repo does not capture yet",
+	"conflicted":    `a patch application is paused on a conflict — fix it, then run "browseros-patch continue"`,
+}
+
 func init() {
 	var src string
+	var summary bool
+	var all bool
 	command := &cobra.Command{
 		Use:         "status [checkout]",
 		Annotations: map[string]string{"group": "Core:"},
 		Short:       "Show checkout sync state",
 		Example: `  browseros-patch status ch1
+  browseros-patch status ch1 --summary
+  browseros-patch status --all
   browseros-patch status --src /path/to/chromium/src`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if all {
+				if len(args) > 0 || src != "" {
+					return fmt.Errorf("--all inspects every registered checkout; drop the checkout argument")
+				}
+				return runStatusAll(cmd)
+			}
 			ws, err := resolveWorkspace(cmd, args, src)
 			if err != nil {
 				return err
@@ -36,16 +58,98 @@ func init() {
 			}
 			return renderResult(status, func() {
 				fmt.Println(ui.Title(fmt.Sprintf("%s (%s)", ws.Name, status.SyncState)))
+				if hint, ok := syncStateHints[status.SyncState]; ok {
+					fmt.Println(ui.Hint(hint))
+				}
 				fmt.Printf("%s  %s\n", ui.Muted("path:"), ws.Path)
 				fmt.Printf("%s  %s\n", ui.Muted("repo head:"), status.RepoHead)
 				fmt.Printf("%s  %s\n", ui.Muted("last sync:"), status.LastSyncRev)
 				fmt.Printf("%s  %s\n", ui.Muted("last apply:"), status.LastApplyRev)
+				fmt.Printf("%s  %s\n", ui.Muted("last extract:"), status.LastExtractRev)
 				fmt.Printf("%s  %d\n", ui.Muted("needs apply:"), len(status.NeedsApply))
 				fmt.Printf("%s  %d\n", ui.Muted("needs update:"), len(status.NeedsUpdate))
 				fmt.Printf("%s  %d\n", ui.Muted("orphaned:"), len(status.Orphaned))
+				if status.PendingStash != "" {
+					fmt.Printf("%s  %s %s\n", ui.Muted("pending stash:"), status.PendingStash, ui.Hint("(local changes parked by sync)"))
+				}
+				if summary && len(status.Orphaned) > 0 {
+					fmt.Println(ui.Header("Orphaned by directory:"))
+					for _, group := range engine.OrphanSummary(status.Orphaned) {
+						fmt.Printf("  %-24s %d\n", group.Dir, group.Count)
+					}
+				}
+				if status.InSyncButUnreproducible() {
+					fmt.Println(ui.Warning("Patch state is in sync, but orphaned files exist — a fresh checkout may not reproduce this workspace."))
+				}
 			})
 		},
 	}
 	command.Flags().StringVar(&src, "src", "", srcFlagUsage)
+	command.Flags().BoolVar(&summary, "summary", false, "Group orphaned files by top-level directory")
+	command.Flags().BoolVar(&all, "all", false, "Show a one-line summary for every registered checkout")
 	rootCmd.AddCommand(command)
+}
+
+// statusRow is the compact per-checkout shape used by status --all.
+type statusRow struct {
+	Workspace    string `json:"workspace"`
+	Path         string `json:"path"`
+	SyncState    string `json:"sync_state,omitempty"`
+	NeedsApply   int    `json:"needs_apply"`
+	NeedsUpdate  int    `json:"needs_update"`
+	Orphaned     int    `json:"orphaned"`
+	PendingStash bool   `json:"pending_stash"`
+	Error        string `json:"error,omitempty"`
+}
+
+func runStatusAll(cmd *cobra.Command) error {
+	info, err := repoInfo()
+	if err != nil {
+		return err
+	}
+	if len(appState.Registry.Workspaces) == 0 {
+		return fmt.Errorf(`no Chromium checkouts registered; run "browseros-patch add <name> <path>" first`)
+	}
+	rows := make([]statusRow, 0, len(appState.Registry.Workspaces))
+	for _, entry := range appState.Registry.Workspaces {
+		row := statusRow{Workspace: entry.Name, Path: entry.Path}
+		status, err := engine.InspectWorkspace(cmd.Context(), engine.InspectWorkspaceOptions{
+			Workspace: workspace.Entry{Name: entry.Name, Path: entry.Path},
+			Repo:      info,
+			Progress:  commandProgress(cmd),
+		})
+		if err != nil {
+			row.Error = err.Error()
+		} else {
+			row.SyncState = status.SyncState
+			row.NeedsApply = len(status.NeedsApply)
+			row.NeedsUpdate = len(status.NeedsUpdate)
+			row.Orphaned = len(status.Orphaned)
+			row.PendingStash = status.PendingStash != ""
+		}
+		rows = append(rows, row)
+	}
+	return renderResult(rows, func() {
+		headers := []string{"NAME", "STATE", "APPLY", "UPDATE", "ORPHANED", "STASH"}
+		tableRows := make([][]string, 0, len(rows))
+		for _, row := range rows {
+			if row.Error != "" {
+				tableRows = append(tableRows, []string{row.Workspace, "error: " + row.Error, "-", "-", "-", "-"})
+				continue
+			}
+			stash := ""
+			if row.PendingStash {
+				stash = "yes"
+			}
+			tableRows = append(tableRows, []string{
+				row.Workspace,
+				row.SyncState,
+				strconv.Itoa(row.NeedsApply),
+				strconv.Itoa(row.NeedsUpdate),
+				strconv.Itoa(row.Orphaned),
+				stash,
+			})
+		}
+		fmt.Println(ui.RenderTable(headers, tableRows))
+	})
 }

--- a/packages/browseros/tools/patch/cmd/status.go
+++ b/packages/browseros/tools/patch/cmd/status.go
@@ -91,6 +91,7 @@ func init() {
 }
 
 // statusRow is the compact per-checkout shape used by status --all.
+// pending_stash carries the same string ref as the single-checkout status.
 type statusRow struct {
 	Workspace    string `json:"workspace"`
 	Path         string `json:"path"`
@@ -98,7 +99,7 @@ type statusRow struct {
 	NeedsApply   int    `json:"needs_apply"`
 	NeedsUpdate  int    `json:"needs_update"`
 	Orphaned     int    `json:"orphaned"`
-	PendingStash bool   `json:"pending_stash"`
+	PendingStash string `json:"pending_stash,omitempty"`
 	Error        string `json:"error,omitempty"`
 }
 
@@ -125,7 +126,7 @@ func runStatusAll(cmd *cobra.Command) error {
 			row.NeedsApply = len(status.NeedsApply)
 			row.NeedsUpdate = len(status.NeedsUpdate)
 			row.Orphaned = len(status.Orphaned)
-			row.PendingStash = status.PendingStash != ""
+			row.PendingStash = status.PendingStash
 		}
 		rows = append(rows, row)
 	}
@@ -138,7 +139,7 @@ func runStatusAll(cmd *cobra.Command) error {
 				continue
 			}
 			stash := ""
-			if row.PendingStash {
+			if row.PendingStash != "" {
 				stash = "yes"
 			}
 			tableRows = append(tableRows, []string{

--- a/packages/browseros/tools/patch/cmd/sync.go
+++ b/packages/browseros/tools/patch/cmd/sync.go
@@ -11,12 +11,16 @@ import (
 func init() {
 	var src string
 	var rebase bool
+	var noRebase bool
 	var remote string
 	command := &cobra.Command{
 		Use:         "sync [checkout]",
+		Aliases:     []string{"pull"},
 		Annotations: map[string]string{"group": "Core:"},
-		Short:       "Sync a checkout with the latest patch repo state",
+		Short:       "Pull the latest patches and rebase local changes onto them",
 		Example: `  browseros-patch sync ch1
+  browseros-patch pull ch1
+  browseros-patch sync ch1 --no-rebase
   browseros-patch sync --src /path/to/chromium/src`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -32,30 +36,46 @@ func init() {
 				Workspace: ws,
 				Repo:      info,
 				Remote:    remote,
-				Rebase:    rebase,
+				Rebase:    !noRebase,
 				Progress:  commandProgress(cmd),
 			})
 			if err != nil {
 				return err
 			}
-			return renderResult(result, func() {
+			if err := renderResult(result, func() {
 				fmt.Println(ui.Title(fmt.Sprintf("Synced %s", ws.Name)))
 				fmt.Printf("%s  %s\n", ui.Muted("repo head:"), result.RepoHead)
 				fmt.Printf("%s  %d\n", ui.Muted("applied:"), len(result.Applied))
-				if result.StashRef != "" {
+				switch {
+				case result.StashRestored:
+					fmt.Println(ui.Success("Local changes rebased on top of the new patches."))
+				case result.StashConflict:
+					fmt.Println(ui.Warning("Local changes conflict with the new patches"))
+					for _, file := range result.StashConflictFiles {
+						fmt.Printf("  %s\n", file)
+					}
+					fmt.Println(ui.Hint(`Resolve the conflict markers, then run "git stash drop" in the checkout.`))
+				case result.StashRef != "":
 					fmt.Printf("%s  %s\n", ui.Muted("stash:"), result.StashRef)
+					fmt.Println(ui.Hint("Local changes are parked in the stash (--no-rebase)."))
 				}
 				if len(result.Conflicts) > 0 {
 					fmt.Println(ui.Warning("Conflicts detected"))
 					for _, conflict := range result.Conflicts {
 						fmt.Printf("  %s\n", conflict)
 					}
+					fmt.Println(ui.Hint(`Run "browseros-patch continue" after fixing the current conflict.`))
 				}
-			})
+			}); err != nil {
+				return err
+			}
+			return conflictPauseError(len(result.Conflicts) > 0 || result.StashConflict)
 		},
 	}
 	command.Flags().StringVar(&src, "src", "", srcFlagUsage)
-	command.Flags().BoolVar(&rebase, "rebase", false, "Re-apply stashed local changes after syncing")
+	command.Flags().BoolVar(&rebase, "rebase", true, "Re-apply stashed local changes after syncing")
+	command.Flags().BoolVar(&noRebase, "no-rebase", false, "Leave local changes parked in the stash instead of rebasing them")
+	_ = command.Flags().MarkDeprecated("rebase", "rebasing is now the default; use --no-rebase to opt out")
 	command.Flags().StringVar(&remote, "remote", "origin", "Remote to pull from")
 	rootCmd.AddCommand(command)
 }

--- a/packages/browseros/tools/patch/cmd/sync.go
+++ b/packages/browseros/tools/patch/cmd/sync.go
@@ -54,7 +54,7 @@ func init() {
 					for _, file := range result.StashConflictFiles {
 						fmt.Printf("  %s\n", file)
 					}
-					fmt.Println(ui.Hint(`Resolve the conflict markers, then run "git stash drop" in the checkout.`))
+					fmt.Println(ui.Hint(`Resolve the conflicted files (markers, or restored content for delete conflicts), then "git stash drop" in the checkout.`))
 				case result.StashRef != "":
 					fmt.Printf("%s  %s\n", ui.Muted("stash:"), result.StashRef)
 					fmt.Println(ui.Hint("Local changes are parked in the stash (--no-rebase)."))

--- a/packages/browseros/tools/patch/cmd/sync.go
+++ b/packages/browseros/tools/patch/cmd/sync.go
@@ -36,14 +36,18 @@ func init() {
 				Workspace: ws,
 				Repo:      info,
 				Remote:    remote,
-				Rebase:    !noRebase,
+				Rebase:    rebase && !noRebase,
 				Progress:  commandProgress(cmd),
 			})
 			if err != nil {
 				return err
 			}
 			if err := renderResult(result, func() {
-				fmt.Println(ui.Title(fmt.Sprintf("Synced %s", ws.Name)))
+				if result.StashConflict || len(result.Conflicts) > 0 {
+					fmt.Println(ui.Warning(fmt.Sprintf("Sync paused for %s", ws.Name)))
+				} else {
+					fmt.Println(ui.Title(fmt.Sprintf("Synced %s", ws.Name)))
+				}
 				fmt.Printf("%s  %s\n", ui.Muted("repo head:"), result.RepoHead)
 				fmt.Printf("%s  %d\n", ui.Muted("applied:"), len(result.Applied))
 				switch {

--- a/packages/browseros/tools/patch/internal/engine/apply.go
+++ b/packages/browseros/tools/patch/internal/engine/apply.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,14 +28,17 @@ type ApplyOptions struct {
 }
 
 type ApplyResult struct {
-	Workspace  string              `json:"workspace"`
-	Mode       string              `json:"mode"`
-	BaseCommit string              `json:"base_commit"`
-	RepoRev    string              `json:"repo_rev"`
-	Applied    []string            `json:"applied"`
-	ResetPaths []string            `json:"reset_paths"`
-	Orphaned   []string            `json:"orphaned,omitempty"`
-	Conflicts  []resolve.Operation `json:"conflicts,omitempty"`
+	Workspace          string              `json:"workspace"`
+	Mode               string              `json:"mode"`
+	BaseCommit         string              `json:"base_commit"`
+	RepoRev            string              `json:"repo_rev"`
+	Applied            []string            `json:"applied"`
+	ResetPaths         []string            `json:"reset_paths"`
+	Orphaned           []string            `json:"orphaned,omitempty"`
+	StashRestored      bool                `json:"stash_restored,omitempty"`
+	StashConflict      bool                `json:"stash_conflict,omitempty"`
+	StashConflictFiles []string            `json:"stash_conflict_files,omitempty"`
+	Conflicts          []resolve.Operation `json:"conflicts,omitempty"`
 }
 
 func Apply(ctx context.Context, opts ApplyOptions) (*ApplyResult, error) {
@@ -124,6 +128,9 @@ func Continue(ctx context.Context, opts ContinueOptions) (*ApplyResult, error) {
 		if err := resolve.Delete(ws.Path); err != nil {
 			return nil, err
 		}
+		if err := restorePendingStash(ctx, ws.Path, result, opts.Progress); err != nil {
+			return nil, err
+		}
 	}
 	return result, nil
 }
@@ -168,8 +175,38 @@ func Skip(ctx context.Context, opts SkipOptions) (*ApplyResult, error) {
 		if err := resolve.Delete(ws.Path); err != nil {
 			return nil, err
 		}
+		if err := restorePendingStash(ctx, ws.Path, result, opts.Progress); err != nil {
+			return nil, err
+		}
 	}
 	return result, nil
+}
+
+// restorePendingStash pops a stash a conflicted sync left behind once the
+// last operation completes, so the rebase loop ends with local changes back
+// in the tree. A pop conflict keeps the stash pending and is reported on the
+// result instead of failing.
+func restorePendingStash(ctx context.Context, workspacePath string, result *ApplyResult, progress Progress) error {
+	state, err := workspace.LoadState(workspacePath)
+	if err != nil {
+		return err
+	}
+	if state.PendingStash == "" {
+		return nil
+	}
+	reportProgress(progress, "Rebasing stashed local changes")
+	if err := git.StashRebase(ctx, workspacePath, state.PendingStash); err != nil {
+		var conflict *git.StashConflictError
+		if !errors.As(err, &conflict) {
+			return err
+		}
+		result.StashConflict = true
+		result.StashConflictFiles = conflict.Files
+		return nil
+	}
+	result.StashRestored = true
+	state.PendingStash = ""
+	return workspace.SaveState(workspacePath, state)
 }
 
 func Abort(ctx context.Context, ws workspace.Entry) error {

--- a/packages/browseros/tools/patch/internal/engine/apply.go
+++ b/packages/browseros/tools/patch/internal/engine/apply.go
@@ -196,6 +196,10 @@ func restorePendingStash(ctx context.Context, workspacePath string, result *Appl
 	}
 	reportProgress(progress, "Rebasing stashed local changes")
 	if err := git.StashRebase(ctx, workspacePath, state.PendingStash); err != nil {
+		if errors.Is(err, git.ErrStashNotFound) {
+			state.PendingStash = ""
+			return workspace.SaveState(workspacePath, state)
+		}
 		var conflict *git.StashConflictError
 		if !errors.As(err, &conflict) {
 			return err

--- a/packages/browseros/tools/patch/internal/engine/apply.go
+++ b/packages/browseros/tools/patch/internal/engine/apply.go
@@ -223,7 +223,16 @@ func buildApplyOperations(ctx context.Context, opts ApplyOptions) ([]resolve.Ope
 		}
 		return operationsFromChanges(repoSet, changes, opts.Filters), nil, nil
 	default:
-		localSet, err := patch.BuildWorkingTreePatchSet(ctx, opts.Workspace.Path, opts.Repo.BaseCommit, opts.Filters)
+		ignore, err := patch.LoadIgnoreSet(opts.Repo.Root, nil)
+		if err != nil {
+			return nil, nil, err
+		}
+		localSet, err := patch.BuildWorkingTreePatchSet(ctx, opts.Workspace.Path, patch.WorkingTreeOptions{
+			Base:    opts.Repo.BaseCommit,
+			Filters: opts.Filters,
+			Ignore:  ignore,
+			Report:  func(message string) { reportProgress(opts.Progress, "%s", message) },
+		})
 		if err != nil {
 			return nil, nil, err
 		}
@@ -338,7 +347,10 @@ func verifyResolved(ctx context.Context, workspacePath string, repoInfo *repo.In
 	if err != nil {
 		return err
 	}
-	localSet, err := patch.BuildWorkingTreePatchSet(ctx, workspacePath, base, []string{op.ChromiumPath})
+	localSet, err := patch.BuildWorkingTreePatchSet(ctx, workspacePath, patch.WorkingTreeOptions{
+		Base:    base,
+		Filters: []string{op.ChromiumPath},
+	})
 	if err != nil {
 		return err
 	}

--- a/packages/browseros/tools/patch/internal/engine/apply.go
+++ b/packages/browseros/tools/patch/internal/engine/apply.go
@@ -24,7 +24,10 @@ type ApplyOptions struct {
 	RangeEnd   string
 	Filters    []string
 	Mode       string
-	Progress   Progress
+	// RestorePendingStash carries a rebase-mode sync's intent through a
+	// conflict pause: continue/skip restore the parked stash on completion.
+	RestorePendingStash bool
+	Progress            Progress
 }
 
 type ApplyResult struct {
@@ -68,7 +71,7 @@ func Apply(ctx context.Context, opts ApplyOptions) (*ApplyResult, error) {
 		}
 		return result, nil
 	}
-	next, err := applyOperationRange(ctx, opts.Workspace, opts.Repo, ops, 0, nil, nil, result, opts.Progress)
+	next, err := applyOperationRange(ctx, opts.Workspace, opts.Repo, ops, 0, nil, nil, opts.RestorePendingStash, result, opts.Progress)
 	if err != nil {
 		return nil, err
 	}
@@ -117,7 +120,7 @@ func Continue(ctx context.Context, opts ContinueOptions) (*ApplyResult, error) {
 		Conflicts:  nil,
 	}
 	reportProgress(opts.Progress, "Continuing patch resolution")
-	next, err := applyOperationRange(ctx, ws, repoInfo, state.Operations, state.Current+1, state.Resolved, state.Skipped, result, opts.Progress)
+	next, err := applyOperationRange(ctx, ws, repoInfo, state.Operations, state.Current+1, state.Resolved, state.Skipped, state.RestorePendingStash, result, opts.Progress)
 	if err != nil {
 		return nil, err
 	}
@@ -128,8 +131,10 @@ func Continue(ctx context.Context, opts ContinueOptions) (*ApplyResult, error) {
 		if err := resolve.Delete(ws.Path); err != nil {
 			return nil, err
 		}
-		if err := restorePendingStash(ctx, ws.Path, result, opts.Progress); err != nil {
-			return nil, err
+		if state.RestorePendingStash {
+			if err := restorePendingStash(ctx, ws.Path, result, opts.Progress); err != nil {
+				return nil, err
+			}
 		}
 	}
 	return result, nil
@@ -164,7 +169,7 @@ func Skip(ctx context.Context, opts SkipOptions) (*ApplyResult, error) {
 		Applied:    append([]string{}, state.Resolved...),
 	}
 	reportProgress(opts.Progress, "Skipping current conflict")
-	next, err := applyOperationRange(ctx, ws, repoInfo, state.Operations, state.Current+1, state.Resolved, state.Skipped, result, opts.Progress)
+	next, err := applyOperationRange(ctx, ws, repoInfo, state.Operations, state.Current+1, state.Resolved, state.Skipped, state.RestorePendingStash, result, opts.Progress)
 	if err != nil {
 		return nil, err
 	}
@@ -175,8 +180,10 @@ func Skip(ctx context.Context, opts SkipOptions) (*ApplyResult, error) {
 		if err := resolve.Delete(ws.Path); err != nil {
 			return nil, err
 		}
-		if err := restorePendingStash(ctx, ws.Path, result, opts.Progress); err != nil {
-			return nil, err
+		if state.RestorePendingStash {
+			if err := restorePendingStash(ctx, ws.Path, result, opts.Progress); err != nil {
+				return nil, err
+			}
 		}
 	}
 	return result, nil
@@ -315,6 +322,7 @@ func applyOperationRange(
 	start int,
 	resolved []string,
 	skipped []string,
+	restorePending bool,
 	result *ApplyResult,
 	progress Progress,
 ) (int, error) {
@@ -341,15 +349,16 @@ func applyOperationRange(
 				op.Message = err.Error()
 				ops[idx] = op
 				state := &resolve.State{
-					Workspace:  ws.Path,
-					RepoRoot:   repoInfo.Root,
-					BaseCommit: repoInfo.BaseCommit,
-					RepoRev:    result.RepoRev,
-					Mode:       result.Mode,
-					Current:    idx,
-					Operations: ops,
-					Resolved:   append([]string{}, resolved...),
-					Skipped:    append([]string{}, skipped...),
+					Workspace:           ws.Path,
+					RepoRoot:            repoInfo.Root,
+					BaseCommit:          repoInfo.BaseCommit,
+					RepoRev:             result.RepoRev,
+					Mode:                result.Mode,
+					Current:             idx,
+					Operations:          ops,
+					Resolved:            append([]string{}, resolved...),
+					Skipped:             append([]string{}, skipped...),
+					RestorePendingStash: restorePending,
 				}
 				if err := resolve.Save(ws.Path, state); err != nil {
 					return idx, err

--- a/packages/browseros/tools/patch/internal/engine/apply.go
+++ b/packages/browseros/tools/patch/internal/engine/apply.go
@@ -243,7 +243,10 @@ func Abort(ctx context.Context, ws workspace.Entry) error {
 		return nil
 	}
 	if err := git.StashPop(ctx, ws.Path, workspaceState.PendingStash); err != nil {
-		return err
+		if !errors.Is(err, git.ErrStashNotFound) {
+			return err
+		}
+		// Stale record (stash gone): clearing it is the correct rollback.
 	}
 	workspaceState.PendingStash = ""
 	return workspace.SaveState(ws.Path, workspaceState)

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -491,6 +491,41 @@ func TestSyncNoRebaseKeepsStashRecorded(t *testing.T) {
 	}
 }
 
+func TestSyncRestoresPreviouslyParkedStash(t *testing.T) {
+	ctx := context.Background()
+	ws, repoInfo := syncFixture(t, "PATCHED", "local change")
+
+	// First sync parks the local change (--no-rebase).
+	first, err := Sync(ctx, SyncOptions{Workspace: ws, Repo: repoInfo, Rebase: false})
+	if err != nil {
+		t.Fatalf("first Sync: %v", err)
+	}
+	if first.StashRef == "" {
+		t.Fatalf("expected a parked stash")
+	}
+	assertFile(t, filepath.Join(ws.Path, "local.txt"), "local base\n")
+
+	// Second sync (rebase default) must bring the parked change back.
+	second, err := Sync(ctx, SyncOptions{Workspace: ws, Repo: repoInfo, Rebase: true})
+	if err != nil {
+		t.Fatalf("second Sync: %v", err)
+	}
+	if len(second.Conflicts) != 0 || second.StashConflict {
+		t.Fatalf("unexpected conflicts: %+v", second)
+	}
+	assertFile(t, filepath.Join(ws.Path, "local.txt"), "local change\n")
+	state, err := workspace.LoadState(ws.Path)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if state.PendingStash != "" {
+		t.Fatalf("pending stash should be cleared after restore, got %q", state.PendingStash)
+	}
+	if stashList := gitOutput(t, ws.Path, "stash", "list"); stashList != "" {
+		t.Fatalf("stash should be dropped after restore, got %q", stashList)
+	}
+}
+
 func TestSyncReportsStashPopConflict(t *testing.T) {
 	ctx := context.Background()
 	workspacePath := initGitRepo(t)

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -381,6 +381,211 @@ func TestExtractExcludesFilterUntracked(t *testing.T) {
 	}
 }
 
+// syncFixture builds a workspace with one patched file and one local-only
+// change, plus a patch repo (with bare remote) whose patch rewrites a.txt.
+func syncFixture(t *testing.T, patchedLine string, localLine string) (workspace.Entry, *repo.Info) {
+	t.Helper()
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "a.txt"), "line1\nline2\nline3\n")
+	writeFile(t, filepath.Join(workspacePath, "local.txt"), "local base\n")
+	runGit(t, workspacePath, "add", "a.txt", "local.txt")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	// Build the repo patch for a.txt from a temporary edit.
+	writeFile(t, filepath.Join(workspacePath, "a.txt"), "line1\n"+patchedLine+"\nline3\n")
+	diff, err := git.DiffText(ctx, workspacePath, baseCommit, "--", "a.txt")
+	if err != nil {
+		t.Fatalf("DiffText: %v", err)
+	}
+	runGit(t, workspacePath, "checkout", "--", "a.txt")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFile(t, filepath.Join(repoInfo.PatchesDir, "a.txt"), diff)
+	runGit(t, repoInfo.Root, "add", "chromium_patches/a.txt")
+	runGit(t, repoInfo.Root, "commit", "-m", "add a.txt patch")
+	remoteRepo := t.TempDir()
+	runGit(t, remoteRepo, "init", "--bare")
+	runGit(t, repoInfo.Root, "remote", "add", "origin", remoteRepo)
+	runGit(t, repoInfo.Root, "push", "-u", "origin", "HEAD")
+
+	// Local divergence in the workspace.
+	writeFile(t, filepath.Join(workspacePath, "local.txt"), localLine+"\n")
+	return workspace.Entry{Name: "ws", Path: workspacePath}, repoInfo
+}
+
+func TestSyncRebaseRestoresLocalChanges(t *testing.T) {
+	ctx := context.Background()
+	ws, repoInfo := syncFixture(t, "PATCHED", "local change")
+
+	result, err := Sync(ctx, SyncOptions{Workspace: ws, Repo: repoInfo, Rebase: true})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if len(result.Conflicts) != 0 {
+		t.Fatalf("unexpected conflicts: %v", result.Conflicts)
+	}
+	if !result.StashRestored {
+		t.Fatalf("expected stash restored, got %+v", result)
+	}
+	assertFile(t, filepath.Join(ws.Path, "a.txt"), "line1\nPATCHED\nline3\n")
+	assertFile(t, filepath.Join(ws.Path, "local.txt"), "local change\n")
+	state, err := workspace.LoadState(ws.Path)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if state.PendingStash != "" {
+		t.Fatalf("expected no pending stash, got %q", state.PendingStash)
+	}
+}
+
+func TestSyncNoRebaseKeepsStashRecorded(t *testing.T) {
+	ctx := context.Background()
+	ws, repoInfo := syncFixture(t, "PATCHED", "local change")
+
+	result, err := Sync(ctx, SyncOptions{Workspace: ws, Repo: repoInfo, Rebase: false})
+	if err != nil {
+		t.Fatalf("Sync: %v", err)
+	}
+	if result.StashRef == "" {
+		t.Fatalf("expected stash to be created")
+	}
+	if result.StashRestored {
+		t.Fatalf("no-rebase must not pop the stash")
+	}
+	state, err := workspace.LoadState(ws.Path)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if state.PendingStash != result.StashRef {
+		t.Fatalf("pending stash = %q, want %q (must stay recorded)", state.PendingStash, result.StashRef)
+	}
+	if stashList := gitOutput(t, ws.Path, "stash", "list"); stashList == "" {
+		t.Fatalf("stash entry should still exist")
+	}
+}
+
+func TestSyncReportsStashPopConflict(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "a.txt"), "line1\nline2\nline3\n")
+	runGit(t, workspacePath, "add", "a.txt")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	writeFile(t, filepath.Join(workspacePath, "a.txt"), "line1\nPATCHED\nline3\n")
+	diff, err := git.DiffText(ctx, workspacePath, baseCommit, "--", "a.txt")
+	if err != nil {
+		t.Fatalf("DiffText: %v", err)
+	}
+	runGit(t, workspacePath, "checkout", "--", "a.txt")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFile(t, filepath.Join(repoInfo.PatchesDir, "a.txt"), diff)
+	runGit(t, repoInfo.Root, "add", "chromium_patches/a.txt")
+	runGit(t, repoInfo.Root, "commit", "-m", "add a.txt patch")
+	remoteRepo := t.TempDir()
+	runGit(t, remoteRepo, "init", "--bare")
+	runGit(t, repoInfo.Root, "remote", "add", "origin", remoteRepo)
+	runGit(t, repoInfo.Root, "push", "-u", "origin", "HEAD")
+
+	// Local edit to the same line the patch rewrites -> stash pop conflict.
+	writeFile(t, filepath.Join(workspacePath, "a.txt"), "line1\nLOCAL\nline3\n")
+
+	ws := workspace.Entry{Name: "ws", Path: workspacePath}
+	result, err := Sync(ctx, SyncOptions{Workspace: ws, Repo: repoInfo, Rebase: true})
+	if err != nil {
+		t.Fatalf("Sync should report stash conflicts, not fail: %v", err)
+	}
+	if !result.StashConflict {
+		t.Fatalf("expected stash conflict, got %+v", result)
+	}
+	if !slices.Contains(result.StashConflictFiles, "a.txt") {
+		t.Fatalf("expected a.txt in conflict files, got %v", result.StashConflictFiles)
+	}
+	state, err := workspace.LoadState(ws.Path)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if state.PendingStash == "" {
+		t.Fatalf("pending stash must stay recorded after pop conflict")
+	}
+	if stashList := gitOutput(t, ws.Path, "stash", "list"); stashList == "" {
+		t.Fatalf("stash entry must survive a pop conflict")
+	}
+	merged, err := os.ReadFile(filepath.Join(ws.Path, "a.txt"))
+	if err != nil {
+		t.Fatalf("read merged file: %v", err)
+	}
+	for _, marker := range []string{"<<<<<<<", "PATCHED", "LOCAL", ">>>>>>>"} {
+		if !strings.Contains(string(merged), marker) {
+			t.Fatalf("expected 3-way conflict markers with both sides, got:\n%s", merged)
+		}
+	}
+}
+
+func TestContinueRestoresPendingStashAfterLastConflict(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "b.txt"), "base\n")
+	writeFile(t, filepath.Join(workspacePath, "local.txt"), "local base\n")
+	runGit(t, workspacePath, "add", "b.txt", "local.txt")
+	runGit(t, workspacePath, "commit", "-m", "base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	writeFile(t, filepath.Join(workspacePath, "b.txt"), "patched\n")
+	diff, err := git.DiffText(ctx, workspacePath, baseCommit, "--", "b.txt")
+	if err != nil {
+		t.Fatalf("DiffText: %v", err)
+	}
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFile(t, filepath.Join(repoInfo.PatchesDir, "b.txt"), diff)
+	runGit(t, repoInfo.Root, "add", "chromium_patches/b.txt")
+	runGit(t, repoInfo.Root, "commit", "-m", "add b.txt patch")
+
+	// Park a local change in a stash, recorded as pending (as sync does).
+	writeFile(t, filepath.Join(workspacePath, "local.txt"), "local changed\n")
+	runGit(t, workspacePath, "stash", "push", "-m", "sync stash", "-u", "--", "local.txt")
+	stashRef := gitOutput(t, workspacePath, "stash", "list", "-1", "--format=%gd")
+	if err := workspace.SaveState(workspacePath, &workspace.State{
+		Version:      1,
+		Workspace:    workspacePath,
+		BaseCommit:   baseCommit,
+		PendingStash: stashRef,
+	}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	// The conflicted operation is already resolved in the working tree.
+	if err := resolve.Save(workspacePath, &resolve.State{
+		Workspace:  workspacePath,
+		RepoRoot:   repoInfo.Root,
+		BaseCommit: baseCommit,
+		Current:    0,
+		Operations: []resolve.Operation{{ChromiumPath: "b.txt", PatchRel: "b.txt", Op: patch.OpModify}},
+	}); err != nil {
+		t.Fatalf("resolve.Save: %v", err)
+	}
+
+	result, err := Continue(ctx, ContinueOptions{Workspace: workspace.Entry{Name: "ws", Path: workspacePath}})
+	if err != nil {
+		t.Fatalf("Continue: %v", err)
+	}
+	if !result.StashRestored {
+		t.Fatalf("expected pending stash restored on completion, got %+v", result)
+	}
+	assertFile(t, filepath.Join(workspacePath, "local.txt"), "local changed\n")
+	state, err := workspace.LoadState(workspacePath)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if state.PendingStash != "" {
+		t.Fatalf("pending stash should be cleared, got %q", state.PendingStash)
+	}
+}
+
 func TestSyncClearsPendingStashAfterSuccessfulNonRebaseRun(t *testing.T) {
 	ctx := context.Background()
 	workspacePath := initGitRepo(t)

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -611,6 +611,66 @@ func TestContinueRestoresPendingStashAfterLastConflict(t *testing.T) {
 	}
 }
 
+func TestInspectWorkspaceReportsPendingStash(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser.cc"), "base\n")
+	runGit(t, workspacePath, "add", "chrome/browser.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+	repoInfo := newPatchRepo(t, baseCommit)
+
+	if err := workspace.SaveState(workspacePath, &workspace.State{
+		Version:      1,
+		Workspace:    workspacePath,
+		BaseCommit:   baseCommit,
+		PendingStash: "stash@{0}",
+	}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	status, err := InspectWorkspace(ctx, InspectWorkspaceOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+	})
+	if err != nil {
+		t.Fatalf("InspectWorkspace: %v", err)
+	}
+	if status.PendingStash != "stash@{0}" {
+		t.Fatalf("pending stash = %q, want stash@{0}", status.PendingStash)
+	}
+}
+
+func TestOrphanSummaryGroupsByTopLevelDir(t *testing.T) {
+	groups := OrphanSummary([]string{
+		"chrome/app/one.cc",
+		"chrome/browser/two.cc",
+		"third_party/sparkle/bin",
+		"BUILD.gn",
+	})
+	if len(groups) != 3 {
+		t.Fatalf("expected 3 groups, got %v", groups)
+	}
+	if groups[0].Dir != "chrome" || groups[0].Count != 2 {
+		t.Fatalf("expected chrome first with count 2, got %v", groups)
+	}
+	rest := map[string]int{groups[1].Dir: groups[1].Count, groups[2].Dir: groups[2].Count}
+	if rest["third_party"] != 1 || rest["(root)"] != 1 {
+		t.Fatalf("unexpected groups: %v", groups)
+	}
+}
+
+func TestInSyncButUnreproducible(t *testing.T) {
+	status := &WorkspaceStatus{Orphaned: []string{"chrome/x"}}
+	if !status.InSyncButUnreproducible() {
+		t.Fatalf("expected hint condition with only orphans present")
+	}
+	status.NeedsApply = []string{"chrome/y"}
+	if status.InSyncButUnreproducible() {
+		t.Fatalf("hint must not fire when applies are pending")
+	}
+}
+
 func TestSyncClearsPendingStashAfterSuccessfulNonRebaseRun(t *testing.T) {
 	ctx := context.Background()
 	workspacePath := initGitRepo(t)

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -193,6 +193,194 @@ func TestInspectWorkspaceSkipsIgnoredUntrackedFiles(t *testing.T) {
 	}
 }
 
+// newPatchRepo builds a minimal committed patch repo pointing at baseCommit.
+func newPatchRepo(t *testing.T, baseCommit string) *repo.Info {
+	t.Helper()
+	repoRoot := initGitRepo(t)
+	if err := os.MkdirAll(filepath.Join(repoRoot, "chromium_patches"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	writeFile(t, filepath.Join(repoRoot, "BASE_COMMIT"), baseCommit+"\n")
+	runGit(t, repoRoot, "add", "BASE_COMMIT")
+	runGit(t, repoRoot, "commit", "-m", "patch repo init")
+	repoInfo, err := repo.Load(repoRoot)
+	if err != nil {
+		t.Fatalf("repo.Load: %v", err)
+	}
+	return repoInfo
+}
+
+func TestExtractRoundTripIsChurnFree(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser.cc"), "base\nline\n")
+	runGit(t, workspacePath, "add", "chrome/browser.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser.cc"), "patched\nline\n")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "feature.cc"), "new feature\n")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	ws := workspace.Entry{Name: "ws", Path: workspacePath}
+
+	first, err := Extract(ctx, ExtractOptions{Workspace: ws, Repo: repoInfo})
+	if err != nil {
+		t.Fatalf("first Extract: %v", err)
+	}
+	if len(first.Written) != 2 {
+		t.Fatalf("expected 2 files written, got %v", first.Written)
+	}
+
+	// After extract, status must agree the workspace is fully captured.
+	status, err := InspectWorkspace(ctx, InspectWorkspaceOptions{Workspace: ws, Repo: repoInfo})
+	if err != nil {
+		t.Fatalf("InspectWorkspace: %v", err)
+	}
+	if len(status.NeedsUpdate) != 0 || len(status.NeedsApply) != 0 || len(status.Orphaned) != 0 {
+		t.Fatalf("expected clean status after extract, got needs_update=%v needs_apply=%v orphaned=%v",
+			status.NeedsUpdate, status.NeedsApply, status.Orphaned)
+	}
+
+	beforeBytes := map[string]string{}
+	for _, rel := range first.Written {
+		data, err := os.ReadFile(filepath.Join(repoInfo.PatchesDir, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("read patch %s: %v", rel, err)
+		}
+		beforeBytes[rel] = string(data)
+	}
+
+	second, err := Extract(ctx, ExtractOptions{Workspace: ws, Repo: repoInfo})
+	if err != nil {
+		t.Fatalf("second Extract: %v", err)
+	}
+	if len(second.Written) != 0 || len(second.Deleted) != 0 {
+		t.Fatalf("second extract must be a no-op, wrote %v deleted %v", second.Written, second.Deleted)
+	}
+	if len(second.Unchanged) != 2 {
+		t.Fatalf("expected both files unchanged, got %v", second.Unchanged)
+	}
+	for rel, before := range beforeBytes {
+		data, err := os.ReadFile(filepath.Join(repoInfo.PatchesDir, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("read patch %s: %v", rel, err)
+		}
+		if string(data) != before {
+			t.Fatalf("patch %s churned between identical extracts", rel)
+		}
+	}
+}
+
+func TestExtractFromTwoCheckoutsIsByteIdentical(t *testing.T) {
+	ctx := context.Background()
+	checkout1 := initGitRepo(t)
+	writeFile(t, filepath.Join(checkout1, "chrome", "browser.cc"), "base\nline\n")
+	runGit(t, checkout1, "add", "chrome/browser.cc")
+	runGit(t, checkout1, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, checkout1, "rev-parse", "HEAD")
+
+	checkout2Parent := t.TempDir()
+	runGit(t, checkout2Parent, "clone", checkout1, "clone")
+	checkout2 := filepath.Join(checkout2Parent, "clone")
+	// Hostile per-checkout config must not leak into extracted patches.
+	runGit(t, checkout2, "config", "core.abbrev", "9")
+	runGit(t, checkout2, "config", "diff.algorithm", "histogram")
+	runGit(t, checkout2, "config", "diff.mnemonicPrefix", "true")
+
+	edit := "patched\nline\n"
+	addition := "new feature\n"
+	for _, checkout := range []string{checkout1, checkout2} {
+		writeFile(t, filepath.Join(checkout, "chrome", "browser.cc"), edit)
+		writeFile(t, filepath.Join(checkout, "chrome", "feature.cc"), addition)
+	}
+
+	repo1 := newPatchRepo(t, baseCommit)
+	repo2 := newPatchRepo(t, baseCommit)
+	if _, err := Extract(ctx, ExtractOptions{Workspace: workspace.Entry{Name: "c1", Path: checkout1}, Repo: repo1}); err != nil {
+		t.Fatalf("extract checkout1: %v", err)
+	}
+	if _, err := Extract(ctx, ExtractOptions{Workspace: workspace.Entry{Name: "c2", Path: checkout2}, Repo: repo2}); err != nil {
+		t.Fatalf("extract checkout2: %v", err)
+	}
+
+	for _, rel := range []string{"chrome/browser.cc", "chrome/feature.cc"} {
+		data1, err := os.ReadFile(filepath.Join(repo1.PatchesDir, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("read repo1 %s: %v", rel, err)
+		}
+		data2, err := os.ReadFile(filepath.Join(repo2.PatchesDir, filepath.FromSlash(rel)))
+		if err != nil {
+			t.Fatalf("read repo2 %s: %v", rel, err)
+		}
+		if string(data1) != string(data2) {
+			t.Fatalf("patch %s differs across checkouts\n--- c1 ---\n%s\n--- c2 ---\n%s", rel, data1, data2)
+		}
+	}
+}
+
+func TestExtractDryRunWritesNothing(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser.cc"), "base\n")
+	runGit(t, workspacePath, "add", "chrome/browser.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser.cc"), "patched\n")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	ws := workspace.Entry{Name: "ws", Path: workspacePath}
+
+	result, err := Extract(ctx, ExtractOptions{Workspace: ws, Repo: repoInfo, DryRun: true})
+	if err != nil {
+		t.Fatalf("Extract dry-run: %v", err)
+	}
+	if !result.DryRun {
+		t.Fatalf("expected dry_run result flag")
+	}
+	if len(result.Created) != 1 || result.Created[0] != "chrome/browser.cc" {
+		t.Fatalf("expected planned create, got %+v", result)
+	}
+	if _, err := os.Stat(filepath.Join(repoInfo.PatchesDir, "chrome", "browser.cc")); !os.IsNotExist(err) {
+		t.Fatalf("dry-run must not write patch files")
+	}
+	state, err := workspace.LoadState(workspacePath)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if state.LastExtractRev != "" {
+		t.Fatalf("dry-run must not record extract state, got %q", state.LastExtractRev)
+	}
+}
+
+func TestExtractExcludesFilterUntracked(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser.cc"), "base\n")
+	runGit(t, workspacePath, "add", "chrome/browser.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	writeFile(t, filepath.Join(workspacePath, "scratch", "notes.md"), "junk\n")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "feature.cc"), "real\n")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	result, err := Extract(ctx, ExtractOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+		Excludes:  []string{"scratch/"},
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if slices.Contains(result.Written, "scratch/notes.md") {
+		t.Fatalf("excluded path extracted anyway: %v", result.Written)
+	}
+	if !slices.Contains(result.Written, "chrome/feature.cc") {
+		t.Fatalf("expected real file extracted, got %v", result.Written)
+	}
+}
+
 func TestSyncClearsPendingStashAfterSuccessfulNonRebaseRun(t *testing.T) {
 	ctx := context.Background()
 	workspacePath := initGitRepo(t)

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -491,6 +491,85 @@ func TestSyncNoRebaseKeepsStashRecorded(t *testing.T) {
 	}
 }
 
+func TestAbortRestoresSyncParkedStashBySHA(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "a.txt"), "a\n")
+	writeFile(t, filepath.Join(workspacePath, "local.txt"), "local\n")
+	runGit(t, workspacePath, "add", "a.txt", "local.txt")
+	runGit(t, workspacePath, "commit", "-m", "base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	// Park a local change exactly the way sync does: recorded by commit SHA.
+	writeFile(t, filepath.Join(workspacePath, "local.txt"), "local changed\n")
+	sha, err := git.StashPush(ctx, workspacePath, "sync stash", true, []string{"local.txt"})
+	if err != nil {
+		t.Fatalf("StashPush: %v", err)
+	}
+	if err := workspace.SaveState(workspacePath, &workspace.State{
+		Version:      1,
+		Workspace:    workspacePath,
+		BaseCommit:   baseCommit,
+		PendingStash: sha,
+	}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	writeFile(t, filepath.Join(workspacePath, "a.txt"), "applied\n")
+	if err := resolve.Save(workspacePath, &resolve.State{
+		Workspace:  workspacePath,
+		RepoRoot:   workspacePath,
+		BaseCommit: baseCommit,
+		Current:    0,
+		Operations: []resolve.Operation{
+			{ChromiumPath: "a.txt", PatchRel: "a.txt", Op: patch.OpModify},
+		},
+	}); err != nil {
+		t.Fatalf("resolve.Save: %v", err)
+	}
+
+	if err := Abort(ctx, workspace.Entry{Name: "ws", Path: workspacePath}); err != nil {
+		t.Fatalf("Abort: %v", err)
+	}
+	assertFile(t, filepath.Join(workspacePath, "a.txt"), "a\n")
+	assertFile(t, filepath.Join(workspacePath, "local.txt"), "local changed\n")
+	state, err := workspace.LoadState(workspacePath)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if state.PendingStash != "" {
+		t.Fatalf("expected pending stash cleared, got %q", state.PendingStash)
+	}
+}
+
+func TestSyncRefusesToDoubleParkLocalChanges(t *testing.T) {
+	ctx := context.Background()
+	ws, repoInfo := syncFixture(t, "PATCHED", "local change")
+
+	first, err := Sync(ctx, SyncOptions{Workspace: ws, Repo: repoInfo, Rebase: false})
+	if err != nil {
+		t.Fatalf("first Sync: %v", err)
+	}
+	if first.StashRef == "" {
+		t.Fatalf("expected a parked stash")
+	}
+
+	// New divergence while changes are still parked.
+	writeFile(t, filepath.Join(ws.Path, "local.txt"), "second change\n")
+	_, err = Sync(ctx, SyncOptions{Workspace: ws, Repo: repoInfo, Rebase: false})
+	if err == nil || !strings.Contains(err.Error(), "already parked") {
+		t.Fatalf("expected double-park refusal, got %v", err)
+	}
+	// The original stash record must be intact.
+	state, err := workspace.LoadState(ws.Path)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if state.PendingStash != first.StashRef {
+		t.Fatalf("pending stash = %q, want %q", state.PendingStash, first.StashRef)
+	}
+}
+
 func TestSyncRestoresPreviouslyParkedStash(t *testing.T) {
 	ctx := context.Background()
 	ws, repoInfo := syncFixture(t, "PATCHED", "local change")

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -152,6 +152,47 @@ func TestApplyReportsPatchProgress(t *testing.T) {
 	assertFile(t, filepath.Join(workspacePath, "chrome", "browser.cc"), "patched\n")
 }
 
+func TestInspectWorkspaceSkipsIgnoredUntrackedFiles(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser.cc"), "base\n")
+	runGit(t, workspacePath, "add", "chrome/browser.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	writeFile(t, filepath.Join(workspacePath, ".llm", "scratch.md"), "junk\n")
+	writeFile(t, filepath.Join(workspacePath, "debug.log"), "junk\n")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "feature.cc"), "real\n")
+
+	repoRoot := initGitRepo(t)
+	if err := os.MkdirAll(filepath.Join(repoRoot, "chromium_patches"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	writeFile(t, filepath.Join(repoRoot, "BASE_COMMIT"), baseCommit+"\n")
+	runGit(t, repoRoot, "add", "BASE_COMMIT")
+	runGit(t, repoRoot, "commit", "-m", "patch repo init")
+	repoInfo, err := repo.Load(repoRoot)
+	if err != nil {
+		t.Fatalf("repo.Load: %v", err)
+	}
+
+	status, err := InspectWorkspace(ctx, InspectWorkspaceOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+	})
+	if err != nil {
+		t.Fatalf("InspectWorkspace: %v", err)
+	}
+	if !slices.Contains(status.Orphaned, "chrome/feature.cc") {
+		t.Fatalf("expected real untracked file as orphan, got %v", status.Orphaned)
+	}
+	for _, junk := range []string{".llm/scratch.md", "debug.log"} {
+		if slices.Contains(status.Orphaned, junk) {
+			t.Fatalf("expected %q to be ignored, got orphans %v", junk, status.Orphaned)
+		}
+	}
+}
+
 func TestSyncClearsPendingStashAfterSuccessfulNonRebaseRun(t *testing.T) {
 	ctx := context.Background()
 	workspacePath := initGitRepo(t)

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -319,6 +319,31 @@ func TestExtractFromTwoCheckoutsIsByteIdentical(t *testing.T) {
 	}
 }
 
+func TestExtractReportsUntrackedScanProgress(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser.cc"), "base\n")
+	runGit(t, workspacePath, "add", "chrome/browser.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	writeFile(t, filepath.Join(workspacePath, "chrome", "one.cc"), "one\n")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "two.cc"), "two\n")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	progress := &progressRecorder{}
+	if _, err := Extract(ctx, ExtractOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+		Progress:  progress,
+	}); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	progress.requireContains(t, "Scanning untracked 1/2")
+	progress.requireContains(t, "Scanning untracked 2/2")
+	progress.requireContains(t, "Writing 2 patch files")
+}
+
 func TestExtractDryRunWritesNothing(t *testing.T) {
 	ctx := context.Background()
 	workspacePath := initGitRepo(t)

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -697,13 +697,15 @@ func TestContinueRestoresPendingStashAfterLastConflict(t *testing.T) {
 		t.Fatalf("SaveState: %v", err)
 	}
 
-	// The conflicted operation is already resolved in the working tree.
+	// The conflicted operation is already resolved in the working tree; the
+	// pause came from a rebase-mode sync, so restore intent is recorded.
 	if err := resolve.Save(workspacePath, &resolve.State{
-		Workspace:  workspacePath,
-		RepoRoot:   repoInfo.Root,
-		BaseCommit: baseCommit,
-		Current:    0,
-		Operations: []resolve.Operation{{ChromiumPath: "b.txt", PatchRel: "b.txt", Op: patch.OpModify}},
+		Workspace:           workspacePath,
+		RepoRoot:            repoInfo.Root,
+		BaseCommit:          baseCommit,
+		Current:             0,
+		Operations:          []resolve.Operation{{ChromiumPath: "b.txt", PatchRel: "b.txt", Op: patch.OpModify}},
+		RestorePendingStash: true,
 	}); err != nil {
 		t.Fatalf("resolve.Save: %v", err)
 	}
@@ -722,6 +724,66 @@ func TestContinueRestoresPendingStashAfterLastConflict(t *testing.T) {
 	}
 	if state.PendingStash != "" {
 		t.Fatalf("pending stash should be cleared, got %q", state.PendingStash)
+	}
+}
+
+func TestContinueLeavesExplicitlyParkedStashAlone(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "b.txt"), "base\n")
+	writeFile(t, filepath.Join(workspacePath, "local.txt"), "local base\n")
+	runGit(t, workspacePath, "add", "b.txt", "local.txt")
+	runGit(t, workspacePath, "commit", "-m", "base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	writeFile(t, filepath.Join(workspacePath, "b.txt"), "patched\n")
+	diff, err := git.DiffText(ctx, workspacePath, baseCommit, "--", "b.txt")
+	if err != nil {
+		t.Fatalf("DiffText: %v", err)
+	}
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFile(t, filepath.Join(repoInfo.PatchesDir, "b.txt"), diff)
+	runGit(t, repoInfo.Root, "add", "chromium_patches/b.txt")
+	runGit(t, repoInfo.Root, "commit", "-m", "add b.txt patch")
+
+	// Stash parked by an explicit --no-rebase sync: no restore intent.
+	writeFile(t, filepath.Join(workspacePath, "local.txt"), "local changed\n")
+	sha, err := git.StashPush(ctx, workspacePath, "sync stash", true, []string{"local.txt"})
+	if err != nil {
+		t.Fatalf("StashPush: %v", err)
+	}
+	if err := workspace.SaveState(workspacePath, &workspace.State{
+		Version:      1,
+		Workspace:    workspacePath,
+		BaseCommit:   baseCommit,
+		PendingStash: sha,
+	}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+	if err := resolve.Save(workspacePath, &resolve.State{
+		Workspace:  workspacePath,
+		RepoRoot:   repoInfo.Root,
+		BaseCommit: baseCommit,
+		Current:    0,
+		Operations: []resolve.Operation{{ChromiumPath: "b.txt", PatchRel: "b.txt", Op: patch.OpModify}},
+	}); err != nil {
+		t.Fatalf("resolve.Save: %v", err)
+	}
+
+	result, err := Continue(ctx, ContinueOptions{Workspace: workspace.Entry{Name: "ws", Path: workspacePath}})
+	if err != nil {
+		t.Fatalf("Continue: %v", err)
+	}
+	if result.StashRestored {
+		t.Fatalf("--no-rebase parked stash must stay parked, got %+v", result)
+	}
+	assertFile(t, filepath.Join(workspacePath, "local.txt"), "local base\n")
+	state, err := workspace.LoadState(workspacePath)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if state.PendingStash != sha {
+		t.Fatalf("pending stash record must survive, got %q want %q", state.PendingStash, sha)
 	}
 }
 

--- a/packages/browseros/tools/patch/internal/engine/extract.go
+++ b/packages/browseros/tools/patch/internal/engine/extract.go
@@ -134,12 +134,20 @@ func extractResult(workspaceName string, mode string, base string, plan *patch.W
 		Mode:       mode,
 		BaseCommit: base,
 		DryRun:     dryRun,
-		Written:    plan.Written(),
-		Created:    plan.Creates,
-		Updated:    plan.Updates,
-		Unchanged:  plan.Unchanged,
-		Deleted:    plan.Deletes,
+		Written:    orEmpty(plan.Written()),
+		Created:    orEmpty(plan.Creates),
+		Updated:    orEmpty(plan.Updates),
+		Unchanged:  orEmpty(plan.Unchanged),
+		Deleted:    orEmpty(plan.Deletes),
 	}
+}
+
+// orEmpty keeps agent-facing JSON arrays as [] instead of null.
+func orEmpty(list []string) []string {
+	if list == nil {
+		return []string{}
+	}
+	return list
 }
 
 func changedScope(changes []git.FileChange) []string {

--- a/packages/browseros/tools/patch/internal/engine/extract.go
+++ b/packages/browseros/tools/patch/internal/engine/extract.go
@@ -84,7 +84,7 @@ func Extract(ctx context.Context, opts ExtractOptions) (*ExtractResult, error) {
 		return nil, err
 	}
 	reportProgress(opts.Progress, "Writing %d patch %s", len(set), plural(len(set), "file", "files"))
-	written, deleted, err := patch.WriteRepoPatchSet(opts.Repo.PatchesDir, set, scope)
+	written, deleted, _, err := patch.WriteRepoPatchSet(opts.Repo.PatchesDir, set, scope)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/browseros/tools/patch/internal/engine/extract.go
+++ b/packages/browseros/tools/patch/internal/engine/extract.go
@@ -19,6 +19,8 @@ type ExtractOptions struct {
 	Squash     bool
 	Base       string
 	Filters    []string
+	Excludes   []string
+	DryRun     bool
 	Progress   Progress
 }
 
@@ -26,7 +28,11 @@ type ExtractResult struct {
 	Workspace  string   `json:"workspace"`
 	Mode       string   `json:"mode"`
 	BaseCommit string   `json:"base_commit"`
+	DryRun     bool     `json:"dry_run,omitempty"`
 	Written    []string `json:"written"`
+	Created    []string `json:"created"`
+	Updated    []string `json:"updated"`
+	Unchanged  []string `json:"unchanged"`
 	Deleted    []string `json:"deleted"`
 }
 
@@ -75,7 +81,7 @@ func Extract(ctx context.Context, opts ExtractOptions) (*ExtractResult, error) {
 	default:
 		mode = "working-tree"
 		reportProgress(opts.Progress, "Extracting workspace changes")
-		ignore, ignoreErr := patch.LoadIgnoreSet(opts.Repo.Root, nil)
+		ignore, ignoreErr := patch.LoadIgnoreSet(opts.Repo.Root, opts.Excludes)
 		if ignoreErr != nil {
 			return nil, ignoreErr
 		}
@@ -92,8 +98,16 @@ func Extract(ctx context.Context, opts ExtractOptions) (*ExtractResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	if opts.DryRun {
+		reportProgress(opts.Progress, "Planning %d patch %s (dry run)", len(set), plural(len(set), "file", "files"))
+		plan, err := patch.PlanRepoPatchSet(opts.Repo.PatchesDir, set, scope)
+		if err != nil {
+			return nil, err
+		}
+		return extractResult(opts.Workspace.Name, mode, base, plan, true), nil
+	}
 	reportProgress(opts.Progress, "Writing %d patch %s", len(set), plural(len(set), "file", "files"))
-	written, deleted, _, err := patch.WriteRepoPatchSet(opts.Repo.PatchesDir, set, scope)
+	plan, err := patch.WriteRepoPatchSet(opts.Repo.PatchesDir, set, scope)
 	if err != nil {
 		return nil, err
 	}
@@ -111,13 +125,21 @@ func Extract(ctx context.Context, opts ExtractOptions) (*ExtractResult, error) {
 	if err := workspace.SaveState(opts.Workspace.Path, state); err != nil {
 		return nil, err
 	}
+	return extractResult(opts.Workspace.Name, mode, base, plan, false), nil
+}
+
+func extractResult(workspaceName string, mode string, base string, plan *patch.WritePlan, dryRun bool) *ExtractResult {
 	return &ExtractResult{
-		Workspace:  opts.Workspace.Name,
+		Workspace:  workspaceName,
 		Mode:       mode,
 		BaseCommit: base,
-		Written:    written,
-		Deleted:    deleted,
-	}, nil
+		DryRun:     dryRun,
+		Written:    plan.Written(),
+		Created:    plan.Creates,
+		Updated:    plan.Updates,
+		Unchanged:  plan.Unchanged,
+		Deleted:    plan.Deletes,
+	}
 }
 
 func changedScope(changes []git.FileChange) []string {

--- a/packages/browseros/tools/patch/internal/engine/extract.go
+++ b/packages/browseros/tools/patch/internal/engine/extract.go
@@ -75,7 +75,16 @@ func Extract(ctx context.Context, opts ExtractOptions) (*ExtractResult, error) {
 	default:
 		mode = "working-tree"
 		reportProgress(opts.Progress, "Extracting workspace changes")
-		set, err = patch.BuildWorkingTreePatchSet(ctx, opts.Workspace.Path, base, opts.Filters)
+		ignore, ignoreErr := patch.LoadIgnoreSet(opts.Repo.Root, nil)
+		if ignoreErr != nil {
+			return nil, ignoreErr
+		}
+		set, err = patch.BuildWorkingTreePatchSet(ctx, opts.Workspace.Path, patch.WorkingTreeOptions{
+			Base:    base,
+			Filters: opts.Filters,
+			Ignore:  ignore,
+			Report:  func(message string) { reportProgress(opts.Progress, "%s", message) },
+		})
 		if err == nil && len(opts.Filters) > 0 {
 			scope = opts.Filters
 		}

--- a/packages/browseros/tools/patch/internal/engine/status.go
+++ b/packages/browseros/tools/patch/internal/engine/status.go
@@ -2,6 +2,8 @@ package engine
 
 import (
 	"context"
+	"slices"
+	"strings"
 
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/git"
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/patch"
@@ -17,12 +19,47 @@ type WorkspaceStatus struct {
 	LastApplyRev   string          `json:"last_apply_rev,omitempty"`
 	LastSyncRev    string          `json:"last_sync_rev,omitempty"`
 	LastExtractRev string          `json:"last_extract_rev,omitempty"`
+	PendingStash   string          `json:"pending_stash,omitempty"`
 	ActiveResolve  bool            `json:"active_resolve"`
 	NeedsApply     []string        `json:"needs_apply"`
 	NeedsUpdate    []string        `json:"needs_update"`
 	Orphaned       []string        `json:"orphaned"`
 	UpToDate       []string        `json:"up_to_date"`
 	SyncState      string          `json:"sync_state"`
+}
+
+// InSyncButUnreproducible flags the "patches agree but orphans exist" state:
+// a fresh checkout would not reproduce this workspace.
+func (s *WorkspaceStatus) InSyncButUnreproducible() bool {
+	return len(s.NeedsApply) == 0 && len(s.NeedsUpdate) == 0 && len(s.Orphaned) > 0
+}
+
+type OrphanGroup struct {
+	Dir   string `json:"dir"`
+	Count int    `json:"count"`
+}
+
+// OrphanSummary groups paths by top-level directory, largest group first.
+func OrphanSummary(paths []string) []OrphanGroup {
+	counts := map[string]int{}
+	for _, rel := range paths {
+		dir := "(root)"
+		if idx := strings.IndexByte(rel, '/'); idx > 0 {
+			dir = rel[:idx]
+		}
+		counts[dir]++
+	}
+	groups := make([]OrphanGroup, 0, len(counts))
+	for dir, count := range counts {
+		groups = append(groups, OrphanGroup{Dir: dir, Count: count})
+	}
+	slices.SortFunc(groups, func(a, b OrphanGroup) int {
+		if a.Count != b.Count {
+			return b.Count - a.Count
+		}
+		return strings.Compare(a.Dir, b.Dir)
+	})
+	return groups
 }
 
 type InspectWorkspaceOptions struct {
@@ -67,6 +104,7 @@ func InspectWorkspace(ctx context.Context, opts InspectWorkspaceOptions) (*Works
 		LastApplyRev:   state.LastApplyRev,
 		LastSyncRev:    state.LastSyncRev,
 		LastExtractRev: state.LastExtractRev,
+		PendingStash:   state.PendingStash,
 		ActiveResolve:  resolve.Exists(opts.Workspace.Path),
 	}
 	for _, delta := range patch.Compare(repoSet, localSet) {

--- a/packages/browseros/tools/patch/internal/engine/status.go
+++ b/packages/browseros/tools/patch/internal/engine/status.go
@@ -47,8 +47,16 @@ func InspectWorkspace(ctx context.Context, opts InspectWorkspaceOptions) (*Works
 	if err != nil {
 		return nil, err
 	}
+	ignore, err := patch.LoadIgnoreSet(opts.Repo.Root, nil)
+	if err != nil {
+		return nil, err
+	}
 	reportProgress(opts.Progress, "Building workspace patch set")
-	localSet, err := patch.BuildWorkingTreePatchSet(ctx, opts.Workspace.Path, opts.Repo.BaseCommit, nil)
+	localSet, err := patch.BuildWorkingTreePatchSet(ctx, opts.Workspace.Path, patch.WorkingTreeOptions{
+		Base:   opts.Repo.BaseCommit,
+		Ignore: ignore,
+		Report: func(message string) { reportProgress(opts.Progress, "%s", message) },
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/packages/browseros/tools/patch/internal/engine/sync.go
+++ b/packages/browseros/tools/patch/internal/engine/sync.go
@@ -67,6 +67,40 @@ func Sync(ctx context.Context, opts SyncOptions) (*SyncResult, error) {
 		RepoHead:  head,
 		Rebased:   opts.Rebase,
 	}
+	// A previous run may have parked local changes (--no-rebase or a crash).
+	// Bring them back before measuring divergence so they ride this sync like
+	// any other local change; stale records are cleared.
+	if state.PendingStash != "" {
+		if opts.Rebase {
+			reportProgress(opts.Progress, "Restoring previously parked local changes")
+			switch err := git.StashRebase(ctx, opts.Workspace.Path, state.PendingStash); {
+			case err == nil, errors.Is(err, git.ErrStashNotFound):
+				state.PendingStash = ""
+				if err := workspace.SaveState(opts.Workspace.Path, state); err != nil {
+					return nil, err
+				}
+			default:
+				var conflict *git.StashConflictError
+				if !errors.As(err, &conflict) {
+					return nil, err
+				}
+				result.StashConflict = true
+				result.StashConflictFiles = conflict.Files
+				return result, nil
+			}
+		} else {
+			live, err := git.StashEntryExists(ctx, opts.Workspace.Path, state.PendingStash)
+			if err != nil {
+				return nil, err
+			}
+			if !live {
+				state.PendingStash = ""
+				if err := workspace.SaveState(opts.Workspace.Path, state); err != nil {
+					return nil, err
+				}
+			}
+		}
+	}
 	status, err := InspectWorkspace(ctx, InspectWorkspaceOptions{
 		Workspace: opts.Workspace,
 		Repo:      opts.Repo,
@@ -144,11 +178,13 @@ func Sync(ctx context.Context, opts SyncOptions) (*SyncResult, error) {
 	switch {
 	case result.StashConflict:
 		// Keep PendingStash: git preserved the stash entry and the user
-		// still has to resolve the pop conflict.
+		// still has to resolve the rebase conflict.
 	case !opts.Rebase && result.StashRef != "":
 		// Local changes stay parked; remember where they are instead of
 		// silently forgetting the stash.
 		state.PendingStash = result.StashRef
+	case !opts.Rebase:
+		// Keep any live pre-existing record (validated above).
 	default:
 		state.PendingStash = ""
 	}

--- a/packages/browseros/tools/patch/internal/engine/sync.go
+++ b/packages/browseros/tools/patch/internal/engine/sync.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -19,14 +20,17 @@ type SyncOptions struct {
 }
 
 type SyncResult struct {
-	Workspace string   `json:"workspace"`
-	Remote    string   `json:"remote"`
-	RepoHead  string   `json:"repo_head"`
-	StashRef  string   `json:"stash_ref,omitempty"`
-	Rebased   bool     `json:"rebased"`
-	Fallback  bool     `json:"fallback"`
-	Applied   []string `json:"applied,omitempty"`
-	Conflicts []string `json:"conflicts,omitempty"`
+	Workspace          string   `json:"workspace"`
+	Remote             string   `json:"remote"`
+	RepoHead           string   `json:"repo_head"`
+	StashRef           string   `json:"stash_ref,omitempty"`
+	Rebased            bool     `json:"rebased"`
+	Fallback           bool     `json:"fallback"`
+	StashRestored      bool     `json:"stash_restored,omitempty"`
+	StashConflict      bool     `json:"stash_conflict,omitempty"`
+	StashConflictFiles []string `json:"stash_conflict_files,omitempty"`
+	Applied            []string `json:"applied,omitempty"`
+	Conflicts          []string `json:"conflicts,omitempty"`
 }
 
 func Sync(ctx context.Context, opts SyncOptions) (*SyncResult, error) {
@@ -125,12 +129,29 @@ func Sync(ctx context.Context, opts SyncOptions) (*SyncResult, error) {
 		}
 	}
 	if opts.Rebase && result.StashRef != "" {
-		reportProgress(opts.Progress, "Restoring stashed local changes")
-		if err := git.StashPop(ctx, opts.Workspace.Path, result.StashRef); err != nil {
-			return nil, err
+		reportProgress(opts.Progress, "Rebasing stashed local changes")
+		if err := git.StashRebase(ctx, opts.Workspace.Path, result.StashRef); err != nil {
+			var conflict *git.StashConflictError
+			if !errors.As(err, &conflict) {
+				return nil, err
+			}
+			result.StashConflict = true
+			result.StashConflictFiles = conflict.Files
+		} else {
+			result.StashRestored = true
 		}
 	}
-	state.PendingStash = ""
+	switch {
+	case result.StashConflict:
+		// Keep PendingStash: git preserved the stash entry and the user
+		// still has to resolve the pop conflict.
+	case !opts.Rebase && result.StashRef != "":
+		// Local changes stay parked; remember where they are instead of
+		// silently forgetting the stash.
+		state.PendingStash = result.StashRef
+	default:
+		state.PendingStash = ""
+	}
 	state.BaseCommit = opts.Repo.BaseCommit
 	state.LastSyncRev = head
 	state.LastSyncAt = time.Now().UTC()

--- a/packages/browseros/tools/patch/internal/engine/sync.go
+++ b/packages/browseros/tools/patch/internal/engine/sync.go
@@ -111,6 +111,11 @@ func Sync(ctx context.Context, opts SyncOptions) (*SyncResult, error) {
 	}
 	divergent := append([]string{}, status.NeedsUpdate...)
 	divergent = append(divergent, status.Orphaned...)
+	if !opts.Rebase && state.PendingStash != "" && len(divergent) > 0 {
+		return nil, fmt.Errorf(
+			"a previous sync already parked local changes (stash %s); run \"browseros-patch sync %s\" without --no-rebase to restore them first, or pop the stash manually",
+			state.PendingStash, opts.Workspace.Name)
+	}
 	if len(divergent) > 0 {
 		reportProgress(opts.Progress, "Stashing %d divergent %s", len(divergent), plural(len(divergent), "file", "files"))
 		stashRef, err := git.StashPush(ctx, opts.Workspace.Path, "browseros-patch sync stash", true, divergent)

--- a/packages/browseros/tools/patch/internal/engine/sync.go
+++ b/packages/browseros/tools/patch/internal/engine/sync.go
@@ -131,11 +131,12 @@ func Sync(ctx context.Context, opts SyncOptions) (*SyncResult, error) {
 	if state.LastSyncRev == "" || state.BaseCommit != "" && state.BaseCommit != opts.Repo.BaseCommit {
 		result.Fallback = true
 		applyResult, err := Apply(ctx, ApplyOptions{
-			Workspace: opts.Workspace,
-			Repo:      opts.Repo,
-			Reset:     true,
-			Mode:      "sync-reset",
-			Progress:  opts.Progress,
+			Workspace:           opts.Workspace,
+			Repo:                opts.Repo,
+			Reset:               true,
+			Mode:                "sync-reset",
+			RestorePendingStash: opts.Rebase,
+			Progress:            opts.Progress,
 		})
 		if err != nil {
 			return nil, err
@@ -149,12 +150,13 @@ func Sync(ctx context.Context, opts SyncOptions) (*SyncResult, error) {
 		}
 	} else {
 		applyResult, err := Apply(ctx, ApplyOptions{
-			Workspace:  opts.Workspace,
-			Repo:       opts.Repo,
-			ChangedRef: state.LastSyncRev,
-			RangeEnd:   head,
-			Mode:       "sync",
-			Progress:   opts.Progress,
+			Workspace:           opts.Workspace,
+			Repo:                opts.Repo,
+			ChangedRef:          state.LastSyncRev,
+			RangeEnd:            head,
+			Mode:                "sync",
+			RestorePendingStash: opts.Rebase,
+			Progress:            opts.Progress,
 		})
 		if err != nil {
 			return nil, err

--- a/packages/browseros/tools/patch/internal/git/git.go
+++ b/packages/browseros/tools/patch/internal/git/git.go
@@ -305,6 +305,16 @@ func StashPush(ctx context.Context, dir string, message string, includeUntracked
 	return strings.TrimSpace(list.Stdout), nil
 }
 
+// StashConflictError reports a stash pop that left merge conflicts in the
+// working tree; git keeps the stash entry in that case.
+type StashConflictError struct {
+	Files []string
+}
+
+func (e *StashConflictError) Error() string {
+	return fmt.Sprintf("stash pop conflicted in %s", strings.Join(e.Files, ", "))
+}
+
 func StashPop(ctx context.Context, dir string, stashRef string) error {
 	args := []string{"stash", "pop"}
 	if stashRef != "" {
@@ -314,10 +324,178 @@ func StashPop(ctx context.Context, dir string, stashRef string) error {
 	if err != nil {
 		return err
 	}
+	if result.Code == 0 {
+		return nil
+	}
+	unmerged, unmergedErr := UnmergedFiles(ctx, dir)
+	if unmergedErr == nil && len(unmerged) > 0 {
+		return &StashConflictError{Files: unmerged}
+	}
+	return errors.New(strings.TrimSpace(result.Stderr))
+}
+
+func UnmergedFiles(ctx context.Context, dir string) ([]string, error) {
+	result, err := Run(ctx, dir, nil, "diff", "--name-only", "--diff-filter=U")
+	if err != nil {
+		return nil, err
+	}
+	if result.Code != 0 {
+		return nil, errors.New(strings.TrimSpace(result.Stderr))
+	}
+	return splitLines(result.Stdout), nil
+}
+
+// StashRebase replays a stash on top of the current working tree with a
+// per-file 3-way merge (stash parent as base). Unlike `git stash pop`, it
+// works when the files were modified after the stash was taken — exactly the
+// state a patch apply leaves behind. On success the stash entry is dropped;
+// conflicts leave markers in the files, keep the stash entry, and surface as
+// a StashConflictError.
+func StashRebase(ctx context.Context, dir string, stashRef string) error {
+	if stashRef == "" {
+		stashRef = "stash@{0}"
+	}
+	var conflicts []string
+
+	tracked, err := stashTrackedFiles(ctx, dir, stashRef)
+	if err != nil {
+		return err
+	}
+	for _, rel := range tracked {
+		conflicted, err := rebaseStashedFile(ctx, dir, stashRef, rel)
+		if err != nil {
+			return err
+		}
+		if conflicted {
+			conflicts = append(conflicts, rel)
+		}
+	}
+
+	untracked, err := stashUntrackedFiles(ctx, dir, stashRef)
+	if err != nil {
+		return err
+	}
+	for _, rel := range untracked {
+		theirs, err := ShowFile(ctx, dir, stashRef+"^3", rel)
+		if err != nil {
+			return err
+		}
+		conflicted, err := mergeIntoWorkingFile(ctx, dir, rel, nil, theirs)
+		if err != nil {
+			return err
+		}
+		if conflicted {
+			conflicts = append(conflicts, rel)
+		}
+	}
+
+	if len(conflicts) > 0 {
+		return &StashConflictError{Files: conflicts}
+	}
+	result, err := Run(ctx, dir, nil, "stash", "drop", stashRef)
+	if err != nil {
+		return err
+	}
 	if result.Code != 0 {
 		return errors.New(strings.TrimSpace(result.Stderr))
 	}
 	return nil
+}
+
+func stashTrackedFiles(ctx context.Context, dir string, stashRef string) ([]string, error) {
+	result, err := Run(ctx, dir, nil, "diff", "--name-only", stashRef+"^1", stashRef)
+	if err != nil {
+		return nil, err
+	}
+	if result.Code != 0 {
+		return nil, errors.New(strings.TrimSpace(result.Stderr))
+	}
+	return splitLines(result.Stdout), nil
+}
+
+func stashUntrackedFiles(ctx context.Context, dir string, stashRef string) ([]string, error) {
+	exists, err := CommitExists(ctx, dir, stashRef+"^3")
+	if err != nil || !exists {
+		return nil, err
+	}
+	result, err := Run(ctx, dir, nil, "ls-tree", "-r", "--name-only", stashRef+"^3")
+	if err != nil {
+		return nil, err
+	}
+	if result.Code != 0 {
+		return nil, errors.New(strings.TrimSpace(result.Stderr))
+	}
+	return splitLines(result.Stdout), nil
+}
+
+func rebaseStashedFile(ctx context.Context, dir string, stashRef string, rel string) (bool, error) {
+	base, baseErr := ShowFile(ctx, dir, stashRef+"^1", rel)
+	if baseErr != nil {
+		base = nil // file did not exist when the stash was taken
+	}
+	theirs, theirsErr := ShowFile(ctx, dir, stashRef, rel)
+	workPath := filepath.Join(dir, filepath.FromSlash(rel))
+	if theirsErr != nil {
+		// Stash recorded a deletion. Re-delete when the tree still matches
+		// the stash base; otherwise keep the newer content and flag it.
+		current, readErr := os.ReadFile(workPath)
+		if readErr != nil {
+			if os.IsNotExist(readErr) {
+				return false, nil
+			}
+			return false, readErr
+		}
+		if base != nil && bytes.Equal(current, base) {
+			return false, os.Remove(workPath)
+		}
+		return true, nil
+	}
+	return mergeIntoWorkingFile(ctx, dir, rel, base, theirs)
+}
+
+// mergeIntoWorkingFile 3-way merges stashed content into the working file.
+// A nil base means the stashed file had no ancestor (brand-new file).
+func mergeIntoWorkingFile(ctx context.Context, dir string, rel string, base []byte, theirs []byte) (bool, error) {
+	workPath := filepath.Join(dir, filepath.FromSlash(rel))
+	current, err := os.ReadFile(workPath)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return false, err
+		}
+		// Nothing in the tree: restore the stashed content verbatim.
+		if err := os.MkdirAll(filepath.Dir(workPath), 0o755); err != nil {
+			return false, err
+		}
+		return false, os.WriteFile(workPath, theirs, 0o644)
+	}
+	if bytes.Equal(current, theirs) {
+		return false, nil
+	}
+
+	tmpDir, err := os.MkdirTemp("", "browseros-patch-stash")
+	if err != nil {
+		return false, err
+	}
+	defer os.RemoveAll(tmpDir)
+	basePath := filepath.Join(tmpDir, "base")
+	theirsPath := filepath.Join(tmpDir, "stashed")
+	if err := os.WriteFile(basePath, base, 0o644); err != nil {
+		return false, err
+	}
+	if err := os.WriteFile(theirsPath, theirs, 0o644); err != nil {
+		return false, err
+	}
+	result, err := Run(ctx, dir, nil,
+		"merge-file",
+		"-L", "local", "-L", "base", "-L", "stashed",
+		workPath, basePath, theirsPath)
+	if err != nil {
+		return false, err
+	}
+	if result.Code < 0 {
+		return false, errors.New(strings.TrimSpace(result.Stderr))
+	}
+	return result.Code > 0, nil
 }
 
 func PullRebase(ctx context.Context, dir string, remote string, branch string) error {

--- a/packages/browseros/tools/patch/internal/git/git.go
+++ b/packages/browseros/tools/patch/internal/git/git.go
@@ -164,7 +164,7 @@ func diffArgs(extra ...string) []string {
 		"-c", "diff.noprefix=false",
 		"-c", "diff.mnemonicPrefix=false",
 		"-c", "core.quotepath=false",
-		"diff", "--binary", "--full-index", "-U3",
+		"diff", "--binary", "--full-index", "-U3", "--no-ext-diff", "--no-textconv",
 	}
 	return append(args, extra...)
 }
@@ -191,6 +191,9 @@ func DiffNoIndex(ctx context.Context, dir string, path string) (string, error) {
 	return result.Stdout, nil
 }
 
+// FileModeAtCommit returns the tree mode (e.g. 100644/100755) for rel at ref,
+// or "" with no error when the path has no entry there. Real git failures
+// propagate so callers don't silently mis-mode files.
 func FileModeAtCommit(ctx context.Context, dir string, ref string, rel string) (string, error) {
 	result, err := Run(ctx, dir, nil, "ls-tree", ref, "--", rel)
 	if err != nil {
@@ -201,7 +204,7 @@ func FileModeAtCommit(ctx context.Context, dir string, ref string, rel string) (
 	}
 	fields := strings.Fields(result.Stdout)
 	if len(fields) == 0 {
-		return "", fmt.Errorf("no tree entry for %s at %s", rel, ref)
+		return "", nil
 	}
 	return fields[0], nil
 }
@@ -295,7 +298,9 @@ func StashPush(ctx context.Context, dir string, message string, includeUntracked
 	if strings.Contains(result.Stdout, "No local changes to save") {
 		return "", nil
 	}
-	list, err := Run(ctx, dir, nil, "stash", "list", "-1", "--format=%gd")
+	// Record the stash by commit SHA: positional stash@{N} refs shift on any
+	// later stash and would make us restore (and drop) the wrong entry.
+	list, err := Run(ctx, dir, nil, "stash", "list", "-1", "--format=%H")
 	if err != nil {
 		return "", err
 	}
@@ -303,6 +308,44 @@ func StashPush(ctx context.Context, dir string, message string, includeUntracked
 		return "", errors.New(strings.TrimSpace(list.Stderr))
 	}
 	return strings.TrimSpace(list.Stdout), nil
+}
+
+// ErrStashNotFound reports a recorded stash that is no longer in the stash
+// list (dropped or popped outside the tool).
+var ErrStashNotFound = errors.New("stash entry not found")
+
+// StashEntryExists reports whether a recorded stash SHA/ref is still listed.
+func StashEntryExists(ctx context.Context, dir string, ref string) (bool, error) {
+	_, err := resolveStashEntry(ctx, dir, ref)
+	if errors.Is(err, ErrStashNotFound) {
+		return false, nil
+	}
+	if err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// resolveStashEntry maps a stash commit SHA or positional ref to the current
+// positional name.
+func resolveStashEntry(ctx context.Context, dir string, ref string) (string, error) {
+	result, err := Run(ctx, dir, nil, "-c", "core.quotepath=false", "stash", "list", "--format=%gd %H")
+	if err != nil {
+		return "", err
+	}
+	if result.Code != 0 {
+		return "", errors.New(strings.TrimSpace(result.Stderr))
+	}
+	for _, line := range splitLines(result.Stdout) {
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			continue
+		}
+		if fields[0] == ref || fields[1] == ref || strings.HasPrefix(fields[1], ref) {
+			return fields[0], nil
+		}
+	}
+	return "", ErrStashNotFound
 }
 
 // StashConflictError reports a stash pop that left merge conflicts in the
@@ -349,20 +392,26 @@ func UnmergedFiles(ctx context.Context, dir string) ([]string, error) {
 // per-file 3-way merge (stash parent as base). Unlike `git stash pop`, it
 // works when the files were modified after the stash was taken — exactly the
 // state a patch apply leaves behind. On success the stash entry is dropped;
-// conflicts leave markers in the files, keep the stash entry, and surface as
-// a StashConflictError.
+// conflicts keep the stash entry and surface as a StashConflictError (content
+// conflicts get markers; modify/delete conflicts restore the stashed bytes
+// for visibility). Accepts a stash commit SHA or a stash@{N} ref; returns
+// ErrStashNotFound when the entry no longer exists.
 func StashRebase(ctx context.Context, dir string, stashRef string) error {
 	if stashRef == "" {
 		stashRef = "stash@{0}"
 	}
+	entry, err := resolveStashEntry(ctx, dir, stashRef)
+	if err != nil {
+		return err
+	}
 	var conflicts []string
 
-	tracked, err := stashTrackedFiles(ctx, dir, stashRef)
+	tracked, err := stashTrackedFiles(ctx, dir, entry)
 	if err != nil {
 		return err
 	}
 	for _, rel := range tracked {
-		conflicted, err := rebaseStashedFile(ctx, dir, stashRef, rel)
+		conflicted, err := rebaseStashedFile(ctx, dir, entry, rel)
 		if err != nil {
 			return err
 		}
@@ -371,12 +420,19 @@ func StashRebase(ctx context.Context, dir string, stashRef string) error {
 		}
 	}
 
-	untracked, err := stashUntrackedFiles(ctx, dir, stashRef)
+	untracked, err := stashUntrackedFiles(ctx, dir, entry)
 	if err != nil {
 		return err
 	}
 	for _, rel := range untracked {
-		theirs, err := ShowFile(ctx, dir, stashRef+"^3", rel)
+		workPath := filepath.Join(dir, filepath.FromSlash(rel))
+		if _, statErr := os.Stat(workPath); os.IsNotExist(statErr) {
+			if err := restoreFromTree(ctx, dir, entry+"^3", rel); err != nil {
+				return err
+			}
+			continue
+		}
+		theirs, err := ShowFile(ctx, dir, entry+"^3", rel)
 		if err != nil {
 			return err
 		}
@@ -392,7 +448,7 @@ func StashRebase(ctx context.Context, dir string, stashRef string) error {
 	if len(conflicts) > 0 {
 		return &StashConflictError{Files: conflicts}
 	}
-	result, err := Run(ctx, dir, nil, "stash", "drop", stashRef)
+	result, err := Run(ctx, dir, nil, "stash", "drop", entry)
 	if err != nil {
 		return err
 	}
@@ -403,7 +459,7 @@ func StashRebase(ctx context.Context, dir string, stashRef string) error {
 }
 
 func stashTrackedFiles(ctx context.Context, dir string, stashRef string) ([]string, error) {
-	result, err := Run(ctx, dir, nil, "diff", "--name-only", stashRef+"^1", stashRef)
+	result, err := Run(ctx, dir, nil, "-c", "core.quotepath=false", "diff", "--name-only", stashRef+"^1", stashRef)
 	if err != nil {
 		return nil, err
 	}
@@ -418,7 +474,7 @@ func stashUntrackedFiles(ctx context.Context, dir string, stashRef string) ([]st
 	if err != nil || !exists {
 		return nil, err
 	}
-	result, err := Run(ctx, dir, nil, "ls-tree", "-r", "--name-only", stashRef+"^3")
+	result, err := Run(ctx, dir, nil, "-c", "core.quotepath=false", "ls-tree", "-r", "--name-only", stashRef+"^3")
 	if err != nil {
 		return nil, err
 	}
@@ -426,6 +482,24 @@ func stashUntrackedFiles(ctx context.Context, dir string, stashRef string) ([]st
 		return nil, errors.New(strings.TrimSpace(result.Stderr))
 	}
 	return splitLines(result.Stdout), nil
+}
+
+// restoreFromTree writes a file from a tree-ish into the working tree,
+// preserving the executable bit recorded there.
+func restoreFromTree(ctx context.Context, dir string, treeish string, rel string) error {
+	content, err := ShowFile(ctx, dir, treeish, rel)
+	if err != nil {
+		return err
+	}
+	perm := os.FileMode(0o644)
+	if mode, modeErr := FileModeAtCommit(ctx, dir, treeish, rel); modeErr == nil && mode == "100755" {
+		perm = 0o755
+	}
+	workPath := filepath.Join(dir, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(workPath), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(workPath, content, perm)
 }
 
 func rebaseStashedFile(ctx context.Context, dir string, stashRef string, rel string) (bool, error) {
@@ -450,6 +524,15 @@ func rebaseStashedFile(ctx context.Context, dir string, stashRef string, rel str
 		}
 		return true, nil
 	}
+	if _, statErr := os.Stat(workPath); os.IsNotExist(statErr) {
+		// The file is gone from the tree (e.g. a patch deleted it) while the
+		// stash modified it: a modify/delete conflict. Restore the stashed
+		// content so the user can see and decide, and keep the stash entry.
+		if err := restoreFromTree(ctx, dir, stashRef, rel); err != nil {
+			return false, err
+		}
+		return base != nil, nil
+	}
 	return mergeIntoWorkingFile(ctx, dir, rel, base, theirs)
 }
 
@@ -459,14 +542,7 @@ func mergeIntoWorkingFile(ctx context.Context, dir string, rel string, base []by
 	workPath := filepath.Join(dir, filepath.FromSlash(rel))
 	current, err := os.ReadFile(workPath)
 	if err != nil {
-		if !os.IsNotExist(err) {
-			return false, err
-		}
-		// Nothing in the tree: restore the stashed content verbatim.
-		if err := os.MkdirAll(filepath.Dir(workPath), 0o755); err != nil {
-			return false, err
-		}
-		return false, os.WriteFile(workPath, theirs, 0o644)
+		return false, err
 	}
 	if bytes.Equal(current, theirs) {
 		return false, nil
@@ -492,7 +568,8 @@ func mergeIntoWorkingFile(ctx context.Context, dir string, rel string, base []by
 	if err != nil {
 		return false, err
 	}
-	if result.Code < 0 {
+	// merge-file exits with the conflict count; large codes signal errors.
+	if result.Code < 0 || result.Code > 127 {
 		return false, errors.New(strings.TrimSpace(result.Stderr))
 	}
 	return result.Code > 0, nil

--- a/packages/browseros/tools/patch/internal/git/git.go
+++ b/packages/browseros/tools/patch/internal/git/git.go
@@ -494,8 +494,8 @@ func stashUntrackedFiles(ctx context.Context, dir string, stashRef string) ([]st
 	return splitLines(result.Stdout), nil
 }
 
-// looksBinary mirrors git's heuristic: a NUL within the first 8000 bytes.
-func looksBinary(content []byte) bool {
+// LooksBinary mirrors git's heuristic: a NUL within the first 8000 bytes.
+func LooksBinary(content []byte) bool {
 	probe := content
 	if len(probe) > 8000 {
 		probe = probe[:8000]
@@ -584,7 +584,7 @@ func mergeIntoWorkingFile(ctx context.Context, dir string, rel string, base []by
 	// merge-file cannot merge binary content (exit 255). Treat diverged
 	// binaries as a conflict the user resolves by hand — never a hard error
 	// that would wedge sync retries.
-	if looksBinary(current) || looksBinary(theirs) || looksBinary(base) {
+	if LooksBinary(current) || LooksBinary(theirs) || LooksBinary(base) {
 		return true, nil
 	}
 

--- a/packages/browseros/tools/patch/internal/git/git.go
+++ b/packages/browseros/tools/patch/internal/git/git.go
@@ -163,6 +163,10 @@ func diffArgs(extra ...string) []string {
 		"-c", "diff.algorithm=myers",
 		"-c", "diff.noprefix=false",
 		"-c", "diff.mnemonicPrefix=false",
+		"-c", "diff.srcPrefix=a/",
+		"-c", "diff.dstPrefix=b/",
+		"-c", "diff.interHunkContext=0",
+		"-c", "diff.suppressBlankEmpty=false",
 		"-c", "core.quotepath=false",
 		"diff", "--binary", "--full-index", "-U3", "--no-ext-diff", "--no-textconv",
 	}
@@ -361,7 +365,13 @@ func (e *StashConflictError) Error() string {
 func StashPop(ctx context.Context, dir string, stashRef string) error {
 	args := []string{"stash", "pop"}
 	if stashRef != "" {
-		args = append(args, stashRef)
+		// git stash pop rejects raw commit SHAs; translate to the current
+		// positional entry (also catches records that no longer exist).
+		entry, err := resolveStashEntry(ctx, dir, stashRef)
+		if err != nil {
+			return err
+		}
+		args = append(args, entry)
 	}
 	result, err := Run(ctx, dir, nil, args...)
 	if err != nil {
@@ -484,6 +494,15 @@ func stashUntrackedFiles(ctx context.Context, dir string, stashRef string) ([]st
 	return splitLines(result.Stdout), nil
 }
 
+// looksBinary mirrors git's heuristic: a NUL within the first 8000 bytes.
+func looksBinary(content []byte) bool {
+	probe := content
+	if len(probe) > 8000 {
+		probe = probe[:8000]
+	}
+	return bytes.IndexByte(probe, 0) != -1
+}
+
 // restoreFromTree writes a file from a tree-ish into the working tree,
 // preserving the executable bit recorded there.
 func restoreFromTree(ctx context.Context, dir string, treeish string, rel string) error {
@@ -503,13 +522,24 @@ func restoreFromTree(ctx context.Context, dir string, treeish string, rel string
 }
 
 func rebaseStashedFile(ctx context.Context, dir string, stashRef string, rel string) (bool, error) {
-	base, baseErr := ShowFile(ctx, dir, stashRef+"^1", rel)
-	if baseErr != nil {
-		base = nil // file did not exist when the stash was taken
+	// Distinguish "path absent at ref" from real git failures before reading
+	// content — conflating them could misread an outage as a deletion.
+	baseExists, err := FileExistsAtCommit(ctx, dir, stashRef+"^1", rel)
+	if err != nil {
+		return false, err
 	}
-	theirs, theirsErr := ShowFile(ctx, dir, stashRef, rel)
+	var base []byte
+	if baseExists {
+		if base, err = ShowFile(ctx, dir, stashRef+"^1", rel); err != nil {
+			return false, err
+		}
+	}
+	theirsExists, err := FileExistsAtCommit(ctx, dir, stashRef, rel)
+	if err != nil {
+		return false, err
+	}
 	workPath := filepath.Join(dir, filepath.FromSlash(rel))
-	if theirsErr != nil {
+	if !theirsExists {
 		// Stash recorded a deletion. Re-delete when the tree still matches
 		// the stash base; otherwise keep the newer content and flag it.
 		current, readErr := os.ReadFile(workPath)
@@ -519,10 +549,14 @@ func rebaseStashedFile(ctx context.Context, dir string, stashRef string, rel str
 			}
 			return false, readErr
 		}
-		if base != nil && bytes.Equal(current, base) {
+		if baseExists && bytes.Equal(current, base) {
 			return false, os.Remove(workPath)
 		}
 		return true, nil
+	}
+	theirs, err := ShowFile(ctx, dir, stashRef, rel)
+	if err != nil {
+		return false, err
 	}
 	if _, statErr := os.Stat(workPath); os.IsNotExist(statErr) {
 		// The file is gone from the tree (e.g. a patch deleted it) while the
@@ -531,7 +565,7 @@ func rebaseStashedFile(ctx context.Context, dir string, stashRef string, rel str
 		if err := restoreFromTree(ctx, dir, stashRef, rel); err != nil {
 			return false, err
 		}
-		return base != nil, nil
+		return baseExists, nil
 	}
 	return mergeIntoWorkingFile(ctx, dir, rel, base, theirs)
 }
@@ -546,6 +580,12 @@ func mergeIntoWorkingFile(ctx context.Context, dir string, rel string, base []by
 	}
 	if bytes.Equal(current, theirs) {
 		return false, nil
+	}
+	// merge-file cannot merge binary content (exit 255). Treat diverged
+	// binaries as a conflict the user resolves by hand — never a hard error
+	// that would wedge sync retries.
+	if looksBinary(current) || looksBinary(theirs) || looksBinary(base) {
+		return true, nil
 	}
 
 	tmpDir, err := os.MkdirTemp("", "browseros-patch-stash")

--- a/packages/browseros/tools/patch/internal/git/git.go
+++ b/packages/browseros/tools/patch/internal/git/git.go
@@ -155,8 +155,22 @@ func ResetPathToCommit(ctx context.Context, dir string, ref string, rel string) 
 	return os.RemoveAll(target)
 }
 
+// diffArgs builds a diff invocation whose output is a pure function of the
+// compared content: per-checkout config (abbrev, prefixes, algorithm, context)
+// must not leak into patch files that get committed to the patch repo.
+func diffArgs(extra ...string) []string {
+	args := []string{
+		"-c", "diff.algorithm=myers",
+		"-c", "diff.noprefix=false",
+		"-c", "diff.mnemonicPrefix=false",
+		"-c", "core.quotepath=false",
+		"diff", "--binary", "--full-index", "-U3",
+	}
+	return append(args, extra...)
+}
+
 func DiffText(ctx context.Context, dir string, args ...string) (string, error) {
-	result, err := Run(ctx, dir, nil, append([]string{"diff", "--binary", "-M"}, args...)...)
+	result, err := Run(ctx, dir, nil, diffArgs(append([]string{"-M"}, args...)...)...)
 	if err != nil {
 		return "", err
 	}
@@ -167,7 +181,7 @@ func DiffText(ctx context.Context, dir string, args ...string) (string, error) {
 }
 
 func DiffNoIndex(ctx context.Context, dir string, path string) (string, error) {
-	result, err := Run(ctx, dir, nil, "diff", "--binary", "--no-index", "--", "/dev/null", path)
+	result, err := Run(ctx, dir, nil, diffArgs("--no-index", "--", "/dev/null", path)...)
 	if err != nil {
 		return "", err
 	}
@@ -175,6 +189,21 @@ func DiffNoIndex(ctx context.Context, dir string, path string) (string, error) {
 		return "", errors.New(strings.TrimSpace(result.Stderr))
 	}
 	return result.Stdout, nil
+}
+
+func FileModeAtCommit(ctx context.Context, dir string, ref string, rel string) (string, error) {
+	result, err := Run(ctx, dir, nil, "ls-tree", ref, "--", rel)
+	if err != nil {
+		return "", err
+	}
+	if result.Code != 0 {
+		return "", errors.New(strings.TrimSpace(result.Stderr))
+	}
+	fields := strings.Fields(result.Stdout)
+	if len(fields) == 0 {
+		return "", fmt.Errorf("no tree entry for %s at %s", rel, ref)
+	}
+	return fields[0], nil
 }
 
 func ListUntracked(ctx context.Context, dir string, pathspecs []string) ([]string, error) {

--- a/packages/browseros/tools/patch/internal/git/git_test.go
+++ b/packages/browseros/tools/patch/internal/git/git_test.go
@@ -2,6 +2,7 @@ package git
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -86,8 +87,12 @@ func TestFileModeAtCommit(t *testing.T) {
 	if mode != "100755" {
 		t.Fatalf("exec mode = %q, want 100755", mode)
 	}
-	if _, err := FileModeAtCommit(ctx, dir, "HEAD", "missing.txt"); err == nil {
-		t.Fatalf("expected error for missing path")
+	mode, err = FileModeAtCommit(ctx, dir, "HEAD", "missing.txt")
+	if err != nil {
+		t.Fatalf("missing path must not be a git failure: %v", err)
+	}
+	if mode != "" {
+		t.Fatalf("missing path mode = %q, want empty", mode)
 	}
 }
 
@@ -117,6 +122,98 @@ func writeFile(t *testing.T, path string, body string) {
 	}
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
+	}
+}
+
+func TestStashRebaseFlagsModifyDeleteConflict(t *testing.T) {
+	ctx := context.Background()
+	dir := initGitRepo(t)
+	writeFile(t, filepath.Join(dir, "f.txt"), "base\n")
+	runGit(t, dir, "add", "f.txt")
+	runGit(t, dir, "commit", "-m", "base")
+
+	// Local modification parked in a stash, then the file is deleted from
+	// the tree (as a .deleted patch would do).
+	writeFile(t, filepath.Join(dir, "f.txt"), "local edit\n")
+	sha, err := StashPush(ctx, dir, "test", true, []string{"f.txt"})
+	if err != nil {
+		t.Fatalf("StashPush: %v", err)
+	}
+	if len(sha) != 40 {
+		t.Fatalf("StashPush should return a commit SHA, got %q", sha)
+	}
+	if err := os.Remove(filepath.Join(dir, "f.txt")); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+
+	err = StashRebase(ctx, dir, sha)
+	var conflict *StashConflictError
+	if !errors.As(err, &conflict) {
+		t.Fatalf("expected StashConflictError, got %v", err)
+	}
+	if len(conflict.Files) != 1 || conflict.Files[0] != "f.txt" {
+		t.Fatalf("conflict files = %v, want [f.txt]", conflict.Files)
+	}
+	// Stashed content restored for visibility; stash entry kept.
+	data, err := os.ReadFile(filepath.Join(dir, "f.txt"))
+	if err != nil {
+		t.Fatalf("read restored file: %v", err)
+	}
+	if string(data) != "local edit\n" {
+		t.Fatalf("restored content = %q", string(data))
+	}
+	if exists, err := StashEntryExists(ctx, dir, sha); err != nil || !exists {
+		t.Fatalf("stash entry must survive a conflict (exists=%v err=%v)", exists, err)
+	}
+}
+
+func TestStashRebaseRestoresUntrackedExecutableBySHA(t *testing.T) {
+	ctx := context.Background()
+	dir := initGitRepo(t)
+	writeFile(t, filepath.Join(dir, "f.txt"), "base\n")
+	runGit(t, dir, "add", "f.txt")
+	runGit(t, dir, "commit", "-m", "base")
+
+	writeFile(t, filepath.Join(dir, "tool.sh"), "#!/bin/sh\n")
+	if err := os.Chmod(filepath.Join(dir, "tool.sh"), 0o755); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	sha, err := StashPush(ctx, dir, "test", true, []string{"tool.sh"})
+	if err != nil {
+		t.Fatalf("StashPush: %v", err)
+	}
+
+	// An unrelated stash shifts positional refs; the SHA must still resolve.
+	writeFile(t, filepath.Join(dir, "f.txt"), "other\n")
+	if _, err := StashPush(ctx, dir, "other", true, []string{"f.txt"}); err != nil {
+		t.Fatalf("second StashPush: %v", err)
+	}
+
+	if err := StashRebase(ctx, dir, sha); err != nil {
+		t.Fatalf("StashRebase: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(dir, "tool.sh"))
+	if err != nil {
+		t.Fatalf("stat restored file: %v", err)
+	}
+	if info.Mode()&0o100 == 0 {
+		t.Fatalf("restored file lost the executable bit: %v", info.Mode())
+	}
+	if exists, err := StashEntryExists(ctx, dir, sha); err != nil || exists {
+		t.Fatalf("rebased stash should be dropped (exists=%v err=%v)", exists, err)
+	}
+}
+
+func TestStashRebaseReportsMissingEntry(t *testing.T) {
+	ctx := context.Background()
+	dir := initGitRepo(t)
+	writeFile(t, filepath.Join(dir, "f.txt"), "base\n")
+	runGit(t, dir, "add", "f.txt")
+	runGit(t, dir, "commit", "-m", "base")
+
+	err := StashRebase(ctx, dir, "0123456789abcdef0123456789abcdef01234567")
+	if !errors.Is(err, ErrStashNotFound) {
+		t.Fatalf("expected ErrStashNotFound, got %v", err)
 	}
 }
 

--- a/packages/browseros/tools/patch/internal/git/git_test.go
+++ b/packages/browseros/tools/patch/internal/git/git_test.go
@@ -3,10 +3,122 @@ package git
 import (
 	"context"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 	"time"
 )
+
+var fullIndexLine = regexp.MustCompile(`(?m)^index [0-9a-f]{40}\.\.[0-9a-f]{40}`)
+var fullIndexAddLine = regexp.MustCompile(`(?m)^index 0{40}\.\.[0-9a-f]{40}`)
+
+func TestDiffTextEmitsFullIndexRegardlessOfRepoConfig(t *testing.T) {
+	ctx := context.Background()
+	dir := initGitRepo(t)
+	// Hostile per-checkout config that must not leak into tool output.
+	runGit(t, dir, "config", "core.abbrev", "9")
+	runGit(t, dir, "config", "diff.noprefix", "true")
+	runGit(t, dir, "config", "diff.mnemonicPrefix", "true")
+	runGit(t, dir, "config", "diff.algorithm", "histogram")
+	runGit(t, dir, "config", "diff.context", "8")
+
+	writeFile(t, filepath.Join(dir, "f.txt"), "one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten\n")
+	runGit(t, dir, "add", "f.txt")
+	runGit(t, dir, "commit", "-m", "base")
+	writeFile(t, filepath.Join(dir, "f.txt"), "one\ntwo\nthree\nfour\nCHANGED\nsix\nseven\neight\nnine\nten\n")
+
+	diff, err := DiffText(ctx, dir, "HEAD")
+	if err != nil {
+		t.Fatalf("DiffText: %v", err)
+	}
+	if !fullIndexLine.MatchString(diff) {
+		t.Fatalf("expected full 40-hex index line, got:\n%s", diff)
+	}
+	if !strings.Contains(diff, "--- a/f.txt") || !strings.Contains(diff, "+++ b/f.txt") {
+		t.Fatalf("expected a/ b/ prefixes despite noprefix/mnemonicPrefix config, got:\n%s", diff)
+	}
+	if !strings.Contains(diff, "@@ -2,7 +2,7 @@") {
+		t.Fatalf("expected default 3-line context despite diff.context=8, got:\n%s", diff)
+	}
+}
+
+func TestDiffNoIndexEmitsFullIndexNewFile(t *testing.T) {
+	ctx := context.Background()
+	dir := initGitRepo(t)
+	writeFile(t, filepath.Join(dir, "new.txt"), "hello\n")
+
+	diff, err := DiffNoIndex(ctx, dir, "new.txt")
+	if err != nil {
+		t.Fatalf("DiffNoIndex: %v", err)
+	}
+	if !strings.Contains(diff, "new file mode 100644") {
+		t.Fatalf("expected new file mode, got:\n%s", diff)
+	}
+	if !fullIndexAddLine.MatchString(diff) {
+		t.Fatalf("expected full-index add line, got:\n%s", diff)
+	}
+}
+
+func TestFileModeAtCommit(t *testing.T) {
+	ctx := context.Background()
+	dir := initGitRepo(t)
+	writeFile(t, filepath.Join(dir, "plain.txt"), "x\n")
+	writeFile(t, filepath.Join(dir, "tool.sh"), "#!/bin/sh\n")
+	if err := os.Chmod(filepath.Join(dir, "tool.sh"), 0o755); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	runGit(t, dir, "add", "plain.txt", "tool.sh")
+	runGit(t, dir, "commit", "-m", "base")
+
+	mode, err := FileModeAtCommit(ctx, dir, "HEAD", "plain.txt")
+	if err != nil {
+		t.Fatalf("FileModeAtCommit plain: %v", err)
+	}
+	if mode != "100644" {
+		t.Fatalf("plain mode = %q, want 100644", mode)
+	}
+	mode, err = FileModeAtCommit(ctx, dir, "HEAD", "tool.sh")
+	if err != nil {
+		t.Fatalf("FileModeAtCommit exec: %v", err)
+	}
+	if mode != "100755" {
+		t.Fatalf("exec mode = %q, want 100755", mode)
+	}
+	if _, err := FileModeAtCommit(ctx, dir, "HEAD", "missing.txt"); err == nil {
+		t.Fatalf("expected error for missing path")
+	}
+}
+
+func initGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.name", "Test User")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	return dir
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, string(output))
+	}
+}
+
+func writeFile(t *testing.T, path string, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}
 
 func TestRunReturnsContextError(t *testing.T) {
 	home := t.TempDir()

--- a/packages/browseros/tools/patch/internal/git/git_test.go
+++ b/packages/browseros/tools/patch/internal/git/git_test.go
@@ -3,6 +3,7 @@ package git
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -24,11 +25,23 @@ func TestDiffTextEmitsFullIndexRegardlessOfRepoConfig(t *testing.T) {
 	runGit(t, dir, "config", "diff.mnemonicPrefix", "true")
 	runGit(t, dir, "config", "diff.algorithm", "histogram")
 	runGit(t, dir, "config", "diff.context", "8")
+	runGit(t, dir, "config", "diff.interHunkContext", "10")
+	runGit(t, dir, "config", "diff.suppressBlankEmpty", "true")
+	runGit(t, dir, "config", "diff.srcPrefix", "x/")
+	runGit(t, dir, "config", "diff.dstPrefix", "y/")
 
-	writeFile(t, filepath.Join(dir, "f.txt"), "one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten\n")
+	var lines []string
+	for i := 1; i <= 20; i++ {
+		lines = append(lines, fmt.Sprintf("l%d", i))
+	}
+	lines[3] = "" // blank context line inside the first hunk
+	base := strings.Join(lines, "\n") + "\n"
+	writeFile(t, filepath.Join(dir, "f.txt"), base)
 	runGit(t, dir, "add", "f.txt")
 	runGit(t, dir, "commit", "-m", "base")
-	writeFile(t, filepath.Join(dir, "f.txt"), "one\ntwo\nthree\nfour\nCHANGED\nsix\nseven\neight\nnine\nten\n")
+	lines[1] = "CHANGED2"
+	lines[17] = "CHANGED18"
+	writeFile(t, filepath.Join(dir, "f.txt"), strings.Join(lines, "\n")+"\n")
 
 	diff, err := DiffText(ctx, dir, "HEAD")
 	if err != nil {
@@ -38,10 +51,13 @@ func TestDiffTextEmitsFullIndexRegardlessOfRepoConfig(t *testing.T) {
 		t.Fatalf("expected full 40-hex index line, got:\n%s", diff)
 	}
 	if !strings.Contains(diff, "--- a/f.txt") || !strings.Contains(diff, "+++ b/f.txt") {
-		t.Fatalf("expected a/ b/ prefixes despite noprefix/mnemonicPrefix config, got:\n%s", diff)
+		t.Fatalf("expected a/ b/ prefixes despite prefix config, got:\n%s", diff)
 	}
-	if !strings.Contains(diff, "@@ -2,7 +2,7 @@") {
-		t.Fatalf("expected default 3-line context despite diff.context=8, got:\n%s", diff)
+	if !strings.Contains(diff, "@@ -1,5 +1,5 @@") || !strings.Contains(diff, "@@ -15,6 +15,6 @@") {
+		t.Fatalf("expected two default-context hunks despite diff.context/interHunkContext, got:\n%s", diff)
+	}
+	if !strings.Contains(diff, "\n \n") {
+		t.Fatalf("expected blank context lines to keep their space despite suppressBlankEmpty, got:\n%q", diff)
 	}
 }
 

--- a/packages/browseros/tools/patch/internal/patch/ignore.go
+++ b/packages/browseros/tools/patch/internal/patch/ignore.go
@@ -1,0 +1,85 @@
+package patch
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+const IgnoreFileName = ".browseros-patchignore"
+
+// IgnoreSet filters untracked checkout files (local junk) out of patch sets.
+// Tracked modifications are never filtered — a patch to a real Chromium file
+// always wins over an ignore pattern.
+type IgnoreSet struct {
+	patterns []string
+}
+
+// DefaultIgnorePatterns covers tool state and scratch files that must never
+// be extracted into the patch repo.
+func DefaultIgnorePatterns() []string {
+	return []string{
+		".llm/",
+		".browseros-patch/",
+		"*.log",
+		"*.rej",
+		"*.orig",
+		".DS_Store",
+	}
+}
+
+// LoadIgnoreSet merges the built-in defaults, the optional repo-root
+// .browseros-patchignore file, and per-run extra patterns.
+func LoadIgnoreSet(repoRoot string, extra []string) (*IgnoreSet, error) {
+	patterns := DefaultIgnorePatterns()
+	data, err := os.ReadFile(filepath.Join(repoRoot, IgnoreFileName))
+	switch {
+	case err == nil:
+		for _, line := range strings.Split(string(data), "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			patterns = append(patterns, line)
+		}
+	case !os.IsNotExist(err):
+		return nil, err
+	}
+	patterns = append(patterns, extra...)
+	return &IgnoreSet{patterns: patterns}, nil
+}
+
+func (s *IgnoreSet) Match(rel string) bool {
+	if s == nil {
+		return false
+	}
+	candidate := NormalizeChromiumPath(rel)
+	for _, pattern := range s.patterns {
+		if matchIgnorePattern(pattern, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchIgnorePattern implements a documented gitignore subset:
+// trailing "/" matches the directory at any depth, a pattern containing "/"
+// globs against the full relative path, anything else globs the basename.
+func matchIgnorePattern(pattern string, rel string) bool {
+	pattern = strings.TrimSpace(pattern)
+	if pattern == "" {
+		return false
+	}
+	if dir, isDir := strings.CutSuffix(pattern, "/"); isDir {
+		return rel == dir ||
+			strings.HasPrefix(rel, dir+"/") ||
+			strings.Contains(rel, "/"+dir+"/")
+	}
+	if strings.Contains(pattern, "/") {
+		ok, err := path.Match(pattern, rel)
+		return err == nil && ok
+	}
+	ok, err := path.Match(pattern, path.Base(rel))
+	return err == nil && ok
+}

--- a/packages/browseros/tools/patch/internal/patch/ignore_test.go
+++ b/packages/browseros/tools/patch/internal/patch/ignore_test.go
@@ -1,0 +1,112 @@
+package patch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIgnoreSetDefaultPatterns(t *testing.T) {
+	set, err := LoadIgnoreSet(t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("LoadIgnoreSet: %v", err)
+	}
+	for _, rel := range []string{
+		".llm/task.md",
+		"chrome/.llm/notes.md",
+		".browseros-patch/state.yaml",
+		"debug.log",
+		"chrome/browser/debug.log",
+		"chrome/browser/foo.cc.rej",
+		"chrome/browser/foo.cc.orig",
+		".DS_Store",
+		"chrome/app/.DS_Store",
+	} {
+		if !set.Match(rel) {
+			t.Fatalf("expected default ignore to match %q", rel)
+		}
+	}
+	for _, rel := range []string{
+		"chrome/browser/foo.cc",
+		"chrome/login.cc",
+		"chrome/llm/feature.cc",
+		"tools/logger.cc",
+	} {
+		if set.Match(rel) {
+			t.Fatalf("expected default ignore not to match %q", rel)
+		}
+	}
+}
+
+func TestIgnoreSetNilNeverMatches(t *testing.T) {
+	var set *IgnoreSet
+	if set.Match(".llm/task.md") {
+		t.Fatalf("nil ignore set must not match")
+	}
+}
+
+func TestLoadIgnoreSetReadsRepoFileAndExtras(t *testing.T) {
+	root := t.TempDir()
+	body := "# local junk\n\nscratch/\n*.tmp\nchrome/generated/*.json\n"
+	if err := os.WriteFile(filepath.Join(root, ".browseros-patchignore"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write ignore file: %v", err)
+	}
+	set, err := LoadIgnoreSet(root, []string{"third_party/sparkle/"})
+	if err != nil {
+		t.Fatalf("LoadIgnoreSet: %v", err)
+	}
+	cases := map[string]bool{
+		"scratch/notes.md":              true,
+		"chrome/scratch/notes.md":       true,
+		"build.tmp":                     true,
+		"chrome/generated/strings.json": true,
+		"chrome/generated/sub/x.json":   false,
+		"third_party/sparkle/bin":       true,
+		"chrome/real.cc":                false,
+	}
+	for rel, want := range cases {
+		if got := set.Match(rel); got != want {
+			t.Fatalf("Match(%q) = %v, want %v", rel, got, want)
+		}
+	}
+}
+
+func TestBuildWorkingTreePatchSetAppliesIgnoreToUntrackedOnly(t *testing.T) {
+	ctx := t.Context()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.name", "Test User")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+
+	// Tracked file whose name matches an ignore pattern: must stay visible.
+	writeRepoFile(t, filepath.Join(dir, "chrome", "trace.log"), "tracked\n")
+	runGit(t, dir, "add", "chrome/trace.log")
+	runGit(t, dir, "commit", "-m", "base")
+	base := gitOutput(t, dir, "rev-parse", "HEAD")
+	writeRepoFile(t, filepath.Join(dir, "chrome", "trace.log"), "tracked modified\n")
+
+	// Untracked junk and untracked real content.
+	writeRepoFile(t, filepath.Join(dir, ".llm", "scratch.md"), "junk\n")
+	writeRepoFile(t, filepath.Join(dir, "debug.log"), "junk\n")
+	writeRepoFile(t, filepath.Join(dir, "chrome", "feature.cc"), "real\n")
+
+	ign, err := LoadIgnoreSet(t.TempDir(), nil)
+	if err != nil {
+		t.Fatalf("LoadIgnoreSet: %v", err)
+	}
+	set, err := BuildWorkingTreePatchSet(ctx, dir, WorkingTreeOptions{Base: base, Ignore: ign})
+	if err != nil {
+		t.Fatalf("BuildWorkingTreePatchSet: %v", err)
+	}
+	if _, ok := set["chrome/trace.log"]; !ok {
+		t.Fatalf("tracked modification must never be ignored, got %v", set)
+	}
+	if _, ok := set["chrome/feature.cc"]; !ok {
+		t.Fatalf("untracked real content should be present, got %v", set)
+	}
+	for _, junk := range []string{".llm/scratch.md", "debug.log"} {
+		if _, ok := set[junk]; ok {
+			t.Fatalf("untracked junk %q should be ignored", junk)
+		}
+	}
+}

--- a/packages/browseros/tools/patch/internal/patch/patch_test.go
+++ b/packages/browseros/tools/patch/internal/patch/patch_test.go
@@ -62,7 +62,7 @@ rename to chrome/new.cc
 `),
 		},
 	}
-	if _, _, err := WriteRepoPatchSet(patchesDir, set, nil); err != nil {
+	if _, _, _, err := WriteRepoPatchSet(patchesDir, set, nil); err != nil {
 		t.Fatalf("WriteRepoPatchSet: %v", err)
 	}
 	if _, err := filepath.Abs(filepath.Join(patchesDir, "chrome", "dead.cc.deleted")); err != nil {
@@ -114,6 +114,139 @@ func TestBuildRangePatchSetUsesLatestBaseScopedPatch(t *testing.T) {
 	}
 	if strings.Contains(content, "+two") {
 		t.Fatalf("expected latest base-scoped patch, got %q", content)
+	}
+}
+
+func modifyPatch(rel string, indexLine string, addedLine string) FilePatch {
+	content := "diff --git a/" + rel + " b/" + rel + "\n" +
+		indexLine + "\n" +
+		"--- a/" + rel + "\n" +
+		"+++ b/" + rel + "\n" +
+		"@@ -1 +1 @@\n" +
+		"-old\n" +
+		"+" + addedLine + "\n"
+	return FilePatch{Path: rel, Op: OpModify, Content: []byte(content)}
+}
+
+const fullIndex = "index 0000000000000000000000000000000000000000..1111111111111111111111111111111111111111 100644"
+const abbrevIndex = "index 000000000000a..111111111111b 100644"
+
+func TestWriteRepoPatchSetSkipsUnchangedFiles(t *testing.T) {
+	patchesDir := t.TempDir()
+	rel := "chrome/foo.cc"
+	set := PatchSet{rel: modifyPatch(rel, fullIndex, "new")}
+
+	written, _, _, err := WriteRepoPatchSet(patchesDir, set, nil)
+	if err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if len(written) != 1 {
+		t.Fatalf("first write should create the file, wrote %v", written)
+	}
+
+	// Simulate a legacy on-disk patch: same hunks, abbreviated index line.
+	legacy := string(modifyPatch(rel, abbrevIndex, "new").Content)
+	target := filepath.Join(patchesDir, "chrome", "foo.cc")
+	if err := os.WriteFile(target, []byte(legacy), 0o644); err != nil {
+		t.Fatalf("write legacy: %v", err)
+	}
+
+	written, deleted, unchanged, err := WriteRepoPatchSet(patchesDir, set, nil)
+	if err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	if len(written) != 0 || len(deleted) != 0 {
+		t.Fatalf("expected no-op write, got written=%v deleted=%v", written, deleted)
+	}
+	if len(unchanged) != 1 || unchanged[0] != rel {
+		t.Fatalf("expected %s unchanged, got %v", rel, unchanged)
+	}
+	after, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(after) != legacy {
+		t.Fatalf("legacy bytes must be preserved verbatim\n--- want ---\n%q\n--- got ---\n%q", legacy, string(after))
+	}
+}
+
+func TestWriteRepoPatchSetRewritesChangedContent(t *testing.T) {
+	patchesDir := t.TempDir()
+	rel := "chrome/foo.cc"
+	if _, _, _, err := WriteRepoPatchSet(patchesDir, PatchSet{rel: modifyPatch(rel, fullIndex, "new")}, nil); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+
+	next := modifyPatch(rel, fullIndex, "different")
+	written, _, unchanged, err := WriteRepoPatchSet(patchesDir, PatchSet{rel: next}, nil)
+	if err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	if len(written) != 1 || written[0] != rel {
+		t.Fatalf("expected rewrite of %s, got written=%v unchanged=%v", rel, written, unchanged)
+	}
+	after, err := os.ReadFile(filepath.Join(patchesDir, "chrome", "foo.cc"))
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(after) != string(next.Content) {
+		t.Fatalf("expected canonical rewrite, got %q", string(after))
+	}
+}
+
+func TestWriteRepoPatchSetSkipsUnchangedMarkers(t *testing.T) {
+	patchesDir := t.TempDir()
+	set := PatchSet{"chrome/dead.cc": {Path: "chrome/dead.cc", Op: OpDelete}}
+	if _, _, _, err := WriteRepoPatchSet(patchesDir, set, nil); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	written, _, unchanged, err := WriteRepoPatchSet(patchesDir, set, nil)
+	if err != nil {
+		t.Fatalf("second write: %v", err)
+	}
+	if len(written) != 0 || len(unchanged) != 1 {
+		t.Fatalf("expected marker to be skip-stable, written=%v unchanged=%v", written, unchanged)
+	}
+}
+
+func TestPlanRepoPatchSetClassifies(t *testing.T) {
+	patchesDir := t.TempDir()
+	existingSame := modifyPatch("chrome/same.cc", fullIndex, "new")
+	existingDiff := modifyPatch("chrome/diff.cc", fullIndex, "new")
+	existingGone := modifyPatch("chrome/gone.cc", fullIndex, "new")
+	seed := PatchSet{
+		"chrome/same.cc": existingSame,
+		"chrome/diff.cc": existingDiff,
+		"chrome/gone.cc": existingGone,
+	}
+	if _, _, _, err := WriteRepoPatchSet(patchesDir, seed, nil); err != nil {
+		t.Fatalf("seed write: %v", err)
+	}
+
+	incoming := PatchSet{
+		"chrome/same.cc": existingSame,
+		"chrome/diff.cc": modifyPatch("chrome/diff.cc", fullIndex, "changed"),
+		"chrome/new.cc":  modifyPatch("chrome/new.cc", fullIndex, "new"),
+	}
+	plan, err := PlanRepoPatchSet(patchesDir, incoming, nil)
+	if err != nil {
+		t.Fatalf("PlanRepoPatchSet: %v", err)
+	}
+	assertStrings(t, "creates", plan.Creates, []string{"chrome/new.cc"})
+	assertStrings(t, "updates", plan.Updates, []string{"chrome/diff.cc"})
+	assertStrings(t, "unchanged", plan.Unchanged, []string{"chrome/same.cc"})
+	assertStrings(t, "deletes", plan.Deletes, []string{"chrome/gone.cc"})
+}
+
+func assertStrings(t *testing.T, label string, got []string, want []string) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("%s = %v, want %v", label, got, want)
+	}
+	for idx := range want {
+		if got[idx] != want[idx] {
+			t.Fatalf("%s = %v, want %v", label, got, want)
+		}
 	}
 }
 

--- a/packages/browseros/tools/patch/internal/patch/patch_test.go
+++ b/packages/browseros/tools/patch/internal/patch/patch_test.go
@@ -258,6 +258,8 @@ func TestSyntheticAddPatchMatchesGitByteForByte(t *testing.T) {
 		mode os.FileMode
 	}{
 		{name: "multi line", rel: "chrome/notes.txt", body: "alpha\nbeta\ngamma\n", mode: 0o644},
+		{name: "single line", rel: "chrome/one.txt", body: "single\n", mode: 0o644},
+		{name: "single line no newline", rel: "chrome/one_nonl.txt", body: "single", mode: 0o644},
 		{name: "no trailing newline", rel: "chrome/nonl.txt", body: "alpha\nbeta", mode: 0o644},
 		{name: "empty file", rel: "chrome/empty.txt", body: "", mode: 0o644},
 		{name: "executable", rel: "chrome/tool.sh", body: "#!/bin/sh\necho hi\n", mode: 0o755},

--- a/packages/browseros/tools/patch/internal/patch/patch_test.go
+++ b/packages/browseros/tools/patch/internal/patch/patch_test.go
@@ -2,11 +2,14 @@ package patch
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/git"
 )
 
 func TestParseDiffOutputDetectsRenameAndDeleteSignatures(t *testing.T) {
@@ -112,6 +115,94 @@ func TestBuildRangePatchSetUsesLatestBaseScopedPatch(t *testing.T) {
 	if strings.Contains(content, "+two") {
 		t.Fatalf("expected latest base-scoped patch, got %q", content)
 	}
+}
+
+func TestSyntheticAddPatchMatchesGitByteForByte(t *testing.T) {
+	cases := []struct {
+		name string
+		rel  string
+		body string
+		mode os.FileMode
+	}{
+		{name: "multi line", rel: "chrome/notes.txt", body: "alpha\nbeta\ngamma\n", mode: 0o644},
+		{name: "no trailing newline", rel: "chrome/nonl.txt", body: "alpha\nbeta", mode: 0o644},
+		{name: "empty file", rel: "chrome/empty.txt", body: "", mode: 0o644},
+		{name: "executable", rel: "chrome/tool.sh", body: "#!/bin/sh\necho hi\n", mode: 0o755},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			dir := t.TempDir()
+			runGit(t, dir, "init")
+			full := filepath.Join(dir, filepath.FromSlash(tc.rel))
+			writeRepoFile(t, full, tc.body)
+			if err := os.Chmod(full, tc.mode); err != nil {
+				t.Fatalf("chmod: %v", err)
+			}
+			want := gitNoIndexDiff(t, dir, tc.rel)
+
+			gitMode := "100644"
+			if tc.mode&0o100 != 0 {
+				gitMode = "100755"
+			}
+			got := syntheticAddPatch(tc.rel, []byte(tc.body), gitMode)
+			if got.Op != OpAdd {
+				t.Fatalf("op = %s, want ADD", got.Op)
+			}
+			if string(got.Content) != want {
+				t.Fatalf("synthetic patch differs from git output\n--- git ---\n%q\n--- synthetic ---\n%q", want, string(got.Content))
+			}
+		})
+	}
+}
+
+func TestSyntheticAddPatchAppliesAndRoundTrips(t *testing.T) {
+	ctx := context.Background()
+	body := "alpha\nbeta"
+	patchFile := syntheticAddPatch("chrome/nonl.txt", []byte(body), "100644")
+
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	if _, err := git.ApplyPatch(ctx, dir, patchFile.Content); err != nil {
+		t.Fatalf("ApplyPatch: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "chrome", "nonl.txt"))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	if string(data) != body {
+		t.Fatalf("applied content = %q, want %q (content must not be mutated)", string(data), body)
+	}
+}
+
+func TestSyntheticAddPatchMarksBinaryContent(t *testing.T) {
+	got := syntheticAddPatch("chrome/icon.png", []byte("\x89PNG\x00\x01binary"), "100644")
+	if got.Op != OpBinary || !got.IsBinary {
+		t.Fatalf("expected binary marker patch, got op=%s isBinary=%v", got.Op, got.IsBinary)
+	}
+	if len(got.Content) != 0 {
+		t.Fatalf("binary marker should carry no diff content, got %q", string(got.Content))
+	}
+}
+
+// gitNoIndexDiff returns git's own add-style diff for an untracked file,
+// tolerating the exit status 1 git uses to signal "differences found".
+func gitNoIndexDiff(t *testing.T, dir string, rel string) string {
+	t.Helper()
+	cmd := exec.Command("git",
+		"-c", "diff.algorithm=myers",
+		"-c", "diff.noprefix=false",
+		"-c", "diff.mnemonicPrefix=false",
+		"-c", "core.quotepath=false",
+		"diff", "--binary", "--full-index", "-U3", "--no-index", "--", "/dev/null", rel)
+	cmd.Dir = dir
+	output, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if !errors.As(err, &exitErr) || exitErr.ExitCode() != 1 {
+			t.Fatalf("git diff --no-index: %v\n%s", err, string(output))
+		}
+	}
+	return string(output)
 }
 
 func runGit(t *testing.T, dir string, args ...string) {

--- a/packages/browseros/tools/patch/internal/patch/patch_test.go
+++ b/packages/browseros/tools/patch/internal/patch/patch_test.go
@@ -62,7 +62,7 @@ rename to chrome/new.cc
 `),
 		},
 	}
-	if _, _, _, err := WriteRepoPatchSet(patchesDir, set, nil); err != nil {
+	if _, err := WriteRepoPatchSet(patchesDir, set, nil); err != nil {
 		t.Fatalf("WriteRepoPatchSet: %v", err)
 	}
 	if _, err := filepath.Abs(filepath.Join(patchesDir, "chrome", "dead.cc.deleted")); err != nil {
@@ -136,12 +136,12 @@ func TestWriteRepoPatchSetSkipsUnchangedFiles(t *testing.T) {
 	rel := "chrome/foo.cc"
 	set := PatchSet{rel: modifyPatch(rel, fullIndex, "new")}
 
-	written, _, _, err := WriteRepoPatchSet(patchesDir, set, nil)
+	plan, err := WriteRepoPatchSet(patchesDir, set, nil)
 	if err != nil {
 		t.Fatalf("first write: %v", err)
 	}
-	if len(written) != 1 {
-		t.Fatalf("first write should create the file, wrote %v", written)
+	if len(plan.Written()) != 1 {
+		t.Fatalf("first write should create the file, wrote %v", plan.Written())
 	}
 
 	// Simulate a legacy on-disk patch: same hunks, abbreviated index line.
@@ -151,15 +151,15 @@ func TestWriteRepoPatchSetSkipsUnchangedFiles(t *testing.T) {
 		t.Fatalf("write legacy: %v", err)
 	}
 
-	written, deleted, unchanged, err := WriteRepoPatchSet(patchesDir, set, nil)
+	plan, err = WriteRepoPatchSet(patchesDir, set, nil)
 	if err != nil {
 		t.Fatalf("second write: %v", err)
 	}
-	if len(written) != 0 || len(deleted) != 0 {
-		t.Fatalf("expected no-op write, got written=%v deleted=%v", written, deleted)
+	if len(plan.Written()) != 0 || len(plan.Deletes) != 0 {
+		t.Fatalf("expected no-op write, got written=%v deleted=%v", plan.Written(), plan.Deletes)
 	}
-	if len(unchanged) != 1 || unchanged[0] != rel {
-		t.Fatalf("expected %s unchanged, got %v", rel, unchanged)
+	if len(plan.Unchanged) != 1 || plan.Unchanged[0] != rel {
+		t.Fatalf("expected %s unchanged, got %v", rel, plan.Unchanged)
 	}
 	after, err := os.ReadFile(target)
 	if err != nil {
@@ -173,17 +173,17 @@ func TestWriteRepoPatchSetSkipsUnchangedFiles(t *testing.T) {
 func TestWriteRepoPatchSetRewritesChangedContent(t *testing.T) {
 	patchesDir := t.TempDir()
 	rel := "chrome/foo.cc"
-	if _, _, _, err := WriteRepoPatchSet(patchesDir, PatchSet{rel: modifyPatch(rel, fullIndex, "new")}, nil); err != nil {
+	if _, err := WriteRepoPatchSet(patchesDir, PatchSet{rel: modifyPatch(rel, fullIndex, "new")}, nil); err != nil {
 		t.Fatalf("first write: %v", err)
 	}
 
 	next := modifyPatch(rel, fullIndex, "different")
-	written, _, unchanged, err := WriteRepoPatchSet(patchesDir, PatchSet{rel: next}, nil)
+	plan, err := WriteRepoPatchSet(patchesDir, PatchSet{rel: next}, nil)
 	if err != nil {
 		t.Fatalf("second write: %v", err)
 	}
-	if len(written) != 1 || written[0] != rel {
-		t.Fatalf("expected rewrite of %s, got written=%v unchanged=%v", rel, written, unchanged)
+	if len(plan.Written()) != 1 || plan.Written()[0] != rel {
+		t.Fatalf("expected rewrite of %s, got written=%v unchanged=%v", rel, plan.Written(), plan.Unchanged)
 	}
 	after, err := os.ReadFile(filepath.Join(patchesDir, "chrome", "foo.cc"))
 	if err != nil {
@@ -197,15 +197,15 @@ func TestWriteRepoPatchSetRewritesChangedContent(t *testing.T) {
 func TestWriteRepoPatchSetSkipsUnchangedMarkers(t *testing.T) {
 	patchesDir := t.TempDir()
 	set := PatchSet{"chrome/dead.cc": {Path: "chrome/dead.cc", Op: OpDelete}}
-	if _, _, _, err := WriteRepoPatchSet(patchesDir, set, nil); err != nil {
+	if _, err := WriteRepoPatchSet(patchesDir, set, nil); err != nil {
 		t.Fatalf("first write: %v", err)
 	}
-	written, _, unchanged, err := WriteRepoPatchSet(patchesDir, set, nil)
+	plan, err := WriteRepoPatchSet(patchesDir, set, nil)
 	if err != nil {
 		t.Fatalf("second write: %v", err)
 	}
-	if len(written) != 0 || len(unchanged) != 1 {
-		t.Fatalf("expected marker to be skip-stable, written=%v unchanged=%v", written, unchanged)
+	if len(plan.Written()) != 0 || len(plan.Unchanged) != 1 {
+		t.Fatalf("expected marker to be skip-stable, written=%v unchanged=%v", plan.Written(), plan.Unchanged)
 	}
 }
 
@@ -219,7 +219,7 @@ func TestPlanRepoPatchSetClassifies(t *testing.T) {
 		"chrome/diff.cc": existingDiff,
 		"chrome/gone.cc": existingGone,
 	}
-	if _, _, _, err := WriteRepoPatchSet(patchesDir, seed, nil); err != nil {
+	if _, err := WriteRepoPatchSet(patchesDir, seed, nil); err != nil {
 		t.Fatalf("seed write: %v", err)
 	}
 

--- a/packages/browseros/tools/patch/internal/patch/patch_test.go
+++ b/packages/browseros/tools/patch/internal/patch/patch_test.go
@@ -209,6 +209,23 @@ func TestWriteRepoPatchSetSkipsUnchangedMarkers(t *testing.T) {
 	}
 }
 
+func TestWriteRepoPatchSetScopeMatchesDirectories(t *testing.T) {
+	patchesDir := t.TempDir()
+	inDir := modifyPatch("chrome/sub/in.cc", fullIndex, "new")
+	outDir := modifyPatch("ui/out.cc", fullIndex, "new")
+	plan, err := WriteRepoPatchSet(patchesDir, PatchSet{
+		"chrome/sub/in.cc": inDir,
+		"ui/out.cc":        outDir,
+	}, []string{"chrome/sub"})
+	if err != nil {
+		t.Fatalf("WriteRepoPatchSet: %v", err)
+	}
+	assertStrings(t, "written", plan.Written(), []string{"chrome/sub/in.cc"})
+	if _, err := os.Stat(filepath.Join(patchesDir, "ui", "out.cc")); !os.IsNotExist(err) {
+		t.Fatalf("out-of-scope patch must not be written")
+	}
+}
+
 func TestPlanRepoPatchSetClassifies(t *testing.T) {
 	patchesDir := t.TempDir()
 	existingSame := modifyPatch("chrome/same.cc", fullIndex, "new")

--- a/packages/browseros/tools/patch/internal/patch/repo.go
+++ b/packages/browseros/tools/patch/internal/patch/repo.go
@@ -103,35 +103,40 @@ func sameWriteTarget(patchesDir string, a FilePatch, b FilePatch) bool {
 	return targetA == targetB
 }
 
-func WriteRepoPatchSet(patchesDir string, set PatchSet, scope []string) (written []string, deleted []string, unchanged []string, err error) {
+// Written returns every path the plan actually rewrites.
+func (p *WritePlan) Written() []string {
+	written := append(append([]string{}, p.Creates...), p.Updates...)
+	slices.Sort(written)
+	return written
+}
+
+func WriteRepoPatchSet(patchesDir string, set PatchSet, scope []string) (*WritePlan, error) {
 	existing, err := LoadRepoPatchSet(patchesDir, nil)
 	if err != nil && !os.IsNotExist(err) {
-		return nil, nil, nil, err
+		return nil, err
 	}
 	plan := planRepoPatchSet(patchesDir, existing, set, scope)
 	for _, rel := range plan.Deletes {
 		if err := removePatchVariants(patchesDir, rel); err != nil {
-			return nil, nil, nil, err
+			return nil, err
 		}
 	}
-	for _, rel := range append(append([]string{}, plan.Creates...), plan.Updates...) {
+	for _, rel := range plan.Written() {
 		if err := removePatchVariants(patchesDir, rel); err != nil {
-			return nil, nil, nil, err
+			return nil, err
 		}
 		target, body := patchWriteTarget(patchesDir, set[rel])
 		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-			return nil, nil, nil, err
+			return nil, err
 		}
 		if len(body) == 0 || body[len(body)-1] != '\n' {
 			body = append(body, '\n')
 		}
 		if err := os.WriteFile(target, body, 0o644); err != nil {
-			return nil, nil, nil, err
+			return nil, err
 		}
-		written = append(written, rel)
 	}
-	slices.Sort(written)
-	return written, plan.Deletes, plan.Unchanged, nil
+	return plan, nil
 }
 
 func loadPatchFile(fullPath string, relPath string) (FilePatch, error) {

--- a/packages/browseros/tools/patch/internal/patch/repo.go
+++ b/packages/browseros/tools/patch/internal/patch/repo.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 )
@@ -35,11 +36,25 @@ func LoadRepoPatchSet(patchesDir string, filters []string) (PatchSet, error) {
 	return set, err
 }
 
-func WriteRepoPatchSet(patchesDir string, set PatchSet, scope []string) ([]string, []string, error) {
+// WritePlan classifies what a WriteRepoPatchSet call would do. Unchanged
+// patches (same signature, same marker kind) are never rewritten so volatile
+// diff metadata can't churn the patch repo.
+type WritePlan struct {
+	Creates   []string `json:"creates"`
+	Updates   []string `json:"updates"`
+	Unchanged []string `json:"unchanged"`
+	Deletes   []string `json:"deletes"`
+}
+
+func PlanRepoPatchSet(patchesDir string, set PatchSet, scope []string) (*WritePlan, error) {
 	existing, err := LoadRepoPatchSet(patchesDir, nil)
 	if err != nil && !os.IsNotExist(err) {
-		return nil, nil, err
+		return nil, err
 	}
+	return planRepoPatchSet(patchesDir, existing, set, scope), nil
+}
+
+func planRepoPatchSet(patchesDir string, existing PatchSet, set PatchSet, scope []string) *WritePlan {
 	inScope := map[string]bool{}
 	if len(scope) == 0 {
 		for rel := range existing {
@@ -54,37 +69,69 @@ func WriteRepoPatchSet(patchesDir string, set PatchSet, scope []string) ([]strin
 		}
 	}
 
-	var written []string
-	var deleted []string
+	plan := &WritePlan{}
 	for rel := range existing {
 		if !inScope[rel] || set[rel].Path != "" {
 			continue
 		}
-		if err := removePatchVariants(patchesDir, rel); err != nil {
-			return nil, nil, err
-		}
-		deleted = append(deleted, rel)
+		plan.Deletes = append(plan.Deletes, rel)
 	}
 	for rel, patchFile := range set {
 		if !inScope[rel] {
 			continue
 		}
-		if err := removePatchVariants(patchesDir, rel); err != nil {
-			return nil, nil, err
+		current, ok := existing[rel]
+		switch {
+		case !ok:
+			plan.Creates = append(plan.Creates, rel)
+		case sameWriteTarget(patchesDir, current, patchFile) && signature(current) == signature(patchFile):
+			plan.Unchanged = append(plan.Unchanged, rel)
+		default:
+			plan.Updates = append(plan.Updates, rel)
 		}
-		target, body := patchWriteTarget(patchesDir, patchFile)
+	}
+	slices.Sort(plan.Creates)
+	slices.Sort(plan.Updates)
+	slices.Sort(plan.Unchanged)
+	slices.Sort(plan.Deletes)
+	return plan
+}
+
+func sameWriteTarget(patchesDir string, a FilePatch, b FilePatch) bool {
+	targetA, _ := patchWriteTarget(patchesDir, a)
+	targetB, _ := patchWriteTarget(patchesDir, b)
+	return targetA == targetB
+}
+
+func WriteRepoPatchSet(patchesDir string, set PatchSet, scope []string) (written []string, deleted []string, unchanged []string, err error) {
+	existing, err := LoadRepoPatchSet(patchesDir, nil)
+	if err != nil && !os.IsNotExist(err) {
+		return nil, nil, nil, err
+	}
+	plan := planRepoPatchSet(patchesDir, existing, set, scope)
+	for _, rel := range plan.Deletes {
+		if err := removePatchVariants(patchesDir, rel); err != nil {
+			return nil, nil, nil, err
+		}
+	}
+	for _, rel := range append(append([]string{}, plan.Creates...), plan.Updates...) {
+		if err := removePatchVariants(patchesDir, rel); err != nil {
+			return nil, nil, nil, err
+		}
+		target, body := patchWriteTarget(patchesDir, set[rel])
 		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		if len(body) == 0 || body[len(body)-1] != '\n' {
 			body = append(body, '\n')
 		}
 		if err := os.WriteFile(target, body, 0o644); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		written = append(written, rel)
 	}
-	return written, deleted, nil
+	slices.Sort(written)
+	return written, plan.Deletes, plan.Unchanged, nil
 }
 
 func loadPatchFile(fullPath string, relPath string) (FilePatch, error) {

--- a/packages/browseros/tools/patch/internal/patch/repo.go
+++ b/packages/browseros/tools/patch/internal/patch/repo.go
@@ -55,17 +55,17 @@ func PlanRepoPatchSet(patchesDir string, set PatchSet, scope []string) (*WritePl
 }
 
 func planRepoPatchSet(patchesDir string, existing PatchSet, set PatchSet, scope []string) *WritePlan {
+	// Scope entries follow PathMatches semantics (exact file or directory
+	// prefix) so "extract ch1 -- chrome/dir" scopes the whole directory.
 	inScope := map[string]bool{}
-	if len(scope) == 0 {
-		for rel := range existing {
+	for rel := range existing {
+		if PathMatches(rel, scope) {
 			inScope[rel] = true
 		}
-		for rel := range set {
+	}
+	for rel := range set {
+		if PathMatches(rel, scope) {
 			inScope[rel] = true
-		}
-	} else {
-		for _, rel := range scope {
-			inScope[NormalizeChromiumPath(rel)] = true
 		}
 	}
 

--- a/packages/browseros/tools/patch/internal/patch/workspace.go
+++ b/packages/browseros/tools/patch/internal/patch/workspace.go
@@ -175,7 +175,7 @@ func buildBaseScopedSet(ctx context.Context, workspacePath string, ref string, b
 			}
 			mode, err := git.FileModeAtCommit(ctx, workspacePath, ref, rel)
 			if err != nil {
-				mode = "100644"
+				return nil, err
 			}
 			set[rel] = syntheticAddPatch(rel, content, mode)
 		}
@@ -212,7 +212,12 @@ func RejectPath(workspacePath string, rel string) string {
 // exactly so the same logical patch is identical no matter which extraction
 // path produced it.
 func syntheticAddPatch(rel string, content []byte, mode string) FilePatch {
-	if bytes.IndexByte(content, 0) != -1 {
+	// Match git's binary heuristic: a NUL within the first 8000 bytes.
+	probe := content
+	if len(probe) > 8000 {
+		probe = probe[:8000]
+	}
+	if bytes.IndexByte(probe, 0) != -1 {
 		return FilePatch{Path: rel, Op: OpBinary, IsBinary: true}
 	}
 	if mode == "" {
@@ -227,7 +232,11 @@ func syntheticAddPatch(rel string, content []byte, mode string) FilePatch {
 		missingEOFNewline := !strings.HasSuffix(body, "\n")
 		lines := strings.Split(strings.TrimSuffix(body, "\n"), "\n")
 		fmt.Fprintf(&b, "--- /dev/null\n+++ b/%s\n", rel)
-		fmt.Fprintf(&b, "@@ -0,0 +1,%d @@\n", len(lines))
+		if len(lines) == 1 {
+			b.WriteString("@@ -0,0 +1 @@\n")
+		} else {
+			fmt.Fprintf(&b, "@@ -0,0 +1,%d @@\n", len(lines))
+		}
 		for _, line := range lines {
 			b.WriteString("+")
 			b.WriteString(line)

--- a/packages/browseros/tools/patch/internal/patch/workspace.go
+++ b/packages/browseros/tools/patch/internal/patch/workspace.go
@@ -1,7 +1,10 @@
 package patch
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha1"
+	"encoding/hex"
 	"fmt"
 	"path/filepath"
 	"slices"
@@ -150,7 +153,11 @@ func buildBaseScopedSet(ctx context.Context, workspacePath string, ref string, b
 			if err != nil {
 				return nil, err
 			}
-			set[rel] = syntheticAddPatch(rel, content)
+			mode, err := git.FileModeAtCommit(ctx, workspacePath, ref, rel)
+			if err != nil {
+				mode = "100644"
+			}
+			set[rel] = syntheticAddPatch(rel, content, mode)
 		}
 	}
 	return set, nil
@@ -180,36 +187,44 @@ func RejectPath(workspacePath string, rel string) string {
 	return filepath.Join(workspacePath, filepath.FromSlash(rel+".rej"))
 }
 
-func syntheticAddPatch(rel string, content []byte) FilePatch {
-	body := string(content)
-	if body != "" && body[len(body)-1] != '\n' {
-		body += "\n"
+// syntheticAddPatch builds the add-style diff for content git never saw as a
+// working-tree file. The bytes must match `git diff --no-index --full-index`
+// exactly so the same logical patch is identical no matter which extraction
+// path produced it.
+func syntheticAddPatch(rel string, content []byte, mode string) FilePatch {
+	if bytes.IndexByte(content, 0) != -1 {
+		return FilePatch{Path: rel, Op: OpBinary, IsBinary: true}
 	}
-	patchBody := fmt.Sprintf(
-		"diff --git a/%s b/%s\nnew file mode 100644\n--- /dev/null\n+++ b/%s\n@@ -0,0 +1,%d @@\n%s",
-		rel,
-		rel,
-		rel,
-		countLines(body),
-		prefixLines(body, "+"),
-	)
-	return FilePatch{Path: rel, Op: OpAdd, Content: []byte(patchBody)}
+	if mode == "" {
+		mode = "100644"
+	}
+	var b strings.Builder
+	fmt.Fprintf(&b, "diff --git a/%s b/%s\n", rel, rel)
+	fmt.Fprintf(&b, "new file mode %s\n", mode)
+	fmt.Fprintf(&b, "index %s..%s\n", strings.Repeat("0", 40), blobSHA1(content))
+	if len(content) > 0 {
+		body := string(content)
+		missingEOFNewline := !strings.HasSuffix(body, "\n")
+		lines := strings.Split(strings.TrimSuffix(body, "\n"), "\n")
+		fmt.Fprintf(&b, "--- /dev/null\n+++ b/%s\n", rel)
+		fmt.Fprintf(&b, "@@ -0,0 +1,%d @@\n", len(lines))
+		for _, line := range lines {
+			b.WriteString("+")
+			b.WriteString(line)
+			b.WriteString("\n")
+		}
+		if missingEOFNewline {
+			b.WriteString("\\ No newline at end of file\n")
+		}
+	}
+	return FilePatch{Path: rel, Op: OpAdd, Content: []byte(b.String())}
 }
 
-func countLines(body string) int {
-	if body == "" {
-		return 0
-	}
-	return len(strings.Split(strings.TrimSuffix(body, "\n"), "\n"))
-}
-
-func prefixLines(body string, prefix string) string {
-	lines := strings.Split(strings.TrimSuffix(body, "\n"), "\n")
-	for idx, line := range lines {
-		lines[idx] = prefix + line
-	}
-	if len(lines) == 0 {
-		return ""
-	}
-	return strings.Join(lines, "\n") + "\n"
+// blobSHA1 hashes content the way git names blobs (SHA-1 object format;
+// SHA-256 repos are out of scope — Chromium uses SHA-1).
+func blobSHA1(content []byte) string {
+	h := sha1.New()
+	fmt.Fprintf(h, "blob %d\x00", len(content))
+	h.Write(content)
+	return hex.EncodeToString(h.Sum(nil))
 }

--- a/packages/browseros/tools/patch/internal/patch/workspace.go
+++ b/packages/browseros/tools/patch/internal/patch/workspace.go
@@ -1,7 +1,6 @@
 package patch
 
 import (
-	"bytes"
 	"context"
 	"crypto/sha1"
 	"encoding/hex"
@@ -212,12 +211,7 @@ func RejectPath(workspacePath string, rel string) string {
 // exactly so the same logical patch is identical no matter which extraction
 // path produced it.
 func syntheticAddPatch(rel string, content []byte, mode string) FilePatch {
-	// Match git's binary heuristic: a NUL within the first 8000 bytes.
-	probe := content
-	if len(probe) > 8000 {
-		probe = probe[:8000]
-	}
-	if bytes.IndexByte(probe, 0) != -1 {
+	if git.LooksBinary(content) {
 		return FilePatch{Path: rel, Op: OpBinary, IsBinary: true}
 	}
 	if mode == "" {

--- a/packages/browseros/tools/patch/internal/patch/workspace.go
+++ b/packages/browseros/tools/patch/internal/patch/workspace.go
@@ -13,8 +13,18 @@ import (
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/git"
 )
 
-func BuildWorkingTreePatchSet(ctx context.Context, workspacePath string, base string, filters []string) (PatchSet, error) {
-	diff, err := git.DiffText(ctx, workspacePath, base)
+// WorkingTreeOptions bound a working-tree patch-set build: the base commit to
+// diff against, include filters, an ignore set for untracked junk, and an
+// optional progress callback.
+type WorkingTreeOptions struct {
+	Base    string
+	Filters []string
+	Ignore  *IgnoreSet
+	Report  func(message string)
+}
+
+func BuildWorkingTreePatchSet(ctx context.Context, workspacePath string, opts WorkingTreeOptions) (PatchSet, error) {
+	diff, err := git.DiffText(ctx, workspacePath, opts.Base)
 	if err != nil {
 		return nil, err
 	}
@@ -22,11 +32,21 @@ func BuildWorkingTreePatchSet(ctx context.Context, workspacePath string, base st
 	if err != nil {
 		return nil, err
 	}
-	untracked, err := git.ListUntracked(ctx, workspacePath, filters)
+	untracked, err := git.ListUntracked(ctx, workspacePath, opts.Filters)
 	if err != nil {
 		return nil, err
 	}
+	kept := make([]string, 0, len(untracked))
 	for _, rel := range untracked {
+		if opts.Ignore.Match(rel) {
+			continue
+		}
+		kept = append(kept, rel)
+	}
+	for idx, rel := range kept {
+		if opts.Report != nil {
+			opts.Report(fmt.Sprintf("Scanning untracked %d/%d %s", idx+1, len(kept), rel))
+		}
 		diffText, err := git.DiffNoIndex(ctx, workspacePath, rel)
 		if err != nil {
 			return nil, err
@@ -39,7 +59,7 @@ func BuildWorkingTreePatchSet(ctx context.Context, workspacePath string, base st
 			set[patchPath] = patchFile
 		}
 	}
-	return filterSet(set, filters), nil
+	return filterSet(set, opts.Filters), nil
 }
 
 func BuildCommitPatchSet(ctx context.Context, workspacePath string, ref string, base string, filters []string) (PatchSet, error) {

--- a/packages/browseros/tools/patch/internal/resolve/resolve.go
+++ b/packages/browseros/tools/patch/internal/resolve/resolve.go
@@ -82,7 +82,7 @@ func FindActive(reg *workspace.Registry, cwd string) (workspace.Entry, error) {
 	}
 	switch len(active) {
 	case 0:
-		return workspace.Entry{}, fmt.Errorf(`no active conflict resolution found; run "browseros-patch apply" or "browseros-patch sync --rebase" first`)
+		return workspace.Entry{}, fmt.Errorf(`no active conflict resolution found; run "browseros-patch apply" or "browseros-patch sync" first`)
 	case 1:
 		return active[0], nil
 	default:

--- a/packages/browseros/tools/patch/internal/resolve/resolve.go
+++ b/packages/browseros/tools/patch/internal/resolve/resolve.go
@@ -29,6 +29,10 @@ type State struct {
 	Operations []Operation `json:"operations"`
 	Resolved   []string    `json:"resolved,omitempty"`
 	Skipped    []string    `json:"skipped,omitempty"`
+	// RestorePendingStash marks that the paused operation was a rebase-mode
+	// sync: when the conflict loop completes, the parked stash comes back.
+	// Stashes parked explicitly with --no-rebase stay parked.
+	RestorePendingStash bool `json:"restore_pending_stash,omitempty"`
 }
 
 func Path(workspacePath string) string {


### PR DESCRIPTION
## Summary
- **Fixes the extract-churn bug at the root:** patch bytes are now a pure function of content — `git diff` runs with pinned config (`--full-index -U3 --no-ext-diff --no-textconv`, algorithm/prefix/context/quotepath `-c` overrides), commit-mode synthetic ADD patches are byte-identical to git's own output (computed blob SHA, real mode, `\ No newline`, header-only empties, single-line hunk headers), and `WriteRepoPatchSet` plans create/update/unchanged/delete keyed on the existing `signature()` so semantically-unchanged patches (including all 342 legacy abbreviated-index files) are **never rewritten**. `status` clean ⇒ `extract` is a byte-level no-op; the same change extracted from two differently-configured checkouts produces identical bytes.
- **`sync` (alias `pull`) is now a real `git pull --rebase` for patches:** local changes are stashed (tracked by commit SHA, immune to positional shifts), patches applied, then **rebased back by default** via a per-file 3-way merge that works where `git stash pop` refuses (apply-dirtied files). Conflicts leave standard markers (modify/delete and binary divergence are reported, never silently resolved), the stash entry survives, `--no-rebase` parks changes with an honest `pending_stash` record that the next rebase sync restores, and `continue`/`skip` finish the loop — restoring the parked stash only when the pause came from a rebase-mode sync.
- **Junk-free, previewable extraction:** built-in untracked-file ignores (`.llm/`, `.browseros-patch/`, `*.log`, `*.rej`, `*.orig`, `.DS_Store`) + repo-root `.browseros-patchignore` + repeatable `extract --exclude`; `extract --dry-run` previews created/updated/deleted/unchanged without touching disk or state; directory-scoped `extract ch1 -- chrome/dir` now works.
- **Agent-grade surface:** exit code 2 whenever apply/sync/continue/skip pause on a conflict (output rendered first, JSON intact), and `--llm-txt` rewritten as a full playbook (exit codes, status field semantics, daily sync flow, capture flow, Chromium-upgrade loop with continue/skip/abort).
- **Ergonomics:** TTY-aware single-line progress (`[i/N]` scans, plain lines in pipes, silent in `--json`), `status --summary` (orphans by top-level dir), `status --all` (one-line table per registered checkout), pending-stash visibility, plain-words sync-state explanations, in-sync-but-orphans reproduce hint, `make install` ships a `bpatch` symlink.

## Design
Canonical-write + skip-unchanged: the compare layer (`signature()`) already ignored volatile `index` lines, but the write path emitted whatever bytes the local git produced — re-extraction churned files even when `status` said up-to-date. This PR fixes both sides of the funnel (deterministic bytes in, signature-gated writes out) instead of stripping index lines, which would have de-fanged the `--3way` apply strategy the conflict loop depends on. Legacy patches converge to canonical form organically as their content genuinely changes — no 342-file migration commit. The Python `browseros dev` extract/apply path is untouched.

## Test plan
- [x] `go test ./...` (6 packages, `-count=1`), `go vet`, `gofmt` clean — round-trip invariants covered: extract→status-clean→extract no-op; cross-checkout byte-identity under hostile git config; legacy-byte preservation; synthetic-add byte-equality vs real git output; SHA-stash rebase/conflict/abort flows; ignore semantics; dry-run isolation; exit-code classification
- [x] End-to-end smoke with the built binary: add → status → extract --dry-run → extract → idempotent re-extract → apply → llm-txt
- [ ] Real-world: `browseros-patch status ch1 && browseros-patch extract ch1` twice against a Chromium checkout — second run must leave `packages/browseros/chromium_patches` untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)