### PR TITLE
feat: browseros-version based update feed for sparkle/winsparkle

### DIFF
--- a/packages/browseros/build/common/context.py
+++ b/packages/browseros/build/common/context.py
@@ -30,6 +30,28 @@ from .paths import get_package_root
 
 
 # =============================================================================
+# Update feed versioning
+# =============================================================================
+#
+# resources/BROWSEROS_VERSION is the single source of update identity. The
+# feed version is "10000.MAJOR.MINOR.BUILD.PATCH": carried in the appcast's
+# sparkle:version, stamped into CFBundleVersion before signing (what Sparkle
+# compares), and mirrored by chrome/browser/win/winsparkle_glue.cc for
+# WinSparkle. The fixed 10000 epoch sorts above the retired feed scheme
+# (chromium BUILD.PATCH inflated by BROWSEROS_BUILD_OFFSET, ~7950.97 at
+# cutover) so already-shipped clients keep seeing new releases as upgrades.
+#
+# chrome/VERSION deliberately keeps the BUILD+offset scheme on every
+# platform: the Windows installer needs a unique, monotonically increasing
+# install version per release (versioned install dir + downgrade guard
+# against registry versions already shipped in the offset space), and one
+# uniform scheme everywhere beats a per-platform split. The updaters no
+# longer read it — which also means a release that bumps only the offset is
+# invisible to updaters; every release must bump the BrowserOS version.
+UPDATE_FEED_EPOCH = 10000
+
+
+# =============================================================================
 # Sub-Components - New modular structure
 # =============================================================================
 
@@ -190,6 +212,7 @@ class Context:
     build_type: str = "debug"
     chromium_version: str = ""
     browseros_build_offset: str = ""
+    browseros_version_parts: tuple = ()  # (major, minor, build, patch) ints
     browseros_chromium_version: str = ""
     semantic_version: str = ""  # e.g., "0.31.0" from resources/BROWSEROS_VERSION
     release_version: str = (
@@ -283,9 +306,13 @@ class Context:
                 self.root_dir
             )
 
-        # Load semantic version from resources/BROWSEROS_VERSION
+        # Load semantic version + parts from resources/BROWSEROS_VERSION
         if not self.semantic_version:
             self.semantic_version = self._load_semantic_version(self.root_dir)
+        if not self.browseros_version_parts:
+            self.browseros_version_parts = self._load_browseros_version_parts(
+                self.root_dir
+            )
 
         # Set nxtscape_chromium_version as chromium version with BUILD + nxtscape_version
         if self.chromium_version and self.browseros_build_offset and version_dict:
@@ -355,6 +382,26 @@ class Context:
         if version_file.exists():
             return version_file.read_text().strip()
         return ""
+
+    @staticmethod
+    def _load_browseros_version_parts(root_dir: Path) -> tuple:
+        """Load (major, minor, build, patch) ints from resources/BROWSEROS_VERSION."""
+        version_file = join_paths(root_dir, "resources", "BROWSEROS_VERSION")
+        if not version_file.exists():
+            return ()
+
+        version_dict = {}
+        for line in version_file.read_text().strip().split("\n"):
+            line = line.strip()
+            if not line or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            version_dict[key.strip()] = value.strip()
+
+        return tuple(
+            int(version_dict.get(f"BROWSEROS_{key}", "0"))
+            for key in ("MAJOR", "MINOR", "BUILD", "PATCH")
+        )
 
     @staticmethod
     def _load_semantic_version(root_dir: Path) -> str:
@@ -528,20 +575,19 @@ class Context:
         return self.semantic_version
 
     def get_sparkle_version(self) -> str:
-        """Get Sparkle-compatible version from browseros_chromium_version
+        """Update feed version compared by Sparkle/WinSparkle.
 
-        Sparkle uses BUILD.PATCH format for version comparison.
-        Returns: e.g., "7231.69"
+        Epoch-prefixed BrowserOS version (see version derivation notes at
+        the top of this module). Stamped into CFBundleVersion at signing,
+        mirrored by chrome/browser/win/winsparkle_glue.cc, and carried in
+        the appcast's sparkle:version — the three must stay in lockstep.
+        Returns: e.g., "10000.0.47.0.2"
         """
-        if not self.browseros_chromium_version:
-            raise ValueError("browseros_chromium_version is not set")
+        if not self.browseros_version_parts:
+            raise ValueError("resources/BROWSEROS_VERSION was not loaded")
 
-        parts = self.browseros_chromium_version.split(".")
-        if len(parts) < 4:
-            raise ValueError(
-                f"Invalid browseros_chromium_version format: {self.browseros_chromium_version}"
-            )
-        return f"{parts[2]}.{parts[3]}"
+        major, minor, build, patch = self.browseros_version_parts
+        return f"{UPDATE_FEED_EPOCH}.{major}.{minor}.{build}.{patch}"
 
     def get_release_path(self, platform: str) -> str:
         """Get R2 path for release artifacts

--- a/packages/browseros/build/common/testing_test.py
+++ b/packages/browseros/build/common/testing_test.py
@@ -206,6 +206,7 @@ class MakeContextTest(unittest.TestCase):
             # BUILD 7151 + offset 80 = 7231
             self.assertEqual(ctx.browseros_chromium_version, "137.0.7231.69")
             self.assertEqual(ctx.semantic_version, "0.31.0")
+            self.assertEqual(ctx.get_sparkle_version(), "10000.0.31.0.0")
             self.assertEqual(
                 ctx.get_features_yaml_path(), r.root / "build" / "features.yaml"
             )

--- a/packages/browseros/build/modules/sign/macos.py
+++ b/packages/browseros/build/modules/sign/macos.py
@@ -180,6 +180,7 @@ class MacOSSignModule(CommandModule):
         env_ok, env_vars = check_environment(ctx.env)
 
         self._verify_server_resources(app_path, ctx)
+        self._stamp_update_versions(app_path, ctx)
         self._clear_extended_attributes(app_path)
         self._sign_all_components(app_path, env_vars["certificate_name"], ctx)
         self._verify_signature(app_path, ctx)
@@ -187,6 +188,32 @@ class MacOSSignModule(CommandModule):
 
         ctx.artifact_registry.add("signed_app", app_path)
         log_success("Application signed and notarized successfully")
+
+    def _stamp_update_versions(self, app_path: Path, ctx: Context) -> None:
+        """Bake the update identity into the outer bundle before signing.
+
+        Sparkle compares the appcast's sparkle:version against
+        CFBundleVersion, so it must carry the epoch-prefixed BrowserOS
+        version (Context.get_sparkle_version) — the chromium build stamps
+        BUILD.PATCH there, which belongs to the retired offset scheme.
+        CFBundleShortVersionString is what Finder and Sparkle show users.
+        """
+        info_plist = app_path / "Contents" / "Info.plist"
+        feed_version = ctx.get_sparkle_version()
+        display_version = ctx.get_semantic_version()
+
+        run_command(
+            ["plutil", "-replace", "CFBundleVersion", "-string",
+             feed_version, str(info_plist)]
+        )
+        run_command(
+            ["plutil", "-replace", "CFBundleShortVersionString", "-string",
+             display_version, str(info_plist)]
+        )
+        log_info(
+            f"🏷️  Stamped CFBundleVersion={feed_version}, "
+            f"CFBundleShortVersionString={display_version}"
+        )
 
     def _verify_server_resources(self, app_path: Path, ctx: Context) -> None:
         problems = verify_server_resources_bundle(

--- a/packages/browseros/build/modules/storage/upload.py
+++ b/packages/browseros/build/modules/storage/upload.py
@@ -104,7 +104,7 @@ def generate_release_json(
     }
 
     # Sparkle (macOS) and WinSparkle (Windows) both compare against this
-    # BUILD.PATCH version in the appcast.
+    # epoch-prefixed BrowserOS version in the appcast (Context.get_sparkle_version).
     if platform in ("macos", "win"):
         release_data["sparkle_version"] = ctx.get_sparkle_version()
 

--- a/packages/browseros/chromium_patches/chrome/browser/mac/sparkle_glue.h
+++ b/packages/browseros/chromium_patches/chrome/browser/mac/sparkle_glue.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/mac/sparkle_glue.h b/chrome/browser/mac/sparkle_glue.h
 new file mode 100644
-index 0000000000000..868ffa7c1bfd0
+index 0000000000000..ad8ef816c7cd4
 --- /dev/null
 +++ b/chrome/browser/mac/sparkle_glue.h
-@@ -0,0 +1,84 @@
+@@ -0,0 +1,90 @@
 +// Copyright 2024 BrowserOS Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -52,6 +52,12 @@ index 0000000000000..868ffa7c1bfd0
 +
 +// Main interface for Sparkle integration.
 +// Thread-safety: All methods must be called on the main thread.
++//
++// Version comparison is entirely plist-driven: Sparkle compares the
++// appcast's sparkle:version against the outer bundle's CFBundleVersion,
++// which the release pipeline stamps with "10000.<BrowserOS version>"
++// before signing (Context.get_sparkle_version in the BrowserOS repo).
++// Windows mirrors the same string via winsparkle_glue.cc.
 +@interface SparkleGlue : NSObject
 +
 ++ (nullable instancetype)sharedSparkleGlue;

--- a/packages/browseros/chromium_patches/chrome/browser/win/winsparkle_glue.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/win/winsparkle_glue.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/win/winsparkle_glue.cc b/chrome/browser/win/winsparkle_glue.cc
 new file mode 100644
-index 0000000000000..869ed71be8869
+index 0000000000000..36d8f7ba9d353
 --- /dev/null
 +++ b/chrome/browser/win/winsparkle_glue.cc
-@@ -0,0 +1,351 @@
+@@ -0,0 +1,355 @@
 +// Copyright 2024 BrowserOS Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -15,7 +15,6 @@ index 0000000000000..869ed71be8869
 +#include <stdint.h>
 +
 +#include <string>
-+#include <vector>
 +
 +#include "base/command_line.h"
 +#include "base/files/file_path.h"
@@ -26,12 +25,11 @@ index 0000000000000..869ed71be8869
 +#include "base/path_service.h"
 +#include "base/process/launch.h"
 +#include "base/process/process.h"
-+#include "base/strings/string_number_conversions.h"
++#include "base/strings/strcat.h"
 +#include "base/strings/utf_string_conversions.h"
 +#include "base/task/single_thread_task_runner.h"
 +#include "base/task/thread_pool.h"
 +#include "base/time/time.h"
-+#include "base/version.h"
 +#include "base/version_info/version_info.h"
 +#include "build/build_config.h"
 +#include "content/public/browser/browser_thread.h"
@@ -60,6 +58,19 @@ index 0000000000000..869ed71be8869
 +constexpr int kUpdateCheckIntervalSeconds = 3600;
 +
 +constexpr char kRegistryPath[] = "Software\\BrowserOS\\WinSparkle";
++
++// Version compared against the appcast's sparkle:version: the BrowserOS
++// version behind a fixed epoch component. The epoch keeps new releases
++// sorting above the retired scheme where feeds carried chromium's
++// BUILD.PATCH inflated by BROWSEROS_BUILD_OFFSET (frozen at ~7950.97 at
++// cutover), so already-installed clients still see new releases as
++// upgrades. macOS bakes the identical string into CFBundleVersion at
++// packaging, and the appcast generator derives it in
++// Context.get_sparkle_version() (BrowserOS repo, build/common/context.py);
++// all three must stay in lockstep.
++std::string GetUpdateFeedVersion() {
++  return base::StrCat({"10000.", version_info::GetBrowserOSVersionNumber()});
++}
 +
 +// Owns WinSparkle state for the browser process. All public methods are UI
 +// thread only; Notify* run on the UI thread via PostToUI from WinSparkle's
@@ -273,22 +284,15 @@ index 0000000000000..869ed71be8869
 +    return false;
 +  }
 +
-+  // Display version for WinSparkle UI / User-Agent; comparisons use the
-+  // BUILD.PATCH build version below, which is what the appcast carries in
-+  // sparkle:version (same scheme as CFBundleVersion on macOS).
++  // WinSparkle UI / User-Agent shows the BrowserOS release version;
++  // comparisons use the epoch-prefixed feed version below.
 +  const std::wstring display_version =
-+      base::UTF8ToWide(version_info::GetVersionNumber());
++      base::UTF8ToWide(version_info::GetBrowserOSVersionNumber());
 +  win_sparkle_set_app_details(L"BrowserOS", L"BrowserOS",
 +                              display_version.c_str());
 +
-+  const std::vector<uint32_t>& components =
-+      version_info::GetVersion().components();
-+  if (components.size() >= 4) {
-+    const std::wstring build_version =
-+        base::UTF8ToWide(base::NumberToString(components[2]) + "." +
-+                         base::NumberToString(components[3]));
-+    win_sparkle_set_app_build_version(build_version.c_str());
-+  }
++  const std::wstring build_version = base::UTF8ToWide(GetUpdateFeedVersion());
++  win_sparkle_set_app_build_version(build_version.c_str());
 +
 +  win_sparkle_set_registry_path(kRegistryPath);
 +


### PR DESCRIPTION
## Summary
- Sparkle (mac) and WinSparkle (win) now compare `10000.MAJOR.MINOR.BUILD.PATCH` — the BrowserOS version behind a fixed epoch — instead of chromium `BUILD.PATCH` inflated by the build offset.
- One string, one derivation: `Context.get_sparkle_version()` feeds the appcast for both platforms; macOS gets it stamped into `CFBundleVersion` before signing (`sign/macos.py`), Windows mirrors it in `winsparkle_glue.cc` (patch extracted from chromium `b2232c03b8bf8`).
- `chrome/VERSION` and `BROWSEROS_BUILD_OFFSET` are deliberately untouched on every platform — the Windows installer still needs a unique, monotonically increasing install version per release, and one uniform scheme beats a per-platform split. The updaters simply no longer read it.

## Design
Shipped fleets compare in the old offset space (mac appcast ≤ ~7948.97; win ≤ ~7949.97, live since Jun 20). Sparkle 2.7 deprecates custom comparators and enforces an install-time standard-comparator downgrade guard, so feed versions must sort above that space forever — bare semver (`0.47.x`) would strand every installed client. `10000.<version>` is the smallest encoding that clears the fence while keeping the BrowserOS version legible; users only ever see `0.47.0.2` (shortVersionString everywhere). The three lockstep sites cross-reference each other in comments. One consequence, documented in code: every release must bump the BrowserOS version — an offset-only bump is invisible to updaters.

## Test plan
- [x] `uv run python -m unittest discover -s build -p "*_test.py"` — 108/108 green
- [x] `verify-patches.sh` — 2/2 byte-match + apply-check against chromium tip `b2232c03b8bf8`
- [x] `autoninja -C out/Default_arm64 chrome` green in ch1 (winsparkle_glue.cc is win-only; first Windows CI build is its compile gate)
- [ ] Next release: appcast items carry `sparkle:version 10000.0.47.x` and shipped 0.46/0.47 clients are offered the update

🤖 Generated with [Claude Code](https://claude.com/claude-code)