### PR TITLE
feat: add claw chromium resource build

### DIFF
--- a/packages/browseros-agent/apps/claw-onboard/package.json
+++ b/packages/browseros-agent/apps/claw-onboard/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc --noEmit && vite build",
+    "build:chromium": "tsc --noEmit && vite build --mode chromium && bun scripts/verify-chromium-build.ts",
     "preview": "vite preview",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
@@ -16,9 +17,6 @@
   "dependencies": {
     "@base-ui/react": "^1.5.0",
     "@browseros/claw-server": "workspace:*",
-    "@fontsource-variable/jetbrains-mono": "^5.2.5",
-    "@fontsource-variable/schibsted-grotesk": "^5.2.5",
-    "@fontsource/newsreader": "^5.2.5",
     "@hookform/resolvers": "^5.4.0",
     "@tabler/icons-react": "^3.34.1",
     "class-variance-authority": "^0.7.1",

--- a/packages/browseros-agent/apps/claw-onboard/scripts/verify-chromium-build.ts
+++ b/packages/browseros-agent/apps/claw-onboard/scripts/verify-chromium-build.ts
@@ -7,15 +7,15 @@ const fontAssetPattern = /\.(?:woff2?|ttf|otf)$/i
 const hashedCoreAssetPattern = /\b(?:app|index)-[A-Za-z0-9_-]{6,}\.(?:css|js)\b/
 const dataUrlPattern = /\bdata:(?:[a-z][\w.+-]*\/[a-z0-9.+-]+|;base64|,)/i
 const remoteUrlPattern = /https?:\/\/[^\s"'<>\\)]+/g
-const expectedRuntimeUrlPrefixes = [
-  'http://127.0.0.1:',
-  'http://localhost',
-  'http://www.w3.org/',
-  'http://json-schema.org/',
-  'https://base-ui.com/production-error',
-  'https://json-schema.org/',
-  'https://react.dev/errors/',
-  'https://reactrouter.com/',
+const expectedRuntimeUrlPatterns = [
+  /^http:\/\/127\.0\.0\.1:(?:\d+|\$\{[$A-Z_a-z][\w$]*\})(?:$|[^\w./:-])/,
+  /^http:\/\/localhost(?::\d+)?(?:$|[/?#])/,
+  /^http:\/\/www\.w3\.org\/(?:1998\/Math\/MathML|1999\/xlink|2000\/svg|XML\/1998\/namespace)$/,
+  /^http:\/\/json-schema\.org\/draft-(?:04|07)\/schema#$/,
+  /^https:\/\/base-ui\.com\/production-error$/,
+  /^https:\/\/json-schema\.org\/draft\/2020-12\/schema$/,
+  /^https:\/\/react\.dev\/errors\/$/,
+  /^https:\/\/reactrouter\.com\/en\/main\/routers\/picking-a-router\.(?:$|[^\w./:-])/,
 ]
 
 function fail(message: string): never {
@@ -56,7 +56,7 @@ async function readResource(file: string): Promise<string> {
 }
 
 function isExpectedRuntimeUrl(url: string): boolean {
-  return expectedRuntimeUrlPrefixes.some((prefix) => url.startsWith(prefix))
+  return expectedRuntimeUrlPatterns.some((pattern) => pattern.test(url))
 }
 
 function verifyIndexReferences(indexHtml: string) {

--- a/packages/browseros-agent/apps/claw-onboard/scripts/verify-chromium-build.ts
+++ b/packages/browseros-agent/apps/claw-onboard/scripts/verify-chromium-build.ts
@@ -8,13 +8,13 @@ const hashedCoreAssetPattern = /\b(?:app|index)-[A-Za-z0-9_-]{6,}\.(?:css|js)\b/
 const dataUrlPattern = /\bdata:(?:[a-z][\w.+-]*\/[a-z0-9.+-]+|;base64|,)/i
 const remoteUrlPattern = /https?:\/\/[^\s"'<>\\)]+/g
 const expectedRuntimeUrlPatterns = [
-  /^http:\/\/127\.0\.0\.1:(?:\d+|\$\{[$A-Z_a-z][\w$]*\})(?:$|[^\w./:?#-])/,
-  /^http:\/\/localhost(?::\d+)?(?:$|[^\w./:?#-])/,
+  /^http:\/\/127\.0\.0\.1:(?:\d+|\$\{[$A-Z_a-z][\w$]*\})(?:$|\/mcp(?:$|[^\w./:?#-])|[^\w./:?#-])/,
+  /^http:\/\/localhost(?::\d+)?(?:$|\/mcp(?:$|[^\w./:?#-])|[^\w./:?#-])/,
   /^http:\/\/www\.w3\.org\/(?:1998\/Math\/MathML|1999\/xlink|2000\/svg|XML\/1998\/namespace)$/,
   /^http:\/\/json-schema\.org\/draft-(?:04|07)\/schema#$/,
   /^https:\/\/base-ui\.com\/production-error$/,
   /^https:\/\/json-schema\.org\/draft\/2020-12\/schema$/,
-  /^https:\/\/react\.dev\/errors\/$/,
+  /^https:\/\/react\.dev\/errors\/(?:[A-Za-z0-9_-]+)?$/,
   /^https:\/\/reactrouter\.com\/en\/main\/routers\/picking-a-router\.(?:$|[^\w./:-])/,
 ]
 

--- a/packages/browseros-agent/apps/claw-onboard/scripts/verify-chromium-build.ts
+++ b/packages/browseros-agent/apps/claw-onboard/scripts/verify-chromium-build.ts
@@ -8,8 +8,8 @@ const hashedCoreAssetPattern = /\b(?:app|index)-[A-Za-z0-9_-]{6,}\.(?:css|js)\b/
 const dataUrlPattern = /\bdata:(?:[a-z][\w.+-]*\/[a-z0-9.+-]+|;base64|,)/i
 const remoteUrlPattern = /https?:\/\/[^\s"'<>\\)]+/g
 const expectedRuntimeUrlPatterns = [
-  /^http:\/\/127\.0\.0\.1:(?:\d+|\$\{[$A-Z_a-z][\w$]*\})(?:$|[^\w./:-])/,
-  /^http:\/\/localhost(?::\d+)?(?:$|[/?#])/,
+  /^http:\/\/127\.0\.0\.1:(?:\d+|\$\{[$A-Z_a-z][\w$]*\})(?:$|[^\w./:?#-])/,
+  /^http:\/\/localhost(?::\d+)?(?:$|[^\w./:?#-])/,
   /^http:\/\/www\.w3\.org\/(?:1998\/Math\/MathML|1999\/xlink|2000\/svg|XML\/1998\/namespace)$/,
   /^http:\/\/json-schema\.org\/draft-(?:04|07)\/schema#$/,
   /^https:\/\/base-ui\.com\/production-error$/,

--- a/packages/browseros-agent/apps/claw-onboard/scripts/verify-chromium-build.ts
+++ b/packages/browseros-agent/apps/claw-onboard/scripts/verify-chromium-build.ts
@@ -1,0 +1,89 @@
+import { readdir, readFile } from 'node:fs/promises'
+import path from 'node:path'
+
+const buildDir = path.resolve(import.meta.dir, '../dist/chromium')
+const allowedFiles = new Set(['app.css', 'app.js', 'index.html'])
+const fontAssetPattern = /\.(?:woff2?|ttf|otf)$/i
+const hashedCoreAssetPattern = /\b(?:app|index)-[A-Za-z0-9_-]{6,}\.(?:css|js)\b/
+const dataUrlPattern = /\bdata:(?:[a-z][\w.+-]*\/[a-z0-9.+-]+|;base64|,)/i
+const remoteUrlPattern = /https?:\/\/[^\s"'<>\\)]+/g
+
+function fail(message: string): never {
+  throw new Error(`Chromium build verification failed: ${message}`)
+}
+
+async function listResourceFiles(dir: string, prefix = ''): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true })
+  const files: string[] = []
+
+  for (const entry of entries) {
+    const relativePath = prefix ? `${prefix}/${entry.name}` : entry.name
+    if (entry.isDirectory()) {
+      if (relativePath === 'assets') fail('dist/chromium/assets was emitted')
+      fail(`unexpected directory emitted: ${relativePath}`)
+    }
+    files.push(relativePath)
+  }
+
+  return files.sort()
+}
+
+function verifyFileList(files: string[]) {
+  for (const expected of allowedFiles) {
+    if (!files.includes(expected)) fail(`missing ${expected}`)
+  }
+
+  for (const file of files) {
+    if (!allowedFiles.has(file)) fail(`unexpected file emitted: ${file}`)
+    if (fontAssetPattern.test(file)) fail(`font asset emitted: ${file}`)
+    if (hashedCoreAssetPattern.test(file))
+      fail(`hashed core resource emitted: ${file}`)
+  }
+}
+
+async function readResource(file: string): Promise<string> {
+  return readFile(path.join(buildDir, file), 'utf8')
+}
+
+function verifyIndexReferences(indexHtml: string) {
+  const hasCss =
+    /<link\b(?=[^>]*\brel=["']stylesheet["'])(?=[^>]*\bhref=["']\.\/app\.css["'])[^>]*>/i.test(
+      indexHtml,
+    )
+  const hasJs = /<script\b(?=[^>]*\bsrc=["']\.\/app\.js["'])[^>]*>/i.test(
+    indexHtml,
+  )
+
+  if (!hasCss) fail('index.html does not reference ./app.css')
+  if (!hasJs) fail('index.html does not reference ./app.js')
+}
+
+function verifyResourceContents(file: string, contents: string) {
+  if (dataUrlPattern.test(contents)) fail(`${file} contains a data: URL`)
+  if (contents.includes('assets/')) fail(`${file} references assets/`)
+  if (hashedCoreAssetPattern.test(contents)) {
+    fail(`${file} references a hashed core resource`)
+  }
+
+  if (file !== 'app.js') {
+    const remoteUrls = contents.match(remoteUrlPattern) ?? []
+    if (remoteUrls.length > 0) {
+      fail(`${file} references remote URLs: ${remoteUrls.join(', ')}`)
+    }
+  }
+}
+
+/** Enforces the three-file Chromium WebUI resource contract. */
+async function main() {
+  const files = await listResourceFiles(buildDir)
+  verifyFileList(files)
+
+  const indexHtml = await readResource('index.html')
+  verifyIndexReferences(indexHtml)
+
+  for (const file of files) {
+    verifyResourceContents(file, await readResource(file))
+  }
+}
+
+await main()

--- a/packages/browseros-agent/apps/claw-onboard/scripts/verify-chromium-build.ts
+++ b/packages/browseros-agent/apps/claw-onboard/scripts/verify-chromium-build.ts
@@ -7,6 +7,16 @@ const fontAssetPattern = /\.(?:woff2?|ttf|otf)$/i
 const hashedCoreAssetPattern = /\b(?:app|index)-[A-Za-z0-9_-]{6,}\.(?:css|js)\b/
 const dataUrlPattern = /\bdata:(?:[a-z][\w.+-]*\/[a-z0-9.+-]+|;base64|,)/i
 const remoteUrlPattern = /https?:\/\/[^\s"'<>\\)]+/g
+const expectedRuntimeUrlPrefixes = [
+  'http://127.0.0.1:',
+  'http://localhost',
+  'http://www.w3.org/',
+  'http://json-schema.org/',
+  'https://base-ui.com/production-error',
+  'https://json-schema.org/',
+  'https://react.dev/errors/',
+  'https://reactrouter.com/',
+]
 
 function fail(message: string): never {
   throw new Error(`Chromium build verification failed: ${message}`)
@@ -45,6 +55,10 @@ async function readResource(file: string): Promise<string> {
   return readFile(path.join(buildDir, file), 'utf8')
 }
 
+function isExpectedRuntimeUrl(url: string): boolean {
+  return expectedRuntimeUrlPrefixes.some((prefix) => url.startsWith(prefix))
+}
+
 function verifyIndexReferences(indexHtml: string) {
   const hasCss =
     /<link\b(?=[^>]*\brel=["']stylesheet["'])(?=[^>]*\bhref=["']\.\/app\.css["'])[^>]*>/i.test(
@@ -65,11 +79,10 @@ function verifyResourceContents(file: string, contents: string) {
     fail(`${file} references a hashed core resource`)
   }
 
-  if (file !== 'app.js') {
-    const remoteUrls = contents.match(remoteUrlPattern) ?? []
-    if (remoteUrls.length > 0) {
-      fail(`${file} references remote URLs: ${remoteUrls.join(', ')}`)
-    }
+  const remoteUrls = contents.match(remoteUrlPattern) ?? []
+  const unexpectedUrls = remoteUrls.filter((url) => !isExpectedRuntimeUrl(url))
+  if (unexpectedUrls.length > 0) {
+    fail(`${file} references remote URLs: ${unexpectedUrls.join(', ')}`)
   }
 }
 

--- a/packages/browseros-agent/apps/claw-onboard/src/main.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/main.tsx
@@ -1,8 +1,3 @@
-import '@fontsource-variable/schibsted-grotesk'
-import '@fontsource/newsreader/400-italic.css'
-import '@fontsource/newsreader/500-italic.css'
-import '@fontsource-variable/jetbrains-mono'
-
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router'

--- a/packages/browseros-agent/apps/claw-onboard/src/styles.css
+++ b/packages/browseros-agent/apps/claw-onboard/src/styles.css
@@ -42,9 +42,10 @@
   --color-red: hsl(4 56% 50%);
   --color-red-tint: hsl(4 65% 95%);
   --color-blue: hsl(217 75% 53%);
-  --font-sans: "Schibsted Grotesk Variable", system-ui, sans-serif;
-  --font-serif: "Newsreader", Georgia, serif;
-  --font-mono: "JetBrains Mono Variable", ui-monospace, monospace;
+  --font-sans:
+    system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  --font-serif: Georgia, "Times New Roman", serif;
+  --font-mono: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
   --shadow-card:
     0 1px 2px hsl(35 35% 12% / 0.04), 0 1px 3px hsl(35 35% 12% / 0.03);
   --shadow-pop:

--- a/packages/browseros-agent/apps/claw-onboard/vite.config.ts
+++ b/packages/browseros-agent/apps/claw-onboard/vite.config.ts
@@ -3,11 +3,40 @@ import tailwindcss from '@tailwindcss/vite'
 import react from '@vitejs/plugin-react'
 import { defineConfig } from 'vite'
 
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
-  resolve: {
-    alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url)),
+export default defineConfig(({ mode }) => {
+  const isChromiumBuild = mode === 'chromium'
+
+  return {
+    base: isChromiumBuild ? './' : undefined,
+    plugins: [react(), tailwindcss()],
+    resolve: {
+      alias: {
+        '@': fileURLToPath(new URL('./src', import.meta.url)),
+      },
     },
-  },
+    build: isChromiumBuild
+      ? {
+          outDir: 'dist/chromium',
+          emptyOutDir: true,
+          assetsDir: '.',
+          cssCodeSplit: false,
+          modulePreload: { polyfill: false },
+          assetsInlineLimit: 0,
+          rollupOptions: {
+            output: {
+              entryFileNames: 'app.js',
+              chunkFileNames: 'app.js',
+              inlineDynamicImports: true,
+              assetFileNames: (assetInfo) => {
+                const name = assetInfo.names[0] ?? ''
+                if (name.endsWith('.css')) return 'app.css'
+                throw new Error(
+                  `Unexpected Chromium resource asset emitted: ${name}`,
+                )
+              },
+            },
+          },
+        }
+      : undefined,
+  }
 })

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -179,9 +179,6 @@
       "dependencies": {
         "@base-ui/react": "^1.5.0",
         "@browseros/claw-server": "workspace:*",
-        "@fontsource-variable/jetbrains-mono": "^5.2.5",
-        "@fontsource-variable/schibsted-grotesk": "^5.2.5",
-        "@fontsource/newsreader": "^5.2.5",
         "@hookform/resolvers": "^5.4.0",
         "@tabler/icons-react": "^3.34.1",
         "class-variance-authority": "^0.7.1",


### PR DESCRIPTION
## Summary
- Adds `build:chromium` for `@browseros/claw-onboard`, producing a deterministic Vite-built WebUI bundle at `dist/chromium/index.html`, `app.css`, and `app.js`.
- Removes claw-onboard custom font imports/dependencies and switches theme font variables to system stacks so no font files ship in the Chromium resource output.
- Adds a strict verifier for the Chromium bundle: exact three-file output, relative HTML references, no fonts, no nested `assets/`, no hashed core resource refs, no data URLs, and no unexpected remote URLs.

## Design
The app remains a normal Vite/React app. `vite build --mode chromium` selects a Chromium-oriented build profile with `base: './'`, `dist/chromium`, single CSS output, module preload polyfill disabled, no asset inlining, and fixed `app.js` / `app.css` filenames. The verifier enforces the Chromium packaging contract after Vite builds so future asset additions have to be intentional.

## Test plan
- [x] `cd apps/claw-onboard && bun install`
- [x] `cd apps/claw-onboard && bun run lint`
- [x] `cd apps/claw-onboard && bun run typecheck`
- [x] `cd apps/claw-onboard && bun run test`
- [x] `cd apps/claw-onboard && bun run build`
- [x] `cd apps/claw-onboard && bun run build:chromium`
- [x] `cd apps/claw-onboard && find dist/chromium -maxdepth 2 -print | sort`
- [x] loopback URL bypass checks for verifier regexes
- [x] `bun run check`
- [x] `bun run test`

## Notes
- `bun run check` exits 0 but still prints existing unrelated Biome/fallow warnings in claw-server/claw-app surfaces.
- `bun.lock` still contains fontsource package records because `apps/claw-app` still depends on those fonts; the claw-onboard dependency edge is removed.