### PR TITLE
chore: timestamp dev CLI versions

### DIFF
--- a/packages/browseros-agent/apps/cli/Makefile
+++ b/packages/browseros-agent/apps/cli/Makefile
@@ -2,8 +2,9 @@ BINARY := browseros-cli
 SOURCES := $(shell find . -name '*.go')
 VERSION ?= dev
 POSTHOG_API_KEY ?=
+BUILD_TIMESTAMP ?= $(shell date +%y%m%d-%H%M)
 DIST := dist
-LDFLAGS := -X main.version=$(VERSION) -X browseros-cli/analytics.posthogAPIKey=$(POSTHOG_API_KEY)
+LDFLAGS := -X main.version=$(VERSION) -X main.buildTimestamp=$(BUILD_TIMESTAMP) -X browseros-cli/analytics.posthogAPIKey=$(POSTHOG_API_KEY)
 HOST_OS := $(shell go env GOOS)
 HOST_ARCH := $(shell go env GOARCH)
 HOST_EXT := $(if $(filter windows,$(HOST_OS)),.exe,)

--- a/packages/browseros-agent/apps/cli/main.go
+++ b/packages/browseros-agent/apps/cli/main.go
@@ -2,9 +2,20 @@ package main
 
 import "browseros-cli/cmd"
 
-var version = "dev"
+var (
+	version        = "dev"
+	buildTimestamp string
+)
 
 func main() {
-	cmd.SetVersion(version)
+	cmd.SetVersion(resolvedVersion(version, buildTimestamp))
 	cmd.Execute()
+}
+
+// resolvedVersion adds build-time metadata only to local dev versions.
+func resolvedVersion(version, buildTimestamp string) string {
+	if version == "dev" && buildTimestamp != "" {
+		return version + "-" + buildTimestamp
+	}
+	return version
 }

--- a/packages/browseros-agent/apps/cli/main_test.go
+++ b/packages/browseros-agent/apps/cli/main_test.go
@@ -1,0 +1,39 @@
+package main
+
+import "testing"
+
+func TestResolvedVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		version   string
+		timestamp string
+		want      string
+	}{
+		{
+			name:      "dev with timestamp",
+			version:   "dev",
+			timestamp: "260624-1156",
+			want:      "dev-260624-1156",
+		},
+		{
+			name:    "dev without timestamp",
+			version: "dev",
+			want:    "dev",
+		},
+		{
+			name:      "release with timestamp",
+			version:   "0.2.0",
+			timestamp: "260624-1156",
+			want:      "0.2.0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolvedVersion(tt.version, tt.timestamp)
+			if got != tt.want {
+				t.Fatalf("resolvedVersion(%q, %q) = %q, want %q", tt.version, tt.timestamp, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Default CLI Makefile builds now inject a YYMMDD-HHMM build timestamp alongside dev version metadata.
- Runtime version resolution only suffixes exact dev builds, so release VERSION values still report exactly as provided.
- Added focused unit coverage for dev suffixing, dev fallback, and release passthrough.

## Design
The Makefile passes a separate main.buildTimestamp ldflag for build/install time. main.go resolves dev plus timestamp into dev-YYMMDD-HHMM immediately before cmd.SetVersion, while explicit release versions bypass the suffix.

## Test plan
- [x] cd apps/cli && gofmt -l .
- [x] cd apps/cli && go vet ./...
- [x] cd apps/cli && go build ./...
- [x] cd apps/cli && go test ./...
- [x] make-built smoke: default dev binary reports dev-260624-1157
- [x] make-built smoke: VERSION=0.2.0 binary reports 0.2.0