### PR TITLE
docs: move founders block to README footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,6 @@
 </a>
 <br /><br />
 
-Founders — [@nv_sonti](https://x.com/intent/user?screen_name=nv_sonti) and [@ThatNithin](https://x.com/intent/user?screen_name=ThatNithin):
-
-[![Twitter Follow](https://img.shields.io/twitter/follow/nv_sonti?style=social)](https://x.com/intent/user?screen_name=nv_sonti)
-&emsp;&emsp;&emsp;
-[![Twitter Follow](https://img.shields.io/twitter/follow/ThatNithin?style=social)](https://x.com/intent/user?screen_name=ThatNithin)
-
 </div>
 
 BrowserOS is an open-source Chromium fork that runs AI agents natively. **The privacy-first alternative to ChatGPT Atlas, Perplexity Comet, and Dia.**
@@ -214,6 +208,12 @@ Copyright &copy; 2026 Felafax, Inc.
 Thank you to all our supporters!
 
 [![Star History Chart](https://api.star-history.com/svg?repos=browseros-ai/BrowserOS&type=Date)](https://www.star-history.com/#browseros-ai/BrowserOS&Date)
+
+Founders — [@nv_sonti](https://x.com/intent/user?screen_name=nv_sonti) and [@ThatNithin](https://x.com/intent/user?screen_name=ThatNithin):
+
+[![Twitter Follow](https://img.shields.io/twitter/follow/nv_sonti?style=social)](https://x.com/intent/user?screen_name=nv_sonti)
+&emsp;&emsp;&emsp;
+[![Twitter Follow](https://img.shields.io/twitter/follow/ThatNithin?style=social)](https://x.com/intent/user?screen_name=ThatNithin)
 
 <p align="center">
 Built with ❤️ from San Francisco


### PR DESCRIPTION
## Summary
- Move the existing founders block out of the top README header.
- Reinsert the same founder markdown near the bottom after Stargazers.
- Preserve the BibTeX citation author line and all founder badge/link markup.

## Design
This is a direct Markdown relocation: the opening centered header now closes after the download badges, while the unchanged founders block appears after the stargazers chart and before the existing San Francisco footer.

## Test plan
- [x] `git diff --check HEAD~1..HEAD -- README.md`
- [x] `rg -n "Founders|Twitter Follow|author = \\{Nithin" README.md`