### PR TITLE
fix: start Claude & Codex ACP sessions in dangerously-allow mode

### DIFF
--- a/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
+++ b/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
@@ -10,8 +10,13 @@ import { createOpenAICompatible } from '@ai-sdk/openai-compatible'
 import { EXTERNAL_URLS } from '@browseros/shared/constants/urls'
 import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
 import { createOpenRouter } from '@openrouter/ai-sdk-provider'
+import type { AcpxProvider } from 'acpx-ai-provider'
 import type { LanguageModel } from 'ai'
 import { buildAcpxProvider } from '../lib/agents/acpx-provider/buildAcpxProvider'
+import {
+  DANGEROUS_ALLOW_MODE_CANDIDATES,
+  isHostAcpAdapter,
+} from '../lib/agents/host-acp/config'
 import { resolveAcpSpawnCommand } from '../lib/agents/host-acp/launcher'
 import { getBrowserosDir } from '../lib/browseros-dir'
 import { createBrowserOSFetch } from '../lib/browseros-fetch'
@@ -154,12 +159,84 @@ async function createAcpLanguageModel(
     agentRegistryOverrides,
     mcpServers: config.acpMcpServers,
   })
+  await applyDangerouslyAllowMode(provider, agentId, config.conversationId)
   return {
     model: provider.languageModel() as LanguageModel,
     // acpx-ai-provider's docs put close() ownership on the caller: skip
     // it and the spawned agent process outlives the conversation.
     close: () => provider.close(),
   }
+}
+
+/**
+ * Lifts a freshly built ACP session into the adapter's full-permission
+ * mode (ACP `session/set_mode`) — the equivalent of `claude
+ * --dangerously-skip-permissions` / `codex
+ * --dangerously-bypass-approvals-and-sandbox`. Without it the adapter
+ * inherits the user's own CLI defaults (e.g. Claude `permissions.
+ * defaultMode: "dontAsk"`), which silently auto-denies the BrowserOS MCP
+ * tools. Only built-in agent ids get a mode; custom agents' mode ids are
+ * unknown. Every failure is log-and-continue so the chat never breaks —
+ * worst case is today's behavior.
+ */
+async function applyDangerouslyAllowMode(
+  provider: AcpxProvider,
+  agentId: string,
+  conversationId: string,
+): Promise<void> {
+  const candidates = isHostAcpAdapter(agentId)
+    ? DANGEROUS_ALLOW_MODE_CANDIDATES[agentId]
+    : undefined
+  if (!candidates?.length) return
+
+  try {
+    await provider.prepare()
+  } catch (err) {
+    logger.warn('ACP session prepare failed; mode left at adapter default', {
+      conversationId,
+      agentId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return
+  }
+
+  // AcpxProvider.setMode silently no-ops when the runtime lacks mode
+  // control; check explicitly so we never log a false "applied".
+  if (typeof provider.runtime.setMode !== 'function') {
+    logger.warn('acpx runtime does not expose mode control', {
+      conversationId,
+      agentId,
+      candidates,
+    })
+    return
+  }
+
+  let lastError: unknown
+  for (const mode of candidates) {
+    try {
+      await provider.setMode(mode)
+      logger.info('ACP session dangerously-allow mode applied', {
+        conversationId,
+        agentId,
+        mode,
+      })
+      return
+    } catch (err) {
+      lastError = err
+      logger.warn('ACP session mode rejected', {
+        conversationId,
+        agentId,
+        mode,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+  }
+  logger.warn('ACP session left at adapter default permission mode', {
+    conversationId,
+    agentId,
+    candidates,
+    error: lastError instanceof Error ? lastError.message : String(lastError),
+  })
 }
 
 type ProviderFactory = (

--- a/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
+++ b/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
@@ -159,7 +159,12 @@ async function createAcpLanguageModel(
     agentRegistryOverrides,
     mcpServers: config.acpMcpServers,
   })
-  await applyDangerouslyAllowMode(provider, agentId, config.conversationId)
+  // Only built-in claude/codex providers resolving to their default
+  // agent id get a danger mode. A user-overridden acpAgentId or an
+  // acp-custom agent (even one named 'claude') has unknown mode ids.
+  if (BUILT_IN_ACP_AGENT_BY_PROVIDER[config.provider] === agentId) {
+    await applyDangerouslyAllowMode(provider, agentId, config.conversationId)
+  }
   return {
     model: provider.languageModel() as LanguageModel,
     // acpx-ai-provider's docs put close() ownership on the caller: skip
@@ -223,7 +228,10 @@ async function applyDangerouslyAllowMode(
       return
     } catch (err) {
       lastError = err
-      logger.warn('ACP session mode rejected', {
+      // debug, not warn: codex's first candidate is expected to be
+      // rejected whenever the spawned package advertises the other id.
+      // Only the all-rejected case below warns.
+      logger.debug('ACP session mode candidate rejected', {
         conversationId,
         agentId,
         mode,

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime.ts
@@ -942,7 +942,10 @@ async function applyPermissionBypass(
       return []
     } catch (err) {
       lastError = err
-      logger.warn('Agent harness acpx mode rejected', {
+      // debug, not warn: the harness always spawns @zed-industries/codex-acp
+      // (mode id `full-access`), so codex's first candidate is expected to
+      // be rejected on the happy path. Only the all-rejected case below warns.
+      logger.debug('Agent harness acpx mode candidate rejected', {
         agentId: input.agent.id,
         adapter: input.agent.adapter,
         sessionKey: input.sessionKey,

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime.ts
@@ -32,7 +32,10 @@ import {
   resolveBundledNativeBinary,
   withBundledNativeBinaryPath,
 } from '../host-acp/bundled-native-binary'
-import { HOST_ACP_ADAPTER_CONFIG } from '../host-acp/config'
+import {
+  DANGEROUS_ALLOW_MODE_CANDIDATES,
+  HOST_ACP_ADAPTER_CONFIG,
+} from '../host-acp/config'
 import type {
   AgentHistoryPage,
   AgentPromptInput,
@@ -899,53 +902,63 @@ async function applyRuntimeControls(
   return events
 }
 
+/**
+ * Lifts approve-all sessions into the adapter's full-permission mode via
+ * ACP `session/set_mode` — otherwise the adapter inherits the user's own
+ * CLI permission defaults. Candidates are tried in order because the two
+ * codex-acp packages advertise different ids for the same full-access
+ * preset.
+ */
 async function applyPermissionBypass(
   runtime: AcpxCoreRuntime,
   handle: AcpRuntimeHandle,
   input: AgentPromptInput,
 ): Promise<AgentStreamEvent[]> {
-  if (
-    input.permissionMode !== 'approve-all' ||
-    input.agent.adapter !== 'claude'
-  ) {
-    return []
-  }
+  if (input.permissionMode !== 'approve-all') return []
+  const candidates = DANGEROUS_ALLOW_MODE_CANDIDATES[input.agent.adapter]
+  if (!candidates?.length) return []
+
+  const requested = `${HOST_ACP_ADAPTER_CONFIG[input.agent.adapter].displayName} ${candidates.join(' / ')}`
 
   if (!runtime.setMode) {
     return [
       {
         type: 'status',
-        text: 'Requested Claude bypassPermissions mode, but this acpx/runtime version does not expose mode control.',
+        text: `Requested ${requested} mode, but this acpx/runtime version does not expose mode control.`,
       },
     ]
   }
 
-  try {
-    await runtime.setMode({ handle, mode: 'bypassPermissions' })
-    logger.debug('Agent harness acpx mode applied', {
-      agentId: input.agent.id,
-      adapter: input.agent.adapter,
-      sessionKey: input.sessionKey,
-      mode: 'bypassPermissions',
-    })
-  } catch (err) {
-    logger.warn('Agent harness acpx mode unavailable', {
-      agentId: input.agent.id,
-      adapter: input.agent.adapter,
-      sessionKey: input.sessionKey,
-      mode: 'bypassPermissions',
-      error: err instanceof Error ? err.message : String(err),
-    })
-    return [
-      {
-        type: 'status',
-        text: `Could not apply Claude bypassPermissions mode; continuing with the adapter default. ${
-          err instanceof Error ? err.message : String(err)
-        }`,
-      },
-    ]
+  let lastError: unknown
+  for (const mode of candidates) {
+    try {
+      await runtime.setMode({ handle, mode })
+      logger.debug('Agent harness acpx mode applied', {
+        agentId: input.agent.id,
+        adapter: input.agent.adapter,
+        sessionKey: input.sessionKey,
+        mode,
+      })
+      return []
+    } catch (err) {
+      lastError = err
+      logger.warn('Agent harness acpx mode rejected', {
+        agentId: input.agent.id,
+        adapter: input.agent.adapter,
+        sessionKey: input.sessionKey,
+        mode,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
   }
-  return []
+  return [
+    {
+      type: 'status',
+      text: `Could not apply ${requested} mode; continuing with the adapter default. ${
+        lastError instanceof Error ? lastError.message : String(lastError)
+      }`,
+    },
+  ]
 }
 
 function mapRuntimeEvent(event: AcpRuntimeEvent): AgentStreamEvent {

--- a/packages/browseros-agent/apps/server/src/lib/agents/host-acp/config.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/host-acp/config.ts
@@ -42,6 +42,24 @@ export const HOST_ACP_ADAPTER_CONFIG = {
   },
 } as const satisfies Record<HostAcpAdapter, HostAcpAdapterConfig>
 
+/**
+ * Full-permission ACP session modes per built-in adapter — the ACP
+ * equivalent of `claude --dangerously-skip-permissions` / `codex
+ * --dangerously-bypass-approvals-and-sandbox`. Without this override the
+ * adapter inherits the user's own CLI defaults (e.g. Claude settings
+ * `permissions.defaultMode: "dontAsk"`, which auto-denies the BrowserOS
+ * MCP tools). Candidates are tried in order; codex lists two ids because
+ * @agentclientprotocol/codex-acp advertises `agent-full-access` while
+ * @zed-industries/codex-acp (bundled-bun / npx fallback) uses
+ * `full-access` for the same approval=never + danger-full-access preset.
+ */
+export const DANGEROUS_ALLOW_MODE_CANDIDATES: Readonly<
+  Partial<Record<HostAcpAdapter, readonly string[]>>
+> = {
+  claude: ['bypassPermissions'],
+  codex: ['agent-full-access', 'full-access'],
+}
+
 export function isHostAcpAdapter(value: string): value is HostAcpAdapter {
   return value === 'claude' || value === 'codex' || value === 'hermes'
 }

--- a/packages/browseros-agent/apps/server/tests/agent/provider-factory-acp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/provider-factory-acp.test.ts
@@ -10,10 +10,28 @@ import { join } from 'node:path'
 let lastBuildArgs: Record<string, unknown> | null = null
 const fakeLanguageModel = { kind: 'fake-acp-model' }
 let closeCalls = 0
+let prepareCalls = 0
+let prepareError: Error | null = null
+const setModeCalls: string[] = []
+let rejectModes: string[] = []
+let omitRuntimeSetMode = false
 const fakeProvider = {
   languageModel: () => fakeLanguageModel,
   close: async () => {
     closeCalls += 1
+  },
+  prepare: async () => {
+    prepareCalls += 1
+    if (prepareError) throw prepareError
+  },
+  setMode: async (mode: string) => {
+    setModeCalls.push(mode)
+    if (rejectModes.includes(mode)) {
+      throw new Error(`mode ${mode} is not supported`)
+    }
+  },
+  get runtime() {
+    return omitRuntimeSetMode ? {} : { setMode: async () => {} }
   },
 }
 
@@ -51,6 +69,11 @@ function baseConfig(): Record<string, unknown> {
 beforeEach(() => {
   lastBuildArgs = null
   closeCalls = 0
+  prepareCalls = 0
+  prepareError = null
+  setModeCalls.length = 0
+  rejectModes = []
+  omitRuntimeSetMode = false
   mkdirCalls.length = 0
 })
 
@@ -268,6 +291,76 @@ describe('createLanguageModel — ACP providers', () => {
       acpFixedWorkspacePath: '/tmp/x/$HOME/y',
     } as never)
     expect(lastBuildArgs?.workspacePath).toBe('/tmp/x/$HOME/y')
+  })
+})
+
+describe('createLanguageModel — ACP dangerously-allow mode', () => {
+  it('prepares the session and sets bypassPermissions for claude-code', async () => {
+    const { model } = await createLanguageModel(baseConfig() as never)
+    expect(model).toBe(fakeLanguageModel as never)
+    expect(prepareCalls).toBe(1)
+    expect(setModeCalls).toEqual(['bypassPermissions'])
+  })
+
+  it('sets agent-full-access for codex', async () => {
+    await createLanguageModel({ ...baseConfig(), provider: 'codex' } as never)
+    expect(setModeCalls).toEqual(['agent-full-access'])
+  })
+
+  it('falls back to the zed codex mode id when the first candidate is rejected', async () => {
+    rejectModes = ['agent-full-access']
+    const { model } = await createLanguageModel({
+      ...baseConfig(),
+      provider: 'codex',
+    } as never)
+    expect(model).toBe(fakeLanguageModel as never)
+    expect(setModeCalls).toEqual(['agent-full-access', 'full-access'])
+  })
+
+  it('still returns a model when every mode candidate is rejected', async () => {
+    rejectModes = ['agent-full-access', 'full-access']
+    const { model } = await createLanguageModel({
+      ...baseConfig(),
+      provider: 'codex',
+    } as never)
+    expect(model).toBe(fakeLanguageModel as never)
+    expect(setModeCalls).toEqual(['agent-full-access', 'full-access'])
+  })
+
+  it('still returns a model when prepare() fails, without attempting setMode', async () => {
+    prepareError = new Error('spawn failed')
+    const { model } = await createLanguageModel(baseConfig() as never)
+    expect(model).toBe(fakeLanguageModel as never)
+    expect(prepareCalls).toBe(1)
+    expect(setModeCalls).toEqual([])
+  })
+
+  it('skips mode control when the runtime does not expose setMode', async () => {
+    omitRuntimeSetMode = true
+    const { model } = await createLanguageModel(baseConfig() as never)
+    expect(model).toBe(fakeLanguageModel as never)
+    expect(prepareCalls).toBe(1)
+    expect(setModeCalls).toEqual([])
+  })
+
+  it('does not touch modes for acp-custom agents', async () => {
+    await createLanguageModel({
+      ...baseConfig(),
+      provider: 'acp-custom',
+      acpAgentId: 'my-agent',
+      acpCommand: 'my-bin acp',
+    } as never)
+    expect(prepareCalls).toBe(0)
+    expect(setModeCalls).toEqual([])
+  })
+
+  it('does not touch modes when acpAgentId overrides the built-in default', async () => {
+    await createLanguageModel({
+      ...baseConfig(),
+      acpAgentId: 'claude-experimental',
+    } as never)
+    expect(prepareCalls).toBe(0)
+    expect(setModeCalls).toEqual([])
   })
 })
 

--- a/packages/browseros-agent/apps/server/tests/agent/provider-factory-acp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/provider-factory-acp.test.ts
@@ -362,6 +362,17 @@ describe('createLanguageModel — ACP dangerously-allow mode', () => {
     expect(prepareCalls).toBe(0)
     expect(setModeCalls).toEqual([])
   })
+
+  it('does not touch modes for an acp-custom agent named like a built-in', async () => {
+    await createLanguageModel({
+      ...baseConfig(),
+      provider: 'acp-custom',
+      acpAgentId: 'claude',
+      acpCommand: 'my-bin acp',
+    } as never)
+    expect(prepareCalls).toBe(0)
+    expect(setModeCalls).toEqual([])
+  })
 })
 
 describe('createLanguageModel — ACP mcpServers forwarding', () => {

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -73,6 +73,7 @@ describe('AcpxRuntime', () => {
     expect(calls.map((call) => call.method)).toEqual([
       'createRuntime',
       'ensureSession',
+      'setMode',
       'setConfigOption',
       'startTurn',
     ])
@@ -88,13 +89,16 @@ describe('AcpxRuntime', () => {
       cwd,
     })
     expect(calls[2]?.input).toMatchObject({
+      mode: 'agent-full-access',
+    })
+    expect(calls[3]?.input).toMatchObject({
       key: 'reasoning_effort',
       value: 'medium',
     })
-    expect(calls[3]?.input).toMatchObject({
+    expect(calls[4]?.input).toMatchObject({
       mode: 'prompt',
     })
-    expect(getStartTurnText(calls[3]?.input)).toContain(
+    expect(getStartTurnText(calls[4]?.input)).toContain(
       '<user_request>\nsay hello\n</user_request>',
     )
     expect(events).toEqual([
@@ -1389,7 +1393,7 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
     expect(events).toEqual([
       {
         type: 'status',
-        text: 'Requested Claude bypassPermissions mode, but this acpx/runtime version does not expose mode control.',
+        text: 'Requested Claude Code bypassPermissions mode, but this acpx/runtime version does not expose mode control.',
       },
       {
         type: 'text_delta',
@@ -1410,6 +1414,130 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
         stopReason: 'end_turn',
       },
     ])
+  })
+
+  it('sets Codex approve-all sessions to full access before starting a turn', async () => {
+    const calls: Array<{ method: string; input: unknown }> = []
+    const runtime = new AcpxRuntime({
+      cwd: '/tmp/browseros-acpx-runtime',
+      stateDir: '/tmp/browseros-acpx-state',
+      runtimeFactory: () => createFakeAcpRuntime(calls),
+    })
+    const agent = makeAgent({ id: 'agent-1', adapter: 'codex' })
+
+    await collectStream(
+      await runtime.send({
+        agent,
+        sessionId: 'main',
+        sessionKey: agent.sessionKey,
+        message: 'open example.com',
+        permissionMode: 'approve-all',
+      }),
+    )
+
+    expect(calls.map((call) => call.method)).toEqual([
+      'ensureSession',
+      'setMode',
+      'startTurn',
+    ])
+    expect(calls[1]?.input).toMatchObject({
+      mode: 'agent-full-access',
+    })
+  })
+
+  it('falls back to the zed codex mode id when the first candidate is rejected', async () => {
+    const calls: Array<{ method: string; input: unknown }> = []
+    const runtime = new AcpxRuntime({
+      cwd: '/tmp/browseros-acpx-runtime',
+      stateDir: '/tmp/browseros-acpx-state',
+      runtimeFactory: () =>
+        createFakeAcpRuntime(calls, { rejectModes: ['agent-full-access'] }),
+    })
+    const agent = makeAgent({ id: 'agent-1', adapter: 'codex' })
+
+    const events = await collectStream(
+      await runtime.send({
+        agent,
+        sessionId: 'main',
+        sessionKey: agent.sessionKey,
+        message: 'open example.com',
+        permissionMode: 'approve-all',
+      }),
+    )
+
+    expect(calls.map((call) => call.method)).toEqual([
+      'ensureSession',
+      'setMode',
+      'setMode',
+      'startTurn',
+    ])
+    expect(calls[1]?.input).toMatchObject({ mode: 'agent-full-access' })
+    expect(calls[2]?.input).toMatchObject({ mode: 'full-access' })
+    expect(events.filter((event) => event.type === 'status')).toEqual([])
+  })
+
+  it('continues the turn when every codex mode candidate is rejected', async () => {
+    const calls: Array<{ method: string; input: unknown }> = []
+    const runtime = new AcpxRuntime({
+      cwd: '/tmp/browseros-acpx-runtime',
+      stateDir: '/tmp/browseros-acpx-state',
+      runtimeFactory: () =>
+        createFakeAcpRuntime(calls, {
+          rejectModes: ['agent-full-access', 'full-access'],
+        }),
+    })
+    const agent = makeAgent({ id: 'agent-1', adapter: 'codex' })
+
+    const events = await collectStream(
+      await runtime.send({
+        agent,
+        sessionId: 'main',
+        sessionKey: agent.sessionKey,
+        message: 'open example.com',
+        permissionMode: 'approve-all',
+      }),
+    )
+
+    expect(calls.map((call) => call.method)).toEqual([
+      'ensureSession',
+      'setMode',
+      'setMode',
+      'startTurn',
+    ])
+    expect(events[0]).toMatchObject({
+      type: 'status',
+      text: expect.stringContaining(
+        'Could not apply Codex agent-full-access / full-access mode',
+      ),
+    })
+    expect(events.at(-1)).toEqual({ type: 'done', stopReason: 'end_turn' })
+  })
+
+  it('skips mode control for Hermes adapters', async () => {
+    const browserosDir = await mkdtemp(
+      join(tmpdir(), 'browseros-acpx-browseros-'),
+    )
+    const stateDir = await mkdtemp(join(tmpdir(), 'browseros-acpx-state-'))
+    tempDirs.push(browserosDir, stateDir)
+    const calls: Array<{ method: string; input: unknown }> = []
+    const runtime = new AcpxRuntime({
+      browserosDir,
+      stateDir,
+      runtimeFactory: () => createFakeAcpRuntime(calls),
+    })
+    const agent = makeAgent({ id: 'agent-1', adapter: 'hermes' })
+
+    await collectStream(
+      await runtime.send({
+        agent,
+        sessionId: 'main',
+        sessionKey: agent.sessionKey,
+        message: 'hi',
+        permissionMode: 'approve-all',
+      }),
+    )
+
+    expect(calls.filter((call) => call.method === 'setMode')).toEqual([])
   })
 
   it('reuses cached runtime instances across per-turn timeouts', async () => {
@@ -1578,7 +1706,11 @@ function getCreateRuntimeOptions(
 
 function createFakeAcpRuntime(
   calls: Array<{ method: string; input: unknown }>,
-  options: { failConfig?: boolean; omitModeControl?: boolean } = {},
+  options: {
+    failConfig?: boolean
+    omitModeControl?: boolean
+    rejectModes?: string[]
+  } = {},
 ): AcpxCoreRuntime {
   const runtime: AcpxCoreRuntime = {
     async ensureSession(input) {
@@ -1633,6 +1765,9 @@ function createFakeAcpRuntime(
   if (!options.omitModeControl) {
     runtime.setMode = async (input) => {
       calls.push({ method: 'setMode', input })
+      if (options.rejectModes?.includes(input.mode)) {
+        throw new Error(`mode ${input.mode} is not supported`)
+      }
     }
   }
   return runtime


### PR DESCRIPTION
## Summary
- BrowserOS-spawned Claude/Codex ACP sessions now start in their full-permission mode — the ACP equivalent of `claude --dangerously-skip-permissions` / `codex --dangerously-bypass-approvals-and-sandbox` — instead of inheriting the user's own CLI permission defaults.
- Fixes the reported failure where a chat session ran in `dontAsk` mode (from `~/.claude/settings.json` `permissions.defaultMode`) and silently auto-denied the BrowserOS MCP tools (snapshot, read page, click, fill) without ever surfacing a permission request.
- Applies on **both** paths BrowserOS spawns these agents: the chat provider and the agents harness.

## Design
The adapters resolve their initial permission mode from the user's CLI settings at `session/new` and offer no `session/new` override (`SessionAgentOptions` carries no mode; claude spreads the settings-resolved mode *after* `_meta` options). The one uniform, supported lever is ACP `session/set_mode` — which the harness already trusted for Claude. This change introduces a single shared per-adapter candidate map `DANGEROUS_ALLOW_MODE_CANDIDATES` (`claude → [bypassPermissions]`, `codex → [agent-full-access, full-access]`) in `host-acp/config.ts`. Codex needs two ids because the two codex-acp packages BrowserOS can spawn (`@agentclientprotocol/codex-acp` vs `@zed-industries/codex-acp`) advertise different ids for the same approval=never + danger-full-access preset; candidates are tried in order and the first the adapter accepts wins.

- **Harness** (`acpx/runtime.ts`): generalized the claude-only `applyPermissionBypass` to the shared map; hermes and non-`approve-all` modes are untouched.
- **Chat** (`provider-factory.ts`): after building the acpx provider, eagerly `prepare()` the session then `setMode()` with the same fallback — gated to built-in claude-code/codex providers resolving to their default agent (acp-custom and overridden `acpAgentId` are skipped: unknown mode ids).
- Every failure (adapter rejects the mode, no `setMode` support, all candidates rejected, spawn error) is log-and-continue, so the conversation never breaks — worst case equals today's behavior.

## Test plan
- [x] `bun run lint` · `bun run typecheck` clean
- [x] `cd apps/server && bun run test:agent` (291) · `bun run test:lib` (244) green
- [x] `bun run test:main` (10) green
- [x] New unit coverage: harness codex setMode + zed-id fallback + all-rejected status + hermes skip; chat prepare+setMode per provider + fallback + prepare-failure tolerance + missing `runtime.setMode` + acp-custom (incl. one named `claude`) skip
- [ ] Manual: claude-code chat conversation with `~/.claude/settings.json` `defaultMode: "dontAsk"` can call BrowserOS MCP tools without denial