### PR TITLE
fix: store side panel scope in extension storage

### DIFF
--- a/packages/browseros-agent/apps/agent/lib/browseros/prefs.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/prefs.ts
@@ -9,7 +9,6 @@ export const BROWSEROS_PREFS = {
   RESTART_SERVER: 'browseros.server.restart_requested',
   SHOW_LLM_CHAT: 'browseros.show_llm_chat',
   SHOW_TOOLBAR_LABELS: 'browseros.show_toolbar_labels',
-  SIDE_PANEL_PER_WINDOW: 'browseros.side_panel.per_window',
   VERTICAL_TABS_ENABLED: 'browseros.vertical_tabs_enabled',
   INSTALL_ID: 'browseros.metrics_install_id',
 } as const

--- a/packages/browseros-agent/apps/agent/lib/browseros/sidePanelOpenStateStorage.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/sidePanelOpenStateStorage.ts
@@ -1,5 +1,10 @@
 import { storage } from '@wxt-dev/storage'
 
+export const sidePanelPerWindowStorage = storage.defineItem<boolean>(
+  'local:browseros.side_panel.per_window',
+  { fallback: false },
+)
+
 export const openWindowSidePanelIdsStorage = storage.defineItem<number[]>(
   'session:browseros.side_panel.open_window_ids',
   { fallback: [] },

--- a/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.test.ts
@@ -16,14 +16,6 @@ const onClosedListeners: Array<
   (info: chrome.sidePanel.PanelClosedInfo) => void
 > = []
 
-mock.module('./adapter', () => ({
-  getBrowserOSAdapter: () => ({
-    getPref: async () => {
-      throw new Error('side panel scope should use extension storage')
-    },
-  }),
-}))
-
 mock.module('./sidePanelOpenStateStorage', () => ({
   sidePanelPerWindowStorage: {
     getValue: async () => {

--- a/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.test.ts
@@ -1,20 +1,14 @@
 import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
 
-const BROWSEROS_PREFS = {
-  SIDE_PANEL_PER_WINDOW: 'browseros.side_panel.per_window',
-} as const
-
-let prefValues = new Map<string, unknown>()
 let storedOpenWindowIds: number[] = []
+let storedSidePanelPerWindow = false
 let browserosToggleCalls: unknown[] = []
 let browserosIsOpenCalls: unknown[] = []
 let openCalls: unknown[] = []
 let closeCalls: unknown[] = []
 let setOptionsCalls: unknown[] = []
 let browserosIsOpenResult = false
-let getPrefOverride:
-  | ((name: string) => Promise<{ value: unknown } | null>)
-  | null = null
+let getSidePanelPerWindowOverride: (() => Promise<boolean>) | null = null
 const onOpenedListeners: Array<
   (info: chrome.sidePanel.PanelOpenedInfo) => void
 > = []
@@ -22,34 +16,26 @@ const onClosedListeners: Array<
   (info: chrome.sidePanel.PanelClosedInfo) => void
 > = []
 
-const browserOSAdapter = {
-  getPref: async (name: string) => {
-    if (getPrefOverride) {
-      return await getPrefOverride(name)
-    }
-    return prefValues.has(name) ? { value: prefValues.get(name) } : null
-  },
-}
-
-const BrowserOSAdapter = {
-  getInstance: () => browserOSAdapter,
-}
-
-mock.module('@/lib/browseros/adapter', () => ({
-  BrowserOSAdapter,
-  getBrowserOSAdapter: () => browserOSAdapter,
-}))
-
 mock.module('./adapter', () => ({
-  BrowserOSAdapter,
-  getBrowserOSAdapter: () => browserOSAdapter,
-}))
-
-mock.module('@/lib/browseros/prefs', () => ({
-  BROWSEROS_PREFS,
+  getBrowserOSAdapter: () => ({
+    getPref: async () => {
+      throw new Error('side panel scope should use extension storage')
+    },
+  }),
 }))
 
 mock.module('./sidePanelOpenStateStorage', () => ({
+  sidePanelPerWindowStorage: {
+    getValue: async () => {
+      if (getSidePanelPerWindowOverride) {
+        return await getSidePanelPerWindowOverride()
+      }
+      return storedSidePanelPerWindow
+    },
+    setValue: async (perWindow: boolean) => {
+      storedSidePanelPerWindow = perWindow
+    },
+  },
   openWindowSidePanelIdsStorage: {
     getValue: async () => storedOpenWindowIds,
     setValue: async (windowIds: number[]) => {
@@ -75,15 +61,15 @@ beforeAll(async () => {
 })
 
 beforeEach(async () => {
-  prefValues = new Map()
   storedOpenWindowIds = []
+  storedSidePanelPerWindow = false
   browserosToggleCalls = []
   browserosIsOpenCalls = []
   openCalls = []
   closeCalls = []
   setOptionsCalls = []
   browserosIsOpenResult = false
-  getPrefOverride = null
+  getSidePanelPerWindowOverride = null
 
   globalThis.chrome = {
     sidePanel: {
@@ -140,7 +126,7 @@ function fireWindowClosed(windowId: number) {
 
 describe('side panel scope routing', () => {
   it('hydrates window open state before routing a cold-started toggle', async () => {
-    prefValues.set(BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW, true)
+    storedSidePanelPerWindow = true
     storedOpenWindowIds = [3]
 
     const result = await toggleSidePanel({ tabId: 7, windowId: 3 })
@@ -205,8 +191,8 @@ describe('side panel scope routing', () => {
     expect(closeCalls).toEqual([])
   })
 
-  it('refreshes the cached scope from BrowserOS prefs outside the click path', async () => {
-    prefValues.set(BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW, true)
+  it('refreshes the cached scope from extension storage outside the click path', async () => {
+    storedSidePanelPerWindow = true
 
     await refreshSidePanelRuntimeState()
     const result = await toggleSidePanel({ tabId: 7, windowId: 3 })
@@ -217,16 +203,16 @@ describe('side panel scope routing', () => {
   })
 
   it('keeps a newer explicit setting change over a stale refresh result', async () => {
-    let resolvePref: (pref: { value: unknown } | null) => void = () => {}
-    getPrefOverride = async (_name: string) =>
-      new Promise<{ value: unknown } | null>((resolve) => {
-        resolvePref = resolve
+    let resolveStoredValue: (perWindow: boolean) => void = () => {}
+    getSidePanelPerWindowOverride = async () =>
+      new Promise<boolean>((resolve) => {
+        resolveStoredValue = resolve
       })
 
     const refreshPromise = refreshSidePanelRuntimeState()
     await Promise.resolve()
     await setSidePanelPerWindowPreference(true)
-    resolvePref({ value: false })
+    resolveStoredValue(false)
     await refreshPromise
 
     const result = await toggleSidePanel({ tabId: 7, windowId: 3 })

--- a/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.test.ts
@@ -1,7 +1,7 @@
 import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
 
 let storedOpenWindowIds: number[] = []
-let storedSidePanelPerWindow = false
+let storedSidePanelPerWindow: boolean | undefined
 let browserosToggleCalls: unknown[] = []
 let browserosIsOpenCalls: unknown[] = []
 let openCalls: unknown[] = []
@@ -22,7 +22,7 @@ mock.module('./sidePanelOpenStateStorage', () => ({
       if (getSidePanelPerWindowOverride) {
         return await getSidePanelPerWindowOverride()
       }
-      return storedSidePanelPerWindow
+      return storedSidePanelPerWindow ?? false
     },
     setValue: async (perWindow: boolean) => {
       storedSidePanelPerWindow = perWindow
@@ -54,7 +54,7 @@ beforeAll(async () => {
 
 beforeEach(async () => {
   storedOpenWindowIds = []
-  storedSidePanelPerWindow = false
+  storedSidePanelPerWindow = undefined
   browserosToggleCalls = []
   browserosIsOpenCalls = []
   openCalls = []
@@ -128,7 +128,18 @@ describe('side panel scope routing', () => {
     expect(openCalls).toEqual([])
   })
 
-  it('keeps toolbar toggles on the BrowserOS tab-specific API by default', async () => {
+  it('keeps toolbar toggles on the BrowserOS tab-specific API when scope storage is absent', async () => {
+    const result = await toggleSidePanel({ tabId: 7, windowId: 3 })
+
+    expect(result).toEqual({ opened: true })
+    expect(browserosToggleCalls).toEqual([{ tabId: 7 }])
+    expect(openCalls).toEqual([])
+    expect(closeCalls).toEqual([])
+  })
+
+  it('keeps toolbar toggles on the BrowserOS tab-specific API when scope storage is false', async () => {
+    storedSidePanelPerWindow = false
+
     const result = await toggleSidePanel({ tabId: 7, windowId: 3 })
 
     expect(result).toEqual({ opened: true })

--- a/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.ts
@@ -1,6 +1,7 @@
-import { getBrowserOSAdapter } from './adapter'
-import { BROWSEROS_PREFS } from './prefs'
-import { openWindowSidePanelIdsStorage } from './sidePanelOpenStateStorage'
+import {
+  openWindowSidePanelIdsStorage,
+  sidePanelPerWindowStorage,
+} from './sidePanelOpenStateStorage'
 
 const SIDEPANEL_PATH = 'sidepanel.html'
 const openWindowSidePanelIds = new Set<number>()
@@ -44,10 +45,8 @@ async function applySidePanelPerWindowPreference(
 async function loadSidePanelScopePreference(): Promise<void> {
   const epoch = sidePanelScopePreferenceEpoch
   try {
-    const pref = await getBrowserOSAdapter().getPref(
-      BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW,
-    )
-    await applySidePanelPerWindowPreference(pref?.value === true, epoch)
+    const perWindow = await sidePanelPerWindowStorage.getValue()
+    await applySidePanelPerWindowPreference(perWindow, epoch)
   } catch {
     await applySidePanelPerWindowPreference(false, epoch)
   }

--- a/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.test.tsx
+++ b/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.test.tsx
@@ -19,7 +19,6 @@ const BROWSEROS_PREFS = {
   RESTART_SERVER: 'browseros.server.restart_requested',
   SHOW_LLM_CHAT: 'browseros.show_llm_chat',
   SHOW_TOOLBAR_LABELS: 'browseros.show_toolbar_labels',
-  SIDE_PANEL_PER_WINDOW: 'browseros.side_panel.per_window',
   VERTICAL_TABS_ENABLED: 'browseros.vertical_tabs_enabled',
   INSTALL_ID: 'browseros.metrics_install_id',
 } as const
@@ -114,6 +113,8 @@ function checkFeatureSupport(
 
 let prefValues = new Map<string, unknown>()
 let setPrefCalls: Array<{ name: string; value: unknown }> = []
+let sidePanelPerWindowValue = false
+let sidePanelPerWindowWrites: boolean[] = []
 let sentRuntimeMessages: Array<{ type: string; data: unknown }> = []
 let sendRuntimeMessageError: Error | null = null
 let renderedSwitches: Array<{
@@ -180,6 +181,16 @@ mock.module('@/lib/browseros/prefs', () => ({
   BROWSEROS_PREFS,
 }))
 
+mock.module('@/lib/browseros/sidePanelOpenStateStorage', () => ({
+  sidePanelPerWindowStorage: {
+    getValue: async () => sidePanelPerWindowValue,
+    setValue: async (value: boolean) => {
+      sidePanelPerWindowWrites.push(value)
+      sidePanelPerWindowValue = value
+    },
+  },
+}))
+
 mock.module('@/lib/browseros/capabilities', () => ({
   Capabilities: {
     getStaticSupport: () => null,
@@ -217,6 +228,8 @@ beforeAll(async () => {
 beforeEach(() => {
   prefValues = new Map()
   setPrefCalls = []
+  sidePanelPerWindowValue = false
+  sidePanelPerWindowWrites = []
   sentRuntimeMessages = []
   sendRuntimeMessageError = null
   renderedSwitches = []
@@ -259,12 +272,8 @@ describe('ToolbarSettingsCard', () => {
 
     await getRenderedSwitch('side-panel-per-window').onCheckedChange?.(true)
 
-    expect(setPrefCalls).toEqual([
-      {
-        name: BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW,
-        value: true,
-      },
-    ])
+    expect(sidePanelPerWindowWrites).toEqual([true])
+    expect(setPrefCalls).toEqual([])
     expect(sentRuntimeMessages).toEqual([
       {
         type: 'runtime.sidePanelScopeChanged',
@@ -275,21 +284,13 @@ describe('ToolbarSettingsCard', () => {
 
   it('rolls back the side panel scope pref when background application fails', async () => {
     sendRuntimeMessageError = new Error('No receiver')
-    prefValues.set(BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW, false)
+    sidePanelPerWindowValue = false
     renderCard()
 
     await getRenderedSwitch('side-panel-per-window').onCheckedChange?.(true)
 
-    expect(setPrefCalls).toEqual([
-      {
-        name: BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW,
-        value: true,
-      },
-      {
-        name: BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW,
-        value: false,
-      },
-    ])
-    expect(prefValues.get(BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW)).toBe(false)
+    expect(sidePanelPerWindowWrites).toEqual([true, false])
+    expect(setPrefCalls).toEqual([])
+    expect(sidePanelPerWindowValue).toBe(false)
   })
 })

--- a/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.test.tsx
+++ b/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.test.tsx
@@ -193,6 +193,10 @@ mock.module('@/lib/browseros/sidePanelOpenStateStorage', () => ({
       sidePanelPerWindowValue = value
     },
   },
+  openWindowSidePanelIdsStorage: {
+    getValue: async () => [],
+    setValue: async () => {},
+  },
 }))
 
 mock.module('@/lib/browseros/capabilities', () => ({

--- a/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.test.tsx
+++ b/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.test.tsx
@@ -113,6 +113,7 @@ function checkFeatureSupport(
 
 let prefValues = new Map<string, unknown>()
 let setPrefCalls: Array<{ name: string; value: unknown }> = []
+let getPrefError: Error | null = null
 let sidePanelPerWindowValue = false
 let sidePanelPerWindowWrites: boolean[] = []
 let sentRuntimeMessages: Array<{ type: string; data: unknown }> = []
@@ -127,6 +128,9 @@ const browserOSAdapter = {
   getBrowserosVersion: async () => null,
   getPref: async (name: string) =>
     new Promise<{ value: unknown } | null>((resolve) => {
+      if (getPrefError) {
+        throw getPrefError
+      }
       if (prefValues.has(name)) {
         resolve({ value: prefValues.get(name) })
         return
@@ -219,15 +223,18 @@ mock.module('@/lib/messaging/runtime/runtimeMessages', () => ({
 }))
 
 let ToolbarSettingsCard: FC
+let loadToolbarSettingsState: typeof import('./ToolbarSettingsCard').loadToolbarSettingsState
 
 beforeAll(async () => {
-  ToolbarSettingsCard = (await import('./ToolbarSettingsCard'))
-    .ToolbarSettingsCard
+  const module = await import('./ToolbarSettingsCard')
+  ToolbarSettingsCard = module.ToolbarSettingsCard
+  loadToolbarSettingsState = module.loadToolbarSettingsState
 })
 
 beforeEach(() => {
   prefValues = new Map()
   setPrefCalls = []
+  getPrefError = null
   sidePanelPerWindowValue = false
   sidePanelPerWindowWrites = []
   sentRuntimeMessages = []
@@ -249,6 +256,27 @@ function getRenderedSwitch(id: string) {
 }
 
 describe('ToolbarSettingsCard', () => {
+  it('loads side panel scope from extension storage', async () => {
+    sidePanelPerWindowValue = true
+
+    const state = await loadToolbarSettingsState()
+
+    expect(state.sidePanelPerWindow).toBe(true)
+  })
+
+  it('keeps side panel scope when native prefs fail', async () => {
+    sidePanelPerWindowValue = true
+    getPrefError = new Error('native prefs unavailable')
+
+    const state = await loadToolbarSettingsState()
+
+    expect(state.sidePanelPerWindow).toBe(true)
+    expect(state.showLlmChat).toBe(true)
+    expect(state.showToolbarLabels).toBe(true)
+    expect(state.supportsVerticalTabs).toBe(false)
+    expect(state.verticalTabsEnabled).toBe(true)
+  })
+
   it('renders supported toolbar settings without the unsupported Hub control', () => {
     const html = renderCard()
 

--- a/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.tsx
+++ b/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.tsx
@@ -91,12 +91,6 @@ export const ToolbarSettingsCard: FC = () => {
         setSidePanelPerWindow(state.sidePanelPerWindow)
         setVerticalTabsEnabled(state.verticalTabsEnabled)
         setSupportsVerticalTabs(state.supportsVerticalTabs)
-      } catch {
-        setShowLlmChat(true)
-        setShowToolbarLabels(true)
-        setSidePanelPerWindow(false)
-        setVerticalTabsEnabled(true)
-        setSupportsVerticalTabs(false)
       } finally {
         setIsLoading(false)
       }

--- a/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.tsx
+++ b/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.tsx
@@ -11,6 +11,69 @@ import {
   sendRuntimeMessage,
 } from '@/lib/messaging/runtime/runtimeMessages'
 
+export type ToolbarSettingsState = {
+  showLlmChat: boolean
+  showToolbarLabels: boolean
+  sidePanelPerWindow: boolean
+  verticalTabsEnabled: boolean
+  supportsVerticalTabs: boolean
+}
+
+type NativeToolbarSettingsState = Omit<
+  ToolbarSettingsState,
+  'sidePanelPerWindow'
+>
+
+const DEFAULT_NATIVE_TOOLBAR_SETTINGS_STATE: NativeToolbarSettingsState = {
+  showLlmChat: true,
+  showToolbarLabels: true,
+  verticalTabsEnabled: true,
+  supportsVerticalTabs: false,
+}
+
+async function loadNativeToolbarSettingsState(): Promise<NativeToolbarSettingsState> {
+  try {
+    const adapter = getBrowserOSAdapter()
+    const [chatPref, labelsPref] = await Promise.all([
+      adapter.getPref(BROWSEROS_PREFS.SHOW_LLM_CHAT),
+      adapter.getPref(BROWSEROS_PREFS.SHOW_TOOLBAR_LABELS),
+    ])
+    const supportsVerticalTabs = await Capabilities.supports(
+      Feature.VERTICAL_TABS_SUPPORT,
+    )
+    const verticalTabsEnabled = supportsVerticalTabs
+      ? (await adapter.getPref(BROWSEROS_PREFS.VERTICAL_TABS_ENABLED))
+          ?.value !== false
+      : true
+
+    return {
+      showLlmChat: chatPref?.value !== false,
+      showToolbarLabels: labelsPref?.value !== false,
+      verticalTabsEnabled,
+      supportsVerticalTabs,
+    }
+  } catch {
+    return DEFAULT_NATIVE_TOOLBAR_SETTINGS_STATE
+  }
+}
+
+async function loadSidePanelPerWindowSetting(): Promise<boolean> {
+  try {
+    return await sidePanelPerWindowStorage.getValue()
+  } catch {
+    return false
+  }
+}
+
+/** Loads toolbar settings without letting native pref failures reset extension-local side panel scope. */
+export async function loadToolbarSettingsState(): Promise<ToolbarSettingsState> {
+  const [nativeSettings, sidePanelPerWindow] = await Promise.all([
+    loadNativeToolbarSettingsState(),
+    loadSidePanelPerWindowSetting(),
+  ])
+  return { ...nativeSettings, sidePanelPerWindow }
+}
+
 export const ToolbarSettingsCard: FC = () => {
   const [showLlmChat, setShowLlmChat] = useState(true)
   const [showToolbarLabels, setShowToolbarLabels] = useState(true)
@@ -22,28 +85,12 @@ export const ToolbarSettingsCard: FC = () => {
   useEffect(() => {
     const loadPrefs = async () => {
       try {
-        const adapter = getBrowserOSAdapter()
-        const [chatPref, labelsPref, storedSidePanelPerWindow] =
-          await Promise.all([
-            adapter.getPref(BROWSEROS_PREFS.SHOW_LLM_CHAT),
-            adapter.getPref(BROWSEROS_PREFS.SHOW_TOOLBAR_LABELS),
-            sidePanelPerWindowStorage.getValue(),
-          ])
-        setShowLlmChat(chatPref?.value !== false)
-        setShowToolbarLabels(labelsPref?.value !== false)
-        setSidePanelPerWindow(storedSidePanelPerWindow)
-
-        const hasVerticalTabsSupport = await Capabilities.supports(
-          Feature.VERTICAL_TABS_SUPPORT,
-        )
-        setSupportsVerticalTabs(hasVerticalTabsSupport)
-
-        if (hasVerticalTabsSupport) {
-          const verticalTabsPref = await adapter.getPref(
-            BROWSEROS_PREFS.VERTICAL_TABS_ENABLED,
-          )
-          setVerticalTabsEnabled(verticalTabsPref?.value !== false)
-        }
+        const state = await loadToolbarSettingsState()
+        setShowLlmChat(state.showLlmChat)
+        setShowToolbarLabels(state.showToolbarLabels)
+        setSidePanelPerWindow(state.sidePanelPerWindow)
+        setVerticalTabsEnabled(state.verticalTabsEnabled)
+        setSupportsVerticalTabs(state.supportsVerticalTabs)
       } catch {
         setShowLlmChat(true)
         setShowToolbarLabels(true)

--- a/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.tsx
+++ b/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.tsx
@@ -5,6 +5,7 @@ import { Switch } from '@/components/ui/switch'
 import { getBrowserOSAdapter } from '@/lib/browseros/adapter'
 import { Capabilities, Feature } from '@/lib/browseros/capabilities'
 import { BROWSEROS_PREFS } from '@/lib/browseros/prefs'
+import { sidePanelPerWindowStorage } from '@/lib/browseros/sidePanelOpenStateStorage'
 import {
   RuntimeMessageType,
   sendRuntimeMessage,
@@ -22,15 +23,15 @@ export const ToolbarSettingsCard: FC = () => {
     const loadPrefs = async () => {
       try {
         const adapter = getBrowserOSAdapter()
-        const [chatPref, labelsPref, sidePanelPerWindowPref] =
+        const [chatPref, labelsPref, storedSidePanelPerWindow] =
           await Promise.all([
             adapter.getPref(BROWSEROS_PREFS.SHOW_LLM_CHAT),
             adapter.getPref(BROWSEROS_PREFS.SHOW_TOOLBAR_LABELS),
-            adapter.getPref(BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW),
+            sidePanelPerWindowStorage.getValue(),
           ])
         setShowLlmChat(chatPref?.value !== false)
         setShowToolbarLabels(labelsPref?.value !== false)
-        setSidePanelPerWindow(sidePanelPerWindowPref?.value === true)
+        setSidePanelPerWindow(storedSidePanelPerWindow)
 
         const hasVerticalTabsSupport = await Capabilities.supports(
           Feature.VERTICAL_TABS_SUPPORT,
@@ -44,7 +45,11 @@ export const ToolbarSettingsCard: FC = () => {
           setVerticalTabsEnabled(verticalTabsPref?.value !== false)
         }
       } catch {
-        // API not available - use defaults
+        setShowLlmChat(true)
+        setShowToolbarLabels(true)
+        setSidePanelPerWindow(false)
+        setVerticalTabsEnabled(true)
+        setSupportsVerticalTabs(false)
       } finally {
         setIsLoading(false)
       }
@@ -73,17 +78,10 @@ export const ToolbarSettingsCard: FC = () => {
   }
 
   const handleSidePanelScopeToggle = async (checked: boolean) => {
-    const adapter = getBrowserOSAdapter()
     const previous = sidePanelPerWindow
     let saved = false
     try {
-      const success = await adapter.setPref(
-        BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW,
-        checked,
-      )
-      if (!success) {
-        throw new Error('Failed to update setting')
-      }
+      await sidePanelPerWindowStorage.setValue(checked)
       saved = true
       await sendRuntimeMessage(RuntimeMessageType.sidePanelScopeChanged, {
         perWindow: checked,
@@ -91,9 +89,7 @@ export const ToolbarSettingsCard: FC = () => {
       setSidePanelPerWindow(checked)
     } catch {
       if (saved) {
-        await adapter
-          .setPref(BROWSEROS_PREFS.SIDE_PANEL_PER_WINDOW, previous)
-          .catch(() => null)
+        await sidePanelPerWindowStorage.setValue(previous).catch(() => null)
       }
       setSidePanelPerWindow(previous)
       toast.error('Failed to update setting')


### PR DESCRIPTION
## Summary
- moves the side panel scope toggle off the invalid BrowserOS pref and into WXT local extension storage
- keeps background hydration, runtime apply, and rollback behavior wired to the local setting
- adds coverage for true, false, absent, stale refresh, native-pref failure, and rollback cases

## Design
The side panel scope value is now owned by `sidePanelPerWindowStorage` in the side-panel storage module. Background routing hydrates from that storage, while the settings card reads/writes the same local item and only uses native prefs for the settings that actually have native pref backing.

## Test plan
- [x] `bun test apps/agent/lib/browseros/toggleSidePanel.test.ts apps/agent/screens/customization/ToolbarSettingsCard.test.tsx`
- [x] `bun run --filter @browseros/agent test`
- [x] `bun run --filter @browseros/agent typecheck`
- [x] `bun run --filter @browseros/agent lint`
- [x] `rg -n "SIDE_PANEL_PER_WINDOW|browseros\\.side_panel\\.per_window" apps/agent -g '!**/*.test.*'`