### PR TITLE
fix: default BrowserOS app API env

### DIFF
--- a/packages/browseros-agent/apps/app/lib/browseros-api-url.ts
+++ b/packages/browseros-agent/apps/app/lib/browseros-api-url.ts
@@ -1,0 +1,21 @@
+export const DEFAULT_BROWSEROS_API_URL = 'https://api.browseros.com'
+
+/** Resolves and validates the BrowserOS API base URL for runtime and build config. */
+export function parseBrowserOSApiUrl(value: string | undefined): string {
+  const rawUrl = value?.trim() || DEFAULT_BROWSEROS_API_URL
+  let url: URL
+
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    throw new Error(
+      'VITE_PUBLIC_BROWSEROS_API must be a valid URL including http:// or https://',
+    )
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('VITE_PUBLIC_BROWSEROS_API must use http:// or https://')
+  }
+
+  return url.toString().replace(/\/$/, '')
+}

--- a/packages/browseros-agent/apps/app/lib/env.test.ts
+++ b/packages/browseros-agent/apps/app/lib/env.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import { parseBrowserOSApiUrl } from './browseros-api-url'
 import { parseAlphaFeaturesFlag } from './env'
 
 describe('parseAlphaFeaturesFlag', () => {
@@ -12,5 +13,33 @@ describe('parseAlphaFeaturesFlag', () => {
 
   it('keeps explicit false disabled', () => {
     expect(parseAlphaFeaturesFlag('false')).toBe(false)
+  })
+})
+
+describe('parseBrowserOSApiUrl', () => {
+  it('defaults to the production BrowserOS API when unset', () => {
+    expect(parseBrowserOSApiUrl(undefined)).toBe('https://api.browseros.com')
+  })
+
+  it('preserves explicit overrides', () => {
+    expect(parseBrowserOSApiUrl('http://127.0.0.1:3000')).toBe(
+      'http://127.0.0.1:3000',
+    )
+  })
+
+  it('rejects overrides without a scheme', () => {
+    expect(() => parseBrowserOSApiUrl('api.browseros.com')).toThrow(
+      'VITE_PUBLIC_BROWSEROS_API must be a valid URL including http:// or https://',
+    )
+  })
+
+  it('rejects non-HTTP overrides', () => {
+    expect(() =>
+      parseBrowserOSApiUrl('chrome-extension://extension-id'),
+    ).toThrow('VITE_PUBLIC_BROWSEROS_API must use http:// or https://')
+  })
+
+  it('returns a URL that can form a valid WXT match pattern', () => {
+    expect(`${parseBrowserOSApiUrl(undefined)}/home`).toStartWith('https://')
   })
 })

--- a/packages/browseros-agent/apps/app/lib/env.ts
+++ b/packages/browseros-agent/apps/app/lib/env.ts
@@ -1,4 +1,5 @@
 import { ZodError, z } from 'zod'
+import { parseBrowserOSApiUrl } from './browseros-api-url'
 
 export function parseAlphaFeaturesFlag(value: string | undefined): boolean {
   return (value ?? 'true') === 'true'
@@ -9,7 +10,10 @@ const EnvSchema = z.object({
   VITE_PUBLIC_POSTHOG_KEY: z.string().optional(),
   VITE_PUBLIC_POSTHOG_HOST: z.string().optional(),
   VITE_PUBLIC_SENTRY_DSN: z.string().optional(),
-  VITE_PUBLIC_BROWSEROS_API: z.string().optional(),
+  VITE_PUBLIC_BROWSEROS_API: z
+    .string()
+    .optional()
+    .transform(parseBrowserOSApiUrl),
   PROD: z.boolean().optional().default(false),
 })
 

--- a/packages/browseros-agent/apps/app/wxt.config.ts
+++ b/packages/browseros-agent/apps/app/wxt.config.ts
@@ -1,15 +1,14 @@
 import { sentryVitePlugin } from '@sentry/vite-plugin'
 import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'wxt'
+import { parseBrowserOSApiUrl } from './lib/browseros-api-url'
 import { LEGACY_AGENT_EXTENSION_ID } from './lib/constants/legacyAgentExtensionId'
 import { PRODUCT_WEB_HOST } from './lib/constants/productWebHost'
 
 // biome-ignore lint/style/noProcessEnv: build config file needs env access
 const env = process.env
 
-const apiUrl = new URL(
-  env.VITE_PUBLIC_BROWSEROS_API?.trim() || 'https://api.browseros.com',
-)
+const apiUrl = new URL(parseBrowserOSApiUrl(env.VITE_PUBLIC_BROWSEROS_API))
 const apiPattern = apiUrl.port
   ? `${apiUrl.hostname}:${apiUrl.port}`
   : apiUrl.hostname


### PR DESCRIPTION
## Summary
- Adds a shared BrowserOS API URL parser/default for the extension runtime and WXT config.
- Defaults missing `VITE_PUBLIC_BROWSEROS_API` to `https://api.browseros.com` so fresh `bun run dev:watch` builds valid auth content-script matches.
- Rejects malformed or non-HTTP API overrides before they reach BetterAuth, fetch, or WXT match generation.

## Root Cause
PR #1359 cleanly renamed `apps/agent` to `apps/app`, but fresh renamed worktrees no longer had an old local `apps/agent/.env.development` file. `auth.content` then interpolated an optional `VITE_PUBLIC_BROWSEROS_API` into WXT `matches`, producing `undefined/home`; BetterAuth also fell back to the extension origin and rejected `chrome-extension://...`.

## Test plan
- [x] `bun test apps/app/lib/env.test.ts`
- [x] `bunx @biomejs/biome check apps/app/lib/browseros-api-url.ts apps/app/lib/env.ts apps/app/lib/env.test.ts apps/app/wxt.config.ts`
- [x] `bun --cwd apps/app --env-file=.env.development wxt build --mode development`
- [x] `jq '.content_scripts[] | select((.js // [])[]? == "content-scripts/auth.js") | {matches, js}' apps/app/dist/chrome-mv3-dev/manifest.json`
- [x] `rg -n "apps/(agent|agent-mcp-ui|agent-mcp-interface)|@browseros/(agent-mcp-ui|agent-mcp-interface)|agent-mcp-ui|agent-mcp-interface" --glob '!node_modules/**' --glob '!apps/*/node_modules/**' --glob '!.llm/**' --glob '!bun.lock' .` returns no matches
- [x] `bun run check` (exit 0; existing Biome/Fallow warnings remain)
- [x] `bun run test`
- [x] `git diff --check`
- [x] `cd tools/dev && go test ./...`

## Local cleanup
Removed the ignored leftover directory `/Users/shadowfax/code/browseros-project/grove-ref/main-2/packages/browseros-agent/apps/agent-mcp-interface` after verifying it was an old ignored package directory containing only leftover `node_modules`.