### PR TITLE
fix: include large browser output excerpts

### DIFF
--- a/packages/browseros-agent/apps/server/src/tools/browser/diff-format.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/diff-format.ts
@@ -1,10 +1,13 @@
 import type { SnapshotDiff } from '../../browser/core/snapshot/diff'
 import { writeTempToolOutputFile } from './output-file'
-import { estimateTextTokens } from './token-estimate'
+import {
+  estimateTextTokens,
+  sliceTextByEstimatedTokens,
+} from './token-estimate'
 import { wrapUntrusted } from './trust-boundary'
 
 const MAX_INLINE_DIFF_TOKENS = 10_000
-const MAX_SAVE_FAILURE_EXCERPT_CHARS = 4_000
+const MAX_INLINE_EXCERPT_TOKENS = 5_000
 
 export interface FormattedDiff {
   text: string
@@ -32,17 +35,25 @@ export async function formatDiffResult(
   }
 
   if (tokenEstimate > MAX_INLINE_DIFF_TOKENS) {
+    const excerpt = sliceTextByEstimatedTokens(
+      diffText,
+      MAX_INLINE_EXCERPT_TOKENS,
+    )
     try {
       const path = await writeTempToolOutputFile({
         toolName: 'diff',
         extension: 'md',
         content: wrappedDiff,
       })
-      const text = diff.urlChanged
+      const summary = diff.urlChanged
         ? `URL changed; full current snapshot is ${tokenEstimate} estimated tokens, over the ${MAX_INLINE_DIFF_TOKENS}-token inline limit, saved to: ${path}\nRead the file for the full current snapshot.`
         : `Diff is ${tokenEstimate} estimated tokens, over the ${MAX_INLINE_DIFF_TOKENS}-token inline limit, saved to: ${path}\nRead the file for the full diff.`
       return {
-        text,
+        text: [
+          summary,
+          `Showing the first ${MAX_INLINE_EXCERPT_TOKENS} estimated tokens inline:`,
+          wrapUntrusted(excerpt, origin),
+        ].join('\n'),
         structured: {
           ...structured,
           truncated: true,
@@ -54,14 +65,13 @@ export async function formatDiffResult(
       }
     } catch (error) {
       const saveError = error instanceof Error ? error.message : String(error)
-      const excerpt = diffText.slice(0, MAX_SAVE_FAILURE_EXCERPT_CHARS)
       const text = diff.urlChanged
         ? `URL changed; full current snapshot is ${tokenEstimate} estimated tokens, over the ${MAX_INLINE_DIFF_TOKENS}-token inline limit, but saving it to a BrowserOS output file failed: ${saveError}`
         : `Diff is ${tokenEstimate} estimated tokens, over the ${MAX_INLINE_DIFF_TOKENS}-token inline limit, but saving it to a BrowserOS output file failed: ${saveError}`
       return {
         text: [
           text,
-          `Showing the first ${excerpt.length} chars instead:`,
+          `Showing the first ${MAX_INLINE_EXCERPT_TOKENS} estimated tokens instead:`,
           wrapUntrusted(excerpt, origin),
         ].join('\n'),
         structured: {

--- a/packages/browseros-agent/apps/server/src/tools/browser/snapshot-format.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/snapshot-format.ts
@@ -1,9 +1,12 @@
 import { writeTempToolOutputFile } from './output-file'
-import { estimateTextTokens } from './token-estimate'
+import {
+  estimateTextTokens,
+  sliceTextByEstimatedTokens,
+} from './token-estimate'
 import { wrapUntrusted } from './trust-boundary'
 
 const LARGE_SNAPSHOT_TOKEN_THRESHOLD = 15_000
-const MAX_SAVE_FAILURE_EXCERPT_CHARS = 4_000
+const MAX_INLINE_EXCERPT_TOKENS = 5_000
 
 export interface FormattedSnapshot {
   text: string
@@ -21,6 +24,10 @@ export async function formatSnapshotResult(
   const tokenEstimate = estimateTextTokens(wrappedSnapshot)
 
   if (tokenEstimate > LARGE_SNAPSHOT_TOKEN_THRESHOLD) {
+    const excerpt = sliceTextByEstimatedTokens(
+      snapshotText,
+      MAX_INLINE_EXCERPT_TOKENS,
+    )
     try {
       const path = await writeTempToolOutputFile({
         toolName: 'snapshot',
@@ -32,6 +39,8 @@ export async function formatSnapshotResult(
         text: [
           `Large snapshot (${tokenEstimate} estimated tokens, ${contentLength} chars) saved to: ${path}`,
           'Read the file for the full snapshot and refs.',
+          `Showing the first ${MAX_INLINE_EXCERPT_TOKENS} estimated tokens inline:`,
+          wrapUntrusted(excerpt, origin),
         ].join('\n'),
         structured: {
           path,
@@ -42,11 +51,10 @@ export async function formatSnapshotResult(
       }
     } catch (error) {
       const saveError = error instanceof Error ? error.message : String(error)
-      const excerpt = snapshotText.slice(0, MAX_SAVE_FAILURE_EXCERPT_CHARS)
       return {
         text: [
           `Large snapshot (${tokenEstimate} estimated tokens, ${contentLength} chars) could not be saved to a BrowserOS output file: ${saveError}`,
-          `Showing the first ${excerpt.length} chars instead:`,
+          `Showing the first ${MAX_INLINE_EXCERPT_TOKENS} estimated tokens instead:`,
           wrapUntrusted(excerpt, origin),
         ].join('\n'),
         structured: {

--- a/packages/browseros-agent/apps/server/src/tools/browser/token-estimate.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/token-estimate.ts
@@ -4,3 +4,24 @@ const APPROX_CHARS_PER_TOKEN = 3
 export function estimateTextTokens(text: string): number {
   return Math.ceil(text.length / APPROX_CHARS_PER_TOKEN)
 }
+
+/** Returns the longest prefix that stays within the estimated token limit. */
+export function sliceTextByEstimatedTokens(
+  text: string,
+  maxTokens: number,
+): string {
+  if (estimateTextTokens(text) <= maxTokens) return text
+
+  let low = 0
+  let high = text.length
+  while (low < high) {
+    const mid = Math.floor((low + high + 1) / 2)
+    if (estimateTextTokens(text.slice(0, mid)) <= maxTokens) {
+      low = mid
+    } else {
+      high = mid - 1
+    }
+  }
+
+  return text.slice(0, low)
+}

--- a/packages/browseros-agent/apps/server/tests/tools/browser/framework.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/framework.test.ts
@@ -132,7 +132,9 @@ describe('browser tool framework post-actions', () => {
 
   it('writes large snapshot post-actions to a BrowserOS output file', async () => {
     await withBrowserosDir(async () => {
-      const largeSnapshot = `${'x '.repeat(23_000)}last-node`
+      const firstMarker = 'first-node'
+      const lastMarker = 'last-node'
+      const largeSnapshot = `${firstMarker}\n${'x '.repeat(23_000)}${lastMarker}`
       const postActionTool = defineTool({
         name: 'large_snapshot_post_action_test',
         description: 'Test large snapshot post-action execution.',
@@ -159,15 +161,19 @@ describe('browser tool framework post-actions', () => {
       expect(text).toContain('[Page 8 snapshot]')
       expect(text).toContain('estimated tokens')
       expect(savedPath).toBeTruthy()
-      expect(text).not.toContain('last-node')
-      expect(text).not.toContain('[UNTRUSTED_PAGE_CONTENT')
-      expect(readFileSync(savedPath ?? '', 'utf8')).toContain('last-node')
+      expect(text).toContain('Showing the first 5000 estimated tokens inline')
+      expect(text).toContain('[UNTRUSTED_PAGE_CONTENT')
+      expect(text).toContain(firstMarker)
+      expect(text).not.toContain(lastMarker)
+      expect(readFileSync(savedPath ?? '', 'utf8')).toContain(lastMarker)
     })
   })
 
   it('keeps large snapshot post-actions visible when output file writes fail', async () => {
     await withBrowserosFile(async () => {
-      const largeSnapshot = `${'x '.repeat(23_000)}last-node`
+      const firstMarker = 'first-node'
+      const lastMarker = 'last-node'
+      const largeSnapshot = `${firstMarker}\n${'x '.repeat(23_000)}${lastMarker}`
       const postActionTool = defineTool({
         name: 'large_snapshot_post_action_failure_test',
         description: 'Test failed large snapshot post-action output.',
@@ -194,8 +200,9 @@ describe('browser tool framework post-actions', () => {
       expect(text).toContain('could not be saved to a BrowserOS output file')
       expect(text).toContain('Showing the first')
       expect(text).toContain('[UNTRUSTED_PAGE_CONTENT')
+      expect(text).toContain(firstMarker)
       expect(text).toContain('x x x')
-      expect(text).not.toContain('last-node')
+      expect(text).not.toContain(lastMarker)
     })
   })
 
@@ -247,8 +254,9 @@ describe('browser tool framework post-actions', () => {
 
   it('writes large diff post-actions to a BrowserOS output file', async () => {
     await withBrowserosDir(async () => {
+      const firstMarker = 'first-diff-node'
       const lastMarker = 'last-diff-node'
-      const largeDiff = `${'x'.repeat(30_001)}\n${lastMarker}`
+      const largeDiff = `${firstMarker}\n${'x'.repeat(30_001)}\n${lastMarker}`
       const postActionTool = defineTool({
         name: 'large_diff_post_action_test',
         description: 'Test large diff post-action execution.',
@@ -281,16 +289,19 @@ describe('browser tool framework post-actions', () => {
       expect(text).toContain('[Page 4 diff]')
       expect(text).toContain('estimated tokens')
       expect(savedPath).toBeTruthy()
+      expect(text).toContain('Showing the first 5000 estimated tokens inline')
+      expect(text).toContain('[UNTRUSTED_PAGE_CONTENT')
+      expect(text).toContain(firstMarker)
       expect(text).not.toContain(lastMarker)
-      expect(text).not.toContain('[UNTRUSTED_PAGE_CONTENT')
       expect(readFileSync(savedPath ?? '', 'utf8')).toContain(lastMarker)
     })
   })
 
   it('keeps large diff post-actions visible when output file writes fail', async () => {
     await withBrowserosFile(async () => {
+      const firstMarker = 'first-diff-node'
       const lastMarker = 'last-diff-node'
-      const largeDiff = `${'x'.repeat(30_001)}\n${lastMarker}`
+      const largeDiff = `${firstMarker}\n${'x'.repeat(30_001)}\n${lastMarker}`
       const postActionTool = defineTool({
         name: 'large_diff_post_action_failure_test',
         description: 'Test failed large diff post-action output.',
@@ -323,6 +334,7 @@ describe('browser tool framework post-actions', () => {
       expect(text).toContain('saving it to a BrowserOS output file failed')
       expect(text).toContain('Showing the first')
       expect(text).toContain('[UNTRUSTED_PAGE_CONTENT')
+      expect(text).toContain(firstMarker)
       expect(text).toContain('xxx')
       expect(text).not.toContain(lastMarker)
     })

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -698,8 +698,9 @@ return 'late'
   it('writes large direct diffs to a BrowserOS output markdown file', async () => {
     await withBrowserosDir(async () => {
       const fake = createFakeServer()
+      const firstMarker = 'first-diff-node'
       const lastMarker = 'last-diff-node'
-      const largeDiff = `${'x'.repeat(30_001)}\n${lastMarker}`
+      const largeDiff = `${firstMarker}\n${'x'.repeat(30_001)}\n${lastMarker}`
       const session = {
         observe: () => ({
           diff: async () => ({
@@ -718,6 +719,7 @@ return 'late'
       registerBrowserTools(fake.server as never, session)
 
       const result = await fake.handlers.get('diff')?.({ page: 1 })
+      const text = textOf(result)
 
       expect(result?.isError).toBeFalsy()
       const data = result?.structuredContent as
@@ -759,6 +761,9 @@ return 'late'
           text: expect.not.stringContaining(lastMarker),
         }),
       ])
+      expect(text).toContain('Showing the first 5000 estimated tokens inline')
+      expect(text).toContain('[UNTRUSTED_PAGE_CONTENT')
+      expect(text).toContain(firstMarker)
       const savedContent = readFileSync(savedPath ?? '', 'utf8')
       expect(savedContent).toContain('[UNTRUSTED_PAGE_CONTENT')
       expect(savedContent).toContain(lastMarker)
@@ -841,8 +846,9 @@ return 'late'
   it('writes large URL-change act readbacks to a BrowserOS output file', async () => {
     await withBrowserosDir(async () => {
       const fake = createFakeServer()
+      const firstMarker = 'destination-first-node'
       const lastMarker = 'destination-final-node'
-      const largeSnapshot = `${'x'.repeat(30_001)}\n${lastMarker}`
+      const largeSnapshot = `${firstMarker}\n${'x'.repeat(30_001)}\n${lastMarker}`
       const session = {
         input: () => ({
           click: async () => undefined,
@@ -902,6 +908,9 @@ return 'late'
         ]),
       )
       expect(text).not.toContain(lastMarker)
+      expect(text).toContain('Showing the first 5000 estimated tokens inline')
+      expect(text).toContain('[UNTRUSTED_PAGE_CONTENT')
+      expect(text).toContain(firstMarker)
       await expectBrowserToolOutputPath(savedPath)
       expect(readFileSync(savedPath ?? '', 'utf8')).toContain(lastMarker)
     })
@@ -1281,7 +1290,9 @@ return 'late'
   it('writes very large snapshots to a BrowserOS output markdown file', async () => {
     await withBrowserosDir(async () => {
       const fake = createFakeServer()
-      const largeSnapshot = `${'x '.repeat(23_000)}last-node`
+      const firstMarker = 'first-node'
+      const lastMarker = 'last-node'
+      const largeSnapshot = `${firstMarker}\n${'x '.repeat(23_000)}${lastMarker}`
       expect(largeSnapshot.length).toBeLessThan(50_000)
       const session = {
         observe: () => ({
@@ -1294,6 +1305,7 @@ return 'late'
       registerBrowserTools(fake.server as never, session)
 
       const result = await fake.handlers.get('snapshot')?.({ page: 4 })
+      const text = textOf(result)
 
       expect(result?.isError).toBeFalsy()
       const data = result?.structuredContent as
@@ -1325,12 +1337,16 @@ return 'late'
           text: expect.stringContaining(savedPath ?? ''),
         }),
       ])
+      expect(text).toContain('Showing the first 5000 estimated tokens inline')
+      expect(text).toContain('[UNTRUSTED_PAGE_CONTENT')
+      expect(text).toContain(firstMarker)
+      expect(text).not.toContain(lastMarker)
       expect(existsSync(savedPath ?? '')).toBe(true)
 
       const savedContent = readFileSync(savedPath ?? '', 'utf8')
       expect(savedContent).toContain('[UNTRUSTED_PAGE_CONTENT')
       expect(savedContent).toContain('[END_UNTRUSTED_PAGE_CONTENT')
-      expect(savedContent).toContain('last-node')
+      expect(savedContent).toContain(lastMarker)
       expect(data?.contentLength).toBe(savedContent.length)
     })
   })

--- a/packages/browseros-agent/apps/server/tests/tools/response.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/response.test.ts
@@ -113,7 +113,9 @@ describe('ToolResponse', () => {
   it('writes large snapshot post-actions to a BrowserOS output file', async () => {
     await withBrowserosDir(async () => {
       const response = new ToolResponse({ postActionTimeoutMs: 200 })
-      const largeSnapshot = `${'x '.repeat(23_000)}last-node`
+      const firstMarker = 'first-node'
+      const lastMarker = 'last-node'
+      const largeSnapshot = `${firstMarker}\n${'x '.repeat(23_000)}${lastMarker}`
       response.text('ok')
       response.includeSnapshot(1)
 
@@ -136,8 +138,11 @@ describe('ToolResponse', () => {
       assert.ok(text.includes('Large snapshot ('))
       assert.ok(text.includes('estimated tokens'))
       assert.ok(savedPath)
-      assert.ok(!text.includes('last-node'))
-      assert.ok(readFileSync(savedPath ?? '', 'utf8').includes('last-node'))
+      assert.ok(text.includes('Showing the first 5000 estimated tokens inline'))
+      assert.ok(text.includes('[UNTRUSTED_PAGE_CONTENT'))
+      assert.ok(text.includes(firstMarker))
+      assert.ok(!text.includes(lastMarker))
+      assert.ok(readFileSync(savedPath ?? '', 'utf8').includes(lastMarker))
     })
   })
 


### PR DESCRIPTION
## Summary
- Save full oversized browser snapshot and diff output to BrowserOS output files as before.
- Include the first 5000 estimated tokens inline on oversized success responses.
- Keep inline excerpts wrapped with untrusted-content markers and preserve save-failure fallback metadata.

## Design
The formatter layer remains the owner of oversized output handling. `formatDiffResult` and `formatSnapshotResult` now use a shared estimated-token prefix helper so oversized responses can include a bounded wrapped excerpt while the full wrapped payload is still written to disk for readback.

## Test plan
- [x] `bun --env-file=apps/server/.env.development test apps/server/tests/tools/browser/framework.test.ts apps/server/tests/tools/browser/register.test.ts apps/server/tests/tools/response.test.ts`
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun run test:main`
- [x] `bun run check`

## Local review
- [x] `sf-review` context-free subagent: clean, 0 findings