### PR TITLE
fix(server): isolate Codex ACP runtime config

### DIFF
--- a/packages/browseros-agent/apps/server/src/agent/acp-launchers.ts
+++ b/packages/browseros-agent/apps/server/src/agent/acp-launchers.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import {
+  ensureRuntimeSkills,
+  materializeCodexHome,
+  resolveAgentRuntimePaths,
+} from '../lib/agents/acpx/runtime-context'
+import { resolveAcpSpawnCommand } from '../lib/agents/host-acp/launcher'
+
+const BUILT_IN_ACP_AGENT_IDS = ['claude', 'codex'] as const
+
+export interface ResolveBuiltInAcpAgentRegistryOverridesInput {
+  readonly browserosDir: string
+  readonly resourcesDir?: string | null
+}
+
+export async function resolveBuiltInAcpAgentRegistryOverrides(
+  input: ResolveBuiltInAcpAgentRegistryOverridesInput,
+): Promise<Record<string, string>> {
+  const overrides: Record<string, string> = {}
+  for (const agentId of BUILT_IN_ACP_AGENT_IDS) {
+    const command = await resolveBuiltInAcpCommand({ ...input, agentId })
+    if (command) overrides[agentId] = command
+  }
+  return overrides
+}
+
+async function resolveBuiltInAcpCommand(input: {
+  readonly agentId: (typeof BUILT_IN_ACP_AGENT_IDS)[number]
+  readonly browserosDir: string
+  readonly resourcesDir?: string | null
+}): Promise<string | null> {
+  if (input.agentId === 'codex') {
+    return resolveCodexCommand(input)
+  }
+  const launcher = resolveAcpSpawnCommand({
+    agentType: input.agentId,
+    browserosDir: input.browserosDir,
+    resourcesDir: input.resourcesDir,
+  })
+  return launcher?.source === 'bundled-bun' ? launcher.command : null
+}
+
+async function resolveCodexCommand(input: {
+  readonly browserosDir: string
+  readonly resourcesDir?: string | null
+}): Promise<string | null> {
+  const baseLauncher = resolveAcpSpawnCommand({
+    agentType: 'codex',
+    browserosDir: input.browserosDir,
+    resourcesDir: input.resourcesDir,
+  })
+  if (baseLauncher?.source !== 'bundled-bun') return null
+
+  const paths = resolveAgentRuntimePaths({
+    browserosDir: input.browserosDir,
+    agentId: 'codex-provider',
+  })
+  const skillNames = await ensureRuntimeSkills(paths.runtimeSkillsDir)
+  await materializeCodexHome({ paths, skillNames })
+
+  const launcher = resolveAcpSpawnCommand({
+    agentType: 'codex',
+    browserosDir: input.browserosDir,
+    resourcesDir: input.resourcesDir,
+    env: { ...process.env, CODEX_HOME: paths.codexHome },
+  })
+  return launcher?.source === 'bundled-bun' ? launcher.command : null
+}

--- a/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
+++ b/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
@@ -17,7 +17,6 @@ import {
   DANGEROUS_ALLOW_MODE_CANDIDATES,
   isHostAcpAdapter,
 } from '../lib/agents/host-acp/config'
-import { resolveAcpSpawnCommand } from '../lib/agents/host-acp/launcher'
 import { getBrowserosDir } from '../lib/browseros-dir'
 import { createBrowserOSFetch } from '../lib/browseros-fetch'
 import {
@@ -29,6 +28,7 @@ import { createCopilotFetch } from '../lib/clients/oauth/copilot-fetch'
 import { logger } from '../lib/logger'
 import { createOpenRouterCompatibleFetch } from '../lib/openrouter-fetch'
 import { ensureWorkspaceInstructionFile } from './acp-instructions/ensureInstructionFile'
+import { resolveBuiltInAcpAgentRegistryOverrides } from './acp-launchers'
 import { ACP_PROVIDER_TYPES, isAcpProvider } from './acp-providers'
 import type { BuildSystemPromptOptions } from './prompt'
 import type { ResolvedAgentConfig } from './types'
@@ -147,22 +147,10 @@ async function createAcpLanguageModel(
       : {}),
   })
 
-  const agentRegistryOverrides: Record<string, string> = {}
-  // Pre-seed the built-in adapters with the bundled-Bun launcher so the
-  // spawned child does not depend on `npx` being on the user's PATH.
-  // We only override when the launcher resolved the bundled binary;
-  // host-npx-fallback would only restate acpx's own registry command,
-  // so we let acpx resolve it directly in that case.
-  for (const builtIn of ['claude', 'codex'] as const) {
-    const launcher = resolveAcpSpawnCommand({
-      agentType: builtIn,
-      browserosDir: getBrowserosDir(),
-      resourcesDir: config.resourcesDir,
-    })
-    if (launcher?.source === 'bundled-bun') {
-      agentRegistryOverrides[builtIn] = launcher.command
-    }
-  }
+  const agentRegistryOverrides = await resolveBuiltInAcpAgentRegistryOverrides({
+    browserosDir: getBrowserosDir(),
+    resourcesDir: config.resourcesDir,
+  })
   if (config.provider === LLM_PROVIDERS.ACP_CUSTOM && config.acpCommand) {
     agentRegistryOverrides[agentId] = config.acpCommand
   }

--- a/packages/browseros-agent/apps/server/src/api/services/acpx-probe/probeAgent.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/acpx-probe/probeAgent.ts
@@ -5,6 +5,11 @@
  */
 
 import { type AgentProbeResult, probeAgent as runProbe } from 'acp-probe'
+import {
+  ensureRuntimeSkills,
+  materializeCodexHome,
+  resolveAgentRuntimePaths,
+} from '../../../lib/agents/acpx/runtime-context'
 import { resolveAcpSpawnCommand } from '../../../lib/agents/host-acp/launcher'
 import { getBrowserosDir } from '../../../lib/browseros-dir'
 import { logger } from '../../../lib/logger'
@@ -89,14 +94,22 @@ export async function probeAcpAgent(
   let agentId = input.agentId
   let command = input.command
   if (!command && agentId) {
+    const browserosDir = input.browserosDir ?? getBrowserosDir()
     const launcher = resolveAcpSpawnCommand({
       agentType: agentId,
-      browserosDir: input.browserosDir ?? getBrowserosDir(),
+      browserosDir,
       resourcesDir: input.resourcesDir,
       platform: input.platform,
     })
     if (launcher?.source === 'bundled-bun') {
-      command = launcher.command
+      command =
+        agentId === 'codex'
+          ? await resolveCodexBundledProbeCommand({
+              browserosDir,
+              resourcesDir: input.resourcesDir,
+              platform: input.platform,
+            })
+          : launcher.command
       agentId = undefined
       logger.debug('ACP probe using bundled-bun launcher', {
         originalAgentId: input.agentId,
@@ -112,6 +125,30 @@ export async function probeAcpAgent(
     timeoutMs,
   })
   return normalizeProbeResult(result)
+}
+
+async function resolveCodexBundledProbeCommand(input: {
+  browserosDir: string
+  resourcesDir?: string | null
+  platform?: NodeJS.Platform
+}): Promise<string> {
+  const paths = resolveAgentRuntimePaths({
+    browserosDir: input.browserosDir,
+    agentId: 'codex-probe',
+  })
+  const skillNames = await ensureRuntimeSkills(paths.runtimeSkillsDir)
+  await materializeCodexHome({ paths, skillNames })
+  const launcher = resolveAcpSpawnCommand({
+    agentType: 'codex',
+    browserosDir: input.browserosDir,
+    resourcesDir: input.resourcesDir,
+    platform: input.platform,
+    env: { ...process.env, CODEX_HOME: paths.codexHome },
+  })
+  if (launcher?.source !== 'bundled-bun') {
+    throw new Error('Bundled Codex probe launcher disappeared')
+  }
+  return launcher.command
 }
 
 // codex-acp encodes effort into the advertised model id when it does not

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx/codex-home.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx/codex-home.ts
@@ -1,0 +1,113 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { constants, type Stats } from 'node:fs'
+import {
+  access,
+  mkdir,
+  readFile,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises'
+import { homedir } from 'node:os'
+import { dirname, join } from 'node:path'
+import type { AgentRuntimePaths } from './runtime-context'
+
+export interface MaterializeCodexHomeInput {
+  readonly paths: AgentRuntimePaths
+  readonly skillNames: readonly string[]
+  readonly sourceCodexHome?: string
+}
+
+export async function materializeCodexHome(
+  input: MaterializeCodexHomeInput,
+): Promise<void> {
+  await mkdir(input.paths.codexHome, { recursive: true })
+  const source =
+    input.sourceCodexHome ??
+    process.env.CODEX_HOME?.trim() ??
+    join(homedir(), '.codex')
+  await symlinkIfPresent(
+    join(source, 'auth.json'),
+    join(input.paths.codexHome, 'auth.json'),
+  )
+  await copyIfPresent(
+    join(source, 'instructions.md'),
+    join(input.paths.codexHome, 'instructions.md'),
+  )
+  for (const name of input.skillNames) {
+    const target = join(input.paths.codexHome, 'skills', name, 'SKILL.md')
+    await writeFileIfPresent(
+      target,
+      await readFile(
+        join(input.paths.runtimeSkillsDir, name, 'SKILL.md'),
+        'utf8',
+      ),
+    )
+  }
+}
+
+async function symlinkIfPresent(source: string, target: string): Promise<void> {
+  if (!(await sourceFileExists(source))) return
+  await mkdir(dirname(target), { recursive: true })
+  try {
+    await symlink(source, target)
+  } catch (err) {
+    if (!isAlreadyExistsError(err)) throw err
+  }
+}
+
+async function copyIfPresent(source: string, target: string): Promise<void> {
+  if (!(await sourceFileExists(source))) return
+  const content = await readFile(source, 'utf8')
+  await writeFileIfPresent(target, content)
+}
+
+async function writeFileIfPresent(
+  path: string,
+  content: string,
+): Promise<void> {
+  await mkdir(dirname(path), { recursive: true })
+  try {
+    await writeFile(path, content, { encoding: 'utf8', flag: 'wx' })
+  } catch (err) {
+    if (!isAlreadyExistsError(err)) throw err
+  }
+}
+
+async function sourceFileExists(path: string): Promise<boolean> {
+  let info: Stats
+  try {
+    info = await stat(path)
+    await access(path, constants.R_OK)
+  } catch (err) {
+    if (isNotFoundError(err)) return false
+    throw err
+  }
+  if (!info.isFile()) {
+    throw new Error(`Expected source file to be a file: ${path}`)
+  }
+  return true
+}
+
+function isNotFoundError(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    err.code === 'ENOENT'
+  )
+}
+
+function isAlreadyExistsError(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    'code' in err &&
+    err.code === 'EEXIST'
+  )
+}

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime-context.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime-context.ts
@@ -5,18 +5,8 @@
  */
 
 import { randomUUID } from 'node:crypto'
-import { constants, type Stats } from 'node:fs'
-import {
-  access,
-  mkdir,
-  readFile,
-  rename,
-  rm,
-  stat,
-  symlink,
-  writeFile,
-} from 'node:fs/promises'
-import { homedir } from 'node:os'
+import type { Stats } from 'node:fs'
+import { mkdir, rename, rm, stat, writeFile } from 'node:fs/promises'
 import { basename, dirname, join, resolve } from 'node:path'
 import {
   type AgentDefinition,
@@ -28,6 +18,8 @@ import {
   RUNTIME_SKILLS,
   SOUL_TEMPLATE,
 } from './runtime-templates'
+
+export { materializeCodexHome } from './codex-home'
 
 export const BROWSEROS_ACPX_OPERATING_PROMPT_VERSION = '2026-05-02.v1'
 
@@ -96,36 +88,6 @@ export async function ensureRuntimeSkills(
     await writeFileAtomic(skillPath, RUNTIME_SKILLS[name])
   }
   return names
-}
-
-/** Prepares the Codex home that the ACP adapter will see through CODEX_HOME. */
-export async function materializeCodexHome(input: {
-  paths: AgentRuntimePaths
-  skillNames: string[]
-  sourceCodexHome?: string
-}): Promise<void> {
-  await mkdir(input.paths.codexHome, { recursive: true })
-  const source =
-    input.sourceCodexHome ??
-    process.env.CODEX_HOME?.trim() ??
-    join(homedir(), '.codex')
-  await symlinkIfPresent(
-    join(source, 'auth.json'),
-    join(input.paths.codexHome, 'auth.json'),
-  )
-  for (const file of ['config.json', 'config.toml', 'instructions.md']) {
-    await copyIfPresent(join(source, file), join(input.paths.codexHome, file))
-  }
-  for (const name of input.skillNames) {
-    const target = join(input.paths.codexHome, 'skills', name, 'SKILL.md')
-    await writeFileAtomic(
-      target,
-      await readFile(
-        join(input.paths.runtimeSkillsDir, name, 'SKILL.md'),
-        'utf8',
-      ),
-    )
-  }
 }
 
 /** Builds stable BrowserOS-managed instructions for Claude/Codex ACP turns. */
@@ -218,27 +180,6 @@ async function writeFileIfMissing(
   }
 }
 
-async function symlinkIfPresent(source: string, target: string): Promise<void> {
-  if (!(await sourceFileExists(source))) return
-  await mkdir(dirname(target), { recursive: true })
-  try {
-    await symlink(source, target)
-  } catch (err) {
-    if (!isAlreadyExistsError(err)) throw err
-  }
-}
-
-async function copyIfPresent(source: string, target: string): Promise<void> {
-  if (!(await sourceFileExists(source))) return
-  const content = await readFile(source, 'utf8')
-  await mkdir(dirname(target), { recursive: true })
-  try {
-    await writeFile(target, content, { encoding: 'utf8', flag: 'wx' })
-  } catch (err) {
-    if (!isAlreadyExistsError(err)) throw err
-  }
-}
-
 /** Writes generated content via atomic replace so readers never see partial files. */
 async function writeFileAtomic(path: string, content: string): Promise<void> {
   await mkdir(dirname(path), { recursive: true })
@@ -253,21 +194,6 @@ async function writeFileAtomic(path: string, content: string): Promise<void> {
     await rm(temporaryPath, { force: true }).catch(() => undefined)
     throw err
   }
-}
-
-async function sourceFileExists(path: string): Promise<boolean> {
-  let info: Stats
-  try {
-    info = await stat(path)
-    await access(path, constants.R_OK)
-  } catch (err) {
-    if (isNotFoundError(err)) return false
-    throw err
-  }
-  if (!info.isFile()) {
-    throw new Error(`Expected source file to be a file: ${path}`)
-  }
-  return true
 }
 
 export function shellQuote(value: string): string {

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime.ts
@@ -927,9 +927,9 @@ async function applyPermissionBypass(
       return []
     } catch (err) {
       lastError = err
-      // debug, not warn: the harness always spawns @zed-industries/codex-acp
-      // (mode id `full-access`), so codex's first candidate is expected to
-      // be rejected on the happy path. Only the all-rejected case below warns.
+      // debug, not warn: Codex ACP builds have used both `agent-full-access`
+      // and `full-access` for the same bypass mode. Only the all-rejected
+      // case below warns.
       logger.debug('Agent harness acpx mode candidate rejected', {
         agentId: input.agent.id,
         adapter: input.agent.adapter,

--- a/packages/browseros-agent/apps/server/src/lib/agents/host-acp/config.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/host-acp/config.ts
@@ -29,10 +29,10 @@ export const HOST_ACP_ADAPTER_CONFIG = {
   codex: {
     displayName: 'Codex',
     nativeBinary: 'codex',
-    acpCommand: 'npx -y @zed-industries/codex-acp@^0.12.0',
-    acpPackageSpec: '@zed-industries/codex-acp@^0.12.0',
-    acpPackageName: '@zed-industries/codex-acp',
-    acpPackageVersionRange: '^0.12.0',
+    acpCommand: 'npx -y @agentclientprotocol/codex-acp@^1.0.2',
+    acpPackageSpec: '@agentclientprotocol/codex-acp@^1.0.2',
+    acpPackageName: '@agentclientprotocol/codex-acp',
+    acpPackageVersionRange: '^1.0.2',
     acpBin: 'codex-acp',
   },
 } as const satisfies Record<HostAcpAdapter, HostAcpAdapterConfig>
@@ -44,9 +44,9 @@ export const HOST_ACP_ADAPTER_CONFIG = {
  * adapter inherits the user's own CLI defaults (e.g. Claude settings
  * `permissions.defaultMode: "dontAsk"`, which auto-denies the BrowserOS
  * MCP tools). Candidates are tried in order; codex lists two ids because
- * @agentclientprotocol/codex-acp advertises `agent-full-access` while
- * @zed-industries/codex-acp (bundled-bun / npx fallback) uses
- * `full-access` for the same approval=never + danger-full-access preset.
+ * @agentclientprotocol/codex-acp advertises `agent-full-access`; older
+ * Zed-packaged Codex ACP builds used `full-access` for the same
+ * approval=never + danger-full-access preset, so keep it as a fallback.
  */
 export const DANGEROUS_ALLOW_MODE_CANDIDATES: Readonly<
   Partial<Record<HostAcpAdapter, readonly string[]>>

--- a/packages/browseros-agent/apps/server/tests/agent/provider-factory-acp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/provider-factory-acp.test.ts
@@ -4,6 +4,19 @@
  */
 
 import { afterAll, beforeEach, describe, expect, it, mock } from 'bun:test'
+import {
+  accessSync,
+  chmodSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
 
@@ -38,11 +51,48 @@ const fakeProvider = {
 const mkdirCalls: Array<{ path: string; opts: { recursive?: boolean } }> = []
 let lastInstructionArgs: Record<string, unknown> | null = null
 
-mock.module('node:fs/promises', () => ({
-  mkdir: async (path: string, opts: { recursive?: boolean }) => {
-    mkdirCalls.push({ path, opts })
-  },
-}))
+function mockFsPromises(
+  mkdirImpl: (path: string, opts: { recursive?: boolean }) => Promise<void>,
+): void {
+  mock.module('node:fs/promises', () => ({
+    access: async (path: string, mode?: number) => {
+      accessSync(path, mode)
+    },
+    chmod: async (path: string, mode: number) => {
+      chmodSync(path, mode)
+    },
+    lstat: async (path: string) => lstatSync(path),
+    mkdir: mkdirImpl,
+    mkdtemp: async (prefix: string) => mkdtempSync(prefix),
+    readFile: async (path: string, encoding?: BufferEncoding) =>
+      readFileSync(path, encoding),
+    rename: async (oldPath: string, newPath: string) => {
+      renameSync(oldPath, newPath)
+    },
+    rm: async (
+      path: string,
+      opts?: { recursive?: boolean; force?: boolean },
+    ) => {
+      rmSync(path, opts)
+    },
+    stat: async (path: string) => statSync(path),
+    symlink: async (target: string, path: string) => {
+      symlinkSync(target, path)
+    },
+    writeFile: async (
+      path: string,
+      data: string | NodeJS.TypedArray | DataView,
+      options?: Parameters<typeof writeFileSync>[2],
+    ) => {
+      writeFileSync(path, data, options)
+    },
+  }))
+}
+
+mockFsPromises(async (path: string, opts: { recursive?: boolean }) => {
+  mkdirCalls.push({ path, opts })
+  mkdirSync(path, opts)
+})
 
 mock.module('../../src/lib/browseros-dir', () => ({
   getBrowserosDir: () => join(homedir(), '.browseros-test'),
@@ -279,15 +329,17 @@ describe('createLanguageModel — ACP providers', () => {
   })
 
   it('survives mkdir failures with a warn log and still spawns', async () => {
-    mock.module('node:fs/promises', () => ({
-      mkdir: async () => {
-        throw new Error('permission denied')
-      },
-    }))
+    mockFsPromises(async () => {
+      throw new Error('permission denied')
+    })
     // Re-import the factory so the mkdir mock is picked up.
     delete require.cache[require.resolve('../../src/agent/provider-factory')]
     const reloaded = await import('../../src/agent/provider-factory')
     await reloaded.createLanguageModel(baseConfig() as never)
+    mockFsPromises(async (path: string, opts: { recursive?: boolean }) => {
+      mkdirCalls.push({ path, opts })
+      mkdirSync(path, opts)
+    })
     // buildAcpxProvider still called even though mkdir threw.
     expect(lastBuildArgs?.workspacePath).toBe(
       join(homedir(), '.browseros-test', 'workspaces', 'claude-code'),

--- a/packages/browseros-agent/apps/server/tests/agent/provider-factory-acp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/provider-factory-acp.test.ts
@@ -219,7 +219,7 @@ describe('createLanguageModel — ACP providers', () => {
     expect(overrides?.claude).toContain(bunPath)
     expect(overrides?.claude).toContain('@agentclientprotocol/claude-agent-acp')
     expect(overrides?.codex).toContain(bunPath)
-    expect(overrides?.codex).toContain('@zed-industries/codex-acp')
+    expect(overrides?.codex).toContain('@agentclientprotocol/codex-acp')
 
     fs.rmSync(tmpRoot, { recursive: true, force: true })
   })
@@ -247,7 +247,7 @@ describe('createLanguageModel — ACP providers', () => {
       | undefined
     expect(overrides?.['my-agent']).toBe('my-bin acp')
     expect(overrides?.claude).toContain('@agentclientprotocol/claude-agent-acp')
-    expect(overrides?.codex).toContain('@zed-industries/codex-acp')
+    expect(overrides?.codex).toContain('@agentclientprotocol/codex-acp')
 
     fs.rmSync(tmpRoot, { recursive: true, force: true })
   })
@@ -381,7 +381,7 @@ describe('createLanguageModel — ACP dangerously-allow mode', () => {
     expect(setModeCalls).toEqual(['agent-full-access'])
   })
 
-  it('falls back to the zed codex mode id when the first candidate is rejected', async () => {
+  it('falls back to the legacy codex mode id when the first candidate is rejected', async () => {
     rejectModes = ['agent-full-access']
     const { model } = await createLanguageModel({
       ...baseConfig(),

--- a/packages/browseros-agent/apps/server/tests/agent/provider-factory-codex-home.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/provider-factory-codex-home.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { ResolvedAgentConfig } from '../../src/agent/types'
+
+let browserosDir = ''
+let lastBuildArgs: Record<string, unknown> | null = null
+const tempDirs: string[] = []
+
+const fakeProvider = {
+  languageModel: () => ({ kind: 'fake-acp-model' }),
+  close: async () => {},
+  prepare: async () => {},
+  setMode: async () => {},
+  runtime: { setMode: async () => {} },
+}
+
+mock.module('../../src/lib/browseros-dir', () => ({
+  getBrowserosDir: () => browserosDir,
+}))
+
+mock.module('../../src/lib/agents/acpx-provider/buildAcpxProvider', () => ({
+  buildAcpxProvider: async (opts: Record<string, unknown>) => {
+    lastBuildArgs = opts
+    return fakeProvider
+  },
+}))
+
+const { createLanguageModel, setEnsureWorkspaceInstructionFileForTesting } =
+  await import('../../src/agent/provider-factory')
+
+afterEach(() => {
+  setEnsureWorkspaceInstructionFileForTesting(null)
+  lastBuildArgs = null
+  browserosDir = ''
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+  delete process.env.CODEX_HOME
+})
+
+describe('createLanguageModel Codex managed home', () => {
+  it('uses auth without copying parser-sensitive config for bundled Codex chat', async () => {
+    const tmpRoot = mkdtempSync(join(tmpdir(), 'bos-provider-codex-'))
+    tempDirs.push(tmpRoot)
+    const resourcesDir = join(tmpRoot, 'resources')
+    browserosDir = join(tmpRoot, 'browseros')
+    const sourceCodexHome = join(tmpRoot, 'source-codex-home')
+    const binDir = join(resourcesDir, 'bin', 'third_party')
+    mkdirSync(binDir, { recursive: true })
+    mkdirSync(sourceCodexHome, { recursive: true })
+    const bunPath = join(binDir, 'bun')
+    writeFileSync(bunPath, '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+    writeFileSync(join(sourceCodexHome, 'auth.json'), '{"ok":true}\n')
+    writeFileSync(
+      join(sourceCodexHome, 'config.toml'),
+      '[features.multi_agent_v2]\nenabled = false\n',
+    )
+    process.env.CODEX_HOME = sourceCodexHome
+    setEnsureWorkspaceInstructionFileForTesting(async () => ({
+      action: 'skipped-not-new-conversation',
+    }))
+
+    const config = {
+      conversationId: 'conv-codex-managed-home',
+      provider: 'codex',
+      model: 'gpt-5.4',
+      resourcesDir,
+    } satisfies ResolvedAgentConfig
+    await createLanguageModel(config)
+
+    const managedCodexHome = join(
+      browserosDir,
+      'agents',
+      'harness',
+      'codex-provider',
+      'runtime',
+      'codex-home',
+    )
+    const overrides = lastBuildArgs?.agentRegistryOverrides as
+      | Record<string, string>
+      | undefined
+    expect(overrides?.codex).toContain(bunPath)
+    expect(overrides?.codex).toContain(`CODEX_HOME='${managedCodexHome}'`)
+    expect(
+      lstatSync(join(managedCodexHome, 'auth.json')).isSymbolicLink(),
+    ).toBe(true)
+    expect(existsSync(join(managedCodexHome, 'config.toml'))).toBe(false)
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/api/services/acpx-probe/probeAgent.codex-home.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/acpx-probe/probeAgent.codex-home.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { describe, expect, it, mock } from 'bun:test'
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+interface CapturedCall {
+  agent?: string
+  command?: string
+  cwd?: string
+  authPolicy?: string
+  timeoutMs?: number
+}
+
+interface ProbeResult {
+  models: readonly { readonly id: string; readonly name?: string }[]
+  configOptions: readonly unknown[]
+  reasoning: null
+  supportsConfigOption: boolean
+  agentInfo: null
+  protocolVersion: number
+}
+
+let lastCall: CapturedCall | null = null
+
+mock.module('acp-probe', () => ({
+  probeAgent: async (input: CapturedCall): Promise<ProbeResult> => {
+    lastCall = input
+    return {
+      models: [{ id: 'gpt-5.4', name: 'GPT-5.4' }],
+      configOptions: [],
+      reasoning: null,
+      supportsConfigOption: false,
+      agentInfo: null,
+      protocolVersion: 1,
+    }
+  },
+}))
+
+const { probeAcpAgent } = await import(
+  '../../../../src/api/services/acpx-probe/probeAgent'
+)
+
+describe('probeAcpAgent Codex managed home', () => {
+  it('uses auth without copying parser-sensitive config for bundled probes', async () => {
+    const tmpRoot = mkdtempSync(join(tmpdir(), 'bos-probe-codex-'))
+    const resourcesDir = join(tmpRoot, 'resources')
+    const browserosDir = join(tmpRoot, 'browseros')
+    const sourceCodexHome = join(tmpRoot, 'source-codex-home')
+    const binDir = join(resourcesDir, 'bin', 'third_party')
+    mkdirSync(binDir, { recursive: true })
+    mkdirSync(sourceCodexHome, { recursive: true })
+    const bunPath = join(binDir, 'bun')
+    writeFileSync(bunPath, '#!/bin/sh\nexit 0\n', { mode: 0o755 })
+    writeFileSync(join(sourceCodexHome, 'auth.json'), '{"ok":true}\n')
+    writeFileSync(
+      join(sourceCodexHome, 'config.toml'),
+      '[features.multi_agent_v2]\nenabled = false\n',
+    )
+    const previousCodexHome = process.env.CODEX_HOME
+    process.env.CODEX_HOME = sourceCodexHome
+
+    try {
+      await probeAcpAgent({ agentId: 'codex', browserosDir, resourcesDir })
+
+      const managedCodexHome = join(
+        browserosDir,
+        'agents',
+        'harness',
+        'codex-probe',
+        'runtime',
+        'codex-home',
+      )
+      expect(lastCall?.agent).toBeUndefined()
+      expect(lastCall?.command).toContain(bunPath)
+      expect(lastCall?.command).toContain(`CODEX_HOME='${managedCodexHome}'`)
+      expect(
+        lstatSync(join(managedCodexHome, 'auth.json')).isSymbolicLink(),
+      ).toBe(true)
+      expect(existsSync(join(managedCodexHome, 'config.toml'))).toBe(false)
+    } finally {
+      if (previousCodexHome === undefined) {
+        delete process.env.CODEX_HOME
+      } else {
+        process.env.CODEX_HOME = previousCodexHome
+      }
+      rmSync(tmpRoot, { recursive: true, force: true })
+    }
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime-context.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime-context.test.ts
@@ -4,22 +4,13 @@
  */
 
 import { afterEach, describe, expect, it } from 'bun:test'
-import {
-  chmod,
-  lstat,
-  mkdir,
-  mkdtemp,
-  readFile,
-  rm,
-  writeFile,
-} from 'node:fs/promises'
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   buildAcpxRuntimePromptPrefix,
   ensureAgentHome,
   ensureRuntimeSkills,
-  materializeCodexHome,
   resolveAgentRuntimePaths,
   wrapCommandWithEnv,
 } from '../../../src/lib/agents/acpx/runtime-context'
@@ -194,62 +185,6 @@ describe('acpx runtime context helpers', () => {
     await ensureRuntimeSkills(paths.runtimeSkillsDir)
 
     expect(await readFile(skillPath, 'utf8')).toContain('BrowserOS MCP')
-  })
-
-  it('materializes Codex home with auth symlink and all runtime skills', async () => {
-    const browserosDir = await mkdtemp(join(tmpdir(), 'browseros-context-'))
-    const sourceCodexHome = await mkdtemp(
-      join(tmpdir(), 'browseros-codex-src-'),
-    )
-    tempDirs.push(browserosDir, sourceCodexHome)
-    await writeFile(join(sourceCodexHome, 'auth.json'), '{"ok":true}\n')
-    await writeFile(join(sourceCodexHome, 'config.toml'), 'model = "test"\n')
-    const paths = resolveAgentRuntimePaths({ browserosDir, agentId: 'agent-1' })
-    const skills = await ensureRuntimeSkills(paths.runtimeSkillsDir)
-
-    await materializeCodexHome({ paths, skillNames: skills, sourceCodexHome })
-
-    const auth = await lstat(join(paths.codexHome, 'auth.json'))
-    expect(auth.isSymbolicLink()).toBe(true)
-    expect(await readFile(join(paths.codexHome, 'config.toml'), 'utf8')).toBe(
-      'model = "test"\n',
-    )
-    expect(
-      await readFile(
-        join(paths.codexHome, 'skills', 'browseros', 'SKILL.md'),
-        'utf8',
-      ),
-    ).toContain('BrowserOS MCP')
-  })
-
-  it('rejects non-file Codex auth sources instead of silently skipping auth', async () => {
-    const browserosDir = await mkdtemp(join(tmpdir(), 'browseros-context-'))
-    const sourceCodexHome = await mkdtemp(
-      join(tmpdir(), 'browseros-codex-src-'),
-    )
-    tempDirs.push(browserosDir, sourceCodexHome)
-    await mkdir(join(sourceCodexHome, 'auth.json'))
-    const paths = resolveAgentRuntimePaths({ browserosDir, agentId: 'agent-1' })
-    const skills = await ensureRuntimeSkills(paths.runtimeSkillsDir)
-
-    await expect(
-      materializeCodexHome({ paths, skillNames: skills, sourceCodexHome }),
-    ).rejects.toThrow(/auth\.json/)
-  })
-
-  it('rejects non-file Codex config sources instead of silently skipping config', async () => {
-    const browserosDir = await mkdtemp(join(tmpdir(), 'browseros-context-'))
-    const sourceCodexHome = await mkdtemp(
-      join(tmpdir(), 'browseros-codex-src-'),
-    )
-    tempDirs.push(browserosDir, sourceCodexHome)
-    await mkdir(join(sourceCodexHome, 'config.toml'))
-    const paths = resolveAgentRuntimePaths({ browserosDir, agentId: 'agent-1' })
-    const skills = await ensureRuntimeSkills(paths.runtimeSkillsDir)
-
-    await expect(
-      materializeCodexHome({ paths, skillNames: skills, sourceCodexHome }),
-    ).rejects.toThrow(/config\.toml/)
   })
 
   it('wraps commands with shell-quoted env vars', () => {

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -1116,7 +1116,7 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
     expect(command).toContain('/runtime/codex-home')
     // Spawn must go through BrowserOS's own npx command for the official
     // codex-acp package, not a bare `codex` binary.
-    expect(command).toContain('npx -y @zed-industries/codex-acp')
+    expect(command).toContain('npx -y @agentclientprotocol/codex-acp')
   })
 
   it('prepends the bundled native CLI directory to host ACP adapter commands', async () => {
@@ -1201,7 +1201,7 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
         `'${bunPath}' x --bun --silent --package '@agentclientprotocol/claude-agent-acp@^0.31.0' 'claude-agent-acp'`,
       )
       expect(codexCommand).toContain(
-        `'${bunPath}' x --bun --silent --package '@zed-industries/codex-acp@^0.12.0' 'codex-acp'`,
+        `'${bunPath}' x --bun --silent --package '@agentclientprotocol/codex-acp@^1.0.2' 'codex-acp'`,
       )
       expect(codexCommand).toContain('BUN_INSTALL_CACHE_DIR=')
       expect(codexCommand).toContain('cache/acp-node-shim')
@@ -1376,7 +1376,7 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
     })
   })
 
-  it('falls back to the zed codex mode id when the first candidate is rejected', async () => {
+  it('falls back to the legacy codex mode id when the first candidate is rejected', async () => {
     const calls: Array<{ method: string; input: unknown }> = []
     const runtime = new AcpxRuntime({
       cwd: '/tmp/browseros-acpx-runtime',

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx/codex-home.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx/codex-home.test.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ */
+
+import { afterEach, describe, expect, it } from 'bun:test'
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  rm,
+  writeFile,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { materializeCodexHome } from '../../../../src/lib/agents/acpx/codex-home'
+import {
+  ensureRuntimeSkills,
+  resolveAgentRuntimePaths,
+} from '../../../../src/lib/agents/acpx/runtime-context'
+
+describe('materializeCodexHome', () => {
+  const tempDirs: string[] = []
+
+  afterEach(async () => {
+    await Promise.all(
+      tempDirs.map((dir) => rm(dir, { recursive: true, force: true })),
+    )
+    tempDirs.length = 0
+  })
+
+  it('uses auth and instructions without copying Codex config files', async () => {
+    const browserosDir = await mkdtemp(join(tmpdir(), 'browseros-context-'))
+    const sourceCodexHome = await mkdtemp(
+      join(tmpdir(), 'browseros-codex-src-'),
+    )
+    tempDirs.push(browserosDir, sourceCodexHome)
+    await writeFile(join(sourceCodexHome, 'auth.json'), '{"ok":true}\n')
+    await writeFile(join(sourceCodexHome, 'instructions.md'), 'be concise\n')
+    await writeFile(join(sourceCodexHome, 'config.json'), '{"model":"test"}\n')
+    await writeFile(
+      join(sourceCodexHome, 'config.toml'),
+      '[features.multi_agent_v2]\nenabled = false\n',
+    )
+    const paths = resolveAgentRuntimePaths({ browserosDir, agentId: 'agent-1' })
+    const skills = await ensureRuntimeSkills(paths.runtimeSkillsDir)
+
+    await materializeCodexHome({ paths, skillNames: skills, sourceCodexHome })
+
+    const auth = await lstat(join(paths.codexHome, 'auth.json'))
+    expect(auth.isSymbolicLink()).toBe(true)
+    expect(
+      await readFile(join(paths.codexHome, 'instructions.md'), 'utf8'),
+    ).toBe('be concise\n')
+    await expect(
+      readFile(join(paths.codexHome, 'config.json'), 'utf8'),
+    ).rejects.toThrow(/ENOENT/)
+    await expect(
+      readFile(join(paths.codexHome, 'config.toml'), 'utf8'),
+    ).rejects.toThrow(/ENOENT/)
+    expect(
+      await readFile(
+        join(paths.codexHome, 'skills', 'browseros', 'SKILL.md'),
+        'utf8',
+      ),
+    ).toContain('BrowserOS MCP')
+  })
+
+  it('rejects non-file Codex auth sources instead of silently skipping auth', async () => {
+    const browserosDir = await mkdtemp(join(tmpdir(), 'browseros-context-'))
+    const sourceCodexHome = await mkdtemp(
+      join(tmpdir(), 'browseros-codex-src-'),
+    )
+    tempDirs.push(browserosDir, sourceCodexHome)
+    await mkdir(join(sourceCodexHome, 'auth.json'))
+    const paths = resolveAgentRuntimePaths({ browserosDir, agentId: 'agent-1' })
+    const skills = await ensureRuntimeSkills(paths.runtimeSkillsDir)
+
+    await expect(
+      materializeCodexHome({ paths, skillNames: skills, sourceCodexHome }),
+    ).rejects.toThrow(/auth\.json/)
+  })
+
+  it('ignores non-file Codex config sources', async () => {
+    const browserosDir = await mkdtemp(join(tmpdir(), 'browseros-context-'))
+    const sourceCodexHome = await mkdtemp(
+      join(tmpdir(), 'browseros-codex-src-'),
+    )
+    tempDirs.push(browserosDir, sourceCodexHome)
+    await mkdir(join(sourceCodexHome, 'config.toml'))
+    const paths = resolveAgentRuntimePaths({ browserosDir, agentId: 'agent-1' })
+    const skills = await ensureRuntimeSkills(paths.runtimeSkillsDir)
+
+    await materializeCodexHome({ paths, skillNames: skills, sourceCodexHome })
+
+    await expect(
+      readFile(join(paths.codexHome, 'config.toml'), 'utf8'),
+    ).rejects.toThrow(/ENOENT/)
+  })
+})

--- a/packages/browseros-agent/apps/server/tests/lib/agents/adapter-detection.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/adapter-detection.test.ts
@@ -354,7 +354,7 @@ describe('probeNpxPackageCache', () => {
         '_npx',
         'hit',
         'node_modules',
-        '@zed-industries',
+        '@agentclientprotocol',
         'codex-acp',
       ),
       { recursive: true },
@@ -365,10 +365,10 @@ describe('probeNpxPackageCache', () => {
         '_npx',
         'miss',
         'node_modules',
-        '@zed-industries',
+        '@agentclientprotocol',
         'nested',
         'node_modules',
-        '@zed-industries',
+        '@agentclientprotocol',
         'codex-acp',
       ),
       { recursive: true },
@@ -379,11 +379,11 @@ describe('probeNpxPackageCache', () => {
         '_npx',
         'hit',
         'node_modules',
-        '@zed-industries',
+        '@agentclientprotocol',
         'codex-acp',
         'package.json',
       ),
-      '{"version":"0.12.1"}',
+      '{"version":"1.0.2"}',
     )
     await writeFile(
       join(
@@ -391,20 +391,20 @@ describe('probeNpxPackageCache', () => {
         '_npx',
         'miss',
         'node_modules',
-        '@zed-industries',
+        '@agentclientprotocol',
         'nested',
         'node_modules',
-        '@zed-industries',
+        '@agentclientprotocol',
         'codex-acp',
         'package.json',
       ),
-      '{"version":"0.12.1"}',
+      '{"version":"1.0.2"}',
     )
 
     await expect(
-      probeNpxPackageCache('@zed-industries/codex-acp', {
+      probeNpxPackageCache('@agentclientprotocol/codex-acp', {
         npxCacheDir: join(npmCacheDir, '_npx'),
-        versionRange: '^0.12.0',
+        versionRange: '^1.0.2',
       }),
     ).resolves.toBe(true)
   })
@@ -418,7 +418,7 @@ describe('probeNpxPackageCache', () => {
         '_npx',
         'stale',
         'node_modules',
-        '@zed-industries',
+        '@agentclientprotocol',
         'codex-acp',
       ),
       { recursive: true },
@@ -429,17 +429,17 @@ describe('probeNpxPackageCache', () => {
         '_npx',
         'stale',
         'node_modules',
-        '@zed-industries',
+        '@agentclientprotocol',
         'codex-acp',
         'package.json',
       ),
-      '{"version":"0.11.9"}',
+      '{"version":"1.0.1"}',
     )
 
     await expect(
-      probeNpxPackageCache('@zed-industries/codex-acp', {
+      probeNpxPackageCache('@agentclientprotocol/codex-acp', {
         npxCacheDir: join(npmCacheDir, '_npx'),
-        versionRange: '^0.12.0',
+        versionRange: '^1.0.2',
       }),
     ).resolves.toBe(false)
   })


### PR DESCRIPTION
## Summary
- run bundled Codex ACP probes with a BrowserOS-managed `CODEX_HOME`
- run bundled Codex ACP chat sessions with the same managed Codex home instead of inheriting the user's native Codex config
- move Codex home materialization into a focused helper and avoid copying parser-sensitive `config.json` / `config.toml`
- update the bundled Codex ACP package from stale `@zed-industries/codex-acp@^0.12.0` to `@agentclientprotocol/codex-acp@^1.0.2`
- add regression coverage for both provider setup probing and actual Codex chat provider launch

## Why
`@zed-industries/codex-acp` can lag both the native Codex CLI config schema and current model registry. If BrowserOS launches the ACP adapter without `CODEX_HOME`, the adapter reads `~/.codex/config.toml` and can exit before ACP `initialize` when the user's native Codex config contains newer feature shapes.

Observed locally before this patch:

```text
ACP agent exited before initialize completed (exit=1, signal=null): Error: error loading config: /home/cole/.codex/config.toml:257:1: data did not match any variant of untagged enum FeatureToml
```

The old Zed package also advertised models only up to `gpt-5.4`, while the current `@agentclientprotocol/codex-acp@1.0.2` advertises `gpt-5.5`.

## Verification
- `bun --env-file=.env.development test ./tests/agent/provider-factory-acp.test.ts ./tests/agent/provider-factory-codex-home.test.ts ./tests/api/services/acpx-probe/probeAgent.codex-home.test.ts ./tests/lib/agents/acpx/codex-home.test.ts`
  - `36 pass, 0 fail`
- `bun --env-file=.env.development test ./tests/lib/agents/acpx-runtime.test.ts`
  - `36 pass, 1 skip, 0 fail`
- `bun --env-file=.env.development test ./tests/lib/agents/adapter-detection.test.ts`
  - `11 pass, 0 fail`
- `bun --env-file=.env.development tsc --noEmit`
- `bunx @biomejs/biome check ...`
- `bun run ./tests/__helpers__/run-test-group.ts agent`
  - `302 pass, 0 fail`
- live installed BrowserOS server smoke:
  - `/acpx/probe` for Codex returned model metadata with `gpt-5.5` first, `agentInfo.name=@agentclientprotocol/codex-acp`, `agentInfo.version=1.0.2`, and no `agent_crashed`
  - `/chat` with `provider=codex`, `model=gpt-5.4`, prompt `Reply with OK only.` streamed `OK` and logged `Agent execution complete`
- package comparison smoke:
  - `@agentclientprotocol/codex-acp@1.0.2` advertised `gpt-5.5`
  - `@zed-industries/codex-acp@0.12.0` advertised only up to `gpt-5.4`
