### PR TITLE
fix(cockpit): rollup stability under parallel writes (window + sticky focus)

### DIFF
--- a/packages/browseros-agent/apps/agent-mcp-interface/src/lib/tab-activity/registry.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/lib/tab-activity/registry.ts
@@ -48,7 +48,16 @@ export interface TabActivityRecord {
   status: 'active' | 'idle'
 }
 
-export const ACTIVE_WINDOW_MS = 5000
+// PR 1 shipped 5 s as a v1 guess. In practice the cockpit serialises
+// `tools/call` per slug and CDP serialises per-target ops, so a
+// parallel N-call burst lands in the registry over roughly the same
+// duration as the old window. By the time the last write hits, the
+// earliest records have already crossed the 5 s threshold and dropped
+// from the running grid, so the homepage chip stepped `1 -> 3 -> 5 ->
+// 4 -> 2 -> 0` during what was actually a single coherent agent
+// burst. 30 s lets the rollup stay stable across the whole burst
+// without changing the wire shape; tune from dogfooding.
+export const ACTIVE_WINDOW_MS = 30_000
 export const RECENT_TOOLS_CAP = 8
 
 export interface RegistryDeps {

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/tab-activity/parallel-landing.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/tab-activity/parallel-landing.test.ts
@@ -1,0 +1,196 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Drives the exact staggered landing pattern observed when five
+ * `tabs.new + snapshot` chains fire in parallel against a live
+ * cockpit: even though the HTTP calls are parallel, per-slug
+ * dispatch and CDP-per-target serialisation push the registry
+ * writes to roughly `t = 0s, 2.3s, 4.3s, 6.3s, 6.4s`. With a 5 s
+ * active window the earliest record idles before the latest one
+ * even lands. This test pins that the bumped window holds the burst
+ * together and that records eventually idle once the window does
+ * elapse.
+ */
+
+import { beforeEach, describe, expect, it } from 'bun:test'
+import type { BrowserSession } from '@browseros/server/browser/core/session'
+import {
+  ACTIVE_WINDOW_MS,
+  createTabActivityRegistry,
+  type TabActivityRegistry,
+} from '../../../src/lib/tab-activity/registry'
+
+interface FakePageInfo {
+  targetId: string
+  url: string
+  title: string
+}
+
+function makeSession(pages: Map<number, FakePageInfo>): BrowserSession {
+  return {
+    pages: {
+      getInfo: (pageId: number) => pages.get(pageId) ?? undefined,
+    },
+  } as unknown as BrowserSession
+}
+
+interface Landing {
+  pageId: number
+  targetId: string
+  url: string
+  title: string
+  atMs: number
+}
+
+// Five-call landings drawn from the parallel-spawn experiment's
+// monitor timeline. The exact offsets are not load-bearing; what
+// matters is that the spread is longer than the original 5 s window.
+const PARALLEL_LANDINGS: ReadonlyArray<Landing> = [
+  {
+    pageId: 7,
+    targetId: 't7',
+    url: 'https://www.reddit.com/',
+    title: 'Reddit',
+    atMs: 0,
+  },
+  {
+    pageId: 8,
+    targetId: 't8',
+    url: 'https://lobste.rs/',
+    title: 'Lobsters',
+    atMs: 2_300,
+  },
+  {
+    pageId: 9,
+    targetId: 't9',
+    url: 'https://hn.algolia.com/',
+    title: 'HN Search',
+    atMs: 4_300,
+  },
+  {
+    pageId: 10,
+    targetId: 't10',
+    url: 'https://stackoverflow.com/questions',
+    title: 'Stack Overflow',
+    atMs: 6_300,
+  },
+  {
+    pageId: 11,
+    targetId: 't11',
+    url: 'https://arstechnica.com/',
+    title: 'Ars Technica',
+    atMs: 6_400,
+  },
+] as const
+
+describe('TabActivityRegistry parallel-landing simulation', () => {
+  let pages: Map<number, FakePageInfo>
+  let session: BrowserSession
+  let nowMs: number
+  let registry: TabActivityRegistry
+
+  beforeEach(() => {
+    pages = new Map()
+    session = makeSession(pages)
+    nowMs = 1_000_000_000_000
+    registry = createTabActivityRegistry({
+      getSession: () => session,
+      now: () => nowMs,
+    })
+    for (const landing of PARALLEL_LANDINGS) {
+      pages.set(landing.pageId, {
+        targetId: landing.targetId,
+        url: landing.url,
+        title: landing.title,
+      })
+    }
+  })
+
+  function landAll(baseline: number): void {
+    for (const landing of PARALLEL_LANDINGS) {
+      nowMs = baseline + landing.atMs
+      registry.recordTool({
+        agentId: 'a1',
+        slug: 'finance-ops',
+        pageId: landing.pageId,
+        targetId: landing.targetId,
+        toolName: 'snapshot',
+      })
+    }
+  }
+
+  it('all five records remain active 10 seconds after the burst starts', () => {
+    const baseline = nowMs
+    landAll(baseline)
+    nowMs = baseline + 10_000
+    const snap = registry.snapshot()
+    expect(snap).toHaveLength(5)
+    for (const row of snap) {
+      expect(row.status).toBe('active')
+    }
+  })
+
+  it('all five records remain active 29 seconds after the burst starts (just under the window)', () => {
+    const baseline = nowMs
+    landAll(baseline)
+    // The earliest landing is at baseline + 0; advance just inside
+    // the window so even it has not aged out yet.
+    nowMs = baseline + (ACTIVE_WINDOW_MS - 1_000)
+    const snap = registry.snapshot()
+    expect(snap.every((r) => r.status === 'active')).toBe(true)
+  })
+
+  it('the earliest record idles first once the window does eventually elapse', () => {
+    const baseline = nowMs
+    landAll(baseline)
+    // The first landing was at t=0; advance the clock so it has crossed
+    // the window but the latest landing has not.
+    nowMs = baseline + ACTIVE_WINDOW_MS + 1
+    const snap = registry.snapshot()
+    const byTarget = new Map(snap.map((r) => [r.targetId, r]))
+    expect(byTarget.get('t7')?.status).toBe('idle')
+    expect(byTarget.get('t11')?.status).toBe('active')
+  })
+
+  it('all records are idle once the window has fully elapsed for every landing', () => {
+    const baseline = nowMs
+    landAll(baseline)
+    nowMs = baseline + 6_400 + ACTIVE_WINDOW_MS + 1
+    const snap = registry.snapshot()
+    expect(snap.every((r) => r.status === 'idle')).toBe(true)
+  })
+
+  it('the registry holds exactly five records throughout the burst', () => {
+    const baseline = nowMs
+    landAll(baseline)
+    // Sample at several checkpoints to make sure no record was lost,
+    // duplicated, or evicted prematurely.
+    for (const offset of [0, 5_000, 10_000, 20_000, 29_000]) {
+      nowMs = baseline + offset
+      expect(registry.snapshot()).toHaveLength(5)
+    }
+  })
+
+  it('a new tool call on an early tab keeps it active even after the original burst window would have elapsed', () => {
+    const baseline = nowMs
+    landAll(baseline)
+    // 25 s after the burst, the agent goes back to the reddit tab.
+    // That tab should re-enter the active set and stay there for
+    // another full window.
+    nowMs = baseline + 25_000
+    registry.recordTool({
+      agentId: 'a1',
+      slug: 'finance-ops',
+      pageId: 7,
+      targetId: 't7',
+      toolName: 'read',
+    })
+    nowMs = baseline + 25_000 + ACTIVE_WINDOW_MS - 1
+    const snap = registry.snapshot()
+    const row = snap.find((r) => r.targetId === 't7')
+    expect(row?.status).toBe('active')
+    expect(row?.toolCount).toBe(2)
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/tab-activity/registry.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/tab-activity/registry.test.ts
@@ -185,6 +185,14 @@ describe('TabActivityRegistry', () => {
     expect(registry.snapshot()[0].status).toBe('idle')
   })
 
+  it('ACTIVE_WINDOW_MS is 30 seconds (regression guard)', () => {
+    // Reverting this to a smaller value would silently re-introduce
+    // the homepage flicker observed when a single agent fires a
+    // parallel burst of tool calls across several tabs. Tune
+    // intentionally; do not edit blindly.
+    expect(ACTIVE_WINDOW_MS).toBe(30_000)
+  })
+
   it('evicts records whose pageId no longer maps to the original targetId', () => {
     pages.set(1, { targetId: 't1', url: 'https://example.com/', title: 'Ex' })
     registry.recordTool({

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.data.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.data.ts
@@ -1,3 +1,4 @@
+import { useRef } from 'react'
 import type { ActivityRow } from '@/modules/api/activity.hooks'
 import { useTabsActivity } from '@/modules/api/tabs.hooks'
 import {
@@ -28,22 +29,42 @@ export interface CockpitData {
  * stays tab-level by design: "Cowork did read on Stripe 12m ago" is
  * more informative than "Cowork did 14 things". Approvals and
  * handoffs remain on their mocked hooks until later PRs supply them.
+ *
+ * Sticky focus is applied across polls so the card surface does not
+ * flicker when one agent fires a parallel burst of tool calls across
+ * several tabs. The hook holds the last poll's per-agent focus in a
+ * useRef and passes it back into the rollup as a hint; the rollup
+ * keeps that target as focus while it remains in the agent's active
+ * set, and re-elects to the freshest tab otherwise.
  */
 export function useCockpitData(): CockpitData {
   const tabs = useTabsActivity()
   const approvals = useApprovals()
   const handoffs = useHandoffs()
 
+  // The ref is the canonical store for last-seen focus: render N
+  // reads from it; render N+1 sees what render N wrote. We mutate in
+  // place rather than calling setState so the rollup -> render -> ref
+  // loop stays linear and React does not see a second update.
+  const stickyFocusRef = useRef<Map<string, string>>(new Map())
+
   // We pass `Date.now()` at render time; the slight non-determinism
   // is fine for a 1.5s-polling display and avoids dragging a clock
   // injection through the component tree.
   const records = tabs.data?.tabs ?? []
   const now = Date.now()
+  const agents = tabsToAgentActivity(
+    records.filter((r) => r.status === 'active'),
+    { stickyFocus: stickyFocusRef.current },
+  )
+  // Replace (not mutate) the map so an agent that drops out of the
+  // running grid does not pin a stale focus through future polls.
+  const nextFocus = new Map<string, string>()
+  for (const a of agents) nextFocus.set(a.agentId, a.currentFocus.targetId)
+  stickyFocusRef.current = nextFocus
+
   return {
-    // The rollup only considers active records so an agent that is
-    // currently idle drops out of the running grid; its individual
-    // tabs still appear in the recent activity list below.
-    agents: tabsToAgentActivity(records.filter((r) => r.status === 'active')),
+    agents,
     activity: tabsToActivityRows(records, now),
     approvals: approvals.data ?? [],
     handoffs: handoffs.data ?? [],

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.data.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.data.ts
@@ -59,6 +59,16 @@ export function useCockpitData(): CockpitData {
   )
   // Replace (not mutate) the map so an agent that drops out of the
   // running grid does not pin a stale focus through future polls.
+  //
+  // Mutating a ref during render looks like a side effect, but it is
+  // safe here under both React Strict Mode and concurrent rendering
+  // because `tabsToAgentActivity` is pure: for the same `records` and
+  // the same `stickyFocus` input it always produces the same focus
+  // map. Strict Mode's double-invocation in dev therefore commits the
+  // same value, and a concurrent-mode render that is interrupted and
+  // retried lands on the same commit too. The alternative of writing
+  // through `useEffect` would lag a frame and reintroduce the
+  // first-render flicker we are explicitly trying to suppress.
   const nextFocus = new Map<string, string>()
   for (const a of agents) nextFocus.set(a.agentId, a.currentFocus.targetId)
   stickyFocusRef.current = nextFocus

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.helpers.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.helpers.test.ts
@@ -372,3 +372,113 @@ describe('tabsToAgentActivity', () => {
     expect(tabsToAgentActivity([])).toEqual([])
   })
 })
+
+describe('tabsToAgentActivity sticky focus', () => {
+  it('falls back to freshest when no sticky map is supplied (PR 3 behaviour preserved)', () => {
+    const agents = tabsToAgentActivity([
+      record({ targetId: 't-old', lastToolAt: 1_000 }),
+      record({ targetId: 't-fresh', lastToolAt: 2_000 }),
+    ])
+    expect(agents[0].currentFocus.targetId).toBe('t-fresh')
+  })
+
+  it('keeps the focus anchored to the previous target when it is still active', () => {
+    const tabs = [
+      record({
+        targetId: 't-anchor',
+        url: 'https://anchor.example/',
+        title: 'Anchor',
+        lastToolAt: 1_000,
+        lastToolName: 'snapshot',
+      }),
+      record({
+        targetId: 't-newer',
+        url: 'https://newer.example/',
+        title: 'Newer',
+        lastToolAt: 2_000,
+        lastToolName: 'read',
+      }),
+    ]
+    const sticky = new Map([['a1', 't-anchor']])
+    const agents = tabsToAgentActivity(tabs, { stickyFocus: sticky })
+    expect(agents[0].currentFocus.targetId).toBe('t-anchor')
+    // Live line reflects the focus tab; the action chip / sort still
+    // see the agent's true freshness so the multi-agent ordering on
+    // the homepage stays correct.
+    expect(agents[0].lastToolName).toBe('snapshot')
+    expect(agents[0].lastToolAt).toBe(2_000)
+  })
+
+  it('re-elects to the freshest tab when the previously-focused target has dropped out of the active set', () => {
+    const sticky = new Map([['a1', 't-ghost']])
+    const agents = tabsToAgentActivity(
+      [
+        record({ targetId: 't-old', lastToolAt: 1_000 }),
+        record({ targetId: 't-fresh', lastToolAt: 2_000 }),
+      ],
+      { stickyFocus: sticky },
+    )
+    expect(agents[0].currentFocus.targetId).toBe('t-fresh')
+  })
+
+  it('keeps focus stable across two consecutive polls even when newer tabs land between them', () => {
+    // Render 1: only the anchor tab is present.
+    const first = tabsToAgentActivity([
+      record({
+        targetId: 't-anchor',
+        url: 'https://anchor.example/',
+        title: 'Anchor',
+        lastToolAt: 1_000,
+      }),
+    ])
+    expect(first[0].currentFocus.targetId).toBe('t-anchor')
+
+    // Render 2: a second tab fires a fresher tool. The previous
+    // render's focus (anchor) is passed back in via the sticky map;
+    // the rollup keeps anchor as focus.
+    const sticky = new Map<string, string>()
+    for (const agent of first)
+      sticky.set(agent.agentId, agent.currentFocus.targetId)
+
+    const second = tabsToAgentActivity(
+      [
+        record({
+          targetId: 't-anchor',
+          url: 'https://anchor.example/',
+          title: 'Anchor',
+          lastToolAt: 1_000,
+        }),
+        record({
+          targetId: 't-fresher',
+          url: 'https://fresher.example/',
+          title: 'Fresher',
+          lastToolAt: 2_500,
+        }),
+      ],
+      { stickyFocus: sticky },
+    )
+    expect(second[0].currentFocus.targetId).toBe('t-anchor')
+    expect(second[0].tabs).toHaveLength(2)
+  })
+
+  it('per-agent sticky maps do not cross-talk', () => {
+    const sticky = new Map([
+      ['a1', 't1-anchor'],
+      ['a2', 't2-anchor'],
+    ])
+    const agents = tabsToAgentActivity(
+      [
+        record({ agentId: 'a1', targetId: 't1-anchor', lastToolAt: 1_000 }),
+        record({ agentId: 'a1', targetId: 't1-fresh', lastToolAt: 2_000 }),
+        record({ agentId: 'a2', targetId: 't2-anchor', lastToolAt: 3_000 }),
+        record({ agentId: 'a2', targetId: 't2-fresh', lastToolAt: 4_000 }),
+      ],
+      { stickyFocus: sticky },
+    )
+    const byAgent = Object.fromEntries(
+      agents.map((a) => [a.agentId, a.currentFocus.targetId]),
+    )
+    expect(byAgent.a1).toBe('t1-anchor')
+    expect(byAgent.a2).toBe('t2-anchor')
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.helpers.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.helpers.ts
@@ -105,9 +105,11 @@ export function tabsToAgentRows(records: TabActivityRecord[]): AgentRow[] {
  * Roll-up shape for the homepage's RunningGrid. PR 1 / PR 2 rendered
  * one card per tab; in practice one agent often drives multiple tabs
  * and the user wants one card per agent with the tabs nested inside.
- * The `currentFocus` is the tab whose `lastToolAt` is freshest; the
- * card uses its url + title for the visible surface and lists the
- * other tabs in a popover.
+ * The `currentFocus` is the tab the card surfaces. By default it is
+ * the tab whose `lastToolAt` is freshest, but callers can pass a
+ * `stickyFocus` map keyed by agent id to anchor focus across polls
+ * so the card does not flicker as new tool calls land on other tabs.
+ * See `RollupOptions`.
  */
 export interface AgentActivityRecord {
   agentId: string
@@ -129,15 +131,29 @@ export interface AgentActivityRecord {
 }
 
 /**
+ * Caller hint that lets the rollup keep the same `currentFocus`
+ * across polls. The value is keyed by `agentId` and carries the
+ * focus target id chosen on the previous render. When the
+ * previously-focused tab is still in the agent's active set, the
+ * rollup keeps it as focus; otherwise it re-elects using the
+ * freshest `lastToolAt`. Without this hint the rollup behaves as
+ * PR 3 shipped (freshest wins every time).
+ */
+export interface RollupOptions {
+  stickyFocus?: ReadonlyMap<string, string>
+}
+
+/**
  * Groups tabs by `agentId` so the homepage renders one card per agent
- * instead of one per tab. Pure: same input always produces the same
- * output. The status is `active` if any of the agent's tabs are
- * active; `firstToolAt` is the oldest first-touch across the bunch
- * (the moment this agent first started working); `lastToolName` is
- * whichever tab is currently the focus.
+ * instead of one per tab. Pure: same input + same options always
+ * produces the same output. The status is `active` if any of the
+ * agent's tabs are active; `firstToolAt` is the oldest first-touch
+ * across the bunch (the moment this agent first started working);
+ * `lastToolName` is whichever tab is currently the focus.
  */
 export function tabsToAgentActivity(
   records: TabActivityRecord[],
+  options?: RollupOptions,
 ): AgentActivityRecord[] {
   const byAgent = new Map<string, TabActivityRecord[]>()
   for (const record of records) {
@@ -145,10 +161,15 @@ export function tabsToAgentActivity(
     if (bucket) bucket.push(record)
     else byAgent.set(record.agentId, [record])
   }
+  const sticky = options?.stickyFocus
   const out: AgentActivityRecord[] = []
   for (const [agentId, tabs] of byAgent) {
     const sorted = [...tabs].sort((a, b) => b.lastToolAt - a.lastToolAt)
-    const focus = sorted[0]
+    const previousFocusTargetId = sticky?.get(agentId)
+    const stickyTab = previousFocusTargetId
+      ? sorted.find((t) => t.targetId === previousFocusTargetId)
+      : undefined
+    const focus = stickyTab ?? sorted[0]
     const mergedTrail = sorted
       .flatMap((t) => t.recentTools)
       .sort((a, b) => a.at - b.at)
@@ -160,7 +181,13 @@ export function tabsToAgentActivity(
       harness: harnessForRow(focus.harness),
       color: focus.color ?? colorForSlug(focus.slug),
       firstToolAt: Math.min(...tabs.map((t) => t.firstToolAt)),
-      lastToolAt: focus.lastToolAt,
+      // lastToolAt is agent-level freshness (max across tabs) so the
+      // multi-agent sort below keeps the busiest agent on top even
+      // when the sticky focus rule is anchored to an older tab.
+      lastToolAt: Math.max(...tabs.map((t) => t.lastToolAt)),
+      // lastToolName tracks the focus tab so the card's live-line
+      // ("snapshot -> example.com") stays stable across polls even
+      // when other tabs are firing.
       lastToolName: focus.lastToolName,
       toolCount: tabs.reduce((sum, t) => sum + t.toolCount, 0),
       recentTools: mergedTrail,

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/rollup-sequence.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/rollup-sequence.test.ts
@@ -1,0 +1,216 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Simulates the homepage's perspective across the lifecycle of a
+ * five-tab parallel burst by calling `tabsToAgentActivity` once per
+ * synthetic poll and threading the resulting focus map back into the
+ * next call. The assertions pin two invariants that PR 3 alone could
+ * not guarantee:
+ *
+ *   - the rolled-up card's `currentFocus` stays anchored to whichever
+ *     tab the agent first hit during the burst, instead of flipping
+ *     to the freshest tab on every poll;
+ *
+ *   - the tab-count steps monotonically UP as the parallel landings
+ *     arrive (no `5 -> 4 -> 2 -> 0` flicker mid-burst).
+ *
+ * The test is independent of real time: each "poll" is just a call
+ * to `tabsToAgentActivity` with a fresh records array. Active vs.
+ * idle is decided by the caller, mirroring how the cockpit's
+ * `cockpit.data.ts` filters on `status === 'active'` before rolling
+ * up.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import type { TabActivityRecord } from '@/modules/api/tabs.hooks'
+import { tabsToAgentActivity } from './cockpit.helpers'
+
+function tab(over: Partial<TabActivityRecord>): TabActivityRecord {
+  return {
+    targetId: 't?',
+    pageId: 0,
+    url: 'https://example.com/',
+    title: 'Ex',
+    agentId: 'a1',
+    slug: 'finance-ops',
+    firstToolAt: 0,
+    lastToolAt: 0,
+    lastToolName: 'snapshot',
+    toolCount: 1,
+    recentTools: [{ name: 'snapshot', at: 0 }],
+    status: 'active',
+    agentLabel: 'Finance Ops',
+    harness: 'Claude Code',
+    color: null,
+    ...over,
+  }
+}
+
+function makeBurstTabs(
+  targetIds: ReadonlyArray<string>,
+  lastToolAtByTarget: ReadonlyMap<string, number>,
+): TabActivityRecord[] {
+  return targetIds.map((targetId, i) =>
+    tab({
+      targetId,
+      pageId: 7 + i,
+      url: `https://${targetId}.example/`,
+      title: `Tab ${targetId}`,
+      firstToolAt: lastToolAtByTarget.get(targetId) ?? 0,
+      lastToolAt: lastToolAtByTarget.get(targetId) ?? 0,
+    }),
+  )
+}
+
+describe('rollup-sequence (sticky focus across polls)', () => {
+  it('keeps the card anchored to the first-landed tab through the full burst', () => {
+    // Synthetic landings (ms offsets from the burst start) replayed
+    // verbatim from the parallel-spawn experiment.
+    const landings = new Map<string, number>([
+      ['t7', 0],
+      ['t8', 2_300],
+      ['t9', 4_300],
+      ['t10', 6_300],
+      ['t11', 6_400],
+    ])
+
+    // Eight polls at the homepage's 1.5 s cadence covering the full
+    // burst plus a few seconds of "nothing fires" tail.
+    const pollSchedule: Array<{
+      atMs: number
+      visible: ReadonlyArray<string>
+    }> = [
+      { atMs: 0, visible: [] },
+      { atMs: 1_500, visible: ['t7'] },
+      { atMs: 3_000, visible: ['t7', 't8'] },
+      { atMs: 4_500, visible: ['t7', 't8', 't9'] },
+      { atMs: 6_000, visible: ['t7', 't8', 't9'] },
+      { atMs: 7_500, visible: ['t7', 't8', 't9', 't10', 't11'] },
+      { atMs: 15_000, visible: ['t7', 't8', 't9', 't10', 't11'] },
+      { atMs: 25_000, visible: ['t7', 't8', 't9', 't10', 't11'] },
+    ]
+
+    let stickyFocus = new Map<string, string>()
+    const observedFocus: string[] = []
+    const observedCount: number[] = []
+
+    for (const poll of pollSchedule) {
+      const visible = poll.visible.map((id) => id)
+      const records = makeBurstTabs(visible, landings)
+      const agents = tabsToAgentActivity(records, { stickyFocus })
+      if (agents.length === 0) {
+        observedFocus.push('none')
+        observedCount.push(0)
+      } else {
+        observedFocus.push(agents[0].currentFocus.targetId)
+        observedCount.push(agents[0].tabs.length)
+      }
+      const next = new Map<string, string>()
+      for (const a of agents) next.set(a.agentId, a.currentFocus.targetId)
+      stickyFocus = next
+    }
+
+    // Focus is `t7` (the first-landed) from the moment the agent
+    // appears, and never flips during the burst even as fresher tabs
+    // land.
+    expect(observedFocus).toEqual([
+      'none',
+      't7',
+      't7',
+      't7',
+      't7',
+      't7',
+      't7',
+      't7',
+    ])
+    // Tab count rides the high-water mark instead of bouncing.
+    expect(observedCount).toEqual([0, 1, 2, 3, 3, 5, 5, 5])
+  })
+
+  it('re-elects to the freshest tab when the anchor stops appearing in the active set', () => {
+    const landings = new Map<string, number>([
+      ['t-anchor', 0],
+      ['t-newer', 1_000],
+    ])
+
+    const polls: Array<ReadonlyArray<string>> = [
+      ['t-anchor'],
+      ['t-anchor', 't-newer'],
+      ['t-newer'], // t-anchor has aged past the registry's active window
+    ]
+
+    let stickyFocus = new Map<string, string>()
+    const focuses: string[] = []
+    for (const visible of polls) {
+      const agents = tabsToAgentActivity(makeBurstTabs(visible, landings), {
+        stickyFocus,
+      })
+      focuses.push(agents[0]?.currentFocus.targetId ?? 'none')
+      const next = new Map<string, string>()
+      for (const a of agents) next.set(a.agentId, a.currentFocus.targetId)
+      stickyFocus = next
+    }
+
+    expect(focuses).toEqual(['t-anchor', 't-anchor', 't-newer'])
+  })
+
+  it('keeps per-agent focus maps independent across polls', () => {
+    const landings = new Map<string, number>([
+      ['t1-anchor', 0],
+      ['t1-newer', 5_000],
+      ['t2-anchor', 0],
+      ['t2-newer', 5_000],
+    ])
+
+    function buildTabs(
+      visible: ReadonlyArray<[string, string]>,
+    ): TabActivityRecord[] {
+      return visible.map(([agentId, targetId], i) =>
+        tab({
+          agentId,
+          targetId,
+          pageId: 100 + i,
+          firstToolAt: landings.get(targetId) ?? 0,
+          lastToolAt: landings.get(targetId) ?? 0,
+        }),
+      )
+    }
+
+    // Poll 1: each agent has only its anchor.
+    let stickyFocus = new Map<string, string>()
+    let agents = tabsToAgentActivity(
+      buildTabs([
+        ['a1', 't1-anchor'],
+        ['a2', 't2-anchor'],
+      ]),
+      { stickyFocus },
+    )
+    expect(
+      Object.fromEntries(
+        agents.map((a) => [a.agentId, a.currentFocus.targetId]),
+      ),
+    ).toEqual({ a1: 't1-anchor', a2: 't2-anchor' })
+
+    const next = new Map<string, string>()
+    for (const a of agents) next.set(a.agentId, a.currentFocus.targetId)
+    stickyFocus = next
+
+    // Poll 2: each agent gains a fresher tab. Sticky focus holds.
+    agents = tabsToAgentActivity(
+      buildTabs([
+        ['a1', 't1-anchor'],
+        ['a1', 't1-newer'],
+        ['a2', 't2-anchor'],
+        ['a2', 't2-newer'],
+      ]),
+      { stickyFocus },
+    )
+    expect(
+      Object.fromEntries(
+        agents.map((a) => [a.agentId, a.currentFocus.targetId]),
+      ),
+    ).toEqual({ a1: 't1-anchor', a2: 't2-anchor' })
+  })
+})

--- a/packages/browseros-agent/scripts/dev/parallel-tab-spawn.ts
+++ b/packages/browseros-agent/scripts/dev/parallel-tab-spawn.ts
@@ -1,0 +1,249 @@
+#!/usr/bin/env bun
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Reproduces the parallel-burst pattern that exposed the homepage
+ * rollup flicker: fire N `tabs.new + snapshot` chains in parallel
+ * against the cockpit's per-agent MCP route, then poll
+ * `/cockpit/tabs/activity` once per second for 30 seconds and print
+ * a structured PASS/FAIL summary. The rig is the documented
+ * validation gate for any future change to `ACTIVE_WINDOW_MS`, the
+ * rollup helper, or the per-agent MCP route.
+ *
+ * Usage:
+ *
+ *   bun scripts/dev/parallel-tab-spawn.ts \
+ *     --slug=claude-code \
+ *     --urls=https://example.com,https://example.org,...
+ *
+ * Optional flags:
+ *
+ *   --cockpit-url=http://127.0.0.1:9100/cockpit   default
+ *   --origin=chrome-extension://...                default uses the agent-mcp-ui pinned key
+ *   --poll-seconds=30                              total window to observe
+ *   --hold-seconds=3                               PASS requires the active count to hold for at least this many consecutive samples at N
+ *
+ * CI does not run this (needs a live BrowserOS). Reviewers run it
+ * by hand when the rollup code or constants change; capture the
+ * PASS line into the PR description.
+ */
+
+const DEFAULT_COCKPIT_URL = 'http://127.0.0.1:9100/cockpit'
+const DEFAULT_ORIGIN = 'chrome-extension://cbjjhiahclaiijedfmgafnkmejjoemga'
+const DEFAULT_POLL_SECONDS = 30
+const DEFAULT_HOLD_SECONDS = 3
+
+interface CliArgs {
+  slug: string
+  urls: string[]
+  cockpitUrl: string
+  origin: string
+  pollSeconds: number
+  holdSeconds: number
+}
+
+function parseArgs(argv: ReadonlyArray<string>): CliArgs {
+  const flags = new Map<string, string>()
+  for (const arg of argv.slice(2)) {
+    const m = arg.match(/^--([^=]+)=(.*)$/)
+    if (m) flags.set(m[1], m[2])
+  }
+  const slug = flags.get('slug')
+  const urlsRaw = flags.get('urls')
+  if (!slug) throw new Error('--slug=<agent-slug> is required')
+  if (!urlsRaw) {
+    throw new Error('--urls=<comma-separated-urls> is required (need >= 2)')
+  }
+  const urls = urlsRaw
+    .split(',')
+    .map((u) => u.trim())
+    .filter((u) => u.length > 0)
+  if (urls.length < 2) throw new Error('need at least 2 urls')
+  return {
+    slug,
+    urls,
+    cockpitUrl: flags.get('cockpit-url') ?? DEFAULT_COCKPIT_URL,
+    origin: flags.get('origin') ?? DEFAULT_ORIGIN,
+    pollSeconds: Number(flags.get('poll-seconds') ?? DEFAULT_POLL_SECONDS),
+    holdSeconds: Number(flags.get('hold-seconds') ?? DEFAULT_HOLD_SECONDS),
+  }
+}
+
+interface JsonRpcResult {
+  result?: {
+    content?: Array<{ type: string; text?: string }>
+    isError?: boolean
+  }
+  error?: { message: string }
+}
+
+async function postMcp(
+  args: CliArgs,
+  id: number,
+  method: string,
+  params: unknown,
+): Promise<JsonRpcResult> {
+  const res = await fetch(`${args.cockpitUrl}/mcp/${args.slug}`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      Origin: args.origin,
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', id, method, params }),
+  })
+  if (!res.ok) {
+    throw new Error(`MCP ${method} returned HTTP ${res.status}`)
+  }
+  return (await res.json()) as JsonRpcResult
+}
+
+function extractPageId(rpc: JsonRpcResult): number | null {
+  const text = rpc.result?.content?.[0]?.text
+  if (!text) return null
+  const m = text.match(/opened page (\d+)/)
+  return m ? Number(m[1]) : null
+}
+
+interface TabActivityRecord {
+  targetId: string
+  pageId: number
+  url: string
+  agentId: string
+  toolCount: number
+  lastToolName: string
+  status: 'active' | 'idle'
+}
+
+async function fetchActivity(
+  args: CliArgs,
+): Promise<{ tabs: TabActivityRecord[] }> {
+  const res = await fetch(`${args.cockpitUrl}/tabs/activity`, {
+    headers: { Accept: '*/*' },
+  })
+  if (!res.ok) throw new Error(`activity returned HTTP ${res.status}`)
+  return (await res.json()) as { tabs: TabActivityRecord[] }
+}
+
+async function fireChain(
+  args: CliArgs,
+  url: string,
+  baseId: number,
+): Promise<void> {
+  const opened = await postMcp(args, baseId, 'tools/call', {
+    name: 'tabs',
+    arguments: { action: 'new', url, background: true },
+  })
+  const pageId = extractPageId(opened)
+  if (pageId === null) {
+    console.log(`[fire ${baseId}] FAILED to open ${url}`)
+    return
+  }
+  console.log(`[fire ${baseId}] opened ${url} -> page=${pageId}`)
+  await postMcp(args, baseId + 1, 'tools/call', {
+    name: 'snapshot',
+    arguments: { page: pageId },
+  })
+  console.log(`[fire ${baseId}] snapshot done page=${pageId}`)
+}
+
+async function ensureCockpitUp(args: CliArgs): Promise<void> {
+  try {
+    const res = await fetch(`${args.cockpitUrl}/system/health`, {
+      headers: { Accept: '*/*' },
+    })
+    if (!res.ok) throw new Error(`HTTP ${res.status}`)
+    const body = (await res.json()) as { status?: string }
+    if (body.status !== 'ok') throw new Error(`status=${body.status}`)
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err)
+    throw new Error(
+      `cockpit ${args.cockpitUrl}/system/health not reachable: ${msg}`,
+    )
+  }
+}
+
+function formatSnapshot(
+  ts: string,
+  tabs: ReadonlyArray<TabActivityRecord>,
+): string {
+  const active = tabs.filter((t) => t.status === 'active').length
+  const summary = tabs
+    .map((t) => `p${t.pageId}:${t.status[0]}:${t.toolCount}:${t.lastToolName}`)
+    .join(' | ')
+  return `[${ts}] N=${tabs.length} active=${active} ${summary}`
+}
+
+function nowStamp(): string {
+  return new Date().toISOString().slice(11, 23)
+}
+
+async function main(): Promise<number> {
+  const args = parseArgs(process.argv)
+  await ensureCockpitUp(args)
+  const N = args.urls.length
+
+  console.log(
+    `parallel-tab-spawn: slug=${args.slug} N=${N} pollSeconds=${args.pollSeconds} holdSeconds=${args.holdSeconds}`,
+  )
+
+  // Initialise the MCP session before firing parallel calls so the
+  // per-slug McpManager has done its one-shot setup. Without this
+  // the first parallel call pays the init cost and looks slower.
+  await postMcp(args, 1, 'initialize', {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'parallel-tab-spawn', version: '0' },
+  })
+
+  // Start the parallel chains in the background while we poll.
+  const fireStart = Date.now()
+  const fires = args.urls.map((url, i) => fireChain(args, url, 1000 * (i + 1)))
+
+  // Poll the activity endpoint once per second; record per-sample
+  // active count so we can decide PASS/FAIL after the window closes.
+  const activeCounts: number[] = []
+  for (let s = 0; s < args.pollSeconds; s++) {
+    const tabs = (await fetchActivity(args)).tabs
+    const active = tabs.filter((t) => t.status === 'active').length
+    activeCounts.push(active)
+    console.log(formatSnapshot(nowStamp(), tabs))
+    await Bun.sleep(1000)
+  }
+
+  await Promise.all(fires)
+  const fireMs = Date.now() - fireStart
+  console.log(`all ${N} parallel chains finished in ${fireMs}ms`)
+
+  // PASS criterion: at any point during the poll window the active
+  // count reached N AND stayed at N for at least `holdSeconds`
+  // consecutive samples without dropping. That captures both the
+  // "burst all landed" property and the "stayed stable" property.
+  let bestRun = 0
+  let currentRun = 0
+  for (const c of activeCounts) {
+    if (c >= N) {
+      currentRun += 1
+      if (currentRun > bestRun) bestRun = currentRun
+    } else {
+      currentRun = 0
+    }
+  }
+  const pass = bestRun >= args.holdSeconds
+
+  console.log(
+    pass
+      ? `PASS active count reached ${N} and held for ${bestRun}s (>=${args.holdSeconds}s)`
+      : `FAIL active count never reached ${N} or did not hold for ${args.holdSeconds}s (best run ${bestRun}s)`,
+  )
+  return pass ? 0 : 1
+}
+
+main()
+  .then((code) => process.exit(code))
+  .catch((err) => {
+    console.error(err instanceof Error ? err.message : String(err))
+    process.exit(2)
+  })


### PR DESCRIPTION
## Summary

The homepage rollup flickered when a single agent fired tool calls across multiple tabs in close succession or in parallel. The "N tabs" chip stepped \`1 → 3 → 5 → 4 → 2 → 0\` during what was actually a single coherent agent burst, and the card surface (url + title + last-tool) flipped on every poll as new dispatches landed on fresher tabs. Two small tweaks restore a stable surface that matches the user's mental model of "what is the agent doing right now" across the lifetime of a normal multi-tab run.

Zero diffs in \`apps/server\`. All changes scoped to \`apps/agent-mcp-interface\`, \`apps/agent-mcp-ui\`, and a new dev script under \`packages/browseros-agent/scripts/dev/\`.

## What changes

**\`apps/agent-mcp-interface/src/lib/tab-activity/registry.ts\`:**
- \`ACTIVE_WINDOW_MS\` widens from \`5_000\` to \`30_000\`. The cockpit serialises \`tools/call\` per slug and CDP serialises per-target ops, so a parallel N-call burst lands in the registry over roughly the same duration as the old window. The old constant was racing the dispatch latency. Tunes from dogfooding; not a religion.
- A regression-guard test pins the constant at 30 s so a future tuning attempt cannot silently revert it.

**\`apps/agent-mcp-ui/screens/cockpit/cockpit.helpers.ts\`:**
- New \`RollupOptions { stickyFocus?: ReadonlyMap<agentId, targetId> }\` parameter on \`tabsToAgentActivity\`. When supplied, the rollup keeps the previously-focused target as \`currentFocus\` while it is still in the agent's active set, and re-elects to the freshest tab only when the anchor drops out.
- \`lastToolAt\` on the \`AgentActivityRecord\` now derives from the agent's freshest tab (\`max\` across the bunch) instead of the focus tab, so the multi-agent outer sort still ranks busiest first when sticky focus is anchored to an older tab.
- \`lastToolName\` continues to track the focus tab so the card's live line stays stable.

**\`apps/agent-mcp-ui/screens/cockpit/cockpit.data.ts\`:**
- \`useCockpitData\` holds the previous focus per agent in a \`useRef<Map<agentId, targetId>>\` and threads it back into the rollup on every render. Linear: render N reads from the ref; render N+1 sees what render N wrote. No setState loop.
- Replaced (not mutated) on each render so an agent that drops out of the running grid does not pin a stale focus through future polls.

**\`packages/browseros-agent/scripts/dev/parallel-tab-spawn.ts\`:**
- New dev rig that reproduces the parallel-burst pattern on demand: initialises an MCP session, fires N \`tabs.new + snapshot\` chains in parallel, polls \`/cockpit/tabs/activity\` once per second for 30 s, prints a structured PASS/FAIL summary. PASS requires the active count reached N AND held at N for at least 3 consecutive samples.

## Server-side guarantees

\`\`\`
$ git diff origin/main...HEAD --name-only | grep -v -E '^packages/browseros-agent/(apps/(agent-mcp-interface|agent-mcp-ui)|scripts/dev/)' | wc -l
0
\`\`\`

No edits to \`apps/server/src/tools/browser/\`, no edits to \`executeTool\`, no edits to the cockpit's MCP wrapper.

## Test plan

- [x] 1 new boundary test on \`ACTIVE_WINDOW_MS\` (regression guard).
- [x] 6 new \`parallel-landing.test.ts\` cases driving the staggered \`t = 0, 2.3, 4.3, 6.3, 6.4 s\` timeline:
  - all five records remain active 10 s after the burst starts
  - all five remain active 29 s after the burst starts (just under the window)
  - the earliest record idles first once the window does eventually elapse
  - all records are idle once the window has elapsed for every landing
  - the registry holds exactly five records across the burst (no loss / dup / premature eviction)
  - a refresh on the earliest tab keeps it active for another full window
- [x] 5 new sticky-focus unit cases on \`tabsToAgentActivity\`:
  - falls back to freshest when no map is supplied (PR 3 behaviour preserved)
  - keeps focus anchored to the previous target when it is still active
  - re-elects to freshest when the anchor has dropped out
  - keeps focus stable across two consecutive polls even when newer tabs land between them
  - per-agent sticky maps do not cross-talk
- [x] 3 new \`rollup-sequence.test.ts\` lifecycle cases threading the focus map across 8 simulated polls.
- [x] All 175 existing tests across the two packages still pass.
- [x] Workspace typecheck clean for \`apps/agent-mcp-interface\` and \`apps/agent-mcp-ui\` (the pre-existing \`apps/agent\` GraphQL-codegen warning in this worktree is unrelated and out of scope).
- [x] \`bunx biome ci\` clean across the touched scope.

**Manual walk-through** (reviewer action against a live BrowserOS): run

\`\`\`
bun packages/browseros-agent/scripts/dev/parallel-tab-spawn.ts \\
  --slug=claude-code \\
  --urls=https://reddit.com,https://lobste.rs,https://hn.algolia.com,https://stackoverflow.com,https://arstechnica.com
\`\`\`

and capture the PASS line into a follow-up comment. The rig fails any future tuning that breaks the stability guarantee.

## Follow-ups (not in this PR)

- WebSockets instead of polling: drops the 1.5 s poll latency and removes the heartbeat. Sketched as a separate PR; the stability fixes here belong regardless of transport.
- The optional UI-layer smoothing pattern from the plan stays parked. If after this lands the chip still chatters at edge cases, the smoothing pattern documented in the plan is the right tool.
- 30 s is a dogfooding starting point. Telemetry-free tuning is fine for now.