### PR TITLE
feat: support BrowserOS runtime product override

### DIFF
--- a/packages/browseros/build/common/server_binaries.py
+++ b/packages/browseros/build/common/server_binaries.py
@@ -63,9 +63,9 @@ BROWSEROS_CLAW_SERVER_BUNDLE = ServerBundle(
     local_resources_root=Path("resources/binaries/browseros_claw_server"),
     chromium_resources_root=Path("chrome/browser/browseros/claw_server/resources"),
     macos_bundle_resources_root=Path(
-        "Contents/Resources/BrowserOSClawServer/default/resources"
+        "Contents/Resources/BrowserClawServer/default/resources"
     ),
-    windows_bundle_resources_root=Path("BrowserOSClawServer/default/resources"),
+    windows_bundle_resources_root=Path("BrowserClawServer/default/resources"),
     macos_binaries=BROWSEROS_CLAW_SERVER_MACOS_BINARIES,
     windows_binaries=("browseros-claw-server.exe",),
     required_in_chromium_output=False,

--- a/packages/browseros/build/common/server_binaries_test.py
+++ b/packages/browseros/build/common/server_binaries_test.py
@@ -44,7 +44,7 @@ class MacosServerBinariesTest(unittest.TestCase):
         )
         self.assertEqual(
             BROWSEROS_CLAW_SERVER_BUNDLE.macos_bundle_resources_root,
-            Path("Contents/Resources/BrowserOSClawServer/default/resources"),
+            Path("Contents/Resources/BrowserClawServer/default/resources"),
         )
         self.assertTrue(BROWSEROS_SERVER_BUNDLE.required_in_chromium_output)
         self.assertFalse(BROWSEROS_CLAW_SERVER_BUNDLE.required_in_chromium_output)
@@ -134,7 +134,7 @@ class WindowsServerBinariesTest(unittest.TestCase):
                 / "bin"
                 / "browseros_server.exe",
                 build_output_dir
-                / "BrowserOSClawServer"
+                / "BrowserClawServer"
                 / "default"
                 / "resources"
                 / "bin"

--- a/packages/browseros/build/modules/package/linux.py
+++ b/packages/browseros/build/modules/package/linux.py
@@ -199,7 +199,7 @@ def copy_browser_files(
         "locales",
         "MEIPreload",
         "BrowserOSServer",
-        "BrowserOSClawServer",
+        "BrowserClawServer",
     ]
     for dir_name in dirs_to_copy:
         src = join_paths(out_dir, dir_name)

--- a/packages/browseros/build/modules/package/linux_test.py
+++ b/packages/browseros/build/modules/package/linux_test.py
@@ -72,7 +72,7 @@ class CopyBrowserFilesTest(unittest.TestCase):
             out_dir.mkdir(parents=True)
             (out_dir / "browseros").write_text("browser")
 
-            for bundle_name in ("BrowserOSServer", "BrowserOSClawServer"):
+            for bundle_name in ("BrowserOSServer", "BrowserClawServer"):
                 resources = out_dir / bundle_name / "default" / "resources"
                 resources.mkdir(parents=True)
                 (resources / "marker.txt").write_text(bundle_name)
@@ -98,7 +98,7 @@ class CopyBrowserFilesTest(unittest.TestCase):
             self.assertTrue(
                 (
                     target_dir
-                    / "BrowserOSClawServer"
+                    / "BrowserClawServer"
                     / "default"
                     / "resources"
                     / "marker.txt"

--- a/packages/browseros/build/modules/sign/macos_test.py
+++ b/packages/browseros/build/modules/sign/macos_test.py
@@ -55,7 +55,7 @@ class MacOSSignDiscoveryTest(unittest.TestCase):
                 app_path
                 / "Contents"
                 / "Resources"
-                / "BrowserOSClawServer"
+                / "BrowserClawServer"
                 / "default"
                 / "resources"
                 / "bin"
@@ -164,7 +164,7 @@ class VerifyServerResourcesBundleTest(unittest.TestCase):
                 app_path
                 / "Contents"
                 / "Resources"
-                / "BrowserOSClawServer"
+                / "BrowserClawServer"
                 / "default"
                 / "resources"
             )
@@ -175,7 +175,7 @@ class VerifyServerResourcesBundleTest(unittest.TestCase):
 
             self.assertEqual(len(problems), 1)
             self.assertIn(
-                "Contents/Resources/BrowserOSClawServer/default/resources",
+                "Contents/Resources/BrowserClawServer/default/resources",
                 problems[0],
             )
             self.assertIn("bin/browseros-claw-server", problems[0])

--- a/packages/browseros/build/modules/sign/windows_test.py
+++ b/packages/browseros/build/modules/sign/windows_test.py
@@ -28,7 +28,7 @@ class WindowsSignPathsTest(unittest.TestCase):
                 / "bin"
                 / "browseros_server.exe",
                 build_output_dir
-                / "BrowserOSClawServer"
+                / "BrowserClawServer"
                 / "default"
                 / "resources"
                 / "bin"
@@ -77,7 +77,7 @@ class WindowsSignPathsTest(unittest.TestCase):
             )
             (
                 build_output_dir
-                / "BrowserOSClawServer"
+                / "BrowserClawServer"
                 / "default"
                 / "resources"
                 / "bin"
@@ -87,7 +87,7 @@ class WindowsSignPathsTest(unittest.TestCase):
                 get_missing_required_browseros_server_binary_paths(build_output_dir),
                 [
                     build_output_dir
-                    / "BrowserOSClawServer"
+                    / "BrowserClawServer"
                     / "default"
                     / "resources"
                     / "bin"

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/BUILD.gn
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/BUILD.gn b/chrome/browser/browseros/BUILD.gn
 new file mode 100644
-index 0000000000000..b47e01513026e
+index 0000000000000..9b2f877bec910
 --- /dev/null
 +++ b/chrome/browser/browseros/BUILD.gn
-@@ -0,0 +1,36 @@
+@@ -0,0 +1,37 @@
 +# Copyright 2024 The Chromium Authors
 +# Use of this source code is governed by a BSD-style license that can be
 +# found in the LICENSE file.
@@ -32,6 +32,7 @@ index 0000000000000..b47e01513026e
 +  flags = [
 +    "BROWSEROS_PRODUCT_BROWSEROS=$browseros_product_browseros",
 +    "BROWSEROS_PRODUCT_BROWSERCLAW=$browseros_product_browserclaw",
++    "BROWSEROS_ALLOW_RUNTIME_PRODUCT_OVERRIDE=$browseros_allow_runtime_product_override",
 +  ]
 +}
 +

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/buildflags.gni
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/buildflags.gni
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/buildflags.gni b/chrome/browser/browseros/buildflags.gni
 new file mode 100644
-index 0000000000000..581416a94ad10
+index 0000000000000..0a4b34ea72336
 --- /dev/null
 +++ b/chrome/browser/browseros/buildflags.gni
-@@ -0,0 +1,16 @@
+@@ -0,0 +1,25 @@
 +# Copyright 2024 The Chromium Authors
 +# Use of this source code is governed by a BSD-style license that can be
 +# found in the LICENSE file.
@@ -13,6 +13,15 @@ index 0000000000000..581416a94ad10
 +  # Baked into the binary at build time so runtime switches and field trials
 +  # cannot change product identity for shipped artifacts.
 +  browseros_product = "browseros"
++
++  # Dev/test only. Official builds should leave this false.
++  browseros_allow_runtime_product_override = false
++}
++
++declare_args() {
++  # Usually follows runtime override, but can be forced on for packaging tests.
++  browseros_package_all_server_resources =
++      browseros_allow_runtime_product_override
 +}
 +
 +assert(browseros_product == "browseros" || browseros_product == "browserclaw",

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/BUILD.gn
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/core/BUILD.gn b/chrome/browser/browseros/core/BUILD.gn
 new file mode 100644
-index 0000000000000..bbd0c3210197f
+index 0000000000000..b939da059b981
 --- /dev/null
 +++ b/chrome/browser/browseros/core/BUILD.gn
-@@ -0,0 +1,59 @@
+@@ -0,0 +1,61 @@
 +# Copyright 2024 The Chromium Authors
 +# Use of this source code is governed by a BSD-style license that can be
 +# found in the LICENSE file.
@@ -28,6 +28,8 @@ index 0000000000000..bbd0c3210197f
 +  ]
 +
 +  deps = [
++    ":core",
++    "//base",
 +    "//chrome/browser/browseros:buildflags",
 +  ]
 +}

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_product.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_product.cc
@@ -1,29 +1,82 @@
 diff --git a/chrome/browser/browseros/core/browseros_product.cc b/chrome/browser/browseros/core/browseros_product.cc
 new file mode 100644
-index 0000000000000..566bd675f9fd3
+index 0000000000000..1b51b3ffbdd8a
 --- /dev/null
 +++ b/chrome/browser/browseros/core/browseros_product.cc
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,84 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
 +
 +#include "chrome/browser/browseros/core/browseros_product.h"
 +
++#include <optional>
++#include <string>
++#include <string_view>
++
++#include "base/command_line.h"
++#include "base/logging.h"
 +#include "chrome/browser/browseros/buildflags.h"
++#include "chrome/browser/browseros/core/browseros_switches.h"
 +
 +namespace browseros {
++namespace {
 +
 +static_assert(BUILDFLAG(BROWSEROS_PRODUCT_BROWSEROS) !=
 +                  BUILDFLAG(BROWSEROS_PRODUCT_BROWSERCLAW),
 +              "Exactly one BrowserOS product must be selected");
 +
-+Product GetProduct() {
++Product GetBakedProduct() {
 +#if BUILDFLAG(BROWSEROS_PRODUCT_BROWSERCLAW)
 +  return Product::kBrowserClaw;
 +#else
 +  return Product::kBrowserOS;
 +#endif
++}
++
++#if BUILDFLAG(BROWSEROS_ALLOW_RUNTIME_PRODUCT_OVERRIDE)
++constexpr char kBrowserOSProductValue[] = "browseros";
++constexpr char kBrowserClawProductValue[] = "browserclaw";
++
++std::optional<Product> ProductFromSwitchValue(std::string_view value) {
++  if (value == kBrowserOSProductValue) {
++    return Product::kBrowserOS;
++  }
++  if (value == kBrowserClawProductValue) {
++    return Product::kBrowserClaw;
++  }
++  return std::nullopt;
++}
++#endif
++
++}  // namespace
++
++Product GetProduct() {
++  const Product baked_product = GetBakedProduct();
++
++#if BUILDFLAG(BROWSEROS_ALLOW_RUNTIME_PRODUCT_OVERRIDE)
++  if (!base::CommandLine::InitializedForCurrentProcess()) {
++    return baked_product;
++  }
++
++  const base::CommandLine* command_line =
++      base::CommandLine::ForCurrentProcess();
++  if (!command_line->HasSwitch(kBrowserOSProduct)) {
++    return baked_product;
++  }
++
++  const std::string value =
++      command_line->GetSwitchValueASCII(kBrowserOSProduct);
++  std::optional<Product> product = ProductFromSwitchValue(value);
++  if (product.has_value()) {
++    return *product;
++  }
++
++  LOG(WARNING) << "browseros: Ignoring invalid --" << kBrowserOSProduct << "="
++               << value;
++#endif
++
++  return baked_product;
 +}
 +
 +bool IsBrowserOSProduct() {

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_product.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_product.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/core/browseros_product.h b/chrome/browser/browseros/core/browseros_product.h
 new file mode 100644
-index 0000000000000..8ff030b115de6
+index 0000000000000..a55819d454fdd
 --- /dev/null
 +++ b/chrome/browser/browseros/core/browseros_product.h
-@@ -0,0 +1,26 @@
+@@ -0,0 +1,23 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -13,15 +13,12 @@ index 0000000000000..8ff030b115de6
 +
 +namespace browseros {
 +
-+// Product identity for this build. Selected at build time via the
-+// `browseros_product` GN arg and baked into the binary, so runtime switches
-+// and field trials cannot change it.
 +enum class Product {
 +  kBrowserOS,
 +  kBrowserClaw,
 +};
 +
-+// Returns the product this binary was built as.
++// Returns the baked product, or a dev/test command-line override when enabled.
 +Product GetProduct();
 +
 +bool IsBrowserOSProduct();

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_switches.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_switches.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/core/browseros_switches.h b/chrome/browser/browseros/core/browseros_switches.h
 new file mode 100644
-index 0000000000000..1080aa947bec2
+index 0000000000000..3fa2177e4df87
 --- /dev/null
 +++ b/chrome/browser/browseros/core/browseros_switches.h
-@@ -0,0 +1,83 @@
+@@ -0,0 +1,34 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -13,75 +13,26 @@ index 0000000000000..1080aa947bec2
 +
 +namespace browseros {
 +
-+// =============================================================================
-+// BrowserOS Command-Line Switches
-+// =============================================================================
-+// All BrowserOS-specific command-line flags are defined here.
-+// Usage: --flag-name or --flag-name=value
-+
-+// === Server Switches ===
-+
-+// Disables the BrowserOS server entirely.
 +inline constexpr char kDisableServer[] = "disable-browseros-server";
-+
-+// Disables the BrowserOS server OTA updater.
-+inline constexpr char kDisableServerUpdater[] = "disable-browseros-server-updater";
-+
-+// Overrides the appcast URL for server updates (testing).
++inline constexpr char kDisableServerUpdater[] =
++    "disable-browseros-server-updater";
 +inline constexpr char kServerAppcastUrl[] = "browseros-server-appcast-url";
-+
-+// Overrides the server resources directory path.
 +inline constexpr char kServerResourcesDir[] = "browseros-server-resources-dir";
-+
-+// Overrides the CDP (Chrome DevTools Protocol) port.
 +inline constexpr char kCDPPort[] = "browseros-cdp-port";
-+
-+// Overrides the stable MCP proxy port (what external clients connect to).
 +inline constexpr char kProxyPort[] = "browseros-proxy-port";
-+
-+// Overrides the sidecar backend server port.
 +inline constexpr char kServerPort[] = "browseros-server-port";
-+
-+// === Extension Switches ===
-+
-+// Disables BrowserOS managed extensions.
 +inline constexpr char kDisableExtensions[] = "disable-browseros-extensions";
-+
-+// Overrides the extensions config URL.
 +inline constexpr char kExtensionsUrl[] = "browseros-extensions-url";
-+
-+// === URL Override Switches ===
-+
-+// Disables chrome://browseros/* URL overrides.
-+// Useful for debugging to see raw extension URLs.
-+inline constexpr char kDisableUrlOverrides[] = "browseros-disable-url-overrides";
-+
-+// === Sparkle Switches (macOS Browser Updates) ===
-+
-+// Overrides the Sparkle appcast URL for browser updates.
++inline constexpr char kDisableUrlOverrides[] =
++    "browseros-disable-url-overrides";
 +inline constexpr char kSparkleUrl[] = "browseros-sparkle-url";
-+
-+// Forces an immediate Sparkle update check.
 +inline constexpr char kSparkleForceCheck[] = "browseros-sparkle-force-check";
-+
-+// Runs Sparkle in dry-run mode (no actual updates).
 +inline constexpr char kSparkleDryRun[] = "sparkle-dry-run";
-+
-+// Skips Sparkle signature verification (testing only).
 +inline constexpr char kSparkleSkipSignature[] = "sparkle-skip-signature";
-+
-+// Spoofs the current version for Sparkle (testing).
 +inline constexpr char kSparkleSpoofVersion[] = "sparkle-spoof-version";
-+
-+// Enables verbose Sparkle logging.
 +inline constexpr char kSparkleVerbose[] = "sparkle-verbose";
-+
-+// === Misc Switches ===
-+
-+// Selects a macOS Dock icon tint for CLI-launched BrowserOS variants.
++inline constexpr char kBrowserOSProduct[] = "browseros-product";
 +inline constexpr char kDockIcon[] = "browseros-dock-icon";
-+
-+// Indicates this is the first run of BrowserOS.
 +inline constexpr char kFirstRun[] = "browseros-welcome";
 +
 +}  // namespace browseros

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/BUILD.gn
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/BUILD.gn b/chrome/browser/browseros/server/BUILD.gn
 new file mode 100644
-index 0000000000000..30759104d22c0
+index 0000000000000..8f1f42fae7854
 --- /dev/null
 +++ b/chrome/browser/browseros/server/BUILD.gn
-@@ -0,0 +1,141 @@
+@@ -0,0 +1,173 @@
 +# Copyright 2024 The Chromium Authors
 +# Use of this source code is governed by a BSD-style license that can be
 +# found in the LICENSE file.
@@ -11,23 +11,33 @@ index 0000000000000..30759104d22c0
 +import("//build/config/chrome_build.gni")
 +import("//chrome/browser/browseros/buildflags.gni")
 +
-+if (browseros_product_browserclaw) {
-+  _server_bundle_dir = "BrowserClawServer"
-+  _server_binary_name = "browseros-claw-server"
-+} else {
-+  _server_bundle_dir = "BrowserOSServer"
-+  _server_binary_name = "browseros_server"
-+}
++_browseros_server_resources = "//chrome/browser/browseros/server/resources"
++_browserclaw_server_resources =
++    "//chrome/browser/browseros/claw_server/resources"
++
++_browseros_server_binary_name = "browseros_server"
++_browserclaw_server_binary_name = "browseros-claw-server"
 +
 +if (is_win) {
-+  _server_binary_name += ".exe"
++  _browseros_server_binary_name += ".exe"
++  _browserclaw_server_binary_name += ".exe"
 +}
 +
-+action("validate_browseros_resources") {
++action("validate_browseros_server_resources") {
 +  script = "validate_resources.py"
-+  args = [ "bin/${_server_binary_name}" ]
-+  inputs = [ "resources/bin/${_server_binary_name}" ]
-+  outputs = [ "$target_gen_dir/browseros_resources_validated" ]
++  args = [ "bin/${_browseros_server_binary_name}" ]
++  inputs =
++      [ "${_browseros_server_resources}/bin/${_browseros_server_binary_name}" ]
++  outputs = [ "$target_gen_dir/browseros_server_resources_validated" ]
++}
++
++action("validate_browserclaw_server_resources") {
++  script = "validate_resources.py"
++  args = [ "bin/${_browserclaw_server_binary_name}" ]
++  inputs = [
++    "${_browserclaw_server_resources}/bin/${_browserclaw_server_binary_name}",
++  ]
++  outputs = [ "$target_gen_dir/browserclaw_server_resources_validated" ]
 +}
 +
 +source_set("server") {
@@ -108,6 +118,8 @@ index 0000000000000..30759104d22c0
 +    ":test_support",
 +    "//base",
 +    "//base/test:test_support",
++    "//chrome/browser/browseros:buildflags",
++    "//chrome/browser/browseros/core",
 +    "//components/prefs:test_support",
 +    "//net",
 +    "//testing/gmock",
@@ -119,29 +131,49 @@ index 0000000000000..30759104d22c0
 +  import("//build/config/apple/symbols.gni")
 +  import("//build/config/mac/mac_sdk.gni")
 +
-+  bundle_data("browseros_resources_bundle") {
-+    sources = [ "resources" ]
-+    outputs = [ "{{bundle_resources_dir}}/${_server_bundle_dir}/default/{{source_file_part}}" ]
++  bundle_data("browseros_server_resources_bundle") {
++    sources = [ _browseros_server_resources ]
++    outputs = [
++      "{{bundle_resources_dir}}/BrowserOSServer/default/{{source_file_part}}",
++    ]
++  }
 +
-+    # TODO: Re-enable validation when resources/bin/${_server_binary_name} is available.
-+    # deps = [ ":validate_browseros_resources" ]
++  bundle_data("browserclaw_server_resources_bundle") {
++    sources = [ _browserclaw_server_resources ]
++    outputs = [
++      "{{bundle_resources_dir}}/BrowserClawServer/default/{{source_file_part}}",
++    ]
 +  }
 +} else {
-+  copy("browseros_resources_copy") {
-+    sources = [ "resources" ]
-+    outputs =
-+        [ "$root_out_dir/${_server_bundle_dir}/default/{{source_file_part}}" ]
++  copy("browseros_server_resources_copy") {
++    sources = [ _browseros_server_resources ]
++    outputs = [ "$root_out_dir/BrowserOSServer/default/{{source_file_part}}" ]
++  }
 +
-+    # TODO: Re-enable validation when resources/bin/${_server_binary_name} is available.
-+    # deps = [ ":validate_browseros_resources" ]
++  copy("browserclaw_server_resources_copy") {
++    sources = [ _browserclaw_server_resources ]
++    outputs = [ "$root_out_dir/BrowserClawServer/default/{{source_file_part}}" ]
 +  }
 +}
 +
-+# Group for all BrowserOS server resources
 +group("browseros_server_resources") {
++  deps = []
++
 +  if (is_mac) {
-+    deps = [ ":browseros_resources_bundle" ]
++    if (browseros_product_browseros || browseros_package_all_server_resources) {
++      deps += [ ":browseros_server_resources_bundle" ]
++    }
++    if (browseros_product_browserclaw ||
++        browseros_package_all_server_resources) {
++      deps += [ ":browserclaw_server_resources_bundle" ]
++    }
 +  } else {
-+    deps = [ ":browseros_resources_copy" ]
++    if (browseros_product_browseros || browseros_package_all_server_resources) {
++      deps += [ ":browseros_server_resources_copy" ]
++    }
++    if (browseros_product_browserclaw ||
++        browseros_package_all_server_resources) {
++      deps += [ ":browserclaw_server_resources_copy" ]
++    }
 +  }
 +}

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config.h
@@ -1,6 +1,6 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_config.h b/chrome/browser/browseros/server/browseros_server_config.h
 new file mode 100644
-index 0000000000000..88a323a1c735c
+index 0000000000000..3ace523b486f4
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_config.h
 @@ -0,0 +1,127 @@
@@ -35,7 +35,7 @@ index 0000000000000..88a323a1c735c
 +const ManagedServerDescriptor& GetBrowserOSServerDescriptor();
 +const ManagedServerDescriptor& GetBrowserClawServerDescriptor();
 +
-+// Returns the server descriptor selected by the build-time product identity.
++// Returns the descriptor selected by browseros::GetProduct().
 +const ManagedServerDescriptor& GetManagedServerDescriptor();
 +
 +// Builds the JSON config expected by the selected server product.
@@ -48,7 +48,7 @@ index 0000000000000..88a323a1c735c
 +struct ServerPorts {
 +  int cdp = 0;
 +  int server = 0;  // ephemeral backend port for sidecar (was "mcp")
-+  int proxy = 0;  // stable MCP proxy port bound by Chromium
++  int proxy = 0;   // stable MCP proxy port bound by Chromium
 +
 +  bool operator==(const ServerPorts&) const = default;
 +

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config_unittest.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config_unittest.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_config_unittest.cc b/chrome/browser/browseros/server/browseros_server_config_unittest.cc
 new file mode 100644
-index 0000000000000..ce19186789056
+index 0000000000000..e88bef039ced0
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_config_unittest.cc
-@@ -0,0 +1,132 @@
+@@ -0,0 +1,206 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -12,14 +12,38 @@ index 0000000000000..ce19186789056
 +
 +#include <string_view>
 +
++#include "base/test/scoped_command_line.h"
++#include "chrome/browser/browseros/buildflags.h"
++#include "chrome/browser/browseros/core/browseros_switches.h"
 +#include "testing/gtest/include/gtest/gtest.h"
 +
 +namespace browseros {
 +namespace {
 +
-+base::FilePath::StringType ToPathString(
-+    base::FilePath::StringViewType value) {
++base::FilePath::StringType ToPathString(base::FilePath::StringViewType value) {
 +  return base::FilePath::StringType(value.begin(), value.end());
++}
++
++Product BakedProduct() {
++#if BUILDFLAG(BROWSEROS_PRODUCT_BROWSERCLAW)
++  return Product::kBrowserClaw;
++#else
++  return Product::kBrowserOS;
++#endif
++}
++
++Product OtherProduct() {
++  if (BakedProduct() == Product::kBrowserClaw) {
++    return Product::kBrowserOS;
++  }
++  return Product::kBrowserClaw;
++}
++
++std::string_view ProductSwitchValue(Product product) {
++  if (product == Product::kBrowserClaw) {
++    return "browserclaw";
++  }
++  return "browseros";
 +}
 +
 +ServerLaunchConfig BuildLaunchConfig() {
@@ -43,6 +67,38 @@ index 0000000000000..ce19186789056
 +
 +  return config;
 +}
++
++TEST(BrowserOSProductTest, ReturnsBakedProductWithoutSwitch) {
++  EXPECT_EQ(BakedProduct(), GetProduct());
++}
++
++#if !BUILDFLAG(BROWSEROS_ALLOW_RUNTIME_PRODUCT_OVERRIDE)
++TEST(BrowserOSProductTest, IgnoresProductSwitchWhenOverrideDisabled) {
++  base::test::ScopedCommandLine scoped_command_line;
++  scoped_command_line.GetProcessCommandLine()->AppendSwitchASCII(
++      kBrowserOSProduct, ProductSwitchValue(OtherProduct()));
++
++  EXPECT_EQ(BakedProduct(), GetProduct());
++}
++#endif
++
++#if BUILDFLAG(BROWSEROS_ALLOW_RUNTIME_PRODUCT_OVERRIDE)
++TEST(BrowserOSProductTest, HonorsProductSwitchWhenOverrideEnabled) {
++  base::test::ScopedCommandLine scoped_command_line;
++  scoped_command_line.GetProcessCommandLine()->AppendSwitchASCII(
++      kBrowserOSProduct, ProductSwitchValue(OtherProduct()));
++
++  EXPECT_EQ(OtherProduct(), GetProduct());
++}
++
++TEST(BrowserOSProductTest, InvalidProductSwitchFallsBackToBakedProduct) {
++  base::test::ScopedCommandLine scoped_command_line;
++  scoped_command_line.GetProcessCommandLine()->AppendSwitchASCII(
++      kBrowserOSProduct, "invalid");
++
++  EXPECT_EQ(BakedProduct(), GetProduct());
++}
++#endif
 +
 +TEST(BrowserOSServerConfigTest, BrowserOSDescriptorMatchesLegacyServer) {
 +  const ManagedServerDescriptor& descriptor = GetBrowserOSServerDescriptor();
@@ -74,6 +130,24 @@ index 0000000000000..ce19186789056
 +  EXPECT_EQ(std::string_view("/system/health"), descriptor.health_path);
 +  EXPECT_FALSE(descriptor.enable_updater);
 +}
++
++TEST(BrowserOSServerConfigTest, ManagedDescriptorUsesSelectedProduct) {
++  const ManagedServerDescriptor& descriptor = GetManagedServerDescriptor();
++
++  EXPECT_EQ(GetProduct(), descriptor.product);
++}
++
++#if BUILDFLAG(BROWSEROS_ALLOW_RUNTIME_PRODUCT_OVERRIDE)
++TEST(BrowserOSServerConfigTest, ManagedDescriptorFollowsRuntimeOverride) {
++  base::test::ScopedCommandLine scoped_command_line;
++  scoped_command_line.GetProcessCommandLine()->AppendSwitchASCII(
++      kBrowserOSProduct, ProductSwitchValue(OtherProduct()));
++
++  const ManagedServerDescriptor& descriptor = GetManagedServerDescriptor();
++
++  EXPECT_EQ(OtherProduct(), descriptor.product);
++}
++#endif
 +
 +TEST(BrowserOSServerConfigTest, ServerConfigJsonHasUnifiedShape) {
 +  ServerLaunchConfig config = BuildLaunchConfig();


### PR DESCRIPTION
## Summary
- Extracts the Chromium patch for the dev/test-only BrowserOS product runtime override.
- Splits BrowserOS and BrowserClaw server resource packaging into independent Chromium patch targets.
- Aligns BrowserOS packaging metadata/tests with Chromium's `BrowserClawServer/default/resources` bundle root.

## Design
Official builds remain fixed by the baked `browseros_product` GN arg. Dev/test builds can opt into `browseros_allow_runtime_product_override`, which allows `browseros::GetProduct()` to honor `--browseros-product=browseros|browserclaw`. Runtime server descriptor selection continues to flow through `GetProduct()`, while GN packaging defaults follow the baked product unless package-all resources is explicitly enabled.

## Test plan
- [x] `/Users/shadowfax/.skills/sf-ch-mux/scripts/chpool build -- autoninja -C out/Default_arm64 chrome`
- [x] `/Users/shadowfax/.skills/sf-ch-extract/scripts/verify-patches.sh --chromium-src /Users/shadowfax/ch1-src --worktree /Users/shadowfax/worktrees/main/feat-browseros-runtime-product-override-patches --tip 370c48116837a6ca0a4e5c42bfbdc0e1f67513f3`
- [x] `uv --directory packages/browseros run python -m unittest build.common.server_binaries_test build.modules.package.linux_test build.modules.sign.macos_test build.modules.sign.windows_test`
