### PR TITLE
feat(browseros): extension release pipeline in bos_build

### DIFF
--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -1,0 +1,136 @@
+name: Release Extensions
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version stamped on every selected extension (e.g., 0.0.118)"
+        required: true
+        type: string
+      extension:
+        description: "Extension to release"
+        required: true
+        type: choice
+        options:
+          - all
+          - agent
+          - controller
+          - bugreporter
+          - browserclaw
+        default: "all"
+      branch:
+        description: "Branch override (checkout ref for in-repo builds, clone branch for external repos)"
+        required: false
+        type: string
+        default: ""
+      channel:
+        description: "Update-feed channel to regenerate"
+        required: true
+        type: choice
+        options:
+          - alpha
+          - prod
+        default: "alpha"
+      publish_manifest:
+        description: "Write regenerated update manifests to R2 (unchecked = dry run)"
+        required: false
+        type: boolean
+        default: false
+
+concurrency:
+  group: release-extensions
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.branch || github.ref }}
+
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v8.2.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: "20"
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Verify Chrome is available
+        run: google-chrome --version
+
+      - name: Build release command
+        id: cmd
+        env:
+          VERSION: ${{ inputs.version }}
+          EXTENSION: ${{ inputs.extension }}
+          BRANCH: ${{ inputs.branch }}
+          CHANNEL: ${{ inputs.channel }}
+          PUBLISH_MANIFEST: ${{ inputs.publish_manifest }}
+        run: |
+          set -euo pipefail
+          CMD="uv run browseros ext release --version \"$VERSION\" --channel \"$CHANNEL\""
+          if [ "$EXTENSION" != "all" ]; then
+            CMD="$CMD --name \"$EXTENSION\""
+          fi
+          if [ -n "$BRANCH" ]; then
+            CMD="$CMD --branch \"$BRANCH\""
+          fi
+          if [ "$PUBLISH_MANIFEST" = "true" ]; then
+            CMD="$CMD --publish-manifest"
+          fi
+          echo "command=$CMD" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Release command"
+            echo '```bash'
+            echo "$CMD"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Run extension release
+        working-directory: packages/browseros
+        env:
+          # Cloning private external extension repos
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
+
+          # Cloudflare R2 (crx upload + feed publisher)
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+
+          # Extension signing keys
+          BROWSEROS_AGENT_V2_KEY: ${{ secrets.BROWSEROS_AGENT_V2_KEY }}
+          BROWSEROS_CONTROLLER_KEY: ${{ secrets.BROWSEROS_CONTROLLER_KEY }}
+          BUGREPORTER_KEY: ${{ secrets.BUGREPORTER_KEY }}
+          BROWSERCLAW_KEY: ${{ secrets.BROWSERCLAW_KEY }}
+
+          # Build-time env consumed by the extension bundles
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          VITE_PUBLIC_SENTRY_DSN: ${{ secrets.VITE_PUBLIC_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          VITE_PUBLIC_POSTHOG_KEY: ${{ secrets.VITE_PUBLIC_POSTHOG_KEY }}
+          VITE_PUBLIC_POSTHOG_HOST: ${{ secrets.VITE_PUBLIC_POSTHOG_HOST }}
+          VITE_PUBLIC_BROWSEROS_API: https://api.browseros.com
+          NODE_ENV: production
+        run: ${{ steps.cmd.outputs.command }}
+
+      - name: Upload CRX artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: extension-release-${{ inputs.extension }}-${{ inputs.version }}
+          path: packages/browseros/build/extensions/dist/*.crx
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -68,37 +68,15 @@ jobs:
       - name: Verify Chrome is available
         run: google-chrome --version
 
-      - name: Build release command
-        id: cmd
+      - name: Run extension release
+        working-directory: packages/browseros
         env:
           VERSION: ${{ inputs.version }}
           EXTENSION: ${{ inputs.extension }}
           BRANCH: ${{ inputs.branch }}
           CHANNEL: ${{ inputs.channel }}
           PUBLISH_MANIFEST: ${{ inputs.publish_manifest }}
-        run: |
-          set -euo pipefail
-          CMD="uv run browseros ext release --version \"$VERSION\" --channel \"$CHANNEL\""
-          if [ "$EXTENSION" != "all" ]; then
-            CMD="$CMD --name \"$EXTENSION\""
-          fi
-          if [ -n "$BRANCH" ]; then
-            CMD="$CMD --branch \"$BRANCH\""
-          fi
-          if [ "$PUBLISH_MANIFEST" = "true" ]; then
-            CMD="$CMD --publish-manifest"
-          fi
-          echo "command=$CMD" >> "$GITHUB_OUTPUT"
-          {
-            echo "### Release command"
-            echo '```bash'
-            echo "$CMD"
-            echo '```'
-          } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Run extension release
-        working-directory: packages/browseros
-        env:
           # Cloning private external extension repos
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
 
@@ -124,7 +102,27 @@ jobs:
           VITE_PUBLIC_POSTHOG_HOST: ${{ secrets.VITE_PUBLIC_POSTHOG_HOST }}
           VITE_PUBLIC_BROWSEROS_API: https://api.browseros.com
           NODE_ENV: production
-        run: ${{ steps.cmd.outputs.command }}
+        # Args are quoted at execution time (never baked into a command
+        # string) so a crafted dispatch input cannot break into this shell.
+        run: |
+          set -euo pipefail
+          args=(--version "$VERSION" --channel "$CHANNEL")
+          if [ "$EXTENSION" != "all" ]; then
+            args+=(--name "$EXTENSION")
+          fi
+          if [ -n "$BRANCH" ]; then
+            args+=(--branch "$BRANCH")
+          fi
+          if [ "$PUBLISH_MANIFEST" = "true" ]; then
+            args+=(--publish-manifest)
+          fi
+          {
+            echo "### Release command"
+            echo '```bash'
+            echo "browseros ext release ${args[*]}"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          uv run browseros ext release "${args[@]}"
 
       - name: Upload CRX artifacts
         if: always()

--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Upload CRX artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: extension-release-${{ inputs.extension }}-${{ inputs.version }}
           path: packages/browseros/build/extensions/dist/*.crx

--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ AGENTS.md
 **/resources/binaries/
 
 packages/browseros/build/tools/
+packages/browseros/build/extensions/
 
 # AI SDK DevTools traces
 .devtools/

--- a/packages/browseros/bos_build/browseros.py
+++ b/packages/browseros/bos_build/browseros.py
@@ -13,7 +13,7 @@ Usage:
 """
 import typer
 
-from .cli import build, dev, ota, product, release, source
+from .cli import build, dev, ext, ota, product, release, source
 
 app = typer.Typer(
     help="BrowserOS Build System",
@@ -32,6 +32,7 @@ app.add_typer(source.app, name="source", help="Chromium checkout provisioning")
 app.add_typer(product.app, name="product", help="Product definitions")
 app.add_typer(dev.app, name="dev", help="Dev patch management")
 app.add_typer(release.app, name="release", help="Release automation")
+app.add_typer(ext.app, name="ext", help="Extension packaging & release")
 app.add_typer(ota.app, name="ota", help="OTA update automation")
 
 

--- a/packages/browseros/bos_build/cli/ext.py
+++ b/packages/browseros/bos_build/cli/ext.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""Extension packaging & release commands.
+
+Kept in its own module (browseros.py just add_typers it) mirroring
+cli/release_feeds.py; context/execute helpers stay local for the same
+circular-import reason documented there.
+"""
+
+from typing import List, Optional
+
+import typer
+
+from ..core.context import Context
+from ..core.runner import StepExecutionError, run as run_steps
+from ..lib.notify import slack_subscriber
+from ..lib.paths import get_package_root
+from ..lib.utils import log_error
+from ..release.extensions.release import build_pipeline
+from ..release.extensions.specs import EXTENSION_SPECS
+
+app = typer.Typer(
+    help="Extension packaging & release",
+    pretty_exceptions_enable=False,
+    pretty_exceptions_show_locals=False,
+)
+
+_NAMES = ", ".join(spec.name for spec in EXTENSION_SPECS)
+
+
+def _create_context(version: str) -> Context:
+    root = get_package_root()
+    try:
+        ctx = Context(
+            root_dir=root,
+            chromium_src=root,
+            architecture="",
+            build_type="release",
+            product="browseros",
+        )
+    except ValueError as e:
+        log_error(str(e))
+        raise typer.Exit(1)
+    ctx.release_version = version
+    return ctx
+
+
+def _execute(ctx: Context, steps: List) -> None:
+    try:
+        run_steps(ctx, steps, name="ext-release", subscribers=(slack_subscriber,))
+    except StepExecutionError as e:
+        log_error(str(e))
+        raise typer.Exit(1)
+    except KeyboardInterrupt:
+        raise typer.Exit(130)
+
+
+@app.command("release")
+def release(
+    version: str = typer.Option(
+        ..., "--version", "-v", help="Version stamped on every selected extension"
+    ),
+    name: Optional[str] = typer.Option(
+        None, "--name", "-n", help=f"One extension ({_NAMES}); default: all"
+    ),
+    branch: Optional[str] = typer.Option(
+        None,
+        "--branch",
+        help="Branch override for external-repo extensions "
+        "(in-repo extensions build the current working tree)",
+    ),
+    channel: str = typer.Option(
+        "alpha", "--channel", "-c", help="Feed channel to regenerate: alpha or prod"
+    ),
+    publish_manifest: bool = typer.Option(
+        False,
+        "--publish-manifest",
+        help="Write regenerated update manifests to R2 "
+        "(default is a dry run: full files + diff vs live)",
+    ),
+    chrome_binary: Optional[str] = typer.Option(
+        None, "--chrome-binary", help="Chrome binary for --pack-extension"
+    ),
+):
+    """Build, pack, upload extension CRXs, then regenerate the update feeds.
+
+    In-repo extensions (agent, browserclaw) build from this working tree and
+    stamp --version into their package.json. The CRX uploads immediately;
+    the manifest trio goes through the feeds publisher rails and is only
+    written with --publish-manifest.
+
+    \b
+    Release the agent to alpha (manifest dry-run):
+      browseros ext release --version 0.0.118 --name agent
+
+    \b
+    Release + publish the alpha manifests:
+      browseros ext release --version 0.0.118 --name agent --publish-manifest
+    """
+    try:
+        steps = build_pipeline(
+            version=version,
+            name=name,
+            channel=channel,
+            publish_manifest=publish_manifest,
+            branch=branch,
+            chrome_binary=chrome_binary,
+        )
+    except ValueError as e:
+        log_error(str(e))
+        raise typer.Exit(1)
+
+    _execute(_create_context(version), steps)

--- a/packages/browseros/bos_build/cli/release_feeds.py
+++ b/packages/browseros/bos_build/cli/release_feeds.py
@@ -18,7 +18,7 @@ from ..lib.paths import get_package_root
 from ..core.runner import StepExecutionError, run as run_steps
 from ..lib.utils import log_error
 from ..release.appcast import AppcastModule
-from ..release.extensions import ExtensionsFeedModule, parse_set_options
+from ..release.extensions.manifests import ExtensionsFeedModule, parse_set_options
 from ..release.feeds.publisher import FeedPublisher
 
 feeds_app = typer.Typer(

--- a/packages/browseros/bos_build/core/products.py
+++ b/packages/browseros/bos_build/core/products.py
@@ -14,6 +14,8 @@ from typing import Any, Dict, Optional, Tuple
 BROWSEROS_AGENT_EXTENSION_ID = "bflpfmnmnokmjhmgnolecpppdbdophmk"
 BROWSEROS_BUG_REPORTER_EXTENSION_ID = "adlpneommgkgeanpaekgoaolcpncohkf"
 BROWSERCLAW_EXTENSION_ID = "pjimfkbpehlcllblajnpfamdfjhhlgkc"
+# Packaged to the CDN but neither bundled nor in the update feeds.
+BROWSEROS_CONTROLLER_EXTENSION_ID = "nlnihljpboknmfagkikhkdblbedophja"
 
 # TODO: nikhil - remove packaging all extensions after chromium fix
 DEFAULT_REQUIRED_EXTENSIONS: Tuple[Tuple[str, str], ...] = (

--- a/packages/browseros/bos_build/release/extensions/__init__.py
+++ b/packages/browseros/bos_build/release/extensions/__init__.py
@@ -1,0 +1,3 @@
+#!/usr/bin/env python3
+"""Extension release package: packaging specs, CRX build/pack/upload, and
+coherent update-manifest regeneration through the feeds publisher."""

--- a/packages/browseros/bos_build/release/extensions/crx.py
+++ b/packages/browseros/bos_build/release/extensions/crx.py
@@ -38,9 +38,16 @@ def find_chrome_binary(
     is_valid: Callable[[str], bool] = _is_valid_binary,
     platform_name: Optional[str] = None,
 ) -> str:
-    """Resolve the chrome binary: explicit flag > CHROME_BINARY > candidates."""
-    if preferred and is_valid(preferred):
-        return preferred
+    """Resolve the chrome binary: explicit flag > CHROME_BINARY > candidates.
+
+    An explicit flag that does not validate is an error, not a fallback —
+    silently packing with a different chrome than the operator asked for is
+    worse than failing.
+    """
+    if preferred:
+        if is_valid(preferred):
+            return preferred
+        raise RuntimeError(f"Requested chrome binary is not usable: {preferred}")
 
     env_binary = os.environ.get("CHROME_BINARY")
     if env_binary and is_valid(env_binary):

--- a/packages/browseros/bos_build/release/extensions/crx.py
+++ b/packages/browseros/bos_build/release/extensions/crx.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""CRX packaging via chrome --pack-extension. Port of the actions repo's
+packager.py; command assembly and process execution are split so tests
+never need a real chrome."""
+
+import os
+import platform
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Callable, List, Optional
+
+from ...lib.utils import log_info, log_success
+
+_DARWIN_CANDIDATES = (
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/Applications/Chromium.app/Contents/MacOS/Chromium",
+)
+_LINUX_CANDIDATES = (
+    "google-chrome-stable",
+    "google-chrome",
+    "chromium-browser",
+    "chromium",
+)
+
+
+def _is_valid_binary(path: str) -> bool:
+    p = Path(path)
+    if p.exists() and p.is_file():
+        return os.access(p, os.X_OK)
+    return (
+        subprocess.run(["which", path], capture_output=True).returncode == 0
+    )
+
+
+def find_chrome_binary(
+    preferred: Optional[str] = None,
+    is_valid: Callable[[str], bool] = _is_valid_binary,
+    platform_name: Optional[str] = None,
+) -> str:
+    """Resolve the chrome binary: explicit flag > CHROME_BINARY > candidates."""
+    if preferred and is_valid(preferred):
+        return preferred
+
+    env_binary = os.environ.get("CHROME_BINARY")
+    if env_binary and is_valid(env_binary):
+        return env_binary
+
+    system = platform_name or platform.system()
+    if system == "Darwin":
+        candidates = _DARWIN_CANDIDATES
+    elif system == "Linux":
+        candidates = _LINUX_CANDIDATES
+    else:
+        raise RuntimeError(f"Unsupported platform for CRX packing: {system}")
+
+    for binary in candidates:
+        if is_valid(binary):
+            return binary
+
+    raise RuntimeError(
+        "Chrome/Chromium binary not found — install Chrome, set CHROME_BINARY, "
+        "or pass --chrome-binary"
+    )
+
+
+def pack_extension_command(
+    chrome_binary: str, dist_dir: Path, key_path: Path
+) -> List[str]:
+    return [
+        chrome_binary,
+        f"--pack-extension={dist_dir.absolute()}",
+        f"--pack-extension-key={key_path}",
+    ]
+
+
+def _run(cmd: List[str]) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True)
+
+
+def pack_crx(
+    dist_dir: Path,
+    signing_key_contents: str,
+    chrome_binary: str,
+    output_path: Path,
+    run: Callable[[List[str]], subprocess.CompletedProcess] = _run,
+) -> Path:
+    """Pack dist_dir into output_path with the given PEM key contents.
+
+    The key lands in a mode-0600 temp file only for the duration of the
+    chrome call; chrome writes <dist_dir>.crx next to the source, which is
+    moved to output_path.
+    """
+    if not dist_dir.exists():
+        raise FileNotFoundError(f"Distribution directory not found: {dist_dir}")
+    if not (dist_dir / "manifest.json").exists():
+        raise FileNotFoundError(f"No manifest.json in {dist_dir}")
+
+    log_info(f"Packing CRX from {dist_dir} with {chrome_binary}")
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".pem", delete=False
+    ) as key_file:
+        key_file.write(signing_key_contents)
+        key_path = Path(key_file.name)
+
+    try:
+        result = run(pack_extension_command(chrome_binary, dist_dir, key_path))
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"chrome --pack-extension failed ({result.returncode}): "
+                f"{result.stderr}"
+            )
+
+        generated = Path(f"{dist_dir}.crx")
+        if not generated.exists():
+            raise RuntimeError(
+                f"Expected crx not found after packing: {generated}"
+            )
+
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        generated.replace(output_path)
+        log_success(
+            f"CRX created: {output_path} "
+            f"({output_path.stat().st_size / 1024:.1f} KB)"
+        )
+        return output_path
+    finally:
+        key_path.unlink(missing_ok=True)

--- a/packages/browseros/bos_build/release/extensions/crx_test.py
+++ b/packages/browseros/bos_build/release/extensions/crx_test.py
@@ -25,33 +25,32 @@ class FindChromeBinaryTest(unittest.TestCase):
     def test_first_valid_platform_candidate(self):
         import os
 
-        os.environ.pop("CHROME_BINARY", None)
-        found = find_chrome_binary(
-            None,
-            is_valid=lambda p: p == "google-chrome",
-            platform_name="Linux",
-        )
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("CHROME_BINARY", None)
+            found = find_chrome_binary(
+                None,
+                is_valid=lambda p: p == "google-chrome",
+                platform_name="Linux",
+            )
         self.assertEqual(found, "google-chrome")
 
     def test_none_found_raises_actionable(self):
         import os
 
-        os.environ.pop("CHROME_BINARY", None)
-        with self.assertRaisesRegex(RuntimeError, "CHROME_BINARY"):
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("CHROME_BINARY", None)
+            with self.assertRaisesRegex(RuntimeError, "CHROME_BINARY"):
+                find_chrome_binary(
+                    None, is_valid=lambda p: False, platform_name="Darwin"
+                )
+
+    def test_invalid_explicit_binary_raises(self):
+        with self.assertRaisesRegex(RuntimeError, "/broken/path"):
             find_chrome_binary(
-                None, is_valid=lambda p: False, platform_name="Darwin"
+                "/broken/path",
+                is_valid=lambda p: p == "chromium",
+                platform_name="Linux",
             )
-
-    def test_invalid_explicit_falls_through_to_candidates(self):
-        import os
-
-        os.environ.pop("CHROME_BINARY", None)
-        found = find_chrome_binary(
-            "/broken/path",
-            is_valid=lambda p: p == "chromium",
-            platform_name="Linux",
-        )
-        self.assertEqual(found, "chromium")
 
 
 class PackExtensionCommandTest(unittest.TestCase):

--- a/packages/browseros/bos_build/release/extensions/crx_test.py
+++ b/packages/browseros/bos_build/release/extensions/crx_test.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+"""Tests for CRX packaging helpers (command assembly only — no real chrome)."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from .crx import find_chrome_binary, pack_crx, pack_extension_command
+
+
+class FindChromeBinaryTest(unittest.TestCase):
+    def test_explicit_argument_wins(self):
+        found = find_chrome_binary(
+            "/custom/chrome", is_valid=lambda p: p == "/custom/chrome"
+        )
+        self.assertEqual(found, "/custom/chrome")
+
+    def test_env_var_used_when_no_argument(self):
+        with patch.dict("os.environ", {"CHROME_BINARY": "/env/chrome"}):
+            found = find_chrome_binary(None, is_valid=lambda p: p == "/env/chrome")
+        self.assertEqual(found, "/env/chrome")
+
+    def test_first_valid_platform_candidate(self):
+        import os
+
+        os.environ.pop("CHROME_BINARY", None)
+        found = find_chrome_binary(
+            None,
+            is_valid=lambda p: p == "google-chrome",
+            platform_name="Linux",
+        )
+        self.assertEqual(found, "google-chrome")
+
+    def test_none_found_raises_actionable(self):
+        import os
+
+        os.environ.pop("CHROME_BINARY", None)
+        with self.assertRaisesRegex(RuntimeError, "CHROME_BINARY"):
+            find_chrome_binary(
+                None, is_valid=lambda p: False, platform_name="Darwin"
+            )
+
+    def test_invalid_explicit_falls_through_to_candidates(self):
+        import os
+
+        os.environ.pop("CHROME_BINARY", None)
+        found = find_chrome_binary(
+            "/broken/path",
+            is_valid=lambda p: p == "chromium",
+            platform_name="Linux",
+        )
+        self.assertEqual(found, "chromium")
+
+
+class PackExtensionCommandTest(unittest.TestCase):
+    def test_command_shape(self):
+        cmd = pack_extension_command(
+            "google-chrome", Path("/work/dist"), Path("/tmp/key.pem")
+        )
+        self.assertEqual(
+            cmd,
+            [
+                "google-chrome",
+                "--pack-extension=/work/dist",
+                "--pack-extension-key=/tmp/key.pem",
+            ],
+        )
+
+
+class PackCrxTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+        self.dist = self.root / "dist" / "chrome-mv3"
+        self.dist.mkdir(parents=True)
+        (self.dist / "manifest.json").write_text("{}")
+        self.out = self.root / "out" / "agent-1.0.0.crx"
+
+    def _fake_run(self, create_crx=True, returncode=0, stderr=""):
+        recorded = {}
+
+        def run(cmd):
+            recorded["cmd"] = cmd
+            key_path = cmd[2].split("=", 1)[1]
+            recorded["key_existed"] = Path(key_path).exists()
+            recorded["key_content"] = Path(key_path).read_text()
+            if create_crx:
+                Path(f"{self.dist}.crx").write_bytes(b"crx-bytes")
+            return SimpleNamespace(returncode=returncode, stderr=stderr)
+
+        return run, recorded
+
+    def test_packs_moves_and_cleans_up_key(self):
+        run, recorded = self._fake_run()
+        result = pack_crx(self.dist, "PEM-CONTENT", "google-chrome", self.out, run=run)
+
+        self.assertEqual(result, self.out)
+        self.assertEqual(self.out.read_bytes(), b"crx-bytes")
+        self.assertFalse(Path(f"{self.dist}.crx").exists())
+        self.assertEqual(recorded["cmd"][0], "google-chrome")
+        self.assertTrue(recorded["key_existed"])
+        self.assertEqual(recorded["key_content"], "PEM-CONTENT")
+        key_path = recorded["cmd"][2].split("=", 1)[1]
+        self.assertFalse(Path(key_path).exists())
+
+    def test_chrome_failure_raises_with_stderr(self):
+        run, recorded = self._fake_run(create_crx=False, returncode=1, stderr="boom")
+        with self.assertRaisesRegex(RuntimeError, "boom"):
+            pack_crx(self.dist, "KEY", "chrome", self.out, run=run)
+        key_path = recorded["cmd"][2].split("=", 1)[1]
+        self.assertFalse(Path(key_path).exists())
+
+    def test_missing_crx_output_raises(self):
+        run, _ = self._fake_run(create_crx=False)
+        with self.assertRaisesRegex(RuntimeError, "crx"):
+            pack_crx(self.dist, "KEY", "chrome", self.out, run=run)
+
+    def test_missing_dist_dir_raises_before_chrome(self):
+        calls = []
+
+        def run(cmd):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stderr="")
+
+        with self.assertRaises(FileNotFoundError):
+            pack_crx(self.root / "nope", "KEY", "chrome", self.out, run=run)
+        self.assertEqual(calls, [])
+
+    def test_missing_manifest_raises_before_chrome(self):
+        (self.dist / "manifest.json").unlink()
+        calls = []
+
+        def run(cmd):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stderr="")
+
+        with self.assertRaisesRegex(FileNotFoundError, "manifest.json"):
+            pack_crx(self.dist, "KEY", "chrome", self.out, run=run)
+        self.assertEqual(calls, [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/bos_build/release/extensions/manifests.py
+++ b/packages/browseros/bos_build/release/extensions/manifests.py
@@ -9,18 +9,18 @@ crx objects must already exist in R2 (HEAD-checked before any write).
 
 from typing import Dict, List
 
-from ..core.context import Context
-from ..core.step import Step, ValidationError
-from ..lib.r2 import BOTO3_AVAILABLE
-from ..lib.utils import log_info
-from .feeds.publisher import FeedPublisher
-from .feeds.render import (
+from ...core.context import Context
+from ...core.step import Step, ValidationError
+from ...lib.r2 import BOTO3_AVAILABLE
+from ...lib.utils import log_info
+from ..feeds.publisher import FeedPublisher
+from ..feeds.render import (
     extract_manifest_versions,
     parse_dotted_version,
     render_extensions_json,
     render_update_manifest,
 )
-from .feeds.spec import (
+from ..feeds.spec import (
     EXTENSIONS,
     bundled_manifest_feed,
     extension_by_name,

--- a/packages/browseros/bos_build/release/extensions/manifests_test.py
+++ b/packages/browseros/bos_build/release/extensions/manifests_test.py
@@ -5,10 +5,10 @@ import unittest
 from types import SimpleNamespace
 from typing import cast
 
-from ..core.context import Context
-from ..core.step import ValidationError
-from .extensions import ExtensionsFeedModule, parse_set_options
-from .feeds.render import extract_manifest_versions, render_update_manifest
+from ...core.context import Context
+from ...core.step import ValidationError
+from ..feeds.render import extract_manifest_versions, render_update_manifest
+from .manifests import ExtensionsFeedModule, parse_set_options
 
 AGENT_ID = "bflpfmnmnokmjhmgnolecpppdbdophmk"
 BUGREPORTER_ID = "adlpneommgkgeanpaekgoaolcpncohkf"

--- a/packages/browseros/bos_build/release/extensions/release.py
+++ b/packages/browseros/bos_build/release/extensions/release.py
@@ -21,7 +21,13 @@ from ...lib.utils import log_info, log_success, log_warning
 from ..feeds.spec import CDN_BASE_URL, EXTENSIONS as FEED_EXTENSIONS
 from .crx import find_chrome_binary, pack_crx
 from .manifests import CHANNELS, ExtensionsFeedModule
-from .specs import ExtensionSpec, InRepoSource, select_specs, spec_by_name
+from .specs import (
+    ExtensionSpec,
+    ExternalRepoSource,
+    InRepoSource,
+    select_specs,
+    spec_by_name,
+)
 from .workspace import (
     resolve_source,
     run_command,
@@ -90,6 +96,15 @@ class ExtensionReleaseModule(Step):
         if not ctx.env.has_r2_config():
             raise ValidationError("R2 configuration not set")
 
+        # Public repos clone fine without it — warn, don't fail.
+        if not os.environ.get("GH_TOKEN") and any(
+            isinstance(spec.source, ExternalRepoSource) for spec in specs
+        ):
+            log_warning(
+                "GH_TOKEN is not set — cloning external extension repos "
+                "will fail if any of them is private"
+            )
+
         try:
             find_chrome_binary(self.chrome_binary)
         except RuntimeError as e:
@@ -119,9 +134,12 @@ class ExtensionReleaseModule(Step):
                 source_root / spec.manifest_path, self.version
             )
             if isinstance(spec.source, InRepoSource):
+                touched = spec.manifest_path
+                if spec.env:
+                    touched += f" and {spec.env_dir or '.'}/.env"
                 log_warning(
-                    f"stamped {spec.manifest_path} in the working tree — "
-                    "revert it if this was a local test run"
+                    f"stamped {touched} in the working tree — "
+                    "revert them if this was a local test run"
                 )
             if spec.env:
                 env_dir = (
@@ -172,6 +190,9 @@ def build_pipeline(
             f"Invalid version '{version}' — Chrome extension versions are "
             "1-4 dot-separated integers (e.g. 0.0.118)"
         )
+    # A '-'-prefixed value would be parsed as a git option, not a branch.
+    if branch and branch.startswith("-"):
+        raise ValueError(f"Invalid branch name '{branch}'")
     specs = select_specs(name)
     steps: List[Step] = [
         ExtensionReleaseModule(

--- a/packages/browseros/bos_build/release/extensions/release.py
+++ b/packages/browseros/bos_build/release/extensions/release.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Ext release orchestration: build → stamp → pack → upload per spec, then
+regenerate the update manifests through the Part B feeds publisher.
+
+This is the consolidation the old actions repo could not do — it generated
+update-manifest.xml locally and told the operator to upload it by hand. Here
+the manifests flow through FeedPublisher's rails (dry-run by default,
+--publish-manifest to write), so a released crx and its feed entry can no
+longer drift apart.
+"""
+
+import os
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from ...core.step import Step, ValidationError
+from ...lib.paths import get_package_root
+from ...lib.r2 import BOTO3_AVAILABLE, get_r2_client, upload_file_to_r2
+from ...lib.utils import log_info, log_success
+from ..feeds.spec import CDN_BASE_URL, EXTENSIONS as FEED_EXTENSIONS
+from .crx import find_chrome_binary, pack_crx
+from .manifests import ExtensionsFeedModule
+from .specs import ExtensionSpec, select_specs, spec_by_name
+from .workspace import (
+    resolve_source,
+    run_command,
+    update_manifest_version,
+    write_env_file,
+)
+
+
+def _require_env(name: str) -> str:
+    value = os.environ.get(name, "").strip()
+    if len(value) <= 1:
+        raise EnvironmentError(f"Missing or empty environment variable: {name}")
+    return value
+
+
+class ExtensionReleaseModule(Step):
+    """Build, version-stamp, pack and upload the selected extension CRXs."""
+
+    produces = []
+    requires = []
+    description = "Build and upload extension CRXs to the CDN"
+
+    def __init__(
+        self,
+        version: str,
+        names: Tuple[str, ...],
+        branch_override: Optional[str] = None,
+        chrome_binary: Optional[str] = None,
+        monorepo_root: Optional[Path] = None,
+        work_root: Optional[Path] = None,
+        r2_client=None,
+    ):
+        self.version = version
+        self.names = names
+        self.branch_override = branch_override
+        self.chrome_binary = chrome_binary
+        self._monorepo_root = monorepo_root
+        self._work_root = work_root
+        self._r2_client = r2_client
+
+    def _specs(self) -> List[ExtensionSpec]:
+        return [spec_by_name(name) for name in self.names]
+
+    def validate(self, ctx) -> None:
+        try:
+            specs = self._specs()
+        except ValueError as e:
+            raise ValidationError(str(e))
+
+        for spec in specs:
+            try:
+                _require_env(spec.signing_key_env)
+            except EnvironmentError:
+                raise ValidationError(
+                    f"Signing key env var '{spec.signing_key_env}' for "
+                    f"'{spec.name}' is missing or empty"
+                )
+
+        if not BOTO3_AVAILABLE:
+            raise ValidationError("boto3 library not installed - run: pip install boto3")
+        if not ctx.env.has_r2_config():
+            raise ValidationError("R2 configuration not set")
+
+        try:
+            find_chrome_binary(self.chrome_binary)
+        except RuntimeError as e:
+            raise ValidationError(str(e))
+
+    def execute(self, ctx) -> None:
+        package_root = get_package_root()
+        monorepo_root = self._monorepo_root or package_root.parent.parent
+        work_root = self._work_root or package_root / "build" / "extensions"
+
+        client = self._r2_client
+        if client is None:
+            client = get_r2_client(ctx.env)
+            if client is None:
+                raise RuntimeError("Failed to create R2 client")
+        chrome = find_chrome_binary(self.chrome_binary)
+
+        for spec in self._specs():
+            log_info(f"\n=== Releasing extension: {spec.name} v{self.version} ===")
+            source_root = resolve_source(
+                spec,
+                monorepo_root=monorepo_root,
+                work_root=work_root,
+                branch_override=self.branch_override,
+            )
+            update_manifest_version(
+                source_root / spec.manifest_path, self.version
+            )
+            if spec.env:
+                env_dir = (
+                    source_root / spec.env_dir if spec.env_dir else source_root
+                )
+                write_env_file(env_dir, spec.env)
+            if spec.pre_build:
+                run_command(spec.pre_build, source_root)
+            run_command(spec.build, source_root)
+
+            crx_path = pack_crx(
+                source_root / spec.dist_path,
+                _require_env(spec.signing_key_env),
+                chrome,
+                work_root / "dist" / spec.crx_filename(self.version),
+            )
+
+            r2_key = spec.crx_key(self.version)
+            if not upload_file_to_r2(client, crx_path, r2_key, ctx.env.r2_bucket):
+                raise RuntimeError(f"Upload failed for {r2_key}")
+            log_success(f"CRX live at {CDN_BASE_URL}/{r2_key}")
+
+
+def build_pipeline(
+    version: str,
+    name: Optional[str],
+    channel: str,
+    publish_manifest: bool,
+    branch: Optional[str],
+    chrome_binary: Optional[str],
+) -> List[Step]:
+    """Assemble the release pipeline for one --name (or every spec).
+
+    Extensions the feeds table knows get their new version pinned into an
+    ExtensionsFeedModule step; a selection with no feed members (controller)
+    releases the crx only — there is nothing to regenerate.
+    """
+    specs = select_specs(name)
+    steps: List[Step] = [
+        ExtensionReleaseModule(
+            version=version,
+            names=tuple(spec.name for spec in specs),
+            branch_override=branch,
+            chrome_binary=chrome_binary,
+        )
+    ]
+
+    feed_names = {ext.name for ext in FEED_EXTENSIONS}
+    pins = {spec.name: version for spec in specs if spec.name in feed_names}
+    if pins:
+        steps.append(
+            ExtensionsFeedModule(
+                channel=channel,
+                set_versions=pins,
+                publish=publish_manifest,
+            )
+        )
+    return steps

--- a/packages/browseros/bos_build/release/extensions/release.py
+++ b/packages/browseros/bos_build/release/extensions/release.py
@@ -10,17 +10,18 @@ longer drift apart.
 """
 
 import os
+import re
 from pathlib import Path
 from typing import List, Optional, Tuple
 
 from ...core.step import Step, ValidationError
 from ...lib.paths import get_package_root
 from ...lib.r2 import BOTO3_AVAILABLE, get_r2_client, upload_file_to_r2
-from ...lib.utils import log_info, log_success
+from ...lib.utils import log_info, log_success, log_warning
 from ..feeds.spec import CDN_BASE_URL, EXTENSIONS as FEED_EXTENSIONS
 from .crx import find_chrome_binary, pack_crx
-from .manifests import ExtensionsFeedModule
-from .specs import ExtensionSpec, select_specs, spec_by_name
+from .manifests import CHANNELS, ExtensionsFeedModule
+from .specs import ExtensionSpec, InRepoSource, select_specs, spec_by_name
 from .workspace import (
     resolve_source,
     run_command,
@@ -28,9 +29,14 @@ from .workspace import (
     write_env_file,
 )
 
+# Chrome requires extension versions to be 1-4 dot-separated integers.
+_VERSION_RE = re.compile(r"^\d+(\.\d+){0,3}$")
+
 
 def _require_env(name: str) -> str:
     value = os.environ.get(name, "").strip()
+    # <=1 mirrors the old release tool's guard: 0-1 chars is an unset or
+    # placeholder value ("0", "-"), never a real key.
     if len(value) <= 1:
         raise EnvironmentError(f"Missing or empty environment variable: {name}")
     return value
@@ -112,6 +118,11 @@ class ExtensionReleaseModule(Step):
             update_manifest_version(
                 source_root / spec.manifest_path, self.version
             )
+            if isinstance(spec.source, InRepoSource):
+                log_warning(
+                    f"stamped {spec.manifest_path} in the working tree — "
+                    "revert it if this was a local test run"
+                )
             if spec.env:
                 env_dir = (
                     source_root / spec.env_dir if spec.env_dir else source_root
@@ -147,7 +158,20 @@ def build_pipeline(
     Extensions the feeds table knows get their new version pinned into an
     ExtensionsFeedModule step; a selection with no feed members (controller)
     releases the crx only — there is nothing to regenerate.
+
+    Channel and version are rejected here, at assembly time — the runner
+    validates steps just-in-time, so leaving this to the feeds step would
+    burn a full build + crx upload before a typo surfaces.
     """
+    if channel not in CHANNELS:
+        raise ValueError(
+            f"channel must be one of {'/'.join(CHANNELS)}, got '{channel}'"
+        )
+    if not _VERSION_RE.fullmatch(version):
+        raise ValueError(
+            f"Invalid version '{version}' — Chrome extension versions are "
+            "1-4 dot-separated integers (e.g. 0.0.118)"
+        )
     specs = select_specs(name)
     steps: List[Step] = [
         ExtensionReleaseModule(

--- a/packages/browseros/bos_build/release/extensions/release_test.py
+++ b/packages/browseros/bos_build/release/extensions/release_test.py
@@ -104,6 +104,17 @@ class BuildPipelineTest(unittest.TestCase):
                     chrome_binary=None,
                 )
 
+    def test_dash_prefixed_branch_rejected_at_assembly(self):
+        with self.assertRaisesRegex(ValueError, "branch"):
+            build_pipeline(
+                version="1.0.0",
+                name="controller",
+                channel="alpha",
+                publish_manifest=False,
+                branch="--upload-pack=/bin/sh",
+                chrome_binary=None,
+            )
+
     def test_malformed_version_rejected_at_assembly(self):
         for version in ("1.0.0-beta", "abc", "", "1..2"):
             with self.assertRaisesRegex(ValueError, "version"):
@@ -240,7 +251,7 @@ class ExecuteTest(unittest.TestCase):
         self.assertEqual(
             commands,
             [
-                ("bun install", Path("/src/agent")),
+                ("bun ci", Path("/src/agent")),
                 ("bun run build:agent", Path("/src/agent")),
             ],
         )

--- a/packages/browseros/bos_build/release/extensions/release_test.py
+++ b/packages/browseros/bos_build/release/extensions/release_test.py
@@ -92,6 +92,30 @@ class BuildPipelineTest(unittest.TestCase):
         )
         self.assertFalse(feeds.publish)
 
+    def test_bad_channel_rejected_at_assembly_even_without_feeds_step(self):
+        for name in ("agent", "controller"):
+            with self.assertRaisesRegex(ValueError, "alpha/prod"):
+                build_pipeline(
+                    version="1.0.0",
+                    name=name,
+                    channel="pord",
+                    publish_manifest=False,
+                    branch=None,
+                    chrome_binary=None,
+                )
+
+    def test_malformed_version_rejected_at_assembly(self):
+        for version in ("1.0.0-beta", "abc", "", "1..2"):
+            with self.assertRaisesRegex(ValueError, "version"):
+                build_pipeline(
+                    version=version,
+                    name="agent",
+                    channel="alpha",
+                    publish_manifest=False,
+                    branch=None,
+                    chrome_binary=None,
+                )
+
     def test_dry_run_is_default_for_manifests(self):
         _, feeds = build_pipeline(
             version="1.0.0",

--- a/packages/browseros/bos_build/release/extensions/release_test.py
+++ b/packages/browseros/bos_build/release/extensions/release_test.py
@@ -1,0 +1,268 @@
+#!/usr/bin/env python3
+"""Tests for the ext release orchestration module and pipeline assembly."""
+
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+from ...core.context import Context
+from ...core.step import ValidationError
+from .manifests import ExtensionsFeedModule
+from .release import ExtensionReleaseModule, build_pipeline
+
+MODULE = "bos_build.release.extensions.release"
+
+ALL_KEYS = {
+    "BROWSEROS_AGENT_V2_KEY": "agent-pem",
+    "BROWSEROS_CONTROLLER_KEY": "controller-pem",
+    "BUGREPORTER_KEY": "bugreporter-pem",
+    "BROWSERCLAW_KEY": "claw-pem",
+}
+
+
+def _ctx(has_r2=True, bucket="browseros"):
+    return cast(
+        Context,
+        SimpleNamespace(
+            env=SimpleNamespace(has_r2_config=lambda: has_r2, r2_bucket=bucket)
+        ),
+    )
+
+
+class BuildPipelineTest(unittest.TestCase):
+    def test_unknown_name_raises_with_valid_names(self):
+        with self.assertRaisesRegex(ValueError, "bugreporter"):
+            build_pipeline(
+                version="1.0.0",
+                name="agent-v2",
+                channel="alpha",
+                publish_manifest=False,
+                branch=None,
+                chrome_binary=None,
+            )
+
+    def test_feed_extension_gets_feeds_step_with_exact_pins(self):
+        steps = build_pipeline(
+            version="1.2.3",
+            name="agent",
+            channel="prod",
+            publish_manifest=True,
+            branch=None,
+            chrome_binary=None,
+        )
+        self.assertEqual(len(steps), 2)
+        release, feeds = steps
+        self.assertIsInstance(release, ExtensionReleaseModule)
+        self.assertIsInstance(feeds, ExtensionsFeedModule)
+        self.assertEqual(release.names, ("agent",))
+        self.assertEqual(feeds.set_versions, {"agent": "1.2.3"})
+        self.assertEqual(feeds.channel, "prod")
+        self.assertTrue(feeds.publish)
+
+    def test_controller_only_skips_feeds_step(self):
+        steps = build_pipeline(
+            version="1.2.3",
+            name="controller",
+            channel="alpha",
+            publish_manifest=False,
+            branch=None,
+            chrome_binary=None,
+        )
+        self.assertEqual(len(steps), 1)
+        self.assertIsInstance(steps[0], ExtensionReleaseModule)
+
+    def test_all_extensions_pin_only_feed_members(self):
+        steps = build_pipeline(
+            version="2.0.0",
+            name=None,
+            channel="alpha",
+            publish_manifest=False,
+            branch=None,
+            chrome_binary=None,
+        )
+        release, feeds = steps
+        self.assertEqual(
+            release.names, ("agent", "controller", "bugreporter", "browserclaw")
+        )
+        self.assertEqual(
+            feeds.set_versions,
+            {"agent": "2.0.0", "bugreporter": "2.0.0", "browserclaw": "2.0.0"},
+        )
+        self.assertFalse(feeds.publish)
+
+    def test_dry_run_is_default_for_manifests(self):
+        _, feeds = build_pipeline(
+            version="1.0.0",
+            name="agent",
+            channel="alpha",
+            publish_manifest=False,
+            branch=None,
+            chrome_binary=None,
+        )
+        self.assertFalse(feeds.publish)
+
+
+class ValidateTest(unittest.TestCase):
+    def _module(self, names=("agent",), **kwargs):
+        return ExtensionReleaseModule(version="1.0.0", names=names, **kwargs)
+
+    def test_missing_signing_key_env_names_the_variable(self):
+        with patch.dict("os.environ", {}, clear=False):
+            import os
+
+            os.environ.pop("BROWSEROS_AGENT_V2_KEY", None)
+            with patch(f"{MODULE}.find_chrome_binary", return_value="chrome"):
+                with self.assertRaisesRegex(
+                    ValidationError, "BROWSEROS_AGENT_V2_KEY"
+                ):
+                    self._module().validate(_ctx())
+
+    def test_missing_r2_config_fails(self):
+        with patch.dict("os.environ", ALL_KEYS):
+            with patch(f"{MODULE}.find_chrome_binary", return_value="chrome"):
+                with self.assertRaisesRegex(ValidationError, "R2"):
+                    self._module().validate(_ctx(has_r2=False))
+
+    def test_chrome_resolution_failure_fails_validation(self):
+        with patch.dict("os.environ", ALL_KEYS):
+            with patch(
+                f"{MODULE}.find_chrome_binary",
+                side_effect=RuntimeError("no chrome anywhere"),
+            ):
+                with self.assertRaisesRegex(ValidationError, "no chrome"):
+                    self._module().validate(_ctx())
+
+    def test_unknown_name_fails_validation(self):
+        with self.assertRaisesRegex(ValidationError, "Unknown extension"):
+            self._module(names=("nope",)).validate(_ctx())
+
+
+class ExecuteTest(unittest.TestCase):
+    def setUp(self):
+        self.monorepo = Path("/mono")
+        self.work = Path("/work")
+
+        patches = {
+            "resolve_source": MagicMock(
+                side_effect=lambda spec, **kw: Path("/src") / spec.name
+            ),
+            "update_manifest_version": MagicMock(),
+            "write_env_file": MagicMock(),
+            "run_command": MagicMock(),
+            "pack_crx": MagicMock(
+                side_effect=lambda dist, key, chrome, out, **kw: out
+            ),
+            "upload_file_to_r2": MagicMock(return_value=True),
+            "get_r2_client": MagicMock(return_value="r2-client"),
+            "find_chrome_binary": MagicMock(return_value="chrome-bin"),
+        }
+        self.mocks = {}
+        self.tracker = MagicMock()
+        for name, mock in patches.items():
+            patcher = patch(f"{MODULE}.{name}", mock)
+            patcher.start()
+            self.addCleanup(patcher.stop)
+            self.mocks[name] = mock
+            self.tracker.attach_mock(mock, name)
+
+        env_patcher = patch.dict("os.environ", ALL_KEYS)
+        env_patcher.start()
+        self.addCleanup(env_patcher.stop)
+
+    def _module(self, names, **kwargs):
+        return ExtensionReleaseModule(
+            version="1.0.0",
+            names=names,
+            monorepo_root=self.monorepo,
+            work_root=self.work,
+            **kwargs,
+        )
+
+    def test_agent_flow_order_and_arguments(self):
+        self._module(("agent",)).execute(_ctx())
+
+        called = [c[0] for c in self.tracker.mock_calls]
+        self.assertEqual(
+            called,
+            [
+                "get_r2_client",
+                "find_chrome_binary",
+                "resolve_source",
+                "update_manifest_version",
+                "write_env_file",
+                "run_command",
+                "run_command",
+                "pack_crx",
+                "upload_file_to_r2",
+            ],
+        )
+
+        resolve_kwargs = self.mocks["resolve_source"].call_args.kwargs
+        self.assertEqual(resolve_kwargs["monorepo_root"], self.monorepo)
+        self.assertEqual(resolve_kwargs["work_root"], self.work)
+        self.assertIsNone(resolve_kwargs["branch_override"])
+
+        self.mocks["update_manifest_version"].assert_called_once_with(
+            Path("/src/agent/apps/app/package.json"), "1.0.0"
+        )
+        self.mocks["write_env_file"].assert_called_once()
+        env_args = self.mocks["write_env_file"].call_args.args
+        self.assertEqual(env_args[0], Path("/src/agent/apps/app"))
+        self.assertIn("VITE_PUBLIC_BROWSEROS_API", env_args[1])
+
+        commands = [c.args for c in self.mocks["run_command"].call_args_list]
+        self.assertEqual(
+            commands,
+            [
+                ("bun install", Path("/src/agent")),
+                ("bun run build:agent", Path("/src/agent")),
+            ],
+        )
+
+        pack_args = self.mocks["pack_crx"].call_args.args
+        self.assertEqual(pack_args[0], Path("/src/agent/apps/app/dist/chrome-mv3"))
+        self.assertEqual(pack_args[1], "agent-pem")
+        self.assertEqual(pack_args[2], "chrome-bin")
+        self.assertEqual(pack_args[3], self.work / "dist" / "agent-1.0.0.crx")
+
+        self.mocks["upload_file_to_r2"].assert_called_once_with(
+            "r2-client",
+            self.work / "dist" / "agent-1.0.0.crx",
+            "extensions/agent-1.0.0.crx",
+            "browseros",
+        )
+
+    def test_env_file_lands_at_source_root_without_env_dir(self):
+        self._module(("bugreporter",)).execute(_ctx())
+        env_args = self.mocks["write_env_file"].call_args.args
+        self.assertEqual(env_args[0], Path("/src/bugreporter"))
+
+    def test_upload_failure_stops_later_extensions(self):
+        self.mocks["upload_file_to_r2"].return_value = False
+        with self.assertRaisesRegex(RuntimeError, "extensions/agent-1.0.0.crx"):
+            self._module(("agent", "bugreporter")).execute(_ctx())
+
+        resolved = [
+            c.args[0].name for c in self.mocks["resolve_source"].call_args_list
+        ]
+        self.assertEqual(resolved, ["agent"])
+
+    def test_branch_override_reaches_resolver(self):
+        self._module(("bugreporter",), branch_override="canary").execute(_ctx())
+        self.assertEqual(
+            self.mocks["resolve_source"].call_args.kwargs["branch_override"],
+            "canary",
+        )
+
+    def test_injected_r2_client_skips_factory(self):
+        self._module(("agent",), r2_client="prebuilt").execute(_ctx())
+        self.mocks["get_r2_client"].assert_not_called()
+        self.assertEqual(
+            self.mocks["upload_file_to_r2"].call_args.args[0], "prebuilt"
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/bos_build/release/extensions/specs.py
+++ b/packages/browseros/bos_build/release/extensions/specs.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Extension packaging spec table — one owner for how each extension is
+built, signed and shipped to the CDN.
+
+Same descriptor pattern as feeds/spec.py: a frozen dataclass plus a
+module-level table. This absorbs the actions repo's configs/extensions.yaml;
+the correction over that file is source fidelity — agent and browserclaw
+live in THIS monorepo, so they build from the working tree instead of
+cloning the repo they are already in. Extension ids are single-sourced from
+core/products.py; specs_test pins the crx key formula to feeds/spec.py so
+the two tables cannot drift.
+"""
+
+from dataclasses import dataclass
+from typing import Optional, Tuple, Union
+
+from ...core.products import (
+    BROWSEROS_AGENT_EXTENSION_ID,
+    BROWSEROS_BUG_REPORTER_EXTENSION_ID,
+    BROWSEROS_CONTROLLER_EXTENSION_ID,
+    BROWSERCLAW_EXTENSION_ID,
+)
+
+
+@dataclass(frozen=True)
+class InRepoSource:
+    """Extension source living in this monorepo; path is monorepo-relative."""
+
+    path: str
+
+
+@dataclass(frozen=True)
+class ExternalRepoSource:
+    """Extension source cloned from GitHub (owner/repo) at a default branch."""
+
+    repo: str
+    branch: str
+
+
+@dataclass(frozen=True)
+class ExtensionSpec:
+    """One packagable extension; name is the crx filename prefix.
+
+    dist_path / manifest_path / env_dir are relative to the resolved source
+    root. env lists the variable names the build reads; they are also
+    written to <env_dir or source root>/.env because some bundler configs
+    only read env from file.
+    """
+
+    name: str
+    source: Union[InRepoSource, ExternalRepoSource]
+    pre_build: str
+    build: str
+    dist_path: str
+    manifest_path: str
+    extension_id: str
+    signing_key_env: str
+    env: Tuple[str, ...] = ()
+    env_dir: str = ""
+
+    def crx_filename(self, version: str) -> str:
+        return f"{self.name}-{version}.crx"
+
+    def crx_key(self, version: str) -> str:
+        return f"extensions/{self.crx_filename(version)}"
+
+
+EXTENSION_SPECS: Tuple[ExtensionSpec, ...] = (
+    ExtensionSpec(
+        name="agent",
+        source=InRepoSource(path="packages/browseros-agent"),
+        pre_build="bun install",
+        build="bun run build:agent",
+        dist_path="apps/app/dist/chrome-mv3",
+        manifest_path="apps/app/package.json",
+        extension_id=BROWSEROS_AGENT_EXTENSION_ID,
+        signing_key_env="BROWSEROS_AGENT_V2_KEY",
+        env=(
+            "VITE_PUBLIC_SENTRY_DSN",
+            "SENTRY_AUTH_TOKEN",
+            "SENTRY_ORG",
+            "SENTRY_PROJECT",
+            "VITE_PUBLIC_POSTHOG_KEY",
+            "VITE_PUBLIC_POSTHOG_HOST",
+            "VITE_PUBLIC_BROWSEROS_API",
+            "GRAPHQL_SCHEMA_PATH",
+            "NODE_ENV",
+        ),
+        env_dir="apps/app",
+    ),
+    ExtensionSpec(
+        name="controller",
+        source=ExternalRepoSource(repo="browseros-ai/BrowserOS-agent", branch="main"),
+        pre_build="bun install",
+        build="bun run build:ext",
+        dist_path="apps/controller-ext/dist",
+        manifest_path="apps/controller-ext/manifest.json",
+        extension_id=BROWSEROS_CONTROLLER_EXTENSION_ID,
+        signing_key_env="BROWSEROS_CONTROLLER_KEY",
+        env=("NODE_ENV", "POSTHOG_API_KEY"),
+    ),
+    ExtensionSpec(
+        name="bugreporter",
+        source=ExternalRepoSource(
+            repo="browseros-ai/BrowserOS-feedback-extension", branch="main"
+        ),
+        # --production=false so devDependencies (rimraf et al.) install too.
+        pre_build="yarn install --production=false",
+        build="yarn run build",
+        dist_path="dist",
+        manifest_path="manifest.json",
+        extension_id=BROWSEROS_BUG_REPORTER_EXTENSION_ID,
+        signing_key_env="BUGREPORTER_KEY",
+        env=("NODE_ENV",),
+    ),
+    ExtensionSpec(
+        name="browserclaw",
+        source=InRepoSource(path="packages/browseros-agent"),
+        pre_build="bun install",
+        build="bun run --filter @browseros/claw-app build",
+        dist_path="apps/claw-app/dist/chrome-mv3",
+        manifest_path="apps/claw-app/package.json",
+        extension_id=BROWSERCLAW_EXTENSION_ID,
+        signing_key_env="BROWSERCLAW_KEY",
+        env=("NODE_ENV",),
+        env_dir="apps/claw-app",
+    ),
+)
+
+
+def spec_by_name(name: str) -> ExtensionSpec:
+    for spec in EXTENSION_SPECS:
+        if spec.name == name:
+            return spec
+    valid = ", ".join(sorted(spec.name for spec in EXTENSION_SPECS))
+    raise ValueError(f"Unknown extension '{name}'. Valid: {valid}")
+
+
+def select_specs(name: Optional[str]) -> Tuple[ExtensionSpec, ...]:
+    """Specs for one --name, or the whole table when name is None."""
+    if name is None:
+        return EXTENSION_SPECS
+    return (spec_by_name(name),)

--- a/packages/browseros/bos_build/release/extensions/specs.py
+++ b/packages/browseros/bos_build/release/extensions/specs.py
@@ -69,7 +69,9 @@ EXTENSION_SPECS: Tuple[ExtensionSpec, ...] = (
     ExtensionSpec(
         name="agent",
         source=InRepoSource(path="packages/browseros-agent"),
-        pre_build="bun install",
+        # bun ci (frozen lockfile) for in-repo builds: a release must not
+        # resolve fresh deps or mutate the working-tree lockfile.
+        pre_build="bun ci",
         build="bun run build:agent",
         dist_path="apps/app/dist/chrome-mv3",
         manifest_path="apps/app/package.json",
@@ -116,7 +118,7 @@ EXTENSION_SPECS: Tuple[ExtensionSpec, ...] = (
     ExtensionSpec(
         name="browserclaw",
         source=InRepoSource(path="packages/browseros-agent"),
-        pre_build="bun install",
+        pre_build="bun ci",
         build="bun run --filter @browseros/claw-app build",
         dist_path="apps/claw-app/dist/chrome-mv3",
         manifest_path="apps/claw-app/package.json",

--- a/packages/browseros/bos_build/release/extensions/specs_test.py
+++ b/packages/browseros/bos_build/release/extensions/specs_test.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Tests for the extension packaging spec table."""
+
+import unittest
+
+from ...core.products import (
+    BROWSEROS_AGENT_EXTENSION_ID,
+    BROWSEROS_BUG_REPORTER_EXTENSION_ID,
+    BROWSEROS_CONTROLLER_EXTENSION_ID,
+    BROWSERCLAW_EXTENSION_ID,
+)
+from ...lib.paths import get_package_root
+from ..feeds.spec import EXTENSIONS as FEED_EXTENSIONS
+from .specs import (
+    EXTENSION_SPECS,
+    ExternalRepoSource,
+    InRepoSource,
+    select_specs,
+    spec_by_name,
+)
+
+PRODUCT_IDS = {
+    BROWSEROS_AGENT_EXTENSION_ID,
+    BROWSEROS_BUG_REPORTER_EXTENSION_ID,
+    BROWSEROS_CONTROLLER_EXTENSION_ID,
+    BROWSERCLAW_EXTENSION_ID,
+}
+
+
+class SpecTableTest(unittest.TestCase):
+    def test_table_holds_exactly_the_four_extensions(self):
+        self.assertEqual(
+            {spec.name for spec in EXTENSION_SPECS},
+            {"agent", "controller", "bugreporter", "browserclaw"},
+        )
+
+    def test_names_ids_and_signing_envs_are_unique(self):
+        names = [spec.name for spec in EXTENSION_SPECS]
+        ids = [spec.extension_id for spec in EXTENSION_SPECS]
+        keys = [spec.signing_key_env for spec in EXTENSION_SPECS]
+        self.assertEqual(len(names), len(set(names)))
+        self.assertEqual(len(ids), len(set(ids)))
+        self.assertEqual(len(keys), len(set(keys)))
+
+    def test_every_id_is_a_products_py_constant(self):
+        for spec in EXTENSION_SPECS:
+            self.assertIn(spec.extension_id, PRODUCT_IDS, spec.name)
+
+    def test_controller_id_constant_value(self):
+        self.assertEqual(
+            BROWSEROS_CONTROLLER_EXTENSION_ID,
+            "nlnihljpboknmfagkikhkdblbedophja",
+        )
+        self.assertEqual(
+            spec_by_name("controller").extension_id,
+            BROWSEROS_CONTROLLER_EXTENSION_ID,
+        )
+
+    def test_monorepo_extensions_are_in_repo_sources(self):
+        monorepo_root = get_package_root().parent.parent
+        for name in ("agent", "browserclaw"):
+            source = spec_by_name(name).source
+            self.assertIsInstance(source, InRepoSource, name)
+            self.assertEqual(source.path, "packages/browseros-agent")
+            self.assertTrue((monorepo_root / source.path).is_dir())
+
+    def test_external_extensions_keep_their_repos(self):
+        controller = spec_by_name("controller").source
+        bugreporter = spec_by_name("bugreporter").source
+        self.assertEqual(
+            controller,
+            ExternalRepoSource(repo="browseros-ai/BrowserOS-agent", branch="main"),
+        )
+        self.assertEqual(
+            bugreporter,
+            ExternalRepoSource(
+                repo="browseros-ai/BrowserOS-feedback-extension", branch="main"
+            ),
+        )
+
+    def test_crx_key_matches_feeds_spec_formula(self):
+        feed_by_name = {ext.name: ext for ext in FEED_EXTENSIONS}
+        for spec in EXTENSION_SPECS:
+            self.assertEqual(
+                spec.crx_key("1.2.3.4"), f"extensions/{spec.name}-1.2.3.4.crx"
+            )
+            feed_ext = feed_by_name.get(spec.name)
+            if feed_ext is not None:
+                self.assertEqual(spec.crx_key("9.9.9"), feed_ext.crx_key("9.9.9"))
+                self.assertEqual(spec.extension_id, feed_ext.extension_id)
+
+    def test_controller_is_not_a_feed_extension(self):
+        self.assertNotIn(
+            "controller", {ext.name for ext in FEED_EXTENSIONS}
+        )
+
+    def test_paths_are_relative_and_point_at_build_outputs(self):
+        for spec in EXTENSION_SPECS:
+            for path in (spec.dist_path, spec.manifest_path):
+                self.assertFalse(path.startswith("/"), spec.name)
+        for name in ("agent", "browserclaw"):
+            spec = spec_by_name(name)
+            self.assertTrue(spec.dist_path.endswith("dist/chrome-mv3"), name)
+            self.assertTrue(spec.manifest_path.endswith("package.json"), name)
+            self.assertTrue(spec.env_dir)
+
+    def test_in_repo_manifest_paths_exist_in_working_tree(self):
+        monorepo_root = get_package_root().parent.parent
+        for name in ("agent", "browserclaw"):
+            spec = spec_by_name(name)
+            source = spec.source
+            self.assertIsInstance(source, InRepoSource)
+            manifest = monorepo_root / source.path / spec.manifest_path
+            self.assertTrue(manifest.is_file(), str(manifest))
+
+    def test_spec_by_name_rejects_unknown_with_valid_names(self):
+        with self.assertRaisesRegex(ValueError, "agent.*browserclaw|browserclaw.*agent"):
+            spec_by_name("nope")
+
+    def test_select_specs_all_and_single(self):
+        self.assertEqual(select_specs(None), EXTENSION_SPECS)
+        self.assertEqual(select_specs("agent"), (spec_by_name("agent"),))
+        with self.assertRaises(ValueError):
+            select_specs("agent-v2")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/bos_build/release/extensions/workspace.py
+++ b/packages/browseros/bos_build/release/extensions/workspace.py
@@ -6,6 +6,7 @@ build from the working tree instead of cloning this monorepo into itself."""
 
 import json
 import os
+import re
 import subprocess
 from pathlib import Path
 from typing import Callable, Iterable, List, Optional
@@ -17,15 +18,29 @@ from .specs import ExtensionSpec, ExternalRepoSource, InRepoSource
 
 RunGit = Callable[..., None]
 
+_URL_CREDENTIALS_RE = re.compile(r"://[^/@\s]+@")
+
+
+def _redact_credentials(text: str) -> str:
+    return _URL_CREDENTIALS_RE.sub("://***@", text)
+
+
+def _format_git_error(args: List[str], stderr: str) -> str:
+    """Git failure message with URL credentials masked.
+
+    Clone args (and git's own stderr) can carry the GH_TOKEN-embedded URL;
+    this string reaches Slack via the notify subscriber, which unlike the
+    Actions log does no secret masking.
+    """
+    return _redact_credentials(f"git {' '.join(args)} failed: {stderr.strip()}")
+
 
 def _run_git(args: List[str], cwd: Optional[Path] = None) -> None:
     result = subprocess.run(
         ["git", *args], cwd=cwd, capture_output=True, text=True
     )
     if result.returncode != 0:
-        raise RuntimeError(
-            f"git {' '.join(args)} failed: {result.stderr.strip()}"
-        )
+        raise RuntimeError(_format_git_error(args, result.stderr))
 
 
 def clone_url(repo: str) -> str:

--- a/packages/browseros/bos_build/release/extensions/workspace.py
+++ b/packages/browseros/bos_build/release/extensions/workspace.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""Workspace helpers for extension builds: source checkout, version stamp,
+build .env, and shell command execution. Port of the actions repo's
+repo.py/manifest.py/builder.py with one behavior change — in-repo sources
+build from the working tree instead of cloning this monorepo into itself."""
+
+import json
+import os
+import subprocess
+from pathlib import Path
+from typing import Callable, Iterable, List, Optional
+
+from dotenv import set_key
+
+from ...lib.utils import log_info, log_success, log_warning
+from .specs import ExtensionSpec, ExternalRepoSource, InRepoSource
+
+RunGit = Callable[..., None]
+
+
+def _run_git(args: List[str], cwd: Optional[Path] = None) -> None:
+    result = subprocess.run(
+        ["git", *args], cwd=cwd, capture_output=True, text=True
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git {' '.join(args)} failed: {result.stderr.strip()}"
+        )
+
+
+def clone_url(repo: str) -> str:
+    """https clone URL; GH_TOKEN embeds as x-access-token for private repos."""
+    token = os.environ.get("GH_TOKEN")
+    if token:
+        return f"https://x-access-token:{token}@github.com/{repo}.git"
+    return f"https://github.com/{repo}.git"
+
+
+def resolve_source(
+    spec: ExtensionSpec,
+    monorepo_root: Path,
+    work_root: Path,
+    branch_override: Optional[str],
+    run_git: Optional[RunGit] = None,
+) -> Path:
+    """Return the source root to build from.
+
+    In-repo specs build the monorepo working tree as-is (branch selection is
+    the caller's checkout, e.g. the workflow's ref). External specs clone
+    into work_root/repos/<name>, or fetch+reset an existing checkout.
+    """
+    git = run_git or _run_git
+    source = spec.source
+
+    if isinstance(source, InRepoSource):
+        path = monorepo_root / source.path
+        if not path.is_dir():
+            raise FileNotFoundError(
+                f"In-repo source for '{spec.name}' not found: {path}"
+            )
+        return path
+
+    assert isinstance(source, ExternalRepoSource)
+    branch = branch_override or source.branch
+    dest = work_root / "repos" / source.repo.split("/")[-1]
+
+    if dest.exists():
+        log_info(f"Updating {source.repo} at {dest} ({branch})")
+        git(["fetch", "origin", branch], cwd=dest)
+        git(["checkout", branch], cwd=dest)
+        git(["reset", "--hard", f"origin/{branch}"], cwd=dest)
+    else:
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        log_info(f"Cloning {source.repo} ({branch}) -> {dest}")
+        git(["clone", "--branch", branch, clone_url(source.repo), str(dest)])
+    return dest
+
+
+def update_manifest_version(manifest_path: Path, version: str) -> None:
+    """Stamp version into a JSON manifest/package.json, keeping other keys."""
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"Manifest not found: {manifest_path}")
+
+    manifest = json.loads(manifest_path.read_text())
+    old = manifest.get("version", "unknown")
+    manifest["version"] = version
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n")
+    log_success(f"{manifest_path.name}: version {old} -> {version}")
+
+
+def write_env_file(directory: Path, names: Iterable[str]) -> Path:
+    """Recreate <directory>/.env from the named process env vars.
+
+    Some bundler configs only read env from file (old builder.py constraint),
+    so the build env is materialized next to the app. Unset vars are skipped.
+    """
+    env_path = directory / ".env"
+    env_path.write_text("")
+    for name in names:
+        value = os.environ.get(name)
+        if value:
+            set_key(str(env_path), name, value)
+        else:
+            log_warning(f".env: skipped {name} (not set)")
+    return env_path
+
+
+def run_command(command: str, cwd: Path) -> None:
+    """Run a spec's shell command (pre_build/build) in the source root."""
+    log_info(f"$ {command}  (cwd: {cwd})")
+    result = subprocess.run(command, shell=True, cwd=cwd)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Command failed with exit {result.returncode}: {command}"
+        )

--- a/packages/browseros/bos_build/release/extensions/workspace_test.py
+++ b/packages/browseros/bos_build/release/extensions/workspace_test.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Tests for extension build workspace helpers."""
+
+import dataclasses
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from .specs import ExternalRepoSource, InRepoSource, spec_by_name
+from .workspace import (
+    clone_url,
+    resolve_source,
+    run_command,
+    update_manifest_version,
+    write_env_file,
+)
+
+
+class RecordingGit:
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, args, cwd=None):
+        self.calls.append((tuple(args), cwd))
+
+
+class ResolveSourceTest(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.monorepo = Path(self.tmp.name) / "monorepo"
+        (self.monorepo / "packages/browseros-agent").mkdir(parents=True)
+        self.work_root = Path(self.tmp.name) / "work"
+
+    def test_in_repo_resolves_to_working_tree_without_git(self):
+        git = RecordingGit()
+        path = resolve_source(
+            spec_by_name("agent"),
+            monorepo_root=self.monorepo,
+            work_root=self.work_root,
+            branch_override=None,
+            run_git=git,
+        )
+        self.assertEqual(path, self.monorepo / "packages/browseros-agent")
+        self.assertEqual(git.calls, [])
+
+    def test_in_repo_missing_path_raises(self):
+        broken = dataclasses.replace(
+            spec_by_name("agent"), source=InRepoSource(path="packages/gone")
+        )
+        with self.assertRaisesRegex(FileNotFoundError, "packages/gone"):
+            resolve_source(
+                broken,
+                monorepo_root=self.monorepo,
+                work_root=self.work_root,
+                branch_override=None,
+                run_git=RecordingGit(),
+            )
+
+    def test_external_fresh_clone_command(self):
+        git = RecordingGit()
+        path = resolve_source(
+            spec_by_name("bugreporter"),
+            monorepo_root=self.monorepo,
+            work_root=self.work_root,
+            branch_override=None,
+            run_git=git,
+        )
+        dest = self.work_root / "repos" / "BrowserOS-feedback-extension"
+        self.assertEqual(path, dest)
+        self.assertEqual(
+            git.calls,
+            [
+                (
+                    (
+                        "clone",
+                        "--branch",
+                        "main",
+                        "https://github.com/browseros-ai/BrowserOS-feedback-extension.git",
+                        str(dest),
+                    ),
+                    None,
+                )
+            ],
+        )
+
+    def test_external_existing_updates_and_branch_override(self):
+        git = RecordingGit()
+        dest = self.work_root / "repos" / "BrowserOS-agent"
+        dest.mkdir(parents=True)
+        path = resolve_source(
+            spec_by_name("controller"),
+            monorepo_root=self.monorepo,
+            work_root=self.work_root,
+            branch_override="canary",
+            run_git=git,
+        )
+        self.assertEqual(path, dest)
+        self.assertEqual(
+            git.calls,
+            [
+                (("fetch", "origin", "canary"), dest),
+                (("checkout", "canary"), dest),
+                (("reset", "--hard", "origin/canary"), dest),
+            ],
+        )
+
+    def test_clone_url_embeds_gh_token_when_set(self):
+        with patch.dict("os.environ", {"GH_TOKEN": "secret123"}):
+            self.assertEqual(
+                clone_url("browseros-ai/BrowserOS-agent"),
+                "https://x-access-token:secret123@github.com/browseros-ai/BrowserOS-agent.git",
+            )
+        with patch.dict("os.environ", {}, clear=False):
+            import os
+
+            os.environ.pop("GH_TOKEN", None)
+            self.assertEqual(
+                clone_url("browseros-ai/BrowserOS-agent"),
+                "https://github.com/browseros-ai/BrowserOS-agent.git",
+            )
+
+    def test_branch_override_applies_to_fresh_clone(self):
+        git = RecordingGit()
+        resolve_source(
+            spec_by_name("bugreporter"),
+            monorepo_root=self.monorepo,
+            work_root=self.work_root,
+            branch_override="release-candidate",
+            run_git=git,
+        )
+        args, _ = git.calls[0]
+        self.assertIn("release-candidate", args)
+        self.assertNotIn("main", args)
+
+
+class UpdateManifestVersionTest(unittest.TestCase):
+    def test_bumps_version_and_preserves_other_keys(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            manifest = Path(tmp) / "package.json"
+            manifest.write_text(
+                json.dumps({"name": "@browseros/app", "version": "0.0.1", "private": True})
+            )
+            update_manifest_version(manifest, "9.8.7")
+            content = manifest.read_text()
+            data = json.loads(content)
+            self.assertEqual(data["version"], "9.8.7")
+            self.assertEqual(data["name"], "@browseros/app")
+            self.assertTrue(data["private"])
+            self.assertTrue(content.endswith("\n"))
+
+    def test_missing_manifest_raises(self):
+        with self.assertRaises(FileNotFoundError):
+            update_manifest_version(Path("/nonexistent/manifest.json"), "1.0")
+
+
+class WriteEnvFileTest(unittest.TestCase):
+    def test_writes_present_vars_skips_missing_and_replaces_stale(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            env_dir = Path(tmp)
+            (env_dir / ".env").write_text("STALE=old\n")
+            with patch.dict(
+                "os.environ",
+                {"NODE_ENV": "production", "POSTHOG_API_KEY": "ph-key"},
+            ):
+                import os
+
+                os.environ.pop("MISSING_VAR", None)
+                path = write_env_file(
+                    env_dir, ("NODE_ENV", "POSTHOG_API_KEY", "MISSING_VAR")
+                )
+            content = path.read_text()
+            self.assertIn("NODE_ENV", content)
+            self.assertIn("production", content)
+            self.assertIn("ph-key", content)
+            self.assertNotIn("MISSING_VAR", content)
+            self.assertNotIn("STALE", content)
+
+
+class RunCommandTest(unittest.TestCase):
+    def test_nonzero_exit_raises_with_command(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaisesRegex(RuntimeError, "exit 7"):
+                run_command("exit 7", Path(tmp))
+
+    def test_success_runs_in_cwd(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            run_command("touch made-here", Path(tmp))
+            self.assertTrue((Path(tmp) / "made-here").exists())
+
+
+class SpecSourceTypesTest(unittest.TestCase):
+    def test_external_specs_expose_repo_names_for_work_dirs(self):
+        source = spec_by_name("controller").source
+        self.assertIsInstance(source, ExternalRepoSource)
+        self.assertEqual(source.repo.split("/")[-1], "BrowserOS-agent")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/bos_build/release/extensions/workspace_test.py
+++ b/packages/browseros/bos_build/release/extensions/workspace_test.py
@@ -10,6 +10,7 @@ from unittest.mock import patch
 
 from .specs import ExternalRepoSource, InRepoSource, spec_by_name
 from .workspace import (
+    _format_git_error,
     clone_url,
     resolve_source,
     run_command,
@@ -134,6 +135,35 @@ class ResolveSourceTest(unittest.TestCase):
         args, _ = git.calls[0]
         self.assertIn("release-candidate", args)
         self.assertNotIn("main", args)
+
+
+class GitErrorRedactionTest(unittest.TestCase):
+    def test_token_in_clone_args_and_stderr_is_masked(self):
+        args = [
+            "clone",
+            "--branch",
+            "main",
+            "https://x-access-token:tok3n@github.com/browseros-ai/x.git",
+            "/work/repos/x",
+        ]
+        stderr = (
+            "fatal: repository "
+            "'https://x-access-token:tok3n@github.com/browseros-ai/x.git' "
+            "not found"
+        )
+        message = _format_git_error(args, stderr)
+        self.assertNotIn("tok3n", message)
+        self.assertIn("://***@github.com", message)
+        self.assertIn("git clone --branch main", message)
+
+    def test_plain_urls_pass_through(self):
+        message = _format_git_error(
+            ["fetch", "origin", "main"], "fatal: could not read from remote"
+        )
+        self.assertEqual(
+            message,
+            "git fetch origin main failed: fatal: could not read from remote",
+        )
 
 
 class UpdateManifestVersionTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Absorbs the actions repo's extension packaging (`release-extensions.yml` + `scripts/extensions/*` + `configs/extensions.yaml`) into `bos_build/release/extensions/`: a frozen `ExtensionSpec` table (ids single-sourced from `core/products.py`, new `BROWSEROS_CONTROLLER_EXTENSION_ID`), workspace/CRX helpers, and an `ExtensionReleaseModule` step.
- New CLI: `browseros ext release --version X [--name N] [--branch B] [--channel alpha|prod] [--publish-manifest] [--chrome-binary P]` — builds, stamps, packs and uploads CRXs, then regenerates update-manifest(.alpha).xml + extensions(.alpha).json + bundled-manifest.xml **through the feeds publisher rails** (dry-run default; `--publish-manifest` writes). This kills the old "generate update-manifest.xml locally, upload to R2 by hand" gap.
- In-repo extensions (agent, browserclaw) build from the working tree — no more cloning this monorepo into itself; controller and bugreporter stay external clones. Stale `apps/agent` paths corrected to `apps/app`.
- New `.github/workflows/release-extensions.yml` drives it via `uv run browseros ext release …` (inputs: version / extension / branch / channel / publish_manifest).
- Existing `release/extensions.py` (ExtensionsFeedModule) moved to `release/extensions/manifests.py` unchanged; `browseros release extensions` behaves identically.

## Design
Data-first spec table mirroring `feeds/spec.py`'s pattern; thin injectable helpers (source resolve / manifest stamp / .env / pack) covered by construction-level tests (no chrome, no network, no R2); pipeline assembly (`build_pipeline`) statically validates name/channel/version/branch and appends the feeds step only when a released extension is in the feeds table (controller is packaging-only and never enters feeds — it is not bundled). Two adversarial review rounds hardened: workflow args quoted at execution time (no command-string round-trip), GH_TOKEN redacted from git failure paths (they reach Slack via the notify subscriber), assembly-time channel/version validation so a typo can't burn a build+upload, strict `--chrome-binary`, `bun ci` for in-repo installs.

## Secrets the human must add to THIS repo (workflow reads them)
- `BROWSEROS_AGENT_V2_KEY`, `BROWSEROS_CONTROLLER_KEY`, `BUGREPORTER_KEY`, `BROWSERCLAW_KEY` — CRX signing keys (copy values from the actions repo's secrets)
- `GH_TOKEN` — clone token for external extension repos (needed only if BrowserOS-agent / BrowserOS-feedback-extension are private)
- `VITE_PUBLIC_SENTRY_DSN`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `VITE_PUBLIC_POSTHOG_KEY`, `VITE_PUBLIC_POSTHOG_HOST` — agent build env
- `POSTHOG_API_KEY` — controller build env (already exists in this repo if release-cli uses it)
- `R2_ACCOUNT_ID` / `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` / `R2_BUCKET` — already configured (release-cli.yml uses them)

## Deltas vs the old actions-repo workflow (deliberate)
- Dead `agent-v2` choice dropped (no yaml entry existed; it errored at runtime).
- Dead secrets not carried: `KLAVIS_API_KEY`, `MOONDREAM_API_KEY`, `BROWSEROS_AGENT_KEY` (no current spec references them).
- Draft-GitHub-release step dropped — distribution is CDN + feeds now; CRX artifacts still uploaded to the workflow run (30d retention).
- Manifest regeneration is no longer manual: it flows through the publisher (downgrade guard, channel-metadata rail, crx HEAD checks, feeds-history backup).

## Manual follow-ups (in order)
1. Configure the secrets above.
2. Dispatch `Release Extensions` for ONE extension (suggest `bugreporter`) end-to-end with `publish_manifest` unchecked; inspect the dry-run manifest diff in the logs, then re-run with it checked.
3. Archive `browseros-project/actions` (left untouched by this PR — human step).

## Test plan
- [x] `uv run python -m unittest discover -s bos_build -t . -p "*_test.py"` — 530 tests green (55 new: spec-table integrity incl. crx-key drift guard vs feeds spec, source resolution, manifest stamping, .env, git-error redaction, pack command assembly, orchestration order/fail-fast, pipeline assembly + early validation)
- [x] `uv run ruff check bos_build` clean
- [x] `uv run browseros ext --help`, `ext release --help`, `browseros release extensions --help`, `build --list`, `product doctor` all pass
- [x] `actionlint` clean on the new workflow
- [ ] Post-merge: one-extension end-to-end dispatch (needs secrets — see follow-ups)

🤖 Generated with [Claude Code](https://claude.com/claude-code)