### PR TITLE
fix: bootstrap db schema when migrations are missing

### DIFF
--- a/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
+++ b/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
@@ -28,7 +28,7 @@ import { createCodexFetch } from '../lib/clients/oauth/codex-fetch'
 import { createCopilotFetch } from '../lib/clients/oauth/copilot-fetch'
 import { logger } from '../lib/logger'
 import { createOpenRouterCompatibleFetch } from '../lib/openrouter-fetch'
-import { ensureWorkspaceInstructionFile } from './acp-instructions'
+import { ensureWorkspaceInstructionFile } from './acp-instructions/ensureInstructionFile'
 import { ACP_PROVIDER_TYPES, isAcpProvider } from './acp-providers'
 import type { BuildSystemPromptOptions } from './prompt'
 import type { ResolvedAgentConfig } from './types'
@@ -38,6 +38,18 @@ export { isAcpProvider }
 const BUILT_IN_ACP_AGENT_BY_PROVIDER: Record<string, string> = {
   [LLM_PROVIDERS.CLAUDE_CODE]: 'claude',
   [LLM_PROVIDERS.CODEX]: 'codex',
+}
+
+type EnsureWorkspaceInstructionFile = typeof ensureWorkspaceInstructionFile
+
+let ensureWorkspaceInstructionFileForTesting: EnsureWorkspaceInstructionFile | null =
+  null
+
+/** Overrides ACP instruction-file writes in tests without Bun module mocks. */
+export function setEnsureWorkspaceInstructionFileForTesting(
+  fn: EnsureWorkspaceInstructionFile | null,
+): void {
+  ensureWorkspaceInstructionFileForTesting = fn
 }
 
 /**
@@ -115,7 +127,9 @@ async function createAcpLanguageModel(
     origin: config.origin,
     acpMode: true,
   }
-  const ensureResult = await ensureWorkspaceInstructionFile({
+  const ensure =
+    ensureWorkspaceInstructionFileForTesting ?? ensureWorkspaceInstructionFile
+  const ensureResult = await ensure({
     workspacePath,
     providerType: config.provider,
     promptOptions,

--- a/packages/browseros-agent/apps/server/src/lib/db/client.ts
+++ b/packages/browseros-agent/apps/server/src/lib/db/client.ts
@@ -5,7 +5,7 @@
  */
 
 import { Database as BunDatabase } from 'bun:sqlite'
-import { existsSync, mkdirSync } from 'node:fs'
+import { existsSync, mkdirSync, readFileSync } from 'node:fs'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { type BunSQLiteDatabase, drizzle } from 'drizzle-orm/bun-sqlite'
@@ -13,6 +13,10 @@ import { migrate } from 'drizzle-orm/bun-sqlite/migrator'
 import * as schema from './schema'
 
 export type BrowserOsDatabase = BunSQLiteDatabase<typeof schema>
+
+interface DrizzleJournalEntry {
+  tag: string
+}
 
 export interface DbHandle {
   path: string
@@ -63,7 +67,9 @@ export function resolveMigrationsDir(
   options: Pick<OpenDbOptions, 'migrationsDir' | 'resourcesDir'> = {},
 ): string | null {
   if (options.migrationsDir) {
-    if (existsSync(options.migrationsDir)) return options.migrationsDir
+    if (hasCompleteMigrationSet(options.migrationsDir)) {
+      return options.migrationsDir
+    }
     return null
   }
 
@@ -75,10 +81,61 @@ export function resolveMigrationsDir(
   ].filter((candidate): candidate is string => Boolean(candidate))
 
   for (const candidate of candidates) {
-    if (existsSync(candidate)) return candidate
+    if (hasCompleteMigrationSet(candidate)) return candidate
   }
 
   return null
+}
+
+/** Accepts only migration folders Drizzle can read without filesystem errors. */
+function hasCompleteMigrationSet(migrationsDir: string): boolean {
+  const journal = readDrizzleJournal(join(migrationsDir, 'meta', '_journal.json'))
+  if (!journal) return false
+
+  const journalTags = new Set(journal.entries.map((entry) => entry.tag))
+  if (
+    !currentMigrationHistory.every((migration) =>
+      journalTags.has(migration.tag),
+    )
+  ) {
+    return false
+  }
+
+  return journal.entries.every((entry) =>
+    existsSync(join(migrationsDir, `${entry.tag}.sql`)),
+  )
+}
+
+function readDrizzleJournal(
+  journalPath: string,
+): { entries: DrizzleJournalEntry[] } | null {
+  if (!existsSync(journalPath)) return null
+
+  try {
+    const journal = JSON.parse(readFileSync(journalPath, 'utf8')) as unknown
+    if (!isDrizzleJournal(journal)) return null
+    return journal
+  } catch {
+    return null
+  }
+}
+
+function isDrizzleJournal(
+  value: unknown,
+): value is { entries: DrizzleJournalEntry[] } {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    'entries' in value &&
+    Array.isArray(value.entries) &&
+    value.entries.every(
+      (entry) =>
+        typeof entry === 'object' &&
+        entry !== null &&
+        'tag' in entry &&
+        typeof entry.tag === 'string',
+    )
+  )
 }
 
 /** Creates the current schema when packaged builds lack migration files, and marks those migrations applied. */
@@ -107,19 +164,23 @@ function bootstrapCurrentSchema(sqlite: BunDatabase): void {
 
 const currentMigrationHistory = [
   {
+    tag: '0000_zippy_psylocke',
     hash: 'aadfc2e86410febb11a974d25d99d5f7196aa797d9635ced9a18cd4eeb503b61',
     createdAt: 1777750582590,
   },
   {
+    tag: '0001_lazy_orphan',
     hash: '19e693f7b1adcd1d932fa6cf5638b5b158c66ea5de4f154bc59311f4d6f71261',
     createdAt: 1777752799806,
   },
   {
+    tag: '0002_chemical_whirlwind',
     hash: '02b11bf1dc34a5a289efd216233a48f0b7b950cfc33eaa7ebe6dcbb15d07f75c',
     createdAt: 1777902205667,
   },
 ]
 
+// TODO(nikhil): Remove this fallback once Windows/Linux packaging always includes Drizzle migrations.
 const currentSchemaStatements = [
   `
     CREATE TABLE IF NOT EXISTS agent_definitions (

--- a/packages/browseros-agent/apps/server/src/lib/db/client.ts
+++ b/packages/browseros-agent/apps/server/src/lib/db/client.ts
@@ -16,7 +16,7 @@ export type BrowserOsDatabase = BunSQLiteDatabase<typeof schema>
 
 export interface DbHandle {
   path: string
-  migrationsDir: string
+  migrationsDir: string | null
   sqlite: BunDatabase
   db: BrowserOsDatabase
 }
@@ -43,7 +43,11 @@ export function openBrowserOsDatabase(options: OpenDbOptions): DbHandle {
 
   const db = drizzle(sqlite, { schema })
   if (options.runMigrations !== false) {
-    migrate(db, { migrationsFolder: migrationsDir })
+    if (migrationsDir) {
+      migrate(db, { migrationsFolder: migrationsDir })
+    } else {
+      bootstrapCurrentSchema(sqlite)
+    }
   }
 
   return {
@@ -57,12 +61,10 @@ export function openBrowserOsDatabase(options: OpenDbOptions): DbHandle {
 /** Resolves migrations from explicit test paths, packaged resources, or the source tree. */
 export function resolveMigrationsDir(
   options: Pick<OpenDbOptions, 'migrationsDir' | 'resourcesDir'> = {},
-): string {
+): string | null {
   if (options.migrationsDir) {
     if (existsSync(options.migrationsDir)) return options.migrationsDir
-    throw new Error(
-      `Drizzle migrations directory not found. Checked: ${options.migrationsDir}`,
-    )
+    return null
   }
 
   const candidates = [
@@ -76,7 +78,132 @@ export function resolveMigrationsDir(
     if (existsSync(candidate)) return candidate
   }
 
-  throw new Error(
-    `Drizzle migrations directory not found. Checked: ${candidates.join(', ')}`,
-  )
+  return null
 }
+
+/** Creates the current schema when packaged builds lack migration files, and marks those migrations applied. */
+function bootstrapCurrentSchema(sqlite: BunDatabase): void {
+  sqlite.exec('BEGIN')
+  try {
+    for (const statement of currentSchemaStatements) {
+      sqlite.exec(statement)
+    }
+    for (const migration of currentMigrationHistory) {
+      sqlite.exec(`
+        INSERT INTO __drizzle_migrations ("hash", "created_at")
+        SELECT '${migration.hash}', ${migration.createdAt}
+        WHERE NOT EXISTS (
+          SELECT 1 FROM __drizzle_migrations
+          WHERE created_at = ${migration.createdAt}
+        )
+      `)
+    }
+    sqlite.exec('COMMIT')
+  } catch (error) {
+    sqlite.exec('ROLLBACK')
+    throw error
+  }
+}
+
+const currentMigrationHistory = [
+  {
+    hash: 'aadfc2e86410febb11a974d25d99d5f7196aa797d9635ced9a18cd4eeb503b61',
+    createdAt: 1777750582590,
+  },
+  {
+    hash: '19e693f7b1adcd1d932fa6cf5638b5b158c66ea5de4f154bc59311f4d6f71261',
+    createdAt: 1777752799806,
+  },
+  {
+    hash: '02b11bf1dc34a5a289efd216233a48f0b7b950cfc33eaa7ebe6dcbb15d07f75c',
+    createdAt: 1777902205667,
+  },
+]
+
+const currentSchemaStatements = [
+  `
+    CREATE TABLE IF NOT EXISTS agent_definitions (
+      id text PRIMARY KEY NOT NULL,
+      name text NOT NULL,
+      adapter text NOT NULL,
+      model_id text NOT NULL,
+      reasoning_effort text NOT NULL,
+      permission_mode text DEFAULT 'approve-all' NOT NULL,
+      session_key text NOT NULL,
+      pinned integer DEFAULT false NOT NULL,
+      adapter_config_json text,
+      created_at integer NOT NULL,
+      updated_at integer NOT NULL
+    )
+  `,
+  `
+    CREATE UNIQUE INDEX IF NOT EXISTS agent_definitions_session_key_unique
+    ON agent_definitions (session_key)
+  `,
+  `
+    CREATE INDEX IF NOT EXISTS agent_definitions_updated_at_idx
+    ON agent_definitions (updated_at)
+  `,
+  `
+    CREATE INDEX IF NOT EXISTS agent_definitions_adapter_updated_at_idx
+    ON agent_definitions (adapter, updated_at)
+  `,
+  `
+    CREATE TABLE IF NOT EXISTS oauth_tokens (
+      browseros_id text NOT NULL,
+      provider text NOT NULL,
+      access_token text NOT NULL,
+      refresh_token text NOT NULL,
+      expires_at integer NOT NULL,
+      email text,
+      account_id text,
+      updated_at integer NOT NULL,
+      PRIMARY KEY (browseros_id, provider)
+    )
+  `,
+  `
+    CREATE INDEX IF NOT EXISTS oauth_tokens_browseros_id_idx
+    ON oauth_tokens (browseros_id)
+  `,
+  `
+    CREATE TABLE IF NOT EXISTS produced_files (
+      id text PRIMARY KEY NOT NULL,
+      agent_definition_id text NOT NULL,
+      session_key text NOT NULL,
+      turn_id text NOT NULL,
+      turn_prompt text NOT NULL,
+      path text NOT NULL,
+      size integer NOT NULL,
+      mtime_ms integer NOT NULL,
+      created_at integer NOT NULL,
+      detected_by text DEFAULT 'diff' NOT NULL,
+      FOREIGN KEY (agent_definition_id)
+        REFERENCES agent_definitions(id)
+        ON UPDATE no action
+        ON DELETE cascade
+    )
+  `,
+  `
+    CREATE UNIQUE INDEX IF NOT EXISTS produced_files_agent_path_unique
+    ON produced_files (agent_definition_id, path)
+  `,
+  `
+    CREATE INDEX IF NOT EXISTS produced_files_agent_created_idx
+    ON produced_files (agent_definition_id, created_at)
+  `,
+  `
+    CREATE INDEX IF NOT EXISTS produced_files_turn_idx
+    ON produced_files (turn_id)
+  `,
+  `
+    CREATE INDEX IF NOT EXISTS produced_files_session_idx
+    ON produced_files (session_key)
+  `,
+  `
+    CREATE TABLE IF NOT EXISTS __drizzle_migrations (
+      id SERIAL PRIMARY KEY,
+      hash text NOT NULL,
+      created_at numeric
+    )
+  `,
+]

--- a/packages/browseros-agent/apps/server/src/lib/db/client.ts
+++ b/packages/browseros-agent/apps/server/src/lib/db/client.ts
@@ -10,6 +10,7 @@ import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { type BunSQLiteDatabase, drizzle } from 'drizzle-orm/bun-sqlite'
 import { migrate } from 'drizzle-orm/bun-sqlite/migrator'
+import { logger } from '../logger'
 import * as schema from './schema'
 
 export type BrowserOsDatabase = BunSQLiteDatabase<typeof schema>
@@ -50,6 +51,9 @@ export function openBrowserOsDatabase(options: OpenDbOptions): DbHandle {
     if (migrationsDir) {
       migrate(db, { migrationsFolder: migrationsDir })
     } else {
+      logger.warn('Drizzle migrations unavailable; bootstrapping current schema', {
+        dbPath: options.dbPath,
+      })
       bootstrapCurrentSchema(sqlite)
     }
   }
@@ -70,6 +74,10 @@ export function resolveMigrationsDir(
     if (hasCompleteMigrationSet(options.migrationsDir)) {
       return options.migrationsDir
     }
+    logger.warn(
+      'Configured Drizzle migrations directory is missing or incomplete; bootstrapping current schema',
+      { migrationsDir: options.migrationsDir },
+    )
     return null
   }
 
@@ -145,15 +153,20 @@ function bootstrapCurrentSchema(sqlite: BunDatabase): void {
     for (const statement of currentSchemaStatements) {
       sqlite.exec(statement)
     }
+    const insertMigration = sqlite.prepare(`
+      INSERT INTO __drizzle_migrations ("hash", "created_at")
+      SELECT ?, ?
+      WHERE NOT EXISTS (
+        SELECT 1 FROM __drizzle_migrations
+        WHERE created_at = ?
+      )
+    `)
     for (const migration of currentMigrationHistory) {
-      sqlite.exec(`
-        INSERT INTO __drizzle_migrations ("hash", "created_at")
-        SELECT '${migration.hash}', ${migration.createdAt}
-        WHERE NOT EXISTS (
-          SELECT 1 FROM __drizzle_migrations
-          WHERE created_at = ${migration.createdAt}
-        )
-      `)
+      insertMigration.run(
+        migration.hash,
+        migration.createdAt,
+        migration.createdAt,
+      )
     }
     sqlite.exec('COMMIT')
   } catch (error) {

--- a/packages/browseros-agent/apps/server/tests/agent/provider-factory-acp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/provider-factory-acp.test.ts
@@ -3,7 +3,7 @@
  * Copyright 2025 BrowserOS
  */
 
-import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 
@@ -44,13 +44,6 @@ mock.module('node:fs/promises', () => ({
   },
 }))
 
-mock.module('../../src/agent/acp-instructions', () => ({
-  ensureWorkspaceInstructionFile: async (opts: Record<string, unknown>) => {
-    lastInstructionArgs = opts
-    return { action: 'skipped-not-new-conversation' }
-  },
-}))
-
 mock.module('../../src/lib/browseros-dir', () => ({
   getBrowserosDir: () => join(homedir(), '.browseros-test'),
 }))
@@ -63,7 +56,12 @@ mock.module('../../src/lib/agents/acpx-provider/buildAcpxProvider', () => ({
 }))
 
 const mod = await import('../../src/agent/provider-factory')
-const { createLanguageModel } = mod
+const { createLanguageModel, setEnsureWorkspaceInstructionFileForTesting } = mod
+
+afterAll(() => {
+  setEnsureWorkspaceInstructionFileForTesting(null)
+  mock.restore()
+})
 
 function baseConfig(): Record<string, unknown> {
   return {
@@ -83,6 +81,10 @@ beforeEach(() => {
   omitRuntimeSetMode = false
   mkdirCalls.length = 0
   lastInstructionArgs = null
+  setEnsureWorkspaceInstructionFileForTesting(async (opts) => {
+    lastInstructionArgs = opts as unknown as Record<string, unknown>
+    return { action: 'skipped-not-new-conversation' }
+  })
 })
 
 describe('createLanguageModel — ACP providers', () => {

--- a/packages/browseros-agent/apps/server/tests/lib/db/index.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/db/index.test.ts
@@ -43,15 +43,57 @@ describe('database initialization', () => {
     expect(second).toBe(first)
   })
 
-  it('fails clearly when an explicit migration directory is missing', () => {
+  it('bootstraps the current schema when migration files are unavailable', () => {
     const dir = mkTempDir()
+    const handle = initializeDb({
+      dbPath: join(dir, 'browseros.sqlite'),
+      migrationsDir: join(dir, 'missing-migrations'),
+    })
 
-    expect(() =>
-      initializeDb({
-        dbPath: join(dir, 'browseros.sqlite'),
-        migrationsDir: join(dir, 'missing-migrations'),
-      }),
-    ).toThrow(/Drizzle migrations directory not found/)
+    const tables = handle.sqlite
+      .query<{ name: string }, []>(
+        `
+          SELECT name FROM sqlite_master
+          WHERE type = 'table'
+            AND name IN (
+              'agent_definitions',
+              'oauth_tokens',
+              'produced_files',
+              '__drizzle_migrations'
+            )
+          ORDER BY name
+        `,
+      )
+      .all()
+      .map((row) => row.name)
+
+    expect(tables).toEqual([
+      '__drizzle_migrations',
+      'agent_definitions',
+      'oauth_tokens',
+      'produced_files',
+    ])
+    expect(
+      handle.sqlite
+        .query<{ count: number }, []>(
+          'SELECT COUNT(*) AS count FROM __drizzle_migrations',
+        )
+        .get()?.count,
+    ).toBe(3)
+    expect(handle.db.select().from(agentDefinitions).all()).toEqual([])
+  })
+
+  it('does not rerun old migrations after fallback schema bootstrap', () => {
+    const dir = mkTempDir()
+    const dbPath = join(dir, 'browseros.sqlite')
+
+    initializeDb({
+      dbPath,
+      migrationsDir: join(dir, 'missing-migrations'),
+    })
+    closeDb()
+
+    expect(() => initializeDb({ dbPath })).not.toThrow()
   })
 
   function mkTempDir(): string {

--- a/packages/browseros-agent/apps/server/tests/lib/db/index.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/db/index.test.ts
@@ -121,13 +121,17 @@ describe('database initialization', () => {
       'oauth_tokens',
       'produced_files',
     ])
-    expect(
-      handle.sqlite
-        .query<{ count: number }, []>(
-          'SELECT COUNT(*) AS count FROM __drizzle_migrations',
-        )
-        .get()?.count,
-    ).toBe(3)
+    const migrations = handle.sqlite
+      .query<{ hash: string; createdAt: number }, []>(
+        `
+          SELECT hash, created_at AS createdAt
+          FROM __drizzle_migrations
+          ORDER BY created_at
+        `,
+      )
+      .all()
+
+    expect(migrations).toEqual(expectedMigrationHistory)
   }
 
   function mkTempDir(): string {
@@ -136,3 +140,18 @@ describe('database initialization', () => {
     return dir
   }
 })
+
+const expectedMigrationHistory = [
+  {
+    hash: 'aadfc2e86410febb11a974d25d99d5f7196aa797d9635ced9a18cd4eeb503b61',
+    createdAt: 1777750582590,
+  },
+  {
+    hash: '19e693f7b1adcd1d932fa6cf5638b5b158c66ea5de4f154bc59311f4d6f71261',
+    createdAt: 1777752799806,
+  },
+  {
+    hash: '02b11bf1dc34a5a289efd216233a48f0b7b950cfc33eaa7ebe6dcbb15d07f75c',
+    createdAt: 1777902205667,
+  },
+]

--- a/packages/browseros-agent/apps/server/tests/lib/db/index.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/db/index.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { afterEach, describe, expect, it } from 'bun:test'
-import { existsSync, mkdtempSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync } from 'node:fs'
 import { rm } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -50,6 +50,54 @@ describe('database initialization', () => {
       migrationsDir: join(dir, 'missing-migrations'),
     })
 
+    expectCurrentSchema(handle)
+    expect(handle.db.select().from(agentDefinitions).all()).toEqual([])
+  })
+
+  it('bootstraps the current schema when a migration directory is empty', () => {
+    const dir = mkTempDir()
+    const migrationsDir = join(dir, 'empty-migrations')
+    mkdirSync(migrationsDir)
+
+    const handle = initializeDb({
+      dbPath: join(dir, 'browseros.sqlite'),
+      migrationsDir,
+    })
+
+    expect(handle.migrationsDir).toBe(null)
+    expectCurrentSchema(handle)
+    expect(handle.db.select().from(agentDefinitions).all()).toEqual([])
+  })
+
+  it('skips empty packaged migration resources', () => {
+    const dir = mkTempDir()
+    const resourcesDir = join(dir, 'resources')
+    const packagedMigrationsDir = join(resourcesDir, 'db', 'migrations')
+    mkdirSync(packagedMigrationsDir, { recursive: true })
+
+    const handle = initializeDb({
+      dbPath: join(dir, 'browseros.sqlite'),
+      resourcesDir,
+    })
+
+    expect(handle.migrationsDir).not.toBe(packagedMigrationsDir)
+    expect(handle.db.select().from(agentDefinitions).all()).toEqual([])
+  })
+
+  it('does not rerun old migrations after fallback schema bootstrap', () => {
+    const dir = mkTempDir()
+    const dbPath = join(dir, 'browseros.sqlite')
+
+    initializeDb({
+      dbPath,
+      migrationsDir: join(dir, 'missing-migrations'),
+    })
+    closeDb()
+
+    expect(() => initializeDb({ dbPath })).not.toThrow()
+  })
+
+  function expectCurrentSchema(handle: ReturnType<typeof initializeDb>): void {
     const tables = handle.sqlite
       .query<{ name: string }, []>(
         `
@@ -80,21 +128,7 @@ describe('database initialization', () => {
         )
         .get()?.count,
     ).toBe(3)
-    expect(handle.db.select().from(agentDefinitions).all()).toEqual([])
-  })
-
-  it('does not rerun old migrations after fallback schema bootstrap', () => {
-    const dir = mkTempDir()
-    const dbPath = join(dir, 'browseros.sqlite')
-
-    initializeDb({
-      dbPath,
-      migrationsDir: join(dir, 'missing-migrations'),
-    })
-    closeDb()
-
-    expect(() => initializeDb({ dbPath })).not.toThrow()
-  })
+  }
 
   function mkTempDir(): string {
     const dir = mkdtempSync(join(tmpdir(), 'browseros-db-test-'))


### PR DESCRIPTION
## Summary
- add a temporary SQLite schema bootstrap when Drizzle migration files are missing from packaged resources
- validate migration folders before passing them to Drizzle so empty/partial directories fall back cleanly
- seed the current Drizzle migration history and assert exact hashes/timestamps in DB initialization tests

## Verification
- bun test apps/server/tests/lib/db/index.test.ts apps/server/tests/lib/agents/db-agent-store.test.ts apps/server/tests/lib/clients/oauth/token-store.test.ts
- bun run --filter @browseros/server typecheck
- bun run lint
- git diff --check
- bun --env-file=.env.development test --preload=./tests/__helpers__/test-env.ts ./tests/tools/bookmarks.test.ts ./tests/tools/filesystem/bash.test.ts

Note: a full bun run check hit a transient CDP/test-harness failure in the tools group; after cleanup, the failed bookmark/filesystem bash files passed cleanly.