### PR TITLE
chore(mcp): bump agent-mcp-manager to 0.0.3 and hide Claude Desktop

### DIFF
--- a/packages/browseros-agent/apps/app/screens/mcp-settings/QuickSetupSection.tsx
+++ b/packages/browseros-agent/apps/app/screens/mcp-settings/QuickSetupSection.tsx
@@ -61,33 +61,6 @@ const clients: ClientConfig[] = [
     action: 'Run in your terminal:',
     getSnippet: (url) => `codex mcp add browseros ${url}`,
   },
-  {
-    id: 'claude-desktop',
-    name: 'Claude Desktop',
-    kind: 'config',
-    action: (
-      <>
-        Add to{' '}
-        <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">
-          ~/Library/Application Support/Claude/claude_desktop_config.json
-        </code>{' '}
-        and restart Claude Desktop:
-      </>
-    ),
-    getSnippet: (url) =>
-      JSON.stringify(
-        {
-          mcpServers: {
-            browserOS: {
-              command: 'npx',
-              args: ['mcp-remote', url],
-            },
-          },
-        },
-        null,
-        2,
-      ),
-  },
 ]
 
 const CopyButton: FC<{ text: string; label?: string }> = ({ text, label }) => {

--- a/packages/browseros-agent/apps/app/screens/mcp-settings/agent-marks.tsx
+++ b/packages/browseros-agent/apps/app/screens/mcp-settings/agent-marks.tsx
@@ -12,6 +12,7 @@
 
 import type { FC, SVGProps } from 'react'
 import { AnthropicBlack } from '@/components/ui/svgs/anthropicBlack'
+import { ClaudeAiIcon } from '@/components/ui/svgs/claudeAiIcon'
 import { CodexLight } from '@/components/ui/svgs/codexLight'
 import { CursorLight } from '@/components/ui/svgs/cursorLight'
 import { Vscode } from '@/components/ui/svgs/vscode'
@@ -21,6 +22,13 @@ export type AgentMarkProps = SVGProps<SVGSVGElement>
 
 export const ClaudeMark: FC<AgentMarkProps> = (props) => (
   <AnthropicBlack aria-hidden {...props} />
+)
+
+// Kept so legacy installs that still have an active BrowserOS link
+// to Claude Desktop render with the right brand mark; new users no
+// longer see the row (filtered server-side in listAgents).
+export const ClaudeDesktopMark: FC<AgentMarkProps> = (props) => (
+  <ClaudeAiIcon aria-hidden {...props} />
 )
 
 export const CursorMark: FC<AgentMarkProps> = (props) => (

--- a/packages/browseros-agent/apps/app/screens/mcp-settings/agent-marks.tsx
+++ b/packages/browseros-agent/apps/app/screens/mcp-settings/agent-marks.tsx
@@ -12,7 +12,6 @@
 
 import type { FC, SVGProps } from 'react'
 import { AnthropicBlack } from '@/components/ui/svgs/anthropicBlack'
-import { ClaudeAiIcon } from '@/components/ui/svgs/claudeAiIcon'
 import { CodexLight } from '@/components/ui/svgs/codexLight'
 import { CursorLight } from '@/components/ui/svgs/cursorLight'
 import { Vscode } from '@/components/ui/svgs/vscode'
@@ -22,10 +21,6 @@ export type AgentMarkProps = SVGProps<SVGSVGElement>
 
 export const ClaudeMark: FC<AgentMarkProps> = (props) => (
   <AnthropicBlack aria-hidden {...props} />
-)
-
-export const ClaudeDesktopMark: FC<AgentMarkProps> = (props) => (
-  <ClaudeAiIcon aria-hidden {...props} />
 )
 
 export const CursorMark: FC<AgentMarkProps> = (props) => (

--- a/packages/browseros-agent/apps/app/screens/mcp-settings/integrations-section.helpers.ts
+++ b/packages/browseros-agent/apps/app/screens/mcp-settings/integrations-section.helpers.ts
@@ -1,6 +1,5 @@
 import type { FC, SVGProps } from 'react'
 import {
-  ClaudeDesktopMark,
   ClaudeMark,
   CodexMark,
   CursorMark,
@@ -29,11 +28,6 @@ const AGENT_PRESENTATION: Record<string, AgentPresentation> = {
     label: 'Claude Code',
     installUrl: 'https://claude.ai/code',
     mark: ClaudeMark,
-  },
-  'claude-desktop': {
-    label: 'Claude Desktop',
-    installUrl: 'https://claude.ai/download',
-    mark: ClaudeDesktopMark,
   },
   cursor: {
     label: 'Cursor',

--- a/packages/browseros-agent/apps/app/screens/mcp-settings/integrations-section.helpers.ts
+++ b/packages/browseros-agent/apps/app/screens/mcp-settings/integrations-section.helpers.ts
@@ -1,5 +1,6 @@
 import type { FC, SVGProps } from 'react'
 import {
+  ClaudeDesktopMark,
   ClaudeMark,
   CodexMark,
   CursorMark,
@@ -28,6 +29,16 @@ const AGENT_PRESENTATION: Record<string, AgentPresentation> = {
     label: 'Claude Code',
     installUrl: 'https://claude.ai/code',
     mark: ClaudeMark,
+  },
+  // Hidden from fresh users in `listAgents` because the integration
+  // needs Node on the user's machine. Preserved here so legacy
+  // installs that still have a BrowserOS link to Claude Desktop
+  // render with the right label and brand mark while the user
+  // disconnects.
+  'claude-desktop': {
+    label: 'Claude Desktop',
+    installUrl: 'https://claude.ai/download',
+    mark: ClaudeDesktopMark,
   },
   cursor: {
     label: 'Cursor',

--- a/packages/browseros-agent/apps/app/screens/onboarding/features/Features.tsx
+++ b/packages/browseros-agent/apps/app/screens/onboarding/features/Features.tsx
@@ -66,7 +66,7 @@ const features: Feature[] = [
     highlights: [
       'One-line setup — run `claude mcp add` with your server URL to connect',
       '31 browser tools — tabs, clicks, typing, screenshots, bookmarks, history',
-      'Works everywhere — Claude Code, Gemini CLI, Codex, Claude Desktop',
+      'Works everywhere — Claude Code, Gemini CLI, Codex, Cursor, Zed',
       'Authenticated access — extract data from logged-in pages like LinkedIn',
     ],
     videoDuration: '1:40',

--- a/packages/browseros-agent/apps/claw-app/screens/new-agent/HarnessSection.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/new-agent/HarnessSection.tsx
@@ -12,9 +12,9 @@ import { Input } from '@/components/ui/input'
 import { RadioGroup, RadioGroupItem } from '@/components/ui/radio-group'
 import { cn } from '@/lib/utils'
 import {
-  HARNESSES,
   type Harness,
   type NewAgentValues,
+  SELECTABLE_HARNESSES,
 } from './new-agent.schemas'
 
 export function HarnessSection() {
@@ -60,7 +60,7 @@ export function HarnessSection() {
                 onValueChange={(value) => field.onChange(value as Harness)}
                 className="grid grid-cols-2 gap-2 md:grid-cols-3"
               >
-                {HARNESSES.map((name) => {
+                {SELECTABLE_HARNESSES.map((name) => {
                   const selected = field.value === name
                   return (
                     <label

--- a/packages/browseros-agent/apps/claw-app/screens/new-agent/new-agent.schemas.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/new-agent/new-agent.schemas.ts
@@ -6,6 +6,14 @@ import { z } from 'zod'
  * BrowserOS-internal harnesses that no-op the install. Keep this
  * list in sync with the backend's harnessEnum at
  * `apps/claw-server/src/routes/agents/schemas.ts`.
+ *
+ * NOTE: `HARNESSES` is the full Harness type-domain — it covers any
+ * harness value we may have stored historically. The wizard picker
+ * iterates `SELECTABLE_HARNESSES` (below) instead, which subtracts
+ * `RETIRED_HARNESSES` to drop options BrowserOS no longer offers for
+ * new creates. Existing profiles whose harness lives in
+ * `RETIRED_HARNESSES` still parse, render with the right icon, and
+ * can be uninstalled — they just can't be re-picked.
  */
 export const HARNESSES = [
   'Claude Code',
@@ -20,6 +28,24 @@ export const HARNESSES = [
 ] as const
 
 export type Harness = (typeof HARNESSES)[number]
+
+/**
+ * Harnesses removed from the new-agent picker. Claude Desktop is
+ * hidden because its config parser only validates stdio entries and
+ * the recommended `npx mcp-remote` bridge requires Node on the
+ * user's machine, which BrowserOS cannot guarantee. Mirrors the
+ * apps/server `HIDDEN_AGENTS` rationale.
+ */
+export const RETIRED_HARNESSES = [
+  'Claude Desktop',
+] as const satisfies readonly Harness[]
+
+export const SELECTABLE_HARNESSES = HARNESSES.filter(
+  (h): h is Exclude<Harness, (typeof RETIRED_HARNESSES)[number]> =>
+    !(RETIRED_HARNESSES as readonly Harness[]).includes(h),
+)
+
+export type SelectableHarness = (typeof SELECTABLE_HARNESSES)[number]
 
 export const LOGIN_MODES = ['profile', 'all', 'selective'] as const
 export type LoginMode = (typeof LOGIN_MODES)[number]
@@ -78,7 +104,9 @@ export type CustomAclRule = z.infer<typeof customAclRuleSchema>
 
 export const newAgentSchema = z.object({
   name: z.string().trim().min(1, 'Give the connector a name'),
-  harness: z.enum(HARNESSES),
+  // Form validation rejects retired harnesses so a hand-crafted
+  // submission can't slip Claude Desktop back into the create path.
+  harness: z.enum(SELECTABLE_HARNESSES),
   loginMode: z.enum(LOGIN_MODES),
   selectedSites: z.array(z.string()),
   approvals: z.record(z.string(), z.enum(APPROVAL_VERDICTS)),

--- a/packages/browseros-agent/apps/claw-server/package.json
+++ b/packages/browseros-agent/apps/claw-server/package.json
@@ -34,7 +34,7 @@
     "@browseros/shared": "workspace:*",
     "@hono/zod-validator": "^0.8.0",
     "@modelcontextprotocol/sdk": "^1.27.1",
-    "agent-mcp-manager": "^0.0.1",
+    "agent-mcp-manager": "^0.0.3",
     "commander": "^14.0.3",
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.3",

--- a/packages/browseros-agent/apps/claw-server/src/services/browseros-connect.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/browseros-connect.ts
@@ -16,7 +16,8 @@
  * profile's slug, with a slug-shaped URL. v2 has no per-agent
  * profile, so this layer writes one entry keyed by the constant
  * `BROWSEROS_MCP_SERVER_NAME` ("browseros") with the slugless URL.
- * Both layers share `specFor` for the Codex stdio wrapping.
+ * Both layers share `specFor` for transport selection (HTTP vs the
+ * stdio `npx mcp-remote` fallback for stdio-only agents).
  */
 
 import type { AgentId } from 'agent-mcp-manager'

--- a/packages/browseros-agent/apps/claw-server/src/services/spec-for.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/spec-for.ts
@@ -4,26 +4,31 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
  * Picks the right `McpServerSpec` shape for a given harness agent id.
- * Most harnesses speak HTTP MCP natively, so a `{ transport: 'http',
- * url }` entry is enough. Codex is stdio-only, so we wrap the URL via
- * `npx mcp-remote` the same way `apps/server` does.
+ * Transport capability is sourced from the agent-mcp-manager catalog
+ * (`resolveAgentSurface`) so a bump like Codex moving from stdio-only
+ * to http-capable (0.0.3) is picked up automatically without editing
+ * a parallel allow-list here. Stdio-only agents fall back to wrapping
+ * the URL via `npx mcp-remote`, the same approach `apps/server` uses.
  *
  * Used by both the legacy per-agent install (`harness-install.ts`)
  * and the v2 single-endpoint install (`browseros-connect.ts`) so the
- * stdio-wrapping rule lives in one place.
+ * transport rule lives in one place.
  */
 
-import type { AgentId, McpServerSpec } from 'agent-mcp-manager'
-
-const STDIO_ONLY: ReadonlySet<AgentId> = new Set<AgentId>(['codex'])
+import {
+  type AgentId,
+  type McpServerSpec,
+  resolveAgentSurface,
+} from 'agent-mcp-manager'
 
 export function specFor(agentId: AgentId, mcpUrl: string): McpServerSpec {
-  if (STDIO_ONLY.has(agentId)) {
-    return {
-      transport: 'stdio',
-      command: 'npx',
-      args: ['mcp-remote', mcpUrl],
-    }
+  const surface = resolveAgentSurface(agentId, 'system')
+  if (surface.supportedTransports.includes('http')) {
+    return { transport: 'http', url: mcpUrl }
   }
-  return { transport: 'http', url: mcpUrl }
+  return {
+    transport: 'stdio',
+    command: 'npx',
+    args: ['mcp-remote', mcpUrl],
+  }
 }

--- a/packages/browseros-agent/apps/claw-server/tests/lib/migrate-mcp-urls.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/lib/migrate-mcp-urls.test.ts
@@ -109,11 +109,16 @@ describe('migrateMcpUrls', () => {
       expect(methods).toContain('add')
       expect(methods).toContain('link')
       const addCall = stub.calls.find((c) => c.method === 'add')
+      // `makeInput` defaults to the Claude Desktop harness, whose
+      // config parser only validates stdio entries; specFor sources
+      // that from the agent-mcp-manager catalog and wraps the URL in
+      // `npx mcp-remote`.
       expect(addCall?.payload).toMatchObject({
         name: created.slug,
         spec: {
-          transport: 'http',
-          url: `http://127.0.0.1:9100/mcp/${created.slug}`,
+          transport: 'stdio',
+          command: 'npx',
+          args: ['mcp-remote', `http://127.0.0.1:9100/mcp/${created.slug}`],
         },
       })
     })

--- a/packages/browseros-agent/apps/claw-server/tests/services/browseros-connect.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/browseros-connect.test.ts
@@ -42,19 +42,17 @@ describe('connectBrowserosToHarness', () => {
     expect((link?.payload as { agent: string }).agent).toBe('claude-code')
   })
 
-  it('wraps Codex in npx mcp-remote', async () => {
+  it('writes a direct HTTP spec for Codex (http-capable since agent-mcp-manager 0.0.3)', async () => {
     const stub = createStubMcpManager()
     setMcpManagerForTesting(stub)
     await connectBrowserosToHarness('Codex')
     const add = stub.calls.find((c) => c.method === 'add')
     const payload = add?.payload as {
-      spec: { transport: string; command?: string; args?: string[] }
+      spec: { transport: string; url?: string }
     }
-    expect(payload.spec.transport).toBe('stdio')
-    expect(payload.spec.command).toBe('npx')
-    expect(payload.spec.args?.[0]).toBe('mcp-remote')
-    expect(payload.spec.args?.[1]).toContain('/mcp')
-    expect(payload.spec.args?.[1]).not.toContain('/cockpit')
+    expect(payload.spec.transport).toBe('http')
+    expect(payload.spec.url).toContain('/mcp')
+    expect(payload.spec.url).not.toContain('/cockpit')
   })
 
   it('short-circuits as a no-op for BrowserOS-internal harnesses (Hermes, OpenClaw)', async () => {

--- a/packages/browseros-agent/apps/claw-server/tests/services/harness-install.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/harness-install.test.ts
@@ -36,7 +36,11 @@ function makeInput(overrides: Partial<NewAgentValues> = {}): NewAgentValues {
 }
 
 describe('harness install service', () => {
-  test('installForAgent on Claude Desktop links the slug under claude-desktop', async () => {
+  test('installForAgent on Claude Desktop wraps the slug in npx mcp-remote (stdio-only parser)', async () => {
+    // Claude Desktop's `claude_desktop_config.json` parser validates
+    // stdio-shaped entries only, so the install path must write the
+    // `npx mcp-remote <url>` shape. specFor sources this from the
+    // agent-mcp-manager catalog via resolveAgentSurface.
     await withTempBrowserosDir(async () => {
       const stub = createStubMcpManager()
       setMcpManagerForTesting(stub)
@@ -45,7 +49,11 @@ describe('harness install service', () => {
       const linkCall = stub.calls.find((c) => c.method === 'link')
       expect(addCall?.payload).toMatchObject({
         name: created.slug,
-        spec: { transport: 'http', url: created.mcpUrl },
+        spec: {
+          transport: 'stdio',
+          command: 'npx',
+          args: ['mcp-remote', created.mcpUrl],
+        },
       })
       expect(linkCall?.payload).toMatchObject({
         serverName: created.slug,
@@ -56,7 +64,7 @@ describe('harness install service', () => {
     })
   })
 
-  test('installForAgent on Codex uses stdio + mcp-remote', async () => {
+  test('installForAgent on Codex writes a direct HTTP spec (http-capable since agent-mcp-manager 0.0.3)', async () => {
     await withTempBrowserosDir(async () => {
       const stub = createStubMcpManager()
       setMcpManagerForTesting(stub)
@@ -69,9 +77,8 @@ describe('harness install service', () => {
       expect(addCall?.payload).toMatchObject({
         name: 'cdx-test',
         spec: {
-          transport: 'stdio',
-          command: 'npx',
-          args: ['mcp-remote', 'http://127.0.0.1:9200/mcp/cdx-test'],
+          transport: 'http',
+          url: 'http://127.0.0.1:9200/mcp/cdx-test',
         },
       })
       const linkCall = stub.calls.find((c) => c.method === 'link')

--- a/packages/browseros-agent/apps/server/package.json
+++ b/packages/browseros-agent/apps/server/package.json
@@ -82,7 +82,7 @@
     "acp-probe": "^0.0.2",
     "acpx": "^0.10.0",
     "acpx-ai-provider": "^0.0.6",
-    "agent-mcp-manager": "^0.0.2",
+    "agent-mcp-manager": "^0.0.3",
     "ai": "^6.0.208",
     "commander": "^14.0.3",
     "core-js": "3.45.1",

--- a/packages/browseros-agent/apps/server/src/lib/mcp-manager/manager.ts
+++ b/packages/browseros-agent/apps/server/src/lib/mcp-manager/manager.ts
@@ -15,18 +15,20 @@ import { getBrowserosDir } from '../browseros-dir'
 
 /**
  * Server-name BrowserOS registers itself under for agents that speak
- * MCP over HTTP natively (Claude Code, Claude Desktop, Cursor, VS Code,
- * Zed). The stdio-only agents get a separate entry — see
+ * MCP over HTTP natively (Claude Code, Cursor, VS Code, Codex, Zed).
+ * Stdio-only agents — when supported — get a separate entry under
  * `BROWSEROS_MCP_STDIO_SERVER_NAME` below.
  */
 export const BROWSEROS_MCP_SERVER_NAME = 'browseros'
 
 /**
- * Server-name BrowserOS registers itself under for stdio-only agents
- * (today: Codex). The spec wraps `npx mcp-remote <url>` so a stdio
- * client can speak to the BrowserOS HTTP MCP endpoint. Kept as a
- * separate manifest entry from the HTTP one so each carries its own
- * spec and can be reconciled independently.
+ * Server-name BrowserOS registers itself under for stdio-only agents.
+ * The spec wraps `npx mcp-remote <url>` so a stdio client can speak
+ * to the BrowserOS HTTP MCP endpoint. Kept as a separate manifest
+ * entry from the HTTP one so each carries its own spec and can be
+ * reconciled independently. No surfaced agent currently uses this
+ * branch — Claude Desktop is hidden from the Integrations panel
+ * because its stdio bridge requires Node on the user's machine.
  */
 export const BROWSEROS_MCP_STDIO_SERVER_NAME = 'browseros-stdio'
 

--- a/packages/browseros-agent/apps/server/src/lib/mcp-manager/service.ts
+++ b/packages/browseros-agent/apps/server/src/lib/mcp-manager/service.ts
@@ -36,7 +36,7 @@ export type DetectInstalledAgentsFn = () => Promise<AgentInfo[]>
 
 /**
  * Agents the upstream library supports but BrowserOS deliberately
- * does not surface in the Integrations panel.
+ * does not surface in the Integrations panel for fresh users.
  *
  * - `gemini`: HTTP MCP support is not stable enough to one-click
  *   install against.
@@ -46,8 +46,12 @@ export type DetectInstalledAgentsFn = () => Promise<AgentInfo[]>
  *   bundled-runtime path we cannot make this reliable, so we hide it
  *   rather than ship a broken-by-default flow.
  *
- * Users who actually want either can still copy-paste the manual
- * setup snippet from the disclosure on the same page.
+ * Hiding is conditional in `listAgents`: if the user already has an
+ * active BrowserOS link to a hidden agent (e.g. from before we hid
+ * it), the row stays visible so they can still hit Disconnect to
+ * clean it up. Once the link is removed the next refresh hides it.
+ * Anyone who wants to re-install one of these can still copy-paste
+ * the manual setup snippet from the disclosure on the same page.
  */
 const HIDDEN_AGENTS: ReadonlySet<string> = new Set(['gemini', 'claude-desktop'])
 
@@ -102,11 +106,16 @@ export async function listAgents(
   const mgr = getMcpManager()
   const detect = options.detect ?? detectInstalledAgents
   const [detectedRaw, links] = await Promise.all([detect(), mgr.listLinks()])
-  const detected = detectedRaw.filter((a) => !HIDDEN_AGENTS.has(a.id))
   const linkedSet = new Set(
     links
       .filter((l) => BROWSEROS_SERVER_NAMES.includes(l.serverName))
       .map((l) => l.agent),
+  )
+  // Hidden agents stay visible IF the user already has an active
+  // BrowserOS link; that link still needs a Disconnect tile so they
+  // can remove it. Once unlinked the next refresh filters them out.
+  const detected = detectedRaw.filter(
+    (a) => !HIDDEN_AGENTS.has(a.id) || linkedSet.has(a.id),
   )
   return detected.map((a) => ({
     id: a.id,

--- a/packages/browseros-agent/apps/server/src/lib/mcp-manager/service.ts
+++ b/packages/browseros-agent/apps/server/src/lib/mcp-manager/service.ts
@@ -50,8 +50,11 @@ export type DetectInstalledAgentsFn = () => Promise<AgentInfo[]>
  * active BrowserOS link to a hidden agent (e.g. from before we hid
  * it), the row stays visible so they can still hit Disconnect to
  * clean it up. Once the link is removed the next refresh hides it.
- * Anyone who wants to re-install one of these can still copy-paste
- * the manual setup snippet from the disclosure on the same page.
+ * Gemini users can still re-install via the manual setup snippet on
+ * the same page (the generic HTTP block fits). There is no manual
+ * fallback for Claude Desktop today because its config parser
+ * rejects HTTP-shaped entries; restoring that path needs a bundled
+ * stdio bridge.
  */
 const HIDDEN_AGENTS: ReadonlySet<string> = new Set(['gemini', 'claude-desktop'])
 

--- a/packages/browseros-agent/apps/server/src/lib/mcp-manager/service.ts
+++ b/packages/browseros-agent/apps/server/src/lib/mcp-manager/service.ts
@@ -36,12 +36,20 @@ export type DetectInstalledAgentsFn = () => Promise<AgentInfo[]>
 
 /**
  * Agents the upstream library supports but BrowserOS deliberately
- * does not surface in the Integrations panel. Today: Gemini CLI's
- * MCP HTTP support is not stable enough to one-click-install
- * against. Users who actually want it can still copy-paste the
- * manual setup snippet from the disclosure on the same page.
+ * does not surface in the Integrations panel.
+ *
+ * - `gemini`: HTTP MCP support is not stable enough to one-click
+ *   install against.
+ * - `claude-desktop`: Anthropic's `claude_desktop_config.json` parser
+ *   only validates stdio entries, and the stdio bridge they recommend
+ *   (`npx mcp-remote`) requires Node on the user's machine. Without a
+ *   bundled-runtime path we cannot make this reliable, so we hide it
+ *   rather than ship a broken-by-default flow.
+ *
+ * Users who actually want either can still copy-paste the manual
+ * setup snippet from the disclosure on the same page.
  */
-const HIDDEN_AGENTS: ReadonlySet<string> = new Set(['gemini'])
+const HIDDEN_AGENTS: ReadonlySet<string> = new Set(['gemini', 'claude-desktop'])
 
 /**
  * The two server-names BrowserOS manages in the manifest. Iterating
@@ -63,9 +71,10 @@ interface AgentServerPlan {
  * Transport routing is sourced from the library's catalog via
  * `resolveAgentSurface` so we stay in lock-step with whatever
  * upstream agent-mcp-manager classifies as http-capable. Agents
- * that only accept stdio (claude-desktop, codex, …) get wrapped
- * via `npx mcp-remote <url>` so a stdio client still ends up
- * talking to the local HTTP MCP endpoint.
+ * that only accept stdio (e.g. claude-desktop) get wrapped via
+ * `npx mcp-remote <url>` so a stdio client still ends up talking
+ * to the local HTTP MCP endpoint. Codex moved to native HTTP in
+ * agent-mcp-manager 0.0.3, so it lands on the http branch.
  */
 function planFor(agentId: AgentId, currentUrl: string): AgentServerPlan {
   const surface = resolveAgentSurface(agentId, 'system')

--- a/packages/browseros-agent/apps/server/tests/lib/mcp-manager/service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/mcp-manager/service.test.ts
@@ -130,9 +130,11 @@ describe('listAgents', () => {
   })
 
   it('hides agents BrowserOS does not surface in the panel', async () => {
-    // Today only Gemini CLI is hidden: its HTTP MCP support is not
-    // stable enough for a one-click install. The agent stays
-    // available via the manual setup snippet.
+    // Hidden: Gemini CLI (HTTP MCP support not stable enough for a
+    // one-click install) and Claude Desktop (only stdio config is
+    // valid and the recommended `npx mcp-remote` bridge needs Node
+    // on the user's machine). Both stay available via the manual
+    // setup snippet.
     stubAgents = [
       {
         id: 'claude-code',
@@ -145,6 +147,12 @@ describe('listAgents', () => {
         displayName: 'Gemini CLI',
         installed: true,
         configPath: '/tmp/fake/gemini.json',
+      },
+      {
+        id: 'claude-desktop',
+        displayName: 'Claude Desktop',
+        installed: true,
+        configPath: '/tmp/fake/claude-desktop.json',
       },
     ]
     const { manager: hiddenManager } = makeManagerStub()
@@ -220,25 +228,25 @@ describe('installInto', () => {
     expect(calls.link[0].serverName).toBe('browseros')
   })
 
-  it('uses a stdio mcp-remote spec under a separate server name for codex', async () => {
-    // Codex rejects HTTP MCP specs; the manager surfaces this as an
-    // InvalidServerSpecError. Wrapping the HTTP url in `npx mcp-remote`
-    // lets a stdio-only client still reach the local HTTP endpoint.
+  it('uses an http spec under the http server name for codex', async () => {
+    // Codex gained streamable-HTTP MCP support in agent-mcp-manager
+    // 0.0.3 (its surface flipped to ['stdio', 'http']). planFor now
+    // hits the http branch, mirroring claude-code, so no stdio bridge
+    // is needed and the integration works without npx on the host.
     const { manager, calls } = makeManagerStub()
     setMcpManagerForTesting(manager)
 
     const result = await installInto('codex', 'http://127.0.0.1:9100/mcp')
     expect(result.success).toBe(true)
     expect(calls.add).toHaveLength(1)
-    expect(calls.add[0].name).toBe('browseros-stdio')
+    expect(calls.add[0].name).toBe('browseros')
     expect(calls.add[0].spec).toEqual({
-      transport: 'stdio',
-      command: 'npx',
-      args: ['mcp-remote', 'http://127.0.0.1:9100/mcp'],
+      transport: 'http',
+      url: 'http://127.0.0.1:9100/mcp',
     })
     expect(calls.link).toHaveLength(1)
     expect(calls.link[0].agent).toBe('codex')
-    expect(calls.link[0].serverName).toBe('browseros-stdio')
+    expect(calls.link[0].serverName).toBe('browseros')
   })
 
   it('uses a stdio mcp-remote spec under the stdio server name for claude-desktop', async () => {

--- a/packages/browseros-agent/apps/server/tests/lib/mcp-manager/service.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/mcp-manager/service.test.ts
@@ -129,7 +129,7 @@ describe('listAgents', () => {
     })
   })
 
-  it('hides agents BrowserOS does not surface in the panel', async () => {
+  it('hides agents BrowserOS does not surface when they have no active link', async () => {
     // Hidden: Gemini CLI (HTTP MCP support not stable enough for a
     // one-click install) and Claude Desktop (only stdio config is
     // valid and the recommended `npx mcp-remote` bridge needs Node
@@ -160,6 +160,44 @@ describe('listAgents', () => {
 
     const hiddenRows = await listAgents({ detect: stubDetect })
     expect(hiddenRows.map((r) => r.id)).toEqual(['claude-code'])
+  })
+
+  it('keeps a hidden agent visible while it still has a BrowserOS link so the user can Disconnect it', async () => {
+    // Regression: when we hid Claude Desktop, users who had already
+    // linked it via a prior BrowserOS release lost the Disconnect
+    // tile and were stuck with an orphan entry in their config.
+    // The hidden-agents filter must respect existing links.
+    stubAgents = [
+      {
+        id: 'claude-code',
+        displayName: 'Claude Code',
+        installed: true,
+        configPath: '/tmp/fake/claude-code.json',
+      },
+      {
+        id: 'claude-desktop',
+        displayName: 'Claude Desktop',
+        installed: true,
+        configPath: '/tmp/fake/claude-desktop.json',
+      },
+    ]
+    const { manager } = makeManagerStub({
+      links: [
+        {
+          serverName: 'browseros-stdio',
+          agent: 'claude-desktop',
+          configPath: '/tmp/fake/claude-desktop.json',
+        },
+      ],
+    })
+    setMcpManagerForTesting(manager)
+
+    const rows = await listAgents({ detect: stubDetect })
+    expect(rows.map((r) => r.id).sort()).toEqual([
+      'claude-code',
+      'claude-desktop',
+    ])
+    expect(rows.find((r) => r.id === 'claude-desktop')?.linked).toBe(true)
   })
 
   it('counts codex as linked when wired up under the stdio server name', async () => {

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -212,7 +212,7 @@
         "@browseros/shared": "workspace:*",
         "@hono/zod-validator": "^0.8.0",
         "@modelcontextprotocol/sdk": "^1.27.1",
-        "agent-mcp-manager": "^0.0.1",
+        "agent-mcp-manager": "^0.0.3",
         "commander": "^14.0.3",
         "drizzle-orm": "^0.45.2",
         "hono": "^4.12.3",
@@ -273,7 +273,7 @@
         "acp-probe": "^0.0.2",
         "acpx": "^0.10.0",
         "acpx-ai-provider": "^0.0.6",
-        "agent-mcp-manager": "^0.0.2",
+        "agent-mcp-manager": "^0.0.3",
         "ai": "^6.0.208",
         "commander": "^14.0.3",
         "core-js": "3.45.1",
@@ -1716,7 +1716,7 @@
 
     "agent-base": ["agent-base@6.0.2", "", { "dependencies": { "debug": "4" } }, "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ=="],
 
-    "agent-mcp-manager": ["agent-mcp-manager@0.0.1", "", { "dependencies": { "@iarna/toml": "^2.2.5", "jsonc-parser": "^3.3.1" } }, "sha512-lU6gc4/2+/5wXNl38DWEJuDKO5vkBid6KAWpxkbEGS1F1T1yXurbBPxEsaUohcByqj/Xt3rGHCjSbjKCRASMXw=="],
+    "agent-mcp-manager": ["agent-mcp-manager@0.0.3", "", { "dependencies": { "@iarna/toml": "^2.2.5", "jsonc-parser": "^3.3.1" } }, "sha512-DBbMi56b9hMfaSNCdorX38M1euE1tgrW2gvhkCeGSnNqXsTAYrbCdRZ1aNqNDHn6Ej5/t8Hzswc7fYhEm671wg=="],
 
     "ahooks": ["ahooks@3.9.7", "", { "dependencies": { "@babel/runtime": "^7.21.0", "@types/js-cookie": "^3.0.6", "dayjs": "^1.9.1", "intersection-observer": "^0.12.0", "js-cookie": "^3.0.5", "lodash": "^4.17.21", "react-fast-compare": "^3.2.2", "resize-observer-polyfill": "^1.5.1", "screenfull": "^5.0.0", "tslib": "^2.4.1" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-S0lvzhbdlhK36RFBkGv+RbOM/dbbweym+BIHM/bwwuWVSVN5TuVErHPMWo4w0t1NDYg5KPp2iEf7Y7E5LASYiw=="],
 
@@ -3813,8 +3813,6 @@
     "@browseros/server/@hono/zod-validator": ["@hono/zod-validator@0.4.3", "", { "peerDependencies": { "hono": ">=3.9.0", "zod": "^3.19.1" } }, "sha512-xIgMYXDyJ4Hj6ekm9T9Y27s080Nl9NXHcJkOvkXPhubOLj8hZkOL8pDnnXfvCf5xEE8Q4oMFenQUZZREUY2gqQ=="],
 
     "@browseros/server/@types/bun": ["@types/bun@1.3.5", "", { "dependencies": { "bun-types": "1.3.5" } }, "sha512-RnygCqNrd3srIPEWBd5LFeUYG7plCoH2Yw9WaZGyNmdTEei+gWaHqydbaIRkIkcbXwhBT94q78QljxN0Sk838w=="],
-
-    "@browseros/server/agent-mcp-manager": ["agent-mcp-manager@0.0.2", "", { "dependencies": { "@iarna/toml": "^2.2.5", "jsonc-parser": "^3.3.1" } }, "sha512-1wyJqzeLKSRSpD5URfGI/H9WjwBcDwxyU/ltYNedIgnb6QV12DYd6jy6WigqLlevs0rTkBYhKs3kkHmyes2Dvw=="],
 
     "@browseros/server/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 


### PR DESCRIPTION
agent-mcp-manager 0.0.3 ([release notes](https://github.com/DaniAkash/agent-toolkit/releases/tag/agent-mcp-manager-v0.0.3)) marks Codex as http-capable. The Connect flow now writes Codex's `~/.codex/config.toml` with a direct `url = "<browseros-url>"` entry instead of wrapping it in `npx mcp-remote`, so Codex users without Node on their machine still get a working integration.

Claude Desktop is hidden from the Integrations panel and the manual-setup tabs. `claude_desktop_config.json` accepts stdio entries only, and the recommended `npx mcp-remote` bridge requires Node — which silently breaks the Connect flow for non-developer users. Bringing Claude Desktop back is tracked separately as a bundled-runtime extension; until then, hiding it is the honest default.