### PR TITLE
fix: tighten use-new-tools env parsing

### DIFF
--- a/packages/browseros-agent/apps/server/src/config.ts
+++ b/packages/browseros-agent/apps/server/src/config.ts
@@ -46,32 +46,28 @@ interface ParsedCliArgs {
   overrides: PartialConfig
 }
 
+/** Loads and validates server config from CLI, file, env, and defaults. */
 export function loadServerConfig(
   argv: string[] = process.argv,
 ): ConfigResult<ServerConfig> {
-  // 1. Parse CLI args
   const cli = parseCliArgs(argv)
   if (!cli.ok) return cli
 
-  // 2. Parse config file (only if --config provided)
   const file = parseConfigFile(cli.value.configPath)
   if (!file.ok) return file
 
-  // 3. Parse runtime environment variables
   const runtimeEnv = parseRuntimeEnv()
+  if (!runtimeEnv.ok) return runtimeEnv
 
-  // 4. Merge: Defaults < Env < File < CLI
   const merged = mergeConfigs(
     getDefaults(cli.value.cwd),
-    runtimeEnv,
+    runtimeEnv.value,
     file.value,
     cli.value.overrides,
   )
 
-  // 5. agentPort is deprecated - always equals serverPort
   merged.agentPort = merged.serverPort
 
-  // 6. Validate with Zod
   const result = ServerConfigSchema.safeParse(merged)
   if (!result.success) {
     const errors = result.error.issues
@@ -83,7 +79,6 @@ export function loadServerConfig(
     }
   }
 
-  // 7. Validate required inlined env vars for production
   const inlinedValidation = validateInlinedEnv()
   if (!inlinedValidation.ok) return inlinedValidation
 
@@ -247,30 +242,38 @@ function parseConfigFile(filePath?: string): ConfigResult<PartialConfig> {
   }
 }
 
-function parseRuntimeEnv(): PartialConfig {
+function parseRuntimeEnv(): ConfigResult<PartialConfig> {
   const cwd = process.cwd()
-  return omitUndefined({
-    cdpPort: process.env.BROWSEROS_CDP_PORT
-      ? safeParseInt(process.env.BROWSEROS_CDP_PORT)
-      : undefined,
-    serverPort: process.env.BROWSEROS_SERVER_PORT
-      ? safeParseInt(process.env.BROWSEROS_SERVER_PORT)
-      : undefined,
-    extensionPort: process.env.BROWSEROS_EXTENSION_PORT
-      ? safeParseInt(process.env.BROWSEROS_EXTENSION_PORT)
-      : undefined,
-    resourcesDir: process.env.BROWSEROS_RESOURCES_DIR
-      ? toAbsolutePath(process.env.BROWSEROS_RESOURCES_DIR, cwd)
-      : undefined,
-    executionDir: process.env.BROWSEROS_EXECUTION_DIR
-      ? toAbsolutePath(process.env.BROWSEROS_EXECUTION_DIR, cwd)
-      : undefined,
-    instanceInstallId: process.env.BROWSEROS_INSTALL_ID,
-    instanceClientId: process.env.BROWSEROS_CLIENT_ID,
-    aiSdkDevtoolsEnabled:
-      process.env.BROWSEROS_AI_SDK_DEVTOOLS === 'true' ? true : undefined,
-    browserUseNewTools: parseOptionalBoolean(process.env.BROWSER_USE_NEW_TOOLS),
-  })
+  const browserUseNewTools = parseBrowserUseNewToolsEnv(
+    process.env.BROWSER_USE_NEW_TOOLS,
+  )
+  if (!browserUseNewTools.ok) return browserUseNewTools
+
+  return {
+    ok: true,
+    value: omitUndefined({
+      cdpPort: process.env.BROWSEROS_CDP_PORT
+        ? safeParseInt(process.env.BROWSEROS_CDP_PORT)
+        : undefined,
+      serverPort: process.env.BROWSEROS_SERVER_PORT
+        ? safeParseInt(process.env.BROWSEROS_SERVER_PORT)
+        : undefined,
+      extensionPort: process.env.BROWSEROS_EXTENSION_PORT
+        ? safeParseInt(process.env.BROWSEROS_EXTENSION_PORT)
+        : undefined,
+      resourcesDir: process.env.BROWSEROS_RESOURCES_DIR
+        ? toAbsolutePath(process.env.BROWSEROS_RESOURCES_DIR, cwd)
+        : undefined,
+      executionDir: process.env.BROWSEROS_EXECUTION_DIR
+        ? toAbsolutePath(process.env.BROWSEROS_EXECUTION_DIR, cwd)
+        : undefined,
+      instanceInstallId: process.env.BROWSEROS_INSTALL_ID,
+      instanceClientId: process.env.BROWSEROS_CLIENT_ID,
+      aiSdkDevtoolsEnabled:
+        process.env.BROWSEROS_AI_SDK_DEVTOOLS === 'true' ? true : undefined,
+      browserUseNewTools: browserUseNewTools.value,
+    }),
+  }
 }
 
 function validateInlinedEnv(): ConfigResult<void> {
@@ -324,12 +327,17 @@ function safeParseInt(value: string): number | undefined {
   return Number.isNaN(num) ? undefined : num
 }
 
-function parseOptionalBoolean(value: string | undefined): boolean | undefined {
-  if (value === undefined) return undefined
-  const normalized = value.trim().toLowerCase()
-  if (['true', '1', 'yes', 'y', 'on'].includes(normalized)) return true
-  if (['false', '0', 'no', 'n', 'off'].includes(normalized)) return false
-  return undefined
+/** Parses the local tool-registry opt-in flag with a strict true/false surface. */
+function parseBrowserUseNewToolsEnv(
+  value: string | undefined,
+): ConfigResult<boolean | undefined> {
+  if (value === undefined) return { ok: true, value: undefined }
+  if (value === 'true') return { ok: true, value: true }
+  if (value === 'false') return { ok: true, value: false }
+  return {
+    ok: false,
+    error: 'BROWSER_USE_NEW_TOOLS must be "true" or "false".',
+  }
 }
 
 function omitUndefined<T extends Record<string, unknown>>(obj: T): Partial<T> {

--- a/packages/browseros-agent/apps/server/tests/config.test.ts
+++ b/packages/browseros-agent/apps/server/tests/config.test.ts
@@ -19,7 +19,6 @@ describe('loadServerConfig', () => {
     tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'browseros-config-test-'))
     originalEnv = { ...process.env }
 
-    // Clear relevant env vars
     delete process.env.BROWSEROS_CDP_PORT
     delete process.env.BROWSEROS_SERVER_PORT
     delete process.env.BROWSEROS_EXTENSION_PORT
@@ -50,7 +49,6 @@ describe('loadServerConfig', () => {
       if (!result.ok) return
       assert.strictEqual(result.value.cdpPort, 9222)
       assert.strictEqual(result.value.serverPort, 9223)
-      // agentPort is deprecated - always equals serverPort
       assert.strictEqual(result.value.agentPort, 9223)
       assert.strictEqual(result.value.extensionPort, 9224)
       assert.strictEqual(result.value.mcpAllowRemote, false)
@@ -488,7 +486,7 @@ describe('loadServerConfig', () => {
       assert.strictEqual(result.value.browserUseNewTools, false)
     })
 
-    it('disables new browser tools via BROWSER_USE_NEW_TOOLS=0', () => {
+    it('rejects boolean aliases for BROWSER_USE_NEW_TOOLS', () => {
       process.env.BROWSER_USE_NEW_TOOLS = '0'
 
       const result = loadServerConfig([
@@ -497,9 +495,29 @@ describe('loadServerConfig', () => {
         '--server-port=3000',
       ])
 
-      assert.strictEqual(result.ok, true)
-      if (!result.ok) return
-      assert.strictEqual(result.value.browserUseNewTools, false)
+      assert.strictEqual(result.ok, false)
+      if (result.ok) return
+      assert.match(
+        result.error,
+        /BROWSER_USE_NEW_TOOLS must be "true" or "false"/,
+      )
+    })
+
+    it('rejects invalid BROWSER_USE_NEW_TOOLS values', () => {
+      process.env.BROWSER_USE_NEW_TOOLS = 'enabled'
+
+      const result = loadServerConfig([
+        'bun',
+        'src/index.ts',
+        '--server-port=3000',
+      ])
+
+      assert.strictEqual(result.ok, false)
+      if (result.ok) return
+      assert.match(
+        result.error,
+        /BROWSER_USE_NEW_TOOLS must be "true" or "false"/,
+      )
     })
   })
 


### PR DESCRIPTION
## Summary
- Keep `browserUseNewTools` defaulted to `false` when `BROWSER_USE_NEW_TOOLS` is unset.
- Restrict `BROWSER_USE_NEW_TOOLS` to literal `true` or `false`.
- Return a clear config error for aliases or invalid values like `0` or `enabled`.

## Design
Runtime environment parsing now returns a `ConfigResult`, matching the rest of config loading's fallible sources. The use-new-tools env branch has a dedicated strict parser, so unset still falls through to defaults while invalid explicit values fail before merge/validation.

## Test plan
- [x] `cd apps/server && bun test tests/config.test.ts`
- [x] `bunx biome check apps/server/src/config.ts apps/server/tests/config.test.ts`
- [x] `bun run typecheck`
- [x] `bun run test:main`
- [x] `bun run lint` (exits 0; repo has existing warning-level diagnostics outside this change)