### PR TITLE
feat(patches): browseros showInfoBar extension API

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/extensions/api/browser_os/browser_os_api.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/extensions/api/browser_os/browser_os_api.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/extensions/api/browser_os/browser_os_api.cc b/chrome/browser/extensions/api/browser_os/browser_os_api.cc
 new file mode 100644
-index 0000000000000..a136ab744a9e6
+index 0000000000000..62fdae9e171ae
 --- /dev/null
 +++ b/chrome/browser/extensions/api/browser_os/browser_os_api.cc
-@@ -0,0 +1,291 @@
+@@ -0,0 +1,333 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -23,15 +23,19 @@ index 0000000000000..a136ab744a9e6
 +#include "base/version_info/version_info.h"
 +#include "chrome/browser/browser_process.h"
 +#include "chrome/browser/browseros/metrics/browseros_metrics.h"
++#include "chrome/browser/infobars/simple_alert_infobar_creator.h"
 +#include "chrome/browser/platform_util.h"
 +#include "chrome/browser/profiles/profile.h"
 +#include "chrome/browser/ui/browser.h"
 +#include "chrome/browser/ui/browser_finder.h"
 +#include "chrome/browser/ui/browser_window/public/browser_window_features.h"
 +#include "chrome/browser/ui/select_file_policy/chrome_select_file_policy.h"
++#include "chrome/browser/ui/tabs/tab_strip_model.h"
 +#include "chrome/browser/ui/toasts/api/toast_id.h"
 +#include "chrome/browser/ui/toasts/toast_controller.h"
 +#include "chrome/common/extensions/api/browser_os.h"
++#include "components/infobars/content/content_infobar_manager.h"
++#include "components/infobars/core/infobar_delegate.h"
 +#include "components/prefs/pref_service.h"
 +#include "content/public/browser/web_contents.h"
 +#include "ui/shell_dialogs/selected_file_info.h"
@@ -291,6 +295,44 @@ index 0000000000000..a136ab744a9e6
 +  const bool shown = toast_controller->MaybeShowToast(std::move(toast_params));
 +  return RespondNow(
 +      ArgumentList(browser_os::ShowToast::Results::Create(shown)));
++}
++
++// Bridges chrome.browserOS.showInfoBar to Chrome's tab-scoped alert infobar.
++ExtensionFunction::ResponseAction BrowserOSShowInfoBarFunction::Run() {
++  std::optional<browser_os::ShowInfoBar::Params> params =
++      browser_os::ShowInfoBar::Params::Create(args());
++  EXTENSION_FUNCTION_VALIDATE(params);
++
++  if (params->message.empty()) {
++    return RespondNow(Error("InfoBar message must not be empty"));
++  }
++
++  Profile* profile = Profile::FromBrowserContext(browser_context());
++  Browser* browser = chrome::FindLastActiveWithProfile(profile);
++  if (!browser) {
++    return RespondNow(Error("No active browser window"));
++  }
++
++  content::WebContents* contents =
++      browser->tab_strip_model()->GetActiveWebContents();
++  if (!contents) {
++    return RespondNow(Error("No active tab"));
++  }
++
++  infobars::ContentInfoBarManager* infobar_manager =
++      infobars::ContentInfoBarManager::FromWebContents(contents);
++  if (!infobar_manager) {
++    return RespondNow(Error("InfoBar manager unavailable"));
++  }
++
++  CreateSimpleAlertInfoBar(
++      infobar_manager,
++      infobars::InfoBarDelegate::BROWSEROS_EXTENSION_INFOBAR_DELEGATE, nullptr,
++      base::UTF8ToUTF16(params->message), /*auto_expire=*/true,
++      /*should_animate=*/true, /*closeable=*/true);
++
++  return RespondNow(
++      ArgumentList(browser_os::ShowInfoBar::Results::Create(true)));
 +}
 +
 +}  // namespace api

--- a/packages/browseros/chromium_patches/chrome/browser/extensions/api/browser_os/browser_os_api.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/extensions/api/browser_os/browser_os_api.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/extensions/api/browser_os/browser_os_api.cc b/chrome/browser/extensions/api/browser_os/browser_os_api.cc
 new file mode 100644
-index 0000000000000..62fdae9e171ae
+index 0000000000000..ea477521a09d7
 --- /dev/null
 +++ b/chrome/browser/extensions/api/browser_os/browser_os_api.cc
-@@ -0,0 +1,333 @@
+@@ -0,0 +1,341 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -11,6 +11,7 @@ index 0000000000000..62fdae9e171ae
 +#include "chrome/browser/extensions/api/browser_os/browser_os_api.h"
 +
 +#include <algorithm>
++#include <memory>
 +#include <optional>
 +#include <string>
 +#include <utility>
@@ -23,7 +24,7 @@ index 0000000000000..62fdae9e171ae
 +#include "base/version_info/version_info.h"
 +#include "chrome/browser/browser_process.h"
 +#include "chrome/browser/browseros/metrics/browseros_metrics.h"
-+#include "chrome/browser/infobars/simple_alert_infobar_creator.h"
++#include "chrome/browser/infobars/confirm_infobar_creator.h"
 +#include "chrome/browser/platform_util.h"
 +#include "chrome/browser/profiles/profile.h"
 +#include "chrome/browser/ui/browser.h"
@@ -35,7 +36,9 @@ index 0000000000000..62fdae9e171ae
 +#include "chrome/browser/ui/toasts/toast_controller.h"
 +#include "chrome/common/extensions/api/browser_os.h"
 +#include "components/infobars/content/content_infobar_manager.h"
++#include "components/infobars/core/infobar.h"
 +#include "components/infobars/core/infobar_delegate.h"
++#include "components/infobars/core/simple_alert_infobar_delegate.h"
 +#include "components/prefs/pref_service.h"
 +#include "content/public/browser/web_contents.h"
 +#include "ui/shell_dialogs/selected_file_info.h"
@@ -325,14 +328,19 @@ index 0000000000000..62fdae9e171ae
 +    return RespondNow(Error("InfoBar manager unavailable"));
 +  }
 +
-+  CreateSimpleAlertInfoBar(
-+      infobar_manager,
-+      infobars::InfoBarDelegate::BROWSEROS_EXTENSION_INFOBAR_DELEGATE, nullptr,
-+      base::UTF8ToUTF16(params->message), /*auto_expire=*/true,
-+      /*should_animate=*/true, /*closeable=*/true);
++  const bool shown =
++      infobar_manager
++          ->AddInfoBar(CreateConfirmInfoBar(
++              std::make_unique<SimpleAlertInfoBarDelegate>(
++                  infobars::InfoBarDelegate::
++                      BROWSEROS_EXTENSION_INFOBAR_DELEGATE,
++                  nullptr, base::UTF8ToUTF16(params->message),
++                  /*auto_expire=*/true, /*should_animate=*/true,
++                  /*closeable=*/true)))
++          != nullptr;
 +
 +  return RespondNow(
-+      ArgumentList(browser_os::ShowInfoBar::Results::Create(true)));
++      ArgumentList(browser_os::ShowInfoBar::Results::Create(shown)));
 +}
 +
 +}  // namespace api

--- a/packages/browseros/chromium_patches/chrome/browser/extensions/api/browser_os/browser_os_api.h
+++ b/packages/browseros/chromium_patches/chrome/browser/extensions/api/browser_os/browser_os_api.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/extensions/api/browser_os/browser_os_api.h b/chrome/browser/extensions/api/browser_os/browser_os_api.h
 new file mode 100644
-index 0000000000000..fb83226e2b9e2
+index 0000000000000..0da7f357c6730
 --- /dev/null
 +++ b/chrome/browser/extensions/api/browser_os/browser_os_api.h
-@@ -0,0 +1,112 @@
+@@ -0,0 +1,124 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -109,6 +109,18 @@ index 0000000000000..fb83226e2b9e2
 +
 + protected:
 +  ~BrowserOSShowToastFunction() override = default;
++
++  ResponseAction Run() override;
++};
++
++class BrowserOSShowInfoBarFunction : public ExtensionFunction {
++ public:
++  DECLARE_EXTENSION_FUNCTION("browserOS.showInfoBar", BROWSER_OS_SHOWINFOBAR)
++
++  BrowserOSShowInfoBarFunction() = default;
++
++ protected:
++  ~BrowserOSShowInfoBarFunction() override = default;
 +
 +  ResponseAction Run() override;
 +};

--- a/packages/browseros/chromium_patches/chrome/common/extensions/api/browser_os.idl
+++ b/packages/browseros/chromium_patches/chrome/common/extensions/api/browser_os.idl
@@ -1,9 +1,9 @@
 diff --git a/chrome/common/extensions/api/browser_os.idl b/chrome/common/extensions/api/browser_os.idl
 new file mode 100644
-index 0000000000000..c822c34a0d1cf
+index 0000000000000..baeb98959b39a
 --- /dev/null
 +++ b/chrome/common/extensions/api/browser_os.idl
-@@ -0,0 +1,128 @@
+@@ -0,0 +1,138 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -68,6 +68,9 @@ index 0000000000000..c822c34a0d1cf
 +  // |shown|: True if the toast was displayed, false if it was suppressed.
 +  callback ShowToastCallback = void(boolean shown);
 +
++  // Callback for showInfoBar.
++  callback ShowInfoBarCallback = void(boolean shown);
++
 +  interface Functions {
 +    // Settings API functions - compatible with chrome.settingsPrivate
 +    // Gets a specific preference value
@@ -130,5 +133,12 @@ index 0000000000000..c822c34a0d1cf
 +        DOMString message,
 +        optional long durationMs,
 +        ShowToastCallback callback);
++
++    // Shows a simple alert infobar in the active browser tab.
++    // |message|: Text to display.
++    // |callback|: Called with whether the infobar was shown.
++    static void showInfoBar(
++        DOMString message,
++        ShowInfoBarCallback callback);
 +  };
 +};

--- a/packages/browseros/chromium_patches/components/infobars/core/infobar_delegate.h
+++ b/packages/browseros/chromium_patches/components/infobars/core/infobar_delegate.h
@@ -1,13 +1,14 @@
 diff --git a/components/infobars/core/infobar_delegate.h b/components/infobars/core/infobar_delegate.h
-index 5fe307d621193..d7731d7d9acad 100644
+index 5fe307d621193..fd190cc50a4f8 100644
 --- a/components/infobars/core/infobar_delegate.h
 +++ b/components/infobars/core/infobar_delegate.h
-@@ -216,6 +216,8 @@ class InfoBarDelegate {
+@@ -216,6 +216,9 @@ class InfoBarDelegate {
      AUTOFILL_AI_SAVE_ENTITY_INFOBAR_DELEGATE_IOS = 132,
      JS_OPTIMIZATIONS_INFOBAR_DELEGATE = 133,
      WEB_APP_BLOCKED_MIGRATION_INFOBAR_DELEGATE = 134,
 +    // BrowserOS: agent installation infobar
 +    BROWSEROS_AGENT_INSTALLING_INFOBAR_DELEGATE = 135,
++    BROWSEROS_EXTENSION_INFOBAR_DELEGATE = 136,
    };
    // LINT.ThenChange(//tools/metrics/histograms/metadata/browser/enums.xml:InfoBarIdentifier)
  

--- a/packages/browseros/chromium_patches/extensions/browser/extension_function_histogram_value.h
+++ b/packages/browseros/chromium_patches/extensions/browser/extension_function_histogram_value.h
@@ -1,8 +1,8 @@
 diff --git a/extensions/browser/extension_function_histogram_value.h b/extensions/browser/extension_function_histogram_value.h
-index 8d3b969f8965b..1dff8a0ed8252 100644
+index 8d3b969f8965b..722661f96b29a 100644
 --- a/extensions/browser/extension_function_histogram_value.h
 +++ b/extensions/browser/extension_function_histogram_value.h
-@@ -2022,6 +2022,33 @@ enum HistogramValue {
+@@ -2022,6 +2022,34 @@ enum HistogramValue {
    AUTOFILLPRIVATE_GETREQUIREDATTRIBUTETYPESFORENTITYTYPENAME = 1959,
    PDFVIEWERPRIVATE_GLICSUMMARIZE = 1960,
    GLICPRIVATE_GETSTATE = 1961,
@@ -33,6 +33,7 @@ index 8d3b969f8965b..1dff8a0ed8252 100644
 +  BROWSER_OS_GETBROWSEROSVERSIONNUMBER = 1985,
 +  BROWSER_OS_CHOOSEPATH = 1986,
 +  BROWSER_OS_SHOWTOAST = 1987,
++  BROWSER_OS_SHOWINFOBAR = 1988,
    // Last entry: Add new entries above, then run:
    // tools/metrics/histograms/update_extension_histograms.py
    ENUM_BOUNDARY

--- a/packages/browseros/chromium_patches/tools/metrics/histograms/metadata/browser/enums.xml
+++ b/packages/browseros/chromium_patches/tools/metrics/histograms/metadata/browser/enums.xml
@@ -1,12 +1,13 @@
 diff --git a/tools/metrics/histograms/metadata/browser/enums.xml b/tools/metrics/histograms/metadata/browser/enums.xml
-index e4c6dfc3429a3..d90a93ba344bc 100644
+index e4c6dfc3429a3..181b143095c88 100644
 --- a/tools/metrics/histograms/metadata/browser/enums.xml
 +++ b/tools/metrics/histograms/metadata/browser/enums.xml
-@@ -367,6 +367,7 @@ chromium-metrics-reviews@google.com.
+@@ -367,6 +367,8 @@ chromium-metrics-reviews@google.com.
    <int value="132" label="AUTOFILL_AI_SAVE_ENTITY_INFOBAR_DELEGATE_IOS"/>
    <int value="133" label="JS_OPTIMIZATIONS_INFOBAR_DELEGATE"/>
    <int value="134" label="WEB_APP_BLOCKED_MIGRATION_INFOBAR_DELEGATE"/>
 +  <int value="135" label="BROWSEROS_AGENT_INSTALLING_INFOBAR_DELEGATE"/>
++  <int value="136" label="BROWSEROS_EXTENSION_INFOBAR_DELEGATE"/>
  </enum>
  
  <!-- LINT.ThenChange(//components/infobars/core/infobar_delegate.h:InfoBarIdentifier) -->

--- a/packages/browseros/chromium_patches/tools/metrics/histograms/metadata/extensions/enums.xml
+++ b/packages/browseros/chromium_patches/tools/metrics/histograms/metadata/extensions/enums.xml
@@ -1,8 +1,8 @@
 diff --git a/tools/metrics/histograms/metadata/extensions/enums.xml b/tools/metrics/histograms/metadata/extensions/enums.xml
-index 67daa1883b62f..b0374d92a0709 100644
+index 67daa1883b62f..ee0a736394d66 100644
 --- a/tools/metrics/histograms/metadata/extensions/enums.xml
 +++ b/tools/metrics/histograms/metadata/extensions/enums.xml
-@@ -2891,6 +2891,32 @@ Called by update_extension_histograms.py.-->
+@@ -2891,6 +2891,33 @@ Called by update_extension_histograms.py.-->
        label="AUTOFILLPRIVATE_GETREQUIREDATTRIBUTETYPESFORENTITYTYPENAME"/>
    <int value="1960" label="PDFVIEWERPRIVATE_GLICSUMMARIZE"/>
    <int value="1961" label="GLICPRIVATE_GETSTATE"/>
@@ -32,10 +32,11 @@ index 67daa1883b62f..b0374d92a0709 100644
 +  <int value="1985" label="BROWSER_OS_GETBROWSEROSVERSIONNUMBER"/>
 +  <int value="1986" label="BROWSER_OS_CHOOSEPATH"/>
 +  <int value="1987" label="BROWSER_OS_SHOWTOAST"/>
++  <int value="1988" label="BROWSER_OS_SHOWINFOBAR"/>
  </enum>
  
  <!-- LINT.ThenChange(//extensions/browser/extension_function_histogram_value.h:HistogramValue) -->
-@@ -3282,6 +3308,7 @@ Called by update_extension_permission.py.-->
+@@ -3282,6 +3309,7 @@ Called by update_extension_permission.py.-->
    <int value="263" label="kEnterpriseLogin"/>
    <int value="264" label="kProxyOverrideRulesPrivate"/>
    <int value="265" label="kGlicPrivate"/>


### PR DESCRIPTION
## Summary
- add `chrome.browserOS.showInfoBar(message, callback)` to the BrowserOS extension API patch
- add the BrowserOS extension infobar delegate and metrics IDs, keeping `showToast` at `1987` and using `showInfoBar` at `1988`
- extract corrected Chromium squash commit `d74636bf879f5b3bd6dd127466cc7143f5344b91` into BrowserOS patches

## Design
`showInfoBar` follows the existing BrowserOS extension API pattern and displays a simple alert infobar in the active BrowserOS/Chrome tab. It uses the same confirm-infobar creation path as Chromium's simple alert helper, but calls `InfoBarManager::AddInfoBar` directly so the callback reports whether the infobar was actually accepted.

## Test plan
- [x] `/Users/shadowfax/.skills/sf-ch-mux/scripts/chpool build -- autoninja -C out/Default_arm64 chrome`
- [x] `/Users/shadowfax/.skills/sf-ch-extract/scripts/verify-patches.sh --chromium-src /Users/shadowfax/ch2-src --worktree /Users/shadowfax/worktrees/main/feat-browseros-show-infobar-patches --tip d74636bf879f5b3bd6dd127466cc7143f5344b91`
- [x] `git diff --check`