### PR TITLE
feat(cockpit): v2 phase 4 - per-agent tab groups + Watch focus

### DIFF
--- a/packages/browseros-agent/apps/agent-mcp-interface/src/lib/agent-tab-groups/group-color.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/lib/agent-tab-groups/group-color.ts
@@ -1,0 +1,83 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Deterministic agent slug to colour mapping for the v2 tab-group
+ * system. The browser's `tab_groups` tool accepts one of nine named
+ * colours; we hash the slug into one slot so two parallel sessions
+ * under the same `clientInfo.name` always pick the same colour.
+ *
+ * The matching hex palette is exposed alongside so the cockpit
+ * homepage card can show a left border in the same colour the
+ * BrowserOS tab strip uses. The two ends sharing one function keeps
+ * the colour story stable end-to-end.
+ */
+
+/** Colours the browser's `tab_groups` tool accepts. */
+export const TAB_GROUP_COLORS = [
+  'grey',
+  'blue',
+  'red',
+  'yellow',
+  'green',
+  'pink',
+  'purple',
+  'cyan',
+  'orange',
+] as const
+
+export type TabGroupColor = (typeof TAB_GROUP_COLORS)[number]
+
+/**
+ * Hex equivalents for each `TabGroupColor`. Used by the UI so the
+ * card's left border visually mirrors the BrowserOS tab strip.
+ * Picked to roughly match the system colours Chromium uses for tab
+ * groups so the cross-surface mapping reads cleanly.
+ */
+export const TAB_GROUP_HEX: Record<TabGroupColor, string> = {
+  grey: '#6B7280',
+  blue: '#2F6FE0',
+  red: '#DC2626',
+  yellow: '#F59E0B',
+  green: '#10A37F',
+  pink: '#DB2777',
+  purple: '#7A5AF8',
+  cyan: '#0EA5E9',
+  orange: '#F26B2A',
+}
+
+/**
+ * FNV-1a 32-bit hash. Same algorithm used by `fallbackSlugForSession`
+ * in `mcp-session/identity.ts`, so colour selection has the same
+ * distribution as the synthetic-slug fallback already does.
+ */
+function fnv1a(input: string): number {
+  let hash = 0x811c9dc5
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i)
+    hash =
+      (hash +
+        ((hash << 1) +
+          (hash << 4) +
+          (hash << 7) +
+          (hash << 8) +
+          (hash << 24))) >>>
+      0
+  }
+  return hash
+}
+
+/**
+ * Picks a `TabGroupColor` for the given agent slug. Stable across
+ * processes and across UI / server boundaries.
+ */
+export function colorForSlug(slug: string): TabGroupColor {
+  const idx = fnv1a(slug) % TAB_GROUP_COLORS.length
+  return TAB_GROUP_COLORS[idx] ?? 'grey'
+}
+
+/** Convenience: hex for the colour the agent group will use. */
+export function hexForSlug(slug: string): string {
+  return TAB_GROUP_HEX[colorForSlug(slug)]
+}

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/lib/agent-tab-groups/index.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/lib/agent-tab-groups/index.ts
@@ -1,0 +1,25 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { createTabGroupTracker } from './tracker'
+
+export type { TabGroupColor } from './group-color'
+export {
+  colorForSlug,
+  hexForSlug,
+  TAB_GROUP_COLORS,
+  TAB_GROUP_HEX,
+} from './group-color'
+export type {
+  RecordOpenInput,
+  RememberGroupInput,
+  TabGroupRecord,
+  TabGroupTracker,
+} from './tracker'
+export { createTabGroupTracker } from './tracker'
+
+/** Process-wide singleton consumed by the v2 dispatch path and the focus route. */
+export const tabGroupTracker = createTabGroupTracker()

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/lib/agent-tab-groups/tracker.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/lib/agent-tab-groups/tracker.ts
@@ -1,0 +1,159 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * In-memory map: agentId to the cockpit-owned tab group container the
+ * agent's tabs land in. The orchestrator (`services/tab-group-ops`)
+ * writes here on a successful `tabs new`; the session-close path
+ * decrements the ref count and reads back the record so it knows
+ * which group to close in BrowserOS.
+ *
+ * Ref-counted by MCP session: two parallel sessions whose clients
+ * identify with the same name share one group; the group only
+ * closes when the last session for that agentId ends.
+ */
+
+import { colorForSlug, type TabGroupColor } from './group-color'
+
+export interface TabGroupRecord {
+  agentId: string
+  slug: string
+  /** Set after the cockpit calls `tab_groups create` for the first time. */
+  groupId: string | null
+  /** Set once we know which window the group lives in (returned alongside groupId). */
+  windowId: number | null
+  /** Pages the cockpit has added to the group so far. */
+  pageIds: Set<number>
+  color: TabGroupColor
+  title: string
+  firstOpenedAt: number
+  /** Live MCP sessions whose identity resolves to this agentId. */
+  refCount: number
+}
+
+export interface RecordOpenInput {
+  agentId: string
+  slug: string
+  pageId: number
+}
+
+export interface RememberGroupInput {
+  agentId: string
+  groupId: string
+  windowId?: number | null
+}
+
+export interface TabGroupTracker {
+  /**
+   * Idempotent. Creates a record on first call, or adds `pageId` to
+   * the existing record's pageIds. Does NOT increment refCount; that
+   * happens at session-open time via `incrementSession`.
+   */
+  recordOpen(input: RecordOpenInput): TabGroupRecord
+  /** Called after `tab_groups create` returns so the cockpit can reuse the groupId for subsequent pages. */
+  rememberGroup(input: RememberGroupInput): void
+  /** Called once per MCP session-init keyed by agentId. */
+  incrementSession(agentId: string): void
+  /**
+   * Called once per session close. Returns the record IF this was the
+   * last session for that agentId (caller should now close the group
+   * in BrowserOS); otherwise returns null.
+   */
+  decrementSession(agentId: string): TabGroupRecord | null
+  /** Called when the cockpit detects the on-disk group is gone or stale. */
+  forgetGroup(agentId: string): void
+  list(): readonly TabGroupRecord[]
+  getByAgentId(agentId: string): TabGroupRecord | null
+  size(): number
+  reset(): void
+}
+
+export interface TabGroupTrackerDeps {
+  now?: () => number
+}
+
+export function createTabGroupTracker(
+  deps: TabGroupTrackerDeps = {},
+): TabGroupTracker {
+  const records = new Map<string, TabGroupRecord>()
+  const now = deps.now ?? (() => Date.now())
+
+  return {
+    recordOpen({ agentId, slug, pageId }) {
+      const existing = records.get(agentId)
+      if (existing) {
+        existing.pageIds.add(pageId)
+        return existing
+      }
+      const record: TabGroupRecord = {
+        agentId,
+        slug,
+        groupId: null,
+        windowId: null,
+        pageIds: new Set([pageId]),
+        color: colorForSlug(slug),
+        title: slug,
+        firstOpenedAt: now(),
+        refCount: 0,
+      }
+      records.set(agentId, record)
+      return record
+    },
+    rememberGroup({ agentId, groupId, windowId }) {
+      const record = records.get(agentId)
+      if (!record) return
+      record.groupId = groupId
+      if (typeof windowId === 'number') record.windowId = windowId
+    },
+    incrementSession(agentId) {
+      const record = records.get(agentId)
+      if (record) {
+        record.refCount += 1
+        return
+      }
+      // No tab opened yet for this agent; pre-seed a refCount-only
+      // record so the close path can decrement cleanly.
+      records.set(agentId, {
+        agentId,
+        slug: agentId,
+        groupId: null,
+        windowId: null,
+        pageIds: new Set(),
+        color: colorForSlug(agentId),
+        title: agentId,
+        firstOpenedAt: now(),
+        refCount: 1,
+      })
+    },
+    decrementSession(agentId) {
+      const record = records.get(agentId)
+      if (!record) return null
+      record.refCount -= 1
+      if (record.refCount <= 0) {
+        records.delete(agentId)
+        return record
+      }
+      return null
+    },
+    forgetGroup(agentId) {
+      const record = records.get(agentId)
+      if (!record) return
+      record.groupId = null
+      record.windowId = null
+      record.pageIds.clear()
+    },
+    list() {
+      return Array.from(records.values())
+    },
+    getByAgentId(agentId) {
+      return records.get(agentId) ?? null
+    },
+    size() {
+      return records.size
+    },
+    reset() {
+      records.clear()
+    },
+  }
+}

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/mcp/register.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/mcp/register.ts
@@ -42,6 +42,7 @@ import {
 import { extractPageId, tabActivityRegistry } from '../lib/tab-activity'
 import type { StoredAgentProfile } from '../routes/agents/schemas'
 import { check } from '../services/permissions'
+import { ensureAgentTabGroup } from '../services/tab-group-ops'
 import { asRegister, type ToolResult } from './register-fn'
 
 /**
@@ -374,6 +375,28 @@ export function registerBrowserToolsForSingleServer(
               identity,
               session,
             })
+            // v2 cockpit-owned tab grouping: when the agent opens a
+            // new tab, auto-add it to the agent's tab group. The
+            // orchestrator handles create-on-first-call and
+            // serialises across racing tabs/new dispatches.
+            if (tool.name === 'tabs') {
+              const args = rawArgs as { action?: string } | null | undefined
+              if (args?.action === 'new') {
+                const pageId = (
+                  result.structuredContent as { page?: number } | undefined
+                )?.page
+                if (typeof pageId === 'number') {
+                  const { agentId, slug } = agentIdentityFromClient(identity)
+                  void ensureAgentTabGroup({
+                    agentId,
+                    slug,
+                    pageId,
+                    session,
+                    signal: extra?.signal,
+                  })
+                }
+              }
+            }
           } else {
             // Initialize was skipped or the session id is unknown;
             // the dispatch still succeeded but the homepage will not

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/mcp/single-server.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/mcp/single-server.ts
@@ -17,8 +17,15 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
+import { tabGroupTracker } from '../lib/agent-tab-groups'
+import { getBrowserSession } from '../lib/browser-session'
 import { logger } from '../lib/logger'
-import { type ClientIdentity, identityService } from '../lib/mcp-session'
+import {
+  agentIdentityFromClient,
+  type ClientIdentity,
+  identityService,
+} from '../lib/mcp-session'
+import { closeAgentTabGroupForAgent } from '../services/tab-group-ops'
 import { registerBrowserToolsForSingleServer } from './register'
 
 const SERVER_NAME = 'browseros-agent-mcp-interface'
@@ -50,6 +57,19 @@ function buildSession(): Session {
     sessionIdGenerator: () => crypto.randomUUID(),
     enableJsonResponse: true,
     onsessionclosed(sessionId) {
+      // Read identity BEFORE dropping it so the cleanup hook can
+      // resolve the agentId.
+      const identity = identityService.getIdentity(sessionId)
+      if (identity) {
+        const { agentId } = agentIdentityFromClient(identity)
+        const browserSession = getBrowserSession()
+        if (browserSession) {
+          void closeAgentTabGroupForAgent({
+            agentId,
+            session: browserSession,
+          })
+        }
+      }
       sessions.delete(sessionId)
       identityService.dropSession(sessionId)
       logger.info('cockpit v2 mcp session closed', { sessionId })
@@ -65,7 +85,7 @@ function buildSession(): Session {
     const sessionId = transport.sessionId
     if (!sessionId) return
     const clientInfo = server.server.getClientVersion()
-    identityService.registerInitialize({
+    const identity = identityService.registerInitialize({
       sessionId,
       clientInfo: {
         name: clientInfo?.name,
@@ -73,6 +93,11 @@ function buildSession(): Session {
         title: clientInfo?.title,
       },
     })
+    // Bump the tab-group tracker's per-agentId ref count so the
+    // close path only deletes the group when the last session for
+    // this agent ends.
+    const { agentId } = agentIdentityFromClient(identity)
+    tabGroupTracker.incrementSession(agentId)
     logger.info('cockpit v2 mcp session opened', {
       sessionId,
       clientName: clientInfo?.name ?? '',

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/routes/tabs-focus/index.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/routes/tabs-focus/index.ts
@@ -1,0 +1,32 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Powers the v2 homepage's Watch button. Looks up the agent's tab
+ * group via the shared tracker, expands it, and activates the window
+ * the group lives in so BrowserOS surfaces the live run.
+ *
+ * The work itself lives in `services/tab-group-ops.focusAgentTabGroup`;
+ * this route is the HTTP shape.
+ */
+
+import { Hono } from 'hono'
+import { getBrowserSession } from '../../lib/browser-session'
+import { focusAgentTabGroup } from '../../services/tab-group-ops'
+
+export const tabsFocusRoute = new Hono().post(
+  '/tabs/focus/:agentId',
+  async (c) => {
+    const agentId = c.req.param('agentId')
+    const session = getBrowserSession()
+    if (!session) {
+      return c.json({ ok: false, reason: 'browser session not connected' }, 503)
+    }
+    const result = await focusAgentTabGroup({ agentId, session })
+    if (!result.ok) {
+      return c.json(result, 404)
+    }
+    return c.json(result, 200)
+  },
+)

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/routes/tabs/agent-display.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/routes/tabs/agent-display.ts
@@ -11,15 +11,15 @@
  *      profile (PR 2 behaviour). Use the profile's `name`, `harness`.
  *   2. v2 path: the registry's `agentId` matches a live identity
  *      record (a slugified `clientInfo.name`). Use the identity's
- *      `clientTitle ?? clientName` as the label.
+ *      `clientTitle ?? clientName` as the label, and the hex matching
+ *      the agent's BrowserOS tab group colour so the homepage card's
+ *      left border visually matches the tab strip.
  *   3. final: the identity is gone (e.g. session closed before the
- *      homepage polled). Use the slug itself, harness/colour `null`.
- *
- * Colour is always `null` from the resolver; the UI applies its
- * slug-hash palette when the wire emits `null`. A future profile
- * schema can grow a stored colour without changing this helper.
+ *      homepage polled). Use the slug itself, harness null, colour
+ *      derived from the slug for stability.
  */
 
+import { hexForSlug } from '../../lib/agent-tab-groups'
 import type { ClientIdentity } from '../../lib/mcp-session'
 
 export interface AgentDisplay {
@@ -63,12 +63,12 @@ export function resolveAgentDisplay(
     return {
       agentLabel: label,
       harness: null,
-      color: null,
+      color: hexForSlug(slug),
     }
   }
   return {
     agentLabel: slug,
     harness: null,
-    color: null,
+    color: hexForSlug(slug),
   }
 }

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/server.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/server.ts
@@ -25,6 +25,7 @@ import { permissionsRoute } from './routes/permissions'
 import { siteRulesRoute } from './routes/site-rules'
 import { systemRoute } from './routes/system'
 import { tabsRoute } from './routes/tabs'
+import { tabsFocusRoute } from './routes/tabs-focus'
 
 // Telemetry capture is injectable so the server module stays usable
 // from the bun-test runner without pulling Sentry into the import
@@ -80,6 +81,7 @@ const routes = app
   .route('/', mcpV2Route)
   .route('/', mcpRoute)
   .route('/', tabsRoute)
+  .route('/', tabsFocusRoute)
   .route('/', connectionsRoute)
 
 export type AppType = typeof routes

--- a/packages/browseros-agent/apps/agent-mcp-interface/src/services/tab-group-ops.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/src/services/tab-group-ops.ts
@@ -1,0 +1,299 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * v2 cockpit-owned tab-group orchestration. The dispatch path in
+ * `mcp/register.ts` calls `ensureAgentTabGroup` after every
+ * successful `tabs new` so the cockpit (not the agent) drives
+ * `tab_groups create / update / close` on the agent's behalf.
+ * The session-close path in `mcp/single-server.ts` calls
+ * `closeAgentTabGroupForSession` before dropping the identity
+ * record so the group container disappears in BrowserOS when the
+ * agent disconnects.
+ *
+ * Both calls go through `executeTool` against the same
+ * `BROWSER_TOOLS` catalogue the agent sees. The cockpit cannot just
+ * call `tab_groups` over its MCP transport (that is the agent's
+ * transport, not ours), so we dispatch the tool directly through
+ * the framework, the same way the per-request handler does.
+ *
+ * Race handling: the FIRST `tabs new` per agent triggers a
+ * `tab_groups create`. While that create is in flight, a SECOND
+ * `tabs new` for the same agent would try to create a duplicate
+ * group. We guard with an in-flight promise map keyed by agentId so
+ * the second caller awaits the first call's result and then
+ * dispatches an "add to existing group" call instead.
+ */
+
+import type { BrowserSession } from '@browseros/server/browser/core/session'
+import type { ToolDefinition } from '@browseros/server/tools/browser/framework'
+import { executeTool } from '@browseros/server/tools/browser/framework'
+import { BROWSER_TOOLS } from '@browseros/server/tools/browser/registry'
+import { type TabGroupRecord, tabGroupTracker } from '../lib/agent-tab-groups'
+import { logger } from '../lib/logger'
+
+const TAB_GROUPS_TOOL: ToolDefinition = (() => {
+  const t = BROWSER_TOOLS.find((tool) => tool.name === 'tab_groups')
+  if (!t) {
+    throw new Error('tab_groups tool not found in BROWSER_TOOLS')
+  }
+  return t
+})()
+
+const WINDOWS_TOOL: ToolDefinition = (() => {
+  const t = BROWSER_TOOLS.find((tool) => tool.name === 'windows')
+  if (!t) {
+    throw new Error('windows tool not found in BROWSER_TOOLS')
+  }
+  return t
+})()
+
+interface EnsureInput {
+  agentId: string
+  slug: string
+  pageId: number
+  session: BrowserSession
+  signal?: AbortSignal
+}
+
+interface FocusInput {
+  agentId: string
+  session: BrowserSession
+  signal?: AbortSignal
+}
+
+interface CloseInput {
+  agentId: string
+  session: BrowserSession
+}
+
+/** In-flight create promises keyed by agentId. See file comment. */
+const inflight = new Map<string, Promise<void>>()
+
+function extractFirstText(result: { content: unknown }): string {
+  const arr = result.content as
+    | Array<{ type: string; text?: string }>
+    | undefined
+  return arr?.[0]?.text ?? ''
+}
+
+function readGroupId(result: { structuredContent?: unknown }): string | null {
+  const sc = result.structuredContent as
+    | { group?: { groupId?: string } }
+    | undefined
+  return sc?.group?.groupId ?? null
+}
+
+function readWindowId(result: { structuredContent?: unknown }): number | null {
+  const sc = result.structuredContent as
+    | { group?: { windowId?: number } }
+    | undefined
+  return typeof sc?.group?.windowId === 'number' ? sc.group.windowId : null
+}
+
+async function dispatchCreate(input: EnsureInput, record: TabGroupRecord) {
+  const result = await executeTool(
+    TAB_GROUPS_TOOL,
+    {
+      action: 'create',
+      pages: [input.pageId],
+      title: record.title,
+    },
+    { session: input.session, signal: input.signal },
+  )
+  if (result.isError) {
+    throw new Error(`tab_groups create failed: ${extractFirstText(result)}`)
+  }
+  const groupId = readGroupId(result)
+  const windowId = readWindowId(result)
+  if (!groupId) {
+    throw new Error('tab_groups create returned no groupId')
+  }
+  tabGroupTracker.rememberGroup({
+    agentId: input.agentId,
+    groupId,
+    windowId,
+  })
+  // Lock the colour separately. `tab_groups create` does not accept
+  // a colour today; update does. A failure here does not invalidate
+  // the group, just leaves the default colour.
+  const colorResult = await executeTool(
+    TAB_GROUPS_TOOL,
+    { action: 'update', groupId, color: record.color },
+    { session: input.session, signal: input.signal },
+  )
+  if (colorResult.isError) {
+    logger.warn('agent tab group color lock failed', {
+      agentId: input.agentId,
+      groupId,
+      error: extractFirstText(colorResult),
+    })
+  }
+  logger.info('agent tab group created', {
+    agentId: input.agentId,
+    groupId,
+    windowId,
+    color: record.color,
+  })
+}
+
+async function dispatchAddToGroup(input: EnsureInput, groupId: string) {
+  const result = await executeTool(
+    TAB_GROUPS_TOOL,
+    {
+      action: 'create',
+      groupId,
+      pages: [input.pageId],
+    },
+    { session: input.session, signal: input.signal },
+  )
+  if (!result.isError) return
+  // Most likely cause: the user (or the agent) closed the group out
+  // from under us. Blank the cockpit's record so the next `tabs new`
+  // takes the create-from-scratch path.
+  logger.warn('agent tab group add failed; resetting record', {
+    agentId: input.agentId,
+    groupId,
+    error: extractFirstText(result),
+  })
+  tabGroupTracker.forgetGroup(input.agentId)
+}
+
+/**
+ * Idempotent post-dispatch hook for `tabs new`. Creates the agent's
+ * tab group on the first call, adds the new page to the existing
+ * group on every subsequent call.
+ */
+export async function ensureAgentTabGroup(input: EnsureInput): Promise<void> {
+  const record = tabGroupTracker.recordOpen({
+    agentId: input.agentId,
+    slug: input.slug,
+    pageId: input.pageId,
+  })
+
+  // Serialise creates per agentId so two near-simultaneous `tabs new`
+  // calls do not race into two `tab_groups create` calls.
+  const existingInflight = inflight.get(input.agentId)
+  if (existingInflight) {
+    await existingInflight
+  }
+
+  const refreshed = tabGroupTracker.getByAgentId(input.agentId) ?? record
+  if (refreshed.groupId === null) {
+    const promise = dispatchCreate(input, refreshed).finally(() => {
+      inflight.delete(input.agentId)
+    })
+    inflight.set(input.agentId, promise)
+    try {
+      await promise
+    } catch (err) {
+      logger.warn('agent tab group create failed', {
+        agentId: input.agentId,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    }
+    return
+  }
+
+  try {
+    await dispatchAddToGroup(input, refreshed.groupId)
+  } catch (err) {
+    logger.warn('agent tab group add unexpected error', {
+      agentId: input.agentId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}
+
+/**
+ * Called from the transport's `onsessionclosed`. Decrements the ref
+ * count; only the final session for a given agentId closes the group
+ * in BrowserOS.
+ */
+export async function closeAgentTabGroupForAgent(
+  input: CloseInput,
+): Promise<void> {
+  const record = tabGroupTracker.decrementSession(input.agentId)
+  if (!record?.groupId) return
+  try {
+    const result = await executeTool(
+      TAB_GROUPS_TOOL,
+      { action: 'close', groupId: record.groupId },
+      { session: input.session },
+    )
+    if (result.isError) {
+      logger.warn('agent tab group close returned error', {
+        agentId: input.agentId,
+        groupId: record.groupId,
+        error: extractFirstText(result),
+      })
+      return
+    }
+    logger.info('agent tab group closed', {
+      agentId: input.agentId,
+      groupId: record.groupId,
+    })
+  } catch (err) {
+    logger.warn('agent tab group close threw', {
+      agentId: input.agentId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  }
+}
+
+/**
+ * Called by the focus route. Expands the agent's group (in case it
+ * was collapsed) and activates the window the group lives in so
+ * BrowserOS surfaces the live run for the user.
+ */
+export async function focusAgentTabGroup(input: FocusInput): Promise<{
+  ok: boolean
+  groupId?: string
+  windowId?: number
+  reason?: string
+}> {
+  const record = tabGroupTracker.getByAgentId(input.agentId)
+  if (!record?.groupId) {
+    return { ok: false, reason: 'no group for this agent' }
+  }
+  try {
+    const expand = await executeTool(
+      TAB_GROUPS_TOOL,
+      { action: 'update', groupId: record.groupId, collapsed: false },
+      { session: input.session, signal: input.signal },
+    )
+    if (expand.isError) {
+      return { ok: false, reason: extractFirstText(expand) }
+    }
+    if (typeof record.windowId === 'number') {
+      const activate = await executeTool(
+        WINDOWS_TOOL,
+        {
+          action: 'activate',
+          windowId: record.windowId,
+          activate: true,
+        },
+        { session: input.session, signal: input.signal },
+      )
+      if (activate.isError) {
+        logger.warn('windows activate failed during focus', {
+          agentId: input.agentId,
+          windowId: record.windowId,
+          error: extractFirstText(activate),
+        })
+        // The expand succeeded, so focus is partially honoured.
+      }
+    }
+    return {
+      ok: true,
+      groupId: record.groupId,
+      windowId: record.windowId ?? undefined,
+    }
+  } catch (err) {
+    return {
+      ok: false,
+      reason: err instanceof Error ? err.message : String(err),
+    }
+  }
+}

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/agent-tab-groups/group-color.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/agent-tab-groups/group-color.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'bun:test'
+import {
+  colorForSlug,
+  hexForSlug,
+  TAB_GROUP_COLORS,
+  TAB_GROUP_HEX,
+} from '../../../src/lib/agent-tab-groups/group-color'
+
+describe('colorForSlug', () => {
+  it('returns the same colour for the same slug across calls', () => {
+    expect(colorForSlug('claude-code')).toBe(colorForSlug('claude-code'))
+    expect(colorForSlug('cursor-bot')).toBe(colorForSlug('cursor-bot'))
+  })
+
+  it('returns one of the nine allowed tab_groups colours', () => {
+    for (const slug of ['claude-code', 'cursor', 'codex', 'zed', 'vscode']) {
+      expect(TAB_GROUP_COLORS).toContain(colorForSlug(slug))
+    }
+  })
+
+  it('distributes common harness names across several colours, not all the same', () => {
+    const slugs = [
+      'claude-code',
+      'cursor',
+      'codex',
+      'zed',
+      'vscode',
+      'claude-desktop',
+      'gemini',
+    ]
+    const colours = new Set(slugs.map(colorForSlug))
+    expect(colours.size).toBeGreaterThanOrEqual(3)
+  })
+
+  it('returns a defined colour even for empty / unicode-degenerate slugs', () => {
+    expect(TAB_GROUP_COLORS).toContain(colorForSlug(''))
+    expect(TAB_GROUP_COLORS).toContain(colorForSlug('unknown-abc123'))
+  })
+})
+
+describe('hexForSlug', () => {
+  it('returns the hex matching the colour pick', () => {
+    const slug = 'claude-code'
+    expect(hexForSlug(slug)).toBe(TAB_GROUP_HEX[colorForSlug(slug)])
+  })
+
+  it('looks like a hex colour', () => {
+    expect(hexForSlug('zed')).toMatch(/^#[0-9A-F]{6}$/)
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/agent-tab-groups/tracker.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/lib/agent-tab-groups/tracker.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'bun:test'
+import { createTabGroupTracker } from '../../../src/lib/agent-tab-groups/tracker'
+
+function setup(nowMs = 1_000_000) {
+  return createTabGroupTracker({ now: () => nowMs })
+}
+
+describe('createTabGroupTracker', () => {
+  it('creates a record on first recordOpen and adds pages on subsequent calls', () => {
+    const t = setup()
+    const a = t.recordOpen({
+      agentId: 'claude-code',
+      slug: 'claude-code',
+      pageId: 1,
+    })
+    expect(a.groupId).toBeNull()
+    expect(Array.from(a.pageIds)).toEqual([1])
+    const b = t.recordOpen({
+      agentId: 'claude-code',
+      slug: 'claude-code',
+      pageId: 2,
+    })
+    expect(b).toBe(a)
+    expect(Array.from(a.pageIds).sort()).toEqual([1, 2])
+  })
+
+  it('keeps records per agentId independent', () => {
+    const t = setup()
+    t.recordOpen({ agentId: 'claude-code', slug: 'claude-code', pageId: 1 })
+    t.recordOpen({ agentId: 'cursor', slug: 'cursor', pageId: 2 })
+    expect(t.size()).toBe(2)
+    expect(t.getByAgentId('claude-code')?.slug).toBe('claude-code')
+    expect(t.getByAgentId('cursor')?.slug).toBe('cursor')
+  })
+
+  it('rememberGroup stamps groupId and windowId', () => {
+    const t = setup()
+    t.recordOpen({ agentId: 'a', slug: 'a', pageId: 1 })
+    t.rememberGroup({ agentId: 'a', groupId: 'G1', windowId: 99 })
+    const r = t.getByAgentId('a')
+    expect(r?.groupId).toBe('G1')
+    expect(r?.windowId).toBe(99)
+  })
+
+  it('rememberGroup is a no-op when no record exists', () => {
+    const t = setup()
+    t.rememberGroup({ agentId: 'ghost', groupId: 'G' })
+    expect(t.size()).toBe(0)
+  })
+
+  it('refCount starts at 0; incrementSession adds, decrementSession removes', () => {
+    const t = setup()
+    t.recordOpen({ agentId: 'a', slug: 'a', pageId: 1 })
+    expect(t.getByAgentId('a')?.refCount).toBe(0)
+    t.incrementSession('a')
+    expect(t.getByAgentId('a')?.refCount).toBe(1)
+    t.incrementSession('a')
+    expect(t.getByAgentId('a')?.refCount).toBe(2)
+  })
+
+  it('decrementSession returns null while sessions remain, and the record on the final drop', () => {
+    const t = setup()
+    t.recordOpen({ agentId: 'a', slug: 'a', pageId: 1 })
+    t.incrementSession('a')
+    t.incrementSession('a')
+    expect(t.decrementSession('a')).toBeNull()
+    expect(t.size()).toBe(1)
+    const final = t.decrementSession('a')
+    expect(final).not.toBeNull()
+    expect(final?.agentId).toBe('a')
+    expect(t.size()).toBe(0)
+  })
+
+  it('incrementSession before recordOpen pre-seeds an empty record', () => {
+    const t = setup()
+    t.incrementSession('claude-code')
+    const r = t.getByAgentId('claude-code')
+    expect(r?.refCount).toBe(1)
+    expect(r?.pageIds.size).toBe(0)
+    expect(r?.groupId).toBeNull()
+  })
+
+  it('decrementSession on unknown agentId returns null cleanly', () => {
+    const t = setup()
+    expect(t.decrementSession('nope')).toBeNull()
+  })
+
+  it('forgetGroup clears the groupId so the next tabs new triggers a fresh create', () => {
+    const t = setup()
+    t.recordOpen({ agentId: 'a', slug: 'a', pageId: 1 })
+    t.rememberGroup({ agentId: 'a', groupId: 'G1', windowId: 1 })
+    t.forgetGroup('a')
+    const r = t.getByAgentId('a')
+    expect(r?.groupId).toBeNull()
+    expect(r?.windowId).toBeNull()
+    expect(r?.pageIds.size).toBe(0)
+  })
+
+  it('reset empties the entire map', () => {
+    const t = setup()
+    t.recordOpen({ agentId: 'a', slug: 'a', pageId: 1 })
+    t.recordOpen({ agentId: 'b', slug: 'b', pageId: 2 })
+    t.reset()
+    expect(t.size()).toBe(0)
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/tabs-focus/routes.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/tabs-focus/routes.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Walks the focus route against the in-process Hono app. Mocks the
+ * orchestration service so the test does not need a real browser
+ * session attached.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+// Same isolation note as tab-group-ops.test.ts: only mock the
+// framework, not the registry, so the real BROWSER_TOOLS catalogue
+// stays intact for other suites in the same `bun test` run.
+mock.module('@browseros/server/tools/browser/framework', () => ({
+  executeTool: async () => ({
+    isError: false,
+    content: [{ type: 'text', text: 'ok' }],
+  }),
+}))
+
+const { setBrowserSession } = await import('../../../src/lib/browser-session')
+const { tabGroupTracker } = await import('../../../src/lib/agent-tab-groups')
+const app = (await import('../../../src/server')).default
+
+describe('POST /cockpit/tabs/focus/:agentId', () => {
+  beforeEach(() => {
+    tabGroupTracker.reset()
+  })
+  afterEach(() => {
+    tabGroupTracker.reset()
+    setBrowserSession(null)
+  })
+
+  it('returns 503 when no browser session is attached', async () => {
+    setBrowserSession(null)
+    const res = await app.fetch(
+      new Request('http://localhost/tabs/focus/claude-code', {
+        method: 'POST',
+      }),
+    )
+    expect(res.status).toBe(503)
+    const body = (await res.json()) as { ok: boolean; reason: string }
+    expect(body.ok).toBe(false)
+    expect(body.reason).toContain('browser session')
+  })
+
+  it('returns 404 when the agent has no tracked group', async () => {
+    setBrowserSession({} as never)
+    const res = await app.fetch(
+      new Request('http://localhost/tabs/focus/unknown', { method: 'POST' }),
+    )
+    expect(res.status).toBe(404)
+    const body = (await res.json()) as { ok: boolean }
+    expect(body.ok).toBe(false)
+  })
+
+  it('returns 200 ok with groupId + windowId on the happy path', async () => {
+    setBrowserSession({} as never)
+    tabGroupTracker.recordOpen({
+      agentId: 'claude-code',
+      slug: 'claude-code',
+      pageId: 1,
+    })
+    tabGroupTracker.rememberGroup({
+      agentId: 'claude-code',
+      groupId: 'G1',
+      windowId: 42,
+    })
+    const res = await app.fetch(
+      new Request('http://localhost/tabs/focus/claude-code', {
+        method: 'POST',
+      }),
+    )
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as {
+      ok: boolean
+      groupId: string
+      windowId: number
+    }
+    expect(body).toEqual({ ok: true, groupId: 'G1', windowId: 42 })
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/tabs/agent-display.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/tabs/agent-display.test.ts
@@ -40,7 +40,7 @@ describe('resolveAgentDisplay', () => {
     })
   })
 
-  test('identity wins when no profile, prefers clientTitle', () => {
+  test('identity wins when no profile, prefers clientTitle, and the colour matches the tab-group hex', () => {
     const result = resolveAgentDisplay('claude-code', 'claude-code', {
       profilesById: new Map(),
       identitiesByAgentId: new Map([
@@ -54,11 +54,9 @@ describe('resolveAgentDisplay', () => {
         ],
       ]),
     })
-    expect(result).toEqual({
-      agentLabel: 'Claude Code',
-      harness: null,
-      color: null,
-    })
+    expect(result.agentLabel).toBe('Claude Code')
+    expect(result.harness).toBeNull()
+    expect(result.color).toMatch(/^#[0-9A-F]{6}$/)
   })
 
   test('identity falls back to clientName when title missing', () => {
@@ -75,15 +73,13 @@ describe('resolveAgentDisplay', () => {
     expect(result.harness).toBeNull()
   })
 
-  test('no profile, no identity falls back to slug', () => {
+  test('no profile, no identity falls back to slug and still emits a hex colour', () => {
     const result = resolveAgentDisplay('unknown-abc123', 'unknown-abc123', {
       profilesById: new Map(),
       identitiesByAgentId: new Map(),
     })
-    expect(result).toEqual({
-      agentLabel: 'unknown-abc123',
-      harness: null,
-      color: null,
-    })
+    expect(result.agentLabel).toBe('unknown-abc123')
+    expect(result.harness).toBeNull()
+    expect(result.color).toMatch(/^#[0-9A-F]{6}$/)
   })
 })

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/tabs/routes.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/routes/tabs/routes.test.ts
@@ -145,7 +145,9 @@ describe('/tabs/activity route', () => {
       expect(body.tabs).toHaveLength(1)
       expect(body.tabs[0].agentLabel).toBe('orphan-slug')
       expect(body.tabs[0].harness).toBeNull()
-      expect(body.tabs[0].color).toBeNull()
+      // Phase 4 fills colour from the deterministic agent-tab-groups
+      // hex even when no identity record is around.
+      expect(body.tabs[0].color).toMatch(/^#[0-9A-F]{6}$/)
     })
   })
 })

--- a/packages/browseros-agent/apps/agent-mcp-interface/tests/services/tab-group-ops.test.ts
+++ b/packages/browseros-agent/apps/agent-mcp-interface/tests/services/tab-group-ops.test.ts
@@ -1,0 +1,282 @@
+/**
+ * Stubs the `@browseros/server` browser-tool framework so we can drive
+ * the orchestrator with synthetic results and assert on the dispatch
+ * shape. Bun's `mock.module` works fine because all consumers of the
+ * framework resolve through the same module specifier.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+
+interface CallEntry {
+  toolName: string
+  args: Record<string, unknown>
+}
+
+interface FakeResult {
+  isError: boolean
+  content: Array<{ type: 'text'; text: string }>
+  structuredContent?: unknown
+}
+
+const calls: CallEntry[] = []
+const queued: FakeResult[] = []
+
+function nextResult(toolName: string): FakeResult {
+  const r = queued.shift()
+  if (!r) {
+    throw new Error(`tab-group-ops.test: no queued result for ${toolName}`)
+  }
+  return r
+}
+
+// We deliberately mock only `executeTool` (not BROWSER_TOOLS) because
+// `mock.module` persists across files in the same `bun test` run, and
+// the v2 dispatch suite needs the real BROWSER_TOOLS catalogue. The
+// real `tab_groups` and `windows` ToolDefinition objects pass through
+// our orchestrator untouched; we just short-circuit the dispatch.
+mock.module('@browseros/server/tools/browser/framework', () => ({
+  executeTool: async (def: { name: string }, args: Record<string, unknown>) => {
+    calls.push({ toolName: def.name, args })
+    return nextResult(def.name)
+  },
+}))
+
+// IMPORTANT: dynamic import happens AFTER the module mocks above.
+const { tabGroupTracker } = await import('../../src/lib/agent-tab-groups')
+const { ensureAgentTabGroup, closeAgentTabGroupForAgent, focusAgentTabGroup } =
+  await import('../../src/services/tab-group-ops')
+
+const fakeSession = {} as never
+
+function queue(...rs: FakeResult[]) {
+  queued.push(...rs)
+}
+
+function ok(structured?: unknown): FakeResult {
+  return {
+    isError: false,
+    content: [{ type: 'text', text: 'ok' }],
+    structuredContent: structured,
+  }
+}
+
+function err(msg: string): FakeResult {
+  return {
+    isError: true,
+    content: [{ type: 'text', text: msg }],
+  }
+}
+
+describe('ensureAgentTabGroup', () => {
+  beforeEach(() => {
+    calls.length = 0
+    queued.length = 0
+    tabGroupTracker.reset()
+  })
+  afterEach(() => {
+    queued.length = 0
+  })
+
+  it('first open creates the group, locks the colour, and remembers groupId + windowId', async () => {
+    queue(
+      ok({ group: { groupId: 'G1', windowId: 42, title: 'claude-code' } }),
+      ok(),
+    )
+    await ensureAgentTabGroup({
+      agentId: 'claude-code',
+      slug: 'claude-code',
+      pageId: 1,
+      session: fakeSession,
+    })
+    expect(calls.length).toBe(2)
+    expect(calls[0]?.toolName).toBe('tab_groups')
+    expect(calls[0]?.args).toMatchObject({
+      action: 'create',
+      pages: [1],
+      title: 'claude-code',
+    })
+    expect(calls[1]?.args).toMatchObject({
+      action: 'update',
+      groupId: 'G1',
+    })
+    const record = tabGroupTracker.getByAgentId('claude-code')
+    expect(record?.groupId).toBe('G1')
+    expect(record?.windowId).toBe(42)
+    expect(record?.color).toBeDefined()
+  })
+
+  it('subsequent opens add the new page to the existing group instead of creating a duplicate', async () => {
+    queue(ok({ group: { groupId: 'G1', windowId: 42 } }), ok(), ok())
+    await ensureAgentTabGroup({
+      agentId: 'cursor',
+      slug: 'cursor',
+      pageId: 1,
+      session: fakeSession,
+    })
+    await ensureAgentTabGroup({
+      agentId: 'cursor',
+      slug: 'cursor',
+      pageId: 2,
+      session: fakeSession,
+    })
+    expect(calls.length).toBe(3)
+    // 1st call: create. 2nd: update (colour). 3rd: add to existing group.
+    expect(calls[2]?.args).toMatchObject({
+      action: 'create',
+      groupId: 'G1',
+      pages: [2],
+    })
+  })
+
+  it('swallows tab_groups create errors so the tabs new path is never blocked', async () => {
+    queue(err('manager down'))
+    await ensureAgentTabGroup({
+      agentId: 'zed',
+      slug: 'zed',
+      pageId: 1,
+      session: fakeSession,
+    })
+    const record = tabGroupTracker.getByAgentId('zed')
+    expect(record).not.toBeNull()
+    expect(record?.groupId).toBeNull()
+  })
+
+  it('forgets the stale groupId when add-to-group errors so the next call recreates', async () => {
+    queue(
+      ok({ group: { groupId: 'G1', windowId: 1 } }),
+      ok(),
+      err('group not found'),
+    )
+    await ensureAgentTabGroup({
+      agentId: 'codex',
+      slug: 'codex',
+      pageId: 1,
+      session: fakeSession,
+    })
+    await ensureAgentTabGroup({
+      agentId: 'codex',
+      slug: 'codex',
+      pageId: 2,
+      session: fakeSession,
+    })
+    expect(tabGroupTracker.getByAgentId('codex')?.groupId).toBeNull()
+  })
+
+  it('serialises near-simultaneous opens so only one create dispatches', async () => {
+    queue(ok({ group: { groupId: 'G1', windowId: 1 } }), ok(), ok())
+    await Promise.all([
+      ensureAgentTabGroup({
+        agentId: 'parallel',
+        slug: 'parallel',
+        pageId: 1,
+        session: fakeSession,
+      }),
+      ensureAgentTabGroup({
+        agentId: 'parallel',
+        slug: 'parallel',
+        pageId: 2,
+        session: fakeSession,
+      }),
+    ])
+    const creates = calls.filter(
+      (c) =>
+        c.toolName === 'tab_groups' &&
+        (c.args as { action?: string }).action === 'create' &&
+        (c.args as { groupId?: string }).groupId === undefined,
+    )
+    expect(creates.length).toBe(1)
+  })
+})
+
+describe('closeAgentTabGroupForAgent', () => {
+  beforeEach(() => {
+    calls.length = 0
+    queued.length = 0
+    tabGroupTracker.reset()
+  })
+
+  it('closes the group when the ref count hits zero', async () => {
+    queue(ok({ group: { groupId: 'G1', windowId: 1 } }), ok(), ok())
+    await ensureAgentTabGroup({
+      agentId: 'a',
+      slug: 'a',
+      pageId: 1,
+      session: fakeSession,
+    })
+    tabGroupTracker.incrementSession('a')
+    await closeAgentTabGroupForAgent({ agentId: 'a', session: fakeSession })
+    const closeCall = calls.find(
+      (c) => (c.args as { action?: string }).action === 'close',
+    )
+    expect(closeCall).toBeDefined()
+    expect((closeCall?.args as { groupId?: string }).groupId).toBe('G1')
+  })
+
+  it('keeps the group alive when at least one other session still references the agentId', async () => {
+    queue(ok({ group: { groupId: 'G1', windowId: 1 } }), ok())
+    await ensureAgentTabGroup({
+      agentId: 'a',
+      slug: 'a',
+      pageId: 1,
+      session: fakeSession,
+    })
+    tabGroupTracker.incrementSession('a')
+    tabGroupTracker.incrementSession('a')
+    await closeAgentTabGroupForAgent({ agentId: 'a', session: fakeSession })
+    const closeCall = calls.find(
+      (c) => (c.args as { action?: string }).action === 'close',
+    )
+    expect(closeCall).toBeUndefined()
+  })
+
+  it('is a no-op when the agentId has no tracker record', async () => {
+    await closeAgentTabGroupForAgent({ agentId: 'ghost', session: fakeSession })
+    expect(calls.length).toBe(0)
+  })
+})
+
+describe('focusAgentTabGroup', () => {
+  beforeEach(() => {
+    calls.length = 0
+    queued.length = 0
+    tabGroupTracker.reset()
+  })
+
+  it('returns ok=false when the tracker has no group for the agent', async () => {
+    const r = await focusAgentTabGroup({
+      agentId: 'unknown',
+      session: fakeSession,
+    })
+    expect(r.ok).toBe(false)
+  })
+
+  it('expands the group and activates the window for a tracked agent', async () => {
+    queue(ok({ group: { groupId: 'G1', windowId: 42 } }), ok(), ok(), ok())
+    await ensureAgentTabGroup({
+      agentId: 'a',
+      slug: 'a',
+      pageId: 1,
+      session: fakeSession,
+    })
+    const r = await focusAgentTabGroup({
+      agentId: 'a',
+      session: fakeSession,
+    })
+    expect(r.ok).toBe(true)
+    expect(r.groupId).toBe('G1')
+    expect(r.windowId).toBe(42)
+    const expand = calls.find(
+      (c) =>
+        (c.args as { action?: string }).action === 'update' &&
+        (c.args as { collapsed?: boolean }).collapsed === false,
+    )
+    expect(expand).toBeDefined()
+    const activate = calls.find(
+      (c) =>
+        c.toolName === 'windows' &&
+        (c.args as { action?: string }).action === 'activate',
+    )
+    expect(activate).toBeDefined()
+    expect((activate?.args as { windowId?: number }).windowId).toBe(42)
+  })
+})

--- a/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/AgentRunningCard.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/AgentRunningCard.tsx
@@ -10,6 +10,8 @@ interface AgentRunningCardProps {
   agent: AgentActivityRecord
   onWatch?: () => void
   onStop?: () => void
+  /** When the focus mutation is in flight for this card. */
+  isFocusPending?: boolean
 }
 
 /**
@@ -26,6 +28,7 @@ export function AgentRunningCard({
   agent,
   onWatch,
   onStop,
+  isFocusPending,
 }: AgentRunningCardProps) {
   const focus = agent.currentFocus
   const active = agent.status === 'active'
@@ -35,7 +38,8 @@ export function AgentRunningCard({
   return (
     <Card
       data-agent-card
-      className="group flex cursor-pointer flex-col overflow-hidden border-border-2 p-0 transition hover:border-border-strong hover:shadow-card"
+      className="group flex cursor-pointer flex-col overflow-hidden border-border-2 border-l-4 p-0 transition hover:border-border-strong hover:shadow-card"
+      style={{ borderLeftColor: agent.color }}
     >
       <MiniScreencast site={siteOf(focus.url)} live={active} />
       <div className="flex flex-1 flex-col gap-2 p-3.5">
@@ -79,9 +83,15 @@ export function AgentRunningCard({
           <button
             type="button"
             onClick={onWatch}
-            className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-md px-2 py-1.5 font-semibold text-[12.5px] text-ink-2 transition hover:bg-bg-sunken hover:text-ink"
+            disabled={isFocusPending}
+            className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-md px-2 py-1.5 font-semibold text-[12.5px] text-ink-2 transition hover:bg-bg-sunken hover:text-ink disabled:cursor-not-allowed disabled:opacity-60"
           >
-            <ExternalLink className="size-3.5" /> Watch
+            {isFocusPending ? (
+              <RefreshCw className="size-3.5 animate-spin" />
+            ) : (
+              <ExternalLink className="size-3.5" />
+            )}{' '}
+            Watch
           </button>
           {active && (
             <button

--- a/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/RunningGrid.test.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/RunningGrid.test.tsx
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router'
 import type { TabActivityRecord } from '@/modules/api/tabs.hooks'
@@ -6,7 +7,14 @@ import type { AgentActivityRecord } from '@/screens/cockpit/cockpit.helpers'
 import { RunningGrid } from './RunningGrid'
 
 function renderWithRouter(ui: React.ReactNode): string {
-  return renderToStaticMarkup(<MemoryRouter>{ui}</MemoryRouter>)
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  })
+  return renderToStaticMarkup(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </QueryClientProvider>,
+  )
 }
 
 function tab(over: Partial<TabActivityRecord> = {}): TabActivityRecord {

--- a/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/RunningGrid.tsx
+++ b/packages/browseros-agent/apps/agent-mcp-ui/components/cockpit/RunningGrid.tsx
@@ -1,4 +1,5 @@
-import { Link, useNavigate } from 'react-router'
+import { Link } from 'react-router'
+import { useFocusAgent } from '@/modules/api/focus.hooks'
 import type { AgentActivityRecord } from '@/screens/cockpit/cockpit.helpers'
 import { AgentRunningCard } from './AgentRunningCard'
 import { EmptyState } from './EmptyState'
@@ -11,13 +12,30 @@ interface RunningGridProps {
  * One uniform card per rolled-up agent. v2 has no per-agent profile
  * directory, so the trailing "New profile" tile is gone; the
  * AddAgentTile file stays on disk with a TODO header that names what
- * brings it back. When the registry is empty, the section keeps its
- * header and renders a centred empty-state card pointing the operator
- * at the MCP page.
+ * brings it back. Watch focuses the agent's tab group in BrowserOS
+ * via `POST /cockpit/tabs/focus/:agentId`. When the registry is
+ * empty, the section keeps its header and renders a centred
+ * empty-state card pointing the operator at the MCP page.
  */
 export function RunningGrid({ agents }: RunningGridProps) {
-  const navigate = useNavigate()
+  const focus = useFocusAgent()
   const liveCount = agents.filter((a) => a.status === 'active').length
+
+  const onWatch = (agentId: string) => {
+    focus.mutate(
+      { agentId },
+      {
+        onError: (err) => {
+          // No toast surface in v2 yet; surface a console line so the
+          // operator can read it from devtools while developing.
+          // eslint-disable-next-line no-console
+          console.warn('focus agent failed', { agentId, err })
+        },
+      },
+    )
+  }
+  const pendingAgentId =
+    focus.isPending && focus.variables ? focus.variables.agentId : null
 
   return (
     <section className="space-y-3">
@@ -53,7 +71,8 @@ export function RunningGrid({ agents }: RunningGridProps) {
             <AgentRunningCard
               key={a.agentId}
               agent={a}
-              onWatch={() => navigate(`/run/${a.currentFocus.targetId}`)}
+              onWatch={() => onWatch(a.agentId)}
+              isFocusPending={pendingAgentId === a.agentId}
             />
           ))}
         </div>

--- a/packages/browseros-agent/apps/agent-mcp-ui/modules/api/focus.hooks.ts
+++ b/packages/browseros-agent/apps/agent-mcp-ui/modules/api/focus.hooks.ts
@@ -1,0 +1,36 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * react-query-kit mutation backing the homepage's Watch button.
+ * Hits `POST /cockpit/tabs/focus/:agentId`; the server expands the
+ * agent's tab group in BrowserOS and activates the group's window.
+ */
+
+import { createMutation } from 'react-query-kit'
+import { api } from './client'
+import { parseResponse } from './parseResponse'
+
+export interface FocusAgentResult {
+  ok: boolean
+  groupId?: string
+  windowId?: number
+  reason?: string
+}
+
+interface FocusAgentVariables {
+  agentId: string
+}
+
+export const useFocusAgent = createMutation<
+  FocusAgentResult,
+  FocusAgentVariables
+>({
+  mutationFn: async ({ agentId }) => {
+    const response = await api.tabs.focus[':agentId'].$post({
+      param: { agentId },
+    })
+    return parseResponse<FocusAgentResult>(response)
+  },
+})


### PR DESCRIPTION
## Summary

Every active MCP session is now a tab group in BrowserOS. The cockpit auto-creates the group on the agent's first `tabs new`, auto-adds every subsequent tab the agent opens, and closes the group container (tabs stay open, only the container disappears) when the last session for that agentId ends. Two parallel sessions sharing a `clientInfo.name` share one group via per-agent ref counting.

The homepage's "Watch" button stops dead-linking and starts focusing the agent's tab group in BrowserOS via a new `POST /cockpit/tabs/focus/:agentId` route. Each running card gets a 4 px left border in the agent's tab-group colour so the cockpit and BrowserOS pattern-match visually.

## Architecture

- **Server-side tracker** at `lib/agent-tab-groups/`: in-memory, ref-counted per `agentId`. Stores `groupId`, `windowId`, `pageIds`, deterministic `color`, ref count. Resets cleanly when the agent (or the user) closes the group out from under the cockpit.
- **Orchestrator** at `services/tab-group-ops.ts`: `ensureAgentTabGroup`, `closeAgentTabGroupForAgent`, `focusAgentTabGroup`. Calls go through `executeTool` against the existing `tab_groups` and `windows` browser tools. A per-agentId in-flight promise serialises near-simultaneous `tabs new` dispatches so only one `tab_groups create` ever runs per agent.
- **Dispatch hook** in `mcp/register.ts`: after every successful `tabs new`, read `extra.sessionId` → identity → agentId, call `ensureAgentTabGroup`.
- **Lifecycle wiring** in `mcp/single-server.ts`: `oninitialized` bumps ref count, `onsessionclosed` reads identity before drop, decrements ref count, dispatches `tab_groups close` on the final session.
- **Focus route** at `routes/tabs-focus/`: looks up the tracker, expands the group (`tab_groups update collapsed:false`), activates the window (`windows activate windowId`).
- **Colour parity** in `routes/tabs/agent-display.ts`: `color` field now ships a hex matching the agent's tab-group colour, instead of always-null.

## Tested against the live cockpit

Probed `tab_groups create` response shape against the running cockpit on 127.0.0.1:9100 before writing the orchestrator. Confirmed:

- `structuredContent.group.{groupId, windowId, title, color, collapsed, pageIds}`.
- `tab_groups create` does not accept a `color` arg; `tab_groups update` does. Orchestrator handles the colour lock as a separate dispatch after create.
- `windows activate` accepts `{windowId, activate: true}`.

## UI changes

- New `useFocusAgent` hook (`modules/api/focus.hooks.ts`).
- `RunningGrid` wires Watch to the mutation; failures log to console (no toast surface yet, Phase 5 territory).
- `AgentRunningCard` gets `border-l-4` with `borderLeftColor: agent.color` and a Watch button that shows a spinner while the mutation is in flight.

## Tests

- Backend: 174 → 203 pass (29 new).
  - `lib/agent-tab-groups/group-color.test.ts`: 6 tests covering stability, palette membership, distribution, degenerate slugs.
  - `lib/agent-tab-groups/tracker.test.ts`: 10 tests covering open / increment / decrement / forget / pre-seed cases.
  - `services/tab-group-ops.test.ts`: 10 tests stubbing `executeTool` to assert the orchestration shape (create + colour-lock, add-to-group, swallow failures, recreate on stale group, serialise parallel opens, ref-counted close, focus expand + activate).
  - `routes/tabs-focus/routes.test.ts`: 3 tests covering 503 / 404 / 200 paths.
- UI: 92 → 92 pass. The `RunningGrid` test gets a `QueryClientProvider` wrapper for the new focus hook.
- Workspace typecheck clean on both packages.

## Test plan

- [x] `bun --cwd apps/agent-mcp-interface test` → 203 pass
- [x] `bun --cwd apps/agent-mcp-ui test` → 92 pass
- [x] Typecheck clean on both touched packages
- [ ] Manual smoke against a freshly built BrowserOS: run the 5-agent parallel rig, confirm 5 tab groups appear in BrowserOS each with the agent slug as title, confirm killing a session deletes its group but leaves the tabs open, confirm Watch focuses the right window.

## Notes for review

- No new feature flag. Auto-grouping is unconditional v2 behaviour, per Dani's "every agent will create its own tab group" requirement.
- The tools/list description-augmentation idea from the plan is deferred to a follow-up. The SDK's tool registration API does not expose a clean per-session description override and the practical UX impact is small (the agent does not need to know about its group; the cockpit groups silently).
- The `RunningGrid` test's earlier four failures (before adding the `QueryClientProvider` wrapper) prove the static-markup harness still catches missing context providers cleanly.
- Pre-existing complexity warning in `register.ts` (legacy `registerBrowserTools`, score 45 vs threshold 30) is not from this PR; biome flagged it during pre-commit but it has been over the limit since before Phase 0.