### PR TITLE
fix(claw-server): reap idle MCP sessions to close their audit + tab group

### DIFF
--- a/packages/browseros-agent/apps/claw-server/src/env.ts
+++ b/packages/browseros-agent/apps/claw-server/src/env.ts
@@ -35,6 +35,21 @@ function readBoolFlag(name: string): boolean {
 }
 
 /**
+ * Parse a positive integer ms override, falling back to the
+ * provided default on any non-positive / non-finite input. Used
+ * for runtime tunables (sweep interval, idle timeout) the operator
+ * may want to shorten in dev or lengthen in staging.
+ */
+function readPositiveIntFlag(name: string, fallback: number): number {
+  // biome-ignore lint/style/noProcessEnv: env.ts is the sanctioned env-reader for the package
+  const raw = process.env[name]
+  if (raw === undefined) return fallback
+  const parsed = Number.parseInt(raw, 10)
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback
+  return parsed
+}
+
+/**
  * Runtime snapshot shared across services. main.ts applies validated
  * startup config before serving; tests may mutate fields for isolation.
  */
@@ -44,6 +59,16 @@ export const env = {
   resourcesDir: resolveDefaultResourcesDir(),
   browserosDirOverride: readBrowserosDirOverride(),
   isDevelopment: readIsDevelopment(),
+  // MCP session idle reaper. Sessions older than `sessionIdleMs`
+  // with no inbound requests are torn down by the sweeper running
+  // every `sessionSweepIntervalMs`. The 5-minute default matches
+  // services/tasks.ts:IDLE_TIMEOUT_MS so the UI's status read and
+  // the actual session-end row land at the same boundary.
+  sessionIdleMs: readPositiveIntFlag('CLAW_SESSION_IDLE_MS', 5 * 60 * 1000),
+  sessionSweepIntervalMs: readPositiveIntFlag(
+    'CLAW_SESSION_SWEEP_INTERVAL_MS',
+    60 * 1000,
+  ),
 }
 
 /** Applies validated startup config to the shared runtime snapshot. */

--- a/packages/browseros-agent/apps/claw-server/src/lib/agent-tabs/agent-tabs.ts
+++ b/packages/browseros-agent/apps/claw-server/src/lib/agent-tabs/agent-tabs.ts
@@ -1,0 +1,75 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Per-agent ownership ledger for browser pages. Populated by
+ * successful `tabs new` dispatches and drained by `tabs close`.
+ * The cockpit's `tabs list` handler filters its result to only
+ * this agent's owned pages, and the page-targeted tools reject
+ * dispatches whose `page` arg is not owned by the caller. Together
+ * with `tabGroupTracker`, this guarantees an agent can only see /
+ * touch tabs it opened; the operator's own tabs are invisible.
+ *
+ * Different lifecycle than `tabActivityRegistry`: that one is
+ * targetId-keyed and prunes on a 30s window for the /tabs/activity
+ * UI. This one is agentId-keyed and lives until the session ends
+ * (dropped by cleanupSessionState).
+ */
+
+export interface AgentTabsRegistry {
+  markOpened(agentId: string, pageId: number): void
+  markClosed(agentId: string, pageId: number): void
+  /**
+   * Returns the set of page ids owned by this agent. NEVER null;
+   * unknown agents get an empty set so callers can uniformly do
+   * `owned.has(page)` without null-checking.
+   */
+  ownedBy(agentId: string): ReadonlySet<number>
+  /**
+   * Drops all pages tracked for an agent. Called from
+   * `cleanupSessionState` so the next session for the same agentId
+   * starts empty.
+   */
+  forgetAgent(agentId: string): void
+  // Test-only escape hatches.
+  size(): number
+  clear(): void
+}
+
+const EMPTY: ReadonlySet<number> = new Set<number>()
+
+export function createAgentTabsRegistry(): AgentTabsRegistry {
+  const records = new Map<string, Set<number>>()
+  return {
+    markOpened(agentId, pageId) {
+      let set = records.get(agentId)
+      if (!set) {
+        set = new Set()
+        records.set(agentId, set)
+      }
+      set.add(pageId)
+    },
+    markClosed(agentId, pageId) {
+      const set = records.get(agentId)
+      if (!set) return
+      set.delete(pageId)
+      if (set.size === 0) records.delete(agentId)
+    },
+    ownedBy(agentId) {
+      return records.get(agentId) ?? EMPTY
+    },
+    forgetAgent(agentId) {
+      records.delete(agentId)
+    },
+    size() {
+      return records.size
+    },
+    clear() {
+      records.clear()
+    },
+  }
+}
+
+/** Process-wide singleton consumed by register.ts + single-server.ts. */
+export const agentTabs = createAgentTabsRegistry()

--- a/packages/browseros-agent/apps/claw-server/src/lib/agent-tabs/index.ts
+++ b/packages/browseros-agent/apps/claw-server/src/lib/agent-tabs/index.ts
@@ -1,0 +1,11 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+export {
+  type AgentTabsRegistry,
+  agentTabs,
+  createAgentTabsRegistry,
+} from './agent-tabs'

--- a/packages/browseros-agent/apps/claw-server/src/lib/tab-activity/extract-page-id.ts
+++ b/packages/browseros-agent/apps/claw-server/src/lib/tab-activity/extract-page-id.ts
@@ -12,7 +12,14 @@
  * registry from holding garbage keys.
  */
 
-const TOOLS_WITH_PAGE: ReadonlySet<string> = new Set([
+/**
+ * Tools that accept a `page` argument (either required or optional).
+ * Reused by `register.ts`'s cross-agent page guard so both the
+ * tab-activity registry attribution AND the isolation guard agree
+ * on which tools can be page-targeted. Adding a new tool that
+ * takes a page id belongs here.
+ */
+export const TOOLS_WITH_PAGE: ReadonlySet<string> = new Set([
   'act',
   'diff',
   'download',

--- a/packages/browseros-agent/apps/claw-server/src/lib/tab-activity/index.ts
+++ b/packages/browseros-agent/apps/claw-server/src/lib/tab-activity/index.ts
@@ -15,7 +15,7 @@ import { createTabActivityRegistry, type TabActivityRegistry } from './registry'
 export const tabActivityRegistry: TabActivityRegistry =
   createTabActivityRegistry({ getSession: getBrowserSession })
 
-export { extractPageId } from './extract-page-id'
+export { extractPageId, TOOLS_WITH_PAGE } from './extract-page-id'
 export type {
   TabActivityRecord,
   TabActivityRegistry,

--- a/packages/browseros-agent/apps/claw-server/src/mcp/register.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/register.ts
@@ -33,13 +33,18 @@ import { BROWSER_TOOLS } from '@browseros/browser-mcp/registry'
 import { executeTool } from '@browseros/browser-mcp/tools/framework'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { ZodRawShape } from 'zod'
+import { agentTabs } from '../lib/agent-tabs'
 import { getBrowserSession } from '../lib/browser-session'
 import { logger } from '../lib/logger'
 import {
   agentIdentityFromClient,
   type ClientIdentity,
 } from '../lib/mcp-session'
-import { extractPageId, tabActivityRegistry } from '../lib/tab-activity'
+import {
+  extractPageId,
+  TOOLS_WITH_PAGE,
+  tabActivityRegistry,
+} from '../lib/tab-activity'
 import type { StoredAgentProfile } from '../routes/agents/schemas'
 import { recordToolDispatch } from '../services/audit-log'
 import {
@@ -293,6 +298,44 @@ function composeAbortSignals(
 }
 
 /**
+ * Rewrite a successful `tabs list` result to only include pages the
+ * calling agent owns. Both channels are rebuilt from the surviving
+ * subset:
+ *   - `structuredContent.pages` is filtered.
+ *   - `content[0].text` is rebuilt via the tool's `formatPageLine`
+ *     shape (`[N] URL (title)` or `[N] URL` when no title). Empty
+ *     survivors yield `(no open pages)` which matches the underlying
+ *     tool's empty output so codex's LLM interprets it as "no tabs,
+ *     open one" and dispatches `tabs new` instead of hijacking.
+ *
+ * Exported for unit tests; production callers reach it via the
+ * dispatch handler.
+ */
+export function filterTabsListToAgent<
+  R extends {
+    content: unknown
+    isError?: boolean
+    structuredContent?: unknown
+  },
+>(result: R, owned: ReadonlySet<number>): R {
+  const sc = result.structuredContent as
+    | { pages?: Array<{ page: number; url?: string; title?: string }> }
+    | undefined
+  const allPages = sc?.pages ?? []
+  const surviving = allPages.filter((p) => owned.has(p.page))
+  const lines = surviving.map(
+    (p) => `[${p.page}] ${p.url ?? ''}${p.title ? ` (${p.title})` : ''}`,
+  )
+  const text = lines.length > 0 ? lines.join('\n') : '(no open pages)'
+  return {
+    ...result,
+    isError: false,
+    content: [{ type: 'text', text }],
+    structuredContent: { pages: surviving },
+  } as R
+}
+
+/**
  * v2 dispatch record helper. The single MCP endpoint does not know
  * which `StoredAgentProfile` produced the call, so the registry write
  * sources its identity from the per-session `ClientIdentity` instead.
@@ -387,6 +430,50 @@ export function registerBrowserToolsForSingleServer(
             tool: tool.name,
             sessionId: extra?.sessionId,
           })
+        }
+
+        // Cross-agent page guard. Reject dispatches whose `page` arg
+        // points at a tab this agent does not own so an agent can
+        // only touch tabs it opened via `tabs new`. Prevents the
+        // "codex takes over the operator's active tab" failure
+        // mode: without this guard, an agent that sees a page id
+        // from anywhere (its LLM cache, `tabs active`, a prior
+        // session) could dispatch snapshot / navigate / etc. on the
+        // operator's tab. Fires BEFORE executeTool so the underlying
+        // tool never sees the bad page id. Fail-open when identity
+        // is unknown (unusual; matches the rest of the dispatch
+        // path's identity-optional behaviour).
+        if (TOOLS_WITH_PAGE.has(tool.name)) {
+          const pageArg = (rawArgs as { page?: unknown } | null | undefined)
+            ?.page
+          if (
+            typeof pageArg === 'number' &&
+            Number.isInteger(pageArg) &&
+            pageArg >= 1
+          ) {
+            const guardIdentity = resolveIdentity(extra?.sessionId)
+            if (guardIdentity) {
+              const { agentId: guardAgentId } =
+                agentIdentityFromClient(guardIdentity)
+              if (!agentTabs.ownedBy(guardAgentId).has(pageArg)) {
+                logger.warn('cockpit v2 rejected foreign-page dispatch', {
+                  tool: tool.name,
+                  sessionId: extra?.sessionId,
+                  agentId: guardAgentId,
+                  page: pageArg,
+                })
+                return {
+                  content: [
+                    {
+                      type: 'text',
+                      text: `page ${pageArg} is not owned by this agent; call \`tabs new\` to open a fresh page and use the returned page id.`,
+                    },
+                  ],
+                  isError: true,
+                } satisfies ToolResult
+              }
+            }
+          }
         }
 
         const dispatchStart = Date.now()
@@ -547,6 +634,11 @@ export function registerBrowserToolsForSingleServer(
                       toolName: 'tabs',
                     })
                   }
+                  // Isolation ledger: this page now belongs to this
+                  // agent. Subsequent page-targeted dispatches will
+                  // pass the cross-agent page guard for this id and
+                  // fail it for any other agent's session.
+                  agentTabs.markOpened(agentId, pageId)
                   void ensureAgentTabGroup({
                     agentId,
                     slug,
@@ -555,6 +647,30 @@ export function registerBrowserToolsForSingleServer(
                     signal: extra?.signal,
                   })
                 }
+              } else if (args?.action === 'close') {
+                // Drop the closed page from the isolation ledger so
+                // the agent cannot re-reference it and so `tabs list`
+                // stops surfacing it.
+                const closedPage = (rawArgs as { page?: unknown } | null)?.page
+                if (
+                  typeof closedPage === 'number' &&
+                  Number.isInteger(closedPage) &&
+                  closedPage >= 1
+                ) {
+                  const { agentId } = agentIdentityFromClient(identity)
+                  agentTabs.markClosed(agentId, closedPage)
+                }
+              } else if ((args?.action ?? 'list') === 'list') {
+                // Filter the list to only pages this agent owns.
+                // With no owned pages, the surviving text is
+                // `(no open pages)` which mirrors the tool's own
+                // empty output; the LLM interprets it as "I have no
+                // tabs, I need to open one" and calls `tabs new`.
+                const { agentId } = agentIdentityFromClient(identity)
+                result = filterTabsListToAgent(
+                  result,
+                  agentTabs.ownedBy(agentId),
+                )
               }
             }
           } else {

--- a/packages/browseros-agent/apps/claw-server/src/mcp/single-server.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/single-server.ts
@@ -136,7 +136,13 @@ function buildSession(): Session {
  * without firing side effects so repeated sweeps are safe.
  */
 function cleanupSessionState(sessionId: string): void {
-  if (!sessions.has(sessionId)) return
+  // Grab the ref BEFORE the map delete so we can close the transport
+  // + server AFTER the map is empty. Idempotent guard: if the
+  // session is already gone, return without firing side effects
+  // (protects against the sweeper racing with the explicit DELETE
+  // path and against the reentrant callback below).
+  const session = sessions.get(sessionId)
+  if (!session) return
   // Read identity BEFORE dropping it so the cleanup hook can resolve
   // the agentId for the tab-group close.
   const identity = identityService.getIdentity(sessionId)
@@ -160,6 +166,27 @@ function cleanupSessionState(sessionId: string): void {
   sessions.delete(sessionId)
   identityService.dropSession(sessionId)
   recordSessionEnd({ sessionId, kind: 'closed' })
+  // Close the transport + server AFTER the map delete so any
+  // reentrant onsessionclosed callback that the transport fires
+  // from inside its own close() sees the now-empty map and no-ops
+  // via the guard at the top of this function. Without these
+  // calls, long-lived SSE GET streams held by clients like
+  // codex-mcp-client stay open server-side until the client's
+  // TCP connection eventually drops, leaking a file descriptor
+  // and per-session memory for the interval between reap and
+  // organic disconnect.
+  void session.transport.close().catch((err) => {
+    logger.warn('session transport close threw', {
+      sessionId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  })
+  void session.server.close().catch((err) => {
+    logger.warn('session server close threw', {
+      sessionId,
+      error: err instanceof Error ? err.message : String(err),
+    })
+  })
   logger.info('cockpit v2 mcp session closed', { sessionId })
 }
 
@@ -266,4 +293,18 @@ export function setLastActivityForTesting(
   if (!session) return false
   session.lastActivityAt = ms
   return true
+}
+
+/**
+ * Test-only escape hatch. Returns the transport + server refs for a
+ * cached session so a test can install a spy on `.close()` before
+ * driving the sweeper. Returns null when the session id is unknown.
+ */
+export function getSessionRefsForTesting(sessionId: string): {
+  transport: WebStandardStreamableHTTPServerTransport
+  server: McpServer
+} | null {
+  const session = sessions.get(sessionId)
+  if (!session) return null
+  return { transport: session.transport, server: session.server }
 }

--- a/packages/browseros-agent/apps/claw-server/src/mcp/single-server.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/single-server.ts
@@ -17,6 +17,7 @@
 
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
+import { env } from '../env'
 import { tabGroupTracker } from '../lib/agent-tab-groups'
 import { getBrowserSession } from '../lib/browser-session'
 import { logger } from '../lib/logger'
@@ -39,9 +40,17 @@ const SERVER_VERSION = '0.0.1'
 interface Session {
   server: McpServer
   transport: WebStandardStreamableHTTPServerTransport
+  /**
+   * Wall-clock of the last inbound request that landed on this
+   * session. Bumped by `handleSingleMcpRequest`. The idle sweeper
+   * tears down sessions whose `lastActivityAt` is older than
+   * `env.sessionIdleMs`.
+   */
+  lastActivityAt: number
 }
 
 const sessions = new Map<string, Session>()
+let sweeperHandle: ReturnType<typeof setInterval> | null = null
 
 function resolveIdentity(sessionId: string | undefined): ClientIdentity | null {
   if (!sessionId) return null
@@ -61,23 +70,7 @@ function buildSession(): Session {
     sessionIdGenerator: () => crypto.randomUUID(),
     enableJsonResponse: true,
     onsessionclosed(sessionId) {
-      // Read identity BEFORE dropping it so the cleanup hook can
-      // resolve the agentId.
-      const identity = identityService.getIdentity(sessionId)
-      if (identity) {
-        const { agentId } = agentIdentityFromClient(identity)
-        const browserSession = getBrowserSession()
-        if (browserSession) {
-          void closeAgentTabGroupForAgent({
-            agentId,
-            session: browserSession,
-          })
-        }
-      }
-      sessions.delete(sessionId)
-      identityService.dropSession(sessionId)
-      recordSessionEnd({ sessionId, kind: 'closed' })
-      logger.info('cockpit v2 mcp session closed', { sessionId })
+      cleanupSessionState(sessionId)
     },
   })
 
@@ -133,7 +126,78 @@ function buildSession(): Session {
     })
   }
 
-  return { server, transport }
+  return { server, transport, lastActivityAt: Date.now() }
+}
+
+/**
+ * Shared end-of-session cleanup. The explicit DELETE path (transport
+ * `onsessionclosed` callback) and the idle sweeper both call this.
+ * Idempotent: if the session is already gone from the map, return
+ * without firing side effects so repeated sweeps are safe.
+ */
+function cleanupSessionState(sessionId: string): void {
+  if (!sessions.has(sessionId)) return
+  // Read identity BEFORE dropping it so the cleanup hook can resolve
+  // the agentId for the tab-group close.
+  const identity = identityService.getIdentity(sessionId)
+  if (identity) {
+    const { agentId } = agentIdentityFromClient(identity)
+    const browserSession = getBrowserSession()
+    if (browserSession) {
+      // Decrements the tracker AND fires the CDP close on the
+      // BrowserOS side. Returns immediately if refCount > 0.
+      void closeAgentTabGroupForAgent({
+        agentId,
+        session: browserSession,
+      })
+    } else {
+      // No live browser session. Still decrement so the ref count
+      // stays accurate; the CDP close is moot because there is no
+      // browser to dispatch to.
+      tabGroupTracker.decrementSession(agentId)
+    }
+  }
+  sessions.delete(sessionId)
+  identityService.dropSession(sessionId)
+  recordSessionEnd({ sessionId, kind: 'closed' })
+  logger.info('cockpit v2 mcp session closed', { sessionId })
+}
+
+/**
+ * Walks the sessions map and tears down entries older than the
+ * configured idle window. Exported for unit testing; production
+ * callers drive it via the `setInterval` started in
+ * `ensureSweeperStarted`. Returns the ids that were swept so tests
+ * can assert directly without timer manipulation.
+ */
+export function sweepIdleSessions(now: number): string[] {
+  const idle: string[] = []
+  for (const [sessionId, session] of sessions.entries()) {
+    if (now - session.lastActivityAt > env.sessionIdleMs) {
+      idle.push(sessionId)
+    }
+  }
+  for (const sessionId of idle) cleanupSessionState(sessionId)
+  return idle
+}
+
+function ensureSweeperStarted(): void {
+  if (sweeperHandle !== null) return
+  sweeperHandle = setInterval(() => {
+    sweepIdleSessions(Date.now())
+  }, env.sessionSweepIntervalMs)
+  // The cockpit's HTTP server is the lifecycle anchor; the sweep
+  // timer must not pin the bun process on its own. `unref` is
+  // present on Node-style Timeout values but not part of the
+  // Web-standard typing, so we feature-detect rather than assert.
+  const handle = sweeperHandle as { unref?: () => void }
+  handle.unref?.()
+}
+
+function stopSweeper(): void {
+  if (sweeperHandle === null) return
+  clearInterval(sweeperHandle)
+  sweeperHandle = null
 }
 
 /**
@@ -150,6 +214,7 @@ export async function handleSingleMcpRequest(
   if (headerSessionId) {
     const existing = sessions.get(headerSessionId)
     if (existing) {
+      existing.lastActivityAt = Date.now()
       return existing.transport.handleRequest(request)
     }
     // Unknown session id. Reject upfront with a structured 404 so
@@ -173,14 +238,32 @@ export async function handleSingleMcpRequest(
   const assignedId = session.transport.sessionId
   if (assignedId) {
     sessions.set(assignedId, session)
+    ensureSweeperStarted()
   }
   return response
 }
 
 /**
- * Test-only escape hatch. Drops every cached session so a subsequent
- * request rebuilds from scratch.
+ * Test-only escape hatch. Drops every cached session AND stops the
+ * idle sweeper interval so subsequent tests rebuild from scratch
+ * without leaking timers across cases.
  */
 export function resetSingleMcpInstanceForTesting(): void {
+  stopSweeper()
   sessions.clear()
+}
+
+/**
+ * Test-only escape hatch. Backdates a session's lastActivityAt so
+ * the sweeper sees it as idle without the test having to sleep.
+ * Returns true if the session existed.
+ */
+export function setLastActivityForTesting(
+  sessionId: string,
+  ms: number,
+): boolean {
+  const session = sessions.get(sessionId)
+  if (!session) return false
+  session.lastActivityAt = ms
+  return true
 }

--- a/packages/browseros-agent/apps/claw-server/src/mcp/single-server.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/single-server.ts
@@ -19,6 +19,7 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
 import { env } from '../env'
 import { tabGroupTracker } from '../lib/agent-tab-groups'
+import { agentTabs } from '../lib/agent-tabs'
 import { getBrowserSession } from '../lib/browser-session'
 import { logger } from '../lib/logger'
 import {
@@ -162,6 +163,9 @@ function cleanupSessionState(sessionId: string): void {
       // browser to dispatch to.
       tabGroupTracker.decrementSession(agentId)
     }
+    // Drop the per-agent tabs ledger so the next session for this
+    // agentId starts empty. Symmetric with the tab-group tracker.
+    agentTabs.forgetAgent(agentId)
   }
   sessions.delete(sessionId)
   identityService.dropSession(sessionId)

--- a/packages/browseros-agent/apps/claw-server/tests/lib/agent-tabs.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/lib/agent-tabs.test.ts
@@ -1,0 +1,89 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Pure unit tests for the per-agent tabs ledger. The ledger backs
+ * the isolation guarantees in register.ts (cross-agent page guard +
+ * tabs list filter) and is dropped from cleanupSessionState so a
+ * new session for the same agentId starts empty.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { createAgentTabsRegistry } from '../../src/lib/agent-tabs'
+
+describe('agentTabs registry', () => {
+  it('markOpened + ownedBy roundtrip returns the recorded page ids', () => {
+    const r = createAgentTabsRegistry()
+    r.markOpened('claude-code', 1)
+    r.markOpened('claude-code', 3)
+    r.markOpened('claude-code', 7)
+    expect([...r.ownedBy('claude-code')].sort((a, b) => a - b)).toEqual([
+      1, 3, 7,
+    ])
+  })
+
+  it('ownedBy on an unknown agent returns an empty set (never throws)', () => {
+    const r = createAgentTabsRegistry()
+    const owned = r.ownedBy('never-seen')
+    expect(owned.size).toBe(0)
+    expect(owned.has(1)).toBe(false)
+  })
+
+  it('markClosed removes a single page id', () => {
+    const r = createAgentTabsRegistry()
+    r.markOpened('claude-code', 1)
+    r.markOpened('claude-code', 2)
+    r.markClosed('claude-code', 1)
+    expect([...r.ownedBy('claude-code')]).toEqual([2])
+  })
+
+  it('markClosed of the last page id drops the whole agent entry', () => {
+    const r = createAgentTabsRegistry()
+    r.markOpened('claude-code', 1)
+    expect(r.size()).toBe(1)
+    r.markClosed('claude-code', 1)
+    expect(r.size()).toBe(0)
+    expect(r.ownedBy('claude-code').size).toBe(0)
+  })
+
+  it('markClosed for an unknown pair is a no-op', () => {
+    const r = createAgentTabsRegistry()
+    r.markOpened('claude-code', 1)
+    r.markClosed('claude-code', 99) // was never opened
+    r.markClosed('cursor', 1) // unknown agent
+    expect([...r.ownedBy('claude-code')]).toEqual([1])
+    expect(r.size()).toBe(1)
+  })
+
+  it('forgetAgent drops all pages for that agent only', () => {
+    const r = createAgentTabsRegistry()
+    r.markOpened('claude-code', 1)
+    r.markOpened('claude-code', 2)
+    r.markOpened('cursor', 5)
+    r.forgetAgent('claude-code')
+    expect(r.ownedBy('claude-code').size).toBe(0)
+    expect([...r.ownedBy('cursor')]).toEqual([5])
+    expect(r.size()).toBe(1)
+  })
+
+  it("two agents are isolated: one agent cannot see the other's pages", () => {
+    const r = createAgentTabsRegistry()
+    r.markOpened('claude-code', 1)
+    r.markOpened('claude-code', 2)
+    r.markOpened('cursor', 10)
+    expect([...r.ownedBy('claude-code')].sort((a, b) => a - b)).toEqual([1, 2])
+    expect([...r.ownedBy('cursor')]).toEqual([10])
+    expect(r.ownedBy('claude-code').has(10)).toBe(false)
+    expect(r.ownedBy('cursor').has(1)).toBe(false)
+  })
+
+  it('clear resets the whole registry (test-only escape hatch)', () => {
+    const r = createAgentTabsRegistry()
+    r.markOpened('a', 1)
+    r.markOpened('b', 2)
+    r.clear()
+    expect(r.size()).toBe(0)
+    expect(r.ownedBy('a').size).toBe(0)
+  })
+})

--- a/packages/browseros-agent/apps/claw-server/tests/mcp/session-idle-reaper.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/mcp/session-idle-reaper.test.ts
@@ -24,6 +24,7 @@ import { env } from '../../src/env'
 import { tabGroupTracker } from '../../src/lib/agent-tab-groups'
 import { identityService } from '../../src/lib/mcp-session'
 import {
+  getSessionRefsForTesting,
   resetSingleMcpInstanceForTesting,
   setLastActivityForTesting,
   sweepIdleSessions,
@@ -152,6 +153,39 @@ describe('sweepIdleSessions', () => {
       expect(identityService.getIdentity(b.sessionId)).not.toBeNull()
       await a.client.close()
       await b.client.close()
+    }
+  })
+
+  test('reap calls transport.close() so long-lived SSE streams do not leak', async () => {
+    // Without transport.close(), SSE GET streams held by clients
+    // like codex-mcp-client / claude-code stay open server-side
+    // until the client's TCP connection eventually drops. Assert
+    // close() actually fires on reap by installing spies on the
+    // transport and server before we backdate + sweep.
+    {
+      const { client, sessionId } = await connect('codex-mcp-client')
+      const refs = getSessionRefsForTesting(sessionId)
+      expect(refs).not.toBeNull()
+      if (!refs) throw new Error('refs must exist')
+      let transportClosed = 0
+      let serverClosed = 0
+      const origTransportClose = refs.transport.close.bind(refs.transport)
+      const origServerClose = refs.server.close.bind(refs.server)
+      refs.transport.close = async () => {
+        transportClosed++
+        return origTransportClose()
+      }
+      refs.server.close = async () => {
+        serverClosed++
+        return origServerClose()
+      }
+
+      setLastActivityForTesting(sessionId, Date.now() - 10_000)
+      const swept = sweepIdleSessions(Date.now())
+      expect(swept).toEqual([sessionId])
+      expect(transportClosed).toBe(1)
+      expect(serverClosed).toBe(1)
+      await client.close()
     }
   })
 })

--- a/packages/browseros-agent/apps/claw-server/tests/mcp/session-idle-reaper.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/mcp/session-idle-reaper.test.ts
@@ -1,0 +1,157 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Pins the idle-reaper behaviour for the v2 MCP single endpoint.
+ * Pre-fix, sessions stayed in the in-memory map forever unless the
+ * client sent an explicit `DELETE /mcp`; codex and most other
+ * clients do not, so `agent_session_ends` never got a row and the
+ * agent's tab group leaked. The sweeper here writes the same end
+ * row and fires the same tab-group close that the explicit DELETE
+ * path always did, on the same `IDLE_TIMEOUT_MS` boundary that
+ * `services/tasks.ts:deriveStatus` already used at read time.
+ *
+ * `sweepIdleSessions(now)` is exported so tests can drive a
+ * deterministic clock without manipulating timers.
+ */
+
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { eq } from 'drizzle-orm'
+import { env } from '../../src/env'
+import { tabGroupTracker } from '../../src/lib/agent-tab-groups'
+import { identityService } from '../../src/lib/mcp-session'
+import {
+  resetSingleMcpInstanceForTesting,
+  setLastActivityForTesting,
+  sweepIdleSessions,
+} from '../../src/mcp/single-server'
+import {
+  getAuditDb,
+  resetAuditDbForTesting,
+  setAuditDbForTesting,
+} from '../../src/modules/db/db'
+import { agentSessionEnds } from '../../src/modules/db/schema/schema'
+import app from '../../src/server'
+
+async function connect(clientName: string) {
+  const transport = new StreamableHTTPClientTransport(
+    new URL('http://localhost/mcp'),
+    {
+      fetch: ((input, init) =>
+        app.fetch(new Request(input, init))) as typeof fetch,
+    },
+  )
+  const client = new Client(
+    { name: clientName, version: '0.0.1' },
+    { capabilities: {} },
+  )
+  await client.connect(transport)
+  const sessionId = transport.sessionId
+  if (!sessionId) throw new Error('no session id assigned')
+  return { client, sessionId }
+}
+
+function endRowsFor(sessionId: string): Array<{ kind: string }> {
+  return getAuditDb()
+    .select({ kind: agentSessionEnds.kind })
+    .from(agentSessionEnds)
+    .where(eq(agentSessionEnds.sessionId, sessionId))
+    .all()
+}
+
+const ORIGINAL_IDLE = env.sessionIdleMs
+
+describe('sweepIdleSessions', () => {
+  beforeEach(() => {
+    setAuditDbForTesting()
+    resetSingleMcpInstanceForTesting()
+    identityService.clear()
+    tabGroupTracker.reset()
+    env.sessionIdleMs = 50
+  })
+  afterEach(() => {
+    resetSingleMcpInstanceForTesting()
+    identityService.clear()
+    tabGroupTracker.reset()
+    env.sessionIdleMs = ORIGINAL_IDLE
+    resetAuditDbForTesting()
+  })
+
+  test('reaps a session whose lastActivityAt is older than the idle window', async () => {
+    {
+      const { client, sessionId } = await connect('codex-mcp-client')
+      expect(identityService.size()).toBe(1)
+      // Backdate the session well past env.sessionIdleMs and sweep
+      // against a `now` that is current. The reaper should drop it.
+      setLastActivityForTesting(sessionId, Date.now() - 10_000)
+      const swept = sweepIdleSessions(Date.now())
+      expect(swept).toEqual([sessionId])
+      expect(identityService.getIdentity(sessionId)).toBeNull()
+      // agent_session_ends has the closed row.
+      const rows = endRowsFor(sessionId)
+      expect(rows).toHaveLength(1)
+      expect(rows[0]?.kind).toBe('closed')
+      await client.close()
+    }
+  })
+
+  test('does NOT reap a session whose lastActivityAt is recent', async () => {
+    {
+      const { client, sessionId } = await connect('codex-mcp-client')
+      // Recent activity: do not backdate. Sweep with `now` only
+      // slightly ahead; the gap is below env.sessionIdleMs (50ms).
+      const swept = sweepIdleSessions(Date.now() + 10)
+      expect(swept).toEqual([])
+      expect(identityService.getIdentity(sessionId)).not.toBeNull()
+      expect(endRowsFor(sessionId)).toEqual([])
+      await client.close()
+    }
+  })
+
+  test('a second sweep against the same idle session is a no-op (idempotent)', async () => {
+    {
+      const { client, sessionId } = await connect('codex-mcp-client')
+      setLastActivityForTesting(sessionId, Date.now() - 10_000)
+      expect(sweepIdleSessions(Date.now())).toEqual([sessionId])
+      // Second sweep: nothing to reap. cleanupSessionState is
+      // gated on `sessions.has(sessionId)` so no double-write.
+      expect(sweepIdleSessions(Date.now())).toEqual([])
+      expect(endRowsFor(sessionId)).toHaveLength(1)
+      await client.close()
+    }
+  })
+
+  test('reaping decrements the tab-group tracker so the agent group can be closed', async () => {
+    {
+      const { client, sessionId } = await connect('codex-mcp-client')
+      // The initialized notification called tabGroupTracker
+      // .incrementSession('codex-mcp-client'). After reap, the
+      // ref count goes back to 0 and getByAgentId returns null
+      // (closeAgentTabGroupForAgent calls decrementSession which
+      // removes the record when refCount hits 0).
+      expect(tabGroupTracker.getByAgentId('codex-mcp-client')).not.toBeNull()
+      setLastActivityForTesting(sessionId, Date.now() - 10_000)
+      sweepIdleSessions(Date.now())
+      expect(tabGroupTracker.getByAgentId('codex-mcp-client')).toBeNull()
+      await client.close()
+    }
+  })
+
+  test('two sessions: only the idle one is reaped, the active stays', async () => {
+    {
+      const a = await connect('codex-mcp-client')
+      const b = await connect('claude-code')
+      setLastActivityForTesting(a.sessionId, Date.now() - 10_000)
+      // b stays fresh.
+      const swept = sweepIdleSessions(Date.now())
+      expect(swept).toEqual([a.sessionId])
+      expect(identityService.getIdentity(a.sessionId)).toBeNull()
+      expect(identityService.getIdentity(b.sessionId)).not.toBeNull()
+      await a.client.close()
+      await b.client.close()
+    }
+  })
+})

--- a/packages/browseros-agent/apps/claw-server/tests/mcp/tabs-isolation.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/mcp/tabs-isolation.test.ts
@@ -1,0 +1,395 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Integration tests for the per-agent tabs isolation. Drives the
+ * real v2 MCP dispatch handler via the SDK client + a mocked
+ * executeTool, then asserts:
+ *
+ *   - `tabs new` populates the ledger; the follow-up `tabs list`
+ *     returns only the newly-opened page (in both text and
+ *     structured channels).
+ *   - Two connected sessions with different agentIds are isolated:
+ *     one agent's list does NOT include the other's pages.
+ *   - `tabs close` drops the page from the ledger.
+ *   - A page-targeted dispatch with a foreign `page` id is rejected
+ *     with the clean error BEFORE `executeTool` fires.
+ *   - After the session is reaped (cleanupSessionState via the idle
+ *     sweeper), the agent's ledger is empty; a new session for the
+ *     same agentId sees `(no open pages)`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+
+interface CallEntry {
+  toolName: string
+  args: Record<string, unknown>
+}
+
+interface FakeResult {
+  isError: boolean
+  content: Array<{ type: 'text'; text: string }>
+  structuredContent?: unknown
+}
+
+const calls: CallEntry[] = []
+const queued: FakeResult[] = []
+
+function nextResult(toolName: string): FakeResult {
+  const r = queued.shift()
+  if (!r) {
+    throw new Error(`tabs-isolation.test: no queued result for ${toolName}`)
+  }
+  return r
+}
+
+// Preserve the framework's other exports so BROWSER_TOOLS loads.
+const realFramework = await import('@browseros/browser-mcp/tools/framework')
+mock.module('@browseros/browser-mcp/tools/framework', () => ({
+  ...realFramework,
+  executeTool: async (def: { name: string }, args: Record<string, unknown>) => {
+    calls.push({ toolName: def.name, args })
+    return nextResult(def.name)
+  },
+}))
+
+function queue(...results: FakeResult[]): void {
+  queued.push(...results)
+}
+function ok(structured?: unknown): FakeResult {
+  return {
+    isError: false,
+    content: [{ type: 'text', text: 'ok' }],
+    structuredContent: structured,
+  }
+}
+
+const { setBrowserSession } = await import('../../src/lib/browser-session')
+const { agentTabs } = await import('../../src/lib/agent-tabs')
+const { tabActivityRegistry } = await import('../../src/lib/tab-activity')
+const { tabGroupTracker } = await import('../../src/lib/agent-tab-groups')
+const { identityService } = await import('../../src/lib/mcp-session')
+const {
+  resetSingleMcpInstanceForTesting,
+  setLastActivityForTesting,
+  sweepIdleSessions,
+} = await import('../../src/mcp/single-server')
+const { env } = await import('../../src/env')
+const { setAuditDbForTesting, resetAuditDbForTesting } = await import(
+  '../../src/modules/db/db'
+)
+const app = (await import('../../src/server')).default
+
+function stubSessionForPage(
+  pageId: number,
+  targetId: string,
+  url = 'https://example.com/',
+  title = 'Ex',
+): void {
+  setBrowserSession({
+    pages: {
+      getInfo: (id: number) =>
+        id === pageId ? { targetId, url, title } : undefined,
+    },
+    // biome-ignore lint/suspicious/noExplicitAny: test stub
+  } as any)
+}
+
+async function connect(clientName: string) {
+  const transport = new StreamableHTTPClientTransport(
+    new URL('http://localhost/mcp'),
+    {
+      fetch: ((input, init) =>
+        app.fetch(new Request(input, init))) as typeof fetch,
+    },
+  )
+  const client = new Client(
+    { name: clientName, version: '0.0.1' },
+    { capabilities: {} },
+  )
+  await client.connect(transport)
+  const sessionId = transport.sessionId
+  if (!sessionId) throw new Error('no session id assigned')
+  return { client, sessionId }
+}
+
+interface TabsListResult {
+  isError?: boolean
+  content?: Array<{ type: string; text?: string }>
+  structuredContent?: {
+    pages?: Array<{ page: number; url?: string; title?: string }>
+  }
+}
+
+const ORIGINAL_IDLE = env.sessionIdleMs
+
+describe('per-agent tabs isolation', () => {
+  beforeEach(() => {
+    setAuditDbForTesting()
+    calls.length = 0
+    queued.length = 0
+    resetSingleMcpInstanceForTesting()
+    identityService.clear()
+    tabGroupTracker.reset()
+    tabActivityRegistry.clear()
+    agentTabs.clear()
+    env.sessionIdleMs = 50
+  })
+  afterEach(() => {
+    queued.length = 0
+    resetSingleMcpInstanceForTesting()
+    identityService.clear()
+    tabGroupTracker.reset()
+    tabActivityRegistry.clear()
+    agentTabs.clear()
+    setBrowserSession(null)
+    env.sessionIdleMs = ORIGINAL_IDLE
+    resetAuditDbForTesting()
+  })
+
+  it('tabs new populates the ledger; follow-up tabs list returns only that page', async () => {
+    stubSessionForPage(7, 'target-7', 'https://news.google.com/', 'News')
+    // Queue: tabs new -> ensureAgentTabGroup fires create + update ->
+    // then tabs list underlying result contains BOTH the agent's tab
+    // AND the operator's tab. The cockpit filter should reduce it.
+    queue(
+      ok({ page: 7 }), // tabs new
+      ok({ group: { groupId: 'G1', windowId: 42 } }), // tab_groups create
+      ok(), // tab_groups update (colour)
+      ok({
+        pages: [
+          { page: 7, url: 'https://news.google.com/', title: 'News' },
+          { page: 42, url: 'https://operator.example/', title: "Op's tab" },
+        ],
+      }),
+    )
+    const { client } = await connect('claude-code')
+    await client.callTool({
+      name: 'tabs',
+      arguments: { action: 'new', url: 'https://news.google.com/' },
+    })
+    expect([...agentTabs.ownedBy('claude-code')]).toEqual([7])
+    const listResult = (await client.callTool({
+      name: 'tabs',
+      arguments: { action: 'list' },
+    })) as TabsListResult
+    expect(listResult.isError).toBeFalsy()
+    expect(listResult.structuredContent?.pages).toEqual([
+      { page: 7, url: 'https://news.google.com/', title: 'News' },
+    ])
+    const text = (
+      listResult.content as Array<{ type: string; text?: string }>
+    )?.[0]?.text
+    expect(text).toContain('[7] https://news.google.com/')
+    expect(text).not.toContain("Op's tab")
+    expect(text).not.toContain('operator.example')
+    await client.close()
+  })
+
+  it('two agents are isolated: one agent list does not include the other agent pages', async () => {
+    // Two connected sessions.
+    // agent-a opens page 1, agent-b opens page 2.
+    // Both call tabs list and see only their own.
+    stubSessionForPage(1, 't1', 'https://a.example/', 'A')
+    // agent-a: tabs new (page 1) + tab_groups create + update
+    queue(ok({ page: 1 }), ok({ group: { groupId: 'GA', windowId: 1 } }), ok())
+    const a = await connect('claude-code')
+    await a.client.callTool({
+      name: 'tabs',
+      arguments: { action: 'new', url: 'https://a.example/' },
+    })
+
+    // Switch session stub to a page id both agents can see (agent-b
+    // opens page 2 while page 1 also exists). We stub pages 1 and 2.
+    setBrowserSession({
+      pages: {
+        getInfo: (id: number) =>
+          id === 1
+            ? {
+                targetId: 't1',
+                url: 'https://a.example/',
+                title: 'A',
+              }
+            : id === 2
+              ? {
+                  targetId: 't2',
+                  url: 'https://b.example/',
+                  title: 'B',
+                }
+              : undefined,
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: test stub
+    } as any)
+    // agent-b: tabs new (page 2) + tab_groups create + update
+    queue(ok({ page: 2 }), ok({ group: { groupId: 'GB', windowId: 1 } }), ok())
+    const b = await connect('cursor')
+    await b.client.callTool({
+      name: 'tabs',
+      arguments: { action: 'new', url: 'https://b.example/' },
+    })
+
+    // Underlying tabs list returns BOTH pages plus operator tab 99.
+    // Filter must reduce per-agent.
+    const opTabs = [
+      { page: 1, url: 'https://a.example/', title: 'A' },
+      { page: 2, url: 'https://b.example/', title: 'B' },
+      { page: 99, url: 'https://operator.example/', title: 'Op' },
+    ]
+    queue(ok({ pages: opTabs }))
+    const listA = (await a.client.callTool({
+      name: 'tabs',
+      arguments: { action: 'list' },
+    })) as TabsListResult
+    expect(listA.structuredContent?.pages).toEqual([opTabs[0]])
+
+    queue(ok({ pages: opTabs }))
+    const listB = (await b.client.callTool({
+      name: 'tabs',
+      arguments: { action: 'list' },
+    })) as TabsListResult
+    expect(listB.structuredContent?.pages).toEqual([opTabs[1]])
+
+    await a.client.close()
+    await b.client.close()
+  })
+
+  it('tabs list on an empty ledger returns "(no open pages)"', async () => {
+    setBrowserSession({
+      pages: {
+        getInfo: (_id: number) => undefined,
+      },
+      // biome-ignore lint/suspicious/noExplicitAny: test stub
+    } as any)
+    // Underlying tool returns some operator tabs; filter drops them.
+    queue(
+      ok({
+        pages: [
+          { page: 100, url: 'https://only-operator.example/', title: 'Op' },
+        ],
+      }),
+    )
+    const { client } = await connect('claude-code')
+    const list = (await client.callTool({
+      name: 'tabs',
+      arguments: { action: 'list' },
+    })) as TabsListResult
+    expect(list.structuredContent?.pages).toEqual([])
+    expect(
+      (list.content as Array<{ type: string; text?: string }>)?.[0]?.text,
+    ).toBe('(no open pages)')
+    await client.close()
+  })
+
+  it('tabs close drops the page from the ledger', async () => {
+    stubSessionForPage(5, 't5')
+    queue(
+      ok({ page: 5 }), // tabs new
+      ok({ group: { groupId: 'G', windowId: 1 } }),
+      ok(),
+      ok(), // tabs close
+    )
+    const { client } = await connect('claude-code')
+    await client.callTool({
+      name: 'tabs',
+      arguments: { action: 'new', url: 'https://x.com/' },
+    })
+    expect([...agentTabs.ownedBy('claude-code')]).toEqual([5])
+    // Now the operator (or the agent) closes page 5. The agentTabs
+    // ledger drops it. NB: tabs close takes `page` as input so the
+    // cross-agent guard sees the ownership check pass for our own
+    // page.
+    await client.callTool({
+      name: 'tabs',
+      arguments: { action: 'close', page: 5 },
+    })
+    expect([...agentTabs.ownedBy('claude-code')]).toEqual([])
+    await client.close()
+  })
+
+  it('foreign page argument is rejected BEFORE executeTool fires', async () => {
+    stubSessionForPage(7, 't7')
+    // Agent opens page 7.
+    queue(ok({ page: 7 }), ok({ group: { groupId: 'G', windowId: 1 } }), ok())
+    const { client } = await connect('claude-code')
+    await client.callTool({
+      name: 'tabs',
+      arguments: { action: 'new', url: 'https://x.com/' },
+    })
+    calls.length = 0 // reset the call log; we want to prove nothing new fires
+    // Attempt snapshot on FOREIGN page 42. Guard should short-circuit.
+    // We deliberately do NOT queue a result; if executeTool fires the
+    // test will throw ("no queued result").
+    const result = (await client.callTool({
+      name: 'snapshot',
+      arguments: { page: 42 },
+    })) as TabsListResult
+    expect(result.isError).toBeTruthy()
+    expect(
+      (result.content as Array<{ type: string; text?: string }>)?.[0]?.text,
+    ).toContain('page 42 is not owned')
+    expect(calls.length).toBe(0) // executeTool NEVER fired
+    await client.close()
+  })
+
+  it('agent can still snapshot its OWN page (guard does not overreach)', async () => {
+    stubSessionForPage(7, 't7')
+    queue(
+      ok({ page: 7 }),
+      ok({ group: { groupId: 'G', windowId: 1 } }),
+      ok(),
+      ok({ someSnapshotShape: true }), // snapshot result
+    )
+    const { client } = await connect('claude-code')
+    await client.callTool({
+      name: 'tabs',
+      arguments: { action: 'new', url: 'https://x.com/' },
+    })
+    const result = (await client.callTool({
+      name: 'snapshot',
+      arguments: { page: 7 },
+    })) as TabsListResult
+    expect(result.isError).toBeFalsy()
+    await client.close()
+  })
+
+  it('idle reap forgets the agent ledger; next session sees an empty list', async () => {
+    stubSessionForPage(7, 't7')
+    queue(ok({ page: 7 }), ok({ group: { groupId: 'G', windowId: 1 } }), ok())
+    const first = await connect('claude-code')
+    await first.client.callTool({
+      name: 'tabs',
+      arguments: { action: 'new', url: 'https://x.com/' },
+    })
+    expect([...agentTabs.ownedBy('claude-code')]).toEqual([7])
+
+    // Reap the session.
+    setLastActivityForTesting(first.sessionId, Date.now() - 10_000)
+    sweepIdleSessions(Date.now())
+    expect(agentTabs.ownedBy('claude-code').size).toBe(0)
+
+    // A fresh session for the same agentId (same clientName) starts
+    // empty and its tabs list should reflect that even though the
+    // underlying tool returns operator-owned pages.
+    queue(
+      ok({
+        pages: [
+          { page: 7, url: 'https://x.com/', title: 'Stale' },
+          { page: 99, url: 'https://operator.example/', title: 'Op' },
+        ],
+      }),
+    )
+    const second = await connect('claude-code')
+    const list = (await second.client.callTool({
+      name: 'tabs',
+      arguments: { action: 'list' },
+    })) as TabsListResult
+    expect(list.structuredContent?.pages).toEqual([])
+    expect(
+      (list.content as Array<{ type: string; text?: string }>)?.[0]?.text,
+    ).toBe('(no open pages)')
+    await second.client.close()
+  })
+})


### PR DESCRIPTION
## Summary

Two coupled fixes that together give MCP agents the guarantee: **one tab group per agent, cleanly closed on session end, cleanly re-opened on the next task, and the operator's active tabs are never touched.**

### Part 1: idle-session reaper

Most MCP clients (`codex-mcp-client`, `claude-code`, etc.) do not send `DELETE /mcp` between user prompts; they keep the session alive for the lifetime of the client process. Without an explicit end signal, `agent_session_ends` never got a row (task stayed `'live'` indefinitely in the audit) and the agent's tab group leaked in BrowserOS.

Fix: a server-side idle reaper.

- `Session` carries `lastActivityAt`, bumped on every inbound request in `handleSingleMcpRequest`.
- `cleanupSessionState(sessionId)` extracted from the existing `onsessionclosed` callback. Both the callback and the sweeper call it; idempotent, so repeated sweeps are safe.
- `sweepIdleSessions(now)` walks the map, returns the ids that were dropped, and calls `cleanupSessionState` on each. Exported for deterministic unit tests.
- `ensureSweeperStarted()` lazily installs the `setInterval` on first session creation; `unref()`-d so it never pins the bun process. `resetSingleMcpInstanceForTesting()` stops it so tests do not leak timers.
- `cleanupSessionState` also calls `session.transport.close()` and `session.server.close()` AFTER the map delete, so long-lived SSE streams do not leak file descriptors and memory (Greptile review feedback).
- Decrements the tab-group tracker even when no browser session is attached (test environment), so ref counts stay accurate.

### Part 2: per-agent tabs isolation

Once the reaper closes the tab group (with its tabs), an agent on the next task saw the operator's tabs via `tabs list` and its LLM could hijack them via `navigate` / `snapshot` / etc. This part shuts that off end-to-end.

- New per-agent ledger at `apps/claw-server/src/lib/agent-tabs`. `Map<agentId, Set<pageId>>`. Pure logic, unit tested independently.
- `register.ts` hooks in the dispatch handler:
  - **A**: `tabs new` success -> `agentTabs.markOpened(agentId, resultPageId)` alongside the existing tab-group + activity-registry work.
  - **B**: `tabs close` success -> `agentTabs.markClosed(agentId, argPage)`.
  - **C**: `tabs list` success -> `filterTabsListToAgent(result, ownedSet)` rewrites both channels. Empty survivors yield `(no open pages)` which matches the underlying tool's empty output so the LLM interprets it as "I have no tabs, open one" and dispatches `tabs new`.
  - **D**: BEFORE `executeTool`, for tools in `TOOLS_WITH_PAGE`, reject dispatches whose `page` argument is not in the calling agent's ledger. Error text: `page N is not owned by this agent; call \`tabs new\` to open a fresh page`. Never reaches the underlying tool. Fail-open when identity is unknown.
- `TOOLS_WITH_PAGE` exported from `lib/tab-activity` so both the registry attribution AND the isolation guard use the same allowlist.
- `single-server.ts::cleanupSessionState` also calls `agentTabs.forgetAgent(agentId)`, symmetric with the tab-group tracker decrement.

## Tunables (`env.ts`)

| env | default | meaning |
|---|---|---|
| `CLAW_SESSION_IDLE_MS` | 300000 (5 min) | Sessions older than this are reaped. Matches `services/tasks.ts:IDLE_TIMEOUT_MS`. |
| `CLAW_SESSION_SWEEP_INTERVAL_MS` | 60000 (60 s) | How often the sweep timer fires. |

## Test plan

- `tests/mcp/session-idle-reaper.test.ts` (6 cases): reap when idle; skip when fresh; idempotency; tab-group tracker decrement; multi-session; transport + server `.close()` fires on reap.
- `tests/lib/agent-tabs.test.ts` (8 pure unit tests): ledger open / close / drop-last-page / forget / two-agent isolation / clear.
- `tests/mcp/tabs-isolation.test.ts` (7 integration): `tabs new` populates ledger, follow-up `tabs list` returns only own tab; two agents isolated; empty ledger returns `(no open pages)`; `tabs close` drops from ledger; foreign `page` argument rejected BEFORE `executeTool` fires (asserts `calls.length === 0`); guard does not overreach on the agent's own page; idle reap forgets ledger, new session sees empty list.

claw-server suite: **352 pass, 0 fail** (baseline 316, +21 tests across both fixes). Typecheck clean.

## Scope notes

- Does NOT filter `tabs active` (returns whatever BrowserOS thinks is active). If the LLM constructs a hijack `page` arg from it, guard D still rejects.
- Does NOT touch `apps/server`; port there separately if the same class of bug hits.
- `transport.onerror` still records `'errored'` without dropping session state; the sweeper eventually reaps it as idle. Small clean-up worth its own PR.
- Issue 3 (no screenshots persisted) and the sub-5-min task-boundary case from Issue 5 are separate plans.