### PR TITLE
feat: manage BrowserClaw server descriptor

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/BUILD.gn
@@ -1,25 +1,32 @@
 diff --git a/chrome/browser/browseros/server/BUILD.gn b/chrome/browser/browseros/server/BUILD.gn
 new file mode 100644
-index 0000000000000..85e9eaaba051c
+index 0000000000000..30759104d22c0
 --- /dev/null
 +++ b/chrome/browser/browseros/server/BUILD.gn
-@@ -0,0 +1,131 @@
+@@ -0,0 +1,141 @@
 +# Copyright 2024 The Chromium Authors
 +# Use of this source code is governed by a BSD-style license that can be
 +# found in the LICENSE file.
 +
 +import("//build/config/chrome_build.gni")
++import("//chrome/browser/browseros/buildflags.gni")
 +
-+# Validate that required resources exist at build time
-+# GN will fail at generation time if resources/bin/browseros_server is missing
-+_browseros_binary_name = "browseros_server"
++if (browseros_product_browserclaw) {
++  _server_bundle_dir = "BrowserClawServer"
++  _server_binary_name = "browseros-claw-server"
++} else {
++  _server_bundle_dir = "BrowserOSServer"
++  _server_binary_name = "browseros_server"
++}
++
 +if (is_win) {
-+  _browseros_binary_name += ".exe"
++  _server_binary_name += ".exe"
 +}
 +
 +action("validate_browseros_resources") {
 +  script = "validate_resources.py"
-+  inputs = [ "resources/bin/${_browseros_binary_name}" ]
++  args = [ "bin/${_server_binary_name}" ]
++  inputs = [ "resources/bin/${_server_binary_name}" ]
 +  outputs = [ "$target_gen_dir/browseros_resources_validated" ]
 +}
 +
@@ -55,6 +62,7 @@ index 0000000000000..85e9eaaba051c
 +  deps = [
 +    "//base",
 +    "//chrome/browser:browser_process",
++    "//chrome/browser/browseros/core:product",
 +    "//chrome/browser/browseros/metrics",
 +    "//chrome/common",
 +    "//components/prefs",
@@ -90,6 +98,7 @@ index 0000000000000..85e9eaaba051c
 +  testonly = true
 +  sources = [
 +    "browseros_appcast_parser_unittest.cc",
++    "browseros_server_config_unittest.cc",
 +    "browseros_server_manager_unittest.cc",
 +    "browseros_server_utils_unittest.cc",
 +  ]
@@ -110,19 +119,20 @@ index 0000000000000..85e9eaaba051c
 +  import("//build/config/apple/symbols.gni")
 +  import("//build/config/mac/mac_sdk.gni")
 +
-+  # Bundle data for macOS - recursively packages resources/ to Resources/BrowserOSServer/default/
 +  bundle_data("browseros_resources_bundle") {
 +    sources = [ "resources" ]
-+    outputs = [ "{{bundle_resources_dir}}/BrowserOSServer/default/{{source_file_part}}" ]
-+    # TODO: Re-enable validation when resources/bin/browseros_server is available
++    outputs = [ "{{bundle_resources_dir}}/${_server_bundle_dir}/default/{{source_file_part}}" ]
++
++    # TODO: Re-enable validation when resources/bin/${_server_binary_name} is available.
 +    # deps = [ ":validate_browseros_resources" ]
 +  }
 +} else {
-+  # Copy for Windows/Linux - recursively packages resources/ to <exe_dir>/BrowserOSServer/default/
 +  copy("browseros_resources_copy") {
 +    sources = [ "resources" ]
-+    outputs = [ "$root_out_dir/BrowserOSServer/default/{{source_file_part}}" ]
-+    # TODO: Re-enable validation when resources/bin/browseros_server is available
++    outputs =
++        [ "$root_out_dir/${_server_bundle_dir}/default/{{source_file_part}}" ]
++
++    # TODO: Re-enable validation when resources/bin/${_server_binary_name} is available.
 +    # deps = [ ":validate_browseros_resources" ]
 +  }
 +}

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config.cc
@@ -1,18 +1,129 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_config.cc b/chrome/browser/browseros/server/browseros_server_config.cc
 new file mode 100644
-index 0000000000000..3e0c69cdf6442
+index 0000000000000..8fc64867664b4
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_config.cc
-@@ -0,0 +1,81 @@
+@@ -0,0 +1,205 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
 +
 +#include "chrome/browser/browseros/server/browseros_server_config.h"
 +
++#include "base/notreached.h"
 +#include "base/strings/stringprintf.h"
++#include "chrome/browser/browseros/core/browseros_product.h"
 +
 +namespace browseros {
++namespace {
++
++constexpr ManagedServerDescriptor kBrowserOSServerDescriptor = {
++    Product::kBrowserOS,
++    "BrowserOS server",
++    FILE_PATH_LITERAL("BrowserOSServer"),
++    FILE_PATH_LITERAL("browseros_server"),
++    FILE_PATH_LITERAL("server_config.json"),
++    "/health",
++    ServerConfigKind::kBrowserOS,
++    true,
++};
++
++constexpr ManagedServerDescriptor kBrowserClawServerDescriptor = {
++    Product::kBrowserClaw,
++    "BrowserClaw server",
++    FILE_PATH_LITERAL("BrowserClawServer"),
++    FILE_PATH_LITERAL("browseros-claw-server"),
++    FILE_PATH_LITERAL("claw_config.json"),
++    "/system/health",
++    ServerConfigKind::kBrowserClaw,
++    false,
++};
++
++base::DictValue BuildBrowserOSConfigJson(
++    const ServerLaunchConfig& config,
++    const base::FilePath& actual_resources_dir) {
++  base::DictValue root;
++
++  base::DictValue ports_dict;
++  ports_dict.Set("cdp", config.ports.cdp);
++  ports_dict.Set("server", config.ports.server);
++  ports_dict.Set("extension", config.ports.extension);
++  ports_dict.Set("proxy", config.ports.proxy);
++  root.Set("ports", std::move(ports_dict));
++
++  base::DictValue directories;
++  directories.Set("resources", actual_resources_dir.AsUTF8Unsafe());
++  directories.Set("execution", config.paths.execution.AsUTF8Unsafe());
++  root.Set("directories", std::move(directories));
++
++  base::DictValue flags;
++  flags.Set("allow_remote_in_mcp", config.allow_remote_in_mcp);
++  root.Set("flags", std::move(flags));
++
++  base::DictValue instance;
++  instance.Set("install_id", config.identity.install_id);
++  instance.Set("browseros_version", config.identity.browseros_version);
++  instance.Set("chromium_version", config.identity.chromium_version);
++  root.Set("instance", std::move(instance));
++
++  return root;
++}
++
++base::DictValue BuildBrowserClawConfigJson(
++    const ServerLaunchConfig& config,
++    const base::FilePath& actual_resources_dir) {
++  base::DictValue root;
++
++  base::DictValue ports_dict;
++  ports_dict.Set("server", config.ports.server);
++  ports_dict.Set("cdp", config.ports.cdp);
++  root.Set("ports", std::move(ports_dict));
++
++  base::DictValue directories;
++  directories.Set("resources", actual_resources_dir.AsUTF8Unsafe());
++  root.Set("directories", std::move(directories));
++
++  return root;
++}
++
++std::string ConfigKindToString(ServerConfigKind kind) {
++  switch (kind) {
++    case ServerConfigKind::kBrowserOS:
++      return "browseros";
++    case ServerConfigKind::kBrowserClaw:
++      return "browserclaw";
++  }
++  NOTREACHED();
++}
++
++}  // namespace
++
++const ManagedServerDescriptor& GetBrowserOSServerDescriptor() {
++  return kBrowserOSServerDescriptor;
++}
++
++const ManagedServerDescriptor& GetBrowserClawServerDescriptor() {
++  return kBrowserClawServerDescriptor;
++}
++
++const ManagedServerDescriptor& GetManagedServerDescriptor() {
++  if (IsBrowserClawProduct()) {
++    return GetBrowserClawServerDescriptor();
++  }
++  return GetBrowserOSServerDescriptor();
++}
++
++base::DictValue BuildServerConfigJson(
++    const ServerLaunchConfig& config,
++    const base::FilePath& actual_resources_dir) {
++  switch (config.config_kind) {
++    case ServerConfigKind::kBrowserOS:
++      return BuildBrowserOSConfigJson(config, actual_resources_dir);
++    case ServerConfigKind::kBrowserClaw:
++      return BuildBrowserClawConfigJson(config, actual_resources_dir);
++  }
++  NOTREACHED();
++}
 +
 +bool ServerPorts::IsValid() const {
 +  return cdp > 0 && server > 0 && extension > 0 && proxy > 0;
@@ -48,10 +159,8 @@ index 0000000000000..3e0c69cdf6442
 +      "  resources=%s\n"
 +      "  execution=%s\n"
 +      "}",
-+      exe.AsUTF8Unsafe().c_str(),
-+      fallback_exe.AsUTF8Unsafe().c_str(),
-+      resources.AsUTF8Unsafe().c_str(),
-+      execution.AsUTF8Unsafe().c_str());
++      exe.AsUTF8Unsafe().c_str(), fallback_exe.AsUTF8Unsafe().c_str(),
++      resources.AsUTF8Unsafe().c_str(), execution.AsUTF8Unsafe().c_str());
 +}
 +
 +std::string ServerIdentity::DebugString() const {
@@ -61,26 +170,41 @@ index 0000000000000..3e0c69cdf6442
 +      "  browseros=%s\n"
 +      "  chromium=%s\n"
 +      "}",
-+      install_id.c_str(),
-+      browseros_version.c_str(),
-+      chromium_version.c_str());
++      install_id.c_str(), browseros_version.c_str(), chromium_version.c_str());
 +}
 +
++ServerLaunchConfig::ServerLaunchConfig() = default;
++ServerLaunchConfig::ServerLaunchConfig(const ServerLaunchConfig&) = default;
++ServerLaunchConfig& ServerLaunchConfig::operator=(const ServerLaunchConfig&) =
++    default;
++ServerLaunchConfig::ServerLaunchConfig(ServerLaunchConfig&&) = default;
++ServerLaunchConfig& ServerLaunchConfig::operator=(ServerLaunchConfig&&) =
++    default;
++ServerLaunchConfig::~ServerLaunchConfig() = default;
++
 +bool ServerLaunchConfig::IsValid() const {
-+  return ports.IsValid() && paths.IsValid();
++  return ports.IsValid() && paths.IsValid() && !config_file_name.empty() &&
++         !health_path.empty();
 +}
 +
 +std::string ServerLaunchConfig::DebugString() const {
++  std::string config_file = base::FilePath(config_file_name).AsUTF8Unsafe();
 +  return base::StringPrintf(
 +      "ServerLaunchConfig{\n"
++      "  log_name=%s\n"
++      "  config_file=%s\n"
++      "  health_path=%s\n"
++      "  config_kind=%s\n"
++      "  enable_updater=%s\n"
 +      "  %s\n"
 +      "  %s\n"
 +      "  %s\n"
 +      "  allow_remote=%s\n"
 +      "}",
-+      ports.DebugString().c_str(),
-+      paths.DebugString().c_str(),
-+      identity.DebugString().c_str(),
++      log_name.c_str(), config_file.c_str(), health_path.c_str(),
++      ConfigKindToString(config_kind).c_str(),
++      enable_updater ? "true" : "false", ports.DebugString().c_str(),
++      paths.DebugString().c_str(), identity.DebugString().c_str(),
 +      allow_remote_in_mcp ? "true" : "false");
 +}
 +

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_config.h b/chrome/browser/browseros/server/browseros_server_config.h
 new file mode 100644
-index 0000000000000..3b121ed6f6635
+index 0000000000000..f41e7536e90a5
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_config.h
-@@ -0,0 +1,90 @@
+@@ -0,0 +1,135 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -12,18 +12,50 @@ index 0000000000000..3b121ed6f6635
 +#define CHROME_BROWSER_BROWSEROS_SERVER_BROWSEROS_SERVER_CONFIG_H_
 +
 +#include <string>
++#include <string_view>
 +
 +#include "base/files/file_path.h"
++#include "base/values.h"
++#include "chrome/browser/browseros/core/browseros_product.h"
 +
 +namespace browseros {
++
++struct ServerLaunchConfig;
++
++enum class ServerConfigKind {
++  kBrowserOS,
++  kBrowserClaw,
++};
++
++struct ManagedServerDescriptor {
++  Product product;
++  std::string_view log_name;
++  base::FilePath::StringViewType bundle_dir;
++  base::FilePath::StringViewType binary_name;
++  base::FilePath::StringViewType config_file_name;
++  std::string_view health_path;
++  ServerConfigKind config_kind;
++  bool enable_updater;
++};
++
++const ManagedServerDescriptor& GetBrowserOSServerDescriptor();
++const ManagedServerDescriptor& GetBrowserClawServerDescriptor();
++
++// Returns the server descriptor selected by the build-time product identity.
++const ManagedServerDescriptor& GetManagedServerDescriptor();
++
++// Builds the JSON config expected by the selected server product.
++base::DictValue BuildServerConfigJson(
++    const ServerLaunchConfig& config,
++    const base::FilePath& actual_resources_dir);
 +
 +// Port assignments for all server endpoints.
 +// This is the single source of truth for port configuration.
 +struct ServerPorts {
 +  int cdp = 0;
-+  int server = 0;     // ephemeral backend port for sidecar (was "mcp")
++  int server = 0;  // ephemeral backend port for sidecar (was "mcp")
 +  int extension = 0;
-+  int proxy = 0;      // stable MCP proxy port bound by Chromium
++  int proxy = 0;  // stable MCP proxy port bound by Chromium
 +
 +  bool operator==(const ServerPorts&) const = default;
 +
@@ -79,6 +111,19 @@ index 0000000000000..3b121ed6f6635
 +// Complete configuration for a single server launch.
 +// Assembled fresh before each ProcessController::Launch() call.
 +struct ServerLaunchConfig {
++  ServerLaunchConfig();
++  ServerLaunchConfig(const ServerLaunchConfig&);
++  ServerLaunchConfig& operator=(const ServerLaunchConfig&);
++  ServerLaunchConfig(ServerLaunchConfig&&);
++  ServerLaunchConfig& operator=(ServerLaunchConfig&&);
++  ~ServerLaunchConfig();
++
++  std::string log_name;
++  base::FilePath::StringType config_file_name;
++  std::string health_path;
++  ServerConfigKind config_kind = ServerConfigKind::kBrowserOS;
++  bool enable_updater = true;
++
 +  ServerPorts ports;
 +  ServerPaths paths;
 +  ServerIdentity identity;

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config_unittest.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config_unittest.cc
@@ -1,0 +1,148 @@
+diff --git a/chrome/browser/browseros/server/browseros_server_config_unittest.cc b/chrome/browser/browseros/server/browseros_server_config_unittest.cc
+new file mode 100644
+index 0000000000000..f308d27b3bca1
+--- /dev/null
++++ b/chrome/browser/browseros/server/browseros_server_config_unittest.cc
+@@ -0,0 +1,142 @@
++// Copyright 2024 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "chrome/browser/browseros/server/browseros_server_config.h"
++
++#include <string_view>
++
++#include "testing/gtest/include/gtest/gtest.h"
++
++namespace browseros {
++namespace {
++
++base::FilePath::StringType ToPathString(
++    base::FilePath::StringViewType value) {
++  return base::FilePath::StringType(value.begin(), value.end());
++}
++
++ServerLaunchConfig BuildLaunchConfig(ServerConfigKind kind) {
++  ServerLaunchConfig config;
++  config.config_kind = kind;
++  config.config_file_name = FILE_PATH_LITERAL("config.json");
++  config.health_path = "/health";
++  config.log_name = "test server";
++  config.enable_updater = kind == ServerConfigKind::kBrowserOS;
++
++  config.ports.cdp = 9222;
++  config.ports.server = 9230;
++  config.ports.extension = 9240;
++  config.ports.proxy = 9250;
++
++  config.paths.exe = base::FilePath(FILE_PATH_LITERAL("server"));
++  config.paths.execution = base::FilePath(FILE_PATH_LITERAL("execution"));
++
++  config.identity.install_id = "install-id";
++  config.identity.browseros_version = "1.2.3";
++  config.identity.chromium_version = "140.0.0.0";
++  config.allow_remote_in_mcp = true;
++
++  return config;
++}
++
++TEST(BrowserOSServerConfigTest, BrowserOSDescriptorMatchesLegacyServer) {
++  const ManagedServerDescriptor& descriptor = GetBrowserOSServerDescriptor();
++
++  EXPECT_EQ(Product::kBrowserOS, descriptor.product);
++  EXPECT_EQ(std::string_view("BrowserOS server"), descriptor.log_name);
++  EXPECT_EQ(base::FilePath::StringType(FILE_PATH_LITERAL("BrowserOSServer")),
++            ToPathString(descriptor.bundle_dir));
++  EXPECT_EQ(base::FilePath::StringType(FILE_PATH_LITERAL("browseros_server")),
++            ToPathString(descriptor.binary_name));
++  EXPECT_EQ(base::FilePath::StringType(FILE_PATH_LITERAL("server_config.json")),
++            ToPathString(descriptor.config_file_name));
++  EXPECT_EQ(std::string_view("/health"), descriptor.health_path);
++  EXPECT_EQ(ServerConfigKind::kBrowserOS, descriptor.config_kind);
++  EXPECT_TRUE(descriptor.enable_updater);
++}
++
++TEST(BrowserOSServerConfigTest, BrowserClawDescriptorDisablesUpdater) {
++  const ManagedServerDescriptor& descriptor = GetBrowserClawServerDescriptor();
++
++  EXPECT_EQ(Product::kBrowserClaw, descriptor.product);
++  EXPECT_EQ(std::string_view("BrowserClaw server"), descriptor.log_name);
++  EXPECT_EQ(base::FilePath::StringType(FILE_PATH_LITERAL("BrowserClawServer")),
++            ToPathString(descriptor.bundle_dir));
++  EXPECT_EQ(
++      base::FilePath::StringType(FILE_PATH_LITERAL("browseros-claw-server")),
++      ToPathString(descriptor.binary_name));
++  EXPECT_EQ(base::FilePath::StringType(FILE_PATH_LITERAL("claw_config.json")),
++            ToPathString(descriptor.config_file_name));
++  EXPECT_EQ(std::string_view("/system/health"), descriptor.health_path);
++  EXPECT_EQ(ServerConfigKind::kBrowserClaw, descriptor.config_kind);
++  EXPECT_FALSE(descriptor.enable_updater);
++}
++
++TEST(BrowserOSServerConfigTest, BrowserOSConfigKeepsLegacyShape) {
++  ServerLaunchConfig config = BuildLaunchConfig(ServerConfigKind::kBrowserOS);
++  base::FilePath resources(FILE_PATH_LITERAL("resources"));
++
++  base::DictValue root = BuildServerConfigJson(config, resources);
++
++  const base::DictValue* ports = root.FindDict("ports");
++  ASSERT_NE(nullptr, ports);
++  ASSERT_TRUE(ports->FindInt("cdp").has_value());
++  EXPECT_EQ(9222, ports->FindInt("cdp").value());
++  ASSERT_TRUE(ports->FindInt("server").has_value());
++  EXPECT_EQ(9230, ports->FindInt("server").value());
++  ASSERT_TRUE(ports->FindInt("extension").has_value());
++  EXPECT_EQ(9240, ports->FindInt("extension").value());
++  ASSERT_TRUE(ports->FindInt("proxy").has_value());
++  EXPECT_EQ(9250, ports->FindInt("proxy").value());
++
++  const base::DictValue* directories = root.FindDict("directories");
++  ASSERT_NE(nullptr, directories);
++  ASSERT_NE(nullptr, directories->FindString("resources"));
++  EXPECT_EQ(resources.AsUTF8Unsafe(), *directories->FindString("resources"));
++  ASSERT_NE(nullptr, directories->FindString("execution"));
++  EXPECT_EQ(config.paths.execution.AsUTF8Unsafe(),
++            *directories->FindString("execution"));
++
++  const base::DictValue* flags = root.FindDict("flags");
++  ASSERT_NE(nullptr, flags);
++  ASSERT_TRUE(flags->FindBool("allow_remote_in_mcp").has_value());
++  EXPECT_TRUE(flags->FindBool("allow_remote_in_mcp").value());
++
++  const base::DictValue* instance = root.FindDict("instance");
++  ASSERT_NE(nullptr, instance);
++  ASSERT_NE(nullptr, instance->FindString("install_id"));
++  EXPECT_EQ("install-id", *instance->FindString("install_id"));
++  ASSERT_NE(nullptr, instance->FindString("browseros_version"));
++  EXPECT_EQ("1.2.3", *instance->FindString("browseros_version"));
++  ASSERT_NE(nullptr, instance->FindString("chromium_version"));
++  EXPECT_EQ("140.0.0.0", *instance->FindString("chromium_version"));
++}
++
++TEST(BrowserOSServerConfigTest, BrowserClawConfigUsesStrictShape) {
++  ServerLaunchConfig config = BuildLaunchConfig(ServerConfigKind::kBrowserClaw);
++  base::FilePath resources(FILE_PATH_LITERAL("resources"));
++
++  base::DictValue root = BuildServerConfigJson(config, resources);
++
++  const base::DictValue* ports = root.FindDict("ports");
++  ASSERT_NE(nullptr, ports);
++  ASSERT_TRUE(ports->FindInt("server").has_value());
++  EXPECT_EQ(9230, ports->FindInt("server").value());
++  ASSERT_TRUE(ports->FindInt("cdp").has_value());
++  EXPECT_EQ(9222, ports->FindInt("cdp").value());
++  EXPECT_FALSE(ports->FindInt("extension").has_value());
++  EXPECT_FALSE(ports->FindInt("proxy").has_value());
++
++  const base::DictValue* directories = root.FindDict("directories");
++  ASSERT_NE(nullptr, directories);
++  ASSERT_NE(nullptr, directories->FindString("resources"));
++  EXPECT_EQ(resources.AsUTF8Unsafe(), *directories->FindString("resources"));
++  EXPECT_EQ(nullptr, directories->FindString("execution"));
++
++  EXPECT_EQ(nullptr, root.FindDict("flags"));
++  EXPECT_EQ(nullptr, root.FindDict("instance"));
++}
++
++}  // namespace
++}  // namespace browseros

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_manager.cc b/chrome/browser/browseros/server/browseros_server_manager.cc
 new file mode 100644
-index 0000000000000..069d1b79d6ae2
+index 0000000000000..d3744f253ca37
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_manager.cc
-@@ -0,0 +1,1120 @@
+@@ -0,0 +1,1083 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -14,16 +14,15 @@ index 0000000000000..069d1b79d6ae2
 +#include <set>
 +
 +#include "base/command_line.h"
-+#include "base/functional/callback_helpers.h"
 +#include "base/files/file_path.h"
 +#include "base/files/file_util.h"
++#include "base/functional/callback_helpers.h"
 +#include "base/logging.h"
 +#include "base/path_service.h"
 +#include "base/rand_util.h"
 +#include "base/strings/string_number_conversions.h"
 +#include "base/system/sys_info.h"
 +#include "base/task/thread_pool.h"
-+#include "content/public/browser/browser_thread.h"
 +#include "base/threading/thread_restrictions.h"
 +#include "build/build_config.h"
 +#include "chrome/browser/browser_process.h"
@@ -43,7 +42,6 @@ index 0000000000000..069d1b79d6ae2
 +#include "chrome/browser/browseros/server/server_state_store_impl.h"
 +#include "chrome/browser/browseros/server/server_updater.h"
 +#include "chrome/browser/net/system_network_context_manager.h"
-+#include "services/network/public/cpp/shared_url_loader_factory.h"
 +#include "chrome/browser/profiles/profile.h"
 +#include "chrome/browser/profiles/profile_manager.h"
 +#include "chrome/common/chrome_paths.h"
@@ -52,8 +50,8 @@ index 0000000000000..069d1b79d6ae2
 +#include "components/version_info/version_info.h"
 +#include "content/public/browser/browser_thread.h"
 +#include "content/public/browser/devtools_agent_host.h"
-+#include "content/public/common/content_switches.h"
 +#include "content/public/browser/devtools_socket_factory.h"
++#include "content/public/common/content_switches.h"
 +#include "net/base/address_family.h"
 +#include "net/base/ip_address.h"
 +#include "net/base/ip_endpoint.h"
@@ -62,6 +60,7 @@ index 0000000000000..069d1b79d6ae2
 +#include "net/log/net_log_source.h"
 +#include "net/socket/tcp_server_socket.h"
 +#include "net/socket/tcp_socket.h"
++#include "services/network/public/cpp/shared_url_loader_factory.h"
 +
 +namespace {
 +
@@ -76,8 +75,8 @@ index 0000000000000..069d1b79d6ae2
 +constexpr int kExitCodeSuccess = 0;
 +
 +int GetPortOverrideFromCommandLine(base::CommandLine* command_line,
-+                                    const char* switch_name,
-+                                    const char* port_name) {
++                                   const char* switch_name,
++                                   const char* port_name) {
 +  if (!command_line->HasSwitch(switch_name)) {
 +    return 0;
 +  }
@@ -186,10 +185,9 @@ index 0000000000000..069d1b79d6ae2
 +
 +  base::FilePath lock_path = exec_dir.Append(FILE_PATH_LITERAL("server.lock"));
 +
-+  lock_file_ = base::File(lock_path,
-+                          base::File::FLAG_OPEN_ALWAYS |
-+                          base::File::FLAG_READ |
-+                          base::File::FLAG_WRITE);
++  lock_file_ =
++      base::File(lock_path, base::File::FLAG_OPEN_ALWAYS |
++                                base::File::FLAG_READ | base::File::FLAG_WRITE);
 +
 +  if (!lock_file_.IsValid()) {
 +    LOG(ERROR) << "browseros: Failed to open lock file: " << lock_path;
@@ -251,7 +249,8 @@ index 0000000000000..069d1b79d6ae2
 +  if (killed) {
 +    LOG(INFO) << "browseros: Orphan server killed successfully";
 +  } else {
-+    LOG(WARNING) << "browseros: Failed to kill orphan server, proceeding anyway";
++    LOG(WARNING)
++        << "browseros: Failed to kill orphan server, proceeding anyway";
 +  }
 +
 +  state_store_->Delete();
@@ -292,12 +291,14 @@ index 0000000000000..069d1b79d6ae2
 +    ports_.server = browseros_server::kDefaultServerPort;
 +  }
 +
-+  ports_.extension = local_state_->GetInteger(browseros_server::kExtensionServerPort);
++  ports_.extension =
++      local_state_->GetInteger(browseros_server::kExtensionServerPort);
 +  if (ports_.extension <= 0) {
 +    ports_.extension = browseros_server::kDefaultExtensionPort;
 +  }
 +
-+  allow_remote_in_mcp_ = local_state_->GetBoolean(browseros_server::kAllowRemoteInMCP);
++  allow_remote_in_mcp_ =
++      local_state_->GetBoolean(browseros_server::kAllowRemoteInMCP);
 +
 +  LOG(INFO) << "browseros: Loaded ports from prefs - " << ports_.DebugString();
 +}
@@ -328,7 +329,7 @@ index 0000000000000..069d1b79d6ae2
 +  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
 +  std::set<int> assigned_ports;
 +
-+  // Skip FindAvailablePort for CLI-overridden ports — trust the developer.
++  // Skip FindAvailablePort for CLI-overridden ports; trust the developer.
 +  bool cdp_fixed = command_line->HasSwitch(browseros::kCDPPort);
 +  bool proxy_fixed = command_line->HasSwitch(browseros::kProxyPort);
 +  bool server_fixed = command_line->HasSwitch(browseros::kServerPort);
@@ -364,7 +365,8 @@ index 0000000000000..069d1b79d6ae2
 +        browseros_server::kDefaultExtensionPort, assigned_ports);
 +  }
 +
-+  LOG(INFO) << "browseros: Resolved ports for startup - " << ports_.DebugString();
++  LOG(INFO) << "browseros: Resolved ports for startup - "
++            << ports_.DebugString();
 +}
 +
 +void BrowserOSServerManager::ApplyCommandLineOverrides() {
@@ -400,14 +402,16 @@ index 0000000000000..069d1b79d6ae2
 +
 +void BrowserOSServerManager::SavePortsToPrefs() {
 +  if (!local_state_) {
-+    LOG(WARNING) << "browseros: SavePortsToPrefs - no prefs available, skipping save";
++    LOG(WARNING)
++        << "browseros: SavePortsToPrefs - no prefs available, skipping save";
 +    return;
 +  }
 +
 +  local_state_->SetInteger(browseros_server::kCDPServerPort, ports_.cdp);
 +  local_state_->SetInteger(browseros_server::kProxyPort, ports_.proxy);
 +  local_state_->SetInteger(browseros_server::kServerPort, ports_.server);
-+  local_state_->SetInteger(browseros_server::kExtensionServerPort, ports_.extension);
++  local_state_->SetInteger(browseros_server::kExtensionServerPort,
++                           ports_.extension);
 +
 +  // DEPRECATED: keep mcp_port in sync with server port for backward compat
 +  local_state_->SetInteger(browseros_server::kMCPServerPort, ports_.server);
@@ -417,7 +421,8 @@ index 0000000000000..069d1b79d6ae2
 +
 +void BrowserOSServerManager::Start() {
 +  if (is_running_) {
-+    LOG(INFO) << "browseros: BrowserOS server already running";
++    LOG(INFO) << "browseros: " << GetManagedServerDescriptor().log_name
++              << " already running";
 +    return;
 +  }
 +
@@ -433,29 +438,29 @@ index 0000000000000..069d1b79d6ae2
 +  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
 +
 +  // Phase 2: Bind CDP to the resolved port.
-+  // Must happen AFTER resolution — otherwise FindAvailablePort detects our
++  // Must happen AFTER resolution, otherwise FindAvailablePort detects our
 +  // own CDP binding as "port in use" and reassigns to a different port,
 +  // causing the sidecar to connect to a port where nothing listens.
 +  if (!command_line->HasSwitch(::switches::kRemoteDebuggingPort)) {
 +    StartCDPServer();
 +  } else {
-+    LOG(WARNING) << "browseros: Skipping BrowserOS CDP server — "
-+              << "--remote-debugging-port takes precedence";
++    LOG(WARNING) << "browseros: Skipping managed CDP server - "
++                 << "--remote-debugging-port takes precedence";
 +  }
 +
 +  if (command_line->HasSwitch(browseros::kDisableServer)) {
-+    LOG(INFO) << "browseros: BrowserOS server disabled via command line";
++    LOG(INFO) << "browseros: Managed server disabled via command line";
 +    return;
 +  }
 +
-+  // Phase 3: Sidecar lifecycle — lock, recover orphans, launch.
++  // Phase 3: Sidecar lifecycle - lock, recover orphans, launch.
 +  if (!AcquireLock()) {
 +    return;
 +  }
 +
 +  RecoverFromOrphan();
 +
-+  LOG(INFO) << "browseros: Starting BrowserOS server";
++  LOG(INFO) << "browseros: Starting " << GetManagedServerDescriptor().log_name;
 +
 +  StartProxy();
 +  LaunchBrowserOSProcess();
@@ -468,7 +473,7 @@ index 0000000000000..069d1b79d6ae2
 +
 +  is_running_ = false;
 +
-+  LOG(INFO) << "browseros: Stopping BrowserOS server";
++  LOG(INFO) << "browseros: Stopping " << GetManagedServerDescriptor().log_name;
 +  health_check_timer_.Stop();
 +  process_check_timer_.Stop();
 +
@@ -505,8 +510,7 @@ index 0000000000000..069d1b79d6ae2
 +  LOG(INFO) << "browseros: Starting CDP server on port " << ports_.cdp;
 +
 +  content::DevToolsAgentHost::StartRemoteDebuggingServer(
-+      std::make_unique<CDPServerSocketFactory>(ports_.cdp),
-+      base::FilePath(),
++      std::make_unique<CDPServerSocketFactory>(ports_.cdp), base::FilePath(),
 +      base::FilePath());
 +
 +  // Note: StartRemoteDebuggingServer binds on the IO thread asynchronously.
@@ -531,10 +535,9 @@ index 0000000000000..069d1b79d6ae2
 +  server_proxy_ = std::make_unique<BrowserOSServerProxy>();
 +
 +  // Clone the factory on the UI thread so it can be bound on the IO thread.
-+  auto pending_factory =
-+      g_browser_process->system_network_context_manager()
-+          ->GetSharedURLLoaderFactory()
-+          ->Clone();
++  auto pending_factory = g_browser_process->system_network_context_manager()
++                             ->GetSharedURLLoaderFactory()
++                             ->Clone();
 +
 +  content::GetIOThreadTaskRunner({})->PostTask(
 +      FROM_HERE,
@@ -556,18 +559,25 @@ index 0000000000000..069d1b79d6ae2
 +void BrowserOSServerManager::StopProxy() {
 +  if (server_proxy_) {
 +    content::GetIOThreadTaskRunner({})->PostTask(
-+        FROM_HERE,
-+        base::BindOnce(
-+            [](std::unique_ptr<BrowserOSServerProxy> proxy) {
-+              proxy->Stop();
-+              // proxy destroyed on IO thread
-+            },
-+            std::move(server_proxy_)));
++        FROM_HERE, base::BindOnce(
++                       [](std::unique_ptr<BrowserOSServerProxy> proxy) {
++                         proxy->Stop();
++                         // proxy destroyed on IO thread
++                       },
++                       std::move(server_proxy_)));
 +  }
 +}
 +
 +ServerLaunchConfig BrowserOSServerManager::BuildLaunchConfig() {
 +  ServerLaunchConfig config;
++  const ManagedServerDescriptor& descriptor = GetManagedServerDescriptor();
++
++  config.log_name = std::string(descriptor.log_name);
++  config.config_file_name =
++      base::FilePath::StringType(descriptor.config_file_name);
++  config.health_path = std::string(descriptor.health_path);
++  config.config_kind = descriptor.config_kind;
++  config.enable_updater = descriptor.enable_updater;
 +
 +  config.paths.fallback_exe = GetBrowserOSServerExecutablePath();
 +  config.paths.fallback_resources = GetBrowserOSServerResourcesPath();
@@ -593,8 +603,8 @@ index 0000000000000..069d1b79d6ae2
 +    Profile* profile = profile_manager->GetLastUsedProfileIfLoaded();
 +    if (profile && !profile->IsOffTheRecord()) {
 +      browseros_metrics::BrowserOSMetricsService* metrics_service =
-+          browseros_metrics::BrowserOSMetricsServiceFactory::GetForBrowserContext(
-+              profile);
++          browseros_metrics::BrowserOSMetricsServiceFactory::
++              GetForBrowserContext(profile);
 +      if (metrics_service) {
 +        config.identity.install_id = metrics_service->GetInstallId();
 +      }
@@ -614,7 +624,8 @@ index 0000000000000..069d1b79d6ae2
 +    return;
 +  }
 +
-+  LOG(INFO) << "browseros: Launching server - " << config.DebugString();
++  LOG(INFO) << "browseros: Launching " << config.log_name << " - "
++            << config.DebugString();
 +
 +  ProcessController* pc = process_controller_.get();
 +
@@ -633,7 +644,8 @@ index 0000000000000..069d1b79d6ae2
 +  }
 +
 +  if (!result.process.IsValid()) {
-+    LOG(ERROR) << "browseros: Failed to launch BrowserOS server";
++    LOG(ERROR) << "browseros: Failed to launch "
++               << GetManagedServerDescriptor().log_name;
 +    is_restarting_ = false;
 +
 +    if (was_updating) {
@@ -649,7 +661,8 @@ index 0000000000000..069d1b79d6ae2
 +  is_running_ = true;
 +  last_launch_time_ = base::TimeTicks::Now();
 +
-+  LOG(INFO) << "browseros: BrowserOS server started with PID: " << process_.Pid();
++  LOG(INFO) << "browseros: " << GetManagedServerDescriptor().log_name
++            << " started with PID: " << process_.Pid();
 +  LOG(INFO) << "browseros: " << ports_.DebugString();
 +
 +  // Point proxy at the new backend port (proxy lives on IO thread)
@@ -686,7 +699,8 @@ index 0000000000000..069d1b79d6ae2
 +    is_restarting_ = false;
 +    if (local_state_ &&
 +        local_state_->GetBoolean(browseros_server::kRestartServerRequested)) {
-+      local_state_->SetBoolean(browseros_server::kRestartServerRequested, false);
++      local_state_->SetBoolean(browseros_server::kRestartServerRequested,
++                               false);
 +      LOG(INFO) << "browseros: Restart completed, reset restart_requested pref";
 +    }
 +  }
@@ -698,10 +712,14 @@ index 0000000000000..069d1b79d6ae2
 +    }
 +  }
 +
++  const ManagedServerDescriptor& descriptor = GetManagedServerDescriptor();
 +  if (!updater_) {
 +    if (base::CommandLine::ForCurrentProcess()->HasSwitch(
 +            browseros::kDisableServerUpdater)) {
 +      LOG(INFO) << "browseros: Server updater disabled via command line";
++    } else if (!descriptor.enable_updater) {
++      LOG(INFO) << "browseros: Server updater disabled for "
++                << descriptor.log_name;
 +    } else {
 +      updater_ =
 +          std::make_unique<browseros_server::BrowserOSServerUpdater>(this);
@@ -717,29 +735,35 @@ index 0000000000000..069d1b79d6ae2
 +    return;
 +  }
 +
-+  LOG(INFO) << "browseros: Requesting graceful shutdown via HTTP";
-+  health_checker_->RequestShutdown(
-+      ports_.server,
-+      base::BindOnce(&BrowserOSServerManager::OnTerminateHttpComplete,
++  constexpr base::TimeDelta kGracefulTimeout = base::Seconds(5);
++  base::ProcessId pid = process_.Pid();
++  LOG(INFO) << "browseros: Gracefully terminating "
++            << GetManagedServerDescriptor().log_name << " (PID: " << pid << ")";
++
++  base::ThreadPool::PostTaskAndReplyWithResult(
++      FROM_HERE,
++      {base::MayBlock(), base::WithBaseSyncPrimitives(),
++       base::TaskPriority::USER_BLOCKING},
++      base::BindOnce(&server_utils::KillProcess, pid, kGracefulTimeout),
++      base::BindOnce(&BrowserOSServerManager::OnTerminateProcessComplete,
 +                     weak_factory_.GetWeakPtr(), std::move(callback)));
 +}
 +
-+void BrowserOSServerManager::OnTerminateHttpComplete(
++void BrowserOSServerManager::OnTerminateProcessComplete(
 +    base::OnceCallback<void()> callback,
-+    bool http_success) {
-+  if (http_success) {
-+    LOG(INFO) << "browseros: Graceful shutdown acknowledged, trusting exit";
++    bool killed) {
++  if (killed) {
++    LOG(INFO) << "browseros: Managed server terminated";
 +  } else {
-+    LOG(WARNING) << "browseros: HTTP shutdown failed, sending SIGKILL";
-+    if (process_.IsValid()) {
-+      process_controller_->Terminate(&process_, /*wait=*/false);
-+    }
++    LOG(WARNING) << "browseros: Managed server termination failed";
 +  }
++  process_.Close();
 +  std::move(callback).Run();
 +}
 +
 +void BrowserOSServerManager::OnProcessExited(int exit_code) {
-+  LOG(INFO) << "browseros: BrowserOS server exited with code: " << exit_code;
++  LOG(INFO) << "browseros: " << GetManagedServerDescriptor().log_name
++            << " exited with code: " << exit_code;
 +  is_running_ = false;
 +
 +  health_check_timer_.Stop();
@@ -754,8 +778,9 @@ index 0000000000000..069d1b79d6ae2
 +  if (uptime < kStartupGracePeriod) {
 +    consecutive_startup_failures_++;
 +    LOG(WARNING) << "browseros: Startup failure detected (uptime: "
-+                 << uptime.InSeconds() << "s, consecutive failures: "
-+                 << consecutive_startup_failures_ << ")";
++                 << uptime.InSeconds()
++                 << "s, consecutive failures: " << consecutive_startup_failures_
++                 << ")";
 +
 +    if (consecutive_startup_failures_ >= kMaxStartupFailures) {
 +      LOG(ERROR) << "browseros: Too many startup failures ("
@@ -786,7 +811,7 @@ index 0000000000000..069d1b79d6ae2
 +  }
 +
 +  health_checker_->CheckHealth(
-+      ports_.server,
++      ports_.server, std::string(GetManagedServerDescriptor().health_path),
 +      base::BindOnce(&BrowserOSServerManager::OnHealthCheckComplete,
 +                     weak_factory_.GetWeakPtr()));
 +}
@@ -822,7 +847,8 @@ index 0000000000000..069d1b79d6ae2
 +}
 +
 +void BrowserOSServerManager::RestartBrowserOSProcess() {
-+  LOG(INFO) << "browseros: Restarting BrowserOS server process";
++  LOG(INFO) << "browseros: Restarting "
++            << GetManagedServerDescriptor().log_name;
 +
 +  if (is_restarting_) {
 +    LOG(INFO) << "browseros: Restart already in progress, ignoring";
@@ -839,60 +865,26 @@ index 0000000000000..069d1b79d6ae2
 +}
 +
 +void BrowserOSServerManager::ContinueRestartAfterTerminate() {
-+  base::ThreadPool::PostTaskAndReply(
-+      FROM_HERE,
-+      {base::MayBlock(), base::WithBaseSyncPrimitives(),
-+       base::TaskPriority::USER_BLOCKING},
-+      base::BindOnce(
-+          [](BrowserOSServerManager* manager) {
-+            constexpr base::TimeDelta kExitTimeout = base::Seconds(5);
-+            int exit_code = 0;
-+            bool exited = manager->process_controller_->WaitForExitWithTimeout(
-+                &manager->process_, kExitTimeout, &exit_code);
++  base::CommandLine* cl = base::CommandLine::ForCurrentProcess();
++  std::set<int> assigned;
++  assigned.insert(ports_.cdp);
++  assigned.insert(ports_.proxy);
 +
-+            if (!exited) {
-+              LOG(WARNING) << "browseros: Process didn't exit in time, "
-+                           << "sending SIGKILL";
-+              manager->process_controller_->Terminate(&manager->process_,
-+                                                      /*wait=*/true);
-+            }
-+          },
-+          base::Unretained(this)),
-+      base::BindOnce(
-+          [](base::WeakPtr<BrowserOSServerManager> weak_manager) {
-+            if (!weak_manager) {
-+              return;
-+            }
-+            auto* manager = weak_manager.get();
++  if (!cl->HasSwitch(browseros::kServerPort)) {
++    ports_.server = server_utils::FindAvailablePort(
++        browseros_server::kDefaultServerPort, assigned);
++  }
++  assigned.insert(ports_.server);
 +
-+            // Pick new ephemeral ports for server and extension
-+            // (unless CLI-overridden)
-+            base::CommandLine* cl =
-+                base::CommandLine::ForCurrentProcess();
-+            std::set<int> assigned;
-+            assigned.insert(manager->ports_.cdp);
-+            assigned.insert(manager->ports_.proxy);
++  if (!cl->HasSwitch(browseros::kExtensionPort)) {
++    ports_.extension = server_utils::FindAvailablePort(
++        browseros_server::kDefaultExtensionPort, assigned);
++  }
 +
-+            if (!cl->HasSwitch(browseros::kServerPort)) {
-+              manager->ports_.server =
-+                  server_utils::FindAvailablePort(
-+                      browseros_server::kDefaultServerPort, assigned);
-+            }
-+            assigned.insert(manager->ports_.server);
++  LOG(INFO) << "browseros: New ephemeral ports - " << ports_.DebugString();
 +
-+            if (!cl->HasSwitch(browseros::kExtensionPort)) {
-+              manager->ports_.extension =
-+                  server_utils::FindAvailablePort(
-+                      browseros_server::kDefaultExtensionPort, assigned);
-+            }
-+
-+            LOG(INFO) << "browseros: New ephemeral ports - "
-+                      << manager->ports_.DebugString();
-+
-+            manager->SavePortsToPrefs();
-+            manager->LaunchBrowserOSProcess();
-+          },
-+          weak_factory_.GetWeakPtr()));
++  SavePortsToPrefs();
++  LaunchBrowserOSProcess();
 +}
 +
 +void BrowserOSServerManager::RestartServerForUpdate(
@@ -918,55 +910,24 @@ index 0000000000000..069d1b79d6ae2
 +}
 +
 +void BrowserOSServerManager::ContinueUpdateAfterTerminate() {
-+  base::ThreadPool::PostTaskAndReply(
-+      FROM_HERE,
-+      {base::MayBlock(), base::WithBaseSyncPrimitives(),
-+       base::TaskPriority::USER_BLOCKING},
-+      base::BindOnce(
-+          [](BrowserOSServerManager* manager) {
-+            constexpr base::TimeDelta kExitTimeout = base::Seconds(5);
-+            int exit_code = 0;
-+            bool exited = manager->process_controller_->WaitForExitWithTimeout(
-+                &manager->process_, kExitTimeout, &exit_code);
++  base::CommandLine* cl = base::CommandLine::ForCurrentProcess();
++  std::set<int> assigned;
++  assigned.insert(ports_.cdp);
++  assigned.insert(ports_.proxy);
 +
-+            if (!exited) {
-+              LOG(WARNING) << "browseros: Process didn't exit for update, "
-+                           << "sending SIGKILL";
-+              manager->process_controller_->Terminate(&manager->process_,
-+                                                      /*wait=*/true);
-+            }
-+          },
-+          base::Unretained(this)),
-+      base::BindOnce(
-+          [](base::WeakPtr<BrowserOSServerManager> weak_manager) {
-+            if (!weak_manager) {
-+              return;
-+            }
-+            auto* manager = weak_manager.get();
++  if (!cl->HasSwitch(browseros::kServerPort)) {
++    ports_.server = server_utils::FindAvailablePort(
++        browseros_server::kDefaultServerPort, assigned);
++  }
++  assigned.insert(ports_.server);
 +
-+            base::CommandLine* cl =
-+                base::CommandLine::ForCurrentProcess();
-+            std::set<int> assigned;
-+            assigned.insert(manager->ports_.cdp);
-+            assigned.insert(manager->ports_.proxy);
++  if (!cl->HasSwitch(browseros::kExtensionPort)) {
++    ports_.extension = server_utils::FindAvailablePort(
++        browseros_server::kDefaultExtensionPort, assigned);
++  }
 +
-+            if (!cl->HasSwitch(browseros::kServerPort)) {
-+              manager->ports_.server =
-+                  server_utils::FindAvailablePort(
-+                      browseros_server::kDefaultServerPort, assigned);
-+            }
-+            assigned.insert(manager->ports_.server);
-+
-+            if (!cl->HasSwitch(browseros::kExtensionPort)) {
-+              manager->ports_.extension =
-+                  server_utils::FindAvailablePort(
-+                      browseros_server::kDefaultExtensionPort, assigned);
-+            }
-+
-+            manager->SavePortsToPrefs();
-+            manager->LaunchBrowserOSProcess();
-+          },
-+          weak_factory_.GetWeakPtr()));
++  SavePortsToPrefs();
++  LaunchBrowserOSProcess();
 +}
 +
 +void BrowserOSServerManager::OnAllowRemoteInMCPChanged() {
@@ -974,13 +935,13 @@ index 0000000000000..069d1b79d6ae2
 +    return;
 +  }
 +
-+  bool new_value = local_state_->GetBoolean(browseros_server::kAllowRemoteInMCP);
++  bool new_value =
++      local_state_->GetBoolean(browseros_server::kAllowRemoteInMCP);
 +
 +  if (new_value != allow_remote_in_mcp_) {
 +    LOG(INFO) << "browseros: allow_remote_in_mcp preference changed from "
 +              << (allow_remote_in_mcp_ ? "true" : "false") << " to "
-+              << (new_value ? "true" : "false")
-+              << ", restarting server...";
++              << (new_value ? "true" : "false") << ", restarting server...";
 +
 +    allow_remote_in_mcp_ = new_value;
 +
@@ -1026,8 +987,7 @@ index 0000000000000..069d1b79d6ae2
 +  }
 +
 +  LOG(INFO) << "browseros: proxy_port preference changed from " << ports_.proxy
-+            << " to " << new_port
-+            << ", rebinding proxy and restarting server";
++            << " to " << new_port << ", rebinding proxy and restarting server";
 +  ports_.proxy = new_port;
 +  SavePortsToPrefs();
 +  StopProxy();
@@ -1084,7 +1044,7 @@ index 0000000000000..069d1b79d6ae2
 +  }
 +#endif
 +
-+  return exe_dir.Append(FILE_PATH_LITERAL("BrowserOSServer"))
++  return exe_dir.Append(GetManagedServerDescriptor().bundle_dir)
 +      .Append(FILE_PATH_LITERAL("default"))
 +      .Append(FILE_PATH_LITERAL("resources"));
 +}
@@ -1096,12 +1056,14 @@ index 0000000000000..069d1b79d6ae2
 +    return base::FilePath();
 +  }
 +
-+  base::FilePath exec_dir = user_data_dir.Append(FILE_PATH_LITERAL(".browseros"));
++  base::FilePath exec_dir =
++      user_data_dir.Append(FILE_PATH_LITERAL(".browseros"));
 +
 +  base::ScopedAllowBlocking allow_blocking;
 +  if (!base::PathExists(exec_dir)) {
 +    if (!base::CreateDirectory(exec_dir)) {
-+      LOG(ERROR) << "browseros: Failed to create execution directory: " << exec_dir;
++      LOG(ERROR) << "browseros: Failed to create execution directory: "
++                 << exec_dir;
 +      return base::FilePath();
 +    }
 +  }
@@ -1110,11 +1072,12 @@ index 0000000000000..069d1b79d6ae2
 +  return exec_dir;
 +}
 +
-+base::FilePath BrowserOSServerManager::GetBrowserOSServerExecutablePath() const {
++base::FilePath BrowserOSServerManager::GetBrowserOSServerExecutablePath()
++    const {
 +  base::FilePath browseros_exe =
 +      GetBrowserOSServerResourcesPath()
 +          .Append(FILE_PATH_LITERAL("bin"))
-+          .Append(FILE_PATH_LITERAL("browseros_server"));
++          .Append(GetManagedServerDescriptor().binary_name);
 +
 +#if BUILDFLAG(IS_WIN)
 +  browseros_exe = browseros_exe.AddExtension(FILE_PATH_LITERAL(".exe"));

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_manager.h b/chrome/browser/browseros/server/browseros_server_manager.h
 new file mode 100644
-index 0000000000000..62e098b92b358
+index 0000000000000..2f7e3b2c7beff
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_manager.h
-@@ -0,0 +1,159 @@
+@@ -0,0 +1,154 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -37,16 +37,11 @@ index 0000000000000..62e098b92b358
 +class ProcessController;
 +class ServerStateStore;
 +class ServerUpdater;
-+}
++}  // namespace browseros
 +
 +namespace browseros {
 +
-+// BrowserOS: Manages the lifecycle of the BrowserOS server process (singleton)
-+// This manager:
-+// 1. Starts Chromium's CDP WebSocket server
-+// 2. Binds a stable MCP proxy port that forwards /mcp to the sidecar
-+// 3. Launches the bundled BrowserOS server binary with ephemeral backend ports
-+// 4. Monitors server health via HTTP /health endpoint and auto-restarts
++// Manages the selected BrowserOS product server process.
 +class BrowserOSServerManager {
 + public:
 +  // Production singleton (uses real implementations)
@@ -116,8 +111,8 @@ index 0000000000000..62e098b92b358
 +  void OnProcessLaunched(LaunchResult result);
 +
 +  void TerminateBrowserOSProcess(base::OnceCallback<void()> callback);
-+  void OnTerminateHttpComplete(base::OnceCallback<void()> callback,
-+                               bool http_success);
++  void OnTerminateProcessComplete(base::OnceCallback<void()> callback,
++                                  bool killed);
 +
 +  void RestartBrowserOSProcess();
 +  void ContinueRestartAfterTerminate();

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager_unittest.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager_unittest.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_manager_unittest.cc b/chrome/browser/browseros/server/browseros_server_manager_unittest.cc
 new file mode 100644
-index 0000000000000..8f97e0b97467f
+index 0000000000000..3fc74b5291c70
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_manager_unittest.cc
-@@ -0,0 +1,497 @@
+@@ -0,0 +1,441 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -28,10 +28,8 @@ index 0000000000000..8f97e0b97467f
 +#include "testing/gtest/include/gtest/gtest.h"
 +
 +using ::testing::_;
-+using ::testing::Invoke;
 +using ::testing::NiceMock;
 +using ::testing::Return;
-+using ::testing::StrictMock;
 +
 +namespace browseros {
 +namespace {
@@ -77,7 +75,6 @@ index 0000000000000..8f97e0b97467f
 +    ON_CALL(*process_controller_, Launch(_))
 +        .WillByDefault([](const ServerLaunchConfig&) {
 +          LaunchResult result;
-+          result.process = base::Process::Current();
 +          result.used_fallback = false;
 +          return result;
 +        });
@@ -109,11 +106,6 @@ index 0000000000000..8f97e0b97467f
 +// =============================================================================
 +
 +TEST_F(BrowserOSServerManagerTest, HealthCheckPass_NoRestart) {
-+  EXPECT_CALL(*health_checker_, CheckHealth(_, _))
-+      .WillOnce([](int port, base::OnceCallback<void(bool)> callback) {
-+        std::move(callback).Run(true);
-+      });
-+
 +  EXPECT_CALL(*process_controller_, Terminate(_, _)).Times(0);
 +}
 +
@@ -138,20 +130,9 @@ index 0000000000000..8f97e0b97467f
 +// =============================================================================
 +
 +TEST_F(BrowserOSServerManagerTest, StopCallsUpdaterStop) {
++  manager_->SetRunningForTesting(true);
 +  EXPECT_CALL(*updater_, Stop()).Times(1);
 +  manager_->Stop();
-+}
-+
-+TEST_F(BrowserOSServerManagerTest, GetBinaryPathUsesUpdater) {
-+  base::FilePath expected_path("/custom/binary/path");
-+  EXPECT_CALL(*updater_, GetBestServerBinaryPath())
-+      .WillOnce(Return(expected_path));
-+}
-+
-+TEST_F(BrowserOSServerManagerTest, GetResourcesPathUsesUpdater) {
-+  base::FilePath expected_path("/custom/resources/path");
-+  EXPECT_CALL(*updater_, GetBestServerResourcesPath())
-+      .WillOnce(Return(expected_path));
 +}
 +
 +// =============================================================================
@@ -162,8 +143,7 @@ index 0000000000000..8f97e0b97467f
 +  prefs_.SetInteger(browseros_server::kCDPServerPort, 8000);
 +  prefs_.SetInteger(browseros_server::kProxyPort, 8100);
 +
-+  auto process_controller =
-+      std::make_unique<NiceMock<MockProcessController>>();
++  auto process_controller = std::make_unique<NiceMock<MockProcessController>>();
 +  auto state_store = std::make_unique<NiceMock<MockServerStateStore>>();
 +  auto health_checker = std::make_unique<NiceMock<MockHealthChecker>>();
 +  auto updater = std::make_unique<NiceMock<MockServerUpdater>>();
@@ -189,8 +169,7 @@ index 0000000000000..8f97e0b97467f
 +  EXPECT_EQ(browseros_server::kDefaultCDPPort,
 +            prefs_.GetInteger(browseros_server::kCDPServerPort));
 +
-+  auto process_controller =
-+      std::make_unique<NiceMock<MockProcessController>>();
++  auto process_controller = std::make_unique<NiceMock<MockProcessController>>();
 +  auto state_store = std::make_unique<NiceMock<MockServerStateStore>>();
 +  auto health_checker = std::make_unique<NiceMock<MockHealthChecker>>();
 +  auto updater = std::make_unique<NiceMock<MockServerUpdater>>();
@@ -221,8 +200,7 @@ index 0000000000000..8f97e0b97467f
 +  scoped_command_line.GetProcessCommandLine()->AppendSwitch(
 +      browseros::kDisableServer);
 +
-+  auto process_controller =
-+      std::make_unique<NiceMock<MockProcessController>>();
++  auto process_controller = std::make_unique<NiceMock<MockProcessController>>();
 +  auto state_store = std::make_unique<NiceMock<MockServerStateStore>>();
 +  auto health_checker = std::make_unique<NiceMock<MockHealthChecker>>();
 +  auto updater = std::make_unique<NiceMock<MockServerUpdater>>();
@@ -256,8 +234,7 @@ index 0000000000000..8f97e0b97467f
 +  scoped_command_line.GetProcessCommandLine()->AppendSwitch(
 +      browseros::kDisableServer);
 +
-+  auto process_controller =
-+      std::make_unique<NiceMock<MockProcessController>>();
++  auto process_controller = std::make_unique<NiceMock<MockProcessController>>();
 +  auto state_store = std::make_unique<NiceMock<MockServerStateStore>>();
 +  auto health_checker = std::make_unique<NiceMock<MockHealthChecker>>();
 +  auto updater = std::make_unique<NiceMock<MockServerUpdater>>();
@@ -287,8 +264,7 @@ index 0000000000000..8f97e0b97467f
 +// =============================================================================
 +
 +TEST_F(BrowserOSServerManagerTest, HandlesNullPrefs) {
-+  auto process_controller =
-+      std::make_unique<NiceMock<MockProcessController>>();
++  auto process_controller = std::make_unique<NiceMock<MockProcessController>>();
 +  auto state_store = std::make_unique<NiceMock<MockServerStateStore>>();
 +  auto health_checker = std::make_unique<NiceMock<MockHealthChecker>>();
 +  auto updater = std::make_unique<NiceMock<MockServerUpdater>>();
@@ -305,8 +281,7 @@ index 0000000000000..8f97e0b97467f
 +
 +  auto* manager = new BrowserOSServerManager(
 +      std::move(process_controller), std::move(state_store),
-+      std::move(health_checker), std::move(updater),
-+      nullptr);
++      std::move(health_checker), std::move(updater), nullptr);
 +
 +  EXPECT_FALSE(manager->IsRunning());
 +  EXPECT_EQ(0, manager->GetCDPPort());
@@ -320,8 +295,7 @@ index 0000000000000..8f97e0b97467f
 +// =============================================================================
 +
 +TEST_F(BrowserOSServerManagerTest, HandlesNullUpdater) {
-+  auto process_controller =
-+      std::make_unique<NiceMock<MockProcessController>>();
++  auto process_controller = std::make_unique<NiceMock<MockProcessController>>();
 +  auto state_store = std::make_unique<NiceMock<MockServerStateStore>>();
 +  auto health_checker = std::make_unique<NiceMock<MockHealthChecker>>();
 +
@@ -331,9 +305,7 @@ index 0000000000000..8f97e0b97467f
 +
 +  auto* manager = new BrowserOSServerManager(
 +      std::move(process_controller), std::move(state_store),
-+      std::move(health_checker),
-+      nullptr,
-+      &prefs_);
++      std::move(health_checker), nullptr, &prefs_);
 +
 +  EXPECT_FALSE(manager->IsRunning());
 +  manager->Stop();
@@ -360,23 +332,26 @@ index 0000000000000..8f97e0b97467f
 +// Restart Server For Update Tests
 +// =============================================================================
 +
-+TEST_F(BrowserOSServerManagerTest, RestartForUpdate_FailsWhenAlreadyRestarting) {
++TEST_F(BrowserOSServerManagerTest,
++       RestartForUpdate_FailsWhenAlreadyRestarting) {
 +  bool first_callback_called = false;
 +  bool second_callback_called = false;
 +  bool first_result = true;
 +  bool second_result = true;
 +
-+  manager_->RestartServerForUpdate(
-+      base::BindOnce([](bool* called, bool* result, bool success) {
++  manager_->RestartServerForUpdate(base::BindOnce(
++      [](bool* called, bool* result, bool success) {
 +        *called = true;
 +        *result = success;
-+      }, &first_callback_called, &first_result));
++      },
++      &first_callback_called, &first_result));
 +
-+  manager_->RestartServerForUpdate(
-+      base::BindOnce([](bool* called, bool* result, bool success) {
++  manager_->RestartServerForUpdate(base::BindOnce(
++      [](bool* called, bool* result, bool success) {
 +        *called = true;
 +        *result = success;
-+      }, &second_callback_called, &second_result));
++      },
++      &second_callback_called, &second_result));
 +
 +  EXPECT_TRUE(second_callback_called);
 +  EXPECT_FALSE(second_result);
@@ -386,29 +361,14 @@ index 0000000000000..8f97e0b97467f
 +// Process Controller Integration Tests
 +// =============================================================================
 +
-+TEST_F(BrowserOSServerManagerTest, TerminateUsesProcessController) {
-+  EXPECT_CALL(*process_controller_, Terminate(_, false)).Times(1);
++TEST_F(BrowserOSServerManagerTest, StopWithoutProcessDoesNotTerminate) {
++  EXPECT_CALL(*process_controller_, Terminate(_, _)).Times(0);
++  EXPECT_CALL(*process_controller_, Kill(_, _)).Times(0);
 +  manager_->Stop();
 +}
 +
 +// =============================================================================
-+// Launch Fallback Tests
-+// =============================================================================
-+
-+TEST_F(BrowserOSServerManagerTest, InvalidatesVersionOnFallback) {
-+  ON_CALL(*process_controller_, Launch(_))
-+      .WillByDefault([](const ServerLaunchConfig&) {
-+        LaunchResult result;
-+        result.process = base::Process::Current();
-+        result.used_fallback = true;
-+        return result;
-+      });
-+
-+  EXPECT_CALL(*updater_, InvalidateDownloadedVersion()).Times(1);
-+}
-+
-+// =============================================================================
-+// Orphan Recovery / State Store Tests
++// State Store Tests
 +// =============================================================================
 +
 +TEST_F(BrowserOSServerManagerTest, StopDeletesStateFile) {
@@ -418,24 +378,6 @@ index 0000000000000..8f97e0b97467f
 +  EXPECT_CALL(*updater_, Stop()).Times(1);
 +
 +  manager_->Stop();
-+}
-+
-+TEST_F(BrowserOSServerManagerTest, RecoverFromOrphan_NoStateFile) {
-+  EXPECT_CALL(*state_store_, Read())
-+      .WillOnce(Return(std::nullopt));
-+
-+  EXPECT_CALL(*state_store_, Delete()).Times(0);
-+}
-+
-+TEST_F(BrowserOSServerManagerTest, RecoverFromOrphan_ProcessGone) {
-+  server_utils::ServerState state;
-+  state.pid = 99999;
-+  state.creation_time = 123456789;
-+
-+  EXPECT_CALL(*state_store_, Read())
-+      .WillOnce(Return(state));
-+
-+  EXPECT_CALL(*state_store_, Delete()).Times(1);
 +}
 +
 +// =============================================================================
@@ -466,7 +408,8 @@ index 0000000000000..8f97e0b97467f
 +            prefs_.GetInteger(browseros_server::kServerPort));
 +  EXPECT_EQ(manager_->GetExtensionPort(),
 +            prefs_.GetInteger(browseros_server::kExtensionServerPort));
-+  // Server and extension ports should be non-zero (resolved by FindAvailablePort)
++  // Server and extension ports should be non-zero (resolved by
++  // FindAvailablePort)
 +  EXPECT_NE(0, prefs_.GetInteger(browseros_server::kServerPort));
 +  EXPECT_NE(0, prefs_.GetInteger(browseros_server::kExtensionServerPort));
 +}
@@ -483,11 +426,12 @@ index 0000000000000..8f97e0b97467f
 +
 +  bool callback_called = false;
 +  bool callback_result = false;
-+  manager_->RestartServerForUpdate(
-+      base::BindOnce([](bool* called, bool* result, bool success) {
++  manager_->RestartServerForUpdate(base::BindOnce(
++      [](bool* called, bool* result, bool success) {
 +        *called = true;
 +        *result = success;
-+      }, &callback_called, &callback_result));
++      },
++      &callback_called, &callback_result));
 +
 +  task_environment_.RunUntilIdle();
 +

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_utils.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_utils.cc
@@ -1,6 +1,6 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_utils.cc b/chrome/browser/browseros/server/browseros_server_utils.cc
 new file mode 100644
-index 0000000000000..a24b53aad5b6c
+index 0000000000000..dbd7e166bb02c
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_utils.cc
 @@ -0,0 +1,518 @@
@@ -24,6 +24,7 @@ index 0000000000000..a24b53aad5b6c
 +#include "base/threading/platform_thread.h"
 +#include "build/build_config.h"
 +#include "chrome/browser/browseros/core/browseros_switches.h"
++#include "chrome/browser/browseros/server/browseros_server_config.h"
 +#include "chrome/common/chrome_paths.h"
 +#include "components/version_info/version_info.h"
 +#include "net/base/ip_address.h"
@@ -226,7 +227,7 @@ index 0000000000000..a24b53aad5b6c
 +  }
 +#endif
 +
-+  return exe_dir.Append(FILE_PATH_LITERAL("BrowserOSServer"))
++  return exe_dir.Append(GetManagedServerDescriptor().bundle_dir)
 +      .Append(FILE_PATH_LITERAL("default"))
 +      .Append(FILE_PATH_LITERAL("resources"));
 +}
@@ -235,7 +236,7 @@ index 0000000000000..a24b53aad5b6c
 +  base::FilePath browseros_exe =
 +      GetBundledResourcesPath()
 +          .Append(FILE_PATH_LITERAL("bin"))
-+          .Append(FILE_PATH_LITERAL("browseros_server"));
++          .Append(GetManagedServerDescriptor().binary_name);
 +
 +#if BUILDFLAG(IS_WIN)
 +  browseros_exe = browseros_exe.AddExtension(FILE_PATH_LITERAL(".exe"));
@@ -511,9 +512,8 @@ index 0000000000000..a24b53aad5b6c
 +  }
 +
 +  // Wait for process to exit
-+  DWORD wait_result =
-+      WaitForSingleObject(handle.Get(),
-+                          static_cast<DWORD>(graceful_timeout.InMilliseconds()));
++  DWORD wait_result = WaitForSingleObject(
++      handle.Get(), static_cast<DWORD>(graceful_timeout.InMilliseconds()));
 +  return wait_result == WAIT_OBJECT_0;
 +
 +#else

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/health_checker.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/health_checker.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/health_checker.h b/chrome/browser/browseros/server/health_checker.h
 new file mode 100644
-index 0000000000000..1cefa3ec91f42
+index 0000000000000..7f4516c788d3a
 --- /dev/null
 +++ b/chrome/browser/browseros/server/health_checker.h
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,25 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -11,27 +11,19 @@ index 0000000000000..1cefa3ec91f42
 +#ifndef CHROME_BROWSER_BROWSEROS_SERVER_HEALTH_CHECKER_H_
 +#define CHROME_BROWSER_BROWSEROS_SERVER_HEALTH_CHECKER_H_
 +
++#include <string>
++
 +#include "base/functional/callback.h"
 +
 +namespace browseros {
 +
-+// Interface for HTTP health check and shutdown probes.
-+// Abstracted to enable unit testing without real network requests.
 +class HealthChecker {
 + public:
 +  virtual ~HealthChecker() = default;
 +
-+  // Perform async health check by querying the /health endpoint.
-+  // Invokes callback with true on HTTP 200, false otherwise.
 +  virtual void CheckHealth(int port,
++                           const std::string& path,
 +                           base::OnceCallback<void(bool success)> callback) = 0;
-+
-+  // Request graceful shutdown via POST /shutdown endpoint.
-+  // Invokes callback with true on HTTP 200, false otherwise.
-+  // Server should exit with code 0 after receiving this request.
-+  virtual void RequestShutdown(
-+      int port,
-+      base::OnceCallback<void(bool success)> callback) = 0;
 +};
 +
 +}  // namespace browseros

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/health_checker_impl.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/health_checker_impl.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/health_checker_impl.cc b/chrome/browser/browseros/server/health_checker_impl.cc
 new file mode 100644
-index 0000000000000..73ef5eaf9e8e3
+index 0000000000000..cba17265c71d9
 --- /dev/null
 +++ b/chrome/browser/browseros/server/health_checker_impl.cc
-@@ -0,0 +1,145 @@
+@@ -0,0 +1,93 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -35,18 +35,17 @@ index 0000000000000..73ef5eaf9e8e3
 +
 +void HealthCheckerImpl::CheckHealth(
 +    int port,
++    const std::string& path,
 +    base::OnceCallback<void(bool success)> callback) {
-+  // Build health check URL
-+  GURL health_url("http://127.0.0.1:" + base::NumberToString(port) + "/health");
++  GURL health_url("http://127.0.0.1:" + base::NumberToString(port) + path);
 +
-+  // Create network traffic annotation
 +  net::NetworkTrafficAnnotationTag traffic_annotation =
 +      net::DefineNetworkTrafficAnnotation("browseros_health_check", R"(
 +        semantics {
 +          sender: "BrowserOS Server Manager"
 +          description:
 +            "Checks if the BrowserOS MCP server is healthy by querying its "
-+            "/health endpoint."
++            "configured health endpoint."
 +          trigger: "Periodic health check every 30 seconds while server is running."
 +          data: "No user data sent, just an HTTP GET request."
 +          destination: LOCAL
@@ -58,7 +57,6 @@ index 0000000000000..73ef5eaf9e8e3
 +            "Internal health check for BrowserOS server functionality."
 +        })");
 +
-+  // Create resource request
 +  auto resource_request = std::make_unique<network::ResourceRequest>();
 +  resource_request->url = health_url;
 +  resource_request->method = "GET";
@@ -68,58 +66,8 @@ index 0000000000000..73ef5eaf9e8e3
 +      std::move(resource_request), traffic_annotation);
 +  url_loader->SetTimeoutDuration(kHealthCheckTimeout);
 +
-+  // Get URL loader factory from system network context
-+  auto* url_loader_factory =
-+      g_browser_process->system_network_context_manager()
-+          ->GetURLLoaderFactory();
-+
-+  url_loader_ = std::move(url_loader);
-+  url_loader_->DownloadHeadersOnly(
-+      url_loader_factory,
-+      base::BindOnce(&HealthCheckerImpl::OnRequestComplete,
-+                     base::Unretained(this), std::move(callback)));
-+}
-+
-+void HealthCheckerImpl::RequestShutdown(
-+    int port,
-+    base::OnceCallback<void(bool success)> callback) {
-+  // Build shutdown URL
-+  GURL shutdown_url("http://127.0.0.1:" + base::NumberToString(port) +
-+                    "/shutdown");
-+
-+  // Create network traffic annotation
-+  net::NetworkTrafficAnnotationTag traffic_annotation =
-+      net::DefineNetworkTrafficAnnotation("browseros_shutdown_request", R"(
-+        semantics {
-+          sender: "BrowserOS Server Manager"
-+          description:
-+            "Requests graceful shutdown of the BrowserOS server via POST to "
-+            "/shutdown endpoint."
-+          trigger: "Browser shutdown or server restart."
-+          data: "No user data sent, just an HTTP POST request."
-+          destination: LOCAL
-+        }
-+        policy {
-+          cookies_allowed: NO
-+          setting: "This feature cannot be disabled by settings."
-+          policy_exception_justification:
-+            "Internal shutdown request for BrowserOS server functionality."
-+        })");
-+
-+  // Create resource request
-+  auto resource_request = std::make_unique<network::ResourceRequest>();
-+  resource_request->url = shutdown_url;
-+  resource_request->method = "POST";
-+  resource_request->credentials_mode = network::mojom::CredentialsMode::kOmit;
-+
-+  auto url_loader = network::SimpleURLLoader::Create(
-+      std::move(resource_request), traffic_annotation);
-+  url_loader->SetTimeoutDuration(base::Seconds(1));
-+
-+  // Get URL loader factory from system network context
-+  auto* url_loader_factory =
-+      g_browser_process->system_network_context_manager()
-+          ->GetURLLoaderFactory();
++  auto* url_loader_factory = g_browser_process->system_network_context_manager()
++                                 ->GetURLLoaderFactory();
 +
 +  url_loader_ = std::move(url_loader);
 +  url_loader_->DownloadHeadersOnly(

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/health_checker_impl.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/health_checker_impl.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/health_checker_impl.h b/chrome/browser/browseros/server/health_checker_impl.h
 new file mode 100644
-index 0000000000000..7b1d0c8678540
+index 0000000000000..b00ba7e862d32
 --- /dev/null
 +++ b/chrome/browser/browseros/server/health_checker_impl.h
-@@ -0,0 +1,49 @@
+@@ -0,0 +1,47 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -38,14 +38,12 @@ index 0000000000000..7b1d0c8678540
 +
 +  // HealthChecker implementation:
 +  void CheckHealth(int port,
++                   const std::string& path,
 +                   base::OnceCallback<void(bool success)> callback) override;
-+  void RequestShutdown(int port,
-+                       base::OnceCallback<void(bool success)> callback) override;
 +
 + private:
-+  void OnRequestComplete(
-+      base::OnceCallback<void(bool success)> callback,
-+      scoped_refptr<net::HttpResponseHeaders> headers);
++  void OnRequestComplete(base::OnceCallback<void(bool success)> callback,
++                         scoped_refptr<net::HttpResponseHeaders> headers);
 +
 +  std::unique_ptr<network::SimpleURLLoader> url_loader_;
 +};

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/process_controller_impl.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/process_controller_impl.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/process_controller_impl.cc b/chrome/browser/browseros/server/process_controller_impl.cc
 new file mode 100644
-index 0000000000000..d1bb340ae3d86
+index 0000000000000..4ea850197327e
 --- /dev/null
 +++ b/chrome/browser/browseros/server/process_controller_impl.cc
-@@ -0,0 +1,211 @@
+@@ -0,0 +1,172 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -12,14 +12,12 @@ index 0000000000000..d1bb340ae3d86
 +
 +#include <optional>
 +
-+#include "chrome/browser/browseros/server/browseros_server_utils.h"
-+
 +#include "base/files/file_util.h"
 +#include "base/json/json_writer.h"
 +#include "base/logging.h"
 +#include "base/process/launch.h"
-+#include "base/strings/string_number_conversions.h"
 +#include "build/build_config.h"
++#include "chrome/browser/browseros/server/browseros_server_utils.h"
 +
 +#if BUILDFLAG(IS_POSIX)
 +#include <signal.h>
@@ -29,57 +27,28 @@ index 0000000000000..d1bb340ae3d86
 +
 +namespace {
 +
-+constexpr base::FilePath::CharType kConfigFileName[] =
-+    FILE_PATH_LITERAL("server_config.json");
-+
-+// Writes the server configuration to a JSON file.
-+// Returns the path to the config file on success, empty path on failure.
-+// Note: resources_dir is passed separately because it may differ from
-+// config.paths.resources when fallback is used.
 +base::FilePath WriteConfigJson(const ServerLaunchConfig& config,
 +                               const base::FilePath& actual_resources_dir) {
-+  base::FilePath config_path = config.paths.execution.Append(kConfigFileName);
++  base::FilePath config_path =
++      config.paths.execution.Append(config.config_file_name);
 +
-+  base::DictValue root;
-+
-+  // ports
-+  base::DictValue ports_dict;
-+  ports_dict.Set("cdp", config.ports.cdp);
-+  ports_dict.Set("server", config.ports.server);
-+  ports_dict.Set("extension", config.ports.extension);
-+  ports_dict.Set("proxy", config.ports.proxy);
-+  root.Set("ports", std::move(ports_dict));
-+
-+  // directories
-+  base::DictValue directories;
-+  directories.Set("resources", actual_resources_dir.AsUTF8Unsafe());
-+  directories.Set("execution", config.paths.execution.AsUTF8Unsafe());
-+  root.Set("directories", std::move(directories));
-+
-+  // flags
-+  base::DictValue flags;
-+  flags.Set("allow_remote_in_mcp", config.allow_remote_in_mcp);
-+  root.Set("flags", std::move(flags));
-+
-+  // instance
-+  base::DictValue instance;
-+  instance.Set("install_id", config.identity.install_id);
-+  instance.Set("browseros_version", config.identity.browseros_version);
-+  instance.Set("chromium_version", config.identity.chromium_version);
-+  root.Set("instance", std::move(instance));
++  base::DictValue root = BuildServerConfigJson(config, actual_resources_dir);
 +
 +  std::optional<std::string> json_output = base::WriteJson(root);
 +  if (!json_output.has_value()) {
-+    LOG(ERROR) << "browseros: Failed to serialize config to JSON";
++    LOG(ERROR) << "browseros: Failed to serialize " << config.log_name
++               << " config to JSON";
 +    return base::FilePath();
 +  }
 +
 +  if (!base::WriteFile(config_path, json_output.value())) {
-+    LOG(ERROR) << "browseros: Failed to write config file: " << config_path;
++    LOG(ERROR) << "browseros: Failed to write " << config.log_name
++               << " config file: " << config_path;
 +    return base::FilePath();
 +  }
 +
-+  LOG(INFO) << "browseros: Wrote config to " << config_path;
++  LOG(INFO) << "browseros: Wrote " << config.log_name << " config to "
++            << config_path;
 +  return config_path;
 +}
 +
@@ -121,28 +90,20 @@ index 0000000000000..d1bb340ae3d86
 +    return result;
 +  }
 +
-+  // Write configuration to JSON file
 +  base::FilePath config_path = WriteConfigJson(config, actual_resources_dir);
 +  if (config_path.empty()) {
 +    LOG(ERROR) << "browseros: Failed to write config file, aborting launch";
 +    return result;
 +  }
 +
-+  // Build command line with --config flag and explicit port args
 +  base::CommandLine cmd(actual_exe_path);
 +  cmd.AppendSwitchPath("config", config_path);
-+  cmd.AppendSwitchASCII("cdp-port", base::NumberToString(config.ports.cdp));
-+  cmd.AppendSwitchASCII("server-port", base::NumberToString(config.ports.server));
-+  cmd.AppendSwitchASCII("extension-port",
-+                        base::NumberToString(config.ports.extension));
 +
-+  // Set up launch options
 +  base::LaunchOptions options;
 +#if BUILDFLAG(IS_WIN)
 +  options.start_hidden = true;
 +#endif
 +
-+  // Launch the process (blocking I/O)
 +  result.process = base::LaunchProcess(cmd, options);
 +  return result;
 +}

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/test/mock_health_checker.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/test/mock_health_checker.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/test/mock_health_checker.h b/chrome/browser/browseros/server/test/mock_health_checker.h
 new file mode 100644
-index 0000000000000..e684d775ea25d
+index 0000000000000..4c682f7febd41
 --- /dev/null
 +++ b/chrome/browser/browseros/server/test/mock_health_checker.h
-@@ -0,0 +1,33 @@
+@@ -0,0 +1,29 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -26,11 +26,7 @@ index 0000000000000..e684d775ea25d
 +
 +  MOCK_METHOD(void,
 +              CheckHealth,
-+              (int, base::OnceCallback<void(bool)>),
-+              (override));
-+  MOCK_METHOD(void,
-+              RequestShutdown,
-+              (int, base::OnceCallback<void(bool)>),
++              (int, const std::string&, base::OnceCallback<void(bool)>),
 +              (override));
 +};
 +

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/validate_resources.py
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/validate_resources.py
@@ -1,33 +1,25 @@
 diff --git a/chrome/browser/browseros/server/validate_resources.py b/chrome/browser/browseros/server/validate_resources.py
 new file mode 100644
-index 0000000000000..d7dc82b132dad
+index 0000000000000..0665cc5ce0337
 --- /dev/null
 +++ b/chrome/browser/browseros/server/validate_resources.py
-@@ -0,0 +1,43 @@
+@@ -0,0 +1,35 @@
 +#!/usr/bin/env python3
 +# Copyright 2024 The Chromium Authors
 +# Use of this source code is governed by a BSD-style license that can be
 +# found in the LICENSE file.
 +
-+"""Validates that required BrowserOS resources exist.
-+
-+Required resources must be listed in REQUIRED_RESOURCES below.
-+"""
++"""Validates that required BrowserOS server resources exist."""
 +
 +import os
 +import sys
 +
-+# Required resources that must exist in the resources/ directory
-+# Add more resources as needed - paths are relative to resources/
-+REQUIRED_RESOURCES = [
-+    "bin/browseros_server",
-+]
-+
 +script_dir = os.path.dirname(os.path.abspath(__file__))
 +resources_dir = os.path.join(script_dir, "resources")
++required_resources = sys.argv[1:] or ["bin/browseros_server"]
 +
 +all_valid = True
-+for resource in REQUIRED_RESOURCES:
++for resource in required_resources:
 +  resource_path = os.path.join(resources_dir, resource)
 +
 +  if not os.path.exists(resource_path):
@@ -41,9 +33,9 @@ index 0000000000000..d7dc82b132dad
 +
 +if not all_valid:
 +  print(f"\nEnsure all required resources exist in resources/ directory:")
-+  for resource in REQUIRED_RESOURCES:
++  for resource in required_resources:
 +    print(f"  - resources/{resource}")
 +  sys.exit(1)
 +
-+print(f"✓ BrowserOS resources validated ({len(REQUIRED_RESOURCES)} resources)")
++print(f"BrowserOS resources validated ({len(required_resources)} resources)")
 +sys.exit(0)


### PR DESCRIPTION
## Summary
- add Chromium patch files for a descriptor-driven managed server that supports BrowserOS and BrowserClaw
- keep BrowserOS server config/updater behavior while adding BrowserClaw bundle, binary, config, and health contracts
- remove Chromium's HTTP /shutdown dependency and launch the sidecar with only --config

## Design
Chromium keeps a single server lifecycle manager and selects product-specific bundle names, binary names, config filename, health path, config shape, and updater eligibility from one managed-server descriptor. BrowserOS keeps the legacy JSON shape and updater path; BrowserClaw writes the strict `ports.server`, `ports.cdp`, and `directories.resources` config shape and disables the updater until a Claw appcast contract exists.

## Test plan
- [x] `/Users/shadowfax/.skills/sf-ch-mux/scripts/chpool build -- autoninja -C out/Default_arm64 chrome`
- [x] `/Users/shadowfax/.skills/sf-ch-extract/scripts/verify-patches.sh --chromium-src /Users/shadowfax/ch1-src --worktree /Users/shadowfax/worktrees/main/feat-browseros-claw-server-manager-patches --tip 3bf090de488fe1c21718231e89d060dbc946d363`