### PR TITLE
chore(ci): weekly dependabot + drop audit self-fail step

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,40 @@
+version: 2
+
+updates:
+  - package-ecosystem: "bun"
+    directory: "/packages/browseros-agent"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 3
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+    commit-message:
+      prefix: "chore(deps)"
+      include: "scope"
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Kolkata"
+    open-pull-requests-limit: 5
+    cooldown:
+      default-days: 3
+    commit-message:
+      prefix: "chore(ci)"
+      include: "scope"
+    labels:
+      - "dependencies"
+      - "github-actions"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,6 +32,11 @@ updates:
     open-pull-requests-limit: 5
     cooldown:
       default-days: 3
+    groups:
+      minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
     commit-message:
       prefix: "chore(ci)"
       include: "scope"

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -184,9 +184,3 @@ jobs:
             -H 'Content-Type: application/json' \
             -d @slack-payload.json \
             $SLACK_WEBHOOK_URL
-
-      - name: Fail if vulnerabilities found
-        if: steps.audit.outputs.vuln_count != '0'
-        run: |
-          echo "Security audit found vulnerabilities"
-          exit 1


### PR DESCRIPTION
Adds a dependabot config that opens grouped minor and patch update PRs every Monday for the bun workspace and the github-actions workflows, with a 3-day release cooldown to mirror the existing bunfig minimumReleaseAge.

Drops the trailing fail step in the daily audit workflow so it no longer marks itself red after the Slack notification has already been sent.