### PR TITLE
ci: move agent tests, code quality and weekly eval to WarpBuild

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,7 @@
+self-hosted-runner:
+  labels:
+    # WarpBuild cloud runners (register as self-hosted), e.g.
+    # warp-ubuntu-2404-x64-4x, warp-windows-2025-x64-32x, warp-macos-15-arm64-12x
+    - warp-*
+    # Signed macOS nightly builder (nightly-macos-build.yml)
+    - browseros-builder

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -7,13 +7,18 @@ on:
       - dev
     paths:
       - "packages/browseros-agent/**"
-      - .github/workflows/code-quality.yml
+      - ".github/workflows/code-quality.yml"
   workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   biome:
     name: runner / Biome
     runs-on: warp-ubuntu-2404-x64-4x
+    timeout-minutes: 10
     defaults:
       run:
         working-directory: packages/browseros-agent
@@ -36,6 +41,7 @@ jobs:
   typecheck:
     name: runner / Typecheck
     runs-on: warp-ubuntu-2404-x64-4x
+    timeout-minutes: 15
     defaults:
       run:
         working-directory: packages/browseros-agent

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -7,11 +7,13 @@ on:
       - dev
     paths:
       - "packages/browseros-agent/**"
+      - .github/workflows/code-quality.yml
+  workflow_dispatch:
 
 jobs:
   biome:
     name: runner / Biome
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-2404-x64-4x
     defaults:
       run:
         working-directory: packages/browseros-agent
@@ -33,7 +35,7 @@ jobs:
 
   typecheck:
     name: runner / Typecheck
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-2404-x64-4x
     defaults:
       run:
         working-directory: packages/browseros-agent

--- a/.github/workflows/eval-weekly.yml
+++ b/.github/workflows/eval-weekly.yml
@@ -21,8 +21,10 @@ permissions:
 
 jobs:
   eval:
-    runs-on: ubuntu-latest
-    timeout-minutes: 360
+    # WarpBuild runners register as self-hosted: no GitHub 6h hosted-job cap,
+    # so the timeout can exceed 360 as eval suites grow.
+    runs-on: warp-ubuntu-2404-x64-4x
+    timeout-minutes: 420
 
     steps:
       - name: Checkout

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,11 @@ on:
 permissions:
   contents: read
 
+# Superseded pushes stop billing warp minutes for 10 matrix jobs each.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 env:
   BROWSEROS_APPIMAGE_URL: https://files.browseros.com/download/BrowserOS.AppImage
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,8 +190,10 @@ jobs:
   comment:
     name: PR test summary
     needs: test
+    # !cancelled() (not always()): a run cancelled by concurrency
+    # cancel-in-progress must not post a misleading partial summary.
     if: >-
-      always()
+      !cancelled()
       && github.event_name == 'pull_request'
       && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ env:
 jobs:
   test:
     name: Tests / ${{ matrix.suite }}
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-2404-x64-4x
     timeout-minutes: 20
     defaults:
       run:


### PR DESCRIPTION
## Summary
- Moves the recurring-compute CI jobs to WarpBuild cloud runners (`warp-ubuntu-2404-x64-4x` — same Ubuntu 24.04 as today's `ubuntu-latest`, double the cores): the 10-suite test matrix (`test.yml`), Biome + typecheck (`code-quality.yml`), and the weekly eval (`eval-weekly.yml`, timeout 360 → 420 now that the GitHub-hosted 6h job cap no longer applies).
- Cost guards for metered runners: `concurrency` + `cancel-in-progress` on the two PR-triggered workflows, `timeout-minutes` on the code-quality jobs, and the test-summary comment now skips cancelled runs (`!cancelled()` instead of `always()`).
- `code-quality.yml` gains `workflow_dispatch` and its own path in the `paths` filter (same self-testing pattern `test.yml` uses), so this PR and future workflow edits exercise it.
- New `.github/actionlint.yaml` declaring `warp-*` and `browseros-builder` as known self-hosted labels so actionlint validates all workflows cleanly.

## Design
Targeted label swap, mirroring the conventions #1170 established for the nightly: pin the OS version (2404) rather than `latest` aliases, reserve 32x tiers for chromium compiles, and keep free GitHub-hosted runners for trivial glue (bots, `comment` job, plan/publish jobs). Release workflows (`release-*`) are deliberately untouched — they're rare, operator-triggered and environment-gated, so they can't be verified pre-merge; they can follow once warp is proven in daily CI. Full rationale in `packages/browseros/build/docs/nightly-warpbuild-ci.md` plus this PR.

## Test plan
- [x] `actionlint` clean on all touched workflows (warp labels validated via the new config)
- [x] `bun run typecheck` green; no TS touched (lint warnings pre-existing)
- [ ] Branch dispatches of `test.yml` + `code-quality.yml` picked up by `warp-*` runners and green (queued — see note below)
- [ ] PR checks (test matrix + code quality) green on warp runners
- [ ] `eval-weekly.yml` branch dispatch smoke: env-setup steps (deb install, bun, CLI) green on warp, then cancel before the paid eval body

## ⚠️ Org unblock required before merge
Warp jobs for this **public** repo currently sit queued forever: WarpBuild registers org-level runners, and the org runner group needs **"Allow public repositories"** enabled (https://github.com/organizations/browseros-ai/settings/actions/runner-groups). The dispatched nightly run (27367077749) and this PR's checks all wait on that. Recommended at the same time: set the fork-PR approval policy to *all outside collaborators* (currently `first_time_contributors`) and configure WarpBuild spend limits — this PR attaches paid compute to `pull_request` events.

Follow-up (optional): wire actionlint into CI so a typo'd runner label fails fast instead of queueing 24h.