### PR TITLE
revert: remove deprecated controller extension plumbing

### DIFF
--- a/packages/browseros-agent/apps/server/src/config.ts
+++ b/packages/browseros-agent/apps/server/src/config.ts
@@ -20,6 +20,7 @@ const ServerConfigSchema = z.object({
   cdpPort: portSchema.nullable(),
   serverPort: portSchema,
   agentPort: portSchema,
+  extensionPort: portSchema.nullable(),
   resourcesDir: z.string(),
   executionDir: z.string(),
   mcpAllowRemote: z.boolean(),
@@ -166,6 +167,7 @@ function parseCliArgs(argv: string[]): ConfigResult<ParsedCliArgs> {
       overrides: omitUndefined({
         cdpPort: opts.cdpPort,
         serverPort: opts.serverPort ?? opts.httpMcpPort,
+        extensionPort: opts.extensionPort,
         resourcesDir: opts.resourcesDir
           ? toAbsolutePath(opts.resourcesDir, cwd)
           : undefined,
@@ -209,6 +211,7 @@ function parseConfigFile(filePath?: string): ConfigResult<PartialConfig> {
       value: omitUndefined({
         cdpPort: cfg.ports?.cdp,
         serverPort: cfg.ports?.server ?? cfg.ports?.http_mcp,
+        extensionPort: cfg.ports?.extension,
         resourcesDir: parseAbsolutePath(cfg.directories?.resources, configDir),
         executionDir: parseAbsolutePath(cfg.directories?.execution, configDir),
         mcpAllowRemote:
@@ -256,6 +259,9 @@ function parseRuntimeEnv(): ConfigResult<PartialConfig> {
       serverPort: process.env.BROWSEROS_SERVER_PORT
         ? safeParseInt(process.env.BROWSEROS_SERVER_PORT)
         : undefined,
+      extensionPort: process.env.BROWSEROS_EXTENSION_PORT
+        ? safeParseInt(process.env.BROWSEROS_EXTENSION_PORT)
+        : undefined,
       resourcesDir: process.env.BROWSEROS_RESOURCES_DIR
         ? toAbsolutePath(process.env.BROWSEROS_RESOURCES_DIR, cwd)
         : undefined,
@@ -296,6 +302,7 @@ function validateInlinedEnv(): ConfigResult<void> {
 function getDefaults(cwd: string): PartialConfig {
   return {
     cdpPort: null,
+    extensionPort: null,
     resourcesDir: cwd,
     executionDir: cwd,
     mcpAllowRemote: false,

--- a/packages/browseros-agent/apps/server/tests/config.test.ts
+++ b/packages/browseros-agent/apps/server/tests/config.test.ts
@@ -50,7 +50,7 @@ describe('loadServerConfig', () => {
       assert.strictEqual(result.value.cdpPort, 9222)
       assert.strictEqual(result.value.serverPort, 9223)
       assert.strictEqual(result.value.agentPort, 9223)
-      assert.strictEqual('extensionPort' in result.value, false)
+      assert.strictEqual(result.value.extensionPort, 9224)
       assert.strictEqual(result.value.mcpAllowRemote, false)
     })
 
@@ -77,7 +77,7 @@ describe('loadServerConfig', () => {
       assert.strictEqual(result.ok, true)
       if (!result.ok) return
       assert.strictEqual(result.value.cdpPort, null)
-      assert.strictEqual('extensionPort' in result.value, false)
+      assert.strictEqual(result.value.extensionPort, null)
     })
 
     it('warns when --extension-port is provided', () => {
@@ -119,7 +119,7 @@ describe('loadServerConfig', () => {
       assert.strictEqual(result.value.serverPort, 9223)
       // agentPort is deprecated - always equals serverPort
       assert.strictEqual(result.value.agentPort, 9223)
-      assert.strictEqual('extensionPort' in result.value, false)
+      assert.strictEqual(result.value.extensionPort, 9224)
     })
 
     it('CLI takes precedence over env', () => {
@@ -138,7 +138,7 @@ describe('loadServerConfig', () => {
       assert.strictEqual(result.value.serverPort, 1111)
       // agentPort is deprecated - always equals serverPort
       assert.strictEqual(result.value.agentPort, 1111)
-      assert.strictEqual('extensionPort' in result.value, false)
+      assert.strictEqual(result.value.extensionPort, 3333)
     })
   })
 
@@ -171,7 +171,7 @@ describe('loadServerConfig', () => {
       assert.strictEqual(result.value.serverPort, 3000)
       // agentPort is deprecated - always equals serverPort
       assert.strictEqual(result.value.agentPort, 3000)
-      assert.strictEqual('extensionPort' in result.value, false)
+      assert.strictEqual(result.value.extensionPort, 3002)
       assert.strictEqual(result.value.mcpAllowRemote, true)
     })
 
@@ -420,7 +420,7 @@ describe('loadServerConfig', () => {
       assert.strictEqual(result.value.agentPort, result.value.serverPort)
     })
 
-    it('does not expose deprecated extensionPort', () => {
+    it('defaults extensionPort to null', () => {
       const result = loadServerConfig([
         'bun',
         'src/index.ts',
@@ -429,7 +429,7 @@ describe('loadServerConfig', () => {
 
       assert.strictEqual(result.ok, true)
       if (!result.ok) return
-      assert.strictEqual('extensionPort' in result.value, false)
+      assert.strictEqual(result.value.extensionPort, null)
     })
 
     it('defaults aiSdkDevtoolsEnabled to false', () => {

--- a/packages/browseros-agent/apps/server/tests/main.test.ts
+++ b/packages/browseros-agent/apps/server/tests/main.test.ts
@@ -9,6 +9,7 @@ const config = {
   cdpPort: 9222,
   serverPort: 9100,
   agentPort: 9100,
+  extensionPort: null,
   resourcesDir: '/tmp/browseros-resources',
   executionDir: '/tmp/browseros-execution',
   mcpAllowRemote: false,

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_constants.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_constants.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/core/browseros_constants.h b/chrome/browser/browseros/core/browseros_constants.h
 new file mode 100644
-index 0000000000000..db7b6c9a04290
+index 0000000000000..fdeee36f8cc70
 --- /dev/null
 +++ b/chrome/browser/browseros/core/browseros_constants.h
-@@ -0,0 +1,238 @@
+@@ -0,0 +1,227 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -39,6 +39,10 @@ index 0000000000000..db7b6c9a04290
 +// Bug Reporter Extension ID
 +inline constexpr char kBugReporterExtensionId[] =
 +    "adlpneommgkgeanpaekgoaolcpncohkf";
++
++// Controller Extension ID
++inline constexpr char kControllerExtensionId[] =
++    "nlnihljpboknmfagkikhkdblbedophja";
 +
 +// uBlock Origin Extension ID (Chrome Web Store)
 +// inline constexpr char kUBlockOriginExtensionId[] =
@@ -169,6 +173,7 @@ index 0000000000000..db7b6c9a04290
 +inline constexpr BrowserOSExtensionInfo kBrowserOSExtensions[] = {
 +    {kAgentExtensionId, false, false},
 +    {kBugReporterExtensionId, true, false},
++    {kControllerExtensionId, false, false},
 +    // ublock origin gets installed from chrome web store
 +    // {kUBlockOriginExtensionId, false, false},
 +};
@@ -208,28 +213,12 @@ index 0000000000000..db7b6c9a04290
 +  return extension_id == kAgentExtensionId;
 +}
 +
++// Get all BrowserOS extension IDs
 +inline std::vector<std::string> GetBrowserOSExtensionIds() {
 +  std::vector<std::string> ids;
 +  ids.reserve(kBrowserOSExtensionsCount);
 +  for (const auto& info : kBrowserOSExtensions)
 +    ids.push_back(info.id);
-+  return ids;
-+}
-+
-+inline constexpr std::string_view kDeprecatedBrowserOSExtensions[] = {
-+    "nlnihljpboknmfagkikhkdblbedophja",
-+};
-+
-+inline constexpr size_t kDeprecatedBrowserOSExtensionsCount =
-+    sizeof(kDeprecatedBrowserOSExtensions) /
-+    sizeof(kDeprecatedBrowserOSExtensions[0]);
-+
-+// Returns BrowserOS-managed IDs that should be removed, not installed.
-+inline std::vector<std::string> GetDeprecatedBrowserOSExtensionIds() {
-+  std::vector<std::string> ids;
-+  ids.reserve(kDeprecatedBrowserOSExtensionsCount);
-+  for (std::string_view id : kDeprecatedBrowserOSExtensions)
-+    ids.push_back(std::string(id));
 +  return ids;
 +}
 +

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_maintainer.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_maintainer.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/extensions/browseros_extension_maintainer.cc b/chrome/browser/browseros/extensions/browseros_extension_maintainer.cc
 new file mode 100644
-index 0000000000000..75848548e95a2
+index 0000000000000..5804d54696e8f
 --- /dev/null
 +++ b/chrome/browser/browseros/extensions/browseros_extension_maintainer.cc
-@@ -0,0 +1,409 @@
+@@ -0,0 +1,395 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -79,8 +79,6 @@ index 0000000000000..75848548e95a2
 +            << " extensions, scheduling in "
 +            << kInitialMaintenanceDelay.InSeconds() << "s";
 +
-+  UninstallDeprecatedExtensions();
-+
 +  base::SingleThreadTaskRunner::GetCurrentDefault()->PostDelayedTask(
 +      FROM_HERE,
 +      base::BindOnce(&BrowserOSExtensionMaintainer::RunMaintenanceCycle,
@@ -134,9 +132,7 @@ index 0000000000000..75848548e95a2
 +      last_config_ = std::move(config);
 +
 +      for (const auto [id, _] : last_config_) {
-+        if (IsBrowserOSExtension(id)) {
-+          extension_ids_.insert(id);
-+        }
++        extension_ids_.insert(id);
 +      }
 +
 +      LOG(INFO) << "browseros: Updated config with " << last_config_.size()
@@ -192,7 +188,7 @@ index 0000000000000..75848548e95a2
 +}
 +
 +void BrowserOSExtensionMaintainer::UninstallDeprecatedExtensions() {
-+  if (!profile_) {
++  if (!profile_ || last_config_.empty()) {
 +    return;
 +  }
 +
@@ -205,10 +201,19 @@ index 0000000000000..75848548e95a2
 +    return;
 +  }
 +
-+  auto uninstall = [&](const std::string& id) {
++  std::set<std::string> server_ids;
++  for (const auto [id, _] : last_config_) {
++    server_ids.insert(id);
++  }
++
++  for (const std::string& id : GetBrowserOSExtensionIds()) {
++    if (server_ids.contains(id)) {
++      continue;
++    }
++
 +    const extensions::Extension* ext = registry->GetInstalledExtension(id);
 +    if (!ext) {
-+      return;
++      continue;
 +    }
 +
 +    LOG(INFO) << "browseros: Uninstalling deprecated extension " << id;
@@ -218,25 +223,6 @@ index 0000000000000..75848548e95a2
 +            id, extensions::UNINSTALL_REASON_ORPHANED_EXTERNAL_EXTENSION,
 +            &error)) {
 +      LOG(WARNING) << "browseros: Failed to uninstall " << id << ": " << error;
-+    }
-+  };
-+
-+  for (const std::string& id : GetDeprecatedBrowserOSExtensionIds()) {
-+    uninstall(id);
-+  }
-+
-+  if (last_config_.empty()) {
-+    return;
-+  }
-+
-+  std::set<std::string> server_ids;
-+  for (const auto [id, _] : last_config_) {
-+    server_ids.insert(id);
-+  }
-+
-+  for (const std::string& id : GetBrowserOSExtensionIds()) {
-+    if (!server_ids.contains(id)) {
-+      uninstall(id);
 +    }
 +  }
 +}

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_manager.cc b/chrome/browser/browseros/server/browseros_server_manager.cc
 new file mode 100644
-index 0000000000000..4d90d805f963e
+index 0000000000000..069d1b79d6ae2
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_manager.cc
-@@ -0,0 +1,1116 @@
+@@ -0,0 +1,1120 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -292,7 +292,10 @@ index 0000000000000..4d90d805f963e
 +    ports_.server = browseros_server::kDefaultServerPort;
 +  }
 +
-+  ports_.extension = browseros_server::kDefaultExtensionPort;
++  ports_.extension = local_state_->GetInteger(browseros_server::kExtensionServerPort);
++  if (ports_.extension <= 0) {
++    ports_.extension = browseros_server::kDefaultExtensionPort;
++  }
 +
 +  allow_remote_in_mcp_ = local_state_->GetBoolean(browseros_server::kAllowRemoteInMCP);
 +
@@ -404,6 +407,7 @@ index 0000000000000..4d90d805f963e
 +  local_state_->SetInteger(browseros_server::kCDPServerPort, ports_.cdp);
 +  local_state_->SetInteger(browseros_server::kProxyPort, ports_.proxy);
 +  local_state_->SetInteger(browseros_server::kServerPort, ports_.server);
++  local_state_->SetInteger(browseros_server::kExtensionServerPort, ports_.extension);
 +
 +  // DEPRECATED: keep mcp_port in sync with server port for backward compat
 +  local_state_->SetInteger(browseros_server::kMCPServerPort, ports_.server);

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager_unittest.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager_unittest.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_manager_unittest.cc b/chrome/browser/browseros/server/browseros_server_manager_unittest.cc
 new file mode 100644
-index 0000000000000..7448ebffd0a0d
+index 0000000000000..8f97e0b97467f
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_manager_unittest.cc
-@@ -0,0 +1,482 @@
+@@ -0,0 +1,497 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -446,18 +446,29 @@ index 0000000000000..7448ebffd0a0d
 +  SetupSuccessfulLaunch();
 +  manager_->SetRunningForTesting(true);
 +
++  // Set initial known ports in prefs
 +  prefs_.SetInteger(browseros_server::kServerPort, 9200);
++  prefs_.SetInteger(browseros_server::kExtensionServerPort, 9300);
 +
++  // Mock WaitForExitWithTimeout (called on thread pool during restart)
 +  ON_CALL(*process_controller_, WaitForExitWithTimeout(_, _, _))
 +      .WillByDefault(Return(true));
 +
++  // Trigger restart via health check failure
 +  manager_->OnHealthCheckComplete(false);
 +
++  // Run all pending tasks (thread pool + reply)
 +  task_environment_.RunUntilIdle();
 +
++  // After restart, prefs must reflect the manager's current in-memory ports.
++  // This is the invariant: prefs and in-memory state stay in sync.
 +  EXPECT_EQ(manager_->GetServerPort(),
 +            prefs_.GetInteger(browseros_server::kServerPort));
++  EXPECT_EQ(manager_->GetExtensionPort(),
++            prefs_.GetInteger(browseros_server::kExtensionServerPort));
++  // Server and extension ports should be non-zero (resolved by FindAvailablePort)
 +  EXPECT_NE(0, prefs_.GetInteger(browseros_server::kServerPort));
++  EXPECT_NE(0, prefs_.GetInteger(browseros_server::kExtensionServerPort));
 +}
 +
 +TEST_F(BrowserOSServerManagerTest, UpdateRestartSavesEphemeralPortsToPrefs) {
@@ -465,6 +476,7 @@ index 0000000000000..7448ebffd0a0d
 +  manager_->SetRunningForTesting(true);
 +
 +  prefs_.SetInteger(browseros_server::kServerPort, 9200);
++  prefs_.SetInteger(browseros_server::kExtensionServerPort, 9300);
 +
 +  ON_CALL(*process_controller_, WaitForExitWithTimeout(_, _, _))
 +      .WillByDefault(Return(true));
@@ -481,7 +493,10 @@ index 0000000000000..7448ebffd0a0d
 +
 +  EXPECT_EQ(manager_->GetServerPort(),
 +            prefs_.GetInteger(browseros_server::kServerPort));
++  EXPECT_EQ(manager_->GetExtensionPort(),
++            prefs_.GetInteger(browseros_server::kExtensionServerPort));
 +  EXPECT_NE(0, prefs_.GetInteger(browseros_server::kServerPort));
++  EXPECT_NE(0, prefs_.GetInteger(browseros_server::kExtensionServerPort));
 +}
 +
 +}  // namespace

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_prefs.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_prefs.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_prefs.cc b/chrome/browser/browseros/server/browseros_server_prefs.cc
 new file mode 100644
-index 0000000000000..2dfba7e9914ab
+index 0000000000000..8c3a459477837
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_prefs.cc
-@@ -0,0 +1,45 @@
+@@ -0,0 +1,49 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -23,6 +23,9 @@ index 0000000000000..2dfba7e9914ab
 +// Sidecar backend server port
 +const char kServerPort[] = "browseros.server.server_port";
 +
++// Extension WebSocket server port
++const char kExtensionServerPort[] = "browseros.server.extension_port";
++
 +// Allow remote connections to MCP server (security setting)
 +const char kAllowRemoteInMCP[] = "browseros.server.allow_remote_in_mcp";
 +
@@ -40,6 +43,7 @@ index 0000000000000..2dfba7e9914ab
 +  registry->RegisterIntegerPref(kCDPServerPort, kDefaultCDPPort);
 +  registry->RegisterIntegerPref(kProxyPort, kDefaultProxyPort);
 +  registry->RegisterIntegerPref(kServerPort, kDefaultServerPort);
++  registry->RegisterIntegerPref(kExtensionServerPort, kDefaultExtensionPort);
 +  registry->RegisterBooleanPref(kAllowRemoteInMCP, false);
 +  registry->RegisterBooleanPref(kRestartServerRequested, false);
 +  registry->RegisterStringPref(kServerVersion, std::string());

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_prefs.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_prefs.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_prefs.h b/chrome/browser/browseros/server/browseros_server_prefs.h
 new file mode 100644
-index 0000000000000..21266c319f66b
+index 0000000000000..69bd172f9ce25
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_prefs.h
-@@ -0,0 +1,35 @@
+@@ -0,0 +1,36 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -25,6 +25,7 @@ index 0000000000000..21266c319f66b
 +extern const char kCDPServerPort[];
 +extern const char kProxyPort[];
 +extern const char kServerPort[];
++extern const char kExtensionServerPort[];
 +extern const char kAllowRemoteInMCP[];
 +extern const char kRestartServerRequested[];
 +extern const char kServerVersion[];


### PR DESCRIPTION
## Summary
- Reverts 11b75754, restoring the controller extension plumbing removed in #1218.
- Keeps the later generated bundled extension artifact cleanup intact; that file was already removed after #1218.

## Verification
- `git diff --check`
- pre-commit hook: `biome-check` passed; `file-length` reported the existing `config.test.ts` length warning.
- pre-push hook: `branch-name` passed.
- `autoninja -C out/Default_arm64 chrome` could not run because `out/Default_arm64` does not exist in this worktree.
