### PR TITLE
docs: remove unshipped README features

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,17 +47,12 @@ Use your own API keys or run local models with Ollama. Your data never leaves yo
 |---------|-------------|------|
 | **AI Agent** | 53+ browser automation tools — navigate, click, type, extract data, all with natural language | [Guide](https://docs.browseros.com/getting-started) |
 | **MCP Server** | Control the browser from Claude Code, Gemini CLI, or any MCP client | [Setup](https://docs.browseros.com/features/use-with-claude-code) |
-| **Workflows** | Build repeatable browser automations with a visual graph builder | [Docs](https://docs.browseros.com/features/workflows) |
 | **Cowork** | Combine browser automation with local file operations — research the web, save reports to your folder | [Docs](https://docs.browseros.com/features/cowork) |
 | **Scheduled Tasks** | Run agents on autopilot — daily, hourly, or every few minutes | [Docs](https://docs.browseros.com/features/scheduled-tasks) |
-| **Memory** | Persistent memory across conversations — your assistant remembers context over time | [Docs](https://docs.browseros.com/features/memory) |
-| **SOUL.md** | Define your AI's personality and instructions in a single markdown file | [Docs](https://docs.browseros.com/features/soul-md) |
-| **LLM Hub** | Compare Claude, ChatGPT, and Gemini responses side-by-side on any page | [Docs](https://docs.browseros.com/features/llm-chat-hub) |
-| **40+ App Integrations** | Gmail, Slack, GitHub, Linear, Notion, Figma, Salesforce, and more via MCP | [Docs](https://docs.browseros.com/features/connect-apps) |
+| **40+ App Integrations** | Gmail, Slack, GitHub, Linear, Notion, Figma, Salesforce, and more via MCP | [Docs](https://docs.browseros.com/features/connect-mcps) |
 | **Vertical Tabs** | Side-panel tab management — stay organized even with 100+ tabs open | [Docs](https://docs.browseros.com/features/vertical-tabs) |
 | **Ad Blocking** | uBlock Origin + Manifest V2 support — [10x more protection](https://docs.browseros.com/features/ad-blocking) than Chrome | [Docs](https://docs.browseros.com/features/ad-blocking) |
-| **Cloud Sync** | Sync browser config and agent history across devices | [Docs](https://docs.browseros.com/features/sync) |
-| **Skills** | Custom instruction sets that shape how your AI assistant behaves | [Docs](https://docs.browseros.com/features/skills) |
+| **Cloud Sync** | Sync browser config and agent history across devices | [Docs](https://docs.browseros.com/features/sync-to-cloud) |
 | **Smart Nudges** | Contextual suggestions to connect apps and use features at the right moment | [Docs](https://docs.browseros.com/features/smart-nudges) |
 
 ## Demos

--- a/README.md
+++ b/README.md
@@ -123,7 +123,6 @@ BrowserOS works with any LLM. Bring your own keys, use OAuth, or run models loca
 | Open Source | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |
 | AI Agent | ✅ | ❌ | ❌ | ❌ | ✅ | ✅ |
 | MCP Server | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Visual Workflows | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Cowork (files + browser) | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Scheduled Tasks | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | Bring Your Own Keys | ✅ | ❌ | ✅ | ❌ | ❌ | ❌ |


### PR DESCRIPTION
## Summary
- Remove README feature-table rows for unshipped or docs-deleted surfaces: Workflows, Memory, SOUL.md, LLM Hub, and Skills.
- Remove the stale Visual Workflows comparison claim from the same README.
- Update retained feature links for app integrations and cloud sync to their current docs slugs.

## Design
This is a targeted public-doc cleanup. The README now follows the v0.46.0 changelog and current docs navigation: removed feature pages are no longer advertised, while shipped rows still point at active docs pages.

## Test plan
- [x] git diff --check
- [x] README sweep for removed feature names and stale removed-feature docs links
- [x] bun run check
- [x] bun run test
- [x] sf-review Codex pass: clean after review fix