### PR TITLE
fix(claw-server): version binary from its own package.json

### DIFF
--- a/packages/browseros-agent/apps/claw-server/src/mcp/manager.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/manager.ts
@@ -22,10 +22,10 @@ import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { WebStandardStreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/webStandardStreamableHttp.js'
 import { logger } from '../lib/logger'
 import { findBySlug } from '../routes/agents/service'
+import { VERSION } from '../version'
 import { registerBrowserTools } from './register'
 
 const SERVER_NAME = 'browseros-claw-server'
-const SERVER_VERSION = '0.0.1'
 
 /**
  * Handles a single `/mcp/:slug` request end-to-end. Returns either:
@@ -47,7 +47,7 @@ export async function handleMcpRequest(
   const server = new McpServer({
     name: SERVER_NAME,
     title: `BrowserOS / ${agent.name}`,
-    version: SERVER_VERSION,
+    version: VERSION,
   })
 
   registerBrowserTools(server, agent)

--- a/packages/browseros-agent/apps/claw-server/src/mcp/single-server.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/single-server.ts
@@ -32,11 +32,11 @@ import {
   recordSessionStart,
 } from '../services/session-events'
 import { closeAgentTabGroupForAgent } from '../services/tab-group-ops'
+import { VERSION } from '../version'
 import { registerBrowserToolsForSingleServer } from './register'
 
 const SERVER_NAME = 'browseros-claw-server'
 const SERVER_TITLE = 'BrowserOS'
-const SERVER_VERSION = '0.0.1'
 
 interface Session {
   server: McpServer
@@ -62,7 +62,7 @@ function buildSession(): Session {
   const server = new McpServer({
     name: SERVER_NAME,
     title: SERVER_TITLE,
-    version: SERVER_VERSION,
+    version: VERSION,
   })
 
   registerBrowserToolsForSingleServer(server, resolveIdentity)

--- a/packages/browseros-agent/apps/claw-server/tests/build.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/build.test.ts
@@ -36,7 +36,7 @@ const UNNEEDED_SERVER_AND_R2_ENV_KEYS = [
 
 describe('claw server build', () => {
   const rootDir = resolve(import.meta.dir, '../../..')
-  const versionPkgPath = resolve(rootDir, 'apps/server/package.json')
+  const versionPkgPath = resolve(rootDir, 'apps/claw-server/package.json')
   const buildScript = resolve(rootDir, 'scripts/build/claw-server.ts')
   const target = getNativeTarget()
   const binaryPath = resolve(
@@ -71,6 +71,14 @@ describe('claw server build', () => {
       recursive: true,
       force: true,
     })
+  })
+
+  it('resolves the build version from the claw package', async () => {
+    const pkg = await Bun.file(versionPkgPath).json()
+    const config = loadBuildConfig(rootDir, clawServerBuildProduct, {
+      ci: true,
+    })
+    assert.strictEqual(config.version, pkg.version)
   })
 
   it('uploads artifacts by default while preserving local-only modes', () => {

--- a/packages/browseros-agent/packages/build-server-tools/src/config.ts
+++ b/packages/browseros-agent/packages/build-server-tools/src/config.ts
@@ -9,11 +9,7 @@ function readPackageVersion(
   rootDir: string,
   product: BuildProductDescriptor,
 ): string {
-  const pkgPath = join(
-    rootDir,
-    product.versionPackageDir ?? product.packageDir,
-    'package.json',
-  )
+  const pkgPath = join(rootDir, product.packageDir, 'package.json')
   const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'))
   return pkg.version
 }

--- a/packages/browseros-agent/packages/build-server-tools/src/types.ts
+++ b/packages/browseros-agent/packages/build-server-tools/src/types.ts
@@ -52,7 +52,6 @@ export interface BundleOptions {
 export interface BuildProductDescriptor {
   label: string
   packageDir: string
-  versionPackageDir?: string
   entrypoint: string
   distRoot: string
   rawBinaryBaseName: string

--- a/packages/browseros-agent/packages/build-server-tools/tests/config.test.ts
+++ b/packages/browseros-agent/packages/build-server-tools/tests/config.test.ts
@@ -98,24 +98,6 @@ describe('build config', () => {
     expect(config.r2).toBeUndefined()
   })
 
-  it('can read the build version from a separate package', async () => {
-    const rootDir = await writeProdRoot({}, { envFile: false })
-    const versionPackageDir = join(rootDir, 'apps/version-source')
-    await mkdir(versionPackageDir, { recursive: true })
-    await writeFile(
-      join(versionPackageDir, 'package.json'),
-      '{"version":"1.2.3"}',
-    )
-
-    const config = loadBuildConfig(
-      rootDir,
-      testProduct({ versionPackageDir: 'apps/version-source' }),
-      { ci: true },
-    )
-
-    expect(config.version).toBe('1.2.3')
-  })
-
   it('allows optional-env products to build local artifacts without R2', async () => {
     const rootDir = await writeProdRoot({}, { envFile: false })
     const product = testProduct({

--- a/packages/browseros-agent/scripts/build/claw-server/descriptor.ts
+++ b/packages/browseros-agent/scripts/build/claw-server/descriptor.ts
@@ -5,7 +5,6 @@ export const CLAW_SERVER_BUNDLE_ENTRYPOINT = 'apps/claw-server/src/main.ts'
 export const clawServerBuildProduct: BuildProductDescriptor = {
   label: 'BrowserOS Claw server',
   packageDir: 'apps/claw-server',
-  versionPackageDir: 'apps/server',
   entrypoint: CLAW_SERVER_BUNDLE_ENTRYPOINT,
   distRoot: 'dist/prod/claw-server',
   rawBinaryBaseName: 'browseros-claw-server',


### PR DESCRIPTION
## Summary
- `browseros-claw-server --version` printed the BrowserOS server version (`0.0.124`) instead of the claw package version (`0.0.1`); the build now stamps the binary and `artifact-metadata.json` from `apps/claw-server/package.json`.
- Removes the vestigial `versionPackageDir` mechanism from `build-server-tools` — it was added in 189679fc for a release flow that built claw artifacts under the server release train, but later reworks removed claw from `release-server.yml`, leaving the coupling as a pure mislabel. Claw was its only user.
- Replaces the hardcoded `SERVER_VERSION = '0.0.1'` in both MCP entry points with the shared build-injected `VERSION`, so the MCP handshake reports the real artifact version.

## Design
Every product's build version now comes from its own `packageDir/package.json` (`readPackageVersion` in `build-server-tools/src/config.ts`), which is what the server and CLI products already did implicitly. The `apps/server` build is behavior-identical since it never set `versionPackageDir`. Regression coverage: a fast unit test pins `loadBuildConfig(rootDir, clawServerBuildProduct).version` to the claw package version (fails in ms if the descriptor ever points elsewhere), and the existing build smoke test now asserts binary `--version` + metadata against `apps/claw-server/package.json`.

## Test plan
- [x] Fast regression test red before the descriptor fix (`0.0.124 !== 0.0.1`), green after
- [x] `bun test apps/claw-server` — 372 pass, 0 fail (includes both build smoke tests)
- [x] `bun test packages/build-server-tools` — 17 pass, 0 fail
- [x] `bun run check` (lint + typecheck + fallow) — exit 0
- [x] End-to-end: built `darwin-arm64` binary prints `0.0.1`; `artifact-metadata.json` version is `0.0.1`