### PR TITLE
fix: harden filesystem tool workspace boundaries

### DIFF
--- a/packages/browseros-agent/apps/server/src/agent/ai-sdk-agent.ts
+++ b/packages/browseros-agent/apps/server/src/agent/ai-sdk-agent.ts
@@ -53,6 +53,20 @@ export interface AiSdkAgentConfig {
   browserUseNewTools: boolean
 }
 
+/** Builds filesystem tools only for model-backed agent sessions with an explicit workspace. */
+export function buildAgentFilesystemToolSet(
+  resolvedConfig: ResolvedAgentConfig,
+): ToolSet {
+  if (
+    isAcpProvider(resolvedConfig.provider) ||
+    resolvedConfig.chatMode ||
+    !resolvedConfig.workingDir
+  ) {
+    return {}
+  }
+  return buildFilesystemToolSet(resolvedConfig.workingDir)
+}
+
 export class AiSdkAgent {
   private constructor(
     private _agent: ToolLoopAgent,
@@ -208,12 +222,7 @@ export class AiSdkAgent {
     // workspace is selected, and for ACP providers (Claude Code and
     // Codex ship their own filesystem tools; double-registering would
     // collide on tool names and yield stale-snapshot behaviour).
-    const filesystemTools =
-      !useMcpBoundaryOnly &&
-      !config.resolvedConfig.chatMode &&
-      config.resolvedConfig.workingDir
-        ? buildFilesystemToolSet(config.resolvedConfig.workingDir)
-        : {}
+    const filesystemTools = buildAgentFilesystemToolSet(config.resolvedConfig)
     const tools = {
       ...browserTools,
       ...externalMcpTools,

--- a/packages/browseros-agent/apps/server/src/lib/browseros-dir.ts
+++ b/packages/browseros-agent/apps/server/src/lib/browseros-dir.ts
@@ -43,33 +43,20 @@ export function getCacheDir(): string {
   return join(getBrowserosDir(), PATHS.CACHE_DIR_NAME)
 }
 
-/** Returns the directory used for large generated tool outputs. */
-export function getToolOutputDir(): string {
-  return join(getBrowserosDir(), 'tool-output')
-}
-
-async function realToolOutputDir(): Promise<string> {
-  await mkdir(getToolOutputDir(), {
+/** Returns the ready-to-use directory for large generated tool outputs. */
+export async function getToolOutputDir(): Promise<string> {
+  const outputDirPath = join(getBrowserosDir(), 'tool-output')
+  await mkdir(outputDirPath, {
     recursive: true,
     mode: TOOL_OUTPUT_DIR_MODE,
   })
-  const info = await lstat(getToolOutputDir())
+  const info = await lstat(outputDirPath)
   if (!info.isDirectory() || info.isSymbolicLink()) {
     throw new Error('BrowserOS tool output directory must be a real directory.')
   }
-  const outputDir = await realpath(getToolOutputDir())
+  const outputDir = await realpath(outputDirPath)
   await chmod(outputDir, TOOL_OUTPUT_DIR_MODE)
   return outputDir
-}
-
-/** Ensures large generated tool outputs use a real BrowserOS-owned directory. */
-export async function ensureToolOutputDir(): Promise<string> {
-  return await realToolOutputDir()
-}
-
-/** Resolves the generated tool output directory without creating it. */
-export async function getRealToolOutputDir(): Promise<string> {
-  return await realToolOutputDir()
 }
 
 /** Writes a generated tool output file with private owner-only permissions. */
@@ -115,7 +102,7 @@ export function removeServerConfigSync(): void {
 export async function ensureBrowserosDir(): Promise<void> {
   logDevelopmentBrowserosDir()
   await mkdir(getSessionsDir(), { recursive: true })
-  await realToolOutputDir()
+  await getToolOutputDir()
 }
 
 export async function cleanOldSessions(): Promise<void> {

--- a/packages/browseros-agent/apps/server/src/lib/browseros-dir.ts
+++ b/packages/browseros-agent/apps/server/src/lib/browseros-dir.ts
@@ -31,6 +31,11 @@ export function getCacheDir(): string {
   return join(getBrowserosDir(), PATHS.CACHE_DIR_NAME)
 }
 
+/** Returns the directory used for large generated tool outputs. */
+export function getToolOutputDir(): string {
+  return join(getBrowserosDir(), 'tool-output')
+}
+
 /** Returns the durable SQLite database path for local BrowserOS server state. */
 export function getDbPath(): string {
   return join(getBrowserosDir(), PATHS.DB_DIR_NAME, PATHS.DB_FILE_NAME)

--- a/packages/browseros-agent/apps/server/src/lib/browseros-dir.ts
+++ b/packages/browseros-agent/apps/server/src/lib/browseros-dir.ts
@@ -49,17 +49,11 @@ export function getToolOutputDir(): string {
 }
 
 async function realToolOutputDir(): Promise<string> {
-  let info: Awaited<ReturnType<typeof lstat>>
-  try {
-    info = await lstat(getToolOutputDir())
-  } catch (error) {
-    if (error instanceof Error && 'code' in error) {
-      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
-        throw new Error('BrowserOS tool output directory does not exist.')
-      }
-    }
-    throw error
-  }
+  await mkdir(getToolOutputDir(), {
+    recursive: true,
+    mode: TOOL_OUTPUT_DIR_MODE,
+  })
+  const info = await lstat(getToolOutputDir())
   if (!info.isDirectory() || info.isSymbolicLink()) {
     throw new Error('BrowserOS tool output directory must be a real directory.')
   }
@@ -70,10 +64,6 @@ async function realToolOutputDir(): Promise<string> {
 
 /** Ensures large generated tool outputs use a real BrowserOS-owned directory. */
 export async function ensureToolOutputDir(): Promise<string> {
-  await mkdir(getToolOutputDir(), {
-    recursive: true,
-    mode: TOOL_OUTPUT_DIR_MODE,
-  })
   return await realToolOutputDir()
 }
 
@@ -125,6 +115,7 @@ export function removeServerConfigSync(): void {
 export async function ensureBrowserosDir(): Promise<void> {
   logDevelopmentBrowserosDir()
   await mkdir(getSessionsDir(), { recursive: true })
+  await realToolOutputDir()
 }
 
 export async function cleanOldSessions(): Promise<void> {

--- a/packages/browseros-agent/apps/server/src/lib/browseros-dir.ts
+++ b/packages/browseros-agent/apps/server/src/lib/browseros-dir.ts
@@ -66,6 +66,7 @@ export async function writeToolOutputFile(
 ): Promise<void> {
   await writeFile(filePath, content, {
     encoding: 'utf-8',
+    flag: 'wx',
     mode: TOOL_OUTPUT_FILE_MODE,
   })
   await chmod(filePath, TOOL_OUTPUT_FILE_MODE)

--- a/packages/browseros-agent/apps/server/src/lib/browseros-dir.ts
+++ b/packages/browseros-agent/apps/server/src/lib/browseros-dir.ts
@@ -1,5 +1,6 @@
 import { unlinkSync } from 'node:fs'
 import {
+  chmod,
   lstat,
   mkdir,
   readdir,
@@ -13,6 +14,9 @@ import { join } from 'node:path'
 import { PATHS } from '@browseros/shared/constants/paths'
 import type { ServerDiscoveryConfig } from '@browseros/shared/types/server-config'
 import { logger } from './logger'
+
+export const TOOL_OUTPUT_DIR_MODE = 0o700
+export const TOOL_OUTPUT_FILE_MODE = 0o600
 
 export function getBrowserosDir(): string {
   const override = process.env.BROWSEROS_DIR?.trim()
@@ -59,18 +63,35 @@ async function realToolOutputDir(): Promise<string> {
   if (!info.isDirectory() || info.isSymbolicLink()) {
     throw new Error('BrowserOS tool output directory must be a real directory.')
   }
-  return await realpath(getToolOutputDir())
+  const outputDir = await realpath(getToolOutputDir())
+  await chmod(outputDir, TOOL_OUTPUT_DIR_MODE)
+  return outputDir
 }
 
 /** Ensures large generated tool outputs use a real BrowserOS-owned directory. */
 export async function ensureToolOutputDir(): Promise<string> {
-  await mkdir(getToolOutputDir(), { recursive: true })
+  await mkdir(getToolOutputDir(), {
+    recursive: true,
+    mode: TOOL_OUTPUT_DIR_MODE,
+  })
   return await realToolOutputDir()
 }
 
 /** Resolves the generated tool output directory without creating it. */
 export async function getRealToolOutputDir(): Promise<string> {
   return await realToolOutputDir()
+}
+
+/** Writes a generated tool output file with private owner-only permissions. */
+export async function writeToolOutputFile(
+  filePath: string,
+  content: string,
+): Promise<void> {
+  await writeFile(filePath, content, {
+    encoding: 'utf-8',
+    mode: TOOL_OUTPUT_FILE_MODE,
+  })
+  await chmod(filePath, TOOL_OUTPUT_FILE_MODE)
 }
 
 /** Returns the durable SQLite database path for local BrowserOS server state. */

--- a/packages/browseros-agent/apps/server/src/lib/browseros-dir.ts
+++ b/packages/browseros-agent/apps/server/src/lib/browseros-dir.ts
@@ -1,5 +1,13 @@
 import { unlinkSync } from 'node:fs'
-import { mkdir, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import {
+  lstat,
+  mkdir,
+  readdir,
+  realpath,
+  rm,
+  stat,
+  writeFile,
+} from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 import { PATHS } from '@browseros/shared/constants/paths'
@@ -34,6 +42,35 @@ export function getCacheDir(): string {
 /** Returns the directory used for large generated tool outputs. */
 export function getToolOutputDir(): string {
   return join(getBrowserosDir(), 'tool-output')
+}
+
+async function realToolOutputDir(): Promise<string> {
+  let info: Awaited<ReturnType<typeof lstat>>
+  try {
+    info = await lstat(getToolOutputDir())
+  } catch (error) {
+    if (error instanceof Error && 'code' in error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+        throw new Error('BrowserOS tool output directory does not exist.')
+      }
+    }
+    throw error
+  }
+  if (!info.isDirectory() || info.isSymbolicLink()) {
+    throw new Error('BrowserOS tool output directory must be a real directory.')
+  }
+  return await realpath(getToolOutputDir())
+}
+
+/** Ensures large generated tool outputs use a real BrowserOS-owned directory. */
+export async function ensureToolOutputDir(): Promise<string> {
+  await mkdir(getToolOutputDir(), { recursive: true })
+  return await realToolOutputDir()
+}
+
+/** Resolves the generated tool output directory without creating it. */
+export async function getRealToolOutputDir(): Promise<string> {
+  return await realToolOutputDir()
 }
 
 /** Returns the durable SQLite database path for local BrowserOS server state. */

--- a/packages/browseros-agent/apps/server/src/tools/browser/output-file.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/output-file.ts
@@ -1,9 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
-import {
-  ensureToolOutputDir,
-  writeToolOutputFile,
-} from '../../lib/browseros-dir'
+import { getToolOutputDir, writeToolOutputFile } from '../../lib/browseros-dir'
 
 function sanitizeSegment(value: string): string {
   const sanitized = value.replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '')
@@ -15,7 +12,7 @@ export async function writeTempToolOutputFile(args: {
   extension: string
   content: string
 }): Promise<string> {
-  const outputDir = await ensureToolOutputDir()
+  const outputDir = await getToolOutputDir()
   const toolName = sanitizeSegment(args.toolName)
   const extension = sanitizeSegment(args.extension) || 'txt'
   const filePath = join(

--- a/packages/browseros-agent/apps/server/src/tools/browser/output-file.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/output-file.ts
@@ -1,7 +1,7 @@
 import { randomUUID } from 'node:crypto'
-import { mkdtemp } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
+import { mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
+import { getToolOutputDir } from '../../lib/browseros-dir'
 
 function sanitizeSegment(value: string): string {
   const sanitized = value.replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '')
@@ -13,7 +13,8 @@ export async function writeTempToolOutputFile(args: {
   extension: string
   content: string
 }): Promise<string> {
-  const outputDir = await mkdtemp(join(tmpdir(), 'browseros-browser-tool-'))
+  const outputDir = getToolOutputDir()
+  await mkdir(outputDir, { recursive: true })
   const toolName = sanitizeSegment(args.toolName)
   const extension = sanitizeSegment(args.extension) || 'txt'
   const filePath = join(

--- a/packages/browseros-agent/apps/server/src/tools/browser/output-file.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/output-file.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from 'node:crypto'
-import { mkdir } from 'node:fs/promises'
 import { join } from 'node:path'
-import { getToolOutputDir } from '../../lib/browseros-dir'
+import { ensureToolOutputDir } from '../../lib/browseros-dir'
 
 function sanitizeSegment(value: string): string {
   const sanitized = value.replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '')
@@ -13,8 +12,7 @@ export async function writeTempToolOutputFile(args: {
   extension: string
   content: string
 }): Promise<string> {
-  const outputDir = getToolOutputDir()
-  await mkdir(outputDir, { recursive: true })
+  const outputDir = await ensureToolOutputDir()
   const toolName = sanitizeSegment(args.toolName)
   const extension = sanitizeSegment(args.extension) || 'txt'
   const filePath = join(

--- a/packages/browseros-agent/apps/server/src/tools/browser/output-file.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/output-file.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
-import { ensureToolOutputDir } from '../../lib/browseros-dir'
+import {
+  ensureToolOutputDir,
+  writeToolOutputFile,
+} from '../../lib/browseros-dir'
 
 function sanitizeSegment(value: string): string {
   const sanitized = value.replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '')
@@ -20,6 +23,6 @@ export async function writeTempToolOutputFile(args: {
     `${toolName}-${Date.now()}-${randomUUID()}.${extension}`,
   )
 
-  await Bun.write(filePath, args.content)
+  await writeToolOutputFile(filePath, args.content)
   return filePath
 }

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/edit.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/edit.ts
@@ -1,11 +1,11 @@
 import { readFile, writeFile } from 'node:fs/promises'
-import { resolve } from 'node:path'
 import { tool } from 'ai'
 import { z } from 'zod'
 import {
   detectLineEnding,
   executeWithMetrics,
   normalizeToLF,
+  resolveWorkspacePath,
   restoreLineEndings,
   stripBom,
   toModelOutput,
@@ -77,15 +77,13 @@ export function createEditTool(cwd: string) {
     description:
       'Make a targeted edit to a file by replacing an exact string match. The old_string must match exactly one location in the file. If exact match fails, a whitespace-tolerant match is attempted.',
     inputSchema: z.object({
-      path: z
-        .string()
-        .describe('File path (relative to working directory or absolute)'),
+      path: z.string().describe('File path relative to the selected workspace'),
       old_string: z.string().describe('Exact text to find in the file'),
       new_string: z.string().describe('Replacement text'),
     }),
     execute: (params) =>
       executeWithMetrics(TOOL_NAME, async () => {
-        const resolved = resolve(cwd, params.path)
+        const resolved = await resolveWorkspacePath(cwd, params.path)
         const raw = await readFile(resolved, 'utf-8')
 
         const { content: noBom, hasBom } = stripBom(raw)

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/find.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/find.ts
@@ -45,9 +45,9 @@ export function createFindTool(cwd: string) {
         const glob = new Bun.Glob(effectivePattern)
         const matches: string[] = []
 
-        for await (const relPath of walkFiles(searchPath, searchPath)) {
-          if (glob.match(relPath)) {
-            matches.push(relPath)
+        for await (const file of walkFiles(searchPath, searchPath)) {
+          if (glob.match(file.path)) {
+            matches.push(file.path)
             if (matches.length >= limit) break
           }
         }

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/find.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/find.ts
@@ -1,9 +1,9 @@
-import { resolve } from 'node:path'
 import { tool } from 'ai'
 import { z } from 'zod'
 import {
   DEFAULT_FIND_LIMIT,
   executeWithMetrics,
+  resolveWorkspacePath,
   toModelOutput,
   walkFiles,
 } from './utils'
@@ -23,7 +23,7 @@ export function createFindTool(cwd: string) {
       path: z
         .string()
         .optional()
-        .describe('Directory to search (default: working directory)'),
+        .describe('Directory to search relative to the selected workspace'),
       limit: z
         .number()
         .optional()
@@ -31,7 +31,7 @@ export function createFindTool(cwd: string) {
     }),
     execute: (params) =>
       executeWithMetrics(TOOL_NAME, async () => {
-        const searchPath = resolve(cwd, params.path || '.')
+        const searchPath = await resolveWorkspacePath(cwd, params.path || '.')
         const limit = params.limit || DEFAULT_FIND_LIMIT
 
         let effectivePattern = params.pattern

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/grep.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/grep.ts
@@ -1,5 +1,5 @@
 import { readFile, stat } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
+import { join } from 'node:path'
 import { tool } from 'ai'
 import { z } from 'zod'
 import {
@@ -8,6 +8,7 @@ import {
   GREP_MAX_LINE_LENGTH,
   isBinaryPath,
   MAX_GREP_FILE_SIZE,
+  resolveWorkspacePath,
   toModelOutput,
   truncateLine,
   walkFiles,
@@ -98,7 +99,9 @@ export function createGrepTool(cwd: string) {
       path: z
         .string()
         .optional()
-        .describe('Directory or file to search (default: working directory)'),
+        .describe(
+          'Directory or file to search relative to the selected workspace',
+        ),
       glob: z
         .string()
         .optional()
@@ -120,7 +123,7 @@ export function createGrepTool(cwd: string) {
     execute: (params) =>
       // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: grep tool has many output mode and filtering branches
       executeWithMetrics(TOOL_NAME, async () => {
-        const searchPath = resolve(cwd, params.path || '.')
+        const searchPath = await resolveWorkspacePath(cwd, params.path || '.')
         const limit = params.limit || DEFAULT_GREP_LIMIT
         const context = params.context || 0
 

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/grep.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/grep.ts
@@ -1,5 +1,5 @@
-import { readFile, stat } from 'node:fs/promises'
-import { join } from 'node:path'
+import { constants } from 'node:fs'
+import { open, stat } from 'node:fs/promises'
 import { tool } from 'ai'
 import { z } from 'zod'
 import {
@@ -21,6 +21,34 @@ interface GrepMatch {
   lineNum: number
   line: string
   isMatch: boolean
+}
+
+const GREP_FILE_OPEN_FLAGS =
+  constants.O_RDONLY |
+  (typeof constants.O_NOFOLLOW === 'number' ? constants.O_NOFOLLOW : 0)
+
+/** Reads grep input from a descriptor so final-component symlinks are rejected. */
+async function readGrepFileContent(
+  filePath: string,
+  maxBytes?: number,
+): Promise<string | null> {
+  let handle: Awaited<ReturnType<typeof open>>
+  try {
+    handle = await open(filePath, GREP_FILE_OPEN_FLAGS)
+  } catch {
+    return null
+  }
+
+  try {
+    const fileStat = await handle.stat()
+    if (!fileStat.isFile()) return null
+    if (maxBytes !== undefined && fileStat.size > maxBytes) return null
+    return await handle.readFile({ encoding: 'utf-8' })
+  } catch {
+    return null
+  } finally {
+    await handle.close()
+  }
 }
 
 function searchFileLines(
@@ -163,7 +191,13 @@ export function createGrepTool(cwd: string) {
         let totalMatchCount = 0
 
         if (pathStat.isFile()) {
-          const content = await readFile(searchPath, 'utf-8')
+          const content = await readGrepFileContent(searchPath)
+          if (content === null) {
+            return {
+              text: `Unable to read file: ${params.path || searchPath}`,
+              isError: true,
+            }
+          }
           const lines = content.split('\n')
           const relPath = params.path || searchPath
           const fileMatches = searchFileLines(
@@ -176,24 +210,16 @@ export function createGrepTool(cwd: string) {
           allMatches.push(...fileMatches)
           totalMatchCount = fileMatches.filter((m) => m.isMatch).length
         } else {
-          for await (const relPath of walkFiles(searchPath, searchPath)) {
+          for await (const file of walkFiles(searchPath, searchPath)) {
+            const relPath = file.path
             if (isBinaryPath(relPath)) continue
             if (globMatcher && !globMatcher.match(relPath)) continue
 
-            const fullPath = join(searchPath, relPath)
-            try {
-              const fileStat = await stat(fullPath)
-              if (fileStat.size > MAX_GREP_FILE_SIZE) continue
-            } catch {
-              continue
-            }
-
-            let content: string
-            try {
-              content = await readFile(fullPath, 'utf-8')
-            } catch {
-              continue
-            }
+            const content = await readGrepFileContent(
+              file.realPath,
+              MAX_GREP_FILE_SIZE,
+            )
+            if (content === null) continue
 
             const lines = content.split('\n')
             const remaining = limit - totalMatchCount

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/grep.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/grep.ts
@@ -191,7 +191,10 @@ export function createGrepTool(cwd: string) {
         let totalMatchCount = 0
 
         if (pathStat.isFile()) {
-          const content = await readGrepFileContent(searchPath)
+          const content = await readGrepFileContent(
+            searchPath,
+            MAX_GREP_FILE_SIZE,
+          )
           if (content === null) {
             return {
               text: `Unable to read file: ${params.path || searchPath}`,

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/ls.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/ls.ts
@@ -6,7 +6,8 @@ import { z } from 'zod'
 import {
   DEFAULT_LS_LIMIT,
   executeWithMetrics,
-  resolveWorkspacePath,
+  resolveWorkspacePathFromRoot,
+  resolveWorkspaceRoot,
   toModelOutput,
 } from './utils'
 
@@ -19,7 +20,7 @@ function formatSize(bytes: number): string {
 }
 
 async function collectVisibleEntries(
-  cwd: string,
+  root: string,
   inputPath: string,
   resolved: string,
   entries: Dirent[],
@@ -30,7 +31,7 @@ async function collectVisibleEntries(
   for (const entry of entries) {
     const childPath = join(inputPath, entry.name as string)
     try {
-      await resolveWorkspacePath(cwd, childPath)
+      await resolveWorkspacePathFromRoot(root, childPath)
     } catch {
       continue
     }
@@ -98,11 +99,12 @@ export function createLsTool(cwd: string) {
     execute: (params) =>
       executeWithMetrics(TOOL_NAME, async () => {
         const inputPath = params.path || '.'
-        const resolved = await resolveWorkspacePath(cwd, inputPath)
+        const root = await resolveWorkspaceRoot(cwd)
+        const resolved = await resolveWorkspacePathFromRoot(root, inputPath)
         const limit = params.limit || DEFAULT_LS_LIMIT
         const entries = await readdir(resolved, { withFileTypes: true })
         const { dirs, files } = await collectVisibleEntries(
-          cwd,
+          root,
           inputPath,
           resolved,
           entries,

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/ls.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/ls.ts
@@ -1,8 +1,13 @@
 import { readdir, stat } from 'node:fs/promises'
-import { join, resolve } from 'node:path'
+import { join } from 'node:path'
 import { tool } from 'ai'
 import { z } from 'zod'
-import { DEFAULT_LS_LIMIT, executeWithMetrics, toModelOutput } from './utils'
+import {
+  DEFAULT_LS_LIMIT,
+  executeWithMetrics,
+  resolveWorkspacePath,
+  toModelOutput,
+} from './utils'
 
 const TOOL_NAME = 'filesystem_ls'
 
@@ -20,7 +25,7 @@ export function createLsTool(cwd: string) {
       path: z
         .string()
         .optional()
-        .describe('Directory path (default: working directory)'),
+        .describe('Directory path relative to the selected workspace'),
       limit: z
         .number()
         .optional()
@@ -28,7 +33,8 @@ export function createLsTool(cwd: string) {
     }),
     execute: (params) =>
       executeWithMetrics(TOOL_NAME, async () => {
-        const resolved = resolve(cwd, params.path || '.')
+        const inputPath = params.path || '.'
+        const resolved = await resolveWorkspacePath(cwd, inputPath)
         const limit = params.limit || DEFAULT_LS_LIMIT
         const entries = await readdir(resolved, { withFileTypes: true })
 
@@ -36,6 +42,13 @@ export function createLsTool(cwd: string) {
         const files: Array<{ name: string; size: number }> = []
 
         for (const entry of entries) {
+          const childPath = join(inputPath, entry.name as string)
+          try {
+            await resolveWorkspacePath(cwd, childPath)
+          } catch {
+            continue
+          }
+
           if (entry.isDirectory()) {
             dirs.push(entry.name)
           } else {

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/ls.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/ls.ts
@@ -1,3 +1,4 @@
+import type { Dirent } from 'node:fs'
 import { readdir, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 import { tool } from 'ai'
@@ -15,6 +16,69 @@ function formatSize(bytes: number): string {
   if (bytes < 1024) return `${bytes}B`
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`
   return `${(bytes / (1024 * 1024)).toFixed(1)}MB`
+}
+
+async function collectVisibleEntries(
+  cwd: string,
+  inputPath: string,
+  resolved: string,
+  entries: Dirent[],
+): Promise<{ dirs: string[]; files: Array<{ name: string; size: number }> }> {
+  const dirs: string[] = []
+  const files: Array<{ name: string; size: number }> = []
+
+  for (const entry of entries) {
+    const childPath = join(inputPath, entry.name as string)
+    try {
+      await resolveWorkspacePath(cwd, childPath)
+    } catch {
+      continue
+    }
+
+    if (entry.isDirectory()) {
+      dirs.push(entry.name)
+      continue
+    }
+
+    try {
+      const info = await stat(join(resolved, entry.name))
+      files.push({ name: entry.name, size: info.size })
+    } catch {
+      files.push({ name: entry.name, size: 0 })
+    }
+  }
+
+  return { dirs, files }
+}
+
+function formatEntries(
+  dirs: string[],
+  files: Array<{ name: string; size: number }>,
+  limit: number,
+): string {
+  dirs.sort((a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }))
+  files.sort((a, b) =>
+    a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
+  )
+
+  const lines: string[] = []
+  for (const dir of dirs) {
+    if (lines.length >= limit) break
+    lines.push(`${dir}/`)
+  }
+  for (const file of files) {
+    if (lines.length >= limit) break
+    lines.push(`${file.name} (${formatSize(file.size)})`)
+  }
+
+  if (lines.length === 0) return '(empty directory)'
+
+  let result = lines.join('\n')
+  const total = dirs.length + files.length
+  if (total > limit) {
+    result += `\n\n(Showing ${limit} of ${total} entries. Use limit=${limit * 2} to see more.)`
+  }
+  return result
 }
 
 export function createLsTool(cwd: string) {
@@ -37,58 +101,13 @@ export function createLsTool(cwd: string) {
         const resolved = await resolveWorkspacePath(cwd, inputPath)
         const limit = params.limit || DEFAULT_LS_LIMIT
         const entries = await readdir(resolved, { withFileTypes: true })
-
-        const dirs: string[] = []
-        const files: Array<{ name: string; size: number }> = []
-
-        for (const entry of entries) {
-          const childPath = join(inputPath, entry.name as string)
-          try {
-            await resolveWorkspacePath(cwd, childPath)
-          } catch {
-            continue
-          }
-
-          if (entry.isDirectory()) {
-            dirs.push(entry.name)
-          } else {
-            try {
-              const info = await stat(join(resolved, entry.name))
-              files.push({ name: entry.name, size: info.size })
-            } catch {
-              files.push({ name: entry.name, size: 0 })
-            }
-          }
-        }
-
-        dirs.sort((a, b) =>
-          a.localeCompare(b, undefined, { sensitivity: 'base' }),
+        const { dirs, files } = await collectVisibleEntries(
+          cwd,
+          inputPath,
+          resolved,
+          entries,
         )
-        files.sort((a, b) =>
-          a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }),
-        )
-
-        const lines: string[] = []
-        for (const dir of dirs) {
-          if (lines.length >= limit) break
-          lines.push(`${dir}/`)
-        }
-        for (const file of files) {
-          if (lines.length >= limit) break
-          lines.push(`${file.name} (${formatSize(file.size)})`)
-        }
-
-        if (lines.length === 0) {
-          return { text: '(empty directory)' }
-        }
-
-        let result = lines.join('\n')
-        const total = dirs.length + files.length
-        if (total > limit) {
-          result += `\n\n(Showing ${limit} of ${total} entries. Use limit=${limit * 2} to see more.)`
-        }
-
-        return { text: result }
+        return { text: formatEntries(dirs, files, limit) }
       }),
     toModelOutput,
   })

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/path-boundary.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/path-boundary.ts
@@ -1,0 +1,111 @@
+import { lstat, realpath } from 'node:fs/promises'
+import { dirname, isAbsolute, join, relative, resolve, win32 } from 'node:path'
+import { getBrowserosDir } from '../../lib/browseros-dir'
+
+const BROWSER_TOOL_OUTPUT_DIR_NAME = 'tool-output'
+
+export function getBrowserToolOutputDir(): string {
+  return join(getBrowserosDir(), BROWSER_TOOL_OUTPUT_DIR_NAME)
+}
+
+function isAbsoluteInput(inputPath: string): boolean {
+  return isAbsolute(inputPath) || win32.isAbsolute(inputPath)
+}
+
+export function isPathInside(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate)
+  return rel === '' || (!rel.startsWith('..') && !isAbsoluteInput(rel))
+}
+
+function assertRelativeWorkspaceInput(inputPath: string): void {
+  if (isAbsoluteInput(inputPath)) {
+    throw new Error('Path must be relative to the selected workspace.')
+  }
+}
+
+function assertInsideWorkspace(root: string, candidate: string): void {
+  if (!isPathInside(root, candidate)) {
+    throw new Error('Path is outside the selected workspace.')
+  }
+}
+
+async function realWorkspaceRoot(cwd: string): Promise<string> {
+  return await realpath(cwd)
+}
+
+async function findExistingParent(
+  root: string,
+  targetPath: string,
+): Promise<string> {
+  let parent = dirname(targetPath)
+
+  while (isPathInside(root, parent)) {
+    try {
+      await lstat(parent)
+      return parent
+    } catch (error) {
+      if (!(error instanceof Error) || !('code' in error)) throw error
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    }
+
+    const next = dirname(parent)
+    if (next === parent) break
+    parent = next
+  }
+
+  throw new Error('Path is outside the selected workspace.')
+}
+
+/** Resolves an existing workspace path and rejects traversal or symlink escapes. */
+export async function resolveWorkspacePath(
+  cwd: string,
+  inputPath: string,
+): Promise<string> {
+  assertRelativeWorkspaceInput(inputPath)
+  const root = await realWorkspaceRoot(cwd)
+  const candidate = resolve(root, inputPath)
+  assertInsideWorkspace(root, candidate)
+  const canonical = await realpath(candidate)
+  assertInsideWorkspace(root, canonical)
+  return canonical
+}
+
+/** Resolves a workspace write target, validating the existing parent chain first. */
+export async function resolveWorkspaceWritePath(
+  cwd: string,
+  inputPath: string,
+): Promise<string> {
+  assertRelativeWorkspaceInput(inputPath)
+  const root = await realWorkspaceRoot(cwd)
+  const candidate = resolve(root, inputPath)
+  assertInsideWorkspace(root, candidate)
+
+  try {
+    const canonical = await realpath(candidate)
+    assertInsideWorkspace(root, canonical)
+    return canonical
+  } catch (error) {
+    if (!(error instanceof Error) || !('code' in error)) throw error
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+
+  const parent = await findExistingParent(root, candidate)
+  const canonicalParent = await realpath(parent)
+  assertInsideWorkspace(root, canonicalParent)
+  const resolved = resolve(canonicalParent, relative(parent, candidate))
+  assertInsideWorkspace(root, resolved)
+  return resolved
+}
+
+/** Resolves a BrowserOS-generated output file without exposing sibling app state. */
+export async function resolveBrowserToolOutputPath(
+  inputPath: string,
+): Promise<string> {
+  const outputRoot = await realpath(getBrowserToolOutputDir())
+  const candidate = resolve(inputPath)
+  const canonical = await realpath(candidate)
+  if (!isPathInside(outputRoot, canonical)) {
+    throw new Error('Path is outside BrowserOS tool output.')
+  }
+  return canonical
+}

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/path-boundary.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/path-boundary.ts
@@ -1,11 +1,9 @@
 import { lstat, realpath } from 'node:fs/promises'
-import { dirname, isAbsolute, join, relative, resolve, win32 } from 'node:path'
-import { getBrowserosDir } from '../../lib/browseros-dir'
-
-const BROWSER_TOOL_OUTPUT_DIR_NAME = 'tool-output'
+import { dirname, isAbsolute, relative, resolve, win32 } from 'node:path'
+import { getBrowserosDir, getToolOutputDir } from '../../lib/browseros-dir'
 
 export function getBrowserToolOutputDir(): string {
-  return join(getBrowserosDir(), BROWSER_TOOL_OUTPUT_DIR_NAME)
+  return getToolOutputDir()
 }
 
 function isAbsoluteInput(inputPath: string): boolean {
@@ -15,6 +13,12 @@ function isAbsoluteInput(inputPath: string): boolean {
 export function isPathInside(root: string, candidate: string): boolean {
   const rel = relative(root, candidate)
   return rel === '' || (!rel.startsWith('..') && !isAbsoluteInput(rel))
+}
+
+export function isBrowserosStatePath(inputPath: string): boolean {
+  return (
+    isAbsoluteInput(inputPath) && isPathInside(getBrowserosDir(), inputPath)
+  )
 }
 
 function assertRelativeWorkspaceInput(inputPath: string): void {

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/path-boundary.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/path-boundary.ts
@@ -1,14 +1,6 @@
 import { lstat, realpath } from 'node:fs/promises'
 import { dirname, isAbsolute, relative, resolve, win32 } from 'node:path'
-import {
-  getBrowserosDir,
-  getRealToolOutputDir,
-  getToolOutputDir,
-} from '../../lib/browseros-dir'
-
-export function getBrowserToolOutputDir(): string {
-  return getToolOutputDir()
-}
+import { getBrowserosDir, getToolOutputDir } from '../../lib/browseros-dir'
 
 function isAbsoluteInput(inputPath: string): boolean {
   return isAbsolute(inputPath) || win32.isAbsolute(inputPath)
@@ -123,7 +115,7 @@ export async function resolveWorkspaceWritePath(
 export async function resolveBrowserToolOutputPath(
   inputPath: string,
 ): Promise<string> {
-  const outputRoot = await getRealToolOutputDir()
+  const outputRoot = await getToolOutputDir()
   const candidate = resolve(inputPath)
   const canonical = await realpath(candidate)
   if (!isPathInside(outputRoot, canonical)) {

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/path-boundary.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/path-boundary.ts
@@ -37,13 +37,19 @@ function assertRelativeWorkspaceInput(inputPath: string): void {
   }
 }
 
+function assertAbsoluteBrowserosOutputInput(inputPath: string): void {
+  if (!isAbsoluteInput(inputPath)) {
+    throw new Error('Path must be an absolute BrowserOS tool output path.')
+  }
+}
+
 function assertInsideWorkspace(root: string, candidate: string): void {
   if (!isPathInside(root, candidate)) {
     throw new Error('Path is outside the selected workspace.')
   }
 }
 
-async function realWorkspaceRoot(cwd: string): Promise<string> {
+export async function resolveWorkspaceRoot(cwd: string): Promise<string> {
   return await realpath(cwd)
 }
 
@@ -75,8 +81,18 @@ export async function resolveWorkspacePath(
   cwd: string,
   inputPath: string,
 ): Promise<string> {
+  return await resolveWorkspacePathFromRoot(
+    await resolveWorkspaceRoot(cwd),
+    inputPath,
+  )
+}
+
+/** Resolves an existing workspace path when the canonical workspace root is already known. */
+export async function resolveWorkspacePathFromRoot(
+  root: string,
+  inputPath: string,
+): Promise<string> {
   assertRelativeWorkspaceInput(inputPath)
-  const root = await realWorkspaceRoot(cwd)
   const candidate = resolve(root, inputPath)
   assertInsideWorkspace(root, candidate)
   const canonical = await realpath(candidate)
@@ -90,7 +106,7 @@ export async function resolveWorkspaceWritePath(
   inputPath: string,
 ): Promise<string> {
   assertRelativeWorkspaceInput(inputPath)
-  const root = await realWorkspaceRoot(cwd)
+  const root = await resolveWorkspaceRoot(cwd)
   const candidate = resolve(root, inputPath)
   assertInsideWorkspace(root, candidate)
 
@@ -115,6 +131,7 @@ export async function resolveWorkspaceWritePath(
 export async function resolveBrowserToolOutputPath(
   inputPath: string,
 ): Promise<string> {
+  assertAbsoluteBrowserosOutputInput(inputPath)
   const outputRoot = await getToolOutputDir()
   const candidate = resolve(inputPath)
   const canonical = await realpath(candidate)

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/path-boundary.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/path-boundary.ts
@@ -1,6 +1,10 @@
 import { lstat, realpath } from 'node:fs/promises'
 import { dirname, isAbsolute, relative, resolve, win32 } from 'node:path'
-import { getBrowserosDir, getToolOutputDir } from '../../lib/browseros-dir'
+import {
+  getBrowserosDir,
+  getRealToolOutputDir,
+  getToolOutputDir,
+} from '../../lib/browseros-dir'
 
 export function getBrowserToolOutputDir(): string {
   return getToolOutputDir()
@@ -12,12 +16,26 @@ function isAbsoluteInput(inputPath: string): boolean {
 
 export function isPathInside(root: string, candidate: string): boolean {
   const rel = relative(root, candidate)
-  return rel === '' || (!rel.startsWith('..') && !isAbsoluteInput(rel))
+  const escapesRoot =
+    rel === '..' || rel.startsWith('../') || rel.startsWith('..\\')
+  return rel === '' || (!escapesRoot && !isAbsoluteInput(rel))
 }
 
-export function isBrowserosStatePath(inputPath: string): boolean {
-  return (
-    isAbsoluteInput(inputPath) && isPathInside(getBrowserosDir(), inputPath)
+export async function isBrowserosStatePath(
+  inputPath: string,
+): Promise<boolean> {
+  if (!isAbsoluteInput(inputPath)) return false
+
+  const stateRoot = resolve(getBrowserosDir())
+  const candidate = resolve(inputPath)
+  if (isPathInside(stateRoot, candidate)) return true
+
+  const realStateRoot = await realpath(stateRoot).catch(() => null)
+  const realCandidate = await realpath(candidate).catch(() => null)
+  return Boolean(
+    realStateRoot &&
+      realCandidate &&
+      isPathInside(realStateRoot, realCandidate),
   )
 }
 
@@ -105,7 +123,7 @@ export async function resolveWorkspaceWritePath(
 export async function resolveBrowserToolOutputPath(
   inputPath: string,
 ): Promise<string> {
-  const outputRoot = await realpath(getBrowserToolOutputDir())
+  const outputRoot = await getRealToolOutputDir()
   const candidate = resolve(inputPath)
   const canonical = await realpath(candidate)
   if (!isPathInside(outputRoot, canonical)) {

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/read.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/read.ts
@@ -7,8 +7,10 @@ import {
   type FilesystemToolResult,
   IMAGE_EXTENSIONS,
   IMAGE_MIME_TYPES,
+  isBrowserosStatePath,
   MAX_READ_CHARS,
   MAX_READ_LINES,
+  resolveBrowserToolOutputPath,
   resolveWorkspacePath,
   toModelOutput,
 } from './utils'
@@ -96,6 +98,20 @@ function formatReadResult(args: {
   return { text }
 }
 
+async function resolveReadPath(
+  cwd: string,
+  inputPath: string,
+): Promise<string> {
+  try {
+    return await resolveWorkspacePath(cwd, inputPath)
+  } catch (error) {
+    if (error instanceof Error && isBrowserosStatePath(inputPath)) {
+      return await resolveBrowserToolOutputPath(inputPath)
+    }
+    throw error
+  }
+}
+
 export function createReadTool(cwd: string) {
   return tool({
     description: `Read a file from the filesystem. Returns text content with line numbers, or image data for image files. Text reads are limited to ${MAX_READ_LINES} lines and ${MAX_READ_CHARS} characters per call. Use offset and limit to paginate through large files.`,
@@ -114,7 +130,7 @@ export function createReadTool(cwd: string) {
     }),
     execute: (params) =>
       executeWithMetrics(TOOL_NAME, async () => {
-        const resolved = await resolveWorkspacePath(cwd, params.path)
+        const resolved = await resolveReadPath(cwd, params.path)
         const ext = extname(resolved).toLowerCase()
 
         if (IMAGE_EXTENSIONS.has(ext)) {

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/read.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/read.ts
@@ -1,5 +1,5 @@
 import { readFile } from 'node:fs/promises'
-import { extname, resolve } from 'node:path'
+import { extname } from 'node:path'
 import { tool } from 'ai'
 import { z } from 'zod'
 import {
@@ -9,6 +9,7 @@ import {
   IMAGE_MIME_TYPES,
   MAX_READ_CHARS,
   MAX_READ_LINES,
+  resolveWorkspacePath,
   toModelOutput,
 } from './utils'
 
@@ -99,9 +100,7 @@ export function createReadTool(cwd: string) {
   return tool({
     description: `Read a file from the filesystem. Returns text content with line numbers, or image data for image files. Text reads are limited to ${MAX_READ_LINES} lines and ${MAX_READ_CHARS} characters per call. Use offset and limit to paginate through large files.`,
     inputSchema: z.object({
-      path: z
-        .string()
-        .describe('File path (relative to working directory or absolute)'),
+      path: z.string().describe('File path relative to the selected workspace'),
       offset: z
         .number()
         .optional()
@@ -115,7 +114,7 @@ export function createReadTool(cwd: string) {
     }),
     execute: (params) =>
       executeWithMetrics(TOOL_NAME, async () => {
-        const resolved = resolve(cwd, params.path)
+        const resolved = await resolveWorkspacePath(cwd, params.path)
         const ext = extname(resolved).toLowerCase()
 
         if (IMAGE_EXTENSIONS.has(ext)) {

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/read.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/read.ts
@@ -105,7 +105,7 @@ async function resolveReadPath(
   try {
     return await resolveWorkspacePath(cwd, inputPath)
   } catch (error) {
-    if (error instanceof Error && isBrowserosStatePath(inputPath)) {
+    if (error instanceof Error && (await isBrowserosStatePath(inputPath))) {
       return await resolveBrowserToolOutputPath(inputPath)
     }
     throw error

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/utils.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/utils.ts
@@ -1,10 +1,10 @@
 import type { Dirent } from 'node:fs'
-import { lstat, readdir, realpath } from 'node:fs/promises'
-import { dirname, isAbsolute, join, relative, resolve, win32 } from 'node:path'
+import { readdir, realpath } from 'node:fs/promises'
+import { join, relative } from 'node:path'
 import { TOOL_LIMITS } from '@browseros/shared/constants/limits'
-import { getBrowserosDir } from '../../lib/browseros-dir'
 import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
+import { isPathInside } from './path-boundary'
 
 const MAX_LINES = 2000
 const MAX_BYTES = 50 * 1024
@@ -16,7 +16,13 @@ export const DEFAULT_BASH_TIMEOUT = 120
 export const MAX_GREP_FILE_SIZE = 2 * 1024 * 1024
 export const MAX_READ_LINES = TOOL_LIMITS.FILESYSTEM_READ_MAX_LINES
 export const MAX_READ_CHARS = TOOL_LIMITS.FILESYSTEM_READ_MAX_CHARS
-const BROWSER_TOOL_OUTPUT_DIR_NAME = 'tool-output'
+
+export {
+  getBrowserToolOutputDir,
+  resolveBrowserToolOutputPath,
+  resolveWorkspacePath,
+  resolveWorkspaceWritePath,
+} from './path-boundary'
 
 export interface FilesystemToolResult {
   text: string
@@ -29,118 +35,6 @@ export interface TruncationResult {
   truncated: boolean
   totalLines: number
   keptLines: number
-}
-
-export function getBrowserToolOutputDir(): string {
-  return join(getBrowserosDir(), BROWSER_TOOL_OUTPUT_DIR_NAME)
-}
-
-function isAbsoluteInput(inputPath: string): boolean {
-  return isAbsolute(inputPath) || win32.isAbsolute(inputPath)
-}
-
-function isInside(root: string, candidate: string): boolean {
-  const rel = relative(root, candidate)
-  return rel === '' || (!rel.startsWith('..') && !isAbsoluteInput(rel))
-}
-
-function assertRelativeWorkspaceInput(inputPath: string): void {
-  if (isAbsoluteInput(inputPath)) {
-    throw new Error('Path must be relative to the selected workspace.')
-  }
-}
-
-function assertInsideWorkspace(root: string, candidate: string): void {
-  if (!isInside(root, candidate)) {
-    throw new Error('Path is outside the selected workspace.')
-  }
-}
-
-async function realWorkspaceRoot(cwd: string): Promise<string> {
-  return await realpath(cwd)
-}
-
-async function findExistingParent(
-  root: string,
-  targetPath: string,
-): Promise<string> {
-  let parent = dirname(targetPath)
-
-  while (isInside(root, parent)) {
-    try {
-      await lstat(parent)
-      return parent
-    } catch (error) {
-      if (!(error instanceof Error) || !('code' in error)) throw error
-      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
-    }
-
-    const next = dirname(parent)
-    if (next === parent) break
-    parent = next
-  }
-
-  throw new Error('Path is outside the selected workspace.')
-}
-
-/**
- * Resolves an existing workspace path and rejects traversal or symlink escapes.
- */
-export async function resolveWorkspacePath(
-  cwd: string,
-  inputPath: string,
-): Promise<string> {
-  assertRelativeWorkspaceInput(inputPath)
-  const root = await realWorkspaceRoot(cwd)
-  const candidate = resolve(root, inputPath)
-  assertInsideWorkspace(root, candidate)
-  const canonical = await realpath(candidate)
-  assertInsideWorkspace(root, canonical)
-  return canonical
-}
-
-/**
- * Resolves a workspace write target, validating the existing parent chain first.
- */
-export async function resolveWorkspaceWritePath(
-  cwd: string,
-  inputPath: string,
-): Promise<string> {
-  assertRelativeWorkspaceInput(inputPath)
-  const root = await realWorkspaceRoot(cwd)
-  const candidate = resolve(root, inputPath)
-  assertInsideWorkspace(root, candidate)
-
-  try {
-    const canonical = await realpath(candidate)
-    assertInsideWorkspace(root, canonical)
-    return canonical
-  } catch (error) {
-    if (!(error instanceof Error) || !('code' in error)) throw error
-    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
-  }
-
-  const parent = await findExistingParent(root, candidate)
-  const canonicalParent = await realpath(parent)
-  assertInsideWorkspace(root, canonicalParent)
-  const resolved = resolve(canonicalParent, relative(parent, candidate))
-  assertInsideWorkspace(root, resolved)
-  return resolved
-}
-
-/**
- * Resolves a BrowserOS-generated output file without exposing sibling app state.
- */
-export async function resolveBrowserToolOutputPath(
-  inputPath: string,
-): Promise<string> {
-  const outputRoot = await realpath(getBrowserToolOutputDir())
-  const candidate = resolve(inputPath)
-  const canonical = await realpath(candidate)
-  if (!isInside(outputRoot, canonical)) {
-    throw new Error('Path is outside BrowserOS tool output.')
-  }
-  return canonical
 }
 
 export function truncateHead(
@@ -321,7 +215,9 @@ export const IMAGE_MIME_TYPES: Record<string, string> = {
 export async function* walkFiles(
   dir: string,
   baseDir: string,
+  boundaryRoot?: string,
 ): AsyncGenerator<string> {
+  const root = boundaryRoot ?? (await realpath(baseDir))
   let entries: Dirent[]
   try {
     entries = (await readdir(dir, { withFileTypes: true })) as Dirent[]
@@ -333,8 +229,10 @@ export async function* walkFiles(
     const fullPath = join(dir, entry.name as string)
     if (entry.isDirectory()) {
       if (IGNORED_DIRS.has(entry.name as string)) continue
-      yield* walkFiles(fullPath, baseDir)
+      yield* walkFiles(fullPath, baseDir, root)
     } else if (entry.isFile() || entry.isSymbolicLink()) {
+      const canonical = await realpath(fullPath).catch(() => null)
+      if (!canonical || !isPathInside(root, canonical)) continue
       yield relative(baseDir, fullPath)
     }
   }

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/utils.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/utils.ts
@@ -213,11 +213,17 @@ export const IMAGE_MIME_TYPES: Record<string, string> = {
   '.ico': 'image/x-icon',
 }
 
+export interface WalkFileEntry {
+  path: string
+  realPath: string
+}
+
+/** Walks visible files while preserving both display and canonical read paths. */
 export async function* walkFiles(
   dir: string,
   baseDir: string,
   boundaryRoot?: string,
-): AsyncGenerator<string> {
+): AsyncGenerator<WalkFileEntry> {
   const root = boundaryRoot ?? (await realpath(baseDir))
   let entries: Dirent[]
   try {
@@ -234,7 +240,10 @@ export async function* walkFiles(
     } else if (entry.isFile() || entry.isSymbolicLink()) {
       const canonical = await realpath(fullPath).catch(() => null)
       if (!canonical || !isPathInside(root, canonical)) continue
-      yield relative(baseDir, fullPath)
+      yield {
+        path: relative(baseDir, fullPath),
+        realPath: canonical,
+      }
     }
   }
 }

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/utils.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/utils.ts
@@ -21,6 +21,8 @@ export {
   isBrowserosStatePath,
   resolveBrowserToolOutputPath,
   resolveWorkspacePath,
+  resolveWorkspacePathFromRoot,
+  resolveWorkspaceRoot,
   resolveWorkspaceWritePath,
 } from './path-boundary'
 

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/utils.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/utils.ts
@@ -19,6 +19,7 @@ export const MAX_READ_CHARS = TOOL_LIMITS.FILESYSTEM_READ_MAX_CHARS
 
 export {
   getBrowserToolOutputDir,
+  isBrowserosStatePath,
   resolveBrowserToolOutputPath,
   resolveWorkspacePath,
   resolveWorkspaceWritePath,

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/utils.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/utils.ts
@@ -18,7 +18,6 @@ export const MAX_READ_LINES = TOOL_LIMITS.FILESYSTEM_READ_MAX_LINES
 export const MAX_READ_CHARS = TOOL_LIMITS.FILESYSTEM_READ_MAX_CHARS
 
 export {
-  getBrowserToolOutputDir,
   isBrowserosStatePath,
   resolveBrowserToolOutputPath,
   resolveWorkspacePath,

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/utils.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/utils.ts
@@ -1,7 +1,8 @@
 import type { Dirent } from 'node:fs'
-import { readdir } from 'node:fs/promises'
-import { join, relative } from 'node:path'
+import { lstat, readdir, realpath } from 'node:fs/promises'
+import { dirname, isAbsolute, join, relative, resolve, win32 } from 'node:path'
 import { TOOL_LIMITS } from '@browseros/shared/constants/limits'
+import { getBrowserosDir } from '../../lib/browseros-dir'
 import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
 
@@ -15,6 +16,7 @@ export const DEFAULT_BASH_TIMEOUT = 120
 export const MAX_GREP_FILE_SIZE = 2 * 1024 * 1024
 export const MAX_READ_LINES = TOOL_LIMITS.FILESYSTEM_READ_MAX_LINES
 export const MAX_READ_CHARS = TOOL_LIMITS.FILESYSTEM_READ_MAX_CHARS
+const BROWSER_TOOL_OUTPUT_DIR_NAME = 'tool-output'
 
 export interface FilesystemToolResult {
   text: string
@@ -27,6 +29,118 @@ export interface TruncationResult {
   truncated: boolean
   totalLines: number
   keptLines: number
+}
+
+export function getBrowserToolOutputDir(): string {
+  return join(getBrowserosDir(), BROWSER_TOOL_OUTPUT_DIR_NAME)
+}
+
+function isAbsoluteInput(inputPath: string): boolean {
+  return isAbsolute(inputPath) || win32.isAbsolute(inputPath)
+}
+
+function isInside(root: string, candidate: string): boolean {
+  const rel = relative(root, candidate)
+  return rel === '' || (!rel.startsWith('..') && !isAbsoluteInput(rel))
+}
+
+function assertRelativeWorkspaceInput(inputPath: string): void {
+  if (isAbsoluteInput(inputPath)) {
+    throw new Error('Path must be relative to the selected workspace.')
+  }
+}
+
+function assertInsideWorkspace(root: string, candidate: string): void {
+  if (!isInside(root, candidate)) {
+    throw new Error('Path is outside the selected workspace.')
+  }
+}
+
+async function realWorkspaceRoot(cwd: string): Promise<string> {
+  return await realpath(cwd)
+}
+
+async function findExistingParent(
+  root: string,
+  targetPath: string,
+): Promise<string> {
+  let parent = dirname(targetPath)
+
+  while (isInside(root, parent)) {
+    try {
+      await lstat(parent)
+      return parent
+    } catch (error) {
+      if (!(error instanceof Error) || !('code' in error)) throw error
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+    }
+
+    const next = dirname(parent)
+    if (next === parent) break
+    parent = next
+  }
+
+  throw new Error('Path is outside the selected workspace.')
+}
+
+/**
+ * Resolves an existing workspace path and rejects traversal or symlink escapes.
+ */
+export async function resolveWorkspacePath(
+  cwd: string,
+  inputPath: string,
+): Promise<string> {
+  assertRelativeWorkspaceInput(inputPath)
+  const root = await realWorkspaceRoot(cwd)
+  const candidate = resolve(root, inputPath)
+  assertInsideWorkspace(root, candidate)
+  const canonical = await realpath(candidate)
+  assertInsideWorkspace(root, canonical)
+  return canonical
+}
+
+/**
+ * Resolves a workspace write target, validating the existing parent chain first.
+ */
+export async function resolveWorkspaceWritePath(
+  cwd: string,
+  inputPath: string,
+): Promise<string> {
+  assertRelativeWorkspaceInput(inputPath)
+  const root = await realWorkspaceRoot(cwd)
+  const candidate = resolve(root, inputPath)
+  assertInsideWorkspace(root, candidate)
+
+  try {
+    const canonical = await realpath(candidate)
+    assertInsideWorkspace(root, canonical)
+    return canonical
+  } catch (error) {
+    if (!(error instanceof Error) || !('code' in error)) throw error
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error
+  }
+
+  const parent = await findExistingParent(root, candidate)
+  const canonicalParent = await realpath(parent)
+  assertInsideWorkspace(root, canonicalParent)
+  const resolved = resolve(canonicalParent, relative(parent, candidate))
+  assertInsideWorkspace(root, resolved)
+  return resolved
+}
+
+/**
+ * Resolves a BrowserOS-generated output file without exposing sibling app state.
+ */
+export async function resolveBrowserToolOutputPath(
+  inputPath: string,
+): Promise<string> {
+  const outputRoot = await realpath(getBrowserToolOutputDir())
+  const candidate = resolve(inputPath)
+  const canonical = await realpath(candidate)
+  if (!isInside(outputRoot, canonical)) {
+    throw new Error('Path is outside BrowserOS tool output.')
+  }
+  return canonical
 }
 
 export function truncateHead(

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/write.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/write.ts
@@ -1,8 +1,12 @@
 import { mkdir, writeFile } from 'node:fs/promises'
-import { dirname, resolve } from 'node:path'
+import { dirname } from 'node:path'
 import { tool } from 'ai'
 import { z } from 'zod'
-import { executeWithMetrics, toModelOutput } from './utils'
+import {
+  executeWithMetrics,
+  resolveWorkspaceWritePath,
+  toModelOutput,
+} from './utils'
 
 const TOOL_NAME = 'filesystem_write'
 
@@ -11,14 +15,12 @@ export function createWriteTool(cwd: string) {
     description:
       "Create or overwrite a file. Automatically creates parent directories if they don't exist. Use this to create new files or completely replace file contents.",
     inputSchema: z.object({
-      path: z
-        .string()
-        .describe('File path (relative to working directory or absolute)'),
+      path: z.string().describe('File path relative to the selected workspace'),
       content: z.string().describe('Complete file content to write'),
     }),
     execute: (params) =>
       executeWithMetrics(TOOL_NAME, async () => {
-        const resolved = resolve(cwd, params.path)
+        const resolved = await resolveWorkspaceWritePath(cwd, params.path)
         await mkdir(dirname(resolved), { recursive: true })
         await writeFile(resolved, params.content, 'utf-8')
         const bytes = Buffer.byteLength(params.content, 'utf-8')

--- a/packages/browseros-agent/apps/server/src/tools/legacy/output-file.ts
+++ b/packages/browseros-agent/apps/server/src/tools/legacy/output-file.ts
@@ -1,9 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
-import {
-  ensureToolOutputDir,
-  writeToolOutputFile,
-} from '../../lib/browseros-dir'
+import { getToolOutputDir, writeToolOutputFile } from '../../lib/browseros-dir'
 
 function sanitizeSegment(value: string): string {
   const sanitized = value.replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '')
@@ -15,7 +12,7 @@ export async function writeTempToolOutputFile(args: {
   extension: string
   content: string
 }): Promise<string> {
-  const outputDir = await ensureToolOutputDir()
+  const outputDir = await getToolOutputDir()
   const toolName = sanitizeSegment(args.toolName)
   const extension = sanitizeSegment(args.extension) || 'txt'
   const filePath = join(

--- a/packages/browseros-agent/apps/server/src/tools/legacy/output-file.ts
+++ b/packages/browseros-agent/apps/server/src/tools/legacy/output-file.ts
@@ -1,6 +1,9 @@
 import { randomUUID } from 'node:crypto'
 import { join } from 'node:path'
-import { ensureToolOutputDir } from '../../lib/browseros-dir'
+import {
+  ensureToolOutputDir,
+  writeToolOutputFile,
+} from '../../lib/browseros-dir'
 
 function sanitizeSegment(value: string): string {
   const sanitized = value.replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '')
@@ -20,6 +23,6 @@ export async function writeTempToolOutputFile(args: {
     `${toolName}-${Date.now()}-${randomUUID()}.${extension}`,
   )
 
-  await Bun.write(filePath, args.content)
+  await writeToolOutputFile(filePath, args.content)
   return filePath
 }

--- a/packages/browseros-agent/apps/server/src/tools/legacy/output-file.ts
+++ b/packages/browseros-agent/apps/server/src/tools/legacy/output-file.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from 'node:crypto'
-import { mkdtemp } from 'node:fs/promises'
-import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { ensureToolOutputDir } from '../../lib/browseros-dir'
 
 function sanitizeSegment(value: string): string {
   const sanitized = value.replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '')
@@ -13,7 +12,7 @@ export async function writeTempToolOutputFile(args: {
   extension: string
   content: string
 }): Promise<string> {
-  const outputDir = await mkdtemp(join(tmpdir(), 'browseros-tool-output-'))
+  const outputDir = await ensureToolOutputDir()
   const toolName = sanitizeSegment(args.toolName)
   const extension = sanitizeSegment(args.extension) || 'txt'
   const filePath = join(

--- a/packages/browseros-agent/apps/server/tests/agent/ai-sdk-agent-filesystem.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/ai-sdk-agent-filesystem.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'bun:test'
+import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
+import { buildAgentFilesystemToolSet } from '../../src/agent/ai-sdk-agent'
+import type { ResolvedAgentConfig } from '../../src/agent/types'
+
+function agentConfig(
+  overrides: Partial<ResolvedAgentConfig> = {},
+): ResolvedAgentConfig {
+  return {
+    conversationId: crypto.randomUUID(),
+    provider: LLM_PROVIDERS.OPENAI,
+    model: 'test-model',
+    ...overrides,
+  }
+}
+
+describe('buildAgentFilesystemToolSet', () => {
+  it('omits filesystem tools when no workspace is selected', () => {
+    const tools = buildAgentFilesystemToolSet(agentConfig())
+    expect(Object.keys(tools)).toEqual([])
+  })
+
+  it('includes filesystem tools when a workspace is selected', () => {
+    const tools = buildAgentFilesystemToolSet(
+      agentConfig({ workingDir: '/tmp/browseros-workspace' }),
+    )
+    expect(Object.keys(tools).sort()).toEqual([
+      'filesystem_bash',
+      'filesystem_edit',
+      'filesystem_find',
+      'filesystem_grep',
+      'filesystem_ls',
+      'filesystem_read',
+      'filesystem_write',
+    ])
+  })
+
+  it('omits filesystem tools in chat mode even when a workspace is selected', () => {
+    const tools = buildAgentFilesystemToolSet(
+      agentConfig({ chatMode: true, workingDir: '/tmp/browseros-workspace' }),
+    )
+    expect(Object.keys(tools)).toEqual([])
+  })
+
+  it('omits filesystem tools for ACP providers', () => {
+    const tools = buildAgentFilesystemToolSet(
+      agentConfig({
+        provider: LLM_PROVIDERS.CODEX,
+        workingDir: '/tmp/browseros-workspace',
+      }),
+    )
+    expect(Object.keys(tools)).toEqual([])
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/browseros-dir.test.ts
+++ b/packages/browseros-agent/apps/server/tests/browseros-dir.test.ts
@@ -17,11 +17,9 @@ import { join } from 'node:path'
 import { PATHS } from '@browseros/shared/constants/paths'
 import {
   ensureBrowserosDir,
-  ensureToolOutputDir,
   getBrowserosDir,
   getCacheDir,
   getDbPath,
-  getRealToolOutputDir,
   getSessionsDir,
   getToolOutputDir,
   logDevelopmentBrowserosDir,
@@ -143,7 +141,7 @@ describe('getBrowserosDir', () => {
       await ensureBrowserosDir()
 
       expect(existsSync(getSessionsDir())).toBe(true)
-      expect(existsSync(getToolOutputDir())).toBe(true)
+      expect(existsSync(join(browserosDir, 'tool-output'))).toBe(true)
       expect(existsSync(join(browserosDir, 'cache', 'vm'))).toBe(false)
       expect(existsSync(join(browserosDir, 'vm'))).toBe(false)
       expect(existsSync(join(browserosDir, 'lazy-monitoring'))).toBe(false)
@@ -160,15 +158,16 @@ describe('getBrowserosDir', () => {
     process.env.BROWSEROS_DIR = browserosDir
 
     try {
-      const createdOutputDir = await getRealToolOutputDir()
-      expect(createdOutputDir).toBe(realpathSync(getToolOutputDir()))
+      const rawOutputDir = join(browserosDir, 'tool-output')
+      const createdOutputDir = await getToolOutputDir()
+      expect(createdOutputDir).toBe(realpathSync(rawOutputDir))
       if (process.platform !== 'win32') {
-        chmodSync(getToolOutputDir(), 0o777)
+        chmodSync(rawOutputDir, 0o777)
       }
 
-      const outputDir = await ensureToolOutputDir()
+      const outputDir = await getToolOutputDir()
 
-      expect(outputDir).toBe(realpathSync(getToolOutputDir()))
+      expect(outputDir).toBe(realpathSync(rawOutputDir))
       if (process.platform !== 'win32') {
         expect(statSync(outputDir).mode & 0o777).toBe(TOOL_OUTPUT_DIR_MODE)
       }

--- a/packages/browseros-agent/apps/server/tests/browseros-dir.test.ts
+++ b/packages/browseros-agent/apps/server/tests/browseros-dir.test.ts
@@ -11,6 +11,7 @@ import {
   realpathSync,
   rmSync,
   statSync,
+  writeFileSync,
 } from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -24,6 +25,7 @@ import {
   getToolOutputDir,
   logDevelopmentBrowserosDir,
   TOOL_OUTPUT_DIR_MODE,
+  writeToolOutputFile,
 } from '../src/lib/browseros-dir'
 import { logger } from '../src/lib/logger'
 
@@ -171,6 +173,23 @@ describe('getBrowserosDir', () => {
       if (process.platform !== 'win32') {
         expect(statSync(outputDir).mode & 0o777).toBe(TOOL_OUTPUT_DIR_MODE)
       }
+    } finally {
+      rmSync(browserosDir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not overwrite existing generated tool output files', async () => {
+    const browserosDir = mkdtempSync(join(tmpdir(), 'browseros-dir-test-'))
+    process.env.BROWSEROS_DIR = browserosDir
+
+    try {
+      const outputDir = await getToolOutputDir()
+      const outputPath = join(outputDir, 'existing.txt')
+      writeFileSync(outputPath, 'original')
+
+      await expect(
+        writeToolOutputFile(outputPath, 'replacement'),
+      ).rejects.toThrow('EEXIST')
     } finally {
       rmSync(browserosDir, { recursive: true, force: true })
     }

--- a/packages/browseros-agent/apps/server/tests/browseros-dir.test.ts
+++ b/packages/browseros-agent/apps/server/tests/browseros-dir.test.ts
@@ -21,6 +21,7 @@ import {
   getBrowserosDir,
   getCacheDir,
   getDbPath,
+  getRealToolOutputDir,
   getSessionsDir,
   getToolOutputDir,
   logDevelopmentBrowserosDir,
@@ -142,6 +143,7 @@ describe('getBrowserosDir', () => {
       await ensureBrowserosDir()
 
       expect(existsSync(getSessionsDir())).toBe(true)
+      expect(existsSync(getToolOutputDir())).toBe(true)
       expect(existsSync(join(browserosDir, 'cache', 'vm'))).toBe(false)
       expect(existsSync(join(browserosDir, 'vm'))).toBe(false)
       expect(existsSync(join(browserosDir, 'lazy-monitoring'))).toBe(false)
@@ -158,7 +160,8 @@ describe('getBrowserosDir', () => {
     process.env.BROWSEROS_DIR = browserosDir
 
     try {
-      await ensureToolOutputDir()
+      const createdOutputDir = await getRealToolOutputDir()
+      expect(createdOutputDir).toBe(realpathSync(getToolOutputDir()))
       if (process.platform !== 'win32') {
         chmodSync(getToolOutputDir(), 0o777)
       }

--- a/packages/browseros-agent/apps/server/tests/browseros-dir.test.ts
+++ b/packages/browseros-agent/apps/server/tests/browseros-dir.test.ts
@@ -4,17 +4,27 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
-import { existsSync, mkdtempSync, rmSync } from 'node:fs'
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  statSync,
+} from 'node:fs'
 import { homedir, tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { PATHS } from '@browseros/shared/constants/paths'
 import {
   ensureBrowserosDir,
+  ensureToolOutputDir,
   getBrowserosDir,
   getCacheDir,
   getDbPath,
   getSessionsDir,
+  getToolOutputDir,
   logDevelopmentBrowserosDir,
+  TOOL_OUTPUT_DIR_MODE,
 } from '../src/lib/browseros-dir'
 import { logger } from '../src/lib/logger'
 
@@ -138,6 +148,27 @@ describe('getBrowserosDir', () => {
       expect(existsSync(join(browserosDir, 'lazy-monitoring', 'runs'))).toBe(
         false,
       )
+    } finally {
+      rmSync(browserosDir, { recursive: true, force: true })
+    }
+  })
+
+  it('locks down the tool output directory permissions', async () => {
+    const browserosDir = mkdtempSync(join(tmpdir(), 'browseros-dir-test-'))
+    process.env.BROWSEROS_DIR = browserosDir
+
+    try {
+      await ensureToolOutputDir()
+      if (process.platform !== 'win32') {
+        chmodSync(getToolOutputDir(), 0o777)
+      }
+
+      const outputDir = await ensureToolOutputDir()
+
+      expect(outputDir).toBe(realpathSync(getToolOutputDir()))
+      if (process.platform !== 'win32') {
+        expect(statSync(outputDir).mode & 0o777).toBe(TOOL_OUTPUT_DIR_MODE)
+      }
     } finally {
       rmSync(browserosDir, { recursive: true, force: true })
     }

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -22,6 +22,7 @@ import {
 import type { Browser } from '../../../src/browser/browser'
 import type { BrowserSession } from '../../../src/browser/core/session'
 import {
+  getToolOutputDir,
   TOOL_OUTPUT_DIR_MODE,
   TOOL_OUTPUT_FILE_MODE,
 } from '../../../src/lib/browseros-dir'
@@ -33,7 +34,6 @@ import {
 import { registerBrowserTools } from '../../../src/tools/browser/register'
 import { BROWSER_TOOLS } from '../../../src/tools/browser/registry'
 import { createReadTool } from '../../../src/tools/filesystem/read'
-import { getBrowserToolOutputDir } from '../../../src/tools/filesystem/utils'
 import { get_page_content as legacyGetPageContent } from '../../../src/tools/legacy/browser/snapshot'
 import { executeTool as executeLegacyTool } from '../../../src/tools/legacy/framework'
 
@@ -82,16 +82,15 @@ async function withBrowserosDir<T>(run: () => Promise<T>): Promise<T> {
   }
 }
 
-function expectBrowserToolOutputPath(filePath: string | undefined): void {
+async function expectBrowserToolOutputPath(
+  filePath: string | undefined,
+): Promise<void> {
   expect(filePath).toBeTruthy()
   const path = filePath ?? ''
-  expect(realpathSync(dirname(path))).toBe(
-    realpathSync(getBrowserToolOutputDir()),
-  )
+  const outputDir = await getToolOutputDir()
+  expect(realpathSync(dirname(path))).toBe(realpathSync(outputDir))
   if (process.platform !== 'win32') {
-    expect(statSync(getBrowserToolOutputDir()).mode & 0o777).toBe(
-      TOOL_OUTPUT_DIR_MODE,
-    )
+    expect(statSync(outputDir).mode & 0o777).toBe(TOOL_OUTPUT_DIR_MODE)
     expect(statSync(path).mode & 0o777).toBe(TOOL_OUTPUT_FILE_MODE)
   }
 }
@@ -451,7 +450,7 @@ describe('registerBrowserTools', () => {
         ]),
       )
       const data = result?.structuredContent as { path?: string } | undefined
-      expectBrowserToolOutputPath(data?.path)
+      await expectBrowserToolOutputPath(data?.path)
       expect(readFileSync(data?.path ?? '', 'utf8')).toBe(largeText)
     })
   })
@@ -523,7 +522,7 @@ describe('registerBrowserTools', () => {
         writtenToFile: true,
       })
       const savedPath = data?.path
-      expectBrowserToolOutputPath(savedPath)
+      await expectBrowserToolOutputPath(savedPath)
       expect(savedPath?.endsWith('.md')).toBe(true)
       expect(result?.content).toEqual([
         expect.objectContaining({
@@ -583,7 +582,7 @@ describe('registerBrowserTools', () => {
           text: expect.stringContaining(savedPath ?? ''),
         }),
       ])
-      expectBrowserToolOutputPath(savedPath)
+      await expectBrowserToolOutputPath(savedPath)
       expect(readFileSync(savedPath ?? '', 'utf8')).toContain(largeSnapshot)
     })
   })
@@ -758,7 +757,7 @@ describe('buildBrowserToolSet', () => {
       const data = result.structuredContent as { path?: string } | undefined
       expect(result.isError).toBeUndefined()
       const savedPath = data?.path
-      expectBrowserToolOutputPath(savedPath)
+      await expectBrowserToolOutputPath(savedPath)
 
       const readTool = createReadTool(process.cwd())
       const readResult = (await readTool.execute?.(

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'bun:test'
-import { existsSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { TOOL_LIMITS } from '@browseros/shared/constants/limits'
@@ -20,6 +20,7 @@ import {
 } from '../../../src/tools/browser/framework'
 import { registerBrowserTools } from '../../../src/tools/browser/register'
 import { BROWSER_TOOLS } from '../../../src/tools/browser/registry'
+import { getBrowserToolOutputDir } from '../../../src/tools/filesystem/utils'
 
 type RegisteredHandler = (args: Record<string, unknown>) => Promise<{
   content: unknown
@@ -47,6 +48,22 @@ function createFakeServer() {
         handlers.set(name, handler)
       },
     },
+  }
+}
+
+async function withBrowserosDir<T>(run: () => Promise<T>): Promise<T> {
+  const previous = process.env.BROWSEROS_DIR
+  const browserosDir = mkdtempSync(join(tmpdir(), 'browseros-output-test-'))
+  process.env.BROWSEROS_DIR = browserosDir
+  try {
+    return await run()
+  } finally {
+    if (previous === undefined) {
+      delete process.env.BROWSEROS_DIR
+    } else {
+      process.env.BROWSEROS_DIR = previous
+    }
+    rmSync(browserosDir, { recursive: true, force: true })
   }
 }
 
@@ -363,44 +380,51 @@ describe('registerBrowserTools', () => {
     expect(evaluateCalls[0]?.timeout).toBe(30_000)
   })
 
-  it('caps large read results and writes the full content to a file', async () => {
-    const fake = createFakeServer()
-    const largeText = 'x'.repeat(TOOL_LIMITS.INLINE_PAGE_CONTENT_MAX_CHARS + 1)
-    const session = {
-      pages: {
-        getSession: async () => ({
-          session: {
-            Runtime: {
-              evaluate: async () => ({ result: { value: largeText } }),
+  it('caps large read results and writes the full content to a BrowserOS output file', async () => {
+    await withBrowserosDir(async () => {
+      const fake = createFakeServer()
+      const largeText = 'x'.repeat(
+        TOOL_LIMITS.INLINE_PAGE_CONTENT_MAX_CHARS + 1,
+      )
+      const session = {
+        pages: {
+          getSession: async () => ({
+            session: {
+              Runtime: {
+                evaluate: async () => ({ result: { value: largeText } }),
+              },
             },
-          },
-        }),
-        getInfo: () => ({ url: 'https://example.com' }),
-      },
-    } as unknown as BrowserSession
+          }),
+          getInfo: () => ({ url: 'https://example.com' }),
+        },
+      } as unknown as BrowserSession
 
-    registerBrowserTools(fake.server as never, session)
+      registerBrowserTools(fake.server as never, session)
 
-    const result = await fake.handlers.get('read')?.({
-      page: 1,
-      format: 'text',
+      const result = await fake.handlers.get('read')?.({
+        page: 1,
+        format: 'text',
+      })
+
+      expect(result?.isError).toBeFalsy()
+      expect(result?.structuredContent).toMatchObject({
+        page: 1,
+        format: 'text',
+        contentLength: largeText.length,
+        writtenToFile: true,
+      })
+      expect(result?.content).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'text',
+            text: expect.stringContaining('Content truncated'),
+          }),
+        ]),
+      )
+      const data = result?.structuredContent as { path?: string } | undefined
+      expect(dirname(data?.path ?? '')).toBe(getBrowserToolOutputDir())
+      expect(readFileSync(data?.path ?? '', 'utf8')).toBe(largeText)
     })
-
-    expect(result?.isError).toBeFalsy()
-    expect(result?.structuredContent).toMatchObject({
-      page: 1,
-      format: 'text',
-      contentLength: largeText.length,
-      writtenToFile: true,
-    })
-    expect(result?.content).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          type: 'text',
-          text: expect.stringContaining('Content truncated'),
-        }),
-      ]),
-    )
   })
 
   it('keeps small snapshots inline with the existing structured content', async () => {
@@ -435,25 +459,23 @@ describe('registerBrowserTools', () => {
     expect(JSON.stringify(result?.structuredContent)).not.toContain('path')
   })
 
-  it('writes very large snapshots to a markdown temp file', async () => {
-    const fake = createFakeServer()
-    const largeSnapshot = Array.from(
-      { length: 5001 },
-      (_, i) => `node-${i}`,
-    ).join(' ')
-    const session = {
-      observe: () => ({
-        snapshot: async () => ({ text: largeSnapshot }),
-      }),
-      pages: {
-        getInfo: () => ({ url: 'https://example.com/large' }),
-      },
-    } as unknown as BrowserSession
-    let savedPath: string | undefined
+  it('writes very large snapshots to a BrowserOS output markdown file', async () => {
+    await withBrowserosDir(async () => {
+      const fake = createFakeServer()
+      const largeSnapshot = Array.from(
+        { length: 5001 },
+        (_, i) => `node-${i}`,
+      ).join(' ')
+      const session = {
+        observe: () => ({
+          snapshot: async () => ({ text: largeSnapshot }),
+        }),
+        pages: {
+          getInfo: () => ({ url: 'https://example.com/large' }),
+        },
+      } as unknown as BrowserSession
+      registerBrowserTools(fake.server as never, session)
 
-    registerBrowserTools(fake.server as never, session)
-
-    try {
       const result = await fake.handlers.get('snapshot')?.({ page: 4 })
 
       expect(result?.isError).toBeFalsy()
@@ -471,12 +493,10 @@ describe('registerBrowserTools', () => {
         wordCount: 5001,
         writtenToFile: true,
       })
-      savedPath = data?.path
+      const savedPath = data?.path
       expect(savedPath).toBeTruthy()
       expect(savedPath?.endsWith('.md')).toBe(true)
-      expect(dirname(savedPath ?? '')).toStartWith(
-        join(tmpdir(), 'browseros-browser-tool-'),
-      )
+      expect(dirname(savedPath ?? '')).toBe(getBrowserToolOutputDir())
       expect(result?.content).toEqual([
         expect.objectContaining({
           type: 'text',
@@ -497,28 +517,23 @@ describe('registerBrowserTools', () => {
       expect(savedContent).toContain('node-0')
       expect(savedContent).toContain('node-5000')
       expect(data?.contentLength).toBe(savedContent.length)
-    } finally {
-      if (savedPath)
-        rmSync(dirname(savedPath), { recursive: true, force: true })
-    }
+    })
   })
 
-  it('writes very long unbroken snapshots to a markdown temp file', async () => {
-    const fake = createFakeServer()
-    const largeSnapshot = 'x'.repeat(50_001)
-    const session = {
-      observe: () => ({
-        snapshot: async () => ({ text: largeSnapshot }),
-      }),
-      pages: {
-        getInfo: () => ({ url: 'https://example.com/long-token' }),
-      },
-    } as unknown as BrowserSession
-    let savedPath: string | undefined
+  it('writes very long unbroken snapshots to a BrowserOS output markdown file', async () => {
+    await withBrowserosDir(async () => {
+      const fake = createFakeServer()
+      const largeSnapshot = 'x'.repeat(50_001)
+      const session = {
+        observe: () => ({
+          snapshot: async () => ({ text: largeSnapshot }),
+        }),
+        pages: {
+          getInfo: () => ({ url: 'https://example.com/long-token' }),
+        },
+      } as unknown as BrowserSession
+      registerBrowserTools(fake.server as never, session)
 
-    registerBrowserTools(fake.server as never, session)
-
-    try {
       const result = await fake.handlers.get('snapshot')?.({ page: 5 })
       const data = result?.structuredContent as
         | {
@@ -533,18 +548,16 @@ describe('registerBrowserTools', () => {
         wordCount: 1,
         writtenToFile: true,
       })
-      savedPath = data?.path
+      const savedPath = data?.path
       expect(result?.content).toEqual([
         expect.objectContaining({
           type: 'text',
           text: expect.stringContaining(savedPath ?? ''),
         }),
       ])
+      expect(dirname(savedPath ?? '')).toBe(getBrowserToolOutputDir())
       expect(readFileSync(savedPath ?? '', 'utf8')).toContain(largeSnapshot)
-    } finally {
-      if (savedPath)
-        rmSync(dirname(savedPath), { recursive: true, force: true })
-    }
+    })
   })
 
   it('returns read errors for page-side exceptions', async () => {

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -5,6 +5,7 @@ import {
   readFileSync,
   realpathSync,
   rmSync,
+  statSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -20,6 +21,10 @@ import {
 } from '../../../src/agent/tool-adapter'
 import type { Browser } from '../../../src/browser/browser'
 import type { BrowserSession } from '../../../src/browser/core/session'
+import {
+  TOOL_OUTPUT_DIR_MODE,
+  TOOL_OUTPUT_FILE_MODE,
+} from '../../../src/lib/browseros-dir'
 import {
   defineTool,
   executeTool,
@@ -79,9 +84,16 @@ async function withBrowserosDir<T>(run: () => Promise<T>): Promise<T> {
 
 function expectBrowserToolOutputPath(filePath: string | undefined): void {
   expect(filePath).toBeTruthy()
-  expect(realpathSync(dirname(filePath ?? ''))).toBe(
+  const path = filePath ?? ''
+  expect(realpathSync(dirname(path))).toBe(
     realpathSync(getBrowserToolOutputDir()),
   )
+  if (process.platform !== 'win32') {
+    expect(statSync(getBrowserToolOutputDir()).mode & 0o777).toBe(
+      TOOL_OUTPUT_DIR_MODE,
+    )
+    expect(statSync(path).mode & 0o777).toBe(TOOL_OUTPUT_FILE_MODE)
+  }
 }
 
 describe('registerBrowserTools', () => {

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'bun:test'
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { TOOL_LIMITS } from '@browseros/shared/constants/limits'
@@ -12,6 +18,7 @@ import {
   buildBrowserToolSet,
   buildLegacyBrowserToolSet,
 } from '../../../src/agent/tool-adapter'
+import type { Browser } from '../../../src/browser/browser'
 import type { BrowserSession } from '../../../src/browser/core/session'
 import {
   defineTool,
@@ -20,7 +27,10 @@ import {
 } from '../../../src/tools/browser/framework'
 import { registerBrowserTools } from '../../../src/tools/browser/register'
 import { BROWSER_TOOLS } from '../../../src/tools/browser/registry'
+import { createReadTool } from '../../../src/tools/filesystem/read'
 import { getBrowserToolOutputDir } from '../../../src/tools/filesystem/utils'
+import { get_page_content as legacyGetPageContent } from '../../../src/tools/legacy/browser/snapshot'
+import { executeTool as executeLegacyTool } from '../../../src/tools/legacy/framework'
 
 type RegisteredHandler = (args: Record<string, unknown>) => Promise<{
   content: unknown
@@ -65,6 +75,13 @@ async function withBrowserosDir<T>(run: () => Promise<T>): Promise<T> {
     }
     rmSync(browserosDir, { recursive: true, force: true })
   }
+}
+
+function expectBrowserToolOutputPath(filePath: string | undefined): void {
+  expect(filePath).toBeTruthy()
+  expect(realpathSync(dirname(filePath ?? ''))).toBe(
+    realpathSync(getBrowserToolOutputDir()),
+  )
 }
 
 describe('registerBrowserTools', () => {
@@ -422,7 +439,7 @@ describe('registerBrowserTools', () => {
         ]),
       )
       const data = result?.structuredContent as { path?: string } | undefined
-      expect(dirname(data?.path ?? '')).toBe(getBrowserToolOutputDir())
+      expectBrowserToolOutputPath(data?.path)
       expect(readFileSync(data?.path ?? '', 'utf8')).toBe(largeText)
     })
   })
@@ -494,9 +511,8 @@ describe('registerBrowserTools', () => {
         writtenToFile: true,
       })
       const savedPath = data?.path
-      expect(savedPath).toBeTruthy()
+      expectBrowserToolOutputPath(savedPath)
       expect(savedPath?.endsWith('.md')).toBe(true)
-      expect(dirname(savedPath ?? '')).toBe(getBrowserToolOutputDir())
       expect(result?.content).toEqual([
         expect.objectContaining({
           type: 'text',
@@ -555,7 +571,7 @@ describe('registerBrowserTools', () => {
           text: expect.stringContaining(savedPath ?? ''),
         }),
       ])
-      expect(dirname(savedPath ?? '')).toBe(getBrowserToolOutputDir())
+      expectBrowserToolOutputPath(savedPath)
       expect(readFileSync(savedPath ?? '', 'utf8')).toContain(largeSnapshot)
     })
   })
@@ -709,6 +725,40 @@ describe('buildBrowserToolSet', () => {
     expect(tools.browseros_info).toBeDefined()
     expect(tools.tabs).toBeUndefined()
     expect(Object.keys(tools).length).toBeGreaterThan(50)
+  })
+
+  it('writes legacy large page content to BrowserOS output files readable by filesystem_read', async () => {
+    await withBrowserosDir(async () => {
+      const largeText = `${'legacy output token\n'.repeat(4)}${'x'.repeat(
+        TOOL_LIMITS.INLINE_PAGE_CONTENT_MAX_CHARS + 1,
+      )}`
+      const browser = {
+        contentAsMarkdown: async () => largeText,
+        getTabIdForPage: () => undefined,
+      } as unknown as Browser
+
+      const result = await executeLegacyTool(
+        legacyGetPageContent,
+        { page: 1 },
+        { browser, directories: {} },
+        AbortSignal.timeout(1_000),
+      )
+      const data = result.structuredContent as { path?: string } | undefined
+      expect(result.isError).toBeUndefined()
+      const savedPath = data?.path
+      expectBrowserToolOutputPath(savedPath)
+
+      const readTool = createReadTool(process.cwd())
+      const readResult = (await readTool.execute?.(
+        { path: savedPath as string },
+        {
+          toolCallId: 'read-legacy-output',
+          messages: [],
+        } as never,
+      )) as { text?: string; isError?: boolean }
+      expect(readResult.isError).toBeUndefined()
+      expect(readResult.text).toContain('legacy output token')
+    })
   })
 
   it('uses legacy tool names for legacy chat-mode filtering', () => {

--- a/packages/browseros-agent/apps/server/tests/tools/dom.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/dom.test.ts
@@ -1,12 +1,6 @@
 import { describe, it } from 'bun:test'
 import assert from 'node:assert'
-import {
-  existsSync,
-  readFileSync,
-  realpathSync,
-  rmSync,
-  unlinkSync,
-} from 'node:fs'
+import { existsSync, readFileSync, realpathSync, unlinkSync } from 'node:fs'
 import { dirname, isAbsolute, relative } from 'node:path'
 import { getBrowserToolOutputDir } from '../../src/tools/filesystem/utils'
 import {
@@ -85,9 +79,6 @@ const RICH_PAGE = `data:text/html,${encodeURIComponent(`<!DOCTYPE html>
 
 function cleanupSavedDom(domPath: string): void {
   unlinkSync(domPath)
-  try {
-    rmSync(dirname(domPath))
-  } catch {}
 }
 
 function assertSavedUnderBrowserToolOutput(domPath: string): void {

--- a/packages/browseros-agent/apps/server/tests/tools/dom.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/dom.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'bun:test'
 import assert from 'node:assert'
 import { existsSync, readFileSync, realpathSync, unlinkSync } from 'node:fs'
 import { dirname, isAbsolute, relative } from 'node:path'
-import { getBrowserToolOutputDir } from '../../src/tools/filesystem/utils'
+import { getToolOutputDir } from '../../src/lib/browseros-dir'
 import {
   type WithBrowserContext,
   withBrowser,
@@ -81,11 +81,11 @@ function cleanupSavedDom(domPath: string): void {
   unlinkSync(domPath)
 }
 
-function assertSavedUnderBrowserToolOutput(domPath: string): void {
-  const rel = relative(
-    realpathSync(getBrowserToolOutputDir()),
-    realpathSync(dirname(domPath)),
-  )
+async function assertSavedUnderBrowserToolOutput(
+  domPath: string,
+): Promise<void> {
+  const outputDir = await getToolOutputDir()
+  const rel = relative(realpathSync(outputDir), realpathSync(dirname(domPath)))
   assert.ok(
     rel === '' || (!rel.startsWith('..') && !isAbsolute(rel)),
     'Saved DOM file should be written to BrowserOS tool output',
@@ -129,7 +129,7 @@ describe('get_dom', () => {
 
         assert.ok(textOf(result).includes('Saved DOM'))
         assert.ok(existsSync(domPath), 'Saved DOM file should exist')
-        assertSavedUnderBrowserToolOutput(domPath)
+        await assertSavedUnderBrowserToolOutput(domPath)
         assert.ok(html.includes('<html'), 'Should contain <html> tag')
         assert.ok(html.includes('</html>'), 'Should contain closing </html>')
         assert.ok(html.includes('id="login-form"'), 'Should contain form ID')
@@ -278,7 +278,7 @@ describe('get_dom', () => {
         const html = readFileSync(domPath, 'utf8')
 
         assert.ok(textOf(result).includes('Saved DOM'))
-        assertSavedUnderBrowserToolOutput(domPath)
+        await assertSavedUnderBrowserToolOutput(domPath)
         assert.ok(data.totalLength > 100_000, 'Expected a large DOM payload')
         assert.strictEqual(html.length, data.totalLength)
         assert.ok(

--- a/packages/browseros-agent/apps/server/tests/tools/dom.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/dom.test.ts
@@ -1,8 +1,14 @@
 import { describe, it } from 'bun:test'
 import assert from 'node:assert'
-import { existsSync, readFileSync, rmSync, unlinkSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import {
+  existsSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  unlinkSync,
+} from 'node:fs'
+import { dirname, isAbsolute, relative } from 'node:path'
+import { getBrowserToolOutputDir } from '../../src/tools/filesystem/utils'
 import {
   type WithBrowserContext,
   withBrowser,
@@ -84,6 +90,17 @@ function cleanupSavedDom(domPath: string): void {
   } catch {}
 }
 
+function assertSavedUnderBrowserToolOutput(domPath: string): void {
+  const rel = relative(
+    realpathSync(getBrowserToolOutputDir()),
+    realpathSync(dirname(domPath)),
+  )
+  assert.ok(
+    rel === '' || (!rel.startsWith('..') && !isAbsolute(rel)),
+    'Saved DOM file should be written to BrowserOS tool output',
+  )
+}
+
 /** Opens the shared DOM fixture after its static form controls are queryable. */
 async function openRichPage(
   execute: WithBrowserContext['execute'],
@@ -121,12 +138,7 @@ describe('get_dom', () => {
 
         assert.ok(textOf(result).includes('Saved DOM'))
         assert.ok(existsSync(domPath), 'Saved DOM file should exist')
-        assert.ok(
-          dirname(domPath).startsWith(
-            join(tmpdir(), 'browseros-browser-tool-'),
-          ),
-          'Saved DOM file should be written to an OS temp directory',
-        )
+        assertSavedUnderBrowserToolOutput(domPath)
         assert.ok(html.includes('<html'), 'Should contain <html> tag')
         assert.ok(html.includes('</html>'), 'Should contain closing </html>')
         assert.ok(html.includes('id="login-form"'), 'Should contain form ID')
@@ -275,12 +287,7 @@ describe('get_dom', () => {
         const html = readFileSync(domPath, 'utf8')
 
         assert.ok(textOf(result).includes('Saved DOM'))
-        assert.ok(
-          dirname(domPath).startsWith(
-            join(tmpdir(), 'browseros-browser-tool-'),
-          ),
-          'Saved DOM file should be written to an OS temp directory',
-        )
+        assertSavedUnderBrowserToolOutput(domPath)
         assert.ok(data.totalLength > 100_000, 'Expected a large DOM payload')
         assert.strictEqual(html.length, data.totalLength)
         assert.ok(

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/edit.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/edit.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdir, readFile, rm, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 import { createEditTool } from '../../../src/tools/filesystem/edit'
 import type { FilesystemToolResult } from '../../../src/tools/filesystem/utils'
 
@@ -178,5 +178,58 @@ describe('filesystem_edit', () => {
 
     const content = await readFile(join(tmpDir, 'shrink.ts'), 'utf-8')
     expect(content).toBe('a\nreplaced\ne')
+  })
+
+  it('rejects absolute paths', async () => {
+    const absPath = join(tmpDir, 'abs.ts')
+    await writeFile(absPath, 'const x = 1')
+    const result = await exec({
+      path: absPath,
+      old_string: 'const x = 1',
+      new_string: 'const x = 2',
+    })
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain('relative to the selected workspace')
+  })
+
+  it('rejects traversal outside the workspace', async () => {
+    const outsideDir = join(
+      tmpdir(),
+      `fs-edit-outside-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    )
+    await mkdir(outsideDir, { recursive: true })
+    try {
+      await writeFile(join(outsideDir, 'secret.ts'), 'const secret = true')
+      const result = await exec({
+        path: `../${basename(outsideDir)}/secret.ts`,
+        old_string: 'true',
+        new_string: 'false',
+      })
+      expect(result.isError).toBe(true)
+      expect(result.text).toContain('outside the selected workspace')
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects symlinks that point outside the workspace', async () => {
+    const outsideDir = join(
+      tmpdir(),
+      `fs-edit-symlink-outside-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    )
+    await mkdir(outsideDir, { recursive: true })
+    try {
+      await writeFile(join(outsideDir, 'secret.ts'), 'const secret = true')
+      await symlink(join(outsideDir, 'secret.ts'), join(tmpDir, 'secret-link'))
+      const result = await exec({
+        path: 'secret-link',
+        old_string: 'true',
+        new_string: 'false',
+      })
+      expect(result.isError).toBe(true)
+      expect(result.text).toContain('outside the selected workspace')
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/find.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/find.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 import { createFindTool } from '../../../src/tools/filesystem/find'
 import type { FilesystemToolResult } from '../../../src/tools/filesystem/utils'
 
@@ -133,5 +133,46 @@ describe('filesystem_find', () => {
     await createFileTree()
     const result = await exec({ pattern: '*.json' })
     expect(result.text).toContain('package.json')
+  })
+
+  it('rejects absolute search roots', async () => {
+    const result = await exec({ pattern: '*', path: tmpDir })
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain('relative to the selected workspace')
+  })
+
+  it('rejects traversal outside the workspace', async () => {
+    const outsideDir = join(
+      tmpdir(),
+      `fs-find-outside-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    )
+    await mkdir(outsideDir, { recursive: true })
+    try {
+      const result = await exec({
+        pattern: '*',
+        path: `../${basename(outsideDir)}`,
+      })
+      expect(result.isError).toBe(true)
+      expect(result.text).toContain('outside the selected workspace')
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true })
+    }
+  })
+
+  it('skips symlinks that point outside the workspace', async () => {
+    const outsideDir = join(
+      tmpdir(),
+      `fs-find-symlink-outside-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    )
+    await mkdir(outsideDir, { recursive: true })
+    try {
+      await writeFile(join(outsideDir, 'secret.txt'), '')
+      await symlink(outsideDir, join(tmpDir, 'outside-link'))
+      const result = await exec({ pattern: '*' })
+      expect(result.text).not.toContain('outside-link')
+      expect(result.text).not.toContain('secret.txt')
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/grep.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/grep.test.ts
@@ -3,7 +3,10 @@ import { mkdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
 import { createGrepTool } from '../../../src/tools/filesystem/grep'
-import type { FilesystemToolResult } from '../../../src/tools/filesystem/utils'
+import {
+  type FilesystemToolResult,
+  MAX_GREP_FILE_SIZE,
+} from '../../../src/tools/filesystem/utils'
 
 let tmpDir: string
 let exec: (params: Record<string, unknown>) => Promise<FilesystemToolResult>
@@ -138,6 +141,18 @@ describe('filesystem_grep', () => {
     const result = await exec({ pattern: 'beta', path: 'single.txt' })
     expect(result.text).toContain('beta')
     expect(result.text).not.toContain('alpha')
+  })
+
+  it('does not read oversized single-file targets', async () => {
+    await writeFile(
+      join(tmpDir, 'large.log'),
+      'x'.repeat(MAX_GREP_FILE_SIZE + 1),
+    )
+
+    const result = await exec({ pattern: 'x', path: 'large.log' })
+
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain('Unable to read file')
   })
 
   it('handles regex special characters', async () => {

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/grep.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/grep.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 import { createGrepTool } from '../../../src/tools/filesystem/grep'
 import type { FilesystemToolResult } from '../../../src/tools/filesystem/utils'
 
@@ -151,5 +151,46 @@ describe('filesystem_grep', () => {
     await writeFile(join(tmpDir, 'long.txt'), longLine)
     const result = await exec({ pattern: 'x' })
     expect(result.text).toContain('[truncated]')
+  })
+
+  it('rejects absolute search paths', async () => {
+    const result = await exec({ pattern: 'anything', path: tmpDir })
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain('relative to the selected workspace')
+  })
+
+  it('rejects traversal outside the workspace', async () => {
+    const outsideDir = join(
+      tmpdir(),
+      `fs-grep-outside-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    )
+    await mkdir(outsideDir, { recursive: true })
+    try {
+      const result = await exec({
+        pattern: 'secret',
+        path: `../${basename(outsideDir)}`,
+      })
+      expect(result.isError).toBe(true)
+      expect(result.text).toContain('outside the selected workspace')
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not search symlinks that point outside the workspace', async () => {
+    const outsideDir = join(
+      tmpdir(),
+      `fs-grep-symlink-outside-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    )
+    await mkdir(outsideDir, { recursive: true })
+    try {
+      await writeFile(join(outsideDir, 'secret.txt'), 'secret-token')
+      await symlink(join(outsideDir, 'secret.txt'), join(tmpDir, 'secret-link'))
+      const result = await exec({ pattern: 'secret-token' })
+      expect(result.isError).toBeUndefined()
+      expect(result.text).toBe('No matches found.')
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/ls.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/ls.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 import { createLsTool } from '../../../src/tools/filesystem/ls'
 import type { FilesystemToolResult } from '../../../src/tools/filesystem/utils'
 
@@ -100,9 +100,41 @@ describe('filesystem_ls', () => {
     expect(result.text).toContain('MB')
   })
 
-  it('handles absolute path', async () => {
+  it('rejects absolute paths', async () => {
     await writeFile(join(tmpDir, 'abs.txt'), 'data')
     const result = await exec({ path: tmpDir })
-    expect(result.text).toContain('abs.txt')
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain('relative to the selected workspace')
+  })
+
+  it('rejects traversal outside the workspace', async () => {
+    const outsideDir = join(
+      tmpdir(),
+      `fs-ls-outside-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    )
+    await mkdir(outsideDir, { recursive: true })
+    try {
+      const result = await exec({ path: `../${basename(outsideDir)}` })
+      expect(result.isError).toBe(true)
+      expect(result.text).toContain('outside the selected workspace')
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects symlinked directories outside the workspace', async () => {
+    const outsideDir = join(
+      tmpdir(),
+      `fs-ls-symlink-outside-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    )
+    await mkdir(outsideDir, { recursive: true })
+    try {
+      await symlink(outsideDir, join(tmpDir, 'outside-link'))
+      const result = await exec({ path: 'outside-link' })
+      expect(result.isError).toBe(true)
+      expect(result.text).toContain('outside the selected workspace')
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/read.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/read.test.ts
@@ -5,14 +5,23 @@ import { basename, join } from 'node:path'
 import { createReadTool } from '../../../src/tools/filesystem/read'
 import type { FilesystemToolResult } from '../../../src/tools/filesystem/utils'
 import {
+  getBrowserToolOutputDir,
   MAX_READ_CHARS,
   MAX_READ_LINES,
 } from '../../../src/tools/filesystem/utils'
 
 let tmpDir: string
+let browserosDir: string
+let previousBrowserosDir: string | undefined
 let exec: (params: Record<string, unknown>) => Promise<FilesystemToolResult>
 
 beforeEach(async () => {
+  previousBrowserosDir = process.env.BROWSEROS_DIR
+  browserosDir = join(
+    tmpdir(),
+    `fs-read-browseros-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+  )
+  process.env.BROWSEROS_DIR = browserosDir
   tmpDir = join(
     tmpdir(),
     `fs-read-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
@@ -25,6 +34,12 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await rm(tmpDir, { recursive: true, force: true })
+  await rm(browserosDir, { recursive: true, force: true })
+  if (previousBrowserosDir === undefined) {
+    delete process.env.BROWSEROS_DIR
+  } else {
+    process.env.BROWSEROS_DIR = previousBrowserosDir
+  }
 })
 
 describe('filesystem_read', () => {
@@ -142,6 +157,27 @@ describe('filesystem_read', () => {
     } finally {
       await rm(outsideDir, { recursive: true, force: true })
     }
+  })
+
+  it('reads BrowserOS-generated output files', async () => {
+    const outputDir = getBrowserToolOutputDir()
+    await mkdir(outputDir, { recursive: true })
+    const outputPath = join(outputDir, 'snapshot.md')
+    await writeFile(outputPath, 'generated snapshot')
+
+    const result = await exec({ path: outputPath })
+    expect(result.isError).toBeUndefined()
+    expect(result.text).toContain('generated snapshot')
+  })
+
+  it('rejects absolute BrowserOS state paths outside generated outputs', async () => {
+    await mkdir(getBrowserToolOutputDir(), { recursive: true })
+    const statePath = join(browserosDir, 'config.json')
+    await writeFile(statePath, '{}')
+
+    const result = await exec({ path: statePath })
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain('outside BrowserOS tool output')
   })
 
   it('errors when a read would exceed the line limit', async () => {

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/read.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/read.test.ts
@@ -2,10 +2,10 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { mkdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
+import { getToolOutputDir } from '../../../src/lib/browseros-dir'
 import { createReadTool } from '../../../src/tools/filesystem/read'
 import type { FilesystemToolResult } from '../../../src/tools/filesystem/utils'
 import {
-  getBrowserToolOutputDir,
   MAX_READ_CHARS,
   MAX_READ_LINES,
 } from '../../../src/tools/filesystem/utils'
@@ -160,8 +160,7 @@ describe('filesystem_read', () => {
   })
 
   it('reads BrowserOS-generated output files', async () => {
-    const outputDir = getBrowserToolOutputDir()
-    await mkdir(outputDir, { recursive: true })
+    const outputDir = await getToolOutputDir()
     const outputPath = join(outputDir, 'snapshot.md')
     await writeFile(outputPath, 'generated snapshot')
 
@@ -171,7 +170,7 @@ describe('filesystem_read', () => {
   })
 
   it('rejects absolute BrowserOS state paths outside generated outputs', async () => {
-    await mkdir(getBrowserToolOutputDir(), { recursive: true })
+    await getToolOutputDir()
     const statePath = join(browserosDir, 'config.json')
     await writeFile(statePath, '{}')
 

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/read.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/read.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 import { createReadTool } from '../../../src/tools/filesystem/read'
 import type { FilesystemToolResult } from '../../../src/tools/filesystem/utils'
 import {
@@ -101,11 +101,47 @@ describe('filesystem_read', () => {
     expect(result.text).toContain('nested content')
   })
 
-  it('handles absolute paths', async () => {
+  it('rejects absolute paths', async () => {
     const absPath = join(tmpDir, 'abs.txt')
     await writeFile(absPath, 'absolute')
     const result = await exec({ path: absPath })
-    expect(result.text).toContain('absolute')
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain('relative to the selected workspace')
+  })
+
+  it('rejects traversal outside the workspace', async () => {
+    const outsideDir = join(
+      tmpdir(),
+      `fs-read-outside-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    )
+    await mkdir(outsideDir, { recursive: true })
+    try {
+      await writeFile(join(outsideDir, 'secret.txt'), 'secret')
+      const result = await exec({
+        path: `../${basename(outsideDir)}/secret.txt`,
+      })
+      expect(result.isError).toBe(true)
+      expect(result.text).toContain('outside the selected workspace')
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects symlinks that point outside the workspace', async () => {
+    const outsideDir = join(
+      tmpdir(),
+      `fs-read-symlink-outside-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    )
+    await mkdir(outsideDir, { recursive: true })
+    try {
+      await writeFile(join(outsideDir, 'secret.txt'), 'secret')
+      await symlink(join(outsideDir, 'secret.txt'), join(tmpDir, 'secret-link'))
+      const result = await exec({ path: 'secret-link' })
+      expect(result.isError).toBe(true)
+      expect(result.text).toContain('outside the selected workspace')
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true })
+    }
   })
 
   it('errors when a read would exceed the line limit', async () => {

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/utils.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/utils.test.ts
@@ -190,7 +190,7 @@ describe('walkFiles', () => {
 
     const files: string[] = []
     for await (const f of walkFiles(tmpDir, tmpDir)) {
-      files.push(f)
+      files.push(f.path)
     }
     expect(files).toContain('root.txt')
     expect(files).toContain(join('a', 'mid.txt'))
@@ -204,7 +204,7 @@ describe('walkFiles', () => {
 
     const files: string[] = []
     for await (const f of walkFiles(tmpDir, tmpDir)) {
-      files.push(f)
+      files.push(f.path)
     }
     expect(files).toContain('real.ts')
     expect(files.some((f) => f.includes('node_modules'))).toBe(false)
@@ -217,7 +217,7 @@ describe('walkFiles', () => {
 
     const files: string[] = []
     for await (const f of walkFiles(tmpDir, tmpDir)) {
-      files.push(f)
+      files.push(f.path)
     }
     expect(files).toContain('code.ts')
     expect(files.some((f) => f.includes('.git'))).toBe(false)
@@ -226,7 +226,7 @@ describe('walkFiles', () => {
   it('handles empty directories', async () => {
     const files: string[] = []
     for await (const f of walkFiles(tmpDir, tmpDir)) {
-      files.push(f)
+      files.push(f.path)
     }
     expect(files.length).toBe(0)
   })
@@ -234,9 +234,24 @@ describe('walkFiles', () => {
   it('handles nonexistent directory gracefully', async () => {
     const files: string[] = []
     for await (const f of walkFiles(join(tmpDir, 'nonexistent'), tmpDir)) {
-      files.push(f)
+      files.push(f.path)
     }
     expect(files.length).toBe(0)
+  })
+
+  it('returns canonical read paths for workspace symlinks', async () => {
+    await mkdir(join(tmpDir, 'target'), { recursive: true })
+    const realFile = join(tmpDir, 'target', 'real.txt')
+    await writeFile(realFile, 'ok')
+    await symlink(realFile, join(tmpDir, 'link.txt'))
+
+    const files: Array<{ path: string; realPath: string }> = []
+    for await (const f of walkFiles(tmpDir, tmpDir)) {
+      files.push(f)
+    }
+
+    const link = files.find((f) => f.path === 'link.txt')
+    expect(link?.realPath).toBe(await realpath(realFile))
   })
 })
 

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/utils.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/utils.test.ts
@@ -2,9 +2,9 @@ import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { mkdir, realpath, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { basename, join, resolve } from 'node:path'
+import { getToolOutputDir } from '../../../src/lib/browseros-dir'
 import {
   detectLineEnding,
-  getBrowserToolOutputDir,
   isBinaryPath,
   normalizeToLF,
   resolveBrowserToolOutputPath,
@@ -355,8 +355,7 @@ describe('filesystem path boundaries', () => {
   })
 
   it('accepts BrowserOS tool output paths under the dedicated output directory', async () => {
-    const outputDir = getBrowserToolOutputDir()
-    await mkdir(outputDir, { recursive: true })
+    const outputDir = await getToolOutputDir()
     const outputPath = join(outputDir, 'snapshot.md')
     await writeFile(outputPath, 'snapshot')
     const expectedPath = await realpath(outputPath)
@@ -367,9 +366,9 @@ describe('filesystem path boundaries', () => {
   })
 
   it('rejects sibling BrowserOS state paths outside the output directory', async () => {
-    await mkdir(getBrowserToolOutputDir(), { recursive: true })
-    const siblingPath = join(getBrowserToolOutputDir(), '..', 'config.json')
-    await mkdir(join(getBrowserToolOutputDir(), '..'), { recursive: true })
+    const outputDir = await getToolOutputDir()
+    const siblingPath = join(outputDir, '..', 'config.json')
+    await mkdir(join(outputDir, '..'), { recursive: true })
     await writeFile(siblingPath, '{}')
 
     await expect(resolveBrowserToolOutputPath(siblingPath)).rejects.toThrow(
@@ -378,8 +377,9 @@ describe('filesystem path boundaries', () => {
   })
 
   it('rejects symlinked BrowserOS tool output roots', async () => {
-    await symlink(outsideDir, getBrowserToolOutputDir())
-    const outputPath = join(getBrowserToolOutputDir(), 'snapshot.md')
+    const rawOutputDir = join(browserosDir, 'tool-output')
+    await symlink(outsideDir, rawOutputDir)
+    const outputPath = join(rawOutputDir, 'snapshot.md')
     await writeFile(join(outsideDir, 'snapshot.md'), 'snapshot')
 
     await expect(resolveBrowserToolOutputPath(outputPath)).rejects.toThrow(

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/utils.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/utils.test.ts
@@ -365,6 +365,12 @@ describe('filesystem path boundaries', () => {
     )
   })
 
+  it('rejects relative BrowserOS tool output paths', async () => {
+    await expect(resolveBrowserToolOutputPath('snapshot.md')).rejects.toThrow(
+      'absolute BrowserOS tool output path',
+    )
+  })
+
   it('rejects sibling BrowserOS state paths outside the output directory', async () => {
     const outputDir = await getToolOutputDir()
     const siblingPath = join(outputDir, '..', 'config.json')

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/utils.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/utils.test.ts
@@ -320,9 +320,10 @@ describe('filesystem path boundaries', () => {
     await mkdir(outputDir, { recursive: true })
     const outputPath = join(outputDir, 'snapshot.md')
     await writeFile(outputPath, 'snapshot')
+    const expectedPath = await realpath(outputPath)
 
     await expect(resolveBrowserToolOutputPath(outputPath)).resolves.toBe(
-      outputPath,
+      expectedPath,
     )
   })
 

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/utils.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/utils.test.ts
@@ -243,8 +243,16 @@ describe('walkFiles', () => {
 describe('filesystem path boundaries', () => {
   let tmpDir: string
   let outsideDir: string
+  let browserosDir: string
+  let previousBrowserosDir: string | undefined
 
   beforeEach(async () => {
+    previousBrowserosDir = process.env.BROWSEROS_DIR
+    browserosDir = join(
+      tmpdir(),
+      `fs-boundary-browseros-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    )
+    process.env.BROWSEROS_DIR = browserosDir
     tmpDir = join(
       tmpdir(),
       `fs-boundary-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
@@ -255,12 +263,18 @@ describe('filesystem path boundaries', () => {
     )
     await mkdir(tmpDir, { recursive: true })
     await mkdir(outsideDir, { recursive: true })
+    await mkdir(browserosDir, { recursive: true })
   })
 
   afterEach(async () => {
     await rm(tmpDir, { recursive: true, force: true })
     await rm(outsideDir, { recursive: true, force: true })
-    await rm(getBrowserToolOutputDir(), { recursive: true, force: true })
+    await rm(browserosDir, { recursive: true, force: true })
+    if (previousBrowserosDir === undefined) {
+      delete process.env.BROWSEROS_DIR
+    } else {
+      process.env.BROWSEROS_DIR = previousBrowserosDir
+    }
   })
 
   it('resolves relative workspace paths inside the workspace', async () => {
@@ -287,6 +301,16 @@ describe('filesystem path boundaries', () => {
     await expect(
       resolveWorkspacePath(tmpDir, `../${basename(outsideDir)}/secret.txt`),
     ).rejects.toThrow('outside the selected workspace')
+  })
+
+  it('allows workspace entries whose names start with dot dot text', async () => {
+    await mkdir(join(tmpDir, '..notes'), { recursive: true })
+    await writeFile(join(tmpDir, '..notes', 'file.txt'), 'ok')
+
+    const expectedPath = await realpath(join(tmpDir, '..notes', 'file.txt'))
+    await expect(
+      resolveWorkspacePath(tmpDir, '..notes/file.txt'),
+    ).resolves.toBe(expectedPath)
   })
 
   it('rejects symlinks that resolve outside the workspace', async () => {
@@ -335,6 +359,16 @@ describe('filesystem path boundaries', () => {
 
     await expect(resolveBrowserToolOutputPath(siblingPath)).rejects.toThrow(
       'outside BrowserOS tool output',
+    )
+  })
+
+  it('rejects symlinked BrowserOS tool output roots', async () => {
+    await symlink(outsideDir, getBrowserToolOutputDir())
+    const outputPath = join(getBrowserToolOutputDir(), 'snapshot.md')
+    await writeFile(join(outsideDir, 'snapshot.md'), 'snapshot')
+
+    await expect(resolveBrowserToolOutputPath(outputPath)).rejects.toThrow(
+      'BrowserOS tool output directory must be a real directory',
     )
   })
 })

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/utils.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/utils.test.ts
@@ -1,11 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdir, rm, writeFile } from 'node:fs/promises'
+import { mkdir, realpath, rm, symlink, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, join, resolve } from 'node:path'
 import {
   detectLineEnding,
+  getBrowserToolOutputDir,
   isBinaryPath,
   normalizeToLF,
+  resolveBrowserToolOutputPath,
+  resolveWorkspacePath,
+  resolveWorkspaceWritePath,
   restoreLineEndings,
   stripBom,
   truncateHead,
@@ -233,5 +237,103 @@ describe('walkFiles', () => {
       files.push(f)
     }
     expect(files.length).toBe(0)
+  })
+})
+
+describe('filesystem path boundaries', () => {
+  let tmpDir: string
+  let outsideDir: string
+
+  beforeEach(async () => {
+    tmpDir = join(
+      tmpdir(),
+      `fs-boundary-test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    )
+    outsideDir = join(
+      tmpdir(),
+      `fs-boundary-outside-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    )
+    await mkdir(tmpDir, { recursive: true })
+    await mkdir(outsideDir, { recursive: true })
+  })
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true })
+    await rm(outsideDir, { recursive: true, force: true })
+    await rm(getBrowserToolOutputDir(), { recursive: true, force: true })
+  })
+
+  it('resolves relative workspace paths inside the workspace', async () => {
+    await mkdir(join(tmpDir, 'sub'), { recursive: true })
+    await writeFile(join(tmpDir, 'sub', 'file.txt'), 'ok')
+
+    const expectedPath = await realpath(join(tmpDir, 'sub', 'file.txt'))
+    await expect(resolveWorkspacePath(tmpDir, 'sub/file.txt')).resolves.toBe(
+      expectedPath,
+    )
+  })
+
+  it('rejects absolute workspace paths', async () => {
+    await writeFile(join(tmpDir, 'file.txt'), 'ok')
+
+    await expect(
+      resolveWorkspacePath(tmpDir, join(tmpDir, 'file.txt')),
+    ).rejects.toThrow('relative to the selected workspace')
+  })
+
+  it('rejects traversal outside the workspace', async () => {
+    await writeFile(join(outsideDir, 'secret.txt'), 'secret')
+
+    await expect(
+      resolveWorkspacePath(tmpDir, `../${basename(outsideDir)}/secret.txt`),
+    ).rejects.toThrow('outside the selected workspace')
+  })
+
+  it('rejects symlinks that resolve outside the workspace', async () => {
+    await writeFile(join(outsideDir, 'secret.txt'), 'secret')
+    await symlink(join(outsideDir, 'secret.txt'), join(tmpDir, 'secret-link'))
+
+    await expect(resolveWorkspacePath(tmpDir, 'secret-link')).rejects.toThrow(
+      'outside the selected workspace',
+    )
+  })
+
+  it('allows write targets under an existing workspace parent', async () => {
+    await mkdir(join(tmpDir, 'reports'), { recursive: true })
+
+    const expectedParent = await realpath(join(tmpDir, 'reports'))
+    await expect(
+      resolveWorkspaceWritePath(tmpDir, 'reports/new/deep.txt'),
+    ).resolves.toBe(resolve(expectedParent, 'new', 'deep.txt'))
+  })
+
+  it('rejects write targets below symlinked parents outside the workspace', async () => {
+    await symlink(outsideDir, join(tmpDir, 'outside-link'))
+
+    await expect(
+      resolveWorkspaceWritePath(tmpDir, 'outside-link/new.txt'),
+    ).rejects.toThrow('outside the selected workspace')
+  })
+
+  it('accepts BrowserOS tool output paths under the dedicated output directory', async () => {
+    const outputDir = getBrowserToolOutputDir()
+    await mkdir(outputDir, { recursive: true })
+    const outputPath = join(outputDir, 'snapshot.md')
+    await writeFile(outputPath, 'snapshot')
+
+    await expect(resolveBrowserToolOutputPath(outputPath)).resolves.toBe(
+      outputPath,
+    )
+  })
+
+  it('rejects sibling BrowserOS state paths outside the output directory', async () => {
+    await mkdir(getBrowserToolOutputDir(), { recursive: true })
+    const siblingPath = join(getBrowserToolOutputDir(), '..', 'config.json')
+    await mkdir(join(getBrowserToolOutputDir(), '..'), { recursive: true })
+    await writeFile(siblingPath, '{}')
+
+    await expect(resolveBrowserToolOutputPath(siblingPath)).rejects.toThrow(
+      'outside BrowserOS tool output',
+    )
   })
 })

--- a/packages/browseros-agent/apps/server/tests/tools/filesystem/write.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/filesystem/write.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import { mkdir, readFile, rm, stat } from 'node:fs/promises'
+import { mkdir, readFile, rm, stat, symlink } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
-import { join } from 'node:path'
+import { basename, join } from 'node:path'
 import type { FilesystemToolResult } from '../../../src/tools/filesystem/utils'
 import { createWriteTool } from '../../../src/tools/filesystem/write'
 
@@ -76,12 +76,47 @@ describe('filesystem_write', () => {
     expect(written).toBe(content)
   })
 
-  it('handles absolute paths', async () => {
+  it('rejects absolute paths', async () => {
     const absPath = join(tmpDir, 'absolute.txt')
     const result = await exec({ path: absPath, content: 'abs content' })
-    expect(result.isError).toBeUndefined()
+    expect(result.isError).toBe(true)
+    expect(result.text).toContain('relative to the selected workspace')
+  })
 
-    const content = await readFile(absPath, 'utf-8')
-    expect(content).toBe('abs content')
+  it('rejects traversal outside the workspace', async () => {
+    const outsideDir = join(
+      tmpdir(),
+      `fs-write-outside-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    )
+    await mkdir(outsideDir, { recursive: true })
+    try {
+      const result = await exec({
+        path: `../${basename(outsideDir)}/escape.txt`,
+        content: 'escape',
+      })
+      expect(result.isError).toBe(true)
+      expect(result.text).toContain('outside the selected workspace')
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects writes below symlinked parents outside the workspace', async () => {
+    const outsideDir = join(
+      tmpdir(),
+      `fs-write-symlink-outside-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+    )
+    await mkdir(outsideDir, { recursive: true })
+    try {
+      await symlink(outsideDir, join(tmpDir, 'outside-link'))
+      const result = await exec({
+        path: 'outside-link/new.txt',
+        content: 'escape',
+      })
+      expect(result.isError).toBe(true)
+      expect(result.text).toContain('outside the selected workspace')
+    } finally {
+      await rm(outsideDir, { recursive: true, force: true })
+    }
   })
 })

--- a/packages/browseros-agent/apps/server/tests/tools/input.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/input.test.ts
@@ -90,7 +90,7 @@ const FORM_PAGE = `data:text/html,${encodeURIComponent(`<!DOCTYPE html>
   </script>
 </body></html>`)}`
 
-afterAll(cleanupWithBrowser)
+afterAll(cleanupWithBrowser, 30_000)
 
 describe('input tools', () => {
   it('fill types text into an input', async () => {

--- a/packages/browseros-agent/apps/server/tests/tools/observation.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/observation.test.ts
@@ -1,12 +1,6 @@
 import { describe, it } from 'bun:test'
 import assert from 'node:assert'
-import {
-  existsSync,
-  readFileSync,
-  realpathSync,
-  rmSync,
-  unlinkSync,
-} from 'node:fs'
+import { existsSync, readFileSync, realpathSync, unlinkSync } from 'node:fs'
 import { dirname, isAbsolute, relative } from 'node:path'
 import { getBrowserToolOutputDir } from '../../src/tools/filesystem/utils'
 import { withBrowser } from '../__helpers__/with-browser'
@@ -46,9 +40,6 @@ function pageIdOf(result: {
 
 function cleanupSavedContent(path: string): void {
   unlinkSync(path)
-  try {
-    rmSync(dirname(path))
-  } catch {}
 }
 
 function assertSavedUnderBrowserToolOutput(path: string): void {

--- a/packages/browseros-agent/apps/server/tests/tools/observation.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/observation.test.ts
@@ -2,7 +2,7 @@ import { describe, it } from 'bun:test'
 import assert from 'node:assert'
 import { existsSync, readFileSync, realpathSync, unlinkSync } from 'node:fs'
 import { dirname, isAbsolute, relative } from 'node:path'
-import { getBrowserToolOutputDir } from '../../src/tools/filesystem/utils'
+import { getToolOutputDir } from '../../src/lib/browseros-dir'
 import { withBrowser } from '../__helpers__/with-browser'
 import {
   close_page,
@@ -42,11 +42,9 @@ function cleanupSavedContent(path: string): void {
   unlinkSync(path)
 }
 
-function assertSavedUnderBrowserToolOutput(path: string): void {
-  const rel = relative(
-    realpathSync(getBrowserToolOutputDir()),
-    realpathSync(dirname(path)),
-  )
+async function assertSavedUnderBrowserToolOutput(path: string): Promise<void> {
+  const outputDir = await getToolOutputDir()
+  const rel = relative(realpathSync(outputDir), realpathSync(dirname(path)))
   assert.ok(
     rel === '' || (!rel.startsWith('..') && !isAbsolute(rel)),
     'Saved page content should be written to BrowserOS tool output',
@@ -215,7 +213,7 @@ describe('observation tools', () => {
         assert.ok(textOf(contentResult).includes('Content truncated'))
         assert.ok(textOf(contentResult).includes(savedPath))
         assert.ok(existsSync(savedPath), 'Saved page content file should exist')
-        assertSavedUnderBrowserToolOutput(savedPath)
+        await assertSavedUnderBrowserToolOutput(savedPath)
 
         const savedContent = readFileSync(savedPath, 'utf8')
         assert.strictEqual(savedContent.length, data.contentLength)

--- a/packages/browseros-agent/apps/server/tests/tools/observation.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/observation.test.ts
@@ -1,8 +1,14 @@
 import { describe, it } from 'bun:test'
 import assert from 'node:assert'
-import { existsSync, readFileSync, rmSync, unlinkSync } from 'node:fs'
-import { tmpdir } from 'node:os'
-import { dirname, join } from 'node:path'
+import {
+  existsSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  unlinkSync,
+} from 'node:fs'
+import { dirname, isAbsolute, relative } from 'node:path'
+import { getBrowserToolOutputDir } from '../../src/tools/filesystem/utils'
 import { withBrowser } from '../__helpers__/with-browser'
 import {
   close_page,
@@ -43,6 +49,17 @@ function cleanupSavedContent(path: string): void {
   try {
     rmSync(dirname(path))
   } catch {}
+}
+
+function assertSavedUnderBrowserToolOutput(path: string): void {
+  const rel = relative(
+    realpathSync(getBrowserToolOutputDir()),
+    realpathSync(dirname(path)),
+  )
+  assert.ok(
+    rel === '' || (!rel.startsWith('..') && !isAbsolute(rel)),
+    'Saved page content should be written to BrowserOS tool output',
+  )
 }
 
 describe('observation tools', () => {
@@ -207,12 +224,7 @@ describe('observation tools', () => {
         assert.ok(textOf(contentResult).includes('Content truncated'))
         assert.ok(textOf(contentResult).includes(savedPath))
         assert.ok(existsSync(savedPath), 'Saved page content file should exist')
-        assert.ok(
-          dirname(savedPath).startsWith(
-            join(tmpdir(), 'browseros-browser-tool-'),
-          ),
-          'Saved page content should be written to an OS temp directory',
-        )
+        assertSavedUnderBrowserToolOutput(savedPath)
 
         const savedContent = readFileSync(savedPath, 'utf8')
         assert.strictEqual(savedContent.length, data.contentLength)


### PR DESCRIPTION
## Summary
- Add shared workspace boundary resolution for BrowserOS-owned filesystem tools, rejecting absolute paths, traversal, and symlink escapes outside the selected workspace.
- Omit BrowserOS filesystem tools when no workspace is selected, in chat mode, or for ACP providers; keep `filesystem_bash` unrestricted by command text but run it from the selected workspace cwd.
- Route generated browser large-output files through a dedicated BrowserOS `tool-output` directory that `filesystem_read` can read, while rejecting sibling BrowserOS app state; lock the directory to `0700` and generated files to `0600`.

## Design
The selected workspace is the normal filesystem boundary. Browser-generated large outputs are the only read exception, and only under a dedicated BrowserOS-managed output directory. This intentionally does not claim shell sandboxing for `filesystem_bash`; it preserves cwd behavior per the agreed first fix.

## Test plan
- [x] `cd apps/server && bun --env-file=.env.development test ./tests/tools/filesystem/utils.test.ts ./tests/tools/filesystem/find.test.ts ./tests/tools/filesystem/grep.test.ts`
- [x] `cd apps/server && bun --env-file=.env.development test --preload=./tests/__helpers__/test-env.ts ./tests/tools/dom.test.ts ./tests/tools/observation.test.ts`
- [x] `cd apps/server && bun --env-file=.env.development test ./tests/browseros-dir.test.ts ./tests/tools/browser/register.test.ts`
- [x] `bun run lint` (passes with pre-existing repo-wide warnings)
- [x] `bun run typecheck`
- [x] `bun run test:main` (clean rerun passed; an earlier run hit unrelated CDP connectivity failures in browser tests)