### PR TITLE
fix: remove MCP promo tool count

### DIFF
--- a/packages/browseros-agent/apps/app/screens/ai-settings/McpPromoBanner.test.tsx
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/McpPromoBanner.test.tsx
@@ -1,0 +1,51 @@
+import { beforeAll, describe, expect, it, mock } from 'bun:test'
+import { type ComponentProps, createElement, type FC } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+type MockButtonProps = ComponentProps<'button'> & {
+  variant?: string
+  size?: string
+}
+
+mock.module('react-router', () => ({
+  useNavigate: () => () => {},
+}))
+
+mock.module('@/lib/metrics/track', () => ({
+  track: () => {},
+}))
+
+mock.module('@/lib/constants/analyticsEvents', () => ({
+  MCP_PROMO_BANNER_CLICKED_EVENT: 'settings.mcp_promo_banner.clicked',
+}))
+
+mock.module('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    variant: _variant,
+    size: _size,
+    ...props
+  }: MockButtonProps) =>
+    createElement('button', { type: 'button', ...props }, children),
+}))
+
+let McpPromoBanner: FC
+
+beforeAll(async () => {
+  McpPromoBanner = (await import('./McpPromoBanner')).McpPromoBanner
+})
+
+function renderBanner() {
+  return renderToStaticMarkup(createElement(McpPromoBanner))
+}
+
+describe('McpPromoBanner', () => {
+  it('renders the MCP promo without a fixed tool count', () => {
+    const html = renderBanner()
+
+    expect(html).toContain('Use BrowserOS with Claude Code')
+    expect(html).toContain('Connect your favorite coding tools')
+    expect(html).toContain('Set up')
+    expect(html).not.toContain('66+ tools')
+  })
+})

--- a/packages/browseros-agent/apps/app/screens/ai-settings/McpPromoBanner.tsx
+++ b/packages/browseros-agent/apps/app/screens/ai-settings/McpPromoBanner.tsx
@@ -24,9 +24,6 @@ export const McpPromoBanner: FC = () => {
       <div className="min-w-0 flex-1">
         <p className="flex items-center gap-2 font-semibold text-sm">
           Use BrowserOS with Claude Code, Cursor & more
-          <span className="text-[var(--accent-orange)] text-xs">
-            (66+ tools)
-          </span>
         </p>
         <p className="text-muted-foreground text-xs">
           Connect your favorite coding tools to BrowserOS as an MCP server


### PR DESCRIPTION
## Summary
- Removed the static `(66+ tools)` badge from the AI settings MCP promo banner.
- Added a static render regression test for the banner copy and setup action.

## Design
The MCP promo banner owns this copy directly, so the change removes only the static count span while preserving navigation, analytics, dismissal, and the rest of the banner content.

## Test plan
- [x] `bun run --filter @browseros/app test`
- [x] `bun run check`
- [x] `bun run test`
- [x] `bun run build:agent`