### PR TITLE
chore(claw): title-case Browserclaw in newtab title

### DIFF
--- a/packages/browseros-agent/apps/claw-app/entrypoints/newtab/index.html
+++ b/packages/browseros-agent/apps/claw-app/entrypoints/newtab/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>browserclaw</title>
+    <title>Browserclaw</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- Change the Claw new-tab page `<title>` from `browserclaw` to `Browserclaw` (casing only).
- Scope is the HTML title element alone — manifest `name`/`default_title` and `--browseros-product` identifiers stay lowercase.

## Design
The new-tab entrypoint is a static WXT HTML file whose `<title>` element is the sole source of the browser-tab title (no `document.title` override anywhere in claw-app), so this is a direct one-line edit to `packages/browseros-agent/apps/claw-app/entrypoints/newtab/index.html`.

## Test plan
- [x] `bun run lint` in `apps/claw-app` — clean
- [x] `bun run typecheck` in `apps/claw-app` — clean
- [x] `bun test` in `apps/claw-app` — 145 pass, 0 fail
- [ ] Open a new tab in a Claw build and confirm the tab reads `Browserclaw`

🤖 Generated with [Claude Code](https://claude.com/claude-code)