### PR TITLE
fix(server): stop re-feeding chat history to ACP-backed providers

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
@@ -311,15 +311,35 @@ export class ChatService {
     const wrappedUserMessageId =
       session.agent.messages[session.agent.messages.length - 1]?.id
 
-    const promptUiMessages = filterValidMessages(session.agent.messages).map(
-      (msg) =>
-        msg.id === wrappedUserMessageId && msg.role === 'user'
-          ? {
-              ...msg,
-              parts: [{ type: 'text' as const, text: promptUserText }],
-            }
-          : msg,
-    )
+    // ACP-backed providers run against a persistent acpx session that
+    // owns the agent's conversation memory natively on disk under
+    // <stateDir>/<sessionKey>/. Re-feeding the full UIMessage history
+    // doubles bookkeeping and, worse, trips the AI SDK validator when
+    // it walks phantom tool-<name> parts emitted by acpx-ai-provider
+    // under freshly-generated "acpx-N" ids (acpx#37). For ACP turns
+    // we send only the new user message — acpx's session/load reads
+    // prior turns from disk transparently. The UI continues to see
+    // the growing transcript via session.agent.messages.
+    //
+    // LLM-API providers are stateless and need the full history on
+    // each turn, so they keep the existing shape verbatim.
+    const isAcp = isAcpProvider(agentConfig.provider)
+    const promptUiMessages: UIMessage[] = isAcp
+      ? [
+          {
+            id: wrappedUserMessageId ?? crypto.randomUUID(),
+            role: 'user',
+            parts: [{ type: 'text', text: promptUserText }],
+          },
+        ]
+      : filterValidMessages(session.agent.messages).map((msg) =>
+          msg.id === wrappedUserMessageId && msg.role === 'user'
+            ? {
+                ...msg,
+                parts: [{ type: 'text' as const, text: promptUserText }],
+              }
+            : msg,
+        )
 
     return createAgentUIStreamResponse({
       agent: session.agent.toolLoopAgent,
@@ -330,18 +350,45 @@ export class ChatService {
         // wrapped user text. Restore the raw form before persisting
         // so subsequent turns see the clean text and the client's
         // local UIMessage matches what was originally typed.
-        const restored = messages.map((msg) =>
-          msg.id === wrappedUserMessageId && msg.role === 'user'
-            ? {
-                ...msg,
-                parts: [{ type: 'text' as const, text: request.message }],
-              }
-            : msg,
-        )
-        session.agent.messages = filterValidMessages(restored)
+        //
+        // ACP path: `messages` is the single user msg we sent plus
+        // the assistant's new reply. The user msg already lives in
+        // session.agent.messages via appendUserMessage; we only need
+        // to restore its raw text and append the new assistant
+        // entries from this turn.
+        //
+        // LLM-API path: `messages` is the full conversation as the
+        // AI SDK reconstructed it. Restore the wrapped user message
+        // and replace the entire session history with the result.
+        if (isAcp) {
+          const existingIds = new Set(session.agent.messages.map((m) => m.id))
+          const newMessages = messages.filter((m) => !existingIds.has(m.id))
+          const updated = session.agent.messages.map((m) =>
+            m.id === wrappedUserMessageId && m.role === 'user'
+              ? {
+                  ...m,
+                  parts: [{ type: 'text' as const, text: request.message }],
+                }
+              : m,
+          )
+          session.agent.messages = filterValidMessages([
+            ...updated,
+            ...newMessages,
+          ])
+        } else {
+          const restored = messages.map((msg) =>
+            msg.id === wrappedUserMessageId && msg.role === 'user'
+              ? {
+                  ...msg,
+                  parts: [{ type: 'text' as const, text: request.message }],
+                }
+              : msg,
+          )
+          session.agent.messages = filterValidMessages(restored)
+        }
         logger.info('Agent execution complete', {
           conversationId: request.conversationId,
-          totalMessages: restored.length,
+          totalMessages: session.agent.messages.length,
         })
 
         if (session?.hiddenPageId) {

--- a/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
@@ -361,6 +361,13 @@ export class ChatService {
         // AI SDK reconstructed it. Restore the wrapped user message
         // and replace the entire session history with the result.
         if (isAcp) {
+          // Invariant: an id in both `messages` and session means the
+          // AI SDK handed us back something we already have. With the
+          // single-user-msg input shape that means our own user msg —
+          // the only collision we expect. Any new id is a fresh
+          // assistant entry from this turn. acpx never re-emits prior
+          // turns into the AI SDK stream, so this filter cannot drop a
+          // legitimately new message.
           const existingIds = new Set(session.agent.messages.map((m) => m.id))
           const newMessages = messages.filter((m) => !existingIds.has(m.id))
           const updated = session.agent.messages.map((m) =>

--- a/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
@@ -107,8 +107,11 @@ function createFakeAgent() {
     toolNames: new Set<string>(),
     messages,
     appendUserMessage(text: string) {
+      // Mirror production's id-per-call: a hardcoded constant would
+      // collide on repeat calls in the same agent instance and corrupt
+      // the id-diff logic the ACP onFinish branch relies on.
       this.messages.push({
-        id: 'user-1',
+        id: crypto.randomUUID(),
         role: 'user',
         parts: [{ type: 'text', text }],
       })

--- a/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
@@ -424,3 +424,229 @@ describe('ChatService Klavis session rebuilds', () => {
     expect(firstAgent.messages).toHaveLength(2)
   })
 })
+
+describe('ChatService ACP provider chat history handling', () => {
+  // ACP-backed providers (claude-code, codex, acp-custom) run against
+  // a persistent acpx session that owns the agent's conversation
+  // memory on disk. Re-feeding the full UIMessage history would double
+  // bookkeeping and trip the AI SDK validator when it walks phantom
+  // tool-<name> parts emitted by acpx-ai-provider under freshly-
+  // generated "acpx-N" ids (acpx#37). The chat-service therefore sends
+  // only the new user message on ACP turns; acpx loads prior turns
+  // from disk transparently. These tests pin that branch.
+
+  function withAcpProvider() {
+    resolveLLMConfigSpy.mockImplementation(async () => ({
+      provider: 'claude-code',
+      model: 'opus',
+      apiKey: 'unused',
+    }))
+  }
+
+  function withLlmProvider() {
+    resolveLLMConfigSpy.mockImplementation(async () => ({
+      provider: 'openai',
+      model: 'gpt-5',
+      apiKey: 'test-key',
+    }))
+  }
+
+  function baseDeps() {
+    const browser = {
+      newPage: mock(async () => 0),
+      listPages: mock(async () => []),
+      closePage: mock(async () => {}),
+      createWindow: mock(async () => ({ windowId: 0 })),
+      closeWindow: mock(async () => {}),
+      resolveTabIds: mock(async () => new Map<number, number>()),
+    }
+    return {
+      browser,
+      klavisRef: { handle: null },
+      sessionStore: createSessionStore(),
+    }
+  }
+
+  function chatRequest(overrides: Record<string, unknown> = {}) {
+    return {
+      conversationId: crypto.randomUUID(),
+      message: 'hello',
+      isScheduledTask: false,
+      mode: 'agent',
+      origin: 'sidepanel',
+      browserContext: {
+        activeTab: { id: 1, url: 'https://example.com', title: 'Example' },
+      },
+      ...overrides,
+    } as never
+  }
+
+  it('passes only the new user message to streamText for ACP providers', async () => {
+    withAcpProvider()
+    const agent = createFakeAgent()
+    agentToReturn = agent
+    let captured: MockMessage[] | undefined
+    streamResponseHandler = async ({ uiMessages, onFinish }) => {
+      captured = uiMessages
+      await onFinish({ messages: uiMessages ?? [] })
+      return new Response('ok')
+    }
+    const deps = baseDeps()
+    const service = new ChatService({
+      sessionStore: deps.sessionStore as never,
+      klavisRef: deps.klavisRef,
+      browser: deps.browser as never,
+      registry: {} as never,
+    })
+
+    await service.processMessage(chatRequest(), new AbortController().signal)
+
+    expect(captured).toHaveLength(1)
+    expect(captured?.[0]?.role).toBe('user')
+    expect(captured?.[0]?.parts[0]?.type).toBe('text')
+  })
+
+  it('still passes the full filtered history for LLM-API providers', async () => {
+    withLlmProvider()
+    const agent = createFakeAgent()
+    // Seed prior turns.
+    agent.messages.push(
+      { id: 'u-0', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
+      {
+        id: 'a-0',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'hello' }],
+      },
+    )
+    agentToReturn = agent
+    let captured: MockMessage[] | undefined
+    streamResponseHandler = async ({ uiMessages, onFinish }) => {
+      captured = uiMessages
+      await onFinish({ messages: uiMessages ?? [] })
+      return new Response('ok')
+    }
+    const deps = baseDeps()
+    const service = new ChatService({
+      sessionStore: deps.sessionStore as never,
+      klavisRef: deps.klavisRef,
+      browser: deps.browser as never,
+      registry: {} as never,
+    })
+
+    await service.processMessage(chatRequest(), new AbortController().signal)
+
+    expect(captured?.length).toBeGreaterThan(1)
+    expect(captured?.map((m) => m.role)).toContain('assistant')
+  })
+
+  it('does not re-feed phantom acpx-N tool parts to streamText on a follow-up ACP turn', async () => {
+    withAcpProvider()
+    const agent = createFakeAgent()
+    // Simulate a prior turn where acpx-ai-provider's translator left
+    // a phantom tool part behind in session.agent.messages.
+    agent.messages.push(
+      {
+        id: 'u-prior',
+        role: 'user',
+        parts: [{ type: 'text', text: 'list files' }],
+      },
+      {
+        id: 'a-prior',
+        role: 'assistant',
+        parts: [
+          { type: 'text', text: 'I will list them.' },
+          // The phantom shape we worry about: tool part with the
+          // acpx-N toolCallId and no input. With the old code this
+          // would re-enter streamText on the next turn and trip
+          // the AI SDK validator with the 500 the user reported.
+          // The new code never includes this in promptUiMessages.
+          {
+            type: 'tool-mcp.browseros.grep',
+            // biome-ignore lint/suspicious/noExplicitAny: synthetic phantom shape
+            toolCallId: 'acpx-3',
+            state: 'input-streaming',
+            input: undefined,
+          } as never,
+        ],
+      },
+    )
+    agentToReturn = agent
+    let captured: MockMessage[] | undefined
+    streamResponseHandler = async ({ uiMessages, onFinish }) => {
+      captured = uiMessages
+      await onFinish({ messages: uiMessages ?? [] })
+      return new Response('ok')
+    }
+    const deps = baseDeps()
+    const service = new ChatService({
+      sessionStore: deps.sessionStore as never,
+      klavisRef: deps.klavisRef,
+      browser: deps.browser as never,
+      registry: {} as never,
+    })
+
+    await service.processMessage(
+      chatRequest({ message: 'what about gaming' }),
+      new AbortController().signal,
+    )
+
+    // Crucial: the phantom part never reaches streamText.
+    const allParts = (captured ?? []).flatMap((m) => m.parts)
+    expect(
+      allParts.some((p) => (p as { type?: string }).type?.startsWith('tool-')),
+    ).toBe(false)
+    expect(captured?.length).toBe(1)
+  })
+
+  it('preserves UI display state by appending the assistant reply to session.agent.messages on an ACP turn', async () => {
+    withAcpProvider()
+    const agent = createFakeAgent()
+    agent.messages.push(
+      {
+        id: 'u-prior',
+        role: 'user',
+        parts: [{ type: 'text', text: 'list files' }],
+      },
+      {
+        id: 'a-prior',
+        role: 'assistant',
+        parts: [{ type: 'text', text: 'one, two, three.' }],
+      },
+    )
+    agentToReturn = agent
+    streamResponseHandler = async ({ uiMessages, onFinish }) => {
+      // Simulate the AI SDK reducer yielding the single user msg we
+      // sent + a fresh assistant reply.
+      const assistantMsg = {
+        id: 'a-new',
+        role: 'assistant' as const,
+        parts: [{ type: 'text' as const, text: 'foo, bar, baz.' }],
+      }
+      await onFinish({ messages: [...(uiMessages ?? []), assistantMsg] })
+      return new Response('ok')
+    }
+    const deps = baseDeps()
+    const service = new ChatService({
+      sessionStore: deps.sessionStore as never,
+      klavisRef: deps.klavisRef,
+      browser: deps.browser as never,
+      registry: {} as never,
+    })
+
+    await service.processMessage(
+      chatRequest({ message: 'now read foo.md' }),
+      new AbortController().signal,
+    )
+
+    // Prior turns survive, the new user msg has raw text, the
+    // assistant reply is appended at the end.
+    expect(agent.messages.map((m) => m.role)).toEqual([
+      'user',
+      'assistant',
+      'user',
+      'assistant',
+    ])
+    expect(agent.messages.at(-1)?.parts[0]?.text).toBe('foo, bar, baz.')
+    expect(agent.messages.at(-2)?.parts[0]?.text).toBe('now read foo.md')
+  })
+})


### PR DESCRIPTION
## Summary

acpx-ai-provider runs against a persistent acpx session that owns the agent's conversation memory natively on disk under `<stateDir>/<sessionKey>/`. BrowserOS's `chat-service` was re-feeding the full `UIMessage[]` history into `streamText` on every turn, which (a) double-bookkeeps the agent's memory and (b) trips the AI SDK input validator on the second turn when it walks phantom `tool-<name>` parts that acpx-ai-provider emits under freshly-generated `acpx-N` ids (acpx#37). Users hit this as:

```
"Type validation failed for messages[2].parts[2].input
 (mcp.browseros.grep, id: \"acpx-3\"): Value: undefined.
  Error message: No tool schema found for tool part mcp.browseros.grep"
```

This PR branches the per-turn `promptUiMessages` construction on `isAcpProvider(agentConfig.provider)`. ACP-backed providers send only the new user message; LLM-API providers keep the existing full-history shape because they ARE stateless. acpx's `session/load` reads prior turns from disk transparently on continuations.

This is the same architectural pattern `agent-company` codified after their team hit the same kind of bug (`apps/desktop/src/main/chat/ChatSession.ts` Paths B/C/D). BrowserOS now follows the same invariant: **acpx owns the agent's memory; the UIMessage list is purely display and sync**.

## What is in the diff

| Path | Before | After |
|---|---|---|
| ACP `promptUiMessages` | `filterValidMessages(session.agent.messages)` mapped to wrap the latest user msg | `[{ id, role: 'user', parts: [{ type: 'text', text: promptUserText }] }]` |
| ACP `onFinish` persistence | `session.agent.messages = filterValidMessages(restored)` replacing all history | restore the user msg's raw text in place + append the assistant entries from this turn by id |
| LLM-API `promptUiMessages` | unchanged | unchanged |
| LLM-API `onFinish` persistence | unchanged | unchanged |

## Why the display still grows correctly

`session.agent.appendUserMessage(request.message)` continues to run before either branch. For ACP, that puts the raw user msg into `session.agent.messages` immediately. `onFinish` then finds the matching id, restores the raw text (in case the AI SDK touched parts), and appends any messages the AI SDK produced that did NOT already exist by id (i.e. the assistant reply). Prior turns are preserved. The sidepanel sees the full transcript via the existing SSE stream and `session.agent.messages` round-trip.

## Why this fixes the 500

On the next ACP turn, `promptUiMessages` has exactly one item: a user message with a single text part. The AI SDK validator has no prior parts to walk. The phantom `tool-<name>` parts that previously triggered the validator crash never enter the input. acpx restores its own memory from `<stateDir>/<sessionKey>/`; the agent still knows what it did on prior turns.

## Why we don't need acpx#37 to land first

acpx#37 fixes the phantom-emission upstream. With this PR we no longer feed phantoms back to streamText, so the bug stops mattering at the integration boundary. acpx#37 is still desirable because it would let us drop the cosmetic frontend display filter from PR #1149, but it's no longer a release blocker for the ACP-provider feature.

## Test plan

- [x] `bun run test:agent` — 282 / 282 pass.
- [x] `bun run test:api` — 131 / 131 pass (4 new chat-service cases).
- [x] `bun run test:lib` — 225 / 225 pass.
- [x] `bunx tsc --noEmit` (server) — clean.

New regression tests pin:

1. ACP turns send a single-message `uiMessages` array to `streamText`.
2. LLM-API turns still send the full filtered history.
3. Phantom `tool-mcp.browseros.<name>` parts with `toolCallId: 'acpx-3'` and `input: undefined` left behind in `session.agent.messages` never reach `streamText` on a follow-up ACP turn (this reproduces the exact 500 reported and proves it cannot fire under the new shape).
4. `session.agent.messages` grows correctly across ACP turns: prior turns preserved, latest user has raw text, assistant reply appended at the end.

## Manual smoke

Three turns against a Claude Code provider:

1. "ls"
2. "now read foo.md"
3. "summarise foo.md and tell me which file is largest"

Expected: no 500 on turns 2 or 3; the agent's turn 3 reply demonstrates memory of the earlier listing AND the foo.md read, confirming acpx's persistent session is doing its job without us re-feeding history.

## Out of scope

- `events`-table architecture for atomic ProtocolEvent persistence. BrowserOS's existing UIMessage-based persistence is sufficient for display; rewriting the renderer is a major refactor for marginal gain.
- Tuple-keyed `sessionKey` (`agentKind::modelId::workspacePath::reasoningEffort`). The previous workspace-isolation PR already scopes state per saved provider id; conversation-id keying is fine within a single conversation.
- Event-log replay on mid-conversation provider switches (agent-company's Path A). Rare case; the rebuilt acpx session starts fresh from CLAUDE.md / AGENTS.md which is acceptable behaviour.