### PR TITLE
feat: product-aware Sparkle/WinSparkle update feeds for BrowserClaw

### DIFF
--- a/packages/browseros/bos_build/release/appcast_test.py
+++ b/packages/browseros/bos_build/release/appcast_test.py
@@ -2,12 +2,15 @@
 """Tests for the full-file browser appcast module."""
 
 import unittest
+from dataclasses import replace
 from types import SimpleNamespace
 from typing import cast
+from unittest.mock import patch
 
 from ..core.context import Context
 from ..core.step import ValidationError
 from .appcast import AppcastModule
+from .feeds.spec import browser_feeds_for_product
 
 
 def _artifact(filename: str) -> dict:
@@ -157,11 +160,21 @@ class AppcastModuleTest(unittest.TestCase):
             [c.key for c in self.publisher.calls], ["appcast-claw.xml"]
         )
 
-    def test_validate_refuses_publishing_unpublishable_product(self):
-        module = AppcastModule(product_id="browserclaw", publish=True)
+    def test_validate_refuses_publishing_unpublishable_feed(self):
+        # Every real product now has a client, so synthesize an unpublishable
+        # feed set to exercise the gate itself.
+        unpublishable = tuple(
+            replace(feed, publishable=False)
+            for feed in browser_feeds_for_product("browseros")
+        )
+        module = AppcastModule(product_id="browseros", publish=True)
 
-        with self.assertRaisesRegex(ValidationError, "browserclaw"):
-            module.validate(self._ctx())
+        with patch(
+            "bos_build.release.appcast.browser_feeds_for_product",
+            return_value=unpublishable,
+        ):
+            with self.assertRaisesRegex(ValidationError, "not publishable"):
+                module.validate(self._ctx())
 
     def test_validate_requires_version(self):
         module = AppcastModule()

--- a/packages/browseros/bos_build/release/feeds/publisher_test.py
+++ b/packages/browseros/bos_build/release/feeds/publisher_test.py
@@ -4,6 +4,7 @@
 import io
 import tempfile
 import unittest
+from dataclasses import replace
 from datetime import datetime, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -401,7 +402,7 @@ class PublisherTestCase(unittest.TestCase):
         self.assertIsNone(absent.last_published)
 
     def test_unpublishable_spec_refuses_publish_allows_dry_run(self):
-        spec = feed_by_key("appcast-claw.xml")
+        spec = replace(feed_by_key("appcast-claw.xml"), publishable=False)
         content = render_browser_appcast(
             spec, _artifact(), "0.47.0.2", "10000.0.47.0.2", "2026-06-19T06:41:33Z"
         )

--- a/packages/browseros/bos_build/release/feeds/spec.py
+++ b/packages/browseros/bos_build/release/feeds/spec.py
@@ -76,6 +76,12 @@ class FeedSpec:
 # Browser feed key infix per product ("" keeps today's browseros keys).
 _BROWSER_FEED_SLUGS = {"browseros": "", "browserclaw": "claw"}
 
+# Products whose shipping updater selects this feed by browseros::GetProduct()
+# (sparkle_glue.mm / winsparkle_glue.cc). A product listed in
+# _BROWSER_FEED_SLUGS but missing here would ship an updater still pointing at
+# the browseros feed, so its feeds stay unpublishable until that client lands.
+_BROWSER_FEED_CLIENTS = frozenset({"browseros", "browserclaw"})
+
 # Server feed key slug per bundle (appcast-<slug>[.alpha].xml).
 _SERVER_FEED_SLUGS = {
     "browseros-server": "server",
@@ -86,9 +92,8 @@ _SERVER_FEED_SLUGS = {
 def _browser_feeds(product_id: str) -> Tuple[FeedSpec, ...]:
     """Derive the four Sparkle/WinSparkle browser feeds for one product.
 
-    Only browseros is publishable: sparkle_glue.mm / winsparkle_glue.cc
-    hardcode the browseros keys, so claw feeds have no client until the
-    product-aware URL chromium patch lands.
+    A product's feeds are publishable once its updater selects them by
+    browseros::GetProduct() — see _BROWSER_FEED_CLIENTS.
     """
     slug = _BROWSER_FEED_SLUGS.get(product_id)
     if slug is None:
@@ -98,7 +103,7 @@ def _browser_feeds(product_id: str) -> Tuple[FeedSpec, ...]:
         )
     infix = f"-{slug}" if slug else ""
     display = get_product_descriptor(product_id).display_name
-    publishable = product_id == "browseros"
+    publishable = product_id in _BROWSER_FEED_CLIENTS
 
     def feed(suffix: str, platform: str, artifact_keys: Tuple[str, ...],
              title: str) -> FeedSpec:

--- a/packages/browseros/bos_build/release/feeds/spec_test.py
+++ b/packages/browseros/bos_build/release/feeds/spec_test.py
@@ -49,7 +49,7 @@ class FeedTableTest(unittest.TestCase):
         keys = [feed.key for feed in all_feeds()]
         self.assertEqual(len(keys), len(set(keys)))
 
-    def test_browserclaw_browser_feeds_exist_but_are_unpublishable(self):
+    def test_browserclaw_browser_feeds_are_publishable(self):
         claw_feeds = browser_feeds_for_product("browserclaw")
         self.assertEqual(
             [feed.key for feed in claw_feeds],
@@ -60,7 +60,9 @@ class FeedTableTest(unittest.TestCase):
                 "appcast-claw-win-arm64.xml",
             ],
         )
-        self.assertTrue(all(not feed.publishable for feed in claw_feeds))
+        # Publishable since the product-aware URL chromium patch: both
+        # sparkle_glue.mm and winsparkle_glue.cc select the claw feed.
+        self.assertTrue(all(feed.publishable for feed in claw_feeds))
 
     def test_browseros_browser_feeds_are_publishable(self):
         feeds = browser_feeds_for_product("browseros")

--- a/packages/browseros/chromium_patches/chrome/browser/mac/sparkle_glue.mm
+++ b/packages/browseros/chromium_patches/chrome/browser/mac/sparkle_glue.mm
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/mac/sparkle_glue.mm b/chrome/browser/mac/sparkle_glue.mm
 new file mode 100644
-index 0000000000000..25c4843095e4f
+index 0000000000000..7a5da195279c1
 --- /dev/null
 +++ b/chrome/browser/mac/sparkle_glue.mm
-@@ -0,0 +1,668 @@
+@@ -0,0 +1,673 @@
 +// Copyright 2024 BrowserOS Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -20,6 +20,7 @@ index 0000000000000..25c4843095e4f
 +#include "base/system/sys_info.h"
 +#include "base/version.h"
 +#include "chrome/browser/browser_process.h"
++#include "chrome/browser/browseros/core/browseros_product.h"
 +#include "chrome/browser/browseros/core/browseros_switches.h"
 +#include "chrome/browser/upgrade_detector/build_state.h"
 +
@@ -32,12 +33,16 @@ index 0000000000000..25c4843095e4f
 +namespace {
 +
 +NSString* GetArchitectureSpecificFeedURL() {
-+  const char* kBaseURL = "https://cdn.browseros.com/";
++  // Feed keys are owned by release/feeds/spec.py (_BROWSER_FEED_SLUGS) in
++  // the BrowserOS repo; keep the two in lockstep.
++  const char* base_url = browseros::IsBrowserClawProduct()
++                             ? "https://cdn.browseros.com/appcast-claw"
++                             : "https://cdn.browseros.com/appcast";
 +
 +  if (base::SysInfo::OperatingSystemArchitecture() == "x86_64") {
-+    return [NSString stringWithFormat:@"%sappcast-x86_64.xml", kBaseURL];
++    return [NSString stringWithFormat:@"%s-x86_64.xml", base_url];
 +  }
-+  return [NSString stringWithFormat:@"%sappcast.xml", kBaseURL];
++  return [NSString stringWithFormat:@"%s.xml", base_url];
 +}
 +
 +bool IsOnReadOnlyFilesystem(NSString* path) {

--- a/packages/browseros/chromium_patches/chrome/browser/win/winsparkle_glue.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/win/winsparkle_glue.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/win/winsparkle_glue.cc b/chrome/browser/win/winsparkle_glue.cc
 new file mode 100644
-index 0000000000000..36d8f7ba9d353
+index 0000000000000..93e1ec7170840
 --- /dev/null
 +++ b/chrome/browser/win/winsparkle_glue.cc
-@@ -0,0 +1,355 @@
+@@ -0,0 +1,375 @@
 +// Copyright 2024 BrowserOS Authors. All rights reserved.
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -32,6 +32,7 @@ index 0000000000000..36d8f7ba9d353
 +#include "base/time/time.h"
 +#include "base/version_info/version_info.h"
 +#include "build/build_config.h"
++#include "chrome/browser/browseros/core/browseros_product.h"
 +#include "content/public/browser/browser_thread.h"
 +#include "third_party/winsparkle/include/winsparkle.h"
 +
@@ -45,19 +46,34 @@ index 0000000000000..36d8f7ba9d353
 +constexpr char kEdDSAPublicKey[] =
 +    "LzQmcNuTsdB3/dsivo0eeN+jPfDoriRHAkkEJcfFs2A=";
 +
-+// Windows builds are single-arch, so the feed is chosen at compile time
-+// (macOS picks at runtime because of universal binaries).
++// Windows builds are single-arch, so the arch half of the feed is chosen at
++// compile time (macOS picks at runtime because of universal binaries); the
++// product half follows browseros::GetProduct(). Feed keys are owned by
++// release/feeds/spec.py (_BROWSER_FEED_SLUGS) in the BrowserOS repo; keep
++// the two in lockstep.
 +#if defined(ARCH_CPU_ARM64)
 +constexpr char kAppcastURL[] =
 +    "https://cdn.browseros.com/appcast-win-arm64.xml";
++constexpr char kClawAppcastURL[] =
++    "https://cdn.browseros.com/appcast-claw-win-arm64.xml";
 +#else
 +constexpr char kAppcastURL[] = "https://cdn.browseros.com/appcast-win.xml";
++constexpr char kClawAppcastURL[] =
++    "https://cdn.browseros.com/appcast-claw-win.xml";
 +#endif
++
++const char* GetAppcastURL() {
++  return browseros::IsBrowserClawProduct() ? kClawAppcastURL : kAppcastURL;
++}
 +
 +// Matches SUScheduledCheckInterval on macOS; also WinSparkle's minimum.
 +constexpr int kUpdateCheckIntervalSeconds = 3600;
 +
++// Per-product registry state (skipped version, last check time): BrowserOS
++// and BrowserClaw install side by side, so sharing one path would
++// cross-contaminate their updaters.
 +constexpr char kRegistryPath[] = "Software\\BrowserOS\\WinSparkle";
++constexpr char kClawRegistryPath[] = "Software\\BrowserClaw\\WinSparkle";
 +
 +// Version compared against the appcast's sparkle:version: the BrowserOS
 +// version behind a fixed epoch component. The epoch keeps new releases
@@ -278,23 +294,27 @@ index 0000000000000..36d8f7ba9d353
 +
 +  ui_task_runner_ = content::GetUIThreadTaskRunner({});
 +
-+  win_sparkle_set_appcast_url(kAppcastURL);
++  const char* appcast_url = GetAppcastURL();
++  win_sparkle_set_appcast_url(appcast_url);
 +  if (!win_sparkle_set_eddsa_public_key(kEdDSAPublicKey)) {
 +    LOG(ERROR) << "WinSparkle: invalid EdDSA public key; updater disabled";
 +    return false;
 +  }
 +
++  const bool is_claw = browseros::IsBrowserClawProduct();
++
 +  // WinSparkle UI / User-Agent shows the BrowserOS release version;
 +  // comparisons use the epoch-prefixed feed version below.
 +  const std::wstring display_version =
 +      base::UTF8ToWide(version_info::GetBrowserOSVersionNumber());
-+  win_sparkle_set_app_details(L"BrowserOS", L"BrowserOS",
++  win_sparkle_set_app_details(L"BrowserOS",
++                              is_claw ? L"BrowserClaw" : L"BrowserOS",
 +                              display_version.c_str());
 +
 +  const std::wstring build_version = base::UTF8ToWide(GetUpdateFeedVersion());
 +  win_sparkle_set_app_build_version(build_version.c_str());
 +
-+  win_sparkle_set_registry_path(kRegistryPath);
++  win_sparkle_set_registry_path(is_claw ? kClawRegistryPath : kRegistryPath);
 +
 +  // Pre-seeding the automatic-check setting keeps WinSparkle from showing
 +  // its first-run permission prompt (macOS equivalent: SUEnableAutomaticChecks
@@ -318,7 +338,7 @@ index 0000000000000..36d8f7ba9d353
 +
 +  win_sparkle_init();
 +  enabled_ = true;
-+  VLOG(1) << "WinSparkle: initialized, feed " << kAppcastURL;
++  VLOG(1) << "WinSparkle: initialized, feed " << appcast_url;
 +  return true;
 +}
 +


### PR DESCRIPTION
## Summary
- Sparkle (mac) and WinSparkle (win) now select the update appcast by `browseros::GetProduct()`: BrowserClaw builds poll `appcast-claw[.-*].xml`; BrowserOS keeps today's keys.
- On Windows, the WinSparkle registry path (`Software\BrowserClaw\WinSparkle`) and app display name are product-scoped so side-by-side BrowserOS/BrowserClaw installs don't cross-contaminate skipped-version / last-check state.
- Release pipeline: browserclaw browser feeds are now **publishable** — the gate was waiting on exactly this client. Publishability is keyed on a new `_BROWSER_FEED_CLIENTS` set (the products whose updater selects their feed).

## Design
The feed key already existed on both sides — `_BROWSER_FEED_SLUGS = {"browseros": "", "browserclaw": "claw"}` in `release/feeds/spec.py` derives `appcast-claw*.xml`, and the chromium glue now emits those same keys. macOS picks the arch suffix at runtime (universal binary); Windows picks it at compile time (single-arch) and the product half from `GetProduct()`. The `publishable` gate stays as a general safety valve for any future product added to the slug map before its chromium updater client lands; browserclaw simply now qualifies.

## Test plan
- [x] `autoninja -C out/Default_arm64 chrome` — green (chromium patch compiles)
- [x] `verify-patches.sh` — both patches byte-match `BASE..tip` and apply-check onto the bare base
- [x] `python -m unittest` release (174) + products (29) suites green; feed/appcast/publisher tests updated for the new publishable state
- [ ] Cut a BrowserClaw build and confirm the updater polls `appcast-claw.xml` (mac) / `appcast-claw-win.xml` (win)