### PR TITLE
feat(bpatch): refresh browseros pool checkouts

### DIFF
--- a/packages/browseros/bos_build/features.yaml
+++ b/packages/browseros/bos_build/features.yaml
@@ -115,15 +115,10 @@ features:
   win-sparkle-updater:
     description: "feat: win winsparkle updater"
     files:
-      - chrome/browser/BUILD.gn
-      - chrome/browser/buildflags.gni
       - chrome/browser/chrome_browser_main_win.cc
-      - chrome/browser/sparkle_buildflags.gni
-      - chrome/browser/ui/BUILD.gn
       - chrome/browser/ui/webui/help/version_updater_basic.cc
       - chrome/browser/ui/webui/help/winsparkle_version_updater_win.cc
       - chrome/browser/ui/webui/help/winsparkle_version_updater_win.h
-      - chrome/browser/upgrade_detector/upgrade_detector_impl.cc
       - chrome/browser/win/winsparkle_glue.cc
       - chrome/browser/win/winsparkle_glue.h
       - chrome/installer/mini_installer/BUILD.gn
@@ -275,9 +270,6 @@ features:
   onboarding-import:
     description: "feat: browseros onboarding import support"
     files:
-      - chrome/browser/browseros/BUILD.gn
-      - chrome/browser/browseros/core/browseros_prefs.cc
-      - chrome/browser/browseros/core/browseros_prefs.h
       - chrome/browser/browseros/onboarding/BUILD.gn
       - chrome/browser/browseros/onboarding/browseros_onboarding.cc
       - chrome/browser/browseros/onboarding/browseros_onboarding.h
@@ -287,15 +279,11 @@ features:
       - chrome/browser/browseros/onboarding/resources/app.css
       - chrome/browser/browseros/onboarding/resources/app.js
       - chrome/browser/browseros/onboarding/resources/index.html
-      - chrome/browser/chrome_browser_main.cc
-      - chrome/browser/ui/BUILD.gn
       - chrome/browser/ui/startup/startup_browser_creator.cc
       - chrome/browser/ui/views/profiles/first_run_flow_controller.cc
       - chrome/browser/ui/views/profiles/first_run_flow_controller.h
       - chrome/browser/ui/webui/BUILD.gn
-      - chrome/browser/ui/webui/chrome_web_ui_configs.cc
       - chrome/chrome_paks.gni
-      - chrome/common/webui_url_constants.cc
       - chrome/common/webui_url_constants.h
       - tools/gritsettings/resource_ids.spec
 
@@ -485,7 +473,6 @@ features:
     files:
       - chrome/browser/ui/profiles/profile_error_dialog.cc
       - chrome/browser/ui/startup/infobar_utils.cc
-      - chrome/installer/mini_installer/chrome.release
       - extensions/browser/process_manager.cc
       - extensions/browser/process_manager.h
       - third_party/blink/renderer/core/frame/navigator.cc

--- a/packages/browseros/tools/patch/cmd/common.go
+++ b/packages/browseros/tools/patch/cmd/common.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/engine"
+	patchlock "github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/lock"
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/repo"
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/ui"
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/workspace"
@@ -54,6 +55,8 @@ Rules:
 - browseros-patch list reads only registered Chromium checkouts; it does not inspect sync state.
 - Use browseros-patch status ch1 or browseros-patch diff ch1 before mutating.
 - Mutating commands: browseros-patch sync ch1 (alias: pull), browseros-patch apply ch1, browseros-patch extract ch1, browseros-patch annotate ch1.
+- Pool commands: browseros-patch refresh ch1 rebuilds the local browseros branch as feature commits from canonical patches.
+- Feature registration commands: browseros-patch feature lint validates patch ownership; browseros-patch feature add registers a newly extracted task range.
 - Every command accepts --json for machine-readable output and never prompts.
 
 Exit codes:
@@ -66,6 +69,7 @@ Status fields (browseros-patch status ch1 --json):
 - needs_update: checkout changes missing from the patch repo -> run extract.
 - orphaned: checkout files not represented in the patch set (untracked junk is pre-filtered).
 - pending_stash: sync parked local changes in a stash and has not restored them yet.
+- patches_rev / patches_freshness: patch-stack revision materialized on browseros; fresh or behind N vs repo_head.
 
 Daily flow (pull latest patches, keep local work):
 1. browseros-patch sync ch1            # pull patch repo, apply, rebase local changes
@@ -78,7 +82,18 @@ Capture flow (turn checkout changes into patches):
 3. browseros-patch publish -m "chore: sync patches"   # commit + push chromium_patches
 
 Feature commit flow (turn checkout changes into feature commits):
-1. browseros-patch annotate ch1            # commit changed files for all build/features.yaml features
+1. browseros-patch annotate ch1            # commit changed files for all bos_build/features.yaml features
+
+Pool refresh flow (rebuild browseros branch before leasing a checkout):
+1. browseros-patch status ch1 --json       # check patches_freshness
+2. browseros-patch refresh ch1             # pull patch repo, rebuild browseros from BASE_COMMIT + features
+3. result "fresh" means the browseros tip already carries the current Patches-Rev trailer
+4. use --force only to abandon tracked state or a task/* lease; untracked files and out/ are left alone
+
+After extracting a task branch:
+1. browseros-patch extract ch1 --range browseros..task/my-feature --squash
+2. browseros-patch feature add my-feature ch1 --description "feat: my feature" --files-from-range browseros..task/my-feature
+3. browseros-patch feature lint
 
 Chromium upgrade loop (move patches to a new Chromium base):
 1. gclient sync the checkout to the new Chromium revision.
@@ -183,4 +198,14 @@ func commandProgress(cmd *cobra.Command) engine.Progress {
 	stderr := cmd.ErrOrStderr()
 	activeProgress = &cliProgress{w: stderr, tty: isTerminal(stderr)}
 	return activeProgress
+}
+
+func withPatchRepoLock(cmd *cobra.Command, info *repo.Info, progress engine.Progress, fn func(*repo.Info) error) error {
+	return patchlock.WithRepoLock(cmd.Context(), info.Root, progress, func() error {
+		lockedInfo, err := repo.Load(info.Root)
+		if err != nil {
+			return err
+		}
+		return fn(lockedInfo)
+	})
 }

--- a/packages/browseros/tools/patch/cmd/common_test.go
+++ b/packages/browseros/tools/patch/cmd/common_test.go
@@ -411,6 +411,9 @@ func TestParseRevRange(t *testing.T) {
 	if _, _, err := parseRevRange("browseros"); err == nil {
 		t.Fatalf("expected invalid range error")
 	}
+	if _, _, err := parseRevRange("browseros...task/demo"); err == nil {
+		t.Fatalf("expected three-dot range error")
+	}
 }
 
 func TestCheckoutCommandExamplesUseNamedCheckout(t *testing.T) {

--- a/packages/browseros/tools/patch/cmd/common_test.go
+++ b/packages/browseros/tools/patch/cmd/common_test.go
@@ -350,8 +350,9 @@ func TestCheckoutCommandUsageTerminology(t *testing.T) {
 		{name: "status", use: "status [checkout]"},
 		{name: "apply", use: "apply [checkout] [-- files...]"},
 		{name: "sync", use: "sync [checkout]"},
-		{name: "extract", use: "extract [checkout] [--range <start> <end>] [-- files...]"},
+		{name: "extract", use: "extract [checkout] [--range <start>..<end>|<start> <end>] [-- files...]"},
 		{name: "annotate", use: "annotate [checkout]"},
+		{name: "refresh", use: "refresh [checkout]"},
 	} {
 		cmd, _, err := rootCmd.Find([]string{tc.name})
 		if err != nil {
@@ -384,7 +385,8 @@ func TestRootHelpExplainsPatchRepoAndCheckoutModel(t *testing.T) {
 		"browseros-patch diff ch1",
 		"browseros-patch sync ch1",
 		"browseros-patch extract ch1",
-		"browseros-patch annotate ch1",
+		"browseros-patch refresh ch1",
+		"browseros-patch feature lint",
 	} {
 		if !strings.Contains(rootCmd.Example, want) {
 			t.Fatalf("expected root examples to contain %q, got:\n%s", want, rootCmd.Example)
@@ -395,6 +397,19 @@ func TestRootHelpExplainsPatchRepoAndCheckoutModel(t *testing.T) {
 func TestRootExamplesDoNotRenderSourceTabs(t *testing.T) {
 	if strings.Contains(rootCmd.Example, "\n\t") {
 		t.Fatalf("root examples should render with spaces, got:\n%s", rootCmd.Example)
+	}
+}
+
+func TestParseRevRange(t *testing.T) {
+	start, end, err := parseRevRange("browseros..task/demo")
+	if err != nil {
+		t.Fatalf("parseRevRange: %v", err)
+	}
+	if start != "browseros" || end != "task/demo" {
+		t.Fatalf("range = %s..%s, want browseros..task/demo", start, end)
+	}
+	if _, _, err := parseRevRange("browseros"); err == nil {
+		t.Fatalf("expected invalid range error")
 	}
 }
 
@@ -409,6 +424,7 @@ func TestCheckoutCommandExamplesUseNamedCheckout(t *testing.T) {
 		{name: "sync", example: "browseros-patch sync ch1"},
 		{name: "extract", example: "browseros-patch extract ch1"},
 		{name: "annotate", example: "browseros-patch annotate ch1"},
+		{name: "refresh", example: "browseros-patch refresh ch1"},
 	} {
 		cmd, _, err := rootCmd.Find([]string{tc.name})
 		if err != nil {
@@ -424,7 +440,7 @@ func TestCheckoutCommandExamplesUseNamedCheckout(t *testing.T) {
 }
 
 func TestSrcFlagExplainsDirectCheckoutPath(t *testing.T) {
-	for _, name := range []string{"diff", "status", "apply", "sync", "extract", "annotate"} {
+	for _, name := range []string{"diff", "status", "apply", "sync", "extract", "annotate", "refresh"} {
 		cmd, _, err := rootCmd.Find([]string{name})
 		if err != nil {
 			t.Fatalf("find %s: %v", name, err)

--- a/packages/browseros/tools/patch/cmd/extract.go
+++ b/packages/browseros/tools/patch/cmd/extract.go
@@ -2,8 +2,10 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/engine"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/repo"
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -17,10 +19,11 @@ func init() {
 	var dryRun bool
 	var excludes []string
 	command := &cobra.Command{
-		Use:         "extract [checkout] [--range <start> <end>] [-- files...]",
+		Use:         "extract [checkout] [--range <start>..<end>|<start> <end>] [-- files...]",
 		Annotations: map[string]string{"group": "Core:"},
 		Short:       "Extract checkout changes back to chromium_patches",
 		Example: `  browseros-patch extract ch1
+  browseros-patch extract ch1 --range HEAD~2..HEAD
   browseros-patch extract ch1 --range HEAD~2 HEAD
   browseros-patch extract --src /path/to/chromium/src`,
 		Args: cobra.ArbitraryArgs,
@@ -30,12 +33,21 @@ func init() {
 			rangeStart := ""
 			rangeEnd := ""
 			if rangeMode {
-				if len(positional) < 2 || len(positional) > 3 {
-					return fmt.Errorf(`range mode expects "browseros-patch extract [checkout] --range <start> <end>"`)
+				switch {
+				case len(positional) >= 1 && len(positional) <= 2 && strings.Contains(positional[len(positional)-1], ".."):
+					var parseErr error
+					rangeStart, rangeEnd, parseErr = parseRevRange(positional[len(positional)-1])
+					if parseErr != nil {
+						return parseErr
+					}
+					workspaceArgs = positional[:len(positional)-1]
+				case len(positional) >= 2 && len(positional) <= 3:
+					rangeStart = positional[len(positional)-2]
+					rangeEnd = positional[len(positional)-1]
+					workspaceArgs = positional[:len(positional)-2]
+				default:
+					return fmt.Errorf(`range mode expects "browseros-patch extract [checkout] --range <start>..<end>"`)
 				}
-				rangeStart = positional[len(positional)-2]
-				rangeEnd = positional[len(positional)-1]
-				workspaceArgs = positional[:len(positional)-2]
 			}
 			if len(workspaceArgs) > 1 {
 				return fmt.Errorf("expected at most one checkout name")
@@ -48,19 +60,30 @@ func init() {
 			if err != nil {
 				return err
 			}
-			result, err := engine.Extract(cmd.Context(), engine.ExtractOptions{
-				Workspace:  ws,
-				Repo:       info,
-				Commit:     commit,
-				RangeStart: rangeStart,
-				RangeEnd:   rangeEnd,
-				Squash:     squash,
-				Base:       base,
-				Filters:    filters,
-				Excludes:   excludes,
-				DryRun:     dryRun,
-				Progress:   commandProgress(cmd),
-			})
+			progress := commandProgress(cmd)
+			var result *engine.ExtractResult
+			runExtract := func(runInfo *repo.Info) error {
+				var extractErr error
+				result, extractErr = engine.Extract(cmd.Context(), engine.ExtractOptions{
+					Workspace:  ws,
+					Repo:       runInfo,
+					Commit:     commit,
+					RangeStart: rangeStart,
+					RangeEnd:   rangeEnd,
+					Squash:     squash,
+					Base:       base,
+					Filters:    filters,
+					Excludes:   excludes,
+					DryRun:     dryRun,
+					Progress:   progress,
+				})
+				return extractErr
+			}
+			if dryRun {
+				err = runExtract(info)
+			} else {
+				err = withPatchRepoLock(cmd, info, progress, runExtract)
+			}
 			if err != nil {
 				return err
 			}

--- a/packages/browseros/tools/patch/cmd/feature.go
+++ b/packages/browseros/tools/patch/cmd/feature.go
@@ -124,6 +124,9 @@ func newFeatureAddCommand() *cobra.Command {
 }
 
 func parseRevRange(spec string) (string, string, error) {
+	if strings.Contains(spec, "...") {
+		return "", "", fmt.Errorf(`expected --files-from-range in "<start>..<end>" form, not three-dot syntax`)
+	}
 	parts := strings.Split(spec, "..")
 	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
 		return "", "", fmt.Errorf(`expected --files-from-range in "<start>..<end>" form`)

--- a/packages/browseros/tools/patch/cmd/feature.go
+++ b/packages/browseros/tools/patch/cmd/feature.go
@@ -1,0 +1,132 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/engine"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/repo"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	command := &cobra.Command{
+		Use:         "feature",
+		Annotations: map[string]string{"group": "Core:"},
+		Short:       "Manage patch feature registration",
+	}
+	command.AddCommand(newFeatureLintCommand())
+	command.AddCommand(newFeatureAddCommand())
+	rootCmd.AddCommand(command)
+}
+
+func newFeatureLintCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "lint",
+		Short: "Validate every patch is claimed by exactly one feature",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			info, err := repoInfo()
+			if err != nil {
+				return err
+			}
+			result, err := engine.LintFeatures(info)
+			if err != nil {
+				return err
+			}
+			if err := renderResult(result, func() {
+				if result.Valid() {
+					fmt.Println(ui.Success("Feature ownership is valid"))
+				} else {
+					fmt.Println(ui.Warning("Feature ownership has errors"))
+				}
+				fmt.Printf("%s  %s\n", ui.Muted("features file:"), result.FeaturesFile)
+				fmt.Printf("%s  %d\n", ui.Muted("features:"), result.Features)
+				fmt.Printf("%s  %d\n", ui.Muted("patches:"), result.Patches)
+				printGroup("Unclaimed", result.Unclaimed)
+				if len(result.Duplicates) > 0 {
+					fmt.Println(ui.Header("Duplicates:"))
+					for _, duplicate := range result.Duplicates {
+						fmt.Printf("  %s  %s\n", duplicate.Path, strings.Join(duplicate.Features, ", "))
+					}
+				}
+			}); err != nil {
+				return err
+			}
+			return result.Error()
+		},
+	}
+}
+
+func newFeatureAddCommand() *cobra.Command {
+	var src string
+	var description string
+	var filesFromRange string
+	command := &cobra.Command{
+		Use:   "add <name> [checkout]",
+		Short: "Append a feature entry from a checkout range",
+		Example: `  browseros-patch feature add new-api ch1 --description "feat: new api" --files-from-range browseros..task/new-api
+  browseros-patch feature add new-api --src /path/to/chromium/src --description "feat: new api" --files-from-range browseros..task/new-api`,
+		Args: cobra.RangeArgs(1, 2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name := args[0]
+			workspaceArgs := args[1:]
+			ws, err := resolveWorkspace(cmd, workspaceArgs, src)
+			if err != nil {
+				return err
+			}
+			rangeStart, rangeEnd, err := parseRevRange(filesFromRange)
+			if err != nil {
+				return err
+			}
+			info, err := repoInfo()
+			if err != nil {
+				return err
+			}
+			progress := commandProgress(cmd)
+			var result *engine.FeatureAddResult
+			err = withPatchRepoLock(cmd, info, progress, func(lockedInfo *repo.Info) error {
+				var addErr error
+				result, addErr = engine.AddFeatureFromRange(cmd.Context(), engine.FeatureAddOptions{
+					Workspace:   ws,
+					Repo:        lockedInfo,
+					Name:        name,
+					Description: description,
+					RangeStart:  rangeStart,
+					RangeEnd:    rangeEnd,
+				})
+				return addErr
+			})
+			if err != nil {
+				return err
+			}
+			return renderResult(result, func() {
+				fmt.Println(ui.Title(fmt.Sprintf("Added feature %s", result.Name)))
+				fmt.Printf("%s  %s\n", ui.Muted("features file:"), result.FeaturesFile)
+				fmt.Printf("%s  %d\n", ui.Muted("files:"), len(result.Added))
+				printGroup("Added", result.Added)
+				if len(result.Excluded) > 0 {
+					fmt.Println(ui.Header("Excluded existing claims:"))
+					for _, excluded := range result.Excluded {
+						fmt.Printf("  %s  %s\n", excluded.Path, strings.Join(excluded.Features, ", "))
+					}
+				}
+			})
+		},
+	}
+	command.Flags().StringVar(&src, "src", "", srcFlagUsage)
+	command.Flags().StringVar(&description, "description", "", "Feature commit subject to store in features.yaml")
+	command.Flags().StringVar(&filesFromRange, "files-from-range", "", "Checkout range like browseros..task/name")
+	_ = command.MarkFlagRequired("description")
+	_ = command.MarkFlagRequired("files-from-range")
+	return command
+}
+
+func parseRevRange(spec string) (string, string, error) {
+	parts := strings.Split(spec, "..")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", fmt.Errorf(`expected --files-from-range in "<start>..<end>" form`)
+	}
+	return parts[0], parts[1], nil
+}

--- a/packages/browseros/tools/patch/cmd/publish.go
+++ b/packages/browseros/tools/patch/cmd/publish.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/engine"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/repo"
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -24,11 +25,17 @@ func init() {
 			if len(args) == 1 {
 				remote = args[0]
 			}
-			result, err := engine.Publish(cmd.Context(), engine.PublishOptions{
-				Repo:     info,
-				Remote:   remote,
-				Message:  message,
-				Progress: commandProgress(cmd),
+			progress := commandProgress(cmd)
+			var result *engine.PublishResult
+			err = withPatchRepoLock(cmd, info, progress, func(lockedInfo *repo.Info) error {
+				var publishErr error
+				result, publishErr = engine.Publish(cmd.Context(), engine.PublishOptions{
+					Repo:     lockedInfo,
+					Remote:   remote,
+					Message:  message,
+					Progress: progress,
+				})
+				return publishErr
 			})
 			if err != nil {
 				return err

--- a/packages/browseros/tools/patch/cmd/refresh.go
+++ b/packages/browseros/tools/patch/cmd/refresh.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/engine"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/repo"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	var src string
+	var force bool
+	var remote string
+	command := &cobra.Command{
+		Use:         "refresh [checkout]",
+		Annotations: map[string]string{"group": "Core:"},
+		Short:       "Rebuild a checkout's browseros branch from canonical patches",
+		Example: `  browseros-patch refresh ch1
+  browseros-patch refresh ch1 --force
+  browseros-patch refresh --src /path/to/chromium/src`,
+		Args: cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ws, err := resolveWorkspace(cmd, args, src)
+			if err != nil {
+				return err
+			}
+			info, err := repoInfo()
+			if err != nil {
+				return err
+			}
+			progress := commandProgress(cmd)
+			var result *engine.RefreshResult
+			err = withPatchRepoLock(cmd, info, progress, func(lockedInfo *repo.Info) error {
+				var refreshErr error
+				result, refreshErr = engine.Refresh(cmd.Context(), engine.RefreshOptions{
+					Workspace: ws,
+					Repo:      lockedInfo,
+					Remote:    remote,
+					Force:     force,
+					Pull:      true,
+					Progress:  progress,
+				})
+				return refreshErr
+			})
+			if err != nil {
+				return err
+			}
+			return renderResult(result, func() {
+				if result.Result == "fresh" {
+					fmt.Println(ui.Success(fmt.Sprintf("%s is fresh", ws.Name)))
+				} else {
+					fmt.Println(ui.Title(fmt.Sprintf("Refreshed %s", ws.Name)))
+				}
+				fmt.Printf("%s  %s\n", ui.Muted("patches rev:"), result.PatchesRev)
+				fmt.Printf("%s  %d\n", ui.Muted("features:"), result.Features)
+				fmt.Printf("%s  %d\n", ui.Muted("commits:"), len(result.Commits))
+				for _, warning := range result.Warnings {
+					fmt.Println(ui.Warning(warning))
+				}
+				if len(result.Commits) > 0 {
+					fmt.Println(ui.Header("Committed:"))
+					for _, commit := range result.Commits {
+						fmt.Printf("  %-24s %s  %d %s\n", commit.Feature, shortCommit(commit.Commit), len(commit.Files), pluralFiles(len(commit.Files)))
+					}
+				}
+			})
+		},
+	}
+	command.Flags().StringVar(&src, "src", "", srcFlagUsage)
+	command.Flags().BoolVar(&force, "force", false, "Abandon tracked checkout state before rebuilding")
+	command.Flags().StringVar(&remote, "remote", "origin", "Remote to pull patch repo updates from")
+	rootCmd.AddCommand(command)
+}

--- a/packages/browseros/tools/patch/cmd/refresh.go
+++ b/packages/browseros/tools/patch/cmd/refresh.go
@@ -13,6 +13,7 @@ func init() {
 	var src string
 	var force bool
 	var remote string
+	var noPull bool
 	command := &cobra.Command{
 		Use:         "refresh [checkout]",
 		Annotations: map[string]string{"group": "Core:"},
@@ -39,7 +40,7 @@ func init() {
 					Repo:      lockedInfo,
 					Remote:    remote,
 					Force:     force,
-					Pull:      true,
+					Pull:      !noPull,
 					Progress:  progress,
 				})
 				return refreshErr
@@ -70,6 +71,7 @@ func init() {
 	}
 	command.Flags().StringVar(&src, "src", "", srcFlagUsage)
 	command.Flags().BoolVar(&force, "force", false, "Abandon tracked checkout state before rebuilding")
+	command.Flags().BoolVar(&noPull, "no-pull", false, "Use the local patch repo state without pulling first")
 	command.Flags().StringVar(&remote, "remote", "origin", "Remote to pull patch repo updates from")
 	rootCmd.AddCommand(command)
 }

--- a/packages/browseros/tools/patch/cmd/root.go
+++ b/packages/browseros/tools/patch/cmd/root.go
@@ -98,7 +98,8 @@ Pass a checkout name to run from anywhere, for example "browseros-patch diff ch1
 		"  browseros-patch diff ch1\n" +
 		"  browseros-patch sync ch1\n" +
 		"  browseros-patch extract ch1\n" +
-		"  browseros-patch annotate ch1",
+		"  browseros-patch refresh ch1\n" +
+		"  browseros-patch feature lint",
 	Version:       Version,
 	SilenceUsage:  true,
 	SilenceErrors: true,

--- a/packages/browseros/tools/patch/cmd/status.go
+++ b/packages/browseros/tools/patch/cmd/status.go
@@ -63,9 +63,12 @@ func init() {
 				}
 				fmt.Printf("%s  %s\n", ui.Muted("path:"), ws.Path)
 				fmt.Printf("%s  %s\n", ui.Muted("repo head:"), status.RepoHead)
+				fmt.Printf("%s  %s\n", ui.Muted("patches rev:"), status.PatchesRev)
+				fmt.Printf("%s  %s\n", ui.Muted("patches freshness:"), status.PatchesFreshness)
 				fmt.Printf("%s  %s\n", ui.Muted("last sync:"), status.LastSyncRev)
 				fmt.Printf("%s  %s\n", ui.Muted("last apply:"), status.LastApplyRev)
 				fmt.Printf("%s  %s\n", ui.Muted("last extract:"), status.LastExtractRev)
+				fmt.Printf("%s  %s\n", ui.Muted("last refresh:"), status.LastRefreshRev)
 				fmt.Printf("%s  %d\n", ui.Muted("needs apply:"), len(status.NeedsApply))
 				fmt.Printf("%s  %d\n", ui.Muted("needs update:"), len(status.NeedsUpdate))
 				fmt.Printf("%s  %d\n", ui.Muted("orphaned:"), len(status.Orphaned))
@@ -93,14 +96,16 @@ func init() {
 // statusRow is the compact per-checkout shape used by status --all.
 // pending_stash carries the same string ref as the single-checkout status.
 type statusRow struct {
-	Workspace    string `json:"workspace"`
-	Path         string `json:"path"`
-	SyncState    string `json:"sync_state,omitempty"`
-	NeedsApply   int    `json:"needs_apply"`
-	NeedsUpdate  int    `json:"needs_update"`
-	Orphaned     int    `json:"orphaned"`
-	PendingStash string `json:"pending_stash,omitempty"`
-	Error        string `json:"error,omitempty"`
+	Workspace        string `json:"workspace"`
+	Path             string `json:"path"`
+	SyncState        string `json:"sync_state,omitempty"`
+	NeedsApply       int    `json:"needs_apply"`
+	NeedsUpdate      int    `json:"needs_update"`
+	Orphaned         int    `json:"orphaned"`
+	PatchesRev       string `json:"patches_rev,omitempty"`
+	PatchesFreshness string `json:"patches_freshness,omitempty"`
+	PendingStash     string `json:"pending_stash,omitempty"`
+	Error            string `json:"error,omitempty"`
 }
 
 func runStatusAll(cmd *cobra.Command) error {
@@ -126,16 +131,18 @@ func runStatusAll(cmd *cobra.Command) error {
 			row.NeedsApply = len(status.NeedsApply)
 			row.NeedsUpdate = len(status.NeedsUpdate)
 			row.Orphaned = len(status.Orphaned)
+			row.PatchesRev = status.PatchesRev
+			row.PatchesFreshness = status.PatchesFreshness
 			row.PendingStash = status.PendingStash
 		}
 		rows = append(rows, row)
 	}
 	return renderResult(rows, func() {
-		headers := []string{"NAME", "STATE", "APPLY", "UPDATE", "ORPHANED", "STASH"}
+		headers := []string{"NAME", "STATE", "PATCHES", "APPLY", "UPDATE", "ORPHANED", "STASH"}
 		tableRows := make([][]string, 0, len(rows))
 		for _, row := range rows {
 			if row.Error != "" {
-				tableRows = append(tableRows, []string{row.Workspace, "error: " + row.Error, "-", "-", "-", "-"})
+				tableRows = append(tableRows, []string{row.Workspace, "error: " + row.Error, "-", "-", "-", "-", "-"})
 				continue
 			}
 			stash := ""
@@ -145,6 +152,7 @@ func runStatusAll(cmd *cobra.Command) error {
 			tableRows = append(tableRows, []string{
 				row.Workspace,
 				row.SyncState,
+				row.PatchesFreshness,
 				strconv.Itoa(row.NeedsApply),
 				strconv.Itoa(row.NeedsUpdate),
 				strconv.Itoa(row.Orphaned),

--- a/packages/browseros/tools/patch/cmd/sync.go
+++ b/packages/browseros/tools/patch/cmd/sync.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/engine"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/repo"
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -32,12 +33,18 @@ func init() {
 			if err != nil {
 				return err
 			}
-			result, err := engine.Sync(cmd.Context(), engine.SyncOptions{
-				Workspace: ws,
-				Repo:      info,
-				Remote:    remote,
-				Rebase:    rebase && !noRebase,
-				Progress:  commandProgress(cmd),
+			progress := commandProgress(cmd)
+			var result *engine.SyncResult
+			err = withPatchRepoLock(cmd, info, progress, func(lockedInfo *repo.Info) error {
+				var syncErr error
+				result, syncErr = engine.Sync(cmd.Context(), engine.SyncOptions{
+					Workspace: ws,
+					Repo:      lockedInfo,
+					Remote:    remote,
+					Rebase:    rebase && !noRebase,
+					Progress:  progress,
+				})
+				return syncErr
 			})
 			if err != nil {
 				return err

--- a/packages/browseros/tools/patch/internal/engine/annotate.go
+++ b/packages/browseros/tools/patch/internal/engine/annotate.go
@@ -2,10 +2,7 @@ package engine
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"os"
-	"path/filepath"
 	"slices"
 
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/git"
@@ -44,22 +41,15 @@ type AnnotateSkippedFeature struct {
 	Reason      string `json:"reason"`
 }
 
-type annotateFeature struct {
-	Name        string
-	Description string
-	Files       []string
-}
-
 type annotateFileSet struct {
 	report []string
 	stage  []string
 	commit []string
 }
 
-// Annotate creates Chromium checkout commits grouped by build/features.yaml.
+// Annotate creates Chromium checkout commits grouped by the repo feature registry.
 func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error) {
-	featuresFile := filepath.Join(opts.Repo.Root, "build", "features.yaml")
-	features, err := loadAnnotateFeatures(featuresFile)
+	features, featuresFile, err := LoadFeatures(opts.Repo)
 	if err != nil {
 		return nil, err
 	}
@@ -119,39 +109,6 @@ func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error
 	return result, nil
 }
 
-func loadAnnotateFeatures(featuresFile string) ([]annotateFeature, error) {
-	body, err := os.ReadFile(featuresFile)
-	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
-			return nil, fmt.Errorf("features file not found: %s", featuresFile)
-		}
-		return nil, err
-	}
-	var root yaml.Node
-	if err := yaml.Unmarshal(body, &root); err != nil {
-		return nil, err
-	}
-	featuresNode := mappingValue(&root, "features")
-	if featuresNode == nil || featuresNode.Kind != yaml.MappingNode || len(featuresNode.Content) == 0 {
-		return nil, fmt.Errorf("no features found in %s", featuresFile)
-	}
-	features := make([]annotateFeature, 0, len(featuresNode.Content)/2)
-	for idx := 0; idx+1 < len(featuresNode.Content); idx += 2 {
-		name := featuresNode.Content[idx].Value
-		data := featuresNode.Content[idx+1]
-		description := scalarValue(data, "description")
-		if description == "" {
-			description = name
-		}
-		features = append(features, annotateFeature{
-			Name:        name,
-			Description: description,
-			Files:       stringSequence(data, "files"),
-		})
-	}
-	return features, nil
-}
-
 func mappingValue(node *yaml.Node, key string) *yaml.Node {
 	if node == nil {
 		return nil
@@ -200,7 +157,7 @@ func annotateChanges(ctx context.Context, workspacePath string) ([]git.FileChang
 	return git.StatusPorcelain(ctx, workspacePath, nil)
 }
 
-func modifiedFeatureFiles(changes []git.FileChange, feature annotateFeature) annotateFileSet {
+func modifiedFeatureFiles(changes []git.FileChange, feature FeatureSpec) annotateFileSet {
 	set := annotateFileSet{}
 	reportSeen := map[string]bool{}
 	stageSeen := map[string]bool{}
@@ -225,7 +182,7 @@ func modifiedFeatureFiles(changes []git.FileChange, feature annotateFeature) ann
 	return set
 }
 
-func featureMatchesChange(feature annotateFeature, change git.FileChange) bool {
+func featureMatchesChange(feature FeatureSpec, change git.FileChange) bool {
 	for _, rel := range changeReportPaths(change) {
 		if patch.PathMatches(rel, feature.Files) {
 			return true

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -1282,6 +1282,49 @@ func TestInspectWorkspaceDoesNotReportFreshFromStateAlone(t *testing.T) {
 	}
 }
 
+func TestInspectWorkspaceReportsMismatchForDivergentMaterializedRev(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser.cc"), "base\n")
+	runGit(t, workspacePath, "add", "chrome/browser.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+	repoInfo := newPatchRepo(t, baseCommit)
+	mainBranch := gitOutput(t, repoInfo.Root, "branch", "--show-current")
+
+	runGit(t, repoInfo.Root, "checkout", "-b", "side")
+	writeFile(t, filepath.Join(repoInfo.Root, "side.txt"), "side\n")
+	runGit(t, repoInfo.Root, "add", "side.txt")
+	runGit(t, repoInfo.Root, "commit", "-m", "side")
+	sideRev := gitOutput(t, repoInfo.Root, "rev-parse", "HEAD")
+	runGit(t, repoInfo.Root, "checkout", mainBranch)
+	writeFile(t, filepath.Join(repoInfo.Root, "main.txt"), "main\n")
+	runGit(t, repoInfo.Root, "add", "main.txt")
+	runGit(t, repoInfo.Root, "commit", "-m", "main")
+
+	runGit(t, workspacePath, "checkout", "-b", "browseros")
+	runGit(t, workspacePath, "commit", "--allow-empty", "-m", "materialized", "-m", "Patches-Rev: "+sideRev)
+	if err := workspace.SaveState(workspacePath, &workspace.State{
+		Version:        1,
+		Workspace:      workspacePath,
+		BaseCommit:     baseCommit,
+		LastRefreshRev: sideRev,
+	}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	status, err := InspectWorkspace(ctx, InspectWorkspaceOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+	})
+	if err != nil {
+		t.Fatalf("InspectWorkspace: %v", err)
+	}
+	if status.PatchesFreshness != "mismatch" {
+		t.Fatalf("expected mismatch for divergent materialized rev, got %+v", status)
+	}
+}
+
 func TestRefreshRebuildsIdenticalBrowserOSBranchesAndFastNoops(t *testing.T) {
 	ctx := context.Background()
 	checkout1 := initGitRepo(t)
@@ -1457,6 +1500,43 @@ features:
 	if got := gitOutput(t, workspacePath, "branch", "--show-current"); got != "browseros" {
 		t.Fatalf("branch = %q, want browseros", got)
 	}
+}
+
+func TestRefreshRefusesUntrackedPatchTargetCollision(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "base.cc"), "base\n")
+	runGit(t, workspacePath, "add", "chrome/base.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "new.cc"), "untracked local\n")
+	diff, err := git.DiffNoIndex(ctx, workspacePath, "chrome/new.cc")
+	if err != nil {
+		t.Fatalf("DiffNoIndex: %v", err)
+	}
+	writeFile(t, filepath.Join(repoInfo.PatchesDir, "chrome", "new.cc"), diff)
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  new-file:
+    description: "feat: new file"
+    files:
+      - chrome/new.cc
+`)
+	runGit(t, repoInfo.Root, "add", "chromium_patches", "bos_build/features.yaml")
+	runGit(t, repoInfo.Root, "commit", "-m", "patch stack")
+
+	_, err = Refresh(ctx, RefreshOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+		Force:     true,
+		Pull:      false,
+	})
+	if err == nil || !strings.Contains(err.Error(), "untracked files collide") {
+		t.Fatalf("expected untracked collision error, got %v", err)
+	}
+	assertFile(t, filepath.Join(workspacePath, "chrome", "new.cc"), "untracked local\n")
 }
 
 func TestFeatureLintReportsUnclaimedAndDuplicatePatchClaims(t *testing.T) {

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -1249,6 +1249,39 @@ func TestInspectWorkspaceReportsPendingStash(t *testing.T) {
 	}
 }
 
+func TestInspectWorkspaceDoesNotReportFreshFromStateAlone(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "browser.cc"), "base\n")
+	runGit(t, workspacePath, "add", "chrome/browser.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+	repoInfo := newPatchRepo(t, baseCommit)
+	repoHead := gitOutput(t, repoInfo.Root, "rev-parse", "HEAD")
+	if err := workspace.SaveState(workspacePath, &workspace.State{
+		Version:        1,
+		Workspace:      workspacePath,
+		BaseCommit:     baseCommit,
+		LastRefreshRev: repoHead,
+	}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	status, err := InspectWorkspace(ctx, InspectWorkspaceOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+	})
+	if err != nil {
+		t.Fatalf("InspectWorkspace: %v", err)
+	}
+	if status.PatchesFreshness == "fresh" {
+		t.Fatalf("state alone must not report fresh: %+v", status)
+	}
+	if status.PatchesRev != "" {
+		t.Fatalf("patches_rev should be empty without browseros trailer, got %q", status.PatchesRev)
+	}
+}
+
 func TestRefreshRebuildsIdenticalBrowserOSBranchesAndFastNoops(t *testing.T) {
 	ctx := context.Background()
 	checkout1 := initGitRepo(t)
@@ -1312,6 +1345,11 @@ features:
 	log2 := gitOutput(t, checkout2, "log", "--format=%s%n%B", "browseros", "--not", baseCommit)
 	if log1 != log2 {
 		t.Fatalf("materialized logs differ\n--- checkout1 ---\n%s\n--- checkout2 ---\n%s", log1, log2)
+	}
+	tip1 := gitOutput(t, checkout1, "rev-parse", "browseros")
+	tip2 := gitOutput(t, checkout2, "rev-parse", "browseros")
+	if tip1 != tip2 {
+		t.Fatalf("browseros tips differ: %s != %s", tip1, tip2)
 	}
 	trailer := gitOutput(t, checkout1, "log", "-1", "--format=%B", "browseros")
 	if !strings.Contains(trailer, "Patches-Rev: "+repoHead) {

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -1249,6 +1249,298 @@ func TestInspectWorkspaceReportsPendingStash(t *testing.T) {
 	}
 }
 
+func TestRefreshRebuildsIdenticalBrowserOSBranchesAndFastNoops(t *testing.T) {
+	ctx := context.Background()
+	checkout1 := initGitRepo(t)
+	writeFile(t, filepath.Join(checkout1, "chrome", "a.cc"), "a base\n")
+	writeFile(t, filepath.Join(checkout1, "chrome", "b.cc"), "b base\n")
+	writeFile(t, filepath.Join(checkout1, "chrome", "c.cc"), "c base\n")
+	runGit(t, checkout1, "add", "chrome")
+	runGit(t, checkout1, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, checkout1, "rev-parse", "HEAD")
+
+	cloneParent := t.TempDir()
+	runGit(t, cloneParent, "clone", checkout1, "clone")
+	checkout2 := filepath.Join(cloneParent, "clone")
+	runGit(t, checkout2, "config", "user.name", "Test User")
+	runGit(t, checkout2, "config", "user.email", "test@example.com")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writePatchFromEdit(t, ctx, checkout1, repoInfo, baseCommit, "chrome/a.cc", "a patched\n")
+	writePatchFromEdit(t, ctx, checkout1, repoInfo, baseCommit, "chrome/b.cc", "b patched\n")
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  first:
+    description: "feat: first"
+    files:
+      - chrome/a.cc
+  second:
+    description: "feat: second"
+    files:
+      - chrome/b.cc
+`)
+	runGit(t, repoInfo.Root, "add", "chromium_patches", "bos_build/features.yaml")
+	runGit(t, repoInfo.Root, "commit", "-m", "patch stack")
+	repoHead := gitOutput(t, repoInfo.Root, "rev-parse", "HEAD")
+
+	first, err := Refresh(ctx, RefreshOptions{
+		Workspace: workspace.Entry{Name: "c1", Path: checkout1},
+		Repo:      repoInfo,
+		Pull:      false,
+	})
+	if err != nil {
+		t.Fatalf("refresh checkout1: %v", err)
+	}
+	second, err := Refresh(ctx, RefreshOptions{
+		Workspace: workspace.Entry{Name: "c2", Path: checkout2},
+		Repo:      repoInfo,
+		Pull:      false,
+	})
+	if err != nil {
+		t.Fatalf("refresh checkout2: %v", err)
+	}
+	if first.Result != "refreshed" || second.Result != "refreshed" {
+		t.Fatalf("expected refreshed results, got %+v %+v", first, second)
+	}
+	if len(first.Commits) != 2 || len(second.Commits) != 2 {
+		t.Fatalf("expected two commits per checkout, got %+v %+v", first.Commits, second.Commits)
+	}
+	if got := gitOutput(t, checkout1, "branch", "--show-current"); got != "browseros" {
+		t.Fatalf("checkout1 branch = %q, want browseros", got)
+	}
+	log1 := gitOutput(t, checkout1, "log", "--format=%s%n%B", "browseros", "--not", baseCommit)
+	log2 := gitOutput(t, checkout2, "log", "--format=%s%n%B", "browseros", "--not", baseCommit)
+	if log1 != log2 {
+		t.Fatalf("materialized logs differ\n--- checkout1 ---\n%s\n--- checkout2 ---\n%s", log1, log2)
+	}
+	trailer := gitOutput(t, checkout1, "log", "-1", "--format=%B", "browseros")
+	if !strings.Contains(trailer, "Patches-Rev: "+repoHead) {
+		t.Fatalf("browseros tip missing patches trailer for %s:\n%s", repoHead, trailer)
+	}
+	state, err := workspace.LoadState(checkout1)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if state.LastRefreshRev != repoHead || state.BaseCommit != baseCommit {
+		t.Fatalf("unexpected refresh state: %+v", state)
+	}
+	headBefore := gitOutput(t, checkout1, "rev-parse", "HEAD")
+	fresh, err := Refresh(ctx, RefreshOptions{
+		Workspace: workspace.Entry{Name: "c1", Path: checkout1},
+		Repo:      repoInfo,
+		Pull:      false,
+	})
+	if err != nil {
+		t.Fatalf("fresh refresh: %v", err)
+	}
+	if fresh.Result != "fresh" || len(fresh.Commits) != 0 {
+		t.Fatalf("expected fast fresh no-op, got %+v", fresh)
+	}
+	if headAfter := gitOutput(t, checkout1, "rev-parse", "HEAD"); headAfter != headBefore {
+		t.Fatalf("fresh refresh moved HEAD: before %s after %s", headBefore, headAfter)
+	}
+
+	writePatchFromEdit(t, ctx, checkout1, repoInfo, baseCommit, "chrome/c.cc", "c patched\n")
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  first:
+    description: "feat: first"
+    files:
+      - chrome/a.cc
+  second:
+    description: "feat: second"
+    files:
+      - chrome/b.cc
+  third:
+    description: "feat: third"
+    files:
+      - chrome/c.cc
+`)
+	runGit(t, repoInfo.Root, "add", "chromium_patches", "bos_build/features.yaml")
+	runGit(t, repoInfo.Root, "commit", "-m", "add third patch")
+
+	status, err := InspectWorkspace(ctx, InspectWorkspaceOptions{
+		Workspace: workspace.Entry{Name: "c1", Path: checkout1},
+		Repo:      repoInfo,
+	})
+	if err != nil {
+		t.Fatalf("InspectWorkspace: %v", err)
+	}
+	if status.PatchesFreshness != "behind 1" || status.PatchesBehind != 1 {
+		t.Fatalf("expected behind 1 freshness, got %+v", status)
+	}
+}
+
+func TestRefreshPreconditionsAndForce(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "a.cc"), "a base\n")
+	runGit(t, workspacePath, "add", "chrome/a.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writePatchFromEdit(t, ctx, workspacePath, repoInfo, baseCommit, "chrome/a.cc", "a patched\n")
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  first:
+    description: "feat: first"
+    files:
+      - chrome/a.cc
+`)
+	runGit(t, repoInfo.Root, "add", "chromium_patches", "bos_build/features.yaml")
+	runGit(t, repoInfo.Root, "commit", "-m", "patch stack")
+	runGit(t, workspacePath, "checkout", "-b", "task/demo")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "a.cc"), "local dirty\n")
+	writeFile(t, filepath.Join(workspacePath, "scratch.txt"), "keep me\n")
+
+	_, err := Refresh(ctx, RefreshOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+		Pull:      false,
+	})
+	if err == nil || !strings.Contains(err.Error(), "task branches are leased") {
+		t.Fatalf("expected task branch refusal, got %v", err)
+	}
+
+	result, err := Refresh(ctx, RefreshOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+		Force:     true,
+		Pull:      false,
+	})
+	if err != nil {
+		t.Fatalf("force refresh: %v", err)
+	}
+	if result.Result != "refreshed" {
+		t.Fatalf("expected refreshed, got %+v", result)
+	}
+	assertFile(t, filepath.Join(workspacePath, "scratch.txt"), "keep me\n")
+	if got := gitOutput(t, workspacePath, "branch", "--show-current"); got != "browseros" {
+		t.Fatalf("branch = %q, want browseros", got)
+	}
+}
+
+func TestFeatureLintReportsUnclaimedAndDuplicatePatchClaims(t *testing.T) {
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "a.cc"), "a base\n")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "b.cc"), "b base\n")
+	runGit(t, workspacePath, "add", "chrome")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFile(t, filepath.Join(repoInfo.PatchesDir, "chrome", "a.cc"), testPatchContent("chrome/a.cc", "a base", "a new"))
+	writeFile(t, filepath.Join(repoInfo.PatchesDir, "chrome", "b.cc"), testPatchContent("chrome/b.cc", "b base", "b new"))
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  broad:
+    description: "chore: broad"
+    files:
+      - chrome/
+  specific:
+    description: "chore: specific"
+    files:
+      - chrome/a.cc
+`)
+
+	result, err := LintFeatures(repoInfo)
+	if err != nil {
+		t.Fatalf("LintFeatures: %v", err)
+	}
+	if len(result.Unclaimed) != 0 {
+		t.Fatalf("expected no unclaimed patches, got %v", result.Unclaimed)
+	}
+	if len(result.Duplicates) != 1 || result.Duplicates[0].Path != "chrome/a.cc" {
+		t.Fatalf("expected duplicate chrome/a.cc, got %+v", result.Duplicates)
+	}
+	if err := result.Error(); err == nil || !strings.Contains(err.Error(), "chrome/a.cc claimed by broad, specific") {
+		t.Fatalf("expected duplicate error, got %v", err)
+	}
+
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  specific:
+    description: "chore: specific"
+    files:
+      - chrome/a.cc
+`)
+	result, err = LintFeatures(repoInfo)
+	if err != nil {
+		t.Fatalf("LintFeatures unclaimed: %v", err)
+	}
+	if !slices.Equal(result.Unclaimed, []string{"chrome/b.cc"}) {
+		t.Fatalf("expected chrome/b.cc unclaimed, got %v", result.Unclaimed)
+	}
+}
+
+func TestFeatureAddExcludesExistingClaimsAndLintPasses(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "existing.cc"), "existing base\n")
+	runGit(t, workspacePath, "add", "chrome/existing.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+	runGit(t, workspacePath, "checkout", "-b", "browseros")
+	runGit(t, workspacePath, "checkout", "-b", "task/demo")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "existing.cc"), "existing task\n")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "new.cc"), "new task\n")
+	runGit(t, workspacePath, "add", "chrome")
+	runGit(t, workspacePath, "commit", "-m", "feat: demo")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  existing:
+    description: "chore: existing"
+    files:
+      - chrome/existing.cc
+`)
+	if _, err := Extract(ctx, ExtractOptions{
+		Workspace:  workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:       repoInfo,
+		RangeStart: "browseros",
+		RangeEnd:   "task/demo",
+		Squash:     true,
+	}); err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+
+	result, err := AddFeatureFromRange(ctx, FeatureAddOptions{
+		Workspace:   workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:        repoInfo,
+		Name:        "demo",
+		Description: "feat: demo",
+		RangeStart:  "browseros",
+		RangeEnd:    "task/demo",
+	})
+	if err != nil {
+		t.Fatalf("AddFeatureFromRange: %v", err)
+	}
+	if !slices.Equal(result.Added, []string{"chrome/new.cc"}) {
+		t.Fatalf("added files = %v, want chrome/new.cc", result.Added)
+	}
+	if len(result.Excluded) != 1 || result.Excluded[0].Path != "chrome/existing.cc" {
+		t.Fatalf("expected existing file excluded, got %+v", result.Excluded)
+	}
+	lint, err := LintFeatures(repoInfo)
+	if err != nil {
+		t.Fatalf("LintFeatures: %v", err)
+	}
+	if err := lint.Error(); err != nil {
+		t.Fatalf("feature lint should pass after add: %v", err)
+	}
+	body, err := os.ReadFile(filepath.Join(repoInfo.Root, "bos_build", "features.yaml"))
+	if err != nil {
+		t.Fatalf("read features: %v", err)
+	}
+	for _, want := range []string{"demo:", `description: "feat: demo"`, "chrome/new.cc"} {
+		if !strings.Contains(string(body), want) {
+			t.Fatalf("expected features yaml to contain %q, got:\n%s", want, body)
+		}
+	}
+}
+
 func TestOrphanSummaryGroupsByTopLevelDir(t *testing.T) {
 	groups := OrphanSummary([]string{
 		"chrome/app/one.cc",
@@ -1438,7 +1730,28 @@ func writeFile(t *testing.T, path string, body string) {
 
 func writeFeaturesYAML(t *testing.T, repoRoot string, body string) {
 	t.Helper()
-	writeFile(t, filepath.Join(repoRoot, "build", "features.yaml"), body)
+	writeFile(t, filepath.Join(repoRoot, "bos_build", "features.yaml"), body)
+}
+
+func writePatchFromEdit(t *testing.T, ctx context.Context, workspacePath string, repoInfo *repo.Info, baseCommit string, rel string, body string) {
+	t.Helper()
+	writeFile(t, filepath.Join(workspacePath, filepath.FromSlash(rel)), body)
+	diff, err := git.DiffText(ctx, workspacePath, baseCommit, "--", rel)
+	if err != nil {
+		t.Fatalf("DiffText %s: %v", rel, err)
+	}
+	writeFile(t, filepath.Join(repoInfo.PatchesDir, filepath.FromSlash(rel)), diff)
+	runGit(t, workspacePath, "checkout", baseCommit, "--", rel)
+}
+
+func testPatchContent(rel string, oldLine string, newLine string) string {
+	return "diff --git a/" + rel + " b/" + rel + "\n" +
+		"index 0000000000000000000000000000000000000000..1111111111111111111111111111111111111111 100644\n" +
+		"--- a/" + rel + "\n" +
+		"+++ b/" + rel + "\n" +
+		"@@ -1 +1 @@\n" +
+		"-" + oldLine + "\n" +
+		"+" + newLine + "\n"
 }
 
 func assertFile(t *testing.T, path string, want string) {

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -1340,6 +1340,8 @@ func TestRefreshRebuildsIdenticalBrowserOSBranchesAndFastNoops(t *testing.T) {
 	checkout2 := filepath.Join(cloneParent, "clone")
 	runGit(t, checkout2, "config", "user.name", "Test User")
 	runGit(t, checkout2, "config", "user.email", "test@example.com")
+	runGit(t, checkout1, "config", "commit.gpgsign", "true")
+	runGit(t, checkout2, "config", "commit.gpgsign", "true")
 
 	repoInfo := newPatchRepo(t, baseCommit)
 	writePatchFromEdit(t, ctx, checkout1, repoInfo, baseCommit, "chrome/a.cc", "a patched\n")
@@ -1539,6 +1541,53 @@ features:
 	assertFile(t, filepath.Join(workspacePath, "chrome", "new.cc"), "untracked local\n")
 }
 
+func TestRefreshEmptyPatchStackCreatesFreshMaterializationCommit(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "base.cc"), "base\n")
+	runGit(t, workspacePath, "add", "chrome/base.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  empty:
+    description: "chore: empty"
+    files: []
+`)
+	runGit(t, repoInfo.Root, "add", "bos_build/features.yaml")
+	runGit(t, repoInfo.Root, "commit", "-m", "empty feature registry")
+	repoHead := gitOutput(t, repoInfo.Root, "rev-parse", "HEAD")
+
+	result, err := Refresh(ctx, RefreshOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+		Pull:      false,
+	})
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if len(result.Commits) != 1 || result.Commits[0].Feature != "materialization" {
+		t.Fatalf("expected materialization commit, got %+v", result.Commits)
+	}
+	trailer := gitOutput(t, workspacePath, "log", "-1", "--format=%B", "browseros")
+	if !strings.Contains(trailer, "Patches-Rev: "+repoHead) {
+		t.Fatalf("materialization commit missing trailer:\n%s", trailer)
+	}
+	fresh, err := Refresh(ctx, RefreshOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+		Pull:      false,
+	})
+	if err != nil {
+		t.Fatalf("second Refresh: %v", err)
+	}
+	if fresh.Result != "fresh" {
+		t.Fatalf("expected second refresh to be fresh, got %+v", fresh)
+	}
+}
+
 func TestFeatureLintReportsUnclaimedAndDuplicatePatchClaims(t *testing.T) {
 	workspacePath := initGitRepo(t)
 	writeFile(t, filepath.Join(workspacePath, "chrome", "a.cc"), "a base\n")
@@ -1656,6 +1705,40 @@ features:
 		if !strings.Contains(string(body), want) {
 			t.Fatalf("expected features yaml to contain %q, got:\n%s", want, body)
 		}
+	}
+}
+
+func TestFeatureAddFailsBeforeRangeFilesAreExtracted(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "existing.cc"), "existing base\n")
+	runGit(t, workspacePath, "add", "chrome/existing.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+	runGit(t, workspacePath, "checkout", "-b", "browseros")
+	runGit(t, workspacePath, "checkout", "-b", "task/demo")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "new.cc"), "new task\n")
+	runGit(t, workspacePath, "add", "chrome/new.cc")
+	runGit(t, workspacePath, "commit", "-m", "feat: demo")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  existing:
+    description: "chore: existing"
+    files:
+      - chrome/existing.cc
+`)
+	_, err := AddFeatureFromRange(ctx, FeatureAddOptions{
+		Workspace:   workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:        repoInfo,
+		Name:        "demo",
+		Description: "feat: demo",
+		RangeStart:  "browseros",
+		RangeEnd:    "task/demo",
+	})
+	if err == nil || !strings.Contains(err.Error(), "not extracted to chromium_patches: chrome/new.cc") {
+		t.Fatalf("expected missing extraction error, got %v", err)
 	}
 }
 

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -1656,13 +1656,15 @@ func TestFeatureAddExcludesExistingClaimsAndLintPasses(t *testing.T) {
 	runGit(t, workspacePath, "commit", "-m", "feat: demo")
 
 	repoInfo := newPatchRepo(t, baseCommit)
-	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+	initialFeatures := `version: "1.0"
 features:
+  # keep curated comments
   existing:
     description: "chore: existing"
     files:
       - chrome/existing.cc
-`)
+`
+	writeFeaturesYAML(t, repoInfo.Root, initialFeatures)
 	if _, err := Extract(ctx, ExtractOptions{
 		Workspace:  workspace.Entry{Name: "ws", Path: workspacePath},
 		Repo:       repoInfo,
@@ -1700,6 +1702,9 @@ features:
 	body, err := os.ReadFile(filepath.Join(repoInfo.Root, "bos_build", "features.yaml"))
 	if err != nil {
 		t.Fatalf("read features: %v", err)
+	}
+	if !strings.HasPrefix(string(body), initialFeatures+"\n") {
+		t.Fatalf("feature add should preserve existing yaml text, got:\n%s", body)
 	}
 	for _, want := range []string{"demo:", `description: "feat: demo"`, "chrome/new.cc"} {
 		if !strings.Contains(string(body), want) {

--- a/packages/browseros/tools/patch/internal/engine/features.go
+++ b/packages/browseros/tools/patch/internal/engine/features.go
@@ -1,0 +1,299 @@
+package engine
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/git"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/patch"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/repo"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/workspace"
+	"gopkg.in/yaml.v3"
+)
+
+var featureFileCandidates = []string{
+	filepath.Join("bos_build", "features.yaml"),
+	filepath.Join("build", "features.yaml"),
+}
+
+type FeatureSpec struct {
+	Name        string   `json:"name"`
+	Description string   `json:"description"`
+	Files       []string `json:"files"`
+}
+
+type FeatureClaimConflict struct {
+	Path     string   `json:"path"`
+	Features []string `json:"features"`
+}
+
+type FeatureLintResult struct {
+	FeaturesFile string                 `json:"features_file"`
+	Features     int                    `json:"features"`
+	Patches      int                    `json:"patches"`
+	Unclaimed    []string               `json:"unclaimed"`
+	Duplicates   []FeatureClaimConflict `json:"duplicates"`
+}
+
+type FeatureAddOptions struct {
+	Workspace   workspace.Entry
+	Repo        *repo.Info
+	Name        string
+	Description string
+	RangeStart  string
+	RangeEnd    string
+}
+
+type FeatureAddExcluded struct {
+	Path     string   `json:"path"`
+	Features []string `json:"features"`
+}
+
+type FeatureAddResult struct {
+	FeaturesFile string               `json:"features_file"`
+	Name         string               `json:"name"`
+	Description  string               `json:"description"`
+	Added        []string             `json:"added"`
+	Excluded     []FeatureAddExcluded `json:"excluded"`
+}
+
+// LoadFeatures reads the repo feature registry in YAML order.
+func LoadFeatures(repoInfo *repo.Info) ([]FeatureSpec, string, error) {
+	featuresFile, err := FeatureFilePath(repoInfo.Root)
+	if err != nil {
+		return nil, "", err
+	}
+	features, err := loadFeaturesFile(featuresFile)
+	return features, featuresFile, err
+}
+
+func FeatureFilePath(repoRoot string) (string, error) {
+	for _, rel := range featureFileCandidates {
+		candidate := filepath.Join(repoRoot, rel)
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("features file not found in %s (tried bos_build/features.yaml, build/features.yaml)", repoRoot)
+}
+
+// LintFeatures validates that every concrete patch file has exactly one feature owner.
+func LintFeatures(repoInfo *repo.Info) (*FeatureLintResult, error) {
+	features, featuresFile, err := LoadFeatures(repoInfo)
+	if err != nil {
+		return nil, err
+	}
+	repoSet, err := patch.LoadRepoPatchSet(repoInfo.PatchesDir, nil)
+	if err != nil {
+		return nil, err
+	}
+	paths := patch.ScopeFromSet(repoSet)
+	result := &FeatureLintResult{
+		FeaturesFile: featuresFile,
+		Features:     len(features),
+		Patches:      len(paths),
+		Unclaimed:    []string{},
+		Duplicates:   []FeatureClaimConflict{},
+	}
+	for _, rel := range paths {
+		owners := matchingFeatureNames(features, rel)
+		switch len(owners) {
+		case 0:
+			result.Unclaimed = append(result.Unclaimed, rel)
+		case 1:
+		default:
+			result.Duplicates = append(result.Duplicates, FeatureClaimConflict{Path: rel, Features: owners})
+		}
+	}
+	return result, nil
+}
+
+func (r *FeatureLintResult) Valid() bool {
+	return r != nil && len(r.Unclaimed) == 0 && len(r.Duplicates) == 0
+}
+
+func (r *FeatureLintResult) Error() error {
+	if r.Valid() {
+		return nil
+	}
+	var parts []string
+	if len(r.Unclaimed) > 0 {
+		parts = append(parts, fmt.Sprintf("unclaimed patches: %s", strings.Join(r.Unclaimed, ", ")))
+	}
+	if len(r.Duplicates) > 0 {
+		var duplicates []string
+		for _, duplicate := range r.Duplicates {
+			duplicates = append(duplicates, fmt.Sprintf("%s claimed by %s", duplicate.Path, strings.Join(duplicate.Features, ", ")))
+		}
+		parts = append(parts, "duplicate patch claims: "+strings.Join(duplicates, "; "))
+	}
+	return errors.New(strings.Join(parts, "; "))
+}
+
+// AddFeatureFromRange appends one feature entry using files changed by a checkout commit range.
+func AddFeatureFromRange(ctx context.Context, opts FeatureAddOptions) (*FeatureAddResult, error) {
+	if strings.TrimSpace(opts.Name) == "" {
+		return nil, fmt.Errorf("feature name is required")
+	}
+	if strings.TrimSpace(opts.Description) == "" {
+		return nil, fmt.Errorf("feature description is required")
+	}
+	if opts.RangeStart == "" || opts.RangeEnd == "" {
+		return nil, fmt.Errorf("feature add requires --files-from-range <start>..<end>")
+	}
+	features, featuresFile, err := LoadFeatures(opts.Repo)
+	if err != nil {
+		return nil, err
+	}
+	for _, feature := range features {
+		if feature.Name == opts.Name {
+			return nil, fmt.Errorf("feature %q already exists", opts.Name)
+		}
+	}
+	changes, err := git.DiffNameStatusBetween(ctx, opts.Workspace.Path, opts.RangeStart, opts.RangeEnd, nil)
+	if err != nil {
+		return nil, err
+	}
+	candidates := changedScope(changes)
+	seen := map[string]bool{}
+	var added []string
+	var excluded []FeatureAddExcluded
+	for _, rel := range candidates {
+		if seen[rel] {
+			continue
+		}
+		seen[rel] = true
+		owners := matchingFeatureNames(features, rel)
+		if len(owners) > 0 {
+			excluded = append(excluded, FeatureAddExcluded{Path: rel, Features: owners})
+			continue
+		}
+		added = append(added, rel)
+	}
+	slices.Sort(added)
+	slices.SortFunc(excluded, func(a, b FeatureAddExcluded) int {
+		return strings.Compare(a.Path, b.Path)
+	})
+	if len(added) == 0 {
+		return nil, fmt.Errorf("range %s..%s has no unclaimed files to add", opts.RangeStart, opts.RangeEnd)
+	}
+	if err := appendFeature(featuresFile, FeatureSpec{
+		Name:        opts.Name,
+		Description: opts.Description,
+		Files:       added,
+	}); err != nil {
+		return nil, err
+	}
+	return &FeatureAddResult{
+		FeaturesFile: featuresFile,
+		Name:         opts.Name,
+		Description:  opts.Description,
+		Added:        added,
+		Excluded:     excluded,
+	}, nil
+}
+
+func loadFeaturesFile(featuresFile string) ([]FeatureSpec, error) {
+	body, err := os.ReadFile(featuresFile)
+	if err != nil {
+		return nil, err
+	}
+	var root yaml.Node
+	if err := yaml.Unmarshal(body, &root); err != nil {
+		return nil, err
+	}
+	featuresNode := mappingValue(&root, "features")
+	if featuresNode == nil || featuresNode.Kind != yaml.MappingNode || len(featuresNode.Content) == 0 {
+		return nil, fmt.Errorf("no features found in %s", featuresFile)
+	}
+	features := make([]FeatureSpec, 0, len(featuresNode.Content)/2)
+	for idx := 0; idx+1 < len(featuresNode.Content); idx += 2 {
+		name := featuresNode.Content[idx].Value
+		data := featuresNode.Content[idx+1]
+		description := scalarValue(data, "description")
+		if description == "" {
+			description = name
+		}
+		features = append(features, FeatureSpec{
+			Name:        name,
+			Description: description,
+			Files:       stringSequence(data, "files"),
+		})
+	}
+	return features, nil
+}
+
+func appendFeature(featuresFile string, feature FeatureSpec) error {
+	body, err := os.ReadFile(featuresFile)
+	if err != nil {
+		return err
+	}
+	var root yaml.Node
+	if err := yaml.Unmarshal(body, &root); err != nil {
+		return err
+	}
+	featuresNode := mappingValue(&root, "features")
+	if featuresNode == nil || featuresNode.Kind != yaml.MappingNode {
+		return fmt.Errorf("no features mapping found in %s", featuresFile)
+	}
+	featuresNode.Content = append(featuresNode.Content,
+		&yaml.Node{Kind: yaml.ScalarNode, Value: feature.Name},
+		featureNode(feature),
+	)
+	var builder strings.Builder
+	encoder := yaml.NewEncoder(&builder)
+	encoder.SetIndent(2)
+	if err := encoder.Encode(&root); err != nil {
+		return err
+	}
+	if err := encoder.Close(); err != nil {
+		return err
+	}
+	return os.WriteFile(featuresFile, []byte(builder.String()), 0o644)
+}
+
+func featureNode(feature FeatureSpec) *yaml.Node {
+	files := &yaml.Node{Kind: yaml.SequenceNode}
+	for _, rel := range feature.Files {
+		files.Content = append(files.Content, &yaml.Node{Kind: yaml.ScalarNode, Value: rel})
+	}
+	return &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: "description"},
+			{Kind: yaml.ScalarNode, Value: feature.Description, Style: yaml.DoubleQuotedStyle},
+			{Kind: yaml.ScalarNode, Value: "files"},
+			files,
+		},
+	}
+}
+
+func matchingFeatureNames(features []FeatureSpec, rel string) []string {
+	var owners []string
+	for _, feature := range features {
+		if patch.PathMatches(rel, feature.Files) {
+			owners = append(owners, feature.Name)
+		}
+	}
+	return owners
+}
+
+func featurePatchPaths(feature FeatureSpec, repoSet patch.PatchSet) []string {
+	seen := map[string]bool{}
+	var paths []string
+	for _, filter := range feature.Files {
+		for _, rel := range patch.ScopeFromSet(repoSet) {
+			if !patch.PathMatches(rel, []string{filter}) || seen[rel] {
+				continue
+			}
+			seen[rel] = true
+			paths = append(paths, rel)
+		}
+	}
+	return paths
+}

--- a/packages/browseros/tools/patch/internal/engine/features.go
+++ b/packages/browseros/tools/patch/internal/engine/features.go
@@ -159,10 +159,15 @@ func AddFeatureFromRange(ctx context.Context, opts FeatureAddOptions) (*FeatureA
 	if err != nil {
 		return nil, err
 	}
+	repoSet, err := patch.LoadRepoPatchSet(opts.Repo.PatchesDir, nil)
+	if err != nil {
+		return nil, err
+	}
 	candidates := changedScope(changes)
 	seen := map[string]bool{}
 	var added []string
 	var excluded []FeatureAddExcluded
+	var missing []string
 	for _, rel := range candidates {
 		if seen[rel] {
 			continue
@@ -173,12 +178,20 @@ func AddFeatureFromRange(ctx context.Context, opts FeatureAddOptions) (*FeatureA
 			excluded = append(excluded, FeatureAddExcluded{Path: rel, Features: owners})
 			continue
 		}
+		if _, ok := repoSet[rel]; !ok {
+			missing = append(missing, rel)
+			continue
+		}
 		added = append(added, rel)
 	}
 	slices.Sort(added)
+	slices.Sort(missing)
 	slices.SortFunc(excluded, func(a, b FeatureAddExcluded) int {
 		return strings.Compare(a.Path, b.Path)
 	})
+	if len(missing) > 0 {
+		return nil, fmt.Errorf("range %s..%s has files not extracted to chromium_patches: %s", opts.RangeStart, opts.RangeEnd, strings.Join(missing, ", "))
+	}
 	if len(added) == 0 {
 		return nil, fmt.Errorf("range %s..%s has no unclaimed files to add", opts.RangeStart, opts.RangeEnd)
 	}

--- a/packages/browseros/tools/patch/internal/engine/features.go
+++ b/packages/browseros/tools/patch/internal/engine/features.go
@@ -254,20 +254,42 @@ func appendFeature(featuresFile string, feature FeatureSpec) error {
 	if featuresNode == nil || featuresNode.Kind != yaml.MappingNode {
 		return fmt.Errorf("no features mapping found in %s", featuresFile)
 	}
-	featuresNode.Content = append(featuresNode.Content,
-		&yaml.Node{Kind: yaml.ScalarNode, Value: feature.Name},
-		featureNode(feature),
-	)
+	entry, err := formatFeatureEntry(feature)
+	if err != nil {
+		return err
+	}
+	var builder strings.Builder
+	builder.Write(body)
+	if len(body) > 0 && body[len(body)-1] != '\n' {
+		builder.WriteByte('\n')
+	}
+	builder.WriteByte('\n')
+	for _, line := range strings.Split(strings.TrimRight(entry, "\n"), "\n") {
+		builder.WriteString("  ")
+		builder.WriteString(line)
+		builder.WriteByte('\n')
+	}
+	return os.WriteFile(featuresFile, []byte(builder.String()), 0o644)
+}
+
+func formatFeatureEntry(feature FeatureSpec) (string, error) {
 	var builder strings.Builder
 	encoder := yaml.NewEncoder(&builder)
 	encoder.SetIndent(2)
-	if err := encoder.Encode(&root); err != nil {
-		return err
+	root := &yaml.Node{
+		Kind: yaml.MappingNode,
+		Content: []*yaml.Node{
+			{Kind: yaml.ScalarNode, Value: feature.Name},
+			featureNode(feature),
+		},
+	}
+	if err := encoder.Encode(root); err != nil {
+		return "", err
 	}
 	if err := encoder.Close(); err != nil {
-		return err
+		return "", err
 	}
-	return os.WriteFile(featuresFile, []byte(builder.String()), 0o644)
+	return builder.String(), nil
 }
 
 func featureNode(feature FeatureSpec) *yaml.Node {
@@ -299,8 +321,9 @@ func matchingFeatureNames(features []FeatureSpec, rel string) []string {
 func featurePatchPaths(feature FeatureSpec, repoSet patch.PatchSet) []string {
 	seen := map[string]bool{}
 	var paths []string
+	scope := patch.ScopeFromSet(repoSet)
 	for _, filter := range feature.Files {
-		for _, rel := range patch.ScopeFromSet(repoSet) {
+		for _, rel := range scope {
 			if !patch.PathMatches(rel, []string{filter}) || seen[rel] {
 				continue
 			}

--- a/packages/browseros/tools/patch/internal/engine/refresh.go
+++ b/packages/browseros/tools/patch/internal/engine/refresh.go
@@ -167,7 +167,7 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 		if !dirty {
 			continue
 		}
-		commit, err := git.CommitPathsWithBodyEnv(ctx, opts.Workspace.Path, feature.Description, patchesRevTrailer+": "+repoRev, commitEnv, stagePaths)
+		commit, err := git.CommitIndexWithBodyEnv(ctx, opts.Workspace.Path, feature.Description, patchesRevTrailer+": "+repoRev, commitEnv)
 		if err != nil {
 			return nil, err
 		}
@@ -176,6 +176,18 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 			Description: feature.Description,
 			Commit:      commit,
 			Files:       paths,
+		})
+	}
+	if len(result.Commits) == 0 {
+		commit, err := git.CommitIndexWithBodyEnv(ctx, opts.Workspace.Path, "chore: materialize browseros patches", patchesRevTrailer+": "+repoRev, commitEnv)
+		if err != nil {
+			return nil, err
+		}
+		result.Commits = append(result.Commits, RefreshCommit{
+			Feature:     "materialization",
+			Description: "chore: materialize browseros patches",
+			Commit:      commit,
+			Files:       []string{},
 		})
 	}
 	reportProgress(opts.Progress, "Moving browseros branch")

--- a/packages/browseros/tools/patch/internal/engine/refresh.go
+++ b/packages/browseros/tools/patch/internal/engine/refresh.go
@@ -60,6 +60,11 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	repoCommitTime, err := git.CommitUnixTime(ctx, repoInfo.Root, repoRev)
+	if err != nil {
+		return nil, err
+	}
+	commitEnv := refreshCommitEnv(repoCommitTime)
 	features, _, err := LoadFeatures(repoInfo)
 	if err != nil {
 		return nil, err
@@ -154,7 +159,7 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 		if !dirty {
 			continue
 		}
-		commit, err := git.CommitPathsWithBody(ctx, opts.Workspace.Path, feature.Description, patchesRevTrailer+": "+repoRev, stagePaths)
+		commit, err := git.CommitPathsWithBodyEnv(ctx, opts.Workspace.Path, feature.Description, patchesRevTrailer+": "+repoRev, commitEnv, stagePaths)
 		if err != nil {
 			return nil, err
 		}
@@ -271,4 +276,16 @@ func shortRev(rev string) string {
 		return rev
 	}
 	return rev[:12]
+}
+
+func refreshCommitEnv(unixTime string) []string {
+	date := "@" + unixTime + " +0000"
+	return []string{
+		"GIT_AUTHOR_NAME=BrowserOS Patch Tool",
+		"GIT_AUTHOR_EMAIL=patches@browseros.local",
+		"GIT_AUTHOR_DATE=" + date,
+		"GIT_COMMITTER_NAME=BrowserOS Patch Tool",
+		"GIT_COMMITTER_EMAIL=patches@browseros.local",
+		"GIT_COMMITTER_DATE=" + date,
+	}
 }

--- a/packages/browseros/tools/patch/internal/engine/refresh.go
+++ b/packages/browseros/tools/patch/internal/engine/refresh.go
@@ -1,0 +1,274 @@
+package engine
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/git"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/patch"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/repo"
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/workspace"
+)
+
+const (
+	browserOSBranch   = "browseros"
+	patchesRevTrailer = "Patches-Rev"
+)
+
+type RefreshOptions struct {
+	Workspace workspace.Entry
+	Repo      *repo.Info
+	Remote    string
+	Force     bool
+	Pull      bool
+	Progress  Progress
+}
+
+type RefreshCommit struct {
+	Feature     string   `json:"feature"`
+	Description string   `json:"description"`
+	Commit      string   `json:"commit"`
+	Files       []string `json:"files"`
+}
+
+type RefreshResult struct {
+	Workspace  string          `json:"workspace"`
+	Result     string          `json:"result"`
+	Features   int             `json:"features"`
+	Commits    []RefreshCommit `json:"commits"`
+	PatchesRev string          `json:"patches_rev"`
+	Warnings   []string        `json:"warnings"`
+}
+
+// Refresh rebuilds the local browseros branch as feature commits from the patch repo.
+func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
+	repoInfo := opts.Repo
+	if opts.Remote == "" {
+		opts.Remote = "origin"
+	}
+	if opts.Pull {
+		var err error
+		repoInfo, err = pullPatchRepoForRefresh(ctx, opts, repoInfo)
+		if err != nil {
+			return nil, err
+		}
+	}
+	repoRev, err := git.HeadRev(ctx, repoInfo.Root)
+	if err != nil {
+		return nil, err
+	}
+	features, _, err := LoadFeatures(repoInfo)
+	if err != nil {
+		return nil, err
+	}
+	lint, err := LintFeatures(repoInfo)
+	if err != nil {
+		return nil, err
+	}
+	if err := lint.Error(); err != nil {
+		return nil, err
+	}
+	state, err := workspace.LoadState(opts.Workspace.Path)
+	if err != nil {
+		return nil, err
+	}
+	branch, err := git.CurrentBranch(ctx, opts.Workspace.Path)
+	if err != nil {
+		return nil, err
+	}
+	if strings.HasPrefix(branch, "task/") && !opts.Force {
+		return nil, fmt.Errorf("checkout %s is on %s; task branches are leased, use --force only when abandoning that task", opts.Workspace.Name, branch)
+	}
+	dirty, err := git.IsTrackedDirty(ctx, opts.Workspace.Path)
+	if err != nil {
+		return nil, err
+	}
+	if dirty && !opts.Force {
+		return nil, fmt.Errorf("checkout %s has tracked changes; commit/stash them or use --force to reset tracked state", opts.Workspace.Name)
+	}
+	if dirty && opts.Force {
+		reportProgress(opts.Progress, "Resetting tracked checkout changes")
+		if err := git.ResetHard(ctx, opts.Workspace.Path); err != nil {
+			return nil, err
+		}
+	}
+	if fresh, err := refreshIsFresh(ctx, opts.Workspace.Path, state, repoRev); err != nil {
+		return nil, err
+	} else if fresh {
+		if branch != browserOSBranch {
+			if err := git.CheckoutBranch(ctx, opts.Workspace.Path, browserOSBranch); err != nil {
+				return nil, err
+			}
+		}
+		return &RefreshResult{
+			Workspace:  opts.Workspace.Name,
+			Result:     "fresh",
+			Features:   len(features),
+			Commits:    []RefreshCommit{},
+			PatchesRev: repoRev,
+			Warnings:   []string{},
+		}, nil
+	}
+	repoSet, err := patch.LoadRepoPatchSet(repoInfo.PatchesDir, nil)
+	if err != nil {
+		return nil, err
+	}
+	warnings := baseChangeWarnings(ctx, opts.Workspace.Path, state.BaseCommit, repoInfo.BaseCommit)
+	reportProgress(opts.Progress, "Checking out base %s", shortRev(repoInfo.BaseCommit))
+	if exists, err := git.CommitExists(ctx, opts.Workspace.Path, repoInfo.BaseCommit); err != nil {
+		return nil, err
+	} else if !exists {
+		return nil, fmt.Errorf("BASE_COMMIT %s is not present in checkout %s", repoInfo.BaseCommit, opts.Workspace.Path)
+	}
+	if err := git.CheckoutDetached(ctx, opts.Workspace.Path, repoInfo.BaseCommit); err != nil {
+		return nil, err
+	}
+	result := &RefreshResult{
+		Workspace:  opts.Workspace.Name,
+		Result:     "refreshed",
+		Features:   len(features),
+		Commits:    []RefreshCommit{},
+		PatchesRev: repoRev,
+		Warnings:   warnings,
+	}
+	for _, feature := range features {
+		paths := featurePatchPaths(feature, repoSet)
+		if len(paths) == 0 {
+			continue
+		}
+		reportProgress(opts.Progress, "Materializing feature %s", feature.Name)
+		if err := applyFeaturePatchSet(ctx, opts.Workspace.Path, repoInfo, repoSet, paths); err != nil {
+			return nil, fmt.Errorf("apply feature %s: %w", feature.Name, err)
+		}
+		stagePaths := stagePathsForPatches(repoSet, paths)
+		if err := git.AddAllPaths(ctx, opts.Workspace.Path, stagePaths); err != nil {
+			return nil, err
+		}
+		dirty, err := git.IsDirtyPaths(ctx, opts.Workspace.Path, stagePaths)
+		if err != nil {
+			return nil, err
+		}
+		if !dirty {
+			continue
+		}
+		commit, err := git.CommitPathsWithBody(ctx, opts.Workspace.Path, feature.Description, patchesRevTrailer+": "+repoRev, stagePaths)
+		if err != nil {
+			return nil, err
+		}
+		result.Commits = append(result.Commits, RefreshCommit{
+			Feature:     feature.Name,
+			Description: feature.Description,
+			Commit:      commit,
+			Files:       paths,
+		})
+	}
+	reportProgress(opts.Progress, "Moving browseros branch")
+	if err := git.ForceBranch(ctx, opts.Workspace.Path, browserOSBranch, "HEAD"); err != nil {
+		return nil, err
+	}
+	if err := git.CheckoutBranch(ctx, opts.Workspace.Path, browserOSBranch); err != nil {
+		return nil, err
+	}
+	state.BaseCommit = repoInfo.BaseCommit
+	state.LastRefreshRev = repoRev
+	state.LastRefreshAt = time.Now().UTC()
+	if err := workspace.SaveState(opts.Workspace.Path, state); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+func pullPatchRepoForRefresh(ctx context.Context, opts RefreshOptions, repoInfo *repo.Info) (*repo.Info, error) {
+	reportProgress(opts.Progress, "Checking patch repo status")
+	dirty, err := git.IsDirty(ctx, repoInfo.Root)
+	if err != nil {
+		return nil, err
+	}
+	if dirty {
+		return nil, fmt.Errorf("patches repo has uncommitted changes; commit or stash them before refreshing")
+	}
+	branch, err := git.CurrentBranch(ctx, repoInfo.Root)
+	if err != nil {
+		return nil, err
+	}
+	reportProgress(opts.Progress, "Pulling patch repo from %s/%s", opts.Remote, branch)
+	if err := git.PullRebase(ctx, repoInfo.Root, opts.Remote, branch); err != nil {
+		return nil, err
+	}
+	return repo.Load(repoInfo.Root)
+}
+
+func refreshIsFresh(ctx context.Context, workspacePath string, state *workspace.State, repoRev string) (bool, error) {
+	if state.LastRefreshRev != repoRev {
+		return false, nil
+	}
+	exists, err := git.CommitExists(ctx, workspacePath, browserOSBranch)
+	if err != nil || !exists {
+		return false, err
+	}
+	trailer, err := git.CommitTrailer(ctx, workspacePath, browserOSBranch, patchesRevTrailer)
+	if err != nil {
+		return false, err
+	}
+	return trailer == repoRev, nil
+}
+
+func applyFeaturePatchSet(ctx context.Context, workspacePath string, repoInfo *repo.Info, repoSet patch.PatchSet, paths []string) error {
+	for _, rel := range paths {
+		patchFile := repoSet[rel]
+		if patchFile.OldPath != "" {
+			if err := git.ResetPathToCommit(ctx, workspacePath, repoInfo.BaseCommit, patchFile.OldPath); err != nil {
+				return err
+			}
+		}
+		if err := git.ResetPathToCommit(ctx, workspacePath, repoInfo.BaseCommit, patchFile.Path); err != nil {
+			return err
+		}
+		if err := applySingleOperation(ctx, workspacePath, patchFile); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func stagePathsForPatches(repoSet patch.PatchSet, paths []string) []string {
+	seen := map[string]bool{}
+	var stage []string
+	for _, rel := range paths {
+		patchFile := repoSet[rel]
+		if patchFile.OldPath != "" && !seen[patchFile.OldPath] {
+			seen[patchFile.OldPath] = true
+			stage = append(stage, patchFile.OldPath)
+		}
+		if !seen[patchFile.Path] {
+			seen[patchFile.Path] = true
+			stage = append(stage, patchFile.Path)
+		}
+	}
+	return stage
+}
+
+func baseChangeWarnings(ctx context.Context, workspacePath string, previousBase string, nextBase string) []string {
+	if previousBase == "" || previousBase == nextBase {
+		return nil
+	}
+	changes, err := git.DiffNameStatusBetween(ctx, workspacePath, previousBase, nextBase, []string{"DEPS", filepath.ToSlash(filepath.Join("chrome", "VERSION"))})
+	if err != nil || len(changes) == 0 {
+		return nil
+	}
+	var paths []string
+	for _, change := range changes {
+		paths = append(paths, change.Path)
+	}
+	return []string{fmt.Sprintf("BASE_COMMIT changed and %s differ; run gclient sync before relying on build outputs", strings.Join(paths, ", "))}
+}
+
+func shortRev(rev string) string {
+	if len(rev) <= 12 {
+		return rev
+	}
+	return rev[:12]
+}

--- a/packages/browseros/tools/patch/internal/engine/refresh.go
+++ b/packages/browseros/tools/patch/internal/engine/refresh.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"slices"
 	"strings"
 	"time"
 
@@ -120,6 +121,13 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 	repoSet, err := patch.LoadRepoPatchSet(repoInfo.PatchesDir, nil)
 	if err != nil {
 		return nil, err
+	}
+	collisions, err := untrackedPatchCollisions(ctx, opts.Workspace.Path, repoInfo.BaseCommit, repoSet)
+	if err != nil {
+		return nil, err
+	}
+	if len(collisions) > 0 {
+		return nil, fmt.Errorf("untracked files collide with patch targets; move them aside before refresh: %s", strings.Join(collisions, ", "))
 	}
 	warnings := baseChangeWarnings(ctx, opts.Workspace.Path, state.BaseCommit, repoInfo.BaseCommit)
 	reportProgress(opts.Progress, "Checking out base %s", shortRev(repoInfo.BaseCommit))
@@ -254,6 +262,47 @@ func stagePathsForPatches(repoSet patch.PatchSet, paths []string) []string {
 		}
 	}
 	return stage
+}
+
+func untrackedPatchCollisions(ctx context.Context, workspacePath string, base string, repoSet patch.PatchSet) ([]string, error) {
+	untracked, err := git.ListUntracked(ctx, workspacePath, nil)
+	if err != nil {
+		return nil, err
+	}
+	if len(untracked) == 0 {
+		return nil, nil
+	}
+	seen := map[string]bool{}
+	var collisions []string
+	for _, patchFile := range repoSet {
+		for _, rel := range []string{patchFile.OldPath, patchFile.Path} {
+			if rel == "" || seen[rel] {
+				continue
+			}
+			seen[rel] = true
+			existsAtBase, err := git.FileExistsAtCommit(ctx, workspacePath, base, rel)
+			if err != nil {
+				return nil, err
+			}
+			if existsAtBase {
+				continue
+			}
+			if collidesWithUntracked(rel, untracked) {
+				collisions = append(collisions, rel)
+			}
+		}
+	}
+	slices.Sort(collisions)
+	return collisions, nil
+}
+
+func collidesWithUntracked(rel string, untracked []string) bool {
+	for _, candidate := range untracked {
+		if candidate == rel || strings.HasPrefix(candidate, rel+"/") || strings.HasPrefix(rel, candidate+"/") {
+			return true
+		}
+	}
+	return false
 }
 
 func baseChangeWarnings(ctx context.Context, workspacePath string, previousBase string, nextBase string) []string {

--- a/packages/browseros/tools/patch/internal/engine/refresh.go
+++ b/packages/browseros/tools/patch/internal/engine/refresh.go
@@ -154,22 +154,22 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 		}
 		reportProgress(opts.Progress, "Materializing feature %s", feature.Name)
 		if err := applyFeaturePatchSet(ctx, opts.Workspace.Path, repoInfo, repoSet, paths); err != nil {
-			return nil, fmt.Errorf("apply feature %s: %w", feature.Name, err)
+			return nil, refreshMaterializeError("apply feature "+feature.Name, err)
 		}
 		stagePaths := stagePathsForPatches(repoSet, paths)
 		if err := git.AddAllPaths(ctx, opts.Workspace.Path, stagePaths); err != nil {
-			return nil, err
+			return nil, refreshMaterializeError("stage feature "+feature.Name, err)
 		}
 		dirty, err := git.IsDirtyPaths(ctx, opts.Workspace.Path, stagePaths)
 		if err != nil {
-			return nil, err
+			return nil, refreshMaterializeError("check feature "+feature.Name, err)
 		}
 		if !dirty {
 			continue
 		}
 		commit, err := git.CommitIndexWithBodyEnv(ctx, opts.Workspace.Path, feature.Description, patchesRevTrailer+": "+repoRev, commitEnv)
 		if err != nil {
-			return nil, err
+			return nil, refreshMaterializeError("commit feature "+feature.Name, err)
 		}
 		result.Commits = append(result.Commits, RefreshCommit{
 			Feature:     feature.Name,
@@ -181,7 +181,7 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 	if len(result.Commits) == 0 {
 		commit, err := git.CommitIndexWithBodyEnv(ctx, opts.Workspace.Path, "chore: materialize browseros patches", patchesRevTrailer+": "+repoRev, commitEnv)
 		if err != nil {
-			return nil, err
+			return nil, refreshMaterializeError("commit empty materialization", err)
 		}
 		result.Commits = append(result.Commits, RefreshCommit{
 			Feature:     "materialization",
@@ -192,10 +192,10 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 	}
 	reportProgress(opts.Progress, "Moving browseros branch")
 	if err := git.ForceBranch(ctx, opts.Workspace.Path, browserOSBranch, "HEAD"); err != nil {
-		return nil, err
+		return nil, refreshMaterializeError("move browseros branch", err)
 	}
 	if err := git.CheckoutBranch(ctx, opts.Workspace.Path, browserOSBranch); err != nil {
-		return nil, err
+		return nil, refreshMaterializeError("checkout browseros branch", err)
 	}
 	state.BaseCommit = repoInfo.BaseCommit
 	state.LastRefreshRev = repoRev
@@ -204,6 +204,10 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 		return nil, err
 	}
 	return result, nil
+}
+
+func refreshMaterializeError(step string, err error) error {
+	return fmt.Errorf("%s: %w; checkout may be left in a partial refresh, rerun refresh --force to recover", step, err)
 }
 
 func pullPatchRepoForRefresh(ctx context.Context, opts RefreshOptions, repoInfo *repo.Info) (*repo.Info, error) {

--- a/packages/browseros/tools/patch/internal/engine/status.go
+++ b/packages/browseros/tools/patch/internal/engine/status.go
@@ -150,6 +150,10 @@ func materializedFreshness(ctx context.Context, repoRoot string, workspacePath s
 	case tipRev == repoHead:
 		return tipRev, tipRev, "fresh", 0
 	default:
+		ancestor, err := git.IsAncestor(ctx, repoRoot, tipRev, repoHead)
+		if err != nil || !ancestor {
+			return tipRev, tipRev, "mismatch", 0
+		}
 		behind, err := git.RevListCount(ctx, repoRoot, tipRev, repoHead)
 		if err != nil || behind == 0 {
 			return tipRev, tipRev, "unknown", 0

--- a/packages/browseros/tools/patch/internal/engine/status.go
+++ b/packages/browseros/tools/patch/internal/engine/status.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"fmt"
 	"slices"
 	"strings"
 
@@ -13,19 +14,25 @@ import (
 )
 
 type WorkspaceStatus struct {
-	Workspace      workspace.Entry `json:"workspace"`
-	RepoHead       string          `json:"repo_head"`
-	BaseCommit     string          `json:"base_commit"`
-	LastApplyRev   string          `json:"last_apply_rev,omitempty"`
-	LastSyncRev    string          `json:"last_sync_rev,omitempty"`
-	LastExtractRev string          `json:"last_extract_rev,omitempty"`
-	PendingStash   string          `json:"pending_stash,omitempty"`
-	ActiveResolve  bool            `json:"active_resolve"`
-	NeedsApply     []string        `json:"needs_apply"`
-	NeedsUpdate    []string        `json:"needs_update"`
-	Orphaned       []string        `json:"orphaned"`
-	UpToDate       []string        `json:"up_to_date"`
-	SyncState      string          `json:"sync_state"`
+	Workspace              workspace.Entry `json:"workspace"`
+	RepoHead               string          `json:"repo_head"`
+	BaseCommit             string          `json:"base_commit"`
+	LastApplyRev           string          `json:"last_apply_rev,omitempty"`
+	LastSyncRev            string          `json:"last_sync_rev,omitempty"`
+	LastExtractRev         string          `json:"last_extract_rev,omitempty"`
+	LastRefreshRev         string          `json:"last_refresh_rev,omitempty"`
+	PatchesRev             string          `json:"patches_rev,omitempty"`
+	PatchesHead            string          `json:"patches_head"`
+	PatchesFreshness       string          `json:"patches_freshness"`
+	PatchesBehind          int             `json:"patches_behind,omitempty"`
+	BrowserOSTipPatchesRev string          `json:"browseros_tip_patches_rev,omitempty"`
+	PendingStash           string          `json:"pending_stash,omitempty"`
+	ActiveResolve          bool            `json:"active_resolve"`
+	NeedsApply             []string        `json:"needs_apply"`
+	NeedsUpdate            []string        `json:"needs_update"`
+	Orphaned               []string        `json:"orphaned"`
+	UpToDate               []string        `json:"up_to_date"`
+	SyncState              string          `json:"sync_state"`
 }
 
 // InSyncButUnreproducible flags the "patches agree but orphans exist" state:
@@ -104,9 +111,12 @@ func InspectWorkspace(ctx context.Context, opts InspectWorkspaceOptions) (*Works
 		LastApplyRev:   state.LastApplyRev,
 		LastSyncRev:    state.LastSyncRev,
 		LastExtractRev: state.LastExtractRev,
+		LastRefreshRev: state.LastRefreshRev,
+		PatchesHead:    head,
 		PendingStash:   state.PendingStash,
 		ActiveResolve:  resolve.Exists(opts.Workspace.Path),
 	}
+	status.PatchesRev, status.BrowserOSTipPatchesRev, status.PatchesFreshness, status.PatchesBehind = materializedFreshness(ctx, opts.Repo.Root, opts.Workspace.Path, state, head)
 	for _, delta := range patch.Compare(repoSet, localSet) {
 		switch delta.Kind {
 		case patch.NeedsApply:
@@ -121,6 +131,33 @@ func InspectWorkspace(ctx context.Context, opts InspectWorkspaceOptions) (*Works
 	}
 	status.SyncState = inferSyncState(status)
 	return status, nil
+}
+
+func materializedFreshness(ctx context.Context, repoRoot string, workspacePath string, state *workspace.State, repoHead string) (string, string, string, int) {
+	tipRev := ""
+	if exists, err := git.CommitExists(ctx, workspacePath, browserOSBranch); err == nil && exists {
+		if trailer, trailerErr := git.CommitTrailer(ctx, workspacePath, browserOSBranch, patchesRevTrailer); trailerErr == nil {
+			tipRev = trailer
+		}
+	}
+	rev := state.LastRefreshRev
+	if rev == "" {
+		rev = tipRev
+	}
+	switch {
+	case rev == "":
+		return "", tipRev, "unknown", 0
+	case state.LastRefreshRev != "" && tipRev != "" && state.LastRefreshRev != tipRev:
+		return rev, tipRev, "mismatch", 0
+	case rev == repoHead:
+		return rev, tipRev, "fresh", 0
+	default:
+		behind, err := git.RevListCount(ctx, repoRoot, rev, repoHead)
+		if err != nil || behind == 0 {
+			return rev, tipRev, "unknown", 0
+		}
+		return rev, tipRev, fmt.Sprintf("behind %d", behind), behind
+	}
 }
 
 func inferSyncState(status *WorkspaceStatus) string {

--- a/packages/browseros/tools/patch/internal/engine/status.go
+++ b/packages/browseros/tools/patch/internal/engine/status.go
@@ -140,23 +140,21 @@ func materializedFreshness(ctx context.Context, repoRoot string, workspacePath s
 			tipRev = trailer
 		}
 	}
-	rev := state.LastRefreshRev
-	if rev == "" {
-		rev = tipRev
-	}
 	switch {
-	case rev == "":
+	case tipRev == "":
 		return "", tipRev, "unknown", 0
-	case state.LastRefreshRev != "" && tipRev != "" && state.LastRefreshRev != tipRev:
-		return rev, tipRev, "mismatch", 0
-	case rev == repoHead:
-		return rev, tipRev, "fresh", 0
+	case state.LastRefreshRev == "":
+		return tipRev, tipRev, "unknown", 0
+	case state.LastRefreshRev != tipRev:
+		return tipRev, tipRev, "mismatch", 0
+	case tipRev == repoHead:
+		return tipRev, tipRev, "fresh", 0
 	default:
-		behind, err := git.RevListCount(ctx, repoRoot, rev, repoHead)
+		behind, err := git.RevListCount(ctx, repoRoot, tipRev, repoHead)
 		if err != nil || behind == 0 {
-			return rev, tipRev, "unknown", 0
+			return tipRev, tipRev, "unknown", 0
 		}
-		return rev, tipRev, fmt.Sprintf("behind %d", behind), behind
+		return tipRev, tipRev, fmt.Sprintf("behind %d", behind), behind
 	}
 }
 

--- a/packages/browseros/tools/patch/internal/git/git.go
+++ b/packages/browseros/tools/patch/internal/git/git.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -69,6 +70,17 @@ func HeadRev(ctx context.Context, dir string) (string, error) {
 	return strings.TrimSpace(result.Stdout), nil
 }
 
+func RevParse(ctx context.Context, dir string, ref string) (string, error) {
+	result, err := Run(ctx, dir, nil, "rev-parse", ref)
+	if err != nil {
+		return "", err
+	}
+	if result.Code != 0 {
+		return "", errors.New(strings.TrimSpace(result.Stderr))
+	}
+	return strings.TrimSpace(result.Stdout), nil
+}
+
 func CurrentBranch(ctx context.Context, dir string) (string, error) {
 	result, err := Run(ctx, dir, nil, "branch", "--show-current")
 	if err != nil {
@@ -82,6 +94,17 @@ func CurrentBranch(ctx context.Context, dir string) (string, error) {
 
 func IsDirty(ctx context.Context, dir string) (bool, error) {
 	return IsDirtyPaths(ctx, dir, nil)
+}
+
+func IsTrackedDirty(ctx context.Context, dir string) (bool, error) {
+	result, err := Run(ctx, dir, nil, "status", "--porcelain", "--untracked-files=no")
+	if err != nil {
+		return false, err
+	}
+	if result.Code != 0 {
+		return false, errors.New(strings.TrimSpace(result.Stderr))
+	}
+	return strings.TrimSpace(result.Stdout) != "", nil
 }
 
 func IsDirtyPaths(ctx context.Context, dir string, pathspecs []string) (bool, error) {
@@ -150,6 +173,42 @@ func CommitPaths(ctx context.Context, dir string, message string, paths []string
 		return "", errors.New(strings.TrimSpace(result.Stderr))
 	}
 	return HeadRev(ctx, dir)
+}
+
+func CommitPathsWithBody(ctx context.Context, dir string, subject string, body string, paths []string) (string, error) {
+	args := []string{"commit", "-m", subject}
+	if body != "" {
+		args = append(args, "-m", body)
+	}
+	if len(paths) > 0 {
+		args = append(args, "--")
+		args = append(args, paths...)
+	}
+	result, err := Run(ctx, dir, nil, args...)
+	if err != nil {
+		return "", err
+	}
+	if result.Code != 0 {
+		return "", errors.New(strings.TrimSpace(result.Stderr))
+	}
+	return HeadRev(ctx, dir)
+}
+
+func CommitTrailer(ctx context.Context, dir string, ref string, key string) (string, error) {
+	result, err := Run(ctx, dir, nil, "log", "-1", "--format=%B", ref)
+	if err != nil {
+		return "", err
+	}
+	if result.Code != 0 {
+		return "", errors.New(strings.TrimSpace(result.Stderr))
+	}
+	prefix := key + ":"
+	for _, line := range strings.Split(result.Stdout, "\n") {
+		if strings.HasPrefix(line, prefix) {
+			return strings.TrimSpace(strings.TrimPrefix(line, prefix)), nil
+		}
+	}
+	return "", nil
 }
 
 func CommitExists(ctx context.Context, dir string, ref string) (bool, error) {
@@ -309,6 +368,21 @@ func RevListRange(ctx context.Context, dir string, start string, end string) ([]
 		return nil, errors.New(strings.TrimSpace(result.Stderr))
 	}
 	return splitLines(result.Stdout), nil
+}
+
+func RevListCount(ctx context.Context, dir string, start string, end string) (int, error) {
+	result, err := Run(ctx, dir, nil, "rev-list", "--count", fmt.Sprintf("%s..%s", start, end))
+	if err != nil {
+		return 0, err
+	}
+	if result.Code != 0 {
+		return 0, errors.New(strings.TrimSpace(result.Stderr))
+	}
+	count, err := strconv.Atoi(strings.TrimSpace(result.Stdout))
+	if err != nil {
+		return 0, err
+	}
+	return count, nil
 }
 
 func ApplyPatch(ctx context.Context, dir string, patch []byte) (string, error) {
@@ -676,6 +750,50 @@ func PullRebase(ctx context.Context, dir string, remote string, branch string) e
 		}
 	}
 	result, err := Run(ctx, dir, nil, args...)
+	if err != nil {
+		return err
+	}
+	if result.Code != 0 {
+		return errors.New(strings.TrimSpace(result.Stderr))
+	}
+	return nil
+}
+
+func ResetHard(ctx context.Context, dir string) error {
+	result, err := Run(ctx, dir, nil, "reset", "--hard")
+	if err != nil {
+		return err
+	}
+	if result.Code != 0 {
+		return errors.New(strings.TrimSpace(result.Stderr))
+	}
+	return nil
+}
+
+func CheckoutDetached(ctx context.Context, dir string, ref string) error {
+	result, err := Run(ctx, dir, nil, "checkout", "--detach", ref)
+	if err != nil {
+		return err
+	}
+	if result.Code != 0 {
+		return errors.New(strings.TrimSpace(result.Stderr))
+	}
+	return nil
+}
+
+func CheckoutBranch(ctx context.Context, dir string, branch string) error {
+	result, err := Run(ctx, dir, nil, "checkout", branch)
+	if err != nil {
+		return err
+	}
+	if result.Code != 0 {
+		return errors.New(strings.TrimSpace(result.Stderr))
+	}
+	return nil
+}
+
+func ForceBranch(ctx context.Context, dir string, branch string, ref string) error {
+	result, err := Run(ctx, dir, nil, "branch", "-f", branch, ref)
 	if err != nil {
 		return err
 	}

--- a/packages/browseros/tools/patch/internal/git/git.go
+++ b/packages/browseros/tools/patch/internal/git/git.go
@@ -229,6 +229,7 @@ func CommitIndexWithBodyEnv(ctx context.Context, dir string, subject string, bod
 	if body != "" {
 		message += "\n" + body + "\n"
 	}
+	// Bypass hooks and signing so refresh materialization hashes match across checkouts.
 	result, err := RunEnv(ctx, dir, []byte(message), env, "-c", "commit.gpgsign=false", "commit-tree", tree, "-p", parent)
 	if err != nil {
 		return "", err

--- a/packages/browseros/tools/patch/internal/git/git.go
+++ b/packages/browseros/tools/patch/internal/git/git.go
@@ -407,6 +407,21 @@ func RevListCount(ctx context.Context, dir string, start string, end string) (in
 	return count, nil
 }
 
+func IsAncestor(ctx context.Context, dir string, ancestor string, descendant string) (bool, error) {
+	result, err := Run(ctx, dir, nil, "merge-base", "--is-ancestor", ancestor, descendant)
+	if err != nil {
+		return false, err
+	}
+	switch result.Code {
+	case 0:
+		return true, nil
+	case 1:
+		return false, nil
+	default:
+		return false, errors.New(strings.TrimSpace(result.Stderr))
+	}
+}
+
 func ApplyPatch(ctx context.Context, dir string, patch []byte) (string, error) {
 	strategies := [][]string{
 		{"apply", "--ignore-whitespace", "--whitespace=nowarn", "-p1"},

--- a/packages/browseros/tools/patch/internal/git/git.go
+++ b/packages/browseros/tools/patch/internal/git/git.go
@@ -25,8 +25,15 @@ type FileChange struct {
 }
 
 func Run(ctx context.Context, dir string, stdin []byte, args ...string) (Result, error) {
+	return RunEnv(ctx, dir, stdin, nil, args...)
+}
+
+func RunEnv(ctx context.Context, dir string, stdin []byte, env []string, args ...string) (Result, error) {
 	command := exec.CommandContext(ctx, "git", args...)
 	command.Dir = dir
+	if len(env) > 0 {
+		command.Env = append(os.Environ(), env...)
+	}
 	if stdin != nil {
 		command.Stdin = bytes.NewReader(stdin)
 	}
@@ -176,6 +183,10 @@ func CommitPaths(ctx context.Context, dir string, message string, paths []string
 }
 
 func CommitPathsWithBody(ctx context.Context, dir string, subject string, body string, paths []string) (string, error) {
+	return CommitPathsWithBodyEnv(ctx, dir, subject, body, nil, paths)
+}
+
+func CommitPathsWithBodyEnv(ctx context.Context, dir string, subject string, body string, env []string, paths []string) (string, error) {
 	args := []string{"commit", "-m", subject}
 	if body != "" {
 		args = append(args, "-m", body)
@@ -184,7 +195,7 @@ func CommitPathsWithBody(ctx context.Context, dir string, subject string, body s
 		args = append(args, "--")
 		args = append(args, paths...)
 	}
-	result, err := Run(ctx, dir, nil, args...)
+	result, err := RunEnv(ctx, dir, nil, env, args...)
 	if err != nil {
 		return "", err
 	}
@@ -192,6 +203,17 @@ func CommitPathsWithBody(ctx context.Context, dir string, subject string, body s
 		return "", errors.New(strings.TrimSpace(result.Stderr))
 	}
 	return HeadRev(ctx, dir)
+}
+
+func CommitUnixTime(ctx context.Context, dir string, ref string) (string, error) {
+	result, err := Run(ctx, dir, nil, "show", "-s", "--format=%ct", ref)
+	if err != nil {
+		return "", err
+	}
+	if result.Code != 0 {
+		return "", errors.New(strings.TrimSpace(result.Stderr))
+	}
+	return strings.TrimSpace(result.Stdout), nil
 }
 
 func CommitTrailer(ctx context.Context, dir string, ref string, key string) (string, error) {

--- a/packages/browseros/tools/patch/internal/git/git.go
+++ b/packages/browseros/tools/patch/internal/git/git.go
@@ -216,6 +216,44 @@ func CommitUnixTime(ctx context.Context, dir string, ref string) (string, error)
 	return strings.TrimSpace(result.Stdout), nil
 }
 
+func CommitIndexWithBodyEnv(ctx context.Context, dir string, subject string, body string, env []string) (string, error) {
+	tree, err := writeTree(ctx, dir)
+	if err != nil {
+		return "", err
+	}
+	parent, err := HeadRev(ctx, dir)
+	if err != nil {
+		return "", err
+	}
+	message := subject + "\n"
+	if body != "" {
+		message += "\n" + body + "\n"
+	}
+	result, err := RunEnv(ctx, dir, []byte(message), env, "-c", "commit.gpgsign=false", "commit-tree", tree, "-p", parent)
+	if err != nil {
+		return "", err
+	}
+	if result.Code != 0 {
+		return "", errors.New(strings.TrimSpace(result.Stderr))
+	}
+	commit := strings.TrimSpace(result.Stdout)
+	if err := ResetSoft(ctx, dir, commit); err != nil {
+		return "", err
+	}
+	return commit, nil
+}
+
+func writeTree(ctx context.Context, dir string) (string, error) {
+	result, err := Run(ctx, dir, nil, "write-tree")
+	if err != nil {
+		return "", err
+	}
+	if result.Code != 0 {
+		return "", errors.New(strings.TrimSpace(result.Stderr))
+	}
+	return strings.TrimSpace(result.Stdout), nil
+}
+
 func CommitTrailer(ctx context.Context, dir string, ref string, key string) (string, error) {
 	result, err := Run(ctx, dir, nil, "log", "-1", "--format=%B", ref)
 	if err != nil {
@@ -798,6 +836,17 @@ func PullRebase(ctx context.Context, dir string, remote string, branch string) e
 
 func ResetHard(ctx context.Context, dir string) error {
 	result, err := Run(ctx, dir, nil, "reset", "--hard")
+	if err != nil {
+		return err
+	}
+	if result.Code != 0 {
+		return errors.New(strings.TrimSpace(result.Stderr))
+	}
+	return nil
+}
+
+func ResetSoft(ctx context.Context, dir string, ref string) error {
+	result, err := Run(ctx, dir, nil, "reset", "--soft", ref)
 	if err != nil {
 		return err
 	}

--- a/packages/browseros/tools/patch/internal/lock/lock.go
+++ b/packages/browseros/tools/patch/internal/lock/lock.go
@@ -1,0 +1,72 @@
+package lock
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/git"
+	"golang.org/x/sys/unix"
+)
+
+type Progress interface {
+	Step(message string)
+}
+
+// WithRepoLock serializes mutating operations that share one patch repo worktree.
+func WithRepoLock(ctx context.Context, repoRoot string, progress Progress, fn func() error) error {
+	lockPath, err := repoLockPath(ctx, repoRoot)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		return err
+	}
+	file, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o644)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	if progress != nil {
+		progress.Step("Waiting for patch repo lock")
+	}
+	if err := flock(ctx, int(file.Fd())); err != nil {
+		return err
+	}
+	defer unix.Flock(int(file.Fd()), unix.LOCK_UN)
+	if progress != nil {
+		progress.Step("Acquired patch repo lock")
+	}
+	return fn()
+}
+
+func repoLockPath(ctx context.Context, repoRoot string) (string, error) {
+	result, err := git.Run(ctx, repoRoot, nil, "rev-parse", "--git-path", "browseros-patch.lock")
+	if err != nil {
+		return "", err
+	}
+	if result.Code != 0 {
+		return "", errors.New(result.Stderr)
+	}
+	path := filepath.Clean(strings.TrimSpace(result.Stdout))
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(repoRoot, path)
+	}
+	return path, nil
+}
+
+func flock(ctx context.Context, fd int) error {
+	for {
+		if err := unix.Flock(fd, unix.LOCK_EX); err != unix.EINTR {
+			return err
+		}
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("acquire patch repo lock: %w", ctx.Err())
+		default:
+		}
+	}
+}

--- a/packages/browseros/tools/patch/internal/lock/lock.go
+++ b/packages/browseros/tools/patch/internal/lock/lock.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/git"
 	"golang.org/x/sys/unix"
@@ -59,14 +60,20 @@ func repoLockPath(ctx context.Context, repoRoot string) (string, error) {
 }
 
 func flock(ctx context.Context, fd int) error {
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
 	for {
-		if err := unix.Flock(fd, unix.LOCK_EX); err != unix.EINTR {
+		err := unix.Flock(fd, unix.LOCK_EX|unix.LOCK_NB)
+		if err == nil {
+			return nil
+		}
+		if err != unix.EWOULDBLOCK && err != unix.EAGAIN && err != unix.EINTR {
 			return err
 		}
 		select {
 		case <-ctx.Done():
 			return fmt.Errorf("acquire patch repo lock: %w", ctx.Err())
-		default:
+		case <-ticker.C:
 		}
 	}
 }

--- a/packages/browseros/tools/patch/internal/lock/lock_test.go
+++ b/packages/browseros/tools/patch/internal/lock/lock_test.go
@@ -2,11 +2,13 @@ package lock
 
 import (
 	"context"
+	"errors"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestWithRepoLockUsesGitPrivateLockFile(t *testing.T) {
@@ -27,6 +29,32 @@ func TestWithRepoLockUsesGitPrivateLockFile(t *testing.T) {
 	}
 	if status := gitOutput(t, repoRoot, "status", "--porcelain"); status != "" {
 		t.Fatalf("lock file must not dirty repo, got %q", status)
+	}
+}
+
+func TestWithRepoLockHonorsContextWhileWaiting(t *testing.T) {
+	ctx := context.Background()
+	repoRoot := initGitRepo(t)
+	if err := WithRepoLock(ctx, repoRoot, nil, func() error {
+		waitCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+		defer cancel()
+		errCh := make(chan error, 1)
+		go func() {
+			errCh <- WithRepoLock(waitCtx, repoRoot, nil, func() error {
+				return errors.New("inner lock callback ran")
+			})
+		}()
+		select {
+		case err := <-errCh:
+			if !errors.Is(err, context.DeadlineExceeded) {
+				t.Fatalf("expected deadline exceeded, got %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Fatalf("waiting lock did not honor context deadline")
+		}
+		return nil
+	}); err != nil {
+		t.Fatalf("WithRepoLock: %v", err)
 	}
 }
 

--- a/packages/browseros/tools/patch/internal/lock/lock_test.go
+++ b/packages/browseros/tools/patch/internal/lock/lock_test.go
@@ -1,0 +1,74 @@
+package lock
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWithRepoLockUsesGitPrivateLockFile(t *testing.T) {
+	ctx := context.Background()
+	repoRoot := initGitRepo(t)
+	called := false
+	if err := WithRepoLock(ctx, repoRoot, nil, func() error {
+		called = true
+		return nil
+	}); err != nil {
+		t.Fatalf("WithRepoLock: %v", err)
+	}
+	if !called {
+		t.Fatalf("expected lock callback to run")
+	}
+	if _, err := os.Stat(filepath.Join(repoRoot, ".git", "browseros-patch.lock")); err != nil {
+		t.Fatalf("expected git-private lock file: %v", err)
+	}
+	if status := gitOutput(t, repoRoot, "status", "--porcelain"); status != "" {
+		t.Fatalf("lock file must not dirty repo, got %q", status)
+	}
+}
+
+func initGitRepo(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "config", "user.name", "Test User")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	writeFile(t, filepath.Join(dir, "README.md"), "x\n")
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "-m", "init")
+	return dir
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, string(output))
+	}
+}
+
+func gitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, string(output))
+	}
+	return strings.TrimSpace(string(output))
+}
+
+func writeFile(t *testing.T, path string, body string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+}

--- a/packages/browseros/tools/patch/internal/workspace/state.go
+++ b/packages/browseros/tools/patch/internal/workspace/state.go
@@ -16,10 +16,12 @@ type State struct {
 	LastApplyRev   string    `yaml:"last_apply_rev,omitempty" json:"last_apply_rev,omitempty"`
 	LastSyncRev    string    `yaml:"last_sync_rev,omitempty" json:"last_sync_rev,omitempty"`
 	LastExtractRev string    `yaml:"last_extract_rev,omitempty" json:"last_extract_rev,omitempty"`
+	LastRefreshRev string    `yaml:"last_refresh_rev,omitempty" json:"last_refresh_rev,omitempty"`
 	PendingStash   string    `yaml:"pending_stash,omitempty" json:"pending_stash,omitempty"`
 	LastApplyAt    time.Time `yaml:"last_apply_at,omitempty" json:"last_apply_at,omitempty"`
 	LastSyncAt     time.Time `yaml:"last_sync_at,omitempty" json:"last_sync_at,omitempty"`
 	LastExtractAt  time.Time `yaml:"last_extract_at,omitempty" json:"last_extract_at,omitempty"`
+	LastRefreshAt  time.Time `yaml:"last_refresh_at,omitempty" json:"last_refresh_at,omitempty"`
 }
 
 func StateDir(workspacePath string) string {


### PR DESCRIPTION
## Summary
- add `bpatch refresh` to rebuild local `browseros` branches from canonical patches with per-feature commits and `Patches-Rev` trailers
- add feature registry tooling (`feature add`, `feature lint`) and status freshness JSON for sfmux pool decisions
- serialize patch-repo mutations with a repo-scoped file lock and harden range extraction / refresh materialization
- clean duplicate concrete patch claims in `bos_build/features.yaml` so the exactly-once invariant passes

## Test plan
- `cd packages/browseros/tools/patch && make test && make build && make clean`
- `cd packages/browseros/tools/patch && tmp=$(mktemp -d); XDG_CONFIG_HOME=$tmp go run . feature lint --json`
