### PR TITLE
chore: drop tests from check script

### DIFF
--- a/packages/browseros-agent/CLAUDE.md
+++ b/packages/browseros-agent/CLAUDE.md
@@ -4,13 +4,14 @@ A Bun-workspaces monorepo for the BrowserOS MCP server, agent extension UI, CLI,
 
 ## Before you push
 
-Run the root check suite:
+Run the root check suite and the tests:
 
 ```
 bun run check
+bun run test
 ```
 
-This runs lint, typecheck, Fallow, and the main test suite. For docs-only changes, also run `git diff --check`. For release/build changes, run the relevant `bun run build:*` command.
+`bun run check` runs lint, typecheck, and Fallow. `bun run test` runs the full test suite. For docs-only changes, also run `git diff --check`. For release/build changes, run the relevant `bun run build:*` command.
 
 ## Universal rules
 

--- a/packages/browseros-agent/package.json
+++ b/packages/browseros-agent/package.json
@@ -39,7 +39,7 @@
     "test:all": "bun run ./scripts/run-test-suite.ts all",
     "test:fixtures": "bun apps/server/tests/__fixtures__/browser-fixtures/serve.ts",
     "test:main": "bun run ./scripts/run-test-suite.ts main",
-    "check": "bun run lint && bun run typecheck && bun run fallow && bun run test:main",
+    "check": "bun run lint && bun run typecheck && bun run fallow",
     "typecheck": "bun run --filter '*' typecheck",
     "lint": "bunx biome check",
     "fallow": "fallow check",


### PR DESCRIPTION
## What

- `package.json`: the `check` script now runs **lint + typecheck + Fallow only** — dropped the trailing `&& bun run test:main`.
- `CLAUDE.md` ("Before you push"): documents running both `bun run check` and `bun run test`, and clarifies that `check` is lint/typecheck/Fallow while `bun run test` (→ `test:all`) runs the full test suite.

## Why

Tests are already covered by the dedicated `test` script (`bun run test` → `test:all`). Keeping them inside `check` made the quality gate slow and conflated static checks with the test suite. Separating them lets contributors run the fast static gate and the test suite independently.

## Verification

`bun run check` is green:
- Lint — 1061 files checked, no fixes
- Typecheck — all 6 workspaces exit 0
- Fallow — no issues found

No CI workflow or git hook invoked `bun run check`, so no test coverage is silently dropped from automation (lefthook `pre-push` only validates the branch name). README's "Quality" section never referenced `check`, so it needs no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)