### PR TITLE
fix(app): default BrowserOS API URL so auth-client never sees chrome-extension://

### DIFF
--- a/packages/browseros-agent/apps/app/lib/browseros-api-url.ts
+++ b/packages/browseros-agent/apps/app/lib/browseros-api-url.ts
@@ -1,0 +1,21 @@
+export const DEFAULT_BROWSEROS_API_URL = 'https://api.browseros.com'
+
+/** Resolves and validates the BrowserOS API base URL for runtime and build config. */
+export function parseBrowserOSApiUrl(value: string | undefined): string {
+  const rawUrl = value?.trim() || DEFAULT_BROWSEROS_API_URL
+  let url: URL
+
+  try {
+    url = new URL(rawUrl)
+  } catch {
+    throw new Error(
+      'VITE_PUBLIC_BROWSEROS_API must be a valid URL including http:// or https://',
+    )
+  }
+
+  if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+    throw new Error('VITE_PUBLIC_BROWSEROS_API must use http:// or https://')
+  }
+
+  return url.toString().replace(/\/$/, '')
+}

--- a/packages/browseros-agent/apps/app/lib/env.test.ts
+++ b/packages/browseros-agent/apps/app/lib/env.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'bun:test'
+import { parseBrowserOSApiUrl } from './browseros-api-url'
 import { parseAlphaFeaturesFlag } from './env'
 
 describe('parseAlphaFeaturesFlag', () => {
@@ -12,5 +13,33 @@ describe('parseAlphaFeaturesFlag', () => {
 
   it('keeps explicit false disabled', () => {
     expect(parseAlphaFeaturesFlag('false')).toBe(false)
+  })
+})
+
+describe('parseBrowserOSApiUrl', () => {
+  it('defaults to the production BrowserOS API when unset', () => {
+    expect(parseBrowserOSApiUrl(undefined)).toBe('https://api.browseros.com')
+  })
+
+  it('preserves explicit overrides', () => {
+    expect(parseBrowserOSApiUrl('http://127.0.0.1:3000')).toBe(
+      'http://127.0.0.1:3000',
+    )
+  })
+
+  it('rejects overrides without a scheme', () => {
+    expect(() => parseBrowserOSApiUrl('api.browseros.com')).toThrow(
+      'VITE_PUBLIC_BROWSEROS_API must be a valid URL including http:// or https://',
+    )
+  })
+
+  it('rejects non-HTTP overrides', () => {
+    expect(() =>
+      parseBrowserOSApiUrl('chrome-extension://extension-id'),
+    ).toThrow('VITE_PUBLIC_BROWSEROS_API must use http:// or https://')
+  })
+
+  it('returns a URL that can form a valid WXT match pattern', () => {
+    expect(`${parseBrowserOSApiUrl(undefined)}/home`).toStartWith('https://')
   })
 })

--- a/packages/browseros-agent/apps/app/lib/env.ts
+++ b/packages/browseros-agent/apps/app/lib/env.ts
@@ -1,4 +1,5 @@
 import { ZodError, z } from 'zod'
+import { parseBrowserOSApiUrl } from './browseros-api-url'
 
 export function parseAlphaFeaturesFlag(value: string | undefined): boolean {
   return (value ?? 'true') === 'true'
@@ -9,7 +10,10 @@ const EnvSchema = z.object({
   VITE_PUBLIC_POSTHOG_KEY: z.string().optional(),
   VITE_PUBLIC_POSTHOG_HOST: z.string().optional(),
   VITE_PUBLIC_SENTRY_DSN: z.string().optional(),
-  VITE_PUBLIC_BROWSEROS_API: z.string().optional(),
+  VITE_PUBLIC_BROWSEROS_API: z
+    .string()
+    .optional()
+    .transform(parseBrowserOSApiUrl),
   PROD: z.boolean().optional().default(false),
 })
 

--- a/packages/browseros-agent/apps/app/wxt.config.ts
+++ b/packages/browseros-agent/apps/app/wxt.config.ts
@@ -1,15 +1,14 @@
 import { sentryVitePlugin } from '@sentry/vite-plugin'
 import tailwindcss from '@tailwindcss/vite'
 import { defineConfig } from 'wxt'
+import { parseBrowserOSApiUrl } from './lib/browseros-api-url'
 import { LEGACY_AGENT_EXTENSION_ID } from './lib/constants/legacyAgentExtensionId'
 import { PRODUCT_WEB_HOST } from './lib/constants/productWebHost'
 
 // biome-ignore lint/style/noProcessEnv: build config file needs env access
 const env = process.env
 
-const apiUrl = new URL(
-  env.VITE_PUBLIC_BROWSEROS_API?.trim() || 'https://api.browseros.com',
-)
+const apiUrl = new URL(parseBrowserOSApiUrl(env.VITE_PUBLIC_BROWSEROS_API))
 const apiPattern = apiUrl.port
   ? `${apiUrl.hostname}:${apiUrl.port}`
   : apiUrl.hostname


### PR DESCRIPTION
`VITE_PUBLIC_BROWSEROS_API` is optional in dev. When unset, the env schema handed `undefined` into `createAuthClient({ baseURL })`, better-auth fell back to `window.location.origin`, and on the new tab that origin is `chrome-extension://…` — which fails better-auth's `http(s)` check and crashes the page with `Invalid base URL`.

A new `parseBrowserOSApiUrl` helper defaults to `https://api.browseros.com`, rejects non-http(s) overrides up front, and is consumed by both `lib/env.ts` (the runtime path that feeds `auth-client`) and `wxt.config.ts` (the build-time path that produces the manifest `externally_connectable.matches` patterns), so the two can never drift. Tests cover the default, explicit overrides, scheme-less rejection, and the chrome-extension://… case from the crash.