### PR TITLE
feat: browseros_product GN flag for BrowserOS/BrowserClaw identity

### DIFF
--- a/packages/browseros/build/features.yaml
+++ b/packages/browseros/build/features.yaml
@@ -7,8 +7,9 @@ features:
   browseros-core:
     description: "chore: browseros core infrastructure"
     files:
-      # Directory structure + core constants/prefs/switches
+      # Directory structure + core constants/prefs/switches + product identity
       - chrome/browser/browseros/BUILD.gn
+      - chrome/browser/browseros/buildflags.gni
       - chrome/browser/browseros/core/
       # Shared pref infrastructure (settings-page + metrics + importer)
       - chrome/browser/prefs/browser_prefs.cc

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/BUILD.gn
@@ -1,12 +1,15 @@
 diff --git a/chrome/browser/browseros/BUILD.gn b/chrome/browser/browseros/BUILD.gn
 new file mode 100644
-index 0000000000000..10b6cd8a75016
+index 0000000000000..b47e01513026e
 --- /dev/null
 +++ b/chrome/browser/browseros/BUILD.gn
-@@ -0,0 +1,22 @@
+@@ -0,0 +1,36 @@
 +# Copyright 2024 The Chromium Authors
 +# Use of this source code is governed by a BSD-style license that can be
 +# found in the LICENSE file.
++
++import("//build/buildflag_header.gni")
++import("//chrome/browser/browseros/buildflags.gni")
 +
 +# Master BUILD file for BrowserOS components.
 +# This groups together all BrowserOS-related code that lives under
@@ -15,9 +18,20 @@ index 0000000000000..10b6cd8a75016
 +group("browseros") {
 +  deps = [
 +    "//chrome/browser/browseros/core",
++    "//chrome/browser/browseros/core:product",
 +    "//chrome/browser/browseros/metrics",
 +    "//chrome/browser/browseros/onboarding",
 +    "//chrome/browser/browseros/server",
++  ]
++}
++
++# Selects the product identity (BrowserOS vs BrowserClaw) at build time.
++# See buildflags.gni for the `browseros_product` GN arg.
++buildflag_header("buildflags") {
++  header = "buildflags.h"
++  flags = [
++    "BROWSEROS_PRODUCT_BROWSEROS=$browseros_product_browseros",
++    "BROWSEROS_PRODUCT_BROWSERCLAW=$browseros_product_browserclaw",
 +  ]
 +}
 +

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/buildflags.gni
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/buildflags.gni
@@ -1,0 +1,22 @@
+diff --git a/chrome/browser/browseros/buildflags.gni b/chrome/browser/browseros/buildflags.gni
+new file mode 100644
+index 0000000000000..581416a94ad10
+--- /dev/null
++++ b/chrome/browser/browseros/buildflags.gni
+@@ -0,0 +1,16 @@
++# Copyright 2024 The Chromium Authors
++# Use of this source code is governed by a BSD-style license that can be
++# found in the LICENSE file.
++
++declare_args() {
++  # Product identity to ship this build as: "browseros" or "browserclaw".
++  # Baked into the binary at build time so runtime switches and field trials
++  # cannot change product identity for shipped artifacts.
++  browseros_product = "browseros"
++}
++
++assert(browseros_product == "browseros" || browseros_product == "browserclaw",
++       "browseros_product must be 'browseros' or 'browserclaw'")
++
++browseros_product_browseros = browseros_product == "browseros"
++browseros_product_browserclaw = browseros_product == "browserclaw"

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/BUILD.gn
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/core/BUILD.gn b/chrome/browser/browseros/core/BUILD.gn
 new file mode 100644
-index 0000000000000..6a4c48f2e597d
+index 0000000000000..bbd0c3210197f
 --- /dev/null
 +++ b/chrome/browser/browseros/core/BUILD.gn
-@@ -0,0 +1,49 @@
+@@ -0,0 +1,59 @@
 +# Copyright 2024 The Chromium Authors
 +# Use of this source code is governed by a BSD-style license that can be
 +# found in the LICENSE file.
@@ -21,6 +21,17 @@ index 0000000000000..6a4c48f2e597d
 +  ]
 +}
 +
++source_set("product") {
++  sources = [
++    "browseros_product.cc",
++    "browseros_product.h",
++  ]
++
++  deps = [
++    "//chrome/browser/browseros:buildflags",
++  ]
++}
++
 +source_set("prefs") {
 +  sources = [
 +    "browseros_prefs.cc",
@@ -28,7 +39,6 @@ index 0000000000000..6a4c48f2e597d
 +  ]
 +
 +  deps = [
-+    ":core",
 +    "//base",
 +    "//chrome/browser/ui/actions:actions_headers",
 +    "//chrome/common:constants",

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_product.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_product.cc
@@ -1,0 +1,37 @@
+diff --git a/chrome/browser/browseros/core/browseros_product.cc b/chrome/browser/browseros/core/browseros_product.cc
+new file mode 100644
+index 0000000000000..566bd675f9fd3
+--- /dev/null
++++ b/chrome/browser/browseros/core/browseros_product.cc
+@@ -0,0 +1,31 @@
++// Copyright 2024 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "chrome/browser/browseros/core/browseros_product.h"
++
++#include "chrome/browser/browseros/buildflags.h"
++
++namespace browseros {
++
++static_assert(BUILDFLAG(BROWSEROS_PRODUCT_BROWSEROS) !=
++                  BUILDFLAG(BROWSEROS_PRODUCT_BROWSERCLAW),
++              "Exactly one BrowserOS product must be selected");
++
++Product GetProduct() {
++#if BUILDFLAG(BROWSEROS_PRODUCT_BROWSERCLAW)
++  return Product::kBrowserClaw;
++#else
++  return Product::kBrowserOS;
++#endif
++}
++
++bool IsBrowserOSProduct() {
++  return GetProduct() == Product::kBrowserOS;
++}
++
++bool IsBrowserClawProduct() {
++  return GetProduct() == Product::kBrowserClaw;
++}
++
++}  // namespace browseros

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_product.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_product.h
@@ -1,0 +1,32 @@
+diff --git a/chrome/browser/browseros/core/browseros_product.h b/chrome/browser/browseros/core/browseros_product.h
+new file mode 100644
+index 0000000000000..8ff030b115de6
+--- /dev/null
++++ b/chrome/browser/browseros/core/browseros_product.h
+@@ -0,0 +1,26 @@
++// Copyright 2024 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#ifndef CHROME_BROWSER_BROWSEROS_CORE_BROWSEROS_PRODUCT_H_
++#define CHROME_BROWSER_BROWSEROS_CORE_BROWSEROS_PRODUCT_H_
++
++namespace browseros {
++
++// Product identity for this build. Selected at build time via the
++// `browseros_product` GN arg and baked into the binary, so runtime switches
++// and field trials cannot change it.
++enum class Product {
++  kBrowserOS,
++  kBrowserClaw,
++};
++
++// Returns the product this binary was built as.
++Product GetProduct();
++
++bool IsBrowserOSProduct();
++bool IsBrowserClawProduct();
++
++}  // namespace browseros
++
++#endif  // CHROME_BROWSER_BROWSEROS_CORE_BROWSEROS_PRODUCT_H_


### PR DESCRIPTION
## Summary
- Add a build-time `browseros_product` GN arg (`"browseros"` | `"browserclaw"`, default `"browseros"`) so one source tree can ship as either product.
- Generate `buildflags.h` (`BROWSEROS_PRODUCT_BROWSEROS` / `BROWSEROS_PRODUCT_BROWSERCLAW`) and wrap it in `core/browseros_product.{h,cc}` (`GetProduct()` / `IsBrowserOSProduct()` / `IsBrowserClawProduct()`).
- Product identity is baked into the binary — runtime switches and field trials cannot flip it for shipped artifacts.

## Design
A single GN arg selects the product; a `buildflag_header` turns it into compile-time flags, and a thin C++ helper (with a `static_assert` that exactly one product is selected) hides the raw flags behind `browseros::Product`. Default stays `"browseros"`, so the normal build is unchanged. No dev runtime override switch was added — it would undercut the "identity is un-flippable at runtime" guarantee; it can be added later, gated off in official builds, if dev ergonomics need it.

Extracted as chromium patches under `chromium_patches/chrome/browser/browseros/`; `buildflags.gni` is registered under the `browseros-core` feature (the `core/` files are already covered by that feature's directory entry).

## Test plan
- [x] Default (`browseros`) build links green via the build lock; generated `buildflags.h` has `BROWSEROS_PRODUCT_BROWSEROS=1`, `..._BROWSERCLAW=0`.
- [x] `verify-patches.sh`: 5/5 byte-match + apply-check, 0 skipped.
- [ ] `browseros_product = "browserclaw"` flips the generated header and `GetProduct()` returns `kBrowserClaw`.