### PR TITLE
fix: complete bpatch annotate feature pass

### DIFF
--- a/packages/browseros/tools/patch/internal/engine/annotate.go
+++ b/packages/browseros/tools/patch/internal/engine/annotate.go
@@ -48,7 +48,6 @@ type annotateFeature struct {
 	Name        string
 	Description string
 	Files       []string
-	Index       int
 }
 
 type annotateFileSet struct {
@@ -61,10 +60,6 @@ type annotateFileSet struct {
 func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error) {
 	featuresFile := filepath.Join(opts.Repo.Root, "build", "features.yaml")
 	features, err := loadAnnotateFeatures(featuresFile)
-	if err != nil {
-		return nil, err
-	}
-	changes, err := annotateChanges(ctx, opts.Workspace.Path)
 	if err != nil {
 		return nil, err
 	}
@@ -86,7 +81,11 @@ func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error
 			result.FeaturesSkipped++
 			continue
 		}
-		files := modifiedFeatureFiles(changes, feature, features)
+		changes, err := annotateChanges(ctx, opts.Workspace.Path)
+		if err != nil {
+			return nil, err
+		}
+		files := modifiedFeatureFiles(changes, feature)
 		if len(files.report) == 0 {
 			result.Skipped = append(result.Skipped, AnnotateSkippedFeature{
 				Name:        feature.Name,
@@ -96,15 +95,24 @@ func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error
 			result.FeaturesSkipped++
 			continue
 		}
-		commit, err := commitFeatureFiles(ctx, opts.Workspace.Path, feature.Description, files.stage, files.commit)
+		commit, committedFiles, committed, err := commitFeatureFiles(ctx, opts.Workspace.Path, feature.Description, files.stage, files.commit)
 		if err != nil {
 			return nil, fmt.Errorf("commit feature %s: %w", feature.Name, err)
+		}
+		if !committed {
+			result.Skipped = append(result.Skipped, AnnotateSkippedFeature{
+				Name:        feature.Name,
+				Description: feature.Description,
+				Reason:      "no changes",
+			})
+			result.FeaturesSkipped++
+			continue
 		}
 		result.Committed = append(result.Committed, AnnotateCommittedFeature{
 			Name:        feature.Name,
 			Description: feature.Description,
 			Commit:      commit,
-			Files:       files.report,
+			Files:       committedFiles,
 		})
 		result.CommitsCreated++
 	}
@@ -139,7 +147,6 @@ func loadAnnotateFeatures(featuresFile string) ([]annotateFeature, error) {
 			Name:        name,
 			Description: description,
 			Files:       stringSequence(data, "files"),
-			Index:       len(features),
 		})
 	}
 	return features, nil
@@ -193,14 +200,13 @@ func annotateChanges(ctx context.Context, workspacePath string) ([]git.FileChang
 	return git.StatusPorcelain(ctx, workspacePath, nil)
 }
 
-func modifiedFeatureFiles(changes []git.FileChange, feature annotateFeature, allFeatures []annotateFeature) annotateFileSet {
+func modifiedFeatureFiles(changes []git.FileChange, feature annotateFeature) annotateFileSet {
 	set := annotateFileSet{}
 	reportSeen := map[string]bool{}
 	stageSeen := map[string]bool{}
 	commitSeen := map[string]bool{}
 	for _, change := range changes {
-		owner := ownerFeature(change, allFeatures)
-		if owner == nil || owner.Name != feature.Name {
+		if !featureMatchesChange(feature, change) {
 			continue
 		}
 		for _, rel := range changeReportPaths(change) {
@@ -219,43 +225,13 @@ func modifiedFeatureFiles(changes []git.FileChange, feature annotateFeature, all
 	return set
 }
 
-func ownerFeature(change git.FileChange, features []annotateFeature) *annotateFeature {
-	var owner *annotateFeature
-	bestScore := -1
-	for idx := range features {
-		score := featureChangeScore(features[idx], change)
-		if score < 0 {
-			continue
-		}
-		if score > bestScore || score == bestScore && owner != nil && features[idx].Index > owner.Index {
-			bestScore = score
-			owner = &features[idx]
-		}
-	}
-	return owner
-}
-
-func featureChangeScore(feature annotateFeature, change git.FileChange) int {
-	best := -1
+func featureMatchesChange(feature annotateFeature, change git.FileChange) bool {
 	for _, rel := range changeReportPaths(change) {
-		if score := featurePathScore(feature, rel); score > best {
-			best = score
+		if patch.PathMatches(rel, feature.Files) {
+			return true
 		}
 	}
-	return best
-}
-
-func featurePathScore(feature annotateFeature, rel string) int {
-	best := -1
-	for _, scope := range feature.Files {
-		if !patch.PathMatches(rel, []string{scope}) {
-			continue
-		}
-		if len(scope) > best {
-			best = len(scope)
-		}
-	}
-	return best
+	return false
 }
 
 func changeReportPaths(change git.FileChange) []string {
@@ -305,9 +281,41 @@ func appendUniquePath(paths *[]string, seen map[string]bool, rel string) {
 	*paths = append(*paths, rel)
 }
 
-func commitFeatureFiles(ctx context.Context, workspacePath string, message string, stagePaths []string, commitPaths []string) (string, error) {
+// commitFeatureFiles normalizes selected paths into the index and commits only real HEAD deltas.
+func commitFeatureFiles(ctx context.Context, workspacePath string, message string, stagePaths []string, commitPaths []string) (string, []string, bool, error) {
 	if err := git.AddAllPaths(ctx, workspacePath, stagePaths); err != nil {
-		return "", err
+		return "", nil, false, err
 	}
-	return git.CommitPaths(ctx, workspacePath, message, commitPaths)
+	dirty, err := git.IsDirtyPaths(ctx, workspacePath, commitPaths)
+	if err != nil {
+		return "", nil, false, err
+	}
+	if !dirty {
+		return "", nil, false, nil
+	}
+	commit, err := git.CommitPaths(ctx, workspacePath, message, commitPaths)
+	if err != nil {
+		return "", nil, false, err
+	}
+	committedFiles, err := committedFeatureFiles(ctx, workspacePath, commit, commitPaths)
+	if err != nil {
+		return "", nil, false, err
+	}
+	return commit, committedFiles, true, nil
+}
+
+func committedFeatureFiles(ctx context.Context, workspacePath string, commit string, commitPaths []string) ([]string, error) {
+	changes, err := git.DiffTreeNameStatus(ctx, workspacePath, commit, commitPaths)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	var paths []string
+	for _, change := range changes {
+		for _, rel := range changeReportPaths(change) {
+			appendUniquePath(&paths, seen, rel)
+		}
+	}
+	slices.Sort(paths)
+	return paths, nil
 }

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -180,7 +180,7 @@ features:
 	}
 }
 
-func TestAnnotateAssignsOverlappingPathsToMostSpecificFeature(t *testing.T) {
+func TestAnnotateProcessesOverlappingPathsInFeatureOrder(t *testing.T) {
 	ctx := context.Background()
 	workspacePath := initGitRepo(t)
 	writeFile(t, filepath.Join(workspacePath, "chrome", "browser", "browseros", "core", "shared.cc"), "shared\n")
@@ -212,20 +212,126 @@ features:
 	if err != nil {
 		t.Fatalf("Annotate: %v", err)
 	}
-	if result.CommitsCreated != 2 {
-		t.Fatalf("expected two commits, got %+v", result)
+	if result.CommitsCreated != 1 || result.FeaturesSkipped != 1 {
+		t.Fatalf("expected one commit and one skip, got %+v", result)
 	}
-	if !slices.Equal(result.Committed[0].Files, []string{"chrome/browser/browseros/core/shared.cc"}) {
-		t.Fatalf("core feature stole overlapping path: %v", result.Committed[0].Files)
+	if result.Committed[0].Name != "browseros-core" {
+		t.Fatalf("expected earlier feature to own overlapping path, got %+v", result.Committed[0])
 	}
-	if !slices.Equal(result.Committed[1].Files, []string{"chrome/browser/browseros/core/browseros_prefs.cc"}) {
-		t.Fatalf("specific feature did not own exact path: %v", result.Committed[1].Files)
+	if !slices.Equal(result.Committed[0].Files, []string{
+		"chrome/browser/browseros/core/browseros_prefs.cc",
+		"chrome/browser/browseros/core/shared.cc",
+	}) {
+		t.Fatalf("unexpected core files: %v", result.Committed[0].Files)
 	}
-	if files := strings.Split(gitOutput(t, workspacePath, "show", "--name-only", "--format=", "HEAD~1"), "\n"); !slices.Equal(files, []string{"chrome/browser/browseros/core/shared.cc"}) {
+	if result.Skipped[0].Name != "onboarding-import" || result.Skipped[0].Reason != "no changes" {
+		t.Fatalf("expected later feature to see no remaining change, got %+v", result.Skipped)
+	}
+	if files := strings.Split(gitOutput(t, workspacePath, "show", "--name-only", "--format=", "HEAD"), "\n"); !slices.Equal(files, result.Committed[0].Files) {
 		t.Fatalf("core commit files = %v", files)
 	}
-	if files := strings.Split(gitOutput(t, workspacePath, "show", "--name-only", "--format=", "HEAD"), "\n"); !slices.Equal(files, []string{"chrome/browser/browseros/core/browseros_prefs.cc"}) {
-		t.Fatalf("specific commit files = %v", files)
+	if status := gitOutput(t, workspacePath, "status", "--porcelain"); status != "" {
+		t.Fatalf("expected clean checkout after annotate, got %q", status)
+	}
+}
+
+func TestAnnotateSkipsStaleIndexWhenWorktreeMatchesHead(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	rel := "chrome/browser/browseros/core/browseros_prefs.cc"
+	writeFile(t, filepath.Join(workspacePath, rel), "base\n")
+	runGit(t, workspacePath, "add", rel)
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	writeFile(t, filepath.Join(workspacePath, rel), "patched\n")
+	runGit(t, workspacePath, "add", rel)
+	runGit(t, workspacePath, "commit", "-m", "existing patch")
+	head := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	runGit(t, workspacePath, "checkout", baseCommit, "--", rel)
+	writeFile(t, filepath.Join(workspacePath, rel), "patched\n")
+	if status := gitOutput(t, workspacePath, "status", "--porcelain", "--", rel); status != "MM "+rel {
+		t.Fatalf("test setup expected split index status, got %q", status)
+	}
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  browseros-core:
+    description: "chore: browseros core"
+    files:
+      - chrome/browser/browseros/core/
+`)
+
+	result, err := Annotate(ctx, AnnotateOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+	})
+	if err != nil {
+		t.Fatalf("Annotate: %v", err)
+	}
+	if result.CommitsCreated != 0 || result.FeaturesSkipped != 1 {
+		t.Fatalf("expected stale index no-op to skip cleanly, got %+v", result)
+	}
+	if got := gitOutput(t, workspacePath, "rev-parse", "HEAD"); got != head {
+		t.Fatalf("annotate should not create a commit: got HEAD %s want %s", got, head)
+	}
+	if status := gitOutput(t, workspacePath, "status", "--porcelain"); status != "" {
+		t.Fatalf("expected stale index to be cleaned, got %q", status)
+	}
+}
+
+func TestAnnotateReportsOnlyFilesIncludedInCommit(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	staleRel := "chrome/browser/browseros/core/stale.cc"
+	changedRel := "chrome/browser/browseros/core/changed.cc"
+	writeFile(t, filepath.Join(workspacePath, staleRel), "base stale\n")
+	writeFile(t, filepath.Join(workspacePath, changedRel), "base changed\n")
+	runGit(t, workspacePath, "add", "chrome")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	writeFile(t, filepath.Join(workspacePath, staleRel), "patched stale\n")
+	runGit(t, workspacePath, "add", staleRel)
+	runGit(t, workspacePath, "commit", "-m", "existing stale patch")
+
+	runGit(t, workspacePath, "checkout", baseCommit, "--", staleRel)
+	writeFile(t, filepath.Join(workspacePath, staleRel), "patched stale\n")
+	writeFile(t, filepath.Join(workspacePath, changedRel), "patched changed\n")
+	status := gitOutput(t, workspacePath, "status", "--porcelain", "--", staleRel, changedRel)
+	if !strings.Contains(status, changedRel) || !strings.Contains(status, "MM "+staleRel) {
+		t.Fatalf("test setup expected mixed status, got %q", status)
+	}
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  browseros-core:
+    description: "chore: browseros core"
+    files:
+      - chrome/browser/browseros/core/
+`)
+
+	result, err := Annotate(ctx, AnnotateOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+	})
+	if err != nil {
+		t.Fatalf("Annotate: %v", err)
+	}
+	if result.CommitsCreated != 1 {
+		t.Fatalf("expected one commit, got %+v", result)
+	}
+	if !slices.Equal(result.Committed[0].Files, []string{changedRel}) {
+		t.Fatalf("reported files should match actual commit files, got %v", result.Committed[0].Files)
+	}
+	if files := strings.Split(gitOutput(t, workspacePath, "show", "--name-only", "--format=", "HEAD"), "\n"); !slices.Equal(files, []string{changedRel}) {
+		t.Fatalf("commit files = %v", files)
+	}
+	if status := gitOutput(t, workspacePath, "status", "--porcelain"); status != "" {
+		t.Fatalf("expected clean checkout after annotate, got %q", status)
 	}
 }
 
@@ -269,7 +375,7 @@ features:
 	}
 }
 
-func TestAnnotateSpecificOldPathOwnsRenameFromBroadFeature(t *testing.T) {
+func TestAnnotateBroadFeatureOwnsRenameBeforeSpecificOldPath(t *testing.T) {
 	ctx := context.Background()
 	workspacePath := initGitRepo(t)
 	writeFile(t, filepath.Join(workspacePath, "chrome", "old.cc"), "old\n")
@@ -299,8 +405,8 @@ features:
 	if err != nil {
 		t.Fatalf("Annotate: %v", err)
 	}
-	if result.CommitsCreated != 1 || result.Committed[0].Name != "specific" {
-		t.Fatalf("expected specific feature to own rename, got %+v", result)
+	if result.CommitsCreated != 1 || result.Committed[0].Name != "broad" {
+		t.Fatalf("expected earlier broad feature to own rename, got %+v", result)
 	}
 	if !slices.Equal(result.Committed[0].Files, []string{"chrome/new.cc", "chrome/old.cc"}) {
 		t.Fatalf("unexpected rename files: %v", result.Committed[0].Files)
@@ -313,7 +419,7 @@ features:
 	}
 }
 
-func TestAnnotateSpecificNewPathOwnsRenameFromBroadFeature(t *testing.T) {
+func TestAnnotateBroadFeatureOwnsRenameBeforeSpecificNewPath(t *testing.T) {
 	ctx := context.Background()
 	workspacePath := initGitRepo(t)
 	writeFile(t, filepath.Join(workspacePath, "chrome", "old.cc"), "old\n")
@@ -343,8 +449,8 @@ features:
 	if err != nil {
 		t.Fatalf("Annotate: %v", err)
 	}
-	if result.CommitsCreated != 1 || result.Committed[0].Name != "specific" {
-		t.Fatalf("expected specific feature to own rename, got %+v", result)
+	if result.CommitsCreated != 1 || result.Committed[0].Name != "broad" {
+		t.Fatalf("expected earlier broad feature to own rename, got %+v", result)
 	}
 	if !slices.Equal(result.Committed[0].Files, []string{"chrome/new.cc", "chrome/old.cc"}) {
 		t.Fatalf("unexpected rename files: %v", result.Committed[0].Files)


### PR DESCRIPTION
## Summary
- Make `bpatch annotate` process `features.yaml` in order with fresh checkout status for each feature.
- Normalize apply-created split index entries before committing so stale no-op paths are cleaned instead of failing with `commit feature ...:`.
- Report actual files from the created commit, including rename old/new paths, instead of pre-stage candidates.

## Design
The Go annotator now mirrors the maintained Python annotation pipeline: each feature is evaluated against the current checkout state, staged only when it still has matching changes, and committed only if staging creates a real HEAD delta. This removes the stale one-shot ownership snapshot that failed after the first feature commit.

## Test plan
- [x] `go test ./internal/engine -run 'TestAnnotate'`
- [x] `go test ./...` in `packages/browseros/tools/patch`
- [x] `gofmt -l .` in `packages/browseros/tools/patch`
- [x] `go vet ./...` in `packages/browseros/tools/patch`
- [x] `go build ./...` in `packages/browseros/tools/patch`
- [x] `git diff --check`
- [x] `uv run python -m unittest build.modules.annotate.annotate_test` in `packages/browseros`