### PR TITLE
fix: preserve remote harness output file access

### DIFF
--- a/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
@@ -10,37 +10,19 @@ import type { BrowserSession } from '../../browser/core/session'
 import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
 import { Sentry } from '../../lib/sentry'
-import {
-  type BrowserOutputFileAccess,
-  createBrowserOutputFileAccess,
-} from '../../tools/browser/output-file'
+import { createBrowserOutputFileAccess } from '../../tools/browser/output-file'
 import type { KlavisService } from '../services/klavis'
 import { createMcpServer } from '../services/mcp/mcp-server'
 import type { Env } from '../types'
 
 export const MANAGED_MCP_SERVERS_HEADER = 'X-BrowserOS-Managed-Mcp-Servers'
-export const REMOTE_HERMES_MCP_SOURCE = 'remote-hermes'
+export const REMOTE_AGENT_HARNESS_MCP_SOURCE = 'remote-agent-harness'
 
 interface McpRouteDeps {
   version: string
   browserSession: BrowserSession
   klavis?: KlavisService
   executionDir: string
-}
-
-/** Returns generated-output readback state; scoped harnesses share it across MCP requests. */
-function getRemoteHarnessOutputFileAccess(
-  accessByScope: Map<string, BrowserOutputFileAccess>,
-  scopeId: string | undefined,
-): BrowserOutputFileAccess {
-  if (!scopeId) return createBrowserOutputFileAccess()
-
-  const existing = accessByScope.get(scopeId)
-  if (existing) return existing
-
-  const access = createBrowserOutputFileAccess()
-  accessByScope.set(scopeId, access)
-  return access
 }
 
 function parseOptionalNumber(value: string | undefined): number | undefined {
@@ -76,10 +58,9 @@ export function parseManagedMcpServersHeader(
 
 export function createMcpRoutes(deps: McpRouteDeps) {
   const app = new Hono<Env>()
-  const remoteHarnessOutputFilesByScope = new Map<
-    string,
-    BrowserOutputFileAccess
-  >()
+  const remoteAgentHarness = {
+    outputFileAccess: createBrowserOutputFileAccess(),
+  }
 
   app.get('/', (c) =>
     c.json({
@@ -89,8 +70,8 @@ export function createMcpRoutes(deps: McpRouteDeps) {
   )
 
   app.post('/', async (c) => {
-    const scopeId = c.req.header('X-BrowserOS-Scope-Id')?.trim() || undefined
-    metrics.log('mcp.request', { scopeId: scopeId ?? 'ephemeral' })
+    const scopeId = c.req.header('X-BrowserOS-Scope-Id') || 'ephemeral'
+    metrics.log('mcp.request', { scopeId })
 
     const defaultWindowId = parseOptionalNumber(
       c.req.header('X-BrowserOS-Default-Window-Id'),
@@ -101,14 +82,10 @@ export function createMcpRoutes(deps: McpRouteDeps) {
       c.req.header(MANAGED_MCP_SERVERS_HEADER),
     )
 
-    const isRemoteAgentHarness =
-      c.req.query('source') === REMOTE_HERMES_MCP_SOURCE
-    const outputFileAccess = isRemoteAgentHarness
-      ? getRemoteHarnessOutputFileAccess(
-          remoteHarnessOutputFilesByScope,
-          scopeId,
-        )
-      : undefined
+    const harness =
+      c.req.query('source') === REMOTE_AGENT_HARNESS_MCP_SOURCE
+        ? remoteAgentHarness
+        : undefined
 
     // Per-request server + transport: no shared state, no race conditions,
     // no ID collisions. Required by MCP SDK 1.26.0+ security fix (GHSA-345p-7cg4-v4c7).
@@ -120,8 +97,7 @@ export function createMcpRoutes(deps: McpRouteDeps) {
       defaultWindowId,
       defaultTabGroupId,
       executionDir: deps.executionDir,
-      isRemoteAgentHarness,
-      outputFileAccess,
+      remoteAgentHarness: harness,
     })
     const transport = new StreamableHTTPTransport({
       sessionIdGenerator: undefined,
@@ -134,7 +110,7 @@ export function createMcpRoutes(deps: McpRouteDeps) {
     } catch (error) {
       Sentry.withScope((scope) => {
         scope.setTag('route', 'mcp')
-        scope.setTag('scopeId', scopeId ?? 'ephemeral')
+        scope.setTag('scopeId', scopeId)
         Sentry.captureException(error)
       })
       logger.error('Error handling MCP request', {

--- a/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
@@ -10,6 +10,10 @@ import type { BrowserSession } from '../../browser/core/session'
 import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
 import { Sentry } from '../../lib/sentry'
+import {
+  type BrowserOutputFileAccess,
+  createBrowserOutputFileAccess,
+} from '../../tools/browser/output-file'
 import type { KlavisService } from '../services/klavis'
 import { createMcpServer } from '../services/mcp/mcp-server'
 import type { Env } from '../types'
@@ -22,6 +26,21 @@ interface McpRouteDeps {
   browserSession: BrowserSession
   klavis?: KlavisService
   executionDir: string
+}
+
+/** Returns generated-output readback state; scoped harnesses share it across MCP requests. */
+function getRemoteHarnessOutputFileAccess(
+  accessByScope: Map<string, BrowserOutputFileAccess>,
+  scopeId: string | undefined,
+): BrowserOutputFileAccess {
+  if (!scopeId) return createBrowserOutputFileAccess()
+
+  const existing = accessByScope.get(scopeId)
+  if (existing) return existing
+
+  const access = createBrowserOutputFileAccess()
+  accessByScope.set(scopeId, access)
+  return access
 }
 
 function parseOptionalNumber(value: string | undefined): number | undefined {
@@ -57,6 +76,10 @@ export function parseManagedMcpServersHeader(
 
 export function createMcpRoutes(deps: McpRouteDeps) {
   const app = new Hono<Env>()
+  const remoteHarnessOutputFilesByScope = new Map<
+    string,
+    BrowserOutputFileAccess
+  >()
 
   app.get('/', (c) =>
     c.json({
@@ -66,8 +89,8 @@ export function createMcpRoutes(deps: McpRouteDeps) {
   )
 
   app.post('/', async (c) => {
-    const scopeId = c.req.header('X-BrowserOS-Scope-Id') || 'ephemeral'
-    metrics.log('mcp.request', { scopeId })
+    const scopeId = c.req.header('X-BrowserOS-Scope-Id')?.trim() || undefined
+    metrics.log('mcp.request', { scopeId: scopeId ?? 'ephemeral' })
 
     const defaultWindowId = parseOptionalNumber(
       c.req.header('X-BrowserOS-Default-Window-Id'),
@@ -80,6 +103,12 @@ export function createMcpRoutes(deps: McpRouteDeps) {
 
     const isRemoteAgentHarness =
       c.req.query('source') === REMOTE_HERMES_MCP_SOURCE
+    const outputFileAccess = isRemoteAgentHarness
+      ? getRemoteHarnessOutputFileAccess(
+          remoteHarnessOutputFilesByScope,
+          scopeId,
+        )
+      : undefined
 
     // Per-request server + transport: no shared state, no race conditions,
     // no ID collisions. Required by MCP SDK 1.26.0+ security fix (GHSA-345p-7cg4-v4c7).
@@ -92,6 +121,7 @@ export function createMcpRoutes(deps: McpRouteDeps) {
       defaultTabGroupId,
       executionDir: deps.executionDir,
       isRemoteAgentHarness,
+      outputFileAccess,
     })
     const transport = new StreamableHTTPTransport({
       sessionIdGenerator: undefined,
@@ -104,7 +134,7 @@ export function createMcpRoutes(deps: McpRouteDeps) {
     } catch (error) {
       Sentry.withScope((scope) => {
         scope.setTag('route', 'mcp')
-        scope.setTag('scopeId', scopeId)
+        scope.setTag('scopeId', scopeId ?? 'ephemeral')
         Sentry.captureException(error)
       })
       logger.error('Error handling MCP request', {

--- a/packages/browseros-agent/apps/server/src/api/server.ts
+++ b/packages/browseros-agent/apps/server/src/api/server.ts
@@ -14,7 +14,7 @@ import { getDb } from '../lib/db'
 import { logger } from '../lib/logger'
 import { Sentry } from '../lib/sentry'
 import { createApiRoutes } from './routes'
-import { REMOTE_HERMES_MCP_SOURCE } from './routes/mcp'
+import { REMOTE_AGENT_HARNESS_MCP_SOURCE } from './routes/mcp'
 import { KlavisService } from './services/klavis'
 import { RemoteHermesService } from './services/remote-hermes/remote-hermes-service'
 import type { HttpServerConfig } from './types'
@@ -68,7 +68,7 @@ export async function createHttpServer(config: HttpServerConfig) {
           }),
           resolveLocalMcpUrl: (server) =>
             server === 'browseros'
-              ? `http://127.0.0.1:${port}/mcp?source=${REMOTE_HERMES_MCP_SOURCE}`
+              ? `http://127.0.0.1:${port}/mcp?source=${REMOTE_AGENT_HARNESS_MCP_SOURCE}`
               : null,
         })
       : null

--- a/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-server.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-server.ts
@@ -7,10 +7,9 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { SetLevelRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import type { BrowserSession } from '../../../browser/core/session'
-import type { BrowserOutputFileAccess } from '../../../tools/browser/output-file'
 import type { ConnectorToolScope, KlavisService } from '../klavis'
 import { MCP_INSTRUCTIONS } from './mcp-prompt'
-import { registerTools } from './register-mcp'
+import { type RemoteAgentHarnessTools, registerTools } from './register-mcp'
 
 export interface McpServiceDeps {
   version: string
@@ -20,8 +19,7 @@ export interface McpServiceDeps {
   defaultWindowId?: number
   defaultTabGroupId?: string
   executionDir: string
-  isRemoteAgentHarness: boolean
-  outputFileAccess?: BrowserOutputFileAccess
+  remoteAgentHarness?: RemoteAgentHarnessTools
 }
 
 /** Creates a per-request BrowserOS MCP server with tools for the requested surface. */
@@ -44,8 +42,7 @@ export function createMcpServer(deps: McpServiceDeps): McpServer {
     defaultWindowId: deps.defaultWindowId,
     defaultTabGroupId: deps.defaultTabGroupId,
     executionDir: deps.executionDir,
-    isRemoteAgentHarness: deps.isRemoteAgentHarness,
-    outputFileAccess: deps.outputFileAccess,
+    remoteAgentHarness: deps.remoteAgentHarness,
   })
 
   deps.klavis?.registerMcpTools(server, deps.connectorScope)

--- a/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-server.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-server.ts
@@ -7,6 +7,7 @@
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { SetLevelRequestSchema } from '@modelcontextprotocol/sdk/types.js'
 import type { BrowserSession } from '../../../browser/core/session'
+import type { BrowserOutputFileAccess } from '../../../tools/browser/output-file'
 import type { ConnectorToolScope, KlavisService } from '../klavis'
 import { MCP_INSTRUCTIONS } from './mcp-prompt'
 import { registerTools } from './register-mcp'
@@ -20,6 +21,7 @@ export interface McpServiceDeps {
   defaultTabGroupId?: string
   executionDir: string
   isRemoteAgentHarness: boolean
+  outputFileAccess?: BrowserOutputFileAccess
 }
 
 /** Creates a per-request BrowserOS MCP server with tools for the requested surface. */
@@ -43,6 +45,7 @@ export function createMcpServer(deps: McpServiceDeps): McpServer {
     defaultTabGroupId: deps.defaultTabGroupId,
     executionDir: deps.executionDir,
     isRemoteAgentHarness: deps.isRemoteAgentHarness,
+    outputFileAccess: deps.outputFileAccess,
   })
 
   deps.klavis?.registerMcpTools(server, deps.connectorScope)

--- a/packages/browseros-agent/apps/server/src/api/services/mcp/register-mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/mcp/register-mcp.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { BrowserSession } from '../../../browser/core/session'
+import type { BrowserOutputFileAccess } from '../../../tools/browser/output-file'
 import {
   type BrowserToolDefaults,
   registerBrowserTools,
@@ -10,6 +11,7 @@ export interface RegisterToolsDeps extends BrowserToolDefaults {
   browserSession: BrowserSession
   executionDir: string
   isRemoteAgentHarness: boolean
+  outputFileAccess?: BrowserOutputFileAccess
 }
 
 /** Registers BrowserOS MCP tools for the current request. */
@@ -22,9 +24,13 @@ export function registerTools(
     defaultTabGroupId: deps.defaultTabGroupId,
   }
 
-  registerBrowserTools(mcpServer, deps.browserSession, defaults)
+  registerBrowserTools(mcpServer, deps.browserSession, defaults, {
+    outputFileAccess: deps.outputFileAccess,
+  })
 
   if (deps.isRemoteAgentHarness) {
-    registerFilesystemMcpTools(mcpServer, deps.executionDir)
+    registerFilesystemMcpTools(mcpServer, deps.executionDir, {
+      outputFileAccess: deps.outputFileAccess,
+    })
   }
 }

--- a/packages/browseros-agent/apps/server/src/api/services/mcp/register-mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/mcp/register-mcp.ts
@@ -7,11 +7,14 @@ import {
 } from '../../../tools/browser/register'
 import { registerFilesystemMcpTools } from '../../../tools/filesystem/register-mcp'
 
+export interface RemoteAgentHarnessTools {
+  outputFileAccess: BrowserOutputFileAccess
+}
+
 export interface RegisterToolsDeps extends BrowserToolDefaults {
   browserSession: BrowserSession
   executionDir: string
-  isRemoteAgentHarness: boolean
-  outputFileAccess?: BrowserOutputFileAccess
+  remoteAgentHarness?: RemoteAgentHarnessTools
 }
 
 /** Registers BrowserOS MCP tools for the current request. */
@@ -25,12 +28,12 @@ export function registerTools(
   }
 
   registerBrowserTools(mcpServer, deps.browserSession, defaults, {
-    outputFileAccess: deps.outputFileAccess,
+    outputFileAccess: deps.remoteAgentHarness?.outputFileAccess,
   })
 
-  if (deps.isRemoteAgentHarness) {
+  if (deps.remoteAgentHarness) {
     registerFilesystemMcpTools(mcpServer, deps.executionDir, {
-      outputFileAccess: deps.outputFileAccess,
+      outputFileAccess: deps.remoteAgentHarness.outputFileAccess,
     })
   }
 }

--- a/packages/browseros-agent/apps/server/src/lib/clients/remote-hermes/remote-hermes-client.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/remote-hermes/remote-hermes-client.ts
@@ -51,9 +51,7 @@ export interface RemoteHermesClientOptions {
 }
 
 export class RemoteHermesClient {
-  /** Stable per-install identifier. Exposed so the WS bridge can use it
-   *  as the `X-BrowserOS-Scope-Id` for tool calls dispatched back into
-   *  the laptop's local MCP. */
+  /** Stable per-install identifier used for worker auth and local MCP attribution. */
   readonly browserosId: string
   private readonly jwtSecret: string
   private readonly baseUrl: string

--- a/packages/browseros-agent/apps/server/src/lib/clients/remote-hermes/rpc-router.ts
+++ b/packages/browseros-agent/apps/server/src/lib/clients/remote-hermes/rpc-router.ts
@@ -11,12 +11,7 @@ const MODULE = 'remote-hermes'
 export interface RpcRouterDeps {
   /** Returns the local MCP base URL for a given logical server name. */
   resolveBaseUrl(server: string): string | null
-  /**
-   * Scope id to attach as `X-BrowserOS-Scope-Id`. v1 uses a constant per
-   * install (the browserosId) so all remote-hermes tool calls share state;
-   * threading per-turn conversationId requires the worker to propagate it
-   * in the rpc.request frame (Open Item #2 in the design doc).
-   */
+  /** Scope id attached as `X-BrowserOS-Scope-Id` for local MCP attribution. */
   scopeId: string
   /** Provider id forwarded as `X-BrowserOS-Agent-Id` for audit. */
   agentId: string

--- a/packages/browseros-agent/apps/server/src/tools/browser/register.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/register.ts
@@ -5,6 +5,10 @@ import { logger } from '../../lib/logger'
 import { metrics } from '../../lib/metrics'
 import { shouldLogToolRegistration } from '../registration-log-sampling'
 import { executeTool } from './framework'
+import {
+  type BrowserOutputFileAccess,
+  withBrowserOutputFileAccess,
+} from './output-file'
 import { BROWSER_TOOLS } from './registry'
 
 // The SDK's registerTool is heavily overloaded/generic; retyping it to a concrete signature
@@ -31,6 +35,10 @@ export interface BrowserToolDefaults {
   defaultTabGroupId?: string
 }
 
+export interface BrowserToolRegistrationOptions {
+  outputFileAccess?: BrowserOutputFileAccess
+}
+
 /**
  * Registers the browser-core tool surface on an MCP server, all bound to one BrowserSession.
  */
@@ -38,6 +46,7 @@ export function registerBrowserTools(
   server: McpServer,
   session: BrowserSession,
   defaults: BrowserToolDefaults = {},
+  options: BrowserToolRegistrationOptions = {},
 ): void {
   const register = server.registerTool.bind(server) as unknown as RegisterFn
 
@@ -54,11 +63,15 @@ export function registerBrowserTools(
       async (args, extra) => {
         const startTime = performance.now()
         try {
-          const result = await executeTool(tool, args, {
-            session,
-            ...defaults,
-            signal: extra?.signal,
-          })
+          const result = await withBrowserOutputFileAccess(
+            options.outputFileAccess,
+            () =>
+              executeTool(tool, args, {
+                session,
+                ...defaults,
+                signal: extra?.signal,
+              }),
+          )
           metrics.log('tool_executed', {
             tool_name: tool.name,
             duration_ms: Math.round(performance.now() - startTime),

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/build-toolset.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/build-toolset.ts
@@ -4,12 +4,19 @@ import { createEditTool } from './edit'
 import { createFindTool } from './find'
 import { createGrepTool } from './grep'
 import { createLsTool } from './ls'
-import { createReadTool } from './read'
+import { createReadTool, type ReadToolOptions } from './read'
 import { createWriteTool } from './write'
 
-export function buildFilesystemToolSet(cwd: string): ToolSet {
+export interface FilesystemToolSetOptions {
+  read?: ReadToolOptions
+}
+
+export function buildFilesystemToolSet(
+  cwd: string,
+  options: FilesystemToolSetOptions = {},
+): ToolSet {
   return {
-    filesystem_read: createReadTool(cwd),
+    filesystem_read: createReadTool(cwd, options.read),
     filesystem_write: createWriteTool(cwd),
     filesystem_edit: createEditTool(cwd),
     filesystem_bash: createBashTool(cwd),

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/read.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/read.ts
@@ -20,6 +20,7 @@ const TOOL_NAME = 'filesystem_read'
 
 export interface ReadToolOptions {
   allowedOutputPaths?: ReadonlySet<string>
+  requireAllowedOutputPath?: boolean
 }
 
 function createImageResult(
@@ -133,6 +134,7 @@ async function resolveReadPath(
   cwd: string | undefined,
   inputPath: string,
   allowedOutputPaths: ReadonlySet<string>,
+  requireAllowedOutputPath: boolean,
 ): Promise<string> {
   if (!cwd)
     return await resolveGeneratedOutputPath(inputPath, allowedOutputPaths)
@@ -141,6 +143,9 @@ async function resolveReadPath(
     return await resolveWorkspacePath(cwd, inputPath)
   } catch (error) {
     if (error instanceof Error && (await isBrowserosStatePath(inputPath))) {
+      if (requireAllowedOutputPath) {
+        return await resolveGeneratedOutputPath(inputPath, allowedOutputPaths)
+      }
       return await resolveBrowserToolOutputPath(inputPath)
     }
     throw error
@@ -150,17 +155,18 @@ async function resolveReadPath(
 /** Creates the read tool for workspace files, or generated browser outputs when no workspace exists. */
 export function createReadTool(cwd?: string, options: ReadToolOptions = {}) {
   const allowedOutputPaths = options.allowedOutputPaths ?? new Set<string>()
+  const supportsGeneratedOutputs = Boolean(options.allowedOutputPaths)
 
   return tool({
     description: cwd
-      ? `Read a file from the filesystem. Returns text content with line numbers, or image data for image files. Text reads are limited to ${MAX_READ_LINES} lines and ${MAX_READ_CHARS} characters per call. Use offset and limit to paginate through large files.`
+      ? `Read a file from the filesystem. Returns text content with line numbers, or image data for image files. Text reads are limited to ${MAX_READ_LINES} lines and ${MAX_READ_CHARS} characters per call. Use offset and limit to paginate through large files.${supportsGeneratedOutputs ? ' Also accepts absolute BrowserOS-generated output file paths returned by browser tools.' : ''}`
       : `Read BrowserOS-generated tool output files by absolute path. Returns text content with line numbers, or image data for image files. Text reads are limited to ${MAX_READ_LINES} lines and ${MAX_READ_CHARS} characters per call. Use offset and limit to paginate through large files.`,
     inputSchema: z.object({
       path: z
         .string()
         .describe(
           cwd
-            ? 'File path relative to the selected workspace'
+            ? `File path relative to the selected workspace${supportsGeneratedOutputs ? ', or an absolute BrowserOS-generated output path returned by a browser tool' : ''}`
             : 'Absolute BrowserOS-generated tool output path returned by a browser tool',
         ),
       offset: z
@@ -180,6 +186,7 @@ export function createReadTool(cwd?: string, options: ReadToolOptions = {}) {
           cwd,
           params.path,
           allowedOutputPaths,
+          options.requireAllowedOutputPath ?? false,
         )
         const ext = extname(resolved).toLowerCase()
 

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/register-mcp.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/register-mcp.ts
@@ -13,6 +13,7 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { z } from 'zod'
 import { logger } from '../../lib/logger'
+import type { BrowserOutputFileAccess } from '../browser/output-file'
 import { shouldLogToolRegistration } from '../registration-log-sampling'
 import { buildFilesystemToolSet } from './build-toolset'
 import type { FilesystemToolResult } from './utils'
@@ -43,15 +44,22 @@ type McpRegisterFn = (
   }>,
 ) => void
 
+export interface RegisterFilesystemMcpToolsOptions {
+  outputFileAccess?: BrowserOutputFileAccess
+}
+
 export function registerFilesystemMcpTools(
   server: McpServer,
   cwd: string,
+  options: RegisterFilesystemMcpToolsOptions = {},
 ): void {
   const register = server.registerTool.bind(server) as unknown as McpRegisterFn
-  const tools = buildFilesystemToolSet(cwd) as unknown as Record<
-    string,
-    AiSdkToolLike
-  >
+  const tools = buildFilesystemToolSet(cwd, {
+    read: {
+      allowedOutputPaths: options.outputFileAccess?.paths,
+      requireAllowedOutputPath: Boolean(options.outputFileAccess),
+    },
+  }) as unknown as Record<string, AiSdkToolLike>
 
   for (const [name, tool] of Object.entries(tools)) {
     register(

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/register-mcp.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/register-mcp.ts
@@ -6,8 +6,7 @@
  * Bridges the AI-SDK filesystem toolset onto the laptop's MCP server.
  * The AI-SDK and MCP tool registries are independent (the local agent
  * loop never dials /mcp for its own tools), so registering here only
- * affects external MCP callers — today that's remote-hermes via the
- * WS RPC bridge.
+ * affects external remote-harness MCP callers.
  */
 
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'

--- a/packages/browseros-agent/apps/server/tests/api/routes/mcp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/mcp.test.ts
@@ -7,6 +7,7 @@ import type {
 interface McpServerCreation {
   executionDir: string | undefined
   isRemoteAgentHarness: boolean | undefined
+  outputFileAccess: unknown
   proxyStatus: KlavisProxyStatus | null
   selectedServerNames: readonly string[] | undefined
 }
@@ -29,10 +30,12 @@ const createMcpServerSpy = mock(
     connectorScope?: ConnectorToolScope
     executionDir?: string
     isRemoteAgentHarness?: boolean
+    outputFileAccess?: unknown
   }) => {
     serverCreations.push({
       executionDir: deps.executionDir,
       isRemoteAgentHarness: deps.isRemoteAgentHarness,
+      outputFileAccess: deps.outputFileAccess,
       proxyStatus: deps.klavis?.getProxyStatus() ?? null,
       selectedServerNames: deps.connectorScope?.selectedServerNames,
     })
@@ -126,12 +129,14 @@ describe('createMcpRoutes', () => {
       {
         executionDir: '/tmp/browseros-execution',
         isRemoteAgentHarness: false,
+        outputFileAccess: undefined,
         proxyStatus: { state: 'connecting' },
         selectedServerNames: [],
       },
       {
         executionDir: '/tmp/browseros-execution',
         isRemoteAgentHarness: false,
+        outputFileAccess: undefined,
         proxyStatus: { state: 'ready', toolCount: 3 },
         selectedServerNames: ['Slack', 'Google Docs'],
       },
@@ -160,15 +165,96 @@ describe('createMcpRoutes', () => {
       {
         executionDir: '/tmp/browseros-execution',
         isRemoteAgentHarness: false,
+        outputFileAccess: undefined,
         proxyStatus: null,
         selectedServerNames: [],
       },
       {
         executionDir: '/tmp/browseros-execution',
         isRemoteAgentHarness: true,
+        outputFileAccess: expect.any(Object),
         proxyStatus: null,
         selectedServerNames: [],
       },
     ])
+  })
+
+  it('keeps remote agent harness output-file access stable by scope', async () => {
+    const app = createMcpRoutes({
+      version: '0.0.0-test',
+      browserSession: {} as never,
+      executionDir: '/tmp/browseros-execution',
+    })
+
+    await postMcp(
+      app,
+      { 'X-BrowserOS-Scope-Id': 'scope-a' },
+      '/?source=remote-hermes',
+    )
+    await postMcp(
+      app,
+      { 'X-BrowserOS-Scope-Id': 'scope-a' },
+      '/?source=remote-hermes',
+    )
+    await postMcp(
+      app,
+      { 'X-BrowserOS-Scope-Id': 'scope-b' },
+      '/?source=remote-hermes',
+    )
+
+    expect(serverCreations[0].outputFileAccess).toBe(
+      serverCreations[1].outputFileAccess,
+    )
+    expect(serverCreations[2].outputFileAccess).not.toBe(
+      serverCreations[0].outputFileAccess,
+    )
+  })
+
+  it('does not share remote agent harness output-file access without a scope', async () => {
+    const app = createMcpRoutes({
+      version: '0.0.0-test',
+      browserSession: {} as never,
+      executionDir: '/tmp/browseros-execution',
+    })
+
+    await postMcp(app, {}, '/?source=remote-hermes')
+    await postMcp(app, {}, '/?source=remote-hermes')
+
+    expect(serverCreations[0].outputFileAccess).toEqual(expect.any(Object))
+    expect(serverCreations[1].outputFileAccess).toEqual(expect.any(Object))
+    expect(serverCreations[0].outputFileAccess).not.toBe(
+      serverCreations[1].outputFileAccess,
+    )
+  })
+
+  it('does not silently evict scoped remote agent harness output-file access', async () => {
+    const app = createMcpRoutes({
+      version: '0.0.0-test',
+      browserSession: {} as never,
+      executionDir: '/tmp/browseros-execution',
+    })
+
+    await postMcp(
+      app,
+      { 'X-BrowserOS-Scope-Id': 'scope-0' },
+      '/?source=remote-hermes',
+    )
+    const firstScopeAccess = serverCreations[0].outputFileAccess
+
+    for (let i = 1; i <= 80; i++) {
+      await postMcp(
+        app,
+        { 'X-BrowserOS-Scope-Id': `scope-${i}` },
+        '/?source=remote-hermes',
+      )
+    }
+
+    await postMcp(
+      app,
+      { 'X-BrowserOS-Scope-Id': 'scope-0' },
+      '/?source=remote-hermes',
+    )
+
+    expect(serverCreations.at(-1)?.outputFileAccess).toBe(firstScopeAccess)
   })
 })

--- a/packages/browseros-agent/apps/server/tests/api/routes/mcp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/mcp.test.ts
@@ -6,8 +6,7 @@ import type {
 
 interface McpServerCreation {
   executionDir: string | undefined
-  isRemoteAgentHarness: boolean | undefined
-  outputFileAccess: unknown
+  remoteAgentHarness: { outputFileAccess?: unknown } | undefined
   proxyStatus: KlavisProxyStatus | null
   selectedServerNames: readonly string[] | undefined
 }
@@ -29,13 +28,11 @@ const createMcpServerSpy = mock(
     klavis?: { getProxyStatus(): KlavisProxyStatus }
     connectorScope?: ConnectorToolScope
     executionDir?: string
-    isRemoteAgentHarness?: boolean
-    outputFileAccess?: unknown
+    remoteAgentHarness?: { outputFileAccess?: unknown }
   }) => {
     serverCreations.push({
       executionDir: deps.executionDir,
-      isRemoteAgentHarness: deps.isRemoteAgentHarness,
-      outputFileAccess: deps.outputFileAccess,
+      remoteAgentHarness: deps.remoteAgentHarness,
       proxyStatus: deps.klavis?.getProxyStatus() ?? null,
       selectedServerNames: deps.connectorScope?.selectedServerNames,
     })
@@ -128,15 +125,13 @@ describe('createMcpRoutes', () => {
     expect(serverCreations).toEqual([
       {
         executionDir: '/tmp/browseros-execution',
-        isRemoteAgentHarness: false,
-        outputFileAccess: undefined,
+        remoteAgentHarness: undefined,
         proxyStatus: { state: 'connecting' },
         selectedServerNames: [],
       },
       {
         executionDir: '/tmp/browseros-execution',
-        isRemoteAgentHarness: false,
-        outputFileAccess: undefined,
+        remoteAgentHarness: undefined,
         proxyStatus: { state: 'ready', toolCount: 3 },
         selectedServerNames: ['Slack', 'Google Docs'],
       },
@@ -145,7 +140,7 @@ describe('createMcpRoutes', () => {
     expect(connectCalls).toEqual(transportInstances)
   })
 
-  it('sets the remote agent harness flag only for the remote Hermes source', async () => {
+  it('sets the remote agent harness context only for the remote harness source', async () => {
     const app = createMcpRoutes({
       version: '0.0.0-test',
       browserSession: {} as never,
@@ -153,108 +148,42 @@ describe('createMcpRoutes', () => {
     })
 
     const defaultResponse = await postMcp(app)
-    const remoteHermesResponse = await postMcp(
+    const remoteHarnessResponse = await postMcp(
       app,
       {},
-      '/?source=remote-hermes',
+      '/?source=remote-agent-harness',
     )
 
     expect(defaultResponse.status).toBe(200)
-    expect(remoteHermesResponse.status).toBe(200)
+    expect(remoteHarnessResponse.status).toBe(200)
     expect(serverCreations).toEqual([
       {
         executionDir: '/tmp/browseros-execution',
-        isRemoteAgentHarness: false,
-        outputFileAccess: undefined,
+        remoteAgentHarness: undefined,
         proxyStatus: null,
         selectedServerNames: [],
       },
       {
         executionDir: '/tmp/browseros-execution',
-        isRemoteAgentHarness: true,
-        outputFileAccess: expect.any(Object),
+        remoteAgentHarness: { outputFileAccess: expect.any(Object) },
         proxyStatus: null,
         selectedServerNames: [],
       },
     ])
   })
 
-  it('keeps remote agent harness output-file access stable by scope', async () => {
+  it('keeps remote agent harness context stable by source', async () => {
     const app = createMcpRoutes({
       version: '0.0.0-test',
       browserSession: {} as never,
       executionDir: '/tmp/browseros-execution',
     })
 
-    await postMcp(
-      app,
-      { 'X-BrowserOS-Scope-Id': 'scope-a' },
-      '/?source=remote-hermes',
+    await postMcp(app, {}, '/?source=remote-agent-harness')
+    await postMcp(app, {}, '/?source=remote-agent-harness')
+
+    expect(serverCreations[0].remoteAgentHarness).toBe(
+      serverCreations[1].remoteAgentHarness,
     )
-    await postMcp(
-      app,
-      { 'X-BrowserOS-Scope-Id': 'scope-a' },
-      '/?source=remote-hermes',
-    )
-    await postMcp(
-      app,
-      { 'X-BrowserOS-Scope-Id': 'scope-b' },
-      '/?source=remote-hermes',
-    )
-
-    expect(serverCreations[0].outputFileAccess).toBe(
-      serverCreations[1].outputFileAccess,
-    )
-    expect(serverCreations[2].outputFileAccess).not.toBe(
-      serverCreations[0].outputFileAccess,
-    )
-  })
-
-  it('does not share remote agent harness output-file access without a scope', async () => {
-    const app = createMcpRoutes({
-      version: '0.0.0-test',
-      browserSession: {} as never,
-      executionDir: '/tmp/browseros-execution',
-    })
-
-    await postMcp(app, {}, '/?source=remote-hermes')
-    await postMcp(app, {}, '/?source=remote-hermes')
-
-    expect(serverCreations[0].outputFileAccess).toEqual(expect.any(Object))
-    expect(serverCreations[1].outputFileAccess).toEqual(expect.any(Object))
-    expect(serverCreations[0].outputFileAccess).not.toBe(
-      serverCreations[1].outputFileAccess,
-    )
-  })
-
-  it('does not silently evict scoped remote agent harness output-file access', async () => {
-    const app = createMcpRoutes({
-      version: '0.0.0-test',
-      browserSession: {} as never,
-      executionDir: '/tmp/browseros-execution',
-    })
-
-    await postMcp(
-      app,
-      { 'X-BrowserOS-Scope-Id': 'scope-0' },
-      '/?source=remote-hermes',
-    )
-    const firstScopeAccess = serverCreations[0].outputFileAccess
-
-    for (let i = 1; i <= 80; i++) {
-      await postMcp(
-        app,
-        { 'X-BrowserOS-Scope-Id': `scope-${i}` },
-        '/?source=remote-hermes',
-      )
-    }
-
-    await postMcp(
-      app,
-      { 'X-BrowserOS-Scope-Id': 'scope-0' },
-      '/?source=remote-hermes',
-    )
-
-    expect(serverCreations.at(-1)?.outputFileAccess).toBe(firstScopeAccess)
   })
 })

--- a/packages/browseros-agent/apps/server/tests/api/services/mcp/register-mcp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/mcp/register-mcp.test.ts
@@ -1,7 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { TOOL_LIMITS } from '@browseros/shared/constants/limits'
 import { registerTools } from '../../../../src/api/services/mcp/register-mcp'
 import type { BrowserSession } from '../../../../src/browser/core/session'
 import { logger } from '../../../../src/lib/logger'
+import { createBrowserOutputFileAccess } from '../../../../src/tools/browser/output-file'
 import { BROWSER_TOOLS } from '../../../../src/tools/browser/registry'
 import { resetToolRegistrationLogSamplingForTests } from '../../../../src/tools/registration-log-sampling'
 
@@ -37,8 +42,41 @@ function createFakeServer() {
   }
 }
 
+function textOf(result: Awaited<ReturnType<RegisteredHandler>> | undefined) {
+  if (!Array.isArray(result?.content)) return ''
+  return result.content
+    .filter(
+      (item): item is { type: 'text'; text: string } =>
+        typeof item === 'object' &&
+        item !== null &&
+        'type' in item &&
+        item.type === 'text' &&
+        'text' in item &&
+        typeof item.text === 'string',
+    )
+    .map((item) => item.text)
+    .join('\n')
+}
+
+async function withBrowserosDir<T>(run: () => Promise<T>): Promise<T> {
+  const previous = process.env.BROWSEROS_DIR
+  const browserosDir = await mkdtemp(join(tmpdir(), 'mcp-output-test-'))
+  process.env.BROWSEROS_DIR = browserosDir
+  try {
+    return await run()
+  } finally {
+    if (previous === undefined) {
+      delete process.env.BROWSEROS_DIR
+    } else {
+      process.env.BROWSEROS_DIR = previous
+    }
+    await rm(browserosDir, { recursive: true, force: true })
+  }
+}
+
 describe('registerTools', () => {
   const originalInfo = logger.info
+  const originalError = logger.error
   const filesystemToolNames = [
     'filesystem_read',
     'filesystem_write',
@@ -56,10 +94,12 @@ describe('registerTools', () => {
     logger.info = ((message: string) => {
       infoMessages.push(message)
     }) as typeof logger.info
+    logger.error = (() => {}) as typeof logger.error
   })
 
   afterEach(() => {
     logger.info = originalInfo
+    logger.error = originalError
     resetToolRegistrationLogSamplingForTests()
   })
 
@@ -89,6 +129,74 @@ describe('registerTools', () => {
       ...BROWSER_TOOLS.map((t) => t.name),
       ...filesystemToolNames,
     ])
+  })
+
+  it('lets remote agent harness read browser-generated output files across MCP registrations', async () => {
+    await withBrowserosDir(async () => {
+      const outputFileAccess = createBrowserOutputFileAccess()
+      const largeText = 'remote harness generated output\n'.repeat(
+        Math.ceil(TOOL_LIMITS.INLINE_PAGE_CONTENT_MAX_CHARS / 32) + 1,
+      )
+      const browserSession = {
+        pages: {
+          getSession: async () => ({
+            session: {
+              Runtime: {
+                evaluate: async () => ({ result: { value: largeText } }),
+              },
+            },
+          }),
+          getInfo: () => ({ url: 'https://example.com' }),
+        },
+      } as unknown as BrowserSession
+
+      const browserRequest = createFakeServer()
+      registerTools(browserRequest.server as never, {
+        browserSession,
+        executionDir: '/tmp/browseros-execution',
+        isRemoteAgentHarness: true,
+        outputFileAccess,
+      })
+
+      const browserResult = await browserRequest.handlers.get('read')?.({
+        page: 1,
+        format: 'text',
+      })
+      const savedPath = textOf(browserResult).match(/saved to: (.+\.txt)/)?.[1]
+
+      expect(savedPath).toBeTruthy()
+      expect(outputFileAccess.paths.has(savedPath ?? '')).toBe(true)
+
+      const filesystemRequest = createFakeServer()
+      registerTools(filesystemRequest.server as never, {
+        browserSession: { pages: {} } as unknown as BrowserSession,
+        executionDir: '/tmp/browseros-execution',
+        isRemoteAgentHarness: true,
+        outputFileAccess,
+      })
+
+      const readResult = await filesystemRequest.handlers.get(
+        'filesystem_read',
+      )?.({ path: savedPath })
+
+      expect(readResult?.isError).toBeFalsy()
+      expect(textOf(readResult)).toContain('remote harness generated output')
+
+      const otherScope = createFakeServer()
+      registerTools(otherScope.server as never, {
+        browserSession: { pages: {} } as unknown as BrowserSession,
+        executionDir: '/tmp/browseros-execution',
+        isRemoteAgentHarness: true,
+        outputFileAccess: createBrowserOutputFileAccess(),
+      })
+
+      const denied = await otherScope.handlers.get('filesystem_read')?.({
+        path: savedPath,
+      })
+
+      expect(denied?.isError).toBe(true)
+      expect(textOf(denied)).toContain('returned in this session')
+    })
   })
 
   it('samples repeated registration info logs without skipping tool registration', () => {

--- a/packages/browseros-agent/apps/server/tests/api/services/mcp/register-mcp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/mcp/register-mcp.test.ts
@@ -109,7 +109,6 @@ describe('registerTools', () => {
     registerTools(fake.server as never, {
       browserSession: { pages: {} } as unknown as BrowserSession,
       executionDir: '/tmp/browseros-execution',
-      isRemoteAgentHarness: false,
     })
 
     expect([...fake.handlers.keys()]).toEqual(BROWSER_TOOLS.map((t) => t.name))
@@ -122,7 +121,9 @@ describe('registerTools', () => {
     registerTools(fake.server as never, {
       browserSession: { pages: {} } as unknown as BrowserSession,
       executionDir: '/tmp/browseros-execution',
-      isRemoteAgentHarness: true,
+      remoteAgentHarness: {
+        outputFileAccess: createBrowserOutputFileAccess(),
+      },
     })
 
     expect([...fake.handlers.keys()]).toEqual([
@@ -154,8 +155,7 @@ describe('registerTools', () => {
       registerTools(browserRequest.server as never, {
         browserSession,
         executionDir: '/tmp/browseros-execution',
-        isRemoteAgentHarness: true,
-        outputFileAccess,
+        remoteAgentHarness: { outputFileAccess },
       })
 
       const browserResult = await browserRequest.handlers.get('read')?.({
@@ -171,8 +171,7 @@ describe('registerTools', () => {
       registerTools(filesystemRequest.server as never, {
         browserSession: { pages: {} } as unknown as BrowserSession,
         executionDir: '/tmp/browseros-execution',
-        isRemoteAgentHarness: true,
-        outputFileAccess,
+        remoteAgentHarness: { outputFileAccess },
       })
 
       const readResult = await filesystemRequest.handlers.get(
@@ -182,15 +181,16 @@ describe('registerTools', () => {
       expect(readResult?.isError).toBeFalsy()
       expect(textOf(readResult)).toContain('remote harness generated output')
 
-      const otherScope = createFakeServer()
-      registerTools(otherScope.server as never, {
+      const otherHarness = createFakeServer()
+      registerTools(otherHarness.server as never, {
         browserSession: { pages: {} } as unknown as BrowserSession,
         executionDir: '/tmp/browseros-execution',
-        isRemoteAgentHarness: true,
-        outputFileAccess: createBrowserOutputFileAccess(),
+        remoteAgentHarness: {
+          outputFileAccess: createBrowserOutputFileAccess(),
+        },
       })
 
-      const denied = await otherScope.handlers.get('filesystem_read')?.({
+      const denied = await otherHarness.handlers.get('filesystem_read')?.({
         path: savedPath,
       })
 
@@ -205,7 +205,6 @@ describe('registerTools', () => {
       registerTools(fake.server as never, {
         browserSession: { pages: {} } as unknown as BrowserSession,
         executionDir: '/tmp/browseros-execution',
-        isRemoteAgentHarness: false,
       })
 
       if (i === 1) {
@@ -262,7 +261,6 @@ describe('registerTools', () => {
       defaultWindowId: 7,
       defaultTabGroupId: 'group-a',
       executionDir: '/tmp/browseros-execution',
-      isRemoteAgentHarness: false,
     })
 
     const result = await fake.handlers.get('tabs')?.({


### PR DESCRIPTION
## Summary
- Keep remote harness MCP filesystem tools behind the generic `source=remote-agent-harness` gate.
- Use one `remoteAgentHarness` context to carry generated BrowserOS output-file access through MCP registration.
- Allow remote harness `filesystem_read` to read browser tool output files returned through that harness, while default MCP stays browser-only.

## Design
The route detects remote harness callers from the query parameter and passes a single optional `remoteAgentHarness` object into MCP server creation. Its presence is the only internal signal for registering filesystem tools, and the same object carries the output-file access used by browser tools and `filesystem_read`.

Workspace files remain scoped through `executionDir`. Browser-generated output files remain allow-listed by the output-file access object, so `filesystem_read` can read paths returned by browser tools without exposing arbitrary BrowserOS state paths.

## Test plan
- `cd apps/server && bun test tests/api/routes/mcp.test.ts tests/api/services/mcp/register-mcp.test.ts`
- `bun run lint`
- `bun run typecheck`
- `bun run check`
- `bun run test`

Not merging per review request.
