### PR TITLE
fix: repair cli npm release workflow

### DIFF
--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -169,11 +169,59 @@ jobs:
               --notes-file /tmp/release-notes.md \
               ${CLI_DIST}/*
           fi
+
+          if [ "$(gh release view "$TAG" --json isDraft --jq '.isDraft')" = "true" ]; then
+            gh release edit "$TAG" --draft=false
+          fi
         working-directory: ${{ github.workspace }}
+
+      - name: Verify GitHub release assets are public
+        run: |
+          TAG="${{ steps.release.outputs.tag }}"
+          VERSION="${{ steps.release.outputs.version }}"
+          ENCODED_TAG="${TAG//\//%2F}"
+          ASSET="browseros-cli_${VERSION}_linux_amd64.tar.gz"
+          URL="https://github.com/${{ github.repository }}/releases/download/${ENCODED_TAG}/${ASSET}"
+
+          curl -fsSI -L "$URL" >/dev/null
 
       - name: Publish to npm
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
+          VERSION="${{ steps.release.outputs.version }}"
+          if npm view "browseros-cli@${VERSION}" version >/dev/null 2>&1; then
+            npm dist-tag add "browseros-cli@${VERSION}" latest
+            echo "browseros-cli@${VERSION} already exists on npm; refreshed latest tag and skipped publish."
+            exit 0
+          fi
+
           cd npm
           npm publish --access public
+
+      - name: Verify npm package install
+        env:
+          BROWSEROS_NPM_FORCE: "1"
+        run: |
+          VERSION="${{ steps.release.outputs.version }}"
+          TMP_DIR="$(mktemp -d)"
+          trap 'rm -rf "$TMP_DIR"' EXIT
+
+          cd "$TMP_DIR"
+          npm init -y >/dev/null
+          LATEST="$(npm view browseros-cli dist-tags.latest)"
+          if [ "$LATEST" != "$VERSION" ]; then
+            echo "Expected npm latest to be ${VERSION}, got ${LATEST}" >&2
+            exit 1
+          fi
+
+          for attempt in 1 2 3 4 5; do
+            if npm install browseros-cli@latest; then
+              break
+            fi
+            if [ "$attempt" = "5" ]; then
+              exit 1
+            fi
+            sleep 5
+          done
+          ./node_modules/.bin/browseros-cli --version | grep -F "$VERSION"


### PR DESCRIPTION
## Summary
- Publish existing draft GitHub CLI releases after asset upload so npm postinstall can fetch public release assets.
- Verify the exact public GitHub release archive URL before npm publish.
- Make same-tag repair reruns safe by refreshing the npm latest dist-tag when the version already exists, then verifying a forced npm install of browseros-cli@latest.

## Root Cause
The npm package did publish, but browseros-cli@0.3.2 failed to install because the matching GitHub Release was still draft/untagged. Curl installs worked because they use CDN assets; npm postinstall uses GitHub Release assets.

I also repaired the live cli/v0.3.2 release by publishing the existing draft release and verified a fresh npm install now reports browseros-cli version 0.3.2.

## Test Plan
- [x] ruby -e 'require "yaml"; YAML.load_file(".github/workflows/release-cli.yml"); puts "workflow yaml ok"'
- [x] actionlint .github/workflows/release-cli.yml
- [x] bun test scripts/build/cli/release-policy.test.ts scripts/build/cli/npm-access.test.ts
- [x] cd packages/browseros-agent/apps/cli && gofmt -l .
- [x] cd packages/browseros-agent/apps/cli && go vet ./...
- [x] cd packages/browseros-agent/apps/cli && go build ./...
- [x] cd packages/browseros-agent/apps/cli && go test ./...
- [x] bun run check
- [x] bun run test (rerun passed; first run hit a transient local CDP startup timeout in browseros-cli integration, then targeted cli group passed before full rerun)
- [x] fresh npm install browseros-cli@latest with BROWSEROS_NPM_FORCE=1 -> browseros-cli version 0.3.2