### PR TITLE
feat: add agent mcp dev watch scripts

### DIFF
--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/client.helpers.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/client.helpers.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'bun:test'
+import { resolveApiBaseUrlFromSources } from './client.helpers'
+
+const fallback = 'http://127.0.0.1:9100/cockpit'
+
+describe('resolveApiBaseUrlFromSources', () => {
+  it('prefers the query override', () => {
+    expect(
+      resolveApiBaseUrlFromSources({
+        query: 'http://127.0.0.1:9200/cockpit',
+        stored: 'http://127.0.0.1:9300/cockpit',
+        launcher: 'http://127.0.0.1:9400/cockpit',
+        fallback,
+      }),
+    ).toBe('http://127.0.0.1:9200/cockpit')
+  })
+
+  it('uses session storage before the launcher env', () => {
+    expect(
+      resolveApiBaseUrlFromSources({
+        query: null,
+        stored: 'http://127.0.0.1:9300/cockpit',
+        launcher: 'http://127.0.0.1:9400/cockpit',
+        fallback,
+      }),
+    ).toBe('http://127.0.0.1:9300/cockpit')
+  })
+
+  it('uses the launcher env before the default fallback', () => {
+    expect(
+      resolveApiBaseUrlFromSources({
+        query: null,
+        stored: null,
+        launcher: 'http://127.0.0.1:9400/cockpit',
+        fallback,
+      }),
+    ).toBe('http://127.0.0.1:9400/cockpit')
+  })
+
+  it('ignores non-loopback overrides', () => {
+    expect(
+      resolveApiBaseUrlFromSources({
+        query: 'https://example.com/cockpit',
+        stored: 'http://localhost:9300/cockpit',
+        launcher: 'http://0.0.0.0:9400/cockpit',
+        fallback,
+      }),
+    ).toBe(fallback)
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/client.helpers.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/client.helpers.test.ts
@@ -47,4 +47,26 @@ describe('resolveApiBaseUrlFromSources', () => {
       }),
     ).toBe(fallback)
   })
+
+  it('rejects loopback-looking URLs that parse to another host', () => {
+    expect(
+      resolveApiBaseUrlFromSources({
+        query: 'http://127.0.0.1:@example.com/cockpit',
+        stored: null,
+        launcher: null,
+        fallback,
+      }),
+    ).toBe(fallback)
+  })
+
+  it('rejects malformed ports and non-cockpit paths', () => {
+    expect(
+      resolveApiBaseUrlFromSources({
+        query: 'http://127.0.0.1:99999/cockpit',
+        stored: 'http://127.0.0.1:9300',
+        launcher: 'http://127.0.0.1:9400/cockpit?x=1',
+        fallback,
+      }),
+    ).toBe(fallback)
+  })
 })

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/client.helpers.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/client.helpers.ts
@@ -7,6 +7,7 @@ export type ApiBaseUrlSources = {
 
 export const API_URL_STORAGE_KEY = 'browseros.agent-mcp-ui.apiUrl'
 
+/** Accepts numeric loopback only; `localhost` can go through DNS. */
 export function isLoopbackCockpitUrl(
   value: string | null | undefined,
 ): value is string {

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/client.helpers.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/client.helpers.ts
@@ -7,18 +7,31 @@ export type ApiBaseUrlSources = {
 
 export const API_URL_STORAGE_KEY = 'browseros.agent-mcp-ui.apiUrl'
 
-export function isLoopbackUrl(
+export function isLoopbackCockpitUrl(
   value: string | null | undefined,
 ): value is string {
-  return !!value && value.startsWith('http://127.0.0.1:')
+  if (!value) return false
+  try {
+    const url = new URL(value)
+    return (
+      url.protocol === 'http:' &&
+      url.hostname === '127.0.0.1' &&
+      url.port !== '' &&
+      url.pathname === '/cockpit' &&
+      url.search === '' &&
+      url.hash === ''
+    )
+  } catch {
+    return false
+  }
 }
 
 /** Resolves the cockpit API URL from trusted local dev sources. */
 export function resolveApiBaseUrlFromSources(
   sources: ApiBaseUrlSources,
 ): string {
-  if (isLoopbackUrl(sources.query)) return sources.query
-  if (isLoopbackUrl(sources.stored)) return sources.stored
-  if (isLoopbackUrl(sources.launcher)) return sources.launcher
+  if (isLoopbackCockpitUrl(sources.query)) return sources.query
+  if (isLoopbackCockpitUrl(sources.stored)) return sources.stored
+  if (isLoopbackCockpitUrl(sources.launcher)) return sources.launcher
   return sources.fallback
 }

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/client.helpers.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/client.helpers.ts
@@ -1,0 +1,24 @@
+export type ApiBaseUrlSources = {
+  query: string | null | undefined
+  stored: string | null | undefined
+  launcher: string | null | undefined
+  fallback: string
+}
+
+export const API_URL_STORAGE_KEY = 'browseros.agent-mcp-ui.apiUrl'
+
+export function isLoopbackUrl(
+  value: string | null | undefined,
+): value is string {
+  return !!value && value.startsWith('http://127.0.0.1:')
+}
+
+/** Resolves the cockpit API URL from trusted local dev sources. */
+export function resolveApiBaseUrlFromSources(
+  sources: ApiBaseUrlSources,
+): string {
+  if (isLoopbackUrl(sources.query)) return sources.query
+  if (isLoopbackUrl(sources.stored)) return sources.stored
+  if (isLoopbackUrl(sources.launcher)) return sources.launcher
+  return sources.fallback
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/client.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/client.ts
@@ -30,7 +30,7 @@ import {
 import { hc } from 'hono/client'
 import {
   API_URL_STORAGE_KEY,
-  isLoopbackUrl,
+  isLoopbackCockpitUrl,
   resolveApiBaseUrlFromSources,
 } from './client.helpers'
 
@@ -44,7 +44,7 @@ function resolveApiBaseUrl(): string {
   if (typeof window === 'undefined') return fallback
 
   const fromQuery = new URLSearchParams(window.location.search).get('apiUrl')
-  if (isLoopbackUrl(fromQuery)) {
+  if (isLoopbackCockpitUrl(fromQuery)) {
     try {
       window.sessionStorage.setItem(API_URL_STORAGE_KEY, fromQuery)
     } catch {

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/client.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/client.ts
@@ -57,14 +57,14 @@ function resolveApiBaseUrl(): string {
   try {
     const stored = window.sessionStorage.getItem(API_URL_STORAGE_KEY)
     return resolveApiBaseUrlFromSources({
-      query: fromQuery,
+      query: null,
       stored,
       launcher: import.meta.env.VITE_BROWSEROS_AGENT_MCP_API_URL,
       fallback,
     })
   } catch {
     return resolveApiBaseUrlFromSources({
-      query: fromQuery,
+      query: null,
       stored: null,
       launcher: import.meta.env.VITE_BROWSEROS_AGENT_MCP_API_URL,
       fallback,

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/client.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/client.ts
@@ -14,7 +14,8 @@
  * Resolution order for the base URL:
  *   1. ?apiUrl=… on window.location (dev launcher publishes this)
  *   2. sessionStorage cache of (1)
- *   3. PROD_API_PORT constant on 127.0.0.1
+ *   3. VITE_BROWSEROS_AGENT_MCP_API_URL from the dev watcher
+ *   4. PROD_API_PORT constant on 127.0.0.1
  *
  * The lazy Proxy is what lets us re-resolve the base URL after the
  * dev launcher hot-swaps it without breaking hc's path chaining
@@ -27,12 +28,11 @@ import {
   PROD_API_PORT,
 } from '@browseros/agent-mcp-interface/shared/port'
 import { hc } from 'hono/client'
-
-const API_URL_STORAGE_KEY = 'browseros.agent-mcp-ui.apiUrl'
-
-function isLoopbackUrl(value: string | null | undefined): value is string {
-  return !!value && value.startsWith('http://127.0.0.1:')
-}
+import {
+  API_URL_STORAGE_KEY,
+  isLoopbackUrl,
+  resolveApiBaseUrlFromSources,
+} from './client.helpers'
 
 function resolveApiBaseUrl(): string {
   // The cockpit is mounted under `/cockpit` inside apps/server's
@@ -56,12 +56,20 @@ function resolveApiBaseUrl(): string {
 
   try {
     const stored = window.sessionStorage.getItem(API_URL_STORAGE_KEY)
-    if (isLoopbackUrl(stored)) return stored
+    return resolveApiBaseUrlFromSources({
+      query: fromQuery,
+      stored,
+      launcher: import.meta.env.VITE_BROWSEROS_AGENT_MCP_API_URL,
+      fallback,
+    })
   } catch {
-    // see above
+    return resolveApiBaseUrlFromSources({
+      query: fromQuery,
+      stored: null,
+      launcher: import.meta.env.VITE_BROWSEROS_AGENT_MCP_API_URL,
+      fallback,
+    })
   }
-
-  return fallback
 }
 
 type ApiClient = ReturnType<typeof hc<AppType>>

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/mcp-endpoint.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/mcp-endpoint.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+import { API_URL_STORAGE_KEY } from './client.helpers'
+import { buildMcpEndpointUrl } from './mcp-endpoint'
+
+const originalWindow = globalThis.window
+
+function installWindow(search: string, storage = new Map<string, string>()) {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: {
+      location: { search },
+      sessionStorage: {
+        getItem(key: string) {
+          return storage.get(key) ?? null
+        },
+        setItem(key: string, value: string) {
+          storage.set(key, value)
+        },
+      },
+    },
+  })
+  return storage
+}
+
+afterEach(() => {
+  Object.defineProperty(globalThis, 'window', {
+    configurable: true,
+    value: originalWindow,
+  })
+})
+
+describe('buildMcpEndpointUrl', () => {
+  it('persists a valid query api URL for later same-session calls', () => {
+    const storage = installWindow(
+      '?apiUrl=http%3A%2F%2F127.0.0.1%3A9234%2Fcockpit',
+    )
+
+    expect(buildMcpEndpointUrl('demo')).toBe(
+      'http://127.0.0.1:9234/cockpit/mcp/demo',
+    )
+    expect(storage.get(API_URL_STORAGE_KEY)).toBe(
+      'http://127.0.0.1:9234/cockpit',
+    )
+  })
+
+  it('uses the cached API URL when the query is absent', () => {
+    const storage = new Map([
+      [API_URL_STORAGE_KEY, 'http://127.0.0.1:9345/cockpit'],
+    ])
+    installWindow('', storage)
+
+    expect(buildMcpEndpointUrl('demo')).toBe(
+      'http://127.0.0.1:9345/cockpit/mcp/demo',
+    )
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/mcp-endpoint.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/mcp-endpoint.ts
@@ -10,10 +10,8 @@
  * the wizard / directory pages render flows through these helpers,
  * so the future cutover is confined to this file.
  *
- * TODO(temporary cockpit mount): while `apps/agent-mcp-interface`
- * lives as a sub-route under `apps/server` (mounted at
- * `/cockpit` so it can borrow the server's live BrowserSession and
- * CDP attach), this builder targets the mounted `/cockpit/mcp/<slug>`
+ * While `apps/agent-mcp-interface` lives as a sub-route under
+ * `apps/server`, this builder targets the mounted `/cockpit/mcp/<slug>`
  * shape. It defaults to the production port but honors dev-launcher
  * overrides when `dev:agent-mcp:watch:new` selects a random port.
  */
@@ -24,6 +22,7 @@ import {
 } from '@browseros/agent-mcp-interface/shared/port'
 import {
   API_URL_STORAGE_KEY,
+  isLoopbackCockpitUrl,
   resolveApiBaseUrlFromSources,
 } from './client.helpers'
 
@@ -37,16 +36,25 @@ function resolveMcpBaseUrl(): string {
   if (typeof window === 'undefined') return fallback
 
   const query = new URLSearchParams(window.location.search).get('apiUrl')
+  if (isLoopbackCockpitUrl(query)) {
+    try {
+      window.sessionStorage.setItem(API_URL_STORAGE_KEY, query)
+    } catch {
+      // sessionStorage may reject writes in sandboxed contexts; this call can still use the query URL.
+    }
+    return query
+  }
+
   try {
     return resolveApiBaseUrlFromSources({
-      query,
+      query: null,
       stored: window.sessionStorage.getItem(API_URL_STORAGE_KEY),
       launcher: import.meta.env.VITE_BROWSEROS_AGENT_MCP_API_URL,
       fallback,
     })
   } catch {
     return resolveApiBaseUrlFromSources({
-      query,
+      query: null,
       stored: null,
       launcher: import.meta.env.VITE_BROWSEROS_AGENT_MCP_API_URL,
       fallback,

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/mcp-endpoint.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/mcp-endpoint.ts
@@ -13,22 +13,46 @@
  * TODO(temporary cockpit mount): while `apps/agent-mcp-interface`
  * lives as a sub-route under `apps/server` (mounted at
  * `/cockpit` so it can borrow the server's live BrowserSession and
- * CDP attach), this builder targets the mounted shape
- * `http://127.0.0.1:9100/cockpit/mcp/<slug>`. When the BrowserOS
- * Chromium runtime ships direct CDP integration for the
- * agent-mcp-interface package, the interface will bind its own port
- * and `buildMcpEndpointUrl` will return
- * `http://127.0.0.1:<interface-port>/mcp/<slug>`. The unmount lives
- * in three commits: (1) drop the cockpit mount from
- * `apps/server/src/api/routes/index.ts`, (2) flip the constants
- * imported below, (3) remove the legacy `/cockpit/mcp/<slug>` arm
- * from `slugFromMcpEndpointUrl` once profile migration has run.
+ * CDP attach), this builder targets the mounted `/cockpit/mcp/<slug>`
+ * shape. It defaults to the production port but honors dev-launcher
+ * overrides when `dev:agent-mcp:watch:new` selects a random port.
  */
 
 import {
   COCKPIT_MOUNT_PREFIX,
   PROD_API_PORT,
 } from '@browseros/agent-mcp-interface/shared/port'
+import {
+  API_URL_STORAGE_KEY,
+  resolveApiBaseUrlFromSources,
+} from './client.helpers'
+
+function fallbackBaseUrl(): string {
+  return `http://127.0.0.1:${PROD_API_PORT}${COCKPIT_MOUNT_PREFIX}`
+}
+
+/** Resolves the same cockpit base URL as the API client for pre-create previews. */
+function resolveMcpBaseUrl(): string {
+  const fallback = fallbackBaseUrl()
+  if (typeof window === 'undefined') return fallback
+
+  const query = new URLSearchParams(window.location.search).get('apiUrl')
+  try {
+    return resolveApiBaseUrlFromSources({
+      query,
+      stored: window.sessionStorage.getItem(API_URL_STORAGE_KEY),
+      launcher: import.meta.env.VITE_BROWSEROS_AGENT_MCP_API_URL,
+      fallback,
+    })
+  } catch {
+    return resolveApiBaseUrlFromSources({
+      query,
+      stored: null,
+      launcher: import.meta.env.VITE_BROWSEROS_AGENT_MCP_API_URL,
+      fallback,
+    })
+  }
+}
 
 /**
  * URL the UI shows in the copy widget and embeds in host-agent config
@@ -37,7 +61,7 @@ import {
  * server-side and one composed client-side produce identical strings.
  */
 export function buildMcpEndpointUrl(slug: string): string {
-  return `http://127.0.0.1:${PROD_API_PORT}${COCKPIT_MOUNT_PREFIX}/mcp/${slug}`
+  return `${resolveMcpBaseUrl()}/mcp/${slug}`
 }
 
 /**

--- a/packages/browseros-agent/apps/agent-mcp-ui/wxt.config.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/wxt.config.ts
@@ -12,6 +12,8 @@ export default defineConfig({
   modules: ['@wxt-dev/module-react'],
   manifest: {
     name: 'BrowserOS Agents',
+    // TODO(Nikhil): Add this extension ID to Chromium's new-tab override allowlist.
+    key: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvBDAaDRvv61NpBeLR8etBRw82lv9VJO3sz/mA26gDzWKtVuzW4DXCl8Zfj5oWmoXLTfv3aiTigUXo/LHOoGpSucEVroMmAc7cgu2KuQ1fZPpMvYa0npD/m4h89360q8Oz0oKKaZGS905IJ04M2IkF4CuU3YEHFJBWb+cUyK9H8YVugelYbPD0IVs63T1SkGbh/t/Tfb2DpkinduSO8+x26sKydm30SRt+iZ2+7Nolcdum3LExInUiX2Pgb65Jb+mVw8NqyTVJyCEp8uq0cSHomWFQirSJ80tsDhISp4btwaRKHrXqovQx9XHQv4hCd+3LuB830eUEVMUNuCO+OyPxQIDAQAB',
     permissions: [
       'browserOS',
       'storage',

--- a/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
@@ -18,11 +18,18 @@ import type { Env } from '../types'
 export const MANAGED_MCP_SERVERS_HEADER = 'X-BrowserOS-Managed-Mcp-Servers'
 export const REMOTE_AGENT_HARNESS_MCP_SOURCE = 'remote-agent-harness'
 
+type CreateMcpServerFn = typeof createMcpServer
+type CreateMcpTransportFn = (
+  options: ConstructorParameters<typeof StreamableHTTPTransport>[0],
+) => InstanceType<typeof StreamableHTTPTransport>
+
 interface McpRouteDeps {
   version: string
   browserSession: BrowserSession
   klavis?: KlavisService
   executionDir: string
+  createMcpServer?: CreateMcpServerFn
+  createMcpTransport?: CreateMcpTransportFn
 }
 
 function parseOptionalNumber(value: string | undefined): number | undefined {
@@ -58,6 +65,10 @@ export function parseManagedMcpServersHeader(
 
 export function createMcpRoutes(deps: McpRouteDeps) {
   const app = new Hono<Env>()
+  const makeMcpServer = deps.createMcpServer ?? createMcpServer
+  const makeMcpTransport =
+    deps.createMcpTransport ??
+    ((options) => new StreamableHTTPTransport(options))
   const remoteAgentHarness = {
     outputFileAccess: createBrowserOutputFileAccess(),
   }
@@ -89,7 +100,7 @@ export function createMcpRoutes(deps: McpRouteDeps) {
 
     // Per-request server + transport: no shared state, no race conditions,
     // no ID collisions. Required by MCP SDK 1.26.0+ security fix (GHSA-345p-7cg4-v4c7).
-    const mcpServer = createMcpServer({
+    const mcpServer = makeMcpServer({
       version: deps.version,
       browserSession: deps.browserSession,
       klavis: deps.klavis,
@@ -99,7 +110,7 @@ export function createMcpRoutes(deps: McpRouteDeps) {
       executionDir: deps.executionDir,
       remoteAgentHarness: harness,
     })
-    const transport = new StreamableHTTPTransport({
+    const transport = makeMcpTransport({
       sessionIdGenerator: undefined,
       enableJsonResponse: true,
     })

--- a/packages/browseros-agent/apps/server/tests/api/routes/mcp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/mcp.test.ts
@@ -1,4 +1,9 @@
 import { beforeEach, describe, expect, it, mock } from 'bun:test'
+import {
+  createMcpRoutes,
+  MANAGED_MCP_SERVERS_HEADER,
+  parseManagedMcpServersHeader,
+} from '../../../src/api/routes/mcp'
 import type {
   ConnectorToolScope,
   KlavisProxyStatus,
@@ -23,6 +28,10 @@ class FakeTransport {
   handleRequest = mock(async () => Response.json({ ok: true }))
 }
 
+const createMcpTransportSpy = mock((options: unknown) => {
+  return new FakeTransport(options)
+})
+
 const createMcpServerSpy = mock(
   (deps: {
     klavis?: { getProxyStatus(): KlavisProxyStatus }
@@ -45,25 +54,26 @@ const createMcpServerSpy = mock(
   },
 )
 
-mock.module('@hono/mcp', () => ({
-  StreamableHTTPTransport: FakeTransport,
-}))
-
-mock.module('../../../src/api/services/mcp/mcp-server', () => ({
-  createMcpServer: createMcpServerSpy,
-}))
-
-const {
-  MANAGED_MCP_SERVERS_HEADER,
-  createMcpRoutes,
-  parseManagedMcpServersHeader,
-} = await import('../../../src/api/routes/mcp')
-
 beforeEach(() => {
   serverCreations.length = 0
   transportInstances.length = 0
   connectCalls.length = 0
+  createMcpServerSpy.mockClear()
+  createMcpTransportSpy.mockClear()
 })
+
+function createTestMcpRoutes(
+  overrides: Partial<Parameters<typeof createMcpRoutes>[0]> = {},
+) {
+  return createMcpRoutes({
+    version: '0.0.0-test',
+    browserSession: {} as never,
+    executionDir: '/tmp/browseros-execution',
+    createMcpServer: createMcpServerSpy as never,
+    createMcpTransport: createMcpTransportSpy as never,
+    ...overrides,
+  })
+}
 
 async function postMcp(
   app: ReturnType<typeof createMcpRoutes>,
@@ -106,11 +116,8 @@ describe('createMcpRoutes', () => {
     const klavis = {
       getProxyStatus: () => status,
     }
-    const app = createMcpRoutes({
-      version: '0.0.0-test',
-      browserSession: {} as never,
+    const app = createTestMcpRoutes({
       klavis: klavis as never,
-      executionDir: '/tmp/browseros-execution',
     })
 
     const first = await postMcp(app)
@@ -141,11 +148,7 @@ describe('createMcpRoutes', () => {
   })
 
   it('sets the remote agent harness context only for the remote harness source', async () => {
-    const app = createMcpRoutes({
-      version: '0.0.0-test',
-      browserSession: {} as never,
-      executionDir: '/tmp/browseros-execution',
-    })
+    const app = createTestMcpRoutes()
 
     const defaultResponse = await postMcp(app)
     const remoteHarnessResponse = await postMcp(
@@ -173,11 +176,7 @@ describe('createMcpRoutes', () => {
   })
 
   it('keeps remote agent harness context stable by source', async () => {
-    const app = createMcpRoutes({
-      version: '0.0.0-test',
-      browserSession: {} as never,
-      executionDir: '/tmp/browseros-execution',
-    })
+    const app = createTestMcpRoutes()
 
     await postMcp(app, {}, '/?source=remote-agent-harness')
     await postMcp(app, {}, '/?source=remote-agent-harness')

--- a/packages/browseros-agent/package.json
+++ b/packages/browseros-agent/package.json
@@ -11,6 +11,8 @@
   "scripts": {
     "dev:watch": "./tools/dev/run.sh watch",
     "dev:watch:new": "./tools/dev/run.sh watch --new",
+    "dev:agent-mcp:watch": "./tools/dev/run.sh watch --agent-mcp",
+    "dev:agent-mcp:watch:new": "./tools/dev/run.sh watch --agent-mcp --new",
     "dev:manual": "./tools/dev/run.sh watch --manual",
     "dev:stop": "pkill -f 'browseros-dev watch' ; pkill -f 'bun --watch' ; echo 'dev watch stopped'",
     "devtools": "cd apps/server && bun run devtools",

--- a/packages/browseros-agent/tools/dev/cmd/watch.go
+++ b/packages/browseros-agent/tools/dev/cmd/watch.go
@@ -25,17 +25,24 @@ var watchCmd = &cobra.Command{
 }
 
 var (
-	watchNew    bool
-	watchManual bool
+	watchNew      bool
+	watchManual   bool
+	watchAgentMCP bool
 )
 
 func init() {
 	watchCmd.Flags().BoolVar(&watchNew, "new", false, "Use random available ports in 9000-9999 and create a fresh user-data directory")
 	watchCmd.Flags().BoolVar(&watchManual, "manual", false, "Build agent statically instead of WXT HMR mode")
+	watchCmd.Flags().BoolVar(&watchAgentMCP, "agent-mcp", false, "Run the agent MCP UI and standalone interface")
 	rootCmd.AddCommand(watchCmd)
 }
 
 func runWatch(cmd *cobra.Command, args []string) error {
+	mode, err := watchMode()
+	if err != nil {
+		return err
+	}
+
 	root, err := proc.FindMonorepoRoot()
 	if err != nil {
 		return err
@@ -53,10 +60,6 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	userDataDir, err := proc.DefaultDevUserDataDir(root)
 	if err != nil {
 		return err
-	}
-	mode := "watch"
-	if watchManual {
-		mode = "manual"
 	}
 	var runLock *proc.WatchRunLock
 	acquireRunLock := func(ports proc.Ports) error {
@@ -141,6 +144,9 @@ func runWatch(cmd *cobra.Command, args []string) error {
 
 	env := proc.BuildEnv(p, "development")
 	env = append(env, fmt.Sprintf("BROWSEROS_USER_DATA_DIR=%s", userDataDir))
+	if watchAgentMCP {
+		env = buildAgentMCPWatchEnv(env, p)
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -151,60 +157,14 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	var wg sync.WaitGroup
 	var procs []*proc.ManagedProc
 
-	agentDir := filepath.Join(root, "apps/agent")
-
-	if watchManual {
-		proc.LogMsg(proc.TagBuild, "Building agent (dev)...")
-		if err := proc.RunBlocking(ctx, agentDir, proc.TagBuild,
-			"bun", "--env-file=.env.development", "wxt", "build", "--mode", "development"); err != nil {
-			return fmt.Errorf("agent build failed: %w", err)
+	if watchAgentMCP {
+		procs = startAgentMCPWatch(ctx, &wg, root, env, p, reservations)
+	} else {
+		procs, err = startLegacyWatch(ctx, &wg, root, env, p, reservations, userDataDir, watchManual)
+		if err != nil {
+			return err
 		}
-		proc.LogMsg(proc.TagBuild, "agent built")
-
-		reservations.ReleaseCDP()
-		procs = append(procs, proc.StartManaged(ctx, &wg, proc.ProcConfig{
-			Tag:     proc.TagBrowser,
-			Dir:     root,
-			Restart: false,
-			Cmd: browser.BuildArgs(browser.ArgsConfig{
-				Root:              root,
-				Ports:             p,
-				UserDataDir:       userDataDir,
-				LoadDevExtensions: true,
-			}),
-		}))
-	} else {
-		reservations.ReleaseCDP()
-		procs = append(procs, proc.StartManaged(ctx, &wg, proc.ProcConfig{
-			Tag:     proc.TagAgent,
-			Dir:     agentDir,
-			Env:     env,
-			Restart: true,
-			Cmd:     []string{"bun", "--env-file=.env.development", "wxt"},
-		}))
 	}
-
-	// Wait for CDP
-	proc.LogMsg(proc.TagServer, "Waiting for CDP...")
-	if browser.WaitForCDP(ctx, p.CDP, 60) {
-		proc.LogMsg(proc.TagServer, "CDP ready")
-	} else {
-		proc.LogMsg(proc.TagServer, proc.WarnColor.Sprint("CDP not available, starting server anyway"))
-	}
-
-	// Start server
-	reservations.ReleaseServer()
-	reservations.ReleaseExtension()
-	procs = append(procs, proc.StartManaged(ctx, &wg, proc.ProcConfig{
-		Tag:     proc.TagServer,
-		Dir:     filepath.Join(root, "apps/server"),
-		Env:     env,
-		Restart: true,
-		Cmd:     []string{"bun", "--watch", "--env-file=.env.development", "src/index.ts"},
-		BeforeStart: func() error {
-			return proc.KillPortAndWait(p.Server, 3*time.Second)
-		},
-	}))
 
 	<-sigCh
 	fmt.Println()
@@ -227,6 +187,122 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	wg.Wait()
 	proc.LogMsg(proc.TagInfo, "All processes stopped")
 	return nil
+}
+
+// watchMode resolves the process identity used by logs and run locks.
+func watchMode() (string, error) {
+	if watchManual && watchAgentMCP {
+		return "", fmt.Errorf("--manual cannot be combined with --agent-mcp")
+	}
+	if watchAgentMCP {
+		return "agent-mcp", nil
+	}
+	if watchManual {
+		return "manual", nil
+	}
+	return "watch", nil
+}
+
+// buildAgentMCPWatchEnv bridges the shared dev ports into the standalone MCP apps.
+func buildAgentMCPWatchEnv(env []string, p proc.Ports) []string {
+	apiURL := fmt.Sprintf("http://127.0.0.1:%d/cockpit", p.Server)
+	return append(env,
+		fmt.Sprintf("BROWSEROS_AGENT_MCP_INTERFACE_PORT=%d", p.Server),
+		fmt.Sprintf("BROWSEROS_COCKPIT_CDP_PORT=%d", p.CDP),
+		fmt.Sprintf("VITE_BROWSEROS_AGENT_MCP_API_URL=%s", apiURL),
+	)
+}
+
+// startLegacyWatch supervises the original agent extension plus server dev pair.
+func startLegacyWatch(ctx context.Context, wg *sync.WaitGroup, root string, env []string, p proc.Ports, reservations *proc.PortReservations, userDataDir string, manual bool) ([]*proc.ManagedProc, error) {
+	var procs []*proc.ManagedProc
+	agentDir := filepath.Join(root, "apps/agent")
+
+	if manual {
+		proc.LogMsg(proc.TagBuild, "Building agent (dev)...")
+		if err := proc.RunBlocking(ctx, agentDir, proc.TagBuild,
+			"bun", "--env-file=.env.development", "wxt", "build", "--mode", "development"); err != nil {
+			return nil, fmt.Errorf("agent build failed: %w", err)
+		}
+		proc.LogMsg(proc.TagBuild, "agent built")
+
+		reservations.ReleaseCDP()
+		procs = append(procs, proc.StartManaged(ctx, wg, proc.ProcConfig{
+			Tag:     proc.TagBrowser,
+			Dir:     root,
+			Restart: false,
+			Cmd: browser.BuildArgs(browser.ArgsConfig{
+				Root:              root,
+				Ports:             p,
+				UserDataDir:       userDataDir,
+				LoadDevExtensions: true,
+			}),
+		}))
+	} else {
+		reservations.ReleaseCDP()
+		procs = append(procs, proc.StartManaged(ctx, wg, proc.ProcConfig{
+			Tag:     proc.TagAgent,
+			Dir:     agentDir,
+			Env:     env,
+			Restart: true,
+			Cmd:     []string{"bun", "--env-file=.env.development", "wxt"},
+		}))
+	}
+
+	waitForCDP(ctx, p.CDP)
+
+	reservations.ReleaseServer()
+	reservations.ReleaseExtension()
+	procs = append(procs, proc.StartManaged(ctx, wg, proc.ProcConfig{
+		Tag:     proc.TagServer,
+		Dir:     filepath.Join(root, "apps/server"),
+		Env:     env,
+		Restart: true,
+		Cmd:     []string{"bun", "--watch", "--env-file=.env.development", "src/index.ts"},
+		BeforeStart: func() error {
+			return proc.KillPortAndWait(p.Server, 3*time.Second)
+		},
+	}))
+	return procs, nil
+}
+
+// startAgentMCPWatch supervises the MCP cockpit UI plus standalone interface.
+func startAgentMCPWatch(ctx context.Context, wg *sync.WaitGroup, root string, env []string, p proc.Ports, reservations *proc.PortReservations) []*proc.ManagedProc {
+	var procs []*proc.ManagedProc
+
+	reservations.ReleaseCDP()
+	procs = append(procs, proc.StartManaged(ctx, wg, proc.ProcConfig{
+		Tag:     proc.TagAgent,
+		Dir:     filepath.Join(root, "apps/agent-mcp-ui"),
+		Env:     env,
+		Restart: true,
+		Cmd:     []string{"bun", "wxt"},
+	}))
+
+	waitForCDP(ctx, p.CDP)
+
+	reservations.ReleaseServer()
+	reservations.ReleaseExtension()
+	procs = append(procs, proc.StartManaged(ctx, wg, proc.ProcConfig{
+		Tag:     proc.TagServer,
+		Dir:     filepath.Join(root, "apps/agent-mcp-interface"),
+		Env:     env,
+		Restart: true,
+		Cmd:     []string{"bun", "--watch", "src/main.ts"},
+		BeforeStart: func() error {
+			return proc.KillPortAndWait(p.Server, 3*time.Second)
+		},
+	}))
+	return procs
+}
+
+func waitForCDP(ctx context.Context, port int) {
+	proc.LogMsg(proc.TagServer, "Waiting for CDP...")
+	if browser.WaitForCDP(ctx, port, 60) {
+		proc.LogMsg(proc.TagServer, "CDP ready")
+	} else {
+		proc.LogMsg(proc.TagServer, proc.WarnColor.Sprint("CDP not available, starting server anyway"))
+	}
 }
 
 func ensureLimactlPresent() error {

--- a/packages/browseros-agent/tools/dev/cmd/watch.go
+++ b/packages/browseros-agent/tools/dev/cmd/watch.go
@@ -30,6 +30,8 @@ var (
 	watchAgentMCP bool
 )
 
+const watchRunLockMode = "watch"
+
 func init() {
 	watchCmd.Flags().BoolVar(&watchNew, "new", false, "Use random available ports in 9000-9999 and create a fresh user-data directory")
 	watchCmd.Flags().BoolVar(&watchManual, "manual", false, "Build agent statically instead of WXT HMR mode")
@@ -64,7 +66,7 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	var runLock *proc.WatchRunLock
 	acquireRunLock := func(ports proc.Ports) error {
 		lock, stopped, err := proc.AcquireWatchRunLock(proc.WatchRunIdentity{
-			Mode:    mode,
+			Mode:    watchLockMode(),
 			Profile: userDataDir,
 			Ports:   ports,
 		}, 3*time.Second)
@@ -189,7 +191,7 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// watchMode resolves the process identity used by logs and run locks.
+// watchMode resolves the user-facing mode label for logs.
 func watchMode() (string, error) {
 	if watchManual && watchAgentMCP {
 		return "", fmt.Errorf("--manual cannot be combined with --agent-mcp")
@@ -201,6 +203,11 @@ func watchMode() (string, error) {
 		return "manual", nil
 	}
 	return "watch", nil
+}
+
+// watchLockMode keeps watch variants mutually exclusive for the same profile and ports.
+func watchLockMode() string {
+	return watchRunLockMode
 }
 
 // buildAgentMCPWatchEnv bridges the shared dev ports into the standalone MCP apps.

--- a/packages/browseros-agent/tools/dev/cmd/watch.go
+++ b/packages/browseros-agent/tools/dev/cmd/watch.go
@@ -66,7 +66,8 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	var runLock *proc.WatchRunLock
 	acquireRunLock := func(ports proc.Ports) error {
 		lock, stopped, err := proc.AcquireWatchRunLock(proc.WatchRunIdentity{
-			Mode:    watchLockMode(),
+			// All watch variants share one identity so they cannot supervise the same profile and ports concurrently.
+			Mode:    watchRunLockMode,
 			Profile: userDataDir,
 			Ports:   ports,
 		}, 3*time.Second)
@@ -205,11 +206,6 @@ func watchMode() (string, error) {
 	return "BrowserOS", nil
 }
 
-// watchLockMode keeps watch variants mutually exclusive for the same profile and ports.
-func watchLockMode() string {
-	return watchRunLockMode
-}
-
 // buildBrowserOSForAgentsWatchEnv bridges shared dev ports into the standalone MCP apps.
 func buildBrowserOSForAgentsWatchEnv(env []string, p proc.Ports) []string {
 	apiURL := fmt.Sprintf("http://127.0.0.1:%d/cockpit", p.Server)
@@ -283,7 +279,7 @@ func startBrowserOSForAgentsWatch(ctx context.Context, wg *sync.WaitGroup, root 
 		Dir:     filepath.Join(root, "apps/agent-mcp-ui"),
 		Env:     env,
 		Restart: true,
-		Cmd:     []string{"bun", "wxt"},
+		Cmd:     []string{"bun", "--env-file=.env.development", "wxt"},
 	}))
 
 	waitForCDP(ctx, p.CDP)
@@ -295,7 +291,7 @@ func startBrowserOSForAgentsWatch(ctx context.Context, wg *sync.WaitGroup, root 
 		Dir:     filepath.Join(root, "apps/agent-mcp-interface"),
 		Env:     env,
 		Restart: true,
-		Cmd:     []string{"bun", "--watch", "src/main.ts"},
+		Cmd:     []string{"bun", "--watch", "--env-file=.env.development", "src/main.ts"},
 		BeforeStart: func() error {
 			return proc.KillPortAndWait(p.Server, 3*time.Second)
 		},

--- a/packages/browseros-agent/tools/dev/cmd/watch.go
+++ b/packages/browseros-agent/tools/dev/cmd/watch.go
@@ -25,9 +25,9 @@ var watchCmd = &cobra.Command{
 }
 
 var (
-	watchNew      bool
-	watchManual   bool
-	watchAgentMCP bool
+	watchNew                bool
+	watchManual             bool
+	watchBrowserOSForAgents bool
 )
 
 const watchRunLockMode = "watch"
@@ -35,7 +35,7 @@ const watchRunLockMode = "watch"
 func init() {
 	watchCmd.Flags().BoolVar(&watchNew, "new", false, "Use random available ports in 9000-9999 and create a fresh user-data directory")
 	watchCmd.Flags().BoolVar(&watchManual, "manual", false, "Build agent statically instead of WXT HMR mode")
-	watchCmd.Flags().BoolVar(&watchAgentMCP, "agent-mcp", false, "Run the agent MCP UI and standalone interface")
+	watchCmd.Flags().BoolVar(&watchBrowserOSForAgents, "agent-mcp", false, "Run the agent MCP UI and standalone interface")
 	rootCmd.AddCommand(watchCmd)
 }
 
@@ -146,8 +146,8 @@ func runWatch(cmd *cobra.Command, args []string) error {
 
 	env := proc.BuildEnv(p, "development")
 	env = append(env, fmt.Sprintf("BROWSEROS_USER_DATA_DIR=%s", userDataDir))
-	if watchAgentMCP {
-		env = buildAgentMCPWatchEnv(env, p)
+	if watchBrowserOSForAgents {
+		env = buildBrowserOSForAgentsWatchEnv(env, p)
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -159,10 +159,10 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	var wg sync.WaitGroup
 	var procs []*proc.ManagedProc
 
-	if watchAgentMCP {
-		procs = startAgentMCPWatch(ctx, &wg, root, env, p, reservations)
+	if watchBrowserOSForAgents {
+		procs = startBrowserOSForAgentsWatch(ctx, &wg, root, env, p, reservations)
 	} else {
-		procs, err = startLegacyWatch(ctx, &wg, root, env, p, reservations, userDataDir, watchManual)
+		procs, err = startBrowserOSWatch(ctx, &wg, root, env, p, reservations, userDataDir, watchManual)
 		if err != nil {
 			return err
 		}
@@ -193,16 +193,16 @@ func runWatch(cmd *cobra.Command, args []string) error {
 
 // watchMode resolves the user-facing mode label for logs.
 func watchMode() (string, error) {
-	if watchManual && watchAgentMCP {
+	if watchManual && watchBrowserOSForAgents {
 		return "", fmt.Errorf("--manual cannot be combined with --agent-mcp")
 	}
-	if watchAgentMCP {
-		return "agent-mcp", nil
+	if watchBrowserOSForAgents {
+		return "BrowserOSForAgents", nil
 	}
 	if watchManual {
-		return "manual", nil
+		return "BrowserOS manual", nil
 	}
-	return "watch", nil
+	return "BrowserOS", nil
 }
 
 // watchLockMode keeps watch variants mutually exclusive for the same profile and ports.
@@ -210,8 +210,8 @@ func watchLockMode() string {
 	return watchRunLockMode
 }
 
-// buildAgentMCPWatchEnv bridges the shared dev ports into the standalone MCP apps.
-func buildAgentMCPWatchEnv(env []string, p proc.Ports) []string {
+// buildBrowserOSForAgentsWatchEnv bridges shared dev ports into the standalone MCP apps.
+func buildBrowserOSForAgentsWatchEnv(env []string, p proc.Ports) []string {
 	apiURL := fmt.Sprintf("http://127.0.0.1:%d/cockpit", p.Server)
 	return append(env,
 		fmt.Sprintf("BROWSEROS_AGENT_MCP_INTERFACE_PORT=%d", p.Server),
@@ -220,8 +220,8 @@ func buildAgentMCPWatchEnv(env []string, p proc.Ports) []string {
 	)
 }
 
-// startLegacyWatch supervises the original agent extension plus server dev pair.
-func startLegacyWatch(ctx context.Context, wg *sync.WaitGroup, root string, env []string, p proc.Ports, reservations *proc.PortReservations, userDataDir string, manual bool) ([]*proc.ManagedProc, error) {
+// startBrowserOSWatch supervises the BrowserOS agent extension plus server dev pair.
+func startBrowserOSWatch(ctx context.Context, wg *sync.WaitGroup, root string, env []string, p proc.Ports, reservations *proc.PortReservations, userDataDir string, manual bool) ([]*proc.ManagedProc, error) {
 	var procs []*proc.ManagedProc
 	agentDir := filepath.Join(root, "apps/agent")
 
@@ -273,8 +273,8 @@ func startLegacyWatch(ctx context.Context, wg *sync.WaitGroup, root string, env 
 	return procs, nil
 }
 
-// startAgentMCPWatch supervises the MCP cockpit UI plus standalone interface.
-func startAgentMCPWatch(ctx context.Context, wg *sync.WaitGroup, root string, env []string, p proc.Ports, reservations *proc.PortReservations) []*proc.ManagedProc {
+// startBrowserOSForAgentsWatch supervises the MCP cockpit UI plus standalone interface.
+func startBrowserOSForAgentsWatch(ctx context.Context, wg *sync.WaitGroup, root string, env []string, p proc.Ports, reservations *proc.PortReservations) []*proc.ManagedProc {
 	var procs []*proc.ManagedProc
 
 	reservations.ReleaseCDP()

--- a/packages/browseros-agent/tools/dev/cmd/watch_test.go
+++ b/packages/browseros-agent/tools/dev/cmd/watch_test.go
@@ -5,7 +5,46 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"browseros-dev/proc"
 )
+
+func TestWatchModeRejectsManualAgentMCPCombination(t *testing.T) {
+	oldManual, oldAgentMCP := watchManual, watchAgentMCP
+	watchManual = true
+	watchAgentMCP = true
+	t.Cleanup(func() {
+		watchManual = oldManual
+		watchAgentMCP = oldAgentMCP
+	})
+
+	_, err := watchMode()
+	if err == nil {
+		t.Fatal("expected incompatible watch flags to return an error")
+	}
+	if !strings.Contains(err.Error(), "--manual cannot be combined with --agent-mcp") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuildAgentMCPWatchEnvIncludesSelectedPorts(t *testing.T) {
+	env := buildAgentMCPWatchEnv([]string{"BASE=1"}, proc.Ports{
+		CDP:       9012,
+		Server:    9123,
+		Extension: 9321,
+	})
+
+	for _, want := range []string{
+		"BASE=1",
+		"BROWSEROS_AGENT_MCP_INTERFACE_PORT=9123",
+		"BROWSEROS_COCKPIT_CDP_PORT=9012",
+		"VITE_BROWSEROS_AGENT_MCP_API_URL=http://127.0.0.1:9123/cockpit",
+	} {
+		if !hasEnvEntry(env, want) {
+			t.Fatalf("expected env to contain %q, got %#v", want, env)
+		}
+	}
+}
 
 func TestEnsureLimactlPresentMissingMessage(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
@@ -35,4 +74,13 @@ func TestEnsureLimactlPresentFindsPathBinary(t *testing.T) {
 	if err := ensureLimactlPresent(); err != nil {
 		t.Fatalf("expected limactl to resolve, got %v", err)
 	}
+}
+
+func hasEnvEntry(env []string, want string) bool {
+	for _, got := range env {
+		if got == want {
+			return true
+		}
+	}
+	return false
 }

--- a/packages/browseros-agent/tools/dev/cmd/watch_test.go
+++ b/packages/browseros-agent/tools/dev/cmd/watch_test.go
@@ -9,13 +9,13 @@ import (
 	"browseros-dev/proc"
 )
 
-func TestWatchModeRejectsManualAgentMCPCombination(t *testing.T) {
-	oldManual, oldAgentMCP := watchManual, watchAgentMCP
+func TestWatchModeRejectsManualBrowserOSForAgentsCombination(t *testing.T) {
+	oldManual, oldBrowserOSForAgents := watchManual, watchBrowserOSForAgents
 	watchManual = true
-	watchAgentMCP = true
+	watchBrowserOSForAgents = true
 	t.Cleanup(func() {
 		watchManual = oldManual
-		watchAgentMCP = oldAgentMCP
+		watchBrowserOSForAgents = oldBrowserOSForAgents
 	})
 
 	_, err := watchMode()
@@ -29,21 +29,21 @@ func TestWatchModeRejectsManualAgentMCPCombination(t *testing.T) {
 
 func TestWatchLockModeIsSharedAcrossWatchVariants(t *testing.T) {
 	for _, tc := range []struct {
-		name     string
-		manual   bool
-		agentMCP bool
+		name      string
+		manual    bool
+		forAgents bool
 	}{
-		{name: "legacy"},
+		{name: "BrowserOS"},
 		{name: "manual", manual: true},
-		{name: "agent mcp", agentMCP: true},
+		{name: "BrowserOSForAgents", forAgents: true},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			oldManual, oldAgentMCP := watchManual, watchAgentMCP
+			oldManual, oldBrowserOSForAgents := watchManual, watchBrowserOSForAgents
 			watchManual = tc.manual
-			watchAgentMCP = tc.agentMCP
+			watchBrowserOSForAgents = tc.forAgents
 			t.Cleanup(func() {
 				watchManual = oldManual
-				watchAgentMCP = oldAgentMCP
+				watchBrowserOSForAgents = oldBrowserOSForAgents
 			})
 
 			if got := watchLockMode(); got != "watch" {
@@ -53,8 +53,8 @@ func TestWatchLockModeIsSharedAcrossWatchVariants(t *testing.T) {
 	}
 }
 
-func TestBuildAgentMCPWatchEnvIncludesSelectedPorts(t *testing.T) {
-	env := buildAgentMCPWatchEnv([]string{"BASE=1"}, proc.Ports{
+func TestBuildBrowserOSForAgentsWatchEnvIncludesSelectedPorts(t *testing.T) {
+	env := buildBrowserOSForAgentsWatchEnv([]string{"BASE=1"}, proc.Ports{
 		CDP:       9012,
 		Server:    9123,
 		Extension: 9321,

--- a/packages/browseros-agent/tools/dev/cmd/watch_test.go
+++ b/packages/browseros-agent/tools/dev/cmd/watch_test.go
@@ -27,6 +27,32 @@ func TestWatchModeRejectsManualAgentMCPCombination(t *testing.T) {
 	}
 }
 
+func TestWatchLockModeIsSharedAcrossWatchVariants(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		manual   bool
+		agentMCP bool
+	}{
+		{name: "legacy"},
+		{name: "manual", manual: true},
+		{name: "agent mcp", agentMCP: true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			oldManual, oldAgentMCP := watchManual, watchAgentMCP
+			watchManual = tc.manual
+			watchAgentMCP = tc.agentMCP
+			t.Cleanup(func() {
+				watchManual = oldManual
+				watchAgentMCP = oldAgentMCP
+			})
+
+			if got := watchLockMode(); got != "watch" {
+				t.Fatalf("expected shared watch lock mode, got %q", got)
+			}
+		})
+	}
+}
+
 func TestBuildAgentMCPWatchEnvIncludesSelectedPorts(t *testing.T) {
 	env := buildAgentMCPWatchEnv([]string{"BASE=1"}, proc.Ports{
 		CDP:       9012,

--- a/packages/browseros-agent/tools/dev/cmd/watch_test.go
+++ b/packages/browseros-agent/tools/dev/cmd/watch_test.go
@@ -27,29 +27,9 @@ func TestWatchModeRejectsManualBrowserOSForAgentsCombination(t *testing.T) {
 	}
 }
 
-func TestWatchLockModeIsSharedAcrossWatchVariants(t *testing.T) {
-	for _, tc := range []struct {
-		name      string
-		manual    bool
-		forAgents bool
-	}{
-		{name: "BrowserOS"},
-		{name: "manual", manual: true},
-		{name: "BrowserOSForAgents", forAgents: true},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			oldManual, oldBrowserOSForAgents := watchManual, watchBrowserOSForAgents
-			watchManual = tc.manual
-			watchBrowserOSForAgents = tc.forAgents
-			t.Cleanup(func() {
-				watchManual = oldManual
-				watchBrowserOSForAgents = oldBrowserOSForAgents
-			})
-
-			if got := watchLockMode(); got != "watch" {
-				t.Fatalf("expected shared watch lock mode, got %q", got)
-			}
-		})
+func TestWatchRunLockModeIsSharedAcrossWatchVariants(t *testing.T) {
+	if watchRunLockMode != "watch" {
+		t.Fatalf("expected shared watch lock mode, got %q", watchRunLockMode)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add `dev:agent-mcp:watch` and `dev:agent-mcp:watch:new` for the new MCP cockpit UI/interface pair.
- Add `watch --agent-mcp` to the existing Go dev supervisor so MCP runs reuse the same port, profile, setup, lock, and shutdown behavior as `dev:watch`.
- Pass the selected interface URL through `VITE_BROWSEROS_AGENT_MCP_API_URL` so `--new` random ports work for API calls and MCP URL previews.

## Design
The watcher keeps the existing process manager and switches only the supervised process pair: `apps/agent-mcp-ui` via WXT first, then `apps/agent-mcp-interface` after CDP is ready. All watch variants share the same lock identity for a profile/port tuple so switching between legacy/manual/MCP modes hands off cleanly instead of leaving supervisors fighting. The MCP UI still launches BrowserOS through its WXT config, which already includes `--disable-browseros-extensions` so the MCP extension can be loaded directly.

## Test plan
- [x] `go test ./...` from `packages/browseros-agent/tools/dev`
- [x] `bun test apps/agent-mcp-ui/modules/api/client.helpers.test.ts`
- [x] `bun run --filter @browseros/agent-mcp-ui typecheck`
- [x] `bunx @biomejs/biome check package.json apps/agent-mcp-ui/modules/api/client.ts apps/agent-mcp-ui/modules/api/client.helpers.ts apps/agent-mcp-ui/modules/api/client.helpers.test.ts apps/agent-mcp-ui/modules/api/mcp-endpoint.ts`
- [x] `bun run check` (exits 0; prints existing Biome/Fallow warnings)
- [ ] `bun run test`

## Blocked
- `bun run test` fails in untouched `apps/server/tests/api/routes/nudge-mcp.test.ts` with five `createNudgeMcpRoute` failures.
- Exact error: `this._transport.start is not a function. (In 'this._transport.start()', 'this._transport.start' is undefined)`.
- This branch does not modify `packages/browseros-agent/apps/server`; the failure appears in the server API test group before the touched MCP UI/dev watcher tests run.