### PR TITLE
fix: include drizzle migrations for all server targets

### DIFF
--- a/packages/browseros-agent/scripts/build/config/server-prod-resources.json
+++ b/packages/browseros-agent/scripts/build/config/server-prod-resources.json
@@ -117,9 +117,7 @@
         "path": "apps/server/src/lib/db/migrations"
       },
       "destination": "resources/db/migrations",
-      "recursive": true,
-      "os": ["macos"],
-      "arch": ["arm64", "x64"]
+      "recursive": true
     }
   ]
 }

--- a/packages/browseros-agent/scripts/build/server/stage.test.ts
+++ b/packages/browseros-agent/scripts/build/server/stage.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path'
 import type { S3Client } from '@aws-sdk/client-s3'
 import { getTargetRules, loadManifest } from './manifest'
 import { stageCompiledArtifact, stageTargetArtifact } from './stage'
+import { resolveTargets } from './targets'
 import type { BuildTarget, R2Config, ResourceRule } from './types'
 
 describe('server artifact staging', () => {
@@ -42,8 +43,6 @@ describe('server artifact staging', () => {
             },
             destination: 'resources/db/migrations',
             recursive: true,
-            os: ['macos'],
-            arch: ['arm64', 'x64'],
           },
         ],
       }),
@@ -202,6 +201,25 @@ describe('server artifact staging', () => {
     expect(destinations).toContain('resources/db/migrations')
   })
 
+  it('selects Drizzle migrations for every production server target', () => {
+    const manifest = loadManifest(
+      'scripts/build/config/server-prod-resources.json',
+    )
+
+    for (const target of resolveTargets('all')) {
+      const migrationRules = getTargetRules(manifest, target).filter(
+        (rule) => rule.name === 'Drizzle migrations',
+      )
+
+      expect(migrationRules).toEqual([
+        expect.objectContaining({
+          destination: 'resources/db/migrations',
+          recursive: true,
+        }),
+      ])
+    }
+  })
+
   it('downloads bundled Codex CLI for Linux targets and marks it executable', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'browseros-stage-test-'))
     const sourceRoot = join(tempDir, 'source')
@@ -352,8 +370,6 @@ const migrationRule: ResourceRule = {
   },
   destination: 'resources/db/migrations',
   recursive: true,
-  os: ['macos'],
-  arch: ['arm64', 'x64'],
 }
 
 const bunRule: ResourceRule = {


### PR DESCRIPTION
## Summary
- Include Drizzle migrations in every production server resource artifact by removing platform filters from the migration resource rule.
- Add staging test coverage that checks the production manifest selects the migration rule for every supported server target.

## Design
The resource manifest already treats missing `os` and `arch` fields as unfiltered. The migration resource is shared local data rather than a platform-specific binary, so it should use that existing all-target behavior.

## Test plan
- [x] `bun test scripts/build/server/stage.test.ts`
- [x] `bun run check`
- [x] `bun run build:server:test`