### PR TITLE
feat: add diff post-action

### DIFF
--- a/packages/browseros-agent/apps/server/src/tools/browser/act.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/act.ts
@@ -6,7 +6,6 @@ import {
   type ToolResult,
   textResult,
 } from './framework'
-import { wrapUntrusted } from './trust-boundary'
 
 type InputApi = ReturnType<BrowserSession['input']>
 
@@ -57,32 +56,15 @@ export const act = defineTool({
     clickCount: z.number().int().optional(),
     clear: z.boolean().optional(),
   }),
-  handler: async (args, ctx) => {
+  handler: async (args, ctx, response) => {
     const input = ctx.session.input(args.page)
 
     const err = await runKind(args, input)
     if (err) return err
 
-    const diff = await ctx.session.observe(args.page).diff()
-    const origin =
-      diff.afterUrl ?? ctx.session.pages.getInfo(args.page)?.url ?? 'unknown'
-    const body = diff.urlChanged
-      ? `page URL changed; returning full current snapshot instead of a diff:\n${wrapUntrusted(diff.text || '(empty page)', origin)}`
-      : diff.changed
-        ? `page changed:\n${wrapUntrusted(diff.text, origin)}`
-        : 'no visible change'
-    const structured: Record<string, unknown> = {
-      kind: args.kind,
-      changed: diff.changed,
-    }
-    if (diff.urlChanged) {
-      Object.assign(structured, {
-        urlChanged: true,
-        beforeUrl: diff.beforeUrl,
-        afterUrl: diff.afterUrl,
-      })
-    }
-    return textResult(`ok (${args.kind}) · ${body}`, structured)
+    response.data({ kind: args.kind })
+    response.includeDiff(args.page, { includeStructured: true })
+    return textResult(`ok (${args.kind})`)
   },
 })
 

--- a/packages/browseros-agent/apps/server/src/tools/browser/diff-format.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/diff-format.ts
@@ -34,8 +34,11 @@ export function formatDiffResult(
   }
 
   if (wordCount > MAX_INLINE_DIFF_WORDS) {
+    const text = diff.urlChanged
+      ? `URL changed; full current snapshot is ${wordCount} words, over the ${MAX_INLINE_DIFF_WORDS}-word inline limit. Run snapshot on page ${page} for full details.`
+      : `Diff is ${wordCount} words, over the ${MAX_INLINE_DIFF_WORDS}-word inline limit. Run snapshot on page ${page} for full details.`
     return {
-      text: `Diff is ${wordCount} words, over the ${MAX_INLINE_DIFF_WORDS}-word inline limit. Run snapshot on page ${page} for full details.`,
+      text,
       structured: {
         ...structured,
         truncated: true,

--- a/packages/browseros-agent/apps/server/src/tools/browser/diff-format.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/diff-format.ts
@@ -1,0 +1,58 @@
+import type { SnapshotDiff } from '../../browser/core/snapshot/diff'
+import { wrapUntrusted } from './trust-boundary'
+
+const MAX_INLINE_DIFF_WORDS = 2_000
+
+export interface FormattedDiff {
+  text: string
+  structured?: Record<string, unknown>
+}
+
+function countWords(text: string): number {
+  const trimmed = text.trim()
+  return trimmed ? trimmed.split(/\s+/).length : 0
+}
+
+/** Formats observer diffs for direct tools and automatic post-action readback. */
+export function formatDiffResult(
+  diff: SnapshotDiff,
+  origin: string,
+  page: number,
+): FormattedDiff {
+  if (!diff.changed) return { text: 'no change since last snapshot' }
+
+  const diffText = diff.text || '(empty page)'
+  const wordCount = countWords(diffText)
+  const structured = {
+    added: diff.added,
+    removed: diff.removed,
+    ...(diff.urlChanged && {
+      urlChanged: true,
+      beforeUrl: diff.beforeUrl,
+      afterUrl: diff.afterUrl,
+    }),
+  }
+
+  if (wordCount > MAX_INLINE_DIFF_WORDS) {
+    return {
+      text: `Diff is ${wordCount} words, over the ${MAX_INLINE_DIFF_WORDS}-word inline limit. Run snapshot on page ${page} for full details.`,
+      structured: {
+        ...structured,
+        truncated: true,
+        wordCount,
+      },
+    }
+  }
+
+  if (diff.urlChanged) {
+    return {
+      text: `URL changed; returning full current snapshot instead of a diff:\n${wrapUntrusted(diffText, origin)}`,
+      structured,
+    }
+  }
+
+  return {
+    text: wrapUntrusted(diff.text, origin),
+    structured,
+  }
+}

--- a/packages/browseros-agent/apps/server/src/tools/browser/diff.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/diff.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod'
+import { formatDiffResult } from './diff-format'
 import { defineTool, textResult } from './framework'
-import { wrapUntrusted } from './trust-boundary'
 
 export const diff = defineTool({
   name: 'diff',
@@ -10,24 +10,9 @@ export const diff = defineTool({
   annotations: { readOnlyHint: true },
   handler: async (args, ctx) => {
     const d = await ctx.session.observe(args.page).diff()
-    if (!d.changed) return textResult('no change since last snapshot')
     const origin =
       d.afterUrl ?? ctx.session.pages.getInfo(args.page)?.url ?? 'unknown'
-    if (d.urlChanged) {
-      return textResult(
-        `URL changed; returning full current snapshot instead of a diff:\n${wrapUntrusted(d.text || '(empty page)', origin)}`,
-        {
-          added: d.added,
-          removed: d.removed,
-          urlChanged: true,
-          beforeUrl: d.beforeUrl,
-          afterUrl: d.afterUrl,
-        },
-      )
-    }
-    return textResult(wrapUntrusted(d.text, origin), {
-      added: d.added,
-      removed: d.removed,
-    })
+    const formatted = formatDiffResult(d, origin, args.page)
+    return textResult(formatted.text, formatted.structured)
   },
 })

--- a/packages/browseros-agent/apps/server/src/tools/response.ts
+++ b/packages/browseros-agent/apps/server/src/tools/response.ts
@@ -1,6 +1,7 @@
 import { TIMEOUTS } from '@browseros/shared/constants/timeouts'
 import type { Browser } from '../browser/browser'
 import type { BrowserSession } from '../browser/core/session'
+import { formatDiffResult } from './browser/diff-format'
 import { wrapUntrusted } from './browser/trust-boundary'
 
 export type ContentItem =
@@ -10,6 +11,7 @@ export type ContentItem =
 type PostAction =
   | { type: 'snapshot'; page: number }
   | { type: 'screenshot'; page: number }
+  | { type: 'diff'; page: number; includeStructured?: boolean }
   | { type: 'pages' }
 
 export interface ToolResultMetadata {
@@ -86,6 +88,17 @@ export class ToolResponse {
     this.postActions.push({ type: 'screenshot', page })
   }
 
+  includeDiff(
+    page: number,
+    options: { includeStructured?: boolean } = {},
+  ): void {
+    this.postActions.push({
+      type: 'diff',
+      page,
+      includeStructured: options.includeStructured,
+    })
+  }
+
   includePages(): void {
     this.postActions.push({ type: 'pages' })
   }
@@ -109,6 +122,8 @@ export class ToolResponse {
         this.image(result.data, result.mimeType)
         return
       }
+      case 'diff':
+        return
       case 'pages': {
         const pages = await browser.listPages()
         if (pages.length === 0) {
@@ -148,6 +163,24 @@ export class ToolResponse {
         })
         this.text(`[Page ${action.page} screenshot]`)
         this.image(result.data, 'image/png')
+        return
+      }
+      case 'diff': {
+        const d = await session.observe(action.page).diff()
+        const origin =
+          d.afterUrl ?? session.pages.getInfo(action.page)?.url ?? 'unknown'
+        const formatted = formatDiffResult(d, origin, action.page)
+        this.text(`[Page ${action.page} diff]\n${formatted.text}`)
+        if (action.includeStructured) {
+          this.data({
+            changed: d.changed,
+            ...(d.urlChanged && {
+              urlChanged: true,
+              beforeUrl: d.beforeUrl,
+              afterUrl: d.afterUrl,
+            }),
+          })
+        }
         return
       }
       case 'pages': {

--- a/packages/browseros-agent/apps/server/src/tools/response.ts
+++ b/packages/browseros-agent/apps/server/src/tools/response.ts
@@ -1,6 +1,7 @@
 import { TIMEOUTS } from '@browseros/shared/constants/timeouts'
 import type { Browser } from '../browser/browser'
 import type { BrowserSession } from '../browser/core/session'
+import type { SnapshotDiff } from '../browser/core/snapshot/diff'
 import { formatDiffResult } from './browser/diff-format'
 import { wrapUntrusted } from './browser/trust-boundary'
 
@@ -11,8 +12,14 @@ export type ContentItem =
 type PostAction =
   | { type: 'snapshot'; page: number }
   | { type: 'screenshot'; page: number }
-  | { type: 'diff'; page: number; includeStructured?: boolean }
+  | DiffPostAction
   | { type: 'pages' }
+
+type DiffPostAction = {
+  type: 'diff'
+  page: number
+  includeStructured?: boolean
+}
 
 export interface ToolResultMetadata {
   tabId?: number
@@ -122,8 +129,13 @@ export class ToolResponse {
         this.image(result.data, result.mimeType)
         return
       }
-      case 'diff':
+      case 'diff': {
+        const d = await browser.session.observe(action.page).diff()
+        const origin =
+          d.afterUrl ?? browser.getPageInfo(action.page)?.url ?? 'unknown'
+        this.appendDiffPostAction(action, d, origin)
         return
+      }
       case 'pages': {
         const pages = await browser.listPages()
         if (pages.length === 0) {
@@ -169,18 +181,7 @@ export class ToolResponse {
         const d = await session.observe(action.page).diff()
         const origin =
           d.afterUrl ?? session.pages.getInfo(action.page)?.url ?? 'unknown'
-        const formatted = formatDiffResult(d, origin, action.page)
-        this.text(`[Page ${action.page} diff]\n${formatted.text}`)
-        if (action.includeStructured) {
-          this.data({
-            changed: d.changed,
-            ...(d.urlChanged && {
-              urlChanged: true,
-              beforeUrl: d.beforeUrl,
-              afterUrl: d.afterUrl,
-            }),
-          })
-        }
+        this.appendDiffPostAction(action, d, origin)
         return
       }
       case 'pages': {
@@ -196,6 +197,25 @@ export class ToolResponse {
         }
         return
       }
+    }
+  }
+
+  private appendDiffPostAction(
+    action: DiffPostAction,
+    diff: SnapshotDiff,
+    origin: string,
+  ): void {
+    const formatted = formatDiffResult(diff, origin, action.page)
+    this.text(`[Page ${action.page} diff]\n${formatted.text}`)
+    if (action.includeStructured) {
+      this.data({
+        changed: diff.changed,
+        ...(diff.urlChanged && {
+          urlChanged: true,
+          beforeUrl: diff.beforeUrl,
+          afterUrl: diff.afterUrl,
+        }),
+      })
     }
   }
 

--- a/packages/browseros-agent/apps/server/tests/tools/browser/framework.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/framework.test.ts
@@ -93,6 +93,91 @@ describe('browser tool framework post-actions', () => {
     expect(text).toContain('[END_UNTRUSTED_PAGE_CONTENT')
   })
 
+  it('runs diff post-actions through ToolResponse', async () => {
+    const events: string[] = []
+    const postActionTool = defineTool({
+      name: 'diff_post_action_test',
+      description: 'Test diff post-action execution.',
+      input: z.object({ page: z.number().int() }),
+      handler: async (args, _ctx, response) => {
+        events.push('handler')
+        response.text('handler output')
+        response.includeDiff(args.page)
+      },
+    })
+    const session = {
+      observe: (page: number) => ({
+        diff: async () => {
+          events.push(`diff:${page}`)
+          return {
+            changed: true,
+            text: '+   button "Saved" [ref=e1]\n1 added, 0 removed',
+            added: 1,
+            removed: 0,
+            afterUrl: 'https://example.com/current',
+          }
+        },
+      }),
+      pages: {
+        getInfo: () => ({ url: 'https://example.com/stale' }),
+        getTabId: () => undefined,
+      },
+    } as unknown as BrowserSession
+
+    const result = await executeTool(postActionTool, { page: 3 }, { session })
+    const text = textOf(result)
+
+    expect(events).toEqual(['handler', 'diff:3'])
+    expect(result.isError).toBeFalsy()
+    expect(text.indexOf('handler output')).toBeLessThan(
+      text.indexOf('--- Additional context'),
+    )
+    expect(text).toContain('[Page 3 diff]')
+    expect(text).toContain('origin=https://example.com/current')
+    expect(text).toContain('[UNTRUSTED_PAGE_CONTENT')
+    expect(text).toContain('+   button "Saved" [ref=e1]')
+    expect(text).not.toContain('origin=https://example.com/stale')
+  })
+
+  it('caps large diff post-actions with snapshot guidance', async () => {
+    const largeDiff = Array.from({ length: 2001 }, (_, i) => `word-${i}`).join(
+      ' ',
+    )
+    const postActionTool = defineTool({
+      name: 'large_diff_post_action_test',
+      description: 'Test large diff post-action execution.',
+      input: z.object({ page: z.number().int() }),
+      handler: async (args, _ctx, response) => {
+        response.includeDiff(args.page)
+      },
+    })
+    const session = {
+      observe: () => ({
+        diff: async () => ({
+          changed: true,
+          text: largeDiff,
+          added: 2001,
+          removed: 0,
+          afterUrl: 'https://example.com/large',
+        }),
+      }),
+      pages: {
+        getInfo: () => ({ url: 'https://example.com/large' }),
+        getTabId: () => undefined,
+      },
+    } as unknown as BrowserSession
+
+    const result = await executeTool(postActionTool, { page: 4 }, { session })
+    const text = textOf(result)
+
+    expect(result.isError).toBeFalsy()
+    expect(text).toContain('[Page 4 diff]')
+    expect(text).toContain('Diff is 2001 words')
+    expect(text).toContain('Run snapshot on page 4 for full details')
+    expect(text).not.toContain('word-2000')
+    expect(text).not.toContain('[UNTRUSTED_PAGE_CONTENT')
+  })
+
   it('keeps compact error results from running undeclared post-actions', async () => {
     const errorTool = defineTool({
       name: 'error_test',

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -434,6 +434,59 @@ return 'late'
     ])
   })
 
+  it('caps large direct diffs with snapshot guidance', async () => {
+    const fake = createFakeServer()
+    const largeDiff = Array.from({ length: 2001 }, (_, i) => `word-${i}`).join(
+      ' ',
+    )
+    const session = {
+      observe: () => ({
+        diff: async () => ({
+          changed: true,
+          text: largeDiff,
+          added: 2001,
+          removed: 0,
+          afterUrl: 'https://example.com/large',
+        }),
+      }),
+      pages: {
+        getInfo: () => ({ url: 'https://example.com/large' }),
+      },
+    } as unknown as BrowserSession
+
+    registerBrowserTools(fake.server as never, session)
+
+    const result = await fake.handlers.get('diff')?.({ page: 1 })
+
+    expect(result?.isError).toBeFalsy()
+    expect(result?.structuredContent).toEqual({
+      added: 2001,
+      removed: 0,
+      truncated: true,
+      wordCount: 2001,
+    })
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining('Diff is 2001 words'),
+      }),
+    ])
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.stringContaining(
+          'Run snapshot on page 1 for full details',
+        ),
+      }),
+    ])
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: expect.not.stringContaining('word-2000'),
+      }),
+    ])
+  })
+
   it('returns a full snapshot when act readback sees a URL change', async () => {
     const fake = createFakeServer()
     const calls: string[] = []

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -526,33 +526,93 @@ return 'late'
       beforeUrl: 'https://example.com/start',
       afterUrl: 'https://example.com/destination',
     })
-    expect(result?.content).toEqual([
-      expect.objectContaining({
-        type: 'text',
-        text: expect.stringContaining('page URL changed;'),
-      }),
-    ])
-    expect(result?.content).toEqual([
-      expect.objectContaining({
-        type: 'text',
-        text: expect.stringContaining(
-          'returning full current snapshot instead of a diff',
-        ),
-      }),
-    ])
-    expect(result?.content).toEqual([
-      expect.objectContaining({
-        type: 'text',
-        text: expect.stringContaining('[UNTRUSTED_PAGE_CONTENT'),
-      }),
-    ])
-    expect(result?.content).toEqual([
-      expect.objectContaining({
-        type: 'text',
-        text: expect.stringContaining('- heading "Destination"'),
-      }),
-    ])
+    expect(result?.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining('ok (click)'),
+        }),
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining('[Page 1 diff]'),
+        }),
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining('URL changed;'),
+        }),
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining(
+            'returning full current snapshot instead of a diff',
+          ),
+        }),
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining('[UNTRUSTED_PAGE_CONTENT'),
+        }),
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining('- heading "Destination"'),
+        }),
+      ]),
+    )
     expect(calls).toEqual(['click'])
+  })
+
+  it('appends diff output after successful act mutations', async () => {
+    const fake = createFakeServer()
+    const calls: string[] = []
+    const session = {
+      input: () => ({
+        click: async () => calls.push('click'),
+      }),
+      observe: () => ({
+        diff: async () => {
+          calls.push('diff')
+          return {
+            changed: true,
+            text: '+   button "Saved" [ref=e1]\n1 added, 0 removed',
+            added: 1,
+            removed: 0,
+            afterUrl: 'https://example.com/current',
+          }
+        },
+      }),
+      pages: {
+        getInfo: () => ({ url: 'https://example.com/current' }),
+      },
+    } as unknown as BrowserSession
+
+    registerBrowserTools(fake.server as never, session)
+
+    const result = await fake.handlers.get('act')?.({
+      page: 1,
+      kind: 'click',
+      ref: 'e1',
+    })
+
+    expect(result?.isError).toBeFalsy()
+    expect(result?.structuredContent).toEqual({
+      kind: 'click',
+      changed: true,
+    })
+    expect(result?.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining('ok (click)'),
+        }),
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining('[Page 1 diff]'),
+        }),
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining('+   button "Saved" [ref=e1]'),
+        }),
+      ]),
+    )
+    expect(calls).toEqual(['click', 'diff'])
   })
 
   it('caps page-context JavaScript timeouts', async () => {

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -559,6 +559,76 @@ return 'late'
     expect(calls).toEqual(['click'])
   })
 
+  it('caps large URL-change act readbacks with URL guidance', async () => {
+    const fake = createFakeServer()
+    const largeSnapshot = Array.from(
+      { length: 2001 },
+      (_, i) => `destination-${i}`,
+    ).join(' ')
+    const session = {
+      input: () => ({
+        click: async () => undefined,
+      }),
+      observe: () => ({
+        diff: async () => ({
+          changed: true,
+          text: largeSnapshot,
+          added: 0,
+          removed: 0,
+          urlChanged: true,
+          beforeUrl: 'https://example.com/start',
+          afterUrl: 'https://example.com/destination',
+        }),
+      }),
+      pages: {
+        getInfo: () => ({ url: 'https://example.com/destination' }),
+      },
+    } as unknown as BrowserSession
+
+    registerBrowserTools(fake.server as never, session)
+
+    const result = await fake.handlers.get('act')?.({
+      page: 1,
+      kind: 'click',
+      ref: 'e1',
+    })
+
+    expect(result?.isError).toBeFalsy()
+    expect(result?.structuredContent).toEqual({
+      kind: 'click',
+      changed: true,
+      urlChanged: true,
+      beforeUrl: 'https://example.com/start',
+      afterUrl: 'https://example.com/destination',
+    })
+    expect(result?.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining('URL changed'),
+        }),
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining('full current snapshot is 2001 words'),
+        }),
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining(
+            'Run snapshot on page 1 for full details',
+          ),
+        }),
+      ]),
+    )
+    expect(result?.content).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'text',
+          text: expect.not.stringContaining('destination-2000'),
+        }),
+      ]),
+    )
+  })
+
   it('appends diff output after successful act mutations', async () => {
     const fake = createFakeServer()
     const calls: string[] = []

--- a/packages/browseros-agent/apps/server/tests/tools/response.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/response.test.ts
@@ -73,4 +73,34 @@ describe('ToolResponse', () => {
     assert.ok(text.includes('[Page 1 snapshot]'))
     assert.ok(text.includes('[42] button "Submit"'))
   })
+
+  it('includes diff output when legacy build receives a diff post-action', async () => {
+    const response = new ToolResponse({ postActionTimeoutMs: 200 })
+    response.text('ok')
+    response.includeDiff(1)
+
+    const browser = {
+      session: {
+        observe: () => ({
+          diff: async () => ({
+            changed: true,
+            text: '+   button "Saved" [ref=e1]\n1 added, 0 removed',
+            added: 1,
+            removed: 0,
+            afterUrl: 'https://example.com/current',
+          }),
+        }),
+      },
+      getPageInfo: () => ({ url: 'https://example.com/stale' }),
+    } as unknown as Browser
+
+    const result = await response.build(browser)
+    const text = textOf(result)
+
+    assert.ok(text.includes('ok'))
+    assert.ok(text.includes('[Page 1 diff]'))
+    assert.ok(text.includes('origin=https://example.com/current'))
+    assert.ok(text.includes('+   button "Saved" [ref=e1]'))
+    assert.ok(!text.includes('origin=https://example.com/stale'))
+  })
 })


### PR DESCRIPTION
## Summary
- Add a reusable diff post-action for `ToolResponse`, shared by direct `diff` output and automatic post-action readback.
- Move successful `act` readback onto the post-action path while preserving structured action metadata and validation-error behavior.
- Cap diff output at 2000 words, including URL-change snapshots, with guidance to run `snapshot` for full details.

## Design
The implementation introduces a shared diff formatter used by the direct `diff` tool and `ToolResponse.includeDiff()`. Session and legacy browser response builds both route diff post-actions through the same formatter, while `act` now performs the input mutation and queues diff context afterward.

## Test plan
- [x] `bun test apps/server/tests/tools/browser/framework.test.ts apps/server/tests/tools/browser/register.test.ts`
- [x] `bun test apps/server/tests/tools/response.test.ts apps/server/tests/tools/browser/register.test.ts`
- [x] `bun run check`

Note: `bun run check` exits 0; Fallow still prints two existing unused-code reports unrelated to this change.