### PR TITLE
fix: restore bun run check hygiene

### DIFF
--- a/packages/browseros-agent/apps/agent/biome.json
+++ b/packages/browseros-agent/apps/agent/biome.json
@@ -18,7 +18,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "correctness": {
         "noUnusedImports": "error",
         "noUnusedVariables": "error",

--- a/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/toggleSidePanel.ts
@@ -12,12 +12,12 @@ let sidePanelRuntimeStateLoadPromise: Promise<void> | null = null
 let sidePanelScopePreferenceEpoch = 0
 let persistWindowSidePanelOpenStatePromise: Promise<void> = Promise.resolve()
 
-type SidePanelTarget = {
+export type SidePanelTarget = {
   tabId: number
   windowId: number
 }
 
-type SidePanelToggleResult = {
+export type SidePanelToggleResult = {
   opened: boolean
 }
 

--- a/packages/browseros-agent/apps/server/src/agent/acp-instructions/index.ts
+++ b/packages/browseros-agent/apps/server/src/agent/acp-instructions/index.ts
@@ -1,7 +1,0 @@
-/**
- * @license
- * Copyright 2025 BrowserOS
- * SPDX-License-Identifier: AGPL-3.0-or-later
- */
-
-export { ensureWorkspaceInstructionFile } from './ensureInstructionFile'

--- a/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
+++ b/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
@@ -40,7 +40,8 @@ const BUILT_IN_ACP_AGENT_BY_PROVIDER: Record<string, string> = {
   [LLM_PROVIDERS.CODEX]: 'codex',
 }
 
-type EnsureWorkspaceInstructionFile = typeof ensureWorkspaceInstructionFile
+export type EnsureWorkspaceInstructionFile =
+  typeof ensureWorkspaceInstructionFile
 
 let ensureWorkspaceInstructionFileForTesting: EnsureWorkspaceInstructionFile | null =
   null

--- a/packages/browseros-agent/apps/server/src/browser/dom.ts
+++ b/packages/browseros-agent/apps/server/src/browser/dom.ts
@@ -15,21 +15,3 @@ export function parseNodeAttributes(node: CdpNode): Record<string, string> {
   }
   return attrs
 }
-
-export function formatSearchResult(result: DomSearchResult): string {
-  const parts: string[] = []
-
-  let header = `<${result.tag}`
-  for (const [k, v] of Object.entries(result.attributes)) {
-    header += ` ${k}="${esc(v)}"`
-  }
-  header += '>'
-  parts.push(header)
-  parts.push(`  nodeId: ${result.nodeId}`)
-
-  return parts.join('\n')
-}
-
-function esc(s: string): string {
-  return s.replace(/"/g, '\\"')
-}

--- a/packages/browseros-agent/biome.json
+++ b/packages/browseros-agent/biome.json
@@ -17,7 +17,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "correctness": {
         "noUnusedImports": "error",
         "noUnusedVariables": "error"


### PR DESCRIPTION
## Summary
- Migrates Biome configs from deprecated `recommended: true` to `preset: "recommended"`.
- Removes unused Fallow-reported server DOM/ACP instruction surfaces.
- Exports existing public signature types to satisfy Fallow private-type leak checks.

## Design
This keeps the existing root `bun run check` pipeline intact and fixes the repo-owned warnings/issues it reported at their source, without suppressing rules or weakening checks.

## Test plan
- [x] `git diff --check`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run fallow`
- [x] `bun run check`
- [x] Codex local review: clean
