### PR TITLE
fix: forward browser context on remote hermes turns

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/routes/chat.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/chat.ts
@@ -11,6 +11,7 @@ import { ChatService } from '../services/chat-service'
 import type { KlavisService } from '../services/klavis'
 import type { RemoteHermesService } from '../services/remote-hermes/remote-hermes-service'
 import { ChatRequestSchema } from '../types'
+import { resolveBrowserContextPageIds } from '../utils/resolve-browser-context-page-ids'
 import { ConversationIdParamSchema } from '../utils/validation'
 
 interface ChatRouteDeps {
@@ -94,11 +95,22 @@ export function createChatRoutes(deps: ChatRouteDeps) {
           conversationId: request.conversationId,
           model: request.model,
         })
+        // Resolve Chrome tab IDs to CDP pageIds on the laptop before
+        // forwarding — the remote worker has no CDP target visibility
+        // and the LLM needs pageIds in the prompt to dispatch browser
+        // tools through the WS RPC bridge.
+        const remoteBrowserContext = await resolveBrowserContextPageIds(
+          deps.browser,
+          request.browserContext,
+        )
         return deps.remoteHermes.streamTurn(
           {
             conversationId: request.conversationId,
             message: request.message,
             modelId: request.model,
+            browserContext: remoteBrowserContext,
+            selectedText: request.selectedText,
+            selectedTextSource: request.selectedTextSource,
           },
           c.req.raw.signal,
         )

--- a/packages/browseros-agent/apps/server/src/api/services/remote-hermes/remote-hermes-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/remote-hermes/remote-hermes-service.ts
@@ -432,15 +432,25 @@ function extractDataLine(record: string): string | null {
 }
 
 function buildTurnPayload(input: StreamTurnInput): PostTurnInput {
-  const wrappedMessage = formatUserMessage(
-    input.message,
-    input.browserContext,
-    input.selectedText,
-    input.selectedTextSource,
-  )
+  // Only wrap when there's real context to embed. Without this guard
+  // every remote-hermes turn would gain `<USER_QUERY>` framing
+  // post-upgrade, changing the wire format for conversations that
+  // don't attach tabs or selected text.
+  const hasContext =
+    Boolean(input.browserContext?.activeTab) ||
+    Boolean(input.browserContext?.selectedTabs?.length) ||
+    Boolean(input.selectedText)
+  const message = hasContext
+    ? formatUserMessage(
+        input.message,
+        input.browserContext,
+        input.selectedText,
+        input.selectedTextSource,
+      )
+    : input.message
   return {
     conversationId: input.conversationId,
-    message: wrappedMessage,
+    message,
     modelId: input.modelId,
   }
 }

--- a/packages/browseros-agent/apps/server/src/api/services/remote-hermes/remote-hermes-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/remote-hermes/remote-hermes-service.ts
@@ -21,16 +21,19 @@
  * translation lives anywhere on the path.
  */
 
+import type { BrowserContext } from '@browseros/shared/schemas/browser-context'
 import {
   createUIMessageStream,
   createUIMessageStreamResponse,
   type UIMessageStreamWriter,
 } from 'ai'
+import { formatUserMessage } from '../../../agent/format-message'
 import {
   COLD_START_BUDGET_MS,
   STATUS_POLL_INTERVAL_MS,
 } from '../../../lib/clients/remote-hermes/constants'
 import type {
+  PostTurnInput,
   RemoteHermesClient,
   VmStatusView,
 } from '../../../lib/clients/remote-hermes/remote-hermes-client'
@@ -48,6 +51,11 @@ export interface StreamTurnInput {
   conversationId: string
   message: string
   modelId?: string | null
+  /** Resolved by the route — pageIds already filled in via
+   *  resolveBrowserContextPageIds before the service is called. */
+  browserContext?: BrowserContext
+  selectedText?: string
+  selectedTextSource?: { url: string; title: string }
 }
 
 export class RemoteHermesService {
@@ -163,8 +171,13 @@ export class RemoteHermesService {
       if (!started) return null
     }
 
+    // Wrap the user message with the same browser-context block local
+    // chat injects, so the remote LLM has windowId/tab/pageId metadata
+    // and selected-text framing for tool routing.
+    const turnPayload = buildTurnPayload(input)
+
     // Phase 2: optimistic turn.
-    const first = await this.client.postTurn(input, signal)
+    const first = await this.client.postTurn(turnPayload, signal)
     if (first.ok) return readTaskId(first, writer)
 
     // Phase 3: drift recovery. If the worker proxy returned 503/409
@@ -181,7 +194,7 @@ export class RemoteHermesService {
       )
       const recovered = await this.ensureStarted('cold', writer, signal)
       if (!recovered) return null
-      const retry = await this.client.postTurn(input, signal)
+      const retry = await this.client.postTurn(turnPayload, signal)
       if (retry.ok) return readTaskId(retry, writer)
       writeUpstreamError(writer, await retry.text(), retry.status)
       writeBootStatus(writer, 'error')
@@ -416,6 +429,20 @@ function extractDataLine(record: string): string | null {
   }
   if (dataLines.length === 0) return null
   return dataLines.join('\n')
+}
+
+function buildTurnPayload(input: StreamTurnInput): PostTurnInput {
+  const wrappedMessage = formatUserMessage(
+    input.message,
+    input.browserContext,
+    input.selectedText,
+    input.selectedTextSource,
+  )
+  return {
+    conversationId: input.conversationId,
+    message: wrappedMessage,
+    modelId: input.modelId,
+  }
 }
 
 async function readTaskId(


### PR DESCRIPTION
## Summary

- `/chat` handler dropped `browserContext`, `selectedText`, and `selectedTextSource` on the remote-hermes branch, so the remote LLM never saw the user's attached tabs and couldn't target browser tools dispatched back through the WS RPC bridge — "tab attach" was effectively a no-op.
- Local chat resolves these via `resolveBrowserContextPageIds` + `formatUserMessage`. Remote hermes now does the same on the laptop before posting the turn, wrapping the message with the standard `## Browser Context` block.
- pageId resolution stays on the laptop because the worker has no CDP target visibility; only the wrapped string crosses the wire.

## Changes

- `apps/server/src/api/routes/chat.ts`: resolve `browserContext` and forward it (plus `selectedText` / `selectedTextSource`) to `remoteHermes.streamTurn`.
- `apps/server/src/api/services/remote-hermes/remote-hermes-service.ts`: extend `StreamTurnInput`, call `formatUserMessage` to build the wrapped payload, and use it on both the optimistic `postTurn` and the 503/409 retry.

No worker / VM / wire format changes — the worker continues to receive `{ message, agentId, agentKind, model }`. The `message` now carries the same context preamble the local agent gets.

## Test plan

- [ ] Send a chat to a Remote Hermes thread with an explicitly-attached tab; confirm the remote agent sees the `## Browser Context` block (logs / trace).
- [ ] Verify browser tool calls routed through the WS RPC bridge use the correct `pageId`.
- [ ] Regression: `bun run test:api` in `apps/server` (134 pass locally).
- [ ] Local (non-remote) provider chat unchanged.