### PR TITLE
fix: remove fake window chrome from claw-onboard, fill popup

### DIFF
--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.test.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.test.tsx
@@ -62,9 +62,10 @@ describe('OnboardingV2 shell', () => {
     expect(html).toContain('Under your control')
   })
 
-  it('renders the macwin chrome bar title', () => {
+  it('does not render the fake macOS window chrome', () => {
     const html = renderApp()
-    expect(html).toContain('Welcome to BrowserOS')
+    expect(html).not.toContain('Welcome to BrowserOS')
+    expect(html).not.toContain('#FF5F57')
   })
 
   it('renders four step dots', () => {

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.test.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.test.tsx
@@ -62,8 +62,10 @@ describe('OnboardingV2 shell', () => {
     expect(html).toContain('Under your control')
   })
 
-  it('does not render the fake macOS window chrome', () => {
+  it('renders a full-page main landmark without the fake macOS window chrome', () => {
     const html = renderApp()
+    expect(html).toContain('<main')
+    expect(html).not.toContain('role="dialog"')
     expect(html).not.toContain('Welcome to BrowserOS')
     expect(html).not.toContain('#FF5F57')
   })

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/OnboardingShell.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/OnboardingShell.tsx
@@ -8,39 +8,20 @@ interface OnboardingShellProps {
   children: ReactNode
 }
 
-/** Provides the shared window frame, visual rail, and step progress chrome. */
+/** Full-bleed onboarding frame: visual rail + scrollable step column, sized to fill the embedded popup viewport. */
 export function OnboardingShell({
   step,
   totalSteps,
   children,
 }: OnboardingShellProps) {
   return (
-    <div className="flex min-h-screen items-center justify-center bg-bg-canvas p-6">
-      <div
-        className="flex h-[720px] w-full max-w-[1040px] flex-col overflow-hidden rounded-2xl border border-border-2 bg-bg-canvas shadow-2xl"
-        role="dialog"
-        aria-label="BrowserOS onboarding"
-      >
-        <div className="flex h-11 items-center border-border border-b bg-bg-canvas px-4">
-          <div className="flex items-center gap-1.5">
-            <span aria-hidden className="size-3 rounded-full bg-[#FF5F57]" />
-            <span aria-hidden className="size-3 rounded-full bg-[#FEBC2E]" />
-            <span aria-hidden className="size-3 rounded-full bg-[#28C840]" />
-          </div>
-          <div className="flex-1 text-center font-semibold text-[12.5px] text-ink-3">
-            Welcome to BrowserOS
-          </div>
-          <div className="w-[52px]" />
+    <div className="flex h-screen overflow-hidden bg-bg-canvas">
+      <VisualRail />
+      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-12 pt-11 pb-10">
+        <div className="mb-[30px]">
+          <StepDots step={step} total={totalSteps} />
         </div>
-        <div className="flex min-h-0 flex-1">
-          <VisualRail />
-          <div className="scroll flex flex-1 flex-col overflow-y-auto px-12 pt-11 pb-10">
-            <div className="mb-[30px]">
-              <StepDots step={step} total={totalSteps} />
-            </div>
-            {children}
-          </div>
-        </div>
+        {children}
       </div>
     </div>
   )

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/OnboardingShell.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/OnboardingShell.tsx
@@ -17,12 +17,12 @@ export function OnboardingShell({
   return (
     <div className="flex h-screen overflow-hidden bg-bg-canvas">
       <VisualRail />
-      <div className="flex min-h-0 flex-1 flex-col overflow-y-auto px-12 pt-11 pb-10">
+      <main className="flex min-h-0 flex-1 flex-col overflow-y-auto px-12 pt-11 pb-10">
         <div className="mb-[30px]">
           <StepDots step={step} total={totalSteps} />
         </div>
         {children}
-      </div>
+      </main>
     </div>
   )
 }

--- a/packages/browseros-agent/apps/claw-onboard/src/styles.css
+++ b/packages/browseros-agent/apps/claw-onboard/src/styles.css
@@ -102,19 +102,7 @@ body,
 body {
   color: var(--color-foreground);
   font-family: var(--font-sans);
-  background:
-    radial-gradient(
-      1200px 700px at 18% -8%,
-      hsl(160 12% 91%) 0%,
-      hsl(160 12% 91% / 0) 60%
-    ),
-    radial-gradient(
-      1000px 800px at 100% 110%,
-      hsl(35 25% 90%) 0%,
-      hsl(35 25% 90% / 0) 55%
-    ),
-    linear-gradient(155deg, hsl(170 10% 88%) 0%, hsl(35 18% 89%) 100%);
-  background-attachment: fixed;
+  background: var(--color-bg-canvas);
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
 }


### PR DESCRIPTION
## Summary
- The standalone `claw-onboard` app embeds directly into Chromium as the popup/page, so the simulated macOS-window shell was wrong. Removed the fake chrome: traffic-light title bar, centered "Welcome to BrowserOS" caption, and the fixed-size (`h-[720px] max-w-[1040px]`) rounded/shadowed floating card.
- Reframed `OnboardingShell` to a full-viewport flex row so the visual rail + step column fill the **full popup width and height**; the step column scrolls internally (`min-h-0 overflow-y-auto`) while the page itself never scrolls (`h-screen overflow-hidden`).
- Flattened the body background from the desktop-mimicking gradient (which only sat behind the fake window) to the flat canvas color, avoiding a load-time flash.

## Design
The fake shell was entirely contained in `OnboardingShell.tsx` as two outer wrapper layers (centering + fixed card) plus a title bar around the real content row. The change deletes those and promotes the rail + step column to the root, preserving the existing two-column layout, every step component, copy, and the rail unchanged — this is a framing change, not a redesign. Now that it's a full page (not a modal), `role="dialog"` is dropped and the scrollable step column is marked as the page's `<main>` landmark.

## Test plan
- [x] `bun test` (claw-onboard) — 32 pass / 0 fail; the old chrome-bar test is replaced with a guard asserting the `<main>` landmark and the absence of the dialog chrome (`role="dialog"`, the caption, the traffic-light color).
- [x] `bun run lint` + `bun run typecheck` — clean.
- [x] `bun run build` (tsc + vite) — builds clean.
- [x] Visual check via puppeteer at 1000×680 and 760×600 (Welcome + Import steps): no traffic lights, no title bar, no floating card; rail + content fill the popup; content scrolls internally.

## Notes
- `bun run check`'s **fallow** step reports a pre-existing monorepo-wide dead-code backlog (353 issues, all in untouched `apps/claw-app` & `apps/claw-server`; 3 suppressions already in place). This change adds **zero** fallow issues in `claw-onboard` — lint, typecheck, test, and build are all green.
- Out of scope (non-goals): rail redesign, responsive/mobile breakpoints, Chromium-side embedding wiring, and the rail's "Mac · v1.0 · signed build" footer.