### PR TITLE
chore: clean up claw config ports

### DIFF
--- a/packages/browseros-agent/apps/claw-app/.env.example
+++ b/packages/browseros-agent/apps/claw-app/.env.example
@@ -16,13 +16,10 @@
 # BROWSEROS_USER_DATA_DIR="/tmp/my-browseros-dev"
 
 # BrowserOS launch port forwarded to Chromium as --remote-debugging-port.
-# apps/claw-server dials the same port via BROWSEROS_CLAW_CDP_PORT.
-# BROWSEROS_CDP_PORT="49337"
+# apps/claw-server dials the same port via the same Claw-specific env.
+# BROWSEROS_CLAW_CDP_PORT="49337"
 
 # Optional BrowserOS launch port forwarded as --browseros-mcp-port,
 # --browseros-server-port, and --browseros-proxy-port. This is not the
 # standalone Claw API port; set CLAW_SERVER_PORT in apps/claw-server.
 # BROWSEROS_SERVER_PORT="9100"
-
-# Optional BrowserOS launch port forwarded as --browseros-extension-port.
-# BROWSEROS_EXTENSION_PORT="9300"

--- a/packages/browseros-agent/apps/claw-app/modules/api/client.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/client.ts
@@ -24,8 +24,8 @@
 
 import type { AppType } from '@browseros/claw-server/server'
 import {
+  CLAW_API_PORT_DEFAULT,
   COCKPIT_MOUNT_PREFIX,
-  PROD_API_PORT,
 } from '@browseros/claw-server/shared/port'
 import { hc } from 'hono/client'
 import {
@@ -35,7 +35,7 @@ import {
 } from './client.helpers'
 
 function resolveApiBaseUrl(): string {
-  const fallback = `http://127.0.0.1:${PROD_API_PORT}${COCKPIT_MOUNT_PREFIX}`
+  const fallback = `http://127.0.0.1:${CLAW_API_PORT_DEFAULT}${COCKPIT_MOUNT_PREFIX}`
   if (typeof window === 'undefined') return fallback
 
   const fromQuery = new URLSearchParams(window.location.search).get('apiUrl')

--- a/packages/browseros-agent/apps/claw-app/modules/api/mcp-endpoint.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/mcp-endpoint.ts
@@ -19,8 +19,8 @@ import {
   MCP_PATH,
 } from '@browseros/claw-server/shared/mcp-url'
 import {
+  CLAW_API_PORT_DEFAULT,
   COCKPIT_MOUNT_PREFIX,
-  PROD_API_PORT,
 } from '@browseros/claw-server/shared/port'
 import {
   API_URL_STORAGE_KEY,
@@ -29,7 +29,7 @@ import {
 } from './client.helpers'
 
 function fallbackBaseUrl(): string {
-  return `http://127.0.0.1:${PROD_API_PORT}${COCKPIT_MOUNT_PREFIX}`
+  return `http://127.0.0.1:${CLAW_API_PORT_DEFAULT}${COCKPIT_MOUNT_PREFIX}`
 }
 
 /** Resolves the same cockpit base URL as the API client for pre-create previews. */

--- a/packages/browseros-agent/apps/claw-app/web-ext.config.ts
+++ b/packages/browseros-agent/apps/claw-app/web-ext.config.ts
@@ -54,8 +54,8 @@ const chromiumArgs = [
   '--browseros-dock-icon=dev',
 ]
 
-if (env.BROWSEROS_CDP_PORT) {
-  chromiumArgs.push(`--remote-debugging-port=${env.BROWSEROS_CDP_PORT}`)
+if (env.BROWSEROS_CLAW_CDP_PORT) {
+  chromiumArgs.push(`--remote-debugging-port=${env.BROWSEROS_CLAW_CDP_PORT}`)
 }
 if (env.BROWSEROS_SERVER_PORT) {
   chromiumArgs.push(`--browseros-mcp-port=${env.BROWSEROS_SERVER_PORT}`)
@@ -64,12 +64,6 @@ if (env.BROWSEROS_SERVER_PORT) {
   // port falls back to server port.
   chromiumArgs.push(`--browseros-proxy-port=${env.BROWSEROS_SERVER_PORT}`)
 }
-if (env.BROWSEROS_EXTENSION_PORT) {
-  chromiumArgs.push(
-    `--browseros-extension-port=${env.BROWSEROS_EXTENSION_PORT}`,
-  )
-}
-
 export default defineWebExtConfig({
   binaries: {
     chrome:

--- a/packages/browseros-agent/apps/claw-server/package.json
+++ b/packages/browseros-agent/apps/claw-server/package.json
@@ -33,6 +33,7 @@
     "@hono/zod-validator": "^0.8.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
     "agent-mcp-manager": "^0.0.1",
+    "commander": "^14.0.3",
     "hono": "^4.12.3",
     "nanoid": "^5.1.11",
     "yaml": "^2.9.0",

--- a/packages/browseros-agent/apps/claw-server/src/config.ts
+++ b/packages/browseros-agent/apps/claw-server/src/config.ts
@@ -101,7 +101,12 @@ function parseCliArgs(argv: string[]): ConfigResult<{ configPath?: string }> {
   }
 
   const opts = program.opts<{ config?: string }>()
-  return { ok: true, value: { configPath: cleanString(opts.config) } }
+  const configPath = cleanString(opts.config)
+  if (program.getOptionValueSource('config') === 'cli' && !configPath) {
+    return { ok: false, error: '--config requires a path' }
+  }
+
+  return { ok: true, value: { configPath } }
 }
 
 function parseRuntimeEnv(

--- a/packages/browseros-agent/apps/claw-server/src/config.ts
+++ b/packages/browseros-agent/apps/claw-server/src/config.ts
@@ -1,13 +1,31 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { isAbsolute, resolve } from 'node:path'
-import { parse } from 'yaml'
+import { Command } from 'commander'
+import { parseDocument } from 'yaml'
 import { z } from 'zod'
-import { COCKPIT_CDP_PORT_DEFAULT, PROD_API_PORT } from './shared/port'
+import { CLAW_API_PORT_DEFAULT, CLAW_CDP_PORT_DEFAULT } from './shared/port'
 
 const portSchema = z.number().int().min(1).max(65535)
+const optionalPortSchema = z.preprocess(
+  normalizePortInput,
+  portSchema.optional(),
+)
 const ClawConfigSchema = z.object({
   port: portSchema,
   cdpPort: portSchema,
+})
+const ClawEnvSchema = z.object({
+  port: optionalPortSchema,
+  cdpPort: optionalPortSchema,
+})
+const ClawConfigFileSchema = z.object({
+  ports: z
+    .object({
+      server: optionalPortSchema,
+      cdp: optionalPortSchema,
+    })
+    .strict()
+    .optional(),
 })
 
 export type ClawConfig = z.infer<typeof ClawConfigSchema>
@@ -22,6 +40,12 @@ interface LoadClawConfigOptions {
 }
 
 type PartialClawConfig = Partial<ClawConfig>
+type ConfigIssue = {
+  path: PropertyKey[]
+  message: string
+  code: string
+  keys?: string[]
+}
 
 /** Loads and validates Claw server ports from defaults, env, and YAML config. */
 export function loadClawConfig(
@@ -59,42 +83,52 @@ export function loadClawConfig(
 }
 
 function parseCliArgs(argv: string[]): ConfigResult<{ configPath?: string }> {
-  for (let index = 0; index < argv.length; index++) {
-    const arg = argv[index]
-    if (arg === '--config') {
-      const value = argv[index + 1]
-      if (!value || value.startsWith('--')) {
-        return { ok: false, error: '--config requires a path' }
-      }
-      return { ok: true, value: { configPath: value } }
-    }
-    if (arg.startsWith('--config=')) {
-      const value = arg.slice('--config='.length).trim()
-      if (!value) return { ok: false, error: '--config requires a path' }
-      return { ok: true, value: { configPath: value } }
-    }
+  const program = new Command()
+
+  try {
+    program
+      .name('claw-server')
+      .description('BrowserClaw standalone API')
+      .option('--config <path>', 'Path to YAML configuration file')
+      .exitOverride((err) => {
+        if (err.exitCode === 0) process.exit(0)
+        throw err
+      })
+      .parse(toUserArgs(argv), { from: 'user' })
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err)
+    return { ok: false, error: message }
   }
 
-  return { ok: true, value: {} }
+  const opts = program.opts<{ config?: string }>()
+  return { ok: true, value: { configPath: cleanString(opts.config) } }
 }
 
 function parseRuntimeEnv(
   env: Record<string, string | undefined>,
 ): ConfigResult<PartialClawConfig> {
-  const port = parsePort(env.CLAW_SERVER_PORT, 'CLAW_SERVER_PORT')
-  if (!port.ok) return port
-
-  const cdpPort = parsePort(
-    env.BROWSEROS_CLAW_CDP_PORT,
-    'BROWSEROS_CLAW_CDP_PORT',
-  )
-  if (!cdpPort.ok) return cdpPort
+  const result = ClawEnvSchema.safeParse({
+    port: env.CLAW_SERVER_PORT,
+    cdpPort: env.BROWSEROS_CLAW_CDP_PORT,
+  })
+  if (!result.success) {
+    return {
+      ok: false,
+      error: `Invalid Claw server environment:\n${formatZodIssues(
+        result.error.issues,
+        {
+          port: 'CLAW_SERVER_PORT',
+          cdpPort: 'BROWSEROS_CLAW_CDP_PORT',
+        },
+      )}`,
+    }
+  }
 
   return {
     ok: true,
     value: omitUndefined({
-      port: port.value,
-      cdpPort: cdpPort.value,
+      port: result.data.port,
+      cdpPort: result.data.cdpPort,
     }),
   }
 }
@@ -112,76 +146,84 @@ function parseConfigFile(
 
   let raw: unknown
   try {
-    raw = parse(readFileSync(absPath, 'utf-8'))
+    const doc = parseDocument(readFileSync(absPath, 'utf-8'))
+    if (doc.errors.length > 0) {
+      return {
+        ok: false,
+        error: `Config file error: ${doc.errors.map((err) => err.message).join('\n')}`,
+      }
+    }
+    raw = doc.toJS()
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     return { ok: false, error: `Config file error: ${message}` }
   }
 
-  if (raw == null) return { ok: true, value: {} }
-  if (!isRecord(raw)) {
-    return { ok: false, error: 'Config file error: expected a YAML mapping' }
-  }
-
-  const ports = raw.ports
-  if (ports === undefined) return { ok: true, value: {} }
-  if (!isRecord(ports)) {
-    return { ok: false, error: 'Config file error: ports must be a mapping' }
-  }
-  const unknownPortKeys = Object.keys(ports).filter(
-    (key) => key !== 'server' && key !== 'cdp',
-  )
-  if (unknownPortKeys.length > 0) {
+  const parsed = ClawConfigFileSchema.safeParse(raw ?? {})
+  if (!parsed.success) {
     return {
       ok: false,
-      error: `Config file error: unknown ports key(s): ${unknownPortKeys.join(', ')}`,
+      error: `Config file error:\n${formatZodIssues(parsed.error.issues)}`,
     }
   }
-
-  const port = parsePort(ports.server, 'ports.server')
-  if (!port.ok) return port
-
-  const cdpPort = parsePort(ports.cdp, 'ports.cdp')
-  if (!cdpPort.ok) return cdpPort
 
   return {
     ok: true,
     value: omitUndefined({
-      port: port.value,
-      cdpPort: cdpPort.value,
+      port: parsed.data.ports?.server,
+      cdpPort: parsed.data.ports?.cdp,
     }),
   }
 }
 
-function parsePort(
-  value: unknown,
-  source: string,
-): ConfigResult<number | undefined> {
-  if (value === undefined || value === null || value === '') {
-    return { ok: true, value: undefined }
-  }
+function normalizePortInput(value: unknown): unknown {
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== 'string') return value
 
-  const parsed =
-    typeof value === 'number'
-      ? value
-      : typeof value === 'string'
-        ? Number(value.trim())
-        : Number.NaN
+  const trimmed = value.trim()
+  return trimmed === '' ? undefined : Number(trimmed)
+}
 
-  if (!Number.isInteger(parsed) || parsed < 1 || parsed > 65535) {
-    return {
-      ok: false,
-      error: `${source} must be an integer port between 1 and 65535`,
-    }
-  }
+function toUserArgs(argv: string[]): string[] {
+  return argv.length >= 2 && !argv[0]?.startsWith('-') ? argv.slice(2) : argv
+}
 
-  return { ok: true, value: parsed }
+function formatZodIssues(
+  issues: ConfigIssue[],
+  pathLabels: Record<string, string> = {},
+): string {
+  return issues
+    .map((issue) => {
+      const path = issue.path.map(String).join('.')
+      const source = pathLabels[path] ?? (path || 'config')
+      let message = issue.message
+
+      if (issue.code === 'unrecognized_keys' && issue.keys) {
+        message = `unknown key(s): ${issue.keys.join(', ')}`
+      } else if (isPortSource(source)) {
+        message = 'must be an integer port between 1 and 65535'
+      }
+
+      return `  - ${source}: ${message}`
+    })
+    .join('\n')
+}
+
+function isPortSource(source: string): boolean {
+  return [
+    'port',
+    'cdpPort',
+    'ports.server',
+    'ports.cdp',
+    'CLAW_SERVER_PORT',
+    'BROWSEROS_CLAW_CDP_PORT',
+  ].includes(source)
 }
 
 function getDefaults(): ClawConfig {
   return {
-    port: PROD_API_PORT,
-    cdpPort: COCKPIT_CDP_PORT_DEFAULT,
+    port: CLAW_API_PORT_DEFAULT,
+    cdpPort: CLAW_CDP_PORT_DEFAULT,
   }
 }
 
@@ -201,10 +243,6 @@ function omitUndefined<T extends Record<string, unknown>>(obj: T): Partial<T> {
   return Object.fromEntries(
     Object.entries(obj).filter(([, value]) => value !== undefined),
   ) as Partial<T>
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value)
 }
 
 function cleanString(value: string | undefined): string | undefined {

--- a/packages/browseros-agent/apps/claw-server/src/env.ts
+++ b/packages/browseros-agent/apps/claw-server/src/env.ts
@@ -8,7 +8,7 @@
  */
 
 import type { ClawConfig } from './config'
-import { COCKPIT_CDP_PORT_DEFAULT, PROD_API_PORT } from './shared/port'
+import { CLAW_API_PORT_DEFAULT, CLAW_CDP_PORT_DEFAULT } from './shared/port'
 
 function readBrowserosDirOverride(): string | undefined {
   // biome-ignore lint/style/noProcessEnv: env.ts is the sanctioned env-reader for the package
@@ -40,8 +40,8 @@ function readBoolFlag(name: string): boolean {
  * port config before serving; tests may mutate fields for isolation.
  */
 export const env = {
-  port: PROD_API_PORT,
-  cdpPort: COCKPIT_CDP_PORT_DEFAULT,
+  port: CLAW_API_PORT_DEFAULT,
+  cdpPort: CLAW_CDP_PORT_DEFAULT,
   browserosDirOverride: readBrowserosDirOverride(),
   isDevelopment: readIsDevelopment(),
 }

--- a/packages/browseros-agent/apps/claw-server/src/shared/mcp-url.ts
+++ b/packages/browseros-agent/apps/claw-server/src/shared/mcp-url.ts
@@ -11,7 +11,7 @@
  * single-file edit.
  */
 
-import { COCKPIT_MOUNT_PREFIX, PROD_API_PORT } from './port'
+import { CLAW_API_PORT_DEFAULT, COCKPIT_MOUNT_PREFIX } from './port'
 
 /** Path the v2 single MCP route is mounted at, relative to the cockpit prefix. */
 export const MCP_PATH = '/mcp'
@@ -28,6 +28,6 @@ export const BROWSEROS_MCP_SERVER_NAME = 'browseros'
  * server side only ever uses 127.0.0.1; the UI's `mcp-endpoint.ts`
  * resolves alternate bases (dev-launcher overrides, query string).
  */
-export function canonicalMcpUrlForPort(port = PROD_API_PORT): string {
+export function canonicalMcpUrlForPort(port = CLAW_API_PORT_DEFAULT): string {
   return `http://127.0.0.1:${port}${COCKPIT_MOUNT_PREFIX}${MCP_PATH}`
 }

--- a/packages/browseros-agent/apps/claw-server/src/shared/port.ts
+++ b/packages/browseros-agent/apps/claw-server/src/shared/port.ts
@@ -5,22 +5,22 @@
  */
 
 /** Default loopback port for the standalone BrowserClaw API. */
-export const PROD_API_PORT = 9200
+export const CLAW_API_PORT_DEFAULT = 9200
 
 /** Mount prefix the standalone BrowserClaw API serves under. */
 export const COCKPIT_MOUNT_PREFIX = '/cockpit'
 
 /**
- * Default CDP port the cockpit dials when attaching to the BrowserOS
+ * Default CDP port Claw dials when attaching to the BrowserOS
  * Chromium. Lives in IANA's dynamic / private range (49152-65535)
  * so it cannot collide with a registered service, and is not a round
  * number so a hand-rolled local script is unlikely to pick the same
  * value. Override via `BROWSEROS_CLAW_CDP_PORT`.
  *
  * Important: this is the port BrowserOS's Chromium exposes its
- * DevTools on, not a port the cockpit itself opens. Until the
+ * DevTools on, not a port Claw itself opens. Until the
  * BrowserOS browser shell defaults to the same value, the env var
  * is the bridge -- set it to whatever DevTools port BrowserOS is
  * currently bound on.
  */
-export const COCKPIT_CDP_PORT_DEFAULT = 49337
+export const CLAW_CDP_PORT_DEFAULT = 49337

--- a/packages/browseros-agent/apps/claw-server/tests/config.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/config.test.ts
@@ -3,7 +3,10 @@ import { mkdtemp, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { loadClawConfig } from '../src/config'
-import { COCKPIT_CDP_PORT_DEFAULT, PROD_API_PORT } from '../src/shared/port'
+import {
+  CLAW_API_PORT_DEFAULT,
+  CLAW_CDP_PORT_DEFAULT,
+} from '../src/shared/port'
 
 async function writeConfig(contents: string): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), 'claw-config-'))
@@ -19,8 +22,8 @@ describe('loadClawConfig', () => {
     expect(result).toEqual({
       ok: true,
       value: {
-        port: PROD_API_PORT,
-        cdpPort: COCKPIT_CDP_PORT_DEFAULT,
+        port: CLAW_API_PORT_DEFAULT,
+        cdpPort: CLAW_CDP_PORT_DEFAULT,
       },
     })
   })
@@ -164,10 +167,30 @@ ports:
       env: {},
     })
 
-    expect(result).toEqual({
-      ok: false,
-      error: 'Config file error: unknown ports key(s): cdpPort',
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('ports')
+      expect(result.error).toContain('cdpPort')
+    }
+  })
+
+  test('returns a clear error for malformed YAML', async () => {
+    const configPath = await writeConfig(`
+ports:
+  server: [9200
+`)
+
+    const result = loadClawConfig({
+      argv: ['--config', configPath],
+      cwd: '/',
+      env: {},
     })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.error).toContain('Config file error:')
+      expect(result.error).toContain('Flow sequence')
+    }
   })
 
   test('returns a clear error for a missing config file', () => {

--- a/packages/browseros-agent/apps/claw-server/tests/config.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/config.test.ts
@@ -122,6 +122,37 @@ ports:
     })
   })
 
+  test('rejects an explicitly empty --config value', () => {
+    const result = loadClawConfig({
+      argv: ['--config='],
+      cwd: '/',
+      env: {},
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      error: '--config requires a path',
+    })
+  })
+
+  test('rejects a blank --config value instead of falling back to CLAW_CONFIG', async () => {
+    const envConfigPath = await writeConfig(`
+ports:
+  server: 9300
+`)
+
+    const result = loadClawConfig({
+      argv: ['--config', '   '],
+      cwd: '/',
+      env: { CLAW_CONFIG: envConfigPath },
+    })
+
+    expect(result).toEqual({
+      ok: false,
+      error: '--config requires a path',
+    })
+  })
+
   test('returns a clear error for invalid env ports', () => {
     const result = loadClawConfig({
       argv: [],

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -182,6 +182,7 @@
         "@hono/zod-validator": "^0.8.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
         "agent-mcp-manager": "^0.0.1",
+        "commander": "^14.0.3",
         "hono": "^4.12.3",
         "nanoid": "^5.1.11",
         "yaml": "^2.9.0",


### PR DESCRIPTION
## Summary
- remove Claw app extension-port env/launcher wiring and use the Claw-specific CDP env in the Claw app
- rename Claw server default port exports to Claw-specific names across server/UI consumers
- keep YAML config while moving Claw config parsing to Commander + yaml parseDocument + zod validation
- reject explicitly blank --config values before falling back to CLAW_CONFIG/defaults

## Design
Claw config still merges defaults, YAML config, and env overrides through loadClawConfig. Commander owns CLI parsing, yaml parseDocument surfaces YAML parse errors, and zod validates env/file config shape while preserving /cockpit as the current mount prefix.

## Test plan
- [x] bun test apps/claw-server/tests/config.test.ts
- [x] bun run check
- [x] bun run test
- [x] second local review pass clean