### PR TITLE
feat(agent-mcp-interface): attach to browseros browser over CDP at boot

### DIFF
--- a/packages/browseros-agent/apps/agent-mcp-interface/src/env.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/env.ts
@@ -8,7 +8,7 @@
  * noProcessEnv rule stay on at error level for every other file.
  */
 
-import { PROD_API_PORT } from './shared/port'
+import { COCKPIT_CDP_PORT_DEFAULT, PROD_API_PORT } from './shared/port'
 
 function readPort(): number {
   // biome-ignore lint/style/noProcessEnv: env.ts is the sanctioned env-reader for the package
@@ -17,6 +17,24 @@ function readPort(): number {
   const parsed = Number(raw)
   if (!Number.isInteger(parsed) || parsed < 0 || parsed > 65535) {
     return PROD_API_PORT
+  }
+  return parsed
+}
+
+/**
+ * Port the cockpit dials when attaching to the BrowserOS Chromium
+ * over CDP. Default lives in IANA's dynamic / private range so it
+ * cannot collide with a registered service; the env override is the
+ * bridge until the BrowserOS browser shell defaults its DevTools
+ * port to the same value.
+ */
+function readCdpPort(): number {
+  // biome-ignore lint/style/noProcessEnv: env.ts is the sanctioned env-reader for the package
+  const raw = process.env.BROWSEROS_COCKPIT_CDP_PORT
+  if (!raw) return COCKPIT_CDP_PORT_DEFAULT
+  const parsed = Number(raw)
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+    return COCKPIT_CDP_PORT_DEFAULT
   }
   return parsed
 }
@@ -39,6 +57,7 @@ function readIsDevelopment(): boolean {
  */
 export const env = {
   port: readPort(),
+  cdpPort: readCdpPort(),
   browserosDirOverride: readBrowserosDirOverride(),
   isDevelopment: readIsDevelopment(),
 }

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/lib/browser-bootstrap.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/lib/browser-bootstrap.ts
@@ -1,0 +1,97 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * CDP attach helper for the cockpit's standalone runtime.
+ *
+ * Mirrors how `apps/server` connects to the BrowserOS Chromium:
+ * instantiate a `CdpBackend` against the configured port, dial, wrap
+ * the connection in a `Browser`, and hand the resulting
+ * `BrowserSession` back so `main.ts` can pin it onto the cockpit's
+ * process-wide singleton.
+ *
+ * `exitOnReconnectFailure: false` is deliberate. apps/server runs as
+ * a child of the BrowserOS browser shell, so exiting on a dropped
+ * CDP connection is the right escalation; the parent restarts it.
+ * The standalone cockpit is user-owned — a transient CDP drop must
+ * degrade to "session not connected" until BrowserOS is back up,
+ * not kill the process and lose the UI tab.
+ *
+ * Soft fail at boot: if BrowserOS is not running on the configured
+ * port at startup, return `null` and log a warning. The cockpit
+ * keeps serving the UI, the profile CRUD, the harness installs, and
+ * `tools/list`; only `tools/call` short-circuits with the existing
+ * "browser session not connected" wire shape. Restart the cockpit
+ * after BrowserOS is up to reattach.
+ */
+
+import { Browser } from '@browseros/server/browser'
+import { CdpBackend } from '@browseros/server/browser/backends/cdp'
+import type { BrowserSession } from '@browseros/server/browser/core/session'
+import { env } from '../env'
+import { logger } from './logger'
+
+export interface BrowserBootstrap {
+  session: BrowserSession
+  disconnect(): Promise<void>
+}
+
+/**
+ * Minimal seam every test needs: a CDP-like value with `connect` and
+ * `disconnect` methods, so the unit test can supply a stub without
+ * touching the network. The runtime path passes a real `CdpBackend`.
+ */
+export interface CdpClient {
+  connect(): Promise<void>
+  disconnect(): Promise<void>
+}
+
+export interface BrowserBootstrapDeps {
+  /** Builds the CDP client. Defaulted to a real `CdpBackend` in production. */
+  cdpFactory?: (port: number) => CdpClient
+  /** Builds the `BrowserSession` from a connected CDP client. */
+  buildSession?: (cdp: CdpClient) => BrowserSession
+}
+
+const defaultCdpFactory: NonNullable<BrowserBootstrapDeps['cdpFactory']> = (
+  port,
+) => new CdpBackend({ port, exitOnReconnectFailure: false })
+
+const defaultBuildSession: NonNullable<BrowserBootstrapDeps['buildSession']> = (
+  cdp,
+) => new Browser(cdp as unknown as CdpBackend).session
+
+export async function bootstrapBrowserosBrowser(
+  deps: BrowserBootstrapDeps = {},
+): Promise<BrowserBootstrap | null> {
+  const cdpFactory = deps.cdpFactory ?? defaultCdpFactory
+  const buildSession = deps.buildSession ?? defaultBuildSession
+  const port = env.cdpPort
+  const cdp = cdpFactory(port)
+  try {
+    await cdp.connect()
+  } catch (err) {
+    logger.warn(
+      'browseros browser unreachable on cdp port; cockpit will boot without a session',
+      {
+        port,
+        error: err instanceof Error ? err.message : String(err),
+      },
+    )
+    return null
+  }
+  const session = buildSession(cdp)
+  return {
+    session,
+    disconnect: async () => {
+      try {
+        await cdp.disconnect()
+      } catch (err) {
+        logger.warn('cdp disconnect failed', {
+          error: err instanceof Error ? err.message : String(err),
+        })
+      }
+    },
+  }
+}

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/lib/browser-bootstrap.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/lib/browser-bootstrap.ts
@@ -47,26 +47,35 @@ export interface CdpClient {
   disconnect(): Promise<void>
 }
 
-export interface BrowserBootstrapDeps {
-  /** Builds the CDP client. Defaulted to a real `CdpBackend` in production. */
-  cdpFactory?: (port: number) => CdpClient
-  /** Builds the `BrowserSession` from a connected CDP client. */
-  buildSession?: (cdp: CdpClient) => BrowserSession
+/**
+ * Test seam for swapping out the CDP attach machinery as a single
+ * unit. `cdpFactory` and `buildSession` are deliberately bundled here
+ * rather than exposed as two independent optional overrides: the
+ * default `buildSession` casts its argument to a real `CdpBackend`
+ * before instantiating `Browser`, so mixing a stub `cdpFactory` with
+ * the default `buildSession` would compile but blow up at the first
+ * `Browser` call. Callers either pass no `inject` (production) or
+ * pass both factories (tests).
+ */
+export interface BrowserBootstrapInjection {
+  cdpFactory: (port: number) => CdpClient
+  buildSession: (cdp: CdpClient) => BrowserSession
 }
 
-const defaultCdpFactory: NonNullable<BrowserBootstrapDeps['cdpFactory']> = (
-  port,
-) => new CdpBackend({ port, exitOnReconnectFailure: false })
+export interface BrowserBootstrapDeps {
+  /** Test-only: replace the entire CDP attach machinery with stubs. */
+  inject?: BrowserBootstrapInjection
+}
 
-const defaultBuildSession: NonNullable<BrowserBootstrapDeps['buildSession']> = (
-  cdp,
-) => new Browser(cdp as unknown as CdpBackend).session
+const defaultInjection: BrowserBootstrapInjection = {
+  cdpFactory: (port) => new CdpBackend({ port, exitOnReconnectFailure: false }),
+  buildSession: (cdp) => new Browser(cdp as unknown as CdpBackend).session,
+}
 
 export async function bootstrapBrowserosBrowser(
   deps: BrowserBootstrapDeps = {},
 ): Promise<BrowserBootstrap | null> {
-  const cdpFactory = deps.cdpFactory ?? defaultCdpFactory
-  const buildSession = deps.buildSession ?? defaultBuildSession
+  const { cdpFactory, buildSession } = deps.inject ?? defaultInjection
   const port = env.cdpPort
   const cdp = cdpFactory(port)
   try {

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/main.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/main.ts
@@ -35,13 +35,15 @@ if (typeof Bun === 'undefined') {
 
 import { Hono } from 'hono'
 import { env } from './env'
+import { bootstrapBrowserosBrowser } from './lib/browser-bootstrap'
+import { setBrowserSession } from './lib/browser-session'
 import { logger } from './lib/logger'
 import { migrateMcpUrls } from './lib/migrate-mcp-urls'
 import { setLocalServerUrl } from './local-server-url'
 import server from './server'
 import { COCKPIT_MOUNT_PREFIX } from './shared/port'
 
-function start(): void {
+async function start(): Promise<void> {
   const root = new Hono().route(COCKPIT_MOUNT_PREFIX, server)
   const httpServer = Bun.serve({
     hostname: '127.0.0.1',
@@ -51,6 +53,28 @@ function start(): void {
   const url = `http://${httpServer.hostname}:${httpServer.port}${COCKPIT_MOUNT_PREFIX}`
   setLocalServerUrl(url)
   logger.info('agent-mcp-interface listening', { url })
+
+  // Attach to the BrowserOS Chromium so MCP `tools/call` dispatches
+  // hit a real browser. The bootstrap soft-fails when BrowserOS is
+  // not reachable: the cockpit keeps serving the UI, profile CRUD,
+  // harness installs, and `tools/list`, and `tools/call` continues
+  // to short-circuit with the existing "session not connected"
+  // wire shape until the user restarts the cockpit with BrowserOS
+  // up. Reattach on transient drops is the CdpBackend's job (we
+  // pass `exitOnReconnectFailure: false` so it does not kill the
+  // process).
+  const bootstrap = await bootstrapBrowserosBrowser()
+  if (bootstrap) {
+    setBrowserSession(bootstrap.session)
+    logger.info('cockpit attached to browseros browser', {
+      cdpPort: env.cdpPort,
+    })
+    const cleanup = (): void => {
+      bootstrap.disconnect().finally(() => process.exit(0))
+    }
+    process.once('SIGINT', cleanup)
+    process.once('SIGTERM', cleanup)
+  }
 
   // Mirror what createCockpitRoutes does in the merged runtime: sweep
   // every stored profile and rewrite its harness install + mcpUrl to
@@ -74,4 +98,4 @@ function start(): void {
     )
 }
 
-start()
+void start()

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/main.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/main.ts
@@ -69,7 +69,20 @@ async function start(): Promise<void> {
     logger.info('cockpit attached to browseros browser', {
       cdpPort: env.cdpPort,
     })
+    // `exiting` guards against double-cleanup when a supervisor sends
+    // SIGINT and SIGTERM back-to-back. `process.once` removes each
+    // handler independently, so without the flag a SIGTERM that
+    // arrives while the SIGINT cleanup is still in flight would
+    // restart `disconnect()` on an already-closing CDP connection.
+    // The kill switch guarantees forward progress: a hung
+    // `cdp.disconnect()` (half-open socket, network stall) would
+    // otherwise leave the process stuck because both handlers have
+    // already been removed and only SIGKILL could recover it.
+    let exiting = false
     const cleanup = (): void => {
+      if (exiting) return
+      exiting = true
+      setTimeout(() => process.exit(1), 5_000).unref()
       bootstrap.disconnect().finally(() => process.exit(0))
     }
     process.once('SIGINT', cleanup)

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/shared/port.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/shared/port.ts
@@ -24,3 +24,18 @@ export const COCKPIT_MOUNT_PREFIX = '/cockpit'
 
 /** Standalone dev port for `src/main.ts` when running detached. */
 export const DEV_STANDALONE_PORT = 9200
+
+/**
+ * Default CDP port the cockpit dials when attaching to the BrowserOS
+ * Chromium. Lives in IANA's dynamic / private range (49152-65535)
+ * so it cannot collide with a registered service, and is not a round
+ * number so a hand-rolled local script is unlikely to pick the same
+ * value. Override via `BROWSEROS_COCKPIT_CDP_PORT`.
+ *
+ * Important: this is the port BrowserOS's Chromium exposes its
+ * DevTools on, not a port the cockpit itself opens. Until the
+ * BrowserOS browser shell defaults to the same value, the env var
+ * is the bridge — set it to whatever DevTools port BrowserOS is
+ * currently bound on.
+ */
+export const COCKPIT_CDP_PORT_DEFAULT = 49337

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/browser-bootstrap.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/browser-bootstrap.test.ts
@@ -1,0 +1,111 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Bootstrap covers the connect / disconnect contract the cockpit
+ * relies on when running standalone. The real `CdpBackend` is
+ * injected via `BrowserBootstrapDeps`, so this test never opens a
+ * socket.
+ */
+
+import { describe, expect, test } from 'bun:test'
+import type { BrowserSession } from '@browseros/server/browser/core/session'
+import {
+  bootstrapBrowserosBrowser,
+  type CdpClient,
+} from '../../src/lib/browser-bootstrap'
+
+interface StubCdp extends CdpClient {
+  readonly connectCalls: number
+  readonly disconnectCalls: number
+}
+
+function makeStubCdp(opts: { connectThrows?: Error } = {}): StubCdp {
+  let connectCalls = 0
+  let disconnectCalls = 0
+  return {
+    get connectCalls() {
+      return connectCalls
+    },
+    get disconnectCalls() {
+      return disconnectCalls
+    },
+    connect: async () => {
+      connectCalls++
+      if (opts.connectThrows) throw opts.connectThrows
+    },
+    disconnect: async () => {
+      disconnectCalls++
+    },
+  }
+}
+
+const fakeSession = { tag: 'fake-session' } as unknown as BrowserSession
+
+describe('bootstrapBrowserosBrowser', () => {
+  test('connects, builds a session, and returns a disconnect() that drops the cdp', async () => {
+    const cdp = makeStubCdp()
+    const seenCdps: CdpClient[] = []
+    const result = await bootstrapBrowserosBrowser({
+      cdpFactory: () => cdp,
+      buildSession: (c) => {
+        seenCdps.push(c)
+        return fakeSession
+      },
+    })
+    expect(result).not.toBeNull()
+    expect(result?.session).toBe(fakeSession)
+    expect(cdp.connectCalls).toBe(1)
+    expect(seenCdps).toEqual([cdp])
+    await result?.disconnect()
+    expect(cdp.disconnectCalls).toBe(1)
+  })
+
+  test('returns null when the cdp connect throws and never builds a session', async () => {
+    const cdp = makeStubCdp({ connectThrows: new Error('ECONNREFUSED') })
+    let buildSessionCalls = 0
+    const result = await bootstrapBrowserosBrowser({
+      cdpFactory: () => cdp,
+      buildSession: () => {
+        buildSessionCalls++
+        return fakeSession
+      },
+    })
+    expect(result).toBeNull()
+    expect(cdp.connectCalls).toBe(1)
+    expect(buildSessionCalls).toBe(0)
+  })
+
+  test('disconnect() swallows underlying errors so callers can call it from a signal handler', async () => {
+    const cdp: CdpClient = {
+      connect: async () => undefined,
+      disconnect: async () => {
+        throw new Error('socket already gone')
+      },
+    }
+    const result = await bootstrapBrowserosBrowser({
+      cdpFactory: () => cdp,
+      buildSession: () => fakeSession,
+    })
+    expect(result).not.toBeNull()
+    // The disconnect must not throw — the signal-handler path in
+    // main.ts relies on this so it can always reach process.exit.
+    await expect(result?.disconnect()).resolves.toBeUndefined()
+  })
+
+  test('cdpFactory is invoked with env.cdpPort so a misconfigured port is observable', async () => {
+    const seenPorts: number[] = []
+    const cdp = makeStubCdp()
+    await bootstrapBrowserosBrowser({
+      cdpFactory: (port) => {
+        seenPorts.push(port)
+        return cdp
+      },
+      buildSession: () => fakeSession,
+    })
+    expect(seenPorts).toHaveLength(1)
+    expect(seenPorts[0]).toBeGreaterThan(0)
+    expect(seenPorts[0]).toBeLessThanOrEqual(65535)
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/browser-bootstrap.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/browser-bootstrap.test.ts
@@ -48,10 +48,12 @@ describe('bootstrapBrowserosBrowser', () => {
     const cdp = makeStubCdp()
     const seenCdps: CdpClient[] = []
     const result = await bootstrapBrowserosBrowser({
-      cdpFactory: () => cdp,
-      buildSession: (c) => {
-        seenCdps.push(c)
-        return fakeSession
+      inject: {
+        cdpFactory: () => cdp,
+        buildSession: (c) => {
+          seenCdps.push(c)
+          return fakeSession
+        },
       },
     })
     expect(result).not.toBeNull()
@@ -66,10 +68,12 @@ describe('bootstrapBrowserosBrowser', () => {
     const cdp = makeStubCdp({ connectThrows: new Error('ECONNREFUSED') })
     let buildSessionCalls = 0
     const result = await bootstrapBrowserosBrowser({
-      cdpFactory: () => cdp,
-      buildSession: () => {
-        buildSessionCalls++
-        return fakeSession
+      inject: {
+        cdpFactory: () => cdp,
+        buildSession: () => {
+          buildSessionCalls++
+          return fakeSession
+        },
       },
     })
     expect(result).toBeNull()
@@ -85,8 +89,10 @@ describe('bootstrapBrowserosBrowser', () => {
       },
     }
     const result = await bootstrapBrowserosBrowser({
-      cdpFactory: () => cdp,
-      buildSession: () => fakeSession,
+      inject: {
+        cdpFactory: () => cdp,
+        buildSession: () => fakeSession,
+      },
     })
     expect(result).not.toBeNull()
     // The disconnect must not throw — the signal-handler path in
@@ -98,11 +104,13 @@ describe('bootstrapBrowserosBrowser', () => {
     const seenPorts: number[] = []
     const cdp = makeStubCdp()
     await bootstrapBrowserosBrowser({
-      cdpFactory: (port) => {
-        seenPorts.push(port)
-        return cdp
+      inject: {
+        cdpFactory: (port) => {
+          seenPorts.push(port)
+          return cdp
+        },
+        buildSession: () => fakeSession,
       },
-      buildSession: () => fakeSession,
     })
     expect(seenPorts).toHaveLength(1)
     expect(seenPorts[0]).toBeGreaterThan(0)


### PR DESCRIPTION
## Summary

The cockpit standalone (\`bun src/main.ts\` in \`apps/agent-mcp-interface\`) previously ran the route surface but never set the process-wide \`BrowserSession\`. Every MCP \`tools/call\` short-circuited with the structured \"browser session not connected\" wire shape. Production was unaffected because the merged runtime in \`@browseros/server\` called \`createCockpitRoutes\` with its live session; standalone had no equivalent hand-off.

This PR brings the same CDP attach \`apps/server\` does straight into the cockpit's boot path, so the standalone runtime can drive a real BrowserOS Chromium on its own.

## Changes

- \`src/lib/browser-bootstrap.ts\` (new): instantiates \`CdpBackend\`, dials, wraps in \`Browser\`, returns the \`BrowserSession\` plus a \`disconnect()\` helper. Soft-fails to \`null\` when the browser is not reachable; the cockpit keeps serving UI, profile CRUD, harness installs, and \`tools/list\`. \`exitOnReconnectFailure: false\` so a transient CDP drop degrades the session rather than killing the cockpit.
- \`src/main.ts\`: awaits the bootstrap right after \`Bun.serve\`, calls \`setBrowserSession\` on success, registers \`SIGINT\` / \`SIGTERM\` handlers that disconnect before \`process.exit\`.
- \`src/env.ts\` + \`src/shared/port.ts\`: new \`BROWSEROS_COCKPIT_CDP_PORT\` env var with a 49337 default. Lives in IANA's dynamic / private range (49152-65535) so it cannot collide with a registered service, and is not a round number to avoid a hand-rolled local script picking the same value.
- \`tests/lib/browser-bootstrap.test.ts\` (new): injects a stub \`CdpClient\` through \`BrowserBootstrapDeps\` and exercises connect-success, connect-fail, disconnect-swallows-errors, and the port-flow path. Four cases, zero sockets.

## Behavior matrix

| BrowserOS reachable at boot? | Result |
|---|---|
| Yes | Cockpit attaches, \`setBrowserSession\` runs, every \`tools/call\` dispatches against a real browser through \`executeTool\` |
| No | Cockpit logs a structured warning, keeps booting; \`tools/call\` continues with the existing \"session not connected\" error until restart |
| Transient CDP drop mid-session | \`CdpBackend\` retries with \`exitOnReconnectFailure: false\`; the cockpit process stays up |

## Port choice

Default \`49337\`. Inside IANA's dynamic range, not a round number, no known association with VoIP / IPMI / DLNA / common gateways or container forward ranges. The env override is the bridge until BrowserOS's browser shell defaults its DevTools port to the same value.

This is the port the BrowserOS Chromium exposes its DevTools on, not a port the cockpit itself opens. Today, set \`BROWSEROS_COCKPIT_CDP_PORT\` to whatever port BrowserOS is currently bound on.

## Verification

- \`bun run typecheck\` on the cockpit: clean.
- \`bun test\`: 101 / 101 pass (4 new + the prior 97).
- Local smoke (BrowserOS not running): cockpit boots, soft-fail warning fires, route surface stays healthy, SIGTERM cleans up.

## Out of scope (called out for the follow-up)

- Launching a BrowserOS Chromium from the cockpit. The cockpit is a CDP client; the browser is launched elsewhere.
- Coexisting with \`apps/server\` on the same CDP target. CDP supports multiple attachers but the cockpit assumes it owns the session for \`executeTool\`. Behavior of running both at once is whatever the underlying CDP negotiation produces; no promises.
- A discovery protocol for the port. \`apps/server\` already writes \`cdp_port\` into its server config; the cockpit deliberately does not read that file because it would re-couple the cockpit's bootstrap to \`apps/server\`'s lifecycle.
- BrowserOS-side default of port 49337. Cross-repo work; tracked separately. Until then, the env override is the contract.