### PR TITLE
chore: enable runtime product server resources

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/buildflags.gni
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/buildflags.gni
@@ -1,6 +1,6 @@
 diff --git a/chrome/browser/browseros/buildflags.gni b/chrome/browser/browseros/buildflags.gni
 new file mode 100644
-index 0000000000000..0a4b34ea72336
+index 0000000000000..8c87fe61ab738
 --- /dev/null
 +++ b/chrome/browser/browseros/buildflags.gni
 @@ -0,0 +1,25 @@
@@ -15,13 +15,13 @@ index 0000000000000..0a4b34ea72336
 +  browseros_product = "browseros"
 +
 +  # Dev/test only. Official builds should leave this false.
-+  browseros_allow_runtime_product_override = false
++  # // TODO: nikhil - before prod claw release, set this to false
++  browseros_allow_runtime_product_override = true
 +}
 +
 +declare_args() {
 +  # Usually follows runtime override, but can be forced on for packaging tests.
-+  browseros_package_all_server_resources =
-+      browseros_allow_runtime_product_override
++  browseros_package_all_server_resources = true
 +}
 +
 +assert(browseros_product == "browseros" || browseros_product == "browserclaw",


### PR DESCRIPTION
## Summary
- Updates the Chromium patch for `chrome/browser/browseros/buildflags.gni`.
- Enables the runtime BrowserOS product override flag.
- Packages all BrowserOS server resources so BrowserOS and BrowserClaw can both be tested from the same dev build.

## Design
This extracts Chromium commit `d7726ca575199` into the BrowserOS patch stack. The changed patch keeps the default baked product as BrowserOS, but enables the dev/runtime product switch path and forces both server resource bundles to be packaged.

## Test plan
- [x] `~/.skills/sf-ch-extract/scripts/verify-patches.sh --chromium-src /Users/shadowfax/code/chromium-checkouts/chromium-1/src --worktree /Users/shadowfax/worktrees/main/feat-runtime-product-flags-patches --tip d7726ca5751991fdf5912c6a7d8d093c582bbbff chrome/browser/browseros/buildflags.gni`