### PR TITLE
fix(composer): voice-mode button overlap and home voice entry

### DIFF
--- a/packages/browseros-agent/apps/agent/screens/agent-command/AgentCommandHome.tsx
+++ b/packages/browseros-agent/apps/agent/screens/agent-command/AgentCommandHome.tsx
@@ -164,6 +164,9 @@ export const AgentCommandHome: FC = () => {
                   ? `Ask ${selectedProvider.name} to handle a task...`
                   : 'Loading providers...'
               }
+              onOpenVoiceMode={() => {
+                navigate('/home/chat?voice=open&mode=chat')
+              }}
             />
           </div>
         </div>

--- a/packages/browseros-agent/apps/agent/screens/agent-command/ConversationInput.tsx
+++ b/packages/browseros-agent/apps/agent/screens/agent-command/ConversationInput.tsx
@@ -1,5 +1,6 @@
 import {
   ArrowRight,
+  AudioLines,
   Bot,
   ChevronDown,
   FileText,
@@ -65,6 +66,12 @@ export interface ConversationInputProps {
    * button (legacy behaviour for the home composer).
    */
   onStop?: () => void
+  /**
+   * When set, a voice-mode entry button surfaces next to the dictation
+   * mic. Home uses this to hand off to the chat surface where the full
+   * voice-loop overlay lives. Absent → button hidden.
+   */
+  onOpenVoiceMode?: () => void
 }
 
 function InputActionButton({
@@ -112,6 +119,22 @@ function StopButton({ onStop }: { onStop: () => void }) {
       className="h-8 w-8 flex-shrink-0 rounded-lg bg-destructive/10 text-destructive transition-colors hover:bg-destructive/15 hover:text-destructive"
     >
       <Square className="h-3.5 w-3.5 fill-current" />
+    </Button>
+  )
+}
+
+function VoiceModeEntryButton({ onClick }: { onClick: () => void }) {
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="icon"
+      onClick={onClick}
+      className="h-10 w-10 flex-shrink-0 rounded-xl text-muted-foreground transition-colors hover:text-foreground"
+      title="Open voice mode"
+      aria-label="Open voice mode"
+    >
+      <AudioLines className="h-5 w-5" />
     </Button>
   )
 }
@@ -359,6 +382,7 @@ export const ConversationInput: FC<ConversationInputProps> = ({
   attachmentsEnabled = true,
   variant = 'conversation',
   onStop,
+  onOpenVoiceMode,
 }) => {
   const [input, setInput] = useState('')
   const [selectedTabs, setSelectedTabs] = useState<chrome.tabs.Tab[]>([])
@@ -578,6 +602,9 @@ export const ConversationInput: FC<ConversationInputProps> = ({
             />
           </div>
           {streaming && onStop ? <StopButton onStop={onStop} /> : null}
+          {onOpenVoiceMode ? (
+            <VoiceModeEntryButton onClick={onOpenVoiceMode} />
+          ) : null}
           <VoiceButton
             isRecording={voice.isRecording}
             isTranscribing={voice.isTranscribing}

--- a/packages/browseros-agent/apps/agent/screens/newtab/index/NewTabChat.tsx
+++ b/packages/browseros-agent/apps/agent/screens/newtab/index/NewTabChat.tsx
@@ -29,6 +29,7 @@ import { ChatMessages } from '@/screens/sidepanel/index/ChatMessages'
 export const NewTabChat: FC = () => {
   const [searchParams, setSearchParams] = useSearchParams()
   const hasSentInitialRef = useRef(false)
+  const hasOpenedVoiceRef = useRef(false)
 
   const {
     mode,
@@ -123,6 +124,20 @@ export const NewTabChat: FC = () => {
     } else {
       sendMessage({ text: query })
     }
+  }, [])
+
+  // Honour the `?voice=open` deep link from the home composer's voice-mode
+  // entry button: open the voice loop once after mount and strip the param
+  // so a refresh doesn't reopen it.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: must only run once on mount
+  useEffect(() => {
+    if (hasOpenedVoiceRef.current) return
+    if (searchParams.get('voice') !== 'open') return
+    hasOpenedVoiceRef.current = true
+    const next = new URLSearchParams(searchParams)
+    next.delete('voice')
+    setSearchParams(next, { replace: true })
+    void voiceLoop.open()
   }, [])
 
   const handleNewConversation = () => {

--- a/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatInput.tsx
+++ b/packages/browseros-agent/apps/agent/screens/sidepanel/index/ChatInput.tsx
@@ -347,6 +347,22 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
       )
     }
 
+    // The floating button cluster (voice mode + dictation + send) sits
+    // absolutely on top of the input, so its width has to be reserved as
+    // padding on the input or text slides under the icons. Derive the
+    // padding from the count of buttons that will actually render — the
+    // cluster grows/shrinks with props and recording state.
+    const showVoiceMode = !!onOpenVoiceMode && !voice?.isRecording
+    const showDictation = !!voice
+    const visibleButtonCount =
+      1 + (showVoiceMode ? 1 : 0) + (showDictation ? 1 : 0)
+    const inputPaddingRight =
+      visibleButtonCount === 3
+        ? 'pr-32'
+        : visibleButtonCount === 2
+          ? 'pr-20'
+          : 'pr-11'
+
     return (
       <form
         onSubmit={handleSubmit}
@@ -362,7 +378,12 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
           anchorRef={textareaRef}
         />
         {voice?.isRecording ? (
-          <div className="flex min-h-[42px] flex-1 items-center justify-center gap-1 rounded-2xl border border-red-500/50 bg-muted/50 px-4 py-2.5 pr-[4.5rem]">
+          <div
+            className={cn(
+              'flex min-h-[42px] flex-1 items-center justify-center gap-1 rounded-2xl border border-red-500/50 bg-muted/50 px-4 py-2.5',
+              inputPaddingRight,
+            )}
+          >
             {voice.audioLevels.map((level, i) => (
               <div
                 key={i.toString()}
@@ -378,7 +399,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(
             ref={textareaRef}
             className={cn(
               'field-sizing-content max-h-60 min-h-[42px] flex-1 resize-none overflow-hidden rounded-2xl border border-border/50 bg-muted/50 px-4 py-2.5 text-sm outline-none transition-colors placeholder:text-muted-foreground/70 hover:border-border focus:border-[var(--accent-orange)]',
-              voice ? 'pr-[4.5rem]' : 'pr-11',
+              inputPaddingRight,
             )}
             value={input}
             onChange={(e) => handleInputChange(e.target.value)}


### PR DESCRIPTION
Composer textarea right padding now derives from the number of buttons that actually render, so the floating voice-mode + dictation + send cluster never overlaps the user's text in the sidepanel or in `#/home/chat`.

Adds an AudioLines voice-mode entry button on the home composer; clicking it navigates to `/home/chat?voice=open&mode=chat`. The chat screen reads that deep link on mount and opens the voice loop once, then strips the param so a refresh does not reopen it.