### PR TITLE
fix: use token thresholds for browser output

### DIFF
--- a/packages/browseros-agent/apps/server/src/tools/browser/diff-format.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/diff-format.ts
@@ -1,18 +1,14 @@
 import type { SnapshotDiff } from '../../browser/core/snapshot/diff'
 import { writeTempToolOutputFile } from './output-file'
+import { estimateTextTokens } from './token-estimate'
 import { wrapUntrusted } from './trust-boundary'
 
-const MAX_INLINE_DIFF_WORDS = 10_000
+const MAX_INLINE_DIFF_TOKENS = 10_000
 const MAX_SAVE_FAILURE_EXCERPT_CHARS = 4_000
 
 export interface FormattedDiff {
   text: string
   structured?: Record<string, unknown>
-}
-
-function countWords(text: string): number {
-  const trimmed = text.trim()
-  return trimmed ? trimmed.split(/\s+/).length : 0
 }
 
 /** Formats observer diffs for direct tools and automatic post-action readback. */
@@ -23,8 +19,8 @@ export async function formatDiffResult(
   if (!diff.changed) return { text: 'no change since last snapshot' }
 
   const diffText = diff.text || '(empty page)'
-  const wordCount = countWords(diffText)
   const wrappedDiff = wrapUntrusted(diffText, origin)
+  const tokenEstimate = estimateTextTokens(wrappedDiff)
   const structured = {
     added: diff.added,
     removed: diff.removed,
@@ -35,7 +31,7 @@ export async function formatDiffResult(
     }),
   }
 
-  if (wordCount > MAX_INLINE_DIFF_WORDS) {
+  if (tokenEstimate > MAX_INLINE_DIFF_TOKENS) {
     try {
       const path = await writeTempToolOutputFile({
         toolName: 'diff',
@@ -43,14 +39,14 @@ export async function formatDiffResult(
         content: wrappedDiff,
       })
       const text = diff.urlChanged
-        ? `URL changed; full current snapshot is ${wordCount} words, over the ${MAX_INLINE_DIFF_WORDS}-word inline limit, saved to: ${path}\nRead the file for the full current snapshot.`
-        : `Diff is ${wordCount} words, over the ${MAX_INLINE_DIFF_WORDS}-word inline limit, saved to: ${path}\nRead the file for the full diff.`
+        ? `URL changed; full current snapshot is ${tokenEstimate} estimated tokens, over the ${MAX_INLINE_DIFF_TOKENS}-token inline limit, saved to: ${path}\nRead the file for the full current snapshot.`
+        : `Diff is ${tokenEstimate} estimated tokens, over the ${MAX_INLINE_DIFF_TOKENS}-token inline limit, saved to: ${path}\nRead the file for the full diff.`
       return {
         text,
         structured: {
           ...structured,
           truncated: true,
-          wordCount,
+          tokenEstimate,
           path,
           contentLength: wrappedDiff.length,
           writtenToFile: true,
@@ -60,8 +56,8 @@ export async function formatDiffResult(
       const saveError = error instanceof Error ? error.message : String(error)
       const excerpt = diffText.slice(0, MAX_SAVE_FAILURE_EXCERPT_CHARS)
       const text = diff.urlChanged
-        ? `URL changed; full current snapshot is ${wordCount} words, over the ${MAX_INLINE_DIFF_WORDS}-word inline limit, but saving it to a BrowserOS output file failed: ${saveError}`
-        : `Diff is ${wordCount} words, over the ${MAX_INLINE_DIFF_WORDS}-word inline limit, but saving it to a BrowserOS output file failed: ${saveError}`
+        ? `URL changed; full current snapshot is ${tokenEstimate} estimated tokens, over the ${MAX_INLINE_DIFF_TOKENS}-token inline limit, but saving it to a BrowserOS output file failed: ${saveError}`
+        : `Diff is ${tokenEstimate} estimated tokens, over the ${MAX_INLINE_DIFF_TOKENS}-token inline limit, but saving it to a BrowserOS output file failed: ${saveError}`
       return {
         text: [
           text,
@@ -71,7 +67,7 @@ export async function formatDiffResult(
         structured: {
           ...structured,
           truncated: true,
-          wordCount,
+          tokenEstimate,
           contentLength: wrappedDiff.length,
           writtenToFile: false,
           outputWriteFailed: true,

--- a/packages/browseros-agent/apps/server/src/tools/browser/snapshot-format.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/snapshot-format.ts
@@ -1,18 +1,13 @@
 import { writeTempToolOutputFile } from './output-file'
+import { estimateTextTokens } from './token-estimate'
 import { wrapUntrusted } from './trust-boundary'
 
-const LARGE_SNAPSHOT_WORD_THRESHOLD = 15_000
-const LARGE_SNAPSHOT_CHAR_THRESHOLD = 50_000
+const LARGE_SNAPSHOT_TOKEN_THRESHOLD = 15_000
 const MAX_SAVE_FAILURE_EXCERPT_CHARS = 4_000
 
 export interface FormattedSnapshot {
   text: string
   structured?: Record<string, unknown>
-}
-
-function countWords(text: string): number {
-  const trimmed = text.trim()
-  return trimmed ? trimmed.split(/\s+/).length : 0
 }
 
 /** Formats page snapshots for direct tools and automatic post-action readback. */
@@ -21,14 +16,11 @@ export async function formatSnapshotResult(
   origin: string,
 ): Promise<FormattedSnapshot> {
   const snapshotText = snapshot || '(empty page)'
-  const wordCount = countWords(snapshot)
   const wrappedSnapshot = wrapUntrusted(snapshotText, origin)
   const contentLength = wrappedSnapshot.length
+  const tokenEstimate = estimateTextTokens(wrappedSnapshot)
 
-  if (
-    wordCount > LARGE_SNAPSHOT_WORD_THRESHOLD ||
-    snapshotText.length > LARGE_SNAPSHOT_CHAR_THRESHOLD
-  ) {
+  if (tokenEstimate > LARGE_SNAPSHOT_TOKEN_THRESHOLD) {
     try {
       const path = await writeTempToolOutputFile({
         toolName: 'snapshot',
@@ -38,13 +30,13 @@ export async function formatSnapshotResult(
 
       return {
         text: [
-          `Large snapshot (${wordCount} words, ${contentLength} chars) saved to: ${path}`,
+          `Large snapshot (${tokenEstimate} estimated tokens, ${contentLength} chars) saved to: ${path}`,
           'Read the file for the full snapshot and refs.',
         ].join('\n'),
         structured: {
           path,
           contentLength,
-          wordCount,
+          tokenEstimate,
           writtenToFile: true,
         },
       }
@@ -53,13 +45,13 @@ export async function formatSnapshotResult(
       const excerpt = snapshotText.slice(0, MAX_SAVE_FAILURE_EXCERPT_CHARS)
       return {
         text: [
-          `Large snapshot (${wordCount} words, ${contentLength} chars) could not be saved to a BrowserOS output file: ${saveError}`,
+          `Large snapshot (${tokenEstimate} estimated tokens, ${contentLength} chars) could not be saved to a BrowserOS output file: ${saveError}`,
           `Showing the first ${excerpt.length} chars instead:`,
           wrapUntrusted(excerpt, origin),
         ].join('\n'),
         structured: {
           contentLength,
-          wordCount,
+          tokenEstimate,
           writtenToFile: false,
           outputWriteFailed: true,
           error: saveError,

--- a/packages/browseros-agent/apps/server/src/tools/browser/token-estimate.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/token-estimate.ts
@@ -1,0 +1,6 @@
+const APPROX_CHARS_PER_TOKEN = 3
+
+/** Estimates plain text tokens with the same chars/3 heuristic used by compaction. */
+export function estimateTextTokens(text: string): number {
+  return Math.ceil(text.length / APPROX_CHARS_PER_TOKEN)
+}

--- a/packages/browseros-agent/apps/server/tests/tools/browser/framework.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/framework.test.ts
@@ -132,10 +132,7 @@ describe('browser tool framework post-actions', () => {
 
   it('writes large snapshot post-actions to a BrowserOS output file', async () => {
     await withBrowserosDir(async () => {
-      const largeSnapshot = [
-        ...Array.from({ length: 15000 }, () => 'x'),
-        'last-node',
-      ].join(' ')
+      const largeSnapshot = `${'x '.repeat(23_000)}last-node`
       const postActionTool = defineTool({
         name: 'large_snapshot_post_action_test',
         description: 'Test large snapshot post-action execution.',
@@ -160,7 +157,7 @@ describe('browser tool framework post-actions', () => {
 
       expect(result.isError).toBeFalsy()
       expect(text).toContain('[Page 8 snapshot]')
-      expect(text).toContain('Large snapshot (15001 words')
+      expect(text).toContain('estimated tokens')
       expect(savedPath).toBeTruthy()
       expect(text).not.toContain('last-node')
       expect(text).not.toContain('[UNTRUSTED_PAGE_CONTENT')
@@ -170,10 +167,7 @@ describe('browser tool framework post-actions', () => {
 
   it('keeps large snapshot post-actions visible when output file writes fail', async () => {
     await withBrowserosFile(async () => {
-      const largeSnapshot = [
-        ...Array.from({ length: 15000 }, () => 'x'),
-        'last-node',
-      ].join(' ')
+      const largeSnapshot = `${'x '.repeat(23_000)}last-node`
       const postActionTool = defineTool({
         name: 'large_snapshot_post_action_failure_test',
         description: 'Test failed large snapshot post-action output.',
@@ -253,10 +247,8 @@ describe('browser tool framework post-actions', () => {
 
   it('writes large diff post-actions to a BrowserOS output file', async () => {
     await withBrowserosDir(async () => {
-      const largeDiff = Array.from(
-        { length: 10001 },
-        (_, i) => `word-${i}`,
-      ).join(' ')
+      const lastMarker = 'last-diff-node'
+      const largeDiff = `${'x'.repeat(30_001)}\n${lastMarker}`
       const postActionTool = defineTool({
         name: 'large_diff_post_action_test',
         description: 'Test large diff post-action execution.',
@@ -270,7 +262,7 @@ describe('browser tool framework post-actions', () => {
           diff: async () => ({
             changed: true,
             text: largeDiff,
-            added: 10001,
+            added: 1,
             removed: 0,
             afterUrl: 'https://example.com/large',
           }),
@@ -287,20 +279,18 @@ describe('browser tool framework post-actions', () => {
 
       expect(result.isError).toBeFalsy()
       expect(text).toContain('[Page 4 diff]')
-      expect(text).toContain('Diff is 10001 words')
+      expect(text).toContain('estimated tokens')
       expect(savedPath).toBeTruthy()
-      expect(text).not.toContain('word-10000')
+      expect(text).not.toContain(lastMarker)
       expect(text).not.toContain('[UNTRUSTED_PAGE_CONTENT')
-      expect(readFileSync(savedPath ?? '', 'utf8')).toContain('word-10000')
+      expect(readFileSync(savedPath ?? '', 'utf8')).toContain(lastMarker)
     })
   })
 
   it('keeps large diff post-actions visible when output file writes fail', async () => {
     await withBrowserosFile(async () => {
-      const largeDiff = Array.from(
-        { length: 10001 },
-        (_, i) => `word-${i}`,
-      ).join(' ')
+      const lastMarker = 'last-diff-node'
+      const largeDiff = `${'x'.repeat(30_001)}\n${lastMarker}`
       const postActionTool = defineTool({
         name: 'large_diff_post_action_failure_test',
         description: 'Test failed large diff post-action output.',
@@ -314,7 +304,7 @@ describe('browser tool framework post-actions', () => {
           diff: async () => ({
             changed: true,
             text: largeDiff,
-            added: 10001,
+            added: 1,
             removed: 0,
             afterUrl: 'https://example.com/large',
           }),
@@ -333,8 +323,8 @@ describe('browser tool framework post-actions', () => {
       expect(text).toContain('saving it to a BrowserOS output file failed')
       expect(text).toContain('Showing the first')
       expect(text).toContain('[UNTRUSTED_PAGE_CONTENT')
-      expect(text).toContain('word-0')
-      expect(text).not.toContain('word-10000')
+      expect(text).toContain('xxx')
+      expect(text).not.toContain(lastMarker)
     })
   })
 

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -610,7 +610,6 @@ return 'late'
         | {
             added: number
             removed: number
-            wordCount: number
           }
         | undefined
       expect(data).toMatchObject({
@@ -639,16 +638,14 @@ return 'late'
   it('writes large direct diffs to a BrowserOS output markdown file', async () => {
     await withBrowserosDir(async () => {
       const fake = createFakeServer()
-      const largeDiff = Array.from(
-        { length: 10001 },
-        (_, i) => `word-${i}`,
-      ).join(' ')
+      const lastMarker = 'last-diff-node'
+      const largeDiff = `${'x'.repeat(30_001)}\n${lastMarker}`
       const session = {
         observe: () => ({
           diff: async () => ({
             changed: true,
             text: largeDiff,
-            added: 10001,
+            added: 1,
             removed: 0,
             afterUrl: 'https://example.com/large',
           }),
@@ -668,26 +665,26 @@ return 'late'
             added: number
             removed: number
             truncated: boolean
-            wordCount: number
+            tokenEstimate: number
             path: string
             contentLength: number
             writtenToFile: boolean
           }
         | undefined
       expect(data).toMatchObject({
-        added: 10001,
+        added: 1,
         removed: 0,
         truncated: true,
-        wordCount: 10001,
         writtenToFile: true,
       })
+      expect(data?.tokenEstimate).toBeGreaterThan(10_000)
       const savedPath = data?.path
       await expectBrowserToolOutputPath(savedPath)
       expect(savedPath?.endsWith('.md')).toBe(true)
       expect(result?.content).toEqual([
         expect.objectContaining({
           type: 'text',
-          text: expect.stringContaining('Diff is 10001 words'),
+          text: expect.stringContaining('estimated tokens'),
         }),
       ])
       expect(result?.content).toEqual([
@@ -699,12 +696,12 @@ return 'late'
       expect(result?.content).toEqual([
         expect.objectContaining({
           type: 'text',
-          text: expect.not.stringContaining('word-10000'),
+          text: expect.not.stringContaining(lastMarker),
         }),
       ])
       const savedContent = readFileSync(savedPath ?? '', 'utf8')
       expect(savedContent).toContain('[UNTRUSTED_PAGE_CONTENT')
-      expect(savedContent).toContain('word-10000')
+      expect(savedContent).toContain(lastMarker)
       expect(data?.contentLength).toBe(savedContent.length)
     })
   })
@@ -784,10 +781,8 @@ return 'late'
   it('writes large URL-change act readbacks to a BrowserOS output file', async () => {
     await withBrowserosDir(async () => {
       const fake = createFakeServer()
-      const largeSnapshot = Array.from(
-        { length: 10001 },
-        (_, i) => `destination-${i}`,
-      ).join(' ')
+      const lastMarker = 'destination-final-node'
+      const largeSnapshot = `${'x'.repeat(30_001)}\n${lastMarker}`
       const session = {
         input: () => ({
           click: async () => undefined,
@@ -832,9 +827,11 @@ return 'late'
           }),
           expect.objectContaining({
             type: 'text',
-            text: expect.stringContaining(
-              'full current snapshot is 10001 words',
-            ),
+            text: expect.stringContaining('full current snapshot is'),
+          }),
+          expect.objectContaining({
+            type: 'text',
+            text: expect.stringContaining('estimated tokens'),
           }),
           expect.objectContaining({
             type: 'text',
@@ -846,7 +843,7 @@ return 'late'
         expect.arrayContaining([
           expect.objectContaining({
             type: 'text',
-            text: expect.not.stringContaining('destination-10000'),
+            text: expect.not.stringContaining(lastMarker),
           }),
         ]),
       )
@@ -1183,11 +1180,11 @@ return 'late'
     expect(JSON.stringify(result?.structuredContent)).not.toContain('path')
   })
 
-  it('returns old-threshold-sized snapshots inline', async () => {
+  it('returns below-token-threshold snapshots inline', async () => {
     await withBrowserosDir(async () => {
       const fake = createFakeServer()
       const inlineSnapshot = Array.from(
-        { length: 5001 },
+        { length: 4500 },
         (_, i) => `node-${i}`,
       ).join(' ')
       const session = {
@@ -1215,7 +1212,7 @@ return 'late'
       expect(result?.content).toEqual([
         expect.objectContaining({
           type: 'text',
-          text: expect.stringContaining('node-5000'),
+          text: expect.stringContaining('node-4499'),
         }),
       ])
       expect(result?.content).toEqual([
@@ -1230,10 +1227,7 @@ return 'late'
   it('writes very large snapshots to a BrowserOS output markdown file', async () => {
     await withBrowserosDir(async () => {
       const fake = createFakeServer()
-      const largeSnapshot = [
-        ...Array.from({ length: 15000 }, () => 'x'),
-        'last-node',
-      ].join(' ')
+      const largeSnapshot = `${'x '.repeat(23_000)}last-node`
       expect(largeSnapshot.length).toBeLessThan(50_000)
       const session = {
         observe: () => ({
@@ -1253,15 +1247,15 @@ return 'late'
             page: number
             path: string
             contentLength: number
-            wordCount: number
+            tokenEstimate: number
             writtenToFile: boolean
           }
         | undefined
       expect(data).toMatchObject({
         page: 4,
-        wordCount: 15001,
         writtenToFile: true,
       })
+      expect(data?.tokenEstimate).toBeGreaterThan(15_000)
       const savedPath = data?.path
       await expectBrowserToolOutputPath(savedPath)
       expect(savedPath?.endsWith('.md')).toBe(true)
@@ -1290,7 +1284,7 @@ return 'late'
   it('writes very long unbroken snapshots to a BrowserOS output markdown file', async () => {
     await withBrowserosDir(async () => {
       const fake = createFakeServer()
-      const largeSnapshot = 'x'.repeat(50_001)
+      const largeSnapshot = 'x'.repeat(45_001)
       const session = {
         observe: () => ({
           snapshot: async () => ({ text: largeSnapshot }),
@@ -1305,16 +1299,16 @@ return 'late'
       const data = result?.structuredContent as
         | {
             path: string
-            wordCount: number
+            tokenEstimate: number
             writtenToFile: boolean
           }
         | undefined
 
       expect(result?.isError).toBeFalsy()
       expect(data).toMatchObject({
-        wordCount: 1,
         writtenToFile: true,
       })
+      expect(data?.tokenEstimate).toBeGreaterThan(15_000)
       const savedPath = data?.path
       expect(result?.content).toEqual([
         expect.objectContaining({

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -59,6 +59,22 @@ function createFakeServer() {
   }
 }
 
+function textOf(result: { content?: unknown } | undefined): string {
+  if (!Array.isArray(result?.content)) return ''
+  return result.content
+    .filter(
+      (item): item is { type: 'text'; text: string } =>
+        typeof item === 'object' &&
+        item !== null &&
+        'type' in item &&
+        item.type === 'text' &&
+        'text' in item &&
+        typeof item.text === 'string',
+    )
+    .map((item) => item.text)
+    .join('\n')
+}
+
 async function withBrowserosDir<T>(run: () => Promise<T>): Promise<T> {
   const previous = process.env.BROWSEROS_DIR
   const browserosDir = mkdtempSync(join(tmpdir(), 'browseros-output-test-'))
@@ -812,6 +828,8 @@ return 'late'
       })
 
       expect(result?.isError).toBeFalsy()
+      const text = textOf(result)
+      const savedPath = text.match(/saved to: (.+\.md)/)?.[1]
       expect(result?.structuredContent).toEqual({
         kind: 'click',
         changed: true,
@@ -839,14 +857,9 @@ return 'late'
           }),
         ]),
       )
-      expect(result?.content).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({
-            type: 'text',
-            text: expect.not.stringContaining(lastMarker),
-          }),
-        ]),
-      )
+      expect(text).not.toContain(lastMarker)
+      await expectBrowserToolOutputPath(savedPath)
+      expect(readFileSync(savedPath ?? '', 'utf8')).toContain(lastMarker)
     })
   })
 
@@ -1180,13 +1193,10 @@ return 'late'
     expect(JSON.stringify(result?.structuredContent)).not.toContain('path')
   })
 
-  it('returns below-token-threshold snapshots inline', async () => {
+  it('returns word-threshold-only snapshots inline', async () => {
     await withBrowserosDir(async () => {
       const fake = createFakeServer()
-      const inlineSnapshot = Array.from(
-        { length: 4500 },
-        (_, i) => `node-${i}`,
-      ).join(' ')
+      const inlineSnapshot = `${'x '.repeat(15_001)}last-node`
       const session = {
         observe: () => ({
           snapshot: async () => ({ text: inlineSnapshot }),
@@ -1212,7 +1222,7 @@ return 'late'
       expect(result?.content).toEqual([
         expect.objectContaining({
           type: 'text',
-          text: expect.stringContaining('node-4499'),
+          text: expect.stringContaining('last-node'),
         }),
       ])
       expect(result?.content).toEqual([

--- a/packages/browseros-agent/apps/server/tests/tools/response.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/response.test.ts
@@ -113,10 +113,7 @@ describe('ToolResponse', () => {
   it('writes large snapshot post-actions to a BrowserOS output file', async () => {
     await withBrowserosDir(async () => {
       const response = new ToolResponse({ postActionTimeoutMs: 200 })
-      const largeSnapshot = [
-        ...Array.from({ length: 15000 }, () => 'x'),
-        'last-node',
-      ].join(' ')
+      const largeSnapshot = `${'x '.repeat(23_000)}last-node`
       response.text('ok')
       response.includeSnapshot(1)
 
@@ -136,7 +133,8 @@ describe('ToolResponse', () => {
       assert.ok(!result.isError)
       assert.ok(text.includes('ok'))
       assert.ok(text.includes('[Page 1 snapshot]'))
-      assert.ok(text.includes('Large snapshot (15001 words'))
+      assert.ok(text.includes('Large snapshot ('))
+      assert.ok(text.includes('estimated tokens'))
       assert.ok(savedPath)
       assert.ok(!text.includes('last-node'))
       assert.ok(readFileSync(savedPath ?? '', 'utf8').includes('last-node'))


### PR DESCRIPTION
## Summary
- Replaces snapshot word+char cutoffs with a single 15,000 estimated-token threshold.
- Replaces diff word cutoffs with a single 10,000 estimated-token threshold.
- Reports `tokenEstimate` for saved browser output and keeps save-failure excerpts bounded.

## Design
Browser snapshot and diff formatters now use a local plain-text helper that mirrors compaction's `Math.ceil(chars / 3)` heuristic. They estimate the wrapped browser output payload before deciding whether to inline it or write it to a BrowserOS output markdown file.

## Test plan
- [x] `cd apps/server && bun test tests/tools/browser/register.test.ts tests/tools/browser/framework.test.ts tests/tools/response.test.ts`
- [x] `bun run check`
- [x] local adversarial review, round 2 clean