### PR TITLE
chore: update ChatGPT Plus/Pro models

### DIFF
--- a/docs/features/chatgpt-pro-oauth.mdx
+++ b/docs/features/chatgpt-pro-oauth.mdx
@@ -3,7 +3,7 @@ title: "ChatGPT Pro / Plus"
 description: "Use your ChatGPT subscription to power BrowserOS"
 ---
 
-Connect your ChatGPT Pro or Plus subscription to BrowserOS and access GPT-5 Codex, GPT-5.4, and the full lineup of OpenAI's most advanced models — with up to 400K context. No API keys needed.
+Connect your ChatGPT Pro or Plus subscription to BrowserOS and access GPT-5.5, GPT-5 Codex, GPT-5.4, and the full lineup of OpenAI's most advanced models — with up to 1.05M context. No API keys needed.
 
 ## Setup
 
@@ -25,8 +25,12 @@ Connect your ChatGPT Pro or Plus subscription to BrowserOS and access GPT-5 Code
 
 | Model | Context Window |
 |-------|---------------|
+| `gpt-5.5` | 1.05M |
 | `gpt-5.4` | 400K |
+| `gpt-5.4-mini` | 400K |
+| `gpt-5.4-nano` | 400K |
 | `gpt-5.3-codex` | 400K |
+| `gpt-5.3-codex-spark` | 128K |
 | `gpt-5.2-codex` | 400K |
 | `gpt-5.2` | 200K |
 | `gpt-5.1-codex` | 400K |

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/providerTemplates.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/providerTemplates.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'bun:test'
+import { providerTemplates } from './providerTemplates'
+
+describe('providerTemplates', () => {
+  it('uses GPT-5.5 for new ChatGPT Plus/Pro providers', () => {
+    const template = providerTemplates.find(
+      (provider) => provider.id === 'chatgpt-pro',
+    )
+
+    expect(template).toMatchObject({
+      defaultModelId: 'gpt-5.5',
+      contextWindow: 1050000,
+    })
+  })
+})

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/providerTemplates.ts
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/providerTemplates.ts
@@ -57,9 +57,9 @@ export const providerTemplates: ProviderTemplate[] = [
     id: 'chatgpt-pro',
     name: 'ChatGPT Plus/Pro',
     defaultBaseUrl: 'https://chatgpt.com/backend-api',
-    defaultModelId: 'gpt-5.3-codex',
+    defaultModelId: 'gpt-5.5',
     supportsImages: true,
-    contextWindow: 400000,
+    contextWindow: 1050000,
     setupGuideUrl: 'https://docs.browseros.com/features/chatgpt-pro-oauth',
   },
   {

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/models.test.ts
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/models.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'bun:test'
+import { getModelContextLength, getModelsForProvider } from './models'
+
+describe('ChatGPT Plus/Pro models', () => {
+  it('offers GPT-5.5 as the default first choice', () => {
+    const models = getModelsForProvider('chatgpt-pro')
+
+    expect(models[0]).toEqual({
+      modelId: 'gpt-5.5',
+      contextLength: 1050000,
+    })
+    expect(getModelContextLength('chatgpt-pro', 'gpt-5.5')).toBe(1050000)
+  })
+
+  it('includes current GPT-5.4 low-latency variants', () => {
+    expect(getModelContextLength('chatgpt-pro', 'gpt-5.4-mini')).toBe(400000)
+    expect(getModelContextLength('chatgpt-pro', 'gpt-5.4-nano')).toBe(400000)
+  })
+})

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/models.ts
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/models.ts
@@ -1,8 +1,8 @@
 import {
   getModelsDevModels,
   type ModelsDevModel,
-} from '@/lib/llm-providers/models-dev'
-import type { ProviderType } from '@/lib/llm-providers/types'
+} from '../../lib/llm-providers/models-dev'
+import type { ProviderType } from '../../lib/llm-providers/types'
 
 export interface ModelInfo {
   modelId: string
@@ -17,8 +17,12 @@ const CUSTOM_PROVIDER_MODELS: Partial<Record<ProviderType, ModelInfo[]>> = {
   'openai-compatible': [],
   ollama: [],
   'chatgpt-pro': [
+    { modelId: 'gpt-5.5', contextLength: 1050000 },
     { modelId: 'gpt-5.4', contextLength: 400000 },
+    { modelId: 'gpt-5.4-mini', contextLength: 400000 },
+    { modelId: 'gpt-5.4-nano', contextLength: 400000 },
     { modelId: 'gpt-5.3-codex', contextLength: 400000 },
+    { modelId: 'gpt-5.3-codex-spark', contextLength: 128000 },
     { modelId: 'gpt-5.2-codex', contextLength: 400000 },
     { modelId: 'gpt-5.2', contextLength: 200000 },
     { modelId: 'gpt-5.1-codex', contextLength: 400000 },

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/config.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/config.ts
@@ -26,7 +26,7 @@ export async function resolveLLMConfig(
     return resolveOAuthConfig(config, browserosId, {
       providerId: 'chatgpt-pro',
       displayName: 'ChatGPT Plus/Pro',
-      defaultModel: 'gpt-5.3-codex',
+      defaultModel: 'gpt-5.5',
       useRefresh: true,
       extraFields: (tokens) => ({
         upstreamProvider: 'openai',

--- a/packages/browseros-agent/apps/server/tests/__helpers__/browser.ts
+++ b/packages/browseros-agent/apps/server/tests/__helpers__/browser.ts
@@ -10,6 +10,9 @@ import { spawn, spawnSync } from 'node:child_process'
 import { rmSync } from 'node:fs'
 
 const TEST_USER_DATA_PREFIX = 'browseros-test-'
+// Keep teardown below Bun's default 5s hook timeout.
+const BROWSER_EXIT_GRACE_MS = 1_500
+const BROWSER_FORCED_EXIT_MS = 1_000
 
 export interface BrowserConfig {
   cdpPort: number
@@ -60,13 +63,15 @@ export function getBrowserState(): BrowserState | null {
   return browserState
 }
 
-function killOrphanedTestBrowsers(): void {
+function killOrphanedTestBrowsers(
+  message = 'Killed orphaned test browsers from a previous run',
+): void {
   // Matches only BrowserOS processes launched with a test user-data-dir
   // (e.g., /var/folders/.../browseros-test-XXXX). Never matches a dev
   // BrowserOS run from ~/Library/Application Support/BrowserOS.
   const result = spawnSync('pkill', ['-9', '-f', TEST_USER_DATA_PREFIX])
   if (result.status === 0) {
-    console.log('Killed orphaned test browsers from a previous run')
+    console.log(message)
   }
 }
 
@@ -103,7 +108,7 @@ export async function spawnBrowser(
       ...(config.headless ? ['--headless=new'] : []),
       ...config.extraArgs,
       `--user-data-dir=${config.userDataDir}`,
-      // TODO: replace with --browseros-cdp-port once we fix the browseros bug
+      // BrowserOS tests still need Chromium's remote debugging flag here.
       `--remote-debugging-port=${config.cdpPort}`,
       `--browseros-mcp-port=${config.serverPort}`,
       `--browseros-extension-port=${config.extensionPort}`,
@@ -144,32 +149,51 @@ export async function spawnBrowser(
   return browserState
 }
 
+/** Stops the shared BrowserOS test process and removes its temp profile. */
 export async function killBrowser(): Promise<void> {
-  if (!browserState) {
+  const state = browserState
+  if (!state) {
     return
   }
 
   console.log('Shutting down BrowserOS...')
-  browserState.process.kill('SIGTERM')
+  state.process.kill('SIGTERM')
 
   await new Promise<void>((resolve) => {
-    const timeout = setTimeout(() => {
-      browserState?.process.kill('SIGKILL')
-      resolve()
-    }, 5000)
+    let settled = false
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    let forcedTimeout: ReturnType<typeof setTimeout> | undefined
 
-    browserState?.process.on('exit', () => {
-      clearTimeout(timeout)
+    const finish = () => {
+      if (settled) {
+        return
+      }
+
+      settled = true
+      if (timeout) clearTimeout(timeout)
+      if (forcedTimeout) clearTimeout(forcedTimeout)
+      state.process.off('exit', finish)
       resolve()
-    })
+    }
+
+    timeout = setTimeout(() => {
+      state.process.kill('SIGKILL')
+      forcedTimeout = setTimeout(finish, BROWSER_FORCED_EXIT_MS)
+    }, BROWSER_EXIT_GRACE_MS)
+
+    state.process.once('exit', finish)
+    if (state.process.exitCode !== null || state.process.signalCode !== null) {
+      finish()
+    }
   })
 
   console.log('BrowserOS stopped')
+  killOrphanedTestBrowsers('Killed dangling BrowserOS test processes')
 
-  if (browserState.userDataDir) {
-    console.log(`Cleaning up temp profile: ${browserState.userDataDir}`)
+  if (state.userDataDir) {
+    console.log(`Cleaning up temp profile: ${state.userDataDir}`)
     try {
-      rmSync(browserState.userDataDir, { recursive: true, force: true })
+      rmSync(state.userDataDir, { recursive: true, force: true })
     } catch (error) {
       console.error('Failed to clean up temp directory:', error)
     }

--- a/packages/browseros-agent/apps/server/tests/__helpers__/with-browser.ts
+++ b/packages/browseros-agent/apps/server/tests/__helpers__/with-browser.ts
@@ -69,8 +69,10 @@ async function getOrCreateBrowser(): Promise<Browser> {
   return cachedBrowser
 }
 
+/** Tears down the cached browser/CDP pair used by withBrowser tests. */
 export async function cleanupWithBrowser(): Promise<void> {
   await mutex.runExclusive(async () => {
+    await cachedCdp?.disconnect().catch(() => {})
     await killBrowser()
     cachedCdp = null
     cachedBrowser = null

--- a/packages/browseros-agent/apps/server/tests/lib/clients/llm/config.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/clients/llm/config.test.ts
@@ -1,0 +1,47 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
+
+const tokenManager = {
+  refreshIfExpired: mock(async () => ({
+    accessToken: 'access-token',
+    refreshToken: 'refresh-token',
+    expiresAt: Date.now() + 3600_000,
+    accountId: 'account-id',
+  })),
+}
+
+mock.module('../../../../src/lib/clients/oauth', () => ({
+  getOAuthTokenManager: () => tokenManager,
+}))
+
+const { resolveLLMConfig } = await import(
+  '../../../../src/lib/clients/llm/config'
+)
+
+describe('resolveLLMConfig', () => {
+  beforeEach(() => {
+    tokenManager.refreshIfExpired.mockClear()
+  })
+
+  it('defaults ChatGPT Plus/Pro OAuth providers to GPT-5.5', async () => {
+    const resolved = await resolveLLMConfig(
+      { provider: LLM_PROVIDERS.CHATGPT_PRO },
+      'browseros-id',
+    )
+
+    expect(tokenManager.refreshIfExpired).toHaveBeenCalledWith('chatgpt-pro')
+    expect(resolved).toMatchObject({
+      provider: LLM_PROVIDERS.CHATGPT_PRO,
+      model: 'gpt-5.5',
+      apiKey: 'access-token',
+      upstreamProvider: 'openai',
+      accountId: 'account-id',
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- default ChatGPT Plus/Pro OAuth providers to gpt-5.5 across agent and server config
- add current ChatGPT Pro model entries for gpt-5.5, gpt-5.4-mini, gpt-5.4-nano, and gpt-5.3-codex-spark
- stabilize BrowserOS test teardown so server tools tests do not hit Bun's 5s hook timeout

## Verification
- bun run --filter @browseros/agent test apps/agent/screens/ai-settings/models.test.ts apps/agent/lib/llm-providers/providerTemplates.test.ts
- bun test apps/server/tests/lib/clients/llm/config.test.ts
- bun test --preload=./apps/server/tests/__helpers__/test-env.ts apps/server/tests/tools/input.test.ts
- bun run --filter @browseros/server test:tools
- bun run test:main
- bun run lint
- bun run typecheck
- bun run build:agent

Refs #1079