### PR TITLE
feat(cockpit): Stop button cancels dispatches, Watch switches to actual tab

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/cockpit/AgentRunningCard.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/AgentRunningCard.tsx
@@ -12,6 +12,8 @@ interface AgentRunningCardProps {
   onStop?: () => void
   /** When the focus mutation is in flight for this card. */
   isFocusPending?: boolean
+  /** When the cancel mutation is in flight for this card. */
+  isCancelPending?: boolean
 }
 
 /**
@@ -29,6 +31,7 @@ export function AgentRunningCard({
   onWatch,
   onStop,
   isFocusPending,
+  isCancelPending,
 }: AgentRunningCardProps) {
   const focus = agent.currentFocus
   const active = agent.status === 'active'
@@ -97,13 +100,19 @@ export function AgentRunningCard({
             )}{' '}
             Watch
           </button>
-          {active && (
+          {active && onStop && (
             <button
               type="button"
               onClick={onStop}
-              className="inline-flex items-center justify-center gap-1.5 rounded-md bg-bg-sunken px-2.5 py-1.5 font-semibold text-[12.5px] text-ink-2 transition hover:bg-card-tint hover:text-ink"
+              disabled={isCancelPending}
+              className="inline-flex items-center justify-center gap-1.5 rounded-md bg-bg-sunken px-2.5 py-1.5 font-semibold text-[12.5px] text-ink-2 transition hover:bg-card-tint hover:text-ink disabled:cursor-not-allowed disabled:opacity-60"
             >
-              <Square className="size-3" /> Stop
+              {isCancelPending ? (
+                <RefreshCw className="size-3 animate-spin" />
+              ) : (
+                <Square className="size-3" />
+              )}{' '}
+              Stop
             </button>
           )}
         </div>

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/AgentRunningCard.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/AgentRunningCard.tsx
@@ -105,14 +105,23 @@ export function AgentRunningCard({
               type="button"
               onClick={onStop}
               disabled={isCancelPending}
-              className="inline-flex items-center justify-center gap-1.5 rounded-md bg-bg-sunken px-2.5 py-1.5 font-semibold text-[12.5px] text-ink-2 transition hover:bg-card-tint hover:text-ink disabled:cursor-not-allowed disabled:opacity-60"
+              aria-label={isCancelPending ? 'Cancelling agent' : 'Stop agent'}
+              // min-w-[7rem] reserves enough width for the longer
+              // 'Cancelling' label so swapping in the pending state
+              // does not push the adjacent Watch button (which is
+              // flex-1) around. Centre-aligned content + fixed width
+              // means the icon position stays put across states too.
+              className="inline-flex min-w-[7rem] items-center justify-center gap-1.5 rounded-md bg-bg-sunken px-2.5 py-1.5 font-semibold text-[12.5px] text-ink-2 transition hover:bg-card-tint hover:text-ink disabled:cursor-not-allowed disabled:opacity-60"
             >
               {isCancelPending ? (
-                <RefreshCw className="size-3 animate-spin" />
+                <>
+                  <RefreshCw className="size-3 animate-spin" /> Cancelling
+                </>
               ) : (
-                <Square className="size-3" />
-              )}{' '}
-              Stop
+                <>
+                  <Square className="size-3" /> Stop
+                </>
+              )}
             </button>
           )}
         </div>

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.tsx
@@ -1,3 +1,4 @@
+import { useCancelAgent } from '@/modules/api/cancel.hooks'
 import { useFocusAgent } from '@/modules/api/focus.hooks'
 import type { AgentActivityRecord } from '@/screens/cockpit/cockpit.helpers'
 import { AgentRunningCard } from './AgentRunningCard'
@@ -9,6 +10,7 @@ interface RunningGridProps {
 /** Renders live agent cards and focuses their BrowserOS tab group on watch. */
 export function RunningGrid({ agents }: RunningGridProps) {
   const focus = useFocusAgent()
+  const cancel = useCancelAgent()
   const liveCount = agents.filter((a) => a.status === 'active').length
 
   if (agents.length === 0) return null
@@ -26,8 +28,21 @@ export function RunningGrid({ agents }: RunningGridProps) {
       },
     )
   }
+  const onStop = (agentId: string) => {
+    cancel.mutate(
+      { agentId },
+      {
+        onError: (err) => {
+          // eslint-disable-next-line no-console
+          console.warn('cancel agent failed', { agentId, err })
+        },
+      },
+    )
+  }
   const pendingAgentId =
     focus.isPending && focus.variables ? focus.variables.agentId : null
+  const cancelPendingAgentId =
+    cancel.isPending && cancel.variables ? cancel.variables.agentId : null
 
   return (
     <section className="space-y-3">
@@ -47,7 +62,9 @@ export function RunningGrid({ agents }: RunningGridProps) {
             key={a.agentId}
             agent={a}
             onWatch={() => onWatch(a.agentId)}
+            onStop={() => onStop(a.agentId)}
             isFocusPending={pendingAgentId === a.agentId}
+            isCancelPending={cancelPendingAgentId === a.agentId}
           />
         ))}
       </div>

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.tsx
@@ -7,7 +7,7 @@ interface RunningGridProps {
   agents: AgentActivityRecord[]
 }
 
-/** Renders live agent cards and focuses their BrowserOS tab group on watch. */
+/** Renders live agent cards and switches to the agent's focus tab on Watch. */
 export function RunningGrid({ agents }: RunningGridProps) {
   const focus = useFocusAgent()
   const cancel = useCancelAgent()
@@ -15,15 +15,15 @@ export function RunningGrid({ agents }: RunningGridProps) {
 
   if (agents.length === 0) return null
 
-  const onWatch = (agentId: string) => {
+  const onWatch = (agent: AgentActivityRecord) => {
     focus.mutate(
-      { agentId },
+      { agentId: agent.agentId, focusUrl: agent.currentFocus.url },
       {
         onError: (err) => {
           // No toast surface in v2 yet; surface a console line so the
           // operator can read it from devtools while developing.
           // eslint-disable-next-line no-console
-          console.warn('focus agent failed', { agentId, err })
+          console.warn('focus agent failed', { agentId: agent.agentId, err })
         },
       },
     )
@@ -61,7 +61,7 @@ export function RunningGrid({ agents }: RunningGridProps) {
           <AgentRunningCard
             key={a.agentId}
             agent={a}
-            onWatch={() => onWatch(a.agentId)}
+            onWatch={() => onWatch(a)}
             onStop={() => onStop(a.agentId)}
             isFocusPending={pendingAgentId === a.agentId}
             isCancelPending={cancelPendingAgentId === a.agentId}

--- a/packages/browseros-agent/apps/claw-app/modules/api/cancel.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/cancel.hooks.ts
@@ -1,0 +1,38 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * react-query-kit mutation backing the homepage's Stop button. Hits
+ * `POST /agents/:agentId/cancel`; the server aborts every in-flight
+ * tool dispatch across all of this agent's MCP sessions and reports
+ * the count. The session stays open; the agent's harness sees the
+ * cancelled dispatch as an isError tool result and is free to fire
+ * its next call.
+ */
+
+import { createMutation } from 'react-query-kit'
+import { api } from './client'
+import { parseResponse } from './parseResponse'
+
+export interface CancelAgentResult {
+  ok: boolean
+  cancelled: number
+  reason?: string
+}
+
+interface CancelAgentVariables {
+  agentId: string
+}
+
+export const useCancelAgent = createMutation<
+  CancelAgentResult,
+  CancelAgentVariables
+>({
+  mutationFn: async ({ agentId }) => {
+    const response = await api.agents[':agentId'].cancel.$post({
+      param: { agentId },
+    })
+    return parseResponse<CancelAgentResult>(response)
+  },
+})

--- a/packages/browseros-agent/apps/claw-app/modules/api/cancel.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/cancel.hooks.ts
@@ -33,6 +33,18 @@ export const useCancelAgent = createMutation<
     const response = await api.agents[':agentId'].cancel.$post({
       param: { agentId },
     })
+    // The route returns a structured `{ok:false, cancelled:0, reason}`
+    // with HTTP 404 when there's nothing in flight (the agent is
+    // between dispatches or has gone idle). That is not a mutation
+    // failure; it is the legitimate idle state. Unwrap the body
+    // instead of letting parseResponse throw, so onSuccess fires with
+    // the structured result and the UI can surface "nothing was
+    // running" cleanly once a toast surface ships. Without this the
+    // hook routes the 404 through onError and the operator sees a
+    // misleading "cancel agent failed" console warn.
+    if (response.status === 404) {
+      return (await response.json()) as CancelAgentResult
+    }
     return parseResponse<CancelAgentResult>(response)
   },
 })

--- a/packages/browseros-agent/apps/claw-app/modules/api/focus.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/focus.hooks.ts
@@ -4,33 +4,65 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
  * react-query-kit mutation backing the homepage's Watch button.
- * Hits `POST /tabs/focus/:agentId`; the server expands the
- * agent's tab group in BrowserOS and activates the group's window.
+ *
+ * Drives the BrowserOS Chrome tab activation entirely via the
+ * extension's `chrome.tabs.*` and `chrome.windows.*` APIs. The
+ * earlier server route (`POST /tabs/focus/:agentId`) only expanded
+ * the agent's tab group, which is not what the operator wants when
+ * they click Watch: they want to actually switch BrowserOS to the
+ * tab the agent is currently working on. Doing that requires a
+ * chrome tab id, which the extension already has via
+ * `chrome.tabs.query`. The server has no business in the loop.
+ *
+ * Match strategy: query by the focus tab's URL. If multiple tabs
+ * share the URL we take the first match (rare in cockpit usage; the
+ * cockpit's per-agent tab groups isolate sessions). If no tab
+ * matches (e.g. the tab was closed since the registry last saw it)
+ * we return `ok: false` with a reason and the call site logs to the
+ * console. No toast surface in v2 yet.
  */
 
 import { createMutation } from 'react-query-kit'
-import { api } from './client'
-import { parseResponse } from './parseResponse'
 
 export interface FocusAgentResult {
   ok: boolean
-  groupId?: string
+  tabId?: number
   windowId?: number
   reason?: string
 }
 
 interface FocusAgentVariables {
   agentId: string
+  /**
+   * URL of the agent's freshest tab, sourced from
+   * `agent.currentFocus.url`. Used as the chrome.tabs.query filter.
+   */
+  focusUrl: string
 }
 
 export const useFocusAgent = createMutation<
   FocusAgentResult,
   FocusAgentVariables
 >({
-  mutationFn: async ({ agentId }) => {
-    const response = await api.tabs.focus[':agentId'].$post({
-      param: { agentId },
-    })
-    return parseResponse<FocusAgentResult>(response)
+  mutationFn: async ({ focusUrl }) => {
+    // chrome.tabs accepts a match pattern in `url`. The agent's
+    // focus URL is an exact string and matches itself.
+    const matches = await chrome.tabs.query({ url: focusUrl })
+    const tab = matches[0]
+    if (!tab || typeof tab.id !== 'number') {
+      return {
+        ok: false,
+        reason: `no chrome tab matches ${focusUrl}`,
+      }
+    }
+    await chrome.tabs.update(tab.id, { active: true })
+    if (typeof tab.windowId === 'number') {
+      await chrome.windows.update(tab.windowId, { focused: true })
+    }
+    return {
+      ok: true,
+      tabId: tab.id,
+      windowId: tab.windowId,
+    }
   },
 })

--- a/packages/browseros-agent/apps/claw-server/src/mcp/cancellation-result.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/cancellation-result.ts
@@ -1,0 +1,37 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Shared shape for the structured error result the cockpit returns
+ * when an operator cancels an in-flight tool dispatch via the Stop
+ * button. The MCP client (the agent's harness) sees this as a
+ * normal `isError: true` tool result with a text-content explanation
+ * and a structured discriminator the harness can detect if it wants
+ * to special-case cancellations vs other errors.
+ */
+
+import type { ToolResult } from './register-fn'
+
+/**
+ * The discriminator surfaced on `structuredContent` so a harness can
+ * tell operator-driven cancellations apart from other tool errors
+ * (timeouts, target detached, etc).
+ */
+export const CANCELLATION_DISCRIMINATOR = 'cockpit.operator-cancelled' as const
+
+export interface CancellationStructured {
+  cancellationReason: string
+  cancellationKind: typeof CANCELLATION_DISCRIMINATOR
+}
+
+export function cancellationErrorResult(reason: string): ToolResult {
+  return {
+    isError: true,
+    content: [{ type: 'text', text: reason }],
+    structuredContent: {
+      cancellationReason: reason,
+      cancellationKind: CANCELLATION_DISCRIMINATOR,
+    } satisfies CancellationStructured,
+  }
+}

--- a/packages/browseros-agent/apps/claw-server/src/mcp/register.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/register.ts
@@ -42,9 +42,14 @@ import {
 import { extractPageId, tabActivityRegistry } from '../lib/tab-activity'
 import type { StoredAgentProfile } from '../routes/agents/schemas'
 import { recordToolDispatch } from '../services/audit-log'
+import {
+  CANCELLATION_REASON,
+  dispatchCancellation,
+} from '../services/dispatch-cancellation'
 import { check } from '../services/permissions'
 import { persistScreenshot } from '../services/screenshots'
 import { ensureAgentTabGroup } from '../services/tab-group-ops'
+import { cancellationErrorResult } from './cancellation-result'
 import { asRegister, type ToolResult } from './register-fn'
 
 /**
@@ -267,6 +272,27 @@ export function registerBrowserTools(
 }
 
 /**
+ * Combine zero or more AbortSignals into one. Returns:
+ *  - `undefined` when no inputs are supplied (no abort wiring)
+ *  - the single input when only one is supplied (avoids the
+ *    AbortSignal.any wrapper overhead in the common case)
+ *  - an AbortSignal.any of all defined inputs otherwise
+ *
+ * AbortSignal.any is supported in Node 20.3+ and Bun runtimes the
+ * cockpit targets. Each input is dropped if it is undefined so
+ * callers can pass `[extra?.signal, userCancel.signal]` without
+ * filtering first.
+ */
+function composeAbortSignals(
+  signals: ReadonlyArray<AbortSignal | undefined>,
+): AbortSignal | undefined {
+  const defined = signals.filter((s): s is AbortSignal => s !== undefined)
+  if (defined.length === 0) return undefined
+  if (defined.length === 1) return defined[0]
+  return AbortSignal.any(defined)
+}
+
+/**
  * v2 dispatch record helper. The single MCP endpoint does not know
  * which `StoredAgentProfile` produced the call, so the registry write
  * sources its identity from the per-session `ClientIdentity` instead.
@@ -364,11 +390,81 @@ export function registerBrowserToolsForSingleServer(
         }
 
         const dispatchStart = Date.now()
-        const result = await executeTool(tool, rawArgs, {
-          session,
-          signal: extra?.signal,
-        })
+
+        // Operator-cancel hook. Compose the transport's existing
+        // signal (client-driven notifications/cancelled) with our
+        // own so EITHER side firing aborts executeTool cleanly. The
+        // controller is registered before the call and unregistered
+        // in the finally block so a successful or errored dispatch
+        // never leaves a stale entry behind.
+        const userCancel = new AbortController()
+        const sessionId = extra?.sessionId ?? ''
+        if (sessionId) dispatchCancellation.register(sessionId, userCancel)
+        const composedSignal = composeAbortSignals([
+          extra?.signal,
+          userCancel.signal,
+        ])
+
+        let result: Awaited<ReturnType<typeof executeTool>>
+        try {
+          result = await executeTool(tool, rawArgs, {
+            session,
+            signal: composedSignal,
+          })
+        } catch (err) {
+          if (userCancel.signal.aborted) {
+            result = cancellationErrorResult(CANCELLATION_REASON)
+          } else {
+            throw err
+          }
+        } finally {
+          if (sessionId) dispatchCancellation.unregister(sessionId, userCancel)
+        }
+        // Some tools translate an abort into a structured isError
+        // result rather than throwing; cover that too so the operator
+        // attribution is honest in the audit log.
+        if (userCancel.signal.aborted) {
+          result = cancellationErrorResult(CANCELLATION_REASON)
+        }
         const durationMs = Date.now() - dispatchStart
+
+        // Record cancelled dispatches in the audit log so the task
+        // timeline shows the operator's intervention. The existing
+        // success branch below is left untouched; cancellations are
+        // tracked here with a small adapter that walks the same
+        // recordToolDispatch path with isError: true.
+        if (userCancel.signal.aborted) {
+          const identity = resolveIdentity(extra?.sessionId)
+          if (identity) {
+            const { agentId, slug } = agentIdentityFromClient(identity)
+            const agentLabel =
+              identity.clientTitle && identity.clientTitle.length > 0
+                ? identity.clientTitle
+                : identity.clientName.length > 0
+                  ? identity.clientName
+                  : slug
+            const pageId = extractPageId(tool.name, rawArgs)
+            const live = pageId !== null ? session.pages.getInfo(pageId) : null
+            recordToolDispatch({
+              agentId,
+              slug,
+              agentLabel,
+              sessionId: extra?.sessionId ?? '',
+              toolName: tool.name,
+              pageId,
+              targetId: live?.targetId ?? null,
+              url: live?.url ?? null,
+              title: live?.title ?? null,
+              rawArgs,
+              durationMs,
+              result: {
+                isError: true,
+                structuredContent: result.structuredContent,
+                content: result.content,
+              },
+            })
+          }
+        }
 
         if (!result.isError) {
           const identity = resolveIdentity(extra?.sessionId)

--- a/packages/browseros-agent/apps/claw-server/src/routes/agents-control/index.ts
+++ b/packages/browseros-agent/apps/claw-server/src/routes/agents-control/index.ts
@@ -1,0 +1,39 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Powers the homepage's Stop button. Aborts every in-flight tool
+ * dispatch across all of this agent's live MCP sessions and returns
+ * the count so the UI can surface it. The session itself stays
+ * open; the agent's harness sees the cancelled dispatch as an
+ * isError tool result and is free to fire its next call.
+ */
+
+import { Hono } from 'hono'
+import {
+  CANCELLATION_REASON,
+  dispatchCancellation,
+} from '../../services/dispatch-cancellation'
+
+export const agentsControlRoute = new Hono().post(
+  '/agents/:agentId/cancel',
+  (c) => {
+    const agentId = c.req.param('agentId')
+    const cancelled = dispatchCancellation.cancelByAgent(
+      agentId,
+      CANCELLATION_REASON,
+    )
+    if (cancelled === 0) {
+      return c.json(
+        {
+          ok: false,
+          cancelled: 0,
+          reason: 'no active dispatches for this agent',
+        },
+        404,
+      )
+    }
+    return c.json({ ok: true, cancelled }, 200)
+  },
+)

--- a/packages/browseros-agent/apps/claw-server/src/server.ts
+++ b/packages/browseros-agent/apps/claw-server/src/server.ts
@@ -18,6 +18,7 @@ import { cors } from 'hono/cors'
 import { HttpError } from './lib/errors'
 import { logger } from './lib/logger'
 import { agentsRoute } from './routes/agents'
+import { agentsControlRoute } from './routes/agents-control'
 import { auditRoute } from './routes/audit'
 import { auditScreenshotsRoute } from './routes/audit/screenshots'
 import { auditTasksRoute } from './routes/audit/tasks'
@@ -85,6 +86,7 @@ const routes = app
   .route('/', mcpRoute)
   .route('/', tabsRoute)
   .route('/', tabsFocusRoute)
+  .route('/', agentsControlRoute)
   .route('/', connectionsRoute)
   .route('/', auditRoute)
   .route('/', auditTasksRoute)

--- a/packages/browseros-agent/apps/claw-server/src/services/dispatch-cancellation.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/dispatch-cancellation.ts
@@ -1,0 +1,105 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * In-memory registry of in-flight tool dispatch AbortControllers,
+ * keyed by `sessionId`. The MCP dispatch path in
+ * `apps/claw-server/src/mcp/register.ts` registers a controller at
+ * the start of every tool call and unregisters it in a finally
+ * block when the call resolves. The cockpit's Stop button calls
+ * `cancelByAgent(agentId)` which walks the identity service for
+ * matching sessions and aborts every registered controller.
+ *
+ * Why per-session sets: a single MCP session can have multiple
+ * concurrent tool calls in flight (the SDK allows parallel
+ * dispatch). Tracking a Set per session lets us cancel them all
+ * with one operator action. The session itself stays open after
+ * the abort; the agent's harness sees a normal `isError` result
+ * with the cancellation reason and can fire its next tool call
+ * immediately.
+ *
+ * The abort signal here is one half of an `AbortSignal.any(...)`
+ * composition in register.ts; the other half is the transport's
+ * own signal (from `extra?.signal`, used for client-initiated
+ * `notifications/cancelled`). Either side firing aborts the
+ * executeTool call cleanly without conflict.
+ */
+
+import {
+  agentIdentityFromClient,
+  type IdentityService,
+  identityService,
+} from '../lib/mcp-session'
+
+export interface DispatchCancellationService {
+  /** Called by register.ts at the start of every tool dispatch. */
+  register(sessionId: string, controller: AbortController): void
+  /** Called from a try/finally in register.ts when the dispatch resolves. */
+  unregister(sessionId: string, controller: AbortController): void
+  /**
+   * Aborts every active dispatch for this agent across all of its
+   * live sessions. Returns the count so the route can report
+   * whether anything was actually cancelled.
+   */
+  cancelByAgent(agentId: string, reason: string): number
+  /** Test-only escape hatches mirroring tab-activity / identity. */
+  size(): number
+  clear(): void
+}
+
+export interface CreateDispatchCancellationOpts {
+  identityService: Pick<IdentityService, 'list'>
+}
+
+export const CANCELLATION_REASON = 'Operation cancelled by the User'
+
+export function createDispatchCancellation(
+  opts: CreateDispatchCancellationOpts,
+): DispatchCancellationService {
+  const controllers = new Map<string, Set<AbortController>>()
+
+  return {
+    register(sessionId, controller) {
+      const existing = controllers.get(sessionId)
+      if (existing) {
+        existing.add(controller)
+        return
+      }
+      controllers.set(sessionId, new Set([controller]))
+    },
+    unregister(sessionId, controller) {
+      const set = controllers.get(sessionId)
+      if (!set) return
+      set.delete(controller)
+      if (set.size === 0) controllers.delete(sessionId)
+    },
+    cancelByAgent(agentId, reason) {
+      let cancelled = 0
+      for (const identity of opts.identityService.list()) {
+        const { agentId: candidateAgentId } = agentIdentityFromClient(identity)
+        if (candidateAgentId !== agentId) continue
+        const set = controllers.get(identity.sessionId)
+        if (!set) continue
+        for (const controller of set) {
+          controller.abort(reason)
+          cancelled += 1
+        }
+      }
+      return cancelled
+    },
+    size() {
+      let n = 0
+      for (const set of controllers.values()) n += set.size
+      return n
+    },
+    clear() {
+      controllers.clear()
+    },
+  }
+}
+
+/** Process-wide singleton consumed by register.ts + the cancel route. */
+export const dispatchCancellation = createDispatchCancellation({
+  identityService,
+})

--- a/packages/browseros-agent/apps/claw-server/tests/routes/agents-control/routes.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/routes/agents-control/routes.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Integration test for the POST /agents/:agentId/cancel route. The
+ * route reads from the process-wide dispatchCancellation singleton
+ * which sources its identityService from src/lib/mcp-session. We
+ * drive it by registering identities + AbortControllers directly,
+ * then issuing the HTTP call and asserting the wire shape + abort
+ * propagation.
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import { hc } from 'hono/client'
+import { identityService } from '../../../src/lib/mcp-session'
+import app, { type AppType } from '../../../src/server'
+import { dispatchCancellation } from '../../../src/services/dispatch-cancellation'
+
+function client() {
+  return hc<AppType>('http://localhost', {
+    fetch: (input, init) => app.fetch(new Request(input, init)),
+  })
+}
+
+afterEach(() => {
+  dispatchCancellation.clear()
+  identityService.clear()
+})
+
+describe('POST /agents/:agentId/cancel', () => {
+  test('returns 404 with cancelled: 0 when no sessions match', async () => {
+    const res = await client().agents[':agentId'].cancel.$post({
+      param: { agentId: 'nobody-home' },
+    })
+    expect(res.status).toBe(404)
+    const body = (await res.json()) as { ok: boolean; cancelled: number }
+    expect(body.ok).toBe(false)
+    expect(body.cancelled).toBe(0)
+  })
+
+  test('aborts every registered controller for the agent and returns the count', async () => {
+    const identity = identityService.registerInitialize({
+      sessionId: 's1',
+      clientInfo: { name: 'claude-code', version: '0.1.0' },
+    })
+    const c1 = new AbortController()
+    const c2 = new AbortController()
+    dispatchCancellation.register(identity.sessionId, c1)
+    dispatchCancellation.register(identity.sessionId, c2)
+
+    const res = await client().agents[':agentId'].cancel.$post({
+      param: { agentId: 'claude-code' },
+    })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { ok: boolean; cancelled: number }
+    expect(body.ok).toBe(true)
+    expect(body.cancelled).toBe(2)
+    expect(c1.signal.aborted).toBe(true)
+    expect(c2.signal.aborted).toBe(true)
+    expect(c1.signal.reason).toBe('Operation cancelled by the User')
+  })
+
+  test('does not abort controllers belonging to a different agent', async () => {
+    const a = identityService.registerInitialize({
+      sessionId: 'sA',
+      clientInfo: { name: 'claude-code', version: '0.1.0' },
+    })
+    const b = identityService.registerInitialize({
+      sessionId: 'sB',
+      clientInfo: { name: 'cursor', version: '0.1.0' },
+    })
+    const cA = new AbortController()
+    const cB = new AbortController()
+    dispatchCancellation.register(a.sessionId, cA)
+    dispatchCancellation.register(b.sessionId, cB)
+
+    const res = await client().agents[':agentId'].cancel.$post({
+      param: { agentId: 'claude-code' },
+    })
+
+    expect(res.status).toBe(200)
+    const body = (await res.json()) as { ok: boolean; cancelled: number }
+    expect(body.cancelled).toBe(1)
+    expect(cA.signal.aborted).toBe(true)
+    expect(cB.signal.aborted).toBe(false)
+  })
+})

--- a/packages/browseros-agent/apps/claw-server/tests/services/dispatch-cancellation.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/dispatch-cancellation.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Unit tests for the dispatch-cancellation service. We construct
+ * factory instances with a stub identity service so the tests do not
+ * touch the process-wide singleton.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import type { ClientIdentity, IdentityService } from '../../src/lib/mcp-session'
+import { createDispatchCancellation } from '../../src/services/dispatch-cancellation'
+
+function makeIdentity(over: Partial<ClientIdentity>): ClientIdentity {
+  return {
+    sessionId: 's1',
+    clientName: 'claude-code',
+    clientVersion: '0.1.0',
+    clientTitle: null,
+    firstSeenAt: 1_000_000,
+    ...over,
+  }
+}
+
+function stubIdentityService(
+  identities: ClientIdentity[],
+): Pick<IdentityService, 'list'> {
+  return { list: () => identities }
+}
+
+describe('dispatch-cancellation', () => {
+  it('register + unregister round-trips controllers and prunes empty sets', () => {
+    const svc = createDispatchCancellation({
+      identityService: stubIdentityService([]),
+    })
+    const ctrl1 = new AbortController()
+    const ctrl2 = new AbortController()
+    svc.register('s1', ctrl1)
+    svc.register('s1', ctrl2)
+    expect(svc.size()).toBe(2)
+    svc.unregister('s1', ctrl1)
+    expect(svc.size()).toBe(1)
+    svc.unregister('s1', ctrl2)
+    expect(svc.size()).toBe(0)
+  })
+
+  it('unregister is a no-op for unknown sessionId', () => {
+    const svc = createDispatchCancellation({
+      identityService: stubIdentityService([]),
+    })
+    expect(() => svc.unregister('unknown', new AbortController())).not.toThrow()
+  })
+
+  it('cancelByAgent aborts every controller for matching sessions', () => {
+    const svc = createDispatchCancellation({
+      identityService: stubIdentityService([
+        makeIdentity({ sessionId: 's1', clientName: 'claude-code' }),
+        makeIdentity({ sessionId: 's2', clientName: 'claude-code' }),
+        makeIdentity({ sessionId: 's3', clientName: 'cursor' }),
+      ]),
+    })
+    const c1 = new AbortController()
+    const c2 = new AbortController()
+    const c3 = new AbortController()
+    svc.register('s1', c1)
+    svc.register('s2', c2)
+    svc.register('s3', c3)
+
+    // agentIdentityFromClient slugifies clientName, so 'claude-code'
+    // becomes agentId 'claude-code'.
+    const cancelled = svc.cancelByAgent('claude-code', 'stop now')
+
+    expect(cancelled).toBe(2)
+    expect(c1.signal.aborted).toBe(true)
+    expect(c2.signal.aborted).toBe(true)
+    expect(c3.signal.aborted).toBe(false)
+    expect(c1.signal.reason).toBe('stop now')
+  })
+
+  it('cancelByAgent returns 0 when no sessions match', () => {
+    const svc = createDispatchCancellation({
+      identityService: stubIdentityService([
+        makeIdentity({ sessionId: 's1', clientName: 'claude-code' }),
+      ]),
+    })
+    const c1 = new AbortController()
+    svc.register('s1', c1)
+    expect(svc.cancelByAgent('ghost-agent', 'no')).toBe(0)
+    expect(c1.signal.aborted).toBe(false)
+  })
+
+  it('cancelByAgent returns 0 when the matching session has no controllers', () => {
+    const svc = createDispatchCancellation({
+      identityService: stubIdentityService([
+        makeIdentity({ sessionId: 's1', clientName: 'claude-code' }),
+      ]),
+    })
+    expect(svc.cancelByAgent('claude-code', 'no')).toBe(0)
+  })
+
+  it('clear empties the registry', () => {
+    const svc = createDispatchCancellation({
+      identityService: stubIdentityService([]),
+    })
+    svc.register('s1', new AbortController())
+    svc.register('s2', new AbortController())
+    expect(svc.size()).toBe(2)
+    svc.clear()
+    expect(svc.size()).toBe(0)
+  })
+})


### PR DESCRIPTION
## Summary

Both action buttons on every Running-now homepage card were broken: the Stop button was rendered but its `onClick` was undefined (dead UI), and the Watch button merely expanded the agent's tab group in BrowserOS without actually switching to the tab the agent was working on. This PR makes both do what an operator would expect.

## What changed

### Stop button: cancel in-flight tool dispatches end-to-end

Clicking Stop aborts every in-flight MCP tool dispatch across all of that agent's live sessions and returns a structured error to the agent's harness reading `Operation cancelled by the User`. The MCP session stays open; the agent can fire its next `tools/call` immediately. The cancelled dispatch lands in the audit log as a normal isError row so the task timeline shows the operator's intervention.

\`\`\`
[Stop click] -> POST /agents/:agentId/cancel
                     |
                     v
        dispatch-cancellation service walks identityService
        for matching agentId, aborts every registered
        AbortController across those sessions
                     |
                     v
        register.ts: AbortSignal.any([extra?.signal, userCancel.signal])
        executeTool resolves; register.ts swaps the result for
        cancellationErrorResult(), records to audit, returns to MCP
\`\`\`

Reuses the same `AbortSignal` mechanism the MCP SDK already uses for client-initiated `notifications/cancelled`. From the agent's perspective the response is a tool error result with a structured discriminator (`cancellationKind: 'cockpit.operator-cancelled'`) on `structuredContent` so harnesses can tell operator cancellations apart from other tool errors.

UI affordance: button swaps to `[spinner] Cancelling` while pending, with `min-w-[7rem]` reserving enough width so the adjacent Watch button (which is `flex-1`) doesn't shift on the label swap.

### Watch button: actually switch BrowserOS to the agent's tab

Previously Watch hit `POST /tabs/focus/:agentId` which only collapsed/expanded the agent's tab group, never switching the focus tab. Operator feedback: "there's absolutely no use focusing on a tab group, it should switch to that tab."

The cockpit's server tracks CDP target ids and browser-mcp page ids; neither maps directly to `chrome.tabs.id`. But the claw-app extension already has the `tabs` + `tabGroups` permissions, so it can drive `chrome.tabs.update` itself, no server roundtrip needed.

\`useFocusAgent\` now does its work entirely in the extension:

\`\`\`ts
const matches = await chrome.tabs.query({ url: focusUrl })
await chrome.tabs.update(tab.id, { active: true })
await chrome.windows.update(tab.windowId, { focused: true })
\`\`\`

The mutation takes \`{ agentId, focusUrl }\` where \`focusUrl\` is \`agent.currentFocus.url\` (the freshest tab the agent has touched). If no chrome tab matches the URL (e.g. it was closed since the registry's last snapshot) the mutation returns ok:false and the call site logs a warn. No toast surface in v2 yet.

The server route \`POST /tabs/focus/:agentId\` is now unused; left mounted to keep the API surface stable for any external caller. Removable in a follow-up.

## Commits

| # | Commit | Subject |
|---|---|---|
| 1 | \`59799e87\` | \`feat(claw-server): dispatch-cancellation service\` |
| 2 | \`7cb541e6\` | \`feat(claw-server): register.ts pipes a user-cancel signal into executeTool\` |
| 3 | \`cbbd9acf\` | \`feat(claw-server): POST /agents/:agentId/cancel route\` |
| 4 | \`96552f16\` | \`feat(claw-app): useCancelAgent mutation\` |
| 5 | \`cee86d66\` | \`feat(claw-app): wire Stop button to cancel agent dispatches\` |
| 6 | \`f7896441\` | \`fix(claw-app): Stop button shows 'Cancelling' label without layout shift\` |
| 7 | \`c3ede050\` | \`feat(claw-app): Watch uses chrome.tabs API directly, no server roundtrip\` |

## Files

\`\`\`
apps/claw-server/src/services/dispatch-cancellation.ts                 NEW  ~125 LOC
apps/claw-server/src/routes/agents-control/index.ts                    NEW  ~35 LOC
apps/claw-server/src/mcp/cancellation-result.ts                        NEW  ~35 LOC
apps/claw-server/src/mcp/register.ts                                   EDIT +75 LOC
apps/claw-server/src/server.ts                                         EDIT +2
apps/claw-server/tests/services/dispatch-cancellation.test.ts          NEW  6 cases
apps/claw-server/tests/routes/agents-control/routes.test.ts            NEW  3 cases

apps/claw-app/modules/api/cancel.hooks.ts                              NEW  ~35 LOC
apps/claw-app/modules/api/focus.hooks.ts                               REWRITE (server -> chrome.tabs)
apps/claw-app/components/cockpit/AgentRunningCard.tsx                  EDIT
apps/claw-app/components/cockpit/RunningGrid.tsx                       EDIT
\`\`\`

## Tests

- backend: **293 pass** (+9 vs main: 6 cancel-service + 3 cancel-route)
- UI: **95 pass** (existing prop-passthrough tests cover the wiring)
- typecheck + biome clean on both packages

## Manual smoke verification

End-to-end dogfood with two parallel agents (\`alpha\` running HN, \`beta\` running example.com), each holding 25-second \`wait\` calls:

- **Watch**: clicking Watch on either card switches BrowserOS to the right tab AND brings the window forward; no network roundtrip
- **Stop**: clicking Stop cancels the in-flight \`wait\` within ~50ms; the agent's rig immediately starts its next call; cancel is scoped to the clicked card only (the other agent keeps running)
- **Audit**: cancelled dispatches show up as red isError rows in the task timeline with \`result_meta.cancellationReason: 'Operation cancelled by the User'\`
- **Multi-cancel**: clicking Stop again while another cancel is pending is a safe no-op (button is disabled with 'Cancelling' label)

## Rollback

- Stop route can be un-mounted in one line in \`server.ts\`. The UI button hits 404 and surfaces a console warn; everything else keeps working.
- Stop dispatch-path wiring lives entirely inside \`register.ts\`. Reverting just that commit removes the \`AbortSignal.any\` composition and the try/finally without touching anything else.
- Watch can be reverted by restoring the prior server-call shape of \`focus.hooks.ts\`. The server route is still in place.
- No DB migration, no schema change, no on-disk state.