### PR TITLE
fix: simplify extension release version dispatch

### DIFF
--- a/.github/workflows/release-agent-extension.yml
+++ b/.github/workflows/release-agent-extension.yml
@@ -6,8 +6,8 @@ on:
       - "agent-extension/v*"
   workflow_dispatch:
     inputs:
-      tag:
-        description: Existing release tag to publish, e.g. agent-extension/v0.0.100
+      version:
+        description: "Release version, e.g. 0.0.119"
         required: true
         type: string
 
@@ -17,7 +17,9 @@ concurrency:
 
 jobs:
   release:
+    if: github.event_name != 'push' || github.event.deleted != true
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: write
       pull-requests: write
@@ -31,148 +33,21 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.repository.default_branch || 'main' }}
 
-      - name: Resolve release metadata
+      - name: Resolve release
         id: release
         env:
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
-          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+          REF_NAME: ${{ github.ref_name }}
+          REQUESTED_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          PACKAGE_JSON="packages/browseros-agent/apps/app/package.json"
-          NEW_PREFIX="agent-extension/v"
-          LEGACY_PREFIX="agent-extension-v"
-
-          is_semver() {
-            [[ "$1" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
-          }
-
-          emit() {
-            printf '%s=%s\n' "$1" "$2"
-            printf '%s=%s\n' "$1" "$2" >> "$GITHUB_OUTPUT"
-          }
-
-          git fetch origin "$DEFAULT_BRANCH:refs/remotes/origin/$DEFAULT_BRANCH" --no-tags
-          git fetch origin --tags --prune
-
-          VERSION="${RELEASE_TAG#"$NEW_PREFIX"}"
-          if [ "$RELEASE_TAG" = "$VERSION" ] || ! is_semver "$VERSION"; then
-            echo "::error::Expected extension release tag like ${NEW_PREFIX}X.Y.Z, got: $RELEASE_TAG"
-            exit 1
-          fi
-
-          TAG_TYPE="$(git cat-file -t "refs/tags/$RELEASE_TAG" 2>/dev/null || true)"
-          if [ -z "$TAG_TYPE" ]; then
-            echo "::error::Tag does not exist: $RELEASE_TAG"
-            exit 1
-          fi
-          if [ "$TAG_TYPE" != "tag" ]; then
-            echo "::error::Tag $RELEASE_TAG must be an annotated tag."
-            exit 1
-          fi
-
-          RELEASE_SHA="$(git rev-list -n 1 "$RELEASE_TAG")"
-          if ! PACKAGE_VERSION="$(
-            git show "$RELEASE_SHA:$PACKAGE_JSON" | python3 -c '
-          import json
-          import sys
-
-          print(json.load(sys.stdin)["version"])
-          '
-          )"; then
-            echo "::error::Could not read $PACKAGE_JSON version from $RELEASE_TAG ($RELEASE_SHA)"
-            exit 1
-          fi
-
-          if [ "$PACKAGE_VERSION" != "$VERSION" ]; then
-            echo "::error::$PACKAGE_JSON at $RELEASE_TAG is $PACKAGE_VERSION, expected $VERSION. Bump package.json before tagging."
-            exit 1
-          fi
-
-          if ! git merge-base --is-ancestor "$RELEASE_SHA" "origin/$DEFAULT_BRANCH"; then
-            echo "::error::Tagged commit $RELEASE_SHA is not reachable from origin/$DEFAULT_BRANCH."
-            exit 1
-          fi
-
-          PREVIOUS_RESULT="$(
-            python3 - "$VERSION" "$RELEASE_TAG" "$NEW_PREFIX" "$LEGACY_PREFIX" <<'PY'
-          import re
-          import subprocess
-          import sys
-
-          target = tuple(int(part) for part in sys.argv[1].split("."))
-          target_tag = sys.argv[2]
-          prefixes = sys.argv[3:]
-          latest = None
-          duplicate = None
-
-          for tag in subprocess.check_output(["git", "tag", "-l"], text=True).splitlines():
-              if tag == target_tag:
-                  continue
-
-              for prefix in prefixes:
-                  if not tag.startswith(prefix):
-                      continue
-                  version = tag[len(prefix):]
-                  if not re.fullmatch(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)", version):
-                      continue
-                  parsed = tuple(int(part) for part in version.split("."))
-                  if parsed == target:
-                      duplicate = tag
-                  if latest is None or parsed > latest[0]:
-                      latest = (parsed, tag)
-
-          if duplicate:
-              print(f"duplicate={duplicate}")
-          elif latest and target <= latest[0]:
-              print(f"non_incrementing={'.'.join(str(part) for part in latest[0])}:{latest[1]}")
-          elif latest:
-              print(f"previous={latest[1]}")
-          PY
-          )"
-
-          PREVIOUS_TAG=""
-          case "$PREVIOUS_RESULT" in
-            duplicate=*)
-              DUPLICATE_TAG="${PREVIOUS_RESULT#duplicate=}"
-              echo "::error::Release version $VERSION already exists as tag $DUPLICATE_TAG."
-              exit 1
-              ;;
-            non_incrementing=*)
-              LATEST="${PREVIOUS_RESULT#non_incrementing=}"
-              LATEST_VERSION="${LATEST%%:*}"
-              LATEST_TAG="${LATEST#*:}"
-              echo "::error::Release version $VERSION must be greater than latest existing extension version $LATEST_VERSION ($LATEST_TAG)."
-              exit 1
-              ;;
-            previous=*)
-              PREVIOUS_TAG="${PREVIOUS_RESULT#previous=}"
-              ;;
-            "")
-              ;;
-            *)
-              echo "::error::Unexpected previous tag resolver output: $PREVIOUS_RESULT"
-              exit 1
-              ;;
-          esac
-
-          emit version "$VERSION"
-          emit tag "$RELEASE_TAG"
-          emit release_sha "$RELEASE_SHA"
-          emit previous_tag "$PREVIOUS_TAG"
-
-          cat >> "$GITHUB_STEP_SUMMARY" <<EOF
-          Extension release:
-          - Version: ${VERSION}
-          - Tag: ${RELEASE_TAG}
-          - Release commit: ${RELEASE_SHA}
-          - Package path: ${PACKAGE_JSON}
-
-          Maintainer release flow:
-          1. Bump packages/browseros-agent/apps/app/package.json in a PR and merge it.
-          2. git tag -a agent-extension/v${VERSION} -m "agent-extension v${VERSION}"
-          3. git push origin agent-extension/v${VERSION}
-          EOF
-        working-directory: packages/browseros-agent
+          packages/browseros-agent/scripts/release/prepare-extension-release.sh \
+            --event-name "$EVENT_NAME" \
+            --default-branch "$DEFAULT_BRANCH" \
+            --ref-name "$REF_NAME" \
+            --requested-version "$REQUESTED_VERSION"
+        working-directory: ${{ github.workspace }}
 
       - name: Checkout release commit
         run: git checkout --detach "${{ steps.release.outputs.release_sha }}"

--- a/packages/browseros-agent/apps/app/README.md
+++ b/packages/browseros-agent/apps/app/README.md
@@ -142,7 +142,9 @@ GRAPHQL_SCHEMA_PATH=/path/to/api-repo/.../schema.graphql
 
 ## Release Flow
 
-Extension releases use annotated component tags. First bump `packages/browseros-agent/apps/app/package.json` in a PR, merge that version commit to the default branch, then tag the merged commit:
+Extension releases use annotated component tags. For the usual path, run the `Release BrowserOS Extension` workflow manually with the target version, for example `0.0.119`. The workflow bumps `packages/browseros-agent/apps/app/package.json`, updates the matching `bun.lock` workspace entry, commits that bump to the default branch, creates `agent-extension/vX.Y.Z`, and publishes the GitHub Release.
+
+To release from an existing version commit instead, tag the merged default-branch commit manually:
 
 ```bash
 git tag -a agent-extension/v0.0.100 -m "agent-extension v0.0.100"

--- a/packages/browseros-agent/scripts/release/prepare-extension-release.sh
+++ b/packages/browseros-agent/scripts/release/prepare-extension-release.sh
@@ -274,8 +274,8 @@ else
 
     ensure_git_identity
 
-    if [ "$current_version" != "$version" ]; then
-      update_release_version_files "$version"
+    update_release_version_files "$version"
+    if ! git diff --quiet -- "$EXTENSION_PACKAGE_JSON" "$EXTENSION_LOCK"; then
       git add "$EXTENSION_PACKAGE_JSON" "$EXTENSION_LOCK"
       git commit -m "chore: bump extension version to $version"
     fi

--- a/packages/browseros-agent/scripts/release/prepare-extension-release.sh
+++ b/packages/browseros-agent/scripts/release/prepare-extension-release.sh
@@ -84,6 +84,45 @@ print(json.load(sys.stdin)["version"])
 '
 }
 
+read_lock_version_at_ref() {
+  git show "$1:$EXTENSION_LOCK" | python3 -c '
+import re
+import sys
+
+match = re.search(r"\"apps/app\":\s*\{\s*\"name\":\s*\"@browseros/app\",\s*\"version\":\s*\"([^\"]+)\"", sys.stdin.read())
+if not match:
+    raise SystemExit(1)
+print(match.group(1))
+'
+}
+
+validate_release_version_files_at_ref() {
+  local sha="$1"
+  local release_label="$2"
+  local package_version
+  local lock_version
+
+  if ! package_version="$(read_package_version_at_ref "$sha")"; then
+    echo "::error::Could not read $EXTENSION_PACKAGE_JSON version from $release_label ($sha)"
+    exit 1
+  fi
+
+  if [ "$package_version" != "$version" ]; then
+    echo "::error::$EXTENSION_PACKAGE_JSON at $release_label is $package_version, expected $version. Bump package.json before tagging."
+    exit 1
+  fi
+
+  if ! lock_version="$(read_lock_version_at_ref "$sha")"; then
+    echo "::error::Could not read apps/app version from $EXTENSION_LOCK at $release_label ($sha)"
+    exit 1
+  fi
+
+  if [ "$lock_version" != "$version" ]; then
+    echo "::error::$EXTENSION_LOCK at $release_label has apps/app version $lock_version, expected $version."
+    exit 1
+  fi
+}
+
 compare_versions() {
   python3 - "$1" "$2" <<'PY'
 import sys
@@ -235,13 +274,7 @@ if [ "$event_name" = "push" ]; then
 
   require_annotated_tag "$tag"
   release_sha="$(git rev-list -n 1 "$tag")"
-  package_version="$(read_package_version_at_ref "$release_sha")"
-
-  if [ "$package_version" != "$version" ]; then
-    echo "::error::$EXTENSION_PACKAGE_JSON at $tag is $package_version, expected $version. Bump package.json before tagging."
-    exit 1
-  fi
-
+  validate_release_version_files_at_ref "$release_sha" "$tag"
   ensure_default_branch_release "$release_sha"
   resolve_previous_tag
 else
@@ -256,12 +289,7 @@ else
   if git rev-parse --verify --quiet "refs/tags/$tag" >/dev/null; then
     require_annotated_tag "$tag"
     release_sha="$(git rev-list -n 1 "$tag")"
-    package_version="$(read_package_version_at_ref "$release_sha")"
-
-    if [ "$package_version" != "$version" ]; then
-      echo "::error::$EXTENSION_PACKAGE_JSON at $tag is $package_version, expected $version."
-      exit 1
-    fi
+    validate_release_version_files_at_ref "$release_sha" "$tag"
     ensure_default_branch_release "$release_sha"
   else
     git checkout -B "$default_branch" "$remote/$default_branch"

--- a/packages/browseros-agent/scripts/release/prepare-extension-release.sh
+++ b/packages/browseros-agent/scripts/release/prepare-extension-release.sh
@@ -1,0 +1,303 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prepare an extension GitHub Release by aligning the app package version and tag.
+EXTENSION_PACKAGE_JSON="packages/browseros-agent/apps/app/package.json"
+EXTENSION_LOCK="packages/browseros-agent/bun.lock"
+NEW_PREFIX="agent-extension/v"
+
+usage() {
+  cat >&2 <<'EOF'
+Usage: prepare-extension-release.sh --event-name <push|workflow_dispatch> --default-branch <branch> --ref-name <ref> [--requested-version <X.Y.Z>] [--remote <name>]
+EOF
+}
+
+event_name=""
+default_branch=""
+ref_name=""
+requested_version=""
+remote="origin"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --event-name)
+      event_name="${2:-}"
+      shift 2
+      ;;
+    --default-branch)
+      default_branch="${2:-}"
+      shift 2
+      ;;
+    --ref-name)
+      ref_name="${2:-}"
+      shift 2
+      ;;
+    --requested-version)
+      requested_version="${2:-}"
+      shift 2
+      ;;
+    --remote)
+      remote="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 2
+      ;;
+  esac
+done
+
+if [ -z "$event_name" ] || [ -z "$default_branch" ]; then
+  usage
+  exit 2
+fi
+
+git_root="$(git rev-parse --show-toplevel)"
+git_root="$(cd "$git_root" && pwd -P)"
+cd "$git_root"
+
+is_semver() {
+  [[ "$1" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
+}
+
+read_package_version() {
+  python3 - "$git_root/$EXTENSION_PACKAGE_JSON" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+print(json.loads(Path(sys.argv[1]).read_text())["version"])
+PY
+}
+
+read_package_version_at_ref() {
+  git show "$1:$EXTENSION_PACKAGE_JSON" | python3 -c '
+import json
+import sys
+
+print(json.load(sys.stdin)["version"])
+'
+}
+
+compare_versions() {
+  python3 - "$1" "$2" <<'PY'
+import sys
+
+left = tuple(int(part) for part in sys.argv[1].split("."))
+right = tuple(int(part) for part in sys.argv[2].split("."))
+print((left > right) - (left < right))
+PY
+}
+
+update_release_version_files() {
+  python3 - "$git_root/$EXTENSION_PACKAGE_JSON" "$git_root/$EXTENSION_LOCK" "$1" <<'PY'
+import json
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+lock_path = Path(sys.argv[2])
+version = sys.argv[3]
+data = json.loads(path.read_text())
+data["version"] = version
+path.write_text(json.dumps(data, indent=2) + "\n")
+
+lock_text = lock_path.read_text()
+lock_pattern = re.compile(r'("apps/app":\s*\{\s*"name":\s*"@browseros/app",\s*"version":\s*")(\d+\.\d+\.\d+)(")')
+updated_lock, count = lock_pattern.subn(rf"\g<1>{version}\3", lock_text)
+if count != 1:
+    raise SystemExit("Expected exactly one apps/app version entry in bun.lock")
+lock_path.write_text(updated_lock)
+PY
+}
+
+ensure_git_identity() {
+  git config user.name "github-actions[bot]"
+  git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+}
+
+require_annotated_tag() {
+  local tag="$1"
+  local tag_type
+  tag_type="$(git cat-file -t "refs/tags/$tag" 2>/dev/null || true)"
+  if [ -z "$tag_type" ]; then
+    echo "::error::Tag does not exist: $tag"
+    exit 1
+  fi
+  if [ "$tag_type" != "tag" ]; then
+    echo "::error::Tag $tag must be an annotated tag."
+    exit 1
+  fi
+}
+
+ensure_default_branch_release() {
+  local sha="$1"
+  if ! git merge-base --is-ancestor "$sha" "$remote/$default_branch"; then
+    echo "::error::Tagged commit $sha is not reachable from $remote/$default_branch."
+    exit 1
+  fi
+}
+
+previous_extension_tag() {
+  python3 - "$1" "$2" <<'PY'
+import re
+import subprocess
+import sys
+
+target = tuple(int(part) for part in sys.argv[1].split("."))
+target_tag = sys.argv[2]
+tags = subprocess.check_output(["git", "tag", "-l"], text=True).splitlines()
+latest = None
+duplicate = None
+
+for tag in tags:
+    if tag == target_tag:
+        continue
+
+    for prefix in ("agent-extension/v", "agent-extension-v"):
+        if not tag.startswith(prefix):
+            continue
+        version = tag[len(prefix):]
+        if not re.fullmatch(r"(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)", version):
+            continue
+        parsed = tuple(int(part) for part in version.split("."))
+        if parsed == target:
+            duplicate = tag
+        if latest is None or parsed > latest[0]:
+            latest = (parsed, tag)
+
+if duplicate:
+    print(f"duplicate={duplicate}")
+    sys.exit(0)
+
+if latest and target <= latest[0]:
+    print(f"non_incrementing={'.'.join(str(part) for part in latest[0])}:{latest[1]}")
+    sys.exit(0)
+
+if latest:
+    print(f"previous={latest[1]}")
+PY
+}
+
+resolve_previous_tag() {
+  local previous_result
+  previous_result="$(previous_extension_tag "$version" "$tag")"
+  case "$previous_result" in
+    duplicate=*)
+      duplicate_tag="${previous_result#duplicate=}"
+      echo "::error::Release version $version already exists as tag $duplicate_tag."
+      exit 1
+      ;;
+    non_incrementing=*)
+      latest="${previous_result#non_incrementing=}"
+      latest_version="${latest%%:*}"
+      latest_tag="${latest#*:}"
+      echo "::error::Release version $version must be greater than latest existing extension version $latest_version ($latest_tag)."
+      exit 1
+      ;;
+    previous=*)
+      previous_tag="${previous_result#previous=}"
+      ;;
+    "")
+      previous_tag=""
+      ;;
+    *)
+      echo "::error::Unexpected previous tag resolver output: $previous_result"
+      exit 1
+      ;;
+  esac
+}
+
+emit() {
+  printf '%s=%s\n' "$1" "$2"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s=%s\n' "$1" "$2" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+git fetch "$remote" "$default_branch:refs/remotes/$remote/$default_branch" --no-tags
+git fetch "$remote" --tags --prune
+
+if [ "$event_name" = "push" ]; then
+  tag="$ref_name"
+  version="${tag#"$NEW_PREFIX"}"
+
+  if [ "$tag" = "$version" ] || ! is_semver "$version"; then
+    echo "::error::Expected extension release tag like agent-extension/vX.Y.Z, got: $tag"
+    exit 1
+  fi
+
+  require_annotated_tag "$tag"
+  release_sha="$(git rev-list -n 1 "$tag")"
+  package_version="$(read_package_version_at_ref "$release_sha")"
+
+  if [ "$package_version" != "$version" ]; then
+    echo "::error::$EXTENSION_PACKAGE_JSON at $tag is $package_version, expected $version. Bump package.json before tagging."
+    exit 1
+  fi
+
+  ensure_default_branch_release "$release_sha"
+  resolve_previous_tag
+else
+  version="$requested_version"
+  if ! is_semver "$version"; then
+    echo "::error::Version must be MAJOR.MINOR.PATCH, got: $version"
+    exit 1
+  fi
+
+  tag="${NEW_PREFIX}${version}"
+  resolve_previous_tag
+  if git rev-parse --verify --quiet "refs/tags/$tag" >/dev/null; then
+    require_annotated_tag "$tag"
+    release_sha="$(git rev-list -n 1 "$tag")"
+    package_version="$(read_package_version_at_ref "$release_sha")"
+
+    if [ "$package_version" != "$version" ]; then
+      echo "::error::$EXTENSION_PACKAGE_JSON at $tag is $package_version, expected $version."
+      exit 1
+    fi
+    ensure_default_branch_release "$release_sha"
+  else
+    git checkout -B "$default_branch" "$remote/$default_branch"
+    current_version="$(read_package_version)"
+
+    if [ "$(compare_versions "$version" "$current_version")" = "-1" ]; then
+      echo "::error::Requested extension version $version is lower than $EXTENSION_PACKAGE_JSON ($current_version)."
+      exit 1
+    fi
+
+    ensure_git_identity
+
+    if [ "$current_version" != "$version" ]; then
+      update_release_version_files "$version"
+      git add "$EXTENSION_PACKAGE_JSON" "$EXTENSION_LOCK"
+      git commit -m "chore: bump extension version to $version"
+    fi
+
+    release_sha="$(git rev-parse HEAD)"
+    git tag -a "$tag" -m "BrowserOS Extension - v$version" "$release_sha"
+    git push --atomic "$remote" "HEAD:refs/heads/$default_branch" "refs/tags/$tag"
+    package_version="$version"
+  fi
+fi
+
+emit version "$version"
+emit tag "$tag"
+emit release_sha "$release_sha"
+emit previous_tag "$previous_tag"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  cat >> "$GITHUB_STEP_SUMMARY" <<EOF
+Extension release:
+- Version: $version
+- Tag: $tag
+- Release commit: $release_sha
+- Package path: $EXTENSION_PACKAGE_JSON
+EOF
+fi

--- a/packages/browseros-agent/scripts/release/prepare-extension-release.test.ts
+++ b/packages/browseros-agent/scripts/release/prepare-extension-release.test.ts
@@ -62,10 +62,17 @@ function writeLock(dir: string, version: string): void {
   )
 }
 
+async function commitReleaseFiles(dir: string, version: string): Promise<void> {
+  writePackage(dir, version)
+  writeLock(dir, version)
+  await mustRun(dir, ['git', 'add', packagePath, lockPath])
+  await mustRun(dir, ['git', 'commit', '-m', `version ${version}`])
+}
+
 async function commitPackage(dir: string, version: string): Promise<void> {
   writePackage(dir, version)
   await mustRun(dir, ['git', 'add', packagePath])
-  await mustRun(dir, ['git', 'commit', '-m', `version ${version}`])
+  await mustRun(dir, ['git', 'commit', '-m', `package version ${version}`])
 }
 
 async function tag(dir: string, name: string): Promise<void> {
@@ -255,9 +262,9 @@ describe('prepare-extension-release', () => {
     const { dir, bareDir } = await initFixture('0.0.100')
     try {
       await tag(dir, 'agent-extension-v0.0.100')
-      await commitPackage(dir, '0.0.101')
+      await commitReleaseFiles(dir, '0.0.101')
       await tag(dir, 'agent-extension/v0.0.101')
-      await commitPackage(dir, '0.0.102')
+      await commitReleaseFiles(dir, '0.0.102')
       await tag(dir, 'agent-extension/v0.0.102')
       await mustRun(dir, ['git', 'push', 'origin', 'main', '--tags'])
 
@@ -282,7 +289,7 @@ describe('prepare-extension-release', () => {
     const { dir, bareDir } = await initFixture('0.0.100')
     try {
       await mustRun(dir, ['git', 'checkout', '-b', 'release-side'])
-      await commitPackage(dir, '0.0.101')
+      await commitReleaseFiles(dir, '0.0.101')
       await tag(dir, 'agent-extension/v0.0.101')
       await mustRun(dir, ['git', 'push', 'origin', 'agent-extension/v0.0.101'])
 
@@ -325,7 +332,7 @@ describe('prepare-extension-release', () => {
     const { dir, bareDir } = await initFixture('0.0.102')
     try {
       await tag(dir, 'agent-extension-v0.0.102')
-      await commitPackage(dir, '0.0.101')
+      await commitReleaseFiles(dir, '0.0.101')
       await tag(dir, 'agent-extension/v0.0.101')
       await mustRun(dir, ['git', 'push', 'origin', 'main', '--tags'])
 
@@ -376,6 +383,28 @@ describe('prepare-extension-release', () => {
       expect(result.code).toBe(1)
       expect(outputText(result)).toContain(
         'packages/browseros-agent/apps/app/package.json at agent-extension/v0.0.101 is 0.0.100, expected 0.0.101',
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+      rmSync(bareDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a pushed tag whose lockfile version does not match', async () => {
+    const { dir, bareDir } = await initFixture('0.0.100')
+    try {
+      await commitPackage(dir, '0.0.101')
+      await tag(dir, 'agent-extension/v0.0.101')
+      await mustRun(dir, ['git', 'push', 'origin', 'main', '--tags'])
+
+      const result = await prepare(dir, {
+        eventName: 'push',
+        refName: 'agent-extension/v0.0.101',
+      })
+
+      expect(result.code).toBe(1)
+      expect(outputText(result)).toContain(
+        'packages/browseros-agent/bun.lock at agent-extension/v0.0.101 has apps/app version 0.0.100, expected 0.0.101',
       )
     } finally {
       rmSync(dir, { recursive: true, force: true })

--- a/packages/browseros-agent/scripts/release/prepare-extension-release.test.ts
+++ b/packages/browseros-agent/scripts/release/prepare-extension-release.test.ts
@@ -72,7 +72,10 @@ async function tag(dir: string, name: string): Promise<void> {
   await mustRun(dir, ['git', 'tag', '-a', name, '-m', name])
 }
 
-async function initFixture(version: string): Promise<{
+async function initFixture(
+  version: string,
+  lockVersion = version,
+): Promise<{
   dir: string
   bareDir: string
 }> {
@@ -82,7 +85,7 @@ async function initFixture(version: string): Promise<{
   await mustRun(dir, ['git', 'config', 'user.name', 'BrowserOS Test'])
   await mustRun(dir, ['git', 'config', 'user.email', 'test@browseros.com'])
   writePackage(dir, version)
-  writeLock(dir, version)
+  writeLock(dir, lockVersion)
   await mustRun(dir, ['git', 'add', '.'])
   await mustRun(dir, ['git', 'commit', '-m', `version ${version}`])
   await mustRun(bareDir, ['git', 'init', '--bare', '--initial-branch=main'])
@@ -210,6 +213,38 @@ describe('prepare-extension-release', () => {
       expect(
         (await mustRun(dir, ['git', 'rev-parse', 'origin/main'])).trim(),
       ).toBe(releaseSha)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+      rmSync(bareDir, { recursive: true, force: true })
+    }
+  })
+
+  it('repairs a stale lockfile entry before tagging an already-bumped package', async () => {
+    const { dir, bareDir } = await initFixture('0.0.101', '0.0.100')
+    try {
+      const result = await prepare(dir, {
+        eventName: 'workflow_dispatch',
+        requestedVersion: '0.0.101',
+      })
+
+      expect(result.code, result.stderr || result.stdout).toBe(0)
+      expect(
+        await mustRun(dir, ['git', 'show', `origin/main:${packagePath}`]),
+      ).toContain('"version": "0.0.101"')
+      expect(
+        await mustRun(dir, ['git', 'show', `origin/main:${lockPath}`]),
+      ).toContain('"version": "0.0.101"')
+      expect(
+        (
+          await mustRun(dir, [
+            'git',
+            'rev-list',
+            '-n',
+            '1',
+            'agent-extension/v0.0.101',
+          ])
+        ).trim(),
+      ).toBe((await mustRun(dir, ['git', 'rev-parse', 'origin/main'])).trim())
     } finally {
       rmSync(dir, { recursive: true, force: true })
       rmSync(bareDir, { recursive: true, force: true })

--- a/packages/browseros-agent/scripts/release/prepare-extension-release.test.ts
+++ b/packages/browseros-agent/scripts/release/prepare-extension-release.test.ts
@@ -1,0 +1,350 @@
+import { describe, expect, it } from 'bun:test'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join, resolve } from 'node:path'
+
+const repoRoot = resolve(import.meta.dir, '../..')
+const prepareExtensionRelease = join(
+  repoRoot,
+  'scripts/release/prepare-extension-release.sh',
+)
+const packagePath = 'packages/browseros-agent/apps/app/package.json'
+const lockPath = 'packages/browseros-agent/bun.lock'
+
+async function run(
+  cwd: string,
+  args: string[],
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  const proc = Bun.spawn(args, {
+    cwd,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  })
+  const [stdout, stderr, code] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ])
+  return { code, stdout, stderr }
+}
+
+async function mustRun(cwd: string, args: string[]): Promise<string> {
+  const result = await run(cwd, args)
+  expect(result.code, result.stderr || result.stdout).toBe(0)
+  return result.stdout
+}
+
+function writePackage(dir: string, version: string): void {
+  const path = join(dir, packagePath)
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(
+    path,
+    `${JSON.stringify({ name: '@browseros/app', version }, null, 2)}\n`,
+  )
+}
+
+function writeLock(dir: string, version: string): void {
+  const path = join(dir, lockPath)
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(
+    path,
+    [
+      '{',
+      '  "workspaces": {',
+      '    "apps/app": {',
+      '      "name": "@browseros/app",',
+      `      "version": "${version}",`,
+      '    },',
+      '  },',
+      '}',
+      '',
+    ].join('\n'),
+  )
+}
+
+async function commitPackage(dir: string, version: string): Promise<void> {
+  writePackage(dir, version)
+  await mustRun(dir, ['git', 'add', packagePath])
+  await mustRun(dir, ['git', 'commit', '-m', `version ${version}`])
+}
+
+async function tag(dir: string, name: string): Promise<void> {
+  await mustRun(dir, ['git', 'tag', '-a', name, '-m', name])
+}
+
+async function initFixture(version: string): Promise<{
+  dir: string
+  bareDir: string
+}> {
+  const dir = mkdtempSync(join(tmpdir(), 'extension-release-'))
+  const bareDir = mkdtempSync(join(tmpdir(), 'extension-release-origin-'))
+  await mustRun(dir, ['git', 'init', '--initial-branch=main'])
+  await mustRun(dir, ['git', 'config', 'user.name', 'BrowserOS Test'])
+  await mustRun(dir, ['git', 'config', 'user.email', 'test@browseros.com'])
+  writePackage(dir, version)
+  writeLock(dir, version)
+  await mustRun(dir, ['git', 'add', '.'])
+  await mustRun(dir, ['git', 'commit', '-m', `version ${version}`])
+  await mustRun(bareDir, ['git', 'init', '--bare', '--initial-branch=main'])
+  await mustRun(dir, ['git', 'remote', 'add', 'origin', bareDir])
+  await mustRun(dir, ['git', 'push', '-u', 'origin', 'main'])
+  return { dir, bareDir }
+}
+
+function parseOutput(stdout: string): Record<string, string> {
+  return Object.fromEntries(
+    stdout
+      .trim()
+      .split('\n')
+      .filter(Boolean)
+      .filter((line) => !line.startsWith('::'))
+      .map((line) => line.split(/=(.*)/s).slice(0, 2)),
+  )
+}
+
+function outputText(result: { stdout: string; stderr: string }): string {
+  return `${result.stdout}\n${result.stderr}`
+}
+
+async function prepare(
+  dir: string,
+  options: {
+    eventName: 'push' | 'workflow_dispatch'
+    refName?: string
+    requestedVersion?: string
+  },
+) {
+  return run(dir, [
+    prepareExtensionRelease,
+    '--event-name',
+    options.eventName,
+    '--default-branch',
+    'main',
+    '--ref-name',
+    options.refName ?? 'main',
+    '--requested-version',
+    options.requestedVersion ?? '',
+  ])
+}
+
+describe('prepare-extension-release', () => {
+  it('commits a manual version bump and pushes the branch and tag', async () => {
+    const { dir, bareDir } = await initFixture('0.0.100')
+    try {
+      const result = await prepare(dir, {
+        eventName: 'workflow_dispatch',
+        requestedVersion: '0.0.101',
+      })
+
+      expect(result.code, result.stderr || result.stdout).toBe(0)
+      const output = parseOutput(result.stdout)
+      expect(output).toMatchObject({
+        version: '0.0.101',
+        tag: 'agent-extension/v0.0.101',
+        previous_tag: '',
+      })
+      expect(
+        await mustRun(dir, ['git', 'show', `origin/main:${packagePath}`]),
+      ).toContain('"version": "0.0.101"')
+      expect(
+        await mustRun(dir, ['git', 'show', `origin/main:${lockPath}`]),
+      ).toContain('"version": "0.0.101"')
+      expect(
+        (
+          await mustRun(dir, [
+            'git',
+            'cat-file',
+            '-t',
+            'refs/tags/agent-extension/v0.0.101',
+          ])
+        ).trim(),
+      ).toBe('tag')
+      expect(
+        (
+          await mustRun(dir, [
+            'git',
+            'rev-list',
+            '-n',
+            '1',
+            'agent-extension/v0.0.101',
+          ])
+        ).trim(),
+      ).toBe((await mustRun(dir, ['git', 'rev-parse', 'origin/main'])).trim())
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+      rmSync(bareDir, { recursive: true, force: true })
+    }
+  })
+
+  it('creates a manual tag for the current package version without preconfigured identity', async () => {
+    const { dir, bareDir } = await initFixture('0.0.101')
+    try {
+      const releaseSha = (
+        await mustRun(dir, ['git', 'rev-parse', 'HEAD'])
+      ).trim()
+      await mustRun(dir, ['git', 'config', '--unset', 'user.name'])
+      await mustRun(dir, ['git', 'config', '--unset', 'user.email'])
+
+      const result = await prepare(dir, {
+        eventName: 'workflow_dispatch',
+        requestedVersion: '0.0.101',
+      })
+
+      expect(result.code, result.stderr || result.stdout).toBe(0)
+      expect(parseOutput(result.stdout)).toMatchObject({
+        version: '0.0.101',
+        tag: 'agent-extension/v0.0.101',
+        release_sha: releaseSha,
+      })
+      expect(
+        (
+          await mustRun(dir, [
+            'git',
+            'rev-list',
+            '-n',
+            '1',
+            'agent-extension/v0.0.101',
+          ])
+        ).trim(),
+      ).toBe(releaseSha)
+      expect(
+        (await mustRun(dir, ['git', 'rev-parse', 'origin/main'])).trim(),
+      ).toBe(releaseSha)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+      rmSync(bareDir, { recursive: true, force: true })
+    }
+  })
+
+  it('resolves a pushed extension tag and previous release tag', async () => {
+    const { dir, bareDir } = await initFixture('0.0.100')
+    try {
+      await tag(dir, 'agent-extension-v0.0.100')
+      await commitPackage(dir, '0.0.101')
+      await tag(dir, 'agent-extension/v0.0.101')
+      await commitPackage(dir, '0.0.102')
+      await tag(dir, 'agent-extension/v0.0.102')
+      await mustRun(dir, ['git', 'push', 'origin', 'main', '--tags'])
+
+      const result = await prepare(dir, {
+        eventName: 'push',
+        refName: 'agent-extension/v0.0.102',
+      })
+
+      expect(result.code, result.stderr || result.stdout).toBe(0)
+      expect(parseOutput(result.stdout)).toMatchObject({
+        version: '0.0.102',
+        tag: 'agent-extension/v0.0.102',
+        previous_tag: 'agent-extension/v0.0.101',
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+      rmSync(bareDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a pushed tag whose commit is not on the default branch', async () => {
+    const { dir, bareDir } = await initFixture('0.0.100')
+    try {
+      await mustRun(dir, ['git', 'checkout', '-b', 'release-side'])
+      await commitPackage(dir, '0.0.101')
+      await tag(dir, 'agent-extension/v0.0.101')
+      await mustRun(dir, ['git', 'push', 'origin', 'agent-extension/v0.0.101'])
+
+      const result = await prepare(dir, {
+        eventName: 'push',
+        refName: 'agent-extension/v0.0.101',
+      })
+
+      expect(result.code).toBe(1)
+      expect(outputText(result)).toContain('is not reachable from origin/main')
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+      rmSync(bareDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a release version that already exists as a legacy tag', async () => {
+    const { dir, bareDir } = await initFixture('0.0.101')
+    try {
+      await tag(dir, 'agent-extension-v0.0.101')
+      await tag(dir, 'agent-extension/v0.0.101')
+      await mustRun(dir, ['git', 'push', 'origin', 'main', '--tags'])
+
+      const result = await prepare(dir, {
+        eventName: 'push',
+        refName: 'agent-extension/v0.0.101',
+      })
+
+      expect(result.code).toBe(1)
+      expect(outputText(result)).toContain(
+        'Release version 0.0.101 already exists as tag agent-extension-v0.0.101',
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+      rmSync(bareDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a non-incrementing release version', async () => {
+    const { dir, bareDir } = await initFixture('0.0.102')
+    try {
+      await tag(dir, 'agent-extension-v0.0.102')
+      await commitPackage(dir, '0.0.101')
+      await tag(dir, 'agent-extension/v0.0.101')
+      await mustRun(dir, ['git', 'push', 'origin', 'main', '--tags'])
+
+      const result = await prepare(dir, {
+        eventName: 'push',
+        refName: 'agent-extension/v0.0.101',
+      })
+
+      expect(result.code).toBe(1)
+      expect(outputText(result)).toContain(
+        'Release version 0.0.101 must be greater than latest existing extension version 0.0.102',
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+      rmSync(bareDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects manual downgrades below the current package version', async () => {
+    const { dir, bareDir } = await initFixture('0.0.102')
+    try {
+      const result = await prepare(dir, {
+        eventName: 'workflow_dispatch',
+        requestedVersion: '0.0.101',
+      })
+
+      expect(result.code).toBe(1)
+      expect(outputText(result)).toContain(
+        'Requested extension version 0.0.101 is lower than packages/browseros-agent/apps/app/package.json (0.0.102)',
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+      rmSync(bareDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects a pushed tag whose package version does not match', async () => {
+    const { dir, bareDir } = await initFixture('0.0.100')
+    try {
+      await tag(dir, 'agent-extension/v0.0.101')
+      await mustRun(dir, ['git', 'push', 'origin', 'main', '--tags'])
+
+      const result = await prepare(dir, {
+        eventName: 'push',
+        refName: 'agent-extension/v0.0.101',
+      })
+
+      expect(result.code).toBe(1)
+      expect(outputText(result)).toContain(
+        'packages/browseros-agent/apps/app/package.json at agent-extension/v0.0.101 is 0.0.100, expected 0.0.101',
+      )
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+      rmSync(bareDir, { recursive: true, force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary
- switch extension release dispatch from `tag` to `version`, matching the simplified server release flow
- add `prepare-extension-release.sh` so manual dispatch can bump `apps/app`, align `bun.lock`, create the annotated `agent-extension/vX.Y.Z` tag, and push branch+tag atomically
- validate pushed/existing extension tags against package and lockfile versions, default-branch reachability, annotated tags, and legacy `agent-extension-v` duplicates
- keep extension build, zip, upload, changelog, and GitHub Release behavior intact

## Verification
- `bun run check`
- `bun run test`
- `bun test scripts/release/prepare-extension-release.test.ts scripts/release/prepare-server-release.test.ts`
- `actionlint ../../.github/workflows/release-agent-extension.yml`
- `bash -n scripts/release/prepare-extension-release.sh`
- `git diff --check origin/main..HEAD`
