### PR TITLE
fix: repair server tag version releases

### DIFF
--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -74,6 +74,7 @@ jobs:
     needs: authorize_manual_dispatch
     if: |
       always() &&
+      github.event.deleted != true &&
       (github.event_name != 'workflow_dispatch' || needs.authorize_manual_dispatch.result == 'success')
     runs-on: ubuntu-latest
     outputs:
@@ -140,15 +141,15 @@ jobs:
             local version="$1"
             cat >> "$GITHUB_STEP_SUMMARY" <<EOF
           Maintainer release flow:
-          1. Bump packages/browseros-agent/apps/server/package.json in a PR and merge it.
+          1. Preferred: bump packages/browseros-agent/apps/server/package.json in a PR and merge it.
           2. git tag -a agent-server/v${version} -m "agent-server v${version}"
           3. git push origin agent-server/v${version}
+          4. If the tag points at the current default-branch tip but the package version lags, this workflow commits the bump and retags before release.
           EOF
           }
 
           if [ "$EVENT_NAME" = "push" ]; then
-            ./scripts/release/resolve-component-release.sh \
-              --component agent-server \
+            ./scripts/release/prepare-server-tag-release.sh \
               --tag "$RELEASE_TAG" \
               --default-branch "$DEFAULT_BRANCH"
             write_release_flow_summary "${RELEASE_TAG#agent-server/v}"

--- a/packages/browseros-agent/apps/server/README.md
+++ b/packages/browseros-agent/apps/server/README.md
@@ -153,14 +153,16 @@ bun scripts/build/server.ts --target=all --no-upload
 
 ## Release Flow
 
-Server releases use annotated component tags. First bump `packages/browseros-agent/apps/server/package.json` in a PR, merge that version commit to the default branch, then tag the merged commit:
+Server releases use annotated component tags. The preferred flow is to bump `packages/browseros-agent/apps/server/package.json` in a PR, merge that version commit to the default branch, then tag the merged commit:
 
 ```bash
 git tag -a agent-server/v0.0.122 -m "agent-server v0.0.122"
 git push origin agent-server/v0.0.122
 ```
 
-The release workflow validates that the tag version matches `apps/server/package.json`, that the tagged commit is reachable from the default branch, and that the version is newer than existing `browseros-server-v*` and `agent-server/v*` tags. Legacy `browseros-server-vX.Y.Z` tags remain historical; new GitHub Releases use `agent-server/vX.Y.Z`.
+For tag-first releases, you may push `agent-server/vX.Y.Z` at the current default-branch tip before the package bump. If `apps/server/package.json` still has the previous version, the workflow sets `apps/server/package.json` and `bun.lock` to `X.Y.Z`, commits that bump to the default branch, recreates the annotated tag on the bump commit, and releases from that matching commit. Auto-bump is refused when the tag points at an older default-branch commit; in that case, bump in a PR and tag the merged commit.
+
+The release workflow validates that the tag version matches `apps/server/package.json` before publishing, that the tagged commit is reachable from the default branch, and that the version is newer than existing `browseros-server-v*` and `agent-server/v*` tags. Legacy `browseros-server-vX.Y.Z` tags remain historical; new GitHub Releases use `agent-server/vX.Y.Z`.
 
 The workflow-call and nightly paths can still build/upload server artifacts without publishing a GitHub Release by setting `publish_github_release=false`; that preserves the existing `bump_server_version.py` flow for target-specific builds.
 

--- a/packages/browseros-agent/scripts/release/prepare-server-tag-release.sh
+++ b/packages/browseros-agent/scripts/release/prepare-server-tag-release.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: prepare-server-tag-release.sh --tag <agent-server/vX.Y.Z> --default-branch <branch> [--agent-root <path>] [--bump-script <path>] [--remote <name>]
+EOF
+}
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+agent_root="$(cd "$script_dir/../.." && pwd -P)"
+bump_script="$agent_root/../browseros/build/scripts/bump_server_version.py"
+tag=""
+default_branch=""
+remote="origin"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --tag)
+      tag="${2:-}"
+      shift 2
+      ;;
+    --default-branch)
+      default_branch="${2:-}"
+      shift 2
+      ;;
+    --agent-root)
+      agent_root="$(cd "${2:-}" && pwd -P)"
+      shift 2
+      ;;
+    --bump-script)
+      bump_script="$(cd "$(dirname "${2:-}")" && pwd -P)/$(basename "${2:-}")"
+      shift 2
+      ;;
+    --remote)
+      remote="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$tag" ] || [ -z "$default_branch" ]; then
+  usage
+  exit 2
+fi
+
+resolver="$script_dir/resolve-component-release.sh"
+
+# Runs the component resolver from the package root so path detection matches Actions.
+run_resolver() {
+  (
+    cd "$agent_root"
+    "$resolver" \
+      --component agent-server \
+      --tag "$tag" \
+      --default-branch "$default_branch" \
+      "$@"
+  )
+}
+
+# Extracts the resolver fields needed before deciding whether a tag repair is allowed.
+parse_release_output() {
+  while IFS='=' read -r key value; do
+    [ -n "$key" ] || continue
+    case "$key" in
+      version) version="$value" ;;
+      package_version) package_version="$value" ;;
+      package_version_matches) package_version_matches="$value" ;;
+      release_sha) release_sha="$value" ;;
+    esac
+  done <<< "$1"
+}
+
+# Seeds the Actions bot identity when the checkout has no commit author configured.
+ensure_git_identity() {
+  if ! git -C "$agent_root" config user.name >/dev/null; then
+    git -C "$agent_root" config user.name "github-actions[bot]"
+  fi
+  if ! git -C "$agent_root" config user.email >/dev/null; then
+    git -C "$agent_root" config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  fi
+}
+
+preflight_output="$(unset GITHUB_OUTPUT; run_resolver --allow-package-version-mismatch)"
+
+version=""
+package_version=""
+package_version_matches=""
+release_sha=""
+parse_release_output "$preflight_output"
+
+if [ "$package_version_matches" = "true" ]; then
+  run_resolver
+  exit 0
+fi
+
+git -C "$agent_root" fetch "$remote" "$default_branch:refs/remotes/$remote/$default_branch" --no-tags
+default_sha="$(git -C "$agent_root" rev-parse "$remote/$default_branch")"
+
+if [ "$release_sha" != "$default_sha" ]; then
+  echo "Auto-bump requires $tag to point at current $remote/$default_branch ($default_sha), got $release_sha" >&2
+  exit 1
+fi
+
+ensure_git_identity
+
+git -C "$agent_root" switch -C "$default_branch" "$remote/$default_branch"
+python3 "$bump_script" --agent-root "$agent_root" --set "$version" >/dev/null
+
+if git -C "$agent_root" diff --quiet -- apps/server/package.json bun.lock; then
+  echo "No server version changes produced for $tag" >&2
+  exit 1
+fi
+
+git -C "$agent_root" add apps/server/package.json bun.lock
+git -C "$agent_root" commit -m "chore: bump server version to $version"
+git -C "$agent_root" push "$remote" "HEAD:refs/heads/$default_branch"
+
+git -C "$agent_root" tag -d "$tag" >/dev/null
+git -C "$agent_root" push "$remote" ":refs/tags/$tag"
+git -C "$agent_root" tag -a "$tag" -m "agent-server v$version"
+git -C "$agent_root" push "$remote" "$tag"
+git -C "$agent_root" fetch "$remote" "$default_branch:refs/remotes/$remote/$default_branch" --no-tags
+
+run_resolver

--- a/packages/browseros-agent/scripts/release/prepare-server-tag-release.sh
+++ b/packages/browseros-agent/scripts/release/prepare-server-tag-release.sh
@@ -149,12 +149,10 @@ fi
 
 git -C "$agent_root" add apps/server/package.json bun.lock
 git -C "$agent_root" commit -m "chore: bump server version to $version"
-git -C "$agent_root" push "$remote" "HEAD:refs/heads/$default_branch"
-
-git -C "$agent_root" tag -d "$tag" >/dev/null
-git -C "$agent_root" push "$remote" ":refs/tags/$tag"
-git -C "$agent_root" tag -a "$tag" -m "agent-server v$version"
-git -C "$agent_root" push "$remote" "$tag"
+git -C "$agent_root" tag -f -a "$tag" -m "agent-server v$version"
+git -C "$agent_root" push --atomic "$remote" \
+  "HEAD:refs/heads/$default_branch" \
+  "+refs/tags/$tag:refs/tags/$tag"
 git -C "$agent_root" fetch "$remote" "$default_branch:refs/remotes/$remote/$default_branch" --no-tags
 
 run_resolver

--- a/packages/browseros-agent/scripts/release/prepare-server-tag-release.sh
+++ b/packages/browseros-agent/scripts/release/prepare-server-tag-release.sh
@@ -90,6 +90,27 @@ ensure_git_identity() {
   fi
 }
 
+# Compares strict release versions before allowing the workflow to edit package files.
+version_gt() {
+  local left_major left_minor left_patch right_major right_minor right_patch
+  IFS=. read -r left_major left_minor left_patch <<< "$1"
+  IFS=. read -r right_major right_minor right_patch <<< "$2"
+
+  for part in "$left_major" "$left_minor" "$left_patch" "$right_major" "$right_minor" "$right_patch"; do
+    [[ "$part" =~ ^[0-9]+$ ]] || return 1
+  done
+
+  if [ "$left_major" -ne "$right_major" ]; then
+    [ "$left_major" -gt "$right_major" ]
+    return
+  fi
+  if [ "$left_minor" -ne "$right_minor" ]; then
+    [ "$left_minor" -gt "$right_minor" ]
+    return
+  fi
+  [ "$left_patch" -gt "$right_patch" ]
+}
+
 preflight_output="$(unset GITHUB_OUTPUT; run_resolver --allow-package-version-mismatch)"
 
 version=""
@@ -101,6 +122,11 @@ parse_release_output "$preflight_output"
 if [ "$package_version_matches" = "true" ]; then
   run_resolver
   exit 0
+fi
+
+if ! version_gt "$version" "$package_version"; then
+  echo "Auto-bump requires tag version $version to be greater than package version $package_version" >&2
+  exit 1
 fi
 
 git -C "$agent_root" fetch "$remote" "$default_branch:refs/remotes/$remote/$default_branch" --no-tags

--- a/packages/browseros-agent/scripts/release/resolve-component-release.sh
+++ b/packages/browseros-agent/scripts/release/resolve-component-release.sh
@@ -3,13 +3,14 @@ set -euo pipefail
 
 usage() {
   cat >&2 <<'EOF'
-Usage: resolve-component-release.sh --component agent-extension|agent-server --tag <tag> --default-branch <branch>
+Usage: resolve-component-release.sh --component agent-extension|agent-server --tag <tag> --default-branch <branch> [--allow-package-version-mismatch]
 EOF
 }
 
 component=""
 tag=""
 default_branch=""
+allow_package_version_mismatch=false
 
 while [ "$#" -gt 0 ]; do
   case "$1" in
@@ -24,6 +25,10 @@ while [ "$#" -gt 0 ]; do
     --default-branch)
       default_branch="${2:-}"
       shift 2
+      ;;
+    --allow-package-version-mismatch)
+      allow_package_version_mismatch=true
+      shift
       ;;
     -h|--help)
       usage
@@ -187,9 +192,13 @@ except Exception as exc:
   exit 1
 fi
 
+package_version_matches=true
 if [ "$package_version" != "$tag_version" ]; then
-  echo "Tag version $tag_version does not match $package_json version $package_version" >&2
-  exit 1
+  package_version_matches=false
+  if [ "$allow_package_version_mismatch" != "true" ]; then
+    echo "Tag version $tag_version does not match $package_json version $package_version" >&2
+    exit 1
+  fi
 fi
 
 default_ref=""
@@ -246,6 +255,7 @@ fi
 
 emit version "$tag_version"
 emit package_version "$package_version"
+emit package_version_matches "$package_version_matches"
 emit tag "$tag"
 emit release_sha "$release_sha"
 emit previous_tag "$latest_tag"

--- a/packages/browseros-agent/scripts/release/resolve-component-release.test.ts
+++ b/packages/browseros-agent/scripts/release/resolve-component-release.test.ts
@@ -565,4 +565,36 @@ describe('resolve-component-release', () => {
       rmSync(bareDir, { recursive: true, force: true })
     }
   })
+
+  it('refuses to repair a server tag by downgrading the package version', async () => {
+    const dir = await initFixture('agent-server', '0.0.124')
+    const bareDir = mkdtempSync(join(tmpdir(), 'component-release-remote-'))
+    try {
+      writeServerLock(dir, '0.0.124')
+      await mustRun(dir, ['git', 'add', 'bun.lock'])
+      await mustRun(dir, ['git', 'commit', '-m', 'add server lock'])
+      await mustRun(bareDir, ['git', 'init', '--bare'])
+      await mustRun(dir, ['git', 'remote', 'add', 'origin', bareDir])
+      await mustRun(dir, ['git', 'push', '-u', 'origin', 'main'])
+
+      const currentTag = scopedTag('agent-server', '0.0.123')
+      await tag(dir, currentTag)
+      await mustRun(dir, ['git', 'push', 'origin', currentTag])
+
+      const result = await prepareServerTagRelease(dir, currentTag)
+
+      expect(result.code).toBe(1)
+      expect(result.stderr).toContain(
+        'Auto-bump requires tag version 0.0.123 to be greater than package version 0.0.124',
+      )
+      expect(
+        (
+          await mustRun(dir, ['git', 'show', 'HEAD:apps/server/package.json'])
+        ).trim(),
+      ).toContain('"version": "0.0.124"')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+      rmSync(bareDir, { recursive: true, force: true })
+    }
+  })
 })

--- a/packages/browseros-agent/scripts/release/resolve-component-release.test.ts
+++ b/packages/browseros-agent/scripts/release/resolve-component-release.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'bun:test'
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join, resolve } from 'node:path'
 
@@ -592,6 +598,71 @@ describe('resolve-component-release', () => {
           await mustRun(dir, ['git', 'show', 'HEAD:apps/server/package.json'])
         ).trim(),
       ).toContain('"version": "0.0.124"')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+      rmSync(bareDir, { recursive: true, force: true })
+    }
+  })
+
+  it('does not advance the default branch when the repaired tag push is rejected', async () => {
+    const dir = await initFixture('agent-server', '0.0.122')
+    const bareDir = mkdtempSync(join(tmpdir(), 'component-release-remote-'))
+    try {
+      writeServerLock(dir, '0.0.122')
+      await mustRun(dir, ['git', 'add', 'bun.lock'])
+      await mustRun(dir, ['git', 'commit', '-m', 'add server lock'])
+      await mustRun(bareDir, ['git', 'init', '--bare'])
+      await mustRun(dir, ['git', 'remote', 'add', 'origin', bareDir])
+      await mustRun(dir, ['git', 'push', '-u', 'origin', 'main'])
+
+      const oldSha = (await mustRun(dir, ['git', 'rev-parse', 'HEAD'])).trim()
+      const currentTag = scopedTag('agent-server', '0.0.123')
+      await tag(dir, currentTag)
+      await mustRun(dir, ['git', 'push', 'origin', currentTag])
+      const hook = join(bareDir, 'hooks', 'pre-receive')
+      writeFileSync(
+        hook,
+        [
+          '#!/usr/bin/env bash',
+          'while read -r _old _new ref; do',
+          `  if [ "$ref" = "refs/tags/${currentTag}" ]; then`,
+          '    echo "tag updates blocked" >&2',
+          '    exit 1',
+          '  fi',
+          'done',
+          '',
+        ].join('\n'),
+      )
+      chmodSync(hook, 0o755)
+
+      const result = await prepareServerTagRelease(dir, currentTag)
+
+      expect(result.code).toBe(1)
+      expect(result.stderr).toContain('tag updates blocked')
+      expect(
+        (
+          await mustRun(dir, [
+            'git',
+            '--git-dir',
+            bareDir,
+            'rev-parse',
+            'refs/heads/main',
+          ])
+        ).trim(),
+      ).toBe(oldSha)
+      expect(
+        (
+          await mustRun(dir, [
+            'git',
+            '--git-dir',
+            bareDir,
+            'rev-list',
+            '-n',
+            '1',
+            currentTag,
+          ])
+        ).trim(),
+      ).toBe(oldSha)
     } finally {
       rmSync(dir, { recursive: true, force: true })
       rmSync(bareDir, { recursive: true, force: true })

--- a/packages/browseros-agent/scripts/release/resolve-component-release.test.ts
+++ b/packages/browseros-agent/scripts/release/resolve-component-release.test.ts
@@ -5,6 +5,14 @@ import { dirname, join, resolve } from 'node:path'
 
 const repoRoot = resolve(import.meta.dir, '../..')
 const resolver = join(repoRoot, 'scripts/release/resolve-component-release.sh')
+const prepareServerRelease = join(
+  repoRoot,
+  'scripts/release/prepare-server-tag-release.sh',
+)
+const bumpServerVersion = join(
+  repoRoot,
+  '../browseros/build/scripts/bump_server_version.py',
+)
 
 type Component = 'agent-extension' | 'agent-server'
 
@@ -111,6 +119,25 @@ function writeNestedPackage(
   return packageDir
 }
 
+function writeServerLock(dir: string, version: string): void {
+  writeFileSync(
+    join(dir, 'bun.lock'),
+    JSON.stringify(
+      {
+        lockfileVersion: 1,
+        workspaces: {
+          'apps/server': {
+            name: '@browseros/server',
+            version,
+          },
+        },
+      },
+      null,
+      2,
+    ),
+  )
+}
+
 async function commitVersion(
   dir: string,
   component: Component,
@@ -129,7 +156,12 @@ async function lightweightTag(dir: string, name: string): Promise<void> {
   await mustRun(dir, ['git', 'tag', name])
 }
 
-async function resolveRelease(dir: string, component: Component, name: string) {
+async function resolveRelease(
+  dir: string,
+  component: Component,
+  name: string,
+  extraArgs: string[] = [],
+) {
   return run(dir, [
     resolver,
     '--component',
@@ -138,6 +170,21 @@ async function resolveRelease(dir: string, component: Component, name: string) {
     name,
     '--default-branch',
     'main',
+    ...extraArgs,
+  ])
+}
+
+async function prepareServerTagRelease(dir: string, name: string) {
+  return run(dir, [
+    prepareServerRelease,
+    '--tag',
+    name,
+    '--default-branch',
+    'main',
+    '--agent-root',
+    dir,
+    '--bump-script',
+    bumpServerVersion,
   ])
 }
 
@@ -284,6 +331,28 @@ describe('resolve-component-release', () => {
     }
   })
 
+  it('can preflight a package version mismatch for repair', async () => {
+    const dir = await initFixture('agent-extension', '0.0.99')
+    try {
+      const currentTag = scopedTag('agent-extension', '0.0.100')
+      await tag(dir, currentTag)
+
+      const result = await resolveRelease(dir, 'agent-extension', currentTag, [
+        '--allow-package-version-mismatch',
+      ])
+
+      expect(result.code, result.stderr).toBe(0)
+      expect(parseOutput(result.stdout)).toMatchObject({
+        version: '0.0.100',
+        package_version: '0.0.99',
+        package_version_matches: 'false',
+        tag: currentTag,
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
   it('validates the package version from the tagged commit instead of the current checkout', async () => {
     const dir = await initFixture('agent-extension', '0.0.99')
     try {
@@ -386,6 +455,114 @@ describe('resolve-component-release', () => {
       rmSync(sourceDir, { recursive: true, force: true })
       rmSync(bareDir, { recursive: true, force: true })
       rmSync(checkoutDir, { recursive: true, force: true })
+    }
+  })
+
+  it('repairs a current-tip server tag by committing the requested version and retagging it', async () => {
+    const dir = await initFixture('agent-server', '0.0.122')
+    const bareDir = mkdtempSync(join(tmpdir(), 'component-release-remote-'))
+    try {
+      writeServerLock(dir, '0.0.122')
+      await mustRun(dir, ['git', 'add', 'bun.lock'])
+      await mustRun(dir, ['git', 'commit', '-m', 'add server lock'])
+      await mustRun(bareDir, ['git', 'init', '--bare'])
+      await mustRun(dir, ['git', 'remote', 'add', 'origin', bareDir])
+      await mustRun(dir, ['git', 'push', '-u', 'origin', 'main'])
+
+      const oldSha = (await mustRun(dir, ['git', 'rev-parse', 'HEAD'])).trim()
+      const currentTag = scopedTag('agent-server', '0.0.123')
+      await tag(dir, currentTag)
+      await mustRun(dir, ['git', 'push', 'origin', currentTag])
+
+      const result = await prepareServerTagRelease(dir, currentTag)
+
+      expect(result.code, result.stderr).toBe(0)
+      const output = parseOutput(result.stdout)
+      expect(output).toMatchObject({
+        version: '0.0.123',
+        package_version: '0.0.123',
+        package_version_matches: 'true',
+        tag: currentTag,
+        previous_tag: '',
+      })
+      expect(output.release_sha).not.toBe(oldSha)
+      expect(
+        (await mustRun(dir, ['git', 'rev-parse', 'origin/main'])).trim(),
+      ).toBe(output.release_sha)
+      expect(
+        (await mustRun(dir, ['git', 'rev-list', '-n', '1', currentTag])).trim(),
+      ).toBe(output.release_sha)
+      expect(
+        (
+          await mustRun(dir, [
+            'git',
+            'cat-file',
+            '-t',
+            `refs/tags/${currentTag}`,
+          ])
+        ).trim(),
+      ).toBe('tag')
+      expect(
+        (
+          await mustRun(dir, [
+            'git',
+            'show',
+            `${output.release_sha}:apps/server/package.json`,
+          ])
+        ).trim(),
+      ).toContain('"version": "0.0.123"')
+      expect(
+        (
+          await mustRun(dir, ['git', 'show', `${output.release_sha}:bun.lock`])
+        ).trim(),
+      ).toContain('"version": "0.0.123"')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+      rmSync(bareDir, { recursive: true, force: true })
+    }
+  })
+
+  it('refuses to repair a mismatched server tag that is not the current default-branch tip', async () => {
+    const dir = await initFixture('agent-server', '0.0.122')
+    const bareDir = mkdtempSync(join(tmpdir(), 'component-release-remote-'))
+    try {
+      writeServerLock(dir, '0.0.122')
+      await mustRun(dir, ['git', 'add', 'bun.lock'])
+      await mustRun(dir, ['git', 'commit', '-m', 'add server lock'])
+      await mustRun(bareDir, ['git', 'init', '--bare'])
+      await mustRun(dir, ['git', 'remote', 'add', 'origin', bareDir])
+      await mustRun(dir, ['git', 'push', '-u', 'origin', 'main'])
+
+      const oldSha = (await mustRun(dir, ['git', 'rev-parse', 'HEAD'])).trim()
+      const currentTag = scopedTag('agent-server', '0.0.123')
+      await tag(dir, currentTag)
+      await mustRun(dir, ['git', 'push', 'origin', currentTag])
+      writeFileSync(join(dir, 'README.md'), 'advance main\n')
+      await mustRun(dir, ['git', 'add', 'README.md'])
+      await mustRun(dir, ['git', 'commit', '-m', 'advance main'])
+      await mustRun(dir, ['git', 'push', 'origin', 'main'])
+
+      const result = await prepareServerTagRelease(dir, currentTag)
+
+      expect(result.code).toBe(1)
+      expect(result.stderr).toContain(
+        `Auto-bump requires ${currentTag} to point at current origin/main`,
+      )
+      expect(
+        (await mustRun(dir, ['git', 'rev-list', '-n', '1', currentTag])).trim(),
+      ).toBe(oldSha)
+      expect(
+        (
+          await mustRun(dir, [
+            'git',
+            'show',
+            `${oldSha}:apps/server/package.json`,
+          ])
+        ).trim(),
+      ).toContain('"version": "0.0.122"')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+      rmSync(bareDir, { recursive: true, force: true })
     }
   })
 })


### PR DESCRIPTION
## Summary
- Add a server tag-release prepare step for pushed `agent-server/v*` tags so tag-first releases can repair a stale server package version before publishing.
- Keep strict release validation in `resolve-component-release.sh`, including semver, annotated tags, default-branch reachability, duplicates, monotonic versions, and final package/tag equality.
- Document the preferred pre-bump flow and the tag-first constraints in the server README and workflow summary.

## Design
Pushed server tags now run `prepare-server-tag-release.sh`. If the tagged commit already has the matching server package version, it delegates to the existing strict resolver. If the tag is newer than the package version and points at the current default-branch tip, it sets `apps/server/package.json` and `bun.lock`, commits the bump, recreates the annotated tag locally, and pushes the branch plus tag update atomically before running the strict resolver again. It refuses downgrades and older default-branch commits.

## Test plan
- [x] `bun test scripts/release/resolve-component-release.test.ts`
- [x] `python3 ../browseros/build/scripts/bump_server_version_test.py`
- [x] `actionlint ../../.github/workflows/release-server.yml`
- [x] `bash -n scripts/release/prepare-server-tag-release.sh scripts/release/resolve-component-release.sh`
- [x] `git diff --check`
- [x] `bun run check` (exits 0; existing Claw Biome/Fallow warning inventory still prints)
- [x] `bun run test`

## Notes
- The failed `agent-server/v0.0.123` run used the workflow from the old tagged commit, so this fixes future tag pushes. After this lands, retrying `0.0.123` means pushing the tag again at a commit that includes this workflow.