### PR TITLE
Fix CLI releases to use pushed tags

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -142,11 +142,18 @@ jobs:
           VERSION="${{ steps.release.outputs.version }}"
 
           CLI_DIST="packages/browseros-agent/apps/cli/dist"
-          gh release create "$TAG" \
-            --verify-tag \
-            --title "BrowserOS CLI - v${VERSION}" \
-            --notes-file /tmp/release-notes.md \
-            ${CLI_DIST}/*
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" \
+              --title "BrowserOS CLI - v${VERSION}" \
+              --notes-file /tmp/release-notes.md
+            gh release upload "$TAG" ${CLI_DIST}/* --clobber
+          else
+            gh release create "$TAG" \
+              --verify-tag \
+              --title "BrowserOS CLI - v${VERSION}" \
+              --notes-file /tmp/release-notes.md \
+              ${CLI_DIST}/*
+          fi
         working-directory: ${{ github.workspace }}
 
       - name: Setup Node.js

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,12 +1,9 @@
 name: Release BrowserOS CLI
 
 on:
-  workflow_dispatch:
-    inputs:
-      version:
-        description: "Release version (e.g. 0.1.0)"
-        required: true
-        type: string
+  push:
+    tags:
+      - "cli/v*"
 
 concurrency:
   group: release-cli
@@ -14,7 +11,6 @@ concurrency:
 
 jobs:
   release:
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     environment: release-core
     permissions:
@@ -29,13 +25,25 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: packages/browseros-agent/apps/cli/go.mod
-
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.6"
+
+      - name: Validate release tag
+        id: release
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          bun packages/browseros-agent/scripts/build/cli/release-policy.ts validate \
+            --tag "$RELEASE_TAG" \
+            --default-branch "$DEFAULT_BRANCH" \
+            --repository-root "${{ github.workspace }}"
+        working-directory: ${{ github.workspace }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: packages/browseros-agent/apps/cli/go.mod
 
       - name: Run tests
         run: make test
@@ -44,7 +52,7 @@ jobs:
         run: make vet
 
       - name: Build all platforms
-        run: make release VERSION=${{ inputs.version }} POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}
+        run: make release VERSION=${{ steps.release.outputs.version }} POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}
 
       - name: Install dependencies
         run: bun install
@@ -57,7 +65,7 @@ jobs:
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           R2_BUCKET: ${{ secrets.R2_BUCKET }}
           R2_UPLOAD_PREFIX: cli
-          CLI_VERSION: ${{ inputs.version }}
+          CLI_VERSION: ${{ steps.release.outputs.version }}
         run: |
           bun scripts/build/cli.ts \
             --release \
@@ -70,14 +78,14 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           CLI_PATH="packages/browseros-agent/apps/cli"
-          TAG="browseros-cli-v${{ inputs.version }}"
+          TAG="${{ steps.release.outputs.tag }}"
           CHANGELOG_FILE="/tmp/release-changelog.md"
-          PREV_TAG=$(git tag -l "browseros-cli-v*" --sort=-v:refname | grep -v "^${TAG}$" | head -n 1)
+          PREV_TAG="${{ steps.release.outputs.previous_tag }}"
 
           if [ -z "$PREV_TAG" ]; then
             echo "Initial release of browseros-cli." > "$CHANGELOG_FILE"
           else
-            COMMITS=$(git log "$PREV_TAG"..HEAD --pretty=format:"%H" -- "$CLI_PATH")
+            COMMITS=$(git log "$PREV_TAG".."$TAG" --pretty=format:"%H" -- "$CLI_PATH")
 
             if [ -z "$COMMITS" ]; then
               echo "No notable changes." > "$CHANGELOG_FILE"
@@ -126,22 +134,17 @@ jobs:
           EOF
         working-directory: ${{ github.workspace }}
 
-      - name: Create tag and release
+      - name: Create GitHub release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="browseros-cli-v${{ inputs.version }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-
-          if ! git rev-parse "$TAG" >/dev/null 2>&1; then
-            git tag -a "$TAG" -m "browseros-cli v${{ inputs.version }}"
-            git push origin "$TAG"
-          fi
+          TAG="${{ steps.release.outputs.tag }}"
+          VERSION="${{ steps.release.outputs.version }}"
 
           CLI_DIST="packages/browseros-agent/apps/cli/dist"
           gh release create "$TAG" \
-            --title "BrowserOS CLI - v${{ inputs.version }}" \
+            --verify-tag \
+            --title "BrowserOS CLI - v${VERSION}" \
             --notes-file /tmp/release-notes.md \
             ${CLI_DIST}/*
         working-directory: ${{ github.workspace }}
@@ -156,6 +159,6 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          make npm-version VERSION=${{ inputs.version }}
+          make npm-version VERSION=${{ steps.release.outputs.version }}
           cd npm
           npm publish --access public

--- a/packages/browseros-agent/apps/cli/README.md
+++ b/packages/browseros-agent/apps/cli/README.md
@@ -63,6 +63,27 @@ browseros-cli update --check # check only
 browseros-cli update --yes   # apply without prompting
 ```
 
+### Release flow
+
+CLI releases are cut from annotated git tags. The tag is the source of truth for the release version; do not commit a version bump or add a checked-in version file.
+
+```bash
+git tag -a cli/v0.2.3 -m "browseros-cli v0.2.3"
+git push origin cli/v0.2.3
+```
+
+Pushing `cli/vX.Y.Z` starts the CLI release workflow. The workflow rejects tags that are not newer than production latest or whose target commit is not reachable from the repository default branch.
+
+Inspect versions with:
+
+```bash
+browseros-cli --version
+curl -fsSL https://cdn.browseros.com/cli/latest/version.txt
+curl -fsSL https://cdn.browseros.com/cli/latest/manifest.json
+git tag -l 'cli/v*' --sort=-v:refname
+git tag -l 'browseros-cli-v*' --sort=-v:refname
+```
+
 ## Usage
 
 ```bash

--- a/packages/browseros-agent/apps/cli/npm/scripts/postinstall.js
+++ b/packages/browseros-agent/apps/cli/npm/scripts/postinstall.js
@@ -6,7 +6,8 @@ const { execSync } = require('node:child_process')
 const { createHash } = require('node:crypto')
 
 const VERSION = require('../package.json').version
-const GITHUB_RELEASE_BASE = `https://github.com/browseros-ai/BrowserOS/releases/download/browseros-cli-v${VERSION}`
+const GITHUB_RELEASE_TAG = `cli/v${VERSION}`
+const GITHUB_RELEASE_BASE = `https://github.com/browseros-ai/BrowserOS/releases/download/${encodeURIComponent(GITHUB_RELEASE_TAG)}`
 const BINARY_DIR = path.join(__dirname, '..', '.binary')
 const EXT = process.platform === 'win32' ? '.exe' : ''
 const BINARY_PATH = path.join(BINARY_DIR, `browseros-cli${EXT}`)

--- a/packages/browseros-agent/scripts/build/cli/release-policy.test.ts
+++ b/packages/browseros-agent/scripts/build/cli/release-policy.test.ts
@@ -1,8 +1,14 @@
 import { describe, expect, test } from 'bun:test'
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import {
   assertIncrementingRelease,
   compareReleaseVersions,
+  ensureAnnotatedTag,
+  ensureTagReachableFromDefaultBranch,
   parseCliReleaseTag,
   selectPreviousCliReleaseTag,
 } from './release-policy'
@@ -109,3 +115,58 @@ describe('selectPreviousCliReleaseTag', () => {
     ).toBe('')
   })
 })
+
+describe('ensureTagReachableFromDefaultBranch', () => {
+  test('accepts default-branch tags and rejects tags only reachable from another commit', () => {
+    const tmp = mkdtempSync(join(tmpdir(), 'cli-release-policy-'))
+    try {
+      const remote = join(tmp, 'origin.git')
+      const repo = join(tmp, 'repo')
+      git(tmp, ['init', '--bare', remote])
+      git(tmp, ['clone', remote, repo])
+      git(repo, ['config', 'user.email', 'test@example.com'])
+      git(repo, ['config', 'user.name', 'Test User'])
+      git(repo, ['checkout', '-b', 'main'])
+
+      writeFileSync(join(repo, 'README.md'), 'initial\n')
+      git(repo, ['add', 'README.md'])
+      git(repo, ['commit', '-m', 'initial'])
+      git(repo, ['tag', '-a', 'cli/v0.2.3', '-m', 'browseros-cli v0.2.3'])
+      git(repo, ['push', 'origin', 'main', '--tags'])
+
+      const reachableCommit = git(repo, ['rev-parse', 'cli/v0.2.3^{commit}'])
+      expect(
+        ensureTagReachableFromDefaultBranch(repo, 'cli/v0.2.3', 'main'),
+      ).toBe(reachableCommit)
+      expect(() => ensureAnnotatedTag(repo, 'cli/v0.2.3')).not.toThrow()
+
+      git(repo, ['checkout', '-b', 'side'])
+      writeFileSync(join(repo, 'side.txt'), 'side\n')
+      git(repo, ['add', 'side.txt'])
+      git(repo, ['commit', '-m', 'side'])
+      git(repo, ['tag', '-a', 'cli/v0.2.4', '-m', 'browseros-cli v0.2.4'])
+      git(repo, ['push', 'origin', 'cli/v0.2.4'])
+
+      expect(() =>
+        ensureTagReachableFromDefaultBranch(repo, 'cli/v0.2.4', 'main'),
+      ).toThrow('not reachable')
+
+      git(repo, ['checkout', 'main'])
+      git(repo, ['tag', 'cli/v0.2.5'])
+
+      expect(() => ensureAnnotatedTag(repo, 'cli/v0.2.5')).toThrow(
+        'annotated tag',
+      )
+    } finally {
+      rmSync(tmp, { recursive: true, force: true })
+    }
+  })
+})
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+}

--- a/packages/browseros-agent/scripts/build/cli/release-policy.test.ts
+++ b/packages/browseros-agent/scripts/build/cli/release-policy.test.ts
@@ -20,6 +20,7 @@ describe('parseCliReleaseTag', () => {
       'browseros-cli-v0.2.3',
       'cli/0.2.3',
       'cli/v0.2',
+      'cli/v01.2.3',
       'cli/v0.2.3-rc1',
       'server/v0.2.3',
     ]) {
@@ -59,6 +60,21 @@ describe('assertIncrementingRelease', () => {
       'must be greater',
     )
   })
+
+  test('allows repair reruns when production latest already points at the same tag', () => {
+    expect(() =>
+      assertIncrementingRelease('0.2.3', '0.2.3', {
+        tag: 'cli/v0.2.3',
+        latestTag: 'cli/v0.2.3',
+      }),
+    ).not.toThrow()
+    expect(() =>
+      assertIncrementingRelease('0.2.3', '0.2.3', {
+        tag: 'cli/v0.2.3',
+        latestTag: 'browseros-cli-v0.2.3',
+      }),
+    ).toThrow('must be greater')
+  })
 })
 
 describe('selectPreviousCliReleaseTag', () => {
@@ -69,6 +85,7 @@ describe('selectPreviousCliReleaseTag', () => {
           'browseros-cli-v0.2.0',
           'browseros-cli-v0.2.2',
           'cli/v0.0.1',
+          'cli/v01.9.9',
           'browseros-cli-v0.1.0-rc1',
           'agent-extension-v1.0.0',
         ],

--- a/packages/browseros-agent/scripts/build/cli/release-policy.test.ts
+++ b/packages/browseros-agent/scripts/build/cli/release-policy.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from 'bun:test'
+
+import {
+  assertIncrementingRelease,
+  compareReleaseVersions,
+  parseCliReleaseTag,
+  selectPreviousCliReleaseTag,
+} from './release-policy'
+
+describe('parseCliReleaseTag', () => {
+  test('parses cli release tags', () => {
+    expect(parseCliReleaseTag('cli/v0.2.3')).toEqual({
+      tag: 'cli/v0.2.3',
+      version: '0.2.3',
+    })
+  })
+
+  test('rejects non-cli and non-strict tags', () => {
+    for (const tag of [
+      'browseros-cli-v0.2.3',
+      'cli/0.2.3',
+      'cli/v0.2',
+      'cli/v0.2.3-rc1',
+      'server/v0.2.3',
+    ]) {
+      expect(() => parseCliReleaseTag(tag)).toThrow('cli/vX.Y.Z')
+    }
+  })
+})
+
+describe('compareReleaseVersions', () => {
+  test('orders strict release versions', () => {
+    expect(compareReleaseVersions('0.2.3', '0.2.2')).toBe(1)
+    expect(compareReleaseVersions('0.2.2', '0.2.2')).toBe(0)
+    expect(compareReleaseVersions('0.2.1', '0.2.2')).toBe(-1)
+    expect(compareReleaseVersions('1.0.0', '0.9.9')).toBe(1)
+  })
+
+  test('rejects loose or prerelease versions', () => {
+    expect(() => compareReleaseVersions('v0.2.3', '0.2.2')).toThrow(
+      'strict release version',
+    )
+    expect(() => compareReleaseVersions('0.2.3-rc1', '0.2.2')).toThrow(
+      'strict release version',
+    )
+  })
+})
+
+describe('assertIncrementingRelease', () => {
+  test('allows releases newer than production latest', () => {
+    expect(() => assertIncrementingRelease('0.2.3', '0.2.2')).not.toThrow()
+  })
+
+  test('rejects equal or lower releases', () => {
+    expect(() => assertIncrementingRelease('0.2.2', '0.2.2')).toThrow(
+      'must be greater',
+    )
+    expect(() => assertIncrementingRelease('0.2.1', '0.2.2')).toThrow(
+      'must be greater',
+    )
+  })
+})
+
+describe('selectPreviousCliReleaseTag', () => {
+  test('selects the latest earlier tag across new and legacy CLI tags', () => {
+    expect(
+      selectPreviousCliReleaseTag(
+        [
+          'browseros-cli-v0.2.0',
+          'browseros-cli-v0.2.2',
+          'cli/v0.0.1',
+          'browseros-cli-v0.1.0-rc1',
+          'agent-extension-v1.0.0',
+        ],
+        '0.2.3',
+      ),
+    ).toBe('browseros-cli-v0.2.2')
+  })
+
+  test('prefers new cli tags when versions tie', () => {
+    expect(
+      selectPreviousCliReleaseTag(
+        ['browseros-cli-v0.2.2', 'cli/v0.2.2'],
+        '0.2.3',
+      ),
+    ).toBe('cli/v0.2.2')
+  })
+
+  test('returns empty string when there is no previous CLI release tag', () => {
+    expect(
+      selectPreviousCliReleaseTag(['agent-extension-v1.0.0'], '0.2.3'),
+    ).toBe('')
+  })
+})

--- a/packages/browseros-agent/scripts/build/cli/release-policy.ts
+++ b/packages/browseros-agent/scripts/build/cli/release-policy.ts
@@ -5,9 +5,14 @@ import { appendFileSync } from 'node:fs'
 
 const DEFAULT_LATEST_VERSION_URL =
   'https://cdn.browseros.com/cli/latest/version.txt'
-const CLI_TAG_PATTERN = /^cli\/v(?<version>[0-9]+\.[0-9]+\.[0-9]+)$/
-const LEGACY_CLI_TAG_PATTERN =
-  /^browseros-cli-v(?<version>[0-9]+\.[0-9]+\.[0-9]+)$/
+const DEFAULT_LATEST_MANIFEST_URL =
+  'https://cdn.browseros.com/cli/latest/manifest.json'
+const STRICT_VERSION_SOURCE =
+  '(?<version>(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*)\\.(?:0|[1-9]\\d*))'
+const CLI_TAG_PATTERN = new RegExp(`^cli/v${STRICT_VERSION_SOURCE}$`)
+const LEGACY_CLI_TAG_PATTERN = new RegExp(
+  `^browseros-cli-v${STRICT_VERSION_SOURCE}$`,
+)
 const VERSION_PATTERN =
   /^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)$/
 
@@ -20,6 +25,7 @@ export interface CliReleaseValidation {
   tag: string
   version: string
   latestVersion: string
+  latestTag: string
   previousTag: string
   targetCommit: string
 }
@@ -28,6 +34,7 @@ interface ValidateOptions {
   tag: string
   defaultBranch: string
   latestVersionURL: string
+  latestManifestURL: string
   repositoryRoot: string
 }
 
@@ -60,17 +67,27 @@ export function compareReleaseVersions(a: string, b: string): number {
   return 0
 }
 
-/** Fails releases that do not move production latest forward. */
+/** Fails releases that do not move production latest forward, except same-tag repair reruns. */
 export function assertIncrementingRelease(
   version: string,
   latestVersion: string,
+  options: { tag?: string; latestTag?: string } = {},
 ): void {
   const comparison = compareReleaseVersions(version, latestVersion)
-  if (comparison <= 0) {
-    throw new Error(
-      `Release version ${version} must be greater than latest published CLI ${latestVersion}`,
-    )
+  if (comparison > 0) {
+    return
   }
+  if (
+    comparison === 0 &&
+    options.tag !== undefined &&
+    options.tag === options.latestTag
+  ) {
+    return
+  }
+
+  throw new Error(
+    `Release version ${version} must be greater than latest published CLI ${latestVersion}`,
+  )
 }
 
 /** Picks the closest earlier CLI tag across current and legacy CLI release tag names. */
@@ -119,7 +136,14 @@ export async function validateCliRelease(
     options.defaultBranch,
   )
   const latestVersion = await fetchLatestVersion(options.latestVersionURL)
-  assertIncrementingRelease(parsed.version, latestVersion)
+  const latestTag =
+    compareReleaseVersions(parsed.version, latestVersion) === 0
+      ? await fetchLatestManifestTag(options.latestManifestURL)
+      : ''
+  assertIncrementingRelease(parsed.version, latestVersion, {
+    tag: parsed.tag,
+    latestTag,
+  })
 
   const previousTag = selectPreviousCliReleaseTag(
     listGitTags(options.repositoryRoot),
@@ -130,6 +154,7 @@ export async function validateCliRelease(
     tag: parsed.tag,
     version: parsed.version,
     latestVersion,
+    latestTag,
     previousTag,
     targetCommit,
   }
@@ -163,6 +188,11 @@ function parseKnownCliTag(tag: string): ParsedCliReleaseTag | null {
   const match = tag.match(CLI_TAG_PATTERN) ?? tag.match(LEGACY_CLI_TAG_PATTERN)
   const version = match?.groups?.version
   if (!version) {
+    return null
+  }
+  try {
+    parseReleaseVersion(version)
+  } catch {
     return null
   }
   return { tag, version }
@@ -228,6 +258,18 @@ async function fetchLatestVersion(url: string): Promise<string> {
   return version
 }
 
+async function fetchLatestManifestTag(url: string): Promise<string> {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch latest CLI manifest from ${url}: HTTP ${response.status}`,
+    )
+  }
+
+  const manifest = (await response.json()) as { tag?: unknown }
+  return typeof manifest.tag === 'string' ? manifest.tag : ''
+}
+
 function parseArgs(args: string[]): Record<string, string> {
   const options: Record<string, string> = {}
   for (let index = 0; index < args.length; index += 1) {
@@ -258,6 +300,7 @@ function writeGithubOutputs(validation: CliReleaseValidation): void {
       `tag=${validation.tag}`,
       `version=${validation.version}`,
       `latest_version=${validation.latestVersion}`,
+      `latest_tag=${validation.latestTag}`,
       `previous_tag=${validation.previousTag}`,
       `target_commit=${validation.targetCommit}`,
     ].join('\n')}\n`,
@@ -282,12 +325,15 @@ async function main(): Promise<void> {
     options['default-branch'] ?? process.env.DEFAULT_BRANCH ?? 'main'
   const latestVersionURL =
     options['latest-version-url'] ?? DEFAULT_LATEST_VERSION_URL
+  const latestManifestURL =
+    options['latest-manifest-url'] ?? DEFAULT_LATEST_MANIFEST_URL
   const repositoryRoot = options['repository-root'] ?? process.cwd()
 
   const validation = await validateCliRelease({
     tag,
     defaultBranch,
     latestVersionURL,
+    latestManifestURL,
     repositoryRoot,
   })
 

--- a/packages/browseros-agent/scripts/build/cli/release-policy.ts
+++ b/packages/browseros-agent/scripts/build/cli/release-policy.ts
@@ -135,6 +135,7 @@ export async function validateCliRelease(
     parsed.tag,
     options.defaultBranch,
   )
+  ensureAnnotatedTag(options.repositoryRoot, parsed.tag)
   const latestVersion = await fetchLatestVersion(options.latestVersionURL)
   const latestTag =
     compareReleaseVersions(parsed.version, latestVersion) === 0
@@ -198,11 +199,20 @@ function parseKnownCliTag(tag: string): ParsedCliReleaseTag | null {
   return { tag, version }
 }
 
+/** Enforces annotated release tags so release metadata has an intentional tag object. */
+export function ensureAnnotatedTag(repositoryRoot: string, tag: string): void {
+  const tagType = runGit(repositoryRoot, ['cat-file', '-t', `refs/tags/${tag}`])
+  if (tagType !== 'tag') {
+    throw new Error(`Tag ${tag} must be an annotated tag`)
+  }
+}
+
 function tagPriority(tag: string): number {
   return tag.startsWith('cli/') ? 1 : 0
 }
 
-function ensureTagReachableFromDefaultBranch(
+/** Verifies the pushed tag resolves to a commit already contained in the default branch. */
+export function ensureTagReachableFromDefaultBranch(
   repositoryRoot: string,
   tag: string,
   defaultBranch: string,

--- a/packages/browseros-agent/scripts/build/cli/release-policy.ts
+++ b/packages/browseros-agent/scripts/build/cli/release-policy.ts
@@ -254,13 +254,13 @@ function writeGithubOutputs(validation: CliReleaseValidation): void {
 
   appendFileSync(
     outputPath,
-    [
+    `${[
       `tag=${validation.tag}`,
       `version=${validation.version}`,
       `latest_version=${validation.latestVersion}`,
       `previous_tag=${validation.previousTag}`,
       `target_commit=${validation.targetCommit}`,
-    ].join('\n') + '\n',
+    ].join('\n')}\n`,
   )
 }
 

--- a/packages/browseros-agent/scripts/build/cli/release-policy.ts
+++ b/packages/browseros-agent/scripts/build/cli/release-policy.ts
@@ -1,0 +1,306 @@
+#!/usr/bin/env bun
+
+import { execFileSync } from 'node:child_process'
+import { appendFileSync } from 'node:fs'
+
+const DEFAULT_LATEST_VERSION_URL =
+  'https://cdn.browseros.com/cli/latest/version.txt'
+const CLI_TAG_PATTERN = /^cli\/v(?<version>[0-9]+\.[0-9]+\.[0-9]+)$/
+const LEGACY_CLI_TAG_PATTERN =
+  /^browseros-cli-v(?<version>[0-9]+\.[0-9]+\.[0-9]+)$/
+const VERSION_PATTERN =
+  /^(?<major>0|[1-9]\d*)\.(?<minor>0|[1-9]\d*)\.(?<patch>0|[1-9]\d*)$/
+
+export interface ParsedCliReleaseTag {
+  tag: string
+  version: string
+}
+
+export interface CliReleaseValidation {
+  tag: string
+  version: string
+  latestVersion: string
+  previousTag: string
+  targetCommit: string
+}
+
+interface ValidateOptions {
+  tag: string
+  defaultBranch: string
+  latestVersionURL: string
+  repositoryRoot: string
+}
+
+type VersionTuple = [number, number, number]
+
+/** Parses the pushed CLI release tag into the version used by build and publish steps. */
+export function parseCliReleaseTag(tag: string): ParsedCliReleaseTag {
+  const match = tag.match(CLI_TAG_PATTERN)
+  const version = match?.groups?.version
+  if (!version) {
+    throw new Error(
+      `Expected pushed tag to match cli/vX.Y.Z, received ${JSON.stringify(tag)}`,
+    )
+  }
+  return { tag, version }
+}
+
+/** Compares strict X.Y.Z release versions without accepting prerelease or loose semver forms. */
+export function compareReleaseVersions(a: string, b: string): number {
+  const left = parseReleaseVersion(a)
+  const right = parseReleaseVersion(b)
+
+  for (let index = 0; index < left.length; index += 1) {
+    const diff = left[index] - right[index]
+    if (diff !== 0) {
+      return diff < 0 ? -1 : 1
+    }
+  }
+
+  return 0
+}
+
+/** Fails releases that do not move production latest forward. */
+export function assertIncrementingRelease(
+  version: string,
+  latestVersion: string,
+): void {
+  const comparison = compareReleaseVersions(version, latestVersion)
+  if (comparison <= 0) {
+    throw new Error(
+      `Release version ${version} must be greater than latest published CLI ${latestVersion}`,
+    )
+  }
+}
+
+/** Picks the closest earlier CLI tag across current and legacy CLI release tag names. */
+export function selectPreviousCliReleaseTag(
+  tags: string[],
+  currentVersion: string,
+): string {
+  const current = parseReleaseVersion(currentVersion)
+  const candidates = tags
+    .map(parseKnownCliTag)
+    .filter((tag): tag is ParsedCliReleaseTag => tag !== null)
+    .filter(
+      ({ version }) => compareReleaseVersions(version, currentVersion) < 0,
+    )
+    .sort((a, b) => {
+      const versionOrder = compareReleaseVersions(b.version, a.version)
+      if (versionOrder !== 0) {
+        return versionOrder
+      }
+      return tagPriority(b.tag) - tagPriority(a.tag)
+    })
+
+  if (candidates.length === 0) {
+    return ''
+  }
+
+  const selected = candidates[0]
+  if (
+    compareVersionTuple(parseReleaseVersion(selected.version), current) >= 0
+  ) {
+    throw new Error(
+      `Previous release tag ${selected.tag} is not before ${currentVersion}`,
+    )
+  }
+  return selected.tag
+}
+
+/** Runs the release gate used by the GitHub Actions workflow before publishing starts. */
+export async function validateCliRelease(
+  options: ValidateOptions,
+): Promise<CliReleaseValidation> {
+  const parsed = parseCliReleaseTag(options.tag)
+  const targetCommit = ensureTagReachableFromDefaultBranch(
+    options.repositoryRoot,
+    parsed.tag,
+    options.defaultBranch,
+  )
+  const latestVersion = await fetchLatestVersion(options.latestVersionURL)
+  assertIncrementingRelease(parsed.version, latestVersion)
+
+  const previousTag = selectPreviousCliReleaseTag(
+    listGitTags(options.repositoryRoot),
+    parsed.version,
+  )
+
+  return {
+    tag: parsed.tag,
+    version: parsed.version,
+    latestVersion,
+    previousTag,
+    targetCommit,
+  }
+}
+
+function parseReleaseVersion(version: string): VersionTuple {
+  const match = version.match(VERSION_PATTERN)
+  if (!match?.groups) {
+    throw new Error(
+      `Expected strict release version X.Y.Z, received ${JSON.stringify(version)}`,
+    )
+  }
+  return [
+    Number(match.groups.major),
+    Number(match.groups.minor),
+    Number(match.groups.patch),
+  ]
+}
+
+function compareVersionTuple(a: VersionTuple, b: VersionTuple): number {
+  for (let index = 0; index < a.length; index += 1) {
+    const diff = a[index] - b[index]
+    if (diff !== 0) {
+      return diff < 0 ? -1 : 1
+    }
+  }
+  return 0
+}
+
+function parseKnownCliTag(tag: string): ParsedCliReleaseTag | null {
+  const match = tag.match(CLI_TAG_PATTERN) ?? tag.match(LEGACY_CLI_TAG_PATTERN)
+  const version = match?.groups?.version
+  if (!version) {
+    return null
+  }
+  return { tag, version }
+}
+
+function tagPriority(tag: string): number {
+  return tag.startsWith('cli/') ? 1 : 0
+}
+
+function ensureTagReachableFromDefaultBranch(
+  repositoryRoot: string,
+  tag: string,
+  defaultBranch: string,
+): string {
+  runGit(repositoryRoot, [
+    'fetch',
+    'origin',
+    `refs/heads/${defaultBranch}:refs/remotes/origin/${defaultBranch}`,
+    '--tags',
+  ])
+
+  const targetCommit = runGit(repositoryRoot, ['rev-parse', `${tag}^{commit}`])
+  try {
+    runGit(repositoryRoot, [
+      'merge-base',
+      '--is-ancestor',
+      targetCommit,
+      `origin/${defaultBranch}`,
+    ])
+  } catch {
+    throw new Error(
+      `Tag ${tag} targets ${targetCommit}, which is not reachable from origin/${defaultBranch}`,
+    )
+  }
+  return targetCommit
+}
+
+function listGitTags(repositoryRoot: string): string[] {
+  return runGit(repositoryRoot, ['tag', '-l'])
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+}
+
+function runGit(repositoryRoot: string, args: string[]): string {
+  return execFileSync('git', args, {
+    cwd: repositoryRoot,
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'inherit'],
+  }).trim()
+}
+
+async function fetchLatestVersion(url: string): Promise<string> {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch latest CLI version from ${url}: HTTP ${response.status}`,
+    )
+  }
+
+  const version = (await response.text()).trim()
+  parseReleaseVersion(version)
+  return version
+}
+
+function parseArgs(args: string[]): Record<string, string> {
+  const options: Record<string, string> = {}
+  for (let index = 0; index < args.length; index += 1) {
+    const raw = args[index]
+    if (!raw.startsWith('--')) {
+      throw new Error(`Unexpected argument ${raw}`)
+    }
+    const key = raw.slice(2)
+    const value = args[index + 1]
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Missing value for --${key}`)
+    }
+    options[key] = value
+    index += 1
+  }
+  return options
+}
+
+function writeGithubOutputs(validation: CliReleaseValidation): void {
+  const outputPath = process.env.GITHUB_OUTPUT
+  if (!outputPath) {
+    return
+  }
+
+  appendFileSync(
+    outputPath,
+    [
+      `tag=${validation.tag}`,
+      `version=${validation.version}`,
+      `latest_version=${validation.latestVersion}`,
+      `previous_tag=${validation.previousTag}`,
+      `target_commit=${validation.targetCommit}`,
+    ].join('\n') + '\n',
+  )
+}
+
+async function main(): Promise<void> {
+  const [command, ...args] = process.argv.slice(2)
+  if (command !== 'validate') {
+    throw new Error(
+      'Usage: release-policy.ts validate --tag <tag> --default-branch <branch>',
+    )
+  }
+
+  const options = parseArgs(args)
+  const tag = options.tag ?? process.env.RELEASE_TAG
+  if (!tag) {
+    throw new Error('Missing release tag')
+  }
+
+  const defaultBranch =
+    options['default-branch'] ?? process.env.DEFAULT_BRANCH ?? 'main'
+  const latestVersionURL =
+    options['latest-version-url'] ?? DEFAULT_LATEST_VERSION_URL
+  const repositoryRoot = options['repository-root'] ?? process.cwd()
+
+  const validation = await validateCliRelease({
+    tag,
+    defaultBranch,
+    latestVersionURL,
+    repositoryRoot,
+  })
+
+  writeGithubOutputs(validation)
+  console.log(
+    `Validated ${validation.tag}: version ${validation.version}, latest ${validation.latestVersion}, previous ${validation.previousTag || 'none'}`,
+  )
+}
+
+if (import.meta.main) {
+  main().catch((error) => {
+    const message = error instanceof Error ? error.message : String(error)
+    console.error(`::error::${message}`)
+    process.exit(1)
+  })
+}

--- a/packages/browseros-agent/scripts/build/cli/upload.test.ts
+++ b/packages/browseros-agent/scripts/build/cli/upload.test.ts
@@ -68,7 +68,7 @@ describe('buildCliReleaseManifest', () => {
     expect(manifest).toEqual({
       version: '1.2.3',
       published_at: '2026-03-27T19:00:00Z',
-      tag: 'browseros-cli-v1.2.3',
+      tag: 'cli/v1.2.3',
       assets: {
         'darwin/arm64': {
           filename: 'browseros-cli_1.2.3_darwin_arm64.tar.gz',

--- a/packages/browseros-agent/scripts/build/cli/upload.ts
+++ b/packages/browseros-agent/scripts/build/cli/upload.ts
@@ -170,7 +170,7 @@ export function buildCliReleaseManifest(options: {
   return {
     version: options.version,
     published_at: options.published_at ?? new Date().toISOString(),
-    tag: `browseros-cli-v${options.version}`,
+    tag: `cli/v${options.version}`,
     assets,
   }
 }


### PR DESCRIPTION
## Summary
- trigger CLI release automation from pushed `cli/vX.Y.Z` tags and derive `X.Y.Z` from the tag
- validate strict annotated tags, default-branch reachability, incrementing production versions, and release-note baselines across new plus legacy CLI tags
- update CDN/GitHub/npm release metadata and docs so the git tag is the release source of truth

## Verification
- `bun test scripts/build/cli/release-policy.test.ts scripts/build/cli/upload.test.ts`
- `bun run ./scripts/run-bun-test.ts ./scripts/build`
- `make test` in `packages/browseros-agent/apps/cli` (integration tests skipped because the local server was not reachable at `http://127.0.0.1:9105`)
- `make vet` in `packages/browseros-agent/apps/cli`
- `make release VERSION=0.2.3 POSTHOG_API_KEY=test` in `packages/browseros-agent/apps/cli`
- `bunx @biomejs/biome check scripts/build/cli/release-policy.ts scripts/build/cli/release-policy.test.ts scripts/build/cli/upload.ts scripts/build/cli/upload.test.ts apps/cli/npm/scripts/postinstall.js`

## Draft blocker
- `bun run check` fails in unrelated `apps/server` typecheck errors, including `src/agent/format-message.ts` implicit `any` parameters and `ResolvedLLMConfig` property errors in `src/api/services/chat-service.ts` / `src/lib/clients/llm/provider.ts`.

Expected release command remains:
```bash
git tag -a cli/v0.2.3 -m "browseros-cli v0.2.3"
git push origin cli/v0.2.3
```