### PR TITLE
fix: make patch annotate full-run only

### DIFF
--- a/packages/browseros/tools/patch/cmd/annotate.go
+++ b/packages/browseros/tools/patch/cmd/annotate.go
@@ -12,15 +12,14 @@ import (
 func init() {
 	var src string
 	command := &cobra.Command{
-		Use:         "annotate [checkout] [feature]",
+		Use:         "annotate [checkout]",
 		Annotations: map[string]string{"group": "Core:"},
 		Short:       "Create feature commits in a checkout",
 		Example: `  browseros-patch annotate ch1
-  browseros-patch annotate ch1 api
-  browseros-patch annotate --src /path/to/chromium/src api`,
-		Args: cobra.MaximumNArgs(2),
+  browseros-patch annotate --src /path/to/chromium/src`,
+		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ws, feature, err := resolveAnnotateTarget(cmd, args, src)
+			ws, err := resolveAnnotateTarget(cmd, args, src)
 			if err != nil {
 				return err
 			}
@@ -31,7 +30,6 @@ func init() {
 			result, err := engine.Annotate(cmd.Context(), engine.AnnotateOptions{
 				Workspace: ws,
 				Repo:      info,
-				Feature:   feature,
 				Progress:  commandProgress(cmd),
 			})
 			if err != nil {
@@ -46,37 +44,11 @@ func init() {
 	rootCmd.AddCommand(command)
 }
 
-func resolveAnnotateTarget(cmd *cobra.Command, args []string, src string) (workspace.Entry, string, error) {
-	if src != "" {
-		if len(args) > 1 {
-			return workspace.Entry{}, "", fmt.Errorf("with --src, pass at most one feature name")
-		}
-		ws, err := resolveWorkspace(cmd, nil, src)
-		feature := ""
-		if len(args) == 1 {
-			feature = args[0]
-		}
-		return ws, feature, err
+func resolveAnnotateTarget(cmd *cobra.Command, args []string, src string) (workspace.Entry, error) {
+	if src != "" && len(args) > 0 {
+		return workspace.Entry{}, fmt.Errorf("with --src, do not pass a checkout")
 	}
-	switch len(args) {
-	case 0:
-		ws, err := resolveWorkspace(cmd, nil, "")
-		return ws, "", err
-	case 1:
-		if _, err := appState.Registry.Get(args[0]); err == nil {
-			ws, resolveErr := resolveWorkspace(cmd, args, "")
-			return ws, "", resolveErr
-		}
-		ws, detectErr := resolveWorkspace(cmd, nil, "")
-		if detectErr == nil {
-			return ws, args[0], nil
-		}
-		ws, resolveErr := resolveWorkspace(cmd, args, "")
-		return ws, "", resolveErr
-	default:
-		ws, err := resolveWorkspace(cmd, args[:1], "")
-		return ws, args[1], err
-	}
+	return resolveWorkspace(cmd, args, src)
 }
 
 func printAnnotateResult(ws workspace.Entry, result *engine.AnnotateResult) {

--- a/packages/browseros/tools/patch/cmd/common.go
+++ b/packages/browseros/tools/patch/cmd/common.go
@@ -78,8 +78,7 @@ Capture flow (turn checkout changes into patches):
 3. browseros-patch publish -m "chore: sync patches"   # commit + push chromium_patches
 
 Feature commit flow (turn checkout changes into feature commits):
-1. browseros-patch annotate ch1            # commit changed files by build/features.yaml feature
-2. browseros-patch annotate ch1 api        # commit only one feature
+1. browseros-patch annotate ch1            # commit changed files for all build/features.yaml features
 
 Chromium upgrade loop (move patches to a new Chromium base):
 1. gclient sync the checkout to the new Chromium revision.

--- a/packages/browseros/tools/patch/cmd/common_test.go
+++ b/packages/browseros/tools/patch/cmd/common_test.go
@@ -96,7 +96,7 @@ func TestConflictPauseErrorClassification(t *testing.T) {
 	}
 }
 
-func TestResolveAnnotateTargetUsesSrcArgAsFeature(t *testing.T) {
+func TestResolveAnnotateTargetUsesSrcPath(t *testing.T) {
 	oldAppState := appState
 	t.Cleanup(func() {
 		appState = oldAppState
@@ -111,7 +111,7 @@ func TestResolveAnnotateTargetUsesSrcArgAsFeature(t *testing.T) {
 		Registry: &workspace.Registry{Version: 1},
 	}
 
-	ws, feature, err := resolveAnnotateTarget(&cobra.Command{Use: "annotate"}, []string{"api"}, checkout)
+	ws, err := resolveAnnotateTarget(&cobra.Command{Use: "annotate"}, nil, checkout)
 	if err != nil {
 		t.Fatalf("resolveAnnotateTarget: %v", err)
 	}
@@ -119,12 +119,33 @@ func TestResolveAnnotateTargetUsesSrcArgAsFeature(t *testing.T) {
 	if err != nil {
 		t.Fatalf("EvalSymlinks: %v", err)
 	}
-	if ws.Path != realCheckout || feature != "api" {
-		t.Fatalf("got workspace=%+v feature=%q, want src path and api feature", ws, feature)
+	if ws.Path != realCheckout {
+		t.Fatalf("got workspace=%+v, want src path", ws)
 	}
 }
 
-func TestResolveAnnotateTargetTreatsUnknownSingleArgAsFeatureInCheckout(t *testing.T) {
+func TestResolveAnnotateTargetRejectsSrcWithPositional(t *testing.T) {
+	oldAppState := appState
+	t.Cleanup(func() {
+		appState = oldAppState
+	})
+
+	checkout := filepath.Join(t.TempDir(), "chromium")
+	if err := os.MkdirAll(filepath.Join(checkout, ".git"), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	appState = &app.App{
+		CWD:      t.TempDir(),
+		Registry: &workspace.Registry{Version: 1},
+	}
+
+	_, err := resolveAnnotateTarget(&cobra.Command{Use: "annotate"}, []string{"api"}, checkout)
+	if err == nil || !strings.Contains(err.Error(), "with --src, do not pass a checkout") {
+		t.Fatalf("expected --src positional error, got %v", err)
+	}
+}
+
+func TestResolveAnnotateTargetTreatsSingleArgAsCheckoutName(t *testing.T) {
 	oldAppState := appState
 	t.Cleanup(func() {
 		appState = oldAppState
@@ -142,12 +163,9 @@ func TestResolveAnnotateTargetTreatsUnknownSingleArgAsFeatureInCheckout(t *testi
 		}},
 	}
 
-	ws, feature, err := resolveAnnotateTarget(&cobra.Command{Use: "annotate"}, []string{"api"}, "")
-	if err != nil {
-		t.Fatalf("resolveAnnotateTarget: %v", err)
-	}
-	if ws.Name != "ch1" || feature != "api" {
-		t.Fatalf("got workspace=%+v feature=%q, want ch1 and api", ws, feature)
+	_, err := resolveAnnotateTarget(&cobra.Command{Use: "annotate"}, []string{"api"}, "")
+	if err == nil || !strings.Contains(err.Error(), `checkout "api" not found`) {
+		t.Fatalf("expected unknown checkout error, got %v", err)
 	}
 }
 
@@ -165,12 +183,12 @@ func TestResolveAnnotateTargetTreatsRegisteredSingleArgAsCheckout(t *testing.T) 
 		}},
 	}
 
-	ws, feature, err := resolveAnnotateTarget(&cobra.Command{Use: "annotate"}, []string{"api"}, "")
+	ws, err := resolveAnnotateTarget(&cobra.Command{Use: "annotate"}, []string{"api"}, "")
 	if err != nil {
 		t.Fatalf("resolveAnnotateTarget: %v", err)
 	}
-	if ws.Name != "api" || feature != "" {
-		t.Fatalf("got workspace=%+v feature=%q, want api checkout and empty feature", ws, feature)
+	if ws.Name != "api" {
+		t.Fatalf("got workspace=%+v, want api checkout", ws)
 	}
 }
 
@@ -333,7 +351,7 @@ func TestCheckoutCommandUsageTerminology(t *testing.T) {
 		{name: "apply", use: "apply [checkout] [-- files...]"},
 		{name: "sync", use: "sync [checkout]"},
 		{name: "extract", use: "extract [checkout] [--range <start> <end>] [-- files...]"},
-		{name: "annotate", use: "annotate [checkout] [feature]"},
+		{name: "annotate", use: "annotate [checkout]"},
 	} {
 		cmd, _, err := rootCmd.Find([]string{tc.name})
 		if err != nil {
@@ -399,6 +417,9 @@ func TestCheckoutCommandExamplesUseNamedCheckout(t *testing.T) {
 		if !strings.Contains(cmd.Example, tc.example) {
 			t.Fatalf("expected %s examples to contain %q, got:\n%s", tc.name, tc.example, cmd.Example)
 		}
+		if tc.name == "annotate" && strings.Contains(cmd.Example, "browseros-patch annotate ch1 api") {
+			t.Fatalf("annotate examples should not document single-feature annotate, got:\n%s", cmd.Example)
+		}
 	}
 }
 
@@ -444,7 +465,6 @@ func TestLLMTxtGuideContent(t *testing.T) {
 		"browseros-patch skip",
 		"browseros-patch abort",
 		"browseros-patch extract ch1 --dry-run",
-		"browseros-patch annotate ch1 api",
 		".browseros-patchignore",
 		"BASE_COMMIT",
 		"browseros-patch publish",
@@ -458,6 +478,9 @@ func TestLLMTxtGuideContent(t *testing.T) {
 	}
 	if strings.Contains(text, "\x1b[") {
 		t.Fatalf("llm txt should be uncolored, got:\n%s", text)
+	}
+	if strings.Contains(text, "browseros-patch annotate ch1 api") {
+		t.Fatalf("llm txt should not document single-feature annotate, got:\n%s", text)
 	}
 }
 

--- a/packages/browseros/tools/patch/internal/engine/annotate.go
+++ b/packages/browseros/tools/patch/internal/engine/annotate.go
@@ -18,14 +18,12 @@ import (
 type AnnotateOptions struct {
 	Workspace workspace.Entry
 	Repo      *repo.Info
-	Feature   string
 	Progress  Progress
 }
 
 type AnnotateResult struct {
 	Workspace       string                     `json:"workspace"`
 	FeaturesFile    string                     `json:"features_file"`
-	Feature         string                     `json:"feature,omitempty"`
 	Processed       int                        `json:"processed"`
 	CommitsCreated  int                        `json:"commits_created"`
 	FeaturesSkipped int                        `json:"features_skipped"`
@@ -66,16 +64,6 @@ func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error
 	if err != nil {
 		return nil, err
 	}
-	allFeatures := features
-	if opts.Feature != "" {
-		filtered := slices.DeleteFunc(slices.Clone(features), func(feature annotateFeature) bool {
-			return feature.Name != opts.Feature
-		})
-		if len(filtered) == 0 {
-			return nil, fmt.Errorf("feature %q not found in features.yaml", opts.Feature)
-		}
-		features = filtered
-	}
 	changes, err := annotateChanges(ctx, opts.Workspace.Path)
 	if err != nil {
 		return nil, err
@@ -83,7 +71,6 @@ func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error
 	result := &AnnotateResult{
 		Workspace:    opts.Workspace.Name,
 		FeaturesFile: featuresFile,
-		Feature:      opts.Feature,
 		Committed:    []AnnotateCommittedFeature{},
 		Skipped:      []AnnotateSkippedFeature{},
 	}
@@ -99,7 +86,7 @@ func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error
 			result.FeaturesSkipped++
 			continue
 		}
-		files := modifiedFeatureFiles(changes, feature, allFeatures)
+		files := modifiedFeatureFiles(changes, feature, features)
 		if len(files.report) == 0 {
 			result.Skipped = append(result.Skipped, AnnotateSkippedFeature{
 				Name:        feature.Name,

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -180,53 +180,6 @@ features:
 	}
 }
 
-func TestAnnotateSingleFeatureLeavesOtherChanges(t *testing.T) {
-	ctx := context.Background()
-	workspacePath := initGitRepo(t)
-	writeFile(t, filepath.Join(workspacePath, "chrome", "a.cc"), "a\n")
-	writeFile(t, filepath.Join(workspacePath, "chrome", "b.cc"), "b\n")
-	runGit(t, workspacePath, "add", "chrome")
-	runGit(t, workspacePath, "commit", "-m", "workspace base")
-	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
-
-	writeFile(t, filepath.Join(workspacePath, "chrome", "a.cc"), "a changed\n")
-	writeFile(t, filepath.Join(workspacePath, "chrome", "b.cc"), "b changed\n")
-
-	repoInfo := newPatchRepo(t, baseCommit)
-	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
-features:
-  feature-a:
-    description: "feat: a"
-    files:
-      - chrome/a.cc
-  feature-b:
-    description: "feat: b"
-    files:
-      - chrome/b.cc
-`)
-
-	result, err := Annotate(ctx, AnnotateOptions{
-		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
-		Repo:      repoInfo,
-		Feature:   "feature-a",
-	})
-	if err != nil {
-		t.Fatalf("Annotate: %v", err)
-	}
-	if result.CommitsCreated != 1 || result.Processed != 1 {
-		t.Fatalf("unexpected result: %+v", result)
-	}
-	if subject := gitOutput(t, workspacePath, "log", "-1", "--format=%s"); subject != "feat: a" {
-		t.Fatalf("commit subject = %q, want feat: a", subject)
-	}
-	if status := gitOutput(t, workspacePath, "status", "--porcelain", "--", "chrome/b.cc"); status == "" {
-		t.Fatalf("expected unannotated feature-b change to remain dirty")
-	}
-	if status := gitOutput(t, workspacePath, "status", "--porcelain", "--", "chrome/a.cc"); status != "" {
-		t.Fatalf("expected annotated feature-a path clean, got %q", status)
-	}
-}
-
 func TestAnnotateAssignsOverlappingPathsToMostSpecificFeature(t *testing.T) {
 	ctx := context.Background()
 	workspacePath := initGitRepo(t)
@@ -273,48 +226,6 @@ features:
 	}
 	if files := strings.Split(gitOutput(t, workspacePath, "show", "--name-only", "--format=", "HEAD"), "\n"); !slices.Equal(files, []string{"chrome/browser/browseros/core/browseros_prefs.cc"}) {
 		t.Fatalf("specific commit files = %v", files)
-	}
-}
-
-func TestAnnotateSingleFeatureDoesNotStealMoreSpecificOverlap(t *testing.T) {
-	ctx := context.Background()
-	workspacePath := initGitRepo(t)
-	writeFile(t, filepath.Join(workspacePath, "chrome", "browser", "browseros", "core", "browseros_prefs.cc"), "prefs\n")
-	runGit(t, workspacePath, "add", "chrome")
-	runGit(t, workspacePath, "commit", "-m", "workspace base")
-	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
-
-	writeFile(t, filepath.Join(workspacePath, "chrome", "browser", "browseros", "core", "browseros_prefs.cc"), "prefs changed\n")
-
-	repoInfo := newPatchRepo(t, baseCommit)
-	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
-features:
-  browseros-core:
-    description: "chore: browseros core"
-    files:
-      - chrome/browser/browseros/core/
-  onboarding-import:
-    description: "feat: onboarding import"
-    files:
-      - chrome/browser/browseros/core/browseros_prefs.cc
-`)
-
-	result, err := Annotate(ctx, AnnotateOptions{
-		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
-		Repo:      repoInfo,
-		Feature:   "browseros-core",
-	})
-	if err != nil {
-		t.Fatalf("Annotate: %v", err)
-	}
-	if result.CommitsCreated != 0 || result.FeaturesSkipped != 1 {
-		t.Fatalf("expected broad feature to skip specific overlap, got %+v", result)
-	}
-	if head := gitOutput(t, workspacePath, "log", "-1", "--format=%s"); head != "workspace base" {
-		t.Fatalf("broad feature should not commit overlap, got head %q", head)
-	}
-	if status := gitOutput(t, workspacePath, "status", "--porcelain"); status == "" {
-		t.Fatalf("specific overlap change should remain dirty")
 	}
 }
 
@@ -523,39 +434,6 @@ features:
 	}
 	if nameStatus := gitOutput(t, workspacePath, "show", "--name-status", "--format=", "HEAD"); !strings.Contains(nameStatus, "R100\tchrome/old.cc\tchrome/new.cc") {
 		t.Fatalf("expected rename in commit, got:\n%s", nameStatus)
-	}
-}
-
-func TestAnnotateMissingFeatureDoesNotCommit(t *testing.T) {
-	ctx := context.Background()
-	workspacePath := initGitRepo(t)
-	writeFile(t, filepath.Join(workspacePath, "chrome", "a.cc"), "a\n")
-	runGit(t, workspacePath, "add", "chrome/a.cc")
-	runGit(t, workspacePath, "commit", "-m", "workspace base")
-	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
-	headBefore := gitOutput(t, workspacePath, "rev-parse", "HEAD")
-
-	writeFile(t, filepath.Join(workspacePath, "chrome", "a.cc"), "a changed\n")
-
-	repoInfo := newPatchRepo(t, baseCommit)
-	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
-features:
-  feature-a:
-    description: "feat: a"
-    files:
-      - chrome/a.cc
-`)
-
-	_, err := Annotate(ctx, AnnotateOptions{
-		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
-		Repo:      repoInfo,
-		Feature:   "missing",
-	})
-	if err == nil || !strings.Contains(err.Error(), `feature "missing" not found`) {
-		t.Fatalf("expected missing feature error, got %v", err)
-	}
-	if headAfter := gitOutput(t, workspacePath, "rev-parse", "HEAD"); headAfter != headBefore {
-		t.Fatalf("missing feature should not commit: before %s after %s", headBefore, headAfter)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Changes `browseros-patch annotate` to accept only an optional checkout target.
- Removes the Go patch-tool annotate feature filter so every run processes all `build/features.yaml` features.
- Updates command help, LLM guide text, and Go tests to stop documenting single-feature annotate.

## Design
The CLI now resolves only the checkout target, including the shared `--src` direct-path flag, then calls the engine without any feature selector. The engine keeps existing feature ownership and commit grouping behavior, but no longer exposes a Go feature-filter option or result field.

## Test plan
- [x] `cd packages/browseros/tools/patch && go test ./cmd`
- [x] `cd packages/browseros/tools/patch && go test ./internal/engine`
- [x] `cd packages/browseros/tools/patch && go test ./...`
- [x] local Codex review: clean