### PR TITLE
fix: remove unsupported hub toolbar setting

### DIFF
--- a/packages/browseros-agent/apps/agent/lib/browseros/prefs.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/prefs.ts
@@ -8,7 +8,6 @@ export const BROWSEROS_PREFS = {
   ALLOW_REMOTE_MCP: 'browseros.server.allow_remote_in_mcp',
   RESTART_SERVER: 'browseros.server.restart_requested',
   SHOW_LLM_CHAT: 'browseros.show_llm_chat',
-  SHOW_LLM_HUB: 'browseros.show_llm_hub',
   SHOW_TOOLBAR_LABELS: 'browseros.show_toolbar_labels',
   VERTICAL_TABS_ENABLED: 'browseros.vertical_tabs_enabled',
   INSTALL_ID: 'browseros.metrics_install_id',

--- a/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.test.tsx
+++ b/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.test.tsx
@@ -1,0 +1,74 @@
+import { beforeAll, describe, expect, it, mock } from 'bun:test'
+import { type ComponentProps, createElement, type FC } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+type LabelProps = ComponentProps<'label'>
+
+type SwitchProps = ComponentProps<'button'> & {
+  checked?: boolean
+  onCheckedChange?: (checked: boolean) => void
+}
+
+mock.module('sonner', () => ({
+  toast: { error: () => {} },
+}))
+
+mock.module('@/components/ui/label', () => ({
+  Label: ({ children, ...props }: LabelProps) =>
+    createElement('label', props, children),
+}))
+
+mock.module('@/components/ui/switch', () => ({
+  Switch: ({
+    checked: _checked,
+    onCheckedChange: _onCheckedChange,
+    ...props
+  }: SwitchProps) =>
+    createElement('button', { type: 'button', role: 'switch', ...props }),
+}))
+
+mock.module('@/lib/browseros/adapter', () => ({
+  getBrowserOSAdapter: () => ({
+    getPref: async () => null,
+    setPref: async () => true,
+  }),
+}))
+
+mock.module('@/lib/browseros/prefs', () => ({
+  BROWSEROS_PREFS: {
+    SHOW_LLM_CHAT: 'browseros.show_llm_chat',
+    SHOW_TOOLBAR_LABELS: 'browseros.show_toolbar_labels',
+    VERTICAL_TABS_ENABLED: 'browseros.vertical_tabs_enabled',
+  },
+}))
+
+mock.module('@/lib/browseros/capabilities', () => ({
+  Capabilities: {
+    supports: async () => false,
+  },
+  Feature: {
+    VERTICAL_TABS_SUPPORT: 'VERTICAL_TABS_SUPPORT',
+  },
+}))
+
+let ToolbarSettingsCard: FC
+
+beforeAll(async () => {
+  ToolbarSettingsCard = (await import('./ToolbarSettingsCard'))
+    .ToolbarSettingsCard
+})
+
+function renderCard() {
+  return renderToStaticMarkup(createElement(ToolbarSettingsCard))
+}
+
+describe('ToolbarSettingsCard', () => {
+  it('renders supported toolbar settings without the unsupported Hub control', () => {
+    const html = renderCard()
+
+    expect(html).toContain('Show Chat Button')
+    expect(html).toContain('Show Button Labels')
+    expect(html).not.toContain('Show Hub Button')
+    expect(html).not.toContain('show-llm-hub')
+  })
+})

--- a/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.tsx
+++ b/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.tsx
@@ -8,7 +8,6 @@ import { BROWSEROS_PREFS } from '@/lib/browseros/prefs'
 
 export const ToolbarSettingsCard: FC = () => {
   const [showLlmChat, setShowLlmChat] = useState(true)
-  const [showLlmHub, setShowLlmHub] = useState(false)
   const [showToolbarLabels, setShowToolbarLabels] = useState(true)
   const [verticalTabsEnabled, setVerticalTabsEnabled] = useState(true)
   const [supportsVerticalTabs, setSupportsVerticalTabs] = useState(false)
@@ -18,13 +17,11 @@ export const ToolbarSettingsCard: FC = () => {
     const loadPrefs = async () => {
       try {
         const adapter = getBrowserOSAdapter()
-        const [chatPref, hubPref, labelsPref] = await Promise.all([
+        const [chatPref, labelsPref] = await Promise.all([
           adapter.getPref(BROWSEROS_PREFS.SHOW_LLM_CHAT),
-          adapter.getPref(BROWSEROS_PREFS.SHOW_LLM_HUB),
           adapter.getPref(BROWSEROS_PREFS.SHOW_TOOLBAR_LABELS),
         ])
         setShowLlmChat(chatPref?.value !== false)
-        setShowLlmHub(hubPref?.value === true)
         setShowToolbarLabels(labelsPref?.value !== false)
 
         const hasVerticalTabsSupport = await Capabilities.supports(
@@ -88,25 +85,6 @@ export const ToolbarSettingsCard: FC = () => {
                 checked,
                 setShowLlmChat,
               )
-            }
-            disabled={isLoading}
-          />
-        </div>
-
-        <div className="flex items-center justify-between">
-          <div className="space-y-0.5">
-            <Label htmlFor="show-llm-hub" className="font-medium text-sm">
-              Show Hub Button
-            </Label>
-            <p className="text-muted-foreground text-xs">
-              Display the Hub button in the browser toolbar
-            </p>
-          </div>
-          <Switch
-            id="show-llm-hub"
-            checked={showLlmHub}
-            onCheckedChange={(checked) =>
-              handleToggle(BROWSEROS_PREFS.SHOW_LLM_HUB, checked, setShowLlmHub)
             }
             disabled={isLoading}
           />


### PR DESCRIPTION
## Summary
- Remove the unsupported `Show Hub Button` row from Customization -> Toolbar Settings.
- Stop loading or writing the stale `SHOW_LLM_HUB` browser pref from the agent UI.
- Add render coverage that keeps the supported chat and label toolbar settings visible while asserting the Hub control is gone.

## Design
This is a scoped UI removal in `ToolbarSettingsCard`: delete the isolated Hub switch and its now-unused preference key while leaving the rest of the customization card unchanged.

## Test plan
- [x] `bun run --filter @browseros/agent test`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run build:agent`