### PR TITLE
feat: ship inline chat to everyone

### DIFF
--- a/packages/browseros-agent/apps/agent/screens/agent-command/AgentCommandHome.tsx
+++ b/packages/browseros-agent/apps/agent/screens/agent-command/AgentCommandHome.tsx
@@ -43,9 +43,7 @@ export const AgentCommandHome: FC = () => {
   const { adapters } = useAgentAdapters()
   const { supports, isLoading: capabilitiesLoading } = useCapabilities()
   const hermesAgentSupported = supports(Feature.HERMES_AGENT_SUPPORT)
-  const supportsInlineChat =
-    supports(Feature.ALPHA_FEATURES_SUPPORT) &&
-    supports(Feature.NEWTAB_CHAT_SUPPORT)
+  const supportsInlineChat = supports(Feature.NEWTAB_CHAT_SUPPORT)
   const llmRoutingMode = resolveHomeLlmRoutingMode({
     capabilitiesLoading,
     supportsInlineChat,


### PR DESCRIPTION
## Summary
- Removes the alpha-feature requirement from the new tab home inline chat gate.
- Keeps `NEWTAB_CHAT_SUPPORT` as the BrowserOS compatibility boundary.
- Leaves capability loading and side panel fallback behavior unchanged.

## Design
`AgentCommandHome` already owns the support boolean that feeds `resolveHomeLlmRoutingMode`. This change narrows that boolean to the real compatibility capability, so supported BrowserOS versions use inline chat without requiring alpha opt-in.

## Test plan
- [x] `bun test apps/agent/screens/agent-command/home-compose.helpers.test.ts`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test:main`
- [x] `bun run check`
- [x] `bun run build:agent`