### PR TITLE
feat(cockpit): v2 phase 2 - single MCP endpoint UI with one-click harness connect

### DIFF
--- a/packages/browseros-agent/apps/agent-mcp-interface/package.json
+++ b/packages/browseros-agent/apps/agent-mcp-interface/package.json
@@ -16,6 +16,10 @@
     "./shared/port": {
       "types": "./src/shared/port.ts",
       "default": "./src/shared/port.ts"
+    },
+    "./shared/mcp-url": {
+      "types": "./src/shared/mcp-url.ts",
+      "default": "./src/shared/mcp-url.ts"
     }
   },
   "scripts": {

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/routes/connections/index.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/routes/connections/index.ts
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * /connections route chain. Drives the v2 MCP page's per-harness
+ * "Connect" buttons: GET lists install state for every supported
+ * harness, POST :harness/connect installs BrowserOS as an MCP server
+ * in that harness's config file, POST :harness/disconnect removes
+ * it. The actual filesystem writes live in
+ * `services/browseros-connect`; this layer is the HTTP shape and
+ * validation.
+ */
+
+import { zValidator } from '@hono/zod-validator'
+import { Hono } from 'hono'
+import { z } from 'zod'
+import {
+  connectBrowserosToHarness,
+  disconnectBrowserosFromHarness,
+  listBrowserosConnections,
+} from '../../services/browseros-connect'
+import { harnessEnum } from '../agents/schemas'
+
+const harnessParamSchema = z.object({ harness: harnessEnum })
+
+export const connectionsRoute = new Hono()
+  .get('/connections', async (c) => {
+    return c.json({ connections: await listBrowserosConnections() })
+  })
+  .post(
+    '/connections/:harness/connect',
+    zValidator('param', harnessParamSchema),
+    async (c) => {
+      const { harness } = c.req.valid('param')
+      const state = await connectBrowserosToHarness(harness)
+      return c.json(state)
+    },
+  )
+  .post(
+    '/connections/:harness/disconnect',
+    zValidator('param', harnessParamSchema),
+    async (c) => {
+      const { harness } = c.req.valid('param')
+      const state = await disconnectBrowserosFromHarness(harness)
+      return c.json(state)
+    },
+  )

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/server.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/server.ts
@@ -18,6 +18,7 @@ import { cors } from 'hono/cors'
 import { HttpError } from './lib/errors'
 import { logger } from './lib/logger'
 import { agentsRoute } from './routes/agents'
+import { connectionsRoute } from './routes/connections'
 import { mcpRoute } from './routes/mcp'
 import { mcpV2Route } from './routes/mcp-v2'
 import { permissionsRoute } from './routes/permissions'
@@ -79,6 +80,7 @@ const routes = app
   .route('/', mcpV2Route)
   .route('/', mcpRoute)
   .route('/', tabsRoute)
+  .route('/', connectionsRoute)
 
 export type AppType = typeof routes
 export default routes

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/services/browseros-connect.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/services/browseros-connect.ts
@@ -1,0 +1,231 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * v2 single-endpoint install layer. Writes one canonical
+ * `"browseros"` entry into the harness's MCP config file via
+ * `agent-mcp-manager`, pointing at the slugless canonical URL
+ * (`http://127.0.0.1:9100/cockpit/mcp`). One row per supported
+ * harness, idempotent connect / disconnect, list reads through the
+ * library's manifest so the UI reflects the current install state
+ * within the polling interval.
+ *
+ * Distinct from `harness-install.ts` (the legacy per-agent path).
+ * That path writes one entry per cockpit agent profile, keyed by the
+ * profile's slug, with a slug-shaped URL. v2 has no per-agent
+ * profile, so this layer writes one entry keyed by the constant
+ * `BROWSEROS_MCP_SERVER_NAME` ("browseros") with the slugless URL.
+ * Both layers share `specFor` for the Codex stdio wrapping.
+ */
+
+import type { AgentId } from 'agent-mcp-manager'
+import { ForeignEntryError } from 'agent-mcp-manager'
+import { env } from '../env'
+import { logger } from '../lib/logger'
+import { getMcpManager } from '../lib/mcp-manager'
+import { type Harness, harnessEnum } from '../routes/agents/schemas'
+import {
+  BROWSEROS_MCP_SERVER_NAME,
+  canonicalMcpUrlForPort,
+} from '../shared/mcp-url'
+import { HARNESS_TO_AGENT_ID } from './harness-install'
+import { specFor } from './spec-for'
+
+export interface ConnectionState {
+  harness: Harness
+  /**
+   * True when the harness has a "browseros" entry pointing at the
+   * canonical URL. For BrowserOS-internal harnesses (Hermes,
+   * OpenClaw) `installed` is always true (no third-party config to
+   * write).
+   */
+  installed: boolean
+  /** Filled when `installed` is true and a real config file was touched. */
+  configPath?: string
+  /** Stable agent-mcp-manager id; null for BrowserOS-internal harnesses. */
+  agentId: AgentId | null
+  /** Single-line human-readable message; surfaced to the UI verbatim. */
+  message: string
+}
+
+const ALL_HARNESSES: readonly Harness[] = harnessEnum.options
+
+function canonicalMcpUrl(): string {
+  return canonicalMcpUrlForPort(env.port)
+}
+
+export async function connectBrowserosToHarness(
+  harness: Harness,
+): Promise<ConnectionState> {
+  const agentId = HARNESS_TO_AGENT_ID[harness]
+  if (agentId === null) {
+    return {
+      harness,
+      installed: true,
+      agentId: null,
+      message: `${harness} runs inside BrowserOS; no harness config to write.`,
+    }
+  }
+  const mgr = getMcpManager()
+  const url = canonicalMcpUrl()
+  try {
+    await mgr.add({
+      name: BROWSEROS_MCP_SERVER_NAME,
+      spec: specFor(agentId, url),
+    })
+    const link = await mgr.link({
+      serverName: BROWSEROS_MCP_SERVER_NAME,
+      agent: agentId,
+    })
+    logger.info('connected browseros to harness', {
+      harness,
+      agent: agentId,
+      configPath: link.configPath,
+    })
+    return {
+      harness,
+      installed: true,
+      agentId,
+      configPath: link.configPath,
+      message: `BrowserOS registered as an MCP server in ${harness}.`,
+    }
+  } catch (err) {
+    return failure(harness, agentId, err, 'connect')
+  }
+}
+
+export async function disconnectBrowserosFromHarness(
+  harness: Harness,
+): Promise<ConnectionState> {
+  const agentId = HARNESS_TO_AGENT_ID[harness]
+  if (agentId === null) {
+    return {
+      harness,
+      installed: false,
+      agentId: null,
+      message: `${harness} runs inside BrowserOS; nothing to disconnect.`,
+    }
+  }
+  const mgr = getMcpManager()
+  try {
+    const unlink = await mgr.unlink({
+      serverName: BROWSEROS_MCP_SERVER_NAME,
+      agent: agentId,
+    })
+    // Best-effort: drop the manifest entry so a subsequent list does
+    // not show a phantom entry with zero links. Failure here does not
+    // change the install state from the user's point of view.
+    try {
+      await mgr.remove({
+        serverName: BROWSEROS_MCP_SERVER_NAME,
+        unlinkFirst: false,
+      })
+    } catch {
+      // ServerNotFoundError, etc. Safe to ignore: the link is gone,
+      // which is the user-visible state we care about.
+    }
+    logger.info('disconnected browseros from harness', {
+      harness,
+      agent: agentId,
+      configPath: unlink.configPath,
+    })
+    return {
+      harness,
+      installed: false,
+      agentId,
+      configPath: unlink.configPath,
+      message: `BrowserOS unregistered from ${harness}.`,
+    }
+  } catch (err) {
+    return failure(harness, agentId, err, 'disconnect')
+  }
+}
+
+/**
+ * One row per supported harness. The library's `listLinks` is the
+ * authoritative source: a harness is `installed` iff a link record
+ * for `(serverName: "browseros", agent: <id>)` exists. Internal
+ * harnesses always report `installed: true` so the UI badge counts
+ * them correctly.
+ */
+export async function listBrowserosConnections(): Promise<ConnectionState[]> {
+  const mgr = getMcpManager()
+  let links: Awaited<ReturnType<typeof mgr.listLinks>> = []
+  try {
+    links = await mgr.listLinks({
+      serverNames: [BROWSEROS_MCP_SERVER_NAME],
+    })
+  } catch (err) {
+    logger.warn('listBrowserosConnections failed', {
+      error: err instanceof Error ? err.message : String(err),
+    })
+    // Fall through: every external harness reports not-installed.
+  }
+  const byAgent = new Map<AgentId, (typeof links)[number]>()
+  for (const link of links) {
+    if (!link.broken) byAgent.set(link.agent, link)
+  }
+  return ALL_HARNESSES.map((harness): ConnectionState => {
+    const agentId = HARNESS_TO_AGENT_ID[harness]
+    if (agentId === null) {
+      return {
+        harness,
+        installed: true,
+        agentId: null,
+        message: `${harness} runs inside BrowserOS.`,
+      }
+    }
+    const link = byAgent.get(agentId)
+    if (link) {
+      return {
+        harness,
+        installed: true,
+        agentId,
+        configPath: link.configPath,
+        message: `Configured in ${harness}.`,
+      }
+    }
+    return {
+      harness,
+      installed: false,
+      agentId,
+      message: `${harness} is not configured.`,
+    }
+  })
+}
+
+function failure(
+  harness: Harness,
+  agentId: AgentId,
+  err: unknown,
+  op: 'connect' | 'disconnect',
+): ConnectionState {
+  if (err instanceof ForeignEntryError) {
+    logger.warn('browseros harness entry exists but was not written by us', {
+      harness,
+      serverName: err.serverName,
+      agent: err.agent,
+      configPath: err.configPath,
+    })
+    return {
+      harness,
+      installed: false,
+      agentId,
+      configPath: err.configPath,
+      message: `${harness} already has an entry under "${err.serverName}" that we did not write. Remove it from the config and try again.`,
+    }
+  }
+  const message = err instanceof Error ? err.message : String(err)
+  logger.warn('browseros connect operation failed', {
+    harness,
+    op,
+    error: message,
+  })
+  return {
+    harness,
+    installed: op === 'disconnect',
+    agentId,
+    message: `Could not ${op} ${harness}: ${message}`,
+  }
+}

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/services/harness-install.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/services/harness-install.ts
@@ -22,11 +22,12 @@
  * no-op success.
  */
 
-import type { AgentId, McpServerSpec } from 'agent-mcp-manager'
+import type { AgentId } from 'agent-mcp-manager'
 import { AgentNotSupportedError, ForeignEntryError } from 'agent-mcp-manager'
 import { logger } from '../lib/logger'
 import { getMcpManager } from '../lib/mcp-manager'
 import type { Harness, StoredAgentProfile } from '../routes/agents/schemas'
+import { specFor } from './spec-for'
 
 export interface InstallOutcome {
   /** True iff the harness config was written successfully (or no-op for internal harnesses). */
@@ -49,7 +50,7 @@ export interface InstallOutcome {
  * If a mapping is wrong, change it here and every install/uninstall
  * path picks up the new target.
  */
-const HARNESS_TO_AGENT_ID: Record<Harness, AgentId | null> = {
+export const HARNESS_TO_AGENT_ID: Record<Harness, AgentId | null> = {
   'Claude Code': 'claude-code',
   'Claude Desktop': 'claude-desktop',
   Cursor: 'cursor',
@@ -59,24 +60,6 @@ const HARNESS_TO_AGENT_ID: Record<Harness, AgentId | null> = {
   'Gemini CLI': 'gemini',
   Hermes: null,
   OpenClaw: null,
-}
-
-/**
- * Codex (and any future stdio-only target) cannot speak HTTP MCP, so
- * we wrap the URL in `npx mcp-remote` the same way `apps/server`
- * does. Other agents take the URL directly as `transport: 'http'`.
- */
-const STDIO_ONLY: ReadonlySet<AgentId> = new Set<AgentId>(['codex'])
-
-function specFor(agentId: AgentId, mcpUrl: string): McpServerSpec {
-  if (STDIO_ONLY.has(agentId)) {
-    return {
-      transport: 'stdio',
-      command: 'npx',
-      args: ['mcp-remote', mcpUrl],
-    }
-  }
-  return { transport: 'http', url: mcpUrl }
 }
 
 export async function installForAgent(

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/services/spec-for.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/services/spec-for.ts
@@ -1,0 +1,29 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Picks the right `McpServerSpec` shape for a given harness agent id.
+ * Most harnesses speak HTTP MCP natively, so a `{ transport: 'http',
+ * url }` entry is enough. Codex is stdio-only, so we wrap the URL via
+ * `npx mcp-remote` the same way `apps/server` does.
+ *
+ * Used by both the legacy per-agent install (`harness-install.ts`)
+ * and the v2 single-endpoint install (`browseros-connect.ts`) so the
+ * stdio-wrapping rule lives in one place.
+ */
+
+import type { AgentId, McpServerSpec } from 'agent-mcp-manager'
+
+const STDIO_ONLY: ReadonlySet<AgentId> = new Set<AgentId>(['codex'])
+
+export function specFor(agentId: AgentId, mcpUrl: string): McpServerSpec {
+  if (STDIO_ONLY.has(agentId)) {
+    return {
+      transport: 'stdio',
+      command: 'npx',
+      args: ['mcp-remote', mcpUrl],
+    }
+  }
+  return { transport: 'http', url: mcpUrl }
+}

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/shared/mcp-url.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/shared/mcp-url.ts
@@ -1,0 +1,33 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Canonical v2 MCP URL shape. One endpoint per cockpit, no per-agent
+ * slug. Used by both the server-side install service (writes the URL
+ * into harness configs) and the UI's URL widgets (copy button + CLI
+ * snippet). Keeping the shape in `shared/` mirrors the `shared/port`
+ * precedent so a future cutover (e.g. a non-loopback bind) is a
+ * single-file edit.
+ */
+
+import { COCKPIT_MOUNT_PREFIX, PROD_API_PORT } from './port'
+
+/** Path the v2 single MCP route is mounted at, relative to the cockpit prefix. */
+export const MCP_PATH = '/mcp'
+
+/**
+ * Server name written into harness configs. One canonical name across
+ * every harness so the user sees "browseros" in every `claude mcp list`
+ * / Cursor settings page. Same name reused by the canonical CLI snippet.
+ */
+export const BROWSEROS_MCP_SERVER_NAME = 'browseros'
+
+/**
+ * Builds the slugless canonical URL the v2 cockpit advertises. The
+ * server side only ever uses 127.0.0.1; the UI's `mcp-endpoint.ts`
+ * resolves alternate bases (dev-launcher overrides, query string).
+ */
+export function canonicalMcpUrlForPort(port = PROD_API_PORT): string {
+  return `http://127.0.0.1:${port}${COCKPIT_MOUNT_PREFIX}${MCP_PATH}`
+}

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/connections/routes.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/connections/routes.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import {
+  resetMcpManagerForTesting,
+  setMcpManagerForTesting,
+} from '../../../src/lib/mcp-manager'
+import app from '../../../src/server'
+import { createStubMcpManager } from '../../_helpers/stub-mcp-manager'
+
+describe('/cockpit/connections route chain', () => {
+  beforeEach(() => {
+    resetMcpManagerForTesting()
+    setMcpManagerForTesting(createStubMcpManager())
+  })
+  afterEach(() => resetMcpManagerForTesting())
+
+  it('GET /connections lists one row per harness', async () => {
+    const res = await app.fetch(
+      new Request('http://localhost/connections', { method: 'GET' }),
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      connections: Array<{ harness: string; installed: boolean }>
+    }
+    expect(body.connections.length).toBeGreaterThanOrEqual(9)
+    expect(
+      body.connections.find((c) => c.harness === 'Claude Code'),
+    ).toBeDefined()
+  })
+
+  it('POST /connections/:harness/connect connects a single harness', async () => {
+    const res = await app.fetch(
+      new Request(
+        `http://localhost/connections/${encodeURIComponent('Claude Code')}/connect`,
+        { method: 'POST' },
+      ),
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      installed: boolean
+      agentId: string | null
+    }
+    expect(body.installed).toBe(true)
+    expect(body.agentId).toBe('claude-code')
+  })
+
+  it('POST /connections/:harness/disconnect disconnects a single harness', async () => {
+    const res = await app.fetch(
+      new Request(
+        `http://localhost/connections/${encodeURIComponent('Cursor')}/disconnect`,
+        { method: 'POST' },
+      ),
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      installed: boolean
+      agentId: string | null
+    }
+    expect(body.installed).toBe(false)
+    expect(body.agentId).toBe('cursor')
+  })
+
+  it('rejects an unknown harness with a 400 (zValidator)', async () => {
+    const res = await app.fetch(
+      new Request('http://localhost/connections/NotAHarness/connect', {
+        method: 'POST',
+      }),
+    )
+    expect(res.status).toBe(400)
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/services/browseros-connect.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/services/browseros-connect.test.ts
@@ -1,0 +1,156 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import type { McpServerLink } from 'agent-mcp-manager'
+import {
+  resetMcpManagerForTesting,
+  setMcpManagerForTesting,
+} from '../../src/lib/mcp-manager'
+import {
+  connectBrowserosToHarness,
+  disconnectBrowserosFromHarness,
+  listBrowserosConnections,
+} from '../../src/services/browseros-connect'
+import { createStubMcpManager } from '../_helpers/stub-mcp-manager'
+
+function stubWithLinks(links: McpServerLink[]) {
+  const stub = createStubMcpManager()
+  stub.listLinks = async () => links
+  return stub
+}
+
+describe('connectBrowserosToHarness', () => {
+  beforeEach(() => resetMcpManagerForTesting())
+  afterEach(() => resetMcpManagerForTesting())
+
+  it('writes a "browseros" entry with the canonical URL and links it to the right agent id', async () => {
+    const stub = createStubMcpManager()
+    setMcpManagerForTesting(stub)
+    const result = await connectBrowserosToHarness('Claude Code')
+    expect(result.installed).toBe(true)
+    expect(result.agentId).toBe('claude-code')
+    const add = stub.calls.find((c) => c.method === 'add')
+    expect(add).toBeDefined()
+    const addPayload = add?.payload as {
+      name: string
+      spec: { transport: string; url?: string }
+    }
+    expect(addPayload.name).toBe('browseros')
+    expect(addPayload.spec.transport).toBe('http')
+    expect(addPayload.spec.url).toContain('/cockpit/mcp')
+    const link = stub.calls.find((c) => c.method === 'link')
+    expect(link).toBeDefined()
+    expect((link?.payload as { agent: string }).agent).toBe('claude-code')
+  })
+
+  it('wraps Codex in npx mcp-remote', async () => {
+    const stub = createStubMcpManager()
+    setMcpManagerForTesting(stub)
+    await connectBrowserosToHarness('Codex')
+    const add = stub.calls.find((c) => c.method === 'add')
+    const payload = add?.payload as {
+      spec: { transport: string; command?: string; args?: string[] }
+    }
+    expect(payload.spec.transport).toBe('stdio')
+    expect(payload.spec.command).toBe('npx')
+    expect(payload.spec.args?.[0]).toBe('mcp-remote')
+    expect(payload.spec.args?.[1]).toContain('/cockpit/mcp')
+  })
+
+  it('short-circuits as a no-op for BrowserOS-internal harnesses (Hermes, OpenClaw)', async () => {
+    const stub = createStubMcpManager()
+    setMcpManagerForTesting(stub)
+    const hermes = await connectBrowserosToHarness('Hermes')
+    const openclaw = await connectBrowserosToHarness('OpenClaw')
+    expect(hermes.installed).toBe(true)
+    expect(hermes.agentId).toBeNull()
+    expect(openclaw.installed).toBe(true)
+    expect(openclaw.agentId).toBeNull()
+    expect(stub.calls.find((c) => c.method === 'add')).toBeUndefined()
+    expect(stub.calls.find((c) => c.method === 'link')).toBeUndefined()
+  })
+})
+
+describe('disconnectBrowserosFromHarness', () => {
+  beforeEach(() => resetMcpManagerForTesting())
+  afterEach(() => resetMcpManagerForTesting())
+
+  it('unlinks the browseros entry from the right agent and drops it from the manifest', async () => {
+    const stub = createStubMcpManager()
+    setMcpManagerForTesting(stub)
+    const result = await disconnectBrowserosFromHarness('Cursor')
+    expect(result.installed).toBe(false)
+    expect(result.agentId).toBe('cursor')
+    const unlink = stub.calls.find((c) => c.method === 'unlink')
+    expect(unlink).toBeDefined()
+    const unlinkPayload = unlink?.payload as {
+      serverName: string
+      agent: string
+    }
+    expect(unlinkPayload.serverName).toBe('browseros')
+    expect(unlinkPayload.agent).toBe('cursor')
+    expect(stub.calls.find((c) => c.method === 'remove')).toBeDefined()
+  })
+
+  it('is a no-op for Hermes / OpenClaw', async () => {
+    const stub = createStubMcpManager()
+    setMcpManagerForTesting(stub)
+    const hermes = await disconnectBrowserosFromHarness('Hermes')
+    expect(hermes.installed).toBe(false)
+    expect(hermes.agentId).toBeNull()
+    expect(stub.calls.find((c) => c.method === 'unlink')).toBeUndefined()
+  })
+})
+
+describe('listBrowserosConnections', () => {
+  beforeEach(() => resetMcpManagerForTesting())
+  afterEach(() => resetMcpManagerForTesting())
+
+  it('returns one row per harness; external harnesses report installed=false when listLinks is empty', async () => {
+    setMcpManagerForTesting(stubWithLinks([]))
+    const list = await listBrowserosConnections()
+    expect(list.length).toBeGreaterThanOrEqual(9)
+    const ccode = list.find((c) => c.harness === 'Claude Code')
+    expect(ccode?.installed).toBe(false)
+    const cursor = list.find((c) => c.harness === 'Cursor')
+    expect(cursor?.installed).toBe(false)
+  })
+
+  it('marks Hermes and OpenClaw installed by definition (BrowserOS-internal)', async () => {
+    setMcpManagerForTesting(stubWithLinks([]))
+    const list = await listBrowserosConnections()
+    expect(list.find((c) => c.harness === 'Hermes')?.installed).toBe(true)
+    expect(list.find((c) => c.harness === 'OpenClaw')?.installed).toBe(true)
+  })
+
+  it('reports a harness as installed when listLinks returns a link for its agent id', async () => {
+    setMcpManagerForTesting(
+      stubWithLinks([
+        {
+          serverName: 'browseros',
+          agent: 'claude-code',
+          configPath: '/tmp/stub-claude-code.json',
+        },
+      ]),
+    )
+    const list = await listBrowserosConnections()
+    expect(list.find((c) => c.harness === 'Claude Code')?.installed).toBe(true)
+    expect(list.find((c) => c.harness === 'Claude Code')?.configPath).toBe(
+      '/tmp/stub-claude-code.json',
+    )
+    expect(list.find((c) => c.harness === 'Cursor')?.installed).toBe(false)
+  })
+
+  it('skips broken links so a manifest entry whose disk row is gone reports not-installed', async () => {
+    setMcpManagerForTesting(
+      stubWithLinks([
+        {
+          serverName: 'browseros',
+          agent: 'claude-code',
+          configPath: '/tmp/stub-claude-code.json',
+          broken: true,
+        },
+      ]),
+    )
+    const list = await listBrowserosConnections()
+    expect(list.find((c) => c.harness === 'Claude Code')?.installed).toBe(false)
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/shared/mcp-url.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/shared/mcp-url.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  BROWSEROS_MCP_SERVER_NAME,
+  canonicalMcpUrlForPort,
+  MCP_PATH,
+} from '../../src/shared/mcp-url'
+
+describe('canonicalMcpUrlForPort', () => {
+  it('emits the slugless v2 shape on the default prod port', () => {
+    expect(canonicalMcpUrlForPort(9100)).toBe(
+      'http://127.0.0.1:9100/cockpit/mcp',
+    )
+  })
+
+  it('respects an alternate dev port', () => {
+    expect(canonicalMcpUrlForPort(9200)).toBe(
+      'http://127.0.0.1:9200/cockpit/mcp',
+    )
+  })
+
+  it('uses the constant mcp path', () => {
+    expect(MCP_PATH).toBe('/mcp')
+  })
+})
+
+describe('BROWSEROS_MCP_SERVER_NAME', () => {
+  it('is the canonical "browseros" key written into harness configs', () => {
+    expect(BROWSEROS_MCP_SERVER_NAME).toBe('browseros')
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/components/sidebar/SidebarNavigation.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/sidebar/SidebarNavigation.tsx
@@ -18,12 +18,26 @@ interface NavItem {
   icon: ComponentType<SVGProps<SVGSVGElement>>
 }
 
-const navItems: NavItem[] = [
+const legacyUi = import.meta.env.VITE_COCKPIT_LEGACY_UI === '1'
+
+/**
+ * Agents and Governance route entries are only registered in App.tsx
+ * when `VITE_COCKPIT_LEGACY_UI=1`, so the sidebar drops them from the
+ * v2 default to avoid dead links. Same flag, same source of truth.
+ */
+const v2NavItems: NavItem[] = [
+  { name: 'Cockpit', to: '/', icon: LayoutDashboard },
+  { name: 'MCP', to: '/mcp', icon: PlugZap },
+]
+
+const legacyNavItems: NavItem[] = [
   { name: 'Cockpit', to: '/', icon: LayoutDashboard },
   { name: 'Agents', to: '/agents', icon: Bot },
   { name: 'Governance', to: '/governance', icon: ShieldCheck },
   { name: 'MCP', to: '/mcp', icon: PlugZap },
 ]
+
+const navItems: NavItem[] = legacyUi ? legacyNavItems : v2NavItems
 
 /**
  * `/agents/new` lives under `/agents` so the Agents item should stay

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/connections.hooks.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/connections.hooks.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * react-query-kit factories for the v2 MCP page's per-harness
+ * Connect / Disconnect buttons. Backed by the
+ * `GET /cockpit/connections` and `POST /cockpit/connections/:harness/{connect,disconnect}`
+ * routes shipped in this PR. Mutation success invalidates the list
+ * query by its `getKey()` so the row's "Connected" badge flips
+ * within one render.
+ */
+
+import { createMutation, createQuery } from 'react-query-kit'
+import type { Harness } from '@/screens/new-agent/new-agent.schemas'
+import { api } from './client'
+import { parseResponse } from './parseResponse'
+
+export interface ConnectionState {
+  harness: Harness
+  installed: boolean
+  configPath?: string
+  /** Stable agent-mcp-manager id; null for BrowserOS-internal harnesses. */
+  agentId: string | null
+  message: string
+}
+
+interface ConnectionsResponse {
+  connections: ConnectionState[]
+}
+
+export const useBrowserosConnections = createQuery<ConnectionsResponse>({
+  queryKey: ['cockpit', 'connections'],
+  fetcher: async () => {
+    const response = await api.connections.$get()
+    return parseResponse<ConnectionsResponse>(response)
+  },
+  refetchInterval: 5000,
+})
+
+interface ConnectVariables {
+  harness: Harness
+}
+
+export const useConnectBrowseros = createMutation<
+  ConnectionState,
+  ConnectVariables
+>({
+  mutationFn: async ({ harness }) => {
+    const response = await api.connections[':harness'].connect.$post({
+      param: { harness },
+    })
+    return parseResponse<ConnectionState>(response)
+  },
+})
+
+export const useDisconnectBrowseros = createMutation<
+  ConnectionState,
+  ConnectVariables
+>({
+  mutationFn: async ({ harness }) => {
+    const response = await api.connections[':harness'].disconnect.$post({
+      param: { harness },
+    })
+    return parseResponse<ConnectionState>(response)
+  },
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/mcp-endpoint.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/mcp-endpoint.test.ts
@@ -1,6 +1,10 @@
 import { afterEach, describe, expect, it } from 'bun:test'
 import { API_URL_STORAGE_KEY } from './client.helpers'
-import { buildMcpEndpointUrl } from './mcp-endpoint'
+import {
+  buildCanonicalMcpCliCommand,
+  buildCanonicalMcpEndpointUrl,
+  buildMcpEndpointUrl,
+} from './mcp-endpoint'
 
 const originalWindow = globalThis.window
 
@@ -52,5 +56,32 @@ describe('buildMcpEndpointUrl', () => {
     expect(buildMcpEndpointUrl('demo')).toBe(
       'http://127.0.0.1:9345/cockpit/mcp/demo',
     )
+  })
+})
+
+describe('buildCanonicalMcpEndpointUrl', () => {
+  it('emits the v2 slugless URL using the query-supplied base', () => {
+    installWindow('?apiUrl=http%3A%2F%2F127.0.0.1%3A9234%2Fcockpit')
+    expect(buildCanonicalMcpEndpointUrl()).toBe(
+      'http://127.0.0.1:9234/cockpit/mcp',
+    )
+  })
+
+  it('falls back to the prod port + cockpit prefix when no overrides exist', () => {
+    installWindow('')
+    expect(buildCanonicalMcpEndpointUrl()).toBe(
+      'http://127.0.0.1:9100/cockpit/mcp',
+    )
+  })
+})
+
+describe('buildCanonicalMcpCliCommand', () => {
+  it('produces the standard `claude mcp add` shape with the canonical URL', () => {
+    installWindow('')
+    const cli = buildCanonicalMcpCliCommand()
+    expect(cli).toContain('claude mcp add browseros')
+    expect(cli).toContain('http://127.0.0.1:9100/cockpit/mcp')
+    expect(cli).toContain('--transport http')
+    expect(cli).toContain('--scope user')
   })
 })

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/mcp-endpoint.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/mcp-endpoint.ts
@@ -17,6 +17,10 @@
  */
 
 import {
+  BROWSEROS_MCP_SERVER_NAME,
+  MCP_PATH,
+} from '@browseros/agent-mcp-interface/shared/mcp-url'
+import {
   COCKPIT_MOUNT_PREFIX,
   PROD_API_PORT,
 } from '@browseros/agent-mcp-interface/shared/port'
@@ -90,4 +94,24 @@ export function slugFromMcpEndpointUrl(url: string): string {
  */
 export function buildMcpCliCommand(slug: string): string {
   return `mcp add ${slug}`
+}
+
+/**
+ * Canonical v2 URL the MCP page advertises: one slugless endpoint
+ * for the whole cockpit. Uses the same base resolution as
+ * `buildMcpEndpointUrl` so dev-launcher overrides and query-string
+ * apiUrl forwarding stay consistent across both shapes.
+ */
+export function buildCanonicalMcpEndpointUrl(): string {
+  return `${resolveMcpBaseUrl()}${MCP_PATH}`
+}
+
+/**
+ * Canonical CLI snippet for one-click harnesses that ship their own
+ * MCP CLI. Anthropic's `claude` CLI is the lead consumer; other
+ * harnesses get the "Connect" button on the MCP page instead.
+ */
+export function buildCanonicalMcpCliCommand(): string {
+  const url = buildCanonicalMcpEndpointUrl()
+  return `claude mcp add ${BROWSEROS_MCP_SERVER_NAME} ${url} --transport http --scope user`
 }

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/ConnectionRow.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/ConnectionRow.tsx
@@ -1,0 +1,96 @@
+import { Check, Loader2 } from 'lucide-react'
+import { HarnessIcon } from '@/components/harness/HarnessIcon'
+import type { ConnectionState } from '@/modules/api/connections.hooks'
+
+interface ConnectionRowProps {
+  state: ConnectionState
+  isPending: boolean
+  errorMessage: string | null
+  onConnect: () => void
+  onDisconnect: () => void
+}
+
+/**
+ * One row per supported harness. Click "Connect" to write BrowserOS
+ * into the harness's MCP config file; the row flips to a green
+ * "Connected" pill on success. Click "Disconnect" to remove it.
+ * Errors render below the row in a small red strip.
+ *
+ * BrowserOS-internal harnesses (Hermes, OpenClaw) ship `installed:
+ * true` from the server and render a non-interactive "Built-in" pill.
+ */
+export function ConnectionRow({
+  state,
+  isPending,
+  errorMessage,
+  onConnect,
+  onDisconnect,
+}: ConnectionRowProps) {
+  const internal = state.agentId === null
+
+  return (
+    <div className="border-border-2 border-b last:border-b-0">
+      <div className="flex items-center gap-3 px-4 py-3">
+        <span className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-card">
+          <HarnessIcon harness={state.harness} className="size-5" />
+        </span>
+        <div className="min-w-0 flex-1">
+          <div className="font-bold text-[14px]">{state.harness}</div>
+          {state.installed && state.configPath && (
+            <div className="truncate font-mono text-[11px] text-ink-3">
+              {state.configPath}
+            </div>
+          )}
+          {internal && (
+            <div className="text-[11.5px] text-ink-3">
+              Runs inside BrowserOS
+            </div>
+          )}
+        </div>
+        {internal ? (
+          <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-bg-sunken px-3 py-1.5 font-bold text-[12px] text-ink-2">
+            <Check className="size-3" />
+            Built-in
+          </span>
+        ) : state.installed ? (
+          <div className="flex shrink-0 items-center gap-2">
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-green-tint px-3 py-1 font-bold text-[12px] text-green">
+              <Check className="size-3" />
+              Connected
+            </span>
+            <button
+              type="button"
+              onClick={onDisconnect}
+              disabled={isPending}
+              className="rounded-md px-2 py-1 font-semibold text-[12px] text-ink-3 transition hover:bg-bg-sunken hover:text-ink disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isPending ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                'Disconnect'
+              )}
+            </button>
+          </div>
+        ) : (
+          <button
+            type="button"
+            onClick={onConnect}
+            disabled={isPending}
+            className="inline-flex shrink-0 items-center gap-1.5 rounded-md bg-accent px-3.5 py-1.5 font-bold text-[12.5px] text-accent-foreground transition hover:bg-accent-2 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {isPending ? (
+              <Loader2 className="size-3.5 animate-spin" />
+            ) : (
+              'Connect'
+            )}
+          </button>
+        )}
+      </div>
+      {errorMessage && (
+        <div className="border-red/10 border-t bg-red-tint px-4 py-2 text-[12px] text-red">
+          {errorMessage}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/HeroCard.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/HeroCard.tsx
@@ -1,0 +1,82 @@
+import { Check, Copy, PlugZap } from 'lucide-react'
+import { useState } from 'react'
+
+interface HeroCardProps {
+  url: string
+  cli: string
+}
+
+/**
+ * v2 hero card. One canonical URL, one CLI snippet, two copy
+ * buttons. No per-agent slug, no regenerate flow. The URL block is
+ * the headline; the CLI snippet is a fallback for harnesses without
+ * a Connect button below or for users who prefer the manual install.
+ */
+export function HeroCard({ url, cli }: HeroCardProps) {
+  return (
+    <section className="rounded-2xl border border-border-2 bg-card p-6">
+      <div className="flex items-start gap-3.5">
+        <span className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-accent-tint text-accent">
+          <PlugZap className="size-5" />
+        </span>
+        <div className="flex-1">
+          <div className="flex items-center gap-2">
+            <h1 className="font-extrabold text-2xl tracking-tight">MCP</h1>
+            <span className="inline-flex items-center gap-1.5 rounded-full bg-accent-tint px-2.5 py-0.5 font-bold text-accent-ink text-xs">
+              1 endpoint
+            </span>
+          </div>
+          <p className="mt-1 text-ink-2 text-sm leading-snug">
+            Add BrowserOS as an MCP server in your AI agent. One endpoint, every
+            harness. Use the buttons below to install with one click, or copy
+            the URL for CI configs and manual scripts.
+          </p>
+        </div>
+      </div>
+      <div className="mt-5 space-y-2.5">
+        <CopyBlock label="Endpoint URL" value={url} />
+        <CopyBlock label="CLI snippet" value={cli} />
+      </div>
+    </section>
+  )
+}
+
+interface CopyBlockProps {
+  label: string
+  value: string
+}
+
+function CopyBlock({ label, value }: CopyBlockProps) {
+  const [copied, setCopied] = useState(false)
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(value)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch {
+      setCopied(false)
+    }
+  }
+  return (
+    <div className="space-y-1">
+      <div className="font-semibold text-[11px] text-ink-3 uppercase tracking-wider">
+        {label}
+      </div>
+      <div className="flex items-center gap-2 rounded-xl border border-border-strong bg-ink p-3 text-card">
+        <code className="flex-1 truncate font-mono text-[12.5px]">{value}</code>
+        <button
+          type="button"
+          onClick={copy}
+          aria-label={`Copy ${label}`}
+          className="flex size-7 shrink-0 items-center justify-center rounded-md text-ink-4 transition hover:bg-ink-2 hover:text-card"
+        >
+          {copied ? (
+            <Check className="size-3.5" />
+          ) : (
+            <Copy className="size-3.5" />
+          )}
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/Mcp.test.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/Mcp.test.tsx
@@ -1,0 +1,123 @@
+/**
+ * Pins the v2 MCP page shape: hero card with one URL + CLI snippet,
+ * "Connected agents" board with one row per harness, "N of M
+ * connected" install badge, no McpRow / RegenerateUrlDialog /
+ * "Add agent" CTA.
+ */
+
+import { describe, expect, it, mock } from 'bun:test'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router'
+
+mock.module('@/modules/api/connections.hooks', () => ({
+  useBrowserosConnections: Object.assign(
+    () => ({
+      data: {
+        connections: [
+          {
+            harness: 'Claude Code',
+            installed: false,
+            agentId: 'claude-code',
+            message: '',
+          },
+          {
+            harness: 'Cursor',
+            installed: true,
+            agentId: 'cursor',
+            configPath: '/tmp/cursor.json',
+            message: 'Configured in Cursor.',
+          },
+          {
+            harness: 'Codex',
+            installed: false,
+            agentId: 'codex',
+            message: '',
+          },
+          {
+            harness: 'Hermes',
+            installed: true,
+            agentId: null,
+            message: 'Runs inside BrowserOS.',
+          },
+        ],
+      },
+      isPending: false,
+      isError: false,
+    }),
+    { getKey: () => ['cockpit', 'connections'] },
+  ),
+  useConnectBrowseros: () => ({
+    isPending: false,
+    variables: undefined,
+    mutateAsync: async () => ({ installed: true }),
+  }),
+  useDisconnectBrowseros: () => ({
+    isPending: false,
+    variables: undefined,
+    mutateAsync: async () => ({ installed: false }),
+  }),
+}))
+
+const { Mcp } = await import('./Mcp')
+
+function renderApp(): string {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <Mcp />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  )
+}
+
+describe('Mcp (v2)', () => {
+  it('renders the hero card with the slugless URL and the canonical CLI snippet', () => {
+    const html = renderApp()
+    expect(html).toContain('MCP')
+    expect(html).toContain('1 endpoint')
+    expect(html).toContain('/cockpit/mcp')
+    expect(html).not.toContain('/cockpit/mcp/claude-code')
+    expect(html).toContain('claude mcp add browseros')
+    expect(html).toContain('--transport http')
+  })
+
+  it('renders the Connected agents header with the right install badge', () => {
+    const html = renderApp()
+    expect(html).toContain('Connected agents')
+    // External connected = 1 (Cursor), external total = 3 (Claude Code,
+    // Cursor, Codex). Hermes (internal) is excluded from the badge.
+    expect(html).toContain('1 of 3 connected')
+  })
+
+  it('renders one row per harness from the fixture and surfaces install state', () => {
+    const html = renderApp()
+    expect(html).toContain('Claude Code')
+    expect(html).toContain('Cursor')
+    expect(html).toContain('Codex')
+    expect(html).toContain('Hermes')
+    expect(html).toContain('Connected')
+    expect(html).toContain('Connect')
+  })
+
+  it('renders the internal-harness note at the bottom', () => {
+    const html = renderApp()
+    expect(html).toContain('Hermes and OpenClaw run inside BrowserOS')
+  })
+
+  it('does NOT render the legacy McpRow / RegenerateUrlDialog / "Add agent" CTA', () => {
+    const html = renderApp()
+    expect(html).not.toContain('Add agent')
+    expect(html).not.toContain('Regenerate URL')
+    expect(html).not.toContain('No endpoints yet')
+  })
+
+  it('renders Hermes as a "Built-in" pill, not a Connect button', () => {
+    const html = renderApp()
+    // The Hermes row carries the Built-in pill literal copy.
+    expect(html).toContain('Built-in')
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/Mcp.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/Mcp.tsx
@@ -1,112 +1,130 @@
-import { PlugZap, Plus } from 'lucide-react'
+import { useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
-import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
-import type { AgentProfile } from '@/modules/api/agents.hooks'
-import { McpRow } from './McpRow'
-import { useMcpRegistryData } from './mcp.data'
-import { RegenerateUrlDialog } from './RegenerateUrlDialog'
+import {
+  useBrowserosConnections,
+  useConnectBrowseros,
+  useDisconnectBrowseros,
+} from '@/modules/api/connections.hooks'
+import {
+  buildCanonicalMcpCliCommand,
+  buildCanonicalMcpEndpointUrl,
+} from '@/modules/api/mcp-endpoint'
+import type { Harness } from '@/screens/new-agent/new-agent.schemas'
+import { ConnectionRow } from './ConnectionRow'
+import { HeroCard } from './HeroCard'
 
+/**
+ * v2 MCP page. Hero card with the single canonical endpoint plus a
+ * per-harness "Connect" board that drives `agent-mcp-manager` so the
+ * user installs BrowserOS into Claude Code / Cursor / VS Code / Codex
+ * with one click. Hermes and OpenClaw are BrowserOS-internal and
+ * render as "Built-in" rows.
+ *
+ * Live MCP-session state (who is connected right now) is surfaced on
+ * the homepage's running grid, not here; this page is the install
+ * board.
+ */
 export function Mcp() {
-  const { profiles, isLoading, regenerate, navigate } = useMcpRegistryData()
-  const [pendingRotate, setPendingRotate] = useState<AgentProfile | null>(null)
+  const url = buildCanonicalMcpEndpointUrl()
+  const cli = buildCanonicalMcpCliCommand()
+  const connections = useBrowserosConnections()
+  const connect = useConnectBrowseros()
+  const disconnect = useDisconnectBrowseros()
+  const queryClient = useQueryClient()
+  const [errors, setErrors] = useState<Partial<Record<Harness, string>>>({})
 
-  const onAdd = () => navigate('/agents/new')
+  const isLoading = connections.isPending && !connections.data
+  const list = connections.data?.connections ?? []
+  const externalRows = list.filter((c) => c.agentId !== null)
+  const externalConnected = externalRows.filter((c) => c.installed).length
+  const externalTotal = externalRows.length
 
-  const onConfirmRotate = (profile: AgentProfile) => {
-    regenerate.mutate(
-      { id: profile.id },
-      {
-        onSettled: () => setPendingRotate(null),
-      },
-    )
+  const onConnect = async (harness: Harness) => {
+    setErrors((prev) => ({ ...prev, [harness]: undefined }))
+    try {
+      const result = await connect.mutateAsync({ harness })
+      if (!result.installed) {
+        setErrors((prev) => ({ ...prev, [harness]: result.message }))
+      }
+      void queryClient.invalidateQueries({
+        queryKey: useBrowserosConnections.getKey(),
+      })
+    } catch (err) {
+      setErrors((prev) => ({
+        ...prev,
+        [harness]: err instanceof Error ? err.message : 'Failed to connect.',
+      }))
+    }
   }
 
+  const onDisconnect = async (harness: Harness) => {
+    setErrors((prev) => ({ ...prev, [harness]: undefined }))
+    try {
+      await disconnect.mutateAsync({ harness })
+      void queryClient.invalidateQueries({
+        queryKey: useBrowserosConnections.getKey(),
+      })
+    } catch (err) {
+      setErrors((prev) => ({
+        ...prev,
+        [harness]: err instanceof Error ? err.message : 'Failed to disconnect.',
+      }))
+    }
+  }
+
+  const pendingHarness =
+    connect.isPending && connect.variables
+      ? connect.variables.harness
+      : disconnect.isPending && disconnect.variables
+        ? disconnect.variables.harness
+        : null
+
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col px-8 pt-6 pb-20">
-      <header className="mb-5 flex items-start gap-3">
-        <span className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-accent-tint text-accent">
-          <PlugZap className="size-5" />
-        </span>
-        <div className="flex-1">
-          <div className="flex items-center gap-2">
-            <h1 className="font-extrabold text-2xl text-ink tracking-tight">
-              MCP
-            </h1>
-            {profiles.length > 0 && (
-              <span className="inline-flex items-center gap-1.5 rounded-full bg-accent-tint px-2.5 py-0.5 font-bold text-accent-ink text-xs">
-                {profiles.length} endpoint{profiles.length === 1 ? '' : 's'}
-              </span>
-            )}
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-8 pt-6 pb-20">
+      <HeroCard url={url} cli={cli} />
+      <section className="rounded-2xl border border-border-2 bg-card">
+        <div className="flex items-start gap-3 border-border-2 border-b px-4 py-4">
+          <div className="flex-1">
+            <h2 className="font-bold text-base">Connected agents</h2>
+            <p className="mt-0.5 text-ink-3 text-sm">
+              Add BrowserOS as an MCP server in your AI agents. No copy-paste
+              required.
+            </p>
           </div>
-          <p className="mt-0.5 text-ink-2 text-sm">
-            Every agent profile gets a slug-routed MCP endpoint that is
-            installed into its harness when the agent is created. Copy the URL
-            here for places the harness can't reach (CI configs, manual
-            scripts).
-          </p>
+          {!isLoading && (
+            <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-bg-sunken px-3 py-1 font-bold text-[12px] text-ink-2">
+              {externalConnected} of {externalTotal} connected
+            </span>
+          )}
         </div>
-        <Button type="button" onClick={onAdd}>
-          <Plus className="size-4" />
-          Add agent
-        </Button>
-      </header>
-
-      {isLoading ? (
-        <div className="flex justify-center py-12 text-ink-3">
-          <Spinner />
-        </div>
-      ) : profiles.length === 0 ? (
-        <EmptyState onAdd={onAdd} />
-      ) : (
-        <div className="flex flex-col gap-2.5">
-          {profiles.map((profile) => (
-            <McpRow
-              key={profile.id}
-              profile={profile}
-              isRegenerating={
-                regenerate.isPending && regenerate.variables?.id === profile.id
-              }
-              onRegenerate={setPendingRotate}
-            />
-          ))}
-        </div>
-      )}
-
-      <RegenerateUrlDialog
-        profile={pendingRotate}
-        isRegenerating={
-          regenerate.isPending && regenerate.variables?.id === pendingRotate?.id
-        }
-        onConfirm={onConfirmRotate}
-        onCancel={() => setPendingRotate(null)}
-      />
-    </div>
-  )
-}
-
-/* ---------------------------------------------------------------------------
- * Sub-components, kept private to the registry screen.
- * -------------------------------------------------------------------------*/
-
-function EmptyState({ onAdd }: { onAdd: () => void }) {
-  return (
-    <div className="flex flex-col items-start gap-3 rounded-2xl border border-border border-dashed bg-card px-6 py-10">
-      <span className="flex size-9 items-center justify-center rounded-lg bg-accent-tint text-accent-ink">
-        <PlugZap className="size-4" />
-      </span>
-      <h2 className="font-bold text-ink text-lg tracking-tight">
-        No endpoints yet
-      </h2>
-      <p className="max-w-md text-ink-3 text-sm leading-snug">
-        Endpoints land here when you add an agent profile. Each profile gets a
-        unique slug-routed MCP URL and is auto-installed into its chosen
-        harness.
+        {isLoading ? (
+          <div className="flex justify-center py-10 text-ink-3">
+            <Spinner />
+          </div>
+        ) : connections.isError ? (
+          <div className="px-4 py-6 text-center text-ink-3 text-sm">
+            Could not load the connection list. Check that the cockpit server is
+            running.
+          </div>
+        ) : (
+          <div className="flex flex-col">
+            {list.map((state) => (
+              <ConnectionRow
+                key={state.harness}
+                state={state}
+                isPending={pendingHarness === state.harness}
+                errorMessage={errors[state.harness] ?? null}
+                onConnect={() => onConnect(state.harness)}
+                onDisconnect={() => onDisconnect(state.harness)}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+      <p className="text-[12px] text-ink-3 leading-relaxed">
+        Hermes and OpenClaw run inside BrowserOS and don't need a config write.
       </p>
-      <Button type="button" onClick={onAdd}>
-        <Plus className="size-4" />
-        Add your first agent
-      </Button>
     </div>
   )
 }

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/McpRow.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/McpRow.tsx
@@ -1,3 +1,9 @@
+/**
+ * TODO(v2-restore-per-agent): the v2 MCP page no longer renders one
+ * row per agent profile; the v2 endpoint is a single slugless URL.
+ * Component returns when per-agent profiles return.
+ */
+
 import { Check, Copy, RotateCcw } from 'lucide-react'
 import { useState } from 'react'
 import { HarnessIcon } from '@/components/harness/HarnessIcon'

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/RegenerateUrlDialog.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/RegenerateUrlDialog.tsx
@@ -1,3 +1,10 @@
+/**
+ * TODO(v2-restore-per-agent): the v2 MCP page does not render this
+ * dialog because the v2 endpoint is a single slugless URL with no
+ * per-agent rotate flow. Component returns when per-agent profiles
+ * return (post the SQLite audit phase).
+ */
+
 import {
   AlertDialog,
   AlertDialogAction,

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/mcp.data.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/mcp.data.ts
@@ -1,3 +1,9 @@
+/**
+ * TODO(v2-restore-per-agent): the v2 MCP page reads from
+ * `connections.hooks`, not the agent-profile directory. This hook
+ * stays on disk for the day per-agent profiles return.
+ */
+
 import { useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router'
 import {

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/mcp.helpers.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/mcp/mcp.helpers.ts
@@ -1,3 +1,10 @@
+/**
+ * TODO(v2-restore-per-agent): the v2 MCP page does not consume these
+ * helpers because the v2 URL is slugless. Re-exports stay for the
+ * legacy wizard and the new-agent screen, both of which still use
+ * the slug builder when VITE_COCKPIT_LEGACY_UI=1.
+ */
+
 import type { AgentProfile } from '@/modules/api/agents.hooks'
 import {
   buildMcpCliCommand,


### PR DESCRIPTION
## Summary

Reworks `/newtab.html#/mcp` against the v2 design. Previously the page was a per-agent directory: one row per agent profile, slug-routed URL (`http://127.0.0.1:9100/cockpit/mcp/claude-code`), "Add agent" CTA, Regenerate URL flow. v2 has no per-agent profiles, so all of that misleads.

The new shape:

1. **Hero card** with one canonical URL (`http://127.0.0.1:9100/cockpit/mcp`) and one CLI snippet (`claude mcp add browseros <url> --transport http --scope user`), each with its own copy button.
2. **Connected agents board** with one row per supported harness and a Connect / Disconnect button per row. Clicking Connect writes a `"browseros"` entry into the harness's MCP config file via `agent-mcp-manager` — no copy-paste required. Hermes and OpenClaw render as "Built-in" (they run inside BrowserOS).
3. **Internal-harness footnote** explaining the Built-in cutoff.

The new install path runs in parallel to the legacy per-agent install (`harness-install.ts`); the legacy code stays untouched and is reachable only when the legacy UI flag is on.

## Backend changes (apps/agent-mcp-interface)

- `shared/mcp-url.ts` (new). Canonical URL builder + `BROWSEROS_MCP_SERVER_NAME` constant. Exported via `package.json` so the UI imports it.
- `services/spec-for.ts` (new). Lifts the Codex stdio wrapping out of `harness-install.ts` so both install paths share one helper.
- `services/browseros-connect.ts` (new). `connectBrowserosToHarness`, `disconnectBrowserosFromHarness`, `listBrowserosConnections`. Internal harnesses short-circuit as no-op success.
- `routes/connections/index.ts` (new). `GET /cockpit/connections`, `POST /cockpit/connections/:harness/connect`, `POST /cockpit/connections/:harness/disconnect`.
- `services/harness-install.ts` now consumes the shared `specFor` and re-exports `HARNESS_TO_AGENT_ID` for reuse.

## UI changes (apps/agent-mcp-ui)

- `modules/api/mcp-endpoint.ts`: `buildCanonicalMcpEndpointUrl()` + `buildCanonicalMcpCliCommand()` emit the slugless URL and the canonical `claude mcp add` shape. The slug helpers stay for the legacy wizard.
- `modules/api/connections.hooks.ts` (new). `useBrowserosConnections` (5s refetch), `useConnectBrowseros`, `useDisconnectBrowseros` via `react-query-kit` factories.
- `screens/mcp/Mcp.tsx`: rewritten. Three vertical sections; loading and error UI per the project's React API rule.
- `screens/mcp/HeroCard.tsx` + `ConnectionRow.tsx` (new sub-components).
- `screens/mcp/{McpRow,RegenerateUrlDialog,mcp.data,mcp.helpers}.tsx`: `TODO(v2-restore-per-agent)` headers; files stay on disk.

## Test coverage

- Backend: 17 new tests (`shared/mcp-url`, `services/browseros-connect`, `routes/connections`). Suite: 157 → 174 pass.
- UI: 9 new tests (`Mcp.test.tsx`, extended `mcp-endpoint.test.ts`). Suite: 59 → 68 pass.
- Workspace typecheck (`bun run --filter '@browseros/agent-mcp-interface' --filter '@browseros/agent-mcp-ui' typecheck`): both exit 0.

## Test plan

- [x] `bun --cwd apps/agent-mcp-interface test` → 174 pass
- [x] `bun --cwd apps/agent-mcp-ui test` → 68 pass
- [x] Typecheck clean on the two touched packages
- [ ] Manual smoke: click Connect for Claude Code in the running cockpit, confirm `~/.claude.json` (or the resolved path) gains a `"browseros"` entry pointing at `http://127.0.0.1:9100/cockpit/mcp` with `transport: http`. Click Disconnect, confirm it's gone.
- [ ] Manual smoke: Codex uses stdio wrapping (`"transport": "stdio"`, `"command": "npx"`, `"args": ["mcp-remote", "<url>"]`).
- [ ] Manual smoke: Hermes / OpenClaw rows show "Built-in" pill and never call the backend.

## Notes for review

- Slug collision with legacy installs: a user with the legacy multi-agent build has per-agent slug entries in their harness config. The v2 install adds a separate `"browseros"` key alongside them; legacy entries are not migrated. Operators who want to clean up remove them manually.
- The `ForeignEntryError` path triggers when the harness config already has a `"browseros"` entry the manager did not write (e.g. a hand-edited config). The UI surfaces the message string and the user can fix the config and retry.
- The install board shows install state (config-file present), not live MCP session state. Live state lives on the homepage's running grid.