### PR TITLE
feat(agent-mcp-ui): single source for the MCP endpoint URL shown to humans

### DIFF
--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/mcp-endpoint.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/mcp-endpoint.ts
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Canonical source for the URL the UI advertises as the MCP endpoint
+ * for an agent, the CLI snippet shown alongside it, and the slug
+ * parser used to read URLs that the server-rendered profile responds
+ * with. Every "copy URL" widget and every "add to host agent" config
+ * the wizard / directory pages render flows through these helpers,
+ * so the future cutover is confined to this file.
+ *
+ * TODO(temporary cockpit mount): while `apps/agent-mcp-interface`
+ * lives as a sub-route under `apps/server` (mounted at
+ * `/cockpit` so it can borrow the server's live BrowserSession and
+ * CDP attach), this builder targets the mounted shape
+ * `http://127.0.0.1:9100/cockpit/mcp/<slug>`. When the BrowserOS
+ * Chromium runtime ships direct CDP integration for the
+ * agent-mcp-interface package, the interface will bind its own port
+ * and `buildMcpEndpointUrl` will return
+ * `http://127.0.0.1:<interface-port>/mcp/<slug>`. The unmount lives
+ * in three commits: (1) drop the cockpit mount from
+ * `apps/server/src/api/routes/index.ts`, (2) flip the constants
+ * imported below, (3) remove the legacy `/cockpit/mcp/<slug>` arm
+ * from `slugFromMcpEndpointUrl` once profile migration has run.
+ */
+
+import {
+  COCKPIT_MOUNT_PREFIX,
+  PROD_API_PORT,
+} from '@browseros/agent-mcp-interface/shared/port'
+
+/**
+ * URL the UI shows in the copy widget and embeds in host-agent config
+ * snippets. Matches the URL `apps/agent-mcp-interface` returns from
+ * its `agents` service when running mounted, so a profile created
+ * server-side and one composed client-side produce identical strings.
+ */
+export function buildMcpEndpointUrl(slug: string): string {
+  return `http://127.0.0.1:${PROD_API_PORT}${COCKPIT_MOUNT_PREFIX}/mcp/${slug}`
+}
+
+/**
+ * Pulls the slug segment out of an MCP URL. Tolerates both the
+ * mounted shape (`/cockpit/mcp/<slug>`) and the future direct shape
+ * (`/mcp/<slug>`). Returns an empty string when neither matches so
+ * callers can fall back to a known id.
+ */
+export function slugFromMcpEndpointUrl(url: string): string {
+  const match = url.match(/\/mcp\/([^/?#]+)/)
+  return match?.[1] ?? ''
+}
+
+/**
+ * CLI snippet shown next to the URL widgets and copied as the
+ * "add to host agent" command. Lives here so the directory and the
+ * wizard render identical text from a single source.
+ */
+export function buildMcpCliCommand(slug: string): string {
+  return `mcp add ${slug}`
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/mcp.helpers.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/mcp.helpers.ts
@@ -1,21 +1,21 @@
 import type { AgentProfile } from '@/modules/api/agents.hooks'
+import {
+  buildMcpCliCommand,
+  slugFromMcpEndpointUrl,
+} from '@/modules/api/mcp-endpoint'
+
+// Slug parsing is sourced from `@/modules/api/mcp-endpoint` so the
+// directory and the wizard agree on the URL shape (the canonical
+// builder lives there too). Re-exported so existing call sites do not
+// have to change import paths.
+export { slugFromMcpEndpointUrl as slugFromMcpUrl } from '@/modules/api/mcp-endpoint'
 
 /**
- * Pulls the slug segment out of an MCP URL.
- * `http://127.0.0.1:9000/mcp/cowork-finance-ops` -> `cowork-finance-ops`.
- * Returns an empty string if the URL doesn't follow the `/mcp/<slug>` shape.
- */
-export function slugFromMcpUrl(url: string): string {
-  const match = url.match(/\/mcp\/([^/?#]+)/)
-  return match?.[1] ?? ''
-}
-
-/**
- * Mirrors `new-agent.helpers.ts`'s buildCliCommand so the directory
- * shows the same CLI snippet the wizard's right rail printed when the
- * profile was created.
+ * Profile-shaped wrapper around `buildMcpCliCommand`. Falls back to
+ * the profile id when the saved `mcpUrl` does not parse, which can
+ * happen with legacy rows written before the cockpit-mount cutover.
  */
 export function cliCommandFor(profile: AgentProfile): string {
-  const slug = slugFromMcpUrl(profile.mcpUrl) || profile.id
-  return `mcp add ${slug}`
+  const slug = slugFromMcpEndpointUrl(profile.mcpUrl) || profile.id
+  return buildMcpCliCommand(slug)
 }

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/new-agent/new-agent.helpers.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/new-agent/new-agent.helpers.ts
@@ -48,13 +48,15 @@ export function toSlug(input: string): string {
   return cleaned || 'agent'
 }
 
-export function buildMcpUrl(slug: string): string {
-  return `http://127.0.0.1:9000/mcp/${slug}`
-}
-
-export function buildCliCommand(slug: string): string {
-  return `mcp add ${slug}`
-}
+// MCP endpoint URL + CLI command are sourced from
+// `@/modules/api/mcp-endpoint` so the create wizard, the edit flow,
+// and the directory all render an identical "copy URL" widget and
+// identical host-agent config snippets. See that module's header for
+// the temporary cockpit-mount caveat.
+export {
+  buildMcpCliCommand as buildCliCommand,
+  buildMcpEndpointUrl as buildMcpUrl,
+} from '@/modules/api/mcp-endpoint'
 
 export function describeLogins(
   mode: LoginMode,


### PR DESCRIPTION
## Summary

The wizard at `/newtab.html#/agents/new` and the edit flow at `/agents/:id/edit` were rendering a per-agent MCP URL of the form `http://127.0.0.1:9000/mcp/<slug>` in the copy widget and the host-agent config snippet. That URL is wrong on both axes: port 9000 is the CDP socket, not the API, and the cockpit lives under `/cockpit` while it borrows `apps/server`'s live BrowserSession.

Verified end-to-end in this branch's session that the working endpoint is `http://127.0.0.1:9100/cockpit/mcp/<slug>` (initialize, tools/list, tabs.list, navigate, read all round-trip through the cockpit MCP server against a live BrowserOS browser).

## What changes

New module: `apps/agent-mcp-ui/modules/api/mcp-endpoint.ts`. Exports three functions:

- `buildMcpEndpointUrl(slug)` returns `http://127.0.0.1:9100/cockpit/mcp/<slug>` using the shared port + mount-prefix constants from `@browseros/agent-mcp-interface/shared/port`. Matches what the cockpit's own `agents` service publishes when running mounted, so a profile created server-side and one composed client-side produce identical strings.
- `slugFromMcpEndpointUrl(url)` parses the slug out of either the mounted shape (`/cockpit/mcp/<slug>`) or the future direct shape (`/mcp/<slug>`).
- `buildMcpCliCommand(slug)` returns the `mcp add <slug>` snippet that lives next to the URL widgets.

The module header carries a `TODO(temporary cockpit mount)` block that names the three commits the future unmount will need: drop the cockpit mount from `apps/server`, flip the constants the module imports, and remove the legacy `/cockpit/mcp/<slug>` arm from the slug parser once profile migration has run. Every URL the UI shows on the agent create + edit flow and the MCP directory now reads from this single source.

Consumer updates:

- `screens/new-agent/new-agent.helpers.ts` drops its inline `buildMcpUrl` + `buildCliCommand` and re-exports the new module's helpers under the same names, so `ConnectorPreviewRail` and any other consumer keeps working without an import-path change.
- `screens/mcp/mcp.helpers.ts` drops its inline `slugFromMcpUrl` regex and re-exports `slugFromMcpEndpointUrl` under the same name. `cliCommandFor(profile)` now uses the canonical builders too, so the directory and the wizard print identical text.

## What is not in scope

`screens/onboarding/onboarding.helpers.ts` still has a hardcoded `claude mcp add ... http://127.0.0.1:9000/mcp ...` snippet. That points at a different surface: `apps/server`'s own root MCP route (not the per-agent cockpit endpoint), so it has a different shape and a separate fix. Tracked as a follow-up.

## Test plan

- [ ] `/newtab.html#/agents/new` renders the copy widget with `http://127.0.0.1:9100/cockpit/mcp/<slug>` while filling the wizard, and that copy actually pastes that URL.
- [ ] After save, the wizard switches to `createdAgent.mcpUrl` (server-rendered) and the URL stays the same shape.
- [ ] `/newtab.html#/agents/:id/edit` shows the same URL the directory row shows.
- [ ] The MCP directory's `McpRow` and the directory's "add to host agent" CLI snippet match the wizard exactly.
- [ ] `bun run typecheck` clean in `apps/agent-mcp-ui`.
- [ ] `bunx biome ci .` clean for the touched files.