### PR TITLE
feat(cockpit): v2 phase 3 - onboarding UI shell (RHF + shadcn, no wiring)

### DIFF
--- a/packages/browseros-agent/apps/agent-mcp-ui/components/ui/checkbox.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/ui/checkbox.tsx
@@ -1,0 +1,27 @@
+import { Checkbox as CheckboxPrimitive } from "@base-ui/react/checkbox"
+
+import { cn } from "@/lib/utils"
+import { IconCheck } from "@tabler/icons-react"
+
+function Checkbox({ className, ...props }: CheckboxPrimitive.Root.Props) {
+  return (
+    <CheckboxPrimitive.Root
+      data-slot="checkbox"
+      className={cn(
+        "peer relative flex size-4 shrink-0 items-center justify-center rounded-[4px] border border-input shadow-xs transition-shadow outline-none group-has-disabled/field:opacity-50 after:absolute after:-inset-x-3 after:-inset-y-2 focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 aria-invalid:aria-checked:border-primary dark:bg-input/30 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 data-checked:border-primary data-checked:bg-primary data-checked:text-primary-foreground dark:data-checked:bg-primary",
+        className
+      )}
+      {...props}
+    >
+      <CheckboxPrimitive.Indicator
+        data-slot="checkbox-indicator"
+        className="grid place-content-center text-current transition-none [&>svg]:size-3.5"
+      >
+        <IconCheck
+        />
+      </CheckboxPrimitive.Indicator>
+    </CheckboxPrimitive.Root>
+  )
+}
+
+export { Checkbox }

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/OnboardingV2.test.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/OnboardingV2.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * Static-markup checks for the onboarding shell. Phase 3 cannot
+ * exercise click flows under `renderToStaticMarkup`; per-step content
+ * coverage lives in the per-step files. This file pins the shell
+ * rendering, the visual rail copy, and the step-0 default landing.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router'
+import { OnboardingV2 } from './OnboardingV2'
+
+function renderApp(): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <OnboardingV2 />
+    </MemoryRouter>,
+  )
+}
+
+describe('OnboardingV2 shell', () => {
+  it('lands on step 0 with the welcome heading and primary CTA', () => {
+    const html = renderApp()
+    expect(html).toContain('The browser your agents')
+    expect(html).toContain('drive')
+    expect(html).toContain('Set up')
+  })
+
+  it('renders the visual rail with the v2 quote and three feature blocks', () => {
+    const html = renderApp()
+    expect(html).toContain('BrowserOS')
+    expect(html).toContain('Let the agent you already run')
+    expect(html).toContain('Fast &amp; token-cheap')
+    expect(html).toContain('Logged in as you')
+    expect(html).toContain('Under your control')
+  })
+
+  it('renders the macwin chrome bar title', () => {
+    const html = renderApp()
+    expect(html).toContain('Welcome to BrowserOS')
+  })
+
+  it('renders four step dots', () => {
+    const html = renderApp()
+    // 4 dots = 4 span elements with the rounded-full class. Counting
+    // the rounded-full + h-[7px] combination is structural enough to
+    // not break on minor style edits.
+    const matches = html.match(/h-\[7px\]/g) ?? []
+    expect(matches.length).toBeGreaterThanOrEqual(4)
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/OnboardingV2.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/OnboardingV2.tsx
@@ -1,0 +1,130 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * v2 onboarding shell. Four steps inside one macwin frame with a
+ * persistent visual rail. UI-only: every "action" advances local
+ * state or runs a fake-progress timer. The wiring person hooks real
+ * mutations into the four callbacks below without touching layout,
+ * typography, or the form-state model.
+ *
+ * Wiring-person checklist:
+ *
+ *   - `onQuitChrome`     : replace with a real "quit Chrome safely" call.
+ *   - `onImport`         : replace the fake-progress effect below with a
+ *                          subscription to the import service that drives
+ *                          `setImportProgress` for real.
+ *   - `onAddToClaude`    : replace the connect timer with a mutation
+ *                          against the connect endpoint; flip
+ *                          `setConnectPhase` on the mutation's lifecycle.
+ *   - `onDone`           : confirm the navigation target is right for the
+ *                          post-onboarding home (cockpit homepage today).
+ *
+ * `form.getValues().selectedProfileIds` is the picker's output. RHF
+ * keeps it validated, typed, and stable across step navigations.
+ */
+
+import { zodResolver } from '@hookform/resolvers/zod'
+import { useEffect, useState } from 'react'
+import { useForm } from 'react-hook-form'
+import { useNavigate } from 'react-router'
+import { Form } from '@/components/ui/form'
+import { OnboardingShell } from './components/OnboardingShell'
+import { sumSitesFor } from './onboarding-v2.helpers'
+import {
+  type OnboardingFormValues,
+  onboardingFormDefaults,
+  onboardingFormSchema,
+} from './onboarding-v2.schemas'
+import type { ConnectPhase, ImportPhase, Step } from './onboarding-v2.types'
+import { ConnectStep } from './steps/ConnectStep'
+import { ImportStep } from './steps/ImportStep'
+import { ReadyStep } from './steps/ReadyStep'
+import { WelcomeStep } from './steps/WelcomeStep'
+
+const TOTAL_STEPS = 4
+const FAKE_IMPORT_TICK_MS = 70
+const FAKE_IMPORT_SETTLE_MS = 350
+const FAKE_CONNECT_DELAY_MS = 1700
+
+export function OnboardingV2() {
+  const navigate = useNavigate()
+  const form = useForm<OnboardingFormValues>({
+    resolver: zodResolver(onboardingFormSchema),
+    defaultValues: onboardingFormDefaults,
+    mode: 'onChange',
+  })
+
+  const [step, setStep] = useState<Step>(0)
+  const [importPhase, setImportPhase] = useState<ImportPhase>('pre-quit')
+  const [connectPhase, setConnectPhase] = useState<ConnectPhase>('idle')
+  const [importProgress, setImportProgress] = useState(0)
+
+  // Fake import-progress climber. The wiring person replaces this
+  // entire effect with a subscription to the real import service
+  // that drives `setImportProgress`.
+  useEffect(() => {
+    if (importPhase !== 'importing') return
+    const totalSites = sumSitesFor(form.getValues().selectedProfileIds)
+    if (totalSites === 0) {
+      setImportPhase('imported')
+      return
+    }
+    setImportProgress(0)
+    let cursor = 0
+    const tick = window.setInterval(() => {
+      cursor += Math.ceil(Math.random() * 4)
+      if (cursor >= totalSites) {
+        cursor = totalSites
+        window.clearInterval(tick)
+        window.setTimeout(
+          () => setImportPhase('imported'),
+          FAKE_IMPORT_SETTLE_MS,
+        )
+      }
+      setImportProgress(cursor)
+    }, FAKE_IMPORT_TICK_MS)
+    return () => window.clearInterval(tick)
+  }, [importPhase, form])
+
+  // Fake connect timer. The wiring person replaces this with a real
+  // mutation against the connect endpoint; flip `connectPhase` on
+  // the mutation's success / error lifecycle.
+  useEffect(() => {
+    if (connectPhase !== 'connecting') return
+    const timer = window.setTimeout(
+      () => setConnectPhase('connected'),
+      FAKE_CONNECT_DELAY_MS,
+    )
+    return () => window.clearTimeout(timer)
+  }, [connectPhase])
+
+  return (
+    <Form {...form}>
+      <OnboardingShell step={step} totalSteps={TOTAL_STEPS}>
+        {step === 0 && (
+          <WelcomeStep onPrimary={() => setStep(1)} onSkip={() => setStep(3)} />
+        )}
+        {step === 1 && (
+          <ImportStep
+            phase={importPhase}
+            progress={importProgress}
+            form={form}
+            onQuitChrome={() => setImportPhase('picker')}
+            onImport={() => setImportPhase('importing')}
+            onContinue={() => setStep(2)}
+          />
+        )}
+        {step === 2 && (
+          <ConnectStep
+            phase={connectPhase}
+            onAddToClaude={() => setConnectPhase('connecting')}
+            onContinue={() => setStep(3)}
+          />
+        )}
+        {step === 3 && <ReadyStep onDone={() => navigate('/')} />}
+      </OnboardingShell>
+    </Form>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/ChromeProfileTile.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/ChromeProfileTile.tsx
@@ -1,0 +1,58 @@
+import { User } from 'lucide-react'
+import { Checkbox } from '@/components/ui/checkbox'
+import { cn } from '@/lib/utils'
+import type { ChromeProfile } from '../onboarding-v2.helpers'
+
+interface ChromeProfileTileProps {
+  profile: ChromeProfile
+  checked: boolean
+  onCheckedChange: (next: boolean) => void
+}
+
+/**
+ * One Chrome profile row in the picker. Click-to-toggle on the whole
+ * tile per the project's row-toggle convention. Checked tiles border
+ * in accent orange with an accent-tint background; unchecked tiles
+ * stay neutral. The shadcn `Checkbox` primitive is the visible
+ * checkmark; the row is layout around it.
+ */
+export function ChromeProfileTile({
+  profile,
+  checked,
+  onCheckedChange,
+}: ChromeProfileTileProps) {
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: a button with role=checkbox is the row-toggle pattern; the design demands the entire tile is the click target, not just a checkbox primitive
+    <button
+      type="button"
+      role="checkbox"
+      aria-checked={checked}
+      onClick={() => onCheckedChange(!checked)}
+      className={cn(
+        'flex w-full items-center gap-3 rounded-xl border px-4 py-3 text-left transition-colors',
+        checked
+          ? 'border-accent bg-accent-tint'
+          : 'border-border-2 bg-card hover:border-border-strong',
+      )}
+    >
+      <Checkbox
+        checked={checked}
+        // Click on the underlying primitive is swallowed by the outer
+        // button's onClick; this still keeps the visual primitive in
+        // sync via the `checked` prop.
+        tabIndex={-1}
+        aria-hidden
+      />
+      <span className="flex size-[30px] shrink-0 items-center justify-center rounded-lg border border-border-2 bg-card text-ink-2">
+        <User className="size-[15px]" />
+      </span>
+      <div className="min-w-0 flex-1">
+        <div className="font-bold text-[13.5px] text-ink">{profile.name}</div>
+        <div className="truncate text-[11.5px] text-ink-3">{profile.email}</div>
+      </div>
+      <div className="shrink-0 text-right font-mono text-[11.5px] text-ink-2">
+        {profile.sites} sites . {profile.logins} logins
+      </div>
+    </button>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/ChromeQuitNotice.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/ChromeQuitNotice.tsx
@@ -1,0 +1,31 @@
+import { AlertTriangle, X } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+
+interface ChromeQuitNoticeProps {
+  onQuitChrome: () => void
+}
+
+/**
+ * Amber pre-quit notice that fronts the import step. Tells the user
+ * Chrome needs to close before BrowserOS can read its saved data, and
+ * offers a Quit Chrome button that (in Phase 3) just advances the
+ * sub-phase to the profile picker.
+ */
+export function ChromeQuitNotice({ onQuitChrome }: ChromeQuitNoticeProps) {
+  return (
+    <div className="mb-4 flex items-start gap-3 rounded-xl border border-amber/30 bg-amber-tint p-4">
+      <AlertTriangle className="mt-0.5 size-[18px] shrink-0 text-amber" />
+      <div className="flex-1">
+        <div className="mb-1 font-bold text-[13.5px]">Chrome is open</div>
+        <div className="mb-3 text-[12.5px] text-ink-2 leading-[1.5]">
+          It needs to close so we can read your data safely. We&rsquo;ll never
+          force-quit or touch your profile.
+        </div>
+        <Button type="button" variant="ghost" size="sm" onClick={onQuitChrome}>
+          <X className="size-3.5" />
+          Quit Chrome for me
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/ConnectedSummaryCard.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/ConnectedSummaryCard.tsx
@@ -1,0 +1,23 @@
+import { CheckCircle2 } from 'lucide-react'
+
+/**
+ * Green success card shown after the fake connect flips. Phase 3
+ * hard-codes the tool count and scope strings; the wiring person
+ * threads real values from the connect response when they wire up
+ * the connect mutation.
+ */
+export function ConnectedSummaryCard() {
+  return (
+    <div className="mb-[18px] flex animate-fade-up items-center gap-3 rounded-xl border border-green/30 bg-green-tint p-[18px]">
+      <span className="flex size-[30px] items-center justify-center rounded-lg bg-card text-green">
+        <CheckCircle2 className="size-[18px]" />
+      </span>
+      <div>
+        <div className="font-bold text-[14px]">Connected to Claude</div>
+        <div className="text-[12.5px] text-ink-2">
+          68 browser tools available . scope: user
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/DisplayHeading.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/DisplayHeading.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from 'react'
+
+interface DisplayHeadingProps {
+  children: ReactNode
+}
+
+/**
+ * Big sans-serif heading used at the top of every onboarding step.
+ * Wrap an `<Em>` around accent words ("drive", "logins", "Claude",
+ * "set") to pick up the Newsreader italic serif accent.
+ */
+export function DisplayHeading({ children }: DisplayHeadingProps) {
+  return (
+    <h1 className="mb-[14px] font-extrabold font-sans text-[38px] text-ink leading-[1.05] tracking-tight">
+      {children}
+    </h1>
+  )
+}
+
+interface EmProps {
+  children: ReactNode
+}
+
+export function Em({ children }: EmProps) {
+  return (
+    <span className="font-medium font-serif text-accent italic">
+      {children}
+    </span>
+  )
+}
+
+interface StepCopyProps {
+  children: ReactNode
+  className?: string
+}
+
+/**
+ * Body copy under the display heading. Caps at 470 px so lines do
+ * not stretch all the way to the content column's right edge.
+ */
+export function StepCopy({ children, className = '' }: StepCopyProps) {
+  return (
+    <p
+      className={`mb-[22px] max-w-[470px] text-[14.5px] text-ink-2 leading-[1.55] ${className}`}
+    >
+      {children}
+    </p>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/ImportedSummaryCard.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/ImportedSummaryCard.tsx
@@ -1,0 +1,57 @@
+import { Check, CreditCard, Lock } from 'lucide-react'
+
+interface ImportedSummaryCardProps {
+  sites: number
+  profileCount: number
+}
+
+/**
+ * Success card shown after the fake import flips. Headline + three
+ * bullet rows mirroring the v2 design's success state. Phase 3 leaves
+ * the payment-cards-skipped count hard-coded; the wiring person
+ * threads the real value when they wire up the import service.
+ */
+export function ImportedSummaryCard({
+  sites,
+  profileCount,
+}: ImportedSummaryCardProps) {
+  return (
+    <div className="mb-[18px] animate-fade-up rounded-xl border border-border-2 bg-card p-[18px]">
+      <div className="mb-3 flex items-center gap-2.5">
+        <span className="flex size-7 items-center justify-center rounded-lg bg-green-tint text-green">
+          <Check className="size-4" />
+        </span>
+        <span className="font-bold text-[14px]">
+          Imported {sites} sites from {profileCount} profile
+          {profileCount === 1 ? '' : 's'}
+        </span>
+      </div>
+      <SummaryRow
+        icon={<Check className="size-3.5 text-green" />}
+        text={`${sites} logged-in sessions ready`}
+      />
+      <SummaryRow
+        icon={<Lock className="size-3.5 text-ink-3" />}
+        text="Passwords stored in vault. Never shown to you or the agent."
+      />
+      <SummaryRow
+        icon={<CreditCard className="size-3.5 text-ink-3" />}
+        text="3 payment cards skipped"
+      />
+    </div>
+  )
+}
+
+interface SummaryRowProps {
+  icon: React.ReactNode
+  text: string
+}
+
+function SummaryRow({ icon, text }: SummaryRowProps) {
+  return (
+    <div className="flex items-center gap-2.5 py-1 text-[12.5px] text-ink-2">
+      {icon}
+      {text}
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/ImportingProgressCard.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/ImportingProgressCard.tsx
@@ -1,0 +1,37 @@
+import { RefreshCw } from 'lucide-react'
+
+interface ImportingProgressCardProps {
+  progress: number
+  total: number
+  logins: number
+}
+
+/**
+ * Animated progress card shown while the import sub-phase is
+ * `importing`. The progress prop is a fake counter that climbs
+ * toward `total` over ~1.5 seconds; the bar width is the ratio.
+ */
+export function ImportingProgressCard({
+  progress,
+  total,
+  logins,
+}: ImportingProgressCardProps) {
+  const percent = total === 0 ? 0 : Math.min(100, (progress / total) * 100)
+  return (
+    <div className="rounded-xl border border-border-2 bg-card p-5">
+      <div className="mb-3.5 flex items-center gap-2.5">
+        <RefreshCw className="size-[18px] animate-spin text-accent" />
+        <span className="font-bold text-[14px]">Importing sessions...</span>
+      </div>
+      <div className="mb-2.5 h-2 overflow-hidden rounded-full bg-bg-sunken">
+        <div
+          className="h-full bg-accent transition-[width] duration-100"
+          style={{ width: `${percent}%` }}
+        />
+      </div>
+      <div className="font-mono text-[12.5px] text-ink-2">
+        {progress} / {total} sites . {logins} passwords
+      </div>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/MacKeychainNotice.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/MacKeychainNotice.tsx
@@ -1,0 +1,22 @@
+import { Lock } from 'lucide-react'
+
+/**
+ * Blue info bar that explains the macOS Keychain permission prompt
+ * the user is about to see. Phase 3 just renders it; the real prompt
+ * lives in the wiring layer.
+ */
+export function MacKeychainNotice() {
+  return (
+    <div className="mb-4 flex items-start gap-3 rounded-xl border border-blue/20 bg-[#EEF3FA] p-4">
+      <Lock className="mt-0.5 size-[18px] shrink-0 text-blue" />
+      <div className="text-[12.5px] text-ink-2 leading-[1.5]">
+        <span className="font-semibold text-ink">
+          macOS will ask permission
+        </span>{' '}
+        to read Chrome&rsquo;s saved data. That&rsquo;s expected. Click{' '}
+        <span className="font-semibold text-ink">Allow</span> on the Keychain
+        prompt.
+      </div>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/OnboardingCopyBlock.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/OnboardingCopyBlock.tsx
@@ -1,0 +1,49 @@
+import { Check, Copy } from 'lucide-react'
+import { useState } from 'react'
+
+interface OnboardingCopyBlockProps {
+  text: string
+}
+
+/**
+ * Dark code block with a copy button matching the v2 onboarding
+ * design's CLI snippet shape (green prompt prefix, light mono text,
+ * inline copy chip that flashes a checkmark for ~1.5 seconds). The
+ * MCP page's `HeroCard` has a sibling block; once Phase 3 merges the
+ * two can collapse into a shared `components/code/CopyBlock`, but
+ * keeping them parallel during the Phase 3 window avoids a merge
+ * conflict against Phase 2's just-landed code.
+ */
+export function OnboardingCopyBlock({ text }: OnboardingCopyBlockProps) {
+  const [copied, setCopied] = useState(false)
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch {
+      setCopied(false)
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-2.5 rounded-xl bg-[#15140F] px-3.5 py-3">
+      <span className="font-mono text-[#6FCF8E] text-[12.5px]">$</span>
+      <code className="flex-1 truncate font-mono text-[#EDEAE2] text-[12.5px]">
+        {text}
+      </code>
+      <button
+        type="button"
+        onClick={copy}
+        className="inline-flex items-center gap-1.5 rounded-md bg-white/10 px-2 py-1 font-semibold text-[11.5px] text-white transition hover:bg-white/15"
+      >
+        {copied ? (
+          <Check className="size-3.5" />
+        ) : (
+          <Copy className="size-3.5" />
+        )}
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/OnboardingShell.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/OnboardingShell.tsx
@@ -1,0 +1,57 @@
+import type { ReactNode } from 'react'
+import { StepDots } from './StepDots'
+import { VisualRail } from './VisualRail'
+
+interface OnboardingShellProps {
+  step: number
+  totalSteps: number
+  children: ReactNode
+}
+
+/**
+ * macwin frame for the v2 onboarding. A 44 px chrome bar with three
+ * traffic-light placeholders sits on top; below it, a horizontal flex
+ * with `VisualRail` on the left (360 px fixed) and the scrollable
+ * content column on the right. Centered in the viewport when the
+ * window exceeds 1040 x 720.
+ *
+ * Each step component is rendered as `children`; the shell owns the
+ * dots, the rail, and the chrome bar so a step component only
+ * cares about its own content.
+ */
+export function OnboardingShell({
+  step,
+  totalSteps,
+  children,
+}: OnboardingShellProps) {
+  return (
+    <div className="flex min-h-screen items-center justify-center bg-bg-canvas p-6">
+      <div
+        className="flex h-[720px] w-full max-w-[1040px] flex-col overflow-hidden rounded-2xl border border-border-2 bg-bg-canvas shadow-2xl"
+        role="dialog"
+        aria-label="BrowserOS onboarding"
+      >
+        <div className="flex h-11 items-center border-border border-b bg-bg-canvas px-4">
+          <div className="flex items-center gap-1.5">
+            <span aria-hidden className="size-3 rounded-full bg-[#FF5F57]" />
+            <span aria-hidden className="size-3 rounded-full bg-[#FEBC2E]" />
+            <span aria-hidden className="size-3 rounded-full bg-[#28C840]" />
+          </div>
+          <div className="flex-1 text-center font-semibold text-[12.5px] text-ink-3">
+            Welcome to BrowserOS
+          </div>
+          <div className="w-[52px]" />
+        </div>
+        <div className="flex min-h-0 flex-1">
+          <VisualRail />
+          <div className="scroll flex flex-1 flex-col overflow-y-auto px-12 pt-11 pb-10">
+            <div className="mb-[30px]">
+              <StepDots step={step} total={totalSteps} />
+            </div>
+            {children}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/StarterPromptTile.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/StarterPromptTile.tsx
@@ -1,0 +1,39 @@
+import { Check, Copy, Sparkles } from 'lucide-react'
+import { useState } from 'react'
+
+interface StarterPromptTileProps {
+  prompt: string
+}
+
+/**
+ * Suggested starter prompt row. Clicking Copy puts the prompt on the
+ * clipboard and flashes a checkmark for ~1.5 seconds, matching the
+ * MCP page's CopyBlock pattern.
+ */
+export function StarterPromptTile({ prompt }: StarterPromptTileProps) {
+  const [copied, setCopied] = useState(false)
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(prompt)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch {
+      setCopied(false)
+    }
+  }
+
+  return (
+    <div className="flex items-center gap-3 rounded-xl border border-border-2 bg-card px-4 py-3.5">
+      <Sparkles className="size-4 shrink-0 text-accent" />
+      <span className="flex-1 text-[13.5px] text-ink">{prompt}</span>
+      <button
+        type="button"
+        onClick={copy}
+        className="inline-flex shrink-0 items-center gap-1.5 rounded-md bg-bg-sunken px-2.5 py-1 font-semibold text-[12px] text-ink-2 transition hover:bg-card-tint hover:text-ink"
+      >
+        {copied ? <Check className="size-3" /> : <Copy className="size-3" />}
+        {copied ? 'Copied' : 'Copy'}
+      </button>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/StepDots.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/StepDots.tsx
@@ -1,0 +1,35 @@
+import { cn } from '@/lib/utils'
+
+interface StepDotsProps {
+  step: number
+  total: number
+}
+
+/**
+ * Four-dot progress indicator. Active dot is a 22 px elongated pill
+ * in accent orange, completed dots are accent-tint-2, future dots are
+ * border-2 grey. Width / colour transitions over 300 ms so step
+ * changes feel smooth.
+ */
+export function StepDots({ step, total }: StepDotsProps) {
+  return (
+    <div className="flex items-center gap-[7px]">
+      {Array.from({ length: total }).map((_, idx) => {
+        const isActive = idx === step
+        const isDone = idx < step
+        return (
+          <span
+            // biome-ignore lint/suspicious/noArrayIndexKey: dots are pure decoration with a fixed total; no DOM identity to preserve
+            key={idx}
+            className={cn(
+              'h-[7px] rounded-full transition-all duration-300',
+              isActive ? 'w-[22px] bg-accent' : 'w-[7px]',
+              !isActive && isDone && 'bg-accent-tint-2',
+              !isActive && !isDone && 'bg-border-2',
+            )}
+          />
+        )
+      })}
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/StepWrap.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/StepWrap.tsx
@@ -1,0 +1,14 @@
+import type { ReactNode } from 'react'
+
+interface StepWrapProps {
+  children: ReactNode
+}
+
+/**
+ * Width cap + fade-up animation for every step's content. Caps at
+ * 560 px so the content does not stretch into the visual rail's
+ * width territory.
+ */
+export function StepWrap({ children }: StepWrapProps) {
+  return <div className="w-full max-w-[560px] animate-fade-up">{children}</div>
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/VisualRail.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/components/VisualRail.tsx
@@ -1,0 +1,80 @@
+import { Lock, ShieldCheck, Zap } from 'lucide-react'
+
+/**
+ * Left visual rail of the onboarding shell. 360 px wide with a
+ * warm-orange linear gradient + radial wash, a BrowserOS logo + word
+ * mark at the top, an italic serif quote in the middle, three small
+ * feature blocks below it, and a faint footer caption. Lifted
+ * verbatim from the v2 design's left column.
+ */
+export function VisualRail() {
+  return (
+    <div
+      className="relative flex w-[360px] shrink-0 flex-col justify-between overflow-hidden border-border border-r p-9"
+      style={{
+        background:
+          'linear-gradient(165deg, #F8DCC2 0%, #FBF0E4 55%, #FAF8F5 100%)',
+      }}
+    >
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background:
+            'radial-gradient(420px 300px at 30% 12%, rgba(242,107,42,.16), transparent 70%)',
+        }}
+      />
+      <div className="relative flex items-center gap-2.5">
+        <div className="flex size-[38px] items-center justify-center rounded-[11px] bg-accent font-extrabold text-card text-lg">
+          B
+        </div>
+        <div className="font-extrabold text-[17px] tracking-tight">
+          BrowserOS
+        </div>
+      </div>
+      <div className="relative">
+        <div className="mb-[18px] font-serif text-[23px] text-ink italic leading-snug">
+          &ldquo;Let the agent you already run drive the browser you&rsquo;re
+          already logged into.&rdquo;
+        </div>
+        <div className="flex flex-col gap-3">
+          {FEATURES.map((f) => {
+            const Icon = f.icon
+            return (
+              <div key={f.title} className="flex items-start gap-[11px]">
+                <span className="flex size-7 shrink-0 items-center justify-center rounded-lg bg-white/70 text-accent-ink">
+                  <Icon className="size-[15px]" />
+                </span>
+                <div>
+                  <div className="font-bold text-[13.5px]">{f.title}</div>
+                  <div className="text-[12px] text-ink-2">{f.description}</div>
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      </div>
+      <div className="relative text-[11.5px] text-ink-3">
+        Mac . v1.0 . signed build
+      </div>
+    </div>
+  )
+}
+
+const FEATURES = [
+  {
+    icon: Zap,
+    title: 'Fast & token-cheap',
+    description: 'DOM-first, not a screenshot loop',
+  },
+  {
+    icon: Lock,
+    title: 'Logged in as you',
+    description: 'Imports your Chrome sessions',
+  },
+  {
+    icon: ShieldCheck,
+    title: 'Under your control',
+    description: 'Scoped approvals, hard blocks',
+  },
+] as const

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/onboarding-v2.helpers.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/onboarding-v2.helpers.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  CHROME_PROFILES,
+  profilesByIds,
+  STARTER_PROMPTS,
+  sumLoginsFor,
+  sumSitesFor,
+} from './onboarding-v2.helpers'
+
+describe('CHROME_PROFILES fixture', () => {
+  it('ships three profiles with stable ids', () => {
+    expect(CHROME_PROFILES.map((p) => p.id)).toEqual([
+      'work',
+      'personal',
+      'testing',
+    ])
+  })
+
+  it('uses placeholder example.com emails (no real identifiers)', () => {
+    for (const p of CHROME_PROFILES) {
+      expect(p.email).toContain('example.com')
+    }
+  })
+})
+
+describe('sumSitesFor / sumLoginsFor', () => {
+  it('sums the default selection (work + personal)', () => {
+    expect(sumSitesFor(['work', 'personal'])).toBe(47)
+    expect(sumLoginsFor(['work', 'personal'])).toBe(12)
+  })
+
+  it('returns 0 when the selection is empty', () => {
+    expect(sumSitesFor([])).toBe(0)
+    expect(sumLoginsFor([])).toBe(0)
+  })
+
+  it('handles single-profile selections', () => {
+    expect(sumSitesFor(['testing'])).toBe(8)
+    expect(sumLoginsFor(['testing'])).toBe(2)
+  })
+})
+
+describe('profilesByIds', () => {
+  it('returns profile records for the given ids, preserving fixture order', () => {
+    const result = profilesByIds(['personal', 'work'])
+    expect(result.map((p) => p.id)).toEqual(['work', 'personal'])
+  })
+})
+
+describe('STARTER_PROMPTS', () => {
+  it('ships at least two suggestions for the Ready step', () => {
+    expect(STARTER_PROMPTS.length).toBeGreaterThanOrEqual(2)
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/onboarding-v2.helpers.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/onboarding-v2.helpers.ts
@@ -1,0 +1,67 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Static fixtures for the Phase 3 onboarding shell. Numbers exist so
+ * the import-progress bar has something to climb toward and the
+ * success summary has a concrete count; the wiring person replaces
+ * these with real Chrome profile reads later.
+ */
+
+import type { ChromeProfileId } from './onboarding-v2.schemas'
+
+export interface ChromeProfile {
+  id: ChromeProfileId
+  name: string
+  email: string
+  sites: number
+  logins: number
+}
+
+export const CHROME_PROFILES: readonly ChromeProfile[] = [
+  { id: 'work', name: 'Work', email: 'you@example.com', sites: 31, logins: 9 },
+  {
+    id: 'personal',
+    name: 'Personal',
+    email: 'you.personal@example.com',
+    sites: 16,
+    logins: 3,
+  },
+  {
+    id: 'testing',
+    name: 'Testing',
+    email: 'qa@example.com',
+    sites: 8,
+    logins: 2,
+  },
+]
+
+export function sumSitesFor(ids: readonly ChromeProfileId[]): number {
+  return CHROME_PROFILES.filter((p) => ids.includes(p.id)).reduce(
+    (sum, p) => sum + p.sites,
+    0,
+  )
+}
+
+export function sumLoginsFor(ids: readonly ChromeProfileId[]): number {
+  return CHROME_PROFILES.filter((p) => ids.includes(p.id)).reduce(
+    (sum, p) => sum + p.logins,
+    0,
+  )
+}
+
+export function profilesByIds(
+  ids: readonly ChromeProfileId[],
+): readonly ChromeProfile[] {
+  return CHROME_PROFILES.filter((p) => ids.includes(p.id))
+}
+
+/**
+ * Two starter prompts the Ready step suggests. Hard-coded for Phase 3;
+ * the wiring person can swap this for a real source later.
+ */
+export const STARTER_PROMPTS: readonly string[] = [
+  'Find me a coffee shop within walking distance and save it to my Maps.',
+  'Apply for the SF visa for me, you have my passport scan in iCloud.',
+]

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/onboarding-v2.schemas.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/onboarding-v2.schemas.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  onboardingFormDefaults,
+  onboardingFormSchema,
+} from './onboarding-v2.schemas'
+
+describe('onboardingFormSchema', () => {
+  it('accepts the default values', () => {
+    const parsed = onboardingFormSchema.parse(onboardingFormDefaults)
+    expect(parsed.selectedProfileIds).toEqual(['work', 'personal'])
+  })
+
+  it('rejects an empty selection with a helpful message', () => {
+    const result = onboardingFormSchema.safeParse({ selectedProfileIds: [] })
+    expect(result.success).toBe(false)
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe(
+        'Pick at least one profile to import.',
+      )
+    }
+  })
+
+  it('rejects unknown profile ids', () => {
+    const result = onboardingFormSchema.safeParse({
+      selectedProfileIds: ['ghost'],
+    })
+    expect(result.success).toBe(false)
+  })
+
+  it('accepts a single profile selection', () => {
+    const parsed = onboardingFormSchema.parse({
+      selectedProfileIds: ['testing'],
+    })
+    expect(parsed.selectedProfileIds).toEqual(['testing'])
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/onboarding-v2.schemas.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/onboarding-v2.schemas.ts
@@ -1,0 +1,30 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Form schema for the v2 onboarding flow. Phase 3 wires only the
+ * profile picker through react-hook-form; every other "input" in the
+ * flow is a stateless local-state advancer. When the wiring person
+ * replaces the fake handlers, they read `form.getValues()` here and
+ * post to the real import service.
+ */
+
+import { z } from 'zod'
+
+export const CHROME_PROFILE_IDS = ['work', 'personal', 'testing'] as const
+export type ChromeProfileId = (typeof CHROME_PROFILE_IDS)[number]
+
+export const chromeProfileIdEnum = z.enum(CHROME_PROFILE_IDS)
+
+export const onboardingFormSchema = z.object({
+  selectedProfileIds: z
+    .array(chromeProfileIdEnum)
+    .min(1, 'Pick at least one profile to import.'),
+})
+
+export type OnboardingFormValues = z.infer<typeof onboardingFormSchema>
+
+export const onboardingFormDefaults: OnboardingFormValues = {
+  selectedProfileIds: ['work', 'personal'],
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/onboarding-v2.types.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/onboarding-v2.types.ts
@@ -1,0 +1,15 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Local UX state types for the onboarding flow. These do not leave
+ * the screen and are kept in `useState`. RHF owns the form values
+ * separately.
+ */
+
+export type Step = 0 | 1 | 2 | 3
+
+export type ImportPhase = 'pre-quit' | 'picker' | 'importing' | 'imported'
+
+export type ConnectPhase = 'idle' | 'connecting' | 'connected'

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/steps/ConnectStep.test.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/steps/ConnectStep.test.tsx
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router'
+import type { ConnectPhase } from '../onboarding-v2.types'
+import { ConnectStep } from './ConnectStep'
+
+function render(phase: ConnectPhase): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <ConnectStep
+        phase={phase}
+        onAddToClaude={() => undefined}
+        onContinue={() => undefined}
+      />
+    </MemoryRouter>,
+  )
+}
+
+describe('ConnectStep', () => {
+  it('renders the Add-to-Claude CTA and the canonical CLI snippet in idle phase', () => {
+    const html = render('idle')
+    expect(html).toContain('Add to Claude')
+    expect(html).toContain('or use the CLI')
+    expect(html).toContain('claude mcp add browseros')
+    expect(html).toContain('--transport http')
+  })
+
+  it('shows the Connecting state and disables the button while connecting', () => {
+    const html = render('connecting')
+    expect(html).toContain('Connecting')
+    expect(html).toContain('disabled')
+  })
+
+  it('renders the success card and Continue CTA when connected', () => {
+    const html = render('connected')
+    expect(html).toContain('Connected to Claude')
+    expect(html).toContain('68 browser tools available')
+    expect(html).toContain('You')
+    expect(html).toContain('set')
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/steps/ConnectStep.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/steps/ConnectStep.tsx
@@ -1,0 +1,86 @@
+import { ArrowRight, Link2, RefreshCw } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { buildCanonicalMcpCliCommand } from '@/modules/api/mcp-endpoint'
+import { ConnectedSummaryCard } from '../components/ConnectedSummaryCard'
+import { DisplayHeading, Em, StepCopy } from '../components/DisplayHeading'
+import { OnboardingCopyBlock } from '../components/OnboardingCopyBlock'
+import { StepWrap } from '../components/StepWrap'
+import type { ConnectPhase } from '../onboarding-v2.types'
+
+interface ConnectStepProps {
+  phase: ConnectPhase
+  onAddToClaude: () => void
+  onContinue: () => void
+}
+
+/**
+ * Step 2. Three sub-phases driven by `phase`:
+ *
+ *   idle       : "Add to Claude" button + canonical CLI snippet fallback
+ *   connecting : disabled button with a spinner
+ *   connected  : green success card + "You're set" CTA
+ *
+ * The CLI snippet is the exact string the MCP page advertises so a
+ * user who reaches onboarding via the reconnect path copies the same
+ * command they would copy from /mcp.
+ */
+export function ConnectStep({
+  phase,
+  onAddToClaude,
+  onContinue,
+}: ConnectStepProps) {
+  const cli = buildCanonicalMcpCliCommand()
+  const isConnecting = phase === 'connecting'
+  const isConnected = phase === 'connected'
+
+  return (
+    <StepWrap>
+      <DisplayHeading>
+        Connect to <Em>Claude</Em>.
+      </DisplayHeading>
+      <StepCopy>
+        BrowserOS shows up inside Claude as a connector. One click. No extension
+        handshake to fail.
+      </StepCopy>
+
+      {!isConnected && (
+        <>
+          <Button
+            type="button"
+            size="lg"
+            onClick={onAddToClaude}
+            disabled={isConnecting}
+          >
+            {isConnecting ? (
+              <>
+                <RefreshCw className="size-4 animate-spin" />
+                Connecting...
+              </>
+            ) : (
+              <>
+                <Link2 className="size-4" />
+                Add to Claude
+              </>
+            )}
+          </Button>
+          <div className="my-5 flex items-center gap-3 text-[12px] text-ink-4">
+            <div className="h-px flex-1 bg-border-2" />
+            or use the CLI
+            <div className="h-px flex-1 bg-border-2" />
+          </div>
+          <OnboardingCopyBlock text={cli} />
+        </>
+      )}
+
+      {isConnected && (
+        <>
+          <ConnectedSummaryCard />
+          <Button type="button" size="lg" onClick={onContinue}>
+            <ArrowRight className="size-4" />
+            You&rsquo;re set
+          </Button>
+        </>
+      )}
+    </StepWrap>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/steps/ImportStep.test.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/steps/ImportStep.test.tsx
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'bun:test'
+import { zodResolver } from '@hookform/resolvers/zod'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { useForm } from 'react-hook-form'
+import { MemoryRouter } from 'react-router'
+import { Form } from '@/components/ui/form'
+import {
+  type OnboardingFormValues,
+  onboardingFormDefaults,
+  onboardingFormSchema,
+} from '../onboarding-v2.schemas'
+import type { ImportPhase } from '../onboarding-v2.types'
+import { ImportStep } from './ImportStep'
+
+function Harness({
+  phase,
+  progress = 0,
+}: {
+  phase: ImportPhase
+  progress?: number
+}) {
+  const form = useForm<OnboardingFormValues>({
+    resolver: zodResolver(onboardingFormSchema),
+    defaultValues: onboardingFormDefaults,
+  })
+  return (
+    <Form {...form}>
+      <ImportStep
+        phase={phase}
+        progress={progress}
+        form={form}
+        onQuitChrome={() => undefined}
+        onImport={() => undefined}
+        onContinue={() => undefined}
+      />
+    </Form>
+  )
+}
+
+function render(phase: ImportPhase, progress = 0): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <Harness phase={phase} progress={progress} />
+    </MemoryRouter>,
+  )
+}
+
+describe('ImportStep', () => {
+  it('renders the Chrome-is-open notice in pre-quit phase', () => {
+    const html = render('pre-quit')
+    expect(html).toContain('Chrome is open')
+    expect(html).toContain('Quit Chrome for me')
+  })
+
+  it('renders the picker, the Keychain notice, and an Import button in picker phase', () => {
+    const html = render('picker')
+    expect(html).toContain('Choose which Chrome profiles to import')
+    expect(html).toContain('Work')
+    expect(html).toContain('Personal')
+    expect(html).toContain('Testing')
+    expect(html).toContain('macOS will ask permission')
+    // Default selection sums to 47 sites across 2 profiles.
+    expect(html).toContain('Import 47 sites from 2 profiles')
+  })
+
+  it('renders the importing progress card during importing phase', () => {
+    const html = render('importing', 12)
+    expect(html).toContain('Importing sessions')
+    expect(html).toContain('12 / 47 sites')
+  })
+
+  it('renders the success card and Connect-to-Claude CTA in imported phase', () => {
+    const html = render('imported')
+    expect(html).toContain('Imported 47 sites from 2 profiles')
+    expect(html).toContain('Passwords stored in vault')
+    expect(html).toContain('Connect to Claude')
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/steps/ImportStep.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/steps/ImportStep.tsx
@@ -1,0 +1,137 @@
+import { ArrowRight, Download } from 'lucide-react'
+import type { UseFormReturn } from 'react-hook-form'
+import { Button } from '@/components/ui/button'
+import { FormField, FormItem, FormMessage } from '@/components/ui/form'
+import { ChromeProfileTile } from '../components/ChromeProfileTile'
+import { ChromeQuitNotice } from '../components/ChromeQuitNotice'
+import { DisplayHeading, Em, StepCopy } from '../components/DisplayHeading'
+import { ImportedSummaryCard } from '../components/ImportedSummaryCard'
+import { ImportingProgressCard } from '../components/ImportingProgressCard'
+import { MacKeychainNotice } from '../components/MacKeychainNotice'
+import { StepWrap } from '../components/StepWrap'
+import {
+  CHROME_PROFILES,
+  type ChromeProfile,
+  sumLoginsFor,
+  sumSitesFor,
+} from '../onboarding-v2.helpers'
+import type { OnboardingFormValues } from '../onboarding-v2.schemas'
+import type { ImportPhase } from '../onboarding-v2.types'
+
+interface ImportStepProps {
+  phase: ImportPhase
+  progress: number
+  form: UseFormReturn<OnboardingFormValues>
+  onQuitChrome: () => void
+  onImport: () => void
+  onContinue: () => void
+}
+
+/**
+ * Step 1. Four sub-phases driven by the `phase` prop:
+ *
+ *   pre-quit   : amber notice + "Quit Chrome" button
+ *   picker     : RHF-managed profile picker + Keychain notice + Import button
+ *   importing  : animated progress card (parent owns the timer)
+ *   imported   : success bullets + "Connect to Claude" CTA
+ *
+ * The form lives on the parent so the field stays mounted across all
+ * four sub-phases; only the rendered content swaps.
+ */
+export function ImportStep({
+  phase,
+  progress,
+  form,
+  onQuitChrome,
+  onImport,
+  onContinue,
+}: ImportStepProps) {
+  const selectedIds = form.watch('selectedProfileIds')
+  const selectedProfiles = CHROME_PROFILES.filter((p) =>
+    selectedIds.includes(p.id),
+  )
+  const sites = sumSitesFor(selectedIds)
+  const logins = sumLoginsFor(selectedIds)
+  const isPickerValid = form.formState.isValid
+
+  return (
+    <StepWrap>
+      <DisplayHeading>
+        Import your <Em>logins</Em>.
+      </DisplayHeading>
+      <StepCopy>
+        BrowserOS copies your saved Chrome sessions so the agent never has to
+        log in again. Sessions stay in a local vault on this Mac.
+      </StepCopy>
+
+      {phase === 'pre-quit' && <ChromeQuitNotice onQuitChrome={onQuitChrome} />}
+
+      {phase === 'picker' && (
+        <>
+          <div className="mb-2.5 font-bold text-[12.5px] text-ink-2">
+            Choose which Chrome profiles to import
+          </div>
+          <FormField
+            control={form.control}
+            name="selectedProfileIds"
+            render={({ field }) => (
+              <FormItem className="mb-4 flex flex-col gap-2.5">
+                {CHROME_PROFILES.map((profile: ChromeProfile) => {
+                  const checked = field.value.includes(profile.id)
+                  return (
+                    <ChromeProfileTile
+                      key={profile.id}
+                      profile={profile}
+                      checked={checked}
+                      onCheckedChange={(next) =>
+                        field.onChange(
+                          next
+                            ? [...field.value, profile.id]
+                            : field.value.filter((id) => id !== profile.id),
+                        )
+                      }
+                    />
+                  )
+                })}
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <MacKeychainNotice />
+          <Button
+            type="button"
+            size="lg"
+            onClick={onImport}
+            disabled={!isPickerValid}
+          >
+            <Download className="size-4" />
+            {selectedProfiles.length === 0
+              ? 'Pick at least one profile'
+              : `Import ${sites} sites from ${selectedProfiles.length} profile${selectedProfiles.length === 1 ? '' : 's'}`}
+          </Button>
+        </>
+      )}
+
+      {phase === 'importing' && (
+        <ImportingProgressCard
+          progress={progress}
+          total={sites}
+          logins={logins}
+        />
+      )}
+
+      {phase === 'imported' && (
+        <>
+          <ImportedSummaryCard
+            sites={sites}
+            profileCount={selectedProfiles.length}
+          />
+          <Button type="button" size="lg" onClick={onContinue}>
+            <ArrowRight className="size-4" />
+            Connect to Claude
+          </Button>
+        </>
+      )}
+    </StepWrap>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/steps/ReadyStep.test.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/steps/ReadyStep.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MemoryRouter } from 'react-router'
+import { STARTER_PROMPTS } from '../onboarding-v2.helpers'
+import { ReadyStep } from './ReadyStep'
+
+function render(): string {
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <ReadyStep onDone={() => undefined} />
+    </MemoryRouter>,
+  )
+}
+
+describe('ReadyStep', () => {
+  it('renders the Open BrowserOS CTA', () => {
+    expect(render()).toContain('Open BrowserOS')
+  })
+
+  it('renders the first two starter prompts from the fixture', () => {
+    const html = render()
+    expect(html).toContain(STARTER_PROMPTS[0])
+    expect(html).toContain(STARTER_PROMPTS[1])
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/steps/ReadyStep.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/steps/ReadyStep.tsx
@@ -1,0 +1,39 @@
+import { Sparkles } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { DisplayHeading, Em, StepCopy } from '../components/DisplayHeading'
+import { StarterPromptTile } from '../components/StarterPromptTile'
+import { StepWrap } from '../components/StepWrap'
+import { STARTER_PROMPTS } from '../onboarding-v2.helpers'
+
+interface ReadyStepProps {
+  onDone: () => void
+}
+
+/**
+ * Step 3. Two starter prompt tiles and an "Open BrowserOS" CTA that
+ * navigates the user home. `onDone` lives on the parent so the
+ * wiring person can swap navigation behaviour without touching the
+ * step component.
+ */
+export function ReadyStep({ onDone }: ReadyStepProps) {
+  return (
+    <StepWrap>
+      <DisplayHeading>
+        You&rsquo;re <Em>set</Em>.
+      </DisplayHeading>
+      <StepCopy>
+        Open Claude and try one of these. The task runs here, in BrowserOS. You
+        watch, approve, and audit.
+      </StepCopy>
+      <div className="mb-6 flex flex-col gap-2.5">
+        {STARTER_PROMPTS.slice(0, 2).map((prompt) => (
+          <StarterPromptTile key={prompt} prompt={prompt} />
+        ))}
+      </div>
+      <Button type="button" size="lg" onClick={onDone}>
+        <Sparkles className="size-4" />
+        Open BrowserOS
+      </Button>
+    </StepWrap>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/steps/WelcomeStep.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding-v2/steps/WelcomeStep.tsx
@@ -1,0 +1,39 @@
+import { Zap } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { DisplayHeading, Em, StepCopy } from '../components/DisplayHeading'
+import { StepWrap } from '../components/StepWrap'
+
+interface WelcomeStepProps {
+  onPrimary: () => void
+  onSkip: () => void
+}
+
+/**
+ * Step 0. Welcome copy + two CTAs. Primary advances into the full
+ * flow, the quieter CTA skips ahead to the Ready step for users who
+ * have done this before and just need the canonical CLI snippet
+ * (Phase 3 wires this to step 3 because Connect carries the CLI; the
+ * wiring person can re-route to a reconnect-specific screen later).
+ */
+export function WelcomeStep({ onPrimary, onSkip }: WelcomeStepProps) {
+  return (
+    <StepWrap>
+      <DisplayHeading>
+        The browser your agents <Em>drive</Em>.
+      </DisplayHeading>
+      <StepCopy>
+        Logged in as you, fast, and under your control. Set-up takes about two
+        minutes. Import your logins, connect to Claude, and run your first task.
+      </StepCopy>
+      <div className="flex flex-wrap items-center gap-3">
+        <Button type="button" size="lg" onClick={onPrimary}>
+          <Zap className="size-4" />
+          Set up . about 2 min
+        </Button>
+        <Button type="button" size="lg" variant="ghost" onClick={onSkip}>
+          I&rsquo;ve done this before . reconnect
+        </Button>
+      </div>
+    </StepWrap>
+  )
+}

--- a/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding/OnboardingV2.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/screens/onboarding/OnboardingV2.tsx
@@ -3,32 +3,10 @@
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
- * Phase 0 placeholder for the v2 onboarding flow. The full design
- * (browser-for-agents-v2) lands in a later phase; this stub keeps
- * `/onboarding` reachable so any future deep link does not 404 and
- * gives the UI a place to render the v2 hero copy in the meantime.
+ * v2 onboarding mount point. The real implementation lives under
+ * `screens/onboarding-v2/`; this file is the router's import target
+ * so the App.tsx route table stays unchanged across phases. Phase 0
+ * shipped a placeholder here; Phase 3 swaps it for the real shell.
  */
 
-export function OnboardingV2() {
-  return (
-    <div
-      style={{
-        display: 'flex',
-        flexDirection: 'column',
-        alignItems: 'center',
-        justifyContent: 'center',
-        minHeight: '100vh',
-        gap: 12,
-        textAlign: 'center',
-        padding: '0 24px',
-      }}
-    >
-      <h1 style={{ fontSize: 28, margin: 0 }}>BrowserOS for agents</h1>
-      <p style={{ fontSize: 16, color: '#666', maxWidth: 520 }}>
-        Connect your AI agent to BrowserOS via the standard MCP endpoint at{' '}
-        <code>http://127.0.0.1:9100/cockpit/mcp</code>. The richer onboarding
-        flow ships in the next release.
-      </p>
-    </div>
-  )
-}
+export { OnboardingV2 } from '@/screens/onboarding-v2/OnboardingV2'


### PR DESCRIPTION
## Summary

Ships the four-step v2 onboarding flow at `/newtab.html#/onboarding`. UI shell only: every interaction either advances local state or runs a fake-progress timer. A second person picks up the wiring by replacing four callbacks and two `useEffect` bodies; the form-state model, layout, and typography are stable.

Reference design: `~/workbench/browseros-ai/claude-designs/browser-for-agents-v2/js/onboarding.jsx`.

## Layout

- macwin frame: 44 px chrome bar with three traffic-light placeholders, "Welcome to BrowserOS" title centered.
- 360 px visual rail on the left: warm-orange linear gradient + radial wash, BrowserOS logo + wordmark, italic serif quote, three feature blocks (Fast & token-cheap, Logged in as you, Under your control), faint footer caption.
- Content column on the right: 4-dot step indicator at top, current step content below.
- Centered in viewport at 1040 x 720.

## Steps

- **0 Welcome.** Display heading with italic accent on "drive". Two CTAs: primary "Set up" advances; quiet "reconnect" CTA jumps to step 3.
- **1 Import logins.** Four sub-phases driven by local state:
  - `pre-quit`: amber notice + "Quit Chrome for me" button.
  - `picker`: RHF + Zod profile picker (3 Chrome profiles), Keychain permission notice, dynamic Import CTA labelled with the live site / profile count. Disabled when zero profiles are selected.
  - `importing`: spinner + animated progress bar that climbs to 100 percent in ~1.5 seconds.
  - `imported`: green success card with three bullets + "Connect to Claude" CTA.
- **2 Connect to Claude.** Three sub-phases:
  - `idle`: orange "Add to Claude" CTA + "or use the CLI" divider + the real canonical CLI snippet (`buildCanonicalMcpCliCommand()` from Phase 2) in a dark code block with a copy button.
  - `connecting`: same CTA disabled with a spinning icon. Auto-flips after ~1.7 seconds.
  - `connected`: green "Connected to Claude" card + "You're set" CTA.
- **3 Ready.** Display heading with italic accent on "set". Two starter prompt tiles with Copy buttons. "Open BrowserOS" navigates to `/`.

## Form state model

Single `useForm` instance at the root with `zodResolver(onboardingFormSchema)` and `mode: 'onChange'`. The picker reads `form.watch('selectedProfileIds')` and writes via `field.onChange(next)`. The Import button's disabled state tracks `form.formState.isValid` so it disables the moment the user unchecks the last profile.

```ts
export const onboardingFormSchema = z.object({
  selectedProfileIds: z
    .array(chromeProfileIdEnum)
    .min(1, 'Pick at least one profile to import.'),
})
```

## Wiring person's checklist

Replace these without touching layout, typography, or form state:

1. **`onQuitChrome`** (currently advances `importPhase` to `picker`): real "quit Chrome safely" call.
2. **`onImport`** (currently advances to `importing`): real import service mutation. Replace the fake-progress `useEffect` (commented "Fake import-progress climber") with a subscription that drives `setImportProgress` from real events.
3. **`onAddToClaude`** (currently advances to `connecting`): real connect mutation. Replace the fake connect timer with the mutation lifecycle that flips `connectPhase` on success / error.
4. **`onDone`** (currently `navigate('/')`): confirm the post-onboarding navigation target.

Form values for the import mutation: `form.getValues().selectedProfileIds: ChromeProfileId[]`.

## Test coverage

- `apps/agent-mcp-ui`: 68 → 92 pass (24 new across schema, helpers, shell, and per-step files).
- `bun run typecheck` clean on both touched packages.
- `biome check` clean (two semantic-elements / array-index suppressions documented inline with rationale).

## Test plan

- [x] `bun --cwd apps/agent-mcp-ui test` → 92 pass
- [x] Workspace typecheck clean on the two touched packages
- [x] Biome clean
- [ ] Manual smoke: walk all four steps in the dev build, confirm the picker disabled-state flips when zero profiles are checked, confirm the progress bar lands on 100 percent, confirm the connect success card appears after ~1.7 seconds, confirm Open BrowserOS routes to `/`.
- [ ] Visual parity vs the reference HTML at 1280 x 800. Screenshot pairs go under `~/workbench/screenshots/browseros-ai/BrowserOS/v2-phase3-onboarding/`.

## Notes for review

- `OnboardingCopyBlock` is intentionally parallel to `HeroCard`'s `CopyBlock` rather than shared. They collapse cleanly into a `components/code/CopyBlock` in a follow-up; keeping them parallel here avoids a merge dance during the Phase 3 review window.
- The fake-import effect's tick interval (70 ms) and settle delay (350 ms) match the design's reference values.
- Two biome suppressions inline: `useSemanticElements` on the profile tile (the design demands click-anywhere-on-row, which needs a button with role=checkbox), and `noArrayIndexKey` on the step dots (pure decoration with a fixed total).
- Hidden v2 surfaces stay hidden. No edits to `WaitingStrip`, `AddAgentTile`, the legacy `Onboarding.tsx` flow, or any backend file.