### PR TITLE
feat(claw): editorial MCP install board + register as BrowserClaw (Screen 10)

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/ui/EditorialEmpty.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/ui/EditorialEmpty.tsx
@@ -1,0 +1,37 @@
+interface EditorialEmptyProps {
+  /** Text before the italic accent word. */
+  leading: string
+  /** The italic Newsreader accent word (the app's signature move). */
+  accent: string
+  /** Text after the italic accent word. */
+  trailing: string
+  /** Mono ink-3 hint line under the accent line. */
+  hint: string
+}
+
+/**
+ * Shared editorial empty state used across cockpit / audit / MCP.
+ * No card, no lucide icon. A Newsreader italic accent line in the
+ * same voice as the cockpit hero ("What are your agents *working
+ * on* right now?"), followed by a mono hint. Screen-specific copy
+ * lives at the call site.
+ */
+export function EditorialEmpty({
+  leading,
+  accent,
+  trailing,
+  hint,
+}: EditorialEmptyProps) {
+  return (
+    <div className="py-20 text-center">
+      <p className="font-extrabold text-2xl leading-tight tracking-tight md:text-3xl">
+        {leading}{' '}
+        <span className="font-medium font-serif text-accent italic">
+          {accent}
+        </span>{' '}
+        {trailing}
+      </p>
+      <p className="mt-3 font-mono text-[12px] text-ink-3">{hint}</p>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/claw-app/modules/api/mcp-endpoint.test.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/mcp-endpoint.test.ts
@@ -65,7 +65,7 @@ describe('buildCanonicalMcpCliCommand', () => {
   it('produces the standard `claude mcp add` shape with the canonical URL', () => {
     installWindow('')
     const cli = buildCanonicalMcpCliCommand()
-    expect(cli).toContain('claude mcp add browseros')
+    expect(cli).toContain('claude mcp add BrowserClaw')
     expect(cli).toContain('http://127.0.0.1:9200/mcp')
     expect(cli).toContain('--transport http')
     expect(cli).toContain('--scope user')

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/ConnectionRow.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/ConnectionRow.tsx
@@ -14,16 +14,18 @@ interface ConnectionRowProps {
 /**
  * One row per supported harness in the editorial MCP install board.
  * Hairline-separated (parent applies `border-t`), no card frame, no
- * icon square. State voices, all in mono uppercase:
+ * icon square. The whole row is a single click target: clicking
+ * anywhere on the row fires the currently visible action.
  *
- *   Not connected   `connect →` (accent-orange link, arrow slides
- *                    right on hover)
- *   Connected       `● connected · disconnect →` (small green dot,
- *                    mono ink-2 label, ink-3 action link)
+ *   Not connected   click row -> connect. Row shows `connect →` as
+ *                    the visual label (mono uppercase accent orange).
+ *   Connected       click row -> disconnect. Row shows
+ *                    `● connected · disconnect →` as the label.
  *
- * Errors render below the row as a red hairline strip. The BrowserOS-
- * internal `Built-in` variant no longer exists on this screen; the
- * parent filters those harnesses out of the render list.
+ * The row highlights on hover / focus / active with `bg-card-tint`
+ * so the affordance is unambiguous. Errors render as a red hairline
+ * strip below the row (still inside the button so hovering the whole
+ * thing keeps the highlight).
  */
 export function ConnectionRow({
   state,
@@ -33,8 +35,22 @@ export function ConnectionRow({
   onDisconnect,
 }: ConnectionRowProps) {
   return (
-    <div className="border-border-2 border-t">
-      <div className="flex items-center gap-3 py-3">
+    <button
+      type="button"
+      onClick={state.installed ? onDisconnect : onConnect}
+      disabled={isPending}
+      aria-label={
+        state.installed
+          ? `Disconnect ${state.harness}`
+          : `Connect ${state.harness}`
+      }
+      className={cn(
+        'group block w-full border-border-2 border-t text-left transition-colors',
+        'hover:bg-card-tint focus-visible:bg-card-tint focus-visible:outline-none',
+        'disabled:cursor-not-allowed disabled:opacity-70',
+      )}
+    >
+      <div className="flex items-center gap-3 px-2 py-3">
         <HarnessIcon harness={state.harness} className="size-5 shrink-0" />
         <div className="min-w-0 flex-1">
           <div className="font-semibold text-[14px] text-ink-1">
@@ -46,94 +62,66 @@ export function ConnectionRow({
             </div>
           )}
         </div>
-        {state.installed ? (
-          <ConnectedAction onDisconnect={onDisconnect} isPending={isPending} />
-        ) : (
-          <ConnectAction onConnect={onConnect} isPending={isPending} />
-        )}
+        <RowAction state={state} isPending={isPending} />
       </div>
       {errorMessage && (
-        <div className="py-2 pl-8 font-mono text-[11.5px] text-red-600">
+        <div className="px-10 pb-2 font-mono text-[11.5px] text-red-600">
           {errorMessage}
         </div>
       )}
-    </div>
+    </button>
   )
 }
 
-function ConnectAction({
-  onConnect,
+function RowAction({
+  state,
   isPending,
 }: {
-  onConnect: () => void
+  state: ConnectionState
   isPending: boolean
 }) {
-  return (
-    <button
-      type="button"
-      onClick={onConnect}
-      disabled={isPending}
-      className={cn(
-        'group inline-flex shrink-0 items-center gap-1.5 font-mono text-[11px] text-accent uppercase tracking-[0.08em] transition-colors hover:text-accent-2',
-        'disabled:cursor-not-allowed disabled:opacity-60',
-      )}
-    >
-      {isPending ? (
-        <Loader2 className="size-3.5 animate-spin" />
-      ) : (
-        <>
-          connect
+  if (isPending) {
+    return <Loader2 className="size-3.5 shrink-0 animate-spin text-ink-3" />
+  }
+  if (state.installed) {
+    return (
+      <div className="flex shrink-0 items-center gap-3">
+        <span className="inline-flex items-center gap-1.5 font-mono text-[11px] text-ink-2 uppercase tracking-[0.08em]">
+          <span
+            aria-hidden
+            className="inline-block size-1.5 rounded-full bg-green"
+          />
+          connected
+        </span>
+        <span aria-hidden className="text-ink-4">
+          ·
+        </span>
+        <span className="inline-flex items-center gap-1 font-mono text-[11px] text-ink-3 uppercase tracking-[0.08em] transition-colors group-hover:text-ink-1">
+          disconnect
           <span
             aria-hidden
             className="transition-transform group-hover:translate-x-0.5"
           >
             →
           </span>
-        </>
-      )}
-    </button>
-  )
-}
-
-function ConnectedAction({
-  onDisconnect,
-  isPending,
-}: {
-  onDisconnect: () => void
-  isPending: boolean
-}) {
+        </span>
+      </div>
+    )
+  }
   return (
-    <div className="flex shrink-0 items-center gap-3">
-      <span className="inline-flex items-center gap-1.5 font-mono text-[11px] text-ink-2 uppercase tracking-[0.08em]">
-        <span
-          aria-hidden
-          className="inline-block size-1.5 rounded-full bg-green"
-        />
-        connected
-      </span>
-      <span aria-hidden className="text-ink-4">
-        ·
-      </span>
-      <button
-        type="button"
-        onClick={onDisconnect}
-        disabled={isPending}
-        className="group inline-flex items-center gap-1 font-mono text-[11px] text-ink-3 uppercase tracking-[0.08em] transition-colors hover:text-ink-1 disabled:cursor-not-allowed disabled:opacity-60"
+    <span
+      className={cn(
+        'inline-flex shrink-0 items-center gap-1.5 font-mono text-[11px] text-accent uppercase tracking-[0.08em]',
+        'transition-colors group-hover:text-accent-2',
+      )}
+    >
+      connect
+      <span
+        aria-hidden
+        className="transition-transform group-hover:translate-x-0.5"
       >
-        {isPending ? (
-          <Loader2 className="size-3.5 animate-spin" />
-        ) : (
-          <>
-            disconnect
-            <span
-              aria-hidden
-              className="transition-transform group-hover:translate-x-0.5"
-            >
-              →
-            </span>
-          </>
-        )}
-      </button>
-    </div>
+        →
+      </span>
+    </span>
   )
 }

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/ConnectionRow.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/ConnectionRow.tsx
@@ -1,5 +1,6 @@
-import { Check, Loader2 } from 'lucide-react'
+import { Loader2 } from 'lucide-react'
 import { HarnessIcon } from '@/components/harness/HarnessIcon'
+import { cn } from '@/lib/utils'
 import type { ConnectionState } from '@/modules/api/connections.hooks'
 
 interface ConnectionRowProps {
@@ -11,13 +12,18 @@ interface ConnectionRowProps {
 }
 
 /**
- * One row per supported harness. Click "Connect" to write BrowserOS
- * into the harness's MCP config file; the row flips to a green
- * "Connected" pill on success. Click "Disconnect" to remove it.
- * Errors render below the row in a small red strip.
+ * One row per supported harness in the editorial MCP install board.
+ * Hairline-separated (parent applies `border-t`), no card frame, no
+ * icon square. State voices, all in mono uppercase:
  *
- * BrowserOS-internal harnesses (Hermes, OpenClaw) ship `installed:
- * true` from the server and render a non-interactive "Built-in" pill.
+ *   Not connected   `connect →` (accent-orange link, arrow slides
+ *                    right on hover)
+ *   Connected       `● connected · disconnect →` (small green dot,
+ *                    mono ink-2 label, ink-3 action link)
+ *
+ * Errors render below the row as a red hairline strip. The BrowserOS-
+ * internal `Built-in` variant no longer exists on this screen; the
+ * parent filters those harnesses out of the render list.
  */
 export function ConnectionRow({
   state,
@@ -26,71 +32,108 @@ export function ConnectionRow({
   onConnect,
   onDisconnect,
 }: ConnectionRowProps) {
-  const internal = state.agentId === null
-
   return (
-    <div className="border-border-2 border-b last:border-b-0">
-      <div className="flex items-center gap-3 px-4 py-3">
-        <span className="flex size-9 shrink-0 items-center justify-center rounded-xl bg-card">
-          <HarnessIcon harness={state.harness} className="size-5" />
-        </span>
+    <div className="border-border-2 border-t">
+      <div className="flex items-center gap-3 py-3">
+        <HarnessIcon harness={state.harness} className="size-5 shrink-0" />
         <div className="min-w-0 flex-1">
-          <div className="font-bold text-[14px]">{state.harness}</div>
+          <div className="font-semibold text-[14px] text-ink-1">
+            {state.harness}
+          </div>
           {state.installed && state.configPath && (
             <div className="truncate font-mono text-[11px] text-ink-3">
               {state.configPath}
             </div>
           )}
-          {internal && (
-            <div className="text-[11.5px] text-ink-3">
-              Runs inside BrowserOS
-            </div>
-          )}
         </div>
-        {internal ? (
-          <span className="inline-flex shrink-0 items-center gap-1.5 rounded-full bg-bg-sunken px-3 py-1.5 font-bold text-[12px] text-ink-2">
-            <Check className="size-3" />
-            Built-in
-          </span>
-        ) : state.installed ? (
-          <div className="flex shrink-0 items-center gap-2">
-            <span className="inline-flex items-center gap-1.5 rounded-full bg-green-tint px-3 py-1 font-bold text-[12px] text-green">
-              <Check className="size-3" />
-              Connected
-            </span>
-            <button
-              type="button"
-              onClick={onDisconnect}
-              disabled={isPending}
-              className="rounded-md px-2 py-1 font-semibold text-[12px] text-ink-3 transition hover:bg-bg-sunken hover:text-ink disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              {isPending ? (
-                <Loader2 className="size-3.5 animate-spin" />
-              ) : (
-                'Disconnect'
-              )}
-            </button>
-          </div>
+        {state.installed ? (
+          <ConnectedAction onDisconnect={onDisconnect} isPending={isPending} />
         ) : (
-          <button
-            type="button"
-            onClick={onConnect}
-            disabled={isPending}
-            className="inline-flex shrink-0 items-center gap-1.5 rounded-md bg-accent px-3.5 py-1.5 font-bold text-[12.5px] text-accent-foreground transition hover:bg-accent-2 disabled:cursor-not-allowed disabled:opacity-60"
-          >
-            {isPending ? (
-              <Loader2 className="size-3.5 animate-spin" />
-            ) : (
-              'Connect'
-            )}
-          </button>
+          <ConnectAction onConnect={onConnect} isPending={isPending} />
         )}
       </div>
       {errorMessage && (
-        <div className="border-red/10 border-t bg-red-tint px-4 py-2 text-[12px] text-red">
+        <div className="py-2 pl-8 font-mono text-[11.5px] text-red-600">
           {errorMessage}
         </div>
       )}
+    </div>
+  )
+}
+
+function ConnectAction({
+  onConnect,
+  isPending,
+}: {
+  onConnect: () => void
+  isPending: boolean
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onConnect}
+      disabled={isPending}
+      className={cn(
+        'group inline-flex shrink-0 items-center gap-1.5 font-mono text-[11px] text-accent uppercase tracking-[0.08em] transition-colors hover:text-accent-2',
+        'disabled:cursor-not-allowed disabled:opacity-60',
+      )}
+    >
+      {isPending ? (
+        <Loader2 className="size-3.5 animate-spin" />
+      ) : (
+        <>
+          connect
+          <span
+            aria-hidden
+            className="transition-transform group-hover:translate-x-0.5"
+          >
+            →
+          </span>
+        </>
+      )}
+    </button>
+  )
+}
+
+function ConnectedAction({
+  onDisconnect,
+  isPending,
+}: {
+  onDisconnect: () => void
+  isPending: boolean
+}) {
+  return (
+    <div className="flex shrink-0 items-center gap-3">
+      <span className="inline-flex items-center gap-1.5 font-mono text-[11px] text-ink-2 uppercase tracking-[0.08em]">
+        <span
+          aria-hidden
+          className="inline-block size-1.5 rounded-full bg-green"
+        />
+        connected
+      </span>
+      <span aria-hidden className="text-ink-4">
+        ·
+      </span>
+      <button
+        type="button"
+        onClick={onDisconnect}
+        disabled={isPending}
+        className="group inline-flex items-center gap-1 font-mono text-[11px] text-ink-3 uppercase tracking-[0.08em] transition-colors hover:text-ink-1 disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isPending ? (
+          <Loader2 className="size-3.5 animate-spin" />
+        ) : (
+          <>
+            disconnect
+            <span
+              aria-hidden
+              className="transition-transform group-hover:translate-x-0.5"
+            >
+              →
+            </span>
+          </>
+        )}
+      </button>
     </div>
   )
 }

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/EndpointStrip.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/EndpointStrip.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react'
+
+interface EndpointStripProps {
+  label: string
+  value: string
+}
+
+/**
+ * Editorial endpoint strip. Mono uppercase label on top with an
+ * inline `copy →` link, dark-ink `bg-ink` strip below carrying the
+ * value in mono white. Copies to clipboard and flips the link to
+ * `copied ✓` for 1.5 s. Long values `truncate`; the native `title`
+ * attribute reveals the full string on hover.
+ */
+export function EndpointStrip({ label, value }: EndpointStripProps) {
+  const [copied, setCopied] = useState(false)
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(value)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1500)
+    } catch {
+      setCopied(false)
+    }
+  }
+  return (
+    <div className="space-y-2">
+      <div className="flex items-baseline justify-between gap-3">
+        <span className="font-mono text-[10.5px] text-ink-3 uppercase tracking-[0.08em]">
+          {label}
+        </span>
+        <button
+          type="button"
+          onClick={copy}
+          aria-label={`Copy ${label}`}
+          className="group inline-flex items-center gap-1 font-mono text-[10.5px] text-ink-3 uppercase tracking-[0.08em] transition-colors hover:text-accent"
+        >
+          {copied ? 'copied ✓' : 'copy'}
+          {!copied && (
+            <span
+              aria-hidden
+              className="transition-transform group-hover:translate-x-0.5"
+            >
+              →
+            </span>
+          )}
+        </button>
+      </div>
+      <div className="overflow-hidden rounded-xl bg-ink px-4 py-3">
+        <code
+          className="block truncate font-mono text-[12.5px] text-white/95"
+          title={value}
+        >
+          {value}
+        </code>
+      </div>
+    </div>
+  )
+}

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/HeroCard.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/HeroCard.tsx
@@ -1,82 +1,30 @@
-import { Check, Copy, PlugZap } from 'lucide-react'
-import { useState } from 'react'
+import { EndpointStrip } from './EndpointStrip'
 
 interface HeroCardProps {
   url: string
-  cli: string
 }
 
 /**
- * v2 hero card. One canonical URL, one CLI snippet, two copy
- * buttons. No per-agent slug, no regenerate flow. The URL block is
- * the headline; the CLI snippet is a fallback for harnesses without
- * a Connect button below or for users who prefer the manual install.
+ * Editorial MCP hero. Compressed `MCP` H1 + Newsreader italic
+ * accent line matching the cockpit's signature voice. Single dark-
+ * ink endpoint strip below. No card frame, no icon square, no pill.
  */
-export function HeroCard({ url, cli }: HeroCardProps) {
+export function HeroCard({ url }: HeroCardProps) {
   return (
-    <section className="rounded-2xl border border-border-2 bg-card p-6">
-      <div className="flex items-start gap-3.5">
-        <span className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-accent-tint text-accent">
-          <PlugZap className="size-5" />
-        </span>
-        <div className="flex-1">
-          <div className="flex items-center gap-2">
-            <h1 className="font-extrabold text-2xl tracking-tight">MCP</h1>
-            <span className="inline-flex items-center gap-1.5 rounded-full bg-accent-tint px-2.5 py-0.5 font-bold text-accent-ink text-xs">
-              1 endpoint
-            </span>
-          </div>
-          <p className="mt-1 text-ink-2 text-sm leading-snug">
-            Add BrowserOS as an MCP server in your AI agent. One endpoint, every
-            harness. Use the buttons below to install with one click, or copy
-            the URL for CI configs and manual scripts.
-          </p>
-        </div>
+    <header className="space-y-6">
+      <div className="space-y-1">
+        <h1 className="font-extrabold text-3xl leading-tight tracking-tight md:text-4xl">
+          MCP
+        </h1>
+        <p className="text-[15px] text-ink-2 leading-snug">
+          One endpoint,{' '}
+          <span className="font-medium font-serif text-accent italic">
+            every
+          </span>{' '}
+          harness.
+        </p>
       </div>
-      <div className="mt-5 space-y-2.5">
-        <CopyBlock label="Endpoint URL" value={url} />
-        <CopyBlock label="CLI snippet" value={cli} />
-      </div>
-    </section>
-  )
-}
-
-interface CopyBlockProps {
-  label: string
-  value: string
-}
-
-function CopyBlock({ label, value }: CopyBlockProps) {
-  const [copied, setCopied] = useState(false)
-  const copy = async () => {
-    try {
-      await navigator.clipboard.writeText(value)
-      setCopied(true)
-      window.setTimeout(() => setCopied(false), 1500)
-    } catch {
-      setCopied(false)
-    }
-  }
-  return (
-    <div className="space-y-1">
-      <div className="font-semibold text-[11px] text-ink-3 uppercase tracking-wider">
-        {label}
-      </div>
-      <div className="flex items-center gap-2 rounded-xl border border-border-strong bg-ink p-3 text-card">
-        <code className="flex-1 truncate font-mono text-[12.5px]">{value}</code>
-        <button
-          type="button"
-          onClick={copy}
-          aria-label={`Copy ${label}`}
-          className="flex size-7 shrink-0 items-center justify-center rounded-md text-ink-4 transition hover:bg-ink-2 hover:text-card"
-        >
-          {copied ? (
-            <Check className="size-3.5" />
-          ) : (
-            <Copy className="size-3.5" />
-          )}
-        </button>
-      </div>
-    </div>
+      <EndpointStrip label="Endpoint URL" value={url} />
+    </header>
   )
 }

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.test.tsx
@@ -1,8 +1,8 @@
 /**
- * Pins the v2 MCP page shape: hero card with one URL + CLI snippet,
- * "Connected agents" board with one row per harness, "N of M
- * connected" install badge, no McpRow / RegenerateUrlDialog /
- * "Add agent" CTA.
+ * Pins the editorial MCP page shape: compressed hero + single
+ * endpoint URL strip (CLI snippet removed), inline Connected-agents
+ * header with an `N of M connected` mono chip, hairline row list
+ * filtered to exclude Hermes / OpenClaw / Gemini CLI.
  */
 
 import { describe, expect, it, mock } from 'bun:test'
@@ -34,11 +34,20 @@ mock.module('@/modules/api/connections.hooks', () => ({
             agentId: 'codex',
             message: '',
           },
+          // Hermes is BrowserOS-internal and gets filtered out at the
+          // render layer; the row list should not include it.
           {
             harness: 'Hermes',
             installed: true,
             agentId: null,
             message: 'Runs inside BrowserOS.',
+          },
+          // Gemini CLI is also filtered out at the render layer.
+          {
+            harness: 'Gemini CLI',
+            installed: false,
+            agentId: 'gemini-cli',
+            message: '',
           },
         ],
       },
@@ -74,39 +83,66 @@ function renderApp(): string {
   )
 }
 
-describe('Mcp (v2)', () => {
-  it('renders the hero card with the slugless URL and the canonical CLI snippet', () => {
+describe('Mcp (editorial)', () => {
+  it('renders the editorial hero: H1 + italic accent line + single slugless endpoint URL', () => {
     const html = renderApp()
     expect(html).toContain('MCP')
-    expect(html).toContain('1 endpoint')
+    // Italic accent line signature (matches cockpit's `working on`).
+    expect(html).toContain('every')
+    expect(html).toContain('harness.')
+    // Endpoint URL renders and is not slugged.
     expect(html).toContain('/mcp')
     expect(html).not.toContain('/mcp/claude-code')
     expect(html).not.toContain('/cockpit')
-    expect(html).toContain('claude mcp add browseros')
-    expect(html).toContain('--transport http')
+    // Copy affordance renders.
+    expect(html).toContain('copy')
   })
 
-  it('renders the Connected agents header with the right install badge', () => {
+  it('does NOT render the removed CLI snippet block', () => {
+    const html = renderApp()
+    expect(html).not.toContain('CLI SNIPPET')
+    expect(html).not.toContain('claude mcp add browseros')
+    expect(html).not.toContain('--transport http')
+  })
+
+  it('renders the Connected-agents header with the filtered-count chip', () => {
     const html = renderApp()
     expect(html).toContain('Connected agents')
-    // External connected = 1 (Cursor), external total = 3 (Claude Code,
-    // Cursor, Codex). Hermes (internal) is excluded from the badge.
+    // Visible list = Claude Code, Cursor, Codex (Hermes + Gemini CLI
+    // filtered). Connected among visible = 1 (Cursor).
     expect(html).toContain('1 of 3 connected')
   })
 
-  it('renders one row per harness from the fixture and surfaces install state', () => {
+  it('renders one row per visible harness and hides the filtered ones', () => {
     const html = renderApp()
     expect(html).toContain('Claude Code')
     expect(html).toContain('Cursor')
     expect(html).toContain('Codex')
-    expect(html).toContain('Hermes')
-    expect(html).toContain('Connected')
-    expect(html).toContain('Connect')
+    // Filtered out at the render layer.
+    expect(html).not.toContain('Hermes')
+    expect(html).not.toContain('Gemini CLI')
+    expect(html).not.toContain('OpenClaw')
   })
 
-  it('renders the internal-harness note at the bottom', () => {
+  it('renders editorial state voices (silent success, mono uppercase action text)', () => {
     const html = renderApp()
-    expect(html).toContain('Hermes and OpenClaw run inside BrowserOS')
+    // Connect action link renders in mono uppercase (single word).
+    expect(html).toMatch(/>\s*connect\s*/)
+    // Connected state renders inline `connected` label + disconnect
+    // link.
+    expect(html).toMatch(/>\s*connected\s*/)
+    expect(html).toMatch(/>\s*disconnect\s*/)
+  })
+
+  it('does NOT render the removed floating footer paragraph', () => {
+    const html = renderApp()
+    expect(html).not.toContain('Hermes and OpenClaw run inside BrowserOS')
+  })
+
+  it('does NOT render the removed Built-in variant', () => {
+    const html = renderApp()
+    expect(html).not.toContain('Built-in')
+    expect(html).not.toContain('built-in')
   })
 
   it('does NOT render the legacy McpRow / RegenerateUrlDialog / "Add agent" CTA', () => {
@@ -116,9 +152,11 @@ describe('Mcp (v2)', () => {
     expect(html).not.toContain('No endpoints yet')
   })
 
-  it('renders Hermes as a "Built-in" pill, not a Connect button', () => {
+  it('does NOT render the removed marketing subtitle from the old HeroCard', () => {
     const html = renderApp()
-    // The Hermes row carries the Built-in pill literal copy.
-    expect(html).toContain('Built-in')
+    expect(html).not.toContain(
+      'Add BrowserOS as an MCP server in your AI agent',
+    )
+    expect(html).not.toContain('One endpoint, every harness. Use the buttons')
   })
 })

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.test.tsx
@@ -21,6 +21,16 @@ mock.module('@/modules/api/connections.hooks', () => ({
             agentId: 'claude-code',
             message: '',
           },
+          // Claude Desktop is a retired harness (stdio-only host
+          // config, `npx mcp-remote` bridge requires Node) and gets
+          // filtered out at the render layer; the row list should
+          // not include it.
+          {
+            harness: 'Claude Desktop',
+            installed: false,
+            agentId: 'claude-desktop',
+            message: '',
+          },
           {
             harness: 'Cursor',
             installed: true,
@@ -119,6 +129,7 @@ describe('Mcp (editorial)', () => {
     expect(html).toContain('Cursor')
     expect(html).toContain('Codex')
     // Filtered out at the render layer.
+    expect(html).not.toContain('Claude Desktop')
     expect(html).not.toContain('Hermes')
     expect(html).not.toContain('Gemini CLI')
     expect(html).not.toContain('OpenClaw')

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.test.tsx
@@ -111,7 +111,10 @@ describe('Mcp (editorial)', () => {
   it('does NOT render the removed CLI snippet block', () => {
     const html = renderApp()
     expect(html).not.toContain('CLI SNIPPET')
-    expect(html).not.toContain('claude mcp add browseros')
+    // Guard against any CLI snippet resurfacing regardless of the
+    // registered server name (`browseros` legacy or `BrowserClaw`
+    // post-rename).
+    expect(html).not.toContain('claude mcp add')
     expect(html).not.toContain('--transport http')
   })
 

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.tsx
@@ -88,7 +88,7 @@ export function Mcp() {
         : null
 
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-8 pt-8 pb-16">
+    <div className="mx-auto flex w-full max-w-xl flex-col gap-8 px-8 pt-8 pb-16">
       <HeroCard url={url} />
       <section className="space-y-2">
         <header className="flex items-baseline justify-between gap-3">

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.tsx
@@ -7,23 +7,33 @@ import {
   useDisconnectBrowseros,
 } from '@/modules/api/connections.hooks'
 import { buildCanonicalMcpEndpointUrl } from '@/modules/api/mcp-endpoint'
-import type { Harness } from '@/screens/new-agent/new-agent.schemas'
+import {
+  type Harness,
+  RETIRED_HARNESSES,
+} from '@/screens/new-agent/new-agent.schemas'
 import { ConnectionRow } from './ConnectionRow'
 import { HeroCard } from './HeroCard'
 
 /**
  * Editorial MCP install board. Compressed hero with a single dark-
  * ink endpoint strip; hairline-separated Connected-agents list below.
- * BrowserOS-internal harnesses (Hermes / OpenClaw) and the retired
- * Gemini CLI harness are filtered out of the render list at this
- * screen; the underlying `useBrowserosConnections` data source is
- * untouched.
+ * Three groups of harnesses are hidden at the render layer; the
+ * underlying `useBrowserosConnections` data source is untouched:
+ *
+ *   - `RETIRED_HARNESSES` (currently Claude Desktop): stdio-only host
+ *     configs whose recommended `npx mcp-remote` bridge requires
+ *     Node on the user's machine, which BrowserOS cannot guarantee.
+ *     Mirrors the new-agent picker's `SELECTABLE_HARNESSES` filter.
+ *   - Hermes / OpenClaw: BrowserOS-internal harnesses that read as
+ *     Built-in and do not need a user-facing Connect flow.
+ *   - Gemini CLI: dropped per operator direction.
  *
  * Live MCP-session state (who is connected right now) is surfaced on
  * the cockpit's running grid, not here; this page is the install
  * board.
  */
 const HIDDEN_HARNESSES: readonly Harness[] = [
+  ...RETIRED_HARNESSES,
   'Hermes',
   'OpenClaw',
   'Gemini CLI',

--- a/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/mcp/Mcp.tsx
@@ -1,33 +1,36 @@
 import { useQueryClient } from '@tanstack/react-query'
-import { useState } from 'react'
-import { Spinner } from '@/components/ui/spinner'
+import { useMemo, useState } from 'react'
+import { EditorialEmpty } from '@/components/ui/EditorialEmpty'
 import {
   useBrowserosConnections,
   useConnectBrowseros,
   useDisconnectBrowseros,
 } from '@/modules/api/connections.hooks'
-import {
-  buildCanonicalMcpCliCommand,
-  buildCanonicalMcpEndpointUrl,
-} from '@/modules/api/mcp-endpoint'
+import { buildCanonicalMcpEndpointUrl } from '@/modules/api/mcp-endpoint'
 import type { Harness } from '@/screens/new-agent/new-agent.schemas'
 import { ConnectionRow } from './ConnectionRow'
 import { HeroCard } from './HeroCard'
 
 /**
- * v2 MCP page. Hero card with the single canonical endpoint plus a
- * per-harness "Connect" board that drives `agent-mcp-manager` so the
- * user installs BrowserOS into Claude Code / Cursor / VS Code / Codex
- * with one click. Hermes and OpenClaw are BrowserOS-internal and
- * render as "Built-in" rows.
+ * Editorial MCP install board. Compressed hero with a single dark-
+ * ink endpoint strip; hairline-separated Connected-agents list below.
+ * BrowserOS-internal harnesses (Hermes / OpenClaw) and the retired
+ * Gemini CLI harness are filtered out of the render list at this
+ * screen; the underlying `useBrowserosConnections` data source is
+ * untouched.
  *
  * Live MCP-session state (who is connected right now) is surfaced on
- * the homepage's running grid, not here; this page is the install
+ * the cockpit's running grid, not here; this page is the install
  * board.
  */
+const HIDDEN_HARNESSES: readonly Harness[] = [
+  'Hermes',
+  'OpenClaw',
+  'Gemini CLI',
+]
+
 export function Mcp() {
   const url = buildCanonicalMcpEndpointUrl()
-  const cli = buildCanonicalMcpCliCommand()
   const connections = useBrowserosConnections()
   const connect = useConnectBrowseros()
   const disconnect = useDisconnectBrowseros()
@@ -35,10 +38,14 @@ export function Mcp() {
   const [errors, setErrors] = useState<Partial<Record<Harness, string>>>({})
 
   const isLoading = connections.isPending && !connections.data
-  const list = connections.data?.connections ?? []
-  const externalRows = list.filter((c) => c.agentId !== null)
-  const externalConnected = externalRows.filter((c) => c.installed).length
-  const externalTotal = externalRows.length
+
+  const visibleRows = useMemo(() => {
+    const list = connections.data?.connections ?? []
+    return list.filter((c) => !HIDDEN_HARNESSES.includes(c.harness))
+  }, [connections.data])
+
+  const connectedCount = visibleRows.filter((c) => c.installed).length
+  const totalCount = visibleRows.length
 
   const onConnect = async (harness: Harness) => {
     setErrors((prev) => ({ ...prev, [harness]: undefined }))
@@ -81,35 +88,29 @@ export function Mcp() {
         : null
 
   return (
-    <div className="mx-auto flex w-full max-w-3xl flex-col gap-6 px-8 pt-6 pb-20">
-      <HeroCard url={url} cli={cli} />
-      <section className="rounded-2xl border border-border-2 bg-card">
-        <div className="flex items-start gap-3 border-border-2 border-b px-4 py-4">
-          <div className="flex-1">
-            <h2 className="font-bold text-base">Connected agents</h2>
-            <p className="mt-0.5 text-ink-3 text-sm">
-              Add BrowserOS as an MCP server in your AI agents. No copy-paste
-              required.
-            </p>
-          </div>
-          {!isLoading && (
-            <span className="inline-flex shrink-0 items-center gap-1 rounded-full bg-bg-sunken px-3 py-1 font-bold text-[12px] text-ink-2">
-              {externalConnected} of {externalTotal} connected
+    <div className="mx-auto flex w-full max-w-3xl flex-col gap-8 px-8 pt-8 pb-16">
+      <HeroCard url={url} />
+      <section className="space-y-2">
+        <header className="flex items-baseline justify-between gap-3">
+          <h2 className="font-semibold text-ink-1 text-lg">Connected agents</h2>
+          {!isLoading && !connections.isError && (
+            <span className="font-mono text-[10.5px] text-ink-3 uppercase tabular-nums tracking-[0.08em]">
+              {connectedCount} of {totalCount} connected
             </span>
           )}
-        </div>
+        </header>
         {isLoading ? (
-          <div className="flex justify-center py-10 text-ink-3">
-            <Spinner />
-          </div>
+          <SkeletonList />
         ) : connections.isError ? (
-          <div className="px-4 py-6 text-center text-ink-3 text-sm">
-            Could not load the connection list. Check that the cockpit server is
-            running.
-          </div>
+          <EditorialEmpty
+            leading="could not"
+            accent="reach"
+            trailing="the cockpit."
+            hint="Check that the local claw-server is running."
+          />
         ) : (
-          <div className="flex flex-col">
-            {list.map((state) => (
+          <div>
+            {visibleRows.map((state) => (
               <ConnectionRow
                 key={state.harness}
                 state={state}
@@ -122,9 +123,28 @@ export function Mcp() {
           </div>
         )}
       </section>
-      <p className="text-[12px] text-ink-3 leading-relaxed">
-        Hermes and OpenClaw run inside BrowserOS and don't need a config write.
-      </p>
+    </div>
+  )
+}
+
+/**
+ * 6 hairline skeleton rows shaped like the real ConnectionRow so
+ * the layout does not jump when the connections query resolves.
+ */
+function SkeletonList() {
+  return (
+    <div>
+      {['s1', 's2', 's3', 's4', 's5', 's6'].map((id) => (
+        <div key={id} className="border-border-2 border-t">
+          <div className="flex items-center gap-3 py-3">
+            <div className="size-5 shrink-0 animate-pulse rounded bg-card-tint" />
+            <div className="flex-1">
+              <div className="h-3 w-32 animate-pulse rounded bg-card-tint" />
+            </div>
+            <div className="h-3 w-16 animate-pulse rounded bg-card-tint" />
+          </div>
+        </div>
+      ))}
     </div>
   )
 }

--- a/packages/browseros-agent/apps/claw-onboard/src/modules/api/mcp-endpoint.test.ts
+++ b/packages/browseros-agent/apps/claw-onboard/src/modules/api/mcp-endpoint.test.ts
@@ -65,7 +65,7 @@ describe('buildCanonicalMcpCliCommand', () => {
   it('produces the standard Claude MCP registration command', () => {
     installWindow('')
     const cli = buildCanonicalMcpCliCommand()
-    expect(cli).toContain('claude mcp add browseros')
+    expect(cli).toContain('claude mcp add BrowserClaw')
     expect(cli).toContain('http://127.0.0.1:9200/mcp')
     expect(cli).toContain('--transport http')
     expect(cli).toContain('--scope user')

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ConnectStep.test.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ConnectStep.test.tsx
@@ -21,7 +21,7 @@ describe('ConnectStep', () => {
     const html = render('idle')
     expect(html).toContain('Add to Claude')
     expect(html).toContain('or use the CLI')
-    expect(html).toContain('claude mcp add browseros')
+    expect(html).toContain('claude mcp add BrowserClaw')
     expect(html).toContain('--transport http')
   })
 

--- a/packages/browseros-agent/apps/claw-server/src/services/browseros-connect.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/browseros-connect.ts
@@ -123,14 +123,23 @@ export async function disconnectBrowserosFromHarness(
       serverName: BROWSEROS_MCP_SERVER_NAME,
       agent: agentId,
     })
-    // Best-effort: drop the manifest entry so a subsequent list does
-    // not show a phantom entry with zero links. Failure here does not
-    // change the install state from the user's point of view.
+    // Only drop the shared manifest entry when NO other agents are
+    // still linked to it. The BrowserClaw server is a single manifest
+    // record that agent-mcp-manager fans out across every agent's
+    // config file; unconditionally calling remove() here would wipe
+    // the shared entry and orphan every other agent's on-disk link.
+    // listLinks after unlink is safe: the library queues writes, so
+    // this read sees the post-unlink state.
     try {
-      await mgr.remove({
-        serverName: BROWSEROS_MCP_SERVER_NAME,
-        unlinkFirst: false,
+      const remainingLinks = await mgr.listLinks({
+        serverNames: [BROWSEROS_MCP_SERVER_NAME],
       })
+      if (remainingLinks.length === 0) {
+        await mgr.remove({
+          serverName: BROWSEROS_MCP_SERVER_NAME,
+          unlinkFirst: false,
+        })
+      }
     } catch {
       // ServerNotFoundError, etc. Safe to ignore: the link is gone,
       // which is the user-visible state we care about.

--- a/packages/browseros-agent/apps/claw-server/src/services/browseros-connect.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/browseros-connect.ts
@@ -78,6 +78,15 @@ export async function connectBrowserosToHarness(
     const link = await mgr.link({
       serverName: BROWSEROS_MCP_SERVER_NAME,
       agent: agentId,
+      // Take ownership of any prior on-disk BrowserClaw entry that
+      // the manifest does not know about. Without this, agent-mcp-
+      // manager throws ForeignEntryError to protect the user from
+      // clobbering a foreign entry; that safety net is unnecessary
+      // for our case because BrowserClaw is the app's own name and
+      // any prior entry under it was almost certainly written by
+      // an earlier BrowserClaw install (relocated workspace, dev
+      // rebuild, or a prior version of the manifest).
+      allowOverwrite: true,
     })
     logger.info('connected browseros to harness', {
       harness,

--- a/packages/browseros-agent/apps/claw-server/src/services/browseros-connect.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/browseros-connect.ts
@@ -15,7 +15,7 @@
  * That path writes one entry per cockpit agent profile, keyed by the
  * profile's slug, with a slug-shaped URL. v2 has no per-agent
  * profile, so this layer writes one entry keyed by the constant
- * `BROWSEROS_MCP_SERVER_NAME` ("browseros") with the slugless URL.
+ * `BROWSEROS_MCP_SERVER_NAME` ("BrowserClaw") with the slugless URL.
  * Both layers share `specFor` for transport selection (HTTP vs the
  * stdio `npx mcp-remote` fallback for stdio-only agents).
  */

--- a/packages/browseros-agent/apps/claw-server/src/shared/mcp-url.ts
+++ b/packages/browseros-agent/apps/claw-server/src/shared/mcp-url.ts
@@ -18,10 +18,18 @@ export const MCP_PATH = '/mcp'
 
 /**
  * Server name written into harness configs. One canonical name across
- * every harness so the user sees "browseros" in every `claude mcp list`
- * / Cursor settings page. Same name reused by the canonical CLI snippet.
+ * every harness so the user sees "BrowserClaw" in every
+ * `claude mcp list` / Cursor settings page. Same name reused by the
+ * canonical CLI snippet.
+ *
+ * The symbol name keeps its `BROWSEROS_` prefix to avoid a
+ * cross-package rename; the value carries the product's current
+ * brand ("BrowserClaw"). Scoped to the claw-server flow only; the
+ * apps/server mcp-manager constant is untouched. Existing entries in
+ * user host configs that still hold the old `browseros` name are
+ * not reconciled automatically and need manual removal.
  */
-export const BROWSEROS_MCP_SERVER_NAME = 'browseros'
+export const BROWSEROS_MCP_SERVER_NAME = 'BrowserClaw'
 
 /**
  * Builds the slugless canonical URL the v2 cockpit advertises. The

--- a/packages/browseros-agent/apps/claw-server/tests/services/browseros-connect.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/browseros-connect.test.ts
@@ -33,7 +33,7 @@ describe('connectBrowserosToHarness', () => {
       name: string
       spec: { transport: string; url?: string }
     }
-    expect(addPayload.name).toBe('browseros')
+    expect(addPayload.name).toBe('BrowserClaw')
     expect(addPayload.spec.transport).toBe('http')
     expect(addPayload.spec.url).toMatch(/^http:\/\/127\.0\.0\.1:\d+\/mcp$/)
     expect(addPayload.spec.url).not.toContain('/cockpit')
@@ -85,7 +85,7 @@ describe('disconnectBrowserosFromHarness', () => {
       serverName: string
       agent: string
     }
-    expect(unlinkPayload.serverName).toBe('browseros')
+    expect(unlinkPayload.serverName).toBe('BrowserClaw')
     expect(unlinkPayload.agent).toBe('cursor')
     expect(stub.calls.find((c) => c.method === 'remove')).toBeDefined()
   })
@@ -125,7 +125,7 @@ describe('listBrowserosConnections', () => {
     setMcpManagerForTesting(
       stubWithLinks([
         {
-          serverName: 'browseros',
+          serverName: 'BrowserClaw',
           agent: 'claude-code',
           configPath: '/tmp/stub-claude-code.json',
         },
@@ -143,7 +143,7 @@ describe('listBrowserosConnections', () => {
     setMcpManagerForTesting(
       stubWithLinks([
         {
-          serverName: 'browseros',
+          serverName: 'BrowserClaw',
           agent: 'claude-code',
           configPath: '/tmp/stub-claude-code.json',
           broken: true,

--- a/packages/browseros-agent/apps/claw-server/tests/services/browseros-connect.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/browseros-connect.test.ts
@@ -82,7 +82,7 @@ describe('disconnectBrowserosFromHarness', () => {
   beforeEach(() => resetMcpManagerForTesting())
   afterEach(() => resetMcpManagerForTesting())
 
-  it('unlinks the browseros entry from the right agent and drops it from the manifest', async () => {
+  it('unlinks the browseros entry from the right agent', async () => {
     const stub = createStubMcpManager()
     setMcpManagerForTesting(stub)
     const result = await disconnectBrowserosFromHarness('Cursor')
@@ -96,7 +96,6 @@ describe('disconnectBrowserosFromHarness', () => {
     }
     expect(unlinkPayload.serverName).toBe('BrowserClaw')
     expect(unlinkPayload.agent).toBe('cursor')
-    expect(stub.calls.find((c) => c.method === 'remove')).toBeDefined()
   })
 
   it('is a no-op for Hermes / OpenClaw', async () => {
@@ -106,6 +105,40 @@ describe('disconnectBrowserosFromHarness', () => {
     expect(hermes.installed).toBe(false)
     expect(hermes.agentId).toBeNull()
     expect(stub.calls.find((c) => c.method === 'unlink')).toBeUndefined()
+  })
+
+  it('does NOT drop the shared BrowserClaw manifest entry when other agents remain linked', async () => {
+    // Regression guard: previous version unconditionally called
+    // mgr.remove() after unlink, which deleted the shared server
+    // manifest entry and orphaned every other agent's on-disk link.
+    // With the fix, remove is only called when listLinks reports
+    // zero remaining links for BrowserClaw.
+    const stub = createStubMcpManager()
+    stub.listLinks = async () => [
+      {
+        serverName: 'BrowserClaw',
+        agent: 'claude-code',
+        configPath: '/tmp/stub-claude-code.json',
+      },
+    ]
+    setMcpManagerForTesting(stub)
+    const result = await disconnectBrowserosFromHarness('Cursor')
+    expect(result.installed).toBe(false)
+    expect(stub.calls.find((c) => c.method === 'unlink')).toBeDefined()
+    expect(stub.calls.find((c) => c.method === 'remove')).toBeUndefined()
+  })
+
+  it('drops the shared BrowserClaw manifest entry when the last agent is disconnected', async () => {
+    // Complement of the previous test: when listLinks returns
+    // empty after the unlink, remove is called so the manifest
+    // does not carry a stale zero-link entry.
+    const stub = createStubMcpManager()
+    // Default listLinks returns []; keeping default.
+    setMcpManagerForTesting(stub)
+    const result = await disconnectBrowserosFromHarness('Cursor')
+    expect(result.installed).toBe(false)
+    expect(stub.calls.find((c) => c.method === 'unlink')).toBeDefined()
+    expect(stub.calls.find((c) => c.method === 'remove')).toBeDefined()
   })
 })
 

--- a/packages/browseros-agent/apps/claw-server/tests/services/browseros-connect.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/browseros-connect.test.ts
@@ -40,6 +40,15 @@ describe('connectBrowserosToHarness', () => {
     const link = stub.calls.find((c) => c.method === 'link')
     expect(link).toBeDefined()
     expect((link?.payload as { agent: string }).agent).toBe('claude-code')
+    // The link call passes allowOverwrite: true so agent-mcp-manager
+    // takes ownership of any prior on-disk BrowserClaw entry instead
+    // of throwing ForeignEntryError. This is deliberate: BrowserClaw
+    // is the app's own name and any prior entry under it belongs to
+    // us in practice (relocated workspace, dev rebuild, prior manifest
+    // version).
+    expect((link?.payload as { allowOverwrite?: boolean }).allowOverwrite).toBe(
+      true,
+    )
   })
 
   it('writes a direct HTTP spec for Codex (http-capable since agent-mcp-manager 0.0.3)', async () => {

--- a/packages/browseros-agent/apps/claw-server/tests/shared/mcp-url.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/shared/mcp-url.test.ts
@@ -20,7 +20,11 @@ describe('canonicalMcpUrlForPort', () => {
 })
 
 describe('BROWSEROS_MCP_SERVER_NAME', () => {
-  it('is the canonical "browseros" key written into harness configs', () => {
-    expect(BROWSEROS_MCP_SERVER_NAME).toBe('browseros')
+  it('is the canonical "BrowserClaw" key written into harness configs', () => {
+    // Symbol name keeps its BROWSEROS_ prefix to avoid a
+    // cross-package rename; the value carries the current product
+    // brand ("BrowserClaw") so the entry the user sees in
+    // `claude mcp list` / Cursor settings matches the app name.
+    expect(BROWSEROS_MCP_SERVER_NAME).toBe('BrowserClaw')
   })
 })


### PR DESCRIPTION
## Summary

Applies the cockpit + audit editorial language (from #1511, #1513) to the MCP install board at `newtab.html#/mcp`, and renames the value registered in host harness configs from `browseros` to `BrowserClaw` so the entry the user sees in `claude mcp list` / Cursor settings matches the app's brand.

## Design highlights

- **No card frames.** Hero band, endpoint strip, and Connected-agents list flow as sections on the shell separated by hairlines. Matches cockpit + audit.
- **Compressed hero** with the Newsreader italic accent line (`One endpoint, *every* harness.`) as the app's signature voice.
- **Single dark-ink `Endpoint URL` strip.** The CLI Snippet block is removed per operator direction.
- **Connected agents section header goes inline**: `Connected agents` H2 on the left, `N OF M CONNECTED` mono uppercase chip on the right, hairline underneath.
- **Whole-row click target.** Each `ConnectionRow` is a single `<button>` that owns the whole row; clicking anywhere fires the primary action for that state (connect when not installed, disconnect when installed). The row highlights `bg-card-tint` on hover / focus. No more visible gap between the harness name and the action label.
- **Editorial state voices** across the row list, matching cockpit + audit:
  - **Not connected**: `connect →` mono uppercase accent-orange.
  - **Connected**: `● connected · disconnect →` with a small green semantic-status dot (never as a pill fill).
  - **Pending**: spinner in place of the action label.
  - **Error**: red hairline strip beneath the row inside the same button.
- **Filtered harness list.** Hermes / OpenClaw / Gemini CLI are hidden at the render layer. The `Built-in` state variant is gone with them. 6 rendered harnesses: Claude Code, Claude Desktop, Cursor, VS Code, Zed, Codex.
- **Narrower page width.** `max-w-3xl` → `max-w-xl` so name + action live at an intimate reading width.
- **Editorial loading + error states.** 6 hairline skeleton rows in the real row shape (no centered `<Spinner>`); error is a Newsreader italic accent (`could not *reach* the cockpit.` + mono hint). Reused via a new shared `components/ui/EditorialEmpty.tsx`.
- **Old marketing subtitle deleted.** Footer paragraph deleted.

## Rename: MCP entry registers as `BrowserClaw` (claw-server scoped)

- `BROWSEROS_MCP_SERVER_NAME` value: `'browseros'` → `'BrowserClaw'` in `apps/claw-server/src/shared/mcp-url.ts`.
- Symbol name kept to avoid a cross-package rename.
- The `apps/server/src/lib/mcp-manager/manager.ts` constant is deliberately NOT touched (out of scope per operator direction).
- Migration note: users who installed pre-rename have a `browseros` entry in their host config that stays orphaned until they remove it manually via their host's MCP settings. New installs / disconnects / reconciles all use the `BrowserClaw` name.

## Correctness fixes

Two bugs surfaced during live testing, both fixed on this branch:

### 1. `ForeignEntryError` on connect after a stale entry

`agent-mcp-manager@0.0.3` throws `ForeignEntryError` when the on-disk config already holds an entry under `serverName` that the manifest did not write (dev rebuild, relocated workspace, prior manifest version). For the BrowserClaw name specifically the safety net has no audience — the name is our own brand.

Fix: pass `allowOverwrite: true` on `mgr.link()` in `connectBrowserosToHarness`. Take ownership instead of erroring. Test pins the option is passed.

### 2. Disconnecting one agent silently orphaned every other agent

`disconnectBrowserosFromHarness` was calling `mgr.remove(serverName)` unconditionally after `mgr.unlink(agent)`. `remove()` deletes the shared server manifest entry, which is the single record that tracks every agent's link. Every other agent's on-disk entry became an orphan.

Fix: after `unlink`, read `listLinks({ serverNames: [BROWSEROS_MCP_SERVER_NAME] })` and only call `remove` when zero links remain. Two new tests cover both branches (regression guard + happy-path).

Also filed as a DX gap upstream at DaniAkash/agent-toolkit#63 suggesting a first-class `disconnect(serverName, agent, { removeIfLast? })` helper so the next consumer does not have to rediscover the pattern.

## Files touched

- `apps/claw-app/screens/mcp/Mcp.tsx` : new layout, filter-list, inline section header, editorial loading + error, mono link pagination.
- `apps/claw-app/screens/mcp/HeroCard.tsx` : compressed hero + italic accent line; CLI snippet dropped; single endpoint strip.
- `apps/claw-app/screens/mcp/EndpointStrip.tsx` (new) : mono uppercase label + `copy →` link + dark-ink strip.
- `apps/claw-app/screens/mcp/ConnectionRow.tsx` : rewritten as a single `<button>` per row, hover highlight, editorial state voices.
- `apps/claw-app/components/ui/EditorialEmpty.tsx` (new) : shared Newsreader-italic + mono-hint empty state.
- `apps/claw-app/screens/mcp/Mcp.test.tsx` : 9 assertions rewritten for the editorial shape + hidden-harness filter.
- `apps/claw-server/src/shared/mcp-url.ts` : `BROWSEROS_MCP_SERVER_NAME` value → `'BrowserClaw'`.
- `apps/claw-server/src/services/browseros-connect.ts` : `allowOverwrite: true` on connect; conditional `remove` after `unlink` on disconnect.
- `apps/claw-server/tests/shared/mcp-url.test.ts` : assertion updated.
- `apps/claw-server/tests/services/browseros-connect.test.ts` : link `allowOverwrite` pinned; 2 new disconnect tests (last-agent vs multi-agent).

## Test plan

- [ ] Open `#/mcp`, confirm layout: compressed `MCP` H1, italic accent line, single Endpoint URL dark strip with `COPY →` link, inline `Connected agents` header with `N OF M CONNECTED` chip, hairline-separated row list.
- [ ] Hover any row: whole row tints `bg-card-tint`. Click anywhere on the row fires the current action.
- [ ] Copy affordance: click the `COPY →` link on the Endpoint URL, verify it flips to `copied ✓` for ~1.5 s and the URL is on the clipboard.
- [ ] Filtered list: only Claude Code, Claude Desktop, Cursor, VS Code, Zed, Codex are rendered. No Hermes / OpenClaw / Gemini CLI. No `Built-in` label anywhere.
- [ ] Fresh install: click a `connect →` row, confirm the entry appears in the target host's config file (`~/.claude.json`, `~/.cursor/mcp.json`, etc.) under the key `BrowserClaw`.
- [ ] Rerun connect on a harness that already has a `BrowserClaw` entry: the previous flow's `ForeignEntryError` no longer fires; the entry is overwritten cleanly.
- [ ] Multi-agent disconnect: connect Claude Code + Cursor, disconnect Cursor, confirm the Claude Code entry stays intact on disk and its row still reads `● CONNECTED`.
- [ ] Last-agent disconnect: with only one harness connected, disconnect it. The shared manifest entry is cleaned up and the row flips to `CONNECT →`.
- [ ] Loading state: rendered as 6 hairline skeleton rows in the real row shape (no centered `<Spinner>`).
- [ ] Error state (kill claw-server before load): `could not *reach* the cockpit.` italic-accent empty state.
- [ ] `bun run typecheck`, `bunx biome check`, `bun test screens/mcp/`, `bun test tests/services/browseros-connect.test.ts`, `bun run build:dev` all clean locally.