### PR TITLE
test: pin Klavis MCP live refresh

### DIFF
--- a/packages/browseros-agent/apps/server/tests/api/routes/mcp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/mcp.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import type {
+  KlavisProxyHandle,
+  KlavisProxyRef,
+} from '../../../src/api/services/klavis/strata-proxy'
+
+interface McpServerCreation {
+  handleAtCreate: KlavisProxyHandle | null
+}
+
+const serverCreations: McpServerCreation[] = []
+const transportInstances: FakeTransport[] = []
+const connectCalls: FakeTransport[] = []
+
+class FakeTransport {
+  constructor(readonly options: unknown) {
+    transportInstances.push(this)
+  }
+
+  handleRequest = mock(async () => Response.json({ ok: true }))
+}
+
+const createMcpServerSpy = mock((deps: { klavisRef?: KlavisProxyRef }) => {
+  serverCreations.push({
+    handleAtCreate: deps.klavisRef?.handle ?? null,
+  })
+
+  return {
+    connect: mock(async (transport: FakeTransport) => {
+      connectCalls.push(transport)
+    }),
+  }
+})
+
+mock.module('@hono/mcp', () => ({
+  StreamableHTTPTransport: FakeTransport,
+}))
+
+mock.module('../../../src/api/services/mcp/mcp-server', () => ({
+  createMcpServer: createMcpServerSpy,
+}))
+
+const { createMcpRoutes } = await import('../../../src/api/routes/mcp')
+
+beforeEach(() => {
+  serverCreations.length = 0
+  transportInstances.length = 0
+  connectCalls.length = 0
+})
+
+function createConnectedHandle(): KlavisProxyHandle {
+  return {
+    browserosId: 'browseros-user-1',
+    tools: [],
+    inputSchemas: new Map(),
+    callTool: mock(async () => ({ content: [] })),
+    close: mock(async () => {}),
+  }
+}
+
+async function postMcp(app: ReturnType<typeof createMcpRoutes>) {
+  return app.request('/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+    }),
+  })
+}
+
+describe('createMcpRoutes', () => {
+  it('uses the latest Klavis handle when building each MCP request server', async () => {
+    const klavisRef: KlavisProxyRef = { handle: null }
+    const app = createMcpRoutes({
+      version: '0.0.0-test',
+      browser: {} as never,
+      browserSession: {} as never,
+      klavisRef,
+      browserUseNewTools: true,
+    })
+
+    const first = await postMcp(app)
+
+    const connectedHandle = createConnectedHandle()
+    klavisRef.handle = connectedHandle
+
+    const second = await postMcp(app)
+
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(200)
+    expect(serverCreations.map((creation) => creation.handleAtCreate)).toEqual([
+      null,
+      connectedHandle,
+    ])
+    expect(transportInstances).toHaveLength(2)
+    expect(connectCalls).toEqual(transportInstances)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds route-level regression coverage for `/mcp` request-time server construction.
- Pins that a second MCP POST sees `klavisRef.handle` after the background Klavis connection completes.
- Guards against a future global MCP server freezing an earlier null Klavis state.

## Design
The test mocks the MCP server factory and HTTP transport, sends two POSTs through the real Hono route, mutates the shared `klavisRef` between requests, and asserts the second request builds a fresh server with the connected handle.

## Test plan
- [x] `bun --env-file=apps/server/.env.development test --preload=./apps/server/tests/__helpers__/test-env.ts apps/server/tests/api/routes/mcp.test.ts`
- [x] `bunx biome check apps/server/tests/api/routes/mcp.test.ts`
- [x] `bun run --filter @browseros/server test:api`
- [x] `bun run --filter @browseros/server typecheck`