### PR TITLE
fix: upload claw server artifacts by default

### DIFF
--- a/packages/browseros-agent/apps/claw-server/tests/build.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/build.test.ts
@@ -2,7 +2,10 @@ import { afterAll, describe, it } from 'bun:test'
 import assert from 'node:assert'
 import { existsSync, readFileSync, rmSync } from 'node:fs'
 import { resolve } from 'node:path'
-import { loadBuildConfig } from '../../../packages/build-server-tools/src'
+import {
+  loadBuildConfig,
+  parseBuildArgs,
+} from '../../../packages/build-server-tools/src'
 import { clawServerBuildProduct } from '../../../scripts/build/claw-server/descriptor'
 
 function getNativeTarget(): { id: string; ext: string; stagedName: string } {
@@ -70,17 +73,39 @@ describe('claw server build', () => {
     })
   })
 
+  it('uploads artifacts by default while preserving local-only modes', () => {
+    assert.strictEqual(
+      parseBuildArgs(['--target=darwin-arm64'], clawServerBuildProduct).upload,
+      true,
+    )
+    assert.strictEqual(
+      parseBuildArgs(
+        ['--target=darwin-arm64', '--no-upload'],
+        clawServerBuildProduct,
+      ).upload,
+      false,
+    )
+    assert.strictEqual(
+      parseBuildArgs(['--target=darwin-arm64', '--ci'], clawServerBuildProduct)
+        .upload,
+      false,
+    )
+  })
+
   it('builds a local artifact without apps/server env files', async () => {
     rmSync(zipPath, { force: true })
     const pkg = await Bun.file(clawPkgPath).json()
     const expectedVersion: string = pkg.version
 
-    const build = Bun.spawn(['bun', buildScript, `--target=${target.id}`], {
-      cwd: rootDir,
-      stdout: 'pipe',
-      stderr: 'pipe',
-      env: buildEnv(UNNEEDED_SERVER_AND_R2_ENV_KEYS),
-    })
+    const build = Bun.spawn(
+      ['bun', buildScript, `--target=${target.id}`, '--no-upload'],
+      {
+        cwd: rootDir,
+        stdout: 'pipe',
+        stderr: 'pipe',
+        env: buildEnv(UNNEEDED_SERVER_AND_R2_ENV_KEYS),
+      },
+    )
     const buildExit = await build.exited
     if (buildExit !== 0) {
       const stderr = await new Response(build.stderr).text()

--- a/packages/browseros-agent/scripts/build/claw-server/descriptor.ts
+++ b/packages/browseros-agent/scripts/build/claw-server/descriptor.ts
@@ -11,7 +11,6 @@ export const clawServerBuildProduct: BuildProductDescriptor = {
   stagedBinaryBaseName: 'browseros-claw-server',
   archiveBaseName: 'browseros-claw-server-resources',
   defaultManifestPath: 'scripts/build/config/claw-server-prod-resources.json',
-  defaultUpload: false,
   env: {
     prodEnvPath: 'apps/claw-server/.env.production',
     requireProdEnvFile: false,


### PR DESCRIPTION
## Summary
- Makes the normal Claw server build inherit the shared production upload default, matching `build:server` behavior.
- Keeps local-only verification explicit through `--no-upload`, including the existing `build:claw-server:test` path.
- Adds regression coverage for default upload, `--no-upload`, `--ci`, and the Claw artifact smoke build.

## Design
The Claw build script already uses `runProdResourceBuild` from `@browseros/build-server-tools`; upload behavior is resolved by `parseBuildArgs` and the product descriptor. The bug was the Claw descriptor's `defaultUpload: false`, which made a successful production build archive locally but skip R2 uploads. Removing that override lets Claw inherit the shared default while preserving explicit opt-outs.

## Test plan
- [x] `bun test apps/claw-server/tests/build.test.ts packages/build-server-tools/tests/cli.test.ts`
- [x] `bun run build:claw-server:test`
- [x] `bun run check`
- [x] `bun run test`