### PR TITLE
feat(cockpit): v2 phase 1 - homepage polish, empty states, hide unwired surfaces

### DIFF
--- a/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/AddAgentTile.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/AddAgentTile.tsx
@@ -2,10 +2,15 @@ import { Plus } from 'lucide-react'
 import { Link } from 'react-router'
 
 /**
+ * TODO(v2-restore-multi-agent): v2 has no per-agent profile directory,
+ * so "New profile" links to a route the v2 router no longer registers
+ * (the `/agents/new` route only mounts when VITE_COCKPIT_LEGACY_UI=1).
+ * The running grid no longer renders this tile in the default v2
+ * build. The component returns when the per-agent story does, which
+ * is post the SQLite audit work.
+ *
  * Add-tile that sits as the last item in the running grid. Reads as
- * adding to the set rather than a floating CTA. Links to
- * /agents/new which currently renders the placeholder; gets replaced
- * with the real wizard in a follow-up.
+ * adding to the set rather than a floating CTA.
  */
 export function AddAgentTile() {
   return (

--- a/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/ApprovalBanner.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/ApprovalBanner.tsx
@@ -7,6 +7,10 @@ interface ApprovalBannerProps {
 }
 
 /**
+ * TODO(v2-restore-approvals): only rendered through WaitingStrip,
+ * which is currently unwired in the v2 cockpit. Returns when the
+ * permission gate ships.
+ *
  * Inline "approval needed" card. Three actions: allow once, always
  * allow (scoped), block. Matches dashboard.jsx's ApprovalBanner: a
  * 3px accent gradient strip on top, then a row of agent label,

--- a/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/EmptyState.test.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/EmptyState.test.tsx
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { EmptyState } from './EmptyState'
+
+describe('EmptyState', () => {
+  it('renders the title and hint', () => {
+    const html = renderToStaticMarkup(
+      <EmptyState title="No agents connected" hint="Open the MCP page." />,
+    )
+    expect(html).toContain('No agents connected')
+    expect(html).toContain('Open the MCP page.')
+  })
+
+  it('uses the default icon when none is supplied', () => {
+    const html = renderToStaticMarkup(<EmptyState title="t" hint="h" />)
+    // The default Activity icon from lucide renders an <svg>. We do
+    // not assert which icon; just that an svg is present.
+    expect(html).toMatch(/<svg/)
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/EmptyState.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/EmptyState.tsx
@@ -1,0 +1,29 @@
+import { Activity } from 'lucide-react'
+import type { ReactNode } from 'react'
+
+interface EmptyStateProps {
+  title: string
+  hint: ReactNode
+  icon?: ReactNode
+}
+
+/**
+ * Shared empty-state card used by RunningGrid and RecentActivity when
+ * the registry has nothing to show. Same border / padding rhythm as
+ * the running card so the page does not collapse to a flat header
+ * when no agents are connected.
+ */
+export function EmptyState({ title, hint, icon }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center gap-3 rounded-2xl border border-border-2 bg-card p-8 text-center">
+      <span
+        aria-hidden
+        className="flex size-10 items-center justify-center rounded-xl bg-bg-sunken text-ink-3"
+      >
+        {icon ?? <Activity className="size-5" />}
+      </span>
+      <div className="font-bold text-base">{title}</div>
+      <div className="max-w-md text-ink-3 text-sm leading-relaxed">{hint}</div>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/HandoffRow.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/HandoffRow.tsx
@@ -6,6 +6,10 @@ interface HandoffRowProps {
 }
 
 /**
+ * TODO(v2-restore-approvals): only rendered through WaitingStrip,
+ * which is currently unwired in the v2 cockpit. Returns when the
+ * permission gate ships.
+ *
  * Inline "your turn" handoff row (CAPTCHA / MFA / security challenge).
  * Single action: Take over, which jumps the user into the live run
  * window where they finish the challenge in-place. Amber-themed to

--- a/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/RecentActivity.test.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/RecentActivity.test.tsx
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router'
+import type { ActivityRow } from '@/modules/api/activity.hooks'
+import { RecentActivity } from './RecentActivity'
+
+function renderWithRouter(ui: React.ReactNode): string {
+  return renderToStaticMarkup(<MemoryRouter>{ui}</MemoryRouter>)
+}
+
+function row(over: Partial<ActivityRow> = {}): ActivityRow {
+  return {
+    id: 'r1',
+    agentLabel: 'claude-code',
+    color: '#000',
+    status: 'running',
+    action: 'navigate to example.com',
+    site: 'example.com',
+    when: 'just now',
+    ...over,
+  }
+}
+
+describe('RecentActivity', () => {
+  it('renders the empty-state card when no rows are present', () => {
+    const html = renderWithRouter(<RecentActivity rows={[]} />)
+    expect(html).toContain('No recent activity')
+    expect(html).toContain('Tool calls from connected agents will appear here.')
+  })
+
+  it('still renders the section header in the empty state', () => {
+    const html = renderWithRouter(<RecentActivity rows={[]} />)
+    expect(html).toContain('Recent activity')
+    expect(html).toContain('Across all agents')
+  })
+
+  it('renders one row per ActivityRow when rows are present', () => {
+    const html = renderWithRouter(
+      <RecentActivity
+        rows={[
+          row({ id: 'r1', action: 'first' }),
+          row({ id: 'r2', action: 'second' }),
+        ]}
+      />,
+    )
+    expect(html).toContain('first')
+    expect(html).toContain('second')
+    expect(html).not.toContain('No recent activity')
+  })
+
+  it('surfaces a flagged count chip when at least one row is flagged', () => {
+    const html = renderWithRouter(
+      <RecentActivity
+        rows={[row({ id: 'r1', status: 'blocked', action: 'blocked-thing' })]}
+      />,
+    )
+    expect(html).toContain('1 flagged')
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/RecentActivity.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/RecentActivity.tsx
@@ -1,6 +1,7 @@
-import { Lock } from 'lucide-react'
+import { History, Lock } from 'lucide-react'
 import type { ActivityRow as ActivityRowData } from '@/modules/api/activity.hooks'
 import { ActivityRow } from './ActivityRow'
+import { EmptyState } from './EmptyState'
 
 interface RecentActivityProps {
   rows: ActivityRowData[]
@@ -10,7 +11,9 @@ interface RecentActivityProps {
  * Cross-agent recent activity log. Lives under the running grid so
  * the user can scan WHAT happened and WHICH agent did it, with the
  * flagged statuses (blocked, needs-human) called out by a chip in
- * the header rather than buried in a long list.
+ * the header rather than buried in a long list. Renders an empty
+ * state when no rows are present so the page rhythm stays intact on
+ * a fresh install.
  */
 export function RecentActivity({ rows }: RecentActivityProps) {
   const flaggedCount = rows.filter(
@@ -30,11 +33,19 @@ export function RecentActivity({ rows }: RecentActivityProps) {
         <div className="flex-1" />
         <span className="text-ink-3 text-xs">Across all agents</span>
       </div>
-      <div className="space-y-2">
-        {rows.map((row) => (
-          <ActivityRow key={row.id} row={row} />
-        ))}
-      </div>
+      {rows.length === 0 ? (
+        <EmptyState
+          title="No recent activity"
+          hint="Tool calls from connected agents will appear here."
+          icon={<History className="size-5" />}
+        />
+      ) : (
+        <div className="space-y-2">
+          {rows.map((row) => (
+            <ActivityRow key={row.id} row={row} />
+          ))}
+        </div>
+      )}
     </section>
   )
 }

--- a/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/RunningGrid.test.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/RunningGrid.test.tsx
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router'
+import type { AgentActivityRecord } from '@/screens/cockpit/cockpit.helpers'
+import { RunningGrid } from './RunningGrid'
+
+function renderWithRouter(ui: React.ReactNode): string {
+  return renderToStaticMarkup(<MemoryRouter>{ui}</MemoryRouter>)
+}
+
+function agent(over: Partial<AgentActivityRecord> = {}): AgentActivityRecord {
+  return {
+    agentId: 'claude-code',
+    slug: 'claude-code',
+    agentLabel: 'claude-code',
+    harness: null,
+    color: '#000',
+    status: 'active',
+    lastToolAt: 0,
+    lastToolName: 'navigate',
+    toolCount: 3,
+    recentTools: ['navigate', 'read', 'tabs'],
+    tabs: [],
+    currentFocus: {
+      targetId: 't1',
+      pageId: 1,
+      url: 'https://example.com/foo',
+      title: 'Example',
+      lastToolAt: 0,
+      lastToolName: 'navigate',
+      toolCount: 3,
+      recentTools: ['navigate'],
+    } as AgentActivityRecord['currentFocus'],
+    ...over,
+  }
+}
+
+describe('RunningGrid', () => {
+  it('renders the empty-state card when no agents are present', () => {
+    const html = renderWithRouter(<RunningGrid agents={[]} />)
+    expect(html).toContain('No agents connected')
+    expect(html).toContain('MCP page')
+    expect(html).toContain('/mcp')
+  })
+
+  it('still renders the "Running now · 0 live" header in the empty state', () => {
+    const html = renderWithRouter(<RunningGrid agents={[]} />)
+    expect(html).toContain('Running now')
+    expect(html).toContain('0 live')
+  })
+
+  it('does not render the legacy AddAgentTile when agents are present', () => {
+    const html = renderWithRouter(<RunningGrid agents={[agent()]} />)
+    expect(html).not.toContain('New profile')
+    expect(html).not.toContain('harness . logins . guardrails')
+  })
+
+  it('renders one card per agent and reflects the live count', () => {
+    const html = renderWithRouter(
+      <RunningGrid
+        agents={[agent({ agentId: 'a' }), agent({ agentId: 'b' })]}
+      />,
+    )
+    expect(html).toContain('2 live')
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/RunningGrid.test.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/RunningGrid.test.tsx
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router'
+import type { TabActivityRecord } from '@/modules/api/tabs.hooks'
 import type { AgentActivityRecord } from '@/screens/cockpit/cockpit.helpers'
 import { RunningGrid } from './RunningGrid'
 
@@ -8,29 +9,47 @@ function renderWithRouter(ui: React.ReactNode): string {
   return renderToStaticMarkup(<MemoryRouter>{ui}</MemoryRouter>)
 }
 
+function tab(over: Partial<TabActivityRecord> = {}): TabActivityRecord {
+  return {
+    targetId: 't1',
+    pageId: 1,
+    url: 'https://example.com/foo',
+    title: 'Example',
+    agentId: 'claude-code',
+    slug: 'claude-code',
+    firstToolAt: 0,
+    lastToolAt: 0,
+    lastToolName: 'navigate',
+    toolCount: 3,
+    recentTools: [{ name: 'navigate', at: 0 }],
+    status: 'active',
+    agentLabel: 'claude-code',
+    harness: null,
+    color: null,
+    ...over,
+  }
+}
+
 function agent(over: Partial<AgentActivityRecord> = {}): AgentActivityRecord {
+  const focus = tab()
   return {
     agentId: 'claude-code',
     slug: 'claude-code',
     agentLabel: 'claude-code',
-    harness: null,
+    harness: 'Claude Code',
     color: '#000',
     status: 'active',
+    firstToolAt: 0,
     lastToolAt: 0,
     lastToolName: 'navigate',
     toolCount: 3,
-    recentTools: ['navigate', 'read', 'tabs'],
-    tabs: [],
-    currentFocus: {
-      targetId: 't1',
-      pageId: 1,
-      url: 'https://example.com/foo',
-      title: 'Example',
-      lastToolAt: 0,
-      lastToolName: 'navigate',
-      toolCount: 3,
-      recentTools: ['navigate'],
-    } as AgentActivityRecord['currentFocus'],
+    recentTools: [
+      { name: 'navigate', at: 0 },
+      { name: 'read', at: 0 },
+      { name: 'tabs', at: 0 },
+    ],
+    tabs: [focus],
+    currentFocus: focus,
     ...over,
   }
 }

--- a/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/RunningGrid.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/RunningGrid.tsx
@@ -1,17 +1,19 @@
-import { useNavigate } from 'react-router'
+import { Link, useNavigate } from 'react-router'
 import type { AgentActivityRecord } from '@/screens/cockpit/cockpit.helpers'
-import { AddAgentTile } from './AddAgentTile'
 import { AgentRunningCard } from './AgentRunningCard'
+import { EmptyState } from './EmptyState'
 
 interface RunningGridProps {
   agents: AgentActivityRecord[]
 }
 
 /**
- * Uniform card grid. PR 3 rolls the per-tab records up by agent so
- * each card represents one logical run across however many tabs that
- * agent currently drives. The trailing AddAgentTile reads as "create
- * another profile" so the section feels like a set.
+ * One uniform card per rolled-up agent. v2 has no per-agent profile
+ * directory, so the trailing "New profile" tile is gone; the
+ * AddAgentTile file stays on disk with a TODO header that names what
+ * brings it back. When the registry is empty, the section keeps its
+ * header and renders a centred empty-state card pointing the operator
+ * at the MCP page.
  */
 export function RunningGrid({ agents }: RunningGridProps) {
   const navigate = useNavigate()
@@ -29,16 +31,33 @@ export function RunningGrid({ agents }: RunningGridProps) {
           {liveCount} live
         </span>
       </div>
-      <div className="grid grid-cols-[repeat(auto-fill,minmax(258px,1fr))] items-start gap-3.5">
-        {agents.map((a) => (
-          <AgentRunningCard
-            key={a.agentId}
-            agent={a}
-            onWatch={() => navigate(`/run/${a.currentFocus.targetId}`)}
-          />
-        ))}
-        <AddAgentTile />
-      </div>
+      {agents.length === 0 ? (
+        <EmptyState
+          title="No agents connected"
+          hint={
+            <>
+              Open the{' '}
+              <Link
+                to="/mcp"
+                className="font-semibold text-accent-ink underline-offset-2 hover:underline"
+              >
+                MCP page
+              </Link>{' '}
+              for the URL to paste into Claude Code, Cursor, or Codex.
+            </>
+          }
+        />
+      ) : (
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(258px,1fr))] items-start gap-3.5">
+          {agents.map((a) => (
+            <AgentRunningCard
+              key={a.agentId}
+              agent={a}
+              onWatch={() => navigate(`/run/${a.currentFocus.targetId}`)}
+            />
+          ))}
+        </div>
+      )}
     </section>
   )
 }

--- a/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/WaitingStrip.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/WaitingStrip.tsx
@@ -9,6 +9,12 @@ interface WaitingStripProps {
 }
 
 /**
+ * TODO(v2-restore-approvals): the mocked approval and handoff hooks
+ * have no server-side signal source in v2, so the strip is unwired
+ * from the cockpit homepage. The surface returns when the permission
+ * gate ships in a later phase (per-agent tab groups and the SQLite
+ * audit log on the same wire).
+ *
  * Sticky-attention strip surfaced above the running grid. Renders
  * nothing when both arrays are empty (no count chip, no header). The
  * count chip on the header is bright amber so it draws the eye

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/Cockpit.test.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/Cockpit.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * Pins the v2 homepage's section set: hero, running grid, recent
+ * activity. The waiting strip and the new-profile tile must NOT
+ * render in the default v2 build (their files stay on disk with TODO
+ * headers, but the rendered tree does not reach them).
+ */
+
+import { describe, expect, it, mock } from 'bun:test'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router'
+
+// Stub the data hook so the test does not need a network mock or
+// real polling. The shape mirrors the v2 CockpitData interface.
+mock.module('./cockpit.data', () => ({
+  useCockpitData: () => ({
+    agents: [],
+    activity: [],
+    isPending: false,
+  }),
+}))
+
+const { Cockpit } = await import('./Cockpit')
+
+function renderApp(): string {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <Cockpit />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe('Cockpit (v2)', () => {
+  it('renders the hero, running grid header, and activity header', () => {
+    const html = renderApp()
+    expect(html).toContain('working on')
+    expect(html).toContain('Running now')
+    expect(html).toContain('Recent activity')
+  })
+
+  it('does NOT render the WaitingStrip in the default v2 build', () => {
+    const html = renderApp()
+    expect(html).not.toContain('Waiting on you')
+  })
+
+  it('does NOT render the AddAgentTile in the default v2 build', () => {
+    const html = renderApp()
+    expect(html).not.toContain('New profile')
+    expect(html).not.toContain('harness . logins . guardrails')
+  })
+
+  it('renders both empty-state cards when registry is empty', () => {
+    const html = renderApp()
+    expect(html).toContain('No agents connected')
+    expect(html).toContain('No recent activity')
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/Cockpit.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/Cockpit.tsx
@@ -1,26 +1,21 @@
 import { CockpitHero } from '@/components/cockpit/CockpitHero'
 import { RecentActivity } from '@/components/cockpit/RecentActivity'
 import { RunningGrid } from '@/components/cockpit/RunningGrid'
-import { WaitingStrip } from '@/components/cockpit/WaitingStrip'
 import { useCockpitData } from './cockpit.data'
 
 /**
- * Cockpit home. Four stacked sections matching the design's dashboard
- * order: hero, waiting strip (sticky-attention surface), running
- * grid (the agents themselves), recent activity (cross-agent log).
- *
- * PR 1 wires `RunningGrid` and `RecentActivity` to the real
- * `GET /cockpit/tabs/activity` registry; `WaitingStrip`'s approvals
- * and handoffs remain on their mocked hooks until later PRs supply
- * them.
+ * Cockpit home. v2 ships three stacked sections: hero, running grid,
+ * recent activity. The waiting strip (approvals + handoffs) is hidden
+ * because v2 has no server-side signal source yet; the WaitingStrip
+ * component stays on disk with a TODO header naming what brings it
+ * back when the permission gate ships in a later phase.
  */
 export function Cockpit() {
-  const { agents, activity, approvals, handoffs } = useCockpitData()
+  const { agents, activity } = useCockpitData()
 
   return (
     <div className="mx-auto flex max-w-5xl flex-col gap-8 px-8 pt-10 pb-20">
       <CockpitHero />
-      <WaitingStrip approvals={approvals} handoffs={handoffs} />
       <RunningGrid agents={agents} />
       <RecentActivity rows={activity} />
     </div>

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.data.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/cockpit/cockpit.data.ts
@@ -2,12 +2,6 @@ import { useRef } from 'react'
 import type { ActivityRow } from '@/modules/api/activity.hooks'
 import { useTabsActivity } from '@/modules/api/tabs.hooks'
 import {
-  type ApprovalItem,
-  type HandoffItem,
-  useApprovals,
-  useHandoffs,
-} from '@/modules/api/waiting.hooks'
-import {
   type AgentActivityRecord,
   tabsToActivityRows,
   tabsToAgentActivity,
@@ -16,8 +10,6 @@ import {
 export interface CockpitData {
   agents: AgentActivityRecord[]
   activity: ActivityRow[]
-  approvals: ApprovalItem[]
-  handoffs: HandoffItem[]
   isPending: boolean
 }
 
@@ -39,8 +31,6 @@ export interface CockpitData {
  */
 export function useCockpitData(): CockpitData {
   const tabs = useTabsActivity()
-  const approvals = useApprovals()
-  const handoffs = useHandoffs()
 
   // The ref is the canonical store for last-seen focus: render N
   // reads from it; render N+1 sees what render N wrote. We mutate in
@@ -76,8 +66,6 @@ export function useCockpitData(): CockpitData {
   return {
     agents,
     activity: tabsToActivityRows(records, now),
-    approvals: approvals.data ?? [],
-    handoffs: handoffs.data ?? [],
-    isPending: tabs.isPending || approvals.isPending || handoffs.isPending,
+    isPending: tabs.isPending,
   }
 }


### PR DESCRIPTION
## Summary

Tightens the cockpit homepage at `/newtab.html#/` for the v2 build. Two surfaces with no v2 data source are removed from the rendered tree (the WaitingStrip approvals/handoffs strip, and the trailing AddAgentTile in the running grid). Both surfaces keep their files on disk with `TODO(v2-restore-*)` headers naming what brings them back. A shared `EmptyState` component lands in `components/cockpit/` and is used by both `RunningGrid` and `RecentActivity` so a fresh install renders something useful instead of an empty section.

This is a UI-only PR. Zero diffs in `apps/server/`, zero diffs in `apps/agent-mcp-interface/`. The v2 single MCP endpoint, identity capture, and tabs/activity fallback all already shipped in the previous PR.

## What changed

**Removed from the rendered tree:**

- `WaitingStrip` (`Cockpit.tsx` no longer instantiates it; `cockpit.data.ts` drops `useApprovals` / `useHandoffs`). No real signal source in v2.
- `AddAgentTile` (`RunningGrid.tsx` no longer renders the trailing tile). Links to `/agents/new` which is gated off in the v2 build.

**Kept on disk** with `TODO(v2-restore-*)` headers:

- `components/cockpit/WaitingStrip.tsx`
- `components/cockpit/ApprovalBanner.tsx`
- `components/cockpit/HandoffRow.tsx`
- `components/cockpit/AddAgentTile.tsx`
- The mocked `modules/api/waiting.hooks.ts` (still imported by `WaitingStrip`)

**New:**

- `components/cockpit/EmptyState.tsx`: shared centred card with icon, title, hint. Same border / padding rhythm as the running card.
- `RunningGrid` empty state: "No agents connected" with a `Link to=\"/mcp\"` pointing the operator at the MCP page.
- `RecentActivity` empty state: "No recent activity. Tool calls from connected agents will appear here."

## Test plan

- [x] `bun --cwd apps/agent-mcp-ui test` - 59 pass (up from 45). New tests cover `EmptyState`, `RunningGrid` empty + populated paths, `RecentActivity` empty + populated paths, `Cockpit` section set (asserts WaitingStrip and AddAgentTile do NOT render in the default build).
- [x] `bun --cwd apps/agent-mcp-interface test` - 157 pass, unchanged.
- [x] `bun --cwd apps/agent-mcp-ui run typecheck` - clean.
- [ ] Visual parity: side-by-side screenshot of the v2 cockpit and the design HTML at 1440 x 900. Deferred to a follow-up since the dev server + browser automation is interactive.
- [ ] Manual smoke: connect Claude Code to `http://127.0.0.1:9100/cockpit/mcp` and verify one card labelled "claude-code" appears within ~1.5s, the action count climbs as tool calls fire, the card persists until the session closes.
- [ ] Parallel-tab-spawn rig run: confirm chip count stays stable across 30+ polls.

## Notes for review

- The "Watch" button on each running card still links to `/run/:targetId` which is gated off in the v2 build (only mounts under `VITE_COCKPIT_LEGACY_UI=1`). The button is visible but dead-links in v2; the v2 "Watch" experience is the per-agent tab-group surface (later phase). Operators on v2 build know this; we can swap the button for a no-op tooltip in a follow-up if the dead link reads worse than the surface looking unfinished.
- The mocked `useApprovals` / `useHandoffs` hooks stay because `WaitingStrip` still imports them (the component still exists). Removing the mocks would break the legacy build (`VITE_COCKPIT_LEGACY_UI=1`).