### PR TITLE
fix(dev): pass product flag to dev launches

### DIFF
--- a/packages/browseros-agent/apps/app/web-ext.config.test.ts
+++ b/packages/browseros-agent/apps/app/web-ext.config.test.ts
@@ -1,0 +1,45 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+
+// biome-ignore lint/style/noProcessEnv: test controls import-time env reads.
+const env = process.env
+const originalProduct = env.BROWSEROS_PRODUCT
+let importVersion = 0
+
+afterEach(() => {
+  if (originalProduct === undefined) {
+    delete env.BROWSEROS_PRODUCT
+  } else {
+    env.BROWSEROS_PRODUCT = originalProduct
+  }
+})
+
+async function loadWebExtConfig(product?: string) {
+  if (product === undefined) {
+    delete env.BROWSEROS_PRODUCT
+  } else {
+    env.BROWSEROS_PRODUCT = product
+  }
+
+  const module = await import(`./web-ext.config.ts?test=${importVersion++}`)
+  return module.default as { chromiumArgs: string[] }
+}
+
+describe('web-ext Chromium product args', () => {
+  it('defaults BrowserOS launches to the BrowserOS product', async () => {
+    const config = await loadWebExtConfig()
+
+    expect(config.chromiumArgs).toContain('--browseros-product=browseros')
+  })
+
+  it('honors an explicit BrowserOS product override', async () => {
+    const config = await loadWebExtConfig('browserclaw')
+
+    expect(config.chromiumArgs).toContain('--browseros-product=browserclaw')
+  })
+
+  it('rejects invalid product overrides', async () => {
+    await expect(loadWebExtConfig('invalid')).rejects.toThrow(
+      'BROWSEROS_PRODUCT must be browseros or browserclaw: invalid',
+    )
+  })
+})

--- a/packages/browseros-agent/apps/app/web-ext.config.ts
+++ b/packages/browseros-agent/apps/app/web-ext.config.ts
@@ -42,12 +42,23 @@ function chromiumProfile(): string {
   return profile
 }
 
+function browserOSProduct(defaultProduct: 'browseros' | 'browserclaw') {
+  const product = env.BROWSEROS_PRODUCT?.trim() || defaultProduct
+  if (product !== 'browseros' && product !== 'browserclaw') {
+    throw new Error(
+      `BROWSEROS_PRODUCT must be browseros or browserclaw: ${product}`,
+    )
+  }
+  return product
+}
+
 const chromiumArgs = [
   '--use-mock-keychain',
   '--show-component-extension-options',
   '--disable-browseros-server',
   '--disable-browseros-extensions',
   '--browseros-dock-icon=dev',
+  `--browseros-product=${browserOSProduct('browseros')}`,
 ]
 
 if (env.BROWSEROS_CDP_PORT) {

--- a/packages/browseros-agent/apps/claw-app/web-ext.config.test.ts
+++ b/packages/browseros-agent/apps/claw-app/web-ext.config.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, expect, it } from 'bun:test'
+
+const env = process.env
+const originalProduct = env.BROWSEROS_PRODUCT
+let importVersion = 0
+
+afterEach(() => {
+  if (originalProduct === undefined) {
+    delete env.BROWSEROS_PRODUCT
+  } else {
+    env.BROWSEROS_PRODUCT = originalProduct
+  }
+})
+
+async function loadWebExtConfig(product?: string) {
+  if (product === undefined) {
+    delete env.BROWSEROS_PRODUCT
+  } else {
+    env.BROWSEROS_PRODUCT = product
+  }
+
+  const module = await import(`./web-ext.config.ts?test=${importVersion++}`)
+  return module.default as { chromiumArgs: string[] }
+}
+
+describe('web-ext Chromium product args', () => {
+  it('defaults Claw launches to the BrowserClaw product', async () => {
+    const config = await loadWebExtConfig()
+
+    expect(config.chromiumArgs).toContain('--browseros-product=browserclaw')
+  })
+
+  it('honors an explicit BrowserOS product override', async () => {
+    const config = await loadWebExtConfig('browseros')
+
+    expect(config.chromiumArgs).toContain('--browseros-product=browseros')
+  })
+
+  it('rejects invalid product overrides', async () => {
+    await expect(loadWebExtConfig('invalid')).rejects.toThrow(
+      'BROWSEROS_PRODUCT must be browseros or browserclaw: invalid',
+    )
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/web-ext.config.ts
+++ b/packages/browseros-agent/apps/claw-app/web-ext.config.ts
@@ -43,6 +43,16 @@ function chromiumProfile(): string {
   return profile
 }
 
+function browserOSProduct(defaultProduct: 'browseros' | 'browserclaw') {
+  const product = env.BROWSEROS_PRODUCT?.trim() || defaultProduct
+  if (product !== 'browseros' && product !== 'browserclaw') {
+    throw new Error(
+      `BROWSEROS_PRODUCT must be browseros or browserclaw: ${product}`,
+    )
+  }
+  return product
+}
+
 const chromiumArgs = [
   '--use-mock-keychain',
   '--show-component-extension-options',
@@ -52,6 +62,7 @@ const chromiumArgs = [
   '--disable-browseros-server',
   '--disable-browseros-extensions',
   '--browseros-dock-icon=dev',
+  `--browseros-product=${browserOSProduct('browserclaw')}`,
 ]
 
 if (env.BROWSEROS_CLAW_CDP_PORT) {

--- a/packages/browseros-agent/apps/claw-app/wxt.config.ts
+++ b/packages/browseros-agent/apps/claw-app/wxt.config.ts
@@ -12,9 +12,7 @@ export default defineConfig({
   modules: ['@wxt-dev/module-react'],
   manifest: {
     name: 'browserclaw',
-    key: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvBDAaDRvv61NpBeLR8etBRw82lv9VJO3sz/mA26gDzWKtVuzW4DXCl8Zfj5oWmoXLTfv3aiTigUXo/LHOoGpSucEVroMmAc7cgu2KuQ1fZPpMvYa0npD/m4h89360q8Oz0oKKaZGS905IJ04M2IkF4CuU3YEHFJBWb+cUyK9H8YVugelYbPD0IVs63T1SkGbh/t/Tfb2DpkinduSO8+x26sKydm30SRt+iZ2+7Nolcdum3LExInUiX2Pgb65Jb+mVw8NqyTVJyCEp8uq0cSHomWFQirSJ80tsDhISp4btwaRKHrXqovQx9XHQv4hCd+3LuB830eUEVMUNuCO+OyPxQIDAQAB',
-    // TODO: use the new extension ID after  new build
-    // key: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyXbY2XVCs1/yJqGd53ei1rHdoUGIvZ8uq+x9YKmUc+jnb6NogIrq0USPeRNb6uzszio45GR8BW0O0pgbFKmhlhrCwgs9gEW8mufksE29E1g8Q2ug1sowzj38X6jmitO4I9cBbQMx7+gJZJS8pS5DZ+V7Bl8Uka2LWHMTP/Pf10YjbeNNCA0wj6kQkkTb8lg80r5Vm+gFqyo2xDFaxj8lN2kE73yFBjCt6B4ycntXvnnUTPX4IJqH+eQuwsFWPuqdYEwdvaaIOQ+lCxcYyZusX58zhxr0pkMxQjnEoJqAk6Av5O/JiNIOZYzbwUjm6aA+p9j9/6xzvmG+Lvp74Dk9pwIDAQAB',
+    key: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyXbY2XVCs1/yJqGd53ei1rHdoUGIvZ8uq+x9YKmUc+jnb6NogIrq0USPeRNb6uzszio45GR8BW0O0pgbFKmhlhrCwgs9gEW8mufksE29E1g8Q2ug1sowzj38X6jmitO4I9cBbQMx7+gJZJS8pS5DZ+V7Bl8Uka2LWHMTP/Pf10YjbeNNCA0wj6kQkkTb8lg80r5Vm+gFqyo2xDFaxj8lN2kE73yFBjCt6B4ycntXvnnUTPX4IJqH+eQuwsFWPuqdYEwdvaaIOQ+lCxcYyZusX58zhxr0pkMxQjnEoJqAk6Av5O/JiNIOZYzbwUjm6aA+p9j9/6xzvmG+Lvp74Dk9pwIDAQAB',
     permissions: [
       'browserOS',
       'storage',

--- a/packages/browseros-agent/tools/dev/browser/args.go
+++ b/packages/browseros-agent/tools/dev/browser/args.go
@@ -13,10 +13,21 @@ type ArgsConfig struct {
 	UserDataDir       string
 	Headless          bool
 	LoadDevExtensions bool
+	Product           string
 }
 
+const (
+	ProductBrowserOS   = "browseros"
+	ProductBrowserClaw = "browserclaw"
+)
+
+// BuildArgs returns the BrowserOS Chromium command for non-WXT dev/test launches.
 func BuildArgs(cfg ArgsConfig) []string {
 	binary := "/Applications/BrowserOS.app/Contents/MacOS/BrowserOS"
+	product := cfg.Product
+	if product == "" {
+		product = ProductBrowserOS
+	}
 
 	args := []string{binary}
 
@@ -29,6 +40,7 @@ func BuildArgs(cfg ArgsConfig) []string {
 		"--show-component-extension-options",
 		"--disable-browseros-server",
 		"--browseros-dock-icon=dev",
+		fmt.Sprintf("--browseros-product=%s", product),
 	)
 
 	if cfg.LoadDevExtensions {

--- a/packages/browseros-agent/tools/dev/browser/args_test.go
+++ b/packages/browseros-agent/tools/dev/browser/args_test.go
@@ -19,3 +19,17 @@ func TestBuildArgsUsesDevDockIcon(t *testing.T) {
 		t.Fatalf("missing dev dock icon arg in\n%s", joined)
 	}
 }
+
+func TestBuildArgsUsesProductFlag(t *testing.T) {
+	args := BuildArgs(ArgsConfig{
+		Root:              "/repo/packages/browseros-agent",
+		Ports:             proc.Ports{CDP: 9005, Server: 9105, Extension: 9305},
+		UserDataDir:       "/tmp/browseros-dev",
+		LoadDevExtensions: true,
+		Product:           ProductBrowserClaw,
+	})
+	joined := strings.Join(args, "\n")
+	if !strings.Contains(joined, "--browseros-product=browserclaw") {
+		t.Fatalf("missing BrowserClaw product arg in\n%s", joined)
+	}
+}

--- a/packages/browseros-agent/tools/dev/cmd/test.go
+++ b/packages/browseros-agent/tools/dev/cmd/test.go
@@ -149,6 +149,7 @@ func runTest(cmd *cobra.Command, args []string) error {
 			UserDataDir:       tempDir,
 			Headless:          testHeadless,
 			LoadDevExtensions: false,
+			Product:           browser.ProductBrowserOS,
 		}),
 	}))
 

--- a/packages/browseros-agent/tools/dev/cmd/watch.go
+++ b/packages/browseros-agent/tools/dev/cmd/watch.go
@@ -148,11 +148,7 @@ func runWatch(cmd *cobra.Command, args []string) error {
 	proc.LogMsg(proc.TagInfo, proc.DimColor.Sprint("Press Ctrl+C to stop, double Ctrl+C to force kill"))
 	fmt.Println()
 
-	env := proc.BuildEnv(p, "development")
-	env = append(env, fmt.Sprintf("BROWSEROS_USER_DATA_DIR=%s", userDataDir))
-	if watchClaw {
-		env = buildClawWatchEnv(env, p)
-	}
+	env := buildWatchEnv(p, userDataDir, watchClaw)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -221,6 +217,26 @@ func resolveWatchDefaultPorts(root string, claw bool) (proc.Ports, error) {
 	return ports, nil
 }
 
+// buildWatchEnv forwards the selected product into WXT's Chromium launcher config.
+func buildWatchEnv(p proc.Ports, userDataDir string, claw bool) []string {
+	env := proc.BuildEnv(p, "development")
+	env = append(env,
+		fmt.Sprintf("BROWSEROS_USER_DATA_DIR=%s", userDataDir),
+		fmt.Sprintf("BROWSEROS_PRODUCT=%s", watchProduct(claw)),
+	)
+	if claw {
+		env = buildClawWatchEnv(env, p)
+	}
+	return env
+}
+
+func watchProduct(claw bool) string {
+	if claw {
+		return browser.ProductBrowserClaw
+	}
+	return browser.ProductBrowserOS
+}
+
 // buildClawWatchEnv bridges shared dev ports into the standalone BrowserClaw apps.
 func buildClawWatchEnv(env []string, p proc.Ports) []string {
 	apiURL := fmt.Sprintf("http://127.0.0.1:%d", p.Server)
@@ -253,6 +269,7 @@ func startBrowserOSWatch(ctx context.Context, wg *sync.WaitGroup, root string, e
 				Ports:             p,
 				UserDataDir:       userDataDir,
 				LoadDevExtensions: true,
+				Product:           browser.ProductBrowserOS,
 			}),
 		}))
 	} else {

--- a/packages/browseros-agent/tools/dev/cmd/watch_test.go
+++ b/packages/browseros-agent/tools/dev/cmd/watch_test.go
@@ -61,6 +61,41 @@ func TestResolveWatchDefaultPortsUsesStandaloneClawServerPort(t *testing.T) {
 	}
 }
 
+func TestBuildWatchEnvSelectsBrowserOSProduct(t *testing.T) {
+	env := buildWatchEnv(proc.Ports{
+		CDP:       9012,
+		Server:    9123,
+		Extension: 9321,
+	}, "/tmp/browseros-dev", false)
+
+	for _, want := range []string{
+		"BROWSEROS_PRODUCT=browseros",
+		"BROWSEROS_USER_DATA_DIR=/tmp/browseros-dev",
+	} {
+		if !hasEnvEntry(env, want) {
+			t.Fatalf("expected env to contain %q, got %#v", want, env)
+		}
+	}
+}
+
+func TestBuildWatchEnvSelectsBrowserClawProduct(t *testing.T) {
+	env := buildWatchEnv(proc.Ports{
+		CDP:       9012,
+		Server:    9123,
+		Extension: 9321,
+	}, "/tmp/browseros-dev", true)
+
+	for _, want := range []string{
+		"BROWSEROS_PRODUCT=browserclaw",
+		"BROWSEROS_CLAW_CDP_PORT=9012",
+		"VITE_BROWSEROS_CLAW_API_URL=http://127.0.0.1:9123",
+	} {
+		if !hasEnvEntry(env, want) {
+			t.Fatalf("expected env to contain %q, got %#v", want, env)
+		}
+	}
+}
+
 func TestBuildClawWatchEnvIncludesSelectedPorts(t *testing.T) {
 	env := buildClawWatchEnv([]string{"BASE=1"}, proc.Ports{
 		CDP:       9012,


### PR DESCRIPTION
## Summary
- Pass the BrowserOS runtime product into dev Chromium launches for BrowserOS and BrowserClaw.
- Wire WXT-launched browsers through `BROWSEROS_PRODUCT` and validate accepted product values.
- Keep the new BrowserClaw extension key active and add focused regression tests for WXT config args.

## Design
The dev launcher now selects `browseros` or `browserclaw` once per watch mode and forwards it to WXT via env. WXT configs append the matching `--browseros-product=...` switch, while the Go non-WXT launch path carries the same product through `browser.BuildArgs`.

## Test plan
- [x] `bun run check`
- [x] `bun run test:main`
- [x] `bun test apps/app/web-ext.config.test.ts apps/claw-app/web-ext.config.test.ts`
- [x] `cd tools/dev && go test ./... && go vet ./... && go build ./...`
- [x] live `bun run dev:claw:watch` smoke via CDP confirmed `chrome://newtab/` resolves to `chrome-extension://pjimfkbpehlcllblajnpfamdfjhhlgkc/newtab.html`