### PR TITLE
fix(claw-app): keep MCP URL constants browser-safe

### DIFF
--- a/packages/browseros-agent/apps/claw-app/modules/api/mcp-endpoint.ts
+++ b/packages/browseros-agent/apps/claw-app/modules/api/mcp-endpoint.ts
@@ -15,7 +15,7 @@
 import {
   BROWSEROS_MCP_SERVER_NAME,
   MCP_PATH,
-} from '@browseros/claw-server/shared/mcp-url'
+} from '@browseros/claw-server/shared/mcp-url-common'
 import {
   apiBaseUrlSourcesFromWindow,
   resolveBrowserOSMcpBaseUrl,

--- a/packages/browseros-agent/apps/claw-server/package.json
+++ b/packages/browseros-agent/apps/claw-server/package.json
@@ -16,6 +16,10 @@
     "./shared/mcp-url": {
       "types": "./src/shared/mcp-url.ts",
       "default": "./src/shared/mcp-url.ts"
+    },
+    "./shared/mcp-url-common": {
+      "types": "./src/shared/mcp-url-common.ts",
+      "default": "./src/shared/mcp-url-common.ts"
     }
   },
   "scripts": {

--- a/packages/browseros-agent/apps/claw-server/src/shared/mcp-url-common.ts
+++ b/packages/browseros-agent/apps/claw-server/src/shared/mcp-url-common.ts
@@ -1,0 +1,17 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Browser-safe MCP URL constants shared by claw-server and claw-app.
+ */
+
+import { CLAW_API_PORT_DEFAULT } from './port'
+
+export const MCP_PATH = '/mcp'
+export const BROWSEROS_MCP_SERVER_NAME = 'BrowserClaw'
+
+/** Builds the slugless local MCP URL shared by server config writers and UI copy helpers. */
+export function canonicalMcpUrlForPort(port = CLAW_API_PORT_DEFAULT): string {
+  return `http://127.0.0.1:${port}${MCP_PATH}`
+}

--- a/packages/browseros-agent/apps/claw-server/src/shared/mcp-url.ts
+++ b/packages/browseros-agent/apps/claw-server/src/shared/mcp-url.ts
@@ -3,45 +3,20 @@
  * Copyright 2025 BrowserOS
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *
- * Canonical v2 MCP URL shape. One endpoint per Claw server, no per-agent
- * slug. Used by both the server-side install service (writes the URL
- * into harness configs) and the UI's URL widgets (copy button + CLI
- * snippet). Keeping the shape in `shared/` mirrors the `shared/port`
- * precedent so a future cutover (e.g. a non-loopback bind) is a
- * single-file edit.
+ * Server-side MCP URL helpers. Browser/UI imports must use
+ * mcp-url-common so env/config parsing stays out of the WXT bundle.
  */
 
 import { env } from '../env'
-import { CLAW_API_PORT_DEFAULT } from './port'
+import { canonicalMcpUrlForPort } from './mcp-url-common'
 
-/** Path the v2 single MCP route is mounted at. */
-export const MCP_PATH = '/mcp'
+export {
+  BROWSEROS_MCP_SERVER_NAME,
+  canonicalMcpUrlForPort,
+  MCP_PATH,
+} from './mcp-url-common'
 
-/**
- * Server name written into harness configs. One canonical name across
- * every harness so the user sees "BrowserClaw" in every
- * `claude mcp list` / Cursor settings page. Same name reused by the
- * canonical CLI snippet.
- *
- * The symbol name keeps its `BROWSEROS_` prefix to avoid a
- * cross-package rename; the value carries the product's current
- * brand ("BrowserClaw"). Scoped to the claw-server flow only; the
- * apps/server mcp-manager constant is untouched. Existing entries in
- * user host configs that still hold the old `browseros` name are
- * not reconciled automatically and need manual removal.
- */
-export const BROWSEROS_MCP_SERVER_NAME = 'BrowserClaw'
-
-/**
- * Builds the slugless canonical URL the v2 cockpit advertises. The
- * server side only ever uses 127.0.0.1; the UI's `mcp-endpoint.ts`
- * resolves alternate bases (dev-launcher overrides, query string).
- */
-export function canonicalMcpUrlForPort(port = CLAW_API_PORT_DEFAULT): string {
-  return `http://127.0.0.1:${port}${MCP_PATH}`
-}
-
-/** Public MCP URL for clients: proxy port is Chromium-owned; server port is standalone/dev fallback, never a bind decision. */
+/** Resolves the public server-side MCP URL from runtime ports. */
 export function publicMcpUrl(): string {
   return canonicalMcpUrlForPort(env.proxyPort ?? env.serverPort)
 }


### PR DESCRIPTION
## Summary
- Split browser-safe Claw MCP URL constants/helpers into `@browseros/claw-server/shared/mcp-url-common`.
- Kept server runtime URL resolution in `shared/mcp-url`, where it can still read `env` and startup config.
- Updated claw-app MCP endpoint helpers to import only the browser-safe subpath, keeping `@browseros/shared/schemas/sidecar-config` and `node:fs` out of the WXT bundle.

## Design
The regression came from sharing `shared/mcp-url` between server runtime code and the WXT app. That module imported `../env`, which imported `config.ts`, which imported the sidecar config parser. The sidecar parser imports `node:fs` at module top level, so Vite/Rollup pulled `node:fs` into the client graph. This PR introduces a tiny browser-safe `mcp-url-common` subpath for constants and pure URL shape helpers, then leaves `publicMcpUrl()` in the server-only module.

## Last-five-commits diagnosis
- `a41dc06d` only adjusted the sidebar theme menu anchoring; not in the MCP URL/import chain.
- `c5e09fc8` is the likely regression: it changed `claw-app/modules/api/mcp-endpoint.ts`, `claw-server/src/shared/mcp-url.ts`, `env.ts`, and `config.ts`, and made the app import a module that reaches server env/config and `@browseros/shared/schemas/sidecar-config`.
- `20362a82` was screenshot lightbox UI polish; unrelated to server shared imports.
- `b3c631f8` updated BrowserClaw extension icons; unrelated to runtime imports.
- `bb504f73` added the sidebar theme toggle; unrelated to the MCP URL bundle path.

## Test plan
- [x] Reproduced before fix: `bun run --cwd packages/browseros-agent/apps/claw-app build:dev` failed on `sidecar-config.ts` importing `node:fs`.
- [x] `bun run --cwd packages/browseros-agent/apps/claw-app typecheck`
- [x] `bun run --cwd packages/browseros-agent/apps/claw-app build:dev`
- [x] `bun run --cwd packages/browseros-agent/apps/claw-app build`
- [x] `bun run --cwd packages/browseros-agent/apps/claw-server typecheck`
- [x] `bun test modules/api/mcp-endpoint.test.ts` from `packages/browseros-agent/apps/claw-app`
- [x] `bun test tests/shared/mcp-url.test.ts` from `packages/browseros-agent/apps/claw-server`
- [x] File-scoped Biome checks for touched files
- [x] Searched built `chrome-mv3` and `chrome-mv3-dev` output for `sidecar-config`, `node:fs`, and `__vite-browser-external`; no matches.

## Notes
Package-wide `bun run lint` exits 0 in both packages but still reports unrelated baseline warnings in existing task/screenshots files. File-scoped Biome checks for the touched files are clean.