### PR TITLE
feat(patches): assistant toolbar visibility pref

### DIFF
--- a/packages/browseros/build/features.yaml
+++ b/packages/browseros/build/features.yaml
@@ -326,6 +326,7 @@ features:
       - chrome/browser/ui/toolbar/pinned_toolbar/BUILD.gn
       - chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model.cc
       - chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model.h
+      - chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model_browsertest.cc
       - chrome/browser/ui/toolbar/toolbar_pref_names.h
       - chrome/browser/ui/views/toolbar/BUILD.gn
       - chrome/browser/ui/views/toolbar/pinned_action_toolbar_button.h
@@ -338,6 +339,7 @@ features:
     files:
       - chrome/browser/extensions/extension_context_menu_model.cc
       - chrome/browser/extensions/extension_management.cc
+      - chrome/browser/ui/toolbar/BUILD.gn
       - chrome/browser/ui/toolbar/toolbar_actions_model.cc
       - chrome/browser/ui/views/side_panel/extensions/extension_side_panel_manager.cc
       - chrome/browser/ui/side_panel/side_panel_action_callback.cc

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/BUILD.gn
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/core/BUILD.gn b/chrome/browser/browseros/core/BUILD.gn
 new file mode 100644
-index 0000000000000..24fdd618e6a71
+index 0000000000000..6a4c48f2e597d
 --- /dev/null
 +++ b/chrome/browser/browseros/core/BUILD.gn
-@@ -0,0 +1,48 @@
+@@ -0,0 +1,49 @@
 +# Copyright 2024 The Chromium Authors
 +# Use of this source code is governed by a BSD-style license that can be
 +# found in the LICENSE file.
@@ -28,6 +28,7 @@ index 0000000000000..24fdd618e6a71
 +  ]
 +
 +  deps = [
++    ":core",
 +    "//base",
 +    "//chrome/browser/ui/actions:actions_headers",
 +    "//chrome/common:constants",

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.cc
@@ -1,15 +1,16 @@
 diff --git a/chrome/browser/browseros/core/browseros_prefs.cc b/chrome/browser/browseros/core/browseros_prefs.cc
 new file mode 100644
-index 0000000000000..52f183b59832c
+index 0000000000000..c47c0fad94dda
 --- /dev/null
 +++ b/chrome/browser/browseros/core/browseros_prefs.cc
-@@ -0,0 +1,90 @@
+@@ -0,0 +1,106 @@
 +// Copyright 2025 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
 +
 +#include "chrome/browser/browseros/core/browseros_prefs.h"
 +
++#include "chrome/browser/browseros/core/browseros_constants.h"
 +#include "chrome/browser/ui/actions/chrome_action_id.h"
 +#include "chrome/common/pref_names.h"
 +#include "components/pref_registry/pref_registry_syncable.h"
@@ -21,6 +22,7 @@ index 0000000000000..52f183b59832c
 +void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
 +  // Toolbar visibility prefs
 +  registry->RegisterBooleanPref(prefs::kShowLLMChat, true);
++  registry->RegisterBooleanPref(prefs::kShowAssistant, true);
 +  registry->RegisterBooleanPref(prefs::kShowToolbarLabels, true);
 +
 +  // Vertical tabs pref
@@ -38,6 +40,10 @@ index 0000000000000..52f183b59832c
 +
 +bool ShouldShowLLMChat(PrefService* pref_service) {
 +  return pref_service->GetBoolean(prefs::kShowLLMChat);
++}
++
++bool ShouldShowAssistant(PrefService* pref_service) {
++  return pref_service->GetBoolean(prefs::kShowAssistant);
 +}
 +
 +bool ShouldShowToolbarLabels(PrefService* pref_service) {
@@ -80,6 +86,8 @@ index 0000000000000..52f183b59832c
 +  switch (id) {
 +    case kActionSidePanelShowThirdPartyLlm:
 +      return prefs::kShowLLMChat;
++    case kActionBrowserOSAgent:
++      return prefs::kShowAssistant;
 +    default:
 +      return nullptr;
 +  }
@@ -91,6 +99,14 @@ index 0000000000000..52f183b59832c
 +    return true;  // No pref means always show
 +  }
 +  return pref_service->GetBoolean(pref_key);
++}
++
++bool ShouldPinBrowserOSExtension(const std::string& extension_id,
++                                 PrefService* pref_service) {
++  if (extension_id == kAgentExtensionId) {
++    return ShouldShowAssistant(pref_service);
++  }
++  return IsBrowserOSPinnedExtension(extension_id);
 +}
 +
 +}  // namespace browseros

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.h
@@ -1,15 +1,17 @@
 diff --git a/chrome/browser/browseros/core/browseros_prefs.h b/chrome/browser/browseros/core/browseros_prefs.h
 new file mode 100644
-index 0000000000000..2dabac573bf82
+index 0000000000000..fe576bc18a041
 --- /dev/null
 +++ b/chrome/browser/browseros/core/browseros_prefs.h
-@@ -0,0 +1,82 @@
+@@ -0,0 +1,95 @@
 +// Copyright 2025 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
 +
 +#ifndef CHROME_BROWSER_BROWSEROS_CORE_BROWSEROS_PREFS_H_
 +#define CHROME_BROWSER_BROWSEROS_CORE_BROWSEROS_PREFS_H_
++
++#include <string>
 +
 +#include "components/prefs/pref_service.h"
 +#include "ui/actions/action_id.h"
@@ -25,6 +27,9 @@ index 0000000000000..2dabac573bf82
 +// Toolbar visibility prefs
 +// Boolean: Show LLM Chat in toolbar (default: true)
 +inline constexpr char kShowLLMChat[] = "browseros.show_llm_chat";
++
++// Boolean: Show Assistant in toolbar (default: true)
++inline constexpr char kShowAssistant[] = "browseros.show_assistant";
 +
 +// Boolean: Show labels on BrowserOS toolbar actions (default: true)
 +inline constexpr char kShowToolbarLabels[] = "browseros.show_toolbar_labels";
@@ -55,6 +60,9 @@ index 0000000000000..2dabac573bf82
 +// Check if LLM Chat should be shown in toolbar.
 +bool ShouldShowLLMChat(PrefService* pref_service);
 +
++// Check if Assistant should be shown in toolbar.
++bool ShouldShowAssistant(PrefService* pref_service);
++
 +// Check if toolbar labels should be shown for BrowserOS actions.
 +bool ShouldShowToolbarLabels(PrefService* pref_service);
 +
@@ -72,10 +80,15 @@ index 0000000000000..2dabac573bf82
 +
 +// Check if a toolbar action should be shown based on its visibility pref.
 +// Returns true if:
-+//   - Action has no visibility pref (e.g., Assistant - always visible)
++//   - Action has no visibility pref
 +//   - Action's visibility pref is true
 +// Returns false if action's visibility pref is false.
 +bool ShouldShowToolbarAction(actions::ActionId id, PrefService* pref_service);
++
++// Check if a BrowserOS extension should be pinned in the toolbar based on its
++// extension metadata and visibility pref.
++bool ShouldPinBrowserOSExtension(const std::string& extension_id,
++                                 PrefService* pref_service);
 +
 +// Check if NTP content should receive focus instead of the omnibox.
 +bool IsNtpFocusContentEnabled(PrefService* pref_service);

--- a/packages/browseros/chromium_patches/chrome/browser/extensions/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/extensions/BUILD.gn
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/extensions/BUILD.gn b/chrome/browser/extensions/BUILD.gn
-index 43fd1559eee76..d2342fcab9abd 100644
+index 43fd1559eee76..403c61b70361e 100644
 --- a/chrome/browser/extensions/BUILD.gn
 +++ b/chrome/browser/extensions/BUILD.gn
 @@ -343,6 +343,12 @@ source_set("extensions") {
@@ -30,11 +30,12 @@ index 43fd1559eee76..d2342fcab9abd 100644
        "api/chrome_device_permissions_prompt.h",
        "api/enterprise_reporting_private/conversion_utils.cc",
        "api/enterprise_reporting_private/conversion_utils.h",
-@@ -987,6 +1001,8 @@ source_set("extensions") {
+@@ -987,6 +1001,9 @@ source_set("extensions") {
        "//components/language/core/common",
        "//components/language/core/language_model",
        "//components/live_caption:constants",
 +      "//chrome/browser/browseros/core",
++      "//chrome/browser/browseros/core:prefs",
 +      "//chrome/browser/browseros/metrics",
        "//components/media_device_salt",
        "//components/navigation_interception",

--- a/packages/browseros/chromium_patches/chrome/browser/extensions/api/settings_private/prefs_util.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/extensions/api/settings_private/prefs_util.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/extensions/api/settings_private/prefs_util.cc b/chrome/browser/extensions/api/settings_private/prefs_util.cc
-index 7238955992d8c..9d26d618a7c9d 100644
+index 7238955992d8c..34a90ffe0c372 100644
 --- a/chrome/browser/extensions/api/settings_private/prefs_util.cc
 +++ b/chrome/browser/extensions/api/settings_private/prefs_util.cc
 @@ -14,6 +14,7 @@
@@ -10,7 +10,7 @@ index 7238955992d8c..9d26d618a7c9d 100644
  #include "chrome/browser/content_settings/generated_cookie_prefs.h"
  #include "chrome/browser/content_settings/generated_javascript_optimizer_pref.h"
  #include "chrome/browser/content_settings/generated_permission_prompting_behavior_pref.h"
-@@ -626,6 +627,16 @@ const PrefsUtil::TypedPrefMap& PrefsUtil::GetAllowlistedKeys() {
+@@ -626,6 +627,18 @@ const PrefsUtil::TypedPrefMap& PrefsUtil::GetAllowlistedKeys() {
    (*s_allowlist)[::prefs::kCaretBrowsingEnabled] =
        settings_api::PrefType::kBoolean;
  
@@ -23,11 +23,13 @@ index 7238955992d8c..9d26d618a7c9d 100644
 +      settings_api::PrefType::kBoolean;
 +  (*s_allowlist)[browseros::prefs::kShowLLMChat] =
 +      settings_api::PrefType::kBoolean;
++  (*s_allowlist)[browseros::prefs::kShowAssistant] =
++      settings_api::PrefType::kBoolean;
 +
  #if BUILDFLAG(IS_CHROMEOS)
    // Accounts / Users / People.
    (*s_allowlist)[ash::kAccountsPrefAllowGuest] =
-@@ -1205,6 +1216,10 @@ const PrefsUtil::TypedPrefMap& PrefsUtil::GetAllowlistedKeys() {
+@@ -1205,6 +1218,10 @@ const PrefsUtil::TypedPrefMap& PrefsUtil::GetAllowlistedKeys() {
        settings_api::PrefType::kBoolean;
    (*s_allowlist)[::prefs::kImportDialogSearchEngine] =
        settings_api::PrefType::kBoolean;

--- a/packages/browseros/chromium_patches/chrome/browser/extensions/extension_management.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/extensions/extension_management.cc
@@ -1,17 +1,18 @@
 diff --git a/chrome/browser/extensions/extension_management.cc b/chrome/browser/extensions/extension_management.cc
-index bea1864156f76..eeb9c66eaae67 100644
+index bea1864156f76..1cd240b1027a1 100644
 --- a/chrome/browser/extensions/extension_management.cc
 +++ b/chrome/browser/extensions/extension_management.cc
-@@ -25,6 +25,8 @@
+@@ -25,6 +25,9 @@
  #include "base/values.h"
  #include "base/version.h"
  #include "build/chromeos_buildflags.h"
 +#include "chrome/browser/browser_features.h"
 +#include "chrome/browser/browseros/core/browseros_constants.h"
++#include "chrome/browser/browseros/core/browseros_prefs.h"
  #include "chrome/browser/enterprise/util/managed_browser_utils.h"
  #include "chrome/browser/extensions/cws_info_service_factory.h"
  #include "chrome/browser/extensions/extension_management_constants.h"
-@@ -272,6 +274,15 @@ bool ExtensionManagement::IsUpdateUrlOverridden(const ExtensionId& id) {
+@@ -272,6 +275,15 @@ bool ExtensionManagement::IsUpdateUrlOverridden(const ExtensionId& id) {
  }
  
  GURL ExtensionManagement::GetEffectiveUpdateURL(const Extension& extension) {
@@ -27,14 +28,14 @@ index bea1864156f76..eeb9c66eaae67 100644
    if (IsUpdateUrlOverridden(extension.id())) {
      DCHECK(!extension.was_installed_by_default())
          << "Update URL should not be overridden for default-installed "
-@@ -664,6 +675,14 @@ ExtensionIdSet ExtensionManagement::GetForcePinnedList() const {
+@@ -664,6 +676,14 @@ ExtensionIdSet ExtensionManagement::GetForcePinnedList() const {
        force_pinned_list.insert(entry.first);
      }
    }
 +
 +  // Always force-pin BrowserOS extensions that are marked pinned.
 +  for (const auto& extension_id : browseros::GetBrowserOSExtensionIds()) {
-+    if (browseros::IsBrowserOSPinnedExtension(extension_id)) {
++    if (browseros::ShouldPinBrowserOSExtension(extension_id, pref_service_)) {
 +      force_pinned_list.insert(extension_id);
 +    }
 +  }

--- a/packages/browseros/chromium_patches/chrome/browser/ui/toolbar/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/toolbar/BUILD.gn
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/ui/toolbar/BUILD.gn b/chrome/browser/ui/toolbar/BUILD.gn
+index e2d9d2396f6ba..c50ca0f3fb326 100644
+--- a/chrome/browser/ui/toolbar/BUILD.gn
++++ b/chrome/browser/ui/toolbar/BUILD.gn
+@@ -235,6 +235,7 @@ source_set("impl") {
+     ]
+ 
+     deps += [
++      "//chrome/browser/browseros/core:prefs",
+       "//chrome/browser/extensions",
+       "//chrome/browser/ui/extensions",
+     ]

--- a/packages/browseros/chromium_patches/chrome/browser/ui/toolbar/pinned_toolbar/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/toolbar/pinned_toolbar/BUILD.gn
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/toolbar/pinned_toolbar/BUILD.gn b/chrome/browser/ui/toolbar/pinned_toolbar/BUILD.gn
-index 895f727d5141c..d97e78d1da9f7 100644
+index 895f727d5141c..a77291c87c5e0 100644
 --- a/chrome/browser/ui/toolbar/pinned_toolbar/BUILD.gn
 +++ b/chrome/browser/ui/toolbar/pinned_toolbar/BUILD.gn
 @@ -39,6 +39,8 @@ source_set("impl") {
@@ -11,3 +11,11 @@ index 895f727d5141c..d97e78d1da9f7 100644
        "//chrome/browser/translate",
        "//chrome/browser/ui:tab_search_feature",
        "//chrome/browser/ui:ui_features",
+@@ -59,6 +61,7 @@ if (!is_android) {
+     sources = [ "pinned_toolbar_actions_model_browsertest.cc" ]
+     deps = [
+       ":pinned_toolbar",
++      "//chrome/browser/browseros/core:prefs",
+       "//chrome/browser/ui:tab_search_feature",
+       "//chrome/browser/ui:ui_features",
+       "//chrome/browser/ui/actions:actions_headers",

--- a/packages/browseros/chromium_patches/chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model.cc b/chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model.cc
-index 0177d0e3bda7c..3be84e565fb7b 100644
+index 0177d0e3bda7c..dbdd029d1ffb4 100644
 --- a/chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model.cc
 +++ b/chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model.cc
 @@ -16,6 +16,8 @@
@@ -11,13 +11,18 @@ index 0177d0e3bda7c..3be84e565fb7b 100644
  #include "chrome/browser/profiles/profile.h"
  #include "chrome/browser/ui/actions/chrome_action_id.h"
  #include "chrome/browser/ui/tab_search_feature.h"
-@@ -37,6 +39,18 @@ PinnedToolbarActionsModel::PinnedToolbarActionsModel(Profile* profile)
+@@ -37,6 +39,24 @@ PinnedToolbarActionsModel::PinnedToolbarActionsModel(Profile* profile)
        base::BindRepeating(&PinnedToolbarActionsModel::UpdatePinnedActionIds,
                            base::Unretained(this)));
  
 +  // Observe BrowserOS visibility prefs for reactive updates.
 +  pref_change_registrar_.Add(
 +      browseros::prefs::kShowLLMChat,
++      base::BindRepeating(
++          &PinnedToolbarActionsModel::OnBrowserOSVisibilityPrefChanged,
++          base::Unretained(this)));
++  pref_change_registrar_.Add(
++      browseros::prefs::kShowAssistant,
 +      base::BindRepeating(
 +          &PinnedToolbarActionsModel::OnBrowserOSVisibilityPrefChanged,
 +          base::Unretained(this)));
@@ -29,8 +34,9 @@ index 0177d0e3bda7c..3be84e565fb7b 100644
 +
    // Initialize the model with the current state of the kPinnedActions pref.
    UpdatePinnedActionIds();
++  EnsureAlwaysPinnedActions();
  }
-@@ -239,8 +253,11 @@ void PinnedToolbarActionsModel::MaybeMigrateExistingPinnedStates() {
+@@ -239,8 +258,11 @@ void PinnedToolbarActionsModel::MaybeMigrateExistingPinnedStates() {
    if (!CanUpdate()) {
      return;
    }
@@ -43,7 +49,7 @@ index 0177d0e3bda7c..3be84e565fb7b 100644
      pref_service_->SetBoolean(prefs::kPinnedChromeLabsMigrationComplete, true);
    }
    if (features::HasTabSearchToolbarButton() &&
-@@ -256,6 +273,36 @@ void PinnedToolbarActionsModel::MaybeMigrateExistingPinnedStates() {
+@@ -256,6 +278,36 @@ void PinnedToolbarActionsModel::MaybeMigrateExistingPinnedStates() {
    }
  }
  
@@ -80,7 +86,7 @@ index 0177d0e3bda7c..3be84e565fb7b 100644
  const std::vector<actions::ActionId>&
  PinnedToolbarActionsModel::PinnedActionIds() const {
    return pinned_action_ids_;
-@@ -274,3 +321,20 @@ void PinnedToolbarActionsModel::UpdatePref(
+@@ -274,3 +326,20 @@ void PinnedToolbarActionsModel::UpdatePref(
      list_of_values.Append(id_string.value());
    }
  }

--- a/packages/browseros/chromium_patches/chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model.h
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model.h
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model.h b/chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model.h
-index 9f7cbd0272c0a..c9be4ae585551 100644
+index 9f7cbd0272c0a..84b696bf47bce 100644
 --- a/chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model.h
 +++ b/chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model.h
 @@ -55,6 +55,9 @@ class PinnedToolbarActionsModel : public KeyedService {
@@ -28,7 +28,7 @@ index 9f7cbd0272c0a..c9be4ae585551 100644
  
    void UpdatePref(const std::vector<actions::ActionId>& updated_list);
  
-+  // Called when a BrowserOS visibility pref changes (e.g., kShowLLMChat).
++  // Called when a BrowserOS visibility pref changes.
 +  // Re-evaluates which actions should be pinned and notifies observers.
 +  void OnBrowserOSVisibilityPrefChanged();
 +

--- a/packages/browseros/chromium_patches/chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model_browsertest.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model_browsertest.cc
@@ -1,0 +1,41 @@
+diff --git a/chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model_browsertest.cc b/chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model_browsertest.cc
+index e75fd9b4972b3..8a1cd615d2897 100644
+--- a/chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model_browsertest.cc
++++ b/chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model_browsertest.cc
+@@ -6,6 +6,7 @@
+ 
+ #include <memory>
+ 
++#include "chrome/browser/browseros/core/browseros_prefs.h"
+ #include "chrome/browser/ui/actions/chrome_action_id.h"
+ #include "chrome/browser/ui/browser.h"
+ #include "chrome/browser/ui/tab_search_feature.h"
+@@ -14,6 +15,7 @@
+ #include "chrome/common/pref_names.h"
+ #include "chrome/test/base/in_process_browser_test.h"
+ #include "chrome/test/base/testing_profile.h"
++#include "components/prefs/pref_service.h"
+ #include "content/public/test/browser_test.h"
+ #include "testing/gtest/include/gtest/gtest.h"
+ #include "ui/actions/action_id.h"
+@@ -451,5 +453,20 @@ IN_PROC_BROWSER_TEST_F(PinnedToolbarActionsModelBrowserTest,
+   }
+ }
+ 
++IN_PROC_BROWSER_TEST_F(PinnedToolbarActionsModelBrowserTest,
++                       BrowserOSAssistantVisibilityPrefControlsPinnedState) {
++  PrefService* prefs = browser()->profile()->GetPrefs();
++  EXPECT_TRUE(prefs->GetBoolean(browseros::prefs::kShowAssistant));
++
++  model()->EnsureAlwaysPinnedActions();
++  EXPECT_TRUE(model()->Contains(kActionBrowserOSAgent));
++
++  prefs->SetBoolean(browseros::prefs::kShowAssistant, false);
++  EXPECT_FALSE(model()->Contains(kActionBrowserOSAgent));
++
++  prefs->SetBoolean(browseros::prefs::kShowAssistant, true);
++  EXPECT_TRUE(model()->Contains(kActionBrowserOSAgent));
++}
++
+ // TODO(dljames): Write tests for guest and incognito mode profile that check
+ // that we cannot modify the model at all.

--- a/packages/browseros/chromium_patches/chrome/browser/ui/toolbar/toolbar_actions_model.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/toolbar/toolbar_actions_model.cc
@@ -1,39 +1,23 @@
 diff --git a/chrome/browser/ui/toolbar/toolbar_actions_model.cc b/chrome/browser/ui/toolbar/toolbar_actions_model.cc
-index d4f8091fffc0e..c95ec89588048 100644
+index d4f8091fffc0e..beb80932418cb 100644
 --- a/chrome/browser/ui/toolbar/toolbar_actions_model.cc
 +++ b/chrome/browser/ui/toolbar/toolbar_actions_model.cc
 @@ -18,6 +18,7 @@
  #include "base/one_shot_event.h"
  #include "base/strings/utf_string_conversions.h"
  #include "base/task/single_thread_task_runner.h"
-+#include "chrome/browser/browseros/core/browseros_constants.h"
++#include "chrome/browser/browseros/core/browseros_prefs.h"
  #include "chrome/browser/extensions/extension_management.h"
  #include "chrome/browser/extensions/extension_tab_util.h"
  #include "chrome/browser/extensions/managed_toolbar_pin_mode.h"
-@@ -389,6 +390,11 @@ bool ToolbarActionsModel::IsActionPinned(const ActionId& action_id) const {
+@@ -66,6 +67,10 @@ ToolbarActionsModel::ToolbarActionsModel(
+       extensions::pref_names::kPinnedExtensions,
+       base::BindRepeating(&ToolbarActionsModel::UpdatePinnedActionIds,
+                           base::Unretained(this)));
++  pref_change_registrar_.Add(
++      browseros::prefs::kShowAssistant,
++      base::BindRepeating(&ToolbarActionsModel::UpdatePinnedActionIds,
++                          base::Unretained(this)));
  }
  
- bool ToolbarActionsModel::IsActionForcePinned(const ActionId& action_id) const {
-+  // Check if it's a BrowserOS extension
-+  if (browseros::IsBrowserOSPinnedExtension(action_id)) {
-+    return true;
-+  }
-+
-   auto* management =
-       extensions::ExtensionManagementFactory::GetForBrowserContext(profile_);
-   return management->GetForcePinnedList().contains(action_id);
-@@ -634,6 +640,14 @@ ToolbarActionsModel::GetFilteredPinnedActionIds() const {
-                          return !std::ranges::contains(pinned, id);
-                        });
- 
-+  // Add BrowserOS extensions to the force-pinned list (only those marked as pinned)
-+  for (const std::string& ext_id : browseros::GetBrowserOSExtensionIds()) {
-+    if (browseros::IsBrowserOSPinnedExtension(ext_id) &&
-+        !std::ranges::contains(pinned, ext_id)) {
-+      pinned.push_back(ext_id);
-+    }
-+  }
-+
-   // TODO(pbos): Make sure that the pinned IDs are pruned from ExtensionPrefs on
-   // startup so that we don't keep saving stale IDs.
-   std::vector<ActionId> filtered_action_ids;
+ ToolbarActionsModel::~ToolbarActionsModel() = default;

--- a/packages/browseros/chromium_patches/chrome/browser/ui/views/side_panel/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/views/side_panel/BUILD.gn
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/views/side_panel/BUILD.gn b/chrome/browser/ui/views/side_panel/BUILD.gn
-index 555a27ca0c171..42afed39a3469 100644
+index 555a27ca0c171..39c81946c74d4 100644
 --- a/chrome/browser/ui/views/side_panel/BUILD.gn
 +++ b/chrome/browser/ui/views/side_panel/BUILD.gn
 @@ -56,8 +56,14 @@ source_set("side_panel") {
@@ -17,10 +17,11 @@ index 555a27ca0c171..42afed39a3469 100644
    ]
    public_deps = [
      "//base",
-@@ -76,6 +82,7 @@ source_set("side_panel") {
+@@ -76,6 +82,8 @@ source_set("side_panel") {
      "//chrome/browser/ui/webui/side_panel/customize_chrome",
      "//chrome/common",
      "//chrome/common/read_anything:mojo_bindings",
++    "//chrome/browser/browseros/core:prefs",
 +    "//chrome/browser/browseros/metrics",
      "//components/omnibox/browser",
      "//components/prefs",

--- a/packages/browseros/chromium_patches/chrome/browser/ui/views/side_panel/extensions/extension_side_panel_manager.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/views/side_panel/extensions/extension_side_panel_manager.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/views/side_panel/extensions/extension_side_panel_manager.cc b/chrome/browser/ui/views/side_panel/extensions/extension_side_panel_manager.cc
-index c2437bfc295a9..0c105091d06a2 100644
+index c2437bfc295a9..4b2971f34e108 100644
 --- a/chrome/browser/ui/views/side_panel/extensions/extension_side_panel_manager.cc
 +++ b/chrome/browser/ui/views/side_panel/extensions/extension_side_panel_manager.cc
 @@ -4,8 +4,10 @@
@@ -9,7 +9,7 @@ index c2437bfc295a9..0c105091d06a2 100644
 +#include "base/logging.h"
  #include "base/memory/scoped_refptr.h"
  #include "base/strings/utf_string_conversions.h"
-+#include "chrome/browser/browseros/core/browseros_constants.h"
++#include "chrome/browser/browseros/core/browseros_prefs.h"
  #include "chrome/browser/profiles/profile.h"
  #include "chrome/browser/ui/actions/chrome_action_id.h"
  #include "chrome/browser/ui/actions/chrome_actions.h"
@@ -27,15 +27,16 @@ index c2437bfc295a9..0c105091d06a2 100644
  #include "extensions/common/extension.h"
  #include "extensions/common/extension_features.h"
  #include "extensions/common/permissions/api_permission.h"
-@@ -120,6 +124,15 @@ void ExtensionSidePanelManager::MaybeCreateActionItemForExtension(
+@@ -120,6 +124,16 @@ void ExtensionSidePanelManager::MaybeCreateActionItemForExtension(
                         std::underlying_type_t<actions::ActionPinnableState>(
                             actions::ActionPinnableState::kPinnable))
            .Build());
 +
 +  // Auto-pin BrowserOS extensions to the toolbar.
-+  if (browseros::IsBrowserOSPinnedExtension(extension->id())) {
-+    LOG(INFO) << "browseros: Auto-pinning BrowserOS extension: "
-+              << extension->id();
++  if (browseros::ShouldPinBrowserOSExtension(extension->id(),
++                                             profile_->GetPrefs())) {
++    DVLOG(1) << "browseros: Auto-pinning BrowserOS extension: "
++             << extension->id();
 +    if (auto* pinned_model = PinnedToolbarActionsModel::Get(profile_)) {
 +      pinned_model->UpdatePinnedState(extension_action_id, true);
 +    }
@@ -43,7 +44,7 @@ index c2437bfc295a9..0c105091d06a2 100644
  }
  
  actions::ActionId ExtensionSidePanelManager::GetOrCreateActionIdForExtension(
-@@ -159,6 +172,7 @@ void ExtensionSidePanelManager::OnExtensionUnloaded(
+@@ -159,6 +173,7 @@ void ExtensionSidePanelManager::OnExtensionUnloaded(
      it->second->DeregisterEntry();
      coordinators_.erase(extension->id());
    }


### PR DESCRIPTION
## Summary
- Adds extracted Chromium patches for `browseros.show_assistant`, defaulting Assistant toolbar visibility on.
- Gates BrowserOS Assistant native action and agent extension pinning on the new pref.
- Includes BrowserOS patch feature metadata and browser-test coverage for toggling the pref.

## Design
The Chromium stack adds a BrowserOS pref helper for Assistant visibility and threads it through toolbar pinning, extension-management force pinning, settings-private allowlisting, and side-panel auto-pinning. The BrowserOS patch extraction preserves the cumulative `BASE_COMMIT..a1ed092afeb08` diffs and maps the touched files into existing feature groups.

## Test plan
- [x] `chpool build -- autoninja -C out/Default_arm64 chrome`
- [x] `verify-patches.sh --chromium-src /Users/shadowfax/ch-3 --worktree /Users/shadowfax/worktrees/main/feat-show-assistant-toolbar-patches --tip a1ed092afeb08 <15 patch files>`
- [x] `git diff --check HEAD~1..HEAD -- packages/browseros/build/features.yaml`