### PR TITLE
fix: simplify metrics sampling

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/routes/chat.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/chat.ts
@@ -13,8 +13,6 @@ import type { RemoteHermesService } from '../services/remote-hermes/remote-herme
 import { ChatRequestSchema } from '../types'
 import { ConversationIdParamSchema } from '../utils/validation'
 
-const CHAT_REQUEST_METRIC_SAMPLE_RATE = 1 / 5
-
 interface ChatRouteDeps {
   browser: Browser
   browserSession: BrowserSession
@@ -73,16 +71,10 @@ export function createChatRoutes(deps: ChatRouteDeps) {
           : undefined,
       })
 
-      metrics.log(
-        'chat.request',
-        {
-          provider: request.provider,
-          model: request.model,
-        },
-        {
-          sampling: CHAT_REQUEST_METRIC_SAMPLE_RATE,
-        },
-      )
+      metrics.log('chat.request', {
+        provider: request.provider,
+        model: request.model,
+      })
 
       logger.info('Chat request received', {
         conversationId: request.conversationId,

--- a/packages/browseros-agent/apps/server/src/lib/metrics.ts
+++ b/packages/browseros-agent/apps/server/src/lib/metrics.ts
@@ -9,6 +9,7 @@ import { INLINED_ENV } from '../env'
 
 const POSTHOG_API_KEY = INLINED_ENV.POSTHOG_API_KEY
 const EVENT_PREFIX = 'browseros.server.'
+const DEFAULT_METRICS_SAMPLE_RATE = 1 / 5
 
 /**
  * The two events that previously fired per call and dwarfed every other
@@ -61,10 +62,6 @@ interface RollupBucket {
   period_start_ts: string
   mcp_requests: number
   tool_executions: ToolExecCounters
-}
-
-interface MetricsLogOptions {
-  sampling?: number
 }
 
 class RollupBuffer {
@@ -143,8 +140,8 @@ function defaultAlignedNow(): number {
   return Math.floor(Date.now() / ROLLUP_INTERVAL_MS) * ROLLUP_INTERVAL_MS
 }
 
-function normalizeSampling(sampling: number | undefined): number {
-  if (sampling === undefined || !Number.isFinite(sampling)) return 1
+function normalizeSampling(sampling: number): number {
+  if (!Number.isFinite(sampling)) return DEFAULT_METRICS_SAMPLE_RATE
   return Math.min(Math.max(sampling, 0), 1)
 }
 
@@ -174,18 +171,18 @@ class MetricsService {
     return this.config?.client_id ?? null
   }
 
-  /** Records one metrics event, aggregating known noisy events before immediate capture. */
+  /** Records one metrics event, aggregating noisy events and sampling immediate captures. */
   log(
     eventName: string,
     properties: Record<string, unknown> = {},
-    options: MetricsLogOptions = {},
+    sampling = DEFAULT_METRICS_SAMPLE_RATE,
   ): void {
     if (!this.client || !this.config) {
       return
     }
 
-    // The two highest-volume events get aggregated. Every other event
-    // captures per call as it always has.
+    // The two highest-volume events get aggregated before sampling;
+    // every other event goes through the immediate-capture sample gate.
     if (eventName === AGGREGATED_EVENT_MCP_REQUEST) {
       this.rollup.recordMcpRequest()
       return
@@ -199,7 +196,7 @@ class MetricsService {
       return
     }
 
-    const sampleRate = normalizeSampling(options.sampling)
+    const sampleRate = normalizeSampling(sampling)
     if (sampleRate <= 0) return
     if (sampleRate < 1 && Math.random() >= sampleRate) return
 

--- a/packages/browseros-agent/apps/server/tests/lib/metrics.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/metrics.test.ts
@@ -161,18 +161,37 @@ describe('MetricsService — log dispatch', () => {
     expect(captureCalls).toHaveLength(0)
   })
 
-  it('captures non-aggregated events immediately', () => {
+  it('captures default-sampled non-aggregated events when selected', () => {
     metrics.initialize({ client_id: 'client-a' })
-    metrics.log('chat.request', { mode: 'agent' })
+    withRandom(0.19, () => {
+      metrics.log('chat.request', { mode: 'agent' })
+    })
     expect(captureCalls).toHaveLength(1)
     expect(captureCalls[0]?.event).toBe('browseros.server.chat.request')
     expect(captureCalls[0]?.distinctId).toBe('client-a')
+    expect(captureCalls[0]?.properties.sample_rate).toBe(1 / 5)
+  })
+
+  it('skips default-sampled non-aggregated events when not selected', () => {
+    metrics.initialize({ client_id: 'client-a' })
+    withRandom(0.2, () => {
+      metrics.log('chat.request', { mode: 'agent' })
+    })
+    expect(captureCalls).toHaveLength(0)
+  })
+
+  it('captures unsampled non-aggregated events when sampling is one', () => {
+    metrics.initialize({ client_id: 'client-a' })
+    metrics.log('chat.request', { mode: 'agent' }, 1)
+    expect(captureCalls).toHaveLength(1)
+    expect(captureCalls[0]?.properties.mode).toBe('agent')
+    expect(captureCalls[0]?.properties.sample_rate).toBeUndefined()
   })
 
   it('captures sampled non-aggregated events when selected', () => {
     metrics.initialize({ client_id: 'client-a' })
     withRandom(0.49, () => {
-      metrics.log('chat.request', { mode: 'agent' }, { sampling: 0.5 })
+      metrics.log('chat.request', { mode: 'agent' }, 0.5)
     })
     expect(captureCalls).toHaveLength(1)
     expect(captureCalls[0]?.properties.mode).toBe('agent')
@@ -182,15 +201,22 @@ describe('MetricsService — log dispatch', () => {
   it('skips sampled non-aggregated events when not selected', () => {
     metrics.initialize({ client_id: 'client-a' })
     withRandom(0.5, () => {
-      metrics.log('chat.request', { mode: 'agent' }, { sampling: 0.5 })
+      metrics.log('chat.request', { mode: 'agent' }, 0.5)
+    })
+    expect(captureCalls).toHaveLength(0)
+  })
+
+  it('skips immediate capture when sampling is zero', () => {
+    metrics.initialize({ client_id: 'client-a' })
+    withRandom(0, () => {
+      metrics.log('chat.request', { mode: 'agent' }, 0)
     })
     expect(captureCalls).toHaveLength(0)
   })
 
   it('skips emit entirely when no identity is configured', () => {
-    // No client_id, no install_id → captureNow should short-circuit.
     metrics.initialize({})
-    metrics.log('chat.request', { mode: 'agent' })
+    metrics.log('chat.request', { mode: 'agent' }, 1)
     expect(captureCalls).toHaveLength(0)
   })
 
@@ -207,7 +233,7 @@ describe('MetricsService — log dispatch', () => {
   it('does not sample rollup inputs', async () => {
     metrics.initialize({ client_id: 'client-a' })
     withRandom(0.99, () => {
-      metrics.log('mcp.request', {}, { sampling: 0 })
+      metrics.log('mcp.request', {}, 0)
     })
 
     await metrics.shutdown()


### PR DESCRIPTION
## Summary
- simplify `metrics.log` sampling to a numeric third argument instead of a separate options interface
- make non-aggregated metrics default to `1 / 5` sampling inside the metrics service
- remove chat-route-specific sampling plumbing and expand metrics sampling tests

## Design
`MetricsService.log` now handles aggregation first, then applies a normalized numeric sample rate for immediate captures. Aggregated rollup inputs still bypass sampling so rollup counts stay accurate, while callers can pass `1` to force capture or `0` to skip immediate capture.

## Test plan
- [x] `cd apps/server && bun test tests/lib/metrics.test.ts`
- [x] `bun run lint` (exit 0; existing repo warnings remain outside this diff)
- [x] `bun run typecheck`
- [x] `bun run test:main`