### PR TITLE
fix(ci): windows nightly died logging emoji to cp1252 stdout

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -152,6 +152,11 @@ jobs:
     defaults:
       run:
         shell: bash
+    env:
+      # Windows runners pipe stdout as cp1252, which crashes the emoji-heavy
+      # build CLI with UnicodeEncodeError; force UTF-8 for python and all
+      # its subprocesses (gclient, hooks). No-op on Linux/macOS.
+      PYTHONUTF8: "1"
     steps:
       - uses: actions/checkout@v6
 

--- a/packages/browseros/build/common/logger.py
+++ b/packages/browseros/build/common/logger.py
@@ -13,11 +13,12 @@ from datetime import datetime
 
 # Windows pipes default to the ANSI codepage (cp1252), which cannot encode
 # the emoji these helpers emit — the first log line killed the Windows CI
-# build with UnicodeEncodeError. Degrade to replacement characters instead.
+# build with UnicodeEncodeError. Degrade to escape sequences instead
+# (backslashreplace matches stderr's native fallback behavior).
 for _stream in (sys.stdout, sys.stderr):
     if isinstance(_stream, io.TextIOWrapper):
         with suppress(Exception):
-            _stream.reconfigure(errors="replace")
+            _stream.reconfigure(errors="backslashreplace")
 
 # Global log file handle
 _log_file = None

--- a/packages/browseros/build/common/logger.py
+++ b/packages/browseros/build/common/logger.py
@@ -4,9 +4,20 @@ Logging utilities for the build system
 Provides consistent logging with Typer output and file logging
 """
 
+import io
+import sys
+from contextlib import suppress
+
 import typer
-from pathlib import Path
 from datetime import datetime
+
+# Windows pipes default to the ANSI codepage (cp1252), which cannot encode
+# the emoji these helpers emit — the first log line killed the Windows CI
+# build with UnicodeEncodeError. Degrade to replacement characters instead.
+for _stream in (sys.stdout, sys.stderr):
+    if isinstance(_stream, io.TextIOWrapper):
+        with suppress(Exception):
+            _stream.reconfigure(errors="replace")
 
 # Global log file handle
 _log_file = None

--- a/packages/browseros/build/common/utils.py
+++ b/packages/browseros/build/common/utils.py
@@ -57,6 +57,9 @@ def run_command(
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,  # Merge stderr into stdout
             text=True,
+            # Native Windows tools emit ANSI-codepage bytes; strict decode
+            # would raise mid-stream and kill a multi-hour build.
+            errors="replace",
             bufsize=1,
             universal_newlines=True,
         )


### PR DESCRIPTION
## Summary
The first windows nightly to reach the build CLI (run 27451026914, after #1184 fixed runner pickup) crashed in 2 seconds at its very first log line: `UnicodeEncodeError: 'charmap' codec can't encode character '\U0001f680'`. Windows runners pipe python stdout as cp1252, and the build CLI emits ~300 emoji across its loggers — `log_warning`/`log_error`/`log_success` bake them in, so stripping is not viable. Linux/macOS lanes in the same run are unaffected and still building.

Three thin layers, each verified:
- **Workflow**: `PYTHONUTF8: "1"` job-level env on `build` — UTF-8 mode for the CLI and every python subprocess (gclient, hooks). No-op on Linux/macOS; other jobs untouched.
- **`logger.py`**: reconfigure stdout/stderr with `errors="backslashreplace"` at import, so logging degrades to escapes instead of crashing in any environment (matches stderr's native fallback; isinstance-guarded for pyright).
- **`utils.py` (review finding)**: `run_command`'s Popen decoded child output strictly — under UTF-8 mode, one ANSI-codepage byte from a native tool (MSVC, mt.exe) would `UnicodeDecodeError` a multi-hour ninja stream. Added `errors="replace"` to the decode side of the funnel.

## Test plan
- [x] Crash reproduced locally with `PYTHONIOENCODING=cp1252` (identical traceback to CI), fix verified green (emoji → escapes, exit 0)
- [x] ruff + actionlint clean; pyright error count identical pre/post (2 pre-existing in utils.py, none introduced)
- [ ] Tonight's 08:00 UTC scheduled run is the live verification (concurrency group serializes behind the in-flight linux/macOS builds, so no manual re-dispatch)

🤖 Generated with [Claude Code](https://claude.com/claude-code)