### PR TITLE
fix(server): update Codex ACP package + wire tier-2 npx fallback

### DIFF
--- a/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
+++ b/packages/browseros-agent/apps/server/src/agent/provider-factory.ts
@@ -148,18 +148,21 @@ async function createAcpLanguageModel(
   })
 
   const agentRegistryOverrides: Record<string, string> = {}
-  // Pre-seed the built-in adapters with the bundled-Bun launcher so the
-  // spawned child does not depend on `npx` being on the user's PATH.
-  // We only override when the launcher resolved the bundled binary;
-  // host-npx-fallback would only restate acpx's own registry command,
-  // so we let acpx resolve it directly in that case.
+  // Two-tier chain for the built-in adapters: bundled-Bun when the
+  // shipped binary resolves; otherwise the BrowserOS-pinned
+  // `npx -y <pkg>@<range>` string from HOST_ACP_ADAPTER_CONFIG.
+  // Only a `launcher === null` result (agent not in
+  // HOST_ACP_ADAPTER_CONFIG) leaves the override unset, deferring to
+  // acpx's built-in registry. This keeps BrowserOS in control of the
+  // pinned version range for both tiers instead of falling through to
+  // whatever range acpx happens to ship.
   for (const builtIn of ['claude', 'codex'] as const) {
     const launcher = resolveAcpSpawnCommand({
       agentType: builtIn,
       browserosDir: getBrowserosDir(),
       resourcesDir: config.resourcesDir,
     })
-    if (launcher?.source === 'bundled-bun') {
+    if (launcher) {
       agentRegistryOverrides[builtIn] = launcher.command
     }
   }

--- a/packages/browseros-agent/apps/server/src/api/services/acpx-probe/probeAgent.ts
+++ b/packages/browseros-agent/apps/server/src/api/services/acpx-probe/probeAgent.ts
@@ -81,11 +81,11 @@ export async function probeAcpAgent(
   const timeoutMs = resolveTimeout(input.timeoutMs)
 
   // Built-in agent ids (claude, codex) get rewritten to an explicit
-  // command when the bundled-Bun launcher resolves. When the launcher
-  // would fall back to `npx -y …` we deliberately leave the agentId
-  // alone so acpx's built-in registry produces the same command via
-  // its own code path; this keeps callers that have not threaded
-  // resourcesDir yet on the exact pre-existing behaviour.
+  // command via the two-tier launcher chain: bundled-Bun preferred,
+  // host-npx-fallback second. Only `launcher === null` (agent id not
+  // in HOST_ACP_ADAPTER_CONFIG) leaves the agentId alone and lets
+  // acp-probe / acpx resolve it via their own registry. `launcherSource`
+  // in the log line distinguishes tier 1 vs tier 2 for runtime traces.
   let agentId = input.agentId
   let command = input.command
   if (!command && agentId) {
@@ -95,11 +95,12 @@ export async function probeAcpAgent(
       resourcesDir: input.resourcesDir,
       platform: input.platform,
     })
-    if (launcher?.source === 'bundled-bun') {
+    if (launcher) {
       command = launcher.command
       agentId = undefined
-      logger.debug('ACP probe using bundled-bun launcher', {
+      logger.debug('ACP probe using launcher-resolved command', {
         originalAgentId: input.agentId,
+        launcherSource: launcher.source,
       })
     }
   }

--- a/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/acpx/runtime.ts
@@ -927,9 +927,9 @@ async function applyPermissionBypass(
       return []
     } catch (err) {
       lastError = err
-      // debug, not warn: the harness always spawns @zed-industries/codex-acp
-      // (mode id `full-access`), so codex's first candidate is expected to
-      // be rejected on the happy path. Only the all-rejected case below warns.
+      // debug, not warn: Codex ACP builds have used both `agent-full-access`
+      // and `full-access` for the same bypass mode. Only the all-rejected
+      // case below warns.
       logger.debug('Agent harness acpx mode candidate rejected', {
         agentId: input.agent.id,
         adapter: input.agent.adapter,

--- a/packages/browseros-agent/apps/server/src/lib/agents/host-acp/config.ts
+++ b/packages/browseros-agent/apps/server/src/lib/agents/host-acp/config.ts
@@ -29,10 +29,10 @@ export const HOST_ACP_ADAPTER_CONFIG = {
   codex: {
     displayName: 'Codex',
     nativeBinary: 'codex',
-    acpCommand: 'npx -y @zed-industries/codex-acp@^0.12.0',
-    acpPackageSpec: '@zed-industries/codex-acp@^0.12.0',
-    acpPackageName: '@zed-industries/codex-acp',
-    acpPackageVersionRange: '^0.12.0',
+    acpCommand: 'npx -y @agentclientprotocol/codex-acp@^1.0.2',
+    acpPackageSpec: '@agentclientprotocol/codex-acp@^1.0.2',
+    acpPackageName: '@agentclientprotocol/codex-acp',
+    acpPackageVersionRange: '^1.0.2',
     acpBin: 'codex-acp',
   },
 } as const satisfies Record<HostAcpAdapter, HostAcpAdapterConfig>
@@ -44,9 +44,9 @@ export const HOST_ACP_ADAPTER_CONFIG = {
  * adapter inherits the user's own CLI defaults (e.g. Claude settings
  * `permissions.defaultMode: "dontAsk"`, which auto-denies the BrowserOS
  * MCP tools). Candidates are tried in order; codex lists two ids because
- * @agentclientprotocol/codex-acp advertises `agent-full-access` while
- * @zed-industries/codex-acp (bundled-bun / npx fallback) uses
- * `full-access` for the same approval=never + danger-full-access preset.
+ * @agentclientprotocol/codex-acp advertises `agent-full-access`; older
+ * Zed-packaged Codex ACP builds used `full-access` for the same
+ * approval=never + danger-full-access preset, so keep it as a fallback.
  */
 export const DANGEROUS_ALLOW_MODE_CANDIDATES: Readonly<
   Partial<Record<HostAcpAdapter, readonly string[]>>

--- a/packages/browseros-agent/apps/server/tests/agent/provider-factory-acp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/provider-factory-acp.test.ts
@@ -133,17 +133,27 @@ describe('createLanguageModel — ACP providers', () => {
       acpCommand: 'my-bin acp',
     } as never)
     expect(lastBuildArgs?.agentId).toBe('my-agent')
+    // Built-in tier-2 overrides (BrowserOS-pinned npx commands) are
+    // still populated for claude + codex alongside the user's custom
+    // acp-agent override — nothing about acp-custom suppresses them.
     expect(lastBuildArgs?.agentRegistryOverrides).toEqual({
+      claude: 'npx -y @agentclientprotocol/claude-agent-acp@^0.31.0',
+      codex: 'npx -y @agentclientprotocol/codex-acp@^1.0.2',
       'my-agent': 'my-bin acp',
     })
   })
 
-  it('leaves agentRegistryOverrides empty for built-in agents without a bundled bun', async () => {
+  it('falls back to BrowserOS-pinned npx commands for built-in agents when no bundled bun is available', async () => {
     // baseConfig() has no resourcesDir so the launcher cannot resolve
-    // the bundled Bun and falls back to acpx's own npx command, which
-    // means we deliberately do NOT pre-seed the registry override.
+    // the bundled Bun and returns the tier-2 host-npx-fallback shape.
+    // We DO pre-seed the registry override with that pinned command so
+    // BrowserOS controls the version range instead of deferring to
+    // whatever acpx has hardcoded.
     await createLanguageModel(baseConfig() as never)
-    expect(lastBuildArgs?.agentRegistryOverrides).toEqual({})
+    expect(lastBuildArgs?.agentRegistryOverrides).toEqual({
+      claude: 'npx -y @agentclientprotocol/claude-agent-acp@^0.31.0',
+      codex: 'npx -y @agentclientprotocol/codex-acp@^1.0.2',
+    })
   })
 
   it('pre-seeds the bundled-Bun launcher for claude and codex when resourcesDir points at a real bundled bun', async () => {

--- a/packages/browseros-agent/apps/server/tests/agent/provider-factory-acp.test.ts
+++ b/packages/browseros-agent/apps/server/tests/agent/provider-factory-acp.test.ts
@@ -169,7 +169,7 @@ describe('createLanguageModel — ACP providers', () => {
     expect(overrides?.claude).toContain(bunPath)
     expect(overrides?.claude).toContain('@agentclientprotocol/claude-agent-acp')
     expect(overrides?.codex).toContain(bunPath)
-    expect(overrides?.codex).toContain('@zed-industries/codex-acp')
+    expect(overrides?.codex).toContain('@agentclientprotocol/codex-acp')
 
     fs.rmSync(tmpRoot, { recursive: true, force: true })
   })
@@ -197,7 +197,7 @@ describe('createLanguageModel — ACP providers', () => {
       | undefined
     expect(overrides?.['my-agent']).toBe('my-bin acp')
     expect(overrides?.claude).toContain('@agentclientprotocol/claude-agent-acp')
-    expect(overrides?.codex).toContain('@zed-industries/codex-acp')
+    expect(overrides?.codex).toContain('@agentclientprotocol/codex-acp')
 
     fs.rmSync(tmpRoot, { recursive: true, force: true })
   })
@@ -329,7 +329,7 @@ describe('createLanguageModel — ACP dangerously-allow mode', () => {
     expect(setModeCalls).toEqual(['agent-full-access'])
   })
 
-  it('falls back to the zed codex mode id when the first candidate is rejected', async () => {
+  it('falls back to the legacy codex mode id when the first candidate is rejected', async () => {
     rejectModes = ['agent-full-access']
     const { model } = await createLanguageModel({
       ...baseConfig(),

--- a/packages/browseros-agent/apps/server/tests/api/services/acpx-probe/probeAgent.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/services/acpx-probe/probeAgent.test.ts
@@ -74,10 +74,14 @@ describe('probeAcpAgent — input shape', () => {
     )
   })
 
-  it('forwards agentId to the underlying probe', async () => {
+  it('rewrites a built-in agentId to the tier-2 npx command when no resourcesDir is supplied', async () => {
     nextResult = baseProbeResult()
     await probeAcpAgent({ agentId: 'claude' })
-    expect(lastCall?.agent).toBe('claude')
+    // With no resourcesDir the launcher returns the host-npx-fallback
+    // shape; probeAcpAgent now honours that and forwards the pinned
+    // command rather than deferring to acpx's own registry.
+    expect(lastCall?.agent).toBeUndefined()
+    expect(lastCall?.command).toContain('@agentclientprotocol/claude-agent-acp')
     expect(lastCall?.authPolicy).toBe('skip')
   })
 
@@ -152,21 +156,23 @@ describe('probeAcpAgent — bundled-Bun launcher swap', () => {
     fs.rmSync(tmpRoot, { recursive: true, force: true })
   })
 
-  it('leaves agentId in place when no resourcesDir is supplied so acpx resolves the npx command', async () => {
+  it('produces the tier-2 pinned npx command when no resourcesDir is supplied', async () => {
     nextResult = baseProbeResult()
     await probeAcpAgent({ agentId: 'claude' })
-    expect(lastCall?.agent).toBe('claude')
-    expect(lastCall?.command).toBeUndefined()
+    // Launcher returns host-npx-fallback; probeAcpAgent forwards its
+    // command instead of leaving agentId in place for acpx to resolve.
+    expect(lastCall?.agent).toBeUndefined()
+    expect(lastCall?.command).toContain('@agentclientprotocol/claude-agent-acp')
   })
 
-  it('leaves agentId in place when the bundled bun binary is missing under resourcesDir', async () => {
+  it('produces the tier-2 pinned npx command when the bundled bun binary is missing under resourcesDir', async () => {
     nextResult = baseProbeResult()
     await probeAcpAgent({
       agentId: 'codex',
       resourcesDir: '/nonexistent/path/that/has/no/bundled/bun',
     })
-    expect(lastCall?.agent).toBe('codex')
-    expect(lastCall?.command).toBeUndefined()
+    expect(lastCall?.agent).toBeUndefined()
+    expect(lastCall?.command).toContain('@agentclientprotocol/codex-acp')
   })
 
   it('passes through an explicit command unchanged regardless of resourcesDir', async () => {

--- a/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/acpx-runtime.test.ts
@@ -1116,7 +1116,7 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
     expect(command).toContain('/runtime/codex-home')
     // Spawn must go through BrowserOS's own npx command for the official
     // codex-acp package, not a bare `codex` binary.
-    expect(command).toContain('npx -y @zed-industries/codex-acp')
+    expect(command).toContain('npx -y @agentclientprotocol/codex-acp')
   })
 
   it('prepends the bundled native CLI directory to host ACP adapter commands', async () => {
@@ -1201,7 +1201,7 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
         `'${bunPath}' x --bun --silent --package '@agentclientprotocol/claude-agent-acp@^0.31.0' 'claude-agent-acp'`,
       )
       expect(codexCommand).toContain(
-        `'${bunPath}' x --bun --silent --package '@zed-industries/codex-acp@^0.12.0' 'codex-acp'`,
+        `'${bunPath}' x --bun --silent --package '@agentclientprotocol/codex-acp@^1.0.2' 'codex-acp'`,
       )
       expect(codexCommand).toContain('BUN_INSTALL_CACHE_DIR=')
       expect(codexCommand).toContain('cache/acp-node-shim')
@@ -1376,7 +1376,7 @@ Use the BrowserOS MCP server for all browser tasks, including browsing the web, 
     })
   })
 
-  it('falls back to the zed codex mode id when the first candidate is rejected', async () => {
+  it('falls back to the legacy codex mode id when the first candidate is rejected', async () => {
     const calls: Array<{ method: string; input: unknown }> = []
     const runtime = new AcpxRuntime({
       cwd: '/tmp/browseros-acpx-runtime',

--- a/packages/browseros-agent/apps/server/tests/lib/agents/adapter-detection.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/agents/adapter-detection.test.ts
@@ -354,7 +354,7 @@ describe('probeNpxPackageCache', () => {
         '_npx',
         'hit',
         'node_modules',
-        '@zed-industries',
+        '@agentclientprotocol',
         'codex-acp',
       ),
       { recursive: true },
@@ -365,10 +365,10 @@ describe('probeNpxPackageCache', () => {
         '_npx',
         'miss',
         'node_modules',
-        '@zed-industries',
+        '@agentclientprotocol',
         'nested',
         'node_modules',
-        '@zed-industries',
+        '@agentclientprotocol',
         'codex-acp',
       ),
       { recursive: true },
@@ -379,11 +379,11 @@ describe('probeNpxPackageCache', () => {
         '_npx',
         'hit',
         'node_modules',
-        '@zed-industries',
+        '@agentclientprotocol',
         'codex-acp',
         'package.json',
       ),
-      '{"version":"0.12.1"}',
+      '{"version":"1.0.2"}',
     )
     await writeFile(
       join(
@@ -391,20 +391,20 @@ describe('probeNpxPackageCache', () => {
         '_npx',
         'miss',
         'node_modules',
-        '@zed-industries',
+        '@agentclientprotocol',
         'nested',
         'node_modules',
-        '@zed-industries',
+        '@agentclientprotocol',
         'codex-acp',
         'package.json',
       ),
-      '{"version":"0.12.1"}',
+      '{"version":"1.0.2"}',
     )
 
     await expect(
-      probeNpxPackageCache('@zed-industries/codex-acp', {
+      probeNpxPackageCache('@agentclientprotocol/codex-acp', {
         npxCacheDir: join(npmCacheDir, '_npx'),
-        versionRange: '^0.12.0',
+        versionRange: '^1.0.2',
       }),
     ).resolves.toBe(true)
   })
@@ -418,7 +418,7 @@ describe('probeNpxPackageCache', () => {
         '_npx',
         'stale',
         'node_modules',
-        '@zed-industries',
+        '@agentclientprotocol',
         'codex-acp',
       ),
       { recursive: true },
@@ -429,17 +429,17 @@ describe('probeNpxPackageCache', () => {
         '_npx',
         'stale',
         'node_modules',
-        '@zed-industries',
+        '@agentclientprotocol',
         'codex-acp',
         'package.json',
       ),
-      '{"version":"0.11.9"}',
+      '{"version":"1.0.1"}',
     )
 
     await expect(
-      probeNpxPackageCache('@zed-industries/codex-acp', {
+      probeNpxPackageCache('@agentclientprotocol/codex-acp', {
         npxCacheDir: join(npmCacheDir, '_npx'),
-        versionRange: '^0.12.0',
+        versionRange: '^1.0.2',
       }),
     ).resolves.toBe(false)
   })


### PR DESCRIPTION
## Summary

Two commits — same failure surface, complementary fixes.

**Commit 1 (by @coleleavitt, cherry-picked from #1491):** bumps the bundled Codex ACP adapter from `@zed-industries/codex-acp@^0.12.0` to `@agentclientprotocol/codex-acp@^1.0.2`. Closes the pre-`initialize` crash where the old (Rust) adapter's `#[serde(untagged)]` `FeatureToml` parser rejected any `~/.codex/config.toml` shape it didn't know about:

```
ACP agent exited before initialize completed (exit=1, signal=null):
Error: error loading config: /home/…/.codex/config.toml:257:1:
data did not match any variant of untagged enum FeatureToml
```

The new (TypeScript) adapter is a JSON-RPC proxy that starts `codex app-server` and delegates config parsing to the user's own Codex CLI. Parser-drift class of bug is architecturally gone. `zed-industries/codex-acp`'s own README now points at `@agentclientprotocol/codex-acp` as the successor.

**Commit 2:** wires the tier-2 fallback in the ACP launch chain. Before this, both `provider-factory.ts` and `probeAgent.ts` filtered on `launcher.source === 'bundled-bun'` and dropped the tier-2 `host-npx-fallback` command on the floor — which meant BrowserOS lost control of the pinned adapter version whenever the shipped Bun binary failed to resolve, and `acpx`'s own registry silently took over with whatever version range it happened to ship. Drop the filter; use `launcher.command` whenever the launcher returns non-null.

Effective chain after both commits:
1. **Tier 1** — BrowserOS-bundled Bun at `<resourcesDir>/bin/third_party/bun`. Almost impossible to miss on a shipped install.
2. **Tier 2** — BrowserOS-pinned `npx -y <pkg>@<range>` from `HOST_ACP_ADAPTER_CONFIG.<adapter>.acpCommand`. Same source of truth as tier 1 for the version pin.
3. **Tier 3** — `acpx`'s built-in registry. Only reached for agent ids BrowserOS doesn't ship a `HOST_ACP_ADAPTER_CONFIG` entry for.

## What this PR does not do

- Does **not** land PR #1491's CODEX_HOME isolation refactor. That's a separate improvement (skills separation, `[mcp_servers]` leak prevention) and can rebase on top of this trivially.
- Does **not** touch `acpx-ai-provider` or `acp-probe`. Both are adapter-agnostic protocol clients; the fixes cascade through `HOST_ACP_ADAPTER_CONFIG.<adapter>` and the two spawn-site call patterns.

## Verification

- `bun run --filter @browseros/server typecheck` → clean.
- `bun test tests/agent/provider-factory-acp.test.ts` → 31/31 pass.
- `bun test tests/api/services/acpx-probe/probeAgent.test.ts` → 22/22 pass.
- `bun test tests/lib/agents/acpx-runtime.test.ts` → 37/37 pass.
- `bun test tests/lib/agents/adapter-detection.test.ts` → 11/11 pass.
- `bunx @biomejs/biome check <touched-files>` → clean.
- Running the three test files together in a single `bun test` invocation hits a pre-existing Bun test-runner concurrency flake (reproduces on `main` too, unrelated to this diff). Each file passes in isolation; CI runs each in its own job.

## Commit authorship

Two commits, two authors:
- `e0dba7b0` — `Author: Cole Leavitt <cole@unwrap.rs>` (cherry-picked from Cole's #1491 branch).
- `f4140121` — `Author: DaniAkash <DaniAkash@users.noreply.github.com>` (tier-2 wiring, layered on top).