### PR TITLE
feat: add server MCP logging

### DIFF
--- a/packages/browseros-agent/apps/server/src/agent/ai-sdk-agent.ts
+++ b/packages/browseros-agent/apps/server/src/agent/ai-sdk-agent.ts
@@ -49,6 +49,62 @@ export interface AiSdkAgentConfig {
   outputFileAccess?: BrowserOutputFileAccess
 }
 
+const TOOL_ERROR_PREVIEW_CHARS = 500
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function previewToolText(text: string): string {
+  if (text.length <= TOOL_ERROR_PREVIEW_CHARS) return text
+  return `${text.slice(0, TOOL_ERROR_PREVIEW_CHARS)}... (+${text.length - TOOL_ERROR_PREVIEW_CHARS} chars)`
+}
+
+function summarizeToolInput(input: unknown): Record<string, unknown> {
+  if (!isRecord(input)) {
+    return { inputType: typeof input }
+  }
+  const summary: Record<string, unknown> = {
+    argKeys: Object.keys(input).sort(),
+  }
+  if (typeof input.server_name === 'string') {
+    summary.serverName = input.server_name
+  }
+  if (typeof input.path === 'string') {
+    summary.path = input.path
+  }
+  if (typeof input.page === 'number') {
+    summary.page = input.page
+  }
+  if (typeof input.action === 'string') {
+    summary.action = input.action
+  }
+  return summary
+}
+
+function toolResultIsError(result: unknown): boolean {
+  return isRecord(result) && result.isError === true
+}
+
+function toolResultErrorPreview(result: unknown): string | undefined {
+  if (!isRecord(result) || !Array.isArray(result.content)) {
+    return undefined
+  }
+  const text = result.content
+    .filter(
+      (item): item is { type: 'text'; text: string } =>
+        typeof item === 'object' &&
+        item !== null &&
+        'type' in item &&
+        item.type === 'text' &&
+        'text' in item &&
+        typeof item.text === 'string',
+    )
+    .map((item) => item.text)
+    .join('\n')
+  return text ? previewToolText(text) : undefined
+}
+
 /** Builds filesystem tools for model-backed sessions, with scoped readback outside full workspace mode. */
 export function buildAgentFilesystemToolSet(
   resolvedConfig: ResolvedAgentConfig,
@@ -184,23 +240,53 @@ export class AiSdkAgent {
               ...args: Parameters<NonNullable<typeof originalExecute>>
             ) => {
               const startTime = performance.now()
+              const logBase = {
+                toolName: name,
+                source: 'chat',
+                conversationId: config.resolvedConfig.conversationId,
+                provider: config.resolvedConfig.provider,
+              }
+              logger.debug('External MCP chat tool started', {
+                ...logBase,
+                args: summarizeToolInput(args[0]),
+              })
               try {
                 const result = await originalExecute(...args)
+                const durationMs = Math.round(performance.now() - startTime)
                 metrics.log('tool_executed', {
                   tool_name: name,
-                  duration_ms: Math.round(performance.now() - startTime),
+                  duration_ms: durationMs,
                   success: true,
                   source: 'chat',
                 })
+                logger.debug('External MCP chat tool completed', {
+                  ...logBase,
+                  durationMs,
+                  isError: toolResultIsError(result),
+                })
+                if (toolResultIsError(result)) {
+                  logger.info('External MCP chat tool returned error', {
+                    ...logBase,
+                    durationMs,
+                    error: toolResultErrorPreview(result),
+                  })
+                }
                 return result
               } catch (error) {
+                const errorText =
+                  error instanceof Error ? error.message : String(error)
+                const durationMs = Math.round(performance.now() - startTime)
                 metrics.log('tool_executed', {
                   tool_name: name,
-                  duration_ms: Math.round(performance.now() - startTime),
+                  duration_ms: durationMs,
                   success: false,
-                  error_message:
-                    error instanceof Error ? error.message : String(error),
+                  error_message: errorText,
                   source: 'chat',
+                })
+                logger.info('External MCP chat tool threw', {
+                  ...logBase,
+                  durationMs,
+                  error: errorText,
                 })
                 throw error
               }

--- a/packages/browseros-agent/apps/server/src/agent/ai-sdk-agent.ts
+++ b/packages/browseros-agent/apps/server/src/agent/ai-sdk-agent.ts
@@ -49,15 +49,8 @@ export interface AiSdkAgentConfig {
   outputFileAccess?: BrowserOutputFileAccess
 }
 
-const TOOL_ERROR_PREVIEW_CHARS = 500
-
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
-}
-
-function previewToolText(text: string): string {
-  if (text.length <= TOOL_ERROR_PREVIEW_CHARS) return text
-  return `${text.slice(0, TOOL_ERROR_PREVIEW_CHARS)}... (+${text.length - TOOL_ERROR_PREVIEW_CHARS} chars)`
 }
 
 function summarizeToolInput(input: unknown): Record<string, unknown> {
@@ -86,11 +79,13 @@ function toolResultIsError(result: unknown): boolean {
   return isRecord(result) && result.isError === true
 }
 
-function toolResultErrorPreview(result: unknown): string | undefined {
+function summarizeToolResultError(
+  result: unknown,
+): Record<string, unknown> | undefined {
   if (!isRecord(result) || !Array.isArray(result.content)) {
     return undefined
   }
-  const text = result.content
+  const textBlocks = result.content
     .filter(
       (item): item is { type: 'text'; text: string } =>
         typeof item === 'object' &&
@@ -101,8 +96,13 @@ function toolResultErrorPreview(result: unknown): string | undefined {
         typeof item.text === 'string',
     )
     .map((item) => item.text)
-    .join('\n')
-  return text ? previewToolText(text) : undefined
+  const text = textBlocks.join('\n')
+  return {
+    contentCount: result.content.length,
+    textBlockCount: textBlocks.length,
+    textLength: text.length,
+    lineCount: text.length ? text.split('\n').length : 0,
+  }
 }
 
 /** Builds filesystem tools for model-backed sessions, with scoped readback outside full workspace mode. */
@@ -253,22 +253,23 @@ export class AiSdkAgent {
               try {
                 const result = await originalExecute(...args)
                 const durationMs = Math.round(performance.now() - startTime)
+                const isError = toolResultIsError(result)
                 metrics.log('tool_executed', {
                   tool_name: name,
                   duration_ms: durationMs,
-                  success: true,
+                  success: !isError,
                   source: 'chat',
                 })
                 logger.debug('External MCP chat tool completed', {
                   ...logBase,
                   durationMs,
-                  isError: toolResultIsError(result),
+                  isError,
                 })
-                if (toolResultIsError(result)) {
+                if (isError) {
                   logger.info('External MCP chat tool returned error', {
                     ...logBase,
                     durationMs,
-                    error: toolResultErrorPreview(result),
+                    errorSummary: summarizeToolResultError(result),
                   })
                 }
                 return result

--- a/packages/browseros-agent/apps/server/src/agent/mcp-builder.ts
+++ b/packages/browseros-agent/apps/server/src/agent/mcp-builder.ts
@@ -24,16 +24,27 @@ export interface McpClientBundle {
   tools: ToolSet
 }
 
-// Build list of custom MCP server specs from browser context
-// (Klavis Strata is handled separately via shared background connection)
+function summarizeMcpUrl(value: string): string {
+  try {
+    const url = new URL(value)
+    return `${url.origin}${url.pathname}`
+  } catch {
+    return '(invalid url)'
+  }
+}
+
+/** Builds custom MCP server specs from browser context. */
 export async function buildMcpServerSpecs(
   deps: McpServerSpecDeps,
 ): Promise<McpServerSpec[]> {
   const specs: McpServerSpec[] = []
 
-  // User-provided custom MCP servers
   if (deps.browserContext?.customMcpServers?.length) {
     const servers = deps.browserContext.customMcpServers
+    logger.debug('Resolving custom MCP server transports', {
+      count: servers.length,
+      serverNames: servers.map((server) => server.name),
+    })
     const transports = await Promise.all(
       servers.map((s) => detectMcpTransport(s.url)),
     )
@@ -44,16 +55,30 @@ export async function buildMcpServerSpecs(
         transport: transports[i],
       })
     }
+    logger.debug('Custom MCP server specs resolved', {
+      count: specs.length,
+      specs: specs.map((spec) => ({
+        name: spec.name,
+        url: summarizeMcpUrl(spec.url),
+        transport: spec.transport,
+      })),
+    })
   }
 
   return specs
 }
 
-// Connect a single MCP client with timeout protection
 async function connectMcpClient(
   spec: McpServerSpec,
 ): Promise<{ client: { close(): Promise<void> }; tools: ToolSet } | null> {
   const timeout = TIMEOUTS.MCP_CLIENT_CONNECT
+  const logContext = {
+    name: spec.name,
+    url: summarizeMcpUrl(spec.url),
+    transport: spec.transport,
+    timeoutMs: timeout,
+  }
+  logger.debug('Connecting MCP client', logContext)
   try {
     const client = await Promise.race([
       createMCPClient({
@@ -85,6 +110,10 @@ async function connectMcpClient(
         ),
       ),
     ])
+    logger.debug('MCP client connected', {
+      ...logContext,
+      toolCount: Object.keys(clientTools).length,
+    })
     // Cast keeps the call green when this package compiles in a
     // workspace that also has zod v4 present (the cockpit at
     // apps/claw-server). The two zod majors export
@@ -96,28 +125,39 @@ async function connectMcpClient(
     return { client, tools: clientTools as ToolSet }
   } catch (error) {
     logger.warn('Failed to connect MCP client, skipping', {
-      name: spec.name,
-      url: spec.url,
+      ...logContext,
       error: error instanceof Error ? error.message : String(error),
     })
     return null
   }
 }
 
-// Create MCP clients from specs, return merged toolset
+/** Connects custom MCP servers and returns their merged toolset. */
 export async function createMcpClients(
   specs: McpServerSpec[],
 ): Promise<McpClientBundle> {
   const clients: Array<{ close(): Promise<void> }> = []
   let tools: ToolSet = {}
 
-  // Connect all clients concurrently with per-client timeout
+  if (specs.length > 0) {
+    logger.debug('Creating MCP clients', {
+      count: specs.length,
+      serverNames: specs.map((spec) => spec.name),
+    })
+  }
   const results = await Promise.all(specs.map(connectMcpClient))
   for (const result of results) {
     if (result) {
       clients.push(result.client)
       tools = { ...tools, ...result.tools }
     }
+  }
+  if (specs.length > 0) {
+    logger.debug('MCP clients created', {
+      requestedCount: specs.length,
+      connectedCount: clients.length,
+      toolCount: Object.keys(tools).length,
+    })
   }
 
   return { clients, tools }

--- a/packages/browseros-agent/apps/server/src/agent/tool-adapter.ts
+++ b/packages/browseros-agent/apps/server/src/agent/tool-adapter.ts
@@ -14,6 +14,7 @@ import {
   throwIfAborted,
 } from '@browseros/browser-mcp/tools/framework'
 import { type ToolSet, tool } from 'ai'
+import { logger } from '../lib/logger'
 import { metrics } from '../lib/metrics'
 
 export interface BrowserToolSetOptions {
@@ -26,6 +27,45 @@ interface ToolExecuteOptions {
 }
 
 const BROWSER_TOOL_TIMEOUT_MS = 120_000
+const ERROR_PREVIEW_CHARS = 500
+
+function previewText(text: string): string {
+  if (text.length <= ERROR_PREVIEW_CHARS) return text
+  return `${text.slice(0, ERROR_PREVIEW_CHARS)}... (+${text.length - ERROR_PREVIEW_CHARS} chars)`
+}
+
+function summarizeBrowserToolParams(params: unknown): Record<string, unknown> {
+  if (!params || typeof params !== 'object') {
+    return { inputType: typeof params }
+  }
+  const input = params as Record<string, unknown>
+  const summary: Record<string, unknown> = {
+    argKeys: Object.keys(input).sort(),
+  }
+  if (typeof input.page === 'number') summary.page = input.page
+  if (typeof input.action === 'string') summary.action = input.action
+  if (typeof input.format === 'string') summary.format = input.format
+  if (typeof input.timeoutMs === 'number') summary.timeoutMs = input.timeoutMs
+  if (typeof input.selector === 'string') summary.selectorPresent = true
+  if (typeof input.url === 'string') {
+    try {
+      summary.urlOrigin = new URL(input.url).origin
+    } catch {
+      summary.urlPresent = true
+    }
+  }
+  return summary
+}
+
+function browserToolErrorPreview(content: ContentBlock[]): string | undefined {
+  const text = content
+    .filter(
+      (item): item is ContentBlock & { type: 'text' } => item.type === 'text',
+    )
+    .map((item) => item.text)
+    .join('\n')
+  return text ? previewText(text) : undefined
+}
 
 function withBrowserToolTimeout(signal?: AbortSignal): AbortSignal {
   const timeoutSignal = AbortSignal.timeout(BROWSER_TOOL_TIMEOUT_MS)
@@ -83,21 +123,52 @@ export function buildBrowserToolSet(
         const startTime = performance.now()
         const signal = withBrowserToolTimeout(executeOptions?.abortSignal)
         throwIfAborted(signal)
-        const result =
-          readOnlyGuard(def, params, options) ??
-          (await withBrowserOutputFileAccess(options.outputFileAccess, () =>
-            executeBrowserTool(def, params as Record<string, unknown>, {
-              session,
-              signal,
-            }),
-          ))
-        metrics.log('tool_executed', {
-          tool_name: def.name,
-          duration_ms: Math.round(performance.now() - startTime),
-          success: !result.isError,
+        const logBase = {
+          toolName: def.name,
           source: 'chat',
+        }
+        logger.debug('Browser chat tool started', {
+          ...logBase,
+          args: summarizeBrowserToolParams(params),
+          readOnly: Boolean(options.readOnly),
         })
-        return { content: result.content, isError: result.isError ?? false }
+        try {
+          const result =
+            readOnlyGuard(def, params, options) ??
+            (await withBrowserOutputFileAccess(options.outputFileAccess, () =>
+              executeBrowserTool(def, params as Record<string, unknown>, {
+                session,
+                signal,
+              }),
+            ))
+          const durationMs = Math.round(performance.now() - startTime)
+          metrics.log('tool_executed', {
+            tool_name: def.name,
+            duration_ms: durationMs,
+            success: !result.isError,
+            source: 'chat',
+          })
+          logger.debug('Browser chat tool completed', {
+            ...logBase,
+            durationMs,
+            isError: Boolean(result.isError),
+          })
+          if (result.isError) {
+            logger.info('Browser chat tool returned error', {
+              ...logBase,
+              durationMs,
+              error: browserToolErrorPreview(result.content),
+            })
+          }
+          return { content: result.content, isError: result.isError ?? false }
+        } catch (error) {
+          logger.info('Browser chat tool threw', {
+            ...logBase,
+            durationMs: Math.round(performance.now() - startTime),
+            error: error instanceof Error ? error.message : String(error),
+          })
+          throw error
+        }
       },
       toModelOutput: ({ output }) => {
         const result = output as { content: ContentBlock[]; isError: boolean }

--- a/packages/browseros-agent/apps/server/src/agent/tool-adapter.ts
+++ b/packages/browseros-agent/apps/server/src/agent/tool-adapter.ts
@@ -27,12 +27,6 @@ interface ToolExecuteOptions {
 }
 
 const BROWSER_TOOL_TIMEOUT_MS = 120_000
-const ERROR_PREVIEW_CHARS = 500
-
-function previewText(text: string): string {
-  if (text.length <= ERROR_PREVIEW_CHARS) return text
-  return `${text.slice(0, ERROR_PREVIEW_CHARS)}... (+${text.length - ERROR_PREVIEW_CHARS} chars)`
-}
 
 function summarizeBrowserToolParams(params: unknown): Record<string, unknown> {
   if (!params || typeof params !== 'object') {
@@ -57,14 +51,21 @@ function summarizeBrowserToolParams(params: unknown): Record<string, unknown> {
   return summary
 }
 
-function browserToolErrorPreview(content: ContentBlock[]): string | undefined {
-  const text = content
+function summarizeBrowserToolError(
+  content: ContentBlock[],
+): Record<string, unknown> {
+  const textBlocks = content
     .filter(
       (item): item is ContentBlock & { type: 'text' } => item.type === 'text',
     )
     .map((item) => item.text)
-    .join('\n')
-  return text ? previewText(text) : undefined
+  const text = textBlocks.join('\n')
+  return {
+    contentCount: content.length,
+    textBlockCount: textBlocks.length,
+    textLength: text.length,
+    lineCount: text.length ? text.split('\n').length : 0,
+  }
 }
 
 function withBrowserToolTimeout(signal?: AbortSignal): AbortSignal {
@@ -157,7 +158,7 @@ export function buildBrowserToolSet(
             logger.info('Browser chat tool returned error', {
               ...logBase,
               durationMs,
-              error: browserToolErrorPreview(result.content),
+              errorSummary: summarizeBrowserToolError(result.content),
             })
           }
           return { content: result.content, isError: result.isError ?? false }

--- a/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/mcp.ts
@@ -32,6 +32,16 @@ interface McpRouteDeps {
   createMcpTransport?: CreateMcpTransportFn
 }
 
+interface McpRequestLogContext extends Record<string, unknown> {
+  scopeId: string
+  source?: string
+  remoteAgentHarness: boolean
+  selectedServerNames: string[]
+  selectedServerCount: number
+  defaultWindowId?: number
+  defaultTabGroupId?: string
+}
+
 function parseOptionalNumber(value: string | undefined): number | undefined {
   if (value === undefined) return undefined
   const n = Number(value)
@@ -63,6 +73,7 @@ export function parseManagedMcpServersHeader(
   return out
 }
 
+/** Creates the Hono routes that expose BrowserOS as a request-scoped MCP server. */
 export function createMcpRoutes(deps: McpRouteDeps) {
   const app = new Hono<Env>()
   const makeMcpServer = deps.createMcpServer ?? createMcpServer
@@ -83,6 +94,7 @@ export function createMcpRoutes(deps: McpRouteDeps) {
   app.post('/', async (c) => {
     const scopeId = c.req.header('X-BrowserOS-Scope-Id') || 'ephemeral'
     metrics.log('mcp.request', { scopeId })
+    const source = c.req.query('source') || undefined
 
     const defaultWindowId = parseOptionalNumber(
       c.req.header('X-BrowserOS-Default-Window-Id'),
@@ -94,9 +106,20 @@ export function createMcpRoutes(deps: McpRouteDeps) {
     )
 
     const harness =
-      c.req.query('source') === REMOTE_AGENT_HARNESS_MCP_SOURCE
+      source === REMOTE_AGENT_HARNESS_MCP_SOURCE
         ? remoteAgentHarness
         : undefined
+    const logContext: McpRequestLogContext = {
+      scopeId,
+      source,
+      remoteAgentHarness: Boolean(harness),
+      selectedServerNames,
+      selectedServerCount: selectedServerNames.length,
+      defaultWindowId,
+      defaultTabGroupId,
+    }
+
+    logger.debug('MCP request received', logContext)
 
     // Per-request server + transport: no shared state, no race conditions,
     // no ID collisions. Required by MCP SDK 1.26.0+ security fix (GHSA-345p-7cg4-v4c7).
@@ -117,7 +140,13 @@ export function createMcpRoutes(deps: McpRouteDeps) {
 
     try {
       await mcpServer.connect(transport)
-      return transport.handleRequest(c)
+      logger.debug('MCP request transport connected', logContext)
+      const response = await transport.handleRequest(c)
+      logger.debug('MCP request handled', {
+        ...logContext,
+        status: response?.status,
+      })
+      return response
     } catch (error) {
       Sentry.withScope((scope) => {
         scope.setTag('route', 'mcp')
@@ -125,6 +154,7 @@ export function createMcpRoutes(deps: McpRouteDeps) {
         Sentry.captureException(error)
       })
       logger.error('Error handling MCP request', {
+        ...logContext,
         error: error instanceof Error ? error.message : String(error),
       })
 

--- a/packages/browseros-agent/apps/server/src/api/services/klavis/service.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/klavis/service.ts
@@ -14,7 +14,11 @@ import {
   isSupportedConnector,
 } from './catalog'
 import { KlavisClient } from './client'
-import { buildConnectorInventory, getAuthUrlForServer } from './connector-state'
+import {
+  buildConnectorInventory,
+  getAuthUrlForServer,
+  selectedServerNames,
+} from './connector-state'
 import { KlavisStrataCache } from './strata-cache'
 import {
   type ConnectKlavisStrataSessionDeps,
@@ -183,8 +187,17 @@ export class KlavisService {
 
   registerMcpTools(server: McpServer, scope: ConnectorToolScope = {}): void {
     if (!this.browserosId) {
+      logger.debug('Skipping Klavis MCP tools registration', {
+        reason: 'missing_browseros_id',
+        selectedServers: selectedServerNames(scope),
+      })
       return
     }
+    logger.debug('Registering Klavis MCP tools', {
+      proxyState: this.status.state,
+      selectedServers: selectedServerNames(scope),
+      sessionToolCount: this.session?.tools.length ?? 0,
+    })
     registerKlavisTools(server, this.toolAdapterDeps(scope))
   }
 

--- a/packages/browseros-agent/apps/server/src/api/services/klavis/tool-adapters.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/klavis/tool-adapters.ts
@@ -47,6 +47,8 @@ type ConnectorToolPayload =
       message?: string
     }
 
+const ERROR_PREVIEW_CHARS = 500
+
 function connectorInputSchema(catalog: readonly ConnectorCatalogItem[]) {
   const names = catalog.map((server) => server.name) as [string, ...string[]]
   const serverDescriptions = getConnectorCatalogDescription()
@@ -62,6 +64,59 @@ function connectorInputSchema(catalog: readonly ConnectorCatalogItem[]) {
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
+}
+
+function previewText(text: string): string {
+  if (text.length <= ERROR_PREVIEW_CHARS) return text
+  return `${text.slice(0, ERROR_PREVIEW_CHARS)}... (+${text.length - ERROR_PREVIEW_CHARS} chars)`
+}
+
+function summarizeKlavisArgs(args: Record<string, unknown>) {
+  const summary: Record<string, unknown> = {
+    argKeys: Object.keys(args).sort(),
+  }
+  if (typeof args.server_name === 'string') {
+    summary.serverName = args.server_name
+  }
+  return summary
+}
+
+function summarizeConnectorPayload(payload: ConnectorToolPayload) {
+  if ('available' in payload) {
+    return {
+      type: 'inventory',
+      availableCount: payload.available.length,
+      connectedServers: payload.connected.map((item) => item.name),
+      selectedServers: payload.selected,
+      proxyState: payload.proxy.state,
+    }
+  }
+  return {
+    type: 'connection',
+    serverName: payload.server_name,
+    connected: payload.connected,
+    hasAuthUrl: Boolean(payload.authUrl),
+    proxyState: payload.proxy.state,
+  }
+}
+
+function callToolResultTextPreview(result: unknown): string | undefined {
+  if (!isObjectRecord(result) || !Array.isArray(result.content)) {
+    return undefined
+  }
+  const text = result.content
+    .filter(
+      (item): item is { type: 'text'; text: string } =>
+        typeof item === 'object' &&
+        item !== null &&
+        'type' in item &&
+        item.type === 'text' &&
+        'text' in item &&
+        typeof item.text === 'string',
+    )
+    .map((item) => item.text)
+    .join('\n')
+  return text ? previewText(text) : undefined
 }
 
 async function buildConnectorToolPayload(
@@ -188,15 +243,32 @@ export function registerKlavisTools(
     },
     async (args: Record<string, unknown>) => {
       const startTime = performance.now()
+      const selectedServers = selectedServerNames(deps.scope)
+      const logBase = {
+        toolName: 'connector_mcp_servers',
+        source: 'mcp',
+        proxyState: deps.proxyStatus.state,
+        selectedServers,
+      }
+      logger.debug('MCP Klavis connector tool started', {
+        ...logBase,
+        args: summarizeKlavisArgs(args),
+      })
 
       try {
         const payload = await buildConnectorToolPayload(deps, args)
+        const durationMs = Math.round(performance.now() - startTime)
 
         metrics.log('tool_executed', {
           tool_name: 'connector_mcp_servers',
           source: 'mcp',
-          duration_ms: Math.round(performance.now() - startTime),
+          duration_ms: durationMs,
           success: true,
+        })
+        logger.debug('MCP Klavis connector tool completed', {
+          ...logBase,
+          durationMs,
+          result: summarizeConnectorPayload(payload),
         })
 
         return {
@@ -209,13 +281,19 @@ export function registerKlavisTools(
         }
       } catch (error) {
         const errorText = error instanceof Error ? error.message : String(error)
+        const durationMs = Math.round(performance.now() - startTime)
 
         metrics.log('tool_executed', {
           tool_name: 'connector_mcp_servers',
           source: 'mcp',
-          duration_ms: Math.round(performance.now() - startTime),
+          duration_ms: durationMs,
           success: false,
           error_message: errorText,
+        })
+        logger.info('MCP Klavis connector tool returned error', {
+          ...logBase,
+          durationMs,
+          error: errorText,
         })
 
         return {
@@ -231,10 +309,12 @@ export function registerKlavisTools(
     logger.debug('Registered Klavis connector discovery on MCP server', {
       proxyState: deps.proxyStatus.state,
       selectedServers: selectedServerNames(deps.scope),
+      selectedServerCount: selectedServerNames(deps.scope).length,
     })
     return
   }
 
+  const selectedServers = selectedServerNames(deps.scope)
   for (const strataTool of session.tools) {
     const inputSchema = session.inputSchemas.get(strataTool.name)
 
@@ -246,27 +326,59 @@ export function registerKlavisTools(
       },
       async (args: Record<string, unknown>) => {
         const startTime = performance.now()
+        const logBase = {
+          toolName: strataTool.name,
+          source: 'mcp',
+          proxyState: deps.proxyStatus.state,
+          selectedServers,
+        }
+        logger.debug('MCP Klavis tool started', {
+          ...logBase,
+          args: summarizeKlavisArgs(args),
+        })
         try {
           const result = await session.callTool(strataTool.name, args)
+          const durationMs = Math.round(performance.now() - startTime)
 
           metrics.log('tool_executed', {
             tool_name: strataTool.name,
             source: 'mcp',
-            duration_ms: Math.round(performance.now() - startTime),
+            duration_ms: durationMs,
             success: !result?.isError,
           })
+          logger.debug('MCP Klavis tool completed', {
+            ...logBase,
+            durationMs,
+            isError: Boolean(result?.isError),
+            contentCount: Array.isArray(result?.content)
+              ? result.content.length
+              : 0,
+          })
+          if (result?.isError) {
+            logger.info('MCP Klavis tool returned error', {
+              ...logBase,
+              durationMs,
+              error: callToolResultTextPreview(result),
+            })
+          }
 
           return result
         } catch (error) {
           const errorText =
             error instanceof Error ? error.message : String(error)
+          const durationMs = Math.round(performance.now() - startTime)
 
           metrics.log('tool_executed', {
             tool_name: strataTool.name,
             source: 'mcp',
-            duration_ms: Math.round(performance.now() - startTime),
+            duration_ms: durationMs,
             success: false,
             error_message: errorText,
+          })
+          logger.info('MCP Klavis tool threw', {
+            ...logBase,
+            durationMs,
+            error: errorText,
           })
 
           return {
@@ -280,6 +392,7 @@ export function registerKlavisTools(
 
   logger.debug('Registered Klavis tools on MCP server', {
     count: session.tools.length + 1,
-    selectedServers: selectedServerNames(deps.scope),
+    selectedServers,
+    selectedServerCount: selectedServers.length,
   })
 }

--- a/packages/browseros-agent/apps/server/src/api/services/klavis/tool-adapters.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/klavis/tool-adapters.ts
@@ -47,8 +47,6 @@ type ConnectorToolPayload =
       message?: string
     }
 
-const ERROR_PREVIEW_CHARS = 500
-
 function connectorInputSchema(catalog: readonly ConnectorCatalogItem[]) {
   const names = catalog.map((server) => server.name) as [string, ...string[]]
   const serverDescriptions = getConnectorCatalogDescription()
@@ -64,11 +62,6 @@ function connectorInputSchema(catalog: readonly ConnectorCatalogItem[]) {
 
 function isObjectRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null
-}
-
-function previewText(text: string): string {
-  if (text.length <= ERROR_PREVIEW_CHARS) return text
-  return `${text.slice(0, ERROR_PREVIEW_CHARS)}... (+${text.length - ERROR_PREVIEW_CHARS} chars)`
 }
 
 function summarizeKlavisArgs(args: Record<string, unknown>) {
@@ -100,11 +93,13 @@ function summarizeConnectorPayload(payload: ConnectorToolPayload) {
   }
 }
 
-function callToolResultTextPreview(result: unknown): string | undefined {
+function summarizeCallToolError(
+  result: unknown,
+): Record<string, unknown> | undefined {
   if (!isObjectRecord(result) || !Array.isArray(result.content)) {
     return undefined
   }
-  const text = result.content
+  const textBlocks = result.content
     .filter(
       (item): item is { type: 'text'; text: string } =>
         typeof item === 'object' &&
@@ -115,8 +110,13 @@ function callToolResultTextPreview(result: unknown): string | undefined {
         typeof item.text === 'string',
     )
     .map((item) => item.text)
-    .join('\n')
-  return text ? previewText(text) : undefined
+  const text = textBlocks.join('\n')
+  return {
+    contentCount: result.content.length,
+    textBlockCount: textBlocks.length,
+    textLength: text.length,
+    lineCount: text.length ? text.split('\n').length : 0,
+  }
 }
 
 async function buildConnectorToolPayload(
@@ -358,7 +358,7 @@ export function registerKlavisTools(
             logger.info('MCP Klavis tool returned error', {
               ...logBase,
               durationMs,
-              error: callToolResultTextPreview(result),
+              errorSummary: summarizeCallToolError(result),
             })
           }
 

--- a/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-server.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/mcp/mcp-server.ts
@@ -27,6 +27,16 @@ export interface McpServiceDeps {
 
 /** Creates a per-request BrowserOS MCP server with tools for the requested surface. */
 export function createMcpServer(deps: McpServiceDeps) {
+  const selectedServerNames = deps.connectorScope?.selectedServerNames ?? []
+  logger.debug('Creating BrowserOS MCP server', {
+    version: deps.version,
+    remoteAgentHarness: Boolean(deps.remoteAgentHarness),
+    selectedServerNames,
+    selectedServerCount: selectedServerNames.length,
+    defaultWindowId: deps.defaultWindowId,
+    defaultTabGroupId: deps.defaultTabGroupId,
+  })
+
   const server = createBrowserMcpServer({
     name: 'browseros_mcp',
     title: 'BrowserOS MCP server',
@@ -45,12 +55,20 @@ export function createMcpServer(deps: McpServiceDeps) {
   })
 
   if (deps.remoteAgentHarness) {
+    logger.debug('Registering remote harness filesystem MCP tools', {
+      executionDir: deps.executionDir,
+    })
     registerFilesystemMcpTools(server, deps.executionDir, {
       outputFileAccess: deps.remoteAgentHarness.outputFileAccess,
     })
   }
 
   deps.klavis?.registerMcpTools(server, deps.connectorScope)
+  logger.debug('BrowserOS MCP server created', {
+    remoteAgentHarness: Boolean(deps.remoteAgentHarness),
+    selectedServerNames,
+    selectedServerCount: selectedServerNames.length,
+  })
 
   return server
 }

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/register-mcp.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/register-mcp.ts
@@ -47,8 +47,6 @@ export interface RegisterFilesystemMcpToolsOptions {
   outputFileAccess?: BrowserOutputFileAccess
 }
 
-const ERROR_PREVIEW_CHARS = 500
-
 function summarizeFilesystemArgs(
   args: Record<string, unknown>,
 ): Record<string, unknown> {
@@ -66,9 +64,26 @@ function summarizeFilesystemArgs(
   return summary
 }
 
-function previewText(text: string): string {
-  if (text.length <= ERROR_PREVIEW_CHARS) return text
-  return `${text.slice(0, ERROR_PREVIEW_CHARS)}... (+${text.length - ERROR_PREVIEW_CHARS} chars)`
+function summarizeFilesystemErrorText(
+  toolName: string,
+  text: string,
+): Record<string, unknown> {
+  const summary: Record<string, unknown> = {
+    textLength: text.length,
+    lineCount: text.length ? text.split('\n').length : 0,
+  }
+  if (toolName !== 'filesystem_bash') return summary
+
+  const exitCodeMatch = text.match(/\n\n\[Exit code: (-?\d+)\]\s*$/)
+  if (exitCodeMatch) {
+    summary.exitCode = Number(exitCodeMatch[1])
+  }
+  const timeoutMatch = text.match(/^Command timed out after ([0-9.]+)s\b/)
+  if (timeoutMatch) {
+    summary.timedOut = true
+    summary.timeoutSeconds = Number(timeoutMatch[1])
+  }
+  return summary
 }
 
 export function registerFilesystemMcpTools(
@@ -126,7 +141,7 @@ export function registerFilesystemMcpTools(
           logger.info('MCP filesystem tool returned error', {
             ...logBase,
             durationMs: duration(),
-            error: previewText(result.text),
+            errorSummary: summarizeFilesystemErrorText(name, result.text),
           })
           return {
             content: [{ type: 'text', text: result.text }],

--- a/packages/browseros-agent/apps/server/src/tools/filesystem/register-mcp.ts
+++ b/packages/browseros-agent/apps/server/src/tools/filesystem/register-mcp.ts
@@ -47,6 +47,30 @@ export interface RegisterFilesystemMcpToolsOptions {
   outputFileAccess?: BrowserOutputFileAccess
 }
 
+const ERROR_PREVIEW_CHARS = 500
+
+function summarizeFilesystemArgs(
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  const summary: Record<string, unknown> = {
+    argKeys: Object.keys(args).sort(),
+  }
+  if (typeof args.path === 'string') summary.path = args.path
+  if (typeof args.pattern === 'string')
+    summary.patternLength = args.pattern.length
+  if (typeof args.glob === 'string') summary.glob = args.glob
+  if (typeof args.limit === 'number') summary.limit = args.limit
+  if (typeof args.command === 'string') {
+    summary.commandLength = args.command.length
+  }
+  return summary
+}
+
+function previewText(text: string): string {
+  if (text.length <= ERROR_PREVIEW_CHARS) return text
+  return `${text.slice(0, ERROR_PREVIEW_CHARS)}... (+${text.length - ERROR_PREVIEW_CHARS} chars)`
+}
+
 export function registerFilesystemMcpTools(
   server: McpServer,
   cwd: string,
@@ -68,8 +92,42 @@ export function registerFilesystemMcpTools(
         inputSchema: tool.inputSchema.shape,
       },
       async (args, extra) => {
-        const result = await tool.execute(args, { signal: extra?.signal })
+        const startTime = performance.now()
+        const duration = () => Math.round(performance.now() - startTime)
+        const logBase = {
+          toolName: name,
+          source: 'mcp',
+          cwd,
+        }
+        logger.debug('MCP filesystem tool started', {
+          ...logBase,
+          args: summarizeFilesystemArgs(args),
+        })
+        let result: FilesystemToolResult
+        try {
+          result = await tool.execute(args, { signal: extra?.signal })
+        } catch (error) {
+          const errorText =
+            error instanceof Error ? error.message : String(error)
+          logger.info('MCP filesystem tool threw', {
+            ...logBase,
+            durationMs: duration(),
+            error: errorText,
+          })
+          throw error
+        }
+        logger.debug('MCP filesystem tool completed', {
+          ...logBase,
+          durationMs: duration(),
+          isError: Boolean(result.isError),
+          imageCount: result.images?.length ?? 0,
+        })
         if (result.isError) {
+          logger.info('MCP filesystem tool returned error', {
+            ...logBase,
+            durationMs: duration(),
+            error: previewText(result.text),
+          })
           return {
             content: [{ type: 'text', text: result.text }],
             isError: true,

--- a/packages/browseros-agent/apps/server/tests/api/services/mcp/register-mcp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/mcp/register-mcp.test.ts
@@ -76,6 +76,7 @@ async function withBrowserosDir<T>(run: () => Promise<T>): Promise<T> {
 
 describe('registerTools', () => {
   const originalInfo = logger.info
+  const originalDebug = logger.debug
   const originalError = logger.error
   const filesystemToolNames = [
     'filesystem_read',
@@ -86,19 +87,25 @@ describe('registerTools', () => {
     'filesystem_find',
     'filesystem_ls',
   ]
-  let infoMessages: unknown[] = []
+  let infoLogs: Array<{ message: string; meta?: Record<string, unknown> }> = []
+  let debugLogs: Array<{ message: string; meta?: Record<string, unknown> }> = []
 
   beforeEach(() => {
     resetToolRegistrationLogSamplingForTests()
-    infoMessages = []
-    logger.info = ((message: string) => {
-      infoMessages.push(message)
+    infoLogs = []
+    debugLogs = []
+    logger.info = ((message: string, meta?: Record<string, unknown>) => {
+      infoLogs.push({ message, meta })
     }) as typeof logger.info
+    logger.debug = ((message: string, meta?: Record<string, unknown>) => {
+      debugLogs.push({ message, meta })
+    }) as typeof logger.debug
     logger.error = (() => {}) as typeof logger.error
   })
 
   afterEach(() => {
     logger.info = originalInfo
+    logger.debug = originalDebug
     logger.error = originalError
     resetToolRegistrationLogSamplingForTests()
   })
@@ -218,15 +225,52 @@ describe('registerTools', () => {
       }
     }
 
-    expect(infoMessages).toHaveLength(2)
-    expect(infoMessages).toEqual([
-      expect.stringContaining(
-        `Registered ${BROWSER_TOOLS.length} browser tools`,
-      ),
-      expect.stringContaining(
-        `Registered ${BROWSER_TOOLS.length} browser tools`,
-      ),
+    expect(
+      infoLogs.filter((log) => log.message === 'Registered browser MCP tools'),
+    ).toEqual([
+      expect.objectContaining({
+        meta: expect.objectContaining({ count: BROWSER_TOOLS.length }),
+      }),
+      expect.objectContaining({
+        meta: expect.objectContaining({ count: BROWSER_TOOLS.length }),
+      }),
     ])
+  })
+
+  it('logs filesystem MCP tool errors without changing the MCP result', async () => {
+    const fake = createFakeServer()
+
+    registerTools(fake.server as never, {
+      browserSession: { pages: {} } as unknown as BrowserSession,
+      executionDir: '/tmp/browseros-execution',
+      remoteAgentHarness: {
+        outputFileAccess: createBrowserOutputFileAccess(),
+      },
+    })
+
+    const result = await fake.handlers.get('filesystem_read')?.({
+      path: 'missing-file.txt',
+    })
+
+    expect(result?.isError).toBe(true)
+    expect(textOf(result)).toBeTruthy()
+    expect(debugLogs.map((log) => log.message)).toContain(
+      'MCP filesystem tool started',
+    )
+    expect(
+      infoLogs.find(
+        (log) => log.message === 'MCP filesystem tool returned error',
+      ),
+    ).toEqual(
+      expect.objectContaining({
+        meta: expect.objectContaining({
+          toolName: 'filesystem_read',
+          source: 'mcp',
+          cwd: '/tmp/browseros-execution',
+          error: expect.any(String),
+        }),
+      }),
+    )
   })
 
   it('applies scoped defaults to tab creation', async () => {

--- a/packages/browseros-agent/apps/server/tests/api/services/mcp/register-mcp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/mcp/register-mcp.test.ts
@@ -267,10 +267,14 @@ describe('registerTools', () => {
           toolName: 'filesystem_read',
           source: 'mcp',
           cwd: '/tmp/browseros-execution',
-          error: expect.any(String),
+          errorSummary: expect.objectContaining({
+            textLength: expect.any(Number),
+            lineCount: expect.any(Number),
+          }),
         }),
       }),
     )
+    expect(JSON.stringify(infoLogs)).not.toContain(textOf(result))
   })
 
   it('applies scoped defaults to tab creation', async () => {

--- a/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
+++ b/packages/browseros-agent/apps/server/tests/tools/browser/register.test.ts
@@ -28,6 +28,7 @@ import { TOOL_LIMITS } from '@browseros/shared/constants/limits'
 import { z } from 'zod'
 import { CHAT_MODE_ALLOWED_TOOLS } from '../../../src/agent/chat-mode'
 import { buildBrowserToolSet } from '../../../src/agent/tool-adapter'
+import { logger } from '../../../src/lib/logger'
 import { createReadTool } from '../../../src/tools/filesystem/read'
 
 type RegisteredHandler = (args: Record<string, unknown>) => Promise<{
@@ -2013,6 +2014,49 @@ describe('buildBrowserToolSet', () => {
     expect(activeResult).toMatchObject({ isError: false })
     expect(newResult).toMatchObject({ isError: true })
     expect(calls).toEqual([])
+  })
+
+  it('logs browser chat returned errors without raw result text', async () => {
+    const originalInfo = logger.info
+    const infoLogs: Array<{ message: string; meta?: Record<string, unknown> }> =
+      []
+    logger.info = ((message: string, meta?: Record<string, unknown>) => {
+      infoLogs.push({ message, meta })
+    }) as typeof logger.info
+
+    try {
+      const tools = buildBrowserToolSet(
+        { pages: {} } as unknown as BrowserSession,
+        { readOnly: true },
+      )
+      const result = await tools.tabs.execute?.(
+        { action: 'new', url: 'https://example.com' },
+        { abortSignal: new AbortController().signal } as never,
+      )
+
+      expect(result).toMatchObject({ isError: true })
+      expect(JSON.stringify(infoLogs)).not.toContain('chat mode only supports')
+      expect(
+        infoLogs.find(
+          (log) => log.message === 'Browser chat tool returned error',
+        ),
+      ).toEqual(
+        expect.objectContaining({
+          meta: expect.objectContaining({
+            toolName: 'tabs',
+            source: 'chat',
+            errorSummary: expect.objectContaining({
+              contentCount: expect.any(Number),
+              textBlockCount: expect.any(Number),
+              textLength: expect.any(Number),
+              lineCount: expect.any(Number),
+            }),
+          }),
+        }),
+      )
+    } finally {
+      logger.info = originalInfo
+    }
   })
 
   it('propagates AI SDK abort signals into browser tools', async () => {

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/register.test.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/register.test.ts
@@ -75,7 +75,12 @@ describe('registerBrowserTools', () => {
 
   it('logs sampled registration and records failed tool executions', async () => {
     const fake = createFakeServer()
-    const infoMessages: string[] = []
+    const debugLogs: Array<{
+      message: string
+      meta?: Record<string, unknown>
+    }> = []
+    const infoLogs: Array<{ message: string; meta?: Record<string, unknown> }> =
+      []
     const events: Array<Record<string, unknown>> = []
     const session = {
       pages: {
@@ -90,7 +95,10 @@ describe('registerBrowserTools', () => {
       session,
       {},
       {
-        logger: { info: (message) => infoMessages.push(message) },
+        logger: {
+          debug: (message, meta) => debugLogs.push({ message, meta }),
+          info: (message, meta) => infoLogs.push({ message, meta }),
+        },
         onToolExecuted: (event) => events.push(event),
         shouldLogToolRegistration: () => true,
         source: 'unit-test',
@@ -102,11 +110,37 @@ describe('registerBrowserTools', () => {
       url: 'https://example.com',
     })
 
-    expect(infoMessages).toEqual([
-      expect.stringContaining(
-        `Registered ${BROWSER_TOOLS.length} browser tools`,
-      ),
+    expect(infoLogs).toEqual([
+      {
+        message: 'Registered browser MCP tools',
+        meta: expect.objectContaining({
+          count: BROWSER_TOOLS.length,
+          source: 'unit-test',
+        }),
+      },
+      {
+        message: 'MCP browser tool returned error',
+        meta: expect.objectContaining({
+          toolName: 'tabs',
+          source: 'unit-test',
+          error: expect.stringContaining('tab creation failed'),
+        }),
+      },
     ])
+    expect(debugLogs.map((log) => log.message)).toEqual([
+      'MCP browser tool started',
+      'MCP browser tool completed',
+    ])
+    expect(debugLogs[0]?.meta).toEqual(
+      expect.objectContaining({
+        toolName: 'tabs',
+        source: 'unit-test',
+        args: expect.objectContaining({
+          action: 'new',
+          urlOrigin: 'https://example.com',
+        }),
+      }),
+    )
     expect(result?.isError).toBe(true)
     expect(textOf(result)).toContain('tab creation failed')
     expect(events).toEqual([

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/register.test.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/register.test.ts
@@ -123,10 +123,16 @@ describe('registerBrowserTools', () => {
         meta: expect.objectContaining({
           toolName: 'tabs',
           source: 'unit-test',
-          error: expect.stringContaining('tab creation failed'),
+          errorSummary: expect.objectContaining({
+            contentCount: expect.any(Number),
+            textBlockCount: expect.any(Number),
+            textLength: expect.any(Number),
+            lineCount: expect.any(Number),
+          }),
         }),
       },
     ])
+    expect(JSON.stringify(infoLogs)).not.toContain('tab creation failed')
     expect(debugLogs.map((log) => log.message)).toEqual([
       'MCP browser tool started',
       'MCP browser tool completed',

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/register.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/register.ts
@@ -52,8 +52,6 @@ export interface BrowserToolExecutionEvent extends Record<string, unknown> {
   error_message?: string
 }
 
-const ERROR_PREVIEW_CHARS = 500
-
 function summarizeBrowserToolArgs(
   args: Record<string, unknown>,
 ): Record<string, unknown> {
@@ -76,14 +74,18 @@ function summarizeBrowserToolArgs(
   return summary
 }
 
-function previewText(text: string): string {
-  if (text.length <= ERROR_PREVIEW_CHARS) return text
-  return `${text.slice(0, ERROR_PREVIEW_CHARS)}... (+${text.length - ERROR_PREVIEW_CHARS} chars)`
+function summarizeText(text: string): Record<string, unknown> {
+  return {
+    textLength: text.length,
+    lineCount: text.length ? text.split('\n').length : 0,
+  }
 }
 
-function resultTextPreview(content: unknown): string | undefined {
+function resultTextSummary(
+  content: unknown,
+): Record<string, unknown> | undefined {
   if (!Array.isArray(content)) return undefined
-  const text = content
+  const textBlocks = content
     .filter(
       (item): item is { type: 'text'; text: string } =>
         typeof item === 'object' &&
@@ -94,8 +96,19 @@ function resultTextPreview(content: unknown): string | undefined {
         typeof item.text === 'string',
     )
     .map((item) => item.text)
-    .join('\n')
-  return text ? previewText(text) : undefined
+  if (textBlocks.length === 0) {
+    return {
+      contentCount: content.length,
+      textBlockCount: 0,
+      textLength: 0,
+      lineCount: 0,
+    }
+  }
+  return {
+    contentCount: content.length,
+    textBlockCount: textBlocks.length,
+    ...summarizeText(textBlocks.join('\n')),
+  }
 }
 
 /** Registers the browser tool surface on an MCP server bound to one BrowserSession. */
@@ -149,8 +162,8 @@ export function registerBrowserTools(
             source,
           })
           const durationMs = duration()
-          const errorText = result.isError
-            ? resultTextPreview(result.content)
+          const errorSummary = result.isError
+            ? resultTextSummary(result.content)
             : undefined
           options.logger?.debug?.('MCP browser tool completed', {
             ...logBase,
@@ -162,7 +175,7 @@ export function registerBrowserTools(
             options.logger?.info?.('MCP browser tool returned error', {
               ...logBase,
               durationMs,
-              error: errorText,
+              errorSummary,
             })
           }
           return {

--- a/packages/browseros-agent/packages/browser-mcp/src/tools/register.ts
+++ b/packages/browseros-agent/packages/browser-mcp/src/tools/register.ts
@@ -31,11 +31,16 @@ export interface BrowserToolDefaults {
   defaultTabGroupId?: string
 }
 
+interface BrowserToolLogger {
+  debug?(message: string, meta?: Record<string, unknown>): void
+  info?(message: string, meta?: Record<string, unknown>): void
+}
+
 export interface BrowserToolRegistrationOptions {
   outputFileAccess?: BrowserOutputFileAccess
   onToolExecuted?: (event: BrowserToolExecutionEvent) => void
   shouldLogToolRegistration?: () => boolean
-  logger?: { info(message: string): void }
+  logger?: BrowserToolLogger
   source?: string
 }
 
@@ -45,6 +50,52 @@ export interface BrowserToolExecutionEvent extends Record<string, unknown> {
   success: boolean
   source: string
   error_message?: string
+}
+
+const ERROR_PREVIEW_CHARS = 500
+
+function summarizeBrowserToolArgs(
+  args: Record<string, unknown>,
+): Record<string, unknown> {
+  const summary: Record<string, unknown> = {
+    argKeys: Object.keys(args).sort(),
+  }
+  if (typeof args.page === 'number') summary.page = args.page
+  if (typeof args.action === 'string') summary.action = args.action
+  if (typeof args.format === 'string') summary.format = args.format
+  if (typeof args.timeoutMs === 'number') summary.timeoutMs = args.timeoutMs
+  if (typeof args.timeout === 'number') summary.timeout = args.timeout
+  if (typeof args.selector === 'string') summary.selectorPresent = true
+  if (typeof args.url === 'string') {
+    try {
+      summary.urlOrigin = new URL(args.url).origin
+    } catch {
+      summary.urlPresent = true
+    }
+  }
+  return summary
+}
+
+function previewText(text: string): string {
+  if (text.length <= ERROR_PREVIEW_CHARS) return text
+  return `${text.slice(0, ERROR_PREVIEW_CHARS)}... (+${text.length - ERROR_PREVIEW_CHARS} chars)`
+}
+
+function resultTextPreview(content: unknown): string | undefined {
+  if (!Array.isArray(content)) return undefined
+  const text = content
+    .filter(
+      (item): item is { type: 'text'; text: string } =>
+        typeof item === 'object' &&
+        item !== null &&
+        'type' in item &&
+        item.type === 'text' &&
+        'text' in item &&
+        typeof item.text === 'string',
+    )
+    .map((item) => item.text)
+    .join('\n')
+  return text ? previewText(text) : undefined
 }
 
 /** Registers the browser tool surface on an MCP server bound to one BrowserSession. */
@@ -68,8 +119,19 @@ export function registerBrowserTools(
         }),
       },
       async (args, extra) => {
+        const source = options.source ?? 'mcp'
         const startTime = performance.now()
         const duration = () => Math.round(performance.now() - startTime)
+        const logBase = {
+          toolName: tool.name,
+          source,
+        }
+        options.logger?.debug?.('MCP browser tool started', {
+          ...logBase,
+          args: summarizeBrowserToolArgs(args),
+          defaultWindowId: defaults.defaultWindowId,
+          defaultTabGroupId: defaults.defaultTabGroupId,
+        })
         try {
           const result = await withBrowserOutputFileAccess(
             options.outputFileAccess,
@@ -84,8 +146,25 @@ export function registerBrowserTools(
             tool_name: tool.name,
             duration_ms: duration(),
             success: !result.isError,
-            source: options.source ?? 'mcp',
+            source,
           })
+          const durationMs = duration()
+          const errorText = result.isError
+            ? resultTextPreview(result.content)
+            : undefined
+          options.logger?.debug?.('MCP browser tool completed', {
+            ...logBase,
+            durationMs,
+            isError: Boolean(result.isError),
+            hasStructuredContent: result.structuredContent !== undefined,
+          })
+          if (result.isError) {
+            options.logger?.info?.('MCP browser tool returned error', {
+              ...logBase,
+              durationMs,
+              error: errorText,
+            })
+          }
           return {
             content: result.content,
             isError: result.isError,
@@ -99,7 +178,12 @@ export function registerBrowserTools(
             duration_ms: duration(),
             success: false,
             error_message: errorText,
-            source: options.source ?? 'mcp',
+            source,
+          })
+          options.logger?.info?.('MCP browser tool threw', {
+            ...logBase,
+            durationMs: duration(),
+            error: errorText,
           })
           return {
             content: [{ type: 'text' as const, text: errorText }],
@@ -111,8 +195,10 @@ export function registerBrowserTools(
   }
 
   if (options.shouldLogToolRegistration?.()) {
-    options.logger?.info(
-      `Registered ${BROWSER_TOOLS.length} browser tools: ${BROWSER_TOOLS.map((t) => t.name).join(', ')}`,
-    )
+    options.logger?.info?.('Registered browser MCP tools', {
+      count: BROWSER_TOOLS.length,
+      toolNames: BROWSER_TOOLS.map((t) => t.name),
+      source: options.source ?? 'mcp',
+    })
   }
 }


### PR DESCRIPTION
## Summary

- add request lifecycle logging around the `/mcp` route and per-request MCP server creation
- instrument browser, filesystem, Klavis, custom MCP, and chat tool wrappers with start/complete/error logs
- keep production returned-error logs metadata-only so raw tool output is not written to `info`
- align external MCP chat tool metrics with returned `isError` results

## Verification

- `bun test packages/browser-mcp/src/tools/register.test.ts apps/server/tests/api/services/mcp/register-mcp.test.ts apps/server/tests/tools/browser/register.test.ts`
- `bun run typecheck`
- `bun run check` (exit 0; existing unrelated Claw/app warnings remain)
- `bun run test:main`
- `bun run test`

## Review

- local adversarial review found raw returned-error text in production logs and an external MCP metric mismatch
- both findings fixed
- second review verdict: clean
