### PR TITLE
fix: honor browser tools flag in chat agents

### DIFF
--- a/packages/browseros-agent/apps/eval/src/agents/orchestrated/backends/tool-loop/tool-loop-executor-backend.ts
+++ b/packages/browseros-agent/apps/eval/src/agents/orchestrated/backends/tool-loop/tool-loop-executor-backend.ts
@@ -54,8 +54,10 @@ export class ToolLoopExecutorBackend implements ExecutorBackend {
     try {
       agent = await AiSdkAgent.create({
         resolvedConfig: agentConfig,
+        browser,
         browserSession,
         browserContext,
+        browserUseNewTools: true,
       })
 
       await agent.toolLoopAgent.generate({

--- a/packages/browseros-agent/apps/eval/src/agents/single-agent.ts
+++ b/packages/browseros-agent/apps/eval/src/agents/single-agent.ts
@@ -91,8 +91,10 @@ export class SingleAgentEvaluator implements AgentEvaluator {
     try {
       agent = await AiSdkAgent.create({
         resolvedConfig: agentConfig,
+        browser,
         browserSession,
         browserContext,
+        browserUseNewTools: true,
       })
 
       let finalText: string | null = null

--- a/packages/browseros-agent/apps/server/src/agent/ai-sdk-agent.ts
+++ b/packages/browseros-agent/apps/server/src/agent/ai-sdk-agent.ts
@@ -19,12 +19,16 @@ import {
   buildKlavisToolSet,
   type KlavisProxyRef,
 } from '../api/services/klavis/strata-proxy'
+import type { Browser } from '../browser/browser'
 import type { BrowserSession } from '../browser/core/session'
 import { logger } from '../lib/logger'
 import { metrics } from '../lib/metrics'
 import { buildFilesystemToolSet } from '../tools/filesystem/build-toolset'
 import { isAcpProvider } from './acp-providers'
-import { CHAT_MODE_ALLOWED_TOOLS } from './chat-mode'
+import {
+  CHAT_MODE_ALLOWED_TOOLS,
+  LEGACY_CHAT_MODE_ALLOWED_TOOLS,
+} from './chat-mode'
 import { createCompactionPrepareStep, type StepWithUsage } from './compaction'
 import { buildMcpServerSpecs, createMcpClients } from './mcp-builder'
 import {
@@ -35,16 +39,18 @@ import { buildNudgeToolSet } from './nudge-tools'
 import { buildSystemPrompt } from './prompt'
 import { createLanguageModel } from './provider-factory'
 import { readSoulPrompt } from './soul-prompt'
-import { buildBrowserToolSet } from './tool-adapter'
+import { buildBrowserToolSet, buildLegacyBrowserToolSet } from './tool-adapter'
 import type { ResolvedAgentConfig } from './types'
 
 export interface AiSdkAgentConfig {
   resolvedConfig: ResolvedAgentConfig
+  browser: Browser
   browserSession: BrowserSession
   browserContext?: BrowserContext
   klavisRef?: KlavisProxyRef
   browserosId?: string
   aiSdkDevtoolsEnabled?: boolean
+  browserUseNewTools: boolean
 }
 
 export class AiSdkAgent {
@@ -102,23 +108,34 @@ export class AiSdkAgent {
     // (and any user-configured MCP servers) directly via the
     // mcpServers config on ResolvedAgentConfig.
     const useMcpBoundaryOnly = isAcpProvider(config.resolvedConfig.provider)
+    const useCompactBrowserTools = config.browserUseNewTools === true
 
     const allBrowserTools = useMcpBoundaryOnly
       ? {}
-      : buildBrowserToolSet(config.browserSession, {
-          readOnly: config.resolvedConfig.chatMode,
-        })
+      : useCompactBrowserTools
+        ? buildBrowserToolSet(config.browserSession, {
+            readOnly: config.resolvedConfig.chatMode,
+          })
+        : buildLegacyBrowserToolSet(config.browser, {
+            workingDir: config.resolvedConfig.workingDir,
+            origin: config.resolvedConfig.origin,
+            originPageId: config.browserContext?.activeTab?.pageId,
+          })
     const reservedBrowserToolNames = new Set(Object.keys(allBrowserTools))
+    const chatModeAllowedTools = useCompactBrowserTools
+      ? CHAT_MODE_ALLOWED_TOOLS
+      : LEGACY_CHAT_MODE_ALLOWED_TOOLS
     const browserTools = config.resolvedConfig.chatMode
       ? Object.fromEntries(
           Object.entries(allBrowserTools).filter(([name]) =>
-            CHAT_MODE_ALLOWED_TOOLS.has(name),
+            chatModeAllowedTools.has(name),
           ),
         )
       : allBrowserTools
     if (config.resolvedConfig.chatMode && !useMcpBoundaryOnly) {
       logger.info('Chat mode enabled, restricting to read-only browser tools', {
-        allowedTools: Array.from(CHAT_MODE_ALLOWED_TOOLS),
+        allowedTools: Array.from(chatModeAllowedTools),
+        browserUseNewTools: useCompactBrowserTools,
       })
     }
 

--- a/packages/browseros-agent/apps/server/src/agent/chat-mode.ts
+++ b/packages/browseros-agent/apps/server/src/agent/chat-mode.ts
@@ -12,3 +12,11 @@ export const CHAT_MODE_ALLOWED_TOOLS = new Set([
   ),
   'tabs',
 ])
+
+export const LEGACY_CHAT_MODE_ALLOWED_TOOLS = new Set([
+  'list_pages',
+  'get_page_content',
+  'scroll',
+  'take_snapshot',
+  'evaluate_script',
+])

--- a/packages/browseros-agent/apps/server/src/agent/tool-adapter.ts
+++ b/packages/browseros-agent/apps/server/src/agent/tool-adapter.ts
@@ -1,19 +1,32 @@
 import type { LanguageModelV2ToolResultOutput } from '@ai-sdk/provider'
 import { type ToolSet, tool } from 'ai'
+import type { Browser } from '../browser/browser'
 import type { BrowserSession } from '../browser/core/session'
+import { logger } from '../lib/logger'
 import { metrics } from '../lib/metrics'
 import {
+  type ToolDefinition as BrowserToolDefinition,
+  type ToolResult as BrowserToolResult,
   type ContentBlock,
   errorResult,
-  executeTool,
-  type ToolDefinition,
-  type ToolResult,
+  executeTool as executeBrowserTool,
   throwIfAborted,
 } from '../tools/browser/framework'
 import { BROWSER_TOOLS } from '../tools/browser/registry'
+import {
+  executeTool as executeLegacyTool,
+  type ToolContext as LegacyToolContext,
+} from '../tools/legacy/framework'
+import { registry as LEGACY_BROWSER_TOOLS } from '../tools/legacy/registry'
 
 export interface BrowserToolSetOptions {
   readOnly?: boolean
+}
+
+export interface LegacyBrowserToolSetOptions {
+  workingDir?: string
+  origin?: 'sidepanel' | 'newtab'
+  originPageId?: number
 }
 
 interface ToolExecuteOptions {
@@ -80,7 +93,7 @@ export function buildBrowserToolSet(
         throwIfAborted(signal)
         const result =
           readOnlyGuard(def, params, options) ??
-          (await executeTool(def, params as Record<string, unknown>, {
+          (await executeBrowserTool(def, params as Record<string, unknown>, {
             session,
             signal,
           }))
@@ -114,11 +127,88 @@ export function buildBrowserToolSet(
   return toolSet
 }
 
+/** Wraps the legacy browser tool surface as AI SDK tools for the internal agent. */
+export function buildLegacyBrowserToolSet(
+  browser: Browser,
+  options: LegacyBrowserToolSetOptions = {},
+): ToolSet {
+  const toolSet: ToolSet = {}
+  const context: LegacyToolContext = {
+    browser,
+    directories: { workingDir: options.workingDir },
+    session: {
+      origin: options.origin,
+      originPageId: options.originPageId,
+    },
+  }
+
+  for (const def of LEGACY_BROWSER_TOOLS.all()) {
+    toolSet[def.name] = tool({
+      description: def.description,
+      inputSchema: def.input,
+      execute: async (params, executeOptions?: ToolExecuteOptions) => {
+        const startTime = performance.now()
+        const signal = withBrowserToolTimeout(executeOptions?.abortSignal)
+        try {
+          const result = await executeLegacyTool(def, params, context, signal)
+          metrics.log('tool_executed', {
+            tool_name: def.name,
+            duration_ms: Math.round(performance.now() - startTime),
+            success: !result.isError,
+            source: 'chat',
+          })
+          return {
+            content: result.content,
+            isError: result.isError ?? false,
+            metadata: result.metadata,
+          }
+        } catch (error) {
+          const errorText =
+            error instanceof Error ? error.message : String(error)
+          logger.error('Tool execution failed', {
+            tool: def.name,
+            error: errorText,
+          })
+          metrics.log('tool_executed', {
+            tool_name: def.name,
+            duration_ms: Math.round(performance.now() - startTime),
+            success: false,
+            error_message: errorText,
+            source: 'chat',
+          })
+          return {
+            content: [{ type: 'text' as const, text: errorText }],
+            isError: true,
+          }
+        }
+      },
+      toModelOutput: ({ output }) => {
+        const result = output as { content: ContentBlock[]; isError: boolean }
+        if (result.isError) {
+          const text = result.content
+            .filter(
+              (c): c is ContentBlock & { type: 'text' } => c.type === 'text',
+            )
+            .map((c) => c.text)
+            .join('\n')
+          return { type: 'error-text', value: text }
+        }
+        if (!result.content?.length) {
+          return { type: 'text', value: 'Success' }
+        }
+        return contentToModelOutput(result.content)
+      },
+    })
+  }
+
+  return toolSet
+}
+
 function readOnlyGuard(
-  def: ToolDefinition,
+  def: BrowserToolDefinition,
   params: unknown,
   options: BrowserToolSetOptions,
-): ToolResult | null {
+): BrowserToolResult | null {
   if (!options.readOnly || def.name !== 'tabs') return null
   const action =
     params &&

--- a/packages/browseros-agent/apps/server/src/api/routes/chat.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/chat.ts
@@ -19,6 +19,7 @@ interface ChatRouteDeps {
   browserosId?: string
   klavisRef?: KlavisProxyRef
   aiSdkDevtoolsEnabled?: boolean
+  browserUseNewTools?: boolean
   /** Port the BrowserOS server bound to. Threaded to ACP providers so
    *  the spawned agent can dial back into the local /mcp route. */
   serverPort: number
@@ -42,6 +43,7 @@ export function createChatRoutes(deps: ChatRouteDeps) {
     browserSession: deps.browserSession,
     browserosId,
     aiSdkDevtoolsEnabled: deps.aiSdkDevtoolsEnabled,
+    browserUseNewTools: deps.browserUseNewTools === true,
     serverPort: deps.serverPort,
     resourcesDir: deps.resourcesDir,
   })

--- a/packages/browseros-agent/apps/server/src/api/server.ts
+++ b/packages/browseros-agent/apps/server/src/api/server.ts
@@ -194,6 +194,7 @@ export async function createHttpServer(config: HttpServerConfig) {
         browserosId,
         klavisRef,
         aiSdkDevtoolsEnabled: config.aiSdkDevtoolsEnabled,
+        browserUseNewTools: config.browserUseNewTools,
         serverPort: port,
         resourcesDir,
         remoteHermes,

--- a/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
@@ -30,6 +30,7 @@ export interface ChatServiceDeps {
   browserSession: BrowserSession
   browserosId?: string
   aiSdkDevtoolsEnabled?: boolean
+  browserUseNewTools: boolean
   /** Port the BrowserOS server bound to. Forwarded into the ACP MCP
    *  bridge so the spawned agent can dial back into /mcp. */
   serverPort: number
@@ -247,11 +248,13 @@ export class ChatService {
 
       const agent = await AiSdkAgent.create({
         resolvedConfig: agentConfig,
+        browser: this.deps.browser,
         browserSession: this.deps.browserSession,
         browserContext,
         klavisRef: this.deps.klavisRef,
         browserosId: this.deps.browserosId,
         aiSdkDevtoolsEnabled: this.deps.aiSdkDevtoolsEnabled,
+        browserUseNewTools: this.deps.browserUseNewTools,
       })
       session = {
         agent,
@@ -452,11 +455,13 @@ export class ChatService {
         )
     const agent = await AiSdkAgent.create({
       resolvedConfig: agentConfig,
+      browser: this.deps.browser,
       browserSession: this.deps.browserSession,
       browserContext,
       klavisRef: this.deps.klavisRef,
       browserosId: this.deps.browserosId,
       aiSdkDevtoolsEnabled: this.deps.aiSdkDevtoolsEnabled,
+      browserUseNewTools: this.deps.browserUseNewTools,
     })
     const newSession: AgentSession = {
       agent,

--- a/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/chat-service.test.ts
@@ -294,6 +294,69 @@ describe('ChatService scheduled task hidden page lifecycle', () => {
   })
 })
 
+describe('ChatService browser tool config', () => {
+  it('passes browserUseNewTools and browser into new and rebuilt agent sessions', async () => {
+    const firstAgent = createFakeAgent()
+    const secondAgent = createFakeAgent()
+    agentToReturn = firstAgent
+    streamResponseHandler = async ({ onFinish, uiMessages }) => {
+      await onFinish({ messages: uiMessages ?? [] })
+      return new Response('ok')
+    }
+
+    const klavisRef = { handle: null as object | null }
+    const browser = {
+      resolveTabIds: mock(
+        async (tabIds: number[]) =>
+          new Map(tabIds.map((tabId) => [tabId, tabId + 100])),
+      ),
+      closePage: mock(async () => {}),
+    }
+    const service = new ChatService({
+      sessionStore: createSessionStore() as never,
+      klavisRef: klavisRef as never,
+      browser: browser as never,
+      browserSession: { pages: {} } as never,
+      browserUseNewTools: false,
+    })
+    const createCallsBefore = createAgentSpy.mock.calls.length
+    const request = {
+      conversationId: crypto.randomUUID(),
+      message: 'check integrations',
+      isScheduledTask: false,
+      mode: 'agent',
+      origin: 'sidepanel',
+      browserContext: {
+        activeTab: {
+          id: 3,
+          url: 'https://example.com',
+          title: 'Example',
+        },
+        enabledMcpServers: ['slack'],
+      },
+    } as never
+
+    await service.processMessage(request, new AbortController().signal)
+
+    agentToReturn = secondAgent
+    klavisRef.handle = {}
+
+    await service.processMessage(
+      { ...request, message: 'check integrations again' },
+      new AbortController().signal,
+    )
+
+    const createCalls = createAgentSpy.mock.calls.slice(createCallsBefore)
+    expect(createCalls).toHaveLength(2)
+    for (const [config] of createCalls) {
+      expect(config).toMatchObject({
+        browser,
+        browserUseNewTools: false,
+      })
+    }
+  })
+})
+
 describe('ChatService Klavis session rebuilds', () => {
   it('rebuilds a managed-app session when the shared Klavis handle appears', async () => {
     const firstAgent = createFakeAgent()
@@ -565,7 +628,6 @@ describe('ChatService ACP provider chat history handling', () => {
           // The new code never includes this in promptUiMessages.
           {
             type: 'tool-mcp.browseros.grep',
-            // biome-ignore lint/suspicious/noExplicitAny: synthetic phantom shape
             toolCallId: 'acpx-3',
             state: 'input-streaming',
             input: undefined,

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -4,8 +4,14 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { TOOL_LIMITS } from '@browseros/shared/constants/limits'
 import { z } from 'zod'
-import { CHAT_MODE_ALLOWED_TOOLS } from '../../../src/agent/chat-mode'
-import { buildBrowserToolSet } from '../../../src/agent/tool-adapter'
+import {
+  CHAT_MODE_ALLOWED_TOOLS,
+  LEGACY_CHAT_MODE_ALLOWED_TOOLS,
+} from '../../../src/agent/chat-mode'
+import {
+  buildBrowserToolSet,
+  buildLegacyBrowserToolSet,
+} from '../../../src/agent/tool-adapter'
 import type { BrowserSession } from '../../../src/browser/core/session'
 import {
   defineTool,
@@ -673,6 +679,43 @@ describe('registerBrowserTools', () => {
 })
 
 describe('buildBrowserToolSet', () => {
+  it('builds the compact browser tool surface', () => {
+    const session = { pages: {} } as unknown as BrowserSession
+    const tools = buildBrowserToolSet(session)
+
+    expect(tools.tabs).toBeDefined()
+    expect(tools.new_page).toBeUndefined()
+    expect(Object.keys(tools)).toEqual(BROWSER_TOOLS.map((t) => t.name))
+  })
+
+  it('builds the legacy browser tool surface', () => {
+    const tools = buildLegacyBrowserToolSet({} as never)
+
+    expect(tools.new_page).toBeDefined()
+    expect(tools.get_bookmarks).toBeDefined()
+    expect(tools.browseros_info).toBeDefined()
+    expect(tools.tabs).toBeUndefined()
+    expect(Object.keys(tools).length).toBeGreaterThan(50)
+  })
+
+  it('uses legacy tool names for legacy chat-mode filtering', () => {
+    const legacyTools = buildLegacyBrowserToolSet({} as never)
+    const chatTools = Object.fromEntries(
+      Object.entries(legacyTools).filter(([name]) =>
+        LEGACY_CHAT_MODE_ALLOWED_TOOLS.has(name),
+      ),
+    )
+
+    expect(Object.keys(chatTools).sort()).toEqual([
+      'evaluate_script',
+      'get_page_content',
+      'list_pages',
+      'scroll',
+      'take_snapshot',
+    ])
+    expect(chatTools.tabs).toBeUndefined()
+  })
+
   it('allows chat mode to list tabs without allowing tab mutation', async () => {
     expect(CHAT_MODE_ALLOWED_TOOLS.has('tabs')).toBe(true)
     const calls: string[] = []


### PR DESCRIPTION
## Summary
- Thread parsed `browserUseNewTools` from server startup into the `/chat` route and `ChatService`.
- Let model-backed `AiSdkAgent` sessions choose legacy browser tools by default and compact tools only when explicitly enabled.
- Preserve ACP providers on the MCP boundary and keep eval direct callers on the compact surface explicitly.

## Design
`AiSdkAgent` remains the tool composition point. It now receives both `Browser` and `BrowserSession`, chooses the legacy or compact AI SDK adapter from the parsed config flag, and applies the matching chat-mode allowlist for that tool surface.

## Test plan
- [x] `cd apps/server && bun test tests/tools/browser/register.test.ts`
- [x] `cd apps/server && bun test tests/api/services/chat-service.test.ts`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test:main`