### PR TITLE
feat: add eval and browser sdk run tools

### DIFF
--- a/packages/browseros-agent/apps/server/src/tools/browser/eval.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/eval.ts
@@ -1,0 +1,71 @@
+import { z } from 'zod'
+import { clampTimeout, defineTool, errorResult, textResult } from './framework'
+import { wrapUntrusted } from './trust-boundary'
+
+const DEFAULT_TIMEOUT_MS = 30_000
+const MAX_TIMEOUT_MS = 30_000
+
+const DESCRIPTION = `Evaluate JavaScript in a page context through CDP Runtime.evaluate. Use this for page-state reads or small DOM scripts that are awkward with read/grep. Return a value to read it back.`
+
+export const evalTool = defineTool({
+  name: 'eval',
+  description: DESCRIPTION,
+  input: z.object({
+    page: z.number().int().describe('Page id from `tabs`.'),
+    code: z
+      .string()
+      .describe(
+        'Async-capable JS body evaluated inside the page. Use `return` to read a value.',
+      ),
+    timeout: z
+      .number()
+      .optional()
+      .describe('Max evaluation time in ms (default 30000).'),
+  }),
+  annotations: { openWorldHint: true },
+  handler: async (args, ctx) => {
+    const { session } = await ctx.session.pages.getSession(args.page)
+    const timeout = clampTimeout(
+      args.timeout,
+      DEFAULT_TIMEOUT_MS,
+      MAX_TIMEOUT_MS,
+    )
+    const result = await session.Runtime.evaluate({
+      expression: wrapAsAsyncIife(args.code),
+      returnByValue: true,
+      awaitPromise: true,
+      timeout,
+      userGesture: true,
+    })
+
+    if (result.exceptionDetails) {
+      return errorResult(
+        `eval: ${
+          result.exceptionDetails.exception?.description ??
+          result.exceptionDetails.text
+        }`,
+      )
+    }
+
+    const value = result.result?.value ?? result.result?.description
+    const text = value === undefined ? 'undefined' : safeStringify(value)
+    const origin = ctx.session.pages.getInfo(args.page)?.url ?? 'unknown'
+    return textResult(wrapUntrusted(text, origin), {
+      page: args.page,
+      value,
+    })
+  },
+})
+
+function wrapAsAsyncIife(code: string): string {
+  return `(async () => {\n${code}\n})()`
+}
+
+function safeStringify(value: unknown): string {
+  if (typeof value === 'string') return value
+  try {
+    return JSON.stringify(value, null, 2) ?? String(value)
+  } catch {
+    return String(value)
+  }
+}

--- a/packages/browseros-agent/apps/server/src/tools/browser/registry.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/registry.ts
@@ -1,5 +1,6 @@
 import { act } from './act'
 import { diff } from './diff'
+import { evalTool } from './eval'
 import type { ToolDefinition } from './framework'
 import { grep } from './grep'
 import { navigate } from './navigate'
@@ -10,7 +11,6 @@ import { snapshot } from './snapshot'
 import { tabs } from './tabs'
 import { wait } from './wait'
 
-/** The complete browser tool surface, in a sensible discovery order. */
 export const BROWSER_TOOLS: readonly ToolDefinition[] = [
   tabs,
   navigate,
@@ -21,5 +21,6 @@ export const BROWSER_TOOLS: readonly ToolDefinition[] = [
   grep,
   screenshot,
   wait,
+  evalTool,
   run,
 ]

--- a/packages/browseros-agent/apps/server/src/tools/browser/run.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/run.ts
@@ -1,68 +1,140 @@
 import { z } from 'zod'
-import { clampTimeout, defineTool, errorResult, textResult } from './framework'
-import { wrapUntrusted } from './trust-boundary'
+import { defineTool, errorResult, textResult } from './framework'
 
 const DEFAULT_TIMEOUT_MS = 30_000
-const MAX_TIMEOUT_MS = 30_000
 
-const DESCRIPTION = `Run JavaScript in a page context through CDP Runtime.evaluate. Use this for page-state reads or small DOM scripts that are awkward with read/grep. Return a value to read it back.`
+const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor as new (
+  ...args: string[]
+) => (...injected: unknown[]) => Promise<unknown>
+
+const DESCRIPTION = `Run JavaScript against the \`browser\` SDK in the server runtime for multi-step flows and data extraction that would otherwise take many tool calls. \`console.log\` is captured; \`return\` a value to read it back; exceptions come back as a result, not a thrown error.
+
+Available as \`browser\`:
+  browser.pages.list() / newPage(url) / close(pageId) / getInfo(pageId)
+  browser.observe(pageId).snapshot()  -> { text, refs }
+  browser.observe(pageId).diff()      -> { text, added, removed, changed }
+  browser.observe(pageId).resolveRef(ref)
+  browser.input(pageId).click(ref) / fill(ref,value) / type(text) / press(key) / hover(ref) / selectOption(ref,value) / scroll(dir,amount,ref?)
+  browser.nav(pageId).goto(url) / back() / forward() / reload()
+  browser.cdp(method, params?, sessionId?)   // raw CDP escape hatch
+Refs (eN) come from a snapshot's text/refs.`
+
+interface RunOutcome {
+  ok: boolean
+  value: unknown
+  logs: string[]
+  error?: Error
+}
 
 export const run = defineTool({
   name: 'run',
   description: DESCRIPTION,
   input: z.object({
-    page: z.number().int().describe('Page id from `tabs`.'),
     code: z
       .string()
       .describe(
-        'Async-capable JS body evaluated inside the page. Use `return` to read a value.',
+        'Async-capable JS body. Use top-level await; `return` a value.',
       ),
     timeout: z
       .number()
       .optional()
-      .describe('Max evaluation time in ms (default 30000).'),
+      .describe('Max run time in ms (default 30000).'),
   }),
   annotations: { openWorldHint: true },
   handler: async (args, ctx) => {
-    const { session } = await ctx.session.pages.getSession(args.page)
-    const timeout = clampTimeout(
-      args.timeout,
-      DEFAULT_TIMEOUT_MS,
-      MAX_TIMEOUT_MS,
-    )
-    const result = await session.Runtime.evaluate({
-      expression: wrapAsAsyncIife(args.code),
-      returnByValue: true,
-      awaitPromise: true,
-      timeout,
-      userGesture: true,
-    })
-
-    if (result.exceptionDetails) {
+    let fn: (...injected: unknown[]) => Promise<unknown>
+    try {
+      fn = new AsyncFunction(
+        'browser',
+        'console',
+        `"use strict";\n${args.code}`,
+      )
+    } catch (err) {
       return errorResult(
-        `run: ${
-          result.exceptionDetails.exception?.description ??
-          result.exceptionDetails.text
-        }`,
+        `run: syntax error - ${err instanceof Error ? err.message : String(err)}`,
       )
     }
 
-    const value = result.result?.value ?? result.result?.description
-    const text = value === undefined ? 'undefined' : safeStringify(value)
-    const origin = ctx.session.pages.getInfo(args.page)?.url ?? 'unknown'
-    return textResult(wrapUntrusted(text, origin), {
-      page: args.page,
-      value,
-    })
+    const logs: string[] = []
+    const captured = makeConsole(logs)
+    const outcome = await execute(
+      fn,
+      ctx.session,
+      captured,
+      args.timeout ?? DEFAULT_TIMEOUT_MS,
+      logs,
+    )
+    return outcome.ok
+      ? textResult(format(outcome), { ok: true })
+      : { ...errorResult(format(outcome)), structuredContent: { ok: false } }
   },
 })
 
-function wrapAsAsyncIife(code: string): string {
-  return `(async () => {\n${code}\n})()`
+/** Runs injected agent code and converts script failures into tool results. */
+async function execute(
+  fn: (...injected: unknown[]) => Promise<unknown>,
+  browser: unknown,
+  console: Console,
+  timeoutMs: number,
+  logs: string[],
+): Promise<RunOutcome> {
+  let timer: ReturnType<typeof setTimeout> | undefined
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`run exceeded ${timeoutMs}ms`)),
+      timeoutMs,
+    )
+  })
+  try {
+    const value = await Promise.race([fn(browser, console), timeout])
+    return { ok: true, value, logs }
+  } catch (err) {
+    return {
+      ok: false,
+      value: undefined,
+      logs,
+      error: err instanceof Error ? err : new Error(String(err)),
+    }
+  } finally {
+    if (timer) clearTimeout(timer)
+  }
+}
+
+function makeConsole(logs: string[]): Console {
+  const sink =
+    (level: string) =>
+    (...parts: unknown[]) => {
+      logs.push(
+        `${level}${parts.map((part) => (typeof part === 'string' ? part : safeStringify(part))).join(' ')}`,
+      )
+    }
+  return {
+    log: sink(''),
+    info: sink(''),
+    warn: sink('warn: '),
+    error: sink('error: '),
+    debug: sink(''),
+  } as unknown as Console
+}
+
+function format(outcome: RunOutcome): string {
+  const sections: string[] = []
+  if (outcome.error) {
+    sections.push(`error: ${outcome.error.message}`)
+  } else {
+    sections.push('ok')
+    if (outcome.value !== undefined) {
+      sections.push(`return: ${safeStringify(outcome.value)}`)
+    }
+  }
+  if (outcome.logs.length > 0) {
+    sections.push(`logs:\n${outcome.logs.join('\n')}`)
+  }
+  return sections.join('\n')
 }
 
 function safeStringify(value: unknown): string {
-  if (typeof value === 'string') return value
+  if (value === undefined) return 'undefined'
   try {
     return JSON.stringify(value, null, 2) ?? String(value)
   } catch {

--- a/packages/browseros-agent/apps/server/tests/api/services/mcp/register-mcp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/mcp/register-mcp.test.ts
@@ -90,8 +90,8 @@ describe('registerTools', () => {
 
     expect(infoMessages).toHaveLength(2)
     expect(infoMessages).toEqual([
-      expect.stringContaining('Registered 10 browser tools'),
-      expect.stringContaining('Registered 10 browser tools'),
+      expect.stringContaining('Registered 11 browser tools'),
+      expect.stringContaining('Registered 11 browser tools'),
     ])
   })
 
@@ -119,7 +119,7 @@ describe('registerTools', () => {
     })
 
     expect([...fake.handlers.keys()]).toEqual(BROWSER_TOOLS.map((t) => t.name))
-    expect(fake.handlers.size).toBe(10)
+    expect(fake.handlers.size).toBe(11)
   })
 
   it('registers the legacy browser tools when the switch is disabled', () => {

--- a/packages/browseros-agent/apps/server/tests/tools/browser-boundary.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser-boundary.test.ts
@@ -7,6 +7,7 @@ import { BROWSER_TOOLS } from '../../src/tools/browser/registry'
 const compactBrowserToolFiles = [
   'act.ts',
   'diff.ts',
+  'eval.ts',
   'framework.ts',
   'grep.ts',
   'navigate.ts',

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -103,7 +103,7 @@ describe('registerBrowserTools', () => {
     registerBrowserTools(fake.server as never, session)
 
     expect([...fake.handlers.keys()]).toEqual(BROWSER_TOOLS.map((t) => t.name))
-    expect(fake.handlers.size).toBe(10)
+    expect(fake.handlers.size).toBe(11)
     expect(fake.configs.get('tabs')?.inputSchema).toBeDefined()
   })
 
@@ -160,7 +160,7 @@ describe('registerBrowserTools', () => {
     ])
   })
 
-  it('runs page-context JavaScript through the page session', async () => {
+  it('evaluates page-context JavaScript through the page session', async () => {
     const fake = createFakeServer()
     const evaluateCalls: Array<Record<string, unknown>> = []
     const session = {
@@ -175,13 +175,13 @@ describe('registerBrowserTools', () => {
             },
           },
         }),
-        getInfo: () => ({ url: 'https://example.com/run' }),
+        getInfo: () => ({ url: 'https://example.com/eval' }),
       },
     } as unknown as BrowserSession
 
     registerBrowserTools(fake.server as never, session)
 
-    const result = await fake.handlers.get('run')?.({
+    const result = await fake.handlers.get('eval')?.({
       page: 3,
       code: 'return document.title',
       timeout: 1234,
@@ -398,7 +398,7 @@ describe('registerBrowserTools', () => {
 
     registerBrowserTools(fake.server as never, session)
 
-    const result = await fake.handlers.get('run')?.({
+    const result = await fake.handlers.get('eval')?.({
       page: 3,
       code: 'return true',
       timeout: 120_000,

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -213,6 +213,131 @@ describe('registerBrowserTools', () => {
     )
   })
 
+  it('runs server-runtime JavaScript against the browser session', async () => {
+    const fake = createFakeServer()
+    const session = {
+      pages: {
+        list: async () => [
+          { pageId: 7, url: 'https://example.com', title: 'Example' },
+        ],
+      },
+    } as unknown as BrowserSession
+
+    registerBrowserTools(fake.server as never, session)
+
+    const result = await fake.handlers.get('run')?.({
+      code: `
+const pages = await browser.pages.list()
+console.log('pages', pages.length)
+console.warn({ pageId: pages[0].pageId })
+return { title: pages[0].title }
+`,
+    })
+
+    expect(result?.isError).toBeFalsy()
+    expect(result?.structuredContent).toEqual({ ok: true })
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('ok\nreturn:'),
+      }),
+    ])
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('"title": "Example"'),
+      }),
+    ])
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('logs:\npages 1\nwarn:'),
+      }),
+    ])
+  })
+
+  it('returns run syntax errors without invoking the browser session', async () => {
+    const fake = createFakeServer()
+    let listCalls = 0
+    const session = {
+      pages: {
+        list: async () => {
+          listCalls += 1
+          return []
+        },
+      },
+    } as unknown as BrowserSession
+
+    registerBrowserTools(fake.server as never, session)
+
+    const result = await fake.handlers.get('run')?.({
+      code: 'const = 1',
+    })
+
+    expect(result?.isError).toBe(true)
+    expect(result?.structuredContent).toBeUndefined()
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('run: syntax error'),
+      }),
+    ])
+    expect(listCalls).toBe(0)
+  })
+
+  it('returns run runtime errors with captured logs', async () => {
+    const fake = createFakeServer()
+    const session = { pages: {} } as unknown as BrowserSession
+
+    registerBrowserTools(fake.server as never, session)
+
+    const result = await fake.handlers.get('run')?.({
+      code: `
+console.log('before boom')
+throw new Error('boom')
+`,
+    })
+
+    expect(result?.isError).toBe(true)
+    expect(result?.structuredContent).toEqual({ ok: false })
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('error: boom'),
+      }),
+    ])
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('logs:\nbefore boom'),
+      }),
+    ])
+  })
+
+  it('returns run timeout errors', async () => {
+    const fake = createFakeServer()
+    const session = { pages: {} } as unknown as BrowserSession
+
+    registerBrowserTools(fake.server as never, session)
+
+    const result = await fake.handlers.get('run')?.({
+      code: `
+await new Promise((resolve) => setTimeout(resolve, 50))
+return 'late'
+`,
+      timeout: 1,
+    })
+
+    expect(result?.isError).toBe(true)
+    expect(result?.structuredContent).toEqual({ ok: false })
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('run exceeded 1ms'),
+      }),
+    ])
+  })
+
   it('returns a full snapshot when diff sees a URL change', async () => {
     const fake = createFakeServer()
     const session = {


### PR DESCRIPTION
## Summary
- Rename the page-context CDP JavaScript evaluator from `run` to `eval`.
- Add a new compact browser `run` tool for multi-step JavaScript against the BrowserSession SDK with captured console output.
- Update registration, boundary, and focused tool tests for the 11-tool compact surface.

## Design
The compact browser surface is split by execution context: `eval.ts` owns page-context `Runtime.evaluate`, while `run.ts` owns trusted server-runtime scripts with `browser` injected as the BrowserSession SDK.

## Test plan
- [x] `bun test apps/server/tests/tools/browser/register.test.ts apps/server/tests/tools/browser-boundary.test.ts apps/server/tests/api/services/mcp/register-mcp.test.ts`
- [x] `bun run lint && bun run typecheck && bun run test:main`
- [x] `bun run check`