### PR TITLE
fix: inline production node env for claw server

### DIFF
--- a/packages/browseros-agent/packages/build-server-tools/src/config.ts
+++ b/packages/browseros-agent/packages/build-server-tools/src/config.ts
@@ -101,6 +101,7 @@ export function loadBuildConfig(
       envVars[key] ??= value
     }
   }
+  Object.assign(envVars, product.env.inlineEnvOverrides ?? {})
   if (!options.ci) {
     validateProductionEnv(product, envVars)
   }

--- a/packages/browseros-agent/packages/build-server-tools/src/types.ts
+++ b/packages/browseros-agent/packages/build-server-tools/src/types.ts
@@ -41,6 +41,7 @@ export interface BuildEnvSpec {
   requiredInlineEnvKeys: readonly string[]
   inlineEnvKeys: readonly string[]
   ciInlineEnvDefaults?: Record<string, string>
+  inlineEnvOverrides?: Record<string, string>
   defaultR2UploadPrefix: string
 }
 

--- a/packages/browseros-agent/packages/build-server-tools/tests/config.test.ts
+++ b/packages/browseros-agent/packages/build-server-tools/tests/config.test.ts
@@ -86,6 +86,26 @@ describe('build config', () => {
     expect(config.r2?.uploadPrefix).toBe('process-prefix')
   })
 
+  it('applies product inline env overrides after file and process env', async () => {
+    const rootDir = await writeProdRoot({
+      ...REQUIRED_INLINE_ENV,
+      LOG_LEVEL: 'debug',
+    })
+    process.env.LOG_LEVEL = 'warn'
+    const product = testProduct({
+      env: {
+        ...testProduct().env,
+        inlineEnvOverrides: {
+          LOG_LEVEL: 'info',
+        },
+      },
+    })
+
+    const config = loadBuildConfig(rootDir, product)
+
+    expect(config.envVars.LOG_LEVEL).toBe('info')
+  })
+
   it('does not require a production env file in CI mode', async () => {
     const rootDir = await writeProdRoot({}, { envFile: false })
 

--- a/packages/browseros-agent/scripts/build/claw-server/descriptor.test.ts
+++ b/packages/browseros-agent/scripts/build/claw-server/descriptor.test.ts
@@ -1,0 +1,63 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { loadBuildConfig } from '@browseros/build-server-tools'
+
+import { clawServerBuildProduct } from './descriptor'
+
+describe('claw server build descriptor', () => {
+  let tempRoot: string | null = null
+  let originalNodeEnv: string | undefined
+
+  beforeEach(() => {
+    originalNodeEnv = process.env.NODE_ENV
+    delete process.env.NODE_ENV
+  })
+
+  afterEach(async () => {
+    if (originalNodeEnv === undefined) {
+      delete process.env.NODE_ENV
+    } else {
+      process.env.NODE_ENV = originalNodeEnv
+    }
+
+    if (tempRoot) {
+      await rm(tempRoot, { recursive: true, force: true })
+      tempRoot = null
+    }
+  })
+
+  it('inlines NODE_ENV from the production env file', async () => {
+    const rootDir = await writeClawPackageRoot('NODE_ENV=production\n')
+
+    const config = loadBuildConfig(rootDir, clawServerBuildProduct)
+
+    expect(config.envVars.NODE_ENV).toBe('production')
+  })
+
+  it('defaults CI builds to production NODE_ENV without an env file', async () => {
+    const rootDir = await writeClawPackageRoot()
+
+    const config = loadBuildConfig(rootDir, clawServerBuildProduct, {
+      ci: true,
+    })
+
+    expect(config.envVars.NODE_ENV).toBe('production')
+  })
+
+  async function writeClawPackageRoot(envContent?: string): Promise<string> {
+    tempRoot = await mkdtemp(join(tmpdir(), 'claw-server-build-descriptor-'))
+    const packageDir = join(tempRoot, 'apps/claw-server')
+    await mkdir(packageDir, { recursive: true })
+    await writeFile(
+      join(packageDir, 'package.json'),
+      '{"version":"0.0.0-test"}',
+    )
+    if (envContent !== undefined) {
+      await writeFile(join(packageDir, '.env.production'), envContent)
+    }
+    return tempRoot
+  }
+})

--- a/packages/browseros-agent/scripts/build/claw-server/descriptor.test.ts
+++ b/packages/browseros-agent/scripts/build/claw-server/descriptor.test.ts
@@ -47,6 +47,17 @@ describe('claw server build descriptor', () => {
     expect(config.envVars.NODE_ENV).toBe('production')
   })
 
+  it('forces CI builds to production NODE_ENV over ambient env', async () => {
+    process.env.NODE_ENV = 'development'
+    const rootDir = await writeClawPackageRoot()
+
+    const config = loadBuildConfig(rootDir, clawServerBuildProduct, {
+      ci: true,
+    })
+
+    expect(config.envVars.NODE_ENV).toBe('production')
+  })
+
   async function writeClawPackageRoot(envContent?: string): Promise<string> {
     tempRoot = await mkdtemp(join(tmpdir(), 'claw-server-build-descriptor-'))
     const packageDir = join(tempRoot, 'apps/claw-server')

--- a/packages/browseros-agent/scripts/build/claw-server/descriptor.ts
+++ b/packages/browseros-agent/scripts/build/claw-server/descriptor.ts
@@ -2,6 +2,11 @@ import type { BuildProductDescriptor } from '@browseros/build-server-tools'
 
 export const CLAW_SERVER_BUNDLE_ENTRYPOINT = 'apps/claw-server/src/main.ts'
 
+const INLINED_ENV_VARS = ['NODE_ENV'] as const
+const CI_INLINE_ENV_DEFAULTS = {
+  NODE_ENV: 'production',
+}
+
 export const clawServerBuildProduct: BuildProductDescriptor = {
   label: 'BrowserOS Claw server',
   packageDir: 'apps/claw-server',
@@ -15,8 +20,8 @@ export const clawServerBuildProduct: BuildProductDescriptor = {
     prodEnvPath: 'apps/claw-server/.env.production',
     requireProdEnvFile: false,
     requiredInlineEnvKeys: [],
-    inlineEnvKeys: [],
-    ciInlineEnvDefaults: {},
+    inlineEnvKeys: INLINED_ENV_VARS,
+    ciInlineEnvDefaults: CI_INLINE_ENV_DEFAULTS,
     defaultR2UploadPrefix: 'claw-server/prod-resources',
   },
 }

--- a/packages/browseros-agent/scripts/build/claw-server/descriptor.ts
+++ b/packages/browseros-agent/scripts/build/claw-server/descriptor.ts
@@ -3,7 +3,7 @@ import type { BuildProductDescriptor } from '@browseros/build-server-tools'
 export const CLAW_SERVER_BUNDLE_ENTRYPOINT = 'apps/claw-server/src/main.ts'
 
 const INLINED_ENV_VARS = ['NODE_ENV'] as const
-const CI_INLINE_ENV_DEFAULTS = {
+const PRODUCTION_INLINE_ENV = {
   NODE_ENV: 'production',
 }
 
@@ -21,7 +21,8 @@ export const clawServerBuildProduct: BuildProductDescriptor = {
     requireProdEnvFile: false,
     requiredInlineEnvKeys: [],
     inlineEnvKeys: INLINED_ENV_VARS,
-    ciInlineEnvDefaults: CI_INLINE_ENV_DEFAULTS,
+    ciInlineEnvDefaults: PRODUCTION_INLINE_ENV,
+    inlineEnvOverrides: PRODUCTION_INLINE_ENV,
     defaultR2UploadPrefix: 'claw-server/prod-resources',
   },
 }


### PR DESCRIPTION
## Summary
- Force Claw production resource builds to inline `NODE_ENV=production`.
- Add an optional build descriptor inline-env override so ambient `NODE_ENV=development` cannot leak into Claw bundles.
- Cover Claw descriptor behavior and shared build-config override precedence with focused Bun tests.

## Design
The Claw descriptor now declares `NODE_ENV` as an inline env key and owns a production override. `loadBuildConfig` applies optional descriptor inline overrides after file/process env and CI defaults, leaving existing products unchanged unless they opt in.

## Test plan
- [x] `bun test scripts/build/claw-server/descriptor.test.ts`
- [x] `bun test scripts/build/claw-server/descriptor.test.ts packages/build-server-tools/tests/config.test.ts`
- [x] `bun run check` from `packages/browseros-agent` (exits 0; existing Biome/fallow warning reports still print)