### PR TITLE
fix: default boolean env parser to false

### DIFF
--- a/packages/browseros-agent/apps/server/src/config.ts
+++ b/packages/browseros-agent/apps/server/src/config.ts
@@ -244,7 +244,8 @@ function parseConfigFile(filePath?: string): ConfigResult<PartialConfig> {
 
 function parseRuntimeEnv(): ConfigResult<PartialConfig> {
   const cwd = process.cwd()
-  const browserUseNewTools = parseBrowserUseNewToolsEnv(
+  const browserUseNewTools = parseBooleanEnv(
+    'BROWSER_USE_NEW_TOOLS',
     process.env.BROWSER_USE_NEW_TOOLS,
   )
   if (!browserUseNewTools.ok) return browserUseNewTools
@@ -327,16 +328,17 @@ function safeParseInt(value: string): number | undefined {
   return Number.isNaN(num) ? undefined : num
 }
 
-/** Parses the local tool-registry opt-in flag with a strict true/false surface. */
-function parseBrowserUseNewToolsEnv(
+/** Parses a strict boolean env var, defaulting missing values to false. */
+function parseBooleanEnv(
+  envName: string,
   value: string | undefined,
-): ConfigResult<boolean | undefined> {
-  if (value === undefined) return { ok: true, value: undefined }
+): ConfigResult<boolean> {
+  if (value === undefined) return { ok: true, value: false }
   if (value === 'true') return { ok: true, value: true }
   if (value === 'false') return { ok: true, value: false }
   return {
     ok: false,
-    error: 'BROWSER_USE_NEW_TOOLS must be "true" or "false".',
+    error: `${envName} must be "true" or "false".`,
   }
 }
 


### PR DESCRIPTION
## Summary
- Replace the BROWSER_USE_NEW_TOOLS-specific parser with a local strict boolean env parser.
- Make absent boolean env values parse to false instead of undefined.
- Preserve strict true/false validation and env-specific error messages.

## Design
The config loader now gets a concrete boolean from parseBooleanEnv for BROWSER_USE_NEW_TOOLS. Config file and CLI precedence are unchanged because runtime env still merges before those higher-precedence sources.

## Test plan
- [x] cd apps/server && bun test tests/config.test.ts
- [x] bun run lint
- [x] bun run typecheck
- [x] bun run test:main