### PR TITLE
fix: bake product identity buildflags for browseros/browserclaw release

### DIFF
--- a/packages/browseros/bos_build/core/context.py
+++ b/packages/browseros/bos_build/core/context.py
@@ -296,13 +296,8 @@ class Context:
         return [base / "common", base / "products" / self.product.id]
 
     def get_product_gn_args(self) -> list[str]:
-        """Return BrowserOS product GN args for configure.
-
-        Release bakes product identity: runtime override off, only the
-        baked product's server resources packaged. Debug allows the
-        --browseros-product runtime switch, so it packages both products'
-        server resources — the switch is useless without them.
-        """
+        """Product GN args: release bakes identity; debug keeps the runtime
+        product switch working (it needs both server resource sets)."""
         dev_build = "true" if self.build_type == "debug" else "false"
         return [
             f'browseros_product = "{self.product.gn_product}"',

--- a/packages/browseros/bos_build/core/context.py
+++ b/packages/browseros/bos_build/core/context.py
@@ -296,12 +296,18 @@ class Context:
         return [base / "common", base / "products" / self.product.id]
 
     def get_product_gn_args(self) -> list[str]:
-        """Return BrowserOS product GN args for configure."""
-        runtime_override = "true" if self.build_type == "debug" else "false"
+        """Return BrowserOS product GN args for configure.
+
+        Release bakes product identity: runtime override off, only the
+        baked product's server resources packaged. Debug allows the
+        --browseros-product runtime switch, so it packages both products'
+        server resources — the switch is useless without them.
+        """
+        dev_build = "true" if self.build_type == "debug" else "false"
         return [
             f'browseros_product = "{self.product.gn_product}"',
-            f"browseros_allow_runtime_product_override = {runtime_override}",
-            "browseros_package_all_server_resources = false",
+            f"browseros_allow_runtime_product_override = {dev_build}",
+            f"browseros_package_all_server_resources = {dev_build}",
         ]
 
     def get_features_yaml_path(self) -> Path:

--- a/packages/browseros/bos_build/core/context_test.py
+++ b/packages/browseros/bos_build/core/context_test.py
@@ -113,17 +113,40 @@ class GetAppPathTest(unittest.TestCase):
         self.assertEqual(ctx.product.id, "browserclaw")
         self.assertEqual(ctx.BROWSEROS_APP_BASE_NAME, "BrowserClaw")
 
-    def test_debug_gn_args_allow_runtime_override(self):
+    def test_debug_gn_args_allow_override_and_package_all(self):
         ctx = Context(
             chromium_src=Path("/nonexistent-src"),
             architecture="x64",
             build_type="debug",
         )
 
-        self.assertIn(
-            "browseros_allow_runtime_product_override = true",
+        self.assertEqual(
             ctx.get_product_gn_args(),
+            [
+                'browseros_product = "browseros"',
+                "browseros_allow_runtime_product_override = true",
+                "browseros_package_all_server_resources = true",
+            ],
         )
+
+    def test_release_gn_args_bake_product_identity(self):
+        for product in ("browseros", "browserclaw"):
+            with self.subTest(product=product):
+                ctx = Context(
+                    chromium_src=Path("/nonexistent-src"),
+                    architecture="arm64",
+                    build_type="release",
+                    product=get_product_descriptor(product),
+                )
+
+                self.assertEqual(
+                    ctx.get_product_gn_args(),
+                    [
+                        f'browseros_product = "{product}"',
+                        "browseros_allow_runtime_product_override = false",
+                        "browseros_package_all_server_resources = false",
+                    ],
+                )
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/steps/setup/configure.py
+++ b/packages/browseros/bos_build/steps/setup/configure.py
@@ -5,6 +5,7 @@ import sys
 
 from ...core.step import Step, ValidationError, step
 from ...core.context import Context
+from ...products.server_binaries import all_server_bundles
 from ...lib.utils import (
     run_command,
     log_info,
@@ -72,6 +73,9 @@ class ConfigureModule(Step):
 
         args_file.write_text(args_content)
 
+        if ctx.build_type == "debug":
+            self._warn_missing_server_resources(ctx)
+
         gn_cmd = "gn.bat" if IS_WINDOWS() else "gn"
         gn_args = [gn_cmd, "gen", ctx.out_dir]
         if ctx.build_type != "debug":
@@ -79,6 +83,19 @@ class ConfigureModule(Step):
         run_command(gn_args, cwd=ctx.chromium_src)
 
         log_success("Build configured")
+
+    def _warn_missing_server_resources(self, ctx: Context) -> None:
+        # Debug sets browseros_package_all_server_resources, so ninja needs
+        # every product's server resources staged; a missing set otherwise
+        # surfaces much later as a cryptic missing-input error.
+        for bundle in all_server_bundles():
+            resources_dir = ctx.chromium_src / bundle.chromium_resources_root
+            if not resources_dir.exists():
+                log_warning(
+                    f"⚠️  {bundle.id}: {resources_dir} not staged — debug "
+                    "builds package all server resources; run the resources "
+                    "step first or ninja will fail on missing inputs"
+                )
 
     def _ensure_linux_sysroot(self, ctx: Context) -> None:
         install_script = (

--- a/packages/browseros/bos_build/steps/setup/configure_test.py
+++ b/packages/browseros/bos_build/steps/setup/configure_test.py
@@ -95,7 +95,7 @@ class ConfigureExecuteTest(unittest.TestCase):
             "browseros_package_all_server_resources = false\n",
         )
 
-    def test_debug_args_enable_override_and_all_server_resources(self):
+    def test_debug_args_append_product_args_verbatim(self):
         ctx, chromium, _ = self._execute(
             "debug", architecture="arm64", flags="is_debug = true\n"
         )
@@ -104,9 +104,8 @@ class ConfigureExecuteTest(unittest.TestCase):
         self.assertEqual(
             args_gn,
             'is_debug = true\n\ntarget_cpu = "arm64"\n'
-            'browseros_product = "browseros"\n'
-            "browseros_allow_runtime_product_override = true\n"
-            "browseros_package_all_server_resources = true\n",
+            + "\n".join(ctx.get_product_gn_args())
+            + "\n",
         )
 
     def test_release_build_fails_on_unused_args(self):
@@ -154,6 +153,19 @@ class ConfigureExecuteTest(unittest.TestCase):
         self.assertLess(
             args_gn.index("symbol_level = 1"), args_gn.index("symbol_level=2")
         )
+
+    def test_debug_warns_when_server_resources_not_staged(self):
+        with mock.patch.object(configure, "log_warning") as log_warning:
+            self._execute("debug")
+
+        messages = [call.args[0] for call in log_warning.call_args_list]
+        self.assertTrue(any("server resources" in m for m in messages), messages)
+
+    def test_release_does_not_warn_about_server_resources(self):
+        with mock.patch.object(configure, "log_warning") as log_warning:
+            self._execute("release")
+
+        log_warning.assert_not_called()
 
     def test_extra_gn_args_logged(self):
         with mock.patch.object(configure, "log_info") as log_info:

--- a/packages/browseros/bos_build/steps/setup/configure_test.py
+++ b/packages/browseros/bos_build/steps/setup/configure_test.py
@@ -95,6 +95,20 @@ class ConfigureExecuteTest(unittest.TestCase):
             "browseros_package_all_server_resources = false\n",
         )
 
+    def test_debug_args_enable_override_and_all_server_resources(self):
+        ctx, chromium, _ = self._execute(
+            "debug", architecture="arm64", flags="is_debug = true\n"
+        )
+
+        args_gn = (chromium.src / ctx.out_dir / "args.gn").read_text()
+        self.assertEqual(
+            args_gn,
+            'is_debug = true\n\ntarget_cpu = "arm64"\n'
+            'browseros_product = "browseros"\n'
+            "browseros_allow_runtime_product_override = true\n"
+            "browseros_package_all_server_resources = true\n",
+        )
+
     def test_release_build_fails_on_unused_args(self):
         ctx, _, run_cmd = self._execute("release")
 

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/buildflags.gni
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/buildflags.gni
@@ -1,6 +1,6 @@
 diff --git a/chrome/browser/browseros/buildflags.gni b/chrome/browser/browseros/buildflags.gni
 new file mode 100644
-index 0000000000000..8c87fe61ab738
+index 0000000000000..0a4b34ea72336
 --- /dev/null
 +++ b/chrome/browser/browseros/buildflags.gni
 @@ -0,0 +1,25 @@
@@ -15,13 +15,13 @@ index 0000000000000..8c87fe61ab738
 +  browseros_product = "browseros"
 +
 +  # Dev/test only. Official builds should leave this false.
-+  # // TODO: nikhil - before prod claw release, set this to false
-+  browseros_allow_runtime_product_override = true
++  browseros_allow_runtime_product_override = false
 +}
 +
 +declare_args() {
 +  # Usually follows runtime override, but can be forced on for packaging tests.
-+  browseros_package_all_server_resources = true
++  browseros_package_all_server_resources =
++      browseros_allow_runtime_product_override
 +}
 +
 +assert(browseros_product == "browseros" || browseros_product == "browserclaw",


### PR DESCRIPTION
## Summary
- Restores safe `buildflags.gni` defaults: `browseros_allow_runtime_product_override = false`, `browseros_package_all_server_resources` follows the override — resolving the pre-claw-release TODO from c840d957. Content is byte-identical to the pre-flip version (blob `0a4b34ea72336`), verified to apply cleanly.
- `get_product_gn_args()` now couples `browseros_package_all_server_resources` to the runtime override: debug builds get `true`/`true` (one debug binary can actually run as either product — previously the override was on but the other product's server resources were missing), release builds bake `browseros_product` with both flags `false`. Release args.gn output is unchanged from current main.
- Configure now warns per missing server-resource bundle on debug builds, so an unstaged tree fails with an actionable message at configure time instead of a cryptic ninja missing-input error.

## Design
Release safety lives in two layers on purpose: bos_build states managed-build policy explicitly in args.gn (auditable, belt-and-suspenders for shipped artifacts), while the .gni default protects anything built outside bos_build. The Jun 30 testing need (run either product from one build) is preserved through the managed debug path instead of unsafe global defaults.

## Notes for dev workflows
- Hand-managed args.gn (not written by `browseros build` configure) must add `browseros_allow_runtime_product_override = true` to keep the `--browseros-product` switch; the flipped default compiles it out otherwise. This is the intended pre-claw-release behavior.
- Existing debug out dirs pick up the corrected flags on their next configure run; plans that skip configure keep their frozen args.gn (true of every GN arg).
- Review triage: declined adding a GN assert against `override && !package_all` (legitimate for browser-only cross-product testing without server resources) and declined dropping the explicit package_all arg from args.gn (see Design).

## Test plan
- [x] `uv run python -m unittest discover -s bos_build -t . -p "*_test.py"` — 596 tests OK (new: release golden args for both products, debug wiring test, configure warning tests)
- [x] `uv run ruff check bos_build` — clean
- [x] Edited patch applies cleanly in a scratch repo; `git hash-object` of the result matches the embedded index hash
- [ ] Next nightly debug build: confirm both `BrowserOSServer` and `BrowserClawServer` resources land in the output and `--browseros-product=browserclaw` works end to end