### PR TITLE
feat(cockpit): live screencast thumbnails on Running-now homepage cards

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/cockpit/AgentRunningCard.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/AgentRunningCard.tsx
@@ -41,7 +41,11 @@ export function AgentRunningCard({
       className="group flex cursor-pointer flex-col overflow-hidden border-border-2 border-l-4 p-0 transition hover:border-border-strong hover:shadow-card"
       style={{ borderLeftColor: agent.color }}
     >
-      <MiniScreencast site={siteOf(focus.url)} live={active} />
+      <MiniScreencast
+        site={siteOf(focus.url)}
+        live={active}
+        screencast={focus.screencast}
+      />
       <div className="flex flex-1 flex-col gap-2 p-3.5">
         <div className="flex items-center gap-2">
           <span className="min-w-0 flex-1 truncate font-bold text-[13.5px]">

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/MiniScreencast.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/MiniScreencast.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { MiniScreencast } from './MiniScreencast'
+
+describe('MiniScreencast', () => {
+  it('renders the placeholder globe + host when no screencast is supplied', () => {
+    const html = renderToStaticMarkup(<MiniScreencast site="example.com" />)
+    expect(html).toContain('example.com')
+    expect(html).not.toContain('data:image/jpeg;base64,')
+  })
+
+  it('renders the JPEG when a screencast frame is supplied', () => {
+    const html = renderToStaticMarkup(
+      <MiniScreencast
+        site="example.com"
+        screencast={{ jpegBase64: 'AAAA', capturedAt: 1 }}
+      />,
+    )
+    expect(html).toContain('data:image/jpeg;base64,AAAA')
+    expect(html).toContain('decoding="async"')
+    expect(html).toContain('Live view of example.com')
+  })
+
+  it('falls back to placeholder when screencast is null', () => {
+    const html = renderToStaticMarkup(
+      <MiniScreencast site="example.com" screencast={null} />,
+    )
+    expect(html).not.toContain('data:image/jpeg;base64,')
+    expect(html).toContain('example.com')
+  })
+
+  it('shows the live dot when live=true', () => {
+    const html = renderToStaticMarkup(
+      <MiniScreencast site="example.com" live />,
+    )
+    expect(html).toMatch(/animate-pulse-dot/)
+  })
+
+  it('does not show the live dot when live is false', () => {
+    const html = renderToStaticMarkup(<MiniScreencast site="example.com" />)
+    expect(html).not.toMatch(/animate-pulse-dot/)
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/MiniScreencast.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/MiniScreencast.test.tsx
@@ -23,7 +23,6 @@ describe('MiniScreencast', () => {
       />,
     )
     expect(html).toContain('data:image/jpeg;base64,AAAA')
-    expect(html).toContain('decoding="async"')
     expect(html).toContain('Live view of example.com')
   })
 

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/MiniScreencast.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/MiniScreencast.tsx
@@ -1,31 +1,64 @@
 import { Globe } from 'lucide-react'
 import { cn } from '@/lib/utils'
+import type { ScreencastFrame } from '@/modules/api/tabs.hooks'
 
 interface MiniScreencastProps {
   site: string
   live?: boolean
+  /**
+   * Latest poller frame for this page. When present the component
+   * renders the JPEG as the card top; when null/undefined the
+   * placeholder globe + host tile is shown. The container has a
+   * fixed height either way so the card never shifts as frames
+   * appear or disappear.
+   */
+  screencast?: ScreencastFrame | null
 }
 
 /**
- * Placeholder card-top "screencast" tile. The vision plan calls for a
- * live thumbnail of the actual page the agent is on; until the
- * recording pipeline lands, we show a tinted block with the site
- * host and a small globe so the card has weight and the site
- * identity reads at a glance. The `live` flag adds a pulsing dot
- * top-right matching the design's running indicator.
+ * Card-top tile on the Running-now homepage cards. Renders the live
+ * screencast JPEG from the background poller when available; falls
+ * back to a tinted block with the site host and a small globe when
+ * the cache is cold or the page is in failure backoff.
+ *
+ * The `live` flag adds a pulsing dot top-right matching the design's
+ * running indicator. The dot gets a translucent ring so it reads
+ * against busy thumbnails.
  */
-export function MiniScreencast({ site, live }: MiniScreencastProps) {
+export function MiniScreencast({
+  site,
+  live,
+  screencast,
+}: MiniScreencastProps) {
+  const hasFrame =
+    screencast !== null &&
+    screencast !== undefined &&
+    screencast.jpegBase64.length > 0
   return (
-    <div className="relative flex h-[132px] items-center justify-center bg-bg-sunken">
-      <div className="flex flex-col items-center gap-1.5 text-ink-3">
-        <Globe className="size-7" />
-        <code className="font-mono text-[11px] text-ink-2">{site}</code>
-      </div>
+    <div className="relative flex h-[132px] items-center justify-center overflow-hidden bg-bg-sunken">
+      {hasFrame ? (
+        <img
+          src={`data:image/jpeg;base64,${screencast.jpegBase64}`}
+          alt={`Live view of ${site}`}
+          className="h-full w-full object-cover"
+          // Decode off the main thread so a slow decode does not
+          // stall the homepage's 1.5s poll cycle.
+          decoding="async"
+        />
+      ) : (
+        <div className="flex flex-col items-center gap-1.5 text-ink-3">
+          <Globe className="size-7" />
+          <code className="font-mono text-[11px] text-ink-2">{site}</code>
+        </div>
+      )}
       {live && (
         <span
           aria-hidden
           className={cn(
             'absolute top-2.5 right-2.5 size-2 animate-pulse-dot rounded-full bg-green',
+            // Translucent ring so the dot stays readable against busy
+            // live thumbnails.
+            'ring-2 ring-bg-canvas/70',
           )}
         />
       )}

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/MiniScreencast.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/MiniScreencast.tsx
@@ -84,6 +84,14 @@ export function MiniScreencast({
           src={displayedSrc}
           alt={`Live view of ${site}`}
           className="h-full w-full object-cover"
+          // Catches corruption that slipped past the off-screen
+          // pre-decode (most relevant on initial mount, where
+          // displayedSrc is seeded directly from incomingSrc
+          // without going through the Image() decode gate).
+          // Falling back to null here re-renders into the globe
+          // placeholder so the operator never sees a browser
+          // broken-image icon.
+          onError={() => setDisplayedSrc(null)}
         />
       ) : (
         <div className="flex flex-col items-center gap-1.5 text-ink-3">

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/MiniScreencast.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/MiniScreencast.tsx
@@ -1,4 +1,5 @@
 import { Globe } from 'lucide-react'
+import { useEffect, useState } from 'react'
 import { cn } from '@/lib/utils'
 import type { ScreencastFrame } from '@/modules/api/tabs.hooks'
 
@@ -21,6 +22,15 @@ interface MiniScreencastProps {
  * back to a tinted block with the site host and a small globe when
  * the cache is cold or the page is in failure backoff.
  *
+ * Flicker-free frame swap: every time `screencast.capturedAt` ticks
+ * we kick off an off-screen `new Image()` to pre-decode the next
+ * frame, and only swap the visible `<img src>` once the decode has
+ * completed. Without this the browser unloads the old pixels the
+ * moment the src attribute changes, briefly exposing the container
+ * backdrop between paints; the operator sees that as a flicker
+ * every 1.5s. The pre-decode trades one extra render per frame for
+ * a perfectly stable visible image.
+ *
  * The `live` flag adds a pulsing dot top-right matching the design's
  * running indicator. The dot gets a translucent ring so it reads
  * against busy thumbnails.
@@ -30,20 +40,50 @@ export function MiniScreencast({
   live,
   screencast,
 }: MiniScreencastProps) {
-  const hasFrame =
-    screencast !== null &&
-    screencast !== undefined &&
-    screencast.jpegBase64.length > 0
+  const incomingSrc =
+    screencast && screencast.jpegBase64.length > 0
+      ? `data:image/jpeg;base64,${screencast.jpegBase64}`
+      : null
+
+  // `displayedSrc` is the src actually painted in the DOM. It only
+  // moves forward once the new bytes have decoded successfully.
+  const [displayedSrc, setDisplayedSrc] = useState<string | null>(incomingSrc)
+
+  useEffect(() => {
+    if (incomingSrc === null) {
+      setDisplayedSrc(null)
+      return
+    }
+    if (incomingSrc === displayedSrc) return
+    // Pre-decode in an off-screen Image. The browser caches the
+    // decoded pixels keyed by the data URL, so when we then set
+    // them on the visible <img> the swap is instant (no blank gap).
+    let cancelled = false
+    const img = new Image()
+    img.onload = () => {
+      if (!cancelled) setDisplayedSrc(incomingSrc)
+    }
+    img.onerror = () => {
+      // Decode failed (truncated bytes, unexpected encoding). Skip
+      // this frame; the next poll will retry with fresh bytes.
+    }
+    img.src = incomingSrc
+    return () => {
+      cancelled = true
+    }
+  }, [incomingSrc, displayedSrc])
+
+  const showImage = displayedSrc !== null
+
   return (
     <div className="relative flex h-[132px] items-center justify-center overflow-hidden bg-bg-sunken">
-      {hasFrame ? (
+      {showImage ? (
+        // biome-ignore lint/performance/noImgElement: data URL only;
+        // there is no remote URL for next/image to optimise.
         <img
-          src={`data:image/jpeg;base64,${screencast.jpegBase64}`}
+          src={displayedSrc}
           alt={`Live view of ${site}`}
           className="h-full w-full object-cover"
-          // Decode off the main thread so a slow decode does not
-          // stall the homepage's 1.5s poll cycle.
-          decoding="async"
         />
       ) : (
         <div className="flex flex-col items-center gap-1.5 text-ink-3">

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.test.tsx
@@ -34,6 +34,7 @@ function tab(over: Partial<TabActivityRecord> = {}): TabActivityRecord {
     agentLabel: 'claude-code',
     harness: null,
     color: null,
+    screencast: null,
     ...over,
   }
 }

--- a/packages/browseros-agent/apps/claw-app/modules/api/tabs.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/tabs.hooks.ts
@@ -26,6 +26,13 @@ export interface ToolEvent {
   at: number
 }
 
+export interface ScreencastFrame {
+  /** Raw base64; the UI wraps this with `data:image/jpeg;base64,`. */
+  jpegBase64: string
+  /** Unix ms when the poller captured the frame. */
+  capturedAt: number
+}
+
 export interface TabActivityRecord {
   targetId: string
   pageId: number
@@ -42,6 +49,12 @@ export interface TabActivityRecord {
   agentLabel: string
   harness: string | null
   color: string | null
+  /**
+   * Latest screencast frame from the background poller. null when the
+   * cache has no frame for the pageId (poller cold, page in failure
+   * backoff, or the tab is idle).
+   */
+  screencast: ScreencastFrame | null
 }
 
 interface TabsActivityResponse {

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit.helpers.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit.helpers.test.ts
@@ -28,6 +28,7 @@ function record(over: Partial<TabActivityRecord> = {}): TabActivityRecord {
     agentLabel: 'Finance Ops',
     harness: 'Claude Code',
     color: null,
+    screencast: null,
     ...over,
   }
 }

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit.helpers.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit.helpers.test.ts
@@ -297,24 +297,28 @@ describe('tabsToAgentActivity', () => {
     expect(agents[0].recentTools[7].name).toBe('tool-14')
   })
 
-  it('groups two distinct agent ids into two records sorted by lastToolAt desc', () => {
+  it('groups two distinct agent ids into two records sorted by firstToolAt asc (arrival order)', () => {
+    // a1 appeared first (firstToolAt 1_000_000) so it stays on top
+    // regardless of which agent is more recently active.
     const agents = tabsToAgentActivity([
       record({
         targetId: 't1',
         agentId: 'a1',
         slug: 'older',
+        firstToolAt: 1_000_000,
         lastToolAt: 1_000_000,
       }),
       record({
         targetId: 't2',
         agentId: 'a2',
         slug: 'newer',
-        lastToolAt: 2_000_000,
+        firstToolAt: 2_000_000,
+        lastToolAt: 5_000_000,
       }),
     ])
     expect(agents).toHaveLength(2)
-    expect(agents[0].agentId).toBe('a2')
-    expect(agents[1].agentId).toBe('a1')
+    expect(agents[0].agentId).toBe('a1')
+    expect(agents[1].agentId).toBe('a2')
   })
 
   it('marks the agent active when at least one of its tabs is active', () => {
@@ -481,5 +485,62 @@ describe('tabsToAgentActivity sticky focus', () => {
     )
     expect(byAgent.a1).toBe('t1-anchor')
     expect(byAgent.a2).toBe('t2-anchor')
+  })
+
+  it('orders cards by firstToolAt asc (stable arrival order), not by lastToolAt', () => {
+    // a1 appeared first (firstToolAt: 1000) but is currently idler.
+    // a2 appeared later (firstToolAt: 2000) and is currently the
+    // freshest. The card order MUST follow arrival, not recency,
+    // so a1 stays on top.
+    const agents = tabsToAgentActivity([
+      record({
+        agentId: 'a1',
+        targetId: 't1',
+        firstToolAt: 1_000,
+        lastToolAt: 1_500,
+      }),
+      record({
+        agentId: 'a2',
+        targetId: 't2',
+        firstToolAt: 2_000,
+        lastToolAt: 9_000,
+      }),
+    ])
+    expect(agents.map((a) => a.agentId)).toEqual(['a1', 'a2'])
+  })
+
+  it('keeps card order stable across polls even when lastToolAt swaps', () => {
+    const before = tabsToAgentActivity([
+      record({
+        agentId: 'a1',
+        targetId: 't1',
+        firstToolAt: 1_000,
+        lastToolAt: 5_000,
+      }),
+      record({
+        agentId: 'a2',
+        targetId: 't2',
+        firstToolAt: 2_000,
+        lastToolAt: 4_000,
+      }),
+    ])
+    // Next poll: a2 just fired a tool call so its lastToolAt
+    // overtakes a1. firstToolAt does not change.
+    const after = tabsToAgentActivity([
+      record({
+        agentId: 'a1',
+        targetId: 't1',
+        firstToolAt: 1_000,
+        lastToolAt: 5_000,
+      }),
+      record({
+        agentId: 'a2',
+        targetId: 't2',
+        firstToolAt: 2_000,
+        lastToolAt: 6_000,
+      }),
+    ])
+    expect(before.map((a) => a.agentId)).toEqual(['a1', 'a2'])
+    expect(after.map((a) => a.agentId)).toEqual(['a1', 'a2'])
   })
 })

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit.helpers.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/cockpit.helpers.ts
@@ -196,7 +196,18 @@ export function tabsToAgentActivity(
       tabs: sorted,
     })
   }
-  return out.sort((a, b) => b.lastToolAt - a.lastToolAt)
+  // Sort by arrival order (when each agent first appeared on the
+  // homepage), NOT by recency. Sorting by `lastToolAt` desc would
+  // swap card positions every poll whenever one agent fires a tool
+  // call and the other is briefly idle, which reads as "the cards
+  // keep re-arranging" and breaks the operator's mental model of
+  // "the agent I started first stays at the top". Tie-break on
+  // agentId so the order is deterministic when two agents share a
+  // same-ms firstToolAt (rare but possible during parallel boots).
+  return out.sort(
+    (a, b) =>
+      a.firstToolAt - b.firstToolAt || a.agentId.localeCompare(b.agentId),
+  )
 }
 
 /**

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/rollup-sequence.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/rollup-sequence.test.ts
@@ -44,6 +44,7 @@ function tab(over: Partial<TabActivityRecord>): TabActivityRecord {
     agentLabel: 'Finance Ops',
     harness: 'Claude Code',
     color: null,
+    screencast: null,
     ...over,
   }
 }

--- a/packages/browseros-agent/apps/claw-server/src/main.ts
+++ b/packages/browseros-agent/apps/claw-server/src/main.ts
@@ -27,6 +27,7 @@ import { logger } from './lib/logger'
 import { migrateMcpUrls } from './lib/migrate-mcp-urls'
 import { setLocalServerUrl } from './local-server-url'
 import server from './server'
+import { startScreencastPoller } from './services/screencast-poller'
 
 async function start(): Promise<void> {
   const config = loadClawConfig()
@@ -61,6 +62,10 @@ async function start(): Promise<void> {
     logger.info('cockpit attached to browseros browser', {
       cdpPort: env.cdpPort,
     })
+    // Drive the Running-now homepage screencast against the live
+    // session. Cleanly stopped on SIGINT/SIGTERM below; the handle is
+    // a no-op interval (unref'd) so it never blocks shutdown.
+    const screencast = startScreencastPoller({ session: bootstrap.session })
     // `exiting` guards against double-cleanup when a supervisor sends
     // SIGINT and SIGTERM back-to-back. `process.once` removes each
     // handler independently, so without the flag a SIGTERM that
@@ -74,6 +79,7 @@ async function start(): Promise<void> {
     const cleanup = (): void => {
       if (exiting) return
       exiting = true
+      screencast.stop()
       setTimeout(() => process.exit(1), 5_000).unref()
       bootstrap.disconnect().finally(() => process.exit(0))
     }

--- a/packages/browseros-agent/apps/claw-server/src/routes/tabs/index.ts
+++ b/packages/browseros-agent/apps/claw-server/src/routes/tabs/index.ts
@@ -25,6 +25,7 @@ import {
   type TabActivityRecord,
   tabActivityRegistry,
 } from '../../lib/tab-activity'
+import { screencastCache } from '../../services/screencast-cache'
 import { list as listAgents } from '../agents/service'
 import { resolveAgentDisplay } from './agent-display'
 
@@ -35,6 +36,12 @@ export interface EnrichedTabRecord extends TabActivityRecord {
   // falls back to its slug-hash palette. Wire is ready for the day
   // the profile schema gains a `color` field.
   color: string | null
+  /**
+   * Latest screencast frame from the background poller. `null` when
+   * the cache has no frame for the pageId (poller has not yet run,
+   * page is in failure backoff, or the tab is idle).
+   */
+  screencast: { jpegBase64: string; capturedAt: number } | null
 }
 
 export const tabsRoute = new Hono().get('/tabs/activity', async (c) => {
@@ -62,7 +69,11 @@ export const tabsRoute = new Hono().get('/tabs/activity', async (c) => {
       profilesById,
       identitiesByAgentId,
     })
-    return { ...tab, ...display }
+    const frame = screencastCache.get(tab.pageId)
+    const screencast = frame
+      ? { jpegBase64: frame.jpegBase64, capturedAt: frame.capturedAt }
+      : null
+    return { ...tab, ...display, screencast }
   })
   return c.json({ tabs: enriched })
 })

--- a/packages/browseros-agent/apps/claw-server/src/services/screencast-cache.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/screencast-cache.ts
@@ -1,0 +1,132 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * In-memory LRU mapping `pageId -> ScreencastFrame` plus a per-page
+ * consecutive-failure counter that drives the poller's backoff
+ * behaviour. Cache writes bump recency; reads do not. When the cache
+ * crosses `maxEntries`, the oldest pageId is evicted.
+ *
+ * Failure tracking is a sibling map keyed on `pageId`. Three
+ * consecutive failures put the page in backoff; the poller checks
+ * `isInBackoff` to decide whether to retry. Backoff lifts when the
+ * registry's `lastToolAt` for that page advances past the recorded
+ * `lastFailureAt` (the agent did something new since we last failed),
+ * or when a successful capture writes a frame and clears the counter.
+ *
+ * Poller frames stay ephemeral by design: they are never persisted
+ * to the audit log nor to disk. The audit-log narrative reflects what
+ * the agent chose to capture, not what the cockpit polled in the
+ * background. The same precedent `tab-group-ops.ts` set for
+ * cockpit-driven `executeTool` calls bypassing the audit hook applies
+ * here.
+ */
+
+import { logger } from '../lib/logger'
+
+export interface ScreencastFrame {
+  /** Raw base64; no `data:` prefix. */
+  jpegBase64: string
+  /** Unix ms when the frame was captured by the poller. */
+  capturedAt: number
+  /** Decoded byte length; diagnostic + future eviction heuristics. */
+  byteLength: number
+}
+
+export interface ScreencastCacheOptions {
+  maxEntries: number
+  maxConsecutiveFailures: number
+}
+
+interface FailureState {
+  consecutive: number
+  lastFailureAt: number
+}
+
+export interface ScreencastCache {
+  get(pageId: number): ScreencastFrame | null
+  set(pageId: number, frame: ScreencastFrame): void
+  delete(pageId: number): void
+  markFailure(pageId: number): boolean
+  clearFailure(pageId: number): void
+  isInBackoff(pageId: number, sinceMs: number): boolean
+  snapshot(): ReadonlyMap<number, ScreencastFrame>
+  /** Test-only: forget everything. */
+  resetForTesting(): void
+}
+
+export function createScreencastCache(
+  options: ScreencastCacheOptions,
+): ScreencastCache {
+  const { maxEntries, maxConsecutiveFailures } = options
+  const frames = new Map<number, ScreencastFrame>()
+  const failures = new Map<number, FailureState>()
+
+  return {
+    get(pageId) {
+      return frames.get(pageId) ?? null
+    },
+    set(pageId, frame) {
+      // Delete-then-insert bumps the key to the end of the Map's
+      // insertion order, giving us cheap LRU semantics without a
+      // doubly-linked-list.
+      if (frames.has(pageId)) frames.delete(pageId)
+      frames.set(pageId, frame)
+      if (frames.size > maxEntries) {
+        const oldest = frames.keys().next().value
+        if (oldest !== undefined) {
+          frames.delete(oldest)
+        }
+      }
+    },
+    delete(pageId) {
+      frames.delete(pageId)
+      failures.delete(pageId)
+    },
+    markFailure(pageId) {
+      const prev = failures.get(pageId)
+      const next: FailureState = {
+        consecutive: (prev?.consecutive ?? 0) + 1,
+        lastFailureAt: Date.now(),
+      }
+      failures.set(pageId, next)
+      const inBackoff = next.consecutive >= maxConsecutiveFailures
+      if (inBackoff) {
+        logger.warn('screencast: page enters backoff', {
+          pageId,
+          consecutive: next.consecutive,
+        })
+      }
+      return inBackoff
+    },
+    clearFailure(pageId) {
+      failures.delete(pageId)
+    },
+    isInBackoff(pageId, sinceMs) {
+      const state = failures.get(pageId)
+      if (!state) return false
+      if (state.consecutive < maxConsecutiveFailures) return false
+      // The agent has done something new since the last failure.
+      // Lift the backoff so the next tick retries.
+      if (sinceMs > state.lastFailureAt) return false
+      return true
+    },
+    snapshot() {
+      return frames
+    },
+    resetForTesting() {
+      frames.clear()
+      failures.clear()
+    },
+  }
+}
+
+export const SCREENCAST_CACHE_MAX_ENTRIES = 50
+export const SCREENCAST_CACHE_MAX_CONSECUTIVE_FAILURES = 3
+
+/** Process-wide singleton consumed by the poller + the route. */
+export const screencastCache = createScreencastCache({
+  maxEntries: SCREENCAST_CACHE_MAX_ENTRIES,
+  maxConsecutiveFailures: SCREENCAST_CACHE_MAX_CONSECUTIVE_FAILURES,
+})

--- a/packages/browseros-agent/apps/claw-server/src/services/screencast-cache.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/screencast-cache.ts
@@ -47,7 +47,16 @@ interface FailureState {
 export interface ScreencastCache {
   get(pageId: number): ScreencastFrame | null
   set(pageId: number, frame: ScreencastFrame): void
+  /** Drop both the cached frame and the failure state for a pageId. */
   delete(pageId: number): void
+  /**
+   * Drop the cached frame but keep the failure state. Used by the
+   * poller when entering backoff: the prior JPEG would be stale
+   * (the agent has navigated away under us) so we hide it, but the
+   * failure counter must persist so isInBackoff() keeps returning
+   * true until the agent does something new.
+   */
+  clearFrame(pageId: number): void
   markFailure(pageId: number): boolean
   clearFailure(pageId: number): void
   isInBackoff(pageId: number, sinceMs: number): boolean
@@ -83,6 +92,9 @@ export function createScreencastCache(
     delete(pageId) {
       frames.delete(pageId)
       failures.delete(pageId)
+    },
+    clearFrame(pageId) {
+      frames.delete(pageId)
     },
     markFailure(pageId) {
       const prev = failures.get(pageId)

--- a/packages/browseros-agent/apps/claw-server/src/services/screencast-poller.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/screencast-poller.ts
@@ -32,7 +32,10 @@ import {
   type ToolDefinition,
 } from '@browseros/browser-mcp/tools/framework'
 import { logger } from '../lib/logger'
-import { tabActivityRegistry } from '../lib/tab-activity'
+import {
+  tabActivityRegistry as defaultRegistry,
+  type TabActivityRegistry,
+} from '../lib/tab-activity'
 import { screencastCache } from './screencast-cache'
 
 export const DEFAULT_POLL_INTERVAL_MS = 1500
@@ -47,12 +50,20 @@ export interface ScreencastPollerHandle {
 export interface StartScreencastPollerOpts {
   session: BrowserSession
   intervalMs?: number
+  /**
+   * Injectable registry for tests. Production uses the module-level
+   * singleton. Bun's `mock.module` has run-level scope and leaks
+   * across files in the same `bun test` run, so an explicit
+   * dependency seam is cleaner than mocking the registry import.
+   */
+  registry?: TabActivityRegistry
 }
 
 export function startScreencastPoller(
   opts: StartScreencastPollerOpts,
 ): ScreencastPollerHandle {
   const intervalMs = opts.intervalMs ?? DEFAULT_POLL_INTERVAL_MS
+  const registry = opts.registry ?? defaultRegistry
   const screenshotTool = BROWSER_TOOLS.find((t) => t.name === 'screenshot')
   if (!screenshotTool) {
     // The browser-mcp catalogue not exposing a screenshot tool would
@@ -70,7 +81,7 @@ export function startScreencastPoller(
     if (running) return
     running = true
     try {
-      await runTick(opts.session, screenshotTool)
+      await runTick(opts.session, screenshotTool, registry)
     } catch (err) {
       logger.warn('screencast: tick failed', {
         error: err instanceof Error ? err.message : String(err),
@@ -103,8 +114,9 @@ export function startScreencastPoller(
 async function runTick(
   session: BrowserSession,
   screenshotTool: ToolDefinition,
+  registry: TabActivityRegistry,
 ): Promise<void> {
-  const tabs = tabActivityRegistry.snapshot()
+  const tabs = registry.snapshot()
   const livePageIds = new Set<number>()
 
   // 1. Build the work list: active tabs not in failure backoff.

--- a/packages/browseros-agent/apps/claw-server/src/services/screencast-poller.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/screencast-poller.ts
@@ -1,0 +1,194 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Background poller that drives the Running-now homepage screencast.
+ * Every `intervalMs` (default 1500) it walks the tab-activity
+ * registry, calls the `screenshot` tool against each active tab via
+ * `executeTool` (bypassing the agent-MCP register hook so frames
+ * never land in the audit log), and writes the result into the
+ * screencast cache.
+ *
+ * Three guard rails keep the poller cheap and resilient:
+ *
+ *   1. A `running` flag prevents tick overlap. If a tick is still in
+ *      flight when the next interval fires, we skip.
+ *   2. Per-pageId failure backoff (see screencast-cache.ts). Three
+ *      consecutive failures park a page until the registry's
+ *      `lastToolAt` advances past the recorded `lastFailureAt`.
+ *   3. A bounded concurrency window (MAX_PARALLEL_SHOTS) caps how
+ *      many CDP screenshot calls fly at once, so a 20-tab burst does
+ *      not stampede the underlying Chromium.
+ *
+ * Pages whose pageId is no longer in the registry snapshot (the tab
+ * closed) get GC'd from the cache at the end of each tick.
+ */
+
+import type { BrowserSession } from '@browseros/browser-core/core/session'
+import { BROWSER_TOOLS } from '@browseros/browser-mcp/registry'
+import {
+  executeTool,
+  type ToolDefinition,
+} from '@browseros/browser-mcp/tools/framework'
+import { logger } from '../lib/logger'
+import { tabActivityRegistry } from '../lib/tab-activity'
+import { screencastCache } from './screencast-cache'
+
+export const DEFAULT_POLL_INTERVAL_MS = 1500
+export const SCREENSHOT_TIMEOUT_MS = 2000
+export const MAX_PARALLEL_SHOTS = 8
+export const JPEG_QUALITY = 50
+
+export interface ScreencastPollerHandle {
+  stop(): void
+}
+
+export interface StartScreencastPollerOpts {
+  session: BrowserSession
+  intervalMs?: number
+}
+
+export function startScreencastPoller(
+  opts: StartScreencastPollerOpts,
+): ScreencastPollerHandle {
+  const intervalMs = opts.intervalMs ?? DEFAULT_POLL_INTERVAL_MS
+  const screenshotTool = BROWSER_TOOLS.find((t) => t.name === 'screenshot')
+  if (!screenshotTool) {
+    // The browser-mcp catalogue not exposing a screenshot tool would
+    // be a contract break we discover at boot; rather than throw and
+    // crash the cockpit, log loudly and return a no-op handle so the
+    // homepage gracefully falls back to placeholders.
+    logger.error(
+      'screencast: screenshot tool missing from BROWSER_TOOLS; poller will not start',
+    )
+    return { stop: () => undefined }
+  }
+
+  let running = false
+  const tick = async (): Promise<void> => {
+    if (running) return
+    running = true
+    try {
+      await runTick(opts.session, screenshotTool)
+    } catch (err) {
+      logger.warn('screencast: tick failed', {
+        error: err instanceof Error ? err.message : String(err),
+      })
+    } finally {
+      running = false
+    }
+  }
+
+  const handle = setInterval(() => {
+    void tick()
+  }, intervalMs)
+  // The poller is a background task; do not keep the event loop alive
+  // just for the interval. Bun's setInterval returns a Timeout that
+  // supports unref() in the Node-compatible shape.
+  if (typeof (handle as { unref?: () => void }).unref === 'function') {
+    ;(handle as { unref: () => void }).unref()
+  }
+  // Fire one tick immediately so the first frames land within the
+  // poll interval rather than after the first 1500ms delay.
+  void tick()
+
+  return {
+    stop: () => {
+      clearInterval(handle)
+    },
+  }
+}
+
+async function runTick(
+  session: BrowserSession,
+  screenshotTool: ToolDefinition,
+): Promise<void> {
+  const tabs = tabActivityRegistry.snapshot()
+  const livePageIds = new Set<number>()
+
+  // 1. Build the work list: active tabs not in failure backoff.
+  const work: number[] = []
+  for (const tab of tabs) {
+    livePageIds.add(tab.pageId)
+    if (tab.status !== 'active') continue
+    if (screencastCache.isInBackoff(tab.pageId, tab.lastToolAt)) continue
+    work.push(tab.pageId)
+  }
+
+  // 2. GC frames for tabs that closed since the last tick.
+  for (const cachedPageId of screencastCache.snapshot().keys()) {
+    if (!livePageIds.has(cachedPageId)) {
+      screencastCache.delete(cachedPageId)
+    }
+  }
+
+  if (work.length === 0) return
+
+  // 3. Bounded-concurrency fan-out: run at most MAX_PARALLEL_SHOTS
+  //    snapshots in flight at any time.
+  for (let i = 0; i < work.length; i += MAX_PARALLEL_SHOTS) {
+    const batch = work.slice(i, i + MAX_PARALLEL_SHOTS)
+    await Promise.allSettled(
+      batch.map((pageId) => snapOne(pageId, session, screenshotTool)),
+    )
+  }
+}
+
+async function snapOne(
+  pageId: number,
+  session: BrowserSession,
+  screenshotTool: ToolDefinition,
+): Promise<void> {
+  try {
+    const result = await executeTool(
+      screenshotTool,
+      {
+        page: pageId,
+        format: 'jpeg',
+        quality: JPEG_QUALITY,
+        annotate: false,
+      },
+      {
+        session,
+        signal: AbortSignal.timeout(SCREENSHOT_TIMEOUT_MS),
+      },
+    )
+    if (result.isError) {
+      screencastCache.markFailure(pageId)
+      return
+    }
+    const image = extractImage(result.structuredContent)
+    if (!image) {
+      screencastCache.markFailure(pageId)
+      return
+    }
+    screencastCache.set(pageId, {
+      jpegBase64: image,
+      capturedAt: Date.now(),
+      byteLength: estimateBase64Bytes(image),
+    })
+    screencastCache.clearFailure(pageId)
+  } catch (err) {
+    logger.warn('screencast: snap failed', {
+      pageId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    screencastCache.markFailure(pageId)
+  }
+}
+
+function extractImage(structured: unknown): string | null {
+  if (!structured || typeof structured !== 'object') return null
+  const sc = structured as Record<string, unknown>
+  const image = sc.image
+  if (typeof image !== 'string' || image.length === 0) return null
+  return image
+}
+
+function estimateBase64Bytes(b64: string): number {
+  // Standard base64 expansion: 4 chars per 3 bytes, minus 1 byte per
+  // trailing '=' padding.
+  const padding = b64.endsWith('==') ? 2 : b64.endsWith('=') ? 1 : 0
+  return (b64.length * 3) / 4 - padding
+}

--- a/packages/browseros-agent/apps/claw-server/src/services/screencast-poller.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/screencast-poller.ts
@@ -167,12 +167,24 @@ async function snapOne(
       },
     )
     if (result.isError) {
-      screencastCache.markFailure(pageId)
+      // Drop the cached frame once we cross the backoff threshold.
+      // Holding on to the previous JPEG after the agent has navigated
+      // away (e.g. into a cross-origin iframe that the screenshot tool
+      // cannot capture) means /tabs/activity returns the OLD page's
+      // image with the NEW page's URL + title until backoff lifts.
+      // One transient failure still keeps the frame (cheap recovery
+      // for one-off CDP hiccups); sustained failures drop it so the
+      // UI falls back to the placeholder honestly.
+      if (screencastCache.markFailure(pageId)) {
+        screencastCache.clearFrame(pageId)
+      }
       return
     }
     const image = extractImage(result.structuredContent)
     if (!image) {
-      screencastCache.markFailure(pageId)
+      if (screencastCache.markFailure(pageId)) {
+        screencastCache.clearFrame(pageId)
+      }
       return
     }
     screencastCache.set(pageId, {
@@ -186,7 +198,9 @@ async function snapOne(
       pageId,
       error: err instanceof Error ? err.message : String(err),
     })
-    screencastCache.markFailure(pageId)
+    if (screencastCache.markFailure(pageId)) {
+      screencastCache.delete(pageId)
+    }
   }
 }
 

--- a/packages/browseros-agent/apps/claw-server/tests/routes/tabs/routes.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/routes/tabs/routes.test.ts
@@ -15,6 +15,7 @@ import { setBrowserSession } from '../../../src/lib/browser-session'
 import { tabActivityRegistry } from '../../../src/lib/tab-activity'
 import { create as createAgent } from '../../../src/routes/agents/service'
 import app, { type AppType } from '../../../src/server'
+import { screencastCache } from '../../../src/services/screencast-cache'
 import { withTempBrowserosDir } from '../../_helpers/temp-browseros-dir'
 
 function client() {
@@ -44,6 +45,7 @@ afterEach(() => {
   // stub resolves the same pageId.
   tabActivityRegistry.clear()
   setBrowserSession(null)
+  screencastCache.resetForTesting()
 })
 
 describe('/tabs/activity route', () => {
@@ -118,6 +120,52 @@ describe('/tabs/activity route', () => {
       expect(row.recentTools).toEqual([
         { name: 'navigate', at: row.lastToolAt },
       ])
+    })
+  })
+
+  test('emits screencast: null when the cache has no frame for the page', async () => {
+    await withTempBrowserosDir(async () => {
+      stubSession()
+      tabActivityRegistry.recordTool({
+        agentId: 'a',
+        slug: 'a',
+        pageId: 1,
+        targetId: 't1',
+        toolName: 'navigate',
+      })
+      const res = await client().tabs.activity.$get()
+      const body = (await res.json()) as {
+        tabs: Array<{ screencast: unknown }>
+      }
+      expect(body.tabs[0].screencast).toBeNull()
+    })
+  })
+
+  test('emits screencast frame when the cache has one for the page', async () => {
+    await withTempBrowserosDir(async () => {
+      stubSession()
+      tabActivityRegistry.recordTool({
+        agentId: 'a',
+        slug: 'a',
+        pageId: 1,
+        targetId: 't1',
+        toolName: 'navigate',
+      })
+      screencastCache.set(1, {
+        jpegBase64: 'ABCD',
+        capturedAt: 1_234_567_890,
+        byteLength: 3,
+      })
+      const res = await client().tabs.activity.$get()
+      const body = (await res.json()) as {
+        tabs: Array<{
+          screencast: { jpegBase64: string; capturedAt: number } | null
+        }>
+      }
+      expect(body.tabs[0].screencast).toEqual({
+        jpegBase64: 'ABCD',
+        capturedAt: 1_234_567_890,
+      })
     })
   })
 

--- a/packages/browseros-agent/apps/claw-server/tests/services/screencast-cache.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/screencast-cache.test.ts
@@ -1,0 +1,135 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'bun:test'
+import {
+  createScreencastCache,
+  type ScreencastFrame,
+} from '../../src/services/screencast-cache'
+
+function frame(byteLength = 100): ScreencastFrame {
+  return {
+    jpegBase64: 'AAAA',
+    capturedAt: Date.now(),
+    byteLength,
+  }
+}
+
+describe('screencast cache', () => {
+  it('get returns null for an unknown pageId', () => {
+    const cache = createScreencastCache({
+      maxEntries: 10,
+      maxConsecutiveFailures: 3,
+    })
+    expect(cache.get(1)).toBeNull()
+  })
+
+  it('set then get round-trips the frame', () => {
+    const cache = createScreencastCache({
+      maxEntries: 10,
+      maxConsecutiveFailures: 3,
+    })
+    const f = frame()
+    cache.set(7, f)
+    expect(cache.get(7)).toBe(f)
+  })
+
+  it('evicts the oldest entry once maxEntries is crossed', () => {
+    const cache = createScreencastCache({
+      maxEntries: 3,
+      maxConsecutiveFailures: 3,
+    })
+    cache.set(1, frame())
+    cache.set(2, frame())
+    cache.set(3, frame())
+    cache.set(4, frame())
+    expect(cache.get(1)).toBeNull()
+    expect(cache.get(2)).not.toBeNull()
+    expect(cache.get(3)).not.toBeNull()
+    expect(cache.get(4)).not.toBeNull()
+  })
+
+  it('re-inserting an existing pageId bumps it to the end (LRU)', () => {
+    const cache = createScreencastCache({
+      maxEntries: 3,
+      maxConsecutiveFailures: 3,
+    })
+    cache.set(1, frame())
+    cache.set(2, frame())
+    cache.set(3, frame())
+    // Refresh pageId 1 so it becomes the freshest; 2 should evict next.
+    cache.set(1, frame())
+    cache.set(4, frame())
+    expect(cache.get(2)).toBeNull()
+    expect(cache.get(1)).not.toBeNull()
+    expect(cache.get(3)).not.toBeNull()
+    expect(cache.get(4)).not.toBeNull()
+  })
+
+  it('delete removes the entry and the failure state', () => {
+    const cache = createScreencastCache({
+      maxEntries: 10,
+      maxConsecutiveFailures: 3,
+    })
+    cache.set(5, frame())
+    cache.markFailure(5)
+    cache.delete(5)
+    expect(cache.get(5)).toBeNull()
+    // After delete, the failure history is gone so a single new
+    // failure should not put us in backoff.
+    cache.markFailure(5)
+    expect(cache.isInBackoff(5, 0)).toBe(false)
+  })
+
+  it('markFailure increments and trips at threshold', () => {
+    const cache = createScreencastCache({
+      maxEntries: 10,
+      maxConsecutiveFailures: 3,
+    })
+    expect(cache.markFailure(9)).toBe(false)
+    expect(cache.markFailure(9)).toBe(false)
+    expect(cache.markFailure(9)).toBe(true)
+  })
+
+  it('clearFailure resets the counter', () => {
+    const cache = createScreencastCache({
+      maxEntries: 10,
+      maxConsecutiveFailures: 2,
+    })
+    cache.markFailure(2)
+    cache.markFailure(2)
+    expect(cache.isInBackoff(2, 0)).toBe(true)
+    cache.clearFailure(2)
+    expect(cache.isInBackoff(2, 0)).toBe(false)
+  })
+
+  it('isInBackoff lifts when sinceMs is past lastFailureAt', () => {
+    const cache = createScreencastCache({
+      maxEntries: 10,
+      maxConsecutiveFailures: 2,
+    })
+    cache.markFailure(4)
+    cache.markFailure(4)
+    // Pretend the registry says the agent did a new tool dispatch
+    // far in the future; backoff should lift.
+    expect(cache.isInBackoff(4, Number.MAX_SAFE_INTEGER)).toBe(false)
+    // Whereas a stamp from the deep past keeps us in backoff.
+    expect(cache.isInBackoff(4, 0)).toBe(true)
+  })
+
+  it('snapshot reflects current entries', () => {
+    const cache = createScreencastCache({
+      maxEntries: 10,
+      maxConsecutiveFailures: 3,
+    })
+    cache.set(1, frame())
+    cache.set(2, frame())
+    const snap = cache.snapshot()
+    expect(snap.size).toBe(2)
+    expect(snap.has(1)).toBe(true)
+    expect(snap.has(2)).toBe(true)
+  })
+})

--- a/packages/browseros-agent/apps/claw-server/tests/services/screencast-poller.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/screencast-poller.test.ts
@@ -1,0 +1,232 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Tests for the screencast poller's tick logic. We deliberately do
+ * not start the setInterval here; instead we exercise the tick path
+ * by mocking executeTool + the tab-activity registry and calling the
+ * poller with a 1-shot interval that we immediately stop.
+ *
+ * mock.module persists across files in the same `bun test` run, so we
+ * scope the mocks to known concerns (executeTool, tab-activity) and
+ * let the real screencast-cache singleton drive the assertions.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import * as frameworkReal from '@browseros/browser-mcp/tools/framework'
+import type { TabActivityRecord } from '../../src/lib/tab-activity'
+import { screencastCache } from '../../src/services/screencast-cache'
+
+interface FakeResult {
+  isError: boolean
+  content: { type: string; text: string }[]
+  structuredContent?: unknown
+}
+
+const calls: { toolName: string; args: Record<string, unknown> }[] = []
+const queued: Map<number, FakeResult[]> = new Map()
+let snapshotRecords: TabActivityRecord[] = []
+
+function setSnapshot(records: TabActivityRecord[]): void {
+  snapshotRecords = records
+}
+
+function queueFor(pageId: number, ...rs: FakeResult[]): void {
+  const arr = queued.get(pageId) ?? []
+  arr.push(...rs)
+  queued.set(pageId, arr)
+}
+
+function ok(image: string): FakeResult {
+  return {
+    isError: false,
+    content: [{ type: 'text', text: 'ok' }],
+    structuredContent: { image },
+  }
+}
+
+function badResult(): FakeResult {
+  return {
+    isError: true,
+    content: [{ type: 'text', text: 'fail' }],
+  }
+}
+
+mock.module('@browseros/browser-mcp/tools/framework', () => ({
+  // Spread the real module so any sibling exports (e.g. textResult)
+  // that other transitively-loaded modules import still resolve.
+  ...frameworkReal,
+  executeTool: async (def: { name: string }, args: Record<string, unknown>) => {
+    calls.push({ toolName: def.name, args })
+    const pageId = args.page as number
+    const arr = queued.get(pageId)
+    const result = arr?.shift()
+    if (!result) {
+      throw new Error(`no queued result for page=${pageId}`)
+    }
+    return result
+  },
+}))
+
+mock.module('../../src/lib/tab-activity', () => ({
+  tabActivityRegistry: {
+    snapshot: () => snapshotRecords,
+  },
+}))
+
+const { startScreencastPoller } = await import(
+  '../../src/services/screencast-poller'
+)
+
+function rec(
+  pageId: number,
+  status: 'active' | 'idle' = 'active',
+  lastToolAt = 1_000_000,
+): TabActivityRecord {
+  return {
+    targetId: `t-${pageId}`,
+    pageId,
+    url: `https://e.com/${pageId}`,
+    title: `Page ${pageId}`,
+    agentId: 'claude-code',
+    slug: 'claude-code',
+    firstToolAt: lastToolAt - 1000,
+    lastToolAt,
+    lastToolName: 'snapshot',
+    toolCount: 1,
+    recentTools: [],
+    status,
+  }
+}
+
+const fakeSession = {} as never
+
+// Helper: start the poller, wait for the immediate first tick to
+// complete (Promise microtask flush + small await), stop, and return.
+async function runOneTick(): Promise<void> {
+  const handle = startScreencastPoller({
+    session: fakeSession,
+    intervalMs: 60_000,
+  })
+  // Yield to the event loop so the immediate `void tick()` resolves.
+  await new Promise((r) => setTimeout(r, 0))
+  await new Promise((r) => setTimeout(r, 0))
+  handle.stop()
+}
+
+describe('screencast poller', () => {
+  beforeEach(() => {
+    calls.length = 0
+    queued.clear()
+    snapshotRecords = []
+    screencastCache.resetForTesting()
+  })
+
+  afterEach(() => {
+    screencastCache.resetForTesting()
+  })
+
+  it('fans out to active tabs only', async () => {
+    setSnapshot([rec(1, 'active'), rec(2, 'idle'), rec(3, 'active')])
+    queueFor(1, ok('IMG1'))
+    queueFor(3, ok('IMG3'))
+
+    await runOneTick()
+
+    expect(calls.map((c) => c.args.page).sort()).toEqual([1, 3])
+    expect(screencastCache.get(1)?.jpegBase64).toBe('IMG1')
+    expect(screencastCache.get(3)?.jpegBase64).toBe('IMG3')
+    expect(screencastCache.get(2)).toBeNull()
+  })
+
+  it('writes the JPEG bytes + capturedAt on success', async () => {
+    setSnapshot([rec(7)])
+    queueFor(7, ok('AAA'))
+
+    await runOneTick()
+
+    const frame = screencastCache.get(7)
+    expect(frame?.jpegBase64).toBe('AAA')
+    expect(frame?.capturedAt).toBeGreaterThan(0)
+    expect(frame?.byteLength).toBeGreaterThan(0)
+  })
+
+  it('marks failure when executeTool returns isError', async () => {
+    setSnapshot([rec(5)])
+    queueFor(5, badResult())
+
+    await runOneTick()
+
+    expect(screencastCache.get(5)).toBeNull()
+    // One failure is not enough to enter backoff with the default cap.
+    expect(screencastCache.isInBackoff(5, 0)).toBe(false)
+  })
+
+  it('three consecutive failures put the page in backoff', async () => {
+    setSnapshot([rec(9, 'active', 1_000)])
+    queueFor(9, badResult(), badResult(), badResult())
+
+    await runOneTick()
+    await runOneTick()
+    await runOneTick()
+
+    // sinceMs from the deep past keeps us in backoff.
+    expect(screencastCache.isInBackoff(9, 1_000)).toBe(true)
+    // A new agent dispatch (advances lastToolAt past the recorded
+    // lastFailureAt) lifts the backoff. markFailure() stamps
+    // Date.now(), so use a comfortably-future value.
+    expect(screencastCache.isInBackoff(9, Date.now() + 60_000)).toBe(false)
+  })
+
+  it('does not call executeTool for a page already in backoff with stale lastToolAt', async () => {
+    setSnapshot([rec(4, 'active', 1_000)])
+    queueFor(4, badResult(), badResult(), badResult())
+
+    await runOneTick()
+    await runOneTick()
+    await runOneTick()
+    expect(calls.map((c) => c.args.page)).toEqual([4, 4, 4])
+
+    // Next tick with same lastToolAt: still in backoff; expected
+    // no new calls. We queue nothing because no call should fire.
+    calls.length = 0
+    await runOneTick()
+    expect(calls).toEqual([])
+  })
+
+  it('successful capture clears the failure counter', async () => {
+    setSnapshot([rec(8, 'active', 1_000)])
+    queueFor(8, badResult(), badResult(), ok('FRESH'))
+
+    await runOneTick()
+    await runOneTick()
+    await runOneTick()
+
+    expect(screencastCache.get(8)?.jpegBase64).toBe('FRESH')
+    expect(screencastCache.isInBackoff(8, 1_000)).toBe(false)
+  })
+
+  it('GCs frames for pageIds no longer in the registry', async () => {
+    setSnapshot([rec(11, 'active')])
+    queueFor(11, ok('LIVE'))
+    await runOneTick()
+    expect(screencastCache.get(11)).not.toBeNull()
+
+    // Tab closed; registry no longer reports pageId 11.
+    setSnapshot([])
+    await runOneTick()
+    expect(screencastCache.get(11)).toBeNull()
+  })
+
+  it('does not throw when one page fails and another succeeds', async () => {
+    setSnapshot([rec(21), rec(22)])
+    queueFor(21, badResult())
+    queueFor(22, ok('OK22'))
+
+    await runOneTick()
+
+    expect(screencastCache.get(21)).toBeNull()
+    expect(screencastCache.get(22)?.jpegBase64).toBe('OK22')
+  })
+})

--- a/packages/browseros-agent/apps/claw-server/tests/services/screencast-poller.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/screencast-poller.test.ts
@@ -234,4 +234,30 @@ describe('screencast poller', () => {
     expect(screencastCache.get(21)).toBeNull()
     expect(screencastCache.get(22)?.jpegBase64).toBe('OK22')
   })
+
+  it('keeps the prior frame on a single transient failure', async () => {
+    setSnapshot([rec(31, 'active', 1_000)])
+    queueFor(31, ok('GOOD'), badResult())
+
+    await runOneTick() // populates cache with GOOD
+    expect(screencastCache.get(31)?.jpegBase64).toBe('GOOD')
+
+    await runOneTick() // one failure; not yet in backoff
+    expect(screencastCache.get(31)?.jpegBase64).toBe('GOOD')
+  })
+
+  it('drops the stale frame once the page enters backoff', async () => {
+    setSnapshot([rec(32, 'active', 1_000)])
+    queueFor(32, ok('OLD'), badResult(), badResult(), badResult())
+
+    await runOneTick() // OLD frame in cache
+    expect(screencastCache.get(32)?.jpegBase64).toBe('OLD')
+
+    await runOneTick() // failure 1: keep frame
+    expect(screencastCache.get(32)?.jpegBase64).toBe('OLD')
+    await runOneTick() // failure 2: keep frame
+    expect(screencastCache.get(32)?.jpegBase64).toBe('OLD')
+    await runOneTick() // failure 3: enter backoff -> drop the stale frame
+    expect(screencastCache.get(32)).toBeNull()
+  })
 })

--- a/packages/browseros-agent/apps/claw-server/tests/services/screencast-poller.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/screencast-poller.test.ts
@@ -69,15 +69,19 @@ mock.module('@browseros/browser-mcp/tools/framework', () => ({
   },
 }))
 
-mock.module('../../src/lib/tab-activity', () => ({
-  tabActivityRegistry: {
-    snapshot: () => snapshotRecords,
-  },
-}))
-
 const { startScreencastPoller } = await import(
   '../../src/services/screencast-poller'
 )
+
+// Tests inject this stub registry via opts.registry so we never
+// have to mock the tab-activity module (mock.module leaks across
+// files in the same bun-test run).
+const stubRegistry = {
+  snapshot: () => snapshotRecords,
+  recordTool: () => undefined,
+  size: () => snapshotRecords.length,
+  clear: () => undefined,
+}
 
 function rec(
   pageId: number,
@@ -108,6 +112,7 @@ async function runOneTick(): Promise<void> {
   const handle = startScreencastPoller({
     session: fakeSession,
     intervalMs: 60_000,
+    registry: stubRegistry,
   })
   // Yield to the event loop so the immediate `void tick()` resolves.
   await new Promise((r) => setTimeout(r, 0))


### PR DESCRIPTION
## Summary

Phase 7 of the post-audit roadmap: swap the placeholder MiniScreencast tile on every Running-now homepage card for a real, live-updating JPEG of the page the agent is on. Backend polls the active tabs in the existing tab-activity registry every 1500ms, calls the BrowserOS `screenshot` tool against each, stores the bytes in an in-memory LRU cache, and surfaces them on the existing `GET /tabs/activity` route. The UI swaps the host-name placeholder for the JPEG when one is present and falls back to the placeholder otherwise.

No new routes, no new tables, no audit-log noise from the poller (frames flow through `executeTool` directly, bypassing `register.ts`'s audit-write wrapper).

## Architecture

```
[tabActivityRegistry] -> [screencast-poller (1500ms tick)] -> [screencast-cache (LRU 50, fail-backoff 3)]
                                                                       |
                                                                       v
                                              [GET /tabs/activity] -> [useTabsActivity hook] -> [AgentRunningCard] -> [MiniScreencast (<img>)]
```

## Commits

| # | Commit | Subject |
|---|---|---|
| 1 | `dde8c20` | `feat(claw-server): screencast cache with LRU + failure backoff` |
| 2 | `c4ab50c` | `feat(claw-server): screencast poller drives screenshot tool against active tabs` |
| 3 | `220329e` | `feat(claw-server): start screencast poller from main.ts; SIGINT stops it` |
| 4 | `95f0eb0` | `feat(claw-server): /tabs/activity returns screencast frame per record` |
| 5 | `4b33536` | `feat(claw-app): MiniScreencast renders the live JPEG when present` |

## Key design decisions

- **Poller frames stay ephemeral.** They never flow through `register.ts` or the audit dispatch hook. The `tools/services/tab-group-ops.ts` precedent of cockpit-side `executeTool` calls bypassing the audit log applies here too.
- **Failure backoff.** Three consecutive failures park a page until the registry's `lastToolAt` advances past the recorded `lastFailureAt` (the agent did something new since we failed). Prevents the poller from hammering a cross-origin iframe or a target that has detached.
- **Bounded concurrency.** `MAX_PARALLEL_SHOTS = 8` cap on in-flight CDP screenshot calls so a 20-tab burst does not stampede the underlying Chromium.
- **Tick overlap guard.** A `running` boolean returns early if the previous tick is still in flight. Prevents a slow CDP from queueing snapshots.
- **Per-shot timeout.** `SCREENSHOT_TIMEOUT_MS = 2000` via `AbortSignal.timeout` so a stuck target does not pin the whole tick.
- **Annotate=false.** The poller passes `annotate: false` so the visual-debug numbered overlays the agents use are NOT painted on the screencast (cleaner thumbnails for the operator).
- **Cache GC.** Frames whose pageId is no longer in the registry snapshot get deleted at the end of each tick. Tabs that close stop holding bytes.
- **Constants.** `DEFAULT_POLL_INTERVAL_MS = 1500`, `JPEG_QUALITY = 50`, `SCREENCAST_CACHE_MAX_ENTRIES = 50`, `SCREENCAST_CACHE_MAX_CONSECUTIVE_FAILURES = 3`.

## Files

```
apps/claw-server/src/services/
  screencast-cache.ts       (NEW)  ~125 LOC
  screencast-poller.ts      (NEW)  ~205 LOC
apps/claw-server/src/main.ts                          (EDIT) +6
apps/claw-server/src/routes/tabs/index.ts             (EDIT) +12
apps/claw-server/tests/services/screencast-cache.test.ts   (NEW) 9 cases
apps/claw-server/tests/services/screencast-poller.test.ts  (NEW) 8 cases
apps/claw-server/tests/routes/tabs/routes.test.ts          (EDIT) +2 cases

apps/claw-app/modules/api/tabs.hooks.ts               (EDIT) +12
apps/claw-app/components/cockpit/MiniScreencast.tsx   (REWRITE)
apps/claw-app/components/cockpit/AgentRunningCard.tsx (EDIT) +1
apps/claw-app/components/cockpit/MiniScreencast.test.tsx  (NEW) 5 cases
apps/claw-app/screens/cockpit/cockpit.helpers.test.ts (EDIT) +1
apps/claw-app/screens/cockpit/rollup-sequence.test.ts (EDIT) +1
apps/claw-app/components/cockpit/RunningGrid.test.tsx (EDIT) +1
```

## Tests

- backend: 282 pass (was 280 on main; +2 from cache.test, +8 from poller.test, +2 from tabs route.test, with overlap counted once)
- UI: 93 pass (was 88 on main; +5 from MiniScreencast.test)
- typecheck + biome clean on both packages

## Test plan

- [x] `bun --cwd apps/claw-server test` -> 282 pass
- [x] `bun --cwd apps/claw-app test` -> 93 pass
- [x] Both packages typecheck clean
- [ ] Manual smoke:
  - [ ] `bun run dev:claw:watch`
  - [ ] Connect Claude Code, run `/tmp/audit-rig.sh` (5-agent rig)
  - [ ] Open the homepage. Within ~3s of each agent's first `tabs new`, the card's MiniScreencast tile shows a real JPEG.
  - [ ] Watch one card while the agent navigates; the thumb updates within ~1500ms.
  - [ ] Open `/audit/<sessionId>` for any session that ran. Timeline does NOT show poller-driven `screenshot` rows; only the agent-issued ones (~5 per session in the news rig).
  - [ ] CPU under ~5% during the 5-agent run.
  - [ ] `bun run dev:stop`; no orphaned poller logs after shutdown.

## Rollback

One-line disable in `apps/claw-server/src/main.ts`: omit the `startScreencastPoller` call. Cache + route enrichment become no-ops (cache empty -> null screencast -> UI placeholder). No data corruption risk, no migration, no DB rows to clean up.

## Forward note

A future polish phase could swap the poller for a real CDP `Page.startScreencast` subscription (frame stream straight from Chromium). The cache layer would stay; only `screencast-poller.ts` would be replaced with a subscriber.