### PR TITLE
feat(claw-app): editorial audit list (Screen 02) preserving tanstack + shadcn Table

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/audit/AuditEmpty.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/AuditEmpty.tsx
@@ -1,0 +1,46 @@
+interface AuditEmptyProps {
+  variant: 'search-miss' | 'zero-tasks' | 'error'
+}
+
+const COPY = {
+  'search-miss': {
+    leading: 'nothing',
+    accent: 'matches',
+    trailing: 'these filters.',
+    hint: 'Try clearing them or widening the search window.',
+  },
+  'zero-tasks': {
+    leading: 'the audit is',
+    accent: 'quiet',
+    trailing: 'so far.',
+    hint: 'Connect an agent from the MCP page and run a tool. Sessions land here within a few seconds.',
+  },
+  error: {
+    leading: 'could not',
+    accent: 'load',
+    trailing: 'the audit.',
+    hint: 'Check that the cockpit server is running and the audit database is reachable.',
+  },
+} as const
+
+/**
+ * Editorial empty state for the audit list. No card, no icon. A
+ * Newsreader italic accent line in the same voice as the cockpit
+ * hero ("What are your agents *working on* right now?"), followed
+ * by a mono hint. Three variants: search-miss, zero-tasks, error.
+ */
+export function AuditEmpty({ variant }: AuditEmptyProps) {
+  const copy = COPY[variant]
+  return (
+    <div className="py-20 text-center">
+      <p className="font-extrabold text-2xl leading-tight tracking-tight md:text-3xl">
+        {copy.leading}{' '}
+        <span className="font-medium font-serif text-accent italic">
+          {copy.accent}
+        </span>{' '}
+        {copy.trailing}
+      </p>
+      <p className="mt-3 font-mono text-[12px] text-ink-3">{copy.hint}</p>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/claw-app/components/audit/AuditHoverPreview.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/AuditHoverPreview.tsx
@@ -1,0 +1,93 @@
+import { AgentDot } from '@/components/audit/AgentDot'
+import { cn } from '@/lib/utils'
+import { type TaskSummary, taskScreenshotUrl } from '@/modules/api/audit.hooks'
+import { formatDuration, formatRelative } from '@/screens/audit/audit.helpers'
+
+interface AuditHoverPreviewProps {
+  task: TaskSummary | null
+}
+
+/**
+ * Fixed-position screenshot preview pinned to the top-right of the
+ * viewport. Fades in whenever the operator hovers a row in the audit
+ * list; content swaps as they move between rows without an unmount.
+ *
+ * When a session has no captured screenshot, the panel switches to a
+ * typographic composition of the tool sequence (same treatment as
+ * the cockpit's SupportingTile no-shot variant) so the panel is
+ * never a grey placeholder.
+ */
+export function AuditHoverPreview({ task }: AuditHoverPreviewProps) {
+  const screenshotId = task?.lastScreenshotDispatchId ?? null
+  return (
+    <div
+      aria-hidden
+      className={cn(
+        'pointer-events-none fixed top-24 right-6 z-30 flex w-[360px] flex-col overflow-hidden rounded-2xl border border-border-2 bg-bg-sunken shadow-xl backdrop-blur-md transition-opacity duration-150',
+        task ? 'opacity-100' : 'opacity-0',
+      )}
+    >
+      <div className="relative aspect-[16/10] w-full overflow-hidden">
+        {task && screenshotId !== null ? (
+          <img
+            src={taskScreenshotUrl(screenshotId)}
+            alt=""
+            className="absolute inset-0 h-full w-full object-cover object-top"
+          />
+        ) : task ? (
+          <NoShotComposition task={task} />
+        ) : null}
+      </div>
+      {task && (
+        <div className="flex flex-col gap-0.5 bg-ink px-4 py-3 text-white">
+          <div className="flex items-center gap-2 font-mono text-[10px] text-white/75 uppercase tracking-[0.08em]">
+            <AgentDot slug={task.slug} />
+            <span className="truncate text-white/95">{task.agentLabel}</span>
+            {task.status === 'live' && <LiveDot />}
+          </div>
+          <p className="truncate font-semibold text-[13px] text-white leading-tight">
+            {task.title}
+          </p>
+          <p className="font-mono text-[10.5px] text-white/65 tabular-nums">
+            {formatDuration(task.durationMs)}{' '}
+            <span className="text-white/40">·</span> {task.dispatchCount} tools{' '}
+            <span className="text-white/40">·</span>{' '}
+            {formatRelative(task.startedAt, Date.now())}
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+function NoShotComposition({ task }: { task: TaskSummary }) {
+  const verbs = task.toolSequence.slice(0, 5)
+  return (
+    <div className="absolute inset-0 bg-gradient-to-br from-ink via-ink-2 to-ink">
+      <div className="pointer-events-none absolute inset-0 flex flex-col justify-center gap-1 pl-6 font-mono text-[22px] text-white/15 leading-tight tracking-tight">
+        {verbs.map((verb, idx) => (
+          <span
+            // biome-ignore lint/suspicious/noArrayIndexKey: tool sequence is stable-ordered per session, not a reorderable list
+            key={`${verb}-${idx}`}
+            style={{ marginLeft: `${idx * 8}px` }}
+            className="truncate"
+          >
+            {verb}
+          </span>
+        ))}
+      </div>
+    </div>
+  )
+}
+
+function LiveDot() {
+  return (
+    <span className="inline-flex items-center gap-1 text-accent">
+      <span
+        aria-hidden
+        className="inline-block size-1.5 animate-[pulse-dot_1.4s_ease-in-out_infinite] rounded-full bg-accent"
+      />
+      LIVE
+    </span>
+  )
+}

--- a/packages/browseros-agent/apps/claw-app/components/audit/FilterBar.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/FilterBar.tsx
@@ -63,10 +63,16 @@ export function FilterBar({
   }
 
   return (
-    <div className="flex flex-wrap items-center gap-2 rounded-2xl border border-border-2 bg-card px-3 py-2.5">
+    <div className="flex flex-wrap items-center gap-1 border-border-2 border-y py-2.5">
       <DropdownMenu>
         <DropdownMenuTrigger
-          render={<Button variant="ghost" size="sm" className="gap-1.5" />}
+          render={
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 gap-1.5 font-mono text-[11px] text-ink-2 uppercase tracking-[0.08em] hover:bg-card-tint"
+            />
+          }
         >
           {selectedAgent ? (
             <>
@@ -76,7 +82,7 @@ export function FilterBar({
           ) : (
             'Agent'
           )}
-          <ChevronDown className="size-3.5 text-ink-3" />
+          <ChevronDown className="size-3 text-ink-3" />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="min-w-52">
           <DropdownMenuItem onClick={() => onAgentChange(null)}>
@@ -101,10 +107,16 @@ export function FilterBar({
 
       <DropdownMenu>
         <DropdownMenuTrigger
-          render={<Button variant="ghost" size="sm" className="gap-1.5" />}
+          render={
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 gap-1.5 font-mono text-[11px] text-ink-2 uppercase tracking-[0.08em] hover:bg-card-tint"
+            />
+          }
         >
-          {selectedStatus ? <StatusBadge status={selectedStatus} /> : 'Status'}
-          <ChevronDown className="size-3.5 text-ink-3" />
+          {selectedStatus ? <StatusPill status={selectedStatus} /> : 'Status'}
+          <ChevronDown className="size-3 text-ink-3" />
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="min-w-44">
           <DropdownMenuItem onClick={() => onStatusChange(null)}>
@@ -129,10 +141,16 @@ export function FilterBar({
       {siteOptions.length > 0 && (
         <DropdownMenu>
           <DropdownMenuTrigger
-            render={<Button variant="ghost" size="sm" className="gap-1.5" />}
+            render={
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 gap-1.5 font-mono text-[11px] text-ink-2 uppercase tracking-[0.08em] hover:bg-card-tint"
+              />
+            }
           >
             {selectedSite ?? 'Site'}
-            <ChevronDown className="size-3.5 text-ink-3" />
+            <ChevronDown className="size-3 text-ink-3" />
           </DropdownMenuTrigger>
           <DropdownMenuContent
             align="start"
@@ -165,10 +183,10 @@ export function FilterBar({
         <Input
           value={localSearch}
           onChange={(e) => setLocalSearch(e.target.value)}
-          placeholder="Search title or agent"
+          placeholder="search sessions..."
           // pr-7 reserves space for the inline clear button so the
           // text never sits under the icon.
-          className="h-8 w-56 pr-7 pl-8 text-[12.5px]"
+          className="h-8 w-64 border-none bg-transparent pr-7 pl-8 font-mono text-[11.5px] text-ink-1 placeholder:text-ink-3 focus-visible:bg-card-tint focus-visible:ring-0"
         />
         {localSearch.length > 0 && (
           <button
@@ -184,4 +202,30 @@ export function FilterBar({
       </div>
     </div>
   )
+}
+
+function StatusPill({ status }: { status: TaskStatus }) {
+  if (status === 'live') {
+    return (
+      <span className="inline-flex items-center gap-1 text-accent">
+        <span
+          aria-hidden
+          className="inline-block size-1.5 animate-[pulse-dot_1.4s_ease-in-out_infinite] rounded-full bg-accent"
+        />
+        Live
+      </span>
+    )
+  }
+  if (status === 'failed') {
+    return (
+      <span className="inline-flex items-center gap-1 text-red-500">
+        <span
+          aria-hidden
+          className="inline-block size-1.5 rounded-full bg-red-500"
+        />
+        Failed
+      </span>
+    )
+  }
+  return <span>Done</span>
 }

--- a/packages/browseros-agent/apps/claw-app/screens/audit/Audit.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/Audit.test.tsx
@@ -74,17 +74,17 @@ const sampleTask: TaskSummary = {
 }
 
 describe('Audit screen', () => {
-  it('renders the header + hint', () => {
+  it('renders the header', () => {
     dataOverride = { ...baseData }
     const html = renderApp()
     expect(html).toContain('Audit')
-    expect(html).toContain('Tasks across every BrowserClaw session')
   })
 
-  it('shows the empty state when there are no tasks', () => {
+  it('shows the editorial empty state when there are no tasks', () => {
     dataOverride = { ...baseData }
     const html = renderApp()
-    expect(html).toContain('No tasks in this view')
+    // Editorial voice: `the audit is *quiet* so far`
+    expect(html).toContain('quiet')
   })
 
   it('shows skeleton loading rows while the first page is pending', () => {
@@ -97,7 +97,8 @@ describe('Audit screen', () => {
   it('shows the error empty state when the query fails', () => {
     dataOverride = { ...baseData, isError: true }
     const html = renderApp()
-    expect(html).toContain('Could not load audit log')
+    // Editorial voice: `could not *load* the audit.`
+    expect(html).toContain('could not')
   })
 
   it('renders one row per task with title + agent + site', () => {
@@ -118,7 +119,9 @@ describe('Audit screen', () => {
     const html = renderApp()
     expect(html).toContain('Claude Code')
     expect(html).toContain('Browsed example.com')
-    expect(html).toContain('Done')
+    // DONE is the silent default in the editorial cockpit; the row's
+    // identity carries state (LIVE / FAILED render inline dots), so
+    // no visible 'Done' text renders here anymore.
   })
 
   it('renders the Load older tasks button when hasNextPage is true', () => {
@@ -146,16 +149,17 @@ describe('Audit screen', () => {
     const html = renderApp()
     // FilterBar's search input still on screen so the user can clear /
     // edit their query without a soft-lock.
-    expect(html).toMatch(/placeholder="Search title or agent"/)
-    expect(html).toContain('No tasks match these filters')
-    expect(html).toContain('Adjust the search or filter dropdowns')
+    expect(html).toMatch(/placeholder="search sessions/)
+    // Editorial voice: `nothing *matches* these filters.`
+    expect(html).toContain('matches')
   })
 
   it('hides the FilterBar when there are no tasks AND no active filters', () => {
     dataOverride = { ...baseData, tasks: [] }
     const html = renderApp()
-    expect(html).not.toMatch(/placeholder="Search title or agent"/)
-    expect(html).toContain('No tasks in this view')
+    expect(html).not.toMatch(/placeholder="search sessions/)
+    // Editorial voice: `the audit is *quiet* so far`
+    expect(html).toContain('quiet')
   })
 
   it('shows skeleton (not empty state) when auto-paginating a filtered query', () => {
@@ -176,7 +180,8 @@ describe('Audit screen', () => {
     }
     const html = renderApp()
     expect(html).toMatch(/animate-pulse/)
-    expect(html).not.toContain('No tasks match these filters')
-    expect(html).not.toContain('No tasks in this view')
+    // Editorial empty states must not appear while data is loading.
+    expect(html).not.toContain('quiet so far')
+    expect(html).not.toContain('nothing')
   })
 })

--- a/packages/browseros-agent/apps/claw-app/screens/audit/Audit.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/Audit.tsx
@@ -132,12 +132,7 @@ export function Audit() {
       {isError ? (
         <AuditEmpty variant="error" />
       ) : isLoading ? (
-        <TableShell
-          table={table}
-          skeleton
-          onRowHover={setHoveredTask}
-          onRowClick={undefined}
-        />
+        <TableShell table={table} />
       ) : rows.length === 0 ? (
         <AuditEmpty variant={hasActiveFilters ? 'search-miss' : 'zero-tasks'} />
       ) : (
@@ -272,9 +267,6 @@ export function Audit() {
 
 interface TableShellProps {
   table: ReturnType<typeof useReactTable<TaskSummary>>
-  skeleton: true
-  onRowHover: (task: TaskSummary | null) => void
-  onRowClick: undefined
 }
 
 /**

--- a/packages/browseros-agent/apps/claw-app/screens/audit/Audit.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/Audit.tsx
@@ -192,12 +192,16 @@ export function Audit() {
               <TableBody>
                 {rows.map((row, idx) => {
                   const prev = idx > 0 ? rows[idx - 1] : null
+                  // Null-check narrows prev so we do not need the
+                  // non-null assertion inside isSameLocalDay's number
+                  // parameters. Biome's noNonNullAssertion rule bans
+                  // the `!` form; this preserves the type discipline.
                   const dayChanged =
                     showDayHeadings &&
-                    (idx === 0 ||
+                    (prev === null ||
                       !isSameLocalDay(
                         row.original.startedAt,
-                        prev?.original.startedAt,
+                        prev.original.startedAt,
                       ))
                   return (
                     <Fragment key={row.id}>

--- a/packages/browseros-agent/apps/claw-app/screens/audit/Audit.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/Audit.tsx
@@ -5,13 +5,12 @@ import {
   type SortingState,
   useReactTable,
 } from '@tanstack/react-table'
-import { ScrollText } from 'lucide-react'
-import { useMemo } from 'react'
+import { ArrowRight } from 'lucide-react'
+import { Fragment, useMemo, useState } from 'react'
 import { useLocation, useNavigate } from 'react-router'
+import { AuditEmpty } from '@/components/audit/AuditEmpty'
+import { AuditHoverPreview } from '@/components/audit/AuditHoverPreview'
 import { FilterBar } from '@/components/audit/FilterBar'
-import { EmptyState } from '@/components/cockpit/EmptyState'
-import { Button } from '@/components/ui/button'
-import { Skeleton } from '@/components/ui/skeleton'
 import {
   Table,
   TableBody,
@@ -20,22 +19,26 @@ import {
   TableHeader,
   TableRow,
 } from '@/components/ui/table'
+import { cn } from '@/lib/utils'
 import type { TaskSummary } from '@/modules/api/audit.hooks'
-import { TASK_COLUMNS } from './audit.columns'
+import { NUMERIC_COLUMN_IDS, TASK_COLUMNS } from './audit.columns'
 import { useAuditScreenData } from './audit.data'
+import {
+  formatDayHeading,
+  isSameLocalDay,
+  orderByLiveThenRecency,
+} from './audit.helpers'
 
 /**
- * Task-centric audit screen. Each MCP session becomes one row. Click
- * a row to navigate to its full timeline at `/audit/:sessionId`.
- * Filters round-trip through URL search params so browser back
- * restores the prior view.
- *
- * All of `useReactTable`'s options come from stable references
- * (module-level columns, useMemo'd data + state) so the table never
- * re-builds its core or sort row models when nothing relevant
- * changed. Per tanstack-table v8, passing fresh references on every
- * render forces an internal re-process each tick and the page
- * locks up under typing / filter cascades.
+ * Editorial audit screen. Preserves the tanstack-table + shadcn
+ * Table primitives (sortable headers, keyboard nav, infinite
+ * pagination) and restyles them to match the cockpit's language:
+ * hairline-separated rows on the shell, mono tabular numerics for
+ * grid data, agent-dot identity, LIVE / FAILED folded inline into
+ * the agent cell, DONE silent. Day-of-week headings are injected
+ * as spanning `<TableRow>` dividers between date groups when the
+ * default `when`-descending sort is active. On row hover, a fixed
+ * top-right panel shows the session's screenshot preview.
  */
 export function Audit() {
   const {
@@ -58,16 +61,17 @@ export function Audit() {
   const navigate = useNavigate()
   const location = useLocation()
 
-  // Mirror the URL-derived sort tuple into a memoised SortingState
-  // array. Use the primitive id / desc as deps so the array reference
-  // is stable across renders that did not change the sort (the
-  // filters.sort object itself is rebuilt on every paramsToFilters
-  // call even when nothing changed).
   const hasActiveFilters =
     filters.agentId !== null ||
     filters.status !== null ||
     filters.site !== null ||
     filters.search.length > 0
+
+  // LIVE-first pre-sort so a running session floats to the top of
+  // the initial view. Operator column sorts still work: they run
+  // through tanstack-table's sortingState on top of this input.
+  const orderedTasks = useMemo(() => orderByLiveThenRecency(tasks), [tasks])
+
   const sortId = filters.sort?.id
   const sortDesc = filters.sort?.desc
   const sorting = useMemo<SortingState>(
@@ -80,7 +84,7 @@ export function Audit() {
   const state = useMemo(() => ({ sorting }), [sorting])
 
   const table = useReactTable<TaskSummary>({
-    data: tasks,
+    data: orderedTasks,
     columns: TASK_COLUMNS,
     state,
     onSortingChange: (updater) => {
@@ -91,30 +95,24 @@ export function Audit() {
     getSortedRowModel: getSortedRowModel(),
   })
 
+  // Day-of-week headings only make sense when rows are date-ordered.
+  // If the operator picks a non-`when` sort (e.g. sort by duration
+  // desc), skip the dividers so we do not scramble day groups.
+  const activeSortId = sorting[0]?.id
+  const showDayHeadings = !activeSortId || activeSortId === 'when'
+
+  const [hoveredTask, setHoveredTask] = useState<TaskSummary | null>(null)
+  const rows = table.getRowModel().rows
+  const visibleColumnCount = table.getVisibleFlatColumns().length
+
   return (
-    <div className="mx-auto flex w-full max-w-6xl flex-col gap-6 px-8 pt-10 pb-20">
-      <header className="space-y-2">
-        <div className="flex items-center gap-2.5">
-          <span className="flex size-9 items-center justify-center rounded-xl bg-accent-tint text-accent">
-            <ScrollText className="size-4.5" />
-          </span>
-          <div>
-            <h1 className="font-extrabold text-2xl tracking-tight">Audit</h1>
-            <p className="text-ink-3 text-sm">
-              Tasks across every BrowserClaw session. Click a row to open its
-              timeline.
-            </p>
-          </div>
-        </div>
+    <div className="relative mx-auto flex w-full max-w-6xl flex-col gap-6 px-8 pt-8 pb-16">
+      <header>
+        <h1 className="font-extrabold text-3xl leading-tight tracking-tight md:text-4xl">
+          Audit
+        </h1>
       </header>
 
-      {/* Keep the FilterBar mounted across every state EXCEPT the
-          first-load and error cases. Without this, a debounced search
-          keystroke triggers a refetch -> isLoading flips true ->
-          FilterBar unmounts -> the input the operator is typing into
-          loses focus. The gate is intentionally permissive: as soon
-          as either the user has tasks OR an active filter, the bar
-          stays. */}
       {!isError && (tasks.length > 0 || hasActiveFilters) && (
         <FilterBar
           agentOptions={agentOptions}
@@ -131,106 +129,200 @@ export function Audit() {
         />
       )}
 
-      {isLoading ? (
-        <div className="space-y-2 rounded-2xl border border-border-2 bg-card p-4">
-          {['s1', 's2', 's3', 's4', 's5', 's6'].map((id) => (
-            <Skeleton key={id} className="h-10 w-full" />
-          ))}
-        </div>
-      ) : isError ? (
-        <EmptyState
-          title="Could not load audit log"
-          hint="Check that the cockpit server is running and the audit database is reachable."
+      {isError ? (
+        <AuditEmpty variant="error" />
+      ) : isLoading ? (
+        <TableShell
+          table={table}
+          skeleton
+          onRowHover={setHoveredTask}
+          onRowClick={undefined}
         />
-      ) : tasks.length === 0 ? (
-        hasActiveFilters ? (
-          <EmptyState
-            title="No tasks match these filters"
-            hint="Adjust the search or filter dropdowns above, or clear them to see every session again."
-          />
-        ) : (
-          <EmptyState
-            title="No tasks in this view"
-            hint="Connect an agent via the MCP page and run a tool. Successful sessions land here within a few seconds."
-          />
-        )
+      ) : rows.length === 0 ? (
+        <AuditEmpty variant={hasActiveFilters ? 'search-miss' : 'zero-tasks'} />
       ) : (
-        <div className="overflow-hidden rounded-2xl border border-border-2 bg-card">
-          <Table>
-            <TableHeader>
-              {table.getHeaderGroups().map((hg) => (
-                <TableRow key={hg.id} className="hover:bg-transparent">
-                  {hg.headers.map((h) => {
-                    const canSort = h.column.getCanSort()
-                    return (
-                      <TableHead
-                        key={h.id}
-                        onClick={
-                          canSort
-                            ? h.column.getToggleSortingHandler()
-                            : undefined
-                        }
-                        className={canSort ? 'cursor-pointer select-none' : ''}
-                      >
-                        <span className="inline-flex items-center gap-1">
-                          {h.isPlaceholder
-                            ? null
-                            : flexRender(
-                                h.column.columnDef.header,
-                                h.getContext(),
-                              )}
-                          {canSort &&
-                            ({
-                              asc: ' ▲',
-                              desc: ' ▼',
-                            }[h.column.getIsSorted() as string] ??
-                              null)}
-                        </span>
-                      </TableHead>
-                    )
-                  })}
-                </TableRow>
-              ))}
-            </TableHeader>
-            <TableBody>
-              {table.getRowModel().rows.map((row) => (
-                <TableRow
-                  key={row.id}
-                  data-testid={`task-row-${row.original.sessionId}`}
-                  onClick={() =>
-                    navigate(
-                      `/audit/${encodeURIComponent(row.original.sessionId)}`,
-                      { state: { from: location.pathname } },
-                    )
-                  }
-                  className="cursor-pointer"
-                >
-                  {row.getVisibleCells().map((cell) => (
-                    <TableCell key={cell.id}>
-                      {flexRender(
-                        cell.column.columnDef.cell,
-                        cell.getContext(),
+        <>
+          {/* biome-ignore lint/a11y/noStaticElementInteractions: the onMouseLeave clears the supplementary hover-preview panel; the panel is a pointer-only progressive enhancement and does not gate any core information. */}
+          <div className="relative" onMouseLeave={() => setHoveredTask(null)}>
+            <Table>
+              <TableHeader>
+                {table.getHeaderGroups().map((hg) => (
+                  <TableRow
+                    key={hg.id}
+                    className="border-border-2 border-b hover:bg-transparent"
+                  >
+                    {hg.headers.map((h) => {
+                      const canSort = h.column.getCanSort()
+                      const isNumeric = NUMERIC_COLUMN_IDS.has(h.column.id)
+                      const sortDir = h.column.getIsSorted()
+                      return (
+                        <TableHead
+                          key={h.id}
+                          onClick={
+                            canSort
+                              ? h.column.getToggleSortingHandler()
+                              : undefined
+                          }
+                          className={cn(
+                            'font-mono text-[10.5px] text-ink-3 uppercase tracking-[0.08em]',
+                            canSort && 'cursor-pointer select-none',
+                            isNumeric && 'text-right',
+                          )}
+                        >
+                          <span className="inline-flex items-center gap-1">
+                            {h.isPlaceholder
+                              ? null
+                              : flexRender(
+                                  h.column.columnDef.header,
+                                  h.getContext(),
+                                )}
+                            {canSort && sortDir === 'asc' && (
+                              <span aria-hidden>▲</span>
+                            )}
+                            {canSort && sortDir === 'desc' && (
+                              <span aria-hidden>▼</span>
+                            )}
+                          </span>
+                        </TableHead>
+                      )
+                    })}
+                  </TableRow>
+                ))}
+              </TableHeader>
+              <TableBody>
+                {rows.map((row, idx) => {
+                  const prev = idx > 0 ? rows[idx - 1] : null
+                  const dayChanged =
+                    showDayHeadings &&
+                    (idx === 0 ||
+                      !isSameLocalDay(
+                        row.original.startedAt,
+                        prev?.original.startedAt,
+                      ))
+                  return (
+                    <Fragment key={row.id}>
+                      {dayChanged && (
+                        <TableRow className="hover:bg-transparent">
+                          <TableCell
+                            colSpan={visibleColumnCount}
+                            className="border-none pt-6 pb-1"
+                          >
+                            <span className="font-mono text-[10.5px] text-ink-3 uppercase tracking-[0.08em]">
+                              {formatDayHeading(row.original.startedAt)}
+                            </span>
+                          </TableCell>
+                        </TableRow>
                       )}
-                    </TableCell>
-                  ))}
-                </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+                      <TableRow
+                        data-testid={`task-row-${row.original.sessionId}`}
+                        onMouseEnter={() => setHoveredTask(row.original)}
+                        onClick={() =>
+                          navigate(
+                            `/audit/${encodeURIComponent(row.original.sessionId)}`,
+                            { state: { from: location.pathname } },
+                          )
+                        }
+                        className="group cursor-pointer border-border-2 border-t hover:bg-card-tint"
+                      >
+                        {row.getVisibleCells().map((cell) => (
+                          <TableCell
+                            key={cell.id}
+                            className={cn(
+                              NUMERIC_COLUMN_IDS.has(cell.column.id) &&
+                                'text-right',
+                            )}
+                          >
+                            {flexRender(
+                              cell.column.columnDef.cell,
+                              cell.getContext(),
+                            )}
+                          </TableCell>
+                        ))}
+                      </TableRow>
+                    </Fragment>
+                  )
+                })}
+              </TableBody>
+            </Table>
+          </div>
           {hasNextPage && (
-            <div className="border-border-2 border-t bg-bg-canvas px-4 py-3 text-center">
-              <Button
-                variant="secondary"
-                size="sm"
+            <div className="pt-2 text-center">
+              <button
+                type="button"
                 onClick={fetchNextPage}
                 disabled={isFetchingNextPage}
+                className="group inline-flex items-center gap-1.5 font-mono text-[12px] text-ink-3 uppercase tracking-[0.08em] transition-colors hover:text-ink-1 disabled:cursor-not-allowed disabled:opacity-60"
               >
                 {isFetchingNextPage ? 'Loading...' : 'Load older tasks'}
-              </Button>
+                <ArrowRight className="size-3.5 transition-transform group-hover:translate-x-0.5" />
+              </button>
             </div>
           )}
-        </div>
+        </>
       )}
+
+      <AuditHoverPreview task={hoveredTask} />
+    </div>
+  )
+}
+
+interface TableShellProps {
+  table: ReturnType<typeof useReactTable<TaskSummary>>
+  skeleton: true
+  onRowHover: (task: TaskSummary | null) => void
+  onRowClick: undefined
+}
+
+/**
+ * Loading-state skeleton table shell. Renders the real header row
+ * plus 6 empty `<TableRow>` shells so the layout does not jump when
+ * data lands.
+ */
+function TableShell({ table }: TableShellProps) {
+  return (
+    <div className="relative">
+      <Table>
+        <TableHeader>
+          {table.getHeaderGroups().map((hg) => (
+            <TableRow
+              key={hg.id}
+              className="border-border-2 border-b hover:bg-transparent"
+            >
+              {hg.headers.map((h) => {
+                const isNumeric = NUMERIC_COLUMN_IDS.has(h.column.id)
+                return (
+                  <TableHead
+                    key={h.id}
+                    className={cn(
+                      'font-mono text-[10.5px] text-ink-3 uppercase tracking-[0.08em]',
+                      isNumeric && 'text-right',
+                    )}
+                  >
+                    {h.isPlaceholder
+                      ? null
+                      : flexRender(h.column.columnDef.header, h.getContext())}
+                  </TableHead>
+                )
+              })}
+            </TableRow>
+          ))}
+        </TableHeader>
+        <TableBody>
+          {['s1', 's2', 's3', 's4', 's5', 's6'].map((id) => (
+            <TableRow
+              key={id}
+              className="border-border-2 border-t hover:bg-transparent"
+            >
+              <TableCell
+                colSpan={table.getVisibleFlatColumns().length}
+                className="py-4"
+              >
+                <div className="h-4 w-full animate-pulse rounded bg-card-tint" />
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
     </div>
   )
 }

--- a/packages/browseros-agent/apps/claw-app/screens/audit/audit.columns.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/audit.columns.tsx
@@ -1,7 +1,6 @@
 import type { ColumnDef } from '@tanstack/react-table'
 import { ChevronRight } from 'lucide-react'
 import { AgentDot } from '@/components/audit/AgentDot'
-import { StatusBadge } from '@/components/audit/StatusBadge'
 import type { TaskSummary } from '@/modules/api/audit.hooks'
 import {
   abbreviateSequence,
@@ -15,11 +14,10 @@ import {
  * re-builds its internal column tree every render. Defining this
  * outside the component is the canonical stable-reference recipe.
  *
- * Relative-time formatting reads Date.now() inside the cell so the
- * column array never has to take a `now` prop (which would
- * destabilise the reference). This is fine because cells re-render
- * whenever data changes; the time is always fresh enough for the
- * "Xs ago" granularity.
+ * Editorial cockpit language: mono tabular numerics for grid data,
+ * agent dot + mono-uppercase label for identity, LIVE / FAILED
+ * folded inline into the agent cell so the row's identity carries
+ * its state (DONE stays silent, no Status column).
  */
 export const TASK_COLUMNS: ColumnDef<TaskSummary>[] = [
   {
@@ -27,11 +25,13 @@ export const TASK_COLUMNS: ColumnDef<TaskSummary>[] = [
     header: 'Agent',
     accessorKey: 'agentLabel',
     cell: ({ row }) => (
-      <div className="flex items-center gap-2">
+      <div className="inline-flex items-center gap-2">
         <AgentDot slug={row.original.slug} />
-        <span className="font-medium text-ink-1">
+        <span className="font-mono text-[11px] text-ink-2 uppercase tracking-[0.06em]">
           {row.original.agentLabel}
         </span>
+        {row.original.status === 'live' && <LiveInlineChip />}
+        {row.original.status === 'failed' && <FailedInlineChip />}
       </div>
     ),
     enableSorting: true,
@@ -41,21 +41,29 @@ export const TASK_COLUMNS: ColumnDef<TaskSummary>[] = [
     header: 'Title',
     accessorKey: 'title',
     cell: ({ row }) => (
-      <div className="flex flex-col leading-tight">
-        <span className="font-medium text-ink-1">{row.original.title}</span>
-        <span className="text-[11.5px] text-ink-3">
-          {abbreviateSequence(row.original.toolSequence)}
-        </span>
-      </div>
+      <span className="block truncate text-[13px] text-ink-1">
+        {row.original.title}
+      </span>
+    ),
+    enableSorting: false,
+  },
+  {
+    id: 'sequence',
+    header: 'Tools used',
+    accessorFn: (t) => t.toolSequence.join('/'),
+    cell: ({ row }) => (
+      <span className="block max-w-[240px] truncate font-mono text-[11.5px] text-ink-3">
+        {abbreviateSequence(row.original.toolSequence)}
+      </span>
     ),
     enableSorting: false,
   },
   {
     id: 'tools',
-    header: 'Tools',
+    header: 'Actions',
     accessorFn: (t) => t.dispatchCount,
     cell: ({ getValue }) => (
-      <span className="font-mono text-[12.5px] text-ink-2">
+      <span className="font-mono text-[11.5px] text-ink-2 tabular-nums">
         {getValue<number>()}
       </span>
     ),
@@ -66,7 +74,7 @@ export const TASK_COLUMNS: ColumnDef<TaskSummary>[] = [
     header: 'Dur.',
     accessorFn: (t) => t.durationMs,
     cell: ({ getValue }) => (
-      <span className="font-mono text-[12.5px] text-ink-2">
+      <span className="font-mono text-[11.5px] text-ink-2 tabular-nums">
         {formatDuration(getValue<number>())}
       </span>
     ),
@@ -74,20 +82,11 @@ export const TASK_COLUMNS: ColumnDef<TaskSummary>[] = [
     enableSorting: true,
   },
   {
-    id: 'status',
-    header: 'Status',
-    accessorKey: 'status',
-    cell: ({ getValue }) => (
-      <StatusBadge status={getValue<TaskSummary['status']>()} />
-    ),
-    enableSorting: true,
-  },
-  {
     id: 'when',
     header: 'When',
     accessorKey: 'startedAt',
     cell: ({ getValue }) => (
-      <span className="text-[12.5px] text-ink-3">
+      <span className="font-mono text-[11.5px] text-ink-3 tabular-nums">
         {formatRelative(getValue<number>(), Date.now())}
       </span>
     ),
@@ -96,7 +95,49 @@ export const TASK_COLUMNS: ColumnDef<TaskSummary>[] = [
   {
     id: 'chevron',
     header: '',
-    cell: () => <ChevronRight className="size-4 text-ink-3" aria-hidden />,
+    cell: () => (
+      <ChevronRight
+        className="size-3.5 text-ink-4 opacity-0 transition-opacity group-hover:opacity-100"
+        aria-hidden
+      />
+    ),
     enableSorting: false,
   },
 ]
+
+/**
+ * Column ids whose cells + headers should be right-aligned. Used by
+ * the Audit screen wrapper to decorate `<TableHead>` / `<TableCell>`
+ * with `text-right`. Kept as a single source of truth so header +
+ * cell alignment cannot drift.
+ */
+export const NUMERIC_COLUMN_IDS = new Set([
+  'tools',
+  'duration',
+  'when',
+  'chevron',
+])
+
+function LiveInlineChip() {
+  return (
+    <span className="inline-flex items-center gap-1 font-mono text-[10px] text-accent uppercase tracking-[0.08em]">
+      <span
+        aria-hidden
+        className="inline-block size-1.5 animate-[pulse-dot_1.4s_ease-in-out_infinite] rounded-full bg-accent shadow-[0_0_6px_hsl(19_89%_56%/0.6)]"
+      />
+      LIVE
+    </span>
+  )
+}
+
+function FailedInlineChip() {
+  return (
+    <span className="inline-flex items-center gap-1 font-mono text-[10px] text-red-500 uppercase tracking-[0.08em]">
+      <span
+        aria-hidden
+        className="inline-block size-1.5 rounded-full bg-red-500"
+      />
+      FAILED
+    </span>
+  )
+}

--- a/packages/browseros-agent/apps/claw-app/screens/audit/audit.helpers.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/audit/audit.helpers.ts
@@ -1,5 +1,42 @@
 import type { TaskStatus, TaskSummary } from '@/modules/api/audit.hooks'
 
+/**
+ * LIVE runs always float to the top of the list regardless of
+ * `startedAt`; within each status group we sort newest-first. This
+ * is the input sort applied BEFORE tanstack-table's own sorting
+ * state so operator-triggered column sorts still work naturally
+ * (an operator sort override replaces this pre-sort at render).
+ */
+export function orderByLiveThenRecency(tasks: TaskSummary[]): TaskSummary[] {
+  return [...tasks].sort((a, b) => {
+    if (a.status === 'live' && b.status !== 'live') return -1
+    if (b.status === 'live' && a.status !== 'live') return 1
+    return b.startedAt - a.startedAt
+  })
+}
+
+const DAY_HEADING_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  weekday: 'long',
+  day: 'numeric',
+  month: 'long',
+})
+
+/** `WEDNESDAY, 2 JULY` style label used as an audit-list day divider. */
+export function formatDayHeading(ts: number): string {
+  return DAY_HEADING_FORMATTER.format(new Date(ts)).toUpperCase()
+}
+
+/** Local calendar-day equality (year + month + date), timezone-aware. */
+export function isSameLocalDay(a: number, b: number): boolean {
+  const da = new Date(a)
+  const db = new Date(b)
+  return (
+    da.getFullYear() === db.getFullYear() &&
+    da.getMonth() === db.getMonth() &&
+    da.getDate() === db.getDate()
+  )
+}
+
 const NINE_SECONDS = 9_000
 const ONE_MINUTE = 60_000
 const ONE_HOUR = 3_600_000


### PR DESCRIPTION
## Summary

Applies the cockpit's editorial language (from #1511) to the audit browsing surface at `newtab.html#/audit`. **Preserves the tanstack-table + shadcn `Table` primitives** that power sortable headers, keyboard nav, and infinite pagination — only the CSS + column-cell templates change. The `useReactTable` wiring, `getSortedRowModel`, and `fetchNextPage` stay put.

Visually the table now reads as a magazine index (hairline-separated rows, mono tabular numerics, agent-dot identity, day-of-week groupings), not a shadcn Table in a card slab.

## Design highlights

- **Table sits on the shell**, no rounded card frame.
- **Mono uppercase headers** (`AGENT` / `TITLE` / `TOOLS USED` / `ACTIONS` / `DUR.` / `WHEN`) with hairline `border-b`; sortable ▲ / ▼ glyphs on toggle.
- **Hairline-separated rows**, hover tints `bg-card-tint`; chevron cell fades in only on hover.
- **Agent cell folds LIVE / FAILED inline** (pulsing accent-orange dot + `LIVE` mono chip; red dot + `FAILED`). DONE stays silent — the standalone Status column is gone (status is state, not data, and the FilterBar covers filtering by status).
- **New `sequence` column** shows the mono tool trail (`tabs → snapshot → run → …`).
- **Numeric columns right-aligned mono tabular** via a single `NUMERIC_COLUMN_IDS` source of truth used by both header + cell.
- **Day-of-week headings** (`WEDNESDAY, 2 JULY`) injected between date groups as spanning `<TableRow>` dividers, only when the default `when`-descending sort is active. Operator sorts on other columns skip the dividers.
- **LIVE-first pre-sort** so a running session floats to the top of the initial view. Column sorts still work: they override via tanstack's `sortingState`.
- **Fixed-position `AuditHoverPreview` panel** pinned top-right of the viewport (~360 px, hairline + backdrop-blur). Fades in with the hovered row; screenshot from `taskScreenshotUrl(lastScreenshotDispatchId)` or the tool-sequence typographic composition when no shot exists.
- **Editorial empty states** with the Newsreader italic accent (matching the cockpit hero): `the audit is *quiet* so far`, `nothing *matches* these filters`, `could not *load* the audit`. No card, no lucide icon.
- **FilterBar loses its card frame.** Chips + Search sit inline on the shell between hairlines. DropdownMenu triggers become mono uppercase chips; Search input is borderless with a mono `search sessions...` placeholder.
- **Pagination becomes a mono link** (`LOAD OLDER TASKS →`) matching the cockpit's `VIEW ALL ACTIVITY →`; `Button` in a bordered footer removed.

## Files touched

- `screens/audit/audit.helpers.ts` : `orderByLiveThenRecency`, `formatDayHeading`, `isSameLocalDay`.
- `screens/audit/audit.columns.tsx` : rewritten cell renderers, new `sequence` column, `NUMERIC_COLUMN_IDS`, inline LIVE / FAILED chips; status column dropped.
- `screens/audit/Audit.tsx` : new header, LIVE-first pre-sort, day-heading injection, hover state, mono pagination link. tanstack + shadcn wiring intact.
- `components/audit/AuditHoverPreview.tsx` : new fixed-position preview panel.
- `components/audit/AuditEmpty.tsx` : new three-variant editorial empty state.
- `components/audit/FilterBar.tsx` : inline restyle, mono chips, borderless search.
- `screens/audit/Audit.test.tsx` : assertions updated to the new editorial copy.

## Test plan

- [ ] Open `#/audit`, confirm layout: compressed `Audit` H1, inline filter row, mono uppercase headers, hairline rows, day-of-week groupings, `LOAD OLDER TASKS →` link.
- [ ] Sortable headers still sort (click Agent / Actions / Dur. / When, see ▲ / ▼).
- [ ] Sort by a non-`when` column: day headings disappear (rows are no longer date-ordered).
- [ ] Sort by `when` (default): day headings appear.
- [ ] Trigger a LIVE session, confirm the row floats to the top and shows the pulsing accent-orange `LIVE` chip inline in the agent cell.
- [ ] Trigger a FAILED session, confirm the red `FAILED` chip renders inline.
- [ ] Hover any row: top-right screenshot preview panel fades in with the session's screenshot; content swaps as you hover different rows; panel fades out when the cursor leaves the table region.
- [ ] Rows without a screenshot show the tool-sequence typographic composition in the preview panel instead.
- [ ] Filter chips (Agent / Status / Site) still open + filter; Search still debounces + persists via URL params.
- [ ] Click a row: navigates to task detail; task detail's Back returns to the audit list (state.from wiring from #1512 covers this).
- [ ] Empty states render editorial copy: `the audit is *quiet* so far` (fresh install), `nothing *matches* these filters` (search miss), `could not *load* the audit` (server error).
- [ ] Loading state renders skeleton rows inside the real `<TableBody>` shape; no layout jump when data lands.
- [ ] Pagination link fires `fetchNextPage`; disabled state during fetch.
- [ ] `bun run typecheck`, biome check, `bun test screens/audit/ components/audit/` (18/18), `bun run build:dev` all clean.