### PR TITLE
fix(agent): install MCP against the proxy URL + bump agent-mcp-manager to v0.0.2

### DIFF
--- a/packages/browseros-agent/apps/agent/screens/mcp-settings/IntegrationsSection.tsx
+++ b/packages/browseros-agent/apps/agent/screens/mcp-settings/IntegrationsSection.tsx
@@ -24,7 +24,7 @@ export const IntegrationsSection: FC<IntegrationsSectionProps> = ({
   serverUrl,
 }) => {
   const agentsQuery = useMcpAgents()
-  const install = useInstallAgent()
+  const install = useInstallAgent(serverUrl)
   const uninstall = useUninstallAgent()
   const [errors, setErrors] = useState<Record<string, string | null>>({})
 

--- a/packages/browseros-agent/apps/agent/screens/mcp-settings/IntegrationsSection.tsx
+++ b/packages/browseros-agent/apps/agent/screens/mcp-settings/IntegrationsSection.tsx
@@ -123,6 +123,7 @@ export const IntegrationsSection: FC<IntegrationsSectionProps> = ({
                   (uninstall.isPending && uninstall.variables === agent.id)
                 }
                 error={errors[agent.id] ?? null}
+                canConnect={serverUrl !== null}
                 onInstall={handleInstall}
                 onUninstall={handleUninstall}
               />
@@ -154,6 +155,8 @@ interface AgentRowProps {
   agent: McpAgentRow
   busy: boolean
   error: string | null
+  /** False while the proxy URL hasn't resolved yet — disables Connect. */
+  canConnect: boolean
   onInstall: (id: string) => void
   onUninstall: (id: string) => void
 }
@@ -162,6 +165,7 @@ const AgentRow: FC<AgentRowProps> = ({
   agent,
   busy,
   error,
+  canConnect,
   onInstall,
   onUninstall,
 }) => {
@@ -224,7 +228,16 @@ const AgentRow: FC<AgentRowProps> = ({
           </Button>
         )}
         {agent.installed && !agent.linked && (
-          <Button size="sm" disabled={busy} onClick={() => onInstall(agent.id)}>
+          <Button
+            size="sm"
+            disabled={busy || !canConnect}
+            onClick={() => onInstall(agent.id)}
+            title={
+              !canConnect
+                ? 'Waiting for the MCP server URL to load…'
+                : undefined
+            }
+          >
             {busy && <Loader2 className="mr-1.5 h-3.5 w-3.5 animate-spin" />}
             Connect
           </Button>

--- a/packages/browseros-agent/apps/agent/screens/mcp-settings/integrations-section.hooks.ts
+++ b/packages/browseros-agent/apps/agent/screens/mcp-settings/integrations-section.hooks.ts
@@ -33,12 +33,14 @@ async function callMutation(
   agentServerUrl: string,
   agentId: string,
   action: 'install' | 'uninstall',
+  payload?: Record<string, unknown>,
 ): Promise<MutationResponse> {
   const res = await fetch(
     `${agentServerUrl}/mcp-manager/agents/${encodeURIComponent(agentId)}/${action}`,
     {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload ?? {}),
     },
   )
   const body = (await res.json().catch(() => ({}))) as MutationResponse
@@ -62,14 +64,22 @@ export function useMcpAgents() {
   })
 }
 
-/** Mutation: install BrowserOS as MCP into a single agent. */
-export function useInstallAgent() {
+/**
+ * Mutation: install BrowserOS as MCP into a single agent. Takes the
+ * proxy-facing MCP URL so the agent's on-disk config records the
+ * URL external clients can actually reach (NOT the agent server's
+ * internal port — those differ in production where the browser
+ * proxies `/mcp` to the agent server).
+ */
+export function useInstallAgent(mcpUrl: string | null) {
   const { baseUrl } = useAgentServerUrl()
   const queryClient = useQueryClient()
   return useMutation({
     mutationFn: async (agentId: string) => {
       if (!baseUrl) throw new Error('Agent server URL is unavailable')
-      return callMutation(baseUrl, agentId, 'install')
+      return callMutation(baseUrl, agentId, 'install', {
+        mcpUrl: mcpUrl ?? undefined,
+      })
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: AGENTS_QUERY_KEY })

--- a/packages/browseros-agent/apps/agent/screens/mcp-settings/integrations-section.hooks.ts
+++ b/packages/browseros-agent/apps/agent/screens/mcp-settings/integrations-section.hooks.ts
@@ -70,6 +70,13 @@ export function useMcpAgents() {
  * URL external clients can actually reach (NOT the agent server's
  * internal port — those differ in production where the browser
  * proxies `/mcp` to the agent server).
+ *
+ * Throws synchronously if `mcpUrl` is null. Omitting it would let
+ * the server fall back to its own internal URL — exactly the wrong
+ * value, since that's the bug this whole surface fixes. The Connect
+ * button is disabled when the URL hasn't resolved yet, but this
+ * guard means a stale render or programmatic caller can't bypass
+ * that.
  */
 export function useInstallAgent(mcpUrl: string | null) {
   const { baseUrl } = useAgentServerUrl()
@@ -77,9 +84,12 @@ export function useInstallAgent(mcpUrl: string | null) {
   return useMutation({
     mutationFn: async (agentId: string) => {
       if (!baseUrl) throw new Error('Agent server URL is unavailable')
-      return callMutation(baseUrl, agentId, 'install', {
-        mcpUrl: mcpUrl ?? undefined,
-      })
+      if (!mcpUrl) {
+        throw new Error(
+          'MCP server URL is not ready yet. Wait for the page to finish loading and try again.',
+        )
+      }
+      return callMutation(baseUrl, agentId, 'install', { mcpUrl })
     },
     onSettled: () => {
       queryClient.invalidateQueries({ queryKey: AGENTS_QUERY_KEY })

--- a/packages/browseros-agent/apps/server/package.json
+++ b/packages/browseros-agent/apps/server/package.json
@@ -88,7 +88,7 @@
     "acp-probe": "^0.0.2",
     "acpx": "^0.10.0",
     "acpx-ai-provider": "^0.0.6",
-    "agent-mcp-manager": "^0.0.1",
+    "agent-mcp-manager": "^0.0.2",
     "ai": "^6.0.94",
     "commander": "^14.0.1",
     "core-js": "3.45.1",

--- a/packages/browseros-agent/apps/server/src/api/routes/mcp-manager.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/mcp-manager.ts
@@ -5,6 +5,7 @@
  */
 
 import { Hono } from 'hono'
+import { z } from 'zod'
 import {
   humaniseInstallError,
   installInto,
@@ -14,12 +15,25 @@ import {
 
 interface McpManagerRouteOptions {
   /**
-   * Returns the BrowserOS MCP URL the running server bound to. Hot
-   * because the URL can change between server restarts, so the route
-   * reads it per-request rather than caching at module load time.
+   * Fallback BrowserOS MCP URL the agent server bound to internally.
+   * Only used when the client doesn't pass `mcpUrl` in the install
+   * request body. Hot because the URL can change between server
+   * restarts.
+   *
+   * NOTE: the agent server's own port is NOT the URL external MCP
+   * clients reach. The browser proxies `/mcp` from the user-facing
+   * port to the agent server. The UI always sends the proxy URL via
+   * `mcpUrl`; this fallback exists only for programmatic callers
+   * that have no other source.
    */
   getMcpUrl: () => string
 }
+
+const InstallBodySchema = z
+  .object({
+    mcpUrl: z.string().url().optional(),
+  })
+  .partial()
 
 export function createMcpManagerRoutes(options: McpManagerRouteOptions) {
   const { getMcpUrl } = options
@@ -36,8 +50,20 @@ export function createMcpManagerRoutes(options: McpManagerRouteOptions) {
     })
     .post('/agents/:id/install', async (c) => {
       const id = c.req.param('id')
+      const raw = await c.req.json().catch(() => ({}))
+      const parsed = InstallBodySchema.safeParse(raw)
+      if (!parsed.success) {
+        return c.json(
+          {
+            success: false,
+            message: 'Invalid request body: mcpUrl must be a URL.',
+          },
+          400,
+        )
+      }
+      const url = parsed.data.mcpUrl ?? getMcpUrl()
       try {
-        const result = await installInto(id, getMcpUrl())
+        const result = await installInto(id, url)
         return c.json(result, 200)
       } catch (err) {
         const { message, status } = humaniseInstallError(err)

--- a/packages/browseros-agent/apps/server/src/lib/mcp-manager/service.ts
+++ b/packages/browseros-agent/apps/server/src/lib/mcp-manager/service.ts
@@ -114,6 +114,13 @@ export async function listAgents(
  * layer; if the URL drifted, the older entry is replaced before
  * linking. Stdio-only agents are linked under a separate server
  * name so each transport keeps its own manifest entry.
+ *
+ * Also sweeps the OPPOSITE server name's link for this agent.
+ * Without this, an agent that was first installed under the http
+ * server `browseros` and later re-routed to stdio by the upstream
+ * catalog (or vice versa) would end up double-linked, with the
+ * stale entry surviving every uninstall click that targets only
+ * the current planFor() server.
  */
 export async function installInto(
   agentId: string,
@@ -124,6 +131,8 @@ export async function installInto(
   }
   const mgr = getMcpManager()
   const { serverName, spec } = planFor(agentId, currentUrl)
+
+  await sweepLegacyLinks(agentId, serverName)
 
   // `add` overwrites when the entry already exists; safe to call
   // unconditionally on every install click so a URL drift gets
@@ -138,10 +147,18 @@ export async function installInto(
 }
 
 /**
- * Uninstall BrowserOS from the given agent's config. Idempotent on
- * the manifest side; throws ForeignEntryError when the user has
- * hand-edited the entry and the disk record no longer matches the
- * manifest record.
+ * Uninstall BrowserOS from the given agent's config. Tries every
+ * server name BrowserOS manages because the same agent may be
+ * linked under either `browseros` (http) or `browseros-stdio`
+ * depending on when it was last installed: the upstream catalog's
+ * transport classification for a given agent can flip between
+ * library versions, and a stale link under the prior server name
+ * would otherwise survive forever.
+ *
+ * Returns success when at least one server-name unlink completed.
+ * Surfaces ForeignEntryError when the user hand-edited the disk
+ * entry past what the manifest tracks; that case can only be
+ * cleaned up manually.
  */
 export async function uninstallFrom(
   agentId: string,
@@ -150,23 +167,52 @@ export async function uninstallFrom(
     throw new AgentNotSupportedError(agentId)
   }
   const mgr = getMcpManager()
-  const { serverName } = planFor(agentId, '')
-  try {
-    await mgr.unlink({ serverName, agent: agentId })
-    logger.info('Uninstalled BrowserOS MCP from agent', {
-      agent: agentId,
-      serverName,
-    })
-    return { success: true }
-  } catch (err) {
-    if (err instanceof ForeignEntryError) {
-      return {
-        success: false,
-        message:
-          'Cannot remove a user-edited entry. Please remove BrowserOS from this agent manually and try again.',
+  let foreignError: ForeignEntryError | null = null
+  for (const serverName of BROWSEROS_SERVER_NAMES) {
+    try {
+      await mgr.unlink({ serverName, agent: agentId })
+      logger.info('Uninstalled BrowserOS MCP from agent', {
+        agent: agentId,
+        serverName,
+      })
+    } catch (err) {
+      if (err instanceof ForeignEntryError) {
+        foreignError = err
+        continue
       }
+      throw err
     }
-    throw err
+  }
+  if (foreignError) {
+    return {
+      success: false,
+      message:
+        'Cannot remove a user-edited entry. Please remove BrowserOS from this agent manually and try again.',
+    }
+  }
+  return { success: true }
+}
+
+/**
+ * Cleans any pre-existing BrowserOS link for `agentId` under server
+ * names other than the one we're about to link under. Best-effort:
+ * ForeignEntryError is swallowed (the user hand-edited the foreign
+ * entry; let them keep it and overwrite the manifest below). Any
+ * other error rethrows so install fails loudly.
+ */
+async function sweepLegacyLinks(
+  agentId: AgentId,
+  targetServerName: string,
+): Promise<void> {
+  const mgr = getMcpManager()
+  for (const serverName of BROWSEROS_SERVER_NAMES) {
+    if (serverName === targetServerName) continue
+    try {
+      await mgr.unlink({ serverName, agent: agentId })
+    } catch (err) {
+      if (err instanceof ForeignEntryError) continue
+      throw err
+    }
   }
 }
 

--- a/packages/browseros-agent/apps/server/src/lib/mcp-manager/service.ts
+++ b/packages/browseros-agent/apps/server/src/lib/mcp-manager/service.ts
@@ -8,6 +8,7 @@
  */
 
 import {
+  type AgentId,
   type AgentInfo,
   AgentNotSupportedError,
   detectInstalledAgents,
@@ -16,6 +17,8 @@ import {
   type McpHttpSpec,
   type McpServerSpec,
   type McpStdioSpec,
+  resolveAgentSurface,
+  UnsupportedTransportError,
 } from 'agent-mcp-manager'
 import { logger } from '../logger'
 import {
@@ -41,13 +44,6 @@ export type DetectInstalledAgentsFn = () => Promise<AgentInfo[]>
 const HIDDEN_AGENTS: ReadonlySet<string> = new Set(['gemini'])
 
 /**
- * Agents that reject HTTP MCP specs and only accept stdio. We install
- * BrowserOS into these via `npx mcp-remote <url>` so a stdio client
- * still ends up talking to the local HTTP MCP endpoint.
- */
-const STDIO_ONLY_AGENTS: ReadonlySet<string> = new Set(['codex'])
-
-/**
  * The two server-names BrowserOS manages in the manifest. Iterating
  * both is what `listAgents` + `reconcileUrl` need to do.
  */
@@ -61,9 +57,20 @@ interface AgentServerPlan {
   spec: McpServerSpec
 }
 
-/** Pick the server name + spec a given agent should be linked under. */
-function planFor(agentId: string, currentUrl: string): AgentServerPlan {
-  if (STDIO_ONLY_AGENTS.has(agentId)) {
+/**
+ * Pick the server name + spec a given agent should be linked under.
+ *
+ * Transport routing is sourced from the library's catalog via
+ * `resolveAgentSurface` so we stay in lock-step with whatever
+ * upstream agent-mcp-manager classifies as http-capable. Agents
+ * that only accept stdio (claude-desktop, codex, …) get wrapped
+ * via `npx mcp-remote <url>` so a stdio client still ends up
+ * talking to the local HTTP MCP endpoint.
+ */
+function planFor(agentId: AgentId, currentUrl: string): AgentServerPlan {
+  const surface = resolveAgentSurface(agentId, 'system')
+  const supportsHttp = surface.supportedTransports.includes('http')
+  if (!supportsHttp) {
     const spec: McpStdioSpec = {
       transport: 'stdio',
       command: 'npx',
@@ -175,6 +182,12 @@ export function humaniseInstallError(err: unknown): {
       message:
         "Cannot replace a user-edited entry. Please remove BrowserOS from this agent's config manually and try again.",
       status: 409,
+    }
+  }
+  if (err instanceof UnsupportedTransportError) {
+    return {
+      message: `This agent does not support BrowserOS's MCP transport. ${err.message}`,
+      status: 400,
     }
   }
   const message = err instanceof Error ? err.message : String(err)

--- a/packages/browseros-agent/apps/server/src/main.ts
+++ b/packages/browseros-agent/apps/server/src/main.ts
@@ -106,20 +106,30 @@ export class Application {
     }
 
     // Reconcile every linked agent's BrowserOS MCP URL against the
-    // port we just bound. Drift only happens on restart when the
-    // previous port is taken, but we run unconditionally because the
-    // listServers check is cheap and the cost of a missed reconcile
-    // is broken agent configs.
-    reconcileUrl({
-      currentUrl: `http://127.0.0.1:${this.config.serverPort}/mcp`,
-    }).catch((err) => {
-      logger.warn(
-        'MCP manager URL reconcile failed; agent configs may be stale',
-        {
-          error: err instanceof Error ? err.message : String(err),
-        },
+    // proxy URL external clients actually reach. The agent server's
+    // own `serverPort` is NOT that URL — in production the browser
+    // proxies `/mcp` from a separately-configured proxy port. We
+    // only reconcile when the launching process passes the public
+    // URL via `BROWSEROS_MCP_PUBLIC_URL`; otherwise we'd rewrite
+    // every agent config with the wrong port and break installs that
+    // were previously working. The UI's install flow records the
+    // correct URL per click; reconcile is the boot-time recovery
+    // path for port drift.
+    const publicMcpUrl = process.env.BROWSEROS_MCP_PUBLIC_URL
+    if (publicMcpUrl) {
+      reconcileUrl({ currentUrl: publicMcpUrl }).catch((err) => {
+        logger.warn(
+          'MCP manager URL reconcile failed; agent configs may be stale',
+          {
+            error: err instanceof Error ? err.message : String(err),
+          },
+        )
+      })
+    } else {
+      logger.debug(
+        'Skipping MCP manager URL reconcile — BROWSEROS_MCP_PUBLIC_URL not set',
       )
-    })
+    }
 
     logger.info(
       `HTTP server listening on http://127.0.0.1:${this.config.serverPort}`,

--- a/packages/browseros-agent/apps/server/tests/lib/mcp-manager/service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/mcp-manager/service.test.ts
@@ -265,6 +265,27 @@ describe('installInto', () => {
     expect(calls.link[0].serverName).toBe('browseros-stdio')
   })
 
+  it('sweeps the opposite server name before linking, so an agent never ends up double-linked', async () => {
+    // claude-desktop is stdio-only in v0.0.2; if a v0.0.1 install
+    // left a legacy `browseros` (http) link for the same agent,
+    // installInto must unlink it before linking under
+    // `browseros-stdio`. Otherwise an uninstall click later (which
+    // sweeps both names) would silently delete a "fresh" install
+    // the user just clicked.
+    const { manager, calls } = makeManagerStub()
+    setMcpManagerForTesting(manager)
+    const result = await installInto(
+      'claude-desktop',
+      'http://127.0.0.1:9100/mcp',
+    )
+    expect(result.success).toBe(true)
+    expect(calls.unlink).toHaveLength(1)
+    expect(calls.unlink[0].serverName).toBe('browseros')
+    expect(calls.unlink[0].agent).toBe('claude-desktop')
+    expect(calls.link).toHaveLength(1)
+    expect(calls.link[0].serverName).toBe('browseros-stdio')
+  })
+
   it('rejects unsupported agent ids', async () => {
     const { manager } = makeManagerStub()
     setMcpManagerForTesting(manager)
@@ -275,22 +296,53 @@ describe('installInto', () => {
 })
 
 describe('uninstallFrom', () => {
-  it('calls unlink and returns success on the happy path', async () => {
+  it('sweeps both server names on uninstall and returns success', async () => {
+    // The same agent can be linked under either `browseros` (http) or
+    // `browseros-stdio` (mcp-remote shim) depending on which version
+    // of the agent-mcp-manager catalog wrote the link. Uninstall
+    // must hit both so a legacy link under the prior server name
+    // cannot survive forever.
     const { manager, calls } = makeManagerStub()
     setMcpManagerForTesting(manager)
     const out = await uninstallFrom('claude-code')
     expect(out.success).toBe(true)
-    expect(calls.unlink).toHaveLength(1)
-    expect(calls.unlink[0].serverName).toBe('browseros')
+    expect(calls.unlink).toHaveLength(2)
+    expect(calls.unlink.map((c) => c.serverName).sort()).toEqual([
+      'browseros',
+      'browseros-stdio',
+    ])
+    for (const call of calls.unlink) {
+      expect(call.agent).toBe('claude-code')
+    }
   })
 
-  it('unlinks codex from the stdio server name', async () => {
+  it('sweeps both server names for stdio-only agents too', async () => {
     const { manager, calls } = makeManagerStub()
     setMcpManagerForTesting(manager)
     const out = await uninstallFrom('codex')
     expect(out.success).toBe(true)
-    expect(calls.unlink).toHaveLength(1)
-    expect(calls.unlink[0].serverName).toBe('browseros-stdio')
+    expect(calls.unlink).toHaveLength(2)
+    expect(calls.unlink.map((c) => c.serverName).sort()).toEqual([
+      'browseros',
+      'browseros-stdio',
+    ])
+  })
+
+  it('uninstalls a stdio-only agent that is still linked under the legacy http server name', async () => {
+    // Regression: claude-desktop was http-routed under v0.0.1; the
+    // v0.0.2 catalog now classifies it as stdio-only. Without the
+    // server-name sweep, uninstall would target browseros-stdio
+    // (no-op) and leave the legacy `browseros` link in place
+    // forever, so listAgents would keep reporting linked: true.
+    const { manager, calls } = makeManagerStub()
+    setMcpManagerForTesting(manager)
+    const out = await uninstallFrom('claude-desktop')
+    expect(out.success).toBe(true)
+    expect(calls.unlink).toHaveLength(2)
+    expect(calls.unlink.map((c) => c.serverName).sort()).toEqual([
+      'browseros',
+      'browseros-stdio',
+    ])
   })
 
   it('returns a human message on ForeignEntryError instead of throwing', async () => {

--- a/packages/browseros-agent/apps/server/tests/lib/mcp-manager/service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/mcp-manager/service.test.ts
@@ -241,6 +241,30 @@ describe('installInto', () => {
     expect(calls.link[0].serverName).toBe('browseros-stdio')
   })
 
+  it('uses a stdio mcp-remote spec under the stdio server name for claude-desktop', async () => {
+    // Claude Desktop only accepts stdio MCP entries; an http spec is
+    // silently dropped on launch. The agent-mcp-manager catalog flags
+    // it as stdio-only and `planFor` honours that.
+    const { manager, calls } = makeManagerStub()
+    setMcpManagerForTesting(manager)
+
+    const result = await installInto(
+      'claude-desktop',
+      'http://127.0.0.1:9100/mcp',
+    )
+    expect(result.success).toBe(true)
+    expect(calls.add).toHaveLength(1)
+    expect(calls.add[0].name).toBe('browseros-stdio')
+    expect(calls.add[0].spec).toEqual({
+      transport: 'stdio',
+      command: 'npx',
+      args: ['mcp-remote', 'http://127.0.0.1:9100/mcp'],
+    })
+    expect(calls.link).toHaveLength(1)
+    expect(calls.link[0].agent).toBe('claude-desktop')
+    expect(calls.link[0].serverName).toBe('browseros-stdio')
+  })
+
   it('rejects unsupported agent ids', async () => {
     const { manager } = makeManagerStub()
     setMcpManagerForTesting(manager)

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -158,7 +158,7 @@
         "acp-probe": "^0.0.2",
         "acpx": "^0.10.0",
         "acpx-ai-provider": "^0.0.6",
-        "agent-mcp-manager": "^0.0.1",
+        "agent-mcp-manager": "^0.0.2",
         "ai": "^6.0.94",
         "commander": "^14.0.1",
         "core-js": "3.45.1",
@@ -1757,7 +1757,7 @@
 
     "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
-    "agent-mcp-manager": ["agent-mcp-manager@0.0.1", "", { "dependencies": { "@iarna/toml": "^2.2.5", "jsonc-parser": "^3.3.1" } }, "sha512-lU6gc4/2+/5wXNl38DWEJuDKO5vkBid6KAWpxkbEGS1F1T1yXurbBPxEsaUohcByqj/Xt3rGHCjSbjKCRASMXw=="],
+    "agent-mcp-manager": ["agent-mcp-manager@0.0.2", "", { "dependencies": { "@iarna/toml": "^2.2.5", "jsonc-parser": "^3.3.1" } }, "sha512-1wyJqzeLKSRSpD5URfGI/H9WjwBcDwxyU/ltYNedIgnb6QV12DYd6jy6WigqLlevs0rTkBYhKs3kkHmyes2Dvw=="],
 
     "ahooks": ["ahooks@3.9.6", "", { "dependencies": { "@babel/runtime": "^7.21.0", "@types/js-cookie": "^3.0.6", "dayjs": "^1.9.1", "intersection-observer": "^0.12.0", "js-cookie": "^3.0.5", "lodash": "^4.17.21", "react-fast-compare": "^3.2.2", "resize-observer-polyfill": "^1.5.1", "screenfull": "^5.0.0", "tslib": "^2.4.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-Mr7f05swd5SmKlR9SZo5U6M0LsL4ErweLzpdgXjA1JPmnZ78Vr6wzx0jUtvoxrcqGKYnX0Yjc02iEASVxHFPjQ=="],
 


### PR DESCRIPTION
## Summary

Two fixes, one PR, because they touch the same surface.

**Bug fix — `/settings/mcp` install was writing the wrong URL into agent configs.** Codex made it visible because it spawns `npx mcp-remote <url>` against whatever URL got written into `~/.codex/config.toml`, and that URL pointed at the agent server's internal `serverPort` instead of the user-facing proxy port the browser advertises (and that the UI itself displays as the "Server URL"). The same bug affected every install path; the boot-time URL reconciler was actively rewriting the manifest with the wrong port on every restart.

**Dep bump — `agent-mcp-manager` 0.0.1 → 0.0.2.** v0.0.2 surfaces a typed `UnsupportedTransportError` instead of silently producing broken `{url, headers}` blocks Claude Desktop drops on next launch. Without changes our claude-desktop install path would silently throw post-bump; with this PR it routes correctly to the stdio `mcp-remote` shim.

## What changed

**Server**

- `POST /mcp-manager/agents/:id/install` now accepts an optional `{ mcpUrl }` body (Zod-validated). The UI sends the proxy URL it already shows; the server uses what the caller passed and falls back to `getMcpUrl()` only for programmatic callers without one.
- `planFor` sources stdio vs http from `resolveAgentSurface(agentId, 'system').supportedTransports` instead of the hardcoded `STDIO_ONLY_AGENTS = {'codex'}` set. v0.0.2 catalog classifies claude-desktop AND codex as stdio-only — both auto-route through `npx mcp-remote` now.
- `humaniseInstallError` surfaces the new `UnsupportedTransportError` with a clean 400.
- Boot-time `reconcileUrl()` now runs only when `BROWSEROS_MCP_PUBLIC_URL` is provided. The agent server has no way to know its public-facing proxy port unless the BrowserOS browser tells it; without that env var the reconciler was rewriting every install with the wrong URL. UI-driven installs always carry the right URL per click; boot-time drift recovery is the rare case and can wait for the browser to pass the var.

**Agent UI**

- `useInstallAgent(mcpUrl)` takes the proxy URL and forwards it. `IntegrationsSection` passes its existing `serverUrl` prop in. No other call-site change.

**Tests**

- New regression test in `service.test.ts` asserts claude-desktop installs route through `browseros-stdio` with the `npx mcp-remote <url>` shim.

## Test plan

- [x] `bun run typecheck` — clean across `@browseros/cdp-protocol`, `@browseros/shared`, `@browseros/build-tools`, `@browseros/server`, `@browseros/agent`, `@browseros/eval`
- [x] `bun test apps/server/tests/lib/mcp-manager/` — **16/16 pass** (was 15; added claude-desktop case)
- [x] `bun fallow` — clean
- [ ] Manual: install BrowserOS into codex via `/settings/mcp`, open the resulting `~/.codex/config.toml`, verify the URL matches the proxy port shown in `MCPServerHeader`, launch codex and confirm the tool list shows up
- [ ] Manual: install BrowserOS into claude-desktop via `/settings/mcp`, verify the resulting `claude_desktop_config.json` entry is a stdio `mcp-remote` shim (NOT a `{url, headers}` block), restart Claude Desktop and confirm the BrowserOS tools appear
- [ ] Manual: install into claude-code (system scope) — sanity that the HTTP path still works for HTTP-capable agents

## Notes

- v0.0.2 catalog classifies stdio-only at the library layer. If upstream adds a new stdio-only agent later, our code follows automatically.
- `BROWSEROS_MCP_PUBLIC_URL` is a launch-time hook for the browser to pass in. Until that's wired, port-drift recovery happens lazily on the next install click. The old behaviour rewrote configs with the WRONG URL on every restart, so this is net positive even before the browser-side wiring lands.