### PR TITLE
feat: add compact windows tool

### DIFF
--- a/packages/browseros-agent/apps/server/src/agent/prompt.ts
+++ b/packages/browseros-agent/apps/server/src/agent/prompt.ts
@@ -126,10 +126,11 @@ function getCapabilities(
   let capabilities = `<capabilities>
 ## Your Capabilities
 
-### Browser Control (10 tools)
+### Browser Control (11 tools)
 You control a Chromium browser through a compact tool surface:
 
 - \`tabs\` → list pages, open background/hidden pages, close pages
+- \`windows\` → list, create, close, focus, show, and hide browser windows
 - \`navigate\` → go to URL, back, forward, reload; returns a fresh snapshot
 - \`snapshot\` → accessibility tree with refs like [ref=e12] for acting
 - \`diff\` → what changed since the last snapshot/diff

--- a/packages/browseros-agent/apps/server/src/browser/browser.ts
+++ b/packages/browseros-agent/apps/server/src/browser/browser.ts
@@ -11,6 +11,7 @@ import { fetchLegacyAxTreeWithFrames } from './core/observer/ax-tree'
 import type { PageInfo } from './core/pages'
 import { BrowserSession } from './core/session'
 import * as snapshot from './core/snapshot/legacy'
+import type { SetWindowVisibilityResult, WindowInfo } from './core/windows'
 import { type DomSearchResult, parseNodeAttributes } from './dom'
 import type { HistoryEntry } from './history'
 import * as history from './history'
@@ -18,34 +19,7 @@ import type { TabGroup } from './tab-groups'
 import * as tabGroups from './tab-groups'
 
 export type { PageInfo } from './core/pages'
-
-export interface WindowInfo {
-  windowId: number
-  windowType:
-    | 'normal'
-    | 'popup'
-    | 'app'
-    | 'devtools'
-    | 'app_popup'
-    | 'picture_in_picture'
-  bounds: {
-    left?: number
-    top?: number
-    width?: number
-    height?: number
-    windowState?: 'normal' | 'minimized' | 'maximized' | 'fullscreen'
-  }
-  isActive: boolean
-  isVisible: boolean
-  tabCount: number
-  activeTabId?: number
-}
-
-export interface SetWindowVisibilityResult {
-  window: WindowInfo
-  replaced: boolean
-  previousWindowId: number
-}
+export type { SetWindowVisibilityResult, WindowInfo } from './core/windows'
 
 export class Browser {
   private cdp: CdpBackend
@@ -655,26 +629,20 @@ export class Browser {
     )
   }
 
-  // --- Windows ---
-
   async listWindows(): Promise<WindowInfo[]> {
-    const result = await this.cdp.Browser.getWindows()
-    return result.windows as WindowInfo[]
+    return this.core.windows.list()
   }
 
   async createWindow(opts?: { hidden?: boolean }): Promise<WindowInfo> {
-    const result = await this.cdp.Browser.createWindow({
-      hidden: opts?.hidden ?? false,
-    })
-    return result.window as WindowInfo
+    return this.core.windows.create(opts)
   }
 
   async closeWindow(windowId: number): Promise<void> {
-    await this.cdp.Browser.closeWindow({ windowId })
+    await this.core.windows.close(windowId)
   }
 
   async activateWindow(windowId: number): Promise<void> {
-    await this.cdp.Browser.activateWindow({ windowId })
+    await this.core.windows.activate(windowId)
   }
 
   /**
@@ -685,16 +653,7 @@ export class Browser {
     windowId: number,
     opts: { visible: boolean; activate?: boolean },
   ): Promise<SetWindowVisibilityResult> {
-    const result = await this.cdp.Browser.setWindowVisibility({
-      windowId,
-      visible: opts.visible,
-      ...(opts.activate !== undefined && { activate: opts.activate }),
-    })
-    return {
-      window: result.window as WindowInfo,
-      replaced: result.replaced,
-      previousWindowId: result.previousWindowId,
-    }
+    return this.core.windows.setVisibility(windowId, opts)
   }
 
   async showPage(

--- a/packages/browseros-agent/apps/server/src/browser/core/session.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/session.ts
@@ -4,12 +4,14 @@ import { Navigation } from './navigation'
 import { FrameRegistry } from './observer/frames'
 import { Observer } from './observer/observer'
 import { PageManager, type PageManagerHooks } from './pages'
+import { WindowManager } from './windows'
 
 export interface BrowserSessionHooks extends PageManagerHooks {}
 
 /** Coordinates page registry, observation, input, navigation, and raw CDP access. */
 export class BrowserSession {
   readonly pages: PageManager
+  readonly windows: WindowManager
   private readonly frames: FrameRegistry
   private readonly observers = new Map<number, Observer>()
 
@@ -18,6 +20,7 @@ export class BrowserSession {
     hooks: BrowserSessionHooks = {},
   ) {
     this.frames = new FrameRegistry(connection)
+    this.windows = new WindowManager(connection)
     this.pages = new PageManager(connection, {
       ...hooks,
       onSessionAttached: async (session, pageId, sessionId) => {

--- a/packages/browseros-agent/apps/server/src/browser/core/windows.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/windows.ts
@@ -1,10 +1,7 @@
-import type {
-  WindowInfo,
-  WindowType,
-} from '@browseros/cdp-protocol/domains/browser'
+import type { WindowInfo } from '@browseros/cdp-protocol/domains/browser'
 import type { CdpConnection } from './connection'
 
-export type { WindowInfo, WindowType }
+export type { WindowInfo }
 
 export interface SetWindowVisibilityResult {
   window: WindowInfo

--- a/packages/browseros-agent/apps/server/src/browser/core/windows.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/windows.ts
@@ -1,0 +1,76 @@
+import type {
+  WindowInfo,
+  WindowType,
+} from '@browseros/cdp-protocol/domains/browser'
+import type { CdpConnection } from './connection'
+
+export type { WindowInfo, WindowType }
+
+export interface SetWindowVisibilityResult {
+  window: WindowInfo
+  replaced: boolean
+  previousWindowId: number
+  newWindowId: number
+}
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms))
+
+/** Wraps BrowserOS window CDP commands for browser-core callers and tools. */
+export class WindowManager {
+  constructor(private readonly cdp: CdpConnection) {}
+
+  async list(): Promise<WindowInfo[]> {
+    await this.ensureConnected()
+    const result = await this.cdp.Browser.getWindows()
+    return result.windows as WindowInfo[]
+  }
+
+  async create(opts?: { hidden?: boolean }): Promise<WindowInfo> {
+    await this.ensureConnected()
+    const result = await this.cdp.Browser.createWindow({
+      hidden: opts?.hidden ?? false,
+    })
+    return result.window as WindowInfo
+  }
+
+  async close(windowId: number): Promise<void> {
+    await this.ensureConnected()
+    await this.cdp.Browser.closeWindow({ windowId })
+  }
+
+  async activate(windowId: number): Promise<void> {
+    await this.ensureConnected()
+    await this.cdp.Browser.activateWindow({ windowId })
+  }
+
+  /** Changes visibility and returns the replacement window ID when BrowserOS swaps windows. */
+  async setVisibility(
+    windowId: number,
+    opts: { visible: boolean; activate?: boolean },
+  ): Promise<SetWindowVisibilityResult> {
+    await this.ensureConnected()
+    const result = await this.cdp.Browser.setWindowVisibility({
+      windowId,
+      visible: opts.visible,
+      ...(opts.activate !== undefined && { activate: opts.activate }),
+    })
+    const window = result.window as WindowInfo
+    return {
+      window,
+      replaced: result.replaced,
+      previousWindowId: result.previousWindowId,
+      newWindowId: window.windowId,
+    }
+  }
+
+  private async ensureConnected(): Promise<void> {
+    if (this.cdp.isConnected()) return
+
+    const deadline = Date.now() + 5000
+    while (!this.cdp.isConnected() && Date.now() < deadline) {
+      await delay(50)
+    }
+    if (!this.cdp.isConnected()) throw new Error('CDP not connected')
+  }
+}

--- a/packages/browseros-agent/apps/server/src/tools/browser/registry.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/registry.ts
@@ -10,6 +10,7 @@ import { screenshot } from './screenshot'
 import { snapshot } from './snapshot'
 import { tabs } from './tabs'
 import { wait } from './wait'
+import { windows } from './windows'
 
 export const BROWSER_TOOLS: readonly ToolDefinition[] = [
   tabs,
@@ -21,6 +22,7 @@ export const BROWSER_TOOLS: readonly ToolDefinition[] = [
   grep,
   screenshot,
   wait,
+  windows,
   evalTool,
   run,
 ]

--- a/packages/browseros-agent/apps/server/src/tools/browser/windows.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/windows.ts
@@ -1,0 +1,119 @@
+import { z } from 'zod'
+import type { WindowInfo } from '../../browser/core/windows'
+import { defineTool, errorResult, textResult } from './framework'
+
+const ACTIONS = [
+  'list',
+  'create',
+  'close',
+  'activate',
+  'set_visibility',
+] as const
+
+export const windows = defineTool({
+  name: 'windows',
+  description:
+    'Manage browser windows: list windows, create visible or hidden windows, close or activate a window, and show or hide windows.',
+  input: z.object({
+    action: z.enum(ACTIONS).default('list'),
+    windowId: z
+      .number()
+      .int()
+      .optional()
+      .describe('Window id for close, activate, and set_visibility.'),
+    hidden: z
+      .boolean()
+      .default(false)
+      .describe('Create a hidden window for action="create".'),
+    visible: z
+      .boolean()
+      .optional()
+      .describe('Target visibility for action="set_visibility".'),
+    activate: z
+      .boolean()
+      .optional()
+      .describe('Focus the window after making it visible.'),
+  }),
+  annotations: { openWorldHint: true },
+  handler: async (args, ctx) => {
+    switch (args.action) {
+      case 'list': {
+        const all = await ctx.session.windows.list()
+        return textResult(formatWindowList(all), {
+          action: 'list',
+          windows: all,
+          count: all.length,
+        })
+      }
+      case 'create': {
+        const window = await ctx.session.windows.create({ hidden: args.hidden })
+        const hiddenMarker = !window.isVisible ? ' (hidden)' : ''
+        return textResult(`created window ${window.windowId}${hiddenMarker}`, {
+          action: 'create',
+          window,
+        })
+      }
+      case 'close': {
+        if (args.windowId === undefined) {
+          return errorResult('windows close: windowId is required.')
+        }
+        await ctx.session.windows.close(args.windowId)
+        return textResult(`closed window ${args.windowId}`, {
+          action: 'close',
+          windowId: args.windowId,
+        })
+      }
+      case 'activate': {
+        if (args.windowId === undefined) {
+          return errorResult('windows activate: windowId is required.')
+        }
+        await ctx.session.windows.activate(args.windowId)
+        return textResult(`activated window ${args.windowId}`, {
+          action: 'activate',
+          windowId: args.windowId,
+        })
+      }
+      case 'set_visibility': {
+        if (args.windowId === undefined) {
+          return errorResult('windows set_visibility: windowId is required.')
+        }
+        if (args.visible === undefined) {
+          return errorResult('windows set_visibility: visible is required.')
+        }
+        const result = await ctx.session.windows.setVisibility(args.windowId, {
+          visible: args.visible,
+          activate: args.activate,
+        })
+        const state = result.window.isVisible ? 'visible' : 'hidden'
+        return textResult(
+          `set window ${result.previousWindowId} ${state}; new window id ${result.newWindowId}`,
+          {
+            action: 'set_visibility',
+            previousWindowId: result.previousWindowId,
+            newWindowId: result.newWindowId,
+            replaced: result.replaced,
+            window: result.window,
+          },
+        )
+      }
+      default:
+        return errorResult('windows: unsupported action.')
+    }
+  },
+})
+
+function formatWindowList(windows: WindowInfo[]): string {
+  if (windows.length === 0) return 'No windows found.'
+
+  const lines = [`Found ${windows.length} windows:`, '']
+  for (const window of windows) {
+    const markers: string[] = []
+    if (!window.isVisible) markers.push('HIDDEN')
+    if (window.isActive) markers.push('ACTIVE')
+    const suffix = markers.length > 0 ? ` [${markers.join(', ')}]` : ''
+    lines.push(
+      `Window ${window.windowId} (${window.windowType}, ${window.tabCount} tabs)${suffix}`,
+    )
+  }
+  return lines.join('\n')
+}

--- a/packages/browseros-agent/apps/server/tests/agent/prompt.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/prompt.test.ts
@@ -417,6 +417,7 @@ describe('capability coverage', () => {
     const prompt = buildRegular()
     const browserTools = [
       'tabs',
+      'windows',
       'navigate',
       'snapshot',
       'diff',

--- a/packages/browseros-agent/apps/server/tests/api/services/mcp/register-mcp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/mcp/register-mcp.test.ts
@@ -90,8 +90,8 @@ describe('registerTools', () => {
 
     expect(infoMessages).toHaveLength(2)
     expect(infoMessages).toEqual([
-      expect.stringContaining('Registered 11 browser tools'),
-      expect.stringContaining('Registered 11 browser tools'),
+      expect.stringContaining('Registered 12 browser tools'),
+      expect.stringContaining('Registered 12 browser tools'),
     ])
   })
 
@@ -119,7 +119,7 @@ describe('registerTools', () => {
     })
 
     expect([...fake.handlers.keys()]).toEqual(BROWSER_TOOLS.map((t) => t.name))
-    expect(fake.handlers.size).toBe(11)
+    expect(fake.handlers.size).toBe(12)
   })
 
   it('registers the legacy browser tools when the switch is disabled', () => {

--- a/packages/browseros-agent/apps/server/tests/browser/core/windows.test.ts
+++ b/packages/browseros-agent/apps/server/tests/browser/core/windows.test.ts
@@ -1,0 +1,132 @@
+import { describe, expect, it } from 'bun:test'
+import { Browser } from '../../../src/browser/browser'
+import type { CdpConnection } from '../../../src/browser/core/connection'
+import {
+  type WindowInfo,
+  WindowManager,
+} from '../../../src/browser/core/windows'
+
+function makeWindow(
+  windowId: number,
+  overrides: Partial<WindowInfo> = {},
+): WindowInfo {
+  return {
+    windowId,
+    windowType: 'normal',
+    bounds: {},
+    isActive: false,
+    isVisible: true,
+    tabCount: 1,
+    ...overrides,
+  }
+}
+
+function createConnection() {
+  const calls: Array<{ method: string; params?: unknown }> = []
+  const windows = [makeWindow(1, { isActive: true })]
+
+  const connection = {
+    Browser: {
+      getWindows: async () => {
+        calls.push({ method: 'getWindows' })
+        return { windows }
+      },
+      createWindow: async (params?: { hidden?: boolean }) => {
+        calls.push({ method: 'createWindow', params })
+        return {
+          window: makeWindow(2, { isVisible: params?.hidden !== true }),
+        }
+      },
+      closeWindow: async (params: { windowId: number }) => {
+        calls.push({ method: 'closeWindow', params })
+      },
+      activateWindow: async (params: { windowId: number }) => {
+        calls.push({ method: 'activateWindow', params })
+      },
+      setWindowVisibility: async (params: {
+        windowId: number
+        visible: boolean
+        activate?: boolean
+      }) => {
+        calls.push({ method: 'setWindowVisibility', params })
+        return {
+          previousWindowId: params.windowId,
+          replaced: true,
+          window: makeWindow(3, { isVisible: params.visible }),
+        }
+      },
+    },
+    Target: {
+      on: () => () => {},
+    },
+    isConnected: () => true,
+    connectionEpoch: () => 0,
+    session: () => ({}),
+  } as unknown as CdpConnection
+
+  return { connection, calls, windows }
+}
+
+describe('WindowManager', () => {
+  it('delegates window operations to the Browser CDP domain', async () => {
+    const { connection, calls, windows } = createConnection()
+    const manager = new WindowManager(connection)
+
+    await expect(manager.list()).resolves.toEqual(windows)
+    await expect(manager.create({ hidden: true })).resolves.toMatchObject({
+      windowId: 2,
+      isVisible: false,
+    })
+    await manager.close(7)
+    await manager.activate(8)
+    await expect(
+      manager.setVisibility(9, { visible: true, activate: false }),
+    ).resolves.toMatchObject({
+      previousWindowId: 9,
+      newWindowId: 3,
+      replaced: true,
+      window: { windowId: 3, isVisible: true },
+    })
+
+    expect(calls).toEqual([
+      { method: 'getWindows' },
+      { method: 'createWindow', params: { hidden: true } },
+      { method: 'closeWindow', params: { windowId: 7 } },
+      { method: 'activateWindow', params: { windowId: 8 } },
+      {
+        method: 'setWindowVisibility',
+        params: { windowId: 9, visible: true, activate: false },
+      },
+    ])
+  })
+})
+
+describe('Browser window facade', () => {
+  it('uses the browser-core window manager', async () => {
+    const { connection, calls } = createConnection()
+    const browser = new Browser(connection as never)
+
+    await browser.listWindows()
+    await browser.createWindow({ hidden: true })
+    await browser.closeWindow(4)
+    await browser.activateWindow(5)
+    await expect(
+      browser.setWindowVisibility(6, { visible: false }),
+    ).resolves.toMatchObject({
+      previousWindowId: 6,
+      newWindowId: 3,
+      window: { isVisible: false },
+    })
+
+    expect(calls).toEqual([
+      { method: 'getWindows' },
+      { method: 'createWindow', params: { hidden: true } },
+      { method: 'closeWindow', params: { windowId: 4 } },
+      { method: 'activateWindow', params: { windowId: 5 } },
+      {
+        method: 'setWindowVisibility',
+        params: { windowId: 6, visible: false },
+      },
+    ])
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/tools/browser-boundary.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser-boundary.test.ts
@@ -21,6 +21,7 @@ const compactBrowserToolFiles = [
   'tabs.ts',
   'trust-boundary.ts',
   'wait.ts',
+  'windows.ts',
 ]
 
 const legacyBrowserToolFiles = [
@@ -67,7 +68,7 @@ describe('browser tool boundary', () => {
         existsSync(join(toolsDir, 'legacy/browser', file)),
         `Expected legacy/browser/${file}`,
       )
-      if (file !== 'snapshot.ts') {
+      if (file !== 'snapshot.ts' && file !== 'windows.ts') {
         assert.ok(
           !existsSync(join(toolsDir, 'browser', file)),
           `Unexpected active legacy browser module ${file}`,

--- a/packages/browseros-agent/apps/server/tests/tools/browser-boundary.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser-boundary.test.ts
@@ -46,6 +46,11 @@ const legacyOnlyToolNames = [
   'take_snapshot',
   'group_tabs',
   'list_windows',
+  'create_window',
+  'create_hidden_window',
+  'close_window',
+  'activate_window',
+  'set_window_visibility',
 ]
 
 describe('browser tool boundary', () => {

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -103,8 +103,160 @@ describe('registerBrowserTools', () => {
     registerBrowserTools(fake.server as never, session)
 
     expect([...fake.handlers.keys()]).toEqual(BROWSER_TOOLS.map((t) => t.name))
-    expect(fake.handlers.size).toBe(11)
+    expect(fake.handlers.size).toBe(12)
     expect(fake.configs.get('tabs')?.inputSchema).toBeDefined()
+  })
+
+  it('manages windows through the compact windows tool', async () => {
+    const fake = createFakeServer()
+    const calls: Array<{ method: string; args?: unknown }> = []
+    const window = {
+      windowId: 7,
+      windowType: 'normal' as const,
+      bounds: {},
+      isActive: true,
+      isVisible: true,
+      tabCount: 2,
+    }
+    const hiddenWindow = {
+      ...window,
+      windowId: 8,
+      isActive: false,
+      isVisible: false,
+    }
+    const session = {
+      windows: {
+        list: async () => {
+          calls.push({ method: 'list' })
+          return [window]
+        },
+        create: async (args?: { hidden?: boolean }) => {
+          calls.push({ method: 'create', args })
+          return args?.hidden ? hiddenWindow : window
+        },
+        close: async (windowId: number) => {
+          calls.push({ method: 'close', args: windowId })
+        },
+        activate: async (windowId: number) => {
+          calls.push({ method: 'activate', args: windowId })
+        },
+        setVisibility: async (
+          windowId: number,
+          args: { visible: boolean; activate?: boolean },
+        ) => {
+          calls.push({ method: 'setVisibility', args: { windowId, ...args } })
+          return {
+            previousWindowId: windowId,
+            newWindowId: 9,
+            replaced: true,
+            window: { ...window, windowId: 9, isVisible: args.visible },
+          }
+        },
+      },
+      pages: {
+        list: async () => [],
+      },
+    } as unknown as BrowserSession
+
+    registerBrowserTools(fake.server as never, session)
+    const handler = fake.handlers.get('windows')
+
+    const list = await handler?.({ action: 'list' })
+    expect(list?.isError).toBeFalsy()
+    expect(list?.structuredContent).toEqual({
+      action: 'list',
+      windows: [window],
+      count: 1,
+    })
+    expect(list?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('Window 7 (normal, 2 tabs) [ACTIVE]'),
+      }),
+    ])
+
+    const create = await handler?.({ action: 'create', hidden: true })
+    expect(create?.structuredContent).toEqual({
+      action: 'create',
+      window: hiddenWindow,
+    })
+
+    const close = await handler?.({ action: 'close', windowId: 7 })
+    expect(close?.structuredContent).toEqual({ action: 'close', windowId: 7 })
+
+    const activate = await handler?.({ action: 'activate', windowId: 8 })
+    expect(activate?.structuredContent).toEqual({
+      action: 'activate',
+      windowId: 8,
+    })
+
+    const visibility = await handler?.({
+      action: 'set_visibility',
+      windowId: 8,
+      visible: true,
+      activate: false,
+    })
+    expect(visibility?.structuredContent).toEqual({
+      action: 'set_visibility',
+      previousWindowId: 8,
+      newWindowId: 9,
+      replaced: true,
+      window: { ...window, windowId: 9, isVisible: true },
+    })
+
+    expect(calls).toEqual([
+      { method: 'list' },
+      { method: 'create', args: { hidden: true } },
+      { method: 'close', args: 7 },
+      { method: 'activate', args: 8 },
+      {
+        method: 'setVisibility',
+        args: { windowId: 8, visible: true, activate: false },
+      },
+    ])
+  })
+
+  it('returns clear errors for invalid windows actions', async () => {
+    const fake = createFakeServer()
+    const session = {
+      windows: {},
+      pages: {
+        list: async () => [],
+      },
+    } as unknown as BrowserSession
+
+    registerBrowserTools(fake.server as never, session)
+    const handler = fake.handlers.get('windows')
+
+    const close = await handler?.({ action: 'close' })
+    expect(close?.isError).toBe(true)
+    expect(close?.content).toEqual([
+      expect.objectContaining({
+        text: 'windows close: windowId is required.',
+      }),
+    ])
+
+    const visibilityWindow = await handler?.({
+      action: 'set_visibility',
+      visible: true,
+    })
+    expect(visibilityWindow?.isError).toBe(true)
+    expect(visibilityWindow?.content).toEqual([
+      expect.objectContaining({
+        text: 'windows set_visibility: windowId is required.',
+      }),
+    ])
+
+    const visibilityState = await handler?.({
+      action: 'set_visibility',
+      windowId: 7,
+    })
+    expect(visibilityState?.isError).toBe(true)
+    expect(visibilityState?.content).toEqual([
+      expect.objectContaining({
+        text: 'windows set_visibility: visible is required.',
+      }),
+    ])
   })
 
   it('applies scoped defaults when opening a new tab', async () => {


### PR DESCRIPTION
## Summary
- add a browser-core WindowManager and expose it as BrowserSession.windows
- add one compact `windows` tool for list/create/close/activate/set_visibility
- update compact tool registration, prompt docs, and boundary tests to include `windows` while guarding legacy window names

## Design
The compact tool uses the existing action-dispatch pattern from `tabs`, while the actual BrowserOS window CDP calls live behind browser-core. The legacy Browser facade now delegates to the same manager so old tools keep working without duplicated window behavior.

## Test plan
- [x] `bun --env-file=apps/server/.env.development test apps/server/tests/browser/core/windows.test.ts`
- [x] `bun --env-file=apps/server/.env.development test apps/server/tests/tools/browser/register.test.ts`
- [x] `bun --env-file=apps/server/.env.development test apps/server/tests/api/services/mcp/register-mcp.test.ts apps/server/tests/tools/browser-boundary.test.ts apps/server/tests/agent/prompt.test.ts`
- [x] `bun run test:cleanup && bun run check`