### PR TITLE
fix(browseros): don't require IPv6 loopback bind for port availability

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_utils.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_utils.cc
@@ -3,7 +3,7 @@ new file mode 100644
 index 0000000000000..dbd7e166bb02c
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_utils.cc
-@@ -0,0 +1,518 @@
+@@ -0,0 +1,513 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -151,19 +151,14 @@ index 0000000000000..dbd7e166bb02c
 +    return false;
 +  }
 +
-+  // Try binding to IPv6 localhost
-+  auto socket6 = net::TCPSocket::Create(nullptr, nullptr, net::NetLogSource());
-+  result = socket6->Open(net::ADDRESS_FAMILY_IPV6);
-+  if (result != net::OK) {
-+    return false;
-+  }
-+  result =
-+      socket6->Bind(net::IPEndPoint(net::IPAddress::IPv6Localhost(), port));
-+  socket6->Close();
-+  if (result != net::OK) {
-+    return false;
-+  }
-+
++  // Deliberately not checking IPv6 localhost here: the actual consumers
++  // (CDPServerSocketFactory, the Bun HTTP server) only require IPv4
++  // 127.0.0.1 to succeed and treat IPv6 as an optional fallback, not a
++  // requirement. On hosts with IPv6 disabled (e.g.
++  // net.ipv6.conf.lo.disable_ipv6=1), binding ::1 always fails with
++  // EADDRNOTAVAIL, which previously made every candidate port look
++  // unavailable and forced FindAvailablePort to burn through all
++  // kMaxPortAttempts on every startup.
 +  return true;
 +}
 +


### PR DESCRIPTION
## Summary
- `IsPortAvailable()` in `browseros_server_utils.cc` required **both** an IPv4 (`127.0.0.1`) and an IPv6 (`::1`) bind to succeed before reporting a port as free.
- On hosts with IPv6 disabled (e.g. `net.ipv6.conf.lo.disable_ipv6=1`), the `::1` bind always fails with `EADDRNOTAVAIL`, so **every** candidate port looks unavailable and `FindAvailablePort` burns through all `kMaxPortAttempts` (up to ~400 raw `bind()` syscalls across the CDP + server port scans) on every startup, flooding stderr with `bind() failed: Cannot assign requested address (99)`.
- The actual consumers only need IPv4: `CDPServerSocketFactory` (`browseros_server_manager.cc`) tries `127.0.0.1` first and only falls back to `::1` if that fails, and the Bun HTTP sidecar binds `0.0.0.0` (IPv4-only). The availability probe was stricter than what it's actually gating.

Reported by a user on Ubuntu 24.04 launching the AppImage from a terminal — hundreds of `net/socket/socket_posix.cc` bind errors on startup. Confirmed `net.ipv6.conf.lo.disable_ipv6=1` on the reporter's machine, and confirmed re-enabling IPv6 on loopback (no code change) eliminates the bind() error storm entirely.

**Update after further testing:** the reporter also experiences a browser freeze shortly after launch. Re-enabling IPv6 loopback removes the bind() error storm but the freeze *persists*, so the storm is not the (sole) cause of the freeze — that appears to be a separate, still-unidentified issue. This PR is scoped to the confirmed, reproducible bind()-storm bug only; it should not be read as a fix for the freeze itself. Freeze root-causing is continuing separately.

## Fix
Drop the mandatory IPv6 bind check in `IsPortAvailable()`; a successful IPv4 loopback bind is now sufficient, matching what `CDPServerSocketFactory` and the HTTP sidecar actually require.

## Test plan
- [x] Verified the edited patch file is a syntactically valid unified diff and applies cleanly to a scratch tree (`git apply --check`), with corrected hunk line count.
- [x] Reporter confirmed on their Ubuntu 24.04 machine: re-enabling `net.ipv6.conf.lo.disable_ipv6=0` (simulating what this fix effectively does for the IPv4-only check) makes the hundreds of `bind() failed: Cannot assign requested address (99)` lines disappear, leaving only the expected single `Address already in use` for a genuinely occupied port.
- [ ] Not locally build-verified against a full Chromium checkout (not vendored in this repo) — please confirm via the normal `bos_build`/CI pipeline.
- [ ] The freeze reported alongside this bug is still unresolved and is being investigated separately — see PR discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)