### PR TITLE
feat: read Claw config as JSON

### DIFF
--- a/packages/browseros-agent/apps/claw-server/.env.example
+++ b/packages/browseros-agent/apps/claw-server/.env.example
@@ -7,5 +7,5 @@
 # BrowserOS Chromium DevTools port that Claw-server dials over CDP.
 # BROWSEROS_CLAW_CDP_PORT="49337"
 
-# Optional YAML config path. CLI --config <path> wins when both are set.
-# CLAW_CONFIG="./claw.config.yaml"
+# Optional JSON config path. CLI --config <path> wins when both are set.
+# CLAW_CONFIG="./claw.config.json"

--- a/packages/browseros-agent/apps/claw-server/package.json
+++ b/packages/browseros-agent/apps/claw-server/package.json
@@ -39,7 +39,6 @@
     "drizzle-orm": "^0.45.2",
     "hono": "^4.12.3",
     "nanoid": "^5.1.11",
-    "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/packages/browseros-agent/apps/claw-server/src/config.ts
+++ b/packages/browseros-agent/apps/claw-server/src/config.ts
@@ -1,7 +1,6 @@
 import { existsSync, readFileSync } from 'node:fs'
 import { isAbsolute, resolve } from 'node:path'
 import { Command } from 'commander'
-import { parseDocument } from 'yaml'
 import { z } from 'zod'
 import { CLAW_API_PORT_DEFAULT, CLAW_CDP_PORT_DEFAULT } from './shared/port'
 
@@ -47,7 +46,7 @@ type ConfigIssue = {
   keys?: string[]
 }
 
-/** Loads and validates Claw server ports from defaults, env, and YAML config. */
+/** Loads and validates Claw server ports from defaults, env, and JSON config. */
 export function loadClawConfig(
   options: LoadClawConfigOptions = {},
 ): ConfigResult<ClawConfig> {
@@ -89,7 +88,7 @@ function parseCliArgs(argv: string[]): ConfigResult<{ configPath?: string }> {
     program
       .name('claw-server')
       .description('BrowserClaw standalone API')
-      .option('--config <path>', 'Path to YAML configuration file')
+      .option('--config <path>', 'Path to JSON configuration file')
       .exitOverride((err) => {
         if (err.exitCode === 0) process.exit(0)
         throw err
@@ -151,14 +150,7 @@ function parseConfigFile(
 
   let raw: unknown
   try {
-    const doc = parseDocument(readFileSync(absPath, 'utf-8'))
-    if (doc.errors.length > 0) {
-      return {
-        ok: false,
-        error: `Config file error: ${doc.errors.map((err) => err.message).join('\n')}`,
-      }
-    }
-    raw = doc.toJS()
+    raw = JSON.parse(readFileSync(absPath, 'utf-8'))
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     return { ok: false, error: `Config file error: ${message}` }

--- a/packages/browseros-agent/apps/claw-server/src/env.ts
+++ b/packages/browseros-agent/apps/claw-server/src/env.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
  * Single chokepoint for non-port env reads. Port config lives in
- * config.ts so startup can validate env/YAML before serving.
+ * config.ts so startup can validate env/JSON before serving.
  */
 
 import type { ClawConfig } from './config'

--- a/packages/browseros-agent/apps/claw-server/tests/config.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/config.test.ts
@@ -10,7 +10,7 @@ import {
 
 async function writeConfig(contents: string): Promise<string> {
   const dir = await mkdtemp(join(tmpdir(), 'claw-config-'))
-  const path = join(dir, 'config.yaml')
+  const path = join(dir, 'config.json')
   await writeFile(path, contents)
   return path
 }
@@ -47,12 +47,15 @@ describe('loadClawConfig', () => {
     })
   })
 
-  test('reads ports from a YAML config file', async () => {
-    const configPath = await writeConfig(`
-ports:
-  server: 9420
-  cdp: 9020
-`)
+  test('reads ports from a JSON config file', async () => {
+    const configPath = await writeConfig(
+      JSON.stringify({
+        ports: {
+          server: 9420,
+          cdp: 9020,
+        },
+      }),
+    )
 
     const result = loadClawConfig({
       argv: [],
@@ -69,12 +72,15 @@ ports:
     })
   })
 
-  test('lets env ports override YAML config values', async () => {
-    const configPath = await writeConfig(`
-ports:
-  server: 9520
-  cdp: 9120
-`)
+  test('lets env ports override JSON config values', async () => {
+    const configPath = await writeConfig(
+      JSON.stringify({
+        ports: {
+          server: 9520,
+          cdp: 9120,
+        },
+      }),
+    )
 
     const result = loadClawConfig({
       argv: [],
@@ -96,16 +102,22 @@ ports:
   })
 
   test('--config wins over CLAW_CONFIG for the config file path', async () => {
-    const envConfigPath = await writeConfig(`
-ports:
-  server: 9300
-  cdp: 9000
-`)
-    const cliConfigPath = await writeConfig(`
-ports:
-  server: 9600
-  cdp: 9200
-`)
+    const envConfigPath = await writeConfig(
+      JSON.stringify({
+        ports: {
+          server: 9300,
+          cdp: 9000,
+        },
+      }),
+    )
+    const cliConfigPath = await writeConfig(
+      JSON.stringify({
+        ports: {
+          server: 9600,
+          cdp: 9200,
+        },
+      }),
+    )
 
     const result = loadClawConfig({
       argv: ['bun', 'src/main.ts', '--config', cliConfigPath],
@@ -136,10 +148,13 @@ ports:
   })
 
   test('rejects a blank --config value instead of falling back to CLAW_CONFIG', async () => {
-    const envConfigPath = await writeConfig(`
-ports:
-  server: 9300
-`)
+    const envConfigPath = await writeConfig(
+      JSON.stringify({
+        ports: {
+          server: 9300,
+        },
+      }),
+    )
 
     const result = loadClawConfig({
       argv: ['--config', '   '],
@@ -167,11 +182,14 @@ ports:
     }
   })
 
-  test('returns a clear error for invalid YAML ports', async () => {
-    const configPath = await writeConfig(`
-ports:
-  server: 70000
-`)
+  test('returns a clear error for invalid JSON ports', async () => {
+    const configPath = await writeConfig(
+      JSON.stringify({
+        ports: {
+          server: 70000,
+        },
+      }),
+    )
 
     const result = loadClawConfig({
       argv: ['--config', configPath],
@@ -186,11 +204,14 @@ ports:
     }
   })
 
-  test('returns a clear error for unknown YAML port keys', async () => {
-    const configPath = await writeConfig(`
-ports:
-  cdpPort: 9020
-`)
+  test('returns a clear error for unknown JSON port keys', async () => {
+    const configPath = await writeConfig(
+      JSON.stringify({
+        ports: {
+          cdpPort: 9020,
+        },
+      }),
+    )
 
     const result = loadClawConfig({
       argv: ['--config', configPath],
@@ -205,10 +226,13 @@ ports:
     }
   })
 
-  test('returns a clear error for malformed YAML', async () => {
+  test('returns a clear error for malformed JSON', async () => {
     const configPath = await writeConfig(`
-ports:
-  server: [9200
+{
+  "ports": {
+    "server": 9200,
+  }
+}
 `)
 
     const result = loadClawConfig({
@@ -220,20 +244,20 @@ ports:
     expect(result.ok).toBe(false)
     if (!result.ok) {
       expect(result.error).toContain('Config file error:')
-      expect(result.error).toContain('Flow sequence')
+      expect(result.error).toContain('JSON')
     }
   })
 
   test('returns a clear error for a missing config file', () => {
     const result = loadClawConfig({
-      argv: ['--config', '/missing/claw.yaml'],
+      argv: ['--config', '/missing/claw.json'],
       cwd: '/',
       env: {},
     })
 
     expect(result).toEqual({
       ok: false,
-      error: 'Config file not found: /missing/claw.yaml',
+      error: 'Config file not found: /missing/claw.json',
     })
   })
 })

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -215,7 +215,6 @@
         "drizzle-orm": "^0.45.2",
         "hono": "^4.12.3",
         "nanoid": "^5.1.11",
-        "yaml": "^2.9.0",
         "zod": "^4.4.3",
       },
       "devDependencies": {


### PR DESCRIPTION
## Summary
- Switch Claw config file parsing from YAML to JSON.
- Keep the existing Chromium-compatible `ports.server` and `ports.cdp` shape.
- Remove the Claw package's direct `yaml` dependency and update examples/help text.

## Design
`loadClawConfig` keeps its existing defaults, config file, and env merge path. Only `parseConfigFile` changes: it reads the selected config file with `JSON.parse`, then validates with the existing Zod schema.

## Test plan
- [x] `bun install --frozen-lockfile`
- [x] `bun test apps/claw-server/tests/config.test.ts`
- [x] `bun run --filter @browseros/claw-server typecheck`
- [x] `bun run --filter @browseros/claw-server test`
- [x] `bun run check`
- [x] `bun run test`
- [x] Local `sf-review` Codex review: clean