### PR TITLE
fix: replace Record<string, any> with Record<string, unknown> in GraphQL hooks

### DIFF
--- a/packages/browseros-agent/apps/agent/lib/constants/mediaUrls.ts
+++ b/packages/browseros-agent/apps/agent/lib/constants/mediaUrls.ts
@@ -30,21 +30,18 @@ export const QUICK_SEARCH_GIF_URL =
 
 /**
  * @public
- * TODO: Replace with actual video URL
  */
 export const COWORK_DEMO_URL =
   'https://pub-80f8a01e6e8b4239ae53a7652ef85877.r2.dev/resources/organize%20files%20on%20desktop%201.4x.mp4'
 
 /**
  * @public
- * TODO: Replace with actual video URL
  */
 export const WORKFLOWS_DEMO_URL =
   'https://pub-80f8a01e6e8b4239ae53a7652ef85877.r2.dev/resources/browseros-workflow-demo.mp4'
 
 /**
  * @public
- * TODO: Replace with actual video URL
  */
 export const AGENTIC_CODING_DEMO_URL =
   'https://pub-80f8a01e6e8b4239ae53a7652ef85877.r2.dev/resources/cowork-hn-extract-demo.mp4'

--- a/packages/browseros-agent/apps/agent/lib/graphql/getQueryKeyFromDocument.ts
+++ b/packages/browseros-agent/apps/agent/lib/graphql/getQueryKeyFromDocument.ts
@@ -1,8 +1,8 @@
 import { parse } from 'graphql'
 import type { TypedDocumentString } from '@/generated/graphql/graphql'
 
-const getOperationName = <T, V>(
-  doc: TypedDocumentString<T, V>,
+const getOperationName = <TResult, TVariables>(
+  doc: TypedDocumentString<TResult, TVariables>,
 ): string | null => {
   // Fallback to parsing
   const parsed = parse(doc.toString())
@@ -15,8 +15,7 @@ const getOperationName = <T, V>(
 
 export const getQueryKeyFromDocument = <
   TResult,
-  // biome-ignore lint/suspicious/noExplicitAny: TODO(dani) type GraphQL variables properly
-  TVariables extends Record<string, any> | undefined = undefined,
+  TVariables extends Record<string, unknown> = Record<string, never>,
 >(
   doc: TypedDocumentString<TResult, TVariables>,
 ) => {

--- a/packages/browseros-agent/apps/agent/modules/graphql/graphql-infinite-query.hooks.ts
+++ b/packages/browseros-agent/apps/agent/modules/graphql/graphql-infinite-query.hooks.ts
@@ -13,8 +13,7 @@ import { getQueryKeyFromDocument } from '@/lib/graphql/getQueryKeyFromDocument'
  */
 export const useGraphqlInfiniteQuery = <
   TQueryFnData,
-  // biome-ignore lint/suspicious/noExplicitAny: TODO(dani) type GraphQL variables properly
-  TVariables extends Record<string, any> | undefined = undefined,
+  TVariables extends Record<string, unknown> = Record<string, never>,
   TPageParam extends string | undefined | number = undefined,
 >(
   query: TypedDocumentString<TQueryFnData, TVariables>,

--- a/packages/browseros-agent/apps/agent/modules/graphql/graphql-query.hooks.ts
+++ b/packages/browseros-agent/apps/agent/modules/graphql/graphql-query.hooks.ts
@@ -8,8 +8,7 @@ import { getQueryKeyFromDocument } from '@/lib/graphql/getQueryKeyFromDocument'
  */
 export const useGraphqlQuery = <
   TResult,
-  // biome-ignore lint/suspicious/noExplicitAny: TODO(dani) type GraphQL variables properly
-  TVariables extends Record<string, any> | undefined = undefined,
+  TVariables extends Record<string, unknown> = Record<string, never>,
 >(
   query: TypedDocumentString<TResult, TVariables>,
   variables?: TVariables,


### PR DESCRIPTION
## Description:
- Remove stale TODOs from mediaUrls.ts (URLs already present)
- Rename ambiguous type params T/V to TResult/TVariables
- Replace Record<string, any> | undefined with Record<string, unknown> = Record<string, never>
- Remove no-longer-needed biome-ignore suppressions

### CLA Signature
I have read the CLA Document and I hereby sign the CLA