### PR TITLE
fix(patches): open browser window when onboarding is dismissed

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/ui/startup/startup_browser_creator.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/startup/startup_browser_creator.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/startup/startup_browser_creator.cc b/chrome/browser/ui/startup/startup_browser_creator.cc
-index 597bd5bfdcbbf..9f4392215e04e 100644
+index 597bd5bfdcbbf..9b8998497b560 100644
 --- a/chrome/browser/ui/startup/startup_browser_creator.cc
 +++ b/chrome/browser/ui/startup/startup_browser_creator.cc
 @@ -39,6 +39,7 @@
@@ -10,11 +10,14 @@ index 597bd5bfdcbbf..9f4392215e04e 100644
  #include "chrome/browser/browser_features.h"
  #include "chrome/browser/browser_process.h"
  #include "chrome/browser/extensions/startup_helper.h"
-@@ -474,6 +475,26 @@ void OpenNewWindowForFirstRun(const base::CommandLine& command_line,
+@@ -474,6 +475,46 @@ void OpenNewWindowForFirstRun(const base::CommandLine& command_line,
  }
  #endif  // BUILDFLAG(ENABLE_DICE_SUPPORT)
  
 +#if !BUILDFLAG(IS_CHROMEOS)
++// Exit callback for the BrowserOS onboarding first-run flow. Opens a browser
++// window whether onboarding completed or was dismissed (close/cancel/crash),
++// so the user is never left without a window.
 +void OpenNewWindowForBrowserOSOnboarding(
 +    const base::CommandLine& command_line,
 +    Profile* profile,
@@ -23,12 +26,29 @@ index 597bd5bfdcbbf..9f4392215e04e 100644
 +    chrome::startup::IsProcessStartup process_startup,
 +    chrome::startup::IsFirstRun is_first_run,
 +    ProfilePicker::FirstRunExitStatus status) {
-+  if (status != ProfilePicker::FirstRunExitStatus::kCompleted) {
++  // kAbortTask: a newer first-run attempt took over the picker and owns the
++  // launch. kAbandonedFlow: the user reached a browser window some other way
++  // or quit the app from the onboarding window.
++  if (status == ProfilePicker::FirstRunExitStatus::kAbortTask ||
++      status == ProfilePicker::FirstRunExitStatus::kAbandonedFlow) {
++    return;
++  }
++
++  // On Mac, Cmd+Q closes the onboarding window and reports kQuitAtEnd here;
++  // opening a window would fight the in-flight shutdown.
++  if (browser_shutdown::IsTryingToQuit() ||
++      browser_shutdown::HasShutdownStarted()) {
 +    return;
 +  }
 +
 +  StartupBrowserCreator browser_creator;
-+  browser_creator.AddFirstRunTabs(first_run_urls);
++  if (status == ProfilePicker::FirstRunExitStatus::kCompleted) {
++    browser_creator.AddFirstRunTabs(first_run_urls);
++  } else {
++    // Must precede LaunchBrowser(): it re-checks ShouldShow() and would
++    // re-open the onboarding picker mid-teardown.
++    browseros::onboarding::MarkCompleted(profile);
++  }
 +  browser_creator.LaunchBrowser(command_line, profile, cur_dir, process_startup,
 +                                is_first_run, /*restore_tabbed_browser=*/true);
 +}
@@ -37,7 +57,7 @@ index 597bd5bfdcbbf..9f4392215e04e 100644
  #if BUILDFLAG(IS_CHROMEOS)
  // Returns the app id of the kiosk app associated with the current user session.
  // Returns nullopt for non-kiosk user sessions and for ARCVM kiosk sessions,
-@@ -712,6 +733,18 @@ void StartupBrowserCreator::LaunchBrowser(
+@@ -712,6 +753,18 @@ void StartupBrowserCreator::LaunchBrowser(
        command_line, {profile, StartupProfileMode::kBrowserWindow});
  
    if (!IsSilentLaunchEnabled(command_line, profile)) {


### PR DESCRIPTION
## Summary
- Closing/cancelling the BrowserOS onboarding window (or a crashed flow) left the user with no browser window at all — the app stayed open showing nothing.
- Any non-completion exit now marks onboarding done and opens the default new-tab window; completion behavior is unchanged.
- Quit-in-progress (`Cmd+Q`) and superseded/abandoned flows still skip the launch so we don't fight shutdown or double-launch.

## Design
`OpenNewWindowForBrowserOSOnboarding()` — the `ProfilePicker` first-run exit callback in `chrome/browser/ui/startup/startup_browser_creator.cc` — previously bailed for any status other than `kCompleted`, while window close delivers `kQuitAtEnd`. The fix mirrors upstream FRE semantics (`FirstRunService::OnFirstRunHasExited` treats `kQuitAtEnd` as proceed + mark-finished): on `kQuitAtEnd` we call `browseros::onboarding::MarkCompleted()` and then `LaunchBrowser()`. Marking must happen first because `LaunchBrowser()` re-checks `ShouldShow()` and would re-open the onboarding picker mid-teardown. `kAbortTask`/`kAbandonedFlow` and `browser_shutdown::IsTryingToQuit()`/`HasShutdownStarted()` still return without launching. Extracted from chromium squash commit `8e840137f3582` (ch2, branch `browseros`).

## Test plan
- [x] `autoninja -C out/Default_arm64 chrome` green on the chromium checkout
- [x] `verify-patches.sh`: 1/1 byte-match against `BASE_COMMIT..8e840137f3582`, 1/1 apply-check onto the bare BASE tree
- [ ] Manual: fresh profile → close onboarding via traffic-light → new-tab window opens; relaunch → onboarding does not re-show; completing onboarding still opens the browser with first-run tabs