### PR TITLE
fix: accept Claw MCP URLs in CLI init

### DIFF
--- a/packages/browseros-agent/apps/cli/cmd/init.go
+++ b/packages/browseros-agent/apps/cli/cmd/init.go
@@ -3,13 +3,13 @@ package cmd
 import (
 	"bufio"
 	"fmt"
-	"net/http"
 	"net/url"
 	"os"
 	"strings"
 	"time"
 
 	"browseros-cli/config"
+	"browseros-cli/mcp"
 	"browseros-cli/output"
 
 	"github.com/fatih/color"
@@ -80,18 +80,9 @@ Modes:
 			}
 
 			fmt.Printf("Checking connection to %s ...\n", baseURL)
-			client := &http.Client{Timeout: 5 * time.Second}
-			resp, err := client.Get(baseURL + "/health")
-			if err != nil {
-				output.Errorf(1, "cannot connect to %s: %v\n\n"+
-					"Open BrowserOS Settings > BrowserOS MCP and copy the Server URL.\n"+
-					"Then run: browseros-cli init <Server URL>\n"+
-					"Example:  browseros-cli init http://127.0.0.1:9000/mcp", baseURL, err)
-			}
-			resp.Body.Close()
-
-			if resp.StatusCode >= 400 {
-				output.Errorf(1, "server returned HTTP %d — check the URL", resp.StatusCode)
+			healthClient := mcp.NewClient(baseURL, version, 5*time.Second)
+			if _, err := healthClient.Health(); err != nil {
+				output.Error(err.Error(), 1)
 			}
 
 			cfg := &config.Config{ServerURL: baseURL}

--- a/packages/browseros-agent/apps/cli/cmd/init_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/init_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"browseros-cli/config"
+)
+
+func TestInitCommandAcceptsClawMCPURL(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/health":
+			http.NotFound(w, r)
+		case "/system/health":
+			fmt.Fprint(w, `{"status":"ok"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	cmd, _, err := rootCmd.Find([]string{"init"})
+	if err != nil {
+		t.Fatalf("rootCmd.Find(init) error = %v", err)
+	}
+
+	cmd.Run(cmd, []string{server.URL + "/mcp"})
+
+	cfg, err := config.Load()
+	if err != nil {
+		t.Fatalf("config.Load() error = %v", err)
+	}
+	if cfg.ServerURL != server.URL {
+		t.Fatalf("saved server URL = %q, want %q", cfg.ServerURL, server.URL)
+	}
+}

--- a/packages/browseros-agent/apps/cli/mcp/client.go
+++ b/packages/browseros-agent/apps/cli/mcp/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -136,9 +137,13 @@ func convertResult(r *sdkmcp.CallToolResult) *ToolResult {
 	return result
 }
 
-// Health checks the /health endpoint (REST, not MCP).
+// Health checks BrowserOS-compatible REST health endpoints.
 func (c *Client) Health() (map[string]any, error) {
-	return c.restGET("/health")
+	data, err := c.restGET("/health")
+	if isHTTPStatus(err, http.StatusNotFound) {
+		return c.restGET("/system/health")
+	}
+	return data, err
 }
 
 // Status checks the /status endpoint (REST, not MCP).
@@ -155,7 +160,7 @@ func (c *Client) restGET(path string) (map[string]any, error) {
 
 	if resp.StatusCode >= 400 {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("server returned HTTP %d: %s", resp.StatusCode, string(body))
+		return nil, &restHTTPError{statusCode: resp.StatusCode, body: string(body)}
 	}
 
 	var data map[string]any
@@ -163,6 +168,20 @@ func (c *Client) restGET(path string) (map[string]any, error) {
 		return nil, fmt.Errorf("parse response: %w", err)
 	}
 	return data, nil
+}
+
+type restHTTPError struct {
+	statusCode int
+	body       string
+}
+
+func (e *restHTTPError) Error() string {
+	return fmt.Sprintf("server returned HTTP %d: %s", e.statusCode, e.body)
+}
+
+func isHTTPStatus(err error, statusCode int) bool {
+	var httpErr *restHTTPError
+	return errors.As(err, &httpErr) && httpErr.statusCode == statusCode
 }
 
 // connectionSetupInstructions explains how to recover from a stale or missing server URL.

--- a/packages/browseros-agent/apps/cli/mcp/client_test.go
+++ b/packages/browseros-agent/apps/cli/mcp/client_test.go
@@ -1,0 +1,92 @@
+package mcp
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestHealthUsesBrowserOSHealthEndpoint(t *testing.T) {
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		fmt.Fprint(w, `{"status":"ok","cdpConnected":true}`)
+	}))
+	t.Cleanup(server.Close)
+
+	data, err := NewClient(server.URL, "test", time.Second).Health()
+	if err != nil {
+		t.Fatalf("Health() error = %v", err)
+	}
+	if data["status"] != "ok" {
+		t.Fatalf("Health() status = %v, want ok", data["status"])
+	}
+	assertPaths(t, paths, []string{"/health"})
+}
+
+func TestHealthFallsBackToClawSystemHealthEndpoint(t *testing.T) {
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		switch r.URL.Path {
+		case "/health":
+			http.NotFound(w, r)
+		case "/system/health":
+			fmt.Fprint(w, `{"status":"ok"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	data, err := NewClient(server.URL, "test", time.Second).Health()
+	if err != nil {
+		t.Fatalf("Health() error = %v", err)
+	}
+	if data["status"] != "ok" {
+		t.Fatalf("Health() status = %v, want ok", data["status"])
+	}
+	assertPaths(t, paths, []string{"/health", "/system/health"})
+}
+
+func TestHealthDoesNotFallbackOnBrowserOSHealthFailure(t *testing.T) {
+	var paths []string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		paths = append(paths, r.URL.Path)
+		if r.URL.Path == "/health" {
+			http.Error(w, "boom", http.StatusInternalServerError)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(server.Close)
+
+	_, err := NewClient(server.URL, "test", time.Second).Health()
+	if err == nil {
+		t.Fatal("Health() error = nil, want HTTP 500")
+	}
+	if !strings.Contains(err.Error(), "HTTP 500") {
+		t.Fatalf("Health() error = %q, want HTTP 500", err)
+	}
+	assertPaths(t, paths, []string{"/health"})
+}
+
+func assertPaths(t *testing.T, got, want []string) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("paths = %v, want %v", got, want)
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			t.Fatalf("paths = %v, want %v", got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- accept Claw server MCP URLs in `browseros-cli init` by validating `/system/health` when `/health` is absent
- keep stored server URLs normalized to the base URL without `/mcp`
- keep `browseros-cli health` consistent with init through the shared MCP client health check

## Design
The CLI still normalizes copied MCP URLs to a base URL and the MCP transport still appends `/mcp`. The only changed behavior is REST health validation: `/health` remains the primary probe, and `/system/health` is tried only when `/health` returns 404.

## Test plan
- [x] `cd apps/cli && gofmt -l . && go vet ./... && go build ./... && go test ./...`
- [x] local sf-review subagent: clean
