### PR TITLE
chore: document agent MCP UI API URL env

### DIFF
--- a/packages/browseros-agent/apps/agent-mcp-ui/.env.example
+++ b/packages/browseros-agent/apps/agent-mcp-ui/.env.example
@@ -2,6 +2,10 @@
 # loads these before wxt launches the browser. None are required —
 # every entry has a sensible default in web-ext.config.ts.
 
+# Override the cockpit API base URL used by the UI. The default
+# points at apps/server's mounted cockpit runtime.
+# VITE_BROWSEROS_AGENT_MCP_API_URL="http://127.0.0.1:9100/cockpit"
+
 # Path to a BrowserOS Chromium binary. Default targets the canonical
 # macOS install.
 # BROWSEROS_BINARY="/Applications/BrowserOS.app/Contents/MacOS/BrowserOS"

--- a/packages/browseros-agent/apps/agent-mcp-ui/.env.example
+++ b/packages/browseros-agent/apps/agent-mcp-ui/.env.example
@@ -1,6 +1,6 @@
 # Copy to .env.development locally; bun --env-file=.env.development
-# loads these before wxt launches the browser. None are required —
-# every entry has a sensible default in web-ext.config.ts.
+# loads these before wxt launches the browser. Entries are optional;
+# each has a default in the code path that reads it.
 
 # Override the cockpit API base URL used by the UI. The default
 # points at apps/server's mounted cockpit runtime.


### PR DESCRIPTION
## Summary
- Documents the optional `VITE_BROWSEROS_AGENT_MCP_API_URL` override in `apps/agent-mcp-ui/.env.example`.
- Uses the same loopback `/cockpit` URL shape that the UI client accepts and falls back to.
- Updates the env-example header so defaults are described by consuming code path, not only `web-ext.config.ts`.

## Design
This keeps ownership in the existing agent MCP UI env example because the app's `dev` and `build:dev` scripts load `.env.development` from that package, and the UI reads this Vite-prefixed value through `import.meta.env`.

## Test plan
- [x] `git diff --check`
- [x] `bun run check`
- [x] `bun run test`
- [x] local Codex review round 2: clean