### PR TITLE
feat: add browseros-patch annotate

### DIFF
--- a/packages/browseros/tools/patch/cmd/annotate.go
+++ b/packages/browseros/tools/patch/cmd/annotate.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/engine"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/ui"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/workspace"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	var src string
+	command := &cobra.Command{
+		Use:         "annotate [checkout] [feature]",
+		Annotations: map[string]string{"group": "Core:"},
+		Short:       "Create feature commits in a checkout",
+		Example: `  browseros-patch annotate ch1
+  browseros-patch annotate ch1 api
+  browseros-patch annotate --src /path/to/chromium/src api`,
+		Args: cobra.MaximumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ws, feature, err := resolveAnnotateTarget(cmd, args, src)
+			if err != nil {
+				return err
+			}
+			info, err := repoInfo()
+			if err != nil {
+				return err
+			}
+			result, err := engine.Annotate(cmd.Context(), engine.AnnotateOptions{
+				Workspace: ws,
+				Repo:      info,
+				Feature:   feature,
+				Progress:  commandProgress(cmd),
+			})
+			if err != nil {
+				return err
+			}
+			return renderResult(result, func() {
+				printAnnotateResult(ws, result)
+			})
+		},
+	}
+	command.Flags().StringVar(&src, "src", "", srcFlagUsage)
+	rootCmd.AddCommand(command)
+}
+
+func resolveAnnotateTarget(cmd *cobra.Command, args []string, src string) (workspace.Entry, string, error) {
+	if src != "" {
+		if len(args) > 1 {
+			return workspace.Entry{}, "", fmt.Errorf("with --src, pass at most one feature name")
+		}
+		ws, err := resolveWorkspace(cmd, nil, src)
+		feature := ""
+		if len(args) == 1 {
+			feature = args[0]
+		}
+		return ws, feature, err
+	}
+	switch len(args) {
+	case 0:
+		ws, err := resolveWorkspace(cmd, nil, "")
+		return ws, "", err
+	case 1:
+		if _, err := appState.Registry.Get(args[0]); err == nil {
+			ws, resolveErr := resolveWorkspace(cmd, args, "")
+			return ws, "", resolveErr
+		}
+		ws, detectErr := resolveWorkspace(cmd, nil, "")
+		if detectErr == nil {
+			return ws, args[0], nil
+		}
+		ws, resolveErr := resolveWorkspace(cmd, args, "")
+		return ws, "", resolveErr
+	default:
+		ws, err := resolveWorkspace(cmd, args[:1], "")
+		return ws, args[1], err
+	}
+}
+
+func printAnnotateResult(ws workspace.Entry, result *engine.AnnotateResult) {
+	fmt.Println(ui.Title(fmt.Sprintf("Annotated %s", ws.Name)))
+	fmt.Printf("%s  %s\n", ui.Muted("features file:"), result.FeaturesFile)
+	fmt.Printf("%s  %d\n", ui.Muted("processed:"), result.Processed)
+	fmt.Printf("%s  %d\n", ui.Muted("commits:"), result.CommitsCreated)
+	fmt.Printf("%s  %d\n", ui.Muted("skipped:"), result.FeaturesSkipped)
+	if len(result.Committed) > 0 {
+		fmt.Println(ui.Header("Committed:"))
+		for _, committed := range result.Committed {
+			fmt.Printf("  %-24s %s  %d %s\n", committed.Name, shortCommit(committed.Commit), len(committed.Files), pluralFiles(len(committed.Files)))
+		}
+	}
+	if len(result.Skipped) > 0 {
+		fmt.Println(ui.Header("Skipped:"))
+		for _, skipped := range result.Skipped {
+			fmt.Printf("  %-24s %s\n", skipped.Name, skipped.Reason)
+		}
+	}
+	if result.CommitsCreated == 0 {
+		fmt.Println(ui.Hint("No commits created."))
+	}
+}
+
+func shortCommit(commit string) string {
+	if len(commit) <= 12 {
+		return commit
+	}
+	return commit[:12]
+}
+
+func pluralFiles(count int) string {
+	if count == 1 {
+		return "file"
+	}
+	return "files"
+}

--- a/packages/browseros/tools/patch/cmd/common.go
+++ b/packages/browseros/tools/patch/cmd/common.go
@@ -53,7 +53,7 @@ Rules:
 - Checkout commands work from anywhere when passed a checkout name: browseros-patch diff ch1.
 - browseros-patch list reads only registered Chromium checkouts; it does not inspect sync state.
 - Use browseros-patch status ch1 or browseros-patch diff ch1 before mutating.
-- Mutating commands: browseros-patch sync ch1 (alias: pull), browseros-patch apply ch1, browseros-patch extract ch1.
+- Mutating commands: browseros-patch sync ch1 (alias: pull), browseros-patch apply ch1, browseros-patch extract ch1, browseros-patch annotate ch1.
 - Every command accepts --json for machine-readable output and never prompts.
 
 Exit codes:
@@ -76,6 +76,10 @@ Capture flow (turn checkout changes into patches):
 1. browseros-patch extract ch1 --dry-run   # preview created/updated/deleted/unchanged
 2. browseros-patch extract ch1             # write; unchanged patches are never rewritten
 3. browseros-patch publish -m "chore: sync patches"   # commit + push chromium_patches
+
+Feature commit flow (turn checkout changes into feature commits):
+1. browseros-patch annotate ch1            # commit changed files by build/features.yaml feature
+2. browseros-patch annotate ch1 api        # commit only one feature
 
 Chromium upgrade loop (move patches to a new Chromium base):
 1. gclient sync the checkout to the new Chromium revision.

--- a/packages/browseros/tools/patch/cmd/common_test.go
+++ b/packages/browseros/tools/patch/cmd/common_test.go
@@ -374,6 +374,12 @@ func TestRootHelpExplainsPatchRepoAndCheckoutModel(t *testing.T) {
 	}
 }
 
+func TestRootExamplesDoNotRenderSourceTabs(t *testing.T) {
+	if strings.Contains(rootCmd.Example, "\n\t") {
+		t.Fatalf("root examples should render with spaces, got:\n%s", rootCmd.Example)
+	}
+}
+
 func TestCheckoutCommandExamplesUseNamedCheckout(t *testing.T) {
 	for _, tc := range []struct {
 		name    string

--- a/packages/browseros/tools/patch/cmd/common_test.go
+++ b/packages/browseros/tools/patch/cmd/common_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/app"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/engine"
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/workspace"
 	"github.com/spf13/cobra"
 )
@@ -92,6 +93,118 @@ func TestConflictPauseErrorClassification(t *testing.T) {
 	}
 	if exitErr.code != 2 {
 		t.Fatalf("conflict pause exit code = %d, want 2", exitErr.code)
+	}
+}
+
+func TestResolveAnnotateTargetUsesSrcArgAsFeature(t *testing.T) {
+	oldAppState := appState
+	t.Cleanup(func() {
+		appState = oldAppState
+	})
+
+	checkout := filepath.Join(t.TempDir(), "chromium")
+	if err := os.MkdirAll(filepath.Join(checkout, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	appState = &app.App{
+		CWD:      t.TempDir(),
+		Registry: &workspace.Registry{Version: 1},
+	}
+
+	ws, feature, err := resolveAnnotateTarget(&cobra.Command{Use: "annotate"}, []string{"api"}, checkout)
+	if err != nil {
+		t.Fatalf("resolveAnnotateTarget: %v", err)
+	}
+	realCheckout, err := filepath.EvalSymlinks(checkout)
+	if err != nil {
+		t.Fatalf("EvalSymlinks: %v", err)
+	}
+	if ws.Path != realCheckout || feature != "api" {
+		t.Fatalf("got workspace=%+v feature=%q, want src path and api feature", ws, feature)
+	}
+}
+
+func TestResolveAnnotateTargetTreatsUnknownSingleArgAsFeatureInCheckout(t *testing.T) {
+	oldAppState := appState
+	t.Cleanup(func() {
+		appState = oldAppState
+	})
+
+	checkout := filepath.Join(t.TempDir(), "chromium")
+	cwd := filepath.Join(checkout, "chrome")
+	if err := os.MkdirAll(cwd, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	appState = &app.App{
+		CWD: cwd,
+		Registry: &workspace.Registry{Version: 1, Workspaces: []workspace.Entry{
+			{Name: "ch1", Path: checkout},
+		}},
+	}
+
+	ws, feature, err := resolveAnnotateTarget(&cobra.Command{Use: "annotate"}, []string{"api"}, "")
+	if err != nil {
+		t.Fatalf("resolveAnnotateTarget: %v", err)
+	}
+	if ws.Name != "ch1" || feature != "api" {
+		t.Fatalf("got workspace=%+v feature=%q, want ch1 and api", ws, feature)
+	}
+}
+
+func TestResolveAnnotateTargetTreatsRegisteredSingleArgAsCheckout(t *testing.T) {
+	oldAppState := appState
+	t.Cleanup(func() {
+		appState = oldAppState
+	})
+
+	checkout := filepath.Join(t.TempDir(), "chromium")
+	appState = &app.App{
+		CWD: t.TempDir(),
+		Registry: &workspace.Registry{Version: 1, Workspaces: []workspace.Entry{
+			{Name: "api", Path: checkout},
+		}},
+	}
+
+	ws, feature, err := resolveAnnotateTarget(&cobra.Command{Use: "annotate"}, []string{"api"}, "")
+	if err != nil {
+		t.Fatalf("resolveAnnotateTarget: %v", err)
+	}
+	if ws.Name != "api" || feature != "" {
+		t.Fatalf("got workspace=%+v feature=%q, want api checkout and empty feature", ws, feature)
+	}
+}
+
+func TestPrintAnnotateResultSummarizesHumanOutput(t *testing.T) {
+	output := captureStdout(t, func() {
+		printAnnotateResult(workspace.Entry{Name: "ch1"}, &engine.AnnotateResult{
+			FeaturesFile:    "/repo/build/features.yaml",
+			Processed:       2,
+			CommitsCreated:  1,
+			FeaturesSkipped: 1,
+			Committed: []engine.AnnotateCommittedFeature{{
+				Name:   "api",
+				Commit: "1234567890abcdef",
+				Files:  []string{"chrome/a.cc"},
+			}},
+			Skipped: []engine.AnnotateSkippedFeature{{
+				Name:   "clean",
+				Reason: "no changes",
+			}},
+		})
+	})
+
+	for _, want := range []string{
+		"Annotated ch1",
+		"processed:",
+		"commits:",
+		"api",
+		"1234567890ab",
+		"clean",
+		"no changes",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected output to contain %q, got:\n%s", want, output)
+		}
 	}
 }
 
@@ -220,6 +333,7 @@ func TestCheckoutCommandUsageTerminology(t *testing.T) {
 		{name: "apply", use: "apply [checkout] [-- files...]"},
 		{name: "sync", use: "sync [checkout]"},
 		{name: "extract", use: "extract [checkout] [--range <start> <end>] [-- files...]"},
+		{name: "annotate", use: "annotate [checkout] [feature]"},
 	} {
 		cmd, _, err := rootCmd.Find([]string{tc.name})
 		if err != nil {
@@ -252,6 +366,7 @@ func TestRootHelpExplainsPatchRepoAndCheckoutModel(t *testing.T) {
 		"browseros-patch diff ch1",
 		"browseros-patch sync ch1",
 		"browseros-patch extract ch1",
+		"browseros-patch annotate ch1",
 	} {
 		if !strings.Contains(rootCmd.Example, want) {
 			t.Fatalf("expected root examples to contain %q, got:\n%s", want, rootCmd.Example)
@@ -269,6 +384,7 @@ func TestCheckoutCommandExamplesUseNamedCheckout(t *testing.T) {
 		{name: "apply", example: "browseros-patch apply ch1"},
 		{name: "sync", example: "browseros-patch sync ch1"},
 		{name: "extract", example: "browseros-patch extract ch1"},
+		{name: "annotate", example: "browseros-patch annotate ch1"},
 	} {
 		cmd, _, err := rootCmd.Find([]string{tc.name})
 		if err != nil {
@@ -281,7 +397,7 @@ func TestCheckoutCommandExamplesUseNamedCheckout(t *testing.T) {
 }
 
 func TestSrcFlagExplainsDirectCheckoutPath(t *testing.T) {
-	for _, name := range []string{"diff", "status", "apply", "sync", "extract"} {
+	for _, name := range []string{"diff", "status", "apply", "sync", "extract", "annotate"} {
 		cmd, _, err := rootCmd.Find([]string{name})
 		if err != nil {
 			t.Fatalf("find %s: %v", name, err)
@@ -310,6 +426,7 @@ func TestLLMTxtGuideContent(t *testing.T) {
 		"browseros-patch sync ch1",
 		"browseros-patch apply ch1",
 		"browseros-patch extract ch1",
+		"browseros-patch annotate ch1",
 		"list reads only registered Chromium checkouts",
 		"does not inspect sync state",
 		// agent playbook
@@ -321,6 +438,7 @@ func TestLLMTxtGuideContent(t *testing.T) {
 		"browseros-patch skip",
 		"browseros-patch abort",
 		"browseros-patch extract ch1 --dry-run",
+		"browseros-patch annotate ch1 api",
 		".browseros-patchignore",
 		"BASE_COMMIT",
 		"browseros-patch publish",

--- a/packages/browseros/tools/patch/cmd/root.go
+++ b/packages/browseros/tools/patch/cmd/root.go
@@ -93,12 +93,12 @@ var rootCmd = &cobra.Command{
   Chromium checkout: a named local Chromium src tree, such as ch1
 
 Pass a checkout name to run from anywhere, for example "browseros-patch diff ch1".`,
-	Example: `  browseros-patch add ch1 /path/to/chromium/src
-	  browseros-patch list
-	  browseros-patch diff ch1
-	  browseros-patch sync ch1
-	  browseros-patch extract ch1
-	  browseros-patch annotate ch1`,
+	Example: "  browseros-patch add ch1 /path/to/chromium/src\n" +
+		"  browseros-patch list\n" +
+		"  browseros-patch diff ch1\n" +
+		"  browseros-patch sync ch1\n" +
+		"  browseros-patch extract ch1\n" +
+		"  browseros-patch annotate ch1",
 	Version:       Version,
 	SilenceUsage:  true,
 	SilenceErrors: true,

--- a/packages/browseros/tools/patch/cmd/root.go
+++ b/packages/browseros/tools/patch/cmd/root.go
@@ -94,10 +94,11 @@ var rootCmd = &cobra.Command{
 
 Pass a checkout name to run from anywhere, for example "browseros-patch diff ch1".`,
 	Example: `  browseros-patch add ch1 /path/to/chromium/src
-  browseros-patch list
-  browseros-patch diff ch1
-  browseros-patch sync ch1
-  browseros-patch extract ch1`,
+	  browseros-patch list
+	  browseros-patch diff ch1
+	  browseros-patch sync ch1
+	  browseros-patch extract ch1
+	  browseros-patch annotate ch1`,
 	Version:       Version,
 	SilenceUsage:  true,
 	SilenceErrors: true,

--- a/packages/browseros/tools/patch/internal/engine/annotate.go
+++ b/packages/browseros/tools/patch/internal/engine/annotate.go
@@ -1,0 +1,217 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/git"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/patch"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/repo"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/workspace"
+	"gopkg.in/yaml.v3"
+)
+
+type AnnotateOptions struct {
+	Workspace workspace.Entry
+	Repo      *repo.Info
+	Feature   string
+	Progress  Progress
+}
+
+type AnnotateResult struct {
+	Workspace       string                     `json:"workspace"`
+	FeaturesFile    string                     `json:"features_file"`
+	Feature         string                     `json:"feature,omitempty"`
+	Processed       int                        `json:"processed"`
+	CommitsCreated  int                        `json:"commits_created"`
+	FeaturesSkipped int                        `json:"features_skipped"`
+	Committed       []AnnotateCommittedFeature `json:"committed"`
+	Skipped         []AnnotateSkippedFeature   `json:"skipped"`
+}
+
+type AnnotateCommittedFeature struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Commit      string   `json:"commit"`
+	Files       []string `json:"files"`
+}
+
+type AnnotateSkippedFeature struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Reason      string `json:"reason"`
+}
+
+type annotateFeature struct {
+	Name        string
+	Description string
+	Files       []string
+}
+
+// Annotate creates Chromium checkout commits grouped by build/features.yaml.
+func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error) {
+	featuresFile := filepath.Join(opts.Repo.Root, "build", "features.yaml")
+	features, err := loadAnnotateFeatures(featuresFile)
+	if err != nil {
+		return nil, err
+	}
+	if opts.Feature != "" {
+		filtered := slices.DeleteFunc(slices.Clone(features), func(feature annotateFeature) bool {
+			return feature.Name != opts.Feature
+		})
+		if len(filtered) == 0 {
+			return nil, fmt.Errorf("feature %q not found in features.yaml", opts.Feature)
+		}
+		features = filtered
+	}
+	result := &AnnotateResult{
+		Workspace:    opts.Workspace.Name,
+		FeaturesFile: featuresFile,
+		Feature:      opts.Feature,
+	}
+	for _, feature := range features {
+		result.Processed++
+		reportProgress(opts.Progress, "Annotating feature %s", feature.Name)
+		if len(feature.Files) == 0 {
+			result.Skipped = append(result.Skipped, AnnotateSkippedFeature{
+				Name:        feature.Name,
+				Description: feature.Description,
+				Reason:      "no files",
+			})
+			result.FeaturesSkipped++
+			continue
+		}
+		modified, err := modifiedFeatureFiles(ctx, opts.Workspace.Path, feature.Files)
+		if err != nil {
+			return nil, err
+		}
+		if len(modified) == 0 {
+			result.Skipped = append(result.Skipped, AnnotateSkippedFeature{
+				Name:        feature.Name,
+				Description: feature.Description,
+				Reason:      "no changes",
+			})
+			result.FeaturesSkipped++
+			continue
+		}
+		commit, err := commitFeatureFiles(ctx, opts.Workspace.Path, feature.Description, modified)
+		if err != nil {
+			return nil, fmt.Errorf("commit feature %s: %w", feature.Name, err)
+		}
+		result.Committed = append(result.Committed, AnnotateCommittedFeature{
+			Name:        feature.Name,
+			Description: feature.Description,
+			Commit:      commit,
+			Files:       modified,
+		})
+		result.CommitsCreated++
+	}
+	return result, nil
+}
+
+func loadAnnotateFeatures(featuresFile string) ([]annotateFeature, error) {
+	body, err := os.ReadFile(featuresFile)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("features file not found: %s", featuresFile)
+		}
+		return nil, err
+	}
+	var root yaml.Node
+	if err := yaml.Unmarshal(body, &root); err != nil {
+		return nil, err
+	}
+	featuresNode := mappingValue(&root, "features")
+	if featuresNode == nil || featuresNode.Kind != yaml.MappingNode || len(featuresNode.Content) == 0 {
+		return nil, fmt.Errorf("no features found in %s", featuresFile)
+	}
+	features := make([]annotateFeature, 0, len(featuresNode.Content)/2)
+	for idx := 0; idx+1 < len(featuresNode.Content); idx += 2 {
+		name := featuresNode.Content[idx].Value
+		data := featuresNode.Content[idx+1]
+		description := scalarValue(data, "description")
+		if description == "" {
+			description = name
+		}
+		features = append(features, annotateFeature{
+			Name:        name,
+			Description: description,
+			Files:       stringSequence(data, "files"),
+		})
+	}
+	return features, nil
+}
+
+func mappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node == nil {
+		return nil
+	}
+	if node.Kind == yaml.DocumentNode && len(node.Content) > 0 {
+		node = node.Content[0]
+	}
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+	for idx := 0; idx+1 < len(node.Content); idx += 2 {
+		if node.Content[idx].Value == key {
+			return node.Content[idx+1]
+		}
+	}
+	return nil
+}
+
+func scalarValue(node *yaml.Node, key string) string {
+	value := mappingValue(node, key)
+	if value == nil || value.Kind != yaml.ScalarNode {
+		return ""
+	}
+	return value.Value
+}
+
+func stringSequence(node *yaml.Node, key string) []string {
+	value := mappingValue(node, key)
+	if value == nil || value.Kind != yaml.SequenceNode {
+		return nil
+	}
+	var items []string
+	for _, item := range value.Content {
+		if item.Kind != yaml.ScalarNode {
+			continue
+		}
+		rel := patch.NormalizeChromiumPath(item.Value)
+		if rel != "." && rel != "" {
+			items = append(items, rel)
+		}
+	}
+	return items
+}
+
+func modifiedFeatureFiles(ctx context.Context, workspacePath string, files []string) ([]string, error) {
+	changes, err := git.StatusPorcelain(ctx, workspacePath, files)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	var modified []string
+	for _, change := range changes {
+		rel := patch.NormalizeChromiumPath(change.Path)
+		if rel == "." || rel == "" || patch.IsInternalPath(rel) || seen[rel] {
+			continue
+		}
+		seen[rel] = true
+		modified = append(modified, rel)
+	}
+	slices.Sort(modified)
+	return modified, nil
+}
+
+func commitFeatureFiles(ctx context.Context, workspacePath string, message string, files []string) (string, error) {
+	if err := git.AddPaths(ctx, workspacePath, files); err != nil {
+		return "", err
+	}
+	return git.CommitPaths(ctx, workspacePath, message, files)
+}

--- a/packages/browseros/tools/patch/internal/engine/annotate.go
+++ b/packages/browseros/tools/patch/internal/engine/annotate.go
@@ -76,7 +76,7 @@ func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error
 		}
 		features = filtered
 	}
-	changes, err := annotateChanges(ctx, opts.Workspace.Path, allFeatures)
+	changes, err := annotateChanges(ctx, opts.Workspace.Path)
 	if err != nil {
 		return nil, err
 	}
@@ -202,20 +202,8 @@ func stringSequence(node *yaml.Node, key string) []string {
 	return items
 }
 
-func annotateChanges(ctx context.Context, workspacePath string, features []annotateFeature) ([]git.FileChange, error) {
-	return git.StatusPorcelain(ctx, workspacePath, annotateScope(features))
-}
-
-func annotateScope(features []annotateFeature) []string {
-	seen := map[string]bool{}
-	var scope []string
-	for _, feature := range features {
-		for _, rel := range feature.Files {
-			appendUniquePath(&scope, seen, rel)
-		}
-	}
-	slices.Sort(scope)
-	return scope
+func annotateChanges(ctx context.Context, workspacePath string) ([]git.FileChange, error) {
+	return git.StatusPorcelain(ctx, workspacePath, nil)
 }
 
 func modifiedFeatureFiles(changes []git.FileChange, feature annotateFeature, allFeatures []annotateFeature) annotateFileSet {

--- a/packages/browseros/tools/patch/internal/engine/annotate.go
+++ b/packages/browseros/tools/patch/internal/engine/annotate.go
@@ -76,6 +76,10 @@ func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error
 		}
 		features = filtered
 	}
+	changes, err := annotateChanges(ctx, opts.Workspace.Path, allFeatures)
+	if err != nil {
+		return nil, err
+	}
 	result := &AnnotateResult{
 		Workspace:    opts.Workspace.Name,
 		FeaturesFile: featuresFile,
@@ -95,10 +99,7 @@ func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error
 			result.FeaturesSkipped++
 			continue
 		}
-		files, err := modifiedFeatureFiles(ctx, opts.Workspace.Path, feature, allFeatures)
-		if err != nil {
-			return nil, err
-		}
+		files := modifiedFeatureFiles(changes, feature, allFeatures)
 		if len(files.report) == 0 {
 			result.Skipped = append(result.Skipped, AnnotateSkippedFeature{
 				Name:        feature.Name,
@@ -201,11 +202,23 @@ func stringSequence(node *yaml.Node, key string) []string {
 	return items
 }
 
-func modifiedFeatureFiles(ctx context.Context, workspacePath string, feature annotateFeature, allFeatures []annotateFeature) (annotateFileSet, error) {
-	changes, err := git.StatusPorcelain(ctx, workspacePath, feature.Files)
-	if err != nil {
-		return annotateFileSet{}, err
+func annotateChanges(ctx context.Context, workspacePath string, features []annotateFeature) ([]git.FileChange, error) {
+	return git.StatusPorcelain(ctx, workspacePath, annotateScope(features))
+}
+
+func annotateScope(features []annotateFeature) []string {
+	seen := map[string]bool{}
+	var scope []string
+	for _, feature := range features {
+		for _, rel := range feature.Files {
+			appendUniquePath(&scope, seen, rel)
+		}
 	}
+	slices.Sort(scope)
+	return scope
+}
+
+func modifiedFeatureFiles(changes []git.FileChange, feature annotateFeature, allFeatures []annotateFeature) annotateFileSet {
 	set := annotateFileSet{}
 	reportSeen := map[string]bool{}
 	stageSeen := map[string]bool{}
@@ -228,7 +241,7 @@ func modifiedFeatureFiles(ctx context.Context, workspacePath string, feature ann
 	slices.Sort(set.report)
 	slices.Sort(set.stage)
 	slices.Sort(set.commit)
-	return set, nil
+	return set
 }
 
 func ownerFeature(change git.FileChange, features []annotateFeature) *annotateFeature {

--- a/packages/browseros/tools/patch/internal/engine/annotate.go
+++ b/packages/browseros/tools/patch/internal/engine/annotate.go
@@ -50,6 +50,13 @@ type annotateFeature struct {
 	Name        string
 	Description string
 	Files       []string
+	Index       int
+}
+
+type annotateFileSet struct {
+	report []string
+	stage  []string
+	commit []string
 }
 
 // Annotate creates Chromium checkout commits grouped by build/features.yaml.
@@ -59,6 +66,7 @@ func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error
 	if err != nil {
 		return nil, err
 	}
+	allFeatures := features
 	if opts.Feature != "" {
 		filtered := slices.DeleteFunc(slices.Clone(features), func(feature annotateFeature) bool {
 			return feature.Name != opts.Feature
@@ -87,11 +95,11 @@ func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error
 			result.FeaturesSkipped++
 			continue
 		}
-		modified, err := modifiedFeatureFiles(ctx, opts.Workspace.Path, feature.Files)
+		files, err := modifiedFeatureFiles(ctx, opts.Workspace.Path, feature, allFeatures)
 		if err != nil {
 			return nil, err
 		}
-		if len(modified) == 0 {
+		if len(files.report) == 0 {
 			result.Skipped = append(result.Skipped, AnnotateSkippedFeature{
 				Name:        feature.Name,
 				Description: feature.Description,
@@ -100,7 +108,7 @@ func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error
 			result.FeaturesSkipped++
 			continue
 		}
-		commit, err := commitFeatureFiles(ctx, opts.Workspace.Path, feature.Description, feature.Files)
+		commit, err := commitFeatureFiles(ctx, opts.Workspace.Path, feature.Description, files.stage, files.commit)
 		if err != nil {
 			return nil, fmt.Errorf("commit feature %s: %w", feature.Name, err)
 		}
@@ -108,7 +116,7 @@ func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error
 			Name:        feature.Name,
 			Description: feature.Description,
 			Commit:      commit,
-			Files:       modified,
+			Files:       files.report,
 		})
 		result.CommitsCreated++
 	}
@@ -143,6 +151,7 @@ func loadAnnotateFeatures(featuresFile string) ([]annotateFeature, error) {
 			Name:        name,
 			Description: description,
 			Files:       stringSequence(data, "files"),
+			Index:       len(features),
 		})
 	}
 	return features, nil
@@ -192,30 +201,125 @@ func stringSequence(node *yaml.Node, key string) []string {
 	return items
 }
 
-func modifiedFeatureFiles(ctx context.Context, workspacePath string, files []string) ([]string, error) {
-	changes, err := git.StatusPorcelain(ctx, workspacePath, files)
+func modifiedFeatureFiles(ctx context.Context, workspacePath string, feature annotateFeature, allFeatures []annotateFeature) (annotateFileSet, error) {
+	changes, err := git.StatusPorcelain(ctx, workspacePath, feature.Files)
 	if err != nil {
-		return nil, err
+		return annotateFileSet{}, err
 	}
-	seen := map[string]bool{}
-	var modified []string
+	set := annotateFileSet{}
+	reportSeen := map[string]bool{}
+	stageSeen := map[string]bool{}
+	commitSeen := map[string]bool{}
 	for _, change := range changes {
-		for _, rel := range []string{change.Path, change.OldPath} {
-			rel = patch.NormalizeChromiumPath(rel)
-			if rel == "." || rel == "" || patch.IsInternalPath(rel) || seen[rel] {
-				continue
-			}
-			seen[rel] = true
-			modified = append(modified, rel)
+		owner := ownerFeature(change, allFeatures)
+		if owner == nil || owner.Name != feature.Name {
+			continue
+		}
+		for _, rel := range changeReportPaths(change) {
+			appendUniquePath(&set.report, reportSeen, rel)
+		}
+		for _, rel := range changeStagePaths(change) {
+			appendUniquePath(&set.stage, stageSeen, rel)
+		}
+		for _, rel := range changeReportPaths(change) {
+			appendUniquePath(&set.commit, commitSeen, rel)
 		}
 	}
-	slices.Sort(modified)
-	return modified, nil
+	slices.Sort(set.report)
+	slices.Sort(set.stage)
+	slices.Sort(set.commit)
+	return set, nil
 }
 
-func commitFeatureFiles(ctx context.Context, workspacePath string, message string, files []string) (string, error) {
-	if err := git.AddAllPaths(ctx, workspacePath, files); err != nil {
+func ownerFeature(change git.FileChange, features []annotateFeature) *annotateFeature {
+	var owner *annotateFeature
+	bestScore := -1
+	for idx := range features {
+		score := featureChangeScore(features[idx], change)
+		if score < 0 {
+			continue
+		}
+		if score > bestScore || score == bestScore && owner != nil && features[idx].Index > owner.Index {
+			bestScore = score
+			owner = &features[idx]
+		}
+	}
+	return owner
+}
+
+func featureChangeScore(feature annotateFeature, change git.FileChange) int {
+	best := -1
+	for _, rel := range changeReportPaths(change) {
+		if score := featurePathScore(feature, rel); score > best {
+			best = score
+		}
+	}
+	return best
+}
+
+func featurePathScore(feature annotateFeature, rel string) int {
+	best := -1
+	for _, scope := range feature.Files {
+		if !patch.PathMatches(rel, []string{scope}) {
+			continue
+		}
+		if len(scope) > best {
+			best = len(scope)
+		}
+	}
+	return best
+}
+
+func changeReportPaths(change git.FileChange) []string {
+	paths := []string{change.Path}
+	if change.OldPath != "" {
+		paths = append(paths, change.OldPath)
+	}
+	return normalizeAnnotatePaths(paths)
+}
+
+func changeStagePaths(change git.FileChange) []string {
+	if change.Status == "??" {
+		return normalizeAnnotatePaths([]string{change.Path})
+	}
+	if len(change.Status) < 2 {
+		return changeReportPaths(change)
+	}
+	var paths []string
+	indexStatus := change.Status[0]
+	worktreeStatus := change.Status[1]
+	if worktreeStatus != ' ' {
+		paths = append(paths, change.Path)
+		if indexStatus == ' ' && change.OldPath != "" {
+			paths = append(paths, change.OldPath)
+		}
+	}
+	return normalizeAnnotatePaths(paths)
+}
+
+func normalizeAnnotatePaths(paths []string) []string {
+	normalized := make([]string, 0, len(paths))
+	for _, raw := range paths {
+		rel := patch.NormalizeChromiumPath(raw)
+		if rel == "." || rel == "" || patch.IsInternalPath(rel) {
+			continue
+		}
+		normalized = append(normalized, rel)
+	}
+	return normalized
+}
+
+func appendUniquePath(paths *[]string, seen map[string]bool, rel string) {
+	if seen[rel] {
+		return
+	}
+	seen[rel] = true
+	*paths = append(*paths, rel)
+}
+
+func commitFeatureFiles(ctx context.Context, workspacePath string, message string, stagePaths []string, commitPaths []string) (string, error) {
+	if err := git.AddAllPaths(ctx, workspacePath, stagePaths); err != nil {
 		return "", err
 	}
-	return git.CommitPaths(ctx, workspacePath, message, files)
+	return git.CommitPaths(ctx, workspacePath, message, commitPaths)
 }

--- a/packages/browseros/tools/patch/internal/engine/annotate.go
+++ b/packages/browseros/tools/patch/internal/engine/annotate.go
@@ -72,6 +72,8 @@ func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error
 		Workspace:    opts.Workspace.Name,
 		FeaturesFile: featuresFile,
 		Feature:      opts.Feature,
+		Committed:    []AnnotateCommittedFeature{},
+		Skipped:      []AnnotateSkippedFeature{},
 	}
 	for _, feature := range features {
 		result.Processed++

--- a/packages/browseros/tools/patch/internal/engine/annotate.go
+++ b/packages/browseros/tools/patch/internal/engine/annotate.go
@@ -100,7 +100,7 @@ func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error
 			result.FeaturesSkipped++
 			continue
 		}
-		commit, err := commitFeatureFiles(ctx, opts.Workspace.Path, feature.Description, modified)
+		commit, err := commitFeatureFiles(ctx, opts.Workspace.Path, feature.Description, feature.Files)
 		if err != nil {
 			return nil, fmt.Errorf("commit feature %s: %w", feature.Name, err)
 		}
@@ -200,19 +200,21 @@ func modifiedFeatureFiles(ctx context.Context, workspacePath string, files []str
 	seen := map[string]bool{}
 	var modified []string
 	for _, change := range changes {
-		rel := patch.NormalizeChromiumPath(change.Path)
-		if rel == "." || rel == "" || patch.IsInternalPath(rel) || seen[rel] {
-			continue
+		for _, rel := range []string{change.Path, change.OldPath} {
+			rel = patch.NormalizeChromiumPath(rel)
+			if rel == "." || rel == "" || patch.IsInternalPath(rel) || seen[rel] {
+				continue
+			}
+			seen[rel] = true
+			modified = append(modified, rel)
 		}
-		seen[rel] = true
-		modified = append(modified, rel)
 	}
 	slices.Sort(modified)
 	return modified, nil
 }
 
 func commitFeatureFiles(ctx context.Context, workspacePath string, message string, files []string) (string, error) {
-	if err := git.AddPaths(ctx, workspacePath, files); err != nil {
+	if err := git.AddAllPaths(ctx, workspacePath, files); err != nil {
 		return "", err
 	}
 	return git.CommitPaths(ctx, workspacePath, message, files)

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -227,6 +227,97 @@ features:
 	}
 }
 
+func TestAnnotateAssignsOverlappingPathsToMostSpecificFeature(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser", "browseros", "core", "shared.cc"), "shared\n")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser", "browseros", "core", "browseros_prefs.cc"), "prefs\n")
+	runGit(t, workspacePath, "add", "chrome")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser", "browseros", "core", "shared.cc"), "shared changed\n")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser", "browseros", "core", "browseros_prefs.cc"), "prefs changed\n")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  browseros-core:
+    description: "chore: browseros core"
+    files:
+      - chrome/browser/browseros/core/
+  onboarding-import:
+    description: "feat: onboarding import"
+    files:
+      - chrome/browser/browseros/core/browseros_prefs.cc
+`)
+
+	result, err := Annotate(ctx, AnnotateOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+	})
+	if err != nil {
+		t.Fatalf("Annotate: %v", err)
+	}
+	if result.CommitsCreated != 2 {
+		t.Fatalf("expected two commits, got %+v", result)
+	}
+	if !slices.Equal(result.Committed[0].Files, []string{"chrome/browser/browseros/core/shared.cc"}) {
+		t.Fatalf("core feature stole overlapping path: %v", result.Committed[0].Files)
+	}
+	if !slices.Equal(result.Committed[1].Files, []string{"chrome/browser/browseros/core/browseros_prefs.cc"}) {
+		t.Fatalf("specific feature did not own exact path: %v", result.Committed[1].Files)
+	}
+	if files := strings.Split(gitOutput(t, workspacePath, "show", "--name-only", "--format=", "HEAD~1"), "\n"); !slices.Equal(files, []string{"chrome/browser/browseros/core/shared.cc"}) {
+		t.Fatalf("core commit files = %v", files)
+	}
+	if files := strings.Split(gitOutput(t, workspacePath, "show", "--name-only", "--format=", "HEAD"), "\n"); !slices.Equal(files, []string{"chrome/browser/browseros/core/browseros_prefs.cc"}) {
+		t.Fatalf("specific commit files = %v", files)
+	}
+}
+
+func TestAnnotateSingleFeatureDoesNotStealMoreSpecificOverlap(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser", "browseros", "core", "browseros_prefs.cc"), "prefs\n")
+	runGit(t, workspacePath, "add", "chrome")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser", "browseros", "core", "browseros_prefs.cc"), "prefs changed\n")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  browseros-core:
+    description: "chore: browseros core"
+    files:
+      - chrome/browser/browseros/core/
+  onboarding-import:
+    description: "feat: onboarding import"
+    files:
+      - chrome/browser/browseros/core/browseros_prefs.cc
+`)
+
+	result, err := Annotate(ctx, AnnotateOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+		Feature:   "browseros-core",
+	})
+	if err != nil {
+		t.Fatalf("Annotate: %v", err)
+	}
+	if result.CommitsCreated != 0 || result.FeaturesSkipped != 1 {
+		t.Fatalf("expected broad feature to skip specific overlap, got %+v", result)
+	}
+	if head := gitOutput(t, workspacePath, "log", "-1", "--format=%s"); head != "workspace base" {
+		t.Fatalf("broad feature should not commit overlap, got head %q", head)
+	}
+	if status := gitOutput(t, workspacePath, "status", "--porcelain"); status == "" {
+		t.Fatalf("specific overlap change should remain dirty")
+	}
+}
+
 func TestAnnotateCommitsRenamesUnderDirectoryFeature(t *testing.T) {
 	ctx := context.Background()
 	workspacePath := initGitRepo(t)

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -227,6 +227,46 @@ features:
 	}
 }
 
+func TestAnnotateCommitsRenamesUnderDirectoryFeature(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "old.cc"), "old\n")
+	runGit(t, workspacePath, "add", "chrome/old.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	runGit(t, workspacePath, "mv", "chrome/old.cc", "chrome/new.cc")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  renames:
+    description: "feat: rename file"
+    files:
+      - chrome/
+`)
+
+	result, err := Annotate(ctx, AnnotateOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+	})
+	if err != nil {
+		t.Fatalf("Annotate: %v", err)
+	}
+	if result.CommitsCreated != 1 {
+		t.Fatalf("expected rename commit, got %+v", result)
+	}
+	if !slices.Equal(result.Committed[0].Files, []string{"chrome/new.cc", "chrome/old.cc"}) {
+		t.Fatalf("unexpected committed rename paths: %v", result.Committed[0].Files)
+	}
+	if status := gitOutput(t, workspacePath, "status", "--porcelain"); status != "" {
+		t.Fatalf("expected clean checkout after rename annotate, got %q", status)
+	}
+	if nameStatus := gitOutput(t, workspacePath, "show", "--name-status", "--format=", "HEAD"); !strings.Contains(nameStatus, "R100\tchrome/old.cc\tchrome/new.cc") {
+		t.Fatalf("expected rename in commit, got:\n%s", nameStatus)
+	}
+}
+
 func TestAnnotateMissingFeatureDoesNotCommit(t *testing.T) {
 	ctx := context.Background()
 	workspacePath := initGitRepo(t)

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -358,6 +358,94 @@ features:
 	}
 }
 
+func TestAnnotateSpecificOldPathOwnsRenameFromBroadFeature(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "old.cc"), "old\n")
+	runGit(t, workspacePath, "add", "chrome/old.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	runGit(t, workspacePath, "mv", "chrome/old.cc", "chrome/new.cc")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  broad:
+    description: "chore: broad"
+    files:
+      - chrome/
+  specific:
+    description: "feat: specific rename"
+    files:
+      - chrome/old.cc
+`)
+
+	result, err := Annotate(ctx, AnnotateOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+	})
+	if err != nil {
+		t.Fatalf("Annotate: %v", err)
+	}
+	if result.CommitsCreated != 1 || result.Committed[0].Name != "specific" {
+		t.Fatalf("expected specific feature to own rename, got %+v", result)
+	}
+	if !slices.Equal(result.Committed[0].Files, []string{"chrome/new.cc", "chrome/old.cc"}) {
+		t.Fatalf("unexpected rename files: %v", result.Committed[0].Files)
+	}
+	if status := gitOutput(t, workspacePath, "status", "--porcelain"); status != "" {
+		t.Fatalf("expected clean checkout after rename annotate, got %q", status)
+	}
+	if nameStatus := gitOutput(t, workspacePath, "show", "--name-status", "--format=", "HEAD"); !strings.Contains(nameStatus, "R100\tchrome/old.cc\tchrome/new.cc") {
+		t.Fatalf("expected rename in commit, got:\n%s", nameStatus)
+	}
+}
+
+func TestAnnotateSpecificNewPathOwnsRenameFromBroadFeature(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "old.cc"), "old\n")
+	runGit(t, workspacePath, "add", "chrome/old.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	runGit(t, workspacePath, "mv", "chrome/old.cc", "chrome/new.cc")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  broad:
+    description: "chore: broad"
+    files:
+      - chrome/
+  specific:
+    description: "feat: specific rename"
+    files:
+      - chrome/new.cc
+`)
+
+	result, err := Annotate(ctx, AnnotateOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+	})
+	if err != nil {
+		t.Fatalf("Annotate: %v", err)
+	}
+	if result.CommitsCreated != 1 || result.Committed[0].Name != "specific" {
+		t.Fatalf("expected specific feature to own rename, got %+v", result)
+	}
+	if !slices.Equal(result.Committed[0].Files, []string{"chrome/new.cc", "chrome/old.cc"}) {
+		t.Fatalf("unexpected rename files: %v", result.Committed[0].Files)
+	}
+	if status := gitOutput(t, workspacePath, "status", "--porcelain"); status != "" {
+		t.Fatalf("expected clean checkout after rename annotate, got %q", status)
+	}
+	if nameStatus := gitOutput(t, workspacePath, "show", "--name-status", "--format=", "HEAD"); !strings.Contains(nameStatus, "R100\tchrome/old.cc\tchrome/new.cc") {
+		t.Fatalf("expected rename in commit, got:\n%s", nameStatus)
+	}
+}
+
 func TestAnnotateMissingFeatureDoesNotCommit(t *testing.T) {
 	ctx := context.Background()
 	workspacePath := initGitRepo(t)

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -111,6 +111,155 @@ func TestOperationsFromChangesNormalizesOldPath(t *testing.T) {
 	}
 }
 
+func TestAnnotateCommitsChangedFilesByFeature(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser", "core.cc"), "core\n")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser", "feature.cc"), "feature\n")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser", "nested", "view.cc"), "view\n")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser", "clean.cc"), "clean\n")
+	runGit(t, workspacePath, "add", "chrome")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser", "core.cc"), "core changed\n")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser", "feature.cc"), "feature changed\n")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser", "nested", "view.cc"), "view changed\n")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  core:
+    description: "chore: core feature"
+    files:
+      - chrome/browser/core.cc
+  browser-feature:
+    description: "feat: browser feature"
+    files:
+      - chrome/browser/
+  clean:
+    description: "chore: clean"
+    files:
+      - chrome/browser/clean.cc
+`)
+
+	result, err := Annotate(ctx, AnnotateOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+	})
+	if err != nil {
+		t.Fatalf("Annotate: %v", err)
+	}
+	if result.CommitsCreated != 2 || result.FeaturesSkipped != 1 {
+		t.Fatalf("unexpected counts: %+v", result)
+	}
+	if result.Processed != 3 {
+		t.Fatalf("processed = %d, want 3", result.Processed)
+	}
+	if len(result.Committed) != 2 {
+		t.Fatalf("expected 2 committed features, got %+v", result.Committed)
+	}
+	if result.Committed[0].Name != "core" || result.Committed[0].Commit == "" {
+		t.Fatalf("unexpected first commit result: %+v", result.Committed[0])
+	}
+	if !slices.Equal(result.Committed[0].Files, []string{"chrome/browser/core.cc"}) {
+		t.Fatalf("unexpected core files: %v", result.Committed[0].Files)
+	}
+	if result.Committed[1].Name != "browser-feature" {
+		t.Fatalf("unexpected second commit result: %+v", result.Committed[1])
+	}
+	if !slices.Equal(result.Committed[1].Files, []string{"chrome/browser/feature.cc", "chrome/browser/nested/view.cc"}) {
+		t.Fatalf("unexpected feature files: %v", result.Committed[1].Files)
+	}
+	subjects := strings.Split(gitOutput(t, workspacePath, "log", "--format=%s", "-2"), "\n")
+	if !slices.Equal(subjects, []string{"feat: browser feature", "chore: core feature"}) {
+		t.Fatalf("unexpected commit subjects: %v", subjects)
+	}
+	if status := gitOutput(t, workspacePath, "status", "--porcelain"); status != "" {
+		t.Fatalf("expected clean checkout after annotate, got %q", status)
+	}
+}
+
+func TestAnnotateSingleFeatureLeavesOtherChanges(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "a.cc"), "a\n")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "b.cc"), "b\n")
+	runGit(t, workspacePath, "add", "chrome")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	writeFile(t, filepath.Join(workspacePath, "chrome", "a.cc"), "a changed\n")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "b.cc"), "b changed\n")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  feature-a:
+    description: "feat: a"
+    files:
+      - chrome/a.cc
+  feature-b:
+    description: "feat: b"
+    files:
+      - chrome/b.cc
+`)
+
+	result, err := Annotate(ctx, AnnotateOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+		Feature:   "feature-a",
+	})
+	if err != nil {
+		t.Fatalf("Annotate: %v", err)
+	}
+	if result.CommitsCreated != 1 || result.Processed != 1 {
+		t.Fatalf("unexpected result: %+v", result)
+	}
+	if subject := gitOutput(t, workspacePath, "log", "-1", "--format=%s"); subject != "feat: a" {
+		t.Fatalf("commit subject = %q, want feat: a", subject)
+	}
+	if status := gitOutput(t, workspacePath, "status", "--porcelain", "--", "chrome/b.cc"); status == "" {
+		t.Fatalf("expected unannotated feature-b change to remain dirty")
+	}
+	if status := gitOutput(t, workspacePath, "status", "--porcelain", "--", "chrome/a.cc"); status != "" {
+		t.Fatalf("expected annotated feature-a path clean, got %q", status)
+	}
+}
+
+func TestAnnotateMissingFeatureDoesNotCommit(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "a.cc"), "a\n")
+	runGit(t, workspacePath, "add", "chrome/a.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+	headBefore := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	writeFile(t, filepath.Join(workspacePath, "chrome", "a.cc"), "a changed\n")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  feature-a:
+    description: "feat: a"
+    files:
+      - chrome/a.cc
+`)
+
+	_, err := Annotate(ctx, AnnotateOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+		Feature:   "missing",
+	})
+	if err == nil || !strings.Contains(err.Error(), `feature "missing" not found`) {
+		t.Fatalf("expected missing feature error, got %v", err)
+	}
+	if headAfter := gitOutput(t, workspacePath, "rev-parse", "HEAD"); headAfter != headBefore {
+		t.Fatalf("missing feature should not commit: before %s after %s", headBefore, headAfter)
+	}
+}
+
 func TestApplyReportsPatchProgress(t *testing.T) {
 	ctx := context.Background()
 	workspacePath := initGitRepo(t)
@@ -1002,6 +1151,11 @@ func writeFile(t *testing.T, path string, body string) {
 	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
+}
+
+func writeFeaturesYAML(t *testing.T, repoRoot string, body string) {
+	t.Helper()
+	writeFile(t, filepath.Join(repoRoot, "build", "features.yaml"), body)
 }
 
 func assertFile(t *testing.T, path string, want string) {

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -446,6 +446,86 @@ features:
 	}
 }
 
+func TestAnnotateExactOldPathOnlyOwnsRename(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "old.cc"), "old\n")
+	runGit(t, workspacePath, "add", "chrome/old.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	runGit(t, workspacePath, "mv", "chrome/old.cc", "chrome/new.cc")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  specific:
+    description: "feat: exact old rename"
+    files:
+      - chrome/old.cc
+`)
+
+	result, err := Annotate(ctx, AnnotateOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+	})
+	if err != nil {
+		t.Fatalf("Annotate: %v", err)
+	}
+	if result.CommitsCreated != 1 {
+		t.Fatalf("expected exact old path feature to own rename, got %+v", result)
+	}
+	if !slices.Equal(result.Committed[0].Files, []string{"chrome/new.cc", "chrome/old.cc"}) {
+		t.Fatalf("unexpected rename files: %v", result.Committed[0].Files)
+	}
+	if status := gitOutput(t, workspacePath, "status", "--porcelain"); status != "" {
+		t.Fatalf("expected clean checkout after rename annotate, got %q", status)
+	}
+	if nameStatus := gitOutput(t, workspacePath, "show", "--name-status", "--format=", "HEAD"); !strings.Contains(nameStatus, "R100\tchrome/old.cc\tchrome/new.cc") {
+		t.Fatalf("expected rename in commit, got:\n%s", nameStatus)
+	}
+}
+
+func TestAnnotateExactNewPathOnlyOwnsRename(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "old.cc"), "old\n")
+	runGit(t, workspacePath, "add", "chrome/old.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	runGit(t, workspacePath, "mv", "chrome/old.cc", "chrome/new.cc")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  specific:
+    description: "feat: exact new rename"
+    files:
+      - chrome/new.cc
+`)
+
+	result, err := Annotate(ctx, AnnotateOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+	})
+	if err != nil {
+		t.Fatalf("Annotate: %v", err)
+	}
+	if result.CommitsCreated != 1 {
+		t.Fatalf("expected exact new path feature to own rename, got %+v", result)
+	}
+	if !slices.Equal(result.Committed[0].Files, []string{"chrome/new.cc", "chrome/old.cc"}) {
+		t.Fatalf("unexpected rename files: %v", result.Committed[0].Files)
+	}
+	if status := gitOutput(t, workspacePath, "status", "--porcelain"); status != "" {
+		t.Fatalf("expected clean checkout after rename annotate, got %q", status)
+	}
+	if nameStatus := gitOutput(t, workspacePath, "show", "--name-status", "--format=", "HEAD"); !strings.Contains(nameStatus, "R100\tchrome/old.cc\tchrome/new.cc") {
+		t.Fatalf("expected rename in commit, got:\n%s", nameStatus)
+	}
+}
+
 func TestAnnotateMissingFeatureDoesNotCommit(t *testing.T) {
 	ctx := context.Background()
 	workspacePath := initGitRepo(t)

--- a/packages/browseros/tools/patch/internal/git/git.go
+++ b/packages/browseros/tools/patch/internal/git/git.go
@@ -685,11 +685,28 @@ func PullRebase(ctx context.Context, dir string, remote string, branch string) e
 	return nil
 }
 
+// AddPaths stages existing paths with git add.
 func AddPaths(ctx context.Context, dir string, paths []string) error {
 	if len(paths) == 0 {
 		return nil
 	}
 	args := append([]string{"add", "--"}, paths...)
+	result, err := Run(ctx, dir, nil, args...)
+	if err != nil {
+		return err
+	}
+	if result.Code != 0 {
+		return errors.New(strings.TrimSpace(result.Stderr))
+	}
+	return nil
+}
+
+// AddAllPaths stages additions, modifications, and deletions under paths.
+func AddAllPaths(ctx context.Context, dir string, paths []string) error {
+	if len(paths) == 0 {
+		return nil
+	}
+	args := append([]string{"add", "-A", "--"}, paths...)
 	result, err := Run(ctx, dir, nil, args...)
 	if err != nil {
 		return err

--- a/packages/browseros/tools/patch/internal/git/git.go
+++ b/packages/browseros/tools/patch/internal/git/git.go
@@ -100,6 +100,56 @@ func IsDirtyPaths(ctx context.Context, dir string, pathspecs []string) (bool, er
 	return strings.TrimSpace(result.Stdout) != "", nil
 }
 
+func StatusPorcelain(ctx context.Context, dir string, pathspecs []string) ([]FileChange, error) {
+	args := []string{"-c", "core.quotepath=false", "status", "--porcelain", "--untracked-files=all"}
+	if len(pathspecs) > 0 {
+		args = append(args, "--")
+		args = append(args, pathspecs...)
+	}
+	result, err := Run(ctx, dir, nil, args...)
+	if err != nil {
+		return nil, err
+	}
+	if result.Code != 0 {
+		return nil, errors.New(strings.TrimSpace(result.Stderr))
+	}
+	var changes []FileChange
+	for _, line := range strings.Split(strings.TrimRight(result.Stdout, "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		if len(line) < 4 {
+			continue
+		}
+		status := strings.TrimSpace(line[:2])
+		rel := line[3:]
+		change := FileChange{Status: status, Path: rel}
+		if strings.Contains(rel, " -> ") {
+			parts := strings.SplitN(rel, " -> ", 2)
+			change.OldPath = parts[0]
+			change.Path = parts[1]
+		}
+		changes = append(changes, change)
+	}
+	return changes, nil
+}
+
+func CommitPaths(ctx context.Context, dir string, message string, paths []string) (string, error) {
+	args := []string{"commit", "-m", message}
+	if len(paths) > 0 {
+		args = append(args, "--")
+		args = append(args, paths...)
+	}
+	result, err := Run(ctx, dir, nil, args...)
+	if err != nil {
+		return "", err
+	}
+	if result.Code != 0 {
+		return "", errors.New(strings.TrimSpace(result.Stderr))
+	}
+	return HeadRev(ctx, dir)
+}
+
 func CommitExists(ctx context.Context, dir string, ref string) (bool, error) {
 	result, err := Run(ctx, dir, nil, "rev-parse", "--verify", ref+"^{commit}")
 	if err != nil {

--- a/packages/browseros/tools/patch/internal/git/git.go
+++ b/packages/browseros/tools/patch/internal/git/git.go
@@ -122,7 +122,7 @@ func StatusPorcelain(ctx context.Context, dir string, pathspecs []string) ([]Fil
 		if len(line) < 4 {
 			continue
 		}
-		status := strings.TrimSpace(line[:2])
+		status := line[:2]
 		rel := line[3:]
 		change := FileChange{Status: status, Path: rel}
 		if strings.Contains(rel, " -> ") {

--- a/packages/browseros/tools/patch/internal/git/git.go
+++ b/packages/browseros/tools/patch/internal/git/git.go
@@ -100,6 +100,7 @@ func IsDirtyPaths(ctx context.Context, dir string, pathspecs []string) (bool, er
 	return strings.TrimSpace(result.Stdout) != "", nil
 }
 
+// StatusPorcelain returns tracked and untracked working-tree changes.
 func StatusPorcelain(ctx context.Context, dir string, pathspecs []string) ([]FileChange, error) {
 	args := []string{"-c", "core.quotepath=false", "status", "--porcelain", "--untracked-files=all"}
 	if len(pathspecs) > 0 {
@@ -134,6 +135,7 @@ func StatusPorcelain(ctx context.Context, dir string, pathspecs []string) ([]Fil
 	return changes, nil
 }
 
+// CommitPaths creates a commit scoped to paths and returns the new HEAD.
 func CommitPaths(ctx context.Context, dir string, message string, paths []string) (string, error) {
 	args := []string{"commit", "-m", message}
 	if len(paths) > 0 {


### PR DESCRIPTION
## Summary
- Add `browseros-patch annotate [checkout] [feature]` to create Chromium checkout commits from `build/features.yaml`.
- Implement Go-native feature ownership, including overlapping path specificity and rename-safe commits.
- Add CLI help/agent guidance plus real Git fixture coverage for all-feature, single-feature, overlap, and rename flows.

## Design
The Cobra command resolves the checkout through existing registry/`--src` paths and delegates to a new engine annotate operation. The engine loads ordered `features.yaml`, takes one full dirty status snapshot to preserve rename records, assigns each changed path to the most specific matching feature, and commits only the resolved concrete paths with the feature description as the commit subject.

## Test plan
- [x] `cd packages/browseros/tools/patch && gofmt -l . && go test ./... && go test -count=1 ./...`
- [x] `git diff --check origin/main...HEAD`
- [x] `cd packages/browseros/tools/patch && go run . --help | sed -n '1,28p'`

## Local review
- 4 local review rounds run via context-free reviewers.
- Important findings fixed: rename staging, overlapping feature ownership, exact-path rename preservation.