### PR TITLE
fix(claw-app): replay Back guard uses router state, not window.history.length

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/audit/TaskHeader.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/TaskHeader.tsx
@@ -136,7 +136,11 @@ export function TaskHeader({ task }: TaskHeaderProps) {
             variant="default"
             size="sm"
             disabled={!replayReady}
-            onClick={() => navigate(`/audit/${task.sessionId}/replay`)}
+            onClick={() =>
+              navigate(`/audit/${task.sessionId}/replay`, {
+                state: { from: location.pathname },
+              })
+            }
             title={
               replayReady
                 ? 'Watch the rrweb session replay'

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -22,6 +22,7 @@
 
 import { ArrowLeft, History } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useLocation } from 'react-router'
 import { StatusBadge } from '@/components/cockpit/StatusBadge'
 import { Spinner } from '@/components/ui/spinner'
 import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
@@ -34,6 +35,7 @@ import { usePlayback } from './use-playback'
 
 export function Replay() {
   const { replay, isLoading, navigate } = useReplayData()
+  const location = useLocation()
   const [selectedTabPageId, setSelectedTabPageId] = useState<number | null>(
     null,
   )
@@ -114,10 +116,20 @@ export function Replay() {
   // task detail's Back button keeps its cockpit / audit-list target.
   // Doing navigate(`/audit/${sessionId}`) instead would push a new
   // history entry and lose that state.
+  //
+  // Signal for "reached replay via the in-app flow": task detail's
+  // View Replay button seeds location.state.from with the referring
+  // pathname. Absence of that flag means direct URL / refresh, so we
+  // fall back to the semantic parent. window.history.length is not
+  // used because it counts the whole tab's browser history, not just
+  // SPA-internal navigations, and can misfire on any prior entry.
+  const cameFromInAppFlow =
+    typeof location.state === 'object' &&
+    location.state !== null &&
+    'from' in location.state &&
+    typeof (location.state as { from: unknown }).from === 'string'
   const back = () =>
-    window.history.length > 1
-      ? navigate(-1)
-      : navigate(`/audit/${replay.sessionId}`)
+    cameFromInAppFlow ? navigate(-1) : navigate(`/audit/${replay.sessionId}`)
   // Everything below is tab-scoped: frame index, current frame,
   // scrubber ticks, timeline actions. Playback.time is already in
   // tab-relative seconds thanks to the per-tab usePlayback wiring.


### PR DESCRIPTION
## Summary

Addresses Greptile P2 review comment on [#1511](https://github.com/browseros-ai/BrowserOS/pull/1511#discussion_r3512711058) (comment landed after #1511 was merged, so this ships as a follow-up).

`window.history.length > 1` in a Chrome extension / SPA context counts the whole tab's browser history, not just SPA-internal navigations. Any prior non-SPA entry in the tab makes the guard misfire and `navigate(-1)` escapes the app.

Switch to the same in-app-flow signal already used by `TaskHeader`'s Back button: the referring pathname passed via router state.

- `TaskHeader` seeds `location.state.from` when navigating to `/audit/:sessionId/replay`.
- `Replay` reads `location.state`, checks for a `from: string`, and uses `navigate(-1)` only when the flag is present.
- Absence of the flag means direct URL / refresh: fall back to the semantic parent `/audit/:sessionId` as before.

Pattern now stays consistent across the audit / replay pair.

## Test plan

- [ ] From cockpit -> task detail -> View Replay -> Back returns to task detail (task detail's Back still reaches cockpit).
- [ ] Open `/audit/:sessionId/replay` directly in a new tab, Back falls back to `/audit/:sessionId`.
- [ ] Open `/audit/:sessionId/replay` in a tab that already had prior non-SPA history entries: Back still lands on the semantic parent, does not escape the app.
- [ ] `bun run typecheck`, biome check, and `bun run build:dev` all clean locally.