### PR TITLE
fix: rename ChatGPT provider display

### DIFF
--- a/packages/browseros-agent/apps/agent/lib/llm-providers/provider-display-names.ts
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/provider-display-names.ts
@@ -1,0 +1,1 @@
+export const CHATGPT_PROVIDER_DISPLAY_NAME = 'ChatGPT'

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/provider-name-normalization.ts
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/provider-name-normalization.ts
@@ -1,0 +1,46 @@
+import { CHATGPT_PROVIDER_DISPLAY_NAME } from './provider-display-names'
+import {
+  DEFAULT_PROVIDER_ID,
+  DEFAULT_PROVIDER_NAME,
+} from './provider-selection'
+import type { LlmProviderConfig } from './types'
+
+/** Applies the v3 provider display-name compatibility migration. */
+export function migrateLlmProvidersToV3(
+  providers: LlmProviderConfig[] | null,
+): LlmProviderConfig[] | null {
+  if (!providers) return providers
+  return normalizeProviderNames(providers)
+}
+
+/** Applies compatibility renames for stored provider display names. */
+export function normalizeProviderNames(
+  providers: LlmProviderConfig[],
+): LlmProviderConfig[] {
+  return providers.map((provider) => {
+    if (
+      provider.id === DEFAULT_PROVIDER_ID &&
+      provider.type === 'browseros' &&
+      provider.name !== DEFAULT_PROVIDER_NAME
+    ) {
+      return {
+        ...provider,
+        name: DEFAULT_PROVIDER_NAME,
+      }
+    }
+    if (
+      provider.type === 'chatgpt-pro' &&
+      isLegacyChatGPTProviderName(provider.name)
+    ) {
+      return {
+        ...provider,
+        name: CHATGPT_PROVIDER_DISPLAY_NAME,
+      }
+    }
+    return provider
+  })
+}
+
+function isLegacyChatGPTProviderName(name: string): boolean {
+  return /^ChatGPT Plus\/Pro(?: \([^@\s()]+@[^@\s()]+\))?$/.test(name)
+}

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/providerTemplates.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/providerTemplates.test.ts
@@ -2,12 +2,13 @@ import { describe, expect, it } from 'bun:test'
 import { providerTemplates } from './providerTemplates'
 
 describe('providerTemplates', () => {
-  it('uses GPT-5.5 for new ChatGPT Plus/Pro providers', () => {
+  it('uses ChatGPT as the display name for new ChatGPT providers', () => {
     const template = providerTemplates.find(
       (provider) => provider.id === 'chatgpt-pro',
     )
 
     expect(template).toMatchObject({
+      name: 'ChatGPT',
       defaultModelId: 'gpt-5.5',
       contextWindow: 1050000,
     })

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/providerTemplates.ts
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/providerTemplates.ts
@@ -1,4 +1,5 @@
 import { getModelsDevProvider } from './models-dev'
+import { CHATGPT_PROVIDER_DISPLAY_NAME } from './provider-display-names'
 import type { ProviderType } from './types'
 
 /**
@@ -55,7 +56,7 @@ export const providerTemplates: ProviderTemplate[] = [
   },
   {
     id: 'chatgpt-pro',
-    name: 'ChatGPT Plus/Pro',
+    name: CHATGPT_PROVIDER_DISPLAY_NAME,
     defaultBaseUrl: 'https://chatgpt.com/backend-api',
     defaultModelId: 'gpt-5.5',
     supportsImages: true,
@@ -156,7 +157,7 @@ export const providerTemplates: ProviderTemplate[] = [
  */
 export const providerTypeOptions: { value: ProviderType; label: string }[] = [
   { value: 'remote-hermes', label: 'Remote Hermes' },
-  { value: 'chatgpt-pro', label: 'ChatGPT Plus/Pro' },
+  { value: 'chatgpt-pro', label: CHATGPT_PROVIDER_DISPLAY_NAME },
   { value: 'github-copilot', label: 'GitHub Copilot' },
   { value: 'qwen-code', label: 'Qwen Code' },
   { value: 'codex', label: 'Codex' },

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/storage.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/storage.test.ts
@@ -1,81 +1,9 @@
-import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
+import {
+  migrateLlmProvidersToV3,
+  normalizeProviderNames,
+} from './provider-name-normalization'
 import type { LlmProviderConfig } from './types'
-
-const storageValues = new Map<string, unknown>()
-const storageVersions = new Map<string, number>()
-
-mock.module('@wxt-dev/storage', () => ({
-  storage: {
-    defineItem: <T>(
-      key: string,
-      options?: {
-        fallback?: T
-        version?: number
-        migrations?: Record<number, (value: T | null) => T | null>
-      },
-    ) => ({
-      getValue: async () => {
-        if (!storageValues.has(key)) return options?.fallback
-
-        const currentVersion = options?.version
-        let value = storageValues.get(key) as T | null
-        if (currentVersion && options?.migrations) {
-          const storedVersion = storageVersions.get(key) ?? 1
-          for (
-            let version = storedVersion + 1;
-            version <= currentVersion;
-            version++
-          ) {
-            const migrate = options.migrations[version]
-            if (migrate) value = migrate(value)
-          }
-          storageValues.set(key, value)
-          storageVersions.set(key, currentVersion)
-        }
-        return value
-      },
-      setValue: async (value: T) => {
-        storageValues.set(key, value)
-        if (options?.version) storageVersions.set(key, options.version)
-      },
-      watch: () => () => {},
-    }),
-  },
-}))
-
-mock.module('@/lib/auth/sessionStorage', () => ({
-  sessionStorage: {
-    getValue: async () => null,
-  },
-}))
-
-mock.module('@/lib/browseros/adapter', () => ({
-  getBrowserOSAdapter: () => ({
-    setPref: async () => {},
-  }),
-}))
-
-mock.module('@/lib/browseros/prefs', () => ({
-  BROWSEROS_PREFS: {
-    PROVIDERS: 'browseros.providers',
-  },
-}))
-
-mock.module('./uploadLlmProvidersToGraphql', () => ({
-  uploadLlmProvidersToGraphql: async () => {},
-}))
-
-let loadProviders: typeof import('./storage').loadProviders
-let providersStorage: typeof import('./storage').providersStorage
-
-beforeAll(async () => {
-  ;({ loadProviders, providersStorage } = await import('./storage'))
-})
-
-beforeEach(() => {
-  storageValues.clear()
-  storageVersions.clear()
-})
 
 function providerConfig(
   overrides: Partial<LlmProviderConfig> & Pick<LlmProviderConfig, 'id'>,
@@ -93,9 +21,9 @@ function providerConfig(
   }
 }
 
-describe('loadProviders', () => {
-  it('normalizes legacy ChatGPT display names', async () => {
-    storageValues.set('local:llm-providers', [
+describe('normalizeProviderNames', () => {
+  it('normalizes legacy ChatGPT display names', () => {
+    const providers = normalizeProviderNames([
       providerConfig({
         id: 'chatgpt-pro-1',
         type: 'chatgpt-pro',
@@ -107,23 +35,15 @@ describe('loadProviders', () => {
         name: 'ChatGPT Plus/Pro (user@example.com)',
       }),
     ])
-    storageVersions.set('local:llm-providers', 3)
-
-    const providers = await loadProviders()
 
     expect(providers.map((provider) => provider.name)).toEqual([
       'ChatGPT',
       'ChatGPT',
     ])
-    expect(
-      (storageValues.get('local:llm-providers') as LlmProviderConfig[]).map(
-        (provider) => provider.name,
-      ),
-    ).toEqual(['ChatGPT', 'ChatGPT'])
   })
 
-  it('preserves custom ChatGPT provider names', async () => {
-    const storedProviders = [
+  it('preserves custom ChatGPT provider names', () => {
+    const providers = normalizeProviderNames([
       providerConfig({
         id: 'chatgpt-pro-custom',
         type: 'chatgpt-pro',
@@ -134,39 +54,25 @@ describe('loadProviders', () => {
         type: 'chatgpt-pro',
         name: 'ChatGPT Plus/Pro (Work)',
       }),
-    ]
-    storageValues.set('local:llm-providers', storedProviders)
-    storageVersions.set('local:llm-providers', 3)
-
-    const providers = await loadProviders()
+    ])
 
     expect(providers.map((provider) => provider.name)).toEqual([
       'Work ChatGPT',
       'ChatGPT Plus/Pro (Work)',
     ])
-    expect(storageValues.get('local:llm-providers')).toBe(storedProviders)
   })
 })
 
-describe('providersStorage', () => {
-  it('migrates legacy ChatGPT display names for direct storage reads', async () => {
-    storageValues.set('local:llm-providers', [
+describe('migrateLlmProvidersToV3', () => {
+  it('migrates legacy ChatGPT display names for direct storage reads', () => {
+    const providers = migrateLlmProvidersToV3([
       providerConfig({
         id: 'chatgpt-pro-1',
         type: 'chatgpt-pro',
         name: 'ChatGPT Plus/Pro (user@example.com)',
       }),
     ])
-    storageVersions.set('local:llm-providers', 2)
-
-    const providers = await providersStorage.getValue()
 
     expect(providers?.map((provider) => provider.name)).toEqual(['ChatGPT'])
-    expect(
-      (storageValues.get('local:llm-providers') as LlmProviderConfig[]).map(
-        (provider) => provider.name,
-      ),
-    ).toEqual(['ChatGPT'])
-    expect(storageVersions.get('local:llm-providers')).toBe(3)
   })
 })

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/storage.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/storage.test.ts
@@ -1,0 +1,110 @@
+import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+import type { LlmProviderConfig } from './types'
+
+const storageValues = new Map<string, unknown>()
+
+mock.module('@wxt-dev/storage', () => ({
+  storage: {
+    defineItem: <T>(key: string, options?: { fallback?: T }) => ({
+      getValue: async () =>
+        storageValues.has(key) ? storageValues.get(key) : options?.fallback,
+      setValue: async (value: T) => {
+        storageValues.set(key, value)
+      },
+      watch: () => () => {},
+    }),
+  },
+}))
+
+mock.module('@/lib/auth/sessionStorage', () => ({
+  sessionStorage: {
+    getValue: async () => null,
+  },
+}))
+
+mock.module('@/lib/browseros/adapter', () => ({
+  getBrowserOSAdapter: () => ({
+    setPref: async () => {},
+  }),
+}))
+
+mock.module('@/lib/browseros/prefs', () => ({
+  BROWSEROS_PREFS: {
+    PROVIDERS: 'browseros.providers',
+  },
+}))
+
+mock.module('./uploadLlmProvidersToGraphql', () => ({
+  uploadLlmProvidersToGraphql: async () => {},
+}))
+
+let loadProviders: typeof import('./storage').loadProviders
+
+beforeAll(async () => {
+  ;({ loadProviders } = await import('./storage'))
+})
+
+beforeEach(() => {
+  storageValues.clear()
+})
+
+function providerConfig(
+  overrides: Partial<LlmProviderConfig> & Pick<LlmProviderConfig, 'id'>,
+): LlmProviderConfig {
+  return {
+    type: 'openai',
+    name: 'OpenAI',
+    modelId: 'gpt-5',
+    supportsImages: true,
+    contextWindow: 400000,
+    temperature: 0.2,
+    createdAt: 1000,
+    updatedAt: 1000,
+    ...overrides,
+  }
+}
+
+describe('loadProviders', () => {
+  it('normalizes legacy ChatGPT display names', async () => {
+    storageValues.set('local:llm-providers', [
+      providerConfig({
+        id: 'chatgpt-pro-1',
+        type: 'chatgpt-pro',
+        name: 'ChatGPT Plus/Pro',
+      }),
+      providerConfig({
+        id: 'chatgpt-pro-2',
+        type: 'chatgpt-pro',
+        name: 'ChatGPT Plus/Pro (user@example.com)',
+      }),
+    ])
+
+    const providers = await loadProviders()
+
+    expect(providers.map((provider) => provider.name)).toEqual([
+      'ChatGPT',
+      'ChatGPT',
+    ])
+    expect(
+      (storageValues.get('local:llm-providers') as LlmProviderConfig[]).map(
+        (provider) => provider.name,
+      ),
+    ).toEqual(['ChatGPT', 'ChatGPT'])
+  })
+
+  it('preserves custom ChatGPT provider names', async () => {
+    const storedProviders = [
+      providerConfig({
+        id: 'chatgpt-pro-custom',
+        type: 'chatgpt-pro',
+        name: 'Work ChatGPT',
+      }),
+    ]
+    storageValues.set('local:llm-providers', storedProviders)
+
+    const providers = await loadProviders()
+
+    expect(providers[0]?.name).toBe('Work ChatGPT')
+    expect(storageValues.get('local:llm-providers')).toBe(storedProviders)
+  })
+})

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/storage.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/storage.test.ts
@@ -2,14 +2,41 @@ import { beforeAll, beforeEach, describe, expect, it, mock } from 'bun:test'
 import type { LlmProviderConfig } from './types'
 
 const storageValues = new Map<string, unknown>()
+const storageVersions = new Map<string, number>()
 
 mock.module('@wxt-dev/storage', () => ({
   storage: {
-    defineItem: <T>(key: string, options?: { fallback?: T }) => ({
-      getValue: async () =>
-        storageValues.has(key) ? storageValues.get(key) : options?.fallback,
+    defineItem: <T>(
+      key: string,
+      options?: {
+        fallback?: T
+        version?: number
+        migrations?: Record<number, (value: T | null) => T | null>
+      },
+    ) => ({
+      getValue: async () => {
+        if (!storageValues.has(key)) return options?.fallback
+
+        const currentVersion = options?.version
+        let value = storageValues.get(key) as T | null
+        if (currentVersion && options?.migrations) {
+          const storedVersion = storageVersions.get(key) ?? 1
+          for (
+            let version = storedVersion + 1;
+            version <= currentVersion;
+            version++
+          ) {
+            const migrate = options.migrations[version]
+            if (migrate) value = migrate(value)
+          }
+          storageValues.set(key, value)
+          storageVersions.set(key, currentVersion)
+        }
+        return value
+      },
       setValue: async (value: T) => {
         storageValues.set(key, value)
+        if (options?.version) storageVersions.set(key, options.version)
       },
       watch: () => () => {},
     }),
@@ -39,13 +66,15 @@ mock.module('./uploadLlmProvidersToGraphql', () => ({
 }))
 
 let loadProviders: typeof import('./storage').loadProviders
+let providersStorage: typeof import('./storage').providersStorage
 
 beforeAll(async () => {
-  ;({ loadProviders } = await import('./storage'))
+  ;({ loadProviders, providersStorage } = await import('./storage'))
 })
 
 beforeEach(() => {
   storageValues.clear()
+  storageVersions.clear()
 })
 
 function providerConfig(
@@ -78,6 +107,7 @@ describe('loadProviders', () => {
         name: 'ChatGPT Plus/Pro (user@example.com)',
       }),
     ])
+    storageVersions.set('local:llm-providers', 3)
 
     const providers = await loadProviders()
 
@@ -106,6 +136,7 @@ describe('loadProviders', () => {
       }),
     ]
     storageValues.set('local:llm-providers', storedProviders)
+    storageVersions.set('local:llm-providers', 3)
 
     const providers = await loadProviders()
 
@@ -114,5 +145,28 @@ describe('loadProviders', () => {
       'ChatGPT Plus/Pro (Work)',
     ])
     expect(storageValues.get('local:llm-providers')).toBe(storedProviders)
+  })
+})
+
+describe('providersStorage', () => {
+  it('migrates legacy ChatGPT display names for direct storage reads', async () => {
+    storageValues.set('local:llm-providers', [
+      providerConfig({
+        id: 'chatgpt-pro-1',
+        type: 'chatgpt-pro',
+        name: 'ChatGPT Plus/Pro (user@example.com)',
+      }),
+    ])
+    storageVersions.set('local:llm-providers', 2)
+
+    const providers = await providersStorage.getValue()
+
+    expect(providers?.map((provider) => provider.name)).toEqual(['ChatGPT'])
+    expect(
+      (storageValues.get('local:llm-providers') as LlmProviderConfig[]).map(
+        (provider) => provider.name,
+      ),
+    ).toEqual(['ChatGPT'])
+    expect(storageVersions.get('local:llm-providers')).toBe(3)
   })
 })

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/storage.test.ts
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/storage.test.ts
@@ -99,12 +99,20 @@ describe('loadProviders', () => {
         type: 'chatgpt-pro',
         name: 'Work ChatGPT',
       }),
+      providerConfig({
+        id: 'chatgpt-pro-parenthetical-custom',
+        type: 'chatgpt-pro',
+        name: 'ChatGPT Plus/Pro (Work)',
+      }),
     ]
     storageValues.set('local:llm-providers', storedProviders)
 
     const providers = await loadProviders()
 
-    expect(providers[0]?.name).toBe('Work ChatGPT')
+    expect(providers.map((provider) => provider.name)).toEqual([
+      'Work ChatGPT',
+      'ChatGPT Plus/Pro (Work)',
+    ])
     expect(storageValues.get('local:llm-providers')).toBe(storedProviders)
   })
 })

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/storage.ts
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/storage.ts
@@ -154,7 +154,7 @@ function normalizeProviderNames(
 }
 
 function isLegacyChatGPTProviderName(name: string): boolean {
-  return /^ChatGPT Plus\/Pro(?: \([^)]+\))?$/.test(name)
+  return /^ChatGPT Plus\/Pro(?: \([^@\s()]+@[^@\s()]+\))?$/.test(name)
 }
 
 /** Storage key for the default provider ID */

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/storage.ts
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/storage.ts
@@ -2,7 +2,10 @@ import { storage } from '@wxt-dev/storage'
 import { sessionStorage } from '@/lib/auth/sessionStorage'
 import { getBrowserOSAdapter } from '@/lib/browseros/adapter'
 import { BROWSEROS_PREFS } from '@/lib/browseros/prefs'
-import { CHATGPT_PROVIDER_DISPLAY_NAME } from './provider-display-names'
+import {
+  migrateLlmProvidersToV3,
+  normalizeProviderNames,
+} from './provider-name-normalization'
 import {
   DEFAULT_PROVIDER_ID,
   DEFAULT_PROVIDER_NAME,
@@ -34,8 +37,7 @@ export const providersStorage = storage.defineItem<LlmProviderConfig[]>(
       3: (
         providers: LlmProviderConfig[] | null,
       ): LlmProviderConfig[] | null => {
-        if (!providers) return providers
-        return normalizeProviderNames(providers)
+        return migrateLlmProvidersToV3(providers)
       },
     },
   },
@@ -123,37 +125,6 @@ export function createDefaultBrowserOSProvider(): LlmProviderConfig {
 /** Creates the default providers configuration. Only call when storage is empty. */
 export function createDefaultProvidersConfig(): LlmProviderConfig[] {
   return [createDefaultBrowserOSProvider()]
-}
-
-function normalizeProviderNames(
-  providers: LlmProviderConfig[],
-): LlmProviderConfig[] {
-  return providers.map((provider) => {
-    if (
-      provider.id === DEFAULT_PROVIDER_ID &&
-      provider.type === 'browseros' &&
-      provider.name !== DEFAULT_PROVIDER_NAME
-    ) {
-      return {
-        ...provider,
-        name: DEFAULT_PROVIDER_NAME,
-      }
-    }
-    if (
-      provider.type === 'chatgpt-pro' &&
-      isLegacyChatGPTProviderName(provider.name)
-    ) {
-      return {
-        ...provider,
-        name: CHATGPT_PROVIDER_DISPLAY_NAME,
-      }
-    }
-    return provider
-  })
-}
-
-function isLegacyChatGPTProviderName(name: string): boolean {
-  return /^ChatGPT Plus\/Pro(?: \([^@\s()]+@[^@\s()]+\))?$/.test(name)
 }
 
 export const defaultProviderIdStorage = storage.defineItem<string>(

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/storage.ts
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/storage.ts
@@ -2,6 +2,7 @@ import { storage } from '@wxt-dev/storage'
 import { sessionStorage } from '@/lib/auth/sessionStorage'
 import { getBrowserOSAdapter } from '@/lib/browseros/adapter'
 import { BROWSEROS_PREFS } from '@/lib/browseros/prefs'
+import { CHATGPT_PROVIDER_DISPLAY_NAME } from './provider-display-names'
 import {
   DEFAULT_PROVIDER_ID,
   DEFAULT_PROVIDER_NAME,
@@ -125,10 +126,6 @@ export function createDefaultProvidersConfig(): LlmProviderConfig[] {
   return [createDefaultBrowserOSProvider()]
 }
 
-/**
- * Normalize built-in provider names back to "BrowserOS" (e.g. from "Kimi K2.5"
- * which was set during a previous partnership launch).
- */
 function normalizeProviderNames(
   providers: LlmProviderConfig[],
 ): LlmProviderConfig[] {
@@ -143,8 +140,21 @@ function normalizeProviderNames(
         name: DEFAULT_PROVIDER_NAME,
       }
     }
+    if (
+      provider.type === 'chatgpt-pro' &&
+      isLegacyChatGPTProviderName(provider.name)
+    ) {
+      return {
+        ...provider,
+        name: CHATGPT_PROVIDER_DISPLAY_NAME,
+      }
+    }
     return provider
   })
+}
+
+function isLegacyChatGPTProviderName(name: string): boolean {
+  return /^ChatGPT Plus\/Pro(?: \([^)]+\))?$/.test(name)
 }
 
 /** Storage key for the default provider ID */

--- a/packages/browseros-agent/apps/agent/lib/llm-providers/storage.ts
+++ b/packages/browseros-agent/apps/agent/lib/llm-providers/storage.ts
@@ -12,11 +12,10 @@ import { uploadLlmProvidersToGraphql } from './uploadLlmProvidersToGraphql'
 
 export { DEFAULT_PROVIDER_ID } from './provider-selection'
 
-/** Storage key for LLM providers array */
 export const providersStorage = storage.defineItem<LlmProviderConfig[]>(
   'local:llm-providers',
   {
-    version: 2,
+    version: 3,
     migrations: {
       2: (
         providers: LlmProviderConfig[] | null,
@@ -32,11 +31,17 @@ export const providersStorage = storage.defineItem<LlmProviderConfig[]>(
           return provider
         })
       },
+      3: (
+        providers: LlmProviderConfig[] | null,
+      ): LlmProviderConfig[] | null => {
+        if (!providers) return providers
+        return normalizeProviderNames(providers)
+      },
     },
   },
 )
 
-/** Backup providers to BrowserOS prefs (write-only, best-effort) */
+/** Mirrors provider data into BrowserOS prefs without blocking local writes. */
 async function backupToBrowserOS(backup: LlmProvidersBackup): Promise<void> {
   try {
     const adapter = getBrowserOSAdapter()
@@ -46,10 +51,7 @@ async function backupToBrowserOS(backup: LlmProvidersBackup): Promise<void> {
   }
 }
 
-/**
- * Setup one-way sync of LLM providers to BrowserOS prefs
- * @public
- */
+/** Sets up one-way sync of LLM providers to BrowserOS prefs. */
 export function setupLlmProvidersBackupToBrowserOS(): () => void {
   const unsubscribe = providersStorage.watch(async (providers) => {
     if (providers) {
@@ -60,6 +62,7 @@ export function setupLlmProvidersBackupToBrowserOS(): () => void {
   return unsubscribe
 }
 
+/** Uploads provider metadata for signed-in users. */
 export async function syncLlmProviders(): Promise<void> {
   const providers = await providersStorage.getValue()
   if (!providers || providers.length === 0) return
@@ -71,11 +74,7 @@ export async function syncLlmProviders(): Promise<void> {
   await uploadLlmProvidersToGraphql(providers, userId)
 }
 
-/**
- * Setup one-way sync of LLM providers to GraphQL backend
- * Watches for storage changes and uploads non-sensitive provider data
- * @public
- */
+/** Sets up one-way sync of LLM providers to the GraphQL backend. */
 export function setupLlmProvidersSyncToBackend(): () => void {
   syncLlmProviders().catch(() => {})
 
@@ -89,7 +88,7 @@ export function setupLlmProvidersSyncToBackend(): () => void {
   return unsubscribe
 }
 
-/** Load providers from storage */
+/** Returns provider configs after applying display-name compatibility fixes. */
 export async function loadProviders(): Promise<LlmProviderConfig[]> {
   const providers = (await providersStorage.getValue()) || []
   const normalizedProviders = normalizeProviderNames(providers)
@@ -157,7 +156,6 @@ function isLegacyChatGPTProviderName(name: string): boolean {
   return /^ChatGPT Plus\/Pro(?: \([^@\s()]+@[^@\s()]+\))?$/.test(name)
 }
 
-/** Storage key for the default provider ID */
 export const defaultProviderIdStorage = storage.defineItem<string>(
   'local:default-provider-id',
   {

--- a/packages/browseros-agent/apps/agent/modules/llm-providers/llm-providers.hooks.test.ts
+++ b/packages/browseros-agent/apps/agent/modules/llm-providers/llm-providers.hooks.test.ts
@@ -207,7 +207,7 @@ describe('upsertProviderConfig', () => {
     const incoming = providerConfig({
       id: 'chatgpt-pro-9999',
       type: 'chatgpt-pro',
-      name: 'ChatGPT Plus/Pro (user@example.com)',
+      name: 'ChatGPT',
       modelId: 'gpt-5.5',
       contextWindow: 1050000,
     })
@@ -222,7 +222,7 @@ describe('upsertProviderConfig', () => {
     expect(result[1]).toMatchObject({
       id: 'chatgpt-pro-existing',
       type: 'chatgpt-pro',
-      name: 'ChatGPT Plus/Pro (user@example.com)',
+      name: 'ChatGPT',
       modelId: 'gpt-5.5',
       contextWindow: 1050000,
       createdAt: 1111,

--- a/packages/browseros-agent/apps/agent/modules/llm-providers/oauth-provider-flow.hooks.test.ts
+++ b/packages/browseros-agent/apps/agent/modules/llm-providers/oauth-provider-flow.hooks.test.ts
@@ -21,6 +21,10 @@ mock.module('@/lib/llm-providers/client-oauth', () => ({
   startTokenPolling: () => {},
 }))
 
+mock.module('@/lib/llm-providers/provider-display-names', () => ({
+  CHATGPT_PROVIDER_DISPLAY_NAME: 'ChatGPT',
+}))
+
 mock.module('@/lib/llm-providers/providerTemplates', () => ({
   getProviderTemplate: (providerType: string) =>
     providerType === 'chatgpt-pro'
@@ -42,7 +46,7 @@ mock.module('@/modules/llm-providers/oauth-status.hooks', () => ({
 
 const chatgptConfig: OAuthProviderFlowConfig = {
   providerType: 'chatgpt-pro',
-  displayName: 'ChatGPT Plus/Pro',
+  displayName: 'ChatGPT',
   startedEvent: 'settings.chatgpt_pro.oauth_started',
   completedEvent: 'settings.chatgpt_pro.oauth_completed',
   disconnectedEvent: 'settings.chatgpt_pro.oauth_disconnected',
@@ -88,7 +92,7 @@ describe('saveOAuthProviderFromStatus', () => {
     expect(savedProvider).toMatchObject({
       id: 'chatgpt-pro-1234',
       type: 'chatgpt-pro',
-      name: 'ChatGPT Plus/Pro (user@example.com)',
+      name: 'ChatGPT',
       modelId: 'gpt-5.5',
       contextWindow: 1050000,
       reasoningEffort: 'medium',

--- a/packages/browseros-agent/apps/agent/modules/llm-providers/oauth-provider-flow.hooks.ts
+++ b/packages/browseros-agent/apps/agent/modules/llm-providers/oauth-provider-flow.hooks.ts
@@ -5,6 +5,7 @@ import {
   requestDeviceCode,
   startTokenPolling,
 } from '@/lib/llm-providers/client-oauth'
+import { CHATGPT_PROVIDER_DISPLAY_NAME } from '@/lib/llm-providers/provider-display-names'
 import { getProviderTemplate } from '@/lib/llm-providers/providerTemplates'
 import type { LlmProviderConfig, ProviderType } from '@/lib/llm-providers/types'
 import { track } from '@/lib/metrics/track'
@@ -49,10 +50,14 @@ export async function saveOAuthProviderFromStatus({
   now = Date.now(),
 }: SaveOAuthProviderInput): Promise<LlmProviderConfig> {
   const template = getProviderTemplate(config.providerType)
+  const providerName =
+    config.providerType === 'chatgpt-pro'
+      ? CHATGPT_PROVIDER_DISPLAY_NAME
+      : `${config.displayName}${status.email ? ` (${status.email})` : ''}`
   const provider: LlmProviderConfig = {
     id: `${config.providerType}-${now}`,
     type: config.providerType,
-    name: `${config.displayName}${status.email ? ` (${status.email})` : ''}`,
+    name: providerName,
     modelId: template?.defaultModelId ?? '',
     supportsImages: template?.supportsImages ?? true,
     contextWindow: template?.contextWindow ?? 128000,

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/BrowserOsAiPane.tsx
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/BrowserOsAiPane.tsx
@@ -25,6 +25,7 @@ import {
 } from '@/lib/constants/analyticsEvents'
 import { GetProfileIdByUserIdDocument } from '@/lib/conversations/graphql/uploadConversationDocument'
 import { getQueryKeyFromDocument } from '@/lib/graphql/getQueryKeyFromDocument'
+import { CHATGPT_PROVIDER_DISPLAY_NAME } from '@/lib/llm-providers/provider-display-names'
 import type { ProviderTemplate } from '@/lib/llm-providers/providerTemplates'
 import { testProvider } from '@/lib/llm-providers/testProvider'
 import type { LlmProviderConfig } from '@/lib/llm-providers/types'
@@ -58,7 +59,7 @@ import { ProviderTemplatesSection } from './ProviderTemplatesSection'
 const OAUTH_PROVIDERS_CONFIG: Record<string, OAuthProviderFlowConfig> = {
   'chatgpt-pro': {
     providerType: 'chatgpt-pro',
-    displayName: 'ChatGPT Plus/Pro',
+    displayName: CHATGPT_PROVIDER_DISPLAY_NAME,
     startedEvent: CHATGPT_PRO_OAUTH_STARTED_EVENT,
     completedEvent: CHATGPT_PRO_OAUTH_COMPLETED_EVENT,
     disconnectedEvent: CHATGPT_PRO_OAUTH_DISCONNECTED_EVENT,

--- a/packages/browseros-agent/apps/agent/screens/ai-settings/models.test.ts
+++ b/packages/browseros-agent/apps/agent/screens/ai-settings/models.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import { getModelContextLength, getModelsForProvider } from './models'
 
-describe('ChatGPT Plus/Pro models', () => {
+describe('ChatGPT models', () => {
   it('offers GPT-5.5 as the default first choice', () => {
     const models = getModelsForProvider('chatgpt-pro')
 

--- a/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
+++ b/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
@@ -436,8 +436,7 @@ function createGitHubCopilotFactory(
 function createChatGPTProFactory(
   config: ResolvedAgentConfig,
 ): (modelId: string) => unknown {
-  if (!config.apiKey)
-    throw new Error('ChatGPT Plus/Pro requires OAuth authentication')
+  if (!config.apiKey) throw new Error('ChatGPT requires OAuth authentication')
   return createOpenAI({
     apiKey: config.apiKey,
     fetch: createCodexFetch(config.accountId) as typeof globalThis.fetch,

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/config.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/config.ts
@@ -17,6 +17,8 @@ import {
 } from './mock-language-model'
 import type { ResolvedLLMConfig } from './types'
 
+const CHATGPT_PROVIDER_DISPLAY_NAME = 'ChatGPT'
+
 export async function resolveLLMConfig(
   config: LLMConfig,
   browserosId?: string,
@@ -25,7 +27,7 @@ export async function resolveLLMConfig(
   if (config.provider === LLM_PROVIDERS.CHATGPT_PRO) {
     return resolveOAuthConfig(config, browserosId, {
       providerId: 'chatgpt-pro',
-      displayName: 'ChatGPT Plus/Pro',
+      displayName: CHATGPT_PROVIDER_DISPLAY_NAME,
       defaultModel: 'gpt-5.5',
       useRefresh: true,
       extraFields: (tokens) => ({

--- a/packages/browseros-agent/apps/server/src/lib/clients/llm/provider.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/llm/provider.ts
@@ -173,8 +173,7 @@ function createGitHubCopilotModel(config: ResolvedLLMConfig): LanguageModel {
 }
 
 function createChatGPTProModel(config: ResolvedLLMConfig): LanguageModel {
-  if (!config.apiKey)
-    throw new Error('ChatGPT Plus/Pro requires OAuth authentication')
+  if (!config.apiKey) throw new Error('ChatGPT requires OAuth authentication')
   return createOpenAI({
     apiKey: config.apiKey,
     fetch: createCodexFetch(config.accountId) as typeof globalThis.fetch,

--- a/packages/browseros-agent/apps/server/src/lib/clients/oauth/providers.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/oauth/providers.ts
@@ -6,6 +6,8 @@
 
 import { EXTERNAL_URLS } from '@browseros/shared/constants/urls'
 
+const CHATGPT_PROVIDER_DISPLAY_NAME = 'ChatGPT'
+
 export interface OAuthProviderConfig {
   id: string
   name: string
@@ -25,7 +27,7 @@ export interface OAuthProviderConfig {
 const OAUTH_PROVIDERS: Record<string, OAuthProviderConfig> = {
   'chatgpt-pro': {
     id: 'chatgpt-pro',
-    name: 'ChatGPT Plus/Pro',
+    name: CHATGPT_PROVIDER_DISPLAY_NAME,
     clientId: 'app_EMoamEEZ73f0CkXaXp7hrann',
     authEndpoint: EXTERNAL_URLS.OPENAI_AUTH,
     tokenEndpoint: EXTERNAL_URLS.OPENAI_TOKEN,

--- a/packages/browseros-agent/apps/server/src/lib/clients/oauth/token-manager.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/oauth/token-manager.ts
@@ -86,7 +86,7 @@ export class OAuthTokenManager {
     private readonly callbackServer: OAuthCallbackServer,
   ) {}
 
-  // --- PKCE flow (ChatGPT Plus/Pro) ---
+  // --- PKCE flow (ChatGPT) ---
 
   async generateAuthorizationUrl(
     providerId: string,

--- a/packages/browseros-agent/apps/server/tests/lib/clients/llm/config.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/clients/llm/config.test.ts
@@ -30,7 +30,7 @@ describe('resolveLLMConfig', () => {
     tempDirs.length = 0
   })
 
-  it('defaults ChatGPT Plus/Pro OAuth providers to GPT-5.5', async () => {
+  it('defaults ChatGPT OAuth providers to GPT-5.5', async () => {
     const browserosId = 'browseros-id'
     const dir = mkdtempSync(join(tmpdir(), 'browseros-llm-config-test-'))
     tempDirs.push(dir)


### PR DESCRIPTION
## Summary
- Rename the ChatGPT OAuth provider display from `ChatGPT Plus/Pro (...)` to `ChatGPT` across settings, provider templates, OAuth save flow, assistant sidebar target labels, and server-facing labels.
- Add storage compatibility so legacy `ChatGPT Plus/Pro` and `ChatGPT Plus/Pro (email)` rows migrate to `ChatGPT` while preserving custom user names.
- Bump the provider storage migration to cover direct `providersStorage.getValue()` consumers, including scheduled-task UI reads and backend sync.

## Test Plan
- `bun test apps/agent/lib/llm-providers/storage.test.ts apps/agent/lib/llm-providers/providerTemplates.test.ts apps/agent/modules/llm-providers/oauth-provider-flow.hooks.test.ts apps/agent/modules/llm-providers/llm-providers.hooks.test.ts apps/agent/screens/ai-settings/models.test.ts apps/server/tests/lib/clients/llm/config.test.ts`
- `bun run check`
- `bun run test`
- `bun run build:agent`