### PR TITLE
chore: bump server version to 0.0.124

### DIFF
--- a/packages/browseros-agent/apps/server/package.json
+++ b/packages/browseros-agent/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@browseros/server",
-  "version": "0.0.123",
+  "version": "0.0.124",
   "description": "BrowserOS server",
   "type": "module",
   "main": "./src/index.ts",

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -247,7 +247,7 @@
     },
     "apps/server": {
       "name": "@browseros/server",
-      "version": "0.0.123",
+      "version": "0.0.124",
       "bin": {
         "browseros-server": "./src/index.ts",
       },


### PR DESCRIPTION
Reflect BrowserOS Server v0.0.124 after the tag-driven release was published from agent-server/v0.0.124.\n\nRelease: https://github.com/browseros-ai/BrowserOS/releases/tag/agent-server/v0.0.124\nRun: https://github.com/browseros-ai/BrowserOS/actions/runs/28486382572