### PR TITLE
fix: remove noisy agent list log

### DIFF
--- a/packages/browseros-agent/apps/server/src/lib/agents/storage/db-agent-store.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/storage/db-agent-store.ts
@@ -36,10 +36,6 @@ export class DbAgentStore implements AgentStore {
       const agent = toAgentDefinition(row)
       return agent ? [agent] : []
     })
-    logger.debug('Agent harness store listed agents', {
-      count: agents.length,
-      store: 'sqlite',
-    })
     return agents
   }
 


### PR DESCRIPTION
## Summary
- Remove the high-frequency `Agent harness store listed agents` debug log from `DbAgentStore.list()`.
- Preserve the list query, ordering, conversion, and other agent store logs.

## Design
This is a direct deletion of the single noisy debug side effect in the read path. The mutation and unsupported-row logs remain untouched, and the referenced server MCP logging patch is not changed.

## Test plan
- [x] `rg -n "Agent harness store listed agents" apps/server/src/lib/agents/storage apps/server/src/lib/agents -S` returns no matches
- [x] `bun run check`
- [x] `bun run test`
- [x] local Codex `sf-review` pass: clean