### PR TITLE
fix: make server release tag-driven without pushing to main

### DIFF
--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -123,9 +123,10 @@ jobs:
           pkg.version = version;
           fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
           let lock = fs.readFileSync(lockPath, "utf8");
-          const re = /("apps\/server":\s*\{\s*"name":\s*"@browseros\/server",\s*"version":\s*")(\d+\.\d+\.\d+)(")/;
-          if (!re.test(lock)) {
-            console.error("Expected exactly one apps/server version entry in bun.lock");
+          const re = /("apps\/server":\s*\{\s*"name":\s*"@browseros\/server",\s*"version":\s*")(\d+\.\d+\.\d+)(")/g;
+          const matches = lock.match(re);
+          if (!matches || matches.length !== 1) {
+            console.error("Expected exactly one apps/server version entry in bun.lock, found " + (matches ? matches.length : 0));
             process.exit(1);
           }
           fs.writeFileSync(lockPath, lock.replace(re, (match, prefix, _old, suffix) => prefix + version + suffix));

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -7,12 +7,13 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: "Release version, e.g. 0.0.123"
+        description: "Release version, e.g. 0.0.124"
         required: true
         type: string
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: release-server
@@ -81,3 +82,66 @@ jobs:
               --title "$TITLE" \
               --notes-file /tmp/release-notes.md
           fi
+
+      # Reflect the released version back into the repo through a PR. Repository
+      # rules forbid pushing commits straight to the default branch, so the bump
+      # never touches it directly. This is best-effort (continue-on-error): the
+      # release above is authoritative, and releases are gated by tags, not by
+      # this file, so a failed bump PR must not fail the release.
+      - name: Reflect version on main via PR
+        if: steps.release.outputs.version != ''
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          PACKAGE_JSON="packages/browseros-agent/apps/server/package.json"
+          LOCK="packages/browseros-agent/bun.lock"
+          BRANCH="release/bump-server-v${VERSION}"
+
+          git fetch origin "$DEFAULT_BRANCH" --no-tags
+          git checkout -B "$DEFAULT_BRANCH" "origin/$DEFAULT_BRANCH"
+
+          CURRENT="$(node -e 'const fs = require("fs"); process.stdout.write(JSON.parse(fs.readFileSync(process.argv[1], "utf8")).version)' "$PACKAGE_JSON")"
+          if [ "$CURRENT" = "$VERSION" ]; then
+            echo "$PACKAGE_JSON already at $VERSION; nothing to bump."
+            exit 0
+          fi
+
+          if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
+            echo "Branch $BRANCH already exists; bump PR already open."
+            exit 0
+          fi
+
+          node -e '
+          const fs = require("fs");
+          const [pkgPath, lockPath, version] = process.argv.slice(1);
+          const pkg = JSON.parse(fs.readFileSync(pkgPath, "utf8"));
+          pkg.version = version;
+          fs.writeFileSync(pkgPath, JSON.stringify(pkg, null, 2) + "\n");
+          let lock = fs.readFileSync(lockPath, "utf8");
+          const re = /("apps\/server":\s*\{\s*"name":\s*"@browseros\/server",\s*"version":\s*")(\d+\.\d+\.\d+)(")/;
+          if (!re.test(lock)) {
+            console.error("Expected exactly one apps/server version entry in bun.lock");
+            process.exit(1);
+          }
+          fs.writeFileSync(lockPath, lock.replace(re, (match, prefix, _old, suffix) => prefix + version + suffix));
+          ' "$PACKAGE_JSON" "$LOCK" "$VERSION"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -b "$BRANCH"
+          git add "$PACKAGE_JSON" "$LOCK"
+          git commit -m "chore: bump server version to ${VERSION}"
+          git push origin "$BRANCH"
+
+          gh pr create \
+            --title "chore: bump server version to ${VERSION}" \
+            --body "Automated version bump for BrowserOS Server v${VERSION}, released from tag agent-server/v${VERSION}. The release is already published; merge this to keep apps/server/package.json in sync with the released version." \
+            --base "$DEFAULT_BRANCH" \
+            --head "$BRANCH"
+
+          gh pr merge "$BRANCH" --squash --auto || true

--- a/packages/browseros-agent/scripts/release/prepare-server-release.sh
+++ b/packages/browseros-agent/scripts/release/prepare-server-release.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Prepare a server GitHub Release without building artifacts; release paths are fixed by design.
-SERVER_PACKAGE_JSON="packages/browseros-agent/apps/server/package.json"
-SERVER_LOCK="packages/browseros-agent/bun.lock"
+# Resolve a server GitHub Release. The tag is the source of truth for the version;
+# this script never pushes to the default branch. On manual dispatch it creates and
+# pushes only the annotated tag (allowed under a "changes to main via PR" ruleset);
+# the version is reflected back into package.json by the workflow's bump PR step.
 NEW_PREFIX="agent-server/v"
 
 usage() {
@@ -65,58 +66,6 @@ is_semver() {
   [[ "$1" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]]
 }
 
-read_package_version() {
-  python3 - "$git_root/$SERVER_PACKAGE_JSON" <<'PY'
-import json
-import sys
-from pathlib import Path
-
-print(json.loads(Path(sys.argv[1]).read_text())["version"])
-PY
-}
-
-read_package_version_at_ref() {
-  git show "$1:$SERVER_PACKAGE_JSON" | python3 -c '
-import json
-import sys
-
-print(json.load(sys.stdin)["version"])
-'
-}
-
-compare_versions() {
-  python3 - "$1" "$2" <<'PY'
-import sys
-
-left = tuple(int(part) for part in sys.argv[1].split("."))
-right = tuple(int(part) for part in sys.argv[2].split("."))
-print((left > right) - (left < right))
-PY
-}
-
-update_release_version_files() {
-  python3 - "$git_root/$SERVER_PACKAGE_JSON" "$git_root/$SERVER_LOCK" "$1" <<'PY'
-import json
-import re
-import sys
-from pathlib import Path
-
-path = Path(sys.argv[1])
-lock_path = Path(sys.argv[2])
-version = sys.argv[3]
-data = json.loads(path.read_text())
-data["version"] = version
-path.write_text(json.dumps(data, indent=2) + "\n")
-
-lock_text = lock_path.read_text()
-lock_pattern = re.compile(r'("apps/server":\s*\{\s*"name":\s*"@browseros/server",\s*"version":\s*")(\d+\.\d+\.\d+)(")')
-updated_lock, count = lock_pattern.subn(rf"\g<1>{version}\3", lock_text)
-if count != 1:
-    raise SystemExit("Expected exactly one apps/server version entry in bun.lock")
-lock_path.write_text(updated_lock)
-PY
-}
-
 ensure_git_identity() {
   git config user.name "github-actions[bot]"
   git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
@@ -144,6 +93,8 @@ ensure_default_branch_release() {
   fi
 }
 
+# Resolve the closest earlier server tag across current and legacy prefixes, and
+# reject duplicate or non-incrementing versions. All comparisons are tag-based.
 previous_server_tag() {
   python3 - "$1" "$2" <<'PY'
 import re
@@ -224,6 +175,8 @@ emit() {
 git fetch "$remote" "$default_branch:refs/remotes/$remote/$default_branch" --no-tags
 git fetch "$remote" --tags --prune
 
+previous_tag=""
+
 if [ "$event_name" = "push" ]; then
   tag="$ref_name"
   version="${tag#"$NEW_PREFIX"}"
@@ -235,13 +188,6 @@ if [ "$event_name" = "push" ]; then
 
   require_annotated_tag "$tag"
   release_sha="$(git rev-list -n 1 "$tag")"
-  package_version="$(read_package_version_at_ref "$release_sha")"
-
-  if [ "$package_version" != "$version" ]; then
-    echo "::error::$SERVER_PACKAGE_JSON at $tag is $package_version, expected $version. Bump package.json before tagging."
-    exit 1
-  fi
-
   ensure_default_branch_release "$release_sha"
   resolve_previous_tag
 else
@@ -253,37 +199,16 @@ else
 
   tag="${NEW_PREFIX}${version}"
   resolve_previous_tag
+
   if git rev-parse --verify --quiet "refs/tags/$tag" >/dev/null; then
     require_annotated_tag "$tag"
     release_sha="$(git rev-list -n 1 "$tag")"
-    package_version="$(read_package_version_at_ref "$release_sha")"
-
-    if [ "$package_version" != "$version" ]; then
-      echo "::error::$SERVER_PACKAGE_JSON at $tag is $package_version, expected $version."
-      exit 1
-    fi
     ensure_default_branch_release "$release_sha"
   else
-    git checkout -B "$default_branch" "$remote/$default_branch"
-    current_version="$(read_package_version)"
-
-    if [ "$(compare_versions "$version" "$current_version")" = "-1" ]; then
-      echo "::error::Requested server version $version is lower than $SERVER_PACKAGE_JSON ($current_version)."
-      exit 1
-    fi
-
+    release_sha="$(git rev-parse "$remote/$default_branch")"
     ensure_git_identity
-
-    if [ "$current_version" != "$version" ]; then
-      update_release_version_files "$version"
-      git add "$SERVER_PACKAGE_JSON" "$SERVER_LOCK"
-      git commit -m "chore: bump server version to $version"
-    fi
-
-    release_sha="$(git rev-parse HEAD)"
     git tag -a "$tag" -m "BrowserOS Server - v$version" "$release_sha"
-    git push --atomic "$remote" "HEAD:refs/heads/$default_branch" "refs/tags/$tag"
-    package_version="$version"
+    git push "$remote" "refs/tags/$tag"
   fi
 fi
 
@@ -298,7 +223,6 @@ Server release:
 - Version: $version
 - Tag: $tag
 - Release commit: $release_sha
-- Package path: $SERVER_PACKAGE_JSON
 - Assets: GitHub source archives only
 EOF
 fi

--- a/packages/browseros-agent/scripts/release/prepare-server-release.test.ts
+++ b/packages/browseros-agent/scripts/release/prepare-server-release.test.ts
@@ -72,6 +72,10 @@ async function tag(dir: string, name: string): Promise<void> {
   await mustRun(dir, ['git', 'tag', '-a', name, '-m', name])
 }
 
+async function revParse(dir: string, ref: string): Promise<string> {
+  return (await mustRun(dir, ['git', 'rev-parse', ref])).trim()
+}
+
 async function initFixture(version: string): Promise<{
   dir: string
   bareDir: string
@@ -128,88 +132,102 @@ async function prepare(
 }
 
 describe('prepare-server-release', () => {
-  it('commits a manual version bump and pushes the branch and tag', async () => {
+  it('pushes only the tag on manual dispatch and leaves the default branch untouched', async () => {
     const { dir, bareDir } = await initFixture('0.0.122')
     try {
+      const mainBefore = await revParse(bareDir, 'refs/heads/main')
+
       const result = await prepare(dir, {
         eventName: 'workflow_dispatch',
-        requestedVersion: '0.0.123',
+        requestedVersion: '0.0.124',
       })
 
       expect(result.code, result.stderr || result.stdout).toBe(0)
-      const output = parseOutput(result.stdout)
-      expect(output).toMatchObject({
-        version: '0.0.123',
-        tag: 'agent-server/v0.0.123',
+      expect(parseOutput(result.stdout)).toMatchObject({
+        version: '0.0.124',
+        tag: 'agent-server/v0.0.124',
+        release_sha: mainBefore,
         previous_tag: '',
       })
+
+      // The default branch must be identical — no bump commit, no branch push.
+      expect(await revParse(bareDir, 'refs/heads/main')).toBe(mainBefore)
       expect(
-        await mustRun(dir, ['git', 'show', `origin/main:${packagePath}`]),
-      ).toContain('"version": "0.0.123"')
-      expect(
-        await mustRun(dir, ['git', 'show', `origin/main:${lockPath}`]),
-      ).toContain('"version": "0.0.123"')
+        await mustRun(bareDir, [
+          'git',
+          'show',
+          `refs/heads/main:${packagePath}`,
+        ]),
+      ).toContain('"version": "0.0.122"')
+
+      // Only the annotated tag was published, pointing at the default-branch head.
       expect(
         (
-          await mustRun(dir, [
+          await mustRun(bareDir, [
             'git',
             'cat-file',
             '-t',
-            'refs/tags/agent-server/v0.0.123',
+            'refs/tags/agent-server/v0.0.124',
           ])
         ).trim(),
       ).toBe('tag')
-      expect(
-        (
-          await mustRun(dir, [
-            'git',
-            'rev-list',
-            '-n',
-            '1',
-            'agent-server/v0.0.123',
-          ])
-        ).trim(),
-      ).toBe((await mustRun(dir, ['git', 'rev-parse', 'origin/main'])).trim())
+      expect(await revParse(bareDir, 'agent-server/v0.0.124^{commit}')).toBe(
+        mainBefore,
+      )
     } finally {
       rmSync(dir, { recursive: true, force: true })
       rmSync(bareDir, { recursive: true, force: true })
     }
   })
 
-  it('creates a manual tag for the current package version without preconfigured identity', async () => {
+  it('creates the release tag without a preconfigured git identity', async () => {
     const { dir, bareDir } = await initFixture('0.0.123')
     try {
-      const releaseSha = (
-        await mustRun(dir, ['git', 'rev-parse', 'HEAD'])
-      ).trim()
+      const releaseSha = await revParse(dir, 'HEAD')
       await mustRun(dir, ['git', 'config', '--unset', 'user.name'])
       await mustRun(dir, ['git', 'config', '--unset', 'user.email'])
 
       const result = await prepare(dir, {
         eventName: 'workflow_dispatch',
-        requestedVersion: '0.0.123',
+        requestedVersion: '0.0.124',
       })
 
       expect(result.code, result.stderr || result.stdout).toBe(0)
       expect(parseOutput(result.stdout)).toMatchObject({
-        version: '0.0.123',
-        tag: 'agent-server/v0.0.123',
+        version: '0.0.124',
+        tag: 'agent-server/v0.0.124',
         release_sha: releaseSha,
       })
-      expect(
-        (
-          await mustRun(dir, [
-            'git',
-            'rev-list',
-            '-n',
-            '1',
-            'agent-server/v0.0.123',
-          ])
-        ).trim(),
-      ).toBe(releaseSha)
-      expect(
-        (await mustRun(dir, ['git', 'rev-parse', 'origin/main'])).trim(),
-      ).toBe(releaseSha)
+      expect(await revParse(bareDir, 'agent-server/v0.0.124^{commit}')).toBe(
+        releaseSha,
+      )
+      expect(await revParse(bareDir, 'refs/heads/main')).toBe(releaseSha)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+      rmSync(bareDir, { recursive: true, force: true })
+    }
+  })
+
+  it('re-resolves an already published release tag without recreating it', async () => {
+    const { dir, bareDir } = await initFixture('0.0.123')
+    try {
+      const releaseSha = await revParse(dir, 'HEAD')
+      await tag(dir, 'agent-server/v0.0.124')
+      await mustRun(dir, ['git', 'push', 'origin', 'agent-server/v0.0.124'])
+
+      const result = await prepare(dir, {
+        eventName: 'workflow_dispatch',
+        requestedVersion: '0.0.124',
+      })
+
+      expect(result.code, result.stderr || result.stdout).toBe(0)
+      expect(parseOutput(result.stdout)).toMatchObject({
+        version: '0.0.124',
+        tag: 'agent-server/v0.0.124',
+        release_sha: releaseSha,
+        previous_tag: '',
+      })
+      expect(await revParse(bareDir, 'refs/heads/main')).toBe(releaseSha)
     } finally {
       rmSync(dir, { recursive: true, force: true })
       rmSync(bareDir, { recursive: true, force: true })
@@ -234,6 +252,28 @@ describe('prepare-server-release', () => {
         version: '0.0.123',
         tag: 'agent-server/v0.0.123',
         previous_tag: 'agent-server/v0.0.122',
+      })
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+      rmSync(bareDir, { recursive: true, force: true })
+    }
+  })
+
+  it('resolves a pushed tag even when package.json does not match the version', async () => {
+    const { dir, bareDir } = await initFixture('0.0.122')
+    try {
+      await tag(dir, 'agent-server/v0.0.123')
+      await mustRun(dir, ['git', 'push', 'origin', 'main', '--tags'])
+
+      const result = await prepare(dir, {
+        eventName: 'push',
+        refName: 'agent-server/v0.0.123',
+      })
+
+      expect(result.code, result.stderr || result.stdout).toBe(0)
+      expect(parseOutput(result.stdout)).toMatchObject({
+        version: '0.0.123',
+        tag: 'agent-server/v0.0.123',
       })
     } finally {
       rmSync(dir, { recursive: true, force: true })
@@ -284,9 +324,12 @@ describe('prepare-server-release', () => {
     }
   })
 
-  it('rejects manual downgrades below the current package version', async () => {
-    const { dir, bareDir } = await initFixture('0.0.124')
+  it('rejects a manual dispatch that does not increment past the latest tag', async () => {
+    const { dir, bareDir } = await initFixture('0.0.123')
     try {
+      await tag(dir, 'agent-server/v0.0.124')
+      await mustRun(dir, ['git', 'push', 'origin', 'main', '--tags'])
+
       const result = await prepare(dir, {
         eventName: 'workflow_dispatch',
         requestedVersion: '0.0.123',
@@ -294,28 +337,7 @@ describe('prepare-server-release', () => {
 
       expect(result.code).toBe(1)
       expect(outputText(result)).toContain(
-        'Requested server version 0.0.123 is lower than packages/browseros-agent/apps/server/package.json (0.0.124)',
-      )
-    } finally {
-      rmSync(dir, { recursive: true, force: true })
-      rmSync(bareDir, { recursive: true, force: true })
-    }
-  })
-
-  it('rejects a pushed tag whose package version does not match', async () => {
-    const { dir, bareDir } = await initFixture('0.0.122')
-    try {
-      await tag(dir, 'agent-server/v0.0.123')
-      await mustRun(dir, ['git', 'push', 'origin', 'main', '--tags'])
-
-      const result = await prepare(dir, {
-        eventName: 'push',
-        refName: 'agent-server/v0.0.123',
-      })
-
-      expect(result.code).toBe(1)
-      expect(outputText(result)).toContain(
-        'packages/browseros-agent/apps/server/package.json at agent-server/v0.0.123 is 0.0.122, expected 0.0.123',
+        'Release version 0.0.123 must be greater than latest existing server version 0.0.124 (agent-server/v0.0.124)',
       )
     } finally {
       rmSync(dir, { recursive: true, force: true })


### PR DESCRIPTION
## What & why

Server releases kept failing with **GH013** (`Repository rule violations … changes must be made through a pull request`). The manual-dispatch path in `prepare-server-release.sh` committed a version bump and pushed it straight to `refs/heads/main`:

```
git commit -m "chore: bump server version to $version"
git push --atomic origin HEAD:refs/heads/main refs/tags/$tag
```

The branch push is rejected by the ruleset, and the atomic tag push dies with it (`atomic transaction failed`). No amount of retrying fixes this — a release workflow simply must not push commits to protected `main`.

This realigns the server release with the **tag-driven pattern the repo already uses** for `release-cli` and `release-agent-extension` (the latter already writes back to `main` *via a PR*, never a direct push). Researched against the recommended OSS approach (release-please / semantic-release): the tag is the source of truth, and any write-back to a protected branch goes through a PR.

## Changes

- **`prepare-server-release.sh` → pure resolver.** The tag is the source of truth for the version; it **never** pushes to the default branch. On `workflow_dispatch` it creates and pushes **only the annotated tag** at `origin/main` HEAD (tag refs aren't governed by the "PR required" branch rule), then the release runs inline. Dropped the version-bump commit, the `--atomic` branch push, and the `package.json == tag` precondition. Validation stays tag-based: annotated, reachable from `main`, strictly incrementing, no duplicate (incl. legacy `browseros-server-v*`).
- **`release-server.yml`** gains a `Reflect version on main via PR` step that bumps `apps/server/package.json` + `bun.lock` to the released version **through an auto-opened PR** (mirrors the extension release's changelog PR). It's `continue-on-error: true` — releases are gated by tags, not by this file, so a flaky bump PR can never fail a release. Added `pull-requests: write`.
- **`prepare-server-release.test.ts`** rewritten to the new contract: dispatch pushes only the tag and leaves `main` untouched; push resolves even when `package.json` doesn't match; validation still rejects side-branch tags, duplicates, and non-incrementing versions.

## Maintainer flow (what you wanted)

Either:
```bash
git tag -a agent-server/v0.0.124 -m "BrowserOS Server v0.0.124"
git push origin agent-server/v0.0.124
```
…or click **Run workflow** and type `0.0.124`. Both cut the release at that version and open a PR to bump `package.json`. No direct pushes to `main`, no ruleset fights.

## Verification

- `bun run check` (lint + typecheck + fallow) → green
- `bun test scripts/` → 51 pass (release resolver contract fully covered)
- `actionlint .github/workflows/release-server.yml` → clean
- `shellcheck prepare-server-release.sh` → clean
- Confirmed no `HEAD:refs/heads/*` / `--atomic` branch push remains in the server release path

## Notes

- No new secrets, no GitHub App, no ruleset bypass, no force-push.
- Known + accepted (same as the extension release): a `GITHUB_TOKEN`-created PR doesn't fire required checks, so the bump PR's auto-merge may wait for a human. The bump is cosmetic (releases are tag-gated), so that's fine.
