### PR TITLE
feat: descriptor-driven OTA updater for both sidecar servers

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_config.cc b/chrome/browser/browseros/server/browseros_server_config.cc
 new file mode 100644
-index 0000000000000..108ebf4b1cb5a
+index 0000000000000..6fe71062a9c96
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_config.cc
-@@ -0,0 +1,162 @@
+@@ -0,0 +1,178 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -24,6 +24,13 @@ index 0000000000000..108ebf4b1cb5a
 +    FILE_PATH_LITERAL("config.json"),
 +    "/health",
 +    true,
++    {
++        // Empty state dir keeps the legacy .browseros/current_version layout.
++        FILE_PATH_LITERAL(""),
++        "https://cdn.browseros.com/appcast-server.xml",
++        "https://cdn.browseros.com/appcast-server.alpha.xml",
++        "/status",
++    },
 +};
 +
 +constexpr ManagedServerDescriptor kBrowserClawServerDescriptor = {
@@ -33,7 +40,16 @@ index 0000000000000..108ebf4b1cb5a
 +    FILE_PATH_LITERAL("browseros-claw-server"),
 +    FILE_PATH_LITERAL("config.json"),
 +    "/system/health",
-+    false,
++    true,
++    {
++        // Isolate Claw OTA state under .browseros/BrowserClawServer/.
++        FILE_PATH_LITERAL("BrowserClawServer"),
++        "https://cdn.browseros.com/appcast-claw-server.xml",
++        "https://cdn.browseros.com/appcast-claw-server.alpha.xml",
++        // Claw exposes /system/health but not the {can_update} readiness
++        // contract yet; empty skips readiness and restarts after verification.
++        "",
++    },
 +};
 +
 +}  // namespace

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_config.h b/chrome/browser/browseros/server/browseros_server_config.h
 new file mode 100644
-index 0000000000000..3ace523b486f4
+index 0000000000000..a98e3b74de45e
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_config.h
-@@ -0,0 +1,127 @@
+@@ -0,0 +1,147 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -23,13 +23,33 @@ index 0000000000000..3ace523b486f4
 +struct ServerLaunchConfig;
 +
 +struct ManagedServerDescriptor {
++  // OTA contract consumed by BrowserOSServerUpdater so a single updater can
++  // serve every sidecar product. Grouped into a nested struct to keep the
++  // descriptor under the chromium-style implicit-ctor weight limit (>=10
++  // trivial fields would force an out-of-line ctor, which a constexpr
++  // aggregate cannot have).
++  struct UpdaterConfig {
++    // Subdirectory under .browseros holding this product's OTA state
++    // (current_version file + versions/). Empty keeps the legacy BrowserOS
++    // layout directly under .browseros for backward compatibility.
++    base::FilePath::StringViewType state_dir;
++    // Stable and alpha appcast feeds.
++    std::string_view appcast_url;
++    std::string_view alpha_appcast_url;
++    // Server endpoint returning {can_update} that gates a hot-swap. Empty skips
++    // the readiness fetch and restarts right after verification.
++    std::string_view readiness_path;
++  };
++
 +  Product product;
 +  std::string_view log_name;
 +  base::FilePath::StringViewType bundle_dir;
 +  base::FilePath::StringViewType binary_name;
 +  base::FilePath::StringViewType config_file_name;
 +  std::string_view health_path;
++  // Whether the manager starts an updater for this product at all.
 +  bool enable_updater;
++  UpdaterConfig updater;
 +};
 +
 +const ManagedServerDescriptor& GetBrowserOSServerDescriptor();

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config_unittest.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config_unittest.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_config_unittest.cc b/chrome/browser/browseros/server/browseros_server_config_unittest.cc
 new file mode 100644
-index 0000000000000..e88bef039ced0
+index 0000000000000..9a25f32a0da56
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_config_unittest.cc
-@@ -0,0 +1,206 @@
+@@ -0,0 +1,228 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -113,9 +113,18 @@ index 0000000000000..e88bef039ced0
 +            ToPathString(descriptor.config_file_name));
 +  EXPECT_EQ(std::string_view("/health"), descriptor.health_path);
 +  EXPECT_TRUE(descriptor.enable_updater);
++
++  // Empty state dir preserves the legacy .browseros/current_version layout.
++  EXPECT_TRUE(descriptor.updater.state_dir.empty());
++  EXPECT_EQ(std::string_view("https://cdn.browseros.com/appcast-server.xml"),
++            descriptor.updater.appcast_url);
++  EXPECT_EQ(
++      std::string_view("https://cdn.browseros.com/appcast-server.alpha.xml"),
++      descriptor.updater.alpha_appcast_url);
++  EXPECT_EQ(std::string_view("/status"), descriptor.updater.readiness_path);
 +}
 +
-+TEST(BrowserOSServerConfigTest, BrowserClawDescriptorDisablesUpdater) {
++TEST(BrowserOSServerConfigTest, BrowserClawDescriptorMatchesClawServer) {
 +  const ManagedServerDescriptor& descriptor = GetBrowserClawServerDescriptor();
 +
 +  EXPECT_EQ(Product::kBrowserClaw, descriptor.product);
@@ -128,7 +137,20 @@ index 0000000000000..e88bef039ced0
 +  EXPECT_EQ(base::FilePath::StringType(FILE_PATH_LITERAL("config.json")),
 +            ToPathString(descriptor.config_file_name));
 +  EXPECT_EQ(std::string_view("/system/health"), descriptor.health_path);
-+  EXPECT_FALSE(descriptor.enable_updater);
++  EXPECT_TRUE(descriptor.enable_updater);
++
++  // Claw isolates OTA state under .browseros/BrowserClawServer/ and fetches its
++  // own feed.
++  EXPECT_EQ(base::FilePath::StringType(FILE_PATH_LITERAL("BrowserClawServer")),
++            ToPathString(descriptor.updater.state_dir));
++  EXPECT_EQ(
++      std::string_view("https://cdn.browseros.com/appcast-claw-server.xml"),
++      descriptor.updater.appcast_url);
++  EXPECT_EQ(std::string_view(
++                "https://cdn.browseros.com/appcast-claw-server.alpha.xml"),
++            descriptor.updater.alpha_appcast_url);
++  // No readiness contract yet: empty path skips the status fetch.
++  EXPECT_TRUE(descriptor.updater.readiness_path.empty());
 +}
 +
 +TEST(BrowserOSServerConfigTest, ManagedDescriptorUsesSelectedProduct) {

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_constants.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_constants.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_constants.h b/chrome/browser/browseros/server/browseros_server_constants.h
 new file mode 100644
-index 0000000000000..d2c8229f8c805
+index 0000000000000..8c9469cc988b5
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_constants.h
-@@ -0,0 +1,52 @@
+@@ -0,0 +1,48 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -15,11 +15,7 @@ index 0000000000000..d2c8229f8c805
 +
 +namespace browseros_server {
 +
-+// Appcast URLs for checking server updates
-+inline constexpr char kDefaultAppcastUrl[] =
-+    "https://cdn.browseros.com/appcast-server.xml";
-+inline constexpr char kAlphaAppcastUrl[] =
-+    "https://cdn.browseros.com/appcast-server.alpha.xml";
++// Appcast URLs are product-specific and live on ManagedServerDescriptor.
 +
 +// Interval between update checks
 +inline constexpr base::TimeDelta kUpdateCheckInterval = base::Minutes(15);

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_updater.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_updater.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_updater.cc b/chrome/browser/browseros/server/browseros_server_updater.cc
 new file mode 100644
-index 0000000000000..eb1bd8fd5766d
+index 0000000000000..f154a9f21a6cb
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_updater.cc
-@@ -0,0 +1,1078 @@
+@@ -0,0 +1,1096 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -21,6 +21,7 @@ index 0000000000000..eb1bd8fd5766d
 +#include "base/logging.h"
 +#include "base/path_service.h"
 +#include "base/process/launch.h"
++#include "base/strings/strcat.h"
 +#include "base/strings/string_number_conversions.h"
 +#include "base/strings/string_util.h"
 +#include "base/task/thread_pool.h"
@@ -28,6 +29,7 @@ index 0000000000000..eb1bd8fd5766d
 +#include "chrome/browser/browser_process.h"
 +#include "chrome/browser/browseros/core/browseros_switches.h"
 +#include "chrome/browser/browseros/metrics/browseros_metrics.h"
++#include "chrome/browser/browseros/server/browseros_server_config.h"
 +#include "chrome/browser/browseros/server/browseros_server_constants.h"
 +#include "chrome/browser/browseros/server/browseros_server_manager.h"
 +#include "chrome/browser/browseros/server/browseros_server_prefs.h"
@@ -268,7 +270,8 @@ index 0000000000000..eb1bd8fd5766d
 +
 +BrowserOSServerUpdater::BrowserOSServerUpdater(
 +    browseros::BrowserOSServerManager* manager)
-+    : manager_(manager) {}
++    : manager_(manager),
++      descriptor_(&browseros::GetManagedServerDescriptor()) {}
 +
 +BrowserOSServerUpdater::~BrowserOSServerUpdater() {
 +  Stop();
@@ -413,17 +416,18 @@ index 0000000000000..eb1bd8fd5766d
 +  state_ = State::kFetchingAppcast;
 +  update_in_progress_ = true;
 +
-+  // Get appcast URL (allow override via command line, otherwise use
-+  // alpha/stable)
++  // Get appcast URL (allow override via command line, otherwise use the
++  // selected product's alpha/stable feed). The override switch is
++  // product-agnostic because only the selected sidecar's updater runs.
 +  std::string appcast_url;
 +  base::CommandLine* cmd = base::CommandLine::ForCurrentProcess();
 +  if (cmd->HasSwitch(browseros::kServerAppcastUrl)) {
 +    appcast_url = cmd->GetSwitchValueASCII(browseros::kServerAppcastUrl);
 +    LOG(INFO) << "browseros: Using custom appcast URL: " << appcast_url;
 +  } else if (base::FeatureList::IsEnabled(features::kBrowserOsAlphaFeatures)) {
-+    appcast_url = kAlphaAppcastUrl;
++    appcast_url = std::string(descriptor_->updater.alpha_appcast_url);
 +  } else {
-+    appcast_url = kDefaultAppcastUrl;
++    appcast_url = std::string(descriptor_->updater.appcast_url);
 +  }
 +
 +  GURL url(appcast_url);
@@ -703,8 +707,15 @@ index 0000000000000..eb1bd8fd5766d
 +}
 +
 +void BrowserOSServerUpdater::CheckServerStatus() {
-+  GURL status_url("http://127.0.0.1:" +
-+                  base::NumberToString(manager_->GetServerPort()) + "/status");
++  // Products without a readiness contract restart right after verification.
++  if (descriptor_->updater.readiness_path.empty()) {
++    OnServerStatusChecked(/*can_update=*/true);
++    return;
++  }
++
++  GURL status_url(base::StrCat({"http://127.0.0.1:",
++                                base::NumberToString(manager_->GetServerPort()),
++                                descriptor_->updater.readiness_path}));
 +
 +  LOG(INFO) << "browseros: Checking server status at " << status_url;
 +
@@ -910,7 +921,14 @@ index 0000000000000..eb1bd8fd5766d
 +  if (!base::PathService::Get(chrome::DIR_USER_DATA, &user_data_dir)) {
 +    return base::FilePath();
 +  }
-+  return user_data_dir.Append(FILE_PATH_LITERAL(".browseros"));
++  base::FilePath execution_dir =
++      user_data_dir.Append(FILE_PATH_LITERAL(".browseros"));
++  // Non-empty state dir isolates a product's OTA state (e.g. Claw under
++  // .browseros/BrowserClawServer/); empty keeps the legacy BrowserOS layout.
++  if (!descriptor_->updater.state_dir.empty()) {
++    execution_dir = execution_dir.Append(descriptor_->updater.state_dir);
++  }
++  return execution_dir;
 +}
 +
 +base::FilePath BrowserOSServerUpdater::GetVersionsDir() const {
@@ -940,7 +958,7 @@ index 0000000000000..eb1bd8fd5766d
 +  base::FilePath binary = GetVersionDir(version)
 +                              .Append(FILE_PATH_LITERAL("resources"))
 +                              .Append(FILE_PATH_LITERAL("bin"))
-+                              .Append(FILE_PATH_LITERAL("browseros_server"));
++                              .Append(descriptor_->binary_name);
 +#if BUILDFLAG(IS_WIN)
 +  binary = binary.AddExtension(FILE_PATH_LITERAL(".exe"));
 +#endif

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_updater.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_updater.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_updater.h b/chrome/browser/browseros/server/browseros_server_updater.h
 new file mode 100644
-index 0000000000000..a7edcdd9d98ee
+index 0000000000000..529d7fc706730
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_updater.h
-@@ -0,0 +1,165 @@
+@@ -0,0 +1,170 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -29,21 +29,22 @@ index 0000000000000..a7edcdd9d98ee
 +
 +namespace browseros {
 +class BrowserOSServerManager;
++struct ManagedServerDescriptor;
 +}
 +
 +namespace browseros_server {
 +
-+// Manages automatic updates for the BrowserOS server binary.
++// Manages automatic updates for the selected BrowserOS sidecar server.
 +//
 +// Update flow:
-+// 1. Fetch appcast XML from CDN
-+// 2. Parse and find matching platform enclosure
-+// 3. Download ZIP if newer version available
-+// 4. Verify Ed25519 signature
-+// 5. Extract to versions/{version}/
-+// 6. Test binary with --version
-+// 7. Update current_version file
-+// 8. Signal manager to use new binary on next restart
++// 1. Fetch the descriptor-selected appcast XML from CDN.
++// 2. Parse and find the matching platform enclosure.
++// 3. Download ZIP if a newer version is available.
++// 4. Verify Ed25519 signature.
++// 5. Extract to the product's versions/{version}/ directory.
++// 6. Test the binary with --version.
++// 7. Update the product's current_version file.
++// 8. Signal the manager to restart using the new binary.
 +class BrowserOSServerUpdater : public browseros::ServerUpdater {
 + public:
 +  explicit BrowserOSServerUpdater(browseros::BrowserOSServerManager* manager);
@@ -142,6 +143,10 @@ index 0000000000000..a7edcdd9d98ee
 +  void ResetState();
 +
 +  raw_ptr<browseros::BrowserOSServerManager> manager_;
++
++  // Selected sidecar's OTA contract (appcast feeds, state dir, binary name,
++  // readiness path). Points at a process-lifetime static descriptor.
++  raw_ptr<const browseros::ManagedServerDescriptor> descriptor_;
 +
 +  base::RepeatingTimer update_check_timer_;
 +


### PR DESCRIPTION
## Summary
- Make the single `BrowserOSServerUpdater` serve both the BrowserOS and BrowserClaw sidecars, driven by `ManagedServerDescriptor` instead of hardcoded BrowserOS values.
- BrowserClaw now updates: its own appcast feeds, OTA state isolated under `.browseros/BrowserClawServer/`, `browseros-claw-server` binary, updater enabled.
- BrowserOS behavior is unchanged (legacy `.browseros` state, `/status` readiness, existing feeds).

## Design
`ManagedServerDescriptor` gains a nested `UpdaterConfig` (`state_dir`, `appcast_url`, `alpha_appcast_url`, `readiness_path`); the updater captures the selected descriptor at construction and reads appcast URL, execution/state dir, downloaded binary name, and readiness path from it. `enable_updater` stays a top-level flag the manager checks before starting an updater. It's nested (not flat) to keep the descriptor under the chromium-style implicit-constructor field-weight limit while remaining a `constexpr` aggregate. BrowserClaw's `readiness_path` is empty for now (it exposes `/system/health` but not the `{can_update}` JSON contract yet), so the updater skips the readiness fetch and restarts right after verification. Same Ed25519 key for both products; appcast URLs moved out of constants into the descriptor.

## Test plan
- [x] `browseros_server_config_unittest.cc` asserts both descriptors' fields (feeds, state dir, readiness path, `enable_updater`).
- [x] Full Chromium `chrome` target builds green (arm64), bundling both server resources.
- [x] Extracted patches verified: 6/6 byte-match vs source diff, 6/6 apply-check onto base tree.