### PR TITLE
feat(cli): improve agent browser workflow

### DIFF
--- a/packages/browseros-agent/apps/cli/README.md
+++ b/packages/browseros-agent/apps/cli/README.md
@@ -128,6 +128,8 @@ browseros-cli history recent
 browseros-cli group list
 ```
 
+`batch` supports page-scoped browser steps that map directly to MCP calls: `nav`, `back`, `forward`, `reload`, `eval`, `snapshot`, `read`, `grep`, `find`, `click`, `fill`, `press`, `type`, `hover`, `check`, `uncheck`, `focus`, and `select`.
+
 ## Use as MCP Server
 
 BrowserOS exposes an MCP server that AI coding agents can connect to directly. The CLI is the easiest way to verify the connection and interact with tools from the terminal.

--- a/packages/browseros-agent/apps/cli/README.md
+++ b/packages/browseros-agent/apps/cli/README.md
@@ -2,9 +2,9 @@
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-blue.svg)](../../../../LICENSE)
 
-Command-line interface for controlling BrowserOS — launch and automate the browser from the terminal or from AI coding agents like Claude Code and Gemini CLI.
+Command-line interface for controlling BrowserOS — launch and automate the browser from the terminal or from AI coding agents like Claude Code and Gemini CLI. The installed `bos` command is a short alias for `browseros-cli`.
 
-Communicates with the BrowserOS MCP server over JSON-RPC 2.0 / StreamableHTTP. All 53+ MCP tools are mapped to CLI commands.
+Communicates with the BrowserOS MCP server over JSON-RPC 2.0 / StreamableHTTP and maps the core BrowserOS automation tools to CLI commands.
 
 ## Install
 
@@ -44,6 +44,20 @@ browseros-cli init http://127.0.0.1:9000/mcp
 browseros-cli health
 ```
 
+## Agent workflow
+
+Agents should capture a page id from `open` or `tabs`, then pass it explicitly with `-p`.
+
+```bash
+page=$(browseros-cli open --json https://example.com | jq -r .page)
+browseros-cli -p "$page" snapshot -i
+browseros-cli -p "$page" read --links
+browseros-cli -p "$page" find text "Search" click
+browseros-cli -p "$page" press Enter
+browseros-cli -p "$page" snapshot
+browseros-cli -p "$page" close
+```
+
 ### Other init modes
 
 ```bash
@@ -73,33 +87,39 @@ browseros-cli status
 # Tabs
 browseros-cli tabs                  # List all tabs
 browseros-cli active                # Show active tab
-browseros-cli open https://example.com
-browseros-cli close 42
+browseros-cli open --json https://example.com
+browseros-cli -p 42 close
 
 # Navigation
-browseros-cli nav https://example.com
-browseros-cli back
-browseros-cli forward
-browseros-cli reload
+browseros-cli -p 42 nav https://example.com
+browseros-cli -p 42 back
+browseros-cli -p 42 forward
+browseros-cli -p 42 reload
 
 # Observation
-browseros-cli snap                  # Accessibility tree snapshot
-browseros-cli text                  # Extract page as markdown
-browseros-cli links                 # Extract all links
-browseros-cli eval "document.title" # Run JavaScript
+browseros-cli -p 42 snapshot        # Accessibility tree snapshot
+browseros-cli -p 42 read            # Extract page as markdown
+browseros-cli -p 42 read --links    # Extract all links
+browseros-cli -p 42 grep "Submit"   # Search snapshot lines
+browseros-cli -p 42 eval "document.title" # Run JavaScript
 
 # Input
-browseros-cli click e5              # Click element by ref
-browseros-cli click-at 100 200      # Click at coordinates
-browseros-cli fill e12 "hello"      # Fill input by ref
-browseros-cli key Enter             # Press key
-browseros-cli hover e3
-browseros-cli scroll down 500
+browseros-cli -p 42 click @e5       # Click element by ref
+browseros-cli -p 42 click-at 100 200
+browseros-cli -p 42 fill @e12 "hello"
+browseros-cli -p 42 press Enter
+browseros-cli -p 42 type "hello"
+browseros-cli -p 42 find role button --name "Submit" click
+browseros-cli -p 42 hover @e3
+browseros-cli -p 42 scroll down 500
 
 # Screenshots & export
-browseros-cli ss                    # Screenshot (saves to screenshot.png)
-browseros-cli ss -o shot.png        # Screenshot to specific file
-browseros-cli pdf -o page.pdf       # Export as PDF
+browseros-cli -p 42 screenshot
+browseros-cli -p 42 screenshot -o shot.png
+browseros-cli -p 42 pdf page.pdf
+
+# Batch multiple steps through one MCP session
+browseros-cli -p 42 batch --bail "find role searchbox fill query" "press Enter"
 
 # Resource management (grouped commands)
 browseros-cli window list
@@ -119,7 +139,7 @@ To connect Claude Code, Gemini CLI, or any MCP client, see the [MCP setup guide]
 | Flag | Env Var | Description |
 |------|---------|-------------|
 | `--server, -s` | `BROWSEROS_URL` | Server URL (default: from config) |
-| `--page, -p` | `BROWSEROS_PAGE` | Target page ID (default: active page) |
+| `--page, -p` | | Required page ID for page-scoped commands |
 | `--json` | `BOS_JSON=1` | JSON output (outputs structuredContent) |
 | `--debug` | `BOS_DEBUG=1` | Debug output |
 | `--timeout, -t` | | Request timeout (default: 2m) |
@@ -151,7 +171,7 @@ Tests skip gracefully if no server is reachable — they won't fail in environme
 
 The integration tests (`integration_test.go`) cover:
 - Health check and version
-- Page lifecycle: open → text → snap → eval → screenshot → nav → reload → close
+- Page lifecycle: open → read → snapshot → eval → screenshot → nav → reload → close
 - Active page query
 - Info command
 - Error handling (invalid page ID, JS errors)
@@ -182,9 +202,11 @@ apps/cli/
 │   ├── open.go         # open (new_page / new_hidden_page)
 │   ├── nav.go          # nav, back, forward, reload
 │   ├── pages.go        # tabs/pages alias, active, close
-│   ├── snap.go         # snap (snapshot)
-│   ├── text.go         # text, links
-│   ├── screenshot.go   # ss (take_screenshot / save_screenshot)
+│   ├── snap.go         # snapshot/snap
+│   ├── text.go         # read, text, links, grep
+│   ├── find.go         # find (grep + act)
+│   ├── batch.go        # batch command runner
+│   ├── screenshot.go   # screenshot/ss
 │   ├── eval.go         # eval (evaluate_script)
 │   ├── click.go        # click, click-at
 │   ├── fill.go         # fill, clear, key
@@ -205,9 +227,7 @@ apps/cli/
     └── printer.go      # Human-readable and JSON output formatting
 ```
 
-The CLI communicates with BrowserOS via two HTTP POST requests per command:
-1. `initialize` — MCP handshake
-2. `tools/call` — execute the actual tool
+Normal CLI commands initialize an MCP session, call the requested tool, and close the session. `batch` keeps one MCP session open for all subcommands in that invocation.
 
 ## Links
 

--- a/packages/browseros-agent/apps/cli/cmd/batch.go
+++ b/packages/browseros-agent/apps/cli/cmd/batch.go
@@ -137,6 +137,18 @@ func validateBatchCommand(raw string, opts batchOptions) error {
 	}
 
 	switch remaining[0] {
+	case "nav":
+		if len(remaining) != 2 {
+			return fmt.Errorf("nav requires one url")
+		}
+	case "back", "forward", "reload":
+		if len(remaining) != 1 {
+			return fmt.Errorf("%s does not take arguments", remaining[0])
+		}
+	case "eval":
+		if len(remaining) < 2 {
+			return fmt.Errorf("eval requires code")
+		}
 	case "press", "key":
 		if len(remaining) != 2 {
 			return fmt.Errorf("%s requires one key", remaining[0])
@@ -150,19 +162,27 @@ func validateBatchCommand(raw string, opts batchOptions) error {
 			return fmt.Errorf("click requires one ref")
 		}
 		_, err = elementRef(remaining[1])
+	case "hover", "focus", "check", "uncheck":
+		if len(remaining) != 2 {
+			return fmt.Errorf("%s requires one ref", remaining[0])
+		}
+		_, err = elementRef(remaining[1])
 	case "fill":
 		if len(remaining) < 3 {
 			return fmt.Errorf("fill requires a ref and value")
 		}
 		_, err = elementRef(remaining[1])
+	case "select":
+		if len(remaining) < 3 {
+			return fmt.Errorf("select requires a ref and value")
+		}
+		_, err = elementRef(remaining[1])
 	case "snapshot", "snap":
 		_, err = batchSnapshotFilters(remaining[1:])
 	case "read", "text", "links":
-		err = validateBatchRead(remaining)
+		_, err = batchReadOptions(remaining)
 	case "grep":
-		if len(remaining) != 2 {
-			return fmt.Errorf("grep requires one pattern")
-		}
+		_, _, _, err = batchGrepArgs(remaining)
 	case "find":
 		_, _, err = parseFindTokens(remaining[1:])
 	default:
@@ -209,6 +229,21 @@ func runBatchCommand(c toolCaller, raw string, opts batchOptions) (*mcp.ToolResu
 	}
 
 	switch remaining[0] {
+	case "nav":
+		if len(remaining) != 2 {
+			return nil, fmt.Errorf("nav requires one url")
+		}
+		return c.CallTool("navigate", map[string]any{"page": page, "action": "url", "url": remaining[1]})
+	case "back", "forward", "reload":
+		if len(remaining) != 1 {
+			return nil, fmt.Errorf("%s does not take arguments", remaining[0])
+		}
+		return c.CallTool("navigate", map[string]any{"page": page, "action": remaining[0]})
+	case "eval":
+		if len(remaining) < 2 {
+			return nil, fmt.Errorf("eval requires code")
+		}
+		return c.CallTool("evaluate", map[string]any{"page": page, "code": evalCode(strings.Join(remaining[1:], " "))})
 	case "press", "key":
 		if len(remaining) != 2 {
 			return nil, fmt.Errorf("%s requires one key", remaining[0])
@@ -228,6 +263,15 @@ func runBatchCommand(c toolCaller, raw string, opts batchOptions) (*mcp.ToolResu
 			return nil, err
 		}
 		return c.CallTool("act", clickToolArgs(page, ref, "left", 1))
+	case "hover", "focus", "check", "uncheck":
+		if len(remaining) != 2 {
+			return nil, fmt.Errorf("%s requires one ref", remaining[0])
+		}
+		ref, err := elementRef(remaining[1])
+		if err != nil {
+			return nil, err
+		}
+		return c.CallTool("act", map[string]any{"page": page, "kind": remaining[0], "ref": ref})
 	case "fill":
 		if len(remaining) < 3 {
 			return nil, fmt.Errorf("fill requires a ref and value")
@@ -237,6 +281,15 @@ func runBatchCommand(c toolCaller, raw string, opts batchOptions) (*mcp.ToolResu
 			return nil, err
 		}
 		return c.CallTool("act", fillToolArgs(page, ref, strings.Join(remaining[2:], " "), true))
+	case "select":
+		if len(remaining) < 3 {
+			return nil, fmt.Errorf("select requires a ref and value")
+		}
+		ref, err := elementRef(remaining[1])
+		if err != nil {
+			return nil, err
+		}
+		return c.CallTool("act", map[string]any{"page": page, "kind": "select", "ref": ref, "value": strings.Join(remaining[2:], " ")})
 	case "snapshot", "snap":
 		filters, err := batchSnapshotFilters(remaining[1:])
 		if err != nil {
@@ -250,10 +303,11 @@ func runBatchCommand(c toolCaller, raw string, opts batchOptions) (*mcp.ToolResu
 	case "read", "text", "links":
 		return runBatchRead(c, page, remaining)
 	case "grep":
-		if len(remaining) != 2 {
-			return nil, fmt.Errorf("grep requires one pattern")
+		pattern, over, limit, err := batchGrepArgs(remaining)
+		if err != nil {
+			return nil, err
 		}
-		return c.CallTool("grep", grepToolArgs(page, remaining[1], "ax", 0))
+		return c.CallTool("grep", grepToolArgs(page, pattern, over, limit))
 	case "find":
 		return runBatchFind(c, page, remaining[1:])
 	default:
@@ -277,6 +331,9 @@ func batchPage(tokens []string, opts batchOptions) (int, []string, error) {
 			if err != nil {
 				return 0, nil, fmt.Errorf("invalid page id: %s", tokens[i+1])
 			}
+			if err := validatePageID(value); err != nil {
+				return 0, nil, err
+			}
 			page = value
 			pageSet = true
 			i++
@@ -285,12 +342,18 @@ func batchPage(tokens []string, opts batchOptions) (int, []string, error) {
 			if err != nil {
 				return 0, nil, fmt.Errorf("invalid page id: %s", strings.TrimPrefix(token, "-p="))
 			}
+			if err := validatePageID(value); err != nil {
+				return 0, nil, err
+			}
 			page = value
 			pageSet = true
 		case strings.HasPrefix(token, "--page="):
 			value, err := strconv.Atoi(strings.TrimPrefix(token, "--page="))
 			if err != nil {
 				return 0, nil, fmt.Errorf("invalid page id: %s", strings.TrimPrefix(token, "--page="))
+			}
+			if err := validatePageID(value); err != nil {
+				return 0, nil, err
 			}
 			page = value
 			pageSet = true
@@ -301,51 +364,103 @@ func batchPage(tokens []string, opts batchOptions) (int, []string, error) {
 	if !pageSet {
 		return 0, nil, fmt.Errorf("page id is required: pass -p/--page <id> to batch or the subcommand")
 	}
+	if err := validatePageID(page); err != nil {
+		return 0, nil, err
+	}
 	return page, remaining, nil
 }
 
 func runBatchRead(c toolCaller, page int, tokens []string) (*mcp.ToolResult, error) {
-	if err := validateBatchRead(tokens); err != nil {
+	opts, err := batchReadOptions(tokens)
+	if err != nil {
 		return nil, err
 	}
+	return c.CallTool("read", readToolArgs(page, opts))
+}
+
+func batchReadOptions(tokens []string) (readOptions, error) {
+	opts := readOptions{format: "markdown"}
 	switch tokens[0] {
 	case "text":
-		return c.CallTool("read", readToolArgs(page, readOptions{format: "markdown"}))
 	case "links":
-		return c.CallTool("read", readToolArgs(page, readOptions{format: "links"}))
+		opts.format = "links"
+	case "read":
+	default:
+		return readOptions{}, fmt.Errorf("unsupported read command in batch: %s", tokens[0])
 	}
-	opts := readOptions{format: "markdown"}
-	for _, token := range tokens[1:] {
+	for i := 1; i < len(tokens); i++ {
+		token := tokens[i]
 		switch token {
 		case "--md":
 			opts.format = "markdown"
 		case "--text":
 			opts.format = "text"
 		case "--links":
-			opts.format = "links"
+			if tokens[0] == "text" {
+				opts.includeLinks = true
+			} else {
+				opts.format = "links"
+			}
+		case "--selector":
+			if i+1 >= len(tokens) {
+				return readOptions{}, fmt.Errorf("--selector requires a value")
+			}
+			opts.selector = tokens[i+1]
+			i++
+		case "--viewport":
+			opts.viewportOnly = true
+		case "--include-links":
+			opts.includeLinks = true
+		case "--images":
+			opts.includeImages = true
 		default:
-			return nil, fmt.Errorf("unsupported read flag in batch: %s", token)
+			if strings.HasPrefix(token, "--selector=") {
+				opts.selector = strings.TrimPrefix(token, "--selector=")
+				continue
+			}
+			return readOptions{}, fmt.Errorf("unsupported read flag in batch: %s", token)
 		}
 	}
-	return c.CallTool("read", readToolArgs(page, opts))
+	if tokens[0] == "links" && opts.format != "links" {
+		return readOptions{}, fmt.Errorf("links does not support format flags in batch")
+	}
+	return opts, nil
 }
 
-func validateBatchRead(tokens []string) error {
-	switch tokens[0] {
-	case "text", "links":
-		if len(tokens) != 1 {
-			return fmt.Errorf("%s does not take flags in batch", tokens[0])
-		}
-		return nil
-	}
-	for _, token := range tokens[1:] {
-		switch token {
-		case "--md", "--text", "--links":
+func batchGrepArgs(tokens []string) (string, string, int, error) {
+	over := "ax"
+	limit := 0
+	patterns := []string{}
+	for i := 1; i < len(tokens); i++ {
+		token := tokens[i]
+		switch {
+		case token == "--content":
+			over = "content"
+		case token == "--limit":
+			if i+1 >= len(tokens) {
+				return "", "", 0, fmt.Errorf("--limit requires a value")
+			}
+			value, err := strconv.Atoi(tokens[i+1])
+			if err != nil || value < 1 {
+				return "", "", 0, fmt.Errorf("invalid grep limit: %s", tokens[i+1])
+			}
+			limit = value
+			i++
+		case strings.HasPrefix(token, "--limit="):
+			value := strings.TrimPrefix(token, "--limit=")
+			parsed, err := strconv.Atoi(value)
+			if err != nil || parsed < 1 {
+				return "", "", 0, fmt.Errorf("invalid grep limit: %s", value)
+			}
+			limit = parsed
 		default:
-			return fmt.Errorf("unsupported read flag in batch: %s", token)
+			patterns = append(patterns, token)
 		}
 	}
-	return nil
+	if len(patterns) != 1 {
+		return "", "", 0, fmt.Errorf("grep requires one pattern")
+	}
+	return patterns[0], over, limit, nil
 }
 
 func batchSnapshotFilters(tokens []string) (snapshotFilterOptions, error) {
@@ -410,13 +525,14 @@ func runBatchFind(c toolCaller, page int, args []string) (*mcp.ToolResult, error
 	if err != nil {
 		return nil, err
 	}
-	return findReport(page, matches, selected, action, result), nil
+	return findReport(page, matches, selected, query, action, result), nil
 }
 
 func parseFindTokens(args []string) (findQuery, findAction, error) {
 	filtered := make([]string, 0, len(args))
 	name := ""
 	nth := 1
+	limit := findDefaultGrepLimit
 	for i := 0; i < len(args); i++ {
 		token := args[i]
 		switch {
@@ -444,6 +560,22 @@ func parseFindTokens(args []string) (findQuery, findAction, error) {
 				return findQuery{}, findAction{}, fmt.Errorf("invalid --nth: %s", strings.TrimPrefix(token, "--nth="))
 			}
 			nth = value
+		case token == "--limit":
+			if i+1 >= len(args) {
+				return findQuery{}, findAction{}, fmt.Errorf("--limit requires a value")
+			}
+			value, err := strconv.Atoi(args[i+1])
+			if err != nil {
+				return findQuery{}, findAction{}, fmt.Errorf("invalid --limit: %s", args[i+1])
+			}
+			limit = value
+			i++
+		case strings.HasPrefix(token, "--limit="):
+			value, err := strconv.Atoi(strings.TrimPrefix(token, "--limit="))
+			if err != nil {
+				return findQuery{}, findAction{}, fmt.Errorf("invalid --limit: %s", strings.TrimPrefix(token, "--limit="))
+			}
+			limit = value
 		default:
 			filtered = append(filtered, token)
 		}
@@ -454,7 +586,10 @@ func parseFindTokens(args []string) (findQuery, findAction, error) {
 	if nth < 1 {
 		return findQuery{}, findAction{}, fmt.Errorf("--nth must be 1 or greater")
 	}
-	query := findQuery{mode: filtered[0], nth: nth}
+	if limit < 1 {
+		return findQuery{}, findAction{}, fmt.Errorf("--limit must be 1 or greater")
+	}
+	query := findQuery{mode: filtered[0], nth: nth, limit: limit}
 	var actionArgs []string
 	switch query.mode {
 	case "text":

--- a/packages/browseros-agent/apps/cli/cmd/batch.go
+++ b/packages/browseros-agent/apps/cli/cmd/batch.go
@@ -611,45 +611,67 @@ func splitBatchCommand(raw string) ([]string, error) {
 	tokens := []string{}
 	var current strings.Builder
 	var quote rune
-	escaped := false
-	for _, r := range raw {
-		if escaped {
+	tokenStarted := false
+	runes := []rune(raw)
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
+		if quote == '\'' {
+			tokenStarted = true
+			if r == quote {
+				quote = 0
+				continue
+			}
 			current.WriteRune(r)
-			escaped = false
+			continue
+		}
+		if quote == '"' {
+			tokenStarted = true
+			if r == '\\' {
+				if i+1 < len(runes) && (runes[i+1] == '"' || runes[i+1] == '\\') {
+					i++
+					current.WriteRune(runes[i])
+					continue
+				}
+				current.WriteRune(r)
+				continue
+			}
+			if r == quote {
+				quote = 0
+				continue
+			}
+			current.WriteRune(r)
 			continue
 		}
 		if r == '\\' {
-			escaped = true
-			continue
-		}
-		if quote != 0 {
-			if r == quote {
-				quote = 0
-			} else {
-				current.WriteRune(r)
+			tokenStarted = true
+			if i+1 < len(runes) && (runes[i+1] == ' ' || runes[i+1] == '\t' || runes[i+1] == '\'' || runes[i+1] == '"' || runes[i+1] == '\\') {
+				i++
+				current.WriteRune(runes[i])
+				continue
 			}
+			current.WriteRune(r)
 			continue
 		}
 		if r == '\'' || r == '"' {
 			quote = r
+			tokenStarted = true
 			continue
 		}
 		if r == ' ' || r == '\t' {
-			if current.Len() > 0 {
+			if tokenStarted {
 				tokens = append(tokens, current.String())
 				current.Reset()
+				tokenStarted = false
 			}
 			continue
 		}
 		current.WriteRune(r)
-	}
-	if escaped {
-		current.WriteRune('\\')
+		tokenStarted = true
 	}
 	if quote != 0 {
 		return nil, fmt.Errorf("unterminated quote in batch command")
 	}
-	if current.Len() > 0 {
+	if tokenStarted {
 		tokens = append(tokens, current.String())
 	}
 	return tokens, nil

--- a/packages/browseros-agent/apps/cli/cmd/batch.go
+++ b/packages/browseros-agent/apps/cli/cmd/batch.go
@@ -50,6 +50,10 @@ func init() {
 				pageSet: rootCmd.PersistentFlags().Changed("page"),
 				bail:    bail,
 			}
+			if results := preflightBatchCommands(commands, opts); len(results) > 0 {
+				writeBatchResults(results)
+				os.Exit(1)
+			}
 
 			c := newClient()
 			var results []batchResult
@@ -60,11 +64,7 @@ func init() {
 				output.Error(err.Error(), 1)
 			}
 
-			if jsonOut {
-				output.JSONRaw(results)
-			} else {
-				output.Confirm(formatBatchResults(results))
-			}
+			writeBatchResults(results)
 			if failedBatch(results) {
 				os.Exit(1)
 			}
@@ -72,6 +72,14 @@ func init() {
 	}
 	cmd.Flags().Bool("bail", false, "Stop after the first failed subcommand")
 	rootCmd.AddCommand(cmd)
+}
+
+func writeBatchResults(results []batchResult) {
+	if jsonOut {
+		output.JSONRaw(results)
+	} else {
+		output.Confirm(formatBatchResults(results))
+	}
 }
 
 func batchCommands(args []string, stdin io.Reader) ([]string, error) {
@@ -99,6 +107,68 @@ func batchCommands(args []string, stdin io.Reader) ([]string, error) {
 		return nil, fmt.Errorf("batch requires command strings or stdin lines")
 	}
 	return commands, nil
+}
+
+// preflightBatchCommands validates command syntax and page routing before a shared MCP session can mutate pages.
+func preflightBatchCommands(commands []string, opts batchOptions) []batchResult {
+	results := make([]batchResult, 0)
+	for i, raw := range commands {
+		if err := validateBatchCommand(raw, opts); err != nil {
+			results = append(results, batchResult{Index: i + 1, Command: raw, OK: false, Error: err.Error()})
+			if opts.bail {
+				break
+			}
+		}
+	}
+	return results
+}
+
+func validateBatchCommand(raw string, opts batchOptions) error {
+	tokens, err := splitBatchCommand(raw)
+	if err != nil {
+		return err
+	}
+	_, remaining, err := batchPage(tokens, opts)
+	if err != nil {
+		return err
+	}
+	if len(remaining) == 0 {
+		return fmt.Errorf("empty batch command")
+	}
+
+	switch remaining[0] {
+	case "press", "key":
+		if len(remaining) != 2 {
+			return fmt.Errorf("%s requires one key", remaining[0])
+		}
+	case "type":
+		if len(remaining) < 2 {
+			return fmt.Errorf("type requires text")
+		}
+	case "click":
+		if len(remaining) != 2 {
+			return fmt.Errorf("click requires one ref")
+		}
+		_, err = elementRef(remaining[1])
+	case "fill":
+		if len(remaining) < 3 {
+			return fmt.Errorf("fill requires a ref and value")
+		}
+		_, err = elementRef(remaining[1])
+	case "snapshot", "snap":
+		_, err = batchSnapshotFilters(remaining[1:])
+	case "read", "text", "links":
+		err = validateBatchRead(remaining)
+	case "grep":
+		if len(remaining) != 2 {
+			return fmt.Errorf("grep requires one pattern")
+		}
+	case "find":
+		_, _, err = parseFindTokens(remaining[1:])
+	default:
+		return fmt.Errorf("unsupported batch command: %s", remaining[0])
+	}
+	return err
 }
 
 // runBatchCommands executes each command string independently so failures can be reported per step.
@@ -168,11 +238,15 @@ func runBatchCommand(c toolCaller, raw string, opts batchOptions) (*mcp.ToolResu
 		}
 		return c.CallTool("act", fillToolArgs(page, ref, strings.Join(remaining[2:], " "), true))
 	case "snapshot", "snap":
+		filters, err := batchSnapshotFilters(remaining[1:])
+		if err != nil {
+			return nil, err
+		}
 		result, err := c.CallTool("snapshot", map[string]any{"page": page})
 		if err != nil {
 			return nil, err
 		}
-		return snapshotOutputResult(result, page, snapshotFilterOptions{}, false), nil
+		return snapshotOutputResult(result, page, filters, false), nil
 	case "read", "text", "links":
 		return runBatchRead(c, page, remaining)
 	case "grep":
@@ -231,6 +305,9 @@ func batchPage(tokens []string, opts batchOptions) (int, []string, error) {
 }
 
 func runBatchRead(c toolCaller, page int, tokens []string) (*mcp.ToolResult, error) {
+	if err := validateBatchRead(tokens); err != nil {
+		return nil, err
+	}
 	switch tokens[0] {
 	case "text":
 		return c.CallTool("read", readToolArgs(page, readOptions{format: "markdown"}))
@@ -253,12 +330,70 @@ func runBatchRead(c toolCaller, page int, tokens []string) (*mcp.ToolResult, err
 	return c.CallTool("read", readToolArgs(page, opts))
 }
 
+func validateBatchRead(tokens []string) error {
+	switch tokens[0] {
+	case "text", "links":
+		if len(tokens) != 1 {
+			return fmt.Errorf("%s does not take flags in batch", tokens[0])
+		}
+		return nil
+	}
+	for _, token := range tokens[1:] {
+		switch token {
+		case "--md", "--text", "--links":
+		default:
+			return fmt.Errorf("unsupported read flag in batch: %s", token)
+		}
+	}
+	return nil
+}
+
+func batchSnapshotFilters(tokens []string) (snapshotFilterOptions, error) {
+	filters := snapshotFilterOptions{}
+	for i := 0; i < len(tokens); i++ {
+		token := tokens[i]
+		switch {
+		case token == "-i" || token == "--interactive":
+			filters.interactive = true
+		case token == "-c" || token == "--compact":
+			filters.compact = true
+		case token == "-d" || token == "--depth":
+			if i+1 >= len(tokens) {
+				return snapshotFilterOptions{}, fmt.Errorf("%s requires a depth", token)
+			}
+			depth, err := strconv.Atoi(tokens[i+1])
+			if err != nil || depth < 0 {
+				return snapshotFilterOptions{}, fmt.Errorf("invalid snapshot depth: %s", tokens[i+1])
+			}
+			filters.depth = depth
+			i++
+		case strings.HasPrefix(token, "-d="):
+			value := strings.TrimPrefix(token, "-d=")
+			depth, err := strconv.Atoi(value)
+			if err != nil || depth < 0 {
+				return snapshotFilterOptions{}, fmt.Errorf("invalid snapshot depth: %s", value)
+			}
+			filters.depth = depth
+		case strings.HasPrefix(token, "--depth="):
+			value := strings.TrimPrefix(token, "--depth=")
+			depth, err := strconv.Atoi(value)
+			if err != nil || depth < 0 {
+				return snapshotFilterOptions{}, fmt.Errorf("invalid snapshot depth: %s", value)
+			}
+			filters.depth = depth
+		default:
+			return snapshotFilterOptions{}, fmt.Errorf("unsupported snapshot flag in batch: %s", token)
+		}
+	}
+	return filters, nil
+}
+
 func runBatchFind(c toolCaller, page int, args []string) (*mcp.ToolResult, error) {
 	query, action, err := parseFindTokens(args)
 	if err != nil {
 		return nil, err
 	}
-	grepResult, err := c.CallTool("grep", grepToolArgs(page, query.grepPattern(), "ax", 100))
+	grepResult, err := c.CallTool("grep", findGrepToolArgs(page, query))
 	if err != nil {
 		return nil, err
 	}
@@ -315,6 +450,9 @@ func parseFindTokens(args []string) (findQuery, findAction, error) {
 	}
 	if len(filtered) < 3 {
 		return findQuery{}, findAction{}, fmt.Errorf("find requires a mode, query, and action")
+	}
+	if nth < 1 {
+		return findQuery{}, findAction{}, fmt.Errorf("--nth must be 1 or greater")
 	}
 	query := findQuery{mode: filtered[0], nth: nth}
 	var actionArgs []string

--- a/packages/browseros-agent/apps/cli/cmd/batch.go
+++ b/packages/browseros-agent/apps/cli/cmd/batch.go
@@ -1,0 +1,418 @@
+package cmd
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strconv"
+	"strings"
+
+	"browseros-cli/mcp"
+	"browseros-cli/output"
+
+	"github.com/spf13/cobra"
+)
+
+type toolCaller interface {
+	CallTool(name string, args map[string]any) (*mcp.ToolResult, error)
+}
+
+type batchOptions struct {
+	page    int
+	pageSet bool
+	bail    bool
+}
+
+type batchResult struct {
+	Index      int            `json:"index"`
+	Command    string         `json:"command"`
+	OK         bool           `json:"ok"`
+	Text       string         `json:"text,omitempty"`
+	Error      string         `json:"error,omitempty"`
+	Structured map[string]any `json:"structured,omitempty"`
+}
+
+func init() {
+	cmd := &cobra.Command{
+		Use:         "batch [command...]",
+		Annotations: map[string]string{"group": "Input:"},
+		Short:       "Run browser commands sequentially with one MCP session",
+		Args:        cobra.ArbitraryArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			bail, _ := cmd.Flags().GetBool("bail")
+			commands, err := batchCommands(args, os.Stdin)
+			if err != nil {
+				output.Error(err.Error(), 3)
+			}
+			opts := batchOptions{
+				page:    pageFlag,
+				pageSet: rootCmd.PersistentFlags().Changed("page"),
+				bail:    bail,
+			}
+
+			c := newClient()
+			var results []batchResult
+			if err := c.WithSession(func(shared *mcp.Client) error {
+				results = runBatchCommands(shared, commands, opts)
+				return nil
+			}); err != nil {
+				output.Error(err.Error(), 1)
+			}
+
+			if jsonOut {
+				output.JSONRaw(results)
+			} else {
+				output.Confirm(formatBatchResults(results))
+			}
+			if failedBatch(results) {
+				os.Exit(1)
+			}
+		},
+	}
+	cmd.Flags().Bool("bail", false, "Stop after the first failed subcommand")
+	rootCmd.AddCommand(cmd)
+}
+
+func batchCommands(args []string, stdin io.Reader) ([]string, error) {
+	if len(args) > 0 {
+		return args, nil
+	}
+	if file, ok := stdin.(*os.File); ok {
+		info, err := file.Stat()
+		if err == nil && info.Mode()&os.ModeCharDevice != 0 {
+			return nil, fmt.Errorf("batch requires command strings or stdin lines")
+		}
+	}
+	scanner := bufio.NewScanner(stdin)
+	commands := []string{}
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line != "" {
+			commands = append(commands, line)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	if len(commands) == 0 {
+		return nil, fmt.Errorf("batch requires command strings or stdin lines")
+	}
+	return commands, nil
+}
+
+// runBatchCommands executes each command string independently so failures can be reported per step.
+func runBatchCommands(c toolCaller, commands []string, opts batchOptions) []batchResult {
+	results := make([]batchResult, 0, len(commands))
+	for i, raw := range commands {
+		result := batchResult{Index: i + 1, Command: raw}
+		toolResult, err := runBatchCommand(c, raw, opts)
+		if err != nil {
+			result.OK = false
+			result.Error = err.Error()
+			results = append(results, result)
+			if opts.bail {
+				break
+			}
+			continue
+		}
+		result.OK = true
+		result.Text = toolResult.TextContent()
+		result.Structured = toolResult.StructuredContent
+		results = append(results, result)
+	}
+	return results
+}
+
+// runBatchCommand maps one shell-like command string onto the existing compact browser tools.
+func runBatchCommand(c toolCaller, raw string, opts batchOptions) (*mcp.ToolResult, error) {
+	tokens, err := splitBatchCommand(raw)
+	if err != nil {
+		return nil, err
+	}
+	page, remaining, err := batchPage(tokens, opts)
+	if err != nil {
+		return nil, err
+	}
+	if len(remaining) == 0 {
+		return nil, fmt.Errorf("empty batch command")
+	}
+
+	switch remaining[0] {
+	case "press", "key":
+		if len(remaining) != 2 {
+			return nil, fmt.Errorf("%s requires one key", remaining[0])
+		}
+		return c.CallTool("act", pressToolArgs(page, remaining[1]))
+	case "type":
+		if len(remaining) < 2 {
+			return nil, fmt.Errorf("type requires text")
+		}
+		return c.CallTool("act", typeToolArgs(page, strings.Join(remaining[1:], " ")))
+	case "click":
+		if len(remaining) != 2 {
+			return nil, fmt.Errorf("click requires one ref")
+		}
+		ref, err := elementRef(remaining[1])
+		if err != nil {
+			return nil, err
+		}
+		return c.CallTool("act", clickToolArgs(page, ref, "left", 1))
+	case "fill":
+		if len(remaining) < 3 {
+			return nil, fmt.Errorf("fill requires a ref and value")
+		}
+		ref, err := elementRef(remaining[1])
+		if err != nil {
+			return nil, err
+		}
+		return c.CallTool("act", fillToolArgs(page, ref, strings.Join(remaining[2:], " "), true))
+	case "snapshot", "snap":
+		result, err := c.CallTool("snapshot", map[string]any{"page": page})
+		if err != nil {
+			return nil, err
+		}
+		return snapshotOutputResult(result, page, snapshotFilterOptions{}, false), nil
+	case "read", "text", "links":
+		return runBatchRead(c, page, remaining)
+	case "grep":
+		if len(remaining) != 2 {
+			return nil, fmt.Errorf("grep requires one pattern")
+		}
+		return c.CallTool("grep", grepToolArgs(page, remaining[1], "ax", 0))
+	case "find":
+		return runBatchFind(c, page, remaining[1:])
+	default:
+		return nil, fmt.Errorf("unsupported batch command: %s", remaining[0])
+	}
+}
+
+// batchPage applies an optional subcommand page override over the outer batch page.
+func batchPage(tokens []string, opts batchOptions) (int, []string, error) {
+	page := opts.page
+	pageSet := opts.pageSet
+	remaining := make([]string, 0, len(tokens))
+	for i := 0; i < len(tokens); i++ {
+		token := tokens[i]
+		switch {
+		case token == "-p" || token == "--page":
+			if i+1 >= len(tokens) {
+				return 0, nil, fmt.Errorf("%s requires a page id", token)
+			}
+			value, err := strconv.Atoi(tokens[i+1])
+			if err != nil {
+				return 0, nil, fmt.Errorf("invalid page id: %s", tokens[i+1])
+			}
+			page = value
+			pageSet = true
+			i++
+		case strings.HasPrefix(token, "-p="):
+			value, err := strconv.Atoi(strings.TrimPrefix(token, "-p="))
+			if err != nil {
+				return 0, nil, fmt.Errorf("invalid page id: %s", strings.TrimPrefix(token, "-p="))
+			}
+			page = value
+			pageSet = true
+		case strings.HasPrefix(token, "--page="):
+			value, err := strconv.Atoi(strings.TrimPrefix(token, "--page="))
+			if err != nil {
+				return 0, nil, fmt.Errorf("invalid page id: %s", strings.TrimPrefix(token, "--page="))
+			}
+			page = value
+			pageSet = true
+		default:
+			remaining = append(remaining, token)
+		}
+	}
+	if !pageSet {
+		return 0, nil, fmt.Errorf("page id is required: pass -p/--page <id> to batch or the subcommand")
+	}
+	return page, remaining, nil
+}
+
+func runBatchRead(c toolCaller, page int, tokens []string) (*mcp.ToolResult, error) {
+	switch tokens[0] {
+	case "text":
+		return c.CallTool("read", readToolArgs(page, readOptions{format: "markdown"}))
+	case "links":
+		return c.CallTool("read", readToolArgs(page, readOptions{format: "links"}))
+	}
+	opts := readOptions{format: "markdown"}
+	for _, token := range tokens[1:] {
+		switch token {
+		case "--md":
+			opts.format = "markdown"
+		case "--text":
+			opts.format = "text"
+		case "--links":
+			opts.format = "links"
+		default:
+			return nil, fmt.Errorf("unsupported read flag in batch: %s", token)
+		}
+	}
+	return c.CallTool("read", readToolArgs(page, opts))
+}
+
+func runBatchFind(c toolCaller, page int, args []string) (*mcp.ToolResult, error) {
+	query, action, err := parseFindTokens(args)
+	if err != nil {
+		return nil, err
+	}
+	grepResult, err := c.CallTool("grep", grepToolArgs(page, query.grepPattern(), "ax", 100))
+	if err != nil {
+		return nil, err
+	}
+	matches := findMatches(snapshotLines(grepResult.TextContent()), query)
+	selected, err := selectFindMatch(matches, query)
+	if err != nil {
+		return nil, err
+	}
+	calls, err := findActionCalls(page, selected, action)
+	if err != nil {
+		return nil, err
+	}
+	result, err := callTools(c, calls)
+	if err != nil {
+		return nil, err
+	}
+	return findReport(page, matches, selected, action, result), nil
+}
+
+func parseFindTokens(args []string) (findQuery, findAction, error) {
+	filtered := make([]string, 0, len(args))
+	name := ""
+	nth := 1
+	for i := 0; i < len(args); i++ {
+		token := args[i]
+		switch {
+		case token == "--name":
+			if i+1 >= len(args) {
+				return findQuery{}, findAction{}, fmt.Errorf("--name requires a value")
+			}
+			name = args[i+1]
+			i++
+		case strings.HasPrefix(token, "--name="):
+			name = strings.TrimPrefix(token, "--name=")
+		case token == "--nth":
+			if i+1 >= len(args) {
+				return findQuery{}, findAction{}, fmt.Errorf("--nth requires a value")
+			}
+			value, err := strconv.Atoi(args[i+1])
+			if err != nil {
+				return findQuery{}, findAction{}, fmt.Errorf("invalid --nth: %s", args[i+1])
+			}
+			nth = value
+			i++
+		case strings.HasPrefix(token, "--nth="):
+			value, err := strconv.Atoi(strings.TrimPrefix(token, "--nth="))
+			if err != nil {
+				return findQuery{}, findAction{}, fmt.Errorf("invalid --nth: %s", strings.TrimPrefix(token, "--nth="))
+			}
+			nth = value
+		default:
+			filtered = append(filtered, token)
+		}
+	}
+	if len(filtered) < 3 {
+		return findQuery{}, findAction{}, fmt.Errorf("find requires a mode, query, and action")
+	}
+	query := findQuery{mode: filtered[0], nth: nth}
+	var actionArgs []string
+	switch query.mode {
+	case "text":
+		query.text = filtered[1]
+		actionArgs = filtered[2:]
+	case "role":
+		query.role = filtered[1]
+		query.name = name
+		actionArgs = filtered[2:]
+	default:
+		return findQuery{}, findAction{}, fmt.Errorf("find mode must be text or role")
+	}
+	action, err := parseFindAction(actionArgs)
+	return query, action, err
+}
+
+// splitBatchCommand handles the common quoted argument forms agents use in batch strings.
+func splitBatchCommand(raw string) ([]string, error) {
+	tokens := []string{}
+	var current strings.Builder
+	var quote rune
+	escaped := false
+	for _, r := range raw {
+		if escaped {
+			current.WriteRune(r)
+			escaped = false
+			continue
+		}
+		if r == '\\' {
+			escaped = true
+			continue
+		}
+		if quote != 0 {
+			if r == quote {
+				quote = 0
+			} else {
+				current.WriteRune(r)
+			}
+			continue
+		}
+		if r == '\'' || r == '"' {
+			quote = r
+			continue
+		}
+		if r == ' ' || r == '\t' {
+			if current.Len() > 0 {
+				tokens = append(tokens, current.String())
+				current.Reset()
+			}
+			continue
+		}
+		current.WriteRune(r)
+	}
+	if escaped {
+		current.WriteRune('\\')
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unterminated quote in batch command")
+	}
+	if current.Len() > 0 {
+		tokens = append(tokens, current.String())
+	}
+	return tokens, nil
+}
+
+func callTools(c toolCaller, calls []toolCall) (*mcp.ToolResult, error) {
+	var result *mcp.ToolResult
+	for _, call := range calls {
+		next, err := c.CallTool(call.name, call.args)
+		if err != nil {
+			return nil, err
+		}
+		result = next
+	}
+	return result, nil
+}
+
+func failedBatch(results []batchResult) bool {
+	for _, result := range results {
+		if !result.OK {
+			return true
+		}
+	}
+	return false
+}
+
+func formatBatchResults(results []batchResult) string {
+	lines := make([]string, 0, len(results))
+	for _, result := range results {
+		status := "ok"
+		body := result.Text
+		if !result.OK {
+			status = "failed"
+			body = result.Error
+		}
+		lines = append(lines, fmt.Sprintf("[%d] %s: %s\n%s", result.Index, status, result.Command, body))
+	}
+	return strings.Join(lines, "\n\n")
+}

--- a/packages/browseros-agent/apps/cli/cmd/batch_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/batch_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 
 	"browseros-cli/mcp"
@@ -69,6 +70,48 @@ func TestBatchContinuesWithoutBail(t *testing.T) {
 	}
 	if !failedBatch(results) {
 		t.Fatal("failedBatch() = false, want true")
+	}
+}
+
+func TestBatchPreflightMissingPageBeforeSession(t *testing.T) {
+	results := preflightBatchCommands([]string{"snapshot"}, batchOptions{})
+
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	if results[0].OK {
+		t.Fatal("preflight result OK = true, want false")
+	}
+	if !strings.Contains(results[0].Error, "page id is required") {
+		t.Fatalf("error = %q, want missing page error", results[0].Error)
+	}
+}
+
+func TestBatchPreflightRejectsInvalidFindNth(t *testing.T) {
+	results := preflightBatchCommands([]string{"find --nth -1 text Buy click"}, batchOptions{
+		page:    7,
+		pageSet: true,
+	})
+
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	if !strings.Contains(results[0].Error, "--nth must be 1 or greater") {
+		t.Fatalf("error = %q, want invalid nth error", results[0].Error)
+	}
+}
+
+func TestBatchSnapshotFilters(t *testing.T) {
+	got, err := batchSnapshotFilters([]string{"-i", "--compact", "--depth=3"})
+	if err != nil {
+		t.Fatalf("batchSnapshotFilters() error = %v", err)
+	}
+	if !got.interactive || !got.compact || got.depth != 3 {
+		t.Fatalf("filters = %#v, want interactive compact depth 3", got)
+	}
+
+	if _, err := batchSnapshotFilters([]string{"--selector", "button"}); err == nil {
+		t.Fatal("batchSnapshotFilters() error = nil, want unsupported flag error")
 	}
 }
 

--- a/packages/browseros-agent/apps/cli/cmd/batch_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/batch_test.go
@@ -24,7 +24,7 @@ func (f *fakeToolCaller) CallTool(name string, args map[string]any) (*mcp.ToolRe
 
 func TestBatchCommandsInheritAndOverridePage(t *testing.T) {
 	caller := &fakeToolCaller{}
-	results := runBatchCommands(caller, []string{"press Enter", "-p 9 press Escape"}, batchOptions{
+	results := runBatchCommands(caller, []string{"press Enter", "-p 9 press Escape", "nav https://example.com", "eval document.title", "hover @e3", "select @e4 Large"}, batchOptions{
 		page:    7,
 		pageSet: true,
 		bail:    true,
@@ -36,6 +36,10 @@ func TestBatchCommandsInheritAndOverridePage(t *testing.T) {
 	want := []toolCall{
 		{name: "act", args: map[string]any{"page": 7, "kind": "press", "key": "Enter"}},
 		{name: "act", args: map[string]any{"page": 9, "kind": "press", "key": "Escape"}},
+		{name: "navigate", args: map[string]any{"page": 7, "action": "url", "url": "https://example.com"}},
+		{name: "evaluate", args: map[string]any{"page": 7, "code": evalCode("document.title")}},
+		{name: "act", args: map[string]any{"page": 7, "kind": "hover", "ref": "e3"}},
+		{name: "act", args: map[string]any{"page": 7, "kind": "select", "ref": "e4", "value": "Large"}},
 	}
 	if !reflect.DeepEqual(caller.calls, want) {
 		t.Fatalf("calls = %#v, want %#v", caller.calls, want)
@@ -112,6 +116,39 @@ func TestBatchSnapshotFilters(t *testing.T) {
 
 	if _, err := batchSnapshotFilters([]string{"--selector", "button"}); err == nil {
 		t.Fatal("batchSnapshotFilters() error = nil, want unsupported flag error")
+	}
+}
+
+func TestBatchReadParsesCommandFlags(t *testing.T) {
+	got, err := batchReadOptions([]string{"read", "--text", "--selector=.main", "--viewport", "--include-links", "--images"})
+	if err != nil {
+		t.Fatalf("batchReadOptions() error = %v", err)
+	}
+	want := readOptions{
+		format:        "text",
+		selector:      ".main",
+		viewportOnly:  true,
+		includeLinks:  true,
+		includeImages: true,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("read options = %#v, want %#v", got, want)
+	}
+}
+
+func TestBatchGrepParsesCommandFlags(t *testing.T) {
+	pattern, over, limit, err := batchGrepArgs([]string{"grep", "--content", "--limit=5", "price"})
+	if err != nil {
+		t.Fatalf("batchGrepArgs() error = %v", err)
+	}
+	if pattern != "price" || over != "content" || limit != 5 {
+		t.Fatalf("grep args = %q %q %d, want price content 5", pattern, over, limit)
+	}
+}
+
+func TestBatchPageRejectsNonPositivePage(t *testing.T) {
+	if _, _, err := batchPage([]string{"-p", "0", "snapshot"}, batchOptions{}); err == nil {
+		t.Fatal("batchPage() error = nil, want invalid page error")
 	}
 }
 

--- a/packages/browseros-agent/apps/cli/cmd/batch_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/batch_test.go
@@ -162,3 +162,25 @@ func TestSplitBatchCommandPreservesQuotedArgs(t *testing.T) {
 		t.Fatalf("tokens = %#v, want %#v", got, want)
 	}
 }
+
+func TestSplitBatchCommandPreservesBackslashes(t *testing.T) {
+	got, err := splitBatchCommand(`grep "\\d+"`)
+	if err != nil {
+		t.Fatalf("splitBatchCommand() error = %v", err)
+	}
+	want := []string{"grep", `\d+`}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("tokens = %#v, want %#v", got, want)
+	}
+}
+
+func TestSplitBatchCommandPreservesEmptyQuotedArgs(t *testing.T) {
+	got, err := splitBatchCommand(`fill @e1 ""`)
+	if err != nil {
+		t.Fatalf("splitBatchCommand() error = %v", err)
+	}
+	want := []string{"fill", "@e1", ""}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("tokens = %#v, want %#v", got, want)
+	}
+}

--- a/packages/browseros-agent/apps/cli/cmd/batch_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/batch_test.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+
+	"browseros-cli/mcp"
+)
+
+type fakeToolCaller struct {
+	calls []toolCall
+	fail  map[int]error
+}
+
+func (f *fakeToolCaller) CallTool(name string, args map[string]any) (*mcp.ToolResult, error) {
+	f.calls = append(f.calls, toolCall{name: name, args: args})
+	if err := f.fail[len(f.calls)]; err != nil {
+		return nil, err
+	}
+	return textResult("ok", map[string]any{"ok": true}), nil
+}
+
+func TestBatchCommandsInheritAndOverridePage(t *testing.T) {
+	caller := &fakeToolCaller{}
+	results := runBatchCommands(caller, []string{"press Enter", "-p 9 press Escape"}, batchOptions{
+		page:    7,
+		pageSet: true,
+		bail:    true,
+	})
+
+	if failedBatch(results) {
+		t.Fatalf("batch failed: %#v", results)
+	}
+	want := []toolCall{
+		{name: "act", args: map[string]any{"page": 7, "kind": "press", "key": "Enter"}},
+		{name: "act", args: map[string]any{"page": 9, "kind": "press", "key": "Escape"}},
+	}
+	if !reflect.DeepEqual(caller.calls, want) {
+		t.Fatalf("calls = %#v, want %#v", caller.calls, want)
+	}
+}
+
+func TestBatchBailStopsOnFirstFailure(t *testing.T) {
+	caller := &fakeToolCaller{fail: map[int]error{1: errors.New("boom")}}
+	results := runBatchCommands(caller, []string{"press Enter", "press Escape"}, batchOptions{
+		page:    7,
+		pageSet: true,
+		bail:    true,
+	})
+
+	if len(results) != 1 {
+		t.Fatalf("results = %d, want 1", len(results))
+	}
+	if !failedBatch(results) {
+		t.Fatal("failedBatch() = false, want true")
+	}
+}
+
+func TestBatchContinuesWithoutBail(t *testing.T) {
+	caller := &fakeToolCaller{fail: map[int]error{1: errors.New("boom")}}
+	results := runBatchCommands(caller, []string{"press Enter", "press Escape"}, batchOptions{
+		page:    7,
+		pageSet: true,
+	})
+
+	if len(results) != 2 {
+		t.Fatalf("results = %d, want 2", len(results))
+	}
+	if !failedBatch(results) {
+		t.Fatal("failedBatch() = false, want true")
+	}
+}
+
+func TestSplitBatchCommandPreservesQuotedArgs(t *testing.T) {
+	got, err := splitBatchCommand(`find text "Add to Cart" click`)
+	if err != nil {
+		t.Fatalf("splitBatchCommand() error = %v", err)
+	}
+	want := []string{"find", "text", "Add to Cart", "click"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("tokens = %#v, want %#v", got, want)
+	}
+}

--- a/packages/browseros-agent/apps/cli/cmd/click.go
+++ b/packages/browseros-agent/apps/cli/cmd/click.go
@@ -35,11 +35,11 @@ func init() {
 				clickCount = 2
 			}
 
-			c := newClient()
-			pageID, err := resolvePageID(c)
+			pageID, err := resolvePageID(nil)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
+			c := newClient()
 
 			result, err := c.CallTool("act", clickToolArgs(pageID, ref, button, clickCount))
 			if err != nil {
@@ -71,11 +71,11 @@ func init() {
 				output.Errorf(3, "invalid y coordinate: %s", args[1])
 			}
 
-			c := newClient()
-			pageID, err := resolvePageID(c)
+			pageID, err := resolvePageID(nil)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
+			c := newClient()
 
 			result, err := c.CallTool("act", clickAtToolArgs(pageID, x, y))
 			if err != nil {

--- a/packages/browseros-agent/apps/cli/cmd/diff.go
+++ b/packages/browseros-agent/apps/cli/cmd/diff.go
@@ -13,11 +13,11 @@ func init() {
 		Short:       "Show what changed on the page since the last snapshot or diff",
 		Args:        cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			c := newClient()
-			pageID, err := resolvePageID(c)
+			pageID, err := resolvePageID(nil)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
+			c := newClient()
 
 			result, err := c.CallTool("diff", diffToolArgs(pageID))
 			if err != nil {

--- a/packages/browseros-agent/apps/cli/cmd/eval.go
+++ b/packages/browseros-agent/apps/cli/cmd/eval.go
@@ -17,11 +17,11 @@ func init() {
 		Args:        cobra.MinimumNArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			expression := strings.Join(args, " ")
-			c := newClient()
-			pageID, err := resolvePageID(c)
+			pageID, err := resolvePageID(nil)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
+			c := newClient()
 			result, err := c.CallTool("evaluate", map[string]any{
 				"page": pageID,
 				"code": evalCode(expression),

--- a/packages/browseros-agent/apps/cli/cmd/file_actions.go
+++ b/packages/browseros-agent/apps/cli/cmd/file_actions.go
@@ -15,11 +15,11 @@ func init() {
 		Short:       "Save the current page as PDF",
 		Args:        cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			c := newClient()
-			pageID, err := resolvePageID(c)
+			pageID, err := resolvePageID(nil)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
+			c := newClient()
 			result, err := c.CallTool("pdf", pdfToolArgs(pageID))
 			if err != nil {
 				output.Error(err.Error(), 1)
@@ -55,11 +55,11 @@ func init() {
 				output.Error(err.Error(), 3)
 			}
 
-			c := newClient()
-			pageID, err := resolvePageID(c)
+			pageID, err := resolvePageID(nil)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
+			c := newClient()
 			result, err := c.CallTool("download", downloadToolArgs(pageID, ref))
 			if err != nil {
 				output.Error(err.Error(), 1)

--- a/packages/browseros-agent/apps/cli/cmd/fill.go
+++ b/packages/browseros-agent/apps/cli/cmd/fill.go
@@ -21,11 +21,11 @@ func init() {
 			}
 			value := strings.Join(args[1:], " ")
 
-			c := newClient()
-			pageID, err := resolvePageID(c)
+			pageID, err := resolvePageID(nil)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
+			c := newClient()
 
 			result, err := c.CallTool("act", fillToolArgsFromCommand(cmd, pageID, ref, value))
 			if err != nil {
@@ -54,11 +54,11 @@ func init() {
 		Short:       "Press a key or key combination (e.g., Enter, Control+A)",
 		Args:        cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			c := newClient()
-			pageID, err := resolvePageID(c)
+			pageID, err := resolvePageID(nil)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
+			c := newClient()
 			result, err := c.CallTool("act", map[string]any{
 				"page": pageID,
 				"kind": "press",

--- a/packages/browseros-agent/apps/cli/cmd/fill.go
+++ b/packages/browseros-agent/apps/cli/cmd/fill.go
@@ -48,8 +48,9 @@ func init() {
 		Run:         elementAction("fill", map[string]any{"value": "", "clear": true}),
 	}
 
-	keyCmd := &cobra.Command{
-		Use:         "key <key>",
+	pressCmd := &cobra.Command{
+		Use:         "press <key>",
+		Aliases:     []string{"key"},
 		Annotations: map[string]string{"group": "Input:"},
 		Short:       "Press a key or key combination (e.g., Enter, Control+A)",
 		Args:        cobra.ExactArgs(1),
@@ -59,11 +60,7 @@ func init() {
 				output.Error(err.Error(), 2)
 			}
 			c := newClient()
-			result, err := c.CallTool("act", map[string]any{
-				"page": pageID,
-				"kind": "press",
-				"key":  args[0],
-			})
+			result, err := c.CallTool("act", pressToolArgs(pageID, args[0]))
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -75,7 +72,30 @@ func init() {
 		},
 	}
 
-	rootCmd.AddCommand(fillCmd, clearCmd, keyCmd)
+	typeCmd := &cobra.Command{
+		Use:         "type <text>",
+		Annotations: map[string]string{"group": "Input:"},
+		Short:       "Type text into the focused element",
+		Args:        cobra.MinimumNArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			pageID, err := resolvePageID(nil)
+			if err != nil {
+				output.Error(err.Error(), 2)
+			}
+			c := newClient()
+			result, err := c.CallTool("act", typeToolArgs(pageID, strings.Join(args, " ")))
+			if err != nil {
+				output.Error(err.Error(), 1)
+			}
+			if jsonOut {
+				output.JSON(result)
+			} else {
+				output.Confirm(result.TextContent())
+			}
+		},
+	}
+
+	rootCmd.AddCommand(fillCmd, clearCmd, pressCmd, typeCmd)
 }
 
 // fillToolArgsFromCommand converts parsed fill flags into the compact act payload.
@@ -91,5 +111,21 @@ func fillToolArgs(pageID int, ref, value string, clear bool) map[string]any {
 		"ref":   ref,
 		"value": value,
 		"clear": clear,
+	}
+}
+
+func pressToolArgs(pageID int, key string) map[string]any {
+	return map[string]any{
+		"page": pageID,
+		"kind": "press",
+		"key":  key,
+	}
+}
+
+func typeToolArgs(pageID int, text string) map[string]any {
+	return map[string]any{
+		"page": pageID,
+		"kind": "type",
+		"text": text,
 	}
 }

--- a/packages/browseros-agent/apps/cli/cmd/find.go
+++ b/packages/browseros-agent/apps/cli/cmd/find.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 
 	"browseros-cli/mcp"
@@ -12,11 +13,12 @@ import (
 )
 
 type findQuery struct {
-	mode string
-	text string
-	role string
-	name string
-	nth  int
+	mode  string
+	text  string
+	role  string
+	name  string
+	nth   int
+	limit int
 }
 
 type findAction struct {
@@ -34,7 +36,7 @@ type toolCall struct {
 	args map[string]any
 }
 
-const findGrepLimit = 1_000_000
+const findDefaultGrepLimit = 100
 
 func init() {
 	cmd := &cobra.Command{
@@ -72,7 +74,7 @@ func init() {
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
-			report := findReport(pageID, matches, selected, action, result)
+			report := findReport(pageID, matches, selected, query, action, result)
 			if jsonOut {
 				output.JSONRaw(report.StructuredContent)
 			} else {
@@ -82,6 +84,7 @@ func init() {
 	}
 	cmd.Flags().String("name", "", "Accessible name substring for role matches")
 	cmd.Flags().Int("nth", 1, "One-based match index to select")
+	cmd.Flags().Int("limit", findDefaultGrepLimit, "Maximum snapshot candidates to search")
 	rootCmd.AddCommand(cmd)
 }
 
@@ -90,8 +93,12 @@ func parseFindArgs(cmd *cobra.Command, args []string) (findQuery, findAction, er
 	if nth < 1 {
 		return findQuery{}, findAction{}, fmt.Errorf("--nth must be 1 or greater")
 	}
+	limit, _ := cmd.Flags().GetInt("limit")
+	if limit < 1 {
+		return findQuery{}, findAction{}, fmt.Errorf("--limit must be 1 or greater")
+	}
 	mode := args[0]
-	query := findQuery{mode: mode, nth: nth}
+	query := findQuery{mode: mode, nth: nth, limit: limit}
 	var actionArgs []string
 	switch mode {
 	case "text":
@@ -140,7 +147,18 @@ func (q findQuery) grepPattern() string {
 }
 
 func findGrepToolArgs(pageID int, query findQuery) map[string]any {
-	return grepToolArgs(pageID, query.grepPattern(), "ax", findGrepLimit)
+	return grepToolArgs(pageID, query.grepPattern(), "ax", query.grepLimit())
+}
+
+func (q findQuery) grepLimit() int {
+	limit := q.limit
+	if limit < 1 {
+		limit = findDefaultGrepLimit
+	}
+	if q.nth > limit {
+		return q.nth
+	}
+	return limit
 }
 
 func snapshotLines(text string) []string {
@@ -252,7 +270,7 @@ func findActionCalls(pageID int, match findMatch, action findAction) ([]toolCall
 	}
 }
 
-func findReport(pageID int, matches []findMatch, selected findMatch, action findAction, result *mcp.ToolResult) *mcp.ToolResult {
+func findReport(pageID int, matches []findMatch, selected findMatch, query findQuery, action findAction, result *mcp.ToolResult) *mcp.ToolResult {
 	selectedIndex := 1
 	for i, match := range matches {
 		if match.ref == selected.ref && match.line == selected.line {
@@ -260,8 +278,14 @@ func findReport(pageID int, matches []findMatch, selected findMatch, action find
 			break
 		}
 	}
+	limit := query.grepLimit()
+	limitReached := len(matches) >= limit
+	countLabel := strconv.Itoa(len(matches))
+	if limitReached {
+		countLabel += "+"
+	}
 	ref := "@" + selected.ref
-	text := fmt.Sprintf("match %d/%d %s\n%s", selectedIndex, len(matches), ref, displayElementRefs(selected.line))
+	text := fmt.Sprintf("match %d/%s %s\n%s", selectedIndex, countLabel, ref, displayElementRefs(selected.line))
 	if result != nil && result.TextContent() != "" {
 		text += "\n" + result.TextContent()
 	}
@@ -272,6 +296,10 @@ func findReport(pageID int, matches []findMatch, selected findMatch, action find
 		"matchCount":    len(matches),
 		"selectedIndex": selectedIndex,
 		"action":        action.kind,
+		"matchLimit":    limit,
+	}
+	if limitReached {
+		data["matchLimitReached"] = true
 	}
 	if action.value != "" {
 		data["value"] = action.value

--- a/packages/browseros-agent/apps/cli/cmd/find.go
+++ b/packages/browseros-agent/apps/cli/cmd/find.go
@@ -66,7 +66,10 @@ func init() {
 				output.Error(err.Error(), 3)
 			}
 
-			result := runFindCalls(c, calls)
+			result, err := callTools(c, calls)
+			if err != nil {
+				output.Error(err.Error(), 1)
+			}
 			report := findReport(pageID, matches, selected, action, result)
 			if jsonOut {
 				output.JSONRaw(report.StructuredContent)
@@ -241,18 +244,6 @@ func findActionCalls(pageID int, match findMatch, action findAction) ([]toolCall
 	default:
 		return nil, fmt.Errorf("unsupported find action: %s", action.kind)
 	}
-}
-
-func runFindCalls(c *mcp.Client, calls []toolCall) *mcp.ToolResult {
-	var result *mcp.ToolResult
-	for _, call := range calls {
-		next, err := c.CallTool(call.name, call.args)
-		if err != nil {
-			output.Error(err.Error(), 1)
-		}
-		result = next
-	}
-	return result
 }
 
 func findReport(pageID int, matches []findMatch, selected findMatch, action findAction, result *mcp.ToolResult) *mcp.ToolResult {

--- a/packages/browseros-agent/apps/cli/cmd/find.go
+++ b/packages/browseros-agent/apps/cli/cmd/find.go
@@ -34,6 +34,8 @@ type toolCall struct {
 	args map[string]any
 }
 
+const findGrepLimit = 1_000_000
+
 func init() {
 	cmd := &cobra.Command{
 		Use:         "find text <text> <action> | find role <role> <action>",
@@ -51,7 +53,7 @@ func init() {
 			}
 			c := newClient()
 
-			grepResult, err := c.CallTool("grep", grepToolArgs(pageID, query.grepPattern(), "ax", 100))
+			grepResult, err := c.CallTool("grep", findGrepToolArgs(pageID, query))
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -137,6 +139,10 @@ func (q findQuery) grepPattern() string {
 	return regexp.QuoteMeta(q.text)
 }
 
+func findGrepToolArgs(pageID int, query findQuery) map[string]any {
+	return grepToolArgs(pageID, query.grepPattern(), "ax", findGrepLimit)
+}
+
 func snapshotLines(text string) []string {
 	rawLines := strings.Split(text, "\n")
 	lines := make([]string, 0, len(rawLines))
@@ -202,8 +208,8 @@ func selectFindMatch(matches []findMatch, query findQuery) (findMatch, error) {
 		return findMatch{}, fmt.Errorf("find: no matches")
 	}
 	nth := query.nth
-	if nth == 0 {
-		nth = 1
+	if nth < 1 {
+		return findMatch{}, fmt.Errorf("find: --nth must be 1 or greater")
 	}
 	if nth > len(matches) {
 		return findMatch{}, fmt.Errorf("find: only %d matches, --nth %d is out of range", len(matches), nth)

--- a/packages/browseros-agent/apps/cli/cmd/find.go
+++ b/packages/browseros-agent/apps/cli/cmd/find.go
@@ -1,0 +1,286 @@
+package cmd
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"browseros-cli/mcp"
+	"browseros-cli/output"
+
+	"github.com/spf13/cobra"
+)
+
+type findQuery struct {
+	mode string
+	text string
+	role string
+	name string
+	nth  int
+}
+
+type findAction struct {
+	kind  string
+	value string
+}
+
+type findMatch struct {
+	ref  string
+	line string
+}
+
+type toolCall struct {
+	name string
+	args map[string]any
+}
+
+func init() {
+	cmd := &cobra.Command{
+		Use:         "find text <text> <action> | find role <role> <action>",
+		Annotations: map[string]string{"group": "Input:"},
+		Short:       "Find an element in the snapshot and act on it",
+		Args:        cobra.MinimumNArgs(3),
+		Run: func(cmd *cobra.Command, args []string) {
+			query, action, err := parseFindArgs(cmd, args)
+			if err != nil {
+				output.Error(err.Error(), 3)
+			}
+			pageID, err := resolvePageID(nil)
+			if err != nil {
+				output.Error(err.Error(), 2)
+			}
+			c := newClient()
+
+			grepResult, err := c.CallTool("grep", grepToolArgs(pageID, query.grepPattern(), "ax", 100))
+			if err != nil {
+				output.Error(err.Error(), 1)
+			}
+			lines := snapshotLines(grepResult.TextContent())
+			matches := findMatches(lines, query)
+			selected, err := selectFindMatch(matches, query)
+			if err != nil {
+				output.Error(err.Error(), 1)
+			}
+			calls, err := findActionCalls(pageID, selected, action)
+			if err != nil {
+				output.Error(err.Error(), 3)
+			}
+
+			result := runFindCalls(c, calls)
+			report := findReport(pageID, matches, selected, action, result)
+			if jsonOut {
+				output.JSONRaw(report.StructuredContent)
+			} else {
+				output.Confirm(report.TextContent())
+			}
+		},
+	}
+	cmd.Flags().String("name", "", "Accessible name substring for role matches")
+	cmd.Flags().Int("nth", 1, "One-based match index to select")
+	rootCmd.AddCommand(cmd)
+}
+
+func parseFindArgs(cmd *cobra.Command, args []string) (findQuery, findAction, error) {
+	nth, _ := cmd.Flags().GetInt("nth")
+	if nth < 1 {
+		return findQuery{}, findAction{}, fmt.Errorf("--nth must be 1 or greater")
+	}
+	mode := args[0]
+	query := findQuery{mode: mode, nth: nth}
+	var actionArgs []string
+	switch mode {
+	case "text":
+		query.text = args[1]
+		actionArgs = args[2:]
+	case "role":
+		query.role = args[1]
+		query.name, _ = cmd.Flags().GetString("name")
+		actionArgs = args[2:]
+	default:
+		return findQuery{}, findAction{}, fmt.Errorf("find mode must be text or role")
+	}
+	action, err := parseFindAction(actionArgs)
+	return query, action, err
+}
+
+func parseFindAction(args []string) (findAction, error) {
+	if len(args) == 0 {
+		return findAction{}, fmt.Errorf("find action is required")
+	}
+	action := findAction{kind: args[0]}
+	switch action.kind {
+	case "click", "hover", "check", "uncheck", "focus":
+		if len(args) != 1 {
+			return findAction{}, fmt.Errorf("%s does not take a value", action.kind)
+		}
+	case "fill", "type", "select":
+		if len(args) < 2 {
+			return findAction{}, fmt.Errorf("%s requires a value", action.kind)
+		}
+		action.value = strings.Join(args[1:], " ")
+	default:
+		return findAction{}, fmt.Errorf("unsupported find action: %s", action.kind)
+	}
+	return action, nil
+}
+
+func (q findQuery) grepPattern() string {
+	if q.mode == "role" {
+		if q.name != "" {
+			return regexp.QuoteMeta(q.name)
+		}
+		return regexp.QuoteMeta(q.role)
+	}
+	return regexp.QuoteMeta(q.text)
+}
+
+func snapshotLines(text string) []string {
+	rawLines := strings.Split(text, "\n")
+	lines := make([]string, 0, len(rawLines))
+	for _, line := range rawLines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "[UNTRUSTED_PAGE_CONTENT") || strings.HasPrefix(trimmed, "[END_UNTRUSTED_PAGE_CONTENT") {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	return lines
+}
+
+// findMatches returns snapshot lines with refs that satisfy the requested text or role filter.
+func findMatches(lines []string, query findQuery) []findMatch {
+	matches := []findMatch{}
+	for _, line := range lines {
+		ref, ok := findLineRef(line)
+		if !ok || !findLineMatches(line, query) {
+			continue
+		}
+		matches = append(matches, findMatch{ref: ref, line: line})
+	}
+	return matches
+}
+
+func findLineRef(line string) (string, bool) {
+	match := snapshotRefPattern.FindStringSubmatch(line)
+	if len(match) != 2 {
+		return "", false
+	}
+	return "e" + match[1], true
+}
+
+func findLineMatches(line string, query findQuery) bool {
+	lower := strings.ToLower(line)
+	switch query.mode {
+	case "text":
+		return strings.Contains(lower, strings.ToLower(query.text))
+	case "role":
+		if query.role != "" && lineRole(line) != strings.ToLower(query.role) {
+			return false
+		}
+		return query.name == "" || strings.Contains(lower, strings.ToLower(query.name))
+	default:
+		return false
+	}
+}
+
+func lineRole(line string) string {
+	trimmed := strings.TrimSpace(line)
+	trimmed = strings.TrimPrefix(trimmed, "-")
+	trimmed = strings.TrimSpace(trimmed)
+	fields := strings.Fields(trimmed)
+	if len(fields) == 0 {
+		return ""
+	}
+	return strings.ToLower(fields[0])
+}
+
+func selectFindMatch(matches []findMatch, query findQuery) (findMatch, error) {
+	if len(matches) == 0 {
+		return findMatch{}, fmt.Errorf("find: no matches")
+	}
+	nth := query.nth
+	if nth == 0 {
+		nth = 1
+	}
+	if nth > len(matches) {
+		return findMatch{}, fmt.Errorf("find: only %d matches, --nth %d is out of range", len(matches), nth)
+	}
+	return matches[nth-1], nil
+}
+
+// findActionCalls maps a selected snapshot ref to the act calls needed for the requested action.
+func findActionCalls(pageID int, match findMatch, action findAction) ([]toolCall, error) {
+	ref := match.ref
+	switch action.kind {
+	case "click", "hover", "check", "uncheck", "focus":
+		return []toolCall{{name: "act", args: map[string]any{
+			"page": pageID,
+			"kind": action.kind,
+			"ref":  ref,
+		}}}, nil
+	case "fill":
+		return []toolCall{{name: "act", args: map[string]any{
+			"page":  pageID,
+			"kind":  "fill",
+			"ref":   ref,
+			"value": action.value,
+			"clear": true,
+		}}}, nil
+	case "type":
+		return []toolCall{
+			{name: "act", args: map[string]any{"page": pageID, "kind": "focus", "ref": ref}},
+			{name: "act", args: map[string]any{"page": pageID, "kind": "type", "text": action.value}},
+		}, nil
+	case "select":
+		return []toolCall{{name: "act", args: map[string]any{
+			"page":  pageID,
+			"kind":  "select",
+			"ref":   ref,
+			"value": action.value,
+		}}}, nil
+	default:
+		return nil, fmt.Errorf("unsupported find action: %s", action.kind)
+	}
+}
+
+func runFindCalls(c *mcp.Client, calls []toolCall) *mcp.ToolResult {
+	var result *mcp.ToolResult
+	for _, call := range calls {
+		next, err := c.CallTool(call.name, call.args)
+		if err != nil {
+			output.Error(err.Error(), 1)
+		}
+		result = next
+	}
+	return result
+}
+
+func findReport(pageID int, matches []findMatch, selected findMatch, action findAction, result *mcp.ToolResult) *mcp.ToolResult {
+	selectedIndex := 1
+	for i, match := range matches {
+		if match.ref == selected.ref && match.line == selected.line {
+			selectedIndex = i + 1
+			break
+		}
+	}
+	ref := "@" + selected.ref
+	text := fmt.Sprintf("match %d/%d %s\n%s", selectedIndex, len(matches), ref, displayElementRefs(selected.line))
+	if result != nil && result.TextContent() != "" {
+		text += "\n" + result.TextContent()
+	}
+	data := map[string]any{
+		"page":          pageID,
+		"ref":           ref,
+		"line":          displayElementRefs(selected.line),
+		"matchCount":    len(matches),
+		"selectedIndex": selectedIndex,
+		"action":        action.kind,
+	}
+	if action.value != "" {
+		data["value"] = action.value
+	}
+	if result != nil {
+		data["result"] = result.StructuredContent
+	}
+	return textResult(text, data)
+}

--- a/packages/browseros-agent/apps/cli/cmd/interact.go
+++ b/packages/browseros-agent/apps/cli/cmd/interact.go
@@ -53,11 +53,11 @@ func init() {
 			}
 			value := strings.Join(args[1:], " ")
 
-			c := newClient()
-			pageID, err := resolvePageID(c)
+			pageID, err := resolvePageID(nil)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
+			c := newClient()
 			result, err := c.CallTool("act", map[string]any{
 				"page":  pageID,
 				"kind":  "select",
@@ -91,11 +91,11 @@ func init() {
 				output.Error(err.Error(), 3)
 			}
 
-			c := newClient()
-			pageID, err := resolvePageID(c)
+			pageID, err := resolvePageID(nil)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
+			c := newClient()
 			result, err := c.CallTool("act", map[string]any{
 				"page":      pageID,
 				"kind":      "drag",
@@ -126,11 +126,11 @@ func init() {
 				output.Error(err.Error(), 3)
 			}
 
-			c := newClient()
-			pageID, err := resolvePageID(c)
+			pageID, err := resolvePageID(nil)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
+			c := newClient()
 			result, err := c.CallTool("upload", map[string]any{
 				"page":  pageID,
 				"ref":   ref,
@@ -157,11 +157,11 @@ func elementAction(kind string, extra map[string]any) func(*cobra.Command, []str
 			output.Error(err.Error(), 3)
 		}
 
-		c := newClient()
-		pageID, err := resolvePageID(c)
+		pageID, err := resolvePageID(nil)
 		if err != nil {
 			output.Error(err.Error(), 2)
 		}
+		c := newClient()
 
 		toolArgs := map[string]any{
 			"page": pageID,

--- a/packages/browseros-agent/apps/cli/cmd/nav.go
+++ b/packages/browseros-agent/apps/cli/cmd/nav.go
@@ -13,11 +13,11 @@ func init() {
 		Short:       "Navigate the current page to a URL",
 		Args:        cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
-			c := newClient()
-			pageID, err := resolvePageID(c)
+			pageID, err := resolvePageID(nil)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
+			c := newClient()
 			result, err := c.CallTool("navigate", map[string]any{
 				"page":   pageID,
 				"action": "url",
@@ -63,11 +63,11 @@ func init() {
 
 func navAction(action string) func(*cobra.Command, []string) {
 	return func(cmd *cobra.Command, args []string) {
-		c := newClient()
-		pageID, err := resolvePageID(c)
+		pageID, err := resolvePageID(nil)
 		if err != nil {
 			output.Error(err.Error(), 2)
 		}
+		c := newClient()
 		result, err := c.CallTool("navigate", map[string]any{
 			"page":   pageID,
 			"action": action,

--- a/packages/browseros-agent/apps/cli/cmd/open.go
+++ b/packages/browseros-agent/apps/cli/cmd/open.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
+	"browseros-cli/mcp"
 	"browseros-cli/output"
 
 	"github.com/spf13/cobra"
@@ -20,30 +22,24 @@ func init() {
 			windowID, _ := cmd.Flags().GetInt("window")
 
 			c := newClient()
-			var resultText string
-			var resultData map[string]any
 			var err error
-			var result any
+			var toolResult *mcp.ToolResult
 
 			if cmd.Flags().Changed("window") {
+				var result any
 				_, result, err = browserRunValue(c, openInWindowCode(args[0], hidden, bg, windowID))
 				if err == nil {
-					resultData, _ = valueMap(result)
-					resultText = fmt.Sprintf("opened page %d", numberValue(resultData["page"]))
+					resultData, _ := valueMap(result)
+					toolResult = textResult("", resultData)
 				}
 			} else {
-				toolResult, callErr := c.CallTool("tabs", openTabsToolArgs(args[0], hidden, bg))
-				err = callErr
-				if err == nil {
-					resultText = toolResult.TextContent()
-					resultData = toolResult.StructuredContent
-				}
+				toolResult, err = c.CallTool("tabs", openTabsToolArgs(args[0], hidden, bg))
 			}
 
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
-			resultForOutput := textResult(resultText, resultData)
+			resultForOutput := openResult(args[0], toolResult)
 			if jsonOut {
 				output.JSON(resultForOutput)
 			} else {
@@ -57,6 +53,39 @@ func init() {
 	cmd.Flags().Int("window", 0, "Window ID to open in")
 
 	rootCmd.AddCommand(cmd)
+}
+
+// openResult presents newly opened pages with a stable CLI page handle.
+func openResult(url string, result *mcp.ToolResult) *mcp.ToolResult {
+	data := map[string]any{}
+	if result != nil {
+		for key, value := range result.StructuredContent {
+			if key == "pageId" {
+				continue
+			}
+			data[key] = value
+		}
+		if numberValue(data["page"]) == 0 {
+			if pageID := numberValue(result.StructuredContent["pageId"]); pageID != 0 {
+				data["page"] = pageID
+			}
+		}
+	}
+	if url != "" {
+		data["url"] = url
+	}
+
+	lines := []string{}
+	if pageID := numberValue(data["page"]); pageID != 0 {
+		lines = append(lines, fmt.Sprintf("page=%d", pageID))
+	}
+	if url != "" {
+		lines = append(lines, "url="+url)
+	}
+	if len(lines) == 0 && result != nil {
+		lines = append(lines, result.TextContent())
+	}
+	return textResult(strings.Join(lines, "\n"), data)
 }
 
 func openTabsToolArgs(url string, hidden, background bool) map[string]any {

--- a/packages/browseros-agent/apps/cli/cmd/pages.go
+++ b/packages/browseros-agent/apps/cli/cmd/pages.go
@@ -50,7 +50,7 @@ return page`)
 			if !ok {
 				output.Error("active page response was not an object", 1)
 			}
-			result := textResult(formatActivePage(page), map[string]any{"page": page})
+			result := activePageResult(page)
 			if jsonOut {
 				output.JSON(result)
 			} else {
@@ -102,6 +102,22 @@ func tabsListResult(result *mcp.ToolResult) *mcp.ToolResult {
 		"pages": pages,
 		"count": len(pages),
 	})
+}
+
+func activePageResult(page map[string]any) *mcp.ToolResult {
+	normalized := normalizeTabPages([]any{page})
+	if len(normalized) == 0 {
+		return textResult("Active page: 0", map[string]any{"page": 0})
+	}
+	pageData, ok := normalized[0].(map[string]any)
+	if !ok {
+		return textResult("Active page: 0", map[string]any{"page": 0})
+	}
+	data := make(map[string]any, len(pageData))
+	for key, value := range pageData {
+		data[key] = value
+	}
+	return textResult(formatActivePage(data), data)
 }
 
 // normalizeTabPages exposes numeric page as the CLI's canonical tab handle.

--- a/packages/browseros-agent/apps/cli/cmd/pages.go
+++ b/packages/browseros-agent/apps/cli/cmd/pages.go
@@ -60,25 +60,16 @@ return page`)
 	}
 
 	closeCmd := &cobra.Command{
-		Use:         "close [pageId]",
+		Use:         "close",
 		Annotations: map[string]string{"group": "Navigate:"},
-		Short:       "Close a page (tab)",
-		Args:        cobra.MaximumNArgs(1),
+		Short:       "Close the page selected by -p/--page",
+		Args:        cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			c := newClient()
-			var pageID int
-			var err error
-			if len(args) > 0 {
-				_, err = fmt.Sscanf(args[0], "%d", &pageID)
-				if err != nil {
-					output.Errorf(3, "invalid page ID: %s", args[0])
-				}
-			} else {
-				pageID, err = resolvePageID(c)
-				if err != nil {
-					output.Error(err.Error(), 2)
-				}
+			pageID, err := resolvePageID(nil)
+			if err != nil {
+				output.Error(err.Error(), 2)
 			}
+			c := newClient()
 			result, err := c.CallTool("tabs", map[string]any{
 				"action": "close",
 				"page":   pageID,
@@ -113,7 +104,7 @@ func tabsListResult(result *mcp.ToolResult) *mcp.ToolResult {
 	})
 }
 
-// normalizeTabPages keeps legacy pageId fields when the tabs tool returns page.
+// normalizeTabPages exposes numeric page as the CLI's canonical tab handle.
 func normalizeTabPages(pages []any) []any {
 	normalized := make([]any, 0, len(pages))
 	for _, item := range pages {
@@ -124,11 +115,14 @@ func normalizeTabPages(pages []any) []any {
 		}
 		copy := make(map[string]any, len(page)+1)
 		for key, value := range page {
+			if key == "pageId" {
+				continue
+			}
 			copy[key] = value
 		}
-		if numberValue(copy["pageId"]) == 0 {
-			if pageID := numberValue(copy["page"]); pageID != 0 {
-				copy["pageId"] = pageID
+		if numberValue(copy["page"]) == 0 {
+			if pageID := numberValue(page["pageId"]); pageID != 0 {
+				copy["page"] = pageID
 			}
 		}
 		normalized = append(normalized, copy)

--- a/packages/browseros-agent/apps/cli/cmd/root.go
+++ b/packages/browseros-agent/apps/cli/cmd/root.go
@@ -202,9 +202,19 @@ func resolvePageID(_ *mcp.Client) (int, error) {
 // explicitPageID returns only caller-provided page ids, never ambient browser state.
 func explicitPageID(changed bool, page int) (int, error) {
 	if changed {
+		if err := validatePageID(page); err != nil {
+			return 0, err
+		}
 		return page, nil
 	}
 	return 0, fmt.Errorf("page id is required: pass -p/--page <id> from `browseros-cli open --json | jq -r .page` or `browseros-cli tabs --json`")
+}
+
+func validatePageID(page int) error {
+	if page <= 0 {
+		return fmt.Errorf("invalid page id: %d; page id must be greater than 0", page)
+	}
+	return nil
 }
 
 func envBool(key string) bool {

--- a/packages/browseros-agent/apps/cli/cmd/root.go
+++ b/packages/browseros-agent/apps/cli/cmd/root.go
@@ -162,7 +162,7 @@ func init() {
 	rootCmd.SetUsageTemplate(usageTemplate)
 
 	rootCmd.PersistentFlags().StringVarP(&serverURL, "server", "s", defaultServerURL(), "BrowserOS server URL")
-	rootCmd.PersistentFlags().IntVarP(&pageFlag, "page", "p", 0, "Target page ID (default: active page)")
+	rootCmd.PersistentFlags().IntVarP(&pageFlag, "page", "p", 0, "Target page ID from open or tabs")
 	rootCmd.PersistentFlags().BoolVar(&jsonOut, "json", envBool("BOS_JSON"), "JSON output")
 	rootCmd.PersistentFlags().BoolVar(&debug, "debug", envBool("BOS_DEBUG"), "Debug output")
 	rootCmd.PersistentFlags().DurationVarP(&timeout, "timeout", "t", 120*time.Second, "Request timeout")
@@ -181,18 +181,17 @@ func newClient() *mcp.Client {
 	return c
 }
 
-func resolvePageID(c *mcp.Client) (int, error) {
-	if rootCmd.PersistentFlags().Changed("page") {
-		return pageFlag, nil
-	}
+// resolvePageID enforces the CLI's explicit page contract for page-scoped commands.
+func resolvePageID(_ *mcp.Client) (int, error) {
+	return explicitPageID(rootCmd.PersistentFlags().Changed("page"), pageFlag)
+}
 
-	if env := os.Getenv("BROWSEROS_PAGE"); env != "" {
-		if v, err := strconv.Atoi(env); err == nil {
-			return v, nil
-		}
+// explicitPageID returns only caller-provided page ids, never ambient browser state.
+func explicitPageID(changed bool, page int) (int, error) {
+	if changed {
+		return page, nil
 	}
-
-	return c.ResolvePageID(nil)
+	return 0, fmt.Errorf("page id is required: pass -p/--page <id> from `browseros-cli open --json | jq -r .page` or `browseros-cli tabs --json`")
 }
 
 func envBool(key string) bool {

--- a/packages/browseros-agent/apps/cli/cmd/root.go
+++ b/packages/browseros-agent/apps/cli/cmd/root.go
@@ -49,6 +49,17 @@ func helpAliases(aliases []string) string {
 	return helpAliasColor.Sprintf("(aliases: %s)", strings.Join(aliases, ", "))
 }
 
+func agentStartHelp(cmd *cobra.Command) string {
+	if cmd != rootCmd {
+		return ""
+	}
+	return "\n" + helpHeader("Start here for agents:") + "\n" +
+		"  page=$(browseros-cli open --json https://example.com | jq -r .page)\n" +
+		"  browseros-cli -p \"$page\" snapshot\n" +
+		"  browseros-cli -p \"$page\" read --links\n" +
+		"  browseros-cli -p \"$page\" find text \"Search\" click\n"
+}
+
 var groupOrder = []string{
 	"Navigate:",
 	"Observe:",
@@ -98,6 +109,7 @@ const usageTemplate = `{{helpHeader "Usage:"}}{{if .Runnable}}
 
 {{helpHeader "Examples:"}}
 {{.Example}}{{end}}{{if .HasAvailableSubCommands}}
+{{agentStartHelp .}}
 {{groupedHelp .}}{{end}}{{if .HasAvailableLocalFlags}}
 
 {{helpHeader "Flags:"}}
@@ -158,6 +170,7 @@ func init() {
 	cobra.AddTemplateFunc("helpAliases", helpAliases)
 	cobra.AddTemplateFunc("helpHint", helpHint)
 	cobra.AddTemplateFunc("groupedHelp", groupedHelp)
+	cobra.AddTemplateFunc("agentStartHelp", agentStartHelp)
 
 	rootCmd.SetUsageTemplate(usageTemplate)
 

--- a/packages/browseros-agent/apps/cli/cmd/root.go
+++ b/packages/browseros-agent/apps/cli/cmd/root.go
@@ -217,6 +217,13 @@ func validatePageID(page int) error {
 	return nil
 }
 
+func validateChangedIntMinimum(name string, value int, changed bool, minimum int) error {
+	if changed && value < minimum {
+		return fmt.Errorf("%s must be %d or greater", name, minimum)
+	}
+	return nil
+}
+
 func envBool(key string) bool {
 	v := os.Getenv(key)
 	return v == "1" || v == "true"

--- a/packages/browseros-agent/apps/cli/cmd/root_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/root_test.go
@@ -289,6 +289,18 @@ func TestRequestedBoolFlag(t *testing.T) {
 	}
 }
 
+func TestValidateChangedIntMinimum(t *testing.T) {
+	if err := validateChangedIntMinimum("--limit", 0, false, 1); err != nil {
+		t.Fatalf("unchanged value returned error: %v", err)
+	}
+	if err := validateChangedIntMinimum("--limit", 0, true, 1); err == nil {
+		t.Fatal("validateChangedIntMinimum() error = nil, want minimum error")
+	}
+	if err := validateChangedIntMinimum("--depth", 0, true, 0); err != nil {
+		t.Fatalf("valid changed value returned error: %v", err)
+	}
+}
+
 func TestShouldSkipAutomaticUpdates(t *testing.T) {
 	tests := []struct {
 		name string

--- a/packages/browseros-agent/apps/cli/cmd/root_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/root_test.go
@@ -40,7 +40,7 @@ func TestCommandName(t *testing.T) {
 		{"unknown command", []string{"nonexistent"}, "unknown"},
 		{"subcommand", []string{"bookmark", "search"}, "browseros-cli bookmark search"},
 		{"strata subcommand", []string{"strata", "check"}, "browseros-cli strata check"},
-		{"known with extra args", []string{"snap", "extra"}, "browseros-cli snap"},
+		{"known with extra args", []string{"snap", "extra"}, "browseros-cli snapshot"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -57,14 +57,63 @@ func TestSnapCommandShape(t *testing.T) {
 	if err != nil {
 		t.Fatalf("rootCmd.Find(snap) error = %v", err)
 	}
-	if cmd.Name() != "snap" {
-		t.Fatalf("command name = %q, want snap", cmd.Name())
+	if cmd.Name() != "snapshot" {
+		t.Fatalf("command name = %q, want snapshot", cmd.Name())
 	}
 	if err := cmd.Args(cmd, []string{"extra"}); err == nil {
 		t.Fatal("snap Args accepted a positional argument")
 	}
 	if cmd.Flags().Lookup("enhanced") != nil {
 		t.Fatal("snap command exposes unsupported enhanced flag")
+	}
+}
+
+func TestScreenshotCommandShape(t *testing.T) {
+	for _, name := range []string{"screenshot", "ss"} {
+		t.Run(name, func(t *testing.T) {
+			cmd, _, err := rootCmd.Find([]string{name})
+			if err != nil {
+				t.Fatalf("rootCmd.Find(%s) error = %v", name, err)
+			}
+			if cmd.Name() != "screenshot" {
+				t.Fatalf("%s resolved to %q, want screenshot", name, cmd.Name())
+			}
+		})
+	}
+}
+
+func TestAgentFriendlyInputCommandShapes(t *testing.T) {
+	for _, tt := range []struct {
+		input string
+		want  string
+	}{
+		{"press", "press"},
+		{"key", "press"},
+		{"type", "type"},
+	} {
+		t.Run(tt.input, func(t *testing.T) {
+			cmd, _, err := rootCmd.Find([]string{tt.input})
+			if err != nil {
+				t.Fatalf("rootCmd.Find(%s) error = %v", tt.input, err)
+			}
+			if cmd.Name() != tt.want {
+				t.Fatalf("%s resolved to %q, want %q", tt.input, cmd.Name(), tt.want)
+			}
+		})
+	}
+}
+
+func TestReadAndGrepCommandShapes(t *testing.T) {
+	for _, name := range []string{"read", "text", "links", "grep"} {
+		t.Run(name, func(t *testing.T) {
+			cmd, _, err := rootCmd.Find([]string{name})
+			if err != nil {
+				t.Fatalf("rootCmd.Find(%s) error = %v", name, err)
+			}
+			if cmd == rootCmd {
+				t.Fatalf("%s resolved to root command", name)
+			}
+		})
 	}
 }
 

--- a/packages/browseros-agent/apps/cli/cmd/root_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/root_test.go
@@ -235,6 +235,10 @@ func TestRequireExplicitPageID(t *testing.T) {
 		t.Fatalf("explicitPageID(true, 7) = %d, want 7", page)
 	}
 
+	if _, err := explicitPageID(true, 0); err == nil {
+		t.Fatal("explicitPageID(true, 0) error = nil, want invalid page error")
+	}
+
 	if _, err := explicitPageID(false, 0); err == nil {
 		t.Fatal("explicitPageID(false, 0) error = nil, want missing page error")
 	} else if !strings.Contains(err.Error(), "-p/--page") || strings.Contains(err.Error(), "active") {

--- a/packages/browseros-agent/apps/cli/cmd/root_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/root_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -114,6 +115,59 @@ func TestReadAndGrepCommandShapes(t *testing.T) {
 				t.Fatalf("%s resolved to root command", name)
 			}
 		})
+	}
+}
+
+func TestAgentStartHelpShowsExplicitPageLoop(t *testing.T) {
+	help := agentStartHelp(rootCmd)
+	for _, want := range []string{
+		"Start here for agents:",
+		"open --json",
+		"jq -r .page",
+		"-p \"$page\" snapshot",
+		"-p \"$page\" read",
+		"-p \"$page\" find",
+	} {
+		if !strings.Contains(help, want) {
+			t.Fatalf("agentStartHelp() missing %q in:\n%s", want, help)
+		}
+	}
+}
+
+func TestNpmPackageExposesBosAlias(t *testing.T) {
+	data, err := os.ReadFile("../npm/package.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var pkg struct {
+		Bin map[string]string `json:"bin"`
+	}
+	if err := json.Unmarshal(data, &pkg); err != nil {
+		t.Fatal(err)
+	}
+	if pkg.Bin["browseros-cli"] != "bin/browseros-cli.js" {
+		t.Fatalf("browseros-cli bin = %q", pkg.Bin["browseros-cli"])
+	}
+	if pkg.Bin["bos"] != "bin/browseros-cli.js" {
+		t.Fatalf("bos bin = %q, want shared launcher", pkg.Bin["bos"])
+	}
+}
+
+func TestInstallScriptsCreateBosAlias(t *testing.T) {
+	shellScript, err := os.ReadFile("../scripts/install.sh")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(shellScript), `"${INSTALL_DIR}/bos"`) {
+		t.Fatal("install.sh does not create bos next to browseros-cli")
+	}
+
+	powerShell, err := os.ReadFile("../scripts/install.ps1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(powerShell), `"bos.exe"`) {
+		t.Fatal("install.ps1 does not create bos.exe next to browseros-cli.exe")
 	}
 }
 

--- a/packages/browseros-agent/apps/cli/cmd/root_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/root_test.go
@@ -108,6 +108,37 @@ func TestTabsCommandShape(t *testing.T) {
 	}
 }
 
+func TestCloseCommandRequiresPageFlagOnly(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"close"})
+	if err != nil {
+		t.Fatalf("rootCmd.Find(close) error = %v", err)
+	}
+	if cmd.Name() != "close" {
+		t.Fatalf("command name = %q, want close", cmd.Name())
+	}
+	if err := cmd.Args(cmd, []string{"7"}); err == nil {
+		t.Fatal("close Args accepted a positional page id")
+	}
+}
+
+func TestRequireExplicitPageID(t *testing.T) {
+	t.Setenv("BROWSEROS_PAGE", "9")
+
+	page, err := explicitPageID(true, 7)
+	if err != nil {
+		t.Fatalf("explicitPageID(true, 7) error = %v", err)
+	}
+	if page != 7 {
+		t.Fatalf("explicitPageID(true, 7) = %d, want 7", page)
+	}
+
+	if _, err := explicitPageID(false, 0); err == nil {
+		t.Fatal("explicitPageID(false, 0) error = nil, want missing page error")
+	} else if !strings.Contains(err.Error(), "-p/--page") || strings.Contains(err.Error(), "active") {
+		t.Fatalf("missing page error = %q, want explicit page guidance without active-page fallback", err)
+	}
+}
+
 func TestUnsupportedCommandsAreNotRegistered(t *testing.T) {
 	for _, name := range []string{"dialog", "dom", "dom-search"} {
 		t.Run(name, func(t *testing.T) {

--- a/packages/browseros-agent/apps/cli/cmd/screenshot.go
+++ b/packages/browseros-agent/apps/cli/cmd/screenshot.go
@@ -24,11 +24,11 @@ func init() {
 			format, _ := cmd.Flags().GetString("format")
 			quality, _ := cmd.Flags().GetInt("quality")
 
-			c := newClient()
-			pageID, err := resolvePageID(c)
+			pageID, err := resolvePageID(nil)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
+			c := newClient()
 
 			toolArgs, err := screenshotToolArgs(pageID, format, full, quality, cmd.Flags().Changed("quality"))
 			if err != nil {

--- a/packages/browseros-agent/apps/cli/cmd/screenshot.go
+++ b/packages/browseros-agent/apps/cli/cmd/screenshot.go
@@ -14,7 +14,8 @@ import (
 
 func init() {
 	cmd := &cobra.Command{
-		Use:         "ss",
+		Use:         "screenshot",
+		Aliases:     []string{"ss"},
 		Annotations: map[string]string{"group": "Observe:"},
 		Short:       "Take a screenshot",
 		Args:        cobra.NoArgs,

--- a/packages/browseros-agent/apps/cli/cmd/scroll.go
+++ b/packages/browseros-agent/apps/cli/cmd/scroll.go
@@ -24,11 +24,11 @@ func init() {
 			}
 			element, _ := cmd.Flags().GetInt("element")
 
-			c := newClient()
-			pageID, err := resolvePageID(c)
+			pageID, err := resolvePageID(nil)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
+			c := newClient()
 
 			toolArgs := map[string]any{
 				"page":      pageID,

--- a/packages/browseros-agent/apps/cli/cmd/snap.go
+++ b/packages/browseros-agent/apps/cli/cmd/snap.go
@@ -13,11 +13,11 @@ func init() {
 		Short:       "Snapshot interactive elements on the page",
 		Args:        cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			c := newClient()
-			pageID, err := resolvePageID(c)
+			pageID, err := resolvePageID(nil)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
+			c := newClient()
 
 			result, err := c.CallTool("snapshot", map[string]any{"page": pageID})
 			if err != nil {

--- a/packages/browseros-agent/apps/cli/cmd/snap.go
+++ b/packages/browseros-agent/apps/cli/cmd/snap.go
@@ -14,6 +14,11 @@ func init() {
 		Short:       "Snapshot interactive elements on the page",
 		Args:        cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
+			interactive, _ := cmd.Flags().GetBool("interactive")
+			compact, _ := cmd.Flags().GetBool("compact")
+			depth, _ := cmd.Flags().GetInt("depth")
+			filters := snapshotFilterOptions{interactive: interactive, compact: compact, depth: depth}
+
 			pageID, err := resolvePageID(nil)
 			if err != nil {
 				output.Error(err.Error(), 2)
@@ -24,13 +29,18 @@ func init() {
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
+			result = snapshotOutputResult(result, pageID, filters, jsonOut)
 			if jsonOut {
 				output.JSON(result)
 			} else {
-				output.Text(textResult(displayElementRefs(result.TextContent()), result.StructuredContent))
+				output.Text(result)
 			}
 		},
 	}
+
+	cmd.Flags().BoolP("interactive", "i", false, "Show actionable rows")
+	cmd.Flags().BoolP("compact", "c", false, "Hide empty structural rows")
+	cmd.Flags().IntP("depth", "d", 0, "Maximum indentation depth")
 
 	rootCmd.AddCommand(cmd)
 }

--- a/packages/browseros-agent/apps/cli/cmd/snap.go
+++ b/packages/browseros-agent/apps/cli/cmd/snap.go
@@ -8,7 +8,8 @@ import (
 
 func init() {
 	cmd := &cobra.Command{
-		Use:         "snap",
+		Use:         "snapshot",
+		Aliases:     []string{"snap"},
 		Annotations: map[string]string{"group": "Observe:"},
 		Short:       "Snapshot interactive elements on the page",
 		Args:        cobra.NoArgs,
@@ -26,7 +27,7 @@ func init() {
 			if jsonOut {
 				output.JSON(result)
 			} else {
-				output.Text(result)
+				output.Text(textResult(displayElementRefs(result.TextContent()), result.StructuredContent))
 			}
 		},
 	}

--- a/packages/browseros-agent/apps/cli/cmd/snap.go
+++ b/packages/browseros-agent/apps/cli/cmd/snap.go
@@ -17,6 +17,9 @@ func init() {
 			interactive, _ := cmd.Flags().GetBool("interactive")
 			compact, _ := cmd.Flags().GetBool("compact")
 			depth, _ := cmd.Flags().GetInt("depth")
+			if err := validateChangedIntMinimum("--depth", depth, cmd.Flags().Changed("depth"), 0); err != nil {
+				output.Error(err.Error(), 3)
+			}
 			filters := snapshotFilterOptions{interactive: interactive, compact: compact, depth: depth}
 
 			pageID, err := resolvePageID(nil)

--- a/packages/browseros-agent/apps/cli/cmd/snapshot_filter.go
+++ b/packages/browseros-agent/apps/cli/cmd/snapshot_filter.go
@@ -32,12 +32,6 @@ func (o snapshotFilterOptions) metadata() map[string]any {
 
 // snapshotOutputResult applies print-time filters while preserving the raw structured snapshot.
 func snapshotOutputResult(result *mcp.ToolResult, pageID int, filters snapshotFilterOptions, jsonOutput bool) *mcp.ToolResult {
-	text := result.TextContent()
-	if filters.applied() {
-		text = filterSnapshotText(text, filters)
-	}
-	text = displayElementRefs(text)
-
 	data := map[string]any{}
 	for key, value := range result.StructuredContent {
 		data[key] = value
@@ -45,11 +39,43 @@ func snapshotOutputResult(result *mcp.ToolResult, pageID int, filters snapshotFi
 	if _, ok := data["page"]; !ok {
 		data["page"] = pageID
 	}
+
+	text := result.TextContent()
+	filteredSnapshot := ""
+	if filters.applied() {
+		if snapshot := stringValue(data["snapshot"]); snapshot != "" {
+			text = snapshot
+		}
+		text = filterSnapshotText(text, filters)
+		filteredSnapshot = displayElementRefs(text)
+		if notice := filteredSnapshotNotice(data); notice != "" {
+			text = notice + "\n" + filteredSnapshot
+		} else {
+			text = filteredSnapshot
+		}
+	} else {
+		text = displayElementRefs(text)
+	}
+
 	if jsonOutput && filters.applied() {
-		data["filteredSnapshot"] = text
+		data["filteredSnapshot"] = filteredSnapshot
 		data["filters"] = filters.metadata()
 	}
 	return textResult(text, data)
+}
+
+func filteredSnapshotNotice(data map[string]any) string {
+	if path := stringValue(data["path"]); path != "" {
+		return strings.Join([]string{
+			"Large snapshot saved to: " + path,
+			"Read the file for the full snapshot and refs.",
+			"Showing filtered snapshot inline:",
+		}, "\n")
+	}
+	if failed, _ := data["outputWriteFailed"].(bool); failed {
+		return "Large snapshot could not be saved to a BrowserOS output file; showing filtered snapshot inline:"
+	}
+	return ""
 }
 
 // filterSnapshotText removes snapshot rows that do not match the selected print filters.
@@ -96,6 +122,9 @@ func snapshotLineDepth(line string) int {
 }
 
 func snapshotLineInteractive(line string) bool {
+	if _, ok := findLineRef(line); ok {
+		return true
+	}
 	switch lineRole(line) {
 	case "button", "link", "input", "textbox", "combobox", "checkbox", "radio", "menuitem", "tab":
 		return true

--- a/packages/browseros-agent/apps/cli/cmd/snapshot_filter.go
+++ b/packages/browseros-agent/apps/cli/cmd/snapshot_filter.go
@@ -1,0 +1,120 @@
+package cmd
+
+import (
+	"strings"
+
+	"browseros-cli/mcp"
+)
+
+type snapshotFilterOptions struct {
+	interactive bool
+	compact     bool
+	depth       int
+}
+
+func (o snapshotFilterOptions) applied() bool {
+	return o.interactive || o.compact || o.depth > 0
+}
+
+func (o snapshotFilterOptions) metadata() map[string]any {
+	filters := map[string]any{}
+	if o.interactive {
+		filters["interactive"] = true
+	}
+	if o.compact {
+		filters["compact"] = true
+	}
+	if o.depth > 0 {
+		filters["depth"] = o.depth
+	}
+	return filters
+}
+
+// snapshotOutputResult applies print-time filters while preserving the raw structured snapshot.
+func snapshotOutputResult(result *mcp.ToolResult, pageID int, filters snapshotFilterOptions, jsonOutput bool) *mcp.ToolResult {
+	text := result.TextContent()
+	if filters.applied() {
+		text = filterSnapshotText(text, filters)
+	}
+	text = displayElementRefs(text)
+
+	data := map[string]any{}
+	for key, value := range result.StructuredContent {
+		data[key] = value
+	}
+	if _, ok := data["page"]; !ok {
+		data["page"] = pageID
+	}
+	if jsonOutput && filters.applied() {
+		data["filteredSnapshot"] = text
+		data["filters"] = filters.metadata()
+	}
+	return textResult(text, data)
+}
+
+// filterSnapshotText removes snapshot rows that do not match the selected print filters.
+func filterSnapshotText(text string, filters snapshotFilterOptions) string {
+	lines := strings.Split(text, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if keepSnapshotLine(line, filters) {
+			kept = append(kept, line)
+		}
+	}
+	return strings.Join(kept, "\n")
+}
+
+func keepSnapshotLine(line string, filters snapshotFilterOptions) bool {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return false
+	}
+	if strings.HasPrefix(trimmed, "[UNTRUSTED_PAGE_CONTENT") || strings.HasPrefix(trimmed, "[END_UNTRUSTED_PAGE_CONTENT") {
+		return true
+	}
+	if filters.depth > 0 && snapshotLineDepth(line) > filters.depth {
+		return false
+	}
+	if filters.interactive && !snapshotLineInteractive(line) {
+		return false
+	}
+	if filters.compact && snapshotLineStructuralOnly(line) {
+		return false
+	}
+	return true
+}
+
+func snapshotLineDepth(line string) int {
+	spaces := 0
+	for _, r := range line {
+		if r != ' ' {
+			break
+		}
+		spaces++
+	}
+	return spaces / 2
+}
+
+func snapshotLineInteractive(line string) bool {
+	switch lineRole(line) {
+	case "button", "link", "input", "textbox", "combobox", "checkbox", "radio", "menuitem", "tab":
+		return true
+	default:
+		return false
+	}
+}
+
+func snapshotLineStructuralOnly(line string) bool {
+	if _, ok := findLineRef(line); ok {
+		return false
+	}
+	if strings.Contains(line, `"`) {
+		return false
+	}
+	switch lineRole(line) {
+	case "generic", "section", "group", "list", "listitem", "document", "webarea", "main", "navigation", "form", "region", "article":
+		return true
+	default:
+		return false
+	}
+}

--- a/packages/browseros-agent/apps/cli/cmd/text.go
+++ b/packages/browseros-agent/apps/cli/cmd/text.go
@@ -98,6 +98,9 @@ func init() {
 		Run: func(cmd *cobra.Command, args []string) {
 			content, _ := cmd.Flags().GetBool("content")
 			limit, _ := cmd.Flags().GetInt("limit")
+			if err := validateChangedIntMinimum("--limit", limit, cmd.Flags().Changed("limit"), 1); err != nil {
+				output.Error(err.Error(), 3)
+			}
 			over := "ax"
 			if content {
 				over = "content"

--- a/packages/browseros-agent/apps/cli/cmd/text.go
+++ b/packages/browseros-agent/apps/cli/cmd/text.go
@@ -1,41 +1,56 @@
 package cmd
 
 import (
+	"errors"
+
 	"browseros-cli/output"
 
 	"github.com/spf13/cobra"
 )
 
 func init() {
+	readCmd := &cobra.Command{
+		Use:         "read",
+		Annotations: map[string]string{"group": "Observe:"},
+		Short:       "Read page content as markdown, text, or links",
+		Args:        cobra.NoArgs,
+		Run: func(cmd *cobra.Command, args []string) {
+			opts, err := readOptionsFromCommand(cmd)
+			if err != nil {
+				output.Error(err.Error(), 3)
+			}
+			pageID, err := resolvePageID(nil)
+			if err != nil {
+				output.Error(err.Error(), 2)
+			}
+			c := newClient()
+			result, err := c.CallTool("read", readToolArgs(pageID, opts))
+			if err != nil {
+				output.Error(err.Error(), 1)
+			}
+			if jsonOut {
+				output.JSON(result)
+			} else {
+				output.Text(result)
+			}
+		},
+	}
+	addReadFlags(readCmd, true)
+
 	textCmd := &cobra.Command{
 		Use:         "text",
 		Annotations: map[string]string{"group": "Observe:"},
 		Short:       "Extract page content as markdown",
 		Args:        cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			selector, _ := cmd.Flags().GetString("selector")
-			viewport, _ := cmd.Flags().GetBool("viewport")
-			links, _ := cmd.Flags().GetBool("links")
-			images, _ := cmd.Flags().GetBool("images")
-
 			pageID, err := resolvePageID(nil)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
 			c := newClient()
 
-			toolArgs := map[string]any{
-				"page":          pageID,
-				"format":        "markdown",
-				"viewportOnly":  viewport,
-				"includeLinks":  links,
-				"includeImages": images,
-			}
-			if selector != "" {
-				toolArgs["selector"] = selector
-			}
-
-			result, err := c.CallTool("read", toolArgs)
+			opts := legacyTextReadOptions(cmd)
+			result, err := c.CallTool("read", readToolArgs(pageID, opts))
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -63,10 +78,7 @@ func init() {
 				output.Error(err.Error(), 2)
 			}
 			c := newClient()
-			result, err := c.CallTool("read", map[string]any{
-				"page":   pageID,
-				"format": "links",
-			})
+			result, err := c.CallTool("read", readToolArgs(pageID, readOptions{format: "links"}))
 			if err != nil {
 				output.Error(err.Error(), 1)
 			}
@@ -78,5 +90,151 @@ func init() {
 		},
 	}
 
-	rootCmd.AddCommand(textCmd, linksCmd)
+	grepCmd := &cobra.Command{
+		Use:         "grep <pattern>",
+		Annotations: map[string]string{"group": "Observe:"},
+		Short:       "Search snapshot or page text without dumping the page",
+		Args:        cobra.ExactArgs(1),
+		Run: func(cmd *cobra.Command, args []string) {
+			content, _ := cmd.Flags().GetBool("content")
+			limit, _ := cmd.Flags().GetInt("limit")
+			over := "ax"
+			if content {
+				over = "content"
+			}
+			pageID, err := resolvePageID(nil)
+			if err != nil {
+				output.Error(err.Error(), 2)
+			}
+			c := newClient()
+			result, err := c.CallTool("grep", grepToolArgs(pageID, args[0], over, limit))
+			if err != nil {
+				output.Error(err.Error(), 1)
+			}
+			if jsonOut {
+				output.JSON(result)
+			} else {
+				output.Text(textResult(displayElementRefs(result.TextContent()), result.StructuredContent))
+			}
+		},
+	}
+	grepCmd.Flags().Bool("content", false, "Search visible page text instead of the accessibility tree")
+	grepCmd.Flags().Int("limit", 0, "Maximum matches to return")
+
+	rootCmd.AddCommand(readCmd, textCmd, linksCmd, grepCmd)
+}
+
+type readOptions struct {
+	format        string
+	selector      string
+	viewportOnly  bool
+	includeLinks  bool
+	includeImages bool
+}
+
+func addReadFlags(cmd *cobra.Command, formats bool) {
+	if formats {
+		cmd.Flags().Bool("md", false, "Read markdown")
+		cmd.Flags().Bool("text", false, "Read plain text")
+		cmd.Flags().Bool("links", false, "Read links")
+	}
+	cmd.Flags().String("selector", "", "CSS selector to scope extraction")
+	cmd.Flags().Bool("viewport", false, "Only visible content")
+	cmd.Flags().Bool("include-links", false, "Render links in markdown")
+	cmd.Flags().Bool("images", false, "Include image references")
+}
+
+func readOptionsFromCommand(cmd *cobra.Command) (readOptions, error) {
+	md, _ := cmd.Flags().GetBool("md")
+	plainText, _ := cmd.Flags().GetBool("text")
+	links, _ := cmd.Flags().GetBool("links")
+	if selected := boolCount(md, plainText, links); selected > 1 {
+		return readOptions{}, outputFormatError()
+	}
+
+	format := "markdown"
+	if plainText {
+		format = "text"
+	} else if links {
+		format = "links"
+	}
+
+	selector, _ := cmd.Flags().GetString("selector")
+	viewport, _ := cmd.Flags().GetBool("viewport")
+	includeLinks, _ := cmd.Flags().GetBool("include-links")
+	images, _ := cmd.Flags().GetBool("images")
+	return readOptions{
+		format:        format,
+		selector:      selector,
+		viewportOnly:  viewport,
+		includeLinks:  includeLinks,
+		includeImages: images,
+	}, nil
+}
+
+func legacyTextReadOptions(cmd *cobra.Command) readOptions {
+	selector, _ := cmd.Flags().GetString("selector")
+	viewport, _ := cmd.Flags().GetBool("viewport")
+	links, _ := cmd.Flags().GetBool("links")
+	images, _ := cmd.Flags().GetBool("images")
+	return readOptions{
+		format:        "markdown",
+		selector:      selector,
+		viewportOnly:  viewport,
+		includeLinks:  links,
+		includeImages: images,
+	}
+}
+
+func readToolArgs(pageID int, opts readOptions) map[string]any {
+	format := opts.format
+	if format == "" {
+		format = "markdown"
+	}
+	toolArgs := map[string]any{
+		"page":   pageID,
+		"format": format,
+	}
+	if opts.selector != "" {
+		toolArgs["selector"] = opts.selector
+	}
+	if opts.viewportOnly {
+		toolArgs["viewportOnly"] = true
+	}
+	if opts.includeLinks {
+		toolArgs["includeLinks"] = true
+	}
+	if opts.includeImages {
+		toolArgs["includeImages"] = true
+	}
+	return toolArgs
+}
+
+func grepToolArgs(pageID int, pattern, over string, limit int) map[string]any {
+	if over == "" {
+		over = "ax"
+	}
+	toolArgs := map[string]any{
+		"page":    pageID,
+		"pattern": pattern,
+		"over":    over,
+	}
+	if limit > 0 {
+		toolArgs["limit"] = limit
+	}
+	return toolArgs
+}
+
+func boolCount(values ...bool) int {
+	count := 0
+	for _, value := range values {
+		if value {
+			count++
+		}
+	}
+	return count
+}
+
+func outputFormatError() error {
+	return errors.New("choose only one of --md, --text, or --links")
 }

--- a/packages/browseros-agent/apps/cli/cmd/text.go
+++ b/packages/browseros-agent/apps/cli/cmd/text.go
@@ -18,11 +18,11 @@ func init() {
 			links, _ := cmd.Flags().GetBool("links")
 			images, _ := cmd.Flags().GetBool("images")
 
-			c := newClient()
-			pageID, err := resolvePageID(c)
+			pageID, err := resolvePageID(nil)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
+			c := newClient()
 
 			toolArgs := map[string]any{
 				"page":          pageID,
@@ -58,11 +58,11 @@ func init() {
 		Short:       "Extract all links from the page",
 		Args:        cobra.NoArgs,
 		Run: func(cmd *cobra.Command, args []string) {
-			c := newClient()
-			pageID, err := resolvePageID(c)
+			pageID, err := resolvePageID(nil)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
+			c := newClient()
 			result, err := c.CallTool("read", map[string]any{
 				"page":   pageID,
 				"format": "links",

--- a/packages/browseros-agent/apps/cli/cmd/tool_helpers.go
+++ b/packages/browseros-agent/apps/cli/cmd/tool_helpers.go
@@ -13,7 +13,7 @@ import (
 	"browseros-cli/mcp"
 )
 
-var snapshotRefPattern = regexp.MustCompile(`\[ref=e([0-9]+)\]`)
+var snapshotRefPattern = regexp.MustCompile(`\[ref=@?e([0-9]+)\]`)
 
 // elementRef normalizes legacy numeric element IDs to compact snapshot refs.
 func elementRef(raw string) (string, error) {

--- a/packages/browseros-agent/apps/cli/cmd/tool_helpers.go
+++ b/packages/browseros-agent/apps/cli/cmd/tool_helpers.go
@@ -6,11 +6,14 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
 	"browseros-cli/mcp"
 )
+
+var snapshotRefPattern = regexp.MustCompile(`\[ref=e([0-9]+)\]`)
 
 // elementRef normalizes legacy numeric element IDs to compact snapshot refs.
 func elementRef(raw string) (string, error) {
@@ -18,6 +21,7 @@ func elementRef(raw string) (string, error) {
 	if ref == "" {
 		return "", fmt.Errorf("empty element ref")
 	}
+	ref = strings.TrimPrefix(ref, "@")
 	if strings.HasPrefix(ref, "e") {
 		if _, err := strconv.Atoi(strings.TrimPrefix(ref, "e")); err != nil {
 			return "", fmt.Errorf("invalid element ref: %s", raw)
@@ -28,6 +32,10 @@ func elementRef(raw string) (string, error) {
 		return "", fmt.Errorf("invalid element ref: %s", raw)
 	}
 	return "e" + ref, nil
+}
+
+func displayElementRefs(text string) string {
+	return snapshotRefPattern.ReplaceAllString(text, `[ref=@e$1]`)
 }
 
 // browserRunValue runs compact-tool server JavaScript and returns its structured value.

--- a/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
@@ -94,6 +94,43 @@ func TestCompactToolMappings(t *testing.T) {
 				"clear": false,
 			},
 		},
+		{
+			name: "press",
+			got:  pressToolArgs(7, "Enter"),
+			want: map[string]any{
+				"page": 7,
+				"kind": "press",
+				"key":  "Enter",
+			},
+		},
+		{
+			name: "type",
+			got:  typeToolArgs(7, "hello"),
+			want: map[string]any{
+				"page": 7,
+				"kind": "type",
+				"text": "hello",
+			},
+		},
+		{
+			name: "read markdown",
+			got:  readToolArgs(7, readOptions{format: "markdown", includeLinks: true}),
+			want: map[string]any{
+				"page":         7,
+				"format":       "markdown",
+				"includeLinks": true,
+			},
+		},
+		{
+			name: "grep content",
+			got:  grepToolArgs(7, "Example", "content", 5),
+			want: map[string]any{
+				"page":    7,
+				"pattern": "Example",
+				"over":    "content",
+				"limit":   5,
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -102,6 +139,28 @@ func TestCompactToolMappings(t *testing.T) {
 				t.Fatalf("mapping = %#v, want %#v", tt.got, tt.want)
 			}
 		})
+	}
+}
+
+func TestElementRefAcceptsCopyPasteForms(t *testing.T) {
+	for _, raw := range []string{"@e12", "e12", "12"} {
+		t.Run(raw, func(t *testing.T) {
+			got, err := elementRef(raw)
+			if err != nil {
+				t.Fatalf("elementRef(%q) error = %v", raw, err)
+			}
+			if got != "e12" {
+				t.Fatalf("elementRef(%q) = %q, want e12", raw, got)
+			}
+		})
+	}
+}
+
+func TestDisplayElementRefsPrefersAtRefs(t *testing.T) {
+	got := displayElementRefs("- button \"Buy\" [ref=e12]\n- input [ref=e3]")
+	want := "- button \"Buy\" [ref=@e12]\n- input [ref=@e3]"
+	if got != want {
+		t.Fatalf("displayElementRefs() = %q, want %q", got, want)
 	}
 }
 

--- a/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
@@ -164,6 +164,110 @@ func TestDisplayElementRefsPrefersAtRefs(t *testing.T) {
 	}
 }
 
+func TestFindMatchesTextAndBuildsClick(t *testing.T) {
+	lines := []string{
+		`- button "Add to Cart" [ref=e12]`,
+		`- button "Add to Cart" [ref=e13]`,
+	}
+	query := findQuery{mode: "text", text: "add to cart", nth: 1}
+
+	matches := findMatches(lines, query)
+	if len(matches) != 2 {
+		t.Fatalf("matches = %d, want 2", len(matches))
+	}
+	selected, err := selectFindMatch(matches, query)
+	if err != nil {
+		t.Fatalf("selectFindMatch() error = %v", err)
+	}
+	if selected.ref != "e12" {
+		t.Fatalf("selected ref = %q, want e12", selected.ref)
+	}
+
+	calls, err := findActionCalls(7, selected, findAction{kind: "click"})
+	if err != nil {
+		t.Fatalf("findActionCalls() error = %v", err)
+	}
+	want := []toolCall{{name: "act", args: map[string]any{"page": 7, "kind": "click", "ref": "e12"}}}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("calls = %#v, want %#v", calls, want)
+	}
+}
+
+func TestFindMatchesRoleNameNth(t *testing.T) {
+	lines := []string{
+		`- link "Add to Cart details" [ref=e4]`,
+		`- button "Add to Cart" [ref=e12]`,
+		`- button "Add to Cart" [ref=e13]`,
+	}
+	query := findQuery{mode: "role", role: "button", name: "Add to Cart", nth: 2}
+
+	selected, err := selectFindMatch(findMatches(lines, query), query)
+	if err != nil {
+		t.Fatalf("selectFindMatch() error = %v", err)
+	}
+	if selected.ref != "e13" {
+		t.Fatalf("selected ref = %q, want e13", selected.ref)
+	}
+}
+
+func TestFindNoMatchStopsBeforeAct(t *testing.T) {
+	query := findQuery{mode: "text", text: "missing", nth: 1}
+	if _, err := selectFindMatch(findMatches([]string{`- button "Buy" [ref=e1]`}, query), query); err == nil {
+		t.Fatal("selectFindMatch() error = nil, want no-match error")
+	}
+}
+
+func TestFindActionCalls(t *testing.T) {
+	match := findMatch{ref: "e12", line: `- textbox "Search" [ref=e12]`}
+	tests := []struct {
+		name   string
+		action findAction
+		want   []toolCall
+	}{
+		{
+			name:   "fill",
+			action: findAction{kind: "fill", value: "hello"},
+			want: []toolCall{{name: "act", args: map[string]any{
+				"page":  7,
+				"kind":  "fill",
+				"ref":   "e12",
+				"value": "hello",
+				"clear": true,
+			}}},
+		},
+		{
+			name:   "type",
+			action: findAction{kind: "type", value: "hello"},
+			want: []toolCall{
+				{name: "act", args: map[string]any{"page": 7, "kind": "focus", "ref": "e12"}},
+				{name: "act", args: map[string]any{"page": 7, "kind": "type", "text": "hello"}},
+			},
+		},
+		{
+			name:   "select",
+			action: findAction{kind: "select", value: "Large"},
+			want: []toolCall{{name: "act", args: map[string]any{
+				"page":  7,
+				"kind":  "select",
+				"ref":   "e12",
+				"value": "Large",
+			}}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := findActionCalls(7, match, tt.action)
+			if err != nil {
+				t.Fatalf("findActionCalls() error = %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("calls = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestTabsListResultUsesCanonicalPageField(t *testing.T) {
 	result := tabsListResult(&mcp.ToolResult{
 		StructuredContent: map[string]any{

--- a/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
@@ -224,16 +224,23 @@ func TestFindRejectsInvalidNth(t *testing.T) {
 	}
 }
 
-func TestFindGrepToolArgsUsesHighLimit(t *testing.T) {
+func TestFindGrepToolArgsUsesBoundedDefault(t *testing.T) {
 	got := findGrepToolArgs(7, findQuery{mode: "text", text: "Buy"})
 	want := map[string]any{
 		"page":    7,
 		"pattern": "Buy",
 		"over":    "ax",
-		"limit":   findGrepLimit,
+		"limit":   findDefaultGrepLimit,
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("find grep args = %#v, want %#v", got, want)
+	}
+}
+
+func TestFindGrepToolArgsExpandsToNth(t *testing.T) {
+	got := findGrepToolArgs(7, findQuery{mode: "text", text: "Buy", nth: 150, limit: 10})
+	if got["limit"] != 150 {
+		t.Fatalf("limit = %v, want nth-sized search", got["limit"])
 	}
 }
 
@@ -341,6 +348,42 @@ func TestSnapshotOutputResultReportsFiltersForJSON(t *testing.T) {
 	filters, ok := got.StructuredContent["filters"].(map[string]any)
 	if !ok || filters["interactive"] != true {
 		t.Fatalf("filters = %#v, want interactive metadata", got.StructuredContent["filters"])
+	}
+}
+
+func TestSnapshotOutputResultFiltersStructuredSnapshotAndPreservesPath(t *testing.T) {
+	result := textResult(strings.Join([]string{
+		`Large snapshot (20000 estimated tokens, 80000 chars) saved to: /tmp/browseros/snapshot.md`,
+		`Read the file for the full snapshot and refs.`,
+		`Showing the first 5000 estimated tokens inline:`,
+		`[UNTRUSTED_PAGE_CONTENT origin="https://example.com"]`,
+		`- generic`,
+		`[END_UNTRUSTED_PAGE_CONTENT]`,
+	}, "\n"), map[string]any{
+		"page":          7,
+		"path":          "/tmp/browseros/snapshot.md",
+		"writtenToFile": true,
+		"contentLength": 80000,
+		"tokenEstimate": 20000,
+		"snapshot":      strings.Join([]string{`[UNTRUSTED_PAGE_CONTENT origin="https://example.com"]`, `- generic`, `  - searchbox "Search" [ref=e5]`, `[END_UNTRUSTED_PAGE_CONTENT]`}, "\n"),
+	})
+
+	got := snapshotOutputResult(result, 7, snapshotFilterOptions{interactive: true}, true)
+	text := got.TextContent()
+	for _, want := range []string{
+		"Large snapshot saved to: /tmp/browseros/snapshot.md",
+		"Read the file for the full snapshot and refs.",
+		`- searchbox "Search" [ref=@e5]`,
+	} {
+		if !strings.Contains(text, want) {
+			t.Fatalf("filtered text missing %q in:\n%s", want, text)
+		}
+	}
+	if strings.Contains(text, "- generic") {
+		t.Fatalf("filtered text kept non-interactive row:\n%s", text)
+	}
+	if got.StructuredContent["filteredSnapshot"] != strings.Join([]string{`[UNTRUSTED_PAGE_CONTENT origin="https://example.com"]`, `  - searchbox "Search" [ref=@e5]`, `[END_UNTRUSTED_PAGE_CONTENT]`}, "\n") {
+		t.Fatalf("filteredSnapshot = %#v", got.StructuredContent["filteredSnapshot"])
 	}
 }
 

--- a/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
@@ -434,6 +434,29 @@ func TestOpenResultUsesCanonicalPageField(t *testing.T) {
 	}
 }
 
+func TestActivePageResultUsesCanonicalPageField(t *testing.T) {
+	result := activePageResult(map[string]any{
+		"pageId":   42,
+		"tabId":    9,
+		"title":    "Example",
+		"url":      "https://example.com",
+		"isActive": true,
+	})
+
+	if _, exists := result.StructuredContent["pageId"]; exists {
+		t.Fatalf("active result includes legacy pageId: %#v", result.StructuredContent)
+	}
+	if nested, ok := result.StructuredContent["page"].(map[string]any); ok {
+		t.Fatalf("active result nested page object: %#v", nested)
+	}
+	if got := numberValue(result.StructuredContent["page"]); got != 42 {
+		t.Fatalf("page = %d, want 42", got)
+	}
+	if got := numberValue(result.StructuredContent["tabId"]); got != 9 {
+		t.Fatalf("tabId = %d, want 9", got)
+	}
+}
+
 func TestFillToolArgsFromNoClearFlag(t *testing.T) {
 	cmd := &cobra.Command{}
 	cmd.Flags().Bool("no-clear", false, "")

--- a/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
@@ -105,11 +105,11 @@ func TestCompactToolMappings(t *testing.T) {
 	}
 }
 
-func TestTabsListResultKeepsLegacyShape(t *testing.T) {
+func TestTabsListResultUsesCanonicalPageField(t *testing.T) {
 	result := tabsListResult(&mcp.ToolResult{
 		StructuredContent: map[string]any{
 			"pages": []any{
-				map[string]any{"page": 42, "url": "https://example.com", "title": "Example"},
+				map[string]any{"pageId": 42, "url": "https://example.com", "title": "Example"},
 			},
 		},
 	})
@@ -125,8 +125,30 @@ func TestTabsListResultKeepsLegacyShape(t *testing.T) {
 	if !ok {
 		t.Fatalf("page = %#v, want map", pages[0])
 	}
-	if got := numberValue(page["pageId"]); got != 42 {
-		t.Fatalf("pageId = %d, want 42", got)
+	if _, exists := page["pageId"]; exists {
+		t.Fatalf("page includes legacy pageId: %#v", page)
+	}
+	if got := numberValue(page["page"]); got != 42 {
+		t.Fatalf("page = %d, want 42", got)
+	}
+}
+
+func TestOpenResultUsesCanonicalPageField(t *testing.T) {
+	result := openResult("https://example.com", &mcp.ToolResult{
+		Content: []mcp.ContentItem{{Type: "text", Text: "opened page 42"}},
+		StructuredContent: map[string]any{
+			"pageId": 42,
+		},
+	})
+
+	if _, exists := result.StructuredContent["pageId"]; exists {
+		t.Fatalf("open result includes legacy pageId: %#v", result.StructuredContent)
+	}
+	if got := numberValue(result.StructuredContent["page"]); got != 42 {
+		t.Fatalf("page = %d, want 42", got)
+	}
+	if got := result.TextContent(); got != "page=42\nurl=https://example.com" {
+		t.Fatalf("open text = %q, want stable page/url lines", got)
 	}
 }
 

--- a/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
@@ -268,6 +268,62 @@ func TestFindActionCalls(t *testing.T) {
 	}
 }
 
+func TestFilterSnapshotInteractiveRows(t *testing.T) {
+	input := strings.Join([]string{
+		`- generic`,
+		`  - button "Buy" [ref=e1]`,
+		`  - link "Details" [ref=e2]`,
+		`  - paragraph "Copy"`,
+	}, "\n")
+
+	got := filterSnapshotText(input, snapshotFilterOptions{interactive: true})
+	want := strings.Join([]string{
+		`  - button "Buy" [ref=e1]`,
+		`  - link "Details" [ref=e2]`,
+	}, "\n")
+	if got != want {
+		t.Fatalf("filterSnapshotText() = %q, want %q", got, want)
+	}
+}
+
+func TestFilterSnapshotCompactAndDepth(t *testing.T) {
+	input := strings.Join([]string{
+		`- generic`,
+		`  - section`,
+		`    - paragraph "Visible copy"`,
+		`      - button "Too deep" [ref=e9]`,
+		`  - button "Buy" [ref=e1]`,
+	}, "\n")
+
+	got := filterSnapshotText(input, snapshotFilterOptions{compact: true, depth: 2})
+	want := strings.Join([]string{
+		`    - paragraph "Visible copy"`,
+		`  - button "Buy" [ref=e1]`,
+	}, "\n")
+	if got != want {
+		t.Fatalf("filterSnapshotText() = %q, want %q", got, want)
+	}
+}
+
+func TestSnapshotOutputResultReportsFiltersForJSON(t *testing.T) {
+	result := textResult(`- button "Buy" [ref=e1]`, map[string]any{
+		"page":     7,
+		"snapshot": `- button "Buy" [ref=e1]`,
+	})
+
+	got := snapshotOutputResult(result, 7, snapshotFilterOptions{interactive: true}, true)
+	if got.StructuredContent["page"] != 7 {
+		t.Fatalf("page = %v, want 7", got.StructuredContent["page"])
+	}
+	if got.StructuredContent["filteredSnapshot"] != `- button "Buy" [ref=@e1]` {
+		t.Fatalf("filteredSnapshot = %v", got.StructuredContent["filteredSnapshot"])
+	}
+	filters, ok := got.StructuredContent["filters"].(map[string]any)
+	if !ok || filters["interactive"] != true {
+		t.Fatalf("filters = %#v, want interactive metadata", got.StructuredContent["filters"])
+	}
+}
+
 func TestTabsListResultUsesCanonicalPageField(t *testing.T) {
 	result := tabsListResult(&mcp.ToolResult{
 		StructuredContent: map[string]any{

--- a/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/tool_mapping_test.go
@@ -217,6 +217,26 @@ func TestFindNoMatchStopsBeforeAct(t *testing.T) {
 	}
 }
 
+func TestFindRejectsInvalidNth(t *testing.T) {
+	query := findQuery{mode: "text", text: "Buy", nth: -1}
+	if _, err := selectFindMatch([]findMatch{{ref: "e1", line: `- button "Buy" [ref=e1]`}}, query); err == nil {
+		t.Fatal("selectFindMatch() error = nil, want invalid nth error")
+	}
+}
+
+func TestFindGrepToolArgsUsesHighLimit(t *testing.T) {
+	got := findGrepToolArgs(7, findQuery{mode: "text", text: "Buy"})
+	want := map[string]any{
+		"page":    7,
+		"pattern": "Buy",
+		"over":    "ax",
+		"limit":   findGrepLimit,
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("find grep args = %#v, want %#v", got, want)
+	}
+}
+
 func TestFindActionCalls(t *testing.T) {
 	match := findMatch{ref: "e12", line: `- textbox "Search" [ref=e12]`}
 	tests := []struct {

--- a/packages/browseros-agent/apps/cli/cmd/wait.go
+++ b/packages/browseros-agent/apps/cli/cmd/wait.go
@@ -25,11 +25,11 @@ func init() {
 				output.Errorf(3, "provide only one of --text or --selector")
 			}
 
-			c := newClient()
-			pageID, err := resolvePageID(c)
+			pageID, err := resolvePageID(nil)
 			if err != nil {
 				output.Error(err.Error(), 2)
 			}
+			c := newClient()
 
 			toolArgs := map[string]any{
 				"page":    pageID,

--- a/packages/browseros-agent/apps/cli/integration_test.go
+++ b/packages/browseros-agent/apps/cli/integration_test.go
@@ -270,10 +270,29 @@ func TestInvalidPage(t *testing.T) {
 }
 
 func TestExplicitPageAgentFlows(t *testing.T) {
-	openData := runJSON(t, "open", fixtureURL(`<title>Search Fixture</title><form><label>Search <input aria-label="Search" autofocus></label><button>Go</button></form>`))
+	openData := runJSON(t, "open", fixtureURL(`<title>Search Fixture</title><label>Search <input aria-label="Search" autofocus></label><button type="button">Go</button>`))
 	pageID := openedPage(t, openData)
 	pageArg := fmt.Sprintf("-p=%d", pageID)
 	defer run(t, "close", pageArg)
+
+	batchR := run(t, "--json", "batch", pageArg, "--bail", "find role textbox --name Search fill batch-query", "press Enter", "snapshot -i")
+	if batchR.ExitCode != 0 {
+		t.Fatalf("batch exited %d: %s%s", batchR.ExitCode, batchR.Stdout, batchR.Stderr)
+	}
+	var batchResults []struct {
+		OK bool `json:"ok"`
+	}
+	if err := json.Unmarshal([]byte(batchR.Stdout), &batchResults); err != nil {
+		t.Fatalf("batch JSON parse failed: %v\n%s", err, batchR.Stdout)
+	}
+	if len(batchResults) != 3 {
+		t.Fatalf("batch results = %d, want 3", len(batchResults))
+	}
+	for i, result := range batchResults {
+		if !result.OK {
+			t.Fatalf("batch result %d failed: %s", i+1, batchR.Stdout)
+		}
+	}
 
 	findR := run(t, "--json", "find", pageArg, "role", "textbox", "--name", "Search", "fill", "sensodyne")
 	if findR.ExitCode != 0 {

--- a/packages/browseros-agent/apps/cli/integration_test.go
+++ b/packages/browseros-agent/apps/cli/integration_test.go
@@ -6,9 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
@@ -96,6 +98,28 @@ func runJSON(t *testing.T, args ...string) map[string]any {
 	return data
 }
 
+func fixtureURL(html string) string {
+	return "data:text/html;charset=utf-8," + url.PathEscape(html)
+}
+
+func openedPage(t *testing.T, data map[string]any) int {
+	t.Helper()
+	page, ok := data["page"].(float64)
+	if !ok {
+		t.Fatalf("expected page in open response, got: %v", data)
+	}
+	return int(page)
+}
+
+func markdownLinkTargets(markdown string) []string {
+	matches := regexp.MustCompile(`\]\(([^)]+)\)`).FindAllStringSubmatch(markdown, -1)
+	targets := make([]string, 0, len(matches))
+	for _, match := range matches {
+		targets = append(targets, match[1])
+	}
+	return targets
+}
+
 func TestHealth(t *testing.T) {
 	data := runJSON(t, "health")
 	status, ok := data["status"].(string)
@@ -121,12 +145,8 @@ func TestPageLifecycle(t *testing.T) {
 		t.Log("Warning: no pages found before test, server may not have a browser connected")
 	}
 
-	openData := runJSON(t, "open", "https://example.com")
-	pageIDFloat, ok := openData["pageId"].(float64)
-	if !ok {
-		t.Fatalf("expected pageId in open response, got: %v", openData)
-	}
-	pageID := int(pageIDFloat)
+	openData := runJSON(t, "open", fixtureURL(`<title>Example Fixture</title><main><h1>Example</h1><p>Hello from BrowserOS.</p><button>Submit</button></main>`))
+	pageID := openedPage(t, openData)
 	t.Logf("Opened page %d", pageID)
 
 	pageArg := fmt.Sprintf("-p=%d", pageID)
@@ -147,7 +167,6 @@ func TestPageLifecycle(t *testing.T) {
 		}
 	})
 
-	// Snapshot
 	t.Run("snap", func(t *testing.T) {
 		r := run(t, "--json", "snap", pageArg)
 		if r.ExitCode != 0 {
@@ -158,7 +177,6 @@ func TestPageLifecycle(t *testing.T) {
 		}
 	})
 
-	// Eval
 	t.Run("eval", func(t *testing.T) {
 		r := run(t, "--json", "eval", pageArg, "document.title")
 		if r.ExitCode != 0 {
@@ -170,9 +188,8 @@ func TestPageLifecycle(t *testing.T) {
 		}
 	})
 
-	// Screenshot
 	t.Run("screenshot", func(t *testing.T) {
-		r := run(t, "--json", "ss", pageArg)
+		r := run(t, "--json", "screenshot", pageArg)
 		if r.ExitCode != 0 {
 			t.Fatalf("ss exited %d: %s%s", r.ExitCode, r.Stdout, r.Stderr)
 		}
@@ -183,15 +200,13 @@ func TestPageLifecycle(t *testing.T) {
 		}
 	})
 
-	// Navigate
 	t.Run("nav", func(t *testing.T) {
-		r := run(t, "--json", "nav", pageArg, "https://example.com/nav-test")
+		r := run(t, "--json", "nav", pageArg, fixtureURL(`<title>Nav Fixture</title><p>navigated</p>`))
 		if r.ExitCode != 0 {
 			t.Fatalf("nav exited %d: %s%s", r.ExitCode, r.Stdout, r.Stderr)
 		}
 	})
 
-	// Reload
 	t.Run("reload", func(t *testing.T) {
 		r := run(t, "--json", "reload", pageArg)
 		if r.ExitCode != 0 {
@@ -199,8 +214,7 @@ func TestPageLifecycle(t *testing.T) {
 		}
 	})
 
-	// Close the page (cleanup)
-	closeR := run(t, "--json", "close", fmt.Sprintf("%d", pageID))
+	closeR := run(t, "--json", "close", pageArg)
 	if closeR.ExitCode != 0 {
 		t.Errorf("close exited %d: %s%s", closeR.ExitCode, closeR.Stdout, closeR.Stderr)
 	}
@@ -217,21 +231,13 @@ func TestActivePage(t *testing.T) {
 	}
 }
 
-func TestSnapWithoutExplicitPage(t *testing.T) {
-	activeData := runJSON(t, "active")
-	page, ok := activeData["page"].(map[string]any)
-	if !ok {
-		t.Fatalf("expected active page response to contain page object, got: %v", activeData)
-	}
-	if _, ok := page["pageId"].(float64); !ok {
-		t.Fatalf("expected active page response to contain numeric pageId, got: %v", page)
-	}
+func TestSnapWithoutExplicitPageFails(t *testing.T) {
 	r := run(t, "--json", "snap")
-	if r.ExitCode != 0 {
-		t.Fatalf("snap exited %d: %s%s", r.ExitCode, r.Stdout, r.Stderr)
+	if r.ExitCode == 0 {
+		t.Fatalf("snap without -p succeeded: %s", r.Stdout)
 	}
-	if len(strings.TrimSpace(r.Stdout)) < 10 {
-		t.Fatalf("snapshot output too short: %s", r.Stdout)
+	if !strings.Contains(r.Stderr, "-p/--page") {
+		t.Fatalf("missing-page error = %q, want -p/--page guidance", r.Stderr)
 	}
 }
 
@@ -246,10 +252,9 @@ func TestInfo(t *testing.T) {
 }
 
 func TestEvalError(t *testing.T) {
-	// Open a page for eval
 	openData := runJSON(t, "open", "about:blank")
-	pageID := int(openData["pageId"].(float64))
-	defer run(t, "close", fmt.Sprintf("%d", pageID))
+	pageID := openedPage(t, openData)
+	defer run(t, "close", fmt.Sprintf("-p=%d", pageID))
 
 	r := run(t, "--json", "eval", fmt.Sprintf("-p=%d", pageID), "throw new Error('test-error')")
 	if r.ExitCode == 0 {
@@ -261,6 +266,56 @@ func TestInvalidPage(t *testing.T) {
 	r := run(t, "--json", "snap", "-p=999999")
 	if r.ExitCode == 0 {
 		t.Errorf("expected snap with invalid page ID to exit non-zero")
+	}
+}
+
+func TestExplicitPageAgentFlows(t *testing.T) {
+	openData := runJSON(t, "open", fixtureURL(`<title>Search Fixture</title><form><label>Search <input aria-label="Search" autofocus></label><button>Go</button></form>`))
+	pageID := openedPage(t, openData)
+	pageArg := fmt.Sprintf("-p=%d", pageID)
+	defer run(t, "close", pageArg)
+
+	findR := run(t, "--json", "find", pageArg, "role", "textbox", "--name", "Search", "fill", "sensodyne")
+	if findR.ExitCode != 0 {
+		t.Fatalf("find fill exited %d: %s%s", findR.ExitCode, findR.Stdout, findR.Stderr)
+	}
+	pressR := run(t, "--json", "press", pageArg, "Enter")
+	if pressR.ExitCode != 0 {
+		t.Fatalf("press exited %d: %s%s", pressR.ExitCode, pressR.Stdout, pressR.Stderr)
+	}
+	snapshotR := run(t, "--json", "snapshot", pageArg, "-i")
+	if snapshotR.ExitCode != 0 {
+		t.Fatalf("snapshot exited %d: %s%s", snapshotR.ExitCode, snapshotR.Stdout, snapshotR.Stderr)
+	}
+}
+
+func TestExplicitPageFanOutFlow(t *testing.T) {
+	first := fixtureURL(`<title>First Link</title><p>first page</p>`)
+	second := fixtureURL(`<title>Second Link</title><p>second page</p>`)
+	indexHTML := fmt.Sprintf(`<title>Links Fixture</title><a href=%q>First</a><a href=%q>Second</a>`, first, second)
+	openData := runJSON(t, "open", fixtureURL(indexHTML))
+	pageID := openedPage(t, openData)
+	pageArg := fmt.Sprintf("-p=%d", pageID)
+	defer run(t, "close", pageArg)
+
+	linksR := run(t, "read", pageArg, "--links")
+	if linksR.ExitCode != 0 {
+		t.Fatalf("read --links exited %d: %s%s", linksR.ExitCode, linksR.Stdout, linksR.Stderr)
+	}
+	targets := markdownLinkTargets(linksR.Stdout)
+	if len(targets) < 2 {
+		t.Fatalf("expected at least two link targets, got %v from %q", targets, linksR.Stdout)
+	}
+
+	for _, target := range targets[:2] {
+		childData := runJSON(t, "open", target)
+		childPage := openedPage(t, childData)
+		childPageArg := fmt.Sprintf("-p=%d", childPage)
+		readR := run(t, "read", childPageArg, "--text")
+		if readR.ExitCode != 0 {
+			t.Fatalf("read child exited %d: %s%s", readR.ExitCode, readR.Stdout, readR.Stderr)
+		}
+		run(t, "close", childPageArg)
 	}
 }
 

--- a/packages/browseros-agent/apps/cli/mcp/client.go
+++ b/packages/browseros-agent/apps/cli/mcp/client.go
@@ -19,7 +19,6 @@ type Client struct {
 	Version    string
 	Debug      bool
 	session    *sdkmcp.ClientSession
-	sessionCtx context.Context
 }
 
 func NewClient(baseURL, version string, timeout time.Duration) *Client {
@@ -57,9 +56,6 @@ func (c *Client) CallTool(name string, args map[string]any) (*ToolResult, error)
 	defer cancel()
 
 	if c.session != nil {
-		if c.sessionCtx != nil {
-			ctx = c.sessionCtx
-		}
 		return c.callTool(ctx, c.session, name, args)
 	}
 
@@ -74,7 +70,7 @@ func (c *Client) CallTool(name string, args map[string]any) (*ToolResult, error)
 
 // WithSession runs multiple tool calls through one initialized MCP session.
 func (c *Client) WithSession(fn func(*Client) error) error {
-	ctx, cancel := context.WithTimeout(context.Background(), c.HTTPClient.Timeout)
+	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	session, err := c.connect(ctx)
@@ -85,7 +81,6 @@ func (c *Client) WithSession(fn func(*Client) error) error {
 
 	shared := *c
 	shared.session = session
-	shared.sessionCtx = ctx
 	return fn(&shared)
 }
 

--- a/packages/browseros-agent/apps/cli/mcp/client.go
+++ b/packages/browseros-agent/apps/cli/mcp/client.go
@@ -18,6 +18,8 @@ type Client struct {
 	HTTPClient *http.Client
 	Version    string
 	Debug      bool
+	session    *sdkmcp.ClientSession
+	sessionCtx context.Context
 }
 
 func NewClient(baseURL, version string, timeout time.Duration) *Client {
@@ -54,12 +56,40 @@ func (c *Client) CallTool(name string, args map[string]any) (*ToolResult, error)
 	ctx, cancel := context.WithTimeout(context.Background(), c.HTTPClient.Timeout)
 	defer cancel()
 
+	if c.session != nil {
+		if c.sessionCtx != nil {
+			ctx = c.sessionCtx
+		}
+		return c.callTool(ctx, c.session, name, args)
+	}
+
 	session, err := c.connect(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer session.Close()
 
+	return c.callTool(ctx, session, name, args)
+}
+
+// WithSession runs multiple tool calls through one initialized MCP session.
+func (c *Client) WithSession(fn func(*Client) error) error {
+	ctx, cancel := context.WithTimeout(context.Background(), c.HTTPClient.Timeout)
+	defer cancel()
+
+	session, err := c.connect(ctx)
+	if err != nil {
+		return err
+	}
+	defer session.Close()
+
+	shared := *c
+	shared.session = session
+	shared.sessionCtx = ctx
+	return fn(&shared)
+}
+
+func (c *Client) callTool(ctx context.Context, session *sdkmcp.ClientSession, name string, args map[string]any) (*ToolResult, error) {
 	if args == nil {
 		args = map[string]any{}
 	}

--- a/packages/browseros-agent/apps/cli/npm/README.md
+++ b/packages/browseros-agent/apps/cli/npm/README.md
@@ -51,6 +51,8 @@ browseros-cli -p "$page" screenshot -o shot.png
 browseros-cli -p "$page" close
 ```
 
+`batch` can run shared-session browser steps for navigation, eval, snapshot/read/grep/find, and direct element actions like click/fill/press/type.
+
 ## Documentation
 
 Full documentation is available at [browseros.com](https://browseros.com).

--- a/packages/browseros-agent/apps/cli/npm/README.md
+++ b/packages/browseros-agent/apps/cli/npm/README.md
@@ -1,6 +1,6 @@
 # browseros-cli
 
-Command-line interface for controlling BrowserOS -- launch and automate the browser from the terminal.
+Command-line interface for controlling BrowserOS -- launch and automate the browser from the terminal or AI agents. The package installs both `browseros-cli` and `bos`.
 
 ## Installation
 
@@ -39,36 +39,16 @@ browseros-cli health
 
 ## Usage
 
-### Navigation
+### Agent loop
 
 ```bash
-browseros-cli navigate "https://example.com"
-```
-
-### Observation
-
-```bash
-browseros-cli snapshot           # Get the accessibility tree of the current page
-browseros-cli console-logs       # View browser console output
-```
-
-### Screenshots
-
-```bash
-browseros-cli screenshot         # Capture the current page
-```
-
-### Input
-
-```bash
-browseros-cli click e42          # Click an element by snapshot ref
-browseros-cli fill e85 "query"   # Fill input by snapshot ref
-```
-
-### Agent Mode
-
-```bash
-browseros-cli agent "Search for flights to Tokyo"
+page=$(browseros-cli open --json https://example.com | jq -r .page)
+browseros-cli -p "$page" snapshot -i
+browseros-cli -p "$page" read --links
+browseros-cli -p "$page" find text "Search" click
+browseros-cli -p "$page" press Enter
+browseros-cli -p "$page" screenshot -o shot.png
+browseros-cli -p "$page" close
 ```
 
 ## Documentation

--- a/packages/browseros-agent/apps/cli/npm/bin/browseros-cli.js
+++ b/packages/browseros-agent/apps/cli/npm/bin/browseros-cli.js
@@ -9,7 +9,7 @@ const EXT = process.platform === 'win32' ? '.exe' : ''
 const BIN_PATH = path.join(BINARY_DIR, `browseros-cli${EXT}`)
 
 if (!fs.existsSync(BIN_PATH)) {
-  console.error('browseros-cli: binary not found, downloading...')
+  console.error('browseros-cli/bos: binary not found, downloading...')
   try {
     execFileSync(
       process.execPath,
@@ -18,7 +18,7 @@ if (!fs.existsSync(BIN_PATH)) {
     )
   } catch {
     console.error(
-      'browseros-cli: failed to download binary. Try reinstalling:\n  npm install -g browseros-cli',
+      'browseros-cli/bos: failed to download binary. Try reinstalling:\n  npm install -g browseros-cli',
     )
     process.exit(1)
   }

--- a/packages/browseros-agent/apps/cli/npm/package.json
+++ b/packages/browseros-agent/apps/cli/npm/package.json
@@ -3,7 +3,8 @@
   "version": "0.2.0",
   "description": "Command-line interface for controlling BrowserOS — launch and automate the browser from the terminal",
   "bin": {
-    "browseros-cli": "bin/browseros-cli.js"
+    "browseros-cli": "bin/browseros-cli.js",
+    "bos": "bin/browseros-cli.js"
   },
   "scripts": {
     "postinstall": "node scripts/postinstall.js"

--- a/packages/browseros-agent/apps/cli/scripts/install.ps1
+++ b/packages/browseros-agent/apps/cli/scripts/install.ps1
@@ -93,8 +93,10 @@ try {
     }
 
     Move-Item -Force $Exe.FullName (Join-Path $Dir "$Binary.exe")
+    Copy-Item -Force (Join-Path $Dir "$Binary.exe") (Join-Path $Dir "bos.exe")
 
     Write-Host "Installed $Binary.exe to $Dir"
+    Write-Host "Installed bos.exe alias to $Dir"
 } finally {
     if (Test-Path $TmpDir) { Remove-Item -Recurse -Force $TmpDir -ErrorAction SilentlyContinue }
 }
@@ -112,4 +114,4 @@ if ($Dir -notin $PathEntries) {
 }
 
 Write-Host ""
-Write-Host "Run 'browseros-cli --help' to get started."
+Write-Host "Run 'browseros-cli --help' or 'bos --help' to get started."

--- a/packages/browseros-agent/apps/cli/scripts/install.sh
+++ b/packages/browseros-agent/apps/cli/scripts/install.sh
@@ -129,8 +129,10 @@ fi
 mkdir -p "$INSTALL_DIR"
 mv "$BINARY_PATH" "${INSTALL_DIR}/${BINARY}"
 chmod +x "${INSTALL_DIR}/${BINARY}"
+ln -sf "${BINARY}" "${INSTALL_DIR}/bos"
 
 echo "Installed ${BINARY} to ${INSTALL_DIR}/${BINARY}"
+echo "Installed bos alias to ${INSTALL_DIR}/bos"
 
 # ── PATH hint ────────────────────────────────────────────────────────────────
 
@@ -148,4 +150,4 @@ if ! echo "$PATH" | tr ':' '\n' | grep -qx "$INSTALL_DIR"; then
 fi
 
 echo ""
-echo "Run 'browseros-cli --help' to get started."
+echo "Run 'browseros-cli --help' or 'bos --help' to get started."


### PR DESCRIPTION
## Summary
- Require explicit page ids for page-scoped CLI commands and standardize page output around numeric `page`.
- Add agent-friendly browser verbs: `snapshot`, `screenshot`, `press`, `type`, `read`, `grep`, `find`, and `batch`.
- Add `bos` npm/install alias plus agent-first CLI docs and deterministic integration coverage.

## Design
The CLI keeps the MCP/server surface unchanged and composes existing compact browser tools from Cobra commands. Page-scoped commands validate `-p/--page` before opening an MCP client, `find` composes `grep` plus `act`, snapshot filtering stays client-side over structured snapshot content, and `batch` reuses one MCP session while preserving per-tool timeouts.

## Test plan
- [x] `cd apps/cli && go test ./...`
- [x] `cd apps/cli && go test -tags integration -v ./...` (BrowserOS-backed cases skipped when no server is reachable at `127.0.0.1:9105`)
- [x] `cd apps/cli/npm && npm pack --dry-run`
- [x] `bun run check` (exits 0 with existing unrelated Biome/Fallow warnings)
- [x] `bun run test:main`