### PR TITLE
fix: add claude desktop mcp wrapper setup

### DIFF
--- a/docs/features/use-with-claude-code.mdx
+++ b/docs/features/use-with-claude-code.mdx
@@ -113,13 +113,17 @@ Wondering how BrowserOS MCP compares to Chrome DevTools MCP or other browser aut
     ```json
     {
       "mcpServers": {
-        "browserOS": {
+        "browseros": {
           "command": "npx",
           "args": ["mcp-remote", "http://127.0.0.1:9239/mcp"]
         }
       }
     }
     ```
+
+    <Warning>
+    Do not add BrowserOS to `claude_desktop_config.json` as a raw `{ "url": "..." }` entry. Claude Desktop local config expects a command wrapper here, so use `npx mcp-remote <mcp_url>`.
+    </Warning>
 
     Restart Claude Desktop to connect.
   </Tab>

--- a/packages/browseros-agent/.config/wt.toml
+++ b/packages/browseros-agent/.config/wt.toml
@@ -3,7 +3,7 @@ install = "bun install"
 # env-server = "cp {{ repo_root }}/apps/server/.env.development apps/server/.env.development"
 # env-agent = "cp {{ repo_root }}/apps/app/.env.development apps/app/.env.development"
 env = "for f in {{ repo_root }}/apps/*/.env.*; do [ -f \"$f\" ] && cp \"$f\" \"${f#{{ repo_root }}/}\"; done 2>/dev/null || true"
-llm = "cp -r {{ repo_root }}/.llm . 2>/dev/null || true"
-
-[pre-remove]
-llm-sync = "rsync -au .llm/ {{ repo_root }}/.llm/ 2>/dev/null || true"
+# Trust the worktree (skip the agent first-run trust prompt) and link ./.llm into
+# the shared home archive — in a worktree dotllm init mirrors the main checkout's .llm.
+trust = "dotllm trust -q || true"
+llm = "dotllm init -q || true"

--- a/packages/browseros-agent/apps/app/screens/mcp-settings/QuickSetupSection.test.tsx
+++ b/packages/browseros-agent/apps/app/screens/mcp-settings/QuickSetupSection.test.tsx
@@ -1,0 +1,74 @@
+import { beforeAll, describe, expect, it, mock } from 'bun:test'
+import { type ComponentProps, createElement, type FC } from 'react'
+import { renderToStaticMarkup } from 'react-dom/server'
+
+type MockButtonProps = ComponentProps<'button'> & {
+  variant?: string
+  size?: string
+}
+
+type TabsProps = ComponentProps<'div'> & {
+  defaultValue?: string
+  value?: string
+}
+
+mock.module('@/components/ui/button', () => ({
+  Button: ({
+    children,
+    variant: _variant,
+    size: _size,
+    ...props
+  }: MockButtonProps) =>
+    createElement('button', { type: 'button', ...props }, children),
+}))
+
+mock.module('@/components/ui/tabs', () => ({
+  Tabs: ({ children, defaultValue: _defaultValue, ...props }: TabsProps) =>
+    createElement('div', props, children),
+  TabsContent: ({ children, value: _value, ...props }: TabsProps) =>
+    createElement('div', props, children),
+  TabsList: ({ children, ...props }: ComponentProps<'div'>) =>
+    createElement('div', props, children),
+  TabsTrigger: ({ children, value: _value, ...props }: TabsProps) =>
+    createElement('button', { type: 'button', ...props }, children),
+}))
+
+let QuickSetupSection: FC<{ serverUrl: string | null }>
+
+beforeAll(async () => {
+  QuickSetupSection = (await import('./QuickSetupSection')).QuickSetupSection
+})
+
+function render(serverUrl = 'http://127.0.0.1:9200/mcp'): string {
+  return renderToStaticMarkup(createElement(QuickSetupSection, { serverUrl }))
+}
+
+describe('QuickSetupSection', () => {
+  it('renders Claude Code setup with the served MCP URL', () => {
+    const html = render()
+
+    expect(html).toContain(
+      'claude mcp add --transport http browseros http://127.0.0.1:9200/mcp --scope user',
+    )
+  })
+
+  it('renders Claude Desktop setup as an mcp-remote command wrapper', () => {
+    const html = render()
+
+    expect(html).toContain('Claude Desktop')
+    expect(html).toContain('Add this block to')
+    expect(html).toContain('claude_desktop_config.json')
+    expect(html).toContain('&quot;command&quot;: &quot;npx&quot;')
+    expect(html).toContain('&quot;mcp-remote&quot;')
+    expect(html).toContain('http://127.0.0.1:9200/mcp')
+
+    const commandIndex = html.indexOf('&quot;command&quot;: &quot;npx&quot;')
+    const desktopSnippet = html.slice(
+      commandIndex,
+      html.indexOf('Copy Claude Desktop setup', commandIndex),
+    )
+    expect(desktopSnippet).not.toContain(
+      '&quot;url&quot;: &quot;http://127.0.0.1:9200/mcp&quot;',
+    )
+  })
+})

--- a/packages/browseros-agent/apps/app/screens/mcp-settings/QuickSetupSection.tsx
+++ b/packages/browseros-agent/apps/app/screens/mcp-settings/QuickSetupSection.tsx
@@ -55,6 +55,33 @@ const clients: ClientConfig[] = [
       `claude mcp add --transport http browseros ${url} --scope user`,
   },
   {
+    id: 'claude-desktop',
+    name: 'Claude Desktop',
+    kind: 'config',
+    action: (
+      <>
+        Add this block to{' '}
+        <code className="rounded bg-muted px-1 py-0.5 font-mono text-[11px]">
+          claude_desktop_config.json
+        </code>
+        .
+      </>
+    ),
+    getSnippet: (url) =>
+      JSON.stringify(
+        {
+          mcpServers: {
+            browseros: {
+              command: 'npx',
+              args: ['mcp-remote', url],
+            },
+          },
+        },
+        null,
+        2,
+      ),
+  },
+  {
     id: 'codex',
     name: 'Codex',
     kind: 'command',
@@ -103,8 +130,8 @@ export const QuickSetupSection: FC<QuickSetupSectionProps> = ({
       <div>
         <h3 className="font-semibold text-sm">Manual setup</h3>
         <p className="text-muted-foreground text-xs">
-          Use the snippet for your agent, or paste the URL into any MCP-capable
-          client.
+          Use the snippet for your agent, or use the Server URL with clients
+          that support URL-based MCP config.
         </p>
       </div>
 

--- a/packages/browseros-agent/apps/claw-server/tests/services/browseros-connect.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/browseros-connect.test.ts
@@ -35,7 +35,7 @@ describe('connectBrowserosToHarness', () => {
     }
     expect(addPayload.name).toBe('browseros')
     expect(addPayload.spec.transport).toBe('http')
-    expect(addPayload.spec.url).toContain('/mcp')
+    expect(addPayload.spec.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp$/)
     expect(addPayload.spec.url).not.toContain('/cockpit')
     const link = stub.calls.find((c) => c.method === 'link')
     expect(link).toBeDefined()
@@ -51,7 +51,7 @@ describe('connectBrowserosToHarness', () => {
       spec: { transport: string; url?: string }
     }
     expect(payload.spec.transport).toBe('http')
-    expect(payload.spec.url).toContain('/mcp')
+    expect(payload.spec.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp$/)
     expect(payload.spec.url).not.toContain('/cockpit')
   })
 

--- a/packages/browseros-agent/apps/server/src/lib/mcp-manager/reconcile.ts
+++ b/packages/browseros-agent/apps/server/src/lib/mcp-manager/reconcile.ts
@@ -35,7 +35,7 @@ import {
 import type { McpAgentId, ReconcileResult } from './types'
 
 export interface ReconcileUrlInput {
-  /** The MCP URL the running server bound to, e.g. http://127.0.0.1:9100/mcp */
+  /** The client-facing MCP URL, e.g. http://127.0.0.1:9100/mcp */
   currentUrl: string
 }
 

--- a/packages/browseros-agent/apps/server/src/lib/mcp-manager/service.ts
+++ b/packages/browseros-agent/apps/server/src/lib/mcp-manager/service.ts
@@ -51,10 +51,10 @@ export type DetectInstalledAgentsFn = () => Promise<AgentInfo[]>
  * it), the row stays visible so they can still hit Disconnect to
  * clean it up. Once the link is removed the next refresh hides it.
  * Gemini users can still re-install via the manual setup snippet on
- * the same page (the generic HTTP block fits). There is no manual
- * fallback for Claude Desktop today because its config parser
- * rejects HTTP-shaped entries; restoring that path needs a bundled
- * stdio bridge.
+ * the same page (the generic HTTP block fits). Claude Desktop users
+ * can also copy the manual `mcp-remote` wrapper, but it remains
+ * hidden from one-click install until BrowserOS can provide a
+ * bundled-runtime path instead of assuming `npx` is available.
  */
 const HIDDEN_AGENTS: ReadonlySet<string> = new Set(['gemini', 'claude-desktop'])
 


### PR DESCRIPTION
## Summary
- add a Claude Desktop manual setup snippet that uses `npx mcp-remote <mcp_url>` instead of a raw `url` entry in `claude_desktop_config.json`
- clarify docs to warn against raw `{ "url": "..." }` Desktop config and keep the BrowserOS server name lowercase
- keep BrowserOS local MCP URLs as served HTTP, while tightening tests so generated Claude Code/Codex URLs remain `http://127.0.0.1:<port>/mcp`

## Investigation
- The screenshot failure path was a raw `mcpServers.browseros.url` entry in `claude_desktop_config.json`; Claude Desktop skipped it as an invalid local MCP server config.
- Anthropic Claude Code docs document HTTP MCP transport (`claude mcp add --transport http ...`) and JSON `type: "http"`, and a live local Claude Code check accepted `http://127.0.0.1:9200/mcp`.
- Anthropic remote connector docs are for cloud/account connectors that must be publicly reachable; that is separate from local Desktop config. BrowserOS currently serves local MCP over plain HTTP, so rewriting generated localhost URLs to HTTPS would make clients attempt TLS against a non-TLS server.

## Validation
- `bun test apps/app/screens/mcp-settings/QuickSetupSection.test.tsx apps/claw-server/tests/services/browseros-connect.test.ts apps/server/tests/lib/mcp-manager/reconcile.test.ts apps/server/tests/lib/mcp-manager/service.test.ts`
- `bunx @biomejs/biome check apps/app/screens/mcp-settings/QuickSetupSection.tsx apps/app/screens/mcp-settings/QuickSetupSection.test.tsx apps/claw-server/tests/services/browseros-connect.test.ts apps/server/src/lib/mcp-manager/reconcile.ts apps/server/src/lib/mcp-manager/service.ts`
- `git diff --check`

## Notes
- A broader `bun run test` was also attempted locally; the top-level command still exits under local Bun 1.2.17 on an existing `mock.clearAllMocks` incompatibility in `apps/server/tests/main.test.ts`.