### PR TITLE
feat: share snapshot formatting for post-actions

### DIFF
--- a/packages/browseros-agent/apps/server/src/tools/browser/snapshot-format.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/snapshot-format.ts
@@ -3,6 +3,7 @@ import { wrapUntrusted } from './trust-boundary'
 
 const LARGE_SNAPSHOT_WORD_THRESHOLD = 5_000
 const LARGE_SNAPSHOT_CHAR_THRESHOLD = 50_000
+const MAX_SAVE_FAILURE_EXCERPT_CHARS = 4_000
 
 export interface FormattedSnapshot {
   text: string
@@ -28,23 +29,42 @@ export async function formatSnapshotResult(
     wordCount > LARGE_SNAPSHOT_WORD_THRESHOLD ||
     snapshotText.length > LARGE_SNAPSHOT_CHAR_THRESHOLD
   ) {
-    const path = await writeTempToolOutputFile({
-      toolName: 'snapshot',
-      extension: 'md',
-      content: wrappedSnapshot,
-    })
+    try {
+      const path = await writeTempToolOutputFile({
+        toolName: 'snapshot',
+        extension: 'md',
+        content: wrappedSnapshot,
+      })
 
-    return {
-      text: [
-        `Large snapshot (${wordCount} words, ${contentLength} chars) saved to: ${path}`,
-        'Read the file for the full snapshot and refs.',
-      ].join('\n'),
-      structured: {
-        path,
-        contentLength,
-        wordCount,
-        writtenToFile: true,
-      },
+      return {
+        text: [
+          `Large snapshot (${wordCount} words, ${contentLength} chars) saved to: ${path}`,
+          'Read the file for the full snapshot and refs.',
+        ].join('\n'),
+        structured: {
+          path,
+          contentLength,
+          wordCount,
+          writtenToFile: true,
+        },
+      }
+    } catch (error) {
+      const saveError = error instanceof Error ? error.message : String(error)
+      const excerpt = snapshotText.slice(0, MAX_SAVE_FAILURE_EXCERPT_CHARS)
+      return {
+        text: [
+          `Large snapshot (${wordCount} words, ${contentLength} chars) could not be saved to a BrowserOS output file: ${saveError}`,
+          `Showing the first ${excerpt.length} chars instead:`,
+          wrapUntrusted(excerpt, origin),
+        ].join('\n'),
+        structured: {
+          contentLength,
+          wordCount,
+          writtenToFile: false,
+          outputWriteFailed: true,
+          error: saveError,
+        },
+      }
     }
   }
 

--- a/packages/browseros-agent/apps/server/src/tools/browser/snapshot-format.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/snapshot-format.ts
@@ -1,0 +1,52 @@
+import { writeTempToolOutputFile } from './output-file'
+import { wrapUntrusted } from './trust-boundary'
+
+const LARGE_SNAPSHOT_WORD_THRESHOLD = 5_000
+const LARGE_SNAPSHOT_CHAR_THRESHOLD = 50_000
+
+export interface FormattedSnapshot {
+  text: string
+  structured?: Record<string, unknown>
+}
+
+function countWords(text: string): number {
+  const trimmed = text.trim()
+  return trimmed ? trimmed.split(/\s+/).length : 0
+}
+
+/** Formats page snapshots for direct tools and automatic post-action readback. */
+export async function formatSnapshotResult(
+  snapshot: string,
+  origin: string,
+): Promise<FormattedSnapshot> {
+  const snapshotText = snapshot || '(empty page)'
+  const wordCount = countWords(snapshot)
+  const wrappedSnapshot = wrapUntrusted(snapshotText, origin)
+  const contentLength = wrappedSnapshot.length
+
+  if (
+    wordCount > LARGE_SNAPSHOT_WORD_THRESHOLD ||
+    snapshotText.length > LARGE_SNAPSHOT_CHAR_THRESHOLD
+  ) {
+    const path = await writeTempToolOutputFile({
+      toolName: 'snapshot',
+      extension: 'md',
+      content: wrappedSnapshot,
+    })
+
+    return {
+      text: [
+        `Large snapshot (${wordCount} words, ${contentLength} chars) saved to: ${path}`,
+        'Read the file for the full snapshot and refs.',
+      ].join('\n'),
+      structured: {
+        path,
+        contentLength,
+        wordCount,
+        writtenToFile: true,
+      },
+    }
+  }
+
+  return { text: wrappedSnapshot }
+}

--- a/packages/browseros-agent/apps/server/src/tools/browser/snapshot.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/snapshot.ts
@@ -1,15 +1,6 @@
 import { z } from 'zod'
 import { defineTool, textResult } from './framework'
-import { writeTempToolOutputFile } from './output-file'
-import { wrapUntrusted } from './trust-boundary'
-
-const LARGE_SNAPSHOT_WORD_THRESHOLD = 5_000
-const LARGE_SNAPSHOT_CHAR_THRESHOLD = 50_000
-
-function countWords(text: string): number {
-  const trimmed = text.trim()
-  return trimmed ? trimmed.split(/\s+/).length : 0
-}
+import { formatSnapshotResult } from './snapshot-format'
 
 export const snapshot = defineTool({
   name: 'snapshot',
@@ -22,38 +13,10 @@ export const snapshot = defineTool({
   handler: async (args, ctx) => {
     const { text } = await ctx.session.observe(args.page).snapshot()
     const origin = ctx.session.pages.getInfo(args.page)?.url ?? 'unknown'
-    const snapshotText = text || '(empty page)'
-    const wordCount = countWords(text)
-    const wrappedSnapshot = wrapUntrusted(snapshotText, origin)
-    const contentLength = wrappedSnapshot.length
-
-    if (
-      wordCount > LARGE_SNAPSHOT_WORD_THRESHOLD ||
-      snapshotText.length > LARGE_SNAPSHOT_CHAR_THRESHOLD
-    ) {
-      const path = await writeTempToolOutputFile({
-        toolName: 'snapshot',
-        extension: 'md',
-        content: wrappedSnapshot,
-      })
-
-      return textResult(
-        [
-          `Large snapshot (${wordCount} words, ${contentLength} chars) saved to: ${path}`,
-          'Read the file for the full snapshot and refs.',
-        ].join('\n'),
-        {
-          page: args.page,
-          path,
-          contentLength,
-          wordCount,
-          writtenToFile: true,
-        },
-      )
-    }
-
-    return textResult(wrappedSnapshot, {
+    const formatted = await formatSnapshotResult(text, origin)
+    return textResult(formatted.text, {
       page: args.page,
+      ...formatted.structured,
     })
   },
 })

--- a/packages/browseros-agent/apps/server/src/tools/response.ts
+++ b/packages/browseros-agent/apps/server/src/tools/response.ts
@@ -3,17 +3,22 @@ import type { Browser } from '../browser/browser'
 import type { BrowserSession } from '../browser/core/session'
 import type { SnapshotDiff } from '../browser/core/snapshot/diff'
 import { formatDiffResult } from './browser/diff-format'
-import { wrapUntrusted } from './browser/trust-boundary'
+import { formatSnapshotResult } from './browser/snapshot-format'
 
 export type ContentItem =
   | { type: 'text'; text: string }
   | { type: 'image'; data: string; mimeType: string }
 
 type PostAction =
-  | { type: 'snapshot'; page: number }
+  | SnapshotPostAction
   | { type: 'screenshot'; page: number }
   | DiffPostAction
   | { type: 'pages' }
+
+type SnapshotPostAction = {
+  type: 'snapshot'
+  page: number
+}
 
 type DiffPostAction = {
   type: 'diff'
@@ -117,7 +122,8 @@ export class ToolResponse {
     switch (action.type) {
       case 'snapshot': {
         const tree = await browser.snapshot(action.page)
-        if (tree) this.text(`[Page ${action.page} snapshot]\n${tree}`)
+        const origin = browser.getPageInfo(action.page)?.url ?? 'unknown'
+        await this.appendSnapshotPostAction(action, tree, origin)
         return
       }
       case 'screenshot': {
@@ -160,9 +166,7 @@ export class ToolResponse {
       case 'snapshot': {
         const { text } = await session.observe(action.page).snapshot()
         const origin = session.pages.getInfo(action.page)?.url ?? 'unknown'
-        this.text(
-          `[Page ${action.page} snapshot]\n${wrapUntrusted(text || '(empty page)', origin)}`,
-        )
+        await this.appendSnapshotPostAction(action, text, origin)
         return
       }
       case 'screenshot': {
@@ -198,6 +202,15 @@ export class ToolResponse {
         return
       }
     }
+  }
+
+  private async appendSnapshotPostAction(
+    action: SnapshotPostAction,
+    snapshot: string,
+    origin: string,
+  ): Promise<void> {
+    const formatted = await formatSnapshotResult(snapshot, origin)
+    this.text(`[Page ${action.page} snapshot]\n${formatted.text}`)
   }
 
   private async appendDiffPostAction(

--- a/packages/browseros-agent/apps/server/tests/tools/browser/framework.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/framework.test.ts
@@ -168,6 +168,43 @@ describe('browser tool framework post-actions', () => {
     })
   })
 
+  it('keeps large snapshot post-actions visible when output file writes fail', async () => {
+    await withBrowserosFile(async () => {
+      const largeSnapshot = Array.from(
+        { length: 5001 },
+        (_, i) => `node-${i}`,
+      ).join(' ')
+      const postActionTool = defineTool({
+        name: 'large_snapshot_post_action_failure_test',
+        description: 'Test failed large snapshot post-action output.',
+        input: z.object({ page: z.number().int() }),
+        handler: async (args, _ctx, response) => {
+          response.includeSnapshot(args.page)
+        },
+      })
+      const session = {
+        observe: () => ({
+          snapshot: async () => ({ text: largeSnapshot }),
+        }),
+        pages: {
+          getInfo: () => ({ url: 'https://example.com/large-snapshot' }),
+          getTabId: () => undefined,
+        },
+      } as unknown as BrowserSession
+
+      const result = await executeTool(postActionTool, { page: 8 }, { session })
+      const text = textOf(result)
+
+      expect(result.isError).toBeFalsy()
+      expect(text).toContain('[Page 8 snapshot]')
+      expect(text).toContain('could not be saved to a BrowserOS output file')
+      expect(text).toContain('Showing the first')
+      expect(text).toContain('[UNTRUSTED_PAGE_CONTENT')
+      expect(text).toContain('node-0')
+      expect(text).not.toContain('node-5000')
+    })
+  })
+
   it('runs diff post-actions through ToolResponse', async () => {
     const events: string[] = []
     const postActionTool = defineTool({

--- a/packages/browseros-agent/apps/server/tests/tools/browser/framework.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/framework.test.ts
@@ -130,6 +130,44 @@ describe('browser tool framework post-actions', () => {
     expect(text).toContain('[END_UNTRUSTED_PAGE_CONTENT')
   })
 
+  it('writes large snapshot post-actions to a BrowserOS output file', async () => {
+    await withBrowserosDir(async () => {
+      const largeSnapshot = Array.from(
+        { length: 5001 },
+        (_, i) => `node-${i}`,
+      ).join(' ')
+      const postActionTool = defineTool({
+        name: 'large_snapshot_post_action_test',
+        description: 'Test large snapshot post-action execution.',
+        input: z.object({ page: z.number().int() }),
+        handler: async (args, _ctx, response) => {
+          response.includeSnapshot(args.page)
+        },
+      })
+      const session = {
+        observe: () => ({
+          snapshot: async () => ({ text: largeSnapshot }),
+        }),
+        pages: {
+          getInfo: () => ({ url: 'https://example.com/large-snapshot' }),
+          getTabId: () => undefined,
+        },
+      } as unknown as BrowserSession
+
+      const result = await executeTool(postActionTool, { page: 8 }, { session })
+      const text = textOf(result)
+      const savedPath = text.match(/saved to: (.+\.md)/)?.[1]
+
+      expect(result.isError).toBeFalsy()
+      expect(text).toContain('[Page 8 snapshot]')
+      expect(text).toContain('Large snapshot (5001 words')
+      expect(savedPath).toBeTruthy()
+      expect(text).not.toContain('node-5000')
+      expect(text).not.toContain('[UNTRUSTED_PAGE_CONTENT')
+      expect(readFileSync(savedPath ?? '', 'utf8')).toContain('node-5000')
+    })
+  })
+
   it('runs diff post-actions through ToolResponse', async () => {
     const events: string[] = []
     const postActionTool = defineTool({

--- a/packages/browseros-agent/apps/server/tests/tools/response.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/response.test.ts
@@ -1,5 +1,8 @@
 import { describe, it } from 'bun:test'
 import assert from 'node:assert'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import type { Browser } from '../../src/browser/browser'
 import { ToolResponse } from '../../src/tools/response'
 
@@ -10,6 +13,22 @@ function textOf(result: {
     .filter((item) => item.type === 'text')
     .map((item) => item.text)
     .join('\n')
+}
+
+async function withBrowserosDir<T>(run: () => Promise<T>): Promise<T> {
+  const previous = process.env.BROWSEROS_DIR
+  const browserosDir = mkdtempSync(join(tmpdir(), 'browseros-response-test-'))
+  process.env.BROWSEROS_DIR = browserosDir
+  try {
+    return await run()
+  } finally {
+    if (previous === undefined) {
+      delete process.env.BROWSEROS_DIR
+    } else {
+      process.env.BROWSEROS_DIR = previous
+    }
+    rmSync(browserosDir, { recursive: true, force: true })
+  }
 }
 
 describe('ToolResponse', () => {
@@ -64,6 +83,7 @@ describe('ToolResponse', () => {
 
     const browser = {
       snapshot: async () => '[42] button "Submit"',
+      getPageInfo: () => ({ url: 'https://example.com/small' }),
     } as unknown as Browser
 
     const result = await response.build(browser)
@@ -72,6 +92,35 @@ describe('ToolResponse', () => {
     assert.ok(text.includes('ok'))
     assert.ok(text.includes('[Page 1 snapshot]'))
     assert.ok(text.includes('[42] button "Submit"'))
+  })
+
+  it('writes large legacy snapshot post-actions to a BrowserOS output file', async () => {
+    await withBrowserosDir(async () => {
+      const response = new ToolResponse({ postActionTimeoutMs: 200 })
+      const largeSnapshot = Array.from(
+        { length: 5001 },
+        (_, i) => `node-${i}`,
+      ).join(' ')
+      response.text('ok')
+      response.includeSnapshot(1)
+
+      const browser = {
+        snapshot: async () => largeSnapshot,
+        getPageInfo: () => ({ url: 'https://example.com/legacy-large' }),
+      } as unknown as Browser
+
+      const result = await response.build(browser)
+      const text = textOf(result)
+      const savedPath = text.match(/saved to: (.+\.md)/)?.[1]
+
+      assert.ok(!result.isError)
+      assert.ok(text.includes('ok'))
+      assert.ok(text.includes('[Page 1 snapshot]'))
+      assert.ok(text.includes('Large snapshot (5001 words'))
+      assert.ok(savedPath)
+      assert.ok(!text.includes('node-5000'))
+      assert.ok(readFileSync(savedPath ?? '', 'utf8').includes('node-5000'))
+    })
   })
 
   it('includes diff output when legacy build receives a diff post-action', async () => {


### PR DESCRIPTION
## Summary
- Extract shared snapshot formatting into `formatSnapshotResult` so the direct `snapshot` tool and snapshot post-actions use the same output path.
- Route both legacy and compact snapshot post-actions through the shared formatter, preserving `[Page N snapshot]` prefixes.
- Add large snapshot post-action coverage, including a save-failure fallback that returns a bounded wrapped excerpt instead of silently dropping context.

## Design
Snapshot formatting now lives beside the browser snapshot tool, matching the existing `formatDiffResult` pattern. Callers still own page-specific response shape, while the formatter owns empty-page fallback, trust-boundary wrapping, large-output file writes, metadata, and save-failure fallback text.

## Test plan
- [x] `bun test apps/server/tests/tools/browser/framework.test.ts --timeout 30000`
- [x] `bun test apps/server/tests/tools/response.test.ts --timeout 30000`
- [x] `bun test apps/server/tests/tools/browser/register.test.ts --timeout 30000`
- [x] `bun run check`