### PR TITLE
fix: remove screenshot image from structured content

### DIFF
--- a/packages/browseros-agent/apps/claw-server/src/mcp/register-fn.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/register-fn.ts
@@ -12,13 +12,11 @@
  * Same workaround `@browseros/browser-mcp/register` uses.
  */
 
+import type { ContentItem } from '@browseros/browser-mcp/response'
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import type { ZodRawShape } from 'zod'
 
-export type ToolResultContent = {
-  type: 'text'
-  text: string
-}
+export type ToolResultContent = ContentItem
 
 export interface ToolResult {
   content: ToolResultContent[]

--- a/packages/browseros-agent/apps/claw-server/src/mcp/register.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/register.ts
@@ -262,7 +262,7 @@ export function registerBrowserTools(
           })
         }
         return {
-          content: result.content as ToolResult['content'],
+          content: result.content,
           isError: result.isError,
           structuredContent: result.structuredContent,
         }
@@ -512,6 +512,7 @@ export function registerBrowserToolsForSingleServer(
                 toolName: tool.name,
                 result: {
                   isError: result.isError ?? false,
+                  content: result.content,
                   structuredContent: result.structuredContent,
                 },
               })
@@ -569,7 +570,7 @@ export function registerBrowserToolsForSingleServer(
         }
 
         return {
-          content: result.content as ToolResult['content'],
+          content: result.content,
           isError: result.isError,
           structuredContent: result.structuredContent,
         }

--- a/packages/browseros-agent/apps/claw-server/src/services/screencast-poller.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/screencast-poller.ts
@@ -37,6 +37,7 @@ import {
   type TabActivityRegistry,
 } from '../lib/tab-activity'
 import { screencastCache } from './screencast-cache'
+import { extractToolResultImageData } from './tool-result-image'
 
 export const DEFAULT_POLL_INTERVAL_MS = 1500
 export const SCREENSHOT_TIMEOUT_MS = 2000
@@ -180,7 +181,7 @@ async function snapOne(
       }
       return
     }
-    const image = extractImage(result.structuredContent)
+    const image = extractToolResultImageData(result)
     if (!image) {
       if (screencastCache.markFailure(pageId)) {
         screencastCache.clearFrame(pageId)
@@ -202,14 +203,6 @@ async function snapOne(
       screencastCache.delete(pageId)
     }
   }
-}
-
-function extractImage(structured: unknown): string | null {
-  if (!structured || typeof structured !== 'object') return null
-  const sc = structured as Record<string, unknown>
-  const image = sc.image
-  if (typeof image !== 'string' || image.length === 0) return null
-  return image
 }
 
 function estimateBase64Bytes(b64: string): number {

--- a/packages/browseros-agent/apps/claw-server/src/services/screenshots.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/screenshots.ts
@@ -18,6 +18,7 @@ import { writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { resolveClawServerPath } from '../lib/browseros-dir'
 import { logger } from '../lib/logger'
+import { extractToolResultImageData } from './tool-result-image'
 
 export function screenshotPath(dispatchId: number): string {
   return resolveClawServerPath('screenshots', `${dispatchId}.jpg`)
@@ -28,19 +29,19 @@ export interface PersistScreenshotInput {
   toolName: string
   result: {
     isError: boolean
-    structuredContent: unknown
+    content?: unknown
+    structuredContent?: unknown
   }
 }
 
 /**
  * Fire-and-forget. Never throws.
- * No-op for non-screenshot tools, error results, or results without
- * a base64 image string.
+ * No-op for non-screenshot tools, error results, or results without image data.
  */
 export function persistScreenshot(input: PersistScreenshotInput): void {
   if (input.toolName !== 'screenshot') return
   if (input.result.isError) return
-  const bytes = extractImageBytes(input.result.structuredContent)
+  const bytes = extractImageBytes(input.result)
   if (!bytes) return
   const path = screenshotPath(input.dispatchId)
   try {
@@ -60,11 +61,11 @@ export function persistScreenshot(input: PersistScreenshotInput): void {
   })
 }
 
-function extractImageBytes(structured: unknown): Buffer | null {
-  if (!structured || typeof structured !== 'object') return null
-  const sc = structured as Record<string, unknown>
-  const image = sc.image
-  if (typeof image !== 'string' || image.length === 0) return null
+function extractImageBytes(
+  result: PersistScreenshotInput['result'],
+): Buffer | null {
+  const image = extractToolResultImageData(result)
+  if (!image) return null
   try {
     return Buffer.from(image, 'base64')
   } catch {

--- a/packages/browseros-agent/apps/claw-server/src/services/tool-result-image.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/tool-result-image.ts
@@ -1,0 +1,35 @@
+export interface ToolResultImageSource {
+  content?: unknown
+  structuredContent?: unknown
+}
+
+/** Extracts base64 image data from MCP image content, with a legacy structured fallback. */
+export function extractToolResultImageData(
+  result: ToolResultImageSource,
+): string | null {
+  return (
+    imageDataFromContent(result.content) ??
+    imageDataFromStructuredContent(result.structuredContent)
+  )
+}
+
+function imageDataFromContent(content: unknown): string | null {
+  if (!Array.isArray(content)) return null
+  for (const item of content) {
+    if (!item || typeof item !== 'object') continue
+    const block = item as Record<string, unknown>
+    if (block.type !== 'image') continue
+    if (typeof block.data === 'string' && block.data.length > 0) {
+      return block.data
+    }
+  }
+  return null
+}
+
+function imageDataFromStructuredContent(
+  structuredContent: unknown,
+): string | null {
+  if (!structuredContent || typeof structuredContent !== 'object') return null
+  const image = (structuredContent as Record<string, unknown>).image
+  return typeof image === 'string' && image.length > 0 ? image : null
+}

--- a/packages/browseros-agent/apps/claw-server/tests/services/screencast-poller.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/screencast-poller.test.ts
@@ -20,7 +20,10 @@ import { screencastCache } from '../../src/services/screencast-cache'
 
 interface FakeResult {
   isError: boolean
-  content: { type: string; text: string }[]
+  content: (
+    | { type: 'text'; text: string }
+    | { type: 'image'; data: string; mimeType: string }
+  )[]
   structuredContent?: unknown
 }
 
@@ -41,8 +44,8 @@ function queueFor(pageId: number, ...rs: FakeResult[]): void {
 function ok(image: string): FakeResult {
   return {
     isError: false,
-    content: [{ type: 'text', text: 'ok' }],
-    structuredContent: { image },
+    content: [{ type: 'image', data: image, mimeType: 'image/jpeg' }],
+    structuredContent: { page: 1, format: 'jpeg' },
   }
 }
 

--- a/packages/browseros-agent/apps/claw-server/tests/services/screenshots.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/screenshots.test.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { describe, expect, it } from 'bun:test'
 import { existsSync, readFileSync } from 'node:fs'
 import {
   persistScreenshot,
@@ -16,23 +16,24 @@ const ONE_PX_JPEG_B64 =
   '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/2wBDAQMDAwQDBAgEBAgQCwkLEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBD/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAr/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAA//Z'
 
 describe('persistScreenshot', () => {
-  beforeEach(() => {
-    // each test sets its own tmp dir via withTempBrowserosDir
-  })
-  afterEach(() => {})
-
-  it('writes <dispatchId>.jpg under the screenshots dir', async () => {
+  it('writes <dispatchId>.jpg from image content', async () => {
     await withTempBrowserosDir(async () => {
       persistScreenshot({
         dispatchId: 42,
         toolName: 'screenshot',
         result: {
           isError: false,
+          content: [
+            {
+              type: 'image',
+              data: ONE_PX_JPEG_B64,
+              mimeType: 'image/jpeg',
+            },
+          ],
           structuredContent: {
             page: 1,
             format: 'jpeg',
             bytes: 0,
-            image: ONE_PX_JPEG_B64,
           },
         },
       })
@@ -51,7 +52,14 @@ describe('persistScreenshot', () => {
         toolName: 'snapshot',
         result: {
           isError: false,
-          structuredContent: { image: ONE_PX_JPEG_B64 },
+          content: [
+            {
+              type: 'image',
+              data: ONE_PX_JPEG_B64,
+              mimeType: 'image/jpeg',
+            },
+          ],
+          structuredContent: {},
         },
       })
       await new Promise((r) => setTimeout(r, 30))
@@ -66,7 +74,14 @@ describe('persistScreenshot', () => {
         toolName: 'screenshot',
         result: {
           isError: true,
-          structuredContent: { image: ONE_PX_JPEG_B64 },
+          content: [
+            {
+              type: 'image',
+              data: ONE_PX_JPEG_B64,
+              mimeType: 'image/jpeg',
+            },
+          ],
+          structuredContent: {},
         },
       })
       await new Promise((r) => setTimeout(r, 30))
@@ -74,18 +89,36 @@ describe('persistScreenshot', () => {
     })
   })
 
-  it('no-op when structured image is missing', async () => {
+  it('no-op when image content is missing', async () => {
     await withTempBrowserosDir(async () => {
       persistScreenshot({
         dispatchId: 3,
         toolName: 'screenshot',
         result: {
           isError: false,
+          content: [{ type: 'text', text: 'no image here' }],
           structuredContent: { page: 1, format: 'jpeg' },
         },
       })
       await new Promise((r) => setTimeout(r, 30))
       expect(existsSync(screenshotPath(3))).toBe(false)
+    })
+  })
+
+  it('falls back to legacy structured image data', async () => {
+    await withTempBrowserosDir(async () => {
+      persistScreenshot({
+        dispatchId: 4,
+        toolName: 'screenshot',
+        result: {
+          isError: false,
+          content: [],
+          structuredContent: { image: ONE_PX_JPEG_B64 },
+        },
+      })
+      await new Promise((r) => setTimeout(r, 50))
+      expect(existsSync(screenshotPath(4))).toBe(true)
+      expect(readFileSync(screenshotPath(4)).length).toBeGreaterThan(0)
     })
   })
 })

--- a/packages/browseros-agent/apps/claw-server/tests/services/tasks.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/tasks.test.ts
@@ -35,8 +35,8 @@ function dispatch(
     durationMs: 5,
     result: {
       isError: opts.isError ?? false,
-      structuredContent: { image: 'AAA' },
-      content: null,
+      structuredContent: {},
+      content: [{ type: 'image', data: 'AAA', mimeType: 'image/jpeg' }],
     },
   })
 }

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -158,7 +158,6 @@ describe('registerBrowserTools', () => {
         page: 1,
         format: 'jpeg',
         bytes: Buffer.from('jpeg-data', 'base64').length,
-        image: 'jpeg-data',
       },
     })
     await expect(
@@ -173,7 +172,6 @@ describe('registerBrowserTools', () => {
         page: 1,
         format: 'jpeg',
         bytes: Buffer.from('jpeg-data', 'base64').length,
-        image: 'jpeg-data',
       },
     })
     expect(captureOptions).toEqual([
@@ -260,7 +258,6 @@ describe('registerBrowserTools', () => {
         page: 1,
         format: 'png',
         bytes: Buffer.from('png-data', 'base64').length,
-        image: 'png-data',
       },
     })
     await expect(
@@ -271,7 +268,6 @@ describe('registerBrowserTools', () => {
         page: 1,
         format: 'jpeg',
         bytes: Buffer.from('jpeg-data', 'base64').length,
-        image: 'jpeg-data',
       },
     })
 

--- a/packages/browseros-agent/apps/server/tests/tools/browser/screenshot-tool.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/screenshot-tool.test.ts
@@ -74,7 +74,6 @@ describe('screenshot tool', () => {
       page: 3,
       format: 'jpeg',
       bytes: Buffer.from('jpeg-data', 'base64').length,
-      image: 'jpeg-data',
     })
   })
 
@@ -116,7 +115,6 @@ describe('screenshot tool', () => {
       page: 3,
       format: 'jpeg',
       bytes: Buffer.from('jpeg-data', 'base64').length,
-      image: 'jpeg-data',
     })
   })
 })

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/screenshot.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/screenshot.ts
@@ -90,7 +90,6 @@ export const screenshot = defineTool({
         page: args.page,
         format: args.format,
         bytes: Buffer.from(result.data, 'base64').length,
-        image: result.data,
         ...(result.annotations.length > 0 && {
           annotations: result.annotations,
         }),


### PR DESCRIPTION
## Summary
- Removes screenshot base64 from MCP `structuredContent` while keeping the protocol-native image block in `content`.
- Updates Claw screenshot persistence and screencast polling to read image data from MCP image content.
- Keeps a private Claw fallback for legacy `structuredContent.image` inputs without exposing it from new screenshot results.

## Design
The browser MCP screenshot tool now returns structured metadata only: `page`, `format`, `bytes`, and optional `annotations`. Claw internals use a shared image-content extractor so screenshot files and live screencast frames continue to work from the `content` image block.

## Test plan
- [x] bun test apps/server/tests/tools/browser/screenshot-tool.test.ts apps/server/tests/tools/browser/register.test.ts
- [x] bun test apps/claw-server/tests/services/screenshots.test.ts apps/claw-server/tests/services/screencast-poller.test.ts apps/claw-server/tests/services/tasks.test.ts
- [x] bun run --filter @browseros/browser-mcp typecheck
- [x] bun run --filter @browseros/claw-server typecheck
- [x] bun run check
- [x] bun run test

## Review
- Local `sf-review` Codex pass: clean, no findings.