### PR TITLE
feat(agent-mcp-ui): replay + agents directory + mcp registry

### DIFF
--- a/packages/browseros-agent/apps/agent-mcp-ui/biome.json
+++ b/packages/browseros-agent/apps/agent-mcp-ui/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "root": false,
   "extends": "//",
   "files": {

--- a/packages/browseros-agent/apps/agent-mcp-ui/components/layout/CockpitShell.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/layout/CockpitShell.tsx
@@ -32,8 +32,12 @@ export function CockpitShell() {
   }, [])
 
   useEffect(() => {
+    // Snapshot the ref object so the unmount cleanup closes over a stable
+    // reference (the React docs' canonical pattern for refs in effects).
+    const timeoutRef = collapseTimeoutRef
     return () => {
-      if (collapseTimeoutRef.current) clearTimeout(collapseTimeoutRef.current)
+      const id = timeoutRef.current
+      if (id !== null) clearTimeout(id)
     }
   }, [])
 

--- a/packages/browseros-agent/apps/agent-mcp-ui/components/ui/alert-dialog.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/ui/alert-dialog.tsx
@@ -1,0 +1,185 @@
+import * as React from "react"
+import { AlertDialog as AlertDialogPrimitive } from "@base-ui/react/alert-dialog"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+function AlertDialog({ ...props }: AlertDialogPrimitive.Root.Props) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({ ...props }: AlertDialogPrimitive.Trigger.Props) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({ ...props }: AlertDialogPrimitive.Portal.Props) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: AlertDialogPrimitive.Backdrop.Props) {
+  return (
+    <AlertDialogPrimitive.Backdrop
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "fixed inset-0 isolate z-50 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Popup.Props & {
+  size?: "default" | "sm"
+}) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Popup
+        data-slot="alert-dialog-content"
+        data-size={size}
+        className={cn(
+          "group/alert-dialog-content fixed top-1/2 left-1/2 z-50 grid w-full -translate-x-1/2 -translate-y-1/2 gap-6 rounded-xl bg-popover p-6 text-popover-foreground ring-1 ring-foreground/10 duration-100 outline-none data-[size=default]:max-w-xs data-[size=sm]:max-w-xs data-[size=default]:sm:max-w-lg data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn(
+        "grid grid-rows-[auto_1fr] place-items-center gap-1.5 text-center has-data-[slot=alert-dialog-media]:grid-rows-[auto_auto_1fr] has-data-[slot=alert-dialog-media]:gap-x-6 sm:group-data-[size=default]/alert-dialog-content:place-items-start sm:group-data-[size=default]/alert-dialog-content:text-left sm:group-data-[size=default]/alert-dialog-content:has-data-[slot=alert-dialog-media]:grid-rows-[auto_1fr]",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 group-data-[size=sm]/alert-dialog-content:grid group-data-[size=sm]/alert-dialog-content:grid-cols-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogMedia({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-media"
+      className={cn(
+        "mb-2 inline-flex size-16 items-center justify-center rounded-md bg-muted sm:group-data-[size=default]/alert-dialog-content:row-span-2 *:[svg:not([class*='size-'])]:size-8",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn(
+        "text-lg font-medium sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn(
+        "text-sm text-balance text-muted-foreground md:text-pretty *:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  return (
+    <Button
+      data-slot="alert-dialog-action"
+      className={cn(className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  variant = "outline",
+  size = "default",
+  ...props
+}: AlertDialogPrimitive.Close.Props &
+  Pick<React.ComponentProps<typeof Button>, "variant" | "size">) {
+  return (
+    <AlertDialogPrimitive.Close
+      data-slot="alert-dialog-cancel"
+      className={cn(className)}
+      render={<Button variant={variant} size={size} />}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogMedia,
+  AlertDialogOverlay,
+  AlertDialogPortal,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/entrypoints/newtab/App.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/entrypoints/newtab/App.tsx
@@ -10,6 +10,7 @@ import { SiteRulesTab } from '@/screens/governance/SiteRulesTab'
 import { LiveRun } from '@/screens/live-run/LiveRun'
 import { Mcp } from '@/screens/mcp/Mcp'
 import { NewAgent } from '@/screens/new-agent/NewAgent'
+import { Replay } from '@/screens/replay/Replay'
 
 /**
  * HashRouter wrapping a single layout route that mounts the sidebar
@@ -35,6 +36,7 @@ export function App() {
           <Route path="/mcp" element={<Mcp />} />
         </Route>
         <Route path="/run/:runId" element={<LiveRun />} />
+        <Route path="/governance/audit/:runId/replay" element={<Replay />} />
       </Routes>
     </HashRouter>
   )

--- a/packages/browseros-agent/apps/agent-mcp-ui/entrypoints/newtab/styles.css
+++ b/packages/browseros-agent/apps/agent-mcp-ui/entrypoints/newtab/styles.css
@@ -150,9 +150,12 @@ body {
   text-rendering: optimizeLegibility;
 }
 
-/* Selection: tint with the accent so it reads as BrowserOS, not chrome blue. */
+/* Selection: tint with the accent so it reads as BrowserOS, not chrome blue.
+   Foreground is pinned to ink so light-on-dark surfaces (the MCP URL block,
+   for example) stay readable when selected. */
 ::selection {
   background: var(--color-accent-tint-2);
+  color: var(--color-ink);
 }
 
 /* Honour the system "reduce motion" preference (WCAG 2.3.3). Cuts every

--- a/packages/browseros-agent/apps/agent-mcp-ui/entrypoints/newtab/styles.css
+++ b/packages/browseros-agent/apps/agent-mcp-ui/entrypoints/newtab/styles.css
@@ -154,3 +154,22 @@ body {
 ::selection {
   background: var(--color-accent-tint-2);
 }
+
+/* Honour the system "reduce motion" preference (WCAG 2.3.3). Cuts every
+   animation and CSS transition to a near-instant no-op so users with
+   vestibular sensitivities get a static cockpit. Tailwind utilities
+   like animate-pulse-dot and the replay scrubber transitions pick this
+   up automatically since they go through animation / transition
+   shorthands. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    /* biome-ignore-start lint/complexity/noImportantStyles: !important is the canonical reduced-motion override; needed to win over Tailwind's animation/transition utilities */
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+    /* biome-ignore-end lint/complexity/noImportantStyles: see start of block */
+  }
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/agents.hooks.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/agents.hooks.ts
@@ -240,3 +240,31 @@ export const useDeleteAgent = createMutation<
     return variables
   },
 })
+
+interface RegenerateMcpVariables {
+  id: string
+}
+
+interface RegenerateMcpResult {
+  id: string
+  mcpUrl: string
+}
+
+/**
+ * Mock mutation that rotates a profile's MCP URL. Shape matches the
+ * eventual hono-rpc surface: server picks a fresh slug, returns the
+ * new URL, the client updates the `agent-profiles` cache row by id.
+ * The user must re-paste the URL into their harness once this fires.
+ */
+export const useRegenerateMcpUrl = createMutation<
+  RegenerateMcpResult,
+  RegenerateMcpVariables
+>({
+  mutationFn: async ({ id }) => {
+    await new Promise((resolve) => setTimeout(resolve, 500))
+    return {
+      id,
+      mcpUrl: `${buildMcpUrl(`${toSlug(id)}-${nanoid(6).toLowerCase()}`)}`,
+    }
+  },
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/agents.hooks.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/agents.hooks.ts
@@ -95,3 +95,148 @@ export const useCreateAgent = createMutation<CreatedAgent, NewAgentValues>({
     }
   },
 })
+
+export type AgentProfileStatus = 'configured' | 'paused' | 'disabled'
+
+export interface AgentProfile {
+  id: string
+  /** Connector label, e.g. "Cowork . Finance ops". */
+  name: string
+  harness: AgentRow['harness']
+  /** "All sites from current profile" / "All my logins" / "Selective". */
+  loginScopeLabel: string
+  loginCount: number
+  /** Number of selected ACL rules (seed + custom). */
+  aclRuleCount: number
+  /** Number of approval categories set to Block. */
+  blockedActionCount: number
+  /** Number of "Always allow" grants accumulated. */
+  alwaysAllowCount: number
+  /** Relative time, e.g. "2m ago", "Yesterday 17:42", "Never run". */
+  lastRunAt: string
+  status: AgentProfileStatus
+  /** MCP endpoint URL handed to the harness. */
+  mcpUrl: string
+}
+
+const MOCK_AGENT_PROFILES: AgentProfile[] = [
+  {
+    id: 'cld-concur',
+    name: 'Cowork . Finance ops',
+    harness: 'Claude Cowork',
+    loginScopeLabel: 'Current profile (47)',
+    loginCount: 47,
+    aclRuleCount: 3,
+    blockedActionCount: 1,
+    alwaysAllowCount: 4,
+    lastRunAt: '2m ago',
+    status: 'configured',
+    mcpUrl: 'http://127.0.0.1:9000/mcp/cowork-finance-ops',
+  },
+  {
+    id: 'cld-li',
+    name: 'Cowork . Social posts',
+    harness: 'Claude Cowork',
+    loginScopeLabel: 'Selective (5)',
+    loginCount: 5,
+    aclRuleCount: 5,
+    blockedActionCount: 2,
+    alwaysAllowCount: 1,
+    lastRunAt: '4m ago',
+    status: 'configured',
+    mcpUrl: 'http://127.0.0.1:9000/mcp/cowork-social-posts',
+  },
+  {
+    id: 'cdx-sheet',
+    name: 'Codex . Pricing research',
+    harness: 'Codex',
+    loginScopeLabel: 'Selective (8)',
+    loginCount: 8,
+    aclRuleCount: 4,
+    blockedActionCount: 1,
+    alwaysAllowCount: 2,
+    lastRunAt: '8m ago',
+    status: 'configured',
+    mcpUrl: 'http://127.0.0.1:9000/mcp/codex-pricing-research',
+  },
+  {
+    id: 'cdx-leads',
+    name: 'Codex . Pipeline digest',
+    harness: 'Codex',
+    loginScopeLabel: 'Current profile (47)',
+    loginCount: 47,
+    aclRuleCount: 3,
+    blockedActionCount: 1,
+    alwaysAllowCount: 3,
+    lastRunAt: '34m ago',
+    status: 'configured',
+    mcpUrl: 'http://127.0.0.1:9000/mcp/codex-pipeline-digest',
+  },
+  {
+    id: 'hrm-stripe',
+    name: 'Hermes . Refunds',
+    harness: 'Hermes',
+    loginScopeLabel: 'Selective (2)',
+    loginCount: 2,
+    aclRuleCount: 5,
+    blockedActionCount: 2,
+    alwaysAllowCount: 0,
+    lastRunAt: '1h ago',
+    status: 'paused',
+    mcpUrl: 'http://127.0.0.1:9000/mcp/hermes-refunds',
+  },
+  {
+    id: 'hrm-notion',
+    name: 'Hermes . Weekly recap',
+    harness: 'Hermes',
+    loginScopeLabel: 'Current profile (47)',
+    loginCount: 47,
+    aclRuleCount: 2,
+    blockedActionCount: 1,
+    alwaysAllowCount: 1,
+    lastRunAt: 'Yesterday 09:11',
+    status: 'configured',
+    mcpUrl: 'http://127.0.0.1:9000/mcp/hermes-weekly-recap',
+  },
+  {
+    id: 'cdx-onb',
+    name: 'Codex . Onboarding draft',
+    harness: 'Codex',
+    loginScopeLabel: 'Selective (3)',
+    loginCount: 3,
+    aclRuleCount: 4,
+    blockedActionCount: 1,
+    alwaysAllowCount: 0,
+    lastRunAt: 'Never run',
+    status: 'disabled',
+    mcpUrl: 'http://127.0.0.1:9000/mcp/codex-onboarding-draft',
+  },
+]
+
+export const useAgentProfiles = createQuery<AgentProfile[]>({
+  queryKey: ['agent-profiles'],
+  fetcher: () =>
+    new Promise((resolve) =>
+      setTimeout(() => resolve(MOCK_AGENT_PROFILES), 60),
+    ),
+})
+
+interface DeleteAgentVariables {
+  id: string
+}
+
+/**
+ * Mock deleteAgent mutation. The hono-rpc surface will return
+ * `{ id }`; mutating clients update the `agent-profiles` cache with
+ * `setQueryData` instead of refetching since the row goes away on
+ * success.
+ */
+export const useDeleteAgent = createMutation<
+  DeleteAgentVariables,
+  DeleteAgentVariables
+>({
+  mutationFn: async (variables) => {
+    await new Promise((resolve) => setTimeout(resolve, 400))
+    return variables
+  },
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/replay.hooks.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/replay.hooks.ts
@@ -1,0 +1,205 @@
+import { createQuery } from 'react-query-kit'
+import type { RunStatus } from '@/lib/status'
+import type { RunHarness } from '@/modules/api/runs.hooks'
+
+export type ReplayVerb =
+  | 'navigate'
+  | 'read'
+  | 'click'
+  | 'type'
+  | 'attach'
+  | 'submit'
+  | 'done'
+
+export type ReplayKind = 'action' | 'approval' | 'block' | 'done'
+
+export interface ReplayFrame {
+  /** Seconds into the session. */
+  t: number
+  kind: ReplayKind
+  verb: ReplayVerb
+  /** Short node label, e.g. "Create New Report". */
+  node: string
+  /** Caption sentence rendered both in the viewport overlay and the timeline row. */
+  caption: string
+  /** Optional badge shown on the timeline row ("Allowed once", "Blocked"). */
+  note?: string
+}
+
+export interface ReplayDetail {
+  id: string
+  agentLabel: string
+  /** One-line task description shown in the top bar. */
+  taskTitle: string
+  harness: RunHarness
+  /** Final run status, used to colour the header pill. */
+  status: RunStatus
+  /** Originating site host for the browser-chrome stub. */
+  site: string
+  /** When the run happened, e.g. "Jun 1, 2026". */
+  startedAt: string
+  /** Wall-clock duration as displayed in the stat strip. */
+  duration: string
+  tokens: string
+  steps: string
+  approvals: string
+  /** Total seconds the session covers. */
+  totalSeconds: number
+  frames: ReplayFrame[]
+}
+
+const CONCUR_REPLAY: ReplayDetail = {
+  id: 'run-concur-may',
+  agentLabel: 'Cowork . File expenses',
+  taskTitle: 'See my May invoices and file expenses on SAP Concur',
+  harness: 'Claude Cowork',
+  status: 'done',
+  site: 'app.concur.com',
+  startedAt: 'Jun 1, 2026',
+  duration: '0:57',
+  tokens: '4.3k',
+  steps: '9',
+  approvals: '1',
+  totalSeconds: 60,
+  frames: [
+    {
+      t: 0,
+      kind: 'action',
+      verb: 'navigate',
+      node: 'concur.com',
+      caption: 'Requesting permission to open concur.com',
+    },
+    {
+      t: 2,
+      kind: 'approval',
+      verb: 'navigate',
+      node: 'concur.com',
+      caption: 'You allowed the agent to open concur.com',
+      note: 'Allowed once',
+    },
+    {
+      t: 4,
+      kind: 'action',
+      verb: 'navigate',
+      node: 'concur.com',
+      caption: 'Navigating to concur.com',
+    },
+    {
+      t: 8,
+      kind: 'action',
+      verb: 'read',
+      node: 'Concur home',
+      caption: 'Session restored from vault, signed in as nikhil@example.com',
+    },
+    {
+      t: 13,
+      kind: 'action',
+      verb: 'click',
+      node: '"Create New Report"',
+      caption: 'Opened the new-report form',
+    },
+    {
+      t: 19,
+      kind: 'action',
+      verb: 'read',
+      node: 'May invoices',
+      caption: 'Matched 4 receipts from your invoices folder',
+    },
+    {
+      t: 25,
+      kind: 'action',
+      verb: 'type',
+      node: 'Report name',
+      caption: 'Typed "May 2026 . Engineering"',
+    },
+    {
+      t: 34,
+      kind: 'action',
+      verb: 'type',
+      node: '4 expense lines',
+      caption: 'Filled vendor, date, category and amount for 4 lines',
+    },
+    {
+      t: 42,
+      kind: 'action',
+      verb: 'attach',
+      node: '4 receipts',
+      caption: 'Attached PDF receipts, total $1,284.50',
+    },
+    {
+      t: 48,
+      kind: 'approval',
+      verb: 'submit',
+      node: '"Submit Report"',
+      caption: 'Approval requested: submit the report',
+      note: 'Needs OK',
+    },
+    {
+      t: 51,
+      kind: 'approval',
+      verb: 'submit',
+      node: '"Submit Report"',
+      caption: 'You allowed the submit once',
+      note: 'Allowed once',
+    },
+    {
+      t: 53,
+      kind: 'action',
+      verb: 'read',
+      node: 'Confirmation',
+      caption: 'Report submitted, #EXP-49217, routed to Dana R.',
+    },
+    {
+      t: 56,
+      kind: 'block',
+      verb: 'click',
+      node: '"Pay card balance"',
+      caption: 'Blocked: payments are non-interactive for agents',
+      note: 'Blocked',
+    },
+    {
+      t: 58,
+      kind: 'done',
+      verb: 'done',
+      node: '',
+      caption: 'Run complete, expense report filed',
+    },
+  ],
+}
+
+/**
+ * Per-run replay fixtures. Keys match the run ids surfaced from
+ * `useRuns` so an Audit row click into `/governance/audit/:id/replay`
+ * lands on real data for at least one run.
+ */
+const FIXTURES: Record<string, ReplayDetail> = {
+  'run-concur-may': CONCUR_REPLAY,
+}
+
+const FALLBACK: ReplayDetail = {
+  id: 'unknown',
+  agentLabel: 'Unknown run',
+  taskTitle: 'No replay was recorded for this run.',
+  harness: 'Codex',
+  status: 'stopped',
+  site: 'about:blank',
+  startedAt: '',
+  duration: '0:00',
+  tokens: '0',
+  steps: '0',
+  approvals: '0',
+  totalSeconds: 0,
+  frames: [],
+}
+
+interface UseReplayVariables {
+  runId: string
+}
+
+export const useReplay = createQuery<ReplayDetail, UseReplayVariables>({
+  queryKey: ['replay'],
+  fetcher: ({ runId }) =>
+    new Promise((resolve) =>
+      setTimeout(() => resolve(FIXTURES[runId] ?? FALLBACK), 60),
+    ),
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/agents/AgentDirectoryRow.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/agents/AgentDirectoryRow.tsx
@@ -1,0 +1,90 @@
+import { Clock, Pencil, Trash2 } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import type { AgentProfile } from '@/modules/api/agents.hooks'
+import {
+  harnessIconFor,
+  scopeSummaryFor,
+  statusMetaFor,
+} from './agents.helpers'
+
+interface AgentDirectoryRowProps {
+  profile: AgentProfile
+  onEdit: (profile: AgentProfile) => void
+  onRevoke: (profile: AgentProfile) => void
+}
+
+/**
+ * One row per configured agent profile. Harness icon chip on the
+ * left, profile name + scope summary + last-run timestamp in the
+ * middle, status pill + edit/revoke buttons on the right. The whole
+ * row is non-clickable; explicit Edit / Revoke buttons stay focusable
+ * so screen-reader users hit them in tab order.
+ */
+export function AgentDirectoryRow({
+  profile,
+  onEdit,
+  onRevoke,
+}: AgentDirectoryRowProps) {
+  const HarnessIcon = harnessIconFor(profile.harness)
+  const statusMeta = statusMetaFor(profile.status)
+  return (
+    <div className="flex items-center gap-3.5 rounded-xl border border-border bg-card px-4 py-3.5">
+      <span
+        className={cn(
+          'flex size-9 shrink-0 items-center justify-center rounded-lg',
+          profile.harness === 'Codex'
+            ? 'bg-bg-sunken text-ink-2'
+            : 'bg-accent-tint text-accent',
+        )}
+      >
+        <HarnessIcon className="size-4" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <h3 className="truncate font-bold text-ink text-sm">
+            {profile.name}
+          </h3>
+          <span className="text-ink-4 text-xs">·</span>
+          <span className="text-ink-3 text-xs">{profile.harness}</span>
+        </div>
+        <p className="mt-0.5 truncate text-ink-3 text-xs">
+          {scopeSummaryFor(profile)}
+        </p>
+        <p className="mt-1 flex items-center gap-1 text-[11px] text-ink-4">
+          <Clock className="size-3" />
+          Last run {profile.lastRunAt}
+        </p>
+      </div>
+      <Badge
+        variant="outline"
+        className={cn('font-bold text-[11px]', statusMeta.className)}
+      >
+        {statusMeta.label}
+      </Badge>
+      <div className="flex gap-1.5">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => onEdit(profile)}
+          className="h-8 gap-1.5 px-2.5 text-xs"
+        >
+          <Pencil className="size-3" />
+          Edit
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => onRevoke(profile)}
+          aria-label={`Revoke ${profile.name}`}
+          className="h-8 px-2.5 text-ink-3 hover:text-red"
+        >
+          <Trash2 className="size-3.5" />
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/agents/Agents.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/agents/Agents.tsx
@@ -1,12 +1,112 @@
-import { Bot } from 'lucide-react'
-import { PlaceholderScreen } from '@/components/layout/PlaceholderScreen'
+import { Bot, Plus } from 'lucide-react'
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Spinner } from '@/components/ui/spinner'
+import type { AgentProfile } from '@/modules/api/agents.hooks'
+import { AgentDirectoryRow } from './AgentDirectoryRow'
+import { useAgentsDirectoryData } from './agents.data'
+import { DeleteAgentDialog } from './DeleteAgentDialog'
 
 export function Agents() {
+  const { profiles, isLoading, deleteAgent, navigate } =
+    useAgentsDirectoryData()
+  const [pendingDelete, setPendingDelete] = useState<AgentProfile | null>(null)
+
+  const onAdd = () => navigate('/agents/new')
+  const onEdit = (profile: AgentProfile) =>
+    navigate(`/agents/${profile.id}/edit`)
+  const onRevoke = (profile: AgentProfile) => setPendingDelete(profile)
+  const onConfirmRevoke = (profile: AgentProfile) => {
+    deleteAgent.mutate(
+      { id: profile.id },
+      {
+        onSettled: () => setPendingDelete(null),
+      },
+    )
+  }
+
+  const liveCount = profiles.filter(
+    (profile) => profile.status === 'configured',
+  ).length
+
   return (
-    <PlaceholderScreen
-      icon={Bot}
-      title="Agents"
-      description="The full agents directory lives here. From this screen you'll connect new agent profiles, manage their login scope and ACL rules, and see which harnesses are currently registered against BrowserOS."
-    />
+    <div className="mx-auto flex w-full max-w-3xl flex-col px-8 pt-6 pb-20">
+      <header className="mb-5 flex items-start gap-3">
+        <span className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-accent-tint text-accent">
+          <Bot className="size-5" />
+        </span>
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <h1 className="font-extrabold text-2xl text-ink tracking-tight">
+              Agents
+            </h1>
+            {profiles.length > 0 && (
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-green-tint px-2.5 py-0.5 font-bold text-green text-xs">
+                {liveCount} configured
+              </span>
+            )}
+          </div>
+          <p className="mt-0.5 text-ink-2 text-sm">
+            Every connector you've registered with BrowserOS, with its login
+            scope, guardrails, and MCP endpoint.
+          </p>
+        </div>
+        <Button type="button" onClick={onAdd}>
+          <Plus className="size-4" />
+          Add agent
+        </Button>
+      </header>
+
+      {isLoading ? (
+        <div className="flex justify-center py-12 text-ink-3">
+          <Spinner />
+        </div>
+      ) : profiles.length === 0 ? (
+        <EmptyState onAdd={onAdd} />
+      ) : (
+        <div className="flex flex-col gap-2">
+          {profiles.map((profile) => (
+            <AgentDirectoryRow
+              key={profile.id}
+              profile={profile}
+              onEdit={onEdit}
+              onRevoke={onRevoke}
+            />
+          ))}
+        </div>
+      )}
+
+      <DeleteAgentDialog
+        profile={pendingDelete}
+        isDeleting={deleteAgent.isPending}
+        onConfirm={onConfirmRevoke}
+        onCancel={() => setPendingDelete(null)}
+      />
+    </div>
+  )
+}
+
+/* ---------------------------------------------------------------------------
+ * Sub-components, kept private to the directory screen.
+ * -------------------------------------------------------------------------*/
+
+function EmptyState({ onAdd }: { onAdd: () => void }) {
+  return (
+    <div className="flex flex-col items-start gap-3 rounded-2xl border border-border border-dashed bg-card px-6 py-10">
+      <span className="flex size-9 items-center justify-center rounded-lg bg-accent-tint text-accent-ink">
+        <Bot className="size-4" />
+      </span>
+      <h2 className="font-bold text-ink text-lg tracking-tight">
+        No agents yet
+      </h2>
+      <p className="max-w-md text-ink-3 text-sm leading-snug">
+        Connect a harness like Claude Cowork, Codex, or Hermes to BrowserOS.
+        Each agent gets its own login scope, approval rules, and MCP endpoint.
+      </p>
+      <Button type="button" onClick={onAdd}>
+        <Plus className="size-4" />
+        Add your first agent
+      </Button>
+    </div>
   )
 }

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/agents/DeleteAgentDialog.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/agents/DeleteAgentDialog.tsx
@@ -1,0 +1,66 @@
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog'
+import { buttonVariants } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import type { AgentProfile } from '@/modules/api/agents.hooks'
+
+interface DeleteAgentDialogProps {
+  /** Profile whose row triggered the delete; `null` when the dialog is closed. */
+  profile: AgentProfile | null
+  isDeleting: boolean
+  onConfirm: (profile: AgentProfile) => void
+  onCancel: () => void
+}
+
+/**
+ * Confirm dialog for removing an agent profile. shadcn AlertDialog
+ * gives us proper focus trapping and ARIA semantics out of the box,
+ * which is why this is not a window.confirm.
+ */
+export function DeleteAgentDialog({
+  profile,
+  isDeleting,
+  onConfirm,
+  onCancel,
+}: DeleteAgentDialogProps) {
+  return (
+    <AlertDialog
+      open={profile !== null}
+      onOpenChange={(open) => {
+        if (!open) onCancel()
+      }}
+    >
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>Remove this agent profile?</AlertDialogTitle>
+          <AlertDialogDescription>
+            {profile?.name ? `"${profile.name}"` : 'This profile'} stops
+            responding to the harness immediately. Its MCP endpoint is
+            unregistered and any always-allow grants you gave it are revoked.
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel disabled={isDeleting}>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            disabled={isDeleting || profile === null}
+            onClick={(event) => {
+              event.preventDefault()
+              if (profile) onConfirm(profile)
+            }}
+            className={cn(buttonVariants({ variant: 'destructive' }))}
+          >
+            {isDeleting ? 'Removing…' : 'Remove agent'}
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/agents/agents.data.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/agents/agents.data.ts
@@ -1,0 +1,30 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router'
+import {
+  type AgentProfile,
+  useAgentProfiles,
+  useDeleteAgent,
+} from '@/modules/api/agents.hooks'
+
+/**
+ * Aggregates the Agents directory's server state. Delete mutation
+ * writes back to the `agent-profiles` cache via `setQueryData` so the
+ * row disappears immediately without a refetch, per the project
+ * convention of treating server-cached lists as the source of truth.
+ */
+export function useAgentsDirectoryData() {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const { data: profiles = [], isLoading } = useAgentProfiles()
+
+  const deleteAgent = useDeleteAgent({
+    onSuccess: ({ id }) => {
+      queryClient.setQueryData<AgentProfile[]>(
+        useAgentProfiles.getKey(),
+        (prev) => (prev ?? []).filter((profile) => profile.id !== id),
+      )
+    },
+  })
+
+  return { profiles, isLoading, deleteAgent, navigate }
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/agents/agents.helpers.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/agents/agents.helpers.ts
@@ -1,0 +1,67 @@
+import {
+  Bot,
+  Code,
+  type LucideIcon,
+  MousePointer2,
+  Sparkles,
+  Terminal,
+} from 'lucide-react'
+import type {
+  AgentProfile,
+  AgentProfileStatus,
+} from '@/modules/api/agents.hooks'
+
+const HARNESS_ICON: Record<AgentProfile['harness'], LucideIcon> = {
+  'Claude Cowork': Sparkles,
+  Codex: Code,
+  Hermes: Bot,
+  OpenClaw: MousePointer2,
+  'Gemini CLI': Terminal,
+}
+
+export function harnessIconFor(harness: AgentProfile['harness']): LucideIcon {
+  return HARNESS_ICON[harness]
+}
+
+interface ProfileStatusMeta {
+  label: string
+  /** Tailwind classes for the Badge variant. */
+  className: string
+}
+
+const PROFILE_STATUS_META: Record<AgentProfileStatus, ProfileStatusMeta> = {
+  configured: {
+    label: 'Configured',
+    className: 'bg-green-tint text-green border-transparent',
+  },
+  paused: {
+    label: 'Paused',
+    className: 'bg-amber-tint text-amber border-transparent',
+  },
+  disabled: {
+    label: 'Disabled',
+    className: 'bg-bg-sunken text-ink-3 border-transparent',
+  },
+}
+
+export function statusMetaFor(status: AgentProfileStatus): ProfileStatusMeta {
+  return PROFILE_STATUS_META[status]
+}
+
+export function scopeSummaryFor(profile: AgentProfile): string {
+  const parts = [
+    `${profile.loginCount} login${profile.loginCount === 1 ? '' : 's'}`,
+    `${profile.aclRuleCount} ACL rule${profile.aclRuleCount === 1 ? '' : 's'}`,
+  ]
+  if (profile.blockedActionCount > 0) {
+    parts.push(
+      `${profile.blockedActionCount} blocked action${profile.blockedActionCount === 1 ? '' : 's'}`,
+    )
+  }
+  if (profile.alwaysAllowCount > 0) {
+    parts.push(
+      `${profile.alwaysAllowCount} always-allow grant${profile.alwaysAllowCount === 1 ? '' : 's'}`,
+    )
+  }
+  return parts.join(' · ')
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/Mcp.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/Mcp.tsx
@@ -1,12 +1,91 @@
-import { PlugZap } from 'lucide-react'
-import { PlaceholderScreen } from '@/components/layout/PlaceholderScreen'
+import { PlugZap, Plus } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Spinner } from '@/components/ui/spinner'
+import type { AgentProfile } from '@/modules/api/agents.hooks'
+import { McpRow } from './McpRow'
+import { useMcpRegistryData } from './mcp.data'
 
 export function Mcp() {
+  const { profiles, isLoading, regenerate, navigate } = useMcpRegistryData()
+
+  const onAdd = () => navigate('/agents/new')
+  const onRegenerate = (profile: AgentProfile) =>
+    regenerate.mutate({ id: profile.id })
+
   return (
-    <PlaceholderScreen
-      icon={PlugZap}
-      title="MCP"
-      description="The MCP registry for this BrowserOS install. Per-agent endpoints, their slug-routed URLs, the active connection state, and a setup helper for adding BrowserOS as a connector inside Claude, Codex, and friends."
-    />
+    <div className="mx-auto flex w-full max-w-3xl flex-col px-8 pt-6 pb-20">
+      <header className="mb-5 flex items-start gap-3">
+        <span className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-accent-tint text-accent">
+          <PlugZap className="size-5" />
+        </span>
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <h1 className="font-extrabold text-2xl text-ink tracking-tight">
+              MCP
+            </h1>
+            {profiles.length > 0 && (
+              <span className="inline-flex items-center gap-1.5 rounded-full bg-accent-tint px-2.5 py-0.5 font-bold text-accent-ink text-xs">
+                {profiles.length} endpoint{profiles.length === 1 ? '' : 's'}
+              </span>
+            )}
+          </div>
+          <p className="mt-0.5 text-ink-2 text-sm">
+            Every agent profile gets a slug-routed MCP endpoint. Copy the URL
+            into your harness, or use one-click add if the harness exposes a
+            connector install API.
+          </p>
+        </div>
+        <Button type="button" onClick={onAdd}>
+          <Plus className="size-4" />
+          Add agent
+        </Button>
+      </header>
+
+      {isLoading ? (
+        <div className="flex justify-center py-12 text-ink-3">
+          <Spinner />
+        </div>
+      ) : profiles.length === 0 ? (
+        <EmptyState onAdd={onAdd} />
+      ) : (
+        <div className="flex flex-col gap-2.5">
+          {profiles.map((profile) => (
+            <McpRow
+              key={profile.id}
+              profile={profile}
+              isRegenerating={
+                regenerate.isPending && regenerate.variables?.id === profile.id
+              }
+              onRegenerate={onRegenerate}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+/* ---------------------------------------------------------------------------
+ * Sub-components, kept private to the registry screen.
+ * -------------------------------------------------------------------------*/
+
+function EmptyState({ onAdd }: { onAdd: () => void }) {
+  return (
+    <div className="flex flex-col items-start gap-3 rounded-2xl border border-border border-dashed bg-card px-6 py-10">
+      <span className="flex size-9 items-center justify-center rounded-lg bg-accent-tint text-accent-ink">
+        <PlugZap className="size-4" />
+      </span>
+      <h2 className="font-bold text-ink text-lg tracking-tight">
+        No endpoints yet
+      </h2>
+      <p className="max-w-md text-ink-3 text-sm leading-snug">
+        Endpoints land here when you add an agent profile. Each profile gets a
+        unique slug-routed MCP URL plus a one-click "Add to harness" handoff.
+      </p>
+      <Button type="button" onClick={onAdd}>
+        <Plus className="size-4" />
+        Add your first agent
+      </Button>
+    </div>
   )
 }

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/McpRow.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/McpRow.tsx
@@ -1,0 +1,123 @@
+import { Check, Copy, Link2, RotateCcw } from 'lucide-react'
+import { useState } from 'react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { cn } from '@/lib/utils'
+import type { AgentProfile } from '@/modules/api/agents.hooks'
+import { harnessIconFor, statusMetaFor } from '@/screens/agents/agents.helpers'
+import { cliCommandFor, slugFromMcpUrl } from './mcp.helpers'
+
+interface McpRowProps {
+  profile: AgentProfile
+  isRegenerating: boolean
+  onRegenerate: (profile: AgentProfile) => void
+}
+
+export function McpRow({ profile, isRegenerating, onRegenerate }: McpRowProps) {
+  const HarnessIcon = harnessIconFor(profile.harness)
+  const statusMeta = statusMetaFor(profile.status)
+  const slug = slugFromMcpUrl(profile.mcpUrl)
+  const cliCommand = cliCommandFor(profile)
+  const [copied, setCopied] = useState(false)
+  const [added, setAdded] = useState(false)
+
+  const copyMcpUrl = async () => {
+    try {
+      await navigator.clipboard.writeText(profile.mcpUrl)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch {
+      setCopied(false)
+    }
+  }
+
+  const onAdd = () => {
+    setAdded(true)
+    window.setTimeout(() => setAdded(false), 1800)
+  }
+
+  return (
+    <div className="flex flex-col gap-3 rounded-2xl border border-border bg-card p-4">
+      <div className="flex items-center gap-3.5">
+        <span
+          className={cn(
+            'flex size-9 shrink-0 items-center justify-center rounded-lg',
+            profile.harness === 'Codex'
+              ? 'bg-bg-sunken text-ink-2'
+              : 'bg-accent-tint text-accent',
+          )}
+        >
+          <HarnessIcon className="size-4" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <h3 className="truncate font-bold text-ink text-sm">
+              {profile.name}
+            </h3>
+            <span className="text-ink-4 text-xs">·</span>
+            <span className="text-ink-3 text-xs">{profile.harness}</span>
+          </div>
+          <p className="mt-0.5 truncate text-ink-3 text-xs">
+            slug <span className="font-mono text-ink-2">{slug}</span> · CLI{' '}
+            <span className="font-mono text-ink-2">{cliCommand}</span>
+          </p>
+        </div>
+        <Badge
+          variant="outline"
+          className={cn('font-bold text-[11px]', statusMeta.className)}
+        >
+          {statusMeta.label}
+        </Badge>
+      </div>
+
+      <div className="flex items-center gap-2 rounded-lg bg-[#15140F] px-3 py-2">
+        <code className="min-w-0 flex-1 truncate font-mono text-[#EDEAE2] text-[11.5px]">
+          {profile.mcpUrl}
+        </code>
+        <button
+          type="button"
+          onClick={copyMcpUrl}
+          aria-label="Copy MCP URL"
+          className="flex size-6 items-center justify-center rounded-md bg-white/10 text-white hover:bg-white/20"
+        >
+          {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+        </button>
+      </div>
+
+      <div className="flex gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => onRegenerate(profile)}
+          disabled={isRegenerating}
+          className="gap-1.5"
+        >
+          <RotateCcw
+            className={cn('size-3.5', isRegenerating && 'animate-spin')}
+          />
+          {isRegenerating ? 'Rotating…' : 'Regenerate URL'}
+        </Button>
+        <Button
+          type="button"
+          size="sm"
+          onClick={onAdd}
+          disabled={added}
+          className="gap-1.5"
+        >
+          {added ? (
+            <>
+              <Check className="size-3.5" />
+              Added to {profile.harness}
+            </>
+          ) : (
+            <>
+              <Link2 className="size-3.5" />
+              Add to {profile.harness}
+            </>
+          )}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/mcp.data.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/mcp.data.ts
@@ -1,0 +1,27 @@
+import { useQueryClient } from '@tanstack/react-query'
+import { useNavigate } from 'react-router'
+import {
+  type AgentProfile,
+  useAgentProfiles,
+  useRegenerateMcpUrl,
+} from '@/modules/api/agents.hooks'
+
+export function useMcpRegistryData() {
+  const navigate = useNavigate()
+  const queryClient = useQueryClient()
+  const { data: profiles = [], isLoading } = useAgentProfiles()
+
+  const regenerate = useRegenerateMcpUrl({
+    onSuccess: ({ id, mcpUrl }) => {
+      queryClient.setQueryData<AgentProfile[]>(
+        useAgentProfiles.getKey(),
+        (prev) =>
+          (prev ?? []).map((profile) =>
+            profile.id === id ? { ...profile, mcpUrl } : profile,
+          ),
+      )
+    },
+  })
+
+  return { profiles, isLoading, regenerate, navigate }
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/mcp.helpers.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/mcp.helpers.ts
@@ -1,0 +1,21 @@
+import type { AgentProfile } from '@/modules/api/agents.hooks'
+
+/**
+ * Pulls the slug segment out of an MCP URL.
+ * `http://127.0.0.1:9000/mcp/cowork-finance-ops` -> `cowork-finance-ops`.
+ * Returns an empty string if the URL doesn't follow the `/mcp/<slug>` shape.
+ */
+export function slugFromMcpUrl(url: string): string {
+  const match = url.match(/\/mcp\/([^/?#]+)/)
+  return match?.[1] ?? ''
+}
+
+/**
+ * Mirrors `new-agent.helpers.ts`'s buildCliCommand so the directory
+ * shows the same CLI snippet the wizard's right rail printed when the
+ * profile was created.
+ */
+export function cliCommandFor(profile: AgentProfile): string {
+  const slug = slugFromMcpUrl(profile.mcpUrl) || profile.id
+  return `mcp add ${slug}`
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/replay/EventTimeline.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/replay/EventTimeline.tsx
@@ -1,0 +1,93 @@
+import { Layers } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { ReplayFrame } from '@/modules/api/replay.hooks'
+import { formatTime, KIND_STYLE, VERB_META } from './replay.helpers'
+
+interface EventTimelineProps {
+  frames: readonly ReplayFrame[]
+  currentFrameIndex: number
+  /** Seconds elapsed, used to dim frames that have not played yet. */
+  currentTime: number
+  onSeek: (seconds: number) => void
+}
+
+/**
+ * Right-rail vertical event list. Each row corresponds to one frame
+ * in the recording. Past frames are full-opacity, future frames dim,
+ * and the row matching the playhead gets an accent-tint background.
+ * Clicking a row seeks the player to that frame.
+ */
+export function EventTimeline({
+  frames,
+  currentFrameIndex,
+  currentTime,
+  onSeek,
+}: EventTimelineProps) {
+  return (
+    <aside className="flex w-[320px] shrink-0 flex-col border-border border-l bg-card">
+      <header className="flex items-center gap-1.5 border-border border-b px-4 py-3 font-bold text-ink text-sm">
+        <Layers className="size-3.5 text-ink-3" />
+        Action timeline
+      </header>
+      <div className="flex flex-1 flex-col overflow-y-auto px-3 py-2">
+        {frames.map((frame, i) => {
+          const seen = frame.t <= currentTime + 0.001
+          const isCurrent = i === currentFrameIndex
+          const verb = VERB_META[frame.verb]
+          const kind = KIND_STYLE[frame.kind]
+          const showConnector = i < frames.length - 1
+          return (
+            <button
+              type="button"
+              key={`frame-${frame.kind}-${frame.verb}-${frame.t}`}
+              onClick={() => onSeek(frame.t)}
+              className={cn(
+                'flex gap-3 rounded-lg p-2.5 text-left transition-opacity',
+                isCurrent && 'bg-accent-tint',
+                seen ? 'opacity-100' : 'opacity-50',
+              )}
+            >
+              <div className="flex shrink-0 flex-col items-center">
+                <span
+                  className={cn(
+                    'flex size-6 items-center justify-center rounded-md',
+                    kind.tileBgClass,
+                    kind.tileFgClass,
+                  )}
+                >
+                  <verb.Icon className="size-3" />
+                </span>
+                {showConnector && (
+                  <span aria-hidden className="mt-1 w-px flex-1 bg-border-2" />
+                )}
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-2">
+                  <span className="font-semibold text-ink text-xs">
+                    {verb.label}
+                  </span>
+                  <span className="ml-auto font-mono text-[10.5px] text-ink-3">
+                    {formatTime(frame.t)}
+                  </span>
+                </div>
+                <p className="mt-0.5 text-ink-2 text-xs leading-snug">
+                  {frame.caption}
+                </p>
+                {frame.note && (
+                  <span
+                    className={cn(
+                      'mt-1 inline-block rounded-full px-2 py-0.5 font-bold text-[10px]',
+                      kind.noteClass,
+                    )}
+                  >
+                    {frame.note}
+                  </span>
+                )}
+              </div>
+            </button>
+          )
+        })}
+      </div>
+    </aside>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/replay/PlaybackTransport.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/replay/PlaybackTransport.tsx
@@ -1,0 +1,122 @@
+import { Pause, Play, RotateCcw } from 'lucide-react'
+import type { ChangeEvent } from 'react'
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { cn } from '@/lib/utils'
+import type { ReplayFrame } from '@/modules/api/replay.hooks'
+import { formatTime, KIND_STYLE, PLAYBACK_SPEEDS } from './replay.helpers'
+import type { Playback } from './use-playback'
+
+const SCRUBBER_STEP = 0.1
+
+interface PlaybackTransportProps {
+  playback: Playback
+  totalSeconds: number
+  frames: readonly ReplayFrame[]
+}
+
+/**
+ * Play / pause + scrubber + speed picker. Non-action frames render as
+ * coloured bookmarks on the scrubber so the user can jump straight to
+ * an approval, block, or done moment.
+ */
+export function PlaybackTransport({
+  playback,
+  totalSeconds,
+  frames,
+}: PlaybackTransportProps) {
+  const { time, isPlaying, speed, setSpeed, togglePlay, seek } = playback
+  const finished = time >= totalSeconds
+  const progress = totalSeconds === 0 ? 0 : (time / totalSeconds) * 100
+
+  const onScrubberChange = (event: ChangeEvent<HTMLInputElement>) => {
+    seek(Number(event.target.value))
+  }
+
+  return (
+    <div className="rounded-2xl border border-border-2 bg-card p-3 shadow-sm">
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          onClick={togglePlay}
+          aria-label={
+            finished ? 'Restart playback' : isPlaying ? 'Pause' : 'Play'
+          }
+          className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-accent text-white shadow"
+        >
+          {finished ? (
+            <RotateCcw className="size-4" />
+          ) : isPlaying ? (
+            <Pause className="size-4" />
+          ) : (
+            <Play className="size-4" />
+          )}
+        </button>
+        <span className="w-20 shrink-0 font-mono text-ink-2 text-xs">
+          {formatTime(time)} / {formatTime(totalSeconds)}
+        </span>
+        <div className="relative flex h-7 flex-1 items-center">
+          <div className="absolute right-0 left-0 h-1.5 rounded-full bg-bg-sunken" />
+          <div
+            className="absolute left-0 h-1.5 rounded-full bg-accent transition-[width] duration-100"
+            style={{ width: `${progress}%` }}
+          />
+          {frames.map((frame) => {
+            if (frame.kind === 'action') return null
+            const pct = totalSeconds === 0 ? 0 : (frame.t / totalSeconds) * 100
+            const kind = KIND_STYLE[frame.kind]
+            return (
+              <button
+                type="button"
+                key={`bookmark-${frame.kind}-${frame.t}`}
+                title={frame.caption}
+                aria-label={`Jump to ${frame.caption}`}
+                onClick={() => seek(frame.t)}
+                style={{ left: `${pct}%` }}
+                className={cn(
+                  'absolute z-10 size-2.5 -translate-x-1/2 rounded-full border-2 border-card shadow-sm',
+                  kind.dotClass,
+                )}
+              />
+            )
+          })}
+          <span
+            aria-hidden
+            style={{ left: `${progress}%` }}
+            className="absolute z-10 size-3.5 -translate-x-1/2 rounded-full border-[2.5px] border-accent bg-card shadow"
+          />
+          <input
+            type="range"
+            aria-label="Playback position"
+            aria-valuetext={`${formatTime(time)} of ${formatTime(totalSeconds)}`}
+            min={0}
+            max={totalSeconds}
+            step={SCRUBBER_STEP}
+            value={time}
+            onChange={onScrubberChange}
+            className="absolute inset-0 z-20 h-full w-full cursor-pointer appearance-none bg-transparent opacity-0 focus-visible:opacity-100"
+          />
+        </div>
+        <ToggleGroup
+          value={[String(speed)]}
+          onValueChange={(values) => {
+            const next = Number(values[0])
+            if (Number.isFinite(next)) setSpeed(next)
+          }}
+          spacing={0}
+          variant="outline"
+          className="bg-bg-sunken p-0.5"
+        >
+          {PLAYBACK_SPEEDS.map((s) => (
+            <ToggleGroupItem
+              key={s}
+              value={String(s)}
+              className="h-7 rounded-md border-none bg-transparent px-2.5 font-bold text-ink-3 text-xs shadow-none hover:bg-transparent hover:text-ink aria-pressed:bg-card aria-pressed:text-ink aria-pressed:shadow-sm"
+            >
+              {s}×
+            </ToggleGroupItem>
+          ))}
+        </ToggleGroup>
+      </div>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/replay/Replay.tsx
@@ -1,0 +1,92 @@
+import { ArrowLeft, History } from 'lucide-react'
+import { StatusBadge } from '@/components/cockpit/StatusBadge'
+import { Spinner } from '@/components/ui/spinner'
+import { EventTimeline } from './EventTimeline'
+import { PlaybackTransport } from './PlaybackTransport'
+import { ReplayViewport } from './ReplayViewport'
+import { useReplayData } from './replay.data'
+import { frameIndexAt } from './replay.helpers'
+import { usePlayback } from './use-playback'
+
+export function Replay() {
+  const { replay, isLoading, navigate } = useReplayData()
+  const playback = usePlayback(replay?.totalSeconds ?? 0)
+
+  if (isLoading || !replay) {
+    return (
+      <div className="flex h-full flex-1 items-center justify-center bg-bg-canvas text-ink-3">
+        <Spinner />
+      </div>
+    )
+  }
+
+  const back = () => navigate('/governance/audit')
+  const currentFrameIndex = frameIndexAt(replay.frames, playback.time)
+  const currentFrame = replay.frames[currentFrameIndex]
+
+  const stats: { label: string; value: string }[] = [
+    { label: 'Duration', value: replay.duration },
+    { label: 'Tokens', value: replay.tokens },
+    { label: 'Steps', value: replay.steps },
+    { label: 'Approvals', value: replay.approvals },
+  ]
+
+  return (
+    <div className="flex h-screen min-h-0 flex-col bg-bg-canvas">
+      <header className="flex shrink-0 items-center gap-4 border-border border-b bg-card px-5 py-3">
+        <button
+          type="button"
+          onClick={back}
+          className="flex items-center gap-1.5 font-semibold text-ink-2 text-sm hover:text-ink"
+        >
+          <ArrowLeft className="size-4" />
+          Audit trail
+        </button>
+        <span className="h-5 w-px bg-border-2" />
+        <span className="inline-flex items-center gap-1.5 rounded-full bg-accent-tint px-2.5 py-0.5 font-bold text-[10.5px] text-accent-ink uppercase tracking-wider">
+          <History className="size-3" />
+          Replay
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="truncate font-bold text-ink text-sm">
+            {replay.taskTitle}
+          </div>
+          <div className="text-ink-3 text-xs">
+            {replay.agentLabel} · {replay.harness}
+            {replay.startedAt ? ` · ${replay.startedAt}` : ''}
+          </div>
+        </div>
+        <StatusBadge status={replay.status} />
+        <div className="ml-2 flex gap-5">
+          {stats.map((stat) => (
+            <div key={stat.label}>
+              <div className="font-bold text-[10px] text-ink-4 uppercase tracking-wider">
+                {stat.label}
+              </div>
+              <div className="font-bold font-mono text-ink text-sm">
+                {stat.value}
+              </div>
+            </div>
+          ))}
+        </div>
+      </header>
+
+      <div className="flex min-h-0 flex-1">
+        <div className="flex min-w-0 flex-1 flex-col gap-3 p-4">
+          <ReplayViewport site={replay.site} frame={currentFrame} />
+          <PlaybackTransport
+            playback={playback}
+            totalSeconds={replay.totalSeconds}
+            frames={replay.frames}
+          />
+        </div>
+        <EventTimeline
+          frames={replay.frames}
+          currentFrameIndex={currentFrameIndex}
+          currentTime={playback.time}
+          onSeek={playback.seek}
+        />
+      </div>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/replay/ReplayViewport.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/replay/ReplayViewport.tsx
@@ -1,0 +1,68 @@
+import { Globe, Lock } from 'lucide-react'
+import { cn } from '@/lib/utils'
+import type { ReplayFrame } from '@/modules/api/replay.hooks'
+import { KIND_STYLE, VERB_META } from './replay.helpers'
+
+interface ReplayViewportProps {
+  site: string
+  /** The frame whose caption is currently displayed. */
+  frame: ReplayFrame | undefined
+}
+
+/**
+ * Reconstructed browser viewport for the replay player. Fake site
+ * chrome at the top, tinted page region in the middle, and a caption
+ * overlay pill near the bottom that mirrors the prototype's
+ * RR-Web-style "what is happening right now" hint.
+ */
+export function ReplayViewport({ site, frame }: ReplayViewportProps) {
+  return (
+    <div className="relative flex flex-1 flex-col overflow-hidden rounded-2xl border border-border-2 bg-card shadow-sm">
+      <div className="flex h-9 shrink-0 items-center gap-2 border-border border-b bg-bg-sunken px-3">
+        <span className="flex gap-1.5">
+          <span className="size-2.5 rounded-full bg-[#FF5F57]" />
+          <span className="size-2.5 rounded-full bg-[#FEBC2E]" />
+          <span className="size-2.5 rounded-full bg-[#28C840]" />
+        </span>
+        <div className="ml-3 flex h-6 flex-1 items-center gap-2 rounded-md border border-border-2 bg-card px-3 font-mono text-ink-2 text-xs">
+          <Lock className="size-3 text-ink-3" />
+          <span className="truncate">{site}</span>
+        </div>
+        <span className="rounded-full bg-bg-sunken px-2 py-0.5 font-bold text-[10px] text-ink-3 uppercase tracking-wide">
+          recorded
+        </span>
+      </div>
+      <div className="relative flex flex-1 items-center justify-center overflow-hidden bg-[radial-gradient(circle_at_top,#fff,var(--color-bg-sunken))]">
+        <div className="flex flex-col items-center gap-3 text-ink-3">
+          <Globe className="size-12" />
+          <code className="font-mono text-sm">{site}</code>
+          <p className="max-w-xs text-center text-ink-4 text-xs">
+            Site reconstruction lands once the RR-Web recording pipeline is
+            wired.
+          </p>
+        </div>
+        {frame && <Caption frame={frame} />}
+      </div>
+    </div>
+  )
+}
+
+function Caption({ frame }: { frame: ReplayFrame }) {
+  const verb = VERB_META[frame.verb]
+  const kind = KIND_STYLE[frame.kind]
+  return (
+    <div className="absolute bottom-5 left-1/2 z-10 flex max-w-[82%] -translate-x-1/2 items-center gap-2.5 rounded-full bg-[#1B1A17]/90 px-4 py-2 shadow-xl backdrop-blur">
+      <span
+        className={cn(
+          'flex size-5 items-center justify-center rounded-md text-white',
+          kind.dotClass,
+        )}
+      >
+        <verb.Icon className="size-3" />
+      </span>
+      <span className="truncate font-semibold text-[#EDEAE2] text-xs">
+        {frame.caption}
+      </span>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/replay/replay.data.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/replay/replay.data.ts
@@ -1,0 +1,9 @@
+import { useNavigate, useParams } from 'react-router'
+import { useReplay } from '@/modules/api/replay.hooks'
+
+export function useReplayData() {
+  const { runId = '' } = useParams<{ runId: string }>()
+  const { data: replay, isLoading } = useReplay({ variables: { runId } })
+  const navigate = useNavigate()
+  return { replay, runId, isLoading, navigate }
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/replay/replay.helpers.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/replay/replay.helpers.ts
@@ -1,0 +1,91 @@
+import {
+  CheckCircle2,
+  Compass,
+  Eye,
+  type LucideIcon,
+  MousePointer,
+  Paperclip,
+  Send,
+  Type,
+} from 'lucide-react'
+import type {
+  ReplayFrame,
+  ReplayKind,
+  ReplayVerb,
+} from '@/modules/api/replay.hooks'
+
+export interface VerbMeta {
+  label: string
+  Icon: LucideIcon
+  /** Tailwind class for non-bookmarked verb icon. */
+  iconClass: string
+}
+
+export const VERB_META: Record<ReplayVerb, VerbMeta> = {
+  navigate: { label: 'Navigate', Icon: Compass, iconClass: 'text-blue' },
+  read: { label: 'Read', Icon: Eye, iconClass: 'text-ink-3' },
+  click: { label: 'Click', Icon: MousePointer, iconClass: 'text-ink-2' },
+  type: { label: 'Type', Icon: Type, iconClass: 'text-ink-2' },
+  attach: { label: 'Attach', Icon: Paperclip, iconClass: 'text-ink-2' },
+  submit: { label: 'Submit', Icon: Send, iconClass: 'text-accent-ink' },
+  done: { label: 'Done', Icon: CheckCircle2, iconClass: 'text-green' },
+}
+
+interface KindStyle {
+  /** Solid color for scrubber bookmarks and the caption overlay glyph. */
+  dotClass: string
+  /** Tinted background for the timeline-row icon tile. */
+  tileBgClass: string
+  /** Foreground colour for the timeline-row icon tile. */
+  tileFgClass: string
+  /** Tinted background + colour for the trailing note pill. */
+  noteClass: string
+}
+
+export const KIND_STYLE: Record<ReplayKind, KindStyle> = {
+  action: {
+    dotClass: 'bg-ink-4',
+    tileBgClass: 'bg-bg-sunken',
+    tileFgClass: 'text-ink-2',
+    noteClass: 'bg-bg-sunken text-ink-3',
+  },
+  approval: {
+    dotClass: 'bg-accent',
+    tileBgClass: 'bg-accent-tint',
+    tileFgClass: 'text-accent-ink',
+    noteClass: 'bg-accent-tint text-accent-ink',
+  },
+  block: {
+    dotClass: 'bg-red',
+    tileBgClass: 'bg-red-tint',
+    tileFgClass: 'text-red',
+    noteClass: 'bg-red-tint text-red',
+  },
+  done: {
+    dotClass: 'bg-green',
+    tileBgClass: 'bg-green-tint',
+    tileFgClass: 'text-green',
+    noteClass: 'bg-green-tint text-green',
+  },
+}
+
+export function formatTime(seconds: number): string {
+  const safe = Math.max(0, seconds)
+  const m = Math.floor(safe / 60)
+  const s = Math.floor(safe % 60)
+  return `${m}:${String(s).padStart(2, '0')}`
+}
+
+/** Last frame whose `t` is at or before `time`. Falls back to 0. */
+export function frameIndexAt(
+  frames: readonly ReplayFrame[],
+  time: number,
+): number {
+  let idx = 0
+  for (let i = 0; i < frames.length; i++) {
+    if (frames[i].t <= time + 0.001) idx = i
+  }
+  return idx
+}
+
+export const PLAYBACK_SPEEDS: readonly number[] = [1, 2, 4]

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/replay/use-playback.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/replay/use-playback.ts
@@ -1,0 +1,57 @@
+import { useEffect, useState } from 'react'
+import { PLAYBACK_SPEEDS } from './replay.helpers'
+
+export interface Playback {
+  /** Seconds elapsed in the session. */
+  time: number
+  /** True while the wallclock timer is advancing. */
+  isPlaying: boolean
+  /** Multiplier applied to the 100ms tick. Always one of `PLAYBACK_SPEEDS`. */
+  speed: number
+  setSpeed: (next: number) => void
+  /** Toggles play/pause. Restarts from 0 if the session already finished. */
+  togglePlay: () => void
+  /** Jumps the playhead to `seconds` (clamped to [0, totalSeconds]). */
+  seek: (seconds: number) => void
+}
+
+const TICK_MS = 100
+
+export function usePlayback(totalSeconds: number): Playback {
+  const [time, setTime] = useState(0)
+  const [isPlaying, setIsPlaying] = useState(true)
+  const [speed, setSpeed] = useState<number>(PLAYBACK_SPEEDS[0])
+
+  // External wall-clock timer: starting/cancelling setInterval is one of
+  // the cases the project conventions still allow useEffect for.
+  useEffect(() => {
+    if (!isPlaying || totalSeconds === 0) return
+    const id = window.setInterval(() => {
+      setTime((prev) => {
+        const next = prev + (TICK_MS / 1000) * speed
+        if (next >= totalSeconds) {
+          setIsPlaying(false)
+          return totalSeconds
+        }
+        return next
+      })
+    }, TICK_MS)
+    return () => window.clearInterval(id)
+  }, [isPlaying, speed, totalSeconds])
+
+  const togglePlay = () => {
+    if (time >= totalSeconds) {
+      setTime(0)
+      setIsPlaying(true)
+      return
+    }
+    setIsPlaying((p) => !p)
+  }
+
+  const seek = (seconds: number) => {
+    const clamped = Math.max(0, Math.min(totalSeconds, seconds))
+    setTime(clamped)
+  }
+
+  return { time, isPlaying, speed, setSpeed, togglePlay, seek }
+}

--- a/packages/browseros-agent/biome.json
+++ b/packages/browseros-agent/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -6,7 +6,7 @@
       "name": "browseros-monorepo",
       "devDependencies": {
         "@aws-sdk/client-s3": "^3.933.0",
-        "@biomejs/biome": "2.4.8",
+        "@biomejs/biome": "2.5.0",
         "@sentry/cli": "^2.42.2",
         "@types/bun": "^1.3.5",
         "@types/node": "^24.3.3",
@@ -472,23 +472,23 @@
 
     "@better-fetch/fetch": ["@better-fetch/fetch@1.1.21", "", {}, "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.8", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.8", "@biomejs/cli-darwin-x64": "2.4.8", "@biomejs/cli-linux-arm64": "2.4.8", "@biomejs/cli-linux-arm64-musl": "2.4.8", "@biomejs/cli-linux-x64": "2.4.8", "@biomejs/cli-linux-x64-musl": "2.4.8", "@biomejs/cli-win32-arm64": "2.4.8", "@biomejs/cli-win32-x64": "2.4.8" }, "bin": { "biome": "bin/biome" } }, "sha512-ponn0oKOky1oRXBV+rlSaUlixUxf1aZvWC19Z41zBfUOUesthrQqL3OtiAlSB1EjFjyWpn98Q64DHelhA6jNlA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.0", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.0", "@biomejs/cli-darwin-x64": "2.5.0", "@biomejs/cli-linux-arm64": "2.5.0", "@biomejs/cli-linux-arm64-musl": "2.5.0", "@biomejs/cli-linux-x64": "2.5.0", "@biomejs/cli-linux-x64-musl": "2.5.0", "@biomejs/cli-win32-arm64": "2.5.0", "@biomejs/cli-win32-x64": "2.5.0" }, "bin": { "biome": "bin/biome" } }, "sha512-4kURkd9hAPrdDM3C9n82ycYgx8hvQcW6MjKTEejruj8rK0N8P3OPpdy8BvI8kt3KWY4ycF5XtDOrktetEfhfuw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ARx0tECE8I7S2C2yjnWYLNbBdDoPdq3oyNLhMglmuctThwUsuzFWRKrHmIGwIRWKz0Mat9DuzLEDp52hGnrxGQ=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Mn3Fwi3SA5fgmfCPqmzpWF2DLZnms3BVAhM088nTnGrTZmHS3wwIjcoZPqpXeNgd3DrrLH6xp8vTLIBuJoZiXw=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-Jg9/PsB9vDCJlANE8uhG7qDhb5w0Ix69D7XIIc8IfZPUoiPrbLm33k2Ig3NOJ/7nb3UbesFz3D1aDKm9DvzjhQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-rg3VPL5P8mYro6pqlXYXuJWph21slVp3SZtAqWSrkZs40d2gTzYmHF8E/X1iTID25btmNKltNDJ926sqVBp7DQ=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-5CdrsJct76XG2hpKFwXnEtlT1p+4g4yV+XvvwBpzKsTNLO9c6iLlAxwcae2BJ7ekPGWjNGw9j09T5KGPKKxQig=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tl+LW8fdD96/xdeWtWwc82LIOc5CoY7N2AsogLTp5R4ECErYt+8Jl/N68ezN9vzSiqPTxw6vjcihoLPYKZHrlw=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-Zo9OhBQDJ3IBGPlqHiTISloo5H0+FBIpemqIJdW/0edJ+gEcLR+MZeZozcUyz3o1nXkVA7++DdRKQT0599j9jA=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-vQdM4oSGaf7ZNeGO9w5+Y8SBtyser9M6znxYbm7Ec8wInxJu1WiKxFYZW5Auj2d80bcVvefuGGRxoFOE0eee8g=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.8", "", { "os": "linux", "cpu": "x64" }, "sha512-PdKXspVEaMCQLjtZCn6vfSck/li4KX9KGwSDbZdgIqlrizJ2MnMcE3TvHa2tVfXNmbjMikzcfJpuPWH695yJrw=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-zpEGf4RQbFEh8Vt7OmavLyyOzRbtcE9osCqrS1kfvt8jDvxwhKXLSf7n0ebr/ov0RJ9ssP+lhs6C8a9WwFvrQA=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.8", "", { "os": "linux", "cpu": "x64" }, "sha512-Gi8quv8MEuDdKaPFtS2XjEnMqODPsRg6POT6KhoP+VrkNb+T2ywunVB+TvOU0LX1jAZzfBr+3V1mIbBhzAMKvw=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-+9hIcMngJ+yGUahXqZuZ8CoWKJE9SAZsFsM3QDvXpNsLbXZ9lqVzgBhOk/jTSYkOA0GLP9eu3teukqpLUojHMg=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-LoFatS0tnHv6KkCVpIy3qZCih+MxUMvdYiPWLHRri7mhi2vyOOs8OrbZBcLTUEWCS+ktO72nZMy4F96oMhkOHQ=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-jB0wAvTLI4itx5VidqVUejPQFhRUxiZ9l9FvZ26D5fl6t3qme+ZB4PD3bTSeL1vZ8NI2Rx/zj6H9zcESuGHKGw=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.8", "", { "os": "win32", "cpu": "x64" }, "sha512-vAn7iXDoUbqFXqVocuq1sMYAd33p8+mmurqJkWl6CtIhobd/O6moe4rY5AJvzbunn/qZCdiDVcveqtkFh1e7Hg=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VT/lF+GId+67j8aDfLkxdxNoVApsPSTbyAtB3jJq0IWTrY77WXfbPfpngxq0bA6JCEv/7k8C9qWjDRKRznDlyw=="],
 
     "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.1", "", {}, "sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw=="],
 

--- a/packages/browseros-agent/package.json
+++ b/packages/browseros-agent/package.json
@@ -55,7 +55,7 @@
   "homepage": "https://github.com/browseros-ai/BrowserOS#readme",
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.933.0",
-    "@biomejs/biome": "2.4.8",
+    "@biomejs/biome": "2.5.0",
     "@sentry/cli": "^2.42.2",
     "@types/bun": "^1.3.5",
     "@types/node": "^24.3.3",


### PR DESCRIPTION
## Summary

Builds out the next three cockpit surfaces on top of the cockpit-foundation PR. Five user-visible changes ship here:

- **Replay view** (`/governance/audit/:runId/replay`) — full-bleed RR-Web-style player that sits outside the CockpitShell. Top bar shows the task, agent, harness, status pill, and a stat strip (duration / tokens / steps / approvals). Body is a reconstructed browser viewport with a caption pill that tracks the playhead, a transport (play / pause / restart + scrubber with kind-coloured bookmark dots for approval / block / done frames + 1x / 2x / 4x speed toggle), and a right-rail Action Timeline whose rows highlight the current frame, dim future frames, and click-to-seek. Scrubber is a real `<input type="range">` styled transparently over the visual track so native click, drag, arrow keys, and aria semantics ship for free. Playback wallclock lives in a `usePlayback` hook (the project's one allowed `useEffect`, justified by an external `setInterval`).
- **Agents directory** (`/agents`) — replaces the placeholder. Header with configured-count pill and a primary Add agent CTA that lands the user on `/agents/new`; body renders one row per profile with the harness icon chip, name + harness, scope summary (logins, ACL rules, blocked actions, always-allow grants), last-run timestamp, status badge (Configured / Paused / Disabled), and Edit + Revoke buttons. Revoke runs through a shadcn `AlertDialog` (not `window.confirm`) so focus trapping and ARIA semantics ship for free. `useDeleteAgent`'s `onSuccess` writes back to the `agent-profiles` cache via `setQueryData` so the row vanishes immediately without a refetch.
- **MCP registry** (`/mcp`) — replaces the placeholder. Reads every configured profile from `useAgentProfiles` and renders one card per profile: harness chip + name + harness, slug + CLI hint, status pill, the dark URL block with a copy button that flips to a check icon for 1.5s, and a Regenerate URL + Add to {harness} button pair. `useRegenerateMcpUrl` rotates the slug and writes the new URL straight into the `agent-profiles` cache.
- **Accessibility polish** — global `@media (prefers-reduced-motion: reduce)` block in `styles.css` that collapses every animation and transition to a 0.01ms no-op (WCAG 2.3.3, covers pulse-dot live indicators, sidebar expand, replay scrubber, etc.). `CockpitShell` unmount cleanup now snapshots the timeout ref object into a stable local before closing over it, the React docs' canonical pattern for refs in effects. Both fixes close out the only react-doctor findings inherited from the cockpit foundation; the score moves from 74/100 with 2 findings to 100/100 with 0 findings.
- **Selection readability** — `::selection` now pins the foreground to ink alongside the accent-tint background so light-on-dark surfaces (MCP URL block, live-run caption pill, replay caption) stay readable when text is selected.

## Stack additions

- shadcn primitives added: `alert-dialog`.
- No new runtime deps. All mutations are mocked behind `react-query-kit`'s `createMutation` and write back to their respective cache keys via `setQueryData` to match the project's no-parallel-state-over-cache rule.

## Test plan

- [ ] `bun --cwd apps/agent-mcp-ui dev` and click any cockpit Watch button to land on a live run.
- [ ] Open `/governance/audit` and click a row's Replay action. Confirm the player opens full-bleed, the scrubber + bookmark dots track playback, 1x / 2x / 4x changes speed, clicking a timeline row seeks, and the caption pill in the viewport updates per frame. Arrow keys on the scrubber step the playhead.
- [ ] Open `/agents`. Confirm seven mock rows render with mixed statuses, Add agent routes to `/agents/new`, and Revoke opens an AlertDialog that removes the row on confirm (the row should vanish without a network refetch in dev tools).
- [ ] Open `/mcp`. Confirm copy button flips to a check for 1.5s, Regenerate URL rotates the dark URL block and the new slug persists, Add to {harness} flips into a brief Added confirmation.
- [ ] Toggle macOS / Chrome's reduce-motion preference and confirm pulse-dot indicators stop pulsing.
- [ ] Select text in the dark MCP URL block; confirm the selected characters stay visible (the earlier bug where they vanished into the highlight is fixed).

## Out of scope (deferred)

- `/agents/:id/edit` route. The Edit button navigates there but the route isn't wired yet; lands when the new-agent wizard grows a `mode: 'create' | 'edit'` prop.
- Per-harness `/mcp/setup-claude` / `/mcp/setup-codex` step-by-step helpers. Marked optional in the plan, slated to land with onboarding.
- Onboarding flow at `/onboarding`. Slice G in the running plan.
- Governance Permissions / Site Rules / Grants tabs (still ComingSoonTab).
- Live SSE wire-up. Every hook is mocked behind a `react-query-kit` `createQuery` / `createMutation` whose body is the only thing that has to change when the backend route lands.