### PR TITLE
feat: add dogfood target flags

### DIFF
--- a/packages/browseros-agent/tools/dogfood/README.md
+++ b/packages/browseros-agent/tools/dogfood/README.md
@@ -1,6 +1,6 @@
 # browseros-dogfood
 
-Internal BrowserOS dogfooding CLI for running the current checkout against a copied BrowserOS profile.
+Internal BrowserOS dogfooding CLI for running BrowserOS or BrowserClaw against a copied BrowserOS profile.
 
 ## What It Does
 
@@ -10,9 +10,10 @@ High level:
 
 - You point it at a BrowserOS repo clone used for alpha dogfooding.
 - It tracks a configured branch for that clone and switches to it before builds and update commands.
-- It imports your normal BrowserOS profile into a separate dev profile.
-- It keeps BrowserOS state under `~/.browseros-dogfood`, separate from your normal app state.
-- It builds the local extension, starts the local server, and launches the installed BrowserOS app with the alpha Dock icon against them.
+- It imports your normal BrowserOS profile into a target-specific dogfood profile.
+- It keeps BrowserOS and BrowserClaw state separate from your normal app state and from each other.
+- For BrowserOS, it builds the local extension, starts the local server, and launches the installed BrowserOS app with the alpha Dock icon against them.
+- For BrowserClaw, it starts the BrowserClaw WXT app and standalone Claw server against the installed BrowserOS app.
 - It does not auto-pull on `start`; you choose when to update the checkout.
 
 ## Requirements
@@ -42,10 +43,11 @@ browseros-dogfood --help
 
 ## First-Time Setup
 
-Run:
+Run one or both target setup commands:
 
 ```bash
-browseros-dogfood init
+browseros-dogfood --browseros init
+browseros-dogfood --claw init
 ```
 
 `init` asks for:
@@ -62,41 +64,45 @@ If you have multiple BrowserOS profiles, `init` reads them and shows their real 
 ## Daily Use
 
 ```bash
-browseros-dogfood start
+browseros-dogfood --browseros start
+browseros-dogfood --claw start
 ```
 
-`start` is sync: it runs in your terminal. Press `Ctrl+C` to cancel and stop BrowserOS and the local server.
+`start` is sync: it runs in your terminal. Press `Ctrl+C` to cancel and stop the selected target environment.
 
 For async mode:
 
 ```bash
-browseros-dogfood start-background
+browseros-dogfood --browseros start-background
+browseros-dogfood --claw start-background
 ```
 
 `start-background` keeps running after the command returns. Use the CLI to manage it:
 
 ```bash
-browseros-dogfood status
-browseros-dogfood pull
-browseros-dogfood restart
-browseros-dogfood restart --pull
-browseros-dogfood logs
-browseros-dogfood logs tail
-browseros-dogfood stop
+browseros-dogfood --claw status
+browseros-dogfood --claw pull
+browseros-dogfood --claw restart
+browseros-dogfood --claw restart --pull
+browseros-dogfood --claw logs
+browseros-dogfood --claw logs tail
+browseros-dogfood --claw stop
 ```
 
 - `start` switches a clean checkout to the configured branch before building. It still does not pull.
 - `pull` switches to the configured branch and updates the configured repo for the next sync start.
 - `restart --pull` switches to the configured branch, updates the configured repo, rebuilds, and restarts when new changes land upstream.
-- `logs` prints log file paths; `logs tail` follows background dogfood, BrowserOS, and server logs.
-- `start` and `start-background` use the same lock, so only one dogfood environment runs at a time.
+- `logs` prints log file paths; `logs tail` follows background dogfood, browser/app, and server logs.
+- BrowserOS and BrowserClaw use separate locks, sockets, state files, profiles, and logs.
 
 ## State And Profile Safety
 
 `browseros-dogfood` keeps alpha dogfood separate from normal BrowserOS:
 
 - BrowserOS state, including the local server state and VM data, lives under `~/.browseros-dogfood`.
-- The imported dev profile lives under `~/.config/browseros-dogfood/profile`.
+- BrowserClaw state lives under `~/.browseros-claw-dogfood`.
+- The imported BrowserOS dogfood profile lives under `~/.config/browseros-dogfood/browseros/profile`.
+- The imported BrowserClaw dogfood profile lives under `~/.config/browseros-dogfood/claw/profile`.
 - Your installed BrowserOS profile is only used as the source import. It is not where alpha dogfood runs.
 - Installed extensions, extension-specific settings/state, and extension-owned IndexedDB data are copied so dogfood sessions keep extension setup close to your normal profile.
 - Cache and broad site storage directories are not copied.
@@ -104,7 +110,8 @@ browseros-dogfood stop
 To re-import your main profile:
 
 ```bash
-browseros-dogfood start --refresh-profile
+browseros-dogfood --browseros start --refresh-profile
+browseros-dogfood --claw start --refresh-profile
 ```
 
 If BrowserOS appears to be using the source profile during import, the CLI asks you to quit BrowserOS and press Enter before copying. You can type `continue` if the lock files are stale and you want to import anyway.

--- a/packages/browseros-agent/tools/dogfood/cmd/control.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/control.go
@@ -44,7 +44,7 @@ var statusCmd = &cobra.Command{
 	Short:   "Show dogfood background daemon status",
 	GroupID: groupInspect,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		target, _, err := loadSelectedTargetConfigWithoutValidation()
+		target, err := selectedRequiredTarget()
 		if err != nil {
 			return err
 		}
@@ -62,7 +62,7 @@ var stopCmd = &cobra.Command{
 	Short:   "Stop the dogfood background daemon",
 	GroupID: groupRun,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		target, _, err := loadSelectedTargetConfigWithoutValidation()
+		target, err := selectedRequiredTarget()
 		if err != nil {
 			return err
 		}
@@ -79,7 +79,7 @@ var restartCmd = &cobra.Command{
 	Short:   "Rebuild/restart current checkout; --pull updates, --pull --force resets",
 	GroupID: groupRun,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		target, _, err := loadSelectedTargetConfigWithoutValidation()
+		target, err := selectedRequiredTarget()
 		if err != nil {
 			return err
 		}
@@ -91,7 +91,7 @@ var restartCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		if _, err := sendControlWithPaths(paths, request); err != nil {
+		if _, err := sendControlWithPaths(paths, target, request); err != nil {
 			return err
 		}
 		fmt.Fprintln(os.Stdout, successStyle.Sprint("Restart requested."))
@@ -118,7 +118,7 @@ var logsTailCmd = &cobra.Command{
 	Use:   "tail",
 	Short: "Tail daemon, chromium, and server logs from the background daemon",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		target, _, err := loadSelectedTargetConfigWithoutValidation()
+		target, err := selectedRequiredTarget()
 		if err != nil {
 			return err
 		}
@@ -126,7 +126,7 @@ var logsTailCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		resp, err := sendControlWithPaths(paths, ipc.Request{Command: ipc.CmdStatus})
+		resp, err := sendControlWithPaths(paths, target, ipc.Request{Command: ipc.CmdStatus})
 		if err != nil {
 			return err
 		}
@@ -175,13 +175,13 @@ func sendControl(target config.Target, req ipc.Request) (ipc.Response, error) {
 	if err != nil {
 		return ipc.Response{}, err
 	}
-	return sendControlWithPaths(paths, req)
+	return sendControlWithPaths(paths, target, req)
 }
 
-func sendControlWithPaths(paths runPaths, req ipc.Request) (ipc.Response, error) {
+func sendControlWithPaths(paths runPaths, target config.Target, req ipc.Request) (ipc.Response, error) {
 	resp, err := ipc.NewClient(paths.Socket).Send(req)
 	if err != nil {
-		return ipc.Response{}, daemonUnavailableError(paths, err)
+		return ipc.Response{}, daemonUnavailableError(paths, target, err)
 	}
 	if resp.Error != "" {
 		return ipc.Response{}, errors.New(resp.Error)
@@ -189,7 +189,7 @@ func sendControlWithPaths(paths runPaths, req ipc.Request) (ipc.Response, error)
 	return resp, nil
 }
 
-func daemonUnavailableError(paths runPaths, cause error) error {
+func daemonUnavailableError(paths runPaths, target config.Target, cause error) error {
 	lock, err := dogfoodruntime.AcquireLock(paths.Lock)
 	if err == nil {
 		_ = lock.Close()
@@ -201,7 +201,11 @@ func daemonUnavailableError(paths runPaths, cause error) error {
 		if stateErr == nil && state.Mode == "foreground" {
 			return fmt.Errorf("browseros-dogfood is running in foreground mode (pid %d); background daemon commands are unavailable", state.PID)
 		}
-		return fmt.Errorf("browseros-dogfood background daemon is not responding; try `browseros-dogfood stop` if it is stuck, then `browseros-dogfood start-background`")
+		targetFlag, err := selectedTargetFlag(target)
+		if err != nil {
+			targetFlag = "--browseros"
+		}
+		return fmt.Errorf("browseros-dogfood background daemon is not responding; try `browseros-dogfood %s stop` if it is stuck, then `browseros-dogfood %s start-background`", targetFlag, targetFlag)
 	}
 	return err
 }
@@ -225,7 +229,7 @@ func monitorDaemonUntilRunning(ctx context.Context, monitor daemonMonitor) error
 	status := monitor.Status
 	if status == nil {
 		status = func() (ipc.Response, error) {
-			return sendControlWithPaths(monitor.Paths, ipc.Request{Command: ipc.CmdStatus})
+			return sendControlWithPaths(monitor.Paths, monitor.Target, ipc.Request{Command: ipc.CmdStatus})
 		}
 	}
 	follow := monitor.Follow
@@ -242,7 +246,7 @@ func monitorDaemonUntilRunning(ctx context.Context, monitor daemonMonitor) error
 		})
 	}()
 
-	if done, err := daemonReachedTerminalState(status); done || err != nil {
+	if done, err := daemonReachedTerminalState(status, monitor.Target); done || err != nil {
 		return err
 	}
 	ticker := time.NewTicker(pollInterval)
@@ -266,14 +270,14 @@ func monitorDaemonUntilRunning(ctx context.Context, monitor daemonMonitor) error
 				return err
 			}
 		case <-ticker.C:
-			if done, err := daemonReachedTerminalState(status); done || err != nil {
+			if done, err := daemonReachedTerminalState(status, monitor.Target); done || err != nil {
 				return err
 			}
 		}
 	}
 }
 
-func daemonReachedTerminalState(status func() (ipc.Response, error)) (bool, error) {
+func daemonReachedTerminalState(status func() (ipc.Response, error), target config.Target) (bool, error) {
 	resp, err := status()
 	if err != nil {
 		return false, err
@@ -286,7 +290,11 @@ func daemonReachedTerminalState(status func() (ipc.Response, error)) (bool, erro
 		if lastError == "" {
 			lastError = "daemon entered error state"
 		}
-		return true, fmt.Errorf("%s; run `browseros-dogfood logs tail` for details", lastError)
+		targetFlag, err := selectedTargetFlag(target)
+		if err != nil {
+			targetFlag = "--browseros"
+		}
+		return true, fmt.Errorf("%s; run `browseros-dogfood %s logs tail` for details", lastError, targetFlag)
 	default:
 		return false, nil
 	}

--- a/packages/browseros-agent/tools/dogfood/cmd/control.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/control.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"browseros-dogfood/config"
 	"browseros-dogfood/ipc"
 	"browseros-dogfood/proc"
 	"browseros-dogfood/runlog"
@@ -27,6 +28,7 @@ const defaultMonitorPollInterval = 250 * time.Millisecond
 
 type daemonMonitor struct {
 	Paths        runPaths
+	Target       config.Target
 	Out          io.Writer
 	Filter       string
 	FromStart    bool
@@ -39,10 +41,14 @@ type daemonMonitor struct {
 
 var statusCmd = &cobra.Command{
 	Use:     "status",
-	Short:   "Show browseros-dogfood background daemon status",
+	Short:   "Show dogfood background daemon status",
 	GroupID: groupInspect,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		resp, err := sendControl(ipc.Request{Command: ipc.CmdStatus})
+		target, _, err := loadSelectedTargetConfigWithoutValidation()
+		if err != nil {
+			return err
+		}
+		resp, err := sendControl(target, ipc.Request{Command: ipc.CmdStatus})
 		if err != nil {
 			return err
 		}
@@ -53,13 +59,17 @@ var statusCmd = &cobra.Command{
 
 var stopCmd = &cobra.Command{
 	Use:     "stop",
-	Short:   "Stop the browseros-dogfood background daemon",
+	Short:   "Stop the dogfood background daemon",
 	GroupID: groupRun,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		if _, err := sendControl(ipc.Request{Command: ipc.CmdStop}); err != nil {
+		target, _, err := loadSelectedTargetConfigWithoutValidation()
+		if err != nil {
 			return err
 		}
-		fmt.Printf("%s browseros-dogfood background daemon\n", successStyle.Sprint("Stopping:"))
+		if _, err := sendControl(target, ipc.Request{Command: ipc.CmdStop}); err != nil {
+			return err
+		}
+		fmt.Printf("%s %s background daemon\n", successStyle.Sprint("Stopping:"), targetLabel(target))
 		return nil
 	},
 }
@@ -69,11 +79,15 @@ var restartCmd = &cobra.Command{
 	Short:   "Rebuild/restart current checkout; --pull updates, --pull --force resets",
 	GroupID: groupRun,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		target, _, err := loadSelectedTargetConfigWithoutValidation()
+		if err != nil {
+			return err
+		}
 		request, err := buildRestartRequest(restartPull, restartForce)
 		if err != nil {
 			return err
 		}
-		paths, err := defaultRunPaths()
+		paths, err := defaultTargetRunPaths(target)
 		if err != nil {
 			return err
 		}
@@ -86,6 +100,7 @@ var restartCmd = &cobra.Command{
 		detached := false
 		if err := monitorDaemonUntilRunning(cmd.Context(), daemonMonitor{
 			Paths:    paths,
+			Target:   target,
 			Out:      os.Stdout,
 			Detach:   detach,
 			Detached: &detached,
@@ -93,7 +108,7 @@ var restartCmd = &cobra.Command{
 			return err
 		}
 		if !detached {
-			fmt.Printf("%s browseros-dogfood background environment is healthy\n", successStyle.Sprint("Ready:"))
+			fmt.Printf("%s %s background environment is healthy\n", successStyle.Sprint("Ready:"), targetLabel(target))
 		}
 		return nil
 	},
@@ -103,7 +118,11 @@ var logsTailCmd = &cobra.Command{
 	Use:   "tail",
 	Short: "Tail daemon, chromium, and server logs from the background daemon",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		paths, err := defaultRunPaths()
+		target, _, err := loadSelectedTargetConfigWithoutValidation()
+		if err != nil {
+			return err
+		}
+		paths, err := defaultTargetRunPaths(target)
 		if err != nil {
 			return err
 		}
@@ -151,8 +170,8 @@ func buildRestartRequest(pull bool, force bool) (ipc.Request, error) {
 	return request, nil
 }
 
-func sendControl(req ipc.Request) (ipc.Response, error) {
-	paths, err := defaultRunPaths()
+func sendControl(target config.Target, req ipc.Request) (ipc.Response, error) {
+	paths, err := defaultTargetRunPaths(target)
 	if err != nil {
 		return ipc.Response{}, err
 	}
@@ -236,7 +255,11 @@ func monitorDaemonUntilRunning(ctx context.Context, monitor daemonMonitor) error
 			if monitor.Detached != nil {
 				*monitor.Detached = true
 			}
-			fmt.Fprintf(out, "%s daemon still running. Run %s to reattach.\n", warnStyle.Sprint("Detached;"), commandStyle.Sprint("browseros-dogfood logs tail"))
+			targetFlag, err := selectedTargetFlag(monitor.Target)
+			if err != nil {
+				targetFlag = "--browseros"
+			}
+			fmt.Fprintf(out, "%s daemon still running. Run %s to reattach.\n", warnStyle.Sprint("Detached;"), commandStyle.Sprintf("browseros-dogfood %s logs tail", targetFlag))
 			return nil
 		case err := <-followErr:
 			if err != nil && ctx.Err() == nil {
@@ -315,6 +338,8 @@ func formatRunLogEntry(entry runlog.Entry) string {
 	switch entry.Tag {
 	case "daemon":
 		style = warnStyle
+	case "agent":
+		style = proc.TagAgent.Color
 	case "browser":
 		style = proc.TagBrowser.Color
 	case "server":
@@ -345,6 +370,9 @@ func formatStatus(data any) string {
 		return string(raw) + "\n"
 	}
 	var out strings.Builder
+	if target, ok := stringValue(status["target"]); ok && target != "" {
+		fmt.Fprintf(&out, "%s %s\n", labelStyle.Sprint("Target:"), target)
+	}
 	writeStringField(&out, "State", status["state"])
 	writeNumberField(&out, "PID", status["pid"])
 	writeStringField(&out, "Uptime", status["uptime"])
@@ -355,18 +383,37 @@ func formatStatus(data any) string {
 		fmt.Fprintf(&out, "%s %s\n", warnStyle.Sprint("Last error:"), lastError)
 	}
 	if ports, ok := status["ports"].(map[string]any); ok {
-		fmt.Fprintf(
-			&out,
-			"%s CDP=%d Server=%d Extension=%d\n",
-			labelStyle.Sprint("Ports:"),
-			intValue(ports["CDP"]),
-			intValue(ports["Server"]),
-			intValue(ports["Extension"]),
-		)
+		target, _ := stringValue(status["target"])
+		if target == string(config.TargetClaw) {
+			fmt.Fprintf(&out, "%s CDP=%d API=%d\n", labelStyle.Sprint("Ports:"), intValue(ports["CDP"]), intValue(ports["Server"]))
+		} else {
+			fmt.Fprintf(
+				&out,
+				"%s CDP=%d Server=%d Extension=%d\n",
+				labelStyle.Sprint("Ports:"),
+				intValue(ports["CDP"]),
+				intValue(ports["Server"]),
+				intValue(ports["Extension"]),
+			)
+		}
 	}
-	writeStringField(&out, "BrowserOS dir", status["browseros_dir"])
+	target, _ := stringValue(status["target"])
+	if target == string(config.TargetClaw) {
+		writeStringField(&out, "Claw state", firstStatusValue(status["state_dir"], status["browseros_dir"]))
+	} else {
+		writeStringField(&out, "BrowserOS dir", status["browseros_dir"])
+	}
 	writeStringField(&out, "Logs", status["log_path"])
 	return out.String()
+}
+
+func firstStatusValue(values ...any) any {
+	for _, value := range values {
+		if s, ok := stringValue(value); ok && s != "" {
+			return s
+		}
+	}
+	return nil
 }
 
 func writeStringField(out *strings.Builder, label string, value any) {

--- a/packages/browseros-agent/tools/dogfood/cmd/control.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/control.go
@@ -194,6 +194,9 @@ func daemonUnavailableError(paths runPaths, target config.Target, cause error) e
 	if err == nil {
 		_ = lock.Close()
 		_ = dogfoodruntime.CleanupStaleRunFiles(paths.State)
+		if errors.Is(cause, ipc.ErrDaemonNotRunning) {
+			return fmt.Errorf("%w; start it with `browseros-dogfood %s start-background`", cause, targetFlagOrDefault(target))
+		}
 		return cause
 	}
 	if errors.Is(err, dogfoodruntime.ErrAlreadyRunning) {

--- a/packages/browseros-agent/tools/dogfood/cmd/control.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/control.go
@@ -201,10 +201,7 @@ func daemonUnavailableError(paths runPaths, target config.Target, cause error) e
 		if stateErr == nil && state.Mode == "foreground" {
 			return fmt.Errorf("browseros-dogfood is running in foreground mode (pid %d); background daemon commands are unavailable", state.PID)
 		}
-		targetFlag, err := selectedTargetFlag(target)
-		if err != nil {
-			targetFlag = "--browseros"
-		}
+		targetFlag := targetFlagOrDefault(target)
 		return fmt.Errorf("browseros-dogfood background daemon is not responding; try `browseros-dogfood %s stop` if it is stuck, then `browseros-dogfood %s start-background`", targetFlag, targetFlag)
 	}
 	return err
@@ -259,10 +256,7 @@ func monitorDaemonUntilRunning(ctx context.Context, monitor daemonMonitor) error
 			if monitor.Detached != nil {
 				*monitor.Detached = true
 			}
-			targetFlag, err := selectedTargetFlag(monitor.Target)
-			if err != nil {
-				targetFlag = "--browseros"
-			}
+			targetFlag := targetFlagOrDefault(monitor.Target)
 			fmt.Fprintf(out, "%s daemon still running. Run %s to reattach.\n", warnStyle.Sprint("Detached;"), commandStyle.Sprintf("browseros-dogfood %s logs tail", targetFlag))
 			return nil
 		case err := <-followErr:
@@ -290,10 +284,7 @@ func daemonReachedTerminalState(status func() (ipc.Response, error), target conf
 		if lastError == "" {
 			lastError = "daemon entered error state"
 		}
-		targetFlag, err := selectedTargetFlag(target)
-		if err != nil {
-			targetFlag = "--browseros"
-		}
+		targetFlag := targetFlagOrDefault(target)
 		return true, fmt.Errorf("%s; run `browseros-dogfood %s logs tail` for details", lastError, targetFlag)
 	default:
 		return false, nil

--- a/packages/browseros-agent/tools/dogfood/cmd/control_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/control_test.go
@@ -137,6 +137,28 @@ func TestDaemonUnavailableErrorIncludesTargetCommands(t *testing.T) {
 	}
 }
 
+func TestDaemonUnavailableErrorIncludesTargetStartWhenNotRunning(t *testing.T) {
+	dir := t.TempDir()
+	paths := runPaths{
+		Dir:    dir,
+		Lock:   filepath.Join(dir, "run.lock"),
+		State:  filepath.Join(dir, "state.json"),
+		Socket: filepath.Join(dir, "daemon.sock"),
+	}
+
+	err := daemonUnavailableError(paths, config.TargetClaw, ipc.ErrDaemonNotRunning)
+	if err == nil {
+		t.Fatal("expected daemon unavailable error")
+	}
+	got := err.Error()
+	if !strings.Contains(got, "browseros-dogfood --claw start-background") {
+		t.Fatalf("missing target-specific start command: %v", err)
+	}
+	if strings.Contains(got, "browseros-dogfood start-background") {
+		t.Fatalf("contains targetless start command: %v", err)
+	}
+}
+
 func TestRootUsageShowsRestartPullAndOmitsUpdate(t *testing.T) {
 	usage := stripANSI(rootCmd.UsageString())
 	if !strings.Contains(usage, "restart          Rebuild/restart current checkout; --pull updates, --pull --force resets") {

--- a/packages/browseros-agent/tools/dogfood/cmd/control_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/control_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"browseros-dogfood/config"
 	"browseros-dogfood/ipc"
 	"browseros-dogfood/runlog"
 )
@@ -35,6 +36,33 @@ func TestFormatStatusDataUsesHumanReadableSummary(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("formatted status missing %q:\n%s", want, got)
 		}
+	}
+}
+
+func TestFormatStatusDataForClawOmitsExtensionPort(t *testing.T) {
+	got := formatStatus(map[string]any{
+		"target":    string(config.TargetClaw),
+		"state":     "running",
+		"state_dir": "/tmp/browseros-claw-dogfood",
+		"log_path":  "/tmp/browseros-dogfood/claw/daemon.jsonl",
+		"ports": map[string]any{
+			"CDP":       float64(49337),
+			"Server":    float64(9200),
+			"Extension": float64(9315),
+		},
+	})
+	for _, want := range []string{
+		"Target: claw",
+		"Ports: CDP=49337 API=9200",
+		"Claw state: /tmp/browseros-claw-dogfood",
+		"Logs: /tmp/browseros-dogfood/claw/daemon.jsonl",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("formatted status missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "Extension") {
+		t.Fatalf("claw status should not show extension port:\n%s", got)
 	}
 }
 

--- a/packages/browseros-agent/tools/dogfood/cmd/control_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/control_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"errors"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -10,6 +12,7 @@ import (
 	"browseros-dogfood/config"
 	"browseros-dogfood/ipc"
 	"browseros-dogfood/runlog"
+	dogfoodruntime "browseros-dogfood/runtime"
 )
 
 func TestFormatStatusDataUsesHumanReadableSummary(t *testing.T) {
@@ -99,6 +102,41 @@ func TestBuildRestartRequestRejectsForceWithoutPull(t *testing.T) {
 	}
 }
 
+func TestDaemonUnavailableErrorIncludesTargetCommands(t *testing.T) {
+	dir := t.TempDir()
+	paths := runPaths{
+		Dir:    dir,
+		Lock:   filepath.Join(dir, "run.lock"),
+		State:  filepath.Join(dir, "state.json"),
+		Socket: filepath.Join(dir, "daemon.sock"),
+	}
+	lock, err := dogfoodruntime.AcquireLock(paths.Lock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer lock.Close()
+	if err := dogfoodruntime.WriteRunState(paths.State, dogfoodruntime.RunState{
+		PID:  12345,
+		Mode: "background",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	err = daemonUnavailableError(paths, config.TargetClaw, errors.New("dial failed"))
+	if err == nil {
+		t.Fatal("expected daemon unavailable error")
+	}
+	got := err.Error()
+	for _, want := range []string{
+		"browseros-dogfood --claw stop",
+		"browseros-dogfood --claw start-background",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("missing %q in %q", want, got)
+		}
+	}
+}
+
 func TestRootUsageShowsRestartPullAndOmitsUpdate(t *testing.T) {
 	usage := stripANSI(rootCmd.UsageString())
 	if !strings.Contains(usage, "restart          Rebuild/restart current checkout; --pull updates, --pull --force resets") {
@@ -138,6 +176,7 @@ func TestMonitorDaemonUntilRunningPrintsEntriesAndStops(t *testing.T) {
 
 func TestMonitorDaemonUntilRunningReturnsDaemonError(t *testing.T) {
 	err := monitorDaemonUntilRunning(context.Background(), daemonMonitor{
+		Target:       config.TargetClaw,
 		PollInterval: time.Millisecond,
 		Status: func() (ipc.Response, error) {
 			return ipc.Response{OK: true, Data: map[string]any{
@@ -153,6 +192,9 @@ func TestMonitorDaemonUntilRunningReturnsDaemonError(t *testing.T) {
 	if err == nil || !strings.Contains(err.Error(), "server health check failed") {
 		t.Fatalf("error got %v", err)
 	}
+	if !strings.Contains(err.Error(), "browseros-dogfood --claw logs tail") {
+		t.Fatalf("error missing claw logs command: %v", err)
+	}
 }
 
 func TestMonitorDaemonUntilRunningDetachesOnInterrupt(t *testing.T) {
@@ -161,6 +203,7 @@ func TestMonitorDaemonUntilRunningDetachesOnInterrupt(t *testing.T) {
 	close(detach)
 	err := monitorDaemonUntilRunning(context.Background(), daemonMonitor{
 		Out:          &out,
+		Target:       config.TargetClaw,
 		Detach:       detach,
 		PollInterval: time.Hour,
 		Status: func() (ipc.Response, error) {
@@ -174,7 +217,11 @@ func TestMonitorDaemonUntilRunningDetachesOnInterrupt(t *testing.T) {
 	if err != nil {
 		t.Fatalf("monitor: %v", err)
 	}
-	if !strings.Contains(stripANSI(out.String()), "Detached; daemon still running.") {
+	got := stripANSI(out.String())
+	if !strings.Contains(got, "Detached; daemon still running.") {
 		t.Fatalf("missing detach message in\n%s", out.String())
+	}
+	if !strings.Contains(got, "browseros-dogfood --claw logs tail") {
+		t.Fatalf("missing target-specific tail command in\n%s", out.String())
 	}
 }

--- a/packages/browseros-agent/tools/dogfood/cmd/daemon.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/daemon.go
@@ -74,16 +74,20 @@ func defaultRunPaths() (runPaths, error) {
 	return newRunPaths(path), nil
 }
 
-func daemonArgs(headless bool) []string {
-	args := []string{"daemon"}
+func daemonArgs(target config.Target, headless bool) []string {
+	targetFlag, err := selectedTargetFlag(target)
+	if err != nil {
+		targetFlag = "--browseros"
+	}
+	args := []string{targetFlag, "daemon"}
 	if headless {
 		args = append(args, "--headless")
 	}
 	return args
 }
 
-func daemonArgsWithOptions(headless bool, refreshProfile bool) []string {
-	args := daemonArgs(headless)
+func daemonArgsWithOptions(target config.Target, headless bool, refreshProfile bool) []string {
+	args := daemonArgs(target, headless)
 	if refreshProfile {
 		args = append(args, "--refresh-profile")
 	}
@@ -132,7 +136,7 @@ func runningError(paths runPaths) error {
 	return fmt.Errorf("browseros-dogfood is already running")
 }
 
-func startBackgroundProcess(paths runPaths, headless bool, refreshProfile bool) error {
+func startBackgroundProcess(paths runPaths, target config.Target, headless bool, refreshProfile bool) error {
 	exe, err := os.Executable()
 	if err != nil {
 		return err
@@ -149,7 +153,7 @@ func startBackgroundProcess(paths runPaths, headless bool, refreshProfile bool) 
 	}
 	defer rawLog.Close()
 
-	cmd := exec.Command(exe, daemonArgsWithOptions(headless, refreshProfile)...)
+	cmd := exec.Command(exe, daemonArgsWithOptions(target, headless, refreshProfile)...)
 	cmd.Stdout = rawLog
 	cmd.Stderr = rawLog
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
@@ -174,13 +178,14 @@ func startBackgroundProcess(paths runPaths, headless bool, refreshProfile bool) 
 			return fmt.Errorf("background daemon did not open its control socket; see %s", paths.RawLog)
 		case <-tick.C:
 			if resp, err := ipc.NewClient(paths.Socket).Send(ipc.Request{Command: ipc.CmdStatus}); err == nil && resp.OK {
-				fmt.Printf("%s browseros-dogfood background daemon %s\n", successStyle.Sprint("Started:"), dimStyle.Sprintf("(pid %d)", cmd.Process.Pid))
+				fmt.Printf("%s %s background daemon %s\n", successStyle.Sprint("Started:"), targetLabel(target), dimStyle.Sprintf("(pid %d)", cmd.Process.Pid))
 				fmt.Fprintln(os.Stdout, dimStyle.Sprint("Streaming startup logs until healthy..."))
 				detach, cleanup := newInterruptDetach()
 				defer cleanup()
 				detached := false
 				if err := monitorDaemonUntilRunning(context.Background(), daemonMonitor{
 					Paths:     paths,
+					Target:    target,
 					Out:       os.Stdout,
 					FromStart: true,
 					Detach:    detach,
@@ -191,10 +196,11 @@ func startBackgroundProcess(paths runPaths, headless bool, refreshProfile bool) 
 				if detached {
 					return nil
 				}
-				fmt.Printf("%s browseros-dogfood background environment is healthy\n", successStyle.Sprint("Ready:"))
-				fmt.Printf("  %s %s\n", labelStyle.Sprint("Status:"), commandStyle.Sprint("browseros-dogfood status"))
-				fmt.Printf("  %s   %s\n", labelStyle.Sprint("Logs:"), commandStyle.Sprint("browseros-dogfood logs tail"))
-				fmt.Printf("  %s   %s\n", labelStyle.Sprint("Stop:"), commandStyle.Sprint("browseros-dogfood stop"))
+				targetFlag, _ := selectedTargetFlag(target)
+				fmt.Printf("%s %s background environment is healthy\n", successStyle.Sprint("Ready:"), targetLabel(target))
+				fmt.Printf("  %s %s\n", labelStyle.Sprint("Status:"), commandStyle.Sprintf("browseros-dogfood %s status", targetFlag))
+				fmt.Printf("  %s   %s\n", labelStyle.Sprint("Logs:"), commandStyle.Sprintf("browseros-dogfood %s logs tail", targetFlag))
+				fmt.Printf("  %s   %s\n", labelStyle.Sprint("Stop:"), commandStyle.Sprintf("browseros-dogfood %s stop", targetFlag))
 				return nil
 			}
 		}
@@ -230,6 +236,7 @@ type dogfoodDaemon struct {
 	mu   sync.RWMutex
 
 	env          *environment
+	target       config.Target
 	state        string
 	operation    string
 	lastError    string
@@ -240,6 +247,7 @@ type dogfoodDaemon struct {
 }
 
 type daemonStatus struct {
+	Target       string       `json:"target"`
 	State        string       `json:"state"`
 	Operation    string       `json:"operation,omitempty"`
 	LastError    string       `json:"last_error,omitempty"`
@@ -247,6 +255,7 @@ type daemonStatus struct {
 	Uptime       string       `json:"uptime"`
 	Ports        config.Ports `json:"ports"`
 	BrowserOSDir string       `json:"browseros_dir"`
+	StateDir     string       `json:"state_dir"`
 	LogPath      string       `json:"log_path"`
 }
 
@@ -255,11 +264,11 @@ type healthResponse struct {
 }
 
 func runDaemon(cmd *cobra.Command, args []string) error {
-	cfg, err := loadConfig()
+	target, cfg, err := loadSelectedTargetConfig()
 	if err != nil {
 		return err
 	}
-	paths, err := defaultRunPaths()
+	paths, err := defaultTargetRunPaths(target)
 	if err != nil {
 		return err
 	}
@@ -286,6 +295,7 @@ func runDaemon(cmd *cobra.Command, args []string) error {
 		cancel:       cancel,
 		paths:        paths,
 		logWriter:    logWriter,
+		target:       target,
 		state:        "starting",
 		startedAt:    time.Now(),
 		headless:     daemonHeadless,
@@ -344,6 +354,7 @@ func (d *dogfoodDaemon) status() daemonStatus {
 	d.mu.RLock()
 	defer d.mu.RUnlock()
 	return daemonStatus{
+		Target:       string(d.target),
 		State:        d.state,
 		Operation:    d.operation,
 		LastError:    d.lastError,
@@ -351,6 +362,7 @@ func (d *dogfoodDaemon) status() daemonStatus {
 		Uptime:       time.Since(d.startedAt).Round(time.Second).String(),
 		Ports:        d.ports,
 		BrowserOSDir: d.browserOSDir,
+		StateDir:     d.browserOSDir,
 		LogPath:      d.paths.Log,
 	}
 }
@@ -361,7 +373,7 @@ func (d *dogfoodDaemon) scheduleRestart(pull bool, force bool) error {
 	}
 	return d.scheduleOperation("restarting", func() error {
 		if pull {
-			cfg, err := loadConfig()
+			cfg, err := loadTargetConfig(d.target)
 			if err != nil {
 				return err
 			}
@@ -419,7 +431,7 @@ func (d *dogfoodDaemon) scheduleOperation(name string, fn func() error) error {
 }
 
 func (d *dogfoodDaemon) startLocked(refreshProfile bool) error {
-	cfg, err := loadConfig()
+	cfg, err := loadTargetConfig(d.target)
 	if err != nil {
 		return err
 	}
@@ -497,16 +509,16 @@ func (d *dogfoodDaemon) logLifecycle(format string, args ...any) {
 
 func (d *dogfoodDaemon) waitUntilHealthy(cfg config.Config, maxAttempts int, interval time.Duration) error {
 	d.logLifecycle("waiting for server health")
-	if err := waitForServerHealth(d.ctx, cfg.Ports.Server, maxAttempts, interval); err != nil {
+	if err := waitForServerHealth(d.ctx, cfg, maxAttempts, interval); err != nil {
 		return err
 	}
 	d.logLifecycle("server healthy")
 	return nil
 }
 
-func waitForServerHealth(ctx context.Context, port int, maxAttempts int, interval time.Duration) error {
+func waitForServerHealth(ctx context.Context, cfg config.Config, maxAttempts int, interval time.Duration) error {
 	client := &http.Client{Timeout: time.Second}
-	url := fmt.Sprintf("http://127.0.0.1:%d/health", port)
+	url := healthURL(cfg)
 	var lastErr error
 	for range maxAttempts {
 		if ctx.Err() != nil {
@@ -538,4 +550,11 @@ func waitForServerHealth(ctx context.Context, port int, maxAttempts int, interva
 		return fmt.Errorf("server health check failed: %w", lastErr)
 	}
 	return fmt.Errorf("server health check failed")
+}
+
+func healthURL(cfg config.Config) string {
+	if cfg.Target == config.TargetClaw {
+		return fmt.Sprintf("http://127.0.0.1:%d/system/health", cfg.Ports.Server)
+	}
+	return fmt.Sprintf("http://127.0.0.1:%d/health", cfg.Ports.Server)
 }

--- a/packages/browseros-agent/tools/dogfood/cmd/daemon_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/daemon_test.go
@@ -16,21 +16,21 @@ import (
 )
 
 func TestRunPathsLiveBesideConfig(t *testing.T) {
-	paths := newRunPaths(filepath.Join("/tmp", "browseros-dogfood", "config.yaml"))
-	if paths.Lock != filepath.Join("/tmp", "browseros-dogfood", "run.lock") {
+	paths := newTargetRunPaths(filepath.Join("/tmp", "browseros-dogfood", "config.yaml"), config.TargetClaw)
+	if paths.Lock != filepath.Join("/tmp", "browseros-dogfood", "claw", "run.lock") {
 		t.Fatalf("lock path got %q", paths.Lock)
 	}
-	if paths.Socket != filepath.Join("/tmp", "browseros-dogfood", "daemon.sock") {
+	if paths.Socket != filepath.Join("/tmp", "browseros-dogfood", "claw", "daemon.sock") {
 		t.Fatalf("socket path got %q", paths.Socket)
 	}
-	if paths.Log != filepath.Join("/tmp", "browseros-dogfood", "daemon.jsonl") {
+	if paths.Log != filepath.Join("/tmp", "browseros-dogfood", "claw", "daemon.jsonl") {
 		t.Fatalf("log path got %q", paths.Log)
 	}
 }
 
 func TestDaemonArgsIncludeHeadlessWhenRequested(t *testing.T) {
-	got := daemonArgs(true)
-	want := []string{"daemon", "--headless"}
+	got := daemonArgs(config.TargetClaw, true)
+	want := []string{"--claw", "daemon", "--headless"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("got %#v want %#v", got, want)
 	}
@@ -89,7 +89,7 @@ func TestWaitForServerHealthRequiresCDPConnectedWhenPresent(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := waitForServerHealth(ctx, port, 5, 10*time.Millisecond); err != nil {
+	if err := waitForServerHealth(ctx, config.Config{Ports: config.Ports{Server: port}}, 5, 10*time.Millisecond); err != nil {
 		t.Fatalf("wait health: %v", err)
 	}
 	if requests < 2 {
@@ -105,8 +105,18 @@ func TestWaitForServerHealthAcceptsMissingCDPConnected(t *testing.T) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
-	if err := waitForServerHealth(ctx, port, 1, 10*time.Millisecond); err != nil {
+	if err := waitForServerHealth(ctx, config.Config{Ports: config.Ports{Server: port}}, 1, 10*time.Millisecond); err != nil {
 		t.Fatalf("wait health: %v", err)
+	}
+}
+
+func TestHealthURLUsesClawSystemHealth(t *testing.T) {
+	got := healthURL(config.Config{
+		Target: config.TargetClaw,
+		Ports:  config.Ports{Server: 9200},
+	})
+	if got != "http://127.0.0.1:9200/system/health" {
+		t.Fatalf("got %q", got)
 	}
 }
 

--- a/packages/browseros-agent/tools/dogfood/cmd/init.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/init.go
@@ -22,14 +22,24 @@ func init() {
 
 var initCmd = &cobra.Command{
 	Use:     "init",
-	Short:   "Create or update browseros-dogfood config",
+	Short:   "Create or update dogfood config",
 	GroupID: groupSetup,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		target, ok, err := selectedTarget()
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return fmt.Errorf("choose a dogfood target with --browseros or --claw")
+		}
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return err
 		}
 		cfg := config.Defaults(home)
+		if err := cfg.ApplyTarget(target); err != nil {
+			return err
+		}
 		if cwd, err := os.Getwd(); err == nil && looksLikeRepo(cwd) {
 			cfg.RepoPath = cwd
 		}
@@ -62,16 +72,17 @@ var initCmd = &cobra.Command{
 		if err := pipeline.WriteProductionEnvFiles(cfg.AgentRoot(), cfg); err != nil {
 			return err
 		}
-		printInitNextSteps(cmd.OutOrStdout(), path)
+		printInitNextSteps(cmd.OutOrStdout(), path, target)
 		return nil
 	},
 }
 
-func printInitNextSteps(out io.Writer, path string) {
+func printInitNextSteps(out io.Writer, path string, target config.Target) {
+	targetFlag, _ := selectedTargetFlag(target)
 	fmt.Fprintf(out, "%s %s\n", successStyle.Sprint("Config written:"), pathStyle.Sprint(path))
-	fmt.Fprintln(out, labelStyle.Sprint("Start BrowserOS dogfood:"))
-	fmt.Fprintf(out, "  %s     %s\n", labelStyle.Sprint("Inline:"), commandStyle.Sprint("browseros-dogfood start"))
-	fmt.Fprintf(out, "  %s %s\n", labelStyle.Sprint("Background:"), commandStyle.Sprint("browseros-dogfood start-background"))
+	fmt.Fprintf(out, "%s %s\n", labelStyle.Sprint("Start dogfood:"), targetLabel(target))
+	fmt.Fprintf(out, "  %s     %s\n", labelStyle.Sprint("Inline:"), commandStyle.Sprintf("browseros-dogfood %s start", targetFlag))
+	fmt.Fprintf(out, "  %s %s\n", labelStyle.Sprint("Background:"), commandStyle.Sprintf("browseros-dogfood %s start-background", targetFlag))
 }
 
 func printRepoPathHelp(out io.Writer) {

--- a/packages/browseros-agent/tools/dogfood/cmd/init.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/init.go
@@ -36,11 +36,15 @@ var initCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		cfg := config.Defaults(home)
-		if err := cfg.ApplyTarget(target); err != nil {
+		path, err := config.Path()
+		if err != nil {
 			return err
 		}
-		if cwd, err := os.Getwd(); err == nil && looksLikeRepo(cwd) {
+		cfg, err := loadInitConfig(home, path, target)
+		if err != nil {
+			return err
+		}
+		if cwd, err := os.Getwd(); err == nil && cfg.RepoPath == "" && looksLikeRepo(cwd) {
 			cfg.RepoPath = cwd
 		}
 		reader := bufio.NewReader(os.Stdin)
@@ -62,10 +66,6 @@ var initCmd = &cobra.Command{
 		if err := cfg.Validate(); err != nil {
 			return err
 		}
-		path, err := config.Path()
-		if err != nil {
-			return err
-		}
 		if err := config.Save(path, cfg); err != nil {
 			return err
 		}
@@ -75,6 +75,20 @@ var initCmd = &cobra.Command{
 		printInitNextSteps(cmd.OutOrStdout(), path, target)
 		return nil
 	},
+}
+
+// loadInitConfig preserves existing target settings while allowing first-run defaults.
+func loadInitConfig(home string, path string, target config.Target) (config.Config, error) {
+	cfg := config.Defaults(home)
+	if existing, err := config.Load(path); err == nil {
+		cfg = existing
+	} else if !os.IsNotExist(err) {
+		return config.Config{}, fmt.Errorf("load existing config: %w", err)
+	}
+	if err := cfg.ApplyTarget(target); err != nil {
+		return config.Config{}, err
+	}
+	return cfg, nil
 }
 
 func printInitNextSteps(out io.Writer, path string, target config.Target) {

--- a/packages/browseros-agent/tools/dogfood/cmd/init_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/init_test.go
@@ -6,18 +6,20 @@ import (
 	"strings"
 	"testing"
 
+	"browseros-dogfood/config"
 	"browseros-dogfood/profile"
 )
 
 func TestPrintInitNextStepsShowsInlineAndBackgroundStart(t *testing.T) {
 	var out bytes.Buffer
-	printInitNextSteps(&out, "/tmp/config.yaml")
+	printInitNextSteps(&out, "/tmp/config.yaml", config.TargetClaw)
 
 	got := out.String()
 	for _, want := range []string{
 		"Config written: /tmp/config.yaml",
-		"Inline:     browseros-dogfood start",
-		"Background: browseros-dogfood start-background",
+		"Start dogfood: BrowserClaw",
+		"Inline:     browseros-dogfood --claw start",
+		"Background: browseros-dogfood --claw start-background",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("missing %q in\n%s", want, got)

--- a/packages/browseros-agent/tools/dogfood/cmd/init_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/init_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"bytes"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -24,6 +25,36 @@ func TestPrintInitNextStepsShowsInlineAndBackgroundStart(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("missing %q in\n%s", want, got)
 		}
+	}
+}
+
+func TestLoadInitConfigPreservesExistingOtherTarget(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	cfg := config.Defaults(home)
+	if err := cfg.ApplyTarget(config.TargetBrowserOS); err != nil {
+		t.Fatal(err)
+	}
+	cfg.DevUserDataDir = "/custom-browseros-profile"
+	cfg.BrowserOSDir = "/custom-browseros-state"
+	if err := config.Save(path, cfg); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := loadInitConfig(home, path, config.TargetClaw)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got.Target != config.TargetClaw {
+		t.Fatalf("target got %q want claw", got.Target)
+	}
+	browseros := got.Targets[string(config.TargetBrowserOS)]
+	if browseros.DevUserDataDir != "/custom-browseros-profile" || browseros.BrowserOSDir != "/custom-browseros-state" {
+		t.Fatalf("browseros target was not preserved: %+v", browseros)
+	}
+	if got.DevUserDataDir != filepath.Join(home, ".config/browseros-dogfood/claw/profile") {
+		t.Fatalf("active target profile got %q", got.DevUserDataDir)
 	}
 }
 

--- a/packages/browseros-agent/tools/dogfood/cmd/logs.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/logs.go
@@ -16,10 +16,10 @@ func init() {
 
 var logsCmd = &cobra.Command{
 	Use:     "logs",
-	Short:   "Print browseros-dogfood log files",
+	Short:   "Print dogfood log files",
 	GroupID: groupInspect,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := loadConfigWithoutValidation()
+		_, cfg, err := loadSelectedTargetConfigWithoutValidation()
 		if err != nil {
 			return err
 		}

--- a/packages/browseros-agent/tools/dogfood/cmd/pull.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/pull.go
@@ -17,10 +17,10 @@ func init() {
 
 var pullCmd = &cobra.Command{
 	Use:     "pull",
-	Short:   "Refresh the configured BrowserOS checkout",
+	Short:   "Refresh the configured checkout",
 	GroupID: groupRun,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := loadConfig()
+		_, cfg, err := loadSelectedTargetConfig()
 		if err != nil {
 			return err
 		}

--- a/packages/browseros-agent/tools/dogfood/cmd/refresh_profile.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/refresh_profile.go
@@ -30,7 +30,7 @@ var refreshProfileCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		lock, err := acquireRefreshProfileLock(paths)
+		lock, err := acquireRefreshProfileLock(paths, target)
 		if err != nil {
 			return err
 		}
@@ -54,7 +54,7 @@ var refreshProfileCmd = &cobra.Command{
 	},
 }
 
-func acquireRefreshProfileLock(paths runPaths) (*dogfoodruntime.Lock, error) {
+func acquireRefreshProfileLock(paths runPaths, target config.Target) (*dogfoodruntime.Lock, error) {
 	lock, err := dogfoodruntime.AcquireLock(paths.Lock)
 	if err == nil {
 		if cleanupErr := dogfoodruntime.CleanupStaleRunFiles(paths.State); cleanupErr != nil {
@@ -64,20 +64,21 @@ func acquireRefreshProfileLock(paths runPaths) (*dogfoodruntime.Lock, error) {
 		return lock, nil
 	}
 	if errors.Is(err, dogfoodruntime.ErrAlreadyRunning) {
-		return nil, refreshProfileRunningError(paths)
+		return nil, refreshProfileRunningError(paths, target)
 	}
 	return nil, err
 }
 
-func refreshProfileRunningError(paths runPaths) error {
+func refreshProfileRunningError(paths runPaths, target config.Target) error {
+	targetFlag := targetFlagOrDefault(target)
 	state, err := dogfoodruntime.ReadRunState(paths.State)
 	if err == nil {
 		if state.Mode == "background" {
-			return fmt.Errorf("cannot refresh profile while browseros-dogfood background daemon is running (pid %d); run `browseros-dogfood stop` first", state.PID)
+			return fmt.Errorf("cannot refresh profile while browseros-dogfood background daemon is running (pid %d); run `browseros-dogfood %s stop` first", state.PID, targetFlag)
 		}
 		return fmt.Errorf("cannot refresh profile while browseros-dogfood is running in foreground mode (pid %d); stop it first", state.PID)
 	}
-	return fmt.Errorf("cannot refresh profile while browseros-dogfood is running; run `browseros-dogfood stop` first")
+	return fmt.Errorf("cannot refresh profile while browseros-dogfood is running; run `browseros-dogfood %s stop` first", targetFlag)
 }
 
 func ensureDevProfileNotInUse(cfg config.Config) error {
@@ -86,30 +87,8 @@ func ensureDevProfileNotInUse(cfg config.Config) error {
 		return err
 	}
 	if inUse {
-		return fmt.Errorf("cannot refresh profile because the dogfood dev profile is in use at %s; run `browseros-dogfood stop` first", cfg.DevUserDataDir)
+		targetFlag := targetFlagOrDefault(cfg.Target)
+		return fmt.Errorf("cannot refresh profile because the dogfood dev profile is in use at %s; run `browseros-dogfood %s stop` first", cfg.DevUserDataDir, targetFlag)
 	}
 	return nil
-}
-
-func loadConfig() (config.Config, error) {
-	cfg, err := loadConfigWithoutValidation()
-	if err != nil {
-		return config.Config{}, err
-	}
-	if err := cfg.Validate(); err != nil {
-		return config.Config{}, err
-	}
-	return cfg, nil
-}
-
-func loadConfigWithoutValidation() (config.Config, error) {
-	path, err := config.Path()
-	if err != nil {
-		return config.Config{}, err
-	}
-	cfg, err := config.Load(path)
-	if err != nil {
-		return config.Config{}, fmt.Errorf("missing config at %s; run browseros-dogfood init: %w", path, err)
-	}
-	return cfg, nil
 }

--- a/packages/browseros-agent/tools/dogfood/cmd/refresh_profile.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/refresh_profile.go
@@ -19,14 +19,14 @@ func init() {
 
 var refreshProfileCmd = &cobra.Command{
 	Use:     "refresh-profile",
-	Short:   "Copy the configured BrowserOS profile into the browseros-dogfood dev profile",
+	Short:   "Copy the configured BrowserOS profile into the selected dogfood profile",
 	GroupID: groupRun,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := loadConfig()
+		target, cfg, err := loadSelectedTargetConfig()
 		if err != nil {
 			return err
 		}
-		paths, err := defaultRunPaths()
+		paths, err := defaultTargetRunPaths(target)
 		if err != nil {
 			return err
 		}
@@ -49,7 +49,7 @@ var refreshProfileCmd = &cobra.Command{
 		}); err != nil {
 			return err
 		}
-		fmt.Printf("%s %s\n", successStyle.Sprint("Profile refreshed:"), pathStyle.Sprint(cfg.DevUserDataDir))
+		fmt.Printf("%s %s\n", successStyle.Sprintf("%s profile refreshed:", targetLabel(target)), pathStyle.Sprint(cfg.DevUserDataDir))
 		return nil
 	},
 }

--- a/packages/browseros-agent/tools/dogfood/cmd/refresh_profile_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/refresh_profile_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestAcquireRefreshProfileLockReportsStopCommandWhenRunning(t *testing.T) {
-	paths := newRunPaths(filepath.Join(t.TempDir(), "config.yaml"))
+	paths := newTargetRunPaths(filepath.Join(t.TempDir(), "config.yaml"), config.TargetClaw)
 	lock, err := dogfoodruntime.AcquireLock(paths.Lock)
 	if err != nil {
 		t.Fatal(err)
@@ -24,12 +24,12 @@ func TestAcquireRefreshProfileLockReportsStopCommandWhenRunning(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	_, err = acquireRefreshProfileLock(paths)
+	_, err = acquireRefreshProfileLock(paths, config.TargetClaw)
 
 	if err == nil {
 		t.Fatal("expected refresh profile lock error")
 	}
-	for _, want := range []string{"cannot refresh profile", "browseros-dogfood stop", "12345"} {
+	for _, want := range []string{"cannot refresh profile", "browseros-dogfood --claw stop", "12345"} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error missing %q: %v", want, err)
 		}
@@ -42,12 +42,15 @@ func TestEnsureDevProfileNotInUseReportsStopCommand(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err := ensureDevProfileNotInUse(config.Config{DevUserDataDir: devUserDataDir})
+	err := ensureDevProfileNotInUse(config.Config{
+		Target:         config.TargetClaw,
+		DevUserDataDir: devUserDataDir,
+	})
 
 	if err == nil {
 		t.Fatal("expected dev profile in-use error")
 	}
-	for _, want := range []string{"cannot refresh profile", "browseros-dogfood stop", devUserDataDir} {
+	for _, want := range []string{"cannot refresh profile", "browseros-dogfood --claw stop", devUserDataDir} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error missing %q: %v", want, err)
 		}

--- a/packages/browseros-agent/tools/dogfood/cmd/root.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/root.go
@@ -8,9 +8,18 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:               "browseros-dogfood",
-	Short:             "BrowserOS dogfooding CLI",
-	Long:              "browseros-dogfood - BrowserOS dogfooding CLI",
+	Use:   "browseros-dogfood",
+	Short: "BrowserOS dogfooding CLI",
+	Long:  "browseros-dogfood - BrowserOS dogfooding CLI",
+	Example: `  browseros-dogfood --browseros init
+  browseros-dogfood --claw init
+  browseros-dogfood --browseros start
+  browseros-dogfood --claw start
+  browseros-dogfood --claw start-background
+  browseros-dogfood --claw status
+  browseros-dogfood --claw logs tail
+  browseros-dogfood --claw restart --pull
+  browseros-dogfood --claw stop`,
 	CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
 	SilenceUsage:      true,
 	SilenceErrors:     true,

--- a/packages/browseros-agent/tools/dogfood/cmd/root_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/root_test.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"browseros-dogfood/config"
+
 	"github.com/spf13/cobra"
 )
 
@@ -17,13 +19,66 @@ func TestRootUsageUsesCommandGroups(t *testing.T) {
 		"Setup:",
 		"Run:",
 		"Inspect:",
+		"browseros-dogfood --browseros init",
+		"browseros-dogfood --claw start",
 		"start",
-		"Start BrowserOS dogfooding environment",
+		"Start dogfooding environment",
 		"Use \"browseros-dogfood [command] --help\" for more information.",
 	} {
 		if !strings.Contains(usage, want) {
 			t.Fatalf("missing %q in\n%s", want, usage)
 		}
+	}
+}
+
+func TestResolveTargetFlags(t *testing.T) {
+	tests := []struct {
+		name        string
+		browserOS   bool
+		claw        bool
+		wantTarget  config.Target
+		wantPresent bool
+		wantErr     bool
+	}{
+		{name: "browseros", browserOS: true, wantTarget: config.TargetBrowserOS, wantPresent: true},
+		{name: "claw", claw: true, wantTarget: config.TargetClaw, wantPresent: true},
+		{name: "none"},
+		{name: "both", browserOS: true, claw: true, wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, present, err := resolveTargetFlags(tt.browserOS, tt.claw)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.wantTarget || present != tt.wantPresent {
+				t.Fatalf("got target=%q present=%v want target=%q present=%v", got, present, tt.wantTarget, tt.wantPresent)
+			}
+		})
+	}
+}
+
+func TestCommandRequiresTargetForLifecycleCommands(t *testing.T) {
+	root := &cobra.Command{Use: "browseros-dogfood"}
+	logs := &cobra.Command{Use: "logs"}
+	tail := &cobra.Command{Use: "tail"}
+	configCmd := &cobra.Command{Use: "config"}
+	edit := &cobra.Command{Use: "edit"}
+	logs.AddCommand(tail)
+	configCmd.AddCommand(edit)
+	root.AddCommand(logs, configCmd)
+
+	if !commandRequiresTarget(tail) {
+		t.Fatal("logs tail should require target")
+	}
+	if commandRequiresTarget(edit) {
+		t.Fatal("config edit should not require target")
 	}
 }
 

--- a/packages/browseros-agent/tools/dogfood/cmd/start.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/start.go
@@ -29,8 +29,10 @@ var startBackgroundRefreshProfile bool
 var startBackgroundHeadless bool
 
 const (
-	serverLogName   = "server.log"
-	chromiumLogName = "chromium.log"
+	serverLogName     = "server.log"
+	chromiumLogName   = "chromium.log"
+	clawAppLogName    = "claw-app.log"
+	clawServerLogName = "claw-server.log"
 )
 
 func init() {
@@ -44,17 +46,17 @@ func init() {
 
 var startCmd = &cobra.Command{
 	Use:     "start",
-	Short:   "Start BrowserOS dogfooding environment",
+	Short:   "Start dogfooding environment",
 	GroupID: groupRun,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := loadConfig()
+		target, cfg, err := loadSelectedTargetConfig()
 		if err != nil {
 			return err
 		}
 		if err := promptIfSourceProfileInUse(cmd.OutOrStdout(), bufio.NewReader(os.Stdin), cfg, startRefreshProfile); err != nil {
 			return err
 		}
-		paths, err := defaultRunPaths()
+		paths, err := defaultTargetRunPaths(target)
 		if err != nil {
 			return err
 		}
@@ -75,17 +77,17 @@ var startCmd = &cobra.Command{
 
 var startBackgroundCmd = &cobra.Command{
 	Use:     "start-background",
-	Short:   "Start BrowserOS dogfooding environment in the background",
+	Short:   "Start dogfooding environment in the background",
 	GroupID: groupRun,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := loadConfig()
+		target, cfg, err := loadSelectedTargetConfig()
 		if err != nil {
 			return err
 		}
 		if err := promptIfSourceProfileInUse(cmd.OutOrStdout(), bufio.NewReader(os.Stdin), cfg, startBackgroundRefreshProfile); err != nil {
 			return err
 		}
-		paths, err := defaultRunPaths()
+		paths, err := defaultTargetRunPaths(target)
 		if err != nil {
 			return err
 		}
@@ -99,7 +101,7 @@ var startBackgroundCmd = &cobra.Command{
 		} else {
 			return err
 		}
-		return startBackgroundProcess(paths, startBackgroundHeadless, startBackgroundRefreshProfile)
+		return startBackgroundProcess(paths, target, startBackgroundHeadless, startBackgroundRefreshProfile)
 	},
 }
 
@@ -168,15 +170,38 @@ func buildAndStartEnvironment(ctx context.Context, cfg config.Config, opts envir
 	} else if dirty {
 		fmt.Fprintln(os.Stderr, warnStyle.Sprint("warning: checkout has uncommitted changes; start will use current files"))
 	}
+	switch cfg.Target {
+	case config.TargetBrowserOS:
+		return buildAndStartBrowserOSEnvironment(ctx, cfg, agentRoot, opts)
+	case config.TargetClaw:
+		return buildAndStartClawEnvironment(ctx, cfg, agentRoot, opts)
+	default:
+		return nil, fmt.Errorf("unknown dogfood target %q", cfg.Target)
+	}
+}
+
+func buildAndStartBrowserOSEnvironment(ctx context.Context, cfg config.Config, agentRoot string, opts environmentOptions) (*environment, error) {
 	reportProgress(opts, "preparing profile")
-	if err := prepareEnvironment(&cfg, agentRoot, opts); err != nil {
+	if err := prepareBrowserOSEnvironment(&cfg, agentRoot, opts); err != nil {
 		return nil, err
 	}
 	reportProgress(opts, "building agent")
 	if err := pipeline.Build(ctx, agentRoot, opts.Runner); err != nil {
 		return nil, err
 	}
-	return startEnvironment(ctx, cfg, agentRoot, opts)
+	return startBrowserOSEnvironment(ctx, cfg, agentRoot, opts)
+}
+
+func buildAndStartClawEnvironment(ctx context.Context, cfg config.Config, agentRoot string, opts environmentOptions) (*environment, error) {
+	reportProgress(opts, "preparing profile")
+	if err := prepareClawEnvironment(&cfg, opts); err != nil {
+		return nil, err
+	}
+	reportProgress(opts, "preparing Claw apps")
+	if err := pipeline.Setup(ctx, agentRoot, opts.Runner); err != nil {
+		return nil, err
+	}
+	return startClawEnvironment(ctx, cfg, agentRoot, opts)
 }
 
 // prepareStartCheckout ensures start builds the configured branch without discarding local edits.
@@ -198,7 +223,7 @@ func prepareStartCheckout(ctx context.Context, cfg config.Config, runner pipelin
 	return true, nil
 }
 
-func prepareEnvironment(cfg *config.Config, agentRoot string, opts environmentOptions) error {
+func prepareProfile(cfg *config.Config, opts environmentOptions) error {
 	if profileImportNeeded(*cfg, opts.RefreshProfile) {
 		if err := profile.Import(profile.ImportConfig{
 			SourceUserDataDir: cfg.SourceUserDataDir,
@@ -211,10 +236,28 @@ func prepareEnvironment(cfg *config.Config, agentRoot string, opts environmentOp
 	} else if err := profile.CleanupSingletons(cfg.DevUserDataDir); err != nil {
 		return err
 	}
+	return nil
+}
+
+func prepareBrowserOSEnvironment(cfg *config.Config, agentRoot string, opts environmentOptions) error {
+	if err := prepareProfile(cfg, opts); err != nil {
+		return err
+	}
 	if err := pipeline.WriteProductionEnvFiles(agentRoot, *cfg); err != nil {
 		return err
 	}
-	resolvedPorts, changed, err := proc.ResolvePorts(cfg.Ports)
+	return resolveEnvironmentPorts(cfg, true)
+}
+
+func prepareClawEnvironment(cfg *config.Config, opts environmentOptions) error {
+	if err := prepareProfile(cfg, opts); err != nil {
+		return err
+	}
+	return resolveEnvironmentPorts(cfg, false)
+}
+
+func resolveEnvironmentPorts(cfg *config.Config, includeExtension bool) error {
+	resolvedPorts, changed, err := proc.ResolveTargetPorts(cfg.Ports, includeExtension)
 	if err != nil {
 		return err
 	}
@@ -227,9 +270,9 @@ func prepareEnvironment(cfg *config.Config, agentRoot string, opts environmentOp
 		if err := config.Save(path, *cfg); err != nil {
 			return err
 		}
-		proc.LogMsgf(proc.TagInfo, "Busy ports detected; using CDP=%d Server=%d Extension=%d", cfg.Ports.CDP, cfg.Ports.Server, cfg.Ports.Extension)
+		proc.LogMsgf(proc.TagInfo, "Busy ports detected; using %s", formatPortsForTarget(*cfg))
 	} else {
-		proc.LogMsgf(proc.TagInfo, "Using ports CDP=%d Server=%d Extension=%d", cfg.Ports.CDP, cfg.Ports.Server, cfg.Ports.Extension)
+		proc.LogMsgf(proc.TagInfo, "Using ports %s", formatPortsForTarget(*cfg))
 	}
 	return nil
 }
@@ -240,7 +283,7 @@ func reportProgress(opts environmentOptions, message string) {
 	}
 }
 
-func startEnvironment(parent context.Context, cfg config.Config, agentRoot string, opts environmentOptions) (*environment, error) {
+func startBrowserOSEnvironment(parent context.Context, cfg config.Config, agentRoot string, opts environmentOptions) (*environment, error) {
 	ctx, cancel := context.WithCancel(parent)
 	e := &environment{cancel: cancel, cfg: cfg}
 	reportProgress(opts, "launching Chromium")
@@ -272,6 +315,8 @@ func startEnvironment(parent context.Context, cfg config.Config, agentRoot strin
 	serverDir := filepath.Join(agentRoot, "apps/server")
 	sidecarPath := dogfoodSidecarConfigPath(cfg)
 	if err := writeDogfoodSidecarConfig(sidecarPath, cfg, agentRoot); err != nil {
+		e.Stop()
+		e.Wait()
 		return nil, fmt.Errorf("write server config: %w", err)
 	}
 	reportProgress(opts, "starting server")
@@ -282,6 +327,52 @@ func startEnvironment(parent context.Context, cfg config.Config, agentRoot strin
 		Restart:     true,
 		LogPath:     cfg.LogPath(serverLogName),
 		Cmd:         serverCommand(sidecarPath),
+		LineHandler: opts.LineHandler,
+	}))
+	printSummary(cfg, agentRoot)
+	return e, nil
+}
+
+func startClawEnvironment(parent context.Context, cfg config.Config, agentRoot string, opts environmentOptions) (*environment, error) {
+	ctx, cancel := context.WithCancel(parent)
+	e := &environment{cancel: cancel, cfg: cfg}
+	runtimeEnv := clawRuntimeEnv(os.Environ(), cfg)
+
+	reportProgress(opts, "starting Claw WXT")
+	e.managed = append(e.managed, proc.StartManaged(ctx, &e.wg, proc.ProcConfig{
+		Tag:         proc.TagAgent,
+		Dir:         filepath.Join(agentRoot, "apps/claw-app"),
+		Env:         runtimeEnv,
+		Restart:     true,
+		LogPath:     cfg.LogPath(clawAppLogName),
+		Cmd:         clawAppCommand(),
+		LineHandler: opts.LineHandler,
+	}))
+
+	reportProgress(opts, "waiting for CDP")
+	proc.LogMsg(proc.TagServer, "Waiting for CDP...")
+	if browser.WaitForCDP(ctx, cfg.Ports.CDP, 60) {
+		reportProgress(opts, "CDP ready")
+		proc.LogMsg(proc.TagServer, "CDP ready")
+	} else {
+		reportProgress(opts, "CDP not available, starting server anyway")
+		proc.LogMsg(proc.TagServer, proc.WarnColor.Sprint("CDP not available, starting server anyway"))
+	}
+
+	sidecarPath := dogfoodSidecarConfigPath(cfg)
+	if err := writeDogfoodSidecarConfig(sidecarPath, cfg, agentRoot); err != nil {
+		e.Stop()
+		e.Wait()
+		return nil, fmt.Errorf("write Claw server config: %w", err)
+	}
+	reportProgress(opts, "starting Claw server")
+	e.managed = append(e.managed, proc.StartManaged(ctx, &e.wg, proc.ProcConfig{
+		Tag:         proc.TagServer,
+		Dir:         filepath.Join(agentRoot, "apps/claw-server"),
+		Env:         runtimeEnv,
+		Restart:     true,
+		LogPath:     cfg.LogPath(clawServerLogName),
+		Cmd:         clawServerCommand(sidecarPath),
 		LineHandler: opts.LineHandler,
 	}))
 	printSummary(cfg, agentRoot)
@@ -318,6 +409,14 @@ func serverCommand(configPath string) []string {
 	return []string{"bun", "--env-file=.env.development", "src/index.ts", "--config", configPath}
 }
 
+func clawAppCommand() []string {
+	return []string{"bun", "--env-file=.env.development", "wxt"}
+}
+
+func clawServerCommand(configPath string) []string {
+	return []string{"bun", "--watch", "--env-file=.env.development", "src/main.ts", "--config", configPath}
+}
+
 func serverRuntimeEnv(base []string, cfg config.Config) []string {
 	env := make([]string, 0, len(base)+2)
 	for _, entry := range base {
@@ -332,6 +431,31 @@ func serverRuntimeEnv(base []string, cfg config.Config) []string {
 	)
 }
 
+func clawRuntimeEnv(base []string, cfg config.Config) []string {
+	env := make([]string, 0, len(base)+7)
+	for _, entry := range base {
+		if strings.HasPrefix(entry, "BROWSEROS_DIR=") ||
+			strings.HasPrefix(entry, "BROWSEROS_BINARY=") ||
+			strings.HasPrefix(entry, "BROWSEROS_USER_DATA_DIR=") ||
+			strings.HasPrefix(entry, "BROWSEROS_CLAW_CDP_PORT=") ||
+			strings.HasPrefix(entry, "BROWSEROS_SERVER_PORT=") ||
+			strings.HasPrefix(entry, "VITE_BROWSEROS_CLAW_API_URL=") {
+			continue
+		}
+		env = append(env, entry)
+	}
+	apiURL := fmt.Sprintf("http://127.0.0.1:%d", cfg.Ports.Server)
+	return append(env,
+		"NODE_ENV=development",
+		fmt.Sprintf("BROWSEROS_DIR=%s", cfg.BrowserOSDir),
+		fmt.Sprintf("BROWSEROS_BINARY=%s", cfg.BrowserOSAppPath),
+		fmt.Sprintf("BROWSEROS_USER_DATA_DIR=%s", cfg.DevUserDataDir),
+		fmt.Sprintf("BROWSEROS_CLAW_CDP_PORT=%d", cfg.Ports.CDP),
+		fmt.Sprintf("BROWSEROS_SERVER_PORT=%d", cfg.Ports.Server),
+		fmt.Sprintf("VITE_BROWSEROS_CLAW_API_URL=%s", apiURL),
+	)
+}
+
 func exists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
@@ -339,12 +463,36 @@ func exists(path string) bool {
 
 func printSummary(cfg config.Config, agentRoot string) {
 	fmt.Println()
+	proc.LogMsgf(proc.TagInfo, "Target: %s", targetLabel(cfg.Target))
 	proc.LogMsgf(proc.TagInfo, "App: %s", cfg.BrowserOSAppPath)
 	proc.LogMsgf(proc.TagInfo, "Repo: %s", cfg.RepoPath)
 	proc.LogMsgf(proc.TagInfo, "Agent root: %s", agentRoot)
 	proc.LogMsgf(proc.TagInfo, "Profile: %s", cfg.DevUserDataDir)
-	proc.LogMsgf(proc.TagInfo, "BrowserOS dir: %s", cfg.BrowserOSDir)
+	proc.LogMsgf(proc.TagInfo, "%s: %s", stateDirLabel(cfg.Target), cfg.BrowserOSDir)
 	proc.LogMsgf(proc.TagInfo, "Logs: %s", cfg.LogDir())
-	proc.LogMsgf(proc.TagInfo, "Ports: CDP=%d Server=%d Extension=%d", cfg.Ports.CDP, cfg.Ports.Server, cfg.Ports.Extension)
+	proc.LogMsgf(proc.TagInfo, "Ports: %s", formatPortsForTarget(cfg))
 	fmt.Println()
+}
+
+func targetLabel(target config.Target) string {
+	switch target {
+	case config.TargetClaw:
+		return "BrowserClaw"
+	default:
+		return "BrowserOS"
+	}
+}
+
+func stateDirLabel(target config.Target) string {
+	if target == config.TargetClaw {
+		return "Claw state"
+	}
+	return "BrowserOS dir"
+}
+
+func formatPortsForTarget(cfg config.Config) string {
+	if cfg.Target == config.TargetClaw {
+		return fmt.Sprintf("CDP=%d API=%d", cfg.Ports.CDP, cfg.Ports.Server)
+	}
+	return fmt.Sprintf("CDP=%d Server=%d Extension=%d", cfg.Ports.CDP, cfg.Ports.Server, cfg.Ports.Extension)
 }

--- a/packages/browseros-agent/tools/dogfood/cmd/start.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/start.go
@@ -159,6 +159,7 @@ func runEnvironment(cfg config.Config, opts environmentOptions) error {
 	return nil
 }
 
+// buildAndStartEnvironment prepares the selected target and starts its supervised processes.
 func buildAndStartEnvironment(ctx context.Context, cfg config.Config, opts environmentOptions) (*environment, error) {
 	if opts.Runner == nil {
 		opts.Runner = pipeline.ExecRunner{}
@@ -431,6 +432,7 @@ func serverRuntimeEnv(base []string, cfg config.Config) []string {
 	)
 }
 
+// clawRuntimeEnv wires the WXT app and standalone Claw server to the same BrowserOS session.
 func clawRuntimeEnv(base []string, cfg config.Config) []string {
 	env := make([]string, 0, len(base)+7)
 	for _, entry := range base {

--- a/packages/browseros-agent/tools/dogfood/cmd/start.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/start.go
@@ -213,7 +213,7 @@ func prepareStartCheckout(ctx context.Context, cfg config.Config, runner pipelin
 	}
 	if !dirty {
 		if err := pipeline.EnsureBranch(ctx, cfg.RepoPath, cfg.Branch, runner, false); err != nil {
-			return false, fmt.Errorf("switch to configured branch %s failed; run `browseros-dogfood pull` first if the branch is not available locally: %w", cfg.Branch, err)
+			return false, fmt.Errorf("switch to configured branch %s failed; run `browseros-dogfood %s pull` first if the branch is not available locally: %w", cfg.Branch, targetFlagOrDefault(cfg.Target), err)
 		}
 		return false, nil
 	}

--- a/packages/browseros-agent/tools/dogfood/cmd/start_branch_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/start_branch_test.go
@@ -100,11 +100,15 @@ func TestPrepareStartCheckoutWrapsCleanSwitchFailure(t *testing.T) {
 			"git switch dogfood": errors.New("fatal: invalid reference: dogfood"),
 		},
 	}
-	cfg := config.Config{RepoPath: "/repo", Branch: "dogfood"}
+	cfg := config.Config{
+		Target:   config.TargetClaw,
+		RepoPath: "/repo",
+		Branch:   "dogfood",
+	}
 
 	_, err := prepareStartCheckout(context.Background(), cfg, r)
 
-	if err == nil || !strings.Contains(err.Error(), "run `browseros-dogfood pull` first") {
+	if err == nil || !strings.Contains(err.Error(), "run `browseros-dogfood --claw pull` first") {
 		t.Fatalf("error got %v", err)
 	}
 }

--- a/packages/browseros-agent/tools/dogfood/cmd/start_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/start_test.go
@@ -16,6 +16,20 @@ func TestServerCommandDoesNotWatchFiles(t *testing.T) {
 	}
 }
 
+func TestClawCommandsUseStandaloneWXTAndServer(t *testing.T) {
+	app := clawAppCommand()
+	wantApp := []string{"bun", "--env-file=.env.development", "wxt"}
+	if !reflect.DeepEqual(app, wantApp) {
+		t.Fatalf("claw app command got %#v want %#v", app, wantApp)
+	}
+
+	server := clawServerCommand("/tmp/claw-server.json")
+	wantServer := []string{"bun", "--watch", "--env-file=.env.development", "src/main.ts", "--config", "/tmp/claw-server.json"}
+	if !reflect.DeepEqual(server, wantServer) {
+		t.Fatalf("claw server command got %#v want %#v", server, wantServer)
+	}
+}
+
 func TestReportProgressInvokesConfiguredProgress(t *testing.T) {
 	var got []string
 	reportProgress(environmentOptions{
@@ -27,6 +41,42 @@ func TestReportProgressInvokesConfiguredProgress(t *testing.T) {
 	want := []string{"checking repo"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("progress got %#v want %#v", got, want)
+	}
+}
+
+func TestClawRuntimeEnvWiresBrowserAndAPISettings(t *testing.T) {
+	got := clawRuntimeEnv([]string{
+		"PATH=/bin",
+		"BROWSEROS_DIR=/wrong",
+		"BROWSEROS_CLAW_CDP_PORT=1",
+		"VITE_BROWSEROS_CLAW_API_URL=http://wrong",
+	}, config.Config{
+		BrowserOSAppPath: "/Applications/BrowserOS.app/Contents/MacOS/BrowserOS",
+		DevUserDataDir:   "/tmp/claw-profile",
+		BrowserOSDir:     "/tmp/claw-state",
+		Ports:            config.Ports{CDP: 49337, Server: 9200},
+	})
+
+	assertEnvContains(t, got, "PATH=/bin")
+	assertEnvContains(t, got, "NODE_ENV=development")
+	assertEnvContains(t, got, "BROWSEROS_DIR=/tmp/claw-state")
+	assertEnvContains(t, got, "BROWSEROS_BINARY=/Applications/BrowserOS.app/Contents/MacOS/BrowserOS")
+	assertEnvContains(t, got, "BROWSEROS_USER_DATA_DIR=/tmp/claw-profile")
+	assertEnvContains(t, got, "BROWSEROS_CLAW_CDP_PORT=49337")
+	assertEnvContains(t, got, "BROWSEROS_SERVER_PORT=9200")
+	assertEnvContains(t, got, "VITE_BROWSEROS_CLAW_API_URL=http://127.0.0.1:9200")
+	if strings.Contains(strings.Join(got, "\n"), "http://wrong") {
+		t.Fatalf("inherited claw API URL was not overridden: %#v", got)
+	}
+}
+
+func TestFormatPortsForClawOmitsExtensionPort(t *testing.T) {
+	got := formatPortsForTarget(config.Config{
+		Target: config.TargetClaw,
+		Ports:  config.Ports{CDP: 49337, Server: 9200, Extension: 9315},
+	})
+	if got != "CDP=49337 API=9200" {
+		t.Fatalf("got %q", got)
 	}
 }
 

--- a/packages/browseros-agent/tools/dogfood/cmd/target.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/target.go
@@ -99,6 +99,14 @@ func selectedTargetFlag(target config.Target) (string, error) {
 	}
 }
 
+func targetFlagOrDefault(target config.Target) string {
+	flag, err := selectedTargetFlag(target)
+	if err != nil {
+		return "--browseros"
+	}
+	return flag
+}
+
 // loadTargetConfig loads config and projects it to the requested dogfood target.
 func loadTargetConfig(target config.Target) (config.Config, error) {
 	path, err := config.Path()

--- a/packages/browseros-agent/tools/dogfood/cmd/target.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/target.go
@@ -1,0 +1,164 @@
+package cmd
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"browseros-dogfood/config"
+
+	"github.com/spf13/cobra"
+)
+
+var targetBrowserOS bool
+var targetClaw bool
+
+var targetRequiredCommands = map[string]struct{}{
+	"daemon":           {},
+	"init":             {},
+	"logs":             {},
+	"pull":             {},
+	"refresh-profile":  {},
+	"restart":          {},
+	"start":            {},
+	"start-background": {},
+	"status":           {},
+	"stop":             {},
+	"tail":             {},
+}
+
+func init() {
+	rootCmd.PersistentFlags().BoolVarP(&targetBrowserOS, "browseros", "b", false, "Target BrowserOS dogfood")
+	rootCmd.PersistentFlags().BoolVarP(&targetClaw, "claw", "c", false, "Target BrowserClaw dogfood")
+	rootCmd.PersistentPreRunE = requireTargetForLifecycleCommand
+}
+
+func requireTargetForLifecycleCommand(cmd *cobra.Command, args []string) error {
+	if _, _, err := resolveTargetFlags(targetBrowserOS, targetClaw); err != nil {
+		return err
+	}
+	if !commandRequiresTarget(cmd) {
+		return nil
+	}
+	_, ok, err := selectedTarget()
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return fmt.Errorf("choose a dogfood target with --browseros or --claw")
+	}
+	return nil
+}
+
+func commandRequiresTarget(cmd *cobra.Command) bool {
+	for current := cmd; current != nil; current = current.Parent() {
+		if _, ok := targetRequiredCommands[current.Name()]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func selectedTarget() (config.Target, bool, error) {
+	return resolveTargetFlags(targetBrowserOS, targetClaw)
+}
+
+func resolveTargetFlags(browserOS bool, claw bool) (config.Target, bool, error) {
+	switch {
+	case browserOS && claw:
+		return "", false, fmt.Errorf("--browseros and --claw are mutually exclusive")
+	case browserOS:
+		return config.TargetBrowserOS, true, nil
+	case claw:
+		return config.TargetClaw, true, nil
+	default:
+		return "", false, nil
+	}
+}
+
+func selectedTargetFlag(target config.Target) (string, error) {
+	switch target {
+	case config.TargetBrowserOS:
+		return "--browseros", nil
+	case config.TargetClaw:
+		return "--claw", nil
+	default:
+		return "", fmt.Errorf("unknown dogfood target %q", target)
+	}
+}
+
+func loadTargetConfig(target config.Target) (config.Config, error) {
+	path, err := config.Path()
+	if err != nil {
+		return config.Config{}, err
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		return config.Config{}, fmt.Errorf("missing config at %s; run browseros-dogfood --%s init: %w", path, target, err)
+	}
+	if err := cfg.ApplyTarget(target); err != nil {
+		return config.Config{}, err
+	}
+	if err := cfg.Validate(); err != nil {
+		return config.Config{}, err
+	}
+	return cfg, nil
+}
+
+func loadSelectedTargetConfig() (config.Target, config.Config, error) {
+	target, ok, err := selectedTarget()
+	if err != nil {
+		return "", config.Config{}, err
+	}
+	if !ok {
+		return "", config.Config{}, fmt.Errorf("choose a dogfood target with --browseros or --claw")
+	}
+	cfg, err := loadTargetConfig(target)
+	return target, cfg, err
+}
+
+func loadTargetConfigWithoutValidation(target config.Target) (config.Config, error) {
+	path, err := config.Path()
+	if err != nil {
+		return config.Config{}, err
+	}
+	cfg, err := config.Load(path)
+	if err != nil {
+		return config.Config{}, fmt.Errorf("missing config at %s; run browseros-dogfood --%s init: %w", path, target, err)
+	}
+	if err := cfg.ApplyTarget(target); err != nil {
+		return config.Config{}, err
+	}
+	return cfg, nil
+}
+
+func loadSelectedTargetConfigWithoutValidation() (config.Target, config.Config, error) {
+	target, ok, err := selectedTarget()
+	if err != nil {
+		return "", config.Config{}, err
+	}
+	if !ok {
+		return "", config.Config{}, fmt.Errorf("choose a dogfood target with --browseros or --claw")
+	}
+	cfg, err := loadTargetConfigWithoutValidation(target)
+	return target, cfg, err
+}
+
+func defaultTargetRunPaths(target config.Target) (runPaths, error) {
+	path, err := config.Path()
+	if err != nil {
+		return runPaths{}, err
+	}
+	return newTargetRunPaths(path, target), nil
+}
+
+func newTargetRunPaths(configPath string, target config.Target) runPaths {
+	dir := filepath.Join(filepath.Dir(configPath), string(target))
+	return runPaths{
+		Dir:    dir,
+		Lock:   filepath.Join(dir, "run.lock"),
+		State:  filepath.Join(dir, "state.json"),
+		Socket: filepath.Join(dir, "daemon.sock"),
+		Log:    filepath.Join(dir, "daemon.jsonl"),
+		RawLog: filepath.Join(dir, "daemon.log"),
+	}
+}

--- a/packages/browseros-agent/tools/dogfood/cmd/target.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/target.go
@@ -63,6 +63,18 @@ func selectedTarget() (config.Target, bool, error) {
 	return resolveTargetFlags(targetBrowserOS, targetClaw)
 }
 
+// selectedRequiredTarget returns the flag-selected target without reading config.
+func selectedRequiredTarget() (config.Target, error) {
+	target, ok, err := selectedTarget()
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("choose a dogfood target with --browseros or --claw")
+	}
+	return target, nil
+}
+
 func resolveTargetFlags(browserOS bool, claw bool) (config.Target, bool, error) {
 	switch {
 	case browserOS && claw:
@@ -107,12 +119,9 @@ func loadTargetConfig(target config.Target) (config.Config, error) {
 }
 
 func loadSelectedTargetConfig() (config.Target, config.Config, error) {
-	target, ok, err := selectedTarget()
+	target, err := selectedRequiredTarget()
 	if err != nil {
 		return "", config.Config{}, err
-	}
-	if !ok {
-		return "", config.Config{}, fmt.Errorf("choose a dogfood target with --browseros or --claw")
 	}
 	cfg, err := loadTargetConfig(target)
 	return target, cfg, err
@@ -134,12 +143,9 @@ func loadTargetConfigWithoutValidation(target config.Target) (config.Config, err
 }
 
 func loadSelectedTargetConfigWithoutValidation() (config.Target, config.Config, error) {
-	target, ok, err := selectedTarget()
+	target, err := selectedRequiredTarget()
 	if err != nil {
 		return "", config.Config{}, err
-	}
-	if !ok {
-		return "", config.Config{}, fmt.Errorf("choose a dogfood target with --browseros or --claw")
 	}
 	cfg, err := loadTargetConfigWithoutValidation(target)
 	return target, cfg, err

--- a/packages/browseros-agent/tools/dogfood/cmd/target.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/target.go
@@ -32,6 +32,7 @@ func init() {
 	rootCmd.PersistentPreRunE = requireTargetForLifecycleCommand
 }
 
+// requireTargetForLifecycleCommand enforces explicit target choice for runtime commands.
 func requireTargetForLifecycleCommand(cmd *cobra.Command, args []string) error {
 	if _, _, err := resolveTargetFlags(targetBrowserOS, targetClaw); err != nil {
 		return err
@@ -86,6 +87,7 @@ func selectedTargetFlag(target config.Target) (string, error) {
 	}
 }
 
+// loadTargetConfig loads config and projects it to the requested dogfood target.
 func loadTargetConfig(target config.Target) (config.Config, error) {
 	path, err := config.Path()
 	if err != nil {
@@ -151,6 +153,7 @@ func defaultTargetRunPaths(target config.Target) (runPaths, error) {
 	return newTargetRunPaths(path, target), nil
 }
 
+// newTargetRunPaths keeps daemon IPC and logs isolated per dogfood target.
 func newTargetRunPaths(configPath string, target config.Target) runPaths {
 	dir := filepath.Join(filepath.Dir(configPath), string(target))
 	return runPaths{

--- a/packages/browseros-agent/tools/dogfood/config/config.go
+++ b/packages/browseros-agent/tools/dogfood/config/config.go
@@ -159,6 +159,10 @@ func Save(path string, cfg Config) error {
 }
 
 func (c *Config) Resolve() {
+	target := c.Target
+	if target == "" {
+		target = TargetBrowserOS
+	}
 	home, err := os.UserHomeDir()
 	if err != nil {
 		home = ""
@@ -171,7 +175,7 @@ func (c *Config) Resolve() {
 		c.Branch = DefaultBranch
 	}
 	c.Targets = c.resolveTargets(home)
-	_ = c.ApplyTarget(TargetBrowserOS)
+	_ = c.ApplyTarget(target)
 	c.FillProductionEnvDefaults()
 }
 

--- a/packages/browseros-agent/tools/dogfood/config/config.go
+++ b/packages/browseros-agent/tools/dogfood/config/config.go
@@ -154,7 +154,7 @@ func Save(path string, cfg Config) error {
 	if err != nil {
 		return err
 	}
-	header := "# browseros-dogfood configuration\n# Run: browseros-dogfood init to reconfigure\n\n"
+	header := "# browseros-dogfood configuration\n# Run: browseros-dogfood --browseros init or browseros-dogfood --claw init to reconfigure\n\n"
 	return os.WriteFile(path, append([]byte(header), data...), 0644)
 }
 

--- a/packages/browseros-agent/tools/dogfood/config/config.go
+++ b/packages/browseros-agent/tools/dogfood/config/config.go
@@ -18,26 +18,52 @@ type Ports struct {
 	Extension int `yaml:"extension"`
 }
 
+type Target string
+
+const (
+	TargetBrowserOS Target = "browseros"
+	TargetClaw      Target = "claw"
+)
+
+type TargetConfig struct {
+	DevUserDataDir string `yaml:"dev_user_data_dir"`
+	DevProfileDir  string `yaml:"dev_profile_dir"`
+	BrowserOSDir   string `yaml:"browseros_dir"`
+	Ports          Ports  `yaml:"ports"`
+}
+
 type ProductionEnv struct {
 	Server map[string]string `yaml:"server"`
 	CLI    map[string]string `yaml:"cli"`
 }
 
 type Config struct {
-	RepoPath          string        `yaml:"repo_path"`
-	BrowserOSAppPath  string        `yaml:"browseros_app_path"`
-	SourceUserDataDir string        `yaml:"source_user_data_dir"`
-	SourceProfileDir  string        `yaml:"source_profile_dir"`
-	DevUserDataDir    string        `yaml:"dev_user_data_dir"`
-	DevProfileDir     string        `yaml:"dev_profile_dir"`
-	BrowserOSDir      string        `yaml:"browseros_dir"`
-	Branch            string        `yaml:"branch"`
-	Ports             Ports         `yaml:"ports"`
-	ProductionEnv     ProductionEnv `yaml:"production_env"`
+	RepoPath          string                  `yaml:"repo_path"`
+	BrowserOSAppPath  string                  `yaml:"browseros_app_path"`
+	SourceUserDataDir string                  `yaml:"source_user_data_dir"`
+	SourceProfileDir  string                  `yaml:"source_profile_dir"`
+	DevUserDataDir    string                  `yaml:"dev_user_data_dir"`
+	DevProfileDir     string                  `yaml:"dev_profile_dir"`
+	BrowserOSDir      string                  `yaml:"browseros_dir"`
+	Branch            string                  `yaml:"branch"`
+	Ports             Ports                   `yaml:"ports"`
+	Target            Target                  `yaml:"-"`
+	Targets           map[string]TargetConfig `yaml:"targets"`
+	ProductionEnv     ProductionEnv           `yaml:"production_env"`
 }
 
 type packageJSON struct {
 	Name string `json:"name"`
+}
+
+type fileConfig struct {
+	RepoPath          string                  `yaml:"repo_path"`
+	BrowserOSAppPath  string                  `yaml:"browseros_app_path"`
+	SourceUserDataDir string                  `yaml:"source_user_data_dir"`
+	SourceProfileDir  string                  `yaml:"source_profile_dir"`
+	Branch            string                  `yaml:"branch"`
+	Targets           map[string]TargetConfig `yaml:"targets"`
+	ProductionEnv     ProductionEnv           `yaml:"production_env"`
 }
 
 const LogDirName = "logs"
@@ -59,16 +85,33 @@ func DefaultConfigDir(home string) string {
 }
 
 func Defaults(home string) Config {
-	return Config{
+	cfg := Config{
 		BrowserOSAppPath:  "/Applications/BrowserOS.app/Contents/MacOS/BrowserOS",
 		SourceUserDataDir: filepath.Join(home, "Library/Application Support/BrowserOS"),
 		SourceProfileDir:  "Default",
-		DevUserDataDir:    filepath.Join(DefaultConfigDir(home), "profile"),
-		DevProfileDir:     "Default",
-		BrowserOSDir:      filepath.Join(home, ".browseros-dogfood"),
 		Branch:            DefaultBranch,
-		Ports:             Ports{CDP: 9015, Server: 9115, Extension: 9315},
+		Targets:           DefaultTargets(home),
 		ProductionEnv:     DefaultProductionEnv(),
+	}
+	_ = cfg.ApplyTarget(TargetBrowserOS)
+	return cfg
+}
+
+func DefaultTargets(home string) map[string]TargetConfig {
+	cfgDir := DefaultConfigDir(home)
+	return map[string]TargetConfig{
+		string(TargetBrowserOS): {
+			DevUserDataDir: filepath.Join(cfgDir, "browseros", "profile"),
+			DevProfileDir:  "Default",
+			BrowserOSDir:   filepath.Join(home, ".browseros-dogfood"),
+			Ports:          Ports{CDP: 9015, Server: 9115, Extension: 9315},
+		},
+		string(TargetClaw): {
+			DevUserDataDir: filepath.Join(cfgDir, "claw", "profile"),
+			DevProfileDir:  "Default",
+			BrowserOSDir:   filepath.Join(home, ".browseros-claw-dogfood"),
+			Ports:          Ports{CDP: 49337, Server: 9200},
+		},
 	}
 }
 
@@ -87,10 +130,25 @@ func Load(path string) (Config, error) {
 
 func Save(path string, cfg Config) error {
 	cfg.FillProductionEnvDefaults()
+	cfg.CaptureTarget()
+	cfg.Resolve()
+	if cfg.Target != "" {
+		if err := cfg.ApplyTarget(cfg.Target); err != nil {
+			return err
+		}
+	}
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		return err
 	}
-	data, err := yaml.Marshal(cfg)
+	data, err := yaml.Marshal(fileConfig{
+		RepoPath:          cfg.RepoPath,
+		BrowserOSAppPath:  cfg.BrowserOSAppPath,
+		SourceUserDataDir: cfg.SourceUserDataDir,
+		SourceProfileDir:  cfg.SourceProfileDir,
+		Branch:            cfg.Branch,
+		Targets:           cfg.Targets,
+		ProductionEnv:     cfg.ProductionEnv,
+	})
 	if err != nil {
 		return err
 	}
@@ -105,26 +163,96 @@ func (c *Config) Resolve() {
 	}
 	c.RepoPath = ExpandTilde(c.RepoPath, home)
 	c.SourceUserDataDir = ExpandTilde(c.SourceUserDataDir, home)
-	c.DevUserDataDir = ExpandTilde(c.DevUserDataDir, home)
-	c.BrowserOSDir = ExpandTilde(c.BrowserOSDir, home)
 	c.BrowserOSAppPath = ExpandTilde(c.BrowserOSAppPath, home)
 	c.Branch = strings.TrimSpace(c.Branch)
 	if c.Branch == "" {
 		c.Branch = DefaultBranch
 	}
-	if c.DevProfileDir == "" {
-		c.DevProfileDir = "Default"
-	}
-	if c.Ports.CDP == 0 {
-		c.Ports.CDP = 9015
-	}
-	if c.Ports.Server == 0 {
-		c.Ports.Server = 9115
-	}
-	if c.Ports.Extension == 0 {
-		c.Ports.Extension = 9315
-	}
+	c.Targets = c.resolveTargets(home)
+	_ = c.ApplyTarget(TargetBrowserOS)
 	c.FillProductionEnvDefaults()
+}
+
+func (c Config) resolveTargets(home string) map[string]TargetConfig {
+	defaults := DefaultTargets(home)
+	targets := map[string]TargetConfig{}
+	for key, value := range defaults {
+		targets[key] = value
+	}
+	for key, value := range c.Targets {
+		targets[key] = mergeTargetConfig(value, targets[key], home)
+	}
+	if len(c.Targets) == 0 {
+		legacy := TargetConfig{
+			DevUserDataDir: c.DevUserDataDir,
+			DevProfileDir:  c.DevProfileDir,
+			BrowserOSDir:   c.BrowserOSDir,
+			Ports:          c.Ports,
+		}
+		targets[string(TargetBrowserOS)] = mergeTargetConfig(legacy, targets[string(TargetBrowserOS)], home)
+	}
+	for key, value := range targets {
+		targets[key] = mergeTargetConfig(value, defaultsForTarget(defaults, Target(key)), home)
+	}
+	return targets
+}
+
+func defaultsForTarget(defaults map[string]TargetConfig, target Target) TargetConfig {
+	if cfg, ok := defaults[string(target)]; ok {
+		return cfg
+	}
+	return TargetConfig{DevProfileDir: "Default"}
+}
+
+func mergeTargetConfig(value TargetConfig, fallback TargetConfig, home string) TargetConfig {
+	out := fallback
+	if strings.TrimSpace(value.DevUserDataDir) != "" {
+		out.DevUserDataDir = ExpandTilde(value.DevUserDataDir, home)
+	}
+	if strings.TrimSpace(value.DevProfileDir) != "" {
+		out.DevProfileDir = strings.TrimSpace(value.DevProfileDir)
+	}
+	if strings.TrimSpace(value.BrowserOSDir) != "" {
+		out.BrowserOSDir = ExpandTilde(value.BrowserOSDir, home)
+	}
+	if value.Ports.CDP != 0 {
+		out.Ports.CDP = value.Ports.CDP
+	}
+	if value.Ports.Server != 0 {
+		out.Ports.Server = value.Ports.Server
+	}
+	if value.Ports.Extension != 0 {
+		out.Ports.Extension = value.Ports.Extension
+	}
+	return out
+}
+
+func (c *Config) ApplyTarget(target Target) error {
+	settings, ok := c.Targets[string(target)]
+	if !ok {
+		return fmt.Errorf("unknown dogfood target %q", target)
+	}
+	c.Target = target
+	c.DevUserDataDir = settings.DevUserDataDir
+	c.DevProfileDir = settings.DevProfileDir
+	c.BrowserOSDir = settings.BrowserOSDir
+	c.Ports = settings.Ports
+	return nil
+}
+
+func (c *Config) CaptureTarget() {
+	if c.Target == "" {
+		return
+	}
+	if c.Targets == nil {
+		c.Targets = map[string]TargetConfig{}
+	}
+	c.Targets[string(c.Target)] = TargetConfig{
+		DevUserDataDir: c.DevUserDataDir,
+		DevProfileDir:  c.DevProfileDir,
+		BrowserOSDir:   c.BrowserOSDir,
+		Ports:          c.Ports,
+	}
 }
 
 func (c Config) AgentRoot() string {

--- a/packages/browseros-agent/tools/dogfood/config/config.go
+++ b/packages/browseros-agent/tools/dogfood/config/config.go
@@ -97,6 +97,7 @@ func Defaults(home string) Config {
 	return cfg
 }
 
+// DefaultTargets returns isolated BrowserOS and BrowserClaw runtime settings.
 func DefaultTargets(home string) map[string]TargetConfig {
 	cfgDir := DefaultConfigDir(home)
 	return map[string]TargetConfig{
@@ -129,11 +130,12 @@ func Load(path string) (Config, error) {
 }
 
 func Save(path string, cfg Config) error {
+	target := cfg.Target
 	cfg.FillProductionEnvDefaults()
 	cfg.CaptureTarget()
 	cfg.Resolve()
-	if cfg.Target != "" {
-		if err := cfg.ApplyTarget(cfg.Target); err != nil {
+	if target != "" {
+		if err := cfg.ApplyTarget(target); err != nil {
 			return err
 		}
 	}
@@ -227,6 +229,7 @@ func mergeTargetConfig(value TargetConfig, fallback TargetConfig, home string) T
 	return out
 }
 
+// ApplyTarget projects one target's runtime settings onto the active config view.
 func (c *Config) ApplyTarget(target Target) error {
 	settings, ok := c.Targets[string(target)]
 	if !ok {
@@ -240,6 +243,7 @@ func (c *Config) ApplyTarget(target Target) error {
 	return nil
 }
 
+// CaptureTarget stores the active runtime settings back under their selected target.
 func (c *Config) CaptureTarget() {
 	if c.Target == "" {
 		return

--- a/packages/browseros-agent/tools/dogfood/config/config_test.go
+++ b/packages/browseros-agent/tools/dogfood/config/config_test.go
@@ -17,7 +17,7 @@ func TestDefaults(t *testing.T) {
 	if cfg.SourceUserDataDir != filepath.Join(home, "Library/Application Support/BrowserOS") {
 		t.Fatalf("unexpected source dir: %s", cfg.SourceUserDataDir)
 	}
-	if cfg.DevUserDataDir != filepath.Join(home, ".config/browseros-dogfood/profile") {
+	if cfg.DevUserDataDir != filepath.Join(home, ".config/browseros-dogfood/browseros/profile") {
 		t.Fatalf("unexpected dev dir: %s", cfg.DevUserDataDir)
 	}
 	if cfg.BrowserOSDir != filepath.Join(home, ".browseros-dogfood") {
@@ -26,7 +26,7 @@ func TestDefaults(t *testing.T) {
 	if cfg.Branch != "main" {
 		t.Fatalf("unexpected branch: %s", cfg.Branch)
 	}
-	if cfg.LogDir() != filepath.Join(home, ".config/browseros-dogfood/profile/logs") {
+	if cfg.LogDir() != filepath.Join(home, ".config/browseros-dogfood/browseros/profile/logs") {
 		t.Fatalf("unexpected log dir: %s", cfg.LogDir())
 	}
 	if cfg.DevProfileDir != "Default" {
@@ -46,6 +46,25 @@ func TestDefaults(t *testing.T) {
 	}
 	if cfg.ProductionEnv.CLI["R2_UPLOAD_PREFIX"] != "" {
 		t.Fatalf("cli upload prefix got %q want empty", cfg.ProductionEnv.CLI["R2_UPLOAD_PREFIX"])
+	}
+}
+
+func TestClawDefaultsUseSeparateRuntimePaths(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", "")
+	cfg := Defaults(home)
+	if err := cfg.ApplyTarget(TargetClaw); err != nil {
+		t.Fatal(err)
+	}
+
+	if cfg.DevUserDataDir != filepath.Join(home, ".config/browseros-dogfood/claw/profile") {
+		t.Fatalf("unexpected claw profile dir: %s", cfg.DevUserDataDir)
+	}
+	if cfg.BrowserOSDir != filepath.Join(home, ".browseros-claw-dogfood") {
+		t.Fatalf("unexpected claw state dir: %s", cfg.BrowserOSDir)
+	}
+	if cfg.Ports.CDP != 49337 || cfg.Ports.Server != 9200 || cfg.Ports.Extension != 0 {
+		t.Fatalf("unexpected claw ports: %+v", cfg.Ports)
 	}
 }
 
@@ -98,6 +117,73 @@ func TestSaveLoadRoundTrip(t *testing.T) {
 	}
 	if got.ProductionEnv.CLI["R2_BUCKET"] != "browseros" {
 		t.Fatalf("production env mismatch: %#v", got.ProductionEnv)
+	}
+}
+
+func TestLoadLegacyFlatConfigMapsRuntimeToBrowserOSTarget(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	data := []byte(`
+repo_path: /repo
+browseros_app_path: /bin/sh
+source_user_data_dir: /source
+source_profile_dir: Default
+dev_user_data_dir: /legacy-profile
+dev_profile_dir: Profile 1
+browseros_dir: /legacy-state
+branch: main
+ports:
+  cdp: 1111
+  server: 2222
+  extension: 3333
+`)
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	browseros := cfg.Targets[string(TargetBrowserOS)]
+	if browseros.DevUserDataDir != "/legacy-profile" || browseros.BrowserOSDir != "/legacy-state" {
+		t.Fatalf("legacy runtime not mapped to browseros target: %+v", browseros)
+	}
+	if browseros.Ports != (Ports{CDP: 1111, Server: 2222, Extension: 3333}) {
+		t.Fatalf("legacy ports not mapped: %+v", browseros.Ports)
+	}
+	claw := cfg.Targets[string(TargetClaw)]
+	if claw.DevUserDataDir == browseros.DevUserDataDir || claw.BrowserOSDir == browseros.BrowserOSDir {
+		t.Fatalf("claw target should keep separate defaults: browseros=%+v claw=%+v", browseros, claw)
+	}
+}
+
+func TestSaveSelectedClawDoesNotOverwriteBrowserOSTarget(t *testing.T) {
+	home := t.TempDir()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	cfg := Defaults(home)
+	if err := cfg.ApplyTarget(TargetClaw); err != nil {
+		t.Fatal(err)
+	}
+	cfg.DevUserDataDir = "/custom-claw-profile"
+	cfg.BrowserOSDir = "/custom-claw-state"
+	cfg.Ports = Ports{CDP: 49338, Server: 9201}
+
+	if err := Save(path, cfg); err != nil {
+		t.Fatal(err)
+	}
+	got, err := Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	browseros := got.Targets[string(TargetBrowserOS)]
+	if browseros.DevUserDataDir == "/custom-claw-profile" || browseros.BrowserOSDir == "/custom-claw-state" {
+		t.Fatalf("browseros target was overwritten by claw runtime: %+v", browseros)
+	}
+	claw := got.Targets[string(TargetClaw)]
+	if claw.DevUserDataDir != "/custom-claw-profile" || claw.BrowserOSDir != "/custom-claw-state" {
+		t.Fatalf("claw target was not saved: %+v", claw)
 	}
 }
 

--- a/packages/browseros-agent/tools/dogfood/config/config_test.go
+++ b/packages/browseros-agent/tools/dogfood/config/config_test.go
@@ -197,6 +197,24 @@ func TestResolveDefaultsBranch(t *testing.T) {
 	}
 }
 
+func TestResolvePreservesSelectedTarget(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	cfg := Defaults(home)
+	if err := cfg.ApplyTarget(TargetClaw); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg.Resolve()
+
+	if cfg.Target != TargetClaw {
+		t.Fatalf("target got %q want claw", cfg.Target)
+	}
+	if cfg.DevUserDataDir != filepath.Join(home, ".config/browseros-dogfood/claw/profile") {
+		t.Fatalf("dev profile got %q", cfg.DevUserDataDir)
+	}
+}
+
 func TestExpandTilde(t *testing.T) {
 	got := ExpandTilde("~/x", "/Users/test")
 	want := filepath.Join("/Users/test", "x")

--- a/packages/browseros-agent/tools/dogfood/ipc/ipc.go
+++ b/packages/browseros-agent/tools/dogfood/ipc/ipc.go
@@ -129,7 +129,7 @@ func NewClientWithTimeout(socketPath string, responseTimeout time.Duration) *Cli
 func (c *Client) Send(req Request) (Response, error) {
 	conn, err := net.DialTimeout("unix", c.socketPath, 700*time.Millisecond)
 	if err != nil {
-		return Response{}, fmt.Errorf("%w; start it with `browseros-dogfood start-background`", ErrDaemonNotRunning)
+		return Response{}, ErrDaemonNotRunning
 	}
 	defer conn.Close()
 

--- a/packages/browseros-agent/tools/dogfood/ipc/ipc_test.go
+++ b/packages/browseros-agent/tools/dogfood/ipc/ipc_test.go
@@ -1,8 +1,10 @@
 package ipc
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -37,6 +39,12 @@ func TestClientReportsMissingDaemon(t *testing.T) {
 	_, err := NewClient(filepath.Join(t.TempDir(), "missing.sock")).Send(Request{Command: CmdStatus})
 	if err == nil {
 		t.Fatal("expected missing daemon error")
+	}
+	if !errors.Is(err, ErrDaemonNotRunning) {
+		t.Fatalf("error got %v want ErrDaemonNotRunning", err)
+	}
+	if strings.Contains(err.Error(), "browseros-dogfood start-background") {
+		t.Fatalf("ipc layer should not include targetless CLI advice: %v", err)
 	}
 }
 

--- a/packages/browseros-agent/tools/dogfood/pipeline/build.go
+++ b/packages/browseros-agent/tools/dogfood/pipeline/build.go
@@ -3,10 +3,14 @@ package pipeline
 import "context"
 
 func Build(ctx context.Context, agentRoot string, r Runner) error {
-	if err := r.Run(ctx, agentRoot, "./tools/dev/setup.sh"); err != nil {
+	if err := Setup(ctx, agentRoot, r); err != nil {
 		return err
 	}
 	return r.Run(ctx, agentRoot, "bun", "--cwd", "apps/app", "--env-file=.env.development", "wxt", "build", "--mode", "development")
+}
+
+func Setup(ctx context.Context, agentRoot string, r Runner) error {
+	return r.Run(ctx, agentRoot, "./tools/dev/setup.sh")
 }
 
 type ExecRunner struct{}

--- a/packages/browseros-agent/tools/dogfood/pipeline/build_test.go
+++ b/packages/browseros-agent/tools/dogfood/pipeline/build_test.go
@@ -21,3 +21,14 @@ func TestBuildRunsExpectedCommands(t *testing.T) {
 		}
 	}
 }
+
+func TestSetupRunsDevSetupOnly(t *testing.T) {
+	root := t.TempDir()
+	r := &FakeRunner{}
+	if err := Setup(context.Background(), root, r); err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Commands) != 1 || r.Commands[0] != "./tools/dev/setup.sh" {
+		t.Fatalf("commands got %#v", r.Commands)
+	}
+}

--- a/packages/browseros-agent/tools/dogfood/proc/ports.go
+++ b/packages/browseros-agent/tools/dogfood/proc/ports.go
@@ -10,6 +10,10 @@ import (
 )
 
 func ResolvePorts(start config.Ports) (config.Ports, bool, error) {
+	return ResolveTargetPorts(start, true)
+}
+
+func ResolveTargetPorts(start config.Ports, includeExtension bool) (config.Ports, bool, error) {
 	used := map[int]bool{}
 	cdp, err := resolvePort("CDP", start.CDP, used)
 	if err != nil {
@@ -20,10 +24,14 @@ func ResolvePorts(start config.Ports) (config.Ports, bool, error) {
 	if err != nil {
 		return config.Ports{}, false, err
 	}
-	used[server] = true
-	extension, err := resolvePort("extension", start.Extension, used)
-	if err != nil {
-		return config.Ports{}, false, err
+	extension := start.Extension
+	if includeExtension {
+		used[server] = true
+		resolvedExtension, err := resolvePort("extension", start.Extension, used)
+		if err != nil {
+			return config.Ports{}, false, err
+		}
+		extension = resolvedExtension
 	}
 	resolved := config.Ports{CDP: cdp, Server: server, Extension: extension}
 	return resolved, resolved != start, nil

--- a/packages/browseros-agent/tools/dogfood/proc/ports_test.go
+++ b/packages/browseros-agent/tools/dogfood/proc/ports_test.go
@@ -40,6 +40,24 @@ func TestResolvePortsAvoidsDuplicates(t *testing.T) {
 	}
 }
 
+func TestResolveTargetPortsCanSkipExtensionPort(t *testing.T) {
+	cdp := freePort(t)
+	server := freePort(t)
+	for server == cdp {
+		server = freePort(t)
+	}
+	got, changed, err := ResolveTargetPorts(config.Ports{CDP: cdp, Server: server}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if changed {
+		t.Fatalf("available CDP/API ports should not change: %+v", got)
+	}
+	if got.Extension != 0 {
+		t.Fatalf("extension port should stay unset for claw: %+v", got)
+	}
+}
+
 func freePort(t *testing.T) int {
 	t.Helper()
 	ln, err := net.Listen("tcp", "127.0.0.1:0")


### PR DESCRIPTION
## Summary
- Add explicit global `--browseros/-b` and `--claw/-c` target selection for the dogfood CLI lifecycle surface.
- Split BrowserOS and BrowserClaw profiles, state, daemon sockets, locks, logs, and default ports.
- Add standalone Claw startup through `apps/claw-app` WXT plus `apps/claw-server --config`, with target-aware status/log/control messaging.

## Design
The CLI keeps lifecycle verbs at the root and resolves one global target before runtime commands execute. Common config stays shared, while per-target settings own runtime paths and ports. BrowserOS keeps the existing `apps/app` + `apps/server` path; Claw mirrors the existing `tools/dev --claw` stack and never routes through `apps/server`.

## Test plan
- [x] `cd tools/dogfood && gofmt -l . && go vet ./... && go build ./... && go test ./...`
- [x] `bun test apps/claw-server/tests/config.test.ts`
- [x] context-free local review clean after fixes