### PR TITLE
fix: resolve server release tag paths

### DIFF
--- a/packages/browseros-agent/scripts/release/resolve-component-release.sh
+++ b/packages/browseros-agent/scripts/release/resolve-component-release.sh
@@ -134,12 +134,53 @@ fi
 
 release_sha="$(git rev-list -n 1 "$tag")"
 
+git_root="$(git rev-parse --show-toplevel)"
+git_root="$(cd "$git_root" && pwd -P)"
+current_dir="$(pwd -P)"
+git_package_json="$package_json"
+browseros_agent_package_json="packages/browseros-agent/$package_json"
+
+# Git object paths are repository-root-relative, but release jobs run from the package checkout.
+case "$current_dir" in
+  "$git_root")
+    ;;
+  "$git_root"/*)
+    git_package_json="${current_dir#"$git_root"/}/$package_json"
+    ;;
+esac
+
+git_package_json_candidates=("$git_package_json")
+if [ "$git_package_json" != "$package_json" ]; then
+  git_package_json_candidates+=("$package_json")
+fi
+if [ "$git_package_json" != "$browseros_agent_package_json" ]; then
+  git_package_json_candidates+=("$browseros_agent_package_json")
+fi
+
+found_package_blob=false
+for candidate in "${git_package_json_candidates[@]}"; do
+  if package_blob="$(git show "$release_sha:$candidate" 2>/dev/null)"; then
+    git_package_json="$candidate"
+    found_package_blob=true
+    break
+  fi
+done
+
+if [ "$found_package_blob" != "true" ]; then
+  echo "Could not read $package_json version from $tag ($release_sha)" >&2
+  exit 1
+fi
+
 if ! package_version="$(
-  git show "$release_sha:$package_json" 2>/dev/null | python3 -c '
+  printf '%s\n' "$package_blob" | python3 -c '
 import json
 import sys
 
-print(json.load(sys.stdin)["version"])
+try:
+    print(json.load(sys.stdin)["version"])
+except Exception as exc:
+    print(f"{type(exc).__name__}: {exc}", file=sys.stderr)
+    sys.exit(1)
 '
 )"; then
   echo "Could not read $package_json version from $tag ($release_sha)" >&2

--- a/packages/browseros-agent/scripts/release/resolve-component-release.test.ts
+++ b/packages/browseros-agent/scripts/release/resolve-component-release.test.ts
@@ -86,6 +86,31 @@ function writePackage(
   )
 }
 
+function writeNestedPackage(
+  dir: string,
+  component: Component,
+  version: string,
+): string {
+  const packageDir = join(dir, 'packages/browseros-agent')
+  const path = join(packageDir, packagePath(component))
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(
+    path,
+    JSON.stringify(
+      {
+        name:
+          component === 'agent-extension'
+            ? '@browseros/app'
+            : '@browseros/server',
+        version,
+      },
+      null,
+      2,
+    ),
+  )
+  return packageDir
+}
+
 async function commitVersion(
   dir: string,
   component: Component,
@@ -187,6 +212,38 @@ describe('resolve-component-release', () => {
       expect(parseOutput(result.stdout)).toMatchObject({
         version: '0.0.122',
         previous_tag: legacyTag('agent-server', '0.0.121'),
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('resolves a server slash tag from a nested browseros-agent checkout', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'component-release-nested-'))
+    try {
+      await mustRun(dir, ['git', 'init', '--initial-branch=main'])
+      await mustRun(dir, ['git', 'config', 'user.name', 'BrowserOS Test'])
+      await mustRun(dir, ['git', 'config', 'user.email', 'test@browseros.com'])
+      const packageDir = writeNestedPackage(dir, 'agent-server', '0.0.122')
+      await mustRun(dir, ['git', 'add', '.'])
+      await mustRun(dir, ['git', 'commit', '-m', 'version 0.0.122'])
+      const currentTag = scopedTag('agent-server', '0.0.122')
+      await tag(dir, currentTag)
+      const releaseSha = (
+        await mustRun(dir, ['git', 'rev-parse', 'HEAD'])
+      ).trim()
+
+      const result = await resolveRelease(
+        packageDir,
+        'agent-server',
+        currentTag,
+      )
+
+      expect(result.code, result.stderr).toBe(0)
+      expect(parseOutput(result.stdout)).toMatchObject({
+        package_version: '0.0.122',
+        tag: currentTag,
+        release_sha: releaseSha,
       })
     } finally {
       rmSync(dir, { recursive: true, force: true })


### PR DESCRIPTION
## Summary
- Fix `resolve-component-release.sh` to read tagged package JSON paths relative to the Git repository root when release jobs run from `packages/browseros-agent`.
- Preserve standalone fixture compatibility by trying the package-local path and the canonical BrowserOS nested path.
- Add a nested BrowserOS layout test that reproduces the `agent-server/v0.0.122` release failure shape.

## Design
The resolver keeps component-local paths for messages and existing package-root behavior, but derives candidate Git object paths before `git show`. This prevents the tag-triggered workflow from asking Git for `apps/server/package.json` at repo root when the real tagged file is `packages/browseros-agent/apps/server/package.json`.

## Test plan
- [x] `bun test scripts/release/resolve-component-release.test.ts`
- [x] `./packages/browseros-agent/scripts/release/resolve-component-release.sh --component agent-server --tag agent-server/v0.0.122 --default-branch main`
- [x] `./scripts/release/resolve-component-release.sh --component agent-server --tag agent-server/v0.0.122 --default-branch main`
- [x] `git diff --check`
- [x] `bun run check`
- [x] `bun run test`