### PR TITLE
feat: stabilize snapshot refs

### DIFF
--- a/packages/browseros-agent/apps/server/src/browser/core/observer/observer.test.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/observer/observer.test.ts
@@ -1,0 +1,245 @@
+import { describe, expect, test } from 'bun:test'
+import type { ProtocolApi } from '@browseros/cdp-protocol/protocol-api'
+import type { PageManager } from '../pages'
+import type { AXNode } from '../snapshot/ax-types'
+import type { FrameRegistry } from './frames'
+import { Observer } from './observer'
+
+function ax(
+  nodeId: string,
+  role: string,
+  opts: Partial<AXNode> & { children?: string[] } = {},
+): AXNode {
+  const { children, ...rest } = opts
+  return {
+    nodeId,
+    role: { type: 'role', value: role },
+    childIds: children,
+    ...rest,
+  }
+}
+
+function name(value: string): AXNode['name'] {
+  return { type: 'computedString', value }
+}
+
+interface StubState {
+  loaderId: string
+  url: string
+  nodes: AXNode[]
+  childLoaderId?: string
+  childNodes?: AXNode[]
+  failAxTree?: boolean
+  onFrameTreeRead?: () => void
+}
+
+function stubObserverHarness(state: StubState): Observer {
+  const session = {
+    Page: {
+      getFrameTree: async () => {
+        state.onFrameTreeRead?.()
+        return {
+          frameTree: {
+            frame: {
+              id: 'main',
+              loaderId: state.loaderId,
+              url: state.url,
+              domainAndRegistry: '',
+              securityOrigin: '',
+              mimeType: 'text/html',
+              secureContextType: 'Secure',
+              crossOriginIsolatedContextType: 'NotIsolated',
+              gatedAPIFeatures: [],
+            },
+            childFrames:
+              state.childLoaderId === undefined
+                ? undefined
+                : [
+                    {
+                      frame: {
+                        id: 'child',
+                        parentId: 'main',
+                        loaderId: state.childLoaderId,
+                        url: `${state.url}frame`,
+                        domainAndRegistry: '',
+                        securityOrigin: '',
+                        mimeType: 'text/html',
+                        secureContextType: 'Secure',
+                        crossOriginIsolatedContextType: 'NotIsolated',
+                        gatedAPIFeatures: [],
+                      },
+                    },
+                  ],
+          },
+        }
+      },
+    },
+    DOM: {
+      describeNode: async () => ({
+        node: { contentDocument: { frameId: 'child' } },
+      }),
+    },
+    Accessibility: {
+      getFullAXTree: async ({ frameId }: { frameId?: string } = {}) => {
+        if (state.failAxTree) throw new Error('AX tree failed')
+        return {
+          nodes: frameId === 'child' ? (state.childNodes ?? []) : state.nodes,
+        }
+      },
+    },
+    Runtime: {
+      evaluate: async () => ({ result: { value: [] } }),
+    },
+  } as unknown as ProtocolApi
+
+  const pages = {
+    getSession: async () => ({ targetId: 'target-1', session, url: state.url }),
+    refresh: async () => ({ url: state.url }),
+  } as unknown as PageManager
+
+  const frames = {
+    resolveFrameTarget: (_pageId: number, frameId?: string) => ({
+      session,
+      axParams: frameId === undefined ? {} : { frameId },
+    }),
+  } as unknown as FrameRegistry
+
+  return new Observer(pages, frames, 1)
+}
+
+describe('Observer stable refs', () => {
+  test('diff keeps unchanged same-document nodes matched after insertion', async () => {
+    const state = {
+      loaderId: 'loader-1',
+      url: 'https://example.com/',
+      nodes: [
+        ax('1', 'RootWebArea', { children: ['2', '3'] }),
+        ax('2', 'button', { name: name('A'), backendDOMNodeId: 1 }),
+        ax('3', 'link', { name: name('B'), backendDOMNodeId: 2 }),
+      ],
+    }
+    const observer = stubObserverHarness(state)
+
+    await observer.snapshot()
+    state.nodes = [
+      ax('1', 'RootWebArea', { children: ['4', '2', '3'] }),
+      ax('4', 'button', { name: name('X'), backendDOMNodeId: 3 }),
+      ax('2', 'button', { name: name('A'), backendDOMNodeId: 1 }),
+      ax('3', 'link', { name: name('B'), backendDOMNodeId: 2 }),
+    ]
+
+    const diff = await observer.diff()
+
+    expect(diff.added).toBe(1)
+    expect(diff.removed).toBe(0)
+    expect(diff.text).toContain('+ button "X" [ref=e3]')
+    expect(diff.text).toContain('1 added, 0 removed')
+  })
+
+  test('reload resets the public ref namespace', async () => {
+    const state = {
+      loaderId: 'loader-1',
+      url: 'https://example.com/',
+      nodes: [
+        ax('1', 'RootWebArea', { children: ['2', '3'] }),
+        ax('2', 'button', { name: name('A'), backendDOMNodeId: 1 }),
+        ax('3', 'button', { name: name('B'), backendDOMNodeId: 2 }),
+      ],
+    }
+    const observer = stubObserverHarness(state)
+
+    await observer.snapshot()
+    state.loaderId = 'loader-2'
+    state.nodes = [
+      ax('1', 'RootWebArea', { children: ['4'] }),
+      ax('4', 'button', { name: name('Reloaded'), backendDOMNodeId: 10 }),
+    ]
+
+    const snapshot = await observer.snapshot()
+
+    expect(snapshot.text).toBe('- button "Reloaded" [ref=e1]')
+  })
+
+  test('same-document navigation resets the public ref namespace', async () => {
+    const state = {
+      loaderId: 'loader-1',
+      url: 'https://example.com/one',
+      nodes: [
+        ax('1', 'RootWebArea', { children: ['2', '3'] }),
+        ax('2', 'button', { name: name('A'), backendDOMNodeId: 1 }),
+        ax('3', 'button', { name: name('B'), backendDOMNodeId: 2 }),
+      ],
+    }
+    const observer = stubObserverHarness(state)
+
+    await observer.snapshot()
+    state.url = 'https://example.com/two'
+    state.nodes = [
+      ax('1', 'RootWebArea', { children: ['4'] }),
+      ax('4', 'button', { name: name('Navigated'), backendDOMNodeId: 10 }),
+    ]
+
+    const snapshot = await observer.snapshot()
+
+    expect(snapshot.text).toBe('- button "Navigated" [ref=e1]')
+  })
+
+  test('failed captures do not replace the last committed refs', async () => {
+    const state = {
+      loaderId: 'loader-1',
+      url: 'https://example.com/',
+      nodes: [
+        ax('1', 'RootWebArea', { children: ['2'] }),
+        ax('2', 'button', { name: name('A'), backendDOMNodeId: 1 }),
+      ],
+      failAxTree: false,
+    }
+    const observer = stubObserverHarness(state)
+
+    await observer.snapshot()
+    state.failAxTree = true
+
+    await expect(observer.snapshot()).rejects.toThrow('AX tree failed')
+    expect(observer.lastRefs.get('e1')).toMatchObject({
+      backendNodeId: 1,
+      name: 'A',
+    })
+  })
+
+  test('child-frame document churn falls back without failing the page capture', async () => {
+    const state = {
+      loaderId: 'loader-1',
+      childLoaderId: 'child-loader-1',
+      url: 'https://example.com/',
+      nodes: [
+        ax('1', 'RootWebArea', { children: ['2', '3'] }),
+        ax('2', 'button', { name: name('Outer'), backendDOMNodeId: 1 }),
+        ax('3', 'Iframe', { backendDOMNodeId: 2 }),
+      ],
+      childNodes: [
+        ax('child-root', 'RootWebArea', { children: ['child-button'] }),
+        ax('child-button', 'button', {
+          name: name('Inner'),
+          backendDOMNodeId: 1,
+        }),
+      ],
+      onFrameTreeRead: undefined as (() => void) | undefined,
+    }
+    let frameTreeReads = 0
+    state.onFrameTreeRead = () => {
+      frameTreeReads++
+      if (frameTreeReads === 2) state.childLoaderId = 'child-loader-2'
+    }
+    const observer = stubObserverHarness(state)
+
+    const snapshot = await observer.snapshot()
+
+    expect(snapshot.text).toBe(
+      [
+        '- button "Outer" [ref=e1]',
+        '- iframe',
+        '  - button "Inner" [ref=e2]',
+      ].join('\n'),
+    )
+  })
+})

--- a/packages/browseros-agent/apps/server/src/browser/core/observer/observer.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/observer/observer.ts
@@ -2,7 +2,7 @@ import type { ProtocolApi } from '@browseros/cdp-protocol/protocol-api'
 import type { FrameId } from '../connection'
 import type { PageManager } from '../pages'
 import { diffSnapshotObservations, type SnapshotDiff } from '../snapshot/diff'
-import { RefMap } from '../snapshot/refs'
+import { type DocumentId, RefMap } from '../snapshot/refs'
 import { renderSnapshot } from '../snapshot/render'
 import { fetchAxTree } from './ax-tree'
 import { findCursorHits } from './cursor-augment'
@@ -18,10 +18,36 @@ export interface SnapshotResult {
   url: string
 }
 
+interface MainFrameState {
+  url: string
+  documentId?: DocumentId
+  frameDocuments: Map<FrameId | undefined, DocumentId>
+}
+
+interface RefScope {
+  documentId: DocumentId
+  url: string
+}
+
+interface CaptureResult extends SnapshotResult {
+  scope?: RefScope
+}
+
+interface FrameTreeNode {
+  frame: {
+    id: FrameId
+    loaderId?: string
+    url?: string
+    urlFragment?: string
+  }
+  childFrames?: FrameTreeNode[]
+}
+
 /** Per-page snapshot, ref, and diff state for one BrowserOS page id. */
 export class Observer {
   private baseline?: { text: string; url: string }
   private refs = new RefMap()
+  private refScope?: RefScope
 
   constructor(
     private readonly pages: PageManager,
@@ -60,17 +86,25 @@ export class Observer {
     return resolveRefEntry(session, entry, axParams)
   }
 
-  private async capture(): Promise<SnapshotResult> {
+  private async capture(): Promise<CaptureResult> {
     const pageSession = await this.pages.getSession(this.pageId)
     for (let attempt = 0; attempt < MAX_STABLE_CAPTURE_ATTEMPTS; attempt++) {
-      const beforeUrl = await this.readCurrentUrl(pageSession.session)
-      const refs = new RefMap()
-      const text = await this.captureFrame(undefined, refs, 0, new Set())
-      const afterUrl = await this.readCurrentUrl(pageSession.session)
-      if (!knownUrlsDiffer(beforeUrl, afterUrl))
-        return { text, refs, url: afterUrl }
+      const before = await this.readMainFrameState(pageSession.session)
+      const refs = this.refsForCapture(before)
+      const text = await this.captureFrame(
+        undefined,
+        refs,
+        0,
+        new Set(),
+        pageSession.session,
+        before.frameDocuments,
+      )
+      const after = await this.readMainFrameState(pageSession.session)
+      if (!knownMainFrameChanged(before, after)) {
+        return { text, refs, url: after.url, scope: refScopeFrom(after) }
+      }
     }
-    throw new Error('Page URL changed during snapshot capture; retry.')
+    throw new Error('Page document changed during snapshot capture; retry.')
   }
 
   /** Render a frame, then splice each child iframe's rendered tree under its `- iframe` line. */
@@ -79,6 +113,8 @@ export class Observer {
     refs: RefMap,
     baseDepth: number,
     visited: Set<FrameId>,
+    rootSession: ProtocolApi,
+    frameDocuments: Map<FrameId | undefined, DocumentId>,
   ): Promise<string> {
     if (frameId !== undefined) {
       if (visited.has(frameId)) return ''
@@ -93,9 +129,15 @@ export class Observer {
     const cursorHits = await findCursorHits(session).catch(
       () => new Map<number, string[]>(),
     )
+    const documentId = await this.stableDocumentIdForFrame(
+      rootSession,
+      frameId,
+      frameDocuments,
+    )
     const { text, iframes } = renderSnapshot(nodes, {
       refs,
       frameId,
+      documentId,
       baseDepth,
       cursorHits,
     })
@@ -114,15 +156,18 @@ export class Observer {
         refs,
         stitch.depth + 1,
         visited,
+        rootSession,
+        frameDocuments,
       ).catch(() => '')
       if (childText) lines.splice(stitch.lineIndex + 1, 0, childText)
     }
     return lines.join('\n')
   }
 
-  private commit(result: SnapshotResult): void {
+  private commit(result: CaptureResult): void {
     this.baseline = { text: result.text, url: result.url }
     this.refs = result.refs
+    this.refScope = result.scope
   }
 
   private async readCurrentUrl(session: ProtocolApi): Promise<string> {
@@ -130,6 +175,54 @@ export class Observer {
       const refreshed = await this.pages.refresh(this.pageId)
       return refreshed?.url
     })
+  }
+
+  private refsForCapture(state: MainFrameState): RefMap {
+    if (shouldResetRefs(this.refScope, state)) return new RefMap()
+    return this.refs.forkForSnapshot()
+  }
+
+  private async readMainFrameState(
+    session: ProtocolApi,
+  ): Promise<MainFrameState> {
+    try {
+      const result = await session.Page.getFrameTree()
+      const tree = result.frameTree as FrameTreeNode
+      return {
+        url: frameUrl(tree.frame),
+        documentId: frameDocumentId(tree.frame),
+        frameDocuments: collectFrameDocuments(tree),
+      }
+    } catch {
+      return {
+        url: await this.readCurrentUrl(session),
+        frameDocuments: new Map(),
+      }
+    }
+  }
+
+  private async stableDocumentIdForFrame(
+    rootSession: ProtocolApi,
+    frameId: FrameId | undefined,
+    frameDocuments: Map<FrameId | undefined, DocumentId>,
+  ): Promise<DocumentId | undefined> {
+    const beforeDocumentId = frameDocuments.get(frameId)
+    if (frameId === undefined || beforeDocumentId === undefined) {
+      return beforeDocumentId
+    }
+
+    const latest = await this.readFrameDocuments(rootSession).catch(
+      () => undefined,
+    )
+    const afterDocumentId = latest?.get(frameId)
+    return afterDocumentId === beforeDocumentId ? beforeDocumentId : undefined
+  }
+
+  private async readFrameDocuments(
+    session: ProtocolApi,
+  ): Promise<Map<FrameId | undefined, DocumentId>> {
+    const result = await session.Page.getFrameTree()
+    return collectFrameDocuments(result.frameTree as FrameTreeNode)
   }
 }
 
@@ -154,6 +247,61 @@ function knownUrlsDiffer(beforeUrl: string, afterUrl: string): boolean {
   return (
     beforeUrl !== 'unknown' && afterUrl !== 'unknown' && beforeUrl !== afterUrl
   )
+}
+
+function knownMainFrameChanged(
+  before: MainFrameState,
+  after: MainFrameState,
+): boolean {
+  if (knownUrlsDiffer(before.url, after.url)) return true
+  return (
+    before.documentId !== undefined &&
+    after.documentId !== undefined &&
+    before.documentId !== after.documentId
+  )
+}
+
+function shouldResetRefs(
+  current: RefScope | undefined,
+  next: MainFrameState,
+): boolean {
+  if (current === undefined || next.documentId === undefined) return true
+  if (current.documentId !== next.documentId) return true
+  return knownUrlsDiffer(current.url, next.url)
+}
+
+function refScopeFrom(state: MainFrameState): RefScope | undefined {
+  if (state.documentId === undefined) return undefined
+  return { documentId: state.documentId, url: state.url }
+}
+
+function collectFrameDocuments(
+  tree: FrameTreeNode,
+): Map<FrameId | undefined, DocumentId> {
+  const documents = new Map<FrameId | undefined, DocumentId>()
+
+  function visit(node: FrameTreeNode, isRoot: boolean): void {
+    const documentId = frameDocumentId(node.frame)
+    if (documentId !== undefined) {
+      documents.set(isRoot ? undefined : node.frame.id, documentId)
+      documents.set(node.frame.id, documentId)
+    }
+    for (const child of node.childFrames ?? []) visit(child, false)
+  }
+
+  visit(tree, true)
+  return documents
+}
+
+function frameDocumentId(
+  frame: FrameTreeNode['frame'],
+): DocumentId | undefined {
+  if (frame.loaderId === undefined) return undefined
+  return `${frame.id}:${frame.loaderId}`
+}
+
+function frameUrl(frame: FrameTreeNode['frame']): string {
+  return frame.url ? `${frame.url}${frame.urlFragment ?? ''}` : 'unknown'
 }
 
 /** Resolve an iframe element to the frameId of its embedded document. */

--- a/packages/browseros-agent/apps/server/src/browser/core/snapshot/diff.test.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/snapshot/diff.test.ts
@@ -35,6 +35,22 @@ describe('diffSnapshots', () => {
     expect(d.text).toContain('+   link "About" [ref=e2]')
   })
 
+  test('stable refs turn top insertions into one added line', () => {
+    const before = '- button "A" [ref=e1]\n- link "B" [ref=e2]'
+    const after = [
+      '- button "X" [ref=e3]',
+      '- button "A" [ref=e1]',
+      '- link "B" [ref=e2]',
+    ].join('\n')
+
+    const d = diffSnapshots(before, after)
+
+    expect(d.added).toBe(1)
+    expect(d.removed).toBe(0)
+    expect(d.text).toContain('+ button "X" [ref=e3]')
+    expect(d.text).toContain('1 added, 0 removed')
+  })
+
   test('collapses far-apart context with an ellipsis', () => {
     const before = Array.from({ length: 30 }, (_, i) => `- item ${i}`).join(
       '\n',

--- a/packages/browseros-agent/apps/server/src/browser/core/snapshot/refs.test.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/snapshot/refs.test.ts
@@ -1,0 +1,195 @@
+import { describe, expect, test } from 'bun:test'
+import { RefMap } from './refs'
+
+describe('RefMap', () => {
+  test('reuses refs for the same document backend node across snapshots', () => {
+    const refs = new RefMap()
+
+    const first = refs.mint({
+      documentId: 'main:loader-1',
+      backendNodeId: 1,
+      role: 'button',
+      name: 'A',
+    })
+    const second = refs.mint({
+      documentId: 'main:loader-1',
+      backendNodeId: 2,
+      role: 'link',
+      name: 'B',
+    })
+
+    refs.beginSnapshot()
+
+    const inserted = refs.mint({
+      documentId: 'main:loader-1',
+      backendNodeId: 3,
+      role: 'button',
+      name: 'X',
+    })
+    const firstAgain = refs.mint({
+      documentId: 'main:loader-1',
+      backendNodeId: 1,
+      role: 'button',
+      name: 'A',
+    })
+    const secondAgain = refs.mint({
+      documentId: 'main:loader-1',
+      backendNodeId: 2,
+      role: 'link',
+      name: 'B',
+    })
+
+    expect(firstAgain).toBe(first)
+    expect(secondAgain).toBe(second)
+    expect(inserted).toBe('e3')
+    expect([...refs.byRef.keys()]).toEqual(['e3', 'e1', 'e2'])
+  })
+
+  test('keeps latest-snapshot refs while preserving stable assignments', () => {
+    const refs = new RefMap()
+
+    refs.mint({
+      documentId: 'main:loader-1',
+      backendNodeId: 1,
+      role: 'button',
+      name: 'A',
+    })
+    refs.mint({
+      documentId: 'main:loader-1',
+      backendNodeId: 2,
+      role: 'button',
+      name: 'B',
+    })
+
+    refs.beginSnapshot()
+    const kept = refs.mint({
+      documentId: 'main:loader-1',
+      backendNodeId: 2,
+      role: 'button',
+      name: 'B',
+    })
+
+    expect(kept).toBe('e2')
+    expect(refs.get('e1')).toBeUndefined()
+    expect(refs.get('e2')).toMatchObject({ backendNodeId: 2 })
+  })
+
+  test('resets the public namespace for a new document', () => {
+    const refs = new RefMap()
+
+    expect(
+      refs.mint({
+        documentId: 'main:loader-1',
+        backendNodeId: 10,
+        role: 'button',
+        name: 'Old',
+      }),
+    ).toBe('e1')
+    refs.mint({
+      documentId: 'main:loader-1',
+      backendNodeId: 11,
+      role: 'button',
+      name: 'Second',
+    })
+
+    refs.reset()
+
+    expect(
+      refs.mint({
+        documentId: 'main:loader-2',
+        backendNodeId: 20,
+        role: 'button',
+        name: 'New',
+      }),
+    ).toBe('e1')
+    expect(refs.size).toBe(1)
+  })
+
+  test('uses capture-local traversal order when document identity is unavailable', () => {
+    const refs = new RefMap()
+
+    expect(
+      refs.mint({ backendNodeId: 1, role: 'button', name: 'Fallback' }),
+    ).toBe('e1')
+
+    refs.beginSnapshot()
+
+    expect(
+      refs.mint({ backendNodeId: 2, role: 'button', name: 'Fallback' }),
+    ).toBe('e1')
+  })
+
+  test('scopes backend node identity by frame document', () => {
+    const refs = new RefMap()
+
+    const main = refs.mint({
+      documentId: 'main:loader-1',
+      backendNodeId: 7,
+      role: 'button',
+      name: 'Submit',
+    })
+    const child = refs.mint({
+      documentId: 'child:loader-1',
+      frameId: 'child',
+      backendNodeId: 7,
+      role: 'button',
+      name: 'Submit',
+    })
+
+    refs.beginSnapshot()
+
+    expect(
+      refs.mint({
+        documentId: 'main:loader-1',
+        backendNodeId: 7,
+        role: 'button',
+        name: 'Submit',
+      }),
+    ).toBe(main)
+    expect(
+      refs.mint({
+        documentId: 'child:loader-1',
+        frameId: 'child',
+        backendNodeId: 7,
+        role: 'button',
+        name: 'Submit',
+      }),
+    ).toBe(child)
+    expect(main).not.toBe(child)
+  })
+
+  test('recomputes duplicate nth metadata for each snapshot', () => {
+    const refs = new RefMap()
+
+    refs.mint({
+      documentId: 'main:loader-1',
+      backendNodeId: 1,
+      role: 'button',
+      name: 'OK',
+    })
+    refs.mint({
+      documentId: 'main:loader-1',
+      backendNodeId: 2,
+      role: 'button',
+      name: 'OK',
+    })
+
+    refs.beginSnapshot()
+
+    const second = refs.mint({
+      documentId: 'main:loader-1',
+      backendNodeId: 2,
+      role: 'button',
+      name: 'OK',
+    })
+    const first = refs.mint({
+      documentId: 'main:loader-1',
+      backendNodeId: 1,
+      role: 'button',
+      name: 'OK',
+    })
+
+    expect(refs.get(second)?.nth).toBe(0)
+    expect(refs.get(first)?.nth).toBe(1)
+  })
+})

--- a/packages/browseros-agent/apps/server/src/browser/core/snapshot/refs.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/snapshot/refs.ts
@@ -1,39 +1,82 @@
 export type FrameId = string
+export type DocumentId = string
 
 export interface RefEntry {
   ref: string
   backendNodeId: number
   role: string
   name: string
-  /** Occurrence index of (frameId, role, name) — disambiguates duplicates on re-resolution. */
+  /** Occurrence index of (frameId, role, name), used for stale-node re-resolution. */
   nth: number
-  /** undefined ⇒ main frame. */
   frameId: FrameId | undefined
 }
 
-/**
- * Allocates stable `eN` handles for actionable nodes within one snapshot. All frames of a
- * page share a single RefMap, so refs are globally unique and the agent never sees frame ids.
- *
- * Each entry records (role, name, nth) scoped to its frame so a ref survives DOM churn: when the
- * cached backendNodeId goes stale, the resolver re-queries that frame's AX tree by role+name+nth.
- */
+/** Allocates public `eN` refs while preserving same-document backend-node identity. */
 export class RefMap {
   readonly byRef = new Map<string, RefEntry>()
   private nextRefNum = 1
+  private nextFallbackRefNum = 1
+  private readonly byStableNode = new Map<string, string>()
+  private readonly stableRefs = new Set<string>()
   private readonly nthCounter = new Map<string, number>()
 
+  /** Starts a new snapshot without discarding same-document stable ref assignments. */
+  beginSnapshot(): void {
+    this.byRef.clear()
+    this.nthCounter.clear()
+    this.nextFallbackRefNum = 1
+  }
+
+  /** Returns an isolated working map for a new same-document snapshot capture. */
+  forkForSnapshot(): RefMap {
+    const fork = new RefMap()
+    fork.nextRefNum = this.nextRefNum
+    fork.byStableNode.clear()
+    for (const [key, ref] of this.byStableNode) {
+      fork.byStableNode.set(key, ref)
+    }
+    fork.stableRefs.clear()
+    for (const ref of this.stableRefs) {
+      fork.stableRefs.add(ref)
+    }
+    fork.beginSnapshot()
+    return fork
+  }
+
+  /** Clears all current and stable refs for a new top-level document. */
+  reset(): void {
+    this.byRef.clear()
+    this.byStableNode.clear()
+    this.stableRefs.clear()
+    this.nthCounter.clear()
+    this.nextRefNum = 1
+    this.nextFallbackRefNum = 1
+  }
+
+  /** Returns the public ref for a node and records its latest resolution metadata. */
   mint(node: {
     backendNodeId: number
     role: string
     name: string
+    documentId?: DocumentId
     frameId?: FrameId
   }): string {
     const key = `${node.frameId ?? ''}\u0000${node.role}\u0000${node.name}`
     const nth = this.nthCounter.get(key) ?? 0
     this.nthCounter.set(key, nth + 1)
 
-    const ref = `e${this.nextRefNum++}`
+    const stableKey =
+      node.documentId === undefined
+        ? undefined
+        : stableNodeKey({
+            backendNodeId: node.backendNodeId,
+            documentId: node.documentId,
+            frameId: node.frameId,
+          })
+    const ref =
+      stableKey === undefined
+        ? this.nextFallbackRef()
+        : this.refForStableNode(stableKey)
     this.byRef.set(ref, {
       ref,
       backendNodeId: node.backendNodeId,
@@ -52,4 +95,41 @@ export class RefMap {
   get size(): number {
     return this.byRef.size
   }
+
+  private refForStableNode(key: string): string {
+    const existing = this.byStableNode.get(key)
+    if (existing !== undefined) return existing
+
+    const ref = this.nextRef()
+    this.byStableNode.set(key, ref)
+    this.stableRefs.add(ref)
+    return ref
+  }
+
+  private nextRef(): string {
+    for (;;) {
+      const ref = `e${this.nextRefNum++}`
+      if (!this.isReserved(ref)) return ref
+    }
+  }
+
+  private nextFallbackRef(): string {
+    for (;;) {
+      const ref = `e${this.nextFallbackRefNum++}`
+      if (!this.isReserved(ref)) return ref
+    }
+  }
+
+  private isReserved(ref: string): boolean {
+    if (this.byRef.has(ref)) return true
+    return this.stableRefs.has(ref)
+  }
+}
+
+function stableNodeKey(node: {
+  backendNodeId: number
+  documentId: DocumentId
+  frameId?: FrameId
+}): string {
+  return `${node.documentId}\u0000${node.frameId ?? ''}\u0000${node.backendNodeId}`
 }

--- a/packages/browseros-agent/apps/server/src/browser/core/snapshot/render.test.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/snapshot/render.test.ts
@@ -94,6 +94,40 @@ describe('renderSnapshot', () => {
     })
   })
 
+  test('reuses refs for same-document backend nodes after insertion', () => {
+    const refs = new RefMap()
+    const before: AXNode[] = [
+      ax('1', 'RootWebArea', { children: ['2', '3'] }),
+      ax('2', 'button', { name: name('A'), backendDOMNodeId: 1 }),
+      ax('3', 'link', { name: name('B'), backendDOMNodeId: 2 }),
+    ]
+    const after: AXNode[] = [
+      ax('1', 'RootWebArea', { children: ['4', '2', '3'] }),
+      ax('4', 'button', { name: name('X'), backendDOMNodeId: 3 }),
+      ax('2', 'button', { name: name('A'), backendDOMNodeId: 1 }),
+      ax('3', 'link', { name: name('B'), backendDOMNodeId: 2 }),
+    ]
+
+    const first = renderSnapshot(before, {
+      refs,
+      documentId: 'main:loader-1',
+    })
+    refs.beginSnapshot()
+    const second = renderSnapshot(after, {
+      refs,
+      documentId: 'main:loader-1',
+    })
+
+    expect(first.text).toBe('- button "A" [ref=e1]\n- link "B" [ref=e2]')
+    expect(second.text).toBe(
+      [
+        '- button "X" [ref=e3]',
+        '- button "A" [ref=e1]',
+        '- link "B" [ref=e2]',
+      ].join('\n'),
+    )
+  })
+
   test('marks cursor-augmented non-ARIA nodes actionable', () => {
     const nodes: AXNode[] = [
       ax('1', 'RootWebArea', { children: ['2'] }),

--- a/packages/browseros-agent/apps/server/src/browser/core/snapshot/render.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/snapshot/render.ts
@@ -1,5 +1,5 @@
 import type { AXNode } from './ax-types'
-import type { FrameId, RefMap } from './refs'
+import type { DocumentId, FrameId, RefMap } from './refs'
 import { INTERACTIVE_ROLES, ROOT_ROLES, SKIP_ROLES, VALUE_ROLES } from './roles'
 
 const IFRAME_ROLES: ReadonlySet<string> = new Set(['Iframe', 'iframe'])
@@ -21,21 +21,15 @@ export interface RenderResult {
 export interface RenderOptions {
   /** Shared across all frames of a page so refs form one global namespace. */
   refs: RefMap
-  /** Frame this subtree belongs to; undefined ⇒ main frame. */
   frameId?: FrameId
+  documentId?: DocumentId
   /** backendNodeId → reasons, from the DOM cursor-augmentation pass. */
   cursorHits?: Map<number, string[]>
   /** Extra indent levels to prepend (used when splicing a child frame under its iframe line). */
   baseDepth?: number
 }
 
-/**
- * Renders a CDP accessibility tree into the canonical agent-facing snapshot: an indented
- * semantic tree where every actionable node carries a stable `[ref=eN]` handle and mutates the
- * shared RefMap. Structureless wrappers are dropped so indentation reflects meaning. Iframe
- * nodes are reported as stitch points (their content lives in a child frame) rather than
- * recursed. Pure and deterministic — DOM/CDP-derived signals are injected via opts.
- */
+/** Renders a CDP accessibility tree into the canonical agent-facing snapshot. */
 export function renderSnapshot(
   nodes: AXNode[],
   opts: RenderOptions,
@@ -134,6 +128,7 @@ function formatLine(
       backendNodeId: backendNodeId as number,
       role,
       name,
+      documentId: opts.documentId,
       frameId: opts.frameId,
     })
     line += ` [ref=${ref}]`


### PR DESCRIPTION
## Summary
- Reuse public `eN` snapshot refs for the same backend DOM nodes within a stable document.
- Reset the public ref namespace on top-level navigation, URL changes, reloads, or unavailable document identity.
- Keep diff matching ref-sensitive while preventing insertion-before-existing-node ref cascades.

## Design
`Observer` now owns a committed document/url ref scope and renders each capture into a transactional `RefMap` fork. `RefMap` keeps document-scoped backend-node assignments separate from latest-snapshot resolution metadata, while no-document or unstable child-frame captures fall back to traversal-order refs.

## Test plan
- [x] `bun test apps/server/src/browser/core/snapshot/refs.test.ts apps/server/src/browser/core/snapshot/render.test.ts apps/server/src/browser/core/snapshot/diff.test.ts apps/server/src/browser/core/observer/resolve.test.ts apps/server/src/browser/core/observer/observer.test.ts`
- [x] `bun run check`
- [x] Local adversarial review pass: clean after fixes