### PR TITLE
chore: refresh models dev data

### DIFF
--- a/packages/browseros-agent/apps/agent/lib/llm-providers/models-dev-data.json
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/models-dev-data.json
@@ -307,15 +307,6 @@
         "outputCost": 14
       },
       {
-        "id": "chatgpt-image-latest",
-        "name": "chatgpt-image-latest",
-        "contextWindow": 0,
-        "maxOutput": 0,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": false
-      },
-      {
         "id": "gpt-5.2",
         "name": "GPT-5.2",
         "contextWindow": 400000,
@@ -358,15 +349,6 @@
         "supportsToolCall": true,
         "inputCost": 21,
         "outputCost": 168
-      },
-      {
-        "id": "gpt-image-1.5",
-        "name": "gpt-image-1.5",
-        "contextWindow": 0,
-        "maxOutput": 0,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": false
       },
       {
         "id": "gpt-5.1",
@@ -435,15 +417,6 @@
         "outputCost": 120
       },
       {
-        "id": "gpt-image-1-mini",
-        "name": "gpt-image-1-mini",
-        "contextWindow": 0,
-        "maxOutput": 0,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": false
-      },
-      {
         "id": "gpt-5-codex",
         "name": "GPT-5-Codex",
         "contextWindow": 400000,
@@ -508,15 +481,6 @@
         "supportsToolCall": true,
         "inputCost": 20,
         "outputCost": 80
-      },
-      {
-        "id": "gpt-image-1",
-        "name": "gpt-image-1",
-        "contextWindow": 0,
-        "maxOutput": 0,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": false
       },
       {
         "id": "o3",
@@ -944,28 +908,6 @@
         "supportsToolCall": false,
         "inputCost": 0.15,
         "outputCost": 0
-      },
-      {
-        "id": "gemini-2.5-flash-preview-tts",
-        "name": "Gemini 2.5 Flash Preview TTS",
-        "contextWindow": 8192,
-        "maxOutput": 16384,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0.5,
-        "outputCost": 10
-      },
-      {
-        "id": "gemini-2.5-pro-preview-tts",
-        "name": "Gemini 2.5 Pro Preview TTS",
-        "contextWindow": 8192,
-        "maxOutput": 16384,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 1,
-        "outputCost": 20
       }
     ]
   },

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/models-dev-data.json
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/models-dev-data.json
@@ -670,28 +670,6 @@
         "outputCost": 30
       },
       {
-        "id": "text-embedding-3-large",
-        "name": "text-embedding-3-large",
-        "contextWindow": 8191,
-        "maxOutput": 3072,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0.13,
-        "outputCost": 0
-      },
-      {
-        "id": "text-embedding-3-small",
-        "name": "text-embedding-3-small",
-        "contextWindow": 8191,
-        "maxOutput": 1536,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0.02,
-        "outputCost": 0
-      },
-      {
         "id": "gpt-3.5-turbo",
         "name": "GPT-3.5-turbo",
         "contextWindow": 16385,
@@ -701,17 +679,6 @@
         "supportsToolCall": false,
         "inputCost": 0.5,
         "outputCost": 1.5
-      },
-      {
-        "id": "text-embedding-ada-002",
-        "name": "text-embedding-ada-002",
-        "contextWindow": 8192,
-        "maxOutput": 1536,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0.1,
-        "outputCost": 0
       }
     ]
   },
@@ -778,17 +745,6 @@
         "supportsToolCall": true
       },
       {
-        "id": "gemini-3.1-flash-image-preview",
-        "name": "Nano Banana 2",
-        "contextWindow": 65536,
-        "maxOutput": 65536,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": false,
-        "inputCost": 0.5,
-        "outputCost": 60
-      },
-      {
         "id": "gemini-3.1-pro-preview",
         "name": "Gemini 3.1 Pro Preview",
         "contextWindow": 1048576,
@@ -822,17 +778,6 @@
         "outputCost": 3
       },
       {
-        "id": "gemini-3-pro-image-preview",
-        "name": "Nano Banana Pro",
-        "contextWindow": 131072,
-        "maxOutput": 32768,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": false,
-        "inputCost": 2,
-        "outputCost": 120
-      },
-      {
         "id": "gemini-flash-latest",
         "name": "Gemini Flash Latest",
         "contextWindow": 1048576,
@@ -853,17 +798,6 @@
         "supportsToolCall": true,
         "inputCost": 0.1,
         "outputCost": 0.4
-      },
-      {
-        "id": "gemini-2.5-flash-image",
-        "name": "Nano Banana",
-        "contextWindow": 32768,
-        "maxOutput": 32768,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": false,
-        "inputCost": 0.3,
-        "outputCost": 30
       },
       {
         "id": "gemini-2.5-flash-lite",
@@ -897,17 +831,6 @@
         "supportsToolCall": true,
         "inputCost": 1.25,
         "outputCost": 10
-      },
-      {
-        "id": "gemini-embedding-001",
-        "name": "Gemini Embedding 001",
-        "contextWindow": 2048,
-        "maxOutput": 1,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0.15,
-        "outputCost": 0
       }
     ]
   },
@@ -1421,17 +1344,6 @@
         "outputCost": 3.41
       },
       {
-        "id": "openai/gpt-5.4-image-2",
-        "name": "GPT-5.4 Image 2",
-        "contextWindow": 272000,
-        "maxOutput": 128000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": false,
-        "inputCost": 8,
-        "outputCost": 15
-      },
-      {
         "id": "openrouter/pareto-code",
         "name": "Pareto Code Router",
         "contextWindow": 2000000,
@@ -1859,17 +1771,6 @@
         "outputCost": 0.4
       },
       {
-        "id": "google/gemini-3.1-flash-image-preview",
-        "name": "Nano Banana 2",
-        "contextWindow": 65536,
-        "maxOutput": 65536,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": false,
-        "inputCost": 0.5,
-        "outputCost": 3
-      },
-      {
         "id": "liquid/lfm-2-24b-a2b",
         "name": "LFM2-24B-A2B",
         "contextWindow": 32768,
@@ -2121,28 +2022,6 @@
         "supportsToolCall": false,
         "inputCost": 0,
         "outputCost": 0
-      },
-      {
-        "id": "openai/gpt-audio",
-        "name": "GPT Audio",
-        "contextWindow": 128000,
-        "maxOutput": 16384,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 2.5,
-        "outputCost": 10
-      },
-      {
-        "id": "openai/gpt-audio-mini",
-        "name": "GPT Audio Mini",
-        "contextWindow": 128000,
-        "maxOutput": 16384,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.6,
-        "outputCost": 2.4
       },
       {
         "id": "z-ai/glm-4.7-flash",
@@ -2440,17 +2319,6 @@
         "outputCost": 0.5
       },
       {
-        "id": "google/gemini-3-pro-image-preview",
-        "name": "Nano Banana Pro",
-        "contextWindow": 65536,
-        "maxOutput": 32768,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": false,
-        "inputCost": 2,
-        "outputCost": 12
-      },
-      {
         "id": "deepcogito/cogito-v2.1-671b",
         "name": "Cogito v2.1 671B",
         "contextWindow": 128000,
@@ -2627,17 +2495,6 @@
         "outputCost": 0.35
       },
       {
-        "id": "openai/gpt-5-image-mini",
-        "name": "GPT-5 Image Mini",
-        "contextWindow": 400000,
-        "maxOutput": 128000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": false,
-        "inputCost": 2.5,
-        "outputCost": 2
-      },
-      {
         "id": "anthropic/claude-haiku-4.5",
         "name": "Claude Haiku 4.5 (latest)",
         "contextWindow": 200000,
@@ -2647,17 +2504,6 @@
         "supportsToolCall": true,
         "inputCost": 1,
         "outputCost": 5
-      },
-      {
-        "id": "openai/gpt-5-image",
-        "name": "GPT-5 Image",
-        "contextWindow": 400000,
-        "maxOutput": 128000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": false,
-        "inputCost": 10,
-        "outputCost": 10
       },
       {
         "id": "qwen/qwen3-vl-8b-instruct",
@@ -2922,17 +2768,6 @@
         "supportsToolCall": true,
         "inputCost": 0.08,
         "outputCost": 0.4
-      },
-      {
-        "id": "google/gemini-2.5-flash-image",
-        "name": "Nano Banana",
-        "contextWindow": 32768,
-        "maxOutput": 32768,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0.3,
-        "outputCost": 2.5
       },
       {
         "id": "nousresearch/hermes-4-405b",
@@ -5634,28 +5469,6 @@
         "outputCost": 1.5
       },
       {
-        "id": "text-embedding-3-large",
-        "name": "text-embedding-3-large",
-        "contextWindow": 8191,
-        "maxOutput": 3072,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0.13,
-        "outputCost": 0
-      },
-      {
-        "id": "text-embedding-3-small",
-        "name": "text-embedding-3-small",
-        "contextWindow": 8191,
-        "maxOutput": 1536,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0.02,
-        "outputCost": 0
-      },
-      {
         "id": "cohere-embed-v3-english",
         "name": "Embed v3 English",
         "contextWindow": 512,
@@ -5742,17 +5555,6 @@
         "supportsToolCall": false,
         "inputCost": 1.5,
         "outputCost": 2
-      },
-      {
-        "id": "text-embedding-ada-002",
-        "name": "text-embedding-ada-002",
-        "contextWindow": 8192,
-        "maxOutput": 1536,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0.1,
-        "outputCost": 0
       }
     ]
   },

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/models-dev-data.json
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/models-dev-data.json
@@ -4,6 +4,39 @@
     "doc": "https://docs.anthropic.com/en/docs/about-claude/models",
     "models": [
       {
+        "id": "claude-fable-5",
+        "name": "Claude Fable 5",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 10,
+        "outputCost": 50
+      },
+      {
+        "id": "claude-opus-4-8",
+        "name": "Claude Opus 4.8",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 25
+      },
+      {
+        "id": "claude-opus-4-7",
+        "name": "Claude Opus 4.7",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 25
+      },
+      {
         "id": "claude-opus-4-6",
         "name": "Claude Opus 4.6",
         "contextWindow": 1000000,
@@ -48,17 +81,6 @@
         "outputCost": 25
       },
       {
-        "id": "claude-haiku-4-5-20251001",
-        "name": "Claude Haiku 4.5",
-        "contextWindow": 200000,
-        "maxOutput": 64000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 1,
-        "outputCost": 5
-      },
-      {
         "id": "claude-haiku-4-5",
         "name": "Claude Haiku 4.5 (latest)",
         "contextWindow": 200000,
@@ -70,8 +92,19 @@
         "outputCost": 5
       },
       {
-        "id": "claude-sonnet-4-5-20250929",
-        "name": "Claude Sonnet 4.5",
+        "id": "claude-haiku-4-5-20251001",
+        "name": "Claude Haiku 4.5",
+        "contextWindow": 200000,
+        "maxOutput": 64000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1,
+        "outputCost": 5
+      },
+      {
+        "id": "claude-sonnet-4-5",
+        "name": "Claude Sonnet 4.5 (latest)",
         "contextWindow": 200000,
         "maxOutput": 64000,
         "supportsImages": true,
@@ -81,8 +114,8 @@
         "outputCost": 15
       },
       {
-        "id": "claude-sonnet-4-5",
-        "name": "Claude Sonnet 4.5 (latest)",
+        "id": "claude-sonnet-4-5-20250929",
+        "name": "Claude Sonnet 4.5",
         "contextWindow": 200000,
         "maxOutput": 64000,
         "supportsImages": true,
@@ -114,15 +147,15 @@
         "outputCost": 75
       },
       {
-        "id": "claude-sonnet-4-0",
-        "name": "Claude Sonnet 4 (latest)",
+        "id": "claude-opus-4-0",
+        "name": "Claude Opus 4 (latest)",
         "contextWindow": 200000,
-        "maxOutput": 64000,
+        "maxOutput": 32000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 3,
-        "outputCost": 15
+        "inputCost": 15,
+        "outputCost": 75
       },
       {
         "id": "claude-opus-4-20250514",
@@ -136,41 +169,19 @@
         "outputCost": 75
       },
       {
-        "id": "claude-opus-4-0",
-        "name": "Claude Opus 4 (latest)",
+        "id": "claude-sonnet-4-0",
+        "name": "Claude Sonnet 4 (latest)",
         "contextWindow": 200000,
-        "maxOutput": 32000,
+        "maxOutput": 64000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 15,
-        "outputCost": 75
+        "inputCost": 3,
+        "outputCost": 15
       },
       {
         "id": "claude-sonnet-4-20250514",
         "name": "Claude Sonnet 4",
-        "contextWindow": 200000,
-        "maxOutput": 64000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 3,
-        "outputCost": 15
-      },
-      {
-        "id": "claude-3-7-sonnet-latest",
-        "name": "Claude Sonnet 3.7 (latest)",
-        "contextWindow": 200000,
-        "maxOutput": 64000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 3,
-        "outputCost": 15
-      },
-      {
-        "id": "claude-3-7-sonnet-20250219",
-        "name": "Claude Sonnet 3.7",
         "contextWindow": 200000,
         "maxOutput": 64000,
         "supportsImages": true,
@@ -189,72 +200,6 @@
         "supportsToolCall": true,
         "inputCost": 0.8,
         "outputCost": 4
-      },
-      {
-        "id": "claude-3-5-sonnet-20241022",
-        "name": "Claude Sonnet 3.5 v2",
-        "contextWindow": 200000,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 3,
-        "outputCost": 15
-      },
-      {
-        "id": "claude-3-5-haiku-20241022",
-        "name": "Claude Haiku 3.5",
-        "contextWindow": 200000,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.8,
-        "outputCost": 4
-      },
-      {
-        "id": "claude-3-5-sonnet-20240620",
-        "name": "Claude Sonnet 3.5",
-        "contextWindow": 200000,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 3,
-        "outputCost": 15
-      },
-      {
-        "id": "claude-3-haiku-20240307",
-        "name": "Claude Haiku 3",
-        "contextWindow": 200000,
-        "maxOutput": 4096,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.25,
-        "outputCost": 1.25
-      },
-      {
-        "id": "claude-3-sonnet-20240229",
-        "name": "Claude Sonnet 3",
-        "contextWindow": 200000,
-        "maxOutput": 4096,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 3,
-        "outputCost": 15
-      },
-      {
-        "id": "claude-3-opus-20240229",
-        "name": "Claude Opus 3",
-        "contextWindow": 200000,
-        "maxOutput": 4096,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 15,
-        "outputCost": 75
       }
     ]
   },
@@ -263,15 +208,26 @@
     "doc": "https://platform.openai.com/docs/models",
     "models": [
       {
-        "id": "gpt-5.4-nano",
-        "name": "GPT-5.4 nano",
-        "contextWindow": 400000,
+        "id": "gpt-5.5",
+        "name": "GPT-5.5",
+        "contextWindow": 1050000,
         "maxOutput": 128000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0.2,
-        "outputCost": 1.25
+        "inputCost": 5,
+        "outputCost": 30
+      },
+      {
+        "id": "gpt-5.5-pro",
+        "name": "GPT-5.5 Pro",
+        "contextWindow": 1050000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 30,
+        "outputCost": 180
       },
       {
         "id": "gpt-5.4-mini",
@@ -283,6 +239,17 @@
         "supportsToolCall": true,
         "inputCost": 0.75,
         "outputCost": 4.5
+      },
+      {
+        "id": "gpt-5.4-nano",
+        "name": "GPT-5.4 nano",
+        "contextWindow": 400000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.2,
+        "outputCost": 1.25
       },
       {
         "id": "gpt-5.4",
@@ -307,6 +274,17 @@
         "outputCost": 180
       },
       {
+        "id": "gpt-5.3-chat-latest",
+        "name": "GPT-5.3 Chat (latest)",
+        "contextWindow": 128000,
+        "maxOutput": 16384,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 1.75,
+        "outputCost": 14
+      },
+      {
         "id": "gpt-5.3-codex",
         "name": "GPT-5.3 Codex",
         "contextWindow": 400000,
@@ -322,6 +300,26 @@
         "name": "GPT-5.3 Codex Spark",
         "contextWindow": 128000,
         "maxOutput": 32000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1.75,
+        "outputCost": 14
+      },
+      {
+        "id": "chatgpt-image-latest",
+        "name": "chatgpt-image-latest",
+        "contextWindow": 0,
+        "maxOutput": 0,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": false
+      },
+      {
+        "id": "gpt-5.2",
+        "name": "GPT-5.2",
+        "contextWindow": 400000,
+        "maxOutput": 128000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
@@ -351,17 +349,6 @@
         "outputCost": 14
       },
       {
-        "id": "gpt-5.2",
-        "name": "GPT-5.2",
-        "contextWindow": 400000,
-        "maxOutput": 128000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 1.75,
-        "outputCost": 14
-      },
-      {
         "id": "gpt-5.2-pro",
         "name": "GPT-5.2 Pro",
         "contextWindow": 400000,
@@ -373,41 +360,17 @@
         "outputCost": 168
       },
       {
-        "id": "gpt-5.1-codex-max",
-        "name": "GPT-5.1 Codex Max",
-        "contextWindow": 400000,
-        "maxOutput": 128000,
+        "id": "gpt-image-1.5",
+        "name": "gpt-image-1.5",
+        "contextWindow": 0,
+        "maxOutput": 0,
         "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 1.25,
-        "outputCost": 10
+        "supportsReasoning": false,
+        "supportsToolCall": false
       },
       {
         "id": "gpt-5.1",
         "name": "GPT-5.1",
-        "contextWindow": 400000,
-        "maxOutput": 128000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 1.25,
-        "outputCost": 10
-      },
-      {
-        "id": "gpt-5.1-codex-mini",
-        "name": "GPT-5.1 Codex mini",
-        "contextWindow": 400000,
-        "maxOutput": 128000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.25,
-        "outputCost": 2
-      },
-      {
-        "id": "gpt-5.1-codex",
-        "name": "GPT-5.1 Codex",
         "contextWindow": 400000,
         "maxOutput": 128000,
         "supportsImages": true,
@@ -428,6 +391,39 @@
         "outputCost": 10
       },
       {
+        "id": "gpt-5.1-codex",
+        "name": "GPT-5.1 Codex",
+        "contextWindow": 400000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1.25,
+        "outputCost": 10
+      },
+      {
+        "id": "gpt-5.1-codex-max",
+        "name": "GPT-5.1 Codex Max",
+        "contextWindow": 400000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1.25,
+        "outputCost": 10
+      },
+      {
+        "id": "gpt-5.1-codex-mini",
+        "name": "GPT-5.1 Codex mini",
+        "contextWindow": 400000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.25,
+        "outputCost": 2
+      },
+      {
         "id": "gpt-5-pro",
         "name": "GPT-5 Pro",
         "contextWindow": 400000,
@@ -439,8 +435,28 @@
         "outputCost": 120
       },
       {
+        "id": "gpt-image-1-mini",
+        "name": "gpt-image-1-mini",
+        "contextWindow": 0,
+        "maxOutput": 0,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": false
+      },
+      {
         "id": "gpt-5-codex",
         "name": "GPT-5-Codex",
+        "contextWindow": 400000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1.25,
+        "outputCost": 10
+      },
+      {
+        "id": "gpt-5",
+        "name": "GPT-5",
         "contextWindow": 400000,
         "maxOutput": 128000,
         "supportsImages": true,
@@ -457,17 +473,6 @@
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": false,
-        "inputCost": 1.25,
-        "outputCost": 10
-      },
-      {
-        "id": "gpt-5",
-        "name": "GPT-5",
-        "contextWindow": 400000,
-        "maxOutput": 128000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
         "inputCost": 1.25,
         "outputCost": 10
       },
@@ -505,15 +510,13 @@
         "outputCost": 80
       },
       {
-        "id": "codex-mini-latest",
-        "name": "Codex Mini",
-        "contextWindow": 200000,
-        "maxOutput": 100000,
+        "id": "gpt-image-1",
+        "name": "gpt-image-1",
+        "contextWindow": 0,
+        "maxOutput": 0,
         "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 1.5,
-        "outputCost": 6
+        "supportsReasoning": false,
+        "supportsToolCall": false
       },
       {
         "id": "o3",
@@ -538,17 +541,6 @@
         "outputCost": 4.4
       },
       {
-        "id": "gpt-4.1-nano",
-        "name": "GPT-4.1 nano",
-        "contextWindow": 1047576,
-        "maxOutput": 32768,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.1,
-        "outputCost": 0.4
-      },
-      {
         "id": "gpt-4.1",
         "name": "GPT-4.1",
         "contextWindow": 1047576,
@@ -569,6 +561,17 @@
         "supportsToolCall": true,
         "inputCost": 0.4,
         "outputCost": 1.6
+      },
+      {
+        "id": "gpt-4.1-nano",
+        "name": "GPT-4.1 nano",
+        "contextWindow": 1047576,
+        "maxOutput": 32768,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.1,
+        "outputCost": 0.4
       },
       {
         "id": "o1-pro",
@@ -615,30 +618,8 @@
         "outputCost": 10
       },
       {
-        "id": "o1-preview",
-        "name": "o1-preview",
-        "contextWindow": 128000,
-        "maxOutput": 32768,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": false,
-        "inputCost": 15,
-        "outputCost": 60
-      },
-      {
-        "id": "o1-mini",
-        "name": "o1-mini",
-        "contextWindow": 128000,
-        "maxOutput": 65536,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": false,
-        "inputCost": 1.1,
-        "outputCost": 4.4
-      },
-      {
-        "id": "gpt-4o-2024-08-06",
-        "name": "GPT-4o (2024-08-06)",
+        "id": "gpt-4o",
+        "name": "GPT-4o",
         "contextWindow": 128000,
         "maxOutput": 16384,
         "supportsImages": true,
@@ -648,8 +629,8 @@
         "outputCost": 10
       },
       {
-        "id": "gpt-4o",
-        "name": "GPT-4o",
+        "id": "gpt-4o-2024-08-06",
+        "name": "GPT-4o (2024-08-06)",
         "contextWindow": 128000,
         "maxOutput": 16384,
         "supportsImages": true,
@@ -703,17 +684,6 @@
         "outputCost": 15
       },
       {
-        "id": "gpt-4-turbo",
-        "name": "GPT-4 Turbo",
-        "contextWindow": 128000,
-        "maxOutput": 4096,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 10,
-        "outputCost": 30
-      },
-      {
         "id": "gpt-4",
         "name": "GPT-4",
         "contextWindow": 8192,
@@ -725,15 +695,15 @@
         "outputCost": 60
       },
       {
-        "id": "text-embedding-3-small",
-        "name": "text-embedding-3-small",
-        "contextWindow": 8191,
-        "maxOutput": 1536,
-        "supportsImages": false,
+        "id": "gpt-4-turbo",
+        "name": "GPT-4 Turbo",
+        "contextWindow": 128000,
+        "maxOutput": 4096,
+        "supportsImages": true,
         "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0.02,
-        "outputCost": 0
+        "supportsToolCall": true,
+        "inputCost": 10,
+        "outputCost": 30
       },
       {
         "id": "text-embedding-3-large",
@@ -744,6 +714,17 @@
         "supportsReasoning": false,
         "supportsToolCall": false,
         "inputCost": 0.13,
+        "outputCost": 0
+      },
+      {
+        "id": "text-embedding-3-small",
+        "name": "text-embedding-3-small",
+        "contextWindow": 8191,
+        "maxOutput": 1536,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.02,
         "outputCost": 0
       },
       {
@@ -772,11 +753,22 @@
   },
   "google": {
     "name": "Google",
-    "doc": "https://ai.google.dev/gemini-api/docs/pricing",
+    "doc": "https://ai.google.dev/gemini-api/docs/models",
     "models": [
       {
-        "id": "gemini-3.1-flash-lite-preview",
-        "name": "Gemini 3.1 Flash Lite Preview",
+        "id": "gemini-3.5-flash",
+        "name": "Gemini 3.5 Flash",
+        "contextWindow": 1048576,
+        "maxOutput": 65536,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1.5,
+        "outputCost": 9
+      },
+      {
+        "id": "gemini-3.1-flash-lite",
+        "name": "Gemini 3.1 Flash Lite",
         "contextWindow": 1048576,
         "maxOutput": 65536,
         "supportsImages": true,
@@ -786,19 +778,55 @@
         "outputCost": 1.5
       },
       {
-        "id": "gemini-3.1-flash-image-preview",
-        "name": "Gemini 3.1 Flash Image (Preview)",
-        "contextWindow": 131072,
+        "id": "gemma-4-26b-a4b-it",
+        "name": "Gemma 4 26B A4B IT",
+        "contextWindow": 262144,
         "maxOutput": 32768,
         "supportsImages": true,
         "supportsReasoning": true,
+        "supportsToolCall": true
+      },
+      {
+        "id": "gemma-4-31b-it",
+        "name": "Gemma 4 31B IT",
+        "contextWindow": 262144,
+        "maxOutput": 32768,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true
+      },
+      {
+        "id": "gemma-4-E2B-it",
+        "name": "Gemma 4 E2B IT",
+        "contextWindow": 131072,
+        "maxOutput": 8192,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true
+      },
+      {
+        "id": "gemma-4-E4B-it",
+        "name": "Gemma 4 E4B IT",
+        "contextWindow": 131072,
+        "maxOutput": 8192,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true
+      },
+      {
+        "id": "gemini-3.1-flash-image-preview",
+        "name": "Nano Banana 2",
+        "contextWindow": 65536,
+        "maxOutput": 65536,
+        "supportsImages": true,
+        "supportsReasoning": true,
         "supportsToolCall": false,
-        "inputCost": 0.25,
+        "inputCost": 0.5,
         "outputCost": 60
       },
       {
-        "id": "gemini-3.1-pro-preview-customtools",
-        "name": "Gemini 3.1 Pro Preview Custom Tools",
+        "id": "gemini-3.1-pro-preview",
+        "name": "Gemini 3.1 Pro Preview",
         "contextWindow": 1048576,
         "maxOutput": 65536,
         "supportsImages": true,
@@ -808,8 +836,8 @@
         "outputCost": 12
       },
       {
-        "id": "gemini-3.1-pro-preview",
-        "name": "Gemini 3.1 Pro Preview",
+        "id": "gemini-3.1-pro-preview-customtools",
+        "name": "Gemini 3.1 Pro Preview Custom Tools",
         "contextWindow": 1048576,
         "maxOutput": 65536,
         "supportsImages": true,
@@ -830,37 +858,15 @@
         "outputCost": 3
       },
       {
-        "id": "gemini-3-pro-preview",
-        "name": "Gemini 3 Pro Preview",
-        "contextWindow": 1000000,
-        "maxOutput": 64000,
+        "id": "gemini-3-pro-image-preview",
+        "name": "Nano Banana Pro",
+        "contextWindow": 131072,
+        "maxOutput": 32768,
         "supportsImages": true,
         "supportsReasoning": true,
-        "supportsToolCall": true,
+        "supportsToolCall": false,
         "inputCost": 2,
-        "outputCost": 12
-      },
-      {
-        "id": "gemini-2.5-flash-lite-preview-09-2025",
-        "name": "Gemini 2.5 Flash Lite Preview 09-25",
-        "contextWindow": 1048576,
-        "maxOutput": 65536,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.1,
-        "outputCost": 0.4
-      },
-      {
-        "id": "gemini-2.5-flash-preview-09-2025",
-        "name": "Gemini 2.5 Flash Preview 09-25",
-        "contextWindow": 1048576,
-        "maxOutput": 65536,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.3,
-        "outputCost": 2.5
+        "outputCost": 120
       },
       {
         "id": "gemini-flash-latest",
@@ -885,41 +891,8 @@
         "outputCost": 0.4
       },
       {
-        "id": "gemini-live-2.5-flash-preview-native-audio",
-        "name": "Gemini Live 2.5 Flash Preview Native Audio",
-        "contextWindow": 131072,
-        "maxOutput": 65536,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.5,
-        "outputCost": 2
-      },
-      {
-        "id": "gemini-live-2.5-flash",
-        "name": "Gemini Live 2.5 Flash",
-        "contextWindow": 128000,
-        "maxOutput": 8000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.5,
-        "outputCost": 2
-      },
-      {
         "id": "gemini-2.5-flash-image",
-        "name": "Gemini 2.5 Flash Image",
-        "contextWindow": 32768,
-        "maxOutput": 32768,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": false,
-        "inputCost": 0.3,
-        "outputCost": 30
-      },
-      {
-        "id": "gemini-2.5-flash-image-preview",
-        "name": "Gemini 2.5 Flash Image (Preview)",
+        "name": "Nano Banana",
         "contextWindow": 32768,
         "maxOutput": 32768,
         "supportsImages": true,
@@ -930,7 +903,7 @@
       },
       {
         "id": "gemini-2.5-flash-lite",
-        "name": "Gemini 2.5 Flash Lite",
+        "name": "Gemini 2.5 Flash-Lite",
         "contextWindow": 1048576,
         "maxOutput": 65536,
         "supportsImages": true,
@@ -938,28 +911,6 @@
         "supportsToolCall": true,
         "inputCost": 0.1,
         "outputCost": 0.4
-      },
-      {
-        "id": "gemini-2.5-flash-lite-preview-06-17",
-        "name": "Gemini 2.5 Flash Lite Preview 06-17",
-        "contextWindow": 1048576,
-        "maxOutput": 65536,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.1,
-        "outputCost": 0.4
-      },
-      {
-        "id": "gemini-2.5-pro-preview-06-05",
-        "name": "Gemini 2.5 Pro Preview 06-05",
-        "contextWindow": 1048576,
-        "maxOutput": 65536,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 1.25,
-        "outputCost": 10
       },
       {
         "id": "gemini-2.5-flash",
@@ -987,7 +938,7 @@
         "id": "gemini-embedding-001",
         "name": "Gemini Embedding 001",
         "contextWindow": 2048,
-        "maxOutput": 3072,
+        "maxOutput": 1,
         "supportsImages": false,
         "supportsReasoning": false,
         "supportsToolCall": false,
@@ -995,32 +946,10 @@
         "outputCost": 0
       },
       {
-        "id": "gemini-2.5-flash-preview-05-20",
-        "name": "Gemini 2.5 Flash Preview 05-20",
-        "contextWindow": 1048576,
-        "maxOutput": 65536,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.15,
-        "outputCost": 0.6
-      },
-      {
-        "id": "gemini-2.5-pro-preview-05-06",
-        "name": "Gemini 2.5 Pro Preview 05-06",
-        "contextWindow": 1048576,
-        "maxOutput": 65536,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 1.25,
-        "outputCost": 10
-      },
-      {
         "id": "gemini-2.5-flash-preview-tts",
         "name": "Gemini 2.5 Flash Preview TTS",
-        "contextWindow": 8000,
-        "maxOutput": 16000,
+        "contextWindow": 8192,
+        "maxOutput": 16384,
         "supportsImages": false,
         "supportsReasoning": false,
         "supportsToolCall": false,
@@ -1030,79 +959,13 @@
       {
         "id": "gemini-2.5-pro-preview-tts",
         "name": "Gemini 2.5 Pro Preview TTS",
-        "contextWindow": 8000,
-        "maxOutput": 16000,
+        "contextWindow": 8192,
+        "maxOutput": 16384,
         "supportsImages": false,
         "supportsReasoning": false,
         "supportsToolCall": false,
         "inputCost": 1,
         "outputCost": 20
-      },
-      {
-        "id": "gemini-2.5-flash-preview-04-17",
-        "name": "Gemini 2.5 Flash Preview 04-17",
-        "contextWindow": 1048576,
-        "maxOutput": 65536,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.15,
-        "outputCost": 0.6
-      },
-      {
-        "id": "gemini-2.0-flash-lite",
-        "name": "Gemini 2.0 Flash Lite",
-        "contextWindow": 1048576,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.075,
-        "outputCost": 0.3
-      },
-      {
-        "id": "gemini-2.0-flash",
-        "name": "Gemini 2.0 Flash",
-        "contextWindow": 1048576,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.1,
-        "outputCost": 0.4
-      },
-      {
-        "id": "gemini-1.5-flash-8b",
-        "name": "Gemini 1.5 Flash-8B",
-        "contextWindow": 1000000,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.0375,
-        "outputCost": 0.15
-      },
-      {
-        "id": "gemini-1.5-flash",
-        "name": "Gemini 1.5 Flash",
-        "contextWindow": 1000000,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.075,
-        "outputCost": 0.3
-      },
-      {
-        "id": "gemini-1.5-pro",
-        "name": "Gemini 1.5 Pro",
-        "contextWindow": 1000000,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 1.25,
-        "outputCost": 5
       }
     ]
   },
@@ -1112,65 +975,688 @@
     "doc": "https://openrouter.ai/models",
     "models": [
       {
-        "id": "xiaomi/mimo-v2-omni",
-        "name": "MiMo-V2-Omni",
+        "id": "openrouter/fusion",
+        "name": "Fusion",
+        "contextWindow": 128000,
+        "maxOutput": 128000,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false
+      },
+      {
+        "id": "moonshotai/kimi-k2.7-code",
+        "name": "Kimi K2.7 Code",
         "contextWindow": 262144,
+        "maxOutput": 262144,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.75,
+        "outputCost": 3.5
+      },
+      {
+        "id": "~anthropic/claude-fable-latest",
+        "name": "Claude Fable Latest",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 10,
+        "outputCost": 50
+      },
+      {
+        "id": "anthropic/claude-fable-5",
+        "name": "Claude Fable 5",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 10,
+        "outputCost": 50
+      },
+      {
+        "id": "nex-agi/nex-n2-pro:free",
+        "name": "Nex-N2-Pro (free)",
+        "contextWindow": 262144,
+        "maxOutput": 262144,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "nvidia/nemotron-3-ultra-550b-a55b",
+        "name": "Nemotron 3 Ultra 550B A55B",
+        "contextWindow": 262144,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.5,
+        "outputCost": 2.5
+      },
+      {
+        "id": "nvidia/nemotron-3-ultra-550b-a55b:free",
+        "name": "Nemotron 3 Ultra (free)",
+        "contextWindow": 1000000,
+        "maxOutput": 65536,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "nvidia/nemotron-3.5-content-safety:free",
+        "name": "Nemotron 3.5 Content Safety (free)",
+        "contextWindow": 128000,
+        "maxOutput": 8192,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "qwen/qwen3.7-plus",
+        "name": "Qwen3.7 Plus",
+        "contextWindow": 1000000,
         "maxOutput": 65536,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0.4,
-        "outputCost": 2
+        "inputCost": 0.32,
+        "outputCost": 1.28
       },
       {
-        "id": "xiaomi/mimo-v2-pro",
-        "name": "MiMo-V2-Pro",
-        "contextWindow": 1048576,
-        "maxOutput": 65536,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 1,
-        "outputCost": 3
-      },
-      {
-        "id": "minimax/minimax-m2.7",
-        "name": "MiniMax M2.7",
-        "contextWindow": 204800,
-        "maxOutput": 131072,
-        "supportsImages": false,
+        "id": "minimax/minimax-m3",
+        "name": "MiniMax-M3",
+        "contextWindow": 524288,
+        "maxOutput": 512000,
+        "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
         "inputCost": 0.3,
         "outputCost": 1.2
       },
       {
-        "id": "openai/gpt-5.4-nano",
-        "name": "GPT-5.4 Nano",
+        "id": "stepfun/step-3.7-flash",
+        "name": "Step 3.7 Flash",
+        "contextWindow": 256000,
+        "maxOutput": 256000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.2,
+        "outputCost": 1.15
+      },
+      {
+        "id": "anthropic/claude-opus-4.8",
+        "name": "Claude Opus 4.8",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 25
+      },
+      {
+        "id": "anthropic/claude-opus-4.8-fast",
+        "name": "Claude Opus 4.8 (Fast)",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 10,
+        "outputCost": 50
+      },
+      {
+        "id": "qwen/qwen3.7-max",
+        "name": "Qwen3.7 Max",
+        "contextWindow": 1000000,
+        "maxOutput": 65536,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1.25,
+        "outputCost": 3.75
+      },
+      {
+        "id": "google/gemini-3.5-flash",
+        "name": "Gemini 3.5 Flash",
+        "contextWindow": 1048576,
+        "maxOutput": 65536,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1.5,
+        "outputCost": 9
+      },
+      {
+        "id": "anthropic/claude-opus-4.7-fast",
+        "name": "Claude Opus 4.7 (Fast)",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 30,
+        "outputCost": 150
+      },
+      {
+        "id": "perceptron/perceptron-mk1",
+        "name": "Perceptron Mk1",
+        "contextWindow": 32768,
+        "maxOutput": 8192,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 0.15,
+        "outputCost": 1.5
+      },
+      {
+        "id": "inclusionai/ring-2.6-1t",
+        "name": "Ring-2.6-1T",
+        "contextWindow": 262144,
+        "maxOutput": 65536,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.075,
+        "outputCost": 0.625
+      },
+      {
+        "id": "google/gemini-3.1-flash-lite",
+        "name": "Gemini 3.1 Flash Lite",
+        "contextWindow": 1048576,
+        "maxOutput": 65536,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.25,
+        "outputCost": 1.5
+      },
+      {
+        "id": "openai/gpt-chat-latest",
+        "name": "GPT Chat Latest",
         "contextWindow": 400000,
         "maxOutput": 128000,
         "supportsImages": true,
         "supportsReasoning": false,
         "supportsToolCall": true,
-        "inputCost": 2e-7,
-        "outputCost": 0.00000125
+        "inputCost": 5,
+        "outputCost": 30
       },
       {
-        "id": "openai/gpt-5.4-mini",
-        "name": "GPT-5.4 Mini",
+        "id": "ibm-granite/granite-4.1-8b",
+        "name": "Granite 4.1 8B",
+        "contextWindow": 131072,
+        "maxOutput": 131072,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.05,
+        "outputCost": 0.1
+      },
+      {
+        "id": "mistralai/mistral-medium-3-5",
+        "name": "Mistral Medium 3.5",
+        "contextWindow": 262144,
+        "maxOutput": 262144,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1.5,
+        "outputCost": 7.5
+      },
+      {
+        "id": "nvidia/nemotron-3-nano-omni-30b-a3b-reasoning:free",
+        "name": "Nemotron 3 Nano Omni (free)",
+        "contextWindow": 256000,
+        "maxOutput": 65536,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "openrouter/owl-alpha",
+        "name": "Owl Alpha",
+        "contextWindow": 1048756,
+        "maxOutput": 262144,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "poolside/laguna-m.1:free",
+        "name": "Laguna M.1 (free)",
+        "contextWindow": 262144,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "poolside/laguna-xs.2:free",
+        "name": "Laguna XS.2 (free)",
+        "contextWindow": 262144,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "~anthropic/claude-haiku-latest",
+        "name": "Anthropic Claude Haiku Latest",
+        "contextWindow": 200000,
+        "maxOutput": 64000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1,
+        "outputCost": 5
+      },
+      {
+        "id": "~anthropic/claude-sonnet-latest",
+        "name": "Anthropic Claude Sonnet Latest",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 3,
+        "outputCost": 15
+      },
+      {
+        "id": "~google/gemini-flash-latest",
+        "name": "Google Gemini Flash Latest",
+        "contextWindow": 1048576,
+        "maxOutput": 65536,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1.5,
+        "outputCost": 9
+      },
+      {
+        "id": "~google/gemini-pro-latest",
+        "name": "Google Gemini Pro Latest",
+        "contextWindow": 1048576,
+        "maxOutput": 65536,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 2,
+        "outputCost": 12
+      },
+      {
+        "id": "~moonshotai/kimi-latest",
+        "name": "MoonshotAI Kimi Latest",
+        "contextWindow": 262142,
+        "maxOutput": 262142,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.68,
+        "outputCost": 3.41
+      },
+      {
+        "id": "~openai/gpt-latest",
+        "name": "OpenAI GPT Latest",
+        "contextWindow": 1050000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 30
+      },
+      {
+        "id": "~openai/gpt-mini-latest",
+        "name": "OpenAI GPT Mini Latest",
         "contextWindow": 400000,
         "maxOutput": 128000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 7.5e-7,
-        "outputCost": 0.0000045
+        "inputCost": 0.75,
+        "outputCost": 4.5
       },
       {
-        "id": "x-ai/grok-4.20-multi-agent-beta",
-        "name": "Grok 4.20 Multi - Agent Beta",
+        "id": "qwen/qwen3.5-plus-20260420",
+        "name": "Qwen3.5 Plus 2026-04-20",
+        "contextWindow": 1000000,
+        "maxOutput": 65536,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.3,
+        "outputCost": 1.8
+      },
+      {
+        "id": "qwen/qwen3.6-flash",
+        "name": "Qwen3.6 Flash",
+        "contextWindow": 1000000,
+        "maxOutput": 65536,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.1875,
+        "outputCost": 1.125
+      },
+      {
+        "id": "deepseek/deepseek-v4-flash",
+        "name": "DeepSeek V4 Flash",
+        "contextWindow": 1000000,
+        "maxOutput": 65536,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.09,
+        "outputCost": 0.18
+      },
+      {
+        "id": "deepseek/deepseek-v4-pro",
+        "name": "DeepSeek V4 Pro",
+        "contextWindow": 1048576,
+        "maxOutput": 384000,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.435,
+        "outputCost": 0.87
+      },
+      {
+        "id": "inclusionai/ling-2.6-1t",
+        "name": "Ling-2.6-1T",
+        "contextWindow": 262144,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.075,
+        "outputCost": 0.625
+      },
+      {
+        "id": "openai/gpt-5.5",
+        "name": "GPT-5.5",
+        "contextWindow": 1050000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 30
+      },
+      {
+        "id": "openai/gpt-5.5-pro",
+        "name": "GPT-5.5 Pro",
+        "contextWindow": 1050000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 30,
+        "outputCost": 180
+      },
+      {
+        "id": "qwen/qwen3.6-27b",
+        "name": "Qwen3.6 27B",
+        "contextWindow": 262140,
+        "maxOutput": 262140,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.2885,
+        "outputCost": 3.17
+      },
+      {
+        "id": "xiaomi/mimo-v2.5",
+        "name": "MiMo-V2.5",
+        "contextWindow": 1048576,
+        "maxOutput": 131072,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.14,
+        "outputCost": 0.28
+      },
+      {
+        "id": "xiaomi/mimo-v2.5-pro",
+        "name": "MiMo-V2.5-Pro",
+        "contextWindow": 1048576,
+        "maxOutput": 131072,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.435,
+        "outputCost": 0.87
+      },
+      {
+        "id": "~anthropic/claude-opus-latest",
+        "name": "Claude Opus Latest",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 25
+      },
+      {
+        "id": "inclusionai/ling-2.6-flash",
+        "name": "Ling-2.6-flash",
+        "contextWindow": 262144,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.01,
+        "outputCost": 0.03
+      },
+      {
+        "id": "moonshotai/kimi-k2.6",
+        "name": "Kimi K2.6",
+        "contextWindow": 262142,
+        "maxOutput": 262142,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.68,
+        "outputCost": 3.41
+      },
+      {
+        "id": "openai/gpt-5.4-image-2",
+        "name": "GPT-5.4 Image 2",
+        "contextWindow": 272000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 8,
+        "outputCost": 15
+      },
+      {
+        "id": "openrouter/pareto-code",
+        "name": "Pareto Code Router",
         "contextWindow": 2000000,
-        "maxOutput": 30000,
+        "maxOutput": 200000,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false
+      },
+      {
+        "id": "qwen/qwen3.6-max-preview",
+        "name": "Qwen3.6 Max Preview",
+        "contextWindow": 262144,
+        "maxOutput": 65536,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1.04,
+        "outputCost": 6.24
+      },
+      {
+        "id": "tencent/hy3-preview",
+        "name": "Hy3 preview",
+        "contextWindow": 262144,
+        "maxOutput": 262144,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.063,
+        "outputCost": 0.21
+      },
+      {
+        "id": "qwen/qwen3.6-35b-a3b",
+        "name": "Qwen3.6 35B-A3B",
+        "contextWindow": 262144,
+        "maxOutput": 262144,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.15,
+        "outputCost": 1
+      },
+      {
+        "id": "x-ai/grok-4.3",
+        "name": "Grok 4.3",
+        "contextWindow": 1000000,
+        "maxOutput": 1000000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1.25,
+        "outputCost": 2.5
+      },
+      {
+        "id": "anthropic/claude-opus-4.7",
+        "name": "Claude Opus 4.7",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 25
+      },
+      {
+        "id": "x-ai/grok-build-0.1",
+        "name": "Grok Build 0.1",
+        "contextWindow": 256000,
+        "maxOutput": 256000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1,
+        "outputCost": 2
+      },
+      {
+        "id": "anthropic/claude-opus-4.6-fast",
+        "name": "Claude Opus 4.6 (Fast)",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 30,
+        "outputCost": 150
+      },
+      {
+        "id": "google/gemma-4-26b-a4b-it",
+        "name": "Gemma 4 26B A4B IT",
+        "contextWindow": 262144,
+        "maxOutput": 262144,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.06,
+        "outputCost": 0.33
+      },
+      {
+        "id": "google/gemma-4-26b-a4b-it:free",
+        "name": "Gemma 4 26B A4B  (free)",
+        "contextWindow": 262144,
+        "maxOutput": 32768,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "google/gemma-4-31b-it",
+        "name": "Gemma 4 31B IT",
+        "contextWindow": 262144,
+        "maxOutput": 262144,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.12,
+        "outputCost": 0.35
+      },
+      {
+        "id": "google/gemma-4-31b-it:free",
+        "name": "Gemma 4 31B (free)",
+        "contextWindow": 262144,
+        "maxOutput": 32768,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "qwen/qwen3.6-plus",
+        "name": "Qwen3.6 Plus",
+        "contextWindow": 1000000,
+        "maxOutput": 65536,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.325,
+        "outputCost": 1.95
+      },
+      {
+        "id": "arcee-ai/trinity-large-thinking",
+        "name": "Trinity Large Thinking",
+        "contextWindow": 262144,
+        "maxOutput": 262144,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.22,
+        "outputCost": 0.85
+      },
+      {
+        "id": "x-ai/grok-4.20",
+        "name": "Grok 4.20",
+        "contextWindow": 2000000,
+        "maxOutput": 2000000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1.25,
+        "outputCost": 2.5
+      },
+      {
+        "id": "x-ai/grok-4.20-multi-agent",
+        "name": "Grok 4.20 Multi-Agent",
+        "contextWindow": 2000000,
+        "maxOutput": 2000000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": false,
@@ -1178,29 +1664,150 @@
         "outputCost": 6
       },
       {
-        "id": "x-ai/grok-4.20-beta",
-        "name": "Grok 4.20 Beta",
-        "contextWindow": 2000000,
-        "maxOutput": 30000,
+        "id": "google/lyria-3-clip-preview",
+        "name": "Lyria 3 Clip Preview",
+        "contextWindow": 1048576,
+        "maxOutput": 65536,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "google/lyria-3-pro-preview",
+        "name": "Lyria 3 Pro Preview",
+        "contextWindow": 1048576,
+        "maxOutput": 65536,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "kwaipilot/kat-coder-pro-v2",
+        "name": "KAT-Coder-Pro V2",
+        "contextWindow": 256000,
+        "maxOutput": 80000,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.3,
+        "outputCost": 1.2
+      },
+      {
+        "id": "z-ai/glm-5.1",
+        "name": "GLM-5.1",
+        "contextWindow": 202752,
+        "maxOutput": 131072,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.98,
+        "outputCost": 3.08
+      },
+      {
+        "id": "rekaai/reka-edge",
+        "name": "Reka Edge",
+        "contextWindow": 16384,
+        "maxOutput": 16384,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.1,
+        "outputCost": 0.1
+      },
+      {
+        "id": "minimax/minimax-m2.7",
+        "name": "MiniMax-M2.7",
+        "contextWindow": 196608,
+        "maxOutput": 131072,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.25,
+        "outputCost": 1
+      },
+      {
+        "id": "openai/gpt-5.4-mini",
+        "name": "GPT-5.4 mini",
+        "contextWindow": 400000,
+        "maxOutput": 128000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 2,
-        "outputCost": 6
+        "inputCost": 0.75,
+        "outputCost": 4.5
+      },
+      {
+        "id": "openai/gpt-5.4-nano",
+        "name": "GPT-5.4 nano",
+        "contextWindow": 400000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.2,
+        "outputCost": 1.25
+      },
+      {
+        "id": "mistralai/mistral-small-2603",
+        "name": "Mistral Small 4",
+        "contextWindow": 262144,
+        "maxOutput": 262144,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.15,
+        "outputCost": 0.6
+      },
+      {
+        "id": "z-ai/glm-5-turbo",
+        "name": "GLM-5-Turbo",
+        "contextWindow": 262144,
+        "maxOutput": 131072,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1.2,
+        "outputCost": 4
+      },
+      {
+        "id": "anthropic/claude-opus-4.6",
+        "name": "Claude Opus 4.6",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 25
+      },
+      {
+        "id": "anthropic/claude-sonnet-4.6",
+        "name": "Claude Sonnet 4.6",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 3,
+        "outputCost": 15
       },
       {
         "id": "nvidia/nemotron-3-super-120b-a12b",
-        "name": "Nemotron 3 Super",
+        "name": "Nemotron 3 Super 120B A12B",
         "contextWindow": 262144,
         "maxOutput": 262144,
         "supportsImages": false,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0.1,
-        "outputCost": 0.5
+        "inputCost": 0.09,
+        "outputCost": 0.45
       },
       {
-        "id": "nvidia/nemotron-3-super-120b-a12b-free",
+        "id": "nvidia/nemotron-3-super-120b-a12b:free",
         "name": "Nemotron 3 Super (free)",
         "contextWindow": 262144,
         "maxOutput": 262144,
@@ -1209,6 +1816,28 @@
         "supportsToolCall": true,
         "inputCost": 0,
         "outputCost": 0
+      },
+      {
+        "id": "bytedance-seed/seed-2.0-lite",
+        "name": "Seed-2.0-Lite",
+        "contextWindow": 262144,
+        "maxOutput": 131072,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.25,
+        "outputCost": 2
+      },
+      {
+        "id": "qwen/qwen3.5-9b",
+        "name": "Qwen3.5-9B",
+        "contextWindow": 262144,
+        "maxOutput": 262144,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.1,
+        "outputCost": 0.15
       },
       {
         "id": "openai/gpt-5.4",
@@ -1255,26 +1884,114 @@
         "outputCost": 1.5
       },
       {
-        "id": "openai/gpt-5.3-codex",
-        "name": "GPT-5.3-Codex",
-        "contextWindow": 400000,
-        "maxOutput": 128000,
+        "id": "openai/gpt-5.3-chat",
+        "name": "GPT-5.3 Chat",
+        "contextWindow": 128000,
+        "maxOutput": 16384,
         "supportsImages": true,
-        "supportsReasoning": true,
+        "supportsReasoning": false,
         "supportsToolCall": true,
         "inputCost": 1.75,
         "outputCost": 14
       },
       {
-        "id": "google/gemini-3.1-pro-preview-customtools",
-        "name": "Gemini 3.1 Pro Preview Custom Tools",
-        "contextWindow": 1048576,
+        "id": "deepseek/deepseek-chat",
+        "name": "DeepSeek Chat",
+        "contextWindow": 128000,
+        "maxOutput": 16000,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.2002,
+        "outputCost": 0.8001
+      },
+      {
+        "id": "bytedance-seed/seed-2.0-mini",
+        "name": "Seed-2.0-Mini",
+        "contextWindow": 262144,
+        "maxOutput": 131072,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.1,
+        "outputCost": 0.4
+      },
+      {
+        "id": "google/gemini-3.1-flash-image-preview",
+        "name": "Nano Banana 2",
+        "contextWindow": 65536,
+        "maxOutput": 65536,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 0.5,
+        "outputCost": 3
+      },
+      {
+        "id": "liquid/lfm-2-24b-a2b",
+        "name": "LFM2-24B-A2B",
+        "contextWindow": 32768,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.03,
+        "outputCost": 0.12
+      },
+      {
+        "id": "qwen/qwen3.5-flash-02-23",
+        "name": "Qwen3.5-Flash",
+        "contextWindow": 1000000,
         "maxOutput": 65536,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 2,
-        "outputCost": 12
+        "inputCost": 0.065,
+        "outputCost": 0.26
+      },
+      {
+        "id": "aion-labs/aion-2.0",
+        "name": "Aion-2.0",
+        "contextWindow": 131072,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 0.8,
+        "outputCost": 1.6
+      },
+      {
+        "id": "qwen/qwen3.5-122b-a10b",
+        "name": "Qwen3.5 122B-A10B",
+        "contextWindow": 262144,
+        "maxOutput": 262144,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.26,
+        "outputCost": 2.08
+      },
+      {
+        "id": "qwen/qwen3.5-27b",
+        "name": "Qwen3.5 27B",
+        "contextWindow": 262144,
+        "maxOutput": 65536,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.195,
+        "outputCost": 1.56
+      },
+      {
+        "id": "qwen/qwen3.5-35b-a3b",
+        "name": "Qwen3.5 35B-A3B",
+        "contextWindow": 262144,
+        "maxOutput": 262144,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.14,
+        "outputCost": 1
       },
       {
         "id": "google/gemini-3.1-pro-preview",
@@ -1288,26 +2005,15 @@
         "outputCost": 12
       },
       {
-        "id": "anthropic/claude-sonnet-4.6",
-        "name": "Claude Sonnet 4.6",
-        "contextWindow": 1000000,
-        "maxOutput": 128000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 3,
-        "outputCost": 15
-      },
-      {
-        "id": "qwen/qwen3.5-397b-a17b",
-        "name": "Qwen3.5 397B A17B",
-        "contextWindow": 262144,
+        "id": "google/gemini-3.1-pro-preview-customtools",
+        "name": "Gemini 3.1 Pro Preview Custom Tools",
+        "contextWindow": 1048576,
         "maxOutput": 65536,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0.6,
-        "outputCost": 3.6
+        "inputCost": 2,
+        "outputCost": 12
       },
       {
         "id": "qwen/qwen3.5-plus-02-15",
@@ -1317,276 +2023,67 @@
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0.4,
-        "outputCost": 2.4
+        "inputCost": 0.26,
+        "outputCost": 1.56
+      },
+      {
+        "id": "qwen/qwen3.5-397b-a17b",
+        "name": "Qwen3.5 397B-A17B",
+        "contextWindow": 262144,
+        "maxOutput": 65536,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.39,
+        "outputCost": 2.34
+      },
+      {
+        "id": "stepfun/step-3.5-flash",
+        "name": "Step 3.5 Flash",
+        "contextWindow": 262144,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.09,
+        "outputCost": 0.3
+      },
+      {
+        "id": "minimax/minimax-m2.5",
+        "name": "MiniMax-M2.5",
+        "contextWindow": 196608,
+        "maxOutput": 196608,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.15,
+        "outputCost": 0.9
       },
       {
         "id": "z-ai/glm-5",
         "name": "GLM-5",
         "contextWindow": 202752,
-        "maxOutput": 131000,
+        "maxOutput": 16384,
         "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 1,
-        "outputCost": 3.2
-      },
-      {
-        "id": "minimax/minimax-m2.5",
-        "name": "MiniMax M2.5",
-        "contextWindow": 204800,
-        "maxOutput": 131072,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.3,
-        "outputCost": 1.2
-      },
-      {
-        "id": "anthropic/claude-opus-4.6",
-        "name": "Claude Opus 4.6",
-        "contextWindow": 1000000,
-        "maxOutput": 128000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 5,
-        "outputCost": 25
-      },
-      {
-        "id": "openrouter/free",
-        "name": "Free Models Router",
-        "contextWindow": 200000,
-        "maxOutput": 8000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "nvidia/nemotron-nano-12b-v2-vl:free",
-        "name": "Nemotron Nano 12B 2 VL (free)",
-        "contextWindow": 128000,
-        "maxOutput": 128000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "nvidia/nemotron-3-nano-30b-a3b:free",
-        "name": "Nemotron 3 Nano 30B A3B (free)",
-        "contextWindow": 256000,
-        "maxOutput": 256000,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "cognitivecomputations/dolphin-mistral-24b-venice-edition:free",
-        "name": "Uncensored (free)",
-        "contextWindow": 32768,
-        "maxOutput": 32768,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "openai/gpt-oss-20b:free",
-        "name": "gpt-oss-20b (free)",
-        "contextWindow": 131072,
-        "maxOutput": 32768,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "bytedance-seed/seedream-4.5",
-        "name": "Seedream 4.5",
-        "contextWindow": 4096,
-        "maxOutput": 4096,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "black-forest-labs/flux.2-pro",
-        "name": "FLUX.2 Pro",
-        "contextWindow": 46864,
-        "maxOutput": 46864,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "black-forest-labs/flux.2-flex",
-        "name": "FLUX.2 Flex",
-        "contextWindow": 67344,
-        "maxOutput": 67344,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "black-forest-labs/flux.2-max",
-        "name": "FLUX.2 Max",
-        "contextWindow": 46864,
-        "maxOutput": 46864,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "black-forest-labs/flux.2-klein-4b",
-        "name": "FLUX.2 Klein 4B",
-        "contextWindow": 40960,
-        "maxOutput": 40960,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "stepfun/step-3.5-flash:free",
-        "name": "Step 3.5 Flash (free)",
-        "contextWindow": 256000,
-        "maxOutput": 256000,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "stepfun/step-3.5-flash",
-        "name": "Step 3.5 Flash",
-        "contextWindow": 256000,
-        "maxOutput": 256000,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.1,
-        "outputCost": 0.3
-      },
-      {
-        "id": "arcee-ai/trinity-large-preview:free",
-        "name": "Trinity Large Preview",
-        "contextWindow": 131072,
-        "maxOutput": 131072,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "arcee-ai/trinity-mini:free",
-        "name": "Trinity Mini",
-        "contextWindow": 131072,
-        "maxOutput": 131072,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "liquid/lfm-2.5-1.2b-thinking:free",
-        "name": "LFM2.5-1.2B-Thinking (free)",
-        "contextWindow": 131072,
-        "maxOutput": 32768,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "liquid/lfm-2.5-1.2b-instruct:free",
-        "name": "LFM2.5-1.2B-Instruct (free)",
-        "contextWindow": 131072,
-        "maxOutput": 32768,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "sourceful/riverflow-v2-fast-preview",
-        "name": "Riverflow V2 Fast Preview",
-        "contextWindow": 8192,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "sourceful/riverflow-v2-max-preview",
-        "name": "Riverflow V2 Max Preview",
-        "contextWindow": 8192,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "sourceful/riverflow-v2-standard-preview",
-        "name": "Riverflow V2 Standard Preview",
-        "contextWindow": 8192,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "moonshotai/kimi-k2.5",
-        "name": "Kimi K2.5",
-        "contextWindow": 262144,
-        "maxOutput": 262144,
-        "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
         "inputCost": 0.6,
-        "outputCost": 3
+        "outputCost": 1.92
       },
       {
-        "id": "z-ai/glm-4.7-flash",
-        "name": "GLM-4.7-Flash",
-        "contextWindow": 200000,
-        "maxOutput": 65535,
+        "id": "qwen/qwen3-max-thinking",
+        "name": "Qwen3 Max Thinking",
+        "contextWindow": 262144,
+        "maxOutput": 32768,
         "supportsImages": false,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0.07,
-        "outputCost": 0.4
+        "inputCost": 0.78,
+        "outputCost": 3.9
       },
       {
-        "id": "openai/gpt-5.2-codex",
-        "name": "GPT-5.2-Codex",
+        "id": "openai/gpt-5.3-codex",
+        "name": "GPT-5.3 Codex",
         "contextWindow": 400000,
         "maxOutput": 128000,
         "supportsImages": true,
@@ -1596,37 +2093,15 @@
         "outputCost": 14
       },
       {
-        "id": "minimax/minimax-m2.1",
-        "name": "MiniMax M2.1",
-        "contextWindow": 204800,
-        "maxOutput": 131072,
+        "id": "qwen/qwen3-coder-next",
+        "name": "Qwen3 Coder Next",
+        "contextWindow": 262144,
+        "maxOutput": 262144,
         "supportsImages": false,
-        "supportsReasoning": true,
+        "supportsReasoning": false,
         "supportsToolCall": true,
-        "inputCost": 0.3,
-        "outputCost": 1.2
-      },
-      {
-        "id": "z-ai/glm-4.7",
-        "name": "GLM-4.7",
-        "contextWindow": 204800,
-        "maxOutput": 131072,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.6,
-        "outputCost": 2.2
-      },
-      {
-        "id": "google/gemini-3-flash-preview",
-        "name": "Gemini 3 Flash Preview",
-        "contextWindow": 1048576,
-        "maxOutput": 65536,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.5,
-        "outputCost": 3
+        "inputCost": 0.11,
+        "outputCost": 0.8
       },
       {
         "id": "xiaomi/mimo-v2-flash",
@@ -1640,10 +2115,197 @@
         "outputCost": 0.3
       },
       {
-        "id": "openai/gpt-5.2-chat",
-        "name": "GPT-5.2 Chat",
+        "id": "openrouter/free",
+        "name": "Free Models Router",
+        "contextWindow": 200000,
+        "maxOutput": 8000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "upstage/solar-pro-3",
+        "name": "Solar Pro 3",
+        "contextWindow": 128000,
+        "maxOutput": 128000,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.15,
+        "outputCost": 0.6
+      },
+      {
+        "id": "minimax/minimax-m2-her",
+        "name": "MiniMax M2-her",
+        "contextWindow": 65536,
+        "maxOutput": 2048,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.3,
+        "outputCost": 1.2
+      },
+      {
+        "id": "writer/palmyra-x5",
+        "name": "Palmyra X5",
+        "contextWindow": 1040000,
+        "maxOutput": 8192,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.6,
+        "outputCost": 6
+      },
+      {
+        "id": "liquid/lfm-2.5-1.2b-instruct:free",
+        "name": "LFM2.5-1.2B-Instruct (free)",
+        "contextWindow": 32768,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "liquid/lfm-2.5-1.2b-thinking:free",
+        "name": "LFM2.5-1.2B-Thinking (free)",
+        "contextWindow": 32768,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "openai/gpt-audio",
+        "name": "GPT Audio",
         "contextWindow": 128000,
         "maxOutput": 16384,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 2.5,
+        "outputCost": 10
+      },
+      {
+        "id": "openai/gpt-audio-mini",
+        "name": "GPT Audio Mini",
+        "contextWindow": 128000,
+        "maxOutput": 16384,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.6,
+        "outputCost": 2.4
+      },
+      {
+        "id": "z-ai/glm-4.7-flash",
+        "name": "GLM-4.7-Flash",
+        "contextWindow": 202752,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.06,
+        "outputCost": 0.4
+      },
+      {
+        "id": "moonshotai/kimi-k2.5",
+        "name": "Kimi K2.5",
+        "contextWindow": 256000,
+        "maxOutput": 262144,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.375,
+        "outputCost": 2.025
+      },
+      {
+        "id": "bytedance-seed/seed-1.6",
+        "name": "Seed 1.6",
+        "contextWindow": 262144,
+        "maxOutput": 32768,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.25,
+        "outputCost": 2
+      },
+      {
+        "id": "bytedance-seed/seed-1.6-flash",
+        "name": "Seed 1.6 Flash",
+        "contextWindow": 262144,
+        "maxOutput": 32768,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.075,
+        "outputCost": 0.3
+      },
+      {
+        "id": "minimax/minimax-m2.1",
+        "name": "MiniMax-M2.1",
+        "contextWindow": 196608,
+        "maxOutput": 196608,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.29,
+        "outputCost": 0.95
+      },
+      {
+        "id": "z-ai/glm-4.7",
+        "name": "GLM-4.7",
+        "contextWindow": 202752,
+        "maxOutput": 131072,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.4,
+        "outputCost": 1.75
+      },
+      {
+        "id": "google/gemini-3-flash-preview",
+        "name": "Gemini 3 Flash Preview",
+        "contextWindow": 1048576,
+        "maxOutput": 65536,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.5,
+        "outputCost": 3
+      },
+      {
+        "id": "nvidia/nemotron-3-nano-30b-a3b",
+        "name": "Nemotron 3 Nano 30B A3B",
+        "contextWindow": 262144,
+        "maxOutput": 228000,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.05,
+        "outputCost": 0.2
+      },
+      {
+        "id": "nvidia/nemotron-3-nano-30b-a3b:free",
+        "name": "Nemotron 3 Nano 30B A3B (free)",
+        "contextWindow": 256000,
+        "maxOutput": 256000,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "openai/gpt-5.2",
+        "name": "GPT-5.2",
+        "contextWindow": 400000,
+        "maxOutput": 128000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
@@ -1651,8 +2313,8 @@
         "outputCost": 14
       },
       {
-        "id": "openai/gpt-5.2",
-        "name": "GPT-5.2",
+        "id": "openai/gpt-5.2-codex",
+        "name": "GPT-5.2 Codex",
         "contextWindow": 400000,
         "maxOutput": 128000,
         "supportsImages": true,
@@ -1673,32 +2335,151 @@
         "outputCost": 168
       },
       {
-        "id": "deepseek/deepseek-v3.2-speciale",
-        "name": "DeepSeek V3.2 Speciale",
-        "contextWindow": 163840,
-        "maxOutput": 65536,
+        "id": "openai/gpt-5.2-chat",
+        "name": "GPT-5.2 Chat",
+        "contextWindow": 128000,
+        "maxOutput": 16384,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 1.75,
+        "outputCost": 14
+      },
+      {
+        "id": "relace/relace-search",
+        "name": "Relace Search",
+        "contextWindow": 256000,
+        "maxOutput": 128000,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 1,
+        "outputCost": 3
+      },
+      {
+        "id": "z-ai/glm-4.6v",
+        "name": "GLM-4.6V",
+        "contextWindow": 131072,
+        "maxOutput": 32768,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.3,
+        "outputCost": 0.9
+      },
+      {
+        "id": "essentialai/rnj-1-instruct",
+        "name": "Rnj 1 Instruct",
+        "contextWindow": 32768,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.15,
+        "outputCost": 0.15
+      },
+      {
+        "id": "openrouter/bodybuilder",
+        "name": "Body Builder (beta)",
+        "contextWindow": 128000,
+        "maxOutput": 128000,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false
+      },
+      {
+        "id": "amazon/nova-2-lite-v1",
+        "name": "Nova 2 Lite",
+        "contextWindow": 1000000,
+        "maxOutput": 65535,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.3,
+        "outputCost": 2.5
+      },
+      {
+        "id": "mistralai/ministral-14b-2512",
+        "name": "Ministral 3 14B 2512",
+        "contextWindow": 262144,
+        "maxOutput": 262144,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.2,
+        "outputCost": 0.2
+      },
+      {
+        "id": "mistralai/ministral-3b-2512",
+        "name": "Ministral 3 3B 2512",
+        "contextWindow": 131072,
+        "maxOutput": 131072,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.1,
+        "outputCost": 0.1
+      },
+      {
+        "id": "mistralai/ministral-8b-2512",
+        "name": "Ministral 3 8B 2512",
+        "contextWindow": 262144,
+        "maxOutput": 262144,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.15,
+        "outputCost": 0.15
+      },
+      {
+        "id": "mistralai/mistral-large-2512",
+        "name": "Mistral Large 3",
+        "contextWindow": 262144,
+        "maxOutput": 262144,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.5,
+        "outputCost": 1.5
+      },
+      {
+        "id": "arcee-ai/trinity-mini",
+        "name": "Trinity Mini",
+        "contextWindow": 131072,
+        "maxOutput": 131072,
         "supportsImages": false,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0.27,
-        "outputCost": 0.41
+        "inputCost": 0.045,
+        "outputCost": 0.15
       },
       {
         "id": "deepseek/deepseek-v3.2",
         "name": "DeepSeek V3.2",
-        "contextWindow": 163840,
-        "maxOutput": 65536,
+        "contextWindow": 128000,
+        "maxOutput": 64000,
         "supportsImages": false,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0.28,
-        "outputCost": 0.4
+        "inputCost": 0.2288,
+        "outputCost": 0.3432
+      },
+      {
+        "id": "prime-intellect/intellect-3",
+        "name": "INTELLECT-3",
+        "contextWindow": 131072,
+        "maxOutput": 131072,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.2,
+        "outputCost": 1.1
       },
       {
         "id": "anthropic/claude-opus-4.5",
-        "name": "Claude Opus 4.5",
+        "name": "Claude Opus 4.5 (latest)",
         "contextWindow": 200000,
-        "maxOutput": 32000,
+        "maxOutput": 64000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
@@ -1706,26 +2487,37 @@
         "outputCost": 25
       },
       {
-        "id": "x-ai/grok-4.1-fast",
-        "name": "Grok 4.1 Fast",
-        "contextWindow": 2000000,
-        "maxOutput": 30000,
-        "supportsImages": true,
+        "id": "allenai/olmo-3-32b-think",
+        "name": "Olmo 3 32B Think",
+        "contextWindow": 65536,
+        "maxOutput": 65536,
+        "supportsImages": false,
         "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.2,
+        "supportsToolCall": false,
+        "inputCost": 0.15,
         "outputCost": 0.5
       },
       {
-        "id": "openai/gpt-5.1-codex-max",
-        "name": "GPT-5.1-Codex-Max",
-        "contextWindow": 400000,
-        "maxOutput": 128000,
+        "id": "google/gemini-3-pro-image-preview",
+        "name": "Nano Banana Pro",
+        "contextWindow": 65536,
+        "maxOutput": 32768,
         "supportsImages": true,
         "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 1.1,
-        "outputCost": 9
+        "supportsToolCall": false,
+        "inputCost": 2,
+        "outputCost": 12
+      },
+      {
+        "id": "deepcogito/cogito-v2.1-671b",
+        "name": "Cogito v2.1 671B",
+        "contextWindow": 128000,
+        "maxOutput": 128000,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 1.25,
+        "outputCost": 1.25
       },
       {
         "id": "openai/gpt-5.1",
@@ -1742,7 +2534,29 @@
         "id": "openai/gpt-5.1-chat",
         "name": "GPT-5.1 Chat",
         "contextWindow": 128000,
-        "maxOutput": 16384,
+        "maxOutput": 32000,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 1.25,
+        "outputCost": 10
+      },
+      {
+        "id": "openai/gpt-5.1-codex",
+        "name": "GPT-5.1 Codex",
+        "contextWindow": 400000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1.25,
+        "outputCost": 10
+      },
+      {
+        "id": "openai/gpt-5.1-codex-max",
+        "name": "GPT-5.1 Codex Max",
+        "contextWindow": 400000,
+        "maxOutput": 128000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
@@ -1751,7 +2565,7 @@
       },
       {
         "id": "openai/gpt-5.1-codex-mini",
-        "name": "GPT-5.1-Codex-Mini",
+        "name": "GPT-5.1 Codex mini",
         "contextWindow": 400000,
         "maxOutput": 100000,
         "supportsImages": true,
@@ -1759,17 +2573,6 @@
         "supportsToolCall": true,
         "inputCost": 0.25,
         "outputCost": 2
-      },
-      {
-        "id": "openai/gpt-5.1-codex",
-        "name": "GPT-5.1-Codex",
-        "contextWindow": 400000,
-        "maxOutput": 128000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 1.25,
-        "outputCost": 10
       },
       {
         "id": "moonshotai/kimi-k2-thinking",
@@ -1783,19 +2586,41 @@
         "outputCost": 2.5
       },
       {
-        "id": "google/gemini-3-pro-preview",
-        "name": "Gemini 3 Pro Preview",
-        "contextWindow": 1050000,
-        "maxOutput": 66000,
+        "id": "amazon/nova-premier-v1",
+        "name": "Nova Premier 1.0",
+        "contextWindow": 1000000,
+        "maxOutput": 32000,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 2.5,
+        "outputCost": 12.5
+      },
+      {
+        "id": "mistralai/voxtral-small-24b-2507",
+        "name": "Voxtral Small 24B 2507",
+        "contextWindow": 32000,
+        "maxOutput": 32000,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.1,
+        "outputCost": 0.3
+      },
+      {
+        "id": "perplexity/sonar-pro-search",
+        "name": "Sonar Pro Search",
+        "contextWindow": 200000,
+        "maxOutput": 8000,
         "supportsImages": true,
         "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 2,
-        "outputCost": 12
+        "supportsToolCall": false,
+        "inputCost": 3,
+        "outputCost": 15
       },
       {
         "id": "openai/gpt-oss-safeguard-20b",
-        "name": "GPT OSS Safeguard 20B",
+        "name": "gpt-oss-safeguard-20b",
         "contextWindow": 131072,
         "maxOutput": 65536,
         "supportsImages": false,
@@ -1805,19 +2630,74 @@
         "outputCost": 0.3
       },
       {
+        "id": "nvidia/nemotron-nano-12b-v2-vl:free",
+        "name": "Nemotron Nano 12B 2 VL (free)",
+        "contextWindow": 128000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
         "id": "minimax/minimax-m2",
-        "name": "MiniMax M2",
-        "contextWindow": 196600,
-        "maxOutput": 118000,
+        "name": "MiniMax-M2",
+        "contextWindow": 196608,
+        "maxOutput": 196608,
         "supportsImages": false,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0.28,
-        "outputCost": 1.15
+        "inputCost": 0.255,
+        "outputCost": 1
+      },
+      {
+        "id": "qwen/qwen3-vl-32b-instruct",
+        "name": "Qwen3 VL 32B Instruct",
+        "contextWindow": 131072,
+        "maxOutput": 32768,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.104,
+        "outputCost": 0.416
+      },
+      {
+        "id": "ibm-granite/granite-4.0-h-micro",
+        "name": "Granite 4.0 Micro",
+        "contextWindow": 131000,
+        "maxOutput": 131000,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.017,
+        "outputCost": 0.112
+      },
+      {
+        "id": "microsoft/phi-4-mini-instruct",
+        "name": "Phi 4 Mini Instruct",
+        "contextWindow": 128000,
+        "maxOutput": 128000,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.08,
+        "outputCost": 0.35
+      },
+      {
+        "id": "openai/gpt-5-image-mini",
+        "name": "GPT-5 Image Mini",
+        "contextWindow": 400000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 2.5,
+        "outputCost": 2
       },
       {
         "id": "anthropic/claude-haiku-4.5",
-        "name": "Claude Haiku 4.5",
+        "name": "Claude Haiku 4.5 (latest)",
         "contextWindow": 200000,
         "maxOutput": 64000,
         "supportsImages": true,
@@ -1833,15 +2713,37 @@
         "maxOutput": 128000,
         "supportsImages": true,
         "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 5,
+        "supportsToolCall": false,
+        "inputCost": 10,
         "outputCost": 10
+      },
+      {
+        "id": "qwen/qwen3-vl-8b-instruct",
+        "name": "Qwen3 VL 8B Instruct",
+        "contextWindow": 131072,
+        "maxOutput": 32768,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.08,
+        "outputCost": 0.5
+      },
+      {
+        "id": "qwen/qwen3-vl-8b-thinking",
+        "name": "Qwen3 VL 8B Thinking",
+        "contextWindow": 131072,
+        "maxOutput": 32768,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.117,
+        "outputCost": 1.365
       },
       {
         "id": "openai/gpt-5-pro",
         "name": "GPT-5 Pro",
         "contextWindow": 400000,
-        "maxOutput": 272000,
+        "maxOutput": 128000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
@@ -1849,30 +2751,41 @@
         "outputCost": 120
       },
       {
-        "id": "z-ai/glm-4.6:exacto",
-        "name": "GLM 4.6 (exacto)",
-        "contextWindow": 200000,
-        "maxOutput": 128000,
-        "supportsImages": false,
+        "id": "qwen/qwen3-vl-30b-a3b-instruct",
+        "name": "Qwen3 VL 30B A3B Instruct",
+        "contextWindow": 131072,
+        "maxOutput": 32768,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.13,
+        "outputCost": 0.52
+      },
+      {
+        "id": "qwen/qwen3-vl-30b-a3b-thinking",
+        "name": "Qwen3 VL 30B A3B Thinking",
+        "contextWindow": 131072,
+        "maxOutput": 32768,
+        "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0.6,
-        "outputCost": 1.9
+        "inputCost": 0.13,
+        "outputCost": 1.56
       },
       {
         "id": "z-ai/glm-4.6",
-        "name": "GLM 4.6",
-        "contextWindow": 200000,
-        "maxOutput": 128000,
+        "name": "GLM-4.6",
+        "contextWindow": 202752,
+        "maxOutput": 131072,
         "supportsImages": false,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0.6,
-        "outputCost": 2.2
+        "inputCost": 0.43,
+        "outputCost": 1.74
       },
       {
         "id": "anthropic/claude-sonnet-4.5",
-        "name": "Claude Sonnet 4.5",
+        "name": "Claude Sonnet 4.5 (latest)",
         "contextWindow": 1000000,
         "maxOutput": 64000,
         "supportsImages": true,
@@ -1882,10 +2795,43 @@
         "outputCost": 15
       },
       {
-        "id": "google/gemini-2.5-flash-lite-preview-09-2025",
-        "name": "Gemini 2.5 Flash Lite Preview 09-25",
-        "contextWindow": 1048576,
+        "id": "deepseek/deepseek-v3.2-exp",
+        "name": "DeepSeek V3.2 Exp",
+        "contextWindow": 163840,
         "maxOutput": 65536,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.27,
+        "outputCost": 0.41
+      },
+      {
+        "id": "thedrummer/cydonia-24b-v4.1",
+        "name": "Cydonia 24B V4.1",
+        "contextWindow": 131072,
+        "maxOutput": 131072,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.3,
+        "outputCost": 0.5
+      },
+      {
+        "id": "relace/relace-apply-3",
+        "name": "Relace Apply 3",
+        "contextWindow": 256000,
+        "maxOutput": 128000,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.85,
+        "outputCost": 1.25
+      },
+      {
+        "id": "google/gemini-2.5-flash-lite-preview-09-2025",
+        "name": "Gemini 2.5 Flash Lite Preview 09-2025",
+        "contextWindow": 1048576,
+        "maxOutput": 65535,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
@@ -1893,41 +2839,52 @@
         "outputCost": 0.4
       },
       {
-        "id": "google/gemini-2.5-flash-preview-09-2025",
-        "name": "Gemini 2.5 Flash Preview 09-25",
-        "contextWindow": 1048576,
-        "maxOutput": 65536,
+        "id": "qwen/qwen3-max",
+        "name": "Qwen3 Max",
+        "contextWindow": 262144,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.78,
+        "outputCost": 3.9
+      },
+      {
+        "id": "qwen/qwen3-vl-235b-a22b-instruct",
+        "name": "Qwen3 VL 235B A22B Instruct",
+        "contextWindow": 262144,
+        "maxOutput": 16384,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.2,
+        "outputCost": 0.88
+      },
+      {
+        "id": "qwen/qwen3-vl-235b-a22b-thinking",
+        "name": "Qwen3 VL 235B A22B Thinking",
+        "contextWindow": 131072,
+        "maxOutput": 32768,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0.3,
-        "outputCost": 2.5
-      },
-      {
-        "id": "deepseek/deepseek-v3.1-terminus:exacto",
-        "name": "DeepSeek V3.1 Terminus (exacto)",
-        "contextWindow": 131072,
-        "maxOutput": 65536,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.27,
-        "outputCost": 1
+        "inputCost": 0.26,
+        "outputCost": 2.6
       },
       {
         "id": "deepseek/deepseek-v3.1-terminus",
         "name": "DeepSeek V3.1 Terminus",
-        "contextWindow": 131072,
-        "maxOutput": 65536,
+        "contextWindow": 163840,
+        "maxOutput": 32768,
         "supportsImages": false,
         "supportsReasoning": true,
         "supportsToolCall": true,
         "inputCost": 0.27,
-        "outputCost": 1
+        "outputCost": 0.95
       },
       {
         "id": "openai/gpt-5-codex",
-        "name": "GPT-5 Codex",
+        "name": "GPT-5-Codex",
         "contextWindow": 400000,
         "maxOutput": 128000,
         "supportsImages": true,
@@ -1937,26 +2894,59 @@
         "outputCost": 10
       },
       {
-        "id": "mistralai/devstral-2512",
-        "name": "Devstral 2 2512",
+        "id": "qwen/qwen-plus",
+        "name": "Qwen Plus",
+        "contextWindow": 1000000,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.26,
+        "outputCost": 0.78
+      },
+      {
+        "id": "qwen/qwen-plus-2025-07-28",
+        "name": "Qwen Plus 0728",
+        "contextWindow": 1000000,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.26,
+        "outputCost": 0.78
+      },
+      {
+        "id": "qwen/qwen-plus-2025-07-28:thinking",
+        "name": "Qwen Plus 0728 (thinking)",
+        "contextWindow": 1000000,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.26,
+        "outputCost": 0.78
+      },
+      {
+        "id": "moonshotai/kimi-k2-0905",
+        "name": "Kimi K2 0905",
         "contextWindow": 262144,
         "maxOutput": 262144,
         "supportsImages": false,
         "supportsReasoning": false,
         "supportsToolCall": true,
-        "inputCost": 0.15,
-        "outputCost": 0.6
+        "inputCost": 0.6,
+        "outputCost": 2.5
       },
       {
-        "id": "qwen/qwen3-next-80b-a3b-thinking",
-        "name": "Qwen3 Next 80B A3B Thinking",
+        "id": "qwen/qwen3-next-80b-a3b-instruct",
+        "name": "Qwen3-Next 80B-A3B Instruct",
         "contextWindow": 262144,
-        "maxOutput": 262144,
+        "maxOutput": 16384,
         "supportsImages": false,
-        "supportsReasoning": true,
+        "supportsReasoning": false,
         "supportsToolCall": true,
-        "inputCost": 0.14,
-        "outputCost": 1.4
+        "inputCost": 0.09,
+        "outputCost": 1.1
       },
       {
         "id": "qwen/qwen3-next-80b-a3b-instruct:free",
@@ -1970,59 +2960,37 @@
         "outputCost": 0
       },
       {
-        "id": "qwen/qwen3-next-80b-a3b-instruct",
-        "name": "Qwen3 Next 80B A3B Instruct",
-        "contextWindow": 262144,
-        "maxOutput": 262144,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.14,
-        "outputCost": 1.4
-      },
-      {
-        "id": "moonshotai/kimi-k2-0905",
-        "name": "Kimi K2 Instruct 0905",
-        "contextWindow": 262144,
-        "maxOutput": 16384,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.6,
-        "outputCost": 2.5
-      },
-      {
-        "id": "moonshotai/kimi-k2-0905:exacto",
-        "name": "Kimi K2 Instruct 0905 (exacto)",
-        "contextWindow": 262144,
-        "maxOutput": 16384,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.6,
-        "outputCost": 2.5
-      },
-      {
-        "id": "qwen/qwen3-max",
-        "name": "Qwen3 Max",
-        "contextWindow": 262144,
+        "id": "qwen/qwen3-next-80b-a3b-thinking",
+        "name": "Qwen3-Next 80B-A3B (Thinking)",
+        "contextWindow": 131072,
         "maxOutput": 32768,
         "supportsImages": false,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 1.2,
-        "outputCost": 6
+        "inputCost": 0.0975,
+        "outputCost": 0.78
       },
       {
-        "id": "x-ai/grok-code-fast-1",
-        "name": "Grok Code Fast 1",
-        "contextWindow": 256000,
-        "maxOutput": 10000,
+        "id": "qwen/qwen3-30b-a3b-thinking-2507",
+        "name": "Qwen3 30B A3B Thinking 2507",
+        "contextWindow": 131072,
+        "maxOutput": 131072,
         "supportsImages": false,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0.2,
-        "outputCost": 1.5
+        "inputCost": 0.08,
+        "outputCost": 0.4
+      },
+      {
+        "id": "google/gemini-2.5-flash-image",
+        "name": "Nano Banana",
+        "contextWindow": 32768,
+        "maxOutput": 32768,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.3,
+        "outputCost": 2.5
       },
       {
         "id": "nousresearch/hermes-4-405b",
@@ -2031,7 +2999,7 @@
         "maxOutput": 131072,
         "supportsImages": false,
         "supportsReasoning": true,
-        "supportsToolCall": true,
+        "supportsToolCall": false,
         "inputCost": 1,
         "outputCost": 3
       },
@@ -2042,31 +3010,20 @@
         "maxOutput": 131072,
         "supportsImages": false,
         "supportsReasoning": true,
-        "supportsToolCall": true,
+        "supportsToolCall": false,
         "inputCost": 0.13,
         "outputCost": 0.4
       },
       {
         "id": "deepseek/deepseek-chat-v3.1",
-        "name": "DeepSeek-V3.1",
+        "name": "DeepSeek V3.1",
         "contextWindow": 163840,
-        "maxOutput": 163840,
+        "maxOutput": 32768,
         "supportsImages": false,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0.2,
-        "outputCost": 0.8
-      },
-      {
-        "id": "x-ai/grok-4-fast",
-        "name": "Grok 4 Fast",
-        "contextWindow": 2000000,
-        "maxOutput": 30000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.2,
-        "outputCost": 0.5
+        "inputCost": 0.21,
+        "outputCost": 0.79
       },
       {
         "id": "nvidia/nemotron-nano-9b-v2:free",
@@ -2080,20 +3037,9 @@
         "outputCost": 0
       },
       {
-        "id": "nvidia/nemotron-nano-9b-v2",
-        "name": "nvidia-nemotron-nano-9b-v2",
-        "contextWindow": 131072,
-        "maxOutput": 131072,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.04,
-        "outputCost": 0.16
-      },
-      {
         "id": "mistralai/mistral-medium-3.1",
         "name": "Mistral Medium 3.1",
-        "contextWindow": 262144,
+        "contextWindow": 131072,
         "maxOutput": 262144,
         "supportsImages": true,
         "supportsReasoning": false,
@@ -2103,8 +3049,8 @@
       },
       {
         "id": "z-ai/glm-4.5v",
-        "name": "GLM 4.5V",
-        "contextWindow": 64000,
+        "name": "GLM-4.5V",
+        "contextWindow": 65536,
         "maxOutput": 16384,
         "supportsImages": true,
         "supportsReasoning": true,
@@ -2113,15 +3059,15 @@
         "outputCost": 1.8
       },
       {
-        "id": "openai/gpt-5-chat",
-        "name": "GPT-5 Chat (latest)",
-        "contextWindow": 400000,
-        "maxOutput": 128000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": false,
-        "inputCost": 1.25,
-        "outputCost": 10
+        "id": "ai21/jamba-large-1.7",
+        "name": "Jamba Large 1.7",
+        "contextWindow": 256000,
+        "maxOutput": 4096,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 2,
+        "outputCost": 8
       },
       {
         "id": "openai/gpt-5",
@@ -2131,6 +3077,17 @@
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
+        "inputCost": 1.25,
+        "outputCost": 10
+      },
+      {
+        "id": "openai/gpt-5-chat",
+        "name": "GPT-5 Chat",
+        "contextWindow": 128000,
+        "maxOutput": 16384,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
         "inputCost": 1.25,
         "outputCost": 10
       },
@@ -2157,52 +3114,8 @@
         "outputCost": 0.4
       },
       {
-        "id": "openai/gpt-oss-120b:exacto",
-        "name": "GPT OSS 120B (exacto)",
-        "contextWindow": 131072,
-        "maxOutput": 32768,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.05,
-        "outputCost": 0.24
-      },
-      {
-        "id": "openai/gpt-oss-120b",
-        "name": "GPT OSS 120B",
-        "contextWindow": 131072,
-        "maxOutput": 32768,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.072,
-        "outputCost": 0.28
-      },
-      {
-        "id": "openai/gpt-oss-20b",
-        "name": "GPT OSS 20B",
-        "contextWindow": 131072,
-        "maxOutput": 32768,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.05,
-        "outputCost": 0.2
-      },
-      {
-        "id": "openai/gpt-oss-120b:free",
-        "name": "gpt-oss-120b (free)",
-        "contextWindow": 131072,
-        "maxOutput": 32768,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
         "id": "anthropic/claude-opus-4.1",
-        "name": "Claude Opus 4.1",
+        "name": "Claude Opus 4.1 (latest)",
         "contextWindow": 200000,
         "maxOutput": 32000,
         "supportsImages": true,
@@ -2212,65 +3125,87 @@
         "outputCost": 75
       },
       {
+        "id": "openai/gpt-oss-120b",
+        "name": "gpt-oss-120b",
+        "contextWindow": 131072,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.039,
+        "outputCost": 0.18
+      },
+      {
+        "id": "openai/gpt-oss-120b:free",
+        "name": "gpt-oss-120b (free)",
+        "contextWindow": 131072,
+        "maxOutput": 131072,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
+        "id": "openai/gpt-oss-20b",
+        "name": "gpt-oss-20b",
+        "contextWindow": 131072,
+        "maxOutput": 131072,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.029,
+        "outputCost": 0.14
+      },
+      {
+        "id": "openai/gpt-oss-20b:free",
+        "name": "gpt-oss-20b (free)",
+        "contextWindow": 131072,
+        "maxOutput": 8192,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0,
+        "outputCost": 0
+      },
+      {
         "id": "mistralai/codestral-2508",
         "name": "Codestral 2508",
         "contextWindow": 256000,
         "maxOutput": 256000,
-        "supportsImages": false,
+        "supportsImages": true,
         "supportsReasoning": false,
         "supportsToolCall": true,
         "inputCost": 0.3,
         "outputCost": 0.9
       },
       {
-        "id": "qwen/qwen3-coder-30b-a3b-instruct",
-        "name": "Qwen3 Coder 30B A3B Instruct",
-        "contextWindow": 160000,
+        "id": "qwen/qwen3-30b-a3b-instruct-2507",
+        "name": "Qwen3 30B A3B Instruct 2507",
+        "contextWindow": 128000,
+        "maxOutput": 32000,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.04815,
+        "outputCost": 0.19305
+      },
+      {
+        "id": "qwen/qwen3-coder-flash",
+        "name": "Qwen3 Coder Flash",
+        "contextWindow": 1000000,
         "maxOutput": 65536,
         "supportsImages": false,
         "supportsReasoning": false,
         "supportsToolCall": true,
-        "inputCost": 0.07,
-        "outputCost": 0.27
-      },
-      {
-        "id": "qwen/qwen3-30b-a3b-instruct-2507",
-        "name": "Qwen3 30B A3B Instruct 2507",
-        "contextWindow": 262000,
-        "maxOutput": 262000,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.2,
-        "outputCost": 0.8
-      },
-      {
-        "id": "qwen/qwen3-30b-a3b-thinking-2507",
-        "name": "Qwen3 30B A3B Thinking 2507",
-        "contextWindow": 262000,
-        "maxOutput": 262000,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.2,
-        "outputCost": 0.8
-      },
-      {
-        "id": "z-ai/glm-4.5-air",
-        "name": "GLM 4.5 Air",
-        "contextWindow": 128000,
-        "maxOutput": 96000,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.2,
-        "outputCost": 1.1
+        "inputCost": 0.195,
+        "outputCost": 0.975
       },
       {
         "id": "z-ai/glm-4.5",
-        "name": "GLM 4.5",
-        "contextWindow": 128000,
-        "maxOutput": 96000,
+        "name": "GLM-4.5",
+        "contextWindow": 131072,
+        "maxOutput": 98304,
         "supportsImages": false,
         "supportsReasoning": true,
         "supportsToolCall": true,
@@ -2278,32 +3213,65 @@
         "outputCost": 2.2
       },
       {
-        "id": "z-ai/glm-4.5-air:free",
-        "name": "GLM 4.5 Air (free)",
-        "contextWindow": 128000,
-        "maxOutput": 96000,
+        "id": "z-ai/glm-4.5-air",
+        "name": "GLM-4.5-Air",
+        "contextWindow": 131070,
+        "maxOutput": 131070,
         "supportsImages": false,
         "supportsReasoning": true,
-        "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
+        "supportsToolCall": true,
+        "inputCost": 0.125,
+        "outputCost": 0.85
+      },
+      {
+        "id": "nvidia/llama-3.3-nemotron-super-49b-v1.5",
+        "name": "Llama 3.3 Nemotron Super 49B v1.5",
+        "contextWindow": 131072,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.4,
+        "outputCost": 0.4
       },
       {
         "id": "qwen/qwen3-235b-a22b-thinking-2507",
         "name": "Qwen3 235B A22B Thinking 2507",
         "contextWindow": 262144,
-        "maxOutput": 81920,
+        "maxOutput": 262144,
         "supportsImages": false,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0.078,
-        "outputCost": 0.312
+        "inputCost": 0.1,
+        "outputCost": 0.1
+      },
+      {
+        "id": "qwen/qwen3-coder",
+        "name": "Qwen3 Coder 480B A35B",
+        "contextWindow": 262144,
+        "maxOutput": 65536,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.22,
+        "outputCost": 1.8
+      },
+      {
+        "id": "qwen/qwen3-coder-plus",
+        "name": "Qwen3 Coder Plus",
+        "contextWindow": 1000000,
+        "maxOutput": 65536,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.65,
+        "outputCost": 3.25
       },
       {
         "id": "qwen/qwen3-coder:free",
-        "name": "Qwen3 Coder 480B A35B Instruct (free)",
-        "contextWindow": 262144,
-        "maxOutput": 66536,
+        "name": "Qwen3 Coder 480B A35B (free)",
+        "contextWindow": 262000,
+        "maxOutput": 262000,
         "supportsImages": false,
         "supportsReasoning": false,
         "supportsToolCall": true,
@@ -2311,65 +3279,120 @@
         "outputCost": 0
       },
       {
-        "id": "qwen/qwen3-coder-flash",
-        "name": "Qwen3 Coder Flash",
+        "id": "bytedance/ui-tars-1.5-7b",
+        "name": "UI-TARS 7B ",
         "contextWindow": 128000,
-        "maxOutput": 66536,
-        "supportsImages": false,
+        "maxOutput": 2048,
+        "supportsImages": true,
         "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.3,
-        "outputCost": 1.5
+        "supportsToolCall": false,
+        "inputCost": 0.1,
+        "outputCost": 0.2
       },
       {
-        "id": "qwen/qwen3-coder",
-        "name": "Qwen3 Coder",
+        "id": "qwen/qwen3-235b-a22b-2507",
+        "name": "Qwen3 235B A22B Instruct 2507",
         "contextWindow": 262144,
-        "maxOutput": 66536,
+        "maxOutput": 16384,
         "supportsImages": false,
         "supportsReasoning": false,
         "supportsToolCall": true,
-        "inputCost": 0.3,
-        "outputCost": 1.2
+        "inputCost": 0.09,
+        "outputCost": 0.1
       },
       {
-        "id": "qwen/qwen3-coder:exacto",
-        "name": "Qwen3 Coder (exacto)",
+        "id": "moonshotai/kimi-k2",
+        "name": "Kimi K2 0711",
         "contextWindow": 131072,
         "maxOutput": 32768,
         "supportsImages": false,
         "supportsReasoning": false,
         "supportsToolCall": true,
-        "inputCost": 0.38,
-        "outputCost": 1.53
+        "inputCost": 0.57,
+        "outputCost": 2.3
       },
       {
-        "id": "qwen/qwen3-4b:free",
-        "name": "Qwen3 4B (free)",
-        "contextWindow": 40960,
-        "maxOutput": 40960,
+        "id": "switchpoint/router",
+        "name": "Switchpoint Router",
+        "contextWindow": 131072,
+        "maxOutput": 131072,
         "supportsImages": false,
         "supportsReasoning": true,
-        "supportsToolCall": true,
+        "supportsToolCall": false,
+        "inputCost": 0.85,
+        "outputCost": 3.4
+      },
+      {
+        "id": "cognitivecomputations/dolphin-mistral-24b-venice-edition:free",
+        "name": "Uncensored (free)",
+        "contextWindow": 32768,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
         "inputCost": 0,
         "outputCost": 0
       },
       {
-        "id": "qwen/qwen3-235b-a22b-07-25",
-        "name": "Qwen3 235B A22B Instruct 2507",
+        "id": "tencent/hunyuan-a13b-instruct",
+        "name": "Hunyuan A13B Instruct",
+        "contextWindow": 131072,
+        "maxOutput": 131072,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 0.14,
+        "outputCost": 0.57
+      },
+      {
+        "id": "morph/morph-v3-fast",
+        "name": "Morph V3 Fast",
+        "contextWindow": 81920,
+        "maxOutput": 38000,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.8,
+        "outputCost": 1.2
+      },
+      {
+        "id": "morph/morph-v3-large",
+        "name": "Morph V3 Large",
         "contextWindow": 262144,
         "maxOutput": 131072,
         "supportsImages": false,
         "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.9,
+        "outputCost": 1.9
+      },
+      {
+        "id": "baidu/ernie-4.5-vl-424b-a47b",
+        "name": "ERNIE 4.5 VL 424B A47B ",
+        "contextWindow": 123000,
+        "maxOutput": 16000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 0.42,
+        "outputCost": 1.25
+      },
+      {
+        "id": "mistralai/mistral-small-3.2-24b-instruct",
+        "name": "Mistral Small 3.2 24B",
+        "contextWindow": 128000,
+        "maxOutput": 16384,
+        "supportsImages": true,
+        "supportsReasoning": false,
         "supportsToolCall": true,
-        "inputCost": 0.15,
-        "outputCost": 0.85
+        "inputCost": 0.075,
+        "outputCost": 0.2
       },
       {
         "id": "google/gemini-2.5-flash",
         "name": "Gemini 2.5 Flash",
         "contextWindow": 1048576,
-        "maxOutput": 65536,
+        "maxOutput": 65535,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
@@ -2377,103 +3400,26 @@
         "outputCost": 2.5
       },
       {
-        "id": "moonshotai/kimi-k2",
-        "name": "Kimi K2",
-        "contextWindow": 131072,
-        "maxOutput": 32768,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.55,
-        "outputCost": 2.2
-      },
-      {
-        "id": "moonshotai/kimi-k2:free",
-        "name": "Kimi K2 (free)",
-        "contextWindow": 32800,
-        "maxOutput": 32800,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "mistralai/devstral-medium-2507",
-        "name": "Devstral Medium",
-        "contextWindow": 131072,
-        "maxOutput": 131072,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.4,
-        "outputCost": 2
-      },
-      {
-        "id": "mistralai/devstral-small-2507",
-        "name": "Devstral Small 1.1",
-        "contextWindow": 131072,
-        "maxOutput": 131072,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.1,
-        "outputCost": 0.3
-      },
-      {
-        "id": "google/gemma-3n-e2b-it:free",
-        "name": "Gemma 3n 2B (free)",
-        "contextWindow": 8192,
-        "maxOutput": 2000,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "x-ai/grok-4",
-        "name": "Grok 4",
-        "contextWindow": 256000,
-        "maxOutput": 64000,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 3,
-        "outputCost": 15
-      },
-      {
-        "id": "inception/mercury",
-        "name": "Mercury",
-        "contextWindow": 128000,
-        "maxOutput": 32000,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.25,
-        "outputCost": 0.75
-      },
-      {
-        "id": "mistralai/mistral-small-3.2-24b-instruct",
-        "name": "Mistral Small 3.2 24B Instruct",
-        "contextWindow": 96000,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
         "id": "google/gemini-2.5-flash-lite",
-        "name": "Gemini 2.5 Flash Lite",
+        "name": "Gemini 2.5 Flash-Lite",
         "contextWindow": 1048576,
-        "maxOutput": 65536,
+        "maxOutput": 65535,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
         "inputCost": 0.1,
         "outputCost": 0.4
+      },
+      {
+        "id": "google/gemini-2.5-pro",
+        "name": "Gemini 2.5 Pro",
+        "contextWindow": 1048576,
+        "maxOutput": 65536,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1.25,
+        "outputCost": 10
       },
       {
         "id": "minimax/minimax-m1",
@@ -2487,7 +3433,18 @@
         "outputCost": 2.2
       },
       {
-        "id": "google/gemini-2.5-pro-preview-06-05",
+        "id": "openai/o3-pro",
+        "name": "o3-pro",
+        "contextWindow": 200000,
+        "maxOutput": 100000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 20,
+        "outputCost": 80
+      },
+      {
+        "id": "google/gemini-2.5-pro-preview",
         "name": "Gemini 2.5 Pro Preview 06-05",
         "contextWindow": 1048576,
         "maxOutput": 65536,
@@ -2498,15 +3455,26 @@
         "outputCost": 10
       },
       {
-        "id": "google/gemini-2.5-pro",
-        "name": "Gemini 2.5 Pro",
-        "contextWindow": 1048576,
-        "maxOutput": 65536,
-        "supportsImages": true,
+        "id": "deepseek/deepseek-r1",
+        "name": "DeepSeek-R1",
+        "contextWindow": 64000,
+        "maxOutput": 16000,
+        "supportsImages": false,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 1.25,
-        "outputCost": 10
+        "inputCost": 0.7,
+        "outputCost": 2.5
+      },
+      {
+        "id": "deepseek/deepseek-r1-0528",
+        "name": "R1 0528",
+        "contextWindow": 163840,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.5,
+        "outputCost": 2.15
       },
       {
         "id": "anthropic/claude-opus-4",
@@ -2522,7 +3490,7 @@
       {
         "id": "anthropic/claude-sonnet-4",
         "name": "Claude Sonnet 4",
-        "contextWindow": 200000,
+        "contextWindow": 1000000,
         "maxOutput": 64000,
         "supportsImages": true,
         "supportsReasoning": true,
@@ -2531,26 +3499,26 @@
         "outputCost": 15
       },
       {
-        "id": "google/gemma-3n-e4b-it:free",
-        "name": "Gemma 3n 4B (free)",
-        "contextWindow": 8192,
-        "maxOutput": 2000,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
         "id": "google/gemma-3n-e4b-it",
         "name": "Gemma 3n 4B",
         "contextWindow": 32768,
         "maxOutput": 32768,
-        "supportsImages": true,
+        "supportsImages": false,
         "supportsReasoning": false,
         "supportsToolCall": false,
-        "inputCost": 0.02,
-        "outputCost": 0.04
+        "inputCost": 0.06,
+        "outputCost": 0.12
+      },
+      {
+        "id": "google/gemini-2.5-pro-preview-05-06",
+        "name": "Gemini 2.5 Pro Preview 05-06",
+        "contextWindow": 1048576,
+        "maxOutput": 65535,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1.25,
+        "outputCost": 10
       },
       {
         "id": "mistralai/mistral-medium-3",
@@ -2564,41 +3532,96 @@
         "outputCost": 2
       },
       {
-        "id": "mistralai/devstral-small-2505",
-        "name": "Devstral Small",
-        "contextWindow": 128000,
-        "maxOutput": 128000,
+        "id": "arcee-ai/coder-large",
+        "name": "Coder Large",
+        "contextWindow": 32768,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.5,
+        "outputCost": 0.8
+      },
+      {
+        "id": "arcee-ai/virtuoso-large",
+        "name": "Virtuoso Large",
+        "contextWindow": 131072,
+        "maxOutput": 64000,
         "supportsImages": false,
         "supportsReasoning": false,
         "supportsToolCall": true,
-        "inputCost": 0.06,
-        "outputCost": 0.12
+        "inputCost": 0.75,
+        "outputCost": 1.2
       },
       {
-        "id": "google/gemini-2.5-pro-preview-05-06",
-        "name": "Gemini 2.5 Pro Preview 05-06",
-        "contextWindow": 1048576,
-        "maxOutput": 65536,
+        "id": "meta-llama/llama-guard-4-12b",
+        "name": "Llama Guard 4 12B",
+        "contextWindow": 163840,
+        "maxOutput": 16384,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.18,
+        "outputCost": 0.18
+      },
+      {
+        "id": "qwen/qwen3-14b",
+        "name": "Qwen3 14B",
+        "contextWindow": 40960,
+        "maxOutput": 40960,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.1,
+        "outputCost": 0.24
+      },
+      {
+        "id": "qwen/qwen3-30b-a3b",
+        "name": "Qwen3 30B A3B",
+        "contextWindow": 40960,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.12,
+        "outputCost": 0.5
+      },
+      {
+        "id": "qwen/qwen3-8b",
+        "name": "Qwen3 8B",
+        "contextWindow": 40960,
+        "maxOutput": 8192,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.05,
+        "outputCost": 0.4
+      },
+      {
+        "id": "openai/o3",
+        "name": "o3",
+        "contextWindow": 200000,
+        "maxOutput": 100000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 1.25,
-        "outputCost": 10
-      },
-      {
-        "id": "inception/mercury-coder",
-        "name": "Mercury Coder",
-        "contextWindow": 128000,
-        "maxOutput": 32000,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.25,
-        "outputCost": 0.75
+        "inputCost": 2,
+        "outputCost": 8
       },
       {
         "id": "openai/o4-mini",
-        "name": "o4 Mini",
+        "name": "o4-mini",
+        "contextWindow": 200000,
+        "maxOutput": 100000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1.1,
+        "outputCost": 4.4
+      },
+      {
+        "id": "openai/o4-mini-high",
+        "name": "o4 Mini High",
         "contextWindow": 200000,
         "maxOutput": 100000,
         "supportsImages": true,
@@ -2620,7 +3643,7 @@
       },
       {
         "id": "openai/gpt-4.1-mini",
-        "name": "GPT-4.1 Mini",
+        "name": "GPT-4.1 mini",
         "contextWindow": 1047576,
         "maxOutput": 32768,
         "supportsImages": true,
@@ -2630,197 +3653,10 @@
         "outputCost": 1.6
       },
       {
-        "id": "deepseek/deepseek-chat-v3-0324",
-        "name": "DeepSeek V3 0324",
-        "contextWindow": 16384,
-        "maxOutput": 8192,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "mistralai/mistral-small-3.1-24b-instruct",
-        "name": "Mistral Small 3.1 24B Instruct",
-        "contextWindow": 128000,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "google/gemma-3-12b-it:free",
-        "name": "Gemma 3 12B (free)",
-        "contextWindow": 32768,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "google/gemma-3-4b-it:free",
-        "name": "Gemma 3 4B (free)",
-        "contextWindow": 32768,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "google/gemma-3-12b-it",
-        "name": "Gemma 3 12B",
-        "contextWindow": 131072,
-        "maxOutput": 131072,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0.03,
-        "outputCost": 0.1
-      },
-      {
-        "id": "google/gemma-3-4b-it",
-        "name": "Gemma 3 4B",
-        "contextWindow": 96000,
-        "maxOutput": 96000,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0.01703,
-        "outputCost": 0.06815
-      },
-      {
-        "id": "google/gemma-3-27b-it",
-        "name": "Gemma 3 27B",
-        "contextWindow": 96000,
-        "maxOutput": 96000,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.04,
-        "outputCost": 0.15
-      },
-      {
-        "id": "google/gemma-3-27b-it:free",
-        "name": "Gemma 3 27B (free)",
-        "contextWindow": 131072,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "anthropic/claude-3.7-sonnet",
-        "name": "Claude Sonnet 3.7",
-        "contextWindow": 200000,
-        "maxOutput": 128000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 15,
-        "outputCost": 75
-      },
-      {
-        "id": "x-ai/grok-3",
-        "name": "Grok 3",
-        "contextWindow": 131072,
-        "maxOutput": 8192,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 3,
-        "outputCost": 15
-      },
-      {
-        "id": "x-ai/grok-3-mini-beta",
-        "name": "Grok 3 Mini Beta",
-        "contextWindow": 131072,
-        "maxOutput": 8192,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.3,
-        "outputCost": 0.5
-      },
-      {
-        "id": "x-ai/grok-3-mini",
-        "name": "Grok 3 Mini",
-        "contextWindow": 131072,
-        "maxOutput": 8192,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.3,
-        "outputCost": 0.5
-      },
-      {
-        "id": "x-ai/grok-3-beta",
-        "name": "Grok 3 Beta",
-        "contextWindow": 131072,
-        "maxOutput": 8192,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 3,
-        "outputCost": 15
-      },
-      {
-        "id": "qwen/qwen2.5-vl-72b-instruct",
-        "name": "Qwen2.5 VL 72B Instruct",
-        "contextWindow": 32768,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "deepseek/deepseek-r1-distill-llama-70b",
-        "name": "DeepSeek R1 Distill Llama 70B",
-        "contextWindow": 8192,
-        "maxOutput": 8192,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "prime-intellect/intellect-3",
-        "name": "Intellect 3",
-        "contextWindow": 131072,
-        "maxOutput": 8192,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.2,
-        "outputCost": 1.1
-      },
-      {
-        "id": "minimax/minimax-01",
-        "name": "MiniMax-01",
-        "contextWindow": 1000000,
-        "maxOutput": 1000000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.2,
-        "outputCost": 1.1
-      },
-      {
-        "id": "google/gemini-2.0-flash-001",
-        "name": "Gemini 2.0 Flash",
-        "contextWindow": 1048576,
-        "maxOutput": 8192,
+        "id": "openai/gpt-4.1-nano",
+        "name": "GPT-4.1 nano",
+        "contextWindow": 1047576,
+        "maxOutput": 32768,
         "supportsImages": true,
         "supportsReasoning": false,
         "supportsToolCall": true,
@@ -2828,9 +3664,394 @@
         "outputCost": 0.4
       },
       {
+        "id": "meta-llama/llama-4-maverick",
+        "name": "Llama 4 Maverick",
+        "contextWindow": 1048576,
+        "maxOutput": 16384,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.15,
+        "outputCost": 0.6
+      },
+      {
+        "id": "meta-llama/llama-4-scout",
+        "name": "Llama 4 Scout",
+        "contextWindow": 327680,
+        "maxOutput": 16384,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.1,
+        "outputCost": 0.3
+      },
+      {
+        "id": "qwen/qwen3-235b-a22b",
+        "name": "Qwen3 235B-A22B",
+        "contextWindow": 131072,
+        "maxOutput": 8192,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.455,
+        "outputCost": 1.82
+      },
+      {
+        "id": "qwen/qwen3-32b",
+        "name": "Qwen3 32B",
+        "contextWindow": 40960,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.08,
+        "outputCost": 0.28
+      },
+      {
+        "id": "qwen/qwen3-coder-30b-a3b-instruct",
+        "name": "Qwen3-Coder 30B-A3B Instruct",
+        "contextWindow": 160000,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.07,
+        "outputCost": 0.27
+      },
+      {
+        "id": "deepseek/deepseek-chat-v3-0324",
+        "name": "DeepSeek V3 0324",
+        "contextWindow": 163840,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.2,
+        "outputCost": 0.77
+      },
+      {
+        "id": "openai/o1-pro",
+        "name": "o1-pro",
+        "contextWindow": 200000,
+        "maxOutput": 100000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 150,
+        "outputCost": 600
+      },
+      {
+        "id": "mistralai/mistral-small-3.1-24b-instruct",
+        "name": "Mistral Small 3.1 24B",
+        "contextWindow": 128000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.351,
+        "outputCost": 0.555
+      },
+      {
+        "id": "cohere/command-a",
+        "name": "Command A",
+        "contextWindow": 256000,
+        "maxOutput": 8192,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 2.5,
+        "outputCost": 10
+      },
+      {
+        "id": "google/gemma-3-12b-it",
+        "name": "Gemma 3 12B",
+        "contextWindow": 131072,
+        "maxOutput": 16384,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.05,
+        "outputCost": 0.15
+      },
+      {
+        "id": "google/gemma-3-4b-it",
+        "name": "Gemma 3 4B",
+        "contextWindow": 131072,
+        "maxOutput": 16384,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.05,
+        "outputCost": 0.1
+      },
+      {
+        "id": "google/gemma-3-27b-it",
+        "name": "Gemma 3 27B",
+        "contextWindow": 131072,
+        "maxOutput": 16384,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.08,
+        "outputCost": 0.16
+      },
+      {
+        "id": "openai/gpt-4o-mini-search-preview",
+        "name": "GPT-4o-mini Search Preview",
+        "contextWindow": 128000,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.15,
+        "outputCost": 0.6
+      },
+      {
+        "id": "openai/gpt-4o-search-preview",
+        "name": "GPT-4o Search Preview",
+        "contextWindow": 128000,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 2.5,
+        "outputCost": 10
+      },
+      {
+        "id": "rekaai/reka-flash-3",
+        "name": "Reka Flash 3",
+        "contextWindow": 65536,
+        "maxOutput": 65536,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 0.1,
+        "outputCost": 0.2
+      },
+      {
+        "id": "thedrummer/skyfall-36b-v2",
+        "name": "Skyfall 36B V2",
+        "contextWindow": 32768,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.55,
+        "outputCost": 0.8
+      },
+      {
+        "id": "perplexity/sonar-deep-research",
+        "name": "Sonar Deep Research",
+        "contextWindow": 128000,
+        "maxOutput": 128000,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 2,
+        "outputCost": 8
+      },
+      {
+        "id": "perplexity/sonar-pro",
+        "name": "Sonar Pro",
+        "contextWindow": 200000,
+        "maxOutput": 8000,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 3,
+        "outputCost": 15
+      },
+      {
+        "id": "perplexity/sonar-reasoning-pro",
+        "name": "Sonar Reasoning Pro",
+        "contextWindow": 128000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 2,
+        "outputCost": 8
+      },
+      {
+        "id": "mistralai/mistral-saba",
+        "name": "Saba",
+        "contextWindow": 32768,
+        "maxOutput": 32768,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.2,
+        "outputCost": 0.6
+      },
+      {
+        "id": "openai/o3-mini-high",
+        "name": "o3 Mini High",
+        "contextWindow": 200000,
+        "maxOutput": 100000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1.1,
+        "outputCost": 4.4
+      },
+      {
+        "id": "aion-labs/aion-1.0",
+        "name": "Aion-1.0",
+        "contextWindow": 131072,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 4,
+        "outputCost": 8
+      },
+      {
+        "id": "aion-labs/aion-1.0-mini",
+        "name": "Aion-1.0-Mini",
+        "contextWindow": 131072,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 0.7,
+        "outputCost": 1.4
+      },
+      {
+        "id": "aion-labs/aion-rp-llama-3.1-8b",
+        "name": "Aion-RP 1.0 (8B)",
+        "contextWindow": 32768,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.8,
+        "outputCost": 1.6
+      },
+      {
+        "id": "qwen/qwen2.5-vl-72b-instruct",
+        "name": "Qwen2.5 VL 72B Instruct",
+        "contextWindow": 128000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.8,
+        "outputCost": 1
+      },
+      {
+        "id": "mistralai/mistral-small-24b-instruct-2501",
+        "name": "Mistral Small 3",
+        "contextWindow": 32768,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.05,
+        "outputCost": 0.08
+      },
+      {
+        "id": "deepseek/deepseek-r1-distill-qwen-32b",
+        "name": "R1 Distill Qwen 32B",
+        "contextWindow": 32768,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 0.29,
+        "outputCost": 0.29
+      },
+      {
+        "id": "openai/o3-mini",
+        "name": "o3-mini",
+        "contextWindow": 200000,
+        "maxOutput": 100000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1.1,
+        "outputCost": 4.4
+      },
+      {
+        "id": "perplexity/sonar",
+        "name": "Sonar",
+        "contextWindow": 127072,
+        "maxOutput": 127072,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 1,
+        "outputCost": 1
+      },
+      {
+        "id": "deepseek/deepseek-r1-distill-llama-70b",
+        "name": "R1 Distill Llama 70B",
+        "contextWindow": 8192,
+        "maxOutput": 8192,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 0.8,
+        "outputCost": 0.8
+      },
+      {
+        "id": "minimax/minimax-01",
+        "name": "MiniMax-01",
+        "contextWindow": 1000192,
+        "maxOutput": 1000192,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.2,
+        "outputCost": 1.1
+      },
+      {
+        "id": "microsoft/phi-4",
+        "name": "Phi 4",
+        "contextWindow": 16384,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.065,
+        "outputCost": 0.14
+      },
+      {
+        "id": "sao10k/l3.1-70b-hanami-x1",
+        "name": "Llama 3.1 70B Hanami x1",
+        "contextWindow": 16000,
+        "maxOutput": 16000,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 3,
+        "outputCost": 3
+      },
+      {
+        "id": "sao10k/l3.3-euryale-70b",
+        "name": "Llama 3.3 Euryale 70B",
+        "contextWindow": 131072,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.65,
+        "outputCost": 0.75
+      },
+      {
+        "id": "meta-llama/llama-3.3-70b-instruct",
+        "name": "Llama-3.3-70B-Instruct",
+        "contextWindow": 131072,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.1,
+        "outputCost": 0.32
+      },
+      {
         "id": "meta-llama/llama-3.3-70b-instruct:free",
         "name": "Llama 3.3 70B Instruct (free)",
-        "contextWindow": 131072,
+        "contextWindow": 65536,
         "maxOutput": 131072,
         "supportsImages": false,
         "supportsReasoning": false,
@@ -2839,19 +4060,107 @@
         "outputCost": 0
       },
       {
-        "id": "qwen/qwen-2.5-coder-32b-instruct",
-        "name": "Qwen2.5 Coder 32B Instruct",
-        "contextWindow": 32768,
-        "maxOutput": 8192,
+        "id": "amazon/nova-lite-v1",
+        "name": "Nova Lite 1.0",
+        "contextWindow": 300000,
+        "maxOutput": 5120,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.06,
+        "outputCost": 0.24
+      },
+      {
+        "id": "amazon/nova-micro-v1",
+        "name": "Nova Micro 1.0",
+        "contextWindow": 128000,
+        "maxOutput": 5120,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.035,
+        "outputCost": 0.14
+      },
+      {
+        "id": "amazon/nova-pro-v1",
+        "name": "Nova Pro 1.0",
+        "contextWindow": 300000,
+        "maxOutput": 5120,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.8,
+        "outputCost": 3.2
+      },
+      {
+        "id": "openai/o1",
+        "name": "o1",
+        "contextWindow": 200000,
+        "maxOutput": 100000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 15,
+        "outputCost": 60
+      },
+      {
+        "id": "cohere/command-r7b-12-2024",
+        "name": "Command R7B",
+        "contextWindow": 128000,
+        "maxOutput": 4000,
         "supportsImages": false,
         "supportsReasoning": false,
         "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
+        "inputCost": 0.0375,
+        "outputCost": 0.15
+      },
+      {
+        "id": "openai/gpt-4o-2024-11-20",
+        "name": "GPT-4o (2024-11-20)",
+        "contextWindow": 128000,
+        "maxOutput": 16384,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 2.5,
+        "outputCost": 10
+      },
+      {
+        "id": "mistralai/mistral-large-2407",
+        "name": "Mistral Large 2407",
+        "contextWindow": 131072,
+        "maxOutput": 131072,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 2,
+        "outputCost": 6
+      },
+      {
+        "id": "qwen/qwen-2.5-coder-32b-instruct",
+        "name": "Qwen2.5 Coder 32B Instruct",
+        "contextWindow": 32768,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.66,
+        "outputCost": 1
+      },
+      {
+        "id": "thedrummer/unslopnemo-12b",
+        "name": "UnslopNemo 12B",
+        "contextWindow": 32768,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.4,
+        "outputCost": 0.4
       },
       {
         "id": "anthropic/claude-3.5-haiku",
-        "name": "Claude Haiku 3.5",
+        "name": "Claude 3.5 Haiku",
         "contextWindow": 200000,
         "maxOutput": 8192,
         "supportsImages": true,
@@ -2861,26 +4170,169 @@
         "outputCost": 4
       },
       {
+        "id": "anthracite-org/magnum-v4-72b",
+        "name": "Magnum v4 72B",
+        "contextWindow": 16384,
+        "maxOutput": 2048,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 3,
+        "outputCost": 5
+      },
+      {
+        "id": "qwen/qwen-2.5-7b-instruct",
+        "name": "Qwen2.5 7B Instruct",
+        "contextWindow": 32768,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.04,
+        "outputCost": 0.1
+      },
+      {
+        "id": "inflection/inflection-3-pi",
+        "name": "Inflection 3 Pi",
+        "contextWindow": 8000,
+        "maxOutput": 1024,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 2.5,
+        "outputCost": 10
+      },
+      {
+        "id": "inflection/inflection-3-productivity",
+        "name": "Inflection 3 Productivity",
+        "contextWindow": 8000,
+        "maxOutput": 1024,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 2.5,
+        "outputCost": 10
+      },
+      {
+        "id": "thedrummer/rocinante-12b",
+        "name": "Rocinante 12B",
+        "contextWindow": 32768,
+        "maxOutput": 32768,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.17,
+        "outputCost": 0.43
+      },
+      {
         "id": "meta-llama/llama-3.2-11b-vision-instruct",
         "name": "Llama 3.2 11B Vision Instruct",
         "contextWindow": 131072,
-        "maxOutput": 8192,
+        "maxOutput": 16384,
         "supportsImages": true,
         "supportsReasoning": false,
         "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
+        "inputCost": 0.345,
+        "outputCost": 0.345
+      },
+      {
+        "id": "meta-llama/llama-3.2-1b-instruct",
+        "name": "Llama 3.2 1B Instruct",
+        "contextWindow": 60000,
+        "maxOutput": 60000,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.027,
+        "outputCost": 0.201
+      },
+      {
+        "id": "meta-llama/llama-3.2-3b-instruct",
+        "name": "Llama 3.2 3B Instruct",
+        "contextWindow": 80000,
+        "maxOutput": 80000,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.0509,
+        "outputCost": 0.335
       },
       {
         "id": "meta-llama/llama-3.2-3b-instruct:free",
         "name": "Llama 3.2 3B Instruct (free)",
         "contextWindow": 131072,
         "maxOutput": 131072,
-        "supportsImages": true,
+        "supportsImages": false,
         "supportsReasoning": false,
         "supportsToolCall": false,
         "inputCost": 0,
         "outputCost": 0
+      },
+      {
+        "id": "qwen/qwen-2.5-72b-instruct",
+        "name": "Qwen2.5 72B Instruct",
+        "contextWindow": 32768,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.36,
+        "outputCost": 0.4
+      },
+      {
+        "id": "cohere/command-r-08-2024",
+        "name": "Command R",
+        "contextWindow": 128000,
+        "maxOutput": 4000,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.15,
+        "outputCost": 0.6
+      },
+      {
+        "id": "cohere/command-r-plus-08-2024",
+        "name": "Command R+",
+        "contextWindow": 128000,
+        "maxOutput": 4000,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 2.5,
+        "outputCost": 10
+      },
+      {
+        "id": "sao10k/l3.1-euryale-70b",
+        "name": "Llama 3.1 Euryale 70B v2.2",
+        "contextWindow": 131072,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.85,
+        "outputCost": 0.85
+      },
+      {
+        "id": "nousresearch/hermes-3-llama-3.1-70b",
+        "name": "Hermes 3 70B Instruct",
+        "contextWindow": 131072,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.7,
+        "outputCost": 0.7
+      },
+      {
+        "id": "nousresearch/hermes-3-llama-3.1-405b",
+        "name": "Hermes 3 405B Instruct",
+        "contextWindow": 131072,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 1,
+        "outputCost": 1
       },
       {
         "id": "nousresearch/hermes-3-llama-3.1-405b:free",
@@ -2888,14 +4340,69 @@
         "contextWindow": 131072,
         "maxOutput": 131072,
         "supportsImages": false,
-        "supportsReasoning": true,
+        "supportsReasoning": false,
         "supportsToolCall": false,
         "inputCost": 0,
         "outputCost": 0
       },
       {
+        "id": "sao10k/l3-lunaris-8b",
+        "name": "Llama 3 8B Lunaris",
+        "contextWindow": 8192,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.04,
+        "outputCost": 0.05
+      },
+      {
+        "id": "openai/gpt-4o",
+        "name": "GPT-4o",
+        "contextWindow": 128000,
+        "maxOutput": 16384,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 2.5,
+        "outputCost": 10
+      },
+      {
+        "id": "openai/gpt-4o-2024-08-06",
+        "name": "GPT-4o (2024-08-06)",
+        "contextWindow": 128000,
+        "maxOutput": 16384,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 2.5,
+        "outputCost": 10
+      },
+      {
+        "id": "meta-llama/llama-3.1-70b-instruct",
+        "name": "Llama 3.1 70B Instruct",
+        "contextWindow": 131072,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.4,
+        "outputCost": 0.4
+      },
+      {
+        "id": "meta-llama/llama-3.1-8b-instruct",
+        "name": "Llama 3.1 8B Instruct",
+        "contextWindow": 131072,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.02,
+        "outputCost": 0.03
+      },
+      {
         "id": "openai/gpt-4o-mini",
-        "name": "GPT-4o-mini",
+        "name": "GPT-4o mini",
         "contextWindow": 128000,
         "maxOutput": 16384,
         "supportsImages": true,
@@ -2905,15 +4412,255 @@
         "outputCost": 0.6
       },
       {
-        "id": "google/gemma-2-9b-it",
-        "name": "Gemma 2 9B",
+        "id": "openai/gpt-4o-mini-2024-07-18",
+        "name": "GPT-4o-mini (2024-07-18)",
+        "contextWindow": 128000,
+        "maxOutput": 16384,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.15,
+        "outputCost": 0.6
+      },
+      {
+        "id": "google/gemma-2-27b-it",
+        "name": "Gemma 2 27B",
+        "contextWindow": 8192,
+        "maxOutput": 2048,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.65,
+        "outputCost": 0.65
+      },
+      {
+        "id": "mistralai/mistral-nemo",
+        "name": "Mistral Nemo",
+        "contextWindow": 131072,
+        "maxOutput": 131072,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.02,
+        "outputCost": 0.03
+      },
+      {
+        "id": "openai/o3-deep-research",
+        "name": "o3-deep-research",
+        "contextWindow": 200000,
+        "maxOutput": 100000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 10,
+        "outputCost": 40
+      },
+      {
+        "id": "openai/o4-mini-deep-research",
+        "name": "o4-mini-deep-research",
+        "contextWindow": 200000,
+        "maxOutput": 100000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 2,
+        "outputCost": 8
+      },
+      {
+        "id": "openai/gpt-4o-2024-05-13",
+        "name": "GPT-4o (2024-05-13)",
+        "contextWindow": 128000,
+        "maxOutput": 4096,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 15
+      },
+      {
+        "id": "meta-llama/llama-3-70b-instruct",
+        "name": "Llama 3 70B Instruct",
+        "contextWindow": 8192,
+        "maxOutput": 8000,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.51,
+        "outputCost": 0.74
+      },
+      {
+        "id": "meta-llama/llama-3-8b-instruct",
+        "name": "Llama 3 8B Instruct",
         "contextWindow": 8192,
         "maxOutput": 8192,
         "supportsImages": false,
         "supportsReasoning": false,
         "supportsToolCall": false,
-        "inputCost": 0.03,
-        "outputCost": 0.09
+        "inputCost": 0.14,
+        "outputCost": 0.14
+      },
+      {
+        "id": "mistralai/mixtral-8x22b-instruct",
+        "name": "Mixtral 8x22B Instruct",
+        "contextWindow": 65536,
+        "maxOutput": 65536,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 2,
+        "outputCost": 6
+      },
+      {
+        "id": "microsoft/wizardlm-2-8x22b",
+        "name": "WizardLM-2 8x22B",
+        "contextWindow": 65535,
+        "maxOutput": 8000,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.62,
+        "outputCost": 0.62
+      },
+      {
+        "id": "openai/gpt-4",
+        "name": "GPT-4",
+        "contextWindow": 8191,
+        "maxOutput": 4096,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 30,
+        "outputCost": 60
+      },
+      {
+        "id": "openai/gpt-4-turbo",
+        "name": "GPT-4 Turbo",
+        "contextWindow": 128000,
+        "maxOutput": 4096,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 10,
+        "outputCost": 30
+      },
+      {
+        "id": "anthropic/claude-3-haiku",
+        "name": "Claude 3 Haiku",
+        "contextWindow": 200000,
+        "maxOutput": 4096,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.25,
+        "outputCost": 1.25
+      },
+      {
+        "id": "mistralai/mistral-large",
+        "name": "Mistral Large",
+        "contextWindow": 128000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 2,
+        "outputCost": 6
+      },
+      {
+        "id": "openai/gpt-3.5-turbo-0613",
+        "name": "GPT-3.5 Turbo (older v0613)",
+        "contextWindow": 4095,
+        "maxOutput": 4096,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 1,
+        "outputCost": 2
+      },
+      {
+        "id": "openai/gpt-4-turbo-preview",
+        "name": "GPT-4 Turbo Preview",
+        "contextWindow": 128000,
+        "maxOutput": 4096,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 10,
+        "outputCost": 30
+      },
+      {
+        "id": "openrouter/auto",
+        "name": "Auto Router",
+        "contextWindow": 2000000,
+        "maxOutput": 2000000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true
+      },
+      {
+        "id": "openai/gpt-3.5-turbo",
+        "name": "GPT-3.5-turbo",
+        "contextWindow": 16385,
+        "maxOutput": 4096,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.5,
+        "outputCost": 1.5
+      },
+      {
+        "id": "openai/gpt-3.5-turbo-instruct",
+        "name": "GPT-3.5 Turbo Instruct",
+        "contextWindow": 4095,
+        "maxOutput": 4096,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 1.5,
+        "outputCost": 2
+      },
+      {
+        "id": "openai/gpt-3.5-turbo-16k",
+        "name": "GPT-3.5 Turbo 16k",
+        "contextWindow": 16385,
+        "maxOutput": 4096,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 3,
+        "outputCost": 4
+      },
+      {
+        "id": "mancer/weaver",
+        "name": "Weaver (alpha)",
+        "contextWindow": 8000,
+        "maxOutput": 2000,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.75,
+        "outputCost": 1
+      },
+      {
+        "id": "undi95/remm-slerp-l2-13b",
+        "name": "ReMM SLERP 13B",
+        "contextWindow": 6144,
+        "maxOutput": 4096,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.45,
+        "outputCost": 0.65
+      },
+      {
+        "id": "gryphe/mythomax-l2-13b",
+        "name": "MythoMax 13B",
+        "contextWindow": 4096,
+        "maxOutput": 4096,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.06,
+        "outputCost": 0.06
       }
     ]
   },
@@ -2922,15 +4669,81 @@
     "doc": "https://learn.microsoft.com/en-us/azure/ai-services/openai/concepts/models",
     "models": [
       {
-        "id": "gpt-5.4-nano",
-        "name": "GPT-5.4 Nano",
-        "contextWindow": 400000,
+        "id": "claude-fable-5",
+        "name": "Claude Fable 5",
+        "contextWindow": 1000000,
         "maxOutput": 128000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0.2,
-        "outputCost": 1.25
+        "inputCost": 10,
+        "outputCost": 50
+      },
+      {
+        "id": "deepseek-v4-flash",
+        "name": "DeepSeek-V4-Flash",
+        "contextWindow": 1000000,
+        "maxOutput": 384000,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 0.19,
+        "outputCost": 0.51
+      },
+      {
+        "id": "deepseek-v4-pro",
+        "name": "DeepSeek-V4-Pro",
+        "contextWindow": 1000000,
+        "maxOutput": 384000,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 1.74,
+        "outputCost": 3.48
+      },
+      {
+        "id": "gpt-5.5",
+        "name": "GPT-5.5",
+        "contextWindow": 1050000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 30
+      },
+      {
+        "id": "kimi-k2.6",
+        "name": "Kimi K2.6",
+        "contextWindow": 262144,
+        "maxOutput": 262144,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.95,
+        "outputCost": 4
+      },
+      {
+        "id": "grok-4-20-non-reasoning",
+        "name": "Grok 4.20 (Non-Reasoning)",
+        "contextWindow": 262000,
+        "maxOutput": 8192,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 2,
+        "outputCost": 6
+      },
+      {
+        "id": "grok-4-20-reasoning",
+        "name": "Grok 4.20 (Reasoning)",
+        "contextWindow": 262000,
+        "maxOutput": 8192,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 2,
+        "outputCost": 6
       },
       {
         "id": "gpt-5.4-mini",
@@ -2944,9 +4757,31 @@
         "outputCost": 4.5
       },
       {
+        "id": "gpt-5.4-nano",
+        "name": "GPT-5.4 Nano",
+        "contextWindow": 400000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.2,
+        "outputCost": 1.25
+      },
+      {
+        "id": "claude-sonnet-4-6",
+        "name": "Claude Sonnet 4.6",
+        "contextWindow": 1000000,
+        "maxOutput": 64000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 3,
+        "outputCost": 15
+      },
+      {
         "id": "gpt-5.4",
         "name": "GPT-5.4",
-        "contextWindow": 400000,
+        "contextWindow": 1050000,
         "maxOutput": 128000,
         "supportsImages": true,
         "supportsReasoning": true,
@@ -2957,7 +4792,7 @@
       {
         "id": "gpt-5.4-pro",
         "name": "GPT-5.4 Pro",
-        "contextWindow": 400000,
+        "contextWindow": 1050000,
         "maxOutput": 128000,
         "supportsImages": true,
         "supportsReasoning": true,
@@ -3021,10 +4856,10 @@
         "outputCost": 14
       },
       {
-        "id": "gpt-5.2-chat",
-        "name": "GPT-5.2 Chat",
-        "contextWindow": 128000,
-        "maxOutput": 16384,
+        "id": "gpt-5.2",
+        "name": "GPT-5.2",
+        "contextWindow": 400000,
+        "maxOutput": 128000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
@@ -3032,10 +4867,10 @@
         "outputCost": 14
       },
       {
-        "id": "gpt-5.2",
-        "name": "GPT-5.2",
-        "contextWindow": 400000,
-        "maxOutput": 128000,
+        "id": "gpt-5.2-chat",
+        "name": "GPT-5.2 Chat",
+        "contextWindow": 128000,
+        "maxOutput": 16384,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
@@ -3054,17 +4889,6 @@
         "outputCost": 2.5
       },
       {
-        "id": "deepseek-v3.2-speciale",
-        "name": "DeepSeek-V3.2-Speciale",
-        "contextWindow": 128000,
-        "maxOutput": 128000,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": false,
-        "inputCost": 0.58,
-        "outputCost": 1.68
-      },
-      {
         "id": "deepseek-v3.2",
         "name": "DeepSeek-V3.2",
         "contextWindow": 128000,
@@ -3076,26 +4900,15 @@
         "outputCost": 1.68
       },
       {
-        "id": "claude-opus-4-1",
-        "name": "Claude Opus 4.1",
-        "contextWindow": 200000,
-        "maxOutput": 32000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 15,
-        "outputCost": 75
-      },
-      {
-        "id": "model-router",
-        "name": "Model Router",
+        "id": "deepseek-v3.2-speciale",
+        "name": "DeepSeek-V3.2-Speciale",
         "contextWindow": 128000,
-        "maxOutput": 16384,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.14,
-        "outputCost": 0
+        "maxOutput": 128000,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 0.58,
+        "outputCost": 1.68
       },
       {
         "id": "claude-haiku-4-5",
@@ -3109,6 +4922,17 @@
         "outputCost": 5
       },
       {
+        "id": "claude-opus-4-1",
+        "name": "Claude Opus 4.1",
+        "contextWindow": 200000,
+        "maxOutput": 32000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 15,
+        "outputCost": 75
+      },
+      {
         "id": "claude-sonnet-4-5",
         "name": "Claude Sonnet 4.5",
         "contextWindow": 200000,
@@ -3118,6 +4942,17 @@
         "supportsToolCall": true,
         "inputCost": 3,
         "outputCost": 15
+      },
+      {
+        "id": "model-router",
+        "name": "Model Router",
+        "contextWindow": 128000,
+        "maxOutput": 16384,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.14,
+        "outputCost": 0
       },
       {
         "id": "gpt-5.1",
@@ -3142,17 +4977,6 @@
         "outputCost": 10
       },
       {
-        "id": "gpt-5.1-codex-mini",
-        "name": "GPT-5.1 Codex Mini",
-        "contextWindow": 400000,
-        "maxOutput": 128000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.25,
-        "outputCost": 2
-      },
-      {
         "id": "gpt-5.1-codex",
         "name": "GPT-5.1 Codex",
         "contextWindow": 400000,
@@ -3162,6 +4986,17 @@
         "supportsToolCall": true,
         "inputCost": 1.25,
         "outputCost": 10
+      },
+      {
+        "id": "gpt-5.1-codex-mini",
+        "name": "GPT-5.1 Codex Mini",
+        "contextWindow": 400000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.25,
+        "outputCost": 2
       },
       {
         "id": "gpt-5.1-codex-max",
@@ -3197,17 +5032,6 @@
         "outputCost": 0.5
       },
       {
-        "id": "grok-4-fast-non-reasoning",
-        "name": "Grok 4 Fast (Non-Reasoning)",
-        "contextWindow": 2000000,
-        "maxOutput": 30000,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.2,
-        "outputCost": 0.5
-      },
-      {
         "id": "gpt-5-codex",
         "name": "GPT-5-Codex",
         "contextWindow": 400000,
@@ -3217,17 +5041,6 @@
         "supportsToolCall": true,
         "inputCost": 1.25,
         "outputCost": 10
-      },
-      {
-        "id": "grok-code-fast-1",
-        "name": "Grok Code Fast 1",
-        "contextWindow": 256000,
-        "maxOutput": 10000,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.2,
-        "outputCost": 1.5
       },
       {
         "id": "deepseek-v3.1",
@@ -3241,17 +5054,6 @@
         "outputCost": 1.68
       },
       {
-        "id": "gpt-5-chat",
-        "name": "GPT-5 Chat",
-        "contextWindow": 128000,
-        "maxOutput": 16384,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": false,
-        "inputCost": 1.25,
-        "outputCost": 10
-      },
-      {
         "id": "gpt-5",
         "name": "GPT-5",
         "contextWindow": 272000,
@@ -3259,6 +5061,17 @@
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
+        "inputCost": 1.25,
+        "outputCost": 10
+      },
+      {
+        "id": "gpt-5-chat",
+        "name": "GPT-5 Chat",
+        "contextWindow": 128000,
+        "maxOutput": 16384,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
         "inputCost": 1.25,
         "outputCost": 10
       },
@@ -3296,15 +5109,15 @@
         "outputCost": 25
       },
       {
-        "id": "grok-4",
-        "name": "Grok 4",
-        "contextWindow": 256000,
-        "maxOutput": 64000,
-        "supportsImages": false,
-        "supportsReasoning": true,
+        "id": "grok-4-1-fast-non-reasoning",
+        "name": "Grok 4.1 Fast (Non-Reasoning)",
+        "contextWindow": 128000,
+        "maxOutput": 8192,
+        "supportsImages": true,
+        "supportsReasoning": false,
         "supportsToolCall": true,
-        "inputCost": 3,
-        "outputCost": 15
+        "inputCost": 0.2,
+        "outputCost": 0.5
       },
       {
         "id": "grok-4-1-fast-reasoning",
@@ -3313,17 +5126,6 @@
         "maxOutput": 8192,
         "supportsImages": true,
         "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.2,
-        "outputCost": 0.5
-      },
-      {
-        "id": "grok-4-1-fast-non-reasoning",
-        "name": "Grok 4.1 Fast (Non-Reasoning)",
-        "contextWindow": 128000,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
         "supportsToolCall": true,
         "inputCost": 0.2,
         "outputCost": 0.5
@@ -3395,17 +5197,6 @@
         "outputCost": 0
       },
       {
-        "id": "gpt-4.1-nano",
-        "name": "GPT-4.1 nano",
-        "contextWindow": 1047576,
-        "maxOutput": 32768,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.1,
-        "outputCost": 0.4
-      },
-      {
         "id": "gpt-4.1",
         "name": "GPT-4.1",
         "contextWindow": 1047576,
@@ -3428,15 +5219,15 @@
         "outputCost": 1.6
       },
       {
-        "id": "llama-4-scout-17b-16e-instruct",
-        "name": "Llama 4 Scout 17B 16E Instruct",
-        "contextWindow": 128000,
-        "maxOutput": 8192,
+        "id": "gpt-4.1-nano",
+        "name": "GPT-4.1 nano",
+        "contextWindow": 1047576,
+        "maxOutput": 32768,
         "supportsImages": true,
         "supportsReasoning": false,
         "supportsToolCall": true,
-        "inputCost": 0.2,
-        "outputCost": 0.78
+        "inputCost": 0.1,
+        "outputCost": 0.4
       },
       {
         "id": "llama-4-maverick-17b-128e-instruct-fp8",
@@ -3448,6 +5239,17 @@
         "supportsToolCall": true,
         "inputCost": 0.25,
         "outputCost": 1
+      },
+      {
+        "id": "llama-4-scout-17b-16e-instruct",
+        "name": "Llama 4 Scout 17B 16E Instruct",
+        "contextWindow": 128000,
+        "maxOutput": 8192,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.2,
+        "outputCost": 0.78
       },
       {
         "id": "deepseek-v3-0324",
@@ -3483,28 +5285,6 @@
         "outputCost": 0.3
       },
       {
-        "id": "grok-3",
-        "name": "Grok 3",
-        "contextWindow": 131072,
-        "maxOutput": 8192,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 3,
-        "outputCost": 15
-      },
-      {
-        "id": "grok-3-mini",
-        "name": "Grok 3 Mini",
-        "contextWindow": 131072,
-        "maxOutput": 8192,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.3,
-        "outputCost": 0.5
-      },
-      {
         "id": "o3-mini",
         "name": "o3-mini",
         "contextWindow": 200000,
@@ -3514,17 +5294,6 @@
         "supportsToolCall": true,
         "inputCost": 1.1,
         "outputCost": 4.4
-      },
-      {
-        "id": "mai-ds-r1",
-        "name": "MAI-DS-R1",
-        "contextWindow": 128000,
-        "maxOutput": 8192,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": false,
-        "inputCost": 1.35,
-        "outputCost": 5.4
       },
       {
         "id": "deepseek-r1",
@@ -3549,15 +5318,15 @@
         "outputCost": 0.9
       },
       {
-        "id": "phi-4-multimodal",
-        "name": "Phi-4-multimodal",
+        "id": "phi-4",
+        "name": "Phi-4",
         "contextWindow": 128000,
         "maxOutput": 4096,
-        "supportsImages": true,
+        "supportsImages": false,
         "supportsReasoning": false,
         "supportsToolCall": false,
-        "inputCost": 0.08,
-        "outputCost": 0.32
+        "inputCost": 0.125,
+        "outputCost": 0.5
       },
       {
         "id": "phi-4-mini",
@@ -3571,28 +5340,6 @@
         "outputCost": 0.3
       },
       {
-        "id": "phi-4",
-        "name": "Phi-4",
-        "contextWindow": 128000,
-        "maxOutput": 4096,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0.125,
-        "outputCost": 0.5
-      },
-      {
-        "id": "phi-4-reasoning-plus",
-        "name": "Phi-4-reasoning-plus",
-        "contextWindow": 32000,
-        "maxOutput": 4096,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": false,
-        "inputCost": 0.125,
-        "outputCost": 0.5
-      },
-      {
         "id": "phi-4-mini-reasoning",
         "name": "Phi-4-mini-reasoning",
         "contextWindow": 128000,
@@ -3604,8 +5351,30 @@
         "outputCost": 0.3
       },
       {
+        "id": "phi-4-multimodal",
+        "name": "Phi-4-multimodal",
+        "contextWindow": 128000,
+        "maxOutput": 4096,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.08,
+        "outputCost": 0.32
+      },
+      {
         "id": "phi-4-reasoning",
         "name": "Phi-4-reasoning",
+        "contextWindow": 32000,
+        "maxOutput": 4096,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": false,
+        "inputCost": 0.125,
+        "outputCost": 0.5
+      },
+      {
+        "id": "phi-4-reasoning-plus",
+        "name": "Phi-4-reasoning-plus",
         "contextWindow": 32000,
         "maxOutput": 4096,
         "supportsImages": false,
@@ -3659,17 +5428,6 @@
         "outputCost": 0.04
       },
       {
-        "id": "llama-3.2-90b-vision-instruct",
-        "name": "Llama-3.2-90B-Vision-Instruct",
-        "contextWindow": 128000,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 2.04,
-        "outputCost": 2.04
-      },
-      {
         "id": "llama-3.2-11b-vision-instruct",
         "name": "Llama-3.2-11B-Vision-Instruct",
         "contextWindow": 128000,
@@ -3681,15 +5439,15 @@
         "outputCost": 0.37
       },
       {
-        "id": "o1-preview",
-        "name": "o1-preview",
+        "id": "llama-3.2-90b-vision-instruct",
+        "name": "Llama-3.2-90B-Vision-Instruct",
         "contextWindow": 128000,
-        "maxOutput": 32768,
-        "supportsImages": false,
-        "supportsReasoning": true,
+        "maxOutput": 8192,
+        "supportsImages": true,
+        "supportsReasoning": false,
         "supportsToolCall": true,
-        "inputCost": 16.5,
-        "outputCost": 66
+        "inputCost": 2.04,
+        "outputCost": 2.04
       },
       {
         "id": "o1-mini",
@@ -3703,6 +5461,17 @@
         "outputCost": 4.4
       },
       {
+        "id": "cohere-command-r-08-2024",
+        "name": "Command R",
+        "contextWindow": 128000,
+        "maxOutput": 4000,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.15,
+        "outputCost": 0.6
+      },
+      {
         "id": "cohere-command-r-plus-08-2024",
         "name": "Command R+",
         "contextWindow": 128000,
@@ -3714,15 +5483,15 @@
         "outputCost": 10
       },
       {
-        "id": "cohere-command-r-08-2024",
-        "name": "Command R",
+        "id": "phi-3.5-mini-instruct",
+        "name": "Phi-3.5-mini-instruct",
         "contextWindow": 128000,
-        "maxOutput": 4000,
+        "maxOutput": 4096,
         "supportsImages": false,
         "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.15,
-        "outputCost": 0.6
+        "supportsToolCall": false,
+        "inputCost": 0.13,
+        "outputCost": 0.52
       },
       {
         "id": "phi-3.5-moe-instruct",
@@ -3736,15 +5505,15 @@
         "outputCost": 0.64
       },
       {
-        "id": "phi-3.5-mini-instruct",
-        "name": "Phi-3.5-mini-instruct",
+        "id": "gpt-4o",
+        "name": "GPT-4o",
         "contextWindow": 128000,
-        "maxOutput": 4096,
-        "supportsImages": false,
+        "maxOutput": 16384,
+        "supportsImages": true,
         "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0.13,
-        "outputCost": 0.52
+        "supportsToolCall": true,
+        "inputCost": 2.5,
+        "outputCost": 10
       },
       {
         "id": "meta-llama-3.1-405b-instruct",
@@ -3802,28 +5571,6 @@
         "outputCost": 0.15
       },
       {
-        "id": "gpt-4o",
-        "name": "GPT-4o",
-        "contextWindow": 128000,
-        "maxOutput": 16384,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 2.5,
-        "outputCost": 10
-      },
-      {
-        "id": "phi-3-small-128k-instruct",
-        "name": "Phi-3-small-instruct (128k)",
-        "contextWindow": 128000,
-        "maxOutput": 4096,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0.15,
-        "outputCost": 0.6
-      },
-      {
         "id": "phi-3-medium-128k-instruct",
         "name": "Phi-3-medium-instruct (128k)",
         "contextWindow": 128000,
@@ -3833,17 +5580,6 @@
         "supportsToolCall": false,
         "inputCost": 0.17,
         "outputCost": 0.68
-      },
-      {
-        "id": "phi-3-mini-4k-instruct",
-        "name": "Phi-3-mini-instruct (4k)",
-        "contextWindow": 4096,
-        "maxOutput": 1024,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0.13,
-        "outputCost": 0.52
       },
       {
         "id": "phi-3-medium-4k-instruct",
@@ -3868,6 +5604,28 @@
         "outputCost": 0.52
       },
       {
+        "id": "phi-3-mini-4k-instruct",
+        "name": "Phi-3-mini-instruct (4k)",
+        "contextWindow": 4096,
+        "maxOutput": 1024,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.13,
+        "outputCost": 0.52
+      },
+      {
+        "id": "phi-3-small-128k-instruct",
+        "name": "Phi-3-small-instruct (128k)",
+        "contextWindow": 128000,
+        "maxOutput": 4096,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.15,
+        "outputCost": 0.6
+      },
+      {
         "id": "phi-3-small-8k-instruct",
         "name": "Phi-3-small-instruct (8k)",
         "contextWindow": 8192,
@@ -3877,17 +5635,6 @@
         "supportsToolCall": false,
         "inputCost": 0.15,
         "outputCost": 0.6
-      },
-      {
-        "id": "meta-llama-3-8b-instruct",
-        "name": "Meta-Llama-3-8B-Instruct",
-        "contextWindow": 8192,
-        "maxOutput": 2048,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0.3,
-        "outputCost": 0.61
       },
       {
         "id": "meta-llama-3-70b-instruct",
@@ -3901,15 +5648,15 @@
         "outputCost": 3.54
       },
       {
-        "id": "gpt-4-turbo-vision",
-        "name": "GPT-4 Turbo Vision",
-        "contextWindow": 128000,
-        "maxOutput": 4096,
-        "supportsImages": true,
+        "id": "meta-llama-3-8b-instruct",
+        "name": "Meta-Llama-3-8B-Instruct",
+        "contextWindow": 8192,
+        "maxOutput": 2048,
+        "supportsImages": false,
         "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 10,
-        "outputCost": 30
+        "supportsToolCall": false,
+        "inputCost": 0.3,
+        "outputCost": 0.61
       },
       {
         "id": "gpt-4-turbo",
@@ -3923,26 +5670,15 @@
         "outputCost": 30
       },
       {
-        "id": "text-embedding-3-small",
-        "name": "text-embedding-3-small",
-        "contextWindow": 8191,
-        "maxOutput": 1536,
-        "supportsImages": false,
+        "id": "gpt-4-turbo-vision",
+        "name": "GPT-4 Turbo Vision",
+        "contextWindow": 128000,
+        "maxOutput": 4096,
+        "supportsImages": true,
         "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0.02,
-        "outputCost": 0
-      },
-      {
-        "id": "text-embedding-3-large",
-        "name": "text-embedding-3-large",
-        "contextWindow": 8191,
-        "maxOutput": 3072,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": false,
-        "inputCost": 0.13,
-        "outputCost": 0
+        "supportsToolCall": true,
+        "inputCost": 10,
+        "outputCost": 30
       },
       {
         "id": "gpt-3.5-turbo-0125",
@@ -3956,8 +5692,30 @@
         "outputCost": 1.5
       },
       {
-        "id": "cohere-embed-v3-multilingual",
-        "name": "Embed v3 Multilingual",
+        "id": "text-embedding-3-large",
+        "name": "text-embedding-3-large",
+        "contextWindow": 8191,
+        "maxOutput": 3072,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.13,
+        "outputCost": 0
+      },
+      {
+        "id": "text-embedding-3-small",
+        "name": "text-embedding-3-small",
+        "contextWindow": 8191,
+        "maxOutput": 1536,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": false,
+        "inputCost": 0.02,
+        "outputCost": 0
+      },
+      {
+        "id": "cohere-embed-v3-english",
+        "name": "Embed v3 English",
         "contextWindow": 512,
         "maxOutput": 1024,
         "supportsImages": false,
@@ -3967,8 +5725,8 @@
         "outputCost": 0
       },
       {
-        "id": "cohere-embed-v3-english",
-        "name": "Embed v3 English",
+        "id": "cohere-embed-v3-multilingual",
+        "name": "Embed v3 Multilingual",
         "contextWindow": 512,
         "maxOutput": 1024,
         "supportsImages": false,
@@ -4011,10 +5769,10 @@
         "outputCost": 4
       },
       {
-        "id": "gpt-4-32k",
-        "name": "GPT-4 32K",
-        "contextWindow": 32768,
-        "maxOutput": 32768,
+        "id": "gpt-4",
+        "name": "GPT-4",
+        "contextWindow": 8192,
+        "maxOutput": 8192,
         "supportsImages": false,
         "supportsReasoning": false,
         "supportsToolCall": true,
@@ -4022,10 +5780,10 @@
         "outputCost": 120
       },
       {
-        "id": "gpt-4",
-        "name": "GPT-4",
-        "contextWindow": 8192,
-        "maxOutput": 8192,
+        "id": "gpt-4-32k",
+        "name": "GPT-4 32K",
+        "contextWindow": 32768,
+        "maxOutput": 32768,
         "supportsImages": false,
         "supportsReasoning": false,
         "supportsToolCall": true,
@@ -4061,15 +5819,213 @@
     "doc": "https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html",
     "models": [
       {
-        "id": "eu.anthropic.claude-sonnet-4-6",
-        "name": "Claude Sonnet 4.6 (EU)",
+        "id": "eu.anthropic.claude-fable-5",
+        "name": "Claude Fable 5 (EU)",
         "contextWindow": 1000000,
-        "maxOutput": 64000,
+        "maxOutput": 128000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 3,
-        "outputCost": 15
+        "inputCost": 11,
+        "outputCost": 55
+      },
+      {
+        "id": "global.anthropic.claude-fable-5",
+        "name": "Claude Fable 5 (Global)",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 10,
+        "outputCost": 50
+      },
+      {
+        "id": "us.anthropic.claude-fable-5",
+        "name": "Claude Fable 5 (US)",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 10,
+        "outputCost": 50
+      },
+      {
+        "id": "openai.gpt-5.4",
+        "name": "GPT-5.4",
+        "contextWindow": 272000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 2.75,
+        "outputCost": 16.5
+      },
+      {
+        "id": "openai.gpt-5.5",
+        "name": "GPT-5.5",
+        "contextWindow": 272000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5.5,
+        "outputCost": 33
+      },
+      {
+        "id": "anthropic.claude-opus-4-8",
+        "name": "Claude Opus 4.8",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 25
+      },
+      {
+        "id": "au.anthropic.claude-opus-4-8",
+        "name": "Claude Opus 4.8 (AU)",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 25
+      },
+      {
+        "id": "eu.anthropic.claude-opus-4-8",
+        "name": "Claude Opus 4.8 (EU)",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5.5,
+        "outputCost": 27.5
+      },
+      {
+        "id": "global.anthropic.claude-opus-4-8",
+        "name": "Claude Opus 4.8 (Global)",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 25
+      },
+      {
+        "id": "jp.anthropic.claude-opus-4-8",
+        "name": "Claude Opus 4.8 (JP)",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 25
+      },
+      {
+        "id": "us.anthropic.claude-opus-4-8",
+        "name": "Claude Opus 4.8 (US)",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 25
+      },
+      {
+        "id": "anthropic.claude-opus-4-7",
+        "name": "Claude Opus 4.7",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 25
+      },
+      {
+        "id": "eu.anthropic.claude-opus-4-7",
+        "name": "Claude Opus 4.7 (EU)",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5.5,
+        "outputCost": 27.5
+      },
+      {
+        "id": "global.anthropic.claude-opus-4-7",
+        "name": "Claude Opus 4.7 (Global)",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 25
+      },
+      {
+        "id": "jp.anthropic.claude-opus-4-7",
+        "name": "Claude Opus 4.7 (JP)",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 25
+      },
+      {
+        "id": "us.anthropic.claude-opus-4-7",
+        "name": "Claude Opus 4.7 (US)",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 25
+      },
+      {
+        "id": "minimax.minimax-m2.5",
+        "name": "MiniMax M2.5",
+        "contextWindow": 196608,
+        "maxOutput": 98304,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.3,
+        "outputCost": 1.2
+      },
+      {
+        "id": "zai.glm-5",
+        "name": "GLM-5",
+        "contextWindow": 202752,
+        "maxOutput": 101376,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1,
+        "outputCost": 3.2
+      },
+      {
+        "id": "anthropic.claude-opus-4-6-v1",
+        "name": "Claude Opus 4.6",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 25
       },
       {
         "id": "anthropic.claude-sonnet-4-6",
@@ -4083,41 +6039,30 @@
         "outputCost": 15
       },
       {
+        "id": "eu.anthropic.claude-opus-4-6-v1",
+        "name": "Claude Opus 4.6 (EU)",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5.5,
+        "outputCost": 27.5
+      },
+      {
+        "id": "eu.anthropic.claude-sonnet-4-6",
+        "name": "Claude Sonnet 4.6 (EU)",
+        "contextWindow": 1000000,
+        "maxOutput": 64000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 3.3,
+        "outputCost": 16.5
+      },
+      {
         "id": "global.anthropic.claude-opus-4-6-v1",
         "name": "Claude Opus 4.6 (Global)",
-        "contextWindow": 1000000,
-        "maxOutput": 128000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 5,
-        "outputCost": 25
-      },
-      {
-        "id": "minimax.minimax-m2.5",
-        "name": "MiniMax M2.5",
-        "contextWindow": 1000000,
-        "maxOutput": 131072,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.3,
-        "outputCost": 1.2
-      },
-      {
-        "id": "us.anthropic.claude-opus-4-6-v1",
-        "name": "Claude Opus 4.6 (US)",
-        "contextWindow": 1000000,
-        "maxOutput": 128000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 5,
-        "outputCost": 25
-      },
-      {
-        "id": "anthropic.claude-opus-4-6-v1",
-        "name": "Claude Opus 4.6",
         "contextWindow": 1000000,
         "maxOutput": 128000,
         "supportsImages": true,
@@ -4138,6 +6083,28 @@
         "outputCost": 15
       },
       {
+        "id": "jp.anthropic.claude-sonnet-4-6",
+        "name": "Claude Sonnet 4.6 (JP)",
+        "contextWindow": 1000000,
+        "maxOutput": 64000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 3,
+        "outputCost": 15
+      },
+      {
+        "id": "us.anthropic.claude-opus-4-6-v1",
+        "name": "Claude Opus 4.6 (US)",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 25
+      },
+      {
         "id": "us.anthropic.claude-sonnet-4-6",
         "name": "Claude Sonnet 4.6 (US)",
         "contextWindow": 1000000,
@@ -4149,26 +6116,26 @@
         "outputCost": 15
       },
       {
-        "id": "zai.glm-5",
-        "name": "GLM-5",
-        "contextWindow": 200000,
+        "id": "nvidia.nemotron-super-3-120b",
+        "name": "NVIDIA Nemotron 3 Super 120B A12B",
+        "contextWindow": 262144,
         "maxOutput": 131072,
         "supportsImages": false,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 1,
-        "outputCost": 3.2
+        "inputCost": 0.15,
+        "outputCost": 0.65
       },
       {
-        "id": "eu.anthropic.claude-opus-4-6-v1",
-        "name": "Claude Opus 4.6 (EU)",
+        "id": "au.anthropic.claude-sonnet-4-6",
+        "name": "AU Anthropic Claude Sonnet 4.6",
         "contextWindow": 1000000,
         "maxOutput": 128000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 5,
-        "outputCost": 25
+        "inputCost": 3.3,
+        "outputCost": 16.5
       },
       {
         "id": "mistral.devstral-2-123b",
@@ -4195,13 +6162,35 @@
       {
         "id": "moonshotai.kimi-k2.5",
         "name": "Kimi K2.5",
-        "contextWindow": 256000,
-        "maxOutput": 256000,
+        "contextWindow": 262143,
+        "maxOutput": 16000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
         "inputCost": 0.6,
         "outputCost": 3
+      },
+      {
+        "id": "qwen.qwen3-coder-next",
+        "name": "Qwen3 Coder Next",
+        "contextWindow": 131072,
+        "maxOutput": 65536,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.22,
+        "outputCost": 1.8
+      },
+      {
+        "id": "au.anthropic.claude-opus-4-6-v1",
+        "name": "AU Anthropic Claude Opus 4.6",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 16.5,
+        "outputCost": 82.5
       },
       {
         "id": "zai.glm-4.7-flash",
@@ -4248,12 +6237,12 @@
         "outputCost": 2.2
       },
       {
-        "id": "mistral.mistral-large-3-675b-instruct",
-        "name": "Mistral Large 3",
-        "contextWindow": 256000,
-        "maxOutput": 8192,
+        "id": "mistral.magistral-small-2509",
+        "name": "Magistral Small 1.2",
+        "contextWindow": 128000,
+        "maxOutput": 40000,
         "supportsImages": true,
-        "supportsReasoning": false,
+        "supportsReasoning": true,
         "supportsToolCall": true,
         "inputCost": 0.5,
         "outputCost": 1.5
@@ -4270,37 +6259,26 @@
         "outputCost": 0.1
       },
       {
-        "id": "moonshot.kimi-k2-thinking",
-        "name": "Kimi K2 Thinking",
+        "id": "mistral.mistral-large-3-675b-instruct",
+        "name": "Mistral Large 3",
         "contextWindow": 256000,
-        "maxOutput": 256000,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0.6,
-        "outputCost": 2.5
-      },
-      {
-        "id": "mistral.magistral-small-2509",
-        "name": "Magistral Small 1.2",
-        "contextWindow": 128000,
-        "maxOutput": 40000,
+        "maxOutput": 8192,
         "supportsImages": true,
-        "supportsReasoning": true,
+        "supportsReasoning": false,
         "supportsToolCall": true,
         "inputCost": 0.5,
         "outputCost": 1.5
       },
       {
-        "id": "qwen.qwen3-vl-235b-a22b",
-        "name": "Qwen/Qwen3-VL-235B-A22B-Instruct",
-        "contextWindow": 262000,
-        "maxOutput": 262000,
-        "supportsImages": true,
-        "supportsReasoning": false,
+        "id": "moonshot.kimi-k2-thinking",
+        "name": "Kimi K2 Thinking",
+        "contextWindow": 262143,
+        "maxOutput": 16000,
+        "supportsImages": false,
+        "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0.3,
-        "outputCost": 1.5
+        "inputCost": 0.6,
+        "outputCost": 2.5
       },
       {
         "id": "qwen.qwen3-next-80b-a3b",
@@ -4314,6 +6292,39 @@
         "outputCost": 1.4
       },
       {
+        "id": "qwen.qwen3-vl-235b-a22b",
+        "name": "Qwen/Qwen3-VL-235B-A22B-Instruct",
+        "contextWindow": 262000,
+        "maxOutput": 262000,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.3,
+        "outputCost": 1.5
+      },
+      {
+        "id": "openai.gpt-oss-safeguard-120b",
+        "name": "GPT OSS Safeguard 120B",
+        "contextWindow": 128000,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.15,
+        "outputCost": 0.6
+      },
+      {
+        "id": "openai.gpt-oss-safeguard-20b",
+        "name": "GPT OSS Safeguard 20B",
+        "contextWindow": 128000,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.07,
+        "outputCost": 0.2
+      },
+      {
         "id": "minimax.minimax-m2",
         "name": "MiniMax M2",
         "contextWindow": 204608,
@@ -4323,6 +6334,28 @@
         "supportsToolCall": true,
         "inputCost": 0.3,
         "outputCost": 1.2
+      },
+      {
+        "id": "anthropic.claude-haiku-4-5-20251001-v1:0",
+        "name": "Claude Haiku 4.5",
+        "contextWindow": 200000,
+        "maxOutput": 64000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1,
+        "outputCost": 5
+      },
+      {
+        "id": "au.anthropic.claude-haiku-4-5-20251001-v1:0",
+        "name": "Claude Haiku 4.5 (AU)",
+        "contextWindow": 200000,
+        "maxOutput": 64000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1,
+        "outputCost": 5
       },
       {
         "id": "eu.anthropic.claude-haiku-4-5-20251001-v1:0",
@@ -4358,19 +6391,8 @@
         "outputCost": 5
       },
       {
-        "id": "anthropic.claude-haiku-4-5-20251001-v1:0",
-        "name": "Claude Haiku 4.5",
-        "contextWindow": 200000,
-        "maxOutput": 64000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 1,
-        "outputCost": 5
-      },
-      {
-        "id": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
-        "name": "Claude Sonnet 4.5 (EU)",
+        "id": "anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "name": "Claude Sonnet 4.5",
         "contextWindow": 200000,
         "maxOutput": 64000,
         "supportsImages": true,
@@ -4380,8 +6402,41 @@
         "outputCost": 15
       },
       {
-        "id": "anthropic.claude-sonnet-4-5-20250929-v1:0",
-        "name": "Claude Sonnet 4.5",
+        "id": "au.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "name": "Claude Sonnet 4.5 (AU)",
+        "contextWindow": 200000,
+        "maxOutput": 64000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 3,
+        "outputCost": 15
+      },
+      {
+        "id": "eu.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "name": "Claude Sonnet 4.5 (EU)",
+        "contextWindow": 200000,
+        "maxOutput": 64000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 3.3,
+        "outputCost": 16.5
+      },
+      {
+        "id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "name": "Claude Sonnet 4.5 (Global)",
+        "contextWindow": 200000,
+        "maxOutput": 64000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 3,
+        "outputCost": 15
+      },
+      {
+        "id": "jp.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        "name": "Claude Sonnet 4.5 (JP)",
         "contextWindow": 200000,
         "maxOutput": 64000,
         "supportsImages": true,
@@ -4402,28 +6457,6 @@
         "outputCost": 15
       },
       {
-        "id": "global.anthropic.claude-sonnet-4-5-20250929-v1:0",
-        "name": "Claude Sonnet 4.5 (Global)",
-        "contextWindow": 200000,
-        "maxOutput": 64000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 3,
-        "outputCost": 15
-      },
-      {
-        "id": "qwen.qwen3-coder-480b-a35b-v1:0",
-        "name": "Qwen3 Coder 480B A35B Instruct",
-        "contextWindow": 131072,
-        "maxOutput": 65536,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.22,
-        "outputCost": 1.8
-      },
-      {
         "id": "deepseek.v3-v1:0",
         "name": "DeepSeek-V3.1",
         "contextWindow": 163840,
@@ -4433,17 +6466,6 @@
         "supportsToolCall": true,
         "inputCost": 0.58,
         "outputCost": 1.68
-      },
-      {
-        "id": "qwen.qwen3-coder-30b-a3b-v1:0",
-        "name": "Qwen3 Coder 30B A3B Instruct",
-        "contextWindow": 262144,
-        "maxOutput": 131072,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.15,
-        "outputCost": 0.6
       },
       {
         "id": "qwen.qwen3-235b-a22b-2507-v1:0",
@@ -4468,6 +6490,28 @@
         "outputCost": 0.6
       },
       {
+        "id": "qwen.qwen3-coder-30b-a3b-v1:0",
+        "name": "Qwen3 Coder 30B A3B Instruct",
+        "contextWindow": 262144,
+        "maxOutput": 131072,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.15,
+        "outputCost": 0.6
+      },
+      {
+        "id": "qwen.qwen3-coder-480b-a35b-v1:0",
+        "name": "Qwen3 Coder 480B A35B Instruct",
+        "contextWindow": 131072,
+        "maxOutput": 65536,
+        "supportsImages": false,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.22,
+        "outputCost": 1.8
+      },
+      {
         "id": "anthropic.claude-opus-4-1-20250805-v1:0",
         "name": "Claude Opus 4.1",
         "contextWindow": 200000,
@@ -4477,6 +6521,50 @@
         "supportsToolCall": true,
         "inputCost": 15,
         "outputCost": 75
+      },
+      {
+        "id": "openai.gpt-oss-120b",
+        "name": "gpt-oss-120b",
+        "contextWindow": 128000,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.15,
+        "outputCost": 0.6
+      },
+      {
+        "id": "openai.gpt-oss-120b-1:0",
+        "name": "gpt-oss-120b",
+        "contextWindow": 128000,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.15,
+        "outputCost": 0.6
+      },
+      {
+        "id": "openai.gpt-oss-20b",
+        "name": "gpt-oss-20b",
+        "contextWindow": 128000,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.07,
+        "outputCost": 0.3
+      },
+      {
+        "id": "openai.gpt-oss-20b-1:0",
+        "name": "gpt-oss-20b",
+        "contextWindow": 128000,
+        "maxOutput": 16384,
+        "supportsImages": false,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.07,
+        "outputCost": 0.3
       },
       {
         "id": "us.anthropic.claude-opus-4-1-20250805-v1:0",
@@ -4490,19 +6578,8 @@
         "outputCost": 75
       },
       {
-        "id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
-        "name": "Claude Opus 4.5 (Global)",
-        "contextWindow": 200000,
-        "maxOutput": 64000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 5,
-        "outputCost": 25
-      },
-      {
-        "id": "us.anthropic.claude-opus-4-5-20251101-v1:0",
-        "name": "Claude Opus 4.5 (US)",
+        "id": "anthropic.claude-opus-4-5-20251101-v1:0",
+        "name": "Claude Opus 4.5",
         "contextWindow": 200000,
         "maxOutput": 64000,
         "supportsImages": true,
@@ -4523,8 +6600,19 @@
         "outputCost": 25
       },
       {
-        "id": "anthropic.claude-opus-4-5-20251101-v1:0",
-        "name": "Claude Opus 4.5",
+        "id": "global.anthropic.claude-opus-4-5-20251101-v1:0",
+        "name": "Claude Opus 4.5 (Global)",
+        "contextWindow": 200000,
+        "maxOutput": 64000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 25
+      },
+      {
+        "id": "us.anthropic.claude-opus-4-5-20251101-v1:0",
+        "name": "Claude Opus 4.5 (US)",
         "contextWindow": 200000,
         "maxOutput": 64000,
         "supportsImages": true,
@@ -4567,70 +6655,15 @@
         "outputCost": 5.4
       },
       {
-        "id": "us.anthropic.claude-opus-4-20250514-v1:0",
-        "name": "Claude Opus 4 (US)",
-        "contextWindow": 200000,
-        "maxOutput": 32000,
-        "supportsImages": true,
+        "id": "us.deepseek.r1-v1:0",
+        "name": "DeepSeek-R1 (US)",
+        "contextWindow": 128000,
+        "maxOutput": 32768,
+        "supportsImages": false,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 15,
-        "outputCost": 75
-      },
-      {
-        "id": "anthropic.claude-sonnet-4-20250514-v1:0",
-        "name": "Claude Sonnet 4",
-        "contextWindow": 200000,
-        "maxOutput": 64000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 3,
-        "outputCost": 15
-      },
-      {
-        "id": "anthropic.claude-opus-4-20250514-v1:0",
-        "name": "Claude Opus 4",
-        "contextWindow": 200000,
-        "maxOutput": 32000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 15,
-        "outputCost": 75
-      },
-      {
-        "id": "us.anthropic.claude-sonnet-4-20250514-v1:0",
-        "name": "Claude Sonnet 4 (US)",
-        "contextWindow": 200000,
-        "maxOutput": 64000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 3,
-        "outputCost": 15
-      },
-      {
-        "id": "global.anthropic.claude-sonnet-4-20250514-v1:0",
-        "name": "Claude Sonnet 4 (Global)",
-        "contextWindow": 200000,
-        "maxOutput": 64000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 3,
-        "outputCost": 15
-      },
-      {
-        "id": "eu.anthropic.claude-sonnet-4-20250514-v1:0",
-        "name": "Claude Sonnet 4 (EU)",
-        "contextWindow": 200000,
-        "maxOutput": 64000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 3,
-        "outputCost": 15
+        "inputCost": 1.35,
+        "outputCost": 5.4
       },
       {
         "id": "writer.palmyra-x4-v1:0",
@@ -4688,15 +6721,26 @@
         "outputCost": 0.66
       },
       {
-        "id": "anthropic.claude-3-7-sonnet-20250219-v1:0",
-        "name": "Claude Sonnet 3.7",
-        "contextWindow": 200000,
-        "maxOutput": 8192,
+        "id": "us.meta.llama4-maverick-17b-instruct-v1:0",
+        "name": "Llama 4 Maverick 17B Instruct (US)",
+        "contextWindow": 1000000,
+        "maxOutput": 16384,
         "supportsImages": true,
         "supportsReasoning": false,
         "supportsToolCall": true,
-        "inputCost": 3,
-        "outputCost": 15
+        "inputCost": 0.24,
+        "outputCost": 0.97
+      },
+      {
+        "id": "us.meta.llama4-scout-17b-instruct-v1:0",
+        "name": "Llama 4 Scout 17B Instruct (US)",
+        "contextWindow": 3500000,
+        "maxOutput": 16384,
+        "supportsImages": true,
+        "supportsReasoning": false,
+        "supportsToolCall": true,
+        "inputCost": 0.17,
+        "outputCost": 0.66
       },
       {
         "id": "meta.llama3-3-70b-instruct-v1:0",
@@ -4743,59 +6787,15 @@
         "outputCost": 3.2
       },
       {
-        "id": "amazon.nova-premier-v1:0",
-        "name": "Nova Premier",
-        "contextWindow": 1000000,
-        "maxOutput": 16384,
+        "id": "amazon.nova-2-lite-v1:0",
+        "name": "Nova 2 Lite",
+        "contextWindow": 128000,
+        "maxOutput": 4096,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 2.5,
-        "outputCost": 12.5
-      },
-      {
-        "id": "openai.gpt-oss-120b-1:0",
-        "name": "gpt-oss-120b",
-        "contextWindow": 128000,
-        "maxOutput": 4096,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.15,
-        "outputCost": 0.6
-      },
-      {
-        "id": "nvidia.nemotron-nano-12b-v2",
-        "name": "NVIDIA Nemotron Nano 12B v2 VL BF16",
-        "contextWindow": 128000,
-        "maxOutput": 4096,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.2,
-        "outputCost": 0.6
-      },
-      {
-        "id": "mistral.ministral-3-8b-instruct",
-        "name": "Ministral 3 8B",
-        "contextWindow": 128000,
-        "maxOutput": 4096,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.15,
-        "outputCost": 0.15
-      },
-      {
-        "id": "openai.gpt-oss-safeguard-20b",
-        "name": "GPT OSS Safeguard 20B",
-        "contextWindow": 128000,
-        "maxOutput": 4096,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.07,
-        "outputCost": 0.2
+        "inputCost": 0.33,
+        "outputCost": 2.75
       },
       {
         "id": "google.gemma-3-12b-it",
@@ -4809,17 +6809,6 @@
         "outputCost": 0.09999999999999999
       },
       {
-        "id": "mistral.ministral-3-14b-instruct",
-        "name": "Ministral 14B 3.0",
-        "contextWindow": 128000,
-        "maxOutput": 4096,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.2,
-        "outputCost": 0.2
-      },
-      {
         "id": "google.gemma-3-4b-it",
         "name": "Gemma 3 4B IT",
         "contextWindow": 128000,
@@ -4831,48 +6820,26 @@
         "outputCost": 0.08
       },
       {
-        "id": "nvidia.nemotron-nano-9b-v2",
-        "name": "NVIDIA Nemotron Nano 9B v2",
+        "id": "mistral.ministral-3-14b-instruct",
+        "name": "Ministral 14B 3.0",
         "contextWindow": 128000,
         "maxOutput": 4096,
         "supportsImages": false,
         "supportsReasoning": false,
         "supportsToolCall": true,
-        "inputCost": 0.06,
-        "outputCost": 0.23
+        "inputCost": 0.2,
+        "outputCost": 0.2
       },
       {
-        "id": "openai.gpt-oss-20b-1:0",
-        "name": "gpt-oss-20b",
-        "contextWindow": 128000,
-        "maxOutput": 4096,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.07,
-        "outputCost": 0.3
-      },
-      {
-        "id": "openai.gpt-oss-safeguard-120b",
-        "name": "GPT OSS Safeguard 120B",
+        "id": "mistral.ministral-3-8b-instruct",
+        "name": "Ministral 3 8B",
         "contextWindow": 128000,
         "maxOutput": 4096,
         "supportsImages": false,
         "supportsReasoning": false,
         "supportsToolCall": true,
         "inputCost": 0.15,
-        "outputCost": 0.6
-      },
-      {
-        "id": "amazon.nova-2-lite-v1:0",
-        "name": "Nova 2 Lite",
-        "contextWindow": 128000,
-        "maxOutput": 4096,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.33,
-        "outputCost": 2.75
+        "outputCost": 0.15
       },
       {
         "id": "mistral.voxtral-mini-3b-2507",
@@ -4886,70 +6853,26 @@
         "outputCost": 0.04
       },
       {
-        "id": "anthropic.claude-3-5-sonnet-20241022-v2:0",
-        "name": "Claude Sonnet 3.5 v2",
-        "contextWindow": 200000,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 3,
-        "outputCost": 15
-      },
-      {
-        "id": "anthropic.claude-3-5-haiku-20241022-v1:0",
-        "name": "Claude Haiku 3.5",
-        "contextWindow": 200000,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.8,
-        "outputCost": 4
-      },
-      {
-        "id": "meta.llama3-2-90b-instruct-v1:0",
-        "name": "Llama 3.2 90B Instruct",
+        "id": "nvidia.nemotron-nano-12b-v2",
+        "name": "NVIDIA Nemotron Nano 12B v2 VL BF16",
         "contextWindow": 128000,
         "maxOutput": 4096,
         "supportsImages": true,
         "supportsReasoning": false,
         "supportsToolCall": true,
-        "inputCost": 0.72,
-        "outputCost": 0.72
+        "inputCost": 0.2,
+        "outputCost": 0.6
       },
       {
-        "id": "meta.llama3-2-1b-instruct-v1:0",
-        "name": "Llama 3.2 1B Instruct",
-        "contextWindow": 131000,
-        "maxOutput": 4096,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.1,
-        "outputCost": 0.1
-      },
-      {
-        "id": "meta.llama3-2-11b-instruct-v1:0",
-        "name": "Llama 3.2 11B Instruct",
+        "id": "nvidia.nemotron-nano-9b-v2",
+        "name": "NVIDIA Nemotron Nano 9B v2",
         "contextWindow": 128000,
         "maxOutput": 4096,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.16,
-        "outputCost": 0.16
-      },
-      {
-        "id": "meta.llama3-2-3b-instruct-v1:0",
-        "name": "Llama 3.2 3B Instruct",
-        "contextWindow": 131000,
-        "maxOutput": 4096,
         "supportsImages": false,
         "supportsReasoning": false,
         "supportsToolCall": true,
-        "inputCost": 0.15,
-        "outputCost": 0.15
+        "inputCost": 0.06,
+        "outputCost": 0.23
       },
       {
         "id": "meta.llama3-1-70b-instruct-v1:0",
@@ -4972,39 +6895,6 @@
         "supportsToolCall": true,
         "inputCost": 0.22,
         "outputCost": 0.22
-      },
-      {
-        "id": "meta.llama3-1-405b-instruct-v1:0",
-        "name": "Llama 3.1 405B Instruct",
-        "contextWindow": 128000,
-        "maxOutput": 4096,
-        "supportsImages": false,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 2.4,
-        "outputCost": 2.4
-      },
-      {
-        "id": "anthropic.claude-3-5-sonnet-20240620-v1:0",
-        "name": "Claude Sonnet 3.5",
-        "contextWindow": 200000,
-        "maxOutput": 8192,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 3,
-        "outputCost": 15
-      },
-      {
-        "id": "anthropic.claude-3-haiku-20240307-v1:0",
-        "name": "Claude Haiku 3",
-        "contextWindow": 200000,
-        "maxOutput": 4096,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0.25,
-        "outputCost": 1.25
       }
     ]
   },
@@ -5053,6 +6943,28 @@
     "api": "https://api.moonshot.ai/v1",
     "doc": "https://platform.moonshot.ai/docs/api/chat",
     "models": [
+      {
+        "id": "kimi-k2.7-code",
+        "name": "Kimi K2.7 Code",
+        "contextWindow": 262144,
+        "maxOutput": 262144,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.95,
+        "outputCost": 4
+      },
+      {
+        "id": "kimi-k2.6",
+        "name": "Kimi K2.6",
+        "contextWindow": 262144,
+        "maxOutput": 262144,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.95,
+        "outputCost": 4
+      },
       {
         "id": "kimi-k2.5",
         "name": "Kimi K2.5",
@@ -5127,6 +7039,61 @@
     "doc": "https://docs.github.com/en/copilot",
     "models": [
       {
+        "id": "claude-fable-5",
+        "name": "Claude Fable 5",
+        "contextWindow": 1000000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 10,
+        "outputCost": 50
+      },
+      {
+        "id": "claude-opus-4.8",
+        "name": "Claude Opus 4.8",
+        "contextWindow": 200000,
+        "maxOutput": 64000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 25
+      },
+      {
+        "id": "gemini-3.5-flash",
+        "name": "Gemini 3.5 Flash",
+        "contextWindow": 200000,
+        "maxOutput": 64000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1.5,
+        "outputCost": 9
+      },
+      {
+        "id": "gpt-5.5",
+        "name": "GPT-5.5",
+        "contextWindow": 400000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 30
+      },
+      {
+        "id": "claude-opus-4.7",
+        "name": "Claude Opus 4.7",
+        "contextWindow": 200000,
+        "maxOutput": 32000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 5,
+        "outputCost": 25
+      },
+      {
         "id": "gpt-5.4-mini",
         "name": "GPT-5.4 mini",
         "contextWindow": 400000,
@@ -5134,41 +7101,30 @@
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
+        "inputCost": 0.75,
+        "outputCost": 4.5
       },
       {
-        "id": "gpt-5.4",
-        "name": "GPT-5.4",
+        "id": "gpt-5.4-nano",
+        "name": "GPT-5.4 nano",
         "contextWindow": 400000,
         "maxOutput": 128000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
+        "inputCost": 0.2,
+        "outputCost": 1.25
       },
       {
-        "id": "gpt-5.3-codex",
-        "name": "GPT-5.3-Codex",
-        "contextWindow": 400000,
-        "maxOutput": 128000,
+        "id": "claude-opus-4.6",
+        "name": "Claude Opus 4.6",
+        "contextWindow": 200000,
+        "maxOutput": 32000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "gemini-3.1-pro-preview",
-        "name": "Gemini 3.1 Pro Preview",
-        "contextWindow": 128000,
-        "maxOutput": 64000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
+        "inputCost": 5,
+        "outputCost": 25
       },
       {
         "id": "claude-sonnet-4.6",
@@ -5178,184 +7134,129 @@
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
+        "inputCost": 3,
+        "outputCost": 15
       },
       {
-        "id": "claude-opus-4.6",
-        "name": "Claude Opus 4.6",
-        "contextWindow": 144000,
-        "maxOutput": 64000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "gemini-3-flash-preview",
-        "name": "Gemini 3 Flash",
-        "contextWindow": 128000,
-        "maxOutput": 64000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "gpt-5.2-codex",
-        "name": "GPT-5.2-Codex",
+        "id": "gpt-5.4",
+        "name": "GPT-5.4",
         "contextWindow": 400000,
         "maxOutput": 128000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
+        "inputCost": 2.5,
+        "outputCost": 15
+      },
+      {
+        "id": "gemini-3.1-pro-preview",
+        "name": "Gemini 3.1 Pro Preview",
+        "contextWindow": 200000,
+        "maxOutput": 64000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 2,
+        "outputCost": 12
+      },
+      {
+        "id": "gpt-5.3-codex",
+        "name": "GPT-5.3 Codex",
+        "contextWindow": 400000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1.75,
+        "outputCost": 14
+      },
+      {
+        "id": "gemini-3-flash-preview",
+        "name": "Gemini 3 Flash Preview",
+        "contextWindow": 128000,
+        "maxOutput": 64000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.5,
+        "outputCost": 3
       },
       {
         "id": "gpt-5.2",
         "name": "GPT-5.2",
-        "contextWindow": 264000,
-        "maxOutput": 64000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "gpt-5.1-codex-max",
-        "name": "GPT-5.1-Codex-max",
         "contextWindow": 400000,
         "maxOutput": 128000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
+        "inputCost": 1.75,
+        "outputCost": 14
       },
       {
-        "id": "gemini-3-pro-preview",
-        "name": "Gemini 3 Pro Preview",
-        "contextWindow": 128000,
-        "maxOutput": 64000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "gpt-5.1",
-        "name": "GPT-5.1",
-        "contextWindow": 264000,
-        "maxOutput": 64000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "gpt-5.1-codex-mini",
-        "name": "GPT-5.1-Codex-mini",
+        "id": "gpt-5.2-codex",
+        "name": "GPT-5.2 Codex",
         "contextWindow": 400000,
         "maxOutput": 128000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "gpt-5.1-codex",
-        "name": "GPT-5.1-Codex",
-        "contextWindow": 400000,
-        "maxOutput": 128000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "claude-haiku-4.5",
-        "name": "Claude Haiku 4.5",
-        "contextWindow": 144000,
-        "maxOutput": 32000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "claude-sonnet-4.5",
-        "name": "Claude Sonnet 4.5",
-        "contextWindow": 144000,
-        "maxOutput": 32000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "grok-code-fast-1",
-        "name": "Grok Code Fast 1",
-        "contextWindow": 128000,
-        "maxOutput": 64000,
-        "supportsImages": false,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "gpt-5-mini",
-        "name": "GPT-5-mini",
-        "contextWindow": 264000,
-        "maxOutput": 64000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "gpt-5",
-        "name": "GPT-5",
-        "contextWindow": 128000,
-        "maxOutput": 128000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "claude-opus-41",
-        "name": "Claude Opus 4.1",
-        "contextWindow": 80000,
-        "maxOutput": 16000,
-        "supportsImages": true,
-        "supportsReasoning": true,
-        "supportsToolCall": false,
-        "inputCost": 0,
-        "outputCost": 0
+        "inputCost": 1.75,
+        "outputCost": 14
       },
       {
         "id": "claude-opus-4.5",
-        "name": "Claude Opus 4.5",
-        "contextWindow": 160000,
+        "name": "Claude Opus 4.5 (latest)",
+        "contextWindow": 200000,
         "maxOutput": 32000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
+        "inputCost": 5,
+        "outputCost": 25
+      },
+      {
+        "id": "claude-haiku-4.5",
+        "name": "Claude Haiku 4.5 (latest)",
+        "contextWindow": 200000,
+        "maxOutput": 64000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 1,
+        "outputCost": 5
+      },
+      {
+        "id": "claude-sonnet-4.5",
+        "name": "Claude Sonnet 4.5 (latest)",
+        "contextWindow": 200000,
+        "maxOutput": 32000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 3,
+        "outputCost": 15
+      },
+      {
+        "id": "gpt-5-mini",
+        "name": "GPT-5 Mini",
+        "contextWindow": 264000,
+        "maxOutput": 64000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.25,
+        "outputCost": 2
+      },
+      {
+        "id": "raptor-mini",
+        "name": "Raptor mini",
+        "contextWindow": 400000,
+        "maxOutput": 128000,
+        "supportsImages": true,
+        "supportsReasoning": true,
+        "supportsToolCall": true,
+        "inputCost": 0.25,
+        "outputCost": 2
       },
       {
         "id": "gemini-2.5-pro",
@@ -5363,21 +7264,21 @@
         "contextWindow": 128000,
         "maxOutput": 64000,
         "supportsImages": true,
-        "supportsReasoning": false,
+        "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
+        "inputCost": 1.25,
+        "outputCost": 10
       },
       {
         "id": "claude-sonnet-4",
-        "name": "Claude Sonnet 4",
+        "name": "Claude Sonnet 4 (latest)",
         "contextWindow": 216000,
         "maxOutput": 16000,
         "supportsImages": true,
         "supportsReasoning": true,
         "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
+        "inputCost": 3,
+        "outputCost": 15
       },
       {
         "id": "gpt-4.1",
@@ -5387,19 +7288,8 @@
         "supportsImages": true,
         "supportsReasoning": false,
         "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
-      },
-      {
-        "id": "gpt-4o",
-        "name": "GPT-4o",
-        "contextWindow": 128000,
-        "maxOutput": 4096,
-        "supportsImages": true,
-        "supportsReasoning": false,
-        "supportsToolCall": true,
-        "inputCost": 0,
-        "outputCost": 0
+        "inputCost": 2,
+        "outputCost": 8
       }
     ]
   }

--- a/packages/browseros-agent/scripts/generate-models.test.ts
+++ b/packages/browseros-agent/scripts/generate-models.test.ts
@@ -1,11 +1,24 @@
 import { describe, expect, test } from 'bun:test'
-
+import modelsDevData from '../apps/agent/lib/llm-providers/models-dev-data.json'
 import {
   formatModelsData,
   generateModelsData,
   type ModelsDevModel,
   type ModelsDevProvider,
+  type OutputProvider,
 } from './generate-models'
+
+const REQUIRED_PROVIDER_IDS = [
+  'anthropic',
+  'openai',
+  'google',
+  'openrouter',
+  'azure',
+  'bedrock',
+  'lmstudio',
+  'moonshot',
+  'github-copilot',
+]
 
 function model(overrides: Partial<ModelsDevModel>): ModelsDevModel {
   return {
@@ -74,6 +87,34 @@ describe('generateModelsData', () => {
     })
   })
 
+  test('omits non-chat models', () => {
+    const output = generateModelsData(
+      {
+        'source-provider': provider({
+          imageOnly: model({
+            id: 'image-only',
+            modalities: { input: ['text'], output: ['image'] },
+            limit: { context: 0, output: 0 },
+          }),
+          missingLimits: model({
+            id: 'missing-limits',
+            modalities: { input: ['text'], output: ['text'] },
+            limit: { context: 0, output: 8192 },
+          }),
+          chat: model({
+            id: 'chat-model',
+            modalities: { input: ['text', 'image'], output: ['text'] },
+          }),
+        }),
+      },
+      { 'source-provider': 'browseros-provider' },
+    )
+
+    expect(output['browseros-provider']?.models.map((m) => m.id)).toEqual([
+      'chat-model',
+    ])
+  })
+
   test('sorts models by last update then id', () => {
     const output = generateModelsData(
       {
@@ -126,5 +167,32 @@ describe('generateModelsData', () => {
 
     expect(json.endsWith('\n')).toBe(true)
     expect(JSON.parse(json)).toEqual(output)
+  })
+
+  test('checked-in snapshot has required chat providers and models', () => {
+    const data = modelsDevData as Record<string, OutputProvider>
+
+    expect(Object.keys(data)).toEqual(REQUIRED_PROVIDER_IDS)
+
+    for (const [providerId, provider] of Object.entries(data)) {
+      expect(provider.models.length).toBeGreaterThan(0)
+
+      const ids = new Set<string>()
+      for (const model of provider.models) {
+        expect(ids.has(model.id)).toBe(false)
+        ids.add(model.id)
+
+        expect(model.id).toBeTruthy()
+        expect(model.name).toBeTruthy()
+        expect(model.contextWindow).toBeGreaterThan(0)
+        expect(model.maxOutput).toBeGreaterThan(0)
+        expect(typeof model.supportsImages).toBe('boolean')
+        expect(typeof model.supportsReasoning).toBe('boolean')
+        expect(typeof model.supportsToolCall).toBe('boolean')
+      }
+
+      expect(ids.size).toBe(provider.models.length)
+      expect(REQUIRED_PROVIDER_IDS).toContain(providerId)
+    }
   })
 })

--- a/packages/browseros-agent/scripts/generate-models.test.ts
+++ b/packages/browseros-agent/scripts/generate-models.test.ts
@@ -20,6 +20,9 @@ const REQUIRED_PROVIDER_IDS = [
   'github-copilot',
 ]
 
+const NON_CHAT_MODEL_CLASS_PATTERN =
+  /embedding|image|audio|tts|transcribe|whisper|moderation/i
+
 function model(overrides: Partial<ModelsDevModel>): ModelsDevModel {
   return {
     id: 'model-a',
@@ -96,10 +99,28 @@ describe('generateModelsData', () => {
             modalities: { input: ['text'], output: ['image'] },
             limit: { context: 0, output: 0 },
           }),
+          imageTextOutput: model({
+            id: 'gemini-3-pro-image-preview',
+            name: 'Nano Banana Pro',
+            modalities: { input: ['text', 'image'], output: ['text', 'image'] },
+          }),
+          audioTextOutput: model({
+            id: 'openai/gpt-audio',
+            name: 'GPT Audio',
+            modalities: { input: ['text', 'audio'], output: ['text', 'audio'] },
+          }),
+          embeddingFamily: model({
+            id: 'text-embedding-3-large',
+            family: 'text-embedding',
+          }),
           missingLimits: model({
             id: 'missing-limits',
             modalities: { input: ['text'], output: ['text'] },
             limit: { context: 0, output: 8192 },
+          }),
+          noTextInput: model({
+            id: 'non-text-input',
+            modalities: { input: ['image'], output: ['text'] },
           }),
           chat: model({
             id: 'chat-model',
@@ -184,6 +205,8 @@ describe('generateModelsData', () => {
 
         expect(model.id).toBeTruthy()
         expect(model.name).toBeTruthy()
+        expect(model.id).not.toMatch(NON_CHAT_MODEL_CLASS_PATTERN)
+        expect(model.name).not.toMatch(NON_CHAT_MODEL_CLASS_PATTERN)
         expect(model.contextWindow).toBeGreaterThan(0)
         expect(model.maxOutput).toBeGreaterThan(0)
         expect(typeof model.supportsImages).toBe('boolean')

--- a/packages/browseros-agent/scripts/generate-models.test.ts
+++ b/packages/browseros-agent/scripts/generate-models.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  formatModelsData,
+  generateModelsData,
+  type ModelsDevModel,
+  type ModelsDevProvider,
+} from './generate-models'
+
+function model(overrides: Partial<ModelsDevModel>): ModelsDevModel {
+  return {
+    id: 'model-a',
+    name: 'Model A',
+    attachment: false,
+    reasoning: false,
+    tool_call: true,
+    modalities: { input: ['text'], output: ['text'] },
+    limit: { context: 128000, output: 8192 },
+    release_date: '2026-01-01',
+    last_updated: '2026-01-01',
+    ...overrides,
+  }
+}
+
+function provider(models: Record<string, ModelsDevModel>): ModelsDevProvider {
+  return {
+    id: 'source-provider',
+    name: 'Source Provider',
+    npm: '@ai-sdk/source-provider',
+    doc: 'https://example.com/docs',
+    env: ['SOURCE_API_KEY'],
+    models,
+  }
+}
+
+describe('generateModelsData', () => {
+  test('maps providers and omits deprecated models', () => {
+    const output = generateModelsData(
+      {
+        'source-provider': provider({
+          current: model({
+            id: 'current-model',
+            name: 'Current Model',
+            attachment: true,
+            reasoning: true,
+            cost: { input: 1, output: 2 },
+          }),
+          deprecated: model({
+            id: 'deprecated-model',
+            status: 'deprecated',
+          }),
+        }),
+      },
+      { 'source-provider': 'browseros-provider' },
+    )
+
+    expect(Object.keys(output)).toEqual(['browseros-provider'])
+    expect(output['browseros-provider']).toEqual({
+      name: 'Source Provider',
+      doc: 'https://example.com/docs',
+      models: [
+        {
+          id: 'current-model',
+          name: 'Current Model',
+          contextWindow: 128000,
+          maxOutput: 8192,
+          supportsImages: true,
+          supportsReasoning: true,
+          supportsToolCall: true,
+          inputCost: 1,
+          outputCost: 2,
+        },
+      ],
+    })
+  })
+
+  test('sorts models by last update then id', () => {
+    const output = generateModelsData(
+      {
+        'source-provider': provider({
+          b: model({ id: 'b-model', last_updated: '2026-01-01' }),
+          a: model({ id: 'a-model', last_updated: '2026-01-01' }),
+          c: model({ id: 'c-model', last_updated: '2026-02-01' }),
+        }),
+      },
+      { 'source-provider': 'browseros-provider' },
+    )
+
+    expect(output['browseros-provider']?.models.map((m) => m.id)).toEqual([
+      'c-model',
+      'a-model',
+      'b-model',
+    ])
+  })
+
+  test('rejects duplicate transformed model ids', () => {
+    expect(() =>
+      generateModelsData(
+        {
+          'source-provider': provider({
+            first: model({ id: 'duplicate-model' }),
+            second: model({ id: 'duplicate-model' }),
+          }),
+        },
+        { 'source-provider': 'browseros-provider' },
+      ),
+    ).toThrow('Duplicate model id for browseros-provider: duplicate-model')
+  })
+
+  test('rejects missing required providers', () => {
+    expect(() =>
+      generateModelsData({}, { 'source-provider': 'browseros-provider' }),
+    ).toThrow('Provider not found in models.dev: source-provider')
+  })
+
+  test('formats generated JSON with a trailing newline', () => {
+    const output = {
+      'browseros-provider': {
+        name: 'Source Provider',
+        doc: 'https://example.com/docs',
+        models: [],
+      },
+    }
+
+    const json = formatModelsData(output)
+
+    expect(json.endsWith('\n')).toBe(true)
+    expect(JSON.parse(json)).toEqual(output)
+  })
+})

--- a/packages/browseros-agent/scripts/generate-models.ts
+++ b/packages/browseros-agent/scripts/generate-models.ts
@@ -66,9 +66,29 @@ export const PROVIDER_MAP: Record<string, string> = {
   'github-copilot': 'github-copilot',
 }
 
+const NON_CHAT_MODEL_CLASS_TERMS = [
+  'embedding',
+  'image',
+  'audio',
+  'tts',
+  'transcribe',
+  'whisper',
+  'moderation',
+]
+
+function isNonChatModelClass(model: ModelsDevModel): boolean {
+  return [model.id, model.name, model.family ?? ''].some((value) => {
+    const normalized = value.toLowerCase()
+
+    return NON_CHAT_MODEL_CLASS_TERMS.some((term) => normalized.includes(term))
+  })
+}
+
 /** Converts a models.dev model into the compact BrowserOS snapshot shape. */
 export function transformModel(model: ModelsDevModel): OutputModel | null {
   if (model.status === 'deprecated') return null
+  if (isNonChatModelClass(model)) return null
+  if (!model.modalities.input.includes('text')) return null
   if (!model.modalities.output.includes('text')) return null
   if (model.limit.context <= 0 || model.limit.output <= 0) return null
 

--- a/packages/browseros-agent/scripts/generate-models.ts
+++ b/packages/browseros-agent/scripts/generate-models.ts
@@ -69,6 +69,8 @@ export const PROVIDER_MAP: Record<string, string> = {
 /** Converts a models.dev model into the compact BrowserOS snapshot shape. */
 export function transformModel(model: ModelsDevModel): OutputModel | null {
   if (model.status === 'deprecated') return null
+  if (!model.modalities.output.includes('text')) return null
+  if (model.limit.context <= 0 || model.limit.output <= 0) return null
 
   const supportsImages =
     model.attachment || model.modalities.input.includes('image')

--- a/packages/browseros-agent/scripts/generate-models.ts
+++ b/packages/browseros-agent/scripts/generate-models.ts
@@ -1,15 +1,10 @@
-/**
- * Fetches models.dev/api.json and generates a compact models data file
- * for BrowserOS. Run: bun scripts/generate-models.ts
- */
-
 const API_URL = 'https://models.dev/api.json'
 const OUTPUT_PATH = new URL(
   '../apps/agent/lib/llm-providers/models-dev-data.json',
   import.meta.url,
 ).pathname
 
-interface ModelsDevModel {
+export interface ModelsDevModel {
   id: string
   name: string
   family?: string
@@ -30,7 +25,7 @@ interface ModelsDevModel {
   last_updated: string
 }
 
-interface ModelsDevProvider {
+export interface ModelsDevProvider {
   id: string
   name: string
   npm: string
@@ -40,7 +35,7 @@ interface ModelsDevProvider {
   models: Record<string, ModelsDevModel>
 }
 
-interface OutputModel {
+export interface OutputModel {
   id: string
   name: string
   contextWindow: number
@@ -52,15 +47,14 @@ interface OutputModel {
   outputCost?: number
 }
 
-interface OutputProvider {
+export interface OutputProvider {
   name: string
   api?: string
   doc: string
   models: OutputModel[]
 }
 
-// models.dev ID → BrowserOS provider ID
-const PROVIDER_MAP: Record<string, string> = {
+export const PROVIDER_MAP: Record<string, string> = {
   anthropic: 'anthropic',
   openai: 'openai',
   google: 'google',
@@ -72,7 +66,8 @@ const PROVIDER_MAP: Record<string, string> = {
   'github-copilot': 'github-copilot',
 }
 
-function transformModel(model: ModelsDevModel): OutputModel | null {
+/** Converts a models.dev model into the compact BrowserOS snapshot shape. */
+export function transformModel(model: ModelsDevModel): OutputModel | null {
   if (model.status === 'deprecated') return null
 
   const supportsImages =
@@ -93,31 +88,50 @@ function transformModel(model: ModelsDevModel): OutputModel | null {
   }
 }
 
-async function main() {
-  console.log(`Fetching ${API_URL}...`)
-  const response = await fetch(API_URL)
-  if (!response.ok) throw new Error(`Failed to fetch: ${response.status}`)
+function assertUniqueModels(providerId: string, models: OutputModel[]) {
+  const seen = new Set<string>()
 
-  const data: Record<string, ModelsDevProvider> = await response.json()
-  console.log(`Fetched ${Object.keys(data).length} providers`)
+  for (const model of models) {
+    if (seen.has(model.id)) {
+      throw new Error(`Duplicate model id for ${providerId}: ${model.id}`)
+    }
 
+    seen.add(model.id)
+  }
+}
+
+/** Builds the BrowserOS provider snapshot from raw models.dev API data. */
+export function generateModelsData(
+  data: Record<string, ModelsDevProvider>,
+  providerMap: Record<string, string> = PROVIDER_MAP,
+): Record<string, OutputProvider> {
   const output: Record<string, OutputProvider> = {}
 
-  for (const [modelsDevId, browserosId] of Object.entries(PROVIDER_MAP)) {
+  for (const [modelsDevId, browserosId] of Object.entries(providerMap)) {
     const provider = data[modelsDevId]
     if (!provider) {
-      console.warn(`Provider not found in models.dev: ${modelsDevId}`)
-      continue
+      throw new Error(`Provider not found in models.dev: ${modelsDevId}`)
     }
 
     const models = Object.values(provider.models)
-      .map(transformModel)
-      .filter((m): m is OutputModel => m !== null)
-      .sort((a, b) => {
-        const dateA = provider.models[a.id]?.last_updated ?? ''
-        const dateB = provider.models[b.id]?.last_updated ?? ''
-        return dateB.localeCompare(dateA)
+      .map((model) => {
+        const transformed = transformModel(model)
+
+        return transformed
+          ? { lastUpdated: model.last_updated, model: transformed }
+          : null
       })
+      .filter(
+        (m): m is { lastUpdated: string; model: OutputModel } => m !== null,
+      )
+      .sort((a, b) => {
+        const byLastUpdated = b.lastUpdated.localeCompare(a.lastUpdated)
+
+        return byLastUpdated || a.model.id.localeCompare(b.model.id)
+      })
+      .map(({ model }) => model)
+
+    assertUniqueModels(browserosId, models)
 
     output[browserosId] = {
       name: provider.name,
@@ -127,6 +141,26 @@ async function main() {
     }
   }
 
+  return output
+}
+
+export function formatModelsData(
+  output: Record<string, OutputProvider>,
+): string {
+  return `${JSON.stringify(output, null, 2)}\n`
+}
+
+/** Fetches live models.dev data and writes the checked-in BrowserOS snapshot. */
+export async function main() {
+  console.log(`Fetching ${API_URL}...`)
+  const response = await fetch(API_URL)
+  if (!response.ok) throw new Error(`Failed to fetch: ${response.status}`)
+
+  const data: Record<string, ModelsDevProvider> = await response.json()
+  console.log(`Fetched ${Object.keys(data).length} providers`)
+
+  const output = generateModelsData(data)
+
   const totalModels = Object.values(output).reduce(
     (sum, p) => sum + p.models.length,
     0,
@@ -135,11 +169,13 @@ async function main() {
     `Generated ${Object.keys(output).length} providers with ${totalModels} models`,
   )
 
-  await Bun.write(OUTPUT_PATH, JSON.stringify(output, null, 2))
+  await Bun.write(OUTPUT_PATH, formatModelsData(output))
   console.log(`Written to ${OUTPUT_PATH}`)
 }
 
-main().catch((err) => {
-  console.error(err)
-  process.exit(1)
-})
+if (import.meta.main) {
+  main().catch((err) => {
+    console.error(err)
+    process.exit(1)
+  })
+}


### PR DESCRIPTION
## Summary
- refresh `models-dev-data.json` from the repo's existing `bun run generate:models` flow
- harden the generator with pure helpers, duplicate/default-provider failures, deterministic sorting, and non-chat model filtering
- add focused Bun tests plus checked-in snapshot invariants

## Notes
- This replaces the stale approach in #1190; that PR was inspected but not used or merged.
- Rebased onto current `origin/main` before opening.

## Verification
- `bun run generate:models`
- `bun test scripts/generate-models.test.ts`
- `git diff --check`
- `bun run lint` (passes; existing warnings remain)
- `bun run typecheck`
- `bun run build:agent`
