### PR TITLE
feat: add metrics sampling option

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/routes/chat.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/chat.ts
@@ -13,6 +13,8 @@ import type { RemoteHermesService } from '../services/remote-hermes/remote-herme
 import { ChatRequestSchema } from '../types'
 import { ConversationIdParamSchema } from '../utils/validation'
 
+const CHAT_REQUEST_METRIC_SAMPLE_RATE = 1 / 5
+
 interface ChatRouteDeps {
   browser: Browser
   browserSession: BrowserSession
@@ -71,10 +73,16 @@ export function createChatRoutes(deps: ChatRouteDeps) {
           : undefined,
       })
 
-      metrics.log('chat.request', {
-        provider: request.provider,
-        model: request.model,
-      })
+      metrics.log(
+        'chat.request',
+        {
+          provider: request.provider,
+          model: request.model,
+        },
+        {
+          sampling: CHAT_REQUEST_METRIC_SAMPLE_RATE,
+        },
+      )
 
       logger.info('Chat request received', {
         conversationId: request.conversationId,

--- a/packages/browseros-agent/apps/server/src/lib/metrics.ts
+++ b/packages/browseros-agent/apps/server/src/lib/metrics.ts
@@ -63,6 +63,10 @@ interface RollupBucket {
   tool_executions: ToolExecCounters
 }
 
+interface MetricsLogOptions {
+  sampling?: number
+}
+
 class RollupBuffer {
   private current: RollupBucket | null = null
 
@@ -139,6 +143,11 @@ function defaultAlignedNow(): number {
   return Math.floor(Date.now() / ROLLUP_INTERVAL_MS) * ROLLUP_INTERVAL_MS
 }
 
+function normalizeSampling(sampling: number | undefined): number {
+  if (sampling === undefined || !Number.isFinite(sampling)) return 1
+  return Math.min(Math.max(sampling, 0), 1)
+}
+
 class MetricsService {
   private client: PostHog | null = null
   private config: MetricsConfig | null = null
@@ -165,7 +174,12 @@ class MetricsService {
     return this.config?.client_id ?? null
   }
 
-  log(eventName: string, properties: Record<string, unknown> = {}): void {
+  /** Records one metrics event, aggregating known noisy events before immediate capture. */
+  log(
+    eventName: string,
+    properties: Record<string, unknown> = {},
+    options: MetricsLogOptions = {},
+  ): void {
     if (!this.client || !this.config) {
       return
     }
@@ -185,7 +199,14 @@ class MetricsService {
       return
     }
 
-    this.captureNow(eventName, properties)
+    const sampleRate = normalizeSampling(options.sampling)
+    if (sampleRate <= 0) return
+    if (sampleRate < 1 && Math.random() >= sampleRate) return
+
+    this.captureNow(
+      eventName,
+      sampleRate < 1 ? { ...properties, sample_rate: sampleRate } : properties,
+    )
   }
 
   async shutdown(): Promise<void> {

--- a/packages/browseros-agent/apps/server/tests/lib/metrics.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/metrics.test.ts
@@ -39,6 +39,16 @@ const {
   RollupBuffer,
 } = __internal__
 
+function withRandom<T>(value: number, fn: () => T): T {
+  const original = Math.random
+  Math.random = () => value
+  try {
+    return fn()
+  } finally {
+    Math.random = original
+  }
+}
+
 beforeEach(async () => {
   // Drain whatever's left in the singleton RollupBuffer + PostHog
   // client from a prior test so each test is hermetic. shutdown nulls
@@ -159,6 +169,24 @@ describe('MetricsService — log dispatch', () => {
     expect(captureCalls[0]?.distinctId).toBe('client-a')
   })
 
+  it('captures sampled non-aggregated events when selected', () => {
+    metrics.initialize({ client_id: 'client-a' })
+    withRandom(0.49, () => {
+      metrics.log('chat.request', { mode: 'agent' }, { sampling: 0.5 })
+    })
+    expect(captureCalls).toHaveLength(1)
+    expect(captureCalls[0]?.properties.mode).toBe('agent')
+    expect(captureCalls[0]?.properties.sample_rate).toBe(0.5)
+  })
+
+  it('skips sampled non-aggregated events when not selected', () => {
+    metrics.initialize({ client_id: 'client-a' })
+    withRandom(0.5, () => {
+      metrics.log('chat.request', { mode: 'agent' }, { sampling: 0.5 })
+    })
+    expect(captureCalls).toHaveLength(0)
+  })
+
   it('skips emit entirely when no identity is configured', () => {
     // No client_id, no install_id → captureNow should short-circuit.
     metrics.initialize({})
@@ -174,6 +202,19 @@ describe('MetricsService — log dispatch', () => {
     // means the emit on the underlying captureNow is also skipped.
     await metrics.shutdown()
     expect(captureCalls).toHaveLength(0)
+  })
+
+  it('does not sample rollup inputs', async () => {
+    metrics.initialize({ client_id: 'client-a' })
+    withRandom(0.99, () => {
+      metrics.log('mcp.request', {}, { sampling: 0 })
+    })
+
+    await metrics.shutdown()
+
+    expect(captureCalls).toHaveLength(1)
+    expect(captureCalls[0]?.event).toBe('browseros.server.usage_rollup')
+    expect(captureCalls[0]?.properties.mcp_requests_count).toBe(1)
   })
 })
 


### PR DESCRIPTION
## Summary
- Add a third `metrics.log` options argument for local event sampling.
- Keep aggregated `mcp.request` and `tool_executed` rollups exact.
- Sample `chat.request` metrics at `1 / 5` and tag captured sampled events with `sample_rate`.

## Design
Sampling is per-call and only applies to immediate captures after the existing rollup checks. Missing or invalid sampling values preserve full capture, so existing call sites remain unchanged unless they opt in.

## Test plan
- [x] bun test apps/server/tests/lib/metrics.test.ts
- [x] bunx biome check apps/server/src/lib/metrics.ts apps/server/src/api/routes/chat.ts apps/server/tests/lib/metrics.test.ts
- [x] bun run typecheck
- [x] bun run test:main