### PR TITLE
feat(browser-mcp): structured results for screenshot, grep, and diff

### DIFF
--- a/packages/browseros-agent/apps/server/tests/tools/browser/grep.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/grep.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'bun:test'
+import type { BrowserSession } from '@browseros/browser-core/core/session'
+import { executeTool } from '@browseros/browser-mcp/tools/framework'
+import { grep } from '@browseros/browser-mcp/tools/grep'
+
+function sessionWithSnapshot(text: string): BrowserSession {
+  return {
+    observe: () => ({ snapshot: async () => ({ text }) }),
+    pages: { getInfo: () => ({ url: 'https://example.com' }) },
+  } as unknown as BrowserSession
+}
+
+describe('grep tool', () => {
+  it('returns matched lines with page, over, and count in structured output', async () => {
+    const session = sessionWithSnapshot(
+      'button "Save" [ref=e1]\nlink "Home"\nbutton "Save draft" [ref=e2]',
+    )
+
+    const result = await executeTool(
+      grep,
+      { page: 4, pattern: 'save', over: 'ax' },
+      { session },
+    )
+
+    expect(result.isError).toBeFalsy()
+    expect(result.structuredContent).toEqual({
+      page: 4,
+      over: 'ax',
+      count: 2,
+      matches: ['button "Save" [ref=e1]', 'button "Save draft" [ref=e2]'],
+    })
+  })
+
+  it('reports zero matches with an empty matches array', async () => {
+    const session = sessionWithSnapshot('link "Home"\nlink "About"')
+
+    const result = await executeTool(
+      grep,
+      { page: 4, pattern: 'checkout', over: 'ax' },
+      { session },
+    )
+
+    expect(result.isError).toBeFalsy()
+    expect(result.structuredContent).toEqual({
+      page: 4,
+      over: 'ax',
+      count: 0,
+      matches: [],
+    })
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -154,6 +154,12 @@ describe('registerBrowserTools', () => {
       fake.handlers.get('screenshot')?.({ page: 1 }),
     ).resolves.toEqual({
       content: [{ type: 'image', data: 'jpeg-data', mimeType: 'image/jpeg' }],
+      structuredContent: {
+        page: 1,
+        format: 'jpeg',
+        bytes: Buffer.from('jpeg-data', 'base64').length,
+        image: 'jpeg-data',
+      },
     })
     await expect(
       fake.handlers.get('screenshot')?.({
@@ -163,6 +169,12 @@ describe('registerBrowserTools', () => {
       }),
     ).resolves.toEqual({
       content: [{ type: 'image', data: 'jpeg-data', mimeType: 'image/jpeg' }],
+      structuredContent: {
+        page: 1,
+        format: 'jpeg',
+        bytes: Buffer.from('jpeg-data', 'base64').length,
+        image: 'jpeg-data',
+      },
     })
     expect(captureOptions).toEqual([
       {
@@ -244,11 +256,23 @@ describe('registerBrowserTools', () => {
       }),
     ).resolves.toEqual({
       content: [{ type: 'image', data: 'png-data', mimeType: 'image/png' }],
+      structuredContent: {
+        page: 1,
+        format: 'png',
+        bytes: Buffer.from('png-data', 'base64').length,
+        image: 'png-data',
+      },
     })
     await expect(
       fake.handlers.get('screenshot')?.({ page: 1, fullPage: true }),
     ).resolves.toEqual({
       content: [{ type: 'image', data: 'jpeg-data', mimeType: 'image/jpeg' }],
+      structuredContent: {
+        page: 1,
+        format: 'jpeg',
+        bytes: Buffer.from('jpeg-data', 'base64').length,
+        image: 'jpeg-data',
+      },
     })
 
     expect(layoutMetricCalls).toBe(1)
@@ -845,6 +869,31 @@ return 'late'
       expect.objectContaining({
         type: 'text',
         text: expect.not.stringContaining('origin=https://example.com/stale'),
+      }),
+    ])
+  })
+
+  it('reports an unchanged diff with a changed:false discriminator', async () => {
+    const fake = createFakeServer()
+    const session = {
+      observe: () => ({
+        diff: async () => ({ changed: false, text: '', added: 0, removed: 0 }),
+      }),
+      pages: {
+        getInfo: () => ({ url: 'https://example.com' }),
+      },
+    } as unknown as BrowserSession
+
+    registerBrowserTools(fake.server as never, session)
+
+    const result = await fake.handlers.get('diff')?.({ page: 1 })
+
+    expect(result?.isError).toBeFalsy()
+    expect(result?.structuredContent).toEqual({ changed: false })
+    expect(result?.content).toEqual([
+      expect.objectContaining({
+        type: 'text',
+        text: 'no change since last snapshot',
       }),
     ])
   })

--- a/packages/browseros-agent/apps/server/tests/tools/browser/screenshot-tool.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/screenshot-tool.test.ts
@@ -70,6 +70,9 @@ describe('screenshot tool', () => {
     ])
     expect(result.structuredContent).toEqual({
       page: 3,
+      format: 'jpeg',
+      bytes: Buffer.from('jpeg-data', 'base64').length,
+      image: 'jpeg-data',
       annotations: [
         {
           ref: 'e1',
@@ -116,6 +119,11 @@ describe('screenshot tool', () => {
     expect(result.content).toEqual([
       { type: 'image', data: 'jpeg-data', mimeType: 'image/jpeg' },
     ])
-    expect(result.structuredContent).toBeUndefined()
+    expect(result.structuredContent).toEqual({
+      page: 3,
+      format: 'jpeg',
+      bytes: Buffer.from('jpeg-data', 'base64').length,
+      image: 'jpeg-data',
+    })
   })
 })

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/diff-format.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/diff-format.ts
@@ -19,12 +19,18 @@ export async function formatDiffResult(
   diff: SnapshotDiff,
   origin: string,
 ): Promise<FormattedDiff> {
-  if (!diff.changed) return { text: 'no change since last snapshot' }
+  if (!diff.changed) {
+    return {
+      text: 'no change since last snapshot',
+      structured: { changed: false },
+    }
+  }
 
   const diffText = diff.text || '(empty page)'
   const wrappedDiff = wrapUntrusted(diffText, origin)
   const tokenEstimate = estimateTextTokens(wrappedDiff)
   const structured = {
+    changed: true,
     added: diff.added,
     removed: diff.removed,
     ...(diff.urlChanged && {

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/grep.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/grep.ts
@@ -39,11 +39,21 @@ export const grep = defineTool({
       .split('\n')
       .filter((line) => regex.test(line))
       .slice(0, args.limit ?? 50)
-    if (matches.length === 0) return textResult('no matches', { count: 0 })
+    if (matches.length === 0) {
+      return textResult('no matches', {
+        page: args.page,
+        over: args.over,
+        count: 0,
+        matches: [],
+      })
+    }
 
     const origin = ctx.session.pages.getInfo(args.page)?.url ?? 'unknown'
     return textResult(wrapUntrusted(matches.join('\n'), origin), {
+      page: args.page,
+      over: args.over,
       count: matches.length,
+      matches,
     })
   },
 })

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/screenshot.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/screenshot.ts
@@ -86,12 +86,15 @@ export const screenshot = defineTool({
       content: [
         { type: 'image', data: result.data, mimeType: result.mimeType },
       ],
-      ...(result.annotations.length > 0 && {
-        structuredContent: {
-          page: args.page,
+      structuredContent: {
+        page: args.page,
+        format: args.format,
+        bytes: Buffer.from(result.data, 'base64').length,
+        image: result.data,
+        ...(result.annotations.length > 0 && {
           annotations: result.annotations,
-        },
-      }),
+        }),
+      },
     }
   },
 })


### PR DESCRIPTION
## Summary
Close the remaining gaps so every `browser-mcp` tool returns clean, minimal `structuredContent` on success (most already did; `snapshot`/`diff`/`act`/`navigate`/`tabs`/`read`/etc. were already structured).

- **screenshot**: now always emits `structuredContent` — `{ page, format, bytes, image, annotations? }` (previously only `{ page, annotations }`, and only when annotations existed). `bytes` is the decoded image byte length; `image` is the base64 string.
- **grep**: emits `{ page, over, count, matches }` on both the match and no-match paths (previously just `{ count }`). The human/text output is byte-for-byte unchanged.
- **diff**: adds a `changed` boolean discriminator — `{ changed: false }` on the no-change path (previously no `structuredContent` at all), and `changed: true` alongside `added`/`removed` on the change path.

## Design
Surgical, additive edits through the existing `textResult` / `response.data` plumbing — no new abstractions, no `outputSchema` declarations (only `run` declares one, by convention). `tabs active`/`list` were **intentionally left untouched**: they already return good structured output (the request cited them as examples, not gaps), and the Go CLI's `active` command consumes `structuredContent.page` as a full page object and normalizes it itself (`apps/cli/cmd/tabs.go`), so reshaping it would break `active` and `snap`.

Note on `screenshot.image`: the base64 is intentionally included in `structuredContent` (as requested) even though it also appears in the image content block. This makes structured-only MCP clients self-sufficient; the trade-off is a larger payload on the `browseros-cli screenshot --json` path that has no `--out` (the `--out` path overrides structuredContent with `{ path }`). Easy to drop the `image` field later if that payload size matters.

## Test plan
- [x] `bun run check` (lint + typecheck + Fallow) — green
- [x] `bun run test` (full monorepo suite, incl. the Go-CLI integration test that launches BrowserOS) — green
- [x] Added/updated structured-content assertions: `screenshot-tool.test.ts`, new `grep.test.ts`, diff no-change in `register.test.ts`
- [x] Verified the Go CLI consumers are unaffected: `find` reads grep's text (unchanged), `screenshot --out` overrides structured, `diff` change is additive
