### PR TITLE
feat: use dedicated bundled extension manifest

### DIFF
--- a/packages/browseros/build/common/context.py
+++ b/packages/browseros/build/common/context.py
@@ -434,9 +434,8 @@ class Context:
         return f"https://github.com/vslavik/winsparkle/releases/download/v{self.WINSPARKLE_VERSION}/WinSparkle-{self.WINSPARKLE_VERSION}.zip"
 
     def get_extensions_manifest_url(self) -> str:
-        """Get CDN URL for bundled extensions update manifest"""
-        # return "https://cdn.browseros.com/extensions/update-manifest.xml"
-        return "https://cdn.browseros.com/extensions/update-manifest.alpha.xml"
+        """Get CDN URL for bundled extensions manifest"""
+        return "https://cdn.browseros.com/extensions/bundled-manifest.xml"
 
     def get_entitlements_dir(self) -> Path:
         """Get entitlements directory"""

--- a/packages/browseros/build/common/context_test.py
+++ b/packages/browseros/build/common/context_test.py
@@ -9,6 +9,18 @@ from .context import Context
 
 
 class GetAppPathTest(unittest.TestCase):
+    def test_extensions_manifest_url_uses_dedicated_bundled_manifest(self):
+        ctx = Context(
+            chromium_src=Path("/nonexistent-src"),
+            architecture="arm64",
+            build_type="release",
+        )
+
+        self.assertEqual(
+            ctx.get_extensions_manifest_url(),
+            "https://cdn.browseros.com/extensions/bundled-manifest.xml",
+        )
+
     def test_arch_build_ignores_stale_universal_app(self):
         # Regression: a leftover out/Default_universal app must never hijack
         # an arch-specific build's sign/package stages.

--- a/packages/browseros/build/modules/extensions/bundled_extensions.py
+++ b/packages/browseros/build/modules/extensions/bundled_extensions.py
@@ -11,7 +11,7 @@ import requests
 
 from ...common.context import Context
 from ...common.module import CommandModule, ValidationError
-from ...common.utils import log_info, log_success, log_error
+from ...common.utils import log_info, log_success
 
 
 class ExtensionInfo(NamedTuple):

--- a/packages/browseros/build/modules/extensions/bundled_extensions_test.py
+++ b/packages/browseros/build/modules/extensions/bundled_extensions_test.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+"""Tests for bundled extension manifest handling."""
+
+import unittest
+from pathlib import Path
+
+from build.modules.extensions.bundled_extensions import BundledExtensionsModule
+
+
+class BundledExtensionsManifestTest(unittest.TestCase):
+    def test_bundled_manifest_parses_requested_alpha_entries(self) -> None:
+        repo_root = Path(__file__).resolve().parents[5]
+        manifest_path = repo_root / "updates" / "extensions" / "bundled-manifest.xml"
+
+        extensions = BundledExtensionsModule()._parse_manifest_xml(
+            manifest_path.read_text()
+        )
+
+        self.assertEqual(
+            extensions,
+            [
+                (
+                    "adlpneommgkgeanpaekgoaolcpncohkf",
+                    "52.0.0.0",
+                    "https://cdn.browseros.com/extensions/bugreporter-52.0.0.0.crx",
+                ),
+                (
+                    "nlnihljpboknmfagkikhkdblbedophja",
+                    "1.1.0.0",
+                    "https://cdn.browseros.com/extensions/controller-1.1.0.0.crx",
+                ),
+                (
+                    "bflpfmnmnokmjhmgnolecpppdbdophmk",
+                    "0.0.115.0",
+                    "https://cdn.browseros.com/extensions/agent-0.0.115.0.crx",
+                ),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/updates/extensions/bundled-manifest.xml
+++ b/updates/extensions/bundled-manifest.xml
@@ -1,0 +1,12 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<gupdate xmlns="http://www.google.com/update2/response" protocol="2.0">
+  <app appid="adlpneommgkgeanpaekgoaolcpncohkf">
+    <updatecheck codebase="https://cdn.browseros.com/extensions/bugreporter-52.0.0.0.crx" version="52.0.0.0"/>
+  </app>
+  <app appid="nlnihljpboknmfagkikhkdblbedophja">
+    <updatecheck codebase="https://cdn.browseros.com/extensions/controller-1.1.0.0.crx" version="1.1.0.0"/>
+  </app>
+  <app appid="bflpfmnmnokmjhmgnolecpppdbdophmk">
+    <updatecheck codebase="https://cdn.browseros.com/extensions/agent-0.0.115.0.crx" version="0.0.115.0"/>
+  </app>
+</gupdate>


### PR DESCRIPTION
## Summary
- Point build-time bundled extension downloads at `https://cdn.browseros.com/extensions/bundled-manifest.xml` instead of the alpha update manifest.
- Add `updates/extensions/bundled-manifest.xml` with the copied alpha extension entries for the bundled source.
- Add regression tests for the context URL and manifest parsing.

## Design
The existing bundled extension downloader still owns XML parsing, CRX downloads, and `bundled_extensions.json` generation. This PR only changes the build context URL that feeds that downloader and adds the new checked-in XML source file.

## Test plan
- [x] `uv run --project packages/browseros ruff check packages/browseros/build/common/context.py packages/browseros/build/common/context_test.py packages/browseros/build/modules/extensions/bundled_extensions.py packages/browseros/build/modules/extensions/bundled_extensions_test.py`
- [x] `uv run --project packages/browseros python -m unittest build.common.context_test build.modules.extensions.bundled_extensions_test`
- [x] `uv run --project packages/browseros python -m unittest discover -s packages/browseros/build -p '*_test.py'`