### PR TITLE
fix(claw): use browserclaw as newtab title

### DIFF
--- a/packages/browseros-agent/apps/claw-app/entrypoints/newtab/index.html
+++ b/packages/browseros-agent/apps/claw-app/entrypoints/newtab/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>BrowserOS Agents</title>
+    <title>browserclaw</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/browseros-agent/apps/claw-app/entrypoints/newtab/styles.css
+++ b/packages/browseros-agent/apps/claw-app/entrypoints/newtab/styles.css
@@ -5,7 +5,7 @@
 @custom-variant dark (&:is(.dark *));
 
 /*
- * BrowserOS Agents cockpit palette.
+ * BrowserClaw cockpit palette.
  *
  * The shadcn base-vega primitives we installed all read --color-background,
  * --color-foreground, --color-primary etc. We re-point those at the


### PR DESCRIPTION
## Summary
- The claw-app newtab page rendered browser tabs titled "BrowserOS Agents"; the extension itself is already named `browserclaw` in `wxt.config.ts` (manifest `name` and `action.default_title`).
- Update the stale newtab `<title>` to `browserclaw` (lowercase, matching the manifest exactly) and the palette header comment in `styles.css` to the `BrowserClaw` product casing.

## Design
The visible tab title for a `chrome_url_overrides.newtab` page comes from the page's HTML `<title>`, not the extension manifest — so the fix is confined to the newtab entrypoint's source HTML. A repo-wide grep (excluding `dist/`, `node_modules/`, `.wxt/`) confirmed these were the only two stale occurrences of the old name in claw-app source.

## Test plan
- [x] `bun run typecheck` (wxt prepare + tsc) — pass
- [x] `bun run build` — pass; `dist/chrome-mv3/newtab.html` emits `<title>browserclaw</title>` and manifest name stays `browserclaw`
- [x] `bunx biome check` on both changed files — clean
- [x] Workspace `bun run check` — fallow's 388 issues are byte-identical on the clean base commit (pre-existing)
- [x] Workspace `bun run test` — 57/57 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)