### PR TITLE
fix: ungate server resource staging

### DIFF
--- a/packages/browseros/bos_build/config/copy_resources.yaml
+++ b/packages/browseros/bos_build/config/copy_resources.yaml
@@ -93,7 +93,6 @@ copy_operations:
     source: "resources/binaries/browseros_server/darwin-arm64/resources"
     destination: "chrome/browser/browseros/server/resources"
     type: "directory"
-    product: ["browseros"]
     os: ["macos"]
     arch: ["arm64"]
 
@@ -101,7 +100,6 @@ copy_operations:
     source: "resources/binaries/browseros_server/darwin-x64/resources"
     destination: "chrome/browser/browseros/server/resources"
     type: "directory"
-    product: ["browseros"]
     os: ["macos"]
     arch: ["x64"]
 
@@ -109,7 +107,6 @@ copy_operations:
     source: "resources/binaries/browseros_server/linux-arm64/resources"
     destination: "chrome/browser/browseros/server/resources"
     type: "directory"
-    product: ["browseros"]
     os: ["linux"]
     arch: ["arm64"]
 
@@ -117,7 +114,6 @@ copy_operations:
     source: "resources/binaries/browseros_server/linux-x64/resources"
     destination: "chrome/browser/browseros/server/resources"
     type: "directory"
-    product: ["browseros"]
     os: ["linux"]
     arch: ["x64"]
 
@@ -125,7 +121,6 @@ copy_operations:
     source: "resources/binaries/browseros_server/windows-x64/resources"
     destination: "chrome/browser/browseros/server/resources"
     type: "directory"
-    product: ["browseros"]
     os: ["windows"]
     arch: ["x64"]
 
@@ -134,7 +129,6 @@ copy_operations:
     source: "resources/binaries/browseros_claw_server/darwin-arm64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
     type: "directory"
-    product: ["browserclaw"]
     os: ["macos"]
     arch: ["arm64"]
 
@@ -142,7 +136,6 @@ copy_operations:
     source: "resources/binaries/browseros_claw_server/darwin-x64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
     type: "directory"
-    product: ["browserclaw"]
     os: ["macos"]
     arch: ["x64"]
 
@@ -150,7 +143,6 @@ copy_operations:
     source: "resources/binaries/browseros_claw_server/linux-arm64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
     type: "directory"
-    product: ["browserclaw"]
     os: ["linux"]
     arch: ["arm64"]
 
@@ -158,7 +150,6 @@ copy_operations:
     source: "resources/binaries/browseros_claw_server/linux-x64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
     type: "directory"
-    product: ["browserclaw"]
     os: ["linux"]
     arch: ["x64"]
 
@@ -166,6 +157,5 @@ copy_operations:
     source: "resources/binaries/browseros_claw_server/windows-x64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
     type: "directory"
-    product: ["browserclaw"]
     os: ["windows"]
     arch: ["x64"]

--- a/packages/browseros/bos_build/config/download_resources.yaml
+++ b/packages/browseros/bos_build/config/download_resources.yaml
@@ -39,7 +39,6 @@ download_operations:
     r2_key: "artifacts/server/latest/browseros-server-resources-darwin-arm64.zip"
     destination: "resources/binaries/browseros_server/darwin-arm64"
     download_type: "artifact_zip"
-    product: ["browseros"]
     os: ["macos"]
     arch: ["arm64"]
 
@@ -47,7 +46,6 @@ download_operations:
     r2_key: "artifacts/server/latest/browseros-server-resources-darwin-x64.zip"
     destination: "resources/binaries/browseros_server/darwin-x64"
     download_type: "artifact_zip"
-    product: ["browseros"]
     os: ["macos"]
     arch: ["x64"]
 
@@ -55,7 +53,6 @@ download_operations:
     r2_key: "artifacts/server/latest/browseros-server-resources-linux-arm64.zip"
     destination: "resources/binaries/browseros_server/linux-arm64"
     download_type: "artifact_zip"
-    product: ["browseros"]
     os: ["linux"]
     arch: ["arm64"]
 
@@ -63,7 +60,6 @@ download_operations:
     r2_key: "artifacts/server/latest/browseros-server-resources-linux-x64.zip"
     destination: "resources/binaries/browseros_server/linux-x64"
     download_type: "artifact_zip"
-    product: ["browseros"]
     os: ["linux"]
     arch: ["x64"]
 
@@ -71,7 +67,6 @@ download_operations:
     r2_key: "artifacts/server/latest/browseros-server-resources-windows-x64.zip"
     destination: "resources/binaries/browseros_server/windows-x64"
     download_type: "artifact_zip"
-    product: ["browseros"]
     os: ["windows"]
     arch: ["x64"]
 
@@ -80,7 +75,6 @@ download_operations:
     r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-arm64.zip"
     destination: "resources/binaries/browseros_claw_server/darwin-arm64"
     download_type: "artifact_zip"
-    product: ["browserclaw"]
     os: ["macos"]
     arch: ["arm64"]
 
@@ -88,7 +82,6 @@ download_operations:
     r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-x64.zip"
     destination: "resources/binaries/browseros_claw_server/darwin-x64"
     download_type: "artifact_zip"
-    product: ["browserclaw"]
     os: ["macos"]
     arch: ["x64"]
 
@@ -96,7 +89,6 @@ download_operations:
     r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-arm64.zip"
     destination: "resources/binaries/browseros_claw_server/linux-arm64"
     download_type: "artifact_zip"
-    product: ["browserclaw"]
     os: ["linux"]
     arch: ["arm64"]
 
@@ -104,7 +96,6 @@ download_operations:
     r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-x64.zip"
     destination: "resources/binaries/browseros_claw_server/linux-x64"
     download_type: "artifact_zip"
-    product: ["browserclaw"]
     os: ["linux"]
     arch: ["x64"]
 
@@ -112,6 +103,5 @@ download_operations:
     r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-windows-x64.zip"
     destination: "resources/binaries/browseros_claw_server/windows-x64"
     download_type: "artifact_zip"
-    product: ["browserclaw"]
     os: ["windows"]
     arch: ["x64"]

--- a/packages/browseros/bos_build/core/context_test.py
+++ b/packages/browseros/bos_build/core/context_test.py
@@ -5,7 +5,9 @@ import tempfile
 import unittest
 from pathlib import Path
 from typing import cast
+from unittest import mock
 
+from . import context as context_mod
 from .context import Context
 from .products import ProductDescriptor, get_product_descriptor
 
@@ -72,35 +74,43 @@ class GetAppPathTest(unittest.TestCase):
         self.assertEqual(ctx.get_app_path(), pinned)
 
     def test_browserclaw_context_derives_names_and_paths(self):
-        ctx = Context(
-            chromium_src=Path("/nonexistent-src"),
-            architecture="arm64",
-            build_type="release",
-            product=get_product_descriptor("browserclaw"),
-        )
+        with (
+            mock.patch.object(context_mod, "IS_MACOS", return_value=True),
+            mock.patch.object(context_mod, "IS_WINDOWS", return_value=False),
+        ):
+            ctx = Context(
+                chromium_src=Path("/nonexistent-src"),
+                architecture="arm64",
+                build_type="release",
+                product=get_product_descriptor("browserclaw"),
+            )
 
-        self.assertEqual(ctx.BROWSEROS_APP_BASE_NAME, "BrowserClaw")
-        self.assertEqual(ctx.BROWSEROS_APP_NAME, "BrowserClaw.app")
-        self.assertEqual(ctx.out_dir, "out/Default_browserclaw_arm64")
-        self.assertEqual(
-            ctx.get_artifact_name("dmg"),
-            f"BrowserClaw_v{ctx.semantic_version}_arm64.dmg",
-        )
-        self.assertEqual(
-            ctx.get_release_path("macos"),
-            f"releases/browserclaw/{ctx.semantic_version}/macos/",
-        )
+            self.assertEqual(ctx.BROWSEROS_APP_BASE_NAME, "BrowserClaw")
+            self.assertEqual(ctx.BROWSEROS_APP_NAME, "BrowserClaw.app")
+            self.assertEqual(ctx.out_dir, "out/Default_browserclaw_arm64")
+            self.assertEqual(
+                ctx.get_artifact_name("dmg"),
+                f"BrowserClaw_v{ctx.semantic_version}_arm64.dmg",
+            )
+            self.assertEqual(
+                ctx.get_release_path("macos"),
+                f"releases/browserclaw/{ctx.semantic_version}/macos/",
+            )
 
     def test_context_accepts_product_id(self):
-        ctx = Context(
-            chromium_src=Path("/nonexistent-src"),
-            architecture="arm64",
-            build_type="release",
-            product=cast(ProductDescriptor, "browserclaw"),
-        )
+        with (
+            mock.patch.object(context_mod, "IS_MACOS", return_value=True),
+            mock.patch.object(context_mod, "IS_WINDOWS", return_value=False),
+        ):
+            ctx = Context(
+                chromium_src=Path("/nonexistent-src"),
+                architecture="arm64",
+                build_type="release",
+                product=cast(ProductDescriptor, "browserclaw"),
+            )
 
-        self.assertEqual(ctx.product.id, "browserclaw")
-        self.assertEqual(ctx.BROWSEROS_APP_NAME, "BrowserClaw.app")
+            self.assertEqual(ctx.product.id, "browserclaw")
+            self.assertEqual(ctx.BROWSEROS_APP_NAME, "BrowserClaw.app")
 
     def test_context_accepts_product_id_string(self):
         ctx = Context(

--- a/packages/browseros/bos_build/steps/resources/resources_test.py
+++ b/packages/browseros/bos_build/steps/resources/resources_test.py
@@ -187,7 +187,7 @@ class CopyResourcesTest(unittest.TestCase):
 
         self.assertFalse((self.chromium.src / "chrome" / "ghost").exists())
 
-    def test_real_config_copies_browseros_server_for_browseros_product(self):
+    def test_real_config_copies_server_resources_for_browseros_product(self):
         self.root.write_copy_config(self._real_copy_config())
         browseros_source = (
             self.root.root
@@ -240,9 +240,9 @@ class CopyResourcesTest(unittest.TestCase):
             / "browseros-claw-server"
         )
         self.assertEqual(browseros_dest.read_text(), "browseros")
-        self.assertFalse(claw_dest.exists())
+        self.assertEqual(claw_dest.read_text(), "claw")
 
-    def test_real_config_copies_claw_server_for_browserclaw_product(self):
+    def test_real_config_copies_server_resources_for_browserclaw_product(self):
         self.root.write_copy_config(self._real_copy_config())
         browseros_source = (
             self.root.root
@@ -295,7 +295,7 @@ class CopyResourcesTest(unittest.TestCase):
             / "bin"
             / "browseros-claw-server"
         )
-        self.assertFalse(browseros_dest.exists())
+        self.assertEqual(browseros_dest.read_text(), "browseros")
         self.assertEqual(claw_dest.read_text(), "claw")
 
     def _real_copy_config(self) -> dict:

--- a/packages/browseros/bos_build/steps/storage/download_test.py
+++ b/packages/browseros/bos_build/steps/storage/download_test.py
@@ -199,7 +199,7 @@ class ExtractArtifactZipTest(unittest.TestCase):
 
 
 class DownloadResourceConfigTest(unittest.TestCase):
-    def test_real_config_includes_browseros_artifacts_by_target(self) -> None:
+    def test_real_config_includes_server_artifacts_by_target(self) -> None:
         cases = [
             (
                 "macos",
@@ -209,6 +209,11 @@ class DownloadResourceConfigTest(unittest.TestCase):
                         "BrowserOS Server Resources - macOS ARM64",
                         "artifacts/server/latest/browseros-server-resources-darwin-arm64.zip",
                         "resources/binaries/browseros_server/darwin-arm64",
+                    ),
+                    (
+                        "BrowserOS Claw Server Resources - macOS ARM64",
+                        "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-arm64.zip",
+                        "resources/binaries/browseros_claw_server/darwin-arm64",
                     ),
                 ],
             ),
@@ -221,6 +226,11 @@ class DownloadResourceConfigTest(unittest.TestCase):
                         "artifacts/server/latest/browseros-server-resources-darwin-x64.zip",
                         "resources/binaries/browseros_server/darwin-x64",
                     ),
+                    (
+                        "BrowserOS Claw Server Resources - macOS x64",
+                        "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-x64.zip",
+                        "resources/binaries/browseros_claw_server/darwin-x64",
+                    ),
                 ],
             ),
             (
@@ -231,6 +241,11 @@ class DownloadResourceConfigTest(unittest.TestCase):
                         "BrowserOS Server Resources - Linux ARM64",
                         "artifacts/server/latest/browseros-server-resources-linux-arm64.zip",
                         "resources/binaries/browseros_server/linux-arm64",
+                    ),
+                    (
+                        "BrowserOS Claw Server Resources - Linux ARM64",
+                        "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-arm64.zip",
+                        "resources/binaries/browseros_claw_server/linux-arm64",
                     ),
                 ],
             ),
@@ -243,6 +258,11 @@ class DownloadResourceConfigTest(unittest.TestCase):
                         "artifacts/server/latest/browseros-server-resources-linux-x64.zip",
                         "resources/binaries/browseros_server/linux-x64",
                     ),
+                    (
+                        "BrowserOS Claw Server Resources - Linux x64",
+                        "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-x64.zip",
+                        "resources/binaries/browseros_claw_server/linux-x64",
+                    ),
                 ],
             ),
             (
@@ -253,6 +273,11 @@ class DownloadResourceConfigTest(unittest.TestCase):
                         "BrowserOS Server Resources - Windows x64",
                         "artifacts/server/latest/browseros-server-resources-windows-x64.zip",
                         "resources/binaries/browseros_server/windows-x64",
+                    ),
+                    (
+                        "BrowserOS Claw Server Resources - Windows x64",
+                        "claw-server/prod-resources/latest/browseros-claw-server-resources-windows-x64.zip",
+                        "resources/binaries/browseros_claw_server/windows-x64",
                     ),
                 ],
             ),
@@ -278,11 +303,13 @@ class DownloadResourceConfigTest(unittest.TestCase):
             [
                 "BrowserOS Server Resources - macOS ARM64",
                 "BrowserOS Server Resources - macOS x64",
+                "BrowserOS Claw Server Resources - macOS ARM64",
+                "BrowserOS Claw Server Resources - macOS x64",
             ],
             [op["name"] for op in filtered],
         )
 
-    def test_real_config_includes_claw_artifacts_for_browserclaw_product(self) -> None:
+    def test_real_config_includes_server_artifacts_for_browserclaw_product(self) -> None:
         operations = self._real_download_operations()
 
         filtered = self._filter_operations(
@@ -291,6 +318,11 @@ class DownloadResourceConfigTest(unittest.TestCase):
 
         self.assertEqual(
             [
+                (
+                    "BrowserOS Server Resources - macOS ARM64",
+                    "artifacts/server/latest/browseros-server-resources-darwin-arm64.zip",
+                    "resources/binaries/browseros_server/darwin-arm64",
+                ),
                 (
                     "BrowserOS Claw Server Resources - macOS ARM64",
                     "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-arm64.zip",


### PR DESCRIPTION
## Summary
- stage BrowserOS and BrowserClaw server resource downloads for every product while retaining OS/arch filters
- copy both server resource trees for every product so Chromium resource bundle targets can consume paths selected by GN flags
- update real-config tests for download/copy filtering across products and target platforms

## Test plan
- cd packages/browseros && uv run python -m unittest bos_build.steps.resources.resources_test bos_build.steps.storage.download_test
- cd packages/browseros && uv run python -m unittest discover -s bos_build -t . -p "*_test.py"

## Notes
- Adversarial review verdict: clean.
- Did not run autoninja because this patch does not change Chromium source code.
