### PR TITLE
feat(claw-server): 24h rotating file logger

### DIFF
--- a/packages/browseros-agent/apps/claw-server/src/lib/logger.ts
+++ b/packages/browseros-agent/apps/claw-server/src/lib/logger.ts
@@ -10,18 +10,26 @@
  * log views render both producers identically.
  *
  * `setLogFile` adds an optional file sink with startup-time rotation
- * (rename to `.old` when the file was created over 24h ago) so prod
- * runs keep an on-disk record. Deliberately dep-free: pino's async
- * transports bring Bun-compile caveats, and at this log volume sync
- * per-line writes are fine — and survive crashes, which is when the
- * file matters most.
+ * (rename to `.old` when the file was created over 24h ago or grew
+ * past the size cap) so prod runs keep an on-disk record. Deliberately
+ * dep-free: pino's async transports bring Bun-compile caveats, and at
+ * this log volume sync per-line writes are fine — and survive crashes,
+ * which is when the file matters most.
+ *
+ * Known limitation: rotation assumes one claw-server per
+ * <browserosDir>. Two instances on different ports sharing a dir can
+ * rotate each other's live log; guarding that needs a real file lock,
+ * which this basic logger doesn't attempt.
  */
 
 import fs from 'node:fs'
 import path from 'node:path'
 
 const LOG_FILE_NAME = 'claw-server.log'
-const LOG_FILE_MAX_AGE_MS = 24 * 60 * 60 * 1000 // 1 day
+const LOG_FILE_MAX_AGE_MS = 24 * 60 * 60 * 1000
+// Backstop for filesystems without birthtime, where an actively
+// written log never looks stale: cap growth at restart boundaries.
+const LOG_FILE_MAX_SIZE_BYTES = 20 * 1024 * 1024
 
 type LogLevel = 'debug' | 'info' | 'warn' | 'error'
 
@@ -33,11 +41,12 @@ const LEVEL_PRIORITY: Record<LogLevel, number> = {
 }
 
 let fileFd: number | null = null
+let filePath: string | null = null
 
 /**
- * Rotate the log file if it was created more than max age ago.
- * Startup-time only: renames current to `.old`, replacing any
- * previous backup.
+ * Rotate the log file if it was created more than max age ago or
+ * outgrew the size cap. Startup-time only: renames current to
+ * `.old`, replacing any previous backup.
  */
 function rotateLogIfNeeded(logPath: string): void {
   let stale = false
@@ -47,7 +56,9 @@ function rotateLogIfNeeded(logPath: string): void {
     // so an mtime key would never rotate a log with regular traffic.
     // birthtime is 0 on filesystems that don't track it.
     const createdMs = stat.birthtimeMs > 0 ? stat.birthtimeMs : stat.mtimeMs
-    stale = Date.now() - createdMs > LOG_FILE_MAX_AGE_MS
+    stale =
+      Date.now() - createdMs > LOG_FILE_MAX_AGE_MS ||
+      stat.size > LOG_FILE_MAX_SIZE_BYTES
   } catch {
     return // No log file yet, nothing to rotate
   }
@@ -58,20 +69,33 @@ function rotateLogIfNeeded(logPath: string): void {
     // rename replaces an existing backup atomically; unlink-first
     // would lose the old backup if the rename then failed.
     fs.renameSync(logPath, backupPath)
-  } catch {
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code
+    // Only a dest-exists failure (Windows semantics) justifies
+    // deleting the backup; unlinking on other errors would destroy
+    // it without enabling the rename.
+    if (code !== 'EEXIST' && code !== 'EPERM') {
+      warnRotationFailed(logPath, error)
+      return
+    }
     try {
       fs.unlinkSync(backupPath)
       fs.renameSync(logPath, backupPath)
-    } catch (error) {
-      write('warn', 'log rotation failed; appending to stale log', {
-        logPath,
-        error: error instanceof Error ? error.message : String(error),
-      })
+    } catch (retryError) {
+      warnRotationFailed(logPath, retryError)
     }
   }
 }
 
+function warnRotationFailed(logPath: string, error: unknown): void {
+  write('warn', 'log rotation failed; appending to stale log', {
+    logPath,
+    error: error instanceof Error ? error.message : String(error),
+  })
+}
+
 function closeLogFile(): void {
+  filePath = null
   if (fileFd === null) return
   const fd = fileFd
   fileFd = null
@@ -93,7 +117,12 @@ function setLogFile(logDir: string): void {
   let fd: number
   try {
     fs.mkdirSync(logDir, { recursive: true })
-    rotateLogIfNeeded(logPath)
+    // Never rotate the file the live sink is writing to: if the open
+    // below failed, the kept fd would silently follow the rename into
+    // the .old backup.
+    if (fileFd === null || filePath !== logPath) {
+      rotateLogIfNeeded(logPath)
+    }
     fd = fs.openSync(logPath, 'a')
   } catch (error) {
     write('warn', 'could not open log file; file sink unchanged', {
@@ -104,17 +133,19 @@ function setLogFile(logDir: string): void {
   }
   closeLogFile()
   fileFd = fd
+  filePath = logPath
 }
 
 function write(level: LogLevel, msg: string, fields?: Record<string, unknown>) {
-  // Envelope keys are applied after the spread so a stray msg/level/
-  // time in caller data can't break the pino shape downstream log
-  // views parse.
+  // Envelope keys stay first (pino-canonical order) and win over any
+  // stray msg/level/time in caller data, so downstream log views keep
+  // parsing every line.
+  const { level: _level, time: _time, msg: _msg, ...rest } = fields ?? {}
   const event = {
-    ...fields,
     level: LEVEL_PRIORITY[level],
     time: Date.now(),
     msg,
+    ...rest,
   }
   let line: string
   try {

--- a/packages/browseros-agent/apps/claw-server/src/lib/logger.ts
+++ b/packages/browseros-agent/apps/claw-server/src/lib/logger.ts
@@ -71,10 +71,13 @@ function rotateLogIfNeeded(logPath: string): void {
     fs.renameSync(logPath, backupPath)
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code
-    // Only a dest-exists failure (Windows semantics) justifies
-    // deleting the backup; unlinking on other errors would destroy
-    // it without enabling the rename.
-    if (code !== 'EEXIST' && code !== 'EPERM') {
+    // The unlink fallback is only for dest-exists failures (Windows
+    // semantics), which require an existing backup; unlinking on any
+    // other error would destroy the backup without enabling the
+    // rename, and the original error is the one worth reporting.
+    const destExists =
+      (code === 'EEXIST' || code === 'EPERM') && fs.existsSync(backupPath)
+    if (!destExists) {
       warnRotationFailed(logPath, error)
       return
     }

--- a/packages/browseros-agent/apps/claw-server/src/lib/logger.ts
+++ b/packages/browseros-agent/apps/claw-server/src/lib/logger.ts
@@ -8,7 +8,20 @@
  * stdout traffic. The shape matches @browseros/server's pino output
  * (level, time, msg, plus arbitrary structured fields) so existing
  * log views render both producers identically.
+ *
+ * `setLogFile` adds an optional file sink with the same startup-time
+ * 24h rotation as @browseros/server (rename to `.old` when stale) so
+ * prod runs keep an on-disk record. Deliberately dep-free: pino's
+ * async transports bring Bun-compile caveats, and at this log volume
+ * sync per-line writes are fine — and survive crashes, which is when
+ * the file matters most.
  */
+
+import fs from 'node:fs'
+import path from 'node:path'
+
+const LOG_FILE_NAME = 'claw-server.log'
+const LOG_FILE_MAX_AGE_MS = 24 * 60 * 60 * 1000 // 1 day
 
 type LogLevel = 'debug' | 'info' | 'warn' | 'error'
 
@@ -19,6 +32,62 @@ const LEVEL_PRIORITY: Record<LogLevel, number> = {
   error: 50,
 }
 
+let fileFd: number | null = null
+
+/**
+ * Rotate the log file if it's older than max age. Startup-time only:
+ * deletes the previous backup and renames current to `.old`.
+ */
+function rotateLogIfNeeded(logPath: string): void {
+  try {
+    const stat = fs.statSync(logPath)
+    const ageMs = Date.now() - stat.mtimeMs
+
+    if (ageMs > LOG_FILE_MAX_AGE_MS) {
+      const backupPath = `${logPath}.old`
+      try {
+        fs.unlinkSync(backupPath)
+      } catch {
+        // Backup doesn't exist, that's fine
+      }
+      fs.renameSync(logPath, backupPath)
+    }
+  } catch {
+    // File doesn't exist, nothing to rotate
+  }
+}
+
+function closeLogFile(): void {
+  if (fileFd === null) return
+  const fd = fileFd
+  fileFd = null
+  try {
+    fs.closeSync(fd)
+  } catch {
+    // Already closed or invalid; sink is detached either way
+  }
+}
+
+/**
+ * Point the file sink at `<logDir>/claw-server.log`, rotating a stale
+ * file first. Never throws: on any failure the logger stays
+ * stderr-only, because a broken log dir must not take the server down.
+ */
+function setLogFile(logDir: string): void {
+  closeLogFile()
+  const logPath = path.join(logDir, LOG_FILE_NAME)
+  try {
+    fs.mkdirSync(logDir, { recursive: true })
+    rotateLogIfNeeded(logPath)
+    fileFd = fs.openSync(logPath, 'a')
+  } catch (error) {
+    write('warn', 'file logging disabled: could not open log file', {
+      logPath,
+      error: error instanceof Error ? error.message : String(error),
+    })
+  }
+}
+
 function write(level: LogLevel, msg: string, fields?: Record<string, unknown>) {
   const event = {
     level: LEVEL_PRIORITY[level],
@@ -26,8 +95,18 @@ function write(level: LogLevel, msg: string, fields?: Record<string, unknown>) {
     msg,
     ...fields,
   }
+  const line = JSON.stringify(event)
   // biome-ignore lint/suspicious/noConsole: logger is the sanctioned console wrapper for the package
-  console.error(JSON.stringify(event))
+  console.error(line)
+  if (fileFd !== null) {
+    try {
+      fs.writeSync(fileFd, `${line}\n`)
+    } catch {
+      // Dead sink (disk full, fd invalidated): detach so every later
+      // log call doesn't re-fail; stderr keeps working.
+      closeLogFile()
+    }
+  }
 }
 
 export const logger = {
@@ -39,4 +118,6 @@ export const logger = {
     write('warn', msg, fields),
   error: (msg: string, fields?: Record<string, unknown>) =>
     write('error', msg, fields),
+  setLogFile,
+  closeLogFile,
 }

--- a/packages/browseros-agent/apps/claw-server/src/lib/logger.ts
+++ b/packages/browseros-agent/apps/claw-server/src/lib/logger.ts
@@ -9,12 +9,12 @@
  * (level, time, msg, plus arbitrary structured fields) so existing
  * log views render both producers identically.
  *
- * `setLogFile` adds an optional file sink with the same startup-time
- * 24h rotation as @browseros/server (rename to `.old` when stale) so
- * prod runs keep an on-disk record. Deliberately dep-free: pino's
- * async transports bring Bun-compile caveats, and at this log volume
- * sync per-line writes are fine — and survive crashes, which is when
- * the file matters most.
+ * `setLogFile` adds an optional file sink with startup-time rotation
+ * (rename to `.old` when the file was created over 24h ago) so prod
+ * runs keep an on-disk record. Deliberately dep-free: pino's async
+ * transports bring Bun-compile caveats, and at this log volume sync
+ * per-line writes are fine — and survive crashes, which is when the
+ * file matters most.
  */
 
 import fs from 'node:fs'
@@ -35,25 +35,39 @@ const LEVEL_PRIORITY: Record<LogLevel, number> = {
 let fileFd: number | null = null
 
 /**
- * Rotate the log file if it's older than max age. Startup-time only:
- * deletes the previous backup and renames current to `.old`.
+ * Rotate the log file if it was created more than max age ago.
+ * Startup-time only: renames current to `.old`, replacing any
+ * previous backup.
  */
 function rotateLogIfNeeded(logPath: string): void {
+  let stale = false
   try {
     const stat = fs.statSync(logPath)
-    const ageMs = Date.now() - stat.mtimeMs
-
-    if (ageMs > LOG_FILE_MAX_AGE_MS) {
-      const backupPath = `${logPath}.old`
-      try {
-        fs.unlinkSync(backupPath)
-      } catch {
-        // Backup doesn't exist, that's fine
-      }
-      fs.renameSync(logPath, backupPath)
-    }
+    // Keyed on creation time, not mtime: every write refreshes mtime,
+    // so an mtime key would never rotate a log with regular traffic.
+    // birthtime is 0 on filesystems that don't track it.
+    const createdMs = stat.birthtimeMs > 0 ? stat.birthtimeMs : stat.mtimeMs
+    stale = Date.now() - createdMs > LOG_FILE_MAX_AGE_MS
   } catch {
-    // File doesn't exist, nothing to rotate
+    return // No log file yet, nothing to rotate
+  }
+  if (!stale) return
+
+  const backupPath = `${logPath}.old`
+  try {
+    // rename replaces an existing backup atomically; unlink-first
+    // would lose the old backup if the rename then failed.
+    fs.renameSync(logPath, backupPath)
+  } catch {
+    try {
+      fs.unlinkSync(backupPath)
+      fs.renameSync(logPath, backupPath)
+    } catch (error) {
+      write('warn', 'log rotation failed; appending to stale log', {
+        logPath,
+        error: error instanceof Error ? error.message : String(error),
+      })
+    }
   }
 }
 
@@ -70,32 +84,51 @@ function closeLogFile(): void {
 
 /**
  * Point the file sink at `<logDir>/claw-server.log`, rotating a stale
- * file first. Never throws: on any failure the logger stays
- * stderr-only, because a broken log dir must not take the server down.
+ * file first. Never throws, and only swaps sinks once the new file is
+ * open — a broken log dir leaves any working sink (or stderr-only
+ * logging) intact rather than taking the server down.
  */
 function setLogFile(logDir: string): void {
-  closeLogFile()
   const logPath = path.join(logDir, LOG_FILE_NAME)
+  let fd: number
   try {
     fs.mkdirSync(logDir, { recursive: true })
     rotateLogIfNeeded(logPath)
-    fileFd = fs.openSync(logPath, 'a')
+    fd = fs.openSync(logPath, 'a')
   } catch (error) {
-    write('warn', 'file logging disabled: could not open log file', {
+    write('warn', 'could not open log file; file sink unchanged', {
       logPath,
       error: error instanceof Error ? error.message : String(error),
     })
+    return
   }
+  closeLogFile()
+  fileFd = fd
 }
 
 function write(level: LogLevel, msg: string, fields?: Record<string, unknown>) {
+  // Envelope keys are applied after the spread so a stray msg/level/
+  // time in caller data can't break the pino shape downstream log
+  // views parse.
   const event = {
+    ...fields,
     level: LEVEL_PRIORITY[level],
     time: Date.now(),
     msg,
-    ...fields,
   }
-  const line = JSON.stringify(event)
+  let line: string
+  try {
+    line = JSON.stringify(event)
+  } catch {
+    // Circular or BigInt field: drop fields rather than throw out of
+    // a log call.
+    line = JSON.stringify({
+      level: LEVEL_PRIORITY[level],
+      time: Date.now(),
+      msg,
+      logSerializationFailed: true,
+    })
+  }
   // biome-ignore lint/suspicious/noConsole: logger is the sanctioned console wrapper for the package
   console.error(line)
   if (fileFd !== null) {

--- a/packages/browseros-agent/apps/claw-server/src/main.ts
+++ b/packages/browseros-agent/apps/claw-server/src/main.ts
@@ -23,6 +23,7 @@ import { loadClawConfig } from './config'
 import { applyClawConfig, env } from './env'
 import { bootstrapBrowserosBrowser } from './lib/browser-bootstrap'
 import { setBrowserSession } from './lib/browser-session'
+import { getClawServerDir } from './lib/browseros-dir'
 import { logger } from './lib/logger'
 import { migrateMcpUrls } from './lib/migrate-mcp-urls'
 import { setLocalServerUrl } from './local-server-url'
@@ -37,6 +38,7 @@ async function start(): Promise<void> {
     process.exit(1)
   }
   applyClawConfig(config.value)
+  logger.setLogFile(getClawServerDir())
 
   const httpServer = Bun.serve({
     hostname: '127.0.0.1',

--- a/packages/browseros-agent/apps/claw-server/src/main.ts
+++ b/packages/browseros-agent/apps/claw-server/src/main.ts
@@ -113,6 +113,7 @@ async function start(): Promise<void> {
 start().catch((error: unknown) => {
   logger.error('claw-server startup failed', {
     error: error instanceof Error ? error.message : String(error),
+    stack: error instanceof Error ? error.stack : undefined,
   })
   process.exit(1)
 })

--- a/packages/browseros-agent/apps/claw-server/src/main.ts
+++ b/packages/browseros-agent/apps/claw-server/src/main.ts
@@ -38,13 +38,16 @@ async function start(): Promise<void> {
     process.exit(1)
   }
   applyClawConfig(config.value)
-  logger.setLogFile(getClawServerDir())
 
   const httpServer = Bun.serve({
     hostname: '127.0.0.1',
     port: env.port,
     fetch: server.fetch,
   })
+  // File sink attaches only after the port bind succeeds: the bind is
+  // the de-facto singleton lock, so a second accidental launch dies on
+  // EADDRINUSE before it can rotate the live instance's log file.
+  logger.setLogFile(getClawServerDir())
   const url = `http://${httpServer.hostname}:${httpServer.port}`
   setLocalServerUrl(url)
   logger.info('claw-server listening', { url })
@@ -107,4 +110,9 @@ async function start(): Promise<void> {
     )
 }
 
-void start()
+start().catch((error: unknown) => {
+  logger.error('claw-server startup failed', {
+    error: error instanceof Error ? error.message : String(error),
+  })
+  process.exit(1)
+})

--- a/packages/browseros-agent/apps/claw-server/tests/lib/logger.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/lib/logger.test.ts
@@ -1,0 +1,140 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { afterEach, describe, expect, test } from 'bun:test'
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { logger } from '../../src/lib/logger'
+
+const LOG_NAME = 'claw-server.log'
+const tempDirs: string[] = []
+
+function makeTempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), 'claw-logger-'))
+  tempDirs.push(dir)
+  return dir
+}
+
+function readLines(logPath: string): Array<Record<string, unknown>> {
+  return readFileSync(logPath, 'utf8')
+    .split('\n')
+    .filter((line) => line.length > 0)
+    .map((line) => JSON.parse(line))
+}
+
+afterEach(() => {
+  logger.closeLogFile()
+  for (const dir of tempDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+})
+
+describe('logger.setLogFile', () => {
+  test('writes JSON lines with pino-shaped fields to the log file', () => {
+    const dir = makeTempDir()
+    logger.setLogFile(dir)
+
+    logger.info('hello file', { url: 'http://127.0.0.1:1234' })
+    logger.error('boom')
+
+    const lines = readLines(join(dir, LOG_NAME))
+    expect(lines).toHaveLength(2)
+    expect(lines[0]).toMatchObject({
+      level: 30,
+      msg: 'hello file',
+      url: 'http://127.0.0.1:1234',
+    })
+    expect(typeof lines[0]?.time).toBe('number')
+    expect(lines[1]).toMatchObject({ level: 50, msg: 'boom' })
+  })
+
+  test('creates the log directory when missing', () => {
+    const dir = join(makeTempDir(), 'nested', 'claw-server')
+    logger.setLogFile(dir)
+
+    logger.info('created')
+
+    expect(existsSync(join(dir, LOG_NAME))).toBe(true)
+  })
+
+  test('appends to a fresh log file without rotating', () => {
+    const dir = makeTempDir()
+    const logPath = join(dir, LOG_NAME)
+    writeFileSync(logPath, '{"level":30,"msg":"previous run"}\n')
+
+    logger.setLogFile(dir)
+    logger.info('next run')
+
+    expect(existsSync(`${logPath}.old`)).toBe(false)
+    const lines = readLines(logPath)
+    expect(lines).toHaveLength(2)
+    expect(lines[1]).toMatchObject({ msg: 'next run' })
+  })
+
+  test('rotates a stale log file to .old and starts fresh', () => {
+    const dir = makeTempDir()
+    const logPath = join(dir, LOG_NAME)
+    writeFileSync(logPath, '{"level":30,"msg":"stale"}\n')
+    const staleSeconds = (Date.now() - 25 * 60 * 60 * 1000) / 1000
+    utimesSync(logPath, staleSeconds, staleSeconds)
+
+    logger.setLogFile(dir)
+    logger.info('fresh')
+
+    const backup = readLines(`${logPath}.old`)
+    expect(backup[0]).toMatchObject({ msg: 'stale' })
+    const lines = readLines(logPath)
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toMatchObject({ msg: 'fresh' })
+  })
+
+  test('replaces an existing .old backup on rotation', () => {
+    const dir = makeTempDir()
+    const logPath = join(dir, LOG_NAME)
+    writeFileSync(`${logPath}.old`, '{"level":30,"msg":"ancient"}\n')
+    writeFileSync(logPath, '{"level":30,"msg":"stale"}\n')
+    const staleSeconds = (Date.now() - 25 * 60 * 60 * 1000) / 1000
+    utimesSync(logPath, staleSeconds, staleSeconds)
+
+    logger.setLogFile(dir)
+
+    const backup = readLines(`${logPath}.old`)
+    expect(backup).toHaveLength(1)
+    expect(backup[0]).toMatchObject({ msg: 'stale' })
+  })
+
+  test('does not throw when the log dir is unwritable', () => {
+    const dir = join(makeTempDir(), 'blocked')
+    // A file where the directory should be makes mkdir fail
+    writeFileSync(dir, 'not a directory')
+
+    expect(() => logger.setLogFile(dir)).not.toThrow()
+    expect(() => logger.info('stderr only')).not.toThrow()
+  })
+
+  test('re-pointing the sink switches files', () => {
+    const first = makeTempDir()
+    const second = makeTempDir()
+
+    logger.setLogFile(first)
+    logger.info('one')
+    logger.setLogFile(second)
+    logger.info('two')
+
+    expect(readLines(join(first, LOG_NAME))).toHaveLength(1)
+    const lines = readLines(join(second, LOG_NAME))
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toMatchObject({ msg: 'two' })
+  })
+})

--- a/packages/browseros-agent/apps/claw-server/tests/lib/logger.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/lib/logger.test.ts
@@ -10,6 +10,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  utimesSync,
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -102,19 +103,33 @@ describe('logger.setLogFile', () => {
   test('rotates on stale creation time even when recently written', () => {
     const dir = makeTempDir()
     const logPath = join(dir, LOG_NAME)
-    writeFileSync(logPath, '{"level":30,"msg":"stale"}\n')
+    writeFileSync(logPath, '{"level":30,"msg":"old lines"}\n')
     setSystemTime(new Date(Date.now() + STALE_JUMP_MS))
-    // A write refreshes mtime but not creation time
-    logger.setLogFile(dir)
-    logger.info('recent write')
-    logger.closeLogFile()
-    setSystemTime(new Date(Date.now() + STALE_JUMP_MS))
+    // Refresh mtime to the mocked "now" so this only passes when
+    // rotation keys on creation time — an mtime key would see a
+    // fresh file and skip.
+    const mockedNowSec = Date.now() / 1000
+    utimesSync(logPath, mockedNowSec, mockedNowSec)
 
     logger.setLogFile(dir)
 
     const backup = readLines(`${logPath}.old`)
-    expect(backup.at(-1)).toMatchObject({ msg: 'recent write' })
+    expect(backup.at(-1)).toMatchObject({ msg: 'old lines' })
     expect(readLines(logPath)).toHaveLength(0)
+  })
+
+  test('rotates when the log outgrows the size cap', () => {
+    const dir = makeTempDir()
+    const logPath = join(dir, LOG_NAME)
+    writeFileSync(logPath, Buffer.alloc(20 * 1024 * 1024 + 1, 0x61))
+
+    logger.setLogFile(dir)
+    logger.info('fresh')
+
+    expect(existsSync(`${logPath}.old`)).toBe(true)
+    const lines = readLines(logPath)
+    expect(lines).toHaveLength(1)
+    expect(lines[0]).toMatchObject({ msg: 'fresh' })
   })
 
   test('replaces an existing .old backup on rotation', () => {
@@ -186,6 +201,12 @@ describe('logger event shape', () => {
     const lines = readLines(join(dir, LOG_NAME))
     expect(lines[0]).toMatchObject({ level: 30, msg: 'real message', extra: 1 })
     expect(typeof lines[0]?.time).toBe('number')
+    // pino-canonical key order so prefix-matching consumers keep working
+    expect(Object.keys(lines[0] ?? {}).slice(0, 3)).toEqual([
+      'level',
+      'time',
+      'msg',
+    ])
   })
 
   test('unserializable fields do not throw and keep the message', () => {

--- a/packages/browseros-agent/apps/claw-server/tests/lib/logger.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/lib/logger.test.ts
@@ -10,6 +10,7 @@ import {
   mkdtempSync,
   readFileSync,
   rmSync,
+  statSync,
   utimesSync,
   writeFileSync,
 } from 'node:fs'
@@ -107,9 +108,12 @@ describe('logger.setLogFile', () => {
     setSystemTime(new Date(Date.now() + STALE_JUMP_MS))
     // Refresh mtime to the mocked "now" so this only passes when
     // rotation keys on creation time — an mtime key would see a
-    // fresh file and skip.
-    const mockedNowSec = Date.now() / 1000
-    utimesSync(logPath, mockedNowSec, mockedNowSec)
+    // fresh file and skip. Filesystems without birthtime fall back
+    // to mtime, so only differentiate where creation time is real.
+    if (statSync(logPath).birthtimeMs > 0) {
+      const mockedNowSec = Date.now() / 1000
+      utimesSync(logPath, mockedNowSec, mockedNowSec)
+    }
 
     logger.setLogFile(dir)
 

--- a/packages/browseros-agent/apps/claw-server/tests/lib/logger.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/lib/logger.test.ts
@@ -4,13 +4,12 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { afterEach, describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, setSystemTime, test } from 'bun:test'
 import {
   existsSync,
   mkdtempSync,
   readFileSync,
   rmSync,
-  utimesSync,
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -18,6 +17,7 @@ import { join } from 'node:path'
 import { logger } from '../../src/lib/logger'
 
 const LOG_NAME = 'claw-server.log'
+const STALE_JUMP_MS = 25 * 60 * 60 * 1000
 const tempDirs: string[] = []
 
 function makeTempDir(): string {
@@ -34,6 +34,7 @@ function readLines(logPath: string): Array<Record<string, unknown>> {
 }
 
 afterEach(() => {
+  setSystemTime()
   logger.closeLogFile()
   for (const dir of tempDirs.splice(0)) {
     rmSync(dir, { recursive: true, force: true })
@@ -86,8 +87,7 @@ describe('logger.setLogFile', () => {
     const dir = makeTempDir()
     const logPath = join(dir, LOG_NAME)
     writeFileSync(logPath, '{"level":30,"msg":"stale"}\n')
-    const staleSeconds = (Date.now() - 25 * 60 * 60 * 1000) / 1000
-    utimesSync(logPath, staleSeconds, staleSeconds)
+    setSystemTime(new Date(Date.now() + STALE_JUMP_MS))
 
     logger.setLogFile(dir)
     logger.info('fresh')
@@ -99,13 +99,30 @@ describe('logger.setLogFile', () => {
     expect(lines[0]).toMatchObject({ msg: 'fresh' })
   })
 
+  test('rotates on stale creation time even when recently written', () => {
+    const dir = makeTempDir()
+    const logPath = join(dir, LOG_NAME)
+    writeFileSync(logPath, '{"level":30,"msg":"stale"}\n')
+    setSystemTime(new Date(Date.now() + STALE_JUMP_MS))
+    // A write refreshes mtime but not creation time
+    logger.setLogFile(dir)
+    logger.info('recent write')
+    logger.closeLogFile()
+    setSystemTime(new Date(Date.now() + STALE_JUMP_MS))
+
+    logger.setLogFile(dir)
+
+    const backup = readLines(`${logPath}.old`)
+    expect(backup.at(-1)).toMatchObject({ msg: 'recent write' })
+    expect(readLines(logPath)).toHaveLength(0)
+  })
+
   test('replaces an existing .old backup on rotation', () => {
     const dir = makeTempDir()
     const logPath = join(dir, LOG_NAME)
     writeFileSync(`${logPath}.old`, '{"level":30,"msg":"ancient"}\n')
     writeFileSync(logPath, '{"level":30,"msg":"stale"}\n')
-    const staleSeconds = (Date.now() - 25 * 60 * 60 * 1000) / 1000
-    utimesSync(logPath, staleSeconds, staleSeconds)
+    setSystemTime(new Date(Date.now() + STALE_JUMP_MS))
 
     logger.setLogFile(dir)
 
@@ -123,6 +140,21 @@ describe('logger.setLogFile', () => {
     expect(() => logger.info('stderr only')).not.toThrow()
   })
 
+  test('a failed re-point keeps the previous sink', () => {
+    const dir = makeTempDir()
+    logger.setLogFile(dir)
+    logger.info('before')
+
+    const blocked = join(makeTempDir(), 'blocked')
+    writeFileSync(blocked, 'not a directory')
+    logger.setLogFile(blocked)
+    logger.info('after')
+
+    const msgs = readLines(join(dir, LOG_NAME)).map((line) => line.msg)
+    expect(msgs).toContain('before')
+    expect(msgs).toContain('after')
+  })
+
   test('re-pointing the sink switches files', () => {
     const first = makeTempDir()
     const second = makeTempDir()
@@ -136,5 +168,38 @@ describe('logger.setLogFile', () => {
     const lines = readLines(join(second, LOG_NAME))
     expect(lines).toHaveLength(1)
     expect(lines[0]).toMatchObject({ msg: 'two' })
+  })
+})
+
+describe('logger event shape', () => {
+  test('envelope keys win over caller-supplied fields', () => {
+    const dir = makeTempDir()
+    logger.setLogFile(dir)
+
+    logger.info('real message', {
+      msg: 'clobber',
+      level: 'high',
+      time: 'noon',
+      extra: 1,
+    })
+
+    const lines = readLines(join(dir, LOG_NAME))
+    expect(lines[0]).toMatchObject({ level: 30, msg: 'real message', extra: 1 })
+    expect(typeof lines[0]?.time).toBe('number')
+  })
+
+  test('unserializable fields do not throw and keep the message', () => {
+    const dir = makeTempDir()
+    logger.setLogFile(dir)
+
+    const circular: Record<string, unknown> = {}
+    circular.self = circular
+    expect(() => logger.info('circular', circular)).not.toThrow()
+
+    const lines = readLines(join(dir, LOG_NAME))
+    expect(lines[0]).toMatchObject({
+      msg: 'circular',
+      logSerializationFailed: true,
+    })
   })
 })


### PR DESCRIPTION
## Summary
- Adds a file sink to the claw-server logger so prod info logs on execution are persisted to `<browserosDir>/claw-server/claw-server.log`, mirroring the 24h startup rotation `apps/server` uses (stale log renamed to `.old`).
- Rotation keys on file creation time (mtime refreshes on every write and would never rotate an active log) with a 20MB size backstop for filesystems that don't track birthtime.
- stderr JSON-line output is unchanged; the file sink is dep-free (`node:fs`, sync per-line writes) — no pino, avoiding its Bun-compile transport caveats.

## Design
The existing minimal console-wrapper logger gains `setLogFile(dir)`: mkdir, rotate-if-stale, open an append fd; every log line is written to both stderr and the file. All failure paths degrade instead of crashing — a broken log dir keeps stderr-only logging, a failed re-point keeps the previous sink, a dead fd detaches the sink, and unserializable fields fall back to a stub line. `main.ts` attaches the sink only after `Bun.serve` binds the port, so a second accidental launch dies on EADDRINUSE before it can rotate the live instance's log, and `start()` now logs fatal startup errors (with stack) before exiting. Rotation renames first and only unlinks the old backup for genuine dest-exists failures, so history is never destroyed without enabling the rename.

Three review rounds ran locally (multi-agent); all confirmed findings fixed. Accepted tradeoffs: sync `writeSync` per line (low volume, crash-safe); rotation helper intentionally not extracted to `@browseros/shared` (implementations now diverge — follow-up if server adopts the same keying); cross-port multi-instance rotation needs a real file lock and is documented as a limitation.

## Test plan
- [x] `cd apps/claw-server && bun test` — 383 pass (13 logger tests: sink writes, dir creation, fresh-file append, stale rotation, creation-time vs mtime keying, size-cap rotation, backup replacement, unwritable dir, failed re-point keeps sink, re-point switches files, envelope precedence + key order, circular fields)
- [x] `bun run check` at monorepo root — exit 0
- [x] E2E: booted claw-server against a temp `BROWSEROS_DIR`; `claw-server listening` lands in the log file; a second launch on the held port exits 1 with a structured error and does not rotate the live log