### PR TITLE
fix(claw-app): keep sidebar theme menu anchored to its trigger

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarThemeToggle.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarThemeToggle.tsx
@@ -1,5 +1,5 @@
 import { Monitor, Moon, Sun } from 'lucide-react'
-import type { ComponentType, SVGProps } from 'react'
+import { type ComponentType, type SVGProps, useRef } from 'react'
 import { useTheme } from '@/components/theme-provider'
 import {
   DropdownMenu,
@@ -45,9 +45,17 @@ export function SidebarThemeToggle({
   const current =
     themeOptions.find((option) => option.value === theme) ?? themeOptions[0]
   const CurrentIcon = current.icon
+  // Keep the trigger in one stable subtree across expand/collapse. Swapping it
+  // between a bare and a Tooltip-wrapped trigger remounts the button, which
+  // drops base-ui's popup anchor and flings the open menu to the top-left
+  // (0,0) — the hover-collapse fires while the menu is open because the popup
+  // is portaled outside the sidebar's hover zone. The explicit anchor below
+  // then keeps the popup pinned to the live trigger as the rail resizes.
+  const triggerRef = useRef<HTMLButtonElement>(null)
 
   const trigger = (
     <DropdownMenuTrigger
+      ref={triggerRef}
       aria-label={`Theme: ${current.label}`}
       className="flex h-9 w-full items-center gap-3 overflow-hidden whitespace-nowrap rounded-md px-2.5 font-medium text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground aria-expanded:bg-sidebar-accent aria-expanded:text-sidebar-accent-foreground"
     >
@@ -65,15 +73,12 @@ export function SidebarThemeToggle({
 
   return (
     <DropdownMenu modal={false}>
-      {expanded ? (
-        trigger
-      ) : (
-        <Tooltip>
-          <TooltipTrigger render={trigger} />
-          <TooltipContent side="right">Theme</TooltipContent>
-        </Tooltip>
-      )}
+      <Tooltip>
+        <TooltipTrigger render={trigger} />
+        {expanded ? null : <TooltipContent side="right">Theme</TooltipContent>}
+      </Tooltip>
       <DropdownMenuContent
+        anchor={() => triggerRef.current}
         side={expanded ? 'top' : 'right'}
         align={expanded ? 'start' : 'end'}
         sideOffset={8}

--- a/packages/browseros-agent/apps/claw-app/components/ui/dropdown-menu.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/ui/dropdown-menu.tsx
@@ -21,12 +21,13 @@ function DropdownMenuContent({
   alignOffset = 0,
   side = "bottom",
   sideOffset = 4,
+  anchor,
   className,
   ...props
 }: MenuPrimitive.Popup.Props &
   Pick<
     MenuPrimitive.Positioner.Props,
-    "align" | "alignOffset" | "side" | "sideOffset"
+    "align" | "alignOffset" | "side" | "sideOffset" | "anchor"
   >) {
   return (
     <MenuPrimitive.Portal>
@@ -36,6 +37,7 @@ function DropdownMenuContent({
         alignOffset={alignOffset}
         side={side}
         sideOffset={sideOffset}
+        anchor={anchor}
       >
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"


### PR DESCRIPTION
## Summary
- The BrowserClaw sidebar **System/Light/Dark** menu intermittently opened at the **top-left corner (0,0)** instead of next to its footer trigger (see the reported screenshot).
- Root cause: the sidebar expands on hover and the menu popup is portaled to `document.body` — *outside* the sidebar's hover zone — so moving the pointer onto the open menu fires the 150ms mouse-leave collapse. That flipped the trigger between a **bare** and a **Tooltip-wrapped** subtree, **remounting the button while the menu was open**; base-ui read the popup anchor during the remount's transient-null window and cached (0,0). Being timing-dependent, it only reproduced "at times."

## Design
Two-part, minimal fix:
1. **Stable trigger subtree** — `SidebarThemeToggle` now always renders the trigger inside one `Tooltip` wrapper (the tooltip label shows only when collapsed), so toggling `expanded` changes props, not structure. The button DOM node is never remounted → base-ui never loses its anchor.
2. **Explicit anchor** — `DropdownMenuContent` gains an additive `anchor` passthrough to base-ui's `Menu.Positioner`, and the theme menu passes `anchor={() => triggerRef.current}` so the popup stays pinned to the *live* trigger element (and re-measures as the rail resizes). The prop defaults to `undefined`, so every other `DropdownMenu` consumer keeps base-ui's default anchoring unchanged.

## Test plan
- [x] `bun run typecheck` (claw-app: wxt prepare + tsc) — clean
- [x] `bunx biome check` on both changed files — clean
- [x] `bun test` (claw-app) — 168 pass / 0 fail
- [x] **Real-browser verification** (harness reproducing the exact structure + hover-collapse, driven via CDP, reading the popup's `getBoundingClientRect`):
  - pre-fix, remount-while-open: **6/6** landed top-left (0,0)
  - post-fix, remount-while-open: **0/8** — anchored every time (expanded: above the trigger; collapsed: to its right), tracking the rail as it narrows
  - fresh opens (expanded + collapsed) anchor correctly in both variants
- [ ] Manual: open the theme menu from the sidebar footer, move onto the menu so the sidebar collapses, confirm the menu stays put and switching System/Light/Dark still works (light + dark mode)

## Notes
- Bug-class scan: `SidebarNavigation` swaps subtrees the same way, but its trigger is a `NavLink` with only a transient hover tooltip (no persistent `Menu.Positioner`), so it can't exhibit this bug — intentionally left untouched.
- `bun run check` at the package root: **lint + typecheck pass**; the `fallow` step reports 387 pre-existing dead-code findings across 93 unrelated files — **identical with and without this change** (verified by stashing), i.e. a pre-existing repo baseline, not introduced here.