### PR TITLE
feat: browseros onboarding import patches

### DIFF
--- a/packages/browseros/build/features.yaml
+++ b/packages/browseros/build/features.yaml
@@ -271,6 +271,33 @@ features:
       - chrome/browser/ui/webui/nxtscape_first_run.h
       - chrome/common/webui_url_constants.cc
 
+  onboarding-import:
+    description: "feat: browseros onboarding import support"
+    files:
+      - chrome/browser/browseros/BUILD.gn
+      - chrome/browser/browseros/core/browseros_prefs.cc
+      - chrome/browser/browseros/core/browseros_prefs.h
+      - chrome/browser/browseros/onboarding/BUILD.gn
+      - chrome/browser/browseros/onboarding/browseros_onboarding.cc
+      - chrome/browser/browseros/onboarding/browseros_onboarding.h
+      - chrome/browser/browseros/onboarding/browseros_onboarding_api.ts
+      - chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
+      - chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h
+      - chrome/browser/browseros/onboarding/resources/app.css
+      - chrome/browser/browseros/onboarding/resources/app.js
+      - chrome/browser/browseros/onboarding/resources/index.html
+      - chrome/browser/chrome_browser_main.cc
+      - chrome/browser/ui/BUILD.gn
+      - chrome/browser/ui/startup/startup_browser_creator.cc
+      - chrome/browser/ui/views/profiles/first_run_flow_controller.cc
+      - chrome/browser/ui/views/profiles/first_run_flow_controller.h
+      - chrome/browser/ui/webui/BUILD.gn
+      - chrome/browser/ui/webui/chrome_web_ui_configs.cc
+      - chrome/chrome_paks.gni
+      - chrome/common/webui_url_constants.cc
+      - chrome/common/webui_url_constants.h
+      - tools/gritsettings/resource_ids.spec
+
   llm-chat:
     description: "feat: llm chat side panel"
     files:

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/BUILD.gn
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/BUILD.gn b/chrome/browser/browseros/BUILD.gn
 new file mode 100644
-index 0000000000000..a7e89ea2d1c47
+index 0000000000000..10b6cd8a75016
 --- /dev/null
 +++ b/chrome/browser/browseros/BUILD.gn
-@@ -0,0 +1,21 @@
+@@ -0,0 +1,22 @@
 +# Copyright 2024 The Chromium Authors
 +# Use of this source code is governed by a BSD-style license that can be
 +# found in the LICENSE file.
@@ -16,6 +16,7 @@ index 0000000000000..a7e89ea2d1c47
 +  deps = [
 +    "//chrome/browser/browseros/core",
 +    "//chrome/browser/browseros/metrics",
++    "//chrome/browser/browseros/onboarding",
 +    "//chrome/browser/browseros/server",
 +  ]
 +}

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/core/browseros_prefs.cc b/chrome/browser/browseros/core/browseros_prefs.cc
 new file mode 100644
-index 0000000000000..cbc95b13018f2
+index 0000000000000..52f183b59832c
 --- /dev/null
 +++ b/chrome/browser/browseros/core/browseros_prefs.cc
-@@ -0,0 +1,89 @@
+@@ -0,0 +1,90 @@
 +// Copyright 2025 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -33,6 +33,7 @@ index 0000000000000..cbc95b13018f2
 +
 +  // NTP focus pref
 +  registry->RegisterBooleanPref(prefs::kNtpFocusContent, false);
++  registry->RegisterBooleanPref(prefs::kOnboardingCompleted, false);
 +}
 +
 +bool ShouldShowLLMChat(PrefService* pref_service) {

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/core/browseros_prefs.h b/chrome/browser/browseros/core/browseros_prefs.h
 new file mode 100644
-index 0000000000000..048f60b720339
+index 0000000000000..2dabac573bf82
 --- /dev/null
 +++ b/chrome/browser/browseros/core/browseros_prefs.h
-@@ -0,0 +1,80 @@
+@@ -0,0 +1,82 @@
 +// Copyright 2025 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -44,6 +44,8 @@ index 0000000000000..048f60b720339
 +
 +// Boolean: Focus NTP content instead of omnibox on new tab (default: true)
 +inline constexpr char kNtpFocusContent[] = "browseros.ntp_focus_content";
++
++inline constexpr char kOnboardingCompleted[] = "browseros.onboarding_completed";
 +
 +}  // namespace prefs
 +

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/BUILD.gn
@@ -1,0 +1,62 @@
+diff --git a/chrome/browser/browseros/onboarding/BUILD.gn b/chrome/browser/browseros/onboarding/BUILD.gn
+new file mode 100644
+index 0000000000000..81c3bd53932f8
+--- /dev/null
++++ b/chrome/browser/browseros/onboarding/BUILD.gn
+@@ -0,0 +1,56 @@
++# Copyright 2026 The Chromium Authors
++# Use of this source code is governed by a BSD-style license that can be
++# found in the LICENSE file.
++
++import("//tools/grit/grit_rule.gni")
++import("//ui/webui/resources/tools/generate_grd.gni")
++
++_browseros_onboarding_resource_files = [
++  "index.html",
++  "app.css",
++  "app.js",
++]
++
++generate_grd("build_resources_grd") {
++  grd_prefix = "browseros_onboarding"
++  out_grd = "$target_gen_dir/resources.grd"
++  input_files = _browseros_onboarding_resource_files
++  input_files_base_dir = rebase_path("resources", "//")
++}
++
++grit("resources") {
++  source = "$target_gen_dir/resources.grd"
++  deps = [ ":build_resources_grd" ]
++  outputs = [
++    "grit/browseros_onboarding_resources.h",
++    "grit/browseros_onboarding_resources_map.h",
++    "grit/browseros_onboarding_resources_map.cc",
++    "browseros_onboarding_resources.pak",
++  ]
++  output_dir = "$root_gen_dir/chrome"
++}
++
++source_set("onboarding") {
++  sources = [
++    "browseros_onboarding.cc",
++    "browseros_onboarding.h",
++    "browseros_onboarding_prefs.cc",
++    "browseros_onboarding_prefs.h",
++  ]
++
++  deps = [
++    ":resources",
++    "//base",
++    "//chrome/browser:browser_process",
++    "//chrome/browser/browseros/core:prefs",
++    "//chrome/browser/importer",
++    "//chrome/browser/importer:impl",
++    "//chrome/browser/profiles:profile",
++    "//chrome/common:constants",
++    "//components/prefs",
++    "//components/user_data_importer/common",
++    "//content/public/browser",
++    "//content/public/common",
++    "//ui/webui",
++  ]
++}

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding.cc
@@ -1,0 +1,414 @@
+diff --git a/chrome/browser/browseros/onboarding/browseros_onboarding.cc b/chrome/browser/browseros/onboarding/browseros_onboarding.cc
+new file mode 100644
+index 0000000000000..861b651ec3cbe
+--- /dev/null
++++ b/chrome/browser/browseros/onboarding/browseros_onboarding.cc
+@@ -0,0 +1,408 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "chrome/browser/browseros/onboarding/browseros_onboarding.h"
++
++#include <stdint.h>
++
++#include <memory>
++#include <string>
++#include <string_view>
++#include <utility>
++
++#include "base/functional/bind.h"
++#include "base/functional/callback.h"
++#include "base/strings/stringprintf.h"
++#include "base/strings/utf_string_conversions.h"
++#include "base/values.h"
++#include "chrome/browser/browser_process.h"
++#include "chrome/browser/importer/external_process_importer_host.h"
++#include "chrome/browser/importer/importer_list.h"
++#include "chrome/browser/importer/importer_progress_observer.h"
++#include "chrome/browser/importer/profile_writer.h"
++#include "chrome/browser/profiles/profile.h"
++#include "chrome/common/webui_url_constants.h"
++#include "chrome/grit/browseros_onboarding_resources.h"
++#include "chrome/grit/browseros_onboarding_resources_map.h"
++#include "components/user_data_importer/common/importer_data_types.h"
++#include "content/public/browser/web_ui.h"
++#include "content/public/browser/web_ui_data_source.h"
++#include "content/public/browser/web_ui_message_handler.h"
++#include "content/public/common/url_constants.h"
++#include "ui/webui/webui_util.h"
++
++namespace {
++
++constexpr int kBrowserOSOnboardingApiVersion = 1;
++constexpr uint16_t kBrowserOSImportableItems =
++    user_data_importer::HISTORY | user_data_importer::FAVORITES |
++    user_data_importer::COOKIES | user_data_importer::PASSWORDS |
++    user_data_importer::SEARCH_ENGINES |
++    user_data_importer::AUTOFILL_FORM_DATA | user_data_importer::EXTENSIONS;
++
++std::string SourceIdForIndex(size_t index) {
++  return base::StringPrintf("source-%zu", index);
++}
++
++const char* ImportItemToString(user_data_importer::ImportItem item) {
++  switch (item) {
++    case user_data_importer::HISTORY:
++      return "history";
++    case user_data_importer::FAVORITES:
++      return "bookmarks";
++    case user_data_importer::COOKIES:
++      return "cookies";
++    case user_data_importer::PASSWORDS:
++      return "passwords";
++    case user_data_importer::SEARCH_ENGINES:
++      return "searchEngines";
++    case user_data_importer::AUTOFILL_FORM_DATA:
++      return "autofill";
++    case user_data_importer::EXTENSIONS:
++      return "extensions";
++    case user_data_importer::NONE:
++    case user_data_importer::HOME_PAGE:
++    case user_data_importer::ALL:
++      return nullptr;
++  }
++}
++
++uint16_t ImportItemMaskFromString(std::string_view item) {
++  if (item == "history") {
++    return user_data_importer::HISTORY;
++  }
++  if (item == "bookmarks") {
++    return user_data_importer::FAVORITES;
++  }
++  if (item == "cookies") {
++    return user_data_importer::COOKIES;
++  }
++  if (item == "passwords") {
++    return user_data_importer::PASSWORDS;
++  }
++  if (item == "searchEngines") {
++    return user_data_importer::SEARCH_ENGINES;
++  }
++  if (item == "autofill") {
++    return user_data_importer::AUTOFILL_FORM_DATA;
++  }
++  if (item == "extensions") {
++    return user_data_importer::EXTENSIONS;
++  }
++  return user_data_importer::NONE;
++}
++
++void AppendImportItem(base::ListValue& items,
++                      uint16_t services,
++                      user_data_importer::ImportItem item) {
++  if ((services & item) == 0) {
++    return;
++  }
++
++  const char* name = ImportItemToString(item);
++  if (name) {
++    items.Append(name);
++  }
++}
++
++base::ListValue ImportItemsFromMask(uint16_t services) {
++  base::ListValue items;
++  AppendImportItem(items, services, user_data_importer::HISTORY);
++  AppendImportItem(items, services, user_data_importer::FAVORITES);
++  AppendImportItem(items, services, user_data_importer::COOKIES);
++  AppendImportItem(items, services, user_data_importer::PASSWORDS);
++  AppendImportItem(items, services, user_data_importer::SEARCH_ENGINES);
++  AppendImportItem(items, services, user_data_importer::AUTOFILL_FORM_DATA);
++  AppendImportItem(items, services, user_data_importer::EXTENSIONS);
++  return items;
++}
++
++}  // namespace
++
++class BrowserOSOnboardingHandler : public content::WebUIMessageHandler,
++                                   public importer::ImporterProgressObserver {
++ public:
++  BrowserOSOnboardingHandler() = default;
++  BrowserOSOnboardingHandler(const BrowserOSOnboardingHandler&) = delete;
++  BrowserOSOnboardingHandler& operator=(const BrowserOSOnboardingHandler&) =
++      delete;
++  ~BrowserOSOnboardingHandler() override {
++    if (importer_host_) {
++      importer_host_->set_observer(nullptr);
++    }
++  }
++
++  void SetCompletionCallback(base::RepeatingClosure completion_callback) {
++    completion_callback_ = std::move(completion_callback);
++  }
++
++ private:
++  void RegisterMessages() override {
++    web_ui()->RegisterMessageCallback(
++        "browserosOnboardingPageReady",
++        base::BindRepeating(&BrowserOSOnboardingHandler::HandlePageReady,
++                            base::Unretained(this)));
++    web_ui()->RegisterMessageCallback(
++        "browserosOnboardingRefreshSources",
++        base::BindRepeating(&BrowserOSOnboardingHandler::HandleRefreshSources,
++                            base::Unretained(this)));
++    web_ui()->RegisterMessageCallback(
++        "browserosOnboardingStartImport",
++        base::BindRepeating(&BrowserOSOnboardingHandler::HandleStartImport,
++                            base::Unretained(this)));
++    web_ui()->RegisterMessageCallback(
++        "browserosOnboardingComplete",
++        base::BindRepeating(&BrowserOSOnboardingHandler::HandleComplete,
++                            base::Unretained(this)));
++  }
++
++  void OnJavascriptDisallowed() override {
++    importer_list_.reset();
++    importer_list_loaded_ = false;
++    current_item_ = user_data_importer::NONE;
++    completed_items_ = user_data_importer::NONE;
++    imported_items_ = user_data_importer::NONE;
++    if (importer_host_) {
++      importer_host_->set_observer(nullptr);
++      importer_host_ = nullptr;
++    }
++  }
++
++  void HandlePageReady(const base::ListValue& args) {
++    if (!IsJavascriptAllowed()) {
++      AllowJavascript();
++    }
++    SendState("detecting");
++    DetectSources();
++  }
++
++  void HandleRefreshSources(const base::ListValue& args) {
++    SendState("detecting");
++    DetectSources();
++  }
++
++  void HandleStartImport(const base::ListValue& args) {
++    if (!importer_list_loaded_ || !importer_list_ ||
++        importer_list_->count() == 0) {
++      SendFailure("no_sources", "No detected import source is ready.");
++      return;
++    }
++
++    int browser_index = 0;
++    uint16_t selected_items = user_data_importer::NONE;
++    bool has_selected_items = false;
++    if (!args.empty() && args[0].is_dict()) {
++      const base::DictValue& request = args[0].GetDict();
++      const std::string* source_id = request.FindString("sourceId");
++      if (!source_id || !FindSourceIndex(*source_id, &browser_index)) {
++        SendFailure("invalid_source", "Selected import source is not valid.");
++        return;
++      }
++
++      if (const base::ListValue* items = request.FindList("items")) {
++        has_selected_items = true;
++        for (const base::Value& item : *items) {
++          if (item.is_string()) {
++            selected_items |= ImportItemMaskFromString(item.GetString());
++          }
++        }
++      }
++    } else if (!args.empty()) {
++      browser_index = args[0].GetInt();
++    }
++    if (browser_index < 0 ||
++        browser_index >= static_cast<int>(importer_list_->count())) {
++      SendFailure("invalid_source", "Selected import source is out of range.");
++      return;
++    }
++
++    const user_data_importer::SourceProfile& source_profile =
++        importer_list_->GetSourceProfileAt(browser_index);
++    uint16_t supported_items =
++        source_profile.services_supported & kBrowserOSImportableItems;
++    uint16_t imported_items = has_selected_items
++                                  ? (selected_items & supported_items)
++                                  : supported_items;
++    if (!imported_items) {
++      SendFailure("no_supported_items",
++                  "Selected source has no supported import items.");
++      return;
++    }
++
++    if (importer_host_) {
++      importer_host_->set_observer(nullptr);
++    }
++
++    import_did_succeed_ = false;
++    imported_items_ = imported_items;
++    completed_items_ = user_data_importer::NONE;
++    current_item_ = user_data_importer::NONE;
++    importer_host_ = new ExternalProcessImporterHost();
++    importer_host_->set_observer(this);
++    Profile* profile = Profile::FromWebUI(web_ui());
++    SendState("importing");
++    importer_host_->StartImportSettings(source_profile, profile, imported_items,
++                                        new ProfileWriter(profile));
++  }
++
++  void HandleComplete(const base::ListValue& args) {
++    SendState("completed");
++
++    base::RepeatingClosure completion_callback = completion_callback_;
++    if (completion_callback) {
++      completion_callback.Run();
++      return;
++    }
++  }
++
++  void DetectSources() {
++    importer_list_loaded_ = false;
++    current_item_ = user_data_importer::NONE;
++    completed_items_ = user_data_importer::NONE;
++    imported_items_ = user_data_importer::NONE;
++    importer_list_ = std::make_unique<ImporterList>();
++    importer_list_->DetectSourceProfiles(
++        g_browser_process->GetApplicationLocale(), false,
++        base::BindOnce(&BrowserOSOnboardingHandler::HandleSourcesDetected,
++                       base::Unretained(this)));
++  }
++
++  void HandleSourcesDetected() {
++    importer_list_loaded_ = true;
++    SendState("ready");
++  }
++
++  bool FindSourceIndex(const std::string& source_id, int* index) const {
++    for (size_t i = 0; importer_list_ && i < importer_list_->count(); ++i) {
++      if (SourceIdForIndex(i) == source_id) {
++        *index = static_cast<int>(i);
++        return true;
++      }
++    }
++    return false;
++  }
++
++  base::ListValue BuildSources() const {
++    base::ListValue sources;
++    for (size_t i = 0; importer_list_ && i < importer_list_->count(); ++i) {
++      const user_data_importer::SourceProfile& source_profile =
++          importer_list_->GetSourceProfileAt(i);
++      uint16_t services = source_profile.services_supported;
++      std::string browser_name =
++          base::UTF16ToUTF8(source_profile.importer_name);
++      std::string profile_name = base::UTF16ToUTF8(source_profile.profile);
++      std::string display_name = profile_name.empty()
++                                     ? browser_name
++                                     : browser_name + " - " + profile_name;
++
++      base::DictValue source;
++      source.Set("id", SourceIdForIndex(i));
++      source.Set("displayName", display_name);
++      source.Set("browserName", browser_name);
++      source.Set("profileName", profile_name);
++      source.Set("supportedItems", ImportItemsFromMask(services));
++      source.Set("recommendedItems", ImportItemsFromMask(services));
++      sources.Append(std::move(source));
++    }
++    return sources;
++  }
++
++  base::DictValue BuildProgress() const {
++    base::DictValue progress;
++    progress.Set("completedItems", ImportItemsFromMask(completed_items_));
++    progress.Set("totalItems",
++                 static_cast<int>(ImportItemsFromMask(imported_items_).size()));
++    const char* current_item = ImportItemToString(current_item_);
++    if (current_item) {
++      progress.Set("currentItem", current_item);
++    }
++    return progress;
++  }
++
++  void SendState(std::string_view status) {
++    if (IsJavascriptAllowed()) {
++      base::DictValue state;
++      state.Set("apiVersion", kBrowserOSOnboardingApiVersion);
++      state.Set("status", std::string(status));
++      state.Set("sources", BuildSources());
++      if (imported_items_) {
++        state.Set("progress", BuildProgress());
++      }
++      CallJavascriptFunction("browserosOnboarding.receiveState", state);
++    }
++  }
++
++  void SendFailure(const std::string& code, const std::string& message) {
++    if (IsJavascriptAllowed()) {
++      base::DictValue state;
++      state.Set("apiVersion", kBrowserOSOnboardingApiVersion);
++      state.Set("status", "failed");
++      state.Set("sources", BuildSources());
++      base::DictValue error;
++      error.Set("code", code);
++      error.Set("message", message);
++      state.Set("error", std::move(error));
++      CallJavascriptFunction("browserosOnboarding.receiveState", state);
++    }
++  }
++
++  void ImportStarted() override { SendState("importing"); }
++
++  void ImportItemStarted(user_data_importer::ImportItem item) override {
++    current_item_ = item;
++    SendState("importing");
++  }
++
++  void ImportItemEnded(user_data_importer::ImportItem item) override {
++    completed_items_ |= static_cast<uint16_t>(item);
++    current_item_ = user_data_importer::NONE;
++    import_did_succeed_ = true;
++    SendState("importing");
++  }
++
++  void ImportEnded() override {
++    if (importer_host_) {
++      importer_host_->set_observer(nullptr);
++      importer_host_ = nullptr;
++    }
++    current_item_ = user_data_importer::NONE;
++    SendState(import_did_succeed_ ? "succeeded" : "failed");
++  }
++
++  std::unique_ptr<ImporterList> importer_list_;
++  raw_ptr<ExternalProcessImporterHost> importer_host_ = nullptr;
++  base::RepeatingClosure completion_callback_;
++  user_data_importer::ImportItem current_item_ = user_data_importer::NONE;
++  uint16_t completed_items_ = user_data_importer::NONE;
++  uint16_t imported_items_ = user_data_importer::NONE;
++  bool importer_list_loaded_ = false;
++  bool import_did_succeed_ = false;
++};
++
++BrowserOSOnboardingUIConfig::BrowserOSOnboardingUIConfig()
++    : DefaultWebUIConfig(content::kChromeUIScheme,
++                         chrome::kChromeUIBrowserOSOnboardingHost) {}
++
++BrowserOSOnboarding::BrowserOSOnboarding(content::WebUI* web_ui)
++    : content::WebUIController(web_ui) {
++  content::WebUIDataSource* source = content::WebUIDataSource::CreateAndAdd(
++      Profile::FromWebUI(web_ui), chrome::kChromeUIBrowserOSOnboardingHost);
++  webui::SetupWebUIDataSource(source, kBrowserosOnboardingResources,
++                              IDR_BROWSEROS_ONBOARDING_INDEX_HTML);
++
++  auto handler = std::make_unique<BrowserOSOnboardingHandler>();
++  handler_ = handler.get();
++  web_ui->AddMessageHandler(std::move(handler));
++}
++
++BrowserOSOnboarding::~BrowserOSOnboarding() = default;
++
++void BrowserOSOnboarding::SetCompletionCallback(
++    base::RepeatingClosure completion_callback) {
++  if (handler_) {
++    handler_->SetCompletionCallback(std::move(completion_callback));
++  }
++}
++
++WEB_UI_CONTROLLER_TYPE_IMPL(BrowserOSOnboarding)

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding.h
@@ -1,0 +1,43 @@
+diff --git a/chrome/browser/browseros/onboarding/browseros_onboarding.h b/chrome/browser/browseros/onboarding/browseros_onboarding.h
+new file mode 100644
+index 0000000000000..6d84599152fc6
+--- /dev/null
++++ b/chrome/browser/browseros/onboarding/browseros_onboarding.h
+@@ -0,0 +1,37 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_BROWSEROS_ONBOARDING_BROWSEROS_ONBOARDING_H_
++#define CHROME_BROWSER_BROWSEROS_ONBOARDING_BROWSEROS_ONBOARDING_H_
++
++#include "base/functional/callback_forward.h"
++#include "base/memory/raw_ptr.h"
++#include "content/public/browser/web_ui_controller.h"
++#include "content/public/browser/webui_config.h"
++
++class BrowserOSOnboardingHandler;
++class BrowserOSOnboarding;
++
++class BrowserOSOnboardingUIConfig
++    : public content::DefaultWebUIConfig<BrowserOSOnboarding> {
++ public:
++  BrowserOSOnboardingUIConfig();
++};
++
++class BrowserOSOnboarding : public content::WebUIController {
++ public:
++  explicit BrowserOSOnboarding(content::WebUI* web_ui);
++  BrowserOSOnboarding(const BrowserOSOnboarding&) = delete;
++  BrowserOSOnboarding& operator=(const BrowserOSOnboarding&) = delete;
++  ~BrowserOSOnboarding() override;
++
++  void SetCompletionCallback(base::RepeatingClosure completion_callback);
++
++ private:
++  raw_ptr<BrowserOSOnboardingHandler> handler_ = nullptr;
++
++  WEB_UI_CONTROLLER_TYPE_DECL();
++};
++
++#endif  // CHROME_BROWSER_BROWSEROS_ONBOARDING_BROWSEROS_ONBOARDING_H_

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_api.ts
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_api.ts
@@ -1,0 +1,77 @@
+diff --git a/chrome/browser/browseros/onboarding/browseros_onboarding_api.ts b/chrome/browser/browseros/onboarding/browseros_onboarding_api.ts
+new file mode 100644
+index 0000000000000..2edbc3d19f087
+--- /dev/null
++++ b/chrome/browser/browseros/onboarding/browseros_onboarding_api.ts
+@@ -0,0 +1,71 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++export const BROWSEROS_ONBOARDING_API_VERSION = 1 as const;
++
++export type BrowserOSImportItem =
++    'history'|'bookmarks'|'cookies'|'passwords'|'searchEngines'|'autofill'|
++    'extensions';
++
++export type BrowserOSImportStatus =
++    'idle'|'detecting'|'ready'|'importing'|'succeeded'|'failed'|'completed';
++
++export const BrowserOSOnboardingMessage = {
++  PAGE_READY: 'browserosOnboardingPageReady',
++  REFRESH_SOURCES: 'browserosOnboardingRefreshSources',
++  START_IMPORT: 'browserosOnboardingStartImport',
++  COMPLETE: 'browserosOnboardingComplete',
++} as const;
++
++export type BrowserOSOnboardingMessage =
++    typeof BrowserOSOnboardingMessage[keyof typeof BrowserOSOnboardingMessage];
++
++export interface BrowserOSImportSource {
++  id: string;
++  displayName: string;
++  browserName: string;
++  profileName: string;
++  supportedItems: BrowserOSImportItem[];
++  recommendedItems: BrowserOSImportItem[];
++}
++
++export interface BrowserOSImportProgress {
++  currentItem?: BrowserOSImportItem;
++  completedItems: BrowserOSImportItem[];
++  totalItems: number;
++}
++
++export interface BrowserOSOnboardingError {
++  code: string;
++  message: string;
++}
++
++export interface BrowserOSOnboardingState {
++  apiVersion: typeof BROWSEROS_ONBOARDING_API_VERSION;
++  status: BrowserOSImportStatus;
++  sources: BrowserOSImportSource[];
++  progress?: BrowserOSImportProgress;
++  error?: BrowserOSOnboardingError;
++}
++
++export interface BrowserOSStartImportRequest {
++  sourceId: string;
++  items?: BrowserOSImportItem[];
++}
++
++export interface BrowserOSOnboardingClient {
++  receiveState(state: BrowserOSOnboardingState): void;
++}
++
++export interface BrowserOSOnboardingChrome {
++  send(message: BrowserOSOnboardingMessage, args?: unknown[]): void;
++}
++
++declare global {
++  interface Window {
++    browserosOnboarding?: BrowserOSOnboardingClient;
++  }
++
++  const chrome: BrowserOSOnboardingChrome;
++}

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
@@ -1,0 +1,37 @@
+diff --git a/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc b/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
+new file mode 100644
+index 0000000000000..635f4df18b9f4
+--- /dev/null
++++ b/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
+@@ -0,0 +1,31 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h"
++
++#include "chrome/browser/browseros/core/browseros_prefs.h"
++#include "chrome/browser/profiles/profile.h"
++#include "components/prefs/pref_service.h"
++
++namespace browseros::onboarding {
++
++bool ShouldShow(Profile* profile) {
++  if (!profile || !profile->IsRegularProfile() || profile->IsOffTheRecord()) {
++    return false;
++  }
++
++  return !profile->GetPrefs()->GetBoolean(
++      browseros::prefs::kOnboardingCompleted);
++}
++
++void MarkCompleted(Profile* profile) {
++  if (!profile || !profile->IsRegularProfile()) {
++    return;
++  }
++
++  profile->GetPrefs()->SetBoolean(browseros::prefs::kOnboardingCompleted,
++                                  true);
++}
++
++}  // namespace browseros::onboarding

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h
@@ -1,0 +1,26 @@
+diff --git a/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h b/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h
+new file mode 100644
+index 0000000000000..fc0d5b3bfc641
+--- /dev/null
++++ b/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h
+@@ -0,0 +1,20 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_BROWSEROS_ONBOARDING_BROWSEROS_ONBOARDING_PREFS_H_
++#define CHROME_BROWSER_BROWSEROS_ONBOARDING_BROWSEROS_ONBOARDING_PREFS_H_
++
++class Profile;
++
++namespace browseros::onboarding {
++
++// Returns whether BrowserOS onboarding should interrupt startup for `profile`.
++bool ShouldShow(Profile* profile);
++
++// Marks the BrowserOS onboarding popup complete for `profile`.
++void MarkCompleted(Profile* profile);
++
++}  // namespace browseros::onboarding
++
++#endif  // CHROME_BROWSER_BROWSEROS_ONBOARDING_BROWSEROS_ONBOARDING_PREFS_H_

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/resources/app.css
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/resources/app.css
@@ -1,0 +1,7 @@
+diff --git a/chrome/browser/browseros/onboarding/resources/app.css b/chrome/browser/browseros/onboarding/resources/app.css
+new file mode 100644
+index 0000000000000..8b137891791fe
+--- /dev/null
++++ b/chrome/browser/browseros/onboarding/resources/app.css
+@@ -0,0 +1 @@
++

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/resources/app.js
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/resources/app.js
@@ -1,0 +1,64 @@
+diff --git a/chrome/browser/browseros/onboarding/resources/app.js b/chrome/browser/browseros/onboarding/resources/app.js
+new file mode 100644
+index 0000000000000..3962409a6d71f
+--- /dev/null
++++ b/chrome/browser/browseros/onboarding/resources/app.js
+@@ -0,0 +1,58 @@
++const sources = document.querySelector('#sources');
++const importButton = document.querySelector('#import');
++const refreshButton = document.querySelector('#refresh');
++const continueButton = document.querySelector('#continue');
++const status = document.querySelector('#status');
++
++function send(message, args = []) {
++  chrome.send(message, args);
++}
++
++function renderState(state) {
++  sources.textContent = '';
++
++  for (const source of state.sources) {
++    const option = document.createElement('option');
++    option.value = source.id;
++    option.textContent = source.displayName;
++    sources.appendChild(option);
++  }
++
++  const selectedSource =
++      state.sources.find(source => source.id === sources.value);
++  importButton.disabled =
++      state.status === 'detecting' || state.status === 'importing' ||
++      !selectedSource;
++  refreshButton.disabled =
++      state.status === 'detecting' || state.status === 'importing';
++  sources.disabled =
++      state.status === 'detecting' || state.status === 'importing';
++
++  if (state.error) {
++    status.textContent = `${state.status}: ${state.error.message}`;
++    return;
++  }
++
++  status.textContent = `${state.status} (${state.sources.length} source(s))`;
++}
++
++window.browserosOnboarding = {
++  receiveState: renderState,
++};
++
++importButton.addEventListener('click', () => {
++  if (!sources.value) {
++    return;
++  }
++  send('browserosOnboardingStartImport', [{sourceId: sources.value}]);
++});
++
++refreshButton.addEventListener('click', () => {
++  send('browserosOnboardingRefreshSources');
++});
++
++continueButton.addEventListener('click', () => {
++  send('browserosOnboardingComplete');
++});
++
++send('browserosOnboardingPageReady');

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/resources/index.html
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/resources/index.html
@@ -1,0 +1,26 @@
+diff --git a/chrome/browser/browseros/onboarding/resources/index.html b/chrome/browser/browseros/onboarding/resources/index.html
+new file mode 100644
+index 0000000000000..8ac1513559d4e
+--- /dev/null
++++ b/chrome/browser/browseros/onboarding/resources/index.html
+@@ -0,0 +1,20 @@
++<!doctype html>
++<html lang="en">
++<head>
++<meta charset="utf-8">
++<meta name="viewport" content="width=device-width, initial-scale=1">
++<title>BrowserOS Onboarding</title>
++<script src="app.js" defer></script>
++</head>
++<body>
++<main>
++  <h1>Welcome to BrowserOS</h1>
++  <label for="sources">Import from</label>
++  <select id="sources"></select>
++  <button id="import">Import</button>
++  <button id="refresh">Refresh</button>
++  <button id="continue">Continue</button>
++  <div id="status">Loading import sources...</div>
++</main>
++</body>
++</html>

--- a/packages/browseros/chromium_patches/chrome/browser/chrome_browser_main.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/chrome_browser_main.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/chrome_browser_main.cc b/chrome/browser/chrome_browser_main.cc
-index a8ebab6e15ac1..99ca2fdcc4e84 100644
+index a8ebab6e15ac1..725dce9fa19de 100644
 --- a/chrome/browser/chrome_browser_main.cc
 +++ b/chrome/browser/chrome_browser_main.cc
 @@ -10,6 +10,7 @@
@@ -10,15 +10,7 @@ index a8ebab6e15ac1..99ca2fdcc4e84 100644
  #include "base/base_switches.h"
  #include "base/check.h"
  #include "base/command_line.h"
-@@ -1261,6 +1262,7 @@ int ChromeBrowserMainParts::PreCreateThreadsImpl() {
-   if (first_run::IsChromeFirstRun()) {
-     if (!base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kApp) &&
-         !base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kAppId)) {
-+      browser_creator_->AddFirstRunTabs({GURL("chrome://browseros-welcome")});
-       browser_creator_->AddFirstRunTabs(master_prefs_->new_tabs);
-     }
-   }
-@@ -1280,6 +1282,43 @@ int ChromeBrowserMainParts::PreCreateThreadsImpl() {
+@@ -1280,6 +1281,43 @@ int ChromeBrowserMainParts::PreCreateThreadsImpl() {
    }
  #endif
  
@@ -62,7 +54,7 @@ index a8ebab6e15ac1..99ca2fdcc4e84 100644
  #if BUILDFLAG(IS_MAC)
  #if defined(ARCH_CPU_X86_64)
    // The use of Rosetta to run the x64 version of Chromium on Arm is neither
-@@ -1887,6 +1926,12 @@ int ChromeBrowserMainParts::PreMainMessageLoopRunImpl() {
+@@ -1887,6 +1925,12 @@ int ChromeBrowserMainParts::PreMainMessageLoopRunImpl() {
      g_browser_process->CreateDevToolsAutoOpener();
    }
  
@@ -75,7 +67,7 @@ index a8ebab6e15ac1..99ca2fdcc4e84 100644
    // Needs to be done before PostProfileInit, since the SODA Installer setup is
    // called inside PostProfileInit and depends on it.
    if (!base::CommandLine::ForCurrentProcess()->HasSwitch(
-@@ -2175,6 +2220,11 @@ void ChromeBrowserMainParts::PostMainMessageLoopRun() {
+@@ -2175,6 +2219,11 @@ void ChromeBrowserMainParts::PostMainMessageLoopRun() {
      chrome_extra_part->PostMainMessageLoopRun();
    }
  

--- a/packages/browseros/chromium_patches/chrome/browser/ui/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/BUILD.gn
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/BUILD.gn b/chrome/browser/ui/BUILD.gn
-index 5907498d01115..a741ba1ff4ae6 100644
+index 5907498d01115..1d062220a528c 100644
 --- a/chrome/browser/ui/BUILD.gn
 +++ b/chrome/browser/ui/BUILD.gn
 @@ -8,6 +8,7 @@ import("//build/config/features.gni")
@@ -10,7 +10,15 @@ index 5907498d01115..a741ba1ff4ae6 100644
  import("//chrome/common/features.gni")
  import("//components/captive_portal/core/features.gni")
  import("//components/compose/features.gni")
-@@ -1349,6 +1350,8 @@ static_library("ui") {
+@@ -278,6 +279,7 @@ static_library("ui") {
+     "//chrome/browser:flags",
+     "//chrome/browser:font_pref",
+     "//chrome/browser:global_features",
++    "//chrome/browser/browseros/onboarding",
+     "//chrome/browser/affiliations",
+     "//chrome/browser/ai",
+     "//chrome/browser/autocomplete",
+@@ -1349,6 +1351,8 @@ static_library("ui") {
        "webui/settings/search_engines_handler.h",
        "webui/settings/security_settings_provider.cc",
        "webui/settings/security_settings_provider.h",
@@ -19,7 +27,7 @@ index 5907498d01115..a741ba1ff4ae6 100644
        "webui/settings/settings_clear_browsing_data_handler.cc",
        "webui/settings/settings_clear_browsing_data_handler.h",
        "webui/settings/settings_localized_strings_privacy_sandbox_provider.cc",
-@@ -3356,6 +3359,8 @@ static_library("ui") {
+@@ -3356,6 +3360,8 @@ static_library("ui") {
        "views/frame/immersive_mode_overlay_views_mac.mm",
        "views/tab_contents/chrome_web_contents_view_delegate_views_mac.h",
        "views/tab_contents/chrome_web_contents_view_delegate_views_mac.mm",
@@ -28,7 +36,7 @@ index 5907498d01115..a741ba1ff4ae6 100644
        "webui/help/version_updater_mac.mm",
        "webui/settings/mac_system_settings_handler.cc",
        "webui/settings/mac_system_settings_handler.h",
-@@ -3497,6 +3502,12 @@ static_library("ui") {
+@@ -3497,6 +3503,12 @@ static_library("ui") {
        ]
      } else {
        sources += [ "webui/help/version_updater_basic.cc" ]

--- a/packages/browseros/chromium_patches/chrome/browser/ui/startup/startup_browser_creator.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/startup/startup_browser_creator.cc
@@ -1,0 +1,58 @@
+diff --git a/chrome/browser/ui/startup/startup_browser_creator.cc b/chrome/browser/ui/startup/startup_browser_creator.cc
+index 597bd5bfdcbbf..9f4392215e04e 100644
+--- a/chrome/browser/ui/startup/startup_browser_creator.cc
++++ b/chrome/browser/ui/startup/startup_browser_creator.cc
+@@ -39,6 +39,7 @@
+ #include "chrome/browser/apps/app_service/app_service_proxy_factory.h"
+ #include "chrome/browser/apps/platform_apps/app_load_service.h"
+ #include "chrome/browser/apps/platform_apps/platform_app_launch.h"
++#include "chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h"
+ #include "chrome/browser/browser_features.h"
+ #include "chrome/browser/browser_process.h"
+ #include "chrome/browser/extensions/startup_helper.h"
+@@ -474,6 +475,26 @@ void OpenNewWindowForFirstRun(const base::CommandLine& command_line,
+ }
+ #endif  // BUILDFLAG(ENABLE_DICE_SUPPORT)
+ 
++#if !BUILDFLAG(IS_CHROMEOS)
++void OpenNewWindowForBrowserOSOnboarding(
++    const base::CommandLine& command_line,
++    Profile* profile,
++    const base::FilePath& cur_dir,
++    const std::vector<GURL>& first_run_urls,
++    chrome::startup::IsProcessStartup process_startup,
++    chrome::startup::IsFirstRun is_first_run,
++    ProfilePicker::FirstRunExitStatus status) {
++  if (status != ProfilePicker::FirstRunExitStatus::kCompleted) {
++    return;
++  }
++
++  StartupBrowserCreator browser_creator;
++  browser_creator.AddFirstRunTabs(first_run_urls);
++  browser_creator.LaunchBrowser(command_line, profile, cur_dir, process_startup,
++                                is_first_run, /*restore_tabbed_browser=*/true);
++}
++#endif  // !BUILDFLAG(IS_CHROMEOS)
++
+ #if BUILDFLAG(IS_CHROMEOS)
+ // Returns the app id of the kiosk app associated with the current user session.
+ // Returns nullopt for non-kiosk user sessions and for ARCVM kiosk sessions,
+@@ -712,6 +733,18 @@ void StartupBrowserCreator::LaunchBrowser(
+       command_line, {profile, StartupProfileMode::kBrowserWindow});
+ 
+   if (!IsSilentLaunchEnabled(command_line, profile)) {
++#if !BUILDFLAG(IS_CHROMEOS)
++    if (!command_line.HasSwitch(switches::kNoFirstRun) &&
++        browseros::onboarding::ShouldShow(profile)) {
++      ProfilePicker::Show(ProfilePicker::Params::ForFirstRun(
++          profile->GetPath(),
++          base::BindOnce(&OpenNewWindowForBrowserOSOnboarding, command_line,
++                         profile, cur_dir, first_run_tabs_, process_startup,
++                         is_first_run)));
++      return;
++    }
++#endif  // !BUILDFLAG(IS_CHROMEOS)
++
+ #if BUILDFLAG(ENABLE_DICE_SUPPORT)
+     auto* fre_service = FirstRunServiceFactory::GetForBrowserContext(profile);
+     if (fre_service && fre_service->ShouldOpenFirstRun()) {

--- a/packages/browseros/chromium_patches/chrome/browser/ui/views/profiles/first_run_flow_controller.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/views/profiles/first_run_flow_controller.cc
@@ -1,0 +1,107 @@
+diff --git a/chrome/browser/ui/views/profiles/first_run_flow_controller.cc b/chrome/browser/ui/views/profiles/first_run_flow_controller.cc
+index 41048ae6fbd36..3b2d6f6162b34 100644
+--- a/chrome/browser/ui/views/profiles/first_run_flow_controller.cc
++++ b/chrome/browser/ui/views/profiles/first_run_flow_controller.cc
+@@ -19,6 +19,8 @@
+ #include "base/time/time.h"
+ #include "base/version_info/channel.h"
+ #include "chrome/browser/browser_process.h"
++#include "chrome/browser/browseros/onboarding/browseros_onboarding.h"
++#include "chrome/browser/browseros/onboarding/browseros_onboarding_prefs.h"
+ #include "chrome/browser/enterprise/util/managed_browser_utils.h"
+ #include "chrome/browser/policy/cloud/user_policy_signin_service.h"
+ #include "chrome/browser/policy/cloud/user_policy_signin_service_factory.h"
+@@ -195,6 +197,60 @@ class IntroStepController : public ProfileManagementStepController {
+   base::WeakPtrFactory<IntroStepController> weak_ptr_factory_{this};
+ };
+ 
++class BrowserOSOnboardingStepController
++    : public ProfileManagementStepController {
++ public:
++  BrowserOSOnboardingStepController(ProfilePickerWebContentsHost* host,
++                                    base::RepeatingClosure completion_callback)
++      : ProfileManagementStepController(host),
++        completion_callback_(std::move(completion_callback)) {}
++
++  ~BrowserOSOnboardingStepController() override = default;
++
++  void Show(StepSwitchFinishedCallback step_shown_callback,
++            bool reset_state) override {
++    if (reset_state) {
++      host()->ShowScreenInPickerContents(
++          GURL(chrome::kChromeUIBrowserOSOnboardingURL),
++          base::BindOnce(&BrowserOSOnboardingStepController::OnLoaded,
++                         weak_ptr_factory_.GetWeakPtr(),
++                         std::move(step_shown_callback)));
++      return;
++    }
++
++    DCHECK_EQ(GURL(chrome::kChromeUIBrowserOSOnboardingURL),
++              host()->GetPickerContents()->GetURL());
++    host()->ShowScreenInPickerContents(
++        GURL(), base::BindOnce(std::move(step_shown_callback.value()), true));
++    ExpectCompletionCallback();
++  }
++
++  void OnNavigateBackRequested() override {
++    NavigateBackInternal(host()->GetPickerContents());
++  }
++
++ private:
++  void OnLoaded(StepSwitchFinishedCallback step_shown_callback) {
++    std::move(step_shown_callback.value()).Run(/*success=*/true);
++    ExpectCompletionCallback();
++  }
++
++  void ExpectCompletionCallback() {
++    auto* onboarding_ui = host()
++                              ->GetPickerContents()
++                              ->GetWebUI()
++                              ->GetController()
++                              ->GetAs<BrowserOSOnboarding>();
++    DCHECK(onboarding_ui);
++    onboarding_ui->SetCompletionCallback(completion_callback_);
++  }
++
++  base::RepeatingClosure completion_callback_;
++
++  base::WeakPtrFactory<BrowserOSOnboardingStepController> weak_ptr_factory_{
++      this};
++};
++
+ class DefaultBrowserStepController : public ProfileManagementStepController {
+  public:
+   explicit DefaultBrowserStepController(
+@@ -539,16 +595,12 @@ void FirstRunFlowController::ShowSigninError(Profile* profile,
+ void FirstRunFlowController::Init() {
+   RegisterStep(
+       Step::kIntro,
+-      CreateIntroStep(
++      std::make_unique<BrowserOSOnboardingStepController>(
+           host(),
+-          base::BindRepeating(&FirstRunFlowController::HandleIntroSigninChoice,
+-                              weak_ptr_factory_.GetWeakPtr()),
+-          /*enable_animations=*/true));
++          base::BindRepeating(
++              &FirstRunFlowController::HandleBrowserOSOnboardingComplete,
++              weak_ptr_factory_.GetWeakPtr())));
+   SwitchToStep(Step::kIntro, /*reset_state=*/true);
+-
+-  signin_metrics::LogSignInOffered(
+-      kAccessPoint, signin_metrics::PromoAction::
+-                        PROMO_ACTION_NEW_ACCOUNT_NO_EXISTING_ACCOUNT);
+ }
+ 
+ void FirstRunFlowController::CancelSigninFlow() {
+@@ -598,6 +650,11 @@ void FirstRunFlowController::HandleIntroSigninChoice(IntroChoice choice) {
+       kAccessPoint, profile_->GetPath());
+ }
+ 
++void FirstRunFlowController::HandleBrowserOSOnboardingComplete() {
++  browseros::onboarding::MarkCompleted(profile_);
++  FinishFlowAndRunInBrowser(profile_, PostHostClearedCallback());
++}
++
+ std::unique_ptr<ProfilePickerPostSignInAdapter>
+ FirstRunFlowController::CreatePostSignInAdapter(
+     Profile* signed_in_profile,

--- a/packages/browseros/chromium_patches/chrome/browser/ui/views/profiles/first_run_flow_controller.h
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/views/profiles/first_run_flow_controller.h
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/ui/views/profiles/first_run_flow_controller.h b/chrome/browser/ui/views/profiles/first_run_flow_controller.h
+index ec68e45018034..a2644df0d8430 100644
+--- a/chrome/browser/ui/views/profiles/first_run_flow_controller.h
++++ b/chrome/browser/ui/views/profiles/first_run_flow_controller.h
+@@ -61,6 +61,7 @@ class FirstRunFlowController : public ProfileManagementFlowControllerImpl {
+ 
+  private:
+   void HandleIntroSigninChoice(IntroChoice choice);
++  void HandleBrowserOSOnboardingComplete();
+ 
+   // Run the `finish_flow_callback_` if it's not empty.
+   void RunFinishFlowCallback();

--- a/packages/browseros/chromium_patches/chrome/browser/ui/webui/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/webui/BUILD.gn
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/ui/webui/BUILD.gn b/chrome/browser/ui/webui/BUILD.gn
+index 0cccaa551b871..8b0e1ded36f1b 100644
+--- a/chrome/browser/ui/webui/BUILD.gn
++++ b/chrome/browser/ui/webui/BUILD.gn
+@@ -46,6 +46,7 @@ source_set("configs") {
+   deps = [
+     ":webui",
+     "//chrome/browser/actor/ui:actor_overlay",
++    "//chrome/browser/browseros/onboarding",
+     "//chrome/browser/contextual_tasks:ui",
+     "//chrome/browser/glic",
+     "//chrome/browser/optimization_guide",

--- a/packages/browseros/chromium_patches/chrome/browser/ui/webui/chrome_web_ui_configs.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/webui/chrome_web_ui_configs.cc
@@ -1,19 +1,28 @@
 diff --git a/chrome/browser/ui/webui/chrome_web_ui_configs.cc b/chrome/browser/ui/webui/chrome_web_ui_configs.cc
-index 30dddd61a226f..21b4dfc68602c 100644
+index 30dddd61a226f..c6a0798f6843c 100644
 --- a/chrome/browser/ui/webui/chrome_web_ui_configs.cc
 +++ b/chrome/browser/ui/webui/chrome_web_ui_configs.cc
-@@ -53,6 +53,7 @@
- #include "chrome/browser/ui/webui/signin_internals_ui.h"
- #include "chrome/browser/ui/webui/sync_internals/sync_internals_ui.h"
- #include "chrome/browser/ui/webui/translate_internals/translate_internals_ui.h"
+@@ -7,6 +7,7 @@
+ #include "build/android_buildflags.h"
+ #include "build/branding_buildflags.h"
+ #include "build/build_config.h"
++#include "chrome/browser/browseros/onboarding/browseros_onboarding.h"
+ #include "chrome/browser/contextual_tasks/contextual_tasks_ui.h"
+ #include "chrome/browser/glic/host/glic_ui.h"
+ #include "chrome/browser/optimization_guide/optimization_guide_internals_ui.h"
+@@ -16,6 +17,7 @@
+ #include "chrome/browser/ui/webui/autofill_and_password_manager_internals/autofill_internals_ui.h"
+ #include "chrome/browser/ui/webui/autofill_and_password_manager_internals/password_manager_internals_ui.h"
+ #include "chrome/browser/ui/webui/bluetooth_internals/bluetooth_internals_ui.h"  // nogncheck
 +#include "chrome/browser/ui/webui/browseros_welcome.h"
- #include "chrome/browser/ui/webui/usb_internals/usb_internals_ui.h"
- #include "chrome/browser/ui/webui/version/version_ui.h"
- #include "components/enterprise/buildflags/buildflags.h"
-@@ -290,6 +291,7 @@ void RegisterChromeWebUIConfigs() {
+ #include "chrome/browser/ui/webui/browsing_topics/browsing_topics_internals_ui.h"
+ #include "chrome/browser/ui/webui/chrome_finds_internals/chrome_finds_internals_ui.h"
+ #include "chrome/browser/ui/webui/chrome_urls/chrome_urls_ui.h"
+@@ -290,6 +292,8 @@ void RegisterChromeWebUIConfigs() {
    map.AddWebUIConfig(std::make_unique<SiteEngagementUIConfig>());
    map.AddWebUIConfig(std::make_unique<SyncInternalsUIConfig>());
    map.AddWebUIConfig(std::make_unique<TranslateInternalsUIConfig>());
++  map.AddWebUIConfig(std::make_unique<BrowserOSOnboardingUIConfig>());
 +  map.AddWebUIConfig(std::make_unique<BrowserOSWelcomeUIConfig>());
    map.AddWebUIConfig(std::make_unique<UsbInternalsUIConfig>());
    map.AddWebUIConfig(std::make_unique<user_actions_ui::UserActionsUIConfig>());

--- a/packages/browseros/chromium_patches/chrome/chrome_paks.gni
+++ b/packages/browseros/chromium_patches/chrome/chrome_paks.gni
@@ -1,0 +1,20 @@
+diff --git a/chrome/chrome_paks.gni b/chrome/chrome_paks.gni
+index ffc4930414158..0cca4bb52b60e 100644
+--- a/chrome/chrome_paks.gni
++++ b/chrome/chrome_paks.gni
+@@ -209,6 +209,7 @@ template("chrome_extra_paks") {
+         "$root_gen_dir/chrome/app_service_internals_resources.pak",
+         "$root_gen_dir/chrome/autofill_ml_internals_resources.pak",
+         "$root_gen_dir/chrome/bookmarks_resources.pak",
++        "$root_gen_dir/chrome/browseros_onboarding_resources.pak",
+         "$root_gen_dir/chrome/browser/actor/resources/actor_browser_resources.pak",
+         "$root_gen_dir/chrome/browser/actor/resources/actor_common_resources.pak",
+         "$root_gen_dir/chrome/certificate_manager_resources.pak",
+@@ -262,6 +263,7 @@ template("chrome_extra_paks") {
+       ]
+       deps += [
+         "//chrome/browser/actor/resources:browser_resources",
++        "//chrome/browser/browseros/onboarding:resources",
+         "//chrome/browser/resources:dev_ui_paks",
+         "//chrome/browser/resources/actor_overlay:resources",
+         "//chrome/browser/resources/autofill_ml_internals:resources",

--- a/packages/browseros/chromium_patches/chrome/common/webui_url_constants.cc
+++ b/packages/browseros/chromium_patches/chrome/common/webui_url_constants.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/common/webui_url_constants.cc b/chrome/common/webui_url_constants.cc
-index 016104d9a3035..87450514ce3f0 100644
+index 016104d9a3035..5b05791b4f778 100644
 --- a/chrome/common/webui_url_constants.cc
 +++ b/chrome/common/webui_url_constants.cc
 @@ -120,6 +120,7 @@ bool IsSystemWebUIHost(std::string_view host) {
@@ -10,3 +10,11 @@ index 016104d9a3035..87450514ce3f0 100644
        kChromeUIAboutHost,
        kChromeUIAccessibilityHost,
        kChromeUIActorInternalsHost,
+@@ -128,6 +129,7 @@ base::span<const base::cstring_view> ChromeURLHosts() {
+ #endif
+       kChromeUIAutofillInternalsHost,
+       kChromeUIBluetoothInternalsHost,
++      kChromeUIBrowserOSOnboardingHost,
+       kChromeUIBrowsingTopicsInternalsHost,
+       kChromeUIChromeFindsInternalsHost,
+       kChromeUIChromeURLsHost,

--- a/packages/browseros/chromium_patches/chrome/common/webui_url_constants.h
+++ b/packages/browseros/chromium_patches/chrome/common/webui_url_constants.h
@@ -1,12 +1,16 @@
 diff --git a/chrome/common/webui_url_constants.h b/chrome/common/webui_url_constants.h
-index d4f57a6ed3430..f560f7b32d532 100644
+index d4f57a6ed3430..70112d4153015 100644
 --- a/chrome/common/webui_url_constants.h
 +++ b/chrome/common/webui_url_constants.h
-@@ -33,6 +33,7 @@ namespace chrome {
+@@ -33,6 +33,11 @@ namespace chrome {
  // needed.
  // Please keep in alphabetical order, with OS/feature specific sections below.
  inline constexpr char kChromeUIAboutHost[] = "about";
 +inline constexpr char kBrowserOSFirstRun[] = "browseros-welcome";
++inline constexpr char kChromeUIBrowserOSOnboardingHost[] =
++    "browseros-onboarding";
++inline constexpr char kChromeUIBrowserOSOnboardingURL[] =
++    "chrome://browseros-onboarding/";
  inline constexpr char kChromeUIAboutURL[] = "chrome://about/";
  inline constexpr char kChromeUIAccessCodeCastHost[] = "access-code-cast";
  inline constexpr char kChromeUIAccessCodeCastURL[] =

--- a/packages/browseros/chromium_patches/tools/gritsettings/resource_ids.spec
+++ b/packages/browseros/chromium_patches/tools/gritsettings/resource_ids.spec
@@ -1,0 +1,15 @@
+diff --git a/tools/gritsettings/resource_ids.spec b/tools/gritsettings/resource_ids.spec
+index ffd47250ce5a6..34bf8cf50a085 100644
+--- a/tools/gritsettings/resource_ids.spec
++++ b/tools/gritsettings/resource_ids.spec
+@@ -165,6 +165,10 @@
+     "messages": [2540],
+     "includes": [2600],
+   },
++  "<(SHARED_INTERMEDIATE_DIR)/chrome/browser/browseros/onboarding/resources.grd": {
++    "META": {"sizes": {"includes": [20]}},
++    "includes": [2680],
++  },
+   # END chrome/browser section.
+ 
+   # START chrome/ WebUI resources section


### PR DESCRIPTION
## Summary
- Adds the BrowserOS Chromium patch set for the onboarding import WebUI and first-run popup wiring.
- Registers the new `onboarding-import` feature in `packages/browseros/build/features.yaml`.
- Includes the bundled WebUI resources and the native import API bridge needed by the onboarding app.

## Design
This extracts the Chromium-side onboarding import stack into BrowserOS per-file patches. The WebUI controller, message handler, resource packaging, prefs, first-run popup integration, WebUI URL registration, and pak/resource IDs are kept under the BrowserOS patch surface so downstream Chromium builds can apply the feature from `chromium_patches`.

## Test plan
- [x] `~/.skills/sf-ch-extract/scripts/verify-patches.sh --chromium-src /Users/shadowfax/code/chromium-checkouts/chromium-1/src --worktree /Users/shadowfax/worktrees/main/feat-onboarding-import-patches --tip 8241bc982537b2a91c2ada1547ef798a5cd9cb5a <23 committed patch paths>`
- [x] `git diff --check`