### PR TITLE
feat(cockpit): roll up homepage running grid by agent (PR 3/3)

### DIFF
--- a/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/AgentRunningCard.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/AgentRunningCard.tsx
@@ -1,0 +1,99 @@
+import { Check, ExternalLink, RefreshCw, Square } from 'lucide-react'
+import { Card } from '@/components/ui/card'
+import type { AgentActivityRecord } from '@/screens/cockpit/cockpit.helpers'
+import { formatToolTrail, siteOf } from '@/screens/cockpit/cockpit.helpers'
+import { MiniScreencast } from './MiniScreencast'
+import { StatusBadge } from './StatusBadge'
+import { TabCountChip } from './TabCountChip'
+
+interface AgentRunningCardProps {
+  agent: AgentActivityRecord
+  onWatch?: () => void
+  onStop?: () => void
+}
+
+/**
+ * One card per agent on the homepage running grid. The focus tab is
+ * the agent's freshest `lastToolAt` and supplies the visible
+ * surface: site host, task title, mini-screencast. The "N tabs" chip
+ * in the header opens a popover with the full tab list when the
+ * agent is driving more than one tab. Trail and action count are
+ * merged across all of this agent's tabs so the card tells the
+ * complete story of what the agent has been doing, not just the
+ * current focus.
+ */
+export function AgentRunningCard({
+  agent,
+  onWatch,
+  onStop,
+}: AgentRunningCardProps) {
+  const focus = agent.currentFocus
+  const active = agent.status === 'active'
+  const trail = formatToolTrail(agent.recentTools)
+  const liveLine = `${agent.lastToolName} - ${focus.title || siteOf(focus.url)}`
+
+  return (
+    <Card
+      data-agent-card
+      className="group flex cursor-pointer flex-col overflow-hidden border-border-2 p-0 transition hover:border-border-strong hover:shadow-card"
+    >
+      <MiniScreencast site={siteOf(focus.url)} live={active} />
+      <div className="flex flex-1 flex-col gap-2 p-3.5">
+        <div className="flex items-center gap-2">
+          <span className="min-w-0 flex-1 truncate font-bold text-[13.5px]">
+            {agent.agentLabel}
+          </span>
+          <TabCountChip tabs={agent.tabs} focusTargetId={focus.targetId} />
+          <StatusBadge status={active ? 'running' : 'done'} />
+        </div>
+        <code className="truncate font-mono text-[11px] text-ink-3">
+          {siteOf(focus.url)}
+        </code>
+        <p className="line-clamp-2 min-h-9 text-[12.5px] text-ink-2 leading-snug">
+          {focus.title || siteOf(focus.url)}
+        </p>
+        <div className="mt-auto flex items-center gap-1.5 text-[11.5px] text-ink-2">
+          {active ? (
+            <RefreshCw className="size-3 shrink-0 animate-spin text-accent" />
+          ) : (
+            <Check className="size-3 shrink-0 text-green" />
+          )}
+          <span className="min-w-0 flex-1 truncate font-mono">
+            {active ? liveLine : 'Completed'}
+          </span>
+          {agent.toolCount > 0 && (
+            <span className="shrink-0 rounded-full bg-bg-sunken px-1.5 py-0.5 font-mono text-[10.5px] text-ink-2">
+              {agent.toolCount} {agent.toolCount === 1 ? 'action' : 'actions'}
+            </span>
+          )}
+        </div>
+        {trail && (
+          <code
+            className="truncate font-mono text-[10.5px] text-ink-3"
+            title={trail}
+          >
+            {trail}
+          </code>
+        )}
+        <div className="flex gap-2 border-border border-t pt-2.5">
+          <button
+            type="button"
+            onClick={onWatch}
+            className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-md px-2 py-1.5 font-semibold text-[12.5px] text-ink-2 transition hover:bg-bg-sunken hover:text-ink"
+          >
+            <ExternalLink className="size-3.5" /> Watch
+          </button>
+          {active && (
+            <button
+              type="button"
+              onClick={onStop}
+              className="inline-flex items-center justify-center gap-1.5 rounded-md bg-bg-sunken px-2.5 py-1.5 font-semibold text-[12.5px] text-ink-2 transition hover:bg-card-tint hover:text-ink"
+            >
+              <Square className="size-3" /> Stop
+            </button>
+          )}
+        </div>
+      </div>
+    </Card>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/RunningGrid.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/RunningGrid.tsx
@@ -1,22 +1,21 @@
 import { useNavigate } from 'react-router'
-import { isActiveStatus } from '@/lib/status'
-import type { AgentRow } from '@/modules/api/agents.hooks'
+import type { AgentActivityRecord } from '@/screens/cockpit/cockpit.helpers'
 import { AddAgentTile } from './AddAgentTile'
-import { RunningCard } from './RunningCard'
+import { AgentRunningCard } from './AgentRunningCard'
 
 interface RunningGridProps {
-  agents: AgentRow[]
+  agents: AgentActivityRecord[]
 }
 
 /**
- * Uniform card grid. Renders one card per agent plus a trailing
- * AddAgentTile so "create another profile" reads as adding to the
- * set, not a floating header CTA. The live-count chip on the header
- * surfaces the most-useful at-a-glance metric.
+ * Uniform card grid. PR 3 rolls the per-tab records up by agent so
+ * each card represents one logical run across however many tabs that
+ * agent currently drives. The trailing AddAgentTile reads as "create
+ * another profile" so the section feels like a set.
  */
 export function RunningGrid({ agents }: RunningGridProps) {
   const navigate = useNavigate()
-  const liveCount = agents.filter((a) => isActiveStatus(a.status)).length
+  const liveCount = agents.filter((a) => a.status === 'active').length
 
   return (
     <section className="space-y-3">
@@ -32,10 +31,10 @@ export function RunningGrid({ agents }: RunningGridProps) {
       </div>
       <div className="grid grid-cols-[repeat(auto-fill,minmax(258px,1fr))] items-start gap-3.5">
         {agents.map((a) => (
-          <RunningCard
-            key={a.id}
+          <AgentRunningCard
+            key={a.agentId}
             agent={a}
-            onWatch={() => navigate(`/run/${a.id}`)}
+            onWatch={() => navigate(`/run/${a.currentFocus.targetId}`)}
           />
         ))}
         <AddAgentTile />

--- a/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/TabCountChip.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/TabCountChip.tsx
@@ -1,0 +1,68 @@
+import { Layers } from 'lucide-react'
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover'
+import type { TabActivityRecord } from '@/modules/api/tabs.hooks'
+import { siteOf } from '@/screens/cockpit/cockpit.helpers'
+
+interface TabCountChipProps {
+  tabs: TabActivityRecord[]
+  /** Target id of the focus tab so the popover can highlight it. */
+  focusTargetId: string
+}
+
+/**
+ * "N tabs" chip on the AgentRunningCard header. Click to open a
+ * popover listing every tab this agent owns, with the current focus
+ * highlighted and the last tool name shown per row.
+ */
+export function TabCountChip({ tabs, focusTargetId }: TabCountChipProps) {
+  if (tabs.length <= 1) return null
+  return (
+    <Popover>
+      <PopoverTrigger
+        data-tab-count={tabs.length}
+        className="inline-flex shrink-0 items-center gap-1 rounded-full border border-border-2 bg-card px-1.5 py-[1.5px] font-bold text-[10px] text-ink-2 uppercase tracking-wider transition hover:border-border-strong"
+      >
+        <Layers className="size-2.5" />
+        {tabs.length} tabs
+      </PopoverTrigger>
+      <PopoverContent className="w-72 p-2" align="end">
+        <ul className="flex flex-col gap-1">
+          {tabs.map((tab) => {
+            const isFocus = tab.targetId === focusTargetId
+            return (
+              <li
+                key={tab.targetId}
+                className={
+                  isFocus
+                    ? 'flex items-start gap-2 rounded-md bg-card-tint px-2 py-1.5'
+                    : 'flex items-start gap-2 rounded-md px-2 py-1.5 hover:bg-bg-sunken'
+                }
+              >
+                <span
+                  aria-hidden
+                  className={
+                    isFocus
+                      ? 'mt-1 size-1.5 shrink-0 rounded-full bg-accent'
+                      : 'mt-1 size-1.5 shrink-0 rounded-full bg-ink-4'
+                  }
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="truncate font-semibold text-[12px]">
+                    {tab.title || siteOf(tab.url)}
+                  </div>
+                  <div className="truncate font-mono text-[10.5px] text-ink-3">
+                    {tab.lastToolName} . {siteOf(tab.url)}
+                  </div>
+                </div>
+              </li>
+            )
+          })}
+        </ul>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.data.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.data.ts
@@ -1,5 +1,4 @@
 import type { ActivityRow } from '@/modules/api/activity.hooks'
-import type { AgentRow } from '@/modules/api/agents.hooks'
 import { useTabsActivity } from '@/modules/api/tabs.hooks'
 import {
   type ApprovalItem,
@@ -7,10 +6,14 @@ import {
   useApprovals,
   useHandoffs,
 } from '@/modules/api/waiting.hooks'
-import { tabsToActivityRows, tabsToAgentRows } from './cockpit.helpers'
+import {
+  type AgentActivityRecord,
+  tabsToActivityRows,
+  tabsToAgentActivity,
+} from './cockpit.helpers'
 
 export interface CockpitData {
-  agents: AgentRow[]
+  agents: AgentActivityRecord[]
   activity: ActivityRow[]
   approvals: ApprovalItem[]
   handoffs: HandoffItem[]
@@ -19,10 +22,12 @@ export interface CockpitData {
 
 /**
  * Single data aggregation hook for the homepage. Per the project
- * convention, the screen calls this and nothing else. PR 1 wires the
- * running grid and recent activity to the real
- * `GET /cockpit/tabs/activity` registry; approvals and handoffs
- * remain on their mocked hooks until later PRs supply them.
+ * convention, the screen calls this and nothing else. PR 3 rolls up
+ * the running grid by agent so each card represents one logical run
+ * across however many tabs it touches. The recent-activity section
+ * stays tab-level by design: "Cowork did read on Stripe 12m ago" is
+ * more informative than "Cowork did 14 things". Approvals and
+ * handoffs remain on their mocked hooks until later PRs supply them.
  */
 export function useCockpitData(): CockpitData {
   const tabs = useTabsActivity()
@@ -35,7 +40,10 @@ export function useCockpitData(): CockpitData {
   const records = tabs.data?.tabs ?? []
   const now = Date.now()
   return {
-    agents: tabsToAgentRows(records),
+    // The rollup only considers active records so an agent that is
+    // currently idle drops out of the running grid; its individual
+    // tabs still appear in the recent activity list below.
+    agents: tabsToAgentActivity(records.filter((r) => r.status === 'active')),
     activity: tabsToActivityRows(records, now),
     approvals: approvals.data ?? [],
     handoffs: handoffs.data ?? [],

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.helpers.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.helpers.test.ts
@@ -7,6 +7,7 @@ import {
   harnessForRow,
   siteOf,
   tabsToActivityRows,
+  tabsToAgentActivity,
   tabsToAgentRows,
 } from './cockpit.helpers'
 
@@ -210,5 +211,164 @@ describe('tabsToActivityRows', () => {
     )
     expect(rows[0].toolCount).toBe(3)
     expect(rows[0].trail).toBe('navigate -> snapshot -> read')
+  })
+})
+
+describe('tabsToAgentActivity', () => {
+  it('returns a single record when one agent owns one tab', () => {
+    const agents = tabsToAgentActivity([record({ targetId: 't1' })])
+    expect(agents).toHaveLength(1)
+    expect(agents[0].tabs).toHaveLength(1)
+    expect(agents[0].currentFocus.targetId).toBe('t1')
+    expect(agents[0].toolCount).toBe(1)
+    expect(agents[0].lastToolName).toBe('navigate')
+  })
+
+  it('rolls three tabs of the same agent into one record', () => {
+    const agents = tabsToAgentActivity([
+      record({
+        targetId: 't1',
+        firstToolAt: 1_000_000,
+        lastToolAt: 1_000_200,
+        lastToolName: 'navigate',
+        toolCount: 1,
+        recentTools: [{ name: 'navigate', at: 1_000_200 }],
+      }),
+      record({
+        targetId: 't2',
+        firstToolAt: 1_000_100,
+        lastToolAt: 1_000_500,
+        lastToolName: 'snapshot',
+        toolCount: 2,
+        recentTools: [
+          { name: 'navigate', at: 1_000_100 },
+          { name: 'snapshot', at: 1_000_500 },
+        ],
+      }),
+      record({
+        targetId: 't3',
+        firstToolAt: 1_000_050,
+        lastToolAt: 1_001_000,
+        lastToolName: 'act',
+        toolCount: 3,
+        recentTools: [
+          { name: 'read', at: 1_000_300 },
+          { name: 'grep', at: 1_000_600 },
+          { name: 'act', at: 1_001_000 },
+        ],
+      }),
+    ])
+    expect(agents).toHaveLength(1)
+    const agent = agents[0]
+    expect(agent.tabs).toHaveLength(3)
+    expect(agent.currentFocus.targetId).toBe('t3')
+    expect(agent.firstToolAt).toBe(1_000_000)
+    expect(agent.lastToolAt).toBe(1_001_000)
+    expect(agent.lastToolName).toBe('act')
+    expect(agent.toolCount).toBe(6)
+    // Merged trail is sorted by `at`, capped at MERGED_TRAIL_CAP=8.
+    expect(agent.recentTools.map((t) => t.name)).toEqual([
+      'navigate',
+      'navigate',
+      'read',
+      'snapshot',
+      'grep',
+      'act',
+    ])
+  })
+
+  it('caps the merged trail at MERGED_TRAIL_CAP=8', () => {
+    const events = (offset: number) =>
+      Array.from({ length: 5 }, (_, i) => ({
+        name: `tool-${offset + i}`,
+        at: 1_000_000 + offset * 1000 + i,
+      }))
+    const agents = tabsToAgentActivity([
+      record({ targetId: 't1', recentTools: events(0), toolCount: 5 }),
+      record({ targetId: 't2', recentTools: events(5), toolCount: 5 }),
+      record({ targetId: 't3', recentTools: events(10), toolCount: 5 }),
+    ])
+    expect(agents).toHaveLength(1)
+    expect(agents[0].recentTools).toHaveLength(8)
+    // After the cap, the oldest 7 entries are dropped; the newest 8
+    // (sorted by `at`) survive.
+    expect(agents[0].recentTools[0].name).toBe('tool-7')
+    expect(agents[0].recentTools[7].name).toBe('tool-14')
+  })
+
+  it('groups two distinct agent ids into two records sorted by lastToolAt desc', () => {
+    const agents = tabsToAgentActivity([
+      record({
+        targetId: 't1',
+        agentId: 'a1',
+        slug: 'older',
+        lastToolAt: 1_000_000,
+      }),
+      record({
+        targetId: 't2',
+        agentId: 'a2',
+        slug: 'newer',
+        lastToolAt: 2_000_000,
+      }),
+    ])
+    expect(agents).toHaveLength(2)
+    expect(agents[0].agentId).toBe('a2')
+    expect(agents[1].agentId).toBe('a1')
+  })
+
+  it('marks the agent active when at least one of its tabs is active', () => {
+    const agents = tabsToAgentActivity([
+      record({ targetId: 't1', status: 'idle' }),
+      record({ targetId: 't2', status: 'active' }),
+    ])
+    expect(agents[0].status).toBe('active')
+  })
+
+  it('marks the agent idle when all tabs are idle', () => {
+    const agents = tabsToAgentActivity([
+      record({ targetId: 't1', status: 'idle' }),
+      record({ targetId: 't2', status: 'idle' }),
+    ])
+    expect(agents[0].status).toBe('idle')
+  })
+
+  it('falls back to slug when the server-side agentLabel is missing', () => {
+    const agents = tabsToAgentActivity([
+      record({
+        targetId: 't1',
+        slug: 'orphan',
+        agentLabel: '',
+        harness: null,
+        color: null,
+      }),
+    ])
+    expect(agents[0].agentLabel).toBe('orphan')
+    expect(agents[0].harness).toBe('Claude Code')
+    expect(agents[0].color).toBe(colorForSlug('orphan'))
+  })
+
+  it('uses the focus tab for the current url/title surface even when older tabs have more activity', () => {
+    const agents = tabsToAgentActivity([
+      record({
+        targetId: 't-busy',
+        url: 'https://busy.example.com/',
+        title: 'Busy',
+        toolCount: 100,
+        lastToolAt: 1_000_000,
+      }),
+      record({
+        targetId: 't-fresh',
+        url: 'https://fresh.example.com/',
+        title: 'Fresh',
+        toolCount: 1,
+        lastToolAt: 2_000_000,
+      }),
+    ])
+    expect(agents[0].currentFocus.targetId).toBe('t-fresh')
+    expect(agents[0].currentFocus.url).toBe('https://fresh.example.com/')
+  })
+
+  it('returns an empty array for empty input', () => {
+    expect(tabsToAgentActivity([])).toEqual([])
   })
 })

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.helpers.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.helpers.ts
@@ -19,6 +19,7 @@ const PALETTE = [
 ]
 
 const TRAIL_DISPLAY_CAP = 4
+const MERGED_TRAIL_CAP = 8
 
 export function colorForSlug(slug: string): string {
   let hash = 0
@@ -98,6 +99,77 @@ export function tabsToAgentRows(records: TabActivityRecord[]): AgentRow[] {
       startedAt: r.firstToolAt,
       trail: formatToolTrail(r.recentTools),
     }))
+}
+
+/**
+ * Roll-up shape for the homepage's RunningGrid. PR 1 / PR 2 rendered
+ * one card per tab; in practice one agent often drives multiple tabs
+ * and the user wants one card per agent with the tabs nested inside.
+ * The `currentFocus` is the tab whose `lastToolAt` is freshest; the
+ * card uses its url + title for the visible surface and lists the
+ * other tabs in a popover.
+ */
+export interface AgentActivityRecord {
+  agentId: string
+  slug: string
+  agentLabel: string
+  harness: Harness
+  color: string
+  firstToolAt: number
+  lastToolAt: number
+  lastToolName: string
+  toolCount: number
+  /** Merged across all this agent's tabs, sorted by `at`, capped at MERGED_TRAIL_CAP. */
+  recentTools: ToolEvent[]
+  status: 'active' | 'idle'
+  /** The tab whose `lastToolAt` is freshest. Always present (a rollup with no tabs is impossible). */
+  currentFocus: TabActivityRecord
+  /** All tabs this agent owns, sorted by `lastToolAt` desc so the popover reads chronologically. */
+  tabs: TabActivityRecord[]
+}
+
+/**
+ * Groups tabs by `agentId` so the homepage renders one card per agent
+ * instead of one per tab. Pure: same input always produces the same
+ * output. The status is `active` if any of the agent's tabs are
+ * active; `firstToolAt` is the oldest first-touch across the bunch
+ * (the moment this agent first started working); `lastToolName` is
+ * whichever tab is currently the focus.
+ */
+export function tabsToAgentActivity(
+  records: TabActivityRecord[],
+): AgentActivityRecord[] {
+  const byAgent = new Map<string, TabActivityRecord[]>()
+  for (const record of records) {
+    const bucket = byAgent.get(record.agentId)
+    if (bucket) bucket.push(record)
+    else byAgent.set(record.agentId, [record])
+  }
+  const out: AgentActivityRecord[] = []
+  for (const [agentId, tabs] of byAgent) {
+    const sorted = [...tabs].sort((a, b) => b.lastToolAt - a.lastToolAt)
+    const focus = sorted[0]
+    const mergedTrail = sorted
+      .flatMap((t) => t.recentTools)
+      .sort((a, b) => a.at - b.at)
+      .slice(-MERGED_TRAIL_CAP)
+    out.push({
+      agentId,
+      slug: focus.slug,
+      agentLabel: focus.agentLabel || focus.slug,
+      harness: harnessForRow(focus.harness),
+      color: focus.color ?? colorForSlug(focus.slug),
+      firstToolAt: Math.min(...tabs.map((t) => t.firstToolAt)),
+      lastToolAt: focus.lastToolAt,
+      lastToolName: focus.lastToolName,
+      toolCount: tabs.reduce((sum, t) => sum + t.toolCount, 0),
+      recentTools: mergedTrail,
+      status: tabs.some((t) => t.status === 'active') ? 'active' : 'idle',
+      currentFocus: focus,
+      tabs: sorted,
+    })
+  }
+  return out.sort((a, b) => b.lastToolAt - a.lastToolAt)
 }
 
 /**


### PR DESCRIPTION
## Summary

Third of three PRs from the cockpit-homepage plan. PR 1 + PR 2 rendered one card per tab; in practice one agent often drives multiple tabs and the homepage answered "what tabs are open" when the user actually wants to know "what is each agent doing". PR 3 collapses each agent's tabs into one card and shows the running grid at the agent grain.

Zero diffs in `apps/server` and `apps/agent-mcp-interface`. All changes scoped to `apps/agent-mcp-ui`. Pure UI + client-side aggregation; the route response shape is unchanged.

## What changes

**`screens/cockpit/cockpit.helpers.ts`:**
- `AgentActivityRecord` type and `tabsToAgentActivity` pure helper. Buckets `TabActivityRecord[]` by `agentId`; the resulting record carries the merged trail (sorted by `at`, capped at `MERGED_TRAIL_CAP = 8`), summed `toolCount`, oldest `firstToolAt`, freshest `lastToolAt`, the `currentFocus` tab (freshest `lastToolAt`), and the full `tabs` list sorted by `lastToolAt` desc.
- The agent is `active` if any of its tabs are active.

**`screens/cockpit/cockpit.data.ts`:**
- `useCockpitData()` now exposes `agents: AgentActivityRecord[]`. Rollup runs only on active records so an agent whose tabs have all gone idle drops out of the running grid; its individual tabs still appear in the recent activity list below.
- Recent activity stays tab-level by design: "Cowork did read on Stripe 12m ago" is more informative than "Cowork did 14 things".

**`components/cockpit/`:**
- New `AgentRunningCard` mirrors the PR 2 `RunningCard` design but reads from `AgentActivityRecord`. The header gains a `TabCountChip` when the agent owns more than one tab; single-tab agents render without the chip so they look unchanged from PR 2.
- New `TabCountChip` opens a `Popover` listing every tab this agent owns. The current focus is highlighted with an accent dot. Each row shows the tab title, the last tool name, and the site host.
- `RunningGrid` consumes the new `AgentActivityRecord[]` and delegates to `AgentRunningCard`. Navigation still routes to `/run/<targetId>` using the focus tab.

`RunningCard` and `AgentRow` stay exported because nothing in this PR breaks downstream type imports; cleanup can land later if they prove unused.

## Test plan

- [x] 9 new unit tests for `tabsToAgentActivity`:
  - Single tab into one record (fields propagate cleanly).
  - Three tabs of the same agent merge into one record with the right `firstToolAt`, `lastToolAt`, `toolCount`, and the focus tab being the freshest.
  - Merged trail caps at 8 events and the oldest entries drop.
  - Two distinct agent ids produce two records sorted by `lastToolAt` desc.
  - Status is `active` if any tab is active, `idle` only when all tabs are idle.
  - Missing-profile fallback (slug + Claude Code + hashed colour).
  - Current focus is the freshest tab even when an older tab has more activity.
  - Empty input returns empty array.
- [x] All 29 helper tests still pass.
- [x] `bun run --filter '*' typecheck` clean across the workspace (8 packages, all exit 0).
- [x] `bunx biome ci .` clean (0 errors / 0 warnings).
- [x] `git diff origin/main...HEAD --name-only | grep -v '^packages/browseros-agent/apps/agent-mcp-ui' | wc -l` returns 0.

**Manual walk-through** (reviewer action against a live BrowserOS):

1. Start `apps/server` against a running BrowserOS, open the cockpit homepage. Confirm `RunningGrid` is empty.
2. With one agent profile, drive page 1 to `https://example.com`. The grid shows one card titled with the agent's configured name, no tab-count chip, action count 1, trail `navigate`.
3. Open a second tab via `tabs.open` and navigate page 2 to `https://news.google.com` from the same `/cockpit/mcp/<slug>` endpoint. The card grows a "2 tabs" chip in the header; the merged trail now reads `navigate -> navigate`; the action count chip says `2 actions`; the focus surface (site host + title) reflects whichever was most recent.
4. Hover the "2 tabs" chip. The popover lists both tabs with title + last tool name. The current focus tab is highlighted with an accent dot.
5. Fire `read { page: 1 }` then `act { page: 2, ... }`. The trail advances chronologically across both tabs (`navigate -> navigate -> read -> act`). The focus flips to page 2 (the freshest). The popover updates on the next 1.5 s poll.
6. Wait 5 s without firing tools. The card drops out of the running grid; both tabs appear in `RecentActivity` as separate idle rows with their own trails and counts.
7. PR 1 / PR 2 regressions: failed dispatch (`navigate { page: 999 }`) does not bump counts or trails; closed tabs are evicted from the next snapshot.

## Open questions resolved (from the plan's Notes section)

- **Recent activity stays tab-level.** Idle rows continue to render one per tab so the user can see "Cowork on Stripe finished 47s ago" without that being collapsed into a single agent line.
- **Two agents on the same tab:** last-write-wins (PR 2 invariant carried forward; the rollup picks up whichever agent owns the target id at read time).
- **Consecutive identical tool names** in the merged trail: not deduplicated in this PR. Easy follow-up.
- **Persistence:** stays a separate future plan; PR 3 is purely additive on volatile data.
- **Live thumbnails:** stays an optional next slice that would slot into `MiniScreencast` without changing the rollup contract.

## Follow-ups (not in this PR)

- Drop `RunningCard` and `AgentRow` / `tabsToAgentRows` after a quick grep confirms no other surface consumes them.
- Dedup consecutive identical tool names at render time so a chatty `snapshot` loop reads cleaner.
- Live tab thumbnails via `apps/server`'s screencast endpoint.
- The human-takeover branch of the parent plan stays parked.