### PR TITLE
feat: add annotated browser screenshots

### DIFF
--- a/packages/browseros-agent/apps/server/src/browser/core/observer/resolve.test.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/observer/resolve.test.ts
@@ -10,6 +10,7 @@ import { resolveRefEntry } from './resolve'
 function stubSession(opts: {
   live: Set<number>
   axTree?: AXNode[]
+  releases?: string[]
 }): ProtocolApi {
   return {
     DOM: {
@@ -20,6 +21,11 @@ function stubSession(opts: {
     },
     Accessibility: {
       getFullAXTree: async () => ({ nodes: opts.axTree ?? [] }),
+    },
+    Runtime: {
+      releaseObject: async ({ objectId }: { objectId: string }) => {
+        opts.releases?.push(objectId)
+      },
     },
   } as unknown as ProtocolApi
 }
@@ -35,13 +41,15 @@ function axButton(nodeId: string, name: string, backendId: number): AXNode {
 
 describe('resolveRefEntry', () => {
   test('tier 1 returns the cached backendNodeId when still live', async () => {
+    const releases: string[] = []
     const refs = new RefMap()
     const ref = refs.mint({ backendNodeId: 10, role: 'button', name: 'OK' })
     const resolved = await resolveRefEntry(
-      stubSession({ live: new Set([10]) }),
+      stubSession({ live: new Set([10]), releases }),
       refs.get(ref) as never,
     )
     expect(resolved.backendNodeId).toBe(10)
+    expect(releases).toEqual(['obj-10'])
   })
 
   test('tier 2 re-queries by role+name+nth when the cached node is stale', async () => {

--- a/packages/browseros-agent/apps/server/src/browser/core/observer/resolve.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/observer/resolve.ts
@@ -40,7 +40,11 @@ async function isLive(
 ): Promise<boolean> {
   try {
     const resolved = await session.DOM.resolveNode({ backendNodeId })
-    return Boolean(resolved.object?.objectId)
+    const objectId = resolved.object?.objectId
+    if (objectId) {
+      await session.Runtime.releaseObject({ objectId }).catch(() => {})
+    }
+    return Boolean(objectId)
   } catch {
     return false
   }

--- a/packages/browseros-agent/apps/server/src/browser/core/screenshot-frame.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/screenshot-frame.ts
@@ -1,0 +1,25 @@
+import type { ProtocolApi } from '@browseros/cdp-protocol/protocol-api'
+
+interface FrameTreeNode {
+  frame: { id: string }
+  childFrames?: FrameTreeNode[]
+}
+
+/** Finds a frame's depth in the page tree so annotation projection only handles safe frame cases. */
+export async function frameDepth(
+  pageSession: ProtocolApi,
+  frameId: string,
+): Promise<number | undefined> {
+  const result = await pageSession.Page.getFrameTree()
+
+  function visit(node: FrameTreeNode): number | undefined {
+    if (node.frame.id === frameId) return 0
+    for (const child of node.childFrames ?? []) {
+      const depth = visit(child)
+      if (depth !== undefined) return depth + 1
+    }
+    return undefined
+  }
+
+  return visit(result.frameTree as FrameTreeNode)
+}

--- a/packages/browseros-agent/apps/server/src/browser/core/screenshot-geometry.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/screenshot-geometry.ts
@@ -1,0 +1,126 @@
+import type { ProtocolApi } from '@browseros/cdp-protocol/protocol-api'
+
+export interface Rect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export interface RawAnnotation {
+  ref: string
+  number: number
+  role: string
+  name?: string
+  rect: Rect
+}
+
+export async function readViewportRect(session: ProtocolApi): Promise<Rect> {
+  const result = await session.Runtime.evaluate({
+    expression:
+      '({x:0,y:0,width:window.innerWidth||0,height:window.innerHeight||0})',
+    returnByValue: true,
+    awaitPromise: false,
+  })
+  return (
+    parseRect(result.result?.value) ?? {
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+    }
+  )
+}
+
+export async function readScrollOffsets(
+  session: ProtocolApi,
+): Promise<{ x: number; y: number }> {
+  const result = await session.Runtime.evaluate({
+    expression: '({x: window.scrollX || 0, y: window.scrollY || 0})',
+    returnByValue: true,
+    awaitPromise: false,
+  })
+  const value = result.result?.value
+  if (!isRecord(value)) return { x: 0, y: 0 }
+  const x =
+    typeof value.x === 'number' && Number.isFinite(value.x) ? value.x : 0
+  const y =
+    typeof value.y === 'number' && Number.isFinite(value.y) ? value.y : 0
+  return { x, y }
+}
+
+export function projectAnnotations(
+  annotations: RawAnnotation[],
+  scroll?: { x: number; y: number },
+): Array<{
+  ref: string
+  number: number
+  role: string
+  name?: string
+  box: Rect
+}> {
+  return annotations.map((annotation) => ({
+    ref: annotation.ref,
+    number: annotation.number,
+    role: annotation.role,
+    ...(annotation.name && { name: annotation.name }),
+    box: {
+      x: round(annotation.rect.x + (scroll?.x ?? 0)),
+      y: round(annotation.rect.y + (scroll?.y ?? 0)),
+      width: round(annotation.rect.width),
+      height: round(annotation.rect.height),
+    },
+  }))
+}
+
+export function clipAnnotations(
+  annotations: RawAnnotation[],
+  captureArea: Rect | undefined,
+): RawAnnotation[] {
+  if (!captureArea || captureArea.width <= 0 || captureArea.height <= 0) {
+    return annotations
+  }
+  return annotations.flatMap((annotation) => {
+    const rect = intersectRects(annotation.rect, captureArea)
+    return rect ? [{ ...annotation, rect }] : []
+  })
+}
+
+export function parseRect(value: unknown): Rect | undefined {
+  if (!isRecord(value)) return undefined
+  const { x, y, width, height } = value
+  if (
+    typeof x !== 'number' ||
+    typeof y !== 'number' ||
+    typeof width !== 'number' ||
+    typeof height !== 'number'
+  ) {
+    return undefined
+  }
+  if (
+    !Number.isFinite(x) ||
+    !Number.isFinite(y) ||
+    !Number.isFinite(width) ||
+    !Number.isFinite(height)
+  ) {
+    return undefined
+  }
+  return { x, y, width, height }
+}
+
+function intersectRects(left: Rect, right: Rect): Rect | undefined {
+  const x1 = Math.max(left.x, right.x)
+  const y1 = Math.max(left.y, right.y)
+  const x2 = Math.min(left.x + left.width, right.x + right.width)
+  const y2 = Math.min(left.y + left.height, right.y + right.height)
+  if (x2 <= x1 || y2 <= y1) return undefined
+  return { x: x1, y: y1, width: x2 - x1, height: y2 - y1 }
+}
+
+function round(value: number): number {
+  return Math.round(value)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}

--- a/packages/browseros-agent/apps/server/src/browser/core/screenshot-overlay.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/screenshot-overlay.ts
@@ -21,6 +21,7 @@ export async function injectAnnotationOverlay(
   token: string,
   fullPage: boolean,
   annotations: OverlayAnnotation[],
+  scroll?: { x: number; y: number },
 ): Promise<void> {
   const items = JSON.stringify(
     annotations.map((annotation) => ({
@@ -34,6 +35,7 @@ export async function injectAnnotationOverlay(
   const overlayAttr = JSON.stringify(ANNOTATION_OVERLAY_ATTR)
   const overlayToken = JSON.stringify(token)
   const useDocumentSpaceLabels = JSON.stringify(fullPage)
+  const scrollData = JSON.stringify(scroll ?? null)
 
   await session.Runtime.evaluate({
     expression: `(() => {
@@ -41,12 +43,9 @@ export async function injectAnnotationOverlay(
       var attr = ${overlayAttr};
       var token = ${overlayToken};
       var useDocumentSpaceLabels = ${useDocumentSpaceLabels};
-      var existing = document.querySelectorAll('[' + attr + ']');
-      for (var j = 0; j < existing.length; j++) {
-        if (existing[j].getAttribute(attr) === token) existing[j].remove();
-      }
-      var sx = window.scrollX || 0;
-      var sy = window.scrollY || 0;
+      var scroll = ${scrollData};
+      var sx = scroll && typeof scroll.x === 'number' ? scroll.x : window.scrollX || 0;
+      var sy = scroll && typeof scroll.y === 'number' ? scroll.y : window.scrollY || 0;
       var c = document.createElement('div');
       c.setAttribute(attr, token);
       c.style.cssText = 'position:absolute;top:0;left:0;width:0;height:0;pointer-events:none;z-index:2147483647;';

--- a/packages/browseros-agent/apps/server/src/browser/core/screenshot-overlay.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/screenshot-overlay.ts
@@ -1,0 +1,94 @@
+import type { ProtocolApi } from '@browseros/cdp-protocol/protocol-api'
+
+const ANNOTATION_OVERLAY_ATTR = 'data-browseros-screenshot-annotation'
+
+interface OverlayAnnotation {
+  number: number
+  rect: {
+    x: number
+    y: number
+    width: number
+    height: number
+  }
+}
+
+export function createOverlayToken(): string {
+  return `browseros-${Date.now()}-${Math.random().toString(36).slice(2)}`
+}
+
+export async function injectAnnotationOverlay(
+  session: ProtocolApi,
+  token: string,
+  annotations: OverlayAnnotation[],
+): Promise<void> {
+  const items = JSON.stringify(
+    annotations.map((annotation) => ({
+      number: annotation.number,
+      x: round(annotation.rect.x),
+      y: round(annotation.rect.y),
+      width: round(annotation.rect.width),
+      height: round(annotation.rect.height),
+    })),
+  )
+  const overlayAttr = JSON.stringify(ANNOTATION_OVERLAY_ATTR)
+  const overlayToken = JSON.stringify(token)
+
+  await session.Runtime.evaluate({
+    expression: `(() => {
+      var items = ${items};
+      var attr = ${overlayAttr};
+      var token = ${overlayToken};
+      var existing = document.querySelectorAll('[' + attr + ']');
+      for (var j = 0; j < existing.length; j++) {
+        if (existing[j].getAttribute(attr) === token) existing[j].remove();
+      }
+      var sx = window.scrollX || 0;
+      var sy = window.scrollY || 0;
+      var c = document.createElement('div');
+      c.setAttribute(attr, token);
+      c.style.cssText = 'position:absolute;top:0;left:0;width:0;height:0;pointer-events:none;z-index:2147483647;';
+      for (var i = 0; i < items.length; i++) {
+        var it = items[i];
+        var dx = it.x + sx;
+        var dy = it.y + sy;
+        var b = document.createElement('div');
+        b.style.cssText = 'position:absolute;left:' + dx + 'px;top:' + dy + 'px;width:' + it.width + 'px;height:' + it.height + 'px;border:2px solid rgba(255,0,0,0.8);box-sizing:border-box;pointer-events:none;';
+        var l = document.createElement('div');
+        l.textContent = String(it.number);
+        var labelTop = dy < 14 ? '2px' : '-14px';
+        l.style.cssText = 'position:absolute;top:' + labelTop + ';left:-2px;background:rgba(255,0,0,0.9);color:#fff;font:bold 11px/14px monospace;padding:0 4px;border-radius:2px;white-space:nowrap;';
+        b.appendChild(l);
+        c.appendChild(b);
+      }
+      document.documentElement.appendChild(c);
+      return true;
+    })()`,
+    returnByValue: true,
+    awaitPromise: false,
+  })
+}
+
+export async function removeAnnotationOverlay(
+  session: ProtocolApi,
+  token: string,
+): Promise<void> {
+  const overlayAttr = JSON.stringify(ANNOTATION_OVERLAY_ATTR)
+  const overlayToken = JSON.stringify(token)
+  await session.Runtime.evaluate({
+    expression: `(() => {
+      var attr = ${overlayAttr};
+      var token = ${overlayToken};
+      var existing = document.querySelectorAll('[' + attr + ']');
+      for (var i = 0; i < existing.length; i++) {
+        if (existing[i].getAttribute(attr) === token) existing[i].remove();
+      }
+      return true;
+    })()`,
+    returnByValue: true,
+    awaitPromise: false,
+  })
+}
+
+function round(value: number): number {
+  return Math.round(value)
+}

--- a/packages/browseros-agent/apps/server/src/browser/core/screenshot-overlay.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/screenshot-overlay.ts
@@ -19,6 +19,7 @@ export function createOverlayToken(): string {
 export async function injectAnnotationOverlay(
   session: ProtocolApi,
   token: string,
+  fullPage: boolean,
   annotations: OverlayAnnotation[],
 ): Promise<void> {
   const items = JSON.stringify(
@@ -32,12 +33,14 @@ export async function injectAnnotationOverlay(
   )
   const overlayAttr = JSON.stringify(ANNOTATION_OVERLAY_ATTR)
   const overlayToken = JSON.stringify(token)
+  const useDocumentSpaceLabels = JSON.stringify(fullPage)
 
   await session.Runtime.evaluate({
     expression: `(() => {
       var items = ${items};
       var attr = ${overlayAttr};
       var token = ${overlayToken};
+      var useDocumentSpaceLabels = ${useDocumentSpaceLabels};
       var existing = document.querySelectorAll('[' + attr + ']');
       for (var j = 0; j < existing.length; j++) {
         if (existing[j].getAttribute(attr) === token) existing[j].remove();
@@ -55,7 +58,8 @@ export async function injectAnnotationOverlay(
         b.style.cssText = 'position:absolute;left:' + dx + 'px;top:' + dy + 'px;width:' + it.width + 'px;height:' + it.height + 'px;border:2px solid rgba(255,0,0,0.8);box-sizing:border-box;pointer-events:none;';
         var l = document.createElement('div');
         l.textContent = String(it.number);
-        var labelTop = dy < 14 ? '2px' : '-14px';
+        var labelAnchor = useDocumentSpaceLabels ? dy : it.y;
+        var labelTop = labelAnchor < 14 ? '2px' : '-14px';
         l.style.cssText = 'position:absolute;top:' + labelTop + ';left:-2px;background:rgba(255,0,0,0.9);color:#fff;font:bold 11px/14px monospace;padding:0 4px;border-radius:2px;white-space:nowrap;';
         b.appendChild(l);
         c.appendChild(b);

--- a/packages/browseros-agent/apps/server/src/browser/core/screenshot-queue.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/screenshot-queue.ts
@@ -1,0 +1,27 @@
+import type { ProtocolApi } from '@browseros/cdp-protocol/protocol-api'
+
+const annotatedCaptureQueues = new WeakMap<ProtocolApi, Promise<void>>()
+
+/** Serializes annotated captures because page overlay DOM is visible to all screenshots on that page. */
+export async function runExclusiveAnnotatedCapture<T>(
+  pageSession: ProtocolApi,
+  task: () => Promise<T>,
+): Promise<T> {
+  const previous = annotatedCaptureQueues.get(pageSession) ?? Promise.resolve()
+  let releaseCurrent = () => {}
+  const current = new Promise<void>((resolve) => {
+    releaseCurrent = resolve
+  })
+  const tail = previous.catch(() => {}).then(() => current)
+  annotatedCaptureQueues.set(pageSession, tail)
+
+  await previous.catch(() => {})
+  try {
+    return await task()
+  } finally {
+    releaseCurrent()
+    if (annotatedCaptureQueues.get(pageSession) === tail) {
+      annotatedCaptureQueues.delete(pageSession)
+    }
+  }
+}

--- a/packages/browseros-agent/apps/server/src/browser/core/screenshot-queue.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/screenshot-queue.ts
@@ -1,27 +1,27 @@
 import type { ProtocolApi } from '@browseros/cdp-protocol/protocol-api'
 
-const annotatedCaptureQueues = new WeakMap<ProtocolApi, Promise<void>>()
+const screenshotCaptureQueues = new WeakMap<ProtocolApi, Promise<void>>()
 
-/** Serializes annotated captures because page overlay DOM is visible to all screenshots on that page. */
-export async function runExclusiveAnnotatedCapture<T>(
+/** Serializes captures because annotation overlay DOM is page-global while screenshots are in flight. */
+export async function runExclusiveScreenshotCapture<T>(
   pageSession: ProtocolApi,
   task: () => Promise<T>,
 ): Promise<T> {
-  const previous = annotatedCaptureQueues.get(pageSession) ?? Promise.resolve()
+  const previous = screenshotCaptureQueues.get(pageSession) ?? Promise.resolve()
   let releaseCurrent = () => {}
   const current = new Promise<void>((resolve) => {
     releaseCurrent = resolve
   })
   const tail = previous.catch(() => {}).then(() => current)
-  annotatedCaptureQueues.set(pageSession, tail)
+  screenshotCaptureQueues.set(pageSession, tail)
 
   await previous.catch(() => {})
   try {
     return await task()
   } finally {
     releaseCurrent()
-    if (annotatedCaptureQueues.get(pageSession) === tail) {
-      annotatedCaptureQueues.delete(pageSession)
+    if (screenshotCaptureQueues.get(pageSession) === tail) {
+      screenshotCaptureQueues.delete(pageSession)
     }
   }
 }

--- a/packages/browseros-agent/apps/server/src/browser/core/screenshot.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/screenshot.ts
@@ -2,7 +2,8 @@ import type { ProtocolApi } from '@browseros/cdp-protocol/protocol-api'
 import type { Observer } from './observer/observer'
 import type { RefEntry } from './snapshot/refs'
 
-const ANNOTATION_OVERLAY_ID = '__browseros_screenshot_annotations__'
+const ANNOTATION_OVERLAY_ATTR = 'data-browseros-screenshot-annotation'
+const OBJECT_GROUP = 'browseros-screenshot-annotations'
 
 export type ScreenshotFormat = 'png' | 'jpeg' | 'webp'
 
@@ -55,6 +56,11 @@ interface RawAnnotation {
   rect: Rect
 }
 
+interface FrameTreeNode {
+  frame: { id: string }
+  childFrames?: FrameTreeNode[]
+}
+
 /** Captures a screenshot, optionally painting current snapshot refs into a temporary page overlay. */
 export async function captureScreenshotWithAnnotations({
   pageSession,
@@ -63,14 +69,23 @@ export async function captureScreenshotWithAnnotations({
 }: CaptureInput): Promise<ScreenshotCaptureResult> {
   const format = options.format ?? 'png'
   const fullPage = options.fullPage ?? false
+  const annotate = options.annotate ?? true
   let annotations: RawAnnotation[] = []
   let overlayInjected = false
+  const overlayToken = createOverlayToken()
+  const objectSessions = new Set<ProtocolApi>()
 
   try {
-    if (options.annotate) {
-      annotations = await collectAnnotations(pageSession, observer)
+    if (annotate) {
+      const captureArea = fullPage
+        ? undefined
+        : await readViewportRect(pageSession).catch(() => undefined)
+      annotations = clipAnnotations(
+        await collectAnnotations(pageSession, observer, objectSessions),
+        captureArea,
+      )
       if (annotations.length > 0) {
-        await injectAnnotationOverlay(pageSession, annotations)
+        await injectAnnotationOverlay(pageSession, overlayToken, annotations)
         overlayInjected = true
       }
     }
@@ -93,21 +108,25 @@ export async function captureScreenshotWithAnnotations({
     }
   } finally {
     if (overlayInjected) {
-      await removeAnnotationOverlay(pageSession).catch(() => {})
+      await removeAnnotationOverlay(pageSession, overlayToken).catch(() => {})
     }
+    await releaseObjectGroup(objectSessions)
   }
 }
 
 async function collectAnnotations(
   pageSession: ProtocolApi,
   observer: Observer,
+  objectSessions: Set<ProtocolApi>,
 ): Promise<RawAnnotation[]> {
   const snapshot = await observer.snapshot()
   const entries = [...snapshot.refs.byRef.values()].sort(
     (left, right) => annotationNumber(left.ref) - annotationNumber(right.ref),
   )
   const annotations = await Promise.all(
-    entries.map((entry) => collectAnnotation(pageSession, observer, entry)),
+    entries.map((entry) =>
+      collectAnnotation(pageSession, observer, objectSessions, entry),
+    ),
   )
   return annotations.filter((item): item is RawAnnotation => item !== undefined)
 }
@@ -115,6 +134,7 @@ async function collectAnnotations(
 async function collectAnnotation(
   pageSession: ProtocolApi,
   observer: Observer,
+  objectSessions: Set<ProtocolApi>,
   entry: RefEntry,
 ): Promise<RawAnnotation | undefined> {
   try {
@@ -122,13 +142,19 @@ async function collectAnnotation(
     const localRect = await readElementRect(
       resolved.session,
       resolved.backendNodeId,
+      objectSessions,
     )
     if (!localRect) return undefined
 
     const rect =
       entry.frameId === undefined
         ? localRect
-        : await projectFrameRect(pageSession, entry.frameId, localRect)
+        : await projectFrameRect(
+            pageSession,
+            objectSessions,
+            entry.frameId,
+            localRect,
+          )
     if (!rect) return undefined
 
     return {
@@ -145,14 +171,17 @@ async function collectAnnotation(
 
 async function projectFrameRect(
   pageSession: ProtocolApi,
+  objectSessions: Set<ProtocolApi>,
   frameId: string,
   rect: Rect,
 ): Promise<Rect | undefined> {
   try {
+    if ((await frameDepth(pageSession, frameId)) !== 1) return undefined
     const owner = await pageSession.DOM.getFrameOwner({ frameId })
     const offset = await readFrameContentOffset(
       pageSession,
       owner.backendNodeId,
+      objectSessions,
     )
     if (!offset) return undefined
     return {
@@ -169,8 +198,9 @@ async function projectFrameRect(
 async function readElementRect(
   session: ProtocolApi,
   backendNodeId: number,
+  objectSessions: Set<ProtocolApi>,
 ): Promise<Rect | undefined> {
-  const objectId = await resolveObjectId(session, backendNodeId)
+  const objectId = await resolveObjectId(session, backendNodeId, objectSessions)
   if (!objectId) return undefined
 
   const result = await session.Runtime.callFunctionOn({
@@ -187,8 +217,9 @@ async function readElementRect(
 async function readFrameContentOffset(
   session: ProtocolApi,
   backendNodeId: number,
+  objectSessions: Set<ProtocolApi>,
 ): Promise<{ x: number; y: number } | undefined> {
-  const objectId = await resolveObjectId(session, backendNodeId)
+  const objectId = await resolveObjectId(session, backendNodeId, objectSessions)
   if (!objectId) return undefined
 
   const result = await session.Runtime.callFunctionOn({
@@ -209,13 +240,16 @@ async function readFrameContentOffset(
 async function resolveObjectId(
   session: ProtocolApi,
   backendNodeId: number,
+  objectSessions: Set<ProtocolApi>,
 ): Promise<string | undefined> {
   try {
     const resolved = await session.DOM.resolveNode({
       backendNodeId,
-      objectGroup: 'browseros-screenshot-annotations',
+      objectGroup: OBJECT_GROUP,
     })
-    return resolved.object?.objectId
+    const objectId = resolved.object?.objectId
+    if (objectId) objectSessions.add(session)
+    return objectId
   } catch {
     return undefined
   }
@@ -245,6 +279,7 @@ function parseRect(value: unknown): Rect | undefined {
 
 async function injectAnnotationOverlay(
   session: ProtocolApi,
+  token: string,
   annotations: RawAnnotation[],
 ): Promise<void> {
   const items = JSON.stringify(
@@ -256,18 +291,22 @@ async function injectAnnotationOverlay(
       height: round(annotation.rect.height),
     })),
   )
-  const overlayId = JSON.stringify(ANNOTATION_OVERLAY_ID)
+  const overlayAttr = JSON.stringify(ANNOTATION_OVERLAY_ATTR)
+  const overlayToken = JSON.stringify(token)
 
   await session.Runtime.evaluate({
     expression: `(() => {
       var items = ${items};
-      var id = ${overlayId};
-      var existing = document.getElementById(id);
-      if (existing) existing.remove();
+      var attr = ${overlayAttr};
+      var token = ${overlayToken};
+      var existing = document.querySelectorAll('[' + attr + ']');
+      for (var j = 0; j < existing.length; j++) {
+        if (existing[j].getAttribute(attr) === token) existing[j].remove();
+      }
       var sx = window.scrollX || 0;
       var sy = window.scrollY || 0;
       var c = document.createElement('div');
-      c.id = id;
+      c.setAttribute(attr, token);
       c.style.cssText = 'position:absolute;top:0;left:0;width:0;height:0;pointer-events:none;z-index:2147483647;';
       for (var i = 0; i < items.length; i++) {
         var it = items[i];
@@ -290,17 +329,42 @@ async function injectAnnotationOverlay(
   })
 }
 
-async function removeAnnotationOverlay(session: ProtocolApi): Promise<void> {
-  const overlayId = JSON.stringify(ANNOTATION_OVERLAY_ID)
+async function removeAnnotationOverlay(
+  session: ProtocolApi,
+  token: string,
+): Promise<void> {
+  const overlayAttr = JSON.stringify(ANNOTATION_OVERLAY_ATTR)
+  const overlayToken = JSON.stringify(token)
   await session.Runtime.evaluate({
     expression: `(() => {
-      var el = document.getElementById(${overlayId});
-      if (el) el.remove();
+      var attr = ${overlayAttr};
+      var token = ${overlayToken};
+      var existing = document.querySelectorAll('[' + attr + ']');
+      for (var i = 0; i < existing.length; i++) {
+        if (existing[i].getAttribute(attr) === token) existing[i].remove();
+      }
       return true;
     })()`,
     returnByValue: true,
     awaitPromise: false,
   })
+}
+
+async function readViewportRect(session: ProtocolApi): Promise<Rect> {
+  const result = await session.Runtime.evaluate({
+    expression:
+      '({x:0,y:0,width:window.innerWidth||0,height:window.innerHeight||0})',
+    returnByValue: true,
+    awaitPromise: false,
+  })
+  return (
+    parseRect(result.result?.value) ?? {
+      x: 0,
+      y: 0,
+      width: 0,
+      height: 0,
+    }
+  )
 }
 
 async function readScrollOffsets(
@@ -336,6 +400,60 @@ function projectAnnotations(
       height: round(annotation.rect.height),
     },
   }))
+}
+
+function clipAnnotations(
+  annotations: RawAnnotation[],
+  captureArea: Rect | undefined,
+): RawAnnotation[] {
+  if (!captureArea || captureArea.width <= 0 || captureArea.height <= 0) {
+    return annotations
+  }
+  return annotations.flatMap((annotation) => {
+    const rect = intersectRects(annotation.rect, captureArea)
+    return rect ? [{ ...annotation, rect }] : []
+  })
+}
+
+function intersectRects(left: Rect, right: Rect): Rect | undefined {
+  const x1 = Math.max(left.x, right.x)
+  const y1 = Math.max(left.y, right.y)
+  const x2 = Math.min(left.x + left.width, right.x + right.width)
+  const y2 = Math.min(left.y + left.height, right.y + right.height)
+  if (x2 <= x1 || y2 <= y1) return undefined
+  return { x: x1, y: y1, width: x2 - x1, height: y2 - y1 }
+}
+
+async function frameDepth(
+  pageSession: ProtocolApi,
+  frameId: string,
+): Promise<number | undefined> {
+  const result = await pageSession.Page.getFrameTree()
+
+  function visit(node: FrameTreeNode): number | undefined {
+    if (node.frame.id === frameId) return 0
+    for (const child of node.childFrames ?? []) {
+      const depth = visit(child)
+      if (depth !== undefined) return depth + 1
+    }
+    return undefined
+  }
+
+  return visit(result.frameTree as FrameTreeNode)
+}
+
+async function releaseObjectGroup(sessions: Set<ProtocolApi>): Promise<void> {
+  await Promise.all(
+    [...sessions].map((session) =>
+      session.Runtime.releaseObjectGroup({ objectGroup: OBJECT_GROUP }).catch(
+        () => {},
+      ),
+    ),
+  )
+}
+
+function createOverlayToken(): string {
+  return `browseros-${Date.now()}-${Math.random().toString(36).slice(2)}`
 }
 
 function annotationNumber(ref: string): number {

--- a/packages/browseros-agent/apps/server/src/browser/core/screenshot.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/screenshot.ts
@@ -1,8 +1,12 @@
 import type { ProtocolApi } from '@browseros/cdp-protocol/protocol-api'
 import type { Observer } from './observer/observer'
+import {
+  createOverlayToken,
+  injectAnnotationOverlay,
+  removeAnnotationOverlay,
+} from './screenshot-overlay'
 import type { RefEntry } from './snapshot/refs'
 
-const ANNOTATION_OVERLAY_ATTR = 'data-browseros-screenshot-annotation'
 const OBJECT_GROUP = 'browseros-screenshot-annotations'
 
 export type ScreenshotFormat = 'png' | 'jpeg' | 'webp'
@@ -277,79 +281,6 @@ function parseRect(value: unknown): Rect | undefined {
   return { x, y, width, height }
 }
 
-async function injectAnnotationOverlay(
-  session: ProtocolApi,
-  token: string,
-  annotations: RawAnnotation[],
-): Promise<void> {
-  const items = JSON.stringify(
-    annotations.map((annotation) => ({
-      number: annotation.number,
-      x: round(annotation.rect.x),
-      y: round(annotation.rect.y),
-      width: round(annotation.rect.width),
-      height: round(annotation.rect.height),
-    })),
-  )
-  const overlayAttr = JSON.stringify(ANNOTATION_OVERLAY_ATTR)
-  const overlayToken = JSON.stringify(token)
-
-  await session.Runtime.evaluate({
-    expression: `(() => {
-      var items = ${items};
-      var attr = ${overlayAttr};
-      var token = ${overlayToken};
-      var existing = document.querySelectorAll('[' + attr + ']');
-      for (var j = 0; j < existing.length; j++) {
-        if (existing[j].getAttribute(attr) === token) existing[j].remove();
-      }
-      var sx = window.scrollX || 0;
-      var sy = window.scrollY || 0;
-      var c = document.createElement('div');
-      c.setAttribute(attr, token);
-      c.style.cssText = 'position:absolute;top:0;left:0;width:0;height:0;pointer-events:none;z-index:2147483647;';
-      for (var i = 0; i < items.length; i++) {
-        var it = items[i];
-        var dx = it.x + sx;
-        var dy = it.y + sy;
-        var b = document.createElement('div');
-        b.style.cssText = 'position:absolute;left:' + dx + 'px;top:' + dy + 'px;width:' + it.width + 'px;height:' + it.height + 'px;border:2px solid rgba(255,0,0,0.8);box-sizing:border-box;pointer-events:none;';
-        var l = document.createElement('div');
-        l.textContent = String(it.number);
-        var labelTop = dy < 14 ? '2px' : '-14px';
-        l.style.cssText = 'position:absolute;top:' + labelTop + ';left:-2px;background:rgba(255,0,0,0.9);color:#fff;font:bold 11px/14px monospace;padding:0 4px;border-radius:2px;white-space:nowrap;';
-        b.appendChild(l);
-        c.appendChild(b);
-      }
-      document.documentElement.appendChild(c);
-      return true;
-    })()`,
-    returnByValue: true,
-    awaitPromise: false,
-  })
-}
-
-async function removeAnnotationOverlay(
-  session: ProtocolApi,
-  token: string,
-): Promise<void> {
-  const overlayAttr = JSON.stringify(ANNOTATION_OVERLAY_ATTR)
-  const overlayToken = JSON.stringify(token)
-  await session.Runtime.evaluate({
-    expression: `(() => {
-      var attr = ${overlayAttr};
-      var token = ${overlayToken};
-      var existing = document.querySelectorAll('[' + attr + ']');
-      for (var i = 0; i < existing.length; i++) {
-        if (existing[i].getAttribute(attr) === token) existing[i].remove();
-      }
-      return true;
-    })()`,
-    returnByValue: true,
-    awaitPromise: false,
-  })
-}
-
 async function readViewportRect(session: ProtocolApi): Promise<Rect> {
   const result = await session.Runtime.evaluate({
     expression:
@@ -450,10 +381,6 @@ async function releaseObjectGroup(sessions: Set<ProtocolApi>): Promise<void> {
       ),
     ),
   )
-}
-
-function createOverlayToken(): string {
-  return `browseros-${Date.now()}-${Math.random().toString(36).slice(2)}`
 }
 
 function annotationNumber(ref: string): number {

--- a/packages/browseros-agent/apps/server/src/browser/core/screenshot.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/screenshot.ts
@@ -1,0 +1,352 @@
+import type { ProtocolApi } from '@browseros/cdp-protocol/protocol-api'
+import type { Observer } from './observer/observer'
+import type { RefEntry } from './snapshot/refs'
+
+const ANNOTATION_OVERLAY_ID = '__browseros_screenshot_annotations__'
+
+export type ScreenshotFormat = 'png' | 'jpeg' | 'webp'
+
+export interface ScreenshotCaptureOptions {
+  format?: ScreenshotFormat
+  quality?: number
+  fullPage?: boolean
+  annotate?: boolean
+}
+
+export interface ScreenshotAnnotationBox {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+export interface ScreenshotAnnotation {
+  ref: string
+  number: number
+  role: string
+  name?: string
+  box: ScreenshotAnnotationBox
+}
+
+export interface ScreenshotCaptureResult {
+  data: string
+  mimeType: string
+  annotations: ScreenshotAnnotation[]
+}
+
+interface CaptureInput {
+  pageSession: ProtocolApi
+  observer: Observer
+  options: ScreenshotCaptureOptions
+}
+
+interface Rect {
+  x: number
+  y: number
+  width: number
+  height: number
+}
+
+interface RawAnnotation {
+  ref: string
+  number: number
+  role: string
+  name?: string
+  rect: Rect
+}
+
+/** Captures a screenshot, optionally painting current snapshot refs into a temporary page overlay. */
+export async function captureScreenshotWithAnnotations({
+  pageSession,
+  observer,
+  options,
+}: CaptureInput): Promise<ScreenshotCaptureResult> {
+  const format = options.format ?? 'png'
+  const fullPage = options.fullPage ?? false
+  let annotations: RawAnnotation[] = []
+  let overlayInjected = false
+
+  try {
+    if (options.annotate) {
+      annotations = await collectAnnotations(pageSession, observer)
+      if (annotations.length > 0) {
+        await injectAnnotationOverlay(pageSession, annotations)
+        overlayInjected = true
+      }
+    }
+
+    const result = await pageSession.Page.captureScreenshot({
+      format,
+      ...(format !== 'png' &&
+        options.quality !== undefined && { quality: options.quality }),
+      captureBeyondViewport: fullPage,
+    })
+    const scroll =
+      fullPage && annotations.length > 0
+        ? await readScrollOffsets(pageSession).catch(() => undefined)
+        : undefined
+
+    return {
+      data: result.data,
+      mimeType: `image/${format}`,
+      annotations: projectAnnotations(annotations, scroll),
+    }
+  } finally {
+    if (overlayInjected) {
+      await removeAnnotationOverlay(pageSession).catch(() => {})
+    }
+  }
+}
+
+async function collectAnnotations(
+  pageSession: ProtocolApi,
+  observer: Observer,
+): Promise<RawAnnotation[]> {
+  const snapshot = await observer.snapshot()
+  const entries = [...snapshot.refs.byRef.values()].sort(
+    (left, right) => annotationNumber(left.ref) - annotationNumber(right.ref),
+  )
+  const annotations = await Promise.all(
+    entries.map((entry) => collectAnnotation(pageSession, observer, entry)),
+  )
+  return annotations.filter((item): item is RawAnnotation => item !== undefined)
+}
+
+async function collectAnnotation(
+  pageSession: ProtocolApi,
+  observer: Observer,
+  entry: RefEntry,
+): Promise<RawAnnotation | undefined> {
+  try {
+    const resolved = await observer.resolveRef(entry.ref)
+    const localRect = await readElementRect(
+      resolved.session,
+      resolved.backendNodeId,
+    )
+    if (!localRect) return undefined
+
+    const rect =
+      entry.frameId === undefined
+        ? localRect
+        : await projectFrameRect(pageSession, entry.frameId, localRect)
+    if (!rect) return undefined
+
+    return {
+      ref: entry.ref,
+      number: annotationNumber(entry.ref),
+      role: entry.role,
+      ...(entry.name && { name: entry.name }),
+      rect,
+    }
+  } catch {
+    return undefined
+  }
+}
+
+async function projectFrameRect(
+  pageSession: ProtocolApi,
+  frameId: string,
+  rect: Rect,
+): Promise<Rect | undefined> {
+  try {
+    const owner = await pageSession.DOM.getFrameOwner({ frameId })
+    const offset = await readFrameContentOffset(
+      pageSession,
+      owner.backendNodeId,
+    )
+    if (!offset) return undefined
+    return {
+      x: offset.x + rect.x,
+      y: offset.y + rect.y,
+      width: rect.width,
+      height: rect.height,
+    }
+  } catch {
+    return undefined
+  }
+}
+
+async function readElementRect(
+  session: ProtocolApi,
+  backendNodeId: number,
+): Promise<Rect | undefined> {
+  const objectId = await resolveObjectId(session, backendNodeId)
+  if (!objectId) return undefined
+
+  const result = await session.Runtime.callFunctionOn({
+    functionDeclaration:
+      'function(){var r=this.getBoundingClientRect();return{x:r.x,y:r.y,width:r.width,height:r.height}}',
+    objectId,
+    returnByValue: true,
+  })
+  const rect = parseRect(result.result?.value)
+  if (!rect || rect.width <= 0 || rect.height <= 0) return undefined
+  return rect
+}
+
+async function readFrameContentOffset(
+  session: ProtocolApi,
+  backendNodeId: number,
+): Promise<{ x: number; y: number } | undefined> {
+  const objectId = await resolveObjectId(session, backendNodeId)
+  if (!objectId) return undefined
+
+  const result = await session.Runtime.callFunctionOn({
+    functionDeclaration:
+      'function(){var r=this.getBoundingClientRect();return{x:r.x+(this.clientLeft||0),y:r.y+(this.clientTop||0)}}',
+    objectId,
+    returnByValue: true,
+  })
+  const value = result.result?.value
+  if (!isRecord(value)) return undefined
+  const x = value.x
+  const y = value.y
+  if (typeof x !== 'number' || typeof y !== 'number') return undefined
+  if (!Number.isFinite(x) || !Number.isFinite(y)) return undefined
+  return { x, y }
+}
+
+async function resolveObjectId(
+  session: ProtocolApi,
+  backendNodeId: number,
+): Promise<string | undefined> {
+  try {
+    const resolved = await session.DOM.resolveNode({
+      backendNodeId,
+      objectGroup: 'browseros-screenshot-annotations',
+    })
+    return resolved.object?.objectId
+  } catch {
+    return undefined
+  }
+}
+
+function parseRect(value: unknown): Rect | undefined {
+  if (!isRecord(value)) return undefined
+  const { x, y, width, height } = value
+  if (
+    typeof x !== 'number' ||
+    typeof y !== 'number' ||
+    typeof width !== 'number' ||
+    typeof height !== 'number'
+  ) {
+    return undefined
+  }
+  if (
+    !Number.isFinite(x) ||
+    !Number.isFinite(y) ||
+    !Number.isFinite(width) ||
+    !Number.isFinite(height)
+  ) {
+    return undefined
+  }
+  return { x, y, width, height }
+}
+
+async function injectAnnotationOverlay(
+  session: ProtocolApi,
+  annotations: RawAnnotation[],
+): Promise<void> {
+  const items = JSON.stringify(
+    annotations.map((annotation) => ({
+      number: annotation.number,
+      x: round(annotation.rect.x),
+      y: round(annotation.rect.y),
+      width: round(annotation.rect.width),
+      height: round(annotation.rect.height),
+    })),
+  )
+  const overlayId = JSON.stringify(ANNOTATION_OVERLAY_ID)
+
+  await session.Runtime.evaluate({
+    expression: `(() => {
+      var items = ${items};
+      var id = ${overlayId};
+      var existing = document.getElementById(id);
+      if (existing) existing.remove();
+      var sx = window.scrollX || 0;
+      var sy = window.scrollY || 0;
+      var c = document.createElement('div');
+      c.id = id;
+      c.style.cssText = 'position:absolute;top:0;left:0;width:0;height:0;pointer-events:none;z-index:2147483647;';
+      for (var i = 0; i < items.length; i++) {
+        var it = items[i];
+        var dx = it.x + sx;
+        var dy = it.y + sy;
+        var b = document.createElement('div');
+        b.style.cssText = 'position:absolute;left:' + dx + 'px;top:' + dy + 'px;width:' + it.width + 'px;height:' + it.height + 'px;border:2px solid rgba(255,0,0,0.8);box-sizing:border-box;pointer-events:none;';
+        var l = document.createElement('div');
+        l.textContent = String(it.number);
+        var labelTop = dy < 14 ? '2px' : '-14px';
+        l.style.cssText = 'position:absolute;top:' + labelTop + ';left:-2px;background:rgba(255,0,0,0.9);color:#fff;font:bold 11px/14px monospace;padding:0 4px;border-radius:2px;white-space:nowrap;';
+        b.appendChild(l);
+        c.appendChild(b);
+      }
+      document.documentElement.appendChild(c);
+      return true;
+    })()`,
+    returnByValue: true,
+    awaitPromise: false,
+  })
+}
+
+async function removeAnnotationOverlay(session: ProtocolApi): Promise<void> {
+  const overlayId = JSON.stringify(ANNOTATION_OVERLAY_ID)
+  await session.Runtime.evaluate({
+    expression: `(() => {
+      var el = document.getElementById(${overlayId});
+      if (el) el.remove();
+      return true;
+    })()`,
+    returnByValue: true,
+    awaitPromise: false,
+  })
+}
+
+async function readScrollOffsets(
+  session: ProtocolApi,
+): Promise<{ x: number; y: number }> {
+  const result = await session.Runtime.evaluate({
+    expression: '({x: window.scrollX || 0, y: window.scrollY || 0})',
+    returnByValue: true,
+    awaitPromise: false,
+  })
+  const value = result.result?.value
+  if (!isRecord(value)) return { x: 0, y: 0 }
+  const x =
+    typeof value.x === 'number' && Number.isFinite(value.x) ? value.x : 0
+  const y =
+    typeof value.y === 'number' && Number.isFinite(value.y) ? value.y : 0
+  return { x, y }
+}
+
+function projectAnnotations(
+  annotations: RawAnnotation[],
+  scroll?: { x: number; y: number },
+): ScreenshotAnnotation[] {
+  return annotations.map((annotation) => ({
+    ref: annotation.ref,
+    number: annotation.number,
+    role: annotation.role,
+    ...(annotation.name && { name: annotation.name }),
+    box: {
+      x: round(annotation.rect.x + (scroll?.x ?? 0)),
+      y: round(annotation.rect.y + (scroll?.y ?? 0)),
+      width: round(annotation.rect.width),
+      height: round(annotation.rect.height),
+    },
+  }))
+}
+
+function annotationNumber(ref: string): number {
+  const number = Number.parseInt(ref.replace(/^e/, ''), 10)
+  return Number.isFinite(number) ? number : 0
+}
+
+function round(value: number): number {
+  return Math.round(value)
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}

--- a/packages/browseros-agent/apps/server/src/browser/core/screenshot.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/screenshot.ts
@@ -2,13 +2,21 @@ import type { ProtocolApi } from '@browseros/cdp-protocol/protocol-api'
 import type { Observer } from './observer/observer'
 import { frameDepth } from './screenshot-frame'
 import {
+  clipAnnotations,
+  parseRect,
+  projectAnnotations,
+  type RawAnnotation,
+  type Rect,
+  readScrollOffsets,
+  readViewportRect,
+} from './screenshot-geometry'
+import {
   createOverlayToken,
   injectAnnotationOverlay,
   removeAnnotationOverlay,
 } from './screenshot-overlay'
+import { runExclusiveAnnotatedCapture } from './screenshot-queue'
 import type { RefEntry } from './snapshot/refs'
-
-const OBJECT_GROUP = 'browseros-screenshot-annotations'
 
 export type ScreenshotFormat = 'png' | 'jpeg' | 'webp'
 
@@ -46,53 +54,76 @@ interface CaptureInput {
   options: ScreenshotCaptureOptions
 }
 
-interface Rect {
-  x: number
-  y: number
-  width: number
-  height: number
-}
-
-interface RawAnnotation {
-  ref: string
-  number: number
-  role: string
-  name?: string
-  rect: Rect
-}
-
 /** Captures a screenshot, optionally painting current snapshot refs into a temporary page overlay. */
 export async function captureScreenshotWithAnnotations({
   pageSession,
   observer,
   options,
 }: CaptureInput): Promise<ScreenshotCaptureResult> {
+  if ((options.annotate ?? true) === false) {
+    return capturePlainScreenshot(pageSession, options)
+  }
+
+  return runExclusiveAnnotatedCapture(pageSession, () =>
+    captureAnnotatedScreenshot({ pageSession, observer, options }),
+  )
+}
+
+async function capturePlainScreenshot(
+  pageSession: ProtocolApi,
+  options: ScreenshotCaptureOptions,
+): Promise<ScreenshotCaptureResult> {
   const format = options.format ?? 'png'
   const fullPage = options.fullPage ?? false
-  const annotate = options.annotate ?? true
+
+  const result = await pageSession.Page.captureScreenshot({
+    format,
+    ...(format !== 'png' &&
+      options.quality !== undefined && { quality: options.quality }),
+    captureBeyondViewport: fullPage,
+  })
+
+  return {
+    data: result.data,
+    mimeType: `image/${format}`,
+    annotations: [],
+  }
+}
+
+async function captureAnnotatedScreenshot({
+  pageSession,
+  observer,
+  options,
+}: CaptureInput): Promise<ScreenshotCaptureResult> {
+  const format = options.format ?? 'png'
+  const fullPage = options.fullPage ?? false
   let annotations: RawAnnotation[] = []
   let overlayInjected = false
   const overlayToken = createOverlayToken()
+  const objectGroup = overlayToken
   const objectSessions = new Set<ProtocolApi>()
 
   try {
-    if (annotate) {
-      const captureArea = fullPage
-        ? undefined
-        : await readViewportRect(pageSession).catch(() => undefined)
-      annotations = clipAnnotations(
-        await collectAnnotations(pageSession, observer, objectSessions),
-        captureArea,
+    const captureArea = fullPage
+      ? undefined
+      : await readViewportRect(pageSession).catch(() => undefined)
+    annotations = clipAnnotations(
+      await collectAnnotations(
+        pageSession,
+        observer,
+        objectGroup,
+        objectSessions,
+      ),
+      captureArea,
+    )
+    if (annotations.length > 0) {
+      await injectAnnotationOverlay(
+        pageSession,
+        overlayToken,
+        fullPage,
+        annotations,
       )
-      if (annotations.length > 0) {
-        await injectAnnotationOverlay(
-          pageSession,
-          overlayToken,
-          fullPage,
-          annotations,
-        )
-        overlayInjected = true
-      }
+      overlayInjected = true
     }
 
     const result = await pageSession.Page.captureScreenshot({
@@ -115,13 +146,14 @@ export async function captureScreenshotWithAnnotations({
     if (overlayInjected) {
       await removeAnnotationOverlay(pageSession, overlayToken).catch(() => {})
     }
-    await releaseObjectGroup(objectSessions)
+    await releaseObjectGroup(objectSessions, objectGroup)
   }
 }
 
 async function collectAnnotations(
   pageSession: ProtocolApi,
   observer: Observer,
+  objectGroup: string,
   objectSessions: Set<ProtocolApi>,
 ): Promise<RawAnnotation[]> {
   const snapshot = await observer.snapshot()
@@ -130,7 +162,13 @@ async function collectAnnotations(
   )
   const annotations = await Promise.all(
     entries.map((entry) =>
-      collectAnnotation(pageSession, observer, objectSessions, entry),
+      collectAnnotation(
+        pageSession,
+        observer,
+        objectGroup,
+        objectSessions,
+        entry,
+      ),
     ),
   )
   return annotations.filter((item): item is RawAnnotation => item !== undefined)
@@ -139,6 +177,7 @@ async function collectAnnotations(
 async function collectAnnotation(
   pageSession: ProtocolApi,
   observer: Observer,
+  objectGroup: string,
   objectSessions: Set<ProtocolApi>,
   entry: RefEntry,
 ): Promise<RawAnnotation | undefined> {
@@ -147,6 +186,7 @@ async function collectAnnotation(
     const localRect = await readElementRect(
       resolved.session,
       resolved.backendNodeId,
+      objectGroup,
       objectSessions,
     )
     if (!localRect) return undefined
@@ -156,6 +196,7 @@ async function collectAnnotation(
         ? localRect
         : await projectFrameRect(
             pageSession,
+            objectGroup,
             objectSessions,
             entry.frameId,
             localRect,
@@ -176,6 +217,7 @@ async function collectAnnotation(
 
 async function projectFrameRect(
   pageSession: ProtocolApi,
+  objectGroup: string,
   objectSessions: Set<ProtocolApi>,
   frameId: string,
   rect: Rect,
@@ -186,6 +228,7 @@ async function projectFrameRect(
     const offset = await readFrameContentOffset(
       pageSession,
       owner.backendNodeId,
+      objectGroup,
       objectSessions,
     )
     if (!offset) return undefined
@@ -203,9 +246,15 @@ async function projectFrameRect(
 async function readElementRect(
   session: ProtocolApi,
   backendNodeId: number,
+  objectGroup: string,
   objectSessions: Set<ProtocolApi>,
 ): Promise<Rect | undefined> {
-  const objectId = await resolveObjectId(session, backendNodeId, objectSessions)
+  const objectId = await resolveObjectId(
+    session,
+    backendNodeId,
+    objectGroup,
+    objectSessions,
+  )
   if (!objectId) return undefined
 
   const result = await session.Runtime.callFunctionOn({
@@ -222,9 +271,15 @@ async function readElementRect(
 async function readFrameContentOffset(
   session: ProtocolApi,
   backendNodeId: number,
+  objectGroup: string,
   objectSessions: Set<ProtocolApi>,
 ): Promise<{ x: number; y: number } | undefined> {
-  const objectId = await resolveObjectId(session, backendNodeId, objectSessions)
+  const objectId = await resolveObjectId(
+    session,
+    backendNodeId,
+    objectGroup,
+    objectSessions,
+  )
   if (!objectId) return undefined
 
   const result = await session.Runtime.callFunctionOn({
@@ -245,12 +300,13 @@ async function readFrameContentOffset(
 async function resolveObjectId(
   session: ProtocolApi,
   backendNodeId: number,
+  objectGroup: string,
   objectSessions: Set<ProtocolApi>,
 ): Promise<string | undefined> {
   try {
     const resolved = await session.DOM.resolveNode({
       backendNodeId,
-      objectGroup: OBJECT_GROUP,
+      objectGroup,
     })
     const objectId = resolved.object?.objectId
     if (objectId) objectSessions.add(session)
@@ -260,108 +316,13 @@ async function resolveObjectId(
   }
 }
 
-function parseRect(value: unknown): Rect | undefined {
-  if (!isRecord(value)) return undefined
-  const { x, y, width, height } = value
-  if (
-    typeof x !== 'number' ||
-    typeof y !== 'number' ||
-    typeof width !== 'number' ||
-    typeof height !== 'number'
-  ) {
-    return undefined
-  }
-  if (
-    !Number.isFinite(x) ||
-    !Number.isFinite(y) ||
-    !Number.isFinite(width) ||
-    !Number.isFinite(height)
-  ) {
-    return undefined
-  }
-  return { x, y, width, height }
-}
-
-async function readViewportRect(session: ProtocolApi): Promise<Rect> {
-  const result = await session.Runtime.evaluate({
-    expression:
-      '({x:0,y:0,width:window.innerWidth||0,height:window.innerHeight||0})',
-    returnByValue: true,
-    awaitPromise: false,
-  })
-  return (
-    parseRect(result.result?.value) ?? {
-      x: 0,
-      y: 0,
-      width: 0,
-      height: 0,
-    }
-  )
-}
-
-async function readScrollOffsets(
-  session: ProtocolApi,
-): Promise<{ x: number; y: number }> {
-  const result = await session.Runtime.evaluate({
-    expression: '({x: window.scrollX || 0, y: window.scrollY || 0})',
-    returnByValue: true,
-    awaitPromise: false,
-  })
-  const value = result.result?.value
-  if (!isRecord(value)) return { x: 0, y: 0 }
-  const x =
-    typeof value.x === 'number' && Number.isFinite(value.x) ? value.x : 0
-  const y =
-    typeof value.y === 'number' && Number.isFinite(value.y) ? value.y : 0
-  return { x, y }
-}
-
-function projectAnnotations(
-  annotations: RawAnnotation[],
-  scroll?: { x: number; y: number },
-): ScreenshotAnnotation[] {
-  return annotations.map((annotation) => ({
-    ref: annotation.ref,
-    number: annotation.number,
-    role: annotation.role,
-    ...(annotation.name && { name: annotation.name }),
-    box: {
-      x: round(annotation.rect.x + (scroll?.x ?? 0)),
-      y: round(annotation.rect.y + (scroll?.y ?? 0)),
-      width: round(annotation.rect.width),
-      height: round(annotation.rect.height),
-    },
-  }))
-}
-
-function clipAnnotations(
-  annotations: RawAnnotation[],
-  captureArea: Rect | undefined,
-): RawAnnotation[] {
-  if (!captureArea || captureArea.width <= 0 || captureArea.height <= 0) {
-    return annotations
-  }
-  return annotations.flatMap((annotation) => {
-    const rect = intersectRects(annotation.rect, captureArea)
-    return rect ? [{ ...annotation, rect }] : []
-  })
-}
-
-function intersectRects(left: Rect, right: Rect): Rect | undefined {
-  const x1 = Math.max(left.x, right.x)
-  const y1 = Math.max(left.y, right.y)
-  const x2 = Math.min(left.x + left.width, right.x + right.width)
-  const y2 = Math.min(left.y + left.height, right.y + right.height)
-  if (x2 <= x1 || y2 <= y1) return undefined
-  return { x: x1, y: y1, width: x2 - x1, height: y2 - y1 }
-}
-
-async function releaseObjectGroup(sessions: Set<ProtocolApi>): Promise<void> {
+async function releaseObjectGroup(
+  sessions: Set<ProtocolApi>,
+  objectGroup: string,
+): Promise<void> {
   await Promise.all(
     [...sessions].map((session) =>
-      session.Runtime.releaseObjectGroup({ objectGroup: OBJECT_GROUP }).catch(
-        () => {},
-      ),
+      session.Runtime.releaseObjectGroup({ objectGroup }).catch(() => {}),
     ),
   )
 }
@@ -369,10 +330,6 @@ async function releaseObjectGroup(sessions: Set<ProtocolApi>): Promise<void> {
 function annotationNumber(ref: string): number {
   const number = Number.parseInt(ref.replace(/^e/, ''), 10)
   return Number.isFinite(number) ? number : 0
-}
-
-function round(value: number): number {
-  return Math.round(value)
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {

--- a/packages/browseros-agent/apps/server/src/browser/core/screenshot.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/screenshot.ts
@@ -1,5 +1,6 @@
 import type { ProtocolApi } from '@browseros/cdp-protocol/protocol-api'
 import type { Observer } from './observer/observer'
+import { frameDepth } from './screenshot-frame'
 import {
   createOverlayToken,
   injectAnnotationOverlay,
@@ -60,11 +61,6 @@ interface RawAnnotation {
   rect: Rect
 }
 
-interface FrameTreeNode {
-  frame: { id: string }
-  childFrames?: FrameTreeNode[]
-}
-
 /** Captures a screenshot, optionally painting current snapshot refs into a temporary page overlay. */
 export async function captureScreenshotWithAnnotations({
   pageSession,
@@ -89,7 +85,12 @@ export async function captureScreenshotWithAnnotations({
         captureArea,
       )
       if (annotations.length > 0) {
-        await injectAnnotationOverlay(pageSession, overlayToken, annotations)
+        await injectAnnotationOverlay(
+          pageSession,
+          overlayToken,
+          fullPage,
+          annotations,
+        )
         overlayInjected = true
       }
     }
@@ -353,24 +354,6 @@ function intersectRects(left: Rect, right: Rect): Rect | undefined {
   const y2 = Math.min(left.y + left.height, right.y + right.height)
   if (x2 <= x1 || y2 <= y1) return undefined
   return { x: x1, y: y1, width: x2 - x1, height: y2 - y1 }
-}
-
-async function frameDepth(
-  pageSession: ProtocolApi,
-  frameId: string,
-): Promise<number | undefined> {
-  const result = await pageSession.Page.getFrameTree()
-
-  function visit(node: FrameTreeNode): number | undefined {
-    if (node.frame.id === frameId) return 0
-    for (const child of node.childFrames ?? []) {
-      const depth = visit(child)
-      if (depth !== undefined) return depth + 1
-    }
-    return undefined
-  }
-
-  return visit(result.frameTree as FrameTreeNode)
 }
 
 async function releaseObjectGroup(sessions: Set<ProtocolApi>): Promise<void> {

--- a/packages/browseros-agent/apps/server/src/browser/core/screenshot.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/screenshot.ts
@@ -16,7 +16,7 @@ import {
   injectAnnotationOverlay,
   removeAnnotationOverlay,
 } from './screenshot-overlay'
-import { runExclusiveAnnotatedCapture } from './screenshot-queue'
+import { runExclusiveScreenshotCapture } from './screenshot-queue'
 import type { RefEntry } from './snapshot/refs'
 
 export type ScreenshotFormat = 'png' | 'jpeg' | 'webp'
@@ -63,10 +63,12 @@ export async function captureScreenshotWithAnnotations({
   options,
 }: CaptureInput): Promise<ScreenshotCaptureResult> {
   if ((options.annotate ?? true) === false) {
-    return capturePlainScreenshot(pageSession, options)
+    return runExclusiveScreenshotCapture(pageSession, () =>
+      capturePlainScreenshot(pageSession, options),
+    )
   }
 
-  return runExclusiveAnnotatedCapture(pageSession, () =>
+  return runExclusiveScreenshotCapture(pageSession, () =>
     captureAnnotatedScreenshot({ pageSession, observer, options }),
   )
 }
@@ -102,6 +104,7 @@ async function captureAnnotatedScreenshot({
   const format = options.format ?? 'png'
   const fullPage = options.fullPage ?? false
   let annotations: RawAnnotation[] = []
+  let scroll: { x: number; y: number } | undefined
   let overlayInjected = false
   const overlayToken = createOverlayToken()
   const objectGroup = overlayToken
@@ -123,11 +126,15 @@ async function captureAnnotatedScreenshot({
       captureArea,
     )
     if (annotations.length > 0) {
+      scroll = fullPage
+        ? await readScrollOffsets(pageSession).catch(() => undefined)
+        : undefined
       await injectAnnotationOverlay(
         pageSession,
         overlayToken,
         fullPage,
         annotations,
+        scroll,
       )
       overlayInjected = true
     }
@@ -140,11 +147,6 @@ async function captureAnnotatedScreenshot({
       captureBeyondViewport: fullPage,
       ...(!fullPage && options.clip && { clip: options.clip }),
     })
-    const scroll =
-      fullPage && annotations.length > 0
-        ? await readScrollOffsets(pageSession).catch(() => undefined)
-        : undefined
-
     return {
       data: result.data,
       mimeType: `image/${format}`,

--- a/packages/browseros-agent/apps/server/src/browser/core/session.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/session.ts
@@ -4,6 +4,11 @@ import { Navigation } from './navigation'
 import { FrameRegistry } from './observer/frames'
 import { Observer } from './observer/observer'
 import { PageManager, type PageManagerHooks } from './pages'
+import {
+  captureScreenshotWithAnnotations,
+  type ScreenshotCaptureOptions,
+  type ScreenshotCaptureResult,
+} from './screenshot'
 import { WindowManager } from './windows'
 
 export interface BrowserSessionHooks extends PageManagerHooks {}
@@ -51,6 +56,19 @@ export class BrowserSession {
   /** Navigation (url/back/forward/reload) for a page. */
   nav(pageId: number): Navigation {
     return new Navigation(this.pages, pageId)
+  }
+
+  /** Captures a page screenshot, optionally overlaying current snapshot refs. */
+  async screenshot(
+    pageId: number,
+    options: ScreenshotCaptureOptions = {},
+  ): Promise<ScreenshotCaptureResult> {
+    const { session } = await this.pages.getSession(pageId)
+    return captureScreenshotWithAnnotations({
+      pageSession: session,
+      observer: this.observe(pageId),
+      options,
+    })
   }
 
   /** Raw CDP escape hatch for `run` code, e.g. cdp("Page.navigate", { url }). */

--- a/packages/browseros-agent/apps/server/src/tools/browser/screenshot.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/screenshot.ts
@@ -8,16 +8,26 @@ export const screenshot = defineTool({
   input: z.object({
     page: z.number().int(),
     fullPage: z.boolean().optional().describe('Capture beyond the viewport.'),
+    annotate: z
+      .boolean()
+      .optional()
+      .describe('Overlay numbered refs from a fresh snapshot. Defaults true.'),
   }),
   annotations: { readOnlyHint: true },
   handler: async (args, ctx) => {
-    const { session } = await ctx.session.pages.getSession(args.page)
-    const result = await session.Page.captureScreenshot({
+    const result = await ctx.session.screenshot(args.page, {
       format: 'png',
-      captureBeyondViewport: args.fullPage ?? false,
+      fullPage: args.fullPage ?? false,
+      annotate: args.annotate ?? true,
     })
     return {
       content: [{ type: 'image', data: result.data, mimeType: 'image/png' }],
+      ...(result.annotations.length > 0 && {
+        structuredContent: {
+          page: args.page,
+          annotations: result.annotations,
+        },
+      }),
     }
   },
 })

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -1472,6 +1472,11 @@ return 'late'
         },
       }),
       input: () => input,
+      screenshot: async () => ({
+        data: 'png-data',
+        mimeType: 'image/png',
+        annotations: [],
+      }),
       pages: {
         getInfo: () => ({ url: 'https://example.com' }),
         refresh: async () => ({ url: 'https://example.com' }),

--- a/packages/browseros-agent/apps/server/tests/tools/browser/screenshot-tool.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/screenshot-tool.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'bun:test'
+import type {
+  ScreenshotCaptureOptions,
+  ScreenshotCaptureResult,
+} from '../../../src/browser/core/screenshot'
+import type { BrowserSession } from '../../../src/browser/core/session'
+import { executeTool } from '../../../src/tools/browser/framework'
+import { screenshot } from '../../../src/tools/browser/screenshot'
+
+describe('screenshot tool', () => {
+  it('defaults annotate to true and returns inline PNG content', async () => {
+    let captured:
+      | { page: number; options: ScreenshotCaptureOptions }
+      | undefined
+    const session = {
+      screenshot: async (page: number, options: ScreenshotCaptureOptions) => {
+        captured = { page, options }
+        return {
+          data: 'png-data',
+          mimeType: 'image/png',
+          annotations: [
+            {
+              ref: 'e1',
+              number: 1,
+              role: 'button',
+              name: 'Save',
+              box: { x: 1, y: 2, width: 3, height: 4 },
+            },
+          ],
+        } satisfies ScreenshotCaptureResult
+      },
+      pages: {
+        getTabId: () => undefined,
+      },
+    } as unknown as BrowserSession
+
+    const result = await executeTool(screenshot, { page: 3 }, { session })
+
+    expect(captured).toEqual({
+      page: 3,
+      options: { format: 'png', fullPage: false, annotate: true },
+    })
+    expect(result.content).toEqual([
+      { type: 'image', data: 'png-data', mimeType: 'image/png' },
+    ])
+    expect(result.structuredContent).toEqual({
+      page: 3,
+      annotations: [
+        {
+          ref: 'e1',
+          number: 1,
+          role: 'button',
+          name: 'Save',
+          box: { x: 1, y: 2, width: 3, height: 4 },
+        },
+      ],
+    })
+  })
+
+  it('passes annotate false through to the browser session', async () => {
+    let captured:
+      | { page: number; options: ScreenshotCaptureOptions }
+      | undefined
+    const session = {
+      screenshot: async (page: number, options: ScreenshotCaptureOptions) => {
+        captured = { page, options }
+        return {
+          data: 'png-data',
+          mimeType: 'image/png',
+          annotations: [],
+        } satisfies ScreenshotCaptureResult
+      },
+      pages: {
+        getTabId: () => undefined,
+      },
+    } as unknown as BrowserSession
+
+    const result = await executeTool(
+      screenshot,
+      { page: 3, fullPage: true, annotate: false },
+      { session },
+    )
+
+    expect(captured).toEqual({
+      page: 3,
+      options: { format: 'png', fullPage: true, annotate: false },
+    })
+    expect(result.content).toEqual([
+      { type: 'image', data: 'png-data', mimeType: 'image/png' },
+    ])
+    expect(result.structuredContent).toBeUndefined()
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/tools/browser/screenshot.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/screenshot.test.ts
@@ -19,7 +19,12 @@ function createRefs(): RefMap {
   return refs
 }
 
-function createHarness(options: { rejectCapture?: boolean } = {}) {
+function createHarness(
+  options: {
+    rect?: { x: number; y: number; width: number; height: number }
+    rejectCapture?: boolean
+  } = {},
+) {
   const events: string[] = []
   const expressions: string[] = []
   const refs = createRefs()
@@ -35,7 +40,12 @@ function createHarness(options: { rejectCapture?: boolean } = {}) {
         events.push(`bounds:${objectId}`)
         return {
           result: {
-            value: { x: 10.6, y: 20.5, width: 40.2, height: 15.4 },
+            value: options.rect ?? {
+              x: 10.6,
+              y: 20.5,
+              width: 40.2,
+              height: 15.4,
+            },
           },
         }
       },
@@ -45,14 +55,23 @@ function createHarness(options: { rejectCapture?: boolean } = {}) {
           events.push('scroll')
           return { result: { value: { x: 5, y: 100 } } }
         }
+        if (expression.trim().startsWith('({x:0,y:0,width:')) {
+          events.push('viewport')
+          return {
+            result: { value: { x: 0, y: 0, width: 800, height: 600 } },
+          }
+        }
         if (expression.includes('createElement')) {
           events.push('inject')
-        } else if (expression.includes('document.getElementById')) {
+        } else if (expression.includes('querySelectorAll')) {
           events.push('remove')
         } else {
           events.push('evaluate')
         }
         return { result: { value: true } }
+      },
+      releaseObjectGroup: async () => {
+        events.push('release')
       },
     },
     Page: {
@@ -90,10 +109,11 @@ describe('captureScreenshotWithAnnotations', () => {
     const result = await captureScreenshotWithAnnotations({
       pageSession: harness.pageSession as never,
       observer: harness.observer as never,
-      options: { format: 'png', fullPage: false, annotate: true },
+      options: { format: 'png', fullPage: false },
     })
 
     expect(harness.events).toEqual([
+      'viewport',
       'snapshot',
       'ref:e1',
       'resolve:101',
@@ -101,11 +121,13 @@ describe('captureScreenshotWithAnnotations', () => {
       'inject',
       'capture:false',
       'remove',
+      'release',
     ])
-    expect(harness.expressions[0]).toContain(
-      '__browseros_screenshot_annotations__',
+    expect(harness.expressions[1]).toContain(
+      'data-browseros-screenshot-annotation',
     )
-    expect(harness.expressions[0]).toContain('"number":1')
+    expect(harness.expressions[1]).not.toContain('getElementById')
+    expect(harness.expressions[1]).toContain('"number":1')
     expect(result).toEqual({
       data: 'png-data',
       mimeType: 'image/png',
@@ -153,6 +175,7 @@ describe('captureScreenshotWithAnnotations', () => {
     ).rejects.toThrow('capture failed')
 
     expect(harness.events).toEqual([
+      'viewport',
       'snapshot',
       'ref:e1',
       'resolve:101',
@@ -160,6 +183,7 @@ describe('captureScreenshotWithAnnotations', () => {
       'inject',
       'capture:false',
       'remove',
+      'release',
     ])
   })
 
@@ -181,12 +205,32 @@ describe('captureScreenshotWithAnnotations', () => {
       'capture:true',
       'scroll',
       'remove',
+      'release',
     ])
     expect(result.annotations[0]?.box).toEqual({
       x: 16,
       y: 121,
       width: 40,
       height: 15,
+    })
+  })
+
+  it('clips viewport annotations to the visible screenshot area', async () => {
+    const harness = createHarness({
+      rect: { x: -5, y: 10, width: 20, height: 20 },
+    })
+
+    const result = await captureScreenshotWithAnnotations({
+      pageSession: harness.pageSession as never,
+      observer: harness.observer as never,
+      options: { format: 'png', fullPage: false },
+    })
+
+    expect(result.annotations[0]?.box).toEqual({
+      x: 0,
+      y: 10,
+      width: 15,
+      height: 20,
     })
   })
 })

--- a/packages/browseros-agent/apps/server/tests/tools/browser/screenshot.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/screenshot.test.ts
@@ -231,9 +231,9 @@ describe('captureScreenshotWithAnnotations', () => {
       'ref:e1',
       'resolve:101',
       'bounds:node-101',
+      'scroll',
       'inject',
       'capture:true',
-      'scroll',
       'remove',
       'release',
     ])
@@ -310,15 +310,8 @@ describe('captureScreenshotWithAnnotations', () => {
     const second = captureScreenshotWithAnnotations(input)
     await Promise.resolve()
 
-    expect(harness.events).toEqual([
-      'viewport',
-      'snapshot',
-      'ref:e1',
-      'resolve:101',
-      'bounds:node-101',
-      'inject',
-      'capture:false',
-    ])
+    expect(harness.events).toHaveLength(7)
+    expect(harness.events.at(-1)).toBe('capture:false')
 
     releaseFirstCapture.resolve()
     await Promise.all([first, second])
@@ -352,5 +345,50 @@ describe('captureScreenshotWithAnnotations', () => {
     expect(resolveGroups).toHaveLength(2)
     expect(releaseGroups).toEqual(resolveGroups)
     expect(resolveGroups[0]).not.toBe(resolveGroups[1])
+  })
+
+  it('keeps plain screenshots out of an in-flight annotated overlay window', async () => {
+    const firstCaptureStarted = deferred()
+    const releaseFirstCapture = deferred()
+    const harness = createHarness({
+      onCapture: async (count) => {
+        if (count === 1) {
+          firstCaptureStarted.resolve()
+          await releaseFirstCapture.promise
+        }
+      },
+    })
+
+    const annotated = captureScreenshotWithAnnotations({
+      pageSession: harness.pageSession as never,
+      observer: harness.observer as never,
+      options: { format: 'png', fullPage: false },
+    })
+    await firstCaptureStarted.promise
+    const plain = captureScreenshotWithAnnotations({
+      pageSession: harness.pageSession as never,
+      observer: harness.observer as never,
+      options: { format: 'png', fullPage: false, annotate: false },
+    })
+    await Promise.resolve()
+
+    expect(harness.events).toHaveLength(7)
+    expect(harness.events.at(-1)).toBe('capture:false')
+
+    releaseFirstCapture.resolve()
+    await Promise.all([annotated, plain])
+
+    expect(harness.events).toEqual([
+      'viewport',
+      'snapshot',
+      'ref:e1',
+      'resolve:101',
+      'bounds:node-101',
+      'inject',
+      'capture:false',
+      'remove',
+      'release',
+      'capture:false',
+    ])
   })
 })

--- a/packages/browseros-agent/apps/server/tests/tools/browser/screenshot.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/screenshot.test.ts
@@ -1,12 +1,6 @@
 import { describe, expect, it } from 'bun:test'
-import {
-  captureScreenshotWithAnnotations,
-  type ScreenshotCaptureOptions,
-} from '../../../src/browser/core/screenshot'
-import type { BrowserSession } from '../../../src/browser/core/session'
+import { captureScreenshotWithAnnotations } from '../../../src/browser/core/screenshot'
 import { RefMap } from '../../../src/browser/core/snapshot/refs'
-import { executeTool } from '../../../src/tools/browser/framework'
-import { screenshot } from '../../../src/tools/browser/screenshot'
 
 function createRefs(): RefMap {
   const refs = new RefMap()
@@ -23,15 +17,25 @@ function createHarness(
   options: {
     rect?: { x: number; y: number; width: number; height: number }
     rejectCapture?: boolean
+    onCapture?: (count: number) => Promise<void> | void
   } = {},
 ) {
   const events: string[] = []
   const expressions: string[] = []
+  const objectGroups: string[] = []
   const refs = createRefs()
+  let captureCount = 0
   const pageSession = {
     DOM: {
-      resolveNode: async ({ backendNodeId }: { backendNodeId: number }) => {
+      resolveNode: async ({
+        backendNodeId,
+        objectGroup,
+      }: {
+        backendNodeId: number
+        objectGroup?: string
+      }) => {
         events.push(`resolve:${backendNodeId}`)
+        if (objectGroup) objectGroups.push(objectGroup)
         return { object: { objectId: `node-${backendNodeId}` } }
       },
     },
@@ -70,7 +74,8 @@ function createHarness(
         }
         return { result: { value: true } }
       },
-      releaseObjectGroup: async () => {
+      releaseObjectGroup: async ({ objectGroup }: { objectGroup: string }) => {
+        objectGroups.push(`release:${objectGroup}`)
         events.push('release')
       },
     },
@@ -79,6 +84,8 @@ function createHarness(
         captureBeyondViewport?: boolean
       }) => {
         events.push(`capture:${params.captureBeyondViewport}`)
+        captureCount += 1
+        await options.onCapture?.(captureCount)
         if (options.rejectCapture) throw new Error('capture failed')
         return { data: 'png-data' }
       },
@@ -99,7 +106,15 @@ function createHarness(
     },
   }
 
-  return { events, expressions, observer, pageSession }
+  return { events, expressions, objectGroups, observer, pageSession }
+}
+
+function deferred() {
+  let resolve = () => {}
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
 }
 
 describe('captureScreenshotWithAnnotations', () => {
@@ -239,89 +254,70 @@ describe('captureScreenshotWithAnnotations', () => {
       height: 20,
     })
   })
-})
 
-describe('screenshot tool', () => {
-  it('defaults annotate to true and returns inline PNG content', async () => {
-    let captured:
-      | { page: number; options: ScreenshotCaptureOptions }
-      | undefined
-    const session = {
-      screenshot: async (page: number, options: ScreenshotCaptureOptions) => {
-        captured = { page, options }
-        return {
-          data: 'png-data',
-          mimeType: 'image/png',
-          annotations: [
-            {
-              ref: 'e1',
-              number: 1,
-              role: 'button',
-              name: 'Save',
-              box: { x: 1, y: 2, width: 3, height: 4 },
-            },
-          ],
+  it('serializes concurrent annotated captures on the same page session', async () => {
+    const firstCaptureStarted = deferred()
+    const releaseFirstCapture = deferred()
+    const harness = createHarness({
+      onCapture: async (count) => {
+        if (count === 1) {
+          firstCaptureStarted.resolve()
+          await releaseFirstCapture.promise
         }
       },
-      pages: {
-        getTabId: () => undefined,
-      },
-    } as unknown as BrowserSession
-
-    const result = await executeTool(screenshot, { page: 3 }, { session })
-
-    expect(captured).toEqual({
-      page: 3,
-      options: { format: 'png', fullPage: false, annotate: true },
     })
-    expect(result.content).toEqual([
-      { type: 'image', data: 'png-data', mimeType: 'image/png' },
+    const input = {
+      pageSession: harness.pageSession as never,
+      observer: harness.observer as never,
+      options: { format: 'png' as const, fullPage: false },
+    }
+
+    const first = captureScreenshotWithAnnotations(input)
+    await firstCaptureStarted.promise
+    const second = captureScreenshotWithAnnotations(input)
+    await Promise.resolve()
+
+    expect(harness.events).toEqual([
+      'viewport',
+      'snapshot',
+      'ref:e1',
+      'resolve:101',
+      'bounds:node-101',
+      'inject',
+      'capture:false',
     ])
-    expect(result.structuredContent).toEqual({
-      page: 3,
-      annotations: [
-        {
-          ref: 'e1',
-          number: 1,
-          role: 'button',
-          name: 'Save',
-          box: { x: 1, y: 2, width: 3, height: 4 },
-        },
-      ],
-    })
-  })
 
-  it('passes annotate false through to the browser session', async () => {
-    let captured:
-      | { page: number; options: ScreenshotCaptureOptions }
-      | undefined
-    const session = {
-      screenshot: async (page: number, options: ScreenshotCaptureOptions) => {
-        captured = { page, options }
-        return {
-          data: 'png-data',
-          mimeType: 'image/png',
-          annotations: [],
-        }
-      },
-      pages: {
-        getTabId: () => undefined,
-      },
-    } as unknown as BrowserSession
+    releaseFirstCapture.resolve()
+    await Promise.all([first, second])
 
-    const result = await executeTool(
-      screenshot,
-      { page: 3, fullPage: true, annotate: false },
-      { session },
+    expect(harness.events).toEqual([
+      'viewport',
+      'snapshot',
+      'ref:e1',
+      'resolve:101',
+      'bounds:node-101',
+      'inject',
+      'capture:false',
+      'remove',
+      'release',
+      'viewport',
+      'snapshot',
+      'ref:e1',
+      'resolve:101',
+      'bounds:node-101',
+      'inject',
+      'capture:false',
+      'remove',
+      'release',
+    ])
+    const resolveGroups = harness.objectGroups.filter(
+      (group) => !group.startsWith('release:'),
     )
-
-    expect(captured).toEqual({
-      page: 3,
-      options: { format: 'png', fullPage: true, annotate: false },
-    })
-    expect(result.content).toEqual([
-      { type: 'image', data: 'png-data', mimeType: 'image/png' },
-    ])
-    expect(result.structuredContent).toBeUndefined()
+    const releaseGroups = harness.objectGroups
+      .filter((group) => group.startsWith('release:'))
+      .map((group) => group.replace(/^release:/, ''))
+    expect(resolveGroups).toHaveLength(2)
+    expect(releaseGroups).toEqual(resolveGroups)
+    expect(resolveGroups[0]).not.toBe(resolveGroups[1])
   })
 })

--- a/packages/browseros-agent/apps/server/tests/tools/browser/screenshot.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/screenshot.test.ts
@@ -1,0 +1,277 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  captureScreenshotWithAnnotations,
+  type ScreenshotCaptureOptions,
+} from '../../../src/browser/core/screenshot'
+import type { BrowserSession } from '../../../src/browser/core/session'
+import { RefMap } from '../../../src/browser/core/snapshot/refs'
+import { executeTool } from '../../../src/tools/browser/framework'
+import { screenshot } from '../../../src/tools/browser/screenshot'
+
+function createRefs(): RefMap {
+  const refs = new RefMap()
+  refs.mint({
+    backendNodeId: 101,
+    role: 'button',
+    name: 'Save',
+    documentId: 'doc-1',
+  })
+  return refs
+}
+
+function createHarness(options: { rejectCapture?: boolean } = {}) {
+  const events: string[] = []
+  const expressions: string[] = []
+  const refs = createRefs()
+  const pageSession = {
+    DOM: {
+      resolveNode: async ({ backendNodeId }: { backendNodeId: number }) => {
+        events.push(`resolve:${backendNodeId}`)
+        return { object: { objectId: `node-${backendNodeId}` } }
+      },
+    },
+    Runtime: {
+      callFunctionOn: async ({ objectId }: { objectId?: string }) => {
+        events.push(`bounds:${objectId}`)
+        return {
+          result: {
+            value: { x: 10.6, y: 20.5, width: 40.2, height: 15.4 },
+          },
+        }
+      },
+      evaluate: async ({ expression }: { expression: string }) => {
+        expressions.push(expression)
+        if (expression.trim().startsWith('({x: window.scrollX')) {
+          events.push('scroll')
+          return { result: { value: { x: 5, y: 100 } } }
+        }
+        if (expression.includes('createElement')) {
+          events.push('inject')
+        } else if (expression.includes('document.getElementById')) {
+          events.push('remove')
+        } else {
+          events.push('evaluate')
+        }
+        return { result: { value: true } }
+      },
+    },
+    Page: {
+      captureScreenshot: async (params: {
+        captureBeyondViewport?: boolean
+      }) => {
+        events.push(`capture:${params.captureBeyondViewport}`)
+        if (options.rejectCapture) throw new Error('capture failed')
+        return { data: 'png-data' }
+      },
+    },
+  }
+  const observer = {
+    snapshot: async () => {
+      events.push('snapshot')
+      return {
+        text: '- button "Save" [ref=e1]',
+        refs,
+        url: 'https://example.com',
+      }
+    },
+    resolveRef: async (ref: string) => {
+      events.push(`ref:${ref}`)
+      return { session: pageSession, backendNodeId: 101 }
+    },
+  }
+
+  return { events, expressions, observer, pageSession }
+}
+
+describe('captureScreenshotWithAnnotations', () => {
+  it('defaults through the annotation lifecycle and returns annotation metadata', async () => {
+    const harness = createHarness()
+
+    const result = await captureScreenshotWithAnnotations({
+      pageSession: harness.pageSession as never,
+      observer: harness.observer as never,
+      options: { format: 'png', fullPage: false, annotate: true },
+    })
+
+    expect(harness.events).toEqual([
+      'snapshot',
+      'ref:e1',
+      'resolve:101',
+      'bounds:node-101',
+      'inject',
+      'capture:false',
+      'remove',
+    ])
+    expect(harness.expressions[0]).toContain(
+      '__browseros_screenshot_annotations__',
+    )
+    expect(harness.expressions[0]).toContain('"number":1')
+    expect(result).toEqual({
+      data: 'png-data',
+      mimeType: 'image/png',
+      annotations: [
+        {
+          ref: 'e1',
+          number: 1,
+          role: 'button',
+          name: 'Save',
+          box: { x: 11, y: 21, width: 40, height: 15 },
+        },
+      ],
+    })
+  })
+
+  it('captures without snapshot or overlay work when annotations are disabled', async () => {
+    const harness = createHarness()
+    harness.observer.snapshot = async () => {
+      throw new Error('snapshot should not run')
+    }
+
+    const result = await captureScreenshotWithAnnotations({
+      pageSession: harness.pageSession as never,
+      observer: harness.observer as never,
+      options: { format: 'png', fullPage: true, annotate: false },
+    })
+
+    expect(harness.events).toEqual(['capture:true'])
+    expect(result).toEqual({
+      data: 'png-data',
+      mimeType: 'image/png',
+      annotations: [],
+    })
+  })
+
+  it('removes the injected overlay when screenshot capture fails', async () => {
+    const harness = createHarness({ rejectCapture: true })
+
+    await expect(
+      captureScreenshotWithAnnotations({
+        pageSession: harness.pageSession as never,
+        observer: harness.observer as never,
+        options: { format: 'png', fullPage: false, annotate: true },
+      }),
+    ).rejects.toThrow('capture failed')
+
+    expect(harness.events).toEqual([
+      'snapshot',
+      'ref:e1',
+      'resolve:101',
+      'bounds:node-101',
+      'inject',
+      'capture:false',
+      'remove',
+    ])
+  })
+
+  it('projects full-page annotation metadata into document coordinates', async () => {
+    const harness = createHarness()
+
+    const result = await captureScreenshotWithAnnotations({
+      pageSession: harness.pageSession as never,
+      observer: harness.observer as never,
+      options: { format: 'png', fullPage: true, annotate: true },
+    })
+
+    expect(harness.events).toEqual([
+      'snapshot',
+      'ref:e1',
+      'resolve:101',
+      'bounds:node-101',
+      'inject',
+      'capture:true',
+      'scroll',
+      'remove',
+    ])
+    expect(result.annotations[0]?.box).toEqual({
+      x: 16,
+      y: 121,
+      width: 40,
+      height: 15,
+    })
+  })
+})
+
+describe('screenshot tool', () => {
+  it('defaults annotate to true and returns inline PNG content', async () => {
+    let captured:
+      | { page: number; options: ScreenshotCaptureOptions }
+      | undefined
+    const session = {
+      screenshot: async (page: number, options: ScreenshotCaptureOptions) => {
+        captured = { page, options }
+        return {
+          data: 'png-data',
+          mimeType: 'image/png',
+          annotations: [
+            {
+              ref: 'e1',
+              number: 1,
+              role: 'button',
+              name: 'Save',
+              box: { x: 1, y: 2, width: 3, height: 4 },
+            },
+          ],
+        }
+      },
+      pages: {
+        getTabId: () => undefined,
+      },
+    } as unknown as BrowserSession
+
+    const result = await executeTool(screenshot, { page: 3 }, { session })
+
+    expect(captured).toEqual({
+      page: 3,
+      options: { format: 'png', fullPage: false, annotate: true },
+    })
+    expect(result.content).toEqual([
+      { type: 'image', data: 'png-data', mimeType: 'image/png' },
+    ])
+    expect(result.structuredContent).toEqual({
+      page: 3,
+      annotations: [
+        {
+          ref: 'e1',
+          number: 1,
+          role: 'button',
+          name: 'Save',
+          box: { x: 1, y: 2, width: 3, height: 4 },
+        },
+      ],
+    })
+  })
+
+  it('passes annotate false through to the browser session', async () => {
+    let captured:
+      | { page: number; options: ScreenshotCaptureOptions }
+      | undefined
+    const session = {
+      screenshot: async (page: number, options: ScreenshotCaptureOptions) => {
+        captured = { page, options }
+        return {
+          data: 'png-data',
+          mimeType: 'image/png',
+          annotations: [],
+        }
+      },
+      pages: {
+        getTabId: () => undefined,
+      },
+    } as unknown as BrowserSession
+
+    const result = await executeTool(
+      screenshot,
+      { page: 3, fullPage: true, annotate: false },
+      { session },
+    )
+
+    expect(captured).toEqual({
+      page: 3,
+      options: { format: 'png', fullPage: true, annotate: false },
+    })
+    expect(result.content).toEqual([
+      { type: 'image', data: 'png-data', mimeType: 'image/png' },
+    ])
+    expect(result.structuredContent).toBeUndefined()
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/tools/browser/screenshot.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/screenshot.test.ts
@@ -127,6 +127,12 @@ describe('captureScreenshotWithAnnotations', () => {
       'data-browseros-screenshot-annotation',
     )
     expect(harness.expressions[1]).not.toContain('getElementById')
+    expect(harness.expressions[1]).toContain(
+      'var useDocumentSpaceLabels = false;',
+    )
+    expect(harness.expressions[1]).toContain(
+      'var labelAnchor = useDocumentSpaceLabels ? dy : it.y;',
+    )
     expect(harness.expressions[1]).toContain('"number":1')
     expect(result).toEqual({
       data: 'png-data',


### PR DESCRIPTION
## Summary
- add annotated screenshot capture through the browser core/session path, with `annotate` defaulting to true
- inject token-owned temporary DOM overlays and remove them after capture
- clip viewport annotations, handle full-page document coordinates, skip unsafe nested-frame projection, and serialize annotated captures per page session
- release resolved renderer objects, including liveness-check objects, and cover the behavior with focused tests

## Verification
- `bun run lint`
- `bun run typecheck`
- `bun run test:main`
- `bun --env-file=apps/server/.env.development test apps/server/src/browser/core/observer/resolve.test.ts apps/server/tests/tools/browser/register.test.ts apps/server/tests/tools/browser/screenshot.test.ts apps/server/tests/tools/browser/screenshot-tool.test.ts`

## Review Notes
- fixed findings from 3 adversarial review rounds: overlay ownership, viewport clipping, frame projection safety, object cleanup, annotate default, label placement, and concurrent capture isolation
