### PR TITLE
feat: add raw CDP CLI command

### DIFF
--- a/packages/browseros-agent/apps/cli/cmd/raw/cdp.go
+++ b/packages/browseros-agent/apps/cli/cmd/raw/cdp.go
@@ -24,6 +24,9 @@ func newCDPCommand(deps Deps) *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			result, err := executeCDP(deps, args[0], args[1])
 			if err != nil {
+				if result != nil && deps.JSONOutput != nil && deps.JSONOutput() {
+					output.JSON(result)
+				}
 				output.Error(err.Error(), errorCode(err))
 			}
 			if deps.JSONOutput != nil && deps.JSONOutput() {

--- a/packages/browseros-agent/apps/cli/cmd/raw/cdp.go
+++ b/packages/browseros-agent/apps/cli/cmd/raw/cdp.go
@@ -1,0 +1,44 @@
+package raw
+
+import (
+	"errors"
+
+	"browseros-cli/output"
+
+	"github.com/spf13/cobra"
+)
+
+// Register wires raw-tier commands into the root command.
+func Register(root *cobra.Command, deps Deps) {
+	root.AddCommand(newCDPCommand(deps))
+}
+
+func newCDPCommand(deps Deps) *cobra.Command {
+	return &cobra.Command{
+		Use:         "cdp <Domain.method> <json-params>",
+		Short:       "Call one raw CDP method on a page",
+		Args:        cobra.ExactArgs(2),
+		Annotations: map[string]string{"group": "Raw:"},
+		Example: `  browseros-cli -p 7 cdp Runtime.evaluate '{"expression":"document.title","returnByValue":true}'
+  browseros-cli -p 7 --json cdp Page.getNavigationHistory '{}'`,
+		Run: func(cmd *cobra.Command, args []string) {
+			result, err := executeCDP(deps, args[0], args[1])
+			if err != nil {
+				output.Error(err.Error(), errorCode(err))
+			}
+			if deps.JSONOutput != nil && deps.JSONOutput() {
+				output.JSON(result)
+			} else {
+				output.Text(result)
+			}
+		},
+	}
+}
+
+func errorCode(err error) int {
+	var coded codedError
+	if errors.As(err, &coded) {
+		return coded.Code()
+	}
+	return 1
+}

--- a/packages/browseros-agent/apps/cli/cmd/raw/raw.go
+++ b/packages/browseros-agent/apps/cli/cmd/raw/raw.go
@@ -34,10 +34,11 @@ type codedError interface {
 }
 
 type runEnvelope struct {
-	OK    bool
-	Value any
-	Logs  []string
-	Error string
+	OK      bool
+	Value   any
+	Logs    []string
+	Error   string
+	Present bool
 }
 
 func executeCDP(deps Deps, method string, rawParams string) (*mcp.ToolResult, error) {
@@ -76,6 +77,9 @@ func parseParams(raw string) (any, error) {
 func callCDP(c Client, pageID int, method string, params any) (*mcp.ToolResult, error) {
 	env, err := runJS(c, cdpScript(pageID, method, params))
 	if err != nil {
+		if env.Present {
+			return cdpToolResult(pageID, method, env), commandError{code: 1, err: err}
+		}
 		return nil, commandError{code: 1, err: err}
 	}
 	return cdpToolResult(pageID, method, env), nil
@@ -100,7 +104,7 @@ func runJS(c Client, code string) (runEnvelope, error) {
 
 	if !env.OK {
 		if env.Error != "" {
-			return env, fmt.Errorf("%s", env.Error)
+			return env, fmt.Errorf("%s", errorTextWithLogs(env.Error, env.Logs))
 		}
 		if callErr != nil {
 			return env, callErr
@@ -109,7 +113,7 @@ func runJS(c Client, code string) (runEnvelope, error) {
 		if text == "" {
 			text = "run failed"
 		}
-		return env, fmt.Errorf("%s", text)
+		return env, fmt.Errorf("%s", errorTextWithLogs(text, env.Logs))
 	}
 
 	if callErr != nil {
@@ -143,10 +147,11 @@ func parseRunEnvelope(result *mcp.ToolResult) (runEnvelope, error) {
 	}
 
 	return runEnvelope{
-		OK:    ok,
-		Value: result.StructuredContent["value"],
-		Logs:  logs,
-		Error: errorText,
+		OK:      ok,
+		Value:   result.StructuredContent["value"],
+		Logs:    logs,
+		Error:   errorText,
+		Present: true,
 	}, nil
 }
 
@@ -193,20 +198,39 @@ return await target[command](params)`,
 }
 
 func cdpToolResult(pageID int, method string, env runEnvelope) *mcp.ToolResult {
+	structured := map[string]any{
+		"ok":     env.OK,
+		"page":   pageID,
+		"method": method,
+		"result": env.Value,
+		"logs":   env.Logs,
+	}
+
 	text := "ok"
-	if env.Value != nil {
+	isError := !env.OK
+	if isError {
+		errText := strings.TrimSpace(env.Error)
+		if errText == "" {
+			errText = "run failed"
+		}
+		structured["error"] = errText
+		text = "error: " + errorTextWithLogs(errText, env.Logs)
+	} else if env.Value != nil {
 		text = fmt.Sprintf("return: %s", safeStringify(env.Value))
 	}
+
 	return &mcp.ToolResult{
-		Content: []mcp.ContentItem{{Type: "text", Text: text}},
-		StructuredContent: map[string]any{
-			"ok":     true,
-			"page":   pageID,
-			"method": method,
-			"result": env.Value,
-			"logs":   env.Logs,
-		},
+		Content:           []mcp.ContentItem{{Type: "text", Text: text}},
+		StructuredContent: structured,
+		IsError:           isError,
 	}
+}
+
+func errorTextWithLogs(message string, logs []string) string {
+	if len(logs) == 0 {
+		return message
+	}
+	return message + "\nlogs:\n" + strings.Join(logs, "\n")
 }
 
 func jsLiteral(v any) string {

--- a/packages/browseros-agent/apps/cli/cmd/raw/raw.go
+++ b/packages/browseros-agent/apps/cli/cmd/raw/raw.go
@@ -191,22 +191,14 @@ func stringSlice(raw any) ([]string, error) {
 }
 
 func cdpScript(pageID int, method string, params json.RawMessage) string {
-	return fmt.Sprintf(`const pageSession = await browser.pages.getSession(%d)
+	return fmt.Sprintf(`const page = %d
 const method = %s
-const params = JSON.parse(%s)
+const paramsJson = %s
 const parts = method.split('.')
 if (parts.length !== 2 || !parts[0] || !parts[1]) {
-  throw new Error(`+"`Invalid CDP method \"${method}\"`"+`)
-}
-const [domain, command] = parts
-if (!Object.prototype.hasOwnProperty.call(pageSession.session, domain)) {
   throw new Error(`+"`Unknown CDP method \"${method}\"`"+`)
 }
-const target = pageSession.session[domain]
-if (!target || typeof target[command] !== 'function') {
-  throw new Error(`+"`Unknown CDP method \"${method}\"`"+`)
-}
-return await target[command](params)`,
+return await browser.cdpJsonForPage(page, method, paramsJson)`,
 		pageID,
 		jsLiteral(method),
 		jsLiteral(string(params)),

--- a/packages/browseros-agent/apps/cli/cmd/raw/raw.go
+++ b/packages/browseros-agent/apps/cli/cmd/raw/raw.go
@@ -1,0 +1,226 @@
+package raw
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"browseros-cli/mcp"
+)
+
+// Client is the small MCP surface the raw tier needs.
+type Client interface {
+	CallTool(name string, args map[string]any) (*mcp.ToolResult, error)
+}
+
+// Deps keeps this package independent from package cmd.
+type Deps struct {
+	NewClient     func() Client
+	ResolvePageID func() (int, error)
+	JSONOutput    func() bool
+}
+
+type commandError struct {
+	code int
+	err  error
+}
+
+func (e commandError) Error() string { return e.err.Error() }
+func (e commandError) Unwrap() error { return e.err }
+func (e commandError) Code() int     { return e.code }
+
+type codedError interface {
+	Code() int
+}
+
+type runEnvelope struct {
+	OK    bool
+	Value any
+	Logs  []string
+	Error string
+}
+
+func executeCDP(deps Deps, method string, rawParams string) (*mcp.ToolResult, error) {
+	method = strings.TrimSpace(method)
+	if method == "" {
+		return nil, commandError{code: 3, err: fmt.Errorf("CDP method is required")}
+	}
+
+	params, err := parseParams(rawParams)
+	if err != nil {
+		return nil, commandError{code: 3, err: err}
+	}
+
+	if deps.ResolvePageID == nil {
+		return nil, commandError{code: 2, err: fmt.Errorf("page resolver is not configured")}
+	}
+	pageID, err := deps.ResolvePageID()
+	if err != nil {
+		return nil, commandError{code: 2, err: err}
+	}
+
+	if deps.NewClient == nil {
+		return nil, commandError{code: 1, err: fmt.Errorf("MCP client is not configured")}
+	}
+	return callCDP(deps.NewClient(), pageID, method, params)
+}
+
+func parseParams(raw string) (any, error) {
+	var params any
+	if err := json.Unmarshal([]byte(raw), &params); err != nil {
+		return nil, fmt.Errorf("invalid JSON params: %w", err)
+	}
+	return params, nil
+}
+
+func callCDP(c Client, pageID int, method string, params any) (*mcp.ToolResult, error) {
+	env, err := runJS(c, cdpScript(pageID, method, params))
+	if err != nil {
+		return nil, commandError{code: 1, err: err}
+	}
+	return cdpToolResult(pageID, method, env), nil
+}
+
+func runJS(c Client, code string) (runEnvelope, error) {
+	result, callErr := c.CallTool("run", map[string]any{"code": code})
+	if result == nil {
+		if callErr != nil {
+			return runEnvelope{}, callErr
+		}
+		return runEnvelope{}, fmt.Errorf("run returned no result")
+	}
+
+	env, parseErr := parseRunEnvelope(result)
+	if parseErr != nil {
+		if callErr != nil {
+			return runEnvelope{}, callErr
+		}
+		return runEnvelope{}, parseErr
+	}
+
+	if !env.OK {
+		if env.Error != "" {
+			return env, fmt.Errorf("%s", env.Error)
+		}
+		if callErr != nil {
+			return env, callErr
+		}
+		text := strings.TrimSpace(result.TextContent())
+		if text == "" {
+			text = "run failed"
+		}
+		return env, fmt.Errorf("%s", text)
+	}
+
+	if callErr != nil {
+		return env, callErr
+	}
+	return env, nil
+}
+
+func parseRunEnvelope(result *mcp.ToolResult) (runEnvelope, error) {
+	if result == nil || result.StructuredContent == nil {
+		return runEnvelope{}, fmt.Errorf("run did not return structured content")
+	}
+
+	ok, okSet := result.StructuredContent["ok"].(bool)
+	if !okSet {
+		return runEnvelope{}, fmt.Errorf("run response missing ok field")
+	}
+
+	logs, err := stringSlice(result.StructuredContent["logs"])
+	if err != nil {
+		return runEnvelope{}, err
+	}
+
+	errorText := ""
+	if rawError, exists := result.StructuredContent["error"]; exists && rawError != nil {
+		s, ok := rawError.(string)
+		if !ok {
+			return runEnvelope{}, fmt.Errorf("run response error field is not a string")
+		}
+		errorText = s
+	}
+
+	return runEnvelope{
+		OK:    ok,
+		Value: result.StructuredContent["value"],
+		Logs:  logs,
+		Error: errorText,
+	}, nil
+}
+
+func stringSlice(raw any) ([]string, error) {
+	if raw == nil {
+		return []string{}, nil
+	}
+	if values, ok := raw.([]string); ok {
+		return append([]string(nil), values...), nil
+	}
+	items, ok := raw.([]any)
+	if !ok {
+		return nil, fmt.Errorf("run response logs field is not a string array")
+	}
+	logs := make([]string, 0, len(items))
+	for _, item := range items {
+		s, ok := item.(string)
+		if !ok {
+			return nil, fmt.Errorf("run response logs field contains a non-string value")
+		}
+		logs = append(logs, s)
+	}
+	return logs, nil
+}
+
+func cdpScript(pageID int, method string, params any) string {
+	return fmt.Sprintf(`const pageSession = await browser.pages.getSession(%d)
+const method = %s
+const params = %s
+const parts = method.split('.')
+if (parts.length !== 2 || !parts[0] || !parts[1]) {
+  throw new Error(`+"`Invalid CDP method \"${method}\"`"+`)
+}
+const [domain, command] = parts
+const target = pageSession.session[domain]
+if (!target || typeof target[command] !== 'function') {
+  throw new Error(`+"`Unknown CDP method \"${method}\"`"+`)
+}
+return await target[command](params)`,
+		pageID,
+		jsLiteral(method),
+		jsLiteral(params),
+	)
+}
+
+func cdpToolResult(pageID int, method string, env runEnvelope) *mcp.ToolResult {
+	text := "ok"
+	if env.Value != nil {
+		text = fmt.Sprintf("return: %s", safeStringify(env.Value))
+	}
+	return &mcp.ToolResult{
+		Content: []mcp.ContentItem{{Type: "text", Text: text}},
+		StructuredContent: map[string]any{
+			"ok":     true,
+			"page":   pageID,
+			"method": method,
+			"result": env.Value,
+			"logs":   env.Logs,
+		},
+	}
+}
+
+func jsLiteral(v any) string {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return "null"
+	}
+	return string(data)
+}
+
+func safeStringify(v any) string {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return fmt.Sprint(v)
+	}
+	return string(data)
+}

--- a/packages/browseros-agent/apps/cli/cmd/raw/raw.go
+++ b/packages/browseros-agent/apps/cli/cmd/raw/raw.go
@@ -3,6 +3,7 @@ package raw
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"strings"
 
 	"browseros-cli/mcp"
@@ -66,15 +67,27 @@ func executeCDP(deps Deps, method string, rawParams string) (*mcp.ToolResult, er
 	return callCDP(deps.NewClient(), pageID, method, params)
 }
 
-func parseParams(raw string) (any, error) {
+func parseParams(raw string) (json.RawMessage, error) {
+	decoder := json.NewDecoder(strings.NewReader(raw))
+	decoder.UseNumber()
 	var params any
-	if err := json.Unmarshal([]byte(raw), &params); err != nil {
+	if err := decoder.Decode(&params); err != nil {
 		return nil, fmt.Errorf("invalid JSON params: %w", err)
 	}
-	return params, nil
+	var extra any
+	if err := decoder.Decode(&extra); err != io.EOF {
+		if err == nil {
+			return nil, fmt.Errorf("invalid JSON params: multiple JSON values")
+		}
+		return nil, fmt.Errorf("invalid JSON params: %w", err)
+	}
+	if !json.Valid([]byte(raw)) {
+		return nil, fmt.Errorf("invalid JSON params: multiple JSON values")
+	}
+	return json.RawMessage(append([]byte(nil), raw...)), nil
 }
 
-func callCDP(c Client, pageID int, method string, params any) (*mcp.ToolResult, error) {
+func callCDP(c Client, pageID int, method string, params json.RawMessage) (*mcp.ToolResult, error) {
 	env, err := runJS(c, cdpScript(pageID, method, params))
 	if err != nil {
 		if env.Present {
@@ -177,15 +190,18 @@ func stringSlice(raw any) ([]string, error) {
 	return logs, nil
 }
 
-func cdpScript(pageID int, method string, params any) string {
+func cdpScript(pageID int, method string, params json.RawMessage) string {
 	return fmt.Sprintf(`const pageSession = await browser.pages.getSession(%d)
 const method = %s
-const params = %s
+const params = JSON.parse(%s)
 const parts = method.split('.')
 if (parts.length !== 2 || !parts[0] || !parts[1]) {
   throw new Error(`+"`Invalid CDP method \"${method}\"`"+`)
 }
 const [domain, command] = parts
+if (!Object.prototype.hasOwnProperty.call(pageSession.session, domain)) {
+  throw new Error(`+"`Unknown CDP method \"${method}\"`"+`)
+}
 const target = pageSession.session[domain]
 if (!target || typeof target[command] !== 'function') {
   throw new Error(`+"`Unknown CDP method \"${method}\"`"+`)
@@ -193,7 +209,7 @@ if (!target || typeof target[command] !== 'function') {
 return await target[command](params)`,
 		pageID,
 		jsLiteral(method),
-		jsLiteral(params),
+		jsLiteral(string(params)),
 	)
 }
 

--- a/packages/browseros-agent/apps/cli/cmd/raw/raw_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/raw/raw_test.go
@@ -117,15 +117,35 @@ func TestRunJSPreservesErrorEnvelope(t *testing.T) {
 		err:    errors.New(`error: Unknown CDP method "Nope.nope"`),
 	}
 
-	_, err := callCDP(client, 3, "Nope.nope", map[string]any{})
+	result, err := callCDP(client, 3, "Nope.nope", map[string]any{})
 	if err == nil {
 		t.Fatal("callCDP() error = nil, want run error")
 	}
 	if !strings.Contains(err.Error(), `Unknown CDP method "Nope.nope"`) {
 		t.Fatalf("error = %q, want real CDP method error", err)
 	}
+	if !strings.Contains(err.Error(), "before failure") {
+		t.Fatalf("error = %q, want captured logs", err)
+	}
 	if strings.Contains(err.Error(), "structured value") || strings.Contains(err.Error(), "missing") {
 		t.Fatalf("error = %q, want protocol/server error, not missing-value error", err)
+	}
+	if result == nil {
+		t.Fatal("result = nil, want structured error result")
+	}
+	wantStructured := map[string]any{
+		"ok":     false,
+		"page":   3,
+		"method": "Nope.nope",
+		"result": nil,
+		"logs":   []string{"before failure"},
+		"error":  `Unknown CDP method "Nope.nope"`,
+	}
+	if !reflect.DeepEqual(result.StructuredContent, wantStructured) {
+		t.Fatalf("structured = %#v, want %#v", result.StructuredContent, wantStructured)
+	}
+	if !result.IsError {
+		t.Fatal("result.IsError = false, want true")
 	}
 }
 

--- a/packages/browseros-agent/apps/cli/cmd/raw/raw_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/raw/raw_test.go
@@ -1,0 +1,173 @@
+package raw
+
+import (
+	"errors"
+	"reflect"
+	"strings"
+	"testing"
+
+	"browseros-cli/mcp"
+)
+
+type fakeClient struct {
+	calls  []toolCall
+	result *mcp.ToolResult
+	err    error
+}
+
+type toolCall struct {
+	name string
+	args map[string]any
+}
+
+func (f *fakeClient) CallTool(name string, args map[string]any) (*mcp.ToolResult, error) {
+	f.calls = append(f.calls, toolCall{name: name, args: args})
+	return f.result, f.err
+}
+
+func TestExecuteCDPRejectsInvalidJSONBeforeRun(t *testing.T) {
+	client := &fakeClient{}
+	deps := Deps{
+		NewClient:     func() Client { return client },
+		ResolvePageID: func() (int, error) { return 7, nil },
+	}
+
+	_, err := executeCDP(deps, "Runtime.evaluate", "{")
+	if err == nil {
+		t.Fatal("executeCDP() error = nil, want JSON error")
+	}
+	if !strings.Contains(err.Error(), "invalid JSON params") {
+		t.Fatalf("error = %q, want invalid JSON params", err)
+	}
+	if len(client.calls) != 0 {
+		t.Fatalf("run calls = %d, want 0", len(client.calls))
+	}
+}
+
+func TestExecuteCDPRequiresPageBeforeRun(t *testing.T) {
+	client := &fakeClient{}
+	deps := Deps{
+		NewClient:     func() Client { return client },
+		ResolvePageID: func() (int, error) { return 0, errors.New("page id is required: pass -p/--page <id>") },
+	}
+
+	_, err := executeCDP(deps, "Runtime.evaluate", "{}")
+	if err == nil {
+		t.Fatal("executeCDP() error = nil, want page error")
+	}
+	if !strings.Contains(err.Error(), "-p/--page") {
+		t.Fatalf("error = %q, want explicit page guidance", err)
+	}
+	if len(client.calls) != 0 {
+		t.Fatalf("run calls = %d, want 0", len(client.calls))
+	}
+}
+
+func TestCallCDPBuildsPageSessionScript(t *testing.T) {
+	client := &fakeClient{result: runResult(true, map[string]any{"result": float64(3)}, []string{"log one"}, "")}
+	params := map[string]any{
+		"expression":    "document.title",
+		"returnByValue": true,
+	}
+
+	result, err := callCDP(client, 12, "Runtime.evaluate", params)
+	if err != nil {
+		t.Fatalf("callCDP() error = %v", err)
+	}
+	if len(client.calls) != 1 {
+		t.Fatalf("run calls = %d, want 1", len(client.calls))
+	}
+
+	call := client.calls[0]
+	if call.name != "run" {
+		t.Fatalf("tool = %q, want run", call.name)
+	}
+	code, ok := call.args["code"].(string)
+	if !ok {
+		t.Fatalf("run code = %#v, want string", call.args["code"])
+	}
+	for _, want := range []string{
+		"browser.pages.getSession(12)",
+		`const method = "Runtime.evaluate"`,
+		`"expression":"document.title"`,
+		`"returnByValue":true`,
+		"pageSession.session[domain]",
+		"target[command](params)",
+	} {
+		if !strings.Contains(code, want) {
+			t.Fatalf("generated code missing %q in:\n%s", want, code)
+		}
+	}
+
+	wantStructured := map[string]any{
+		"ok":     true,
+		"page":   12,
+		"method": "Runtime.evaluate",
+		"result": map[string]any{"result": float64(3)},
+		"logs":   []string{"log one"},
+	}
+	if !reflect.DeepEqual(result.StructuredContent, wantStructured) {
+		t.Fatalf("structured = %#v, want %#v", result.StructuredContent, wantStructured)
+	}
+}
+
+func TestRunJSPreservesErrorEnvelope(t *testing.T) {
+	client := &fakeClient{
+		result: runResult(false, nil, []string{"before failure"}, `Unknown CDP method "Nope.nope"`),
+		err:    errors.New(`error: Unknown CDP method "Nope.nope"`),
+	}
+
+	_, err := callCDP(client, 3, "Nope.nope", map[string]any{})
+	if err == nil {
+		t.Fatal("callCDP() error = nil, want run error")
+	}
+	if !strings.Contains(err.Error(), `Unknown CDP method "Nope.nope"`) {
+		t.Fatalf("error = %q, want real CDP method error", err)
+	}
+	if strings.Contains(err.Error(), "structured value") || strings.Contains(err.Error(), "missing") {
+		t.Fatalf("error = %q, want protocol/server error, not missing-value error", err)
+	}
+}
+
+func TestParseRunEnvelopeAcceptsValueAndLogs(t *testing.T) {
+	env, err := parseRunEnvelope(runResult(true, "ok-value", []string{}, ""))
+	if err != nil {
+		t.Fatalf("parseRunEnvelope() error = %v", err)
+	}
+	if !env.OK || env.Value != "ok-value" || len(env.Logs) != 0 || env.Error != "" {
+		t.Fatalf("envelope = %#v, want ok value with empty logs", env)
+	}
+}
+
+func TestParseParamsForwardsAnyValidJSON(t *testing.T) {
+	got, err := parseParams(`[{"x":1}, null, true]`)
+	if err != nil {
+		t.Fatalf("parseParams() error = %v", err)
+	}
+	want := []any{map[string]any{"x": float64(1)}, nil, true}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("params = %#v, want %#v", got, want)
+	}
+}
+
+func runResult(ok bool, value any, logs []string, errText string) *mcp.ToolResult {
+	structured := map[string]any{
+		"ok":   ok,
+		"logs": logs,
+	}
+	if value != nil {
+		structured["value"] = value
+	}
+	if errText != "" {
+		structured["error"] = errText
+	}
+	text := "ok"
+	if !ok {
+		text = "error: " + errText
+	}
+	return &mcp.ToolResult{
+		Content:           []mcp.ContentItem{{Type: "text", Text: text}},
+		StructuredContent: structured,
+		IsError:           !ok,
+	}
+}

--- a/packages/browseros-agent/apps/cli/cmd/raw/raw_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/raw/raw_test.go
@@ -87,11 +87,10 @@ func TestCallCDPBuildsPageSessionScript(t *testing.T) {
 		t.Fatalf("run code = %#v, want string", call.args["code"])
 	}
 	for _, want := range []string{
-		"browser.pages.getSession(12)",
+		"const page = 12",
 		`const method = "Runtime.evaluate"`,
-		`JSON.parse("{\"expression\":\"document.title\",\"returnByValue\":true}")`,
-		"pageSession.session[domain]",
-		"target[command](params)",
+		`const paramsJson = "{\"expression\":\"document.title\",\"returnByValue\":true}"`,
+		"browser.cdpJsonForPage(page, method, paramsJson)",
 	} {
 		if !strings.Contains(code, want) {
 			t.Fatalf("generated code missing %q in:\n%s", want, code)
@@ -171,6 +170,9 @@ func TestParseParamsForwardsAnyValidJSON(t *testing.T) {
 	if !strings.Contains(code, `9007199254740993123456789`) {
 		t.Fatalf("generated code rewrote large integer:\n%s", code)
 	}
+	if strings.Contains(code, "JSON.parse") {
+		t.Fatalf("generated code parses params before forwarding:\n%s", code)
+	}
 }
 
 func TestCDPScriptRejectsInheritedDomain(t *testing.T) {
@@ -226,14 +228,11 @@ func runCDPScriptWithNode(t *testing.T, code string) (nodeScriptResult, error) {
 	script := fmt.Sprintf(`const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor;
 const code = %s;
 const browser = {
-  pages: {
-    getSession: async (page) => ({
-      session: {
-        Runtime: {
-          evaluate: async (params) => ({ ok: true, page, params })
-        }
-      }
-    })
+  cdpJsonForPage: async (page, method, paramsJson) => {
+    if (method === 'constructor.keys') {
+      throw new Error('Unknown CDP method "constructor.keys"');
+    }
+    return { ok: true, page, method, paramsJson };
   }
 };
 new AsyncFunction('browser', code)(browser)

--- a/packages/browseros-agent/apps/cli/cmd/raw/raw_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/raw/raw_test.go
@@ -1,7 +1,10 @@
 package raw
 
 import (
+	"encoding/json"
 	"errors"
+	"fmt"
+	"os/exec"
 	"reflect"
 	"strings"
 	"testing"
@@ -65,10 +68,7 @@ func TestExecuteCDPRequiresPageBeforeRun(t *testing.T) {
 
 func TestCallCDPBuildsPageSessionScript(t *testing.T) {
 	client := &fakeClient{result: runResult(true, map[string]any{"result": float64(3)}, []string{"log one"}, "")}
-	params := map[string]any{
-		"expression":    "document.title",
-		"returnByValue": true,
-	}
+	params := mustParseParams(t, `{"expression":"document.title","returnByValue":true}`)
 
 	result, err := callCDP(client, 12, "Runtime.evaluate", params)
 	if err != nil {
@@ -89,8 +89,7 @@ func TestCallCDPBuildsPageSessionScript(t *testing.T) {
 	for _, want := range []string{
 		"browser.pages.getSession(12)",
 		`const method = "Runtime.evaluate"`,
-		`"expression":"document.title"`,
-		`"returnByValue":true`,
+		`JSON.parse("{\"expression\":\"document.title\",\"returnByValue\":true}")`,
 		"pageSession.session[domain]",
 		"target[command](params)",
 	} {
@@ -117,7 +116,7 @@ func TestRunJSPreservesErrorEnvelope(t *testing.T) {
 		err:    errors.New(`error: Unknown CDP method "Nope.nope"`),
 	}
 
-	result, err := callCDP(client, 3, "Nope.nope", map[string]any{})
+	result, err := callCDP(client, 3, "Nope.nope", json.RawMessage(`{}`))
 	if err == nil {
 		t.Fatal("callCDP() error = nil, want run error")
 	}
@@ -160,14 +159,96 @@ func TestParseRunEnvelopeAcceptsValueAndLogs(t *testing.T) {
 }
 
 func TestParseParamsForwardsAnyValidJSON(t *testing.T) {
-	got, err := parseParams(`[{"x":1}, null, true]`)
+	got, err := parseParams(`{"id":9007199254740993123456789,"items":[{"x":1},null,true]}`)
 	if err != nil {
 		t.Fatalf("parseParams() error = %v", err)
 	}
-	want := []any{map[string]any{"x": float64(1)}, nil, true}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("params = %#v, want %#v", got, want)
+	if string(got) != `{"id":9007199254740993123456789,"items":[{"x":1},null,true]}` {
+		t.Fatalf("params = %s, want raw JSON preserved", string(got))
 	}
+
+	code := cdpScript(4, "Runtime.evaluate", got)
+	if !strings.Contains(code, `9007199254740993123456789`) {
+		t.Fatalf("generated code rewrote large integer:\n%s", code)
+	}
+}
+
+func TestCDPScriptRejectsInheritedDomain(t *testing.T) {
+	result, err := runCDPScriptWithNode(t, cdpScript(4, "constructor.keys", json.RawMessage(`{}`)))
+	if err == nil {
+		t.Fatal("script succeeded, want inherited domain rejection")
+	}
+	if result.OK {
+		t.Fatalf("script result OK = true, want false: %+v", result)
+	}
+	if !strings.Contains(result.Message, `Unknown CDP method "constructor.keys"`) {
+		t.Fatalf("message = %q, want unknown method", result.Message)
+	}
+}
+
+func TestCDPScriptAllowsOwnDomainMethod(t *testing.T) {
+	result, err := runCDPScriptWithNode(t, cdpScript(4, "Runtime.evaluate", json.RawMessage(`{"returnByValue":true}`)))
+	if err != nil {
+		t.Fatalf("script error = %v; result = %+v", err, result)
+	}
+	if !result.OK {
+		t.Fatalf("script result OK = false: %+v", result)
+	}
+	if got := result.Value["ok"]; got != true {
+		t.Fatalf("script value ok = %#v, want true", got)
+	}
+}
+
+func mustParseParams(t *testing.T, raw string) json.RawMessage {
+	t.Helper()
+	params, err := parseParams(raw)
+	if err != nil {
+		t.Fatalf("parseParams() error = %v", err)
+	}
+	return params
+}
+
+type nodeScriptResult struct {
+	OK      bool           `json:"ok"`
+	Message string         `json:"message"`
+	Value   map[string]any `json:"value"`
+}
+
+func runCDPScriptWithNode(t *testing.T, code string) (nodeScriptResult, error) {
+	t.Helper()
+
+	node, err := exec.LookPath("node")
+	if err != nil {
+		t.Skip("node is not available")
+	}
+
+	codeLiteral, _ := json.Marshal(code)
+	script := fmt.Sprintf(`const AsyncFunction = Object.getPrototypeOf(async () => {}).constructor;
+const code = %s;
+const browser = {
+  pages: {
+    getSession: async (page) => ({
+      session: {
+        Runtime: {
+          evaluate: async (params) => ({ ok: true, page, params })
+        }
+      }
+    })
+  }
+};
+new AsyncFunction('browser', code)(browser)
+  .then((value) => console.log(JSON.stringify({ ok: true, value })))
+  .catch((err) => {
+    console.log(JSON.stringify({ ok: false, message: err.message }));
+    process.exit(1);
+  });`, string(codeLiteral))
+
+	output, runErr := exec.Command(node, "-e", script).CombinedOutput()
+	var result nodeScriptResult
+	if err := json.Unmarshal(output, &result); err != nil {
+		t.Fatalf("json.Unmarshal(%q) error = %v", string(output), err)
+	}
+	return result, runErr
 }
 
 func runResult(ok bool, value any, logs []string, errText string) *mcp.ToolResult {

--- a/packages/browseros-agent/apps/cli/cmd/root.go
+++ b/packages/browseros-agent/apps/cli/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"browseros-cli/analytics"
+	"browseros-cli/cmd/raw"
 	"browseros-cli/config"
 	"browseros-cli/mcp"
 	"browseros-cli/output"
@@ -65,6 +66,7 @@ var groupOrder = []string{
 	"Navigate:",
 	"Observe:",
 	"Input:",
+	"Raw:",
 	"Resources:",
 	"Integrations:",
 	"Setup:",
@@ -193,6 +195,17 @@ func init() {
 	rootCmd.Flags().BoolVar(&showLLMTxt, "llm-txt", false, "Print the agent usage guide and exit")
 
 	rootCmd.Version = version
+	raw.Register(rootCmd, raw.Deps{
+		NewClient: func() raw.Client {
+			return newClient()
+		},
+		ResolvePageID: func() (int, error) {
+			return resolvePageID(nil)
+		},
+		JSONOutput: func() bool {
+			return jsonOut
+		},
+	})
 }
 
 func newClient() *mcp.Client {

--- a/packages/browseros-agent/apps/cli/cmd/root_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/root_test.go
@@ -189,6 +189,36 @@ func TestDiffCommandShape(t *testing.T) {
 	}
 }
 
+func TestRawCDPCommandShape(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"cdp"})
+	if err != nil {
+		t.Fatalf("rootCmd.Find(cdp) error = %v", err)
+	}
+	if cmd.Name() != "cdp" {
+		t.Fatalf("command name = %q, want cdp", cmd.Name())
+	}
+	if got := cmd.Annotations["group"]; got != "Raw:" {
+		t.Fatalf("cdp group = %q, want Raw:", got)
+	}
+	if err := cmd.Args(cmd, []string{"Runtime.evaluate", `{"returnByValue":true}`}); err != nil {
+		t.Fatalf("cdp Args rejected valid args: %v", err)
+	}
+	if err := cmd.Args(cmd, []string{"Runtime.evaluate"}); err == nil {
+		t.Fatal("cdp Args accepted missing json params")
+	}
+}
+
+func TestGroupedHelpShowsRawGroup(t *testing.T) {
+	help := groupedHelp(rootCmd)
+	rawIndex := strings.Index(help, "Raw:")
+	if rawIndex < 0 {
+		t.Fatalf("groupedHelp missing Raw group:\n%s", help)
+	}
+	if !strings.Contains(help[rawIndex:], "cdp") {
+		t.Fatalf("Raw group missing cdp command:\n%s", help)
+	}
+}
+
 func TestTabsCommandShape(t *testing.T) {
 	cmd, _, err := rootCmd.Find([]string{"tabs"})
 	if err != nil {

--- a/packages/browseros-agent/packages/browser-core/src/backends/cdp.ts
+++ b/packages/browseros-agent/packages/browser-core/src/backends/cdp.ts
@@ -395,9 +395,26 @@ class CdpBackend implements ICdpBackend {
     }))
   }
 
-  private async rawSend(
+  async rawSend(
     method: string,
     params?: Record<string, unknown>,
+    sessionId?: string,
+  ): Promise<unknown> {
+    return this.sendRawMessage(method, params ?? {}, sessionId)
+  }
+
+  async rawSendJson(
+    method: string,
+    paramsJson: string,
+    sessionId?: string,
+  ): Promise<unknown> {
+    JSON.parse(paramsJson)
+    return this.sendRawMessage(method, paramsJson, sessionId)
+  }
+
+  private async sendRawMessage(
+    method: string,
+    params: Record<string, unknown> | string,
     sessionId?: string,
   ): Promise<unknown> {
     if (!this.ws || !this.connected) {
@@ -405,14 +422,15 @@ class CdpBackend implements ICdpBackend {
     }
 
     const id = ++this.messageId
-    const message: Record<string, unknown> = {
-      id,
-      method,
-      params: params ?? {},
-    }
-    if (sessionId) {
-      message.sessionId = sessionId
-    }
+    const messageJson =
+      typeof params === 'string'
+        ? this.rawMessageJson(id, method, params, sessionId)
+        : JSON.stringify({
+            id,
+            method,
+            params,
+            ...(sessionId && { sessionId }),
+          })
 
     const ws = this.ws
     return new Promise<unknown>((resolve, reject) => {
@@ -424,7 +442,7 @@ class CdpBackend implements ICdpBackend {
       this.pending.set(id, { resolve, reject, timer })
 
       try {
-        ws.send(JSON.stringify(message))
+        ws.send(messageJson)
       } catch (err) {
         clearTimeout(timer)
         this.pending.delete(id)
@@ -435,6 +453,21 @@ class CdpBackend implements ICdpBackend {
         this.handleDeadConnection()
       }
     })
+  }
+
+  private rawMessageJson(
+    id: number,
+    method: string,
+    paramsJson: string,
+    sessionId?: string,
+  ): string {
+    const fields = [
+      `"id":${id}`,
+      `"method":${JSON.stringify(method)}`,
+      `"params":${paramsJson}`,
+    ]
+    if (sessionId) fields.push(`"sessionId":${JSON.stringify(sessionId)}`)
+    return `{${fields.join(',')}}`
   }
 
   private rawOn(event: string, handler: (params: unknown) => void): () => void {

--- a/packages/browseros-agent/packages/browser-core/src/backends/types.ts
+++ b/packages/browseros-agent/packages/browser-core/src/backends/types.ts
@@ -7,6 +7,16 @@ export interface CdpBackend extends ProtocolApi {
   connectionEpoch(): number
   getTargets(): Promise<CdpTarget[]>
   session(sessionId: string): ProtocolApi
+  rawSend(
+    method: string,
+    params?: Record<string, unknown>,
+    sessionId?: string,
+  ): Promise<unknown>
+  rawSendJson(
+    method: string,
+    paramsJson: string,
+    sessionId?: string,
+  ): Promise<unknown>
   onSessionEvent(
     event: string,
     handler: (params: unknown, sessionId: string) => void,

--- a/packages/browseros-agent/packages/browser-core/src/core/connection.ts
+++ b/packages/browseros-agent/packages/browser-core/src/core/connection.ts
@@ -10,6 +10,16 @@ export type FrameId = string
  */
 export interface CdpConnection extends ProtocolApi {
   session(sessionId: SessionId): ProtocolApi
+  rawSend(
+    method: string,
+    params?: Record<string, unknown>,
+    sessionId?: SessionId,
+  ): Promise<unknown>
+  rawSendJson(
+    method: string,
+    paramsJson: string,
+    sessionId?: SessionId,
+  ): Promise<unknown>
   isConnected(): boolean
   connectionEpoch(): number
 }

--- a/packages/browseros-agent/packages/browser-core/src/core/pages.ts
+++ b/packages/browseros-agent/packages/browser-core/src/core/pages.ts
@@ -32,6 +32,7 @@ type WindowInfo = {
 
 export interface PageSession {
   targetId: string
+  sessionId: string
   session: ProtocolApi
   url: string
 }
@@ -124,6 +125,7 @@ export class PageManager {
     const sessionId = await this.attach(info.targetId, pageId)
     return {
       targetId: info.targetId,
+      sessionId,
       session: this.cdp.session(sessionId),
       url: info.url,
     }
@@ -156,6 +158,7 @@ export class PageManager {
     const sessionId = await this.attach(tab.targetId, pageId)
     return {
       targetId: tab.targetId,
+      sessionId,
       session: this.cdp.session(sessionId),
       url: tab.url,
     }

--- a/packages/browseros-agent/packages/browser-core/src/core/session.ts
+++ b/packages/browseros-agent/packages/browser-core/src/core/session.ts
@@ -77,18 +77,26 @@ export class BrowserSession {
     params?: Record<string, unknown>,
     sessionId?: string,
   ): Promise<unknown> {
-    const api = sessionId ? this.connection.session(sessionId) : this.connection
-    const [domain, command] = method.split('.')
-    const target = (
-      api as unknown as Record<
-        string,
-        Record<string, (p?: unknown) => Promise<unknown>>
-      >
-    )[domain]
-    if (!target?.[command]) {
-      throw new Error(`Unknown CDP method "${method}"`)
-    }
-    return target[command](params ?? {})
+    return this.connection.rawSend(method, params ?? {}, sessionId)
+  }
+
+  /** Raw CDP escape hatch that sends already-validated JSON params verbatim. */
+  async cdpJson(
+    method: string,
+    paramsJson: string,
+    sessionId?: string,
+  ): Promise<unknown> {
+    return this.connection.rawSendJson(method, paramsJson, sessionId)
+  }
+
+  /** Page-scoped raw CDP for CLI/run callers that start from a BrowserOS page id. */
+  async cdpJsonForPage(
+    pageId: number,
+    method: string,
+    paramsJson: string,
+  ): Promise<unknown> {
+    const { sessionId } = await this.pages.getSession(pageId)
+    return this.connection.rawSendJson(method, paramsJson, sessionId)
   }
 
   isConnected(): boolean {

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/run.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/run.ts
@@ -17,6 +17,7 @@ Available as \`browser\`:
   browser.input(pageId).click(ref) / fill(ref,value) / type(text) / press(key) / hover(ref) / selectOption(ref,value) / scroll(dir,amount,ref?)
   browser.nav(pageId).goto(url) / back() / forward() / reload()
   browser.cdp(method, params?, sessionId?)   // raw CDP escape hatch
+  browser.cdpJsonForPage(pageId, method, paramsJson) // page-scoped raw CDP with validated JSON params
 Refs (eN) come from a snapshot's text/refs.`
 
 interface RunOutcome {


### PR DESCRIPTION
## Summary
- Add `browseros-cli -p <page> cdp <Domain.method> '<json-params>'` under a visible `Raw:` help group.
- Route raw calls through the existing MCP `run` tool into browser-core, with page-scoped `rawSendJson` so method/params reach CDP without a Go CDP client or generated-proxy allow-listing.
- Preserve structured success and error envelopes for `--json`, including `ok`, `page`, `method`, `result`, `logs`, and protocol errors.

## Design
The CLI owns argument validation and output shaping in a new `cmd/raw` package. Browser-core owns the actual raw CDP send: the run script calls `browser.cdpJsonForPage(page, method, paramsJson)`, which resolves the BrowserOS page id to its CDP session and sends the validated JSON params directly over the existing CDP backend.

## Test plan
- [x] `gofmt -l .`
- [x] `go vet ./...`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] `packages/browser-core`: `bun run typecheck`, `bun test`
- [x] `packages/browser-mcp`: `bun run typecheck`, `bun test`
- [x] Installed local CLI, initialized `http://127.0.0.1:9853/mcp`, and live-smoked raw CDP success/error paths.
- [x] Live HN smoke: opened HN best page 3, 9th post comments, and top 5 story links via CLI raw CDP.