### PR TITLE
fix(sign): per-slice signing for asymmetric fat Mach-O notarization

### DIFF
--- a/packages/browseros/build/modules/sign/macos.py
+++ b/packages/browseros/build/modules/sign/macos.py
@@ -448,7 +448,8 @@ def _run_probe(cmd: List[str]) -> subprocess.CompletedProcess:
     """Run a read-only Mach-O inspection quietly (no build-log streaming)."""
     try:
         return subprocess.run(cmd, capture_output=True, text=True)
-    except OSError:
+    except OSError as e:
+        log_warning(f"Mach-O probe failed to run ({cmd[0]}): {e}")
         return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
 
 
@@ -463,7 +464,7 @@ def get_macho_archs(path: Path) -> List[str]:
 def slice_has_embedded_info_plist(path: Path, arch: str) -> bool:
     """True if the given slice carries a __TEXT,__info_plist section."""
     result = _run_probe(["otool", "-arch", arch, "-l", str(path)])
-    return result.returncode == 0 and "__info_plist" in result.stdout
+    return result.returncode == 0 and "sectname __info_plist" in result.stdout
 
 
 def find_asymmetric_info_plist_archs(path: Path) -> List[str]:
@@ -800,7 +801,9 @@ def verify_signature(app_path: Path, ctx: Optional[Context] = None) -> bool:
     # --deep seals plain executables under Resources/ as files without
     # validating their own signatures (Apple's notary does, per slice) —
     # verify each file-type component directly so a bad slice fails here
-    # instead of after a multi-minute notarization round-trip.
+    # instead of after a multi-minute notarization round-trip. Helpers,
+    # frameworks, and XPC services are proper sub-bundles --deep already
+    # recurses into.
     components = find_components_to_sign(app_path, ctx)
     for component in components["executables"] + components["dylibs"]:
         result = run_command(

--- a/packages/browseros/build/modules/sign/macos.py
+++ b/packages/browseros/build/modules/sign/macos.py
@@ -474,7 +474,9 @@ def find_asymmetric_info_plist_archs(path: Path) -> List[str]:
     and Apple's notary service rejects it (the upstream claude binary ships
     the section on arm64 only). Empty result = thin, symmetric, or not Mach-O.
     """
-    if not path.is_file():
+    # Symlinks excluded (matches the Go port's Lstat): os.replace would
+    # silently turn a bundle symlink into a regular file.
+    if path.is_symlink() or not path.is_file():
         return []
     archs = get_macho_archs(path)
     if len(archs) < 2:

--- a/packages/browseros/build/modules/sign/macos.py
+++ b/packages/browseros/build/modules/sign/macos.py
@@ -5,6 +5,7 @@ import os
 import sys
 import subprocess
 import shutil
+import tempfile
 from pathlib import Path
 from typing import Optional, List, Dict, Tuple
 from ...common.module import CommandModule, ValidationError
@@ -166,7 +167,7 @@ class MacOSSignModule(CommandModule):
         self._verify_server_resources(app_path, ctx)
         self._clear_extended_attributes(app_path)
         self._sign_all_components(app_path, env_vars["certificate_name"], ctx)
-        self._verify_signature(app_path)
+        self._verify_signature(app_path, ctx)
         self._notarize(app_path, env_vars, ctx)
 
         ctx.artifact_registry.add("signed_app", app_path)
@@ -188,8 +189,8 @@ class MacOSSignModule(CommandModule):
         if not sign_all_components(app_path, certificate_name, ctx.root_dir, ctx):
             raise RuntimeError("Failed to sign all components")
 
-    def _verify_signature(self, app_path: Path) -> None:
-        if not verify_signature(app_path):
+    def _verify_signature(self, app_path: Path, ctx: Optional[Context] = None) -> None:
+        if not verify_signature(app_path, ctx):
             raise RuntimeError("Signature verification failed")
 
     def _notarize(self, app_path: Path, env_vars: Dict[str, str], ctx: Context) -> None:
@@ -443,14 +444,54 @@ def get_signing_options(component_path: Path) -> str:
     return "runtime"
 
 
-def sign_component(
+def _run_probe(cmd: List[str]) -> subprocess.CompletedProcess:
+    """Run a read-only Mach-O inspection quietly (no build-log streaming)."""
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True)
+    except OSError:
+        return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+
+
+def get_macho_archs(path: Path) -> List[str]:
+    """Architectures lipo reports for a file; empty when it is not Mach-O."""
+    result = _run_probe(["lipo", "-archs", str(path)])
+    if result.returncode != 0:
+        return []
+    return result.stdout.split()
+
+
+def slice_has_embedded_info_plist(path: Path, arch: str) -> bool:
+    """True if the given slice carries a __TEXT,__info_plist section."""
+    result = _run_probe(["otool", "-arch", arch, "-l", str(path)])
+    return result.returncode == 0 and "__info_plist" in result.stdout
+
+
+def find_asymmetric_info_plist_archs(path: Path) -> List[str]:
+    """Archs of a fat file whose slices disagree on an embedded Info.plist.
+
+    codesign, signing a fat file, binds the file-level Info.plist into every
+    slice's CodeDirectory — a slice without the section then never validates
+    and Apple's notary service rejects it (the upstream claude binary ships
+    the section on arm64 only). Empty result = thin, symmetric, or not Mach-O.
+    """
+    if not path.is_file():
+        return []
+    archs = get_macho_archs(path)
+    if len(archs) < 2:
+        return []
+    with_plist = sum(1 for arch in archs if slice_has_embedded_info_plist(path, arch))
+    if with_plist in (0, len(archs)):
+        return []
+    return archs
+
+
+def _codesign_cmd(
     component_path: Path,
     certificate_name: str,
     identifier: Optional[str] = None,
     options: Optional[str] = None,
     entitlements: Optional[Path] = None,
-) -> bool:
-    """Sign a single component"""
+) -> List[str]:
     cmd = ["codesign", "--sign", certificate_name, "--force", "--timestamp"]
 
     if identifier:
@@ -463,9 +504,75 @@ def sign_component(
         cmd.extend(["--entitlements", str(entitlements)])
 
     cmd.append(str(component_path))
+    return cmd
+
+
+def sign_fat_component_per_slice(
+    component_path: Path,
+    certificate_name: str,
+    archs: List[str],
+    identifier: Optional[str] = None,
+    options: Optional[str] = None,
+    entitlements: Optional[Path] = None,
+) -> bool:
+    """Sign each slice as a thin file and lipo them back together."""
+    try:
+        with tempfile.TemporaryDirectory(dir=component_path.parent) as tmp:
+            tmp_dir = Path(tmp)
+            thin_paths = []
+            for arch in archs:
+                thin = tmp_dir / f"{component_path.name}.{arch}"
+                run_command(
+                    ["lipo", str(component_path), "-thin", arch, "-output", str(thin)]
+                )
+                run_command(
+                    _codesign_cmd(
+                        thin, certificate_name, identifier, options, entitlements
+                    )
+                )
+                thin_paths.append(thin)
+
+            fat = tmp_dir / f"{component_path.name}.fat"
+            run_command(
+                ["lipo", "-create", *[str(p) for p in thin_paths], "-output", str(fat)]
+            )
+            shutil.copymode(component_path, fat)
+            os.replace(fat, component_path)
+        return True
+    except Exception as e:
+        log_error(f"Failed to sign {component_path} per-slice: {e}")
+        return False
+
+
+def sign_component(
+    component_path: Path,
+    certificate_name: str,
+    identifier: Optional[str] = None,
+    options: Optional[str] = None,
+    entitlements: Optional[Path] = None,
+) -> bool:
+    """Sign a single component"""
+    asymmetric_archs = find_asymmetric_info_plist_archs(component_path)
+    if asymmetric_archs:
+        log_warning(
+            f"{component_path.name}: slices disagree on embedded Info.plist "
+            f"({', '.join(asymmetric_archs)}) — signing per-slice"
+        )
+        return sign_fat_component_per_slice(
+            component_path,
+            certificate_name,
+            asymmetric_archs,
+            identifier,
+            options,
+            entitlements,
+        )
 
     try:
-        run_command(cmd)
+        run_command(
+            _codesign_cmd(
+                component_path, certificate_name, identifier, options, entitlements
+            )
+        )
         return True
     except Exception as e:
         log_error(f"Failed to sign {component_path}: {e}")
@@ -675,7 +782,7 @@ def sign_all_components(
     return True
 
 
-def verify_signature(app_path: Path) -> bool:
+def verify_signature(app_path: Path, ctx: Optional[Context] = None) -> bool:
     """Verify application signature"""
     log_info("\n🔍 Verifying application signature integrity...")
 
@@ -687,6 +794,20 @@ def verify_signature(app_path: Path) -> bool:
     if result.returncode != 0:
         log_error("Signature verification failed!")
         return False
+
+    # --deep seals plain executables under Resources/ as files without
+    # validating their own signatures (Apple's notary does, per slice) —
+    # verify each file-type component directly so a bad slice fails here
+    # instead of after a multi-minute notarization round-trip.
+    components = find_components_to_sign(app_path, ctx)
+    for component in components["executables"] + components["dylibs"]:
+        result = run_command(
+            ["codesign", "--verify", "--verbose=2", str(component)],
+            check=False,
+        )
+        if result.returncode != 0:
+            log_error(f"Component signature verification failed: {component}")
+            return False
 
     log_success("Signature verification passed")
     return True
@@ -877,7 +998,7 @@ def sign_app(ctx: Context, create_dmg: bool = True) -> bool:
             return False
 
         # Verify signature
-        if not verify_signature(app_path):
+        if not verify_signature(app_path, ctx):
             return False
 
         # Notarize app

--- a/packages/browseros/build/modules/sign/macos_test.py
+++ b/packages/browseros/build/modules/sign/macos_test.py
@@ -1,18 +1,24 @@
 #!/usr/bin/env python3
 """Tests for macOS app signing discovery."""
 
+import os
+import subprocess
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 import yaml
 
 from ...common.context import Context
+from . import macos as macos_module
 from .macos import (
     SERVER_RESOURCES_SOURCE_REL,
     MacOSSignModule,
     find_components_to_sign,
+    sign_component,
     verify_server_resources_bundle,
+    verify_signature,
 )
 
 
@@ -205,6 +211,218 @@ class SignModuleGuardWiringTest(unittest.TestCase):
             )
 
             MacOSSignModule()._verify_server_resources(app_path, ctx)
+
+
+def _completed(cmd, returncode=0, stdout=""):
+    return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr="")
+
+
+def _fake_probe(archs, plist_archs, macho=True):
+    """Stub for macos._run_probe: lipo -archs and otool -l answers."""
+
+    def probe(cmd):
+        if cmd[:2] == ["lipo", "-archs"]:
+            if not macho:
+                return _completed(cmd, returncode=1)
+            return _completed(cmd, stdout=" ".join(archs) + "\n")
+        if cmd[0] == "otool":
+            arch = cmd[2]
+            section = "__info_plist" if arch in plist_archs else "__text"
+            return _completed(cmd, stdout=f"Section\n  sectname {section}\n")
+        raise AssertionError(f"unexpected probe command: {cmd}")
+
+    return probe
+
+
+def _fake_run_command(calls, fail_predicate=None):
+    """Stub for macos.run_command: records calls, materializes lipo outputs."""
+
+    def run(cmd, cwd=None, check=True):
+        calls.append(cmd)
+        if fail_predicate and fail_predicate(cmd):
+            raise subprocess.CalledProcessError(1, cmd)
+        if cmd[0] == "lipo" and "-output" in cmd:
+            payload = b"signed-fat" if "-create" in cmd else b"thin"
+            Path(cmd[cmd.index("-output") + 1]).write_bytes(payload)
+        return _completed(cmd)
+
+    return run
+
+
+class SignComponentPerSliceTest(unittest.TestCase):
+    """Fat binaries whose slices disagree on an embedded Info.plist must be
+    signed slice-by-slice: codesign on the fat file binds the file-level
+    Info.plist into every slice's CodeDirectory, which the plist-less slice
+    can never satisfy (Apple notarization rejects it)."""
+
+    def _make_component(self, tmp):
+        component = Path(tmp) / "claude"
+        component.write_bytes(b"original-fat")
+        component.chmod(0o755)
+        return component
+
+    def test_asymmetric_fat_signs_each_slice_and_reassembles(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            component = self._make_component(tmp)
+            calls = []
+            with (
+                mock.patch.object(
+                    macos_module,
+                    "_run_probe",
+                    _fake_probe(["x86_64", "arm64"], {"arm64"}),
+                ),
+                mock.patch.object(
+                    macos_module, "run_command", _fake_run_command(calls)
+                ),
+            ):
+                ok = sign_component(
+                    component, "Cert", "com.browseros.claude", "runtime"
+                )
+
+            self.assertTrue(ok)
+            codesign_calls = [c for c in calls if c[0] == "codesign"]
+            self.assertEqual(len(codesign_calls), 2)
+            for cmd in codesign_calls:
+                self.assertNotEqual(cmd[-1], str(component))
+                self.assertIn("--force", cmd)
+                self.assertIn("--timestamp", cmd)
+                self.assertIn("--identifier", cmd)
+                self.assertIn("com.browseros.claude", cmd)
+                self.assertIn("--options", cmd)
+                self.assertIn("runtime", cmd)
+            thin_calls = [c for c in calls if c[0] == "lipo" and "-thin" in c]
+            self.assertEqual(
+                {c[c.index("-thin") + 1] for c in thin_calls}, {"x86_64", "arm64"}
+            )
+            create_calls = [c for c in calls if c[0] == "lipo" and "-create" in c]
+            self.assertEqual(len(create_calls), 1)
+            self.assertEqual(component.read_bytes(), b"signed-fat")
+            self.assertTrue(os.access(component, os.X_OK))
+            self.assertEqual(
+                sorted(p.name for p in Path(tmp).iterdir()), ["claude"]
+            )
+
+    def test_symmetric_fat_uses_single_codesign(self):
+        for plist_archs in ({"x86_64", "arm64"}, set()):
+            with self.subTest(plist_archs=plist_archs):
+                with tempfile.TemporaryDirectory() as tmp:
+                    component = self._make_component(tmp)
+                    calls = []
+                    with (
+                        mock.patch.object(
+                            macos_module,
+                            "_run_probe",
+                            _fake_probe(["x86_64", "arm64"], plist_archs),
+                        ),
+                        mock.patch.object(
+                            macos_module, "run_command", _fake_run_command(calls)
+                        ),
+                    ):
+                        ok = sign_component(component, "Cert")
+
+                    self.assertTrue(ok)
+                    self.assertEqual(len(calls), 1)
+                    self.assertEqual(calls[0][0], "codesign")
+                    self.assertEqual(calls[0][-1], str(component))
+                    self.assertEqual(component.read_bytes(), b"original-fat")
+
+    def test_non_macho_executable_uses_single_codesign(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            component = self._make_component(tmp)
+            calls = []
+            with (
+                mock.patch.object(
+                    macos_module, "_run_probe", _fake_probe([], set(), macho=False)
+                ),
+                mock.patch.object(
+                    macos_module, "run_command", _fake_run_command(calls)
+                ),
+            ):
+                ok = sign_component(component, "Cert")
+
+            self.assertTrue(ok)
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(calls[0][0], "codesign")
+            self.assertEqual(calls[0][-1], str(component))
+
+    def test_failing_slice_codesign_keeps_original_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            component = self._make_component(tmp)
+            calls = []
+            with (
+                mock.patch.object(
+                    macos_module,
+                    "_run_probe",
+                    _fake_probe(["x86_64", "arm64"], {"arm64"}),
+                ),
+                mock.patch.object(
+                    macos_module,
+                    "run_command",
+                    _fake_run_command(
+                        calls, fail_predicate=lambda cmd: cmd[0] == "codesign"
+                    ),
+                ),
+            ):
+                ok = sign_component(component, "Cert")
+
+            self.assertFalse(ok)
+            self.assertEqual(component.read_bytes(), b"original-fat")
+            self.assertTrue(os.access(component, os.X_OK))
+            self.assertEqual(
+                sorted(p.name for p in Path(tmp).iterdir()), ["claude"]
+            )
+
+
+class VerifySignatureComponentTest(unittest.TestCase):
+    """The app-level --deep verify seals Resources executables as plain files
+    without validating their own signatures; verify_signature must check each
+    file-type component directly so a bad slice fails locally, not at Apple."""
+
+    def _build_app(self, tmp):
+        app_path = Path(tmp) / "BrowserOS.app"
+        claude = (
+            app_path
+            / "Contents"
+            / "Resources"
+            / "BrowserOSServer"
+            / "default"
+            / "resources"
+            / "bin"
+            / "third_party"
+            / "claude"
+        )
+        _write_exec(claude)
+        return app_path, claude
+
+    def test_fails_when_component_signature_invalid(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            app_path, claude = self._build_app(tmp)
+            calls = []
+
+            def run(cmd, cwd=None, check=True):
+                calls.append(cmd)
+                returncode = 1 if cmd[-1] == str(claude) else 0
+                return _completed(cmd, returncode=returncode)
+
+            with mock.patch.object(macos_module, "run_command", run):
+                self.assertFalse(verify_signature(app_path))
+
+    def test_passes_and_verifies_each_component(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            app_path, claude = self._build_app(tmp)
+            calls = []
+
+            with mock.patch.object(
+                macos_module, "run_command", _fake_run_command(calls)
+            ):
+                self.assertTrue(verify_signature(app_path))
+
+            self.assertTrue(
+                any(
+                    c[0] == "codesign" and "--verify" in c and c[-1] == str(claude)
+                    for c in calls
+                )
+            )
 
 
 if __name__ == "__main__":

--- a/packages/browseros/build/modules/sign/macos_test.py
+++ b/packages/browseros/build/modules/sign/macos_test.py
@@ -345,6 +345,25 @@ class SignComponentPerSliceTest(unittest.TestCase):
             self.assertEqual(calls[0][0], "codesign")
             self.assertEqual(calls[0][-1], str(component))
 
+    def test_thin_single_arch_uses_single_codesign(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            component = self._make_component(tmp)
+            calls = []
+            with (
+                mock.patch.object(
+                    macos_module, "_run_probe", _fake_probe(["arm64"], {"arm64"})
+                ),
+                mock.patch.object(
+                    macos_module, "run_command", _fake_run_command(calls)
+                ),
+            ):
+                ok = sign_component(component, "Cert")
+
+            self.assertTrue(ok)
+            self.assertEqual(len(calls), 1)
+            self.assertEqual(calls[0][0], "codesign")
+            self.assertEqual(calls[0][-1], str(component))
+
     def test_failing_slice_codesign_keeps_original_file(self):
         with tempfile.TemporaryDirectory() as tmp:
             component = self._make_component(tmp)
@@ -406,6 +425,10 @@ class VerifySignatureComponentTest(unittest.TestCase):
 
             with mock.patch.object(macos_module, "run_command", run):
                 self.assertFalse(verify_signature(app_path))
+
+            self.assertTrue(
+                any(c[0] == "codesign" and c[-1] == str(claude) for c in calls)
+            )
 
     def test_passes_and_verifies_each_component(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/packages/browseros/build_go/internal/modules/sign/macos.go
+++ b/packages/browseros/build_go/internal/modules/sign/macos.go
@@ -338,9 +338,14 @@ func SigningOptions(componentPath string) string {
 	return "runtime"
 }
 
-// runProbe runs a read-only Mach-O inspection quietly (no build-log stream).
+// runProbe runs a read-only Mach-O inspection quietly (no Stream → execx
+// captures without logging).
 func runProbe(ctx *buildctx.Context, args ...string) execx.Result {
-	res, _ := ctx.Runner.Run(execx.Cmd{Args: args, Dir: ctx.ChromiumSrc})
+	res, err := ctx.Runner.Run(execx.Cmd{Args: args, Dir: ctx.ChromiumSrc})
+	if err != nil {
+		logx.Warning(fmt.Sprintf("Mach-O probe failed to run (%s): %v", args[0], err))
+		return execx.Result{Code: 1}
+	}
 	return res
 }
 
@@ -358,7 +363,7 @@ func machoArchs(ctx *buildctx.Context, path string) []string {
 // __TEXT,__info_plist section.
 func sliceHasEmbeddedInfoPlist(ctx *buildctx.Context, path, arch string) bool {
 	res := runProbe(ctx, "otool", "-arch", arch, "-l", path)
-	return res.Code == 0 && strings.Contains(res.Stdout, "__info_plist")
+	return res.Code == 0 && strings.Contains(res.Stdout, "sectname __info_plist")
 }
 
 // asymmetricInfoPlistArchs returns the archs of a fat file whose slices
@@ -621,7 +626,9 @@ func VerifySignature(ctx *buildctx.Context, appPath string) error {
 	// --deep seals plain executables under Resources/ as files without
 	// validating their own signatures (Apple's notary does, per slice) —
 	// verify each file-type component directly so a bad slice fails here
-	// instead of after a multi-minute notarization round-trip.
+	// instead of after a multi-minute notarization round-trip. Helpers,
+	// frameworks, and XPC services are proper sub-bundles --deep already
+	// recurses into.
 	comps := FindComponentsToSign(ctx, appPath)
 	for _, comp := range append(append([]string{}, comps.Executables...), comps.Dylibs...) {
 		res := runUnchecked(ctx, "codesign", "--verify", "--verbose=2", comp)

--- a/packages/browseros/build_go/internal/modules/sign/macos.go
+++ b/packages/browseros/build_go/internal/modules/sign/macos.go
@@ -338,7 +338,58 @@ func SigningOptions(componentPath string) string {
 	return "runtime"
 }
 
-func signComponent(ctx *buildctx.Context, componentPath, certificate, identifier, options, entitlements string) error {
+// runProbe runs a read-only Mach-O inspection quietly (no build-log stream).
+func runProbe(ctx *buildctx.Context, args ...string) execx.Result {
+	res, _ := ctx.Runner.Run(execx.Cmd{Args: args, Dir: ctx.ChromiumSrc})
+	return res
+}
+
+// machoArchs returns the architectures lipo reports for a file; nil when it
+// is not Mach-O.
+func machoArchs(ctx *buildctx.Context, path string) []string {
+	res := runProbe(ctx, "lipo", "-archs", path)
+	if res.Code != 0 {
+		return nil
+	}
+	return strings.Fields(res.Stdout)
+}
+
+// sliceHasEmbeddedInfoPlist reports whether the given slice carries a
+// __TEXT,__info_plist section.
+func sliceHasEmbeddedInfoPlist(ctx *buildctx.Context, path, arch string) bool {
+	res := runProbe(ctx, "otool", "-arch", arch, "-l", path)
+	return res.Code == 0 && strings.Contains(res.Stdout, "__info_plist")
+}
+
+// asymmetricInfoPlistArchs returns the archs of a fat file whose slices
+// disagree on an embedded Info.plist (macos.py
+// find_asymmetric_info_plist_archs). codesign, signing a fat file, binds the
+// file-level Info.plist into every slice's CodeDirectory — a slice without
+// the section then never validates and Apple's notary rejects it (the
+// upstream claude binary ships the section on arm64 only). nil = thin,
+// symmetric, or not Mach-O.
+func asymmetricInfoPlistArchs(ctx *buildctx.Context, path string) []string {
+	st, err := os.Lstat(path)
+	if err != nil || !st.Mode().IsRegular() {
+		return nil
+	}
+	archs := machoArchs(ctx, path)
+	if len(archs) < 2 {
+		return nil
+	}
+	withPlist := 0
+	for _, arch := range archs {
+		if sliceHasEmbeddedInfoPlist(ctx, path, arch) {
+			withPlist++
+		}
+	}
+	if withPlist == 0 || withPlist == len(archs) {
+		return nil
+	}
+	return archs
+}
+
+func codesignCmd(componentPath, certificate, identifier, options, entitlements string) []string {
 	cmd := []string{"codesign", "--sign", certificate, "--force", "--timestamp"}
 	if identifier != "" {
 		cmd = append(cmd, "--identifier", identifier)
@@ -351,8 +402,55 @@ func signComponent(ctx *buildctx.Context, componentPath, certificate, identifier
 			cmd = append(cmd, "--entitlements", entitlements)
 		}
 	}
-	cmd = append(cmd, componentPath)
-	if _, err := run(ctx, cmd...); err != nil {
+	return append(cmd, componentPath)
+}
+
+// signFatComponentPerSlice signs each slice as a thin file and lipos them
+// back together (macos.py sign_fat_component_per_slice).
+func signFatComponentPerSlice(ctx *buildctx.Context, componentPath, certificate string, archs []string, identifier, options, entitlements string) error {
+	st, err := os.Stat(componentPath)
+	if err != nil {
+		return err
+	}
+	tmpDir, err := os.MkdirTemp(filepath.Dir(componentPath), ".sign-slices-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(tmpDir)
+
+	name := filepath.Base(componentPath)
+	thins := make([]string, 0, len(archs))
+	for _, arch := range archs {
+		thin := filepath.Join(tmpDir, name+"."+arch)
+		if _, err := run(ctx, "lipo", componentPath, "-thin", arch, "-output", thin); err != nil {
+			return fmt.Errorf("failed to extract %s slice of %s: %w", arch, componentPath, err)
+		}
+		if _, err := run(ctx, codesignCmd(thin, certificate, identifier, options, entitlements)...); err != nil {
+			return fmt.Errorf("failed to sign %s slice of %s: %w", arch, componentPath, err)
+		}
+		thins = append(thins, thin)
+	}
+
+	fat := filepath.Join(tmpDir, name+".fat")
+	args := append([]string{"lipo", "-create"}, thins...)
+	args = append(args, "-output", fat)
+	if _, err := run(ctx, args...); err != nil {
+		return fmt.Errorf("failed to reassemble %s: %w", componentPath, err)
+	}
+	if err := os.Chmod(fat, st.Mode().Perm()); err != nil {
+		return err
+	}
+	return os.Rename(fat, componentPath)
+}
+
+func signComponent(ctx *buildctx.Context, componentPath, certificate, identifier, options, entitlements string) error {
+	if archs := asymmetricInfoPlistArchs(ctx, componentPath); len(archs) > 0 {
+		logx.Warning(fmt.Sprintf(
+			"%s: slices disagree on embedded Info.plist (%s) — signing per-slice",
+			filepath.Base(componentPath), strings.Join(archs, ", ")))
+		return signFatComponentPerSlice(ctx, componentPath, certificate, archs, identifier, options, entitlements)
+	}
+	if _, err := run(ctx, codesignCmd(componentPath, certificate, identifier, options, entitlements)...); err != nil {
 		return fmt.Errorf("failed to sign %s: %w", componentPath, err)
 	}
 	return nil
@@ -519,6 +617,19 @@ func VerifySignature(ctx *buildctx.Context, appPath string) error {
 	if res.Code != 0 {
 		return fmt.Errorf("signature verification failed")
 	}
+
+	// --deep seals plain executables under Resources/ as files without
+	// validating their own signatures (Apple's notary does, per slice) —
+	// verify each file-type component directly so a bad slice fails here
+	// instead of after a multi-minute notarization round-trip.
+	comps := FindComponentsToSign(ctx, appPath)
+	for _, comp := range append(append([]string{}, comps.Executables...), comps.Dylibs...) {
+		res := runUnchecked(ctx, "codesign", "--verify", "--verbose=2", comp)
+		if res.Code != 0 {
+			return fmt.Errorf("component signature verification failed: %s", comp)
+		}
+	}
+
 	logx.Success("Signature verification passed")
 	return nil
 }

--- a/packages/browseros/build_go/internal/modules/sign/sign_test.go
+++ b/packages/browseros/build_go/internal/modules/sign/sign_test.go
@@ -153,7 +153,15 @@ func TestSignAllComponentsOrderAndArgs(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	argv := rec.Argv()
+	// Drop the read-only Mach-O probes signComponent uses for routing; only
+	// the mutating codesign sequence is under test here.
+	var argv []string
+	for _, cmd := range rec.Argv() {
+		if strings.HasPrefix(cmd, "lipo -archs ") || strings.HasPrefix(cmd, "otool ") {
+			continue
+		}
+		argv = append(argv, cmd)
+	}
 	for _, cmd := range argv {
 		if !strings.HasPrefix(cmd, "codesign --sign Developer ID Application: Test --force --timestamp") {
 			t.Errorf("unexpected command: %q", cmd)
@@ -379,5 +387,247 @@ func TestLinuxSignIsNoOp(t *testing.T) {
 	}
 	if len(rec.Cmds) != 0 {
 		t.Errorf("linux sign should run nothing: %v", rec.Argv())
+	}
+}
+
+// --- per-slice signing of asymmetric fat Mach-Os ---
+
+func hasArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+func argAfter(args []string, flag string) string {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+// sliceHandler fakes lipo/otool/codesign: two archs, an embedded Info.plist
+// only on the archs in plistArchs, and lipo -output materialized on disk.
+func sliceHandler(t *testing.T, plistArchs map[string]bool, codesignCode int, machO bool) func(execx.Cmd) (execx.Result, error) {
+	t.Helper()
+	return func(c execx.Cmd) (execx.Result, error) {
+		args := c.Args
+		switch {
+		case args[0] == "lipo" && args[1] == "-archs":
+			if !machO {
+				return execx.Result{Code: 1}, nil
+			}
+			return execx.Result{Stdout: "x86_64 arm64\n"}, nil
+		case args[0] == "otool":
+			if plistArchs[args[2]] {
+				return execx.Result{Stdout: "sectname __info_plist\n"}, nil
+			}
+			return execx.Result{Stdout: "sectname __text\n"}, nil
+		case args[0] == "lipo":
+			payload := "thin"
+			if args[1] == "-create" {
+				payload = "signed-fat"
+			}
+			if out := argAfter(args, "-output"); out != "" {
+				if err := os.WriteFile(out, []byte(payload), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			return execx.Result{}, nil
+		case args[0] == "codesign":
+			return execx.Result{Code: codesignCode}, nil
+		}
+		return execx.Result{}, nil
+	}
+}
+
+func TestSignComponentAsymmetricFatSignsPerSlice(t *testing.T) {
+	ctx, rec := fixtureCtx(t, macArm)
+	dir := t.TempDir()
+	component := filepath.Join(dir, "claude")
+	writeFile(t, component, "original-fat")
+	if err := os.Chmod(component, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	rec.Handler = sliceHandler(t, map[string]bool{"arm64": true}, 0, true)
+
+	if err := signComponent(ctx, component, "Cert", "com.browseros.claude", "runtime", ""); err != nil {
+		t.Fatal(err)
+	}
+
+	var codesigns, thins, creates [][]string
+	for _, c := range rec.Cmds {
+		switch {
+		case c.Args[0] == "codesign":
+			codesigns = append(codesigns, c.Args)
+		case c.Args[0] == "lipo" && hasArg(c.Args, "-thin"):
+			thins = append(thins, c.Args)
+		case c.Args[0] == "lipo" && c.Args[1] == "-create":
+			creates = append(creates, c.Args)
+		}
+	}
+	if len(codesigns) != 2 {
+		t.Fatalf("want 2 codesign calls (one per slice), got %d: %v", len(codesigns), rec.Argv())
+	}
+	for _, args := range codesigns {
+		if args[len(args)-1] == component {
+			t.Errorf("codesign ran on the fat file instead of a thin slice: %v", args)
+		}
+		for _, want := range []string{"--force", "--timestamp", "--identifier", "com.browseros.claude", "--options", "runtime"} {
+			if !hasArg(args, want) {
+				t.Errorf("codesign missing %q: %v", want, args)
+			}
+		}
+	}
+	thinArchs := map[string]bool{}
+	for _, args := range thins {
+		thinArchs[argAfter(args, "-thin")] = true
+	}
+	if !thinArchs["x86_64"] || !thinArchs["arm64"] {
+		t.Errorf("want thin extraction for both archs, got %v", thinArchs)
+	}
+	if len(creates) != 1 {
+		t.Fatalf("want 1 lipo -create, got %d", len(creates))
+	}
+	data, err := os.ReadFile(component)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "signed-fat" {
+		t.Errorf("component not replaced with reassembled fat: %q", data)
+	}
+	st, err := os.Stat(component)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if st.Mode().Perm() != 0o755 {
+		t.Errorf("mode not preserved: %v", st.Mode().Perm())
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("temp artifacts left behind: %v", entries)
+	}
+}
+
+func TestSignComponentSymmetricFatSingleCodesign(t *testing.T) {
+	for name, plistArchs := range map[string]map[string]bool{
+		"both_have_plist": {"x86_64": true, "arm64": true},
+		"neither_has":     {},
+	} {
+		t.Run(name, func(t *testing.T) {
+			ctx, rec := fixtureCtx(t, macArm)
+			dir := t.TempDir()
+			component := filepath.Join(dir, "claude")
+			writeFile(t, component, "original-fat")
+			rec.Handler = sliceHandler(t, plistArchs, 0, true)
+
+			if err := signComponent(ctx, component, "Cert", "", "", ""); err != nil {
+				t.Fatal(err)
+			}
+			var codesigns [][]string
+			for _, c := range rec.Cmds {
+				if c.Args[0] == "codesign" {
+					codesigns = append(codesigns, c.Args)
+				}
+				if c.Args[0] == "lipo" && (hasArg(c.Args, "-thin") || c.Args[1] == "-create") {
+					t.Errorf("symmetric fat must not be split: %v", c.Args)
+				}
+			}
+			if len(codesigns) != 1 || codesigns[0][len(codesigns[0])-1] != component {
+				t.Errorf("want a single codesign on the fat file, got %v", codesigns)
+			}
+			data, _ := os.ReadFile(component)
+			if string(data) != "original-fat" {
+				t.Errorf("file must not be rewritten: %q", data)
+			}
+		})
+	}
+}
+
+func TestSignComponentNonMachOSingleCodesign(t *testing.T) {
+	ctx, rec := fixtureCtx(t, macArm)
+	dir := t.TempDir()
+	component := filepath.Join(dir, "wrapper")
+	writeExec(t, component)
+	rec.Handler = sliceHandler(t, nil, 0, false)
+
+	if err := signComponent(ctx, component, "Cert", "", "", ""); err != nil {
+		t.Fatal(err)
+	}
+	var codesigns [][]string
+	for _, c := range rec.Cmds {
+		if c.Args[0] == "codesign" {
+			codesigns = append(codesigns, c.Args)
+		}
+	}
+	if len(codesigns) != 1 || codesigns[0][len(codesigns[0])-1] != component {
+		t.Errorf("want a single codesign on the file, got %v", codesigns)
+	}
+}
+
+func TestSignComponentPerSliceCodesignFailureKeepsOriginal(t *testing.T) {
+	ctx, rec := fixtureCtx(t, macArm)
+	dir := t.TempDir()
+	component := filepath.Join(dir, "claude")
+	writeFile(t, component, "original-fat")
+	rec.Handler = sliceHandler(t, map[string]bool{"arm64": true}, 1, true)
+
+	if err := signComponent(ctx, component, "Cert", "", "", ""); err == nil {
+		t.Fatal("want error when a slice fails to sign")
+	}
+	data, _ := os.ReadFile(component)
+	if string(data) != "original-fat" {
+		t.Errorf("original file must be left in place: %q", data)
+	}
+	entries, _ := os.ReadDir(dir)
+	if len(entries) != 1 {
+		t.Errorf("temp artifacts left behind: %v", entries)
+	}
+}
+
+func TestVerifySignatureFailsOnInvalidComponent(t *testing.T) {
+	ctx, rec := fixtureCtx(t, macArm)
+	appPath := filepath.Join(t.TempDir(), "BrowserOS.app")
+	claude := filepath.Join(appPath, "Contents", "Resources", "BrowserOSServer",
+		"default", "resources", "bin", "third_party", "claude")
+	writeExec(t, claude)
+
+	rec.Handler = func(c execx.Cmd) (execx.Result, error) {
+		if c.Args[0] == "codesign" && c.Args[len(c.Args)-1] == claude {
+			return execx.Result{Code: 1}, nil
+		}
+		return execx.Result{}, nil
+	}
+	err := VerifySignature(ctx, appPath)
+	if err == nil || !strings.Contains(err.Error(), "claude") {
+		t.Fatalf("want component verification failure naming claude, got %v", err)
+	}
+}
+
+func TestVerifySignaturePassesAndChecksEachComponent(t *testing.T) {
+	ctx, rec := fixtureCtx(t, macArm)
+	appPath := filepath.Join(t.TempDir(), "BrowserOS.app")
+	claude := filepath.Join(appPath, "Contents", "Resources", "BrowserOSServer",
+		"default", "resources", "bin", "third_party", "claude")
+	writeExec(t, claude)
+
+	if err := VerifySignature(ctx, appPath); err != nil {
+		t.Fatal(err)
+	}
+	found := false
+	for _, c := range rec.Cmds {
+		if c.Args[0] == "codesign" && hasArg(c.Args, "--verify") && c.Args[len(c.Args)-1] == claude {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("claude was not verified: %v", rec.Argv())
 	}
 }

--- a/packages/browseros/build_go/internal/modules/sign/sign_test.go
+++ b/packages/browseros/build_go/internal/modules/sign/sign_test.go
@@ -154,7 +154,9 @@ func TestSignAllComponentsOrderAndArgs(t *testing.T) {
 	}
 
 	// Drop the read-only Mach-O probes signComponent uses for routing; only
-	// the mutating codesign sequence is under test here.
+	// the mutating codesign sequence is under test here. (No Handler is set,
+	// so probes get zero-value results: machoArchs sees no archs and the
+	// per-slice path — lipo -thin/-create — never fires.)
 	var argv []string
 	for _, cmd := range rec.Argv() {
 		if strings.HasPrefix(cmd, "lipo -archs ") || strings.HasPrefix(cmd, "otool ") {

--- a/packages/browseros/build_go/internal/modules/sign/sign_test.go
+++ b/packages/browseros/build_go/internal/modules/sign/sign_test.go
@@ -551,6 +551,36 @@ func TestSignComponentSymmetricFatSingleCodesign(t *testing.T) {
 	}
 }
 
+func TestSignComponentThinSingleArchSingleCodesign(t *testing.T) {
+	ctx, rec := fixtureCtx(t, macArm)
+	dir := t.TempDir()
+	component := filepath.Join(dir, "claude")
+	writeFile(t, component, "thin-binary")
+	rec.Handler = func(c execx.Cmd) (execx.Result, error) {
+		if c.Args[0] == "lipo" && c.Args[1] == "-archs" {
+			return execx.Result{Stdout: "arm64\n"}, nil
+		}
+		return execx.Result{}, nil
+	}
+
+	if err := signComponent(ctx, component, "Cert", "", "", ""); err != nil {
+		t.Fatal(err)
+	}
+	var codesigns [][]string
+	for _, c := range rec.Cmds {
+		if c.Args[0] == "codesign" {
+			codesigns = append(codesigns, c.Args)
+		}
+	}
+	if len(codesigns) != 1 || codesigns[0][len(codesigns[0])-1] != component {
+		t.Errorf("want a single codesign on the thin file, got %v", codesigns)
+	}
+	data, _ := os.ReadFile(component)
+	if string(data) != "thin-binary" {
+		t.Errorf("file must not be rewritten: %q", data)
+	}
+}
+
 func TestSignComponentNonMachOSingleCodesign(t *testing.T) {
 	ctx, rec := fixtureCtx(t, macArm)
 	dir := t.TempDir()


### PR DESCRIPTION
## Summary
- Universal macOS builds failed notarization (`status: Invalid`): Apple's notary log names exactly one issue — `Contents/Resources/BrowserOSServer/default/resources/bin/third_party/claude`, "The signature of the binary is invalid", architecture **x86_64**.
- Root cause: the upstream `claude` binary ships an embedded `__TEXT,__info_plist` section on **arm64 only**. After the universalizer lipo-merges the per-arch binaries, `codesign` signing the fat file binds the file-level Info.plist hash into **both** slices' CodeDirectories (verified via `codesign -d --verbose=6`: x86_64 slot `-1=fb267ae7…` vs `0000…` when thin-signed) — the plist-less x86_64 slice can never validate.
- Fix: `sign_component` probes fat plain-file Mach-Os (`lipo -archs` + `otool -arch <a> -l`); when slices disagree on the embedded plist it signs each slice as a thin file and `lipo -create`s them back. Symmetric/thin/non-Mach-O inputs keep the exact existing path.
- Gap closed: `verify_signature` now codesign-verifies every file-type component — the app-level `--deep --strict` seals Resources executables as plain files without validating their own signatures, which is why this only surfaced at Apple after a ~3-minute round-trip.
- Go port (`build_go`) mirrors both changes to keep the pending Python↔Go side-by-side validation meaningful.

## Design
Detection is structural, not filename-based, so `codex`/`bun`/future binaries are covered if their upstreams regress the same way. Per-slice signing reuses the same codesign arg-builder as the fat path (identifier/options/entitlements/`--force --timestamp` cannot drift), preserves permission bits, and replaces the file atomically via a same-directory temp dir. Probes run quietly (no build-log streaming); mutating ops stay on the logged runner.

## Test plan
- [x] Python: 17 sign-module tests (asymmetric routing, both symmetric cases, thin single-arch, non-Mach-O, slice-failure recovery, component-verify pass/fail) — 261 build tests green, pyright clean
- [x] Go: mirrored tests via `RecordingRunner` — `go test ./internal/modules/sign/` green, `go vet`/`gofmt` clean
- [x] Real artifact: ran the new code against a copy of the actual rejected fat `claude` — pre-fix `invalid Info.plist (x86_64)`, post-fix `valid on disk` for the fat file and both `--architecture` slices; slot `-1` zeroed on x86_64, plist hash bound on arm64; mode preserved, no temp leftovers
- [ ] Next universal release build notarizes `Accepted` end-to-end

Note: `internal/resolver`'s `TestRealConfigsResolveLikePython` fails on `main` (expects 14 Windows pipeline steps; WinSparkle PRs made it 16) — pre-existing, untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)