### PR TITLE
fix(claw): enlarge and polish the screenshot lightbox

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.tsx
@@ -63,11 +63,11 @@ export function ScreenshotLightbox({
             {screenshotBaseUrl !== null ? (
               <img
                 src={taskScreenshotUrl(dispatchId, screenshotBaseUrl)}
-                alt={`Screenshot — ${caption}`}
-                className="max-h-[calc(92vh-3.25rem)] w-auto max-w-[94vw] rounded-xl object-contain shadow-2xl ring-1 ring-foreground/10"
+                alt={host ? `Screenshot of ${host}` : 'Screenshot'}
+                className="max-h-[calc(92vh-3.5rem)] w-auto max-w-[94vw] rounded-xl object-contain shadow-2xl ring-1 ring-foreground/10"
               />
             ) : (
-              <div className="aspect-[16/10] w-[70vw] max-w-[94vw] animate-pulse rounded-xl bg-card-tint ring-1 ring-foreground/10" />
+              <div className="aspect-[16/10] max-h-[calc(92vh-3.5rem)] w-[70vw] max-w-[94vw] animate-pulse rounded-xl bg-card-tint ring-1 ring-foreground/10" />
             )}
           </>
         )}

--- a/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotLightbox.tsx
@@ -1,32 +1,76 @@
-import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
+import { IconX } from '@tabler/icons-react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogTitle,
+} from '@/components/ui/dialog'
 import {
   taskScreenshotUrl,
   useTaskScreenshotBaseUrl,
 } from '@/modules/api/audit.hooks'
+import { formatOffset, hostOf } from './screenshot.helpers'
 
 interface ScreenshotLightboxProps {
   dispatchId: number | null
+  sourceUrl?: string | null
+  offsetMs?: number | null
   onClose: () => void
 }
 
+/**
+ * Full-size screenshot inspector. A caption + close toolbar sits above
+ * the image (never over it), and the image is bounded to the viewport
+ * with object-contain so it renders as large as possible without
+ * overflow or distortion.
+ *
+ * DialogContent's default width clamp is `sm:max-w-md` (448px); the
+ * `sm:max-w-[94vw]` override is load-bearing — a base-only `max-w` is
+ * silently ignored at every width ≥640px.
+ */
 export function ScreenshotLightbox({
   dispatchId,
+  sourceUrl = null,
+  offsetMs = null,
   onClose,
 }: ScreenshotLightboxProps) {
   const screenshotBaseUrl = useTaskScreenshotBaseUrl()
+  const host = hostOf(sourceUrl)
+  const caption =
+    [host, offsetMs != null ? `T+${formatOffset(offsetMs)}` : null]
+      .filter(Boolean)
+      .join(' · ') || 'Screenshot'
+
   return (
     <Dialog open={dispatchId !== null} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent className="max-w-4xl border-none bg-transparent p-0 shadow-none">
-        <DialogTitle className="sr-only">Screenshot</DialogTitle>
-        {dispatchId !== null && screenshotBaseUrl !== null ? (
-          <img
-            src={taskScreenshotUrl(dispatchId, screenshotBaseUrl)}
-            alt={`Screenshot from dispatch ${dispatchId}`}
-            className="h-auto w-full rounded-lg"
-          />
-        ) : dispatchId !== null ? (
-          <div className="aspect-[16/10] w-full animate-pulse rounded-lg bg-card-tint" />
-        ) : null}
+      <DialogContent
+        showCloseButton={false}
+        className="flex max-h-[92vh] w-auto max-w-[94vw] flex-col gap-2 bg-transparent p-0 shadow-none ring-0 sm:max-w-[94vw]"
+      >
+        <DialogTitle className="sr-only">Screenshot preview</DialogTitle>
+        {dispatchId !== null && (
+          <>
+            <div className="flex items-center justify-between gap-3 rounded-lg bg-popover/95 px-3 py-2 ring-1 ring-foreground/10 supports-backdrop-filter:backdrop-blur">
+              <span className="min-w-0 truncate font-mono text-[12.5px] text-ink-2">
+                {caption}
+              </span>
+              <DialogClose render={<Button variant="ghost" size="icon-sm" />}>
+                <IconX />
+                <span className="sr-only">Close</span>
+              </DialogClose>
+            </div>
+            {screenshotBaseUrl !== null ? (
+              <img
+                src={taskScreenshotUrl(dispatchId, screenshotBaseUrl)}
+                alt={`Screenshot — ${caption}`}
+                className="max-h-[calc(92vh-3.25rem)] w-auto max-w-[94vw] rounded-xl object-contain shadow-2xl ring-1 ring-foreground/10"
+              />
+            ) : (
+              <div className="aspect-[16/10] w-[70vw] max-w-[94vw] animate-pulse rounded-xl bg-card-tint ring-1 ring-foreground/10" />
+            )}
+          </>
+        )}
       </DialogContent>
     </Dialog>
   )

--- a/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotStrip.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/ScreenshotStrip.tsx
@@ -6,6 +6,7 @@ import {
   taskScreenshotUrl,
   useTaskScreenshotBaseUrl,
 } from '@/modules/api/audit.hooks'
+import { formatOffset, hostOf } from './screenshot.helpers'
 
 interface ScreenshotStripProps {
   dispatches: ToolDispatchRow[]
@@ -91,23 +92,4 @@ export function ScreenshotStrip({
       </ScrollArea>
     </section>
   )
-}
-
-function formatOffset(ms: number): string {
-  if (ms < 1000) return `${ms}ms`
-  const seconds = ms / 1000
-  if (seconds < 60) return `${seconds.toFixed(1)}s`
-  const totalSec = Math.floor(seconds)
-  const mins = Math.floor(totalSec / 60)
-  const rem = totalSec % 60
-  return `${mins}m${rem.toString().padStart(2, '0')}s`
-}
-
-function hostOf(url: string | null): string {
-  if (!url) return ''
-  try {
-    return new URL(url).hostname.replace(/^www\./, '')
-  } catch {
-    return ''
-  }
 }

--- a/packages/browseros-agent/apps/claw-app/components/audit/screenshot.helpers.test.ts
+++ b/packages/browseros-agent/apps/claw-app/components/audit/screenshot.helpers.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'bun:test'
+import { formatOffset, hostOf } from './screenshot.helpers'
+
+describe('formatOffset', () => {
+  it('renders sub-second offsets in milliseconds', () => {
+    expect(formatOffset(0)).toBe('0ms')
+    expect(formatOffset(500)).toBe('500ms')
+    expect(formatOffset(999)).toBe('999ms')
+  })
+
+  it('renders sub-minute offsets in seconds with one decimal', () => {
+    expect(formatOffset(1000)).toBe('1.0s')
+    expect(formatOffset(1500)).toBe('1.5s')
+    expect(formatOffset(59900)).toBe('59.9s')
+  })
+
+  it('renders minute-plus offsets as m + zero-padded seconds', () => {
+    expect(formatOffset(60000)).toBe('1m00s')
+    expect(formatOffset(65000)).toBe('1m05s')
+    expect(formatOffset(600000)).toBe('10m00s')
+  })
+})
+
+describe('hostOf', () => {
+  it('strips the scheme, path, and leading www.', () => {
+    expect(hostOf('https://www.example.com/admin?q=1')).toBe('example.com')
+    expect(hostOf('https://admin.google.com')).toBe('admin.google.com')
+  })
+
+  it('returns an empty string for null or unparseable input', () => {
+    expect(hostOf(null)).toBe('')
+    expect(hostOf('not a url')).toBe('')
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/components/audit/screenshot.helpers.ts
+++ b/packages/browseros-agent/apps/claw-app/components/audit/screenshot.helpers.ts
@@ -1,0 +1,20 @@
+/** `T+` label for a screenshot's offset from task start. */
+export function formatOffset(ms: number): string {
+  if (ms < 1000) return `${ms}ms`
+  const seconds = ms / 1000
+  if (seconds < 60) return `${seconds.toFixed(1)}s`
+  const totalSec = Math.floor(seconds)
+  const mins = Math.floor(totalSec / 60)
+  const rem = totalSec % 60
+  return `${mins}m${rem.toString().padStart(2, '0')}s`
+}
+
+/** Bare hostname (no `www.`) for a captured page URL, or `''` when unknown. */
+export function hostOf(url: string | null): string {
+  if (!url) return ''
+  try {
+    return new URL(url).hostname.replace(/^www\./, '')
+  } catch {
+    return ''
+  }
+}

--- a/packages/browseros-agent/apps/claw-app/screens/task-detail/TaskDetailPage.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/task-detail/TaskDetailPage.tsx
@@ -61,6 +61,11 @@ export function TaskDetailPage() {
     )
   }
 
+  const selectedDispatch =
+    lightboxId !== null
+      ? (task.dispatches.find((d) => d.id === lightboxId) ?? null)
+      : null
+
   const items: AutoHideTabsItem[] = groups.map((g) => ({
     id: g.id,
     label: (
@@ -91,6 +96,12 @@ export function TaskDetailPage() {
       />
       <ScreenshotLightbox
         dispatchId={lightboxId}
+        sourceUrl={selectedDispatch?.url ?? null}
+        offsetMs={
+          selectedDispatch
+            ? Math.max(0, selectedDispatch.createdAt - task.startedAt)
+            : null
+        }
         onClose={() => setLightboxId(null)}
       />
     </div>


### PR DESCRIPTION
## Summary
- The task-detail screenshot lightbox was clamped to **448px on every desktop width** and had a close button awkwardly overlapping the image corner. Root cause: `DialogContent`'s default `sm:max-w-md` silently overrode the lightbox's base-only `max-w-4xl` — `tailwind-merge` treats the `sm:` variant as non-conflicting, so it won at every width ≥640px.
- Reworked into a proper image inspector: the image now fills up to **94vw / 92vh** with `object-contain` (no distortion, no overflow), centered, with a clean **caption + close toolbar sitting _above_ the image** so controls never overlap content.
- Caption (source host + `T+offset`) is derived in `TaskDetailPage` from data already loaded — no new coupling through the strip/timeline. The two formatters moved to a shared, unit-tested `screenshot.helpers.ts`.

## Design
Kept base-ui `DialogContent` (preserves portal, overlay, Esc/backdrop-dismiss, focus-trap) but stripped its card chrome and overrode the width clamp in **both** the base and `sm:` variants (`max-w-[94vw] sm:max-w-[94vw]`) — the actual fix. `showCloseButton={false}` plus a labeled `DialogClose` ghost icon button in the toolbar. Image bounded by viewport `max-h`/`max-w` with `w-auto`/`object-contain`. No shared component touched, no new dependencies. Scoped to the claw-app screenshot popup + its immediate wiring.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bunx biome check` (touched files) — clean
- [x] `bun test` (claw-app) — **173/173 pass**, incl. new `screenshot.helpers.test.ts` and the unchanged `TaskDetailPage.test.tsx` (closed lightbox still renders no screenshot URL)
- [x] Visual (faithful CSS harness, real viewport via CDP):
  - Desktop — viewport 1466px → **image 1378px wide (~94vw)**, vs the old 448px cap; centered, contained, undistorted; toolbar + close render above the image.
  - Narrow — viewport 420px → **image 395px wide**, no horizontal overflow; caption truncates, close stays visible.
  - Page behind stays dimmed/blurred (shared overlay unchanged).

> Note: `bun run check` also runs `fallow`, which reports a **pre-existing** monorepo-wide baseline of `private-type-leak` lints (386 issues across 93 files — claw-server, ai-elements, etc.). **Zero** are introduced by this change; none of the 5 touched files are flagged.