### PR TITLE
fix: avoid runtime message format collisions

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/auth.content/index.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/auth.content/index.ts
@@ -1,4 +1,8 @@
 import { env } from '@/lib/env'
+import {
+  RuntimeMessageType,
+  sendRuntimeMessage,
+} from '@/lib/messaging/runtime/runtimeMessages'
 
 export default defineContentScript({
   matches: [`${env.VITE_PUBLIC_BROWSEROS_API}/home`],
@@ -6,7 +10,7 @@ export default defineContentScript({
   main() {
     window.addEventListener('message', (event) => {
       if (event.data?.type === 'AUTH_SUCCESS') {
-        chrome.runtime.sendMessage({ type: 'AUTH_SUCCESS' })
+        void sendRuntimeMessage(RuntimeMessageType.authSuccess)
       }
     })
   },

--- a/packages/browseros-agent/apps/agent/entrypoints/background/index.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/background/index.ts
@@ -10,6 +10,10 @@ import {
   syncLlmProviders,
 } from '@/lib/llm-providers/storage'
 import { fetchMcpTools } from '@/lib/mcp/client'
+import {
+  onRuntimeMessage,
+  RuntimeMessageType,
+} from '@/lib/messaging/runtime/runtimeMessages'
 import { onServerMessage } from '@/lib/messaging/server/serverMessages'
 import { onOpenSidePanelWithSearch } from '@/lib/messaging/sidepanel/openSidepanelWithSearch'
 import { authRedirectPathStorage } from '@/lib/onboarding/onboardingStorage'
@@ -83,39 +87,36 @@ export default defineBackground(() => {
     }
   })
 
-  chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
-    if (message?.type === 'get-tab-id') {
-      sendResponse({ tabId: sender.tab?.id })
-      return true
-    }
+  onRuntimeMessage(RuntimeMessageType.getTabId, ({ sender }) => {
+    return { tabId: sender.tab?.id }
+  })
 
-    if (message?.type === 'AUTH_SUCCESS' && sender.tab?.id) {
-      const tabId = sender.tab.id
-      authRedirectPathStorage
-        .getValue()
-        .then((redirectPath) => {
-          const hash = redirectPath || '/home'
-          chrome.tabs.update(tabId, {
-            url: chrome.runtime.getURL(`app.html#${hash}`),
-          })
-          if (redirectPath) authRedirectPathStorage.removeValue()
-        })
-        .catch(() => {
-          chrome.tabs.update(tabId, {
-            url: chrome.runtime.getURL('app.html#/home'),
-          })
-        })
-    }
+  onRuntimeMessage(RuntimeMessageType.authSuccess, async ({ sender }) => {
+    if (!sender.tab?.id) return
 
-    if (message?.type === 'stop-agent' && message?.conversationId) {
-      stopAgentStorage.setValue({
-        conversationId: message.conversationId,
-        timestamp: Date.now(),
+    const tabId = sender.tab.id
+
+    try {
+      const redirectPath = await authRedirectPathStorage.getValue()
+      const hash = redirectPath || '/home'
+      await chrome.tabs.update(tabId, {
+        url: chrome.runtime.getURL(`app.html#${hash}`),
+      })
+      if (redirectPath) await authRedirectPathStorage.removeValue()
+    } catch {
+      await chrome.tabs.update(tabId, {
+        url: chrome.runtime.getURL('app.html#/home'),
       })
     }
   })
 
-  // Clean up selected text storage when a tab is closed
+  onRuntimeMessage(RuntimeMessageType.stopAgent, async ({ data }) => {
+    await stopAgentStorage.setValue({
+      conversationId: data.conversationId,
+      timestamp: Date.now(),
+    })
+  })
+
   chrome.tabs.onRemoved.addListener((tabId) => {
     const key = String(tabId)
     selectedTextStorage.getValue().then((map) => {

--- a/packages/browseros-agent/apps/agent/entrypoints/glow.content/index.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/glow.content/index.ts
@@ -1,4 +1,8 @@
 import confetti from 'canvas-confetti'
+import {
+  RuntimeMessageType,
+  sendRuntimeMessage,
+} from '@/lib/messaging/runtime/runtimeMessages'
 import type { GlowMessage } from './GlowMessage'
 
 const GLOW_OVERLAY_ID = 'browseros-glow-overlay'
@@ -119,8 +123,7 @@ function startGlow(): void {
     '<svg width="16" height="16" viewBox="0 0 16 16" fill="white" xmlns="http://www.w3.org/2000/svg"><rect x="1" y="1" width="14" height="14" rx="2"/></svg>'
   button.addEventListener('click', () => {
     if (activeConversationId) {
-      browser.runtime.sendMessage({
-        type: 'stop-agent',
+      void sendRuntimeMessage(RuntimeMessageType.stopAgent, {
         conversationId: activeConversationId,
       })
     }

--- a/packages/browseros-agent/apps/agent/entrypoints/selection.content.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/selection.content.ts
@@ -1,3 +1,7 @@
+import {
+  RuntimeMessageType,
+  sendRuntimeMessage,
+} from '@/lib/messaging/runtime/runtimeMessages'
 import { selectedTextStorage } from '@/lib/selected-text/selectedTextStorage'
 
 const MAX_SELECTED_TEXT_LENGTH = 5000
@@ -6,7 +10,7 @@ export default defineContentScript({
   matches: ['*://*/*'],
   runAt: 'document_idle',
   async main() {
-    const response = await chrome.runtime.sendMessage({ type: 'get-tab-id' })
+    const response = await sendRuntimeMessage(RuntimeMessageType.getTabId)
     const tabId: number | undefined = response?.tabId
     if (!tabId) return
 
@@ -29,7 +33,6 @@ export default defineContentScript({
           })
         })
       } else {
-        // User clicked without selecting — clear this tab's entry only
         selectedTextStorage.getValue().then((map) => {
           if (map[key]) {
             const { [key]: _, ...rest } = map

--- a/packages/browseros-agent/apps/agent/lib/messaging/runtime/runtimeMessages.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/messaging/runtime/runtimeMessages.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import type {
+  RuntimeStopAgentData,
+  RuntimeTabIdResponse,
+} from './runtimeMessages'
+
+const readAgentFile = (path: string) =>
+  readFileSync(new URL(`../../../${path}`, import.meta.url), 'utf8')
+
+describe('runtime message protocol', () => {
+  it('uses namespaced typed message names instead of legacy raw types', () => {
+    const source = readAgentFile('lib/messaging/runtime/runtimeMessages.ts')
+
+    expect(source).toContain("getTabId: 'runtime.getTabId'")
+    expect(source).toContain("authSuccess: 'runtime.authSuccess'")
+    expect(source).toContain("stopAgent: 'runtime.stopAgent'")
+    expect(source).not.toContain("'get-tab-id'")
+    expect(source).not.toContain("'AUTH_SUCCESS'")
+    expect(source).not.toContain("'stop-agent'")
+  })
+
+  it('keeps the vulnerable content scripts off raw runtime message shapes', () => {
+    const files = [
+      'entrypoints/selection.content.ts',
+      'entrypoints/auth.content/index.ts',
+      'entrypoints/glow.content/index.ts',
+    ]
+
+    for (const file of files) {
+      expect(readAgentFile(file)).not.toMatch(
+        /(?:chrome|browser)\.runtime\.sendMessage\(\s*\{\s*type\s*:/,
+      )
+    }
+  })
+
+  it('keeps background handling off the legacy raw runtime listener', () => {
+    const source = readAgentFile('entrypoints/background/index.ts')
+
+    expect(source).not.toContain('chrome.runtime.onMessage.addListener')
+    expect(source).not.toContain("message?.type === 'get-tab-id'")
+    expect(source).not.toContain("message?.type === 'AUTH_SUCCESS'")
+    expect(source).not.toContain("message?.type === 'stop-agent'")
+  })
+
+  it('keeps the stop-agent and tab-id payload contracts explicit', () => {
+    const stopAgent = {
+      conversationId: 'conversation-1',
+    } satisfies RuntimeStopAgentData
+    const tabId = { tabId: 123 } satisfies RuntimeTabIdResponse
+
+    expect(stopAgent.conversationId).toBe('conversation-1')
+    expect(tabId.tabId).toBe(123)
+  })
+})

--- a/packages/browseros-agent/apps/agent/lib/messaging/runtime/runtimeMessages.ts
+++ b/packages/browseros-agent/apps/agent/lib/messaging/runtime/runtimeMessages.ts
@@ -1,0 +1,26 @@
+import { defineExtensionMessaging } from '@webext-core/messaging'
+
+export const RuntimeMessageType = {
+  getTabId: 'runtime.getTabId',
+  authSuccess: 'runtime.authSuccess',
+  stopAgent: 'runtime.stopAgent',
+} as const
+
+export interface RuntimeTabIdResponse {
+  tabId?: number
+}
+
+export interface RuntimeStopAgentData {
+  conversationId: string
+}
+
+type RuntimeMessagesProtocol = {
+  [RuntimeMessageType.getTabId](): RuntimeTabIdResponse
+  [RuntimeMessageType.authSuccess](): void
+  [RuntimeMessageType.stopAgent](data: RuntimeStopAgentData): void
+}
+
+const { sendMessage, onMessage } =
+  defineExtensionMessaging<RuntimeMessagesProtocol>()
+
+export { onMessage as onRuntimeMessage, sendMessage as sendRuntimeMessage }


### PR DESCRIPTION
## Summary
- Add a typed internal runtime messaging protocol for content-to-background events.
- Migrate selected-text tab id lookup, auth success routing, and glow stop-agent signaling off raw runtime `{ type: ... }` messages.
- Add focused regression coverage for the typed protocol and vulnerable raw-message call sites.

## Design
The fix follows the existing `defineExtensionMessaging` wrapper pattern, keeping the behavior in the background entrypoint while ensuring these messages use the same envelope expected by `@webext-core/messaging`.

## Test plan
- [x] `cd apps/agent && bun test lib/messaging/runtime/runtimeMessages.test.ts`
- [x] `cd apps/agent && bun run typecheck`
- [x] `cd apps/agent && bun run test`
- [x] `cd apps/agent && bun run lint`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run build:agent`