### PR TITLE
feat(patches): WinSparkle Windows updater chromium patches

### DIFF
--- a/packages/browseros/build/features.yaml
+++ b/packages/browseros/build/features.yaml
@@ -112,6 +112,28 @@ features:
     files:
       - third_party/sparkle/
 
+  win-sparkle-updater:
+    description: "feat: win winsparkle updater"
+    files:
+      - chrome/browser/BUILD.gn
+      - chrome/browser/buildflags.gni
+      - chrome/browser/chrome_browser_main_win.cc
+      - chrome/browser/sparkle_buildflags.gni
+      - chrome/browser/ui/BUILD.gn
+      - chrome/browser/ui/webui/help/version_updater_basic.cc
+      - chrome/browser/ui/webui/help/winsparkle_version_updater_win.cc
+      - chrome/browser/ui/webui/help/winsparkle_version_updater_win.h
+      - chrome/browser/upgrade_detector/upgrade_detector_impl.cc
+      - chrome/browser/win/winsparkle_glue.cc
+      - chrome/browser/win/winsparkle_glue.h
+      - chrome/installer/mini_installer/BUILD.gn
+      - chrome/installer/mini_installer/chrome.release
+
+  winsparkle-third-party:
+    description: "feat: winsparkle third party library (downloaded on-the-fly)"
+    files:
+      - third_party/winsparkle/
+
   server:
     description: "feat: browseros server"
     files:

--- a/packages/browseros/chromium_patches/chrome/browser/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/BUILD.gn
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/BUILD.gn b/chrome/browser/BUILD.gn
-index 97b17f850c30d..df33111248beb 100644
+index 97b17f850c30d..3676d4608aca8 100644
 --- a/chrome/browser/BUILD.gn
 +++ b/chrome/browser/BUILD.gn
 @@ -12,6 +12,7 @@ import("//build/config/features.gni")
@@ -10,15 +10,16 @@ index 97b17f850c30d..df33111248beb 100644
  import("//chrome/browser/downgrade/buildflags.gni")
  import("//chrome/common/features.gni")
  import("//chrome/common/request_header_integrity/buildflags.gni")
-@@ -95,6 +96,7 @@ if (is_win) {
+@@ -95,6 +96,8 @@ if (is_win) {
  buildflag_header("buildflags") {
    header = "buildflags.h"
    flags = [
 +    "ENABLE_SPARKLE=$enable_sparkle",
++    "ENABLE_WINSPARKLE=$enable_winsparkle",
      "ENABLE_UPDATER=$enable_updater",
      "ENABLE_UPDATE_NOTIFICATIONS=$enable_update_notifications",
      "USE_MINIKIN_HYPHENATION=$use_minikin_hyphenation",
-@@ -1443,6 +1445,7 @@ static_library("browser") {
+@@ -1443,6 +1446,7 @@ static_library("browser") {
      "//chrome/browser/bookmarks",
      "//chrome/browser/bookmarks:impl",
      "//chrome/browser/breadcrumbs",
@@ -26,7 +27,7 @@ index 97b17f850c30d..df33111248beb 100644
      "//chrome/browser/browsing_data",
      "//chrome/browser/browsing_data:constants",
      "//chrome/browser/browsing_topics",
-@@ -6204,6 +6207,16 @@ static_library("browser") {
+@@ -6204,6 +6208,27 @@ static_library("browser") {
      ]
    }
  
@@ -38,6 +39,17 @@ index 97b17f850c30d..df33111248beb 100644
 +
 +    # Headers config for compilation (linking handled by chrome_framework)
 +    public_configs = [ "//third_party/sparkle:sparkle_link_framework" ]
++  }
++
++  if (is_win && enable_winsparkle) {
++    sources += [
++      "win/winsparkle_glue.cc",
++      "win/winsparkle_glue.h",
++    ]
++
++    # Link flags (import lib + /DELAYLOAD) propagate to every binary linking
++    # this target via all_dependent_configs on the group.
++    deps += [ "//third_party/winsparkle" ]
 +  }
 +
    if (is_android || is_mac || is_win || is_chromeos) {

--- a/packages/browseros/chromium_patches/chrome/browser/buildflags.gni
+++ b/packages/browseros/chromium_patches/chrome/browser/buildflags.gni
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/buildflags.gni b/chrome/browser/buildflags.gni
-index 095e232be0479..804f948c34bbb 100644
+index 095e232be0479..55b11261c28cf 100644
 --- a/chrome/browser/buildflags.gni
 +++ b/chrome/browser/buildflags.gni
 @@ -3,6 +3,7 @@
@@ -10,12 +10,14 @@ index 095e232be0479..804f948c34bbb 100644
  
  # IMPORTANT
  # We are not accepting any new build flags in //chrome. See
-@@ -16,6 +17,6 @@ declare_args() {
+@@ -16,6 +17,8 @@ declare_args() {
    enable_updater = is_chrome_branded && !is_fuchsia && target_os != "android"
  
    # Detect updates and notify the user for Google Chrome across all platforms.
 -  # Chromium does not use an auto-updater.
 -  enable_update_notifications = is_chrome_branded
-+  # Chromium does not use an auto-updater. Enable for Sparkle builds on macOS.
-+  enable_update_notifications = is_chrome_branded || enable_sparkle
++  # Chromium does not use an auto-updater. Enable for Sparkle builds on macOS
++  # and WinSparkle builds on Windows.
++  enable_update_notifications =
++      is_chrome_branded || enable_sparkle || enable_winsparkle
  }

--- a/packages/browseros/chromium_patches/chrome/browser/chrome_browser_main_win.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/chrome_browser_main_win.cc
@@ -1,0 +1,48 @@
+diff --git a/chrome/browser/chrome_browser_main_win.cc b/chrome/browser/chrome_browser_main_win.cc
+index 5baaa31780017..2e060b78b2a2a 100644
+--- a/chrome/browser/chrome_browser_main_win.cc
++++ b/chrome/browser/chrome_browser_main_win.cc
+@@ -57,6 +57,7 @@
+ #include "chrome/browser/active_use_util.h"
+ #include "chrome/browser/browser_features.h"
+ #include "chrome/browser/browser_process.h"
++#include "chrome/browser/buildflags.h"
+ #include "chrome/browser/first_run/first_run.h"
+ #include "chrome/browser/first_run/upgrade_util.h"
+ #include "chrome/browser/first_run/upgrade_util_win.h"
+@@ -135,6 +136,10 @@
+ #include "chrome/browser/platform_experience/installer/installer_win.h"
+ #endif  // BUILDFLAG(GOOGLE_CHROME_BRANDING)
+ 
++#if BUILDFLAG(ENABLE_WINSPARKLE)
++#include "chrome/browser/win/winsparkle_glue.h"
++#endif  // BUILDFLAG(ENABLE_WINSPARKLE)
++
+ namespace {
+ 
+ typedef HRESULT (STDAPICALLTYPE* RegisterApplicationRestartProc)(
+@@ -599,6 +604,11 @@ void ChromeBrowserMainPartsWin::PostCreateThreads() {
+ }
+ 
+ void ChromeBrowserMainPartsWin::PostMainMessageLoopRun() {
++#if BUILDFLAG(ENABLE_WINSPARKLE)
++  // Shut WinSparkle down while the task system is still alive.
++  winsparkle_glue::Cleanup();
++#endif
++
+   base::ImportantFileWriterCleaner::GetInstance().Stop();
+ 
+   ChromeBrowserMainParts::PostMainMessageLoopRun();
+@@ -660,6 +670,12 @@ void ChromeBrowserMainPartsWin::PostBrowserStart() {
+ 
+   InitializeChromeElf();
+ 
++#if BUILDFLAG(ENABLE_WINSPARKLE)
++  // Start the WinSparkle auto-updater. Must come after browser start so its
++  // first automatic check (and any update UI) runs behind a visible browser.
++  winsparkle_glue::Initialize();
++#endif
++
+ #if BUILDFLAG(USE_GOOGLE_UPDATE_INTEGRATION)
+   if constexpr (kShouldRecordActiveUse) {
+     did_run_updater_.emplace();

--- a/packages/browseros/chromium_patches/chrome/browser/sparkle_buildflags.gni
+++ b/packages/browseros/chromium_patches/chrome/browser/sparkle_buildflags.gni
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/sparkle_buildflags.gni b/chrome/browser/sparkle_buildflags.gni
 new file mode 100644
-index 0000000000000..984f9ab75b1fa
+index 0000000000000..000a98292437f
 --- /dev/null
 +++ b/chrome/browser/sparkle_buildflags.gni
-@@ -0,0 +1,21 @@
+@@ -0,0 +1,24 @@
 + # Copyright 2024 Nxtscape Browser Authors. All rights reserved.
 +# Use of this source code is governed by a BSD-style license that can be
 +# found in the LICENSE file.
@@ -18,6 +18,9 @@ index 0000000000000..984f9ab75b1fa
 +  # Enable Sparkle updater for macOS builds
 +  # enable_sparkle = is_mac && !is_component_build && is_official_build
 +  enable_sparkle = is_mac
++
++  # Enable WinSparkle updater (https://winsparkle.org) for Windows builds
++  enable_winsparkle = is_win
 +
 +  # Path to Sparkle framework
 +  sparkle_framework_path = "//third_party/sparkle/Sparkle.framework"

--- a/packages/browseros/chromium_patches/chrome/browser/ui/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/BUILD.gn
@@ -1,8 +1,16 @@
 diff --git a/chrome/browser/ui/BUILD.gn b/chrome/browser/ui/BUILD.gn
-index 5907498d01115..e4e49f3221f22 100644
+index 5907498d01115..a741ba1ff4ae6 100644
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
-@@ -1349,6 +1349,8 @@ static_library("ui") {
+@@ -8,6 +8,7 @@ import("//build/config/features.gni")
+ import("//build/config/ozone.gni")
+ import("//build/config/ui.gni")
+ import("//chrome/browser/buildflags.gni")
++import("//chrome/browser/sparkle_buildflags.gni")
+ import("//chrome/common/features.gni")
+ import("//components/captive_portal/core/features.gni")
+ import("//components/compose/features.gni")
+@@ -1349,6 +1350,8 @@ static_library("ui") {
        "webui/settings/search_engines_handler.h",
        "webui/settings/security_settings_provider.cc",
        "webui/settings/security_settings_provider.h",
@@ -11,7 +19,7 @@ index 5907498d01115..e4e49f3221f22 100644
        "webui/settings/settings_clear_browsing_data_handler.cc",
        "webui/settings/settings_clear_browsing_data_handler.h",
        "webui/settings/settings_localized_strings_privacy_sandbox_provider.cc",
-@@ -3356,6 +3358,8 @@ static_library("ui") {
+@@ -3356,6 +3359,8 @@ static_library("ui") {
        "views/frame/immersive_mode_overlay_views_mac.mm",
        "views/tab_contents/chrome_web_contents_view_delegate_views_mac.h",
        "views/tab_contents/chrome_web_contents_view_delegate_views_mac.mm",
@@ -20,3 +28,16 @@ index 5907498d01115..e4e49f3221f22 100644
        "webui/help/version_updater_mac.mm",
        "webui/settings/mac_system_settings_handler.cc",
        "webui/settings/mac_system_settings_handler.h",
+@@ -3497,6 +3502,12 @@ static_library("ui") {
+       ]
+     } else {
+       sources += [ "webui/help/version_updater_basic.cc" ]
++      if (enable_winsparkle) {
++        sources += [
++          "webui/help/winsparkle_version_updater_win.cc",
++          "webui/help/winsparkle_version_updater_win.h",
++        ]
++      }
+     }
+   }
+ 

--- a/packages/browseros/chromium_patches/chrome/browser/ui/webui/help/version_updater_basic.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/webui/help/version_updater_basic.cc
@@ -1,0 +1,36 @@
+diff --git a/chrome/browser/ui/webui/help/version_updater_basic.cc b/chrome/browser/ui/webui/help/version_updater_basic.cc
+index ebcef5637b150..27d1abebda5c7 100644
+--- a/chrome/browser/ui/webui/help/version_updater_basic.cc
++++ b/chrome/browser/ui/webui/help/version_updater_basic.cc
+@@ -5,9 +5,16 @@
+ #include <memory>
+ #include <string>
+ 
++#include "base/logging.h"
++#include "chrome/browser/buildflags.h"
+ #include "chrome/browser/ui/webui/help/version_updater.h"
+ #include "chrome/browser/upgrade_detector/upgrade_detector.h"
+ 
++#if BUILDFLAG(ENABLE_WINSPARKLE)
++#include "chrome/browser/ui/webui/help/winsparkle_version_updater_win.h"
++#include "chrome/browser/win/winsparkle_glue.h"
++#endif
++
+ namespace {
+ 
+ // Bare bones implementation just checks if a new version is ready.
+@@ -31,5 +38,14 @@ class VersionUpdaterBasic : public VersionUpdater {
+ 
+ std::unique_ptr<VersionUpdater> VersionUpdater::Create(
+     content::WebContents* web_contents) {
++#if BUILDFLAG(ENABLE_WINSPARKLE)
++  // Mirror the macOS Sparkle behavior: prefer WinSparkle when it came up,
++  // fall back to the basic updater otherwise.
++  if (winsparkle_glue::IsEnabled()) {
++    VLOG(1) << "VersionUpdater: Using WinSparkle updater";
++    return std::make_unique<WinSparkleVersionUpdater>();
++  }
++  VLOG(1) << "VersionUpdater: WinSparkle not available, using basic updater";
++#endif
+   return std::make_unique<VersionUpdaterBasic>();
+ }

--- a/packages/browseros/chromium_patches/chrome/browser/ui/webui/help/winsparkle_version_updater_win.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/webui/help/winsparkle_version_updater_win.cc
@@ -1,0 +1,79 @@
+diff --git a/chrome/browser/ui/webui/help/winsparkle_version_updater_win.cc b/chrome/browser/ui/webui/help/winsparkle_version_updater_win.cc
+new file mode 100644
+index 0000000000000..85d25fbec8532
+--- /dev/null
++++ b/chrome/browser/ui/webui/help/winsparkle_version_updater_win.cc
+@@ -0,0 +1,73 @@
++// Copyright 2024 BrowserOS Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "chrome/browser/ui/webui/help/winsparkle_version_updater_win.h"
++
++#include <string>
++
++#include "base/functional/bind.h"
++#include "base/task/task_traits.h"
++#include "base/task/thread_pool.h"
++#include "chrome/browser/first_run/upgrade_util.h"
++
++WinSparkleVersionUpdater::WinSparkleVersionUpdater() {
++  winsparkle_glue::AddObserver(this);
++}
++
++WinSparkleVersionUpdater::~WinSparkleVersionUpdater() {
++  winsparkle_glue::RemoveObserver(this);
++}
++
++void WinSparkleVersionUpdater::CheckForUpdate(StatusCallback status_callback,
++                                              PromoteCallback) {
++  status_callback_ = std::move(status_callback);
++  RunCallback(CHECKING);
++
++  // A background update may already be installed and only waiting for a
++  // relaunch — same short-circuit as the Google Update implementation.
++  base::ThreadPool::PostTaskAndReplyWithResult(
++      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
++      base::BindOnce(&upgrade_util::IsUpdatePendingRestart),
++      base::BindOnce(&WinSparkleVersionUpdater::OnPendingRestartCheck,
++                     weak_factory_.GetWeakPtr()));
++}
++
++void WinSparkleVersionUpdater::OnPendingRestartCheck(
++    bool is_update_pending_restart) {
++  if (is_update_pending_restart) {
++    RunCallback(NEARLY_UPDATED);
++    return;
++  }
++  winsparkle_glue::CheckForUpdatesWithUI();
++}
++
++void WinSparkleVersionUpdater::OnUpdateFound() {
++  // WinSparkle's dialog is downloading / awaiting user choice; the install
++  // completion arrives via OnUpdateInstalled.
++  RunCallback(UPDATING);
++}
++
++void WinSparkleVersionUpdater::OnNoUpdateFound() {
++  RunCallback(UPDATED);
++}
++
++void WinSparkleVersionUpdater::OnUpdateCancelled() {
++  RunCallback(UPDATED);
++}
++
++void WinSparkleVersionUpdater::OnUpdateInstalled() {
++  RunCallback(NEARLY_UPDATED);
++}
++
++void WinSparkleVersionUpdater::OnUpdateError() {
++  RunCallback(FAILED);
++}
++
++void WinSparkleVersionUpdater::RunCallback(Status status) {
++  if (status_callback_.is_null()) {
++    return;
++  }
++  status_callback_.Run(status, 0, false, false, std::string(), 0,
++                       std::u16string());
++}

--- a/packages/browseros/chromium_patches/chrome/browser/ui/webui/help/winsparkle_version_updater_win.h
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/webui/help/winsparkle_version_updater_win.h
@@ -1,0 +1,49 @@
+diff --git a/chrome/browser/ui/webui/help/winsparkle_version_updater_win.h b/chrome/browser/ui/webui/help/winsparkle_version_updater_win.h
+new file mode 100644
+index 0000000000000..66058657abe14
+--- /dev/null
++++ b/chrome/browser/ui/webui/help/winsparkle_version_updater_win.h
+@@ -0,0 +1,43 @@
++// Copyright 2024 BrowserOS Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_UI_WEBUI_HELP_WINSPARKLE_VERSION_UPDATER_WIN_H_
++#define CHROME_BROWSER_UI_WEBUI_HELP_WINSPARKLE_VERSION_UPDATER_WIN_H_
++
++#include "base/memory/weak_ptr.h"
++#include "chrome/browser/ui/webui/help/version_updater.h"
++#include "chrome/browser/win/winsparkle_glue.h"
++
++// VersionUpdater for Windows backed by WinSparkle instead of Google Update;
++// drives the chrome://settings/help status while WinSparkle's own dialogs
++// handle consent and download.
++class WinSparkleVersionUpdater : public VersionUpdater,
++                                 public winsparkle_glue::WinSparkleObserver {
++ public:
++  WinSparkleVersionUpdater();
++  WinSparkleVersionUpdater(const WinSparkleVersionUpdater&) = delete;
++  WinSparkleVersionUpdater& operator=(const WinSparkleVersionUpdater&) =
++      delete;
++  ~WinSparkleVersionUpdater() override;
++
++  // VersionUpdater:
++  void CheckForUpdate(StatusCallback status_callback,
++                      PromoteCallback promote_callback) override;
++
++  // winsparkle_glue::WinSparkleObserver:
++  void OnUpdateFound() override;
++  void OnNoUpdateFound() override;
++  void OnUpdateCancelled() override;
++  void OnUpdateInstalled() override;
++  void OnUpdateError() override;
++
++ private:
++  void OnPendingRestartCheck(bool is_update_pending_restart);
++  void RunCallback(Status status);
++
++  StatusCallback status_callback_;
++  base::WeakPtrFactory<WinSparkleVersionUpdater> weak_factory_{this};
++};
++
++#endif  // CHROME_BROWSER_UI_WEBUI_HELP_WINSPARKLE_VERSION_UPDATER_WIN_H_

--- a/packages/browseros/chromium_patches/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/upgrade_detector/upgrade_detector_impl.cc b/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
-index 07b7e0fcf5119..68c429d702873 100644
+index 07b7e0fcf5119..f966d9e8d562b 100644
 --- a/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
 +++ b/chrome/browser/upgrade_detector/upgrade_detector_impl.cc
 @@ -49,11 +49,13 @@
@@ -21,44 +21,46 @@ index 07b7e0fcf5119..68c429d702873 100644
  
  // How long to wait (each cycle) before checking which severity level we should
  // be at. Once we reach the highest severity, the timer will stop.
-@@ -69,7 +71,10 @@ constexpr auto kOutdatedBuildDetectorPeriod = base::Days(1);
+@@ -69,7 +71,11 @@ constexpr auto kOutdatedBuildDetectorPeriod = base::Days(1);
  constexpr auto kOutdatedBuildAge = base::Days(7) * 8;
  
  bool ShouldDetectOutdatedBuilds() {
 -#if BUILDFLAG(ENABLE_UPDATE_NOTIFICATIONS) && !BUILDFLAG(IS_CHROMEOS)
-+#if BUILDFLAG(ENABLE_SPARKLE)
-+  // Sparkle handles its own updates, no need for outdated build detection.
++#if BUILDFLAG(ENABLE_SPARKLE) || BUILDFLAG(ENABLE_WINSPARKLE)
++  // Sparkle/WinSparkle handle their own updates, no need for outdated build
++  // detection.
 +  return false;
 +#elif BUILDFLAG(ENABLE_UPDATE_NOTIFICATIONS) && !BUILDFLAG(IS_CHROMEOS)
    // Don't show the bubble if we have a brand code that is NOT organic
    std::string brand;
    if (google_brand::GetBrand(&brand) && !google_brand::IsOrganic(brand)) {
-@@ -163,6 +168,16 @@ void UpgradeDetectorImpl::CalculateThresholds() {
+@@ -163,6 +169,17 @@ void UpgradeDetectorImpl::CalculateThresholds() {
  void UpgradeDetectorImpl::DoCalculateThresholds() {
    DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
  
-+#if BUILDFLAG(ENABLE_SPARKLE)
-+  // Sparkle notifies us when updates are ready to install.
-+  // Zero thresholds so the badge appears immediately on the same call stack
-+  // as NotifyUpgradeReady() — no timer delay needed.
++#if BUILDFLAG(ENABLE_SPARKLE) || BUILDFLAG(ENABLE_WINSPARKLE)
++  // Sparkle notifies us when updates are ready to install, and on Windows the
++  // installed-version poller reports only after the background install
++  // finished. Zero thresholds so the badge appears immediately on the same
++  // call stack as NotifyUpgradeReady() — no timer delay needed.
 +  stages_[kStagesIndexVeryLow] = base::TimeDelta();
 +  stages_[kStagesIndexLow] = base::TimeDelta();
 +  stages_[kStagesIndexElevated] = base::TimeDelta();
 +  stages_[kStagesIndexGrace] = base::TimeDelta();
 +  stages_[kStagesIndexHigh] = base::TimeDelta();
-+#else   // !BUILDFLAG(ENABLE_SPARKLE)
++#else   // !BUILDFLAG(ENABLE_SPARKLE) && !BUILDFLAG(ENABLE_WINSPARKLE)
    base::TimeDelta notification_period = GetRelaunchNotificationPeriod();
    const std::optional<RelaunchWindow> relaunch_window =
        GetRelaunchWindowPolicyValue();
-@@ -216,6 +231,7 @@ void UpgradeDetectorImpl::DoCalculateThresholds() {
+@@ -216,6 +233,7 @@ void UpgradeDetectorImpl::DoCalculateThresholds() {
      for (auto& stage : stages_)
        stage /= scale_factor;
    }
-+#endif  // BUILDFLAG(ENABLE_SPARKLE)
++#endif  // BUILDFLAG(ENABLE_SPARKLE) || BUILDFLAG(ENABLE_WINSPARKLE)
  }
  
  void UpgradeDetectorImpl::StartOutdatedBuildDetector() {
-@@ -281,6 +297,8 @@ void UpgradeDetectorImpl::DetectOutdatedInstall() {
+@@ -281,6 +299,8 @@ void UpgradeDetectorImpl::DetectOutdatedInstall() {
  void UpgradeDetectorImpl::UpgradeDetected(UpgradeAvailable upgrade_available) {
    DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
  
@@ -67,7 +69,7 @@ index 07b7e0fcf5119..68c429d702873 100644
    set_upgrade_available(upgrade_available);
    set_critical_update_acknowledged(false);
  
-@@ -333,6 +351,10 @@ void UpgradeDetectorImpl::NotifyOnUpgradeWithTimePassed(
+@@ -333,6 +353,10 @@ void UpgradeDetectorImpl::NotifyOnUpgradeWithTimePassed(
        next_delay = *(it - 1) - time_passed;
    }
  
@@ -78,7 +80,7 @@ index 07b7e0fcf5119..68c429d702873 100644
    set_upgrade_notification_stage(new_stage);
    if (!next_delay.is_zero()) {
      // Schedule the next wakeup in 20 minutes or when the next change to the
-@@ -360,7 +382,6 @@ void UpgradeDetectorImpl::NotifyOnUpgradeWithTimePassed(
+@@ -360,7 +384,6 @@ void UpgradeDetectorImpl::NotifyOnUpgradeWithTimePassed(
  base::TimeDelta UpgradeDetectorImpl::GetThresholdForLevel(
      UpgradeNotificationAnnoyanceLevel level) {
    DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
@@ -86,7 +88,7 @@ index 07b7e0fcf5119..68c429d702873 100644
    return stages_[AnnoyanceLevelToStagesIndex(level)];
  }
  
-@@ -491,7 +512,10 @@ void UpgradeDetectorImpl::Init() {
+@@ -491,7 +514,10 @@ void UpgradeDetectorImpl::Init() {
  
    auto* const build_state = g_browser_process->GetBuildState();
    build_state->AddObserver(this);
@@ -97,7 +99,7 @@ index 07b7e0fcf5119..68c429d702873 100644
  #endif  // BUILDFLAG(ENABLE_UPDATE_NOTIFICATIONS)
  }
  
-@@ -535,6 +559,9 @@ base::Time UpgradeDetectorImpl::GetAnnoyanceLevelDeadline(
+@@ -535,6 +561,9 @@ base::Time UpgradeDetectorImpl::GetAnnoyanceLevelDeadline(
  void UpgradeDetectorImpl::OnUpdate(const BuildState* build_state) {
    DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
  

--- a/packages/browseros/chromium_patches/chrome/browser/win/winsparkle_glue.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/win/winsparkle_glue.cc
@@ -1,0 +1,357 @@
+diff --git a/chrome/browser/win/winsparkle_glue.cc b/chrome/browser/win/winsparkle_glue.cc
+new file mode 100644
+index 0000000000000..869ed71be8869
+--- /dev/null
++++ b/chrome/browser/win/winsparkle_glue.cc
+@@ -0,0 +1,351 @@
++// Copyright 2024 BrowserOS Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "chrome/browser/win/winsparkle_glue.h"
++
++#include <windows.h>
++
++#include <stdint.h>
++
++#include <string>
++#include <vector>
++
++#include "base/command_line.h"
++#include "base/files/file_path.h"
++#include "base/functional/bind.h"
++#include "base/logging.h"
++#include "base/no_destructor.h"
++#include "base/observer_list.h"
++#include "base/path_service.h"
++#include "base/process/launch.h"
++#include "base/process/process.h"
++#include "base/strings/string_number_conversions.h"
++#include "base/strings/utf_string_conversions.h"
++#include "base/task/single_thread_task_runner.h"
++#include "base/task/thread_pool.h"
++#include "base/time/time.h"
++#include "base/version.h"
++#include "base/version_info/version_info.h"
++#include "build/build_config.h"
++#include "content/public/browser/browser_thread.h"
++#include "third_party/winsparkle/include/winsparkle.h"
++
++namespace winsparkle_glue {
++
++namespace {
++
++// Same Ed25519 public key as the macOS Sparkle build (SUPublicEDKey in
++// chrome/app/app-Info.plist); the BrowserOS release pipeline signs all
++// platforms' artifacts with the one key.
++constexpr char kEdDSAPublicKey[] =
++    "LzQmcNuTsdB3/dsivo0eeN+jPfDoriRHAkkEJcfFs2A=";
++
++// Windows builds are single-arch, so the feed is chosen at compile time
++// (macOS picks at runtime because of universal binaries).
++#if defined(ARCH_CPU_ARM64)
++constexpr char kAppcastURL[] =
++    "https://cdn.browseros.com/appcast-win-arm64.xml";
++#else
++constexpr char kAppcastURL[] = "https://cdn.browseros.com/appcast-win.xml";
++#endif
++
++// Matches SUScheduledCheckInterval on macOS; also WinSparkle's minimum.
++constexpr int kUpdateCheckIntervalSeconds = 3600;
++
++constexpr char kRegistryPath[] = "Software\\BrowserOS\\WinSparkle";
++
++// Owns WinSparkle state for the browser process. All public methods are UI
++// thread only; Notify* run on the UI thread via PostToUI from WinSparkle's
++// worker threads.
++class WinSparkleGlue {
++ public:
++  static WinSparkleGlue* GetInstance() {
++    static base::NoDestructor<WinSparkleGlue> instance;
++    return instance.get();
++  }
++
++  bool Initialize();
++  bool enabled() const { return enabled_; }
++  void Cleanup();
++
++  void AddObserver(WinSparkleObserver* observer) {
++    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++    observers_.AddObserver(observer);
++  }
++
++  void RemoveObserver(WinSparkleObserver* observer) {
++    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++    observers_.RemoveObserver(observer);
++  }
++
++  // Thread-safe; tasks posted after shutdown are dropped by the task runner.
++  void PostToUI(base::OnceClosure task) {
++    if (ui_task_runner_) {
++      ui_task_runner_->PostTask(FROM_HERE, std::move(task));
++    }
++  }
++
++  // Launches the downloaded installer. Called on WinSparkle's thread; the
++  // launch happens synchronously there so a browser shutdown racing this
++  // callback cannot drop a user-confirmed install — only the wait for the
++  // installer to finish moves to the thread pool. mini_installer supports
++  // in-use updates (it stages the new version next to the running one), so
++  // the browser keeps running and the standard relaunch-to-update flow
++  // finishes the job.
++  bool LaunchInstaller(const base::FilePath& installer_path) {
++    base::LaunchOptions options;
++    options.start_hidden = true;
++    base::Process process =
++        base::LaunchProcess(base::CommandLine(installer_path), options);
++    if (!process.IsValid()) {
++      LOG(ERROR) << "WinSparkle: failed to launch installer "
++                 << installer_path.value();
++      PostToUI(base::BindOnce(&WinSparkleGlue::NotifyUpdateError,
++                              base::Unretained(this)));
++      return false;
++    }
++    base::ThreadPool::PostTask(
++        FROM_HERE,
++        {base::MayBlock(), base::TaskPriority::BEST_EFFORT,
++         base::TaskShutdownBehavior::CONTINUE_ON_SHUTDOWN},
++        base::BindOnce(&WinSparkleGlue::WaitForInstaller, std::move(process)));
++    return true;
++  }
++
++  void NotifyUpdateFound() {
++    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++    for (WinSparkleObserver& observer : observers_) {
++      observer.OnUpdateFound();
++    }
++  }
++
++  void NotifyNoUpdateFound() {
++    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++    for (WinSparkleObserver& observer : observers_) {
++      observer.OnNoUpdateFound();
++    }
++  }
++
++  void NotifyUpdateCancelled() {
++    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++    for (WinSparkleObserver& observer : observers_) {
++      observer.OnUpdateCancelled();
++    }
++  }
++
++  void NotifyUpdateInstalled() {
++    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++    for (WinSparkleObserver& observer : observers_) {
++      observer.OnUpdateInstalled();
++    }
++  }
++
++  void NotifyUpdateError() {
++    DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++    for (WinSparkleObserver& observer : observers_) {
++      observer.OnUpdateError();
++    }
++  }
++
++ private:
++  friend class base::NoDestructor<WinSparkleGlue>;
++  WinSparkleGlue() = default;
++
++  static void WaitForInstaller(base::Process process);
++
++  bool initialized_ = false;
++  bool enabled_ = false;
++  scoped_refptr<base::SingleThreadTaskRunner> ui_task_runner_;
++  base::ObserverList<WinSparkleObserver> observers_;
++};
++
++// WinSparkle C callbacks. Invoked on WinSparkle's worker threads — never on
++// the browser UI thread — so everything is marshalled through PostToUI.
++
++void __cdecl OnErrorCallback() {
++  WinSparkleGlue* glue = WinSparkleGlue::GetInstance();
++  glue->PostToUI(base::BindOnce(&WinSparkleGlue::NotifyUpdateError,
++                                base::Unretained(glue)));
++}
++
++void __cdecl OnDidFindUpdateCallback() {
++  WinSparkleGlue* glue = WinSparkleGlue::GetInstance();
++  glue->PostToUI(base::BindOnce(&WinSparkleGlue::NotifyUpdateFound,
++                                base::Unretained(glue)));
++}
++
++void __cdecl OnDidNotFindUpdateCallback() {
++  WinSparkleGlue* glue = WinSparkleGlue::GetInstance();
++  glue->PostToUI(base::BindOnce(&WinSparkleGlue::NotifyNoUpdateFound,
++                                base::Unretained(glue)));
++}
++
++void __cdecl OnUpdateCancelledCallback() {
++  WinSparkleGlue* glue = WinSparkleGlue::GetInstance();
++  glue->PostToUI(base::BindOnce(&WinSparkleGlue::NotifyUpdateCancelled,
++                                base::Unretained(glue)));
++}
++
++int __cdecl OnUserRunInstallerCallback(const wchar_t* installer_path) {
++  if (!installer_path || !installer_path[0]) {
++    return WINSPARKLE_RETURN_ERROR;
++  }
++  // 1 = handled: WinSparkle must not run the installer itself. A failed
++  // launch returns an error so WinSparkle's dialog reports it instead of
++  // silently closing.
++  return WinSparkleGlue::GetInstance()->LaunchInstaller(
++             base::FilePath(installer_path))
++             ? 1
++             : WINSPARKLE_RETURN_ERROR;
++}
++
++// static
++void WinSparkleGlue::WaitForInstaller(base::Process process) {
++  WinSparkleGlue* glue = GetInstance();
++
++  int exit_code = 0;
++  if (!process.WaitForExitWithTimeout(base::Minutes(10), &exit_code)) {
++    LOG(ERROR) << "WinSparkle: timed out waiting for the installer";
++    glue->PostToUI(base::BindOnce(&WinSparkleGlue::NotifyUpdateError,
++                                  base::Unretained(glue)));
++    return;
++  }
++  if (exit_code != 0) {
++    LOG(ERROR) << "WinSparkle: installer exited with code " << exit_code;
++    glue->PostToUI(base::BindOnce(&WinSparkleGlue::NotifyUpdateError,
++                                  base::Unretained(glue)));
++    return;
++  }
++
++  VLOG(1) << "WinSparkle: installer completed; update pending relaunch";
++  glue->PostToUI(base::BindOnce(&WinSparkleGlue::NotifyUpdateInstalled,
++                                base::Unretained(glue)));
++}
++
++bool WinSparkleGlue::Initialize() {
++  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
++  if (initialized_) {
++    return enabled_;
++  }
++  initialized_ = true;
++
++  // Same kill switch as the macOS Sparkle glue; keeps dev runs and tests
++  // from hitting the production appcast.
++  auto* command_line = base::CommandLine::ForCurrentProcess();
++  if (command_line && command_line->HasSwitch("disable-updates")) {
++    VLOG(1) << "WinSparkle: updates disabled via command line";
++    return false;
++  }
++
++  base::FilePath module_dir;
++  if (!base::PathService::Get(base::DIR_MODULE, &module_dir)) {
++    return false;
++  }
++  base::FilePath dll_path =
++      module_dir.Append(FILE_PATH_LITERAL("WinSparkle.dll"));
++
++  // Explicit absolute-path load. chrome.dll only delay-loads the import, so
++  // resolving it here (a) keeps the standard DLL search path out of the
++  // picture and (b) turns a missing DLL into a disabled updater instead of a
++  // delay-load crash on first call. Dependencies may resolve only from the
++  // DLL's own directory and system32.
++  HMODULE module = ::LoadLibraryExW(
++      dll_path.value().c_str(), nullptr,
++      LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32);
++  if (!module) {
++    VLOG(1) << "WinSparkle: " << dll_path.value()
++            << " not found; updater disabled";
++    return false;
++  }
++
++  ui_task_runner_ = content::GetUIThreadTaskRunner({});
++
++  win_sparkle_set_appcast_url(kAppcastURL);
++  if (!win_sparkle_set_eddsa_public_key(kEdDSAPublicKey)) {
++    LOG(ERROR) << "WinSparkle: invalid EdDSA public key; updater disabled";
++    return false;
++  }
++
++  // Display version for WinSparkle UI / User-Agent; comparisons use the
++  // BUILD.PATCH build version below, which is what the appcast carries in
++  // sparkle:version (same scheme as CFBundleVersion on macOS).
++  const std::wstring display_version =
++      base::UTF8ToWide(version_info::GetVersionNumber());
++  win_sparkle_set_app_details(L"BrowserOS", L"BrowserOS",
++                              display_version.c_str());
++
++  const std::vector<uint32_t>& components =
++      version_info::GetVersion().components();
++  if (components.size() >= 4) {
++    const std::wstring build_version =
++        base::UTF8ToWide(base::NumberToString(components[2]) + "." +
++                         base::NumberToString(components[3]));
++    win_sparkle_set_app_build_version(build_version.c_str());
++  }
++
++  win_sparkle_set_registry_path(kRegistryPath);
++
++  // Pre-seeding the automatic-check setting keeps WinSparkle from showing
++  // its first-run permission prompt (macOS equivalent: SUEnableAutomaticChecks
++  // plus the auto-granting user driver).
++  win_sparkle_set_automatic_check_for_updates(1);
++  win_sparkle_set_update_check_interval(kUpdateCheckIntervalSeconds);
++
++  // can_shutdown / shutdown_request stay unregistered on purpose: WinSparkle
++  // 0.9.3 calls the shutdown request unconditionally after the run-installer
++  // callback reports "handled" (ui.cpp OnRunInstaller), and the unregistered
++  // default is a no-op — exactly right for the background-install flow where
++  // the browser must keep running.
++  win_sparkle_set_error_callback(&OnErrorCallback);
++  win_sparkle_set_did_find_update_callback(&OnDidFindUpdateCallback);
++  win_sparkle_set_did_not_find_update_callback(&OnDidNotFindUpdateCallback);
++  win_sparkle_set_update_cancelled_callback(&OnUpdateCancelledCallback);
++  win_sparkle_set_update_skipped_callback(&OnUpdateCancelledCallback);
++  win_sparkle_set_update_postponed_callback(&OnUpdateCancelledCallback);
++  win_sparkle_set_update_dismissed_callback(&OnUpdateCancelledCallback);
++  win_sparkle_set_user_run_installer_callback(&OnUserRunInstallerCallback);
++
++  win_sparkle_init();
++  enabled_ = true;
++  VLOG(1) << "WinSparkle: initialized, feed " << kAppcastURL;
++  return true;
++}
++
++void WinSparkleGlue::Cleanup() {
++  if (enabled_) {
++    win_sparkle_cleanup();
++    enabled_ = false;
++  }
++}
++
++}  // namespace
++
++bool Initialize() {
++  return WinSparkleGlue::GetInstance()->Initialize();
++}
++
++bool IsEnabled() {
++  return WinSparkleGlue::GetInstance()->enabled();
++}
++
++void Cleanup() {
++  WinSparkleGlue::GetInstance()->Cleanup();
++}
++
++void CheckForUpdatesWithUI() {
++  if (!IsEnabled()) {
++    return;
++  }
++  win_sparkle_check_update_with_ui();
++}
++
++void AddObserver(WinSparkleObserver* observer) {
++  WinSparkleGlue::GetInstance()->AddObserver(observer);
++}
++
++void RemoveObserver(WinSparkleObserver* observer) {
++  WinSparkleGlue::GetInstance()->RemoveObserver(observer);
++}
++
++}  // namespace winsparkle_glue

--- a/packages/browseros/chromium_patches/chrome/browser/win/winsparkle_glue.h
+++ b/packages/browseros/chromium_patches/chrome/browser/win/winsparkle_glue.h
@@ -1,0 +1,59 @@
+diff --git a/chrome/browser/win/winsparkle_glue.h b/chrome/browser/win/winsparkle_glue.h
+new file mode 100644
+index 0000000000000..98cdca2137440
+--- /dev/null
++++ b/chrome/browser/win/winsparkle_glue.h
+@@ -0,0 +1,53 @@
++// Copyright 2024 BrowserOS Authors. All rights reserved.
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_WIN_WINSPARKLE_GLUE_H_
++#define CHROME_BROWSER_WIN_WINSPARKLE_GLUE_H_
++
++#include "base/observer_list_types.h"
++
++// C++ wrapper around the WinSparkle C API (//third_party/winsparkle), the
++// Windows counterpart of chrome/browser/mac/sparkle_glue.h. WinSparkle drives
++// update checks and its own consent/progress dialogs on a background thread;
++// this glue feeds the downloaded installer through a silent background
++// install so the browser never has to quit (see winsparkle_glue.cc).
++namespace winsparkle_glue {
++
++// Update events, dispatched on the UI thread.
++class WinSparkleObserver : public base::CheckedObserver {
++ public:
++  virtual void OnUpdateFound() {}
++  virtual void OnNoUpdateFound() {}
++  virtual void OnUpdateCancelled() {}
++  // The installer ran to completion in the background; the new version takes
++  // effect on relaunch (the upgrade detector badge appears independently via
++  // the installed-version poller).
++  virtual void OnUpdateInstalled() {}
++  virtual void OnUpdateError() {}
++};
++
++// Loads WinSparkle.dll from the version directory, configures it and starts
++// the update scheduler. Browser process UI thread only, call once after the
++// browser has started. Returns false and leaves the updater disabled if the
++// DLL or the signing key is unavailable.
++bool Initialize();
++
++// True if Initialize() succeeded.
++bool IsEnabled();
++
++// Shuts WinSparkle down (its UI thread; 0.9.3 leaves checker threads
++// running — upstream FIXME). Safe to call when disabled.
++void Cleanup();
++
++// Manual, user-initiated update check showing WinSparkle's progress UI.
++// Ignores a previously skipped version, per WinSparkle semantics.
++void CheckForUpdatesWithUI();
++
++// Observer registration. UI thread only.
++void AddObserver(WinSparkleObserver* observer);
++void RemoveObserver(WinSparkleObserver* observer);
++
++}  // namespace winsparkle_glue
++
++#endif  // CHROME_BROWSER_WIN_WINSPARKLE_GLUE_H_

--- a/packages/browseros/chromium_patches/chrome/installer/mini_installer/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/installer/mini_installer/BUILD.gn
@@ -1,0 +1,26 @@
+diff --git a/chrome/installer/mini_installer/BUILD.gn b/chrome/installer/mini_installer/BUILD.gn
+index 5f9acdb7f3550..1b8b27d5d763b 100644
+--- a/chrome/installer/mini_installer/BUILD.gn
++++ b/chrome/installer/mini_installer/BUILD.gn
+@@ -6,6 +6,7 @@ import("//build/config/compiler/compiler.gni")
+ import("//build/config/python.gni")
+ import("//build/config/ui.gni")
+ import("//build/timestamp.gni")
++import("//chrome/browser/sparkle_buildflags.gni")
+ import("//chrome/process_version_rc_template.gni")
+ import("//third_party/dawn/scripts/dawn_features.gni")
+ import("//third_party/ffmpeg/ffmpeg_options.gni")
+@@ -223,6 +224,13 @@ action("mini_installer_archive") {
+     inputs += [ "$root_out_dir/icudtl.dat" ]
+   }
+ 
++  if (enable_winsparkle) {
++    # chrome.release stages WinSparkle.dll into the version dir; depend on the
++    # copy so the archive step never races it.
++    inputs += [ "$root_out_dir/WinSparkle.dll" ]
++    deps += [ "//third_party/winsparkle:winsparkle_dll" ]
++  }
++
+   if (v8_use_external_startup_data) {
+     deps += [ "//v8" ]
+     if (use_v8_context_snapshot) {

--- a/packages/browseros/chromium_patches/chrome/installer/mini_installer/chrome.release
+++ b/packages/browseros/chromium_patches/chrome/installer/mini_installer/chrome.release
@@ -1,8 +1,16 @@
 diff --git a/chrome/installer/mini_installer/chrome.release b/chrome/installer/mini_installer/chrome.release
-index 0f331c3e0f2a3..e16dcd326b97f 100644
+index 0f331c3e0f2a3..051d499bcfa37 100644
 --- a/chrome/installer/mini_installer/chrome.release
 +++ b/chrome/installer/mini_installer/chrome.release
-@@ -63,6 +63,12 @@ PrivacySandboxAttestationsPreloaded\privacy-sandbox-attestations.dat: %(VersionD
+@@ -36,6 +36,7 @@ vk_swiftshader.dll: %(VersionDir)s\
+ vk_swiftshader_icd.json: %(VersionDir)s\
+ vulkan-1.dll: %(VersionDir)s\
+ v8_context_snapshot.bin: %(VersionDir)s\
++WinSparkle.dll: %(VersionDir)s\
+ #
+ # Sub directories living in the version dir
+ #
+@@ -63,6 +64,12 @@ PrivacySandboxAttestationsPreloaded\privacy-sandbox-attestations.dat: %(VersionD
  MEIPreload\manifest.json: %(VersionDir)s\MEIPreload\
  MEIPreload\preloaded_data.pb: %(VersionDir)s\MEIPreload\
  

--- a/packages/browseros/chromium_patches/third_party/winsparkle/BUILD.gn
+++ b/packages/browseros/chromium_patches/third_party/winsparkle/BUILD.gn
@@ -1,0 +1,49 @@
+diff --git a/third_party/winsparkle/BUILD.gn b/third_party/winsparkle/BUILD.gn
+new file mode 100644
+index 0000000000000..3aa632868b181
+--- /dev/null
++++ b/third_party/winsparkle/BUILD.gn
+@@ -0,0 +1,43 @@
++# Copyright 2024 BrowserOS Authors. All rights reserved.
++# Use of this source code is governed by a BSD-style license that can be
++# found in the LICENSE file.
++
++assert(is_win)
++
++# WinSparkle release zip layout: Release/ is x86, x64/Release/ is x64,
++# ARM64/Release/ is arm64.
++if (target_cpu == "x64") {
++  _winsparkle_bin_dir = "x64/Release"
++} else if (target_cpu == "arm64") {
++  _winsparkle_bin_dir = "ARM64/Release"
++} else {
++  _winsparkle_bin_dir = "Release"
++}
++
++# winsparkle.h injects /DEFAULTLIB:WinSparkle.lib via #pragma comment(lib)
++# into every object that includes it, so lib_dirs must reach every binary
++# that links such objects (tests included) — hence all_dependent_configs
++# on the group below.
++#
++# The DLL is delay-loaded on purpose: child processes never map it, and the
++# browser process loads it explicitly by absolute path from the version dir
++# (see chrome/browser/win/winsparkle_glue.cc). A missing DLL disables the
++# updater instead of failing process startup.
++config("winsparkle_link") {
++  lib_dirs = [ _winsparkle_bin_dir ]
++  libs = [ "WinSparkle.lib" ]
++  ldflags = [ "/DELAYLOAD:WinSparkle.dll" ]
++}
++
++# Stage WinSparkle.dll next to the build outputs. The installer picks it up
++# from there into the version dir via chrome/installer/mini_installer/
++# chrome.release.
++copy("winsparkle_dll") {
++  sources = [ "$_winsparkle_bin_dir/WinSparkle.dll" ]
++  outputs = [ "$root_out_dir/WinSparkle.dll" ]
++}
++
++group("winsparkle") {
++  all_dependent_configs = [ ":winsparkle_link" ]
++  data_deps = [ ":winsparkle_dll" ]
++}

--- a/packages/browseros/chromium_patches/third_party/winsparkle/README.browseros
+++ b/packages/browseros/chromium_patches/third_party/winsparkle/README.browseros
@@ -1,0 +1,26 @@
+diff --git a/third_party/winsparkle/README.browseros b/third_party/winsparkle/README.browseros
+new file mode 100644
+index 0000000000000..eeacd5a4f89c1
+--- /dev/null
++++ b/third_party/winsparkle/README.browseros
+@@ -0,0 +1,20 @@
++Name: WinSparkle
++URL: https://winsparkle.org/
++Source: https://github.com/vslavik/winsparkle/releases/download/v0.9.3/WinSparkle-0.9.3.zip
++Version: 0.9.3
++License: MIT (COPYING), expat parser under COPYING.expat
++Security Critical: yes (verifies Ed25519-signed updates)
++
++App update framework for Windows, the Windows counterpart of the Sparkle
++framework used by the macOS build (//third_party/sparkle).
++
++This directory holds a subset of the official prebuilt release zip with the
++top-level WinSparkle-<version>/ folder stripped: include/, per-arch
++{Release,x64/Release,ARM64/Release}/WinSparkle.{dll,lib}, and license/docs.
++Omitted: *.pdb, bin/ (winsparkle-tool.exe — release signing is done by
++packages/browseros/build/common/sparkle.py in the BrowserOS repo).
++
++The BrowserOS release pipeline does not rely on these vendored binaries: the
++winsparkle_setup build module downloads and extracts the same zip on the fly
++(mirroring sparkle_setup on macOS). To bump the version, update
++WINSPARKLE_VERSION in the BrowserOS repo's build config and re-vendor here.


### PR DESCRIPTION
## Summary
- Extracts the WinSparkle chromium-side work into `chromium_patches/` via `browseros dev extract commit` (4 stack commits: third_party vendoring, glue, integration, review fixes) — 15 per-file patches against `BASE_COMMIT` (148.0.7778.97 tag).
- `third_party/winsparkle/` carries only `BUILD.gn` + `README.browseros` (mirrors mac sparkle): the DLLs/headers come from the `winsparkle_setup` on-the-fly download, so the zip-provided text files were pruned to avoid new-file patch collisions in the release build.
- Registers `win-sparkle-updater` and `winsparkle-third-party` features in `features.yaml` (mirrors `mac-sparkle-updater` / `sparkle-third-party`).

## Verification
- Every extracted patch byte-matches `git diff BASE_COMMIT..HEAD -- <file>` in the chromium checkout (15/15).
- Every patch passes `git apply --check` against the bare `BASE_COMMIT` tree via a temp index (15/15) — same as the release build's apply-all onto the clean tag.

## Test plan
- [ ] Windows build will be triggered to validate end to end (this completes the patch-sync prerequisite from #1171; remaining ops step: `appcast-win.xml` on the CDN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)