### PR TITLE
feat: install newer bundled extensions over installed versions

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_installer.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_installer.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/extensions/browseros_extension_installer.cc b/chrome/browser/browseros/extensions/browseros_extension_installer.cc
 new file mode 100644
-index 0000000000000..8b976ef54e385
+index 0000000000000..ed44e6788a59e
 --- /dev/null
 +++ b/chrome/browser/browseros/extensions/browseros_extension_installer.cc
-@@ -0,0 +1,310 @@
+@@ -0,0 +1,309 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -94,12 +94,11 @@ index 0000000000000..8b976ef54e385
 +  base::FilePath manifest_path =
 +      bundled_path.Append(FILE_PATH_LITERAL("bundled_extensions.json"));
 +
-+  if (!base::PathExists(manifest_path)) {
-+    LOG(INFO) << "browseros: No bundled manifest at " << manifest_path.value();
-+    return false;
-+  }
-+
 +  LOG(INFO) << "browseros: Loading from bundled at " << bundled_path.value();
++
++  // Manifest existence is checked on the blocking task below (missing file
++  // yields empty prefs and OnBundledLoadComplete falls back to remote), so
++  // startup never touches the disk on the UI thread here.
 +
 +  base::ThreadPool::PostTaskAndReplyWithResult(
 +      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_BLOCKING},
@@ -117,7 +116,7 @@ index 0000000000000..8b976ef54e385
 +    const base::FilePath& bundled_path) {
 +  std::string json_content;
 +  if (!base::ReadFileToString(manifest_path, &json_content)) {
-+    LOG(ERROR) << "browseros: Failed to read bundled manifest";
++    LOG(INFO) << "browseros: No bundled manifest at " << manifest_path.value();
 +    return base::DictValue();
 +  }
 +

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_loader.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_loader.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/extensions/browseros_extension_loader.cc b/chrome/browser/browseros/extensions/browseros_extension_loader.cc
 new file mode 100644
-index 0000000000000..936c8d7cf7948
+index 0000000000000..f3665bd1ba8d9
 --- /dev/null
 +++ b/chrome/browser/browseros/extensions/browseros_extension_loader.cc
-@@ -0,0 +1,267 @@
+@@ -0,0 +1,279 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -30,12 +30,6 @@ index 0000000000000..936c8d7cf7948
 +#include "extensions/common/verifier_formats.h"
 +
 +namespace browseros {
-+
-+namespace {
-+
-+constexpr base::TimeDelta kImmediateInstallDelay = base::Seconds(2);
-+
-+}  // namespace
 +
 +BrowserOSExtensionLoader::BrowserOSExtensionLoader(Profile* profile)
 +    : profile_(profile) {
@@ -143,18 +137,19 @@ index 0000000000000..936c8d7cf7948
 +  LOG(INFO) << "browseros: Startup complete (from_bundled=" << from_bundled
 +            << ")";
 +
++  // Posted (not called synchronously) because StartLoading() can run inside
++  // ExtensionService::Init(); one message-loop hop guarantees the extension
++  // system is fully up (ExtensionUpdater::InstallPendingNow CHECKs alive_).
 +  if (from_bundled) {
-+    base::SingleThreadTaskRunner::GetCurrentDefault()->PostDelayedTask(
++    base::SingleThreadTaskRunner::GetCurrentDefault()->PostTask(
 +        FROM_HERE,
 +        base::BindOnce(&BrowserOSExtensionLoader::InstallBundledExtensionsNow,
-+                       weak_ptr_factory_.GetWeakPtr()),
-+        kImmediateInstallDelay);
++                       weak_ptr_factory_.GetWeakPtr()));
 +  } else {
-+    base::SingleThreadTaskRunner::GetCurrentDefault()->PostDelayedTask(
++    base::SingleThreadTaskRunner::GetCurrentDefault()->PostTask(
 +        FROM_HERE,
 +        base::BindOnce(&BrowserOSExtensionLoader::InstallRemoteExtensionsNow,
-+                       weak_ptr_factory_.GetWeakPtr(), last_config_.Clone()),
-+        kImmediateInstallDelay);
++                       weak_ptr_factory_.GetWeakPtr(), last_config_.Clone()));
 +  }
 +
 +  // Maintainer owns the config now
@@ -232,11 +227,8 @@ index 0000000000000..936c8d7cf7948
 +    return;
 +  }
 +
-+  LOG(INFO) << "browseros: Installing " << extension_ids_.size()
-+            << " bundled extensions immediately";
-+
 +  for (const std::string& id : extension_ids_) {
-+    if (registry->GetInstalledExtension(id) || pending->IsIdPending(id)) {
++    if (pending->IsIdPending(id)) {
 +      continue;
 +    }
 +
@@ -245,15 +237,35 @@ index 0000000000000..936c8d7cf7948
 +      continue;
 +    }
 +
++    base::Version bundled_version(it->second);
++    if (!bundled_version.IsValid()) {
++      continue;
++    }
++
++    // Install when missing, or upgrade when the bundled CRX is newer than
++    // the installed version; waiting for the OTA update check instead would
++    // leave users on the old version for up to a maintenance cycle.
++    const extensions::Extension* installed =
++        registry->GetInstalledExtension(id);
++    if (installed && installed->version().CompareTo(bundled_version) >= 0) {
++      continue;
++    }
++
 +    base::FilePath crx_path = bundled_crx_base_path_.Append(
 +        base::FilePath::FromUTF8Unsafe(id + ".crx"));
 +
-+    LOG(INFO) << "browseros: Installing bundled " << id << " v" << it->second;
++    if (installed) {
++      LOG(INFO) << "browseros: Upgrading " << id << " v"
++                << installed->version().GetString() << " -> v" << it->second
++                << " from bundled CRX";
++    } else {
++      LOG(INFO) << "browseros: Installing bundled " << id << " v" << it->second;
++    }
 +
 +    pending->AddFromExternalFile(
 +        id, extensions::mojom::ManifestLocation::kExternalComponent,
-+        base::Version(it->second),
-+        extensions::Extension::WAS_INSTALLED_BY_DEFAULT, false);
++        bundled_version, extensions::Extension::WAS_INSTALLED_BY_DEFAULT,
++        false);
 +
 +    scoped_refptr<extensions::CrxInstaller> installer(
 +        extensions::CrxInstaller::CreateSilent(profile_));

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_loader.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/extensions/browseros_extension_loader.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/extensions/browseros_extension_loader.h b/chrome/browser/browseros/extensions/browseros_extension_loader.h
 new file mode 100644
-index 0000000000000..ea2c856556f5f
+index 0000000000000..9673304e2eecb
 --- /dev/null
 +++ b/chrome/browser/browseros/extensions/browseros_extension_loader.h
-@@ -0,0 +1,86 @@
+@@ -0,0 +1,89 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -67,10 +67,13 @@ index 0000000000000..ea2c856556f5f
 +  // preventing orphan detection from uninstalling existing extensions.
 +  base::DictValue ReconstructPrefsFromInstalledExtensions();
 +
-+  // Installs remote extensions immediately via PendingExtensionManager + updater.
++  // Installs remote extensions immediately via PendingExtensionManager +
++  // updater.
 +  void InstallRemoteExtensionsNow(base::DictValue config);
 +
-+  // Installs bundled CRX extensions immediately via CrxInstaller.
++  // Installs bundled CRX extensions immediately via CrxInstaller. Covers
++  // fresh installs and upgrades where the bundled version is newer than the
++  // installed one (e.g. right after an app update shipped a newer CRX).
 +  void InstallBundledExtensionsNow();
 +
 +  raw_ptr<Profile> profile_;


### PR DESCRIPTION
## Summary
- Bundled CRXs now install when they are **newer** than the already-installed extension, instead of being skipped — previously users waited on the network OTA cycle (up to ~10-15 min: 60s initial maintenance delay + 15-min cycles + CDN lag) after an app update shipped a newer bundle.
- First-start installs kick off sooner: the 2s immediate-install delay is gone (plain `PostTask` — safe because `ExtensionUpdater::Start()` runs inside `ExtensionService::Init()` before `CheckForExternalUpdates()` triggers the loader).
- `TryLoadFromBundled()` no longer does blocking `PathExists` disk I/O on the UI thread during startup; the missing-manifest case is handled on the FILE-thread task with the existing remote-config fallback.

## Design
`InstallBundledExtensionsNow()` gains a version gate: skip if an install is already pending (dedupe against the external-provider path), skip if the installed version is same-or-newer, otherwise install/upgrade the bundled CRX via silent `CrxInstaller` with `install_immediately`. Downgrades are never installed. The pending-check ordering keeps the fast path idempotent with the `ExternalProviderImpl` file-found flow that runs at startup.

## Test plan
- [x] `autoninja -C out/Default_arm64 chrome` green on chromium `browseros` branch (squash `273d1e6e8f529`)
- [x] Patch extraction verified: 3/3 byte-match against `BASE_COMMIT..tip`, 3/3 apply-check onto bare BASE tree
- [ ] Manual: with an older extension version installed, launch a build with a newer bundled CRX and confirm log line `browseros: Upgrading <id> vX -> vY from bundled CRX` and the new version active within seconds