### PR TITLE
feat: gate Hermes on development mode

### DIFF
--- a/packages/browseros-agent/apps/agent/lib/browseros/capabilities.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/capabilities.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test'
 import {
   checkFeatureSupport,
   Feature,
+  resolveFeatureStaticSupport,
   resolveStaticFeatureSupport,
 } from './capabilities'
 
@@ -43,6 +44,64 @@ describe('resolveStaticFeatureSupport', () => {
       }),
     ).toBeNull()
   })
+
+  it('enables development-only features in development', () => {
+    expect(
+      resolveStaticFeatureSupport({
+        isDevelopment: true,
+        alphaFeaturesEnabled: false,
+        requiresDevelopmentFlag: true,
+      }),
+    ).toBe(true)
+  })
+
+  it('disables development-only features outside development', () => {
+    expect(
+      resolveStaticFeatureSupport({
+        isDevelopment: false,
+        alphaFeaturesEnabled: true,
+        requiresDevelopmentFlag: true,
+      }),
+    ).toBe(false)
+  })
+})
+
+describe('resolveFeatureStaticSupport', () => {
+  it('gates Hermes support on development mode only', () => {
+    expect(
+      resolveFeatureStaticSupport({
+        feature: Feature.HERMES_AGENT_SUPPORT,
+        isDevelopment: true,
+        alphaFeaturesEnabled: false,
+      }),
+    ).toBe(true)
+
+    expect(
+      resolveFeatureStaticSupport({
+        feature: Feature.HERMES_AGENT_SUPPORT,
+        isDevelopment: false,
+        alphaFeaturesEnabled: true,
+      }),
+    ).toBe(false)
+  })
+
+  it('preserves alpha-gated support for alpha features', () => {
+    expect(
+      resolveFeatureStaticSupport({
+        feature: Feature.ALPHA_FEATURES_SUPPORT,
+        isDevelopment: false,
+        alphaFeaturesEnabled: false,
+      }),
+    ).toBe(false)
+
+    expect(
+      resolveFeatureStaticSupport({
+        feature: Feature.ALPHA_FEATURES_SUPPORT,
+        isDevelopment: false,
+        alphaFeaturesEnabled: true,
+      }),
+    ).toBe(true)
+  })
 })
 
 describe('checkFeatureSupport — AGENT_HARNESS_SUPPORT', () => {
@@ -65,7 +124,7 @@ describe('checkFeatureSupport — AGENT_HARNESS_SUPPORT', () => {
 })
 
 describe('checkFeatureSupport — HERMES_AGENT_SUPPORT', () => {
-  it('has no version dependency once the static alpha gate allows it', () => {
+  it('has no version dependency once static support allows it', () => {
     expect(
       checkFeatureSupport(
         { browserOSVersion: null, serverVersion: null },

--- a/packages/browseros-agent/apps/agent/lib/browseros/capabilities.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/capabilities.ts
@@ -9,6 +9,7 @@ type FeatureConfig = {
   minServerVersion?: string
   maxServerVersion?: string
   requiresAlphaFlag?: boolean
+  requiresDevelopmentFlag?: boolean
 }
 
 /**
@@ -16,7 +17,7 @@ type FeatureConfig = {
  * Add new features here with corresponding config in FEATURE_CONFIG.
  *
  * Note: In development mode, all features are enabled regardless of version
- * or alpha flag.
+ * or alpha flag. Development-only gates resolve false outside development.
  * @public
  */
 export enum Feature {
@@ -81,7 +82,7 @@ const FEATURE_CONFIG: { [K in Feature]: FeatureConfig } = {
   [Feature.QWEN_CODE_SUPPORT]: { minServerVersion: '0.0.77' },
   [Feature.CREDITS_SUPPORT]: { minServerVersion: '0.0.78' },
   [Feature.AGENT_HARNESS_SUPPORT]: { minBrowserOSVersion: '0.46.0.0' },
-  [Feature.HERMES_AGENT_SUPPORT]: { requiresAlphaFlag: true },
+  [Feature.HERMES_AGENT_SUPPORT]: { requiresDevelopmentFlag: true },
 }
 
 function parseVersion(version: string): number[] {
@@ -122,15 +123,21 @@ function checkVersionConstraints(
   return true
 }
 
+/** Resolves static environment gates before version checks. */
 export function resolveStaticFeatureSupport({
   isDevelopment,
   alphaFeaturesEnabled,
+  requiresDevelopmentFlag = false,
   requiresAlphaFlag = false,
 }: {
   isDevelopment: boolean
   alphaFeaturesEnabled: boolean
+  requiresDevelopmentFlag?: boolean
   requiresAlphaFlag?: boolean
 }): boolean | null {
+  if (requiresDevelopmentFlag) {
+    return isDevelopment
+  }
   if (isDevelopment) {
     return true
   }
@@ -138,6 +145,26 @@ export function resolveStaticFeatureSupport({
     return alphaFeaturesEnabled
   }
   return null
+}
+
+/** Applies configured static gates with caller-provided environment flags. */
+export function resolveFeatureStaticSupport({
+  feature,
+  isDevelopment,
+  alphaFeaturesEnabled,
+}: {
+  feature: Feature
+  isDevelopment: boolean
+  alphaFeaturesEnabled: boolean
+}): boolean | null {
+  const config = FEATURE_CONFIG[feature]
+  if (!config) return false
+  return resolveStaticFeatureSupport({
+    isDevelopment,
+    alphaFeaturesEnabled,
+    requiresDevelopmentFlag: config.requiresDevelopmentFlag,
+    requiresAlphaFlag: config.requiresAlphaFlag,
+  })
 }
 
 export type CapabilitiesState = {
@@ -148,12 +175,10 @@ export type CapabilitiesState = {
 let initPromise: Promise<CapabilitiesState> | null = null
 
 function getStaticFeatureSupport(feature: Feature): boolean | null {
-  const config = FEATURE_CONFIG[feature]
-  if (!config) return false
-  return resolveStaticFeatureSupport({
+  return resolveFeatureStaticSupport({
+    feature,
     isDevelopment: import.meta.env.DEV,
     alphaFeaturesEnabled: env.VITE_ALPHA_FEATURES,
-    requiresAlphaFlag: config.requiresAlphaFlag,
   })
 }
 


### PR DESCRIPTION
## Summary
- Adds a `requiresDevelopmentFlag` static capability gate.
- Moves `Feature.HERMES_AGENT_SUPPORT` off the alpha gate and onto development mode only.
- Adds focused tests for the new gate and Hermes static support behavior.

## Design
Capability policy stays centralized in `apps/agent/lib/browseros/capabilities.ts`: `FEATURE_CONFIG` declares the static gate, `resolveStaticFeatureSupport` resolves it before version checks, and existing UI consumers continue to call `supports(Feature.HERMES_AGENT_SUPPORT)`.

## Test plan
- [x] `cd apps/agent && bun test lib/browseros/capabilities.test.ts`
- [x] `bunx biome check apps/agent/lib/browseros/capabilities.ts apps/agent/lib/browseros/capabilities.test.ts`
- [x] `bun run lint` (exits 0; reports existing warnings outside this change)
- [x] `bun run typecheck`
- [x] `bun run test:main`
- [x] `bun run build:agent`
