### PR TITLE
chore(ci): pin @ricky0123/vad-web out of Dependabot's routine queue

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,12 @@ updates:
       - dependency-name: "*"
         update-types:
           - "version-update:semver-major"
+      # @ricky0123/vad-web is pre-1.0 and treats every patch as a
+      # breaking API change (0.0.17 → 0.0.30 rewrote MicVAD.new's
+      # stream option into a getStream/pauseStream/resumeStream
+      # callback trio). Pin it here so it's opt-in only; a real
+      # upgrade needs a hand migration of `modules/voice/vad.silero.ts`.
+      - dependency-name: "@ricky0123/vad-web"
     groups:
       minor-and-patch:
         update-types:


### PR DESCRIPTION
The v0.0.17 → v0.0.30 bump inside the current grouped PR #1460 rewrote `MicVAD.new`'s `stream: MediaStream` option into a `getStream` / `pauseStream` / `resumeStream` callback trio, which broke typecheck at `modules/voice/vad.silero.ts:40`. Because the package is pre-1.0, semver treats that as a patch — so the existing "ignore majors" rule doesn't catch it.

Adding `@ricky0123/vad-web` to the ecosystem's `ignore` list pins it until we're ready to migrate the caller. After this merges, closing #1460 lets Dependabot regenerate the group without the vad-web bump — the remaining 29 updates typecheck cleanly.