### PR TITLE
chore: clarify side panel scope toggle copy

### DIFF
--- a/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.test.tsx
+++ b/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.test.tsx
@@ -293,8 +293,10 @@ describe('ToolbarSettingsCard', () => {
   it('renders the side panel scope toggle in the default per-tab state', () => {
     const html = renderCard()
 
-    expect(html).toContain('One Side Panel Per Window')
-    expect(html).toContain('Share the side panel across tabs in this window')
+    expect(html).toContain('Share Side Panel Across Tabs')
+    expect(html).toContain(
+      'Use one side panel for the whole window instead of a separate one for each tab',
+    )
     expect(html).toContain('id="side-panel-per-window"')
     expect(getRenderedSwitch('side-panel-per-window').checked).toBe(false)
   })

--- a/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.tsx
+++ b/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.tsx
@@ -197,10 +197,11 @@ export const ToolbarSettingsCard: FC = () => {
               htmlFor="side-panel-per-window"
               className="font-medium text-sm"
             >
-              One Side Panel Per Window
+              Share Side Panel Across Tabs
             </Label>
             <p className="text-muted-foreground text-xs">
-              Share the side panel across tabs in this window
+              Use one side panel for the whole window instead of a separate one
+              for each tab
             </p>
           </div>
           <Switch


### PR DESCRIPTION
## What

Rewrites the **name** and **description** of the side panel scope toggle in **Customization → Toolbar Settings** so a non-technical user instantly understands what it does and how the two states differ. Pure copy change — the DOM id (`side-panel-per-window`), state var (`sidePanelPerWindow`), storage key, and all toggle logic are unchanged.

## Before / after

| | Before | After |
|---|---|---|
| **Label** | One Side Panel Per Window | Share Side Panel Across Tabs |
| **Description** | Share the side panel across tabs in this window | Use one side panel for the whole window instead of a separate one for each tab |

## Why

The old copy had three flaws: it led with scope jargon ("per window"), the description only described the ON state, and "this window" implied a window-local setting when it's actually a global preference. The new label leads with the user-visible behavior and is parallel to the sibling toggles ("Show Chat Button", "Show Button Labels", "Use Vertical Tabs"); the new description contrasts **both** states in one plain sentence via "instead of". Direction verified against `toggleSidePanel.ts`: ON (`sidePanelPerWindow = true`) = one window-scoped panel shared across every tab; OFF (default) = each tab controls its own panel.

## Verify

- `cd apps/agent && bun run typecheck` — pass
- `cd apps/agent && bun test screens/customization/ToolbarSettingsCard.test.tsx` — 6 pass, 0 fail (both string assertions updated to the new exact copy)
- `bun run check` (lint, typecheck, fallow, full test suite) — exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)