### PR TITLE
feat(claw-app): group audit dispatches per tab using shadcn Tabs

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/audit/Timeline.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/Timeline.test.tsx
@@ -33,16 +33,30 @@ const startedAt = 1_000_000
 function render(
   dispatches: ToolDispatchRow[],
   screenshotDispatchIds: readonly number[] = [],
+  extra: { showSessionEnd?: boolean; endEvent?: TimelineEndEvent } = {},
 ): string {
   return renderToStaticMarkup(
     <Timeline
       dispatches={dispatches}
       screenshotDispatchIds={screenshotDispatchIds}
       startedAt={startedAt}
-      endEvent={null}
+      endEvent={extra.endEvent ?? null}
+      showSessionEnd={extra.showSessionEnd}
       onScreenshotClick={() => undefined}
     />,
   )
+}
+
+type TimelineEndEvent = {
+  createdAt: number
+  kind: 'closed' | 'errored'
+  reason: string | null
+} | null
+
+const CLOSED_END: TimelineEndEvent = {
+  createdAt: startedAt + 60_000,
+  kind: 'closed',
+  reason: null,
 }
 
 describe('Timeline', () => {
@@ -119,5 +133,25 @@ describe('Timeline', () => {
       }),
     ])
     expect(html).not.toContain('data-testid="timeline-block-copy-screenshot"')
+  })
+
+  it('renders the SessionEndRow by default (backward compat)', () => {
+    const html = render([dispatch({ id: 1 })], [], { endEvent: CLOSED_END })
+    // SessionEndRow markup includes the literal "session closed" (or
+    // "session errored") tail; either is enough to pin the presence
+    // of the row.
+    expect(html).toContain('session closed')
+  })
+
+  it('hides the SessionEndRow when showSessionEnd is false (per-tab view)', () => {
+    const html = render([dispatch({ id: 1 })], [], {
+      endEvent: CLOSED_END,
+      showSessionEnd: false,
+    })
+    expect(html).not.toContain('session closed')
+    expect(html).not.toContain('session errored')
+    expect(html).not.toContain('Still running')
+    // The dispatch row itself is still there.
+    expect(html).toContain('snapshot')
   })
 })

--- a/packages/browseros-agent/apps/claw-app/components/audit/Timeline.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/Timeline.tsx
@@ -35,6 +35,13 @@ interface TimelineProps {
     kind: 'closed' | 'errored'
     reason: string | null
   } | null
+  /**
+   * Whether to render the session-end row below the dispatch list.
+   * Default true keeps existing consumers unchanged. Per-tab views
+   * (see `TabView.tsx`) pass false because the session end is not
+   * scoped to any one tab; it lives on the Session tab only.
+   */
+  showSessionEnd?: boolean
   onScreenshotClick: (dispatchId: number) => void
 }
 
@@ -53,6 +60,7 @@ export function Timeline({
   screenshotDispatchIds,
   startedAt,
   endEvent,
+  showSessionEnd = true,
   onScreenshotClick,
 }: TimelineProps) {
   const screenshotIdSet = new Set(screenshotDispatchIds)
@@ -123,7 +131,9 @@ export function Timeline({
             onScreenshotClick={onScreenshotClick}
           />
         ))}
-        <SessionEndRow startedAt={startedAt} endEvent={endEvent} />
+        {showSessionEnd && (
+          <SessionEndRow startedAt={startedAt} endEvent={endEvent} />
+        )}
       </ol>
     </section>
   )

--- a/packages/browseros-agent/apps/claw-app/components/ui/tabs-auto-hide.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/ui/tabs-auto-hide.test.tsx
@@ -1,0 +1,48 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { AutoHideTabs } from './tabs-auto-hide'
+
+describe('AutoHideTabs', () => {
+  it('renders nothing when given an empty items array', () => {
+    const html = renderToStaticMarkup(<AutoHideTabs items={[]} />)
+    expect(html).toBe('')
+  })
+
+  it('renders the single item content without any tab triggers', () => {
+    const html = renderToStaticMarkup(
+      <AutoHideTabs
+        items={[{ id: 'only', label: 'Only', content: <p>only content</p> }]}
+      />,
+    )
+    // Content is present.
+    expect(html).toContain('only content')
+    // But no tablist / tab markers should exist.
+    expect(html).not.toContain('data-slot="tabs-list"')
+    expect(html).not.toContain('data-slot="tabs-trigger"')
+    // And the trigger label itself is absent (single-item mode skips the bar).
+    expect(html).not.toContain('Only')
+  })
+
+  it('renders full tabs UI when two or more items are given', () => {
+    const html = renderToStaticMarkup(
+      <AutoHideTabs
+        items={[
+          { id: 'a', label: 'Alpha', content: <p>alpha content</p> },
+          { id: 'b', label: 'Bravo', content: <p>bravo content</p> },
+        ]}
+      />,
+    )
+    expect(html).toContain('data-slot="tabs-list"')
+    expect(html).toContain('Alpha')
+    expect(html).toContain('Bravo')
+    // Both content panels render (the primitive keeps them mounted for
+    // fast switching; only the selected one is visible via CSS).
+    expect(html).toContain('alpha content')
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/components/ui/tabs-auto-hide.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/ui/tabs-auto-hide.tsx
@@ -29,6 +29,8 @@ export interface AutoHideTabsProps {
   items: AutoHideTabsItem[]
   /** Which tab id is selected on mount. Falls back to the first item. */
   defaultId?: string
+  /** Passes through to shadcn TabsList's variant (`default` | `line`). */
+  listVariant?: 'default' | 'line'
   className?: string
   listClassName?: string
 }
@@ -36,6 +38,7 @@ export interface AutoHideTabsProps {
 export function AutoHideTabs({
   items,
   defaultId,
+  listVariant,
   className,
   listClassName,
 }: AutoHideTabsProps) {
@@ -44,7 +47,7 @@ export function AutoHideTabs({
   const initial = defaultId ?? items[0]!.id
   return (
     <Tabs defaultValue={initial} className={className}>
-      <TabsList className={listClassName}>
+      <TabsList variant={listVariant} className={listClassName}>
         {items.map((it) => (
           <TabsTrigger key={it.id} value={it.id}>
             {it.label}

--- a/packages/browseros-agent/apps/claw-app/components/ui/tabs-auto-hide.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/ui/tabs-auto-hide.tsx
@@ -1,0 +1,61 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Thin wrapper around shadcn `Tabs`. When only one item is given,
+ * renders that item's content directly with no `TabsList`. When
+ * zero, renders nothing. When two or more, renders the full tabs
+ * UI. Purpose: on screens that MIGHT need multi-view partitioning
+ * (per-tab audit view, agent detail sub-panels, MCP settings
+ * sub-sections) we want the tab bar to appear only when it
+ * actually carries information. Callers do not have to branch on
+ * `items.length` themselves.
+ */
+
+import type * as React from 'react'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from './tabs'
+
+export interface AutoHideTabsItem {
+  /** Stable id used as the `value` for Tabs + React key. */
+  id: string
+  /** Tab trigger label. Kept as ReactNode so callers can add badges. */
+  label: React.ReactNode
+  /** Tab body. Kept as ReactNode so callers can compose freely. */
+  content: React.ReactNode
+}
+
+export interface AutoHideTabsProps {
+  items: AutoHideTabsItem[]
+  /** Which tab id is selected on mount. Falls back to the first item. */
+  defaultId?: string
+  className?: string
+  listClassName?: string
+}
+
+export function AutoHideTabs({
+  items,
+  defaultId,
+  className,
+  listClassName,
+}: AutoHideTabsProps) {
+  if (items.length === 0) return null
+  if (items.length === 1) return <>{items[0]!.content}</>
+  const initial = defaultId ?? items[0]!.id
+  return (
+    <Tabs defaultValue={initial} className={className}>
+      <TabsList className={listClassName}>
+        {items.map((it) => (
+          <TabsTrigger key={it.id} value={it.id}>
+            {it.label}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+      {items.map((it) => (
+        <TabsContent key={it.id} value={it.id}>
+          {it.content}
+        </TabsContent>
+      ))}
+    </Tabs>
+  )
+}

--- a/packages/browseros-agent/apps/claw-app/components/ui/tabs-auto-hide.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/ui/tabs-auto-hide.tsx
@@ -43,7 +43,12 @@ export function AutoHideTabs({
   listClassName,
 }: AutoHideTabsProps) {
   if (items.length === 0) return null
-  if (items.length === 1) return <>{items[0]!.content}</>
+  // Wrap the single-item content in a div so `className` still
+  // applies (Fragments silently drop it). Keeps behaviour
+  // consistent whether the tab bar is hidden or shown.
+  if (items.length === 1) {
+    return <div className={className}>{items[0]!.content}</div>
+  }
   const initial = defaultId ?? items[0]!.id
   return (
     <Tabs defaultValue={initial} className={className}>

--- a/packages/browseros-agent/apps/claw-app/modules/api/replay.hooks.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/replay.hooks.ts
@@ -51,6 +51,22 @@ export interface ReplayFrame {
   node: string
   /** Caption sentence rendered in the viewport overlay + timeline row. */
   caption: string
+  /**
+   * Full URL captured on this dispatch's audit row, when the tool
+   * targeted a page. Populates the replay viewport's browser-chrome
+   * address bar so the operator can see the exact URL the agent
+   * was on at this instant. Null for tools that do not target a
+   * page (`run`, `windows`, `tab_groups`, `tabs new` before the
+   * result comes back).
+   */
+  url?: string | null
+  /**
+   * BrowserOS pageId this frame belongs to, or null when the tool
+   * did not target a page. Enables per-tab filtering on the replay
+   * screen so the address bar + caption reflect the selected tab
+   * as the operator switches between them.
+   */
+  pageId?: number | null
   /** Optional badge shown on the timeline row ("Blocked", "Cancelled"). */
   note?: string
   /** Source dispatch id so the replay surface can deep-link. */

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -24,6 +24,7 @@ import { ArrowLeft, History } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { StatusBadge } from '@/components/cockpit/StatusBadge'
 import { Spinner } from '@/components/ui/spinner'
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { EventTimeline } from './EventTimeline'
 import { PlaybackTransport } from './PlaybackTransport'
 import { type ReplayPlayerHandle, ReplayViewport } from './ReplayViewport'
@@ -132,13 +133,24 @@ export function Replay() {
 
       <div className="flex min-h-0 flex-1">
         <div className="flex min-w-0 flex-1 flex-col gap-3 p-4">
+          {replay.tabPageIds.length > 1 && selectedTabPageId !== null && (
+            <Tabs
+              value={String(selectedTabPageId)}
+              onValueChange={(v) => setSelectedTabPageId(Number(v))}
+            >
+              <TabsList variant="line">
+                {replay.tabPageIds.map((id, idx) => (
+                  <TabsTrigger key={id} value={String(id)}>
+                    Tab {idx + 1}
+                  </TabsTrigger>
+                ))}
+              </TabsList>
+            </Tabs>
+          )}
           <ReplayViewport
             site={replay.site}
             frame={currentFrame}
             events={eventsForSelectedTab}
-            tabPageIds={replay.tabPageIds}
-            selectedTabPageId={selectedTabPageId}
-            onTabPageIdChange={setSelectedTabPageId}
             onPlayerReady={onPlayerReady}
           />
           <PlaybackTransport

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -28,13 +28,12 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { EventTimeline } from './EventTimeline'
 import { PlaybackTransport } from './PlaybackTransport'
 import { type ReplayPlayerHandle, ReplayViewport } from './ReplayViewport'
-import { useReplayData } from './replay.data'
+import { buildTabView, EMPTY_TAB_VIEW, useReplayData } from './replay.data'
 import { frameIndexAt } from './replay.helpers'
 import { usePlayback } from './use-playback'
 
 export function Replay() {
   const { replay, isLoading, navigate } = useReplayData()
-  const playback = usePlayback(replay?.totalSeconds ?? 0)
   const [selectedTabPageId, setSelectedTabPageId] = useState<number | null>(
     null,
   )
@@ -47,21 +46,30 @@ export function Replay() {
     setSelectedTabPageId(replay.tabPageIds[0])
   }, [replay, selectedTabPageId])
 
-  const eventsForSelectedTab = useMemo(() => {
-    if (!replay || selectedTabPageId === null) return []
-    return replay.eventsForTab(selectedTabPageId)
-  }, [replay, selectedTabPageId])
-
-  // Frames restricted to the selected tab. Must be declared
-  // BEFORE the isLoading early-return below so rules-of-hooks
-  // stays honest (hook count invariant across renders).
-  const framesForSelectedTab = useMemo(
+  // Per-tab view: frames + events + duration scoped to the
+  // currently-selected tab, with frames time-shifted to tab-
+  // relative t=0. Every panel below (viewport, timeline, scrubber)
+  // reads from this and only this. Must be declared BEFORE the
+  // isLoading early-return so rules-of-hooks stays honest.
+  const perTabView = useMemo(
     () =>
-      !replay || selectedTabPageId === null
-        ? []
-        : replay.frames.filter((f) => f.pageId === selectedTabPageId),
+      replay
+        ? buildTabView(
+            {
+              frames: replay.frames,
+              eventsForTab: replay.eventsForTab,
+              startedAtMs: replay.startedAtMs,
+            },
+            selectedTabPageId,
+          )
+        : EMPTY_TAB_VIEW,
     [replay, selectedTabPageId],
   )
+
+  // Tab-scoped clock. Its totalSeconds changes when the operator
+  // switches tabs; the seek-to-0 effect below lands the playhead
+  // at the start of the new tab's story.
+  const playback = usePlayback(perTabView.totalSeconds)
 
   // When playback's time changes (driven by the scaffold's
   // setInterval clock), forward to the rrweb-player. Without this
@@ -70,6 +78,15 @@ export function Replay() {
   useEffect(() => {
     playerHandleRef.current?.goto(playback.time * 1000)
   }, [playback.time])
+
+  // On tab switch, reset the clock to 0 so the operator lands at
+  // the tab's start (Option A: per-tab clocks). usePlayback's
+  // internal useState would otherwise keep the previous tab's
+  // position, which is meaningless in the new tab's timeline.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally scoped to selectedTabPageId; `playback.seek` is a new reference every render and would cause an infinite loop.
+  useEffect(() => {
+    playback.seek(0)
+  }, [selectedTabPageId])
 
   // Mirror play/pause to the rrweb-player. The player still has
   // its own internal clock for rendering frames between our seek
@@ -93,19 +110,11 @@ export function Replay() {
   }
 
   const back = () => navigate(`/audit/${replay.sessionId}`)
-  const currentFrameIndex = frameIndexAt(replay.frames, playback.time)
-  const currentFrame = replay.frames[currentFrameIndex]
-
-  // Per-tab current frame. Drives the viewport's address bar and
-  // caption so that switching tabs immediately reflects that
-  // tab's most recent dispatch at the current playback time.
-  // Falls back to the session-global currentFrame when the
-  // selected tab has no frames at or before `playback.time`
-  // (e.g. the operator scrubbed to an instant before that tab
-  // was ever active).
-  const currentTabFrameIndex = frameIndexAt(framesForSelectedTab, playback.time)
-  const currentTabFrame =
-    framesForSelectedTab[currentTabFrameIndex] ?? currentFrame
+  // Everything below is tab-scoped: frame index, current frame,
+  // scrubber ticks, timeline actions. Playback.time is already in
+  // tab-relative seconds thanks to the per-tab usePlayback wiring.
+  const currentTabFrameIndex = frameIndexAt(perTabView.frames, playback.time)
+  const currentTabFrame = perTabView.frames[currentTabFrameIndex]
 
   const stats: { label: string; value: string }[] = [
     { label: 'Duration', value: replay.duration },
@@ -172,18 +181,18 @@ export function Replay() {
           <ReplayViewport
             site={replay.site}
             frame={currentTabFrame}
-            events={eventsForSelectedTab}
+            events={perTabView.events}
             onPlayerReady={onPlayerReady}
           />
           <PlaybackTransport
             playback={playback}
-            totalSeconds={replay.totalSeconds}
-            frames={replay.frames}
+            totalSeconds={perTabView.totalSeconds}
+            frames={perTabView.frames}
           />
         </div>
         <EventTimeline
-          frames={replay.frames}
-          currentFrameIndex={currentFrameIndex}
+          frames={perTabView.frames}
+          currentFrameIndex={currentTabFrameIndex}
           currentTime={playback.time}
           onSeek={playback.seek}
         />

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -52,6 +52,17 @@ export function Replay() {
     return replay.eventsForTab(selectedTabPageId)
   }, [replay, selectedTabPageId])
 
+  // Frames restricted to the selected tab. Must be declared
+  // BEFORE the isLoading early-return below so rules-of-hooks
+  // stays honest (hook count invariant across renders).
+  const framesForSelectedTab = useMemo(
+    () =>
+      !replay || selectedTabPageId === null
+        ? []
+        : replay.frames.filter((f) => f.pageId === selectedTabPageId),
+    [replay, selectedTabPageId],
+  )
+
   // When playback's time changes (driven by the scaffold's
   // setInterval clock), forward to the rrweb-player. Without this
   // the player would sit idle while the scrubber + timeline
@@ -84,6 +95,17 @@ export function Replay() {
   const back = () => navigate(`/audit/${replay.sessionId}`)
   const currentFrameIndex = frameIndexAt(replay.frames, playback.time)
   const currentFrame = replay.frames[currentFrameIndex]
+
+  // Per-tab current frame. Drives the viewport's address bar and
+  // caption so that switching tabs immediately reflects that
+  // tab's most recent dispatch at the current playback time.
+  // Falls back to the session-global currentFrame when the
+  // selected tab has no frames at or before `playback.time`
+  // (e.g. the operator scrubbed to an instant before that tab
+  // was ever active).
+  const currentTabFrameIndex = frameIndexAt(framesForSelectedTab, playback.time)
+  const currentTabFrame =
+    framesForSelectedTab[currentTabFrameIndex] ?? currentFrame
 
   const stats: { label: string; value: string }[] = [
     { label: 'Duration', value: replay.duration },
@@ -149,7 +171,7 @@ export function Replay() {
           )}
           <ReplayViewport
             site={replay.site}
-            frame={currentFrame}
+            frame={currentTabFrame}
             events={eventsForSelectedTab}
             onPlayerReady={onPlayerReady}
           />

--- a/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
@@ -96,6 +96,30 @@ interface PlayerCanvasProps {
   onReady: (handle: ReplayPlayerHandle) => void
 }
 
+/**
+ * Fallback DOM viewport for pages that never emitted a meta event.
+ * rrweb ALWAYS emits type 4 as its first event under normal
+ * conditions, so this is defensive.
+ */
+const DEFAULT_RECORDED_SIZE = { width: 1280, height: 720 }
+
+function readRecordedSize(events: ReplayEvent[]): {
+  width: number
+  height: number
+} {
+  const meta = events.find((e) => e.type === 4)
+  const data = meta?.data as { width?: unknown; height?: unknown } | undefined
+  const width =
+    typeof data?.width === 'number' && data.width > 0
+      ? data.width
+      : DEFAULT_RECORDED_SIZE.width
+  const height =
+    typeof data?.height === 'number' && data.height > 0
+      ? data.height
+      : DEFAULT_RECORDED_SIZE.height
+  return { width, height }
+}
+
 function PlayerCanvas({ events, onReady }: PlayerCanvasProps) {
   const mountRef = useRef<HTMLDivElement>(null)
   // We deliberately use useEffect rather than deriving during render
@@ -134,6 +158,36 @@ function PlayerCanvas({ events, onReady }: PlayerCanvasProps) {
       console.warn('[browseros-claw replay] Replayer ctor threw', err)
       return
     }
+
+    // rrweb-player normally handles fit-to-container scaling; we
+    // mount the raw Replayer (see notes at the top of the file) so
+    // we do it ourselves. Read the recorded viewport from the meta
+    // event, absolute-position the .replayer-wrapper at 0,0 of the
+    // mount, and apply a uniform transform so it fits regardless of
+    // the player pane's size. A ResizeObserver keeps the scale in
+    // sync with layout changes (window resize, split-pane drags,
+    // tab switch narrowing the viewport, etc.).
+    const { width: recordedW, height: recordedH } = readRecordedSize(events)
+    const wrapper = mount.querySelector<HTMLElement>('.replayer-wrapper')
+    let observer: ResizeObserver | null = null
+    if (wrapper) {
+      wrapper.style.position = 'absolute'
+      wrapper.style.transformOrigin = 'top left'
+      const applyScale = (): void => {
+        const rect = mount.getBoundingClientRect()
+        if (rect.width === 0 || rect.height === 0) return
+        const scale = Math.min(rect.width / recordedW, rect.height / recordedH)
+        const scaledW = recordedW * scale
+        const scaledH = recordedH * scale
+        wrapper.style.transform = `scale(${scale})`
+        wrapper.style.left = `${Math.max(0, (rect.width - scaledW) / 2)}px`
+        wrapper.style.top = `${Math.max(0, (rect.height - scaledH) / 2)}px`
+      }
+      applyScale()
+      observer = new ResizeObserver(applyScale)
+      observer.observe(mount)
+    }
+
     onReady({
       // `pause(timeOffset)` jumps to that time and pauses. We pause
       // rather than play so our scaffold's playback clock stays the
@@ -143,6 +197,7 @@ function PlayerCanvas({ events, onReady }: PlayerCanvasProps) {
       pause: () => replayer.pause(replayer.getCurrentTime()),
     })
     return () => {
+      observer?.disconnect()
       try {
         replayer.destroy()
       } catch {
@@ -155,7 +210,7 @@ function PlayerCanvas({ events, onReady }: PlayerCanvasProps) {
   return (
     <div
       ref={mountRef}
-      className="flex flex-1 items-center justify-center"
+      className="relative flex-1 overflow-hidden"
       data-replay-canvas
     />
   )

--- a/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
@@ -113,12 +113,11 @@ function PlayerCanvas({ events, onReady }: PlayerCanvasProps) {
 
     // Strip the cockpit annotations so rrweb sees its canonical
     // {type, data, timestamp} shape.
-    // biome-ignore lint/suspicious/noExplicitAny: rrweb's event
-    // union is wide; we trust the recorder's output shape.
     const rrwebEvents = events.map((e) => ({
       type: e.type,
       data: e.data,
       timestamp: e.ts,
+      // biome-ignore lint/suspicious/noExplicitAny: rrweb's event union is wide; we trust the recorder's output shape.
     })) as any[]
 
     mount.replaceChildren()

--- a/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
@@ -59,9 +59,14 @@ export function ReplayViewport({
   events,
   onPlayerReady,
 }: ReplayViewportProps) {
+  // Prefer the current frame's full URL so the address bar shows
+  // exactly where the agent was at this instant. Falls back to the
+  // task-level site (a hostname) when the frame carries no url
+  // (e.g. `run`, `windows`, `tab_groups` dispatches).
+  const addressBar = frame?.url ?? site
   return (
     <div className="relative flex flex-1 flex-col overflow-hidden rounded-2xl border border-border-2 bg-card shadow-sm">
-      <Chrome site={site} />
+      <Chrome url={addressBar} />
       <div className="relative flex flex-1 items-stretch justify-center overflow-hidden bg-bg-sunken">
         <PlayerCanvas events={events} onReady={onPlayerReady} />
         {frame && <Caption frame={frame} />}
@@ -70,7 +75,7 @@ export function ReplayViewport({
   )
 }
 
-function Chrome({ site }: { site: string }) {
+function Chrome({ url }: { url: string }) {
   return (
     <div className="flex h-9 shrink-0 items-center gap-2 border-border border-b bg-bg-sunken px-3">
       <span className="flex gap-1.5">
@@ -80,11 +85,8 @@ function Chrome({ site }: { site: string }) {
       </span>
       <div className="ml-3 flex h-6 flex-1 items-center gap-2 rounded-md border border-border-2 bg-card px-3 font-mono text-ink-2 text-xs">
         <Lock className="size-3 text-ink-3" />
-        <span className="truncate">{site}</span>
+        <span className="truncate">{url}</span>
       </div>
-      <span className="rounded-full bg-bg-sunken px-2 py-0.5 font-bold text-[10px] text-ink-3 uppercase tracking-wide">
-        rrweb
-      </span>
     </div>
   )
 }
@@ -111,12 +113,12 @@ function PlayerCanvas({ events, onReady }: PlayerCanvasProps) {
 
     // Strip the cockpit annotations so rrweb sees its canonical
     // {type, data, timestamp} shape.
+    // biome-ignore lint/suspicious/noExplicitAny: rrweb's event
+    // union is wide; we trust the recorder's output shape.
     const rrwebEvents = events.map((e) => ({
       type: e.type,
       data: e.data,
       timestamp: e.ts,
-      // biome-ignore lint/suspicious/noExplicitAny: rrweb's event
-      // union is wide; we trust the recorder's output shape.
     })) as any[]
 
     mount.replaceChildren()

--- a/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
@@ -6,9 +6,9 @@
  * Replay viewport for the audit page. The original scaffold drew a
  * fake browser chrome with a tinted page region and a caption pill.
  * This version mounts rrweb-player inside that chrome so the actual
- * recorded DOM mutations play back. A tab selector above the chrome
- * lets the operator switch between tabs the agent drove in the same
- * session.
+ * recorded DOM mutations play back. Tab selection lives at the
+ * page level (see `Replay.tsx`) as a prominent shadcn Tabs bar; the
+ * viewport itself just renders the currently-selected tab's events.
  *
  * The player's built-in controller is hidden via `showController:
  * false`; PlaybackTransport (see use-playback wiring) is the single
@@ -49,10 +49,6 @@ interface ReplayViewportProps {
   frame: ReplayFrame | undefined
   /** rrweb events for the currently-selected tabPageId. */
   events: ReplayEvent[]
-  /** Distinct tabPageIds the operator can pick from. */
-  tabPageIds: number[]
-  selectedTabPageId: number | null
-  onTabPageIdChange: (id: number) => void
   /** Called once the rrweb-player has mounted with usable controls. */
   onPlayerReady: (handle: ReplayPlayerHandle) => void
 }
@@ -61,19 +57,11 @@ export function ReplayViewport({
   site,
   frame,
   events,
-  tabPageIds,
-  selectedTabPageId,
-  onTabPageIdChange,
   onPlayerReady,
 }: ReplayViewportProps) {
   return (
     <div className="relative flex flex-1 flex-col overflow-hidden rounded-2xl border border-border-2 bg-card shadow-sm">
-      <Chrome
-        site={site}
-        tabPageIds={tabPageIds}
-        selectedTabPageId={selectedTabPageId}
-        onTabPageIdChange={onTabPageIdChange}
-      />
+      <Chrome site={site} />
       <div className="relative flex flex-1 items-stretch justify-center overflow-hidden bg-bg-sunken">
         <PlayerCanvas events={events} onReady={onPlayerReady} />
         {frame && <Caption frame={frame} />}
@@ -82,19 +70,7 @@ export function ReplayViewport({
   )
 }
 
-interface ChromeProps {
-  site: string
-  tabPageIds: number[]
-  selectedTabPageId: number | null
-  onTabPageIdChange: (id: number) => void
-}
-
-function Chrome({
-  site,
-  tabPageIds,
-  selectedTabPageId,
-  onTabPageIdChange,
-}: ChromeProps) {
+function Chrome({ site }: { site: string }) {
   return (
     <div className="flex h-9 shrink-0 items-center gap-2 border-border border-b bg-bg-sunken px-3">
       <span className="flex gap-1.5">
@@ -106,20 +82,6 @@ function Chrome({
         <Lock className="size-3 text-ink-3" />
         <span className="truncate">{site}</span>
       </div>
-      {tabPageIds.length > 1 && (
-        <select
-          aria-label="Tab to replay"
-          value={selectedTabPageId ?? ''}
-          onChange={(e) => onTabPageIdChange(Number(e.target.value))}
-          className="h-6 rounded-md border border-border-2 bg-card px-2 font-mono text-[11px] text-ink-2"
-        >
-          {tabPageIds.map((id) => (
-            <option key={id} value={id}>
-              Tab {id}
-            </option>
-          ))}
-        </select>
-      )}
       <span className="rounded-full bg-bg-sunken px-2 py-0.5 font-bold text-[10px] text-ink-3 uppercase tracking-wide">
         rrweb
       </span>

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
@@ -185,6 +185,8 @@ function mapDispatchToFrame(
     verb,
     node,
     caption,
+    url: row.url,
+    pageId: row.pageId,
     note,
     dispatchId: row.id,
   }

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
@@ -110,13 +110,21 @@ function buildReplayData(task: TaskDetail, events: ReplayEvent[]): ReplayData {
     mapDispatchToFrame(row, sessionStartMs),
   )
 
-  const tabsForEvents = new Set<number>()
+  // Preserve first-appearance order for the tab list so per-tab
+  // labels (Tab 1, Tab 2, ...) match the operator's mental
+  // narrative and align with the audit view's sequential
+  // numbering. The raw BrowserOS pageId is non-contiguous and not
+  // useful to surface as a label.
+  const tabsInOrder: number[] = []
   const eventsByTab = new Map<number, ReplayEvent[]>()
   for (const ev of events) {
-    tabsForEvents.add(ev.tabPageId)
     const list = eventsByTab.get(ev.tabPageId)
-    if (list) list.push(ev)
-    else eventsByTab.set(ev.tabPageId, [ev])
+    if (list) {
+      list.push(ev)
+    } else {
+      eventsByTab.set(ev.tabPageId, [ev])
+      tabsInOrder.push(ev.tabPageId)
+    }
   }
 
   return {
@@ -133,7 +141,7 @@ function buildReplayData(task: TaskDetail, events: ReplayEvent[]): ReplayData {
     approvals: String(countApprovals(task.dispatches)),
     totalSeconds: totalMs / 1000,
     frames,
-    tabPageIds: [...tabsForEvents].sort((a, b) => a - b),
+    tabPageIds: tabsInOrder,
     eventsForTab: (id) => eventsByTab.get(id) ?? [],
   }
 }

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
@@ -50,6 +50,13 @@ export interface ReplayData {
   status: RunStatus
   site: string
   startedAt: string
+  /**
+   * Raw session start in ms since epoch. Used by `buildTabView` to
+   * translate a frame's session-relative `t` into tab-relative time.
+   * `startedAt` above is the formatted date string; this is the
+   * machine-readable original.
+   */
+  startedAtMs: number
   duration: string
   /** Stat strip displayed in the header. Strings are presentation. */
   tokens: string
@@ -63,6 +70,16 @@ export interface ReplayData {
   /** Filter helper: events scoped to one tabPageId. */
   eventsForTab: (tabPageId: number) => ReplayEvent[]
 }
+
+// `buildTabView` and the `TabView` shape live in `./tab-view.ts` so
+// tests can import them without dragging the react-query-kit hook
+// graph. Re-exported here for backward-compat with existing
+// callers that reach it through this module.
+export {
+  buildTabView,
+  EMPTY_TAB_VIEW,
+  type TabView,
+} from './tab-view'
 
 export interface UseReplayDataResult {
   replay: ReplayData | null
@@ -135,6 +152,7 @@ function buildReplayData(task: TaskDetail, events: ReplayEvent[]): ReplayData {
     status: mapTaskStatus(task.status),
     site: task.site ?? 'about:blank',
     startedAt: formatStartedAt(task.startedAt),
+    startedAtMs: sessionStartMs,
     duration: formatDuration(totalMs),
     tokens: '-',
     steps: String(task.dispatchCount),

--- a/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.test.ts
@@ -1,0 +1,123 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Pure unit tests for `buildTabView`. Lives in `tab-view.ts` (not
+ * `replay.data.ts`) so bun test does not import the react-query-kit
+ * hook graph, which sibling tests `mock.module`-poison globally.
+ */
+
+import { describe, expect, it } from 'bun:test'
+import type { ReplayEvent, ReplayFrame } from '@/modules/api/replay.hooks'
+import { type BuildTabViewInput, buildTabView } from './tab-view'
+
+function frame(
+  t: number,
+  pageId: number | null,
+  extra: Partial<ReplayFrame> = {},
+): ReplayFrame {
+  return {
+    t,
+    kind: 'action',
+    verb: 'read',
+    node: 'test',
+    caption: 'test',
+    pageId,
+    ...extra,
+  }
+}
+
+function event(ts: number, tabPageId: number): ReplayEvent {
+  return { sessionId: 'test', tabPageId, type: 3, data: {}, ts }
+}
+
+function makeInput(
+  overrides: Partial<BuildTabViewInput> = {},
+): BuildTabViewInput {
+  return {
+    frames: [],
+    eventsForTab: () => [],
+    startedAtMs: 1_000_000,
+    ...overrides,
+  }
+}
+
+describe('buildTabView', () => {
+  it('returns EMPTY for null tabPageId', () => {
+    const v = buildTabView(makeInput(), null)
+    expect(v.frames).toEqual([])
+    expect(v.events).toEqual([])
+    expect(v.totalSeconds).toBe(0)
+  })
+
+  it('returns EMPTY when the tab has no frames AND no events', () => {
+    const v = buildTabView(makeInput({ frames: [frame(5, 1)] }), 42)
+    expect(v.frames).toEqual([])
+    expect(v.events).toEqual([])
+    expect(v.totalSeconds).toBe(0)
+  })
+
+  it('filters frames to only the target tab', () => {
+    const v = buildTabView(
+      makeInput({
+        frames: [frame(1, 1), frame(2, 4), frame(3, 1), frame(4, 5)],
+      }),
+      1,
+    )
+    expect(v.frames).toHaveLength(2)
+    expect(v.frames.map((f) => f.pageId)).toEqual([1, 1])
+  })
+
+  it('shifts frame `t` to be tab-relative (first frame at t=0)', () => {
+    // Session started at 1_000_000 ms; frame at t=5 means the tab's
+    // first activity is 5 seconds into the session. In tab-relative
+    // time that first frame is at t=0.
+    const v = buildTabView(
+      makeInput({
+        frames: [frame(5, 7), frame(8, 7), frame(12, 7)],
+        eventsForTab: () => [event(1_005_000, 7), event(1_012_000, 7)],
+      }),
+      7,
+    )
+    expect(v.frames.map((f) => f.t)).toEqual([0, 3, 7])
+  })
+
+  it('totalSeconds = tab activity window (last event - first event)', () => {
+    const v = buildTabView(
+      makeInput({
+        frames: [frame(3, 1), frame(6, 1)],
+        eventsForTab: () => [event(1_003_000, 1), event(1_007_500, 1)],
+      }),
+      1,
+    )
+    // 7500 - 3000 = 4500 ms = 4.5s
+    expect(v.totalSeconds).toBeCloseTo(4.5)
+  })
+
+  it('falls back to frame timespan when no events exist', () => {
+    const v = buildTabView(
+      makeInput({
+        frames: [frame(2, 9), frame(10, 9)],
+        eventsForTab: () => [],
+      }),
+      9,
+    )
+    // 10 - 2 = 8 seconds
+    expect(v.totalSeconds).toBe(8)
+    expect(v.frames.map((f) => f.t)).toEqual([0, 8])
+  })
+
+  it('preserves other frame fields when shifting `t`', () => {
+    const v = buildTabView(
+      makeInput({
+        frames: [frame(5, 3, { verb: 'navigate', url: 'https://example.com' })],
+      }),
+      3,
+    )
+    expect(v.frames[0]?.verb).toBe('navigate')
+    expect(v.frames[0]?.url).toBe('https://example.com')
+    expect(v.frames[0]?.pageId).toBe(3)
+    expect(v.frames[0]?.t).toBe(0)
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.ts
@@ -1,0 +1,80 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Pure `buildTabView` helper. Kept in its own file (not
+ * `replay.data.ts`) so tests can import it without dragging the
+ * whole react-query-kit hook graph, which some sibling tests
+ * `mock.module`-poison in ways that break transitively.
+ *
+ * See the replay tab-driven architecture plan for the rationale
+ * and the surrounding refactor.
+ */
+
+import type { ReplayEvent, ReplayFrame } from '@/modules/api/replay.hooks'
+
+/**
+ * A single tab's replay view. All fields are scoped to one
+ * `tabPageId`:
+ *   - `frames`: filtered AND time-shifted so `t=0` is the tab's
+ *     first activity, not session start.
+ *   - `events`: pass-through. rrweb's Replayer treats the first
+ *     event's `ts` as its playback origin, so a tab-relative
+ *     `playback.time` maps 1:1 to `goto(time*1000)`.
+ *   - `totalSeconds`: duration of this tab's activity window (from
+ *     first event to last event). 0 for empty tabs.
+ */
+export interface TabView {
+  frames: ReplayFrame[]
+  events: ReplayEvent[]
+  totalSeconds: number
+}
+
+export const EMPTY_TAB_VIEW: TabView = {
+  frames: [],
+  events: [],
+  totalSeconds: 0,
+}
+
+export interface BuildTabViewInput {
+  /** Session-scoped frames (any pageId). */
+  frames: ReplayFrame[]
+  /**
+   * The events lookup for the selected tab. Called once at most;
+   * returning an empty array means the tab has no rrweb data.
+   */
+  eventsForTab: (tabPageId: number) => ReplayEvent[]
+  /** Session start in ms since epoch. Anchor for frame `t` values. */
+  startedAtMs: number
+}
+
+/**
+ * Pure. O(N) over frames. Callers should memoise per
+ * (input, tabPageId) pair.
+ */
+export function buildTabView(
+  input: BuildTabViewInput,
+  tabPageId: number | null,
+): TabView {
+  if (tabPageId === null) return EMPTY_TAB_VIEW
+  const rawFrames = input.frames.filter((f) => f.pageId === tabPageId)
+  const events = input.eventsForTab(tabPageId)
+  if (rawFrames.length === 0 && events.length === 0) return EMPTY_TAB_VIEW
+  const startedMs = input.startedAtMs
+  const originMs =
+    events.length > 0
+      ? events[0]?.ts
+      : startedMs + (rawFrames[0]?.t ?? 0) * 1000
+  const endMs =
+    events.length > 0
+      ? events[events.length - 1]?.ts
+      : startedMs + (rawFrames[rawFrames.length - 1]?.t ?? 0) * 1000
+  const totalSeconds = Math.max(0, (endMs - originMs) / 1000)
+  const originT = (originMs - startedMs) / 1000
+  const frames = rawFrames.map((f) => ({
+    ...f,
+    t: Math.max(0, f.t - originT),
+  }))
+  return { frames, events, totalSeconds }
+}

--- a/packages/browseros-agent/apps/claw-app/screens/task-detail/TabView.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/task-detail/TabView.tsx
@@ -1,0 +1,66 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Renders a single `TabGroup`'s body: a small context header
+ * (URL / title), the filtered ScreenshotStrip, and the filtered
+ * Timeline. Session groups additionally show the SessionEndRow
+ * inside their Timeline; per-page groups hide it because the
+ * session end is not scoped to any one tab.
+ */
+
+import { ScreenshotStrip } from '@/components/audit/ScreenshotStrip'
+import { Timeline } from '@/components/audit/Timeline'
+import type { TabGroup } from './task-detail.helpers'
+
+export interface TabViewProps {
+  group: TabGroup
+  startedAt: number
+  endEvent: {
+    createdAt: number
+    kind: 'closed' | 'errored'
+    reason: string | null
+  } | null
+  onScreenshotClick: (dispatchId: number) => void
+}
+
+export function TabView({
+  group,
+  startedAt,
+  endEvent,
+  onScreenshotClick,
+}: TabViewProps) {
+  const isSession = group.id === 'session'
+  return (
+    <div className="space-y-4">
+      {(group.displayUrl || group.displayTitle) && (
+        <div className="rounded-2xl border border-border-2 bg-card px-4 py-3 text-[12.5px] text-ink-3">
+          <div className="font-semibold text-ink-1">{group.label}</div>
+          {group.displayUrl && (
+            <div className="truncate font-mono text-[11.5px]">
+              {group.displayUrl}
+            </div>
+          )}
+          {group.displayTitle && (
+            <div className="truncate">{group.displayTitle}</div>
+          )}
+        </div>
+      )}
+      <ScreenshotStrip
+        dispatches={group.dispatches}
+        screenshotDispatchIds={group.screenshotDispatchIds}
+        startedAt={startedAt}
+        onSelect={onScreenshotClick}
+      />
+      <Timeline
+        dispatches={group.dispatches}
+        screenshotDispatchIds={group.screenshotDispatchIds}
+        startedAt={startedAt}
+        endEvent={isSession ? endEvent : null}
+        showSessionEnd={isSession}
+        onScreenshotClick={onScreenshotClick}
+      />
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/claw-app/screens/task-detail/TaskDetailPage.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/task-detail/TaskDetailPage.tsx
@@ -84,7 +84,11 @@ export function TaskDetailPage() {
   return (
     <div className="mx-auto w-full max-w-5xl space-y-6 px-8 pt-10 pb-20">
       <TaskHeader task={task} />
-      <AutoHideTabs items={items} defaultId={pickDefaultTabId(groups)} />
+      <AutoHideTabs
+        items={items}
+        defaultId={pickDefaultTabId(groups)}
+        listVariant="line"
+      />
       <ScreenshotLightbox
         dispatchId={lightboxId}
         onClose={() => setLightboxId(null)}

--- a/packages/browseros-agent/apps/claw-app/screens/task-detail/TaskDetailPage.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/task-detail/TaskDetailPage.tsx
@@ -1,12 +1,16 @@
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 import { useParams } from 'react-router'
 import { ScreenshotLightbox } from '@/components/audit/ScreenshotLightbox'
-import { ScreenshotStrip } from '@/components/audit/ScreenshotStrip'
 import { TaskHeader } from '@/components/audit/TaskHeader'
-import { Timeline } from '@/components/audit/Timeline'
 import { EmptyState } from '@/components/cockpit/EmptyState'
 import { Skeleton } from '@/components/ui/skeleton'
+import {
+  AutoHideTabs,
+  type AutoHideTabsItem,
+} from '@/components/ui/tabs-auto-hide'
+import { TabView } from './TabView'
 import { useTaskDetailScreenData } from './task-detail.data'
+import { groupDispatchesByTab, pickDefaultTabId } from './task-detail.helpers'
 
 /**
  * Full-page view of one MCP task. Reached from the homepage card
@@ -14,16 +18,24 @@ import { useTaskDetailScreenData } from './task-detail.data'
  *
  *   - TaskHeader     header card with agent, status, timestamps,
  *                    primary actions
- *   - ScreenshotStrip horizontal gallery of every screenshot the
- *                    task captured (clicks open the lightbox)
- *   - Timeline       vertical rail of every dispatch (HIGH RISK
- *                    rows auto-expand)
- *   - Lightbox       shadcn Dialog for the full-size view
+ *   - AutoHideTabs   one tab per distinct pageId plus a leftmost
+ *                    "Session" tab for pageId-less dispatches. When
+ *                    the task touched exactly one bucket the tab
+ *                    bar hides and the single view renders inline.
+ *   - Lightbox       shadcn Dialog for the full-size screenshot
  */
 export function TaskDetailPage() {
   const { sessionId = '' } = useParams()
   const { task, isPending, isError, error } = useTaskDetailScreenData(sessionId)
   const [lightboxId, setLightboxId] = useState<number | null>(null)
+
+  const groups = useMemo(
+    () =>
+      task
+        ? groupDispatchesByTab(task.dispatches, task.screenshotDispatchIds)
+        : [],
+    [task],
+  )
 
   if (isPending) {
     return (
@@ -49,22 +61,30 @@ export function TaskDetailPage() {
     )
   }
 
-  return (
-    <div className="mx-auto w-full max-w-5xl space-y-6 px-8 pt-10 pb-20">
-      <TaskHeader task={task} />
-      <ScreenshotStrip
-        dispatches={task.dispatches}
-        screenshotDispatchIds={task.screenshotDispatchIds}
-        startedAt={task.startedAt}
-        onSelect={setLightboxId}
-      />
-      <Timeline
-        dispatches={task.dispatches}
-        screenshotDispatchIds={task.screenshotDispatchIds}
+  const items: AutoHideTabsItem[] = groups.map((g) => ({
+    id: g.id,
+    label: (
+      <span className="inline-flex items-center gap-1.5">
+        <span>{g.label}</span>
+        <span className="rounded bg-muted px-1.5 py-0.5 font-mono text-[10.5px] text-ink-3">
+          {g.dispatchCount}
+        </span>
+      </span>
+    ),
+    content: (
+      <TabView
+        group={g}
         startedAt={task.startedAt}
         endEvent={task.endEvent}
         onScreenshotClick={setLightboxId}
       />
+    ),
+  }))
+
+  return (
+    <div className="mx-auto w-full max-w-5xl space-y-6 px-8 pt-10 pb-20">
+      <TaskHeader task={task} />
+      <AutoHideTabs items={items} defaultId={pickDefaultTabId(groups)} />
       <ScreenshotLightbox
         dispatchId={lightboxId}
         onClose={() => setLightboxId(null)}

--- a/packages/browseros-agent/apps/claw-app/screens/task-detail/task-detail.helpers.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/task-detail/task-detail.helpers.test.ts
@@ -1,0 +1,159 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, it } from 'bun:test'
+import type { ToolDispatchRow } from '@/modules/api/audit.hooks'
+import { groupDispatchesByTab, pickDefaultTabId } from './task-detail.helpers'
+
+function dispatch(
+  id: number,
+  pageId: number | null,
+  overrides: Partial<ToolDispatchRow> = {},
+): ToolDispatchRow {
+  return {
+    id,
+    createdAt: 1_000_000 + id,
+    agentId: 'codex',
+    slug: 'codex',
+    agentLabel: 'Codex',
+    sessionId: 's',
+    toolName: 'snapshot',
+    pageId,
+    targetId: null,
+    url: null,
+    title: null,
+    argsJson: null,
+    resultMeta: null,
+    durationMs: 5,
+    ...overrides,
+  }
+}
+
+describe('groupDispatchesByTab', () => {
+  it('returns an empty array for zero dispatches', () => {
+    expect(groupDispatchesByTab([], [])).toEqual([])
+  })
+
+  it('groups all null-pageId dispatches into a single Session bucket', () => {
+    const rows = [dispatch(1, null), dispatch(2, null), dispatch(3, null)]
+    const groups = groupDispatchesByTab(rows, [])
+    expect(groups).toHaveLength(1)
+    expect(groups[0]!.id).toBe('session')
+    expect(groups[0]!.label).toBe('Session')
+    expect(groups[0]!.pageId).toBeNull()
+    expect(groups[0]!.dispatchCount).toBe(3)
+    expect(groups[0]!.dispatches.map((d) => d.id)).toEqual([1, 2, 3])
+  })
+
+  it('single pageId with no null dispatches yields exactly one page bucket', () => {
+    const rows = [
+      dispatch(1, 7, { url: 'https://a.example/', title: 'A' }),
+      dispatch(2, 7, { url: 'https://a.example/next', title: 'A2' }),
+    ]
+    const groups = groupDispatchesByTab(rows, [])
+    expect(groups).toHaveLength(1)
+    expect(groups[0]!.id).toBe('page-7')
+    expect(groups[0]!.label).toBe('Page 7')
+    expect(groups[0]!.dispatchCount).toBe(2)
+  })
+
+  it('mixed session + pages produces Session first, then ascending pageIds', () => {
+    const rows = [
+      dispatch(1, null),
+      dispatch(2, 7),
+      dispatch(3, 1),
+      dispatch(4, null),
+      dispatch(5, 3),
+      dispatch(6, 7),
+      dispatch(7, 3),
+      dispatch(8, 1),
+    ]
+    const groups = groupDispatchesByTab(rows, [])
+    expect(groups.map((g) => g.id)).toEqual([
+      'session',
+      'page-1',
+      'page-3',
+      'page-7',
+    ])
+    expect(groups[0]!.dispatchCount).toBe(2)
+    expect(groups[1]!.dispatchCount).toBe(2)
+    expect(groups[2]!.dispatchCount).toBe(2)
+    expect(groups[3]!.dispatchCount).toBe(2)
+  })
+
+  it('preserves chronological order inside each group', () => {
+    const rows = [
+      dispatch(1, 5),
+      dispatch(2, null),
+      dispatch(3, 5),
+      dispatch(4, 5),
+      dispatch(5, null),
+    ]
+    const groups = groupDispatchesByTab(rows, [])
+    expect(
+      groups.find((g) => g.id === 'session')!.dispatches.map((d) => d.id),
+    ).toEqual([2, 5])
+    expect(
+      groups.find((g) => g.id === 'page-5')!.dispatches.map((d) => d.id),
+    ).toEqual([1, 3, 4])
+  })
+
+  it('displayUrl uses the LAST non-null url observed in the group', () => {
+    const rows = [
+      dispatch(1, 7, { url: 'https://first.example/', title: 'First' }),
+      dispatch(2, 7, { url: null, title: null }),
+      dispatch(3, 7, { url: 'https://latest.example/', title: 'Latest' }),
+      dispatch(4, 7, { url: null, title: null }),
+    ]
+    const g = groupDispatchesByTab(rows, [])[0]!
+    expect(g.displayUrl).toBe('https://latest.example/')
+    expect(g.displayTitle).toBe('Latest')
+  })
+
+  it('displayUrl is null when every url in the group is null', () => {
+    const rows = [dispatch(1, 9), dispatch(2, 9)]
+    const g = groupDispatchesByTab(rows, [])[0]!
+    expect(g.displayUrl).toBeNull()
+    expect(g.displayTitle).toBeNull()
+  })
+
+  it('screenshotDispatchIds filters allScreenshotIds to this group only', () => {
+    const rows = [
+      dispatch(1, null),
+      dispatch(2, 3),
+      dispatch(3, 3),
+      dispatch(4, 7),
+      dispatch(5, 7),
+    ]
+    // Assume screenshots exist for ids 1, 3, 5 (mixed groups).
+    const groups = groupDispatchesByTab(rows, [1, 3, 5])
+    expect(
+      groups.find((g) => g.id === 'session')!.screenshotDispatchIds,
+    ).toEqual([1])
+    expect(
+      groups.find((g) => g.id === 'page-3')!.screenshotDispatchIds,
+    ).toEqual([3])
+    expect(
+      groups.find((g) => g.id === 'page-7')!.screenshotDispatchIds,
+    ).toEqual([5])
+  })
+})
+
+describe('pickDefaultTabId', () => {
+  it('returns the first non-session page tab when one exists', () => {
+    const rows = [dispatch(1, null), dispatch(2, 3), dispatch(3, 7)]
+    expect(pickDefaultTabId(groupDispatchesByTab(rows, []))).toBe('page-3')
+  })
+
+  it('falls back to session when no page tabs exist', () => {
+    const rows = [dispatch(1, null), dispatch(2, null)]
+    expect(pickDefaultTabId(groupDispatchesByTab(rows, []))).toBe('session')
+  })
+
+  it('returns undefined for an empty group list', () => {
+    expect(pickDefaultTabId([])).toBeUndefined()
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/screens/task-detail/task-detail.helpers.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/task-detail/task-detail.helpers.test.ts
@@ -37,7 +37,7 @@ describe('groupDispatchesByTab', () => {
     expect(groupDispatchesByTab([], [])).toEqual([])
   })
 
-  it('groups all null-pageId dispatches into a single Session bucket', () => {
+  it('all null-pageId dispatches yields a Session bucket only (no page tabs)', () => {
     const rows = [dispatch(1, null), dispatch(2, null), dispatch(3, null)]
     const groups = groupDispatchesByTab(rows, [])
     expect(groups).toHaveLength(1)
@@ -48,43 +48,63 @@ describe('groupDispatchesByTab', () => {
     expect(groups[0]!.dispatches.map((d) => d.id)).toEqual([1, 2, 3])
   })
 
-  it('single pageId with no null dispatches yields exactly one page bucket', () => {
+  it('single pageId + zero null dispatches yields Session + one page tab', () => {
     const rows = [
       dispatch(1, 7, { url: 'https://a.example/', title: 'A' }),
       dispatch(2, 7, { url: 'https://a.example/next', title: 'A2' }),
     ]
     const groups = groupDispatchesByTab(rows, [])
-    expect(groups).toHaveLength(1)
-    expect(groups[0]!.id).toBe('page-7')
-    expect(groups[0]!.label).toBe('Page 7')
+    expect(groups).toHaveLength(2)
+    expect(groups[0]!.id).toBe('session')
     expect(groups[0]!.dispatchCount).toBe(2)
+    expect(groups[1]!.id).toBe('page-7')
+    expect(groups[1]!.label).toBe('Tab 1')
   })
 
-  it('mixed session + pages produces Session first, then ascending pageIds', () => {
+  it('page tabs are labelled sequentially by first-appearance order (Tab 1, Tab 2, ...) not by raw pageId', () => {
+    // codex may open pageIds 43, 21, 55 in that chronological order.
+    // We want Tab 1 -> 43, Tab 2 -> 21, Tab 3 -> 55.
+    const rows = [
+      dispatch(1, 43),
+      dispatch(2, 21),
+      dispatch(3, 43),
+      dispatch(4, 55),
+      dispatch(5, 21),
+    ]
+    const groups = groupDispatchesByTab(rows, [])
+    const pageGroups = groups.filter((g) => g.id !== 'session')
+    expect(pageGroups.map((g) => g.label)).toEqual(['Tab 1', 'Tab 2', 'Tab 3'])
+    expect(pageGroups.map((g) => g.pageId)).toEqual([43, 21, 55])
+  })
+
+  it('Session bucket contains EVERY dispatch (overview semantics)', () => {
     const rows = [
       dispatch(1, null),
       dispatch(2, 7),
       dispatch(3, 1),
       dispatch(4, null),
       dispatch(5, 3),
-      dispatch(6, 7),
-      dispatch(7, 3),
-      dispatch(8, 1),
     ]
     const groups = groupDispatchesByTab(rows, [])
-    expect(groups.map((g) => g.id)).toEqual([
-      'session',
-      'page-1',
-      'page-3',
-      'page-7',
-    ])
-    expect(groups[0]!.dispatchCount).toBe(2)
-    expect(groups[1]!.dispatchCount).toBe(2)
-    expect(groups[2]!.dispatchCount).toBe(2)
-    expect(groups[3]!.dispatchCount).toBe(2)
+    const session = groups.find((g) => g.id === 'session')!
+    expect(session.dispatchCount).toBe(5)
+    expect(session.dispatches.map((d) => d.id)).toEqual([1, 2, 3, 4, 5])
   })
 
-  it('preserves chronological order inside each group', () => {
+  it('Session bucket contains EVERY screenshot (overview semantics)', () => {
+    const rows = [
+      dispatch(1, null),
+      dispatch(2, 3),
+      dispatch(3, 3),
+      dispatch(4, 7),
+      dispatch(5, 7),
+    ]
+    const groups = groupDispatchesByTab(rows, [1, 3, 5])
+    const session = groups.find((g) => g.id === 'session')!
+    expect(session.screenshotDispatchIds).toEqual([1, 3, 5])
+  })
+
+  it('preserves chronological order inside per-page groups', () => {
     const rows = [
       dispatch(1, 5),
       dispatch(2, null),
@@ -94,33 +114,30 @@ describe('groupDispatchesByTab', () => {
     ]
     const groups = groupDispatchesByTab(rows, [])
     expect(
-      groups.find((g) => g.id === 'session')!.dispatches.map((d) => d.id),
-    ).toEqual([2, 5])
-    expect(
       groups.find((g) => g.id === 'page-5')!.dispatches.map((d) => d.id),
     ).toEqual([1, 3, 4])
   })
 
-  it('displayUrl uses the LAST non-null url observed in the group', () => {
+  it('per-page displayUrl uses the LAST non-null url observed in that group', () => {
     const rows = [
       dispatch(1, 7, { url: 'https://first.example/', title: 'First' }),
       dispatch(2, 7, { url: null, title: null }),
       dispatch(3, 7, { url: 'https://latest.example/', title: 'Latest' }),
       dispatch(4, 7, { url: null, title: null }),
     ]
-    const g = groupDispatchesByTab(rows, [])[0]!
+    const g = groupDispatchesByTab(rows, []).find((x) => x.id === 'page-7')!
     expect(g.displayUrl).toBe('https://latest.example/')
     expect(g.displayTitle).toBe('Latest')
   })
 
-  it('displayUrl is null when every url in the group is null', () => {
+  it('per-page displayUrl is null when every url in the group is null', () => {
     const rows = [dispatch(1, 9), dispatch(2, 9)]
-    const g = groupDispatchesByTab(rows, [])[0]!
+    const g = groupDispatchesByTab(rows, []).find((x) => x.id === 'page-9')!
     expect(g.displayUrl).toBeNull()
     expect(g.displayTitle).toBeNull()
   })
 
-  it('screenshotDispatchIds filters allScreenshotIds to this group only', () => {
+  it('per-page screenshotDispatchIds filters to that page only', () => {
     const rows = [
       dispatch(1, null),
       dispatch(2, 3),
@@ -131,9 +148,6 @@ describe('groupDispatchesByTab', () => {
     // Assume screenshots exist for ids 1, 3, 5 (mixed groups).
     const groups = groupDispatchesByTab(rows, [1, 3, 5])
     expect(
-      groups.find((g) => g.id === 'session')!.screenshotDispatchIds,
-    ).toEqual([1])
-    expect(
       groups.find((g) => g.id === 'page-3')!.screenshotDispatchIds,
     ).toEqual([3])
     expect(
@@ -143,13 +157,18 @@ describe('groupDispatchesByTab', () => {
 })
 
 describe('pickDefaultTabId', () => {
-  it('returns the first non-session page tab when one exists', () => {
+  it('always returns Session when it exists (overview-first)', () => {
     const rows = [dispatch(1, null), dispatch(2, 3), dispatch(3, 7)]
-    expect(pickDefaultTabId(groupDispatchesByTab(rows, []))).toBe('page-3')
+    expect(pickDefaultTabId(groupDispatchesByTab(rows, []))).toBe('session')
   })
 
-  it('falls back to session when no page tabs exist', () => {
+  it('returns Session even for a session-only task', () => {
     const rows = [dispatch(1, null), dispatch(2, null)]
+    expect(pickDefaultTabId(groupDispatchesByTab(rows, []))).toBe('session')
+  })
+
+  it('returns Session even for a page-only task', () => {
+    const rows = [dispatch(1, 5), dispatch(2, 5)]
     expect(pickDefaultTabId(groupDispatchesByTab(rows, []))).toBe('session')
   })
 

--- a/packages/browseros-agent/apps/claw-app/screens/task-detail/task-detail.helpers.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/task-detail/task-detail.helpers.test.ts
@@ -137,6 +137,35 @@ describe('groupDispatchesByTab', () => {
     expect(g.displayTitle).toBeNull()
   })
 
+  it('per-page displayUrl + displayTitle come from the SAME paired dispatch when one exists', () => {
+    // Simulates a mid-navigation dispatch (has url but null title)
+    // FOLLOWED by a load-complete dispatch (has both url + title).
+    // Without the paired-preference guard, `lastWithTitle` might
+    // reach further back and return a stale title next to the
+    // freshest url. With the guard, both come from the last
+    // dispatch that carried them together.
+    const rows = [
+      dispatch(1, 7, { url: 'https://old.example/', title: 'Old title' }),
+      dispatch(2, 7, { url: 'https://new.example/', title: null }),
+      dispatch(3, 7, { url: 'https://new.example/', title: 'New title' }),
+    ]
+    const g = groupDispatchesByTab(rows, []).find((x) => x.id === 'page-7')!
+    expect(g.displayUrl).toBe('https://new.example/')
+    expect(g.displayTitle).toBe('New title')
+  })
+
+  it('per-page displayUrl/displayTitle fall back independently when no paired dispatch exists', () => {
+    // No single dispatch carries both fields; each field falls
+    // back to its own most-recent non-null value.
+    const rows = [
+      dispatch(1, 3, { url: null, title: 'Only title' }),
+      dispatch(2, 3, { url: 'https://only-url.example/', title: null }),
+    ]
+    const g = groupDispatchesByTab(rows, []).find((x) => x.id === 'page-3')!
+    expect(g.displayUrl).toBe('https://only-url.example/')
+    expect(g.displayTitle).toBe('Only title')
+  })
+
   it('per-page screenshotDispatchIds filters to that page only', () => {
     const rows = [
       dispatch(1, null),

--- a/packages/browseros-agent/apps/claw-app/screens/task-detail/task-detail.helpers.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/task-detail/task-detail.helpers.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Pure helpers for the task-detail screen. Isolated from the
+ * screen component so they can be unit-tested against synthetic
+ * dispatch rows without a React tree.
+ */
+
+import type { ToolDispatchRow } from '@/modules/api/audit.hooks'
+
+export interface TabGroup {
+  /**
+   * Stable id used by the shadcn Tabs primitive. `'session'` for
+   * pageId-less dispatches; `'page-${pageId}'` for a real tab.
+   */
+  id: string
+  pageId: number | null
+  /** Human label shown on the tab trigger. */
+  label: string
+  /**
+   * Latest URL observed among this group's dispatches. Null when
+   * every dispatch in the group has a null url (typical for the
+   * Session bucket). Displayed as the tab body's header hint.
+   */
+  displayUrl: string | null
+  displayTitle: string | null
+  /** Chronological subset of the task's dispatches for this group. */
+  dispatches: ToolDispatchRow[]
+  dispatchCount: number
+  /** Subset of `allScreenshotIds` whose dispatch belongs to this group. */
+  screenshotDispatchIds: number[]
+}
+
+/**
+ * Groups a task's dispatch stream into one bucket per distinct
+ * `pageId`, plus a leftmost "Session" bucket for dispatches with
+ * `pageId === null`. Ordering: Session first (if present), then
+ * ascending numeric pageId. Chronological order is preserved
+ * inside each group.
+ *
+ * Complexity: O(N) over dispatches, one pass. Callers should
+ * memoise per task-detail response.
+ */
+export function groupDispatchesByTab(
+  dispatches: ToolDispatchRow[],
+  allScreenshotIds: readonly number[],
+): TabGroup[] {
+  const screenshotSet = new Set(allScreenshotIds)
+  const buckets = new Map<number | 'session', ToolDispatchRow[]>()
+  for (const d of dispatches) {
+    const key: number | 'session' = d.pageId ?? 'session'
+    const arr = buckets.get(key)
+    if (arr) arr.push(d)
+    else buckets.set(key, [d])
+  }
+
+  const groups: TabGroup[] = []
+
+  const sessionRows = buckets.get('session')
+  if (sessionRows && sessionRows.length > 0) {
+    groups.push({
+      id: 'session',
+      pageId: null,
+      label: 'Session',
+      displayUrl: null,
+      displayTitle: null,
+      dispatches: sessionRows,
+      dispatchCount: sessionRows.length,
+      screenshotDispatchIds: sessionRows
+        .map((d) => d.id)
+        .filter((id) => screenshotSet.has(id)),
+    })
+  }
+
+  const pageKeys: number[] = []
+  for (const key of buckets.keys()) {
+    if (typeof key === 'number') pageKeys.push(key)
+  }
+  pageKeys.sort((a, b) => a - b)
+
+  for (const pageId of pageKeys) {
+    const rows = buckets.get(pageId)!
+    const lastWithUrl = [...rows].reverse().find((d) => d.url !== null)
+    const lastWithTitle = [...rows].reverse().find((d) => d.title !== null)
+    groups.push({
+      id: `page-${pageId}`,
+      pageId,
+      label: `Page ${pageId}`,
+      displayUrl: lastWithUrl?.url ?? null,
+      displayTitle: lastWithTitle?.title ?? null,
+      dispatches: rows,
+      dispatchCount: rows.length,
+      screenshotDispatchIds: rows
+        .map((d) => d.id)
+        .filter((id) => screenshotSet.has(id)),
+    })
+  }
+
+  return groups
+}
+
+/**
+ * Picks which tab should be selected first. Prefers the first
+ * real page tab (the operator usually wants to see actual page
+ * activity first); falls back to Session when the task is
+ * pageId-less all the way through.
+ */
+export function pickDefaultTabId(groups: TabGroup[]): string | undefined {
+  const firstPage = groups.find((g) => g.id !== 'session')
+  return firstPage?.id ?? groups[0]?.id
+}

--- a/packages/browseros-agent/apps/claw-app/screens/task-detail/task-detail.helpers.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/task-detail/task-detail.helpers.ts
@@ -97,8 +97,18 @@ export function groupDispatchesByTab(
   // Per-page buckets, numbered by first-appearance order.
   pageOrder.forEach((pageId, idx) => {
     const rows = buckets.get(pageId)!
-    const lastWithUrl = [...rows].reverse().find((d) => d.url !== null)
-    const lastWithTitle = [...rows].reverse().find((d) => d.title !== null)
+    // Prefer a dispatch that carries url + title TOGETHER so the
+    // tab header shows a consistent (url, title) pair from a
+    // single moment in time. If no such paired dispatch exists in
+    // this tab, fall back to the last individual non-null values
+    // independently. The edge case: mid-navigation dispatches may
+    // have a url but null title (or vice versa); without this
+    // guard the header could show a stale title alongside a fresh
+    // url.
+    const reversed = [...rows].reverse()
+    const lastPaired = reversed.find((d) => d.url !== null && d.title !== null)
+    const lastWithUrl = lastPaired ?? reversed.find((d) => d.url !== null)
+    const lastWithTitle = lastPaired ?? reversed.find((d) => d.title !== null)
     groups.push({
       id: `page-${pageId}`,
       pageId,

--- a/packages/browseros-agent/apps/claw-app/screens/task-detail/task-detail.helpers.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/task-detail/task-detail.helpers.ts
@@ -34,11 +34,20 @@ export interface TabGroup {
 }
 
 /**
- * Groups a task's dispatch stream into one bucket per distinct
- * `pageId`, plus a leftmost "Session" bucket for dispatches with
- * `pageId === null`. Ordering: Session first (if present), then
- * ascending numeric pageId. Chronological order is preserved
- * inside each group.
+ * Groups a task's dispatch stream into a leftmost "Session"
+ * overview bucket plus one bucket per distinct `pageId`.
+ *
+ * The Session bucket is the task-level overview: it contains
+ * EVERY dispatch and EVERY screenshot, so the operator can see
+ * the whole task at a glance without picking a specific tab.
+ * Each per-page bucket contains only the dispatches + screenshots
+ * scoped to that tab.
+ *
+ * Page tabs are labelled sequentially (`Tab 1`, `Tab 2`, ...) in
+ * chronological order of first appearance. The underlying BrowserOS
+ * pageId is intentionally not surfaced in the label: it is stable
+ * across the extension's lifetime and can range into the hundreds,
+ * which reads as noise.
  *
  * Complexity: O(N) over dispatches, one pass. Callers should
  * memoise per task-detail response.
@@ -48,46 +57,52 @@ export function groupDispatchesByTab(
   allScreenshotIds: readonly number[],
 ): TabGroup[] {
   const screenshotSet = new Set(allScreenshotIds)
-  const buckets = new Map<number | 'session', ToolDispatchRow[]>()
+  const buckets = new Map<number, ToolDispatchRow[]>()
+  // Preserve first-seen order for the sequential Tab numbering
+  // (agents typically open tabs in chronological order, so this
+  // matches the operator's mental narrative better than sorting
+  // by raw pageId).
+  const pageOrder: number[] = []
   for (const d of dispatches) {
-    const key: number | 'session' = d.pageId ?? 'session'
-    const arr = buckets.get(key)
-    if (arr) arr.push(d)
-    else buckets.set(key, [d])
+    if (d.pageId === null) continue
+    const arr = buckets.get(d.pageId)
+    if (arr) {
+      arr.push(d)
+    } else {
+      buckets.set(d.pageId, [d])
+      pageOrder.push(d.pageId)
+    }
   }
 
   const groups: TabGroup[] = []
 
-  const sessionRows = buckets.get('session')
-  if (sessionRows && sessionRows.length > 0) {
+  // Session overview: EVERY dispatch and EVERY screenshot. This is
+  // the default view when the operator opens the task and does not
+  // yet know which tab they want to drill into.
+  if (dispatches.length > 0) {
     groups.push({
       id: 'session',
       pageId: null,
       label: 'Session',
       displayUrl: null,
       displayTitle: null,
-      dispatches: sessionRows,
-      dispatchCount: sessionRows.length,
-      screenshotDispatchIds: sessionRows
+      dispatches,
+      dispatchCount: dispatches.length,
+      screenshotDispatchIds: dispatches
         .map((d) => d.id)
         .filter((id) => screenshotSet.has(id)),
     })
   }
 
-  const pageKeys: number[] = []
-  for (const key of buckets.keys()) {
-    if (typeof key === 'number') pageKeys.push(key)
-  }
-  pageKeys.sort((a, b) => a - b)
-
-  for (const pageId of pageKeys) {
+  // Per-page buckets, numbered by first-appearance order.
+  pageOrder.forEach((pageId, idx) => {
     const rows = buckets.get(pageId)!
     const lastWithUrl = [...rows].reverse().find((d) => d.url !== null)
     const lastWithTitle = [...rows].reverse().find((d) => d.title !== null)
     groups.push({
       id: `page-${pageId}`,
       pageId,
-      label: `Page ${pageId}`,
+      label: `Tab ${idx + 1}`,
       displayUrl: lastWithUrl?.url ?? null,
       displayTitle: lastWithTitle?.title ?? null,
       dispatches: rows,
@@ -96,18 +111,19 @@ export function groupDispatchesByTab(
         .map((d) => d.id)
         .filter((id) => screenshotSet.has(id)),
     })
-  }
+  })
 
   return groups
 }
 
 /**
- * Picks which tab should be selected first. Prefers the first
- * real page tab (the operator usually wants to see actual page
- * activity first); falls back to Session when the task is
- * pageId-less all the way through.
+ * Picks which tab should be selected first. Prefers the Session
+ * overview so the operator sees the task-wide screenshot strip
+ * and timeline on entry; page tabs are drill-downs. Falls back to
+ * the first available id when Session is absent (e.g. an empty
+ * task).
  */
 export function pickDefaultTabId(groups: TabGroup[]): string | undefined {
-  const firstPage = groups.find((g) => g.id !== 'session')
-  return firstPage?.id ?? groups[0]?.id
+  const session = groups.find((g) => g.id === 'session')
+  return session?.id ?? groups[0]?.id
 }


### PR DESCRIPTION
## Summary

Fixes Issue 6a from the session-lifecycle audit. Multi-tab MCP sessions (codex research workflows that open 5+ tabs) previously rendered as one flat timeline with no visible tab context. The operator could not tell which dispatches happened on which tab without scanning every row.

Post-fix, the task detail page groups dispatches into **shadcn Tabs**, one per distinct `pageId`, plus a leftmost **"Session"** tab for `pageId`-null dispatches (`tabs new`, `run`, `windows`, `tab_groups`). Each tab body renders its own filtered `ScreenshotStrip` + `Timeline`. When the task touched exactly one bucket the tab bar hides and the layout collapses to a single view.

## Before / After

**Before (flat):**
```
[Screenshots: 5 imgs from 5 different tabs, no grouping]
Timeline (18 events)
T+0.0s   tabs   action:new
T+2.3s   read   page:1
T+7.9s   run
T+8.2s   tabs   action:new
T+13.4s  read   page:7
... (flat, no visible tab boundaries)
```

**After (per-tab):**
```
[Session (2)] [Page 1 (1)] [Page 7 (4)] [Page 8 (4)] [Page 9 (3)] [Page 10 (4)]

Page 7   en.wikipedia.org/wiki/2026_European_heatwaves
[Screenshots for Page 7 only]
Timeline (4 events)
T+8.5s   tabs      opened this tab
T+15.9s  read      markdown extract
T+52.1s  snapshot
T+61.4s  tabs      closed by agent
```

**Single-tab session (tab bar hidden):**
```
Page 3   www.google.com/search?q=heat+waves
[Screenshots]
Timeline (4 events)
T+0.0s   navigate
...
```

## Implementation

New files:

| File | LOC | Role |
|---|---|---|
| `components/ui/tabs-auto-hide.tsx` | ~40 | Reusable primitive: 0 items -> null; 1 item -> content only, no bar; 2+ items -> full shadcn Tabs |
| `screens/task-detail/task-detail.helpers.ts` | ~100 | Pure `groupDispatchesByTab(dispatches, allScreenshotIds) -> TabGroup[]` + `pickDefaultTabId()` |
| `screens/task-detail/TabView.tsx` | ~55 | Renders one `TabGroup` as (URL/title header + filtered ScreenshotStrip + filtered Timeline) |

Modified files:

| File | Change |
|---|---|
| `components/audit/Timeline.tsx` | New optional `showSessionEnd?: boolean` prop, default `true`. Existing consumers unchanged; per-tab views pass `false`, only the Session tab passes `true` |
| `screens/task-detail/TaskDetailPage.tsx` | Wires `AutoHideTabs` around per-group `TabView`s. Old direct `ScreenshotStrip` + `Timeline` calls removed |

**Server-side data model unchanged.** All grouping is client-side from the existing `task.dispatches` + `task.screenshotDispatchIds` on the audit detail response.

## Test plan

`screens/task-detail/task-detail.helpers.test.ts` (11 cases):
- Empty input -> empty result.
- All-null pageId -> single Session bucket.
- Single pageId, no nulls -> single Page N bucket.
- Mixed session + pages -> Session first, then ascending pageIds.
- Chronological order preserved inside each group.
- `displayUrl` = LAST non-null url per group.
- `displayUrl` = null when every url in the group is null.
- `screenshotDispatchIds` filtered per-group.
- `pickDefaultTabId` prefers the first page tab.
- `pickDefaultTabId` falls back to Session when no page tabs exist.
- `pickDefaultTabId` returns undefined on empty.

`components/ui/tabs-auto-hide.test.tsx` (3 cases):
- Empty items renders nothing.
- Single item renders content only (no `data-slot="tabs-list"`).
- Two items renders full tabs UI with both trigger labels.

`components/audit/Timeline.test.tsx` (2 new cases):
- Default (no prop) renders `session closed` SessionEndRow (backward compat pin).
- `showSessionEnd={false}` hides the row entirely; dispatch rows still render.

claw-app suite: **130 pass, 0 fail** (baseline 114 + 16 net new). Typecheck clean.

Visual smoke via agent-browser against a self-contained `wxt build:dev` output: homepage renders full palette; audit detail route with a fake session id renders the styled "Task not found" empty state (no runtime errors from the new code paths). Live-data verification will happen against `bun run dev:claw:watch` (PR #1489) once this merges.

## What this does NOT do

- **Does not touch any server code**. Zero changes to `services/tasks.ts`, `register.ts`, etc.
- **Does not enrich the task title** ("Browsed A + N more sites"). Deferred to a follow-up PR to keep this one client-only.
- **Does not solve Issue 6b** (recorder pipeline drops short-lived tabs) or **6c** (multi-tab timeline replay).