### PR TITLE
fix(ci): nightly macOS lane needs the macOS 26 image for chromium 148

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -60,7 +60,7 @@ jobs:
           matrix='[
             {"platform":"linux","arch":"x64","runner":"warp-ubuntu-2204-x64-32x","config":"release.linux.ci.yaml","timeout":660},
             {"platform":"windows","arch":"x64","runner":"warp-windows-2025-x64-32x","config":"release.windows.ci.yaml","timeout":780},
-            {"platform":"macos","arch":"arm64","runner":"warp-macos-15-arm64-12x","config":"release.macos.arm64.ci.yaml","timeout":720}
+            {"platform":"macos","arch":"arm64","runner":"warp-macos-26-arm64-12x","config":"release.macos.arm64.ci.yaml","timeout":720}
           ]'
           if [ "$PLATFORMS" != "all" ]; then
             matrix="$(jq -c --arg p "$PLATFORMS" '[ .[] | select(.platform == $p) ]' <<<"$matrix")"

--- a/packages/browseros/build/docs/nightly-warpbuild-ci.md
+++ b/packages/browseros/build/docs/nightly-warpbuild-ci.md
@@ -13,14 +13,19 @@ up here, that workflow can be retired.
 | --- | --- | --- | --- |
 | Linux x64 | `warp-ubuntu-2204-x64-32x` | 32 vCPU / 128 GB | 256 GB |
 | Windows x64 | `warp-windows-2025-x64-32x` | 32 vCPU / 128 GB | 256 GB |
-| macOS arm64 | `warp-macos-15-arm64-12x` | M4 Pro, 12 vCPU / 44 GB | 500 GB |
+| macOS arm64 | `warp-macos-26-arm64-12x` | M4 Pro, 12 vCPU / 44 GB | 500 GB |
 
-There is no 32-core macOS tier; 12x is WarpBuild's largest Mac. WarpBuild
-runners register as self-hosted, so GitHub's 6-hour hosted-job cap does not
-apply — but `timeout-minutes` must be set explicitly (the implicit default is
-360). Disk is comfortable on all three tiers — the ~60-75 GB checkout +
-~25-40 GB out dir leave ample headroom. The workflow prints `df -h`
-after each build. Specs above come from the account's runner catalog
+There is no 32-core macOS tier; 12x is WarpBuild's largest Mac. The macOS
+image version must satisfy the chromium pin's SDK requirement — check
+`build/config/mac/mac_sdk.gni` (`mac_sdk_official_version`) in the pinned
+tree when bumping `CHROMIUM_VERSION`; chromium 148 needs the macOS 26 SDK,
+and the macOS 15 image (Xcode 16.4 / SDK 15.5) fails compiling
+`skia_utils_mac.mm` (`kCGImageByteOrder32Host` only exists in SDK 26).
+WarpBuild runners register as self-hosted, so GitHub's 6-hour hosted-job
+cap does not apply — but `timeout-minutes` must be set explicitly (the
+implicit default is 360). Disk is comfortable on all three tiers — the
+~60-75 GB checkout + ~25-40 GB out dir leave ample headroom. The workflow
+prints `df -h` after each build. Specs above come from the account's runner catalog
 (app.warpbuild.com → Runners), which is the source of truth for labels
 and sizes; WarpBuild's public docs pages can lag it.
 


### PR DESCRIPTION
## Summary
The first macOS nightly to reach compile (run 27451026914) failed on unpatched upstream chromium: `skia/ext/skia_utils_mac.mm:84: use of undeclared identifier 'kCGImageByteOrder32Host'`. Root cause is an SDK mismatch, proven three ways:

- chromium `148.0.7778.97` declares `mac_sdk_official_version = "26.2"` in `build/config/mac/mac_sdk.gni` — the tree is written against the macOS 26 SDK.
- The macOS 26 SDK defines `kCGImageByteOrder32Host` as a `CGImageByteOrderInfo` enum member; the `warp-macos-15` image's Xcode 16.4 / SDK 15.5 does not.
- The same tree+pin builds green on the self-hosted signing Mac (Xcode 26); the pin has been unchanged since May 25.

Fix: run the lane on WarpBuild's catalog-listed `warp-macos-26-arm64-12x` image. The chromium WarpCache key is platform/arch-based (no image component), so the cache the failed run saved post-sync restores warm on the new image, and the clean module + sync hooks regenerate anything host-dependent.

Docs: runner table updated, plus a note coupling the macOS image choice to the chromium pin's SDK requirement (check `mac_sdk.gni` on every `CHROMIUM_VERSION` bump).

## Test plan
- [x] `actionlint` + YAML parse green; matrix JSON validated through the workflow's own jq pipeline
- [x] Repo-wide grep: no stale `warp-macos-15` references (the doc's historical note is intentional)
- [ ] Tonight's 08:00 UTC scheduled run verifies on the warm mac cache

🤖 Generated with [Claude Code](https://claude.com/claude-code)