### PR TITLE
feat: check out chromium as local browseros branch in git setup

### DIFF
--- a/packages/browseros/build/modules/setup/git.py
+++ b/packages/browseros/build/modules/setup/git.py
@@ -23,6 +23,8 @@ from ...common.utils import (
     safe_rmtree,
 )
 
+BROWSEROS_BRANCH = "browseros"
+
 
 class GitSetupModule(CommandModule):
     produces = []
@@ -44,8 +46,7 @@ class GitSetupModule(CommandModule):
 
         self._verify_tag_exists(ctx)
 
-        log_info(f"🔀 Checking out tag: {ctx.chromium_version}")
-        run_command(["git", "checkout", f"tags/{ctx.chromium_version}"], cwd=ctx.chromium_src)
+        self._checkout_browseros_branch(ctx)
 
         # On Linux, depot_tools fetches per-arch sysroots automatically when
         # `.gclient` declares `target_cpus`. Ensure both x64 and arm64 are
@@ -55,11 +56,30 @@ class GitSetupModule(CommandModule):
 
         log_info("📥 Syncing dependencies (this may take a while)...")
         if IS_WINDOWS():
-            run_command(["gclient.bat", "sync", "-D", "--no-history", "--shallow"], cwd=ctx.chromium_src)
+            run_command(
+                ["gclient.bat", "sync", "-D", "--no-history", "--shallow"],
+                cwd=ctx.chromium_src,
+            )
         else:
-            run_command(["gclient", "sync", "-D", "--no-history", "--shallow"], cwd=ctx.chromium_src)
+            run_command(
+                ["gclient", "sync", "-D", "--no-history", "--shallow"],
+                cwd=ctx.chromium_src,
+            )
 
         log_success("Git setup complete")
+
+    def _checkout_browseros_branch(self, ctx: Context) -> None:
+        """Create/reset local `browseros` branch at the pinned tag, not detached HEAD."""
+        # `-B` creates or force-resets in one step from an explicit start-point,
+        # so no redundant detached-HEAD checkout is needed first. gclient's
+        # solution is `managed: False`, so the later sync ignores this branch.
+        log_info(
+            f"🔀 Checking out tag {ctx.chromium_version} as branch: {BROWSEROS_BRANCH}"
+        )
+        run_command(
+            ["git", "checkout", "-B", BROWSEROS_BRANCH, f"tags/{ctx.chromium_version}"],
+            cwd=ctx.chromium_src,
+        )
 
     def _ensure_gclient_target_cpus(self, ctx: Context, required: List[str]) -> None:
         """Idempotently add `target_cpus` to .gclient so depot_tools fetches
@@ -91,12 +111,8 @@ class GitSetupModule(CommandModule):
                 return
             merged = sorted(set(existing) | set(required))
             new_line = f"target_cpus = {merged!r}"
-            content = (
-                content[: match.start()] + new_line + content[match.end() :]
-            )
-            log_info(
-                f"📝 Updating .gclient target_cpus: {existing} → {merged}"
-            )
+            content = content[: match.start()] + new_line + content[match.end() :]
+            log_info(f"📝 Updating .gclient target_cpus: {existing} → {merged}")
         else:
             new_line = f"\ntarget_cpus = {required!r}\n"
             content = content.rstrip() + "\n" + new_line
@@ -133,6 +149,7 @@ class SparkleSetupModule(CommandModule):
 
     def validate(self, ctx: Context) -> None:
         from ...common.utils import IS_MACOS
+
         if not IS_MACOS():
             raise ValidationError("Sparkle setup requires macOS")
 
@@ -204,7 +221,9 @@ def extract_winsparkle_zip(archive: Path, dest: Path) -> None:
 
         # The official archive wraps everything in a single version dir; a
         # different layout would silently produce a broken tree, so fail fast.
-        top_levels = {Path(info.filename).parts[0] for info in infos if info.filename.strip("/")}
+        top_levels = {
+            Path(info.filename).parts[0] for info in infos if info.filename.strip("/")
+        }
         if len(top_levels) != 1:
             raise RuntimeError(
                 f"Expected a single top-level directory in {archive.name}, "

--- a/packages/browseros/build/modules/setup/git_test.py
+++ b/packages/browseros/build/modules/setup/git_test.py
@@ -4,8 +4,9 @@
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
-from .git import GitSetupModule
+from .git import GitSetupModule, BROWSEROS_BRANCH
 from ...common.context import Context
 from ...common.module import ValidationError
 from ...common.testing import MockBrowserOSRoot, MockChromium, make_context
@@ -48,6 +49,63 @@ class GitSetupValidateTest(unittest.TestCase):
             GitSetupModule().validate(ctx)
 
 
+class GitSetupExecuteTest(unittest.TestCase):
+    def setUp(self):
+        self._chromium_tmp = tempfile.TemporaryDirectory()
+        self._root_tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._chromium_tmp.cleanup)
+        self.addCleanup(self._root_tmp.cleanup)
+        self.ctx = make_context(
+            MockChromium(Path(self._chromium_tmp.name)),
+            MockBrowserOSRoot(Path(self._root_tmp.name)),
+        )
+
+    def test_checks_out_tag_as_browseros_branch(self):
+        commands = []
+
+        def fake_run_command(cmd, cwd=None):
+            commands.append(cmd)
+
+        with (
+            mock.patch("build.modules.setup.git.run_command", fake_run_command),
+            mock.patch("build.modules.setup.git.IS_LINUX", return_value=False),
+            mock.patch("build.modules.setup.git.IS_WINDOWS", return_value=False),
+            mock.patch.object(GitSetupModule, "_verify_tag_exists", return_value=None),
+        ):
+            GitSetupModule().execute(self.ctx)
+
+        tag_ref = f"tags/{self.ctx.chromium_version}"
+        # One checkout creates the branch straight from the tag; the redundant
+        # detached-HEAD checkout that #1216 shipped (and was reverted) is gone.
+        self.assertEqual(
+            commands,
+            [
+                ["git", "fetch", "--tags", "--force"],
+                ["git", "checkout", "-B", BROWSEROS_BRANCH, tag_ref],
+                ["gclient", "sync", "-D", "--no-history", "--shallow"],
+            ],
+        )
+
+    def test_missing_tag_stops_before_checkout(self):
+        commands = []
+
+        def fake_run_command(cmd, cwd=None):
+            commands.append(cmd)
+
+        with (
+            mock.patch("build.modules.setup.git.run_command", fake_run_command),
+            mock.patch.object(
+                GitSetupModule,
+                "_verify_tag_exists",
+                side_effect=ValidationError("missing"),
+            ),
+        ):
+            with self.assertRaises(ValidationError):
+                GitSetupModule().execute(self.ctx)
+
+        self.assertEqual(commands, [["git", "fetch", "--tags", "--force"]])
+
+
 class EnsureGclientTargetCpusTest(unittest.TestCase):
     def setUp(self):
         self._tmp = tempfile.TemporaryDirectory()
@@ -76,9 +134,7 @@ class EnsureGclientTargetCpusTest(unittest.TestCase):
         self.assertIn("solutions = [", content)
 
     def test_merges_missing_archs_into_existing_list(self):
-        self.gclient.write_text(
-            self.gclient.read_text() + "\ntarget_cpus = ['x64']\n"
-        )
+        self.gclient.write_text(self.gclient.read_text() + "\ntarget_cpus = ['x64']\n")
 
         self.module._ensure_gclient_target_cpus(self.ctx, ["x64", "arm64"])
 


### PR DESCRIPTION
## Summary
- `git_setup` now lands the Chromium tree on a **named local `browseros` branch**
  instead of a detached HEAD, via a single `git checkout -B browseros tags/<version>`.
- This lets feature work happen on `feat/<xyz>` branches that merge back into
  `browseros`, or just `git checkout browseros` to return to the build base.
- Clean reland of #1216 (reverted in #1228) — **without** the redundant
  detached-HEAD checkout both reviewers flagged.

## Design
`GitSetupModule.execute` keeps fetch → tag verification, then runs a single
`git checkout -B browseros tags/<version>` (new `_checkout_browseros_branch`
helper; branch name is the `BROWSEROS_BRANCH` constant).

- **`-B`** creates the branch or force-resets it if it already exists, keeping
  setup idempotent across reruns and chromium version bumps (covers "if browseros
  exists we can delete it").
- **Explicit tag start-point** means no detached-HEAD checkout is needed first —
  this removes the redundant double-checkout that characterized the reverted
  #1216 (flagged by both Claude and Greptile there).
- **Local-build only by design.** CI does not run `git_setup`
  (`scripts/ci/setup_chromium.py` replaces it and checks out detached — there is
  no human running `git checkout` on a CI runner), so it is intentionally left
  untouched.

### Why this is safe (it does not repeat the revert)
- `.gclient` is `managed: False`, so the following `gclient sync` ignores the
  working branch entirely.
- `clean` runs `git reset --hard HEAD` before `git_setup`, and patches apply via
  `git apply` (uncommitted) — so the branch tip always equals the pristine tag,
  which is exactly what patch application needs. Branch-vs-detached HEAD is
  immaterial to the build output.
- `-B` over the same tag start-point has no failure mode the prior plain
  `git checkout tags/<version>` didn't already have; it only additionally writes
  the branch ref.

Also restores the `missing-tag-stops-before-checkout` test that the revert
dropped (its behavior still exists in `execute`).

## Test plan
- [x] `cd packages/browseros && uv run python -m unittest build.modules.setup.git_test` (9 pass)
- [x] `cd packages/browseros && uv run python -m unittest build.modules.setup.clean_test build.modules.setup.configure_test build.modules.setup.git_test build.modules.setup.winsparkle_test` (23 pass)
- [x] `cd packages/browseros && uv run ruff check build/modules/setup/git.py build/modules/setup/git_test.py`
- [x] `cd packages/browseros && uv run ruff format --check build/modules/setup/git.py build/modules/setup/git_test.py`
