### PR TITLE
feat: gate hermes on alpha support

### DIFF
--- a/packages/browseros-agent/apps/agent/lib/browseros/capabilities.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/capabilities.test.ts
@@ -67,7 +67,7 @@ describe('resolveStaticFeatureSupport', () => {
 })
 
 describe('resolveFeatureStaticSupport', () => {
-  it('gates Hermes support on development mode only', () => {
+  it('gates Hermes support on alpha features', () => {
     expect(
       resolveFeatureStaticSupport({
         feature: Feature.HERMES_AGENT_SUPPORT,
@@ -80,9 +80,17 @@ describe('resolveFeatureStaticSupport', () => {
       resolveFeatureStaticSupport({
         feature: Feature.HERMES_AGENT_SUPPORT,
         isDevelopment: false,
-        alphaFeaturesEnabled: true,
+        alphaFeaturesEnabled: false,
       }),
     ).toBe(false)
+
+    expect(
+      resolveFeatureStaticSupport({
+        feature: Feature.HERMES_AGENT_SUPPORT,
+        isDevelopment: false,
+        alphaFeaturesEnabled: true,
+      }),
+    ).toBe(true)
   })
 
   it('preserves alpha-gated support for alpha features', () => {

--- a/packages/browseros-agent/apps/agent/lib/browseros/capabilities.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/capabilities.ts
@@ -82,7 +82,7 @@ const FEATURE_CONFIG: { [K in Feature]: FeatureConfig } = {
   [Feature.QWEN_CODE_SUPPORT]: { minServerVersion: '0.0.77' },
   [Feature.CREDITS_SUPPORT]: { minServerVersion: '0.0.78' },
   [Feature.AGENT_HARNESS_SUPPORT]: { minBrowserOSVersion: '0.46.0.0' },
-  [Feature.HERMES_AGENT_SUPPORT]: { requiresDevelopmentFlag: true },
+  [Feature.HERMES_AGENT_SUPPORT]: { requiresAlphaFlag: true },
 }
 
 function parseVersion(version: string): number[] {

--- a/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.test.tsx
+++ b/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.test.tsx
@@ -90,7 +90,11 @@ function resolveFeatureStaticSupport({
   alphaFeaturesEnabled: boolean
 }): boolean | null {
   if (feature === Feature.HERMES_AGENT_SUPPORT) {
-    return isDevelopment
+    return resolveStaticFeatureSupport({
+      isDevelopment,
+      alphaFeaturesEnabled,
+      requiresAlphaFlag: true,
+    })
   }
   if (feature === Feature.ALPHA_FEATURES_SUPPORT) {
     return alphaFeaturesEnabled


### PR DESCRIPTION
## Summary
- Move `HERMES_AGENT_SUPPORT` from development-only gating to the existing alpha feature gate.
- Keep Hermes enabled automatically in development through the existing alpha/static shortcut.
- Update capability tests and the duplicated customization test mock to cover the alpha-gated behavior.

## Design
Hermes visibility already flows through `Capabilities.supports(Feature.HERMES_AGENT_SUPPORT)`, so the central capability config is the right ownership point. This changes only that config entry from `requiresDevelopmentFlag` to `requiresAlphaFlag` and aligns the tests with production alpha-on/off behavior.

## Test plan
- [x] `bun test apps/agent/lib/browseros/capabilities.test.ts apps/agent/screens/customization/ToolbarSettingsCard.test.tsx`
- [x] `bun run check`