### PR TITLE
fix: default screenshot annotations off

### DIFF
--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -181,7 +181,7 @@ describe('registerBrowserTools', () => {
         format: 'jpeg',
         quality: 80,
         fullPage: false,
-        annotate: true,
+        annotate: false,
         clip: {
           x: 5,
           y: 7,
@@ -194,7 +194,7 @@ describe('registerBrowserTools', () => {
         format: 'jpeg',
         quality: 60,
         fullPage: false,
-        annotate: true,
+        annotate: false,
         clip: {
           x: 5,
           y: 7,
@@ -280,7 +280,7 @@ describe('registerBrowserTools', () => {
       {
         format: 'png',
         fullPage: false,
-        annotate: true,
+        annotate: false,
         clip: {
           x: 0,
           y: 0,
@@ -293,7 +293,7 @@ describe('registerBrowserTools', () => {
         format: 'jpeg',
         quality: 80,
         fullPage: true,
-        annotate: true,
+        annotate: false,
       },
     ])
   })

--- a/packages/browseros-agent/apps/server/tests/tools/browser/screenshot-tool.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/screenshot-tool.test.ts
@@ -8,7 +8,7 @@ import { executeTool } from '@browseros/browser-mcp/tools/framework'
 import { screenshot } from '@browseros/browser-mcp/tools/screenshot'
 
 describe('screenshot tool', () => {
-  it('defaults annotate to true and returns inline JPEG content', async () => {
+  it('defaults annotate to false and returns inline JPEG content', async () => {
     let captured:
       | { page: number; options: ScreenshotCaptureOptions }
       | undefined
@@ -18,15 +18,17 @@ describe('screenshot tool', () => {
         return {
           data: 'jpeg-data',
           mimeType: `image/${options.format}`,
-          annotations: [
-            {
-              ref: 'e1',
-              number: 1,
-              role: 'button',
-              name: 'Save',
-              box: { x: 1, y: 2, width: 3, height: 4 },
-            },
-          ],
+          annotations: options.annotate
+            ? [
+                {
+                  ref: 'e1',
+                  number: 1,
+                  role: 'button',
+                  name: 'Save',
+                  box: { x: 1, y: 2, width: 3, height: 4 },
+                },
+              ]
+            : [],
         } satisfies ScreenshotCaptureResult
       },
       pages: {
@@ -61,7 +63,7 @@ describe('screenshot tool', () => {
         format: 'jpeg',
         quality: 80,
         fullPage: false,
-        annotate: true,
+        annotate: false,
         clip: { x: 5, y: 7, width: 2048, height: 1536, scale: 0.5 },
       },
     })
@@ -73,15 +75,6 @@ describe('screenshot tool', () => {
       format: 'jpeg',
       bytes: Buffer.from('jpeg-data', 'base64').length,
       image: 'jpeg-data',
-      annotations: [
-        {
-          ref: 'e1',
-          number: 1,
-          role: 'button',
-          name: 'Save',
-          box: { x: 1, y: 2, width: 3, height: 4 },
-        },
-      ],
     })
   })
 

--- a/packages/browseros-agent/apps/server/tests/tools/browser/screenshot.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/screenshot.test.ts
@@ -127,13 +127,33 @@ function deferred() {
 }
 
 describe('captureScreenshotWithAnnotations', () => {
-  it('defaults through the annotation lifecycle and returns annotation metadata', async () => {
+  it('defaults to plain capture without snapshot or overlay work', async () => {
     const harness = createHarness()
+    harness.observer.snapshot = async () => {
+      throw new Error('snapshot should not run')
+    }
 
     const result = await captureScreenshotWithAnnotations({
       pageSession: harness.pageSession as never,
       observer: harness.observer as never,
       options: { format: 'png', fullPage: false },
+    })
+
+    expect(harness.events).toEqual(['capture:false'])
+    expect(result).toEqual({
+      data: 'png-data',
+      mimeType: 'image/png',
+      annotations: [],
+    })
+  })
+
+  it('runs the annotation lifecycle and returns annotation metadata when requested', async () => {
+    const harness = createHarness()
+
+    const result = await captureScreenshotWithAnnotations({
+      pageSession: harness.pageSession as never,
+      observer: harness.observer as never,
+      options: { format: 'png', fullPage: false, annotate: true },
     })
 
     expect(harness.events).toEqual([
@@ -253,7 +273,7 @@ describe('captureScreenshotWithAnnotations', () => {
     const result = await captureScreenshotWithAnnotations({
       pageSession: harness.pageSession as never,
       observer: harness.observer as never,
-      options: { format: 'png', fullPage: false },
+      options: { format: 'png', fullPage: false, annotate: true },
     })
 
     expect(result.annotations[0]?.box).toEqual({
@@ -271,7 +291,7 @@ describe('captureScreenshotWithAnnotations', () => {
     const result = await captureScreenshotWithAnnotations({
       pageSession: harness.pageSession as never,
       observer: harness.observer as never,
-      options: { format: 'jpeg', fullPage: false, clip },
+      options: { format: 'jpeg', fullPage: false, clip, annotate: true },
     })
 
     expect(harness.captureParams[0]).toEqual({
@@ -302,7 +322,7 @@ describe('captureScreenshotWithAnnotations', () => {
     const input = {
       pageSession: harness.pageSession as never,
       observer: harness.observer as never,
-      options: { format: 'png' as const, fullPage: false },
+      options: { format: 'png' as const, fullPage: false, annotate: true },
     }
 
     const first = captureScreenshotWithAnnotations(input)
@@ -362,7 +382,7 @@ describe('captureScreenshotWithAnnotations', () => {
     const annotated = captureScreenshotWithAnnotations({
       pageSession: harness.pageSession as never,
       observer: harness.observer as never,
-      options: { format: 'png', fullPage: false },
+      options: { format: 'png', fullPage: false, annotate: true },
     })
     await firstCaptureStarted.promise
     const plain = captureScreenshotWithAnnotations({

--- a/packages/browseros-agent/packages/browser-core/src/core/screenshot.ts
+++ b/packages/browseros-agent/packages/browser-core/src/core/screenshot.ts
@@ -62,7 +62,7 @@ export async function captureScreenshotWithAnnotations({
   observer,
   options,
 }: CaptureInput): Promise<ScreenshotCaptureResult> {
-  if ((options.annotate ?? true) === false) {
+  if ((options.annotate ?? false) === false) {
     return runExclusiveScreenshotCapture(pageSession, () =>
       capturePlainScreenshot(pageSession, options),
     )

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/screenshot.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/screenshot.ts
@@ -61,7 +61,7 @@ export const screenshot = defineTool({
     annotate: z
       .boolean()
       .optional()
-      .describe('Overlay numbered refs from a fresh snapshot. Defaults true.'),
+      .describe('Overlay numbered refs from a fresh snapshot. Defaults false.'),
   }),
   annotations: { readOnlyHint: true },
   handler: async (args, ctx) => {
@@ -69,7 +69,7 @@ export const screenshot = defineTool({
     const captureOptions: ScreenshotCaptureOptions = {
       format: args.format,
       fullPage,
-      annotate: args.annotate ?? true,
+      annotate: args.annotate ?? false,
     }
     const quality = screenshotQuality(args.format, args.quality)
     if (quality !== undefined) captureOptions.quality = quality


### PR DESCRIPTION
## Summary
- Default omitted screenshot `annotate` to false in the MCP tool.
- Default omitted browser-core screenshot annotation options to plain capture.
- Updated screenshot tool, registration, and core capture tests for default-off behavior while preserving explicit `annotate: true`.

## Design
The MCP screenshot handler and browser-core helper are both defaulting boundaries, so both now treat omitted `annotate` as false. Explicit `annotate: true` continues through the existing overlay lifecycle and metadata path.

## Test plan
- [x] `bun test apps/server/tests/tools/browser/screenshot-tool.test.ts apps/server/tests/tools/browser/register.test.ts apps/server/tests/tools/browser/screenshot.test.ts`
- [x] `bun run check`
- [x] `bun run test`