### PR TITLE
chore: clear biome ci debt

### DIFF
--- a/packages/browseros-agent/apps/agent/biome.json
+++ b/packages/browseros-agent/apps/agent/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "root": false,
   "extends": "//",
   "vcs": {

--- a/packages/browseros-agent/apps/agent/lib/sentry/sanitize.ts
+++ b/packages/browseros-agent/apps/agent/lib/sentry/sanitize.ts
@@ -46,8 +46,8 @@ function sanitize<T>(obj: T): T {
   return obj
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Sentry event type varies by SDK
 export function sanitizeEvent<E>(event: E): E {
+  // biome-ignore lint/suspicious/noExplicitAny: Sentry event type varies by SDK
   const e = event as Record<string, any>
 
   if (Array.isArray(e.breadcrumbs)) {

--- a/packages/browseros-agent/apps/agent/lib/tool-labels.ts
+++ b/packages/browseros-agent/apps/agent/lib/tool-labels.ts
@@ -277,8 +277,8 @@ function canonicalName(rawName: string): string {
 function humanizeToolName(rawName: string): string {
   const stripped = canonicalName(rawName)
   const words = stripped.split(/[_-]/).filter((w) => w.length > 0)
-  if (words.length === 0) return rawName
-  const first = words[0]!
+  const first = words[0]
+  if (!first) return rawName
   return [
     first.charAt(0).toUpperCase() + first.slice(1),
     ...words.slice(1),

--- a/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatError.tsx
+++ b/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatError.tsx
@@ -140,7 +140,7 @@ export const ChatError: FC<ChatErrorProps> = ({
             rel="noopener noreferrer"
             className="underline hover:text-foreground"
           >
-            Learn more
+            About daily limits
           </a>
           {' or '}
           <a

--- a/packages/browseros-agent/apps/eval/src/agents/orchestrated/backends/clado/clado-action-executor.ts
+++ b/packages/browseros-agent/apps/eval/src/agents/orchestrated/backends/clado/clado-action-executor.ts
@@ -77,6 +77,7 @@ export class CladoActionExecutor {
     await this.mcpClient.close()
   }
 
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: action-loop orchestration; refactor tracked separately
   async execute(
     instruction: string,
     signal?: AbortSignal,

--- a/packages/browseros-agent/apps/eval/src/agents/single-agent.ts
+++ b/packages/browseros-agent/apps/eval/src/agents/single-agent.ts
@@ -8,7 +8,7 @@ import { Browser } from '@browseros/server/browser'
 import { CdpBackend } from '@browseros/server/browser/backends/cdp'
 import { CaptchaWaiter } from '../capture/captcha-waiter'
 import { DEFAULT_TIMEOUT_MS } from '../constants'
-import type { TaskMetadata, TokenUsage } from '../types'
+import type { TaskMetadata, TokenUsage, UIMessageStreamEvent } from '../types'
 import { extractDatasetMetadata } from '../utils/dataset-metadata'
 import { resolveProviderConfig } from '../utils/resolve-provider-config'
 import {
@@ -148,12 +148,12 @@ export class SingleAgentEvaluator implements AgentEvaluator {
               addTokenUsageFromAiSdkStep(tokenUsage, step)
               if (toolCalls) {
                 for (const tc of toolCalls) {
-                  const inputEvent = {
+                  const inputEvent: UIMessageStreamEvent = {
                     type: 'tool-input-available',
                     toolCallId: tc.toolCallId,
                     toolName: tc.toolName,
                     input: tc.input,
-                  } as any
+                  }
                   await capture.messageLogger.logStreamEvent(inputEvent)
                   capture.emitEvent(task.query_id, inputEvent)
                 }
@@ -161,11 +161,11 @@ export class SingleAgentEvaluator implements AgentEvaluator {
 
               if (toolResults) {
                 for (const tr of toolResults) {
-                  const outputEvent = {
+                  const outputEvent: UIMessageStreamEvent = {
                     type: 'tool-output-available',
                     toolCallId: tr.toolCallId,
                     output: tr.output,
-                  } as any
+                  }
                   const screenshot = screenshotByToolCallId.get(tr.toolCallId)
                   await capture.messageLogger.logStreamEvent(
                     outputEvent,
@@ -183,13 +183,19 @@ export class SingleAgentEvaluator implements AgentEvaluator {
 
               if (text) {
                 const textId = randomUUID()
-                const startEvent = { type: 'text-start', id: textId } as any
-                const deltaEvent = {
+                const startEvent: UIMessageStreamEvent = {
+                  type: 'text-start',
+                  id: textId,
+                }
+                const deltaEvent: UIMessageStreamEvent = {
                   type: 'text-delta',
                   id: textId,
                   delta: text,
-                } as any
-                const endEvent = { type: 'text-end', id: textId } as any
+                }
+                const endEvent: UIMessageStreamEvent = {
+                  type: 'text-end',
+                  id: textId,
+                }
                 await capture.messageLogger.logStreamEvent(startEvent)
                 await capture.messageLogger.logStreamEvent(deltaEvent)
                 await capture.messageLogger.logStreamEvent(endEvent)

--- a/packages/browseros-agent/apps/eval/src/runs/task-run-pipeline.ts
+++ b/packages/browseros-agent/apps/eval/src/runs/task-run-pipeline.ts
@@ -79,6 +79,7 @@ class TaskRunPipeline {
     return 1
   }
 
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: task-run orchestration; refactor tracked separately
   async execute(task: Task): Promise<TaskResult> {
     const startTime = Date.now()
     const mcpUrl = `${this.config.browseros.server_url}/mcp`

--- a/packages/browseros-agent/apps/eval/tests/capture/captcha-waiter.test.ts
+++ b/packages/browseros-agent/apps/eval/tests/capture/captcha-waiter.test.ts
@@ -1,17 +1,18 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import type { Browser } from '@browseros/server/browser'
 import { CaptchaWaiter } from '../../src/capture/captcha-waiter'
 
 function createMockBrowser(
   evaluateResults: Array<{ value?: unknown; error?: string }>,
-) {
+): Browser {
   let callIndex = 0
   return {
     evaluate: mock(async (_page: number, _expr: string) => {
-      const result = evaluateResults[callIndex] ?? evaluateResults.at(-1)!
+      const result = evaluateResults[callIndex] ?? evaluateResults.at(-1)
       callIndex++
       return result
     }),
-  } as any
+  } as unknown as Browser
 }
 
 describe('CaptchaWaiter', () => {
@@ -113,7 +114,7 @@ describe('CaptchaWaiter', () => {
       evaluate: mock(async () => {
         throw new Error('Connection lost')
       }),
-    } as any
+    } as unknown as Browser
 
     const result = await waiter.waitIfCaptchaPresent(browser, 1)
 

--- a/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/chat-service.ts
@@ -43,6 +43,7 @@ export interface ChatServiceDeps {
 export class ChatService {
   constructor(private deps: ChatServiceDeps) {}
 
+  // biome-ignore lint/complexity/noExcessiveCognitiveComplexity: chat request orchestration; refactor tracked separately
   async processMessage(
     request: ChatRequest,
     abortSignal: AbortSignal,

--- a/packages/browseros-agent/apps/server/src/lib/agents/host-acp/binary-resolver.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/host-acp/binary-resolver.ts
@@ -184,7 +184,7 @@ async function lookupWithCommand(
   const result = await runCommand(cmd, args, { env, timeoutMs }).catch(
     () => null,
   )
-  if (!result || result.exitCode !== 0) return null
+  if (result?.exitCode !== 0) return null
   return firstOutputPath(result.stdout)
 }
 

--- a/packages/browseros-agent/apps/server/src/lib/agents/host-acp/detection.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/host-acp/detection.ts
@@ -239,7 +239,7 @@ async function probeVersion(
     env: binary.env,
     timeoutMs,
   }).catch(() => null)
-  if (!result || result.exitCode !== 0) return { ok: false }
+  if (result?.exitCode !== 0) return { ok: false }
   const firstLine = result.stdout.trim().split(/\r?\n/)[0]?.trim()
   return {
     ok: true,

--- a/packages/browseros-agent/apps/server/src/lib/agents/turns/active-turn-registry.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/turns/active-turn-registry.ts
@@ -327,8 +327,10 @@ export class TurnRegistry {
         const pump = async () => {
           try {
             while (true) {
-              while (pendingFrames.length > 0) {
-                controller.enqueue(pendingFrames.shift()!)
+              let nextFrame = pendingFrames.shift()
+              while (nextFrame !== undefined) {
+                controller.enqueue(nextFrame)
+                nextFrame = pendingFrames.shift()
               }
               if (turn.status !== 'running' && pendingFrames.length === 0) {
                 break

--- a/packages/browseros-agent/apps/server/src/lib/clients/oauth/callback-server.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/oauth/callback-server.ts
@@ -84,7 +84,10 @@ export class OAuthCallbackServer {
   }
 
   private bind(): void {
-    const tokenManager = this.tokenManager!
+    const tokenManager = this.tokenManager
+    if (!tokenManager) {
+      throw new Error('OAuth callback server not initialized')
+    }
 
     this.server = Bun.serve({
       port: OAUTH_CALLBACK_PORT,

--- a/packages/browseros-agent/apps/server/tests/agent/acp-instructions/managedBlock.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/acp-instructions/managedBlock.test.ts
@@ -98,7 +98,8 @@ describe('spliceManagedBlock', () => {
     const userBottom = '\n\n## addendum from me\nmore content.\n'
     const source = userTop + oldBlock + userBottom
 
-    const block = findManagedBlock(source)!
+    const block = findManagedBlock(source)
+    if (!block) throw new Error('expected managed block in fixture')
     const fresh = renderManagedBlock('new body', 'newhash')
     const next = spliceManagedBlock(source, block, fresh)
 

--- a/packages/browseros-agent/apps/server/tests/lib/agents/active-turn-registry.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/active-turn-registry.test.ts
@@ -93,7 +93,8 @@ describe('TurnRegistry', () => {
       stream: 'output',
     })
 
-    const stream = registry.subscribe(turn.turnId, { fromSeq: -1 })!
+    const stream = registry.subscribe(turn.turnId, { fromSeq: -1 })
+    if (!stream) throw new Error('expected subscribe to return a stream')
     // Push more after subscribe — both buffered and live frames should
     // arrive in order.
     registry.pushEvent(turn.turnId, {
@@ -123,7 +124,8 @@ describe('TurnRegistry', () => {
     }
     registry.pushEvent(turn.turnId, { type: 'done', stopReason: 'end_turn' })
 
-    const stream = registry.subscribe(turn.turnId, { fromSeq: 2 })!
+    const stream = registry.subscribe(turn.turnId, { fromSeq: 2 })
+    if (!stream) throw new Error('expected subscribe to return a stream')
     const frames = await collect(stream)
     expect(frames.map((f) => f.seq)).toEqual([3, 4])
   })
@@ -131,7 +133,8 @@ describe('TurnRegistry', () => {
   it('marks status `cancelled` and emits a synthetic terminal on cancel', async () => {
     const registry = makeRegistry()
     const turn = registry.register('agent-1')
-    const stream = registry.subscribe(turn.turnId, { fromSeq: -1 })!
+    const stream = registry.subscribe(turn.turnId, { fromSeq: -1 })
+    if (!stream) throw new Error('expected subscribe to return a stream')
 
     registry.pushEvent(turn.turnId, {
       type: 'text_delta',

--- a/packages/browseros-agent/biome.json
+++ b/packages/browseros-agent/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.8/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.0/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/packages/browseros-agent/biome.json
+++ b/packages/browseros-agent/biome.json
@@ -7,7 +7,7 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "includes": ["**", "!**/apps/eval/src/dashboard/index.html"]
+    "includes": ["**", "!**/apps/eval/src/dashboard/index.html", "!**/*.svg"]
   },
   "formatter": {
     "enabled": true,
@@ -50,16 +50,6 @@
     }
   },
   "overrides": [
-    {
-      "includes": ["**/*.svg"],
-      "linter": {
-        "rules": {
-          "a11y": {
-            "noSvgWithoutTitle": "off"
-          }
-        }
-      }
-    },
     {
       "includes": ["**/apps/eval/src/dashboard/viewer.html"],
       "linter": {

--- a/packages/browseros-agent/biome.json
+++ b/packages/browseros-agent/biome.json
@@ -63,6 +63,16 @@
           }
         }
       }
+    },
+    {
+      "includes": ["**/scripts/dev/inspect-ui.ts"],
+      "linter": {
+        "rules": {
+          "complexity": {
+            "noExcessiveCognitiveComplexity": "off"
+          }
+        }
+      }
     }
   ]
 }

--- a/packages/browseros-agent/biome.json
+++ b/packages/browseros-agent/biome.json
@@ -48,5 +48,31 @@
         "organizeImports": "on"
       }
     }
-  }
+  },
+  "overrides": [
+    {
+      "includes": ["**/*.svg"],
+      "linter": {
+        "rules": {
+          "a11y": {
+            "noSvgWithoutTitle": "off"
+          }
+        }
+      }
+    },
+    {
+      "includes": ["**/apps/eval/src/dashboard/viewer.html"],
+      "linter": {
+        "rules": {
+          "a11y": {
+            "useValidAnchor": "off"
+          },
+          "complexity": {
+            "noExcessiveCognitiveComplexity": "off",
+            "useOptionalChain": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -6,7 +6,7 @@
       "name": "browseros-monorepo",
       "devDependencies": {
         "@aws-sdk/client-s3": "^3.933.0",
-        "@biomejs/biome": "2.4.8",
+        "@biomejs/biome": "2.5.0",
         "@sentry/cli": "^2.42.2",
         "@types/bun": "^1.3.5",
         "@types/node": "^24.3.3",
@@ -401,23 +401,23 @@
 
     "@better-fetch/fetch": ["@better-fetch/fetch@1.1.21", "", {}, "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="],
 
-    "@biomejs/biome": ["@biomejs/biome@2.4.8", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.4.8", "@biomejs/cli-darwin-x64": "2.4.8", "@biomejs/cli-linux-arm64": "2.4.8", "@biomejs/cli-linux-arm64-musl": "2.4.8", "@biomejs/cli-linux-x64": "2.4.8", "@biomejs/cli-linux-x64-musl": "2.4.8", "@biomejs/cli-win32-arm64": "2.4.8", "@biomejs/cli-win32-x64": "2.4.8" }, "bin": { "biome": "bin/biome" } }, "sha512-ponn0oKOky1oRXBV+rlSaUlixUxf1aZvWC19Z41zBfUOUesthrQqL3OtiAlSB1EjFjyWpn98Q64DHelhA6jNlA=="],
+    "@biomejs/biome": ["@biomejs/biome@2.5.0", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "2.5.0", "@biomejs/cli-darwin-x64": "2.5.0", "@biomejs/cli-linux-arm64": "2.5.0", "@biomejs/cli-linux-arm64-musl": "2.5.0", "@biomejs/cli-linux-x64": "2.5.0", "@biomejs/cli-linux-x64-musl": "2.5.0", "@biomejs/cli-win32-arm64": "2.5.0", "@biomejs/cli-win32-x64": "2.5.0" }, "bin": { "biome": "bin/biome" } }, "sha512-4kURkd9hAPrdDM3C9n82ycYgx8hvQcW6MjKTEejruj8rK0N8P3OPpdy8BvI8kt3KWY4ycF5XtDOrktetEfhfuw=="],
 
-    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.4.8", "", { "os": "darwin", "cpu": "arm64" }, "sha512-ARx0tECE8I7S2C2yjnWYLNbBdDoPdq3oyNLhMglmuctThwUsuzFWRKrHmIGwIRWKz0Mat9DuzLEDp52hGnrxGQ=="],
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@2.5.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Mn3Fwi3SA5fgmfCPqmzpWF2DLZnms3BVAhM088nTnGrTZmHS3wwIjcoZPqpXeNgd3DrrLH6xp8vTLIBuJoZiXw=="],
 
-    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.4.8", "", { "os": "darwin", "cpu": "x64" }, "sha512-Jg9/PsB9vDCJlANE8uhG7qDhb5w0Ix69D7XIIc8IfZPUoiPrbLm33k2Ig3NOJ/7nb3UbesFz3D1aDKm9DvzjhQ=="],
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@2.5.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-rg3VPL5P8mYro6pqlXYXuJWph21slVp3SZtAqWSrkZs40d2gTzYmHF8E/X1iTID25btmNKltNDJ926sqVBp7DQ=="],
 
-    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.4.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-5CdrsJct76XG2hpKFwXnEtlT1p+4g4yV+XvvwBpzKsTNLO9c6iLlAxwcae2BJ7ekPGWjNGw9j09T5KGPKKxQig=="],
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@2.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-tl+LW8fdD96/xdeWtWwc82LIOc5CoY7N2AsogLTp5R4ECErYt+8Jl/N68ezN9vzSiqPTxw6vjcihoLPYKZHrlw=="],
 
-    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.4.8", "", { "os": "linux", "cpu": "arm64" }, "sha512-Zo9OhBQDJ3IBGPlqHiTISloo5H0+FBIpemqIJdW/0edJ+gEcLR+MZeZozcUyz3o1nXkVA7++DdRKQT0599j9jA=="],
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@2.5.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-vQdM4oSGaf7ZNeGO9w5+Y8SBtyser9M6znxYbm7Ec8wInxJu1WiKxFYZW5Auj2d80bcVvefuGGRxoFOE0eee8g=="],
 
-    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.4.8", "", { "os": "linux", "cpu": "x64" }, "sha512-PdKXspVEaMCQLjtZCn6vfSck/li4KX9KGwSDbZdgIqlrizJ2MnMcE3TvHa2tVfXNmbjMikzcfJpuPWH695yJrw=="],
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@2.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-zpEGf4RQbFEh8Vt7OmavLyyOzRbtcE9osCqrS1kfvt8jDvxwhKXLSf7n0ebr/ov0RJ9ssP+lhs6C8a9WwFvrQA=="],
 
-    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.4.8", "", { "os": "linux", "cpu": "x64" }, "sha512-Gi8quv8MEuDdKaPFtS2XjEnMqODPsRg6POT6KhoP+VrkNb+T2ywunVB+TvOU0LX1jAZzfBr+3V1mIbBhzAMKvw=="],
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@2.5.0", "", { "os": "linux", "cpu": "x64" }, "sha512-+9hIcMngJ+yGUahXqZuZ8CoWKJE9SAZsFsM3QDvXpNsLbXZ9lqVzgBhOk/jTSYkOA0GLP9eu3teukqpLUojHMg=="],
 
-    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.4.8", "", { "os": "win32", "cpu": "arm64" }, "sha512-LoFatS0tnHv6KkCVpIy3qZCih+MxUMvdYiPWLHRri7mhi2vyOOs8OrbZBcLTUEWCS+ktO72nZMy4F96oMhkOHQ=="],
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@2.5.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-jB0wAvTLI4itx5VidqVUejPQFhRUxiZ9l9FvZ26D5fl6t3qme+ZB4PD3bTSeL1vZ8NI2Rx/zj6H9zcESuGHKGw=="],
 
-    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.8", "", { "os": "win32", "cpu": "x64" }, "sha512-vAn7iXDoUbqFXqVocuq1sMYAd33p8+mmurqJkWl6CtIhobd/O6moe4rY5AJvzbunn/qZCdiDVcveqtkFh1e7Hg=="],
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.5.0", "", { "os": "win32", "cpu": "x64" }, "sha512-VT/lF+GId+67j8aDfLkxdxNoVApsPSTbyAtB3jJq0IWTrY77WXfbPfpngxq0bA6JCEv/7k8C9qWjDRKRznDlyw=="],
 
     "@braintree/sanitize-url": ["@braintree/sanitize-url@7.1.1", "", {}, "sha512-i1L7noDNxtFyL5DmZafWy1wRVhGehQmzZaz1HiN5e7iylJMSZR7ekOV7NsIqa5qBldlLrsKv4HbgFUVlQrz8Mw=="],
 

--- a/packages/browseros-agent/package.json
+++ b/packages/browseros-agent/package.json
@@ -56,7 +56,7 @@
   "homepage": "https://github.com/browseros-ai/BrowserOS#readme",
   "devDependencies": {
     "@aws-sdk/client-s3": "^3.933.0",
-    "@biomejs/biome": "2.4.8",
+    "@biomejs/biome": "2.5.0",
     "@sentry/cli": "^2.42.2",
     "@types/bun": "^1.3.5",
     "@types/node": "^24.3.3",

--- a/packages/browseros-agent/packages/shared/src/sentry/sanitize.ts
+++ b/packages/browseros-agent/packages/shared/src/sentry/sanitize.ts
@@ -56,8 +56,8 @@ export function sanitize<T>(obj: T): T {
  * - Extra data
  * - Local variables captured in stack frames
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Sentry event type varies by SDK
 export function sanitizeEvent<E>(event: E): E {
+  // biome-ignore lint/suspicious/noExplicitAny: Sentry event type varies by SDK
   const e = event as Record<string, any>
 
   if (Array.isArray(e.breadcrumbs)) {


### PR DESCRIPTION
## Summary

Brings `bunx biome ci .` from `packages/browseros-agent` to **0 errors / 0 warnings** so the `code-quality.yml` Biome gate stays green on main and on every downstream stacked branch. None of the diagnostics were in `apps/agent-mcp-ui` (the package the recent PR stack touches); this is pure pre-existing legacy debt elsewhere.

Baseline on main: 61 errors, 32 warnings, 2 infos. After this PR: 0 errors, 0 warnings, 2 infos (deprecation notes about the `recommended` field in biome.json, which do not fail CI).

## Approach

Three buckets, applied as one commit each.

**Auto-fix:** `useOptionalChain` rewrites in `host-acp/binary-resolver.ts` and `host-acp/detection.ts` (mechanical `!a || a.b` to `a?.b`).

**Path overrides** in `packages/browseros-agent/biome.json`:
- `**/*.svg` is excluded from biome entirely. Biome 2.5.0 also tries to parse SVG files and trips parser errors on the vendored brand icons; not first-party code.
- `apps/eval/src/dashboard/viewer.html` turns off `noExcessiveCognitiveComplexity`, `useOptionalChain`, and `useValidAnchor`. It is a 2k-line standalone viewer composed mostly of inline script and is treated as a bundled artifact.
- `scripts/dev/inspect-ui.ts` turns off `noExcessiveCognitiveComplexity`. Dev CLI dispatch, not product code.

**Real fixes:**
- 9 `noExplicitAny`: Sentry sanitize pair gets a biome-ignore replacing the legacy eslint-disable directive (project does not run eslint). `single-agent.ts` drops 5 `as any` casts and mirrors `orchestrator-executor`'s `UIMessageStreamEvent` typing. `captcha-waiter.test.ts` mocks now type as `as unknown as Browser`.
- 8 `noNonNullAssertion`: replaced with explicit guards. Tests use `if (!x) throw new Error(...)`; source code (`tool-labels`, `active-turn-registry`, `oauth/callback-server`) restructured to avoid the assertion entirely.
- 3 `noExcessiveCognitiveComplexity` warnings on orchestration entry points (`clado-action-executor.execute`, `task-run-pipeline.execute`, `chat-service.processMessage`) get a per-function `biome-ignore` with a justification noting the refactor is tracked separately. No behavior change in this PR.
- 1 `noAmbiguousAnchorText`: chat-error link text changed from "Learn more" to "About daily limits".

## Bump

`@biomejs/biome` 2.4.8 → 2.5.0 (also reflected in the two `biome.json` `$schema` URLs and `bun.lock`).

## What is NOT in this PR

- Refactors of the three orchestration entry points (suppressions left in place with TODO justifications).
- Any change under `packages/browseros-agent/apps/agent-mcp-ui/**`.
- Rule severity changes outside scoped overrides.

## Test plan

- [ ] CI: `code-quality.yml` Biome job goes green on this PR.
- [ ] Local: `cd packages/browseros-agent && bunx biome ci .` exits 0.
- [ ] `bun run --filter '*' typecheck` succeeds across cdp-protocol, shared, build-tools, server, agent, eval.
- [ ] Spot-check the two auto-fixed `host-acp` files keep the same runtime behavior under `lookupWithCommand` / `probeVersion`.