### PR TITLE
feat(build): WinSparkle auto-update pipeline for Windows

### DIFF
--- a/packages/browseros/build/cli/build.py
+++ b/packages/browseros/build/cli/build.py
@@ -81,7 +81,7 @@ AVAILABLE_MODULES = {
     "sign_macos": MacOSSignModule,
     "sign_windows": WindowsSignModule,
     "sign_linux": LinuxSignModule,
-    "sparkle_sign": SparkleSignModule,  # macOS Sparkle signing for auto-update
+    "sparkle_sign": SparkleSignModule,  # Sparkle/WinSparkle Ed25519 signing for auto-update
     # Package (platform-specific, validated at runtime)
     "package_macos": MacOSPackageModule,
     "package_windows": WindowsPackageModule,

--- a/packages/browseros/build/cli/build.py
+++ b/packages/browseros/build/cli/build.py
@@ -35,7 +35,11 @@ from ..common.utils import (
 
 # Import all module classes
 from ..modules.setup.clean import CleanModule
-from ..modules.setup.git import GitSetupModule, SparkleSetupModule
+from ..modules.setup.git import (
+    GitSetupModule,
+    SparkleSetupModule,
+    WinSparkleSetupModule,
+)
 from ..modules.setup.configure import ConfigureModule
 from ..modules.compile import CompileModule, UniversalBuildModule
 from ..modules.patches.patches import PatchesModule
@@ -60,6 +64,7 @@ AVAILABLE_MODULES = {
     "clean": CleanModule,
     "git_setup": GitSetupModule,
     "sparkle_setup": SparkleSetupModule,
+    "winsparkle_setup": WinSparkleSetupModule,
     "configure": ConfigureModule,
     # Patches & Resources
     "patches": PatchesModule,
@@ -112,10 +117,20 @@ def _get_package_module():
         sys.exit(1)
 
 
+def _get_setup_modules():
+    """Setup phase modules; the Sparkle/WinSparkle download is platform-bound."""
+    modules = ["clean", "git_setup"]
+    if IS_MACOS():
+        modules.append("sparkle_setup")
+    elif IS_WINDOWS():
+        modules.append("winsparkle_setup")
+    return modules
+
+
 # Fixed execution order - flags enable/disable phases, order is always the same
 EXECUTION_ORDER = [
     # Phase 1: Setup & Clean
-    ("setup", ["clean", "git_setup", "sparkle_setup"]),
+    ("setup", _get_setup_modules()),
     # Phase 2: Patches & Resources
     (
         "prep",
@@ -264,7 +279,7 @@ def main(
     setup: bool = typer.Option(
         False,
         "--setup",
-        help="Run setup phase (clean, git_setup, sparkle_setup)",
+        help="Run setup phase (clean, git_setup, sparkle_setup/winsparkle_setup)",
     ),
     prep: bool = typer.Option(
         False,

--- a/packages/browseros/build/common/context.py
+++ b/packages/browseros/build/common/context.py
@@ -158,6 +158,7 @@ class BuildConfig:
 
         # Third party versions
         self.SPARKLE_VERSION = "2.7.0"
+        self.WINSPARKLE_VERSION = "0.9.3"
 
         # Set platform-specific app names
         self._set_app_names()
@@ -205,6 +206,7 @@ class Context:
 
     # Third party
     SPARKLE_VERSION: str = "2.7.0"
+    WINSPARKLE_VERSION: str = "0.9.3"
 
     # Legacy artifacts dict - kept for backward compatibility
     # New code should use ctx.artifacts (ArtifactRegistry) instead
@@ -422,6 +424,14 @@ class Context:
     def get_sparkle_url(self) -> str:
         """Get Sparkle download URL"""
         return f"https://github.com/sparkle-project/Sparkle/releases/download/{self.SPARKLE_VERSION}/Sparkle-{self.SPARKLE_VERSION}.tar.xz"
+
+    def get_winsparkle_dir(self) -> Path:
+        """Get WinSparkle directory"""
+        return join_paths(self.chromium_src, "third_party", "winsparkle")
+
+    def get_winsparkle_url(self) -> str:
+        """Get WinSparkle download URL (note the v-prefixed release tag)"""
+        return f"https://github.com/vslavik/winsparkle/releases/download/v{self.WINSPARKLE_VERSION}/WinSparkle-{self.WINSPARKLE_VERSION}.zip"
 
     def get_extensions_manifest_url(self) -> str:
         """Get CDN URL for bundled extensions update manifest"""

--- a/packages/browseros/build/common/pipeline.py
+++ b/packages/browseros/build/common/pipeline.py
@@ -35,7 +35,7 @@ def show_available_modules(available_modules: Dict[str, Type[CommandModule]]) ->
 
     # Group modules by prefix
     groups = {
-        "Setup & Environment": ["clean", "git_setup", "sparkle_setup", "configure"],
+        "Setup & Environment": ["clean", "git_setup", "sparkle_setup", "winsparkle_setup", "configure"],
         "Patches & Resources": ["patches", "chromium_replace", "string_replaces", "resources"],
         "Build": ["compile"],
         "Code Signing": ["sign_macos", "sign_windows", "sign_linux"],

--- a/packages/browseros/build/common/testing.py
+++ b/packages/browseros/build/common/testing.py
@@ -100,6 +100,12 @@ class MockChromium:
         sparkle.mkdir(parents=True, exist_ok=True)
         return sparkle
 
+    def with_winsparkle(self) -> Path:
+        """Create the third_party/winsparkle directory marker."""
+        winsparkle = self.src / "third_party" / "winsparkle"
+        winsparkle.mkdir(parents=True, exist_ok=True)
+        return winsparkle
+
     def with_pkg_dmg(self) -> Path:
         """Create the chrome/installer/mac/pkg-dmg tool marker."""
         return self.add_file("chrome/installer/mac/pkg-dmg", "#!/bin/sh\n")

--- a/packages/browseros/build/config/release.windows.yaml
+++ b/packages/browseros/build/config/release.windows.yaml
@@ -16,6 +16,7 @@ modules:
   # Phase 1: Setup
   - clean
   - git_setup
+  - winsparkle_setup
 
   # Phase 2: Patches & Resources
   - download_resources
@@ -33,6 +34,9 @@ modules:
   # Phase 4: Sign & Package
   - sign_windows
   - package_windows
+  # Ed25519-sign the packaged installer for WinSparkle (after authenticode
+  # signing so the signature covers the final bytes)
+  - sparkle_sign
 
   # Phase 5: Upload
   - upload
@@ -44,6 +48,7 @@ required_envs:
   - ESIGNER_USERNAME            # SSL.com eSigner username
   - ESIGNER_PASSWORD            # SSL.com eSigner password
   - ESIGNER_TOTP_SECRET         # SSL.com eSigner TOTP secret
+  - SPARKLE_PRIVATE_KEY         # Ed25519 key for WinSparkle update signing
 
 # Notification settings
 notifications:

--- a/packages/browseros/build/modules/release/appcast.py
+++ b/packages/browseros/build/modules/release/appcast.py
@@ -31,18 +31,28 @@ class AppcastModule(CommandModule):
         version = ctx.release_version
         metadata = fetch_all_release_metadata(version, ctx.env)
 
-        if "macos" not in metadata:
-            log_info(f"No macOS release metadata found for version {version}")
+        if "macos" not in metadata and "win" not in metadata:
+            log_info(
+                f"No macOS or Windows release metadata found for version {version}"
+            )
             return
-
-        release = metadata["macos"]
-        sparkle_version = release.get("sparkle_version", "")
-        build_date = release.get("build_date", "")
-        artifacts = release.get("artifacts", {})
 
         log_info(f"\n{'='*60}")
         log_info(f"APPCAST SNIPPETS FOR v{version}")
         log_info(f"{'='*60}")
+
+        if "macos" in metadata:
+            self._print_macos_items(metadata["macos"], version)
+
+        if "win" in metadata:
+            self._print_windows_items(metadata["win"], version)
+
+        log_info(f"\n{'='*60}")
+
+    def _print_macos_items(self, release: dict, version: str) -> None:
+        sparkle_version = release.get("sparkle_version", "")
+        build_date = release.get("build_date", "")
+        artifacts = release.get("artifacts", {})
 
         arch_to_file = {
             "arm64": "appcast.xml",
@@ -61,4 +71,29 @@ class AppcastModule(CommandModule):
             log_info(f"\n{arch_to_file[arch]} ({arch}):")
             print(generate_appcast_item(artifact, version, sparkle_version, build_date))
 
-        log_info(f"\n{'='*60}")
+    def _print_windows_items(self, release: dict, version: str) -> None:
+        sparkle_version = release.get("sparkle_version", "")
+        build_date = release.get("build_date", "")
+        artifacts = release.get("artifacts", {})
+
+        # WinSparkle feeds, one per arch (chrome/browser/win/winsparkle_glue.cc
+        # picks the matching URL at compile time).
+        key_to_file = {
+            "x64_installer": "appcast-win.xml",
+            "arm64_installer": "appcast-win-arm64.xml",
+        }
+
+        for key, appcast_file in key_to_file.items():
+            if key not in artifacts:
+                continue
+
+            artifact = artifacts[key]
+            if "sparkle_signature" not in artifact:
+                log_warning(f"{key} artifact missing sparkle_signature")
+
+            log_info(f"\n{appcast_file} ({key}):")
+            print(
+                generate_appcast_item(
+                    artifact, version, sparkle_version, build_date, platform="win"
+                )
+            )

--- a/packages/browseros/build/modules/release/common.py
+++ b/packages/browseros/build/modules/release/common.py
@@ -136,21 +136,17 @@ def generate_appcast_item(
     signature = artifact.get("sparkle_signature", "")
     length = artifact.get("sparkle_length", artifact.get("size", 0))
 
-    if platform == "win":
-        enclosure = f"""<enclosure
-    url="{artifact['url']}"
-    sparkle:os="windows"
+    os_attr = '\n    sparkle:os="windows"' if platform == "win" else ""
+    footer = (
+        ""
+        if platform == "win"
+        else "\n  <sparkle:minimumSystemVersion>10.15</sparkle:minimumSystemVersion>"
+    )
+    enclosure = f"""<enclosure
+    url="{artifact['url']}"{os_attr}
     sparkle:edSignature="{signature}"
     length="{length}"
     type="application/octet-stream" />"""
-        footer = ""
-    else:
-        enclosure = f"""<enclosure
-    url="{artifact['url']}"
-    sparkle:edSignature="{signature}"
-    length="{length}"
-    type="application/octet-stream" />"""
-        footer = "\n  <sparkle:minimumSystemVersion>10.15</sparkle:minimumSystemVersion>"
 
     return f"""<item>
   <title>BrowserOS - {version}</title>

--- a/packages/browseros/build/modules/release/common.py
+++ b/packages/browseros/build/modules/release/common.py
@@ -120,8 +120,13 @@ def generate_appcast_item(
     version: str,
     sparkle_version: str,
     build_date: str,
+    platform: str = "macos",
 ) -> str:
-    """Generate Sparkle <item> XML for an artifact"""
+    """Generate a Sparkle/WinSparkle <item> XML for an artifact
+
+    macOS items carry a minimumSystemVersion; Windows items instead tag the
+    enclosure with sparkle:os="windows" so WinSparkle accepts it.
+    """
     try:
         dt = datetime.fromisoformat(build_date.replace("Z", "+00:00"))
         pub_date = dt.strftime("%a, %d %b %Y %H:%M:%S %z")
@@ -131,6 +136,22 @@ def generate_appcast_item(
     signature = artifact.get("sparkle_signature", "")
     length = artifact.get("sparkle_length", artifact.get("size", 0))
 
+    if platform == "win":
+        enclosure = f"""<enclosure
+    url="{artifact['url']}"
+    sparkle:os="windows"
+    sparkle:edSignature="{signature}"
+    length="{length}"
+    type="application/octet-stream" />"""
+        footer = ""
+    else:
+        enclosure = f"""<enclosure
+    url="{artifact['url']}"
+    sparkle:edSignature="{signature}"
+    length="{length}"
+    type="application/octet-stream" />"""
+        footer = "\n  <sparkle:minimumSystemVersion>10.15</sparkle:minimumSystemVersion>"
+
     return f"""<item>
   <title>BrowserOS - {version}</title>
   <description sparkle:format="plain-text">
@@ -139,12 +160,7 @@ def generate_appcast_item(
   <sparkle:shortVersionString>{version}</sparkle:shortVersionString>
   <pubDate>{pub_date}</pubDate>
   <link>https://browseros.com</link>
-  <enclosure
-    url="{artifact['url']}"
-    sparkle:edSignature="{signature}"
-    length="{length}"
-    type="application/octet-stream" />
-  <sparkle:minimumSystemVersion>10.15</sparkle:minimumSystemVersion>
+  {enclosure}{footer}
 </item>"""
 
 

--- a/packages/browseros/build/modules/release/common_test.py
+++ b/packages/browseros/build/modules/release/common_test.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Tests for appcast item generation."""
+
+import unittest
+
+from .common import generate_appcast_item
+
+ARTIFACT = {
+    "url": "https://cdn.browseros.com/releases/0.31.0/win/BrowserOS_v0.31.0_x64_installer.exe",
+    "sparkle_signature": "c2lnbmF0dXJl",
+    "sparkle_length": 12345,
+}
+
+
+class GenerateAppcastItemTest(unittest.TestCase):
+    def test_windows_item_has_os_attr_and_no_min_system_version(self):
+        item = generate_appcast_item(
+            ARTIFACT, "0.31.0", "7778.97", "2026-06-11T00:00:00Z", platform="win"
+        )
+        self.assertIn('sparkle:os="windows"', item)
+        self.assertIn('sparkle:edSignature="c2lnbmF0dXJl"', item)
+        self.assertIn('length="12345"', item)
+        self.assertIn("<sparkle:version>7778.97</sparkle:version>", item)
+        self.assertIn(
+            "<sparkle:shortVersionString>0.31.0</sparkle:shortVersionString>", item
+        )
+        self.assertNotIn("minimumSystemVersion", item)
+
+    def test_macos_item_unchanged_by_default(self):
+        item = generate_appcast_item(
+            ARTIFACT, "0.31.0", "7778.97", "2026-06-11T00:00:00Z"
+        )
+        self.assertIn(
+            "<sparkle:minimumSystemVersion>10.15</sparkle:minimumSystemVersion>",
+            item,
+        )
+        self.assertNotIn("sparkle:os=", item)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/modules/setup/clean.py
+++ b/packages/browseros/build/modules/setup/clean.py
@@ -33,6 +33,9 @@ class CleanModule(CommandModule):
         sparkle_dir = ctx.get_sparkle_dir()
         if sparkle_dir.exists():
             safe_rmtree(sparkle_dir)
+        winsparkle_dir = ctx.get_winsparkle_dir()
+        if winsparkle_dir.exists():
+            safe_rmtree(winsparkle_dir)
         log_success("Cleaned Sparkle build directory")
 
     def _git_reset(self, ctx: Context) -> None:

--- a/packages/browseros/build/modules/setup/clean.py
+++ b/packages/browseros/build/modules/setup/clean.py
@@ -36,7 +36,7 @@ class CleanModule(CommandModule):
         winsparkle_dir = ctx.get_winsparkle_dir()
         if winsparkle_dir.exists():
             safe_rmtree(winsparkle_dir)
-        log_success("Cleaned Sparkle build directory")
+        log_success("Cleaned Sparkle/WinSparkle build directories")
 
     def _git_reset(self, ctx: Context) -> None:
         run_command(["git", "reset", "--hard", "HEAD"], cwd=ctx.chromium_src)

--- a/packages/browseros/build/modules/setup/clean_test.py
+++ b/packages/browseros/build/modules/setup/clean_test.py
@@ -38,12 +38,14 @@ class CleanExecuteTest(unittest.TestCase):
             )
             out_dir = chromium.with_out_dir("x64", args_gn="is_debug = false\n")
             sparkle = chromium.with_sparkle()
+            winsparkle = chromium.with_winsparkle()
 
             with mock.patch.object(clean, "run_command") as run_cmd:
                 clean.CleanModule().execute(ctx)
 
             self.assertFalse(out_dir.exists())
             self.assertFalse(sparkle.exists())
+            self.assertFalse(winsparkle.exists())
 
             git_commands = [call.args[0] for call in run_cmd.call_args_list]
             self.assertEqual(

--- a/packages/browseros/build/modules/setup/git.py
+++ b/packages/browseros/build/modules/setup/git.py
@@ -2,9 +2,12 @@
 """Git operations module for BrowserOS build system"""
 
 import re
+import shutil
 import subprocess
 import tarfile
 import urllib.request
+import zipfile
+from pathlib import Path
 from typing import List
 
 from ...common.module import CommandModule, ValidationError
@@ -156,3 +159,59 @@ class SparkleSetupModule(CommandModule):
         sparkle_archive.unlink()
 
         log_success("Sparkle setup complete")
+
+
+class WinSparkleSetupModule(CommandModule):
+    produces = []
+    requires = []
+    description = "Download and setup WinSparkle library (Windows only)"
+
+    def validate(self, ctx: Context) -> None:
+        if not IS_WINDOWS():
+            raise ValidationError("WinSparkle setup requires Windows")
+
+    def execute(self, ctx: Context) -> None:
+        log_info("\n✨ Setting up WinSparkle library...")
+
+        winsparkle_dir = ctx.get_winsparkle_dir()
+
+        if winsparkle_dir.exists():
+            safe_rmtree(winsparkle_dir)
+
+        winsparkle_dir.mkdir(parents=True)
+
+        winsparkle_url = ctx.get_winsparkle_url()
+        winsparkle_archive = winsparkle_dir / "winsparkle.zip"
+
+        log_info(f"Downloading WinSparkle from {winsparkle_url}...")
+        urllib.request.urlretrieve(winsparkle_url, winsparkle_archive)
+
+        log_info("Extracting WinSparkle...")
+        extract_winsparkle_zip(winsparkle_archive, winsparkle_dir)
+
+        winsparkle_archive.unlink()
+
+        log_success("WinSparkle setup complete")
+
+
+def extract_winsparkle_zip(archive: Path, dest: Path) -> None:
+    """Extract the release zip stripping its top-level WinSparkle-<version>/
+    directory, so //third_party/winsparkle paths stay version-independent
+    (include/, x64/Release/, ...) and match the vendored BUILD.gn.
+    """
+    with zipfile.ZipFile(archive) as zf:
+        for info in zf.infolist():
+            parts = Path(info.filename).parts
+            if info.filename.startswith(("/", "\\")) or ".." in parts:
+                raise RuntimeError(f"Unsafe path in archive: {info.filename}")
+            # parts[0] is the WinSparkle-<version>/ wrapper; entries directly
+            # at the root (only the wrapper dir itself) carry nothing to copy.
+            if len(parts) <= 1:
+                continue
+            target = dest.joinpath(*parts[1:])
+            if info.is_dir():
+                target.mkdir(parents=True, exist_ok=True)
+                continue
+            target.parent.mkdir(parents=True, exist_ok=True)
+            with zf.open(info) as src, open(target, "wb") as out:
+                shutil.copyfileobj(src, out)

--- a/packages/browseros/build/modules/setup/git.py
+++ b/packages/browseros/build/modules/setup/git.py
@@ -200,15 +200,26 @@ def extract_winsparkle_zip(archive: Path, dest: Path) -> None:
     (include/, x64/Release/, ...) and match the vendored BUILD.gn.
     """
     with zipfile.ZipFile(archive) as zf:
-        for info in zf.infolist():
+        infos = zf.infolist()
+
+        # The official archive wraps everything in a single version dir; a
+        # different layout would silently produce a broken tree, so fail fast.
+        top_levels = {Path(info.filename).parts[0] for info in infos if info.filename.strip("/")}
+        if len(top_levels) != 1:
+            raise RuntimeError(
+                f"Expected a single top-level directory in {archive.name}, "
+                f"got: {sorted(top_levels)}"
+            )
+
+        resolved_dest = dest.resolve()
+        for info in infos:
             parts = Path(info.filename).parts
-            if info.filename.startswith(("/", "\\")) or ".." in parts:
-                raise RuntimeError(f"Unsafe path in archive: {info.filename}")
-            # parts[0] is the WinSparkle-<version>/ wrapper; entries directly
-            # at the root (only the wrapper dir itself) carry nothing to copy.
             if len(parts) <= 1:
                 continue
             target = dest.joinpath(*parts[1:])
+            # Guards against zip-slip (.., absolute or drive-relative paths).
+            if not target.resolve().is_relative_to(resolved_dest):
+                raise RuntimeError(f"Unsafe path in archive: {info.filename}")
             if info.is_dir():
                 target.mkdir(parents=True, exist_ok=True)
                 continue

--- a/packages/browseros/build/modules/setup/winsparkle_test.py
+++ b/packages/browseros/build/modules/setup/winsparkle_test.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Tests for the WinSparkle setup module."""
+
+import tempfile
+import unittest
+import zipfile
+from pathlib import Path
+from unittest import mock
+
+from . import git
+from ...common.module import ValidationError
+from ...common.testing import MockBrowserOSRoot, MockChromium, make_context
+
+
+def _make_release_zip(path: Path, version: str = "0.9.3") -> None:
+    """Build a zip shaped like the official WinSparkle release archive."""
+    top = f"WinSparkle-{version}"
+    with zipfile.ZipFile(path, "w") as zf:
+        zf.writestr(f"{top}/include/winsparkle.h", "// header\n")
+        zf.writestr(f"{top}/include/winsparkle-version.h", "// version\n")
+        zf.writestr(f"{top}/x64/Release/WinSparkle.dll", b"dll-bytes")
+        zf.writestr(f"{top}/x64/Release/WinSparkle.lib", b"lib-bytes")
+        zf.writestr(f"{top}/ARM64/Release/WinSparkle.dll", b"dll-bytes-arm")
+        zf.writestr(f"{top}/COPYING", "MIT\n")
+
+
+class ExtractWinSparkleZipTest(unittest.TestCase):
+    def test_strips_top_level_version_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "winsparkle.zip"
+            dest = Path(tmp) / "out"
+            dest.mkdir()
+            _make_release_zip(archive)
+
+            git.extract_winsparkle_zip(archive, dest)
+
+            self.assertTrue((dest / "include" / "winsparkle.h").exists())
+            self.assertTrue(
+                (dest / "x64" / "Release" / "WinSparkle.dll").exists()
+            )
+            self.assertTrue(
+                (dest / "ARM64" / "Release" / "WinSparkle.dll").exists()
+            )
+            self.assertEqual((dest / "COPYING").read_text(), "MIT\n")
+            self.assertFalse((dest / "WinSparkle-0.9.3").exists())
+
+    def test_rejects_path_traversal(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            archive = Path(tmp) / "evil.zip"
+            dest = Path(tmp) / "out"
+            dest.mkdir()
+            with zipfile.ZipFile(archive, "w") as zf:
+                zf.writestr("WinSparkle-0.9.3/../../evil.txt", "boom")
+
+            with self.assertRaises(RuntimeError):
+                git.extract_winsparkle_zip(archive, dest)
+            self.assertFalse((Path(tmp) / "evil.txt").exists())
+
+
+class WinSparkleSetupModuleTest(unittest.TestCase):
+    def test_validate_requires_windows(self):
+        with (
+            tempfile.TemporaryDirectory() as chromium_tmp,
+            tempfile.TemporaryDirectory() as root_tmp,
+        ):
+            ctx = make_context(
+                MockChromium(Path(chromium_tmp)),
+                MockBrowserOSRoot(Path(root_tmp)),
+                architecture="x64",
+            )
+            with mock.patch.object(git, "IS_WINDOWS", return_value=False):
+                with self.assertRaises(ValidationError):
+                    git.WinSparkleSetupModule().validate(ctx)
+            with mock.patch.object(git, "IS_WINDOWS", return_value=True):
+                git.WinSparkleSetupModule().validate(ctx)
+
+    def test_execute_downloads_extracts_and_replaces_existing(self):
+        with (
+            tempfile.TemporaryDirectory() as chromium_tmp,
+            tempfile.TemporaryDirectory() as root_tmp,
+        ):
+            chromium = MockChromium(Path(chromium_tmp))
+            ctx = make_context(
+                chromium, MockBrowserOSRoot(Path(root_tmp)), architecture="x64"
+            )
+            stale = chromium.with_winsparkle() / "stale.txt"
+            stale.write_text("old contents")
+
+            def fake_urlretrieve(url, dest):
+                self.assertEqual(url, ctx.get_winsparkle_url())
+                _make_release_zip(Path(dest))
+
+            with mock.patch.object(
+                git.urllib.request, "urlretrieve", side_effect=fake_urlretrieve
+            ):
+                git.WinSparkleSetupModule().execute(ctx)
+
+            winsparkle_dir = ctx.get_winsparkle_dir()
+            self.assertTrue(
+                (winsparkle_dir / "include" / "winsparkle.h").exists()
+            )
+            self.assertFalse(stale.exists())
+            self.assertFalse((winsparkle_dir / "winsparkle.zip").exists())
+
+
+class WinSparkleContextTest(unittest.TestCase):
+    def test_url_and_dir_helpers(self):
+        with (
+            tempfile.TemporaryDirectory() as chromium_tmp,
+            tempfile.TemporaryDirectory() as root_tmp,
+        ):
+            chromium = MockChromium(Path(chromium_tmp))
+            ctx = make_context(
+                chromium, MockBrowserOSRoot(Path(root_tmp)), architecture="x64"
+            )
+            self.assertEqual(
+                ctx.get_winsparkle_dir(),
+                chromium.src / "third_party" / "winsparkle",
+            )
+            version = ctx.WINSPARKLE_VERSION
+            self.assertEqual(
+                ctx.get_winsparkle_url(),
+                "https://github.com/vslavik/winsparkle/releases/download/"
+                f"v{version}/WinSparkle-{version}.zip",
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/modules/sign/sparkle.py
+++ b/packages/browseros/build/modules/sign/sparkle.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Sparkle signing module for macOS auto-update"""
+"""Sparkle/WinSparkle Ed25519 signing module for auto-update"""
 
 from pathlib import Path
-from typing import Dict, Tuple
+from typing import Dict, List, Tuple
 
 from ...common.module import CommandModule, ValidationError
 from ...common.context import Context
@@ -14,12 +14,20 @@ from ...common.utils import (
 )
 
 
+def find_signable_artifacts(dist_dir: Path) -> List[Path]:
+    """Update artifacts the appcast points at: DMGs on macOS, the installer
+    EXE on Windows (WinSparkle downloads and runs the installer directly;
+    the portable ZIP is not an update enclosure, so it is not signed).
+    """
+    return sorted(dist_dir.glob("*.dmg")) + sorted(dist_dir.glob("*.exe"))
+
+
 class SparkleSignModule(CommandModule):
-    """Sign DMGs with Sparkle for macOS auto-update"""
+    """Sign update artifacts with the Sparkle Ed25519 key"""
 
     produces = ["sparkle_signatures"]
     requires = []
-    description = "Sign DMG files with Sparkle Ed25519 key for auto-update"
+    description = "Sign update artifacts with Sparkle Ed25519 key for auto-update"
 
     def validate(self, ctx: Context) -> None:
         if not ctx.env.has_sparkle_key():
@@ -28,21 +36,20 @@ class SparkleSignModule(CommandModule):
             )
 
     def execute(self, ctx: Context) -> None:
-        log_info("\n🔐 Signing DMGs with Sparkle...")
+        log_info("\n🔐 Signing update artifacts with Sparkle...")
 
-        # Find DMG files in dist directory
         dist_dir = ctx.get_dist_dir()
         if not dist_dir.exists():
             log_warning(f"Dist directory not found: {dist_dir}")
             return
 
-        dmg_files = list(dist_dir.glob("*.dmg"))
-        if not dmg_files:
-            log_warning("No DMG files found to sign")
+        artifact_files = find_signable_artifacts(dist_dir)
+        if not artifact_files:
+            log_warning("No signable artifacts (*.dmg, *.exe) found to sign")
             return
 
-        # Sign each DMG and collect signatures
-        signatures = sign_dmgs_with_sparkle(ctx, dmg_files)
+        # Sign each artifact and collect signatures
+        signatures = sign_files_with_sparkle(ctx, artifact_files)
 
         # Store signatures in artifact registry for upload module
         for filename, (sig, length) in signatures.items():
@@ -52,30 +59,30 @@ class SparkleSignModule(CommandModule):
         # Store signatures for upload module to access via ctx.artifacts
         ctx.artifacts["sparkle_signatures"] = signatures
 
-        log_success(f"✅ Signed {len(signatures)} DMG(s) with Sparkle")
+        log_success(f"✅ Signed {len(signatures)} artifact(s) with Sparkle")
 
 
-def sign_dmgs_with_sparkle(
+def sign_files_with_sparkle(
     ctx: Context,
-    dmg_files: list,
+    files: list,
 ) -> Dict[str, Tuple[str, int]]:
-    """Sign DMG files with Sparkle and return signatures
+    """Sign files with Sparkle and return signatures
 
     Args:
         ctx: Build context
-        dmg_files: List of DMG file paths to sign
+        files: List of file paths to sign
 
     Returns:
         Dict mapping filename to (signature, length) tuple
     """
     signatures = {}
 
-    for dmg_path in dmg_files:
-        log_info(f"🔐 Signing {dmg_path.name}...")
-        sig, length = sparkle_sign_file(dmg_path, ctx.env)
+    for file_path in files:
+        log_info(f"🔐 Signing {file_path.name}...")
+        sig, length = sparkle_sign_file(file_path, ctx.env)
         if sig:
-            signatures[dmg_path.name] = (sig, length)
-            log_success(f"✓ Signed {dmg_path.name}")
+            signatures[file_path.name] = (sig, length)
+            log_success(f"✓ Signed {file_path.name}")
 
     return signatures
 

--- a/packages/browseros/build/modules/sign/sparkle_test.py
+++ b/packages/browseros/build/modules/sign/sparkle_test.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""Tests for Sparkle/WinSparkle signing artifact selection."""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from .sparkle import find_signable_artifacts
+
+
+class FindSignableArtifactsTest(unittest.TestCase):
+    def test_picks_dmgs_and_installer_exe_but_not_zip(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            dist = Path(tmp)
+            (dist / "BrowserOS_v0.31.0_arm64.dmg").write_bytes(b"dmg")
+            (dist / "BrowserOS_v0.31.0_x64_installer.exe").write_bytes(b"exe")
+            (dist / "BrowserOS_v0.31.0_x64_installer.zip").write_bytes(b"zip")
+            (dist / "notes.txt").write_text("not an artifact")
+
+            names = [p.name for p in find_signable_artifacts(dist)]
+
+            self.assertEqual(
+                names,
+                [
+                    "BrowserOS_v0.31.0_arm64.dmg",
+                    "BrowserOS_v0.31.0_x64_installer.exe",
+                ],
+            )
+
+    def test_empty_dist(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual(find_signable_artifacts(Path(tmp)), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/modules/storage/upload.py
+++ b/packages/browseros/build/modules/storage/upload.py
@@ -276,9 +276,10 @@ def upload_release_artifacts(
         artifact_metadata.append(metadata)
 
     release_data = generate_release_json(ctx, artifact_metadata, platform)
-    if platform == "linux":
-        # Linux x64 and arm64 release jobs must be sequenced. A parallel
-        # fetch-merge-upload flow can still race and drop one architecture.
+    if platform in ("linux", "win"):
+        # Per-arch release jobs (linux x64/arm64, win x64/arm64) must be
+        # sequenced. A parallel fetch-merge-upload flow can still race and
+        # drop one architecture.
         existing_release_data = get_release_json(
             ctx.get_semantic_version(), platform, env
         )
@@ -293,7 +294,7 @@ def upload_release_artifacts(
     log_success(f"\nSuccessfully uploaded {len(artifacts)} artifact(s) to R2")
     log_info("\nRelease metadata:")
     log_info(f"  Version: {release_data['version']}")
-    if platform == "macos":
+    if platform in ("macos", "win"):
         log_info(f"  Sparkle version: {release_data.get('sparkle_version', 'N/A')}")
     log_info(f"  Artifacts: {list(release_data['artifacts'].keys())}")
 

--- a/packages/browseros/build/modules/storage/upload.py
+++ b/packages/browseros/build/modules/storage/upload.py
@@ -101,7 +101,9 @@ def generate_release_json(
         "artifacts": {},
     }
 
-    if platform == "macos":
+    # Sparkle (macOS) and WinSparkle (Windows) both compare against this
+    # BUILD.PATCH version in the appcast.
+    if platform in ("macos", "win"):
         release_data["sparkle_version"] = ctx.get_sparkle_version()
 
     base_url = f"{env.r2_cdn_base_url}/{ctx.get_release_path(platform)}"
@@ -176,9 +178,9 @@ def _get_artifact_key(filename: str, platform: str) -> str:
 
     elif platform == "win":
         if "installer.exe" in lower:
-            return "x64_installer"
+            return "arm64_installer" if "arm64" in lower else "x64_installer"
         elif "installer.zip" in lower:
-            return "x64_zip"
+            return "arm64_zip" if "arm64" in lower else "x64_zip"
 
     elif platform == "linux":
         artifact_key = _get_linux_artifact_key(filename)

--- a/packages/browseros/build/modules/storage/upload_test.py
+++ b/packages/browseros/build/modules/storage/upload_test.py
@@ -31,6 +31,24 @@ class UploadMetadataTest(unittest.TestCase):
             "arm64_deb",
         )
 
+    def test_windows_installer_artifacts_use_arch_keys(self) -> None:
+        self.assertEqual(
+            _get_artifact_key("BrowserOS_v1.2.3_x64_installer.exe", "win"),
+            "x64_installer",
+        )
+        self.assertEqual(
+            _get_artifact_key("BrowserOS_v1.2.3_x64_installer.zip", "win"),
+            "x64_zip",
+        )
+        self.assertEqual(
+            _get_artifact_key("BrowserOS_v1.2.3_arm64_installer.exe", "win"),
+            "arm64_installer",
+        )
+        self.assertEqual(
+            _get_artifact_key("BrowserOS_v1.2.3_arm64_installer.zip", "win"),
+            "arm64_zip",
+        )
+
     def test_merge_release_metadata_preserves_existing_artifacts(self) -> None:
         existing = {
             "platform": "linux",


### PR DESCRIPTION
## Summary
- Adds WinSparkle (v0.9.3, https://winsparkle.org) auto-update support to the Windows build/release pipeline, mirroring the macOS Sparkle flow.
- `winsparkle_setup` module downloads the official release zip on the fly into `third_party/winsparkle/` (top-level zip dir stripped so GN paths stay version-independent); wired into `release.windows.yaml` after `git_setup`; `clean` wipes it.
- `sparkle_sign` now signs Windows installer EXEs with the same Ed25519 key (`SPARKLE_PRIVATE_KEY`) — runs after `package_windows` so the signature covers the authenticode-signed final bytes. The signature + `sparkle_version` (BUILD.PATCH) flow into the win `release.json`, and the appcast module emits Windows `<item>` snippets (`sparkle:os="windows"`, no mac `minimumSystemVersion`) labeled `appcast-win.xml` / `appcast-win-arm64.xml`.
- Windows `release.json` now merges across per-arch uploads (same protection linux already had).

## Design
The chromium-side integration (committed on the chromium patch stack: `cda19c4ee3980` third_party vendoring, `b80907e45aaed` glue, `3d1623add60f4` integration, `034ba1bba05a4` review fixes) initializes WinSparkle in the browser process with the appcast at `https://cdn.browseros.com/appcast-win.xml` and the same Ed25519 public key as macOS. When WinSparkle downloads an update, the browser runs `mini_installer` silently in the background (in-use update) and chromium's stock installed-version poller / relaunch-to-update machinery takes over — the browser never force-quits.

## Deployment notes (action needed before first Windows release)
- [ ] Run the `bros patch` / chromium_patches sync so `third_party/winsparkle/BUILD.gn` + the `chrome/` winsparkle files land in `packages/browseros/chromium_patches/` (the windows release build applies patches after `winsparkle_setup`; without the sync the GN target won't exist).
- [ ] Create `appcast-win.xml` on cdn.browseros.com (snippets come from the appcast module output).

## Test plan
- [x] Full build-module suite: 255 tests green (includes new tests for zip extraction/strip + traversal guard, setup module download/replace, signable-artifact selection, win appcast item shape, win artifact keying).
- [x] macOS release flow untouched (mac-only globs/branches preserved; suite green).
- [ ] First Windows release build is the end-to-end gate (cannot compile Windows on this macOS host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)