### PR TITLE
feat: add claw server version flag

### DIFF
--- a/packages/browseros-agent/apps/claw-server/src/config.ts
+++ b/packages/browseros-agent/apps/claw-server/src/config.ts
@@ -3,6 +3,7 @@ import { dirname, isAbsolute, resolve } from 'node:path'
 import { Command } from 'commander'
 import { z } from 'zod'
 import { CLAW_API_PORT_DEFAULT, CLAW_CDP_PORT_DEFAULT } from './shared/port'
+import { VERSION } from './version'
 
 const portSchema = z.number().int().min(1).max(65535)
 const optionalPortSchema = z.preprocess(
@@ -120,6 +121,7 @@ function parseCliArgs(
     program
       .name('claw-server')
       .description('BrowserClaw standalone API')
+      .version(VERSION)
       .option('--config <path>', 'Path to JSON configuration file')
       .option('--resources-dir <path>', 'Resources directory path')
       .exitOverride((err) => {

--- a/packages/browseros-agent/apps/claw-server/src/version.ts
+++ b/packages/browseros-agent/apps/claw-server/src/version.ts
@@ -1,0 +1,6 @@
+declare const __BROWSEROS_VERSION__: string
+
+export const VERSION: string =
+  typeof __BROWSEROS_VERSION__ !== 'undefined'
+    ? __BROWSEROS_VERSION__
+    : '0.0.0-dev'

--- a/packages/browseros-agent/apps/claw-server/tests/build.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/build.test.ts
@@ -73,6 +73,7 @@ describe('claw server build', () => {
   it('builds a local artifact without apps/server env files', async () => {
     rmSync(zipPath, { force: true })
     const pkg = await Bun.file(clawPkgPath).json()
+    const expectedVersion: string = pkg.version
 
     const build = Bun.spawn(['bun', buildScript, `--target=${target.id}`], {
       cwd: rootDir,
@@ -98,8 +99,23 @@ describe('claw server build', () => {
     )
 
     const metadata = JSON.parse(readFileSync(metadataPath, 'utf-8'))
-    assert.strictEqual(metadata.version, pkg.version)
+    assert.strictEqual(metadata.version, expectedVersion)
     assert.strictEqual(metadata.target, target.id)
+
+    const versionResult = await collectProcess(
+      Bun.spawn([binaryPath, '--version'], {
+        stdout: 'pipe',
+        stderr: 'pipe',
+      }),
+    )
+    assert.strictEqual(
+      versionResult.exitCode,
+      0,
+      `Binary --version exited non-zero:\n${versionResult.stderr}`,
+    )
+    const actualVersion = versionResult.stdout.trim()
+    assert.strictEqual(actualVersion, expectedVersion)
+    assert.notStrictEqual(actualVersion, Bun.version)
 
     const zipListing = await collectProcess(
       Bun.spawn(['unzip', '-l', zipPath], {


### PR DESCRIPTION
## Summary
- Adds a Claw server `VERSION` constant using the shared build-time version define.
- Registers Commander `.version(VERSION)` so the standalone Claw server binary supports `--version`.
- Extends the Claw build smoke test to execute the compiled binary and compare output to `apps/claw-server/package.json`.

## Design
This mirrors `browseros-server`: the shared build tooling injects the active build product package version into `__BROWSEROS_VERSION__`, and Claw consumes that through a tiny local version module before Commander parses CLI args.

## Test plan
- [x] `bun test apps/claw-server/tests/config.test.ts apps/claw-server/tests/build.test.ts`
- [x] `bun run check`

## Review
- Local sf-review: clean, no findings.