### PR TITLE
fix: prevent Bun temp native addon extraction

### DIFF
--- a/packages/browseros-agent/scripts/build/server/compile.ts
+++ b/packages/browseros-agent/scripts/build/server/compile.ts
@@ -12,6 +12,9 @@ const BUNDLE_DIR = join(TMP_ROOT, 'bundle')
 const BUNDLE_ENTRY = join(BUNDLE_DIR, 'index.js')
 const BINARIES_DIR = join(TMP_ROOT, 'binaries')
 
+// Bun embeds native addons by extracting hidden temp `.node` files at runtime.
+export const COMPILED_SERVER_EXEC_ARGV = ['--no-addons']
+
 function compiledBinaryPath(target: BuildTarget): string {
   return join(
     BINARIES_DIR,
@@ -63,9 +66,11 @@ async function compileTarget(
     '--outfile',
     binaryPath,
     `--target=${target.bunTarget}`,
+    `--compile-exec-argv=${COMPILED_SERVER_EXEC_ARGV.join(' ')}`,
     '--external=node-pty',
   ]
   await runCommand('bun', args, env)
+  await adHocSignMacBinary(target, binaryPath, env)
 
   if (target.os === 'windows') {
     if (ci) {
@@ -80,6 +85,25 @@ async function compileTarget(
   }
 
   return binaryPath
+}
+
+/** Keeps local macOS server artifacts valid until release signing replaces the ad-hoc signature. */
+async function adHocSignMacBinary(
+  target: BuildTarget,
+  binaryPath: string,
+  env: NodeJS.ProcessEnv,
+): Promise<void> {
+  if (target.os !== 'macos') return
+  if (process.platform !== 'darwin') {
+    log.warn(`Skipping ad-hoc signing for ${target.id} outside macOS`)
+    return
+  }
+
+  await runCommand(
+    'codesign',
+    ['--force', '--sign', '-', '--timestamp=none', binaryPath],
+    env,
+  )
 }
 
 export async function compileServerBinaries(

--- a/packages/browseros-agent/scripts/build/server/config.test.ts
+++ b/packages/browseros-agent/scripts/build/server/config.test.ts
@@ -104,13 +104,34 @@ describe('server build config', () => {
     expect(config.envVars.AGENT_RUNNER_JWT_SECRET).toBeUndefined()
   })
 
-  async function writeProdRoot(env: Record<string, string>): Promise<string> {
+  it('does not require a production env file in CI mode', async () => {
+    const rootDir = await writeProdRoot({}, { envFile: false })
+
+    const config = loadBuildConfig(rootDir, { ci: true })
+
+    expect(config.envVars).toEqual({
+      BROWSEROS_CONFIG_URL:
+        'https://browseros.invalid/api/browseros-server/config',
+      LOG_LEVEL: 'info',
+      NODE_ENV: 'production',
+      POSTHOG_API_KEY: 'phc_browseros_ci',
+      SENTRY_DSN: 'https://ci@sentry.invalid/1',
+    })
+    expect(config.r2).toBeUndefined()
+  })
+
+  async function writeProdRoot(
+    env: Record<string, string>,
+    options: { envFile?: boolean } = {},
+  ): Promise<string> {
     tempRoot = await mkdtemp(join(tmpdir(), 'browseros-build-config-test-'))
     const serverDir = join(tempRoot, 'apps/server')
     await mkdir(serverDir, { recursive: true })
     await writeFile(join(serverDir, 'package.json'), '{"version":"0.0.0-test"}')
     await writeFile(join(serverDir, '.env.production.example'), '')
-    await writeFile(join(serverDir, '.env.production'), formatEnv(env))
+    if (options.envFile !== false) {
+      await writeFile(join(serverDir, '.env.production'), formatEnv(env))
+    }
     return tempRoot
   }
 })

--- a/packages/browseros-agent/scripts/build/server/config.ts
+++ b/packages/browseros-agent/scripts/build/server/config.ts
@@ -16,6 +16,13 @@ const INLINED_ENV_VARS = [
   'NODE_ENV',
   'LOG_LEVEL',
 ] as const
+const CI_INLINE_ENV_DEFAULTS = {
+  BROWSEROS_CONFIG_URL: 'https://browseros.invalid/api/browseros-server/config',
+  LOG_LEVEL: 'info',
+  NODE_ENV: 'production',
+  POSTHOG_API_KEY: 'phc_browseros_ci',
+  SENTRY_DSN: 'https://ci@sentry.invalid/1',
+} satisfies Partial<Record<(typeof INLINED_ENV_VARS)[number], string>>
 const PROD_ENV_PATH = join('apps', 'server', '.env.production')
 const PROD_ENV_TEMPLATE_PATH = join('apps', 'server', '.env.production.example')
 
@@ -33,9 +40,14 @@ function pickEnv(name: string, fileEnv: Record<string, string>): string {
   return value
 }
 
-function loadProdEnv(rootDir: string): Record<string, string> {
+function loadProdEnv(
+  rootDir: string,
+  options: { required?: boolean } = {},
+): Record<string, string> {
   const prodEnvPath = join(rootDir, PROD_ENV_PATH)
   if (!existsSync(prodEnvPath)) {
+    if (options.required === false) return {}
+
     const prodEnvTemplatePath = join(rootDir, PROD_ENV_TEMPLATE_PATH)
     if (existsSync(prodEnvTemplatePath)) {
       throw new Error(
@@ -82,8 +94,13 @@ export function loadBuildConfig(
   rootDir: string,
   options: LoadBuildConfigOptions = {},
 ): BuildConfig {
-  const fileEnv = loadProdEnv(rootDir)
+  const fileEnv = loadProdEnv(rootDir, { required: !options.ci })
   const envVars = buildInlineEnv(fileEnv)
+  if (options.ci) {
+    for (const [key, value] of Object.entries(CI_INLINE_ENV_DEFAULTS)) {
+      envVars[key] ??= value
+    }
+  }
   if (!options.ci) {
     validateProductionEnv(envVars)
   }

--- a/packages/browseros-agent/scripts/build/server/native-addon-policy.test.ts
+++ b/packages/browseros-agent/scripts/build/server/native-addon-policy.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { COMPILED_SERVER_EXEC_ARGV } from './compile'
+
+describe('compiled server native addon policy', () => {
+  let tempDir: string | null = null
+
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true })
+      tempDir = null
+    }
+  })
+
+  it('bakes native-addon loading disablement into compiled server binaries', () => {
+    expect(COMPILED_SERVER_EXEC_ARGV).toContain('--no-addons')
+  })
+
+  it('prevents Bun from opening hidden temp native addons', async () => {
+    if (process.platform !== 'darwin') return
+
+    tempDir = await mkdtemp(join(tmpdir(), 'browseros-native-addon-policy-'))
+    const sourcePath = join(tempDir, 'app.js')
+    const addonPath = join(tempDir, 'addon.node')
+    const binaryPath = join(tempDir, 'app')
+    const runTmpDir = join(tempDir, 'tmp')
+
+    await writeFile(addonPath, 'not a native addon')
+    await writeFile(
+      sourcePath,
+      [
+        'try {',
+        '  require("./addon.node")',
+        '} catch (error) {',
+        '  console.error(error?.message ?? String(error))',
+        '  setInterval(() => {}, 1000)',
+        '}',
+      ].join('\n'),
+    )
+
+    const build = Bun.spawn(
+      [
+        'bun',
+        'build',
+        '--compile',
+        `--compile-exec-argv=${COMPILED_SERVER_EXEC_ARGV.join(' ')}`,
+        sourcePath,
+        '--outfile',
+        binaryPath,
+      ],
+      {
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
+    )
+    const buildResult = await collectProcess(build)
+    expect(buildResult).toMatchObject({ exitCode: 0 })
+
+    await rm(sourcePath)
+    await rm(addonPath)
+    await mkdir(runTmpDir)
+
+    const app = Bun.spawn([binaryPath], {
+      env: {
+        ...process.env,
+        BUN_TMPDIR: runTmpDir,
+        TMPDIR: runTmpDir,
+      },
+      stdout: 'pipe',
+      stderr: 'pipe',
+    })
+    await Bun.sleep(500)
+
+    const openFiles = await collectProcess(
+      Bun.spawn(['lsof', '-p', String(app.pid)], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+      }),
+    )
+
+    app.kill()
+    const appResult = await collectProcess(app)
+
+    expect(appResult.stderr).toContain(
+      'Cannot load native addon because loading addons is disabled',
+    )
+    expect(openFiles.stdout).not.toContain('.node')
+  })
+})
+
+interface CollectableProcess {
+  stdout: ReadableStream
+  stderr: ReadableStream
+  exited: Promise<number>
+}
+
+async function collectProcess(process: CollectableProcess) {
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(process.stdout).text(),
+    new Response(process.stderr).text(),
+    process.exited,
+  ])
+
+  return { stdout, stderr, exitCode }
+}


### PR DESCRIPTION
## Summary
- compile BrowserOS server binaries with Bun native addon loading disabled so embedded addons cannot be extracted as hidden temp `.node` files
- ad-hoc sign local macOS server binaries immediately after Bun compile, before release signing replaces the signature
- allow CI server builds to run without local production env/R2 credentials by using benign inline defaults
- add focused regression coverage for the native-addon policy and CI env loading

## Verification
- `bun test scripts/build/server/config.test.ts scripts/build/server/native-addon-policy.test.ts scripts/build/server/stage.test.ts`
- `bun scripts/build/server.ts --target=darwin-arm64 --ci`
- fresh compiled server `/health` probe with isolated temp dirs and `lsof` check: no `.node` handles
- `codesign --verify --verbose=2 dist/prod/server/darwin-arm64/resources/bin/browseros_server`
- `bun run check`
- `bun run test:main`

## Notes
- `bun run build:server:test` still exercises full R2-backed staging and cannot complete in this checkout without release R2 credentials.