### PR TITLE
docs: add v0.43.0-v0.46.0 to the changelog

### DIFF
--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -7,6 +7,37 @@ All notable changes to BrowserOS are documented here. For the full release histo
 
 ---
 
+## v0.46.0
+<sub>June 17, 2026</sub>
+
+- **Claude Code & Codex in your browser** — The agent harness now bundles full coding agents. Claude Code and Codex plug straight into the assistant, so you can drive your browser with the agent — and the subscription — you already use.
+- **A brand new experience** — A redesigned new tab, a calmer composer, and a rebuilt command center for switching between agents. The whole assistant is cleaner, faster to reach, and easier to live in.
+- **New MCP tools** — A tighter, more reliable browser tool surface for agents, rebuilt from the ground up. Plus one-click install of BrowserOS as an MCP server into the agents you already run, with automatic URL sync.
+- **Chromium 148** — Updated to the latest Chromium base with all recent upstream fixes and security patches
+- **Streamlined** — We've pulled back a few features that weren't getting much use — Skills, Soul, and Memory — so we can focus and ship better versions soon.
+
+---
+
+## v0.44.0
+<sub>March 20, 2026</sub>
+
+- **ChatGPT Pro & GitHub Copilot** — Already paying for ChatGPT Pro, Plus, or GitHub Copilot? Use that subscription to automate browser tasks in BrowserOS at no extra cost — just log in with your existing account.
+- **Voice input** — Talk to your agent instead of typing. The chat bar now accepts voice input for any query.
+- **Smarter agent** — Overhauled agent grounding for more reliable and precise browser actions.
+- **Bug fixes & reliability** — Improved memory tools, fixed fill tool issues, new tab layout fixes, and numerous stability improvements across the board.
+
+---
+
+## v0.43.0
+<sub>March 12, 2026</sub>
+
+- **Skills** — Reusable instructions that teach your agent how to handle specific tasks. Ships with 12 built-in skills like deep research, price comparison, and form filling — and you can create your own.
+- **Memory** — Your assistant now remembers you across conversations. Core memory stores permanent facts like your name and projects, while daily notes capture session context and auto-expire after 30 days. Everything stays local on your machine.
+- **Kimi K2.5** — In partnership with Moonshot AI, Kimi K2.5 is now the default model in BrowserOS — open-source, multimodal, and great for browser automation. Bring your own key from [platform.moonshot.ai](https://platform.moonshot.ai/) anytime.
+- **SOUL.md** — Shape your assistant's personality, tone, and boundaries. It evolves on its own as you interact — the more you use it, the more it feels like yours.
+
+---
+
 ## v0.42.0
 <sub>March 9, 2026</sub>
 


### PR DESCRIPTION
## Summary
- Backfills the three BrowserOS **product** releases shipped since the changelog's previous top entry (v0.42.0): **v0.46.0** (Jun 17), **v0.44.0** (Mar 20), **v0.43.0** (Mar 12).
- Highlights are distilled from each GitHub release's notes into the changelog's existing concise, bold-label bullet style.
- Only BrowserOS product releases are included — not Server / Extension / CLI / Agent SDK releases.

## Approach
A single localized insert at the top of `docs/changelog.mdx`; no existing entries are touched. Dates use Pacific Time to match the rest of the file (note v0.44.0's `2026-03-21T00:36Z` UTC publish is **March 20** in PT).

Following #1323 (which removed the Skills / Soul / Memory / LLM Chat Hub / Workflows / Qwen pages and de-linked them from changelog history), the new entries reference those features by name only — **no `[Read more →]` links to removed pages**. The only link added is the external `platform.moonshot.ai` for Kimi K2.5. Entries are text-only, consistent with the existing text-only entries (v0.41.0, v0.40.1, v0.38.0).

## Test plan
- [x] `git diff --check` clean
- [x] `mint broken-links` → no broken links
- [x] Entries render in descending order (v0.46.0 → v0.44.0 → v0.43.0 → v0.42.0) with correct dates
- [x] No links to any page removed in #1323