### PR TITLE
feat(cockpit): live activity trail with action count + agent profile join (PR 2/3)

### DIFF
--- a/packages/browseros-agent/apps/agent-mcp-interface/src/lib/tab-activity/index.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/lib/tab-activity/index.ts
@@ -16,5 +16,13 @@ export const tabActivityRegistry: TabActivityRegistry =
   createTabActivityRegistry({ getSession: getBrowserSession })
 
 export { extractPageId } from './extract-page-id'
-export type { TabActivityRecord, TabActivityRegistry } from './registry'
-export { ACTIVE_WINDOW_MS, createTabActivityRegistry } from './registry'
+export type {
+  TabActivityRecord,
+  TabActivityRegistry,
+  ToolEvent,
+} from './registry'
+export {
+  ACTIVE_WINDOW_MS,
+  createTabActivityRegistry,
+  RECENT_TOOLS_CAP,
+} from './registry'

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/lib/tab-activity/registry.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/lib/tab-activity/registry.ts
@@ -3,11 +3,20 @@
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
- * In-memory registry mapping a stable CDP target id to the most
- * recent agent-tool dispatch that touched it. The cockpit's
- * `mcp/register.ts` wrapper writes a record after every successful
- * `executeTool` call; the homepage polls `GET /tabs/activity` to
- * render the live view.
+ * In-memory registry mapping a stable CDP target id to the live
+ * activity trail for the agent currently driving that tab. The
+ * cockpit's `mcp/register.ts` wrapper appends to the trail after
+ * every successful `executeTool` call; the homepage polls
+ * `GET /tabs/activity` to render the current view.
+ *
+ * Each record carries:
+ *   - `firstToolAt`: when this agent first touched the tab (does not
+ *     update on subsequent tool calls).
+ *   - `lastToolAt` / `lastToolName`: the most recent dispatch.
+ *   - `toolCount`: total dispatches against this target since the
+ *     record was created.
+ *   - `recentTools`: ring buffer capped at `RECENT_TOOLS_CAP` so the
+ *     UI can render a short trail without unbounded memory.
  *
  * `status` is derived at read time: a record is `active` when the
  * last tool fired within `ACTIVE_WINDOW_MS`, otherwise `idle`. No
@@ -19,6 +28,11 @@
 
 import type { BrowserSession } from '@browseros/server/browser/core/session'
 
+export interface ToolEvent {
+  name: string
+  at: number
+}
+
 export interface TabActivityRecord {
   targetId: string
   pageId: number
@@ -26,12 +40,16 @@ export interface TabActivityRecord {
   title: string
   agentId: string
   slug: string
+  firstToolAt: number
   lastToolAt: number
   lastToolName: string
+  toolCount: number
+  recentTools: ToolEvent[]
   status: 'active' | 'idle'
 }
 
 export const ACTIVE_WINDOW_MS = 5000
+export const RECENT_TOOLS_CAP = 8
 
 export interface RegistryDeps {
   getSession(): BrowserSession | null
@@ -43,8 +61,11 @@ interface RawRecord {
   pageId: number
   agentId: string
   slug: string
+  firstToolAt: number
   lastToolAt: number
   lastToolName: string
+  toolCount: number
+  recentTools: ToolEvent[]
 }
 
 export interface TabActivityRegistry {
@@ -72,13 +93,35 @@ export function createTabActivityRegistry(
 
   return {
     recordTool(input) {
+      const t = now()
+      const existing = records.get(input.targetId)
+      if (existing) {
+        // Same agent or a different agent rebinding to this target:
+        // overwrite the attribution so the homepage reflects the
+        // most-recent caller. firstToolAt is preserved so the card
+        // can render "started 47s ago" against the original touch.
+        existing.agentId = input.agentId
+        existing.slug = input.slug
+        existing.pageId = input.pageId
+        existing.lastToolAt = t
+        existing.lastToolName = input.toolName
+        existing.toolCount += 1
+        existing.recentTools.push({ name: input.toolName, at: t })
+        if (existing.recentTools.length > RECENT_TOOLS_CAP) {
+          existing.recentTools.shift()
+        }
+        return
+      }
       records.set(input.targetId, {
         targetId: input.targetId,
         pageId: input.pageId,
         agentId: input.agentId,
         slug: input.slug,
-        lastToolAt: now(),
+        firstToolAt: t,
+        lastToolAt: t,
         lastToolName: input.toolName,
+        toolCount: 1,
+        recentTools: [{ name: input.toolName, at: t }],
       })
     },
     snapshot() {
@@ -103,8 +146,13 @@ export function createTabActivityRegistry(
           title: live.title,
           agentId: raw.agentId,
           slug: raw.slug,
+          firstToolAt: raw.firstToolAt,
           lastToolAt: raw.lastToolAt,
           lastToolName: raw.lastToolName,
+          toolCount: raw.toolCount,
+          // Hand the consumer its own copy; the registry keeps mutating
+          // its private buffer.
+          recentTools: raw.recentTools.slice(),
           status: t - raw.lastToolAt < ACTIVE_WINDOW_MS ? 'active' : 'idle',
         })
       }

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/routes/tabs/index.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/routes/tabs/index.ts
@@ -7,14 +7,52 @@
  * being driven right now" view. The registry behind this route is
  * fed by `apps/agent-mcp-interface/src/mcp/register.ts` every time a
  * browser tool dispatch succeeds; this route just publishes the
- * current snapshot. Polling is the v1 transport (the UI hook polls
- * every 1500 ms); SSE on `?stream=1` is a future option if polling
- * proves chatty.
+ * current snapshot.
+ *
+ * The snapshot is joined against the agents directory so the UI
+ * receives `agentLabel` and `harness` directly instead of a slug it
+ * has to format itself. Profile lookups fall back to the slug when a
+ * record references an agent whose stored profile has been deleted;
+ * the route never throws on a missing profile.
+ *
+ * Polling is the v1 transport (the UI hook polls every 1500 ms); SSE
+ * on `?stream=1` is a future option if polling proves chatty.
  */
 
 import { Hono } from 'hono'
-import { tabActivityRegistry } from '../../lib/tab-activity'
+import {
+  type TabActivityRecord,
+  tabActivityRegistry,
+} from '../../lib/tab-activity'
+import { list as listAgents } from '../agents/service'
 
-export const tabsRoute = new Hono().get('/tabs/activity', (c) =>
-  c.json({ tabs: tabActivityRegistry.snapshot() }),
-)
+export interface EnrichedTabRecord extends TabActivityRecord {
+  agentLabel: string
+  harness: string | null
+  // No stored colour on the agent profile yet; emit null so the UI
+  // falls back to its slug-hash palette. Wire is ready for the day
+  // the profile schema gains a `color` field.
+  color: string | null
+}
+
+export const tabsRoute = new Hono().get('/tabs/activity', async (c) => {
+  const tabs = tabActivityRegistry.snapshot()
+  if (tabs.length === 0) {
+    return c.json({ tabs: [] as EnrichedTabRecord[] })
+  }
+  // O(records + profiles) join. The agents directory reads from disk
+  // on every call today; if the read becomes a bottleneck we can add
+  // a stale-while-revalidate cache next to the registry.
+  const profiles = await listAgents()
+  const byId = new Map(profiles.map((p) => [p.id, p]))
+  const enriched: EnrichedTabRecord[] = tabs.map((tab) => {
+    const profile = byId.get(tab.agentId)
+    return {
+      ...tab,
+      agentLabel: profile?.name ?? tab.slug,
+      harness: profile?.harness ?? null,
+      color: null,
+    }
+  })
+  return c.json({ tabs: enriched })
+})

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/tab-activity/registry.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/tab-activity/registry.test.ts
@@ -3,6 +3,7 @@ import type { BrowserSession } from '@browseros/server/browser/core/session'
 import {
   ACTIVE_WINDOW_MS,
   createTabActivityRegistry,
+  RECENT_TOOLS_CAP,
   type TabActivityRegistry,
 } from '../../../src/lib/tab-activity/registry'
 
@@ -54,9 +55,13 @@ describe('TabActivityRegistry', () => {
       title: 'Ex',
       agentId: 'a1',
       slug: 'finance-ops',
+      firstToolAt: nowMs,
+      lastToolAt: nowMs,
       lastToolName: 'navigate',
+      toolCount: 1,
       status: 'active',
     })
+    expect(snap[0].recentTools).toEqual([{ name: 'navigate', at: nowMs }])
   })
 
   it('updates an existing record rather than appending a duplicate', () => {
@@ -80,6 +85,88 @@ describe('TabActivityRegistry', () => {
     expect(snap).toHaveLength(1)
     expect(snap[0].lastToolName).toBe('snapshot')
     expect(snap[0].lastToolAt).toBe(1_001_000)
+    // firstToolAt is set on the first write and never moves.
+    expect(snap[0].firstToolAt).toBe(1_000_000)
+    expect(snap[0].toolCount).toBe(2)
+    expect(snap[0].recentTools).toEqual([
+      { name: 'navigate', at: 1_000_000 },
+      { name: 'snapshot', at: 1_001_000 },
+    ])
+  })
+
+  it('caps recentTools at RECENT_TOOLS_CAP and drops the oldest entry', () => {
+    pages.set(1, { targetId: 't1', url: 'https://example.com/', title: 'Ex' })
+    const tools = [
+      'navigate',
+      'snapshot',
+      'read',
+      'grep',
+      'screenshot',
+      'act',
+      'diff',
+      'read',
+      'snapshot',
+      'act',
+    ]
+    for (let i = 0; i < tools.length; i++) {
+      nowMs = 1_000_000 + i * 100
+      registry.recordTool({
+        agentId: 'a1',
+        slug: 'finance-ops',
+        pageId: 1,
+        targetId: 't1',
+        toolName: tools[i],
+      })
+    }
+    const snap = registry.snapshot()
+    expect(snap).toHaveLength(1)
+    expect(snap[0].toolCount).toBe(tools.length)
+    expect(snap[0].recentTools).toHaveLength(RECENT_TOOLS_CAP)
+    // The two oldest (navigate, snapshot) should have dropped off; the
+    // newest (act) is the tail.
+    expect(snap[0].recentTools[0].name).toBe('read')
+    expect(snap[0].recentTools[snap[0].recentTools.length - 1].name).toBe('act')
+  })
+
+  it('hands consumers a defensive copy of recentTools', () => {
+    pages.set(1, { targetId: 't1', url: 'https://example.com/', title: 'Ex' })
+    registry.recordTool({
+      agentId: 'a1',
+      slug: 'finance-ops',
+      pageId: 1,
+      targetId: 't1',
+      toolName: 'navigate',
+    })
+    const first = registry.snapshot()[0].recentTools
+    first.push({ name: 'mutated', at: 0 })
+    const second = registry.snapshot()[0].recentTools
+    expect(second).toHaveLength(1)
+    expect(second[0].name).toBe('navigate')
+  })
+
+  it('overwrites attribution but preserves firstToolAt when a different agent claims the same tab', () => {
+    pages.set(1, { targetId: 't1', url: 'https://example.com/', title: 'Ex' })
+    registry.recordTool({
+      agentId: 'a1',
+      slug: 'finance',
+      pageId: 1,
+      targetId: 't1',
+      toolName: 'navigate',
+    })
+    nowMs += 500
+    registry.recordTool({
+      agentId: 'a2',
+      slug: 'travel',
+      pageId: 1,
+      targetId: 't1',
+      toolName: 'snapshot',
+    })
+    const snap = registry.snapshot()
+    expect(snap).toHaveLength(1)
+    expect(snap[0].agentId).toBe('a2')
+    expect(snap[0].slug).toBe('travel')
+    expect(snap[0].firstToolAt).toBe(1_000_000)
+    expect(snap[0].toolCount).toBe(2)
   })
 
   it('marks records active within the window and idle outside it', () => {
@@ -204,26 +291,7 @@ describe('TabActivityRegistry', () => {
     expect(snap.map((r) => r.targetId)).toEqual(['t1', 't2'])
   })
 
-  it('last write wins on agent attribution when two agents touch the same tab', () => {
-    pages.set(1, { targetId: 't1', url: 'https://a.com/', title: 'A' })
-    registry.recordTool({
-      agentId: 'a1',
-      slug: 'finance',
-      pageId: 1,
-      targetId: 't1',
-      toolName: 'navigate',
-    })
-    nowMs += 100
-    registry.recordTool({
-      agentId: 'a2',
-      slug: 'travel',
-      pageId: 1,
-      targetId: 't1',
-      toolName: 'snapshot',
-    })
-    const snap = registry.snapshot()
-    expect(snap).toHaveLength(1)
-    expect(snap[0].agentId).toBe('a2')
-    expect(snap[0].slug).toBe('travel')
-  })
+  // Superseded by "overwrites attribution but preserves firstToolAt"
+  // above; that case also checks the firstToolAt + toolCount semantics
+  // we want from PR 2.
 })

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/tabs/routes.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/tabs/routes.test.ts
@@ -4,21 +4,35 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
  * Integration test for the /tabs/activity route. Pins the response
- * shape and the empty-state behaviour. The registry-population path
- * is exercised by mcp/register tests; this file only verifies the
- * route surface.
+ * shape, the empty-state behaviour, and the agent-profile join.
+ * The registry-population path is exercised by mcp/register tests;
+ * this file only verifies the route surface.
  */
 
 import { afterEach, describe, expect, test } from 'bun:test'
 import { hc } from 'hono/client'
 import { setBrowserSession } from '../../../src/lib/browser-session'
 import { tabActivityRegistry } from '../../../src/lib/tab-activity'
+import { create as createAgent } from '../../../src/routes/agents/service'
 import app, { type AppType } from '../../../src/server'
+import { withTempBrowserosDir } from '../../_helpers/temp-browseros-dir'
 
 function client() {
   return hc<AppType>('http://localhost', {
     fetch: (input, init) => app.fetch(new Request(input, init)),
   })
+}
+
+function stubSession() {
+  setBrowserSession({
+    pages: {
+      getInfo: (pageId: number) =>
+        pageId === 1
+          ? { targetId: 't1', url: 'https://example.com/', title: 'Ex' }
+          : undefined,
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: stub for test
+  } as any)
 }
 
 afterEach(() => {
@@ -41,47 +55,97 @@ describe('/tabs/activity route', () => {
     expect(body).toEqual({ tabs: [] })
   })
 
-  test('returns the registry snapshot once tools have been recorded', async () => {
-    // Plant a fake session whose PageManager resolves a single page,
-    // record a tool against it, and expect the route to surface it.
-    setBrowserSession({
-      pages: {
-        getInfo: (pageId: number) =>
-          pageId === 1
-            ? { targetId: 't1', url: 'https://example.com/', title: 'Ex' }
-            : undefined,
-      },
-      // biome-ignore lint/suspicious/noExplicitAny: stub for test
-    } as any)
-    tabActivityRegistry.recordTool({
-      agentId: 'a-1',
-      slug: 'finance-ops',
-      pageId: 1,
-      targetId: 't1',
-      toolName: 'navigate',
+  test('returns the enriched record once a tool has been recorded', async () => {
+    await withTempBrowserosDir(async () => {
+      // Seed a real agent profile on disk so the route's join finds
+      // a label + harness instead of falling back.
+      const agent = await createAgent({
+        name: 'Finance Ops',
+        harness: 'Claude Code',
+        loginMode: 'profile',
+        selectedSites: ['stripe.com'],
+        approvals: {
+          submit: 'Ask',
+          payment: 'Block',
+          delete: 'Ask',
+          upload: 'Ask',
+          navigate: 'Auto',
+          input: 'Auto',
+        },
+        aclRuleIds: [],
+        customAclRules: [],
+      })
+      stubSession()
+      tabActivityRegistry.recordTool({
+        agentId: agent.id,
+        slug: agent.slug,
+        pageId: 1,
+        targetId: 't1',
+        toolName: 'navigate',
+      })
+      const res = await client().tabs.activity.$get()
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as {
+        tabs: Array<{
+          targetId: string
+          agentId: string
+          slug: string
+          firstToolAt: number
+          lastToolAt: number
+          lastToolName: string
+          toolCount: number
+          recentTools: Array<{ name: string; at: number }>
+          agentLabel: string
+          harness: string | null
+          color: string | null
+          status: 'active' | 'idle'
+        }>
+      }
+      expect(body.tabs).toHaveLength(1)
+      const row = body.tabs[0]
+      expect(row).toMatchObject({
+        targetId: 't1',
+        agentId: agent.id,
+        slug: agent.slug,
+        lastToolName: 'navigate',
+        toolCount: 1,
+        agentLabel: 'Finance Ops',
+        harness: 'Claude Code',
+        color: null,
+        status: 'active',
+      })
+      expect(row.firstToolAt).toBe(row.lastToolAt)
+      expect(row.recentTools).toEqual([
+        { name: 'navigate', at: row.lastToolAt },
+      ])
     })
-    const api = client()
-    const res = await api.tabs.activity.$get()
-    expect(res.status).toBe(200)
-    const body = (await res.json()) as {
-      tabs: Array<{
-        targetId: string
-        agentId: string
-        slug: string
-        toolName?: string
-        lastToolName: string
-        url: string
-        status: 'active' | 'idle'
-      }>
-    }
-    expect(body.tabs).toHaveLength(1)
-    expect(body.tabs[0]).toMatchObject({
-      targetId: 't1',
-      agentId: 'a-1',
-      slug: 'finance-ops',
-      lastToolName: 'navigate',
-      url: 'https://example.com/',
-      status: 'active',
+  })
+
+  test('falls back to slug when the agent profile is missing', async () => {
+    await withTempBrowserosDir(async () => {
+      // No profile on disk: the route should not throw, and should
+      // surface the slug as a fallback label with null harness/color.
+      stubSession()
+      tabActivityRegistry.recordTool({
+        agentId: 'unknown',
+        slug: 'orphan-slug',
+        pageId: 1,
+        targetId: 't1',
+        toolName: 'navigate',
+      })
+      const res = await client().tabs.activity.$get()
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as {
+        tabs: Array<{
+          agentLabel: string
+          harness: string | null
+          color: string | null
+        }>
+      }
+      expect(body.tabs).toHaveLength(1)
+      expect(body.tabs[0].agentLabel).toBe('orphan-slug')
+      expect(body.tabs[0].harness).toBeNull()
+      expect(body.tabs[0].color).toBeNull()
     })
   })
 })

--- a/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/ActivityRow.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/ActivityRow.tsx
@@ -150,7 +150,23 @@ export function ActivityRow({ row }: ActivityRowProps) {
               </span>
             </>
           )}
+          {row.toolCount !== undefined && row.toolCount > 0 && (
+            <>
+              {' . '}
+              <span className="font-mono text-[11.5px] text-ink-3">
+                {row.toolCount} {row.toolCount === 1 ? 'action' : 'actions'}
+              </span>
+            </>
+          )}
         </div>
+        {row.trail && (
+          <div
+            className="mt-0.5 truncate font-mono text-[10.5px] text-ink-3"
+            title={row.trail}
+          >
+            {row.trail}
+          </div>
+        )}
       </div>
       {flagged && jumpLabel ? (
         <button

--- a/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/RunningCard.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/RunningCard.tsx
@@ -60,7 +60,20 @@ export function RunningCard({ agent, onWatch, onStop }: RunningCardProps) {
                 ? 'Stopped by you'
                 : 'Completed'}
           </span>
+          {agent.toolCount !== undefined && agent.toolCount > 0 && (
+            <span className="shrink-0 rounded-full bg-bg-sunken px-1.5 py-0.5 font-mono text-[10.5px] text-ink-2">
+              {agent.toolCount} {agent.toolCount === 1 ? 'action' : 'actions'}
+            </span>
+          )}
         </div>
+        {agent.trail && (
+          <code
+            className="truncate font-mono text-[10.5px] text-ink-3"
+            title={agent.trail}
+          >
+            {agent.trail}
+          </code>
+        )}
         <div className="flex gap-2 border-border border-t pt-2.5">
           <button
             type="button"

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/activity.hooks.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/activity.hooks.ts
@@ -20,6 +20,10 @@ export interface ActivityRow {
    * `/governance/audit/:runId/replay`. Only required on done rows.
    */
   runId?: string
+  /** Total tool dispatches recorded against this tab. Surfaces as a badge. */
+  toolCount?: number
+  /** Short trail of recent tool names, e.g. `navigate -> snapshot -> act`. */
+  trail?: string
 }
 
 /**

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/agents.hooks.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/agents.hooks.ts
@@ -23,6 +23,19 @@ export interface AgentRow {
   liveLine: string
   /** Hex color used for the per-agent dot in cross-agent activity rows. */
   color: string
+  /**
+   * Total tool dispatches recorded against this tab since the agent
+   * first touched it. Surfaced as a small badge on the running card.
+   */
+  toolCount?: number
+  /** Epoch ms of the first tool dispatch on this tab. Surfaces as "started Xm ago". */
+  startedAt?: number
+  /**
+   * Short formatted trail of the last few tool names, e.g.
+   * `navigate -> snapshot -> act`. Empty string when no trail is
+   * available; the card hides the row in that case.
+   */
+  trail?: string
 }
 
 const MOCK_AGENTS: AgentRow[] = [

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/tabs.hooks.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/tabs.hooks.ts
@@ -4,15 +4,27 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
  * Polls `GET /cockpit/tabs/activity` so the homepage can render a
- * live view of which tabs each agent has touched and how recently.
- * Backed by the in-memory registry in
+ * live view of which tabs each agent has touched, how recently, and
+ * what sequence of tool calls produced the current state. Backed by
+ * the in-memory registry in
  * `apps/agent-mcp-interface/src/lib/tab-activity/`; refer to that
- * module for the record shape and the active-window threshold.
+ * module for the record shape, the active-window threshold, and the
+ * RECENT_TOOLS_CAP that bounds `recentTools`.
+ *
+ * The route enriches each record with the agent profile (label,
+ * harness, color), falling back to slug / null when the profile has
+ * been deleted between record and read. The hook surfaces those
+ * enriched fields directly so the screen does not have to join again.
  */
 
 import { createQuery } from 'react-query-kit'
 import { api } from './client'
 import { parseResponse } from './parseResponse'
+
+export interface ToolEvent {
+  name: string
+  at: number
+}
 
 export interface TabActivityRecord {
   targetId: string
@@ -21,9 +33,15 @@ export interface TabActivityRecord {
   title: string
   agentId: string
   slug: string
+  firstToolAt: number
   lastToolAt: number
   lastToolName: string
+  toolCount: number
+  recentTools: ToolEvent[]
   status: 'active' | 'idle'
+  agentLabel: string
+  harness: string | null
+  color: string | null
 }
 
 interface TabsActivityResponse {

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.helpers.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.helpers.test.ts
@@ -3,6 +3,8 @@ import type { TabActivityRecord } from '@/modules/api/tabs.hooks'
 import {
   colorForSlug,
   formatRelative,
+  formatToolTrail,
+  harnessForRow,
   siteOf,
   tabsToActivityRows,
   tabsToAgentRows,
@@ -16,9 +18,15 @@ function record(over: Partial<TabActivityRecord> = {}): TabActivityRecord {
     title: 'Ex',
     agentId: 'a1',
     slug: 'finance',
+    firstToolAt: 1_000_000,
     lastToolAt: 1_000_000,
     lastToolName: 'navigate',
+    toolCount: 1,
+    recentTools: [{ name: 'navigate', at: 1_000_000 }],
     status: 'active',
+    agentLabel: 'Finance Ops',
+    harness: 'Claude Code',
+    color: null,
     ...over,
   }
 }
@@ -61,6 +69,37 @@ describe('colorForSlug', () => {
   })
 })
 
+describe('formatToolTrail', () => {
+  it('joins tool names with -> and caps to the last N entries', () => {
+    const tools = ['navigate', 'snapshot', 'act', 'read', 'grep', 'screenshot']
+    expect(
+      formatToolTrail(
+        tools.map((name, i) => ({ name, at: i })),
+        4,
+      ),
+    ).toBe('act -> read -> grep -> screenshot')
+  })
+  it('returns an empty string when no recent tools exist', () => {
+    expect(formatToolTrail([])).toBe('')
+  })
+  it('uses the full trail when shorter than the cap', () => {
+    expect(formatToolTrail([{ name: 'navigate', at: 0 }], 4)).toBe('navigate')
+  })
+})
+
+describe('harnessForRow', () => {
+  it('passes through known harness names', () => {
+    expect(harnessForRow('Cursor')).toBe('Cursor')
+    expect(harnessForRow('Codex')).toBe('Codex')
+  })
+  it('falls back to Claude Code for null', () => {
+    expect(harnessForRow(null)).toBe('Claude Code')
+  })
+  it('falls back to Claude Code for unknown values', () => {
+    expect(harnessForRow('Atlas-9000')).toBe('Claude Code')
+  })
+})
+
 describe('tabsToAgentRows', () => {
   it('filters out idle records and maps to AgentRow shape', () => {
     const rows = tabsToAgentRows([
@@ -69,12 +108,60 @@ describe('tabsToAgentRows', () => {
     ])
     expect(rows.map((r) => r.id)).toEqual(['t1'])
     expect(rows[0]).toMatchObject({
-      label: 'finance',
+      label: 'Finance Ops',
       harness: 'Claude Code',
       site: 'example.com',
       task: 'Ex',
       status: 'running',
     })
+  })
+
+  it('uses the server-supplied agent label and harness', () => {
+    const rows = tabsToAgentRows([
+      record({
+        targetId: 't1',
+        status: 'active',
+        agentLabel: 'Cowork . File expenses',
+        harness: 'Cursor',
+      }),
+    ])
+    expect(rows[0].label).toBe('Cowork . File expenses')
+    expect(rows[0].harness).toBe('Cursor')
+  })
+
+  it('falls back to slug + Claude Code + hashed colour when the server returned null', () => {
+    const rows = tabsToAgentRows([
+      record({
+        targetId: 't1',
+        status: 'active',
+        slug: 'orphan',
+        agentLabel: '',
+        harness: null,
+        color: null,
+      }),
+    ])
+    expect(rows[0].label).toBe('orphan')
+    expect(rows[0].harness).toBe('Claude Code')
+    expect(rows[0].color).toBe(colorForSlug('orphan'))
+  })
+
+  it('surfaces the trail, action count, and startedAt on the row', () => {
+    const rows = tabsToAgentRows([
+      record({
+        targetId: 't1',
+        status: 'active',
+        recentTools: [
+          { name: 'navigate', at: 1_000_000 },
+          { name: 'snapshot', at: 1_000_100 },
+          { name: 'read', at: 1_000_200 },
+        ],
+        toolCount: 3,
+        firstToolAt: 1_000_000,
+      }),
+    ])
+    expect(rows[0].toolCount).toBe(3)
+    expect(rows[0].startedAt).toBe(1_000_000)
+    expect(rows[0].trail).toBe('navigate -> snapshot -> read')
   })
 })
 
@@ -95,11 +182,33 @@ describe('tabsToActivityRows', () => {
     )
     expect(rows.map((r) => r.id)).toEqual(['t2'])
     expect(rows[0]).toMatchObject({
-      agentLabel: 'travel',
+      agentLabel: 'Finance Ops',
       status: 'done',
       action: 'read on Ex',
       site: 'example.com',
       when: '50s ago',
     })
+  })
+
+  it('surfaces the trail + action count on idle rows too', () => {
+    const rows = tabsToActivityRows(
+      [
+        record({
+          targetId: 't2',
+          status: 'idle',
+          lastToolAt: 950_000,
+          lastToolName: 'read',
+          recentTools: [
+            { name: 'navigate', at: 900_000 },
+            { name: 'snapshot', at: 925_000 },
+            { name: 'read', at: 950_000 },
+          ],
+          toolCount: 3,
+        }),
+      ],
+      1_000_000,
+    )
+    expect(rows[0].toolCount).toBe(3)
+    expect(rows[0].trail).toBe('navigate -> snapshot -> read')
   })
 })

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.helpers.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.helpers.ts
@@ -1,10 +1,12 @@
 import type { ActivityRow } from '@/modules/api/activity.hooks'
 import type { AgentRow } from '@/modules/api/agents.hooks'
-import type { TabActivityRecord } from '@/modules/api/tabs.hooks'
+import type { TabActivityRecord, ToolEvent } from '@/modules/api/tabs.hooks'
+import { HARNESSES, type Harness } from '@/screens/new-agent/new-agent.schemas'
 
-// Small palette so each agent gets a stable colour without joining a
-// profile lookup. Hash the slug; if two agents collide it is purely
-// cosmetic.
+// Fallback palette used when the server-side join did not return a
+// colour for the agent (today no profile field exists; the server
+// always emits null). Hashing the slug keeps the colour stable per
+// agent so cards do not flicker between polls.
 const PALETTE = [
   '#F26B2A',
   '#2F6FE0',
@@ -15,6 +17,8 @@ const PALETTE = [
   '#F59E0B',
   '#DB2777',
 ]
+
+const TRAIL_DISPLAY_CAP = 4
 
 export function colorForSlug(slug: string): string {
   let hash = 0
@@ -45,25 +49,54 @@ export function formatRelative(ms: number, now: number): string {
 }
 
 /**
+ * Returns the most recent N tool names joined with `->` for the
+ * RunningCard's trail row. Capped to keep the card visually tight;
+ * the full ring buffer is still in the data for any other consumer.
+ */
+export function formatToolTrail(
+  recentTools: ToolEvent[],
+  max: number = TRAIL_DISPLAY_CAP,
+): string {
+  if (recentTools.length === 0) return ''
+  const tail = recentTools.slice(-max)
+  return tail.map((t) => t.name).join(' -> ')
+}
+
+/**
+ * Coerces the server-supplied harness string back into the UI's
+ * `Harness` union. Unknown values (older profiles, hand-edited
+ * files, server-side enum drift) fall back to 'Claude Code' so the
+ * harness icon still resolves to something concrete.
+ */
+export function harnessForRow(value: string | null): Harness {
+  if (!value) return 'Claude Code'
+  return (HARNESSES as readonly string[]).includes(value)
+    ? (value as Harness)
+    : 'Claude Code'
+}
+
+/**
  * Tabs whose `status === 'active'` become live agent cards. The
- * label, harness, and color are derived locally from the slug since
- * PR 1 does not join the agent profile.
+ * label, harness, and colour all come from the route's profile join
+ * when available, falling back to slug-derived defaults so a record
+ * whose profile was deleted between dispatch and render still shows
+ * something useful.
  */
 export function tabsToAgentRows(records: TabActivityRecord[]): AgentRow[] {
   return records
     .filter((r) => r.status === 'active')
     .map((r) => ({
       id: r.targetId,
-      label: r.slug,
-      // TODO(pr-3 homepage): join the agent profile and surface the
-      // real harness; today every row reads "Claude Code" because the
-      // TabActivityRecord does not carry it.
-      harness: 'Claude Code',
+      label: r.agentLabel || r.slug,
+      harness: harnessForRow(r.harness),
       site: siteOf(r.url),
       task: r.title || siteOf(r.url),
       status: 'running' as const,
       liveLine: `${r.lastToolName} - ${r.title || siteOf(r.url)}`,
-      color: colorForSlug(r.slug),
+      color: r.color ?? colorForSlug(r.slug),
+      toolCount: r.toolCount,
+      startedAt: r.firstToolAt,
+      trail: formatToolTrail(r.recentTools),
     }))
 }
 
@@ -79,11 +112,13 @@ export function tabsToActivityRows(
     .filter((r) => r.status === 'idle')
     .map((r) => ({
       id: r.targetId,
-      agentLabel: r.slug,
-      color: colorForSlug(r.slug),
+      agentLabel: r.agentLabel || r.slug,
+      color: r.color ?? colorForSlug(r.slug),
       status: 'done' as const,
       action: `${r.lastToolName} on ${r.title || siteOf(r.url)}`,
       site: siteOf(r.url),
       when: formatRelative(r.lastToolAt, now),
+      toolCount: r.toolCount,
+      trail: formatToolTrail(r.recentTools),
     }))
 }


### PR DESCRIPTION
## Summary

Second of three PRs from the cockpit-homepage plan. PR 1 gave us one snapshot per tab; this one turns it into a live activity trail so a user can glance at a card and see the agent walking through the page. Each record gains a ring buffer of recent tool calls, a total action count, and the timestamp of the first dispatch, and the route response joins the agent profile so the homepage drops the slug-hash placeholder colour and shows the real label + harness. No human-takeover work yet; the takeover branch of the parent plan stays parked.

Zero diffs in `apps/server`. All changes scoped to `apps/agent-mcp-interface` and `apps/agent-mcp-ui`.

## What changes

**`apps/agent-mcp-interface`:**

- `TabActivityRecord` grows `firstToolAt` (immutable after first write), `lastToolAt` / `lastToolName` (kept), `toolCount`, and `recentTools: { name, at }[]` capped at `RECENT_TOOLS_CAP = 8`.
- `recordTool` now updates an existing record in place rather than overwriting wholesale so the trail and counts accumulate. When a different agent rebinds to the same target, attribution moves to the new agent but `firstToolAt` is preserved.
- `snapshot()` hands consumers a defensive copy of `recentTools` so callers cannot mutate the internal ring buffer.
- `GET /cockpit/tabs/activity` joins the agents directory and adds `agentLabel`, `harness`, and `color` per row. Missing profiles fall back to slug + null and never throw. `color` is null today because the stored profile shape has no colour field; the wire is ready for the day it does.

**`apps/agent-mcp-ui`:**

- `tabs.hooks` record type mirrors the enriched server shape.
- New helpers in `cockpit.helpers.ts`:
  - `formatToolTrail(recentTools, cap = 4)` returns `navigate -> snapshot -> act -> read`.
  - `harnessForRow(value)` coerces an unknown harness string to a known union with a `Claude Code` fallback.
- `tabsToAgentRows` / `tabsToActivityRows` read the joined `agentLabel` / `harness` / `color` directly, keeping the slug-hash palette as a fallback when the server returns null. The PR 1 `TODO(pr-3 homepage)` comment is gone.
- `AgentRow` and `ActivityRow` grow optional `toolCount` / `startedAt` / `trail` fields.
- `RunningCard` renders the trail as a tight mono line under the live-status row and adds an action-count chip. `ActivityRow` surfaces the action count inline with the action text and the trail underneath. PR 3 can polish the styling.

## Server-side guarantees

```
$ git diff origin/main...HEAD --name-only | grep '^packages/browseros-agent/apps/server' | wc -l
0
```

No edits to `apps/server/src/tools/browser/`, no edits to `executeTool`, no new fields threaded through the framework. The cockpit reads the agents service and the PageManager via accessors it already owns.

## Test plan

- [x] Unit tests for `TabActivityRegistry`:
  - First record carries `firstToolAt === lastToolAt`, `toolCount: 1`, single-entry `recentTools`.
  - Two records for the same target: `firstToolAt` unchanged, `toolCount: 2`, both events in chronological order.
  - Nine records: trail caps at 8, oldest two drop off, `toolCount: 9`.
  - Defensive copy: mutating the returned `recentTools` does not affect future snapshots.
  - Different-agent rebind: attribution flips, `firstToolAt` preserved, `toolCount` keeps incrementing.
- [x] Integration tests for `/tabs/activity`:
  - Enriched response shape with seeded agent profile (label / harness / color).
  - Missing-profile fallback: slug as label, null harness and color, no crash.
- [x] Helper tests for the new UI surface:
  - `formatToolTrail` caps + joins + empty-state.
  - `harnessForRow` passes known values, falls back on null / unknown.
  - `tabsToAgentRows` uses server-supplied label / harness / colour when present, slug fallback when null.
  - `tabsToActivityRows` surfaces the trail + count on idle rows.
- [x] All 143 existing tests still pass across the two packages.
- [x] `bun run --filter '*' typecheck` clean across the workspace.
- [x] `bunx biome ci .` clean.

**Manual walk-through** (reviewer action against a live BrowserOS):

1. Start `apps/server` against a running BrowserOS.
2. With one active agent profile (e.g. "Finance Ops" / Claude Code), open the cockpit homepage. Confirm `RunningGrid` is empty.
3. Fire `navigate { page: 1, url: 'https://example.com' }` against `/cockpit/mcp/<slug>`.
4. Within ~2 s the homepage card shows the agent's configured name ("Finance Ops" not the slug), the harness icon for Claude Code, the trail `navigate`, and a `1 action` chip.
5. Fire `snapshot { page: 1 }`, then `read { page: 1 }`. The trail line grows to `navigate -> snapshot -> read`, `3 actions`.
6. Wait 5 s. The card moves to `RecentActivity` with the same trail + action count.
7. Delete the agent profile (`DELETE /cockpit/agents/:id`) without closing the tab. The card label degrades to the slug, harness icon falls back to Claude Code, colour falls back to the hashed palette.
8. Failed dispatch (`navigate { page: 999 }`) does NOT advance `toolCount` or extend the trail (PR 1 behaviour intact).
9. Closing the tab evicts the record on the next snapshot read.

## Follow-ups (not in this PR)

- PR 3 of the homepage arc: polish styling on the trail row, sparkline visualisation, per-tool relative timestamps on hover.
- Add a stored `color` field to the agent profile so the route emits a real colour instead of `null` and the UI drops the slug-hash fallback entirely.