### PR TITLE
refactor(patches): drop agent-port switch, unify server config

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_switches.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_switches.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/core/browseros_switches.h b/chrome/browser/browseros/core/browseros_switches.h
 new file mode 100644
-index 0000000000000..465149164d56b
+index 0000000000000..1080aa947bec2
 --- /dev/null
 +++ b/chrome/browser/browseros/core/browseros_switches.h
-@@ -0,0 +1,86 @@
+@@ -0,0 +1,83 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -41,9 +41,6 @@ index 0000000000000..465149164d56b
 +
 +// Overrides the sidecar backend server port.
 +inline constexpr char kServerPort[] = "browseros-server-port";
-+
-+// Overrides the Agent server port.
-+inline constexpr char kAgentPort[] = "browseros-agent-port";
 +
 +// === Extension Switches ===
 +

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config.cc
@@ -1,16 +1,15 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_config.cc b/chrome/browser/browseros/server/browseros_server_config.cc
 new file mode 100644
-index 0000000000000..fc4a5deeb7916
+index 0000000000000..108ebf4b1cb5a
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_config.cc
-@@ -0,0 +1,203 @@
+@@ -0,0 +1,162 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
 +
 +#include "chrome/browser/browseros/server/browseros_server_config.h"
 +
-+#include "base/notreached.h"
 +#include "base/strings/stringprintf.h"
 +#include "chrome/browser/browseros/core/browseros_product.h"
 +
@@ -22,9 +21,8 @@ index 0000000000000..fc4a5deeb7916
 +    "BrowserOS server",
 +    FILE_PATH_LITERAL("BrowserOSServer"),
 +    FILE_PATH_LITERAL("browseros_server"),
-+    FILE_PATH_LITERAL("server_config.json"),
++    FILE_PATH_LITERAL("config.json"),
 +    "/health",
-+    ServerConfigKind::kBrowserOS,
 +    true,
 +};
 +
@@ -33,13 +31,32 @@ index 0000000000000..fc4a5deeb7916
 +    "BrowserClaw server",
 +    FILE_PATH_LITERAL("BrowserClawServer"),
 +    FILE_PATH_LITERAL("browseros-claw-server"),
-+    FILE_PATH_LITERAL("claw_config.json"),
++    FILE_PATH_LITERAL("config.json"),
 +    "/system/health",
-+    ServerConfigKind::kBrowserClaw,
 +    false,
 +};
 +
-+base::DictValue BuildBrowserOSConfigJson(
++}  // namespace
++
++const ManagedServerDescriptor& GetBrowserOSServerDescriptor() {
++  return kBrowserOSServerDescriptor;
++}
++
++const ManagedServerDescriptor& GetBrowserClawServerDescriptor() {
++  return kBrowserClawServerDescriptor;
++}
++
++const ManagedServerDescriptor& GetManagedServerDescriptor() {
++  if (IsBrowserClawProduct()) {
++    return GetBrowserClawServerDescriptor();
++  }
++  return GetBrowserOSServerDescriptor();
++}
++
++// Single config.json shape shared by every managed server product. Any
++// product-specific server binary (e.g. the Claw server) must tolerate the full
++// key set below; it must not reject unknown keys.
++base::DictValue BuildServerConfigJson(
 +    const ServerLaunchConfig& config,
 +    const base::FilePath& actual_resources_dir) {
 +  base::DictValue root;
@@ -66,62 +83,6 @@ index 0000000000000..fc4a5deeb7916
 +  root.Set("instance", std::move(instance));
 +
 +  return root;
-+}
-+
-+base::DictValue BuildBrowserClawConfigJson(
-+    const ServerLaunchConfig& config,
-+    const base::FilePath& actual_resources_dir) {
-+  base::DictValue root;
-+
-+  base::DictValue ports_dict;
-+  ports_dict.Set("server", config.ports.server);
-+  ports_dict.Set("cdp", config.ports.cdp);
-+  root.Set("ports", std::move(ports_dict));
-+
-+  base::DictValue directories;
-+  directories.Set("resources", actual_resources_dir.AsUTF8Unsafe());
-+  root.Set("directories", std::move(directories));
-+
-+  return root;
-+}
-+
-+std::string ConfigKindToString(ServerConfigKind kind) {
-+  switch (kind) {
-+    case ServerConfigKind::kBrowserOS:
-+      return "browseros";
-+    case ServerConfigKind::kBrowserClaw:
-+      return "browserclaw";
-+  }
-+  NOTREACHED();
-+}
-+
-+}  // namespace
-+
-+const ManagedServerDescriptor& GetBrowserOSServerDescriptor() {
-+  return kBrowserOSServerDescriptor;
-+}
-+
-+const ManagedServerDescriptor& GetBrowserClawServerDescriptor() {
-+  return kBrowserClawServerDescriptor;
-+}
-+
-+const ManagedServerDescriptor& GetManagedServerDescriptor() {
-+  if (IsBrowserClawProduct()) {
-+    return GetBrowserClawServerDescriptor();
-+  }
-+  return GetBrowserOSServerDescriptor();
-+}
-+
-+base::DictValue BuildServerConfigJson(
-+    const ServerLaunchConfig& config,
-+    const base::FilePath& actual_resources_dir) {
-+  switch (config.config_kind) {
-+    case ServerConfigKind::kBrowserOS:
-+      return BuildBrowserOSConfigJson(config, actual_resources_dir);
-+    case ServerConfigKind::kBrowserClaw:
-+      return BuildBrowserClawConfigJson(config, actual_resources_dir);
-+  }
-+  NOTREACHED();
 +}
 +
 +bool ServerPorts::IsValid() const {
@@ -192,7 +153,6 @@ index 0000000000000..fc4a5deeb7916
 +      "  log_name=%s\n"
 +      "  config_file=%s\n"
 +      "  health_path=%s\n"
-+      "  config_kind=%s\n"
 +      "  enable_updater=%s\n"
 +      "  %s\n"
 +      "  %s\n"
@@ -200,7 +160,6 @@ index 0000000000000..fc4a5deeb7916
 +      "  allow_remote=%s\n"
 +      "}",
 +      log_name.c_str(), config_file.c_str(), health_path.c_str(),
-+      ConfigKindToString(config_kind).c_str(),
 +      enable_updater ? "true" : "false", ports.DebugString().c_str(),
 +      paths.DebugString().c_str(), identity.DebugString().c_str(),
 +      allow_remote_in_mcp ? "true" : "false");

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_config.h b/chrome/browser/browseros/server/browseros_server_config.h
 new file mode 100644
-index 0000000000000..8ef87b9c85014
+index 0000000000000..88a323a1c735c
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_config.h
-@@ -0,0 +1,134 @@
+@@ -0,0 +1,127 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -22,11 +22,6 @@ index 0000000000000..8ef87b9c85014
 +
 +struct ServerLaunchConfig;
 +
-+enum class ServerConfigKind {
-+  kBrowserOS,
-+  kBrowserClaw,
-+};
-+
 +struct ManagedServerDescriptor {
 +  Product product;
 +  std::string_view log_name;
@@ -34,7 +29,6 @@ index 0000000000000..8ef87b9c85014
 +  base::FilePath::StringViewType binary_name;
 +  base::FilePath::StringViewType config_file_name;
 +  std::string_view health_path;
-+  ServerConfigKind config_kind;
 +  bool enable_updater;
 +};
 +
@@ -120,7 +114,6 @@ index 0000000000000..8ef87b9c85014
 +  std::string log_name;
 +  base::FilePath::StringType config_file_name;
 +  std::string health_path;
-+  ServerConfigKind config_kind = ServerConfigKind::kBrowserOS;
 +  bool enable_updater = true;
 +
 +  ServerPorts ports;

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config_unittest.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config_unittest.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_config_unittest.cc b/chrome/browser/browseros/server/browseros_server_config_unittest.cc
 new file mode 100644
-index 0000000000000..b851337b9f356
+index 0000000000000..ce19186789056
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_config_unittest.cc
-@@ -0,0 +1,138 @@
+@@ -0,0 +1,132 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -22,13 +22,12 @@ index 0000000000000..b851337b9f356
 +  return base::FilePath::StringType(value.begin(), value.end());
 +}
 +
-+ServerLaunchConfig BuildLaunchConfig(ServerConfigKind kind) {
++ServerLaunchConfig BuildLaunchConfig() {
 +  ServerLaunchConfig config;
-+  config.config_kind = kind;
 +  config.config_file_name = FILE_PATH_LITERAL("config.json");
 +  config.health_path = "/health";
 +  config.log_name = "test server";
-+  config.enable_updater = kind == ServerConfigKind::kBrowserOS;
++  config.enable_updater = true;
 +
 +  config.ports.cdp = 9222;
 +  config.ports.server = 9230;
@@ -54,10 +53,9 @@ index 0000000000000..b851337b9f356
 +            ToPathString(descriptor.bundle_dir));
 +  EXPECT_EQ(base::FilePath::StringType(FILE_PATH_LITERAL("browseros_server")),
 +            ToPathString(descriptor.binary_name));
-+  EXPECT_EQ(base::FilePath::StringType(FILE_PATH_LITERAL("server_config.json")),
++  EXPECT_EQ(base::FilePath::StringType(FILE_PATH_LITERAL("config.json")),
 +            ToPathString(descriptor.config_file_name));
 +  EXPECT_EQ(std::string_view("/health"), descriptor.health_path);
-+  EXPECT_EQ(ServerConfigKind::kBrowserOS, descriptor.config_kind);
 +  EXPECT_TRUE(descriptor.enable_updater);
 +}
 +
@@ -71,15 +69,14 @@ index 0000000000000..b851337b9f356
 +  EXPECT_EQ(
 +      base::FilePath::StringType(FILE_PATH_LITERAL("browseros-claw-server")),
 +      ToPathString(descriptor.binary_name));
-+  EXPECT_EQ(base::FilePath::StringType(FILE_PATH_LITERAL("claw_config.json")),
++  EXPECT_EQ(base::FilePath::StringType(FILE_PATH_LITERAL("config.json")),
 +            ToPathString(descriptor.config_file_name));
 +  EXPECT_EQ(std::string_view("/system/health"), descriptor.health_path);
-+  EXPECT_EQ(ServerConfigKind::kBrowserClaw, descriptor.config_kind);
 +  EXPECT_FALSE(descriptor.enable_updater);
 +}
 +
-+TEST(BrowserOSServerConfigTest, BrowserOSConfigKeepsLegacyShape) {
-+  ServerLaunchConfig config = BuildLaunchConfig(ServerConfigKind::kBrowserOS);
++TEST(BrowserOSServerConfigTest, ServerConfigJsonHasUnifiedShape) {
++  ServerLaunchConfig config = BuildLaunchConfig();
 +  base::FilePath resources(FILE_PATH_LITERAL("resources"));
 +
 +  base::DictValue root = BuildServerConfigJson(config, resources);
@@ -116,28 +113,25 @@ index 0000000000000..b851337b9f356
 +  EXPECT_EQ("140.0.0.0", *instance->FindString("chromium_version"));
 +}
 +
-+TEST(BrowserOSServerConfigTest, BrowserClawConfigUsesStrictShape) {
-+  ServerLaunchConfig config = BuildLaunchConfig(ServerConfigKind::kBrowserClaw);
++// Both BrowserOS and BrowserClaw consume this same config.json. Guard against
++// re-stripping the shape per product: the keys the old Claw config omitted
++// (ports.proxy, directories.execution, flags, instance) must stay present.
++TEST(BrowserOSServerConfigTest, ServerConfigJsonIncludesSharedRuntimeKeys) {
++  ServerLaunchConfig config = BuildLaunchConfig();
 +  base::FilePath resources(FILE_PATH_LITERAL("resources"));
 +
 +  base::DictValue root = BuildServerConfigJson(config, resources);
 +
 +  const base::DictValue* ports = root.FindDict("ports");
 +  ASSERT_NE(nullptr, ports);
-+  ASSERT_TRUE(ports->FindInt("server").has_value());
-+  EXPECT_EQ(9230, ports->FindInt("server").value());
-+  ASSERT_TRUE(ports->FindInt("cdp").has_value());
-+  EXPECT_EQ(9222, ports->FindInt("cdp").value());
-+  EXPECT_FALSE(ports->FindInt("proxy").has_value());
++  EXPECT_TRUE(ports->FindInt("proxy").has_value());
 +
 +  const base::DictValue* directories = root.FindDict("directories");
 +  ASSERT_NE(nullptr, directories);
-+  ASSERT_NE(nullptr, directories->FindString("resources"));
-+  EXPECT_EQ(resources.AsUTF8Unsafe(), *directories->FindString("resources"));
-+  EXPECT_EQ(nullptr, directories->FindString("execution"));
++  EXPECT_NE(nullptr, directories->FindString("execution"));
 +
-+  EXPECT_EQ(nullptr, root.FindDict("flags"));
-+  EXPECT_EQ(nullptr, root.FindDict("instance"));
++  EXPECT_NE(nullptr, root.FindDict("flags"));
++  EXPECT_NE(nullptr, root.FindDict("instance"));
 +}
 +
 +}  // namespace

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_manager.cc b/chrome/browser/browseros/server/browseros_server_manager.cc
 new file mode 100644
-index 0000000000000..67698c3e33388
+index 0000000000000..c39cdbe4f8f1c
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_manager.cc
-@@ -0,0 +1,1049 @@
+@@ -0,0 +1,1048 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -553,7 +553,6 @@ index 0000000000000..67698c3e33388
 +  config.config_file_name =
 +      base::FilePath::StringType(descriptor.config_file_name);
 +  config.health_path = std::string(descriptor.health_path);
-+  config.config_kind = descriptor.config_kind;
 +  config.enable_updater = descriptor.enable_updater;
 +
 +  config.paths.fallback_exe = GetBrowserOSServerExecutablePath();


### PR DESCRIPTION
## Summary
- Remove the unused `browseros-agent-port` switch (`kAgentPort`) — it had no live readers anywhere in the tree.
- Collapse the per-product managed-server config into a single `config.json` shape shared by BrowserOS and BrowserClaw.
- Drop `ServerConfigKind`, the `config_kind` fields, `ConfigKindToString`, and the two per-product JSON builders; one `BuildServerConfigJson` now serves both.

## Design
The prior BrowserClaw descriptor work introduced two near-identical config shapes (`server_config.json` full vs `claw_config.json` stripped) selected by a `ServerConfigKind` enum. This unifies them: both descriptors emit `config.json` and one builder produces the shape below. Genuinely product-specific descriptor fields are untouched — `product`, `log_name`, `bundle_dir` (`BrowserOSServer` vs `BrowserClawServer`), `binary_name` (`browseros_server` vs `browseros-claw-server`), `health_path` (`/health` vs `/system/health`), and `enable_updater` (`true` vs `false`). Product-specific resource roots are unchanged.

```json
{
  "ports":       { "cdp": ..., "server": ..., "proxy": ... },
  "directories": { "resources": "...", "execution": "..." },
  "flags":       { "allow_remote_in_mcp": false },
  "instance":    { "install_id": "...", "browseros_version": "...", "chromium_version": "..." }
}
```

## ⚠️ Claw config-loader follow-up
The Claw loader previously consumed only `ports.server`, `ports.cdp`, and `directories.resources` (the removed `BrowserClawConfigUsesStrictShape` test encoded that). The unified `config.json` now also sends Claw `ports.proxy`, `directories.execution`, `flags`, and `instance`. **This requires the `browseros-claw-server` parser to tolerate (ignore) unknown keys.** That parser is not in the Chromium tree and was not inspectable here. BrowserClaw is brand-new/unreleased, so nothing in production breaks today — but if the loader rejects unknown keys, a Claw-side parser change is required before Claw ships.

## Test plan
- [x] `autoninja -C out/Default_arm64 chrome` — green
- [x] `verify-patches.sh` — 5/5 byte-match + apply-check
- [x] Reworked `browseros_server_config_unittest.cc` (descriptors assert `config.json`; new `ServerConfigJsonIncludesSharedRuntimeKeys` regression guard)