### PR TITLE
chore(ci): drop major version bumps from Dependabot's routine queue

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,15 @@ updates:
     open-pull-requests-limit: 10
     cooldown:
       default-days: 3
+    # Major bumps are opt-in only via security advisories. Routine
+    # version PRs are limited to minor + patch so the queue stays
+    # actionable. A security update that requires a major bump still
+    # gets opened by Dependabot — `ignore` rules do not apply to
+    # security updates.
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     groups:
       minor-and-patch:
         update-types:
@@ -32,6 +41,10 @@ updates:
     open-pull-requests-limit: 5
     cooldown:
       default-days: 3
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
     groups:
       minor-and-patch:
         update-types:


### PR DESCRIPTION
Routine Dependabot PRs now skip `version-update:semver-major` for both the bun workspace and github-actions ecosystems via per-ecosystem `ignore` rules. The existing `minor-and-patch` group continues to batch low-risk bumps into a single PR per cycle.

Security updates are unaffected — `ignore` rules do not apply to them — so a CVE that requires a major bump (transitive or direct) will still surface a Dependabot PR. The follow-up step is to close the routine major-bump PRs already open under the previous config; Dependabot will not reopen them under the new rules.