### PR TITLE
fix(cli): use tabs tool for tab listing

### DIFF
--- a/packages/browseros-agent/apps/cli/README.md
+++ b/packages/browseros-agent/apps/cli/README.md
@@ -70,8 +70,8 @@ browseros-cli update --yes   # apply without prompting
 browseros-cli health
 browseros-cli status
 
-# Pages
-browseros-cli pages                 # List all tabs
+# Tabs
+browseros-cli tabs                  # List all tabs
 browseros-cli active                # Show active tab
 browseros-cli open https://example.com
 browseros-cli close 42
@@ -182,7 +182,7 @@ apps/cli/
 │   ├── launch.go       # launch (find and start BrowserOS, wait for server)
 │   ├── open.go         # open (new_page / new_hidden_page)
 │   ├── nav.go          # nav, back, forward, reload
-│   ├── pages.go        # pages, active, close
+│   ├── pages.go        # tabs/pages alias, active, close
 │   ├── snap.go         # snap (take_snapshot / take_enhanced_snapshot)
 │   ├── text.go         # text, links
 │   ├── screenshot.go   # ss (take_screenshot / save_screenshot)

--- a/packages/browseros-agent/apps/cli/cmd/init.go
+++ b/packages/browseros-agent/apps/cli/cmd/init.go
@@ -103,7 +103,7 @@ Modes:
 			green.Printf("Connected! Config saved to %s\n", config.Path())
 			fmt.Println()
 			dim.Println("Try: browseros-cli health")
-			dim.Println("     browseros-cli pages")
+			dim.Println("     browseros-cli tabs")
 		},
 	}
 

--- a/packages/browseros-agent/apps/cli/cmd/pages.go
+++ b/packages/browseros-agent/apps/cli/cmd/pages.go
@@ -4,28 +4,26 @@ import (
 	"fmt"
 	"strings"
 
+	"browseros-cli/mcp"
 	"browseros-cli/output"
 
 	"github.com/spf13/cobra"
 )
 
 func init() {
-	pagesCmd := &cobra.Command{
-		Use:         "pages",
+	tabsCmd := &cobra.Command{
+		Use:         "tabs",
+		Aliases:     []string{"pages"},
 		Annotations: map[string]string{"group": "Navigate:"},
-		Short:       "List all open pages (tabs)",
+		Short:       "List all open tabs",
 		Args:        cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
 			c := newClient()
-			_, value, err := browserRunValue(c, "return await browser.pages.list()")
+			toolResult, err := c.CallTool("tabs", tabsListToolArgs())
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
-			pages := valueSlice(value)
-			result := textResult(formatPages(pages), map[string]any{
-				"pages": pages,
-				"count": len(pages),
-			})
+			result := tabsListResult(toolResult)
 			if jsonOut {
 				output.JSON(result)
 			} else {
@@ -96,7 +94,46 @@ return page`)
 		},
 	}
 
-	rootCmd.AddCommand(pagesCmd, activeCmd, closeCmd)
+	rootCmd.AddCommand(tabsCmd, activeCmd, closeCmd)
+}
+
+func tabsListToolArgs() map[string]any {
+	return map[string]any{"action": "list"}
+}
+
+// tabsListResult preserves the CLI's legacy pages/count shape around the MCP tabs tool.
+func tabsListResult(result *mcp.ToolResult) *mcp.ToolResult {
+	var pages []any
+	if result != nil && result.StructuredContent != nil {
+		pages = normalizeTabPages(valueSlice(result.StructuredContent["pages"]))
+	}
+	return textResult(formatPages(pages), map[string]any{
+		"pages": pages,
+		"count": len(pages),
+	})
+}
+
+// normalizeTabPages keeps legacy pageId fields when the tabs tool returns page.
+func normalizeTabPages(pages []any) []any {
+	normalized := make([]any, 0, len(pages))
+	for _, item := range pages {
+		page, ok := valueMap(item)
+		if !ok {
+			normalized = append(normalized, item)
+			continue
+		}
+		copy := make(map[string]any, len(page)+1)
+		for key, value := range page {
+			copy[key] = value
+		}
+		if numberValue(copy["pageId"]) == 0 {
+			if pageID := numberValue(copy["page"]); pageID != 0 {
+				copy["pageId"] = pageID
+			}
+		}
+		normalized = append(normalized, copy)
+	}
+	return normalized
 }
 
 func formatPages(pages []any) string {

--- a/packages/browseros-agent/apps/cli/cmd/root_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/root_test.go
@@ -68,6 +68,30 @@ func TestDiffCommandShape(t *testing.T) {
 	}
 }
 
+func TestTabsCommandShape(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"tabs"})
+	if err != nil {
+		t.Fatalf("rootCmd.Find(tabs) error = %v", err)
+	}
+	if cmd.Name() != "tabs" {
+		t.Fatalf("command name = %q, want tabs", cmd.Name())
+	}
+
+	alias, _, err := rootCmd.Find([]string{"pages"})
+	if err != nil {
+		t.Fatalf("rootCmd.Find(pages) error = %v", err)
+	}
+	if alias.Name() != "tabs" {
+		t.Fatalf("pages alias resolved to %q, want tabs", alias.Name())
+	}
+	if err := cmd.Args(cmd, []string{"extra"}); err == nil {
+		t.Fatal("tabs Args accepted a positional argument")
+	}
+	if cmd.LocalFlags().HasAvailableFlags() {
+		t.Fatal("tabs command exposes local flags")
+	}
+}
+
 func TestRawDOMCommandsAreNotRegistered(t *testing.T) {
 	for _, name := range []string{"dom", "dom-search"} {
 		t.Run(name, func(t *testing.T) {

--- a/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	"browseros-cli/mcp"
 )
 
 func TestCompactToolMappings(t *testing.T) {
@@ -34,6 +36,11 @@ func TestCompactToolMappings(t *testing.T) {
 				"x":    10,
 				"y":    20,
 			},
+		},
+		{
+			name: "list tabs",
+			got:  tabsListToolArgs(),
+			want: map[string]any{"action": "list"},
 		},
 		{
 			name: "open tab",
@@ -71,6 +78,31 @@ func TestCompactToolMappings(t *testing.T) {
 				t.Fatalf("mapping = %#v, want %#v", tt.got, tt.want)
 			}
 		})
+	}
+}
+
+func TestTabsListResultKeepsLegacyShape(t *testing.T) {
+	result := tabsListResult(&mcp.ToolResult{
+		StructuredContent: map[string]any{
+			"pages": []any{
+				map[string]any{"page": 42, "url": "https://example.com", "title": "Example"},
+			},
+		},
+	})
+
+	if got := result.StructuredContent["count"]; got != 1 {
+		t.Fatalf("count = %v, want 1", got)
+	}
+	pages, ok := result.StructuredContent["pages"].([]any)
+	if !ok || len(pages) != 1 {
+		t.Fatalf("pages = %#v, want one page", result.StructuredContent["pages"])
+	}
+	page, ok := pages[0].(map[string]any)
+	if !ok {
+		t.Fatalf("page = %#v, want map", pages[0])
+	}
+	if got := numberValue(page["pageId"]); got != 42 {
+		t.Fatalf("pageId = %d, want 42", got)
 	}
 }
 

--- a/packages/browseros-agent/apps/cli/integration_test.go
+++ b/packages/browseros-agent/apps/cli/integration_test.go
@@ -115,14 +115,12 @@ func TestVersion(t *testing.T) {
 }
 
 func TestPageLifecycle(t *testing.T) {
-	// List existing pages
-	pagesBefore := runJSON(t, "pages")
+	pagesBefore := runJSON(t, "tabs")
 	countBefore, _ := pagesBefore["count"].(float64)
 	if countBefore < 1 {
 		t.Log("Warning: no pages found before test, server may not have a browser connected")
 	}
 
-	// Open a new page
 	openData := runJSON(t, "open", "https://example.com")
 	pageIDFloat, ok := openData["pageId"].(float64)
 	if !ok {
@@ -133,21 +131,16 @@ func TestPageLifecycle(t *testing.T) {
 
 	pageArg := fmt.Sprintf("-p=%d", pageID)
 
-	// Verify page count increased
-	pagesAfter := runJSON(t, "pages")
+	pagesAfter := runJSON(t, "tabs")
 	countAfter, _ := pagesAfter["count"].(float64)
 	if countAfter <= countBefore {
 		t.Errorf("expected page count to increase: before=%v after=%v", countBefore, countAfter)
 	}
 
-	// Wait for page to load
 	time.Sleep(2 * time.Second)
 
-	// Text extraction
 	t.Run("text", func(t *testing.T) {
 		data := runJSON(t, "text", pageArg)
-		// structuredContent may have a "text" key or the content items have text
-		// With --json, the output is structuredContent if present
 		raw, _ := json.Marshal(data)
 		if !strings.Contains(strings.ToLower(string(raw)), "example") {
 			t.Errorf("expected page content to mention 'example', got: %s", string(raw))

--- a/packages/browseros-agent/apps/cli/output/printer.go
+++ b/packages/browseros-agent/apps/cli/output/printer.go
@@ -93,7 +93,11 @@ func PageList(result *mcp.ToolResult) {
 			marker = " " + boldColor.Sprint("[ACTIVE]")
 		}
 
-		fmt.Printf("  %d. %s (tab %d)%s\n", pageID, title, tabID, marker)
+		if tabID == 0 {
+			fmt.Printf("  %d. %s%s\n", pageID, title, marker)
+		} else {
+			fmt.Printf("  %d. %s (tab %d)%s\n", pageID, title, tabID, marker)
+		}
 		fmt.Printf("     %s\n", dimColor.Sprint(url))
 	}
 }
@@ -119,7 +123,11 @@ func ActivePage(result *mcp.ToolResult) {
 	title := strVal(page["title"])
 	url := strVal(page["url"])
 
-	fmt.Printf("Active page: %d (tab %d)\n", pageID, tabID)
+	if tabID == 0 {
+		fmt.Printf("Active page: %d\n", pageID)
+	} else {
+		fmt.Printf("Active page: %d (tab %d)\n", pageID, tabID)
+	}
 	fmt.Println(title)
 	fmt.Println(dimColor.Sprint(url))
 }


### PR DESCRIPTION
## Summary
- Renames the CLI list command to `browseros-cli tabs` while keeping `pages` as a compatibility alias.
- Replaces the list path's `run`/`browser.pages.list()` bridge with the existing MCP `tabs` tool.
- Preserves the legacy JSON shape with `pages`, `count`, and normalized `pageId`, and updates CLI docs/hints to show `tabs`.

## Design
The CLI command family stays in `apps/cli/cmd/pages.go`; only the list command now calls `c.CallTool("tabs", {"action":"list"})`. The CLI wraps the MCP result so existing consumers keep the prior output contract even though the MCP tool returns page ids under `page` and does not include `count`.

## Test plan
- [x] `cd apps/cli && gofmt -l .`
- [x] `cd apps/cli && go vet ./...`
- [x] `cd apps/cli && go build ./...`
- [x] `cd apps/cli && go test ./...`
- [x] `git diff --check`
- [x] local context-free review: clean