### PR TITLE
feat(patches): gate BrowserOS extensions by active product

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_action_utils.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_action_utils.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/core/browseros_action_utils.h b/chrome/browser/browseros/core/browseros_action_utils.h
 new file mode 100644
-index 0000000000000..e263119b0fb23
+index 0000000000000..cf8770fd34479
 --- /dev/null
 +++ b/chrome/browser/browseros/core/browseros_action_utils.h
-@@ -0,0 +1,67 @@
+@@ -0,0 +1,60 @@
 +// Copyright 2025 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -17,33 +17,28 @@ index 0000000000000..e263119b0fb23
 +#include "base/containers/fixed_flat_set.h"
 +#include "chrome/browser/browseros/core/browseros_constants.h"
 +#include "chrome/browser/ui/actions/chrome_action_id.h"
-+#include "chrome/browser/ui/ui_features.h"
 +#include "chrome/browser/ui/side_panel/side_panel_entry_key.h"
++#include "chrome/browser/ui/ui_features.h"
 +#include "chrome/common/chrome_features.h"
 +#include "ui/actions/actions.h"
 +
 +namespace browseros {
 +
-+// Native action IDs for BrowserOS panels that need special treatment.
-+// These actions will:
-+// - Always be pinned (unless disabled via pref)
-+// - Show text labels (when enabled via pref)
-+// - Have high flex priority (always visible)
 +constexpr auto kBrowserOSNativeActionIds =
 +    base::MakeFixedFlatSet<actions::ActionId>({
 +        kActionSidePanelShowThirdPartyLlm,
-+        kActionBrowserOSAgent,
 +    });
 +
-+// Check if an action ID is a BrowserOS action (native or extension).
 +inline bool IsBrowserOSAction(actions::ActionId id) {
-+  // Check native actions
++  if (id == kActionBrowserOSAgent) {
++    return browseros::IsActiveBrowserOSExtension(browseros::kAgentExtensionId);
++  }
++
 +  if (kBrowserOSNativeActionIds.contains(id)) {
 +    return true;
 +  }
 +
-+  // Only labelled extensions are considered for BrowserOS actions
-+  for (const auto& ext_id : browseros::GetBrowserOSExtensionIds()) {
++  for (const auto& ext_id : browseros::GetActiveBrowserOSExtensionIds()) {
 +    if (!browseros::IsBrowserOSLabelledExtension(ext_id)) {
 +      continue;
 +    }
@@ -57,9 +52,7 @@ index 0000000000000..e263119b0fb23
 +  return false;
 +}
 +
-+// Get the feature flag for a native BrowserOS action.
-+inline const base::Feature* GetFeatureForBrowserOSAction(
-+    actions::ActionId id) {
++inline const base::Feature* GetFeatureForBrowserOSAction(actions::ActionId id) {
 +  switch (id) {
 +    case kActionSidePanelShowThirdPartyLlm:
 +      return &features::kThirdPartyLlmPanel;

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_constants.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_constants.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/core/browseros_constants.h b/chrome/browser/browseros/core/browseros_constants.h
 new file mode 100644
-index 0000000000000..550550ce68436
+index 0000000000000..fb5ac988ee89c
 --- /dev/null
 +++ b/chrome/browser/browseros/core/browseros_constants.h
-@@ -0,0 +1,227 @@
+@@ -0,0 +1,251 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -17,55 +17,126 @@ index 0000000000000..550550ce68436
 +#include <vector>
 +
 +#include "base/command_line.h"
++#include "chrome/browser/browseros/core/browseros_product.h"
 +#include "chrome/browser/browseros/core/browseros_switches.h"
 +
 +namespace browseros {
 +
-+// Check if URL overrides are disabled via command line flag
 +inline bool IsURLOverridesDisabled() {
-+  return base::CommandLine::ForCurrentProcess()->HasSwitch(kDisableUrlOverrides);
++  return base::CommandLine::ForCurrentProcess()->HasSwitch(
++      kDisableUrlOverrides);
 +}
 +
-+// BrowserOS extension config URLs
 +inline constexpr char kBrowserOSConfigUrl[] =
 +    "https://cdn.browseros.com/extensions/extensions.json";
 +inline constexpr char kBrowserOSAlphaConfigUrl[] =
 +    "https://cdn.browseros.com/extensions/extensions.alpha.json";
 +
-+// Agent Extension ID
-+inline constexpr char kAgentExtensionId[] =
-+    "bflpfmnmnokmjhmgnolecpppdbdophmk";
++inline constexpr char kAgentExtensionId[] = "bflpfmnmnokmjhmgnolecpppdbdophmk";
 +
-+// Bug Reporter Extension ID
 +inline constexpr char kBugReporterExtensionId[] =
 +    "adlpneommgkgeanpaekgoaolcpncohkf";
 +
-+// BrowserClaw Extension ID
++inline constexpr char kControllerExtensionId[] =
++    "nlnihljpboknmfagkikhkdblbedophja";
++
 +inline constexpr char kBrowserClawExtensionId[] =
 +    "pjimfkbpehlcllblajnpfamdfjhhlgkc";
 +
-+// uBlock Origin Extension ID (Chrome Web Store)
-+// inline constexpr char kUBlockOriginExtensionId[] =
-+//     "cjpalhdlnbpafiamejdnhcphjbkeiagm";
-+
-+// BrowserOS CDN update manifest URL
-+// Used for extensions installed from local .crx files that don't have
-+// an update_url in their manifest
 +inline constexpr char kBrowserOSUpdateUrl[] =
 +    "https://cdn.browseros.com/extensions/update-manifest.xml";
 +inline constexpr char kBrowserOSAlphaUpdateUrl[] =
 +    "https://cdn.browseros.com/extensions/update-manifest.alpha.xml";
 +
-+// chrome://browseros host constant
 +inline constexpr char kBrowserOSHost[] = "browseros";
 +
-+// URL route mapping for chrome://browseros/* virtual URLs
 +struct BrowserOSURLRoute {
-+  const char* virtual_path;    // Path in chrome://browseros/*, e.g., "/ai"
-+  const char* extension_id;    // Extension that handles this route
-+  const char* extension_page;  // Page within extension, e.g., "options.html"
-+  const char* extension_hash;  // Hash/fragment without #, e.g., "ai" (empty if none)
++  const char* virtual_path;
++  const char* extension_id;
++  const char* extension_page;
++  const char* extension_hash;
 +};
++
++enum class BrowserOSExtensionProduct {
++  kBrowserOS,
++  kBrowserClaw,
++  kAll,
++};
++
++struct BrowserOSExtensionInfo {
++  const char* id;
++  bool is_pinned;
++  bool is_labelled;
++  BrowserOSExtensionProduct product;
++};
++
++inline constexpr BrowserOSExtensionInfo kBrowserOSExtensions[] = {
++    {kAgentExtensionId, false, false, BrowserOSExtensionProduct::kBrowserOS},
++    {kBugReporterExtensionId, true, false, BrowserOSExtensionProduct::kAll},
++    {kControllerExtensionId, false, false,
++     BrowserOSExtensionProduct::kBrowserOS},
++    {kBrowserClawExtensionId, true, false,
++     BrowserOSExtensionProduct::kBrowserClaw},
++};
++
++inline constexpr size_t kBrowserOSExtensionsCount =
++    sizeof(kBrowserOSExtensions) / sizeof(kBrowserOSExtensions[0]);
++
++inline bool IsBrowserOSExtensionProductActive(
++    BrowserOSExtensionProduct product) {
++  switch (product) {
++    case BrowserOSExtensionProduct::kBrowserOS:
++      return IsBrowserOSProduct();
++    case BrowserOSExtensionProduct::kBrowserClaw:
++      return IsBrowserClawProduct();
++    case BrowserOSExtensionProduct::kAll:
++      return true;
++  }
++  return false;
++}
++
++inline const BrowserOSExtensionInfo* FindBrowserOSExtensionInfo(
++    const std::string& extension_id) {
++  for (const auto& info : kBrowserOSExtensions) {
++    if (extension_id == info.id) {
++      return &info;
++    }
++  }
++  return nullptr;
++}
++
++// Known means catalog membership, independent of the current product.
++inline bool IsKnownBrowserOSExtension(const std::string& extension_id) {
++  return FindBrowserOSExtensionInfo(extension_id) != nullptr;
++}
++
++// Active means the catalog entry belongs to the current BrowserOS product.
++inline bool IsActiveBrowserOSExtension(const std::string& extension_id) {
++  const BrowserOSExtensionInfo* info = FindBrowserOSExtensionInfo(extension_id);
++  return info && IsBrowserOSExtensionProductActive(info->product);
++}
++
++// Returns catalog IDs that should participate in current-product behavior.
++inline std::vector<std::string> GetActiveBrowserOSExtensionIds() {
++  std::vector<std::string> ids;
++  ids.reserve(kBrowserOSExtensionsCount);
++  for (const auto& info : kBrowserOSExtensions) {
++    if (IsBrowserOSExtensionProductActive(info.product)) {
++      ids.push_back(info.id);
++    }
++  }
++  return ids;
++}
++
++// Returns every managed catalog ID for cleanup and migration paths.
++inline std::vector<std::string> GetAllBrowserOSExtensionIds() {
++  std::vector<std::string> ids;
++  ids.reserve(kBrowserOSExtensionsCount);
++  for (const auto& info : kBrowserOSExtensions) {
++    ids.push_back(info.id);
++  }
++  return ids;
++}
 +
 +inline constexpr BrowserOSURLRoute kBrowserOSURLRoutes[] = {
 +    {"/settings", kAgentExtensionId, "app.html", "/settings"},
@@ -76,20 +147,16 @@ index 0000000000000..550550ce68436
 +inline constexpr size_t kBrowserOSURLRoutesCount =
 +    sizeof(kBrowserOSURLRoutes) / sizeof(kBrowserOSURLRoutes[0]);
 +
-+// Find a route for a given virtual path (e.g., "/ai")
-+// Returns nullptr if no matching route found
 +inline const BrowserOSURLRoute* FindBrowserOSRoute(std::string_view path) {
 +  for (const auto& route : kBrowserOSURLRoutes) {
-+    if (path == route.virtual_path) {
++    if (path == route.virtual_path &&
++        IsActiveBrowserOSExtension(route.extension_id)) {
 +      return &route;
 +    }
 +  }
 +  return nullptr;
 +}
 +
-+// Get the extension URL for a chrome://browseros/* path
-+// Returns empty string if no matching route or if URL overrides are disabled
-+// Example: "/ai" -> "chrome-extension://bflp.../options.html#ai"
 +inline std::string GetBrowserOSExtensionURL(std::string_view virtual_path) {
 +  if (IsURLOverridesDisabled()) {
 +    return std::string();
@@ -107,14 +174,6 @@ index 0000000000000..550550ce68436
 +  return url;
 +}
 +
-+// Check if an extension URL matches a BrowserOS route
-+// If matched, returns the virtual URL (chrome://browseros/...)
-+// Returns empty string if not a BrowserOS extension URL
-+// Parameters:
-+//   extension_id: from url.host()
-+//   extension_path: from url.path(), e.g., "/options.html"
-+//   extension_ref: from url.ref(), e.g., "ai" or "/ai" (normalized internally)
-+// Fallback: If no exact hash match, falls back to route with empty hash for same page
 +inline std::string GetBrowserOSVirtualURL(std::string_view extension_id,
 +                                          std::string_view extension_path,
 +                                          std::string_view extension_ref) {
@@ -131,13 +190,18 @@ index 0000000000000..550550ce68436
 +  const BrowserOSURLRoute* fallback_route = nullptr;
 +
 +  for (const auto& route : kBrowserOSURLRoutes) {
++    if (!IsActiveBrowserOSExtension(route.extension_id)) {
++      continue;
++    }
++
 +    if (extension_id != route.extension_id) {
 +      continue;
 +    }
 +
 +    // Compare path (handle leading slash)
 +    std::string route_path = std::string("/") + route.extension_page;
-+    if (extension_path != route_path && extension_path != route.extension_page) {
++    if (extension_path != route_path &&
++        extension_path != route.extension_page) {
 +      continue;
 +    }
 +
@@ -158,68 +222,28 @@ index 0000000000000..550550ce68436
 +
 +  // No exact match - use fallback if available
 +  if (fallback_route) {
-+    return std::string("chrome://") + kBrowserOSHost + fallback_route->virtual_path;
++    return std::string("chrome://") + kBrowserOSHost +
++           fallback_route->virtual_path;
 +  }
 +
 +  return std::string();
 +}
 +
-+struct BrowserOSExtensionInfo {
-+  const char* id;
-+  bool is_pinned;
-+  bool is_labelled;
-+};
-+
-+inline constexpr BrowserOSExtensionInfo kBrowserOSExtensions[] = {
-+    {kAgentExtensionId, false, false},
-+    {kBugReporterExtensionId, true, false},
-+    {kBrowserClawExtensionId, true, false},
-+    // ublock origin gets installed from chrome web store
-+    // {kUBlockOriginExtensionId, false, false},
-+};
-+
-+inline constexpr size_t kBrowserOSExtensionsCount =
-+    sizeof(kBrowserOSExtensions) / sizeof(kBrowserOSExtensions[0]);
-+
-+inline const BrowserOSExtensionInfo* FindBrowserOSExtensionInfo(
-+    const std::string& extension_id) {
-+  for (const auto& info : kBrowserOSExtensions) {
-+    if (extension_id == info.id)
-+      return &info;
-+  }
-+  return nullptr;
-+}
-+
-+// Check if an extension is a BrowserOS extension
-+inline bool IsBrowserOSExtension(const std::string& extension_id) {
-+  return FindBrowserOSExtensionInfo(extension_id) != nullptr;
-+}
-+
 +inline bool IsBrowserOSPinnedExtension(const std::string& extension_id) {
-+  const BrowserOSExtensionInfo* info =
-+      FindBrowserOSExtensionInfo(extension_id);
-+  return info && info->is_pinned;
++  const BrowserOSExtensionInfo* info = FindBrowserOSExtensionInfo(extension_id);
++  return info && IsBrowserOSExtensionProductActive(info->product) &&
++         info->is_pinned;
 +}
 +
 +inline bool IsBrowserOSLabelledExtension(const std::string& extension_id) {
-+  const BrowserOSExtensionInfo* info =
-+      FindBrowserOSExtensionInfo(extension_id);
-+  return info && info->is_labelled;
++  const BrowserOSExtensionInfo* info = FindBrowserOSExtensionInfo(extension_id);
++  return info && IsBrowserOSExtensionProductActive(info->product) &&
++         info->is_labelled;
 +}
 +
-+// Returns true if this extension uses the contextual (tab-specific) side panel
-+// toggle behavior. Currently only the Agent extension uses this.
 +inline bool UsesContextualSidePanelToggle(const std::string& extension_id) {
-+  return extension_id == kAgentExtensionId;
-+}
-+
-+// Get all BrowserOS extension IDs
-+inline std::vector<std::string> GetBrowserOSExtensionIds() {
-+  std::vector<std::string> ids;
-+  ids.reserve(kBrowserOSExtensionsCount);
-+  for (const auto& info : kBrowserOSExtensions)
-+    ids.push_back(info.id);
-+  return ids;
++  return IsActiveBrowserOSExtension(extension_id) &&
++         extension_id == kAgentExtensionId;
 +}
 +
 +// Sentry crash reporting

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_product.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_product.cc
@@ -1,90 +1,11 @@
 diff --git a/chrome/browser/browseros/core/browseros_product.cc b/chrome/browser/browseros/core/browseros_product.cc
 new file mode 100644
-index 0000000000000..1b51b3ffbdd8a
+index 0000000000000..f72f4f8694f81
 --- /dev/null
 +++ b/chrome/browser/browseros/core/browseros_product.cc
-@@ -0,0 +1,84 @@
+@@ -0,0 +1,5 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
 +
 +#include "chrome/browser/browseros/core/browseros_product.h"
-+
-+#include <optional>
-+#include <string>
-+#include <string_view>
-+
-+#include "base/command_line.h"
-+#include "base/logging.h"
-+#include "chrome/browser/browseros/buildflags.h"
-+#include "chrome/browser/browseros/core/browseros_switches.h"
-+
-+namespace browseros {
-+namespace {
-+
-+static_assert(BUILDFLAG(BROWSEROS_PRODUCT_BROWSEROS) !=
-+                  BUILDFLAG(BROWSEROS_PRODUCT_BROWSERCLAW),
-+              "Exactly one BrowserOS product must be selected");
-+
-+Product GetBakedProduct() {
-+#if BUILDFLAG(BROWSEROS_PRODUCT_BROWSERCLAW)
-+  return Product::kBrowserClaw;
-+#else
-+  return Product::kBrowserOS;
-+#endif
-+}
-+
-+#if BUILDFLAG(BROWSEROS_ALLOW_RUNTIME_PRODUCT_OVERRIDE)
-+constexpr char kBrowserOSProductValue[] = "browseros";
-+constexpr char kBrowserClawProductValue[] = "browserclaw";
-+
-+std::optional<Product> ProductFromSwitchValue(std::string_view value) {
-+  if (value == kBrowserOSProductValue) {
-+    return Product::kBrowserOS;
-+  }
-+  if (value == kBrowserClawProductValue) {
-+    return Product::kBrowserClaw;
-+  }
-+  return std::nullopt;
-+}
-+#endif
-+
-+}  // namespace
-+
-+Product GetProduct() {
-+  const Product baked_product = GetBakedProduct();
-+
-+#if BUILDFLAG(BROWSEROS_ALLOW_RUNTIME_PRODUCT_OVERRIDE)
-+  if (!base::CommandLine::InitializedForCurrentProcess()) {
-+    return baked_product;
-+  }
-+
-+  const base::CommandLine* command_line =
-+      base::CommandLine::ForCurrentProcess();
-+  if (!command_line->HasSwitch(kBrowserOSProduct)) {
-+    return baked_product;
-+  }
-+
-+  const std::string value =
-+      command_line->GetSwitchValueASCII(kBrowserOSProduct);
-+  std::optional<Product> product = ProductFromSwitchValue(value);
-+  if (product.has_value()) {
-+    return *product;
-+  }
-+
-+  LOG(WARNING) << "browseros: Ignoring invalid --" << kBrowserOSProduct << "="
-+               << value;
-+#endif
-+
-+  return baked_product;
-+}
-+
-+bool IsBrowserOSProduct() {
-+  return GetProduct() == Product::kBrowserOS;
-+}
-+
-+bool IsBrowserClawProduct() {
-+  return GetProduct() == Product::kBrowserClaw;
-+}
-+
-+}  // namespace browseros

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_product.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_product.h
@@ -1,15 +1,24 @@
 diff --git a/chrome/browser/browseros/core/browseros_product.h b/chrome/browser/browseros/core/browseros_product.h
 new file mode 100644
-index 0000000000000..a55819d454fdd
+index 0000000000000..e35cbdaf72a25
 --- /dev/null
 +++ b/chrome/browser/browseros/core/browseros_product.h
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,89 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
 +
 +#ifndef CHROME_BROWSER_BROWSEROS_CORE_BROWSEROS_PRODUCT_H_
 +#define CHROME_BROWSER_BROWSEROS_CORE_BROWSEROS_PRODUCT_H_
++
++#include <optional>
++#include <string>
++#include <string_view>
++
++#include "base/command_line.h"
++#include "base/logging.h"
++#include "chrome/browser/browseros/buildflags.h"
++#include "chrome/browser/browseros/core/browseros_switches.h"
 +
 +namespace browseros {
 +
@@ -18,11 +27,68 @@ index 0000000000000..a55819d454fdd
 +  kBrowserClaw,
 +};
 +
-+// Returns the baked product, or a dev/test command-line override when enabled.
-+Product GetProduct();
++static_assert(BUILDFLAG(BROWSEROS_PRODUCT_BROWSEROS) !=
++                  BUILDFLAG(BROWSEROS_PRODUCT_BROWSERCLAW),
++              "Exactly one BrowserOS product must be selected");
 +
-+bool IsBrowserOSProduct();
-+bool IsBrowserClawProduct();
++inline Product GetBakedProduct() {
++#if BUILDFLAG(BROWSEROS_PRODUCT_BROWSERCLAW)
++  return Product::kBrowserClaw;
++#else
++  return Product::kBrowserOS;
++#endif
++}
++
++#if BUILDFLAG(BROWSEROS_ALLOW_RUNTIME_PRODUCT_OVERRIDE)
++inline constexpr char kBrowserOSProductValue[] = "browseros";
++inline constexpr char kBrowserClawProductValue[] = "browserclaw";
++
++inline std::optional<Product> ProductFromSwitchValue(std::string_view value) {
++  if (value == kBrowserOSProductValue) {
++    return Product::kBrowserOS;
++  }
++  if (value == kBrowserClawProductValue) {
++    return Product::kBrowserClaw;
++  }
++  return std::nullopt;
++}
++#endif
++
++inline Product GetProduct() {
++  const Product baked_product = GetBakedProduct();
++
++#if BUILDFLAG(BROWSEROS_ALLOW_RUNTIME_PRODUCT_OVERRIDE)
++  if (!base::CommandLine::InitializedForCurrentProcess()) {
++    return baked_product;
++  }
++
++  const base::CommandLine* command_line =
++      base::CommandLine::ForCurrentProcess();
++  if (!command_line->HasSwitch(kBrowserOSProduct)) {
++    return baked_product;
++  }
++
++  const std::string value =
++      command_line->GetSwitchValueASCII(kBrowserOSProduct);
++  std::optional<Product> product = ProductFromSwitchValue(value);
++  if (product.has_value()) {
++    return *product;
++  }
++
++  LOG(WARNING) << "browseros: Ignoring invalid --" << kBrowserOSProduct << "="
++               << value;
++#endif
++
++  return baked_product;
++}
++
++inline bool IsBrowserOSProduct() {
++  return GetProduct() == Product::kBrowserOS;
++}
++
++inline bool IsBrowserClawProduct() {
++  return GetProduct() == Product::kBrowserClaw;
++}
 +
 +}  // namespace browseros
 +

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_installer.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_installer.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/extensions/browseros_extension_installer.cc b/chrome/browser/browseros/extensions/browseros_extension_installer.cc
 new file mode 100644
-index 0000000000000..54dbe08156bb6
+index 0000000000000..8b976ef54e385
 --- /dev/null
 +++ b/chrome/browser/browseros/extensions/browseros_extension_installer.cc
-@@ -0,0 +1,313 @@
+@@ -0,0 +1,310 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -61,7 +61,7 @@ index 0000000000000..54dbe08156bb6
 +
 +BrowserOSExtensionInstaller::BrowserOSExtensionInstaller(Profile* profile)
 +    : profile_(profile) {
-+  for (const std::string& id : GetBrowserOSExtensionIds()) {
++  for (const std::string& id : GetActiveBrowserOSExtensionIds()) {
 +    extension_ids_.insert(id);
 +  }
 +}
@@ -135,9 +135,8 @@ index 0000000000000..54dbe08156bb6
 +      continue;
 +    }
 +
-+    // Only install registered BrowserOS extensions
-+    if (!IsBrowserOSExtension(extension_id)) {
-+      LOG(WARNING) << "browseros: Skipping unregistered extension "
++    if (!IsActiveBrowserOSExtension(extension_id)) {
++      LOG(WARNING) << "browseros: Skipping inactive or unregistered extension "
 +                   << extension_id;
 +      continue;
 +    }
@@ -249,9 +248,8 @@ index 0000000000000..54dbe08156bb6
 +      continue;
 +    }
 +
-+    // Only install registered BrowserOS extensions
-+    if (!IsBrowserOSExtension(extension_id)) {
-+      LOG(WARNING) << "browseros: Skipping unregistered extension "
++    if (!IsActiveBrowserOSExtension(extension_id)) {
++      LOG(WARNING) << "browseros: Skipping inactive or unregistered extension "
 +                   << extension_id;
 +      continue;
 +    }
@@ -299,8 +297,7 @@ index 0000000000000..54dbe08156bb6
 +    return base::DictValue();
 +  }
 +
-+  const base::DictValue* extensions =
-+      parsed->GetDict().FindDict("extensions");
++  const base::DictValue* extensions = parsed->GetDict().FindDict("extensions");
 +
 +  if (!extensions) {
 +    LOG(ERROR) << "browseros: No 'extensions' key in config";

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_loader.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_loader.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/extensions/browseros_extension_loader.cc b/chrome/browser/browseros/extensions/browseros_extension_loader.cc
 new file mode 100644
-index 0000000000000..70ad8710a39b7
+index 0000000000000..936c8d7cf7948
 --- /dev/null
 +++ b/chrome/browser/browseros/extensions/browseros_extension_loader.cc
-@@ -0,0 +1,269 @@
+@@ -0,0 +1,267 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -18,11 +18,11 @@ index 0000000000000..70ad8710a39b7
 +#include "base/version.h"
 +#include "chrome/browser/browser_features.h"
 +#include "chrome/browser/browseros/core/browseros_constants.h"
-+#include "extensions/browser/crx_installer.h"
 +#include "chrome/browser/extensions/external_provider_impl.h"
 +#include "chrome/browser/extensions/updater/extension_updater.h"
 +#include "chrome/browser/profiles/profile.h"
 +#include "extensions/browser/crx_file_info.h"
++#include "extensions/browser/crx_installer.h"
 +#include "extensions/browser/extension_registry.h"
 +#include "extensions/browser/pending_extension_manager.h"
 +#include "extensions/common/extension.h"
@@ -44,7 +44,7 @@ index 0000000000000..70ad8710a39b7
 +               ? kBrowserOSAlphaConfigUrl
 +               : kBrowserOSConfigUrl);
 +
-+  for (const std::string& id : GetBrowserOSExtensionIds()) {
++  for (const std::string& id : GetActiveBrowserOSExtensionIds()) {
 +    extension_ids_.insert(id);
 +  }
 +}
@@ -62,9 +62,8 @@ index 0000000000000..70ad8710a39b7
 +  maintainer_ = std::make_unique<BrowserOSExtensionMaintainer>(profile_);
 +
 +  installer_->StartInstallation(
-+      config_url_,
-+      base::BindOnce(&BrowserOSExtensionLoader::OnInstallComplete,
-+                     weak_ptr_factory_.GetWeakPtr()));
++      config_url_, base::BindOnce(&BrowserOSExtensionLoader::OnInstallComplete,
++                                  weak_ptr_factory_.GetWeakPtr()));
 +}
 +
 +void BrowserOSExtensionLoader::OnInstallComplete(InstallResult result) {
@@ -95,8 +94,8 @@ index 0000000000000..70ad8710a39b7
 +    LOG(WARNING) << "browseros: Install returned empty prefs, "
 +                 << "reconstructing from installed extensions";
 +    prefs_to_load = ReconstructPrefsFromInstalledExtensions();
-+    LOG(INFO) << "browseros: Reconstructed prefs for "
-+              << prefs_to_load.size() << " installed extensions";
++    LOG(INFO) << "browseros: Reconstructed prefs for " << prefs_to_load.size()
++              << " installed extensions";
 +  }
 +
 +  LoadFinished(std::move(prefs_to_load));
@@ -118,7 +117,7 @@ index 0000000000000..70ad8710a39b7
 +          ? kBrowserOSAlphaUpdateUrl
 +          : kBrowserOSUpdateUrl;
 +
-+  for (const std::string& id : GetBrowserOSExtensionIds()) {
++  for (const std::string& id : GetActiveBrowserOSExtensionIds()) {
 +    const extensions::Extension* ext = registry->GetInstalledExtension(id);
 +    if (!ext) {
 +      continue;
@@ -129,8 +128,8 @@ index 0000000000000..70ad8710a39b7
 +                 update_url);
 +    prefs.Set(id, std::move(ext_pref));
 +
-+    LOG(INFO) << "browseros: Reconstructed pref for installed extension "
-+              << id << " v" << ext->version().GetString();
++    LOG(INFO) << "browseros: Reconstructed pref for installed extension " << id
++              << " v" << ext->version().GetString();
 +  }
 +
 +  return prefs;
@@ -147,9 +146,8 @@ index 0000000000000..70ad8710a39b7
 +  if (from_bundled) {
 +    base::SingleThreadTaskRunner::GetCurrentDefault()->PostDelayedTask(
 +        FROM_HERE,
-+        base::BindOnce(
-+            &BrowserOSExtensionLoader::InstallBundledExtensionsNow,
-+            weak_ptr_factory_.GetWeakPtr()),
++        base::BindOnce(&BrowserOSExtensionLoader::InstallBundledExtensionsNow,
++                       weak_ptr_factory_.GetWeakPtr()),
 +        kImmediateInstallDelay);
 +  } else {
 +    base::SingleThreadTaskRunner::GetCurrentDefault()->PostDelayedTask(
@@ -213,7 +211,7 @@ index 0000000000000..70ad8710a39b7
 +  if (updater) {
 +    extensions::ExtensionUpdater::CheckParams params;
 +    params.ids = std::list<extensions::ExtensionId>(extension_ids_.begin(),
-+                                                     extension_ids_.end());
++                                                    extension_ids_.end());
 +    params.install_immediately = true;
 +    params.fetch_priority = extensions::DownloadFetchPriority::kForeground;
 +    updater->InstallPendingNow(std::move(params));
@@ -266,8 +264,8 @@ index 0000000000000..70ad8710a39b7
 +    installer->set_creation_flags(
 +        extensions::Extension::WAS_INSTALLED_BY_DEFAULT);
 +
-+    extensions::CRXFileInfo file_info(
-+        crx_path, extensions::GetExternalVerifierFormat());
++    extensions::CRXFileInfo file_info(crx_path,
++                                      extensions::GetExternalVerifierFormat());
 +    installer->InstallCrxFile(file_info);
 +  }
 +}

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_maintainer.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_maintainer.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/extensions/browseros_extension_maintainer.cc b/chrome/browser/browseros/extensions/browseros_extension_maintainer.cc
 new file mode 100644
-index 0000000000000..5804d54696e8f
+index 0000000000000..568aba57b6197
 --- /dev/null
 +++ b/chrome/browser/browseros/extensions/browseros_extension_maintainer.cc
-@@ -0,0 +1,395 @@
+@@ -0,0 +1,440 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -72,7 +72,12 @@ index 0000000000000..5804d54696e8f
 +                                         std::set<std::string> extension_ids,
 +                                         base::DictValue initial_config) {
 +  config_url_ = config_url;
-+  extension_ids_ = std::move(extension_ids);
++  extension_ids_.clear();
++  for (const std::string& id : extension_ids) {
++    if (IsActiveBrowserOSExtension(id)) {
++      extension_ids_.insert(id);
++    }
++  }
 +  last_config_ = std::move(initial_config);
 +
 +  LOG(INFO) << "browseros: Maintainer started, " << extension_ids_.size()
@@ -88,7 +93,12 @@ index 0000000000000..5804d54696e8f
 +
 +void BrowserOSExtensionMaintainer::UpdateExtensionIds(
 +    std::set<std::string> ids) {
-+  extension_ids_ = std::move(ids);
++  extension_ids_.clear();
++  for (const std::string& id : ids) {
++    if (IsActiveBrowserOSExtension(id)) {
++      extension_ids_.insert(id);
++    }
++  }
 +}
 +
 +void BrowserOSExtensionMaintainer::RunMaintenanceCycle() {
@@ -132,7 +142,9 @@ index 0000000000000..5804d54696e8f
 +      last_config_ = std::move(config);
 +
 +      for (const auto [id, _] : last_config_) {
-+        extension_ids_.insert(id);
++        if (IsActiveBrowserOSExtension(id)) {
++          extension_ids_.insert(id);
++        }
 +      }
 +
 +      LOG(INFO) << "browseros: Updated config with " << last_config_.size()
@@ -158,8 +170,7 @@ index 0000000000000..5804d54696e8f
 +    return base::DictValue();
 +  }
 +
-+  const base::DictValue* extensions =
-+      parsed->GetDict().FindDict("extensions");
++  const base::DictValue* extensions = parsed->GetDict().FindDict("extensions");
 +
 +  if (!extensions) {
 +    LOG(ERROR) << "browseros: No 'extensions' key in config";
@@ -172,6 +183,7 @@ index 0000000000000..5804d54696e8f
 +void BrowserOSExtensionMaintainer::ExecuteMaintenanceTasks() {
 +  LOG(INFO) << "browseros: Executing maintenance tasks";
 +
++  UninstallInactiveProductExtensions();
 +  UninstallDeprecatedExtensions();
 +  ReinstallMissingExtensions();
 +  ReenableDisabledExtensions();
@@ -185,6 +197,41 @@ index 0000000000000..5804d54696e8f
 +      base::BindOnce(&BrowserOSExtensionMaintainer::RunMaintenanceCycle,
 +                     weak_ptr_factory_.GetWeakPtr()),
 +      kMaintenanceInterval);
++}
++
++void BrowserOSExtensionMaintainer::UninstallInactiveProductExtensions() {
++  if (!profile_) {
++    return;
++  }
++
++  extensions::ExtensionRegistry* registry =
++      extensions::ExtensionRegistry::Get(profile_);
++  extensions::ExtensionRegistrar* registrar =
++      extensions::ExtensionRegistrar::Get(profile_);
++
++  if (!registry || !registrar) {
++    return;
++  }
++
++  for (const std::string& id : GetAllBrowserOSExtensionIds()) {
++    if (IsActiveBrowserOSExtension(id)) {
++      continue;
++    }
++
++    const extensions::Extension* ext = registry->GetInstalledExtension(id);
++    if (!ext) {
++      continue;
++    }
++
++    LOG(INFO) << "browseros: Uninstalling inactive product extension " << id;
++
++    std::u16string error;
++    if (!registrar->UninstallExtension(
++            id, extensions::UNINSTALL_REASON_ORPHANED_EXTERNAL_EXTENSION,
++            &error)) {
++      LOG(WARNING) << "browseros: Failed to uninstall " << id << ": " << error;
++    }
++  }
 +}
 +
 +void BrowserOSExtensionMaintainer::UninstallDeprecatedExtensions() {
@@ -206,7 +253,7 @@ index 0000000000000..5804d54696e8f
 +    server_ids.insert(id);
 +  }
 +
-+  for (const std::string& id : GetBrowserOSExtensionIds()) {
++  for (const std::string& id : GetActiveBrowserOSExtensionIds()) {
 +    if (server_ids.contains(id)) {
 +      continue;
 +    }
@@ -275,8 +322,7 @@ index 0000000000000..5804d54696e8f
 +      extensions::ExtensionUpdater::CheckParams params;
 +      params.ids = {id};
 +      params.install_immediately = true;
-+      params.fetch_priority =
-+          extensions::DownloadFetchPriority::kForeground;
++      params.fetch_priority = extensions::DownloadFetchPriority::kForeground;
 +      // Use InstallPendingNow - the extension is in PendingExtensionManager,
 +      // CheckNow with specific IDs only checks installed extensions.
 +      updater->InstallPendingNow(std::move(params));
@@ -321,15 +367,15 @@ index 0000000000000..5804d54696e8f
 +    return;
 +  }
 +
-+  LOG(INFO) << "browseros: Force update check for "
-+            << extension_ids_.size() << " extensions";
++  LOG(INFO) << "browseros: Force update check for " << extension_ids_.size()
++            << " extensions";
 +
 +  for (const std::string& id : extension_ids_) {
 +    const extensions::Extension* ext =
 +        registry ? registry->GetInstalledExtension(id) : nullptr;
 +    if (ext) {
-+      LOG(INFO) << "browseros: ext=" << id
-+                << " v" << ext->version().GetString();
++      LOG(INFO) << "browseros: ext=" << id << " v"
++                << ext->version().GetString();
 +    } else {
 +      LOG(INFO) << "browseros: ext=" << id << " not installed";
 +    }
@@ -337,7 +383,7 @@ index 0000000000000..5804d54696e8f
 +
 +  extensions::ExtensionUpdater::CheckParams params;
 +  params.ids = std::list<extensions::ExtensionId>(extension_ids_.begin(),
-+                                                   extension_ids_.end());
++                                                  extension_ids_.end());
 +  params.install_immediately = true;
 +  params.fetch_priority = extensions::DownloadFetchPriority::kForeground;
 +  updater->CheckNow(std::move(params));
@@ -351,8 +397,7 @@ index 0000000000000..5804d54696e8f
 +
 +  extensions::ExtensionRegistry* registry =
 +      extensions::ExtensionRegistry::Get(profile_);
-+  extensions::ExtensionPrefs* prefs =
-+      extensions::ExtensionPrefs::Get(profile_);
++  extensions::ExtensionPrefs* prefs = extensions::ExtensionPrefs::Get(profile_);
 +
 +  if (!registry || !prefs) {
 +    return;

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_maintainer.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_maintainer.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/extensions/browseros_extension_maintainer.h b/chrome/browser/browseros/extensions/browseros_extension_maintainer.h
 new file mode 100644
-index 0000000000000..7102e07ad867b
+index 0000000000000..c70cbd4076100
 --- /dev/null
 +++ b/chrome/browser/browseros/extensions/browseros_extension_maintainer.h
-@@ -0,0 +1,84 @@
+@@ -0,0 +1,69 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -31,9 +31,6 @@ index 0000000000000..7102e07ad867b
 +
 +namespace browseros {
 +
-+// Handles periodic maintenance of BrowserOS extensions.
-+// Tasks: uninstall deprecated, reinstall missing, re-enable disabled,
-+// force update check, log health metrics.
 +class BrowserOSExtensionMaintainer {
 + public:
 +  explicit BrowserOSExtensionMaintainer(Profile* profile);
@@ -43,32 +40,20 @@ index 0000000000000..7102e07ad867b
 +  BrowserOSExtensionMaintainer& operator=(const BrowserOSExtensionMaintainer&) =
 +      delete;
 +
-+  // Starts maintenance with an initial delay.
 +  void Start(const GURL& config_url,
 +             std::set<std::string> extension_ids,
 +             base::DictValue initial_config);
 +
-+  // Updates the set of tracked extension IDs.
 +  void UpdateExtensionIds(std::set<std::string> ids);
 +
 + private:
-+  // Fetches remote config and runs maintenance.
 +  void RunMaintenanceCycle();
-+
-+  // Called when config fetch completes.
 +  void OnConfigFetched(std::unique_ptr<network::SimpleURLLoader> loader,
 +                       std::optional<std::string> response_body);
-+
-+  // Parses config JSON and returns extensions dict.
 +  base::DictValue ParseConfigJson(const std::string& json_content);
-+
-+  // Executes all maintenance tasks.
 +  void ExecuteMaintenanceTasks();
-+
-+  // Schedules next maintenance cycle.
 +  void ScheduleNextMaintenance();
-+
-+  // Individual maintenance tasks
++  void UninstallInactiveProductExtensions();
 +  void UninstallDeprecatedExtensions();
 +  void ReinstallMissingExtensions();
 +  void ReenableDisabledExtensions();

--- a/packages/browseros/chromium_patches/chrome/browser/chrome_content_browser_client.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/chrome_content_browser_client.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/chrome_content_browser_client.cc b/chrome/browser/chrome_content_browser_client.cc
-index f823433796c5c..4ec24d90dfc02 100644
+index f823433796c5c..1bc6610d0626e 100644
 --- a/chrome/browser/chrome_content_browser_client.cc
 +++ b/chrome/browser/chrome_content_browser_client.cc
 @@ -623,6 +623,7 @@
@@ -19,12 +19,28 @@ index f823433796c5c..4ec24d90dfc02 100644
    // Register user prefs for mapping SitePerProcess and IsolateOrigins in
    // user policy in addition to the same named ones in Local State (which are
    // used for mapping the command-line flags).
-@@ -5052,6 +5053,43 @@ bool ChromeContentBrowserClient::
+@@ -4479,10 +4480,10 @@ bool ChromeContentBrowserClient::CanCreateWindow(
+         web_contents->GetResponsibleWebContents();
+     bool is_from_embedded_page = web_contents != responsible_web_contents;
+     if (contextual_tasks_ui_service &&
+-        contextual_tasks_ui_service->HandleNavigation(
+-            std::move(url_params), responsible_web_contents,
+-            is_from_embedded_page,
+-            /*is_to_new_tab=*/true)) {
++        contextual_tasks_ui_service->HandleNavigation(std::move(url_params),
++                                                      responsible_web_contents,
++                                                      is_from_embedded_page,
++                                                      /*is_to_new_tab=*/true)) {
+       return false;
+     }
+   }
+@@ -5052,6 +5053,44 @@ bool ChromeContentBrowserClient::
               prefs.root_scrollbar_theme_color;
  }
  
 +// Handles chrome://browseros/* URLs by rewriting to extension URLs.
-+// Forward handler: chrome://browseros/ai -> chrome-extension://[id]/options.html
++// Forward handler: chrome://browseros/ai ->
++// chrome-extension://[id]/options.html
 +static bool HandleBrowserOSURL(GURL* url,
 +                               content::BrowserContext* browser_context) {
 +  if (!url->SchemeIs(content::kChromeUIScheme) ||
@@ -32,8 +48,7 @@ index f823433796c5c..4ec24d90dfc02 100644
 +    return false;
 +  }
 +
-+  std::string extension_url =
-+      browseros::GetBrowserOSExtensionURL(url->path());
++  std::string extension_url = browseros::GetBrowserOSExtensionURL(url->path());
 +  if (extension_url.empty()) {
 +    return false;
 +  }
@@ -42,16 +57,17 @@ index f823433796c5c..4ec24d90dfc02 100644
 +  return true;
 +}
 +
-+// Reverse handler: chrome-extension://[id]/options.html#ai -> chrome://browseros/ai
-+// This ensures the virtual URL is shown in the address bar.
++// Reverse handler: chrome-extension://[id]/options.html#ai ->
++// chrome://browseros/ai This ensures the virtual URL is shown in the address
++// bar.
 +static bool ReverseBrowserOSURL(GURL* url,
 +                                content::BrowserContext* browser_context) {
 +  if (!url->SchemeIs(extensions::kExtensionScheme)) {
 +    return false;
 +  }
 +
-+  std::string virtual_url = browseros::GetBrowserOSVirtualURL(
-+      url->host(), url->path(), url->ref());
++  std::string virtual_url =
++      browseros::GetBrowserOSVirtualURL(url->host(), url->path(), url->ref());
 +  if (virtual_url.empty()) {
 +    return false;
 +  }
@@ -63,7 +79,7 @@ index f823433796c5c..4ec24d90dfc02 100644
  void ChromeContentBrowserClient::BrowserURLHandlerCreated(
      BrowserURLHandler* handler) {
    // The group policy NTP URL handler must be registered before the other NTP
-@@ -5068,6 +5106,13 @@ void ChromeContentBrowserClient::BrowserURLHandlerCreated(
+@@ -5068,6 +5107,13 @@ void ChromeContentBrowserClient::BrowserURLHandlerCreated(
    handler->AddHandlerPair(&HandleChromeAboutAndChromeSyncRewrite,
                            BrowserURLHandler::null_handler());
  
@@ -77,7 +93,7 @@ index f823433796c5c..4ec24d90dfc02 100644
  #if BUILDFLAG(IS_ANDROID)
    // Handler to rewrite chrome://newtab on Android.
    handler->AddHandlerPair(&chrome::android::HandleAndroidNativePageURL,
-@@ -7901,6 +7946,15 @@ content::ContentBrowserClient::LocalNetworkAccessRequestPolicyOverride
+@@ -7901,6 +7947,15 @@ content::ContentBrowserClient::LocalNetworkAccessRequestPolicyOverride
  ChromeContentBrowserClient::ShouldOverrideLocalNetworkAccessRequestPolicy(
      content::BrowserContext* browser_context,
      const url::Origin& origin) {
@@ -85,7 +101,7 @@ index f823433796c5c..4ec24d90dfc02 100644
 +  // Allow BrowserOS extensions to access private networks (e.g., localhost).
 +  // This enables extension service workers to connect to local servers.
 +  if (origin.scheme() == extensions::kExtensionScheme &&
-+      browseros::IsBrowserOSExtension(origin.host())) {
++      browseros::IsActiveBrowserOSExtension(origin.host())) {
 +    return LocalNetworkAccessRequestPolicyOverride::kForceAllow;
 +  }
 +#endif

--- a/packages/browseros/chromium_patches/chrome/browser/extensions/chrome_extension_registrar_delegate.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/extensions/chrome_extension_registrar_delegate.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/extensions/chrome_extension_registrar_delegate.cc b/chrome/browser/extensions/chrome_extension_registrar_delegate.cc
-index 7d18f147508d6..3dd559e1c3877 100644
+index 7d18f147508d6..26ae243f550f4 100644
 --- a/chrome/browser/extensions/chrome_extension_registrar_delegate.cc
 +++ b/chrome/browser/extensions/chrome_extension_registrar_delegate.cc
 @@ -12,6 +12,7 @@
@@ -18,7 +18,7 @@ index 7d18f147508d6..3dd559e1c3877 100644
 +  // Preserve chrome.storage.local data for BrowserOS extensions. These may be
 +  // transiently uninstalled during update cycles (e.g., when both bundled CRX
 +  // and remote config fail on startup). User configuration must survive.
-+  if (browseros::IsBrowserOSExtension(extension->id())) {
++  if (browseros::IsKnownBrowserOSExtension(extension->id())) {
 +    LOG(INFO) << "browseros: Preserving storage for extension "
 +              << extension->id();
 +    subtask_done_callback.Run();
@@ -34,7 +34,7 @@ index 7d18f147508d6..3dd559e1c3877 100644
    }
  
 +  // - BrowserOS extensions cannot be disabled by users
-+  if (browseros::IsBrowserOSExtension(extension->id())) {
++  if (browseros::IsActiveBrowserOSExtension(extension->id())) {
 +    LOG(INFO) << "browseros: Extension " << extension->id()
 +              << " cannot be disabled (BrowserOS extension)";
 +    return false;

--- a/packages/browseros/chromium_patches/chrome/browser/extensions/extension_context_menu_model.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/extensions/extension_context_menu_model.cc
@@ -1,22 +1,133 @@
 diff --git a/chrome/browser/extensions/extension_context_menu_model.cc b/chrome/browser/extensions/extension_context_menu_model.cc
-index 1e3ccdabbab2a..ff720a438bbbf 100644
+index 1e3ccdabbab2a..e2e9be67b6fc4 100644
 --- a/chrome/browser/extensions/extension_context_menu_model.cc
 +++ b/chrome/browser/extensions/extension_context_menu_model.cc
-@@ -6,6 +6,7 @@
- 
- #include <memory>
- 
+@@ -15,6 +15,7 @@
+ #include "base/notreached.h"
+ #include "base/strings/utf_string_conversions.h"
+ #include "base/types/pass_key.h"
 +#include "chrome/browser/browseros/core/browseros_constants.h"
- #include "base/feature_list.h"
- #include "base/functional/bind.h"
- #include "base/metrics/histogram_macros.h"
-@@ -829,7 +830,8 @@ void ExtensionContextMenuModel::InitMenuWithFeature(
+ #include "chrome/browser/extensions/context_menu_matcher.h"
+ #include "chrome/browser/extensions/extension_management.h"
+ #include "chrome/browser/extensions/extension_tab_util.h"
+@@ -92,13 +93,15 @@ namespace {
+ // Returns true if the given |item| is of the given |type|.
+ bool MenuItemMatchesAction(const std::optional<ActionInfo::Type> action_type,
+                            const MenuItem* item) {
+-  if (!action_type)
++  if (!action_type) {
+     return false;
++  }
+ 
+   const MenuItem::ContextList& contexts = item->contexts();
+ 
+-  if (contexts.Contains(MenuItem::ALL))
++  if (contexts.Contains(MenuItem::ALL)) {
+     return true;
++  }
+   if (contexts.Contains(MenuItem::PAGE_ACTION) &&
+       (*action_type == ActionInfo::Type::kPage)) {
+     return true;
+@@ -390,11 +393,13 @@ void ExtensionContextMenuModel::Init(const Extension* extension,
+ 
+ bool ExtensionContextMenuModel::IsCommandIdChecked(int command_id) const {
+   const Extension* extension = GetExtension();
+-  if (!extension)
++  if (!extension) {
+     return false;
++  }
+ 
+-  if (ContextMenuMatcher::IsExtensionsCustomCommandId(command_id))
++  if (ContextMenuMatcher::IsExtensionsCustomCommandId(command_id)) {
+     return extension_items_->IsCommandIdChecked(command_id);
++  }
+ 
+   if (command_id == PAGE_ACCESS_RUN_ON_CLICK ||
+       command_id == PAGE_ACCESS_RUN_ON_SITE ||
+@@ -410,11 +415,13 @@ bool ExtensionContextMenuModel::IsCommandIdChecked(int command_id) const {
+ 
+ bool ExtensionContextMenuModel::IsCommandIdVisible(int command_id) const {
+   const Extension* extension = GetExtension();
+-  if (!extension)
++  if (!extension) {
+     return false;
++  }
+ 
+-  if (ContextMenuMatcher::IsExtensionsCustomCommandId(command_id))
++  if (ContextMenuMatcher::IsExtensionsCustomCommandId(command_id)) {
+     return extension_items_->IsCommandIdVisible(command_id);
++  }
+ 
+   // Items added by Chrome to the menu are always visible.
+   return true;
+@@ -422,11 +429,13 @@ bool ExtensionContextMenuModel::IsCommandIdVisible(int command_id) const {
+ 
+ bool ExtensionContextMenuModel::IsCommandIdEnabled(int command_id) const {
+   const Extension* extension = GetExtension();
+-  if (!extension)
++  if (!extension) {
+     return false;
++  }
+ 
+-  if (ContextMenuMatcher::IsExtensionsCustomCommandId(command_id))
++  if (ContextMenuMatcher::IsExtensionsCustomCommandId(command_id)) {
+     return extension_items_->IsCommandIdEnabled(command_id);
++  }
+ 
+   switch (command_id) {
+     case HOME_PAGE:
+@@ -502,8 +511,9 @@ void ExtensionContextMenuModel::RecordUkmForExtension(
+ void ExtensionContextMenuModel::ExecuteCommand(int command_id,
+                                                int event_flags) {
+   const Extension* extension = GetExtension();
+-  if (!extension)
++  if (!extension) {
+     return;
++  }
+ 
+   if (ContextMenuMatcher::IsExtensionsCustomCommandId(command_id)) {
+     DCHECK(extension_items_);
+@@ -829,7 +839,9 @@ void ExtensionContextMenuModel::InitMenuWithFeature(
  
    // Controls section.
    bool has_options_page = OptionsPageInfo::HasOptionsPage(extension);
 -  bool can_uninstall_extension = !is_component_ && !is_required_by_policy;
-+  bool can_uninstall_extension = !is_component_ && !is_required_by_policy &&
-+                                  !browseros::IsBrowserOSExtension(extension->id());
++  bool can_uninstall_extension =
++      !is_component_ && !is_required_by_policy &&
++      !browseros::IsActiveBrowserOSExtension(extension->id());
    if (can_show_icon_in_toolbar || has_options_page || can_uninstall_extension) {
      AddSeparator(ui::NORMAL_SEPARATOR);
    }
+@@ -893,8 +905,9 @@ void ExtensionContextMenuModel::InitMenu(const Extension* extension,
+   std::optional<ActionInfo::Type> action_type;
+   extension_action_ =
+       ExtensionActionManager::Get(profile_)->GetExtensionAction(*extension);
+-  if (extension_action_)
++  if (extension_action_) {
+     action_type = extension_action_->action_type();
++  }
+ 
+   extension_items_ = std::make_unique<ContextMenuMatcher>(
+       profile_, this, this,
+@@ -919,8 +932,9 @@ void ExtensionContextMenuModel::InitMenu(const Extension* extension,
+     AddSeparator(ui::NORMAL_SEPARATOR);
+   }
+ 
+-  if (OptionsPageInfo::HasOptionsPage(extension))
++  if (OptionsPageInfo::HasOptionsPage(extension)) {
+     AddItemWithStringId(OPTIONS, IDS_EXTENSIONS_OPTIONS_MENU_ITEM);
++  }
+ 
+   if (!is_component_) {
+     if (IsExtensionRequiredByPolicy(extension, profile_)) {
+@@ -1005,8 +1019,9 @@ const Extension* ExtensionContextMenuModel::GetExtension() const {
+ void ExtensionContextMenuModel::AppendExtensionItems() {
+   MenuManager* menu_manager = MenuManager::Get(profile_);
+   if (!menu_manager ||  // Null in unit tests
+-      !menu_manager->MenuItems(MenuItem::ExtensionKey(extension_id_)))
++      !menu_manager->MenuItems(MenuItem::ExtensionKey(extension_id_))) {
+     return;
++  }
+ 
+   AddSeparator(ui::NORMAL_SEPARATOR);
+ 

--- a/packages/browseros/chromium_patches/chrome/browser/extensions/extension_management.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/extensions/extension_management.cc
@@ -1,18 +1,44 @@
 diff --git a/chrome/browser/extensions/extension_management.cc b/chrome/browser/extensions/extension_management.cc
-index bea1864156f76..1cd240b1027a1 100644
+index bea1864156f76..cad92ebeb592f 100644
 --- a/chrome/browser/extensions/extension_management.cc
 +++ b/chrome/browser/extensions/extension_management.cc
-@@ -25,6 +25,9 @@
+@@ -25,6 +25,8 @@
  #include "base/values.h"
  #include "base/version.h"
  #include "build/chromeos_buildflags.h"
 +#include "chrome/browser/browser_features.h"
 +#include "chrome/browser/browseros/core/browseros_constants.h"
-+#include "chrome/browser/browseros/core/browseros_prefs.h"
  #include "chrome/browser/enterprise/util/managed_browser_utils.h"
  #include "chrome/browser/extensions/cws_info_service_factory.h"
  #include "chrome/browser/extensions/extension_management_constants.h"
-@@ -272,6 +275,15 @@ bool ExtensionManagement::IsUpdateUrlOverridden(const ExtensionId& id) {
+@@ -186,7 +188,7 @@ bool ExtensionManagement::ExtensionsEnabledForDesktopAndroid() const {
+     std::string domain = gaia::ExtractDomainName(user_name);
+     if (domain == "google.com" || domain == "managedchrome.com") {
+       return base::FeatureList::IsEnabled(
+-              extensions_features::kEnableExtensionsForCorpDesktopAndroid);
++          extensions_features::kEnableExtensionsForCorpDesktopAndroid);
+     }
+   }
+   return true;
+@@ -208,13 +210,15 @@ ManagedInstallationMode ExtensionManagement::GetInstallationMode(
+ 
+   // Check per-extension installation mode setting first.
+   auto* setting = GetSettingsForId(extension_id);
+-  if (setting)
++  if (setting) {
+     return setting->installation_mode;
++  }
+   // Check per-update-url installation mode setting.
+   if (!update_url.empty()) {
+     auto iter_update_url = settings_by_update_url_.find(update_url);
+-    if (iter_update_url != settings_by_update_url_.end())
++    if (iter_update_url != settings_by_update_url_.end()) {
+       return iter_update_url->second->installation_mode;
++    }
+   }
+   // Fall back to default installation mode setting.
+   return default_settings_->installation_mode;
+@@ -272,6 +276,15 @@ bool ExtensionManagement::IsUpdateUrlOverridden(const ExtensionId& id) {
  }
  
  GURL ExtensionManagement::GetEffectiveUpdateURL(const Extension& extension) {
@@ -20,7 +46,7 @@ index bea1864156f76..1cd240b1027a1 100644
 +  // the alpha channel. Must live here (not in the extension's manifest.json
 +  // update_url) so a mid-session channel flip takes effect on the next update
 +  // check, without uninstalling the extension.
-+  if (browseros::IsBrowserOSExtension(extension.id()) &&
++  if (browseros::IsActiveBrowserOSExtension(extension.id()) &&
 +      base::FeatureList::IsEnabled(features::kBrowserOsAlphaFeatures)) {
 +    return GURL(browseros::kBrowserOSAlphaUpdateUrl);
 +  }
@@ -28,14 +54,129 @@ index bea1864156f76..1cd240b1027a1 100644
    if (IsUpdateUrlOverridden(extension.id())) {
      DCHECK(!extension.was_installed_by_default())
          << "Update URL should not be overridden for default-installed "
-@@ -664,6 +676,14 @@ ExtensionIdSet ExtensionManagement::GetForcePinnedList() const {
+@@ -320,8 +333,9 @@ bool ExtensionManagement::IsInstallationExplicitlyBlocked(
+     const ExtensionId& id) {
+   auto* setting = GetSettingsForId(id);
+   // No settings explicitly specified for |id|.
+-  if (setting == nullptr)
++  if (setting == nullptr) {
+     return false;
++  }
+   // Checks if the extension is listed as blocked or removed.
+   ManagedInstallationMode mode = setting->installation_mode;
+   return mode == ManagedInstallationMode::kBlocked ||
+@@ -332,13 +346,15 @@ bool ExtensionManagement::IsOffstoreInstallAllowed(
+     const GURL& url,
+     const GURL& referrer_url) const {
+   // No allowed install sites specified, disallow by default.
+-  if (!global_settings_->install_sources.has_value())
++  if (!global_settings_->install_sources.has_value()) {
+     return false;
++  }
+ 
+   const URLPatternSet& url_patterns = *global_settings_->install_sources;
+ 
+-  if (!url_patterns.MatchesURL(url))
++  if (!url_patterns.MatchesURL(url)) {
+     return false;
++  }
+ 
+   // The referrer URL must also be allowlisted, unless the URL has the file
+   // scheme (there's no referrer for those URLs).
+@@ -352,12 +368,14 @@ bool ExtensionManagement::IsAllowedManifestType(
+   // If a managed theme has been set for the current profile, theme extension
+   // installations are not allowed.
+   if (manifest_type == Manifest::Type::TYPE_THEME &&
+-      ThemeServiceFactory::GetForProfile(profile_)->UsingPolicyTheme())
++      ThemeServiceFactory::GetForProfile(profile_)->UsingPolicyTheme()) {
+     return false;
++  }
+ #endif  // BUILDFLAG(ENABLE_EXTENSIONS)
+ 
+-  if (!global_settings_->allowed_types.has_value())
++  if (!global_settings_->allowed_types.has_value()) {
+     return true;
++  }
+   const std::vector<Manifest::Type>& allowed_types =
+       *global_settings_->allowed_types;
+   return std::ranges::contains(allowed_types, manifest_type);
+@@ -571,8 +589,9 @@ APIPermissionSet ExtensionManagement::GetBlockedAPIPermissions(
+ 
+   // Fetch per-update-url blocked permissions setting.
+   auto iter_update_url = settings_by_update_url_.end();
+-  if (!update_url.empty())
++  if (!update_url.empty()) {
+     iter_update_url = settings_by_update_url_.find(update_url);
++  }
+ 
+   if (setting && iter_update_url != settings_by_update_url_.end()) {
+     // Blocked permissions setting are specified in both per-extension and
+@@ -584,10 +603,12 @@ APIPermissionSet ExtensionManagement::GetBlockedAPIPermissions(
+     return merged;
+   }
+   // Check whether if in one of them, setting is specified.
+-  if (setting)
++  if (setting) {
+     return setting->blocked_permissions.Clone();
+-  if (iter_update_url != settings_by_update_url_.end())
++  }
++  if (iter_update_url != settings_by_update_url_.end()) {
+     return iter_update_url->second->blocked_permissions.Clone();
++  }
+   // Fall back to the default blocked permissions setting.
+   return default_settings_->blocked_permissions.Clone();
+ }
+@@ -603,16 +624,18 @@ const URLPatternSet& ExtensionManagement::GetDefaultPolicyAllowedHosts() const {
+ const URLPatternSet& ExtensionManagement::GetPolicyBlockedHosts(
+     const Extension* extension) {
+   auto* setting = GetSettingsForId(extension->id());
+-  if (setting)
++  if (setting) {
+     return setting->policy_blocked_hosts;
++  }
+   return default_settings_->policy_blocked_hosts;
+ }
+ 
+ const URLPatternSet& ExtensionManagement::GetPolicyAllowedHosts(
+     const Extension* extension) {
+   auto* setting = GetSettingsForId(extension->id());
+-  if (setting)
++  if (setting) {
+     return setting->policy_allowed_hosts;
++  }
+   return default_settings_->policy_allowed_hosts;
+ }
+ 
+@@ -643,8 +666,9 @@ bool ExtensionManagement::IsPermissionSetAllowed(
+     const PermissionSet& perms) {
+   for (const APIPermission* blocked_api :
+        GetBlockedAPIPermissions(extension_id, update_url)) {
+-    if (perms.HasAPIPermission(blocked_api->id()))
++    if (perms.HasAPIPermission(blocked_api->id())) {
+       return false;
++    }
+   }
+   return true;
+ }
+@@ -652,8 +676,9 @@ bool ExtensionManagement::IsPermissionSetAllowed(
+ const std::string ExtensionManagement::BlockedInstallMessage(
+     const ExtensionId& id) {
+   auto* setting = GetSettingsForId(id);
+-  if (setting)
++  if (setting) {
+     return setting->blocked_install_message;
++  }
+   return default_settings_->blocked_install_message;
+ }
+ 
+@@ -664,6 +689,14 @@ ExtensionIdSet ExtensionManagement::GetForcePinnedList() const {
        force_pinned_list.insert(entry.first);
      }
    }
 +
 +  // Always force-pin BrowserOS extensions that are marked pinned.
-+  for (const auto& extension_id : browseros::GetBrowserOSExtensionIds()) {
-+    if (browseros::ShouldPinBrowserOSExtension(extension_id, pref_service_)) {
++  for (const auto& extension_id : browseros::GetActiveBrowserOSExtensionIds()) {
++    if (browseros::IsBrowserOSPinnedExtension(extension_id)) {
 +      force_pinned_list.insert(extension_id);
 +    }
 +  }
@@ -43,3 +184,173 @@ index bea1864156f76..1cd240b1027a1 100644
    return force_pinned_list;
  }
  
+@@ -685,13 +718,15 @@ bool ExtensionManagement::CheckMinimumVersion(const Extension* extension,
+                                               std::string* required_version) {
+   auto* setting = GetSettingsForId(extension->id());
+   // If there are no minimum version required for |extension|, return true.
+-  if (!setting || !setting->minimum_version_required)
++  if (!setting || !setting->minimum_version_required) {
+     return true;
++  }
+   bool meets_requirement =
+       extension->version().CompareTo(*setting->minimum_version_required) >= 0;
+   // Output a human readable version string for prompting if necessary.
+-  if (!meets_requirement && required_version)
++  if (!meets_requirement && required_version) {
+     *required_version = setting->minimum_version_required->GetString();
++  }
+   return meets_requirement;
+ }
+ 
+@@ -747,28 +782,34 @@ void ExtensionManagement::Refresh() {
+     // Settings from new preference have higher priority over legacy ones.
+     const base::ListValue* list_value =
+         subdict->FindList(schema_constants::kInstallSources);
+-    if (list_value)
++    if (list_value) {
+       install_sources_pref = list_value;
++    }
+ 
+     list_value = subdict->FindList(schema_constants::kAllowedTypes);
+-    if (list_value)
++    if (list_value) {
+       allowed_types_pref = list_value;
++    }
+   }
+ 
+   // Parse legacy preferences.
+   if (allowed_list_pref) {
+     for (const auto& entry : *allowed_list_pref) {
+-      if (entry.is_string() && crx_file::id_util::IdIsValid(entry.GetString()))
++      if (entry.is_string() &&
++          crx_file::id_util::IdIsValid(entry.GetString())) {
+         AccessById(entry.GetString())->installation_mode =
+             ManagedInstallationMode::kAllowed;
++      }
+     }
+   }
+ 
+   if (denied_list_pref) {
+     for (const auto& entry : *denied_list_pref) {
+-      if (entry.is_string() && crx_file::id_util::IdIsValid(entry.GetString()))
++      if (entry.is_string() &&
++          crx_file::id_util::IdIsValid(entry.GetString())) {
+         AccessById(entry.GetString())->installation_mode =
+             ManagedInstallationMode::kBlocked;
++      }
+     }
+   }
+ 
+@@ -801,8 +842,9 @@ void ExtensionManagement::Refresh() {
+       } else if (entry.is_string()) {
+         Manifest::Type manifest_type =
+             schema_constants::GetManifestType(entry.GetString());
+-        if (manifest_type != Manifest::TYPE_UNKNOWN)
++        if (manifest_type != Manifest::TYPE_UNKNOWN) {
+           global_settings_->allowed_types->push_back(manifest_type);
++        }
+       }
+     }
+   }
+@@ -833,11 +875,13 @@ void ExtensionManagement::Refresh() {
+         std::move(installed_extension_ids));
+ 
+     for (auto iter : *dict_pref) {
+-      if (iter.first == schema_constants::kWildcard)
++      if (iter.first == schema_constants::kWildcard) {
+         continue;
++      }
+       const base::DictValue* subdict = iter.second.GetIfDict();
+-      if (!subdict)
++      if (!subdict) {
+         continue;
++      }
+       std::optional<std::string_view> remainder =
+           base::RemovePrefix(iter.first, schema_constants::kUpdateUrlPrefix);
+       if (remainder) {
+@@ -893,8 +937,9 @@ void ExtensionManagement::Refresh() {
+           internal::IndividualSettings* by_id = AccessById(extension_id);
+           const bool included_in_forcelist =
+               by_id->installation_mode == ManagedInstallationMode::kForced;
+-          if (!ParseById(extension_id, *subdict))
++          if (!ParseById(extension_id, *subdict)) {
+             continue;
++          }
+ 
+           // If applying the ExtensionSettings policy changes installation mode
+           // from force-installed to anything else, the extension might not get
+@@ -915,8 +960,9 @@ void ExtensionManagement::Refresh() {
+ bool ExtensionManagement::ParseById(const std::string& extension_id,
+                                     const base::DictValue& subdict) {
+   internal::IndividualSettings* by_id = AccessById(extension_id);
+-  if (by_id->Parse(subdict, internal::IndividualSettings::SCOPE_INDIVIDUAL))
++  if (by_id->Parse(subdict, internal::IndividualSettings::SCOPE_INDIVIDUAL)) {
+     return true;
++  }
+ 
+   settings_by_id_.erase(extension_id);
+   InstallStageTrackerFactory::GetForBrowserContext(profile_)->ReportFailure(
+@@ -935,8 +981,9 @@ internal::IndividualSettings* ExtensionManagement::GetSettingsForId(
+   }
+ 
+   auto iter_id = settings_by_id_.find(extension_id);
+-  if (iter_id == settings_by_id_.end())
++  if (iter_id == settings_by_id_.end()) {
+     return nullptr;
++  }
+ 
+   return iter_id->second.get();
+ }
+@@ -958,8 +1005,9 @@ void ExtensionManagement::LoadDeferredExtensionSetting(
+       continue;
+     }
+     const base::DictValue* subdict = iter.second.GetIfDict();
+-    if (!subdict)
++    if (!subdict) {
+       continue;
++    }
+ 
+     auto extension_ids = base::SplitStringPiece(
+         iter.first, ",", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+@@ -977,15 +1025,17 @@ const base::Value* ExtensionManagement::LoadPreference(
+     const char* pref_name,
+     bool force_managed,
+     base::Value::Type expected_type) const {
+-  if (!pref_service_)
++  if (!pref_service_) {
+     return nullptr;
++  }
+   const PrefService::Preference* pref =
+       pref_service_->FindPreference(pref_name);
+   if (pref && !pref->IsDefaultValue() &&
+       (!force_managed || pref->IsManaged())) {
+     const base::Value* value = pref->GetValue();
+-    if (value && value->type() == expected_type)
++    if (value && value->type() == expected_type) {
+       return value;
++    }
+   }
+   return nullptr;
+ }
+@@ -1016,8 +1066,9 @@ void ExtensionManagement::NotifyExtensionManagementPrefChanged() {
+       InstallStageTracker::InstallCreationStage::NOTIFIED_FROM_MANAGEMENT,
+       InstallStageTracker::InstallCreationStage::
+           NOTIFIED_FROM_MANAGEMENT_NOT_FORCED);
+-  for (auto& observer : observer_list_)
++  for (auto& observer : observer_list_) {
+     observer.OnExtensionManagementSettingsChanged();
++  }
+ }
+ 
+ void ExtensionManagement::ReportExtensionManagementInstallCreationStage(
+@@ -1055,8 +1106,9 @@ base::DictValue ExtensionManagement::GetInstallListByMode(
+ 
+ void ExtensionManagement::UpdateForcedExtensions(
+     const base::DictValue* extension_dict) {
+-  if (!extension_dict)
++  if (!extension_dict) {
+     return;
++  }
+ 
+   InstallStageTracker* install_stage_tracker =
+       InstallStageTrackerFactory::GetForBrowserContext(profile_);

--- a/packages/browseros/chromium_patches/chrome/browser/extensions/extension_url_overrides_registrar.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/extensions/extension_url_overrides_registrar.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/extensions/extension_url_overrides_registrar.cc b/chrome/browser/extensions/extension_url_overrides_registrar.cc
-index 7762e0c775c22..8a486c6dd7a66 100644
+index 7762e0c775c22..ede0065069244 100644
 --- a/chrome/browser/extensions/extension_url_overrides_registrar.cc
 +++ b/chrome/browser/extensions/extension_url_overrides_registrar.cc
 @@ -7,6 +7,7 @@
@@ -10,11 +10,12 @@ index 7762e0c775c22..8a486c6dd7a66 100644
  #include "chrome/browser/extensions/extension_url_overrides.h"
  #include "chrome/browser/profiles/profile.h"
  #include "extensions/browser/extension_system.h"
-@@ -34,6 +35,10 @@ void ExtensionUrlOverridesRegistrar::OnExtensionLoaded(
+@@ -34,6 +35,11 @@ void ExtensionUrlOverridesRegistrar::OnExtensionLoaded(
      const Extension* extension) {
    const URLOverrides::URLOverrideMap& overrides =
        URLOverrides::GetChromeURLOverrides(extension);
-+  if (!overrides.empty() && !browseros::IsBrowserOSExtension(extension->id())) {
++  if (!overrides.empty() &&
++      !browseros::IsActiveBrowserOSExtension(extension->id())) {
 +    return;
 +  }
 +

--- a/packages/browseros/chromium_patches/chrome/browser/media/extension_media_access_handler.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/media/extension_media_access_handler.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/media/extension_media_access_handler.cc b/chrome/browser/media/extension_media_access_handler.cc
-index 779440e0a1944..ad54815fcc4c2 100644
+index 779440e0a1944..8e87bb0f6fa12 100644
 --- a/chrome/browser/media/extension_media_access_handler.cc
 +++ b/chrome/browser/media/extension_media_access_handler.cc
 @@ -6,6 +6,7 @@
@@ -18,23 +18,21 @@ index 779440e0a1944..ad54815fcc4c2 100644
  // Once http://crbug.com/40333126 is fixed, remove this allowlist.
  bool IsMediaRequestAllowedForExtension(const extensions::Extension* extension) {
    return extension->id() == extension_misc::kKeyboardExtensionId ||
-@@ -37,7 +39,9 @@ bool IsMediaRequestAllowedForExtension(const extensions::Extension* extension) {
+@@ -37,7 +39,8 @@ bool IsMediaRequestAllowedForExtension(const extensions::Extension* extension) {
           extension->id() == "nbpagnldghgfoolbancepceaanlmhfmd" ||
           extension->id() == "jkghodnilhceideoidjikpgommlajknk" ||
           extension->id() == "gjaehgfemfahhmlgpdfknkhdnemmolop" ||
 -         extension->id() == "egfdjlfmgnehecnclamagfafdccgfndp";
 +         extension->id() == "egfdjlfmgnehecnclamagfafdccgfndp" ||
-+         // BrowserOS extensions
-+         browseros::IsBrowserOSExtension(extension->id());
++         browseros::IsActiveBrowserOSExtension(extension->id());
  }
  
  }  // namespace
-@@ -90,6 +94,12 @@ void ExtensionMediaAccessHandler::HandleRequest(
+@@ -90,6 +93,11 @@ void ExtensionMediaAccessHandler::HandleRequest(
        GetDevicePolicy(profile, extension->url(), prefs::kVideoCaptureAllowed,
                        prefs::kVideoCaptureAllowedUrls) != ALWAYS_DENY;
  
-+  // For BrowserOS extensions in sidepanel, allow audio for teach mode
-+  if (browseros::IsBrowserOSExtension(extension->id())) {
++  if (browseros::IsActiveBrowserOSExtension(extension->id())) {
 +    audio_allowed = request.audio_type ==
 +                    blink::mojom::MediaStreamType::DEVICE_AUDIO_CAPTURE;
 +  }

--- a/packages/browseros/chromium_patches/chrome/browser/ui/browser_actions.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/browser_actions.cc
@@ -1,31 +1,56 @@
 diff --git a/chrome/browser/ui/browser_actions.cc b/chrome/browser/ui/browser_actions.cc
-index 8a43e7c2fcde5..505e079c15c5f 100644
+index 8a43e7c2fcde5..2f9e4a7a80b4b 100644
 --- a/chrome/browser/ui/browser_actions.cc
 +++ b/chrome/browser/ui/browser_actions.cc
-@@ -17,6 +17,7 @@
- #include "base/metrics/user_metrics_action.h"
+@@ -18,13 +18,17 @@
  #include "build/branding_buildflags.h"
  #include "chrome/app/chrome_command_ids.h"
-+#include "chrome/grit/theme_resources.h"
  #include "chrome/app/vector_icons/vector_icons.h"
++#include "chrome/browser/browseros/core/browseros_constants.h"
  #include "chrome/browser/contextual_tasks/contextual_tasks_side_panel_coordinator.h"
  #include "chrome/browser/devtools/devtools_window.h"
-@@ -31,7 +32,14 @@
- #include "chrome/browser/sharing_hub/sharing_hub_features.h"
- #include "chrome/browser/ui/actions/chrome_action_id.h"
- #include "chrome/browser/ui/actions/chrome_actions.h"
-+#include "chrome/browser/browseros/core/browseros_constants.h"
 +#include "chrome/browser/extensions/api/side_panel/side_panel_service.h"
 +#include "chrome/browser/extensions/extension_tab_util.h"
+ #include "chrome/browser/glic/browser_ui/glic_vector_icon_manager.h"
+ #include "chrome/browser/glic/host/glic.mojom.h"
+ #include "chrome/browser/glic/public/glic_enabling.h"
+ #include "chrome/browser/glic/public/glic_keyed_service.h"
+ #include "chrome/browser/indigo/indigo_page_action_controller.h"
 +#include "chrome/browser/infobars/simple_alert_infobar_creator.h"
- #include "chrome/browser/ui/ai_overlay_dialog/ai_overlay_dialog_controller.h"
+ #include "chrome/browser/prefs/incognito_mode_prefs.h"
+ #include "chrome/browser/profiles/profile.h"
+ #include "chrome/browser/search_engines/template_url_service_factory.h"
+@@ -49,6 +53,7 @@
+ #include "chrome/browser/ui/browser_window/public/browser_window_interface.h"
+ #include "chrome/browser/ui/commerce/commerce_ui_tab_helper.h"
+ #include "chrome/browser/ui/customize_chrome/side_panel_controller.h"
 +#include "chrome/browser/ui/extensions/extension_side_panel_utils.h"
+ #include "chrome/browser/ui/intent_picker_tab_helper.h"
+ #include "chrome/browser/ui/lens/lens_overlay_controller.h"
+ #include "chrome/browser/ui/lens/lens_overlay_entry_point_controller.h"
+@@ -107,11 +112,13 @@
+ #include "chrome/common/record_replay/record_replay_features.h"
+ #include "chrome/grit/branded_strings.h"
+ #include "chrome/grit/generated_resources.h"
++#include "chrome/grit/theme_resources.h"
+ #include "components/collaboration/public/messaging/activity_log.h"
+ #include "components/commerce/core/metrics/discounts_metric_collector.h"
+ #include "components/content_settings/core/common/features.h"
+ #include "components/contextual_tasks/public/features.h"
+ #include "components/feature_engagement/public/feature_constants.h"
 +#include "components/infobars/content/content_infobar_manager.h"
+ #include "components/lens/lens_features.h"
+ #include "components/media_router/browser/media_router_dialog_controller.h"
+ #include "components/media_router/browser/media_router_metrics.h"
+@@ -125,6 +132,7 @@
+ #include "components/tabs/public/tab_interface.h"
+ #include "components/user_prefs/user_prefs.h"
+ #include "components/vector_icons/vector_icons.h"
 +#include "extensions/browser/extension_registry.h"
- #include "chrome/browser/ui/autofill/address_bubbles_icon_controller.h"
- #include "chrome/browser/ui/autofill/autofill_bubble_base.h"
- #include "chrome/browser/ui/autofill/payments/filled_card_information_bubble_controller_impl.h"
-@@ -310,6 +318,91 @@ void BrowserActions::InitializeSidePanelActions() {
+ #include "ui/accessibility/accessibility_features.h"
+ #include "ui/actions/actions.h"
+ #include "ui/base/l10n/l10n_util.h"
+@@ -310,6 +318,92 @@ void BrowserActions::InitializeSidePanelActions() {
              .Build());
    }
  
@@ -33,86 +58,87 @@ index 8a43e7c2fcde5..505e079c15c5f 100644
 +  if (base::FeatureList::IsEnabled(features::kThirdPartyLlmPanel)) {
 +    root_action_item_->AddChild(
 +        SidePanelAction(SidePanelEntryId::kThirdPartyLlm,
-+                        IDS_THIRD_PARTY_LLM_TITLE,
-+                        IDS_THIRD_PARTY_LLM_TITLE,
++                        IDS_THIRD_PARTY_LLM_TITLE, IDS_THIRD_PARTY_LLM_TITLE,
 +                        vector_icons::kChatOrangeIcon,
 +                        kActionSidePanelShowThirdPartyLlm, bwi, true)
 +            .Build());
 +  }
 +
-+  // BrowserOS Agent - toggles contextual side panel on active tab.
-+  // This is a native action that dynamically looks up the extension at
-+  // invocation time, avoiding stale WeakPtr issues during extension updates.
-+  root_action_item_->AddChild(
-+      actions::ActionItem::Builder(
-+          base::BindRepeating(
-+              [](BrowserWindowInterface* bwi, actions::ActionItem* item,
-+                 actions::ActionInvocationContext context) {
-+                auto* tab = bwi->GetActiveTabInterface();
-+                if (!tab || !tab->GetContents()) {
-+                  LOG(WARNING) << "browseros: No active tab for Agent action";
-+                  return;
-+                }
-+
-+                content::WebContents* contents = tab->GetContents();
-+                Profile* profile =
-+                    Profile::FromBrowserContext(contents->GetBrowserContext());
-+
-+                const extensions::Extension* extension =
-+                    extensions::ExtensionRegistry::Get(profile)
-+                        ->enabled_extensions()
-+                        .GetByID(browseros::kAgentExtensionId);
-+                if (!extension) {
-+                  LOG(WARNING) << "browseros: Agent extension not found";
-+                  infobars::ContentInfoBarManager* infobar_manager =
-+                      infobars::ContentInfoBarManager::FromWebContents(contents);
-+                  if (infobar_manager) {
-+                    CreateSimpleAlertInfoBar(
-+                        infobar_manager,
-+                        infobars::InfoBarDelegate::
-+                            BROWSEROS_AGENT_INSTALLING_INFOBAR_DELEGATE,
-+                        nullptr,
-+                        u"BrowserOS Agent is installing/updating. Please try again shortly.",
-+                        /*auto_expire=*/true,
-+                        /*should_animate=*/true,
-+                        /*closeable=*/true);
++  if (browseros::IsActiveBrowserOSExtension(browseros::kAgentExtensionId)) {
++    root_action_item_->AddChild(
++        actions::ActionItem::Builder(
++            base::BindRepeating(
++                [](BrowserWindowInterface* bwi, actions::ActionItem* item,
++                   actions::ActionInvocationContext context) {
++                  auto* tab = bwi->GetActiveTabInterface();
++                  if (!tab || !tab->GetContents()) {
++                    LOG(WARNING) << "browseros: No active tab for Agent action";
++                    return;
 +                  }
-+                  return;
-+                }
 +
-+                int tab_id = extensions::ExtensionTabUtil::GetTabId(contents);
-+                LOG(INFO) << "browseros: Agent toolbar action for tab_id="
-+                          << tab_id;
++                  content::WebContents* contents = tab->GetContents();
++                  Profile* profile = Profile::FromBrowserContext(
++                      contents->GetBrowserContext());
 +
-+                extensions::SidePanelService* service =
-+                    extensions::SidePanelService::Get(profile);
-+                if (!service) {
-+                  LOG(WARNING) << "browseros: SidePanelService not found";
-+                  return;
-+                }
++                  const extensions::Extension* extension =
++                      extensions::ExtensionRegistry::Get(profile)
++                          ->enabled_extensions()
++                          .GetByID(browseros::kAgentExtensionId);
++                  if (!extension) {
++                    LOG(WARNING) << "browseros: Agent extension not found";
++                    infobars::ContentInfoBarManager* infobar_manager =
++                        infobars::ContentInfoBarManager::FromWebContents(
++                            contents);
++                    if (infobar_manager) {
++                      CreateSimpleAlertInfoBar(
++                          infobar_manager,
++                          infobars::InfoBarDelegate::
++                              BROWSEROS_AGENT_INSTALLING_INFOBAR_DELEGATE,
++                          nullptr,
++                          u"BrowserOS Agent is installing/updating. Please try "
++                          u"again shortly.",
++                          /*auto_expire=*/true,
++                          /*should_animate=*/true,
++                          /*closeable=*/true);
++                    }
++                    return;
++                  }
 +
-+                auto result = service->BrowserosToggleSidePanelForTab(
-+                    *extension, profile, tab_id,
-+                    /*include_incognito_information=*/true,
-+                    /*desired_state=*/std::nullopt);
++                  int tab_id = extensions::ExtensionTabUtil::GetTabId(contents);
++                  LOG(INFO) << "browseros: Agent toolbar action for tab_id="
++                            << tab_id;
 +
-+                if (!result.has_value()) {
-+                  LOG(WARNING) << "browseros: Agent toggle failed: "
-+                               << result.error();
-+                } else {
-+                  LOG(INFO) << "browseros: Agent toggle result: "
-+                            << result.value();
-+                }
-+              },
-+              bwi))
-+          .SetActionId(kActionBrowserOSAgent)
-+          .SetText(u"Assistant")
-+          .SetTooltipText(u"Ask BrowserOS")
-+          .SetImage(ui::ImageModel::FromResourceId(IDR_PRODUCT_LOGO_16))
-+          .SetProperty(actions::kActionItemPinnableKey,
-+                       std::underlying_type_t<actions::ActionPinnableState>(
-+                           actions::ActionPinnableState::kEnterpriseControlled))
-+          .Build());
++                  extensions::SidePanelService* service =
++                      extensions::SidePanelService::Get(profile);
++                  if (!service) {
++                    LOG(WARNING) << "browseros: SidePanelService not found";
++                    return;
++                  }
++
++                  auto result = service->BrowserosToggleSidePanelForTab(
++                      *extension, profile, tab_id,
++                      /*include_incognito_information=*/true,
++                      /*desired_state=*/std::nullopt);
++
++                  if (!result.has_value()) {
++                    LOG(WARNING)
++                        << "browseros: Agent toggle failed: " << result.error();
++                  } else {
++                    LOG(INFO)
++                        << "browseros: Agent toggle result: " << result.value();
++                  }
++                },
++                bwi))
++            .SetActionId(kActionBrowserOSAgent)
++            .SetText(u"Assistant")
++            .SetTooltipText(u"Ask BrowserOS")
++            .SetImage(ui::ImageModel::FromResourceId(IDR_PRODUCT_LOGO_16))
++            .SetProperty(
++                actions::kActionItemPinnableKey,
++                std::underlying_type_t<actions::ActionPinnableState>(
++                    actions::ActionPinnableState::kEnterpriseControlled))
++            .Build());
++  }
 +
    if (HistorySidePanelCoordinator::IsSupported()) {
      root_action_item_->AddChild(

--- a/packages/browseros/chromium_patches/chrome/browser/ui/browser_command_controller.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/browser_command_controller.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/browser_command_controller.cc b/chrome/browser/ui/browser_command_controller.cc
-index 738696abf04fa..aa1a1a1ce6a85 100644
+index 738696abf04fa..ec170ce291d37 100644
 --- a/chrome/browser/ui/browser_command_controller.cc
 +++ b/chrome/browser/ui/browser_command_controller.cc
 @@ -7,7 +7,9 @@
@@ -12,12 +12,11 @@ index 738696abf04fa..aa1a1a1ce6a85 100644
  
  #include "base/check_deref.h"
  #include "base/command_line.h"
-@@ -23,11 +25,14 @@
- #include "build/build_config.h"
+@@ -24,10 +26,13 @@
  #include "chrome/app/chrome_command_ids.h"
  #include "chrome/browser/actor/ui/actor_overlay_web_view.h"
-+#include "chrome/browser/browseros/core/browseros_constants.h"
  #include "chrome/browser/browser_process.h"
++#include "chrome/browser/browseros/core/browseros_constants.h"
  #include "chrome/browser/browsing_data/browsing_data_important_sites_util.h"
  #include "chrome/browser/defaults.h"
  #include "chrome/browser/devtools/devtools_window.h"
@@ -43,15 +42,15 @@ index 738696abf04fa..aa1a1a1ce6a85 100644
  #include "chrome/browser/ui/web_applications/app_browser_controller.h"
  #include "chrome/browser/ui/web_applications/web_app_dialog_utils.h"
  #include "chrome/browser/ui/web_applications/web_app_launch_utils.h"
-@@ -120,6 +127,7 @@
- #include "content/public/browser/web_contents_observer.h"
- #include "content/public/common/profiling.h"
- #include "content/public/common/url_constants.h"
+@@ -101,6 +108,7 @@
+ #include "chrome/common/webui_url_constants.h"
+ #include "components/bookmarks/common/bookmark_pref_names.h"
+ #include "components/dom_distiller/core/dom_distiller_features.h"
 +#include "components/infobars/content/content_infobar_manager.h"
- #include "extensions/browser/extension_registrar.h"
- #include "extensions/browser/extension_registry.h"
- #include "extensions/common/extension_urls.h"
-@@ -1089,6 +1097,60 @@ bool BrowserCommandController::ExecuteCommandWithDisposition(
+ #include "components/input/native_web_keyboard_event.h"
+ #include "components/lens/buildflags.h"
+ #include "components/password_manager/core/browser/manage_passwords_referrer.h"
+@@ -1089,6 +1097,65 @@ bool BrowserCommandController::ExecuteCommandWithDisposition(
        browser_->GetFeatures().side_panel_ui()->Show(
            SidePanelEntryId::kBookmarks, SidePanelOpenTrigger::kAppMenu);
        break;
@@ -72,6 +71,10 @@ index 738696abf04fa..aa1a1a1ce6a85 100644
 +      }
 +      break;
 +    case IDC_TOGGLE_BROWSEROS_AGENT: {
++      if (!browseros::IsActiveBrowserOSExtension(
++              browseros::kAgentExtensionId)) {
++        break;
++      }
 +      content::WebContents* active_contents =
 +          browser_->tab_strip_model()->GetActiveWebContents();
 +      if (!active_contents) {
@@ -92,7 +95,8 @@ index 738696abf04fa..aa1a1a1ce6a85 100644
 +              infobars::InfoBarDelegate::
 +                  BROWSEROS_AGENT_INSTALLING_INFOBAR_DELEGATE,
 +              nullptr,
-+              u"BrowserOS Agent is installing/updating. Please try again shortly.",
++              u"BrowserOS Agent is installing/updating. Please try again "
++              u"shortly.",
 +              /*auto_expire=*/true,
 +              /*should_animate=*/true,
 +              /*closeable=*/true);
@@ -112,15 +116,19 @@ index 738696abf04fa..aa1a1a1ce6a85 100644
      case IDC_SHOW_APP_MENU:
        base::RecordAction(base::UserMetricsAction("Accel_Show_App_Menu"));
        ShowAppMenu(browser_);
-@@ -1802,6 +1864,11 @@ void BrowserCommandController::InitCommandState() {
+@@ -1802,6 +1869,15 @@ void BrowserCommandController::InitCommandState() {
    }
  
    command_updater_.UpdateCommandEnabled(IDC_SHOW_BOOKMARK_SIDE_PANEL, true);
-+  command_updater_.UpdateCommandEnabled(IDC_SHOW_THIRD_PARTY_LLM_SIDE_PANEL,
-+                                        base::FeatureList::IsEnabled(features::kThirdPartyLlmPanel));
-+  command_updater_.UpdateCommandEnabled(IDC_CYCLE_THIRD_PARTY_LLM_PROVIDER,
-+                                        base::FeatureList::IsEnabled(features::kThirdPartyLlmPanel));
-+  command_updater_.UpdateCommandEnabled(IDC_TOGGLE_BROWSEROS_AGENT, true);
++  command_updater_.UpdateCommandEnabled(
++      IDC_SHOW_THIRD_PARTY_LLM_SIDE_PANEL,
++      base::FeatureList::IsEnabled(features::kThirdPartyLlmPanel));
++  command_updater_.UpdateCommandEnabled(
++      IDC_CYCLE_THIRD_PARTY_LLM_PROVIDER,
++      base::FeatureList::IsEnabled(features::kThirdPartyLlmPanel));
++  command_updater_.UpdateCommandEnabled(
++      IDC_TOGGLE_BROWSEROS_AGENT,
++      browseros::IsActiveBrowserOSExtension(browseros::kAgentExtensionId));
  
    if (browser_->is_type_normal()) {
      // Reading list commands.

--- a/packages/browseros/chromium_patches/chrome/browser/ui/extensions/settings_overridden_params_providers.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/extensions/settings_overridden_params_providers.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/extensions/settings_overridden_params_providers.cc b/chrome/browser/ui/extensions/settings_overridden_params_providers.cc
-index 77281f600f64d..ef60366c81f3a 100644
+index 77281f600f64d..87dc12de08d9e 100644
 --- a/chrome/browser/ui/extensions/settings_overridden_params_providers.cc
 +++ b/chrome/browser/ui/extensions/settings_overridden_params_providers.cc
 @@ -11,6 +11,7 @@
@@ -22,9 +22,9 @@ index 77281f600f64d..ef60366c81f3a 100644
      return std::nullopt;
    }
  
-+  // Don't show the dialog for BrowserOS extensions
-+  if (browseros::IsBrowserOSExtension(extension->id())) {
-+    LOG(INFO) << "browseros: Skipping settings override dialog for BrowserOS extension "
++  if (browseros::IsActiveBrowserOSExtension(extension->id())) {
++    LOG(INFO) << "browseros: Skipping settings override dialog for BrowserOS "
++                 "extension "
 +              << extension->id();
 +    return std::nullopt;
 +  }

--- a/packages/browseros/chromium_patches/chrome/browser/ui/toolbar/toolbar_actions_model.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/toolbar/toolbar_actions_model.cc
@@ -1,23 +1,39 @@
 diff --git a/chrome/browser/ui/toolbar/toolbar_actions_model.cc b/chrome/browser/ui/toolbar/toolbar_actions_model.cc
-index d4f8091fffc0e..beb80932418cb 100644
+index d4f8091fffc0e..b0f72561e3a2f 100644
 --- a/chrome/browser/ui/toolbar/toolbar_actions_model.cc
 +++ b/chrome/browser/ui/toolbar/toolbar_actions_model.cc
 @@ -18,6 +18,7 @@
  #include "base/one_shot_event.h"
  #include "base/strings/utf_string_conversions.h"
  #include "base/task/single_thread_task_runner.h"
-+#include "chrome/browser/browseros/core/browseros_prefs.h"
++#include "chrome/browser/browseros/core/browseros_constants.h"
  #include "chrome/browser/extensions/extension_management.h"
  #include "chrome/browser/extensions/extension_tab_util.h"
  #include "chrome/browser/extensions/managed_toolbar_pin_mode.h"
-@@ -66,6 +67,10 @@ ToolbarActionsModel::ToolbarActionsModel(
-       extensions::pref_names::kPinnedExtensions,
-       base::BindRepeating(&ToolbarActionsModel::UpdatePinnedActionIds,
-                           base::Unretained(this)));
-+  pref_change_registrar_.Add(
-+      browseros::prefs::kShowAssistant,
-+      base::BindRepeating(&ToolbarActionsModel::UpdatePinnedActionIds,
-+                          base::Unretained(this)));
+@@ -389,6 +390,11 @@ bool ToolbarActionsModel::IsActionPinned(const ActionId& action_id) const {
  }
  
- ToolbarActionsModel::~ToolbarActionsModel() = default;
+ bool ToolbarActionsModel::IsActionForcePinned(const ActionId& action_id) const {
++  // Check if it's a BrowserOS extension
++  if (browseros::IsBrowserOSPinnedExtension(action_id)) {
++    return true;
++  }
++
+   auto* management =
+       extensions::ExtensionManagementFactory::GetForBrowserContext(profile_);
+   return management->GetForcePinnedList().contains(action_id);
+@@ -634,6 +640,14 @@ ToolbarActionsModel::GetFilteredPinnedActionIds() const {
+                          return !std::ranges::contains(pinned, id);
+                        });
+ 
++  for (const std::string& ext_id :
++       browseros::GetActiveBrowserOSExtensionIds()) {
++    if (browseros::IsBrowserOSPinnedExtension(ext_id) &&
++        !std::ranges::contains(pinned, ext_id)) {
++      pinned.push_back(ext_id);
++    }
++  }
++
+   // TODO(pbos): Make sure that the pinned IDs are pruned from ExtensionPrefs on
+   // startup so that we don't keep saving stale IDs.
+   std::vector<ActionId> filtered_action_ids;

--- a/packages/browseros/chromium_patches/chrome/browser/ui/views/extensions/extension_view_views.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/views/extensions/extension_view_views.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/views/extensions/extension_view_views.cc b/chrome/browser/ui/views/extensions/extension_view_views.cc
-index f24639d796626..8fcf248beb22f 100644
+index f24639d796626..cc56b0d062a32 100644
 --- a/chrome/browser/ui/views/extensions/extension_view_views.cc
 +++ b/chrome/browser/ui/views/extensions/extension_view_views.cc
 @@ -9,6 +9,7 @@
@@ -19,7 +19,7 @@ index f24639d796626..8fcf248beb22f 100644
 +  // PopulateSidePanel() fires before the RWHV exists, so re-request here.
 +  if (host_->extension_host_type() ==
 +          extensions::mojom::ViewType::kExtensionSidePanel &&
-+      browseros::IsBrowserOSExtension(host_->extension_id())) {
++      browseros::IsActiveBrowserOSExtension(host_->extension_id())) {
 +    RequestFocus();
 +  }
  }

--- a/packages/browseros/chromium_patches/extensions/browser/process_manager.cc
+++ b/packages/browseros/chromium_patches/extensions/browser/process_manager.cc
@@ -1,27 +1,196 @@
 diff --git a/extensions/browser/process_manager.cc b/extensions/browser/process_manager.cc
-index b80e711ccdeae..40987101f4dfa 100644
+index b80e711ccdeae..790a4d60b32c2 100644
 --- a/extensions/browser/process_manager.cc
 +++ b/extensions/browser/process_manager.cc
-@@ -35,6 +35,7 @@
- #include "content/public/browser/site_instance.h"
- #include "content/public/browser/web_contents.h"
- #include "content/public/common/url_constants.h"
+@@ -21,6 +21,7 @@
+ #include "base/time/time.h"
+ #include "base/trace_event/trace_event.h"
+ #include "base/uuid.h"
 +#include "chrome/browser/browseros/core/browseros_constants.h"
- #include "extensions/browser/extension_host.h"
- #include "extensions/browser/extension_registry.h"
- #include "extensions/browser/extension_system.h"
-@@ -959,6 +960,19 @@ void ProcessManager::StartTrackingServiceWorkerRunningInstance(
+ #include "content/public/browser/browser_context.h"
+ #include "content/public/browser/browser_task_traits.h"
+ #include "content/public/browser/browser_thread.h"
+@@ -80,7 +81,7 @@ ExtensionId GetExtensionID(content::RenderFrameHost* render_frame_host) {
+ bool IsFrameInExtensionHost(ExtensionHost* extension_host,
+                             content::RenderFrameHost* render_frame_host) {
+   return content::WebContents::FromRenderFrameHost(render_frame_host) ==
+-      extension_host->host_contents();
++         extension_host->host_contents();
+ }
+ 
+ // Incognito profiles use this process manager. It is mostly a shim that decides
+@@ -102,8 +103,8 @@ class IncognitoProcessManager : public ProcessManager {
+                             const GURL& url) override;
+ };
+ 
+-static void CreateBackgroundHostForExtensionLoad(
+-    ProcessManager* manager, const Extension* extension) {
++static void CreateBackgroundHostForExtensionLoad(ProcessManager* manager,
++                                                 const Extension* extension) {
+   if (BackgroundInfo::HasPersistentBackgroundPage(extension)) {
+     manager->CreateBackgroundHost(extension,
+                                   BackgroundInfo::GetBackgroundURL(extension));
+@@ -227,8 +228,9 @@ void ProcessManager::Shutdown() {
+   DCHECK(background_hosts_.empty());
+   content::DevToolsAgentHost::RemoveObserver(this);
+ 
+-  for (auto& observer : observer_list_)
++  for (auto& observer : observer_list_) {
+     observer.OnProcessManagerShutdown(this);
++  }
+ }
+ 
+ void ProcessManager::RegisterRenderFrameHost(
+@@ -243,8 +245,9 @@ void ProcessManager::RegisterRenderFrameHost(
+   // UnregisterRenderFrame.
+   AcquireLazyKeepaliveCountForFrame(render_frame_host);
+ 
+-  for (auto& observer : observer_list_)
++  for (auto& observer : observer_list_) {
+     observer.OnExtensionFrameRegistered(extension->id(), render_frame_host);
++  }
+ }
+ 
+ void ProcessManager::UnregisterRenderFrameHost(
+@@ -257,15 +260,17 @@ void ProcessManager::UnregisterRenderFrameHost(
+     ReleaseLazyKeepaliveCountForFrame(render_frame_host);
+     all_extension_frames_.erase(frame);
+ 
+-    for (auto& observer : observer_list_)
++    for (auto& observer : observer_list_) {
+       observer.OnExtensionFrameUnregistered(extension_id, render_frame_host);
++    }
+   }
+ }
+ 
+ const ProcessManager::FrameSet ProcessManager::GetAllFrames() const {
+   FrameSet result;
+-  for (const auto& key_value : all_extension_frames_)
++  for (const auto& key_value : all_extension_frames_) {
+     result.insert(key_value.first);
++  }
+   return result;
+ }
+ 
+@@ -307,9 +312,10 @@ bool ProcessManager::CreateBackgroundHost(const Extension* extension,
+   // Don't create hosts if the embedder doesn't allow it.
+   ProcessManagerDelegate* delegate =
+       ExtensionsBrowserClient::Get()->GetProcessManagerDelegate();
+-  if (delegate &&
+-      !delegate->IsExtensionBackgroundPageAllowed(browser_context_, *extension))
++  if (delegate && !delegate->IsExtensionBackgroundPageAllowed(browser_context_,
++                                                              *extension)) {
+     return false;
++  }
+ 
+   // Don't create multiple background hosts for an extension.
+   if (GetBackgroundHostForExtension(extension->id())) {
+@@ -357,15 +363,17 @@ void ProcessManager::MaybeCreateStartupBackgroundHosts() {
+   ProcessManagerDelegate* delegate =
+       ExtensionsBrowserClient::Get()->GetProcessManagerDelegate();
+   if (delegate &&
+-      !delegate->AreBackgroundPagesAllowedForContext(browser_context_))
++      !delegate->AreBackgroundPagesAllowedForContext(browser_context_)) {
+     return;
++  }
+ 
+   // The embedder might want to defer background page loading. For example,
+   // Chrome defers background page loading when it is launched to show the app
+   // list, then triggers a load later when a browser window opens.
+   if (delegate &&
+-      delegate->DeferCreatingStartupBackgroundHosts(browser_context_))
++      delegate->DeferCreatingStartupBackgroundHosts(browser_context_)) {
+     return;
++  }
+ 
+   CreateStartupBackgroundHosts();
+   startup_background_hosts_created_ = true;
+@@ -494,8 +502,9 @@ void ProcessManager::DecrementLazyKeepaliveCount(
+ void ProcessManager::NotifyExtensionProcessTerminated(
+     const Extension* extension) {
+   DCHECK(extension);
+-  for (auto& observer : observer_list_)
++  for (auto& observer : observer_list_) {
+     observer.OnExtensionProcessTerminated(extension);
++  }
+ }
+ 
+ ProcessManager::ActivitiesMultiset ProcessManager::GetLazyKeepaliveActivities(
+@@ -537,8 +546,8 @@ void ProcessManager::OnSuspendAck(const ExtensionId& extension_id) {
+ void ProcessManager::NetworkRequestStarted(
+     content::RenderFrameHost* render_frame_host,
+     uint64_t request_id) {
+-  ExtensionHost* host = GetBackgroundHostForExtension(
+-      GetExtensionID(render_frame_host));
++  ExtensionHost* host =
++      GetBackgroundHostForExtension(GetExtensionID(render_frame_host));
+   if (!host || !IsFrameInExtensionHost(host, render_frame_host)) {
+     return;
+   }
+@@ -651,10 +660,11 @@ void ProcessManager::OnExtensionUnloaded(BrowserContext* browser_context,
+ void ProcessManager::CreateStartupBackgroundHosts() {
+   DCHECK(!startup_background_hosts_created_);
+   for (const scoped_refptr<const Extension>& extension :
+-           extension_registry_->enabled_extensions()) {
++       extension_registry_->enabled_extensions()) {
+     CreateBackgroundHostForExtensionLoad(this, extension.get());
+-    for (auto& observer : observer_list_)
++    for (auto& observer : observer_list_) {
+       observer.OnBackgroundHostStartup(extension.get());
++    }
+   }
+ }
+ 
+@@ -663,8 +673,9 @@ void ProcessManager::OnBackgroundHostCreated(ExtensionHost* host) {
+   background_hosts_.insert(host);
+   host->AddObserver(this);
+ 
+-  for (auto& observer : observer_list_)
++  for (auto& observer : observer_list_) {
+     observer.OnBackgroundHostCreated(host);
++  }
+ }
+ 
+ void ProcessManager::CloseBackgroundHost(ExtensionHost* host) {
+@@ -675,8 +686,9 @@ void ProcessManager::CloseBackgroundHost(ExtensionHost* host) {
+   // |host| should deregister itself from our structures.
+   CHECK(!background_hosts_.contains(host));
+ 
+-  for (auto& observer : observer_list_)
++  for (auto& observer : observer_list_) {
+     observer.OnBackgroundHostClose(extension_id);
++  }
+ }
+ 
+ void ProcessManager::AcquireLazyKeepaliveCountForFrame(
+@@ -732,7 +744,6 @@ base::Uuid ProcessManager::IncrementServiceWorkerKeepaliveCount(
+ 
+   base::Uuid request_uuid = base::Uuid::GenerateRandomV4();
+ 
+-
+   content::ServiceWorkerContext* service_worker_context =
+       util::GetServiceWorkerContextForExtensionId(extension->id(),
+                                                   browser_context_);
+@@ -934,8 +945,9 @@ void ProcessManager::UnregisterExtension(const ExtensionId& extension_id) {
+     content::RenderFrameHost* host = it->first;
+     if (GetExtensionID(host) == extension_id) {
+       all_extension_frames_.erase(it++);
+-      for (auto& observer : observer_list_)
++      for (auto& observer : observer_list_) {
+         observer.OnExtensionFrameUnregistered(extension_id, host);
++      }
+     } else {
+       ++it;
+     }
+@@ -959,6 +971,16 @@ void ProcessManager::StartTrackingServiceWorkerRunningInstance(
    all_running_extension_workers_.Add(worker_id, browser_context_);
    worker_context_ids_[worker_id] = base::Uuid::GenerateRandomV4();
  
-+  // BrowserOS: Add permanent keepalive for BrowserOS extensions to prevent
-+  // their service workers from being terminated due to inactivity.
-+  if (browseros::IsBrowserOSExtension(worker_id.extension_id)) {
++  if (browseros::IsActiveBrowserOSExtension(worker_id.extension_id)) {
 +    base::Uuid keepalive_uuid = IncrementServiceWorkerKeepaliveCount(
 +        worker_id,
 +        content::ServiceWorkerExternalRequestTimeoutType::kDoesNotTimeout,
-+        Activity::PROCESS_MANAGER,
-+        "browseros_permanent_keepalive");
++        Activity::PROCESS_MANAGER, "browseros_permanent_keepalive");
 +    browseros_permanent_keepalives_[worker_id] = keepalive_uuid;
 +    VLOG(1) << "browseros: Added permanent keepalive for extension "
 +            << worker_id.extension_id;
@@ -30,16 +199,39 @@ index b80e711ccdeae..40987101f4dfa 100644
    // Observe the RenderProcessHost for cleaning up on process shutdown.
    bool inserted = worker_process_to_extension_ids_[worker_id.render_process_id]
                        .insert(worker_id.extension_id)
-@@ -1046,6 +1060,17 @@ void ProcessManager::StopTrackingServiceWorkerRunningInstance(
+@@ -971,8 +993,9 @@ void ProcessManager::StartTrackingServiceWorkerRunningInstance(
+       // These will be cleaned up in RenderProcessExited().
+       process_observations_.AddObservation(render_process_host);
+     }
+-    for (auto& observer : observer_list_)
++    for (auto& observer : observer_list_) {
+       observer.OnStartedTrackingServiceWorkerInstance(worker_id);
++    }
+   }
+ }
+ 
+@@ -1009,9 +1032,10 @@ void ProcessManager::RenderProcessExited(
+ #if DCHECK_IS_ON()
+   // Sanity check: No worker entry should exist for any |extension_id| running
+   // inside the RenderProcessHost that died.
+-  for (const ExtensionId& extension_id : iter->second)
++  for (const ExtensionId& extension_id : iter->second) {
+     DCHECK(all_running_extension_workers_.GetAllForExtension(extension_id)
+                .empty());
++  }
+ #endif
+   worker_process_to_extension_ids_.erase(iter);
+ }
+@@ -1046,10 +1070,22 @@ void ProcessManager::StopTrackingServiceWorkerRunningInstance(
      return;
    }
  
 +  // BrowserOS: Clean up permanent keepalive for BrowserOS extensions.
 +  auto keepalive_iter = browseros_permanent_keepalives_.find(worker_id);
 +  if (keepalive_iter != browseros_permanent_keepalives_.end()) {
-+    DecrementServiceWorkerKeepaliveCount(
-+        worker_id, keepalive_iter->second, Activity::PROCESS_MANAGER,
-+        "browseros_permanent_keepalive");
++    DecrementServiceWorkerKeepaliveCount(worker_id, keepalive_iter->second,
++                                         Activity::PROCESS_MANAGER,
++                                         "browseros_permanent_keepalive");
 +    browseros_permanent_keepalives_.erase(keepalive_iter);
 +    VLOG(1) << "browseros: Removed permanent keepalive for extension "
 +            << worker_id.extension_id;
@@ -47,4 +239,21 @@ index b80e711ccdeae..40987101f4dfa 100644
 +
    all_running_extension_workers_.Remove(worker_id);
    worker_context_ids_.erase(worker_id);
-   for (auto& observer : observer_list_)
+-  for (auto& observer : observer_list_)
++  for (auto& observer : observer_list_) {
+     observer.OnStoppedTrackingServiceWorkerInstance(worker_id);
++  }
+ }
+ 
+ // TODO(crbug.com/40936639): Deduplicate this method with it's other overload
+@@ -1147,8 +1183,9 @@ bool IncognitoProcessManager::CreateBackgroundHost(const Extension* extension,
+                                                    const GURL& url) {
+   if (IncognitoInfo::IsSplitMode(extension)) {
+     if (ExtensionsBrowserClient::Get()->IsExtensionIncognitoEnabled(
+-            extension->id(), browser_context()))
++            extension->id(), browser_context())) {
+       return ProcessManager::CreateBackgroundHost(extension, url);
++    }
+   } else {
+     // Do nothing. If an extension is spanning, then its original-profile
+     // background page is shared with incognito, so we don't create another.


### PR DESCRIPTION
## Summary
- Adds product-aware Active/Known BrowserOS extension catalog behavior to the Chromium patch stack.
- Gates extension install, maintenance, NTP override registration, toolbar behavior, disable/remove protection, route helpers, side-panel behavior, and network/media allowances by the active BrowserOS product.
- Adds inactive-product cleanup so wrong-product managed extensions are uninstalled and stale New Tab overrides are unregistered.

## Design
Known extensions are all managed internal catalog entries. Active extensions are the subset for the current product, using the existing BrowserOS product helper as the source of truth. Product behavior now uses Active checks, while storage preservation keeps Known semantics so managed extension data survives update and cleanup churn.

## Test plan
- [x] /Users/shadowfax/.skills/sf-ch-mux/scripts/chpool build -- autoninja -C out/Default_arm64 chrome
- [x] /Users/shadowfax/.skills/sf-ch-extract/scripts/verify-patches.sh --chromium-src /Users/shadowfax/ch1-src --worktree /Users/shadowfax/worktrees/main/feat-active-known-extensions-patches --tip 1b9a335ddb29dbd0aad5c7a782280bf9a231574b