### PR TITLE
chore(ci): make nightly release workflow manual

### DIFF
--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,6 +1,6 @@
 name: Nightly Release Build
 
-# Daily UNSIGNED release builds of BrowserOS for all three platforms on
+# Manual UNSIGNED release builds of BrowserOS for all three platforms on
 # WarpBuild runners. Signing is intentionally not wired up yet; see
 # packages/browseros/build/docs/nightly-warpbuild-ci.md for the design and
 # the secret names that enable signing later.
@@ -12,10 +12,6 @@ name: Nightly Release Build
 #                  not support Windows runners; actions/cache caps at 10GB)
 
 on:
-  schedule:
-    # Midnight US Pacific (DST). The signed self-hosted macOS nightly runs
-    # at 05:00 UTC; keep these apart so version-bump PRs don't race.
-    - cron: "0 8 * * *"
   workflow_dispatch:
     inputs:
       platforms:
@@ -49,7 +45,6 @@ jobs:
       - name: Resolve build matrix and publish flag
         id: plan
         env:
-          EVENT_NAME: ${{ github.event_name }}
           PLATFORMS: ${{ inputs.platforms || 'all' }}
           PUBLISH_INPUT: ${{ inputs.publish_nightly }}
           REF_NAME: ${{ github.ref_name }}
@@ -70,7 +65,7 @@ jobs:
 
           publish="false"
           if [ "$REF_NAME" = "$DEFAULT_BRANCH" ]; then
-            if [ "$EVENT_NAME" = "schedule" ] || [ "$PUBLISH_INPUT" = "true" ]; then
+            if [ "$PUBLISH_INPUT" = "true" ]; then
               publish="true"
             fi
           fi


### PR DESCRIPTION
## Summary
- Make the Nightly Release Build workflow manual-only by removing the scheduled cron trigger.
- Remove the stale schedule-based publish branch so `publish_nightly` is the manual publish gate.
- Update the workflow header comment from daily builds to manual builds.

## Design
The workflow now starts only from `workflow_dispatch`. Manual operators keep the existing platform selector and can still set `publish_nightly` on the default branch to update the rolling prerelease.

## Test plan
- [x] `git diff --check`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/nightly-release.yml"); puts "yaml ok"'`\n- [x] `actionlint .github/workflows/nightly-release.yml`\n- [x] `bun run check`