### PR TITLE
chore: clean up claw config envs

### DIFF
--- a/packages/browseros-agent/apps/claw-app/.env.example
+++ b/packages/browseros-agent/apps/claw-app/.env.example
@@ -17,7 +17,7 @@
 
 # BrowserOS launch port forwarded to Chromium as --remote-debugging-port.
 # apps/claw-server dials the same port via BROWSEROS_CLAW_CDP_PORT.
-# BROWSEROS_CDP_PORT="9000"
+# BROWSEROS_CDP_PORT="49337"
 
 # Optional BrowserOS launch port forwarded as --browseros-mcp-port,
 # --browseros-server-port, and --browseros-proxy-port. This is not the

--- a/packages/browseros-agent/apps/claw-app/.env.example
+++ b/packages/browseros-agent/apps/claw-app/.env.example
@@ -2,7 +2,8 @@
 # loads these before wxt launches the browser. Entries are optional;
 # each has a default in the code path that reads it.
 
-# Override the cockpit API base URL used by the UI.
+# Override the standalone Claw API base URL used by the UI. tools/dev
+# sets this when dev:claw:watch selects a port for apps/claw-server.
 # VITE_BROWSEROS_CLAW_API_URL="http://127.0.0.1:9200/cockpit"
 
 # Path to a BrowserOS Chromium binary. Default targets the canonical
@@ -14,13 +15,14 @@
 # agent extension or with other worktrees.
 # BROWSEROS_USER_DATA_DIR="/tmp/my-browseros-dev"
 
-# When set, forwarded to Chromium as --remote-debugging-port.
+# BrowserOS launch port forwarded to Chromium as --remote-debugging-port.
+# apps/claw-server dials the same port via BROWSEROS_CLAW_CDP_PORT.
 # BROWSEROS_CDP_PORT="9000"
 
-# When set, forwarded as --browseros-mcp-port, --browseros-server-port,
-# and --browseros-proxy-port. Points BrowserOS at a sibling agent
-# server (the existing apps/server). Leave unset if you don't need it.
+# Optional BrowserOS launch port forwarded as --browseros-mcp-port,
+# --browseros-server-port, and --browseros-proxy-port. This is not the
+# standalone Claw API port; set CLAW_SERVER_PORT in apps/claw-server.
 # BROWSEROS_SERVER_PORT="9100"
 
-# When set, forwarded as --browseros-extension-port.
+# Optional BrowserOS launch port forwarded as --browseros-extension-port.
 # BROWSEROS_EXTENSION_PORT="9300"

--- a/packages/browseros-agent/apps/claw-server/.env.example
+++ b/packages/browseros-agent/apps/claw-server/.env.example
@@ -1,0 +1,11 @@
+# Copy to .env.development locally; bun --env-file=.env.development
+# loads these before the standalone Claw server starts.
+
+# HTTP port for the standalone Claw API served under /cockpit.
+# CLAW_SERVER_PORT="9200"
+
+# BrowserOS Chromium DevTools port that Claw-server dials over CDP.
+# BROWSEROS_CLAW_CDP_PORT="49337"
+
+# Optional YAML config path. CLI --config <path> wins when both are set.
+# CLAW_CONFIG="./claw.config.yaml"

--- a/packages/browseros-agent/apps/claw-server/package.json
+++ b/packages/browseros-agent/apps/claw-server/package.json
@@ -35,6 +35,7 @@
     "agent-mcp-manager": "^0.0.1",
     "hono": "^4.12.3",
     "nanoid": "^5.1.11",
+    "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/browseros-agent/apps/claw-server/src/config.ts
+++ b/packages/browseros-agent/apps/claw-server/src/config.ts
@@ -43,7 +43,7 @@ export function loadClawConfig(
   if (!fileConfig.ok) return fileConfig
 
   const result = ClawConfigSchema.safeParse(
-    mergeConfigs(getDefaults(), envConfig.value, fileConfig.value),
+    mergeConfigs(getDefaults(), fileConfig.value, envConfig.value),
   )
   if (!result.success) {
     const errors = result.error.issues
@@ -127,6 +127,15 @@ function parseConfigFile(
   if (ports === undefined) return { ok: true, value: {} }
   if (!isRecord(ports)) {
     return { ok: false, error: 'Config file error: ports must be a mapping' }
+  }
+  const unknownPortKeys = Object.keys(ports).filter(
+    (key) => key !== 'server' && key !== 'cdp',
+  )
+  if (unknownPortKeys.length > 0) {
+    return {
+      ok: false,
+      error: `Config file error: unknown ports key(s): ${unknownPortKeys.join(', ')}`,
+    }
   }
 
   const port = parsePort(ports.server, 'ports.server')

--- a/packages/browseros-agent/apps/claw-server/src/config.ts
+++ b/packages/browseros-agent/apps/claw-server/src/config.ts
@@ -1,0 +1,204 @@
+import { existsSync, readFileSync } from 'node:fs'
+import { isAbsolute, resolve } from 'node:path'
+import { parse } from 'yaml'
+import { z } from 'zod'
+import { COCKPIT_CDP_PORT_DEFAULT, PROD_API_PORT } from './shared/port'
+
+const portSchema = z.number().int().min(1).max(65535)
+const ClawConfigSchema = z.object({
+  port: portSchema,
+  cdpPort: portSchema,
+})
+
+export type ClawConfig = z.infer<typeof ClawConfigSchema>
+export type ConfigResult<T> =
+  | { ok: true; value: T }
+  | { ok: false; error: string }
+
+interface LoadClawConfigOptions {
+  argv?: string[]
+  cwd?: string
+  env?: Record<string, string | undefined>
+}
+
+type PartialClawConfig = Partial<ClawConfig>
+
+/** Loads and validates Claw server ports from defaults, env, and YAML config. */
+export function loadClawConfig(
+  options: LoadClawConfigOptions = {},
+): ConfigResult<ClawConfig> {
+  const argv = options.argv ?? process.argv
+  const cwd = options.cwd ?? process.cwd()
+  // biome-ignore lint/style/noProcessEnv: config.ts is the sanctioned Claw config reader
+  const runtimeEnv = options.env ?? process.env
+
+  const cli = parseCliArgs(argv)
+  if (!cli.ok) return cli
+
+  const envConfig = parseRuntimeEnv(runtimeEnv)
+  if (!envConfig.ok) return envConfig
+
+  const configPath = cli.value.configPath ?? cleanString(runtimeEnv.CLAW_CONFIG)
+  const fileConfig = parseConfigFile(configPath, cwd)
+  if (!fileConfig.ok) return fileConfig
+
+  const result = ClawConfigSchema.safeParse(
+    mergeConfigs(getDefaults(), envConfig.value, fileConfig.value),
+  )
+  if (!result.success) {
+    const errors = result.error.issues
+      .map((issue) => `  - ${issue.path.join('.')}: ${issue.message}`)
+      .join('\n')
+    return {
+      ok: false,
+      error: `Invalid Claw server configuration:\n${errors}`,
+    }
+  }
+
+  return { ok: true, value: result.data }
+}
+
+function parseCliArgs(argv: string[]): ConfigResult<{ configPath?: string }> {
+  for (let index = 0; index < argv.length; index++) {
+    const arg = argv[index]
+    if (arg === '--config') {
+      const value = argv[index + 1]
+      if (!value || value.startsWith('--')) {
+        return { ok: false, error: '--config requires a path' }
+      }
+      return { ok: true, value: { configPath: value } }
+    }
+    if (arg.startsWith('--config=')) {
+      const value = arg.slice('--config='.length).trim()
+      if (!value) return { ok: false, error: '--config requires a path' }
+      return { ok: true, value: { configPath: value } }
+    }
+  }
+
+  return { ok: true, value: {} }
+}
+
+function parseRuntimeEnv(
+  env: Record<string, string | undefined>,
+): ConfigResult<PartialClawConfig> {
+  const port = parsePort(env.CLAW_SERVER_PORT, 'CLAW_SERVER_PORT')
+  if (!port.ok) return port
+
+  const cdpPort = parsePort(
+    env.BROWSEROS_CLAW_CDP_PORT,
+    'BROWSEROS_CLAW_CDP_PORT',
+  )
+  if (!cdpPort.ok) return cdpPort
+
+  return {
+    ok: true,
+    value: omitUndefined({
+      port: port.value,
+      cdpPort: cdpPort.value,
+    }),
+  }
+}
+
+function parseConfigFile(
+  filePath: string | undefined,
+  cwd: string,
+): ConfigResult<PartialClawConfig> {
+  if (!filePath) return { ok: true, value: {} }
+
+  const absPath = isAbsolute(filePath) ? filePath : resolve(cwd, filePath)
+  if (!existsSync(absPath)) {
+    return { ok: false, error: `Config file not found: ${absPath}` }
+  }
+
+  let raw: unknown
+  try {
+    raw = parse(readFileSync(absPath, 'utf-8'))
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { ok: false, error: `Config file error: ${message}` }
+  }
+
+  if (raw == null) return { ok: true, value: {} }
+  if (!isRecord(raw)) {
+    return { ok: false, error: 'Config file error: expected a YAML mapping' }
+  }
+
+  const ports = raw.ports
+  if (ports === undefined) return { ok: true, value: {} }
+  if (!isRecord(ports)) {
+    return { ok: false, error: 'Config file error: ports must be a mapping' }
+  }
+
+  const port = parsePort(ports.server, 'ports.server')
+  if (!port.ok) return port
+
+  const cdpPort = parsePort(ports.cdp, 'ports.cdp')
+  if (!cdpPort.ok) return cdpPort
+
+  return {
+    ok: true,
+    value: omitUndefined({
+      port: port.value,
+      cdpPort: cdpPort.value,
+    }),
+  }
+}
+
+function parsePort(
+  value: unknown,
+  source: string,
+): ConfigResult<number | undefined> {
+  if (value === undefined || value === null || value === '') {
+    return { ok: true, value: undefined }
+  }
+
+  const parsed =
+    typeof value === 'number'
+      ? value
+      : typeof value === 'string'
+        ? Number(value.trim())
+        : Number.NaN
+
+  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
+    return {
+      ok: false,
+      error: `${source} must be an integer port between 1 and 65535`,
+    }
+  }
+
+  return { ok: true, value: parsed }
+}
+
+function getDefaults(): ClawConfig {
+  return {
+    port: PROD_API_PORT,
+    cdpPort: COCKPIT_CDP_PORT_DEFAULT,
+  }
+}
+
+function mergeConfigs(...configs: PartialClawConfig[]): PartialClawConfig {
+  const result: PartialClawConfig = {}
+  for (const config of configs) {
+    for (const [key, value] of Object.entries(config)) {
+      if (value !== undefined) {
+        ;(result as Record<string, unknown>)[key] = value
+      }
+    }
+  }
+  return result
+}
+
+function omitUndefined<T extends Record<string, unknown>>(obj: T): Partial<T> {
+  return Object.fromEntries(
+    Object.entries(obj).filter(([, value]) => value !== undefined),
+  ) as Partial<T>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function cleanString(value: string | undefined): string | undefined {
+  const trimmed = value?.trim()
+  return trimmed ? trimmed : undefined
+}

--- a/packages/browseros-agent/apps/claw-server/src/env.ts
+++ b/packages/browseros-agent/apps/claw-server/src/env.ts
@@ -3,41 +3,12 @@
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
- * Single chokepoint for env reads. Centralising here keeps the rest
- * of the source free of process.env access and lets biome's
- * noProcessEnv rule stay on at error level for every other file.
+ * Single chokepoint for non-port env reads. Port config lives in
+ * config.ts so startup can validate env/YAML before serving.
  */
 
+import type { ClawConfig } from './config'
 import { COCKPIT_CDP_PORT_DEFAULT, PROD_API_PORT } from './shared/port'
-
-function readPort(): number {
-  // biome-ignore lint/style/noProcessEnv: env.ts is the sanctioned env-reader for the package
-  const raw = process.env.BROWSEROS_CLAW_SERVER_PORT
-  if (!raw) return PROD_API_PORT
-  const parsed = Number(raw)
-  if (!Number.isInteger(parsed) || parsed < 0 || parsed > 65535) {
-    return PROD_API_PORT
-  }
-  return parsed
-}
-
-/**
- * Port the cockpit dials when attaching to BrowserOS Chromium
- * over CDP. Default lives in IANA's dynamic / private range so it
- * cannot collide with a registered service; the env override is the
- * bridge until the BrowserOS browser shell defaults its DevTools
- * port to the same value.
- */
-function readCdpPort(): number {
-  // biome-ignore lint/style/noProcessEnv: env.ts is the sanctioned env-reader for the package
-  const raw = process.env.BROWSEROS_COCKPIT_CDP_PORT
-  if (!raw) return COCKPIT_CDP_PORT_DEFAULT
-  const parsed = Number(raw)
-  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
-    return COCKPIT_CDP_PORT_DEFAULT
-  }
-  return parsed
-}
 
 function readBrowserosDirOverride(): string | undefined {
   // biome-ignore lint/style/noProcessEnv: env.ts is the sanctioned env-reader for the package
@@ -65,15 +36,20 @@ function readBoolFlag(name: string): boolean {
 }
 
 /**
- * Reads happen once at module load. Tests that need different values
- * mutate this object before importing the rest of the source graph;
- * production code treats it as immutable.
+ * Runtime snapshot shared across services. main.ts applies validated
+ * port config before serving; tests may mutate fields for isolation.
  */
 export const env = {
-  port: readPort(),
-  cdpPort: readCdpPort(),
+  port: PROD_API_PORT,
+  cdpPort: COCKPIT_CDP_PORT_DEFAULT,
   browserosDirOverride: readBrowserosDirOverride(),
   isDevelopment: readIsDevelopment(),
+}
+
+/** Applies validated startup config to the shared runtime snapshot. */
+export function applyClawConfig(config: ClawConfig): void {
+  env.port = config.port
+  env.cdpPort = config.cdpPort
 }
 
 /**

--- a/packages/browseros-agent/apps/claw-server/src/main.ts
+++ b/packages/browseros-agent/apps/claw-server/src/main.ts
@@ -20,7 +20,8 @@ if (typeof Bun === 'undefined') {
 }
 
 import { Hono } from 'hono'
-import { env } from './env'
+import { loadClawConfig } from './config'
+import { applyClawConfig, env } from './env'
 import { bootstrapBrowserosBrowser } from './lib/browser-bootstrap'
 import { setBrowserSession } from './lib/browser-session'
 import { logger } from './lib/logger'
@@ -30,6 +31,14 @@ import server from './server'
 import { COCKPIT_MOUNT_PREFIX } from './shared/port'
 
 async function start(): Promise<void> {
+  const config = loadClawConfig()
+  if (!config.ok) {
+    // biome-ignore lint/suspicious/noConsole: pre-logger startup error
+    console.error(config.error)
+    process.exit(1)
+  }
+  applyClawConfig(config.value)
+
   const root = new Hono().route(COCKPIT_MOUNT_PREFIX, server)
   const httpServer = Bun.serve({
     hostname: '127.0.0.1',

--- a/packages/browseros-agent/apps/claw-server/src/shared/port.ts
+++ b/packages/browseros-agent/apps/claw-server/src/shared/port.ts
@@ -15,12 +15,12 @@ export const COCKPIT_MOUNT_PREFIX = '/cockpit'
  * Chromium. Lives in IANA's dynamic / private range (49152-65535)
  * so it cannot collide with a registered service, and is not a round
  * number so a hand-rolled local script is unlikely to pick the same
- * value. Override via `BROWSEROS_COCKPIT_CDP_PORT`.
+ * value. Override via `BROWSEROS_CLAW_CDP_PORT`.
  *
  * Important: this is the port BrowserOS's Chromium exposes its
  * DevTools on, not a port the cockpit itself opens. Until the
  * BrowserOS browser shell defaults to the same value, the env var
- * is the bridge — set it to whatever DevTools port BrowserOS is
+ * is the bridge -- set it to whatever DevTools port BrowserOS is
  * currently bound on.
  */
 export const COCKPIT_CDP_PORT_DEFAULT = 49337

--- a/packages/browseros-agent/apps/claw-server/tests/config.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/config.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { loadClawConfig } from '../src/config'
+import { COCKPIT_CDP_PORT_DEFAULT, PROD_API_PORT } from '../src/shared/port'
+
+async function writeConfig(contents: string): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), 'claw-config-'))
+  const path = join(dir, 'config.yaml')
+  await writeFile(path, contents)
+  return path
+}
+
+describe('loadClawConfig', () => {
+  test('uses standalone defaults when no env or config file is provided', () => {
+    const result = loadClawConfig({ argv: [], env: {}, cwd: '/' })
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        port: PROD_API_PORT,
+        cdpPort: COCKPIT_CDP_PORT_DEFAULT,
+      },
+    })
+  })
+
+  test('reads Claw-specific port env values', () => {
+    const result = loadClawConfig({
+      argv: [],
+      cwd: '/',
+      env: {
+        CLAW_SERVER_PORT: '9310',
+        BROWSEROS_CLAW_CDP_PORT: '9010',
+      },
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        port: 9310,
+        cdpPort: 9010,
+      },
+    })
+  })
+
+  test('reads ports from a YAML config file', async () => {
+    const configPath = await writeConfig(`
+ports:
+  server: 9420
+  cdp: 9020
+`)
+
+    const result = loadClawConfig({
+      argv: [],
+      cwd: '/',
+      env: { CLAW_CONFIG: configPath },
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        port: 9420,
+        cdpPort: 9020,
+      },
+    })
+  })
+
+  test('lets YAML config values override env ports', async () => {
+    const configPath = await writeConfig(`
+ports:
+  server: 9520
+  cdp: 9120
+`)
+
+    const result = loadClawConfig({
+      argv: [],
+      cwd: '/',
+      env: {
+        CLAW_SERVER_PORT: '9310',
+        BROWSEROS_CLAW_CDP_PORT: '9010',
+        CLAW_CONFIG: configPath,
+      },
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        port: 9520,
+        cdpPort: 9120,
+      },
+    })
+  })
+
+  test('--config wins over CLAW_CONFIG for the config file path', async () => {
+    const envConfigPath = await writeConfig(`
+ports:
+  server: 9300
+  cdp: 9000
+`)
+    const cliConfigPath = await writeConfig(`
+ports:
+  server: 9600
+  cdp: 9200
+`)
+
+    const result = loadClawConfig({
+      argv: ['bun', 'src/main.ts', '--config', cliConfigPath],
+      cwd: '/',
+      env: { CLAW_CONFIG: envConfigPath },
+    })
+
+    expect(result).toEqual({
+      ok: true,
+      value: {
+        port: 9600,
+        cdpPort: 9200,
+      },
+    })
+  })
+
+  test('returns a clear error for invalid env ports', () => {
+    const result = loadClawConfig({
+      argv: [],
+      cwd: '/',
+      env: { CLAW_SERVER_PORT: 'abc' },
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('CLAW_SERVER_PORT')
+      expect(result.error).toContain('integer port between 1 and 65535')
+    }
+  })
+
+  test('returns a clear error for invalid YAML ports', async () => {
+    const configPath = await writeConfig(`
+ports:
+  server: 70000
+`)
+
+    const result = loadClawConfig({
+      argv: ['--config', configPath],
+      cwd: '/',
+      env: {},
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('ports.server')
+      expect(result.error).toContain('integer port between 1 and 65535')
+    }
+  })
+
+  test('returns a clear error for a missing config file', () => {
+    const result = loadClawConfig({
+      argv: ['--config', '/missing/claw.yaml'],
+      cwd: '/',
+      env: {},
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Config file not found: /missing/claw.yaml',
+    })
+  })
+})

--- a/packages/browseros-agent/apps/claw-server/tests/config.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/config.test.ts
@@ -66,7 +66,7 @@ ports:
     })
   })
 
-  test('lets YAML config values override env ports', async () => {
+  test('lets env ports override YAML config values', async () => {
     const configPath = await writeConfig(`
 ports:
   server: 9520
@@ -86,8 +86,8 @@ ports:
     expect(result).toEqual({
       ok: true,
       value: {
-        port: 9520,
-        cdpPort: 9120,
+        port: 9310,
+        cdpPort: 9010,
       },
     })
   })
@@ -150,6 +150,24 @@ ports:
       expect(result.error).toContain('ports.server')
       expect(result.error).toContain('integer port between 1 and 65535')
     }
+  })
+
+  test('returns a clear error for unknown YAML port keys', async () => {
+    const configPath = await writeConfig(`
+ports:
+  cdpPort: 9020
+`)
+
+    const result = loadClawConfig({
+      argv: ['--config', configPath],
+      cwd: '/',
+      env: {},
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'Config file error: unknown ports key(s): cdpPort',
+    })
   })
 
   test('returns a clear error for a missing config file', () => {

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -184,6 +184,7 @@
         "agent-mcp-manager": "^0.0.1",
         "hono": "^4.12.3",
         "nanoid": "^5.1.11",
+        "yaml": "^2.9.0",
         "zod": "^4.4.3",
       },
       "devDependencies": {

--- a/packages/browseros-agent/tools/dev/cmd/watch.go
+++ b/packages/browseros-agent/tools/dev/cmd/watch.go
@@ -225,8 +225,8 @@ func resolveWatchDefaultPorts(root string, claw bool) (proc.Ports, error) {
 func buildClawWatchEnv(env []string, p proc.Ports) []string {
 	apiURL := fmt.Sprintf("http://127.0.0.1:%d/cockpit", p.Server)
 	return append(env,
-		fmt.Sprintf("BROWSEROS_CLAW_SERVER_PORT=%d", p.Server),
-		fmt.Sprintf("BROWSEROS_COCKPIT_CDP_PORT=%d", p.CDP),
+		fmt.Sprintf("CLAW_SERVER_PORT=%d", p.Server),
+		fmt.Sprintf("BROWSEROS_CLAW_CDP_PORT=%d", p.CDP),
 		fmt.Sprintf("VITE_BROWSEROS_CLAW_API_URL=%s", apiURL),
 	)
 }

--- a/packages/browseros-agent/tools/dev/cmd/watch_test.go
+++ b/packages/browseros-agent/tools/dev/cmd/watch_test.go
@@ -70,8 +70,8 @@ func TestBuildClawWatchEnvIncludesSelectedPorts(t *testing.T) {
 
 	for _, want := range []string{
 		"BASE=1",
-		"BROWSEROS_CLAW_SERVER_PORT=9123",
-		"BROWSEROS_COCKPIT_CDP_PORT=9012",
+		"CLAW_SERVER_PORT=9123",
+		"BROWSEROS_CLAW_CDP_PORT=9012",
 		"VITE_BROWSEROS_CLAW_API_URL=http://127.0.0.1:9123/cockpit",
 	} {
 		if !hasEnvEntry(env, want) {


### PR DESCRIPTION
## Summary
- Rename standalone Claw server envs to `CLAW_SERVER_PORT` and `BROWSEROS_CLAW_CDP_PORT`.
- Add a small validated `apps/claw-server/src/config.ts` loader for env and YAML port config.
- Update `tools/dev` Claw watch env wiring and Claw app/server env examples.

## Design
Claw-server now validates startup ports through a local config loader before serving, then applies them to the existing runtime `env` snapshot used by routes and CDP bootstrap. `tools/dev --claw` remains standalone and maps selected ports into Claw-specific env names while preserving `VITE_BROWSEROS_CLAW_API_URL` for the UI.

## Test plan
- [x] `bun test apps/claw-server/tests/config.test.ts`
- [x] `bun test apps/claw-server/tests/config.test.ts apps/claw-server/tests/lib/browser-bootstrap.test.ts`
- [x] `go test ./cmd` in `tools/dev`
- [x] `go test ./...` in `tools/dev`
- [x] `git diff --check`
- [x] old env-name grep: `BROWSEROS_CLAW_SERVER_PORT|BROWSEROS_COCKPIT_CDP_PORT`
- [x] `bun run check` (exits 0; prints existing unrelated Biome/Fallow warnings)
- [x] `bun run test`