### PR TITLE
fix(build): pin enable_winsparkle in Windows GN flag configs

### DIFF
--- a/packages/browseros/build/config/gn/flags.windows.debug.gn
+++ b/packages/browseros/build/config/gn/flags.windows.debug.gn
@@ -36,8 +36,7 @@ proprietary_codecs = true
 enable_platform_hevc = true
 disable_fieldtrial_testing_config = true
 
-# Windows doesn't support Sparkle (macOS update framework)
-# enable_sparkle = false
+enable_winsparkle = true
 
 # Disable Windows-specific features that macOS doesn't use
 enable_nacl = false

--- a/packages/browseros/build/config/gn/flags.windows.release.gn
+++ b/packages/browseros/build/config/gn/flags.windows.release.gn
@@ -8,6 +8,7 @@ symbol_level = 0
 is_clang=true
 chrome_pgo_phase = 0
 dcheck_always_on=false
+enable_winsparkle=true
 enable_swiftshader=false
 proprietary_codecs=true
 


### PR DESCRIPTION
## Summary
- Set `enable_winsparkle = true` explicitly in `flags.windows.debug.gn` and `flags.windows.release.gn` — the WinSparkle updater patches (#1173) gate all Windows updater code behind this GN arg, and the release flags file is what CI nightly Windows builds consume.
- Remove the stale "Windows doesn't support Sparkle (macOS update framework)" comment from the debug flags file — #1173 made it false.

## Design
Mirrors the established macOS convention byte-for-byte: `enable_sparkle = is_mac` already defaults true on mac, yet both macOS flag files still pin `enable_sparkle=true`. Same here — `enable_winsparkle = is_win` defaults true on Windows, but pinning it makes the config deterministic and survives any future tightening of the declare_args default (the originally intended Sparkle default was official-build-only). Behavior-neutral today; placement in the release file matches `flags.macos.release.gn` (right after `dcheck_always_on`).

## Test plan
- [x] `grep enable_winsparkle packages/browseros/build/config/gn/flags.windows.*.gn` — both files pin it true
- [x] GN args syntax sanity (`key = value` lines) + `git diff --check` clean
- [x] Adversarial diff review: clean (arg declared in `sparkle_buildflags.gni` patch; `patches` runs before `configure`, so release's `gn gen --fail-on-unused-args` sees the declaration)
- [ ] Next nightly Windows build compiles WinSparkle glue + stages WinSparkle.dll

🤖 Generated with [Claude Code](https://claude.com/claude-code)