### PR TITLE
feat: register browserclaw extension (pinned, unlabelled)

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_constants.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_constants.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/core/browseros_constants.h b/chrome/browser/browseros/core/browseros_constants.h
 new file mode 100644
-index 0000000000000..fdeee36f8cc70
+index 0000000000000..550550ce68436
 --- /dev/null
 +++ b/chrome/browser/browseros/core/browseros_constants.h
-@@ -0,0 +1,222 @@
+@@ -0,0 +1,227 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -39,6 +39,10 @@ index 0000000000000..fdeee36f8cc70
 +// Bug Reporter Extension ID
 +inline constexpr char kBugReporterExtensionId[] =
 +    "adlpneommgkgeanpaekgoaolcpncohkf";
++
++// BrowserClaw Extension ID
++inline constexpr char kBrowserClawExtensionId[] =
++    "pjimfkbpehlcllblajnpfamdfjhhlgkc";
 +
 +// uBlock Origin Extension ID (Chrome Web Store)
 +// inline constexpr char kUBlockOriginExtensionId[] =
@@ -169,6 +173,7 @@ index 0000000000000..fdeee36f8cc70
 +inline constexpr BrowserOSExtensionInfo kBrowserOSExtensions[] = {
 +    {kAgentExtensionId, false, false},
 +    {kBugReporterExtensionId, true, false},
++    {kBrowserClawExtensionId, true, false},
 +    // ublock origin gets installed from chrome web store
 +    // {kUBlockOriginExtensionId, false, false},
 +};


### PR DESCRIPTION
## Summary
- Register the **browserclaw** extension (`pjimfkbpehlcllblajnpfamdfjhhlgkc`) in the chromium-side BrowserOS constants — **pinned**, **not labelled**.
- This is the chromium half of browserclaw; it complements the extension manifest key/name that produces this id, added in #1411 (`apps/claw-app/wxt.config.ts`).

## Design
Adds `kBrowserClawExtensionId` and a `{kBrowserClawExtensionId, true, false}` entry (`is_pinned=true`, `is_labelled=false`) to `kBrowserOSExtensions` in the `chromium_patches/.../browseros_constants.h` patch. Without it, the browser would not pin browserclaw or treat it as a first-party BrowserOS extension. The controller extension stays removed (#1304) — only browserclaw is added.

## Test plan
- [x] Patch applies cleanly onto the BASE chromium tree (the release build's apply-all gate).
- [ ] A built BrowserOS pins browserclaw to the toolbar and shows no label for it.

## Note
The `ch1-src` chromium patch-stack checkout still carries the controller extension in this same file (stale relative to #1304), so a raw byte-match of this patch against that checkout differs **for this one file**; apply-check passes and the PR diff is browserclaw-only. Reconciling ch1-src is a separate follow-up, not part of this PR.