### PR TITLE
fix(claw): add missing manifest permissions for app parity

### DIFF
--- a/packages/browseros-agent/apps/claw-app/wxt.config.ts
+++ b/packages/browseros-agent/apps/claw-app/wxt.config.ts
@@ -13,15 +13,24 @@ export default defineConfig({
   manifest: {
     name: 'browserclaw',
     key: 'MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAyXbY2XVCs1/yJqGd53ei1rHdoUGIvZ8uq+x9YKmUc+jnb6NogIrq0USPeRNb6uzszio45GR8BW0O0pgbFKmhlhrCwgs9gEW8mufksE29E1g8Q2ug1sowzj38X6jmitO4I9cBbQMx7+gJZJS8pS5DZ+V7Bl8Uka2LWHMTP/Pf10YjbeNNCA0wj6kQkkTb8lg80r5Vm+gFqyo2xDFaxj8lN2kE73yFBjCt6B4ycntXvnnUTPX4IJqH+eQuwsFWPuqdYEwdvaaIOQ+lCxcYyZusX58zhxr0pkMxQjnEoJqAk6Av5O/JiNIOZYzbwUjm6aA+p9j9/6xzvmG+Lvp74Dk9pwIDAQAB',
+    // Mirrors apps/app/wxt.config.ts permissions (keep in sync — adding
+    // permissions later re-prompts/disables existing installs on update),
+    // followed by claw-specific extras.
     permissions: [
-      'browserOS',
+      'topSites',
       'storage',
+      'unlimitedStorage',
+      'scripting',
       'tabs',
       'tabGroups',
       'sidePanel',
-      'notifications',
+      'bookmarks',
+      'history',
+      'browserOS',
+      'alarms',
       'webNavigation',
-      'scripting',
+      'downloads',
+      'notifications',
     ],
     // <all_urls> is a SCOPE grant. The extension is allowed to
     // inject content scripts anywhere via chrome.scripting, BUT


### PR DESCRIPTION
## Summary
- Bring the BrowserClaw extension's manifest permissions to parity with the BrowserOS app extension (`apps/app/wxt.config.ts`): adds `topSites`, `unlimitedStorage`, `bookmarks`, `history`, `alarms`, `downloads`.
- Keeps the claw-specific `notifications` grant and leaves `host_permissions` untouched.
- Permission list now mirrors the app's ordering with claw extras last, so future parity diffs are eyeball-able.

## Design
Direct edit of the manifest literal in `apps/claw-app/wxt.config.ts` — WXT copies the array verbatim into the generated manifest, so no runtime code is involved. Front-loading the grants now matters because MV3 permission additions re-prompt/disable existing installs on update. A shared permissions constant across the two apps was considered and rejected as YAGNI (different extras, different release surfaces).

## Test plan
- [x] `cd apps/claw-app && bun run typecheck && bun run build` — green
- [x] Generated `dist/chrome-mv3/manifest.json` asserted: exactly the 13 app permissions + `notifications` (14 total, no duplicates), `host_permissions` unchanged
- [x] Monorepo `bun run lint`, `bun run typecheck`, `bun run test` — green (fallow failures are pre-existing on base, verified via stash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)