### PR TITLE
chore: switch Linux release config to x64

### DIFF
--- a/packages/browseros/build/config/release.linux.yaml
+++ b/packages/browseros/build/config/release.linux.yaml
@@ -1,8 +1,7 @@
 # BrowserOS Linux Release Build Configuration
 #
-# Pinned to arm64-only to validate the cross-compile sysroot bootstrap
-# end-to-end on a Linux x64 host. Flip back to `[x64, arm64]` once arm64
-# is green.
+# Pinned to x64 for the manual Linux release path. Add arm64 back as a
+# second architecture once the cross-compile path is ready for release.
 #
 # Run:
 #   browseros build --config build/config/release.linux.yaml
@@ -13,7 +12,7 @@
 
 build:
   type: release
-  architecture: arm64
+  architecture: x64
 
 gn_flags:
   file: build/config/gn/flags.linux.release.gn


### PR DESCRIPTION
## Summary
- Switch the manual Linux release build config from `arm64` to `x64`.
- Update the header comment so it no longer describes an arm64-only release path.

## Design
This keeps the Linux release config as a scalar single-architecture build and changes only the checked-in default. The existing resolver and packaging code already accept `x64`.

## Test plan
- [x] `python3 -c 'from pathlib import Path; p=Path("packages/browseros/build/config/release.linux.yaml"); text=p.read_text(); assert "  architecture: x64" in text; assert "architecture: arm64" not in text; assert "arm64-only" not in text'`
- [x] `git diff --check`
- [x] local context-free `sf-review` returned `VERDICT: clean`