### PR TITLE
fix: preserve Windows bundled Bun launcher paths

### DIFF
--- a/packages/browseros-agent/apps/server/src/lib/agents/host-acp/launcher.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/host-acp/launcher.ts
@@ -56,15 +56,15 @@ export function resolveAcpSpawnCommand(
     platform: input.platform,
   })
   if (bunPath) {
-    // `bun x <pkg>@<range>` mirrors `npx -y <pkg>@<range>`. Quote the
-    // bun path because the BrowserOS resources directory can include
-    // spaces (on macOS the resources sit inside the .app bundle which
-    // can include "Application Support" or similar). acpx's splitArgv
-    // honours both single and double quotes.
     return {
-      command: `"${bunPath}" x ${config.acpPackageSpec}`,
+      command: `${quoteAcpCommandToken(bunPath)} x ${config.acpPackageSpec}`,
       source: 'bundled-bun',
     }
   }
   return { command: config.acpCommand, source: 'host-npx-fallback' }
+}
+
+/** Quotes a token for acpx command splitting while preserving Windows backslashes. */
+function quoteAcpCommandToken(value: string): string {
+  return `'${value.replace(/'/g, "'\\''")}'`
 }

--- a/packages/browseros-agent/apps/server/tests/lib/agents/host-acp/launcher.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/host-acp/launcher.test.ts
@@ -128,7 +128,7 @@ describe('resolveAcpSpawnCommand', () => {
 
   it('quotes the bundled bun path so paths with spaces survive', () => {
     const bunWithSpaces =
-      '/Applications/BrowserOS.app/Contents/bin/third_party/bun'
+      '/Applications/BrowserOS App/Contents/bin/third party/bun'
     const out = resolveAcpSpawnCommand({
       agentType: 'claude',
       resourcesDir: '/Applications/BrowserOS.app/Contents/Resources',
@@ -137,6 +137,10 @@ describe('resolveAcpSpawnCommand', () => {
     expect(out?.command).toBe(
       `'${bunWithSpaces}' x ${HOST_ACP_ADAPTER_CONFIG.claude.acpPackageSpec}`,
     )
+    expect(splitCommandLikeAcpx(out?.command ?? '')).toEqual({
+      command: bunWithSpaces,
+      args: ['x', HOST_ACP_ADAPTER_CONFIG.claude.acpPackageSpec],
+    })
   })
 
   it('preserves Windows bundled bun path separators through acpx command splitting', () => {

--- a/packages/browseros-agent/apps/server/tests/lib/agents/host-acp/launcher.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/host-acp/launcher.test.ts
@@ -8,12 +8,60 @@ import { HOST_ACP_ADAPTER_CONFIG } from '../../../../src/lib/agents/host-acp/con
 import { resolveAcpSpawnCommand } from '../../../../src/lib/agents/host-acp/launcher'
 
 const FAKE_BUN_PATH = '/Volumes/BrowserOS/bin/third_party/bun'
+const WINDOWS_BUN_PATH =
+  'C:\\Users\\shadowfax\\AppData\\Local\\BrowserOS\\Application\\148.0.7947.97\\BrowserOSServer\\default\\resources\\bin\\third_party\\bun.exe'
 
 const stubBunPresent: typeof import('../../../../src/lib/agents/host-acp/bundled-bun').resolveBundledBun =
   () => FAKE_BUN_PATH
 
 const stubBunMissing: typeof import('../../../../src/lib/agents/host-acp/bundled-bun').resolveBundledBun =
   () => null
+
+function splitCommandLikeAcpx(value: string): {
+  command: string
+  args: string[]
+} {
+  const parts: string[] = []
+  let current = ''
+  let quote: string | null = null
+  let escaping = false
+
+  for (const ch of value) {
+    if (escaping) {
+      current += ch
+      escaping = false
+      continue
+    }
+    if (ch === '\\' && quote !== "'") {
+      escaping = true
+      continue
+    }
+    if (quote) {
+      if (ch === quote) {
+        quote = null
+      } else {
+        current += ch
+      }
+      continue
+    }
+    if (ch === "'" || ch === '"') {
+      quote = ch
+      continue
+    }
+    if (/\s/.test(ch)) {
+      if (current.length > 0) {
+        parts.push(current)
+        current = ''
+      }
+      continue
+    }
+    current += ch
+  }
+
+  if (escaping) current += '\\'
+  if (current.length > 0) parts.push(current)
+  return { command: parts[0] ?? '', args: parts.slice(1) }
+}
 
 describe('resolveAcpSpawnCommand', () => {
   it('returns the bundled-bun launcher for claude when the binary exists', () => {
@@ -25,7 +73,7 @@ describe('resolveAcpSpawnCommand', () => {
     expect(out).not.toBeNull()
     expect(out?.source).toBe('bundled-bun')
     expect(out?.command).toBe(
-      `"${FAKE_BUN_PATH}" x ${HOST_ACP_ADAPTER_CONFIG.claude.acpPackageSpec}`,
+      `'${FAKE_BUN_PATH}' x ${HOST_ACP_ADAPTER_CONFIG.claude.acpPackageSpec}`,
     )
   })
 
@@ -37,7 +85,7 @@ describe('resolveAcpSpawnCommand', () => {
     })
     expect(out?.source).toBe('bundled-bun')
     expect(out?.command).toBe(
-      `"${FAKE_BUN_PATH}" x ${HOST_ACP_ADAPTER_CONFIG.codex.acpPackageSpec}`,
+      `'${FAKE_BUN_PATH}' x ${HOST_ACP_ADAPTER_CONFIG.codex.acpPackageSpec}`,
     )
   })
 
@@ -78,7 +126,7 @@ describe('resolveAcpSpawnCommand', () => {
     expect(out).toBeNull()
   })
 
-  it('double-quotes the bundled bun path so paths with spaces survive', () => {
+  it('quotes the bundled bun path so paths with spaces survive', () => {
     const bunWithSpaces =
       '/Applications/BrowserOS.app/Contents/bin/third_party/bun'
     const out = resolveAcpSpawnCommand({
@@ -87,7 +135,21 @@ describe('resolveAcpSpawnCommand', () => {
       resolveBundledBun: () => bunWithSpaces,
     })
     expect(out?.command).toBe(
-      `"${bunWithSpaces}" x ${HOST_ACP_ADAPTER_CONFIG.claude.acpPackageSpec}`,
+      `'${bunWithSpaces}' x ${HOST_ACP_ADAPTER_CONFIG.claude.acpPackageSpec}`,
+    )
+  })
+
+  it('preserves Windows bundled bun path separators through acpx command splitting', () => {
+    const out = resolveAcpSpawnCommand({
+      agentType: 'claude',
+      resourcesDir: 'C:\\fake\\resources',
+      platform: 'win32',
+      resolveBundledBun: () => WINDOWS_BUN_PATH,
+    })
+
+    expect(out?.source).toBe('bundled-bun')
+    expect(splitCommandLikeAcpx(out?.command ?? '').command).toBe(
+      WINDOWS_BUN_PATH,
     )
   })
 })


### PR DESCRIPTION
## Summary
- Quote bundled Bun ACP launcher command tokens with acpx-safe single quotes so Windows backslashes survive command splitting.
- Add launcher coverage for Windows `C:\...\bun.exe` paths and bundled paths containing spaces.
- Keep resource packaging and custom ACP commands unchanged.

## Design
The failure was at the ACP command-string boundary: acpx treats backslashes as escapes outside single quotes, so a double-quoted Windows path could become `C:Users...`. The launcher now quotes the Bun executable token in the form acpx preserves before spawning.

## Test plan
- [x] `bun test apps/server/tests/lib/agents/host-acp/launcher.test.ts`
- [x] `bun run check`
- [x] local adversarial review, 2 rounds; first finding fixed, second clean