### PR TITLE
chore(ci): remove release-core gates

### DIFF
--- a/.github/workflows/nightly-macos-build.yml
+++ b/.github/workflows/nightly-macos-build.yml
@@ -72,19 +72,8 @@ jobs:
             echo "upload_to_r2=$upload_to_r2"
           } >> "$GITHUB_OUTPUT"
 
-  authorize_manual_dispatch:
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: [self-hosted, macOS, ARM64, browseros-builder]
-    environment: release-core
-    steps:
-      - run: echo "Manual dispatch approved through release-core."
-
   build:
-    needs: [authorize_manual_dispatch, resolve_inputs]
-    if: |
-      always() &&
-      needs.resolve_inputs.result == 'success' &&
-      (github.event_name == 'schedule' || needs.authorize_manual_dispatch.result == 'success')
+    needs: resolve_inputs
     runs-on: [self-hosted, macOS, ARM64, browseros-builder]
     permissions:
       contents: write

--- a/.github/workflows/release-agent-extension.yml
+++ b/.github/workflows/release-agent-extension.yml
@@ -16,18 +16,7 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  authorize_manual_dispatch:
-    if: github.event_name == 'workflow_dispatch'
-    runs-on: ubuntu-latest
-    environment: release-core
-    steps:
-      - run: echo "Manual dispatch approved through release-core."
-
   release:
-    needs: authorize_manual_dispatch
-    if: |
-      always() &&
-      (github.event_name != 'workflow_dispatch' || needs.authorize_manual_dispatch.result == 'success')
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -12,7 +12,6 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
-    environment: release-core
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- Remove the redundant `release-core` environment gate from the nightly macOS, agent extension, and CLI release workflows.
- Delete the approval-only manual-dispatch jobs whose only purpose was binding `release-core`.
- Preserve existing release/build triggers, publish steps, permissions, and release-policy validation.

## Design
This is a direct workflow-policy cleanup: nightly still depends on `resolve_inputs`, extension release now runs directly for supported tag and manual triggers, and CLI release keeps its `cli/v*` tag trigger without an environment approval gate.

## Test plan
- [x] `rg -n "release-core|authorize_manual_dispatch|Manual dispatch approved" .github/workflows || true`
- [x] `actionlint -ignore 'label "browseros-builder" is unknown' .github/workflows/nightly-macos-build.yml .github/workflows/release-agent-extension.yml .github/workflows/release-cli.yml`
- [x] `git diff --check HEAD`
- [x] `bun run check`
- [x] `bun run test`