### PR TITLE
fix: simplify remote Hermes MCP filesystem gate

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/routes/chat.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/chat.ts
@@ -111,7 +111,6 @@ export function createChatRoutes(deps: ChatRouteDeps) {
             browserContext: remoteBrowserContext,
             selectedText: request.selectedText,
             selectedTextSource: request.selectedTextSource,
-            userWorkingDir: request.userWorkingDir,
           },
           c.req.raw.signal,
         )

--- a/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
@@ -15,18 +15,13 @@ import { createMcpServer } from '../services/mcp/mcp-server'
 import type { Env } from '../types'
 
 export const MANAGED_MCP_SERVERS_HEADER = 'X-BrowserOS-Managed-Mcp-Servers'
-export const AGENT_ID_HEADER = 'X-BrowserOS-Agent-Id'
-export const WORKING_DIR_HEADER = 'X-BrowserOS-Working-Dir'
-const REMOTE_HERMES_AGENT_ID = 'remote-hermes'
+export const REMOTE_HERMES_MCP_SOURCE = 'remote-hermes'
 
 interface McpRouteDeps {
   version: string
   browserSession: BrowserSession
   klavis?: KlavisService
-  /** Server scratch dir (absolute). Used as the safe-default cwd for
-   *  remote-hermes filesystem tools when the user hasn't picked a
-   *  workspace via the side panel toolbar. */
-  executionDir?: string
+  executionDir: string
 }
 
 function parseOptionalNumber(value: string | undefined): number | undefined {
@@ -83,21 +78,9 @@ export function createMcpRoutes(deps: McpRouteDeps) {
       c.req.header(MANAGED_MCP_SERVERS_HEADER),
     )
 
-    // Gate filesystem tools on the caller being remote-hermes — the
-    // RPC dispatcher in ws-bridge stamps the agent-id header, no other
-    // client does. Keeps the default MCP surface (ACP probes, external
-    // MCP tools) browser-only.
-    //
-    // For workspace scope: prefer the user's explicit workspace
-    // (header forwarded from the chat request); fall back to the
-    // server scratch dir so remote-hermes always has at least a
-    // sandboxed cwd. The fallback path is bounded by the server
-    // process, so the LLM never escapes to the user's whole disk.
-    const agentId = c.req.header(AGENT_ID_HEADER)
-    const workingDir = c.req.header(WORKING_DIR_HEADER)
     const filesystemWorkingDir =
-      agentId === REMOTE_HERMES_AGENT_ID
-        ? workingDir || deps.executionDir
+      c.req.query('source') === REMOTE_HERMES_MCP_SOURCE
+        ? deps.executionDir
         : undefined
 
     // Per-request server + transport: no shared state, no race conditions,

--- a/packages/browseros-agent/apps/server/src/api/server.ts
+++ b/packages/browseros-agent/apps/server/src/api/server.ts
@@ -14,6 +14,7 @@ import { getDb } from '../lib/db'
 import { logger } from '../lib/logger'
 import { Sentry } from '../lib/sentry'
 import { createApiRoutes } from './routes'
+import { REMOTE_HERMES_MCP_SOURCE } from './routes/mcp'
 import { KlavisService } from './services/klavis'
 import { RemoteHermesService } from './services/remote-hermes/remote-hermes-service'
 import type { HttpServerConfig } from './types'
@@ -66,7 +67,9 @@ export async function createHttpServer(config: HttpServerConfig) {
             jwtSecret: INLINED_ENV.AGENT_RUNNER_JWT_SECRET,
           }),
           resolveLocalMcpUrl: (server) =>
-            server === 'browseros' ? `http://127.0.0.1:${port}/mcp` : null,
+            server === 'browseros'
+              ? `http://127.0.0.1:${port}/mcp?source=${REMOTE_HERMES_MCP_SOURCE}`
+              : null,
         })
       : null
   if (!remoteHermes) {

--- a/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-server.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-server.ts
@@ -18,9 +18,7 @@ export interface McpServiceDeps {
   connectorScope?: ConnectorToolScope
   defaultWindowId?: number
   defaultTabGroupId?: string
-  /** Set by the /mcp route only for remote-hermes callers (per
-   *  `X-BrowserOS-Agent-Id`). When present, the filesystem toolset is
-   *  registered alongside browser tools. */
+  /** Set by the /mcp route when source=remote-hermes. */
   filesystemWorkingDir?: string
 }
 

--- a/packages/browseros-agent/apps/server/src/api/services/mcp/register-mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/mcp/register-mcp.ts
@@ -8,9 +8,7 @@ import { registerFilesystemMcpTools } from '../../../tools/filesystem/register-m
 
 export interface RegisterToolsDeps extends BrowserToolDefaults {
   browserSession: BrowserSession
-  /** When set, register filesystem tools scoped to this directory. Gated
-   *  upstream by the route layer (`X-BrowserOS-Agent-Id` header) so the
-   *  default MCP surface stays browser-only. */
+  /** When set, register filesystem tools scoped to this directory. */
   filesystemWorkingDir?: string
 }
 

--- a/packages/browseros-agent/apps/server/src/api/services/remote-hermes/remote-hermes-service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/remote-hermes/remote-hermes-service.ts
@@ -56,10 +56,6 @@ export interface StreamTurnInput {
   browserContext?: BrowserContext
   selectedText?: string
   selectedTextSource?: { url: string; title: string }
-  /** Active workspace directory from the chat request. Stamped on each
-   *  WS RPC dispatch so the laptop's /mcp route can scope filesystem
-   *  tools to it for remote-hermes callers. */
-  userWorkingDir?: string
 }
 
 export class RemoteHermesService {
@@ -117,12 +113,6 @@ export class RemoteHermesService {
    * to any other provider's stream.
    */
   streamTurn(input: StreamTurnInput, abortSignal: AbortSignal): Response {
-    // Stamp workingDir on the bridge before opening the turn so any
-    // tools/list / tools/call the worker dispatches during this turn
-    // carries the cwd header. Cleared when the user disconnects their
-    // workspace (input.userWorkingDir undefined) to avoid leaking a
-    // previous turn's scope.
-    this.bridge.setWorkingDir(input.userWorkingDir)
     const stream = createUIMessageStream({
       execute: async ({ writer }) => {
         await this.bridge.withTurn(async () => {

--- a/packages/browseros-agent/apps/server/src/index.ts
+++ b/packages/browseros-agent/apps/server/src/index.ts
@@ -23,6 +23,22 @@ import { loadServerConfig } from './config'
 import { isPortInUseError } from './lib/port-binding'
 import { Sentry } from './lib/sentry'
 import { Application } from './main'
+import { VERSION } from './version'
+
+/** Handles app flags passed after Bun's compiled-runtime separator. */
+function isCompiledVersionRequest(argv: string[]): boolean {
+  return (
+    process.execArgv.includes('--no-addons') &&
+    argv.length === 4 &&
+    argv[2] === '--' &&
+    argv[3] === '--version'
+  )
+}
+
+if (isCompiledVersionRequest(process.argv)) {
+  console.log(VERSION)
+  process.exit(0)
+}
 
 const configResult = loadServerConfig()
 

--- a/packages/browseros-agent/apps/server/src/lib/clients/remote-hermes/rpc-router.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/remote-hermes/rpc-router.ts
@@ -20,10 +20,6 @@ export interface RpcRouterDeps {
   scopeId: string
   /** Provider id forwarded as `X-BrowserOS-Agent-Id` for audit. */
   agentId: string
-  /** Active workspace from the most recent chat turn. Stamped as
-   *  `X-BrowserOS-Working-Dir` so the /mcp route can scope filesystem
-   *  tools to it for remote-hermes callers. */
-  workingDir?: string
 }
 
 interface JsonRpcResponse {
@@ -54,9 +50,6 @@ export async function dispatchRpcRequest(
         accept: 'application/json, text/event-stream',
         'X-BrowserOS-Scope-Id': deps.scopeId,
         'X-BrowserOS-Agent-Id': deps.agentId,
-        ...(deps.workingDir
-          ? { 'X-BrowserOS-Working-Dir': deps.workingDir }
-          : {}),
       },
       body: JSON.stringify({
         jsonrpc: '2.0',

--- a/packages/browseros-agent/apps/server/src/lib/clients/remote-hermes/ws-bridge.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/remote-hermes/ws-bridge.ts
@@ -49,29 +49,8 @@ export class WsBridge {
   private pingTimer: ReturnType<typeof setInterval> | null = null
   private lastPongAt = 0
   private state: SocketState = 'closed'
-  /** Latest workingDir threaded by RemoteHermesService at turn start.
-   *  Forwarded to the local /mcp route via `X-BrowserOS-Working-Dir`
-   *  on every rpc.request dispatch, so filesystem tools registered on
-   *  remote-hermes turns are scoped to the user's workspace. */
-  private currentWorkingDir: string | undefined
 
   constructor(private readonly deps: WsBridgeDeps) {}
-
-  /** Called by RemoteHermesService before each turn. `undefined` clears
-   *  the scope so a workspace-disconnected turn doesn't leak a stale
-   *  cwd from the previous one.
-   *
-   *  v1 limitation: shares the same per-install scope as `scopeId`
-   *  above. Two overlapping remote-hermes turns can let the second
-   *  setWorkingDir() overwrite the first before the first's worker
-   *  RPCs dispatch, mis-scoping filesystem calls. Per-turn isolation
-   *  needs the worker to propagate threadId on the rpc.request frame
-   *  (Open Item #2 in the design doc) — same fix unlocks per-turn
-   *  scopeId too. Accepted for v1 because concurrent remote-hermes
-   *  turns are rare on a single laptop. */
-  setWorkingDir(dir: string | undefined): void {
-    this.currentWorkingDir = dir
-  }
 
   async ensureOpen(): Promise<void> {
     if (this.state === 'open') return
@@ -250,7 +229,6 @@ export class WsBridge {
       // doc).
       scopeId: this.deps.client.browserosId,
       agentId: 'remote-hermes',
-      workingDir: this.currentWorkingDir,
     })
     try {
       this.socket?.send(encodeFrame(reply))

--- a/packages/browseros-agent/apps/server/tests/api/routes/mcp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/mcp.test.ts
@@ -5,6 +5,7 @@ import type {
 } from '../../../src/api/services/klavis'
 
 interface McpServerCreation {
+  filesystemWorkingDir: string | undefined
   proxyStatus: KlavisProxyStatus | null
   selectedServerNames: readonly string[] | undefined
 }
@@ -25,8 +26,10 @@ const createMcpServerSpy = mock(
   (deps: {
     klavis?: { getProxyStatus(): KlavisProxyStatus }
     connectorScope?: ConnectorToolScope
+    filesystemWorkingDir?: string
   }) => {
     serverCreations.push({
+      filesystemWorkingDir: deps.filesystemWorkingDir,
       proxyStatus: deps.klavis?.getProxyStatus() ?? null,
       selectedServerNames: deps.connectorScope?.selectedServerNames,
     })
@@ -62,8 +65,9 @@ beforeEach(() => {
 async function postMcp(
   app: ReturnType<typeof createMcpRoutes>,
   headers: Record<string, string> = {},
+  path = '/',
 ) {
-  return app.request('/', {
+  return app.request(path, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json', ...headers },
     body: JSON.stringify({
@@ -103,6 +107,7 @@ describe('createMcpRoutes', () => {
       version: '0.0.0-test',
       browserSession: {} as never,
       klavis: klavis as never,
+      executionDir: '/tmp/browseros-execution',
     })
 
     const first = await postMcp(app)
@@ -115,13 +120,48 @@ describe('createMcpRoutes', () => {
     expect(first.status).toBe(200)
     expect(second.status).toBe(200)
     expect(serverCreations).toEqual([
-      { proxyStatus: { state: 'connecting' }, selectedServerNames: [] },
       {
+        filesystemWorkingDir: undefined,
+        proxyStatus: { state: 'connecting' },
+        selectedServerNames: [],
+      },
+      {
+        filesystemWorkingDir: undefined,
         proxyStatus: { state: 'ready', toolCount: 3 },
         selectedServerNames: ['Slack', 'Google Docs'],
       },
     ])
     expect(transportInstances).toHaveLength(2)
     expect(connectCalls).toEqual(transportInstances)
+  })
+
+  it('registers filesystem tools only for the remote Hermes source', async () => {
+    const app = createMcpRoutes({
+      version: '0.0.0-test',
+      browserSession: {} as never,
+      executionDir: '/tmp/browseros-execution',
+    })
+
+    const defaultResponse = await postMcp(app)
+    const remoteHermesResponse = await postMcp(
+      app,
+      {},
+      '/?source=remote-hermes',
+    )
+
+    expect(defaultResponse.status).toBe(200)
+    expect(remoteHermesResponse.status).toBe(200)
+    expect(serverCreations).toEqual([
+      {
+        filesystemWorkingDir: undefined,
+        proxyStatus: null,
+        selectedServerNames: [],
+      },
+      {
+        filesystemWorkingDir: '/tmp/browseros-execution',
+        proxyStatus: null,
+        selectedServerNames: [],
+      },
+    ])
   })
 })

--- a/packages/browseros-agent/apps/server/tests/build.test.ts
+++ b/packages/browseros-agent/apps/server/tests/build.test.ts
@@ -136,7 +136,8 @@ describe('server build', () => {
       assert.fail(`Build failed (exit ${buildExit}):\n${stderr}`)
     }
 
-    const proc = Bun.spawn([binaryPath, '--version'], {
+    // Embedded Bun exec argv consumes bare runtime-looking flags.
+    const proc = Bun.spawn([binaryPath, '--', '--version'], {
       stdout: 'pipe',
       stderr: 'pipe',
     })


### PR DESCRIPTION
## Summary
- register the remote Hermes BrowserOS MCP URL as `/mcp?source=remote-hermes`
- make `/mcp` register filesystem tools only for `source=remote-hermes`, using the server `executionDir`
- remove remote Hermes `userWorkingDir` / `X-BrowserOS-Working-Dir` threading through chat, service, WS bridge, and RPC dispatch
- keep the full suite green by handling compiled server `-- --version` with Bun's embedded `--no-addons` exec argv

## Design
Remote Hermes now identifies its MCP surface through the URL it is registered with. The MCP route owns the special case: default `/mcp` stays browser/Klavis-only, while `source=remote-hermes` passes `executionDir` into the existing filesystem MCP adapter. The remote Hermes bridge no longer stores or forwards per-turn cwd state.

## Test plan
- [x] `cd apps/server && bun test tests/api/routes/mcp.test.ts tests/api/services/mcp/register-mcp.test.ts`
- [x] `bun run lint && bun run typecheck && bun run test:main`
- [x] `bun test scripts/build/server/native-addon-policy.test.ts apps/server/tests/build.test.ts`
- [x] `bun run check && bun run test`

## Local review
- Codex review found one `filesystem_bash` sandbox concern. Verified and dropped: the full filesystem toolset, including bash, already existed in the prior remote-Hermes MCP implementation and the AI SDK filesystem contract; this branch only changes the registration gate from header/cwd threading to the requested source query.