### PR TITLE
fix: fail CLI releases early on npm token mismatch

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -41,6 +41,21 @@ jobs:
             --repository-root "${{ github.workspace }}"
         working-directory: ${{ github.workspace }}
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Prepare npm package
+        run: make npm-version VERSION=${{ steps.release.outputs.version }}
+
+      - name: Verify npm publish access
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: bun scripts/build/cli/npm-access.ts --package browseros-cli
+        working-directory: packages/browseros-agent
+
       - uses: actions/setup-go@v5
         with:
           go-version-file: packages/browseros-agent/apps/cli/go.mod
@@ -156,16 +171,9 @@ jobs:
           fi
         working-directory: ${{ github.workspace }}
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: "20"
-          registry-url: "https://registry.npmjs.org"
-
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          make npm-version VERSION=${{ steps.release.outputs.version }}
           cd npm
           npm publish --access public

--- a/packages/browseros-agent/apps/cli/README.md
+++ b/packages/browseros-agent/apps/cli/README.md
@@ -91,6 +91,8 @@ git push origin cli/v0.2.3
 
 Pushing `cli/vX.Y.Z` starts the CLI release workflow. The workflow rejects tags that are not newer than production latest or whose target commit is not reachable from the repository default branch.
 
+The `NPM_TOKEN` release secret must authenticate as an npm owner of `browseros-cli`; the workflow checks this before uploading CDN assets or creating the GitHub release.
+
 Inspect versions with:
 
 ```bash

--- a/packages/browseros-agent/apps/cli/npm/package.json
+++ b/packages/browseros-agent/apps/cli/npm/package.json
@@ -20,7 +20,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/browseros-ai/BrowserOS",
+    "url": "git+https://github.com/browseros-ai/BrowserOS.git",
     "directory": "packages/browseros-agent/apps/cli/npm"
   },
   "homepage": "https://browseros.com",

--- a/packages/browseros-agent/scripts/build/cli/npm-access.test.ts
+++ b/packages/browseros-agent/scripts/build/cli/npm-access.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from 'bun:test'
+
+import { verifyNpmPublishAccess } from './npm-access'
+
+describe('verifyNpmPublishAccess', () => {
+  test('accepts an authenticated package owner', () => {
+    const calls: string[][] = []
+    const result = verifyNpmPublishAccess('browseros-cli', (args) => {
+      calls.push(args)
+      if (args[0] === 'whoami') {
+        return 'browseros_eng\n'
+      }
+      if (args.join(' ') === 'owner ls browseros-cli') {
+        return 'browseros_eng <eng@felafax.ai>\nother_owner <owner@example.com>\n'
+      }
+      throw new Error(`unexpected npm args: ${args.join(' ')}`)
+    })
+
+    expect(result).toEqual({
+      packageName: 'browseros-cli',
+      user: 'browseros_eng',
+      owners: ['browseros_eng', 'other_owner'],
+    })
+    expect(calls).toEqual([['whoami'], ['owner', 'ls', 'browseros-cli']])
+  })
+
+  test('rejects a token user that is not a package owner', () => {
+    expect(() =>
+      verifyNpmPublishAccess('browseros-cli', (args) => {
+        if (args[0] === 'whoami') {
+          return 'ci_bot\n'
+        }
+        if (args.join(' ') === 'owner ls browseros-cli') {
+          return 'browseros_eng <eng@felafax.ai>\n'
+        }
+        throw new Error(`unexpected npm args: ${args.join(' ')}`)
+      }),
+    ).toThrow(
+      'NPM_TOKEN authenticates as ci_bot, but browseros-cli owners are: browseros_eng',
+    )
+  })
+
+  test('rejects an unreadable owner list', () => {
+    expect(() =>
+      verifyNpmPublishAccess('browseros-cli', (args) => {
+        if (args[0] === 'whoami') {
+          return 'browseros_eng\n'
+        }
+        if (args.join(' ') === 'owner ls browseros-cli') {
+          return '\n'
+        }
+        throw new Error(`unexpected npm args: ${args.join(' ')}`)
+      }),
+    ).toThrow('No npm owners found for browseros-cli')
+  })
+})

--- a/packages/browseros-agent/scripts/build/cli/npm-access.test.ts
+++ b/packages/browseros-agent/scripts/build/cli/npm-access.test.ts
@@ -13,6 +13,12 @@ describe('verifyNpmPublishAccess', () => {
       if (args.join(' ') === 'owner ls browseros-cli') {
         return 'browseros_eng <eng@felafax.ai>\nother_owner <owner@example.com>\n'
       }
+      if (
+        args.join(' ') ===
+        'access list collaborators browseros-cli browseros_eng --json'
+      ) {
+        return JSON.stringify({ browseros_eng: 'read-write' })
+      }
       throw new Error(`unexpected npm args: ${args.join(' ')}`)
     })
 
@@ -20,8 +26,20 @@ describe('verifyNpmPublishAccess', () => {
       packageName: 'browseros-cli',
       user: 'browseros_eng',
       owners: ['browseros_eng', 'other_owner'],
+      access: 'read-write',
     })
-    expect(calls).toEqual([['whoami'], ['owner', 'ls', 'browseros-cli']])
+    expect(calls).toEqual([
+      ['whoami'],
+      ['owner', 'ls', 'browseros-cli'],
+      [
+        'access',
+        'list',
+        'collaborators',
+        'browseros-cli',
+        'browseros_eng',
+        '--json',
+      ],
+    ])
   })
 
   test('rejects a token user that is not a package owner', () => {
@@ -52,5 +70,25 @@ describe('verifyNpmPublishAccess', () => {
         throw new Error(`unexpected npm args: ${args.join(' ')}`)
       }),
     ).toThrow('No npm owners found for browseros-cli')
+  })
+
+  test('rejects owner tokens without read-write package access', () => {
+    expect(() =>
+      verifyNpmPublishAccess('browseros-cli', (args) => {
+        if (args[0] === 'whoami') {
+          return 'browseros_eng\n'
+        }
+        if (args.join(' ') === 'owner ls browseros-cli') {
+          return 'browseros_eng <eng@felafax.ai>\n'
+        }
+        if (
+          args.join(' ') ===
+          'access list collaborators browseros-cli browseros_eng --json'
+        ) {
+          return JSON.stringify({ browseros_eng: 'read-only' })
+        }
+        throw new Error(`unexpected npm args: ${args.join(' ')}`)
+      }),
+    ).toThrow('does not have read-write access to browseros-cli')
   })
 })

--- a/packages/browseros-agent/scripts/build/cli/npm-access.ts
+++ b/packages/browseros-agent/scripts/build/cli/npm-access.ts
@@ -6,6 +6,7 @@ export interface NpmPublishAccess {
   packageName: string
   user: string
   owners: string[]
+  access: string
 }
 
 type NpmRunner = (args: string[]) => string
@@ -33,7 +34,9 @@ export function verifyNpmPublishAccess(
     )
   }
 
-  return { packageName: normalizedPackageName, user, owners }
+  const access = readCollaboratorAccess(normalizedPackageName, user, runNpm)
+
+  return { packageName: normalizedPackageName, user, owners, access }
 }
 
 function parseNpmOwners(output: string): string[] {
@@ -58,6 +61,53 @@ function runWhoami(runNpm: NpmRunner): string {
     throw new Error('NPM_TOKEN authenticated with npm but returned no username')
   }
   return user
+}
+
+function readCollaboratorAccess(
+  packageName: string,
+  user: string,
+  runNpm: NpmRunner,
+): string {
+  let output: string
+  try {
+    output = runNpm([
+      'access',
+      'list',
+      'collaborators',
+      packageName,
+      user,
+      '--json',
+    ])
+  } catch (error) {
+    throw new Error(
+      `NPM_TOKEN could not read collaborator access for ${packageName}: ${errorMessage(error)}`,
+    )
+  }
+
+  const access = parseCollaboratorAccess(output, user)
+  if (access !== 'read-write') {
+    throw new Error(
+      `NPM_TOKEN authenticates as ${user}, but ${user} does not have read-write access to ${packageName}`,
+    )
+  }
+  return access
+}
+
+function parseCollaboratorAccess(output: string, user: string): string {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(output)
+  } catch {
+    throw new Error(`Could not parse npm collaborator access for ${user}`)
+  }
+
+  if (!parsed || typeof parsed !== 'object') {
+    throw new Error(`No npm collaborator access found for ${user}`)
+  }
+
+  const collaborators = parsed as Record<string, unknown>
+  const access = collaborators[user] ?? collaborators[user.toLowerCase()]
+  return typeof access === 'string' ? access : ''
 }
 
 function runNpmCommand(args: string[]): string {

--- a/packages/browseros-agent/scripts/build/cli/npm-access.ts
+++ b/packages/browseros-agent/scripts/build/cli/npm-access.ts
@@ -1,0 +1,112 @@
+#!/usr/bin/env bun
+
+import { execFileSync } from 'node:child_process'
+
+export interface NpmPublishAccess {
+  packageName: string
+  user: string
+  owners: string[]
+}
+
+type NpmRunner = (args: string[]) => string
+
+/** Confirms the configured npm token belongs to a package owner before release side effects. */
+export function verifyNpmPublishAccess(
+  packageName: string,
+  runNpm: NpmRunner = runNpmCommand,
+): NpmPublishAccess {
+  const normalizedPackageName = packageName.trim()
+  if (!normalizedPackageName) {
+    throw new Error('Missing npm package name')
+  }
+
+  const user = runWhoami(runNpm)
+  const owners = parseNpmOwners(runNpm(['owner', 'ls', normalizedPackageName]))
+
+  if (owners.length === 0) {
+    throw new Error(`No npm owners found for ${normalizedPackageName}`)
+  }
+
+  if (!owners.includes(user)) {
+    throw new Error(
+      `NPM_TOKEN authenticates as ${user}, but ${normalizedPackageName} owners are: ${owners.join(', ')}. Use a token for a listed owner or add ${user} as an owner before releasing.`,
+    )
+  }
+
+  return { packageName: normalizedPackageName, user, owners }
+}
+
+function parseNpmOwners(output: string): string[] {
+  return output
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => line.split(/\s+/)[0])
+    .filter(Boolean)
+}
+
+function runWhoami(runNpm: NpmRunner): string {
+  let user: string
+  try {
+    user = runNpm(['whoami']).trim()
+  } catch (error) {
+    throw new Error(
+      `NPM_TOKEN could not authenticate with npm: ${errorMessage(error)}`,
+    )
+  }
+  if (!user) {
+    throw new Error('NPM_TOKEN authenticated with npm but returned no username')
+  }
+  return user
+}
+
+function runNpmCommand(args: string[]): string {
+  return execFileSync('npm', args, {
+    encoding: 'utf-8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  }).trim()
+}
+
+function parseArgs(args: string[]): { packageName: string } {
+  let packageName = 'browseros-cli'
+
+  for (let index = 0; index < args.length; index += 1) {
+    const raw = args[index]
+    if (raw !== '--package') {
+      throw new Error(`Unexpected argument ${raw}`)
+    }
+    const value = args[index + 1]
+    if (!value || value.startsWith('--')) {
+      throw new Error('Missing value for --package')
+    }
+    packageName = value
+    index += 1
+  }
+
+  return { packageName }
+}
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    const stderr = 'stderr' in error ? String(error.stderr).trim() : ''
+    return stderr || error.message
+  }
+  return String(error)
+}
+
+function main(): void {
+  const { packageName } = parseArgs(process.argv.slice(2))
+  const access = verifyNpmPublishAccess(packageName)
+  console.log(
+    `Validated npm publish access for ${access.packageName}: ${access.user}`,
+  )
+}
+
+if (import.meta.main) {
+  try {
+    main()
+  } catch (error) {
+    console.error(`::error::${errorMessage(error)}`)
+    process.exit(1)
+  }
+}


### PR DESCRIPTION
## Summary
- Add a tested npm publish-access preflight for `browseros-cli` that checks the token user and read-write collaborator access.
- Run Node setup, `make npm-version`, and the npm preflight before CDN upload or GitHub release creation.
- Normalize the npm package repository URL and document the `NPM_TOKEN` ownership requirement.

## Design
The release still publishes npm after GitHub release assets exist, so npm postinstall can fetch the matching `cli/vX.Y.Z` binaries. The new preflight catches bad npm credentials before those public release side effects.

## Test plan
- [x] `bun test scripts/build/cli/npm-access.test.ts scripts/build/cli/release-policy.test.ts`
- [x] `actionlint ../../.github/workflows/release-cli.yml`
- [x] `bun run check` (exit 0; existing Claw warnings still printed)
- [x] `cd apps/cli && gofmt -l . && go vet ./... && go build ./... && go test ./...`
- [x] temp `browseros-cli@0.3.1` `npm publish --dry-run --access public`

## Note
The existing failed `cli/v0.3.1` tag run still needs a valid npm token with `browseros-cli` read-write access; this PR prevents future runs from discovering that only after partial release side effects.