### PR TITLE
feat: add side panel scope toggle

### DIFF
--- a/packages/browseros-agent/apps/agent/entrypoints/background/index.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/background/index.ts
@@ -3,8 +3,8 @@ import { sessionStorage } from '@/lib/auth/sessionStorage'
 import { Capabilities } from '@/lib/browseros/capabilities'
 import { getHealthCheckUrl, getMcpServerUrl } from '@/lib/browseros/helpers'
 import {
+  ensureSidePanelRuntimeStateLoaded,
   openSidePanel,
-  refreshSidePanelScopePreference,
   registerSidePanelOpenStateListeners,
   setSidePanelPerWindowPreference,
   toggleSidePanel,
@@ -50,7 +50,7 @@ const cleanupLegacyToolApprovalStorage = async () => {
 export default defineBackground(() => {
   chrome.sidePanel.setOptions({ enabled: false })
   registerSidePanelOpenStateListeners()
-  refreshSidePanelScopePreference().catch(() => null)
+  ensureSidePanelRuntimeStateLoaded().catch(() => null)
 
   Capabilities.initialize().catch(() => null)
   setupLlmProvidersBackupToBrowserOS()

--- a/packages/browseros-agent/apps/agent/entrypoints/background/index.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/background/index.ts
@@ -48,7 +48,6 @@ const cleanupLegacyToolApprovalStorage = async () => {
 }
 
 export default defineBackground(() => {
-  chrome.sidePanel.setOptions({ enabled: false })
   registerSidePanelOpenStateListeners()
   ensureSidePanelRuntimeStateLoaded().catch(() => null)
 

--- a/packages/browseros-agent/apps/agent/entrypoints/background/index.ts
+++ b/packages/browseros-agent/apps/agent/entrypoints/background/index.ts
@@ -2,7 +2,13 @@ import { storage } from '@wxt-dev/storage'
 import { sessionStorage } from '@/lib/auth/sessionStorage'
 import { Capabilities } from '@/lib/browseros/capabilities'
 import { getHealthCheckUrl, getMcpServerUrl } from '@/lib/browseros/helpers'
-import { openSidePanel, toggleSidePanel } from '@/lib/browseros/toggleSidePanel'
+import {
+  openSidePanel,
+  refreshSidePanelScopePreference,
+  registerSidePanelOpenStateListeners,
+  setSidePanelPerWindowPreference,
+  toggleSidePanel,
+} from '@/lib/browseros/toggleSidePanel'
 import { checkAndShowChangelog } from '@/lib/changelog/changelog-notifier'
 import {
   setupLlmProvidersBackupToBrowserOS,
@@ -43,6 +49,8 @@ const cleanupLegacyToolApprovalStorage = async () => {
 
 export default defineBackground(() => {
   chrome.sidePanel.setOptions({ enabled: false })
+  registerSidePanelOpenStateListeners()
+  refreshSidePanelScopePreference().catch(() => null)
 
   Capabilities.initialize().catch(() => null)
   setupLlmProvidersBackupToBrowserOS()
@@ -52,8 +60,8 @@ export default defineBackground(() => {
   scheduledJobRuns()
 
   chrome.action.onClicked.addListener(async (tab) => {
-    if (tab.id) {
-      await toggleSidePanel(tab.id)
+    if (typeof tab.id === 'number' && typeof tab.windowId === 'number') {
+      await toggleSidePanel({ tabId: tab.id, windowId: tab.windowId })
     }
   })
 
@@ -62,9 +70,15 @@ export default defineBackground(() => {
       active: true,
       currentWindow: true,
     })
-    const currentTab = currentTabsList?.[0]?.id
-    if (currentTab) {
-      const { opened } = await openSidePanel(currentTab)
+    const currentTab = currentTabsList?.[0]
+    if (
+      typeof currentTab?.id === 'number' &&
+      typeof currentTab.windowId === 'number'
+    ) {
+      const { opened } = await openSidePanel({
+        tabId: currentTab.id,
+        windowId: currentTab.windowId,
+      })
 
       if (opened) {
         setTimeout(() => {
@@ -116,6 +130,13 @@ export default defineBackground(() => {
       timestamp: Date.now(),
     })
   })
+
+  onRuntimeMessage(
+    RuntimeMessageType.sidePanelScopeChanged,
+    async ({ data }) => {
+      await setSidePanelPerWindowPreference(data.perWindow)
+    },
+  )
 
   chrome.tabs.onRemoved.addListener((tabId) => {
     const key = String(tabId)

--- a/packages/browseros-agent/apps/agent/lib/browseros/chrome-browser-os.d.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/chrome-browser-os.d.ts
@@ -52,3 +52,37 @@ declare namespace chrome.browserOS {
   ): void
   function choosePath(callback: (result: SelectedPath | null) => void): void
 }
+
+declare namespace chrome.sidePanel {
+  interface BrowserosToggleOptions {
+    tabId: number
+    open?: boolean
+  }
+
+  interface BrowserosToggleResult {
+    opened: boolean
+  }
+
+  interface BrowserosIsOpenOptions {
+    tabId: number
+  }
+
+  function browserosToggle(
+    options: BrowserosToggleOptions,
+  ): Promise<BrowserosToggleResult>
+  function browserosToggle(
+    options: BrowserosToggleOptions,
+    callback: (result: BrowserosToggleResult) => void,
+  ): void
+
+  function browserosIsOpen(options: BrowserosIsOpenOptions): Promise<boolean>
+  function browserosIsOpen(
+    options: BrowserosIsOpenOptions,
+    callback: (isOpen: boolean) => void,
+  ): void
+
+  function close(options: CloseOptions): Promise<void>
+  function close(options: CloseOptions, callback: () => void): void
+
+  const onClosed: chrome.events.Event<(info: PanelClosedInfo) => void>
+}

--- a/packages/browseros-agent/apps/agent/lib/browseros/prefs.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/prefs.ts
@@ -9,6 +9,7 @@ export const BROWSEROS_PREFS = {
   RESTART_SERVER: 'browseros.server.restart_requested',
   SHOW_LLM_CHAT: 'browseros.show_llm_chat',
   SHOW_TOOLBAR_LABELS: 'browseros.show_toolbar_labels',
+  SIDE_PANEL_PER_WINDOW: 'browseros.side_panel.per_window',
   VERTICAL_TABS_ENABLED: 'browseros.vertical_tabs_enabled',
   INSTALL_ID: 'browseros.metrics_install_id',
 } as const

--- a/packages/browseros-agent/apps/agent/lib/browseros/sidePanelOpenStateStorage.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/sidePanelOpenStateStorage.ts
@@ -1,0 +1,6 @@
+import { storage } from '@wxt-dev/storage'
+
+export const openWindowSidePanelIdsStorage = storage.defineItem<number[]>(
+  'session:browseros.side_panel.open_window_ids',
+  { fallback: [] },
+)

--- a/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.test.ts
@@ -218,7 +218,7 @@ describe('side panel scope routing', () => {
 
   it('keeps a newer explicit setting change over a stale refresh result', async () => {
     let resolvePref: (pref: { value: unknown } | null) => void = () => {}
-    getPrefOverride = async () =>
+    getPrefOverride = async (_name: string) =>
       new Promise<{ value: unknown } | null>((resolve) => {
         resolvePref = resolve
       })

--- a/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.test.ts
@@ -180,16 +180,29 @@ describe('side panel scope routing', () => {
     expect(closeCalls).toEqual([{ windowId: 3 }])
   })
 
-  it('opens without closing when search opens an already-open window panel', async () => {
-    registerSidePanelOpenStateListeners()
+  it('keeps programmatic opens on the BrowserOS API in window mode', async () => {
     await setSidePanelPerWindowPreference(true)
-    fireWindowOpened(3)
 
     const result = await openSidePanel({ tabId: 7, windowId: 3 })
 
     expect(result).toEqual({ opened: true })
+    expect(browserosIsOpenCalls).toEqual([{ tabId: 7 }])
+    expect(browserosToggleCalls).toEqual([{ tabId: 7 }])
+    expect(openCalls).toEqual([])
     expect(closeCalls).toEqual([])
+  })
+
+  it('opens without closing when programmatic opens target an already-open tab panel', async () => {
+    await setSidePanelPerWindowPreference(true)
+    browserosIsOpenResult = true
+
+    const result = await openSidePanel({ tabId: 7, windowId: 3 })
+
+    expect(result).toEqual({ opened: true })
+    expect(browserosIsOpenCalls).toEqual([{ tabId: 7 }])
     expect(browserosToggleCalls).toEqual([])
+    expect(openCalls).toEqual([])
+    expect(closeCalls).toEqual([])
   })
 
   it('refreshes the cached scope from BrowserOS prefs outside the click path', async () => {

--- a/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.test.ts
@@ -1,0 +1,175 @@
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+const BROWSEROS_PREFS = {
+  SIDE_PANEL_PER_WINDOW: 'browseros.side_panel.per_window',
+} as const
+
+let prefValues = new Map<string, unknown>()
+let browserosToggleCalls: unknown[] = []
+let browserosIsOpenCalls: unknown[] = []
+let openCalls: unknown[] = []
+let closeCalls: unknown[] = []
+let setOptionsCalls: unknown[] = []
+let browserosIsOpenResult = false
+const onOpenedListeners: Array<
+  (info: chrome.sidePanel.PanelOpenedInfo) => void
+> = []
+const onClosedListeners: Array<
+  (info: chrome.sidePanel.PanelClosedInfo) => void
+> = []
+
+const browserOSAdapter = {
+  getPref: async (name: string) =>
+    prefValues.has(name) ? { value: prefValues.get(name) } : null,
+}
+
+const BrowserOSAdapter = {
+  getInstance: () => browserOSAdapter,
+}
+
+mock.module('@/lib/browseros/adapter', () => ({
+  BrowserOSAdapter,
+  getBrowserOSAdapter: () => browserOSAdapter,
+}))
+
+mock.module('./adapter', () => ({
+  BrowserOSAdapter,
+  getBrowserOSAdapter: () => browserOSAdapter,
+}))
+
+mock.module('@/lib/browseros/prefs', () => ({
+  BROWSEROS_PREFS,
+}))
+
+let openSidePanel: typeof import('./toggleSidePanel').openSidePanel
+let toggleSidePanel: typeof import('./toggleSidePanel').toggleSidePanel
+let registerSidePanelOpenStateListeners: typeof import('./toggleSidePanel').registerSidePanelOpenStateListeners
+let refreshSidePanelScopePreference: typeof import('./toggleSidePanel').refreshSidePanelScopePreference
+let setSidePanelPerWindowPreference: typeof import('./toggleSidePanel').setSidePanelPerWindowPreference
+
+beforeAll(async () => {
+  const module = await import('./toggleSidePanel')
+  openSidePanel = module.openSidePanel
+  toggleSidePanel = module.toggleSidePanel
+  registerSidePanelOpenStateListeners =
+    module.registerSidePanelOpenStateListeners
+  refreshSidePanelScopePreference = module.refreshSidePanelScopePreference
+  setSidePanelPerWindowPreference = module.setSidePanelPerWindowPreference
+})
+
+beforeEach(async () => {
+  prefValues = new Map()
+  browserosToggleCalls = []
+  browserosIsOpenCalls = []
+  openCalls = []
+  closeCalls = []
+  setOptionsCalls = []
+  browserosIsOpenResult = false
+
+  globalThis.chrome = {
+    sidePanel: {
+      browserosToggle: async (options: unknown) => {
+        browserosToggleCalls.push(options)
+        return { opened: true }
+      },
+      browserosIsOpen: async (options: unknown) => {
+        browserosIsOpenCalls.push(options)
+        return browserosIsOpenResult
+      },
+      open: async (options: unknown) => {
+        openCalls.push(options)
+      },
+      close: async (options: unknown) => {
+        closeCalls.push(options)
+      },
+      setOptions: async (options: unknown) => {
+        setOptionsCalls.push(options)
+      },
+      onOpened: {
+        addListener: (
+          listener: (info: chrome.sidePanel.PanelOpenedInfo) => void,
+        ) => {
+          onOpenedListeners.push(listener)
+        },
+      },
+      onClosed: {
+        addListener: (
+          listener: (info: chrome.sidePanel.PanelClosedInfo) => void,
+        ) => {
+          onClosedListeners.push(listener)
+        },
+      },
+    },
+  } as typeof chrome
+
+  fireWindowClosed(3)
+  await setSidePanelPerWindowPreference(false)
+  setOptionsCalls = []
+})
+
+function fireWindowOpened(windowId: number) {
+  for (const listener of onOpenedListeners) {
+    listener({ windowId, path: 'sidepanel.html' })
+  }
+}
+
+function fireWindowClosed(windowId: number) {
+  for (const listener of onClosedListeners) {
+    listener({ windowId, path: 'sidepanel.html' })
+  }
+}
+
+describe('side panel scope routing', () => {
+  it('keeps toolbar toggles on the BrowserOS tab-specific API by default', async () => {
+    const result = await toggleSidePanel({ tabId: 7, windowId: 3 })
+
+    expect(result).toEqual({ opened: true })
+    expect(browserosToggleCalls).toEqual([{ tabId: 7 }])
+    expect(openCalls).toEqual([])
+    expect(closeCalls).toEqual([])
+  })
+
+  it('uses Chromium window APIs when the window-level preference is enabled', async () => {
+    registerSidePanelOpenStateListeners()
+    await setSidePanelPerWindowPreference(true)
+
+    expect(setOptionsCalls).toEqual([{ enabled: true, path: 'sidepanel.html' }])
+    setOptionsCalls = []
+
+    const opened = await toggleSidePanel({ tabId: 7, windowId: 3 })
+
+    expect(opened).toEqual({ opened: true })
+    expect(setOptionsCalls).toEqual([])
+    expect(openCalls).toEqual([{ windowId: 3 }])
+    expect(browserosToggleCalls).toEqual([])
+
+    fireWindowOpened(3)
+    const closed = await toggleSidePanel({ tabId: 7, windowId: 3 })
+
+    expect(closed).toEqual({ opened: false })
+    expect(closeCalls).toEqual([{ windowId: 3 }])
+  })
+
+  it('opens without closing when search opens an already-open window panel', async () => {
+    registerSidePanelOpenStateListeners()
+    await setSidePanelPerWindowPreference(true)
+    fireWindowOpened(3)
+
+    const result = await openSidePanel({ tabId: 7, windowId: 3 })
+
+    expect(result).toEqual({ opened: true })
+    expect(closeCalls).toEqual([])
+    expect(browserosToggleCalls).toEqual([])
+  })
+
+  it('refreshes the cached scope from BrowserOS prefs outside the click path', async () => {
+    prefValues.set(BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW, true)
+
+    await refreshSidePanelScopePreference()
+    const result = await toggleSidePanel({ tabId: 7, windowId: 3 })
+
+    expect(result).toEqual({ opened: true })
+    expect(openCalls).toEqual([{ windowId: 3 }])
+    expect(browserosToggleCalls).toEqual([])
+  })
+})

--- a/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.test.ts
@@ -5,12 +5,16 @@ const BROWSEROS_PREFS = {
 } as const
 
 let prefValues = new Map<string, unknown>()
+let storedOpenWindowIds: number[] = []
 let browserosToggleCalls: unknown[] = []
 let browserosIsOpenCalls: unknown[] = []
 let openCalls: unknown[] = []
 let closeCalls: unknown[] = []
 let setOptionsCalls: unknown[] = []
 let browserosIsOpenResult = false
+let getPrefOverride:
+  | ((name: string) => Promise<{ value: unknown } | null>)
+  | null = null
 const onOpenedListeners: Array<
   (info: chrome.sidePanel.PanelOpenedInfo) => void
 > = []
@@ -19,8 +23,12 @@ const onClosedListeners: Array<
 > = []
 
 const browserOSAdapter = {
-  getPref: async (name: string) =>
-    prefValues.has(name) ? { value: prefValues.get(name) } : null,
+  getPref: async (name: string) => {
+    if (getPrefOverride) {
+      return await getPrefOverride(name)
+    }
+    return prefValues.has(name) ? { value: prefValues.get(name) } : null
+  },
 }
 
 const BrowserOSAdapter = {
@@ -41,10 +49,19 @@ mock.module('@/lib/browseros/prefs', () => ({
   BROWSEROS_PREFS,
 }))
 
+mock.module('./sidePanelOpenStateStorage', () => ({
+  openWindowSidePanelIdsStorage: {
+    getValue: async () => storedOpenWindowIds,
+    setValue: async (windowIds: number[]) => {
+      storedOpenWindowIds = windowIds
+    },
+  },
+}))
+
 let openSidePanel: typeof import('./toggleSidePanel').openSidePanel
 let toggleSidePanel: typeof import('./toggleSidePanel').toggleSidePanel
 let registerSidePanelOpenStateListeners: typeof import('./toggleSidePanel').registerSidePanelOpenStateListeners
-let refreshSidePanelScopePreference: typeof import('./toggleSidePanel').refreshSidePanelScopePreference
+let refreshSidePanelRuntimeState: typeof import('./toggleSidePanel').refreshSidePanelRuntimeState
 let setSidePanelPerWindowPreference: typeof import('./toggleSidePanel').setSidePanelPerWindowPreference
 
 beforeAll(async () => {
@@ -53,18 +70,20 @@ beforeAll(async () => {
   toggleSidePanel = module.toggleSidePanel
   registerSidePanelOpenStateListeners =
     module.registerSidePanelOpenStateListeners
-  refreshSidePanelScopePreference = module.refreshSidePanelScopePreference
+  refreshSidePanelRuntimeState = module.refreshSidePanelRuntimeState
   setSidePanelPerWindowPreference = module.setSidePanelPerWindowPreference
 })
 
 beforeEach(async () => {
   prefValues = new Map()
+  storedOpenWindowIds = []
   browserosToggleCalls = []
   browserosIsOpenCalls = []
   openCalls = []
   closeCalls = []
   setOptionsCalls = []
   browserosIsOpenResult = false
+  getPrefOverride = null
 
   globalThis.chrome = {
     sidePanel: {
@@ -120,6 +139,17 @@ function fireWindowClosed(windowId: number) {
 }
 
 describe('side panel scope routing', () => {
+  it('hydrates window open state before routing a cold-started toggle', async () => {
+    prefValues.set(BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW, true)
+    storedOpenWindowIds = [3]
+
+    const result = await toggleSidePanel({ tabId: 7, windowId: 3 })
+
+    expect(result).toEqual({ opened: false })
+    expect(closeCalls).toEqual([{ windowId: 3 }])
+    expect(openCalls).toEqual([])
+  })
+
   it('keeps toolbar toggles on the BrowserOS tab-specific API by default', async () => {
     const result = await toggleSidePanel({ tabId: 7, windowId: 3 })
 
@@ -165,7 +195,27 @@ describe('side panel scope routing', () => {
   it('refreshes the cached scope from BrowserOS prefs outside the click path', async () => {
     prefValues.set(BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW, true)
 
-    await refreshSidePanelScopePreference()
+    await refreshSidePanelRuntimeState()
+    const result = await toggleSidePanel({ tabId: 7, windowId: 3 })
+
+    expect(result).toEqual({ opened: true })
+    expect(openCalls).toEqual([{ windowId: 3 }])
+    expect(browserosToggleCalls).toEqual([])
+  })
+
+  it('keeps a newer explicit setting change over a stale refresh result', async () => {
+    let resolvePref: (pref: { value: unknown } | null) => void = () => {}
+    getPrefOverride = async () =>
+      new Promise<{ value: unknown } | null>((resolve) => {
+        resolvePref = resolve
+      })
+
+    const refreshPromise = refreshSidePanelRuntimeState()
+    await Promise.resolve()
+    await setSidePanelPerWindowPreference(true)
+    resolvePref({ value: false })
+    await refreshPromise
+
     const result = await toggleSidePanel({ tabId: 7, windowId: 3 })
 
     expect(result).toEqual({ opened: true })

--- a/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.ts
@@ -1,10 +1,15 @@
 import { getBrowserOSAdapter } from './adapter'
 import { BROWSEROS_PREFS } from './prefs'
+import { openWindowSidePanelIdsStorage } from './sidePanelOpenStateStorage'
 
 const SIDEPANEL_PATH = 'sidepanel.html'
 const openWindowSidePanelIds = new Set<number>()
 let sidePanelPerWindow = false
 let sidePanelOpenStateListenersRegistered = false
+let sidePanelRuntimeStateLoaded = false
+let sidePanelRuntimeStateLoadPromise: Promise<void> | null = null
+let sidePanelScopePreferenceEpoch = 0
+let persistWindowSidePanelOpenStatePromise: Promise<void> = Promise.resolve()
 
 type SidePanelTarget = {
   tabId: number
@@ -19,22 +24,85 @@ type SidePanelToggleResult = {
 export async function setSidePanelPerWindowPreference(
   perWindow: boolean,
 ): Promise<void> {
-  sidePanelPerWindow = perWindow
+  const epoch = sidePanelScopePreferenceEpoch + 1
+  sidePanelScopePreferenceEpoch = epoch
+  await applySidePanelPerWindowPreference(perWindow, epoch)
+}
+
+async function applySidePanelPerWindowPreference(
+  perWindow: boolean,
+  epoch: number,
+): Promise<void> {
+  if (epoch !== sidePanelScopePreferenceEpoch) return
   await chrome.sidePanel.setOptions(
     perWindow ? { enabled: true, path: SIDEPANEL_PATH } : { enabled: false },
   )
+  if (epoch !== sidePanelScopePreferenceEpoch) return
+  sidePanelPerWindow = perWindow
 }
 
-/** Loads the stored side panel scope before user-triggered side panel actions run. */
-export async function refreshSidePanelScopePreference(): Promise<void> {
+async function loadSidePanelScopePreference(): Promise<void> {
+  const epoch = sidePanelScopePreferenceEpoch
   try {
     const pref = await getBrowserOSAdapter().getPref(
       BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW,
     )
-    await setSidePanelPerWindowPreference(pref?.value === true)
+    await applySidePanelPerWindowPreference(pref?.value === true, epoch)
   } catch {
-    await setSidePanelPerWindowPreference(false)
+    await applySidePanelPerWindowPreference(false, epoch)
   }
+}
+
+async function loadWindowSidePanelOpenState(): Promise<void> {
+  const windowIds = await openWindowSidePanelIdsStorage.getValue()
+  openWindowSidePanelIds.clear()
+  for (const windowId of windowIds) {
+    if (Number.isInteger(windowId)) {
+      openWindowSidePanelIds.add(windowId)
+    }
+  }
+}
+
+function queuePersistWindowSidePanelOpenState(): void {
+  const windowIds = [...openWindowSidePanelIds]
+  persistWindowSidePanelOpenStatePromise =
+    persistWindowSidePanelOpenStatePromise
+      .catch(() => undefined)
+      .then(() => openWindowSidePanelIdsStorage.setValue(windowIds))
+}
+
+function rememberWindowSidePanelOpen(windowId: number): void {
+  if (openWindowSidePanelIds.has(windowId)) return
+  openWindowSidePanelIds.add(windowId)
+  queuePersistWindowSidePanelOpenState()
+}
+
+function rememberWindowSidePanelClosed(windowId: number): void {
+  if (!openWindowSidePanelIds.delete(windowId)) return
+  queuePersistWindowSidePanelOpenState()
+}
+
+/** Refreshes the cached side panel scope and open-window state from storage. */
+export async function refreshSidePanelRuntimeState(): Promise<void> {
+  await Promise.all([
+    loadSidePanelScopePreference(),
+    loadWindowSidePanelOpenState(),
+  ])
+  sidePanelRuntimeStateLoaded = true
+}
+
+/** Serializes background startup state before a user-triggered side panel action routes. */
+export async function ensureSidePanelRuntimeStateLoaded(): Promise<void> {
+  if (sidePanelRuntimeStateLoaded) return
+  sidePanelRuntimeStateLoadPromise ??= refreshSidePanelRuntimeState()
+    .catch((error) => {
+      sidePanelRuntimeStateLoaded = false
+      throw error
+    })
+    .finally(() => {
+      sidePanelRuntimeStateLoadPromise = null
+    })
+  await sidePanelRuntimeStateLoadPromise
 }
 
 async function openTabSidePanel({
@@ -58,7 +126,7 @@ async function openWindowSidePanel({
 }: SidePanelTarget): Promise<SidePanelToggleResult> {
   if (!openWindowSidePanelIds.has(windowId)) {
     await chrome.sidePanel.open({ windowId })
-    openWindowSidePanelIds.add(windowId)
+    rememberWindowSidePanelOpen(windowId)
   }
   return { opened: true }
 }
@@ -68,7 +136,7 @@ async function toggleWindowSidePanel(
 ): Promise<SidePanelToggleResult> {
   if (openWindowSidePanelIds.has(target.windowId)) {
     await chrome.sidePanel.close({ windowId: target.windowId })
-    openWindowSidePanelIds.delete(target.windowId)
+    rememberWindowSidePanelClosed(target.windowId)
     return { opened: false }
   }
   return await openWindowSidePanel(target)
@@ -81,13 +149,13 @@ export function registerSidePanelOpenStateListeners(): void {
 
   chrome.sidePanel.onOpened.addListener((info) => {
     if (info.tabId === undefined) {
-      openWindowSidePanelIds.add(info.windowId)
+      rememberWindowSidePanelOpen(info.windowId)
     }
   })
 
   chrome.sidePanel.onClosed.addListener((info) => {
     if (info.tabId === undefined) {
-      openWindowSidePanelIds.delete(info.windowId)
+      rememberWindowSidePanelClosed(info.windowId)
     }
   })
 }
@@ -96,6 +164,7 @@ export function registerSidePanelOpenStateListeners(): void {
 export async function openSidePanel(
   target: SidePanelTarget,
 ): Promise<SidePanelToggleResult> {
+  await ensureSidePanelRuntimeStateLoaded()
   if (sidePanelPerWindow) {
     return await openWindowSidePanel(target)
   }
@@ -106,6 +175,7 @@ export async function openSidePanel(
 export async function toggleSidePanel(
   target: SidePanelTarget,
 ): Promise<SidePanelToggleResult> {
+  await ensureSidePanelRuntimeStateLoaded()
   if (sidePanelPerWindow) {
     return await toggleWindowSidePanel(target)
   }

--- a/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.ts
@@ -1,24 +1,113 @@
-/**
- * @public
- */
-export async function openSidePanel(
-  tabId: number,
-): Promise<{ opened: boolean }> {
-  // @ts-expect-error browserosIsOpen is a BrowserOS-specific API
+import { getBrowserOSAdapter } from './adapter'
+import { BROWSEROS_PREFS } from './prefs'
+
+const SIDEPANEL_PATH = 'sidepanel.html'
+const openWindowSidePanelIds = new Set<number>()
+let sidePanelPerWindow = false
+let sidePanelOpenStateListenersRegistered = false
+
+type SidePanelTarget = {
+  tabId: number
+  windowId: number
+}
+
+type SidePanelToggleResult = {
+  opened: boolean
+}
+
+/** Applies the cached side panel scope and keeps Chromium's global panel options in sync. */
+export async function setSidePanelPerWindowPreference(
+  perWindow: boolean,
+): Promise<void> {
+  sidePanelPerWindow = perWindow
+  await chrome.sidePanel.setOptions(
+    perWindow ? { enabled: true, path: SIDEPANEL_PATH } : { enabled: false },
+  )
+}
+
+/** Loads the stored side panel scope before user-triggered side panel actions run. */
+export async function refreshSidePanelScopePreference(): Promise<void> {
+  try {
+    const pref = await getBrowserOSAdapter().getPref(
+      BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW,
+    )
+    await setSidePanelPerWindowPreference(pref?.value === true)
+  } catch {
+    await setSidePanelPerWindowPreference(false)
+  }
+}
+
+async function openTabSidePanel({
+  tabId,
+}: SidePanelTarget): Promise<SidePanelToggleResult> {
   const isAlreadyOpen = await chrome.sidePanel.browserosIsOpen({ tabId })
   if (isAlreadyOpen) {
     return { opened: true }
   }
-  // @ts-expect-error browserosToggle is a BrowserOS-specific API
   return await chrome.sidePanel.browserosToggle({ tabId })
 }
 
-/**
- * @public
- */
-export async function toggleSidePanel(
-  tabId: number,
-): Promise<{ opened: boolean }> {
-  // @ts-expect-error browserosToggle is a BrowserOS-specific API
+async function toggleTabSidePanel({
+  tabId,
+}: SidePanelTarget): Promise<SidePanelToggleResult> {
   return await chrome.sidePanel.browserosToggle({ tabId })
+}
+
+async function openWindowSidePanel({
+  windowId,
+}: SidePanelTarget): Promise<SidePanelToggleResult> {
+  if (!openWindowSidePanelIds.has(windowId)) {
+    await chrome.sidePanel.open({ windowId })
+    openWindowSidePanelIds.add(windowId)
+  }
+  return { opened: true }
+}
+
+async function toggleWindowSidePanel(
+  target: SidePanelTarget,
+): Promise<SidePanelToggleResult> {
+  if (openWindowSidePanelIds.has(target.windowId)) {
+    await chrome.sidePanel.close({ windowId: target.windowId })
+    openWindowSidePanelIds.delete(target.windowId)
+    return { opened: false }
+  }
+  return await openWindowSidePanel(target)
+}
+
+/** Tracks standard side panel events so window mode can behave like a toggle. */
+export function registerSidePanelOpenStateListeners(): void {
+  if (sidePanelOpenStateListenersRegistered) return
+  sidePanelOpenStateListenersRegistered = true
+
+  chrome.sidePanel.onOpened.addListener((info) => {
+    if (info.tabId === undefined) {
+      openWindowSidePanelIds.add(info.windowId)
+    }
+  })
+
+  chrome.sidePanel.onClosed.addListener((info) => {
+    if (info.tabId === undefined) {
+      openWindowSidePanelIds.delete(info.windowId)
+    }
+  })
+}
+
+/** Opens the configured side panel scope without closing an already-open panel. */
+export async function openSidePanel(
+  target: SidePanelTarget,
+): Promise<SidePanelToggleResult> {
+  if (sidePanelPerWindow) {
+    return await openWindowSidePanel(target)
+  }
+  return await openTabSidePanel(target)
+}
+
+/** Toggles the configured side panel scope from a toolbar/user gesture. */
+export async function toggleSidePanel(
+  target: SidePanelTarget,
+): Promise<SidePanelToggleResult> {
+  if (sidePanelPerWindow) {
+    return await toggleWindowSidePanel(target)
+  }
+  return await toggleTabSidePanel(target)
 }

--- a/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.ts
@@ -160,14 +160,11 @@ export function registerSidePanelOpenStateListeners(): void {
   })
 }
 
-/** Opens the configured side panel scope without closing an already-open panel. */
+/** Opens from non-toolbar flows that may not carry Chrome's user gesture. */
 export async function openSidePanel(
   target: SidePanelTarget,
 ): Promise<SidePanelToggleResult> {
   await ensureSidePanelRuntimeStateLoaded()
-  if (sidePanelPerWindow) {
-    return await openWindowSidePanel(target)
-  }
   return await openTabSidePanel(target)
 }
 

--- a/packages/browseros-agent/apps/agent/lib/messaging/runtime/runtimeMessages.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/messaging/runtime/runtimeMessages.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import { readFileSync } from 'node:fs'
 import type {
+  RuntimeSidePanelScopeChangedData,
   RuntimeStopAgentData,
   RuntimeTabIdResponse,
 } from './runtimeMessages'
@@ -15,6 +16,9 @@ describe('runtime message protocol', () => {
     expect(source).toContain("getTabId: 'runtime.getTabId'")
     expect(source).toContain("authSuccess: 'runtime.authSuccess'")
     expect(source).toContain("stopAgent: 'runtime.stopAgent'")
+    expect(source).toContain(
+      "sidePanelScopeChanged: 'runtime.sidePanelScopeChanged'",
+    )
     expect(source).not.toContain("'get-tab-id'")
     expect(source).not.toContain("'AUTH_SUCCESS'")
     expect(source).not.toContain("'stop-agent'")
@@ -48,8 +52,12 @@ describe('runtime message protocol', () => {
       conversationId: 'conversation-1',
     } satisfies RuntimeStopAgentData
     const tabId = { tabId: 123 } satisfies RuntimeTabIdResponse
+    const sidePanelScope = {
+      perWindow: true,
+    } satisfies RuntimeSidePanelScopeChangedData
 
     expect(stopAgent.conversationId).toBe('conversation-1')
     expect(tabId.tabId).toBe(123)
+    expect(sidePanelScope.perWindow).toBe(true)
   })
 })

--- a/packages/browseros-agent/apps/agent/lib/messaging/runtime/runtimeMessages.ts
+++ b/packages/browseros-agent/apps/agent/lib/messaging/runtime/runtimeMessages.ts
@@ -4,6 +4,7 @@ export const RuntimeMessageType = {
   getTabId: 'runtime.getTabId',
   authSuccess: 'runtime.authSuccess',
   stopAgent: 'runtime.stopAgent',
+  sidePanelScopeChanged: 'runtime.sidePanelScopeChanged',
 } as const
 
 export interface RuntimeTabIdResponse {
@@ -14,10 +15,17 @@ export interface RuntimeStopAgentData {
   conversationId: string
 }
 
+export interface RuntimeSidePanelScopeChangedData {
+  perWindow: boolean
+}
+
 type RuntimeMessagesProtocol = {
   [RuntimeMessageType.getTabId](): RuntimeTabIdResponse
   [RuntimeMessageType.authSuccess](): void
   [RuntimeMessageType.stopAgent](data: RuntimeStopAgentData): void
+  [RuntimeMessageType.sidePanelScopeChanged](
+    data: RuntimeSidePanelScopeChangedData,
+  ): void
 }
 
 const { sendMessage, onMessage } =

--- a/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.test.tsx
+++ b/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.test.tsx
@@ -114,6 +114,7 @@ function checkFeatureSupport(
 
 let prefValues = new Map<string, unknown>()
 let setPrefCalls: Array<{ name: string; value: unknown }> = []
+let sentRuntimeMessages: Array<{ type: string; data: unknown }> = []
 let renderedSwitches: Array<{
   id?: string
   checked?: boolean
@@ -193,6 +194,15 @@ mock.module('@/lib/browseros/capabilities', () => ({
   resolveStaticFeatureSupport,
 }))
 
+mock.module('@/lib/messaging/runtime/runtimeMessages', () => ({
+  RuntimeMessageType: {
+    sidePanelScopeChanged: 'runtime.sidePanelScopeChanged',
+  },
+  sendRuntimeMessage: async (type: string, data: unknown) => {
+    sentRuntimeMessages.push({ type, data })
+  },
+}))
+
 let ToolbarSettingsCard: FC
 
 beforeAll(async () => {
@@ -203,6 +213,7 @@ beforeAll(async () => {
 beforeEach(() => {
   prefValues = new Map()
   setPrefCalls = []
+  sentRuntimeMessages = []
   renderedSwitches = []
 })
 
@@ -247,6 +258,12 @@ describe('ToolbarSettingsCard', () => {
       {
         name: BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW,
         value: true,
+      },
+    ])
+    expect(sentRuntimeMessages).toEqual([
+      {
+        type: 'runtime.sidePanelScopeChanged',
+        data: { perWindow: true },
       },
     ])
   })

--- a/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.test.tsx
+++ b/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.test.tsx
@@ -1,4 +1,4 @@
-import { beforeAll, describe, expect, it, mock } from 'bun:test'
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
 import { type ComponentProps, createElement, type FC } from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 
@@ -19,6 +19,7 @@ const BROWSEROS_PREFS = {
   RESTART_SERVER: 'browseros.server.restart_requested',
   SHOW_LLM_CHAT: 'browseros.show_llm_chat',
   SHOW_TOOLBAR_LABELS: 'browseros.show_toolbar_labels',
+  SIDE_PANEL_PER_WINDOW: 'browseros.side_panel.per_window',
   VERTICAL_TABS_ENABLED: 'browseros.vertical_tabs_enabled',
   INSTALL_ID: 'browseros.metrics_install_id',
 } as const
@@ -111,10 +112,22 @@ function checkFeatureSupport(
   return false
 }
 
+let prefValues = new Map<string, unknown>()
+let setPrefCalls: Array<{ name: string; value: unknown }> = []
+let renderedSwitches: Array<{
+  id?: string
+  checked?: boolean
+  onCheckedChange?: (checked: boolean) => void
+}> = []
+
 const browserOSAdapter = {
   getBrowserosVersion: async () => null,
   getPref: async (name: string) =>
     new Promise<{ value: unknown } | null>((resolve) => {
+      if (prefValues.has(name)) {
+        resolve({ value: prefValues.get(name) })
+        return
+      }
       const getPref = globalThis.chrome?.browserOS?.getPref
       if (getPref) {
         getPref(name, resolve)
@@ -122,7 +135,11 @@ const browserOSAdapter = {
       }
       resolve(name === BROWSEROS_PREFS.MCP_PORT ? { value: 9105 } : null)
     }),
-  setPref: async () => true,
+  setPref: async (name: string, value: unknown) => {
+    setPrefCalls.push({ name, value })
+    prefValues.set(name, value)
+    return true
+  },
 }
 
 mock.module('sonner', () => ({
@@ -135,12 +152,19 @@ mock.module('@/components/ui/label', () => ({
 }))
 
 mock.module('@/components/ui/switch', () => ({
-  Switch: ({
-    checked: _checked,
-    onCheckedChange: _onCheckedChange,
-    ...props
-  }: SwitchProps) =>
-    createElement('button', { type: 'button', role: 'switch', ...props }),
+  Switch: ({ checked, onCheckedChange, ...props }: SwitchProps) => {
+    renderedSwitches.push({
+      id: typeof props.id === 'string' ? props.id : undefined,
+      checked,
+      onCheckedChange,
+    })
+    return createElement('button', {
+      type: 'button',
+      role: 'switch',
+      'data-checked': String(checked),
+      ...props,
+    })
+  },
 }))
 
 mock.module('@/lib/browseros/adapter', () => ({
@@ -176,8 +200,23 @@ beforeAll(async () => {
     .ToolbarSettingsCard
 })
 
+beforeEach(() => {
+  prefValues = new Map()
+  setPrefCalls = []
+  renderedSwitches = []
+})
+
 function renderCard() {
+  renderedSwitches = []
   return renderToStaticMarkup(createElement(ToolbarSettingsCard))
+}
+
+function getRenderedSwitch(id: string) {
+  const renderedSwitch = renderedSwitches.find((item) => item.id === id)
+  if (!renderedSwitch) {
+    throw new Error(`Missing switch: ${id}`)
+  }
+  return renderedSwitch
 }
 
 describe('ToolbarSettingsCard', () => {
@@ -188,5 +227,27 @@ describe('ToolbarSettingsCard', () => {
     expect(html).toContain('Show Button Labels')
     expect(html).not.toContain('Show Hub Button')
     expect(html).not.toContain('show-llm-hub')
+  })
+
+  it('renders the side panel scope toggle in the default per-tab state', () => {
+    const html = renderCard()
+
+    expect(html).toContain('One Side Panel Per Window')
+    expect(html).toContain('Share the side panel across tabs in this window')
+    expect(html).toContain('id="side-panel-per-window"')
+    expect(getRenderedSwitch('side-panel-per-window').checked).toBe(false)
+  })
+
+  it('persists the side panel scope toggle', async () => {
+    renderCard()
+
+    await getRenderedSwitch('side-panel-per-window').onCheckedChange?.(true)
+
+    expect(setPrefCalls).toEqual([
+      {
+        name: BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW,
+        value: true,
+      },
+    ])
   })
 })

--- a/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.test.tsx
+++ b/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.test.tsx
@@ -115,6 +115,7 @@ function checkFeatureSupport(
 let prefValues = new Map<string, unknown>()
 let setPrefCalls: Array<{ name: string; value: unknown }> = []
 let sentRuntimeMessages: Array<{ type: string; data: unknown }> = []
+let sendRuntimeMessageError: Error | null = null
 let renderedSwitches: Array<{
   id?: string
   checked?: boolean
@@ -200,6 +201,9 @@ mock.module('@/lib/messaging/runtime/runtimeMessages', () => ({
   },
   sendRuntimeMessage: async (type: string, data: unknown) => {
     sentRuntimeMessages.push({ type, data })
+    if (sendRuntimeMessageError) {
+      throw sendRuntimeMessageError
+    }
   },
 }))
 
@@ -214,6 +218,7 @@ beforeEach(() => {
   prefValues = new Map()
   setPrefCalls = []
   sentRuntimeMessages = []
+  sendRuntimeMessageError = null
   renderedSwitches = []
 })
 
@@ -266,5 +271,25 @@ describe('ToolbarSettingsCard', () => {
         data: { perWindow: true },
       },
     ])
+  })
+
+  it('rolls back the side panel scope pref when background application fails', async () => {
+    sendRuntimeMessageError = new Error('No receiver')
+    prefValues.set(BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW, false)
+    renderCard()
+
+    await getRenderedSwitch('side-panel-per-window').onCheckedChange?.(true)
+
+    expect(setPrefCalls).toEqual([
+      {
+        name: BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW,
+        value: true,
+      },
+      {
+        name: BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW,
+        value: false,
+      },
+    ])
+    expect(prefValues.get(BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW)).toBe(false)
   })
 })

--- a/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.tsx
+++ b/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.tsx
@@ -5,6 +5,10 @@ import { Switch } from '@/components/ui/switch'
 import { getBrowserOSAdapter } from '@/lib/browseros/adapter'
 import { Capabilities, Feature } from '@/lib/browseros/capabilities'
 import { BROWSEROS_PREFS } from '@/lib/browseros/prefs'
+import {
+  RuntimeMessageType,
+  sendRuntimeMessage,
+} from '@/lib/messaging/runtime/runtimeMessages'
 
 export const ToolbarSettingsCard: FC = () => {
   const [showLlmChat, setShowLlmChat] = useState(true)
@@ -61,8 +65,23 @@ export const ToolbarSettingsCard: FC = () => {
         throw new Error('Failed to update setting')
       }
       setter(value)
+      return true
     } catch {
       toast.error('Failed to update setting')
+      return false
+    }
+  }
+
+  const handleSidePanelScopeToggle = async (checked: boolean) => {
+    const updated = await handleToggle(
+      BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW,
+      checked,
+      setSidePanelPerWindow,
+    )
+    if (updated) {
+      await sendRuntimeMessage(RuntimeMessageType.sidePanelScopeChanged, {
+        perWindow: checked,
+      }).catch(() => null)
     }
   }
 
@@ -135,13 +154,7 @@ export const ToolbarSettingsCard: FC = () => {
           <Switch
             id="side-panel-per-window"
             checked={sidePanelPerWindow}
-            onCheckedChange={(checked) =>
-              handleToggle(
-                BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW,
-                checked,
-                setSidePanelPerWindow,
-              )
-            }
+            onCheckedChange={handleSidePanelScopeToggle}
             disabled={isLoading}
           />
         </div>

--- a/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.tsx
+++ b/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.tsx
@@ -73,15 +73,30 @@ export const ToolbarSettingsCard: FC = () => {
   }
 
   const handleSidePanelScopeToggle = async (checked: boolean) => {
-    const updated = await handleToggle(
-      BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW,
-      checked,
-      setSidePanelPerWindow,
-    )
-    if (updated) {
+    const adapter = getBrowserOSAdapter()
+    const previous = sidePanelPerWindow
+    let saved = false
+    try {
+      const success = await adapter.setPref(
+        BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW,
+        checked,
+      )
+      if (!success) {
+        throw new Error('Failed to update setting')
+      }
+      saved = true
       await sendRuntimeMessage(RuntimeMessageType.sidePanelScopeChanged, {
         perWindow: checked,
-      }).catch(() => null)
+      })
+      setSidePanelPerWindow(checked)
+    } catch {
+      if (saved) {
+        await adapter
+          .setPref(BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW, previous)
+          .catch(() => null)
+      }
+      setSidePanelPerWindow(previous)
+      toast.error('Failed to update setting')
     }
   }
 

--- a/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.tsx
+++ b/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.tsx
@@ -9,6 +9,7 @@ import { BROWSEROS_PREFS } from '@/lib/browseros/prefs'
 export const ToolbarSettingsCard: FC = () => {
   const [showLlmChat, setShowLlmChat] = useState(true)
   const [showToolbarLabels, setShowToolbarLabels] = useState(true)
+  const [sidePanelPerWindow, setSidePanelPerWindow] = useState(false)
   const [verticalTabsEnabled, setVerticalTabsEnabled] = useState(true)
   const [supportsVerticalTabs, setSupportsVerticalTabs] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
@@ -17,12 +18,15 @@ export const ToolbarSettingsCard: FC = () => {
     const loadPrefs = async () => {
       try {
         const adapter = getBrowserOSAdapter()
-        const [chatPref, labelsPref] = await Promise.all([
-          adapter.getPref(BROWSEROS_PREFS.SHOW_LLM_CHAT),
-          adapter.getPref(BROWSEROS_PREFS.SHOW_TOOLBAR_LABELS),
-        ])
+        const [chatPref, labelsPref, sidePanelPerWindowPref] =
+          await Promise.all([
+            adapter.getPref(BROWSEROS_PREFS.SHOW_LLM_CHAT),
+            adapter.getPref(BROWSEROS_PREFS.SHOW_TOOLBAR_LABELS),
+            adapter.getPref(BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW),
+          ])
         setShowLlmChat(chatPref?.value !== false)
         setShowToolbarLabels(labelsPref?.value !== false)
+        setSidePanelPerWindow(sidePanelPerWindowPref?.value === true)
 
         const hasVerticalTabsSupport = await Capabilities.supports(
           Feature.VERTICAL_TABS_SUPPORT,
@@ -116,8 +120,34 @@ export const ToolbarSettingsCard: FC = () => {
           />
         </div>
 
+        <div className="flex items-center justify-between border-border border-t pt-4">
+          <div className="space-y-0.5">
+            <Label
+              htmlFor="side-panel-per-window"
+              className="font-medium text-sm"
+            >
+              One Side Panel Per Window
+            </Label>
+            <p className="text-muted-foreground text-xs">
+              Share the side panel across tabs in this window
+            </p>
+          </div>
+          <Switch
+            id="side-panel-per-window"
+            checked={sidePanelPerWindow}
+            onCheckedChange={(checked) =>
+              handleToggle(
+                BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW,
+                checked,
+                setSidePanelPerWindow,
+              )
+            }
+            disabled={isLoading}
+          />
+        </div>
+
         {supportsVerticalTabs && (
-          <div className="flex items-center justify-between">
+          <div className="flex items-center justify-between border-border border-t pt-4">
             <div className="space-y-0.5">
               <Label
                 htmlFor="vertical-tabs-enabled"


### PR DESCRIPTION
## Summary
- Add a Customization switch for one side panel per window, stored in `browseros.side_panel.per_window`.
- Route toolbar side panel toggles through BrowserOS tab APIs by default and Chromium window `sidePanel.open/close` when the setting is enabled.
- Keep programmatic/search opens on the BrowserOS API because Chromium `sidePanel.open` requires a live user gesture.
- Persist per-window open state in session storage so service worker restarts preserve toggle semantics.

## Verification
- `bun run --filter @browseros/agent test`
- `bun run lint`
- `bun run typecheck`
- `bun run test:main`
- `bun run build:agent`
- `git diff --check`
