### PR TITLE
fix(build): drop claude from server signing

### DIFF
--- a/packages/browseros/build/cli/storage_test.py
+++ b/packages/browseros/build/cli/storage_test.py
@@ -407,17 +407,11 @@ class PackagedAgentCliContractTest(unittest.TestCase):
             f"artifacts/vendor/{resource['source']['key']}"
             for resource in manifest["resources"]
             if resource["source"]["type"] == "r2"
-            and (
-                resource["source"]["key"].startswith("third_party/codex/")
-                or resource["source"]["key"].startswith("third_party/claude-code/")
-            )
+            and resource["source"]["key"].startswith("third_party/codex/")
         }
         expected_keys = {
             f"{storage.CODEX_R2_PREFIX}/{storage._platform_binary_object_name('codex', platform.target)}"
             for platform in storage.CODEX_PLATFORMS
-        } | {
-            f"{storage.CLAUDE_CODE_R2_PREFIX}/{storage._platform_binary_object_name('claude', platform.target)}"
-            for platform in storage.CLAUDE_CODE_PLATFORMS
         }
 
         self.assertEqual(actual_keys, expected_keys)

--- a/packages/browseros/build/common/server_binaries.py
+++ b/packages/browseros/build/common/server_binaries.py
@@ -1,10 +1,5 @@
 #!/usr/bin/env python3
-"""Shared sign metadata for BrowserOS Server binaries.
-
-Consumed by both the Chromium-build signing path (build/modules/sign/) and the
-OTA release path (build/modules/ota/). Adding a new third-party binary here
-means both paths pick it up automatically.
-"""
+"""Shared sign metadata for BrowserOS Server binaries."""
 
 from dataclasses import dataclass
 from pathlib import Path
@@ -13,11 +8,7 @@ from typing import Dict, List, Optional
 
 @dataclass(frozen=True)
 class SignSpec:
-    """Per-binary codesign metadata.
-
-    ``entitlements`` is the filename of the plist under
-    ``resources/entitlements/``; ``None`` means no extra entitlements.
-    """
+    """Per-binary codesign metadata."""
 
     identifier_suffix: str
     options: str
@@ -30,7 +21,6 @@ MACOS_SERVER_BINARIES: Dict[str, SignSpec] = {
     ),
     "bun": SignSpec("bun", "runtime", "browseros-executable-entitlements.plist"),
     "codex": SignSpec("codex", "runtime"),
-    "claude": SignSpec("claude", "runtime"),
     "rg": SignSpec("rg", "runtime"),
 }
 
@@ -38,12 +28,11 @@ MACOS_SERVER_BINARIES: Dict[str, SignSpec] = {
 WINDOWS_SERVER_BINARIES: List[str] = [
     "browseros_server.exe",
     "third_party/codex.exe",
-    "third_party/claude.exe",
 ]
 
 
 def macos_sign_spec_for(binary_path: Path) -> Optional[SignSpec]:
-    """Look up sign metadata by file stem, such as ``codex`` or ``claude``."""
+    """Look up sign metadata by file stem."""
     return MACOS_SERVER_BINARIES.get(binary_path.stem)
 
 

--- a/packages/browseros/build/common/server_binaries_test.py
+++ b/packages/browseros/build/common/server_binaries_test.py
@@ -34,12 +34,13 @@ class MacosServerBinariesTest(unittest.TestCase):
         self.assertIsNone(macos_sign_spec_for(Path("/x/not_a_known_binary")))
 
     def test_agent_cli_entries_use_plain_hardened_runtime(self):
-        for binary in ["codex", "claude"]:
+        for binary in ["codex"]:
             spec = macos_sign_spec_for(Path(f"/x/{binary}"))
             assert spec is not None
             self.assertEqual(spec.identifier_suffix, binary)
             self.assertEqual(spec.options, "runtime")
             self.assertIsNone(spec.entitlements)
+        self.assertIsNone(macos_sign_spec_for(Path("/x/claude")))
 
     def test_lima_is_not_registered_for_signing(self):
         keys = set(MACOS_SERVER_BINARIES.keys())
@@ -71,7 +72,6 @@ class WindowsServerBinariesTest(unittest.TestCase):
 
     def test_windows_includes_agent_cli_entries(self):
         self.assertIn("third_party/codex.exe", WINDOWS_SERVER_BINARIES)
-        self.assertIn("third_party/claude.exe", WINDOWS_SERVER_BINARIES)
 
     def test_expected_windows_binary_paths_joins_root(self):
         root = Path("/tmp/fake/resources/bin")
@@ -87,6 +87,7 @@ class WindowsServerBinariesTest(unittest.TestCase):
             "third_party/podman/win-sshproxy.exe",
             "third_party/bun.exe",
             "third_party/rg.exe",
+            "third_party/claude.exe",
         }
         leftover = forbidden & set(WINDOWS_SERVER_BINARIES)
         self.assertFalse(leftover, f"stale entries still present: {leftover}")

--- a/packages/browseros/build/modules/ota/sign_binary_test.py
+++ b/packages/browseros/build/modules/ota/sign_binary_test.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Tests for OTA binary signing."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from ...common.env import EnvConfig
+from . import sign_binary
+
+
+def _write_exe(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"exe")
+
+
+class SignServerBundleWindowsTest(unittest.TestCase):
+    def test_signs_shipped_windows_binaries_without_claude(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            resources = Path(tmp) / "resources"
+            _write_exe(resources / "bin" / "browseros_server.exe")
+            _write_exe(resources / "bin" / "third_party" / "codex.exe")
+
+            signed = []
+
+            def fake_sign(path, env):
+                signed.append(path.relative_to(resources / "bin").as_posix())
+                return True
+
+            with mock.patch.object(
+                sign_binary, "sign_windows_binary", side_effect=fake_sign
+            ):
+                self.assertTrue(
+                    sign_binary.sign_server_bundle_windows(resources, EnvConfig())
+                )
+
+            self.assertEqual(signed, ["browseros_server.exe", "third_party/codex.exe"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/modules/sign/macos_test.py
+++ b/packages/browseros/build/modules/sign/macos_test.py
@@ -57,7 +57,7 @@ class MacOSSignDiscoveryTest(unittest.TestCase):
             self.assertIn(server_bin / "browseros_server", executables)
             self.assertIn(server_bin / "third_party" / "rg", executables)
             self.assertIn(server_bin / "third_party" / "codex", executables)
-            self.assertIn(server_bin / "third_party" / "claude", executables)
+            self.assertNotIn(server_bin / "third_party" / "claude", executables)
             self.assertNotIn(
                 server_bin / "third_party" / "lima" / "bin" / "limactl",
                 executables,
@@ -256,7 +256,7 @@ class SignComponentPerSliceTest(unittest.TestCase):
     can never satisfy (Apple notarization rejects it)."""
 
     def _make_component(self, tmp):
-        component = Path(tmp) / "claude"
+        component = Path(tmp) / "tool"
         component.write_bytes(b"original-fat")
         component.chmod(0o755)
         return component
@@ -276,7 +276,7 @@ class SignComponentPerSliceTest(unittest.TestCase):
                 ),
             ):
                 ok = sign_component(
-                    component, "Cert", "com.browseros.claude", "runtime"
+                    component, "Cert", "com.browseros.tool", "runtime"
                 )
 
             self.assertTrue(ok)
@@ -287,7 +287,7 @@ class SignComponentPerSliceTest(unittest.TestCase):
                 self.assertIn("--force", cmd)
                 self.assertIn("--timestamp", cmd)
                 self.assertIn("--identifier", cmd)
-                self.assertIn("com.browseros.claude", cmd)
+                self.assertIn("com.browseros.tool", cmd)
                 self.assertIn("--options", cmd)
                 self.assertIn("runtime", cmd)
             thin_calls = [c for c in calls if c[0] == "lipo" and "-thin" in c]
@@ -299,7 +299,7 @@ class SignComponentPerSliceTest(unittest.TestCase):
             self.assertEqual(component.read_bytes(), b"signed-fat")
             self.assertTrue(os.access(component, os.X_OK))
             self.assertEqual(
-                sorted(p.name for p in Path(tmp).iterdir()), ["claude"]
+                sorted(p.name for p in Path(tmp).iterdir()), ["tool"]
             )
 
     def test_symmetric_fat_uses_single_codesign(self):
@@ -388,7 +388,7 @@ class SignComponentPerSliceTest(unittest.TestCase):
             self.assertEqual(component.read_bytes(), b"original-fat")
             self.assertTrue(os.access(component, os.X_OK))
             self.assertEqual(
-                sorted(p.name for p in Path(tmp).iterdir()), ["claude"]
+                sorted(p.name for p in Path(tmp).iterdir()), ["tool"]
             )
 
 
@@ -399,7 +399,7 @@ class VerifySignatureComponentTest(unittest.TestCase):
 
     def _build_app(self, tmp):
         app_path = Path(tmp) / "BrowserOS.app"
-        claude = (
+        codex = (
             app_path
             / "Contents"
             / "Resources"
@@ -408,31 +408,31 @@ class VerifySignatureComponentTest(unittest.TestCase):
             / "resources"
             / "bin"
             / "third_party"
-            / "claude"
+            / "codex"
         )
-        _write_exec(claude)
-        return app_path, claude
+        _write_exec(codex)
+        return app_path, codex
 
     def test_fails_when_component_signature_invalid(self):
         with tempfile.TemporaryDirectory() as tmp:
-            app_path, claude = self._build_app(tmp)
+            app_path, codex = self._build_app(tmp)
             calls = []
 
             def run(cmd, cwd=None, check=True):
                 calls.append(cmd)
-                returncode = 1 if cmd[-1] == str(claude) else 0
+                returncode = 1 if cmd[-1] == str(codex) else 0
                 return _completed(cmd, returncode=returncode)
 
             with mock.patch.object(macos_module, "run_command", run):
                 self.assertFalse(verify_signature(app_path))
 
             self.assertTrue(
-                any(c[0] == "codesign" and c[-1] == str(claude) for c in calls)
+                any(c[0] == "codesign" and c[-1] == str(codex) for c in calls)
             )
 
     def test_passes_and_verifies_each_component(self):
         with tempfile.TemporaryDirectory() as tmp:
-            app_path, claude = self._build_app(tmp)
+            app_path, codex = self._build_app(tmp)
             calls = []
 
             with mock.patch.object(
@@ -442,7 +442,7 @@ class VerifySignatureComponentTest(unittest.TestCase):
 
             self.assertTrue(
                 any(
-                    c[0] == "codesign" and "--verify" in c and c[-1] == str(claude)
+                    c[0] == "codesign" and "--verify" in c and c[-1] == str(codex)
                     for c in calls
                 )
             )

--- a/packages/browseros/build_go/internal/modules/sign/sign_test.go
+++ b/packages/browseros/build_go/internal/modules/sign/sign_test.go
@@ -111,14 +111,13 @@ func TestFindComponentsToSignDiscoversAllCategories(t *testing.T) {
 
 func TestIdentifierForComponent(t *testing.T) {
 	cases := map[string]string{
-		"/x/Sparkle.framework/Versions/B/Autoupdate":      "org.sparkle-project.Autoupdate",
-		"/x/Helpers/chrome_crashpad_handler":              "com.browseros.crashpad_handler",
-		"/x/Helpers/BrowserOS Helper (Renderer).app":      "com.browseros.helper.renderer",
-		"/x/Helpers/BrowserOS Helper (GPU).app":           "com.browseros.helper.gpu",
-		"/x/Frameworks/BrowserOS Framework.framework":     "com.browseros.framework",
-		"/x/Libraries/libEGL.dylib":                       "com.browseros.libEGL",
-		"/x/BrowserOSServer/default/resources/bin/codex":  "com.browseros.codex",
-		"/x/BrowserOSServer/default/resources/bin/claude": "com.browseros.claude",
+		"/x/Sparkle.framework/Versions/B/Autoupdate":     "org.sparkle-project.Autoupdate",
+		"/x/Helpers/chrome_crashpad_handler":             "com.browseros.crashpad_handler",
+		"/x/Helpers/BrowserOS Helper (Renderer).app":     "com.browseros.helper.renderer",
+		"/x/Helpers/BrowserOS Helper (GPU).app":          "com.browseros.helper.gpu",
+		"/x/Frameworks/BrowserOS Framework.framework":    "com.browseros.framework",
+		"/x/Libraries/libEGL.dylib":                      "com.browseros.libEGL",
+		"/x/BrowserOSServer/default/resources/bin/codex": "com.browseros.codex",
 	}
 	for path, want := range cases {
 		if got := IdentifierForComponent(path); got != want {
@@ -370,7 +369,9 @@ func TestWindowsSignValidateAndServerPaths(t *testing.T) {
 	}
 
 	paths := ServerBinaryPaths(ctx.OutDirAbs())
-	if len(paths) != 3 || !strings.HasSuffix(paths[0], "browseros_server.exe") {
+	if len(paths) != 2 ||
+		!strings.HasSuffix(paths[0], "browseros_server.exe") ||
+		!strings.HasSuffix(paths[1], "third_party/codex.exe") {
 		t.Errorf("server paths = %v", paths)
 	}
 	mac := MacOSSign{}
@@ -450,14 +451,14 @@ func sliceHandler(t *testing.T, plistArchs map[string]bool, codesignCode int, ma
 func TestSignComponentAsymmetricFatSignsPerSlice(t *testing.T) {
 	ctx, rec := fixtureCtx(t, macArm)
 	dir := t.TempDir()
-	component := filepath.Join(dir, "claude")
+	component := filepath.Join(dir, "tool")
 	writeFile(t, component, "original-fat")
 	if err := os.Chmod(component, 0o755); err != nil {
 		t.Fatal(err)
 	}
 	rec.Handler = sliceHandler(t, map[string]bool{"arm64": true}, 0, true)
 
-	if err := signComponent(ctx, component, "Cert", "com.browseros.claude", "runtime", ""); err != nil {
+	if err := signComponent(ctx, component, "Cert", "com.browseros.tool", "runtime", ""); err != nil {
 		t.Fatal(err)
 	}
 
@@ -479,7 +480,7 @@ func TestSignComponentAsymmetricFatSignsPerSlice(t *testing.T) {
 		if args[len(args)-1] == component {
 			t.Errorf("codesign ran on the fat file instead of a thin slice: %v", args)
 		}
-		for _, want := range []string{"--force", "--timestamp", "--identifier", "com.browseros.claude", "--options", "runtime"} {
+		for _, want := range []string{"--force", "--timestamp", "--identifier", "com.browseros.tool", "--options", "runtime"} {
 			if !hasArg(args, want) {
 				t.Errorf("codesign missing %q: %v", want, args)
 			}
@@ -526,7 +527,7 @@ func TestSignComponentSymmetricFatSingleCodesign(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			ctx, rec := fixtureCtx(t, macArm)
 			dir := t.TempDir()
-			component := filepath.Join(dir, "claude")
+			component := filepath.Join(dir, "tool")
 			writeFile(t, component, "original-fat")
 			rec.Handler = sliceHandler(t, plistArchs, 0, true)
 
@@ -556,7 +557,7 @@ func TestSignComponentSymmetricFatSingleCodesign(t *testing.T) {
 func TestSignComponentThinSingleArchSingleCodesign(t *testing.T) {
 	ctx, rec := fixtureCtx(t, macArm)
 	dir := t.TempDir()
-	component := filepath.Join(dir, "claude")
+	component := filepath.Join(dir, "tool")
 	writeFile(t, component, "thin-binary")
 	rec.Handler = func(c execx.Cmd) (execx.Result, error) {
 		if c.Args[0] == "lipo" && c.Args[1] == "-archs" {
@@ -607,7 +608,7 @@ func TestSignComponentNonMachOSingleCodesign(t *testing.T) {
 func TestSignComponentPerSliceCodesignFailureKeepsOriginal(t *testing.T) {
 	ctx, rec := fixtureCtx(t, macArm)
 	dir := t.TempDir()
-	component := filepath.Join(dir, "claude")
+	component := filepath.Join(dir, "tool")
 	writeFile(t, component, "original-fat")
 	rec.Handler = sliceHandler(t, map[string]bool{"arm64": true}, 1, true)
 
@@ -627,39 +628,39 @@ func TestSignComponentPerSliceCodesignFailureKeepsOriginal(t *testing.T) {
 func TestVerifySignatureFailsOnInvalidComponent(t *testing.T) {
 	ctx, rec := fixtureCtx(t, macArm)
 	appPath := filepath.Join(t.TempDir(), "BrowserOS.app")
-	claude := filepath.Join(appPath, "Contents", "Resources", "BrowserOSServer",
-		"default", "resources", "bin", "third_party", "claude")
-	writeExec(t, claude)
+	codex := filepath.Join(appPath, "Contents", "Resources", "BrowserOSServer",
+		"default", "resources", "bin", "third_party", "codex")
+	writeExec(t, codex)
 
 	rec.Handler = func(c execx.Cmd) (execx.Result, error) {
-		if c.Args[0] == "codesign" && c.Args[len(c.Args)-1] == claude {
+		if c.Args[0] == "codesign" && c.Args[len(c.Args)-1] == codex {
 			return execx.Result{Code: 1}, nil
 		}
 		return execx.Result{}, nil
 	}
 	err := VerifySignature(ctx, appPath)
-	if err == nil || !strings.Contains(err.Error(), "claude") {
-		t.Fatalf("want component verification failure naming claude, got %v", err)
+	if err == nil || !strings.Contains(err.Error(), "codex") {
+		t.Fatalf("want component verification failure naming codex, got %v", err)
 	}
 }
 
 func TestVerifySignaturePassesAndChecksEachComponent(t *testing.T) {
 	ctx, rec := fixtureCtx(t, macArm)
 	appPath := filepath.Join(t.TempDir(), "BrowserOS.app")
-	claude := filepath.Join(appPath, "Contents", "Resources", "BrowserOSServer",
-		"default", "resources", "bin", "third_party", "claude")
-	writeExec(t, claude)
+	codex := filepath.Join(appPath, "Contents", "Resources", "BrowserOSServer",
+		"default", "resources", "bin", "third_party", "codex")
+	writeExec(t, codex)
 
 	if err := VerifySignature(ctx, appPath); err != nil {
 		t.Fatal(err)
 	}
 	found := false
 	for _, c := range rec.Cmds {
-		if c.Args[0] == "codesign" && hasArg(c.Args, "--verify") && c.Args[len(c.Args)-1] == claude {
+		if c.Args[0] == "codesign" && hasArg(c.Args, "--verify") && c.Args[len(c.Args)-1] == codex {
 			found = true
 		}
 	}
 	if !found {
-		t.Errorf("claude was not verified: %v", rec.Argv())
+		t.Errorf("codex was not verified: %v", rec.Argv())
 	}
 }

--- a/packages/browseros/build_go/internal/serverbin/serverbin.go
+++ b/packages/browseros/build_go/internal/serverbin/serverbin.go
@@ -21,7 +21,6 @@ var MacOSServerBinaries = map[string]SignSpec{
 	"browseros_server": {"browseros_server", "runtime", "browseros-executable-entitlements.plist"},
 	"bun":              {"bun", "runtime", "browseros-executable-entitlements.plist"},
 	"codex":            {"codex", "runtime", ""},
-	"claude":           {"claude", "runtime", ""},
 	"rg":               {"rg", "runtime", ""},
 }
 
@@ -29,7 +28,6 @@ var MacOSServerBinaries = map[string]SignSpec{
 var WindowsServerBinaries = []string{
 	"browseros_server.exe",
 	"third_party/codex.exe",
-	"third_party/claude.exe",
 }
 
 // MacOSSignSpecFor looks up sign metadata by file stem (e.g. "codex").

--- a/packages/browseros/build_go/internal/serverbin/serverbin_test.go
+++ b/packages/browseros/build_go/internal/serverbin/serverbin_test.go
@@ -1,0 +1,47 @@
+package serverbin
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestMacOSSignSpecForShippedAgentCLIs(t *testing.T) {
+	spec, ok := MacOSSignSpecFor("/x/codex")
+	if !ok {
+		t.Fatal("codex is not registered")
+	}
+	if spec.IdentifierSuffix != "codex" || spec.Options != "runtime" || spec.Entitlements != "" {
+		t.Fatalf("codex spec = %#v", spec)
+	}
+	if _, ok := MacOSSignSpecFor("/x/claude"); ok {
+		t.Fatal("claude should not be registered")
+	}
+}
+
+func TestWindowsServerBinaries(t *testing.T) {
+	wantCodex := false
+	for _, rel := range WindowsServerBinaries {
+		if rel == "third_party/codex.exe" {
+			wantCodex = true
+		}
+		if rel == "third_party/claude.exe" {
+			t.Fatal("claude should not be registered")
+		}
+	}
+	if !wantCodex {
+		t.Fatal("codex is not registered")
+	}
+}
+
+func TestExpectedWindowsBinaryPaths(t *testing.T) {
+	root := filepath.Join("tmp", "resources", "bin")
+	paths := ExpectedWindowsBinaryPaths(root)
+	if len(paths) != len(WindowsServerBinaries) {
+		t.Fatalf("paths = %d, want %d", len(paths), len(WindowsServerBinaries))
+	}
+	for i, rel := range WindowsServerBinaries {
+		if paths[i] != filepath.Join(root, filepath.FromSlash(rel)) {
+			t.Fatalf("paths[%d] = %q, want %q", i, paths[i], filepath.Join(root, filepath.FromSlash(rel)))
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Remove Claude from BrowserOS server binary signing metadata for Python and Go release paths.
- Keep Codex signing expectations intact and update package/storage contract tests for the unshipped Claude CLI.
- Add regression coverage for Windows OTA signing without `third_party/claude.exe`.

## Design
The release signing paths both derive expected Windows server binaries from shared metadata. The fix removes Claude from that shared metadata instead of weakening missing-binary checks, so Windows signing still fails for truly missing shipped binaries while no longer requiring an unshipped Claude executable.

## Test plan
- [x] `uv run python -m unittest discover -s build -p '*_test.py'`
- [x] `go test ./...`