### PR TITLE
fix(claw-server): record tabs new in tab-activity registry from result

### DIFF
--- a/packages/browseros-agent/apps/claw-server/src/mcp/register.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/register.ts
@@ -528,6 +528,25 @@ export function registerBrowserToolsForSingleServer(
                 )?.page
                 if (typeof pageId === 'number') {
                   const { agentId, slug } = agentIdentityFromClient(identity)
+                  // tabs new carries no `page` field in its input
+                  // args; the page id is born in the dispatch result.
+                  // recordSuccessfulDispatchV2 above therefore
+                  // skipped the registry write (extractPageId
+                  // returned null). Record here using the result-
+                  // derived pageId so /tabs/activity reflects the
+                  // new tab the moment it opens, not when a later
+                  // page-targeted dispatch (snapshot / navigate)
+                  // happens to land on it.
+                  const live = session.pages.getInfo(pageId)
+                  if (live) {
+                    tabActivityRegistry.recordTool({
+                      agentId,
+                      slug,
+                      pageId,
+                      targetId: live.targetId,
+                      toolName: 'tabs',
+                    })
+                  }
                   void ensureAgentTabGroup({
                     agentId,
                     slug,
@@ -535,13 +554,6 @@ export function registerBrowserToolsForSingleServer(
                     session,
                     signal: extra?.signal,
                   })
-                  // The rrweb session replay recorder is no longer
-                  // injected from here. F8 moved recording to a
-                  // content script driven by the claw-app extension's
-                  // background worker, which polls /replay/tabs and
-                  // injects via chrome.scripting.executeScript only
-                  // into tabs the cockpit reports as agent-driven.
-                  // See plan: 2026-06-29-1450-...content-script.md
                 }
               }
             }

--- a/packages/browseros-agent/apps/claw-server/tests/mcp/register-tabs-new.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/mcp/register-tabs-new.test.ts
@@ -1,0 +1,205 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Pins the registry-write side effect of the `tabs new` dispatch
+ * branch in mcp/register.ts. Pre-fix, the registry only learned
+ * about a tab from a subsequent page-targeted dispatch (snapshot,
+ * navigate, etc) because `extractPageId` reads `page` from input
+ * args, and `tabs new` carries no `page` in its input (the page id
+ * is born in the result). Post-fix, the result-side pageId is
+ * also written to the registry so `/tabs/activity` reflects the
+ * tab the moment it opens.
+ *
+ * Pattern mirrors tab-group-ops.test.ts: mock `executeTool` at the
+ * module boundary so the orchestrator drives synthetic results,
+ * stub the browser session so `pages.getInfo(pageId)` returns a
+ * known targetId, and assert against the singleton registry.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+
+interface CallEntry {
+  toolName: string
+  args: Record<string, unknown>
+}
+
+interface FakeResult {
+  isError: boolean
+  content: Array<{ type: 'text'; text: string }>
+  structuredContent?: unknown
+}
+
+const calls: CallEntry[] = []
+const queued: FakeResult[] = []
+
+function nextResult(toolName: string): FakeResult {
+  const r = queued.shift()
+  if (!r) {
+    throw new Error(`register-tabs-new.test: no queued result for ${toolName}`)
+  }
+  return r
+}
+
+// Preserve the framework's other exports (defineTool, textResult,
+// errorResult, etc.) since `server.ts` -> `register.ts` ->
+// `BROWSER_TOOLS` transitively imports every tool's source, and
+// each tool imports helpers from this same module. Without the
+// spread, those imports throw 'Export named "textResult" not found'
+// when the catalogue loads.
+const realFramework = await import('@browseros/browser-mcp/tools/framework')
+mock.module('@browseros/browser-mcp/tools/framework', () => ({
+  ...realFramework,
+  executeTool: async (def: { name: string }, args: Record<string, unknown>) => {
+    calls.push({ toolName: def.name, args })
+    return nextResult(def.name)
+  },
+}))
+
+function queue(...results: FakeResult[]): void {
+  queued.push(...results)
+}
+
+function ok(structured?: unknown): FakeResult {
+  return {
+    isError: false,
+    content: [{ type: 'text', text: 'ok' }],
+    structuredContent: structured,
+  }
+}
+
+// Imports must come AFTER mock.module so the orchestrator picks up
+// the stubbed executeTool.
+const { setBrowserSession } = await import('../../src/lib/browser-session')
+const { tabActivityRegistry } = await import('../../src/lib/tab-activity')
+const { identityService } = await import('../../src/lib/mcp-session')
+const { resetSingleMcpInstanceForTesting } = await import(
+  '../../src/mcp/single-server'
+)
+const app = (await import('../../src/server')).default
+
+function stubSessionForPageId(pageId: number, targetId: string): void {
+  setBrowserSession({
+    pages: {
+      getInfo: (id: number) =>
+        id === pageId
+          ? { targetId, url: 'https://example.com/', title: 'Ex' }
+          : undefined,
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: test stub
+  } as any)
+}
+
+async function connect(clientName: string) {
+  const transport = new StreamableHTTPClientTransport(
+    new URL('http://localhost/mcp'),
+    {
+      fetch: ((input, init) =>
+        app.fetch(new Request(input, init))) as typeof fetch,
+    },
+  )
+  const client = new Client(
+    { name: clientName, version: '0.0.1' },
+    { capabilities: {} },
+  )
+  await client.connect(transport)
+  return { client, transport }
+}
+
+describe('mcp/register.ts: tabs new registry write', () => {
+  beforeEach(() => {
+    calls.length = 0
+    queued.length = 0
+    resetSingleMcpInstanceForTesting()
+    identityService.clear()
+    tabActivityRegistry.clear()
+  })
+  afterEach(() => {
+    queued.length = 0
+    resetSingleMcpInstanceForTesting()
+    identityService.clear()
+    tabActivityRegistry.clear()
+    setBrowserSession(null)
+  })
+
+  it('records a registry entry from the result-derived page id when tabs new succeeds', async () => {
+    stubSessionForPageId(7, 'target-7')
+    // tabs new returns page=7 in structuredContent. ensureAgentTabGroup
+    // also fires for action:'new' (one create + one update for colour)
+    // so we queue those too.
+    queue(ok({ page: 7 }), ok({ group: { groupId: 'G1', windowId: 42 } }), ok())
+    const { client } = await connect('codex-mcp-client')
+    const result = await client.callTool({
+      name: 'tabs',
+      arguments: { action: 'new', url: 'https://example.com/' },
+    })
+    expect(result.isError).toBeFalsy()
+
+    const snapshot = tabActivityRegistry.snapshot()
+    expect(snapshot).toHaveLength(1)
+    expect(snapshot[0]).toMatchObject({
+      pageId: 7,
+      targetId: 'target-7',
+      agentId: 'codex-mcp-client',
+      slug: 'codex-mcp-client',
+      lastToolName: 'tabs',
+    })
+
+    await client.close()
+  })
+
+  it('does NOT record when the result has no page id (defensive)', async () => {
+    stubSessionForPageId(7, 'target-7')
+    queue(ok({})) // tabs new succeeded but the result lacks `page`
+    const { client } = await connect('codex-mcp-client')
+    const result = await client.callTool({
+      name: 'tabs',
+      arguments: { action: 'new', url: 'https://example.com/' },
+    })
+    expect(result.isError).toBeFalsy()
+
+    expect(tabActivityRegistry.snapshot()).toEqual([])
+    await client.close()
+  })
+
+  it('does NOT record from the result-derived path when action is not new', async () => {
+    // The new code path is gated to action:'new' specifically; for
+    // other actions, attribution still goes through extractPageId
+    // (which requires `page` in input args).
+    stubSessionForPageId(7, 'target-7')
+    queue(ok({ tabs: [] }))
+    const { client } = await connect('codex-mcp-client')
+    const result = await client.callTool({
+      name: 'tabs',
+      arguments: { action: 'list' },
+    })
+    expect(result.isError).toBeFalsy()
+    expect(tabActivityRegistry.snapshot()).toEqual([])
+    await client.close()
+  })
+
+  it('does NOT record if the result-derived page id is missing from the live session', async () => {
+    // session.pages.getInfo returns undefined for page 99: the live
+    // CDP target list does not contain it (race between tabs new
+    // returning and the page registering with the session). Skip
+    // the write rather than insert a record with a placeholder
+    // targetId.
+    stubSessionForPageId(7, 'target-7')
+    queue(
+      ok({ page: 99 }),
+      ok({ group: { groupId: 'G1', windowId: 42 } }),
+      ok(),
+    )
+    const { client } = await connect('codex-mcp-client')
+    const result = await client.callTool({
+      name: 'tabs',
+      arguments: { action: 'new', url: 'https://example.com/' },
+    })
+    expect(result.isError).toBeFalsy()
+    expect(tabActivityRegistry.snapshot()).toEqual([])
+    await client.close()
+  })
+})


### PR DESCRIPTION
## Summary

`GET /tabs/activity` was empty for any agent that opened a tab via `tabs new` and didn't immediately follow up with a page-targeted dispatch (`snapshot`, `navigate`, `read`). Surfaced during dogfood with `codex-mcp-client`. The homepage Running Now view stayed blank for the entire agent run.

**Root cause:** `recordSuccessfulDispatchV2` calls `tabActivityRegistry.recordTool` only when `extractPageId(toolName, rawArgs)` returns a positive integer. `extractPageId` reads `page` from the tool's INPUT args, but `tabs new` has no `page` field in its input. The page id is born in the dispatch RESULT under `structuredContent.page`. So the registry write was silently skipped on every tab creation.

**Fix:** In the `tabs` + `action: 'new'` branch of `register.ts` where we already extract the result-side `pageId` for `ensureAgentTabGroup`, also call `tabActivityRegistry.recordTool` with that same `pageId` plus the `targetId` looked up via `session.pages.getInfo`. The existing `extractPageId`-driven write in `recordSuccessfulDispatchV2` is untouched; attribution for every other tool stays exactly as it was. `recordTool` is idempotent by `targetId`, so subsequent page-targeted dispatches on the same tab just update `lastToolAt` without double counting.

Defensive: skip the new write if `session.pages.getInfo` returns undefined for the result-derived `pageId`. That can happen during the brief race between `tabs new` returning and the page registering with the CDP target list; the next dispatch will catch it.

## Test plan

New file `tests/mcp/register-tabs-new.test.ts` with four cases:
- [x] `tabs new` returning `page: 7` records the registry entry with the right `pageId`, `targetId`, `agentId`, `slug`, `lastToolName: 'tabs'`
- [x] `tabs new` with no `page` in result records nothing (defensive)
- [x] `tabs` with `action: 'list'` records nothing from this path (gated to `action: 'new'`)
- [x] `tabs new` returning a `pageId` not present in the live session records nothing

claw-server suite: **331 pass** (was 327; 4 new tests). Typecheck clean.

Pattern mirrors `tests/services/tab-group-ops.test.ts`: mock `@browseros/browser-mcp/tools/framework.executeTool` while preserving the other exports (`defineTool`, `textResult`, etc.) so the full `BROWSER_TOOLS` catalogue loads cleanly when `server.ts` registers it.

## Scope

Issue 1 only, from the wider session-lifecycle audit. Issues 2 (task forever 'live'), 3 (no screenshots persisted), 4 (tab group leak), 5 (two tasks merged into one session) need separate plans + PRs.