### PR TITLE
fix(ci): repair nightly macOS workflow

### DIFF
--- a/.github/workflows/nightly-macos-build.yml
+++ b/.github/workflows/nightly-macos-build.yml
@@ -2,8 +2,8 @@ name: Nightly macOS Build
 
 on:
   schedule:
-    # About 10 PM US Pacific during daylight saving time. GitHub cron is UTC.
-    - cron: "0 5 * * *"
+    # About 9 PM US Pacific during daylight saving time. GitHub cron is UTC.
+    - cron: "0 4 * * *"
   workflow_dispatch:
     inputs:
       bump:
@@ -134,6 +134,7 @@ jobs:
       (github.event_name == 'schedule' || needs.authorize_manual_dispatch.result == 'success')
     permissions:
       contents: write
+      pull-requests: read
     uses: ./.github/workflows/release-server.yml
     with:
       version: ${{ needs.resolve_inputs.outputs.server_version }}

--- a/packages/browseros/build/docs/nightly-macos-ci.md
+++ b/packages/browseros/build/docs/nightly-macos-ci.md
@@ -1,9 +1,9 @@
 # Nightly macOS CI
 
 This workflow builds signed BrowserOS macOS arm64 DMGs on the dedicated Mac Mini.
-It runs nightly, can be triggered manually from any branch, bumps build versions,
-uploads the DMG to the Actions run, and leaves build lifecycle Slack updates to
-the existing BrowserOS build notifier.
+It runs nightly at 04:00 UTC, can be triggered manually from any branch, bumps
+build versions, uploads the DMG to the Actions run, and leaves build lifecycle
+Slack updates to the existing BrowserOS build notifier.
 
 ## What It Builds
 
@@ -89,10 +89,13 @@ Add these in GitHub repo settings under Actions variables:
 
 The workflow calls `build/scripts/bump_version.py`.
 
-- Nightly schedule: `offset+build`, commit and push enabled, R2 upload enabled
+- Nightly schedule: 04:00 UTC, `offset+build`, commit and push enabled, R2 upload enabled
 - Manual dispatch default: `offset+build`, commit disabled, R2 upload enabled
 - Manual hotfix option: choose `offset+patch`
 - Manual dry run option: choose `none`
+
+04:00 UTC is 9 PM US Pacific during daylight saving time. GitHub cron schedules
+are UTC-only and do not track daylight saving changes.
 
 `BROWSEROS_BUILD_OFFSET` is the internal Chromium-build monotonic counter.
 `BROWSEROS_BUILD` advances the public nightly semantic version. `BROWSEROS_PATCH`
@@ -111,6 +114,8 @@ squash merge, then auto-merge, and leaves the PR open if GitHub will not merge i
 yet. The persistent clone must already have credentials that can push bot
 branches. The workflow's `GITHUB_TOKEN` has `contents: write` and
 `pull-requests: write` for the build job so it can create and merge those PRs.
+The reusable server release job also receives `pull-requests: read`, matching the
+permission requested by `.github/workflows/release-server.yml`.
 
 ## Manual Branch Build
 


### PR DESCRIPTION
## Summary
- Grant the nightly `release_server` caller `pull-requests: read` so `.github/workflows/release-server.yml` can request its declared permissions.
- Move the nightly cron to `0 4 * * *`, which is 9 PM US Pacific during daylight saving time.
- Update the nightly macOS CI docs with the UTC schedule and reusable workflow permission note.

## Design
The caller job sets the maximum `GITHUB_TOKEN` permissions for the reusable workflow. Because `release-server.yml` declares `pull-requests: read`, the nightly caller must grant that permission alongside `contents: write`; otherwise GitHub rejects the workflow at startup. GitHub cron is UTC-only, so this uses 04:00 UTC for the requested 9 PM Pacific daylight-saving slot. Literal 9 PM PST is 05:00 UTC, which was the existing schedule.

## Test plan
- [x] `actionlint -ignore 'label "browseros-builder" is unknown' .github/workflows/nightly-macos-build.yml .github/workflows/release-server.yml`
- [x] `git diff --check HEAD`
- [x] `bun run check` (exits 0; prints existing unrelated Claw Biome/fallow warnings)

## Review
- Local review recorded no KEEP findings in `.llm/260626-1723_fix_nightly_macos_ci/review.md`.
