### PR TITLE
feat(claw-app): editorial cockpit homepage (lead story + asymmetric bento + typographic tail)

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/audit/TaskHeader.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/TaskHeader.tsx
@@ -6,7 +6,7 @@ import {
   Settings2,
 } from 'lucide-react'
 import { useState } from 'react'
-import { NavLink, useNavigate } from 'react-router'
+import { useNavigate } from 'react-router'
 import { Button } from '@/components/ui/button'
 import type { TaskDetail } from '@/modules/api/audit.hooks'
 import { useReplayMetadata } from '@/modules/api/replay.hooks'
@@ -32,13 +32,14 @@ export function TaskHeader({ task }: TaskHeaderProps) {
 
   return (
     <section className="space-y-4">
-      <NavLink
-        to="/audit"
+      <button
+        type="button"
+        onClick={() => navigate(-1)}
         className="inline-flex items-center gap-1 text-[12.5px] text-ink-3 hover:text-ink-1"
       >
         <ChevronLeft className="size-3.5" />
-        Back to Audit
-      </NavLink>
+        Back
+      </button>
 
       <header className="rounded-2xl border border-border-2 bg-card p-5">
         <div className="flex items-start justify-between gap-4">

--- a/packages/browseros-agent/apps/claw-app/components/audit/TaskHeader.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/TaskHeader.tsx
@@ -6,7 +6,7 @@ import {
   Settings2,
 } from 'lucide-react'
 import { useState } from 'react'
-import { useNavigate } from 'react-router'
+import { useLocation, useNavigate } from 'react-router'
 import { Button } from '@/components/ui/button'
 import type { TaskDetail } from '@/modules/api/audit.hooks'
 import { useReplayMetadata } from '@/modules/api/replay.hooks'
@@ -22,6 +22,18 @@ export function TaskHeader({ task }: TaskHeaderProps) {
   const [copied, setCopied] = useState(false)
   const finalUrl = lastUrl(task) ?? task.dispatches[0]?.url ?? null
   const navigate = useNavigate()
+  const location = useLocation()
+  // Semantic back: prefer the referring path passed via router state
+  // (see cockpit tiles + audit list). Falls back to /audit for direct
+  // URL loads. Never uses navigate(-1) because history-based back is
+  // unreliable once the user has forward/back navigation in history.
+  const backTo =
+    typeof location.state === 'object' &&
+    location.state !== null &&
+    'from' in location.state &&
+    typeof location.state.from === 'string'
+      ? location.state.from
+      : '/audit'
   // Poll the metadata endpoint so the View Replay button unlocks
   // within seconds once the first rrweb batch lands. The
   // useReplayMetadata hook handles its own staleTime + interval.
@@ -34,7 +46,7 @@ export function TaskHeader({ task }: TaskHeaderProps) {
     <section className="space-y-4">
       <button
         type="button"
-        onClick={() => navigate(-1)}
+        onClick={() => navigate(backTo)}
         className="inline-flex items-center gap-1 text-[12.5px] text-ink-3 hover:text-ink-1"
       >
         <ChevronLeft className="size-3.5" />

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/AgentRunningCard.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/AgentRunningCard.tsx
@@ -46,12 +46,12 @@ export function AgentRunningCard({
           live={active}
           screencast={focus.screencast}
         />
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-ink-1 via-ink-1/60 to-transparent" />
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-ink via-ink/60 to-transparent" />
         <div className="absolute top-3 right-3">
           <TabCountChip tabs={agent.tabs} focusTargetId={focus.targetId} />
         </div>
       </div>
-      <div className="flex flex-col gap-1.5 bg-ink-1 px-4 py-3 text-white">
+      <div className="flex flex-col gap-1.5 bg-ink px-4 py-3 text-white">
         <div className="flex items-center gap-3 font-mono text-[10.5px] text-white/80 uppercase tracking-[0.08em]">
           <span className="inline-flex items-center gap-1.5">
             <AgentDot slug={agent.slug} />

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/AgentRunningCard.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/AgentRunningCard.tsx
@@ -46,7 +46,6 @@ export function AgentRunningCard({
           live={active}
           screencast={focus.screencast}
         />
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-ink via-ink/60 to-transparent" />
         <div className="absolute top-3 right-3">
           <TabCountChip tabs={agent.tabs} focusTargetId={focus.targetId} />
         </div>

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/AgentRunningCard.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/AgentRunningCard.tsx
@@ -1,9 +1,8 @@
-import { Check, ExternalLink, RefreshCw, Square } from 'lucide-react'
-import { Card } from '@/components/ui/card'
+import { ExternalLink, RefreshCw, Square } from 'lucide-react'
+import { AgentDot } from '@/components/audit/AgentDot'
 import type { AgentActivityRecord } from '@/screens/cockpit/cockpit.helpers'
 import { formatToolTrail, siteOf } from '@/screens/cockpit/cockpit.helpers'
 import { MiniScreencast } from './MiniScreencast'
-import { StatusBadge } from './StatusBadge'
 import { TabCountChip } from './TabCountChip'
 
 interface AgentRunningCardProps {
@@ -17,14 +16,14 @@ interface AgentRunningCardProps {
 }
 
 /**
- * One card per agent on the homepage running grid. The focus tab is
- * the agent's freshest `lastToolAt` and supplies the visible
- * surface: site host, task title, mini-screencast. The "N tabs" chip
- * in the header opens a popover with the full tab list when the
- * agent is driving more than one tab. Trail and action count are
- * merged across all of this agent's tabs so the card tells the
- * complete story of what the agent has been doing, not just the
- * current focus.
+ * One card per LIVE agent in the "Running now" strip. Uses the
+ * same split-zone language as the editorial lead-story tile in
+ * Recent activity: the current focus screencast dominates the top,
+ * a dark caption block at the bottom carries the agent identity,
+ * the current tool, and Watch / Stop actions as inline chips.
+ *
+ * LIVE indicator uses the app's accent orange with a pulsing dot,
+ * not a green pill; the whole app has one accent color.
  */
 export function AgentRunningCard({
   agent,
@@ -36,68 +35,56 @@ export function AgentRunningCard({
   const focus = agent.currentFocus
   const active = agent.status === 'active'
   const trail = formatToolTrail(agent.recentTools)
-  const liveLine = `${agent.lastToolName} - ${focus.title || siteOf(focus.url)}`
-
   return (
-    <Card
+    <div
       data-agent-card
-      className="group flex cursor-pointer flex-col overflow-hidden border-border-2 border-l-4 p-0 transition hover:border-border-strong hover:shadow-card"
-      style={{ borderLeftColor: agent.color }}
+      className="group relative flex h-[300px] flex-col overflow-hidden rounded-2xl border border-border-2 bg-bg-sunken transition-[border-color] duration-150 hover:border-accent/40"
     >
-      <MiniScreencast
-        site={siteOf(focus.url)}
-        live={active}
-        screencast={focus.screencast}
-      />
-      <div className="flex flex-1 flex-col gap-2 p-3.5">
-        <div className="flex items-center gap-2">
-          <span className="min-w-0 flex-1 truncate font-bold text-[13.5px]">
-            {agent.agentLabel}
-          </span>
+      <div className="relative flex-1 overflow-hidden">
+        <MiniScreencast
+          site={siteOf(focus.url)}
+          live={active}
+          screencast={focus.screencast}
+        />
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-10 bg-gradient-to-t from-ink-1 via-ink-1/60 to-transparent" />
+        <div className="absolute top-3 right-3">
           <TabCountChip tabs={agent.tabs} focusTargetId={focus.targetId} />
-          <StatusBadge status={active ? 'running' : 'done'} />
         </div>
-        <code className="truncate font-mono text-[11px] text-ink-3">
-          {siteOf(focus.url)}
-        </code>
-        <p className="line-clamp-2 min-h-9 text-[12.5px] text-ink-2 leading-snug">
-          {focus.title || siteOf(focus.url)}
-        </p>
-        <div className="mt-auto flex items-center gap-1.5 text-[11.5px] text-ink-2">
-          {active ? (
-            <RefreshCw className="size-3 shrink-0 animate-spin text-accent" />
-          ) : (
-            <Check className="size-3 shrink-0 text-green" />
-          )}
-          <span className="min-w-0 flex-1 truncate font-mono">
-            {active ? liveLine : 'Completed'}
+      </div>
+      <div className="flex flex-col gap-1.5 bg-ink-1 px-4 py-3 text-white">
+        <div className="flex items-center gap-3 font-mono text-[10.5px] text-white/80 uppercase tracking-[0.08em]">
+          <span className="inline-flex items-center gap-1.5">
+            <AgentDot slug={agent.slug} />
+            <span className="text-white">{agent.agentLabel}</span>
           </span>
-          {agent.toolCount > 0 && (
-            <span className="shrink-0 rounded-full bg-bg-sunken px-1.5 py-0.5 font-mono text-[10.5px] text-ink-2">
-              {agent.toolCount} {agent.toolCount === 1 ? 'action' : 'actions'}
+          {active && (
+            <span className="inline-flex items-center gap-1.5 text-accent">
+              <span
+                aria-hidden
+                className="inline-block size-1.5 animate-[pulse-dot_1.4s_ease-in-out_infinite] rounded-full bg-accent shadow-[0_0_8px_hsl(19_89%_56%/0.7)]"
+              />
+              LIVE
             </span>
           )}
         </div>
-        {trail && (
-          <code
-            className="truncate font-mono text-[10.5px] text-ink-3"
-            title={trail}
-          >
-            {trail}
-          </code>
-        )}
-        <div className="flex gap-2 border-border border-t pt-2.5">
+        <h3 className="truncate font-semibold text-[14px] text-white leading-tight">
+          {focus.title || siteOf(focus.url)}
+        </h3>
+        <p className="truncate font-mono text-[11px] text-white/60">
+          {trail || siteOf(focus.url)}
+        </p>
+        <div className="mt-1 flex items-center gap-2 border-white/10 border-t pt-2">
           <button
             type="button"
             onClick={onWatch}
             disabled={isFocusPending}
-            className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-md px-2 py-1.5 font-semibold text-[12.5px] text-ink-2 transition hover:bg-bg-sunken hover:text-ink disabled:cursor-not-allowed disabled:opacity-60"
+            className="inline-flex flex-1 items-center justify-center gap-1.5 rounded-md bg-white/10 px-2 py-1.5 font-mono text-[10.5px] text-white/90 uppercase tracking-[0.08em] transition hover:bg-white/20 disabled:cursor-not-allowed disabled:opacity-60"
           >
             {isFocusPending ? (
-              <RefreshCw className="size-3.5 animate-spin" />
+              <RefreshCw className="size-3 animate-spin" />
             ) : (
-              <ExternalLink className="size-3.5" />
-            )}{' '}
+              <ExternalLink className="size-3" />
+            )}
             Watch
           </button>
           {active && onStop && (
@@ -106,12 +93,10 @@ export function AgentRunningCard({
               onClick={onStop}
               disabled={isCancelPending}
               aria-label={isCancelPending ? 'Cancelling agent' : 'Stop agent'}
-              // min-w-[7rem] reserves enough width for the longer
+              // min-w reserves enough width for the longer
               // 'Cancelling' label so swapping in the pending state
-              // does not push the adjacent Watch button (which is
-              // flex-1) around. Centre-aligned content + fixed width
-              // means the icon position stays put across states too.
-              className="inline-flex min-w-[7rem] items-center justify-center gap-1.5 rounded-md bg-bg-sunken px-2.5 py-1.5 font-semibold text-[12.5px] text-ink-2 transition hover:bg-card-tint hover:text-ink disabled:cursor-not-allowed disabled:opacity-60"
+              // does not push the Watch button around.
+              className="inline-flex min-w-[92px] items-center justify-center gap-1.5 rounded-md bg-white/10 px-2 py-1.5 font-mono text-[10.5px] text-white/90 uppercase tracking-[0.08em] transition hover:bg-red-500/30 hover:text-red-100 disabled:cursor-not-allowed disabled:opacity-60"
             >
               {isCancelPending ? (
                 <>
@@ -126,6 +111,6 @@ export function AgentRunningCard({
           )}
         </div>
       </div>
-    </Card>
+    </div>
   )
 }

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/CockpitHero.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/CockpitHero.tsx
@@ -1,24 +1,19 @@
 /**
- * Cockpit hero. Lifted verbatim from the design prototype's dashboard:
- * sans-serif title with a Newsreader italic accent on "working on"
- * sitting on the BrowserOS accent color. Subtitle anchors the IA
- * ("watch, approve, audit") so the user doesn't expect the cockpit
- * to be the place they author tasks.
+ * Cockpit hero. Editorial-cockpit direction: compressed vertical
+ * space, left-aligned, Newsreader italic accent on "working on"
+ * preserved as the app signature. Filters live in the section
+ * header below, not here.
  */
 export function CockpitHero() {
   return (
-    <header className="space-y-3 pt-2 text-center">
-      <h1 className="font-extrabold text-4xl leading-tight tracking-tight md:text-5xl">
+    <header className="pt-1">
+      <h1 className="font-extrabold text-3xl leading-[1.15] tracking-tight md:text-4xl">
         What are your agents{' '}
         <span className="font-medium font-serif text-accent italic">
           working on
         </span>{' '}
         right now?
       </h1>
-      <p className="text-ink-3 text-sm">
-        Tasks start in Claude Code &amp; Codex. BrowserOS is where you watch,
-        approve, and audit them.
-      </p>
     </header>
   )
 }

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/LeadRunTile.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/LeadRunTile.tsx
@@ -16,11 +16,16 @@ interface LeadRunTileProps {
 }
 
 /**
- * The lead-story tile for the cockpit editorial layout. Screenshot
- * dominates the composition; a soft ink scrim over the bottom half
- * makes the caption legible. No card body under the image, no glass
- * chip overlay. Whole tile is a link. Hover raises a tiny arrow in
- * the top-right corner as the only affordance.
+ * Lead-story tile for the cockpit editorial layout.
+ *
+ * Split into two zones so the caption never has to fight the
+ * screenshot for legibility: the top ~62% is the raw screenshot,
+ * the bottom ~38% is a solid dark caption block carrying the
+ * session meta in white. The transition between the two is a
+ * short gradient fade so the seam does not read as a hard line.
+ *
+ * Hover raises a tiny arrow chip in the top-right corner as the
+ * only affordance. Whole tile is a link.
  */
 export function LeadRunTile({ task, now, className }: LeadRunTileProps) {
   const isLive = task.status === 'live'
@@ -31,37 +36,30 @@ export function LeadRunTile({ task, now, className }: LeadRunTileProps) {
       to={`/audit/${encodeURIComponent(task.sessionId)}`}
       data-testid={`lead-tile-${task.sessionId}`}
       className={cn(
-        'group relative flex flex-col overflow-hidden rounded-[20px] border border-border-2 transition-[border-color] duration-150 hover:border-accent/40',
-        // No fill, no shadow: this is a shell, not a card. The
-        // screenshot below carries all the visual weight.
-        'bg-bg-sunken',
+        'group relative flex flex-col overflow-hidden rounded-[18px] border border-border-2 bg-bg-sunken transition-[border-color] duration-150 hover:border-accent/40',
         className,
       )}
     >
-      {screenshotId !== null ? (
-        <img
-          src={taskScreenshotUrl(screenshotId)}
-          alt={`Session hero from ${task.agentLabel}`}
-          loading="lazy"
-          decoding="async"
-          className="absolute inset-0 h-full w-full object-cover"
-        />
-      ) : (
-        <LeadNoShotComposition task={task} />
-      )}
-
-      {/* Soft ink scrim over the bottom half so the caption reads
-          against the recorded page below. Kept CSS-only, no
-          backdrop-blur, no glass. */}
-      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-[62%] bg-gradient-to-t from-ink-1/85 via-ink-1/50 to-transparent" />
-
-      {/* Hover cue: a small arrow slides into the top-right corner.
-          Uses translate + opacity, both on the composited layer, so
-          the underlying image is not re-rasterised. */}
-      <span className="pointer-events-none absolute top-4 right-4 flex size-8 items-center justify-center rounded-full bg-white/85 text-ink-1 opacity-0 shadow-sm backdrop-blur-md transition-[opacity,transform] duration-200 group-hover:-translate-y-0.5 group-hover:opacity-100">
-        <ArrowUpRight className="size-4" />
-      </span>
-
+      <div className="relative flex-1 overflow-hidden">
+        {screenshotId !== null ? (
+          <img
+            src={taskScreenshotUrl(screenshotId)}
+            alt={`Session hero from ${task.agentLabel}`}
+            loading="lazy"
+            decoding="async"
+            className="absolute inset-0 h-full w-full object-cover object-top"
+          />
+        ) : (
+          <LeadNoShotComposition task={task} />
+        )}
+        {/* Short fade at the bottom of the image so the seam
+            between screenshot and caption block reads as intentional
+            rather than as a hard cut. */}
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-14 bg-gradient-to-t from-ink-1 via-ink-1/60 to-transparent" />
+        <span className="pointer-events-none absolute top-3 right-3 flex size-8 items-center justify-center rounded-full bg-white/85 text-ink-1 opacity-0 shadow-sm backdrop-blur-md transition-[opacity,transform] duration-200 group-hover:-translate-y-0.5 group-hover:opacity-100">
+          <ArrowUpRight className="size-4" />
+        </span>
+      </div>
       <Caption task={task} now={now} isLive={isLive} isFailed={isFailed} />
     </NavLink>
   )
@@ -79,8 +77,8 @@ function Caption({
   isFailed: boolean
 }) {
   return (
-    <div className="relative mt-auto flex flex-col gap-1.5 p-6 pt-16 text-white">
-      <div className="flex items-center gap-3 font-mono text-[11.5px] text-white/85 uppercase tracking-[0.08em]">
+    <div className="flex flex-col gap-1 bg-ink-1 px-5 py-3 text-white">
+      <div className="flex items-center gap-3 font-mono text-[10.5px] text-white/80 uppercase tracking-[0.08em]">
         <span className="inline-flex items-center gap-1.5">
           <AgentDot slug={task.slug} />
           <span className="text-white">{task.agentLabel}</span>
@@ -104,19 +102,19 @@ function Caption({
           </span>
         )}
       </div>
-      <h2 className="text-balance font-semibold text-2xl leading-tight tracking-tight md:text-[26px]">
+      <h2 className="truncate font-semibold text-[17px] text-white leading-tight tracking-tight md:text-[19px]">
         {task.title}
       </h2>
-      <p className="font-mono text-[12.5px] text-white/75 tabular-nums">
+      <p className="font-mono text-[11.5px] text-white/70 tabular-nums">
         {formatDuration(task.durationMs)}{' '}
-        <span className="text-white/50">·</span> {task.dispatchCount} tool
+        <span className="text-white/40">·</span> {task.dispatchCount} tool
         {task.dispatchCount === 1 ? '' : 's'}{' '}
-        <span className="text-white/50">·</span>{' '}
+        <span className="text-white/40">·</span>{' '}
         {isLive
           ? 'running now'
           : `started ${formatRelative(task.startedAt, now)}`}
       </p>
-      <p className="truncate font-mono text-[12px] text-white/60">
+      <p className="truncate font-mono text-[11px] text-white/55">
         {abbreviateSequence(task.toolSequence)}
       </p>
     </div>
@@ -124,21 +122,20 @@ function Caption({
 }
 
 /**
- * When the lead session has no screenshot yet we make the ink
- * gradient the whole background and let the tool sequence become
- * the composition. This is intentional: the screen still has weight
- * and drama, it just uses type as the material.
+ * When the lead session has no screenshot yet the top zone becomes
+ * a dark composition of the tool sequence rendered as large mono
+ * type. The absence of an image becomes a design opportunity.
  */
 function LeadNoShotComposition({ task }: { task: TaskSummary }) {
-  const verbs = task.toolSequence.slice(0, 6)
+  const verbs = task.toolSequence.slice(0, 5)
   return (
     <div className="absolute inset-0 bg-gradient-to-br from-ink-1 via-ink-2 to-ink-1">
-      <div className="pointer-events-none absolute inset-0 flex flex-col justify-center gap-1 p-10 font-mono text-[38px] text-white/10 leading-[1.1] tracking-tight md:text-[52px]">
+      <div className="pointer-events-none absolute inset-0 flex flex-col justify-center gap-1 p-8 font-mono text-[30px] text-white/12 leading-[1.05] tracking-tight md:text-[38px]">
         {verbs.map((verb, idx) => (
           <span
             // biome-ignore lint/suspicious/noArrayIndexKey: tool sequence is stable-ordered per session, not a reorderable list
             key={`${verb}-${idx}`}
-            style={{ marginLeft: `${(idx % 3) * 24}px` }}
+            style={{ marginLeft: `${(idx % 3) * 20}px` }}
           >
             {verb}
           </span>

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/LeadRunTile.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/LeadRunTile.tsx
@@ -52,10 +52,6 @@ export function LeadRunTile({ task, now, className }: LeadRunTileProps) {
         ) : (
           <LeadNoShotComposition task={task} />
         )}
-        {/* Short fade at the bottom of the image so the seam
-            between screenshot and caption block reads as intentional
-            rather than as a hard cut. */}
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-14 bg-gradient-to-t from-ink via-ink/60 to-transparent" />
         <span className="pointer-events-none absolute top-3 right-3 flex size-8 items-center justify-center rounded-full bg-white/85 text-ink opacity-0 shadow-sm backdrop-blur-md transition-[opacity,transform] duration-200 group-hover:-translate-y-0.5 group-hover:opacity-100">
           <ArrowUpRight className="size-4" />
         </span>

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/LeadRunTile.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/LeadRunTile.tsx
@@ -55,8 +55,8 @@ export function LeadRunTile({ task, now, className }: LeadRunTileProps) {
         {/* Short fade at the bottom of the image so the seam
             between screenshot and caption block reads as intentional
             rather than as a hard cut. */}
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-14 bg-gradient-to-t from-ink-1 via-ink-1/60 to-transparent" />
-        <span className="pointer-events-none absolute top-3 right-3 flex size-8 items-center justify-center rounded-full bg-white/85 text-ink-1 opacity-0 shadow-sm backdrop-blur-md transition-[opacity,transform] duration-200 group-hover:-translate-y-0.5 group-hover:opacity-100">
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-14 bg-gradient-to-t from-ink via-ink/60 to-transparent" />
+        <span className="pointer-events-none absolute top-3 right-3 flex size-8 items-center justify-center rounded-full bg-white/85 text-ink opacity-0 shadow-sm backdrop-blur-md transition-[opacity,transform] duration-200 group-hover:-translate-y-0.5 group-hover:opacity-100">
           <ArrowUpRight className="size-4" />
         </span>
       </div>
@@ -77,7 +77,7 @@ function Caption({
   isFailed: boolean
 }) {
   return (
-    <div className="flex flex-col gap-1 bg-ink-1 px-5 py-3 text-white">
+    <div className="flex flex-col gap-1 bg-ink px-5 py-3 text-white">
       <div className="flex items-center gap-3 font-mono text-[10.5px] text-white/80 uppercase tracking-[0.08em]">
         <span className="inline-flex items-center gap-1.5">
           <AgentDot slug={task.slug} />
@@ -129,7 +129,7 @@ function Caption({
 function LeadNoShotComposition({ task }: { task: TaskSummary }) {
   const verbs = task.toolSequence.slice(0, 5)
   return (
-    <div className="absolute inset-0 bg-gradient-to-br from-ink-1 via-ink-2 to-ink-1">
+    <div className="absolute inset-0 bg-gradient-to-br from-ink via-ink-2 to-ink">
       <div className="pointer-events-none absolute inset-0 flex flex-col justify-center gap-1 p-8 font-mono text-[30px] text-white/12 leading-[1.05] tracking-tight md:text-[38px]">
         {verbs.map((verb, idx) => (
           <span

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/LeadRunTile.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/LeadRunTile.tsx
@@ -1,0 +1,149 @@
+import { ArrowUpRight } from 'lucide-react'
+import { NavLink } from 'react-router'
+import { AgentDot } from '@/components/audit/AgentDot'
+import { cn } from '@/lib/utils'
+import { type TaskSummary, taskScreenshotUrl } from '@/modules/api/audit.hooks'
+import {
+  abbreviateSequence,
+  formatDuration,
+  formatRelative,
+} from '@/screens/audit/audit.helpers'
+
+interface LeadRunTileProps {
+  task: TaskSummary
+  now: number
+  className?: string
+}
+
+/**
+ * The lead-story tile for the cockpit editorial layout. Screenshot
+ * dominates the composition; a soft ink scrim over the bottom half
+ * makes the caption legible. No card body under the image, no glass
+ * chip overlay. Whole tile is a link. Hover raises a tiny arrow in
+ * the top-right corner as the only affordance.
+ */
+export function LeadRunTile({ task, now, className }: LeadRunTileProps) {
+  const isLive = task.status === 'live'
+  const isFailed = task.status === 'failed'
+  const screenshotId = task.lastScreenshotDispatchId
+  return (
+    <NavLink
+      to={`/audit/${encodeURIComponent(task.sessionId)}`}
+      data-testid={`lead-tile-${task.sessionId}`}
+      className={cn(
+        'group relative flex flex-col overflow-hidden rounded-[20px] border border-border-2 transition-[border-color] duration-150 hover:border-accent/40',
+        // No fill, no shadow: this is a shell, not a card. The
+        // screenshot below carries all the visual weight.
+        'bg-bg-sunken',
+        className,
+      )}
+    >
+      {screenshotId !== null ? (
+        <img
+          src={taskScreenshotUrl(screenshotId)}
+          alt={`Session hero from ${task.agentLabel}`}
+          loading="lazy"
+          decoding="async"
+          className="absolute inset-0 h-full w-full object-cover"
+        />
+      ) : (
+        <LeadNoShotComposition task={task} />
+      )}
+
+      {/* Soft ink scrim over the bottom half so the caption reads
+          against the recorded page below. Kept CSS-only, no
+          backdrop-blur, no glass. */}
+      <div className="pointer-events-none absolute inset-x-0 bottom-0 h-[62%] bg-gradient-to-t from-ink-1/85 via-ink-1/50 to-transparent" />
+
+      {/* Hover cue: a small arrow slides into the top-right corner.
+          Uses translate + opacity, both on the composited layer, so
+          the underlying image is not re-rasterised. */}
+      <span className="pointer-events-none absolute top-4 right-4 flex size-8 items-center justify-center rounded-full bg-white/85 text-ink-1 opacity-0 shadow-sm backdrop-blur-md transition-[opacity,transform] duration-200 group-hover:-translate-y-0.5 group-hover:opacity-100">
+        <ArrowUpRight className="size-4" />
+      </span>
+
+      <Caption task={task} now={now} isLive={isLive} isFailed={isFailed} />
+    </NavLink>
+  )
+}
+
+function Caption({
+  task,
+  now,
+  isLive,
+  isFailed,
+}: {
+  task: TaskSummary
+  now: number
+  isLive: boolean
+  isFailed: boolean
+}) {
+  return (
+    <div className="relative mt-auto flex flex-col gap-1.5 p-6 pt-16 text-white">
+      <div className="flex items-center gap-3 font-mono text-[11.5px] text-white/85 uppercase tracking-[0.08em]">
+        <span className="inline-flex items-center gap-1.5">
+          <AgentDot slug={task.slug} />
+          <span className="text-white">{task.agentLabel}</span>
+        </span>
+        {isLive && (
+          <span className="inline-flex items-center gap-1.5 text-accent">
+            <span
+              aria-hidden
+              className="inline-block size-1.5 animate-[pulse-dot_1.4s_ease-in-out_infinite] rounded-full bg-accent shadow-[0_0_8px_hsl(19_89%_56%/0.7)]"
+            />
+            LIVE
+          </span>
+        )}
+        {isFailed && (
+          <span className="inline-flex items-center gap-1.5 text-red-400">
+            <span
+              aria-hidden
+              className="inline-block size-1.5 rounded-full bg-red-400"
+            />
+            FAILED
+          </span>
+        )}
+      </div>
+      <h2 className="text-balance font-semibold text-2xl leading-tight tracking-tight md:text-[26px]">
+        {task.title}
+      </h2>
+      <p className="font-mono text-[12.5px] text-white/75 tabular-nums">
+        {formatDuration(task.durationMs)}{' '}
+        <span className="text-white/50">·</span> {task.dispatchCount} tool
+        {task.dispatchCount === 1 ? '' : 's'}{' '}
+        <span className="text-white/50">·</span>{' '}
+        {isLive
+          ? 'running now'
+          : `started ${formatRelative(task.startedAt, now)}`}
+      </p>
+      <p className="truncate font-mono text-[12px] text-white/60">
+        {abbreviateSequence(task.toolSequence)}
+      </p>
+    </div>
+  )
+}
+
+/**
+ * When the lead session has no screenshot yet we make the ink
+ * gradient the whole background and let the tool sequence become
+ * the composition. This is intentional: the screen still has weight
+ * and drama, it just uses type as the material.
+ */
+function LeadNoShotComposition({ task }: { task: TaskSummary }) {
+  const verbs = task.toolSequence.slice(0, 6)
+  return (
+    <div className="absolute inset-0 bg-gradient-to-br from-ink-1 via-ink-2 to-ink-1">
+      <div className="pointer-events-none absolute inset-0 flex flex-col justify-center gap-1 p-10 font-mono text-[38px] text-white/10 leading-[1.1] tracking-tight md:text-[52px]">
+        {verbs.map((verb, idx) => (
+          <span
+            // biome-ignore lint/suspicious/noArrayIndexKey: tool sequence is stable-ordered per session, not a reorderable list
+            key={`${verb}-${idx}`}
+            style={{ marginLeft: `${(idx % 3) * 24}px` }}
+          >
+            {verb}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/LeadRunTile.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/LeadRunTile.tsx
@@ -1,5 +1,5 @@
 import { ArrowUpRight } from 'lucide-react'
-import { NavLink } from 'react-router'
+import { NavLink, useLocation } from 'react-router'
 import { AgentDot } from '@/components/audit/AgentDot'
 import { cn } from '@/lib/utils'
 import { type TaskSummary, taskScreenshotUrl } from '@/modules/api/audit.hooks'
@@ -31,9 +31,11 @@ export function LeadRunTile({ task, now, className }: LeadRunTileProps) {
   const isLive = task.status === 'live'
   const isFailed = task.status === 'failed'
   const screenshotId = task.lastScreenshotDispatchId
+  const location = useLocation()
   return (
     <NavLink
       to={`/audit/${encodeURIComponent(task.sessionId)}`}
+      state={{ from: location.pathname }}
       data-testid={`lead-tile-${task.sessionId}`}
       className={cn(
         'group relative flex flex-col overflow-hidden rounded-[18px] border border-border-2 bg-bg-sunken transition-[border-color] duration-150 hover:border-accent/40',

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.test.tsx
@@ -62,7 +62,7 @@ describe('RecentActivity', () => {
     expect(html).toContain('No recent activity')
   })
 
-  it('renders one TaskCard per task', () => {
+  it('renders the freshest task as the lead tile with title, agent, and meta', () => {
     queryOverride = {
       isPending: false,
       data: { pages: [{ tasks: [sampleTask] }] },
@@ -70,7 +70,9 @@ describe('RecentActivity', () => {
     const html = render()
     expect(html).toContain('Browsed example.com')
     expect(html).toContain('Claude Code')
-    expect(html).toContain('Done')
+    // DONE is the silent default in the editorial cockpit; the tile
+    // instead carries a mono meta line with the dispatch count.
+    expect(html).toContain('4 tools')
   })
 
   it('renders the section header + view-all CTA in the empty state', () => {

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.tsx
@@ -1,16 +1,31 @@
 import { ArrowRight, History } from 'lucide-react'
 import { NavLink } from 'react-router'
 import { Skeleton } from '@/components/ui/skeleton'
-import { useTasks } from '@/modules/api/audit.hooks'
+import { type TaskSummary, useTasks } from '@/modules/api/audit.hooks'
 import { EmptyState } from './EmptyState'
-import { TaskCard } from './TaskCard'
+import { LeadRunTile } from './LeadRunTile'
+import { RunRow } from './RunRow'
+import { SupportingTile } from './SupportingTile'
 
-const HOME_TASK_LIMIT = 5
+const HOME_TASK_LIMIT = 10
 
 /**
- * Homepage Recent activity strip. Renders one TaskCard per recent
- * MCP session (newest first). Skeleton while loading; the empty
- * state appears only when the loaded page is empty.
+ * Cockpit editorial layout: lead-story tile + asymmetric supporting
+ * bento + typographic tail. LIVE runs always take the lead slot
+ * regardless of start time; everything else stacks newest-first.
+ *
+ * Grid shape (desktop, `lg` and up):
+ *
+ *   ┌────────────────────────┬────────┬────────┐
+ *   │                        │  s1    │  s2    │
+ *   │         lead           ├────────┴────────┤
+ *   │                        │      s3         │
+ *   │                        ├─────────────────┤
+ *   │                        │      s4         │
+ *   └────────────────────────┴─────────────────┘
+ *
+ * At `md`: lead full-width above a 2-column supporting strip.
+ * At mobile: everything single-column.
  */
 export function RecentActivity() {
   const query = useTasks({ variables: { limit: HOME_TASK_LIMIT } })
@@ -18,39 +33,140 @@ export function RecentActivity() {
     .flatMap((p) => p.tasks)
     .slice(0, HOME_TASK_LIMIT)
   const now = Date.now()
+  const ordered = orderByLiveThenRecency(tasks)
+  const lead = ordered[0]
+  const supporting = ordered.slice(1, 5)
+  const tail = ordered.slice(5)
 
   return (
-    <section className="space-y-3">
-      <div className="flex items-center gap-2.5">
-        <h2 className="font-bold text-base">Recent activity</h2>
-        <div className="flex-1" />
-        <NavLink
-          to="/audit"
-          className="group inline-flex items-center gap-1 rounded-md px-2 py-1 font-medium text-[12.5px] text-ink-3 transition hover:bg-card-tint hover:text-ink-1"
-        >
-          View all activity
-          <ArrowRight className="size-3.5 transition group-hover:translate-x-0.5" />
-        </NavLink>
-      </div>
+    <section className="space-y-4">
+      <SectionHeader />
       {query.isPending ? (
-        <div className="space-y-3">
-          {['s1', 's2', 's3'].map((id) => (
-            <Skeleton key={id} className="h-28 w-full rounded-2xl" />
-          ))}
-        </div>
-      ) : tasks.length === 0 ? (
+        <BentoSkeleton />
+      ) : !lead ? (
         <EmptyState
           title="No recent activity"
           hint="Tool calls from connected agents will appear here."
           icon={<History className="size-5" />}
         />
       ) : (
-        <div className="space-y-3">
-          {tasks.map((task) => (
-            <TaskCard key={task.sessionId} task={task} now={now} />
-          ))}
-        </div>
+        <>
+          <BentoGrid lead={lead} supporting={supporting} now={now} />
+          {tail.length > 0 && <Tail tail={tail} now={now} />}
+        </>
       )}
+      <div className="pt-1">
+        <NavLink
+          to="/audit"
+          className="group inline-flex items-center gap-1.5 font-mono text-[12px] text-ink-3 uppercase tracking-[0.08em] transition-colors hover:text-ink-1"
+        >
+          View all activity
+          <ArrowRight className="size-3.5 transition-transform group-hover:translate-x-0.5" />
+        </NavLink>
+      </div>
     </section>
   )
+}
+
+function SectionHeader() {
+  return (
+    <header className="flex flex-wrap items-baseline justify-between gap-3">
+      <h2 className="font-semibold text-ink-1 text-lg">Recent activity</h2>
+      <div className="flex items-center gap-3 font-mono text-[11.5px] text-ink-3 uppercase tracking-[0.08em]">
+        <FilterChip>Recent 24h</FilterChip>
+        <FilterChip>All agents</FilterChip>
+        <FilterChip>All sites</FilterChip>
+      </div>
+    </header>
+  )
+}
+
+function FilterChip({ children }: { children: React.ReactNode }) {
+  // Static text-only chip for now. Dropdown wiring is a separate
+  // phase; this reserves the visual slot without pretending to
+  // be interactive.
+  return (
+    <span className="cursor-default rounded-md border border-transparent px-2 py-0.5 transition-colors hover:border-border-2 hover:bg-card-tint">
+      {children}
+    </span>
+  )
+}
+
+interface BentoGridProps {
+  lead: TaskSummary
+  supporting: TaskSummary[]
+  now: number
+}
+
+function BentoGrid({ lead, supporting, now }: BentoGridProps) {
+  return (
+    <div className="grid grid-cols-1 gap-3 md:grid-cols-12 md:grid-rows-2">
+      <LeadRunTile
+        task={lead}
+        now={now}
+        className="md:col-span-7 md:row-span-2 md:min-h-[420px]"
+      />
+      {supporting.map((task, idx) => (
+        <SupportingTile
+          key={task.sessionId}
+          task={task}
+          now={now}
+          className={supportingSlotClass(idx)}
+        />
+      ))}
+    </div>
+  )
+}
+
+function supportingSlotClass(idx: number): string {
+  // Four supporting slots arranged asymmetrically inside the right
+  // 5 columns of the bento (see the diagram in the RecentActivity
+  // docstring). Slots 0 and 1 sit on top side-by-side, slot 2
+  // spans both columns beneath them, slot 3 is a safety net that
+  // hides on desktop (drops into the tail instead).
+  switch (idx) {
+    case 0:
+      return 'md:col-span-3 md:col-start-8 md:row-start-1'
+    case 1:
+      return 'md:col-span-2 md:col-start-11 md:row-start-1'
+    case 2:
+      return 'md:col-span-5 md:col-start-8 md:row-start-2'
+    case 3:
+      return 'md:hidden'
+    default:
+      return 'md:hidden'
+  }
+}
+
+function Tail({ tail, now }: { tail: TaskSummary[]; now: number }) {
+  return (
+    <div className="pt-2">
+      {tail.map((task) => (
+        <RunRow key={task.sessionId} task={task} now={now} />
+      ))}
+    </div>
+  )
+}
+
+function BentoSkeleton() {
+  return (
+    <div className="grid grid-cols-1 gap-3 md:grid-cols-12 md:grid-rows-2">
+      <Skeleton className="rounded-[20px] md:col-span-7 md:row-span-2 md:min-h-[420px]" />
+      <Skeleton className="min-h-[180px] rounded-2xl md:col-span-3 md:col-start-8 md:row-start-1" />
+      <Skeleton className="min-h-[180px] rounded-2xl md:col-span-2 md:col-start-11 md:row-start-1" />
+      <Skeleton className="min-h-[200px] rounded-2xl md:col-span-5 md:col-start-8 md:row-start-2" />
+    </div>
+  )
+}
+
+/**
+ * LIVE runs always float to the top. Within each status group we
+ * sort by `startedAt` descending. Exported for unit tests.
+ */
+export function orderByLiveThenRecency(tasks: TaskSummary[]): TaskSummary[] {
+  return [...tasks].sort((a, b) => {
+    if (a.status === 'live' && b.status !== 'live') return -1
+    if (b.status === 'live' && a.status !== 'live') return 1
+    return b.startedAt - a.startedAt
+  })
 }

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.tsx
@@ -84,7 +84,7 @@ interface BentoGridProps {
 
 function BentoGrid({ lead, supporting, now }: BentoGridProps) {
   return (
-    <div className="grid grid-cols-1 gap-3 md:auto-rows-[200px] md:grid-cols-12 md:grid-rows-2">
+    <div className="grid grid-cols-1 gap-3 md:grid-cols-12 md:grid-rows-[200px_200px]">
       <LeadRunTile
         task={lead}
         now={now}
@@ -132,7 +132,7 @@ function Tail({ tail, now }: { tail: TaskSummary[]; now: number }) {
 
 function BentoSkeleton() {
   return (
-    <div className="grid grid-cols-1 gap-3 md:auto-rows-[200px] md:grid-cols-12 md:grid-rows-2">
+    <div className="grid grid-cols-1 gap-3 md:grid-cols-12 md:grid-rows-[200px_200px]">
       <Skeleton className="rounded-[18px] md:col-span-6 md:row-span-2" />
       <Skeleton className="rounded-2xl md:col-span-3 md:col-start-7 md:row-start-1" />
       <Skeleton className="rounded-2xl md:col-span-3 md:col-start-10 md:row-start-1" />

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.tsx
@@ -7,24 +7,24 @@ import { LeadRunTile } from './LeadRunTile'
 import { RunRow } from './RunRow'
 import { SupportingTile } from './SupportingTile'
 
-const HOME_TASK_LIMIT = 10
+const HOME_TASK_LIMIT = 12
 
 /**
- * Cockpit editorial layout: lead-story tile + asymmetric supporting
- * bento + typographic tail. LIVE runs always take the lead slot
+ * Cockpit editorial layout: lead-story tile + a 2x2 supporting
+ * grid + typographic tail. LIVE runs always take the lead slot
  * regardless of start time; everything else stacks newest-first.
  *
- * Grid shape (desktop, `lg` and up):
+ * Grid shape (md and up):
  *
  *   ┌────────────────────────┬────────┬────────┐
  *   │                        │  s1    │  s2    │
- *   │         lead           ├────────┴────────┤
- *   │                        │      s3         │
- *   │                        ├─────────────────┤
- *   │                        │      s4         │
- *   └────────────────────────┴─────────────────┘
+ *   │         lead           ├────────┼────────┤
+ *   │                        │  s3    │  s4    │
+ *   └────────────────────────┴────────┴────────┘
  *
- * At `md`: lead full-width above a 2-column supporting strip.
+ * Rows are locked to `auto-rows-[150px]` so every supporting cell
+ * is the same size regardless of internal content. The lead spans
+ * both rows so it doubles that height (~300px) without ballooning.
  * At mobile: everything single-column.
  */
 export function RecentActivity() {
@@ -70,25 +70,9 @@ export function RecentActivity() {
 
 function SectionHeader() {
   return (
-    <header className="flex flex-wrap items-baseline justify-between gap-3">
+    <header className="flex items-baseline gap-3">
       <h2 className="font-semibold text-ink-1 text-lg">Recent activity</h2>
-      <div className="flex items-center gap-3 font-mono text-[11.5px] text-ink-3 uppercase tracking-[0.08em]">
-        <FilterChip>Recent 24h</FilterChip>
-        <FilterChip>All agents</FilterChip>
-        <FilterChip>All sites</FilterChip>
-      </div>
     </header>
-  )
-}
-
-function FilterChip({ children }: { children: React.ReactNode }) {
-  // Static text-only chip for now. Dropdown wiring is a separate
-  // phase; this reserves the visual slot without pretending to
-  // be interactive.
-  return (
-    <span className="cursor-default rounded-md border border-transparent px-2 py-0.5 transition-colors hover:border-border-2 hover:bg-card-tint">
-      {children}
-    </span>
   )
 }
 
@@ -100,11 +84,11 @@ interface BentoGridProps {
 
 function BentoGrid({ lead, supporting, now }: BentoGridProps) {
   return (
-    <div className="grid grid-cols-1 gap-3 md:grid-cols-12 md:grid-rows-2">
+    <div className="grid grid-cols-1 gap-3 md:auto-rows-[150px] md:grid-cols-12 md:grid-rows-2">
       <LeadRunTile
         task={lead}
         now={now}
-        className="md:col-span-7 md:row-span-2 md:min-h-[420px]"
+        className="md:col-span-6 md:row-span-2"
       />
       {supporting.map((task, idx) => (
         <SupportingTile
@@ -119,20 +103,18 @@ function BentoGrid({ lead, supporting, now }: BentoGridProps) {
 }
 
 function supportingSlotClass(idx: number): string {
-  // Four supporting slots arranged asymmetrically inside the right
-  // 5 columns of the bento (see the diagram in the RecentActivity
-  // docstring). Slots 0 and 1 sit on top side-by-side, slot 2
-  // spans both columns beneath them, slot 3 is a safety net that
-  // hides on desktop (drops into the tail instead).
+  // Uniform 2x2 grid of supporting cells (3 cols wide, 1 row tall
+  // each) to the right of the lead. Every tile has the same
+  // footprint so the visual weight of the row is even.
   switch (idx) {
     case 0:
-      return 'md:col-span-3 md:col-start-8 md:row-start-1'
+      return 'md:col-span-3 md:col-start-7 md:row-start-1'
     case 1:
-      return 'md:col-span-2 md:col-start-11 md:row-start-1'
+      return 'md:col-span-3 md:col-start-10 md:row-start-1'
     case 2:
-      return 'md:col-span-5 md:col-start-8 md:row-start-2'
+      return 'md:col-span-3 md:col-start-7 md:row-start-2'
     case 3:
-      return 'md:hidden'
+      return 'md:col-span-3 md:col-start-10 md:row-start-2'
     default:
       return 'md:hidden'
   }
@@ -150,11 +132,12 @@ function Tail({ tail, now }: { tail: TaskSummary[]; now: number }) {
 
 function BentoSkeleton() {
   return (
-    <div className="grid grid-cols-1 gap-3 md:grid-cols-12 md:grid-rows-2">
-      <Skeleton className="rounded-[20px] md:col-span-7 md:row-span-2 md:min-h-[420px]" />
-      <Skeleton className="min-h-[180px] rounded-2xl md:col-span-3 md:col-start-8 md:row-start-1" />
-      <Skeleton className="min-h-[180px] rounded-2xl md:col-span-2 md:col-start-11 md:row-start-1" />
-      <Skeleton className="min-h-[200px] rounded-2xl md:col-span-5 md:col-start-8 md:row-start-2" />
+    <div className="grid grid-cols-1 gap-3 md:auto-rows-[150px] md:grid-cols-12 md:grid-rows-2">
+      <Skeleton className="rounded-[18px] md:col-span-6 md:row-span-2" />
+      <Skeleton className="rounded-2xl md:col-span-3 md:col-start-7 md:row-start-1" />
+      <Skeleton className="rounded-2xl md:col-span-3 md:col-start-10 md:row-start-1" />
+      <Skeleton className="rounded-2xl md:col-span-3 md:col-start-7 md:row-start-2" />
+      <Skeleton className="rounded-2xl md:col-span-3 md:col-start-10 md:row-start-2" />
     </div>
   )
 }

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RecentActivity.tsx
@@ -58,7 +58,7 @@ export function RecentActivity() {
       <div className="pt-1">
         <NavLink
           to="/audit"
-          className="group inline-flex items-center gap-1.5 font-mono text-[12px] text-ink-3 uppercase tracking-[0.08em] transition-colors hover:text-ink-1"
+          className="group inline-flex items-center gap-1.5 font-mono text-[12px] text-ink-3 uppercase tracking-[0.08em] transition-colors hover:text-ink"
         >
           View all activity
           <ArrowRight className="size-3.5 transition-transform group-hover:translate-x-0.5" />
@@ -71,7 +71,7 @@ export function RecentActivity() {
 function SectionHeader() {
   return (
     <header className="flex items-baseline gap-3">
-      <h2 className="font-semibold text-ink-1 text-lg">Recent activity</h2>
+      <h2 className="font-semibold text-ink text-lg">Recent activity</h2>
     </header>
   )
 }
@@ -84,7 +84,7 @@ interface BentoGridProps {
 
 function BentoGrid({ lead, supporting, now }: BentoGridProps) {
   return (
-    <div className="grid grid-cols-1 gap-3 md:auto-rows-[150px] md:grid-cols-12 md:grid-rows-2">
+    <div className="grid grid-cols-1 gap-3 md:auto-rows-[200px] md:grid-cols-12 md:grid-rows-2">
       <LeadRunTile
         task={lead}
         now={now}
@@ -132,7 +132,7 @@ function Tail({ tail, now }: { tail: TaskSummary[]; now: number }) {
 
 function BentoSkeleton() {
   return (
-    <div className="grid grid-cols-1 gap-3 md:auto-rows-[150px] md:grid-cols-12 md:grid-rows-2">
+    <div className="grid grid-cols-1 gap-3 md:auto-rows-[200px] md:grid-cols-12 md:grid-rows-2">
       <Skeleton className="rounded-[18px] md:col-span-6 md:row-span-2" />
       <Skeleton className="rounded-2xl md:col-span-3 md:col-start-7 md:row-start-1" />
       <Skeleton className="rounded-2xl md:col-span-3 md:col-start-10 md:row-start-1" />

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RunRow.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RunRow.tsx
@@ -1,0 +1,56 @@
+import { NavLink } from 'react-router'
+import { AgentDot } from '@/components/audit/AgentDot'
+import type { TaskSummary } from '@/modules/api/audit.hooks'
+import {
+  abbreviateSequence,
+  formatDuration,
+  formatRelative,
+} from '@/screens/audit/audit.helpers'
+
+interface RunRowProps {
+  task: TaskSummary
+  now: number
+}
+
+/**
+ * Typographic-tail row for older sessions. Hairline-separated,
+ * no card frame, no screenshot. Reads like the "next up" strip on
+ * a magazine cover. Row layout mirrors the audit list to give the
+ * operator a familiar scan pattern.
+ */
+export function RunRow({ task, now }: RunRowProps) {
+  const isLive = task.status === 'live'
+  return (
+    <NavLink
+      to={`/audit/${encodeURIComponent(task.sessionId)}`}
+      data-testid={`run-row-${task.sessionId}`}
+      className="group grid grid-cols-[max-content_1fr_max-content_max-content_max-content] items-center gap-4 border-border-2 border-t px-2 py-3 transition-colors duration-150 hover:bg-card-tint"
+    >
+      <span className="inline-flex items-center gap-2 font-mono text-[11.5px] text-ink-3 uppercase tracking-[0.06em]">
+        <AgentDot slug={task.slug} />
+        <span className="text-ink-2">{task.agentLabel}</span>
+        {isLive && (
+          <span className="inline-flex items-center gap-1 text-accent">
+            <span
+              aria-hidden
+              className="inline-block size-1.5 animate-[pulse-dot_1.4s_ease-in-out_infinite] rounded-full bg-accent"
+            />
+            LIVE
+          </span>
+        )}
+      </span>
+      <span className="min-w-0 truncate text-[13px] text-ink-1">
+        {task.title}
+      </span>
+      <span className="hidden truncate font-mono text-[11.5px] text-ink-3 md:inline-block md:max-w-[240px]">
+        {abbreviateSequence(task.toolSequence)}
+      </span>
+      <span className="text-right font-mono text-[11.5px] text-ink-2 tabular-nums">
+        {formatDuration(task.durationMs)}
+      </span>
+      <span className="text-right font-mono text-[11.5px] text-ink-3 tabular-nums">
+        {formatRelative(task.startedAt, now)}
+      </span>
+    </NavLink>
+  )
+}

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RunRow.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RunRow.tsx
@@ -1,4 +1,4 @@
-import { NavLink } from 'react-router'
+import { NavLink, useLocation } from 'react-router'
 import { AgentDot } from '@/components/audit/AgentDot'
 import type { TaskSummary } from '@/modules/api/audit.hooks'
 import {
@@ -20,9 +20,11 @@ interface RunRowProps {
  */
 export function RunRow({ task, now }: RunRowProps) {
   const isLive = task.status === 'live'
+  const location = useLocation()
   return (
     <NavLink
       to={`/audit/${encodeURIComponent(task.sessionId)}`}
+      state={{ from: location.pathname }}
       data-testid={`run-row-${task.sessionId}`}
       className="group grid grid-cols-[max-content_1fr_max-content_max-content_max-content] items-center gap-4 border-border-2 border-t px-2 py-3 transition-colors duration-150 hover:bg-card-tint"
     >

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.tsx
@@ -45,7 +45,7 @@ export function RunningGrid({ agents }: RunningGridProps) {
   return (
     <section className="space-y-4">
       <header className="flex items-baseline gap-3">
-        <h2 className="font-semibold text-ink-1 text-lg">Running now</h2>
+        <h2 className="font-semibold text-ink text-lg">Running now</h2>
         <span className="inline-flex items-center gap-1.5 font-mono text-[11px] text-accent uppercase tracking-[0.08em]">
           <span
             aria-hidden

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/RunningGrid.tsx
@@ -20,8 +20,6 @@ export function RunningGrid({ agents }: RunningGridProps) {
       { agentId: agent.agentId, focusUrl: agent.currentFocus.url },
       {
         onError: (err) => {
-          // No toast surface in v2 yet; surface a console line so the
-          // operator can read it from devtools while developing.
           // eslint-disable-next-line no-console
           console.warn('focus agent failed', { agentId: agent.agentId, err })
         },
@@ -45,18 +43,18 @@ export function RunningGrid({ agents }: RunningGridProps) {
     cancel.isPending && cancel.variables ? cancel.variables.agentId : null
 
   return (
-    <section className="space-y-3">
-      <div className="flex items-center gap-2.5">
-        <h2 className="font-bold text-base">Running now</h2>
-        <span className="inline-flex items-center gap-1.5 rounded-full bg-green-tint px-2 py-0.5 font-bold text-[11px] text-green">
+    <section className="space-y-4">
+      <header className="flex items-baseline gap-3">
+        <h2 className="font-semibold text-ink-1 text-lg">Running now</h2>
+        <span className="inline-flex items-center gap-1.5 font-mono text-[11px] text-accent uppercase tracking-[0.08em]">
           <span
             aria-hidden
-            className="size-1.5 animate-pulse-dot rounded-full bg-green"
+            className="inline-block size-1.5 animate-[pulse-dot_1.4s_ease-in-out_infinite] rounded-full bg-accent shadow-[0_0_8px_hsl(19_89%_56%/0.7)]"
           />
           {liveCount} live
         </span>
-      </div>
-      <div className="grid grid-cols-[repeat(auto-fill,minmax(258px,1fr))] items-start gap-3.5">
+      </header>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {agents.map((a) => (
           <AgentRunningCard
             key={a.agentId}

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/SupportingTile.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/SupportingTile.tsx
@@ -1,5 +1,5 @@
 import { ArrowUpRight } from 'lucide-react'
-import { NavLink } from 'react-router'
+import { NavLink, useLocation } from 'react-router'
 import { AgentDot } from '@/components/audit/AgentDot'
 import { cn } from '@/lib/utils'
 import { type TaskSummary, taskScreenshotUrl } from '@/modules/api/audit.hooks'
@@ -23,9 +23,11 @@ interface SupportingTileProps {
 export function SupportingTile({ task, now, className }: SupportingTileProps) {
   const isLive = task.status === 'live'
   const screenshotId = task.lastScreenshotDispatchId
+  const location = useLocation()
   return (
     <NavLink
       to={`/audit/${encodeURIComponent(task.sessionId)}`}
+      state={{ from: location.pathname }}
       data-testid={`support-tile-${task.sessionId}`}
       className={cn(
         'group relative flex flex-col overflow-hidden rounded-2xl border border-border-2 bg-bg-sunken transition-[border-color] duration-150 hover:border-accent/40',

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/SupportingTile.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/SupportingTile.tsx
@@ -44,8 +44,8 @@ export function SupportingTile({ task, now, className }: SupportingTileProps) {
         ) : (
           <NoShotComposition task={task} />
         )}
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-ink-1 via-ink-1/60 to-transparent" />
-        <span className="pointer-events-none absolute top-2.5 right-2.5 flex size-6 items-center justify-center rounded-full bg-white/85 text-ink-1 opacity-0 shadow-sm backdrop-blur-md transition-[opacity,transform] duration-200 group-hover:-translate-y-0.5 group-hover:opacity-100">
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-ink via-ink/60 to-transparent" />
+        <span className="pointer-events-none absolute top-2.5 right-2.5 flex size-6 items-center justify-center rounded-full bg-white/85 text-ink opacity-0 shadow-sm backdrop-blur-md transition-[opacity,transform] duration-200 group-hover:-translate-y-0.5 group-hover:opacity-100">
           <ArrowUpRight className="size-3.5" />
         </span>
       </div>
@@ -64,7 +64,7 @@ function Caption({
   isLive: boolean
 }) {
   return (
-    <div className="flex flex-col gap-0.5 bg-ink-1 px-3.5 py-2 text-white">
+    <div className="flex flex-col gap-0.5 bg-ink px-3.5 py-2 text-white">
       <div className="flex items-center gap-2 font-mono text-[9.5px] text-white/75 uppercase tracking-[0.08em]">
         <AgentDot slug={task.slug} />
         <span className="truncate text-white/95">{task.agentLabel}</span>
@@ -98,7 +98,7 @@ function NoShotComposition({ task }: { task: TaskSummary }) {
   // two-color card.
   const verbs = task.toolSequence.slice(0, 4)
   return (
-    <div className="absolute inset-0 bg-gradient-to-br from-ink-1 via-ink-2 to-ink-1">
+    <div className="absolute inset-0 bg-gradient-to-br from-ink via-ink-2 to-ink">
       <div className="pointer-events-none absolute inset-0 flex flex-col justify-center gap-0.5 pl-4 font-mono text-[14px] text-white/18 leading-tight tracking-tight">
         {verbs.map((verb, idx) => (
           <span

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/SupportingTile.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/SupportingTile.tsx
@@ -1,0 +1,128 @@
+import { ArrowUpRight } from 'lucide-react'
+import { NavLink } from 'react-router'
+import { AgentDot } from '@/components/audit/AgentDot'
+import { cn } from '@/lib/utils'
+import { type TaskSummary, taskScreenshotUrl } from '@/modules/api/audit.hooks'
+import {
+  abbreviateSequence,
+  formatDuration,
+  formatRelative,
+} from '@/screens/audit/audit.helpers'
+
+interface SupportingTileProps {
+  task: TaskSummary
+  now: number
+  className?: string
+}
+
+/**
+ * Supporting tile in the cockpit editorial bento. Two variants
+ * driven by data: with-screenshot (top half is the image, bottom
+ * half is a hairline-separated meta block) and without-screenshot
+ * (the tool sequence is rendered as a vertical typographic list,
+ * turning the absence of an image into a composition opportunity).
+ * No filled card body, no shadows, hairline border only. Whole
+ * tile is a link.
+ */
+export function SupportingTile({ task, now, className }: SupportingTileProps) {
+  const isLive = task.status === 'live'
+  const hasShot = task.lastScreenshotDispatchId !== null
+  return (
+    <NavLink
+      to={`/audit/${encodeURIComponent(task.sessionId)}`}
+      data-testid={`support-tile-${task.sessionId}`}
+      className={cn(
+        'group relative flex flex-col overflow-hidden rounded-2xl border border-border-2 bg-card transition-[border-color] duration-150 hover:border-accent/40',
+        className,
+      )}
+    >
+      {hasShot ? (
+        <WithScreenshot task={task} />
+      ) : (
+        <WithoutScreenshot task={task} />
+      )}
+      <MetaBlock task={task} now={now} isLive={isLive} />
+      <span className="pointer-events-none absolute top-3 right-3 flex size-6 items-center justify-center rounded-full bg-white/85 text-ink-1 opacity-0 shadow-sm backdrop-blur-md transition-[opacity,transform] duration-200 group-hover:-translate-y-0.5 group-hover:opacity-100">
+        <ArrowUpRight className="size-3.5" />
+      </span>
+    </NavLink>
+  )
+}
+
+function WithScreenshot({ task }: { task: TaskSummary }) {
+  const screenshotId = task.lastScreenshotDispatchId
+  if (screenshotId === null) return null
+  return (
+    <div className="relative aspect-[16/10] w-full overflow-hidden bg-bg-sunken">
+      <img
+        src={taskScreenshotUrl(screenshotId)}
+        alt={`Session preview from ${task.agentLabel}`}
+        loading="lazy"
+        decoding="async"
+        className="absolute inset-0 h-full w-full object-cover"
+      />
+    </div>
+  )
+}
+
+function WithoutScreenshot({ task }: { task: TaskSummary }) {
+  // Tool sequence as a vertical typographic list. Sits on a warm
+  // tinted surface so it visually differs from the screenshot-
+  // bearing tiles without being a placeholder.
+  const verbs = task.toolSequence.slice(0, 5)
+  return (
+    <div className="relative aspect-[16/10] w-full overflow-hidden bg-bg-sunken">
+      <div className="pointer-events-none absolute inset-0 flex flex-col justify-center gap-0.5 pl-5 font-mono text-[18px] text-ink-3/80 leading-tight tracking-tight">
+        {verbs.map((verb, idx) => (
+          <span
+            // biome-ignore lint/suspicious/noArrayIndexKey: tool sequence is stable-ordered per session, not a reorderable list
+            key={`${verb}-${idx}`}
+            style={{ marginLeft: `${idx * 8}px` }}
+            className="truncate"
+          >
+            {verb}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function MetaBlock({
+  task,
+  now,
+  isLive,
+}: {
+  task: TaskSummary
+  now: number
+  isLive: boolean
+}) {
+  return (
+    <div className="flex flex-col gap-1 border-border-2 border-t px-4 py-3">
+      <div className="flex items-center gap-2 font-mono text-[10.5px] text-ink-3 uppercase tracking-[0.08em]">
+        <AgentDot slug={task.slug} />
+        <span className="text-ink-2">{task.agentLabel}</span>
+        {isLive && (
+          <span className="inline-flex items-center gap-1 text-accent">
+            <span
+              aria-hidden
+              className="inline-block size-1.5 animate-[pulse-dot_1.4s_ease-in-out_infinite] rounded-full bg-accent"
+            />
+            LIVE
+          </span>
+        )}
+      </div>
+      <h3 className="truncate font-semibold text-[13.5px] text-ink-1">
+        {task.title}
+      </h3>
+      <p className="font-mono text-[11px] text-ink-3 tabular-nums">
+        {formatDuration(task.durationMs)} <span className="text-ink-4">·</span>{' '}
+        {task.dispatchCount}t <span className="text-ink-4">·</span>{' '}
+        {formatRelative(task.startedAt, now)}
+      </p>
+      <p className="truncate font-mono text-[10.5px] text-ink-3">
+        {abbreviateSequence(task.toolSequence)}
+      </p>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/SupportingTile.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/SupportingTile.tsx
@@ -3,11 +3,7 @@ import { NavLink } from 'react-router'
 import { AgentDot } from '@/components/audit/AgentDot'
 import { cn } from '@/lib/utils'
 import { type TaskSummary, taskScreenshotUrl } from '@/modules/api/audit.hooks'
-import {
-  abbreviateSequence,
-  formatDuration,
-  formatRelative,
-} from '@/screens/audit/audit.helpers'
+import { formatDuration, formatRelative } from '@/screens/audit/audit.helpers'
 
 interface SupportingTileProps {
   task: TaskSummary
@@ -16,79 +12,49 @@ interface SupportingTileProps {
 }
 
 /**
- * Supporting tile in the cockpit editorial bento. Two variants
- * driven by data: with-screenshot (top half is the image, bottom
- * half is a hairline-separated meta block) and without-screenshot
- * (the tool sequence is rendered as a vertical typographic list,
- * turning the absence of an image into a composition opportunity).
- * No filled card body, no shadows, hairline border only. Whole
- * tile is a link.
+ * Supporting tile in the cockpit editorial bento. Mirrors the
+ * lead's split-zone structure (visual on top, dark caption block
+ * at the bottom) at a smaller scale so all four supporting cells
+ * share the lead's visual language. Two variants driven by data:
+ * with-screenshot fills the top zone with the captured image;
+ * without-screenshot renders the tool sequence as a small
+ * typographic composition in place of the image.
  */
 export function SupportingTile({ task, now, className }: SupportingTileProps) {
   const isLive = task.status === 'live'
-  const hasShot = task.lastScreenshotDispatchId !== null
+  const screenshotId = task.lastScreenshotDispatchId
   return (
     <NavLink
       to={`/audit/${encodeURIComponent(task.sessionId)}`}
       data-testid={`support-tile-${task.sessionId}`}
       className={cn(
-        'group relative flex flex-col overflow-hidden rounded-2xl border border-border-2 bg-card transition-[border-color] duration-150 hover:border-accent/40',
+        'group relative flex flex-col overflow-hidden rounded-2xl border border-border-2 bg-bg-sunken transition-[border-color] duration-150 hover:border-accent/40',
         className,
       )}
     >
-      {hasShot ? (
-        <WithScreenshot task={task} />
-      ) : (
-        <WithoutScreenshot task={task} />
-      )}
-      <MetaBlock task={task} now={now} isLive={isLive} />
-      <span className="pointer-events-none absolute top-3 right-3 flex size-6 items-center justify-center rounded-full bg-white/85 text-ink-1 opacity-0 shadow-sm backdrop-blur-md transition-[opacity,transform] duration-200 group-hover:-translate-y-0.5 group-hover:opacity-100">
-        <ArrowUpRight className="size-3.5" />
-      </span>
+      <div className="relative flex-1 overflow-hidden">
+        {screenshotId !== null ? (
+          <img
+            src={taskScreenshotUrl(screenshotId)}
+            alt={`Session preview from ${task.agentLabel}`}
+            loading="lazy"
+            decoding="async"
+            className="absolute inset-0 h-full w-full object-cover object-top"
+          />
+        ) : (
+          <NoShotComposition task={task} />
+        )}
+        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-ink-1 via-ink-1/60 to-transparent" />
+        <span className="pointer-events-none absolute top-2.5 right-2.5 flex size-6 items-center justify-center rounded-full bg-white/85 text-ink-1 opacity-0 shadow-sm backdrop-blur-md transition-[opacity,transform] duration-200 group-hover:-translate-y-0.5 group-hover:opacity-100">
+          <ArrowUpRight className="size-3.5" />
+        </span>
+      </div>
+      <Caption task={task} now={now} isLive={isLive} />
     </NavLink>
   )
 }
 
-function WithScreenshot({ task }: { task: TaskSummary }) {
-  const screenshotId = task.lastScreenshotDispatchId
-  if (screenshotId === null) return null
-  return (
-    <div className="relative aspect-[16/10] w-full overflow-hidden bg-bg-sunken">
-      <img
-        src={taskScreenshotUrl(screenshotId)}
-        alt={`Session preview from ${task.agentLabel}`}
-        loading="lazy"
-        decoding="async"
-        className="absolute inset-0 h-full w-full object-cover"
-      />
-    </div>
-  )
-}
-
-function WithoutScreenshot({ task }: { task: TaskSummary }) {
-  // Tool sequence as a vertical typographic list. Sits on a warm
-  // tinted surface so it visually differs from the screenshot-
-  // bearing tiles without being a placeholder.
-  const verbs = task.toolSequence.slice(0, 5)
-  return (
-    <div className="relative aspect-[16/10] w-full overflow-hidden bg-bg-sunken">
-      <div className="pointer-events-none absolute inset-0 flex flex-col justify-center gap-0.5 pl-5 font-mono text-[18px] text-ink-3/80 leading-tight tracking-tight">
-        {verbs.map((verb, idx) => (
-          <span
-            // biome-ignore lint/suspicious/noArrayIndexKey: tool sequence is stable-ordered per session, not a reorderable list
-            key={`${verb}-${idx}`}
-            style={{ marginLeft: `${idx * 8}px` }}
-            className="truncate"
-          >
-            {verb}
-          </span>
-        ))}
-      </div>
-    </div>
-  )
-}
-
-function MetaBlock({
+function Caption({
   task,
   now,
   isLive,
@@ -98,10 +64,10 @@ function MetaBlock({
   isLive: boolean
 }) {
   return (
-    <div className="flex flex-col gap-1 border-border-2 border-t px-4 py-3">
-      <div className="flex items-center gap-2 font-mono text-[10.5px] text-ink-3 uppercase tracking-[0.08em]">
+    <div className="flex flex-col gap-0.5 bg-ink-1 px-3.5 py-2 text-white">
+      <div className="flex items-center gap-2 font-mono text-[9.5px] text-white/75 uppercase tracking-[0.08em]">
         <AgentDot slug={task.slug} />
-        <span className="text-ink-2">{task.agentLabel}</span>
+        <span className="truncate text-white/95">{task.agentLabel}</span>
         {isLive && (
           <span className="inline-flex items-center gap-1 text-accent">
             <span
@@ -112,17 +78,39 @@ function MetaBlock({
           </span>
         )}
       </div>
-      <h3 className="truncate font-semibold text-[13.5px] text-ink-1">
+      <h3 className="truncate font-semibold text-[12.5px] text-white leading-tight">
         {task.title}
       </h3>
-      <p className="font-mono text-[11px] text-ink-3 tabular-nums">
-        {formatDuration(task.durationMs)} <span className="text-ink-4">·</span>{' '}
-        {task.dispatchCount}t <span className="text-ink-4">·</span>{' '}
+      <p className="font-mono text-[10.5px] text-white/65 tabular-nums">
+        {formatDuration(task.durationMs)}{' '}
+        <span className="text-white/35">·</span> {task.dispatchCount}t{' '}
+        <span className="text-white/35">·</span>{' '}
         {formatRelative(task.startedAt, now)}
       </p>
-      <p className="truncate font-mono text-[10.5px] text-ink-3">
-        {abbreviateSequence(task.toolSequence)}
-      </p>
+    </div>
+  )
+}
+
+function NoShotComposition({ task }: { task: TaskSummary }) {
+  // Small typographic composition, still on the same dark ink
+  // background so the caption block flows continuously into the
+  // top zone. Keeps the tile a single dark object rather than a
+  // two-color card.
+  const verbs = task.toolSequence.slice(0, 4)
+  return (
+    <div className="absolute inset-0 bg-gradient-to-br from-ink-1 via-ink-2 to-ink-1">
+      <div className="pointer-events-none absolute inset-0 flex flex-col justify-center gap-0.5 pl-4 font-mono text-[14px] text-white/18 leading-tight tracking-tight">
+        {verbs.map((verb, idx) => (
+          <span
+            // biome-ignore lint/suspicious/noArrayIndexKey: tool sequence is stable-ordered per session, not a reorderable list
+            key={`${verb}-${idx}`}
+            style={{ marginLeft: `${idx * 6}px` }}
+            className="truncate"
+          >
+            {verb}
+          </span>
+        ))}
+      </div>
     </div>
   )
 }

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/SupportingTile.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/SupportingTile.tsx
@@ -44,7 +44,6 @@ export function SupportingTile({ task, now, className }: SupportingTileProps) {
         ) : (
           <NoShotComposition task={task} />
         )}
-        <div className="pointer-events-none absolute inset-x-0 bottom-0 h-8 bg-gradient-to-t from-ink via-ink/60 to-transparent" />
         <span className="pointer-events-none absolute top-2.5 right-2.5 flex size-6 items-center justify-center rounded-full bg-white/85 text-ink opacity-0 shadow-sm backdrop-blur-md transition-[opacity,transform] duration-200 group-hover:-translate-y-0.5 group-hover:opacity-100">
           <ArrowUpRight className="size-3.5" />
         </span>

--- a/packages/browseros-agent/apps/claw-app/screens/audit/Audit.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/Audit.tsx
@@ -7,7 +7,7 @@ import {
 } from '@tanstack/react-table'
 import { ScrollText } from 'lucide-react'
 import { useMemo } from 'react'
-import { useNavigate } from 'react-router'
+import { useLocation, useNavigate } from 'react-router'
 import { FilterBar } from '@/components/audit/FilterBar'
 import { EmptyState } from '@/components/cockpit/EmptyState'
 import { Button } from '@/components/ui/button'
@@ -56,6 +56,7 @@ export function Audit() {
     setSort,
   } = useAuditScreenData()
   const navigate = useNavigate()
+  const location = useLocation()
 
   // Mirror the URL-derived sort tuple into a memoised SortingState
   // array. Use the primitive id / desc as deps so the array reference
@@ -199,6 +200,7 @@ export function Audit() {
                   onClick={() =>
                     navigate(
                       `/audit/${encodeURIComponent(row.original.sessionId)}`,
+                      { state: { from: location.pathname } },
                     )
                   }
                   className="cursor-pointer"

--- a/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/cockpit/Cockpit.tsx
@@ -14,7 +14,7 @@ export function Cockpit() {
   const { agents } = useCockpitData()
 
   return (
-    <div className="mx-auto flex max-w-5xl flex-col gap-8 px-8 pt-10 pb-20">
+    <div className="mx-auto flex max-w-7xl flex-col gap-8 px-8 pt-8 pb-16">
       <CockpitHero />
       <RunningGrid agents={agents} />
       <RecentActivity />

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -109,7 +109,15 @@ export function Replay() {
     )
   }
 
-  const back = () => navigate(`/audit/${replay.sessionId}`)
+  // navigate(-1) preserves task detail's original location.state.from
+  // (the entry we're moving back to is re-focused, not re-created), so
+  // task detail's Back button keeps its cockpit / audit-list target.
+  // Doing navigate(`/audit/${sessionId}`) instead would push a new
+  // history entry and lose that state.
+  const back = () =>
+    window.history.length > 1
+      ? navigate(-1)
+      : navigate(`/audit/${replay.sessionId}`)
   // Everything below is tab-scoped: frame index, current frame,
   // scrubber ticks, timeline actions. Playback.time is already in
   // tab-relative seconds thanks to the per-tab usePlayback wiring.


### PR DESCRIPTION
## Summary

Redesigns the claw-app cockpit homepage as a screenshot-forward editorial layout. The freshest / LIVE session becomes a **lead-story tile** on the left; the next four sessions fill a **uniform 2x2 supporting bento** on the right; older sessions fall into a **hairline-separated typographic tail** beneath. `Running now` (currently-active agents) uses the same visual language: screencast on top, solid dark caption block below, `Watch` / `Stop` as inline mono chips.

- Every tile is a link: whole card, cursor pointer, tiny arrow-up-right chip in the top-right corner on hover.
- **LIVE** indicator unified to accent orange with a pulsing dot everywhere (was green pill in Running now, orange dot elsewhere). One accent color per app.
- Caption block is `bg-ink` (solid dark) with white sans title + mono tabular numerics, so text is always legible regardless of what the screenshot underneath looks like. No gradient scrim polluting the image.
- Grid rows locked via `md:grid-rows-[200px_200px]` so every supporting cell is the same 200 px square (lead spans both rows for 412 px total).
- Empty state, loading skeleton, no-screenshot variant (renders the tool sequence as a mono typographic composition on the same dark ink surface, not a grey placeholder pill).
- `TaskHeader` **Back** button switches from a hard-coded `/audit` NavLink to a semantic-referrer pattern: reads `location.state.from` (passed by cockpit tiles + audit list row click), falls back to `/audit` for direct URL loads. Replay's back button uses `navigate(-1)` so the task-detail entry we return to preserves its original `state.from`, and one more Back returns to the true origin (cockpit or audit list) rather than looping back to replay.

## Files touched

- `components/cockpit/CockpitHero.tsx` : compressed one-line hero, italic accent preserved.
- `components/cockpit/LeadRunTile.tsx` : new lead-story tile.
- `components/cockpit/SupportingTile.tsx` : new supporting bento tile.
- `components/cockpit/RunRow.tsx` : new typographic-tail row.
- `components/cockpit/RecentActivity.tsx` : rewritten around the new tiles + explicit 12-col x 2-row grid template.
- `components/cockpit/AgentRunningCard.tsx` : rewritten in the same visual language.
- `components/cockpit/RunningGrid.tsx` : LIVE pill unified to accent orange, cleaner section header.
- `screens/cockpit/Cockpit.tsx` : max-width raised to `max-w-7xl` to give the bento room to breathe.
- `components/audit/TaskHeader.tsx` : Back reads `location.state.from` with `/audit` fallback.
- `screens/replay/Replay.tsx` : back-to-task-detail uses `navigate(-1)` with a `history.length` guard for direct-URL entry.
- `screens/audit/Audit.tsx` : audit-list row click passes `state.from` when navigating to task detail.

## Test plan

- [ ] Open the cockpit newtab, confirm layout: hero, `Running now` section (only when a live agent exists), `Recent activity` bento (lead + 2x2 supporting), typographic tail beneath, `View all activity` link.
- [ ] Confirm every tile is a link and shows the arrow chip on hover.
- [ ] Confirm LIVE runs float to the lead slot and show the pulsing accent-orange dot next to the agent name.
- [ ] Confirm text is legible on every tile regardless of the underlying screenshot content.
- [ ] Trigger an agent, confirm the running-now card matches the editorial language and `Watch` / `Stop` work.
- [ ] From cockpit -> click task -> Back returns to cockpit.
- [ ] From audit list -> click row -> Back returns to audit list.
- [ ] From cockpit -> click task -> View Replay -> Back from replay -> task detail -> Back from task detail returns to cockpit (not replay).
- [ ] Load a `/audit/:sessionId` URL directly in a new tab, Back falls back to `/audit`.
- [ ] `bun run typecheck`, biome, and `bun run build:dev` all clean.