### PR TITLE
feat(ci): nightly unsigned release builds on WarpBuild runners

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,0 +1,285 @@
+name: Nightly Release Build
+
+# Daily UNSIGNED release builds of BrowserOS for all three platforms on
+# WarpBuild runners. Signing is intentionally not wired up yet; see
+# packages/browseros/build/docs/nightly-warpbuild-ci.md for the design and
+# the secret names that enable signing later.
+#
+# The pinned chromium checkout (packages/browseros/CHROMIUM_VERSION) is
+# cached post-`gclient sync`:
+#   - Linux/macOS: WarpCache (WarpBuilds/cache, no size cap)
+#   - Windows:     R2 tarball via scripts/ci/r2_cache.py (WarpCache does
+#                  not support Windows runners; actions/cache caps at 10GB)
+
+on:
+  schedule:
+    # Midnight US Pacific (DST). The signed self-hosted macOS nightly runs
+    # at 05:00 UTC; keep these apart so version-bump PRs don't race.
+    - cron: "0 8 * * *"
+  workflow_dispatch:
+    inputs:
+      platforms:
+        description: Platforms to build
+        type: choice
+        default: all
+        options:
+          - all
+          - linux
+          - windows
+          - macos
+      publish_nightly:
+        description: Update the rolling `nightly` prerelease (main only)
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-release
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+      publish: ${{ steps.plan.outputs.publish }}
+    steps:
+      - name: Resolve build matrix and publish flag
+        id: plan
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PLATFORMS: ${{ inputs.platforms || 'all' }}
+          PUBLISH_INPUT: ${{ inputs.publish_nightly }}
+          REF_NAME: ${{ github.ref_name }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+
+          matrix='[
+            {"platform":"linux","arch":"x64","runner":"warp-ubuntu-2204-x64-32x","config":"release.linux.ci.yaml","timeout":660},
+            {"platform":"windows","arch":"x64","runner":"warp-windows-2025-x64-32x","config":"release.windows.ci.yaml","timeout":780},
+            {"platform":"macos","arch":"arm64","runner":"warp-macos-15-arm64-12x","config":"release.macos.arm64.ci.yaml","timeout":720}
+          ]'
+          if [ "$PLATFORMS" != "all" ]; then
+            matrix="$(jq -c --arg p "$PLATFORMS" '[ .[] | select(.platform == $p) ]' <<<"$matrix")"
+          else
+            matrix="$(jq -c . <<<"$matrix")"
+          fi
+
+          publish="false"
+          if [ "$REF_NAME" = "$DEFAULT_BRANCH" ]; then
+            if [ "$EVENT_NAME" = "schedule" ] || [ "$PUBLISH_INPUT" = "true" ]; then
+              publish="true"
+            fi
+          fi
+
+          {
+            echo "matrix=$matrix"
+            echo "publish=$publish"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: plan
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    name: build (${{ matrix.platform }}-${{ matrix.arch }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: ${{ matrix.timeout }}
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v8
+
+      - name: Resolve chromium pin and paths
+        id: pin
+        run: |
+          set -euo pipefail
+          . packages/browseros/CHROMIUM_VERSION
+          version="$MAJOR.$MINOR.$BUILD.$PATCH"
+
+          # Keep the checkout outside the workspace so actions/checkout
+          # never touches it. pwd -W yields a native path on Windows.
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            parent="$(cd "$GITHUB_WORKSPACE/.." && pwd -W)"
+          else
+            parent="$(cd "$GITHUB_WORKSPACE/.." && pwd)"
+          fi
+
+          {
+            echo "version=$version"
+            echo "cache_key=chromium-src-${{ matrix.platform }}-${{ matrix.arch }}-v1-$version"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "CHROMIUM_ROOT=$parent/chromium"
+            echo "CHROMIUM_SRC=$parent/chromium/src"
+          } >> "$GITHUB_ENV"
+
+      - name: Restore chromium checkout (WarpCache)
+        if: runner.os != 'Windows'
+        id: warpcache
+        uses: WarpBuilds/cache/restore@v1
+        with:
+          path: ${{ env.CHROMIUM_ROOT }}
+          key: ${{ steps.pin.outputs.cache_key }}
+          restore-keys: |
+            chromium-src-${{ matrix.platform }}-${{ matrix.arch }}-v1-
+
+      - name: Restore chromium checkout (R2)
+        if: runner.os == 'Windows'
+        id: r2cache
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          set -euo pipefail
+          uv run --project packages/browseros python scripts/ci/r2_cache.py restore \
+            --key "${{ steps.pin.outputs.cache_key }}" \
+            --root "$CHROMIUM_ROOT"
+
+      - name: Ensure chromium checkout at pinned tag
+        run: |
+          set -euo pipefail
+          uv run --project packages/browseros python scripts/ci/setup_chromium.py \
+            --chromium-root "$CHROMIUM_ROOT" --step checkout
+
+      - name: Reset chromium tree (clean module)
+        working-directory: packages/browseros
+        run: |
+          set -euo pipefail
+          uv run browseros build --modules clean \
+            --chromium-src "$CHROMIUM_SRC" \
+            --build-type release \
+            --arch "${{ matrix.arch }}"
+
+      - name: Sync chromium dependencies (gclient)
+        run: |
+          set -euo pipefail
+          uv run --project packages/browseros python scripts/ci/setup_chromium.py \
+            --chromium-root "$CHROMIUM_ROOT" --step sync
+
+      # Save immediately after sync: the tree is pristine (no BrowserOS
+      # patches, no out/ dir), which keeps the cache deterministic and as
+      # small as possible.
+      - name: Save chromium checkout (WarpCache)
+        if: runner.os != 'Windows' && steps.warpcache.outputs.cache-hit != 'true'
+        uses: WarpBuilds/cache/save@v1
+        with:
+          path: ${{ env.CHROMIUM_ROOT }}
+          key: ${{ steps.pin.outputs.cache_key }}
+
+      - name: Save chromium checkout (R2)
+        if: runner.os == 'Windows' && steps.r2cache.outputs.cache-hit != 'true'
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          set -euo pipefail
+          uv run --project packages/browseros python scripts/ci/r2_cache.py save \
+            --key "${{ steps.pin.outputs.cache_key }}" \
+            --root "$CHROMIUM_ROOT"
+
+      - name: Install Linux build deps
+        if: matrix.platform == 'linux'
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          # libfuse2: appimagetool is itself an AppImage and needs FUSE
+          sudo apt-get install -y libfuse2
+          "$CHROMIUM_SRC/build/install-build-deps.sh" --no-prompt
+
+      - name: Build BrowserOS (unsigned)
+        working-directory: packages/browseros
+        env:
+          # download_resources pulls BrowserOS Server bundles from R2
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+          # --- Signing placeholders (unused until signing is wired up) ---
+          # macOS (sign_macos + notarization):
+          #   MACOS_CERTIFICATE_P12 / MACOS_CERTIFICATE_PWD (import into a CI keychain)
+          #   MACOS_CERTIFICATE_NAME, MACOS_KEYCHAIN_PASSWORD
+          #   PROD_MACOS_NOTARIZATION_APPLE_ID / _TEAM_ID / _PWD
+          #   SPARKLE_PRIVATE_KEY (sparkle_sign)
+          # Windows (sign_windows via SSL.com CodeSignTool):
+          #   ESIGNER_USERNAME / ESIGNER_PASSWORD / ESIGNER_TOTP_SECRET
+          #   ESIGNER_CREDENTIAL_ID, CODE_SIGN_TOOL_PATH (tool install dir)
+        run: |
+          set -euo pipefail
+          uv run browseros build \
+            --config "build/config/${{ matrix.config }}" \
+            --chromium-src "$CHROMIUM_SRC"
+
+      - name: Report disk usage
+        if: always()
+        run: df -h || true
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: browseros-nightly-${{ matrix.platform }}-${{ matrix.arch }}
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 0
+          path: |
+            packages/browseros/releases/*/*.dmg
+            packages/browseros/releases/*/*.AppImage
+            packages/browseros/releases/*/*.deb
+            packages/browseros/releases/*/*_installer.exe
+            packages/browseros/releases/*/*_installer.zip
+
+  publish:
+    needs: [plan, build]
+    if: needs.plan.outputs.publish == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+          merge-multiple: true
+
+      - name: Update rolling nightly prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=(dist/*/*.dmg dist/*/*.AppImage dist/*/*.deb dist/*/*_installer.exe dist/*/*_installer.zip dist/*.dmg dist/*.AppImage dist/*.deb dist/*_installer.exe dist/*_installer.zip)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "::error::No artifacts found to publish"
+            exit 1
+          fi
+          printf 'Publishing:\n%s\n' "${files[@]}"
+
+          notes_file="$(mktemp)"
+          cat > "$notes_file" <<EOF
+          Automated unsigned nightly build from \`main\` (commit $GITHUB_SHA).
+
+          These artifacts are NOT code signed or notarized — expect OS warnings on install. For signed builds use the regular releases.
+          EOF
+
+          # The `nightly` tag is rolling: recreate it via the API each run
+          # (release delete + create; no git force-push involved).
+          gh release delete nightly --cleanup-tag --yes || true
+          gh release create nightly \
+            --prerelease \
+            --latest=false \
+            --target "$GITHUB_SHA" \
+            --title "BrowserOS Nightly (unsigned) $(date -u +%Y-%m-%d)" \
+            --notes-file "$notes_file" \
+            "${files[@]}"

--- a/packages/browseros/build/cli/build.py
+++ b/packages/browseros/build/cli/build.py
@@ -52,7 +52,7 @@ from ..modules.sign.windows import WindowsSignModule
 from ..modules.sign.linux import LinuxSignModule
 from ..modules.sign.sparkle import SparkleSignModule
 from ..modules.package.macos import MacOSPackageModule
-from ..modules.package.windows import WindowsPackageModule
+from ..modules.package.windows import WindowsPackageModule, MiniInstallerModule
 from ..modules.package.linux import LinuxPackageModule
 
 AVAILABLE_MODULES = {
@@ -78,6 +78,7 @@ AVAILABLE_MODULES = {
     "sign_linux": LinuxSignModule,
     "sparkle_sign": SparkleSignModule,  # macOS Sparkle signing for auto-update
     # Package (platform-specific, validated at runtime)
+    "mini_installer": MiniInstallerModule,  # Unsigned installer build (CI)
     "package_macos": MacOSPackageModule,
     "package_windows": WindowsPackageModule,
     "package_linux": LinuxPackageModule,

--- a/packages/browseros/build/config/release.linux.ci.yaml
+++ b/packages/browseros/build/config/release.linux.ci.yaml
@@ -1,0 +1,38 @@
+# BrowserOS Linux CI Release Build (unsigned, no upload)
+#
+# Nightly WarpBuild variant of release.linux.yaml. Differences:
+#   - x64 only (runner arch); arm64 cross-compile can be re-added later
+#   - no clean/git_setup: CI runs `--modules clean` and `gclient sync`
+#     itself so the chromium checkout cache stays a pristine post-sync tree
+#     (git_setup's `git fetch --tags` is unusable on the shallow CI clone)
+#   - no upload: artifacts are published via GitHub Actions
+#
+# Run (from packages/browseros, after checkout + clean + sync):
+#   uv run browseros build --config build/config/release.linux.ci.yaml --chromium-src <src>
+
+build:
+  type: release
+  architecture: x64
+
+gn_flags:
+  file: build/config/gn/flags.linux.release.gn
+
+modules:
+  # Patches & Resources
+  - download_resources
+  - resources
+  - bundled_extensions
+  - chromium_replace
+  - string_replaces
+  - series_patches
+  - patches
+
+  # Build
+  - configure
+  - compile
+
+  # Package (Linux is not code signed)
+  - package_linux
+
+notifications:
+  slack: false

--- a/packages/browseros/build/config/release.macos.arm64.ci.yaml
+++ b/packages/browseros/build/config/release.macos.arm64.ci.yaml
@@ -1,0 +1,41 @@
+# BrowserOS macOS arm64 CI Release Build (unsigned, no upload)
+#
+# Nightly WarpBuild variant of release.macos.arm64.noupload.yaml. Differences:
+#   - no clean/git_setup: CI runs `--modules clean` and `gclient sync`
+#     itself so the chromium checkout cache stays a pristine post-sync tree
+#   - no sign_macos: package_macos creates an UNSIGNED dmg when the
+#     signed_app artifact is absent
+#   - no required signing envs
+#
+# Run (from packages/browseros, after checkout + clean + sync):
+#   uv run browseros build --config build/config/release.macos.arm64.ci.yaml --chromium-src <src>
+
+build:
+  type: release
+  architecture: arm64
+
+gn_flags:
+  file: build/config/gn/flags.macos.release.gn
+
+modules:
+  # Setup (sparkle_setup re-creates third_party/sparkle itself)
+  - sparkle_setup
+
+  # Patches & Resources
+  - download_resources
+  - resources
+  - bundled_extensions
+  - chromium_replace
+  - string_replaces
+  - series_patches
+  - patches
+
+  # Build
+  - configure
+  - compile
+
+  # Package (unsigned dmg)
+  - package_macos
+
+notifications:
+  slack: false

--- a/packages/browseros/build/config/release.windows.ci.yaml
+++ b/packages/browseros/build/config/release.windows.ci.yaml
@@ -1,0 +1,39 @@
+# BrowserOS Windows CI Release Build (unsigned, no upload)
+#
+# Nightly WarpBuild variant of release.windows.yaml. Differences:
+#   - no clean/git_setup: CI runs `--modules clean` and `gclient sync`
+#     itself so the chromium checkout cache stays a pristine post-sync tree
+#   - no sign_windows: unsigned artifacts. mini_installer is normally built
+#     inside sign_windows, so the standalone mini_installer module replaces it
+#   - no upload: artifacts are published via GitHub Actions
+#
+# Run (from packages/browseros, after checkout + clean + sync):
+#   uv run browseros build --config build/config/release.windows.ci.yaml --chromium-src <src>
+
+build:
+  type: release
+  architecture: x64
+
+gn_flags:
+  file: build/config/gn/flags.windows.release.gn
+
+modules:
+  # Patches & Resources
+  - download_resources
+  - resources
+  - bundled_extensions
+  - chromium_replace
+  - string_replaces
+  - series_patches
+  - patches
+
+  # Build
+  - configure
+  - compile
+  - mini_installer
+
+  # Package (unsigned installer + zip)
+  - package_windows
+
+notifications:
+  slack: false

--- a/packages/browseros/build/docs/nightly-warpbuild-ci.md
+++ b/packages/browseros/build/docs/nightly-warpbuild-ci.md
@@ -1,0 +1,129 @@
+# Nightly WarpBuild Release Builds
+
+`.github/workflows/nightly-release.yml` builds UNSIGNED release artifacts for
+Linux x64, Windows x64, and macOS arm64 every night on WarpBuild cloud
+runners, uploads them to the Actions run, and refreshes a rolling `nightly`
+prerelease on GitHub. It complements (does not replace) the signed
+self-hosted macOS nightly in `nightly-macos-build.yml`; once signing is wired
+up here, that workflow can be retired.
+
+## Runners
+
+| Platform | Label | Specs | Disk |
+| --- | --- | --- | --- |
+| Linux x64 | `warp-ubuntu-2204-x64-32x` | 32 vCPU / 128 GB | 150 GB |
+| Windows x64 | `warp-windows-2025-x64-32x` | 32 vCPU / 128 GB | 256 GB |
+| macOS arm64 | `warp-macos-15-arm64-12x` | M4 Pro, 12 vCPU / 44 GB | 270 GB |
+
+There is no 32-core macOS tier; 12x is WarpBuild's largest Mac. WarpBuild
+runners register as self-hosted, so GitHub's 6-hour hosted-job cap does not
+apply — but `timeout-minutes` must be set explicitly (the implicit default is
+360). Linux's 150 GB disk is the tightest fit: ~60-75 GB checkout +
+~25-40 GB out dir + OS image. The workflow prints `df -h` after each build.
+
+## Per-night pipeline (per platform)
+
+1. `actions/checkout` + `astral-sh/setup-uv`.
+2. Restore the pinned chromium checkout from cache (see below).
+3. `scripts/ci/setup_chromium.py --step checkout` — ensures depot_tools and
+   `src` at the tag from `packages/browseros/CHROMIUM_VERSION`. No-op when
+   the cache is warm and the pin unchanged.
+4. `uv run browseros build --modules clean ...` — the standard clean module
+   resets the tree (it also deletes hook-managed toolchains like
+   `third_party/llvm-build`, which the next step restores).
+5. `scripts/ci/setup_chromium.py --step sync` — `gclient sync -D
+   --no-history --shallow`, exactly what the git_setup module runs.
+6. Save the cache (only when the restore missed, i.e. first run per pin).
+7. `uv run browseros build --config build/config/release.<os>.ci.yaml
+   --chromium-src .../src`.
+8. Upload artifacts (14-day retention); a follow-up job recreates the
+   rolling `nightly` prerelease for scheduled main runs.
+
+The `release.*.ci.yaml` configs are the release configs minus `clean`/
+`git_setup` (steps 4-5 replace them), minus `sign_*`/`upload`. Why not run
+`git_setup` as-is: it does `git fetch --tags`, which on the shallow CI clone
+would pull objects for all ~70k chromium tags; the script instead fetches
+exactly the pinned tag at depth 2. On Windows the new `mini_installer`
+module builds the installer that `sign_windows` would otherwise build.
+
+## Caching strategy
+
+Cache key: `chromium-src-<platform>-<arch>-v1-<CHROMIUM_VERSION>`. Contents:
+the whole gclient root (depot_tools, `.gclient`, post-sync `src`) captured
+immediately after `gclient sync`, before patches and before any `out/` dir
+exists — pristine and deterministic. The pin changes rarely, so steady state
+is one cold sync per chromium bump per platform.
+
+- **Linux / macOS — WarpCache** (`WarpBuilds/cache@v1`): drop-in for
+  `actions/cache` with no size cap (entries expire 7 days after last use;
+  storage $0.20/GB-month). Restore-keys fall back to the previous pin's
+  cache, then the script fast-forwards `src` with a single-tag fetch.
+- **Windows — R2 tarball** (`scripts/ci/r2_cache.py`): WarpCache does not
+  support Windows runners and `actions/cache` caps at 10 GB/repo. The tree
+  is zstd-tarred (~25-30 GB) into `ci-cache/chromium/` in the existing R2
+  bucket using the same `R2_*` secrets the build already needs for
+  `download_resources`. R2 has zero egress fees. Missing credentials or a
+  cache miss degrade to a cold checkout, never a failure.
+
+Expected timings (32-core linux/windows, M4 Pro mac):
+
+| Phase | Cold (first run / pin bump) | Warm |
+| --- | --- | --- |
+| Checkout + sync | 40-70 min | restore 3-10 min + sync 5-15 min |
+| Compile + package | 2.5-6 h (per platform) | same — out/ is rebuilt nightly |
+| Total | ~4-7 h | ~3-6 h |
+
+The compile dominates either way; the cache removes the checkout cost and
+network flakiness. Toolchains deleted by `clean` (~2-4 GB) are re-fetched by
+hooks each night — accepted, matches the maintainer's local flow.
+
+Cost ballpark at WarpBuild list prices: linux 32x $3.84/h, windows 32x
+$7.68/h, mac 12x $9.60/h → roughly $60-120 per full nightly, plus ~$12/month
+cache storage.
+
+### Future optimizations (not yet wired)
+
+- **Snapshot runners (Linux only)**: boot from a disk image with the
+  checkout baked in (`runs-on: "warp-ubuntu-2204-x64-32x;snapshot.key=..."`
+  + `WarpBuilds/snapshot-save`). Kills even the cache-restore minutes, but
+  snapshots expire after 15 days and need a bake/boot split; revisit once
+  the cache flow is proven.
+- **Compiler cache (sccache/ccache via `cc_wrapper`)** in a CI gn flags
+  variant: nightly sources are nearly identical night-to-night, so this is
+  the lever that could cut warm builds to well under an hour.
+- **Linux arm64** via `architecture: [x64, arm64]` in the CI config once
+  the x64 lane is green (sysroot bootstrap already handled by the modules).
+
+## Signing later (placeholders)
+
+The workflow leaves named-but-unused secret placeholders documented next to
+the build step. To enable signing:
+
+- **macOS**: add `sign_macos` (and optionally `sparkle_sign`) back to
+  `release.macos.arm64.ci.yaml`, provide `MACOS_CERTIFICATE_P12` +
+  `MACOS_CERTIFICATE_PWD` (import into a temporary CI keychain in a step
+  before the build), `MACOS_CERTIFICATE_NAME`, `MACOS_KEYCHAIN_PASSWORD`,
+  `PROD_MACOS_NOTARIZATION_APPLE_ID/_TEAM_ID/_PWD`, `SPARKLE_PRIVATE_KEY`.
+- **Windows**: replace `mini_installer` with `sign_windows` in
+  `release.windows.ci.yaml`, install SSL.com CodeSignTool in a step, set
+  `CODE_SIGN_TOOL_PATH` and `ESIGNER_USERNAME/_PASSWORD/_TOTP_SECRET`
+  (+ `ESIGNER_CREDENTIAL_ID`).
+- **Linux**: unsigned by design (no sign module in the release config).
+
+## Operating it
+
+```bash
+# Full run on all platforms (no prerelease update):
+gh workflow run "Nightly Release Build"
+
+# One platform while iterating:
+gh workflow run "Nightly Release Build" -f platforms=linux
+
+# Manual run that also refreshes the rolling prerelease (main only):
+gh workflow run "Nightly Release Build" -f publish_nightly=true
+```
+
+The first run per platform is the cache warm-up; expect cold timings. If a
+pin bump lands, the next night is cold again for that version. To force a
+fresh checkout, bump the `v1` in the cache key (workflow) — for Windows also
+delete the old object under `ci-cache/chromium/` in R2.

--- a/packages/browseros/build/modules/package/windows.py
+++ b/packages/browseros/build/modules/package/windows.py
@@ -20,6 +20,34 @@ from ...common.notify import get_notifier, COLOR_GREEN
 from ..compile.standard import autoninja_command
 
 
+class MiniInstallerModule(CommandModule):
+    """Build mini_installer.exe without signing.
+
+    The signed release flow builds mini_installer inside WindowsSignModule
+    (sign binaries -> build installer -> sign installer). Unsigned CI builds
+    skip sign_windows entirely, so this module provides the installer build
+    step that package_windows requires.
+    """
+
+    produces = []
+    requires = []
+    description = "Build unsigned mini_installer.exe (CI builds without signing)"
+
+    def validate(self, ctx: Context) -> None:
+        if not IS_WINDOWS():
+            raise ValidationError("mini_installer build requires Windows")
+
+        args_file = ctx.get_gn_args_file()
+        if not args_file.exists():
+            raise ValidationError(
+                f"Build not configured - args.gn not found: {args_file}"
+            )
+
+    def execute(self, ctx: Context) -> None:
+        if not build_mini_installer(ctx):
+            raise RuntimeError("Failed to build mini_installer")
+
+
 class WindowsPackageModule(CommandModule):
     produces = ["installer", "installer_zip"]
     requires = []

--- a/packages/browseros/build/modules/package/windows.py
+++ b/packages/browseros/build/modules/package/windows.py
@@ -4,7 +4,6 @@
 import shutil
 import zipfile
 from pathlib import Path
-from typing import List
 from ...common.module import CommandModule, ValidationError
 from ...common.context import Context
 from ...common.utils import (
@@ -33,18 +32,18 @@ class MiniInstallerModule(CommandModule):
     requires = []
     description = "Build unsigned mini_installer.exe (CI builds without signing)"
 
-    def validate(self, ctx: Context) -> None:
+    def validate(self, context: Context) -> None:
         if not IS_WINDOWS():
             raise ValidationError("mini_installer build requires Windows")
 
-        args_file = ctx.get_gn_args_file()
+        args_file = context.get_gn_args_file()
         if not args_file.exists():
             raise ValidationError(
                 f"Build not configured - args.gn not found: {args_file}"
             )
 
-    def execute(self, ctx: Context) -> None:
-        if not build_mini_installer(ctx):
+    def execute(self, context: Context) -> None:
+        if not build_mini_installer(context):
             raise RuntimeError("Failed to build mini_installer")
 
 
@@ -53,24 +52,24 @@ class WindowsPackageModule(CommandModule):
     requires = []
     description = "Create Windows installer and portable ZIP"
 
-    def validate(self, ctx: Context) -> None:
+    def validate(self, context: Context) -> None:
         if not IS_WINDOWS():
             raise ValidationError("Windows packaging requires Windows")
 
-        build_output_dir = join_paths(ctx.chromium_src, ctx.out_dir)
+        build_output_dir = join_paths(context.chromium_src, context.out_dir)
         mini_installer_path = build_output_dir / "mini_installer.exe"
 
         if not mini_installer_path.exists():
             raise ValidationError(f"mini_installer.exe not found: {mini_installer_path}")
 
-    def execute(self, ctx: Context) -> None:
+    def execute(self, context: Context) -> None:
         log_info("\n📦 Creating Windows packages...")
 
-        installer_path = self._create_installer(ctx)
-        zip_path = self._create_portable_zip(ctx)
+        installer_path = self._create_installer(context)
+        zip_path = self._create_portable_zip(context)
 
-        ctx.artifact_registry.add("installer", installer_path)
-        ctx.artifact_registry.add("installer_zip", zip_path)
+        context.artifact_registry.add("installer", installer_path)
+        context.artifact_registry.add("installer_zip", zip_path)
 
         log_success("Windows packages created successfully")
 
@@ -81,7 +80,7 @@ class WindowsPackageModule(CommandModule):
             "Windows packages created successfully",
             {
                 "Artifacts": f"{installer_path.name}, {zip_path.name}",
-                "Version": ctx.semantic_version,
+                "Version": context.semantic_version,
             },
             color=COLOR_GREEN,
         )
@@ -261,13 +260,6 @@ def create_portable_zip(ctx: Context) -> bool:
 # - sign_with_codesigntool()
 # - get_browseros_server_binary_paths()
 # These are now in modules/sign/windows.py
-
-
-def package_universal(contexts: List[Context]) -> bool:
-    """Windows doesn't support universal binaries like macOS"""
-    log_warning("Universal binaries are not supported on Windows")
-    log_info("Consider creating separate packages for each architecture")
-    return True
 
 
 def get_target_cpu(build_output_dir: Path) -> str:

--- a/scripts/ci/r2_cache.py
+++ b/scripts/ci/r2_cache.py
@@ -1,0 +1,190 @@
+#!/usr/bin/env python3
+"""Chromium checkout cache in Cloudflare R2 for runners without WarpCache.
+
+WarpBuild's cache action does not support Windows runners, and GitHub's
+actions/cache caps at 10GB/repo — useless for a ~60GB checkout. R2 has
+zero egress fees and the repo already ships R2 credentials for release
+uploads, so Windows caches the post-sync tree as a zstd tarball under
+ci-cache/chromium/.
+
+Cache misses (and missing credentials) exit 0 with cache-hit=false so a
+nightly build degrades to a cold checkout instead of failing.
+
+Run inside the browseros uv project for boto3:
+  uv run --project packages/browseros python scripts/ci/r2_cache.py restore --key K --root DIR
+"""
+
+import argparse
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+OBJECT_PREFIX = "ci-cache/chromium/"
+
+
+def log(msg: str) -> None:
+    print(f"[r2_cache] {msg}", flush=True)
+
+
+def write_github_output(name: str, value: str) -> None:
+    output_path = os.environ.get("GITHUB_OUTPUT")
+    if output_path:
+        with open(output_path, "a") as f:
+            f.write(f"{name}={value}\n")
+    log(f"output: {name}={value}")
+
+
+def find_tool(name: str) -> str:
+    # System32 tar.exe is bsdtar, which mishandles >260-char paths in the
+    # chromium tree; prefer Git's bundled GNU tar on Windows.
+    if name == "tar" and sys.platform == "win32":
+        for candidate in (
+            r"C:\Program Files\Git\usr\bin\tar.exe",
+            r"C:\Program Files (x86)\Git\usr\bin\tar.exe",
+        ):
+            if Path(candidate).exists():
+                return candidate
+    path = shutil.which(name)
+    if not path:
+        raise SystemExit(f"[r2_cache] required tool not found on PATH: {name}")
+    return path
+
+
+def get_r2_client():
+    account_id = os.environ.get("R2_ACCOUNT_ID")
+    access_key = os.environ.get("R2_ACCESS_KEY_ID")
+    secret_key = os.environ.get("R2_SECRET_ACCESS_KEY")
+    if not (account_id and access_key and secret_key):
+        return None
+
+    import boto3
+    from boto3.s3.transfer import TransferConfig
+
+    client = boto3.client(
+        "s3",
+        endpoint_url=f"https://{account_id}.r2.cloudflarestorage.com",
+        aws_access_key_id=access_key,
+        aws_secret_access_key=secret_key,
+        region_name="auto",
+    )
+    transfer_config = TransferConfig(
+        multipart_threshold=64 * 1024 * 1024,
+        multipart_chunksize=128 * 1024 * 1024,
+        max_concurrency=16,
+    )
+    return client, transfer_config
+
+
+def object_exists(client, bucket: str, key: str) -> bool:
+    try:
+        client.head_object(Bucket=bucket, Key=key)
+        return True
+    except Exception:
+        return False
+
+
+def run_pipeline(producer: list[str], consumer: list[str]) -> None:
+    log(f"$ {' '.join(producer)} | {' '.join(consumer)}")
+    p1 = subprocess.Popen(producer, stdout=subprocess.PIPE)
+    p2 = subprocess.Popen(consumer, stdin=p1.stdout)
+    p1.stdout.close()
+    rc2 = p2.wait()
+    rc1 = p1.wait()
+    if rc1 != 0 or rc2 != 0:
+        raise SystemExit(
+            f"[r2_cache] pipeline failed (producer={rc1}, consumer={rc2})"
+        )
+
+
+def restore(args: argparse.Namespace) -> None:
+    r2 = get_r2_client()
+    if r2 is None:
+        log("R2 credentials not set; skipping cache restore")
+        write_github_output("cache-hit", "false")
+        return
+
+    client, transfer_config = r2
+    bucket = os.environ.get("R2_BUCKET", "browseros")
+    object_key = f"{OBJECT_PREFIX}{args.key}.tar.zst"
+
+    if not object_exists(client, bucket, object_key):
+        log(f"Cache miss: s3://{bucket}/{object_key}")
+        write_github_output("cache-hit", "false")
+        return
+
+    root = args.root.resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    tarball = Path(tempfile.gettempdir()) / "chromium-cache.tar.zst"
+
+    log(f"Downloading s3://{bucket}/{object_key} -> {tarball}")
+    client.download_file(
+        bucket, object_key, str(tarball), Config=transfer_config
+    )
+    size_gb = tarball.stat().st_size / 1024**3
+    log(f"Downloaded {size_gb:.1f} GiB; extracting to {root}")
+
+    run_pipeline(
+        [find_tool("zstd"), "-d", "-c", str(tarball)],
+        [find_tool("tar"), "-xf", "-", "-C", str(root)],
+    )
+    tarball.unlink()
+    write_github_output("cache-hit", "true")
+
+
+def save(args: argparse.Namespace) -> None:
+    r2 = get_r2_client()
+    if r2 is None:
+        log("R2 credentials not set; skipping cache save")
+        return
+
+    client, transfer_config = r2
+    bucket = os.environ.get("R2_BUCKET", "browseros")
+    object_key = f"{OBJECT_PREFIX}{args.key}.tar.zst"
+
+    if object_exists(client, bucket, object_key):
+        log(f"Cache already exists, not overwriting: s3://{bucket}/{object_key}")
+        return
+
+    root = args.root.resolve()
+    tarball = root.parent / "chromium-cache.tar.zst"
+
+    log(f"Archiving {root} -> {tarball}")
+    run_pipeline(
+        [
+            find_tool("tar"),
+            "-cf",
+            "-",
+            "--exclude=./src/out",
+            "-C",
+            str(root),
+            ".",
+        ],
+        [find_tool("zstd"), "-T0", "-3", "-f", "-o", str(tarball)],
+    )
+    size_gb = tarball.stat().st_size / 1024**3
+    log(f"Uploading {size_gb:.1f} GiB -> s3://{bucket}/{object_key}")
+    client.upload_file(str(tarball), bucket, object_key, Config=transfer_config)
+    tarball.unlink()
+    log("Cache saved")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    for name, handler in (("restore", restore), ("save", save)):
+        p = sub.add_parser(name)
+        p.add_argument("--key", required=True, help="cache key (no prefix/extension)")
+        p.add_argument(
+            "--root", required=True, type=Path, help="chromium gclient root dir"
+        )
+        p.set_defaults(handler=handler)
+
+    args = parser.parse_args()
+    args.handler(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ci/r2_cache.py
+++ b/scripts/ci/r2_cache.py
@@ -60,8 +60,14 @@ def get_r2_client():
     if not (account_id and access_key and secret_key):
         return None
 
-    import boto3
-    from boto3.s3.transfer import TransferConfig
+    try:
+        import boto3
+        from boto3.s3.transfer import TransferConfig
+    except ImportError:
+        raise SystemExit(
+            "[r2_cache] boto3 not installed - run via the browseros project env: "
+            "uv run --project packages/browseros python scripts/ci/r2_cache.py ..."
+        )
 
     client = boto3.client(
         "s3",
@@ -89,6 +95,7 @@ def object_exists(client, bucket: str, key: str) -> bool:
 def run_pipeline(producer: list[str], consumer: list[str]) -> None:
     log(f"$ {' '.join(producer)} | {' '.join(consumer)}")
     p1 = subprocess.Popen(producer, stdout=subprocess.PIPE)
+    assert p1.stdout is not None  # guaranteed by stdout=PIPE
     p2 = subprocess.Popen(consumer, stdin=p1.stdout)
     p1.stdout.close()
     rc2 = p2.wait()

--- a/scripts/ci/setup_chromium.py
+++ b/scripts/ci/setup_chromium.py
@@ -1,0 +1,183 @@
+#!/usr/bin/env python3
+"""Provision the pinned Chromium checkout for nightly CI builds.
+
+Replaces the build CLI's git_setup module on ephemeral runners: git_setup
+assumes a full clone where `git fetch --tags` is incremental, but on the
+shallow CI checkout fetching all of Chromium's ~70k tags would effectively
+unshallow the repo. Instead this script fetches exactly the pinned tag
+(depth 2, no tag-following) and lets `gclient sync` do the rest.
+
+Steps (run as separate invocations so the build CLI's `clean` module can
+run between them — clean deletes hook-managed toolchains like
+third_party/llvm-build, which sync then restores):
+  checkout  ensure depot_tools + src at the pinned tag (no-op on warm cache)
+  sync      gclient sync -D --no-history --shallow
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+CHROMIUM_SRC_URL = "https://chromium.googlesource.com/chromium/src.git"
+DEPOT_TOOLS_URL = (
+    "https://chromium.googlesource.com/chromium/tools/depot_tools.git"
+)
+
+GCLIENT_SPEC = """solutions = [
+  {
+    "name": "src",
+    "url": "%s",
+    "deps_file": "DEPS",
+    "managed": False,
+    "custom_deps": {},
+    "custom_vars": {},
+  },
+]
+""" % CHROMIUM_SRC_URL
+
+
+def log(msg: str) -> None:
+    print(f"[setup_chromium] {msg}", flush=True)
+
+
+def run(cmd: list[str], cwd: Path, env: dict | None = None) -> None:
+    log(f"$ {' '.join(cmd)}  (cwd={cwd})")
+    subprocess.run(cmd, cwd=cwd, env=env, check=True)
+
+
+def read_pinned_version(version_file: Path) -> str:
+    parts = {}
+    for line in version_file.read_text().strip().splitlines():
+        key, value = line.split("=")
+        parts[key.strip()] = value.strip()
+    return f"{parts['MAJOR']}.{parts['MINOR']}.{parts['BUILD']}.{parts['PATCH']}"
+
+
+def append_github_file(env_var: str, line: str) -> None:
+    path = os.environ.get(env_var)
+    if not path:
+        return
+    with open(path, "a") as f:
+        f.write(line + "\n")
+
+
+def ensure_depot_tools(root: Path) -> Path:
+    depot_tools = root / "depot_tools"
+    if not (depot_tools / ".git").exists():
+        log("Cloning depot_tools...")
+        run(
+            ["git", "clone", "--depth", "1", DEPOT_TOOLS_URL, str(depot_tools)],
+            cwd=root,
+        )
+    else:
+        log("depot_tools already present")
+
+    append_github_file("GITHUB_PATH", str(depot_tools))
+    if sys.platform == "win32":
+        append_github_file("GITHUB_ENV", "DEPOT_TOOLS_WIN_TOOLCHAIN=0")
+    return depot_tools
+
+
+def ensure_gclient_config(root: Path) -> None:
+    gclient_file = root / ".gclient"
+    if gclient_file.exists() and gclient_file.read_text() == GCLIENT_SPEC:
+        return
+    log(f"Writing {gclient_file}")
+    gclient_file.write_text(GCLIENT_SPEC)
+
+
+def git_output(args: list[str], cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True
+    )
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def ensure_src_at_tag(root: Path, version: str) -> Path:
+    src = root / "src"
+    tag_ref = f"refs/tags/{version}"
+
+    if not (src / ".git").exists():
+        log(f"Initializing fresh src checkout at {src}")
+        src.mkdir(parents=True, exist_ok=True)
+        run(["git", "init"], cwd=src)
+        run(["git", "remote", "add", "origin", CHROMIUM_SRC_URL], cwd=src)
+        if sys.platform == "win32":
+            run(["git", "config", "core.longpaths", "true"], cwd=src)
+
+    if not git_output(["rev-parse", "--verify", "--quiet", f"{tag_ref}^{{commit}}"], cwd=src):
+        # depth 2 so positioning tools (git describe / lastchange) have a parent
+        log(f"Fetching pinned tag {version} (shallow)...")
+        run(
+            [
+                "git", "fetch", "--depth", "2", "--no-tags", "origin",
+                f"+{tag_ref}:{tag_ref}",
+            ],
+            cwd=src,
+        )
+    else:
+        log(f"Tag {version} already present")
+
+    head = git_output(["rev-parse", "HEAD"], cwd=src)
+    tag_commit = git_output(["rev-parse", f"{tag_ref}^{{commit}}"], cwd=src)
+    if head != tag_commit:
+        log(f"Checking out {version}...")
+        run(["git", "checkout", "--force", "--detach", tag_ref], cwd=src)
+    else:
+        log(f"HEAD already at {version}")
+
+    return src
+
+
+def gclient_sync(root: Path, depot_tools: Path) -> None:
+    env = os.environ.copy()
+    env["PATH"] = str(depot_tools) + os.pathsep + env.get("PATH", "")
+    env["DEPOT_TOOLS_WIN_TOOLCHAIN"] = "0"
+
+    gclient = depot_tools / ("gclient.bat" if sys.platform == "win32" else "gclient")
+    run(
+        [str(gclient), "sync", "-D", "--no-history", "--shallow"],
+        cwd=root / "src",
+        env=env,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--chromium-root",
+        required=True,
+        type=Path,
+        help="gclient root: holds depot_tools/, .gclient and src/",
+    )
+    parser.add_argument("--step", required=True, choices=["checkout", "sync"])
+    parser.add_argument(
+        "--version-file",
+        type=Path,
+        default=Path(__file__).resolve().parents[2]
+        / "packages/browseros/CHROMIUM_VERSION",
+        help="CHROMIUM_VERSION pin file (MAJOR=/MINOR=/BUILD=/PATCH= lines)",
+    )
+    args = parser.parse_args()
+
+    root = args.chromium_root.resolve()
+    root.mkdir(parents=True, exist_ok=True)
+    version = read_pinned_version(args.version_file)
+    log(f"Pinned Chromium version: {version}")
+    log(f"Chromium root: {root}")
+
+    depot_tools = ensure_depot_tools(root)
+    ensure_gclient_config(root)
+
+    if args.step == "checkout":
+        src = ensure_src_at_tag(root, version)
+        log(f"Checkout ready: {src}")
+    else:
+        gclient_sync(root, depot_tools)
+        log("gclient sync complete")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What

Daily (and on-demand) **unsigned** release builds of BrowserOS for all three platforms on WarpBuild runners, with the chromium checkout aggressively cached so nightly runs never pay for a full checkout. Signing stays out of scope by design — named secret placeholders are documented for wiring later.

| Platform | Runner | Config |
| --- | --- | --- |
| Linux x64 | `warp-ubuntu-2204-x64-32x` (32 vCPU / 128 GB / 150 GB) | `release.linux.ci.yaml` |
| Windows x64 | `warp-windows-2025-x64-32x` (32 vCPU / 128 GB / 256 GB) | `release.windows.ci.yaml` |
| macOS arm64 | `warp-macos-15-arm64-12x` (M4 Pro / 44 GB / 270 GB) | `release.macos.arm64.ci.yaml` |

> Label correction: `warp-macos-14-arm64-32x` (originally requested) does not exist — WarpBuild macs top out at 12 vCPU and macOS 14 is only offered at 6x. `warp-macos-15-arm64-12x` is their largest Mac.

## Pipeline design

One workflow (`nightly-release.yml`, `schedule` 08:00 UTC + `workflow_dispatch`) with a 3-entry matrix rather than three sibling workflows: one schedule, one shared publish job, and the per-OS deltas are a handful of `runner.os` conditionals — duplicating the cache/sync/build skeleton three times invites drift.

Per platform, each night:

1. Restore pinned checkout cache (see below).
2. `scripts/ci/setup_chromium.py --step checkout` — depot_tools + `src` at the tag from `packages/browseros/CHROMIUM_VERSION` (no-op when warm).
3. `uv run browseros build --modules clean ...` — the stock clean module resets the tree.
4. `scripts/ci/setup_chromium.py --step sync` — `gclient sync -D --no-history --shallow`, exactly what `git_setup` runs.
5. Save cache (first run per chromium pin only) — captured *post-sync, pre-patch, no `out/`*, so the cache is pristine and deterministic.
6. `uv run browseros build --config build/config/release.<os>.ci.yaml --chromium-src .../src`.
7. `actions/upload-artifact` (14d retention): `.dmg`, `.AppImage`, `.deb`, `_installer.exe`, `_installer.zip`.
8. A follow-up job recreates a rolling `nightly` prerelease (scheduled main runs, or dispatch with `publish_nightly=true`).

The CI configs are the release configs minus `sign_*`/`upload`/`clean`/`git_setup`:

- `git_setup` does `git fetch --tags`, which against chromium's ~70k tags would effectively unshallow the CI clone — the script fetches **exactly the pinned tag at depth 2** instead. Everything else (`clean`, `gclient sync` flags, prep/build/package modules) is reused unchanged.
- Unsigned macOS needed zero changes: `package_macos` already builds an unsigned DMG when `sign_macos` didn't run.
- Unsigned Windows needed one small build-system addition: **`mini_installer` module** — the installer was previously only built *inside* `sign_windows` (sign → build installer → sign installer). The new module exposes the existing `build_mini_installer` step so `package_windows` has its input.
- Linux CI builds x64 (the runner arch); `release.linux.yaml` stays on its temporary arm64 cross-compile pin.

## Caching strategy (the core problem)

Key: `chromium-src-<platform>-<arch>-v1-<CHROMIUM_VERSION>` (pin: 148.0.7778.97). Contents: the whole gclient root (depot_tools, `.gclient`, post-sync `src`).

- **Linux/macOS — WarpCache** (`WarpBuilds/cache@v1`): drop-in for `actions/cache` with **no size cap** (vs GitHub's 10 GB/repo), 7-day idle expiry, $0.20/GB-mo. `restore-keys` falls back to the previous pin's cache and the script fast-forwards with a single-tag fetch.
- **Windows — R2 tarball** (`scripts/ci/r2_cache.py`): WarpCache **does not support Windows runners**, so the post-sync tree is zstd-tarred (~25–30 GB) to `ci-cache/chromium/` in the existing R2 bucket using the same `R2_*` secrets the build already needs for `download_resources`. R2 egress is free. Cache miss or missing creds degrade to a cold checkout, never a failure.
- ungoogled-chromium's tarball-fetch approach (no gclient at all) was evaluated and rejected: it requires hand-maintaining every toolchain download (clang/rust/node/gn/esbuild per OS) that `gclient sync` gives us for free, and BrowserOS's `clean`/`git_setup` modules assume a git+gclient tree. Their multi-stage job chaining exists for GitHub's 6 h hosted cap — WarpBuild runners register as self-hosted (5-day job cap), so single long jobs with explicit `timeout-minutes` (660/780/720) are simpler.

**Expected timings** (cold = first run or pin bump):

| | Cold | Warm |
| --- | --- | --- |
| Checkout + sync | 40–70 min | restore 3–10 min + sync 5–15 min |
| Build + package | 2.5–6 h | same (full rebuild nightly; `out/` is never cached) |

Compile dominates either way; the cache removes checkout cost, tag-fetch pathology and network flake. Phase-2 levers (documented in `packages/browseros/build/docs/nightly-warpbuild-ci.md`): WarpBuild **snapshot runners** (Ubuntu-only) to kill the restore minutes, and **sccache/ccache via `cc_wrapper`** which could cut warm builds to <1 h since nightly sources are near-identical.

**Disk note:** Linux is the tight fit (150 GB total — ~60–75 GB checkout + 25–40 GB `out/` + image); the workflow prints `df -h` every run. Windows (256 GB) and mac 12x (270 GB) are comfortable.

## Cost / runtime notes

WarpBuild list prices: linux 32x $3.84/h, windows 32x $7.68/h, mac 12x $9.60/h → roughly **$60–120 per full nightly** (~$2–3.5k/mo at daily cadence), plus ~$12/mo cache storage and ~$0.50/mo R2. `workflow_dispatch` has a `platforms` input so test iterations can burn one runner instead of three.

## Signing later

Placeholders are documented in the workflow env block and the doc — none are consumed today:

- macOS: `MACOS_CERTIFICATE_P12`, `MACOS_CERTIFICATE_PWD`, `MACOS_CERTIFICATE_NAME`, `MACOS_KEYCHAIN_PASSWORD`, `PROD_MACOS_NOTARIZATION_APPLE_ID/_TEAM_ID/_PWD`, `SPARKLE_PRIVATE_KEY` → add `sign_macos` (+ `sparkle_sign`) back to the CI config and import the cert into a temp keychain in a pre-build step.
- Windows: `ESIGNER_USERNAME/_PASSWORD/_TOTP_SECRET`, `ESIGNER_CREDENTIAL_ID`, `CODE_SIGN_TOOL_PATH` → swap `mini_installer` for `sign_windows` and install CodeSignTool in a step.

## Relationship to `nightly-macos-build.yml`

The task brief described it as a 4-line stub to supersede — on `main` it is actually the **live signed self-hosted Mac-Mini nightly** (R2 publish + version-bump PRs), so this PR deliberately does **not** touch it. Once this lane is proven and signing is wired here, it can be retired.

## Validation done (chromium can't be built in this environment)

- `actionlint` clean on the new workflow.
- All three CI configs loaded through the real `load_config`/module-registry path (all modules resolve, incl. `mini_installer`; gn flag files exist).
- `uv run browseros build --modules clean ...` executed end-to-end against a scratch git repo with the exact CI flags.
- `setup_chromium.py` git plumbing exercised against a fixture remote: cold clone, warm no-op, pin-bump fast-forward.
- `r2_cache.py`: no-creds path degrades gracefully (`cache-hit=false`, exit 0); tar|zstd pipeline round-trips with the `src/out` exclusion honored.
- `ruff check` clean on changed Python. (Repo's pytest harness fails collection on these modules identically before/after this change — pre-existing.)

## Post-merge test plan

```bash
# 1. Cheapest lane first; doubles as the Linux cache warm-up (~4-6h cold):
gh workflow run "Nightly Release Build" -f platforms=linux

# 2. Then the other two (windows also seeds the R2 cache):
gh workflow run "Nightly Release Build" -f platforms=windows
gh workflow run "Nightly Release Build" -f platforms=macos

# 3. Re-run one platform to confirm the warm path (restore + fast sync):
gh workflow run "Nightly Release Build" -f platforms=linux

# 4. Full run incl. rolling prerelease:
gh workflow run "Nightly Release Build" -f publish_nightly=true

# Watch: gh run list --workflow "Nightly Release Build" / gh run watch <id>
```

First-run risks to watch (called out in the doc): WarpBuild Windows image parity with GitHub's (VS 2022 toolset + Windows SDK version chromium 148 wants, zstd/GNU-tar availability) and Linux disk headroom from the `df -h` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
