### PR TITLE
feat(cockpit): tab activity registry + homepage feedback loop (PR 1/3)

### DIFF
--- a/packages/browseros-agent/apps/agent-mcp-interface/src/lib/tab-activity/extract-page-id.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/lib/tab-activity/extract-page-id.ts
@@ -1,0 +1,41 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Pulls the `page` argument out of a browser-tool dispatch so the
+ * cockpit's tab-activity registry can attribute the call to a tab.
+ * Tools without a `page` parameter (`tab_groups`, `windows`, `run`)
+ * always yield null. Tools that accept it optionally (`tabs` action
+ * variants like `list` vs `close`) yield null when the caller omits
+ * it. Non-integer / non-positive values are rejected to keep the
+ * registry from holding garbage keys.
+ */
+
+const TOOLS_WITH_PAGE: ReadonlySet<string> = new Set([
+  'act',
+  'diff',
+  'download',
+  'evaluate',
+  'grep',
+  'navigate',
+  'pdf',
+  'read',
+  'screenshot',
+  'snapshot',
+  'tabs',
+  'upload',
+  'wait',
+])
+
+export function extractPageId(
+  toolName: string,
+  rawArgs: unknown,
+): number | null {
+  if (!TOOLS_WITH_PAGE.has(toolName)) return null
+  if (!rawArgs || typeof rawArgs !== 'object') return null
+  const page = (rawArgs as { page?: unknown }).page
+  if (typeof page !== 'number') return null
+  if (!Number.isInteger(page) || page < 1) return null
+  return page
+}

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/lib/tab-activity/index.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/lib/tab-activity/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Process-wide singleton registry. Bound to the same
+ * `getBrowserSession` accessor the rest of the cockpit uses so the
+ * registry sees the same `PageManager` instance the tool dispatches
+ * write to.
+ */
+
+import { getBrowserSession } from '../browser-session'
+import { createTabActivityRegistry, type TabActivityRegistry } from './registry'
+
+export const tabActivityRegistry: TabActivityRegistry =
+  createTabActivityRegistry({ getSession: getBrowserSession })
+
+export { extractPageId } from './extract-page-id'
+export type { TabActivityRecord, TabActivityRegistry } from './registry'
+export { ACTIVE_WINDOW_MS, createTabActivityRegistry } from './registry'

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/lib/tab-activity/registry.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/lib/tab-activity/registry.ts
@@ -1,0 +1,114 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * In-memory registry mapping a stable CDP target id to the most
+ * recent agent-tool dispatch that touched it. The cockpit's
+ * `mcp/register.ts` wrapper writes a record after every successful
+ * `executeTool` call; the homepage polls `GET /tabs/activity` to
+ * render the live view.
+ *
+ * `status` is derived at read time: a record is `active` when the
+ * last tool fired within `ACTIVE_WINDOW_MS`, otherwise `idle`. No
+ * background timers. Records whose underlying tab has closed are
+ * evicted lazily on the next `snapshot()` read; we detect that by
+ * looking up `pageId` on the live `PageManager` and confirming the
+ * targetId still matches (pageIds are reused after a tab closes).
+ */
+
+import type { BrowserSession } from '@browseros/server/browser/core/session'
+
+export interface TabActivityRecord {
+  targetId: string
+  pageId: number
+  url: string
+  title: string
+  agentId: string
+  slug: string
+  lastToolAt: number
+  lastToolName: string
+  status: 'active' | 'idle'
+}
+
+export const ACTIVE_WINDOW_MS = 5000
+
+export interface RegistryDeps {
+  getSession(): BrowserSession | null
+  now?: () => number
+}
+
+interface RawRecord {
+  targetId: string
+  pageId: number
+  agentId: string
+  slug: string
+  lastToolAt: number
+  lastToolName: string
+}
+
+export interface TabActivityRegistry {
+  recordTool(input: {
+    agentId: string
+    slug: string
+    pageId: number
+    targetId: string
+    toolName: string
+  }): void
+  snapshot(): TabActivityRecord[]
+  // Test-only escape hatch; lets unit tests assert eviction without
+  // mocking BrowserSession internals.
+  size(): number
+}
+
+export function createTabActivityRegistry(
+  deps: RegistryDeps,
+): TabActivityRegistry {
+  const records = new Map<string, RawRecord>()
+  const now = deps.now ?? (() => Date.now())
+
+  return {
+    recordTool(input) {
+      records.set(input.targetId, {
+        targetId: input.targetId,
+        pageId: input.pageId,
+        agentId: input.agentId,
+        slug: input.slug,
+        lastToolAt: now(),
+        lastToolName: input.toolName,
+      })
+    },
+    snapshot() {
+      const session = deps.getSession()
+      if (!session) return []
+      const out: TabActivityRecord[] = []
+      const t = now()
+      for (const [targetId, raw] of records) {
+        const live = session.pages.getInfo(raw.pageId)
+        // PageManager reuses pageId after a tab closes; the targetId
+        // is the stable identity. If they no longer match, the
+        // original tab is gone (the pageId may now belong to a
+        // different tab).
+        if (!live || live.targetId !== targetId) {
+          records.delete(targetId)
+          continue
+        }
+        out.push({
+          targetId: raw.targetId,
+          pageId: raw.pageId,
+          url: live.url,
+          title: live.title,
+          agentId: raw.agentId,
+          slug: raw.slug,
+          lastToolAt: raw.lastToolAt,
+          lastToolName: raw.lastToolName,
+          status: t - raw.lastToolAt < ACTIVE_WINDOW_MS ? 'active' : 'idle',
+        })
+      }
+      return out.sort((a, b) => b.lastToolAt - a.lastToolAt)
+    },
+    size() {
+      return records.size
+    },
+  }
+}

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/lib/tab-activity/registry.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/lib/tab-activity/registry.ts
@@ -56,9 +56,12 @@ export interface TabActivityRegistry {
     toolName: string
   }): void
   snapshot(): TabActivityRecord[]
-  // Test-only escape hatch; lets unit tests assert eviction without
-  // mocking BrowserSession internals.
+  // Test-only escape hatches; let unit tests assert eviction and
+  // restore isolation without mocking BrowserSession internals. The
+  // singleton lives across the whole test run, so explicit clearing
+  // is the only safe way to keep `afterEach` honest.
   size(): number
+  clear(): void
 }
 
 export function createTabActivityRegistry(
@@ -109,6 +112,9 @@ export function createTabActivityRegistry(
     },
     size() {
       return records.size
+    },
+    clear() {
+      records.clear()
     },
   }
 }

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/mcp/register.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/mcp/register.ts
@@ -35,6 +35,7 @@ import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { ZodRawShape } from 'zod'
 import { getBrowserSession } from '../lib/browser-session'
 import { logger } from '../lib/logger'
+import { extractPageId, tabActivityRegistry } from '../lib/tab-activity'
 import type { StoredAgentProfile } from '../routes/agents/schemas'
 import { check } from '../services/permissions'
 import { asRegister, type ToolResult } from './register-fn'
@@ -115,6 +116,32 @@ function domainForCall(
     }
   }
   return agent.selectedSites[0] ?? '*'
+}
+
+/**
+ * Records a successful dispatch into the tab-activity registry. The
+ * homepage attributes the tab to the agent and surfaces the latest
+ * tool name. Failed dispatches and tools without a `page` arg are
+ * skipped at the call site by `extractPageId` returning `null`.
+ */
+function recordSuccessfulDispatch(args: {
+  toolName: string
+  rawArgs: unknown
+  agent: StoredAgentProfile
+  session: ReturnType<typeof getBrowserSession>
+}): void {
+  if (!args.session) return
+  const pageId = extractPageId(args.toolName, args.rawArgs)
+  if (pageId === null) return
+  const live = args.session.pages.getInfo(pageId)
+  if (!live) return
+  tabActivityRegistry.recordTool({
+    agentId: args.agent.id,
+    slug: args.agent.slug,
+    pageId,
+    targetId: live.targetId,
+    toolName: args.toolName,
+  })
 }
 
 export function registerBrowserTools(
@@ -214,6 +241,14 @@ export function registerBrowserTools(
           session,
           signal: extra?.signal,
         })
+        if (!result.isError) {
+          recordSuccessfulDispatch({
+            toolName: tool.name,
+            rawArgs,
+            agent,
+            session,
+          })
+        }
         return {
           content: result.content as ToolResult['content'],
           isError: result.isError,

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/routes/tabs/index.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/routes/tabs/index.ts
@@ -1,0 +1,20 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Read endpoint backing the cockpit homepage's "which tabs are
+ * being driven right now" view. The registry behind this route is
+ * fed by `apps/agent-mcp-interface/src/mcp/register.ts` every time a
+ * browser tool dispatch succeeds; this route just publishes the
+ * current snapshot. Polling is the v1 transport (the UI hook polls
+ * every 1500 ms); SSE on `?stream=1` is a future option if polling
+ * proves chatty.
+ */
+
+import { Hono } from 'hono'
+import { tabActivityRegistry } from '../../lib/tab-activity'
+
+export const tabsRoute = new Hono().get('/tabs/activity', (c) =>
+  c.json({ tabs: tabActivityRegistry.snapshot() }),
+)

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/server.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/server.ts
@@ -22,6 +22,7 @@ import { mcpRoute } from './routes/mcp'
 import { permissionsRoute } from './routes/permissions'
 import { siteRulesRoute } from './routes/site-rules'
 import { systemRoute } from './routes/system'
+import { tabsRoute } from './routes/tabs'
 
 // Telemetry capture is injectable so the server module stays usable
 // from the bun-test runner without pulling Sentry into the import
@@ -70,6 +71,7 @@ const routes = app
   .route('/', siteRulesRoute)
   .route('/', permissionsRoute)
   .route('/', mcpRoute)
+  .route('/', tabsRoute)
 
 export type AppType = typeof routes
 export default routes

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/tab-activity/extract-page-id.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/tab-activity/extract-page-id.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'bun:test'
+import { extractPageId } from '../../../src/lib/tab-activity/extract-page-id'
+
+describe('extractPageId', () => {
+  it('returns the page id for every tool that takes a page arg', () => {
+    for (const tool of [
+      'act',
+      'diff',
+      'download',
+      'evaluate',
+      'grep',
+      'navigate',
+      'pdf',
+      'read',
+      'screenshot',
+      'snapshot',
+      'tabs',
+      'upload',
+      'wait',
+    ]) {
+      expect(extractPageId(tool, { page: 7 })).toBe(7)
+    }
+  })
+
+  it('returns null for tools without a page arg', () => {
+    expect(extractPageId('tab_groups', { page: 7 })).toBeNull()
+    expect(extractPageId('windows', { page: 7 })).toBeNull()
+    expect(extractPageId('run', { page: 7 })).toBeNull()
+  })
+
+  it('returns null for unknown tools', () => {
+    expect(extractPageId('completely_unknown', { page: 1 })).toBeNull()
+  })
+
+  it('returns null when page is missing', () => {
+    expect(extractPageId('navigate', { url: 'https://example.com' })).toBeNull()
+    expect(extractPageId('navigate', {})).toBeNull()
+  })
+
+  it('returns null when page is not a number', () => {
+    expect(extractPageId('navigate', { page: '7' })).toBeNull()
+    expect(extractPageId('navigate', { page: null })).toBeNull()
+    expect(extractPageId('navigate', { page: undefined })).toBeNull()
+  })
+
+  it('returns null for non-integer page', () => {
+    expect(extractPageId('navigate', { page: 1.5 })).toBeNull()
+  })
+
+  it('returns null for non-positive page', () => {
+    expect(extractPageId('navigate', { page: 0 })).toBeNull()
+    expect(extractPageId('navigate', { page: -1 })).toBeNull()
+  })
+
+  it('returns null for non-object args', () => {
+    expect(extractPageId('navigate', null)).toBeNull()
+    expect(extractPageId('navigate', undefined)).toBeNull()
+    expect(extractPageId('navigate', 'page=1')).toBeNull()
+    expect(extractPageId('navigate', 42)).toBeNull()
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/tab-activity/registry.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/tab-activity/registry.test.ts
@@ -1,0 +1,229 @@
+import { beforeEach, describe, expect, it } from 'bun:test'
+import type { BrowserSession } from '@browseros/server/browser/core/session'
+import {
+  ACTIVE_WINDOW_MS,
+  createTabActivityRegistry,
+  type TabActivityRegistry,
+} from '../../../src/lib/tab-activity/registry'
+
+interface FakePageInfo {
+  targetId: string
+  url: string
+  title: string
+}
+
+function makeSession(pages: Map<number, FakePageInfo>): BrowserSession {
+  return {
+    pages: {
+      getInfo: (pageId: number) => pages.get(pageId) ?? undefined,
+    },
+  } as unknown as BrowserSession
+}
+
+describe('TabActivityRegistry', () => {
+  let pages: Map<number, FakePageInfo>
+  let session: BrowserSession
+  let nowMs: number
+  let registry: TabActivityRegistry
+
+  beforeEach(() => {
+    pages = new Map()
+    session = makeSession(pages)
+    nowMs = 1_000_000
+    registry = createTabActivityRegistry({
+      getSession: () => session,
+      now: () => nowMs,
+    })
+  })
+
+  it('records a tool dispatch and surfaces it via snapshot', () => {
+    pages.set(1, { targetId: 't1', url: 'https://example.com/', title: 'Ex' })
+    registry.recordTool({
+      agentId: 'a1',
+      slug: 'finance-ops',
+      pageId: 1,
+      targetId: 't1',
+      toolName: 'navigate',
+    })
+    const snap = registry.snapshot()
+    expect(snap).toHaveLength(1)
+    expect(snap[0]).toMatchObject({
+      targetId: 't1',
+      pageId: 1,
+      url: 'https://example.com/',
+      title: 'Ex',
+      agentId: 'a1',
+      slug: 'finance-ops',
+      lastToolName: 'navigate',
+      status: 'active',
+    })
+  })
+
+  it('updates an existing record rather than appending a duplicate', () => {
+    pages.set(1, { targetId: 't1', url: 'https://example.com/', title: 'Ex' })
+    registry.recordTool({
+      agentId: 'a1',
+      slug: 'finance-ops',
+      pageId: 1,
+      targetId: 't1',
+      toolName: 'navigate',
+    })
+    nowMs += 1000
+    registry.recordTool({
+      agentId: 'a1',
+      slug: 'finance-ops',
+      pageId: 1,
+      targetId: 't1',
+      toolName: 'snapshot',
+    })
+    const snap = registry.snapshot()
+    expect(snap).toHaveLength(1)
+    expect(snap[0].lastToolName).toBe('snapshot')
+    expect(snap[0].lastToolAt).toBe(1_001_000)
+  })
+
+  it('marks records active within the window and idle outside it', () => {
+    pages.set(1, { targetId: 't1', url: 'https://example.com/', title: 'Ex' })
+    registry.recordTool({
+      agentId: 'a1',
+      slug: 'finance-ops',
+      pageId: 1,
+      targetId: 't1',
+      toolName: 'navigate',
+    })
+    expect(registry.snapshot()[0].status).toBe('active')
+    nowMs += ACTIVE_WINDOW_MS - 1
+    expect(registry.snapshot()[0].status).toBe('active')
+    nowMs += 2
+    expect(registry.snapshot()[0].status).toBe('idle')
+  })
+
+  it('evicts records whose pageId no longer maps to the original targetId', () => {
+    pages.set(1, { targetId: 't1', url: 'https://example.com/', title: 'Ex' })
+    registry.recordTool({
+      agentId: 'a1',
+      slug: 'finance-ops',
+      pageId: 1,
+      targetId: 't1',
+      toolName: 'navigate',
+    })
+    expect(registry.size()).toBe(1)
+    // The tab closes, pageId 1 is reused by a fresh tab with a new targetId.
+    pages.set(1, { targetId: 't2-different', url: 'about:blank', title: '' })
+    expect(registry.snapshot()).toHaveLength(0)
+    expect(registry.size()).toBe(0)
+  })
+
+  it('evicts records whose pageId no longer exists at all', () => {
+    pages.set(1, { targetId: 't1', url: 'https://example.com/', title: 'Ex' })
+    registry.recordTool({
+      agentId: 'a1',
+      slug: 'finance-ops',
+      pageId: 1,
+      targetId: 't1',
+      toolName: 'navigate',
+    })
+    pages.delete(1)
+    expect(registry.snapshot()).toHaveLength(0)
+    expect(registry.size()).toBe(0)
+  })
+
+  it('returns an empty snapshot when no session is connected', () => {
+    pages.set(1, { targetId: 't1', url: 'https://example.com/', title: 'Ex' })
+    registry.recordTool({
+      agentId: 'a1',
+      slug: 'finance-ops',
+      pageId: 1,
+      targetId: 't1',
+      toolName: 'navigate',
+    })
+    const detached = createTabActivityRegistry({
+      getSession: () => null,
+      now: () => nowMs,
+    })
+    detached.recordTool({
+      agentId: 'a1',
+      slug: 'finance-ops',
+      pageId: 1,
+      targetId: 't1',
+      toolName: 'navigate',
+    })
+    expect(detached.snapshot()).toEqual([])
+  })
+
+  it('keeps separate records per target id', () => {
+    pages.set(1, { targetId: 't1', url: 'https://a.com/', title: 'A' })
+    pages.set(2, { targetId: 't2', url: 'https://b.com/', title: 'B' })
+    registry.recordTool({
+      agentId: 'a1',
+      slug: 'finance',
+      pageId: 1,
+      targetId: 't1',
+      toolName: 'navigate',
+    })
+    nowMs += 100
+    registry.recordTool({
+      agentId: 'a2',
+      slug: 'travel',
+      pageId: 2,
+      targetId: 't2',
+      toolName: 'read',
+    })
+    const snap = registry.snapshot()
+    expect(snap).toHaveLength(2)
+    expect(snap.map((r) => r.targetId)).toEqual(['t2', 't1'])
+  })
+
+  it('sorts the snapshot by lastToolAt descending', () => {
+    pages.set(1, { targetId: 't1', url: 'https://a.com/', title: 'A' })
+    pages.set(2, { targetId: 't2', url: 'https://b.com/', title: 'B' })
+    registry.recordTool({
+      agentId: 'a1',
+      slug: 'finance',
+      pageId: 1,
+      targetId: 't1',
+      toolName: 'navigate',
+    })
+    nowMs += 100
+    registry.recordTool({
+      agentId: 'a2',
+      slug: 'travel',
+      pageId: 2,
+      targetId: 't2',
+      toolName: 'read',
+    })
+    nowMs += 100
+    registry.recordTool({
+      agentId: 'a1',
+      slug: 'finance',
+      pageId: 1,
+      targetId: 't1',
+      toolName: 'snapshot',
+    })
+    const snap = registry.snapshot()
+    expect(snap.map((r) => r.targetId)).toEqual(['t1', 't2'])
+  })
+
+  it('last write wins on agent attribution when two agents touch the same tab', () => {
+    pages.set(1, { targetId: 't1', url: 'https://a.com/', title: 'A' })
+    registry.recordTool({
+      agentId: 'a1',
+      slug: 'finance',
+      pageId: 1,
+      targetId: 't1',
+      toolName: 'navigate',
+    })
+    nowMs += 100
+    registry.recordTool({
+      agentId: 'a2',
+      slug: 'travel',
+      pageId: 1,
+      targetId: 't1',
+      toolName: 'snapshot',
+    })
+    const snap = registry.snapshot()
+    expect(snap).toHaveLength(1)
+    expect(snap[0].agentId).toBe('a2')
+    expect(snap[0].slug).toBe('travel')
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/tabs/routes.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/tabs/routes.test.ts
@@ -23,8 +23,12 @@ function client() {
 
 afterEach(() => {
   // Clear the singleton registry between cases so test ordering does
-  // not leak state. We snapshot then drop everything: there is no
-  // public clear() so we evict by detaching the session.
+  // not leak state. Setting the session to null short-circuits
+  // `snapshot()` but does NOT empty the underlying records Map; only
+  // the explicit `clear()` does that. Skipping it would leave a stale
+  // record visible to a later test that re-attaches a session whose
+  // stub resolves the same pageId.
+  tabActivityRegistry.clear()
   setBrowserSession(null)
 })
 

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/tabs/routes.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/tabs/routes.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Integration test for the /tabs/activity route. Pins the response
+ * shape and the empty-state behaviour. The registry-population path
+ * is exercised by mcp/register tests; this file only verifies the
+ * route surface.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { hc } from 'hono/client'
+import { setBrowserSession } from '../../../src/lib/browser-session'
+import { tabActivityRegistry } from '../../../src/lib/tab-activity'
+import app, { type AppType } from '../../../src/server'
+
+function client() {
+  return hc<AppType>('http://localhost', {
+    fetch: (input, init) => app.fetch(new Request(input, init)),
+  })
+}
+
+afterEach(() => {
+  // Clear the singleton registry between cases so test ordering does
+  // not leak state. We snapshot then drop everything: there is no
+  // public clear() so we evict by detaching the session.
+  setBrowserSession(null)
+})
+
+describe('/tabs/activity route', () => {
+  test('returns an empty list when nothing has been recorded', async () => {
+    const api = client()
+    const res = await api.tabs.activity.$get()
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { tabs: unknown[] }
+    expect(body).toEqual({ tabs: [] })
+  })
+
+  test('returns the registry snapshot once tools have been recorded', async () => {
+    // Plant a fake session whose PageManager resolves a single page,
+    // record a tool against it, and expect the route to surface it.
+    setBrowserSession({
+      pages: {
+        getInfo: (pageId: number) =>
+          pageId === 1
+            ? { targetId: 't1', url: 'https://example.com/', title: 'Ex' }
+            : undefined,
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: stub for test
+    } as any)
+    tabActivityRegistry.recordTool({
+      agentId: 'a-1',
+      slug: 'finance-ops',
+      pageId: 1,
+      targetId: 't1',
+      toolName: 'navigate',
+    })
+    const api = client()
+    const res = await api.tabs.activity.$get()
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      tabs: Array<{
+        targetId: string
+        agentId: string
+        slug: string
+        toolName?: string
+        lastToolName: string
+        url: string
+        status: 'active' | 'idle'
+      }>
+    }
+    expect(body.tabs).toHaveLength(1)
+    expect(body.tabs[0]).toMatchObject({
+      targetId: 't1',
+      agentId: 'a-1',
+      slug: 'finance-ops',
+      lastToolName: 'navigate',
+      url: 'https://example.com/',
+      status: 'active',
+    })
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/tabs.hooks.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/tabs.hooks.ts
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Polls `GET /cockpit/tabs/activity` so the homepage can render a
+ * live view of which tabs each agent has touched and how recently.
+ * Backed by the in-memory registry in
+ * `apps/agent-mcp-interface/src/lib/tab-activity/`; refer to that
+ * module for the record shape and the active-window threshold.
+ */
+
+import { createQuery } from 'react-query-kit'
+import { api } from './client'
+import { parseResponse } from './parseResponse'
+
+export interface TabActivityRecord {
+  targetId: string
+  pageId: number
+  url: string
+  title: string
+  agentId: string
+  slug: string
+  lastToolAt: number
+  lastToolName: string
+  status: 'active' | 'idle'
+}
+
+interface TabsActivityResponse {
+  tabs: TabActivityRecord[]
+}
+
+export const useTabsActivity = createQuery<TabsActivityResponse>({
+  queryKey: ['tabs', 'activity'],
+  fetcher: async () => {
+    const res = await api.tabs.activity.$get()
+    return parseResponse<TabsActivityResponse>(res)
+  },
+  refetchInterval: 1500,
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/Cockpit.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/Cockpit.tsx
@@ -2,35 +2,27 @@ import { CockpitHero } from '@/components/cockpit/CockpitHero'
 import { RecentActivity } from '@/components/cockpit/RecentActivity'
 import { RunningGrid } from '@/components/cockpit/RunningGrid'
 import { WaitingStrip } from '@/components/cockpit/WaitingStrip'
-import { useRecentActivity } from '@/modules/api/activity.hooks'
-import { useAgents } from '@/modules/api/agents.hooks'
-import { useApprovals, useHandoffs } from '@/modules/api/waiting.hooks'
+import { useCockpitData } from './cockpit.data'
 
 /**
  * Cockpit home. Four stacked sections matching the design's dashboard
  * order: hero, waiting strip (sticky-attention surface), running
  * grid (the agents themselves), recent activity (cross-agent log).
  *
- * Data comes from mock hooks for now; each hook is `react-query-kit`
- * with a setTimeout fetcher so loading states render and the eventual
- * swap to the real agent-mcp-interface endpoints is a fetcher-body
- * change rather than a refactor.
+ * PR 1 wires `RunningGrid` and `RecentActivity` to the real
+ * `GET /cockpit/tabs/activity` registry; `WaitingStrip`'s approvals
+ * and handoffs remain on their mocked hooks until later PRs supply
+ * them.
  */
 export function Cockpit() {
-  const agents = useAgents()
-  const activity = useRecentActivity()
-  const approvals = useApprovals()
-  const handoffs = useHandoffs()
+  const { agents, activity, approvals, handoffs } = useCockpitData()
 
   return (
     <div className="mx-auto flex max-w-5xl flex-col gap-8 px-8 pt-10 pb-20">
       <CockpitHero />
-      <WaitingStrip
-        approvals={approvals.data ?? []}
-        handoffs={handoffs.data ?? []}
-      />
-      <RunningGrid agents={agents.data ?? []} />
-      <RecentActivity rows={activity.data ?? []} />
+      <WaitingStrip approvals={approvals} handoffs={handoffs} />
+      <RunningGrid agents={agents} />
+      <RecentActivity rows={activity} />
     </div>
   )
 }

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.data.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.data.ts
@@ -39,6 +39,6 @@ export function useCockpitData(): CockpitData {
     activity: tabsToActivityRows(records, now),
     approvals: approvals.data ?? [],
     handoffs: handoffs.data ?? [],
-    isPending: tabs.isPending,
+    isPending: tabs.isPending || approvals.isPending || handoffs.isPending,
   }
 }

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.data.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.data.ts
@@ -1,0 +1,44 @@
+import type { ActivityRow } from '@/modules/api/activity.hooks'
+import type { AgentRow } from '@/modules/api/agents.hooks'
+import { useTabsActivity } from '@/modules/api/tabs.hooks'
+import {
+  type ApprovalItem,
+  type HandoffItem,
+  useApprovals,
+  useHandoffs,
+} from '@/modules/api/waiting.hooks'
+import { tabsToActivityRows, tabsToAgentRows } from './cockpit.helpers'
+
+export interface CockpitData {
+  agents: AgentRow[]
+  activity: ActivityRow[]
+  approvals: ApprovalItem[]
+  handoffs: HandoffItem[]
+  isPending: boolean
+}
+
+/**
+ * Single data aggregation hook for the homepage. Per the project
+ * convention, the screen calls this and nothing else. PR 1 wires the
+ * running grid and recent activity to the real
+ * `GET /cockpit/tabs/activity` registry; approvals and handoffs
+ * remain on their mocked hooks until later PRs supply them.
+ */
+export function useCockpitData(): CockpitData {
+  const tabs = useTabsActivity()
+  const approvals = useApprovals()
+  const handoffs = useHandoffs()
+
+  // We pass `Date.now()` at render time; the slight non-determinism
+  // is fine for a 1.5s-polling display and avoids dragging a clock
+  // injection through the component tree.
+  const records = tabs.data?.tabs ?? []
+  const now = Date.now()
+  return {
+    agents: tabsToAgentRows(records),
+    activity: tabsToActivityRows(records, now),
+    approvals: approvals.data ?? [],
+    handoffs: handoffs.data ?? [],
+    isPending: tabs.isPending,
+  }
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.helpers.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.helpers.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'bun:test'
+import type { TabActivityRecord } from '@/modules/api/tabs.hooks'
+import {
+  colorForSlug,
+  formatRelative,
+  siteOf,
+  tabsToActivityRows,
+  tabsToAgentRows,
+} from './cockpit.helpers'
+
+function record(over: Partial<TabActivityRecord> = {}): TabActivityRecord {
+  return {
+    targetId: 't1',
+    pageId: 1,
+    url: 'https://example.com/foo',
+    title: 'Ex',
+    agentId: 'a1',
+    slug: 'finance',
+    lastToolAt: 1_000_000,
+    lastToolName: 'navigate',
+    status: 'active',
+    ...over,
+  }
+}
+
+describe('siteOf', () => {
+  it('returns the host without leading www', () => {
+    expect(siteOf('https://www.example.com/foo')).toBe('example.com')
+    expect(siteOf('https://docs.google.com/sheets/abc')).toBe('docs.google.com')
+  })
+
+  it('falls back to the raw url for invalid input', () => {
+    expect(siteOf('not a url')).toBe('not a url')
+  })
+})
+
+describe('formatRelative', () => {
+  it('returns seconds within a minute', () => {
+    expect(formatRelative(99_000, 99_500)).toBe('0s ago')
+    expect(formatRelative(95_000, 100_000)).toBe('5s ago')
+  })
+  it('returns minutes within an hour', () => {
+    expect(formatRelative(0, 60_000)).toBe('1m ago')
+    expect(formatRelative(0, 3_540_000)).toBe('59m ago')
+  })
+  it('returns hours within a day', () => {
+    expect(formatRelative(0, 3_600_000)).toBe('1h ago')
+    expect(formatRelative(0, 23 * 3_600_000)).toBe('23h ago')
+  })
+  it('returns days otherwise', () => {
+    expect(formatRelative(0, 24 * 3_600_000)).toBe('1d ago')
+  })
+})
+
+describe('colorForSlug', () => {
+  it('is deterministic per slug', () => {
+    expect(colorForSlug('finance')).toBe(colorForSlug('finance'))
+  })
+  it('returns a hex string', () => {
+    expect(colorForSlug('travel')).toMatch(/^#[0-9A-F]{6}$/i)
+  })
+})
+
+describe('tabsToAgentRows', () => {
+  it('filters out idle records and maps to AgentRow shape', () => {
+    const rows = tabsToAgentRows([
+      record({ targetId: 't1', status: 'active', slug: 'finance' }),
+      record({ targetId: 't2', status: 'idle', slug: 'travel' }),
+    ])
+    expect(rows.map((r) => r.id)).toEqual(['t1'])
+    expect(rows[0]).toMatchObject({
+      label: 'finance',
+      harness: 'Claude Code',
+      site: 'example.com',
+      task: 'Ex',
+      status: 'running',
+    })
+  })
+})
+
+describe('tabsToActivityRows', () => {
+  it('filters out active records and maps to ActivityRow shape', () => {
+    const rows = tabsToActivityRows(
+      [
+        record({ targetId: 't1', status: 'active' }),
+        record({
+          targetId: 't2',
+          status: 'idle',
+          slug: 'travel',
+          lastToolAt: 950_000,
+          lastToolName: 'read',
+        }),
+      ],
+      1_000_000,
+    )
+    expect(rows.map((r) => r.id)).toEqual(['t2'])
+    expect(rows[0]).toMatchObject({
+      agentLabel: 'travel',
+      status: 'done',
+      action: 'read on Ex',
+      site: 'example.com',
+      when: '50s ago',
+    })
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.helpers.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.helpers.ts
@@ -55,6 +55,9 @@ export function tabsToAgentRows(records: TabActivityRecord[]): AgentRow[] {
     .map((r) => ({
       id: r.targetId,
       label: r.slug,
+      // TODO(pr-3 homepage): join the agent profile and surface the
+      // real harness; today every row reads "Claude Code" because the
+      // TabActivityRecord does not carry it.
       harness: 'Claude Code',
       site: siteOf(r.url),
       task: r.title || siteOf(r.url),

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.helpers.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.helpers.ts
@@ -1,0 +1,86 @@
+import type { ActivityRow } from '@/modules/api/activity.hooks'
+import type { AgentRow } from '@/modules/api/agents.hooks'
+import type { TabActivityRecord } from '@/modules/api/tabs.hooks'
+
+// Small palette so each agent gets a stable colour without joining a
+// profile lookup. Hash the slug; if two agents collide it is purely
+// cosmetic.
+const PALETTE = [
+  '#F26B2A',
+  '#2F6FE0',
+  '#7A5AF8',
+  '#10A37F',
+  '#E0561C',
+  '#0EA5E9',
+  '#F59E0B',
+  '#DB2777',
+]
+
+export function colorForSlug(slug: string): string {
+  let hash = 0
+  for (let i = 0; i < slug.length; i++) {
+    hash = (hash * 31 + slug.charCodeAt(i)) >>> 0
+  }
+  return PALETTE[hash % PALETTE.length] ?? PALETTE[0]
+}
+
+export function siteOf(url: string): string {
+  try {
+    return new URL(url).hostname.replace(/^www\./, '')
+  } catch {
+    return url
+  }
+}
+
+export function formatRelative(ms: number, now: number): string {
+  const delta = Math.max(0, now - ms)
+  const seconds = Math.floor(delta / 1000)
+  if (seconds < 60) return `${seconds}s ago`
+  const minutes = Math.floor(seconds / 60)
+  if (minutes < 60) return `${minutes}m ago`
+  const hours = Math.floor(minutes / 60)
+  if (hours < 24) return `${hours}h ago`
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+/**
+ * Tabs whose `status === 'active'` become live agent cards. The
+ * label, harness, and color are derived locally from the slug since
+ * PR 1 does not join the agent profile.
+ */
+export function tabsToAgentRows(records: TabActivityRecord[]): AgentRow[] {
+  return records
+    .filter((r) => r.status === 'active')
+    .map((r) => ({
+      id: r.targetId,
+      label: r.slug,
+      harness: 'Claude Code',
+      site: siteOf(r.url),
+      task: r.title || siteOf(r.url),
+      status: 'running' as const,
+      liveLine: `${r.lastToolName} - ${r.title || siteOf(r.url)}`,
+      color: colorForSlug(r.slug),
+    }))
+}
+
+/**
+ * Idle records flow into RecentActivity so the user can see the last
+ * thing each agent did on a tab even after the active window expires.
+ */
+export function tabsToActivityRows(
+  records: TabActivityRecord[],
+  now: number,
+): ActivityRow[] {
+  return records
+    .filter((r) => r.status === 'idle')
+    .map((r) => ({
+      id: r.targetId,
+      agentLabel: r.slug,
+      color: colorForSlug(r.slug),
+      status: 'done' as const,
+      action: `${r.lastToolName} on ${r.title || siteOf(r.url)}`,
+      site: siteOf(r.url),
+      when: formatRelative(r.lastToolAt, now),
+    }))
+}


### PR DESCRIPTION
## Summary

First of three PRs from the cockpit-homepage plan. Every successful browser-tool dispatch the cockpit observes is recorded against the calling agent and the targeted CDP target id; the homepage polls `GET /cockpit/tabs/activity` every 1500 ms and renders the live view. No takeover gate yet (PR 2), no UI redesign beyond rewiring the data hooks. Zero diffs in `apps/server`.

## What changes

**`apps/agent-mcp-interface`:**

- `lib/tab-activity/extract-page-id.ts` is a pure helper that reads `rawArgs.page` for tools that accept it (`act`, `diff`, `download`, `evaluate`, `grep`, `navigate`, `pdf`, `read`, `screenshot`, `snapshot`, `tabs`, `upload`, `wait`) and rejects non-integer / non-positive values. Tools without a `page` (`tab_groups`, `windows`, `run`) yield `null`.
- `lib/tab-activity/registry.ts` is the in-memory map keyed by stable CDP `targetId`. `recordTool` writes; `snapshot()` reads. `status` is derived at read time (`active` within 5 s of the last tool, `idle` afterwards). Closed tabs are evicted lazily on the next snapshot read by checking `PageManager.getInfo(pageId)?.targetId === storedTargetId` (pageIds are reused, target ids are not). The registry takes an optional `now` clock for deterministic tests.
- `lib/tab-activity/index.ts` exports a process-wide singleton bound to the existing `getBrowserSession` accessor.
- `mcp/register.ts` wraps the existing `executeTool` call with `recordSuccessfulDispatch(...)`. Failed dispatches and tools without a `page` arg are skipped. The new helper is extracted so the dispatcher function stays under biome's cognitive-complexity threshold.
- `routes/tabs/index.ts` exposes `GET /tabs/activity` returning `{ tabs: TabActivityRecord[] }`. Mounted in `server.ts` so the chained `AppType` picks it up automatically.

**`apps/agent-mcp-ui`:**

- `modules/api/tabs.hooks.ts` defines `useTabsActivity` with `react-query-kit`, polling every 1500 ms via the existing hono-rpc client.
- `screens/cockpit/cockpit.helpers.ts` derives per-slug colours, parses the site from the URL, formats relative time, and maps `TabActivityRecord[]` to `AgentRow[]` (active records, `status=running`) and `ActivityRow[]` (idle records, `status=done`).
- `screens/cockpit/cockpit.data.ts` is the new aggregator hook. The homepage screen calls it and nothing else.
- `Cockpit.tsx` drops the mocked `useAgents` / `useRecentActivity` calls and consumes `useCockpitData()` instead. Approvals + handoffs stay on their mocks until later PRs supply them.

## Server-side guarantees

```
$ git diff origin/feat/agent-mcp-interface-bootstrap...HEAD --name-only | grep '^packages/browseros-agent/apps/server' | wc -l
0
```

No edits to `apps/server/src/tools/browser/framework.ts`, no edits to `executeTool`, no edits to `BROWSER_TOOLS`. The cockpit reads `PageManager` via the shared `BrowserSession` singleton it already owns.

## Test plan

- [x] Unit tests for `extractPageId` (8 cases): every tool with a page, every tool without, missing / non-integer / non-object args.
- [x] Unit tests for `TabActivityRegistry` (9 cases): record + snapshot, dedup-by-targetId, status timing with injectable clock, eviction on pageId reuse + outright deletion, no-session no-op, multi-tab independence, sort by `lastToolAt` desc, last-write-wins on shared target.
- [x] Integration test for `/tabs/activity` route: empty-state shape + populated shape after recording.
- [x] Unit tests for cockpit helpers (10 cases): site parsing, relative-time formatter (seconds / minutes / hours / days), colour determinism, AgentRow / ActivityRow mappers filtering by status.
- [x] All 120 existing `apps/agent-mcp-interface` tests still pass.
- [x] `bunx tsc --noEmit` clean in both packages.
- [x] `bunx biome ci` clean.

**Manual walk-through against a live BrowserOS** (reviewer action):

1. Start `apps/server` against a running BrowserOS browser (CDP up).
2. Open the agent-mcp-ui at the cockpit homepage. Confirm `RunningGrid` is empty.
3. From a terminal, `tools/call navigate { page: 1, url: 'https://example.com' }` against `/cockpit/mcp/<slug>` for any agent profile.
4. `curl http://127.0.0.1:9100/cockpit/tabs/activity` should now show a record with `agentId`, `slug`, `targetId`, `pageId: 1`, `url: 'https://example.com/'`, `title: 'Example Domain'`, `lastToolName: 'navigate'`, `status: 'active'`.
5. The homepage's `RunningGrid` should show one card within 2 seconds, labelled with the slug.
6. Wait 5 seconds without making another tool call. The card moves to `RecentActivity` with status `done` and a relative-time chip.
7. Close the corresponding browser tab. The record disappears from `/tabs/activity` on the next read (caught by the eviction-on-read pass).
8. Make a failed tool call (`navigate { page: 999, url: '...' }`). No new record appears, the previous record's `lastToolAt` does NOT advance.

## Follow-ups (PR 2 and PR 3)

- PR 2 adds a `TakeoverRegistry`, `POST /cockpit/tabs/:targetId/takeover` + `/release`, and an MCP-error gate in the same wrapper.
- PR 3 surfaces "Take over" / "Resume agent" buttons in the UI and a "User driving" section in `WaitingStrip`.