### PR TITLE
fix: align Biome checks with pinned CLI

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,7 +19,7 @@ pre-commit:
     biome-check:
       root: "packages/browseros-agent/"
       glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-      run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+      run: bunx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
       stage_fixed: true
 
     file-length:

--- a/packages/browseros-agent/apps/agent/package.json
+++ b/packages/browseros-agent/apps/agent/package.json
@@ -11,9 +11,9 @@
     "zip": "wxt zip",
     "test": "bun run ../../scripts/run-bun-test.ts ./apps/agent",
     "compile": "bun --env-file=.env.development wxt prepare && tsgo --noEmit",
-    "lint": "bunx biome check",
+    "lint": "bunx @biomejs/biome check",
     "typecheck": "bun --env-file=.env.development wxt prepare && tsgo --noEmit",
-    "lint:fix": "bunx biome check --write --unsafe",
+    "lint:fix": "bunx @biomejs/biome check --write --unsafe",
     "clean:cache": "rm -rf node_modules/.cache && rm -rf .output/ && rm -rf .wxt/",
     "codegen": "bun --env-file=.env.development graphql-codegen --config codegen.ts",
     "codegen:watch": "graphql-codegen --config codegen.ts --watch"

--- a/packages/browseros-agent/lefthook.yml
+++ b/packages/browseros-agent/lefthook.yml
@@ -18,7 +18,7 @@ pre-commit:
   commands:
     check:
       glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-      run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+      run: bunx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
       stage_fixed: true
 
     file-length:

--- a/packages/browseros-agent/package.json
+++ b/packages/browseros-agent/package.json
@@ -41,9 +41,9 @@
     "test:main": "bun run ./scripts/run-test-suite.ts main",
     "check": "bun run lint && bun run typecheck && bun run fallow",
     "typecheck": "bun run --filter '*' typecheck",
-    "lint": "bunx biome check",
+    "lint": "bunx @biomejs/biome check",
     "fallow": "fallow check",
-    "lint:fix": "bunx biome check --write --unsafe",
+    "lint:fix": "bunx @biomejs/biome check --write --unsafe",
     "gen:cdp": "bun scripts/codegen/cdp-protocol.ts",
     "generate:models": "bun scripts/generate-models.ts"
   },


### PR DESCRIPTION
## Summary
- Switch BrowserOS agent Biome hook commands from npm's `npx` path to Bun's scoped `@biomejs/biome` runner.
- Update agent lint scripts to call `@biomejs/biome` instead of the unrelated `biome` package.
- Keep the existing Biome 2.5.0 config unchanged because package.json and bun.lock already pin 2.5.0.

## Design
The reported failure happens when the Biome check runs with CLI 2.4.8 against a 2.5.0 config. The repo already declares and locks `@biomejs/biome@2.5.0`, so the fix is to make hooks and scripts resolve that scoped package consistently instead of using a transient npm path or the unscoped `biome` package.

## Test plan
- [x] `npx @biomejs/biome@2.4.8 check --config-path biome.json --no-errors-on-unmatched --files-ignore-unknown=true --colors=off biome.json` reproduces the original error
- [x] `bunx @biomejs/biome --version && bunx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off biome.json package.json apps/agent/package.json ../../lefthook.yml lefthook.yml`
- [x] `git diff --check`
- [x] `bun install --frozen-lockfile`
- [x] `bun run codegen:agent`
- [x] `bun run check`
- [x] `bun run test`