### PR TITLE
feat: align compact browser file tools

### DIFF
--- a/packages/browseros-agent/apps/server/src/browser/core/input/input.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/input/input.ts
@@ -255,12 +255,17 @@ export class Input {
     return false
   }
 
-  async uploadFile(backendNodeId: number, files: string[]): Promise<void> {
+  async uploadFile(ref: string, files: string[]): Promise<void>
+  async uploadFile(backendNodeId: number, files: string[]): Promise<void>
+  async uploadFile(target: string | number, files: string[]): Promise<void> {
+    if (typeof target === 'string') {
+      const { session, backendNodeId } = await this.observer.resolveRef(target)
+      await session.DOM.setFileInputFiles({ files, backendNodeId })
+      return
+    }
+
     await this.withPageSessionRetry((session) =>
-      session.DOM.setFileInputFiles({
-        files,
-        backendNodeId,
-      }),
+      session.DOM.setFileInputFiles({ files, backendNodeId: target }),
     )
   }
 

--- a/packages/browseros-agent/apps/server/src/tools/browser/pdf.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/pdf.ts
@@ -11,15 +11,24 @@ export const pdf = defineTool({
     landscape: z.boolean().optional().describe('Use landscape orientation.'),
     background: z
       .boolean()
-      .default(true)
+      .optional()
+      .describe('Compatibility alias for printBackground.'),
+    printBackground: z
+      .boolean()
+      .optional()
       .describe('Print background graphics.'),
+    preferCSSPageSize: z
+      .boolean()
+      .default(false)
+      .describe('Use CSS page size when the page defines one.'),
   }),
   annotations: { readOnlyHint: true },
   handler: async (args, ctx) => {
     const { session } = await ctx.session.pages.getSession(args.page)
     const { data } = await session.Page.printToPDF({
       landscape: args.landscape ?? false,
-      printBackground: args.background,
+      printBackground: args.printBackground ?? args.background ?? true,
+      preferCSSPageSize: args.preferCSSPageSize,
     })
     const bytes = Buffer.from(data, 'base64')
     const path = await writeTempToolOutputBinaryFile({

--- a/packages/browseros-agent/apps/server/src/tools/browser/registry.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/registry.ts
@@ -12,6 +12,7 @@ import { screenshot } from './screenshot'
 import { snapshot } from './snapshot'
 import { tab_groups } from './tab-groups'
 import { tabs } from './tabs'
+import { upload } from './upload'
 import { wait } from './wait'
 import { windows } from './windows'
 
@@ -23,6 +24,7 @@ export const BROWSER_TOOLS: readonly ToolDefinition[] = [
   diff,
   act,
   download,
+  upload,
   read,
   grep,
   screenshot,

--- a/packages/browseros-agent/apps/server/src/tools/browser/upload.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/upload.ts
@@ -1,0 +1,33 @@
+import { z } from 'zod'
+import { defineTool, errorResult, textResult } from './framework'
+
+export const upload = defineTool({
+  name: 'upload',
+  description:
+    'Set local file path(s) on a file input using a ref from the last snapshot. Use for <input type="file"> upload flows; files must exist on the server filesystem.',
+  input: z.object({
+    page: z.number().int().describe('Page id from `tabs`.'),
+    ref: z
+      .string()
+      .describe('Ref of the <input type="file"> element, e.g. "e12".'),
+    file: z.string().optional().describe('Single local file path to upload.'),
+    files: z
+      .array(z.string())
+      .optional()
+      .describe('Local file paths to upload.'),
+  }),
+  handler: async (args, ctx) => {
+    const files = args.files ?? (args.file === undefined ? [] : [args.file])
+    if (files.length === 0) {
+      return errorResult('upload: provide file or files[].')
+    }
+
+    await ctx.session.input(args.page).uploadFile(args.ref, files)
+    return textResult(`Uploaded ${files.length} file(s) to ${args.ref}`, {
+      page: args.page,
+      ref: args.ref,
+      files,
+      uploaded: files.length,
+    })
+  },
+})

--- a/packages/browseros-agent/apps/server/tests/api/services/mcp/register-mcp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/mcp/register-mcp.test.ts
@@ -90,8 +90,12 @@ describe('registerTools', () => {
 
     expect(infoMessages).toHaveLength(2)
     expect(infoMessages).toEqual([
-      expect.stringContaining('Registered 13 browser tools'),
-      expect.stringContaining('Registered 13 browser tools'),
+      expect.stringContaining(
+        `Registered ${BROWSER_TOOLS.length} browser tools`,
+      ),
+      expect.stringContaining(
+        `Registered ${BROWSER_TOOLS.length} browser tools`,
+      ),
     ])
   })
 
@@ -119,7 +123,7 @@ describe('registerTools', () => {
     })
 
     expect([...fake.handlers.keys()]).toEqual(BROWSER_TOOLS.map((t) => t.name))
-    expect(fake.handlers.size).toBe(13)
+    expect(fake.handlers.size).toBe(BROWSER_TOOLS.length)
   })
 
   it('registers the legacy browser tools when the switch is disabled', () => {

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -942,9 +942,18 @@ return 'late'
         landscape: true,
         background: false,
       })
+      const upstreamOptions = await fake.handlers.get('pdf')?.({
+        page: 1,
+        printBackground: false,
+        preferCSSPageSize: true,
+      })
 
       expect(result?.isError).toBeFalsy()
-      expect(printCalls).toEqual([{ landscape: true, printBackground: false }])
+      expect(upstreamOptions?.isError).toBeFalsy()
+      expect(printCalls).toEqual([
+        { landscape: true, printBackground: false, preferCSSPageSize: false },
+        { landscape: false, printBackground: false, preferCSSPageSize: true },
+      ])
       const data = result?.structuredContent as
         | { page?: number; path?: string; bytes?: number }
         | undefined

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -103,7 +103,7 @@ describe('registerBrowserTools', () => {
     registerBrowserTools(fake.server as never, session)
 
     expect([...fake.handlers.keys()]).toEqual(BROWSER_TOOLS.map((t) => t.name))
-    expect(fake.handlers.size).toBe(13)
+    expect(fake.handlers.size).toBe(16)
     expect(fake.configs.get('tabs')?.inputSchema).toBeDefined()
   })
 
@@ -1016,6 +1016,46 @@ return 'late'
         realpathSync(outputDir),
       )
       expect(data?.path?.endsWith('report.csv')).toBe(true)
+    })
+  })
+
+  it('uploads files into a ref-resolved file input', async () => {
+    const fake = createFakeServer()
+    const uploads: Array<{ ref: string; files: string[] }> = []
+    const session = {
+      input: () => ({
+        uploadFile: async (ref: string, files: string[]) => {
+          uploads.push({ ref, files })
+        },
+      }),
+      pages: {},
+    } as unknown as BrowserSession
+
+    registerBrowserTools(fake.server as never, session)
+    expect(fake.handlers.has('upload')).toBe(true)
+
+    const multiple = await fake.handlers.get('upload')?.({
+      page: 1,
+      ref: 'e12',
+      files: ['/tmp/a.txt', '/tmp/b.txt'],
+    })
+    const single = await fake.handlers.get('upload')?.({
+      page: 1,
+      ref: 'e13',
+      file: '/tmp/c.txt',
+    })
+
+    expect(multiple?.isError).toBeFalsy()
+    expect(single?.isError).toBeFalsy()
+    expect(uploads).toEqual([
+      { ref: 'e12', files: ['/tmp/a.txt', '/tmp/b.txt'] },
+      { ref: 'e13', files: ['/tmp/c.txt'] },
+    ])
+    expect(single?.structuredContent).toEqual({
+      page: 1,
+      ref: 'e13',
+      files: ['/tmp/c.txt'],
+      uploaded: 1,
     })
   })
 


### PR DESCRIPTION
## Summary
- add compact `upload` browser tool using snapshot refs and existing CDP file-input upload path
- align compact `pdf` with agent-browser print option names (`printBackground`, `preferCSSPageSize`) while keeping `background` compatibility
- keep compact download behavior covered and update MCP registration assertions to follow the registry size

## Design
The compact browser toolset now exposes upload as a first-class tool, with file inputs resolved through `BrowserSession.input(page)` so it shares the same iframe-aware ref handling as `act`. PDF accepts the agent-browser CDP option names while preserving BrowserOS-managed output paths for generated files.

## Test plan
- [x] `bun test apps/server/tests/tools/browser/register.test.ts --test-name-pattern upload`
- [x] `bun test apps/server/tests/tools/browser/register.test.ts --test-name-pattern PDF`
- [x] `bun test apps/server/tests/api/services/mcp/register-mcp.test.ts`
- [x] `bun test apps/server/tests/tools/browser/register.test.ts`
- [x] `bun run check`