### PR TITLE
feat: create browseros chromium branch during setup

### DIFF
--- a/packages/browseros/build/modules/setup/git.py
+++ b/packages/browseros/build/modules/setup/git.py
@@ -23,6 +23,8 @@ from ...common.utils import (
     safe_rmtree,
 )
 
+BROWSEROS_BRANCH = "browseros"
+
 
 class GitSetupModule(CommandModule):
     produces = []
@@ -37,6 +39,7 @@ class GitSetupModule(CommandModule):
             raise ValidationError("Chromium version not set")
 
     def execute(self, ctx: Context) -> None:
+        """Prepare Chromium at the configured tag for BrowserOS patch application."""
         log_info(f"\n🔀 Setting up Chromium {ctx.chromium_version}...")
 
         log_info("📥 Fetching all tags from remote...")
@@ -45,7 +48,10 @@ class GitSetupModule(CommandModule):
         self._verify_tag_exists(ctx)
 
         log_info(f"🔀 Checking out tag: {ctx.chromium_version}")
-        run_command(["git", "checkout", f"tags/{ctx.chromium_version}"], cwd=ctx.chromium_src)
+        run_command(
+            ["git", "checkout", f"tags/{ctx.chromium_version}"], cwd=ctx.chromium_src
+        )
+        self._checkout_browseros_branch(ctx)
 
         # On Linux, depot_tools fetches per-arch sysroots automatically when
         # `.gclient` declares `target_cpus`. Ensure both x64 and arm64 are
@@ -55,22 +61,34 @@ class GitSetupModule(CommandModule):
 
         log_info("📥 Syncing dependencies (this may take a while)...")
         if IS_WINDOWS():
-            run_command(["gclient.bat", "sync", "-D", "--no-history", "--shallow"], cwd=ctx.chromium_src)
+            run_command(
+                ["gclient.bat", "sync", "-D", "--no-history", "--shallow"],
+                cwd=ctx.chromium_src,
+            )
         else:
-            run_command(["gclient", "sync", "-D", "--no-history", "--shallow"], cwd=ctx.chromium_src)
+            run_command(
+                ["gclient", "sync", "-D", "--no-history", "--shallow"],
+                cwd=ctx.chromium_src,
+            )
 
         log_success("Git setup complete")
 
-    def _ensure_gclient_target_cpus(self, ctx: Context, required: List[str]) -> None:
-        """Idempotently add `target_cpus` to .gclient so depot_tools fetches
-        the matching Linux sysroots for cross-compilation.
+    def _checkout_browseros_branch(self, ctx: Context) -> None:
+        """Switch Chromium onto the local branch that receives BrowserOS patches."""
+        log_info(f"🔀 Creating/resetting branch: {BROWSEROS_BRANCH}")
+        run_command(
+            [
+                "git",
+                "checkout",
+                "-B",
+                BROWSEROS_BRANCH,
+                f"tags/{ctx.chromium_version}",
+            ],
+            cwd=ctx.chromium_src,
+        )
 
-        depot_tools convention: .gclient lives one directory above
-        chromium_src (i.e. ../.gclient). It is a Python file with a list
-        of solution dicts followed by optional top-level assignments.
-        We append a `target_cpus = [...]` line if missing or merge in any
-        archs that aren't already present.
-        """
+    def _ensure_gclient_target_cpus(self, ctx: Context, required: List[str]) -> None:
+        """Ensure gclient sync fetches the Linux sysroots needed for target CPUs."""
         gclient_path = ctx.chromium_src.parent / ".gclient"
         if not gclient_path.exists():
             log_warning(
@@ -91,12 +109,8 @@ class GitSetupModule(CommandModule):
                 return
             merged = sorted(set(existing) | set(required))
             new_line = f"target_cpus = {merged!r}"
-            content = (
-                content[: match.start()] + new_line + content[match.end() :]
-            )
-            log_info(
-                f"📝 Updating .gclient target_cpus: {existing} → {merged}"
-            )
+            content = content[: match.start()] + new_line + content[match.end() :]
+            log_info(f"📝 Updating .gclient target_cpus: {existing} → {merged}")
         else:
             new_line = f"\ntarget_cpus = {required!r}\n"
             content = content.rstrip() + "\n" + new_line
@@ -133,6 +147,7 @@ class SparkleSetupModule(CommandModule):
 
     def validate(self, ctx: Context) -> None:
         from ...common.utils import IS_MACOS
+
         if not IS_MACOS():
             raise ValidationError("Sparkle setup requires macOS")
 
@@ -195,16 +210,15 @@ class WinSparkleSetupModule(CommandModule):
 
 
 def extract_winsparkle_zip(archive: Path, dest: Path) -> None:
-    """Extract the release zip stripping its top-level WinSparkle-<version>/
-    directory, so //third_party/winsparkle paths stay version-independent
-    (include/, x64/Release/, ...) and match the vendored BUILD.gn.
-    """
+    """Extract WinSparkle so Chromium paths stay version-independent."""
     with zipfile.ZipFile(archive) as zf:
         infos = zf.infolist()
 
         # The official archive wraps everything in a single version dir; a
         # different layout would silently produce a broken tree, so fail fast.
-        top_levels = {Path(info.filename).parts[0] for info in infos if info.filename.strip("/")}
+        top_levels = {
+            Path(info.filename).parts[0] for info in infos if info.filename.strip("/")
+        }
         if len(top_levels) != 1:
             raise RuntimeError(
                 f"Expected a single top-level directory in {archive.name}, "

--- a/packages/browseros/build/modules/setup/git_test.py
+++ b/packages/browseros/build/modules/setup/git_test.py
@@ -4,6 +4,7 @@
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 from .git import GitSetupModule
 from ...common.context import Context
@@ -48,6 +49,86 @@ class GitSetupValidateTest(unittest.TestCase):
             GitSetupModule().validate(ctx)
 
 
+class GitSetupExecuteTest(unittest.TestCase):
+    def setUp(self):
+        self._chromium_tmp = tempfile.TemporaryDirectory()
+        self._root_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._chromium_tmp.cleanup)
+        self.addCleanup(self._root_tmp.cleanup)
+        self.ctx = make_context(
+            MockChromium(Path(self._chromium_tmp.name)),
+            MockBrowserOSRoot(Path(self._root_tmp.name)),
+        )
+
+    def test_checks_out_browseros_branch_after_tag(self):
+        commands = []
+        events = []
+
+        def fake_run_command(cmd, cwd=None):
+            commands.append(cmd)
+            if cmd[:3] == ["git", "checkout", "-B"]:
+                events.append("checkout_browseros")
+            elif cmd[:2] == ["git", "checkout"]:
+                events.append("checkout_tag")
+            else:
+                events.append(cmd[0])
+
+        def fake_ensure_gclient_target_cpus(module, ctx, required):
+            events.append("ensure_gclient_target_cpus")
+
+        with (
+            mock.patch("build.modules.setup.git.run_command", fake_run_command),
+            mock.patch("build.modules.setup.git.IS_LINUX", return_value=True),
+            mock.patch("build.modules.setup.git.IS_WINDOWS", return_value=False),
+            mock.patch.object(GitSetupModule, "_verify_tag_exists", return_value=None),
+            mock.patch.object(
+                GitSetupModule,
+                "_ensure_gclient_target_cpus",
+                fake_ensure_gclient_target_cpus,
+            ),
+        ):
+            GitSetupModule().execute(self.ctx)
+
+        self.assertEqual(
+            commands[:3],
+            [
+                ["git", "fetch", "--tags", "--force"],
+                ["git", "checkout", f"tags/{self.ctx.chromium_version}"],
+                [
+                    "git",
+                    "checkout",
+                    "-B",
+                    "browseros",
+                    f"tags/{self.ctx.chromium_version}",
+                ],
+            ],
+        )
+        self.assertLess(
+            events.index("checkout_browseros"),
+            events.index("ensure_gclient_target_cpus"),
+        )
+        self.assertLess(events.index("checkout_browseros"), events.index("gclient"))
+
+    def test_missing_tag_stops_before_checkout(self):
+        commands = []
+
+        def fake_run_command(cmd, cwd=None):
+            commands.append(cmd)
+
+        with (
+            mock.patch("build.modules.setup.git.run_command", fake_run_command),
+            mock.patch.object(
+                GitSetupModule,
+                "_verify_tag_exists",
+                side_effect=ValidationError("missing"),
+            ),
+        ):
+            with self.assertRaises(ValidationError):
+                GitSetupModule().execute(self.ctx)
+
+        self.assertEqual(commands, [["git", "fetch", "--tags", "--force"]])
+
+
 class EnsureGclientTargetCpusTest(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
@@ -76,9 +157,7 @@ class EnsureGclientTargetCpusTest(unittest.TestCase):
         self.assertIn("solutions = [", content)
 
     def test_merges_missing_archs_into_existing_list(self):
-        self.gclient.write_text(
-            self.gclient.read_text() + "\ntarget_cpus = ['x64']\n"
-        )
+        self.gclient.write_text(self.gclient.read_text() + "\ntarget_cpus = ['x64']\n")
 
         self.module._ensure_gclient_target_cpus(self.ctx, ["x64", "arm64"])
 


### PR DESCRIPTION
## Summary
- Creates or resets a local `browseros` branch immediately after checking out the configured Chromium tag.
- Leaves the existing `patches` module responsible for applying `chromium_patches/` on top of the selected branch.
- Adds unit coverage for command ordering and missing-tag behavior.

## Design
`GitSetupModule.execute` keeps the existing fetch, tag verification, and tag checkout flow, then runs `git checkout -B browseros tags/<version>` before Linux `.gclient` setup and `gclient sync`. `-B` makes setup repeatable when the branch already exists or when the Chromium version changes.

## Test plan
- [x] `cd packages/browseros && uv run python -m unittest build.modules.setup.git_test`
- [x] `cd packages/browseros && uv run python -m unittest build.modules.setup.clean_test build.modules.setup.configure_test build.modules.setup.git_test build.modules.setup.winsparkle_test`
- [x] `cd packages/browseros && uv run ruff check build/modules/setup/git.py build/modules/setup/git_test.py`
- [x] `cd packages/browseros && uv run ruff format --check build/modules/setup/git.py build/modules/setup/git_test.py`
- [x] `git diff --check`
