### PR TITLE
fix: sample MCP registration logs

### DIFF
--- a/packages/browseros-agent/apps/server/src/tools/browser/register.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/register.ts
@@ -3,6 +3,7 @@ import type { ZodRawShape } from 'zod'
 import type { BrowserSession } from '../../browser/core/session'
 import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
+import { shouldLogToolRegistration } from '../registration-log-sampling'
 import { executeTool } from './framework'
 import { BROWSER_TOOLS } from './registry'
 
@@ -88,7 +89,9 @@ export function registerBrowserTools(
     )
   }
 
-  logger.info(
-    `Registered ${BROWSER_TOOLS.length} browser tools: ${BROWSER_TOOLS.map((t) => t.name).join(', ')}`,
-  )
+  if (shouldLogToolRegistration()) {
+    logger.info(
+      `Registered ${BROWSER_TOOLS.length} browser tools: ${BROWSER_TOOLS.map((t) => t.name).join(', ')}`,
+    )
+  }
 }

--- a/packages/browseros-agent/apps/server/src/tools/legacy/register.ts
+++ b/packages/browseros-agent/apps/server/src/tools/legacy/register.ts
@@ -3,6 +3,7 @@ import { type ZodRawShape, z } from 'zod'
 import type { Browser } from '../../browser/browser'
 import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
+import { shouldLogToolRegistration } from '../registration-log-sampling'
 import { executeTool, type ToolDefinition } from './framework'
 import { registry } from './registry'
 
@@ -92,7 +93,9 @@ export function registerLegacyBrowserTools(
     )
   }
 
-  logger.info(
-    `Registered ${tools.length} legacy browser tools: ${tools.map((t) => t.name).join(', ')}`,
-  )
+  if (shouldLogToolRegistration()) {
+    logger.info(
+      `Registered ${tools.length} legacy browser tools: ${tools.map((t) => t.name).join(', ')}`,
+    )
+  }
 }

--- a/packages/browseros-agent/apps/server/src/tools/registration-log-sampling.ts
+++ b/packages/browseros-agent/apps/server/src/tools/registration-log-sampling.ts
@@ -1,0 +1,12 @@
+const REGISTRATION_LOG_SAMPLE_RATE = 10
+let registrationLogEvents = 0
+
+/** Samples noisy tool-registration info logs while keeping a startup breadcrumb. */
+export function shouldLogToolRegistration(): boolean {
+  registrationLogEvents += 1
+  return (registrationLogEvents - 1) % REGISTRATION_LOG_SAMPLE_RATE === 0
+}
+
+export function resetToolRegistrationLogSamplingForTests(): void {
+  registrationLogEvents = 0
+}

--- a/packages/browseros-agent/apps/server/tests/api/services/mcp/register-mcp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/mcp/register-mcp.test.ts
@@ -1,7 +1,9 @@
-import { describe, expect, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { registerTools } from '../../../../src/api/services/mcp/register-mcp'
 import type { BrowserSession } from '../../../../src/browser/core/session'
+import { logger } from '../../../../src/lib/logger'
 import { BROWSER_TOOLS } from '../../../../src/tools/browser/registry'
+import { resetToolRegistrationLogSamplingForTests } from '../../../../src/tools/registration-log-sampling'
 
 type RegisteredHandler = (
   args: Record<string, unknown>,
@@ -36,6 +38,22 @@ function createFakeServer() {
 }
 
 describe('registerTools', () => {
+  const originalInfo = logger.info
+  let infoMessages: unknown[] = []
+
+  beforeEach(() => {
+    resetToolRegistrationLogSamplingForTests()
+    infoMessages = []
+    logger.info = ((message: string) => {
+      infoMessages.push(message)
+    }) as typeof logger.info
+  })
+
+  afterEach(() => {
+    logger.info = originalInfo
+    resetToolRegistrationLogSamplingForTests()
+  })
+
   it('registers the legacy browser tools by default', () => {
     const fake = createFakeServer()
 
@@ -48,6 +66,33 @@ describe('registerTools', () => {
     expect(fake.handlers.has('new_page')).toBe(true)
     expect(fake.handlers.has('get_bookmarks')).toBe(true)
     expect(fake.handlers.has('browseros_info')).toBe(true)
+  })
+
+  it('samples repeated registration info logs without skipping tool registration', () => {
+    for (let i = 0; i < 20; i++) {
+      const fake = createFakeServer()
+      registerTools(fake.server as never, {
+        browser: {} as never,
+        browserSession: { pages: {} } as unknown as BrowserSession,
+        useNewTools: i < 5,
+      })
+
+      if (i === 1) {
+        expect(fake.handlers.has('tabs')).toBe(true)
+        expect(fake.handlers.has('new_page')).toBe(false)
+      }
+      if (i === 10) {
+        expect(fake.handlers.has('tabs')).toBe(false)
+        expect(fake.handlers.has('new_page')).toBe(true)
+      }
+    }
+
+    expect(infoMessages).toHaveLength(2)
+    expect(infoMessages).toEqual([
+      expect.stringContaining('Registered 10 browser tools'),
+      expect.stringContaining('Registered'),
+    ])
+    expect(String(infoMessages[1])).toContain('legacy browser tools')
   })
 
   it('registers the new compact browser tools when explicitly enabled', () => {

--- a/packages/browseros-agent/apps/server/tests/api/services/mcp/register-mcp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/mcp/register-mcp.test.ts
@@ -71,28 +71,42 @@ describe('registerTools', () => {
   it('samples repeated registration info logs without skipping tool registration', () => {
     for (let i = 0; i < 20; i++) {
       const fake = createFakeServer()
+      const useNewTools = i % 2 === 0
       registerTools(fake.server as never, {
         browser: {} as never,
         browserSession: { pages: {} } as unknown as BrowserSession,
-        useNewTools: i < 5,
+        useNewTools,
       })
 
       if (i === 1) {
-        expect(fake.handlers.has('tabs')).toBe(true)
-        expect(fake.handlers.has('new_page')).toBe(false)
-      }
-      if (i === 10) {
         expect(fake.handlers.has('tabs')).toBe(false)
         expect(fake.handlers.has('new_page')).toBe(true)
+      }
+      if (i === 2) {
+        expect(fake.handlers.has('tabs')).toBe(true)
+        expect(fake.handlers.has('new_page')).toBe(false)
       }
     }
 
     expect(infoMessages).toHaveLength(2)
     expect(infoMessages).toEqual([
       expect.stringContaining('Registered 10 browser tools'),
-      expect.stringContaining('Registered'),
+      expect.stringContaining('Registered 10 browser tools'),
     ])
-    expect(String(infoMessages[1])).toContain('legacy browser tools')
+  })
+
+  it('keeps the legacy registration info log available when sampled in', () => {
+    const fake = createFakeServer()
+
+    registerTools(fake.server as never, {
+      browser: {} as never,
+      browserSession: { pages: {} } as unknown as BrowserSession,
+      useNewTools: false,
+    })
+
+    expect(infoMessages).toEqual([
+      expect.stringContaining('legacy browser tools'),
+    ])
   })
 
   it('registers the new compact browser tools when explicitly enabled', () => {


### PR DESCRIPTION
## Summary
- Sample the noisy browser tool registration info logs at one out of every ten registration events.
- Apply the same shared sampler to compact and legacy MCP browser tool registration.
- Add MCP selector tests covering sampled-out compact and legacy registrations.

## Design
A small module-level counter gates the existing registration log calls after handler registration completes. The first event still logs as a startup breadcrumb, then every tenth event logs after that; tool registration and metrics behavior stay unchanged.

## Test plan
- [x] cd apps/server && bun test tests/api/services/mcp/register-mcp.test.ts tests/tools/browser/register.test.ts
- [x] cd apps/server && bun run typecheck
- [x] bun run lint (exit 0; existing unrelated warnings remain)
- [x] bun run typecheck
- [x] bun run build:agent
- [x] codex review round 2: clean