### PR TITLE
fix: enable claw resource downloads

### DIFF
--- a/packages/browseros/build/config/download_resources.yaml
+++ b/packages/browseros/build/config/download_resources.yaml
@@ -71,37 +71,37 @@ download_operations:
     arch: ["x64"]
 
   # BrowserOS Claw Server resource bundles - Platform & Architecture specific
-  # - name: "BrowserOS Claw Server Resources - macOS ARM64"
-  #   r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-arm64.zip"
-  #   destination: "resources/binaries/browseros_claw_server/darwin-arm64"
-  #   download_type: "artifact_zip"
-  #   os: ["macos"]
-  #   arch: ["arm64"]
-  #
-  # - name: "BrowserOS Claw Server Resources - macOS x64"
-  #   r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-x64.zip"
-  #   destination: "resources/binaries/browseros_claw_server/darwin-x64"
-  #   download_type: "artifact_zip"
-  #   os: ["macos"]
-  #   arch: ["x64"]
-  #
-  # - name: "BrowserOS Claw Server Resources - Linux ARM64"
-  #   r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-arm64.zip"
-  #   destination: "resources/binaries/browseros_claw_server/linux-arm64"
-  #   download_type: "artifact_zip"
-  #   os: ["linux"]
-  #   arch: ["arm64"]
-  #
-  # - name: "BrowserOS Claw Server Resources - Linux x64"
-  #   r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-x64.zip"
-  #   destination: "resources/binaries/browseros_claw_server/linux-x64"
-  #   download_type: "artifact_zip"
-  #   os: ["linux"]
-  #   arch: ["x64"]
-  #
-  # - name: "BrowserOS Claw Server Resources - Windows x64"
-  #   r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-windows-x64.zip"
-  #   destination: "resources/binaries/browseros_claw_server/windows-x64"
-  #   download_type: "artifact_zip"
-  #   os: ["windows"]
-  #   arch: ["x64"]
+  - name: "BrowserOS Claw Server Resources - macOS ARM64"
+    r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-arm64.zip"
+    destination: "resources/binaries/browseros_claw_server/darwin-arm64"
+    download_type: "artifact_zip"
+    os: ["macos"]
+    arch: ["arm64"]
+
+  - name: "BrowserOS Claw Server Resources - macOS x64"
+    r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-x64.zip"
+    destination: "resources/binaries/browseros_claw_server/darwin-x64"
+    download_type: "artifact_zip"
+    os: ["macos"]
+    arch: ["x64"]
+
+  - name: "BrowserOS Claw Server Resources - Linux ARM64"
+    r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-arm64.zip"
+    destination: "resources/binaries/browseros_claw_server/linux-arm64"
+    download_type: "artifact_zip"
+    os: ["linux"]
+    arch: ["arm64"]
+
+  - name: "BrowserOS Claw Server Resources - Linux x64"
+    r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-x64.zip"
+    destination: "resources/binaries/browseros_claw_server/linux-x64"
+    download_type: "artifact_zip"
+    os: ["linux"]
+    arch: ["x64"]
+
+  - name: "BrowserOS Claw Server Resources - Windows x64"
+    r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-windows-x64.zip"
+    destination: "resources/binaries/browseros_claw_server/windows-x64"
+    download_type: "artifact_zip"
+    os: ["windows"]
+    arch: ["x64"]


### PR DESCRIPTION
## Summary
- enables the existing platform-specific Claw server resource bundle downloads
- stages Claw artifacts under `resources/binaries/browseros_claw_server/<target>` so copy resources lands them in `chrome/browser/browseros/claw_server/resources`
- keeps BrowserOS server resource downloads unchanged

## Design
This activates the already-defined `artifact_zip` entries for the Claw resource bundles using the R2 prefix produced by the Claw server build descriptor. The existing artifact extraction and copy-resource steps already preserve the expected `resources/...` tree shape.

## Test plan
- [x] `cd packages/browseros && python -m unittest build.modules.storage.download_test.DownloadResourceConfigTest build.modules.resources.resources_test.CopyResourcesTest.test_real_config_copies_browseros_and_claw_server_roots_apart`
- [x] `cd packages/browseros && python -m unittest discover -s build -p '*_test.py'`
- [x] `git diff --check`