### PR TITLE
chore: raise snapshot and diff inline thresholds

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@v2
         with:
-          version: 2.4.8
+          version: 2.5.0
 
       - name: Run Biome
         run: biome ci .

--- a/packages/browseros-agent/apps/server/src/tools/browser/diff-format.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/diff-format.ts
@@ -2,7 +2,7 @@ import type { SnapshotDiff } from '../../browser/core/snapshot/diff'
 import { writeTempToolOutputFile } from './output-file'
 import { wrapUntrusted } from './trust-boundary'
 
-const MAX_INLINE_DIFF_WORDS = 2_000
+const MAX_INLINE_DIFF_WORDS = 10_000
 const MAX_SAVE_FAILURE_EXCERPT_CHARS = 4_000
 
 export interface FormattedDiff {

--- a/packages/browseros-agent/apps/server/src/tools/browser/snapshot.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/snapshot.ts
@@ -3,7 +3,7 @@ import { defineTool, textResult } from './framework'
 import { writeTempToolOutputFile } from './output-file'
 import { wrapUntrusted } from './trust-boundary'
 
-const LARGE_SNAPSHOT_WORD_THRESHOLD = 5_000
+const LARGE_SNAPSHOT_WORD_THRESHOLD = 15_000
 const LARGE_SNAPSHOT_CHAR_THRESHOLD = 50_000
 
 function countWords(text: string): number {

--- a/packages/browseros-agent/apps/server/tests/tools/browser/framework.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/framework.test.ts
@@ -179,7 +179,7 @@ describe('browser tool framework post-actions', () => {
   it('writes large diff post-actions to a BrowserOS output file', async () => {
     await withBrowserosDir(async () => {
       const largeDiff = Array.from(
-        { length: 2001 },
+        { length: 10001 },
         (_, i) => `word-${i}`,
       ).join(' ')
       const postActionTool = defineTool({
@@ -195,7 +195,7 @@ describe('browser tool framework post-actions', () => {
           diff: async () => ({
             changed: true,
             text: largeDiff,
-            added: 2001,
+            added: 10001,
             removed: 0,
             afterUrl: 'https://example.com/large',
           }),
@@ -212,18 +212,18 @@ describe('browser tool framework post-actions', () => {
 
       expect(result.isError).toBeFalsy()
       expect(text).toContain('[Page 4 diff]')
-      expect(text).toContain('Diff is 2001 words')
+      expect(text).toContain('Diff is 10001 words')
       expect(savedPath).toBeTruthy()
-      expect(text).not.toContain('word-2000')
+      expect(text).not.toContain('word-10000')
       expect(text).not.toContain('[UNTRUSTED_PAGE_CONTENT')
-      expect(readFileSync(savedPath ?? '', 'utf8')).toContain('word-2000')
+      expect(readFileSync(savedPath ?? '', 'utf8')).toContain('word-10000')
     })
   })
 
   it('keeps large diff post-actions visible when output file writes fail', async () => {
     await withBrowserosFile(async () => {
       const largeDiff = Array.from(
-        { length: 2001 },
+        { length: 10001 },
         (_, i) => `word-${i}`,
       ).join(' ')
       const postActionTool = defineTool({
@@ -239,7 +239,7 @@ describe('browser tool framework post-actions', () => {
           diff: async () => ({
             changed: true,
             text: largeDiff,
-            added: 2001,
+            added: 10001,
             removed: 0,
             afterUrl: 'https://example.com/large',
           }),
@@ -259,7 +259,7 @@ describe('browser tool framework post-actions', () => {
       expect(text).toContain('Showing the first')
       expect(text).toContain('[UNTRUSTED_PAGE_CONTENT')
       expect(text).toContain('word-0')
-      expect(text).not.toContain('word-2000')
+      expect(text).not.toContain('word-10000')
     })
   })
 

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -579,10 +579,10 @@ return 'late'
     ])
   })
 
-  it('writes large direct diffs to a BrowserOS output markdown file', async () => {
+  it('returns old-threshold-sized direct diffs inline', async () => {
     await withBrowserosDir(async () => {
       const fake = createFakeServer()
-      const largeDiff = Array.from(
+      const inlineDiff = Array.from(
         { length: 2001 },
         (_, i) => `word-${i}`,
       ).join(' ')
@@ -590,8 +590,65 @@ return 'late'
         observe: () => ({
           diff: async () => ({
             changed: true,
-            text: largeDiff,
+            text: inlineDiff,
             added: 2001,
+            removed: 0,
+            afterUrl: 'https://example.com/large',
+          }),
+        }),
+        pages: {
+          getInfo: () => ({ url: 'https://example.com/large' }),
+        },
+      } as unknown as BrowserSession
+
+      registerBrowserTools(fake.server as never, session)
+
+      const result = await fake.handlers.get('diff')?.({ page: 1 })
+
+      expect(result?.isError).toBeFalsy()
+      const data = result?.structuredContent as
+        | {
+            added: number
+            removed: number
+            wordCount: number
+          }
+        | undefined
+      expect(data).toMatchObject({
+        added: 2001,
+        removed: 0,
+      })
+      expect(JSON.stringify(result?.structuredContent)).not.toContain('path')
+      expect(JSON.stringify(result?.structuredContent)).not.toContain(
+        'writtenToFile',
+      )
+      expect(result?.content).toEqual([
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining('word-2000'),
+        }),
+      ])
+      expect(result?.content).toEqual([
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining('[UNTRUSTED_PAGE_CONTENT'),
+        }),
+      ])
+    })
+  })
+
+  it('writes large direct diffs to a BrowserOS output markdown file', async () => {
+    await withBrowserosDir(async () => {
+      const fake = createFakeServer()
+      const largeDiff = Array.from(
+        { length: 10001 },
+        (_, i) => `word-${i}`,
+      ).join(' ')
+      const session = {
+        observe: () => ({
+          diff: async () => ({
+            changed: true,
+            text: largeDiff,
+            added: 10001,
             removed: 0,
             afterUrl: 'https://example.com/large',
           }),
@@ -618,10 +675,10 @@ return 'late'
           }
         | undefined
       expect(data).toMatchObject({
-        added: 2001,
+        added: 10001,
         removed: 0,
         truncated: true,
-        wordCount: 2001,
+        wordCount: 10001,
         writtenToFile: true,
       })
       const savedPath = data?.path
@@ -630,7 +687,7 @@ return 'late'
       expect(result?.content).toEqual([
         expect.objectContaining({
           type: 'text',
-          text: expect.stringContaining('Diff is 2001 words'),
+          text: expect.stringContaining('Diff is 10001 words'),
         }),
       ])
       expect(result?.content).toEqual([
@@ -642,12 +699,12 @@ return 'late'
       expect(result?.content).toEqual([
         expect.objectContaining({
           type: 'text',
-          text: expect.not.stringContaining('word-2000'),
+          text: expect.not.stringContaining('word-10000'),
         }),
       ])
       const savedContent = readFileSync(savedPath ?? '', 'utf8')
       expect(savedContent).toContain('[UNTRUSTED_PAGE_CONTENT')
-      expect(savedContent).toContain('word-2000')
+      expect(savedContent).toContain('word-10000')
       expect(data?.contentLength).toBe(savedContent.length)
     })
   })
@@ -728,7 +785,7 @@ return 'late'
     await withBrowserosDir(async () => {
       const fake = createFakeServer()
       const largeSnapshot = Array.from(
-        { length: 2001 },
+        { length: 10001 },
         (_, i) => `destination-${i}`,
       ).join(' ')
       const session = {
@@ -776,7 +833,7 @@ return 'late'
           expect.objectContaining({
             type: 'text',
             text: expect.stringContaining(
-              'full current snapshot is 2001 words',
+              'full current snapshot is 10001 words',
             ),
           }),
           expect.objectContaining({
@@ -789,7 +846,7 @@ return 'late'
         expect.arrayContaining([
           expect.objectContaining({
             type: 'text',
-            text: expect.not.stringContaining('destination-2000'),
+            text: expect.not.stringContaining('destination-10000'),
           }),
         ]),
       )
@@ -1126,11 +1183,55 @@ return 'late'
     expect(JSON.stringify(result?.structuredContent)).not.toContain('path')
   })
 
+  it('returns old-threshold-sized snapshots inline', async () => {
+    await withBrowserosDir(async () => {
+      const fake = createFakeServer()
+      const inlineSnapshot = Array.from(
+        { length: 5001 },
+        (_, i) => `node-${i}`,
+      ).join(' ')
+      const session = {
+        observe: () => ({
+          snapshot: async () => ({ text: inlineSnapshot }),
+        }),
+        pages: {
+          getInfo: () => ({ url: 'https://example.com/large' }),
+        },
+      } as unknown as BrowserSession
+      registerBrowserTools(fake.server as never, session)
+
+      const result = await fake.handlers.get('snapshot')?.({ page: 4 })
+
+      expect(result?.isError).toBeFalsy()
+      const data = result?.structuredContent as
+        | {
+            page: number
+          }
+        | undefined
+      expect(data).toMatchObject({
+        page: 4,
+      })
+      expect(JSON.stringify(result?.structuredContent)).not.toContain('path')
+      expect(result?.content).toEqual([
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining('node-5000'),
+        }),
+      ])
+      expect(result?.content).toEqual([
+        expect.objectContaining({
+          type: 'text',
+          text: expect.stringContaining('[UNTRUSTED_PAGE_CONTENT'),
+        }),
+      ])
+    })
+  })
+
   it('writes very large snapshots to a BrowserOS output markdown file', async () => {
     await withBrowserosDir(async () => {
       const fake = createFakeServer()
       const largeSnapshot = Array.from(
-        { length: 5001 },
+        { length: 15001 },
         (_, i) => `node-${i}`,
       ).join(' ')
       const session = {
@@ -1157,7 +1258,7 @@ return 'late'
         | undefined
       expect(data).toMatchObject({
         page: 4,
-        wordCount: 5001,
+        wordCount: 15001,
         writtenToFile: true,
       })
       const savedPath = data?.path
@@ -1181,7 +1282,7 @@ return 'late'
       expect(savedContent).toContain('[UNTRUSTED_PAGE_CONTENT')
       expect(savedContent).toContain('[END_UNTRUSTED_PAGE_CONTENT')
       expect(savedContent).toContain('node-0')
-      expect(savedContent).toContain('node-5000')
+      expect(savedContent).toContain('node-15000')
       expect(data?.contentLength).toBe(savedContent.length)
     })
   })

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -1230,10 +1230,11 @@ return 'late'
   it('writes very large snapshots to a BrowserOS output markdown file', async () => {
     await withBrowserosDir(async () => {
       const fake = createFakeServer()
-      const largeSnapshot = Array.from(
-        { length: 15001 },
-        (_, i) => `node-${i}`,
-      ).join(' ')
+      const largeSnapshot = [
+        ...Array.from({ length: 15000 }, () => 'x'),
+        'last-node',
+      ].join(' ')
+      expect(largeSnapshot.length).toBeLessThan(50_000)
       const session = {
         observe: () => ({
           snapshot: async () => ({ text: largeSnapshot }),
@@ -1281,8 +1282,7 @@ return 'late'
       const savedContent = readFileSync(savedPath ?? '', 'utf8')
       expect(savedContent).toContain('[UNTRUSTED_PAGE_CONTENT')
       expect(savedContent).toContain('[END_UNTRUSTED_PAGE_CONTENT')
-      expect(savedContent).toContain('node-0')
-      expect(savedContent).toContain('node-15000')
+      expect(savedContent).toContain('last-node')
       expect(data?.contentLength).toBe(savedContent.length)
     })
   })


### PR DESCRIPTION
## Summary
- Raise snapshot inline word threshold from 5,000 to 15,000.
- Raise diff inline word threshold from 2,000 to 10,000.
- Add boundary coverage for old-limit inline behavior and new-limit output-file spill behavior.
- Align the Code Quality workflow Biome setup with the package's Biome 2.5.0 config.

## Design
This keeps the existing browser tool formatting flow intact and only changes the two word thresholds. Snapshot char spill behavior and diff save-failure excerpt behavior are unchanged. The CI workflow now installs the same Biome version declared by the package config.

## Test plan
- [x] `bun test apps/server/tests/tools/browser/register.test.ts apps/server/tests/tools/browser/framework.test.ts`
- [x] `bunx biome ci .`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test:main`
- [x] local context-free review, final round clean
