### PR TITLE
fix: open new tab after onboarding complete

### DIFF
--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.test.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.test.tsx
@@ -88,7 +88,7 @@ describe('OnboardingV2 shell', () => {
 
     openBrowserOsNewTab()
 
-    expect(getAssignedUrl()).toBe('chrome://new-tab')
+    expect(getAssignedUrl()).toBe('chrome://newtab')
   })
 
   it('does not treat failed or completed Chromium states as import success', () => {

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.test.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.test.tsx
@@ -1,7 +1,11 @@
 import { afterEach, describe, expect, it } from 'bun:test'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router'
-import { importPhaseFor, OnboardingV2, openBrowserOsHome } from './OnboardingV2'
+import {
+  importPhaseFor,
+  OnboardingV2,
+  openBrowserOsNewTab,
+} from './OnboardingV2'
 
 const originalWindow = globalThis.window
 
@@ -77,14 +81,14 @@ describe('OnboardingV2 shell', () => {
     expect(matches.length).toBe(4)
   })
 
-  it('opens the resolved BrowserOS cockpit URL when onboarding completes', () => {
+  it('opens BrowserOS new tab when onboarding completes', () => {
     const getAssignedUrl = installAssignableWindow(
       '?apiUrl=http%3A%2F%2F127.0.0.1%3A9234',
     )
 
-    openBrowserOsHome()
+    openBrowserOsNewTab()
 
-    expect(getAssignedUrl()).toBe('http://127.0.0.1:9234')
+    expect(getAssignedUrl()).toBe('chrome://new-tab')
   })
 
   it('does not treat failed or completed Chromium states as import success', () => {

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.tsx
@@ -31,7 +31,7 @@ import { WelcomeStep } from './steps/WelcomeStep'
 
 const TOTAL_STEPS = 4
 const FAKE_CONNECT_DELAY_MS = 1700
-const BROWSEROS_NEW_TAB_URL = 'chrome://new-tab'
+const BROWSEROS_NEW_TAB_URL = 'chrome://newtab'
 
 const initialOnboardingState: BrowserOSOnboardingState = {
   apiVersion: BROWSEROS_ONBOARDING_API_VERSION,

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.tsx
@@ -7,7 +7,6 @@
 import { useEffect, useRef, useState } from 'react'
 import { useForm } from 'react-hook-form'
 import { Form } from '@/components/ui/form'
-import { buildCockpitHomeUrl } from '@/modules/api/mcp-endpoint'
 import {
   BROWSEROS_ONBOARDING_API_VERSION,
   type BrowserOSImportStatus,
@@ -32,6 +31,7 @@ import { WelcomeStep } from './steps/WelcomeStep'
 
 const TOTAL_STEPS = 4
 const FAKE_CONNECT_DELAY_MS = 1700
+const BROWSEROS_NEW_TAB_URL = 'chrome://new-tab'
 
 const initialOnboardingState: BrowserOSOnboardingState = {
   apiVersion: BROWSEROS_ONBOARDING_API_VERSION,
@@ -51,9 +51,9 @@ export function importPhaseFor(
   return 'picker'
 }
 
-/** Leaves the standalone onboarding app and opens the BrowserOS cockpit. */
-export function openBrowserOsHome() {
-  window.location.assign(buildCockpitHomeUrl())
+/** Leaves standalone onboarding for BrowserOS's Chromium new-tab page. */
+export function openBrowserOsNewTab() {
+  window.location.assign(BROWSEROS_NEW_TAB_URL)
 }
 
 /** Runs the standalone four-step BrowserClaw onboarding flow. */
@@ -127,7 +127,7 @@ export function OnboardingV2() {
 
   function finishOnboarding() {
     bridge.complete()
-    openBrowserOsHome()
+    openBrowserOsNewTab()
   }
 
   return (


### PR DESCRIPTION
## Summary
- Keep standalone BrowserClaw onboarding completion on the existing `browserosOnboardingComplete` Chromium bridge message.
- Replace the post-completion cockpit redirect with Chromium's canonical new-tab URL, `chrome://newtab`.
- Update the focused onboarding test to lock the new destination.

## Design
`OnboardingV2` still calls `bridge.complete()` before navigating away, so native onboarding completion stays at the Chromium bridge boundary. The only UI-side behavior change is that the finish action now leaves the standalone onboarding WebUI for the BrowserOS new-tab page instead of resolving and opening the cockpit API root. I used `chrome://newtab` rather than the requested `chrome://new-tab` because local BrowserOS launch configs and Chromium constants use `chrome://newtab` / `chrome://newtab/`, and no `chrome://new-tab` alias showed up in the local sources.

## Test plan
- [x] `bun test apps/claw-onboard/src/onboarding/OnboardingV2.test.tsx apps/claw-onboard/src/onboarding/browseros-onboarding-bridge.test.ts`
- [x] `bun run check` (exits 0; prints existing unrelated Biome/Fallow warnings)
- [x] `bun run test`
- [x] local Codex diff review, round 2 clean
