### PR TITLE
fix(cli): support compact browser tools

### DIFF
--- a/packages/browseros-agent/apps/cli/analytics/analytics.go
+++ b/packages/browseros-agent/apps/cli/analytics/analytics.go
@@ -25,7 +25,7 @@ const eventPrefix = "browseros.cli."
 var svc *service
 
 type service struct {
-	client    posthog.Client
+	client     posthog.Client
 	distinctID string
 }
 

--- a/packages/browseros-agent/apps/cli/cmd/bookmark.go
+++ b/packages/browseros-agent/apps/cli/cmd/bookmark.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"fmt"
+	"strings"
+
+	"browseros-cli/mcp"
 	"browseros-cli/output"
 
 	"github.com/spf13/cobra"
@@ -19,7 +23,13 @@ func init() {
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			c := newClient()
-			result, err := c.CallTool("get_bookmarks", nil)
+			result, err := runBookmarkCommand(c, "getBookmarks", map[string]any{}, func(value any) *mcp.ToolResult {
+				nodes := valueSlice(value)
+				return textResult(formatBookmarkList(nodes), map[string]any{
+					"bookmarks": nodes,
+					"count":     len(nodes),
+				})
+			})
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -45,7 +55,19 @@ func init() {
 				toolArgs["parentId"] = parent
 			}
 			c := newClient()
-			result, err := c.CallTool("create_bookmark", toolArgs)
+			result, err := runBookmarkCommand(c, "createBookmark", toolArgs, func(value any) *mcp.ToolResult {
+				node, _ := valueMap(value)
+				title := stringValue(node["title"])
+				id := stringValue(node["id"])
+				message := fmt.Sprintf("Created folder: %s\nID: %s", title, id)
+				if url := stringValue(node["url"]); url != "" {
+					message = fmt.Sprintf("Created bookmark: %s\nURL: %s\nID: %s", title, url, id)
+				}
+				return textResult(message, map[string]any{
+					"action":   "create_bookmark",
+					"bookmark": node,
+				})
+			})
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -64,10 +86,17 @@ func init() {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			c := newClient()
-			result, err := c.CallTool("remove_bookmark", map[string]any{"id": args[0]})
+			id := args[0]
+			_, value, err := browserRunValue(c, fmt.Sprintf(
+				`await browser.cdp('Bookmarks.removeBookmark', { id: %s })
+return { action: 'remove_bookmark', id: %s }`,
+				jsLiteral(id),
+				jsLiteral(id),
+			))
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
+			result := textResult(fmt.Sprintf("Removed bookmark %s", id), resultData(value))
 			if jsonOut {
 				output.JSON(result)
 			} else {
@@ -91,7 +120,16 @@ func init() {
 				toolArgs["url"] = url
 			}
 			c := newClient()
-			result, err := c.CallTool("update_bookmark", toolArgs)
+			result, err := runBookmarkCommand(c, "updateBookmark", toolArgs, func(value any) *mcp.ToolResult {
+				node, _ := valueMap(value)
+				return textResult(
+					fmt.Sprintf("Updated bookmark: %s\nID: %s", stringValue(node["title"]), stringValue(node["id"])),
+					map[string]any{
+						"action":   "update_bookmark",
+						"bookmark": node,
+					},
+				)
+			})
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -120,7 +158,16 @@ func init() {
 				toolArgs["index"] = index
 			}
 			c := newClient()
-			result, err := c.CallTool("move_bookmark", toolArgs)
+			result, err := runBookmarkCommand(c, "moveBookmark", toolArgs, func(value any) *mcp.ToolResult {
+				node, _ := valueMap(value)
+				return textResult(
+					fmt.Sprintf("Moved: %s", stringValue(node["title"])),
+					map[string]any{
+						"action":   "move_bookmark",
+						"bookmark": node,
+					},
+				)
+			})
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -140,7 +187,19 @@ func init() {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			c := newClient()
-			result, err := c.CallTool("search_bookmarks", map[string]any{"query": args[0]})
+			query := args[0]
+			result, err := runBookmarkCommand(c, "searchBookmarks", map[string]any{"query": query}, func(value any) *mcp.ToolResult {
+				nodes := valueSlice(value)
+				message := fmt.Sprintf("No bookmarks found matching %q.", query)
+				if len(nodes) > 0 {
+					message = fmt.Sprintf("Found %d bookmarks matching %q:\n\n%s", len(nodes), query, formatBookmarkTree(nodes))
+				}
+				return textResult(message, map[string]any{
+					"query":     query,
+					"bookmarks": nodes,
+					"count":     len(nodes),
+				})
+			})
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -154,4 +213,53 @@ func init() {
 
 	bookmarkCmd.AddCommand(listCmd, createCmd, removeCmd, updateCmd, moveCmd, searchCmd)
 	rootCmd.AddCommand(bookmarkCmd)
+}
+
+// runBookmarkCommand bridges bookmark subcommands through the compact run tool's CDP escape hatch.
+func runBookmarkCommand(c *mcp.Client, method string, params map[string]any, build func(any) *mcp.ToolResult) (*mcp.ToolResult, error) {
+	resultExpr := "result.nodes"
+	switch method {
+	case "searchBookmarks":
+		resultExpr = "result.results"
+	case "createBookmark", "updateBookmark", "moveBookmark":
+		resultExpr = "result.node"
+	}
+	_, value, err := browserRunValue(c, fmt.Sprintf(
+		"const result = await browser.cdp(%s, %s)\nreturn %s",
+		jsLiteral("Bookmarks."+method),
+		jsLiteral(params),
+		resultExpr,
+	))
+	if err != nil {
+		return nil, err
+	}
+	return build(value), nil
+}
+
+func formatBookmarkList(nodes []any) string {
+	if len(nodes) == 0 {
+		return "No bookmarks found."
+	}
+	return fmt.Sprintf("Found %d bookmarks:\n\n%s", len(nodes), formatBookmarkTree(nodes))
+}
+
+func formatBookmarkTree(nodes []any) string {
+	lines := make([]string, 0, len(nodes)*2)
+	for _, item := range nodes {
+		node, ok := valueMap(item)
+		if !ok {
+			continue
+		}
+		id := stringValue(node["id"])
+		title := stringValue(node["title"])
+		if stringValue(node["type"]) == "folder" {
+			lines = append(lines, fmt.Sprintf("[%s] %s (folder)", id, title))
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("[%s] %s", id, title))
+		if url := stringValue(node["url"]); url != "" {
+			lines = append(lines, "    "+url)
+		}
+	}
+	return strings.Join(lines, "\n")
 }

--- a/packages/browseros-agent/apps/cli/cmd/click.go
+++ b/packages/browseros-agent/apps/cli/cmd/click.go
@@ -15,9 +15,9 @@ func init() {
 		Short:       "Click an element by snapshot ID",
 		Args:        cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			var element int
-			if _, err := fmt.Sscanf(args[0], "%d", &element); err != nil {
-				output.Errorf(3, "invalid element ID: %s", args[0])
+			ref, err := elementRef(args[0])
+			if err != nil {
+				output.Error(err.Error(), 3)
 			}
 
 			right, _ := cmd.Flags().GetBool("right")
@@ -41,12 +41,7 @@ func init() {
 				output.Error(err.Error(), 2)
 			}
 
-			result, err := c.CallTool("click", map[string]any{
-				"page":       pageID,
-				"element":    element,
-				"button":     button,
-				"clickCount": clickCount,
-			})
+			result, err := c.CallTool("act", clickToolArgs(pageID, ref, button, clickCount))
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -82,11 +77,7 @@ func init() {
 				output.Error(err.Error(), 2)
 			}
 
-			result, err := c.CallTool("click_at", map[string]any{
-				"page": pageID,
-				"x":    x,
-				"y":    y,
-			})
+			result, err := c.CallTool("act", clickAtToolArgs(pageID, x, y))
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -99,4 +90,23 @@ func init() {
 	}
 
 	rootCmd.AddCommand(clickCmd, clickAtCmd)
+}
+
+func clickToolArgs(pageID int, ref, button string, clickCount int) map[string]any {
+	return map[string]any{
+		"page":       pageID,
+		"kind":       "click",
+		"ref":        ref,
+		"button":     button,
+		"clickCount": clickCount,
+	}
+}
+
+func clickAtToolArgs(pageID, x, y int) map[string]any {
+	return map[string]any{
+		"page": pageID,
+		"kind": "click_at",
+		"x":    x,
+		"y":    y,
+	}
 }

--- a/packages/browseros-agent/apps/cli/cmd/dialog.go
+++ b/packages/browseros-agent/apps/cli/cmd/dialog.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"browseros-cli/output"
 
 	"github.com/spf13/cobra"
@@ -26,18 +28,27 @@ func init() {
 				output.Error(err.Error(), 2)
 			}
 
-			toolArgs := map[string]any{
-				"page":   pageID,
-				"accept": action == "accept",
-			}
+			promptArg := "undefined"
 			if promptText != "" {
-				toolArgs["promptText"] = promptText
+				promptArg = jsLiteral(promptText)
 			}
-
-			result, err := c.CallTool("handle_dialog", toolArgs)
+			_, value, err := browserRunValue(c, fmt.Sprintf(
+				`await browser.input(%d).handleDialog(%t, %s)
+return { action: 'handle_dialog', page: %d, accept: %t }`,
+				pageID,
+				action == "accept",
+				promptArg,
+				pageID,
+				action == "accept",
+			))
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
+			message := "Dialog dismissed"
+			if action == "accept" {
+				message = "Dialog accepted"
+			}
+			result := textResult(message, resultData(value))
 			if jsonOut {
 				output.JSON(result)
 			} else {

--- a/packages/browseros-agent/apps/cli/cmd/dom.go
+++ b/packages/browseros-agent/apps/cli/cmd/dom.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 
+	"browseros-cli/mcp"
 	"browseros-cli/output"
 
 	"github.com/spf13/cobra"
@@ -23,12 +25,19 @@ func init() {
 				output.Error(err.Error(), 2)
 			}
 
-			toolArgs := map[string]any{"page": pageID}
+			code := "const root = document.documentElement\nif (!root) throw new Error('Page has no DOM content.')\nreturn root.outerHTML"
 			if selector != "" {
-				toolArgs["selector"] = selector
+				code = fmt.Sprintf(
+					"const root = document.querySelector(%s)\nif (!root) throw new Error(%s)\nreturn root.outerHTML",
+					jsLiteral(selector),
+					jsLiteral(fmt.Sprintf("No element found matching %q.", selector)),
+				)
 			}
 
-			result, err := c.CallTool("get_dom", toolArgs)
+			result, err := c.CallTool("evaluate", map[string]any{
+				"page": pageID,
+				"code": code,
+			})
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -56,14 +65,14 @@ func init() {
 				output.Error(err.Error(), 2)
 			}
 
-			result, err := c.CallTool("search_dom", map[string]any{
-				"page":  pageID,
-				"query": query,
-				"limit": limit,
+			result, err := c.CallTool("evaluate", map[string]any{
+				"page": pageID,
+				"code": domSearchScript(query, limit),
 			})
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
+			result = domSearchResult(query, result)
 			if jsonOut {
 				output.JSON(result)
 			} else {
@@ -74,4 +83,65 @@ func init() {
 	domSearchCmd.Flags().Int("limit", 25, "Max results")
 
 	rootCmd.AddCommand(domCmd, domSearchCmd)
+}
+
+// domSearchScript preserves the CLI's CSS/XPath/text search behavior through evaluate.
+func domSearchScript(query string, limit int) string {
+	return fmt.Sprintf(`
+const query = %s
+const limit = %d
+let nodes = []
+try {
+  nodes = Array.from(document.querySelectorAll(query))
+} catch {}
+if (nodes.length === 0 && query.startsWith('/')) {
+  const result = document.evaluate(query, document, null, XPathResult.ORDERED_NODE_SNAPSHOT_TYPE, null)
+  nodes = Array.from({ length: result.snapshotLength }, (_, i) => result.snapshotItem(i)).filter(Boolean)
+}
+if (nodes.length === 0) {
+  const needle = query.toLowerCase()
+  const walker = document.createTreeWalker(document.body || document.documentElement, NodeFilter.SHOW_ELEMENT)
+  for (let node = walker.currentNode; node; node = walker.nextNode()) {
+    if ((node.textContent || '').toLowerCase().includes(needle)) nodes.push(node)
+  }
+}
+const shown = nodes.slice(0, limit).map((node) => ({
+  tag: node.tagName ? node.tagName.toLowerCase() : '',
+  text: (node.textContent || '').trim().replace(/\s+/g, ' ').slice(0, 160),
+  id: node.id || '',
+  className: typeof node.className === 'string' ? node.className : '',
+}))
+return { query, totalCount: nodes.length, shownCount: shown.length, results: shown }
+`, jsLiteral(query), limit)
+}
+
+func domSearchResult(query string, result *mcp.ToolResult) *mcp.ToolResult {
+	value, ok := result.StructuredContent["value"].(map[string]any)
+	if !ok {
+		return result
+	}
+	results := valueSlice(value["results"])
+	if len(results) == 0 {
+		return textResult(fmt.Sprintf("No elements matching %q found.", query), value)
+	}
+
+	lines := []string{fmt.Sprintf("Found %d matching elements:", numberValue(value["totalCount"])), ""}
+	for _, item := range results {
+		row, ok := valueMap(item)
+		if !ok {
+			continue
+		}
+		label := stringValue(row["tag"])
+		if id := stringValue(row["id"]); id != "" {
+			label += "#" + id
+		}
+		if className := stringValue(row["className"]); className != "" {
+			label += "." + strings.Join(strings.Fields(className), ".")
+		}
+		lines = append(lines, label)
+		if text := stringValue(row["text"]); text != "" {
+			lines = append(lines, "  "+text)
+		}
+	}
+	return textResult(strings.Join(lines, "\n"), value)
 }

--- a/packages/browseros-agent/apps/cli/cmd/eval.go
+++ b/packages/browseros-agent/apps/cli/cmd/eval.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"strings"
 
 	"browseros-cli/output"
@@ -21,9 +22,9 @@ func init() {
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
-			result, err := c.CallTool("evaluate_script", map[string]any{
-				"page":       pageID,
-				"expression": expression,
+			result, err := c.CallTool("evaluate", map[string]any{
+				"page": pageID,
+				"code": evalCode(expression),
 			})
 			if err != nil {
 				output.Error(err.Error(), 1)
@@ -37,4 +38,22 @@ func init() {
 	}
 
 	rootCmd.AddCommand(cmd)
+}
+
+// evalCode preserves the old expression-style CLI while still accepting statement snippets.
+func evalCode(source string) string {
+	return fmt.Sprintf(`const source = %s
+const isSyntaxError = (err) => err instanceof SyntaxError || err?.name === 'SyntaxError'
+try {
+  return await (0, eval)(`+"`(async () => (${source}))()`"+`)
+} catch (expressionError) {
+  if (!isSyntaxError(expressionError)) throw expressionError
+  try {
+    const value = (0, eval)(source)
+    return value && typeof value.then === 'function' ? await value : value
+  } catch (statementError) {
+    if (!isSyntaxError(statementError)) throw statementError
+    return await (0, eval)(`+"`(async () => { ${source} })()`"+`)
+  }
+}`, jsLiteral(source))
 }

--- a/packages/browseros-agent/apps/cli/cmd/eval_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/eval_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os/exec"
+	"testing"
+)
+
+func TestEvalCodeSupportsExpressionsAndSnippets(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   any
+	}{
+		{
+			name:   "expression",
+			source: "1 + 2",
+			want:   float64(3),
+		},
+		{
+			name:   "statement completion",
+			source: "let x = 4; x + 1",
+			want:   float64(5),
+		},
+		{
+			name:   "async body return",
+			source: "return await Promise.resolve('ok')",
+			want:   "ok",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := runEvalCode(t, tt.source)
+			if got != tt.want {
+				t.Fatalf("runEvalCode() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEvalCodeDoesNotHideRuntimeErrors(t *testing.T) {
+	result, err := runEvalCodeResult(t, "missingVariable")
+	if err == nil {
+		t.Fatal("runEvalCodeResult() error = nil, want runtime failure")
+	}
+	if result.Name != "ReferenceError" {
+		t.Fatalf("error name = %q, want ReferenceError", result.Name)
+	}
+}
+
+func runEvalCode(t *testing.T, source string) any {
+	t.Helper()
+
+	result, err := runEvalCodeResult(t, source)
+	if err != nil {
+		t.Fatalf("runEvalCodeResult() error = %v; result = %+v", err, result)
+	}
+	return result.Value
+}
+
+type evalCodeResult struct {
+	OK      bool   `json:"ok"`
+	Value   any    `json:"value"`
+	Name    string `json:"name"`
+	Message string `json:"message"`
+}
+
+func runEvalCodeResult(t *testing.T, source string) (evalCodeResult, error) {
+	t.Helper()
+
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is not available")
+	}
+
+	script := fmt.Sprintf(`(async () => {
+%s
+})()
+  .then((value) => console.log(JSON.stringify({ ok: true, value })))
+  .catch((err) => {
+    console.log(JSON.stringify({ ok: false, name: err.name, message: err.message }))
+    process.exit(1)
+  })`, evalCode(source))
+	output, runErr := exec.Command(node, "-e", script).CombinedOutput()
+
+	var result evalCodeResult
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error = %v", string(output), err)
+	}
+	return result, runErr
+}

--- a/packages/browseros-agent/apps/cli/cmd/file_actions.go
+++ b/packages/browseros-agent/apps/cli/cmd/file_actions.go
@@ -20,13 +20,22 @@ func init() {
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
-			result, err := c.CallTool("save_pdf", map[string]any{
-				"page": pageID,
-				"path": args[0],
-			})
+			result, err := c.CallTool("pdf", pdfToolArgs(pageID))
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
+			generatedPath := stringValue(result.StructuredContent["path"])
+			if generatedPath == "" {
+				output.Error("pdf tool did not return a file path", 1)
+			}
+			if err := copyLocalFile(generatedPath, args[0]); err != nil {
+				output.Errorf(1, "copy PDF: %s", err)
+			}
+			result = textResult(fmt.Sprintf("Saved PDF to %s", args[0]), map[string]any{
+				"path":          args[0],
+				"generatedPath": generatedPath,
+				"page":          pageID,
+			})
 			if jsonOut {
 				output.JSON(result)
 			} else {
@@ -41,9 +50,9 @@ func init() {
 		Short:       "Click element to trigger download and save to directory",
 		Args:        cobra.ExactArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			var element int
-			if _, err := fmt.Sscanf(args[0], "%d", &element); err != nil {
-				output.Errorf(3, "invalid element ID: %s", args[0])
+			ref, err := elementRef(args[0])
+			if err != nil {
+				output.Error(err.Error(), 3)
 			}
 
 			c := newClient()
@@ -51,14 +60,27 @@ func init() {
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
-			result, err := c.CallTool("download_file", map[string]any{
-				"page":    pageID,
-				"element": element,
-				"path":    args[1],
-			})
+			result, err := c.CallTool("download", downloadToolArgs(pageID, ref))
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
+			generatedPath := stringValue(result.StructuredContent["path"])
+			filename := stringValue(result.StructuredContent["filename"])
+			if generatedPath == "" || filename == "" {
+				output.Error("download tool did not return a file path and filename", 1)
+			}
+			destinationPath, err := copyDownloadFile(generatedPath, args[1], filename)
+			if err != nil {
+				output.Errorf(1, "copy download: %s", err)
+			}
+			result = textResult(fmt.Sprintf("Downloaded %q to %s", filename, destinationPath), map[string]any{
+				"page":            pageID,
+				"ref":             ref,
+				"path":            destinationPath,
+				"generatedPath":   generatedPath,
+				"filename":        filename,
+				"destinationPath": destinationPath,
+			})
 			if jsonOut {
 				output.JSON(result)
 			} else {
@@ -68,4 +90,15 @@ func init() {
 	}
 
 	rootCmd.AddCommand(pdfCmd, downloadCmd)
+}
+
+func pdfToolArgs(pageID int) map[string]any {
+	return map[string]any{"page": pageID}
+}
+
+func downloadToolArgs(pageID int, ref string) map[string]any {
+	return map[string]any{
+		"page": pageID,
+		"ref":  ref,
+	}
 }

--- a/packages/browseros-agent/apps/cli/cmd/fill.go
+++ b/packages/browseros-agent/apps/cli/cmd/fill.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"strings"
 
 	"browseros-cli/output"
@@ -16,9 +15,9 @@ func init() {
 		Short:       "Type text into an input element",
 		Args:        cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			var element int
-			if _, err := fmt.Sscanf(args[0], "%d", &element); err != nil {
-				output.Errorf(3, "invalid element ID: %s", args[0])
+			ref, err := elementRef(args[0])
+			if err != nil {
+				output.Error(err.Error(), 3)
 			}
 			text := strings.Join(args[1:], " ")
 			noClear, _ := cmd.Flags().GetBool("no-clear")
@@ -29,11 +28,12 @@ func init() {
 				output.Error(err.Error(), 2)
 			}
 
-			result, err := c.CallTool("fill", map[string]any{
-				"page":    pageID,
-				"element": element,
-				"text":    text,
-				"clear":   !noClear,
+			result, err := c.CallTool("act", map[string]any{
+				"page":  pageID,
+				"kind":  "fill",
+				"ref":   ref,
+				"value": text,
+				"clear": !noClear,
 			})
 			if err != nil {
 				output.Error(err.Error(), 1)
@@ -52,7 +52,7 @@ func init() {
 		Annotations: map[string]string{"group": "Input:"},
 		Short:       "Clear text content of an input element",
 		Args:        cobra.ExactArgs(1),
-		Run:   elementAction("clear"),
+		Run:         elementAction("fill", map[string]any{"value": "", "clear": true}),
 	}
 
 	keyCmd := &cobra.Command{
@@ -66,8 +66,9 @@ func init() {
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
-			result, err := c.CallTool("press_key", map[string]any{
+			result, err := c.CallTool("act", map[string]any{
 				"page": pageID,
+				"kind": "press",
 				"key":  args[0],
 			})
 			if err != nil {

--- a/packages/browseros-agent/apps/cli/cmd/group.go
+++ b/packages/browseros-agent/apps/cli/cmd/group.go
@@ -21,7 +21,7 @@ func init() {
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			c := newClient()
-			result, err := c.CallTool("list_tab_groups", nil)
+			result, err := c.CallTool("tab_groups", map[string]any{"action": "list"})
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -49,13 +49,16 @@ func init() {
 				pageIDs = append(pageIDs, id)
 			}
 
-			toolArgs := map[string]any{"pageIds": pageIDs}
+			toolArgs := map[string]any{
+				"action": "create",
+				"pages":  pageIDs,
+			}
 			if title != "" {
 				toolArgs["title"] = title
 			}
 
 			c := newClient()
-			result, err := c.CallTool("group_tabs", toolArgs)
+			result, err := c.CallTool("tab_groups", toolArgs)
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -77,7 +80,10 @@ func init() {
 			color, _ := cmd.Flags().GetString("color")
 			collapsed, _ := cmd.Flags().GetBool("collapsed")
 
-			toolArgs := map[string]any{"groupId": args[0]}
+			toolArgs := map[string]any{
+				"action":  "update",
+				"groupId": args[0],
+			}
 			if title != "" {
 				toolArgs["title"] = title
 			}
@@ -89,7 +95,7 @@ func init() {
 			}
 
 			c := newClient()
-			result, err := c.CallTool("update_tab_group", toolArgs)
+			result, err := c.CallTool("tab_groups", toolArgs)
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -119,7 +125,10 @@ func init() {
 			}
 
 			c := newClient()
-			result, err := c.CallTool("ungroup_tabs", map[string]any{"pageIds": pageIDs})
+			result, err := c.CallTool("tab_groups", map[string]any{
+				"action": "ungroup",
+				"pages":  pageIDs,
+			})
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -137,7 +146,10 @@ func init() {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			c := newClient()
-			result, err := c.CallTool("close_tab_group", map[string]any{"groupId": args[0]})
+			result, err := c.CallTool("tab_groups", map[string]any{
+				"action":  "close",
+				"groupId": args[0],
+			})
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}

--- a/packages/browseros-agent/apps/cli/cmd/history.go
+++ b/packages/browseros-agent/apps/cli/cmd/history.go
@@ -1,6 +1,11 @@
 package cmd
 
 import (
+	"fmt"
+	"strings"
+	"time"
+
+	"browseros-cli/mcp"
 	"browseros-cli/output"
 
 	"github.com/spf13/cobra"
@@ -24,7 +29,18 @@ func init() {
 			if cmd.Flags().Changed("max") {
 				toolArgs["maxResults"] = max
 			}
-			result, err := c.CallTool("search_history", toolArgs)
+			query := args[0]
+			result, err := runHistoryEntries(c, "search", toolArgs, func(items []any) *mcp.ToolResult {
+				message := fmt.Sprintf("No history items found matching %q.", query)
+				if len(items) > 0 {
+					message = fmt.Sprintf("Found %d history items matching %q:\n\n%s", len(items), query, formatHistoryItems(items, true))
+				}
+				return textResult(message, map[string]any{
+					"query": query,
+					"items": items,
+					"count": len(items),
+				})
+			})
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -48,7 +64,16 @@ func init() {
 			if cmd.Flags().Changed("max") {
 				toolArgs["maxResults"] = max
 			}
-			result, err := c.CallTool("get_recent_history", toolArgs)
+			result, err := runHistoryEntries(c, "getRecent", toolArgs, func(items []any) *mcp.ToolResult {
+				message := "No recent history items."
+				if len(items) > 0 {
+					message = fmt.Sprintf("Retrieved %d recent history items:\n\n%s", len(items), formatHistoryItems(items, false))
+				}
+				return textResult(message, map[string]any{
+					"items": items,
+					"count": len(items),
+				})
+			})
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -67,10 +92,17 @@ func init() {
 		Args:  cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			c := newClient()
-			result, err := c.CallTool("delete_history_url", map[string]any{"url": args[0]})
+			url := args[0]
+			_, value, err := browserRunValue(c, fmt.Sprintf(
+				`await browser.cdp('History.deleteUrl', { url: %s })
+return { action: 'delete_history_url', url: %s }`,
+				jsLiteral(url),
+				jsLiteral(url),
+			))
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
+			result := textResult(fmt.Sprintf("Deleted %s from history", url), resultData(value))
 			if jsonOut {
 				output.JSON(result)
 			} else {
@@ -87,13 +119,23 @@ func init() {
 			start, _ := cmd.Flags().GetInt("start")
 			end, _ := cmd.Flags().GetInt("end")
 			c := newClient()
-			result, err := c.CallTool("delete_history_range", map[string]any{
-				"startTime": start,
-				"endTime":   end,
-			})
+			_, value, err := browserRunValue(c, fmt.Sprintf(
+				`await browser.cdp('History.deleteRange', { startTime: %d, endTime: %d })
+return { action: 'delete_history_range', startTime: %d, endTime: %d, startIso: new Date(%d).toISOString(), endIso: new Date(%d).toISOString() }`,
+				start,
+				end,
+				start,
+				end,
+				start,
+				end,
+			))
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
+			result := textResult(
+				fmt.Sprintf("Deleted history from %s to %s", time.UnixMilli(int64(start)).UTC().Format(time.RFC3339Nano), time.UnixMilli(int64(end)).UTC().Format(time.RFC3339Nano)),
+				resultData(value),
+			)
 			if jsonOut {
 				output.JSON(result)
 			} else {
@@ -108,4 +150,52 @@ func init() {
 
 	historyCmd.AddCommand(searchCmd, recentCmd, deleteCmd, deleteRangeCmd)
 	rootCmd.AddCommand(historyCmd)
+}
+
+// runHistoryEntries bridges history subcommands through the compact run tool's CDP escape hatch.
+func runHistoryEntries(c *mcp.Client, method string, params map[string]any, build func([]any) *mcp.ToolResult) (*mcp.ToolResult, error) {
+	_, value, err := browserRunValue(c, fmt.Sprintf(
+		"const result = await browser.cdp(%s, %s)\nreturn result.entries",
+		jsLiteral("History."+method),
+		jsLiteral(params),
+	))
+	if err != nil {
+		return nil, err
+	}
+	return build(valueSlice(value)), nil
+}
+
+func formatHistoryItems(items []any, includeVisitCount bool) string {
+	blocks := make([]string, 0, len(items))
+	for _, item := range items {
+		entry, ok := valueMap(item)
+		if !ok {
+			continue
+		}
+		id := stringValue(entry["id"])
+		title := stringValue(entry["title"])
+		if title == "" {
+			title = "Untitled"
+		}
+		url := stringValue(entry["url"])
+		if url == "" {
+			url = "No URL"
+		}
+		lastVisit := "Unknown date"
+		if ms := numberValue(entry["lastVisitTime"]); ms > 0 {
+			lastVisit = time.UnixMilli(int64(ms)).UTC().Format(time.RFC3339Nano)
+		}
+		lines := []string{
+			fmt.Sprintf("[%s] %s", id, title),
+			"    " + url,
+			"    Last visited: " + lastVisit,
+		}
+		if includeVisitCount {
+			if visits := numberValue(entry["visitCount"]); visits > 0 {
+				lines = append(lines, fmt.Sprintf("    Visit count: %d", visits))
+			}
+		}
+		blocks = append(blocks, strings.Join(lines, "\n"))
+	}
+	return strings.Join(blocks, "\n\n")
 }

--- a/packages/browseros-agent/apps/cli/cmd/info.go
+++ b/packages/browseros-agent/apps/cli/cmd/info.go
@@ -1,10 +1,30 @@
 package cmd
 
 import (
+	"sort"
+	"strings"
+
 	"browseros-cli/output"
 
 	"github.com/spf13/cobra"
 )
+
+const browserOSInfoOverview = `# BrowserOS
+
+BrowserOS is an open-source AI browser built on Chromium. It exposes local browser automation through an MCP server and lets agents drive tabs, pages, screenshots, files, and connected apps.
+
+Docs: https://docs.browseros.com/`
+
+var browserOSInfoTopics = map[string]string{
+	"overview":           browserOSInfoOverview,
+	"mcp-server":         "BrowserOS exposes a local MCP server for browser automation. Use the CLI against the server URL from BrowserOS Settings > BrowserOS MCP.",
+	"filesystem-access":  "BrowserOS agents can use scoped filesystem tools when a workspace is selected.",
+	"connect-apps":       "BrowserOS can connect external apps through managed MCP integrations.",
+	"bring-your-own-llm": "Connect BrowserOS to your preferred LLM provider or local model from BrowserOS settings.",
+	"scheduled-tasks":    "Scheduled Tasks run BrowserOS automations on a recurring schedule while BrowserOS is open.",
+	"chat-hub":           "Chat and LLM Hub provide side-panel AI chat and model comparison across webpages.",
+	"ad-blocking":        "BrowserOS includes built-in ad blocking powered by uBlock Origin.",
+}
 
 func init() {
 	cmd := &cobra.Command{
@@ -13,15 +33,23 @@ func init() {
 		Short:       "Get information about BrowserOS features",
 		Args:        cobra.MaximumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			c := newClient()
-			toolArgs := map[string]any{}
+			topic := "overview"
 			if len(args) > 0 {
-				toolArgs["topic"] = args[0]
+				topic = args[0]
 			}
-			result, err := c.CallTool("browseros_info", toolArgs)
-			if err != nil {
-				output.Error(err.Error(), 1)
+			content, ok := browserOSInfoTopics[topic]
+			if !ok {
+				valid := make([]string, 0, len(browserOSInfoTopics))
+				for key := range browserOSInfoTopics {
+					valid = append(valid, key)
+				}
+				sort.Strings(valid)
+				output.Errorf(3, "unknown topic %q; valid topics: %s", topic, strings.Join(valid, ", "))
 			}
+			result := textResult(content, map[string]any{
+				"topic":   topic,
+				"content": content,
+			})
 			if jsonOut {
 				output.JSON(result)
 			} else {

--- a/packages/browseros-agent/apps/cli/cmd/interact.go
+++ b/packages/browseros-agent/apps/cli/cmd/interact.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"fmt"
 	"strings"
 
 	"browseros-cli/output"
@@ -15,7 +14,7 @@ func init() {
 		Annotations: map[string]string{"group": "Input:"},
 		Short:       "Hover over an element",
 		Args:        cobra.ExactArgs(1),
-		Run:   elementAction("hover"),
+		Run:         elementAction("hover", nil),
 	}
 
 	focusCmd := &cobra.Command{
@@ -23,7 +22,7 @@ func init() {
 		Annotations: map[string]string{"group": "Input:"},
 		Short:       "Focus an element",
 		Args:        cobra.ExactArgs(1),
-		Run:   elementAction("focus"),
+		Run:         elementAction("focus", nil),
 	}
 
 	checkCmd := &cobra.Command{
@@ -31,7 +30,7 @@ func init() {
 		Annotations: map[string]string{"group": "Input:"},
 		Short:       "Check a checkbox or radio button",
 		Args:        cobra.ExactArgs(1),
-		Run:   elementAction("check"),
+		Run:         elementAction("check", nil),
 	}
 
 	uncheckCmd := &cobra.Command{
@@ -39,7 +38,7 @@ func init() {
 		Annotations: map[string]string{"group": "Input:"},
 		Short:       "Uncheck a checkbox",
 		Args:        cobra.ExactArgs(1),
-		Run:   elementAction("uncheck"),
+		Run:         elementAction("uncheck", nil),
 	}
 
 	selectCmd := &cobra.Command{
@@ -48,9 +47,9 @@ func init() {
 		Short:       "Select a dropdown option",
 		Args:        cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			var element int
-			if _, err := fmt.Sscanf(args[0], "%d", &element); err != nil {
-				output.Errorf(3, "invalid element ID: %s", args[0])
+			ref, err := elementRef(args[0])
+			if err != nil {
+				output.Error(err.Error(), 3)
 			}
 			value := strings.Join(args[1:], " ")
 
@@ -59,10 +58,11 @@ func init() {
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
-			result, err := c.CallTool("select_option", map[string]any{
-				"page":    pageID,
-				"element": element,
-				"value":   value,
+			result, err := c.CallTool("act", map[string]any{
+				"page":  pageID,
+				"kind":  "select",
+				"ref":   ref,
+				"value": value,
 			})
 			if err != nil {
 				output.Error(err.Error(), 1)
@@ -81,21 +81,26 @@ func init() {
 		Short:       "Drag from one element to another",
 		Args:        cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			var source int
-			if _, err := fmt.Sscanf(args[0], "%d", &source); err != nil {
-				output.Errorf(3, "invalid source element: %s", args[0])
+			sourceRef, err := elementRef(args[0])
+			if err != nil {
+				output.Error(err.Error(), 3)
 			}
-			target, _ := cmd.Flags().GetInt("to")
+			target, _ := cmd.Flags().GetString("to")
+			targetRef, err := elementRef(target)
+			if err != nil {
+				output.Error(err.Error(), 3)
+			}
 
 			c := newClient()
 			pageID, err := resolvePageID(c)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
-			result, err := c.CallTool("drag", map[string]any{
-				"page":          pageID,
-				"sourceElement": source,
-				"targetElement": target,
+			result, err := c.CallTool("act", map[string]any{
+				"page":      pageID,
+				"kind":      "drag",
+				"ref":       sourceRef,
+				"targetRef": targetRef,
 			})
 			if err != nil {
 				output.Error(err.Error(), 1)
@@ -107,7 +112,7 @@ func init() {
 			}
 		},
 	}
-	dragCmd.Flags().Int("to", 0, "Target element ID")
+	dragCmd.Flags().String("to", "", "Target element ID or ref")
 	_ = dragCmd.MarkFlagRequired("to")
 
 	uploadCmd := &cobra.Command{
@@ -116,9 +121,9 @@ func init() {
 		Short:       "Upload files to a file input",
 		Args:        cobra.MinimumNArgs(2),
 		Run: func(cmd *cobra.Command, args []string) {
-			var element int
-			if _, err := fmt.Sscanf(args[0], "%d", &element); err != nil {
-				output.Errorf(3, "invalid element ID: %s", args[0])
+			ref, err := elementRef(args[0])
+			if err != nil {
+				output.Error(err.Error(), 3)
 			}
 
 			c := newClient()
@@ -126,10 +131,10 @@ func init() {
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
-			result, err := c.CallTool("upload_file", map[string]any{
-				"page":    pageID,
-				"element": element,
-				"files":   args[1:],
+			result, err := c.CallTool("upload", map[string]any{
+				"page":  pageID,
+				"ref":   ref,
+				"files": args[1:],
 			})
 			if err != nil {
 				output.Error(err.Error(), 1)
@@ -145,12 +150,11 @@ func init() {
 	rootCmd.AddCommand(hoverCmd, focusCmd, checkCmd, uncheckCmd, selectCmd, dragCmd, uploadCmd)
 }
 
-// elementAction creates a simple element-based tool command.
-func elementAction(toolName string) func(*cobra.Command, []string) {
+func elementAction(kind string, extra map[string]any) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
-		var element int
-		if _, err := fmt.Sscanf(args[0], "%d", &element); err != nil {
-			output.Errorf(3, "invalid element ID: %s", args[0])
+		ref, err := elementRef(args[0])
+		if err != nil {
+			output.Error(err.Error(), 3)
 		}
 
 		c := newClient()
@@ -159,10 +163,15 @@ func elementAction(toolName string) func(*cobra.Command, []string) {
 			output.Error(err.Error(), 2)
 		}
 
-		result, err := c.CallTool(toolName, map[string]any{
-			"page":    pageID,
-			"element": element,
-		})
+		toolArgs := map[string]any{
+			"page": pageID,
+			"kind": kind,
+			"ref":  ref,
+		}
+		for key, value := range extra {
+			toolArgs[key] = value
+		}
+		result, err := c.CallTool("act", toolArgs)
 		if err != nil {
 			output.Error(err.Error(), 1)
 		}

--- a/packages/browseros-agent/apps/cli/cmd/nav.go
+++ b/packages/browseros-agent/apps/cli/cmd/nav.go
@@ -18,7 +18,7 @@ func init() {
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
-			result, err := c.CallTool("navigate_page", map[string]any{
+			result, err := c.CallTool("navigate", map[string]any{
 				"page":   pageID,
 				"action": "url",
 				"url":    args[0],
@@ -39,7 +39,7 @@ func init() {
 		Annotations: map[string]string{"group": "Navigate:"},
 		Short:       "Navigate back",
 		Args:        cobra.NoArgs,
-		Run:   navAction("back"),
+		Run:         navAction("back"),
 	}
 
 	forwardCmd := &cobra.Command{
@@ -47,7 +47,7 @@ func init() {
 		Annotations: map[string]string{"group": "Navigate:"},
 		Short:       "Navigate forward",
 		Args:        cobra.NoArgs,
-		Run:   navAction("forward"),
+		Run:         navAction("forward"),
 	}
 
 	reloadCmd := &cobra.Command{
@@ -55,7 +55,7 @@ func init() {
 		Annotations: map[string]string{"group": "Navigate:"},
 		Short:       "Reload the current page",
 		Args:        cobra.NoArgs,
-		Run:   navAction("reload"),
+		Run:         navAction("reload"),
 	}
 
 	rootCmd.AddCommand(navCmd, backCmd, forwardCmd, reloadCmd)
@@ -68,7 +68,7 @@ func navAction(action string) func(*cobra.Command, []string) {
 		if err != nil {
 			output.Error(err.Error(), 2)
 		}
-		result, err := c.CallTool("navigate_page", map[string]any{
+		result, err := c.CallTool("navigate", map[string]any{
 			"page":   pageID,
 			"action": action,
 		})

--- a/packages/browseros-agent/apps/cli/cmd/open.go
+++ b/packages/browseros-agent/apps/cli/cmd/open.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"browseros-cli/output"
 
 	"github.com/spf13/cobra"
@@ -18,32 +20,34 @@ func init() {
 			windowID, _ := cmd.Flags().GetInt("window")
 
 			c := newClient()
-			toolArgs := map[string]any{
-				"url":        args[0],
-				"hidden":     hidden,
-				"background": bg,
-			}
-			if cmd.Flags().Changed("window") {
-				toolArgs["windowId"] = windowID
-			}
+			var resultText string
+			var resultData map[string]any
+			var err error
+			var result any
 
-			toolName := "new_page"
-			if hidden {
-				toolName = "new_hidden_page"
-				toolArgs = map[string]any{"url": args[0]}
-				if cmd.Flags().Changed("window") {
-					toolArgs["windowId"] = windowID
+			if cmd.Flags().Changed("window") {
+				_, result, err = browserRunValue(c, openInWindowCode(args[0], hidden, bg, windowID))
+				if err == nil {
+					resultData, _ = valueMap(result)
+					resultText = fmt.Sprintf("opened page %d", numberValue(resultData["page"]))
+				}
+			} else {
+				toolResult, callErr := c.CallTool("tabs", openTabsToolArgs(args[0], hidden, bg))
+				err = callErr
+				if err == nil {
+					resultText = toolResult.TextContent()
+					resultData = toolResult.StructuredContent
 				}
 			}
 
-			result, err := c.CallTool(toolName, toolArgs)
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
+			resultForOutput := textResult(resultText, resultData)
 			if jsonOut {
-				output.JSON(result)
+				output.JSON(resultForOutput)
 			} else {
-				output.Confirm(result.TextContent())
+				output.Confirm(resultForOutput.TextContent())
 			}
 		},
 	}
@@ -53,4 +57,28 @@ func init() {
 	cmd.Flags().Int("window", 0, "Window ID to open in")
 
 	rootCmd.AddCommand(cmd)
+}
+
+func openTabsToolArgs(url string, hidden, background bool) map[string]any {
+	return map[string]any{
+		"action":     "new",
+		"url":        url,
+		"hidden":     hidden,
+		"background": background,
+	}
+}
+
+func openInWindowCode(url string, hidden, background bool, windowID int) string {
+	return fmt.Sprintf(
+		`const page = await browser.pages.newPage(%s, { hidden: %t, background: %t, windowId: %d })
+return { page, url: %s, hidden: %t, background: %t, windowId: %d }`,
+		jsLiteral(url),
+		hidden,
+		background,
+		windowID,
+		jsLiteral(url),
+		hidden,
+		background,
+		windowID,
+	)
 }

--- a/packages/browseros-agent/apps/cli/cmd/pages.go
+++ b/packages/browseros-agent/apps/cli/cmd/pages.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"browseros-cli/output"
 
@@ -16,10 +17,15 @@ func init() {
 		Args:        cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			c := newClient()
-			result, err := c.CallTool("list_pages", nil)
+			_, value, err := browserRunValue(c, "return await browser.pages.list()")
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
+			pages := valueSlice(value)
+			result := textResult(formatPages(pages), map[string]any{
+				"pages": pages,
+				"count": len(pages),
+			})
 			if jsonOut {
 				output.JSON(result)
 			} else {
@@ -35,10 +41,18 @@ func init() {
 		Args:        cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			c := newClient()
-			result, err := c.CallTool("get_active_page", nil)
+			_, value, err := browserRunValue(c, `const pages = await browser.pages.list()
+const page = pages.find((p) => p.isActive) ?? pages[0]
+if (!page) throw new Error('No active page found.')
+return page`)
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
+			page, ok := valueMap(value)
+			if !ok {
+				output.Error("active page response was not an object", 1)
+			}
+			result := textResult(formatActivePage(page), map[string]any{"page": page})
 			if jsonOut {
 				output.JSON(result)
 			} else {
@@ -67,7 +81,10 @@ func init() {
 					output.Error(err.Error(), 2)
 				}
 			}
-			result, err := c.CallTool("close_page", map[string]any{"page": pageID})
+			result, err := c.CallTool("tabs", map[string]any{
+				"action": "close",
+				"page":   pageID,
+			})
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -80,4 +97,51 @@ func init() {
 	}
 
 	rootCmd.AddCommand(pagesCmd, activeCmd, closeCmd)
+}
+
+func formatPages(pages []any) string {
+	if len(pages) == 0 {
+		return "No pages open."
+	}
+	lines := make([]string, 0, len(pages))
+	for _, item := range pages {
+		page, ok := valueMap(item)
+		if !ok {
+			continue
+		}
+		pageID := numberValue(page["pageId"])
+		if pageID == 0 {
+			pageID = numberValue(page["page"])
+		}
+		tabID := numberValue(page["tabId"])
+		title := stringValue(page["title"])
+		url := stringValue(page["url"])
+		if title == "" {
+			title = "(untitled)"
+		}
+		active := ""
+		if isActive, _ := page["isActive"].(bool); isActive {
+			active = " [ACTIVE]"
+		}
+		if tabID == 0 {
+			lines = append(lines, fmt.Sprintf("%d. %s%s\n   %s", pageID, title, active, url))
+		} else {
+			lines = append(lines, fmt.Sprintf("%d. %s (tab %d)%s\n   %s", pageID, title, tabID, active, url))
+		}
+	}
+	return strings.Join(lines, "\n\n")
+}
+
+func formatActivePage(page map[string]any) string {
+	pageID := numberValue(page["pageId"])
+	if pageID == 0 {
+		pageID = numberValue(page["page"])
+	}
+	tabID := numberValue(page["tabId"])
+	title := stringValue(page["title"])
+	url := stringValue(page["url"])
+	if tabID == 0 {
+		return fmt.Sprintf("Active page: %d\n%s\n%s", pageID, title, url)
+	}
+	return fmt.Sprintf("Active page: %d (tab %d)\n%s\n%s", pageID, tabID, title, url)
 }

--- a/packages/browseros-agent/apps/cli/cmd/screenshot.go
+++ b/packages/browseros-agent/apps/cli/cmd/screenshot.go
@@ -4,7 +4,9 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"path/filepath"
 
+	"browseros-cli/mcp"
 	"browseros-cli/output"
 
 	"github.com/spf13/cobra"
@@ -28,48 +30,31 @@ func init() {
 				output.Error(err.Error(), 2)
 			}
 
-			if outFile != "" {
-				toolArgs := map[string]any{
-					"page":   pageID,
-					"path":   outFile,
-					"format": format,
-				}
-				if full {
-					toolArgs["fullPage"] = true
-				}
-				if cmd.Flags().Changed("quality") {
-					toolArgs["quality"] = quality
-				}
-				result, err := c.CallTool("save_screenshot", toolArgs)
-				if err != nil {
-					output.Error(err.Error(), 1)
-				}
-				if jsonOut {
-					output.JSON(result)
-				} else {
-					output.Confirm(result.TextContent())
-				}
-				return
+			toolArgs, err := screenshotToolArgs(pageID, format, full, quality, cmd.Flags().Changed("quality"))
+			if err != nil {
+				output.Error(err.Error(), 3)
 			}
 
-			toolArgs := map[string]any{
-				"page":   pageID,
-				"format": format,
-			}
-			if full {
-				toolArgs["fullPage"] = true
-			}
-			if cmd.Flags().Changed("quality") {
-				toolArgs["quality"] = quality
-			}
-
-			result, err := c.CallTool("take_screenshot", toolArgs)
+			result, err := c.CallTool("screenshot", toolArgs)
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
 
+			if outFile != "" {
+				if err := writeScreenshot(result, outFile); err != nil {
+					output.Error(err.Error(), 1)
+				}
+				result.StructuredContent = map[string]any{"path": outFile}
+				if jsonOut {
+					output.JSON(result)
+				} else {
+					fmt.Printf("Screenshot saved: %s\n", outFile)
+				}
+				return
+			}
+
 			if jsonOut {
-				output.JSON(result)
+				output.JSONRaw(result)
 				return
 			}
 
@@ -83,13 +68,12 @@ func init() {
 			if ext == "" {
 				ext = "png"
 			}
-			filename := "screenshot." + ext
-			data, err := base64.StdEncoding.DecodeString(img.Data)
-			if err != nil {
-				output.Errorf(1, "decode image: %s", err)
+			filename := outFile
+			if filename == "" {
+				filename = "screenshot." + ext
 			}
-			if err := os.WriteFile(filename, data, 0644); err != nil {
-				output.Errorf(1, "write file: %s", err)
+			if err := writeScreenshot(result, filename); err != nil {
+				output.Error(err.Error(), 1)
 			}
 			fmt.Printf("Screenshot saved: %s\n", filename)
 		},
@@ -98,7 +82,43 @@ func init() {
 	cmd.Flags().StringP("out", "o", "", "Output file path")
 	cmd.Flags().BoolP("full", "f", false, "Full page screenshot")
 	cmd.Flags().String("format", "png", "Image format (png, jpeg, webp)")
-	cmd.Flags().Int("quality", 0, "Compression quality (jpeg/webp)")
+	cmd.Flags().Int("quality", 0, "Compression quality (jpeg only)")
 
 	rootCmd.AddCommand(cmd)
+}
+
+func screenshotToolArgs(pageID int, format string, full bool, quality int, qualityChanged bool) (map[string]any, error) {
+	toolArgs := map[string]any{
+		"page":   pageID,
+		"format": format,
+	}
+	if full {
+		toolArgs["fullPage"] = true
+	}
+	if qualityChanged {
+		if format != "jpeg" {
+			return nil, fmt.Errorf("--quality is only supported with --format jpeg")
+		}
+		toolArgs["quality"] = quality
+	}
+	return toolArgs, nil
+}
+
+// writeScreenshot stores inline MCP image content at the CLI-requested path.
+func writeScreenshot(result *mcp.ToolResult, filename string) error {
+	img := result.ImageContent()
+	if img == nil {
+		return fmt.Errorf("screenshot returned no image data")
+	}
+	data, err := base64.StdEncoding.DecodeString(img.Data)
+	if err != nil {
+		return fmt.Errorf("decode image: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(filename), 0755); err != nil {
+		return fmt.Errorf("create output directory: %w", err)
+	}
+	if err := os.WriteFile(filename, data, 0644); err != nil {
+		return fmt.Errorf("write file: %w", err)
+	}
+	return nil
 }

--- a/packages/browseros-agent/apps/cli/cmd/scroll.go
+++ b/packages/browseros-agent/apps/cli/cmd/scroll.go
@@ -39,7 +39,13 @@ func init() {
 				toolArgs["element"] = element
 			}
 
-			result, err := c.CallTool("scroll", toolArgs)
+			toolArgs["kind"] = "scroll"
+			if cmd.Flags().Changed("element") {
+				toolArgs["ref"] = fmt.Sprintf("e%d", element)
+				delete(toolArgs, "element")
+			}
+
+			result, err := c.CallTool("act", toolArgs)
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}

--- a/packages/browseros-agent/apps/cli/cmd/snap.go
+++ b/packages/browseros-agent/apps/cli/cmd/snap.go
@@ -14,18 +14,17 @@ func init() {
 		Args:        cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			enhanced, _ := cmd.Flags().GetBool("enhanced")
+			if enhanced {
+				output.Error("snap --enhanced is not supported by the compact BrowserOS tool surface; use snap", 3)
+			}
+
 			c := newClient()
 			pageID, err := resolvePageID(c)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
 
-			toolName := "take_snapshot"
-			if enhanced {
-				toolName = "take_enhanced_snapshot"
-			}
-
-			result, err := c.CallTool(toolName, map[string]any{"page": pageID})
+			result, err := c.CallTool("snapshot", map[string]any{"page": pageID})
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -37,6 +36,6 @@ func init() {
 		},
 	}
 
-	cmd.Flags().BoolP("enhanced", "e", false, "Detailed accessibility tree with structural context")
+	cmd.Flags().BoolP("enhanced", "e", false, "Unsupported by compact BrowserOS tools; exits with a migration error")
 	rootCmd.AddCommand(cmd)
 }

--- a/packages/browseros-agent/apps/cli/cmd/text.go
+++ b/packages/browseros-agent/apps/cli/cmd/text.go
@@ -25,16 +25,17 @@ func init() {
 			}
 
 			toolArgs := map[string]any{
-				"page":         pageID,
-				"viewportOnly": viewport,
-				"includeLinks": links,
+				"page":          pageID,
+				"format":        "markdown",
+				"viewportOnly":  viewport,
+				"includeLinks":  links,
 				"includeImages": images,
 			}
 			if selector != "" {
 				toolArgs["selector"] = selector
 			}
 
-			result, err := c.CallTool("get_page_content", toolArgs)
+			result, err := c.CallTool("read", toolArgs)
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -62,7 +63,10 @@ func init() {
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
-			result, err := c.CallTool("get_page_links", map[string]any{"page": pageID})
+			result, err := c.CallTool("read", map[string]any{
+				"page":   pageID,
+				"format": "links",
+			})
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}

--- a/packages/browseros-agent/apps/cli/cmd/tool_helpers.go
+++ b/packages/browseros-agent/apps/cli/cmd/tool_helpers.go
@@ -1,0 +1,187 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"browseros-cli/mcp"
+)
+
+// elementRef normalizes legacy numeric element IDs to compact snapshot refs.
+func elementRef(raw string) (string, error) {
+	ref := strings.TrimSpace(raw)
+	if ref == "" {
+		return "", fmt.Errorf("empty element ref")
+	}
+	if strings.HasPrefix(ref, "e") {
+		if _, err := strconv.Atoi(strings.TrimPrefix(ref, "e")); err != nil {
+			return "", fmt.Errorf("invalid element ref: %s", raw)
+		}
+		return ref, nil
+	}
+	if _, err := strconv.Atoi(ref); err != nil {
+		return "", fmt.Errorf("invalid element ref: %s", raw)
+	}
+	return "e" + ref, nil
+}
+
+// browserRunValue runs compact-tool server JavaScript and returns its structured value.
+func browserRunValue(c *mcp.Client, code string) (*mcp.ToolResult, any, error) {
+	result, err := c.CallTool("run", map[string]any{"code": code})
+	if err != nil {
+		return result, nil, err
+	}
+	value, ok := result.StructuredContent["value"]
+	if !ok {
+		return result, nil, fmt.Errorf("run did not return a structured value")
+	}
+	return result, value, nil
+}
+
+func textResult(text string, structured map[string]any) *mcp.ToolResult {
+	return &mcp.ToolResult{
+		Content:           []mcp.ContentItem{{Type: "text", Text: text}},
+		StructuredContent: structured,
+	}
+}
+
+func jsLiteral(v any) string {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return "null"
+	}
+	return string(data)
+}
+
+func valueMap(v any) (map[string]any, bool) {
+	m, ok := v.(map[string]any)
+	return m, ok
+}
+
+func resultData(value any) map[string]any {
+	if data, ok := valueMap(value); ok {
+		return data
+	}
+	return map[string]any{"value": value}
+}
+
+func valueSlice(v any) []any {
+	items, ok := v.([]any)
+	if !ok {
+		return nil
+	}
+	return items
+}
+
+func stringValue(v any) string {
+	if s, ok := v.(string); ok {
+		return s
+	}
+	return ""
+}
+
+func numberValue(v any) int {
+	switch n := v.(type) {
+	case int:
+		return n
+	case int32:
+		return int(n)
+	case int64:
+		return int(n)
+	case float64:
+		return int(n)
+	case json.Number:
+		i, _ := n.Int64()
+		return int(i)
+	default:
+		return 0
+	}
+}
+
+func copyLocalFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	if err := os.MkdirAll(filepath.Dir(dst), 0755); err != nil {
+		return err
+	}
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+
+	if _, err := io.Copy(out, in); err != nil {
+		_ = out.Close()
+		return err
+	}
+	return out.Close()
+}
+
+// sanitizeDownloadFilename keeps browser-provided names inside the requested directory.
+func sanitizeDownloadFilename(filename string) (string, error) {
+	name := strings.TrimSpace(filename)
+	if name == "" || name == "." || name == ".." {
+		return "", fmt.Errorf("unsafe download filename: %q", filename)
+	}
+	if filepath.IsAbs(name) || filepath.VolumeName(name) != "" || filepath.Base(name) != name || strings.ContainsAny(name, `/\`) {
+		return "", fmt.Errorf("unsafe download filename: %q", filename)
+	}
+	return name, nil
+}
+
+func copyDownloadFile(src, dir, filename string) (string, error) {
+	safeName, err := sanitizeDownloadFilename(filename)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return "", err
+	}
+
+	in, err := os.Open(src)
+	if err != nil {
+		return "", err
+	}
+	defer in.Close()
+
+	ext := filepath.Ext(safeName)
+	base := strings.TrimSuffix(safeName, ext)
+	if base == "" {
+		base = safeName
+		ext = ""
+	}
+	for i := 0; i < 1000; i++ {
+		name := safeName
+		if i > 0 {
+			name = fmt.Sprintf("%s-%d%s", base, i, ext)
+		}
+		dst := filepath.Join(dir, name)
+		out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+		if os.IsExist(err) {
+			continue
+		}
+		if err != nil {
+			return "", err
+		}
+		if _, err := io.Copy(out, in); err != nil {
+			_ = out.Close()
+			_ = os.Remove(dst)
+			return "", err
+		}
+		if err := out.Close(); err != nil {
+			_ = os.Remove(dst)
+			return "", err
+		}
+		return dst, nil
+	}
+	return "", fmt.Errorf("no available destination for %q", safeName)
+}

--- a/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
@@ -1,0 +1,156 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestCompactToolMappings(t *testing.T) {
+	tests := []struct {
+		name string
+		got  map[string]any
+		want map[string]any
+	}{
+		{
+			name: "click",
+			got:  clickToolArgs(7, "e12", "right", 2),
+			want: map[string]any{
+				"page":       7,
+				"kind":       "click",
+				"ref":        "e12",
+				"button":     "right",
+				"clickCount": 2,
+			},
+		},
+		{
+			name: "click at",
+			got:  clickAtToolArgs(7, 10, 20),
+			want: map[string]any{
+				"page": 7,
+				"kind": "click_at",
+				"x":    10,
+				"y":    20,
+			},
+		},
+		{
+			name: "open tab",
+			got:  openTabsToolArgs("https://example.com", true, false),
+			want: map[string]any{
+				"action":     "new",
+				"url":        "https://example.com",
+				"hidden":     true,
+				"background": false,
+			},
+		},
+		{
+			name: "pdf",
+			got:  pdfToolArgs(7),
+			want: map[string]any{"page": 7},
+		},
+		{
+			name: "download",
+			got:  downloadToolArgs(7, "e12"),
+			want: map[string]any{
+				"page": 7,
+				"ref":  "e12",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !reflect.DeepEqual(tt.got, tt.want) {
+				t.Fatalf("mapping = %#v, want %#v", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestOpenInWindowCodeUsesCompactRunBridge(t *testing.T) {
+	code := openInWindowCode("https://example.com/?q=one two", true, false, 9)
+	for _, want := range []string{
+		"browser.pages.newPage",
+		`"https://example.com/?q=one two"`,
+		"hidden: true",
+		"background: false",
+		"windowId: 9",
+	} {
+		if !strings.Contains(code, want) {
+			t.Fatalf("openInWindowCode() missing %q in:\n%s", want, code)
+		}
+	}
+}
+
+func TestScreenshotToolArgsRejectsUnsupportedQualityFormat(t *testing.T) {
+	_, err := screenshotToolArgs(7, "webp", false, 20, true)
+	if err == nil {
+		t.Fatal("screenshotToolArgs() error = nil, want unsupported quality error")
+	}
+
+	got, err := screenshotToolArgs(7, "jpeg", true, 80, true)
+	if err != nil {
+		t.Fatalf("screenshotToolArgs() error = %v", err)
+	}
+	want := map[string]any{
+		"page":     7,
+		"format":   "jpeg",
+		"fullPage": true,
+		"quality":  80,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("screenshot args = %#v, want %#v", got, want)
+	}
+}
+
+func TestCopyDownloadFileRejectsUnsafeNames(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source")
+	if err := os.WriteFile(src, []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, filename := range []string{"", ".", "..", "../report.csv", "nested/report.csv", `nested\report.csv`, "/tmp/report.csv"} {
+		t.Run(filename, func(t *testing.T) {
+			if _, err := copyDownloadFile(src, dir, filename); err == nil {
+				t.Fatalf("copyDownloadFile(%q) error = nil, want unsafe filename error", filename)
+			}
+		})
+	}
+}
+
+func TestCopyDownloadFileAvoidsOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "source")
+	if err := os.WriteFile(src, []byte("new"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	existing := filepath.Join(dir, "report.csv")
+	if err := os.WriteFile(existing, []byte("old"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	dst, err := copyDownloadFile(src, dir, "report.csv")
+	if err != nil {
+		t.Fatalf("copyDownloadFile() error = %v", err)
+	}
+	if filepath.Base(dst) != "report-1.csv" {
+		t.Fatalf("destination = %q, want report-1.csv suffix", dst)
+	}
+	existingData, err := os.ReadFile(existing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(existingData) != "old" {
+		t.Fatalf("existing file = %q, want old", existingData)
+	}
+	newData, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(newData) != "new" {
+		t.Fatalf("copied file = %q, want new", newData)
+	}
+}

--- a/packages/browseros-agent/apps/cli/cmd/wait.go
+++ b/packages/browseros-agent/apps/cli/cmd/wait.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"browseros-cli/output"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -20,6 +21,9 @@ func init() {
 			if text == "" && selector == "" {
 				output.Errorf(3, "provide --text or --selector")
 			}
+			if text != "" && selector != "" {
+				output.Errorf(3, "provide only one of --text or --selector")
+			}
 
 			c := newClient()
 			pageID, err := resolvePageID(c)
@@ -32,15 +36,24 @@ func init() {
 				"timeout": waitTimeout,
 			}
 			if text != "" {
-				toolArgs["text"] = text
-			}
-			if selector != "" {
-				toolArgs["selector"] = selector
+				toolArgs["for"] = "text"
+				toolArgs["value"] = text
+			} else {
+				toolArgs["for"] = "selector"
+				toolArgs["value"] = selector
 			}
 
-			result, err := c.CallTool("wait_for", toolArgs)
+			result, err := c.CallTool("wait", toolArgs)
 			if err != nil {
 				output.Error(err.Error(), 1)
+			}
+			matched, hasMatch := result.StructuredContent["matched"].(bool)
+			if hasMatch && !matched {
+				if jsonOut {
+					output.JSON(result)
+					os.Exit(1)
+				}
+				output.Error(result.TextContent(), 1)
 			}
 			if jsonOut {
 				output.JSON(result)

--- a/packages/browseros-agent/apps/cli/cmd/window.go
+++ b/packages/browseros-agent/apps/cli/cmd/window.go
@@ -21,7 +21,7 @@ func init() {
 		Args:  cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			c := newClient()
-			result, err := c.CallTool("list_windows", nil)
+			result, err := c.CallTool("windows", map[string]any{"action": "list"})
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -41,13 +41,10 @@ func init() {
 			hidden, _ := cmd.Flags().GetBool("hidden")
 
 			c := newClient()
-			toolName := "create_window"
-			toolArgs := map[string]any{}
-			if hidden {
-				toolName = "create_hidden_window"
-			}
-
-			result, err := c.CallTool(toolName, toolArgs)
+			result, err := c.CallTool("windows", map[string]any{
+				"action": "create",
+				"hidden": hidden,
+			})
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -70,7 +67,10 @@ func init() {
 				output.Errorf(3, "invalid window ID: %s", args[0])
 			}
 			c := newClient()
-			result, err := c.CallTool("close_window", map[string]any{"windowId": windowID})
+			result, err := c.CallTool("windows", map[string]any{
+				"action":   "close",
+				"windowId": windowID,
+			})
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -92,7 +92,10 @@ func init() {
 				output.Errorf(3, "invalid window ID: %s", args[0])
 			}
 			c := newClient()
-			result, err := c.CallTool("activate_window", map[string]any{"windowId": windowID})
+			result, err := c.CallTool("windows", map[string]any{
+				"action":   "activate",
+				"windowId": windowID,
+			})
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}

--- a/packages/browseros-agent/apps/cli/mcp/client.go
+++ b/packages/browseros-agent/apps/cli/mcp/client.go
@@ -117,7 +117,12 @@ func (c *Client) ResolvePageID(explicit *int) (int, error) {
 	if explicit != nil {
 		return *explicit, nil
 	}
-	result, err := c.CallTool("get_active_page", nil)
+	result, err := c.CallTool("run", map[string]any{
+		"code": `const pages = await browser.pages.list()
+const page = pages.find((p) => p.isActive) ?? pages[0]
+if (!page) throw new Error('No active page found.')
+return page.pageId`,
+	})
 	if err != nil {
 		return 0, fmt.Errorf("no active page: %w", err)
 	}
@@ -136,7 +141,19 @@ func extractPageID(sc map[string]any) (int, bool) {
 	if pageID, ok := intValue(sc["pageId"]); ok {
 		return pageID, true
 	}
+	if pageID, ok := intValue(sc["value"]); ok {
+		return pageID, true
+	}
 	page, ok := sc["page"].(map[string]any)
+	if !ok {
+		if value, valueOK := sc["value"].(map[string]any); valueOK {
+			pageID, ok := intValue(value["pageId"])
+			if ok {
+				return pageID, true
+			}
+			page, ok = value["page"].(map[string]any)
+		}
+	}
 	if !ok {
 		return 0, false
 	}

--- a/packages/browseros-agent/apps/cli/mcp/client_test.go
+++ b/packages/browseros-agent/apps/cli/mcp/client_test.go
@@ -63,6 +63,24 @@ func TestExtractPageID(t *testing.T) {
 			ok:   true,
 		},
 		{
+			name: "run value page id",
+			data: map[string]any{
+				"value": float64(17),
+			},
+			want: 17,
+			ok:   true,
+		},
+		{
+			name: "run value page object",
+			data: map[string]any{
+				"value": map[string]any{
+					"pageId": float64(19),
+				},
+			},
+			want: 19,
+			ok:   true,
+		},
+		{
 			name: "non whole float page id",
 			data: map[string]any{
 				"pageId": 3.5,

--- a/packages/browseros-agent/apps/cli/output/printer.go
+++ b/packages/browseros-agent/apps/cli/output/printer.go
@@ -80,6 +80,9 @@ func PageList(result *mcp.ToolResult) {
 			continue
 		}
 		pageID := intVal(page["pageId"])
+		if pageID == 0 {
+			pageID = intVal(page["page"])
+		}
 		tabID := intVal(page["tabId"])
 		title := strVal(page["title"])
 		url := strVal(page["url"])
@@ -103,10 +106,18 @@ func ActivePage(result *mcp.ToolResult) {
 	}
 
 	sc := result.StructuredContent
-	pageID := intVal(sc["pageId"])
-	tabID := intVal(sc["tabId"])
-	title := strVal(sc["title"])
-	url := strVal(sc["url"])
+	page := sc
+	if nested, ok := sc["page"].(map[string]any); ok {
+		page = nested
+	}
+
+	pageID := intVal(page["pageId"])
+	if pageID == 0 {
+		pageID = intVal(page["page"])
+	}
+	tabID := intVal(page["tabId"])
+	title := strVal(page["title"])
+	url := strVal(page["url"])
 
 	fmt.Printf("Active page: %d (tab %d)\n", pageID, tabID)
 	fmt.Println(title)
@@ -114,8 +125,18 @@ func ActivePage(result *mcp.ToolResult) {
 }
 
 func intVal(v any) int {
-	if f, ok := v.(float64); ok {
-		return int(f)
+	switch n := v.(type) {
+	case int:
+		return n
+	case int32:
+		return int(n)
+	case int64:
+		return int(n)
+	case float64:
+		return int(n)
+	case json.Number:
+		i, _ := n.Int64()
+		return int(i)
 	}
 	return 0
 }

--- a/packages/browseros-agent/apps/server/src/browser/core/input/input.ts
+++ b/packages/browseros-agent/apps/server/src/browser/core/input/input.ts
@@ -23,6 +23,11 @@ export interface ClickOptions {
   clickCount?: number
 }
 
+export interface DragResult {
+  from: { x: number; y: number }
+  to: { x: number; y: number }
+}
+
 export type ScrollDirection = 'up' | 'down' | 'left' | 'right'
 
 const SELECT_OPTION_FN = `function(val){
@@ -196,6 +201,12 @@ export class Input {
     return coords
   }
 
+  async focus(ref: string): Promise<void> {
+    const { session, backendNodeId } = await this.observer.resolveRef(ref)
+    await scrollIntoView(session, backendNodeId)
+    await focusElement(session, backendNodeId)
+  }
+
   async type(text: string): Promise<void> {
     await this.withPageSessionRetry((session) => typeText(session, text))
   }
@@ -230,6 +241,28 @@ export class Input {
       [value],
     )
     return (selected as string | null) ?? null
+  }
+
+  async check(ref: string): Promise<boolean> {
+    const { session, backendNodeId } = await this.observer.resolveRef(ref)
+    const checked = await callOnElement(
+      session,
+      backendNodeId,
+      'function(){return this.checked}',
+    )
+    if (!checked) await this.clickNode(session, backendNodeId)
+    return true
+  }
+
+  async uncheck(ref: string): Promise<boolean> {
+    const { session, backendNodeId } = await this.observer.resolveRef(ref)
+    const checked = await callOnElement(
+      session,
+      backendNodeId,
+      'function(){return this.checked}',
+    )
+    if (checked) await this.clickNode(session, backendNodeId)
+    return false
   }
 
   async focusBackendNode(backendNodeId: number): Promise<void> {
@@ -278,13 +311,25 @@ export class Input {
     )
   }
 
+  async drag(sourceRef: string, targetRef: string): Promise<DragResult> {
+    const source = await this.observer.resolveRef(sourceRef)
+    const target = await this.observer.resolveRef(targetRef)
+    if (source.session !== target.session) {
+      throw new Error('Drag across frame sessions is not supported.')
+    }
+
+    await scrollIntoView(source.session, source.backendNodeId)
+    await scrollIntoView(target.session, target.backendNodeId)
+    const from = await getElementCenter(source.session, source.backendNodeId)
+    const to = await getElementCenter(target.session, target.backendNodeId)
+    await dispatchDrag(source.session, from, to)
+    return { from, to }
+  }
+
   async dragBackendNode(
     sourceBackendNodeId: number,
     target: { element?: number; x?: number; y?: number },
-  ): Promise<{
-    from: { x: number; y: number }
-    to: { x: number; y: number }
-  }> {
+  ): Promise<DragResult> {
     return this.withPageSessionRetry(async (session) => {
       await scrollIntoView(session, sourceBackendNodeId)
       const from = await getElementCenter(session, sourceBackendNodeId)

--- a/packages/browseros-agent/apps/server/src/tools/browser/act.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/act.ts
@@ -14,7 +14,7 @@ type InputApi = ReturnType<BrowserSession['input']>
 export const act = defineTool({
   name: 'act',
   description:
-    'Act on the page using refs from the last snapshot. kinds: click, type (into focused element), fill (one field via ref+value, or many via fields[]), press (a key/combo), hover, select (an option value), scroll. Reads back a diff of what changed - re-snapshot if you need fresh refs.',
+    'Act on the page using refs from the last snapshot. kinds: click, type (into focused element), fill (one field via ref+value, or many via fields[]), press (a key/combo), hover, focus, check, uncheck, select (an option value), scroll, drag. Reads back a diff of what changed - re-snapshot if you need fresh refs.',
   input: z.object({
     page: z.number().int(),
     kind: z.enum([
@@ -26,8 +26,12 @@ export const act = defineTool({
       'press',
       'hover',
       'hover_at',
+      'focus',
+      'check',
+      'uncheck',
       'select',
       'scroll',
+      'drag',
       'drag_at',
     ]),
     ref: z.string().optional().describe('Target element ref, e.g. "e12".'),
@@ -48,6 +52,7 @@ export const act = defineTool({
       .describe('Scroll amount (wheel notches), default 3.'),
     x: z.number().optional().describe('Viewport x coordinate for *_at kinds.'),
     y: z.number().optional().describe('Viewport y coordinate for *_at kinds.'),
+    targetRef: z.string().optional().describe('Target ref for kind=drag.'),
     startX: z.number().optional().describe('Drag start x coordinate.'),
     startY: z.number().optional().describe('Drag start y coordinate.'),
     endX: z.number().optional().describe('Drag end x coordinate.'),
@@ -79,6 +84,7 @@ type ActArgs = {
   amount?: number
   x?: number
   y?: number
+  targetRef?: string
   startX?: number
   startY?: number
   endX?: number
@@ -102,8 +108,12 @@ const ACT_HANDLERS: Record<string, ActHandler> = {
   press,
   hover,
   hover_at: hoverAt,
+  focus,
+  check,
+  uncheck,
   select,
   scroll,
+  drag,
   drag_at: dragAt,
 }
 
@@ -162,11 +172,12 @@ async function fill(
   input: InputApi,
 ): Promise<ToolResult | undefined> {
   if (args.fields) {
-    for (const field of args.fields) await input.fill(field.ref, field.value)
+    for (const field of args.fields)
+      await input.fill(field.ref, field.value, { clear: args.clear })
     return undefined
   }
   if (args.ref && args.value !== undefined) {
-    await input.fill(args.ref, args.value)
+    await input.fill(args.ref, args.value, { clear: args.clear })
     return undefined
   }
   return errorResult('act fill: provide fields[] or both ref and value.')
@@ -200,6 +211,33 @@ async function hoverAt(
   return undefined
 }
 
+async function focus(
+  args: ActArgs,
+  input: InputApi,
+): Promise<ToolResult | undefined> {
+  if (!args.ref) return errorResult('act focus: ref is required.')
+  await input.focus(args.ref)
+  return undefined
+}
+
+async function check(
+  args: ActArgs,
+  input: InputApi,
+): Promise<ToolResult | undefined> {
+  if (!args.ref) return errorResult('act check: ref is required.')
+  await input.check(args.ref)
+  return undefined
+}
+
+async function uncheck(
+  args: ActArgs,
+  input: InputApi,
+): Promise<ToolResult | undefined> {
+  if (!args.ref) return errorResult('act uncheck: ref is required.')
+  await input.uncheck(args.ref)
+  return undefined
+}
+
 async function select(
   args: ActArgs,
   input: InputApi,
@@ -216,6 +254,17 @@ async function scroll(
   input: InputApi,
 ): Promise<ToolResult | undefined> {
   await input.scroll(args.direction ?? 'down', args.amount ?? 3, args.ref)
+  return undefined
+}
+
+async function drag(
+  args: ActArgs,
+  input: InputApi,
+): Promise<ToolResult | undefined> {
+  if (!args.ref || !args.targetRef) {
+    return errorResult('act drag: ref and targetRef are required.')
+  }
+  await input.drag(args.ref, args.targetRef)
   return undefined
 }
 

--- a/packages/browseros-agent/apps/server/src/tools/browser/read.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/read.ts
@@ -25,12 +25,33 @@ export const read = defineTool({
     page: z.number().int(),
     format: z.enum(['markdown', 'text', 'links']).default('markdown'),
     selector: z.string().optional().describe('Restrict to a CSS subtree.'),
+    viewportOnly: z
+      .boolean()
+      .optional()
+      .describe('For markdown reads, include only visible viewport content.'),
+    includeLinks: z
+      .boolean()
+      .optional()
+      .describe('For markdown reads, render links as markdown links.'),
+    includeImages: z
+      .boolean()
+      .optional()
+      .describe('For markdown reads, include image references.'),
   }),
   annotations: { readOnlyHint: true },
   handler: async (args, ctx) => {
     const { session } = await ctx.session.pages.getSession(args.page)
+    const code =
+      args.format === 'markdown'
+        ? buildContentMarkdownExpression({
+            selector: args.selector,
+            viewportOnly: args.viewportOnly,
+            includeLinks: args.includeLinks,
+            includeImages: args.includeImages,
+          })
+        : expressionFor(args.format, args.selector)
     const result = await session.Runtime.evaluate({
-      expression: expressionFor(args.format, args.selector),
+      expression: code,
       returnByValue: true,
     })
     if (result.exceptionDetails) {

--- a/packages/browseros-agent/apps/server/src/tools/browser/run.ts
+++ b/packages/browseros-agent/apps/server/src/tools/browser/run.ts
@@ -64,9 +64,22 @@ export const run = defineTool({
       args.timeout ?? DEFAULT_TIMEOUT_MS,
       logs,
     )
-    return outcome.ok
-      ? textResult(format(outcome), { ok: true })
-      : { ...errorResult(format(outcome)), structuredContent: { ok: false } }
+    if (outcome.ok) {
+      const value = jsonSafeValue(outcome.value)
+      return textResult(format(outcome), {
+        ok: true,
+        ...(value !== undefined && { value }),
+        logs: outcome.logs,
+      })
+    }
+    return {
+      ...errorResult(format(outcome)),
+      structuredContent: {
+        ok: false,
+        logs: outcome.logs,
+        error: outcome.error?.message,
+      },
+    }
   },
 })
 
@@ -140,4 +153,26 @@ function safeStringify(value: unknown): string {
   } catch {
     return String(value)
   }
+}
+
+function jsonSafeValue(value: unknown): unknown {
+  const seen = new WeakSet<object>()
+  let encoded: string | undefined
+  try {
+    encoded = JSON.stringify(value, (_key, next) => {
+      if (typeof next === 'bigint') return next.toString()
+      if (typeof next === 'function' || typeof next === 'symbol') {
+        return String(next)
+      }
+      if (typeof next === 'number' && !Number.isFinite(next)) return null
+      if (typeof next === 'object' && next !== null) {
+        if (seen.has(next)) return '[Circular]'
+        seen.add(next)
+      }
+      return next
+    })
+  } catch {
+    return safeStringify(value)
+  }
+  return encoded === undefined ? undefined : JSON.parse(encoded)
 }

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -598,7 +598,11 @@ return { title: pages[0].title }
     })
 
     expect(result?.isError).toBeFalsy()
-    expect(result?.structuredContent).toEqual({ ok: true })
+    expect(result?.structuredContent).toEqual({
+      ok: true,
+      value: { title: 'Example' },
+      logs: ['pages 1', 'warn: {\n  "pageId": 7\n}'],
+    })
     expect(result?.content).toEqual([
       expect.objectContaining({
         type: 'text',
@@ -617,6 +621,28 @@ return { title: pages[0].title }
         text: expect.stringContaining('logs:\npages 1\nwarn:'),
       }),
     ])
+  })
+
+  it('keeps run structured values JSON-safe', async () => {
+    const fake = createFakeServer()
+    const session = { pages: {} } as unknown as BrowserSession
+
+    registerBrowserTools(fake.server as never, session)
+
+    const result = await fake.handlers.get('run')?.({
+      code: `
+const value = { id: 1n }
+value.self = value
+return value
+`,
+    })
+
+    expect(result?.isError).toBeFalsy()
+    expect(result?.structuredContent).toEqual({
+      ok: true,
+      value: { id: '1', self: '[Circular]' },
+      logs: [],
+    })
   })
 
   it('returns run syntax errors without invoking the browser session', async () => {
@@ -662,7 +688,11 @@ throw new Error('boom')
     })
 
     expect(result?.isError).toBe(true)
-    expect(result?.structuredContent).toEqual({ ok: false })
+    expect(result?.structuredContent).toEqual({
+      ok: false,
+      logs: ['before boom'],
+      error: 'boom',
+    })
     expect(result?.content).toEqual([
       expect.objectContaining({
         type: 'text',
@@ -692,7 +722,11 @@ return 'late'
     })
 
     expect(result?.isError).toBe(true)
-    expect(result?.structuredContent).toEqual({ ok: false })
+    expect(result?.structuredContent).toEqual({
+      ok: false,
+      logs: [],
+      error: 'run exceeded 1ms',
+    })
     expect(result?.content).toEqual([
       expect.objectContaining({
         type: 'text',
@@ -1624,8 +1658,13 @@ return 'late'
       press: async () => calls.push('press'),
       hover: async () => calls.push('hover'),
       hoverAt: async () => calls.push('hoverAt'),
+      focus: async (ref: string) => calls.push(`focus:${ref}`),
+      check: async (ref: string) => calls.push(`check:${ref}`),
+      uncheck: async (ref: string) => calls.push(`uncheck:${ref}`),
       selectOption: async () => calls.push('selectOption'),
       scroll: async () => calls.push('scroll'),
+      drag: async (source: string, target: string) =>
+        calls.push(`drag:${source}->${target}`),
       dragAt: async () => calls.push('dragAt'),
     }
     const session = {
@@ -1720,6 +1759,27 @@ return 'late'
         ref: 'e1',
       }),
     ).toMatchObject({ structuredContent: { kind: 'click', changed: true } })
+    await fake.handlers.get('act')?.({
+      page: 1,
+      kind: 'focus',
+      ref: 'e1',
+    })
+    await fake.handlers.get('act')?.({
+      page: 1,
+      kind: 'check',
+      ref: 'e2',
+    })
+    await fake.handlers.get('act')?.({
+      page: 1,
+      kind: 'uncheck',
+      ref: 'e3',
+    })
+    await fake.handlers.get('act')?.({
+      page: 1,
+      kind: 'drag',
+      ref: 'e4',
+      targetRef: 'e5',
+    })
     expect(calls).toEqual([
       'goto',
       'snapshot',
@@ -1727,6 +1787,14 @@ return 'late'
       'diff',
       'snapshot',
       'click',
+      'diff',
+      'focus:e1',
+      'diff',
+      'check:e2',
+      'diff',
+      'uncheck:e3',
+      'diff',
+      'drag:e4->e5',
       'diff',
     ])
   })


### PR DESCRIPTION
## Summary
- remap browseros-cli commands onto the compact BrowserOS MCP tool surface
- bridge bookmark/history and window-specific flows through compact run where needed
- add compact server compatibility for CLI actions, read flags, and JSON-safe run structured values
- add focused CLI/server coverage for tool mappings, eval snippets, safe downloads, screenshot args, and compact action routing

## Verification
- apps/cli: gofmt -l . && go vet ./... && go build ./... && go test ./...
- bun test apps/server/tests/tools/browser/register.test.ts
- legacy direct CallTool scan for removed browser tool names
- git diff --check
- bun run check (exits 0; existing Biome/fallow warnings remain)
- bun run test