### PR TITLE
fix: avoid server release bump branch conflict

### DIFF
--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -83,14 +83,11 @@ jobs:
               --notes-file /tmp/release-notes.md
           fi
 
-      # Reflect the released version back into the repo through a PR. Repository
-      # rules forbid pushing commits straight to the default branch, so the bump
-      # never touches it directly. This is best-effort (continue-on-error): the
-      # release above is authoritative, and releases are gated by tags, not by
-      # this file, so a failed bump PR must not fail the release.
+      # Reflect the released version back into the repo through a PR. The release
+      # above is authoritative, but a failed reflection should leave a visible
+      # red run and summary instead of looking like a successful sync.
       - name: Reflect version on main via PR
         if: steps.release.outputs.version != ''
-        continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch || 'main' }}
@@ -100,7 +97,36 @@ jobs:
 
           PACKAGE_JSON="packages/browseros-agent/apps/server/package.json"
           LOCK="packages/browseros-agent/bun.lock"
-          BRANCH="release/bump-server-v${VERSION}"
+          BRANCH="chore-bump-server-v${VERSION}"
+
+          # Summarizes post-release sync failures without implying the release was rolled back.
+          write_reflection_failure_summary() {
+            local status="$1"
+            [ "$status" -ne 0 ] || return 0
+
+            echo "::error::Server version reflection failed after release publication; agent-server/v${VERSION} remains published."
+            if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+              {
+                echo "### Server version reflection failed"
+                echo
+                echo "The BrowserOS Server release for \`agent-server/v${VERSION}\` was already published."
+                echo "The follow-up version bump PR failed while using branch \`${BRANCH}\`."
+                echo
+                echo "Rerun the workflow or create the bump PR manually to sync \`${PACKAGE_JSON}\` and \`${LOCK}\`."
+              } >> "$GITHUB_STEP_SUMMARY" || true
+            fi
+          }
+          trap 'status=$?; write_reflection_failure_summary "$status"; exit "$status"' EXIT
+
+          create_reflection_pr() {
+            gh pr create \
+              --title "chore: bump server version to ${VERSION}" \
+              --body "Automated version bump for BrowserOS Server v${VERSION}, released from tag agent-server/v${VERSION}. The release is already published; merge this to keep apps/server/package.json in sync with the released version." \
+              --base "$DEFAULT_BRANCH" \
+              --head "$BRANCH"
+
+            gh pr merge "$BRANCH" --squash --auto || true
+          }
 
           git fetch origin "$DEFAULT_BRANCH" --no-tags
           git checkout -B "$DEFAULT_BRANCH" "origin/$DEFAULT_BRANCH"
@@ -112,7 +138,15 @@ jobs:
           fi
 
           if git ls-remote --exit-code --heads origin "$BRANCH" >/dev/null 2>&1; then
-            echo "Branch $BRANCH already exists; bump PR already open."
+            EXISTING_PR="$(gh pr list --state open --head "$BRANCH" --json number --jq '.[0].number // ""')"
+            if [ -n "$EXISTING_PR" ]; then
+              echo "Branch $BRANCH already has open bump PR #$EXISTING_PR."
+              gh pr merge "$BRANCH" --squash --auto || true
+              exit 0
+            fi
+
+            echo "Branch $BRANCH already exists without an open bump PR; creating it."
+            create_reflection_pr
             exit 0
           fi
 
@@ -139,10 +173,4 @@ jobs:
           git commit -m "chore: bump server version to ${VERSION}"
           git push origin "$BRANCH"
 
-          gh pr create \
-            --title "chore: bump server version to ${VERSION}" \
-            --body "Automated version bump for BrowserOS Server v${VERSION}, released from tag agent-server/v${VERSION}. The release is already published; merge this to keep apps/server/package.json in sync with the released version." \
-            --base "$DEFAULT_BRANCH" \
-            --head "$BRANCH"
-
-          gh pr merge "$BRANCH" --squash --auto || true
+          create_reflection_pr

--- a/packages/browseros-agent/scripts/release/release-server-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-server-workflow.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'bun:test'
+import { readFileSync } from 'node:fs'
+import { resolve } from 'node:path'
+
+const repoRoot = resolve(import.meta.dir, '../../../..')
+const workflow = readFileSync(
+  resolve(repoRoot, '.github/workflows/release-server.yml'),
+  'utf8',
+)
+const shellVersionPlaceholder = '$' + '{VERSION}'
+const expectedBumpBranch = `chore-bump-server-v${shellVersionPlaceholder}`
+
+function reflectVersionStep(): string {
+  const start = workflow.indexOf('- name: Reflect version on main via PR')
+  expect(start).toBeGreaterThanOrEqual(0)
+  return workflow.slice(start)
+}
+
+describe('release-server workflow', () => {
+  it('uses a flat branch for post-release version bump PRs', () => {
+    const step = reflectVersionStep()
+    const branch = step.match(/^\s*BRANCH="([^"]+)"$/m)?.[1]
+
+    expect(branch).toBe(expectedBumpBranch)
+    expect(branch?.startsWith('release/')).toBe(false)
+  })
+
+  it('fails visibly when post-release version reflection fails', () => {
+    const step = reflectVersionStep()
+
+    expect(step).not.toContain('continue-on-error: true')
+    expect(step).toContain('GITHUB_STEP_SUMMARY')
+    expect(step).toContain('::error::')
+  })
+
+  it('creates a missing PR when the remote bump branch already exists', () => {
+    const step = reflectVersionStep()
+
+    expect(step).toContain('gh pr list --state open --head "$BRANCH"')
+    expect(step).toContain(
+      'Branch $BRANCH already exists without an open bump PR; creating it.',
+    )
+    expect(step).toContain('create_reflection_pr')
+  })
+})


### PR DESCRIPTION
## Summary
- switch the server release reflection PR branch from `release/bump-server-v${VERSION}` to the flat `chore-bump-server-v${VERSION}` ref
- remove `continue-on-error` from the reflection step so post-release sync failures make the workflow red while the tag release remains authoritative
- recover reruns where the bump branch already exists but the PR was never created

## Design
The release publication path stays unchanged. Only the post-release reflection step now uses a flat branch name, writes a GitHub error/step summary on failure, and verifies an open PR exists before treating an existing remote branch as complete.

## Test plan
- [x] `bun test scripts/release/release-server-workflow.test.ts`
- [x] `bun run ./scripts/run-bun-test.ts ./scripts/release`
- [x] `actionlint ../../.github/workflows/release-server.yml`
- [x] `git diff --check`
- [x] `bun run check`
- [x] `bun run test`

## Review
- Local adversarial review round 1 found the branch-exists-without-PR rerun gap; fixed.
- Local adversarial review round 2 was clean.