### PR TITLE
chore(build): remove Claude binaries from server release

### DIFF
--- a/packages/browseros-agent/scripts/build/config/server-prod-resources.json
+++ b/packages/browseros-agent/scripts/build/config/server-prod-resources.json
@@ -67,34 +67,12 @@
       "executable": true
     },
     {
-      "name": "Claude Code - macOS ARM64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/claude-code/claude-darwin-arm64"
-      },
-      "destination": "resources/bin/third_party/claude",
-      "os": ["macos"],
-      "arch": ["arm64"],
-      "executable": true
-    },
-    {
       "name": "Codex - macOS x64",
       "source": {
         "type": "r2",
         "key": "third_party/codex/codex-darwin-x64"
       },
       "destination": "resources/bin/third_party/codex",
-      "os": ["macos"],
-      "arch": ["x64"],
-      "executable": true
-    },
-    {
-      "name": "Claude Code - macOS x64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/claude-code/claude-darwin-x64"
-      },
-      "destination": "resources/bin/third_party/claude",
       "os": ["macos"],
       "arch": ["x64"],
       "executable": true
@@ -111,17 +89,6 @@
       "executable": true
     },
     {
-      "name": "Claude Code - Linux ARM64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/claude-code/claude-linux-arm64"
-      },
-      "destination": "resources/bin/third_party/claude",
-      "os": ["linux"],
-      "arch": ["arm64"],
-      "executable": true
-    },
-    {
       "name": "Codex - Linux x64",
       "source": {
         "type": "r2",
@@ -133,34 +100,12 @@
       "executable": true
     },
     {
-      "name": "Claude Code - Linux x64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/claude-code/claude-linux-x64"
-      },
-      "destination": "resources/bin/third_party/claude",
-      "os": ["linux"],
-      "arch": ["x64"],
-      "executable": true
-    },
-    {
       "name": "Codex - Windows x64",
       "source": {
         "type": "r2",
         "key": "third_party/codex/codex-windows-x64.exe"
       },
       "destination": "resources/bin/third_party/codex.exe",
-      "os": ["windows"],
-      "arch": ["x64"],
-      "executable": true
-    },
-    {
-      "name": "Claude Code - Windows x64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/claude-code/claude-windows-x64.exe"
-      },
-      "destination": "resources/bin/third_party/claude.exe",
       "os": ["windows"],
       "arch": ["x64"],
       "executable": true

--- a/packages/browseros-agent/scripts/build/server/stage.test.ts
+++ b/packages/browseros-agent/scripts/build/server/stage.test.ts
@@ -202,7 +202,7 @@ describe('server artifact staging', () => {
     expect(destinations).toContain('resources/db/migrations')
   })
 
-  it('downloads bundled agent CLIs for Linux targets and marks them executable', async () => {
+  it('downloads bundled Codex CLI for Linux targets and marks it executable', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'browseros-stage-test-'))
     const sourceRoot = join(tempDir, 'source')
     const distRoot = join(tempDir, 'dist')
@@ -213,27 +213,22 @@ describe('server artifact staging', () => {
       distRoot,
       binaryPath,
       linuxArm64Target,
-      [codexLinuxArm64Rule, claudeLinuxArm64Rule],
+      [codexLinuxArm64Rule],
       sourceRoot,
       fakeObjectClient({
         'artifacts/vendor/third_party/codex/codex-linux-arm64':
           '#!/bin/sh\ncodex\n',
-        'artifacts/vendor/third_party/claude-code/claude-linux-arm64':
-          '#!/bin/sh\nclaude\n',
       }),
       fakeR2Config,
       '0.0.0-test',
     )
 
     const codexPath = join(artifact.resourcesDir, 'bin/third_party/codex')
-    const claudePath = join(artifact.resourcesDir, 'bin/third_party/claude')
     expect(await readFile(codexPath, 'utf8')).toBe('#!/bin/sh\ncodex\n')
-    expect(await readFile(claudePath, 'utf8')).toBe('#!/bin/sh\nclaude\n')
     expect((await stat(codexPath)).mode & 0o111).not.toBe(0)
-    expect((await stat(claudePath)).mode & 0o111).not.toBe(0)
   })
 
-  it('downloads bundled agent CLIs for Windows targets without chmod', async () => {
+  it('downloads bundled Codex CLI for Windows targets without chmod', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'browseros-stage-test-'))
     const sourceRoot = join(tempDir, 'source')
     const distRoot = join(tempDir, 'dist')
@@ -244,23 +239,18 @@ describe('server artifact staging', () => {
       distRoot,
       binaryPath,
       windowsX64Target,
-      [codexWindowsX64Rule, claudeWindowsX64Rule],
+      [codexWindowsX64Rule],
       sourceRoot,
       fakeObjectClient({
         'artifacts/vendor/third_party/codex/codex-windows-x64.exe': 'codex.exe',
-        'artifacts/vendor/third_party/claude-code/claude-windows-x64.exe':
-          'claude.exe',
       }),
       fakeR2Config,
       '0.0.0-test',
     )
 
     const codexPath = join(artifact.resourcesDir, 'bin/third_party/codex.exe')
-    const claudePath = join(artifact.resourcesDir, 'bin/third_party/claude.exe')
     expect(await readFile(codexPath, 'utf8')).toBe('codex.exe')
-    expect(await readFile(claudePath, 'utf8')).toBe('claude.exe')
     expect((await stat(codexPath)).mode & 0o111).toBe(0)
-    expect((await stat(claudePath)).mode & 0o111).toBe(0)
   })
 
   it('loads target-filtered bundled CLI rules from the production manifest', () => {
@@ -269,6 +259,12 @@ describe('server artifact staging', () => {
     )
     const linuxRules = getTargetRules(manifest, linuxArm64Target)
     const windowsRules = getTargetRules(manifest, windowsX64Target)
+    const claudeRules = manifest.resources.filter(
+      (rule) =>
+        rule.name.includes('Claude Code') ||
+        rule.destination.includes('third_party/claude') ||
+        (rule.source.type === 'r2' && rule.source.key.includes('claude-code')),
+    )
 
     expect(linuxRules).toEqual(
       expect.arrayContaining([
@@ -279,15 +275,6 @@ describe('server artifact staging', () => {
             key: 'third_party/codex/codex-linux-arm64',
           },
           destination: 'resources/bin/third_party/codex',
-          executable: true,
-        }),
-        expect.objectContaining({
-          name: 'Claude Code - Linux ARM64',
-          source: {
-            type: 'r2',
-            key: 'third_party/claude-code/claude-linux-arm64',
-          },
-          destination: 'resources/bin/third_party/claude',
           executable: true,
         }),
       ]),
@@ -303,17 +290,9 @@ describe('server artifact staging', () => {
           destination: 'resources/bin/third_party/codex.exe',
           executable: true,
         }),
-        expect.objectContaining({
-          name: 'Claude Code - Windows x64',
-          source: {
-            type: 'r2',
-            key: 'third_party/claude-code/claude-windows-x64.exe',
-          },
-          destination: 'resources/bin/third_party/claude.exe',
-          executable: true,
-        }),
       ]),
     )
+    expect(claudeRules).toEqual([])
     expect(linuxRules.find((rule) => rule.name === 'Codex - Windows x64')).toBe(
       undefined,
     )
@@ -401,18 +380,6 @@ const codexLinuxArm64Rule: ResourceRule = {
   executable: true,
 }
 
-const claudeLinuxArm64Rule: ResourceRule = {
-  name: 'Claude Code - Linux ARM64',
-  source: {
-    type: 'r2',
-    key: 'third_party/claude-code/claude-linux-arm64',
-  },
-  destination: 'resources/bin/third_party/claude',
-  os: ['linux'],
-  arch: ['arm64'],
-  executable: true,
-}
-
 const codexWindowsX64Rule: ResourceRule = {
   name: 'Codex - Windows x64',
   source: {
@@ -420,18 +387,6 @@ const codexWindowsX64Rule: ResourceRule = {
     key: 'third_party/codex/codex-windows-x64.exe',
   },
   destination: 'resources/bin/third_party/codex.exe',
-  os: ['windows'],
-  arch: ['x64'],
-  executable: true,
-}
-
-const claudeWindowsX64Rule: ResourceRule = {
-  name: 'Claude Code - Windows x64',
-  source: {
-    type: 'r2',
-    key: 'third_party/claude-code/claude-windows-x64.exe',
-  },
-  destination: 'resources/bin/third_party/claude.exe',
   os: ['windows'],
   arch: ['x64'],
   executable: true,


### PR DESCRIPTION
## Summary
- Remove all Claude Code binary resource rules from the production server release manifest.
- Keep Bun, Codex, and migration resources unchanged.
- Update server staging tests so production manifest expectations now assert Claude binary resources are absent.

## Design
Production server resources remain declarative in `server-prod-resources.json`; staging remains generic and target-filtered. This change only trims the production manifest and realigns tests around the reduced bundled CLI set.

## Test plan
- [x] bun test scripts/build/server/stage.test.ts
- [x] bun run lint
- [x] bun run typecheck
- [x] bun run test:main
- [x] bun run build:server:test