### PR TITLE
feat: add BrowserOS showToast API

### DIFF
--- a/packages/browseros/build/features.yaml
+++ b/packages/browseros/build/features.yaml
@@ -175,6 +175,11 @@ features:
       - chrome/browser/extensions/chrome_extensions_browser_api_provider.cc
       - chrome/browser/media/extension_media_access_handler.cc
       - chrome/browser/ui/extensions/extension_side_panel_utils.h
+      - chrome/browser/ui/toasts/api/toast_id.cc
+      - chrome/browser/ui/toasts/api/toast_id.h
+      - chrome/browser/ui/toasts/toast_controller.cc
+      - chrome/browser/ui/toasts/toast_controller.h
+      - chrome/browser/ui/toasts/toast_service.cc
       - chrome/browser/ui/views/side_panel/extensions/extension_side_panel_utils.cc
       - chrome/common/extensions/api/_api_features.json
       - chrome/common/extensions/api/_permission_features.json
@@ -186,6 +191,7 @@ features:
       - extensions/browser/extension_function_histogram_value.h
       - extensions/common/mojom/api_permission_id.mojom
       - tools/metrics/histograms/metadata/extensions/enums.xml
+      - tools/metrics/histograms/metadata/toasts/enums.xml
 
   ota-updater:
     description: "feat: extensions ota updater"

--- a/packages/browseros/chromium_patches/chrome/browser/extensions/api/browser_os/browser_os_api.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/extensions/api/browser_os/browser_os_api.cc
@@ -1,15 +1,16 @@
 diff --git a/chrome/browser/extensions/api/browser_os/browser_os_api.cc b/chrome/browser/extensions/api/browser_os/browser_os_api.cc
 new file mode 100644
-index 0000000000000..a75e576033207
+index 0000000000000..a136ab744a9e6
 --- /dev/null
 +++ b/chrome/browser/extensions/api/browser_os/browser_os_api.cc
-@@ -0,0 +1,250 @@
+@@ -0,0 +1,291 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
 +
 +#include "chrome/browser/extensions/api/browser_os/browser_os_api.h"
 +
++#include <algorithm>
 +#include <optional>
 +#include <string>
 +#include <utility>
@@ -17,13 +18,19 @@ index 0000000000000..a75e576033207
 +#include "base/files/file_util.h"
 +#include "base/logging.h"
 +#include "base/strings/utf_string_conversions.h"
++#include "base/time/time.h"
 +#include "base/values.h"
 +#include "base/version_info/version_info.h"
 +#include "chrome/browser/browser_process.h"
 +#include "chrome/browser/browseros/metrics/browseros_metrics.h"
 +#include "chrome/browser/platform_util.h"
 +#include "chrome/browser/profiles/profile.h"
++#include "chrome/browser/ui/browser.h"
++#include "chrome/browser/ui/browser_finder.h"
++#include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 +#include "chrome/browser/ui/select_file_policy/chrome_select_file_policy.h"
++#include "chrome/browser/ui/toasts/api/toast_id.h"
++#include "chrome/browser/ui/toasts/toast_controller.h"
 +#include "chrome/common/extensions/api/browser_os.h"
 +#include "components/prefs/pref_service.h"
 +#include "content/public/browser/web_contents.h"
@@ -250,6 +257,40 @@ index 0000000000000..a75e576033207
 +  results.Append(base::Value());
 +  Respond(ArgumentList(std::move(results)));
 +  Release();
++}
++
++ExtensionFunction::ResponseAction BrowserOSShowToastFunction::Run() {
++  std::optional<browser_os::ShowToast::Params> params =
++      browser_os::ShowToast::Params::Create(args());
++  EXTENSION_FUNCTION_VALIDATE(params);
++
++  if (params->message.empty()) {
++    return RespondNow(Error("Toast message must not be empty"));
++  }
++
++  Profile* profile = Profile::FromBrowserContext(browser_context());
++  Browser* browser = chrome::FindLastActiveWithProfile(profile);
++  if (!browser) {
++    return RespondNow(Error("No active browser window"));
++  }
++
++  ToastController* toast_controller = browser->GetFeatures().toast_controller();
++  if (!toast_controller) {
++    return RespondNow(Error("Toast controller unavailable"));
++  }
++
++  ToastParams toast_params(ToastId::kBrowserOSToast);
++  toast_params.body_string_override = base::UTF8ToUTF16(params->message);
++  if (params->duration_ms) {
++    constexpr int kMinDurationMs = 1000;
++    constexpr int kMaxDurationMs = 30000;
++    toast_params.timeout_override = base::Milliseconds(
++        std::clamp(*params->duration_ms, kMinDurationMs, kMaxDurationMs));
++  }
++
++  const bool shown = toast_controller->MaybeShowToast(std::move(toast_params));
++  return RespondNow(
++      ArgumentList(browser_os::ShowToast::Results::Create(shown)));
 +}
 +
 +}  // namespace api

--- a/packages/browseros/chromium_patches/chrome/browser/extensions/api/browser_os/browser_os_api.h
+++ b/packages/browseros/chromium_patches/chrome/browser/extensions/api/browser_os/browser_os_api.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/extensions/api/browser_os/browser_os_api.h b/chrome/browser/extensions/api/browser_os/browser_os_api.h
 new file mode 100644
-index 0000000000000..df88116794a9e
+index 0000000000000..fb83226e2b9e2
 --- /dev/null
 +++ b/chrome/browser/extensions/api/browser_os/browser_os_api.h
-@@ -0,0 +1,100 @@
+@@ -0,0 +1,112 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -99,6 +99,18 @@ index 0000000000000..df88116794a9e
 +
 + private:
 +  scoped_refptr<ui::SelectFileDialog> select_file_dialog_;
++};
++
++class BrowserOSShowToastFunction : public ExtensionFunction {
++ public:
++  DECLARE_EXTENSION_FUNCTION("browserOS.showToast", BROWSER_OS_SHOWTOAST)
++
++  BrowserOSShowToastFunction() = default;
++
++ protected:
++  ~BrowserOSShowToastFunction() override = default;
++
++  ResponseAction Run() override;
 +};
 +
 +}  // namespace extensions::api

--- a/packages/browseros/chromium_patches/chrome/browser/ui/toasts/api/toast_id.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/toasts/api/toast_id.cc
@@ -1,0 +1,13 @@
+diff --git a/chrome/browser/ui/toasts/api/toast_id.cc b/chrome/browser/ui/toasts/api/toast_id.cc
+index 6a52e958fdcb5..8d2e1ae503c60 100644
+--- a/chrome/browser/ui/toasts/api/toast_id.cc
++++ b/chrome/browser/ui/toasts/api/toast_id.cc
+@@ -75,6 +75,8 @@ std::string_view GetToastName(ToastId toast_id) {
+       return "MultistepFilterSuggestionRecent";
+     case ToastId::kSkillSavedWithoutInvokeButton:
+       return "SkillSavedWithoutInvokeButton";
++    case ToastId::kBrowserOSToast:
++      return "BrowserOSToast";
+   }
+ 
+   NOTREACHED();

--- a/packages/browseros/chromium_patches/chrome/browser/ui/toasts/api/toast_id.h
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/toasts/api/toast_id.h
@@ -1,0 +1,14 @@
+diff --git a/chrome/browser/ui/toasts/api/toast_id.h b/chrome/browser/ui/toasts/api/toast_id.h
+index 5f3c3ff3443c8..32a88e78f3024 100644
+--- a/chrome/browser/ui/toasts/api/toast_id.h
++++ b/chrome/browser/ui/toasts/api/toast_id.h
+@@ -54,7 +54,8 @@ enum class ToastId {
+   kMultistepFilterSuggestion = 31,
+   kMultistepFilterSuggestionRecent = 32,
+   kSkillSavedWithoutInvokeButton = 33,
+-  kMaxValue = kSkillSavedWithoutInvokeButton,
++  kBrowserOSToast = 34,
++  kMaxValue = kBrowserOSToast,
+ };
+ // LINT.ThenChange(/tools/metrics/histograms/metadata/toasts/enums.xml:ToastId)
+ 

--- a/packages/browseros/chromium_patches/chrome/browser/ui/toasts/toast_controller.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/toasts/toast_controller.cc
@@ -1,0 +1,15 @@
+diff --git a/chrome/browser/ui/toasts/toast_controller.cc b/chrome/browser/ui/toasts/toast_controller.cc
+index 1b41d0c895b88..459f1ac0972d3 100644
+--- a/chrome/browser/ui/toasts/toast_controller.cc
++++ b/chrome/browser/ui/toasts/toast_controller.cc
+@@ -268,8 +268,8 @@ void ToastController::ShowToast(ToastParams params) {
+   const bool is_actionable =
+       current_toast_spec->action_button_string_id().has_value() ||
+       current_toast_spec->has_menu();
+-  base::TimeDelta timeout =
+-      is_actionable ? kToastWithActionTimeout : kToastDefaultTimeout;
++  base::TimeDelta timeout = params.timeout_override.value_or(
++      is_actionable ? kToastWithActionTimeout : kToastDefaultTimeout);
+ 
+   toast_close_timer_.Start(
+       FROM_HERE, timeout,

--- a/packages/browseros/chromium_patches/chrome/browser/ui/toasts/toast_controller.h
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/toasts/toast_controller.h
@@ -1,0 +1,22 @@
+diff --git a/chrome/browser/ui/toasts/toast_controller.h b/chrome/browser/ui/toasts/toast_controller.h
+index 5bc5eefc90cff..666367db29962 100644
+--- a/chrome/browser/ui/toasts/toast_controller.h
++++ b/chrome/browser/ui/toasts/toast_controller.h
+@@ -15,6 +15,7 @@
+ #include "base/functional/callback_helpers.h"
+ #include "base/memory/raw_ptr.h"
+ #include "base/scoped_observation.h"
++#include "base/time/time.h"
+ #include "base/timer/timer.h"
+ #include "chrome/browser/ui/exclusive_access/fullscreen_controller.h"
+ #include "chrome/browser/ui/exclusive_access/fullscreen_observer.h"
+@@ -57,6 +58,9 @@ struct ToastParams {
+   std::vector<std::u16string> action_button_string_replacement_params;
+   std::optional<int> body_string_cardinality_param;
+   std::optional<std::u16string> body_string_override;
++  // Overrides the auto-dismiss timeout. When unset, the controller falls back
++  // to the default (or with-action) timeout.
++  std::optional<base::TimeDelta> timeout_override;
+   std::optional<ui::ImageModel> image_override;
+   std::unique_ptr<ui::MenuModel> menu_model;
+   base::ScopedClosureRunner toast_close_callback;

--- a/packages/browseros/chromium_patches/chrome/browser/ui/toasts/toast_service.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/toasts/toast_service.cc
@@ -1,0 +1,18 @@
+diff --git a/chrome/browser/ui/toasts/toast_service.cc b/chrome/browser/ui/toasts/toast_service.cc
+index 09f145e630ca2..8084a7da406a8 100644
+--- a/chrome/browser/ui/toasts/toast_service.cc
++++ b/chrome/browser/ui/toasts/toast_service.cc
+@@ -365,6 +365,13 @@ void ToastService::RegisterToasts(
+   toast_registry_->RegisterToast(
+       ToastId::kRecordReplay, ToastSpecification::Builder(kInfoIcon).Build());
+ 
++  // BrowserOS extension toast. The body text is supplied dynamically at show
++  // time via ToastParams::body_string_override, so the spec has no body string
++  // id. Global-scoped so it survives tab switches while it is visible.
++  toast_registry_->RegisterToast(
++      ToastId::kBrowserOSToast,
++      ToastSpecification::Builder(kInfoIcon).AddGlobalScoped().Build());
++
+   toast_registry_->RegisterToast(
+       ToastId::kAutoSignIn,
+       ToastSpecification::Builder(vector_icons::kPasswordManagerIcon,

--- a/packages/browseros/chromium_patches/chrome/common/extensions/api/browser_os.idl
+++ b/packages/browseros/chromium_patches/chrome/common/extensions/api/browser_os.idl
@@ -1,9 +1,9 @@
 diff --git a/chrome/common/extensions/api/browser_os.idl b/chrome/common/extensions/api/browser_os.idl
 new file mode 100644
-index 0000000000000..8a69e95064494
+index 0000000000000..c822c34a0d1cf
 --- /dev/null
 +++ b/chrome/common/extensions/api/browser_os.idl
-@@ -0,0 +1,112 @@
+@@ -0,0 +1,128 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -64,6 +64,10 @@ index 0000000000000..8a69e95064494
 +  // |result|: Selected path info, or null if user cancelled.
 +  callback ChoosePathCallback = void(optional SelectedPath result);
 +
++  // Callback for showToast.
++  // |shown|: True if the toast was displayed, false if it was suppressed.
++  callback ShowToastCallback = void(boolean shown);
++
 +  interface Functions {
 +    // Settings API functions - compatible with chrome.settingsPrivate
 +    // Gets a specific preference value
@@ -114,5 +118,17 @@ index 0000000000000..8a69e95064494
 +    static void choosePath(
 +        optional ChoosePathOptions options,
 +        ChoosePathCallback callback);
++
++    // Shows a transient toast notification in the active browser window. The
++    // message is supplied dynamically, so no resource string is required.
++    // |message|: The text to display in the toast.
++    // |durationMs|: How long the toast stays visible, in milliseconds. Clamped
++    //     to [1000, 30000]. Defaults to the standard toast timeout if omitted.
++    // |callback|: Called with true if the toast was shown, false if it was
++    //     suppressed (e.g. by the user's toast alert-level setting).
++    static void showToast(
++        DOMString message,
++        optional long durationMs,
++        ShowToastCallback callback);
 +  };
 +};

--- a/packages/browseros/chromium_patches/extensions/browser/extension_function_histogram_value.h
+++ b/packages/browseros/chromium_patches/extensions/browser/extension_function_histogram_value.h
@@ -1,8 +1,8 @@
 diff --git a/extensions/browser/extension_function_histogram_value.h b/extensions/browser/extension_function_histogram_value.h
-index 8d3b969f8965b..73a01963005e0 100644
+index 8d3b969f8965b..1dff8a0ed8252 100644
 --- a/extensions/browser/extension_function_histogram_value.h
 +++ b/extensions/browser/extension_function_histogram_value.h
-@@ -2022,6 +2022,32 @@ enum HistogramValue {
+@@ -2022,6 +2022,33 @@ enum HistogramValue {
    AUTOFILLPRIVATE_GETREQUIREDATTRIBUTETYPESFORENTITYTYPENAME = 1959,
    PDFVIEWERPRIVATE_GLICSUMMARIZE = 1960,
    GLICPRIVATE_GETSTATE = 1961,
@@ -32,6 +32,7 @@ index 8d3b969f8965b..73a01963005e0 100644
 +  SIDEPANEL_BROWSEROSISOPEN = 1984,
 +  BROWSER_OS_GETBROWSEROSVERSIONNUMBER = 1985,
 +  BROWSER_OS_CHOOSEPATH = 1986,
++  BROWSER_OS_SHOWTOAST = 1987,
    // Last entry: Add new entries above, then run:
    // tools/metrics/histograms/update_extension_histograms.py
    ENUM_BOUNDARY

--- a/packages/browseros/chromium_patches/tools/metrics/histograms/metadata/extensions/enums.xml
+++ b/packages/browseros/chromium_patches/tools/metrics/histograms/metadata/extensions/enums.xml
@@ -1,8 +1,8 @@
 diff --git a/tools/metrics/histograms/metadata/extensions/enums.xml b/tools/metrics/histograms/metadata/extensions/enums.xml
-index 67daa1883b62f..5ba89feefd54a 100644
+index 67daa1883b62f..b0374d92a0709 100644
 --- a/tools/metrics/histograms/metadata/extensions/enums.xml
 +++ b/tools/metrics/histograms/metadata/extensions/enums.xml
-@@ -2891,6 +2891,31 @@ Called by update_extension_histograms.py.-->
+@@ -2891,6 +2891,32 @@ Called by update_extension_histograms.py.-->
        label="AUTOFILLPRIVATE_GETREQUIREDATTRIBUTETYPESFORENTITYTYPENAME"/>
    <int value="1960" label="PDFVIEWERPRIVATE_GLICSUMMARIZE"/>
    <int value="1961" label="GLICPRIVATE_GETSTATE"/>
@@ -31,10 +31,11 @@ index 67daa1883b62f..5ba89feefd54a 100644
 +  <int value="1984" label="SIDEPANEL_BROWSEROSISOPEN"/>
 +  <int value="1985" label="BROWSER_OS_GETBROWSEROSVERSIONNUMBER"/>
 +  <int value="1986" label="BROWSER_OS_CHOOSEPATH"/>
++  <int value="1987" label="BROWSER_OS_SHOWTOAST"/>
  </enum>
  
  <!-- LINT.ThenChange(//extensions/browser/extension_function_histogram_value.h:HistogramValue) -->
-@@ -3282,6 +3307,7 @@ Called by update_extension_permission.py.-->
+@@ -3282,6 +3308,7 @@ Called by update_extension_permission.py.-->
    <int value="263" label="kEnterpriseLogin"/>
    <int value="264" label="kProxyOverrideRulesPrivate"/>
    <int value="265" label="kGlicPrivate"/>

--- a/packages/browseros/chromium_patches/tools/metrics/histograms/metadata/toasts/enums.xml
+++ b/packages/browseros/chromium_patches/tools/metrics/histograms/metadata/toasts/enums.xml
@@ -1,0 +1,12 @@
+diff --git a/tools/metrics/histograms/metadata/toasts/enums.xml b/tools/metrics/histograms/metadata/toasts/enums.xml
+index de288d30cc6c3..e20afd52721e3 100644
+--- a/tools/metrics/histograms/metadata/toasts/enums.xml
++++ b/tools/metrics/histograms/metadata/toasts/enums.xml
+@@ -92,6 +92,7 @@ chromium-metrics-reviews@google.com.
+   <int value="31" label="Filter Suggestion"/>
+   <int value="32" label="Filter Suggestion Recent"/>
+   <int value="33" label="Saved Skill without Invoke Button"/>
++  <int value="34" label="BrowserOS extension toast"/>
+ </enum>
+ 
+ <!-- LINT.ThenChange(/chrome/browser/ui/toasts/api/toast_id.h:ToastId) -->


### PR DESCRIPTION
## Summary
- Adds `chrome.browserOS.showToast(message, durationMs?)` for BrowserOS extensions.
- Registers a BrowserOS toast ID/spec and supports dynamic body text plus optional clamped timeout override.
- Adds the toast files and histogram metadata to the existing BrowserOS API patch feature.

## Design
The API parses the extension call in `BrowserOSShowToastFunction`, finds the active browser for the caller profile, and shows a global-scoped Chromium toast through `ToastController`. The toast body is supplied through `ToastParams::body_string_override`, avoiding a static GRD string for caller-provided text, and `durationMs` is clamped to 1-30 seconds before becoming a timeout override.

## Test plan
- [x] `git apply --numstat` for each changed Chromium patch file
- [x] `go test ./...` in `packages/browseros/tools/patch`
- [x] `autoninja -C out/Default_arm64 chrome` in `/Users/shadowfax/code/chromium-checkouts/chromium-1/src`