### PR TITLE
feat(claw-server): auto-persist a screencast frame per state-mutating dispatch

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/audit/Timeline.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/Timeline.test.tsx
@@ -30,10 +30,14 @@ function dispatch(overrides: Partial<ToolDispatchRow> = {}): ToolDispatchRow {
 
 const startedAt = 1_000_000
 
-function render(dispatches: ToolDispatchRow[]): string {
+function render(
+  dispatches: ToolDispatchRow[],
+  screenshotDispatchIds: readonly number[] = [],
+): string {
   return renderToStaticMarkup(
     <Timeline
       dispatches={dispatches}
+      screenshotDispatchIds={screenshotDispatchIds}
       startedAt={startedAt}
       endEvent={null}
       onScreenshotClick={() => undefined}

--- a/packages/browseros-agent/apps/claw-app/components/audit/Timeline.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/Timeline.tsx
@@ -19,6 +19,16 @@ import { parseResultMeta } from '@/screens/audit/audit.helpers'
 
 interface TimelineProps {
   dispatches: ToolDispatchRow[]
+  /**
+   * Dispatch ids whose screenshot file is confirmed to exist on
+   * disk (from `TaskDetail.screenshotDispatchIds`). Used to decide
+   * which rows show the screenshot preview block. Predates PR #1488:
+   * previously the row derived this from `toolName === 'screenshot'`
+   * but the screencast fallback and first-capture policy now write
+   * screenshots for many non-screenshot-tool dispatches, so the
+   * server-side disk-existence list is authoritative.
+   */
+  screenshotDispatchIds: readonly number[]
   startedAt: number
   endEvent: {
     createdAt: number
@@ -40,10 +50,12 @@ function defaultExpandedSet(dispatches: ToolDispatchRow[]): Set<number> {
 
 export function Timeline({
   dispatches,
+  screenshotDispatchIds,
   startedAt,
   endEvent,
   onScreenshotClick,
 }: TimelineProps) {
+  const screenshotIdSet = new Set(screenshotDispatchIds)
   // Initial state: HIGH RISK rows pre-expanded. Lazy init so the
   // dispatch list is only walked once per mount; future polling
   // updates do not reset the user's manual toggles.
@@ -106,6 +118,7 @@ export function Timeline({
             dispatch={d}
             offsetMs={Math.max(0, d.createdAt - startedAt)}
             expanded={expanded.has(d.id)}
+            hasScreenshot={screenshotIdSet.has(d.id)}
             onToggle={() => toggle(d.id)}
             onScreenshotClick={onScreenshotClick}
           />
@@ -120,6 +133,14 @@ interface TimelineRowProps {
   dispatch: ToolDispatchRow
   offsetMs: number
   expanded: boolean
+  /**
+   * Whether this dispatch has a screenshot file on disk (per the
+   * server's authoritative `screenshotDispatchIds` list). True for
+   * both explicit-screenshot-tool calls AND the many non-screenshot
+   * dispatches (navigate / act / tabs new / first read / ...) that
+   * the screencast fallback + first-capture policy now capture.
+   */
+  hasScreenshot: boolean
   onToggle: () => void
   onScreenshotClick: (dispatchId: number) => void
 }
@@ -128,13 +149,14 @@ function TimelineRow({
   dispatch,
   offsetMs,
   expanded,
+  hasScreenshot,
   onToggle,
   onScreenshotClick,
 }: TimelineRowProps) {
   const highRisk = HIGH_RISK_TOOLS.has(dispatch.toolName)
   const meta = parseResultMeta(dispatch.resultMeta)
   const isError = meta?.isError ?? false
-  const isScreenshot = dispatch.toolName === 'screenshot' && !isError
+  const isScreenshot = hasScreenshot && !isError
   return (
     <li
       className={cn(

--- a/packages/browseros-agent/apps/claw-app/screens/task-detail/TaskDetailPage.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/task-detail/TaskDetailPage.tsx
@@ -60,6 +60,7 @@ export function TaskDetailPage() {
       />
       <Timeline
         dispatches={task.dispatches}
+        screenshotDispatchIds={task.screenshotDispatchIds}
         startedAt={task.startedAt}
         endEvent={task.endEvent}
         onScreenshotClick={setLightboxId}

--- a/packages/browseros-agent/apps/claw-server/src/env.ts
+++ b/packages/browseros-agent/apps/claw-server/src/env.ts
@@ -50,6 +50,19 @@ function readPositiveIntFlag(name: string, fallback: number): number {
 }
 
 /**
+ * Opt-out gate for features that should be ON by default. Only `0`
+ * and `false` (case-insensitive) disable; everything else including
+ * an unset env keeps the feature on.
+ */
+function readBoolFlagDefaultTrue(name: string): boolean {
+  // biome-ignore lint/style/noProcessEnv: env.ts is the sanctioned env-reader for the package
+  const raw = process.env[name]
+  if (raw === undefined) return true
+  const normalised = raw.trim().toLowerCase()
+  return normalised !== '0' && normalised !== 'false'
+}
+
+/**
  * Runtime snapshot shared across services. main.ts applies validated
  * startup config before serving; tests may mutate fields for isolation.
  */
@@ -68,6 +81,15 @@ export const env = {
   sessionSweepIntervalMs: readPositiveIntFlag(
     'CLAW_SESSION_SWEEP_INTERVAL_MS',
     60 * 1000,
+  ),
+  // Audit screenshot fallback. When on (default), a successful
+  // state-mutating page-targeted dispatch that did not carry image
+  // bytes in its result grabs the current screencast cache frame for
+  // the tab and persists it as the dispatch's screenshot. Set to
+  // `0`/`false` to revert to the strict behaviour where only the
+  // explicit `screenshot` tool populates the audit's image column.
+  screencastScreenshotFallback: readBoolFlagDefaultTrue(
+    'CLAW_SCREENCAST_SCREENSHOT_FALLBACK',
   ),
 }
 

--- a/packages/browseros-agent/apps/claw-server/src/lib/agent-tabs/agent-tabs.ts
+++ b/packages/browseros-agent/apps/claw-server/src/lib/agent-tabs/agent-tabs.ts
@@ -32,6 +32,23 @@ export interface AgentTabsRegistry {
    * starts empty.
    */
   forgetAgent(agentId: string): void
+  /**
+   * First-capture policy for the audit screenshot fallback. Returns
+   * true iff this agent has already had a screenshot written for
+   * this pageId within the current session. `services/screenshots.ts`
+   * uses this to give every tab exactly one visual anchor even when
+   * every dispatch is a read-only tool: the first successful
+   * dispatch on a tab writes; subsequent read-only dispatches on
+   * the same tab skip. Different agents on the same pageId are
+   * tracked independently; each gets its own first-capture write.
+   */
+  hasFirstCapture(agentId: string, pageId: number): boolean
+  /**
+   * Records that a screenshot was written for this (agent, page)
+   * pair. Called from `persistScreenshot` after a successful write
+   * (both tool-result and cache-fallback branches).
+   */
+  markFirstCaptureDone(agentId: string, pageId: number): void
   // Test-only escape hatches.
   size(): number
   clear(): void
@@ -41,6 +58,7 @@ const EMPTY: ReadonlySet<number> = new Set<number>()
 
 export function createAgentTabsRegistry(): AgentTabsRegistry {
   const records = new Map<string, Set<number>>()
+  const firstCaptures = new Map<string, Set<number>>()
   return {
     markOpened(agentId, pageId) {
       let set = records.get(agentId)
@@ -61,12 +79,25 @@ export function createAgentTabsRegistry(): AgentTabsRegistry {
     },
     forgetAgent(agentId) {
       records.delete(agentId)
+      firstCaptures.delete(agentId)
+    },
+    hasFirstCapture(agentId, pageId) {
+      return firstCaptures.get(agentId)?.has(pageId) ?? false
+    },
+    markFirstCaptureDone(agentId, pageId) {
+      let set = firstCaptures.get(agentId)
+      if (!set) {
+        set = new Set()
+        firstCaptures.set(agentId, set)
+      }
+      set.add(pageId)
     },
     size() {
       return records.size
     },
     clear() {
       records.clear()
+      firstCaptures.clear()
     },
   }
 }

--- a/packages/browseros-agent/apps/claw-server/src/mcp/register.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/register.ts
@@ -597,6 +597,10 @@ export function registerBrowserToolsForSingleServer(
               persistScreenshot({
                 dispatchId,
                 toolName: tool.name,
+                // Passed through so the screencast fallback branch
+                // can look up the current cache frame for this tab
+                // when the tool result carried no image bytes.
+                pageId,
                 result: {
                   isError: result.isError ?? false,
                   content: result.content,

--- a/packages/browseros-agent/apps/claw-server/src/mcp/register.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/register.ts
@@ -594,13 +594,27 @@ export function registerBrowserToolsForSingleServer(
               },
             })
             if (dispatchId !== null) {
+              // `tabs new` is the one page-targeted tool whose page
+              // id is only born in the RESULT (not in args). Prefer
+              // the result-derived value so the screencast fallback
+              // + first-capture policy see the right pageId.
+              let screenshotPageId: number | null = pageId
+              if (tool.name === 'tabs') {
+                const args = rawArgs as { action?: string } | null | undefined
+                if (args?.action === 'new') {
+                  const resultPageId = (
+                    result.structuredContent as { page?: number } | undefined
+                  )?.page
+                  if (typeof resultPageId === 'number') {
+                    screenshotPageId = resultPageId
+                  }
+                }
+              }
               persistScreenshot({
                 dispatchId,
                 toolName: tool.name,
-                // Passed through so the screencast fallback branch
-                // can look up the current cache frame for this tab
-                // when the tool result carried no image bytes.
-                pageId,
+                pageId: screenshotPageId,
+                agentId,
                 result: {
                   isError: result.isError ?? false,
                   content: result.content,

--- a/packages/browseros-agent/apps/claw-server/src/services/screencast-cache.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/screencast-cache.ts
@@ -15,12 +15,17 @@
  * `lastFailureAt` (the agent did something new since we last failed),
  * or when a successful capture writes a frame and clears the counter.
  *
- * Poller frames stay ephemeral by design: they are never persisted
- * to the audit log nor to disk. The audit-log narrative reflects what
- * the agent chose to capture, not what the cockpit polled in the
- * background. The same precedent `tab-group-ops.ts` set for
- * cockpit-driven `executeTool` calls bypassing the audit hook applies
- * here.
+ * The cache itself stays ephemeral: entries live in memory, evict
+ * on LRU, and are never mirrored to disk. `services/screenshots.ts`
+ * DOES take a single snapshot from the cache at dispatch complete
+ * time for state-mutating page-targeted dispatches (fills in the
+ * audit's screenshot column when the tool result did not carry
+ * image bytes), gated by `env.screencastScreenshotFallback`. That
+ * snapshot is per-dispatch and one-shot; the cache is not otherwise
+ * observed by the audit layer, and the "cockpit-driven executeTool
+ * bypasses the audit hook" precedent (see `tab-group-ops.ts`) is
+ * preserved: the narrative is still agent-driven, the image is
+ * decoration attached to that narrative.
  */
 
 import { logger } from '../lib/logger'

--- a/packages/browseros-agent/apps/claw-server/src/services/screenshots.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/screenshots.ts
@@ -24,8 +24,14 @@
  *      would otherwise render as image-less rows.
  *
  * Read-only page-targeted tools (`snapshot`, `read`, `grep`, `diff`,
- * `wait`) are excluded from the fallback: back-to-back reads would
- * produce visually identical frames.
+ * `wait`) are normally excluded from the fallback: back-to-back reads
+ * would produce visually identical frames. EXCEPTION: the FIRST
+ * successful dispatch on a given (agentId, pageId) pair within the
+ * session writes even if the tool is read-only. This guarantees at
+ * least one visual anchor per tab for audits that consist entirely
+ * of reads (a common codex research pattern). Tracked by
+ * `agentTabs.hasFirstCapture` / `markFirstCaptureDone`; the ledger
+ * is dropped on session end via `cleanupSessionState`.
  *
  * The screencast cache remains ephemeral. The persistence here is a
  * single snapshot AT dispatch complete time, not a continuous
@@ -36,6 +42,7 @@ import { mkdirSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
 import { env } from '../env'
+import { agentTabs } from '../lib/agent-tabs'
 import { resolveClawServerPath } from '../lib/browseros-dir'
 import { logger } from '../lib/logger'
 import { screencastCache } from './screencast-cache'
@@ -49,13 +56,21 @@ export interface PersistScreenshotInput {
   dispatchId: number
   toolName: string
   /**
-   * Page id for the dispatch, resolved via `extractPageId` at the
-   * call site. Null when the tool does not target a specific page
-   * (`tab_groups`, `windows`, `run`) OR when the dispatch is a
-   * `tabs new` whose page id is only born in the result. The
-   * fallback path skips when this is null.
+   * Page id for the dispatch. For most tools this is the args-derived
+   * value from `extractPageId`. For `tabs new` the caller derives it
+   * from `result.structuredContent.page` (only place the id exists).
+   * Null when the tool does not target a specific page (`tab_groups`,
+   * `windows`, `run`); the fallback path skips when this is null.
    */
   pageId: number | null
+  /**
+   * Agent id resolved from the MCP client identity. Needed for the
+   * first-capture-per-page policy so we can track per-agent-per-page
+   * whether the audit already has a visual anchor for this tab.
+   * Null when identity resolution failed; the first-capture override
+   * cannot fire without an agentId (falls back to strict deny-list).
+   */
+  agentId: string | null
   result: {
     isError: boolean
     content?: unknown
@@ -65,12 +80,11 @@ export interface PersistScreenshotInput {
 
 /**
  * Tools that read from the current page state without mutating it.
- * Excluded from the screencast fallback: back-to-back reads produce
- * visually identical frames, so writing one per dispatch is pure
- * waste. Tools NOT in this set that ARE page-targeted (act, navigate,
- * tabs, evaluate, download, pdf, upload, screenshot) get the
- * fallback because they either change page state or the operator
- * wants a visual around the time they fired.
+ * Excluded from the screencast fallback by default: back-to-back reads
+ * produce visually identical frames, so writing one per dispatch is
+ * pure waste. Overridden by the first-capture policy so the FIRST
+ * read-only dispatch on a given tab still fires (see the docstring
+ * at the top of this file).
  */
 const READ_ONLY_TOOLS: ReadonlySet<string> = new Set([
   'snapshot',
@@ -89,15 +103,26 @@ export function persistScreenshot(input: PersistScreenshotInput): void {
   const toolBytes = extractImageBytes(input.result)
   if (toolBytes) {
     writeBytesToDisk(input.dispatchId, toolBytes)
+    if (input.agentId !== null && input.pageId !== null) {
+      agentTabs.markFirstCaptureDone(input.agentId, input.pageId)
+    }
     return
   }
 
-  // Branch 2: screencast cache fallback for page-targeted
-  // state-mutating dispatches. Guarded by an env flag so operators
-  // can revert to the strict behaviour without a code change.
+  // Branch 2: screencast cache fallback. Guarded by an env flag so
+  // operators can revert to strict behaviour without a code change.
   if (!env.screencastScreenshotFallback) return
-  if (READ_ONLY_TOOLS.has(input.toolName)) return
-  if (input.pageId == null) return
+  if (input.pageId === null) return
+
+  if (READ_ONLY_TOOLS.has(input.toolName)) {
+    // Read-only tools are skipped by default. EXCEPT: if this is
+    // the first successful capture for this (agent, page) pair,
+    // we let the write through so the operator gets at least one
+    // visual anchor per tab even in an all-read-only audit.
+    if (input.agentId === null) return
+    if (agentTabs.hasFirstCapture(input.agentId, input.pageId)) return
+  }
+
   const frame = screencastCache.get(input.pageId)
   if (!frame) return
   let cacheBytes: Buffer
@@ -107,6 +132,9 @@ export function persistScreenshot(input: PersistScreenshotInput): void {
     return
   }
   writeBytesToDisk(input.dispatchId, cacheBytes)
+  if (input.agentId !== null) {
+    agentTabs.markFirstCaptureDone(input.agentId, input.pageId)
+  }
 }
 
 function writeBytesToDisk(dispatchId: number, bytes: Buffer): void {

--- a/packages/browseros-agent/apps/claw-server/src/services/screenshots.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/screenshots.ts
@@ -11,13 +11,34 @@
  * SQLite stores only the dispatch row plus a result_meta summary;
  * the JPEG bytes live on disk so the audit DB stays small and the
  * stream path is a plain file send.
+ *
+ * Two branches feed the file:
+ *
+ *   1. Tool-result branch (original): the tool result carries base64
+ *      image bytes (the explicit `screenshot` tool does this; some
+ *      future variants may too). We decode + write.
+ *   2. Screencast-fallback branch: for a page-targeted state-mutating
+ *      dispatch that produced no image bytes, we snapshot the current
+ *      screencast cache frame for the tab. Populates the audit with
+ *      visual context for `navigate` / `act` / `tabs new` / etc. that
+ *      would otherwise render as image-less rows.
+ *
+ * Read-only page-targeted tools (`snapshot`, `read`, `grep`, `diff`,
+ * `wait`) are excluded from the fallback: back-to-back reads would
+ * produce visually identical frames.
+ *
+ * The screencast cache remains ephemeral. The persistence here is a
+ * single snapshot AT dispatch complete time, not a continuous
+ * mirror of the cache to disk.
  */
 
 import { mkdirSync } from 'node:fs'
 import { writeFile } from 'node:fs/promises'
 import { dirname } from 'node:path'
+import { env } from '../env'
 import { resolveClawServerPath } from '../lib/browseros-dir'
 import { logger } from '../lib/logger'
+import { screencastCache } from './screencast-cache'
 import { extractToolResultImageData } from './tool-result-image'
 
 export function screenshotPath(dispatchId: number): string {
@@ -27,6 +48,14 @@ export function screenshotPath(dispatchId: number): string {
 export interface PersistScreenshotInput {
   dispatchId: number
   toolName: string
+  /**
+   * Page id for the dispatch, resolved via `extractPageId` at the
+   * call site. Null when the tool does not target a specific page
+   * (`tab_groups`, `windows`, `run`) OR when the dispatch is a
+   * `tabs new` whose page id is only born in the result. The
+   * fallback path skips when this is null.
+   */
+  pageId: number | null
   result: {
     isError: boolean
     content?: unknown
@@ -35,27 +64,65 @@ export interface PersistScreenshotInput {
 }
 
 /**
- * Fire-and-forget. Never throws.
- * No-op for non-screenshot tools, error results, or results without image data.
+ * Tools that read from the current page state without mutating it.
+ * Excluded from the screencast fallback: back-to-back reads produce
+ * visually identical frames, so writing one per dispatch is pure
+ * waste. Tools NOT in this set that ARE page-targeted (act, navigate,
+ * tabs, evaluate, download, pdf, upload, screenshot) get the
+ * fallback because they either change page state or the operator
+ * wants a visual around the time they fired.
  */
+const READ_ONLY_TOOLS: ReadonlySet<string> = new Set([
+  'snapshot',
+  'read',
+  'grep',
+  'diff',
+  'wait',
+])
+
+/** Fire-and-forget. Never throws. */
 export function persistScreenshot(input: PersistScreenshotInput): void {
-  if (input.toolName !== 'screenshot') return
   if (input.result.isError) return
-  const bytes = extractImageBytes(input.result)
-  if (!bytes) return
-  const path = screenshotPath(input.dispatchId)
+
+  // Branch 1: tool result carries image bytes (explicit screenshot
+  // tool, or any future tool that emits an image content block).
+  const toolBytes = extractImageBytes(input.result)
+  if (toolBytes) {
+    writeBytesToDisk(input.dispatchId, toolBytes)
+    return
+  }
+
+  // Branch 2: screencast cache fallback for page-targeted
+  // state-mutating dispatches. Guarded by an env flag so operators
+  // can revert to the strict behaviour without a code change.
+  if (!env.screencastScreenshotFallback) return
+  if (READ_ONLY_TOOLS.has(input.toolName)) return
+  if (input.pageId == null) return
+  const frame = screencastCache.get(input.pageId)
+  if (!frame) return
+  let cacheBytes: Buffer
+  try {
+    cacheBytes = Buffer.from(frame.jpegBase64, 'base64')
+  } catch {
+    return
+  }
+  writeBytesToDisk(input.dispatchId, cacheBytes)
+}
+
+function writeBytesToDisk(dispatchId: number, bytes: Buffer): void {
+  const path = screenshotPath(dispatchId)
   try {
     mkdirSync(dirname(path), { recursive: true })
   } catch (err) {
     logger.warn('screenshot dir create failed', {
-      dispatchId: input.dispatchId,
+      dispatchId,
       error: err instanceof Error ? err.message : String(err),
     })
     return
   }
   void writeFile(path, bytes).catch((err) => {
     logger.warn('screenshot write failed', {
-      dispatchId: input.dispatchId,
+      dispatchId,
       error: err instanceof Error ? err.message : String(err),
     })
   })

--- a/packages/browseros-agent/apps/claw-server/src/services/screenshots.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/screenshots.ts
@@ -124,13 +124,13 @@ export function persistScreenshot(input: PersistScreenshotInput): void {
   }
 
   const frame = screencastCache.get(input.pageId)
-  if (!frame) return
-  let cacheBytes: Buffer
-  try {
-    cacheBytes = Buffer.from(frame.jpegBase64, 'base64')
-  } catch {
-    return
-  }
+  if (!frame || !frame.jpegBase64) return
+  // Buffer.from(str, 'base64') never throws in Node/Bun; invalid
+  // chars are silently skipped. Guard against a zero-length result
+  // explicitly so we never write a 0-byte JPEG that renders as a
+  // broken icon in the audit UI.
+  const cacheBytes = Buffer.from(frame.jpegBase64, 'base64')
+  if (cacheBytes.length === 0) return
   writeBytesToDisk(input.dispatchId, cacheBytes)
   if (input.agentId !== null) {
     agentTabs.markFirstCaptureDone(input.agentId, input.pageId)
@@ -161,9 +161,10 @@ function extractImageBytes(
 ): Buffer | null {
   const image = extractToolResultImageData(result)
   if (!image) return null
-  try {
-    return Buffer.from(image, 'base64')
-  } catch {
-    return null
-  }
+  // Buffer.from(str, 'base64') never throws; a zero-length result
+  // means the tool sent garbage or empty base64. Treat as absent so
+  // the fallback branch can decide whether to write the cache frame
+  // instead of writing a 0-byte file here.
+  const bytes = Buffer.from(image, 'base64')
+  return bytes.length > 0 ? bytes : null
 }

--- a/packages/browseros-agent/apps/claw-server/src/services/tasks.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/tasks.ts
@@ -23,6 +23,7 @@
  * same millisecond.
  */
 
+import { existsSync } from 'node:fs'
 import { and, desc, eq, inArray, lt, sql } from 'drizzle-orm'
 import { getAuditDb } from '../modules/db/db'
 import {
@@ -31,6 +32,24 @@ import {
   type ToolDispatchRow,
   toolDispatches,
 } from '../modules/db/schema/schema'
+import { screenshotPath } from './screenshots'
+
+/**
+ * Returns true if this dispatch actually has a screenshot file on
+ * disk. Replaces the older `toolName === 'screenshot'` heuristic
+ * which predated the screencast fallback + first-capture policy in
+ * `persistScreenshot`: many non-screenshot-tool dispatches (navigate,
+ * act, tabs new, first read on a page, ...) now produce files too.
+ * A tiny `existsSync` per dispatch is cheap for the audit endpoints
+ * and correct across every write path.
+ */
+function dispatchHasScreenshotFile(d: {
+  id: number
+  resultMeta: string | null
+}): boolean {
+  if (resultIsError(d.resultMeta)) return false
+  return existsSync(screenshotPath(d.id))
+}
 
 const IDLE_TIMEOUT_MS = 5 * 60 * 1000
 
@@ -243,12 +262,12 @@ export function getTask(sessionId: string): TaskDetail | null {
     ...summary,
     dispatches,
     screenshotDispatchIds: dispatches
-      // Skip dispatches whose result was an error: persistScreenshot
-      // never wrote a file for them, so referencing those ids in the
-      // strip would render broken thumbnails.
-      .filter(
-        (d) => d.toolName === 'screenshot' && !resultIsError(d.resultMeta),
-      )
+      // Only include dispatches whose screenshot file actually
+      // exists on disk. Covers the explicit `screenshot` tool, the
+      // screencast fallback path (navigate / act / tabs new / ...),
+      // and the first-capture override for read-only tools. Skipping
+      // missing files avoids broken thumbnails in the UI strip.
+      .filter(dispatchHasScreenshotFile)
       .map((d) => d.id),
     startEvent: starts[0]
       ? {
@@ -288,10 +307,10 @@ function buildSummary(input: BuildSummaryInput): TaskSummary {
   const first = ds[0]
   const lastScreenshot = [...ds]
     .reverse()
-    // Same reason as getTask's screenshotDispatchIds filter:
-    // error-result screenshot dispatches have no file on disk, so
-    // using their id as the hero would 404 on every TaskCard.
-    .find((d) => d.toolName === 'screenshot' && !resultIsError(d.resultMeta))
+    // Same disk-existence check as getTask's screenshotDispatchIds
+    // filter; picks the most recent dispatch whose JPEG is present
+    // as the hero thumbnail on the TaskCard.
+    .find(dispatchHasScreenshotFile)
   const site = firstSiteOf(ds)
   const title = site
     ? `Browsed ${site}`

--- a/packages/browseros-agent/apps/claw-server/tests/lib/agent-tabs.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/lib/agent-tabs.test.ts
@@ -86,4 +86,50 @@ describe('agentTabs registry', () => {
     expect(r.size()).toBe(0)
     expect(r.ownedBy('a').size).toBe(0)
   })
+
+  it('hasFirstCapture returns false on an unrecorded (agent, page) pair', () => {
+    const r = createAgentTabsRegistry()
+    expect(r.hasFirstCapture('claude-code', 1)).toBe(false)
+    r.markOpened('claude-code', 1)
+    // Owning the page does not imply it has been captured yet.
+    expect(r.hasFirstCapture('claude-code', 1)).toBe(false)
+  })
+
+  it('markFirstCaptureDone flips hasFirstCapture to true', () => {
+    const r = createAgentTabsRegistry()
+    r.markFirstCaptureDone('claude-code', 1)
+    expect(r.hasFirstCapture('claude-code', 1)).toBe(true)
+    expect(r.hasFirstCapture('claude-code', 2)).toBe(false)
+  })
+
+  it('forgetAgent drops the first-capture set too', () => {
+    const r = createAgentTabsRegistry()
+    r.markFirstCaptureDone('claude-code', 1)
+    r.markFirstCaptureDone('claude-code', 2)
+    r.markFirstCaptureDone('cursor', 5)
+    r.forgetAgent('claude-code')
+    expect(r.hasFirstCapture('claude-code', 1)).toBe(false)
+    expect(r.hasFirstCapture('claude-code', 2)).toBe(false)
+    expect(r.hasFirstCapture('cursor', 5)).toBe(true)
+  })
+
+  it('two agents first-capture sets are isolated', () => {
+    const r = createAgentTabsRegistry()
+    r.markFirstCaptureDone('agent-a', 30)
+    // agent-b on the SAME pageId should still be able to record its
+    // own first capture; the two tracks are independent.
+    expect(r.hasFirstCapture('agent-a', 30)).toBe(true)
+    expect(r.hasFirstCapture('agent-b', 30)).toBe(false)
+    r.markFirstCaptureDone('agent-b', 30)
+    expect(r.hasFirstCapture('agent-b', 30)).toBe(true)
+  })
+
+  it('clear resets the first-capture set too', () => {
+    const r = createAgentTabsRegistry()
+    r.markFirstCaptureDone('a', 1)
+    r.markFirstCaptureDone('b', 2)
+    r.clear()
+    expect(r.hasFirstCapture('a', 1)).toBe(false)
+    expect(r.hasFirstCapture('b', 2)).toBe(false)
+  })
 })

--- a/packages/browseros-agent/apps/claw-server/tests/routes/audit/tasks.routes.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/routes/audit/tasks.routes.test.ts
@@ -5,13 +5,24 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
 import {
   resetAuditDbForTesting,
   setAuditDbForTesting,
 } from '../../../src/modules/db/db'
 import app from '../../../src/server'
 import { recordToolDispatch } from '../../../src/services/audit-log'
+import { screenshotPath } from '../../../src/services/screenshots'
 import { recordSessionEnd } from '../../../src/services/session-events'
+import { withTempBrowserosDir } from '../../_helpers/temp-browseros-dir'
+
+function seedScreenshotFile(dispatchId: number | null | undefined): void {
+  if (typeof dispatchId !== 'number') return
+  const path = screenshotPath(dispatchId)
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, Buffer.from([0xff, 0xd8, 0xff, 0xd9]))
+}
 
 function seed(sessionId: string, toolName: string, url: string | null = null) {
   return recordToolDispatch({
@@ -79,20 +90,25 @@ describe('GET /audit/tasks/:sessionId', () => {
   })
 
   it('returns the full task detail', async () => {
-    seed('detail-1', 'tabs', 'https://e.com')
-    seed('detail-1', 'screenshot')
+    await withTempBrowserosDir(async () => {
+      seed('detail-1', 'tabs', 'https://e.com')
+      const screenshotId = seed('detail-1', 'screenshot')
+      // Simulate persistScreenshot's fire-and-forget disk write; the
+      // deriver checks existence at read time.
+      seedScreenshotFile(screenshotId)
 
-    const res = await app.fetch(
-      new Request('http://localhost/audit/tasks/detail-1'),
-    )
-    expect(res.status).toBe(200)
-    const body = (await res.json()) as {
-      sessionId: string
-      dispatches: unknown[]
-      screenshotDispatchIds: number[]
-    }
-    expect(body.sessionId).toBe('detail-1')
-    expect(body.dispatches).toHaveLength(2)
-    expect(body.screenshotDispatchIds).toHaveLength(1)
+      const res = await app.fetch(
+        new Request('http://localhost/audit/tasks/detail-1'),
+      )
+      expect(res.status).toBe(200)
+      const body = (await res.json()) as {
+        sessionId: string
+        dispatches: unknown[]
+        screenshotDispatchIds: number[]
+      }
+      expect(body.sessionId).toBe('detail-1')
+      expect(body.dispatches).toHaveLength(2)
+      expect(body.screenshotDispatchIds).toHaveLength(1)
+    })
   })
 })

--- a/packages/browseros-agent/apps/claw-server/tests/services/screenshots.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/screenshots.test.ts
@@ -3,19 +3,26 @@
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
- * Covers both branches of persistScreenshot:
+ * Covers both branches of persistScreenshot AND the first-capture
+ * policy that guarantees at least one visual anchor per tab.
+ *
  *   1. Tool-result branch: image bytes in the tool result get written
  *      regardless of tool name.
  *   2. Screencast-fallback branch: state-mutating page-targeted
  *      dispatches with no image bytes AND a cache frame for the
  *      pageId AND the env flag on -> cache bytes get written.
- * Plus the guard rails: read-only deny-list, null pageId, empty
- * cache, env flag off, isError true.
+ *   3. First-capture override: the FIRST read-only dispatch on a
+ *      given (agentId, pageId) pair also writes so an all-read-only
+ *      audit still has a visual anchor for each tab. Subsequent
+ *      read-only dispatches on the same tab skip.
+ * Plus the guard rails: read-only deny-list-after-first, null pageId,
+ * empty cache, env flag off, isError true, cross-agent isolation.
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { existsSync, readFileSync } from 'node:fs'
 import { env } from '../../src/env'
+import { agentTabs } from '../../src/lib/agent-tabs'
 import { screencastCache } from '../../src/services/screencast-cache'
 import {
   persistScreenshot,
@@ -25,6 +32,8 @@ import { withTempBrowserosDir } from '../_helpers/temp-browseros-dir'
 
 const ONE_PX_JPEG_B64 =
   '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/2wBDAQMDAwQDBAgEBAgQCwkLEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBD/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAr/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAA//Z'
+
+const AGENT = 'test-agent'
 
 function primeCache(pageId: number, b64: string = ONE_PX_JPEG_B64): void {
   const raw = Buffer.from(b64, 'base64')
@@ -40,10 +49,12 @@ const ORIGINAL_FALLBACK = env.screencastScreenshotFallback
 describe('persistScreenshot', () => {
   beforeEach(() => {
     screencastCache.resetForTesting()
+    agentTabs.clear()
     env.screencastScreenshotFallback = true
   })
   afterEach(() => {
     screencastCache.resetForTesting()
+    agentTabs.clear()
     env.screencastScreenshotFallback = ORIGINAL_FALLBACK
   })
 
@@ -53,14 +64,11 @@ describe('persistScreenshot', () => {
         dispatchId: 42,
         toolName: 'screenshot',
         pageId: 1,
+        agentId: AGENT,
         result: {
           isError: false,
           content: [
-            {
-              type: 'image',
-              data: ONE_PX_JPEG_B64,
-              mimeType: 'image/jpeg',
-            },
+            { type: 'image', data: ONE_PX_JPEG_B64, mimeType: 'image/jpeg' },
           ],
           structuredContent: { page: 1, format: 'jpeg', bytes: 0 },
         },
@@ -78,6 +86,7 @@ describe('persistScreenshot', () => {
         dispatchId: 4,
         toolName: 'screenshot',
         pageId: 1,
+        agentId: AGENT,
         result: {
           isError: false,
           content: [],
@@ -96,14 +105,11 @@ describe('persistScreenshot', () => {
         dispatchId: 2,
         toolName: 'screenshot',
         pageId: 1,
+        agentId: AGENT,
         result: {
           isError: true,
           content: [
-            {
-              type: 'image',
-              data: ONE_PX_JPEG_B64,
-              mimeType: 'image/jpeg',
-            },
+            { type: 'image', data: ONE_PX_JPEG_B64, mimeType: 'image/jpeg' },
           ],
           structuredContent: {},
         },
@@ -120,6 +126,7 @@ describe('persistScreenshot', () => {
         dispatchId: 100,
         toolName: 'navigate',
         pageId: 7,
+        agentId: AGENT,
         result: {
           isError: false,
           content: [{ type: 'text', text: 'navigated' }],
@@ -145,6 +152,7 @@ describe('persistScreenshot', () => {
           dispatchId,
           toolName,
           pageId: 3,
+          agentId: AGENT,
           result: {
             isError: false,
             content: [{ type: 'text', text: 'ok' }],
@@ -159,9 +167,13 @@ describe('persistScreenshot', () => {
     })
   })
 
-  it('screencast fallback SKIPS read-only tools (snapshot / read / grep / diff / wait)', async () => {
+  it('read-only tools SKIP the fallback once the page has been captured before', async () => {
+    // Simulates the "already got a visual anchor for this tab" case:
+    // pre-mark first-capture-done, then verify snapshot / read / grep
+    // / diff / wait do NOT write.
     await withTempBrowserosDir(async () => {
       primeCache(9)
+      agentTabs.markFirstCaptureDone(AGENT, 9)
       for (const [dispatchId, toolName] of [
         [301, 'snapshot'],
         [302, 'read'],
@@ -173,6 +185,7 @@ describe('persistScreenshot', () => {
           dispatchId,
           toolName,
           pageId: 9,
+          agentId: AGENT,
           result: {
             isError: false,
             content: [{ type: 'text', text: 'read result' }],
@@ -193,6 +206,7 @@ describe('persistScreenshot', () => {
         dispatchId: 400,
         toolName: 'navigate',
         pageId: null,
+        agentId: AGENT,
         result: {
           isError: false,
           content: [{ type: 'text', text: 'navigated' }],
@@ -212,6 +226,7 @@ describe('persistScreenshot', () => {
         dispatchId: 500,
         toolName: 'navigate',
         pageId: 51,
+        agentId: AGENT,
         result: {
           isError: false,
           content: [{ type: 'text', text: 'navigated' }],
@@ -231,6 +246,7 @@ describe('persistScreenshot', () => {
         dispatchId: 600,
         toolName: 'navigate',
         pageId: 11,
+        agentId: AGENT,
         result: {
           isError: false,
           content: [{ type: 'text', text: 'navigated' }],
@@ -244,14 +260,11 @@ describe('persistScreenshot', () => {
         dispatchId: 601,
         toolName: 'screenshot',
         pageId: 11,
+        agentId: AGENT,
         result: {
           isError: false,
           content: [
-            {
-              type: 'image',
-              data: ONE_PX_JPEG_B64,
-              mimeType: 'image/jpeg',
-            },
+            { type: 'image', data: ONE_PX_JPEG_B64, mimeType: 'image/jpeg' },
           ],
           structuredContent: {},
         },
@@ -262,9 +275,6 @@ describe('persistScreenshot', () => {
   })
 
   it('tool-result branch wins over cache when both are available', async () => {
-    // If the tool result already carried image bytes, we use those
-    // instead of the (possibly older) cache frame. Prove it with
-    // distinguishable byte payloads.
     await withTempBrowserosDir(async () => {
       const CACHE_B64 = ONE_PX_JPEG_B64
       const TOOL_B64 =
@@ -274,6 +284,7 @@ describe('persistScreenshot', () => {
         dispatchId: 700,
         toolName: 'screenshot',
         pageId: 1,
+        agentId: AGENT,
         result: {
           isError: false,
           content: [{ type: 'image', data: TOOL_B64, mimeType: 'image/jpeg' }],
@@ -284,6 +295,144 @@ describe('persistScreenshot', () => {
       const written = readFileSync(screenshotPath(700))
       expect(written).toEqual(Buffer.from(TOOL_B64, 'base64'))
       expect(written).not.toEqual(Buffer.from(CACHE_B64, 'base64'))
+    })
+  })
+
+  it('FIRST-CAPTURE: first read on a page writes even though `read` is in the deny-list', async () => {
+    await withTempBrowserosDir(async () => {
+      primeCache(20)
+      persistScreenshot({
+        dispatchId: 800,
+        toolName: 'read',
+        pageId: 20,
+        agentId: AGENT,
+        result: {
+          isError: false,
+          content: [{ type: 'text', text: 'page content' }],
+          structuredContent: {},
+        },
+      })
+      await new Promise((r) => setTimeout(r, 50))
+      expect(existsSync(screenshotPath(800))).toBe(true)
+      expect(agentTabs.hasFirstCapture(AGENT, 20)).toBe(true)
+    })
+  })
+
+  it('FIRST-CAPTURE: second read on the SAME page does NOT write', async () => {
+    await withTempBrowserosDir(async () => {
+      primeCache(21)
+      // First read fires the override + marks first-capture-done.
+      persistScreenshot({
+        dispatchId: 900,
+        toolName: 'read',
+        pageId: 21,
+        agentId: AGENT,
+        result: {
+          isError: false,
+          content: [{ type: 'text', text: 'first read' }],
+          structuredContent: {},
+        },
+      })
+      // Second read on the same page hits the deny-list and skips.
+      persistScreenshot({
+        dispatchId: 901,
+        toolName: 'read',
+        pageId: 21,
+        agentId: AGENT,
+        result: {
+          isError: false,
+          content: [{ type: 'text', text: 'second read' }],
+          structuredContent: {},
+        },
+      })
+      await new Promise((r) => setTimeout(r, 50))
+      expect(existsSync(screenshotPath(900))).toBe(true)
+      expect(existsSync(screenshotPath(901))).toBe(false)
+    })
+  })
+
+  it('FIRST-CAPTURE: state-mutating write also marks; subsequent read on same page skips', async () => {
+    await withTempBrowserosDir(async () => {
+      primeCache(22)
+      persistScreenshot({
+        dispatchId: 1000,
+        toolName: 'navigate',
+        pageId: 22,
+        agentId: AGENT,
+        result: {
+          isError: false,
+          content: [{ type: 'text', text: 'navigated' }],
+          structuredContent: {},
+        },
+      })
+      // Read on the same page should now skip because the navigate
+      // already marked this page as first-captured.
+      persistScreenshot({
+        dispatchId: 1001,
+        toolName: 'read',
+        pageId: 22,
+        agentId: AGENT,
+        result: {
+          isError: false,
+          content: [{ type: 'text', text: 'read after navigate' }],
+          structuredContent: {},
+        },
+      })
+      await new Promise((r) => setTimeout(r, 50))
+      expect(existsSync(screenshotPath(1000))).toBe(true)
+      expect(existsSync(screenshotPath(1001))).toBe(false)
+    })
+  })
+
+  it('FIRST-CAPTURE: two agents on the same pageId EACH get their own first-capture write', async () => {
+    await withTempBrowserosDir(async () => {
+      primeCache(30)
+      persistScreenshot({
+        dispatchId: 1100,
+        toolName: 'read',
+        pageId: 30,
+        agentId: 'agent-a',
+        result: {
+          isError: false,
+          content: [{ type: 'text', text: 'a reads' }],
+          structuredContent: {},
+        },
+      })
+      persistScreenshot({
+        dispatchId: 1101,
+        toolName: 'read',
+        pageId: 30,
+        agentId: 'agent-b',
+        result: {
+          isError: false,
+          content: [{ type: 'text', text: 'b reads' }],
+          structuredContent: {},
+        },
+      })
+      await new Promise((r) => setTimeout(r, 50))
+      expect(existsSync(screenshotPath(1100))).toBe(true)
+      expect(existsSync(screenshotPath(1101))).toBe(true)
+      expect(agentTabs.hasFirstCapture('agent-a', 30)).toBe(true)
+      expect(agentTabs.hasFirstCapture('agent-b', 30)).toBe(true)
+    })
+  })
+
+  it('FIRST-CAPTURE: cannot override when agentId is null (falls back to strict deny-list)', async () => {
+    await withTempBrowserosDir(async () => {
+      primeCache(40)
+      persistScreenshot({
+        dispatchId: 1200,
+        toolName: 'read',
+        pageId: 40,
+        agentId: null, // e.g. identity resolution failed
+        result: {
+          isError: false,
+          content: [{ type: 'text', text: 'read' }],
+          structuredContent: {},
+        },
+      })
+      await new Promise((r) => setTimeout(r, 30))
+      expect(existsSync(screenshotPath(1200))).toBe(false)
     })
   })
 })

--- a/packages/browseros-agent/apps/claw-server/tests/services/screenshots.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/screenshots.test.ts
@@ -2,10 +2,21 @@
  * @license
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Covers both branches of persistScreenshot:
+ *   1. Tool-result branch: image bytes in the tool result get written
+ *      regardless of tool name.
+ *   2. Screencast-fallback branch: state-mutating page-targeted
+ *      dispatches with no image bytes AND a cache frame for the
+ *      pageId AND the env flag on -> cache bytes get written.
+ * Plus the guard rails: read-only deny-list, null pageId, empty
+ * cache, env flag off, isError true.
  */
 
-import { describe, expect, it } from 'bun:test'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
 import { existsSync, readFileSync } from 'node:fs'
+import { env } from '../../src/env'
+import { screencastCache } from '../../src/services/screencast-cache'
 import {
   persistScreenshot,
   screenshotPath,
@@ -15,12 +26,33 @@ import { withTempBrowserosDir } from '../_helpers/temp-browseros-dir'
 const ONE_PX_JPEG_B64 =
   '/9j/4AAQSkZJRgABAQEASABIAAD/2wBDAAMCAgICAgMCAgIDAwMDBAYEBAQEBAgGBgUGCQgKCgkICQkKDA8MCgsOCwkJDRENDg8QEBEQCgwSExIQEw8QEBD/2wBDAQMDAwQDBAgEBAgQCwkLEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBD/wAARCAABAAEDASIAAhEBAxEB/8QAFQABAQAAAAAAAAAAAAAAAAAAAAr/xAAUEAEAAAAAAAAAAAAAAAAAAAAA/8QAFAEBAAAAAAAAAAAAAAAAAAAAAP/EABQRAQAAAAAAAAAAAAAAAAAAAAD/2gAMAwEAAhEDEQA/AKpAA//Z'
 
+function primeCache(pageId: number, b64: string = ONE_PX_JPEG_B64): void {
+  const raw = Buffer.from(b64, 'base64')
+  screencastCache.set(pageId, {
+    jpegBase64: b64,
+    capturedAt: 1_000_000,
+    byteLength: raw.length,
+  })
+}
+
+const ORIGINAL_FALLBACK = env.screencastScreenshotFallback
+
 describe('persistScreenshot', () => {
-  it('writes <dispatchId>.jpg from image content', async () => {
+  beforeEach(() => {
+    screencastCache.resetForTesting()
+    env.screencastScreenshotFallback = true
+  })
+  afterEach(() => {
+    screencastCache.resetForTesting()
+    env.screencastScreenshotFallback = ORIGINAL_FALLBACK
+  })
+
+  it('writes <dispatchId>.jpg from tool-result image content (explicit screenshot tool)', async () => {
     await withTempBrowserosDir(async () => {
       persistScreenshot({
         dispatchId: 42,
         toolName: 'screenshot',
+        pageId: 1,
         result: {
           isError: false,
           content: [
@@ -30,14 +62,9 @@ describe('persistScreenshot', () => {
               mimeType: 'image/jpeg',
             },
           ],
-          structuredContent: {
-            page: 1,
-            format: 'jpeg',
-            bytes: 0,
-          },
+          structuredContent: { page: 1, format: 'jpeg', bytes: 0 },
         },
       })
-      // writeFile is async; small delay so the fire-and-forget settles.
       await new Promise((r) => setTimeout(r, 50))
       const path = screenshotPath(42)
       expect(existsSync(path)).toBe(true)
@@ -45,33 +72,30 @@ describe('persistScreenshot', () => {
     })
   })
 
-  it('no-op for non-screenshot tools', async () => {
+  it('legacy structured.image field still routes through the tool-result branch', async () => {
     await withTempBrowserosDir(async () => {
       persistScreenshot({
-        dispatchId: 1,
-        toolName: 'snapshot',
+        dispatchId: 4,
+        toolName: 'screenshot',
+        pageId: 1,
         result: {
           isError: false,
-          content: [
-            {
-              type: 'image',
-              data: ONE_PX_JPEG_B64,
-              mimeType: 'image/jpeg',
-            },
-          ],
-          structuredContent: {},
+          content: [],
+          structuredContent: { image: ONE_PX_JPEG_B64 },
         },
       })
-      await new Promise((r) => setTimeout(r, 30))
-      expect(existsSync(screenshotPath(1))).toBe(false)
+      await new Promise((r) => setTimeout(r, 50))
+      expect(existsSync(screenshotPath(4))).toBe(true)
     })
   })
 
-  it('no-op when isError=true', async () => {
+  it('no-op when isError=true even if tool-result carries image bytes AND cache has a frame', async () => {
     await withTempBrowserosDir(async () => {
+      primeCache(1)
       persistScreenshot({
         dispatchId: 2,
         toolName: 'screenshot',
+        pageId: 1,
         result: {
           isError: true,
           content: [
@@ -89,36 +113,177 @@ describe('persistScreenshot', () => {
     })
   })
 
-  it('no-op when image content is missing', async () => {
+  it('screencast fallback: state-mutating dispatch with no image bytes + cache frame writes cache bytes', async () => {
     await withTempBrowserosDir(async () => {
+      primeCache(7)
       persistScreenshot({
-        dispatchId: 3,
-        toolName: 'screenshot',
+        dispatchId: 100,
+        toolName: 'navigate',
+        pageId: 7,
         result: {
           isError: false,
-          content: [{ type: 'text', text: 'no image here' }],
-          structuredContent: { page: 1, format: 'jpeg' },
-        },
-      })
-      await new Promise((r) => setTimeout(r, 30))
-      expect(existsSync(screenshotPath(3))).toBe(false)
-    })
-  })
-
-  it('falls back to legacy structured image data', async () => {
-    await withTempBrowserosDir(async () => {
-      persistScreenshot({
-        dispatchId: 4,
-        toolName: 'screenshot',
-        result: {
-          isError: false,
-          content: [],
-          structuredContent: { image: ONE_PX_JPEG_B64 },
+          content: [{ type: 'text', text: 'navigated' }],
+          structuredContent: { ok: true },
         },
       })
       await new Promise((r) => setTimeout(r, 50))
-      expect(existsSync(screenshotPath(4))).toBe(true)
-      expect(readFileSync(screenshotPath(4)).length).toBeGreaterThan(0)
+      const path = screenshotPath(100)
+      expect(existsSync(path)).toBe(true)
+      expect(readFileSync(path).length).toBeGreaterThan(0)
+    })
+  })
+
+  it('screencast fallback: `act`, `tabs`, `evaluate` (state-mutating) also get cache bytes', async () => {
+    await withTempBrowserosDir(async () => {
+      primeCache(3)
+      for (const [dispatchId, toolName] of [
+        [201, 'act'],
+        [202, 'tabs'],
+        [203, 'evaluate'],
+      ] as const) {
+        persistScreenshot({
+          dispatchId,
+          toolName,
+          pageId: 3,
+          result: {
+            isError: false,
+            content: [{ type: 'text', text: 'ok' }],
+            structuredContent: {},
+          },
+        })
+      }
+      await new Promise((r) => setTimeout(r, 50))
+      expect(existsSync(screenshotPath(201))).toBe(true)
+      expect(existsSync(screenshotPath(202))).toBe(true)
+      expect(existsSync(screenshotPath(203))).toBe(true)
+    })
+  })
+
+  it('screencast fallback SKIPS read-only tools (snapshot / read / grep / diff / wait)', async () => {
+    await withTempBrowserosDir(async () => {
+      primeCache(9)
+      for (const [dispatchId, toolName] of [
+        [301, 'snapshot'],
+        [302, 'read'],
+        [303, 'grep'],
+        [304, 'diff'],
+        [305, 'wait'],
+      ] as const) {
+        persistScreenshot({
+          dispatchId,
+          toolName,
+          pageId: 9,
+          result: {
+            isError: false,
+            content: [{ type: 'text', text: 'read result' }],
+            structuredContent: {},
+          },
+        })
+      }
+      await new Promise((r) => setTimeout(r, 50))
+      for (const dispatchId of [301, 302, 303, 304, 305]) {
+        expect(existsSync(screenshotPath(dispatchId))).toBe(false)
+      }
+    })
+  })
+
+  it('screencast fallback SKIPS when pageId is null', async () => {
+    await withTempBrowserosDir(async () => {
+      persistScreenshot({
+        dispatchId: 400,
+        toolName: 'navigate',
+        pageId: null,
+        result: {
+          isError: false,
+          content: [{ type: 'text', text: 'navigated' }],
+          structuredContent: {},
+        },
+      })
+      await new Promise((r) => setTimeout(r, 30))
+      expect(existsSync(screenshotPath(400))).toBe(false)
+    })
+  })
+
+  it('screencast fallback SKIPS when the cache has no frame for the pageId', async () => {
+    await withTempBrowserosDir(async () => {
+      // Cache primed for a DIFFERENT pageId only.
+      primeCache(50)
+      persistScreenshot({
+        dispatchId: 500,
+        toolName: 'navigate',
+        pageId: 51,
+        result: {
+          isError: false,
+          content: [{ type: 'text', text: 'navigated' }],
+          structuredContent: {},
+        },
+      })
+      await new Promise((r) => setTimeout(r, 30))
+      expect(existsSync(screenshotPath(500))).toBe(false)
+    })
+  })
+
+  it('screencast fallback SKIPS when env.screencastScreenshotFallback is off (tool-result branch still fires)', async () => {
+    await withTempBrowserosDir(async () => {
+      env.screencastScreenshotFallback = false
+      primeCache(11)
+      persistScreenshot({
+        dispatchId: 600,
+        toolName: 'navigate',
+        pageId: 11,
+        result: {
+          isError: false,
+          content: [{ type: 'text', text: 'navigated' }],
+          structuredContent: {},
+        },
+      })
+      await new Promise((r) => setTimeout(r, 30))
+      expect(existsSync(screenshotPath(600))).toBe(false)
+      // Sanity: tool-result branch STILL fires when flag is off.
+      persistScreenshot({
+        dispatchId: 601,
+        toolName: 'screenshot',
+        pageId: 11,
+        result: {
+          isError: false,
+          content: [
+            {
+              type: 'image',
+              data: ONE_PX_JPEG_B64,
+              mimeType: 'image/jpeg',
+            },
+          ],
+          structuredContent: {},
+        },
+      })
+      await new Promise((r) => setTimeout(r, 50))
+      expect(existsSync(screenshotPath(601))).toBe(true)
+    })
+  })
+
+  it('tool-result branch wins over cache when both are available', async () => {
+    // If the tool result already carried image bytes, we use those
+    // instead of the (possibly older) cache frame. Prove it with
+    // distinguishable byte payloads.
+    await withTempBrowserosDir(async () => {
+      const CACHE_B64 = ONE_PX_JPEG_B64
+      const TOOL_B64 =
+        '/9j/4AAQSkZJRgABAAEASABIAAD/2wBDAAgGBgcGBQgHBwcJCQgKDBQNDAsLDBkSEw8UHRofHh0aHBwgJC4nICIsIxwcKDcpLDAxNDQ0Hyc5PTgyPC4zNDL/wAALCAABAAEBAREA/8QAFAABAAAAAAAAAAAAAAAAAAAACv/EABQBAQAAAAAAAAAAAAAAAAAAAAD/2gAIAQEAAD8Aqp//2Q=='
+      primeCache(1, CACHE_B64)
+      persistScreenshot({
+        dispatchId: 700,
+        toolName: 'screenshot',
+        pageId: 1,
+        result: {
+          isError: false,
+          content: [{ type: 'image', data: TOOL_B64, mimeType: 'image/jpeg' }],
+          structuredContent: {},
+        },
+      })
+      await new Promise((r) => setTimeout(r, 50))
+      const written = readFileSync(screenshotPath(700))
+      expect(written).toEqual(Buffer.from(TOOL_B64, 'base64'))
+      expect(written).not.toEqual(Buffer.from(CACHE_B64, 'base64'))
     })
   })
 })

--- a/packages/browseros-agent/apps/claw-server/tests/services/tasks.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/tasks.test.ts
@@ -5,16 +5,33 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
 import {
   resetAuditDbForTesting,
   setAuditDbForTesting,
 } from '../../src/modules/db/db'
 import { recordToolDispatch } from '../../src/services/audit-log'
+import { screenshotPath } from '../../src/services/screenshots'
 import {
   recordSessionEnd,
   recordSessionStart,
 } from '../../src/services/session-events'
 import { getTask, listTasks } from '../../src/services/tasks'
+import { withTempBrowserosDir } from '../_helpers/temp-browseros-dir'
+
+/**
+ * Simulates persistScreenshot having written a JPEG for this dispatch
+ * id. Needed because the tasks deriver checks disk existence (real
+ * writes are fire-and-forget from the MCP handler; the read-time
+ * deriver just answers "does the file exist right now?").
+ */
+function seedScreenshotFile(dispatchId: number | null | undefined): void {
+  if (typeof dispatchId !== 'number') return
+  const path = screenshotPath(dispatchId)
+  mkdirSync(dirname(path), { recursive: true })
+  writeFileSync(path, Buffer.from([0xff, 0xd8, 0xff, 0xd9]))
+}
 
 function dispatch(
   sessionId: string,
@@ -144,28 +161,57 @@ describe('getTask', () => {
     expect(getTask('nope')).toBeNull()
   })
 
-  it('returns dispatches + screenshot ids in chronological order', () => {
-    startSession('cc-screens')
-    dispatch('cc-screens', 'tabs', { url: 'https://e.com' })
-    const id1 = dispatch('cc-screens', 'screenshot')
-    dispatch('cc-screens', 'read')
-    const id2 = dispatch('cc-screens', 'screenshot')
-    recordSessionEnd({ sessionId: 'cc-screens', kind: 'closed' })
+  it('returns dispatches + screenshot ids in chronological order', async () => {
+    await withTempBrowserosDir(async () => {
+      startSession('cc-screens')
+      dispatch('cc-screens', 'tabs', { url: 'https://e.com' })
+      const id1 = dispatch('cc-screens', 'screenshot')
+      dispatch('cc-screens', 'read')
+      const id2 = dispatch('cc-screens', 'screenshot')
+      recordSessionEnd({ sessionId: 'cc-screens', kind: 'closed' })
+      // Simulate that persistScreenshot wrote a file for both.
+      seedScreenshotFile(id1)
+      seedScreenshotFile(id2)
 
-    const detail = getTask('cc-screens')!
-    expect(detail.dispatches).toHaveLength(4)
-    expect(detail.screenshotDispatchIds).toEqual([id1!, id2!])
-    expect(detail.startEvent?.clientName).toBe('claude-code')
-    expect(detail.endEvent?.kind).toBe('closed')
-    expect(detail.status).toBe('done')
+      const detail = getTask('cc-screens')!
+      expect(detail.dispatches).toHaveLength(4)
+      expect(detail.screenshotDispatchIds).toEqual([id1!, id2!])
+      expect(detail.startEvent?.clientName).toBe('claude-code')
+      expect(detail.endEvent?.kind).toBe('closed')
+      expect(detail.status).toBe('done')
+    })
   })
 
-  it('excludes error-result screenshot dispatches from the strip', () => {
-    dispatch('cc-err', 'tabs', { url: 'https://e.com' })
-    const ok = dispatch('cc-err', 'screenshot')
-    dispatch('cc-err', 'screenshot', { isError: true })
-    const detail = getTask('cc-err')!
-    expect(detail.screenshotDispatchIds).toEqual([ok!])
+  it('excludes error-result screenshot dispatches from the strip', async () => {
+    await withTempBrowserosDir(async () => {
+      dispatch('cc-err', 'tabs', { url: 'https://e.com' })
+      const ok = dispatch('cc-err', 'screenshot')
+      dispatch('cc-err', 'screenshot', { isError: true })
+      // Only the non-error dispatch has a file (persistScreenshot
+      // skips isError). The error dispatch may or may not have one,
+      // but is filtered by resultIsError() before the disk check.
+      seedScreenshotFile(ok)
+      const detail = getTask('cc-err')!
+      expect(detail.screenshotDispatchIds).toEqual([ok!])
+    })
+  })
+
+  it('includes non-`screenshot`-tool dispatches whose JPEG is on disk (screencast fallback + first-capture paths)', async () => {
+    // This is the point of the PR #1488 follow-up: the tasks deriver
+    // must not gate on toolName. `navigate`, `act`, `tabs`, and
+    // first-read overrides all persist files today; the audit UI's
+    // strip and per-row previews should surface them.
+    await withTempBrowserosDir(async () => {
+      const nav = dispatch('cc-fb', 'navigate', { url: 'https://e.com' })
+      const first_read = dispatch('cc-fb', 'read')
+      const second_read = dispatch('cc-fb', 'read') // no file (deny-list)
+      // Simulate what the new persistScreenshot writes today:
+      seedScreenshotFile(nav)
+      seedScreenshotFile(first_read)
+      const detail = getTask('cc-fb')!
+      expect(detail.screenshotDispatchIds).toEqual([nav!, first_read!])
+      expect(detail.screenshotDispatchIds).not.toContain(second_read)
+    })
   })
 })
 
@@ -192,11 +238,15 @@ describe('listTasks / getTask consistency on double end rows', () => {
     expect(list.endedAt).toBe(detail.endedAt)
   })
 
-  it('lastScreenshotDispatchId skips error screenshots in listTasks', () => {
-    dispatch('cc-last', 'tabs', { url: 'https://e.com' })
-    const ok = dispatch('cc-last', 'screenshot')
-    dispatch('cc-last', 'screenshot', { isError: true })
-    const list = listTasks({}).tasks[0]!
-    expect(list.lastScreenshotDispatchId).toBe(ok)
+  it('lastScreenshotDispatchId skips error screenshots in listTasks', async () => {
+    await withTempBrowserosDir(async () => {
+      dispatch('cc-last', 'tabs', { url: 'https://e.com' })
+      const ok = dispatch('cc-last', 'screenshot')
+      dispatch('cc-last', 'screenshot', { isError: true })
+      // Only the non-error dispatch has a file on disk.
+      seedScreenshotFile(ok)
+      const list = listTasks({}).tasks[0]!
+      expect(list.lastScreenshotDispatchId).toBe(ok)
+    })
   })
 })


### PR DESCRIPTION
## Summary

Fixes Issue 3 from the session-lifecycle audit. Before this change, the audit only stored an image when the agent explicitly called the `screenshot` MCP tool. Codex and claude-mcp-client almost never do (they prefer `snapshot` which returns text), so the audit trail ended up with naked rows for every `navigate` / `act` / `tabs new` / `evaluate` dispatch.

Post-fix, the audit gets a JPEG on every state-mutating page-targeted dispatch AND at least one visual anchor per tab even in an all-read-only audit, sourced from the existing screencast cache (already refreshed every 1.5 s by `services/screencast-poller.ts`) when the tool result carried no image bytes of its own. Both the API surface and the audit UI recognize the newly-written files.

## Commits

- `56f10363`: initial two-branch `persistScreenshot` (tool-result + screencast fallback).
- `58851781`: dogfood-driven follow-up. Fixes `tabs new` pageId gap + first-capture-per-page policy so read-only audits also get a visual anchor per tab.
- `bf907a64`: surface the newly-written files in the audit UI. Server-side task deriver + client-side Timeline row both stopped assuming `toolName === 'screenshot'`; the deriver now checks disk existence and the row derives from the server's authoritative `screenshotDispatchIds` list.

## Design

### Server (`services/screenshots.ts`)

Two-branch function:

1. **Tool-result branch** (unchanged in shape): if the tool result carries base64 image bytes, decode + write. Handles the explicit `screenshot` tool AND any future tool that emits image content blocks.
2. **Screencast-fallback branch**: if branch 1 finds no bytes AND the tool is page-targeted AND (state-mutating OR this is the tab's first capture for this agent) AND the cache has a frame, decode + write.

The old `toolName !== 'screenshot'` early return is gone; branch 1 handles the tool-provided-bytes case regardless of tool name.

**Read-only deny-list**: `{snapshot, read, grep, diff, wait}` normally skip the fallback (back-to-back reads produce visually identical frames). **First-capture override**: the FIRST successful dispatch on each `(agentId, pageId)` pair fires anyway so an all-read-only audit still has one visual per tab. Tracked by `agentTabs.hasFirstCapture` / `markFirstCaptureDone`; dropped by `cleanupSessionState` alongside the ownership records.

**`tabs new` pageId** is derived from `result.structuredContent.page` at the `persistScreenshot` call site (the args-side extractor returns null for `tabs new` because the id is born in the result).

**`register.ts`** passes `agentId` (already computed in the enclosing block) into `persistScreenshot`.

**`screencast-cache.ts` docstring** updated: the cache itself stays ephemeral, but a snapshot IS taken from it at dispatch complete time. The cockpit-driven-executeTool-bypasses-audit-hook precedent from `tab-group-ops.ts` is preserved: the narrative stays agent-driven, the image is decoration attached to it.

### Server (`services/tasks.ts`)

The audit endpoints derive `screenshotDispatchIds` (audit detail) and `lastScreenshotDispatchId` (task list hero) from disk existence:

```ts
function dispatchHasScreenshotFile(d): boolean {
  if (resultIsError(d.resultMeta)) return false
  return existsSync(screenshotPath(d.id))
}
```

Replaces the older `toolName === 'screenshot'` heuristic that predated the fallback + first-capture policy. One `fs.existsSync` per dispatch. Correct across every write path.

### Client (`components/audit/Timeline.tsx` + `TaskDetailPage.tsx`)

`Timeline` gets a new `screenshotDispatchIds: readonly number[]` prop from the parent. Row-level `isScreenshot` derives from set membership instead of tool name, so any dispatch whose file exists on disk gets the per-row preview block.

## Tunables

| env | default | meaning |
|---|---|---|
| `CLAW_SCREENCAST_SCREENSHOT_FALLBACK` | `true` | Set to `0` or `false` to disable the cache fallback (both the state-mutating and first-capture paths) and revert to strict "only the `screenshot` tool persists images" behaviour, no code change required. |

## Test plan

`tests/services/screenshots.test.ts` (15 cases):
- Tool-result image content is written (explicit `screenshot` tool).
- Legacy `structured.image` field still routes through the tool-result branch.
- `isError: true` is a no-op even when the tool carries bytes AND the cache has a frame.
- `navigate` + cache frame writes cache bytes (state-mutating happy path).
- `act`, `tabs`, `evaluate` (state-mutating) also get cache bytes.
- Read-only tools SKIP the fallback once the page has been captured before.
- `pageId: null` skips the fallback.
- Cache with a different `pageId` only does not fire fallback.
- Env flag off disables fallback but tool-result branch still fires.
- Tool-result branch wins over cache when both are available.
- FIRST-CAPTURE: first read on a page writes even though `read` is in the deny-list.
- FIRST-CAPTURE: second read on the same page does NOT write.
- FIRST-CAPTURE: state-mutating first, read second on same page: mutation writes AND marks; the follow-up read skips.
- FIRST-CAPTURE: two agents on the same pageId each get their own first-capture write.
- FIRST-CAPTURE: `agentId: null` falls back to strict deny-list.

`tests/lib/agent-tabs.test.ts` (13 cases, +5 for the first-capture ledger extension).

`tests/services/tasks.test.ts` (3 updated + 1 new):
- Existing screenshot-strip tests now seed a real JPEG on disk to match the new disk-existence deriver.
- NEW: `navigate` + first `read` + second `read` scenario: only `navigate` + first `read` appear in `screenshotDispatchIds` (matches what `persistScreenshot` writes today).

`tests/routes/audit/tasks.routes.test.ts`: `GET /audit/tasks/:sessionId` test now seeds a JPEG for the `screenshot` dispatch so the disk-existence deriver returns it in the response.

`components/audit/Timeline.test.tsx`: test helper extended to accept `screenshotDispatchIds`; existing static-markup pins still hold.

Full suites:
- claw-server: **369 pass, 0 fail** (baseline 353 + 16 net new).
- claw-app: **114 pass, 0 fail**.
- Typecheck clean on both.

## Freshness + retention notes

- Cache frame is up to 1500 ms stale. Acceptable v1. Future improvement: force a fresh CDP `Page.captureScreenshot` for state-mutating dispatches; not blocking on this PR.
- At ~50 KB/frame, a busy operator sees ~25 MB/day. Bounded further by the first-capture policy (at most N screenshots per tab per session for read-only workflows, plus one per mutation).

## Known follow-ups (called out explicitly)

- **`run`-opened tabs bypass the poller.** Agents that open tabs via the `run` tool's arbitrary JS (`browser.pages.newPage`) do not register those pages with `tabActivityRegistry`, so the screencast poller never captures them and the cache stays empty. Bridge that into the poller pipeline; likely lives with audit Issue 6b.
- **Retention policy** for `screenshots/` directory (age-based prune, LRU by disk footprint, or per-session cap).
- **Fresh CDP captures** for state-mutating dispatches instead of the up-to-1500 ms cache read.
- **Audit Issue 6b**: shrink the recorder-race window for fast-open-fast-close tabs; the cache is empty at persist time for those.

## Scope

- Does NOT add per-session or per-day disk quotas.
- Does NOT force fresh CDP captures.
- Does NOT change the read route (`GET /audit/screenshot/:dispatchId`).
- Does NOT bridge `run`-opened tabs into the poller (separate follow-up).