### PR TITLE
fix: stabilize replay viewport playback

### DIFF
--- a/packages/browseros-agent/apps/claw-app/screens/replay/PlaybackTransport.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/PlaybackTransport.tsx
@@ -12,6 +12,7 @@ interface PlaybackTransportProps {
   playback: Playback
   totalSeconds: number
   frames: readonly ReplayFrame[]
+  onSeek: (seconds: number) => void
 }
 
 /**
@@ -23,13 +24,14 @@ export function PlaybackTransport({
   playback,
   totalSeconds,
   frames,
+  onSeek,
 }: PlaybackTransportProps) {
-  const { time, isPlaying, speed, setSpeed, togglePlay, seek } = playback
+  const { time, isPlaying, speed, setSpeed, togglePlay } = playback
   const finished = time >= totalSeconds
   const progress = totalSeconds === 0 ? 0 : (time / totalSeconds) * 100
 
   const onScrubberChange = (event: ChangeEvent<HTMLInputElement>) => {
-    seek(Number(event.target.value))
+    onSeek(Number(event.target.value))
   }
 
   return (
@@ -70,7 +72,7 @@ export function PlaybackTransport({
                 key={`bookmark-${frame.kind}-${frame.t}`}
                 title={frame.caption}
                 aria-label={`Jump to ${frame.caption}`}
-                onClick={() => seek(frame.t)}
+                onClick={() => onSeek(frame.t)}
                 style={{ left: `${pct}%` }}
                 className={cn(
                   'absolute z-10 size-2.5 -translate-x-1/2 rounded-full border-2 border-card shadow-sm',

--- a/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/Replay.tsx
@@ -2,22 +2,6 @@
  * @license
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
- *
- * Top-level page for `/audit/:sessionId/replay`. Reuses the
- * existing scaffold's header / viewport / transport / timeline
- * layout but wires it to real data via `useReplayData`. The page
- * owns three pieces of state:
- *
- *   1. `selectedTabPageId`: which of the agent's tabs is currently
- *      replaying. Defaults to the first tab that has events.
- *   2. `playerHandle`: the imperative interface ReplayViewport
- *      hands back once rrweb-player mounts. We forward
- *      PlaybackTransport's seek/play/pause to it.
- *   3. The scaffold's `usePlayback` clock keeps owning the time
- *      cursor. PlaybackTransport's scrub event fires
- *      `playback.seek(t)` AND `playerHandle.goto(t * 1000)` in
- *      lockstep. The rrweb-player runs silently in the background
- *      since its controller is hidden.
  */
 
 import { ArrowLeft, History } from 'lucide-react'
@@ -33,6 +17,7 @@ import { buildTabView, EMPTY_TAB_VIEW, useReplayData } from './replay.data'
 import { frameIndexAt } from './replay.helpers'
 import { usePlayback } from './use-playback'
 
+/** Renders the audit replay page and syncs rrweb playback to the transport UI. */
 export function Replay() {
   const { replay, isLoading, navigate } = useReplayData()
   const location = useLocation()
@@ -40,19 +25,17 @@ export function Replay() {
     null,
   )
   const playerHandleRef = useRef<ReplayPlayerHandle | null>(null)
+  const playbackTimeRef = useRef(0)
+  const playbackSpeedRef = useRef(1)
+  const playbackIsPlayingRef = useRef(true)
+  const hasInitializedTabRef = useRef(false)
 
-  // Default the tab selector once the data lands.
   useEffect(() => {
     if (selectedTabPageId !== null) return
     if (!replay || replay.tabPageIds.length === 0) return
     setSelectedTabPageId(replay.tabPageIds[0])
   }, [replay, selectedTabPageId])
 
-  // Per-tab view: frames + events + duration scoped to the
-  // currently-selected tab, with frames time-shifted to tab-
-  // relative t=0. Every panel below (viewport, timeline, scrubber)
-  // reads from this and only this. Must be declared BEFORE the
-  // isLoading early-return so rules-of-hooks stays honest.
   const perTabView = useMemo(
     () =>
       replay
@@ -68,39 +51,80 @@ export function Replay() {
     [replay, selectedTabPageId],
   )
 
-  // Tab-scoped clock. Its totalSeconds changes when the operator
-  // switches tabs; the seek-to-0 effect below lands the playhead
-  // at the start of the new tab's story.
   const playback = usePlayback(perTabView.totalSeconds)
 
-  // When playback's time changes (driven by the scaffold's
-  // setInterval clock), forward to the rrweb-player. Without this
-  // the player would sit idle while the scrubber + timeline
-  // advance on their own.
   useEffect(() => {
-    playerHandleRef.current?.goto(playback.time * 1000)
+    playbackTimeRef.current = playback.time
   }, [playback.time])
 
-  // On tab switch, reset the clock to 0 so the operator lands at
-  // the tab's start (Option A: per-tab clocks). usePlayback's
-  // internal useState would otherwise keep the previous tab's
-  // position, which is meaningless in the new tab's timeline.
-  // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally scoped to selectedTabPageId; `playback.seek` is a new reference every render and would cause an infinite loop.
   useEffect(() => {
-    playback.seek(0)
-  }, [selectedTabPageId])
+    playbackSpeedRef.current = playback.speed
+    playerHandleRef.current?.setSpeed(playback.speed)
+  }, [playback.speed])
 
-  // Mirror play/pause to the rrweb-player. The player still has
-  // its own internal clock for rendering frames between our seek
-  // updates, so a coarse play/pause is enough.
   useEffect(() => {
-    if (!playerHandleRef.current) return
-    if (playback.isPlaying) playerHandleRef.current.play()
-    else playerHandleRef.current.pause()
+    playbackIsPlayingRef.current = playback.isPlaying
   }, [playback.isPlaying])
 
-  const onPlayerReady = useCallback((handle: ReplayPlayerHandle) => {
+  // biome-ignore lint/correctness/useExhaustiveDependencies: tab changes are the only reset trigger; task-duration updates must not restart playback.
+  useEffect(() => {
+    if (selectedTabPageId === null) return
+    if (!hasInitializedTabRef.current) {
+      hasInitializedTabRef.current = true
+      playbackTimeRef.current = 0
+      return
+    }
+    const seconds = playback.seek(0)
+    playbackTimeRef.current = seconds
+    playbackIsPlayingRef.current = false
+    playerHandleRef.current?.seek(0)
+  }, [selectedTabPageId])
+
+  useEffect(() => {
+    if (!playerHandleRef.current) return
+    if (playback.isPlaying) {
+      playerHandleRef.current.play(playbackTimeRef.current * 1000)
+    } else {
+      playerHandleRef.current.pause()
+    }
+  }, [playback.isPlaying])
+
+  useEffect(() => {
+    if (!playback.isPlaying || perTabView.totalSeconds === 0) return
+    let rafId = 0
+    let active = true
+    const sync = () => {
+      if (!active) return
+      const handle = playerHandleRef.current
+      const keepGoing = handle
+        ? playback.syncFromPlayer(handle.getCurrentTime() / 1000)
+        : true
+      if (keepGoing) rafId = window.requestAnimationFrame(sync)
+    }
+    rafId = window.requestAnimationFrame(sync)
+    return () => {
+      active = false
+      window.cancelAnimationFrame(rafId)
+    }
+  }, [playback.isPlaying, playback.syncFromPlayer, perTabView.totalSeconds])
+
+  const seekTo = useCallback(
+    (seconds: number) => {
+      const next = playback.seek(seconds)
+      playbackTimeRef.current = next
+      playbackIsPlayingRef.current = false
+      playerHandleRef.current?.seek(next * 1000)
+    },
+    [playback.seek],
+  )
+
+  const onPlayerReady = useCallback((handle: ReplayPlayerHandle | null) => {
     playerHandleRef.current = handle
+    if (!handle) return
+    const ms = playbackTimeRef.current * 1000
+    handle.setSpeed(playbackSpeedRef.current)
+    handle.seek(ms)
+    if (playbackIsPlayingRef.current) handle.play(ms)
   }, [])
 
   if (isLoading || !replay) {
@@ -130,9 +154,6 @@ export function Replay() {
     typeof (location.state as { from: unknown }).from === 'string'
   const back = () =>
     cameFromInAppFlow ? navigate(-1) : navigate(`/audit/${replay.sessionId}`)
-  // Everything below is tab-scoped: frame index, current frame,
-  // scrubber ticks, timeline actions. Playback.time is already in
-  // tab-relative seconds thanks to the per-tab usePlayback wiring.
   const currentTabFrameIndex = frameIndexAt(perTabView.frames, playback.time)
   const currentTabFrame = perTabView.frames[currentTabFrameIndex]
 
@@ -208,13 +229,14 @@ export function Replay() {
             playback={playback}
             totalSeconds={perTabView.totalSeconds}
             frames={perTabView.frames}
+            onSeek={seekTo}
           />
         </div>
         <EventTimeline
           frames={perTabView.frames}
           currentFrameIndex={currentTabFrameIndex}
           currentTime={playback.time}
-          onSeek={playback.seek}
+          onSeek={seekTo}
         />
       </div>
     </div>

--- a/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/ReplayViewport.tsx
@@ -2,21 +2,6 @@
  * @license
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
- *
- * Replay viewport for the audit page. The original scaffold drew a
- * fake browser chrome with a tinted page region and a caption pill.
- * This version mounts rrweb-player inside that chrome so the actual
- * recorded DOM mutations play back. Tab selection lives at the
- * page level (see `Replay.tsx`) as a prominent shadcn Tabs bar; the
- * viewport itself just renders the currently-selected tab's events.
- *
- * The player's built-in controller is hidden via `showController:
- * false`; PlaybackTransport (see use-playback wiring) is the single
- * source of UI truth. Time sync between this player and the
- * scaffold's `usePlayback` clock is set up imperatively via the
- * `onPlayerReady` callback so the page-level component can drive
- * the player from the same scrub events the timeline already
- * dispatches.
  */
 
 import { Lock } from 'lucide-react'
@@ -38,9 +23,11 @@ import 'rrweb-player/dist/style.css'
 import { Replayer } from 'rrweb'
 
 export interface ReplayPlayerHandle {
-  goto(ms: number): void
-  play(): void
+  seek(ms: number): void
+  play(ms: number): void
   pause(): void
+  setSpeed(speed: number): void
+  getCurrentTime(): number
 }
 
 interface ReplayViewportProps {
@@ -48,11 +35,12 @@ interface ReplayViewportProps {
   /** The frame whose caption is currently displayed in the overlay. */
   frame: ReplayFrame | undefined
   /** rrweb events for the currently-selected tabPageId. */
-  events: ReplayEvent[]
-  /** Called once the rrweb-player has mounted with usable controls. */
-  onPlayerReady: (handle: ReplayPlayerHandle) => void
+  events: readonly ReplayEvent[]
+  /** Called when the rrweb Replayer mounts or is destroyed. */
+  onPlayerReady: (handle: ReplayPlayerHandle | null) => void
 }
 
+/** Displays the selected tab's rrweb replay inside the audit browser chrome. */
 export function ReplayViewport({
   site,
   frame,
@@ -92,8 +80,8 @@ function Chrome({ url }: { url: string }) {
 }
 
 interface PlayerCanvasProps {
-  events: ReplayEvent[]
-  onReady: (handle: ReplayPlayerHandle) => void
+  events: readonly ReplayEvent[]
+  onReady: (handle: ReplayPlayerHandle | null) => void
 }
 
 /**
@@ -102,8 +90,11 @@ interface PlayerCanvasProps {
  * conditions, so this is defensive.
  */
 const DEFAULT_RECORDED_SIZE = { width: 1280, height: 720 }
+// rrweb casts events strictly before the target; 0ms can leave the first
+// snapshot blank while paused.
+const MIN_RENDER_SEEK_MS = 1
 
-function readRecordedSize(events: ReplayEvent[]): {
+function readRecordedSize(events: readonly ReplayEvent[]): {
   width: number
   height: number
 } {
@@ -120,14 +111,10 @@ function readRecordedSize(events: ReplayEvent[]): {
   return { width, height }
 }
 
+/** Mounts rrweb's imperative Replayer and exposes the narrow playback handle. */
 function PlayerCanvas({ events, onReady }: PlayerCanvasProps) {
   const mountRef = useRef<HTMLDivElement>(null)
-  // We deliberately use useEffect rather than deriving during render
-  // because Replayer mounts into the DOM imperatively and its
-  // cleanup needs to happen on unmount + on events-array swap (tab
-  // change). Re-renders without a swap should NOT re-mount; the
-  // ref-comparison guard below handles that.
-  const lastEventsRef = useRef<ReplayEvent[] | null>(null)
+  const lastEventsRef = useRef<readonly ReplayEvent[] | null>(null)
   useEffect(() => {
     const mount = mountRef.current
     if (!mount) return
@@ -135,8 +122,6 @@ function PlayerCanvas({ events, onReady }: PlayerCanvasProps) {
     if (lastEventsRef.current === events) return
     lastEventsRef.current = events
 
-    // Strip the cockpit annotations so rrweb sees its canonical
-    // {type, data, timestamp} shape.
     const rrwebEvents = events.map((e) => ({
       type: e.type,
       data: e.data,
@@ -159,14 +144,6 @@ function PlayerCanvas({ events, onReady }: PlayerCanvasProps) {
       return
     }
 
-    // rrweb-player normally handles fit-to-container scaling; we
-    // mount the raw Replayer (see notes at the top of the file) so
-    // we do it ourselves. Read the recorded viewport from the meta
-    // event, absolute-position the .replayer-wrapper at 0,0 of the
-    // mount, and apply a uniform transform so it fits regardless of
-    // the player pane's size. A ResizeObserver keeps the scale in
-    // sync with layout changes (window resize, split-pane drags,
-    // tab switch narrowing the viewport, etc.).
     const { width: recordedW, height: recordedH } = readRecordedSize(events)
     const wrapper = mount.querySelector<HTMLElement>('.replayer-wrapper')
     let observer: ResizeObserver | null = null
@@ -189,14 +166,14 @@ function PlayerCanvas({ events, onReady }: PlayerCanvasProps) {
     }
 
     onReady({
-      // `pause(timeOffset)` jumps to that time and pauses. We pause
-      // rather than play so our scaffold's playback clock stays the
-      // source of truth.
-      goto: (ms) => replayer.pause(ms),
-      play: () => replayer.play(replayer.getCurrentTime()),
-      pause: () => replayer.pause(replayer.getCurrentTime()),
+      seek: (ms) => replayer.pause(Math.max(MIN_RENDER_SEEK_MS, ms)),
+      play: (ms) => replayer.play(ms),
+      pause: () => replayer.pause(),
+      setSpeed: (speed) => replayer.setConfig({ speed }),
+      getCurrentTime: () => replayer.getCurrentTime(),
     })
     return () => {
+      onReady(null)
       observer?.disconnect()
       try {
         replayer.destroy()

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay-events.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay-events.ts
@@ -1,0 +1,44 @@
+/**
+ * @license
+ * Copyright 2026 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import type { ReplayEvent } from '@/modules/api/replay.hooks'
+
+export const EMPTY_REPLAY_EVENTS: readonly ReplayEvent[] = []
+
+export interface ReplayEventTabs {
+  tabPageIds: number[]
+  eventsForTab: (tabPageId: number) => readonly ReplayEvent[]
+}
+
+/** Groups rrweb events by tab while preserving each tab array's identity. */
+export function buildReplayEventTabs(
+  events: readonly ReplayEvent[],
+): ReplayEventTabs {
+  if (events.length === 0) {
+    return {
+      tabPageIds: [],
+      eventsForTab: () => EMPTY_REPLAY_EVENTS,
+    }
+  }
+
+  const tabPageIds: number[] = []
+  const eventsByTab = new Map<number, ReplayEvent[]>()
+  for (const event of events) {
+    const list = eventsByTab.get(event.tabPageId)
+    if (list) {
+      list.push(event)
+    } else {
+      eventsByTab.set(event.tabPageId, [event])
+      tabPageIds.push(event.tabPageId)
+    }
+  }
+
+  return {
+    tabPageIds,
+    eventsForTab: (tabPageId) =>
+      eventsByTab.get(tabPageId) ?? EMPTY_REPLAY_EVENTS,
+  }
+}

--- a/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/replay.data.ts
@@ -2,28 +2,6 @@
  * @license
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
- *
- * Bridges the audit task + rrweb replay data into the shape the
- * existing `Replay.tsx` scaffold consumes. Two concurrent queries:
- *
- *   - `useTaskDetail({sessionId})` for the dispatch trail
- *     (one ToolDispatchRow per agent action) plus session start /
- *     end events. This populates `ReplayFrame[]`, the right-side
- *     EventTimeline, and the page metadata strip (agent, status,
- *     duration).
- *   - `useReplayEvents({sessionId})` for the rrweb event stream
- *     (mounted by `ReplayViewport` into rrweb-player). The events
- *     are passed through this hook's return value so the page can
- *     pick a tabPageId and the viewport can subscribe to filtered
- *     events.
- *
- * `frames` is derived from `dispatches` here. Mapping is
- * deterministic; see `mapDispatchToFrame` for the toolName ->
- * verb/kind translation. The `t` (seconds-into-session) is
- * computed against `sessionStartMs` from the task's startEvent.
- *
- * `replay` is null while either query is loading or there is no
- * task at all (404).
  */
 
 import { useMemo } from 'react'
@@ -41,6 +19,11 @@ import {
   type ReplayVerb,
   useReplayEvents,
 } from '@/modules/api/replay.hooks'
+import {
+  buildReplayEventTabs,
+  EMPTY_REPLAY_EVENTS,
+  type ReplayEventTabs,
+} from './replay-events'
 
 export interface ReplayData {
   sessionId: string
@@ -68,7 +51,7 @@ export interface ReplayData {
   /** Distinct tabPageIds with rrweb events. */
   tabPageIds: number[]
   /** Filter helper: events scoped to one tabPageId. */
-  eventsForTab: (tabPageId: number) => ReplayEvent[]
+  eventsForTab: (tabPageId: number) => readonly ReplayEvent[]
 }
 
 // `buildTabView` and the `TabView` shape live in `./tab-view.ts` so
@@ -88,6 +71,7 @@ export interface UseReplayDataResult {
   navigate: ReturnType<typeof useNavigate>
 }
 
+/** Loads task metadata and stable rrweb event buckets for the replay page. */
 export function useReplayData(): UseReplayDataResult {
   const { sessionId = '' } = useParams<{ sessionId: string }>()
   const navigate = useNavigate()
@@ -100,10 +84,12 @@ export function useReplayData(): UseReplayDataResult {
     enabled: sessionId.length > 0,
   })
 
+  const events = eventsQuery.data?.events ?? EMPTY_REPLAY_EVENTS
+  const eventTabs = useMemo(() => buildReplayEventTabs(events), [events])
   const replay = useMemo<ReplayData | null>(() => {
     if (!taskQuery.data) return null
-    return buildReplayData(taskQuery.data, eventsQuery.data?.events ?? [])
-  }, [taskQuery.data, eventsQuery.data])
+    return buildReplayData(taskQuery.data, eventTabs)
+  }, [taskQuery.data, eventTabs])
 
   return {
     replay,
@@ -113,7 +99,11 @@ export function useReplayData(): UseReplayDataResult {
   }
 }
 
-function buildReplayData(task: TaskDetail, events: ReplayEvent[]): ReplayData {
+/** Converts task rows into replay metadata while reusing event buckets. */
+function buildReplayData(
+  task: TaskDetail,
+  eventTabs: ReplayEventTabs,
+): ReplayData {
   const sessionStartMs = task.startedAt
   const lastDispatchAt = task.dispatches.length
     ? task.dispatches[task.dispatches.length - 1].createdAt
@@ -126,23 +116,6 @@ function buildReplayData(task: TaskDetail, events: ReplayEvent[]): ReplayData {
   const frames: ReplayFrame[] = task.dispatches.map((row) =>
     mapDispatchToFrame(row, sessionStartMs),
   )
-
-  // Preserve first-appearance order for the tab list so per-tab
-  // labels (Tab 1, Tab 2, ...) match the operator's mental
-  // narrative and align with the audit view's sequential
-  // numbering. The raw BrowserOS pageId is non-contiguous and not
-  // useful to surface as a label.
-  const tabsInOrder: number[] = []
-  const eventsByTab = new Map<number, ReplayEvent[]>()
-  for (const ev of events) {
-    const list = eventsByTab.get(ev.tabPageId)
-    if (list) {
-      list.push(ev)
-    } else {
-      eventsByTab.set(ev.tabPageId, [ev])
-      tabsInOrder.push(ev.tabPageId)
-    }
-  }
 
   return {
     sessionId: task.sessionId,
@@ -159,8 +132,8 @@ function buildReplayData(task: TaskDetail, events: ReplayEvent[]): ReplayData {
     approvals: String(countApprovals(task.dispatches)),
     totalSeconds: totalMs / 1000,
     frames,
-    tabPageIds: tabsInOrder,
-    eventsForTab: (id) => eventsByTab.get(id) ?? [],
+    tabPageIds: eventTabs.tabPageIds,
+    eventsForTab: eventTabs.eventsForTab,
   }
 }
 

--- a/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.test.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, expect, it } from 'bun:test'
 import type { ReplayEvent, ReplayFrame } from '@/modules/api/replay.hooks'
+import { buildReplayEventTabs } from './replay-events'
 import { type BuildTabViewInput, buildTabView } from './tab-view'
 
 function frame(
@@ -70,9 +71,6 @@ describe('buildTabView', () => {
   })
 
   it('shifts frame `t` to be tab-relative (first frame at t=0)', () => {
-    // Session started at 1_000_000 ms; frame at t=5 means the tab's
-    // first activity is 5 seconds into the session. In tab-relative
-    // time that first frame is at t=0.
     const v = buildTabView(
       makeInput({
         frames: [frame(5, 7), frame(8, 7), frame(12, 7)],
@@ -91,7 +89,6 @@ describe('buildTabView', () => {
       }),
       1,
     )
-    // 7500 - 3000 = 4500 ms = 4.5s
     expect(v.totalSeconds).toBeCloseTo(4.5)
   })
 
@@ -103,7 +100,6 @@ describe('buildTabView', () => {
       }),
       9,
     )
-    // 10 - 2 = 8 seconds
     expect(v.totalSeconds).toBe(8)
     expect(v.frames.map((f) => f.t)).toEqual([0, 8])
   })
@@ -119,5 +115,30 @@ describe('buildTabView', () => {
     expect(v.frames[0]?.url).toBe('https://example.com')
     expect(v.frames[0]?.pageId).toBe(3)
     expect(v.frames[0]?.t).toBe(0)
+  })
+
+  it('keeps a tab events array stable across task-only data changes', () => {
+    const eventTabs = buildReplayEventTabs([
+      event(1_002_000, 3),
+      event(1_003_000, 3),
+      event(1_004_000, 8),
+    ])
+    const first = buildTabView(
+      makeInput({
+        frames: [frame(2, 3)],
+        eventsForTab: eventTabs.eventsForTab,
+      }),
+      3,
+    )
+    const afterTaskPoll = buildTabView(
+      makeInput({
+        frames: [frame(2, 3), frame(4, 3)],
+        eventsForTab: eventTabs.eventsForTab,
+      }),
+      3,
+    )
+
+    expect(afterTaskPoll.events).toBe(first.events)
+    expect(afterTaskPoll.frames).not.toBe(first.frames)
   })
 })

--- a/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/tab-view.ts
@@ -2,14 +2,6 @@
  * @license
  * Copyright 2026 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
- *
- * Pure `buildTabView` helper. Kept in its own file (not
- * `replay.data.ts`) so tests can import it without dragging the
- * whole react-query-kit hook graph, which some sibling tests
- * `mock.module`-poison in ways that break transitively.
- *
- * See the replay tab-driven architecture plan for the rationale
- * and the surrounding refactor.
  */
 
 import type { ReplayEvent, ReplayFrame } from '@/modules/api/replay.hooks'
@@ -19,15 +11,14 @@ import type { ReplayEvent, ReplayFrame } from '@/modules/api/replay.hooks'
  * `tabPageId`:
  *   - `frames`: filtered AND time-shifted so `t=0` is the tab's
  *     first activity, not session start.
- *   - `events`: pass-through. rrweb's Replayer treats the first
- *     event's `ts` as its playback origin, so a tab-relative
- *     `playback.time` maps 1:1 to `goto(time*1000)`.
+ *   - `events`: pass-through. rrweb treats the first event's `ts`
+ *     as the tab-relative playback origin.
  *   - `totalSeconds`: duration of this tab's activity window (from
  *     first event to last event). 0 for empty tabs.
  */
 export interface TabView {
   frames: ReplayFrame[]
-  events: ReplayEvent[]
+  events: readonly ReplayEvent[]
   totalSeconds: number
 }
 
@@ -40,19 +31,12 @@ export const EMPTY_TAB_VIEW: TabView = {
 export interface BuildTabViewInput {
   /** Session-scoped frames (any pageId). */
   frames: ReplayFrame[]
-  /**
-   * The events lookup for the selected tab. Called once at most;
-   * returning an empty array means the tab has no rrweb data.
-   */
-  eventsForTab: (tabPageId: number) => ReplayEvent[]
+  eventsForTab: (tabPageId: number) => readonly ReplayEvent[]
   /** Session start in ms since epoch. Anchor for frame `t` values. */
   startedAtMs: number
 }
 
-/**
- * Pure. O(N) over frames. Callers should memoise per
- * (input, tabPageId) pair.
- */
+/** Builds the frame/event/duration view for the selected replay tab. */
 export function buildTabView(
   input: BuildTabViewInput,
   tabPageId: number | null,

--- a/packages/browseros-agent/apps/claw-app/screens/replay/use-playback.ts
+++ b/packages/browseros-agent/apps/claw-app/screens/replay/use-playback.ts
@@ -1,57 +1,84 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import { PLAYBACK_SPEEDS } from './replay.helpers'
 
 export interface Playback {
   /** Seconds elapsed in the session. */
   time: number
-  /** True while the wallclock timer is advancing. */
+  /** True while rrweb's internal timer should be running. */
   isPlaying: boolean
-  /** Multiplier applied to the 100ms tick. Always one of `PLAYBACK_SPEEDS`. */
+  /** Multiplier applied by rrweb's internal timer. */
   speed: number
   setSpeed: (next: number) => void
   /** Toggles play/pause. Restarts from 0 if the session already finished. */
   togglePlay: () => void
-  /** Jumps the playhead to `seconds` (clamped to [0, totalSeconds]). */
-  seek: (seconds: number) => void
+  /** Jumps the playhead to `seconds` and pauses. */
+  seek: (seconds: number) => number
+  /** Updates display state from rrweb without seeking the player. */
+  syncFromPlayer: (seconds: number) => boolean
 }
 
-const TICK_MS = 100
+const END_EPSILON_SECONDS = 0.01
 
+/** Owns replay transport state while rrweb owns the playback timer. */
 export function usePlayback(totalSeconds: number): Playback {
   const [time, setTime] = useState(0)
   const [isPlaying, setIsPlaying] = useState(true)
   const [speed, setSpeed] = useState<number>(PLAYBACK_SPEEDS[0])
 
-  // External wall-clock timer: starting/cancelling setInterval is one of
-  // the cases the project conventions still allow useEffect for.
+  const clamp = useCallback(
+    (seconds: number) => Math.max(0, Math.min(totalSeconds, seconds)),
+    [totalSeconds],
+  )
+
   useEffect(() => {
-    if (!isPlaying || totalSeconds === 0) return
-    const id = window.setInterval(() => {
-      setTime((prev) => {
-        const next = prev + (TICK_MS / 1000) * speed
-        if (next >= totalSeconds) {
-          setIsPlaying(false)
-          return totalSeconds
-        }
-        return next
-      })
-    }, TICK_MS)
-    return () => window.clearInterval(id)
-  }, [isPlaying, speed, totalSeconds])
+    setTime((prev) => clamp(prev))
+  }, [clamp])
 
-  const togglePlay = () => {
-    if (time >= totalSeconds) {
-      setTime(0)
-      setIsPlaying(true)
-      return
-    }
-    setIsPlaying((p) => !p)
+  const setPlaybackSpeed = useCallback((next: number) => {
+    if (PLAYBACK_SPEEDS.includes(next)) setSpeed(next)
+  }, [])
+
+  const togglePlay = useCallback(() => {
+    setIsPlaying((playing) => {
+      if (playing) return false
+      setTime((prev) => (prev >= totalSeconds ? 0 : prev))
+      return totalSeconds > 0
+    })
+  }, [totalSeconds])
+
+  const seek = useCallback(
+    (seconds: number) => {
+      const clamped = clamp(seconds)
+      setTime(clamped)
+      setIsPlaying(false)
+      return clamped
+    },
+    [clamp],
+  )
+
+  const syncFromPlayer = useCallback(
+    (seconds: number) => {
+      const clamped = clamp(seconds)
+      const finished =
+        totalSeconds > 0 && clamped >= totalSeconds - END_EPSILON_SECONDS
+      if (finished) {
+        setTime(totalSeconds)
+        setIsPlaying(false)
+        return false
+      }
+      setTime(clamped)
+      return true
+    },
+    [clamp, totalSeconds],
+  )
+
+  return {
+    time,
+    isPlaying,
+    speed,
+    setSpeed: setPlaybackSpeed,
+    togglePlay,
+    seek,
+    syncFromPlayer,
   }
-
-  const seek = (seconds: number) => {
-    const clamped = Math.max(0, Math.min(totalSeconds, seconds))
-    setTime(clamped)
-  }
-
-  return { time, isPlaying, speed, setSpeed, togglePlay, seek }
 }


### PR DESCRIPTION
## Summary
- Keep per-tab rrweb event arrays stable across live task-detail refetches so unchanged replay events no longer remount the Replayer.
- Replace the 100ms external `pause(t)` playback loop with rrweb-owned playback and rAF readback for the scrubber/timeline clock.
- Route explicit scrub/timeline/tab-switch seeks through a narrow player handle and keep speed control on `replayer.setConfig({ speed })`.

## Design
Replay data now builds tab event buckets from the replay-events query alone, then task-derived metadata can update without changing the selected tab's `events` identity. The viewport exposes `seek`, `play`, `pause`, `setSpeed`, and `getCurrentTime`; `Replay` calls offset seeks only for explicit navigation, uses `play(offset)`/`pause()` for transport state, and syncs display time by reading rrweb current time on rAF while playing.

## Test plan
- [x] `bun test apps/claw-app/screens/replay/tab-view.test.ts`
- [x] `bun run check` from `packages/browseros-agent`
- [x] `bun run test` from `packages/browseros-agent`

## Notes
`bun run check` exits 0 while still printing the repo's existing Biome/Fallow warning backlog outside this change.