### PR TITLE
fix: harden Chrome login importer on Windows (App-Bound v20)

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/importer/importer_list.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/importer/importer_list.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/importer/importer_list.cc b/chrome/browser/importer/importer_list.cc
-index 62546b572bab8..5e387e769912c 100644
+index 62546b572bab8..6ebad489e44bb 100644
 --- a/chrome/browser/importer/importer_list.cc
 +++ b/chrome/browser/importer/importer_list.cc
 @@ -6,10 +6,15 @@
@@ -26,7 +26,7 @@ index 62546b572bab8..5e387e769912c 100644
  
  #if BUILDFLAG(IS_MAC)
  #include "base/apple/foundation_util.h"
-@@ -29,6 +35,200 @@
+@@ -29,6 +35,203 @@
  
  namespace {
  
@@ -203,8 +203,11 @@ index 62546b572bab8..5e387e769912c 100644
 +    if (!profile_id || !name)
 +      continue;
 +
-+    base::FilePath profile_folder = chrome_path.Append(
-+        base::FilePath::StringType(profile_id->begin(), profile_id->end()));
++    // Profile ids from Local State are UTF-8 ("Default", "Profile 1", ...);
++    // convert properly rather than widening bytes so the path is correct on
++    // Windows (FilePath uses wchar_t there).
++    base::FilePath profile_folder =
++        chrome_path.Append(base::FilePath::FromUTF8Unsafe(*profile_id).value());
 +    uint16_t services = user_data_importer::NONE;
 +
 +    if (!ChromeImporterCanImport(profile_folder, &services))
@@ -227,7 +230,7 @@ index 62546b572bab8..5e387e769912c 100644
  #if BUILDFLAG(IS_WIN)
  void DetectIEProfiles(
      std::vector<user_data_importer::SourceProfile>* profiles) {
-@@ -71,6 +271,21 @@ void DetectBuiltinWindowsProfiles(
+@@ -71,6 +274,21 @@ void DetectBuiltinWindowsProfiles(
  
  #endif  // BUILDFLAG(IS_WIN)
  
@@ -249,7 +252,7 @@ index 62546b572bab8..5e387e769912c 100644
  #if BUILDFLAG(IS_MAC)
  void DetectSafariProfiles(
      std::vector<user_data_importer::SourceProfile>* profiles) {
-@@ -88,8 +303,30 @@ void DetectSafariProfiles(
+@@ -88,8 +306,30 @@ void DetectSafariProfiles(
    safari.services_supported = items;
    profiles->push_back(safari);
  }
@@ -280,7 +283,7 @@ index 62546b572bab8..5e387e769912c 100644
  // |locale|: The application locale used for lookups in Firefox's
  // locale-specific search engines feature (see firefox_importer.cc for
  // details).
-@@ -170,8 +407,10 @@ std::vector<user_data_importer::SourceProfile> DetectSourceProfilesWorker(
+@@ -170,8 +410,10 @@ std::vector<user_data_importer::SourceProfile> DetectSourceProfilesWorker(
  #if BUILDFLAG(IS_WIN)
    if (shell_integration::IsFirefoxDefaultBrowser()) {
      DetectFirefoxProfiles(locale, &profiles);
@@ -291,7 +294,7 @@ index 62546b572bab8..5e387e769912c 100644
      DetectBuiltinWindowsProfiles(&profiles);
      DetectFirefoxProfiles(locale, &profiles);
    }
-@@ -179,11 +418,15 @@ std::vector<user_data_importer::SourceProfile> DetectSourceProfilesWorker(
+@@ -179,11 +421,15 @@ std::vector<user_data_importer::SourceProfile> DetectSourceProfilesWorker(
    if (shell_integration::IsFirefoxDefaultBrowser()) {
      DetectFirefoxProfiles(locale, &profiles);
      DetectSafariProfiles(&profiles);

--- a/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_cookie_importer.cc
+++ b/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_cookie_importer.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/utility/importer/browseros/chrome_cookie_importer.cc b/chrome/utility/importer/browseros/chrome_cookie_importer.cc
 new file mode 100644
-index 0000000000000..570f83ac1274c
+index 0000000000000..f905d442b87ef
 --- /dev/null
 +++ b/chrome/utility/importer/browseros/chrome_cookie_importer.cc
-@@ -0,0 +1,306 @@
+@@ -0,0 +1,299 @@
 +// Copyright 2024 AKW Technology Inc
 +// Chrome cookie importer implementation
 +
@@ -14,6 +14,7 @@ index 0000000000000..570f83ac1274c
 +#include "base/files/file_util.h"
 +#include "base/logging.h"
 +#include "chrome/utility/importer/browseros/chrome_decryptor.h"
++#include "chrome/utility/importer/browseros/chrome_importer_utils.h"
 +#include "sql/database.h"
 +#include "sql/statement.h"
 +
@@ -36,34 +37,6 @@ index 0000000000000..570f83ac1274c
 +inline constexpr sql::Database::Tag kDatabaseTag{"ChromeImporter"};
 +
 +constexpr char kCookiesFilename[] = "Cookies";
-+
-+// Copy database to temp location to avoid locking issues with Chrome
-+base::FilePath CopyDatabaseToTemp(const base::FilePath& db_path) {
-+  base::FilePath temp_path;
-+  if (!base::CreateTemporaryFile(&temp_path)) {
-+    LOG(WARNING) << "browseros: Failed to create temp file";
-+    return base::FilePath();
-+  }
-+
-+  if (!base::CopyFile(db_path, temp_path)) {
-+    LOG(WARNING) << "browseros: Failed to copy database to temp";
-+    base::DeleteFile(temp_path);
-+    return base::FilePath();
-+  }
-+
-+  return temp_path;
-+}
-+
-+// Convert Chrome's microseconds since Windows epoch to base::Time
-+// Chrome stores times as microseconds since Jan 1, 1601 (Windows epoch)
-+base::Time ChromeTimeToBaseTime(int64_t chrome_time) {
-+  if (chrome_time == 0) {
-+    return base::Time();
-+  }
-+  // base::Time::FromDeltaSinceWindowsEpoch handles the conversion
-+  return base::Time::FromDeltaSinceWindowsEpoch(
-+      base::Microseconds(chrome_time));
-+}
 +
 +// Map Chrome's samesite integer to net::CookieSameSite
 +net::CookieSameSite IntToSameSite(int value) {
@@ -209,7 +182,7 @@ index 0000000000000..570f83ac1274c
 +  sql::Database db(kDatabaseTag);
 +  if (!db.Open(temp_db_path)) {
 +    LOG(WARNING) << "browseros: Failed to open Cookies database";
-+    base::DeleteFile(temp_db_path);
++    DeleteDatabaseTemp(temp_db_path);
 +    return cookies;
 +  }
 +
@@ -228,6 +201,10 @@ index 0000000000000..570f83ac1274c
 +  constexpr size_t kSha256HashLength = 32;
 +  const bool has_domain_hash_prefix = (db_version >= 24);
 +
++  // Counters for cookies we cannot import (reported after the loop).
++  int skipped_app_bound = 0;
++  int failed_decrypt = 0;
++
 +  // Query cookies table - use scope block to ensure statement is destroyed
 +  // before db.Close() to avoid DCHECK failure
 +  {
@@ -242,7 +219,7 @@ index 0000000000000..570f83ac1274c
 +    sql::Statement statement(db.GetUniqueStatement(kQuery));
 +    if (!statement.is_valid()) {
 +      LOG(WARNING) << "browseros: Failed to prepare query";
-+      base::DeleteFile(temp_db_path);
++      DeleteDatabaseTemp(temp_db_path);
 +      return cookies;
 +    }
 +
@@ -259,19 +236,27 @@ index 0000000000000..570f83ac1274c
 +      // Prefer encrypted_value if present, otherwise use plaintext
 +      if (!encrypted_value.empty()) {
 +        std::string decrypted_value;
-+        if (DecryptChromeValue(encrypted_value, encryption_key,
-+                               &decrypted_value)) {
-+          // Chrome 130+ (db version ≥ 24) prepends SHA256 hash of domain
-+          // to the cookie value before encryption. Strip it after decryption.
-+          if (has_domain_hash_prefix &&
-+              decrypted_value.size() > kSha256HashLength) {
-+            entry.value = decrypted_value.substr(kSha256HashLength);
-+          } else {
-+            entry.value = decrypted_value;
-+          }
++        DecryptResult decrypt_result = DecryptChromeValue(
++            encrypted_value, encryption_key, &decrypted_value);
++        if (decrypt_result == DecryptResult::kAppBoundUnsupported) {
++          // Chrome 127+ App-Bound (v20) cookie. Its key is held by Chrome's
++          // SYSTEM elevation service, so we skip it instead of importing an
++          // undecryptable value.
++          ++skipped_app_bound;
++          continue;
++        }
++        if (decrypt_result != DecryptResult::kSuccess) {
++          // Genuine decryption failure: skip rather than store a junk value.
++          ++failed_decrypt;
++          continue;
++        }
++        // Chrome 130+ (db version ≥ 24) prepends the SHA256 hash of the domain
++        // to the cookie value before encryption. Strip it after decryption.
++        if (has_domain_hash_prefix &&
++            decrypted_value.size() >= kSha256HashLength) {
++          entry.value = decrypted_value.substr(kSha256HashLength);
 +        } else {
-+          // Fall back to plaintext if decryption fails
-+          entry.value = plaintext_value;
++          entry.value = decrypted_value;
 +        }
 +      } else {
 +        entry.value = plaintext_value;
@@ -304,7 +289,15 @@ index 0000000000000..570f83ac1274c
 +  }  // statement destroyed here
 +
 +  db.Close();
-+  base::DeleteFile(temp_db_path);
++  DeleteDatabaseTemp(temp_db_path);
++
++  if (skipped_app_bound > 0 || failed_decrypt > 0) {
++    LOG(WARNING) << "browseros: Cookie import skipped " << skipped_app_bound
++                 << " App-Bound (v20) cookies and " << failed_decrypt
++                 << " undecryptable cookies; imported " << cookies.size()
++                 << ". App-Bound cookies (Chrome 127+) require Chrome's "
++                    "SYSTEM elevation service and cannot be imported.";
++  }
 +
 +  return cookies;
 +}

--- a/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_decryptor.cc
+++ b/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_decryptor.cc
@@ -1,6 +1,6 @@
 diff --git a/chrome/utility/importer/browseros/chrome_decryptor.cc b/chrome/utility/importer/browseros/chrome_decryptor.cc
 new file mode 100644
-index 0000000000000..cf7ccdf4336f7
+index 0000000000000..36088220e95b9
 --- /dev/null
 +++ b/chrome/utility/importer/browseros/chrome_decryptor.cc
 @@ -0,0 +1,31 @@
@@ -25,11 +25,11 @@ index 0000000000000..cf7ccdf4336f7
 +  return std::string();
 +}
 +
-+bool DecryptChromeValue(const std::string& ciphertext,
-+                        const std::string& key,
-+                        std::string* plaintext) {
++DecryptResult DecryptChromeValue(const std::string& ciphertext,
++                                 const std::string& key,
++                                 std::string* plaintext) {
 +  LOG(INFO) << "browseros: Linux decryption not yet implemented";
-+  return false;
++  return DecryptResult::kError;
 +}
 +
 +#endif  // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS)

--- a/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_decryptor.h
+++ b/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_decryptor.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/utility/importer/browseros/chrome_decryptor.h b/chrome/utility/importer/browseros/chrome_decryptor.h
 new file mode 100644
-index 0000000000000..3805c007ec30c
+index 0000000000000..668d27973e57c
 --- /dev/null
 +++ b/chrome/utility/importer/browseros/chrome_decryptor.h
-@@ -0,0 +1,45 @@
+@@ -0,0 +1,56 @@
 +// Copyright 2024 AKW Technology Inc
 +// Chrome data decryption interface
 +
@@ -38,13 +38,24 @@ index 0000000000000..3805c007ec30c
 +std::string ExtractChromeKey(const base::FilePath& profile_path,
 +                             KeyExtractionResult* result);
 +
++// Outcome of decrypting a single Chrome-encrypted value.
++enum class DecryptResult {
++  kSuccess,              // |plaintext| holds the decrypted value.
++  kEmpty,                // Ciphertext was empty; nothing to decrypt.
++  kAppBoundUnsupported,  // Windows "v20" App-Bound Encryption (Chrome 127+).
++                         // The key is held by Chrome's SYSTEM-level elevation
++                         // service and is intentionally not decryptable by
++                         // another application. Callers should skip the value.
++  kError,                // Decryption failed (bad key, corrupt data, etc.).
++};
++
 +// Decrypt a Chrome-encrypted value (password_value or encrypted_value).
-+// |ciphertext| is the raw blob from the database (includes v10 prefix).
-+// |key| is the encryption key from ExtractChromeKey().
-+// Returns true on success and sets |plaintext|.
-+bool DecryptChromeValue(const std::string& ciphertext,
-+                        const std::string& key,
-+                        std::string* plaintext);
++// |ciphertext| is the raw blob from the database (may carry a "v10"/"v20"
++// version prefix, or be a legacy unprefixed blob). |key| is the key from
++// ExtractChromeKey(). On kSuccess, |plaintext| holds the decrypted value.
++DecryptResult DecryptChromeValue(const std::string& ciphertext,
++                                 const std::string& key,
++                                 std::string* plaintext);
 +
 +}  // namespace browseros_importer
 +

--- a/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_decryptor_mac.mm
+++ b/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_decryptor_mac.mm
@@ -1,9 +1,9 @@
 diff --git a/chrome/utility/importer/browseros/chrome_decryptor_mac.mm b/chrome/utility/importer/browseros/chrome_decryptor_mac.mm
 new file mode 100644
-index 0000000000000..d9aadb0466ace
+index 0000000000000..762582371aee4
 --- /dev/null
 +++ b/chrome/utility/importer/browseros/chrome_decryptor_mac.mm
-@@ -0,0 +1,191 @@
+@@ -0,0 +1,194 @@
 +// Copyright 2024 AKW Technology Inc
 +// Chrome decryption - macOS implementation
 +// Uses Keychain for key retrieval, PBKDF2 for key derivation, AES-128-CBC for decryption
@@ -33,6 +33,8 @@ index 0000000000000..d9aadb0466ace
 +constexpr size_t kIvLength = 16;
 +constexpr char kEncryptionVersionPrefix[] = "v10";
 +constexpr size_t kEncryptionVersionPrefixLength = 3;
++// Windows-only App-Bound marker; guarded against defensively (see below).
++constexpr char kAppBoundVersionPrefix[] = "v20";
 +
 +// IV is 16 space characters
 +constexpr uint8_t kIv[kIvLength] = {
@@ -160,36 +162,37 @@ index 0000000000000..d9aadb0466ace
 +                     derived_key.size());
 +}
 +
-+bool DecryptChromeValue(const std::string& ciphertext,
-+                        const std::string& key,
-+                        std::string* plaintext) {
++DecryptResult DecryptChromeValue(const std::string& ciphertext,
++                                 const std::string& key,
++                                 std::string* plaintext) {
 +  if (ciphertext.empty()) {
-+    return false;
++    return DecryptResult::kEmpty;
 +  }
 +
-+  // Check for v10 prefix (Chrome's encryption marker)
-+  if (ciphertext.length() < kEncryptionVersionPrefixLength ||
-+      !base::StartsWith(ciphertext, kEncryptionVersionPrefix)) {
-+    // Not encrypted with v10, might be plaintext or old format
-+    *plaintext = ciphertext;
-+    return true;
++  // App-Bound Encryption is Windows-only, but guard defensively so a v20 blob
++  // is skipped rather than mistaken for plaintext.
++  if (base::StartsWith(ciphertext, kAppBoundVersionPrefix)) {
++    return DecryptResult::kAppBoundUnsupported;
 +  }
 +
-+  // Extract the actual encrypted data (skip "v10" prefix)
-+  auto ciphertext_span = base::as_byte_span(ciphertext);
-+  auto encrypted_span = ciphertext_span.subspan(kEncryptionVersionPrefixLength);
-+  const uint8_t* encrypted_data = encrypted_span.data();
-+  size_t encrypted_length = encrypted_span.size();
-+
-+  if (encrypted_length == 0) {
-+    LOG(WARNING) << "browseros: Empty ciphertext after prefix";
-+    return false;
++  // v10 values: AES-128-CBC under the Keychain-derived key.
++  if (base::StartsWith(ciphertext, kEncryptionVersionPrefix)) {
++    auto encrypted_span =
++        base::as_byte_span(ciphertext).subspan(kEncryptionVersionPrefixLength);
++    if (encrypted_span.empty()) {
++      LOG(WARNING) << "browseros: Empty ciphertext after v10 prefix";
++      return DecryptResult::kError;
++    }
++    std::vector<uint8_t> key_bytes(key.begin(), key.end());
++    return DecryptAesCbc(key_bytes, encrypted_span.data(),
++                         encrypted_span.size(), plaintext)
++               ? DecryptResult::kSuccess
++               : DecryptResult::kError;
 +  }
 +
-+  // Convert key string to vector
-+  std::vector<uint8_t> key_bytes(key.begin(), key.end());
-+
-+  return DecryptAesCbc(key_bytes, encrypted_data, encrypted_length, plaintext);
++  // Unprefixed values are genuinely unencrypted on macOS.
++  *plaintext = ciphertext;
++  return DecryptResult::kSuccess;
 +}
 +
 +}  // namespace browseros_importer

--- a/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_decryptor_win.cc
+++ b/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_decryptor_win.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/utility/importer/browseros/chrome_decryptor_win.cc b/chrome/utility/importer/browseros/chrome_decryptor_win.cc
 new file mode 100644
-index 0000000000000..2472bd4a87972
+index 0000000000000..97d92c4309ffe
 --- /dev/null
 +++ b/chrome/utility/importer/browseros/chrome_decryptor_win.cc
-@@ -0,0 +1,247 @@
+@@ -0,0 +1,279 @@
 +// Copyright 2024 AKW Technology Inc
 +// Chrome decryption - Windows implementation
 +// Uses DPAPI for key retrieval, AES-256-GCM for decryption
@@ -13,6 +13,9 @@ index 0000000000000..2472bd4a87972
 +#include <windows.h>
 +
 +#include <wincrypt.h>
++
++#include <string>
++#include <utility>
 +
 +#include "base/base64.h"
 +#include "base/files/file_util.h"
@@ -32,6 +35,10 @@ index 0000000000000..2472bd4a87972
 +// Chrome's encryption constants for Windows
 +constexpr char kEncryptionVersionPrefix[] = "v10";
 +constexpr size_t kEncryptionVersionPrefixLength = 3;
++// Chrome 127+ App-Bound Encryption marker. Its key lives in Local State under
++// os_crypt.app_bound_encrypted_key and is sealed by Chrome's SYSTEM elevation
++// service, so values with this prefix cannot be decrypted here.
++constexpr char kAppBoundVersionPrefix[] = "v20";
 +constexpr char kDpapiPrefix[] = "DPAPI";
 +constexpr size_t kDpapiPrefixLength = 5;
 +constexpr size_t kNonceLength = 12;  // AES-GCM nonce
@@ -84,17 +91,44 @@ index 0000000000000..2472bd4a87972
 +  return true;
 +}
 +
-+// Decrypt using Windows DPAPI
++// Decrypt a raw DPAPI blob (no version prefix) with the current user's
++// credentials. Returns false if CryptUnprotectData fails.
++bool DecryptRawDpapiBlob(const uint8_t* data,
++                         size_t length,
++                         std::string* decrypted_data) {
++  DATA_BLOB input_blob;
++  input_blob.pbData = const_cast<BYTE*>(data);
++  input_blob.cbData = static_cast<DWORD>(length);
++
++  DATA_BLOB output_blob = {0};
++  if (!CryptUnprotectData(&input_blob, nullptr, nullptr, nullptr, nullptr,
++                          CRYPTPROTECT_UI_FORBIDDEN, &output_blob)) {
++    return false;
++  }
++
++  bool ok = false;
++  if (output_blob.pbData && output_blob.cbData > 0) {
++    decrypted_data->assign(reinterpret_cast<char*>(output_blob.pbData),
++                           output_blob.cbData);
++    ok = true;
++  }
++  if (output_blob.pbData) {
++    LocalFree(output_blob.pbData);
++  }
++  return ok;
++}
++
++// Decrypt the "DPAPI"-prefixed os_crypt key blob read from Local State.
 +bool DecryptWithDpapi(const std::string& encrypted_data,
 +                      std::string* decrypted_data) {
 +  if (encrypted_data.length() <= kDpapiPrefixLength) {
-+    LOG(WARNING) << "browseros: Encrypted data too short";
++    LOG(WARNING) << "browseros: Encrypted key too short";
 +    return false;
 +  }
 +
 +  // Check for "DPAPI" prefix
 +  if (!base::StartsWith(encrypted_data, kDpapiPrefix)) {
-+    LOG(WARNING) << "browseros: Missing DPAPI prefix";
++    LOG(WARNING) << "browseros: Missing DPAPI prefix on key";
 +    return false;
 +  }
 +
@@ -103,28 +137,12 @@ index 0000000000000..2472bd4a87972
 +                        kDpapiPrefixLength;
 +  size_t data_length = encrypted_data.length() - kDpapiPrefixLength;
 +
-+  DATA_BLOB input_blob;
-+  input_blob.pbData = const_cast<BYTE*>(data);
-+  input_blob.cbData = static_cast<DWORD>(data_length);
-+
-+  DATA_BLOB output_blob = {0};
-+
-+  if (!CryptUnprotectData(&input_blob, nullptr, nullptr, nullptr, nullptr,
-+                          CRYPTPROTECT_UI_FORBIDDEN, &output_blob)) {
-+    DWORD error = GetLastError();
-+    LOG(WARNING) << "browseros: CryptUnprotectData failed with error: "
-+                 << error;
++  if (!DecryptRawDpapiBlob(data, data_length, decrypted_data)) {
++    LOG(WARNING) << "browseros: CryptUnprotectData failed for key with error: "
++                 << GetLastError();
 +    return false;
 +  }
-+
-+  if (output_blob.pbData && output_blob.cbData > 0) {
-+    decrypted_data->assign(reinterpret_cast<char*>(output_blob.pbData),
-+                           output_blob.cbData);
-+    LocalFree(output_blob.pbData);
-+    return true;
-+  }
-+
-+  return false;
++  return true;
 +}
 +
 +// Decrypt AES-256-GCM encrypted data
@@ -218,34 +236,48 @@ index 0000000000000..2472bd4a87972
 +  return decrypted_key;
 +}
 +
-+bool DecryptChromeValue(const std::string& ciphertext,
-+                        const std::string& key,
-+                        std::string* plaintext) {
++DecryptResult DecryptChromeValue(const std::string& ciphertext,
++                                 const std::string& key,
++                                 std::string* plaintext) {
 +  if (ciphertext.empty()) {
-+    return false;
++    return DecryptResult::kEmpty;
 +  }
 +
-+  // Check for v10 prefix (Chrome's encryption marker)
-+  if (ciphertext.length() < kEncryptionVersionPrefixLength ||
-+      !base::StartsWith(ciphertext, kEncryptionVersionPrefix)) {
-+    // Not encrypted with v10, might be plaintext or old format
-+    LOG(INFO) << "browseros: Value doesn't have v10 prefix, may be unencrypted";
-+    *plaintext = ciphertext;
-+    return true;
++  // Chrome 127+ App-Bound Encryption. The key is sealed by Chrome's SYSTEM
++  // elevation service and cannot be recovered by another application, so the
++  // caller must skip this value rather than treat the blob as plaintext.
++  if (base::StartsWith(ciphertext, kAppBoundVersionPrefix)) {
++    return DecryptResult::kAppBoundUnsupported;
 +  }
 +
-+  // Extract the actual encrypted data (skip "v10" prefix)
-+  const uint8_t* encrypted_data =
-+      reinterpret_cast<const uint8_t*>(ciphertext.data()) +
-+      kEncryptionVersionPrefixLength;
-+  size_t encrypted_length = ciphertext.length() - kEncryptionVersionPrefixLength;
-+
-+  if (encrypted_length == 0) {
-+    LOG(WARNING) << "browseros: Empty ciphertext after prefix";
-+    return false;
++  // Modern (v10) values: AES-256-GCM under the DPAPI-wrapped os_crypt key.
++  if (base::StartsWith(ciphertext, kEncryptionVersionPrefix)) {
++    const uint8_t* encrypted_data =
++        reinterpret_cast<const uint8_t*>(ciphertext.data()) +
++        kEncryptionVersionPrefixLength;
++    size_t encrypted_length =
++        ciphertext.length() - kEncryptionVersionPrefixLength;
++    if (encrypted_length == 0) {
++      LOG(WARNING) << "browseros: Empty ciphertext after v10 prefix";
++      return DecryptResult::kError;
++    }
++    return DecryptAesGcm(key, encrypted_data, encrypted_length, plaintext)
++               ? DecryptResult::kSuccess
++               : DecryptResult::kError;
 +  }
 +
-+  return DecryptAesGcm(key, encrypted_data, encrypted_length, plaintext);
++  // Legacy unprefixed blob: either raw DPAPI (pre-v10 Chrome) or a genuinely
++  // unencrypted value. Try DPAPI first, then fall back to plaintext. Mirrors
++  // os_crypt_win.cc's handling of values without a version prefix.
++  std::string dpapi_plaintext;
++  if (DecryptRawDpapiBlob(reinterpret_cast<const uint8_t*>(ciphertext.data()),
++                          ciphertext.length(), &dpapi_plaintext)) {
++    *plaintext = std::move(dpapi_plaintext);
++    return DecryptResult::kSuccess;
++  }
++
++  *plaintext = ciphertext;
++  return DecryptResult::kSuccess;
 +}
 +
 +}  // namespace browseros_importer

--- a/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_importer_utils.cc
+++ b/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_importer_utils.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/utility/importer/browseros/chrome_importer_utils.cc b/chrome/utility/importer/browseros/chrome_importer_utils.cc
 new file mode 100644
-index 0000000000000..8b0401a695e20
+index 0000000000000..3000a42871631
 --- /dev/null
 +++ b/chrome/utility/importer/browseros/chrome_importer_utils.cc
-@@ -0,0 +1,37 @@
+@@ -0,0 +1,65 @@
 +// Copyright 2024 AKW Technology Inc
 +// Chrome importer shared utilities
 +
@@ -38,6 +38,34 @@ index 0000000000000..8b0401a695e20
 +  }
 +
 +  return temp_path;
++}
++
++base::FilePath CopyDatabaseToTemp(const base::FilePath& db_path) {
++  base::FilePath temp_path = CopyToTempFile(db_path);
++  if (temp_path.empty()) {
++    return base::FilePath();
++  }
++
++  // Also copy the "-wal" sidecar if present. base::CopyFile is best-effort: a
++  // partial trailing frame is expected and handled by SQLite's WAL recovery,
++  // which reads up to the last valid commit. Per SQLite guidance the "-shm"
++  // index is not copied; it is regenerated on open.
++  const base::FilePath::StringType kWalSuffix = FILE_PATH_LITERAL("-wal");
++  base::FilePath wal_src(db_path.value() + kWalSuffix);
++  if (base::PathExists(wal_src)) {
++    base::CopyFile(wal_src, base::FilePath(temp_path.value() + kWalSuffix));
++  }
++
++  return temp_path;
++}
++
++void DeleteDatabaseTemp(const base::FilePath& temp_path) {
++  if (temp_path.empty()) {
++    return;
++  }
++  base::DeleteFile(temp_path);
++  base::DeleteFile(base::FilePath(temp_path.value() + FILE_PATH_LITERAL("-wal")));
++  base::DeleteFile(base::FilePath(temp_path.value() + FILE_PATH_LITERAL("-shm")));
 +}
 +
 +}  // namespace browseros_importer

--- a/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_importer_utils.h
+++ b/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_importer_utils.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/utility/importer/browseros/chrome_importer_utils.h b/chrome/utility/importer/browseros/chrome_importer_utils.h
 new file mode 100644
-index 0000000000000..1a144725d2e89
+index 0000000000000..d7334846286cd
 --- /dev/null
 +++ b/chrome/utility/importer/browseros/chrome_importer_utils.h
-@@ -0,0 +1,23 @@
+@@ -0,0 +1,35 @@
 +// Copyright 2024 AKW Technology Inc
 +// Chrome importer shared utilities
 +
@@ -23,6 +23,18 @@ index 0000000000000..1a144725d2e89
 +// source browser is running. Returns empty path on failure.
 +// Caller is responsible for deleting the temp file when done.
 +base::FilePath CopyToTempFile(const base::FilePath& source_path);
++
++// Copies a SQLite database plus its "-wal" write-ahead-log sidecar (if present)
++// to a temporary location. Copying the WAL matters when the source browser is
++// running: recently written rows (e.g. fresh session cookies) may live only in
++// the WAL and would otherwise be missed. SQLite replays the WAL and rebuilds
++// the "-shm" index on open. Returns empty path on failure. Pair with
++// DeleteDatabaseTemp() for cleanup.
++base::FilePath CopyDatabaseToTemp(const base::FilePath& db_path);
++
++// Deletes a temp database created by CopyDatabaseToTemp(), including its "-wal"
++// and "-shm" sidecars. No-op for an empty path.
++void DeleteDatabaseTemp(const base::FilePath& temp_path);
 +
 +}  // namespace browseros_importer
 +

--- a/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_password_importer.cc
+++ b/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_password_importer.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/utility/importer/browseros/chrome_password_importer.cc b/chrome/utility/importer/browseros/chrome_password_importer.cc
 new file mode 100644
-index 0000000000000..1a01e3951aa3f
+index 0000000000000..896f66db32980
 --- /dev/null
 +++ b/chrome/utility/importer/browseros/chrome_password_importer.cc
-@@ -0,0 +1,150 @@
+@@ -0,0 +1,147 @@
 +// Copyright 2024 AKW Technology Inc
 +// Chrome password importer implementation
 +
@@ -13,6 +13,7 @@ index 0000000000000..1a01e3951aa3f
 +#include "base/logging.h"
 +#include "base/strings/utf_string_conversions.h"
 +#include "chrome/utility/importer/browseros/chrome_decryptor.h"
++#include "chrome/utility/importer/browseros/chrome_importer_utils.h"
 +#include "sql/database.h"
 +#include "sql/statement.h"
 +#include "url/gurl.h"
@@ -25,23 +26,6 @@ index 0000000000000..1a01e3951aa3f
 +inline constexpr sql::Database::Tag kDatabaseTag{"ChromeImporter"};
 +
 +constexpr char kLoginDataFilename[] = "Login Data";
-+
-+// Copy database to temp location to avoid locking issues with Chrome
-+base::FilePath CopyDatabaseToTemp(const base::FilePath& db_path) {
-+  base::FilePath temp_path;
-+  if (!base::CreateTemporaryFile(&temp_path)) {
-+    LOG(WARNING) << "browseros: Failed to create temp file";
-+    return base::FilePath();
-+  }
-+
-+  if (!base::CopyFile(db_path, temp_path)) {
-+    LOG(WARNING) << "browseros: Failed to copy database to temp";
-+    base::DeleteFile(temp_path);
-+    return base::FilePath();
-+  }
-+
-+  return temp_path;
-+}
 +
 +}  // namespace
 +
@@ -77,9 +61,12 @@ index 0000000000000..1a01e3951aa3f
 +  sql::Database db(kDatabaseTag);
 +  if (!db.Open(temp_db_path)) {
 +    LOG(WARNING) << "browseros: Failed to open Login Data database";
-+    base::DeleteFile(temp_db_path);
++    DeleteDatabaseTemp(temp_db_path);
 +    return passwords;
 +  }
++
++  // Count of passwords skipped because they use App-Bound Encryption.
++  int skipped_app_bound = 0;
 +
 +  // Query logins table - use scope block to ensure statement is destroyed before
 +  // db.Close() to avoid DCHECK failure
@@ -92,7 +79,7 @@ index 0000000000000..1a01e3951aa3f
 +    sql::Statement statement(db.GetUniqueStatement(kQuery));
 +    if (!statement.is_valid()) {
 +      LOG(WARNING) << "browseros: Failed to prepare query";
-+      base::DeleteFile(temp_db_path);
++      DeleteDatabaseTemp(temp_db_path);
 +      return passwords;
 +    }
 +
@@ -113,8 +100,14 @@ index 0000000000000..1a01e3951aa3f
 +      // Decrypt password
 +      std::string decrypted_password;
 +      if (!encrypted_password.empty()) {
-+        if (!DecryptChromeValue(encrypted_password, encryption_key,
-+                                &decrypted_password)) {
++        DecryptResult decrypt_result = DecryptChromeValue(
++            encrypted_password, encryption_key, &decrypted_password);
++        if (decrypt_result == DecryptResult::kAppBoundUnsupported) {
++          // App-Bound (v20) password; not decryptable outside Chrome. Skip.
++          ++skipped_app_bound;
++          continue;
++        }
++        if (decrypt_result != DecryptResult::kSuccess) {
 +          LOG(WARNING) << "browseros: Failed to decrypt password for: "
 +                       << origin_url;
 +          continue;
@@ -145,10 +138,14 @@ index 0000000000000..1a01e3951aa3f
 +  }  // statement destroyed here
 +
 +  db.Close();
-+  base::DeleteFile(temp_db_path);
++  DeleteDatabaseTemp(temp_db_path);
 +
-+  LOG(INFO) << "browseros: Imported " << passwords.size()
-+            << " passwords";
++  LOG(INFO) << "browseros: Imported " << passwords.size() << " passwords";
++  if (skipped_app_bound > 0) {
++    LOG(WARNING) << "browseros: Skipped " << skipped_app_bound
++                 << " App-Bound (v20) passwords that require Chrome's SYSTEM "
++                    "elevation service and cannot be imported.";
++  }
 +
 +  return passwords;
 +}


### PR DESCRIPTION
## Summary
- Chrome 127+ encrypts Windows cookies with **App-Bound Encryption ("v20")**, whose key is sealed by Chrome's SYSTEM elevation service and cannot be decrypted by another application. The importer only understood **"v10"** and silently imported undecryptable "v20" blobs as **raw ciphertext** — corrupting the import.
- Detect, **skip, and report** v20 values (and genuine decrypt failures) instead of storing garbage. Passwords and v10 cookies keep importing on Windows.
- Windows: decrypt legacy unprefixed values via **DPAPI** before treating them as plaintext (mirrors `os_crypt_win.cc`).
- Copy the SQLite **`-wal` sidecar** with the DB so freshly written cookies/passwords (present when the source browser is running) aren't missed; share the copy/cleanup helper between the cookie and password importers.
- Fix Windows profile-dir path construction to convert UTF-8 profile ids.

## Design
Graceful degradation, **not** a v20 crack. Decrypting v20 requires SYSTEM privileges (the key is behind Chrome's elevation service, which byte-for-byte validates the caller's exe path — a fork is rejected). Even Brave (imports no cookies, disabled Chrome password import) and browser-use-desktop (disables its importer on Windows) punt on this. A new `DecryptResult` status lets the cookie/password importers skip-and-count v20 values; the Windows-only decryptor mirrors Chromium's `os_crypt_win.cc`. macOS behavior is unchanged.

Follow-ups (out of scope): Edge/Brave/Opera/Vivaldi sources; a user-facing "N cookies skipped" banner (currently logged); SYSTEM-based v20 decryption; OSCrypt-reuse refactor.

## Test plan
- [x] `autoninja -C out/Default_arm64 chrome` (macOS arm64) via the global build lock — green; all importer TUs recompiled + linked.
- [x] Patch verify: **9/9 byte-match + apply-check** onto BASE.
- [ ] Windows: import from Google Chrome — passwords + v10 cookies import; v20 cookies logged as skipped, not corrupted.
- [ ] macOS: import from Google Chrome — no regression.

_Note: `chrome_decryptor_win.cc` is `is_win`-gated and not compiled by the macOS build; reviewed manually against `os_crypt_win.cc`._
