### PR TITLE
fix(patches): browseros API provider registration

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/extensions/chrome_extensions_browser_api_provider.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/extensions/chrome_extensions_browser_api_provider.cc
@@ -1,0 +1,12 @@
+diff --git a/chrome/browser/extensions/chrome_extensions_browser_api_provider.cc b/chrome/browser/extensions/chrome_extensions_browser_api_provider.cc
+index a251aaaa53378..94a89781536b2 100644
+--- a/chrome/browser/extensions/chrome_extensions_browser_api_provider.cc
++++ b/chrome/browser/extensions/chrome_extensions_browser_api_provider.cc
+@@ -19,7 +19,6 @@ ChromeExtensionsBrowserAPIProvider::~ChromeExtensionsBrowserAPIProvider() =
+ 
+ void ChromeExtensionsBrowserAPIProvider::RegisterExtensionFunctions(
+     ExtensionFunctionRegistry* registry) {
+-  // Generated APIs from Chrome.
+   api::ChromeGeneratedFunctionRegistry::RegisterAll(registry);
+ }
+ 


### PR DESCRIPTION
## Summary
- Adds the extracted Chromium patch for `chrome/browser/extensions/chrome_extensions_browser_api_provider.cc`.
- Keeps the BrowserOS API provider on the generated registry path and removes the stale generated-API comment from the cumulative patch state.

## Design
This is the BrowserOS patch extraction for Chromium commit `ef156dde0d4ab`, produced from the existing `api` feature file list. `features.yaml` already includes this path, so the PR only adds the missing extracted patch file.

## Test plan
- [x] `/Users/shadowfax/.skills/sf-ch-extract/scripts/verify-patches.sh --chromium-src /Users/shadowfax/code/chromium-checkouts/chromium-2/src --worktree /Users/shadowfax/worktrees/main/feat-browseros-api-registration-patches --tip ef156dde0d4abcd8d8cecbf55aa654a334ffe639 chrome/browser/extensions/chrome_extensions_browser_api_provider.cc`
- [x] `autoninja -C out/Default_arm64 chrome`