### PR TITLE
refactor: remove unused browseros server extension port

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_switches.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_switches.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/core/browseros_switches.h b/chrome/browser/browseros/core/browseros_switches.h
 new file mode 100644
-index 0000000000000..7ac2f2f44fd1d
+index 0000000000000..465149164d56b
 --- /dev/null
 +++ b/chrome/browser/browseros/core/browseros_switches.h
-@@ -0,0 +1,89 @@
+@@ -0,0 +1,86 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -44,9 +44,6 @@ index 0000000000000..7ac2f2f44fd1d
 +
 +// Overrides the Agent server port.
 +inline constexpr char kAgentPort[] = "browseros-agent-port";
-+
-+// Overrides the Extension server port.
-+inline constexpr char kExtensionPort[] = "browseros-extension-port";
 +
 +// === Extension Switches ===
 +

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_config.cc b/chrome/browser/browseros/server/browseros_server_config.cc
 new file mode 100644
-index 0000000000000..8fc64867664b4
+index 0000000000000..fc4a5deeb7916
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_config.cc
-@@ -0,0 +1,205 @@
+@@ -0,0 +1,203 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -47,7 +47,6 @@ index 0000000000000..8fc64867664b4
 +  base::DictValue ports_dict;
 +  ports_dict.Set("cdp", config.ports.cdp);
 +  ports_dict.Set("server", config.ports.server);
-+  ports_dict.Set("extension", config.ports.extension);
 +  ports_dict.Set("proxy", config.ports.proxy);
 +  root.Set("ports", std::move(ports_dict));
 +
@@ -126,7 +125,7 @@ index 0000000000000..8fc64867664b4
 +}
 +
 +bool ServerPorts::IsValid() const {
-+  return cdp > 0 && server > 0 && extension > 0 && proxy > 0;
++  return cdp > 0 && server > 0 && proxy > 0;
 +}
 +
 +std::string ServerPorts::DebugString() const {
@@ -134,10 +133,9 @@ index 0000000000000..8fc64867664b4
 +      "ServerPorts{\n"
 +      "  cdp=%d\n"
 +      "  server=%d\n"
-+      "  ext=%d\n"
 +      "  proxy=%d\n"
 +      "}",
-+      cdp, server, extension, proxy);
++      cdp, server, proxy);
 +}
 +
 +ServerPaths::ServerPaths() = default;

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_config.h b/chrome/browser/browseros/server/browseros_server_config.h
 new file mode 100644
-index 0000000000000..f41e7536e90a5
+index 0000000000000..8ef87b9c85014
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_config.h
-@@ -0,0 +1,135 @@
+@@ -0,0 +1,134 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -54,7 +54,6 @@ index 0000000000000..f41e7536e90a5
 +struct ServerPorts {
 +  int cdp = 0;
 +  int server = 0;  // ephemeral backend port for sidecar (was "mcp")
-+  int extension = 0;
 +  int proxy = 0;  // stable MCP proxy port bound by Chromium
 +
 +  bool operator==(const ServerPorts&) const = default;

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config_unittest.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config_unittest.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_config_unittest.cc b/chrome/browser/browseros/server/browseros_server_config_unittest.cc
 new file mode 100644
-index 0000000000000..f308d27b3bca1
+index 0000000000000..b851337b9f356
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_config_unittest.cc
-@@ -0,0 +1,142 @@
+@@ -0,0 +1,138 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -32,7 +32,6 @@ index 0000000000000..f308d27b3bca1
 +
 +  config.ports.cdp = 9222;
 +  config.ports.server = 9230;
-+  config.ports.extension = 9240;
 +  config.ports.proxy = 9250;
 +
 +  config.paths.exe = base::FilePath(FILE_PATH_LITERAL("server"));
@@ -91,8 +90,6 @@ index 0000000000000..f308d27b3bca1
 +  EXPECT_EQ(9222, ports->FindInt("cdp").value());
 +  ASSERT_TRUE(ports->FindInt("server").has_value());
 +  EXPECT_EQ(9230, ports->FindInt("server").value());
-+  ASSERT_TRUE(ports->FindInt("extension").has_value());
-+  EXPECT_EQ(9240, ports->FindInt("extension").value());
 +  ASSERT_TRUE(ports->FindInt("proxy").has_value());
 +  EXPECT_EQ(9250, ports->FindInt("proxy").value());
 +
@@ -131,7 +128,6 @@ index 0000000000000..f308d27b3bca1
 +  EXPECT_EQ(9230, ports->FindInt("server").value());
 +  ASSERT_TRUE(ports->FindInt("cdp").has_value());
 +  EXPECT_EQ(9222, ports->FindInt("cdp").value());
-+  EXPECT_FALSE(ports->FindInt("extension").has_value());
 +  EXPECT_FALSE(ports->FindInt("proxy").has_value());
 +
 +  const base::DictValue* directories = root.FindDict("directories");

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_manager.cc b/chrome/browser/browseros/server/browseros_server_manager.cc
 new file mode 100644
-index 0000000000000..d3744f253ca37
+index 0000000000000..67698c3e33388
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_manager.cc
-@@ -0,0 +1,1083 @@
+@@ -0,0 +1,1049 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -262,7 +262,6 @@ index 0000000000000..d3744f253ca37
 +    ports_.cdp = browseros_server::kDefaultCDPPort;
 +    ports_.proxy = browseros_server::kDefaultProxyPort;
 +    ports_.server = browseros_server::kDefaultServerPort;
-+    ports_.extension = browseros_server::kDefaultExtensionPort;
 +    allow_remote_in_mcp_ = false;
 +    return;
 +  }
@@ -289,12 +288,6 @@ index 0000000000000..d3744f253ca37
 +  ports_.server = local_state_->GetInteger(browseros_server::kServerPort);
 +  if (ports_.server <= 0) {
 +    ports_.server = browseros_server::kDefaultServerPort;
-+  }
-+
-+  ports_.extension =
-+      local_state_->GetInteger(browseros_server::kExtensionServerPort);
-+  if (ports_.extension <= 0) {
-+    ports_.extension = browseros_server::kDefaultExtensionPort;
 +  }
 +
 +  allow_remote_in_mcp_ =
@@ -333,7 +326,6 @@ index 0000000000000..d3744f253ca37
 +  bool cdp_fixed = command_line->HasSwitch(browseros::kCDPPort);
 +  bool proxy_fixed = command_line->HasSwitch(browseros::kProxyPort);
 +  bool server_fixed = command_line->HasSwitch(browseros::kServerPort);
-+  bool extension_fixed = command_line->HasSwitch(browseros::kExtensionPort);
 +
 +  if (cdp_fixed) {
 +    assigned_ports.insert(ports_.cdp);
@@ -356,13 +348,6 @@ index 0000000000000..d3744f253ca37
 +    ports_.server = server_utils::FindAvailablePort(
 +        browseros_server::kDefaultServerPort, assigned_ports);
 +    assigned_ports.insert(ports_.server);
-+  }
-+
-+  if (extension_fixed) {
-+    assigned_ports.insert(ports_.extension);
-+  } else {
-+    ports_.extension = server_utils::FindAvailablePort(
-+        browseros_server::kDefaultExtensionPort, assigned_ports);
 +  }
 +
 +  LOG(INFO) << "browseros: Resolved ports for startup - "
@@ -390,12 +375,6 @@ index 0000000000000..d3744f253ca37
 +    ports_.server = server_override;
 +  }
 +
-+  int extension_override = GetPortOverrideFromCommandLine(
-+      command_line, browseros::kExtensionPort, "Extension port");
-+  if (extension_override > 0) {
-+    ports_.extension = extension_override;
-+  }
-+
 +  LOG(INFO) << "browseros: Final ports after CLI overrides - "
 +            << ports_.DebugString();
 +}
@@ -410,8 +389,6 @@ index 0000000000000..d3744f253ca37
 +  local_state_->SetInteger(browseros_server::kCDPServerPort, ports_.cdp);
 +  local_state_->SetInteger(browseros_server::kProxyPort, ports_.proxy);
 +  local_state_->SetInteger(browseros_server::kServerPort, ports_.server);
-+  local_state_->SetInteger(browseros_server::kExtensionServerPort,
-+                           ports_.extension);
 +
 +  // DEPRECATED: keep mcp_port in sync with server port for backward compat
 +  local_state_->SetInteger(browseros_server::kMCPServerPort, ports_.server);
@@ -876,11 +853,6 @@ index 0000000000000..d3744f253ca37
 +  }
 +  assigned.insert(ports_.server);
 +
-+  if (!cl->HasSwitch(browseros::kExtensionPort)) {
-+    ports_.extension = server_utils::FindAvailablePort(
-+        browseros_server::kDefaultExtensionPort, assigned);
-+  }
-+
 +  LOG(INFO) << "browseros: New ephemeral ports - " << ports_.DebugString();
 +
 +  SavePortsToPrefs();
@@ -920,11 +892,6 @@ index 0000000000000..d3744f253ca37
 +        browseros_server::kDefaultServerPort, assigned);
 +  }
 +  assigned.insert(ports_.server);
-+
-+  if (!cl->HasSwitch(browseros::kExtensionPort)) {
-+    ports_.extension = server_utils::FindAvailablePort(
-+        browseros_server::kDefaultExtensionPort, assigned);
-+  }
 +
 +  SavePortsToPrefs();
 +  LaunchBrowserOSProcess();
@@ -979,8 +946,7 @@ index 0000000000000..d3744f253ca37
 +                 << " (must be 1-65535), ignoring pref change";
 +    return;
 +  }
-+  if (new_port == ports_.cdp || new_port == ports_.server ||
-+      new_port == ports_.extension) {
++  if (new_port == ports_.cdp || new_port == ports_.server) {
 +    LOG(WARNING) << "browseros: Proxy port " << new_port
 +                 << " collides with another bound port, ignoring pref change";
 +    return;

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_manager.h b/chrome/browser/browseros/server/browseros_server_manager.h
 new file mode 100644
-index 0000000000000..2f7e3b2c7beff
+index 0000000000000..6c9a7e03ebc0d
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_manager.h
-@@ -0,0 +1,154 @@
+@@ -0,0 +1,153 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -66,7 +66,6 @@ index 0000000000000..2f7e3b2c7beff
 +  int GetProxyPort() const { return ports_.proxy; }
 +
 +  int GetCDPPort() const { return ports_.cdp; }
-+  int GetExtensionPort() const { return ports_.extension; }
 +  int GetServerPort() const { return ports_.server; }
 +
 +  const ServerPorts& GetPorts() const { return ports_; }

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager_unittest.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager_unittest.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_manager_unittest.cc b/chrome/browser/browseros/server/browseros_server_manager_unittest.cc
 new file mode 100644
-index 0000000000000..3fc74b5291c70
+index 0000000000000..aee8a1fadceaf
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_manager_unittest.cc
-@@ -0,0 +1,441 @@
+@@ -0,0 +1,431 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -324,7 +324,6 @@ index 0000000000000..3fc74b5291c70
 +  EXPECT_EQ(0, manager_->GetCDPPort());
 +  EXPECT_EQ(0, manager_->GetMCPPort());
 +  EXPECT_EQ(0, manager_->GetProxyPort());
-+  EXPECT_EQ(0, manager_->GetExtensionPort());
 +  EXPECT_EQ(0, manager_->GetServerPort());
 +}
 +
@@ -390,7 +389,6 @@ index 0000000000000..3fc74b5291c70
 +
 +  // Set initial known ports in prefs
 +  prefs_.SetInteger(browseros_server::kServerPort, 9200);
-+  prefs_.SetInteger(browseros_server::kExtensionServerPort, 9300);
 +
 +  // Mock WaitForExitWithTimeout (called on thread pool during restart)
 +  ON_CALL(*process_controller_, WaitForExitWithTimeout(_, _, _))
@@ -406,12 +404,8 @@ index 0000000000000..3fc74b5291c70
 +  // This is the invariant: prefs and in-memory state stay in sync.
 +  EXPECT_EQ(manager_->GetServerPort(),
 +            prefs_.GetInteger(browseros_server::kServerPort));
-+  EXPECT_EQ(manager_->GetExtensionPort(),
-+            prefs_.GetInteger(browseros_server::kExtensionServerPort));
-+  // Server and extension ports should be non-zero (resolved by
-+  // FindAvailablePort)
++  // Server port should be non-zero (resolved by FindAvailablePort)
 +  EXPECT_NE(0, prefs_.GetInteger(browseros_server::kServerPort));
-+  EXPECT_NE(0, prefs_.GetInteger(browseros_server::kExtensionServerPort));
 +}
 +
 +TEST_F(BrowserOSServerManagerTest, UpdateRestartSavesEphemeralPortsToPrefs) {
@@ -419,7 +413,6 @@ index 0000000000000..3fc74b5291c70
 +  manager_->SetRunningForTesting(true);
 +
 +  prefs_.SetInteger(browseros_server::kServerPort, 9200);
-+  prefs_.SetInteger(browseros_server::kExtensionServerPort, 9300);
 +
 +  ON_CALL(*process_controller_, WaitForExitWithTimeout(_, _, _))
 +      .WillByDefault(Return(true));
@@ -437,10 +430,7 @@ index 0000000000000..3fc74b5291c70
 +
 +  EXPECT_EQ(manager_->GetServerPort(),
 +            prefs_.GetInteger(browseros_server::kServerPort));
-+  EXPECT_EQ(manager_->GetExtensionPort(),
-+            prefs_.GetInteger(browseros_server::kExtensionServerPort));
 +  EXPECT_NE(0, prefs_.GetInteger(browseros_server::kServerPort));
-+  EXPECT_NE(0, prefs_.GetInteger(browseros_server::kExtensionServerPort));
 +}
 +
 +}  // namespace

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_prefs.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_prefs.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_prefs.cc b/chrome/browser/browseros/server/browseros_server_prefs.cc
 new file mode 100644
-index 0000000000000..8c3a459477837
+index 0000000000000..2dfba7e9914ab
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_prefs.cc
-@@ -0,0 +1,49 @@
+@@ -0,0 +1,45 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -23,9 +23,6 @@ index 0000000000000..8c3a459477837
 +// Sidecar backend server port
 +const char kServerPort[] = "browseros.server.server_port";
 +
-+// Extension WebSocket server port
-+const char kExtensionServerPort[] = "browseros.server.extension_port";
-+
 +// Allow remote connections to MCP server (security setting)
 +const char kAllowRemoteInMCP[] = "browseros.server.allow_remote_in_mcp";
 +
@@ -43,7 +40,6 @@ index 0000000000000..8c3a459477837
 +  registry->RegisterIntegerPref(kCDPServerPort, kDefaultCDPPort);
 +  registry->RegisterIntegerPref(kProxyPort, kDefaultProxyPort);
 +  registry->RegisterIntegerPref(kServerPort, kDefaultServerPort);
-+  registry->RegisterIntegerPref(kExtensionServerPort, kDefaultExtensionPort);
 +  registry->RegisterBooleanPref(kAllowRemoteInMCP, false);
 +  registry->RegisterBooleanPref(kRestartServerRequested, false);
 +  registry->RegisterStringPref(kServerVersion, std::string());

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_prefs.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_prefs.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_prefs.h b/chrome/browser/browseros/server/browseros_server_prefs.h
 new file mode 100644
-index 0000000000000..69bd172f9ce25
+index 0000000000000..0418034e7d0d6
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_prefs.h
-@@ -0,0 +1,36 @@
+@@ -0,0 +1,34 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -19,13 +19,11 @@ index 0000000000000..69bd172f9ce25
 +inline constexpr int kDefaultCDPPort = 9100;
 +inline constexpr int kDefaultProxyPort = 9000;
 +inline constexpr int kDefaultServerPort = 9200;
-+inline constexpr int kDefaultExtensionPort = 9300;
 +
 +// Preference keys for BrowserOS server configuration
 +extern const char kCDPServerPort[];
 +extern const char kProxyPort[];
 +extern const char kServerPort[];
-+extern const char kExtensionServerPort[];
 +extern const char kAllowRemoteInMCP[];
 +extern const char kRestartServerRequested[];
 +extern const char kServerVersion[];


### PR DESCRIPTION
## Summary
- The managed-server stack resolved, persisted, and advertised a fourth `extension` port alongside `cdp` / `server` / `proxy`, but nothing consumed it — the sidecar logs `--extension-port is deprecated and has no effect`, and no live Chromium code reads `browseros.server.extension_port`.
- Removes the full extension-port surface from the 9 browseros `server/` + `core/` chromium patches, shrinking the port model to `cdp` / `server` / `proxy`.
- BrowserClaw descriptor and product-identity work untouched; the BrowserClaw config never carried an extension port.

## Design
Dropped, across the server-manager patches: `ServerPorts::extension` + `GetExtensionPort()`, the `kExtensionServerPort` / `kDefaultExtensionPort` prefs (load **and** registration), the `browseros::kExtensionPort` (`--browseros-extension-port`) switch, the `"extension"` key in the generated BrowserOS server config JSON, and extension handling in the resolve / CLI-override / save-to-prefs / restart / OTA-update paths plus the proxy-port collision check. Unit-test expectations for the extension port were removed too. `rg` confirmed no remaining live consumer (only unrelated Chrome OS `drivefs` mojo `NativeMessagingPort` code matches `extension_port`). `kAgentPort` is a separate, currently-unused switch left in place as out of scope.

## Test plan
- [x] Chromium builds green: `autoninja -C out/Default_arm64 chrome`
- [x] Patch verifier green: 9/9 byte-match + 9/9 apply-check onto BASE tree
- [ ] Release build applies all patches cleanly (apply-all)

Extracted from ch1 Chromium squash commit `3b0f4441685a2`.