### PR TITLE
feat(agent-mcp-interface): site rules + permissions catalog + check api

### DIFF
--- a/packages/browseros-agent/apps/agent-mcp-interface/src/lib/approval-catalog.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/lib/approval-catalog.ts
@@ -1,0 +1,62 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * System-wide default approval catalog. This is the source for
+ * `GET /permissions/catalog` and the fallback `permissions.check()`
+ * uses when neither a site rule nor an agent verdict applies.
+ *
+ * Keep in sync with the UI's local catalog at
+ * apps/agent-mcp-ui/screens/new-agent/new-agent.schemas.ts
+ * (`APPROVAL_CATEGORIES`). The UI keeps its own copy as the
+ * fetch-failure fallback path for the Permissions tab; this server
+ * copy is the source of truth at the wire boundary.
+ */
+
+import { z } from 'zod'
+
+export const approvalVerdictEnum = z.enum(['Auto', 'Ask', 'Block'])
+export type ApprovalVerdict = z.infer<typeof approvalVerdictEnum>
+
+export const approvalCategorySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  defaultVerdict: approvalVerdictEnum,
+  allowAuto: z.boolean(),
+})
+export type ApprovalCategory = z.infer<typeof approvalCategorySchema>
+
+export const APPROVAL_CATEGORIES: readonly ApprovalCategory[] = [
+  {
+    id: 'submit',
+    name: 'Submit / send / post',
+    defaultVerdict: 'Ask',
+    allowAuto: true,
+  },
+  {
+    id: 'payment',
+    name: 'Payments & checkout',
+    defaultVerdict: 'Block',
+    allowAuto: false,
+  },
+  {
+    id: 'delete',
+    name: 'Delete / destructive',
+    defaultVerdict: 'Ask',
+    allowAuto: true,
+  },
+  { id: 'upload', name: 'File upload', defaultVerdict: 'Ask', allowAuto: true },
+  {
+    id: 'navigate',
+    name: 'Navigate to a new site',
+    defaultVerdict: 'Ask',
+    allowAuto: true,
+  },
+  {
+    id: 'input',
+    name: 'Click & type',
+    defaultVerdict: 'Auto',
+    allowAuto: true,
+  },
+]

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/lib/match-domain.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/lib/match-domain.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Glob matcher for site-rule domain patterns. Patterns the user can
+ * configure today:
+ *
+ *   stripe.com         exact match (case insensitive)
+ *   *.example.com      any subdomain (must have at least one label
+ *                      before .example.com; "example.com" does NOT
+ *                      match)
+ *   admin.*            any domain that starts with "admin."; "admin."
+ *                      alone does not match (we require at least one
+ *                      char after the dot)
+ *   *                  matches every non-empty domain
+ *
+ * Same matcher is reused by Phase 3's executor pre-flight and Phase 6's
+ * grants short-circuit, so the semantics live in one place and the
+ * unit tests pin every shape.
+ */
+
+const REGEX_META = /[.+?^${}()|[\]\\]/g
+
+export function matchDomain(pattern: string, domain: string): boolean {
+  if (!pattern || !domain) return false
+  const lowerPattern = pattern.toLowerCase()
+  const lowerDomain = domain.toLowerCase()
+  // Bare `*` is a hot path: matches any non-empty domain.
+  if (lowerPattern === '*') return lowerDomain.length > 0
+  // Translate the glob to a regex by escaping every metacharacter
+  // EXCEPT `*`, then replacing each `*` with `.+`. `.+` (not `.*`) so
+  // `*.foo.com` requires at least one label before `.foo.com`.
+  const regexSource = lowerPattern
+    .split('*')
+    .map((part) => part.replace(REGEX_META, '\\$&'))
+    .join('.+')
+  return new RegExp(`^${regexSource}$`).test(lowerDomain)
+}

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/routes/permissions/index.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/routes/permissions/index.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * /permissions route chain. Returns the system-wide approval catalog
+ * baked into `lib/approval-catalog.ts`. Customisation (PUT/PATCH on
+ * the catalog) is intentionally deferred; the UI keeps its own copy as
+ * a fetch-failure fallback.
+ */
+
+import { Hono } from 'hono'
+import { APPROVAL_CATEGORIES } from '../../lib/approval-catalog'
+
+export const permissionsRoute = new Hono().get('/permissions/catalog', (c) =>
+  c.json(APPROVAL_CATEGORIES),
+)

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/routes/site-rules/index.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/routes/site-rules/index.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * /site-rules route chain. Thin Hono layer over `./service`: zValidator
+ * rejects malformed bodies with structured 400s, and DELETE surfaces
+ * the service's null-return as 404. The chained `.get / .post /
+ * .delete` calls preserve the inferred shape `AppType` needs; do not
+ * break the chain.
+ */
+
+import { zValidator } from '@hono/zod-validator'
+import { Hono } from 'hono'
+import { HttpError } from '../../lib/errors'
+import { addSiteRuleSchema } from './schemas'
+import { add, list, remove } from './service'
+
+export const siteRulesRoute = new Hono()
+  .get('/site-rules', async (c) => c.json(await list()))
+  .post('/site-rules', zValidator('json', addSiteRuleSchema), async (c) => {
+    const body = c.req.valid('json')
+    const created = await add(body)
+    return c.json(created, 201)
+  })
+  .delete('/site-rules/:id', async (c) => {
+    const removed = await remove(c.req.param('id'))
+    if (!removed) throw new HttpError(404, 'site rule not found')
+    return c.json(removed)
+  })

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/routes/site-rules/schemas.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/routes/site-rules/schemas.ts
@@ -1,0 +1,51 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Zod shapes for the /site-rules routes. Wire shape mirrors
+ * apps/agent-mcp-ui/modules/api/site-rules.hooks.ts so the UI's
+ * existing `SiteRule` / `AddSiteRuleVariables` consumers stay byte
+ * identical after the hook swap.
+ *
+ * Storage shape is a single file holding an array; site-rule lookups
+ * are always full-table scans (typical user has under 20 rules) and
+ * Phase 5's `permissions.check` reads the whole set on every dispatch.
+ */
+
+import { z } from 'zod'
+
+export const siteRuleActionEnum = z.enum([
+  'payments',
+  'submit',
+  'delete',
+  'navigate',
+  'upload',
+  'admin',
+])
+export type SiteRuleAction = z.infer<typeof siteRuleActionEnum>
+
+/** Wire shape: POST body. */
+export const addSiteRuleSchema = z.object({
+  label: z.string().trim().min(1),
+  domain: z.string().trim().min(1),
+  action: siteRuleActionEnum,
+})
+export type AddSiteRuleVariables = z.infer<typeof addSiteRuleSchema>
+
+/** Wire shape: GET / and POST / response item. Also the on-disk row shape. */
+export const siteRuleSchema = z.object({
+  id: z.string(),
+  label: z.string().min(1),
+  domain: z.string().min(1),
+  action: siteRuleActionEnum,
+})
+export type SiteRule = z.infer<typeof siteRuleSchema>
+
+/** Storage wrapper: site-rules.json holds an array. */
+export const siteRulesFileSchema = z.array(siteRuleSchema)
+export type SiteRulesFile = z.infer<typeof siteRulesFileSchema>
+
+/** Wire shape: DELETE response. */
+export const idAckSchema = z.object({ id: z.string() })
+export type IdAck = z.infer<typeof idAckSchema>

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/routes/site-rules/service.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/routes/site-rules/service.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * File-backed site-rules service. All rules live in a single array
+ * file at <browserosDir>/mcp-interface/site-rules.json (typical user
+ * count is under 20, full-array scans on every read are fine and the
+ * single-file shape lets the UI's list view round-trip in one I/O
+ * call).
+ *
+ * Mutations go through a per-service AsyncMutex so two concurrent
+ * `add` calls cannot drop one (the read-then-rewrite window is the
+ * same shape the agents service guards in Phase 1). Reads are
+ * lock-free.
+ */
+
+import { nanoid } from 'nanoid'
+import { AsyncMutex } from '../../lib/async-mutex'
+import { matchDomain } from '../../lib/match-domain'
+import {
+  fileExists,
+  readJson,
+  StorageNotFoundError,
+  writeJson,
+} from '../../lib/storage'
+import {
+  type AddSiteRuleVariables,
+  type SiteRule,
+  siteRulesFileSchema,
+} from './schemas'
+
+const FILE = 'site-rules.json'
+const ID_PATTERN = /^[A-Za-z0-9_-]+$/
+const MAX_ID_LENGTH = 64
+
+/**
+ * `id` is server-generated nanoid; we validate it here too so a
+ * traversal-shaped value handed to the DELETE handler resolves to
+ * not-found before the storage layer ever sees it. Same defence-in-
+ * depth pattern as the agents service.
+ */
+function isValidId(id: string): boolean {
+  return id.length > 0 && id.length <= MAX_ID_LENGTH && ID_PATTERN.test(id)
+}
+
+const mutex = new AsyncMutex()
+
+async function loadAll(): Promise<SiteRule[]> {
+  try {
+    return await readJson(FILE, siteRulesFileSchema)
+  } catch (err) {
+    if (err instanceof StorageNotFoundError) return []
+    throw err
+  }
+}
+
+export async function list(): Promise<SiteRule[]> {
+  return loadAll()
+}
+
+export async function add(input: AddSiteRuleVariables): Promise<SiteRule> {
+  return mutex.run(async () => {
+    const existing = await loadAll()
+    const rule: SiteRule = {
+      id: nanoid(8),
+      label: input.label,
+      domain: input.domain,
+      action: input.action,
+    }
+    const next = [...existing, rule]
+    await writeJson(FILE, next, siteRulesFileSchema)
+    return rule
+  })
+}
+
+export async function remove(id: string): Promise<{ id: string } | null> {
+  if (!isValidId(id)) return null
+  return mutex.run(async () => {
+    if (!(await fileExists(FILE))) return null
+    const existing = await loadAll()
+    const next = existing.filter((rule) => rule.id !== id)
+    if (next.length === existing.length) return null
+    await writeJson(FILE, next, siteRulesFileSchema)
+    return { id }
+  })
+}
+
+/**
+ * In-process helper used by `permissions.check`. Returns every rule
+ * whose `(domain, action)` pair matches the request. Caller decides
+ * how to combine multiple matches (Phase 5: any match with a
+ * configured verb yields a clamp).
+ */
+export async function findMatching(
+  domain: string,
+  action: SiteRule['action'],
+): Promise<SiteRule[]> {
+  const rules = await loadAll()
+  return rules.filter(
+    (rule) => rule.action === action && matchDomain(rule.domain, domain),
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/server.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/server.ts
@@ -18,6 +18,8 @@ import { cors } from 'hono/cors'
 import { HttpError } from './lib/errors'
 import { logger } from './lib/logger'
 import { agentsRoute } from './routes/agents'
+import { permissionsRoute } from './routes/permissions'
+import { siteRulesRoute } from './routes/site-rules'
 import { systemRoute } from './routes/system'
 
 // Telemetry capture is injectable so the server module stays usable
@@ -61,7 +63,11 @@ app.onError((err, c) => {
   return c.json({ error: message }, 500)
 })
 
-const routes = app.route('/', systemRoute).route('/', agentsRoute)
+const routes = app
+  .route('/', systemRoute)
+  .route('/', agentsRoute)
+  .route('/', siteRulesRoute)
+  .route('/', permissionsRoute)
 
 export type AppType = typeof routes
 export default routes

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/services/permissions.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/services/permissions.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * In-process permission check used by the future browser executor
+ * (Phase 3) and run lifecycle (Phase 4). Returns the verdict for a
+ * single (agent, verb, domain) tuple plus the source so callers can
+ * tell the user WHY their action was clamped.
+ *
+ * Precedence (highest wins):
+ *   1. site-rule match -> block, source: 'site-rule'
+ *      Rules are clamps: a matched rule overrides any agent verdict.
+ *      Phase 5 treats every matching rule as a hard block; finer-
+ *      grained per-rule verdicts can land later without churning the
+ *      call site.
+ *   2. agent.approvals[verb] -> source: 'agent'
+ *   3. catalog defaultVerdict[verb] -> source: 'permission-default'
+ *   4. unknown verb -> block, source: 'permission-default'
+ *      Defence in depth: a verb the catalog has never heard of is
+ *      treated as restricted, not auto.
+ *
+ * There is NO HTTP route for this. Callers import and invoke
+ * directly; the unit tests are the only consumer until the executor
+ * lands.
+ */
+
+import {
+  APPROVAL_CATEGORIES,
+  type ApprovalCategory,
+  type ApprovalVerdict,
+} from '../lib/approval-catalog'
+import * as agentsService from '../routes/agents/service'
+import type { SiteRuleAction } from '../routes/site-rules/schemas'
+import * as siteRulesService from '../routes/site-rules/service'
+
+export type CheckVerdict = 'auto' | 'ask' | 'block'
+export type CheckSource = 'agent' | 'site-rule' | 'permission-default'
+
+export interface CheckInput {
+  agentId: string
+  verb: string
+  domain: string
+}
+
+export interface CheckResult {
+  verdict: CheckVerdict
+  source: CheckSource
+}
+
+/**
+ * Catalog verbs the user configures per agent map onto the coarser
+ * site-rule action space. `input` (click & type) is intentionally
+ * not domain-scoped: site rules clamp meaningful actions, not every
+ * keystroke.
+ */
+const VERB_TO_RULE_ACTION: Record<string, SiteRuleAction> = {
+  submit: 'submit',
+  payment: 'payments',
+  delete: 'delete',
+  upload: 'upload',
+  navigate: 'navigate',
+}
+
+const CATALOG_BY_ID: Record<string, ApprovalCategory> = Object.fromEntries(
+  APPROVAL_CATEGORIES.map((category) => [category.id, category]),
+)
+
+function normalize(verdict: ApprovalVerdict): CheckVerdict {
+  return verdict.toLowerCase() as CheckVerdict
+}
+
+export async function check(input: CheckInput): Promise<CheckResult> {
+  const { agentId, verb, domain } = input
+
+  if (domain) {
+    const ruleAction = VERB_TO_RULE_ACTION[verb]
+    if (ruleAction) {
+      const matches = await siteRulesService.findMatching(domain, ruleAction)
+      if (matches.length > 0) {
+        return { verdict: 'block', source: 'site-rule' }
+      }
+    }
+  }
+
+  const profile = await agentsService.getDetail(agentId)
+  const agentVerdict = profile?.approvals[verb]
+  if (agentVerdict) {
+    return { verdict: normalize(agentVerdict), source: 'agent' }
+  }
+
+  const category = CATALOG_BY_ID[verb]
+  if (category) {
+    return {
+      verdict: normalize(category.defaultVerdict),
+      source: 'permission-default',
+    }
+  }
+
+  return { verdict: 'block', source: 'permission-default' }
+}

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/services/permissions.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/services/permissions.ts
@@ -53,6 +53,12 @@ export interface CheckResult {
  * site-rule action space. `input` (click & type) is intentionally
  * not domain-scoped: site rules clamp meaningful actions, not every
  * keystroke.
+ *
+ * `admin` has no catalog counterpart but is a first-class site-rule
+ * action; we still want a verb that callers can use to ask "is this
+ * admin operation blocked on this domain?" so a configured admin
+ * rule attributes the block to `'site-rule'` instead of falling
+ * through to the unknown-verb safety default.
  */
 const VERB_TO_RULE_ACTION: Record<string, SiteRuleAction> = {
   submit: 'submit',
@@ -60,6 +66,7 @@ const VERB_TO_RULE_ACTION: Record<string, SiteRuleAction> = {
   delete: 'delete',
   upload: 'upload',
   navigate: 'navigate',
+  admin: 'admin',
 }
 
 const CATALOG_BY_ID: Record<string, ApprovalCategory> = Object.fromEntries(

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/match-domain.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/match-domain.test.ts
@@ -1,0 +1,72 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { matchDomain } from '../../src/lib/match-domain'
+
+describe('matchDomain', () => {
+  test('exact match is case insensitive', () => {
+    expect(matchDomain('stripe.com', 'stripe.com')).toBe(true)
+    expect(matchDomain('STRIPE.com', 'stripe.com')).toBe(true)
+    expect(matchDomain('stripe.com', 'STRIPE.COM')).toBe(true)
+  })
+
+  test('exact match rejects unrelated domains', () => {
+    expect(matchDomain('stripe.com', 'evil-stripe.com')).toBe(false)
+    expect(matchDomain('stripe.com', 'stripe.com.evil')).toBe(false)
+    expect(matchDomain('stripe.com', 'api.stripe.com')).toBe(false)
+  })
+
+  test('leading wildcard matches subdomains, not the apex', () => {
+    expect(matchDomain('*.example.com', 'foo.example.com')).toBe(true)
+    expect(matchDomain('*.example.com', 'a.b.example.com')).toBe(true)
+    // The apex (no subdomain label) must NOT match: `.example.com`
+    // would normalise to `example.com` which a user wanting to also
+    // cover the apex should add as a separate rule.
+    expect(matchDomain('*.example.com', 'example.com')).toBe(false)
+  })
+
+  test('trailing wildcard matches anything after the dot', () => {
+    expect(matchDomain('admin.*', 'admin.example.com')).toBe(true)
+    expect(matchDomain('admin.*', 'admin.foo')).toBe(true)
+    // Trailing wildcard requires at least one character after the dot.
+    expect(matchDomain('admin.*', 'admin.')).toBe(false)
+    // The bare label must NOT match the wildcard expansion.
+    expect(matchDomain('admin.*', 'admin')).toBe(false)
+  })
+
+  test('bare star matches any non-empty domain', () => {
+    expect(matchDomain('*', 'example.com')).toBe(true)
+    expect(matchDomain('*', 'a')).toBe(true)
+    expect(matchDomain('*', '')).toBe(false)
+  })
+
+  test('star in the middle works for vendor.product patterns', () => {
+    expect(matchDomain('app.*.com', 'app.stripe.com')).toBe(true)
+    expect(matchDomain('app.*.com', 'app.foo.bar.com')).toBe(true)
+    expect(matchDomain('app.*.com', 'web.stripe.com')).toBe(false)
+  })
+
+  test('empty pattern never matches', () => {
+    expect(matchDomain('', 'example.com')).toBe(false)
+    expect(matchDomain('', '')).toBe(false)
+  })
+
+  test('regex metacharacters in patterns are treated as literals', () => {
+    // `.` matters: `a.b` must not match `aXb`.
+    expect(matchDomain('a.b', 'a.b')).toBe(true)
+    expect(matchDomain('a.b', 'aXb')).toBe(false)
+    // `+` and `(` should not be interpreted as regex operators.
+    expect(matchDomain('foo+bar.com', 'foo+bar.com')).toBe(true)
+    expect(matchDomain('foo+bar.com', 'foobar.com')).toBe(false)
+    expect(matchDomain('a(b).com', 'a(b).com')).toBe(true)
+  })
+
+  test('domain comparison is case insensitive', () => {
+    expect(matchDomain('*.Example.com', 'foo.example.com')).toBe(true)
+    expect(matchDomain('*.example.com', 'FOO.example.COM')).toBe(true)
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/permissions/routes.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/permissions/routes.test.ts
@@ -1,0 +1,43 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Integration test for the /permissions/catalog route. Returns the
+ * baked-in approval catalog; this test pins the shape so a UI bump
+ * that re-adds a category notices the backend hasn't followed.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { hc } from 'hono/client'
+import type { ApprovalCategory } from '../../../src/lib/approval-catalog'
+import app, { type AppType } from '../../../src/server'
+
+function client() {
+  return hc<AppType>('http://localhost', {
+    fetch: (input, init) => app.fetch(new Request(input, init)),
+  })
+}
+
+describe('/permissions/catalog route', () => {
+  test('returns the six baked-in categories with the expected defaults', async () => {
+    const api = client()
+    const res = await api.permissions.catalog.$get()
+    expect(res.status).toBe(200)
+    const catalog = (await res.json()) as ApprovalCategory[]
+    expect(catalog.map((c) => c.id)).toEqual([
+      'submit',
+      'payment',
+      'delete',
+      'upload',
+      'navigate',
+      'input',
+    ])
+    const byId = Object.fromEntries(catalog.map((c) => [c.id, c]))
+    expect(byId.submit.defaultVerdict).toBe('Ask')
+    expect(byId.payment.defaultVerdict).toBe('Block')
+    expect(byId.payment.allowAuto).toBe(false)
+    expect(byId.input.defaultVerdict).toBe('Auto')
+    expect(byId.input.allowAuto).toBe(true)
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/site-rules/routes.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/site-rules/routes.test.ts
@@ -1,0 +1,125 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Integration tests for the /site-rules routes. Hits the live Hono
+ * app via the typed client (`hc<AppType>`), routes through
+ * `app.fetch` so no real socket bind, and isolates each test with a
+ * fresh `<browserosDir>`.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { hc } from 'hono/client'
+import type { SiteRule } from '../../../src/routes/site-rules/schemas'
+import app, { type AppType } from '../../../src/server'
+import { withTempBrowserosDir } from '../../_helpers/temp-browseros-dir'
+
+function client() {
+  return hc<AppType>('http://localhost', {
+    fetch: (input, init) => app.fetch(new Request(input, init)),
+  })
+}
+
+describe('/site-rules routes', () => {
+  test('full lifecycle: empty list → create → list → delete → empty list', async () => {
+    await withTempBrowserosDir(async () => {
+      const api = client()
+
+      const emptyRes = await api['site-rules'].$get()
+      expect(emptyRes.status).toBe(200)
+      expect(await emptyRes.json()).toEqual([])
+
+      const createRes = await api['site-rules'].$post({
+        json: {
+          label: 'Wire transfers',
+          domain: 'mercury.com',
+          action: 'payments',
+        },
+      })
+      expect(createRes.status).toBe(201)
+      const created = await createRes.json()
+      expect(created.label).toBe('Wire transfers')
+      expect(created.id).toMatch(/^[A-Za-z0-9_-]+$/)
+
+      const listRes = await api['site-rules'].$get()
+      const list = (await listRes.json()) as SiteRule[]
+      expect(list).toHaveLength(1)
+      expect(list[0].id).toBe(created.id)
+
+      const delRes = await api['site-rules'][':id'].$delete({
+        param: { id: created.id },
+      })
+      expect(delRes.status).toBe(200)
+      expect(await delRes.json()).toEqual({ id: created.id })
+
+      const finalRes = await api['site-rules'].$get()
+      expect(await finalRes.json()).toEqual([])
+    })
+  })
+
+  test('400 when action enum is invalid', async () => {
+    await withTempBrowserosDir(async () => {
+      const api = client()
+      const res = await api['site-rules'].$post({
+        json: {
+          label: 'bad',
+          domain: 'x.com',
+          // biome-ignore lint/suspicious/noExplicitAny: deliberate invalid enum for the test
+          action: 'BOGUS' as any,
+        },
+      })
+      expect(res.status).toBe(400)
+    })
+  })
+
+  test('400 when label is empty', async () => {
+    await withTempBrowserosDir(async () => {
+      const api = client()
+      const res = await api['site-rules'].$post({
+        json: { label: '', domain: 'x.com', action: 'submit' },
+      })
+      expect(res.status).toBe(400)
+    })
+  })
+
+  test('400 when domain is empty', async () => {
+    await withTempBrowserosDir(async () => {
+      const api = client()
+      const res = await api['site-rules'].$post({
+        json: { label: 'x', domain: '', action: 'submit' },
+      })
+      expect(res.status).toBe(400)
+    })
+  })
+
+  test('DELETE returns 404 for unknown id', async () => {
+    await withTempBrowserosDir(async () => {
+      const api = client()
+      const res = await api['site-rules'][':id'].$delete({
+        param: { id: 'does-not-exist' },
+      })
+      expect(res.status).toBe(404)
+    })
+  })
+
+  test('DELETE returns 404 for traversal-shaped ids without touching disk', async () => {
+    await withTempBrowserosDir(async () => {
+      const api = client()
+      // Seed a rule so the file exists; the bogus delete must not
+      // affect it.
+      await api['site-rules'].$post({
+        json: { label: 'Real', domain: 'real.com', action: 'submit' },
+      })
+      const evilIds = ['..%2F..%2Fetc%2Fpasswd', '..', '../config']
+      for (const evil of evilIds) {
+        const res = await api['site-rules'][':id'].$delete({
+          param: { id: evil },
+        })
+        expect(res.status).toBe(404)
+      }
+      const listRes = await api['site-rules'].$get()
+      expect(await listRes.json()).toHaveLength(1)
+    })
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/site-rules/service.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/site-rules/service.test.ts
@@ -1,0 +1,181 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { readJson } from '../../../src/lib/storage'
+import { siteRulesFileSchema } from '../../../src/routes/site-rules/schemas'
+import * as siteRules from '../../../src/routes/site-rules/service'
+import { withTempBrowserosDir } from '../../_helpers/temp-browseros-dir'
+
+describe('site-rules service', () => {
+  test('list returns [] before any rule is added (file does not exist)', async () => {
+    await withTempBrowserosDir(async (dir) => {
+      expect(await siteRules.list()).toEqual([])
+      expect(existsSync(join(dir, 'mcp-interface/site-rules.json'))).toBe(false)
+    })
+  })
+
+  test('add creates the file and round-trips through the schema', async () => {
+    await withTempBrowserosDir(async (dir) => {
+      const created = await siteRules.add({
+        label: 'Wire transfers',
+        domain: 'mercury.com',
+        action: 'payments',
+      })
+      expect(created.id).toMatch(/^[A-Za-z0-9_-]+$/)
+      expect(created.label).toBe('Wire transfers')
+      const file = join(dir, 'mcp-interface/site-rules.json')
+      expect(existsSync(file)).toBe(true)
+      const stored = await readJson('site-rules.json', siteRulesFileSchema)
+      expect(stored).toHaveLength(1)
+      expect(stored[0]).toEqual(created)
+    })
+  })
+
+  test('list returns rules in insertion order', async () => {
+    await withTempBrowserosDir(async () => {
+      const a = await siteRules.add({
+        label: 'A',
+        domain: 'a.com',
+        action: 'submit',
+      })
+      const b = await siteRules.add({
+        label: 'B',
+        domain: 'b.com',
+        action: 'submit',
+      })
+      const c = await siteRules.add({
+        label: 'C',
+        domain: 'c.com',
+        action: 'submit',
+      })
+      const rows = await siteRules.list()
+      expect(rows.map((r) => r.id)).toEqual([a.id, b.id, c.id])
+    })
+  })
+
+  test('duplicate (domain, action, label) tuples are allowed (user-managed)', async () => {
+    await withTempBrowserosDir(async () => {
+      const first = await siteRules.add({
+        label: 'Wire transfers',
+        domain: 'mercury.com',
+        action: 'payments',
+      })
+      const second = await siteRules.add({
+        label: 'Wire transfers',
+        domain: 'mercury.com',
+        action: 'payments',
+      })
+      expect(first.id).not.toBe(second.id)
+      expect(await siteRules.list()).toHaveLength(2)
+    })
+  })
+
+  test('remove deletes the rule, returns the id, and shortens the list', async () => {
+    await withTempBrowserosDir(async () => {
+      const created = await siteRules.add({
+        label: 'X',
+        domain: 'x.com',
+        action: 'submit',
+      })
+      const removed = await siteRules.remove(created.id)
+      expect(removed).toEqual({ id: created.id })
+      expect(await siteRules.list()).toEqual([])
+    })
+  })
+
+  test('remove returns null when the id is unknown', async () => {
+    await withTempBrowserosDir(async () => {
+      await siteRules.add({ label: 'X', domain: 'x.com', action: 'submit' })
+      expect(await siteRules.remove('ghost')).toBeNull()
+      expect(await siteRules.list()).toHaveLength(1)
+    })
+  })
+
+  test('remove returns null when no rules file exists yet', async () => {
+    await withTempBrowserosDir(async () => {
+      expect(await siteRules.remove('anything')).toBeNull()
+    })
+  })
+
+  test('traversal-shaped ids resolve to null without touching disk', async () => {
+    await withTempBrowserosDir(async (dir) => {
+      await siteRules.add({ label: 'X', domain: 'x.com', action: 'submit' })
+      const evilIds = [
+        '../config',
+        '..',
+        '../../etc/passwd',
+        'site-rules/../config',
+      ]
+      for (const evil of evilIds) {
+        expect(await siteRules.remove(evil)).toBeNull()
+      }
+      // The real rule is untouched.
+      expect(await siteRules.list()).toHaveLength(1)
+      expect(existsSync(join(dir, 'mcp-interface/site-rules.json'))).toBe(true)
+    })
+  })
+
+  test('ten parallel adds all persist (no read-then-rewrite race)', async () => {
+    await withTempBrowserosDir(async () => {
+      const count = 10
+      await Promise.all(
+        Array.from({ length: count }, (_, i) =>
+          siteRules.add({
+            label: `Rule ${i}`,
+            domain: `domain-${i}.com`,
+            action: 'submit',
+          }),
+        ),
+      )
+      const rows = await siteRules.list()
+      expect(rows).toHaveLength(count)
+      expect(new Set(rows.map((r) => r.id)).size).toBe(count)
+    })
+  })
+
+  test('findMatching honours glob patterns end-to-end', async () => {
+    await withTempBrowserosDir(async () => {
+      await siteRules.add({
+        label: 'Wire',
+        domain: 'mercury.com',
+        action: 'payments',
+      })
+      await siteRules.add({
+        label: 'Admin',
+        domain: 'admin.*',
+        action: 'admin',
+      })
+      await siteRules.add({
+        label: 'Stripe',
+        domain: '*.stripe.com',
+        action: 'payments',
+      })
+
+      // Exact match.
+      const exact = await siteRules.findMatching('mercury.com', 'payments')
+      expect(exact.map((r) => r.label)).toEqual(['Wire'])
+
+      // Subdomain wildcard hits `*.stripe.com`.
+      const sub = await siteRules.findMatching('api.stripe.com', 'payments')
+      expect(sub.map((r) => r.label)).toEqual(['Stripe'])
+
+      // Trailing wildcard hits `admin.*` for matching action only.
+      const adm = await siteRules.findMatching('admin.example.com', 'admin')
+      expect(adm.map((r) => r.label)).toEqual(['Admin'])
+
+      // Same domain but wrong action returns nothing.
+      const wrongAction = await siteRules.findMatching('mercury.com', 'submit')
+      expect(wrongAction).toEqual([])
+
+      // No matching rule at all.
+      const noMatch = await siteRules.findMatching('elsewhere.org', 'submit')
+      expect(noMatch).toEqual([])
+    })
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/services/permissions.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/services/permissions.test.ts
@@ -1,0 +1,217 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Unit tests for the in-process `permissions.check` API. Exercises
+ * the precedence ladder: site-rule clamp → agent verdict → catalog
+ * default → unknown-verb safety default.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import type { NewAgentValues } from '../../src/routes/agents/schemas'
+import * as agentsService from '../../src/routes/agents/service'
+import * as siteRulesService from '../../src/routes/site-rules/service'
+import * as permissions from '../../src/services/permissions'
+import { withTempBrowserosDir } from '../_helpers/temp-browseros-dir'
+
+function makeProfile(overrides: Partial<NewAgentValues> = {}): NewAgentValues {
+  return {
+    name: 'Cowork . Finance ops',
+    harness: 'Claude Cowork',
+    loginMode: 'profile',
+    selectedSites: [],
+    approvals: {
+      submit: 'Auto',
+      payment: 'Block',
+      delete: 'Ask',
+      upload: 'Ask',
+      navigate: 'Ask',
+      input: 'Auto',
+    },
+    aclRuleIds: [],
+    customAclRules: [],
+    ...overrides,
+  }
+}
+
+describe('permissions.check', () => {
+  test('site rule clamps an agent that wanted Auto', async () => {
+    await withTempBrowserosDir(async () => {
+      const agent = await agentsService.create(makeProfile())
+      await siteRulesService.add({
+        label: 'Wire',
+        domain: 'mercury.com',
+        action: 'payments',
+      })
+      const result = await permissions.check({
+        agentId: agent.id,
+        verb: 'payment',
+        domain: 'mercury.com',
+      })
+      // Agent's payment verdict was Block, so even without the site
+      // rule we'd block; flip to submit to prove the rule wins over
+      // an Auto verdict.
+      expect(result).toEqual({ verdict: 'block', source: 'site-rule' })
+    })
+  })
+
+  test('site rule overrides an agent Auto verdict for submit', async () => {
+    await withTempBrowserosDir(async () => {
+      const agent = await agentsService.create(
+        makeProfile({
+          approvals: {
+            submit: 'Auto',
+            payment: 'Block',
+            delete: 'Ask',
+            upload: 'Ask',
+            navigate: 'Ask',
+            input: 'Auto',
+          },
+        }),
+      )
+      await siteRulesService.add({
+        label: 'Concur',
+        domain: 'concur.com',
+        action: 'submit',
+      })
+      const blocked = await permissions.check({
+        agentId: agent.id,
+        verb: 'submit',
+        domain: 'concur.com',
+      })
+      expect(blocked).toEqual({ verdict: 'block', source: 'site-rule' })
+
+      // Same agent + same verb on a different domain stays Auto.
+      const allowed = await permissions.check({
+        agentId: agent.id,
+        verb: 'submit',
+        domain: 'docs.google.com',
+      })
+      expect(allowed).toEqual({ verdict: 'auto', source: 'agent' })
+    })
+  })
+
+  test('site rule with wildcard matches subdomains', async () => {
+    await withTempBrowserosDir(async () => {
+      const agent = await agentsService.create(makeProfile())
+      await siteRulesService.add({
+        label: 'Stripe',
+        domain: '*.stripe.com',
+        action: 'payments',
+      })
+      const sub = await permissions.check({
+        agentId: agent.id,
+        verb: 'payment',
+        domain: 'api.stripe.com',
+      })
+      expect(sub.source).toBe('site-rule')
+      // Apex stripe.com is NOT clamped by `*.stripe.com` (apex needs a
+      // separate rule). Falls through to the agent verdict (Block).
+      const apex = await permissions.check({
+        agentId: agent.id,
+        verb: 'payment',
+        domain: 'stripe.com',
+      })
+      expect(apex).toEqual({ verdict: 'block', source: 'agent' })
+    })
+  })
+
+  test('agent verdict wins when no site rule matches', async () => {
+    await withTempBrowserosDir(async () => {
+      const agent = await agentsService.create(makeProfile())
+      const result = await permissions.check({
+        agentId: agent.id,
+        verb: 'submit',
+        domain: 'docs.google.com',
+      })
+      expect(result).toEqual({ verdict: 'auto', source: 'agent' })
+    })
+  })
+
+  test('catalog default applies when the agent is missing', async () => {
+    await withTempBrowserosDir(async () => {
+      const result = await permissions.check({
+        agentId: 'ghost',
+        verb: 'payment',
+        domain: 'stripe.com',
+      })
+      expect(result).toEqual({
+        verdict: 'block',
+        source: 'permission-default',
+      })
+    })
+  })
+
+  test('catalog default applies when the agent profile omits the verb', async () => {
+    await withTempBrowserosDir(async () => {
+      const agent = await agentsService.create(
+        makeProfile({
+          approvals: {
+            submit: 'Auto',
+            // payment intentionally omitted
+            delete: 'Ask',
+            upload: 'Ask',
+            navigate: 'Ask',
+            input: 'Auto',
+          },
+        }),
+      )
+      const result = await permissions.check({
+        agentId: agent.id,
+        verb: 'payment',
+        domain: 'stripe.com',
+      })
+      expect(result).toEqual({
+        verdict: 'block',
+        source: 'permission-default',
+      })
+    })
+  })
+
+  test('unknown verb returns block from the permission-default source', async () => {
+    await withTempBrowserosDir(async () => {
+      const agent = await agentsService.create(makeProfile())
+      const result = await permissions.check({
+        agentId: agent.id,
+        verb: 'not-a-real-verb',
+        domain: 'example.com',
+      })
+      expect(result).toEqual({
+        verdict: 'block',
+        source: 'permission-default',
+      })
+    })
+  })
+
+  test('traversal-shaped agentId resolves to catalog default (defence in depth)', async () => {
+    await withTempBrowserosDir(async () => {
+      const result = await permissions.check({
+        agentId: '../config',
+        verb: 'submit',
+        domain: 'example.com',
+      })
+      expect(result.source).toBe('permission-default')
+      expect(result.verdict).toBe('ask')
+    })
+  })
+
+  test('input verb is not domain-scoped: site rules do not clamp it', async () => {
+    await withTempBrowserosDir(async () => {
+      const agent = await agentsService.create(makeProfile())
+      // A submit rule on the same domain must NOT carry over to the
+      // input verb space; input falls through to the agent verdict.
+      await siteRulesService.add({
+        label: 'Concur submit',
+        domain: 'concur.com',
+        action: 'submit',
+      })
+      const result = await permissions.check({
+        agentId: agent.id,
+        verb: 'input',
+        domain: 'concur.com',
+      })
+      expect(result).toEqual({ verdict: 'auto', source: 'agent' })
+    })
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/services/permissions.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/services/permissions.test.ts
@@ -196,6 +196,40 @@ describe('permissions.check', () => {
     })
   })
 
+  test('admin verb is enforced by matching site rules', async () => {
+    await withTempBrowserosDir(async () => {
+      const agent = await agentsService.create(makeProfile())
+      await siteRulesService.add({
+        label: 'Org billing',
+        domain: 'admin.*',
+        action: 'admin',
+      })
+      // Configured admin rule must attribute the block to the rule,
+      // not to the unknown-verb safety default. If this regresses,
+      // the cockpit will show "blocked by default" instead of
+      // "blocked by the rule you configured".
+      const result = await permissions.check({
+        agentId: agent.id,
+        verb: 'admin',
+        domain: 'admin.workspace.google.com',
+      })
+      expect(result).toEqual({ verdict: 'block', source: 'site-rule' })
+
+      // Without a matching rule, admin still defaults to block
+      // (catalog has no admin verdict), but sourced from the
+      // permission-default safety net.
+      const noRule = await permissions.check({
+        agentId: agent.id,
+        verb: 'admin',
+        domain: 'docs.google.com',
+      })
+      expect(noRule).toEqual({
+        verdict: 'block',
+        source: 'permission-default',
+      })
+    })
+  })
+
   test('input verb is not domain-scoped: site rules do not clamp it', async () => {
     await withTempBrowserosDir(async () => {
       const agent = await agentsService.create(makeProfile())

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/permissions.hooks.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/permissions.hooks.ts
@@ -1,0 +1,27 @@
+import { createQuery } from 'react-query-kit'
+import {
+  APPROVAL_CATEGORIES,
+  type ApprovalCategory,
+} from '@/screens/new-agent/new-agent.schemas'
+import { api } from './client'
+import { parseResponse } from './parseResponse'
+
+export type { ApprovalCategory } from '@/screens/new-agent/new-agent.schemas'
+
+/**
+ * System-wide approval catalog. The backend ships the source of truth
+ * baked into `lib/approval-catalog.ts`; the local constant stays as a
+ * silent fallback so the Permissions tab still renders if the cockpit
+ * lost its connection to `agent-mcp-interface`.
+ */
+export const useApprovalCatalog = createQuery<readonly ApprovalCategory[]>({
+  queryKey: ['permissions', 'catalog'],
+  fetcher: async () => {
+    try {
+      const response = await api.permissions.catalog.$get()
+      return await parseResponse<ApprovalCategory[]>(response)
+    } catch {
+      return APPROVAL_CATEGORIES
+    }
+  },
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/permissions.hooks.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/permissions.hooks.ts
@@ -20,7 +20,15 @@ export const useApprovalCatalog = createQuery<readonly ApprovalCategory[]>({
     try {
       const response = await api.permissions.catalog.$get()
       return await parseResponse<ApprovalCategory[]>(response)
-    } catch {
+    } catch (err) {
+      // Surface a single line so operators can tell "intentional
+      // offline fallback" apart from "the backend changed schema
+      // under us". Returning the local constant keeps the tab
+      // usable; the warn is the diagnostic seam.
+      console.warn(
+        '[permissions.useApprovalCatalog] backend catalog fetch failed, using local fallback',
+        err,
+      )
       return APPROVAL_CATEGORIES
     }
   },

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/site-rules.hooks.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/site-rules.hooks.ts
@@ -1,5 +1,6 @@
-import { nanoid } from 'nanoid'
 import { createMutation, createQuery } from 'react-query-kit'
+import { api } from './client'
+import { parseResponse } from './parseResponse'
 
 export type SiteRuleAction =
   | 'payments'
@@ -19,43 +20,12 @@ export interface SiteRule {
   action: SiteRuleAction
 }
 
-const MOCK_SITE_RULES: SiteRule[] = [
-  {
-    id: 'rule-mercury',
-    label: 'Wire transfers',
-    domain: 'mercury.com',
-    action: 'payments',
-  },
-  {
-    id: 'rule-stripe-pay',
-    label: 'Edit payment methods',
-    domain: 'stripe.com',
-    action: 'payments',
-  },
-  {
-    id: 'rule-admin',
-    label: 'Org billing settings',
-    domain: 'admin.*',
-    action: 'admin',
-  },
-  {
-    id: 'rule-workspace',
-    label: 'User management',
-    domain: 'workspace.google.com',
-    action: 'admin',
-  },
-  {
-    id: 'rule-delete',
-    label: 'Delete account',
-    domain: '*',
-    action: 'delete',
-  },
-]
-
 export const useSiteRules = createQuery<SiteRule[]>({
   queryKey: ['site-rules'],
-  fetcher: () =>
-    new Promise((resolve) => setTimeout(() => resolve(MOCK_SITE_RULES), 60)),
+  fetcher: async () => {
+    const response = await api['site-rules'].$get()
+    return parseResponse<SiteRule[]>(response)
+  },
 })
 
 export interface AddSiteRuleVariables {
@@ -66,8 +36,8 @@ export interface AddSiteRuleVariables {
 
 export const useAddSiteRule = createMutation<SiteRule, AddSiteRuleVariables>({
   mutationFn: async (variables) => {
-    await new Promise((resolve) => setTimeout(resolve, 350))
-    return { id: `rule-${nanoid(6).toLowerCase()}`, ...variables }
+    const response = await api['site-rules'].$post({ json: variables })
+    return parseResponse<SiteRule>(response)
   },
 })
 
@@ -79,8 +49,8 @@ export const useDeleteSiteRule = createMutation<
   DeleteSiteRuleVariables,
   DeleteSiteRuleVariables
 >({
-  mutationFn: async (variables) => {
-    await new Promise((resolve) => setTimeout(resolve, 300))
-    return variables
+  mutationFn: async ({ id }) => {
+    const response = await api['site-rules'][':id'].$delete({ param: { id } })
+    return parseResponse<DeleteSiteRuleVariables>(response)
   },
 })

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/governance/PermissionsTab.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/governance/PermissionsTab.tsx
@@ -1,9 +1,9 @@
 import { Ban, Check, type LucideIcon, ShieldQuestion } from 'lucide-react'
 import { cn } from '@/lib/utils'
-import {
-  APPROVAL_CATEGORIES,
-  type ApprovalCategory,
-  type ApprovalVerdict,
+import { useApprovalCatalog } from '@/modules/api/permissions.hooks'
+import type {
+  ApprovalCategory,
+  ApprovalVerdict,
 } from '@/screens/new-agent/new-agent.schemas'
 
 /**
@@ -12,7 +12,8 @@ import {
  * agent; this is the system-wide default each agent starts from.
  */
 export function PermissionsTab() {
-  const buckets = bucketise(APPROVAL_CATEGORIES)
+  const { data: catalog = [] } = useApprovalCatalog()
+  const buckets = bucketise(catalog)
   return (
     <section className="flex flex-col gap-4">
       <p className="text-ink-2 text-sm leading-snug">


### PR DESCRIPTION
## Summary

Replaces the three mocked site-rule hooks in `agent-mcp-ui` with real `@browseros/agent-mcp-interface` endpoints, adds `GET /permissions/catalog` so the Permissions tab reads from the backend (with the local constant retained as a fetch-failure fallback), and ships the in-process `permissions.check(agent, verb, domain)` API the executor and run lifecycle will call into.

Stacked on top of the agent profiles CRUD work. Same five-commit cadence, same loopback-only bind, same `<browserosDir>/mcp-interface/` storage root.

## What ships

**Backend**

- `src/lib/match-domain.ts`: glob matcher with `*`, `*.example.com`, `admin.*` and `*` semantics. Case-insensitive, regex-metachar-safe.
- `src/lib/approval-catalog.ts`: baked-in `APPROVAL_CATEGORIES` constant. Kept in sync with the UI's local copy by lint discipline; comment header points at the UI source.
- `src/routes/site-rules/`: zod schemas + `AsyncMutex`-guarded file-backed CRUD service at `<browserosDir>/mcp-interface/site-rules.json` (single array file; lists are small enough that full-table scans are fine).
- `src/routes/permissions/`: `GET /permissions/catalog` returning the baked-in array. No file written on first read; a future PUT/PATCH would land the customisation file when it exists.
- `src/services/permissions.ts`: in-process `check({agentId, verb, domain})` returning `{verdict, source}`. Precedence: site-rule match (block) wins, then agent verdict, then catalog default, then a block-by-default safety net for unknown verbs.
- 4 new routes wired into `server.ts`:
  - \`GET /site-rules\`
  - \`POST /site-rules\`
  - \`DELETE /site-rules/:id\`
  - \`GET /permissions/catalog\`

**Tests**

35 new tests covering match-domain semantics, site-rules CRUD, route validation 400s, traversal-shaped id 404s, parallel-add ordering, glob-matched `findMatching`, the permissions precedence ladder, and the unknown-verb safety default.

\`\`\`
bun test
74 pass / 0 fail / 218 expect() calls across 9 files
\`\`\`

**UI**

- \`modules/api/site-rules.hooks.ts\`: rewritten on top of the real client. Public types untouched, so \`screens/governance/site-rules.data.ts\` and the row components stay byte-identical.
- \`modules/api/permissions.hooks.ts\`: new \`useApprovalCatalog\` hook. Wraps \`api.permissions.catalog\`, falls back to the local \`APPROVAL_CATEGORIES\` on fetch failure.
- \`screens/governance/PermissionsTab.tsx\`: swaps the direct constant import for the hook. The bucketise pipeline below stays unchanged.

Typecheck + lint on both packages clean.

## Storage layout after this PR

\`\`\`
<browserosDir>/mcp-interface/
  agents/                  (Phase 1)
    <nanoid>.json
  site-rules.json          (this PR; single array)
\`\`\`

\`permissions.json\` is intentionally NOT created. The catalog ships baked-in; a future customisation route can add the file when it exists.

## Precedence the check() API encodes

\`\`\`
result = site-rule match on (verb, domain) -> block, source: 'site-rule'
      ?? agent.approvals[verb]              -> source: 'agent'
      ?? catalog.defaultVerdict(verb)       -> source: 'permission-default'
      ?? 'block'                            -> source: 'permission-default'
\`\`\`

The unknown-verb fallback is the \"deny by default\" rule. A unit test pins it.

## Test plan

- [ ] Backend tests pass (\`bun --filter '@browseros/agent-mcp-interface' test\`)
- [ ] Backend typecheck + lint clean
- [ ] UI typecheck + lint clean
- [ ] Cockpit Governance > Site Rules: add, refresh, persists across reload, delete, file at \`<browserosDir>/mcp-interface/site-rules.json\` matches the list
- [ ] Cockpit Governance > Permissions: six categories render with the expected verdicts
- [ ] Kill the backend, refresh Permissions tab: catalog still renders from the local fallback
- [ ] Curl smoke: empty list, add x3, validation 400s for bad enum and empty label, delete 200 + 404, traversal-shaped id 404, catalog read returns six expected categories, no permissions.json on disk

## What is NOT in this PR (deferred)

- The actual call site for \`permissions.check()\`. Phases 3 (executor) and 4 (runs) will wire it; this PR ships the contract with unit tests so the call shape can be relied on.
- Grants-based \`auto\` short-circuit (Phase 6 layers grants on top of this check).
- Customisation of the permissions catalog (PUT/PATCH on \`/permissions/catalog\`).
- Site-rule precedence hints in the agent wizard.