### PR TITLE
feat: package BrowserClaw runtime payloads

### DIFF
--- a/packages/browseros/build/common/release_configs_test.py
+++ b/packages/browseros/build/common/release_configs_test.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Tests for release config resource phase coverage."""
+
+import unittest
+from pathlib import Path
+
+import yaml
+
+CONFIG_DIR = Path(__file__).resolve().parents[1] / "config"
+
+
+class ReleaseResourceConfigTest(unittest.TestCase):
+    def test_single_arch_release_configs_run_resource_phases(self):
+        configs = [
+            "release.macos.arm64.yaml",
+            "release.macos.arm64.noupload.yaml",
+            "release.macos.arm64.ci.yaml",
+            "release.windows.yaml",
+            "release.windows.ci.yaml",
+            "release.linux.yaml",
+            "release.linux.ci.yaml",
+        ]
+
+        for config_name in configs:
+            with self.subTest(config=config_name):
+                modules = self._modules(config_name)
+                self.assertLess(
+                    modules.index("download_resources"),
+                    modules.index("resources"),
+                )
+                self.assertLess(
+                    modules.index("resources"),
+                    modules.index("bundled_extensions"),
+                )
+
+    def test_macos_universal_downloads_and_bundles_before_universal_build(self):
+        modules = self._modules("release.macos.yaml")
+
+        self.assertLess(modules.index("download_resources"), modules.index("bundled_extensions"))
+        self.assertLess(modules.index("bundled_extensions"), modules.index("universal_build"))
+
+    def _modules(self, config_name: str) -> list[str]:
+        return yaml.safe_load((CONFIG_DIR / config_name).read_text())["modules"]
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/common/server_binaries.py
+++ b/packages/browseros/build/common/server_binaries.py
@@ -26,6 +26,7 @@ class ServerBundle:
     windows_bundle_resources_root: Path
     macos_binaries: Dict[str, SignSpec]
     windows_binaries: Tuple[str, ...]
+    required_in_chromium_output: bool = True
 
 
 BROWSEROS_SERVER_MACOS_BINARIES: Dict[str, SignSpec] = {
@@ -67,6 +68,7 @@ BROWSEROS_CLAW_SERVER_BUNDLE = ServerBundle(
     windows_bundle_resources_root=Path("BrowserOSClawServer/default/resources"),
     macos_binaries=BROWSEROS_CLAW_SERVER_MACOS_BINARIES,
     windows_binaries=("browseros-claw-server.exe",),
+    required_in_chromium_output=False,
 )
 
 SERVER_BUNDLES = (

--- a/packages/browseros/build/common/server_binaries.py
+++ b/packages/browseros/build/common/server_binaries.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
-"""Shared sign metadata for BrowserOS Server binaries."""
+"""Shared sign metadata for bundled BrowserOS server binaries."""
 
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Tuple
 
 
 @dataclass(frozen=True)
@@ -15,7 +15,20 @@ class SignSpec:
     entitlements: Optional[str] = None
 
 
-MACOS_SERVER_BINARIES: Dict[str, SignSpec] = {
+@dataclass(frozen=True)
+class ServerBundle:
+    """Resource roots and signing metadata for one bundled server."""
+
+    name: str
+    local_resources_root: Path
+    chromium_resources_root: Path
+    macos_bundle_resources_root: Path
+    windows_bundle_resources_root: Path
+    macos_binaries: Dict[str, SignSpec]
+    windows_binaries: Tuple[str, ...]
+
+
+BROWSEROS_SERVER_MACOS_BINARIES: Dict[str, SignSpec] = {
     "browseros_server": SignSpec(
         "browseros_server", "runtime", "browseros-executable-entitlements.plist"
     ),
@@ -23,10 +36,51 @@ MACOS_SERVER_BINARIES: Dict[str, SignSpec] = {
     "rg": SignSpec("rg", "runtime"),
 }
 
+BROWSEROS_CLAW_SERVER_MACOS_BINARIES: Dict[str, SignSpec] = {
+    "browseros-claw-server": SignSpec(
+        "browseros_claw_server",
+        "runtime",
+        "browseros-executable-entitlements.plist",
+    ),
+}
 
-WINDOWS_SERVER_BINARIES: List[str] = [
-    "browseros_server.exe",
-]
+
+BROWSEROS_SERVER_BUNDLE = ServerBundle(
+    name="BrowserOS Server",
+    local_resources_root=Path("resources/binaries/browseros_server"),
+    chromium_resources_root=Path("chrome/browser/browseros/server/resources"),
+    macos_bundle_resources_root=Path(
+        "Contents/Resources/BrowserOSServer/default/resources"
+    ),
+    windows_bundle_resources_root=Path("BrowserOSServer/default/resources"),
+    macos_binaries=BROWSEROS_SERVER_MACOS_BINARIES,
+    windows_binaries=("browseros_server.exe",),
+)
+
+BROWSEROS_CLAW_SERVER_BUNDLE = ServerBundle(
+    name="BrowserOS Claw Server",
+    local_resources_root=Path("resources/binaries/browseros_claw_server"),
+    chromium_resources_root=Path("chrome/browser/browseros/claw_server/resources"),
+    macos_bundle_resources_root=Path(
+        "Contents/Resources/BrowserOSClawServer/default/resources"
+    ),
+    windows_bundle_resources_root=Path("BrowserOSClawServer/default/resources"),
+    macos_binaries=BROWSEROS_CLAW_SERVER_MACOS_BINARIES,
+    windows_binaries=("browseros-claw-server.exe",),
+)
+
+SERVER_BUNDLES = (
+    BROWSEROS_SERVER_BUNDLE,
+    BROWSEROS_CLAW_SERVER_BUNDLE,
+)
+
+MACOS_SERVER_BINARIES: Dict[str, SignSpec] = {
+    stem: spec
+    for bundle in SERVER_BUNDLES
+    for stem, spec in bundle.macos_binaries.items()
+}
+
+WINDOWS_SERVER_BINARIES: List[str] = list(BROWSEROS_SERVER_BUNDLE.windows_binaries)
 
 
 def macos_sign_spec_for(binary_path: Path) -> Optional[SignSpec]:
@@ -37,3 +91,12 @@ def macos_sign_spec_for(binary_path: Path) -> Optional[SignSpec]:
 def expected_windows_binary_paths(server_bin_dir: Path) -> List[Path]:
     """Resolve the Windows relative-path list against a ``resources/bin`` dir."""
     return [server_bin_dir / rel for rel in WINDOWS_SERVER_BINARIES]
+
+
+def expected_windows_bundle_binary_paths(build_output_dir: Path) -> List[Path]:
+    """Resolve all bundled server binaries under a Chromium build output dir."""
+    paths: List[Path] = []
+    for bundle in SERVER_BUNDLES:
+        bin_dir = build_output_dir / bundle.windows_bundle_resources_root / "bin"
+        paths.extend(bin_dir / rel for rel in bundle.windows_binaries)
+    return paths

--- a/packages/browseros/build/common/server_binaries_test.py
+++ b/packages/browseros/build/common/server_binaries_test.py
@@ -46,6 +46,8 @@ class MacosServerBinariesTest(unittest.TestCase):
             BROWSEROS_CLAW_SERVER_BUNDLE.macos_bundle_resources_root,
             Path("Contents/Resources/BrowserOSClawServer/default/resources"),
         )
+        self.assertTrue(BROWSEROS_SERVER_BUNDLE.required_in_chromium_output)
+        self.assertFalse(BROWSEROS_CLAW_SERVER_BUNDLE.required_in_chromium_output)
 
     def test_every_entry_has_identifier_and_options(self):
         for stem, spec in MACOS_SERVER_BINARIES.items():

--- a/packages/browseros/build/common/server_binaries_test.py
+++ b/packages/browseros/build/common/server_binaries_test.py
@@ -5,8 +5,12 @@ import unittest
 from pathlib import Path
 
 from .server_binaries import (
+    BROWSEROS_CLAW_SERVER_BUNDLE,
+    BROWSEROS_SERVER_BUNDLE,
     MACOS_SERVER_BINARIES,
+    SERVER_BUNDLES,
     WINDOWS_SERVER_BINARIES,
+    expected_windows_bundle_binary_paths,
     expected_windows_binary_paths,
     macos_sign_spec_for,
 )
@@ -15,6 +19,34 @@ ENTITLEMENTS_DIR = Path(__file__).resolve().parents[2] / "resources" / "entitlem
 
 
 class MacosServerBinariesTest(unittest.TestCase):
+    def test_server_bundles_have_separate_resource_roots(self):
+        self.assertEqual(SERVER_BUNDLES[0], BROWSEROS_SERVER_BUNDLE)
+        self.assertEqual(SERVER_BUNDLES[1], BROWSEROS_CLAW_SERVER_BUNDLE)
+        self.assertEqual(
+            BROWSEROS_SERVER_BUNDLE.local_resources_root,
+            Path("resources/binaries/browseros_server"),
+        )
+        self.assertEqual(
+            BROWSEROS_CLAW_SERVER_BUNDLE.local_resources_root,
+            Path("resources/binaries/browseros_claw_server"),
+        )
+        self.assertEqual(
+            BROWSEROS_SERVER_BUNDLE.chromium_resources_root,
+            Path("chrome/browser/browseros/server/resources"),
+        )
+        self.assertEqual(
+            BROWSEROS_CLAW_SERVER_BUNDLE.chromium_resources_root,
+            Path("chrome/browser/browseros/claw_server/resources"),
+        )
+        self.assertEqual(
+            BROWSEROS_SERVER_BUNDLE.macos_bundle_resources_root,
+            Path("Contents/Resources/BrowserOSServer/default/resources"),
+        )
+        self.assertEqual(
+            BROWSEROS_CLAW_SERVER_BUNDLE.macos_bundle_resources_root,
+            Path("Contents/Resources/BrowserOSClawServer/default/resources"),
+        )
+
     def test_every_entry_has_identifier_and_options(self):
         for stem, spec in MACOS_SERVER_BINARIES.items():
             self.assertTrue(spec.identifier_suffix, f"{stem} missing identifier_suffix")
@@ -32,6 +64,15 @@ class MacosServerBinariesTest(unittest.TestCase):
         assert spec is not None
         self.assertEqual(spec.identifier_suffix, "browseros_server")
         self.assertIsNone(macos_sign_spec_for(Path("/x/not_a_known_binary")))
+
+    def test_macos_sign_spec_for_resolves_claw_server_binary(self):
+        spec = macos_sign_spec_for(Path("/x/browseros-claw-server"))
+        assert spec is not None
+        self.assertEqual(spec.identifier_suffix, "browseros_claw_server")
+        self.assertEqual(spec.options, "runtime")
+        self.assertEqual(
+            spec.entitlements, "browseros-executable-entitlements.plist"
+        )
 
     def test_third_party_tool_entries_use_plain_hardened_runtime(self):
         for binary in ["rg"]:
@@ -77,6 +118,27 @@ class WindowsServerBinariesTest(unittest.TestCase):
         self.assertEqual(len(resolved), len(WINDOWS_SERVER_BINARIES))
         for rel, abs_path in zip(WINDOWS_SERVER_BINARIES, resolved):
             self.assertEqual(abs_path, root / rel)
+
+    def test_expected_windows_bundle_binary_paths_includes_claw(self):
+        build_output_dir = Path("/tmp/out/Default")
+
+        self.assertEqual(
+            expected_windows_bundle_binary_paths(build_output_dir),
+            [
+                build_output_dir
+                / "BrowserOSServer"
+                / "default"
+                / "resources"
+                / "bin"
+                / "browseros_server.exe",
+                build_output_dir
+                / "BrowserOSClawServer"
+                / "default"
+                / "resources"
+                / "bin"
+                / "browseros-claw-server.exe",
+            ],
+        )
 
     def test_windows_has_no_stale_third_party(self):
         forbidden = {

--- a/packages/browseros/build/config/copy_resources.yaml
+++ b/packages/browseros/build/config/copy_resources.yaml
@@ -123,3 +123,39 @@ copy_operations:
     type: "directory"
     os: ["windows"]
     arch: ["x64"]
+
+  # BrowserOS Claw Server resources - Platform & Architecture specific
+  - name: "BrowserOS Claw Server Resources - macOS ARM64"
+    source: "resources/binaries/browseros_claw_server/darwin-arm64/resources"
+    destination: "chrome/browser/browseros/claw_server/resources"
+    type: "directory"
+    os: ["macos"]
+    arch: ["arm64"]
+
+  - name: "BrowserOS Claw Server Resources - macOS x64"
+    source: "resources/binaries/browseros_claw_server/darwin-x64/resources"
+    destination: "chrome/browser/browseros/claw_server/resources"
+    type: "directory"
+    os: ["macos"]
+    arch: ["x64"]
+
+  - name: "BrowserOS Claw Server Resources - Linux ARM64"
+    source: "resources/binaries/browseros_claw_server/linux-arm64/resources"
+    destination: "chrome/browser/browseros/claw_server/resources"
+    type: "directory"
+    os: ["linux"]
+    arch: ["arm64"]
+
+  - name: "BrowserOS Claw Server Resources - Linux x64"
+    source: "resources/binaries/browseros_claw_server/linux-x64/resources"
+    destination: "chrome/browser/browseros/claw_server/resources"
+    type: "directory"
+    os: ["linux"]
+    arch: ["x64"]
+
+  - name: "BrowserOS Claw Server Resources - Windows x64"
+    source: "resources/binaries/browseros_claw_server/windows-x64/resources"
+    destination: "chrome/browser/browseros/claw_server/resources"
+    type: "directory"
+    os: ["windows"]
+    arch: ["x64"]

--- a/packages/browseros/build/config/download_resources.yaml
+++ b/packages/browseros/build/config/download_resources.yaml
@@ -23,6 +23,7 @@
 #
 # R2 Path Structure:
 #   artifacts/server/latest/browseros-server-resources-{target}.zip
+#   claw-server/prod-resources/latest/browseros-claw-server-resources-{target}.zip
 #
 # Example:
 #   - name: "My Artifact - macOS ARM64"
@@ -65,6 +66,42 @@ download_operations:
   - name: "BrowserOS Server Resources - Windows x64"
     r2_key: "artifacts/server/latest/browseros-server-resources-windows-x64.zip"
     destination: "resources/binaries/browseros_server/windows-x64"
+    download_type: "artifact_zip"
+    os: ["windows"]
+    arch: ["x64"]
+
+  # BrowserOS Claw Server resource bundles - Platform & Architecture specific
+  - name: "BrowserOS Claw Server Resources - macOS ARM64"
+    r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-arm64.zip"
+    destination: "resources/binaries/browseros_claw_server/darwin-arm64"
+    download_type: "artifact_zip"
+    os: ["macos"]
+    arch: ["arm64"]
+
+  - name: "BrowserOS Claw Server Resources - macOS x64"
+    r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-x64.zip"
+    destination: "resources/binaries/browseros_claw_server/darwin-x64"
+    download_type: "artifact_zip"
+    os: ["macos"]
+    arch: ["x64"]
+
+  - name: "BrowserOS Claw Server Resources - Linux ARM64"
+    r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-arm64.zip"
+    destination: "resources/binaries/browseros_claw_server/linux-arm64"
+    download_type: "artifact_zip"
+    os: ["linux"]
+    arch: ["arm64"]
+
+  - name: "BrowserOS Claw Server Resources - Linux x64"
+    r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-x64.zip"
+    destination: "resources/binaries/browseros_claw_server/linux-x64"
+    download_type: "artifact_zip"
+    os: ["linux"]
+    arch: ["x64"]
+
+  - name: "BrowserOS Claw Server Resources - Windows x64"
+    r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-windows-x64.zip"
+    destination: "resources/binaries/browseros_claw_server/windows-x64"
     download_type: "artifact_zip"
     os: ["windows"]
     arch: ["x64"]

--- a/packages/browseros/build/modules/extensions/bundled_extensions.py
+++ b/packages/browseros/build/modules/extensions/bundled_extensions.py
@@ -16,9 +16,17 @@ from ...common.utils import log_info, log_success
 
 class ExtensionInfo(NamedTuple):
     """Extension metadata parsed from update manifest"""
+
     id: str
     version: str
     codebase: str
+
+
+REQUIRED_BUNDLED_EXTENSION_IDS: Dict[str, str] = {
+    "adlpneommgkgeanpaekgoaolcpncohkf": "BrowserOS bug reporter",
+    "bflpfmnmnokmjhmgnolecpppdbdophmk": "BrowserOS agent",
+    "pjimfkbpehlcllblajnpfamdfjhhlgkc": "BrowserOS Claw app",
+}
 
 
 class BundledExtensionsModule(CommandModule):
@@ -46,6 +54,7 @@ class BundledExtensionsModule(CommandModule):
         extensions = self._fetch_and_parse_manifest(manifest_url)
         if not extensions:
             raise RuntimeError("No extensions found in manifest")
+        self._validate_required_extensions(extensions)
 
         log_info(f"  Found {len(extensions)} extensions in manifest")
 
@@ -73,15 +82,7 @@ class BundledExtensionsModule(CommandModule):
         return self._parse_manifest_xml(response.text)
 
     def _parse_manifest_xml(self, xml_content: str) -> List[ExtensionInfo]:
-        """Parse Google Update protocol XML manifest
-
-        Expected format (with namespace):
-        <gupdate xmlns="http://www.google.com/update2/response" protocol='2.0'>
-          <app appid='extension_id'>
-            <updatecheck codebase='https://...' version='1.0.0' />
-          </app>
-        </gupdate>
-        """
+        """Parse Google Update protocol XML manifest."""
         extensions = []
 
         try:
@@ -118,6 +119,22 @@ class BundledExtensionsModule(CommandModule):
                 ))
 
         return extensions
+
+    def _validate_required_extensions(
+        self, extensions: List[ExtensionInfo]
+    ) -> None:
+        """Fail if the release manifest omits a required bundled extension."""
+        extension_ids = {ext.id for ext in extensions}
+        missing = [
+            f"{name} ({extension_id})"
+            for extension_id, name in REQUIRED_BUNDLED_EXTENSION_IDS.items()
+            if extension_id not in extension_ids
+        ]
+        if missing:
+            raise RuntimeError(
+                "Bundled extension manifest missing required entries: "
+                + ", ".join(missing)
+            )
 
     def _download_extension(self, ext: ExtensionInfo, output_dir: Path) -> None:
         """Download a single extension .crx file"""

--- a/packages/browseros/build/modules/extensions/bundled_extensions_test.py
+++ b/packages/browseros/build/modules/extensions/bundled_extensions_test.py
@@ -1,10 +1,18 @@
 #!/usr/bin/env python3
 """Tests for bundled extension manifest handling."""
 
+import json
+import tempfile
 import unittest
 from pathlib import Path
 
-from build.modules.extensions.bundled_extensions import BundledExtensionsModule
+from build.modules.extensions.bundled_extensions import (
+    REQUIRED_BUNDLED_EXTENSION_IDS,
+    BundledExtensionsModule,
+    ExtensionInfo,
+)
+
+CLAW_EXTENSION_ID = "pjimfkbpehlcllblajnpfamdfjhhlgkc"
 
 
 class BundledExtensionsManifestTest(unittest.TestCase):
@@ -29,8 +37,70 @@ class BundledExtensionsManifestTest(unittest.TestCase):
                     "0.0.115.0",
                     "https://cdn.browseros.com/extensions/agent-0.0.115.0.crx",
                 ),
+                (
+                    CLAW_EXTENSION_ID,
+                    "0.0.1",
+                    "https://cdn.browseros.com/extensions/browserclaw-0.0.1.crx",
+                ),
             ],
         )
+
+    def test_required_ids_cover_agent_bug_reporter_and_claw(self) -> None:
+        self.assertEqual(
+            REQUIRED_BUNDLED_EXTENSION_IDS,
+            {
+                "adlpneommgkgeanpaekgoaolcpncohkf": "BrowserOS bug reporter",
+                "bflpfmnmnokmjhmgnolecpppdbdophmk": "BrowserOS agent",
+                CLAW_EXTENSION_ID: "BrowserOS Claw app",
+            },
+        )
+
+    def test_generated_json_maps_claw_id_to_crx(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            output_dir = Path(tmp)
+            BundledExtensionsModule()._generate_json(
+                [
+                    ExtensionInfo(
+                        id=CLAW_EXTENSION_ID,
+                        version="0.0.1",
+                        codebase=(
+                            "https://cdn.browseros.com/extensions/"
+                            "browserclaw-0.0.1.crx"
+                        ),
+                    )
+                ],
+                output_dir,
+            )
+
+            data = json.loads((output_dir / "bundled_extensions.json").read_text())
+
+        self.assertEqual(
+            data[CLAW_EXTENSION_ID],
+            {
+                "external_crx": f"{CLAW_EXTENSION_ID}.crx",
+                "external_version": "0.0.1",
+            },
+        )
+
+    def test_missing_claw_app_fails_validation(self) -> None:
+        extensions = [
+            ExtensionInfo(
+                id="adlpneommgkgeanpaekgoaolcpncohkf",
+                version="52.0.0.0",
+                codebase="https://cdn.browseros.com/extensions/bugreporter.crx",
+            ),
+            ExtensionInfo(
+                id="bflpfmnmnokmjhmgnolecpppdbdophmk",
+                version="0.0.115.0",
+                codebase="https://cdn.browseros.com/extensions/agent.crx",
+            ),
+        ]
+
+        with self.assertRaisesRegex(
+            RuntimeError,
+            f"BrowserOS Claw app \\({CLAW_EXTENSION_ID}\\)",
+        ):
+            BundledExtensionsModule()._validate_required_extensions(extensions)
 
 
 if __name__ == "__main__":

--- a/packages/browseros/build/modules/package/linux.py
+++ b/packages/browseros/build/modules/package/linux.py
@@ -195,7 +195,12 @@ def copy_browser_files(
         else:
             log_warning(f"  ⚠ File not found: {file}")
 
-    dirs_to_copy = ["locales", "MEIPreload", "BrowserOSServer"]
+    dirs_to_copy = [
+        "locales",
+        "MEIPreload",
+        "BrowserOSServer",
+        "BrowserOSClawServer",
+    ]
     for dir_name in dirs_to_copy:
         src = join_paths(out_dir, dir_name)
         if Path(src).exists():

--- a/packages/browseros/build/modules/package/linux_test.py
+++ b/packages/browseros/build/modules/package/linux_test.py
@@ -1,11 +1,15 @@
 #!/usr/bin/env python3
 """Tests for Linux packaging architecture helpers."""
 
+import tempfile
 import unittest
+from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from build.modules.package.linux import (
     LINUX_HOST_APPIMAGETOOL,
+    copy_browser_files,
     get_host_appimagetool,
     get_linux_architecture_config,
 )
@@ -57,6 +61,49 @@ class HostAppImageToolTest(unittest.TestCase):
         # builds work in either direction.
         self.assertIn("x64", LINUX_HOST_APPIMAGETOOL)
         self.assertIn("arm64", LINUX_HOST_APPIMAGETOOL)
+
+
+class CopyBrowserFilesTest(unittest.TestCase):
+    def test_copies_browseros_and_claw_server_roots_when_present(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            out_dir = root / "out" / "Release"
+            target_dir = root / "package"
+            out_dir.mkdir(parents=True)
+            (out_dir / "browseros").write_text("browser")
+
+            for bundle_name in ("BrowserOSServer", "BrowserOSClawServer"):
+                resources = out_dir / bundle_name / "default" / "resources"
+                resources.mkdir(parents=True)
+                (resources / "marker.txt").write_text(bundle_name)
+
+            ctx = SimpleNamespace(
+                chromium_src=root,
+                out_dir=Path("out") / "Release",
+                BROWSEROS_APP_NAME="browseros",
+            )
+
+            with patch("build.modules.package.linux.log_warning"):
+                self.assertTrue(copy_browser_files(ctx, target_dir))
+
+            self.assertTrue(
+                (
+                    target_dir
+                    / "BrowserOSServer"
+                    / "default"
+                    / "resources"
+                    / "marker.txt"
+                ).exists()
+            )
+            self.assertTrue(
+                (
+                    target_dir
+                    / "BrowserOSClawServer"
+                    / "default"
+                    / "resources"
+                    / "marker.txt"
+                ).exists()
+            )
 
 
 if __name__ == "__main__":

--- a/packages/browseros/build/modules/resources/resources_test.py
+++ b/packages/browseros/build/modules/resources/resources_test.py
@@ -6,7 +6,9 @@ import unittest
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
+from unittest.mock import patch
 
+import yaml
 from .resources import ResourcesModule, copy_resources_impl
 from ...common.context import Context
 from ...common.module import ValidationError
@@ -184,6 +186,68 @@ class CopyResourcesTest(unittest.TestCase):
         self.assertTrue(copy_resources_impl(self.ctx))
 
         self.assertFalse((self.chromium.src / "chrome" / "ghost").exists())
+
+    def test_real_config_copies_browseros_and_claw_server_roots_apart(self):
+        self.root.write_copy_config(self._real_copy_config())
+        browseros_source = (
+            self.root.root
+            / "resources"
+            / "binaries"
+            / "browseros_server"
+            / "darwin-arm64"
+            / "resources"
+        )
+        claw_source = (
+            self.root.root
+            / "resources"
+            / "binaries"
+            / "browseros_claw_server"
+            / "darwin-arm64"
+            / "resources"
+        )
+        (browseros_source / "bin").mkdir(parents=True)
+        (browseros_source / "bin" / "browseros_server").write_text("browseros")
+        (claw_source / "bin").mkdir(parents=True)
+        (claw_source / "bin" / "browseros-claw-server").write_text("claw")
+
+        with patch("build.modules.resources.resources.get_platform", return_value="macos"):
+            ctx = make_context(
+                self.chromium,
+                self.root,
+                architecture="arm64",
+                build_type="release",
+            )
+            self.assertTrue(copy_resources_impl(ctx))
+
+        browseros_dest = (
+            self.chromium.src
+            / "chrome"
+            / "browser"
+            / "browseros"
+            / "server"
+            / "resources"
+            / "bin"
+            / "browseros_server"
+        )
+        claw_dest = (
+            self.chromium.src
+            / "chrome"
+            / "browser"
+            / "browseros"
+            / "claw_server"
+            / "resources"
+            / "bin"
+            / "browseros-claw-server"
+        )
+        self.assertEqual(browseros_dest.read_text(), "browseros")
+        self.assertEqual(claw_dest.read_text(), "claw")
+
+    def _real_copy_config(self) -> dict:
+        config_path = (
+            Path(__file__).resolve().parents[2] / "config" / "copy_resources.yaml"
+        )
+        with open(config_path, "r") as f:
+            return yaml.safe_load(f)
 
 
 class ResourcesModuleValidateTest(unittest.TestCase):

--- a/packages/browseros/build/modules/sign/macos.py
+++ b/packages/browseros/build/modules/sign/macos.py
@@ -11,7 +11,11 @@ from typing import Optional, List, Dict, Tuple
 from ...common.module import CommandModule, ValidationError
 from ...common.context import Context
 from ...common.env import EnvConfig
-from ...common.server_binaries import macos_sign_spec_for
+from ...common.server_binaries import (
+    SERVER_BUNDLES,
+    ServerBundle,
+    macos_sign_spec_for,
+)
 from ...common.utils import (
     run_command as utils_run_command,
     log_info,
@@ -37,38 +41,34 @@ def get_browseros_server_binary_info(component_path: Path) -> Optional[Dict[str,
     return info
 
 
-SERVER_RESOURCES_SOURCE_REL = Path("chrome/browser/browseros/server/resources")
-SERVER_RESOURCES_BUNDLE_REL = Path(
-    "Contents/Resources/BrowserOSServer/default/resources"
-)
+SERVER_RESOURCES_SOURCE_REL = SERVER_BUNDLES[0].chromium_resources_root
+SERVER_RESOURCES_BUNDLE_REL = SERVER_BUNDLES[0].macos_bundle_resources_root
 # Finder droppings in the staged tree must not fail the nightly sign.
 SERVER_RESOURCES_JUNK_FILES = {".DS_Store"}
 
 
 def verify_server_resources_bundle(app_path: Path, chromium_src: Path) -> List[str]:
-    """Check the app bundle ships exactly what the build staged for the server.
+    """Check bundled server resources match what the build staged."""
+    problems: List[str] = []
+    for bundle in SERVER_BUNDLES:
+        problems.extend(_verify_server_resource_bundle(bundle, app_path, chromium_src))
+    return problems
 
-    Guards against signing/packaging a stale or incomplete bundle (a leftover
-    out/Default_universal app once shipped for two weeks unnoticed): every file
-    staged under chrome/browser/browseros/server/resources must exist in the
-    bundle with executable bits intact. Returns problem strings; empty = OK.
-    Bundle-only extras and a missing source tree (sign-only flows) just warn.
 
-    Deliberately compares paths + exec bits only, never content/size: universal
-    bundles hold lipo-fat binaries whose bytes differ from the thin staged
-    tree, so same-name content staleness is out of this guard's reach.
-    """
-    source_root = chromium_src / SERVER_RESOURCES_SOURCE_REL
-    bundle_root = app_path / SERVER_RESOURCES_BUNDLE_REL
-
+def _verify_server_resource_bundle(
+    bundle: ServerBundle, app_path: Path, chromium_src: Path
+) -> List[str]:
+    source_root = chromium_src / bundle.chromium_resources_root
+    bundle_root = app_path / bundle.macos_bundle_resources_root
     if not source_root.is_dir():
         log_warning(
-            f"Staged server resources not found at {source_root} - "
+            f"Staged {bundle.name} resources not found at {source_root} - "
             "skipping bundle verification"
         )
         return []
 
     problems: List[str] = []
+    bundle_label = bundle.macos_bundle_resources_root.as_posix()
     staged = set()
     for source_file in sorted(source_root.rglob("*")):
         if not source_file.is_file() or source_file.name in SERVER_RESOURCES_JUNK_FILES:
@@ -77,10 +77,14 @@ def verify_server_resources_bundle(app_path: Path, chromium_src: Path) -> List[s
         staged.add(rel)
         bundle_file = bundle_root / rel
         if not bundle_file.is_file():
-            problems.append(f"missing from app bundle: {rel.as_posix()}")
+            problems.append(
+                f"{bundle_label}: missing from app bundle: {rel.as_posix()}"
+            )
             continue
         if os.access(source_file, os.X_OK) and not os.access(bundle_file, os.X_OK):
-            problems.append(f"lost executable bit in app bundle: {rel.as_posix()}")
+            problems.append(
+                f"{bundle_label}: lost executable bit in app bundle: {rel.as_posix()}"
+            )
 
     if bundle_root.is_dir():
         for bundle_file in sorted(bundle_root.rglob("*")):
@@ -92,7 +96,7 @@ def verify_server_resources_bundle(app_path: Path, chromium_src: Path) -> List[s
             rel = bundle_file.relative_to(bundle_root)
             if rel not in staged:
                 log_warning(
-                    f"App bundle has server file not in staged resources "
+                    f"App bundle has {bundle.name} file not in staged resources "
                     f"(stale?): {rel.as_posix()}"
                 )
 
@@ -347,10 +351,11 @@ def find_components_to_sign(
         if nested_app not in components["helpers"]:
             components["apps"].append(nested_app)
 
-    # Find BrowserOS Server binaries
-    browseros_server_dir = join_paths(app_path, "Contents", "Resources", "BrowserOSServer")
-    if browseros_server_dir.exists():
-        for item in browseros_server_dir.rglob("*"):
+    for bundle in SERVER_BUNDLES:
+        bundle_root = app_path / bundle.macos_bundle_resources_root
+        if not bundle_root.exists():
+            continue
+        for item in bundle_root.rglob("*"):
             if (
                 item.is_file()
                 and not item.suffix

--- a/packages/browseros/build/modules/sign/macos.py
+++ b/packages/browseros/build/modules/sign/macos.py
@@ -69,6 +69,13 @@ def _verify_server_resource_bundle(
 
     problems: List[str] = []
     bundle_label = bundle.macos_bundle_resources_root.as_posix()
+    if not bundle_root.is_dir() and not bundle.required_in_chromium_output:
+        log_warning(
+            f"{bundle.name} bundle resources not found at {bundle_root} - "
+            "skipping optional bundle verification"
+        )
+        return []
+
     staged = set()
     for source_file in sorted(source_root.rglob("*")):
         if not source_file.is_file() or source_file.name in SERVER_RESOURCES_JUNK_FILES:

--- a/packages/browseros/build/modules/sign/macos_test.py
+++ b/packages/browseros/build/modules/sign/macos_test.py
@@ -130,7 +130,7 @@ class VerifyServerResourcesBundleTest(unittest.TestCase):
                 verify_server_resources_bundle(app_path, chromium_src), []
             )
 
-    def test_reports_claw_bundle_root_for_missing_resource(self):
+    def test_skips_claw_resource_verification_until_bundle_root_exists(self):
         with tempfile.TemporaryDirectory() as tmp:
             chromium_src = Path(tmp) / "src"
             app_path = Path(tmp) / "out" / "BrowserOS.app"
@@ -143,6 +143,33 @@ class VerifyServerResourcesBundleTest(unittest.TestCase):
                 / "resources"
             )
             _write_exec(source_root / "bin" / "browseros-claw-server")
+
+            problems = verify_server_resources_bundle(app_path, chromium_src)
+
+            self.assertEqual(problems, [])
+
+    def test_reports_claw_bundle_root_for_missing_resource_once_packaged(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            chromium_src = Path(tmp) / "src"
+            app_path = Path(tmp) / "out" / "BrowserOS.app"
+            source_root = (
+                chromium_src
+                / "chrome"
+                / "browser"
+                / "browseros"
+                / "claw_server"
+                / "resources"
+            )
+            bundle_root = (
+                app_path
+                / "Contents"
+                / "Resources"
+                / "BrowserOSClawServer"
+                / "default"
+                / "resources"
+            )
+            _write_exec(source_root / "bin" / "browseros-claw-server")
+            bundle_root.mkdir(parents=True)
 
             problems = verify_server_resources_bundle(app_path, chromium_src)
 

--- a/packages/browseros/build/modules/sign/macos_test.py
+++ b/packages/browseros/build/modules/sign/macos_test.py
@@ -51,17 +51,30 @@ class MacOSSignDiscoveryTest(unittest.TestCase):
             _write_exec(server_bin / "third_party" / "codex")
             _write_exec(server_bin / "third_party" / "claude")
             _write_exec(server_bin / "third_party" / "lima" / "bin" / "limactl")
+            claw_bin = (
+                app_path
+                / "Contents"
+                / "Resources"
+                / "BrowserOSClawServer"
+                / "default"
+                / "resources"
+                / "bin"
+            )
+            _write_exec(claw_bin / "browseros-claw-server")
+            _write_exec(claw_bin / "not-registered")
 
             executables = set(find_components_to_sign(app_path)["executables"])
 
             self.assertIn(server_bin / "browseros_server", executables)
             self.assertIn(server_bin / "third_party" / "rg", executables)
+            self.assertIn(claw_bin / "browseros-claw-server", executables)
             self.assertNotIn(server_bin / "third_party" / "codex", executables)
             self.assertNotIn(server_bin / "third_party" / "claude", executables)
             self.assertNotIn(
                 server_bin / "third_party" / "lima" / "bin" / "limactl",
                 executables,
             )
+            self.assertNotIn(claw_bin / "not-registered", executables)
 
 
 class VerifyServerResourcesBundleTest(unittest.TestCase):
@@ -117,6 +130,29 @@ class VerifyServerResourcesBundleTest(unittest.TestCase):
                 verify_server_resources_bundle(app_path, chromium_src), []
             )
 
+    def test_reports_claw_bundle_root_for_missing_resource(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            chromium_src = Path(tmp) / "src"
+            app_path = Path(tmp) / "out" / "BrowserOS.app"
+            source_root = (
+                chromium_src
+                / "chrome"
+                / "browser"
+                / "browseros"
+                / "claw_server"
+                / "resources"
+            )
+            _write_exec(source_root / "bin" / "browseros-claw-server")
+
+            problems = verify_server_resources_bundle(app_path, chromium_src)
+
+            self.assertEqual(len(problems), 1)
+            self.assertIn(
+                "Contents/Resources/BrowserOSClawServer/default/resources",
+                problems[0],
+            )
+            self.assertIn("bin/browseros-claw-server", problems[0])
+
     def test_skips_when_source_dir_absent(self):
         with tempfile.TemporaryDirectory() as tmp:
             chromium_src, app_path, _, bundle_root = self._setup(tmp)
@@ -163,6 +199,16 @@ class VerifyServerResourcesBundleTest(unittest.TestCase):
         }
 
         self.assertEqual(destinations, {SERVER_RESOURCES_SOURCE_REL.as_posix()})
+
+        claw_destinations = {
+            op["destination"]
+            for op in config["copy_operations"]
+            if op["name"].startswith("BrowserOS Claw Server Resources")
+        }
+        self.assertEqual(
+            claw_destinations,
+            {"chrome/browser/browseros/claw_server/resources"},
+        )
 
 
 class SignModuleGuardWiringTest(unittest.TestCase):

--- a/packages/browseros/build/modules/sign/windows.py
+++ b/packages/browseros/build/modules/sign/windows.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from ...common.module import CommandModule, ValidationError
 from ...common.context import Context
 from ...common.env import EnvConfig
-from ...common.server_binaries import expected_windows_binary_paths
+from ...common.server_binaries import expected_windows_bundle_binary_paths
 from ...common.utils import (
     log_info,
     log_error,
@@ -95,9 +95,8 @@ class WindowsSignModule(CommandModule):
 
 
 def get_browseros_server_binary_paths(build_output_dir: Path) -> List[Path]:
-    """Return absolute paths to BrowserOS Server binaries for signing."""
-    server_dir = build_output_dir / "BrowserOSServer" / "default" / "resources" / "bin"
-    return expected_windows_binary_paths(server_dir)
+    """Return absolute paths to bundled server binaries for signing."""
+    return expected_windows_bundle_binary_paths(build_output_dir)
 
 
 def build_mini_installer(ctx: Context) -> bool:

--- a/packages/browseros/build/modules/sign/windows.py
+++ b/packages/browseros/build/modules/sign/windows.py
@@ -7,7 +7,7 @@ from typing import List, Optional
 from ...common.module import CommandModule, ValidationError
 from ...common.context import Context
 from ...common.env import EnvConfig
-from ...common.server_binaries import expected_windows_bundle_binary_paths
+from ...common.server_binaries import SERVER_BUNDLES, expected_windows_bundle_binary_paths
 from ...common.utils import (
     log_info,
     log_error,
@@ -61,7 +61,15 @@ class WindowsSignModule(CommandModule):
     def _sign_executables(self, build_output_dir: Path, env: EnvConfig) -> None:
         log_info("\nStep 1/3: Signing executables before packaging...")
         binaries_to_sign_first = [build_output_dir / "chrome.exe"]
-        binaries_to_sign_first.extend(get_browseros_server_binary_paths(build_output_dir))
+        binaries_to_sign_first.extend(
+            get_existing_browseros_server_binary_paths(build_output_dir)
+        )
+        missing = get_missing_required_browseros_server_binary_paths(build_output_dir)
+        if missing:
+            raise RuntimeError(
+                "Missing bundled server binaries: "
+                + ", ".join(str(path) for path in missing)
+            )
 
         existing_binaries = []
         for binary in binaries_to_sign_first:
@@ -97,6 +105,29 @@ class WindowsSignModule(CommandModule):
 def get_browseros_server_binary_paths(build_output_dir: Path) -> List[Path]:
     """Return absolute paths to bundled server binaries for signing."""
     return expected_windows_bundle_binary_paths(build_output_dir)
+
+
+def get_existing_browseros_server_binary_paths(build_output_dir: Path) -> List[Path]:
+    """Return bundled server binary paths that exist in a build output dir."""
+    return [
+        path for path in expected_windows_bundle_binary_paths(build_output_dir)
+        if path.exists()
+    ]
+
+
+def get_missing_required_browseros_server_binary_paths(build_output_dir: Path) -> List[Path]:
+    """Return missing bundled server binaries that should already be packaged."""
+    missing: List[Path] = []
+    for bundle in SERVER_BUNDLES:
+        bundle_root = build_output_dir / bundle.windows_bundle_resources_root
+        should_exist = bundle.required_in_chromium_output or bundle_root.exists()
+        if not should_exist:
+            continue
+        for rel in bundle.windows_binaries:
+            path = bundle_root / "bin" / rel
+            if not path.exists():
+                missing.append(path)
+    return missing
 
 
 def build_mini_installer(ctx: Context) -> bool:

--- a/packages/browseros/build/modules/sign/windows_test.py
+++ b/packages/browseros/build/modules/sign/windows_test.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Tests for Windows signing path discovery."""
+
+import unittest
+from pathlib import Path
+
+from .windows import get_browseros_server_binary_paths
+
+
+class WindowsSignPathsTest(unittest.TestCase):
+    def test_browseros_and_claw_server_binaries_are_expected_for_signing(self):
+        build_output_dir = Path("/tmp/out/Default")
+
+        self.assertEqual(
+            get_browseros_server_binary_paths(build_output_dir),
+            [
+                build_output_dir
+                / "BrowserOSServer"
+                / "default"
+                / "resources"
+                / "bin"
+                / "browseros_server.exe",
+                build_output_dir
+                / "BrowserOSClawServer"
+                / "default"
+                / "resources"
+                / "bin"
+                / "browseros-claw-server.exe",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/build/modules/sign/windows_test.py
+++ b/packages/browseros/build/modules/sign/windows_test.py
@@ -2,9 +2,16 @@
 """Tests for Windows signing path discovery."""
 
 import unittest
+from tempfile import TemporaryDirectory
 from pathlib import Path
+from unittest import mock
 
-from .windows import get_browseros_server_binary_paths
+from .windows import (
+    WindowsSignModule,
+    get_browseros_server_binary_paths,
+    get_existing_browseros_server_binary_paths,
+    get_missing_required_browseros_server_binary_paths,
+)
 
 
 class WindowsSignPathsTest(unittest.TestCase):
@@ -28,6 +35,77 @@ class WindowsSignPathsTest(unittest.TestCase):
                 / "browseros-claw-server.exe",
             ],
         )
+
+    def test_missing_optional_claw_binary_is_not_required_before_packaging(self):
+        with TemporaryDirectory() as tmp:
+            build_output_dir = Path(tmp)
+            self._write_binary(
+                build_output_dir
+                / "BrowserOSServer"
+                / "default"
+                / "resources"
+                / "bin"
+                / "browseros_server.exe"
+            )
+
+            self.assertEqual(
+                get_existing_browseros_server_binary_paths(build_output_dir),
+                [
+                    build_output_dir
+                    / "BrowserOSServer"
+                    / "default"
+                    / "resources"
+                    / "bin"
+                    / "browseros_server.exe"
+                ],
+            )
+            self.assertEqual(
+                get_missing_required_browseros_server_binary_paths(build_output_dir),
+                [],
+            )
+
+    def test_missing_claw_binary_is_required_once_root_is_packaged(self):
+        with TemporaryDirectory() as tmp:
+            build_output_dir = Path(tmp)
+            self._write_binary(
+                build_output_dir
+                / "BrowserOSServer"
+                / "default"
+                / "resources"
+                / "bin"
+                / "browseros_server.exe"
+            )
+            (
+                build_output_dir
+                / "BrowserOSClawServer"
+                / "default"
+                / "resources"
+                / "bin"
+            ).mkdir(parents=True)
+
+            self.assertEqual(
+                get_missing_required_browseros_server_binary_paths(build_output_dir),
+                [
+                    build_output_dir
+                    / "BrowserOSClawServer"
+                    / "default"
+                    / "resources"
+                    / "bin"
+                    / "browseros-claw-server.exe"
+                ],
+            )
+
+    def test_sign_executables_fails_when_required_server_binary_missing(self):
+        with TemporaryDirectory() as tmp:
+            build_output_dir = Path(tmp)
+            self._write_binary(build_output_dir / "chrome.exe")
+
+            with self.assertRaisesRegex(RuntimeError, "browseros_server.exe"):
+                WindowsSignModule()._sign_executables(build_output_dir, mock.Mock())
+
+    def _write_binary(self, path: Path) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_bytes(b"binary")
 
 
 if __name__ == "__main__":

--- a/packages/browseros/build/modules/storage/download_test.py
+++ b/packages/browseros/build/modules/storage/download_test.py
@@ -9,9 +9,13 @@ import tempfile
 import unittest
 import zipfile
 from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
 
+import yaml
 from build.modules.storage.download import (
     ARTIFACT_METADATA_NAME,
+    DownloadResourcesModule,
     extract_artifact_zip,
 )
 
@@ -189,6 +193,132 @@ class ExtractArtifactZipTest(unittest.TestCase):
                 for relative_path, content in files.items()
             ],
         }
+
+
+class DownloadResourceConfigTest(unittest.TestCase):
+    def test_real_config_includes_browseros_and_claw_artifacts_by_target(self) -> None:
+        cases = [
+            (
+                "macos",
+                "arm64",
+                [
+                    (
+                        "BrowserOS Server Resources - macOS ARM64",
+                        "artifacts/server/latest/browseros-server-resources-darwin-arm64.zip",
+                        "resources/binaries/browseros_server/darwin-arm64",
+                    ),
+                    (
+                        "BrowserOS Claw Server Resources - macOS ARM64",
+                        "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-arm64.zip",
+                        "resources/binaries/browseros_claw_server/darwin-arm64",
+                    ),
+                ],
+            ),
+            (
+                "macos",
+                "x64",
+                [
+                    (
+                        "BrowserOS Server Resources - macOS x64",
+                        "artifacts/server/latest/browseros-server-resources-darwin-x64.zip",
+                        "resources/binaries/browseros_server/darwin-x64",
+                    ),
+                    (
+                        "BrowserOS Claw Server Resources - macOS x64",
+                        "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-x64.zip",
+                        "resources/binaries/browseros_claw_server/darwin-x64",
+                    ),
+                ],
+            ),
+            (
+                "linux",
+                "arm64",
+                [
+                    (
+                        "BrowserOS Server Resources - Linux ARM64",
+                        "artifacts/server/latest/browseros-server-resources-linux-arm64.zip",
+                        "resources/binaries/browseros_server/linux-arm64",
+                    ),
+                    (
+                        "BrowserOS Claw Server Resources - Linux ARM64",
+                        "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-arm64.zip",
+                        "resources/binaries/browseros_claw_server/linux-arm64",
+                    ),
+                ],
+            ),
+            (
+                "linux",
+                "x64",
+                [
+                    (
+                        "BrowserOS Server Resources - Linux x64",
+                        "artifacts/server/latest/browseros-server-resources-linux-x64.zip",
+                        "resources/binaries/browseros_server/linux-x64",
+                    ),
+                    (
+                        "BrowserOS Claw Server Resources - Linux x64",
+                        "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-x64.zip",
+                        "resources/binaries/browseros_claw_server/linux-x64",
+                    ),
+                ],
+            ),
+            (
+                "windows",
+                "x64",
+                [
+                    (
+                        "BrowserOS Server Resources - Windows x64",
+                        "artifacts/server/latest/browseros-server-resources-windows-x64.zip",
+                        "resources/binaries/browseros_server/windows-x64",
+                    ),
+                    (
+                        "BrowserOS Claw Server Resources - Windows x64",
+                        "claw-server/prod-resources/latest/browseros-claw-server-resources-windows-x64.zip",
+                        "resources/binaries/browseros_claw_server/windows-x64",
+                    ),
+                ],
+            ),
+        ]
+        operations = self._real_download_operations()
+
+        for platform, arch, expected in cases:
+            with self.subTest(platform=platform, arch=arch):
+                filtered = self._filter_operations(operations, platform, arch)
+                actual = [
+                    (op["name"], op["r2_key"], op["destination"])
+                    for op in filtered
+                    if "Server Resources" in op["name"]
+                ]
+                self.assertEqual(expected, actual)
+
+    def test_real_config_includes_both_macos_arches_for_universal(self) -> None:
+        operations = self._real_download_operations()
+
+        filtered = self._filter_operations(operations, "macos", "universal")
+
+        self.assertEqual(
+            [
+                "BrowserOS Server Resources - macOS ARM64",
+                "BrowserOS Server Resources - macOS x64",
+                "BrowserOS Claw Server Resources - macOS ARM64",
+                "BrowserOS Claw Server Resources - macOS x64",
+            ],
+            [op["name"] for op in filtered],
+        )
+
+    def _real_download_operations(self) -> list[dict]:
+        config_path = (
+            Path(__file__).resolve().parents[2] / "config" / "download_resources.yaml"
+        )
+        with open(config_path, "r") as f:
+            return yaml.safe_load(f)["download_operations"]
+
+    def _filter_operations(
+        self, operations: list[dict], platform: str, architecture: str
+    ) -> list[dict]:
+        ctx = SimpleNamespace(architecture=architecture, build_type="release")
+        with patch("build.modules.storage.download.get_platform", return_value=platform):
+            return DownloadResourcesModule()._filter_operations(operations, ctx)
 
 
 if __name__ == "__main__":

--- a/updates/extensions/bundled-manifest.xml
+++ b/updates/extensions/bundled-manifest.xml
@@ -6,4 +6,7 @@
   <app appid="bflpfmnmnokmjhmgnolecpppdbdophmk">
     <updatecheck codebase="https://cdn.browseros.com/extensions/agent-0.0.115.0.crx" version="0.0.115.0"/>
   </app>
+  <app appid="pjimfkbpehlcllblajnpfamdfjhhlgkc">
+    <updatecheck codebase="https://cdn.browseros.com/extensions/browserclaw-0.0.1.crx" version="0.0.1"/>
+  </app>
 </gupdate>


### PR DESCRIPTION
## Summary
- Adds BrowserOS Claw server resource downloads for macOS, Linux, and Windows alongside the existing BrowserOS server resources.
- Stages Claw server resources under a separate Chromium source root and generalizes bundled-server signing metadata for BrowserOS Server plus BrowserOS Claw Server.
- Requires the BrowserOS Claw app in the bundled extension manifest path, while preserving the existing BrowserOS agent and bug reporter entries.

## Design
This keeps the shipped product as BrowserOS and adds Claw as additive runtime payloads. BrowserOS server packaging remains intact. Claw server resources use their own local, Chromium staging, and app-bundle resource roots. Signing now discovers bundled server binaries through shared metadata, and Linux packaging preserves the Claw bundle root when Chromium output contains it. Chromium/GN source-list work remains a separate follow-up per the selected plan.

## Test plan
- [x] cd packages/browseros && uv run python -m unittest build.modules.storage.download_test build.modules.resources.resources_test build.common.server_binaries_test build.modules.sign.macos_test build.modules.sign.windows_test build.modules.extensions.bundled_extensions_test build.common.release_configs_test build.modules.package.linux_test
- [x] cd packages/browseros && uv run ruff check build/modules/storage/download_test.py build/modules/resources/resources_test.py build/common/server_binaries.py build/common/server_binaries_test.py build/modules/sign/macos.py build/modules/sign/macos_test.py build/modules/sign/windows.py build/modules/sign/windows_test.py build/modules/extensions/bundled_extensions.py build/modules/extensions/bundled_extensions_test.py build/common/release_configs_test.py build/modules/package/linux.py build/modules/package/linux_test.py