### PR TITLE
feat(browseros): dev doctor — patch stack health report

### DIFF
--- a/packages/browseros/bos_build/README.md
+++ b/packages/browseros/bos_build/README.md
@@ -151,8 +151,9 @@ browseros dev doctor --against ~/chromium/src   # + which patches fail, by featu
 browseros dev doctor --feature llm-chat --json  # filtered / machine-readable
 ```
 
-Exit 0 healthy / 1 findings. `--against` only ever dry-runs
-(`git apply --check`); the chromium tree is never modified.
+Exit 0 healthy / 1 findings / 2 usage or environment errors. `--against`
+only ever dry-runs (`git apply --check`); the chromium tree is never
+modified.
 
 ## Tests
 

--- a/packages/browseros/bos_build/README.md
+++ b/packages/browseros/bos_build/README.md
@@ -153,7 +153,9 @@ browseros dev doctor --feature llm-chat --json  # filtered / machine-readable
 
 Exit 0 healthy / 1 findings / 2 usage or environment errors. `--against`
 only ever dry-runs (`git apply --check`); the chromium tree is never
-modified.
+modified. The dry-run is stricter than the build's apply step (which
+falls back to `--ignore-whitespace`/`--3way`), so a doctor failure means
+"needs attention", not necessarily "won't build".
 
 ## Tests
 

--- a/packages/browseros/bos_build/README.md
+++ b/packages/browseros/bos_build/README.md
@@ -25,8 +25,9 @@ bos_build/
   release/      RELEASE toolset — list, publish, download, github, appcast;
                 release/ota/ ships server OTA updates
   patchkit/     DEV toolset — the Python patch surface: dev extract,
-                non-interactive batch-apply, features.yaml IO (interactive
-                apply/sync lives in the Go tool: tools/patch, `bpatch`)
+                non-interactive batch-apply, features.yaml IO, and the
+                read-only patch-stack doctor (interactive apply/sync
+                lives in the Go tool: tools/patch, `bpatch`)
   profiles/     saved switch sets (flat yaml; a local profile may opt into
                 an explicit modules: list — shipped profiles never do)
   config/       data: gn flags, resource yamls, appcast templates, offset
@@ -137,6 +138,21 @@ server bundle definitions. Verify with:
 ```bash
 browseros product doctor          # identity uniqueness + branding assets
 ```
+
+## Patch stack
+
+`features.yaml` maps each feature to its patches under
+`chromium_patches/`. The dev doctor keeps that map honest — read-only,
+so it can run in CI and before a chromium bump:
+
+```bash
+browseros dev doctor                            # features.yaml ↔ patches on disk
+browseros dev doctor --against ~/chromium/src   # + which patches fail, by feature
+browseros dev doctor --feature llm-chat --json  # filtered / machine-readable
+```
+
+Exit 0 healthy / 1 findings. `--against` only ever dry-runs
+(`git apply --check`); the chromium tree is never modified.
 
 ## Tests
 

--- a/packages/browseros/bos_build/cli/dev.py
+++ b/packages/browseros/bos_build/cli/dev.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """
-Dev CLI - Chromium patch extraction
+Dev CLI - Chromium patch extraction and patch-stack health
 
-Extracts commits or files from a Chromium checkout into chromium_patches/.
-Interactive patch application, sync, and conflict handling live in the Go
-tool (tools/patch, `bpatch`) — this CLI deliberately keeps only extract.
+Extracts commits or files from a Chromium checkout into chromium_patches/,
+and reports patch-stack health (doctor). Interactive patch application,
+sync, and conflict handling live in the Go tool (tools/patch, `bpatch`).
 """
 
+import json
 from pathlib import Path
 from typing import Optional
 
@@ -73,12 +74,16 @@ def main(
     quiet: bool = Option(False, "--quiet", "-q", help="Suppress non-essential output"),
 ):
     """
-    Dev CLI - Chromium patch extraction
+    Dev CLI - Chromium patch extraction and patch-stack health
 
     Extract patches from commits:
       browseros dev extract commit HEAD
       browseros dev extract range HEAD~5 HEAD
       browseros dev extract patch chrome/common/foo.h
+
+    Check patch-stack health (read-only):
+      browseros dev doctor
+      browseros dev doctor --against ~/chromium/src --json
 
     Applying and syncing patches is handled by the Go tool: bpatch
     (packages/browseros/tools/patch).
@@ -96,6 +101,102 @@ extract_app = Typer(
 )
 
 app.add_typer(extract_app, name="extract")
+
+
+def _render_doctor_report(report: dict) -> None:
+    repo = report["repo"]
+    if repo["findings"]:
+        log_info(
+            f"Repo checks: {repo['errors']} error(s), {repo['warnings']} warning(s)"
+        )
+        for finding in repo["findings"]:
+            if finding["severity"] == "error":
+                log_error(f"  {finding['message']}")
+            else:
+                log_warning(f"  {finding['message']}")
+    else:
+        log_success(
+            f"Repo checks clean: {repo['patches']} patches "
+            f"across {repo['features']} features"
+        )
+
+    apply_section = report["apply"]
+    if apply_section is not None:
+        if apply_section["failures"]:
+            log_error(
+                f"Apply check against {apply_section['against']}: "
+                f"{apply_section['failed']}/{apply_section['total']} patches fail "
+                f"({apply_section['features_affected']} feature(s) affected)"
+            )
+            by_feature: dict = {}
+            for failure in apply_section["failures"]:
+                by_feature.setdefault(failure["feature"], []).append(failure["patch"])
+            for feature_name in sorted(by_feature):
+                log_error(f"  {feature_name}:")
+                for patch in by_feature[feature_name]:
+                    log_error(f"    - {patch}")
+        else:
+            log_success(
+                f"Apply check against {apply_section['against']}: "
+                f"all {apply_section['total']} patches apply cleanly"
+            )
+
+    if report["healthy"]:
+        log_success("Patch doctor: healthy")
+    else:
+        log_error("Patch doctor: unhealthy")
+
+
+@app.command(name="doctor")
+def doctor(
+    against: Optional[Path] = Option(
+        None,
+        "--against",
+        help="Chromium source tree to dry-run every patch against "
+        "(git apply --check)",
+        exists=True,
+        file_okay=False,
+    ),
+    feature: Optional[str] = Option(
+        None, "--feature", help="Restrict the report to one feature"
+    ),
+    json_output: bool = Option(
+        False, "--json", help="Emit a machine-readable JSON report on stdout"
+    ),
+):
+    """Read-only patch-stack health report.
+
+    Verifies features.yaml against the patches on disk (every entry resolves,
+    every patch is claimed by a feature, claims don't overlap); with --against,
+    dry-runs every patch and groups failures by feature. Read-only: nothing is
+    written to the chromium tree. Exit 0 healthy / 1 findings.
+    """
+    from ..lib.paths import get_package_root
+    from ..patchkit.doctor import (
+        build_report,
+        check_apply,
+        check_repo,
+        load_features,
+    )
+
+    root = get_package_root()
+    patches_dir = root / "chromium_patches"
+    features = load_features(root)
+    try:
+        findings = check_repo(features, patches_dir, feature)
+        apply_report = (
+            check_apply(features, patches_dir, against, feature) if against else None
+        )
+    except ValueError as e:
+        log_error(str(e))
+        raise typer.Exit(2)
+
+    report = build_report(root, features, findings, apply_report)
+    if json_output:
+        typer.echo(json.dumps(report, indent=2))
+    else:
+        _render_doctor_report(report)
+    raise typer.Exit(0 if report["healthy"] else 1)
 
 
 @extract_app.command(name="commit")

--- a/packages/browseros/bos_build/cli/dev.py
+++ b/packages/browseros/bos_build/cli/dev.py
@@ -105,15 +105,19 @@ app.add_typer(extract_app, name="extract")
 
 def _render_doctor_report(report: dict) -> None:
     repo = report["repo"]
+    scope = f" for feature '{report['feature']}'" if report["feature"] else ""
     if repo["findings"]:
         log_info(
-            f"Repo checks: {repo['errors']} error(s), {repo['warnings']} warning(s)"
+            f"Repo checks{scope}: "
+            f"{repo['errors']} error(s), {repo['warnings']} warning(s)"
         )
         for finding in repo["findings"]:
             if finding["severity"] == "error":
                 log_error(f"  {finding['message']}")
             else:
                 log_warning(f"  {finding['message']}")
+    elif scope:
+        log_success(f"Repo checks clean{scope}")
     else:
         log_success(
             f"Repo checks clean: {repo['patches']} patches "
@@ -169,8 +173,11 @@ def doctor(
     Verifies features.yaml against the patches on disk (every entry resolves,
     every patch is claimed by a feature, claims don't overlap); with --against,
     dry-runs every patch and groups failures by feature. Read-only: nothing is
-    written to the chromium tree. Exit 0 healthy / 1 findings.
+    written to the chromium tree. Exit 0 healthy / 1 findings / 2 usage or
+    environment errors.
     """
+    import yaml
+
     from ..lib.paths import get_package_root
     from ..patchkit.doctor import (
         build_report,
@@ -178,20 +185,21 @@ def doctor(
         check_repo,
         load_features,
     )
+    from ..patchkit.extract.utils import GitError
 
     root = get_package_root()
     patches_dir = root / "chromium_patches"
-    features = load_features(root)
     try:
+        features = load_features(root)
         findings = check_repo(features, patches_dir, feature)
         apply_report = (
             check_apply(features, patches_dir, against, feature) if against else None
         )
-    except ValueError as e:
+    except (ValueError, yaml.YAMLError, GitError) as e:
         log_error(str(e))
         raise typer.Exit(2)
 
-    report = build_report(root, features, findings, apply_report)
+    report = build_report(root, features, findings, apply_report, feature)
     if json_output:
         typer.echo(json.dumps(report, indent=2))
     else:

--- a/packages/browseros/bos_build/cli/dev.py
+++ b/packages/browseros/bos_build/cli/dev.py
@@ -185,7 +185,14 @@ def doctor(
         check_repo,
         load_features,
     )
-    from ..patchkit.extract.utils import GitError
+    from ..patchkit.extract.utils import GitError, validate_git_repository
+
+    if against and not validate_git_repository(against):
+        log_error(
+            f"--against {against} is not a git repository "
+            "(expected a chromium src checkout)"
+        )
+        raise typer.Exit(2)
 
     root = get_package_root()
     patches_dir = root / "chromium_patches"

--- a/packages/browseros/bos_build/cli/dev_test.py
+++ b/packages/browseros/bos_build/cli/dev_test.py
@@ -2,6 +2,7 @@
 """CLI surface tests for the dev subcommands."""
 
 import json
+import tempfile
 import unittest
 from unittest import mock
 
@@ -9,6 +10,7 @@ import yaml
 from typer.testing import CliRunner
 
 from bos_build.browseros import app
+from bos_build.patchkit.doctor import ApplyFailure, ApplyReport, Finding
 
 runner = CliRunner()
 
@@ -75,6 +77,54 @@ class DoctorCliTest(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 2, combined(result))
         self.assertIn("features.yaml is broken", combined(result))
+
+    def test_findings_render_and_exit_1(self):
+        finding = Finding(
+            "missing-patch",
+            "error",
+            "one: no patch on disk for entry 'chrome/gone.cc'",
+            feature="one",
+            path="chrome/gone.cc",
+        )
+        with mock.patch(
+            "bos_build.patchkit.doctor.check_repo", return_value=[finding]
+        ):
+            result = invoke("doctor")
+
+        self.assertEqual(result.exit_code, 1, combined(result))
+        self.assertIn("chrome/gone.cc", combined(result))
+        self.assertIn("unhealthy", combined(result))
+
+    def test_against_non_git_dir_is_a_usage_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            result = invoke("doctor", "--against", tmp)
+
+        self.assertEqual(result.exit_code, 2, combined(result))
+        self.assertIn("not a git repository", combined(result))
+
+    def test_against_failures_grouped_and_exit_1(self):
+        report = ApplyReport(
+            against="/fake/src",
+            total=2,
+            clean=1,
+            failures=[ApplyFailure("chrome/a.cc", "one", "boom")],
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            with (
+                mock.patch(
+                    "bos_build.patchkit.extract.utils.validate_git_repository",
+                    return_value=True,
+                ),
+                mock.patch(
+                    "bos_build.patchkit.doctor.check_apply", return_value=report
+                ),
+                mock.patch("bos_build.patchkit.doctor.check_repo", return_value=[]),
+            ):
+                result = invoke("doctor", "--against", tmp)
+
+        self.assertEqual(result.exit_code, 1, combined(result))
+        self.assertIn("1/2 patches fail", combined(result))
+        self.assertIn("chrome/a.cc", combined(result))
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/cli/dev_test.py
+++ b/packages/browseros/bos_build/cli/dev_test.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""CLI surface tests for the dev subcommands."""
+
+import json
+import unittest
+
+from typer.testing import CliRunner
+
+from bos_build.browseros import app
+
+runner = CliRunner()
+
+
+def invoke(*args: str):
+    return runner.invoke(app, ["dev", *args])
+
+
+def combined(result) -> str:
+    """stdout + stderr across click versions (8.2 split them)."""
+    out = result.output
+    try:
+        out += result.stderr
+    except (ValueError, AttributeError):
+        pass
+    return out
+
+
+class DevHelpTest(unittest.TestCase):
+    def test_dev_help_lists_extract_and_doctor(self):
+        result = invoke("--help")
+
+        self.assertEqual(result.exit_code, 0, combined(result))
+        self.assertIn("extract", result.output)
+        self.assertIn("doctor", result.output)
+
+
+class DoctorCliTest(unittest.TestCase):
+    def test_help_documents_flags_and_read_only_guarantee(self):
+        result = invoke("doctor", "--help")
+
+        self.assertEqual(result.exit_code, 0, combined(result))
+        for flag in ("--against", "--feature", "--json"):
+            self.assertIn(flag, result.output)
+        self.assertIn("read-only", result.output.lower())
+
+    def test_json_report_has_stable_shape_and_matching_exit_code(self):
+        result = invoke("doctor", "--json")
+
+        report = json.loads(result.output)
+        self.assertEqual(
+            set(report), {"root", "repo", "apply", "healthy"}
+        )
+        self.assertEqual(
+            set(report["repo"]),
+            {"patches", "features", "errors", "warnings", "findings"},
+        )
+        self.assertIsNone(report["apply"])
+        self.assertEqual(result.exit_code, 0 if report["healthy"] else 1)
+
+    def test_unknown_feature_is_a_usage_error(self):
+        result = invoke("doctor", "--feature", "definitely-not-a-feature")
+
+        self.assertEqual(result.exit_code, 2, combined(result))
+        self.assertIn("unknown feature", combined(result))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/bos_build/cli/dev_test.py
+++ b/packages/browseros/bos_build/cli/dev_test.py
@@ -3,7 +3,9 @@
 
 import json
 import unittest
+from unittest import mock
 
+import yaml
 from typer.testing import CliRunner
 
 from bos_build.browseros import app
@@ -48,13 +50,14 @@ class DoctorCliTest(unittest.TestCase):
 
         report = json.loads(result.output)
         self.assertEqual(
-            set(report), {"root", "repo", "apply", "healthy"}
+            set(report), {"root", "feature", "repo", "apply", "healthy"}
         )
         self.assertEqual(
             set(report["repo"]),
             {"patches", "features", "errors", "warnings", "findings"},
         )
         self.assertIsNone(report["apply"])
+        self.assertIsNone(report["feature"])
         self.assertEqual(result.exit_code, 0 if report["healthy"] else 1)
 
     def test_unknown_feature_is_a_usage_error(self):
@@ -62,6 +65,16 @@ class DoctorCliTest(unittest.TestCase):
 
         self.assertEqual(result.exit_code, 2, combined(result))
         self.assertIn("unknown feature", combined(result))
+
+    def test_broken_features_yaml_is_a_clean_usage_error(self):
+        with mock.patch(
+            "bos_build.patchkit.doctor.load_features",
+            side_effect=yaml.YAMLError("features.yaml is broken"),
+        ):
+            result = invoke("doctor")
+
+        self.assertEqual(result.exit_code, 2, combined(result))
+        self.assertIn("features.yaml is broken", combined(result))
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/features.yaml
+++ b/packages/browseros/bos_build/features.yaml
@@ -30,23 +30,15 @@ features:
   branding:
     description: "chore: browseros branding and identity"
     files:
-      # Chrome + BrowserOS version
-      - chrome/VERSION
-      - chrome/BROWSEROS_VERSION
+      # Version info
       - base/version_info/BUILD.gn
       - base/version_info/version_info.h
       - base/version_info/version_info_values.h.version
-      # Branding strings and resources
-      - chrome/app/chromium_strings.grd
-      - chrome/app/settings_chromium_strings.grdp
-      - chrome/app/theme/
-      - chrome/enterprise_companion/branding.gni
       # Branding file paths
       - chrome/common/chrome_constants.cc
       - chrome/common/chrome_paths.cc
       - chrome/common/chrome_paths.h
       - chrome/common/chrome_paths_linux.cc
-      - chrome/install_static/chromium_install_modes.cc
       - chrome/install_static/chromium_install_modes.h
       # About page (version + branding display)
       - chrome/browser/resources/settings/about_page/about_page.html
@@ -56,8 +48,6 @@ features:
       - chrome/browser/chrome_browser_application_mac.mm
       - chrome/browser/ui/cocoa/dock_icon.h
       - chrome/browser/ui/cocoa/dock_icon.mm
-      # Updater branding
-      - chrome/updater/branding.gni
       # Custom vector icons
       - components/vector_icons/BUILD.gn
       - components/vector_icons/chat_orange.icon
@@ -96,7 +86,6 @@ features:
       - chrome/browser/mac/chrome_browser_main_extra_parts_mac.mm
       - chrome/browser/mac/sparkle_glue.h
       - chrome/browser/mac/sparkle_glue.mm
-      - chrome/browser/mac/su_updater.h
       - chrome/browser/sparkle_buildflags.gni
       - chrome/browser/ui/BUILD.gn
       - chrome/browser/ui/toolbar/app_menu_icon_controller.cc
@@ -160,10 +149,6 @@ features:
       - chrome/browser/extensions/api/browser_os/browser_os_api_utils.h
       - chrome/browser/extensions/api/browser_os/browser_os_change_detector.cc
       - chrome/browser/extensions/api/browser_os/browser_os_change_detector.h
-      - chrome/browser/extensions/api/browser_os/browser_os_content_processor.cc
-      - chrome/browser/extensions/api/browser_os/browser_os_content_processor.h
-      - chrome/browser/extensions/api/browser_os/browser_os_snapshot_processor.cc
-      - chrome/browser/extensions/api/browser_os/browser_os_snapshot_processor.h
       - chrome/browser/extensions/api/side_panel/side_panel_api.h
       - chrome/browser/extensions/api/side_panel/side_panel_service.cc
       - chrome/browser/extensions/api/side_panel/side_panel_service.h
@@ -194,11 +179,7 @@ features:
     files:
       - chrome/browser/browseros/bundled_extensions/
       - chrome/browser/browseros/extensions/
-      - chrome/browser/extensions/api/developer_private/extension_info_generator_shared.cc
-      - chrome/browser/extensions/browseros_external_loader.cc
-      - chrome/browser/extensions/browseros_external_loader.h
       - chrome/browser/extensions/chrome_extension_registrar_delegate.cc
-      - chrome/browser/extensions/extension_web_ui_override_registrar.cc
       - chrome/browser/extensions/extension_url_overrides_registrar.cc
       - chrome/browser/extensions/external_provider_impl.cc
       - chrome/browser/extensions/updater/extension_updater.cc
@@ -213,10 +194,6 @@ features:
       - chrome/browser/resources/settings/BUILD.gn
       - chrome/browser/resources/settings/browseros_prefs_page/browseros_prefs_page.html
       - chrome/browser/resources/settings/browseros_prefs_page/browseros_prefs_page.ts
-      - chrome/browser/resources/settings/nxtscape_page/models_data.html
-      - chrome/browser/resources/settings/nxtscape_page/models_data.ts
-      - chrome/browser/resources/settings/nxtscape_page/nxtscape_page.html
-      - chrome/browser/resources/settings/nxtscape_page/nxtscape_page.ts
       - chrome/browser/resources/settings/route.ts
       - chrome/browser/resources/settings/router.ts
       - chrome/browser/resources/settings/settings.ts
@@ -243,8 +220,6 @@ features:
       - chrome/common/importer/importer_bridge.h
       - chrome/common/importer/mock_importer_bridge.h
       - chrome/common/importer/profile_import.mojom
-      - chrome/common/importer/profile_import_process_param_traits.cc
-      - chrome/common/importer/profile_import_process_param_traits.h
       - chrome/common/importer/profile_import_process_param_traits_macros.h
       - chrome/test/BUILD.gn
       - chrome/test/data/webui/settings/import_data_dialog_test.ts
@@ -264,7 +239,6 @@ features:
       - chrome/browser/chrome_browser_main.cc
       - chrome/browser/ui/webui/browseros_welcome.h
       - chrome/browser/ui/webui/chrome_web_ui_configs.cc
-      - chrome/browser/ui/webui/nxtscape_first_run.h
       - chrome/common/webui_url_constants.cc
 
   onboarding-import:
@@ -294,11 +268,9 @@ features:
       - chrome/app/generated_resources.grd
       - chrome/browser/ui/ui_features.cc
       - chrome/browser/ui/ui_features.h
-      - chrome/browser/ui/views/accelerator_table.cc
       - chrome/browser/ui/views/side_panel/BUILD.gn
       - chrome/browser/ui/side_panel/side_panel_entry_id.h
       - chrome/browser/ui/side_panel/side_panel_prefs.cc
-      - chrome/browser/ui/views/side_panel/side_panel_util.cc
       - chrome/browser/ui/views/side_panel/side_panel_helper.cc
       - chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar.mojom
       - chrome/browser/ui/webui/side_panel/customize_chrome/customize_toolbar/customize_toolbar_handler.cc
@@ -311,7 +283,6 @@ features:
     description: "feat: pin browseros native panels"
     files:
       - chrome/browser/sync/prefs/chrome_syncable_prefs_database.cc
-      - chrome/browser/ui/actions/browseros_actions_config.h
       - chrome/browser/ui/toolbar/pinned_toolbar/BUILD.gn
       - chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model.cc
       - chrome/browser/ui/toolbar/pinned_toolbar/pinned_toolbar_actions_model.h
@@ -337,7 +308,6 @@ features:
   flags:
     description: "feat: browser flags"
     files:
-      - chrome/browser/flag_descriptions.cc
       - chrome/browser/flag_descriptions.h
       - chrome/browser/ui/browser_window/internal/browser_window_features.cc
       - chrome/browser/ui/browser_window/public/browser_window_features.h
@@ -439,10 +409,8 @@ features:
       - chrome/browser/resources/settings/reset_page/reset_profile_dialog.html
       - chrome/browser/themes/BUILD.gn
       - chrome/browser/themes/theme_service.cc
-      - chrome/browser/themes/theme_service_factory.cc
       - chrome/browser/ui/browser_ui_prefs.cc
       - chrome/browser/ui/views/extensions/extension_view_views.cc
-      - chrome/browser/ui/startup/google_api_keys_infobar_delegate.cc
       - chrome/browser/ui/views/chrome_layout_provider.cc
       - chrome/browser/ui/views/infobars/infobar_container_view.cc
       - chrome/browser/ui/views/new_tab_footer/
@@ -451,7 +419,6 @@ features:
       - components/bookmarks/browser/bookmark_utils.cc
       - components/content_settings/core/browser/cookie_settings_unittest.cc
       - components/payments/core/payment_prefs.cc
-      - components/performance_manager/user_tuning/prefs.cc
       - components/search/ntp_features.cc
 
   cdp-fixes:

--- a/packages/browseros/bos_build/patchkit/batch_apply.py
+++ b/packages/browseros/bos_build/patchkit/batch_apply.py
@@ -34,6 +34,11 @@ def reset_file_to_commit(file_path: str, commit: str, chromium_src: Path) -> boo
     return result.returncode == 0
 
 
+# Marker files annotate a patch path (deleted/binary/renamed upstream) and
+# are never applied; the doctor maps them back onto their base path.
+MARKER_SUFFIXES = (".deleted", ".binary", ".rename")
+
+
 def find_patch_files(patches_dir: Path) -> List[Path]:
     """Find all valid patch files in a directory.
 
@@ -51,9 +56,7 @@ def find_patch_files(patches_dir: Path) -> List[Path]:
             p
             for p in patches_dir.rglob("*")
             if p.is_file()
-            and not p.name.endswith(".deleted")
-            and not p.name.endswith(".binary")
-            and not p.name.endswith(".rename")
+            and not p.name.endswith(MARKER_SUFFIXES)
             and not p.name.startswith(".")
         ]
     )

--- a/packages/browseros/bos_build/patchkit/batch_apply.py
+++ b/packages/browseros/bos_build/patchkit/batch_apply.py
@@ -59,6 +59,18 @@ def find_patch_files(patches_dir: Path) -> List[Path]:
     )
 
 
+def check_patch_applies(
+    patch_path: Path, chromium_src: Path
+) -> Tuple[bool, Optional[str]]:
+    """Quiet dry-run of one patch (git apply --check); never modifies the tree."""
+    result = run_git_command(
+        ["git", "apply", "--check", "-p1", str(patch_path)], cwd=chromium_src
+    )
+    if result.returncode == 0:
+        return True, None
+    return False, result.stderr
+
+
 def apply_single_patch(
     patch_path: Path,
     chromium_src: Path,
@@ -94,16 +106,13 @@ def apply_single_patch(
                 target_file.unlink()
 
     if dry_run:
-        # Just check if patch would apply
-        result = run_git_command(
-            ["git", "apply", "--check", "-p1", str(patch_path)], cwd=chromium_src
-        )
-        if result.returncode == 0:
+        success, error = check_patch_applies(patch_path, chromium_src)
+        if success:
             log_success(f"  ✓ Would apply: {display_path}")
             return True, None
         else:
             log_error(f"  ✗ Would fail: {display_path}")
-            return False, result.stderr
+            return False, error
     else:
         # Try standard apply first
         result = run_git_command(

--- a/packages/browseros/bos_build/patchkit/batch_apply_test.py
+++ b/packages/browseros/bos_build/patchkit/batch_apply_test.py
@@ -9,7 +9,11 @@ from types import SimpleNamespace
 from typing import cast
 
 from bos_build.core.context import Context
-from bos_build.patchkit.batch_apply import apply_all_patches, find_patch_files
+from bos_build.patchkit.batch_apply import (
+    apply_all_patches,
+    check_patch_applies,
+    find_patch_files,
+)
 
 
 def _git(cwd: Path, *args: str) -> None:
@@ -113,6 +117,52 @@ class BatchApplyTest(unittest.TestCase):
 
         names = [p.name for p in find_patch_files(self.patches_dir)]
         self.assertEqual(names, ["a.patch"])
+
+    def test_dry_run_reports_without_modifying_tree(self):
+        _make_patch(self.repo, self.patches_dir)
+
+        applied, failed = apply_all_patches(self._ctx(), dry_run=True)
+
+        self.assertEqual((applied, failed), (1, []))
+        self.assertNotIn(
+            "line two changed", (self.repo / "chrome" / "a.txt").read_text()
+        )
+
+
+class CheckPatchAppliesTest(unittest.TestCase):
+    def setUp(self):
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        self.root = Path(tmp.name)
+        self.repo = _make_repo(self.root)
+        self.patches_dir = self.root / "chromium_patches"
+        self.patches_dir.mkdir()
+
+    def test_clean_patch_passes_and_tree_untouched(self):
+        _make_patch(self.repo, self.patches_dir)
+
+        ok, error = check_patch_applies(
+            self.patches_dir / "chrome" / "a.txt", self.repo
+        )
+
+        self.assertTrue(ok)
+        self.assertIsNone(error)
+        self.assertNotIn(
+            "line two changed", (self.repo / "chrome" / "a.txt").read_text()
+        )
+
+    def test_failing_patch_returns_stderr(self):
+        bad = self.patches_dir / "chrome" / "a.txt"
+        bad.parent.mkdir(parents=True)
+        bad.write_text(
+            "--- a/chrome/a.txt\n+++ b/chrome/a.txt\n"
+            "@@ -1,1 +1,1 @@\n-no such line\n+replacement\n"
+        )
+
+        ok, error = check_patch_applies(bad, self.repo)
+
+        self.assertFalse(ok)
+        self.assertTrue(error)
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/patchkit/doctor.py
+++ b/packages/browseros/bos_build/patchkit/doctor.py
@@ -33,6 +33,25 @@ class Finding:
     path: Optional[str] = None
 
 
+@dataclass(frozen=True)
+class ApplyFailure:
+    patch: str
+    feature: str  # first claimant, or "(unclassified)"
+    error: str
+
+
+@dataclass(frozen=True)
+class ApplyReport:
+    against: str
+    total: int
+    clean: int
+    failures: List[ApplyFailure]
+
+    @property
+    def features_affected(self) -> int:
+        return len({failure.feature for failure in self.failures})
+
+
 def is_series_feature(spec: Dict) -> bool:
     return str(spec.get("description") or "").startswith(SERIES_PREFIX)
 
@@ -152,14 +171,18 @@ def check_classification(
     return findings
 
 
-def check_repo(
-    features: Dict, patches_dir: Path, feature: Optional[str] = None
-) -> List[Finding]:
-    """All repo-local checks; raises ValueError for an unknown feature filter."""
+def _require_known_feature(features: Dict, feature: Optional[str]) -> None:
     if feature is not None and feature not in features:
         raise ValueError(
             f"unknown feature '{feature}'. Valid: {', '.join(sorted(features))}"
         )
+
+
+def check_repo(
+    features: Dict, patches_dir: Path, feature: Optional[str] = None
+) -> List[Finding]:
+    """All repo-local checks; raises ValueError for an unknown feature filter."""
+    _require_known_feature(features, feature)
     bases = patch_base_paths(patches_dir)
     claims = compute_claims(features, bases)
     findings = [
@@ -180,3 +203,48 @@ def load_features(root_dir: Path) -> Dict:
 def diagnose_repo(root_dir: Path, feature: Optional[str] = None) -> List[Finding]:
     """Repo-local checks against a browseros package root."""
     return check_repo(load_features(root_dir), root_dir / "chromium_patches", feature)
+
+
+def check_apply(
+    features: Dict,
+    patches_dir: Path,
+    chromium_src: Path,
+    feature: Optional[str] = None,
+) -> ApplyReport:
+    """Dry-run every patch against a chromium tree, grouping failures by feature."""
+    from .batch_apply import check_patch_applies, find_patch_files
+
+    _require_known_feature(features, feature)
+    claims = compute_claims(features, patch_base_paths(patches_dir))
+    total = 0
+    failures = []
+    for patch_path in find_patch_files(patches_dir):
+        rel = patch_path.relative_to(patches_dir).as_posix()
+        owners = claims.get(rel, [])
+        if feature is not None and feature not in owners:
+            continue
+        total += 1
+        ok, error = check_patch_applies(patch_path, chromium_src)
+        if not ok:
+            failures.append(
+                ApplyFailure(
+                    patch=rel,
+                    feature=owners[0] if owners else UNCLASSIFIED,
+                    error=(error or "").strip(),
+                )
+            )
+    return ApplyReport(
+        against=str(chromium_src),
+        total=total,
+        clean=total - len(failures),
+        failures=failures,
+    )
+
+
+def diagnose_apply(
+    root_dir: Path, chromium_src: Path, feature: Optional[str] = None
+) -> ApplyReport:
+    """Apply-check against a browseros package root's patch stack."""
+    return check_apply(
+        load_features(root_dir), root_dir / "chromium_patches", chromium_src, feature
+    )

--- a/packages/browseros/bos_build/patchkit/doctor.py
+++ b/packages/browseros/bos_build/patchkit/doctor.py
@@ -194,10 +194,30 @@ def check_repo(
 
 
 def load_features(root_dir: Path) -> Dict:
+    """Load and shape-validate features.yaml; raises ValueError on a broken file."""
     from .features_io import load_features_yaml
 
-    data = load_features_yaml(root_dir / "bos_build" / "features.yaml")
-    return data.get("features") or {}
+    features_file = root_dir / "bos_build" / "features.yaml"
+    data = load_features_yaml(features_file)
+    if not isinstance(data, dict):
+        raise ValueError(f"{features_file}: top level must be a mapping")
+    features = data.get("features") or {}
+    if not isinstance(features, dict):
+        raise ValueError(f"{features_file}: 'features' must be a mapping")
+    for name, spec in features.items():
+        if not isinstance(spec, dict):
+            raise ValueError(
+                f"{features_file}: feature '{name}' must be a mapping "
+                "with description/files"
+            )
+        files = spec.get("files") or []
+        if not isinstance(files, list) or not all(
+            isinstance(entry, str) for entry in files
+        ):
+            raise ValueError(
+                f"{features_file}: feature '{name}' files must be a list of paths"
+            )
+    return features
 
 
 def diagnose_repo(root_dir: Path, feature: Optional[str] = None) -> List[Finding]:
@@ -238,15 +258,6 @@ def check_apply(
         total=total,
         clean=total - len(failures),
         failures=failures,
-    )
-
-
-def diagnose_apply(
-    root_dir: Path, chromium_src: Path, feature: Optional[str] = None
-) -> ApplyReport:
-    """Apply-check against a browseros package root's patch stack."""
-    return check_apply(
-        load_features(root_dir), root_dir / "chromium_patches", chromium_src, feature
     )
 
 

--- a/packages/browseros/bos_build/patchkit/doctor.py
+++ b/packages/browseros/bos_build/patchkit/doctor.py
@@ -12,9 +12,8 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
+from .batch_apply import MARKER_SUFFIXES
 from .validation import validate_description, validate_feature_name
-
-MARKER_SUFFIXES = (".deleted", ".binary", ".rename")
 
 # Features whose description carries this prefix list files touched by
 # series_patches/ quilt patches, not chromium_patches/ paths — they are
@@ -205,6 +204,11 @@ def load_features(root_dir: Path) -> Dict:
     if not isinstance(features, dict):
         raise ValueError(f"{features_file}: 'features' must be a mapping")
     for name, spec in features.items():
+        if not isinstance(name, str):
+            # yaml parses bare on/yes/true/1 keys as non-strings
+            raise ValueError(
+                f"{features_file}: feature name must be a string (got {name!r})"
+            )
         if not isinstance(spec, dict):
             raise ValueError(
                 f"{features_file}: feature '{name}' must be a mapping "

--- a/packages/browseros/bos_build/patchkit/doctor.py
+++ b/packages/browseros/bos_build/patchkit/doctor.py
@@ -229,7 +229,7 @@ def check_apply(
             failures.append(
                 ApplyFailure(
                     patch=rel,
-                    feature=owners[0] if owners else UNCLASSIFIED,
+                    feature=feature or (owners[0] if owners else UNCLASSIFIED),
                     error=(error or "").strip(),
                 )
             )
@@ -255,6 +255,7 @@ def build_report(
     features: Dict,
     findings: List[Finding],
     apply_report: Optional[ApplyReport] = None,
+    feature: Optional[str] = None,
 ) -> Dict:
     """Assemble the stable machine-readable report consumed by --json and renderers."""
     from .batch_apply import find_patch_files
@@ -263,6 +264,7 @@ def build_report(
     warnings = sum(1 for f in findings if f.severity == "warning")
     report: Dict = {
         "root": str(root_dir),
+        "feature": feature,
         "repo": {
             "patches": len(find_patch_files(root_dir / "chromium_patches")),
             "features": len(features),

--- a/packages/browseros/bos_build/patchkit/doctor.py
+++ b/packages/browseros/bos_build/patchkit/doctor.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Patch-stack doctor: read-only health checks for features.yaml ↔ chromium_patches/.
+
+Answers "how healthy is the patch stack" without touching any tree:
+repo-local consistency (every features.yaml entry resolves to a patch,
+every patch is claimed, claims don't overlap) plus an optional dry-run
+apply report against a chromium checkout. Pure functions returning
+findings — callers render and decide exit codes.
+"""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Set
+
+from .validation import validate_description, validate_feature_name
+
+MARKER_SUFFIXES = (".deleted", ".binary", ".rename")
+
+# Features whose description carries this prefix list files touched by
+# series_patches/ quilt patches, not chromium_patches/ paths — they are
+# exempt from patch-resolution checks and never claim on-disk patches.
+SERIES_PREFIX = "series:"
+
+UNCLASSIFIED = "(unclassified)"
+
+
+@dataclass(frozen=True)
+class Finding:
+    check: str  # missing-patch | empty-dir | unclassified | multi-claim | invalid-feature
+    severity: str  # error | warning
+    message: str
+    feature: Optional[str] = None
+    path: Optional[str] = None
+
+
+def is_series_feature(spec: Dict) -> bool:
+    return str(spec.get("description") or "").startswith(SERIES_PREFIX)
+
+
+def patch_base_paths(patches_dir: Path) -> Set[str]:
+    """Relative paths of all patches on disk, markers mapped to their base path."""
+    bases: Set[str] = set()
+    if not patches_dir.exists():
+        return bases
+    for path in patches_dir.rglob("*"):
+        if not path.is_file() or path.name.startswith("."):
+            continue
+        rel = path.relative_to(patches_dir).as_posix()
+        for suffix in MARKER_SUFFIXES:
+            if rel.endswith(suffix):
+                rel = rel[: -len(suffix)]
+                break
+        bases.add(rel)
+    return bases
+
+
+def compute_claims(features: Dict, bases: Set[str]) -> Dict[str, List[str]]:
+    """Map each on-disk base path to the sorted features claiming it."""
+    claims: Dict[str, Set[str]] = {base: set() for base in bases}
+    for name, spec in features.items():
+        if is_series_feature(spec):
+            continue
+        for entry in spec.get("files") or []:
+            if entry.endswith("/"):
+                for base in bases:
+                    if base.startswith(entry):
+                        claims[base].add(name)
+            elif entry in claims:
+                claims[entry].add(name)
+    return {base: sorted(owners) for base, owners in claims.items()}
+
+
+def check_feature_metadata(
+    features: Dict, feature: Optional[str] = None
+) -> List[Finding]:
+    findings = []
+    for name, spec in features.items():
+        if feature is not None and name != feature:
+            continue
+        valid, error = validate_feature_name(name)
+        if not valid:
+            findings.append(
+                Finding("invalid-feature", "error", f"{name}: {error}", feature=name)
+            )
+        valid, error = validate_description(str(spec.get("description") or ""))
+        if not valid:
+            findings.append(
+                Finding("invalid-feature", "error", f"{name}: {error}", feature=name)
+            )
+    return findings
+
+
+def check_entries_resolve(
+    features: Dict, bases: Set[str], feature: Optional[str] = None
+) -> List[Finding]:
+    findings = []
+    for name, spec in features.items():
+        if feature is not None and name != feature:
+            continue
+        if is_series_feature(spec):
+            continue
+        for entry in spec.get("files") or []:
+            if entry.endswith("/"):
+                if not any(base.startswith(entry) for base in bases):
+                    findings.append(
+                        Finding(
+                            "empty-dir",
+                            "error",
+                            f"{name}: directory entry '{entry}' has no patches under it",
+                            feature=name,
+                            path=entry,
+                        )
+                    )
+            elif entry not in bases:
+                findings.append(
+                    Finding(
+                        "missing-patch",
+                        "error",
+                        f"{name}: no patch on disk for entry '{entry}'",
+                        feature=name,
+                        path=entry,
+                    )
+                )
+    return findings
+
+
+def check_classification(
+    claims: Dict[str, List[str]], feature: Optional[str] = None
+) -> List[Finding]:
+    """Unclassified patches (error) and multi-claimed patches (warning)."""
+    findings = []
+    for base, owners in claims.items():
+        if not owners:
+            if feature is None:
+                findings.append(
+                    Finding(
+                        "unclassified",
+                        "error",
+                        f"patch not claimed by any feature: {base}",
+                        path=base,
+                    )
+                )
+        elif len(owners) > 1 and (feature is None or feature in owners):
+            findings.append(
+                Finding(
+                    "multi-claim",
+                    "warning",
+                    f"patch claimed by multiple features ({', '.join(owners)}): {base}",
+                    path=base,
+                )
+            )
+    return findings
+
+
+def check_repo(
+    features: Dict, patches_dir: Path, feature: Optional[str] = None
+) -> List[Finding]:
+    """All repo-local checks; raises ValueError for an unknown feature filter."""
+    if feature is not None and feature not in features:
+        raise ValueError(
+            f"unknown feature '{feature}'. Valid: {', '.join(sorted(features))}"
+        )
+    bases = patch_base_paths(patches_dir)
+    claims = compute_claims(features, bases)
+    findings = [
+        *check_feature_metadata(features, feature),
+        *check_entries_resolve(features, bases, feature),
+        *check_classification(claims, feature),
+    ]
+    return sorted(findings, key=lambda f: (f.check, f.feature or "", f.path or ""))
+
+
+def load_features(root_dir: Path) -> Dict:
+    from .features_io import load_features_yaml
+
+    data = load_features_yaml(root_dir / "bos_build" / "features.yaml")
+    return data.get("features") or {}
+
+
+def diagnose_repo(root_dir: Path, feature: Optional[str] = None) -> List[Finding]:
+    """Repo-local checks against a browseros package root."""
+    return check_repo(load_features(root_dir), root_dir / "chromium_patches", feature)

--- a/packages/browseros/bos_build/patchkit/doctor.py
+++ b/packages/browseros/bos_build/patchkit/doctor.py
@@ -8,7 +8,7 @@ apply report against a chromium checkout. Pure functions returning
 findings — callers render and decide exit codes.
 """
 
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
@@ -248,3 +248,39 @@ def diagnose_apply(
     return check_apply(
         load_features(root_dir), root_dir / "chromium_patches", chromium_src, feature
     )
+
+
+def build_report(
+    root_dir: Path,
+    features: Dict,
+    findings: List[Finding],
+    apply_report: Optional[ApplyReport] = None,
+) -> Dict:
+    """Assemble the stable machine-readable report consumed by --json and renderers."""
+    from .batch_apply import find_patch_files
+
+    errors = sum(1 for f in findings if f.severity == "error")
+    warnings = sum(1 for f in findings if f.severity == "warning")
+    report: Dict = {
+        "root": str(root_dir),
+        "repo": {
+            "patches": len(find_patch_files(root_dir / "chromium_patches")),
+            "features": len(features),
+            "errors": errors,
+            "warnings": warnings,
+            "findings": [asdict(f) for f in findings],
+        },
+        "apply": None,
+        "healthy": errors == 0,
+    }
+    if apply_report is not None:
+        report["apply"] = {
+            "against": apply_report.against,
+            "total": apply_report.total,
+            "clean": apply_report.clean,
+            "failed": len(apply_report.failures),
+            "features_affected": apply_report.features_affected,
+            "failures": [asdict(f) for f in apply_report.failures],
+        }
+        report["healthy"] = report["healthy"] and not apply_report.failures
+    return report

--- a/packages/browseros/bos_build/patchkit/doctor_test.py
+++ b/packages/browseros/bos_build/patchkit/doctor_test.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Tests for the patch-stack doctor."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from typing import Dict, List
+
+from bos_build.patchkit.doctor import (
+    check_repo,
+    compute_claims,
+    patch_base_paths,
+)
+
+
+def _patches_dir(files: List[str]) -> Path:
+    root = Path(tempfile.mkdtemp()) / "chromium_patches"
+    for rel in files:
+        path = root / rel
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("diff")
+    return root
+
+
+def _feature(files: List[str], description: str = "feat: test feature") -> Dict:
+    return {"description": description, "files": files}
+
+
+class PatchBasePathsTest(unittest.TestCase):
+    def test_markers_map_to_base_and_dotfiles_skipped(self):
+        patches = _patches_dir(
+            [
+                "chrome/a.cc",
+                "chrome/b.cc.deleted",
+                "chrome/c.mm.binary",
+                "chrome/d.h.rename",
+                "chrome/.gitignore",
+            ]
+        )
+        self.assertEqual(
+            patch_base_paths(patches),
+            {"chrome/a.cc", "chrome/b.cc", "chrome/c.mm", "chrome/d.h"},
+        )
+
+    def test_missing_dir_is_empty(self):
+        self.assertEqual(patch_base_paths(Path("/nonexistent/patches")), set())
+
+
+class EntryResolutionTest(unittest.TestCase):
+    def test_clean_tree_has_no_findings(self):
+        patches = _patches_dir(["chrome/a.cc", "third_party/lib/x.gn"])
+        features = {
+            "one": _feature(["chrome/a.cc"]),
+            "two": _feature(["third_party/lib/"]),
+        }
+        self.assertEqual(check_repo(features, patches), [])
+
+    def test_missing_file_entry_reported_with_feature_and_path(self):
+        patches = _patches_dir(["chrome/a.cc"])
+        features = {"one": _feature(["chrome/a.cc", "chrome/gone.cc"])}
+        findings = check_repo(features, patches)
+        self.assertEqual(len(findings), 1)
+        f = findings[0]
+        self.assertEqual(
+            (f.check, f.severity, f.feature, f.path),
+            ("missing-patch", "error", "one", "chrome/gone.cc"),
+        )
+
+    def test_marker_variants_resolve_file_entries(self):
+        patches = _patches_dir(
+            ["chrome/a.cc.deleted", "chrome/b.mm.binary", "chrome/c.h.rename"]
+        )
+        features = {
+            "one": _feature(["chrome/a.cc", "chrome/b.mm", "chrome/c.h"]),
+        }
+        self.assertEqual(check_repo(features, patches), [])
+
+    def test_empty_directory_entry_reported(self):
+        patches = _patches_dir(["chrome/a.cc"])
+        features = {
+            "one": _feature(["chrome/a.cc"]),
+            "two": _feature(["third_party/lib/"]),
+        }
+        findings = check_repo(features, patches)
+        self.assertEqual(len(findings), 1)
+        f = findings[0]
+        self.assertEqual(
+            (f.check, f.severity, f.feature, f.path),
+            ("empty-dir", "error", "two", "third_party/lib/"),
+        )
+
+    def test_directory_prefix_does_not_match_sibling(self):
+        patches = _patches_dir(["chrome/subfoo/a.cc"])
+        features = {
+            "one": _feature(["chrome/sub/"]),
+            "two": _feature(["chrome/subfoo/a.cc"]),
+        }
+        findings = check_repo(features, patches)
+        self.assertEqual([f.check for f in findings], ["empty-dir"])
+        self.assertEqual(findings[0].feature, "one")
+
+
+class ClassificationTest(unittest.TestCase):
+    def test_unclassified_patch_reported(self):
+        patches = _patches_dir(["chrome/a.cc", "chrome/orphan.cc"])
+        features = {"one": _feature(["chrome/a.cc"])}
+        findings = check_repo(features, patches)
+        self.assertEqual(len(findings), 1)
+        f = findings[0]
+        self.assertEqual(
+            (f.check, f.severity, f.feature, f.path),
+            ("unclassified", "error", None, "chrome/orphan.cc"),
+        )
+
+    def test_unclaimed_marker_reported_under_base_path(self):
+        patches = _patches_dir(["chrome/gone.cc.deleted"])
+        findings = check_repo({}, patches)
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0].check, "unclassified")
+        self.assertEqual(findings[0].path, "chrome/gone.cc")
+
+    def test_multi_file_claim_is_warning_naming_all_claimants(self):
+        patches = _patches_dir(["chrome/a.cc"])
+        features = {
+            "one": _feature(["chrome/a.cc"]),
+            "two": _feature(["chrome/a.cc"]),
+        }
+        findings = check_repo(features, patches)
+        self.assertEqual(len(findings), 1)
+        f = findings[0]
+        self.assertEqual((f.check, f.severity, f.path), ("multi-claim", "warning", "chrome/a.cc"))
+        self.assertIn("one", f.message)
+        self.assertIn("two", f.message)
+
+    def test_dir_and_file_entry_overlap_is_multi_claim(self):
+        patches = _patches_dir(["chrome/sub/a.cc"])
+        features = {
+            "one": _feature(["chrome/sub/"]),
+            "two": _feature(["chrome/sub/a.cc"]),
+        }
+        findings = check_repo(features, patches)
+        self.assertEqual([f.check for f in findings], ["multi-claim"])
+
+    def test_same_feature_claiming_via_file_and_dir_is_not_multi_claim(self):
+        patches = _patches_dir(["chrome/sub/a.cc"])
+        features = {"one": _feature(["chrome/sub/", "chrome/sub/a.cc"])}
+        self.assertEqual(check_repo(features, patches), [])
+
+
+class SeriesExemptionTest(unittest.TestCase):
+    def test_series_feature_entries_do_not_need_patches(self):
+        patches = _patches_dir(["chrome/a.cc"])
+        features = {
+            "one": _feature(["chrome/a.cc"]),
+            "win": _feature(
+                ["build/config.h", "chrome/app/x.rc"],
+                description="series: windows platform patches",
+            ),
+        }
+        self.assertEqual(check_repo(features, patches), [])
+
+    def test_series_feature_does_not_claim_disk_patches(self):
+        patches = _patches_dir(["chrome/a.cc"])
+        features = {
+            "win": _feature(["chrome/a.cc"], description="series: windows"),
+        }
+        findings = check_repo(features, patches)
+        self.assertEqual([f.check for f in findings], ["unclassified"])
+
+
+class FeatureMetadataTest(unittest.TestCase):
+    def test_invalid_name_and_description_reported(self):
+        patches = _patches_dir(["chrome/a.cc"])
+        features = {
+            "Bad Name": _feature(["chrome/a.cc"]),
+            "two": _feature([], description="no prefix here"),
+        }
+        findings = check_repo(features, patches)
+        checks = [(f.check, f.feature) for f in findings if f.check == "invalid-feature"]
+        self.assertIn(("invalid-feature", "Bad Name"), checks)
+        self.assertIn(("invalid-feature", "two"), checks)
+
+    def test_series_features_still_get_metadata_checks(self):
+        patches = _patches_dir([])
+        features = {"BAD": _feature([], description="series: x")}
+        findings = check_repo(features, patches)
+        self.assertEqual([f.check for f in findings], ["invalid-feature"])
+
+
+class FeatureFilterTest(unittest.TestCase):
+    def _fixture(self):
+        patches = _patches_dir(["chrome/a.cc", "chrome/orphan.cc"])
+        features = {
+            "one": _feature(["chrome/a.cc", "chrome/gone1.cc"]),
+            "two": _feature(["chrome/a.cc", "chrome/gone2.cc"]),
+        }
+        return features, patches
+
+    def test_filter_keeps_only_that_features_findings(self):
+        features, patches = self._fixture()
+        findings = check_repo(features, patches, feature="one")
+        self.assertEqual(
+            [(f.check, f.feature, f.path) for f in findings],
+            [
+                ("missing-patch", "one", "chrome/gone1.cc"),
+                ("multi-claim", None, "chrome/a.cc"),
+            ],
+        )
+
+    def test_filter_drops_unclassified(self):
+        features, patches = self._fixture()
+        findings = check_repo(features, patches, feature="two")
+        self.assertNotIn("unclassified", [f.check for f in findings])
+
+    def test_unknown_feature_raises(self):
+        features, patches = self._fixture()
+        with self.assertRaises(ValueError):
+            check_repo(features, patches, feature="nope")
+
+    def test_findings_sorted_deterministically(self):
+        patches = _patches_dir([])
+        features = {
+            "zed": _feature(["chrome/z.cc"]),
+            "abc": _feature(["chrome/b.cc", "chrome/a.cc"]),
+        }
+        findings = check_repo(features, patches)
+        self.assertEqual(
+            [(f.feature, f.path) for f in findings],
+            [
+                ("abc", "chrome/a.cc"),
+                ("abc", "chrome/b.cc"),
+                ("zed", "chrome/z.cc"),
+            ],
+        )
+
+
+class ComputeClaimsTest(unittest.TestCase):
+    def test_claims_are_sorted_and_deduplicated(self):
+        patches = _patches_dir(["chrome/sub/a.cc"])
+        bases = patch_base_paths(patches)
+        features = {
+            "zed": _feature(["chrome/sub/"]),
+            "abc": _feature(["chrome/sub/a.cc", "chrome/sub/"]),
+        }
+        self.assertEqual(
+            compute_claims(features, bases), {"chrome/sub/a.cc": ["abc", "zed"]}
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/bos_build/patchkit/doctor_test.py
+++ b/packages/browseros/bos_build/patchkit/doctor_test.py
@@ -21,8 +21,10 @@ from bos_build.patchkit.doctor import (
 )
 
 
-def _patches_dir(files: List[str]) -> Path:
-    root = Path(tempfile.mkdtemp()) / "chromium_patches"
+def _patches_dir(case: unittest.TestCase, files: List[str]) -> Path:
+    tmp = tempfile.TemporaryDirectory()
+    case.addCleanup(tmp.cleanup)
+    root = Path(tmp.name) / "chromium_patches"
     for rel in files:
         path = root / rel
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -37,13 +39,14 @@ def _feature(files: List[str], description: str = "feat: test feature") -> Dict:
 class PatchBasePathsTest(unittest.TestCase):
     def test_markers_map_to_base_and_dotfiles_skipped(self):
         patches = _patches_dir(
+            self,
             [
                 "chrome/a.cc",
                 "chrome/b.cc.deleted",
                 "chrome/c.mm.binary",
                 "chrome/d.h.rename",
                 "chrome/.gitignore",
-            ]
+            ],
         )
         self.assertEqual(
             patch_base_paths(patches),
@@ -56,7 +59,7 @@ class PatchBasePathsTest(unittest.TestCase):
 
 class EntryResolutionTest(unittest.TestCase):
     def test_clean_tree_has_no_findings(self):
-        patches = _patches_dir(["chrome/a.cc", "third_party/lib/x.gn"])
+        patches = _patches_dir(self, ["chrome/a.cc", "third_party/lib/x.gn"])
         features = {
             "one": _feature(["chrome/a.cc"]),
             "two": _feature(["third_party/lib/"]),
@@ -64,7 +67,7 @@ class EntryResolutionTest(unittest.TestCase):
         self.assertEqual(check_repo(features, patches), [])
 
     def test_missing_file_entry_reported_with_feature_and_path(self):
-        patches = _patches_dir(["chrome/a.cc"])
+        patches = _patches_dir(self, ["chrome/a.cc"])
         features = {"one": _feature(["chrome/a.cc", "chrome/gone.cc"])}
         findings = check_repo(features, patches)
         self.assertEqual(len(findings), 1)
@@ -76,7 +79,7 @@ class EntryResolutionTest(unittest.TestCase):
 
     def test_marker_variants_resolve_file_entries(self):
         patches = _patches_dir(
-            ["chrome/a.cc.deleted", "chrome/b.mm.binary", "chrome/c.h.rename"]
+            self, ["chrome/a.cc.deleted", "chrome/b.mm.binary", "chrome/c.h.rename"]
         )
         features = {
             "one": _feature(["chrome/a.cc", "chrome/b.mm", "chrome/c.h"]),
@@ -84,7 +87,7 @@ class EntryResolutionTest(unittest.TestCase):
         self.assertEqual(check_repo(features, patches), [])
 
     def test_empty_directory_entry_reported(self):
-        patches = _patches_dir(["chrome/a.cc"])
+        patches = _patches_dir(self, ["chrome/a.cc"])
         features = {
             "one": _feature(["chrome/a.cc"]),
             "two": _feature(["third_party/lib/"]),
@@ -98,7 +101,7 @@ class EntryResolutionTest(unittest.TestCase):
         )
 
     def test_directory_prefix_does_not_match_sibling(self):
-        patches = _patches_dir(["chrome/subfoo/a.cc"])
+        patches = _patches_dir(self, ["chrome/subfoo/a.cc"])
         features = {
             "one": _feature(["chrome/sub/"]),
             "two": _feature(["chrome/subfoo/a.cc"]),
@@ -110,7 +113,7 @@ class EntryResolutionTest(unittest.TestCase):
 
 class ClassificationTest(unittest.TestCase):
     def test_unclassified_patch_reported(self):
-        patches = _patches_dir(["chrome/a.cc", "chrome/orphan.cc"])
+        patches = _patches_dir(self, ["chrome/a.cc", "chrome/orphan.cc"])
         features = {"one": _feature(["chrome/a.cc"])}
         findings = check_repo(features, patches)
         self.assertEqual(len(findings), 1)
@@ -121,14 +124,14 @@ class ClassificationTest(unittest.TestCase):
         )
 
     def test_unclaimed_marker_reported_under_base_path(self):
-        patches = _patches_dir(["chrome/gone.cc.deleted"])
+        patches = _patches_dir(self, ["chrome/gone.cc.deleted"])
         findings = check_repo({}, patches)
         self.assertEqual(len(findings), 1)
         self.assertEqual(findings[0].check, "unclassified")
         self.assertEqual(findings[0].path, "chrome/gone.cc")
 
     def test_multi_file_claim_is_warning_naming_all_claimants(self):
-        patches = _patches_dir(["chrome/a.cc"])
+        patches = _patches_dir(self, ["chrome/a.cc"])
         features = {
             "one": _feature(["chrome/a.cc"]),
             "two": _feature(["chrome/a.cc"]),
@@ -141,7 +144,7 @@ class ClassificationTest(unittest.TestCase):
         self.assertIn("two", f.message)
 
     def test_dir_and_file_entry_overlap_is_multi_claim(self):
-        patches = _patches_dir(["chrome/sub/a.cc"])
+        patches = _patches_dir(self, ["chrome/sub/a.cc"])
         features = {
             "one": _feature(["chrome/sub/"]),
             "two": _feature(["chrome/sub/a.cc"]),
@@ -150,14 +153,14 @@ class ClassificationTest(unittest.TestCase):
         self.assertEqual([f.check for f in findings], ["multi-claim"])
 
     def test_same_feature_claiming_via_file_and_dir_is_not_multi_claim(self):
-        patches = _patches_dir(["chrome/sub/a.cc"])
+        patches = _patches_dir(self, ["chrome/sub/a.cc"])
         features = {"one": _feature(["chrome/sub/", "chrome/sub/a.cc"])}
         self.assertEqual(check_repo(features, patches), [])
 
 
 class SeriesExemptionTest(unittest.TestCase):
     def test_series_feature_entries_do_not_need_patches(self):
-        patches = _patches_dir(["chrome/a.cc"])
+        patches = _patches_dir(self, ["chrome/a.cc"])
         features = {
             "one": _feature(["chrome/a.cc"]),
             "win": _feature(
@@ -168,7 +171,7 @@ class SeriesExemptionTest(unittest.TestCase):
         self.assertEqual(check_repo(features, patches), [])
 
     def test_series_feature_does_not_claim_disk_patches(self):
-        patches = _patches_dir(["chrome/a.cc"])
+        patches = _patches_dir(self, ["chrome/a.cc"])
         features = {
             "win": _feature(["chrome/a.cc"], description="series: windows"),
         }
@@ -178,7 +181,7 @@ class SeriesExemptionTest(unittest.TestCase):
 
 class FeatureMetadataTest(unittest.TestCase):
     def test_invalid_name_and_description_reported(self):
-        patches = _patches_dir(["chrome/a.cc"])
+        patches = _patches_dir(self, ["chrome/a.cc"])
         features = {
             "Bad Name": _feature(["chrome/a.cc"]),
             "two": _feature([], description="no prefix here"),
@@ -189,7 +192,7 @@ class FeatureMetadataTest(unittest.TestCase):
         self.assertIn(("invalid-feature", "two"), checks)
 
     def test_series_features_still_get_metadata_checks(self):
-        patches = _patches_dir([])
+        patches = _patches_dir(self, [])
         features = {"BAD": _feature([], description="series: x")}
         findings = check_repo(features, patches)
         self.assertEqual([f.check for f in findings], ["invalid-feature"])
@@ -197,7 +200,7 @@ class FeatureMetadataTest(unittest.TestCase):
 
 class FeatureFilterTest(unittest.TestCase):
     def _fixture(self):
-        patches = _patches_dir(["chrome/a.cc", "chrome/orphan.cc"])
+        patches = _patches_dir(self, ["chrome/a.cc", "chrome/orphan.cc"])
         features = {
             "one": _feature(["chrome/a.cc", "chrome/gone1.cc"]),
             "two": _feature(["chrome/a.cc", "chrome/gone2.cc"]),
@@ -226,7 +229,7 @@ class FeatureFilterTest(unittest.TestCase):
             check_repo(features, patches, feature="nope")
 
     def test_findings_sorted_deterministically(self):
-        patches = _patches_dir([])
+        patches = _patches_dir(self, [])
         features = {
             "zed": _feature(["chrome/z.cc"]),
             "abc": _feature(["chrome/b.cc", "chrome/a.cc"]),
@@ -259,7 +262,7 @@ def _fake_git(failing_fragments: set, calls: Optional[List] = None):
 
 class CheckApplyTest(unittest.TestCase):
     def test_failures_grouped_by_owning_feature(self):
-        patches = _patches_dir(["chrome/a.cc", "chrome/b.cc", "chrome/orphan.cc"])
+        patches = _patches_dir(self, ["chrome/a.cc", "chrome/b.cc", "chrome/orphan.cc"])
         features = {"one": _feature(["chrome/a.cc", "chrome/b.cc"])}
         with mock.patch(
             "bos_build.patchkit.batch_apply.run_git_command",
@@ -276,7 +279,7 @@ class CheckApplyTest(unittest.TestCase):
         self.assertIn("patch failed", report.failures[0].error)
 
     def test_markers_excluded_from_apply_set(self):
-        patches = _patches_dir(["chrome/a.cc", "chrome/gone.cc.deleted"])
+        patches = _patches_dir(self, ["chrome/a.cc", "chrome/gone.cc.deleted"])
         features = {"one": _feature(["chrome/a.cc", "chrome/gone.cc"])}
         calls = []
         with mock.patch(
@@ -288,7 +291,7 @@ class CheckApplyTest(unittest.TestCase):
         self.assertIn("chrome/a.cc", calls[0][0][-1])
 
     def test_feature_filter_limits_apply_set_to_claimed_patches(self):
-        patches = _patches_dir(["chrome/a.cc", "sub/dir/b.cc", "chrome/orphan.cc"])
+        patches = _patches_dir(self, ["chrome/a.cc", "sub/dir/b.cc", "chrome/orphan.cc"])
         features = {
             "one": _feature(["chrome/a.cc", "sub/dir/"]),
             "two": _feature(["chrome/orphan.cc"]),
@@ -303,21 +306,36 @@ class CheckApplyTest(unittest.TestCase):
         self.assertTrue(all("orphan" not in path for path in ran))
 
     def test_unknown_feature_raises(self):
-        patches = _patches_dir(["chrome/a.cc"])
+        patches = _patches_dir(self, ["chrome/a.cc"])
         with self.assertRaises(ValueError):
             check_apply({}, patches, Path("/fake/src"), feature="nope")
+
+    def test_filtered_failures_attributed_to_the_filtered_feature(self):
+        patches = _patches_dir(self, ["chrome/a.cc"])
+        features = {
+            "aaa": _feature(["chrome/a.cc"]),
+            "zzz": _feature(["chrome/a.cc"]),
+        }
+        with mock.patch(
+            "bos_build.patchkit.batch_apply.run_git_command", _fake_git({"a.cc"})
+        ):
+            report = check_apply(features, patches, Path("/fake/src"), feature="zzz")
+        self.assertEqual([f.feature for f in report.failures], ["zzz"])
 
 
 class BuildReportTest(unittest.TestCase):
     def test_repo_only_report_shape_and_health(self):
-        patches = _patches_dir(["chrome/a.cc"])
+        patches = _patches_dir(self, ["chrome/a.cc"])
         features = {"one": _feature(["chrome/a.cc"])}
         findings = check_repo(features, patches)
 
         report = build_report(patches.parent, features, findings)
 
-        self.assertEqual(set(report), {"root", "repo", "apply", "healthy"})
+        self.assertEqual(
+            set(report), {"root", "feature", "repo", "apply", "healthy"}
+        )
         self.assertIsNone(report["apply"])
+        self.assertIsNone(report["feature"])
         self.assertTrue(report["healthy"])
         self.assertEqual(report["repo"]["patches"], 1)
         self.assertEqual(report["repo"]["features"], 1)
@@ -325,7 +343,7 @@ class BuildReportTest(unittest.TestCase):
         self.assertEqual(report["repo"]["findings"], [])
 
     def test_errors_flip_health_and_serialize_findings(self):
-        patches = _patches_dir(["chrome/a.cc"])
+        patches = _patches_dir(self, ["chrome/a.cc"])
         features = {"one": _feature(["chrome/a.cc", "chrome/gone.cc"])}
         findings = check_repo(features, patches)
 
@@ -340,7 +358,7 @@ class BuildReportTest(unittest.TestCase):
         self.assertEqual(finding["check"], "missing-patch")
 
     def test_warnings_alone_stay_healthy(self):
-        patches = _patches_dir(["chrome/a.cc"])
+        patches = _patches_dir(self, ["chrome/a.cc"])
         features = {
             "one": _feature(["chrome/a.cc"]),
             "two": _feature(["chrome/a.cc"]),
@@ -353,7 +371,7 @@ class BuildReportTest(unittest.TestCase):
         self.assertTrue(report["healthy"])
 
     def test_apply_failures_flip_health_with_stable_keys(self):
-        patches = _patches_dir(["chrome/a.cc"])
+        patches = _patches_dir(self, ["chrome/a.cc"])
         features = {"one": _feature(["chrome/a.cc"])}
         apply_report = ApplyReport(
             against="/src",
@@ -376,7 +394,7 @@ class BuildReportTest(unittest.TestCase):
         )
 
     def test_clean_apply_report_stays_healthy(self):
-        patches = _patches_dir(["chrome/a.cc"])
+        patches = _patches_dir(self, ["chrome/a.cc"])
         features = {"one": _feature(["chrome/a.cc"])}
         apply_report = ApplyReport(against="/src", total=1, clean=1, failures=[])
 
@@ -385,10 +403,18 @@ class BuildReportTest(unittest.TestCase):
         self.assertTrue(report["healthy"])
         self.assertEqual(report["apply"]["failed"], 0)
 
+    def test_feature_filter_recorded_in_report(self):
+        patches = _patches_dir(self, ["chrome/a.cc"])
+        features = {"one": _feature(["chrome/a.cc"])}
+
+        report = build_report(patches.parent, features, [], feature="one")
+
+        self.assertEqual(report["feature"], "one")
+
 
 class ComputeClaimsTest(unittest.TestCase):
     def test_claims_are_sorted_and_deduplicated(self):
-        patches = _patches_dir(["chrome/sub/a.cc"])
+        patches = _patches_dir(self, ["chrome/sub/a.cc"])
         bases = patch_base_paths(patches)
         features = {
             "zed": _feature(["chrome/sub/"]),

--- a/packages/browseros/bos_build/patchkit/doctor_test.py
+++ b/packages/browseros/bos_build/patchkit/doctor_test.py
@@ -17,6 +17,7 @@ from bos_build.patchkit.doctor import (
     check_repo,
     compute_claims,
     diagnose_repo,
+    load_features,
     patch_base_paths,
 )
 
@@ -423,6 +424,41 @@ class ComputeClaimsTest(unittest.TestCase):
         self.assertEqual(
             compute_claims(features, bases), {"chrome/sub/a.cc": ["abc", "zed"]}
         )
+
+
+class LoadFeaturesTest(unittest.TestCase):
+    def _root(self, features_yaml: str) -> Path:
+        tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(tmp.cleanup)
+        root = Path(tmp.name)
+        (root / "bos_build").mkdir()
+        (root / "bos_build" / "features.yaml").write_text(features_yaml)
+        return root
+
+    def test_well_formed_file_loads(self):
+        root = self._root(
+            'version: "1.0"\nfeatures:\n  one:\n'
+            '    description: "feat: x"\n    files:\n      - chrome/a.cc\n'
+        )
+        self.assertEqual(list(load_features(root)), ["one"])
+
+    def test_feature_with_null_body_is_a_value_error(self):
+        root = self._root("features:\n  foo:\n")
+        with self.assertRaisesRegex(ValueError, "foo"):
+            load_features(root)
+
+    def test_non_mapping_top_level_is_a_value_error(self):
+        root = self._root("- not\n- a\n- mapping\n")
+        with self.assertRaisesRegex(ValueError, "mapping"):
+            load_features(root)
+
+    def test_non_string_file_entry_is_a_value_error(self):
+        root = self._root(
+            'features:\n  one:\n    description: "feat: x"\n'
+            "    files:\n      - [nested, list]\n"
+        )
+        with self.assertRaisesRegex(ValueError, "list of paths"):
+            load_features(root)
 
 
 class RepoTruthTest(unittest.TestCase):

--- a/packages/browseros/bos_build/patchkit/doctor_test.py
+++ b/packages/browseros/bos_build/patchkit/doctor_test.py
@@ -9,6 +9,9 @@ from typing import Dict, List, Optional
 from unittest import mock
 
 from bos_build.patchkit.doctor import (
+    ApplyFailure,
+    ApplyReport,
+    build_report,
     check_apply,
     check_repo,
     compute_claims,
@@ -301,6 +304,84 @@ class CheckApplyTest(unittest.TestCase):
         patches = _patches_dir(["chrome/a.cc"])
         with self.assertRaises(ValueError):
             check_apply({}, patches, Path("/fake/src"), feature="nope")
+
+
+class BuildReportTest(unittest.TestCase):
+    def test_repo_only_report_shape_and_health(self):
+        patches = _patches_dir(["chrome/a.cc"])
+        features = {"one": _feature(["chrome/a.cc"])}
+        findings = check_repo(features, patches)
+
+        report = build_report(patches.parent, features, findings)
+
+        self.assertEqual(set(report), {"root", "repo", "apply", "healthy"})
+        self.assertIsNone(report["apply"])
+        self.assertTrue(report["healthy"])
+        self.assertEqual(report["repo"]["patches"], 1)
+        self.assertEqual(report["repo"]["features"], 1)
+        self.assertEqual((report["repo"]["errors"], report["repo"]["warnings"]), (0, 0))
+        self.assertEqual(report["repo"]["findings"], [])
+
+    def test_errors_flip_health_and_serialize_findings(self):
+        patches = _patches_dir(["chrome/a.cc"])
+        features = {"one": _feature(["chrome/a.cc", "chrome/gone.cc"])}
+        findings = check_repo(features, patches)
+
+        report = build_report(patches.parent, features, findings)
+
+        self.assertFalse(report["healthy"])
+        self.assertEqual(report["repo"]["errors"], 1)
+        finding = report["repo"]["findings"][0]
+        self.assertEqual(
+            set(finding), {"check", "severity", "message", "feature", "path"}
+        )
+        self.assertEqual(finding["check"], "missing-patch")
+
+    def test_warnings_alone_stay_healthy(self):
+        patches = _patches_dir(["chrome/a.cc"])
+        features = {
+            "one": _feature(["chrome/a.cc"]),
+            "two": _feature(["chrome/a.cc"]),
+        }
+        findings = check_repo(features, patches)
+
+        report = build_report(patches.parent, features, findings)
+
+        self.assertEqual(report["repo"]["warnings"], 1)
+        self.assertTrue(report["healthy"])
+
+    def test_apply_failures_flip_health_with_stable_keys(self):
+        patches = _patches_dir(["chrome/a.cc"])
+        features = {"one": _feature(["chrome/a.cc"])}
+        apply_report = ApplyReport(
+            against="/src",
+            total=3,
+            clean=2,
+            failures=[ApplyFailure("chrome/a.cc", "one", "boom")],
+        )
+
+        report = build_report(patches.parent, features, [], apply_report)
+
+        self.assertFalse(report["healthy"])
+        self.assertEqual(
+            set(report["apply"]),
+            {"against", "total", "clean", "failed", "features_affected", "failures"},
+        )
+        self.assertEqual(report["apply"]["failed"], 1)
+        self.assertEqual(report["apply"]["features_affected"], 1)
+        self.assertEqual(
+            set(report["apply"]["failures"][0]), {"patch", "feature", "error"}
+        )
+
+    def test_clean_apply_report_stays_healthy(self):
+        patches = _patches_dir(["chrome/a.cc"])
+        features = {"one": _feature(["chrome/a.cc"])}
+        apply_report = ApplyReport(against="/src", total=1, clean=1, failures=[])
+
+        report = build_report(patches.parent, features, [], apply_report)
+
+        self.assertTrue(report["healthy"])
+        self.assertEqual(report["apply"]["failed"], 0)
 
 
 class ComputeClaimsTest(unittest.TestCase):

--- a/packages/browseros/bos_build/patchkit/doctor_test.py
+++ b/packages/browseros/bos_build/patchkit/doctor_test.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from typing import Dict, List, Optional
 from unittest import mock
 
+from bos_build.lib.paths import get_package_root
 from bos_build.patchkit.doctor import (
     ApplyFailure,
     ApplyReport,
@@ -15,6 +16,7 @@ from bos_build.patchkit.doctor import (
     check_apply,
     check_repo,
     compute_claims,
+    diagnose_repo,
     patch_base_paths,
 )
 
@@ -394,6 +396,21 @@ class ComputeClaimsTest(unittest.TestCase):
         }
         self.assertEqual(
             compute_claims(features, bases), {"chrome/sub/a.cc": ["abc", "zed"]}
+        )
+
+
+class RepoTruthTest(unittest.TestCase):
+    def test_repo_features_consistent_with_patches(self):
+        # features.yaml must stay in sync with chromium_patches/ — extract
+        # flows update both, chromium bumps must clean both. Warnings are
+        # advisory and deliberately excluded.
+        errors = [
+            finding
+            for finding in diagnose_repo(get_package_root())
+            if finding.severity == "error"
+        ]
+        self.assertEqual(
+            errors, [], "\n" + "\n".join(finding.message for finding in errors)
         )
 
 

--- a/packages/browseros/bos_build/patchkit/doctor_test.py
+++ b/packages/browseros/bos_build/patchkit/doctor_test.py
@@ -4,9 +4,12 @@
 import tempfile
 import unittest
 from pathlib import Path
-from typing import Dict, List
+from types import SimpleNamespace
+from typing import Dict, List, Optional
+from unittest import mock
 
 from bos_build.patchkit.doctor import (
+    check_apply,
     check_repo,
     compute_claims,
     patch_base_paths,
@@ -232,6 +235,72 @@ class FeatureFilterTest(unittest.TestCase):
                 ("zed", "chrome/z.cc"),
             ],
         )
+
+
+def _fake_git(failing_fragments: set, calls: Optional[List] = None):
+    """run_git_command stand-in failing patches whose path contains a fragment."""
+
+    def fake(cmd, cwd, **kwargs):
+        if calls is not None:
+            calls.append((cmd, cwd))
+        failed = any(fragment in cmd[-1] for fragment in failing_fragments)
+        return SimpleNamespace(
+            returncode=1 if failed else 0,
+            stderr="error: patch failed\n" if failed else "",
+        )
+
+    return fake
+
+
+class CheckApplyTest(unittest.TestCase):
+    def test_failures_grouped_by_owning_feature(self):
+        patches = _patches_dir(["chrome/a.cc", "chrome/b.cc", "chrome/orphan.cc"])
+        features = {"one": _feature(["chrome/a.cc", "chrome/b.cc"])}
+        with mock.patch(
+            "bos_build.patchkit.batch_apply.run_git_command",
+            _fake_git({"b.cc", "orphan.cc"}),
+        ):
+            report = check_apply(features, patches, Path("/fake/src"))
+        self.assertEqual((report.total, report.clean), (3, 1))
+        self.assertEqual(
+            {(f.patch, f.feature) for f in report.failures},
+            {("chrome/b.cc", "one"), ("chrome/orphan.cc", "(unclassified)")},
+        )
+        self.assertEqual(report.features_affected, 2)
+        self.assertEqual(report.against, "/fake/src")
+        self.assertIn("patch failed", report.failures[0].error)
+
+    def test_markers_excluded_from_apply_set(self):
+        patches = _patches_dir(["chrome/a.cc", "chrome/gone.cc.deleted"])
+        features = {"one": _feature(["chrome/a.cc", "chrome/gone.cc"])}
+        calls = []
+        with mock.patch(
+            "bos_build.patchkit.batch_apply.run_git_command", _fake_git(set(), calls)
+        ):
+            report = check_apply(features, patches, Path("/fake/src"))
+        self.assertEqual((report.total, report.clean, report.failures), (1, 1, []))
+        self.assertEqual(len(calls), 1)
+        self.assertIn("chrome/a.cc", calls[0][0][-1])
+
+    def test_feature_filter_limits_apply_set_to_claimed_patches(self):
+        patches = _patches_dir(["chrome/a.cc", "sub/dir/b.cc", "chrome/orphan.cc"])
+        features = {
+            "one": _feature(["chrome/a.cc", "sub/dir/"]),
+            "two": _feature(["chrome/orphan.cc"]),
+        }
+        calls = []
+        with mock.patch(
+            "bos_build.patchkit.batch_apply.run_git_command", _fake_git(set(), calls)
+        ):
+            report = check_apply(features, patches, Path("/fake/src"), feature="one")
+        self.assertEqual(report.total, 2)
+        ran = {call[0][-1] for call in calls}
+        self.assertTrue(all("orphan" not in path for path in ran))
+
+    def test_unknown_feature_raises(self):
+        patches = _patches_dir(["chrome/a.cc"])
+        with self.assertRaises(ValueError):
+            check_apply({}, patches, Path("/fake/src"), feature="nope")
 
 
 class ComputeClaimsTest(unittest.TestCase):

--- a/packages/browseros/bos_build/patchkit/doctor_test.py
+++ b/packages/browseros/bos_build/patchkit/doctor_test.py
@@ -460,6 +460,12 @@ class LoadFeaturesTest(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "list of paths"):
             load_features(root)
 
+    def test_non_string_feature_key_is_a_value_error(self):
+        # yaml parses a bare `on:` key as a boolean
+        root = self._root('features:\n  on:\n    description: "feat: x"\n')
+        with self.assertRaisesRegex(ValueError, "must be a string"):
+            load_features(root)
+
 
 class RepoTruthTest(unittest.TestCase):
     def test_repo_features_consistent_with_patches(self):


### PR DESCRIPTION
## Summary
- `browseros dev doctor` — a read-only health report for the chromium patch stack: verifies `features.yaml` ↔ `chromium_patches/` consistency (every entry resolves to a patch incl. `.deleted`/`.binary`/`.rename` markers and `dir/` forms; every patch claimed by exactly one feature; names/descriptions validated), runnable in CI from any cwd.
- `--against <chromium-src>` adds a pre-bump migration report: dry-runs every patch (`git apply --check`, tree never modified) and groups failures by owning feature. `--feature` filters, `--json` emits a stable-keyed report for future chromium-bump tooling. Exit 0 healthy / 1 findings / 2 usage-or-environment errors.
- Data fix: removed 31 stale `features.yaml` entries (each justified from git log in the commit body — patches deleted in chromium 142/145/146/148 upgrades and cleanups, or files owned by `bump_version.py` / `string_replaces.py` / the `chromium_files` products overlay). A truth test now locks the map to the patches on disk. `series:` features (quilt series) are exempt by design and keep their entries.

## Design
Mirrors the existing `products/doctor.py` pattern upgraded to structured findings: `patchkit/doctor.py` holds pure functions returning `Finding` records (check id, severity, feature, path, message) so `--json` and `--feature` need no string parsing; the CLI in `cli/dev.py` is a thin renderer over one `build_report` dict. The dry-run git invocation was factored into a quiet `check_patch_applies` in `batch_apply.py` that the existing `apply_single_patch` dry-run path now delegates to, so `git apply --check` lives in exactly one place. Claims are computed per on-disk patch, which surfaces file/dir entry overlaps and nested-dir double claims uniformly as warnings (warnings alone stay healthy — the repo convention allows deliberate sharing). Hardened per adversarial review (3 rounds, all findings resolved): misshapen yaml (null bodies, non-string keys/entries) and wrong `--against` paths are clean exit-2 errors, never tracebacks read as findings.

## Test plan
- [x] `cd packages/browseros && uv run python -m unittest discover -s bos_build -t . -p "*_test.py"` — 433 tests green (mock-tree coverage: missing patch, unclassified, multi-claim, dir entries, markers, series exemption, apply grouping with mocked git, json shape, CLI exit codes 0/1/2)
- [x] `uv run ruff check bos_build`
- [x] `uv run browseros dev doctor` — exits 0 on this repo (367 patches / 31 features); truth test keeps it that way
- [x] `uv run browseros dev doctor --feature llm-chat --json` — filtered + machine-readable
- [x] `uv run browseros dev doctor --help` · `uv run browseros build --list`