### PR TITLE
feat: add screenshot quality option

### DIFF
--- a/packages/browseros-agent/apps/server/src/tools/browser/screenshot.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/screenshot.ts
@@ -1,23 +1,89 @@
+import type {
+  CaptureScreenshotParams,
+  Viewport,
+} from '@browseros/cdp-protocol/domains/page'
+import type { ProtocolApi } from '@browseros/cdp-protocol/protocol-api'
 import { z } from 'zod'
 import { defineTool } from './framework'
+
+const DEFAULT_SCREENSHOT_FORMAT = 'jpeg'
+const DEFAULT_SCREENSHOT_QUALITY = 80
+const DEFAULT_SCREENSHOT_SIZE = { width: 1024, height: 768 } as const
+const screenshotFormat = z.enum(['jpeg', 'png', 'webp'])
+const screenshotSize = z.object({
+  width: z.number().int().positive().max(4096).default(1024),
+  height: z.number().int().positive().max(4096).default(768),
+})
+
+type ScreenshotFormat = z.infer<typeof screenshotFormat>
+type ScreenshotSize = z.infer<typeof screenshotSize>
+
+function screenshotQuality(format: ScreenshotFormat, quality?: number) {
+  if (format !== 'jpeg') return undefined
+  return quality ?? DEFAULT_SCREENSHOT_QUALITY
+}
+
+/** Builds a viewport clip that fits the capture within the requested target size. */
+async function buildScreenshotClip(
+  session: ProtocolApi,
+  target: ScreenshotSize,
+): Promise<Viewport> {
+  const metrics = await session.Page.getLayoutMetrics()
+  const viewport = metrics.cssLayoutViewport ?? metrics.layoutViewport
+  const scale =
+    viewport.clientWidth > 0 && viewport.clientHeight > 0
+      ? Math.min(
+          1,
+          target.width / viewport.clientWidth,
+          target.height / viewport.clientHeight,
+        )
+      : 1
+
+  return {
+    x: viewport.pageX,
+    y: viewport.pageY,
+    width: viewport.clientWidth,
+    height: viewport.clientHeight,
+    scale,
+  }
+}
 
 export const screenshot = defineTool({
   name: 'screenshot',
   description:
-    'Capture a PNG screenshot of the page, returned inline. Use when visual layout matters; prefer snapshot for structure/actions.',
+    'Capture a screenshot of the page, returned inline. Defaults to JPEG quality 80 around 1024x768; prefer snapshot for structure/actions.',
   input: z.object({
     page: z.number().int(),
+    format: screenshotFormat.default(DEFAULT_SCREENSHOT_FORMAT),
+    quality: z.number().int().min(0).max(100).optional(),
+    size: screenshotSize
+      .optional()
+      .describe('Max viewport capture size. Defaults to 1024x768.'),
     fullPage: z.boolean().optional().describe('Capture beyond the viewport.'),
   }),
   annotations: { readOnlyHint: true },
   handler: async (args, ctx) => {
     const { session } = await ctx.session.pages.getSession(args.page)
-    const result = await session.Page.captureScreenshot({
-      format: 'png',
-      captureBeyondViewport: args.fullPage ?? false,
-    })
+    const fullPage = args.fullPage ?? false
+    const params: CaptureScreenshotParams = {
+      format: args.format,
+      fromSurface: true,
+      captureBeyondViewport: fullPage,
+    }
+    const quality = screenshotQuality(args.format, args.quality)
+    if (quality !== undefined) params.quality = quality
+    if (!fullPage) {
+      params.clip = await buildScreenshotClip(
+        session,
+        args.size ?? DEFAULT_SCREENSHOT_SIZE,
+      )
+    }
+
+    const result = await session.Page.captureScreenshot(params)
     return {
-      content: [{ type: 'image', data: result.data, mimeType: 'image/png' }],
+      content: [
+        { type: 'image', data: result.data, mimeType: `image/${args.format}` },
+      ],
     }
   },
 })

--- a/packages/browseros-agent/apps/server/tests/lib/clients/llm/config.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/clients/llm/config.test.ts
@@ -4,38 +4,51 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdtempSync } from 'node:fs'
+import { rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 import { LLM_PROVIDERS } from '@browseros/shared/schemas/llm'
-
-const tokenManager = {
-  refreshIfExpired: mock(async () => ({
-    accessToken: 'access-token',
-    refreshToken: 'refresh-token',
-    expiresAt: Date.now() + 3600_000,
-    accountId: 'account-id',
-  })),
-}
-
-mock.module('../../../../src/lib/clients/oauth', () => ({
-  getOAuthTokenManager: () => tokenManager,
-}))
-
-const { resolveLLMConfig } = await import(
-  '../../../../src/lib/clients/llm/config'
-)
+import { resolveLLMConfig } from '../../../../src/lib/clients/llm/config'
+import {
+  initializeOAuth,
+  shutdownOAuth,
+} from '../../../../src/lib/clients/oauth'
+import { OAuthTokenStore } from '../../../../src/lib/clients/oauth/token-store'
+import { closeDb, initializeDb } from '../../../../src/lib/db'
 
 describe('resolveLLMConfig', () => {
-  beforeEach(() => {
-    tokenManager.refreshIfExpired.mockClear()
+  const tempDirs: string[] = []
+
+  afterEach(async () => {
+    shutdownOAuth()
+    closeDb()
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true })),
+    )
+    tempDirs.length = 0
   })
 
   it('defaults ChatGPT Plus/Pro OAuth providers to GPT-5.5', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'browseros-llm-config-test-'))
+    tempDirs.push(dir)
+    const handle = initializeDb({
+      dbPath: join(dir, 'db', 'browseros.sqlite'),
+    })
+    initializeOAuth(handle.db, 'browseros-id')
+    new OAuthTokenStore(handle.db).upsertTokens('browseros-id', 'chatgpt-pro', {
+      accessToken: 'access-token',
+      refreshToken: 'refresh-token',
+      expiresAt: Date.now() + 3600_000,
+      accountId: 'account-id',
+    })
+
     const resolved = await resolveLLMConfig(
       { provider: LLM_PROVIDERS.CHATGPT_PRO },
       'browseros-id',
     )
 
-    expect(tokenManager.refreshIfExpired).toHaveBeenCalledWith('chatgpt-pro')
     expect(resolved).toMatchObject({
       provider: LLM_PROVIDERS.CHATGPT_PRO,
       model: 'gpt-5.5',

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -116,6 +116,160 @@ describe('registerBrowserTools', () => {
     expect(fake.configs.get('tabs')?.inputSchema).toBeDefined()
   })
 
+  it('captures JPEG screenshots with default and custom quality', async () => {
+    const fake = createFakeServer()
+    const captureParams: unknown[] = []
+    const session = {
+      pages: {
+        getSession: async () => ({
+          session: {
+            Page: {
+              getLayoutMetrics: async () => ({
+                layoutViewport: {
+                  pageX: 0,
+                  pageY: 0,
+                  clientWidth: 2048,
+                  clientHeight: 1536,
+                },
+                cssLayoutViewport: {
+                  pageX: 5,
+                  pageY: 7,
+                  clientWidth: 2048,
+                  clientHeight: 1536,
+                },
+              }),
+              captureScreenshot: async (params: unknown) => {
+                captureParams.push(params)
+                return { data: 'jpeg-data' }
+              },
+            },
+          },
+        }),
+      },
+    } as unknown as BrowserSession
+
+    registerBrowserTools(fake.server as never, session)
+
+    await expect(
+      fake.handlers.get('screenshot')?.({ page: 1 }),
+    ).resolves.toEqual({
+      content: [{ type: 'image', data: 'jpeg-data', mimeType: 'image/jpeg' }],
+    })
+    await expect(
+      fake.handlers.get('screenshot')?.({
+        page: 1,
+        quality: 60,
+        size: { width: 512, height: 384 },
+      }),
+    ).resolves.toEqual({
+      content: [{ type: 'image', data: 'jpeg-data', mimeType: 'image/jpeg' }],
+    })
+    expect(captureParams).toEqual([
+      {
+        format: 'jpeg',
+        quality: 80,
+        fromSurface: true,
+        captureBeyondViewport: false,
+        clip: {
+          x: 5,
+          y: 7,
+          width: 2048,
+          height: 1536,
+          scale: 0.5,
+        },
+      },
+      {
+        format: 'jpeg',
+        quality: 60,
+        fromSurface: true,
+        captureBeyondViewport: false,
+        clip: {
+          x: 5,
+          y: 7,
+          width: 2048,
+          height: 1536,
+          scale: 0.25,
+        },
+      },
+    ])
+  })
+
+  it('omits quality for PNG screenshots and skips size clips for full page', async () => {
+    const fake = createFakeServer()
+    const captureParams: unknown[] = []
+    let layoutMetricCalls = 0
+    const session = {
+      pages: {
+        getSession: async () => ({
+          session: {
+            Page: {
+              getLayoutMetrics: async () => {
+                layoutMetricCalls += 1
+                return {
+                  layoutViewport: {
+                    pageX: 0,
+                    pageY: 0,
+                    clientWidth: 800,
+                    clientHeight: 600,
+                  },
+                  cssLayoutViewport: {
+                    pageX: 0,
+                    pageY: 0,
+                    clientWidth: 800,
+                    clientHeight: 600,
+                  },
+                }
+              },
+              captureScreenshot: async (params: unknown) => {
+                captureParams.push(params)
+                return { data: 'png-data' }
+              },
+            },
+          },
+        }),
+      },
+    } as unknown as BrowserSession
+
+    registerBrowserTools(fake.server as never, session)
+
+    await expect(
+      fake.handlers.get('screenshot')?.({
+        page: 1,
+        format: 'png',
+        quality: 25,
+      }),
+    ).resolves.toEqual({
+      content: [{ type: 'image', data: 'png-data', mimeType: 'image/png' }],
+    })
+    await expect(
+      fake.handlers.get('screenshot')?.({ page: 1, fullPage: true }),
+    ).resolves.toEqual({
+      content: [{ type: 'image', data: 'png-data', mimeType: 'image/jpeg' }],
+    })
+
+    expect(layoutMetricCalls).toBe(1)
+    expect(captureParams).toEqual([
+      {
+        format: 'png',
+        fromSurface: true,
+        captureBeyondViewport: false,
+        clip: {
+          x: 0,
+          y: 0,
+          width: 800,
+          height: 600,
+          scale: 1,
+        },
+      },
+      {
+        format: 'jpeg',
+        quality: 80,
+        fromSurface: true,
+        captureBeyondViewport: true,
+      },
+    ])
+  })
+
   it('manages windows through the compact windows tool', async () => {
     const fake = createFakeServer()
     const calls: Array<{ method: string; args?: unknown }> = []
@@ -1481,7 +1635,21 @@ return 'late'
               evaluate: async () => ({ result: { value: true } }),
             },
             Page: {
-              captureScreenshot: async () => ({ data: 'png-data' }),
+              getLayoutMetrics: async () => ({
+                layoutViewport: {
+                  pageX: 0,
+                  pageY: 0,
+                  clientWidth: 1024,
+                  clientHeight: 768,
+                },
+                cssLayoutViewport: {
+                  pageX: 0,
+                  pageY: 0,
+                  clientWidth: 1024,
+                  clientHeight: 768,
+                },
+              }),
+              captureScreenshot: async () => ({ data: 'image-data' }),
             },
           },
         }),
@@ -1511,7 +1679,7 @@ return 'late'
       }),
     ).toMatchObject({ structuredContent: { count: 1 } })
     expect(await fake.handlers.get('screenshot')?.({ page: 1 })).toMatchObject({
-      content: [{ type: 'image', data: 'png-data', mimeType: 'image/png' }],
+      content: [{ type: 'image', data: 'image-data', mimeType: 'image/jpeg' }],
     })
     expect(
       await fake.handlers.get('wait')?.({


### PR DESCRIPTION
## Summary
- Defaults the browser screenshot tool to JPEG quality 80 for smaller inline visual captures.
- Adds optional `format`, `quality`, and `size` inputs; normal viewport captures scale toward 1024x768 with CDP `clip.scale`.
- Keeps PNG quality omitted and skips size clipping for `fullPage` captures.
- Replaces a leaking OAuth module mock in an LLM config test so the full root test suite can run green.

## Design
The screenshot tool now builds a typed `Page.captureScreenshot` request directly from validated Zod inputs. For non-full-page captures it reads layout metrics and sets a scale-only viewport clip, preserving aspect ratio without upscaling. JPEG uses default quality 80 unless overridden; PNG and WebP omit the JPEG-only quality field.

## Test plan
- [x] `bun --env-file=apps/server/.env.development test apps/server/tests/tools/browser/register.test.ts`
- [x] `bun run check`
- [x] `bun run test`
- [x] context-free local review: clean