### PR TITLE
fix: remove controller bundled extension

### DIFF
--- a/packages/browseros/build/modules/extensions/bundled_extensions_test.py
+++ b/packages/browseros/build/modules/extensions/bundled_extensions_test.py
@@ -25,11 +25,6 @@ class BundledExtensionsManifestTest(unittest.TestCase):
                     "https://cdn.browseros.com/extensions/bugreporter-52.0.0.0.crx",
                 ),
                 (
-                    "nlnihljpboknmfagkikhkdblbedophja",
-                    "1.1.0.0",
-                    "https://cdn.browseros.com/extensions/controller-1.1.0.0.crx",
-                ),
-                (
                     "bflpfmnmnokmjhmgnolecpppdbdophmk",
                     "0.0.115.0",
                     "https://cdn.browseros.com/extensions/agent-0.0.115.0.crx",

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/bundled_extensions/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/bundled_extensions/BUILD.gn
@@ -3,7 +3,7 @@ new file mode 100644
 index 0000000000000..0d4aee6f8bad1
 --- /dev/null
 +++ b/chrome/browser/browseros/bundled_extensions/BUILD.gn
-@@ -0,0 +1,32 @@
+@@ -0,0 +1,31 @@
 +# Copyright 2024 The Chromium Authors
 +# Use of this source code is governed by a BSD-style license that can be
 +# found in the LICENSE file.
@@ -21,7 +21,6 @@ index 0000000000000..0d4aee6f8bad1
 +  "bundled_extensions.json",
 +  "bflpfmnmnokmjhmgnolecpppdbdophmk.crx",  # Agent
 +  "adlpneommgkgeanpaekgoaolcpncohkf.crx",  # Bug Reporter
-+  "nlnihljpboknmfagkikhkdblbedophja.crx",  # Controller
 +]
 +
 +if (!is_mac) {

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_constants.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_constants.h
@@ -3,7 +3,7 @@ new file mode 100644
 index 0000000000000..fdeee36f8cc70
 --- /dev/null
 +++ b/chrome/browser/browseros/core/browseros_constants.h
-@@ -0,0 +1,227 @@
+@@ -0,0 +1,222 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -39,10 +39,6 @@ index 0000000000000..fdeee36f8cc70
 +// Bug Reporter Extension ID
 +inline constexpr char kBugReporterExtensionId[] =
 +    "adlpneommgkgeanpaekgoaolcpncohkf";
-+
-+// Controller Extension ID
-+inline constexpr char kControllerExtensionId[] =
-+    "nlnihljpboknmfagkikhkdblbedophja";
 +
 +// uBlock Origin Extension ID (Chrome Web Store)
 +// inline constexpr char kUBlockOriginExtensionId[] =
@@ -173,7 +169,6 @@ index 0000000000000..fdeee36f8cc70
 +inline constexpr BrowserOSExtensionInfo kBrowserOSExtensions[] = {
 +    {kAgentExtensionId, false, false},
 +    {kBugReporterExtensionId, true, false},
-+    {kControllerExtensionId, false, false},
 +    // ublock origin gets installed from chrome web store
 +    // {kUBlockOriginExtensionId, false, false},
 +};

--- a/updates/extensions/bundled-manifest.xml
+++ b/updates/extensions/bundled-manifest.xml
@@ -3,9 +3,6 @@
   <app appid="adlpneommgkgeanpaekgoaolcpncohkf">
     <updatecheck codebase="https://cdn.browseros.com/extensions/bugreporter-52.0.0.0.crx" version="52.0.0.0"/>
   </app>
-  <app appid="nlnihljpboknmfagkikhkdblbedophja">
-    <updatecheck codebase="https://cdn.browseros.com/extensions/controller-1.1.0.0.crx" version="1.1.0.0"/>
-  </app>
   <app appid="bflpfmnmnokmjhmgnolecpppdbdophmk">
     <updatecheck codebase="https://cdn.browseros.com/extensions/agent-0.0.115.0.crx" version="0.0.115.0"/>
   </app>


### PR DESCRIPTION
## Summary
- Remove the deprecated controller extension from the bundled extension CDN manifest.
- Remove the controller CRX from Chromium bundled-extension bundle inputs.
- Stop registering the controller id as a managed BrowserOS extension.

## Design
The bundled extension generator follows `updates/extensions/bundled-manifest.xml`, while Chromium GN separately declares each bundled CRX. This removes the controller from both sources of truth and updates the manifest test so it cannot be regenerated into `bundled_extensions.json`.

## Test plan
- [x] `uv run --project packages/browseros python -m unittest packages.browseros.build.modules.extensions.bundled_extensions_test`
- [x] `git apply --check packages/browseros/chromium_patches/chrome/browser/browseros/bundled_extensions/BUILD.gn`
- [x] `git apply --check packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_constants.h`
- [x] `git diff --check`
- [x] `autoninja -C out/Default_arm64 chrome` in `/Users/shadowfax/code/chromium-checkouts/chromium-2/src` after mirroring the patch into that checkout