### PR TITLE
refactor: move server route composition into routes entrypoint

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/routes/index.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/index.ts
@@ -1,0 +1,127 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { Hono } from 'hono'
+import { cors } from 'hono/cors'
+import type { OAuthTokenManager } from '../../lib/clients/oauth/token-manager'
+import { requireTrustedOrigin } from '../middleware/require-trusted-origin'
+import type { KlavisProxyRef } from '../services/klavis/strata-proxy'
+import type { RemoteHermesService } from '../services/remote-hermes/remote-hermes-service'
+import type { Env, HttpServerConfig } from '../types'
+import { defaultCorsConfig } from '../utils/cors'
+import { requireTrustedAppOrigin } from '../utils/request-auth'
+import { createAcpxProbeRoutes } from './acpx-probe'
+import { createAgentRoutes } from './agents'
+import { createChatRoutes } from './chat'
+import { createCreditsRoutes } from './credits'
+import { createHealthRoute } from './health'
+import { createKlavisRoutes } from './klavis'
+import { createMcpRoutes } from './mcp'
+import { createMcpManagerRoutes } from './mcp-manager'
+import { createOAuthRoutes } from './oauth'
+import { createProviderRoutes } from './provider'
+import { createRefinePromptRoutes } from './refine-prompt'
+import { createRemoteHermesRoutes } from './remote-hermes'
+import { createScreencastRoute } from './screencast'
+import { createShutdownRoute } from './shutdown'
+import { createStatusRoute } from './status'
+
+interface CreateApiRoutesDeps {
+  agentRoutes?: Hono<Env>
+  config: HttpServerConfig
+  gatewayBaseUrl?: string
+  klavisRef: KlavisProxyRef
+  onShutdown: () => void
+  remoteHermes: RemoteHermesService | null
+  tokenManager: OAuthTokenManager | null
+}
+
+/** Composes the BrowserOS HTTP API from the existing route factories. */
+export function createApiRoutes(deps: CreateApiRoutesDeps) {
+  const {
+    agentRoutes,
+    config,
+    gatewayBaseUrl,
+    klavisRef,
+    remoteHermes,
+    tokenManager,
+  } = deps
+  const { browser, browserosId, browserSession, port, resourcesDir, version } =
+    config
+
+  return new Hono<Env>()
+    .use('/*', cors(defaultCorsConfig))
+    .use('/*', requireTrustedOrigin())
+    .route('/health', createHealthRoute({ browser }))
+    .route('/shutdown', createShutdownRoute({ onShutdown: deps.onShutdown }))
+    .route('/status', createStatusRoute({ browser }))
+    .route(
+      '/test-provider',
+      createProviderRoutes({ browserosId, resourcesDir }),
+    )
+    .route('/acpx/probe', createAcpxProbeRoutes({ resourcesDir }))
+    .route('/refine-prompt', createRefinePromptRoutes({ browserosId }))
+    .route('/oauth', oauthRoutes(tokenManager))
+    .route('/klavis', createKlavisRoutes({ browserosId: browserosId || '' }))
+    .route(
+      '/credits',
+      createCreditsRoutes({
+        browserosId,
+        gatewayBaseUrl,
+      }),
+    )
+    .route(
+      '/mcp',
+      createMcpRoutes({
+        version,
+        browserSession,
+        klavisRef,
+      }),
+    )
+    .route(
+      '/mcp-manager',
+      createMcpManagerRoutes({
+        getMcpUrl: () => `http://127.0.0.1:${port}/mcp`,
+      }),
+    )
+    .route(
+      '/chat',
+      createChatRoutes({
+        browser,
+        browserSession,
+        browserosId,
+        klavisRef,
+        aiSdkDevtoolsEnabled: config.aiSdkDevtoolsEnabled,
+        serverPort: port,
+        resourcesDir,
+        remoteHermes,
+      }),
+    )
+    .route('/screencast', createScreencastRoute({ browser }))
+    .route('/agents', agentRoutes ?? protectedAgentRoutes(config))
+    .route(
+      '/remote-hermes',
+      createRemoteHermesRoutes({ service: remoteHermes }),
+    )
+}
+
+function protectedAgentRoutes(config: HttpServerConfig) {
+  return new Hono<Env>().use('/*', requireTrustedAppOrigin()).route(
+    '/',
+    createAgentRoutes({
+      browserosServerPort: config.port,
+      resourcesDir: config.resourcesDir,
+      browser: config.browser,
+    }),
+  )
+}
+
+function oauthRoutes(tokenManager: OAuthTokenManager | null) {
+  const app = new Hono<Env>()
+  if (tokenManager) return app.route('/', createOAuthRoutes({ tokenManager }))
+
+  return app.all('/*', (c) => c.json({ error: 'OAuth not available' }, 503))
+}

--- a/packages/browseros-agent/apps/server/src/api/routes/index.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/index.ts
@@ -101,21 +101,22 @@ export function createApiRoutes(deps: CreateApiRoutesDeps) {
       }),
     )
     .route('/screencast', createScreencastRoute({ browser }))
-    .route('/agents', agentRoutes ?? protectedAgentRoutes(config))
+    .route('/agents', protectedAgentRoutes(config, agentRoutes))
     .route(
       '/remote-hermes',
       createRemoteHermesRoutes({ service: remoteHermes }),
     )
 }
 
-function protectedAgentRoutes(config: HttpServerConfig) {
+function protectedAgentRoutes(config: HttpServerConfig, routes?: Hono<Env>) {
   return new Hono<Env>().use('/*', requireTrustedAppOrigin()).route(
     '/',
-    createAgentRoutes({
-      browserosServerPort: config.port,
-      resourcesDir: config.resourcesDir,
-      browser: config.browser,
-    }),
+    routes ??
+      createAgentRoutes({
+        browserosServerPort: config.port,
+        resourcesDir: config.resourcesDir,
+        browser: config.browser,
+      }),
   )
 }
 

--- a/packages/browseros-agent/apps/server/src/api/server.ts
+++ b/packages/browseros-agent/apps/server/src/api/server.ts
@@ -2,17 +2,9 @@
  * @license
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
- *
- * Consolidated HTTP Server
- *
- * This server combines:
- * - Agent HTTP routes (chat, klavis, provider)
- * - MCP HTTP routes (using @hono/mcp transport)
  */
 
-import { Hono } from 'hono'
 import { websocket } from 'hono/bun'
-import { cors } from 'hono/cors'
 import type { ContentfulStatusCode } from 'hono/utils/http-status'
 import { HttpAgentError } from '../agent/errors'
 import { INLINED_ENV } from '../env'
@@ -22,31 +14,15 @@ import { RemoteHermesClient } from '../lib/clients/remote-hermes/remote-hermes-c
 import { getDb } from '../lib/db'
 import { logger } from '../lib/logger'
 import { Sentry } from '../lib/sentry'
-import { requireTrustedOrigin } from './middleware/require-trusted-origin'
-import { createAcpxProbeRoutes } from './routes/acpx-probe'
-import { createAgentRoutes } from './routes/agents'
-import { createChatRoutes } from './routes/chat'
-import { createCreditsRoutes } from './routes/credits'
-import { createHealthRoute } from './routes/health'
-import { createKlavisRoutes } from './routes/klavis'
-import { createMcpRoutes } from './routes/mcp'
-import { createMcpManagerRoutes } from './routes/mcp-manager'
-import { createOAuthRoutes } from './routes/oauth'
-import { createProviderRoutes } from './routes/provider'
-import { createRefinePromptRoutes } from './routes/refine-prompt'
-import { createRemoteHermesRoutes } from './routes/remote-hermes'
-import { createScreencastRoute } from './routes/screencast'
-import { createShutdownRoute } from './routes/shutdown'
-import { createStatusRoute } from './routes/status'
+import { createApiRoutes } from './routes'
 import {
   connectKlavisInBackground,
   type KlavisProxyRef,
 } from './services/klavis/strata-proxy'
 import { RemoteHermesService } from './services/remote-hermes/remote-hermes-service'
-import type { Env, HttpServerConfig } from './types'
-import { defaultCorsConfig } from './utils/cors'
-import { requireTrustedAppOrigin } from './utils/request-auth'
+import type { HttpServerConfig } from './types'
 
+/** Checks the loopback bind before Bun.serve so startup errors stay explicit. */
 async function assertPortAvailable(port: number): Promise<void> {
   const net = await import('node:net')
   return new Promise((resolve, reject) => {
@@ -70,16 +46,9 @@ async function assertPortAvailable(port: number): Promise<void> {
   })
 }
 
+/** Creates the Hono app and Bun server after wiring process-level dependencies. */
 export async function createHttpServer(config: HttpServerConfig) {
-  const {
-    port,
-    host = '0.0.0.0',
-    browserosId,
-    resourcesDir,
-    version,
-    browser,
-    browserSession,
-  } = config
+  const { port, host = '0.0.0.0', browserosId } = config
 
   const { onShutdown } = config
   const tokenManager = browserosId
@@ -114,97 +83,27 @@ export async function createHttpServer(config: HttpServerConfig) {
     logger.warn('Remote Hermes disabled: AGENT_RUNNER_JWT_SECRET not set')
   }
 
-  const agentRoutes = new Hono<Env>()
-    .use('/*', requireTrustedAppOrigin())
-    .route(
-      '/',
-      createAgentRoutes({
-        browserosServerPort: port,
-        resourcesDir,
-        browser,
-      }),
-    )
+  const app = createApiRoutes({
+    config,
+    gatewayBaseUrl: INLINED_ENV.BROWSEROS_CONFIG_URL
+      ? new URL(INLINED_ENV.BROWSEROS_CONFIG_URL).origin
+      : undefined,
+    klavisRef,
+    remoteHermes,
+    tokenManager,
+    onShutdown: () => {
+      shutdownOAuth()
+      stopKlavisBackground()
+      klavisRef.handle?.close().catch((err) =>
+        logger.warn('Failed to close Klavis proxy transport', {
+          error: err instanceof Error ? err.message : String(err),
+        }),
+      )
+      remoteHermes?.close()
+      onShutdown?.()
+    },
+  })
 
-  const app = new Hono<Env>()
-    .use('/*', cors(defaultCorsConfig))
-    .use('/*', requireTrustedOrigin())
-    .route('/health', createHealthRoute({ browser }))
-    .route(
-      '/shutdown',
-      createShutdownRoute({
-        onShutdown: () => {
-          shutdownOAuth()
-          stopKlavisBackground()
-          klavisRef.handle?.close().catch((err) =>
-            logger.warn('Failed to close Klavis proxy transport', {
-              error: err instanceof Error ? err.message : String(err),
-            }),
-          )
-          remoteHermes?.close()
-          onShutdown?.()
-        },
-      }),
-    )
-    .route('/status', createStatusRoute({ browser }))
-    .route(
-      '/test-provider',
-      createProviderRoutes({ browserosId, resourcesDir }),
-    )
-    .route('/acpx/probe', createAcpxProbeRoutes({ resourcesDir }))
-    .route('/refine-prompt', createRefinePromptRoutes({ browserosId }))
-    .route(
-      '/oauth',
-      tokenManager
-        ? createOAuthRoutes({ tokenManager })
-        : new Hono().all('/*', (c) =>
-            c.json({ error: 'OAuth not available' }, 503),
-          ),
-    )
-    .route('/klavis', createKlavisRoutes({ browserosId: browserosId || '' }))
-    .route(
-      '/credits',
-      createCreditsRoutes({
-        browserosId,
-        gatewayBaseUrl: INLINED_ENV.BROWSEROS_CONFIG_URL
-          ? new URL(INLINED_ENV.BROWSEROS_CONFIG_URL).origin
-          : undefined,
-      }),
-    )
-    .route(
-      '/mcp',
-      createMcpRoutes({
-        version,
-        browserSession,
-        klavisRef,
-      }),
-    )
-    .route(
-      '/mcp-manager',
-      createMcpManagerRoutes({
-        getMcpUrl: () => `http://127.0.0.1:${port}/mcp`,
-      }),
-    )
-    .route(
-      '/chat',
-      createChatRoutes({
-        browser,
-        browserSession,
-        browserosId,
-        klavisRef,
-        aiSdkDevtoolsEnabled: config.aiSdkDevtoolsEnabled,
-        serverPort: port,
-        resourcesDir,
-        remoteHermes,
-      }),
-    )
-    .route('/screencast', createScreencastRoute({ browser }))
-    .route('/agents', agentRoutes)
-    .route(
-      '/remote-hermes',
-      createRemoteHermesRoutes({ service: remoteHermes }),
-    )
-
-  // Error handler
   app.onError((err, c) => {
     const error = err as Error
 

--- a/packages/browseros-agent/apps/server/tests/api/routes/index.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/index.test.ts
@@ -33,9 +33,9 @@ function createTestConfig() {
   } as never
 }
 
-function createTestApp() {
+function createTestApp(agentRoutes = new Hono<Env>()) {
   return createApiRoutes({
-    agentRoutes: new Hono<Env>(),
+    agentRoutes,
     config: createTestConfig(),
     klavisRef: { handle: null },
     remoteHermes: null,
@@ -69,5 +69,26 @@ describe('createApiRoutes', () => {
 
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({ agents: [] })
+  })
+
+  it('keeps injected agent routes behind app-origin auth', async () => {
+    const agentRoutes = new Hono<Env>().post('/guard-check', (c) =>
+      c.json({ ok: true }),
+    )
+    const app = createTestApp(agentRoutes)
+
+    const blocked = await app.request('/agents/guard-check', {
+      method: 'POST',
+    })
+    expect(blocked.status).toBe(403)
+
+    const allowed = await app.request('/agents/guard-check', {
+      method: 'POST',
+      headers: {
+        Origin: 'chrome-extension://bflpfmnmnokmjhmgnolecpppdbdophmk',
+      },
+    })
+    expect(allowed.status).toBe(200)
+    await expect(allowed.json()).resolves.toEqual({ ok: true })
   })
 })

--- a/packages/browseros-agent/apps/server/tests/api/routes/index.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/index.test.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { describe, expect, it, mock } from 'bun:test'
+import { Hono } from 'hono'
+import type { Env } from '../../../src/api/types'
+
+mock.module('../../../src/lib/mcp-manager', () => ({
+  humaniseInstallError: (err: unknown) => ({
+    message: err instanceof Error ? err.message : String(err),
+    status: 500,
+  }),
+  installInto: mock(async () => ({ success: true })),
+  listAgents: mock(async () => []),
+  uninstallFrom: mock(async () => ({ success: true })),
+}))
+
+const { createApiRoutes } = await import('../../../src/api/routes')
+
+function createTestConfig() {
+  return {
+    port: 32123,
+    version: '0.0.0-test',
+    browser: {
+      isCdpConnected: () => false,
+    },
+    browserSession: {},
+    executionDir: '/tmp/browseros-test',
+    resourcesDir: '/tmp/browseros-resources',
+    aiSdkDevtoolsEnabled: false,
+  } as never
+}
+
+function createTestApp() {
+  return createApiRoutes({
+    agentRoutes: new Hono<Env>(),
+    config: createTestConfig(),
+    klavisRef: { handle: null },
+    remoteHermes: null,
+    tokenManager: null,
+    onShutdown: () => {},
+  })
+}
+
+describe('createApiRoutes', () => {
+  it('mounts the health route', async () => {
+    const response = await createTestApp().request('/health')
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      status: 'ok',
+      cdpConnected: false,
+    })
+  })
+
+  it('preserves the OAuth unavailable fallback', async () => {
+    const response = await createTestApp().request('/oauth/openai/status')
+
+    expect(response.status).toBe(503)
+    await expect(response.json()).resolves.toEqual({
+      error: 'OAuth not available',
+    })
+  })
+
+  it('mounts the MCP manager routes', async () => {
+    const response = await createTestApp().request('/mcp-manager/agents')
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ agents: [] })
+  })
+})


### PR DESCRIPTION
## Summary
- Move Hono API route composition into `apps/server/src/api/routes/index.ts` so `server.ts` stays focused on runtime setup and Bun startup.
- Preserve the existing route order, middleware order, shutdown behavior, OAuth fallback, and service dependency wiring.
- Keep `/agents` behind `requireTrustedAppOrigin`, including injected route apps used by tests.

## Design
`createHttpServer` still initializes OAuth, Klavis, Remote Hermes, error handling, port probing, and `Bun.serve`. The new `createApiRoutes` entrypoint composes the existing route factories in one scan-friendly Hono chain, matching the clean route-composition style from the Agent Company server without changing handler logic.

## Test plan
- [x] `cd apps/server && bun test tests/api/routes/index.test.ts`
- [x] `cd apps/server && bun run test:api`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test:main`
- [x] Local context-free review loop: 2 rounds, 1 Important finding fixed, final clean
