### PR TITLE
fix: gate Hermes support on server version

### DIFF
--- a/packages/browseros-agent/apps/agent/lib/browseros/capabilities.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/capabilities.test.ts
@@ -67,7 +67,7 @@ describe('resolveStaticFeatureSupport', () => {
 })
 
 describe('resolveFeatureStaticSupport', () => {
-  it('gates Hermes support on alpha features', () => {
+  it('gates Hermes support on alpha before server version checks', () => {
     expect(
       resolveFeatureStaticSupport({
         feature: Feature.HERMES_AGENT_SUPPORT,
@@ -90,7 +90,7 @@ describe('resolveFeatureStaticSupport', () => {
         isDevelopment: false,
         alphaFeaturesEnabled: true,
       }),
-    ).toBe(true)
+    ).toBeNull()
   })
 
   it('preserves alpha-gated support for alpha features', () => {
@@ -132,12 +132,19 @@ describe('checkFeatureSupport — AGENT_HARNESS_SUPPORT', () => {
 })
 
 describe('checkFeatureSupport — HERMES_AGENT_SUPPORT', () => {
-  it('has no version dependency once static support allows it', () => {
-    expect(
-      checkFeatureSupport(
-        { browserOSVersion: null, serverVersion: null },
-        Feature.HERMES_AGENT_SUPPORT,
-      ),
-    ).toBe(true)
+  const at = (serverVersion: number[] | null) =>
+    checkFeatureSupport(
+      { browserOSVersion: null, serverVersion },
+      Feature.HERMES_AGENT_SUPPORT,
+    )
+
+  it('hides Hermes below server 0.0.116 or when version is unknown', () => {
+    expect(at(null)).toBe(false)
+    expect(at([0, 0, 115])).toBe(false)
+  })
+
+  it('shows Hermes at or above server 0.0.116', () => {
+    expect(at([0, 0, 116])).toBe(true)
+    expect(at([0, 0, 117])).toBe(true)
   })
 })

--- a/packages/browseros-agent/apps/agent/lib/browseros/capabilities.ts
+++ b/packages/browseros-agent/apps/agent/lib/browseros/capabilities.ts
@@ -61,7 +61,19 @@ const FEATURE_CONFIG: { [K in Feature]: FeatureConfig } = {
   [Feature.QWEN_CODE_SUPPORT]: { minServerVersion: '0.0.77' },
   [Feature.CREDITS_SUPPORT]: { minServerVersion: '0.0.78' },
   [Feature.AGENT_HARNESS_SUPPORT]: { minBrowserOSVersion: '0.46.0.0' },
-  [Feature.HERMES_AGENT_SUPPORT]: { requiresAlphaFlag: true },
+  [Feature.HERMES_AGENT_SUPPORT]: {
+    requiresAlphaFlag: true,
+    minServerVersion: '0.0.116',
+  },
+}
+
+function hasVersionConstraints(config: FeatureConfig): boolean {
+  return Boolean(
+    config.minBrowserOSVersion ||
+      config.maxBrowserOSVersion ||
+      config.minServerVersion ||
+      config.maxServerVersion,
+  )
 }
 
 function parseVersion(version: string): number[] {
@@ -126,7 +138,7 @@ export function resolveStaticFeatureSupport({
   return null
 }
 
-/** Applies configured static gates with caller-provided environment flags. */
+/** Applies static gates, falling through when version gates still need evaluation. */
 export function resolveFeatureStaticSupport({
   feature,
   isDevelopment,
@@ -138,12 +150,15 @@ export function resolveFeatureStaticSupport({
 }): boolean | null {
   const config = FEATURE_CONFIG[feature]
   if (!config) return false
-  return resolveStaticFeatureSupport({
+  const staticSupport = resolveStaticFeatureSupport({
     isDevelopment,
     alphaFeaturesEnabled,
     requiresDevelopmentFlag: config.requiresDevelopmentFlag,
     requiresAlphaFlag: config.requiresAlphaFlag,
   })
+  if (staticSupport !== true) return staticSupport
+  if (hasVersionConstraints(config) && !isDevelopment) return null
+  return true
 }
 
 export type CapabilitiesState = {

--- a/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.test.tsx
+++ b/packages/browseros-agent/apps/agent/screens/customization/ToolbarSettingsCard.test.tsx
@@ -83,11 +83,13 @@ function resolveFeatureStaticSupport({
   alphaFeaturesEnabled: boolean
 }): boolean | null {
   if (feature === Feature.HERMES_AGENT_SUPPORT) {
-    return resolveStaticFeatureSupport({
+    const staticSupport = resolveStaticFeatureSupport({
       isDevelopment,
       alphaFeaturesEnabled,
       requiresAlphaFlag: true,
     })
+    if (staticSupport !== true) return staticSupport
+    return isDevelopment ? true : null
   }
   if (feature === Feature.ALPHA_FEATURES_SUPPORT) {
     return alphaFeaturesEnabled
@@ -103,7 +105,7 @@ function checkFeatureSupport(
     return compareVersionAtLeast(state.browserOSVersion, [0, 46, 0, 0])
   }
   if (feature === Feature.HERMES_AGENT_SUPPORT) {
-    return true
+    return compareVersionAtLeast(state.serverVersion, [0, 0, 116])
   }
   return false
 }


### PR DESCRIPTION
## Summary
- Keep Hermes agent support behind the alpha feature flag.
- Add a minimum BrowserOS server version gate of `0.0.116` for Hermes.
- Make satisfied static gates fall through when a feature also has version constraints, so alpha is necessary but not sufficient.

## Design
Hermes stays in the existing `FEATURE_CONFIG` map with `requiresAlphaFlag: true` plus `minServerVersion: '0.0.116'`. `resolveFeatureStaticSupport` now returns `null` when static gates pass but version gates still need evaluation, preserving the existing `Capabilities.supports()` flow without adding Hermes-specific branching.

## Test plan
- [x] `bun test apps/agent/lib/browseros/capabilities.test.ts`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test:main`
- [x] `bun run check`