### PR TITLE
feat: restore recent sites & scheduled outputs on new tab

### DIFF
--- a/packages/browseros-agent/apps/agent/screens/agent-command/AgentCommandHome.tsx
+++ b/packages/browseros-agent/apps/agent/screens/agent-command/AgentCommandHome.tsx
@@ -18,6 +18,8 @@ import {
 import { useLlmProviders } from '@/modules/llm-providers/llm-providers.hooks'
 import { useActiveHint } from '@/screens/newtab/index/active-hint.hooks'
 import { ImportDataHint } from '@/screens/newtab/index/ImportDataHint'
+import { RecentSites } from '@/screens/newtab/index/RecentSites'
+import { ScheduleResults } from '@/screens/newtab/index/ScheduleResults'
 import { SignInHint } from '@/screens/newtab/index/SignInHint'
 import {
   ConversationInput,
@@ -168,6 +170,11 @@ export const AgentCommandHome: FC = () => {
               }
             />
           </div>
+        </div>
+
+        <div className="mx-auto flex w-full max-w-3xl flex-col gap-10 pb-12">
+          <RecentSites />
+          <ScheduleResults />
         </div>
       </div>
 

--- a/packages/browseros-agent/apps/agent/screens/newtab/index/RecentSites.tsx
+++ b/packages/browseros-agent/apps/agent/screens/newtab/index/RecentSites.tsx
@@ -1,0 +1,66 @@
+import { Globe } from 'lucide-react'
+import { type FC, useState } from 'react'
+import { getFavicons } from '@/lib/getFavicons'
+import { useRecentSites } from './recent-sites.hooks'
+
+const RecentSiteIcon: FC<{ src: string; alt: string }> = ({ src, alt }) => {
+  const [failed, setFailed] = useState(false)
+
+  if (failed) {
+    return <Globe className="h-7 w-7 text-foreground" />
+  }
+
+  return (
+    <img
+      src={src}
+      alt={alt}
+      className="h-7 w-7 object-contain"
+      onError={() => {
+        setFailed(true)
+      }}
+      onLoad={(e) => {
+        const img = e.currentTarget
+        if (img.naturalWidth === 0 || img.naturalHeight === 0) {
+          setFailed(true)
+        }
+      }}
+    />
+  )
+}
+
+export const RecentSites: FC = () => {
+  const recentSites = useRecentSites()
+
+  if (!recentSites.length) return null
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-center font-medium text-muted-foreground text-xs uppercase tracking-wide">
+        Recent sites
+      </h2>
+      <div className="flex flex-wrap items-center justify-center gap-6">
+        {recentSites.map((site) => {
+          const icon = site.host ? getFavicons(site.host) : undefined
+          return (
+            <a
+              key={site.url}
+              href={site.url}
+              className="group flex flex-col items-center gap-2 transition-transform hover:scale-110"
+            >
+              <div className="flex h-14 w-14 items-center justify-center rounded-2xl border border-border/50 bg-card shadow-sm transition-all group-hover:border-[var(--accent-orange)]/30 group-hover:shadow-md">
+                {icon ? (
+                  <RecentSiteIcon src={icon} alt={site.name} />
+                ) : (
+                  <Globe className="h-7 w-7 text-foreground" />
+                )}
+              </div>
+              <span className="line-clamp-1 max-w-18 text-muted-foreground text-xs transition-colors group-hover:text-foreground">
+                {site.name}
+              </span>
+            </a>
+          )
+        })}
+      </div>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent/screens/newtab/index/ScheduleResults.tsx
+++ b/packages/browseros-agent/apps/agent/screens/newtab/index/ScheduleResults.tsx
@@ -1,0 +1,202 @@
+import dayjs from 'dayjs'
+import relativeTime from 'dayjs/plugin/relativeTime'
+import {
+  Calendar,
+  CheckCircle2,
+  ChevronDown,
+  Clock,
+  Loader2,
+  RotateCcw,
+  Square,
+  XCircle,
+} from 'lucide-react'
+import { type FC, useMemo, useState } from 'react'
+import { useNavigate } from 'react-router'
+import { RunResultDialog } from '@/components/ai-elements/run-result-dialog'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from '@/components/ui/collapsible'
+import {
+  SCHEDULED_TASK_CANCELLED_EVENT,
+  SCHEDULED_TASK_RETRIED_EVENT,
+  SCHEDULED_TASK_VIEW_MORE_IN_NEWTAB_EVENT,
+  SCHEDULED_TASK_VIEW_RESULTS_IN_NEWTAB_EVENT,
+} from '@/lib/constants/analyticsEvents'
+import { track } from '@/lib/metrics/track'
+import {
+  useScheduledJobRuns,
+  useScheduledJobs,
+} from '@/lib/schedules/scheduleStorage'
+import {
+  countRunningRuns,
+  type JobRunWithDetails,
+  selectDisplayedRuns,
+} from './schedule-results.helpers'
+
+dayjs.extend(relativeTime)
+
+const MAX_DISPLAY_COUNT = 3
+const SCHEDULE_RESULTS_COLLAPSED_KEY = 'schedule-results-collapsed'
+
+const getStatusIcon = (status: JobRunWithDetails['status']) => {
+  switch (status) {
+    case 'completed':
+      return <CheckCircle2 className="h-4 w-4 text-green-500" />
+    case 'running':
+      return <Loader2 className="h-4 w-4 animate-spin text-accent-orange" />
+    case 'failed':
+      return <XCircle className="h-4 w-4 text-destructive" />
+  }
+}
+
+const formatTimestamp = (dateString: string) => dayjs(dateString).fromNow()
+
+export const ScheduleResults: FC = () => {
+  const navigate = useNavigate()
+  const [isOpen, setIsOpen] = useState(() => {
+    const stored = localStorage.getItem(SCHEDULE_RESULTS_COLLAPSED_KEY)
+    return stored !== 'true'
+  })
+  const [viewingRun, setViewingRun] = useState<JobRunWithDetails | null>(null)
+
+  const handleOpenChange = (open: boolean) => {
+    setIsOpen(open)
+    localStorage.setItem(SCHEDULE_RESULTS_COLLAPSED_KEY, (!open).toString())
+  }
+
+  const { jobRuns, cancelJobRun } = useScheduledJobRuns()
+  const { jobs, runJob } = useScheduledJobs()
+
+  const runningCount = countRunningRuns(jobRuns)
+  const displayedRuns = useMemo(
+    () => selectDisplayedRuns(jobRuns, jobs, MAX_DISPLAY_COUNT),
+    [jobRuns, jobs],
+  )
+
+  const viewRun = (run: JobRunWithDetails) => {
+    track(SCHEDULED_TASK_VIEW_RESULTS_IN_NEWTAB_EVENT)
+    setViewingRun(run)
+  }
+
+  const handleCancelRun = async (runId: string) => {
+    await cancelJobRun(runId)
+    track(SCHEDULED_TASK_CANCELLED_EVENT)
+  }
+
+  const handleRetryRun = async (jobId: string) => {
+    await runJob(jobId)
+    setViewingRun(null)
+    track(SCHEDULED_TASK_RETRIED_EVENT)
+  }
+
+  const handleViewMore = () => {
+    track(SCHEDULED_TASK_VIEW_MORE_IN_NEWTAB_EVENT)
+    navigate('/scheduled')
+  }
+
+  if (!displayedRuns.length) return null
+
+  return (
+    <Collapsible
+      open={isOpen}
+      onOpenChange={handleOpenChange}
+      className="space-y-3"
+    >
+      <CollapsibleTrigger asChild>
+        <Button
+          variant="ghost"
+          className="group flex h-auto w-full items-center justify-between rounded-xl border border-border/50 bg-card/50 p-3 transition-all hover:border-border hover:bg-card"
+        >
+          <div className="flex items-center gap-3">
+            <Calendar className="h-4 w-4 text-muted-foreground" />
+            <span className="font-medium text-foreground text-sm">
+              Scheduled Task Outputs
+            </span>
+            {runningCount > 0 && (
+              <Badge variant="secondary" className="text-xs">
+                {runningCount} running
+              </Badge>
+            )}
+          </div>
+          <ChevronDown
+            className={`h-4 w-4 text-muted-foreground transition-transform duration-200 ${isOpen ? 'rotate-180' : ''}`}
+          />
+        </Button>
+      </CollapsibleTrigger>
+
+      <CollapsibleContent className="fade-in-0 slide-in-from-top-2 animate-in space-y-2 duration-200">
+        {displayedRuns.map((run) => (
+          <Button
+            key={run.id}
+            variant="ghost"
+            onClick={() => viewRun(run)}
+            className="h-auto w-full justify-start rounded-xl border border-border/50 bg-card p-4 text-left transition-all hover:border-border"
+          >
+            <div className="flex w-full items-start gap-3">
+              {getStatusIcon(run.status)}
+              <div className="min-w-0 flex-1">
+                <div className="mb-1 flex items-center gap-2">
+                  <span className="truncate font-medium text-foreground text-sm">
+                    {run.job?.name}
+                  </span>
+                  <span className="flex items-center gap-1 text-muted-foreground text-xs">
+                    <Clock className="h-3 w-3" />
+                    {formatTimestamp(run.startedAt)}
+                  </span>
+                </div>
+                {run.result && (
+                  <p className="line-clamp-2 text-ellipsis text-muted-foreground text-xs">
+                    {run.result}
+                  </p>
+                )}
+              </div>
+              {run.status === 'running' && (
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    handleCancelRun(run.id)
+                  }}
+                  className="shrink-0 text-destructive hover:bg-destructive/10 hover:text-destructive"
+                  aria-label="Cancel run"
+                >
+                  <Square className="h-3.5 w-3.5" />
+                </Button>
+              )}
+              {run.status === 'failed' && (
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  onClick={(e) => {
+                    e.stopPropagation()
+                    handleRetryRun(run.jobId)
+                  }}
+                  className="shrink-0 text-muted-foreground hover:text-foreground"
+                  aria-label="Retry run"
+                >
+                  <RotateCcw className="h-3.5 w-3.5" />
+                </Button>
+              )}
+            </div>
+          </Button>
+        ))}
+        <Button variant="ghost" onClick={handleViewMore} className="w-full">
+          View more
+        </Button>
+      </CollapsibleContent>
+
+      <RunResultDialog
+        run={viewingRun}
+        jobName={viewingRun?.job?.name}
+        onOpenChange={(open) => !open && setViewingRun(null)}
+        onCancelRun={handleCancelRun}
+        onRetryRun={handleRetryRun}
+      />
+    </Collapsible>
+  )
+}

--- a/packages/browseros-agent/apps/agent/screens/newtab/index/recent-sites.helpers.test.ts
+++ b/packages/browseros-agent/apps/agent/screens/newtab/index/recent-sites.helpers.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'bun:test'
+import { mapTopSitesToRecentSites } from './recent-sites.helpers'
+
+describe('mapTopSitesToRecentSites', () => {
+  it('maps a top site to name, url, and the parsed host', () => {
+    const [site] = mapTopSitesToRecentSites(
+      [{ url: 'https://example.com/path', title: 'Example' }],
+      5,
+    )
+    expect(site).toEqual({
+      name: 'Example',
+      url: 'https://example.com/path',
+      host: 'example.com',
+    })
+  })
+
+  it('leaves host undefined when the url cannot be parsed', () => {
+    const [site] = mapTopSitesToRecentSites(
+      [{ url: 'not-a-valid-url', title: 'Bad' }],
+      5,
+    )
+    expect(site.host).toBeUndefined()
+    expect(site.name).toBe('Bad')
+  })
+
+  it('returns at most max entries', () => {
+    const sites = Array.from({ length: 8 }, (_, i) => ({
+      url: `https://site${i}.com`,
+      title: `Site ${i}`,
+    }))
+    expect(mapTopSitesToRecentSites(sites, 5)).toHaveLength(5)
+  })
+})

--- a/packages/browseros-agent/apps/agent/screens/newtab/index/recent-sites.helpers.ts
+++ b/packages/browseros-agent/apps/agent/screens/newtab/index/recent-sites.helpers.ts
@@ -4,16 +4,11 @@ export interface RecentSite {
   host?: string
 }
 
-interface TopSiteEntry {
-  url: string
-  title: string
-}
-
 /** Trim raw `chrome.topSites` entries into the shape the row renders: keep the
  * title and url, extract the host for favicon lookup (left undefined when the
  * url can't be parsed), and cap the list at `max`. */
 export function mapTopSitesToRecentSites(
-  sites: readonly TopSiteEntry[],
+  sites: readonly { url: string; title: string }[],
   max: number,
 ): RecentSite[] {
   return sites.slice(0, max).map((site) => {

--- a/packages/browseros-agent/apps/agent/screens/newtab/index/recent-sites.helpers.ts
+++ b/packages/browseros-agent/apps/agent/screens/newtab/index/recent-sites.helpers.ts
@@ -1,0 +1,28 @@
+export interface RecentSite {
+  name: string
+  url: string
+  host?: string
+}
+
+interface TopSiteEntry {
+  url: string
+  title: string
+}
+
+/** Trim raw `chrome.topSites` entries into the shape the row renders: keep the
+ * title and url, extract the host for favicon lookup (left undefined when the
+ * url can't be parsed), and cap the list at `max`. */
+export function mapTopSitesToRecentSites(
+  sites: readonly TopSiteEntry[],
+  max: number,
+): RecentSite[] {
+  return sites.slice(0, max).map((site) => {
+    let host: string | undefined
+    try {
+      host = new URL(site.url).host
+    } catch {
+      // Unparseable url — the row falls back to a generic glyph.
+    }
+    return { name: site.title, url: site.url, host }
+  })
+}

--- a/packages/browseros-agent/apps/agent/screens/newtab/index/recent-sites.hooks.ts
+++ b/packages/browseros-agent/apps/agent/screens/newtab/index/recent-sites.hooks.ts
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+import {
+  mapTopSitesToRecentSites,
+  type RecentSite,
+} from './recent-sites.helpers'
+
+const MAX_RECENT_SITES = 5
+
+export function useRecentSites(): RecentSite[] {
+  const [recentSites, setRecentSites] = useState<RecentSite[]>([])
+
+  useEffect(() => {
+    // `chrome.topSites` is absent until the `topSites` permission is granted
+    // (e.g. before the extension reloads with the restored manifest).
+    if (!chrome.topSites) return
+    chrome.topSites.get().then((sites) => {
+      setRecentSites(mapTopSitesToRecentSites(sites, MAX_RECENT_SITES))
+    })
+  }, [])
+
+  return recentSites
+}

--- a/packages/browseros-agent/apps/agent/screens/newtab/index/schedule-results.helpers.test.ts
+++ b/packages/browseros-agent/apps/agent/screens/newtab/index/schedule-results.helpers.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'bun:test'
+import type {
+  ScheduledJob,
+  ScheduledJobRun,
+} from '@/lib/schedules/scheduleTypes'
+import {
+  countRunningRuns,
+  selectDisplayedRuns,
+} from './schedule-results.helpers'
+
+const job = (id: string, name: string): ScheduledJob => ({
+  id,
+  name,
+  query: 'q',
+  scheduleType: 'daily',
+  enabled: true,
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+})
+
+const run = (
+  id: string,
+  jobId: string,
+  status: ScheduledJobRun['status'],
+  startedAt: string,
+): ScheduledJobRun => ({ id, jobId, status, startedAt })
+
+const jobs = [job('j1', 'Daily digest'), job('j2', 'Hourly check')]
+
+describe('selectDisplayedRuns', () => {
+  it('lists running runs first, then most-recent finished, capped at max', () => {
+    const runs = [
+      run('r1', 'j1', 'completed', '2026-06-10T10:00:00.000Z'),
+      run('r2', 'j2', 'running', '2026-06-10T09:00:00.000Z'),
+      run('r3', 'j1', 'failed', '2026-06-11T10:00:00.000Z'),
+      run('r4', 'j2', 'completed', '2026-06-09T10:00:00.000Z'),
+    ]
+
+    const result = selectDisplayedRuns(runs, jobs, 3)
+
+    expect(result.map((r) => r.id)).toEqual(['r2', 'r3', 'r1'])
+    expect(result[0].job?.name).toBe('Hourly check')
+  })
+
+  it('keeps every running run when they meet or exceed max', () => {
+    const runs = [
+      run('r1', 'j1', 'running', '2026-06-10T10:00:00.000Z'),
+      run('r2', 'j1', 'running', '2026-06-10T11:00:00.000Z'),
+      run('r3', 'j2', 'running', '2026-06-10T12:00:00.000Z'),
+      run('r4', 'j2', 'running', '2026-06-10T13:00:00.000Z'),
+      run('r5', 'j1', 'completed', '2026-06-12T10:00:00.000Z'),
+    ]
+
+    const result = selectDisplayedRuns(runs, jobs, 3)
+
+    expect(result).toHaveLength(4)
+    expect(result.every((r) => r.status === 'running')).toBe(true)
+  })
+
+  it('pairs a run with undefined job when none matches', () => {
+    const runs = [run('r1', 'missing', 'completed', '2026-06-10T10:00:00.000Z')]
+
+    expect(selectDisplayedRuns(runs, jobs, 3)[0].job).toBeUndefined()
+  })
+})
+
+describe('countRunningRuns', () => {
+  it('counts only running runs', () => {
+    const runs = [
+      run('r1', 'j1', 'running', '2026-06-10T10:00:00.000Z'),
+      run('r2', 'j1', 'completed', '2026-06-10T10:00:00.000Z'),
+      run('r3', 'j1', 'running', '2026-06-10T10:00:00.000Z'),
+    ]
+
+    expect(countRunningRuns(runs)).toBe(2)
+  })
+})

--- a/packages/browseros-agent/apps/agent/screens/newtab/index/schedule-results.helpers.ts
+++ b/packages/browseros-agent/apps/agent/screens/newtab/index/schedule-results.helpers.ts
@@ -1,0 +1,41 @@
+import type {
+  ScheduledJob,
+  ScheduledJobRun,
+} from '@/lib/schedules/scheduleTypes'
+
+export interface JobRunWithDetails extends ScheduledJobRun {
+  job: ScheduledJob | undefined
+}
+
+export function countRunningRuns(runs: readonly ScheduledJobRun[]): number {
+  return runs.filter((run) => run.status === 'running').length
+}
+
+/** Pick the runs the home widget shows: all in-flight runs first, then the most
+ * recent finished runs to fill up to `max`. When running runs already meet
+ * `max`, every running run is kept (so nothing in-flight is hidden) and no
+ * finished runs are added. Each run is paired with its owning job. */
+export function selectDisplayedRuns(
+  runs: readonly ScheduledJobRun[],
+  jobs: readonly ScheduledJob[],
+  max: number,
+): JobRunWithDetails[] {
+  const enrich = (run: ScheduledJobRun): JobRunWithDetails => ({
+    ...run,
+    job: jobs.find((job) => job.id === run.jobId),
+  })
+
+  const running = runs.filter((run) => run.status === 'running').map(enrich)
+  if (running.length >= max) return running
+
+  const finished = runs
+    .filter((run) => run.status === 'completed' || run.status === 'failed')
+    .sort(
+      (a, b) =>
+        new Date(b.startedAt).getTime() - new Date(a.startedAt).getTime(),
+    )
+    .slice(0, max - running.length)
+    .map(enrich)
+
+  return [...running, ...finished]
+}

--- a/packages/browseros-agent/apps/agent/wxt.config.ts
+++ b/packages/browseros-agent/apps/agent/wxt.config.ts
@@ -54,6 +54,7 @@ export default defineConfig({
       default_title: 'Ask BrowserOS',
     },
     permissions: [
+      'topSites',
       'storage',
       'unlimitedStorage',
       'scripting',


### PR DESCRIPTION
## Summary
- Restore the **recent sites** and **scheduled task outputs** widgets on the alpha new tab home — both were removed when `afe3292c` ("default alpha new tab experience") deleted the legacy new tab.
- **Recent sites**: a centered row of up to 5 most-visited favicon tiles (`chrome.topSites`), hidden when empty.
- **Scheduled task outputs**: a collapsible card of recent runs (running first, then most-recent completed/failed, capped at 3) that opens the run-result dialog, supports cancel/retry, and links to the full `/scheduled` page via "View more".

## Design
Two widgets colocated under `screens/newtab/index/`, each backed by an extracted, unit-tested pure helper (`recent-sites.helpers.ts`, `schedule-results.helpers.ts`), wired into `AgentCommandHome` below the composer. Reuses the surviving schedule-storage hooks, `RunResultDialog`, `getFavicons`, and the existing `SCHEDULED_TASK_*` analytics events — no new runtime deps. Restores the `topSites` manifest permission. "View more" uses in-app react-router navigation since the home now serves from `app.html`. Favicon-URL construction lives in the component (not the helper) so the pure helper stays free of the `@/lib` import the bun test resolver can't reach for that now-orphaned module.

## Test plan
- [ ] `cd apps/agent && bun run typecheck` — green
- [ ] `cd apps/agent && bun run test` — green (recent-sites + schedule-results helper logic covered)
- [ ] On `/home` with scheduled runs present: the "Scheduled Task Outputs" card shows ≤3 rows (running first); opening a row shows its result; cancel/retry work; "View more" navigates to `/scheduled`.
- [ ] With browsing history present: a "Recent sites" favicon row appears; both widgets vanish cleanly when empty.