### PR TITLE
chore: unship codex server binary

### DIFF
--- a/packages/browseros-agent/scripts/build/config/server-prod-resources.json
+++ b/packages/browseros-agent/scripts/build/config/server-prod-resources.json
@@ -56,61 +56,6 @@
       "executable": true
     },
     {
-      "name": "Codex - macOS ARM64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/codex/codex-darwin-arm64"
-      },
-      "destination": "resources/bin/third_party/codex",
-      "os": ["macos"],
-      "arch": ["arm64"],
-      "executable": true
-    },
-    {
-      "name": "Codex - macOS x64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/codex/codex-darwin-x64"
-      },
-      "destination": "resources/bin/third_party/codex",
-      "os": ["macos"],
-      "arch": ["x64"],
-      "executable": true
-    },
-    {
-      "name": "Codex - Linux ARM64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/codex/codex-linux-arm64"
-      },
-      "destination": "resources/bin/third_party/codex",
-      "os": ["linux"],
-      "arch": ["arm64"],
-      "executable": true
-    },
-    {
-      "name": "Codex - Linux x64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/codex/codex-linux-x64"
-      },
-      "destination": "resources/bin/third_party/codex",
-      "os": ["linux"],
-      "arch": ["x64"],
-      "executable": true
-    },
-    {
-      "name": "Codex - Windows x64",
-      "source": {
-        "type": "r2",
-        "key": "third_party/codex/codex-windows-x64.exe"
-      },
-      "destination": "resources/bin/third_party/codex.exe",
-      "os": ["windows"],
-      "arch": ["x64"],
-      "executable": true
-    },
-    {
       "name": "Drizzle migrations",
       "source": {
         "type": "local",

--- a/packages/browseros-agent/scripts/build/server/stage.test.ts
+++ b/packages/browseros-agent/scripts/build/server/stage.test.ts
@@ -220,33 +220,7 @@ describe('server artifact staging', () => {
     }
   })
 
-  it('downloads bundled Codex CLI for Linux targets and marks it executable', async () => {
-    tempDir = await mkdtemp(join(tmpdir(), 'browseros-stage-test-'))
-    const sourceRoot = join(tempDir, 'source')
-    const distRoot = join(tempDir, 'dist')
-    const binaryPath = join(tempDir, 'browseros-server')
-    await writeFile(binaryPath, 'server')
-
-    const artifact = await stageTargetArtifact(
-      distRoot,
-      binaryPath,
-      linuxArm64Target,
-      [codexLinuxArm64Rule],
-      sourceRoot,
-      fakeObjectClient({
-        'artifacts/vendor/third_party/codex/codex-linux-arm64':
-          '#!/bin/sh\ncodex\n',
-      }),
-      fakeR2Config,
-      '0.0.0-test',
-    )
-
-    const codexPath = join(artifact.resourcesDir, 'bin/third_party/codex')
-    expect(await readFile(codexPath, 'utf8')).toBe('#!/bin/sh\ncodex\n')
-    expect((await stat(codexPath)).mode & 0o111).not.toBe(0)
-  })
-
-  it('downloads bundled Codex CLI for Windows targets without chmod', async () => {
+  it('downloads R2 resources for Windows targets without chmod', async () => {
     tempDir = await mkdtemp(join(tmpdir(), 'browseros-stage-test-'))
     const sourceRoot = join(tempDir, 'source')
     const distRoot = join(tempDir, 'dist')
@@ -257,62 +231,57 @@ describe('server artifact staging', () => {
       distRoot,
       binaryPath,
       windowsX64Target,
-      [codexWindowsX64Rule],
+      [windowsToolRule],
       sourceRoot,
       fakeObjectClient({
-        'artifacts/vendor/third_party/codex/codex-windows-x64.exe': 'codex.exe',
+        'artifacts/vendor/third_party/tool/tool-windows-x64.exe': 'tool.exe',
       }),
       fakeR2Config,
       '0.0.0-test',
     )
 
-    const codexPath = join(artifact.resourcesDir, 'bin/third_party/codex.exe')
-    expect(await readFile(codexPath, 'utf8')).toBe('codex.exe')
-    expect((await stat(codexPath)).mode & 0o111).toBe(0)
+    const toolPath = join(artifact.resourcesDir, 'bin/third_party/tool.exe')
+    expect(await readFile(toolPath, 'utf8')).toBe('tool.exe')
+    expect((await stat(toolPath)).mode & 0o111).toBe(0)
   })
 
-  it('loads target-filtered bundled CLI rules from the production manifest', () => {
+  it('does not package bundled agent CLI rules in the production manifest', () => {
     const manifest = loadManifest(
       'scripts/build/config/server-prod-resources.json',
     )
     const linuxRules = getTargetRules(manifest, linuxArm64Target)
     const windowsRules = getTargetRules(manifest, windowsX64Target)
-    const claudeRules = manifest.resources.filter(
+    const bundledAgentRules = manifest.resources.filter(
       (rule) =>
+        rule.name.includes('Codex') ||
         rule.name.includes('Claude Code') ||
+        rule.destination.includes('third_party/codex') ||
         rule.destination.includes('third_party/claude') ||
-        (rule.source.type === 'r2' && rule.source.key.includes('claude-code')),
+        (rule.source.type === 'r2' &&
+          (rule.source.key.includes('third_party/codex') ||
+            rule.source.key.includes('claude-code'))),
     )
 
-    expect(linuxRules).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'Codex - Linux ARM64',
-          source: {
-            type: 'r2',
-            key: 'third_party/codex/codex-linux-arm64',
-          },
-          destination: 'resources/bin/third_party/codex',
-          executable: true,
-        }),
-      ]),
+    expect(bundledAgentRules).toEqual([])
+    expect(
+      linuxRules.find((rule) => rule.destination.includes('third_party/codex')),
+    ).toBe(undefined)
+    expect(
+      windowsRules.find((rule) =>
+        rule.destination.includes('third_party/codex'),
+      ),
+    ).toBe(undefined)
+    expect(linuxRules.find((rule) => rule.name.startsWith('Bun - '))).toEqual(
+      expect.objectContaining({
+        destination: 'resources/bin/third_party/bun',
+        executable: true,
+      }),
     )
-    expect(windowsRules).toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          name: 'Codex - Windows x64',
-          source: {
-            type: 'r2',
-            key: 'third_party/codex/codex-windows-x64.exe',
-          },
-          destination: 'resources/bin/third_party/codex.exe',
-          executable: true,
-        }),
-      ]),
-    )
-    expect(claudeRules).toEqual([])
-    expect(linuxRules.find((rule) => rule.name === 'Codex - Windows x64')).toBe(
-      undefined,
+    expect(windowsRules.find((rule) => rule.name.startsWith('Bun - '))).toEqual(
+      expect.objectContaining({
+        destination: 'resources/bin/third_party/bun.exe',
+        executable: true,
+      }),
     )
   })
 })
@@ -384,25 +353,13 @@ const bunRule: ResourceRule = {
   executable: true,
 }
 
-const codexLinuxArm64Rule: ResourceRule = {
-  name: 'Codex - Linux ARM64',
+const windowsToolRule: ResourceRule = {
+  name: 'Tool - Windows x64',
   source: {
     type: 'r2',
-    key: 'third_party/codex/codex-linux-arm64',
+    key: 'third_party/tool/tool-windows-x64.exe',
   },
-  destination: 'resources/bin/third_party/codex',
-  os: ['linux'],
-  arch: ['arm64'],
-  executable: true,
-}
-
-const codexWindowsX64Rule: ResourceRule = {
-  name: 'Codex - Windows x64',
-  source: {
-    type: 'r2',
-    key: 'third_party/codex/codex-windows-x64.exe',
-  },
-  destination: 'resources/bin/third_party/codex.exe',
+  destination: 'resources/bin/third_party/tool.exe',
   os: ['windows'],
   arch: ['x64'],
   executable: true,

--- a/packages/browseros/build/cli/storage_test.py
+++ b/packages/browseros/build/cli/storage_test.py
@@ -392,8 +392,8 @@ class BuildManifestTest(unittest.TestCase):
         self.assertIn("uploaded_by", manifest)
 
 
-class PackagedAgentCliContractTest(unittest.TestCase):
-    def test_server_resource_keys_match_storage_upload_keys(self) -> None:
+class ServerResourceManifestContractTest(unittest.TestCase):
+    def test_server_resource_manifest_does_not_package_codex(self) -> None:
         manifest_path = (
             Path(__file__).resolve().parents[3]
             / "browseros-agent"
@@ -403,18 +403,17 @@ class PackagedAgentCliContractTest(unittest.TestCase):
             / "server-prod-resources.json"
         )
         manifest = json.loads(manifest_path.read_text())
-        actual_keys = {
-            f"artifacts/vendor/{resource['source']['key']}"
+        codex_resources = [
+            resource
             for resource in manifest["resources"]
-            if resource["source"]["type"] == "r2"
-            and resource["source"]["key"].startswith("third_party/codex/")
-        }
-        expected_keys = {
-            f"{storage.CODEX_R2_PREFIX}/{storage._platform_binary_object_name('codex', platform.target)}"
-            for platform in storage.CODEX_PLATFORMS
-        }
+            if resource["destination"].startswith("resources/bin/third_party/codex")
+            or (
+                resource["source"]["type"] == "r2"
+                and resource["source"]["key"].startswith("third_party/codex/")
+            )
+        ]
 
-        self.assertEqual(actual_keys, expected_keys)
+        self.assertEqual(codex_resources, [])
 
 
 class ProcessArchTest(unittest.TestCase):

--- a/packages/browseros/build/common/server_binaries.py
+++ b/packages/browseros/build/common/server_binaries.py
@@ -20,14 +20,12 @@ MACOS_SERVER_BINARIES: Dict[str, SignSpec] = {
         "browseros_server", "runtime", "browseros-executable-entitlements.plist"
     ),
     "bun": SignSpec("bun", "runtime", "browseros-executable-entitlements.plist"),
-    "codex": SignSpec("codex", "runtime"),
     "rg": SignSpec("rg", "runtime"),
 }
 
 
 WINDOWS_SERVER_BINARIES: List[str] = [
     "browseros_server.exe",
-    "third_party/codex.exe",
 ]
 
 

--- a/packages/browseros/build/common/server_binaries_test.py
+++ b/packages/browseros/build/common/server_binaries_test.py
@@ -28,18 +28,19 @@ class MacosServerBinariesTest(unittest.TestCase):
             self.assertTrue(plist.exists(), f"{stem}: entitlements {plist} missing")
 
     def test_macos_sign_spec_for_resolves_by_stem(self):
-        spec = macos_sign_spec_for(Path("/x/codex"))
+        spec = macos_sign_spec_for(Path("/x/browseros_server"))
         assert spec is not None
-        self.assertEqual(spec.identifier_suffix, "codex")
+        self.assertEqual(spec.identifier_suffix, "browseros_server")
         self.assertIsNone(macos_sign_spec_for(Path("/x/not_a_known_binary")))
 
-    def test_agent_cli_entries_use_plain_hardened_runtime(self):
-        for binary in ["codex"]:
+    def test_third_party_tool_entries_use_plain_hardened_runtime(self):
+        for binary in ["rg"]:
             spec = macos_sign_spec_for(Path(f"/x/{binary}"))
             assert spec is not None
             self.assertEqual(spec.identifier_suffix, binary)
             self.assertEqual(spec.options, "runtime")
             self.assertIsNone(spec.entitlements)
+        self.assertIsNone(macos_sign_spec_for(Path("/x/codex")))
         self.assertIsNone(macos_sign_spec_for(Path("/x/claude")))
 
     def test_lima_is_not_registered_for_signing(self):
@@ -70,9 +71,6 @@ class WindowsServerBinariesTest(unittest.TestCase):
                 f"{rel} outside expected layout",
             )
 
-    def test_windows_includes_agent_cli_entries(self):
-        self.assertIn("third_party/codex.exe", WINDOWS_SERVER_BINARIES)
-
     def test_expected_windows_binary_paths_joins_root(self):
         root = Path("/tmp/fake/resources/bin")
         resolved = expected_windows_binary_paths(root)
@@ -87,6 +85,7 @@ class WindowsServerBinariesTest(unittest.TestCase):
             "third_party/podman/win-sshproxy.exe",
             "third_party/bun.exe",
             "third_party/rg.exe",
+            "third_party/codex.exe",
             "third_party/claude.exe",
         }
         leftover = forbidden & set(WINDOWS_SERVER_BINARIES)

--- a/packages/browseros/build/modules/ota/common.py
+++ b/packages/browseros/build/modules/ota/common.py
@@ -239,7 +239,7 @@ def create_server_bundle_zip(resources_dir: Path, output_zip: Path) -> bool:
     """Zip an extracted ``resources/`` tree into a Sparkle payload.
 
     Produces entries like ``resources/bin/browseros_server`` and
-    ``resources/bin/third_party/codex`` — mirroring what the agent build
+    ``resources/bin/third_party/bun`` — mirroring what the agent build
     staged and what the Chromium build bakes into the installed app.
     File modes are preserved by ``ZipFile.write`` so executable bits survive.
     """

--- a/packages/browseros/build/modules/ota/sign_binary_test.py
+++ b/packages/browseros/build/modules/ota/sign_binary_test.py
@@ -16,11 +16,10 @@ def _write_exe(path: Path) -> None:
 
 
 class SignServerBundleWindowsTest(unittest.TestCase):
-    def test_signs_shipped_windows_binaries_without_claude(self):
+    def test_signs_shipped_windows_binaries_without_third_party_cli_tools(self):
         with tempfile.TemporaryDirectory() as tmp:
             resources = Path(tmp) / "resources"
             _write_exe(resources / "bin" / "browseros_server.exe")
-            _write_exe(resources / "bin" / "third_party" / "codex.exe")
 
             signed = []
 
@@ -35,7 +34,7 @@ class SignServerBundleWindowsTest(unittest.TestCase):
                     sign_binary.sign_server_bundle_windows(resources, EnvConfig())
                 )
 
-            self.assertEqual(signed, ["browseros_server.exe", "third_party/codex.exe"])
+            self.assertEqual(signed, ["browseros_server.exe"])
 
 
 if __name__ == "__main__":

--- a/packages/browseros/build/modules/sign/macos_test.py
+++ b/packages/browseros/build/modules/sign/macos_test.py
@@ -56,7 +56,7 @@ class MacOSSignDiscoveryTest(unittest.TestCase):
 
             self.assertIn(server_bin / "browseros_server", executables)
             self.assertIn(server_bin / "third_party" / "rg", executables)
-            self.assertIn(server_bin / "third_party" / "codex", executables)
+            self.assertNotIn(server_bin / "third_party" / "codex", executables)
             self.assertNotIn(server_bin / "third_party" / "claude", executables)
             self.assertNotIn(
                 server_bin / "third_party" / "lima" / "bin" / "limactl",
@@ -83,13 +83,13 @@ class VerifyServerResourcesBundleTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             chromium_src, app_path, source_root, bundle_root = self._setup(tmp)
             _write_exec(source_root / "bin" / "browseros_server")
-            _write_exec(source_root / "bin" / "third_party" / "codex")
+            _write_exec(source_root / "bin" / "third_party" / "rg")
             _write_exec(bundle_root / "bin" / "browseros_server")
 
             problems = verify_server_resources_bundle(app_path, chromium_src)
 
             self.assertEqual(len(problems), 1)
-            self.assertIn("bin/third_party/codex", problems[0])
+            self.assertIn("bin/third_party/rg", problems[0])
 
     def test_reports_lost_executable_bit(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -107,10 +107,10 @@ class VerifyServerResourcesBundleTest(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             chromium_src, app_path, source_root, bundle_root = self._setup(tmp)
             _write_exec(source_root / "bin" / "browseros_server")
-            _write_exec(source_root / "bin" / "third_party" / "codex")
+            _write_exec(source_root / "bin" / "third_party" / "rg")
             _write_file(source_root / "db" / "migrations" / "0000_init.sql")
             _write_exec(bundle_root / "bin" / "browseros_server")
-            _write_exec(bundle_root / "bin" / "third_party" / "codex")
+            _write_exec(bundle_root / "bin" / "third_party" / "rg")
             _write_file(bundle_root / "db" / "migrations" / "0000_init.sql")
 
             self.assertEqual(
@@ -173,7 +173,7 @@ class SignModuleGuardWiringTest(unittest.TestCase):
             source_root = (
                 chromium_src / "chrome" / "browser" / "browseros" / "server" / "resources"
             )
-            _write_exec(source_root / "bin" / "third_party" / "codex")
+            _write_exec(source_root / "bin" / "third_party" / "rg")
 
             ctx = Context(
                 chromium_src=chromium_src,
@@ -184,7 +184,7 @@ class SignModuleGuardWiringTest(unittest.TestCase):
             with self.assertRaises(RuntimeError) as raised:
                 MacOSSignModule()._verify_server_resources(app_path, ctx)
 
-            self.assertIn("bin/third_party/codex", str(raised.exception))
+            self.assertIn("bin/third_party/rg", str(raised.exception))
 
     def test_module_guard_accepts_matching_bundle(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -201,8 +201,8 @@ class SignModuleGuardWiringTest(unittest.TestCase):
                 / "default"
                 / "resources"
             )
-            _write_exec(source_root / "bin" / "third_party" / "codex")
-            _write_exec(bundle_root / "bin" / "third_party" / "codex")
+            _write_exec(source_root / "bin" / "third_party" / "rg")
+            _write_exec(bundle_root / "bin" / "third_party" / "rg")
 
             ctx = Context(
                 chromium_src=chromium_src,
@@ -399,7 +399,7 @@ class VerifySignatureComponentTest(unittest.TestCase):
 
     def _build_app(self, tmp):
         app_path = Path(tmp) / "BrowserOS.app"
-        codex = (
+        rg = (
             app_path
             / "Contents"
             / "Resources"
@@ -408,31 +408,31 @@ class VerifySignatureComponentTest(unittest.TestCase):
             / "resources"
             / "bin"
             / "third_party"
-            / "codex"
+            / "rg"
         )
-        _write_exec(codex)
-        return app_path, codex
+        _write_exec(rg)
+        return app_path, rg
 
     def test_fails_when_component_signature_invalid(self):
         with tempfile.TemporaryDirectory() as tmp:
-            app_path, codex = self._build_app(tmp)
+            app_path, rg = self._build_app(tmp)
             calls = []
 
             def run(cmd, cwd=None, check=True):
                 calls.append(cmd)
-                returncode = 1 if cmd[-1] == str(codex) else 0
+                returncode = 1 if cmd[-1] == str(rg) else 0
                 return _completed(cmd, returncode=returncode)
 
             with mock.patch.object(macos_module, "run_command", run):
                 self.assertFalse(verify_signature(app_path))
 
             self.assertTrue(
-                any(c[0] == "codesign" and c[-1] == str(codex) for c in calls)
+                any(c[0] == "codesign" and c[-1] == str(rg) for c in calls)
             )
 
     def test_passes_and_verifies_each_component(self):
         with tempfile.TemporaryDirectory() as tmp:
-            app_path, codex = self._build_app(tmp)
+            app_path, rg = self._build_app(tmp)
             calls = []
 
             with mock.patch.object(
@@ -442,7 +442,7 @@ class VerifySignatureComponentTest(unittest.TestCase):
 
             self.assertTrue(
                 any(
-                    c[0] == "codesign" and "--verify" in c and c[-1] == str(codex)
+                    c[0] == "codesign" and "--verify" in c and c[-1] == str(rg)
                     for c in calls
                 )
             )


### PR DESCRIPTION
## Summary
- Remove Codex binaries from the production server resource manifest.
- Remove Codex from shared macOS/Windows server-binary signing expectations.
- Update staging, signing, OTA, and storage contract tests for the unshipped bundle state.

## Design
The server artifact manifest is the packaging contract, and the Python signing modules consume `build/common/server_binaries.py` as their shared signing contract. This PR removes Codex from those two contracts while leaving non-bundled Codex runtime/upload support intact.

## Test plan
- [x] `cd packages/browseros-agent && bun test scripts/build/server/stage.test.ts`
- [x] `cd packages/browseros && python -m unittest build.common.server_binaries_test build.modules.sign.macos_test build.modules.ota.sign_binary_test build.cli.storage_test`
- [x] `cd packages/browseros-agent && bun run check` (exits 0; repo still prints unrelated existing Biome/Fallow warnings)
- [x] `cd packages/browseros-agent && bun run test`
- [x] `git diff --check`
