### PR TITLE
feat(agent-mcp-interface): phase 1 — agent profiles CRUD end-to-end

### DIFF
--- a/packages/browseros-agent/apps/agent-mcp-interface/package.json
+++ b/packages/browseros-agent/apps/agent-mcp-interface/package.json
@@ -17,15 +17,20 @@
   "scripts": {
     "start": "bun --watch src/main.ts",
     "start:ci": "bun src/main.ts",
+    "test": "bun test",
     "typecheck": "tsc --noEmit",
     "lint": "bunx biome check",
     "lint:fix": "bunx biome check --write --unsafe"
   },
   "dependencies": {
-    "hono": "^4.12.3"
+    "@browseros/shared": "workspace:*",
+    "@hono/zod-validator": "^0.8.0",
+    "hono": "^4.12.3",
+    "nanoid": "^5.1.11",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
-    "typescript": "^5.9.2",
-    "@types/bun": "^1.3.5"
+    "@types/bun": "^1.3.5",
+    "typescript": "^5.9.2"
   }
 }

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/env.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/env.ts
@@ -21,6 +21,24 @@ function readPort(): number {
   return parsed
 }
 
+function readBrowserosDirOverride(): string | undefined {
+  // biome-ignore lint/style/noProcessEnv: env.ts is the sanctioned env-reader for the package
+  const raw = process.env.BROWSEROS_DIR?.trim()
+  return raw && raw.length > 0 ? raw : undefined
+}
+
+function readIsDevelopment(): boolean {
+  // biome-ignore lint/style/noProcessEnv: env.ts is the sanctioned env-reader for the package
+  return process.env.NODE_ENV === 'development'
+}
+
+/**
+ * Reads happen once at module load. Tests that need different values
+ * mutate this object before importing the rest of the source graph;
+ * production code treats it as immutable.
+ */
 export const env = {
   port: readPort(),
+  browserosDirOverride: readBrowserosDirOverride(),
+  isDevelopment: readIsDevelopment(),
 }

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/lib/async-mutex.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/lib/async-mutex.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * In-process async mutex. Tasks queued via `run` execute one at a
+ * time in submission order; subsequent tasks always run, regardless
+ * of whether the previous one resolved or rejected.
+ *
+ * Used by the agents service to serialise slug-mutating operations
+ * (create, update, regenerateMcpUrl) so the read-snapshot → compute
+ * → write pattern cannot race against itself. The interface server
+ * is a single-process loopback bind so per-process serialisation is
+ * the right granularity; multi-process scaling would warrant a
+ * filesystem-level guard (O_EXCL on a lockfile) instead.
+ */
+
+export class AsyncMutex {
+  private chain: Promise<unknown> = Promise.resolve()
+
+  run<T>(task: () => Promise<T>): Promise<T> {
+    // Swallow any previous rejection so the next task always runs;
+    // the caller of the prior task already saw the rejection on its
+    // own promise.
+    const next = this.chain.catch(() => undefined).then(task)
+    this.chain = next.catch(() => undefined)
+    return next
+  }
+}

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/lib/browseros-dir.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/lib/browseros-dir.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Resolves the on-disk directory the interface server reads + writes
+ * under. Path logic intentionally mirrors `apps/server`'s own
+ * resolver so a user pointing both servers at the same machine sees
+ * consistent file locations; env reads stay scoped per package.
+ *
+ * Order of preference:
+ *   1. `BROWSEROS_DIR` env override (read once via `env.ts`).
+ *   2. `<homedir>/.browseros-dev` when `NODE_ENV === 'development'`.
+ *   3. `<homedir>/.browseros` otherwise.
+ *
+ * The interface package writes everything under
+ * `<browserosDir>/mcp-interface/` so other BrowserOS components
+ * (server, CLI) keep their own subtrees untouched.
+ */
+
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import { PATHS } from '@browseros/shared/constants/paths'
+import { env } from '../env'
+
+const INTERFACE_SUBDIR = 'mcp-interface'
+
+export function getBrowserosDir(): string {
+  if (env.browserosDirOverride) return env.browserosDirOverride
+  const dirName = env.isDevelopment
+    ? PATHS.DEV_BROWSEROS_DIR_NAME
+    : PATHS.BROWSEROS_DIR_NAME
+  return join(homedir(), dirName)
+}
+
+/** `<browserosDir>/mcp-interface`, the root for this package's files. */
+export function getInterfaceDir(): string {
+  return join(getBrowserosDir(), INTERFACE_SUBDIR)
+}
+
+/** Convenience: any relative path resolved against the interface root. */
+export function resolveInterfacePath(...segments: string[]): string {
+  return join(getInterfaceDir(), ...segments)
+}

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/lib/slug.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/lib/slug.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Slug helpers, mirrored from the UI's wizard so the values the user
+ * sees in the wizard preview match the slugs the server actually
+ * persists. Keeping the logic identical (lowercase, non-alphanum
+ * runs collapse to `-`, trim leading/trailing `-`, fall back to
+ * `agent`) means we can rename the wizard preview into a stale-state
+ * indicator instead of a "what the server will pick" guess.
+ */
+
+const MAX_COLLISION_SUFFIX = 99
+
+export function toSlug(input: string): string {
+  const cleaned = input
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+  return cleaned || 'agent'
+}
+
+/**
+ * Returns a slug not present in `existing`. Appends `-2`, `-3`, ...,
+ * up to MAX_COLLISION_SUFFIX. Throws if even the highest suffix is
+ * taken (vanishingly unlikely; we surface 409 in the route layer if
+ * it ever fires).
+ */
+export function uniqueSlug(
+  base: string,
+  existing: ReadonlySet<string>,
+): string {
+  if (!existing.has(base)) return base
+  for (let i = 2; i <= MAX_COLLISION_SUFFIX; i++) {
+    const candidate = `${base}-${i}`
+    if (!existing.has(candidate)) return candidate
+  }
+  throw new Error(`slug-collision-exhausted: ${base}`)
+}

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/lib/storage.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/lib/storage.ts
@@ -1,0 +1,167 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * File-backed JSON storage under the interface root. Every read and
+ * write goes through a zod schema so on-disk shapes can't drift
+ * silently. Writes are atomic via a `<name>.tmp` -> rename swap so a
+ * crash mid-write leaves either the prior contents or nothing at all,
+ * never a half-written file.
+ *
+ * The relative path argument is always evaluated against
+ * `getInterfaceDir()`; callers cannot reach outside the interface
+ * root. Absolute paths or `..` segments throw `StorageInvalidPathError`
+ * so a stray join doesn't accidentally escape.
+ */
+
+import {
+  mkdir,
+  readdir,
+  readFile,
+  rename,
+  rm,
+  writeFile,
+} from 'node:fs/promises'
+import { dirname, isAbsolute, normalize, sep } from 'node:path'
+import type { ZodType } from 'zod'
+import { resolveInterfacePath } from './browseros-dir'
+
+export class StorageNotFoundError extends Error {
+  readonly relPath: string
+  constructor(relPath: string) {
+    super(`storage: file not found at ${relPath}`)
+    this.name = 'StorageNotFoundError'
+    this.relPath = relPath
+  }
+}
+
+export class StorageCorruptError extends Error {
+  readonly relPath: string
+  constructor(relPath: string, cause: unknown) {
+    super(`storage: invalid contents at ${relPath}`, { cause })
+    this.name = 'StorageCorruptError'
+    this.relPath = relPath
+  }
+}
+
+export class StorageInvalidPathError extends Error {
+  readonly relPath: string
+  constructor(relPath: string) {
+    super(`storage: relative path escapes the interface root: ${relPath}`)
+    this.name = 'StorageInvalidPathError'
+    this.relPath = relPath
+  }
+}
+
+function guardRelativePath(relPath: string): void {
+  if (isAbsolute(relPath)) throw new StorageInvalidPathError(relPath)
+  const normalized = normalize(relPath)
+  if (normalized.startsWith('..') || normalized.split(sep).includes('..')) {
+    throw new StorageInvalidPathError(relPath)
+  }
+}
+
+async function ensureParentDir(absolutePath: string): Promise<void> {
+  await mkdir(dirname(absolutePath), { recursive: true })
+}
+
+function isFsError(err: unknown, code: string): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    (err as { code?: unknown }).code === code
+  )
+}
+
+export async function ensureDir(relDir: string): Promise<void> {
+  guardRelativePath(relDir)
+  await mkdir(resolveInterfacePath(relDir), { recursive: true })
+}
+
+export async function readJson<T>(
+  relPath: string,
+  schema: ZodType<T>,
+): Promise<T> {
+  guardRelativePath(relPath)
+  const abs = resolveInterfacePath(relPath)
+  let raw: string
+  try {
+    raw = await readFile(abs, 'utf8')
+  } catch (err) {
+    if (isFsError(err, 'ENOENT')) throw new StorageNotFoundError(relPath)
+    throw err
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch (err) {
+    throw new StorageCorruptError(relPath, err)
+  }
+  const result = schema.safeParse(parsed)
+  if (!result.success) throw new StorageCorruptError(relPath, result.error)
+  return result.data
+}
+
+export async function writeJson<T>(
+  relPath: string,
+  value: T,
+  schema: ZodType<T>,
+): Promise<void> {
+  guardRelativePath(relPath)
+  const parseResult = schema.safeParse(value)
+  if (!parseResult.success)
+    throw new StorageCorruptError(relPath, parseResult.error)
+  const abs = resolveInterfacePath(relPath)
+  await ensureParentDir(abs)
+  const tmp = `${abs}.tmp`
+  await writeFile(tmp, JSON.stringify(parseResult.data, null, 2), 'utf8')
+  await rename(tmp, abs)
+}
+
+export async function removeFile(relPath: string): Promise<boolean> {
+  guardRelativePath(relPath)
+  try {
+    await rm(resolveInterfacePath(relPath))
+    return true
+  } catch (err) {
+    if (isFsError(err, 'ENOENT')) return false
+    throw err
+  }
+}
+
+/**
+ * Returns file names (not paths) in the directory, filtered to
+ * `.json` by default. Missing directories resolve to `[]` rather than
+ * throwing; that matches the "first-run, nothing saved yet" UX.
+ */
+export async function listFiles(
+  relDir: string,
+  options: { extension?: string } = {},
+): Promise<string[]> {
+  guardRelativePath(relDir)
+  const extension = options.extension ?? '.json'
+  try {
+    const entries = await readdir(resolveInterfacePath(relDir), {
+      withFileTypes: true,
+    })
+    return entries
+      .filter((entry) => entry.isFile() && entry.name.endsWith(extension))
+      .map((entry) => entry.name)
+  } catch (err) {
+    if (isFsError(err, 'ENOENT')) return []
+    throw err
+  }
+}
+
+export async function fileExists(relPath: string): Promise<boolean> {
+  guardRelativePath(relPath)
+  try {
+    await readFile(resolveInterfacePath(relPath), 'utf8')
+    return true
+  } catch (err) {
+    if (isFsError(err, 'ENOENT')) return false
+    throw err
+  }
+}

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/lib/storage.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/lib/storage.ts
@@ -56,6 +56,13 @@ export class StorageInvalidPathError extends Error {
 
 function guardRelativePath(relPath: string): void {
   if (isAbsolute(relPath)) throw new StorageInvalidPathError(relPath)
+  // Inspect the raw input first: `normalize` collapses `agents/../config.json`
+  // to `config.json`, which would silently escape the intended
+  // subdirectory while still passing the rooted-prefix check below.
+  // Reject any `..` segment in the input.
+  if (relPath.split(/[\\/]/).includes('..')) {
+    throw new StorageInvalidPathError(relPath)
+  }
   const normalized = normalize(relPath)
   if (normalized.startsWith('..') || normalized.split(sep).includes('..')) {
     throw new StorageInvalidPathError(relPath)

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/routes/agents/index.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/routes/agents/index.ts
@@ -1,0 +1,55 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * /agents route chain. Thin Hono layer over `./service`: translate
+ * HTTP shape in and out, surface 404 when the service returns null,
+ * and let `zValidator` reject malformed bodies with structured 400s.
+ *
+ * The chained `.post / .get / .patch / .delete` calls preserve the
+ * inferred shape `AppType` needs; do not break the chain.
+ */
+
+import { zValidator } from '@hono/zod-validator'
+import { Hono } from 'hono'
+import { HttpError } from '../../lib/errors'
+import { newAgentValuesSchema } from './schemas'
+import {
+  create,
+  getDetail,
+  list,
+  regenerateMcpUrl,
+  remove,
+  update,
+} from './service'
+
+export const agentsRoute = new Hono()
+  .post('/agents', zValidator('json', newAgentValuesSchema), async (c) => {
+    const body = c.req.valid('json')
+    const created = await create(body)
+    return c.json(created, 201)
+  })
+  .get('/agents', async (c) => c.json(await list()))
+  .get('/agents/:id', async (c) => {
+    const detail = await getDetail(c.req.param('id'))
+    if (!detail) throw new HttpError(404, 'agent not found')
+    return c.json(detail)
+  })
+  .patch('/agents/:id', zValidator('json', newAgentValuesSchema), async (c) => {
+    const id = c.req.param('id')
+    const body = c.req.valid('json')
+    const updated = await update(id, body)
+    if (!updated) throw new HttpError(404, 'agent not found')
+    return c.json(updated)
+  })
+  .delete('/agents/:id', async (c) => {
+    const removed = await remove(c.req.param('id'))
+    if (!removed) throw new HttpError(404, 'agent not found')
+    return c.json(removed)
+  })
+  .post('/agents/:id/mcp-url:regenerate', async (c) => {
+    const rotated = await regenerateMcpUrl(c.req.param('id'))
+    if (!rotated) throw new HttpError(404, 'agent not found')
+    return c.json(rotated)
+  })

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/routes/agents/schemas.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/routes/agents/schemas.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Zod shapes for the /agents routes. The UI's wizard-side validation
+ * lives in `apps/agent-mcp-ui/screens/new-agent/new-agent.schemas.ts`
+ * (it needs zod for client-side form errors); these schemas are the
+ * wire contract the typed client picks up via AppType.
+ *
+ * Storage shape extends the wire shape with server-managed fields
+ * (id, slug, mcpUrl, status, timestamps). The directory's projection
+ * shape lives at the bottom and is derived from the storage shape.
+ */
+
+import { z } from 'zod'
+
+export const harnessEnum = z.enum([
+  'Claude Cowork',
+  'Codex',
+  'Hermes',
+  'OpenClaw',
+  'Gemini CLI',
+])
+export type Harness = z.infer<typeof harnessEnum>
+
+export const loginModeEnum = z.enum(['profile', 'all', 'selective'])
+export type LoginMode = z.infer<typeof loginModeEnum>
+
+export const approvalVerdictEnum = z.enum(['Auto', 'Ask', 'Block'])
+export type ApprovalVerdict = z.infer<typeof approvalVerdictEnum>
+
+export const profileStatusEnum = z.enum(['configured', 'paused', 'disabled'])
+export type ProfileStatus = z.infer<typeof profileStatusEnum>
+
+export const customAclRuleSchema = z.object({
+  id: z.string(),
+  label: z.string().min(1),
+  domain: z.string().min(1),
+})
+export type CustomAclRule = z.infer<typeof customAclRuleSchema>
+
+/** Wire shape: POST / PATCH body, also GET /:id response. Mirrors UI's NewAgentValues. */
+export const newAgentValuesSchema = z.object({
+  name: z.string().trim().min(1),
+  harness: harnessEnum,
+  loginMode: loginModeEnum,
+  selectedSites: z.array(z.string()),
+  approvals: z.record(z.string(), approvalVerdictEnum),
+  aclRuleIds: z.array(z.string()),
+  customAclRules: z.array(customAclRuleSchema),
+})
+export type NewAgentValues = z.infer<typeof newAgentValuesSchema>
+
+/** On-disk shape under <browserosDir>/mcp-interface/agents/<id>.json. */
+export const storedAgentProfileSchema = newAgentValuesSchema.extend({
+  id: z.string(),
+  slug: z.string(),
+  mcpUrl: z.string(),
+  status: profileStatusEnum,
+  createdAt: z.string(),
+  updatedAt: z.string(),
+})
+export type StoredAgentProfile = z.infer<typeof storedAgentProfileSchema>
+
+/** Wire shape: GET / response. Directory row. */
+export const agentProfileSummarySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  harness: harnessEnum,
+  loginScopeLabel: z.string(),
+  loginCount: z.number(),
+  aclRuleCount: z.number(),
+  blockedActionCount: z.number(),
+  alwaysAllowCount: z.number(),
+  lastRunAt: z.string(),
+  status: profileStatusEnum,
+  mcpUrl: z.string(),
+})
+export type AgentProfileSummary = z.infer<typeof agentProfileSummarySchema>
+
+/** Wire shape: POST / response. Carries the rail's display strings. */
+export const createdAgentSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  harness: harnessEnum,
+  slug: z.string(),
+  mcpUrl: z.string(),
+  cliCommand: z.string(),
+})
+export type CreatedAgent = z.infer<typeof createdAgentSchema>
+
+/** Wire shape: PATCH / response. */
+export const updatedAgentSchema = storedAgentProfileSchema
+export type UpdatedAgent = z.infer<typeof updatedAgentSchema>
+
+/** Wire shape: DELETE / and regenerate. */
+export const idAckSchema = z.object({ id: z.string() })
+export type IdAck = z.infer<typeof idAckSchema>
+
+export const regeneratedMcpUrlSchema = z.object({
+  id: z.string(),
+  mcpUrl: z.string(),
+})
+export type RegeneratedMcpUrl = z.infer<typeof regeneratedMcpUrlSchema>

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/routes/agents/service.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/routes/agents/service.ts
@@ -17,6 +17,8 @@
 
 import { nanoid } from 'nanoid'
 import { env } from '../../env'
+import { AsyncMutex } from '../../lib/async-mutex'
+import { logger } from '../../lib/logger'
 import { toSlug, uniqueSlug } from '../../lib/slug'
 import { listFiles, readJson, removeFile, writeJson } from '../../lib/storage'
 import { getLocalServerUrl } from '../../local-server-url'
@@ -31,6 +33,33 @@ import {
 
 const AGENTS_SUBDIR = 'agents'
 const TOTAL_PROFILE_LOGINS = 47
+
+/**
+ * Serialises every slug-mutating operation (create / update /
+ * regenerateMcpUrl) so the read-snapshot → uniqueSlug → write
+ * window cannot race against itself. Reads (list / getDetail) stay
+ * lock-free; concurrent writes to different ids that don't touch
+ * the slug space could in principle drop the mutex too, but the cost
+ * of the queue is negligible and keeping all three under the same
+ * lock means the slug-uniqueness invariant holds without per-op
+ * reasoning.
+ */
+const slugMutex = new AsyncMutex()
+
+/**
+ * `id` is always a server-generated nanoid(8). Validate it before
+ * forwarding to the filesystem so a traversal-shaped value (e.g.
+ * URL-encoded `..%2Fconfig`) can never reach the storage layer even
+ * if a future route forwards user input directly. Nanoid's default
+ * alphabet is `A-Za-z0-9_-`; we cap the length to keep the file name
+ * predictable.
+ */
+const ID_PATTERN = /^[A-Za-z0-9_-]+$/
+const MAX_ID_LENGTH = 64
+
+export function isValidId(id: string): boolean {
+  return id.length > 0 && id.length <= MAX_ID_LENGTH && ID_PATTERN.test(id)
+}
 
 function fileFor(id: string): string {
   return `${AGENTS_SUBDIR}/${id}.json`
@@ -52,19 +81,41 @@ function buildCliCommand(slug: string): string {
   return `mcp add ${slug}`
 }
 
-/** All stored profiles, in arbitrary order. */
+/**
+ * All readable stored profiles, in arbitrary order. A single corrupt
+ * file is logged + skipped rather than rejecting the whole list, so
+ * one bad agent json (manual edit, partial migration, half-written
+ * file on a weird FS) can't brick the whole package: the directory
+ * still loads and `create` can still write new profiles.
+ */
 async function loadAll(): Promise<StoredAgentProfile[]> {
   const names = await listFiles(AGENTS_SUBDIR)
-  const profiles = await Promise.all(
+  const settled = await Promise.allSettled(
     names.map((name) =>
       readJson(`${AGENTS_SUBDIR}/${name}`, storedAgentProfileSchema),
     ),
   )
+  const profiles: StoredAgentProfile[] = []
+  for (let i = 0; i < settled.length; i++) {
+    const result = settled[i]
+    if (result.status === 'fulfilled') {
+      profiles.push(result.value)
+    } else {
+      logger.warn('skipping unreadable agent profile', {
+        file: `${AGENTS_SUBDIR}/${names[i]}`,
+        error:
+          result.reason instanceof Error
+            ? result.reason.message
+            : String(result.reason),
+      })
+    }
+  }
   return profiles
 }
 
 /** Stored profile for an id, or null when the file is missing. */
 async function loadById(id: string): Promise<StoredAgentProfile | null> {
+  if (!isValidId(id)) return null
   try {
     return await readJson(fileFor(id), storedAgentProfileSchema)
   } catch (err) {
@@ -133,67 +184,72 @@ export async function getDetail(id: string): Promise<NewAgentValues | null> {
 }
 
 export async function create(input: NewAgentValues): Promise<CreatedAgent> {
-  const id = nanoid(8)
-  const existing = await loadAll()
-  const slug = uniqueSlug(
-    toSlug(input.name),
-    new Set(existing.map((p) => p.slug)),
-  )
-  const now = nowIso()
-  const profile: StoredAgentProfile = {
-    ...input,
-    id,
-    slug,
-    mcpUrl: buildMcpUrl(slug),
-    status: 'configured',
-    createdAt: now,
-    updatedAt: now,
-  }
-  await writeJson(fileFor(id), profile, storedAgentProfileSchema)
-  return {
-    id,
-    name: profile.name,
-    harness: profile.harness,
-    slug,
-    mcpUrl: profile.mcpUrl,
-    cliCommand: buildCliCommand(slug),
-  }
+  return slugMutex.run(async () => {
+    const id = nanoid(8)
+    const existing = await loadAll()
+    const slug = uniqueSlug(
+      toSlug(input.name),
+      new Set(existing.map((p) => p.slug)),
+    )
+    const now = nowIso()
+    const profile: StoredAgentProfile = {
+      ...input,
+      id,
+      slug,
+      mcpUrl: buildMcpUrl(slug),
+      status: 'configured',
+      createdAt: now,
+      updatedAt: now,
+    }
+    await writeJson(fileFor(id), profile, storedAgentProfileSchema)
+    return {
+      id,
+      name: profile.name,
+      harness: profile.harness,
+      slug,
+      mcpUrl: profile.mcpUrl,
+      cliCommand: buildCliCommand(slug),
+    }
+  })
 }
 
 export async function update(
   id: string,
   input: NewAgentValues,
 ): Promise<StoredAgentProfile | null> {
-  const existing = await loadById(id)
-  if (!existing) return null
-  const existingProfiles = await loadAll()
-  const nameSlug = toSlug(input.name)
-  const slug =
-    nameSlug === toSlug(existing.name)
-      ? existing.slug
-      : uniqueSlug(
-          nameSlug,
-          new Set(
-            existingProfiles
-              .filter((profile) => profile.id !== id)
-              .map((profile) => profile.slug),
-          ),
-        )
-  const next: StoredAgentProfile = {
-    ...existing,
-    ...input,
-    id,
-    slug,
-    mcpUrl: buildMcpUrl(slug),
-    status: existing.status,
-    createdAt: existing.createdAt,
-    updatedAt: nowIso(),
-  }
-  await writeJson(fileFor(id), next, storedAgentProfileSchema)
-  return next
+  return slugMutex.run(async () => {
+    const existing = await loadById(id)
+    if (!existing) return null
+    const existingProfiles = await loadAll()
+    const nameSlug = toSlug(input.name)
+    const slug =
+      nameSlug === toSlug(existing.name)
+        ? existing.slug
+        : uniqueSlug(
+            nameSlug,
+            new Set(
+              existingProfiles
+                .filter((profile) => profile.id !== id)
+                .map((profile) => profile.slug),
+            ),
+          )
+    const next: StoredAgentProfile = {
+      ...existing,
+      ...input,
+      id,
+      slug,
+      mcpUrl: buildMcpUrl(slug),
+      status: existing.status,
+      createdAt: existing.createdAt,
+      updatedAt: nowIso(),
+    }
+    await writeJson(fileFor(id), next, storedAgentProfileSchema)
+    return next
+  })
 }
 
 export async function remove(id: string): Promise<{ id: string } | null> {
+  if (!isValidId(id)) return null
   const existed = await removeFile(fileFor(id))
   return existed ? { id } : null
 }
@@ -201,26 +257,28 @@ export async function remove(id: string): Promise<{ id: string } | null> {
 export async function regenerateMcpUrl(
   id: string,
 ): Promise<RegeneratedMcpUrl | null> {
-  const existing = await loadById(id)
-  if (!existing) return null
-  const profiles = await loadAll()
-  const taken = new Set(
-    profiles
-      .filter((profile) => profile.id !== id)
-      .map((profile) => profile.slug),
-  )
-  // Route the whole base through toSlug so the nanoid suffix can't
-  // smuggle `_` or `-` characters into the slug; the rotated slug
-  // stays in the canonical lowercase-alphanum-with-single-hyphens
-  // shape.
-  const base = toSlug(`${existing.name} ${nanoid(6)}`)
-  const slug = uniqueSlug(base, taken)
-  const next: StoredAgentProfile = {
-    ...existing,
-    slug,
-    mcpUrl: buildMcpUrl(slug),
-    updatedAt: nowIso(),
-  }
-  await writeJson(fileFor(id), next, storedAgentProfileSchema)
-  return { id, mcpUrl: next.mcpUrl }
+  return slugMutex.run(async () => {
+    const existing = await loadById(id)
+    if (!existing) return null
+    const profiles = await loadAll()
+    const taken = new Set(
+      profiles
+        .filter((profile) => profile.id !== id)
+        .map((profile) => profile.slug),
+    )
+    // Route the whole base through toSlug so the nanoid suffix can't
+    // smuggle `_` or `-` characters into the slug; the rotated slug
+    // stays in the canonical lowercase-alphanum-with-single-hyphens
+    // shape.
+    const base = toSlug(`${existing.name} ${nanoid(6)}`)
+    const slug = uniqueSlug(base, taken)
+    const next: StoredAgentProfile = {
+      ...existing,
+      slug,
+      mcpUrl: buildMcpUrl(slug),
+      updatedAt: nowIso(),
+    }
+    await writeJson(fileFor(id), next, storedAgentProfileSchema)
+    return { id, mcpUrl: next.mcpUrl }
+  })
 }

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/routes/agents/service.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/routes/agents/service.ts
@@ -209,7 +209,11 @@ export async function regenerateMcpUrl(
       .filter((profile) => profile.id !== id)
       .map((profile) => profile.slug),
   )
-  const base = `${toSlug(existing.name)}-${nanoid(6).toLowerCase()}`
+  // Route the whole base through toSlug so the nanoid suffix can't
+  // smuggle `_` or `-` characters into the slug; the rotated slug
+  // stays in the canonical lowercase-alphanum-with-single-hyphens
+  // shape.
+  const base = toSlug(`${existing.name} ${nanoid(6)}`)
   const slug = uniqueSlug(base, taken)
   const next: StoredAgentProfile = {
     ...existing,

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/routes/agents/service.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/routes/agents/service.ts
@@ -1,0 +1,222 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * File-backed agent profile service. One profile per file at
+ * <browserosDir>/mcp-interface/agents/<id>.json keyed by a nanoid;
+ * the slug is the user-facing identifier and is unique across all
+ * profiles. mcpUrl is recomputed from getLocalServerUrl() on every
+ * read so a port change between boots doesn't strand the stored
+ * value.
+ *
+ * Route handlers stay thin: they translate HTTP shape and surface
+ * 404s; everything else (validation, persistence, slug resolution,
+ * derivation) happens here.
+ */
+
+import { nanoid } from 'nanoid'
+import { env } from '../../env'
+import { toSlug, uniqueSlug } from '../../lib/slug'
+import { listFiles, readJson, removeFile, writeJson } from '../../lib/storage'
+import { getLocalServerUrl } from '../../local-server-url'
+import {
+  type AgentProfileSummary,
+  type CreatedAgent,
+  type NewAgentValues,
+  type RegeneratedMcpUrl,
+  type StoredAgentProfile,
+  storedAgentProfileSchema,
+} from './schemas'
+
+const AGENTS_SUBDIR = 'agents'
+const TOTAL_PROFILE_LOGINS = 47
+
+function fileFor(id: string): string {
+  return `${AGENTS_SUBDIR}/${id}.json`
+}
+
+function nowIso(): string {
+  return new Date().toISOString()
+}
+
+function baseUrl(): string {
+  return getLocalServerUrl() ?? `http://127.0.0.1:${env.port}`
+}
+
+function buildMcpUrl(slug: string): string {
+  return `${baseUrl()}/mcp/${slug}`
+}
+
+function buildCliCommand(slug: string): string {
+  return `mcp add ${slug}`
+}
+
+/** All stored profiles, in arbitrary order. */
+async function loadAll(): Promise<StoredAgentProfile[]> {
+  const names = await listFiles(AGENTS_SUBDIR)
+  const profiles = await Promise.all(
+    names.map((name) =>
+      readJson(`${AGENTS_SUBDIR}/${name}`, storedAgentProfileSchema),
+    ),
+  )
+  return profiles
+}
+
+/** Stored profile for an id, or null when the file is missing. */
+async function loadById(id: string): Promise<StoredAgentProfile | null> {
+  try {
+    return await readJson(fileFor(id), storedAgentProfileSchema)
+  } catch (err) {
+    if (
+      err instanceof Error &&
+      (err.name === 'StorageNotFoundError' ||
+        err.name === 'StorageInvalidPathError')
+    ) {
+      return null
+    }
+    throw err
+  }
+}
+
+function summariseProfile(profile: StoredAgentProfile): AgentProfileSummary {
+  const blockedActionCount = Object.values(profile.approvals).filter(
+    (verdict) => verdict === 'Block',
+  ).length
+  const loginCount =
+    profile.loginMode === 'selective'
+      ? profile.selectedSites.length
+      : TOTAL_PROFILE_LOGINS
+  const loginScopeLabel =
+    profile.loginMode === 'selective'
+      ? `Selective (${profile.selectedSites.length})`
+      : profile.loginMode === 'all'
+        ? `All my logins (${TOTAL_PROFILE_LOGINS})`
+        : `Current profile (${TOTAL_PROFILE_LOGINS})`
+  return {
+    id: profile.id,
+    name: profile.name,
+    harness: profile.harness,
+    loginScopeLabel,
+    loginCount,
+    aclRuleCount: profile.aclRuleIds.length,
+    blockedActionCount,
+    alwaysAllowCount: 0,
+    lastRunAt: 'Never run',
+    status: profile.status,
+    mcpUrl: buildMcpUrl(profile.slug),
+  }
+}
+
+function stripWizardShape(profile: StoredAgentProfile): NewAgentValues {
+  return {
+    name: profile.name,
+    harness: profile.harness,
+    loginMode: profile.loginMode,
+    selectedSites: [...profile.selectedSites],
+    approvals: { ...profile.approvals },
+    aclRuleIds: [...profile.aclRuleIds],
+    customAclRules: profile.customAclRules.map((rule) => ({ ...rule })),
+  }
+}
+
+export async function list(): Promise<AgentProfileSummary[]> {
+  const profiles = await loadAll()
+  return profiles
+    .sort((a, b) => (a.updatedAt < b.updatedAt ? 1 : -1))
+    .map((profile) => summariseProfile(profile))
+}
+
+export async function getDetail(id: string): Promise<NewAgentValues | null> {
+  const profile = await loadById(id)
+  return profile ? stripWizardShape(profile) : null
+}
+
+export async function create(input: NewAgentValues): Promise<CreatedAgent> {
+  const id = nanoid(8)
+  const existing = await loadAll()
+  const slug = uniqueSlug(
+    toSlug(input.name),
+    new Set(existing.map((p) => p.slug)),
+  )
+  const now = nowIso()
+  const profile: StoredAgentProfile = {
+    ...input,
+    id,
+    slug,
+    mcpUrl: buildMcpUrl(slug),
+    status: 'configured',
+    createdAt: now,
+    updatedAt: now,
+  }
+  await writeJson(fileFor(id), profile, storedAgentProfileSchema)
+  return {
+    id,
+    name: profile.name,
+    harness: profile.harness,
+    slug,
+    mcpUrl: profile.mcpUrl,
+    cliCommand: buildCliCommand(slug),
+  }
+}
+
+export async function update(
+  id: string,
+  input: NewAgentValues,
+): Promise<StoredAgentProfile | null> {
+  const existing = await loadById(id)
+  if (!existing) return null
+  const existingProfiles = await loadAll()
+  const nameSlug = toSlug(input.name)
+  const slug =
+    nameSlug === toSlug(existing.name)
+      ? existing.slug
+      : uniqueSlug(
+          nameSlug,
+          new Set(
+            existingProfiles
+              .filter((profile) => profile.id !== id)
+              .map((profile) => profile.slug),
+          ),
+        )
+  const next: StoredAgentProfile = {
+    ...existing,
+    ...input,
+    id,
+    slug,
+    mcpUrl: buildMcpUrl(slug),
+    status: existing.status,
+    createdAt: existing.createdAt,
+    updatedAt: nowIso(),
+  }
+  await writeJson(fileFor(id), next, storedAgentProfileSchema)
+  return next
+}
+
+export async function remove(id: string): Promise<{ id: string } | null> {
+  const existed = await removeFile(fileFor(id))
+  return existed ? { id } : null
+}
+
+export async function regenerateMcpUrl(
+  id: string,
+): Promise<RegeneratedMcpUrl | null> {
+  const existing = await loadById(id)
+  if (!existing) return null
+  const profiles = await loadAll()
+  const taken = new Set(
+    profiles
+      .filter((profile) => profile.id !== id)
+      .map((profile) => profile.slug),
+  )
+  const base = `${toSlug(existing.name)}-${nanoid(6).toLowerCase()}`
+  const slug = uniqueSlug(base, taken)
+  const next: StoredAgentProfile = {
+    ...existing,
+    slug,
+    mcpUrl: buildMcpUrl(slug),
+    updatedAt: nowIso(),
+  }
+  await writeJson(fileFor(id), next, storedAgentProfileSchema)
+  return { id, mcpUrl: next.mcpUrl }
+}

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/server.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/server.ts
@@ -17,6 +17,7 @@ import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import { HttpError } from './lib/errors'
 import { logger } from './lib/logger'
+import { agentsRoute } from './routes/agents'
 import { systemRoute } from './routes/system'
 
 // Telemetry capture is injectable so the server module stays usable
@@ -60,7 +61,7 @@ app.onError((err, c) => {
   return c.json({ error: message }, 500)
 })
 
-const routes = app.route('/', systemRoute)
+const routes = app.route('/', systemRoute).route('/', agentsRoute)
 
 export type AppType = typeof routes
 export default routes

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/_helpers/temp-browseros-dir.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/_helpers/temp-browseros-dir.ts
@@ -1,0 +1,35 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Test helper: redirects the interface package's storage root to a
+ * fresh tmp directory so each test is isolated. The override is set
+ * on the shared `env` object (read once at module load), then nudged
+ * back to its prior value after the test.
+ *
+ * Use as a wrapper:
+ *
+ *   await withTempBrowserosDir(async () => {
+ *     // body runs against an isolated <browserosDir>
+ *   })
+ */
+
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { env } from '../../src/env'
+
+export async function withTempBrowserosDir<T>(
+  body: (dir: string) => Promise<T>,
+): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), 'browseros-mcp-interface-'))
+  const prior = env.browserosDirOverride
+  env.browserosDirOverride = dir
+  try {
+    return await body(dir)
+  } finally {
+    env.browserosDirOverride = prior
+    await rm(dir, { recursive: true, force: true })
+  }
+}

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/async-mutex.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/async-mutex.test.ts
@@ -1,0 +1,57 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { AsyncMutex } from '../../src/lib/async-mutex'
+
+describe('AsyncMutex', () => {
+  test('serialises tasks submitted concurrently', async () => {
+    const mutex = new AsyncMutex()
+    const log: string[] = []
+    const make = (name: string, delayMs: number) => () =>
+      new Promise<string>((resolve) => {
+        log.push(`start:${name}`)
+        setTimeout(() => {
+          log.push(`done:${name}`)
+          resolve(name)
+        }, delayMs)
+      })
+
+    const results = await Promise.all([
+      mutex.run(make('a', 30)),
+      mutex.run(make('b', 5)),
+      mutex.run(make('c', 5)),
+    ])
+
+    expect(results).toEqual(['a', 'b', 'c'])
+    // Each task fully completes before the next one starts.
+    expect(log).toEqual([
+      'start:a',
+      'done:a',
+      'start:b',
+      'done:b',
+      'start:c',
+      'done:c',
+    ])
+  })
+
+  test('a rejected task does not block subsequent ones', async () => {
+    const mutex = new AsyncMutex()
+    const ran: string[] = []
+    const rejected = mutex.run(async () => {
+      ran.push('reject')
+      throw new Error('boom')
+    })
+    const ok = mutex.run(async () => {
+      ran.push('after')
+      return 'ok'
+    })
+
+    expect(rejected).rejects.toThrow('boom')
+    expect(await ok).toBe('ok')
+    expect(ran).toEqual(['reject', 'after'])
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/storage.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/storage.test.ts
@@ -1,0 +1,155 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { existsSync } from 'node:fs'
+import { readdir, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { z } from 'zod'
+import {
+  ensureDir,
+  fileExists,
+  listFiles,
+  readJson,
+  removeFile,
+  StorageCorruptError,
+  StorageInvalidPathError,
+  StorageNotFoundError,
+  writeJson,
+} from '../../src/lib/storage'
+import { withTempBrowserosDir } from '../_helpers/temp-browseros-dir'
+
+const sampleSchema = z.object({
+  name: z.string(),
+  ok: z.boolean(),
+})
+
+describe('storage', () => {
+  test('writeJson then readJson round-trips through the schema', async () => {
+    await withTempBrowserosDir(async () => {
+      await writeJson('sample.json', { name: 'one', ok: true }, sampleSchema)
+      const read = await readJson('sample.json', sampleSchema)
+      expect(read).toEqual({ name: 'one', ok: true })
+    })
+  })
+
+  test('writeJson creates parent directories', async () => {
+    await withTempBrowserosDir(async (dir) => {
+      await writeJson(
+        'nested/dir/sample.json',
+        { name: 'nested', ok: true },
+        sampleSchema,
+      )
+      expect(
+        existsSync(join(dir, 'mcp-interface/nested/dir/sample.json')),
+      ).toBe(true)
+    })
+  })
+
+  test('writeJson is atomic: the .tmp file is renamed, not left behind', async () => {
+    await withTempBrowserosDir(async (dir) => {
+      await writeJson('atomic.json', { name: 'a', ok: true }, sampleSchema)
+      const entries = await readdir(join(dir, 'mcp-interface'))
+      expect(entries).toContain('atomic.json')
+      expect(entries.some((entry) => entry.endsWith('.tmp'))).toBe(false)
+    })
+  })
+
+  test('readJson throws StorageNotFoundError on missing file', async () => {
+    await withTempBrowserosDir(async () => {
+      expect(readJson('ghost.json', sampleSchema)).rejects.toBeInstanceOf(
+        StorageNotFoundError,
+      )
+    })
+  })
+
+  test('readJson throws StorageCorruptError when JSON is invalid', async () => {
+    await withTempBrowserosDir(async (dir) => {
+      const root = join(dir, 'mcp-interface')
+      await ensureDir('.')
+      await writeFile(join(root, 'broken.json'), '{not-json', 'utf8')
+      expect(readJson('broken.json', sampleSchema)).rejects.toBeInstanceOf(
+        StorageCorruptError,
+      )
+    })
+  })
+
+  test('readJson throws StorageCorruptError when schema rejects the value', async () => {
+    await withTempBrowserosDir(async (dir) => {
+      const root = join(dir, 'mcp-interface')
+      await ensureDir('.')
+      await writeFile(
+        join(root, 'wrong-shape.json'),
+        JSON.stringify({ name: 1, ok: 'no' }),
+        'utf8',
+      )
+      expect(readJson('wrong-shape.json', sampleSchema)).rejects.toBeInstanceOf(
+        StorageCorruptError,
+      )
+    })
+  })
+
+  test('writeJson refuses values that do not satisfy the schema', async () => {
+    await withTempBrowserosDir(async () => {
+      // biome-ignore lint/suspicious/noExplicitAny: deliberate invalid input for the test
+      const bad = { name: 5, ok: 'not a bool' } as any
+      expect(
+        writeJson('rejected.json', bad, sampleSchema),
+      ).rejects.toBeInstanceOf(StorageCorruptError)
+    })
+  })
+
+  test('removeFile deletes an existing file and returns true', async () => {
+    await withTempBrowserosDir(async () => {
+      await writeJson('to-delete.json', { name: 'd', ok: true }, sampleSchema)
+      expect(await removeFile('to-delete.json')).toBe(true)
+      expect(await fileExists('to-delete.json')).toBe(false)
+    })
+  })
+
+  test('removeFile returns false when the file does not exist', async () => {
+    await withTempBrowserosDir(async () => {
+      expect(await removeFile('never-existed.json')).toBe(false)
+    })
+  })
+
+  test('listFiles defaults to .json and filters non-matching entries', async () => {
+    await withTempBrowserosDir(async (dir) => {
+      const root = join(dir, 'mcp-interface', 'list-test')
+      await ensureDir('list-test')
+      await writeFile(join(root, 'a.json'), '{"name":"a","ok":true}', 'utf8')
+      await writeFile(join(root, 'b.json'), '{"name":"b","ok":true}', 'utf8')
+      await writeFile(join(root, 'c.txt'), 'unrelated', 'utf8')
+      const names = await listFiles('list-test')
+      expect(names.sort()).toEqual(['a.json', 'b.json'])
+    })
+  })
+
+  test('listFiles returns [] when the directory does not exist', async () => {
+    await withTempBrowserosDir(async () => {
+      expect(await listFiles('missing-dir')).toEqual([])
+    })
+  })
+
+  test('relative paths cannot escape the interface root', async () => {
+    await withTempBrowserosDir(async () => {
+      expect(() =>
+        writeJson('../escape.json', { name: 'e', ok: true }, sampleSchema),
+      ).toThrow(StorageInvalidPathError)
+      expect(() => readJson('../escape.json', sampleSchema)).toThrow(
+        StorageInvalidPathError,
+      )
+    })
+  })
+
+  test('absolute paths are rejected', async () => {
+    await withTempBrowserosDir(async () => {
+      expect(() => readJson('/etc/passwd', sampleSchema)).toThrow(
+        StorageInvalidPathError,
+      )
+    })
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/storage.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/storage.test.ts
@@ -152,4 +152,25 @@ describe('storage', () => {
       )
     })
   })
+
+  test('lateral traversal that stays inside the interface root is still rejected', async () => {
+    await withTempBrowserosDir(async () => {
+      // `agents/../config.json` normalises to `config.json` which sits
+      // INSIDE the interface root but escapes the intended subdirectory.
+      // The guard must catch the raw `..` before normalize collapses it.
+      expect(() => readJson('agents/../config.json', sampleSchema)).toThrow(
+        StorageInvalidPathError,
+      )
+      expect(() =>
+        writeJson(
+          'agents/../config.json',
+          { name: 'x', ok: true },
+          sampleSchema,
+        ),
+      ).toThrow(StorageInvalidPathError)
+      expect(() => removeFile('agents/../config.json')).toThrow(
+        StorageInvalidPathError,
+      )
+    })
+  })
 })

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/agents/routes.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/agents/routes.test.ts
@@ -1,0 +1,184 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Integration tests for the /agents routes. Hits the live Hono app
+ * via the typed client (`hc<AppType>`) but routes everything through
+ * `app.fetch` so there is no real socket bind. Each test gets its
+ * own tmp `<browserosDir>` so state doesn't leak between cases.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { hc } from 'hono/client'
+import type {
+  AgentProfileSummary,
+  NewAgentValues,
+  StoredAgentProfile,
+} from '../../../src/routes/agents/schemas'
+import app, { type AppType } from '../../../src/server'
+import { withTempBrowserosDir } from '../../_helpers/temp-browseros-dir'
+
+function client() {
+  // hc only needs a base URL to construct request paths; the fetch
+  // override sends every request to `app.fetch` so no port is bound.
+  return hc<AppType>('http://localhost', {
+    fetch: (input, init) => app.fetch(new Request(input, init)),
+  })
+}
+
+function makeBody(overrides: Partial<NewAgentValues> = {}): NewAgentValues {
+  return {
+    name: 'Cowork . Finance ops',
+    harness: 'Claude Cowork',
+    loginMode: 'profile',
+    selectedSites: [],
+    approvals: {
+      submit: 'Ask',
+      payment: 'Block',
+      delete: 'Ask',
+      upload: 'Ask',
+      navigate: 'Ask',
+      input: 'Auto',
+    },
+    aclRuleIds: ['wire-transfers'],
+    customAclRules: [],
+    ...overrides,
+  }
+}
+
+describe('/agents routes', () => {
+  test('full lifecycle: create → list → detail → update → regenerate → delete', async () => {
+    await withTempBrowserosDir(async () => {
+      const api = client()
+
+      // create
+      const createRes = await api.agents.$post({ json: makeBody() })
+      expect(createRes.status).toBe(201)
+      const created = await createRes.json()
+      expect(created.harness).toBe('Claude Cowork')
+      expect(created.slug).toBe('cowork-finance-ops')
+      expect(created.mcpUrl).toMatch(/\/mcp\/cowork-finance-ops$/)
+      expect(created.cliCommand).toBe('mcp add cowork-finance-ops')
+
+      // list
+      const listRes = await api.agents.$get()
+      expect(listRes.status).toBe(200)
+      const list = (await listRes.json()) as AgentProfileSummary[]
+      expect(list).toHaveLength(1)
+      expect(list[0].id).toBe(created.id)
+
+      // detail
+      const detailRes = await api.agents[':id'].$get({
+        param: { id: created.id },
+      })
+      expect(detailRes.status).toBe(200)
+      const detail = (await detailRes.json()) as NewAgentValues
+      expect(detail.name).toBe('Cowork . Finance ops')
+
+      // update
+      const patchRes = await api.agents[':id'].$patch({
+        param: { id: created.id },
+        json: makeBody({ name: 'Renamed' }),
+      })
+      expect(patchRes.status).toBe(200)
+      const updated = (await patchRes.json()) as StoredAgentProfile
+      expect(updated.name).toBe('Renamed')
+      expect(updated.slug).toBe('renamed')
+
+      // regenerate
+      const regenRes = await api.agents[':id']['mcp-url:regenerate'].$post({
+        param: { id: created.id },
+      })
+      expect(regenRes.status).toBe(200)
+      const regen = await regenRes.json()
+      expect(regen.id).toBe(created.id)
+      expect(regen.mcpUrl).not.toBe(updated.mcpUrl)
+      expect(regen.mcpUrl).toMatch(/\/mcp\/renamed-[a-z0-9-]+$/)
+
+      // delete
+      const delRes = await api.agents[':id'].$delete({
+        param: { id: created.id },
+      })
+      expect(delRes.status).toBe(200)
+      const del = await delRes.json()
+      expect(del).toEqual({ id: created.id })
+
+      // listed empty
+      const emptyRes = await api.agents.$get()
+      const empty = (await emptyRes.json()) as AgentProfileSummary[]
+      expect(empty).toEqual([])
+    })
+  })
+
+  test('404 paths for unknown ids', async () => {
+    await withTempBrowserosDir(async () => {
+      const api = client()
+      const detail = await api.agents[':id'].$get({ param: { id: 'ghost' } })
+      expect(detail.status).toBe(404)
+      const patch = await api.agents[':id'].$patch({
+        param: { id: 'ghost' },
+        json: makeBody(),
+      })
+      expect(patch.status).toBe(404)
+      const del = await api.agents[':id'].$delete({ param: { id: 'ghost' } })
+      expect(del.status).toBe(404)
+      const regen = await api.agents[':id']['mcp-url:regenerate'].$post({
+        param: { id: 'ghost' },
+      })
+      expect(regen.status).toBe(404)
+    })
+  })
+
+  test('400 when the create body fails zod validation', async () => {
+    await withTempBrowserosDir(async () => {
+      const api = client()
+      const res = await api.agents.$post({
+        // biome-ignore lint/suspicious/noExplicitAny: deliberate invalid body for the test
+        json: { ...makeBody(), name: '' } as any,
+      })
+      expect(res.status).toBe(400)
+    })
+  })
+
+  test('two creates with the same name produce slug + slug-2', async () => {
+    await withTempBrowserosDir(async () => {
+      const api = client()
+      const first = await api.agents.$post({ json: makeBody({ name: 'Foo' }) })
+      const second = await api.agents.$post({ json: makeBody({ name: 'Foo' }) })
+      const a = await first.json()
+      const b = await second.json()
+      expect(a.slug).toBe('foo')
+      expect(b.slug).toBe('foo-2')
+    })
+  })
+
+  test('parallel updates of two distinct profiles do not corrupt each other', async () => {
+    await withTempBrowserosDir(async () => {
+      const api = client()
+      const a = await (
+        await api.agents.$post({ json: makeBody({ name: 'A' }) })
+      ).json()
+      const b = await (
+        await api.agents.$post({ json: makeBody({ name: 'B' }) })
+      ).json()
+      await Promise.all([
+        api.agents[':id'].$patch({
+          param: { id: a.id },
+          json: makeBody({ name: 'A renamed' }),
+        }),
+        api.agents[':id'].$patch({
+          param: { id: b.id },
+          json: makeBody({ name: 'B renamed' }),
+        }),
+      ])
+      const list = (await (
+        await api.agents.$get()
+      ).json()) as AgentProfileSummary[]
+      expect(list.map((row) => row.name).sort()).toEqual([
+        'A renamed',
+        'B renamed',
+      ])
+    })
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/agents/service.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/agents/service.test.ts
@@ -1,0 +1,222 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { readJson } from '../../../src/lib/storage'
+import type { NewAgentValues } from '../../../src/routes/agents/schemas'
+import { storedAgentProfileSchema } from '../../../src/routes/agents/schemas'
+import * as agents from '../../../src/routes/agents/service'
+import { withTempBrowserosDir } from '../../_helpers/temp-browseros-dir'
+
+function makeInput(overrides: Partial<NewAgentValues> = {}): NewAgentValues {
+  return {
+    name: 'Cowork . Finance ops',
+    harness: 'Claude Cowork',
+    loginMode: 'profile',
+    selectedSites: [],
+    approvals: {
+      submit: 'Ask',
+      payment: 'Block',
+      delete: 'Ask',
+      upload: 'Ask',
+      navigate: 'Ask',
+      input: 'Auto',
+    },
+    aclRuleIds: ['wire-transfers', 'payment-methods'],
+    customAclRules: [],
+    ...overrides,
+  }
+}
+
+describe('agents service', () => {
+  test('create persists a stored profile that round-trips through the schema', async () => {
+    await withTempBrowserosDir(async (dir) => {
+      const created = await agents.create(makeInput())
+      const file = join(dir, 'mcp-interface/agents', `${created.id}.json`)
+      expect(existsSync(file)).toBe(true)
+      const stored = await readJson(
+        `agents/${created.id}.json`,
+        storedAgentProfileSchema,
+      )
+      expect(stored.id).toBe(created.id)
+      expect(stored.slug).toBe(created.slug)
+      expect(stored.status).toBe('configured')
+      expect(stored.createdAt).toBeTruthy()
+      expect(stored.updatedAt).toBe(stored.createdAt)
+    })
+  })
+
+  test('create derives slug from the name; second create with same name appends -2', async () => {
+    await withTempBrowserosDir(async () => {
+      const first = await agents.create(makeInput({ name: 'Foo' }))
+      const second = await agents.create(makeInput({ name: 'Foo' }))
+      expect(first.slug).toBe('foo')
+      expect(second.slug).toBe('foo-2')
+    })
+  })
+
+  test('list returns the directory projection with derived fields', async () => {
+    await withTempBrowserosDir(async () => {
+      await agents.create(
+        makeInput({
+          name: 'Selective Agent',
+          loginMode: 'selective',
+          selectedSites: ['concur.com', 'stripe.com', 'ramp.com'],
+          aclRuleIds: ['a', 'b', 'c'],
+          approvals: { submit: 'Block', payment: 'Block', input: 'Auto' },
+        }),
+      )
+      const rows = await agents.list()
+      expect(rows).toHaveLength(1)
+      const row = rows[0]
+      expect(row.loginScopeLabel).toBe('Selective (3)')
+      expect(row.loginCount).toBe(3)
+      expect(row.aclRuleCount).toBe(3)
+      expect(row.blockedActionCount).toBe(2)
+      expect(row.alwaysAllowCount).toBe(0)
+      expect(row.lastRunAt).toBe('Never run')
+      expect(row.status).toBe('configured')
+      expect(row.mcpUrl).toMatch(/\/mcp\/selective-agent$/)
+    })
+  })
+
+  test('list sorts by updatedAt descending', async () => {
+    await withTempBrowserosDir(async () => {
+      const a = await agents.create(makeInput({ name: 'Alpha' }))
+      // Force a small delay so the second create has a strictly later
+      // updatedAt; ISO strings sort lexicographically the same way.
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      const b = await agents.create(makeInput({ name: 'Beta' }))
+      const rows = await agents.list()
+      expect(rows.map((row) => row.id)).toEqual([b.id, a.id])
+    })
+  })
+
+  test('getDetail returns the wizard-shape values', async () => {
+    await withTempBrowserosDir(async () => {
+      const created = await agents.create(
+        makeInput({
+          name: 'Detail Test',
+          loginMode: 'selective',
+          selectedSites: ['concur.com'],
+        }),
+      )
+      const detail = await agents.getDetail(created.id)
+      expect(detail).not.toBeNull()
+      if (!detail) throw new Error('unreachable')
+      expect(detail.name).toBe('Detail Test')
+      expect(detail.loginMode).toBe('selective')
+      expect(detail.selectedSites).toEqual(['concur.com'])
+      // Wizard shape carries no server-managed fields.
+      expect('id' in detail).toBe(false)
+      expect('slug' in detail).toBe(false)
+    })
+  })
+
+  test('getDetail returns null for unknown ids', async () => {
+    await withTempBrowserosDir(async () => {
+      expect(await agents.getDetail('ghost')).toBeNull()
+    })
+  })
+
+  test('update rewrites the file; updatedAt advances, createdAt is preserved', async () => {
+    await withTempBrowserosDir(async () => {
+      const created = await agents.create(makeInput())
+      await new Promise((resolve) => setTimeout(resolve, 10))
+      const updated = await agents.update(
+        created.id,
+        makeInput({ name: 'Renamed Profile' }),
+      )
+      expect(updated).not.toBeNull()
+      if (!updated) throw new Error('unreachable')
+      expect(updated.id).toBe(created.id)
+      expect(updated.name).toBe('Renamed Profile')
+      expect(updated.createdAt).toBeTruthy()
+      expect(updated.updatedAt > updated.createdAt).toBe(true)
+    })
+  })
+
+  test('update recomputes slug when the name changes', async () => {
+    await withTempBrowserosDir(async () => {
+      const created = await agents.create(makeInput({ name: 'Cowork Finance' }))
+      expect(created.slug).toBe('cowork-finance')
+      const updated = await agents.update(
+        created.id,
+        makeInput({ name: 'Cowork Reporting' }),
+      )
+      expect(updated?.slug).toBe('cowork-reporting')
+    })
+  })
+
+  test('update keeps slug stable when the name does not change', async () => {
+    await withTempBrowserosDir(async () => {
+      const created = await agents.create(makeInput({ name: 'Stable' }))
+      const updated = await agents.update(
+        created.id,
+        makeInput({ name: 'Stable' }),
+      )
+      expect(updated?.slug).toBe(created.slug)
+    })
+  })
+
+  test('update returns null for unknown ids', async () => {
+    await withTempBrowserosDir(async () => {
+      expect(await agents.update('ghost', makeInput())).toBeNull()
+    })
+  })
+
+  test('remove deletes the file and subsequent getDetail is null', async () => {
+    await withTempBrowserosDir(async () => {
+      const created = await agents.create(makeInput())
+      expect(await agents.remove(created.id)).toEqual({ id: created.id })
+      expect(await agents.getDetail(created.id)).toBeNull()
+    })
+  })
+
+  test('remove returns null when the file does not exist', async () => {
+    await withTempBrowserosDir(async () => {
+      expect(await agents.remove('ghost')).toBeNull()
+    })
+  })
+
+  test('regenerateMcpUrl rotates the slug and persists the new URL', async () => {
+    await withTempBrowserosDir(async () => {
+      const created = await agents.create(makeInput({ name: 'Rotate' }))
+      const result = await agents.regenerateMcpUrl(created.id)
+      expect(result).not.toBeNull()
+      if (!result) throw new Error('unreachable')
+      expect(result.id).toBe(created.id)
+      expect(result.mcpUrl).not.toBe(created.mcpUrl)
+      expect(result.mcpUrl).toMatch(/\/mcp\/rotate-[a-z0-9]+$/)
+      const detail = await agents.getDetail(created.id)
+      expect(detail).not.toBeNull()
+    })
+  })
+
+  test('regenerateMcpUrl returns null for unknown ids', async () => {
+    await withTempBrowserosDir(async () => {
+      expect(await agents.regenerateMcpUrl('ghost')).toBeNull()
+    })
+  })
+
+  test('two parallel updates of different profiles do not corrupt each other', async () => {
+    await withTempBrowserosDir(async () => {
+      const a = await agents.create(makeInput({ name: 'Parallel A' }))
+      const b = await agents.create(makeInput({ name: 'Parallel B' }))
+      await Promise.all([
+        agents.update(a.id, makeInput({ name: 'Parallel A renamed' })),
+        agents.update(b.id, makeInput({ name: 'Parallel B renamed' })),
+      ])
+      const rows = await agents.list()
+      expect(rows.map((row) => row.name).sort()).toEqual([
+        'Parallel A renamed',
+        'Parallel B renamed',
+      ])
+    })
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/agents/service.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/agents/service.test.ts
@@ -204,6 +204,69 @@ describe('agents service', () => {
     })
   })
 
+  test('list skips a corrupt agent file instead of rejecting the whole call', async () => {
+    await withTempBrowserosDir(async (dir) => {
+      const ok = await agents.create(makeInput({ name: 'Healthy' }))
+      // Hand-write a garbage file under agents/. listFiles picks it
+      // up; the per-file readJson rejects; loadAll logs + skips it.
+      const { writeFile } = await import('node:fs/promises')
+      const { join } = await import('node:path')
+      await writeFile(
+        join(dir, 'mcp-interface/agents', 'broken.json'),
+        '{ this is not valid json',
+        'utf8',
+      )
+      const rows = await agents.list()
+      expect(rows.map((row) => row.id)).toEqual([ok.id])
+      // The directory still serves new writes after a corrupt sibling.
+      const fresh = await agents.create(makeInput({ name: 'After corruption' }))
+      const after = await agents.list()
+      expect(after.map((row) => row.id).sort()).toEqual(
+        [ok.id, fresh.id].sort(),
+      )
+    })
+  })
+
+  test('traversal-shaped ids resolve as not-found across every read/write path', async () => {
+    await withTempBrowserosDir(async () => {
+      await agents.create(makeInput({ name: 'Real' }))
+      // Build a path that LOOKS like a profile id but contains
+      // characters the service must reject before the storage layer
+      // sees them.
+      const evilIds = [
+        '../config',
+        'agents/../config',
+        '..',
+        '../../etc/passwd',
+      ]
+      for (const evilId of evilIds) {
+        expect(await agents.getDetail(evilId)).toBeNull()
+        expect(await agents.update(evilId, makeInput())).toBeNull()
+        expect(await agents.remove(evilId)).toBeNull()
+        expect(await agents.regenerateMcpUrl(evilId)).toBeNull()
+      }
+    })
+  })
+
+  test('ten parallel creates with the same name produce distinct slugs (no TOCTOU race)', async () => {
+    await withTempBrowserosDir(async () => {
+      const count = 10
+      const created = await Promise.all(
+        Array.from({ length: count }, () =>
+          agents.create(makeInput({ name: 'Race' })),
+        ),
+      )
+      const slugs = created.map((c) => c.slug).sort()
+      // Expected slugs are race, race-2, race-3, ..., race-10 (sorted
+      // lexicographically -> race, race-10, race-2, race-3, ...).
+      expect(new Set(slugs).size).toBe(count)
+      expect(slugs).toContain('race')
+      for (let i = 2; i <= count; i++) {
+        expect(slugs).toContain(`race-${i}`)
+      }
+    })
+  })
+
   test('two parallel updates of different profiles do not corrupt each other', async () => {
     await withTempBrowserosDir(async () => {
       const a = await agents.create(makeInput({ name: 'Parallel A' }))

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/agents/service.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/agents/service.test.ts
@@ -192,7 +192,7 @@ describe('agents service', () => {
       if (!result) throw new Error('unreachable')
       expect(result.id).toBe(created.id)
       expect(result.mcpUrl).not.toBe(created.mcpUrl)
-      expect(result.mcpUrl).toMatch(/\/mcp\/rotate-[a-z0-9]+$/)
+      expect(result.mcpUrl).toMatch(/\/mcp\/rotate-[a-z0-9-]+$/)
       const detail = await agents.getDetail(created.id)
       expect(detail).not.toBeNull()
     })

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/agents.hooks.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/agents.hooks.ts
@@ -1,20 +1,14 @@
-import { nanoid } from 'nanoid'
 import { createMutation, createQuery } from 'react-query-kit'
 import type { RunStatus } from '@/lib/status'
-import {
-  buildCliCommand,
-  buildMcpUrl,
-  IMPORTED_SITES,
-  SEED_ACL_RULES,
-  toSlug,
-} from '@/screens/new-agent/new-agent.helpers'
-import {
-  APPROVAL_CATEGORIES,
-  type ApprovalVerdict,
-  type LoginMode,
-  type NewAgentValues,
-} from '@/screens/new-agent/new-agent.schemas'
+import type { NewAgentValues } from '@/screens/new-agent/new-agent.schemas'
+import { api } from './client'
+import { parseResponse } from './parseResponse'
 
+/**
+ * Cockpit's running grid still reads mock data; this hook becomes
+ * Phase 4's projection over the runs store. Leave the shape and
+ * fixtures untouched until then.
+ */
 export interface AgentRow {
   id: string
   /** Display label, e.g. "Cowork . File expenses". */
@@ -28,12 +22,6 @@ export interface AgentRow {
   color: string
 }
 
-/**
- * Mock data. Shape matches what the eventual
- * `agent-mcp-interface` /agents endpoint will return. Replacing
- * `fetcher` with a real `$get`-then-parseResponse call is the only
- * change this hook needs when the backend route lands.
- */
 const MOCK_AGENTS: AgentRow[] = [
   {
     id: 'cld-concur',
@@ -82,24 +70,10 @@ export interface CreatedAgent {
   cliCommand: string
 }
 
-/**
- * Mock createAgent mutation. Mirrors the eventual hono-rpc surface so
- * swapping `mutationFn` for a real `$post`-then-parseResponse call is
- * a body-only change. The simulated latency keeps the optimistic UI
- * states honest.
- */
 export const useCreateAgent = createMutation<CreatedAgent, NewAgentValues>({
   mutationFn: async (values) => {
-    await new Promise((resolve) => setTimeout(resolve, 600))
-    const slug = toSlug(values.name || values.harness)
-    return {
-      id: nanoid(8),
-      name: values.name,
-      harness: values.harness,
-      slug,
-      mcpUrl: buildMcpUrl(slug),
-      cliCommand: buildCliCommand(slug),
-    }
+    const response = await api.agents.$post({ json: values })
+    return parseResponse<CreatedAgent>(response)
   },
 })
 
@@ -126,125 +100,25 @@ export interface AgentProfile {
   mcpUrl: string
 }
 
-const MOCK_AGENT_PROFILES: AgentProfile[] = [
-  {
-    id: 'cld-concur',
-    name: 'Cowork . Finance ops',
-    harness: 'Claude Cowork',
-    loginScopeLabel: 'Current profile (47)',
-    loginCount: 47,
-    aclRuleCount: 3,
-    blockedActionCount: 1,
-    alwaysAllowCount: 4,
-    lastRunAt: '2m ago',
-    status: 'configured',
-    mcpUrl: 'http://127.0.0.1:9000/mcp/cowork-finance-ops',
-  },
-  {
-    id: 'cld-li',
-    name: 'Cowork . Social posts',
-    harness: 'Claude Cowork',
-    loginScopeLabel: 'Selective (5)',
-    loginCount: 5,
-    aclRuleCount: 5,
-    blockedActionCount: 2,
-    alwaysAllowCount: 1,
-    lastRunAt: '4m ago',
-    status: 'configured',
-    mcpUrl: 'http://127.0.0.1:9000/mcp/cowork-social-posts',
-  },
-  {
-    id: 'cdx-sheet',
-    name: 'Codex . Pricing research',
-    harness: 'Codex',
-    loginScopeLabel: 'Selective (8)',
-    loginCount: 8,
-    aclRuleCount: 4,
-    blockedActionCount: 1,
-    alwaysAllowCount: 2,
-    lastRunAt: '8m ago',
-    status: 'configured',
-    mcpUrl: 'http://127.0.0.1:9000/mcp/codex-pricing-research',
-  },
-  {
-    id: 'cdx-leads',
-    name: 'Codex . Pipeline digest',
-    harness: 'Codex',
-    loginScopeLabel: 'Current profile (47)',
-    loginCount: 47,
-    aclRuleCount: 3,
-    blockedActionCount: 1,
-    alwaysAllowCount: 3,
-    lastRunAt: '34m ago',
-    status: 'configured',
-    mcpUrl: 'http://127.0.0.1:9000/mcp/codex-pipeline-digest',
-  },
-  {
-    id: 'hrm-stripe',
-    name: 'Hermes . Refunds',
-    harness: 'Hermes',
-    loginScopeLabel: 'Selective (2)',
-    loginCount: 2,
-    aclRuleCount: 5,
-    blockedActionCount: 2,
-    alwaysAllowCount: 0,
-    lastRunAt: '1h ago',
-    status: 'paused',
-    mcpUrl: 'http://127.0.0.1:9000/mcp/hermes-refunds',
-  },
-  {
-    id: 'hrm-notion',
-    name: 'Hermes . Weekly recap',
-    harness: 'Hermes',
-    loginScopeLabel: 'Current profile (47)',
-    loginCount: 47,
-    aclRuleCount: 2,
-    blockedActionCount: 1,
-    alwaysAllowCount: 1,
-    lastRunAt: 'Yesterday 09:11',
-    status: 'configured',
-    mcpUrl: 'http://127.0.0.1:9000/mcp/hermes-weekly-recap',
-  },
-  {
-    id: 'cdx-onb',
-    name: 'Codex . Onboarding draft',
-    harness: 'Codex',
-    loginScopeLabel: 'Selective (3)',
-    loginCount: 3,
-    aclRuleCount: 4,
-    blockedActionCount: 1,
-    alwaysAllowCount: 0,
-    lastRunAt: 'Never run',
-    status: 'disabled',
-    mcpUrl: 'http://127.0.0.1:9000/mcp/codex-onboarding-draft',
-  },
-]
-
 export const useAgentProfiles = createQuery<AgentProfile[]>({
   queryKey: ['agent-profiles'],
-  fetcher: () =>
-    new Promise((resolve) =>
-      setTimeout(() => resolve(MOCK_AGENT_PROFILES), 60),
-    ),
+  fetcher: async () => {
+    const response = await api.agents.$get()
+    return parseResponse<AgentProfile[]>(response)
+  },
 })
 
 interface DeleteAgentVariables {
   id: string
 }
 
-/**
- * Mock deleteAgent mutation. The hono-rpc surface will return
- * `{ id }`; mutating clients update the `agent-profiles` cache with
- * `setQueryData` instead of refetching since the row goes away on
- * success.
- */
 export const useDeleteAgent = createMutation<
   DeleteAgentVariables,
   DeleteAgentVariables
 >({
-  mutationFn: async (variables) => {
-    await new Promise((resolve) => setTimeout(resolve, 400))
-    return variables
+  mutationFn: async ({ id }) => {
+    const response = await api.agents[':id'].$delete({ param: { id } })
+    return parseResponse<DeleteAgentVariables>(response)
   },
 })
 
@@ -257,22 +131,15 @@ interface RegenerateMcpResult {
   mcpUrl: string
 }
 
-/**
- * Mock mutation that rotates a profile's MCP URL. Shape matches the
- * eventual hono-rpc surface: server picks a fresh slug, returns the
- * new URL, the client updates the `agent-profiles` cache row by id.
- * The user must re-paste the URL into their harness once this fires.
- */
 export const useRegenerateMcpUrl = createMutation<
   RegenerateMcpResult,
   RegenerateMcpVariables
 >({
   mutationFn: async ({ id }) => {
-    await new Promise((resolve) => setTimeout(resolve, 500))
-    return {
-      id,
-      mcpUrl: `${buildMcpUrl(`${toSlug(id)}-${nanoid(6).toLowerCase()}`)}`,
-    }
+    const response = await api.agents[':id']['mcp-url:regenerate'].$post({
+      param: { id },
+    })
+    return parseResponse<RegenerateMcpResult>(response)
   },
 })
 
@@ -280,77 +147,31 @@ interface UseAgentProfileDetailVariables {
   id: string
 }
 
-/**
- * Derive a full NewAgentValues from a profile summary. The directory
- * row carries summary fields (loginCount, aclRuleCount,
- * blockedActionCount); the wizard wants the full schema. The real
- * backend will persist + return the wizard shape directly; this
- * mock synthesises a plausible detail from the summary fields so the
- * edit screen prefills sensibly.
- */
-function profileToWizardValues(profile: AgentProfile): NewAgentValues {
-  const loginMode = profile.loginScopeLabel.startsWith('Selective')
-    ? ('selective' as LoginMode)
-    : profile.loginScopeLabel.startsWith('All my logins')
-      ? ('all' as LoginMode)
-      : ('profile' as LoginMode)
-  const selectedSites =
-    loginMode === 'selective'
-      ? IMPORTED_SITES.slice(
-          0,
-          Math.min(profile.loginCount, IMPORTED_SITES.length),
-        )
-      : []
-  const approvals = Object.fromEntries(
-    APPROVAL_CATEGORIES.map((category) => [
-      category.id,
-      category.defaultVerdict,
-    ]),
-  ) as Record<string, ApprovalVerdict>
-  const aclRuleIds = SEED_ACL_RULES.slice(
-    0,
-    Math.min(profile.aclRuleCount, SEED_ACL_RULES.length),
-  ).map((rule) => rule.id)
-  return {
-    name: profile.name,
-    harness: profile.harness,
-    loginMode,
-    selectedSites: [...selectedSites],
-    approvals,
-    aclRuleIds,
-    customAclRules: [],
-  }
-}
-
 export const useAgentProfileDetail = createQuery<
   NewAgentValues | null,
   UseAgentProfileDetailVariables
 >({
   queryKey: ['agent-profile-detail'],
-  fetcher: ({ id }) =>
-    new Promise((resolve) =>
-      setTimeout(() => {
-        const profile = MOCK_AGENT_PROFILES.find((p) => p.id === id) ?? null
-        resolve(profile ? profileToWizardValues(profile) : null)
-      }, 80),
-    ),
+  fetcher: async ({ id }) => {
+    const response = await api.agents[':id'].$get({ param: { id } })
+    if (response.status === 404) return null
+    return parseResponse<NewAgentValues>(response)
+  },
 })
 
 interface UpdateAgentVariables extends NewAgentValues {
   id: string
 }
 
-/**
- * Mock updateAgent mutation. Returns the updated values so the
- * caller can rewrite the matching agent-profiles row. Surface area
- * mirrors the eventual hono-rpc `PATCH /agents/:id` route.
- */
 export const useUpdateAgent = createMutation<
   UpdateAgentVariables,
   UpdateAgentVariables
 >({
-  mutationFn: async (variables) => {
-    await new Promise((resolve) => setTimeout(resolve, 500))
-    return variables
+  mutationFn: async ({ id, ...values }) => {
+    const response = await api.agents[':id'].$patch({
+      param: { id },
+      json: values,
+    })
+    return parseResponse<UpdateAgentVariables>(response)
   },
 })

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -118,7 +118,11 @@
       "name": "@browseros/agent-mcp-interface",
       "version": "0.0.1",
       "dependencies": {
+        "@browseros/shared": "workspace:*",
+        "@hono/zod-validator": "^0.8.0",
         "hono": "^4.12.3",
+        "nanoid": "^5.1.11",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@types/bun": "^1.3.5",
@@ -819,7 +823,7 @@
 
     "@hono/node-server": ["@hono/node-server@1.19.9", "", { "peerDependencies": { "hono": "^4" } }, "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw=="],
 
-    "@hono/zod-validator": ["@hono/zod-validator@0.4.3", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.19.1" } }, "sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ=="],
+    "@hono/zod-validator": ["@hono/zod-validator@0.8.0", "", { "peerDependencies": { "hono": ">=4.10.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-5uS4S1/LKtZQYvD4BtpPUFkOv8d1wNxHHrChm26buMiEYc1FrHWvDUaKVBwkiVtvSExHSpLGDvcnpI2Copyj9w=="],
 
     "@hookform/resolvers": ["@hookform/resolvers@5.2.2", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA=="],
 
@@ -4091,6 +4095,8 @@
 
     "@browseros/agent-mcp-interface/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
+    "@browseros/agent-mcp-interface/nanoid": ["nanoid@5.1.11", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg=="],
+
     "@browseros/agent-mcp-ui/@hookform/resolvers": ["@hookform/resolvers@5.4.0", "", { "dependencies": { "@standard-schema/utils": "^0.3.0" }, "peerDependencies": { "react-hook-form": "^7.55.0" } }, "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw=="],
 
     "@browseros/agent-mcp-ui/@radix-ui/react-use-controllable-state": ["@radix-ui/react-use-controllable-state@1.2.3", "", { "dependencies": { "@radix-ui/react-use-effect-event": "0.0.3", "@radix-ui/react-use-layout-effect": "1.1.2" }, "peerDependencies": { "@types/react": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA=="],
@@ -4120,6 +4126,8 @@
     "@browseros/eval/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@browseros/eval/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
+    "@browseros/server/@hono/zod-validator": ["@hono/zod-validator@0.4.3", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.19.1" } }, "sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ=="],
 
     "@browseros/server/@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
 
@@ -4216,8 +4224,6 @@
     "@graphql-tools/url-loader/@graphql-tools/utils": ["@graphql-tools/utils@11.0.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.1.1", "@whatwg-node/promise-helpers": "^1.0.0", "cross-inspect": "1.0.1", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-bM1HeZdXA2C3LSIeLOnH/bcqSgbQgKEDrjxODjqi3y58xai2TkNrtYcQSoWzGbt9VMN1dORGjR7Vem8SPnUFQA=="],
 
     "@graphql-tools/wrap/@graphql-tools/utils": ["@graphql-tools/utils@11.0.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.1.1", "@whatwg-node/promise-helpers": "^1.0.0", "cross-inspect": "1.0.1", "tslib": "^2.4.0" }, "peerDependencies": { "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0" } }, "sha512-bM1HeZdXA2C3LSIeLOnH/bcqSgbQgKEDrjxODjqi3y58xai2TkNrtYcQSoWzGbt9VMN1dORGjR7Vem8SPnUFQA=="],
-
-    "@hono/zod-validator/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@inquirer/core/wrap-ansi": ["wrap-ansi@6.2.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA=="],
 


### PR DESCRIPTION
## Summary

Phase 1 of the backend roadmap. Replaces the six mocked agent-profile hooks in `agent-mcp-ui` with real `@browseros/agent-mcp-interface` endpoints. Foundation work the phase needs (storage helper, browseros-dir resolver, zod-validator wiring, `bun test`) ships in the same PR.

By the end of this PR a user can `bun --cwd apps/agent-mcp-interface start`, open the cockpit, walk Add agent → Edit → Regenerate URL → Revoke, and watch every step persist to `<browserosDir>/mcp-interface/agents/<id>.json` and disappear on revoke. Every layer is also covered by `bun test`.

- Roadmap reference: `plans/browseros-ai/BrowserOS/features/2026-06-16-1847-claude-code-mcp-interface-backend-roadmap.md`
- Per-phase plan: `plans/browseros-ai/BrowserOS/features/2026-06-16-1858-claude-code-mcp-interface-phase-1-agents-crud.md`

## What landed

### Backend

- `src/env.ts` grows `browserosDirOverride` and `isDevelopment` reads (still the only sanctioned `process.env` reader).
- `src/lib/browseros-dir.ts` — resolves `<homedir>/.browseros` (or `.browseros-dev` under `NODE_ENV=development`) with the env override winning. Everything in this package writes under `<browserosDir>/mcp-interface/`.
- `src/lib/storage.ts` — atomic JSON read/write with zod, list, remove, ensure-dir, exists. Writes go through `<name>.tmp` rename. Absolute paths or `..` escapes throw `StorageInvalidPathError`. Missing files throw `StorageNotFoundError`; schema mismatches throw `StorageCorruptError`.
- `src/lib/slug.ts` — mirrors the UI's `toSlug`; `uniqueSlug` appends `-2`, `-3`, … up to `-99` before throwing.
- `src/routes/agents/schemas.ts` — zod shapes for the wire contract (NewAgentValues, AgentProfileSummary, CreatedAgent, StoredAgentProfile, idAck, RegeneratedMcpUrl) + types.
- `src/routes/agents/service.ts` — file-backed CRUD over `<browserosDir>/mcp-interface/agents/<id>.json`. mcpUrl is recomputed from `getLocalServerUrl()` on every read so a port change between boots doesn't strand the stored value.
- `src/routes/agents/index.ts` — six chained Hono routes wired into `server.ts` via `.route('/', agentsRoute)`; `AppType` automatically picks them up.

### Routes

| Route | Hooks it replaces |
|---|---|
| `POST /agents` | `useCreateAgent` |
| `GET /agents` | `useAgentProfiles` |
| `GET /agents/:id` | `useAgentProfileDetail` |
| `PATCH /agents/:id` | `useUpdateAgent` |
| `DELETE /agents/:id` | `useDeleteAgent` |
| `POST /agents/:id/mcp-url:regenerate` | `useRegenerateMcpUrl` |

### UI

`apps/agent-mcp-ui/modules/api/agents.hooks.ts` shrinks from 357 lines to 178 — six hooks now hit the typed `api.agents.…` client through the existing `parseResponse` helper. Mock fixtures, `profileToWizardValues` synthesiser, mock `nanoid`/`buildMcpUrl`/`toSlug` callsites, and the artificial setTimeout latencies are deleted. The hook return shapes are byte-identical, so no UI component code changes.

`useAgents` (cockpit running grid) stays on a three-row mock with a top-of-file comment naming Phase 4 as its swap.

## Test plan

- [x] `bun --cwd apps/agent-mcp-interface test` — 33 tests / 88 expect calls pass in <100ms (13 storage, 15 service, 5 route integration).
- [x] `bun --cwd apps/agent-mcp-interface typecheck` clean.
- [x] `bun --cwd apps/agent-mcp-interface lint` clean.
- [x] `bun --cwd apps/agent-mcp-ui typecheck` clean.
- [x] `bun --cwd apps/agent-mcp-ui lint` clean.
- [x] `bun --cwd apps/agent-mcp-ui lint:doctor` — 100/100, 0 findings.
- [x] Manual smoke against a live backend (curl walk): create → list (derived projection) → detail → patch (slug recomputed) → regenerate (rotated slug) → delete → empty list. 404 on every unknown id. 400 on empty `name`.

### Reproducing the manual smoke

```bash
cd packages/browseros-agent

# pick a fresh dir so the smoke doesn't pollute your real ~/.browseros
SMOKE_DIR=/tmp/browseros-smoke-$(date +%s)
BROWSEROS_DIR=\$SMOKE_DIR bun --cwd apps/agent-mcp-interface src/main.ts &

# then walk the lifecycle via the cockpit (build + serve apps/agent-mcp-ui) or via curl as in the PR body.
```

## Out of scope (deferred per the roadmap)

- `/mcp/:slug` endpoint and tool dispatch. That's Phase 2.
- Run-derived data (`useAgents` for the cockpit, `lastRunAt`, `alwaysAllowCount`). Phase 4 / 6.
- Vault-derived `loginCount`. Phase 8; today the service trusts what the wizard sends and stores it verbatim.
- UI behaviour changes beyond the hook swap.