### PR TITLE
fix: gate remote MCP filesystem tools by harness

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
@@ -78,10 +78,8 @@ export function createMcpRoutes(deps: McpRouteDeps) {
       c.req.header(MANAGED_MCP_SERVERS_HEADER),
     )
 
-    const filesystemWorkingDir =
+    const isRemoteAgentHarness =
       c.req.query('source') === REMOTE_HERMES_MCP_SOURCE
-        ? deps.executionDir
-        : undefined
 
     // Per-request server + transport: no shared state, no race conditions,
     // no ID collisions. Required by MCP SDK 1.26.0+ security fix (GHSA-345p-7cg4-v4c7).
@@ -92,7 +90,8 @@ export function createMcpRoutes(deps: McpRouteDeps) {
       connectorScope: { selectedServerNames },
       defaultWindowId,
       defaultTabGroupId,
-      filesystemWorkingDir,
+      executionDir: deps.executionDir,
+      isRemoteAgentHarness,
     })
     const transport = new StreamableHTTPTransport({
       sessionIdGenerator: undefined,

--- a/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-server.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-server.ts
@@ -18,10 +18,11 @@ export interface McpServiceDeps {
   connectorScope?: ConnectorToolScope
   defaultWindowId?: number
   defaultTabGroupId?: string
-  /** Set by the /mcp route when source=remote-hermes. */
-  filesystemWorkingDir?: string
+  executionDir: string
+  isRemoteAgentHarness: boolean
 }
 
+/** Creates a per-request BrowserOS MCP server with tools for the requested surface. */
 export function createMcpServer(deps: McpServiceDeps): McpServer {
   const server = new McpServer(
     {
@@ -40,7 +41,8 @@ export function createMcpServer(deps: McpServiceDeps): McpServer {
     browserSession: deps.browserSession,
     defaultWindowId: deps.defaultWindowId,
     defaultTabGroupId: deps.defaultTabGroupId,
-    filesystemWorkingDir: deps.filesystemWorkingDir,
+    executionDir: deps.executionDir,
+    isRemoteAgentHarness: deps.isRemoteAgentHarness,
   })
 
   deps.klavis?.registerMcpTools(server, deps.connectorScope)

--- a/packages/browseros-agent/apps/server/src/api/services/mcp/register-mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/mcp/register-mcp.ts
@@ -8,11 +8,11 @@ import { registerFilesystemMcpTools } from '../../../tools/filesystem/register-m
 
 export interface RegisterToolsDeps extends BrowserToolDefaults {
   browserSession: BrowserSession
-  /** When set, register filesystem tools scoped to this directory. */
-  filesystemWorkingDir?: string
+  executionDir: string
+  isRemoteAgentHarness: boolean
 }
 
-/** Registers BrowserOS browser tools for MCP requests. */
+/** Registers BrowserOS MCP tools for the current request. */
 export function registerTools(
   mcpServer: McpServer,
   deps: RegisterToolsDeps,
@@ -24,7 +24,7 @@ export function registerTools(
 
   registerBrowserTools(mcpServer, deps.browserSession, defaults)
 
-  if (deps.filesystemWorkingDir) {
-    registerFilesystemMcpTools(mcpServer, deps.filesystemWorkingDir)
+  if (deps.isRemoteAgentHarness) {
+    registerFilesystemMcpTools(mcpServer, deps.executionDir)
   }
 }

--- a/packages/browseros-agent/apps/server/tests/api/routes/mcp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/mcp.test.ts
@@ -5,7 +5,8 @@ import type {
 } from '../../../src/api/services/klavis'
 
 interface McpServerCreation {
-  filesystemWorkingDir: string | undefined
+  executionDir: string | undefined
+  isRemoteAgentHarness: boolean | undefined
   proxyStatus: KlavisProxyStatus | null
   selectedServerNames: readonly string[] | undefined
 }
@@ -26,10 +27,12 @@ const createMcpServerSpy = mock(
   (deps: {
     klavis?: { getProxyStatus(): KlavisProxyStatus }
     connectorScope?: ConnectorToolScope
-    filesystemWorkingDir?: string
+    executionDir?: string
+    isRemoteAgentHarness?: boolean
   }) => {
     serverCreations.push({
-      filesystemWorkingDir: deps.filesystemWorkingDir,
+      executionDir: deps.executionDir,
+      isRemoteAgentHarness: deps.isRemoteAgentHarness,
       proxyStatus: deps.klavis?.getProxyStatus() ?? null,
       selectedServerNames: deps.connectorScope?.selectedServerNames,
     })
@@ -121,12 +124,14 @@ describe('createMcpRoutes', () => {
     expect(second.status).toBe(200)
     expect(serverCreations).toEqual([
       {
-        filesystemWorkingDir: undefined,
+        executionDir: '/tmp/browseros-execution',
+        isRemoteAgentHarness: false,
         proxyStatus: { state: 'connecting' },
         selectedServerNames: [],
       },
       {
-        filesystemWorkingDir: undefined,
+        executionDir: '/tmp/browseros-execution',
+        isRemoteAgentHarness: false,
         proxyStatus: { state: 'ready', toolCount: 3 },
         selectedServerNames: ['Slack', 'Google Docs'],
       },
@@ -135,7 +140,7 @@ describe('createMcpRoutes', () => {
     expect(connectCalls).toEqual(transportInstances)
   })
 
-  it('registers filesystem tools only for the remote Hermes source', async () => {
+  it('sets the remote agent harness flag only for the remote Hermes source', async () => {
     const app = createMcpRoutes({
       version: '0.0.0-test',
       browserSession: {} as never,
@@ -153,12 +158,14 @@ describe('createMcpRoutes', () => {
     expect(remoteHermesResponse.status).toBe(200)
     expect(serverCreations).toEqual([
       {
-        filesystemWorkingDir: undefined,
+        executionDir: '/tmp/browseros-execution',
+        isRemoteAgentHarness: false,
         proxyStatus: null,
         selectedServerNames: [],
       },
       {
-        filesystemWorkingDir: '/tmp/browseros-execution',
+        executionDir: '/tmp/browseros-execution',
+        isRemoteAgentHarness: true,
         proxyStatus: null,
         selectedServerNames: [],
       },

--- a/packages/browseros-agent/apps/server/tests/api/services/mcp/register-mcp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/mcp/register-mcp.test.ts
@@ -39,6 +39,15 @@ function createFakeServer() {
 
 describe('registerTools', () => {
   const originalInfo = logger.info
+  const filesystemToolNames = [
+    'filesystem_read',
+    'filesystem_write',
+    'filesystem_edit',
+    'filesystem_bash',
+    'filesystem_grep',
+    'filesystem_find',
+    'filesystem_ls',
+  ]
   let infoMessages: unknown[] = []
 
   beforeEach(() => {
@@ -59,10 +68,27 @@ describe('registerTools', () => {
 
     registerTools(fake.server as never, {
       browserSession: { pages: {} } as unknown as BrowserSession,
+      executionDir: '/tmp/browseros-execution',
+      isRemoteAgentHarness: false,
     })
 
     expect([...fake.handlers.keys()]).toEqual(BROWSER_TOOLS.map((t) => t.name))
     expect(fake.handlers.size).toBe(BROWSER_TOOLS.length)
+  })
+
+  it('registers filesystem tools for remote agent harness requests', () => {
+    const fake = createFakeServer()
+
+    registerTools(fake.server as never, {
+      browserSession: { pages: {} } as unknown as BrowserSession,
+      executionDir: '/tmp/browseros-execution',
+      isRemoteAgentHarness: true,
+    })
+
+    expect([...fake.handlers.keys()]).toEqual([
+      ...BROWSER_TOOLS.map((t) => t.name),
+      ...filesystemToolNames,
+    ])
   })
 
   it('samples repeated registration info logs without skipping tool registration', () => {
@@ -70,6 +96,8 @@ describe('registerTools', () => {
       const fake = createFakeServer()
       registerTools(fake.server as never, {
         browserSession: { pages: {} } as unknown as BrowserSession,
+        executionDir: '/tmp/browseros-execution',
+        isRemoteAgentHarness: false,
       })
 
       if (i === 1) {
@@ -125,6 +153,8 @@ describe('registerTools', () => {
       } as unknown as BrowserSession,
       defaultWindowId: 7,
       defaultTabGroupId: 'group-a',
+      executionDir: '/tmp/browseros-execution',
+      isRemoteAgentHarness: false,
     })
 
     const result = await fake.handlers.get('tabs')?.({


### PR DESCRIPTION
## Summary
- Rename remote Hermes MCP filesystem plumbing to an explicit `isRemoteAgentHarness` gate.
- Keep filesystem MCP tools scoped to `executionDir`, registered only when the remote Hermes source activates harness mode.
- Update route and registration tests for the new contract.

## Design
`/mcp` now treats `source=remote-hermes` as the remote agent harness signal. The route passes that boolean plus the server execution directory into MCP creation, and tool registration uses the boolean as the policy gate before adding filesystem tools.

## Test plan
- [x] `cd apps/server && bun test tests/api/routes/mcp.test.ts tests/api/services/mcp/register-mcp.test.ts`
- [x] `bun run lint && bun run typecheck && bun run test:main`
- [x] `bun run check && bun run test`
- [x] local Codex review: clean