### PR TITLE
fix: warn when patches repo is stale

### DIFF
--- a/packages/browseros/tools/patch/cmd/root.go
+++ b/packages/browseros/tools/patch/cmd/root.go
@@ -111,7 +111,11 @@ Pass a checkout name to run from anywhere, for example "browseros-patch diff ch1
 		}
 		var err error
 		appState, err = app.Load(jsonOut, verbose, "")
-		return err
+		if err != nil {
+			return err
+		}
+		warnIfPatchesRepoDrift(cmd)
+		return nil
 	},
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if llmTxt {

--- a/packages/browseros/tools/patch/cmd/stale_warning.go
+++ b/packages/browseros/tools/patch/cmd/stale_warning.go
@@ -1,0 +1,135 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/git"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/repo"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+const patchesRepoDriftTimeout = 5 * time.Second
+
+type patchesRepoDrift struct {
+	LocalAhead  int
+	RemoteAhead int
+}
+
+func (d patchesRepoDrift) hasDrift() bool {
+	return d.LocalAhead > 0 || d.RemoteAhead > 0
+}
+
+// warnIfPatchesRepoDrift prints a non-fatal freshness warning for the active patches repo.
+func warnIfPatchesRepoDrift(cmd *cobra.Command) {
+	repoPath := patchesRepoWarningPath()
+	if repoPath == "" {
+		return
+	}
+	baseCtx := cmd.Context()
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+	ctx, cancel := context.WithTimeout(baseCtx, patchesRepoDriftTimeout)
+	defer cancel()
+
+	drift, err := patchesRepoRemoteDrift(ctx, repoPath)
+	if err != nil || !drift.hasDrift() {
+		return
+	}
+	fmt.Fprintln(cmd.ErrOrStderr(), formatPatchesRepoDriftWarning(repoPath, drift))
+}
+
+func patchesRepoWarningPath() string {
+	if appState == nil {
+		return ""
+	}
+	if appState.Config != nil && appState.Config.PatchesRepo != "" {
+		return appState.Config.PatchesRepo
+	}
+	if appState.CWD == "" {
+		return ""
+	}
+	discovered, err := repo.Discover(appState.CWD)
+	if err != nil {
+		return ""
+	}
+	return discovered
+}
+
+// patchesRepoRemoteDrift fetches origin/main and counts commits on each side of HEAD.
+func patchesRepoRemoteDrift(ctx context.Context, repoPath string) (patchesRepoDrift, error) {
+	result, err := git.Run(ctx, repoPath, nil, "fetch", "--quiet", "origin", "+refs/heads/main:refs/remotes/origin/main")
+	if err != nil {
+		return patchesRepoDrift{}, err
+	}
+	if result.Code != 0 {
+		return patchesRepoDrift{}, gitResultError(result)
+	}
+
+	result, err = git.Run(ctx, repoPath, nil, "rev-list", "--left-right", "--count", "HEAD...origin/main")
+	if err != nil {
+		return patchesRepoDrift{}, err
+	}
+	if result.Code != 0 {
+		return patchesRepoDrift{}, gitResultError(result)
+	}
+
+	fields := strings.Fields(result.Stdout)
+	if len(fields) != 2 {
+		return patchesRepoDrift{}, fmt.Errorf("unexpected rev-list output: %q", strings.TrimSpace(result.Stdout))
+	}
+	localAhead, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return patchesRepoDrift{}, fmt.Errorf("parse local drift: %w", err)
+	}
+	remoteAhead, err := strconv.Atoi(fields[1])
+	if err != nil {
+		return patchesRepoDrift{}, fmt.Errorf("parse remote drift: %w", err)
+	}
+	return patchesRepoDrift{LocalAhead: localAhead, RemoteAhead: remoteAhead}, nil
+}
+
+func formatPatchesRepoDriftWarning(repoPath string, drift patchesRepoDrift) string {
+	return fmt.Sprintf(
+		"%s patches repo differs from origin/main: %s\n%s %s",
+		ui.Warning("Warning:"),
+		patchesRepoDriftMessage(drift),
+		ui.Muted("path:"),
+		repoPath,
+	)
+}
+
+func patchesRepoDriftMessage(drift patchesRepoDrift) string {
+	var parts []string
+	if drift.RemoteAhead > 0 {
+		parts = append(parts, fmt.Sprintf("remote is %d %s ahead", drift.RemoteAhead, commitNoun(drift.RemoteAhead)))
+	}
+	if drift.LocalAhead > 0 {
+		parts = append(parts, fmt.Sprintf("local is %d %s ahead", drift.LocalAhead, commitNoun(drift.LocalAhead)))
+	}
+	return strings.Join(parts, " and ") + "."
+}
+
+func commitNoun(count int) string {
+	if count == 1 {
+		return "commit"
+	}
+	return "commits"
+}
+
+func gitResultError(result git.Result) error {
+	message := strings.TrimSpace(result.Stderr)
+	if message == "" {
+		message = strings.TrimSpace(result.Stdout)
+	}
+	if message == "" {
+		message = fmt.Sprintf("git exited with status %d", result.Code)
+	}
+	return errors.New(message)
+}

--- a/packages/browseros/tools/patch/cmd/stale_warning.go
+++ b/packages/browseros/tools/patch/cmd/stale_warning.go
@@ -27,7 +27,7 @@ func (d patchesRepoDrift) hasDrift() bool {
 
 // warnIfPatchesRepoDrift prints a non-fatal freshness warning for the active patches repo.
 func warnIfPatchesRepoDrift(cmd *cobra.Command) {
-	repoPath := patchesRepoWarningPath()
+	repoPath := patchesRepoWarningPath(cmd)
 	if repoPath == "" {
 		return
 	}
@@ -45,7 +45,15 @@ func warnIfPatchesRepoDrift(cmd *cobra.Command) {
 	fmt.Fprintln(cmd.ErrOrStderr(), formatPatchesRepoDriftWarning(repoPath, drift))
 }
 
-func patchesRepoWarningPath() string {
+func patchesRepoWarningPath(cmd *cobra.Command) string {
+	if cmd != nil {
+		flag := cmd.Flags().Lookup("patches-repo")
+		if flag != nil && flag.Changed {
+			if override := strings.TrimSpace(flag.Value.String()); override != "" {
+				return override
+			}
+		}
+	}
 	if appState == nil {
 		return ""
 	}

--- a/packages/browseros/tools/patch/cmd/stale_warning_test.go
+++ b/packages/browseros/tools/patch/cmd/stale_warning_test.go
@@ -73,6 +73,42 @@ func TestWarnIfPatchesRepoDriftWritesPathToStderr(t *testing.T) {
 	}
 }
 
+func TestWarnIfPatchesRepoDriftPrefersChangedPatchesRepoFlag(t *testing.T) {
+	configuredRepo, _ := setupWarningRepos(t)
+	overrideRepo, overrideUpstream := setupWarningRepos(t)
+	commitWarningFile(t, overrideUpstream, "remote.txt", "remote\n", "remote change")
+	runWarningGit(t, overrideUpstream, "push", "origin", "main")
+
+	oldAppState := appState
+	t.Cleanup(func() {
+		appState = oldAppState
+	})
+	appState = &app.App{
+		CWD: t.TempDir(),
+		Config: &workspace.Config{
+			PatchesRepo: configuredRepo,
+		},
+	}
+
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{Use: "add"}
+	cmd.Flags().String("patches-repo", "", "")
+	if err := cmd.Flags().Set("patches-repo", overrideRepo); err != nil {
+		t.Fatalf("set patches-repo: %v", err)
+	}
+	cmd.SetErr(&stderr)
+
+	warnIfPatchesRepoDrift(cmd)
+
+	output := stderr.String()
+	if !strings.Contains(output, overrideRepo) {
+		t.Fatalf("expected warning to use override repo %q, got:\n%s", overrideRepo, output)
+	}
+	if strings.Contains(output, configuredRepo) {
+		t.Fatalf("warning should not use configured repo %q when override is set, got:\n%s", configuredRepo, output)
+	}
+}
+
 func setupWarningRepos(t *testing.T) (string, string) {
 	t.Helper()
 

--- a/packages/browseros/tools/patch/cmd/stale_warning_test.go
+++ b/packages/browseros/tools/patch/cmd/stale_warning_test.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/app"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/workspace"
+	"github.com/spf13/cobra"
+)
+
+func TestPatchesRepoRemoteDriftFetchesOriginMain(t *testing.T) {
+	local, upstream := setupWarningRepos(t)
+	commitWarningFile(t, upstream, "remote.txt", "remote\n", "remote change")
+	runWarningGit(t, upstream, "push", "origin", "main")
+
+	drift, err := patchesRepoRemoteDrift(context.Background(), local)
+	if err != nil {
+		t.Fatalf("patchesRepoRemoteDrift: %v", err)
+	}
+	if drift.LocalAhead != 0 || drift.RemoteAhead != 1 {
+		t.Fatalf("drift = %+v, want local=0 remote=1", drift)
+	}
+}
+
+func TestPatchesRepoRemoteDriftQuietWhenEven(t *testing.T) {
+	local, _ := setupWarningRepos(t)
+
+	drift, err := patchesRepoRemoteDrift(context.Background(), local)
+	if err != nil {
+		t.Fatalf("patchesRepoRemoteDrift: %v", err)
+	}
+	if drift.hasDrift() {
+		t.Fatalf("expected no drift, got %+v", drift)
+	}
+}
+
+func TestWarnIfPatchesRepoDriftWritesPathToStderr(t *testing.T) {
+	local, upstream := setupWarningRepos(t)
+	commitWarningFile(t, upstream, "remote.txt", "remote\n", "remote change")
+	runWarningGit(t, upstream, "push", "origin", "main")
+
+	oldAppState := appState
+	t.Cleanup(func() {
+		appState = oldAppState
+	})
+	appState = &app.App{
+		CWD: t.TempDir(),
+		Config: &workspace.Config{
+			PatchesRepo: local,
+		},
+	}
+
+	var stderr bytes.Buffer
+	cmd := &cobra.Command{Use: "status"}
+	cmd.SetErr(&stderr)
+
+	warnIfPatchesRepoDrift(cmd)
+
+	output := stderr.String()
+	for _, want := range []string{
+		"remote is 1 commit ahead",
+		local,
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("expected warning to contain %q, got:\n%s", want, output)
+		}
+	}
+}
+
+func setupWarningRepos(t *testing.T) (string, string) {
+	t.Helper()
+
+	root := t.TempDir()
+	origin := filepath.Join(root, "origin.git")
+	seed := filepath.Join(root, "seed")
+	local := filepath.Join(root, "local")
+	upstream := filepath.Join(root, "upstream")
+
+	if err := os.MkdirAll(seed, 0o755); err != nil {
+		t.Fatalf("mkdir seed: %v", err)
+	}
+	runWarningGit(t, root, "init", "--bare", "--initial-branch=main", origin)
+	runWarningGit(t, seed, "init", "--initial-branch=main")
+	configWarningGitUser(t, seed)
+	commitWarningFile(t, seed, "base.txt", "base\n", "base")
+	runWarningGit(t, seed, "remote", "add", "origin", origin)
+	runWarningGit(t, seed, "push", "-u", "origin", "main")
+
+	runWarningGit(t, root, "clone", origin, local)
+	configWarningGitUser(t, local)
+	runWarningGit(t, root, "clone", origin, upstream)
+	configWarningGitUser(t, upstream)
+
+	return local, upstream
+}
+
+func configWarningGitUser(t *testing.T, dir string) {
+	t.Helper()
+	runWarningGit(t, dir, "config", "user.name", "Test User")
+	runWarningGit(t, dir, "config", "user.email", "test@example.com")
+}
+
+func commitWarningFile(t *testing.T, dir string, rel string, body string, message string) {
+	t.Helper()
+	path := filepath.Join(dir, filepath.FromSlash(rel))
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	runWarningGit(t, dir, "add", rel)
+	runWarningGit(t, dir, "commit", "-m", message)
+}
+
+func runWarningGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	command := exec.Command("git", args...)
+	command.Dir = dir
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, string(output))
+	}
+}


### PR DESCRIPTION
## Summary
- Add a startup warning when the configured or discoverable patches repo differs from `origin/main`.
- Print the drift count and patches repo path to stderr so JSON stdout stays parseable.
- Keep the check best-effort and non-fatal, including support for `add --patches-repo` overrides.

## Design
The root command pre-run now loads app state, resolves the relevant patches repo path, fetches `origin/main` with a short timeout, and compares `HEAD...origin/main`. Any fetch or inspection failure is ignored so patch commands keep working.

## Test plan
- [x] `cd packages/browseros/tools/patch && go test ./...`
- [x] `git diff --check`
- [x] Temporary local smoke test confirmed warning on stderr and normal command output on stdout.
- [x] Local read-only Codex review round 2: clean.