### PR TITLE
feat(claw-server): production logging at key failure paths

### DIFF
--- a/packages/browseros-agent/apps/claw-server/src/mcp/register.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/register.ts
@@ -419,6 +419,15 @@ export function registerBrowserToolsForSingleServer(
           if (typeof url === 'string' && url.length > 0) {
             const scheme = url.slice(0, url.indexOf(':') + 1).toLowerCase()
             if (NAVIGATE_BLOCKED_SCHEMES.has(scheme)) {
+              // Rejections before dispatchStart get their own message
+              // (vs 'dispatch failed'): nothing was executed, and an
+              // agent probing javascript:/file:/data: URLs is signal
+              // worth spotting on its own.
+              logger.warn('cockpit v2 tool dispatch rejected', {
+                tool: tool.name,
+                sessionId: extra?.sessionId,
+                reason: 'blocked navigate scheme',
+              })
               return {
                 content: [
                   {
@@ -434,6 +443,14 @@ export function registerBrowserToolsForSingleServer(
 
         const session = getBrowserSession()
         if (!session) {
+          // Every call an agent makes while the cockpit runs without
+          // an attached BrowserOS lands here; without this line the
+          // only trace is the single boot-time bootstrap warn.
+          logger.warn('cockpit v2 tool dispatch rejected', {
+            tool: tool.name,
+            sessionId: extra?.sessionId,
+            reason: 'browser session not connected',
+          })
           return {
             content: [
               {

--- a/packages/browseros-agent/apps/claw-server/src/mcp/register.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/register.ts
@@ -298,6 +298,28 @@ function composeAbortSignals(
 }
 
 /**
+ * First text block of a failed dispatch result, capped so a long
+ * tool message cannot bloat the log line. executeTool's error
+ * results carry their human-readable reason here.
+ */
+const DISPATCH_ERROR_TEXT_MAX = 200
+
+function dispatchErrorText(content: unknown): string | null {
+  if (!Array.isArray(content)) return null
+  for (const block of content) {
+    if (
+      block !== null &&
+      typeof block === 'object' &&
+      (block as { type?: unknown }).type === 'text' &&
+      typeof (block as { text?: unknown }).text === 'string'
+    ) {
+      return (block as { text: string }).text.slice(0, DISPATCH_ERROR_TEXT_MAX)
+    }
+  }
+  return null
+}
+
+/**
  * Rewrite a successful `tabs list` result to only include pages the
  * calling agent owns. Both channels are rebuilt from the surviving
  * subset:
@@ -502,6 +524,23 @@ export function registerBrowserToolsForSingleServer(
           if (userCancel.signal.aborted) {
             result = cancellationErrorResult(CANCELLATION_REASON)
           } else {
+            // A client-driven abort (notifications/cancelled, harness
+            // timeout) is normal lifecycle, not a server fault; only a
+            // throw with no abort anywhere is a genuine failure.
+            if (extra?.signal?.aborted) {
+              logger.info('cockpit v2 tool dispatch cancelled by client', {
+                tool: tool.name,
+                sessionId: extra?.sessionId,
+                durationMs: Date.now() - dispatchStart,
+              })
+            } else {
+              logger.error('cockpit v2 tool dispatch threw', {
+                tool: tool.name,
+                sessionId: extra?.sessionId,
+                durationMs: Date.now() - dispatchStart,
+                error: err instanceof Error ? err.message : String(err),
+              })
+            }
             throw err
           }
         } finally {
@@ -514,6 +553,18 @@ export function registerBrowserToolsForSingleServer(
           result = cancellationErrorResult(CANCELLATION_REASON)
         }
         const durationMs = Date.now() - dispatchStart
+
+        // Failed dispatches are otherwise invisible server-side: the
+        // audit DB rows land only for successes and operator cancels,
+        // and the isError result rides back to the agent's harness.
+        if (result.isError && !userCancel.signal.aborted) {
+          logger.warn('cockpit v2 tool dispatch failed', {
+            tool: tool.name,
+            sessionId: extra?.sessionId,
+            durationMs,
+            error: dispatchErrorText(result.content),
+          })
+        }
 
         // Record cancelled dispatches in the audit log so the task
         // timeline shows the operator's intervention. The existing

--- a/packages/browseros-agent/apps/claw-server/src/mcp/single-server.ts
+++ b/packages/browseros-agent/apps/claw-server/src/mcp/single-server.ts
@@ -77,6 +77,10 @@ function buildSession(): Session {
 
   transport.onerror = (err) => {
     const sessionId = transport.sessionId
+    logger.warn('mcp session transport error', {
+      sessionId: sessionId ?? null,
+      error: err instanceof Error ? err.message : String(err),
+    })
     if (!sessionId) return
     recordSessionEnd({
       sessionId,
@@ -208,6 +212,11 @@ export function sweepIdleSessions(now: number): string[] {
       idle.push(sessionId)
     }
   }
+  // Distinguishes sweeper teardowns from client DELETEs in the log:
+  // the 'session closed' lines that follow this one were idle reaps.
+  if (idle.length > 0) {
+    logger.info('sweeping idle mcp sessions', { count: idle.length })
+  }
   for (const sessionId of idle) cleanupSessionState(sessionId)
   return idle
 }
@@ -254,6 +263,12 @@ export async function handleSingleMcpRequest(
     // + transport that the SDK immediately rejects in validateSession
     // (no matching session id), leaving the pair connected and
     // un-tracked: a per-request leak.
+    // Expected after a server restart (every live client's next
+    // request lands here once) — logged because a client stuck in
+    // this state shows up as a run of these lines.
+    logger.warn('rejected request for unknown mcp session', {
+      sessionId: headerSessionId,
+    })
     return new Response(
       JSON.stringify({
         error: 'unknown mcp-session-id',

--- a/packages/browseros-agent/apps/claw-server/src/modules/db/db.ts
+++ b/packages/browseros-agent/apps/claw-server/src/modules/db/db.ts
@@ -17,6 +17,7 @@ import { mkdirSync } from 'node:fs'
 import { dirname } from 'node:path'
 import { type BunSQLiteDatabase, drizzle } from 'drizzle-orm/bun-sqlite'
 import { resolveClawServerPath } from '../../lib/browseros-dir'
+import { logger } from '../../lib/logger'
 import { runMigrations } from './migrator'
 import * as schema from './schema/schema'
 
@@ -37,8 +38,19 @@ export function getAuditDb(): AuditDb {
   raw.run('PRAGMA synchronous = NORMAL;')
   raw.run('PRAGMA foreign_keys = ON;')
   const db = drizzle({ client: raw, schema })
-  runMigrations(db)
+  try {
+    runMigrations(db)
+  } catch (err) {
+    // Without this line a broken migration surfaces only as
+    // downstream 'audit log write failed' warns or route 500s.
+    logger.error('audit db migration failed', {
+      path,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    throw err
+  }
   cached = { db, raw }
+  logger.info('audit db ready', { path })
   return db
 }
 

--- a/packages/browseros-agent/apps/claw-server/src/routes/agents-control/index.ts
+++ b/packages/browseros-agent/apps/claw-server/src/routes/agents-control/index.ts
@@ -11,6 +11,7 @@
  */
 
 import { Hono } from 'hono'
+import { logger } from '../../lib/logger'
 import {
   CANCELLATION_REASON,
   dispatchCancellation,
@@ -34,6 +35,12 @@ export const agentsControlRoute = new Hono().post(
         404,
       )
     }
+    // The operator's Stop button: pairs with the cancelled-dispatch
+    // audit rows so a mid-run abort is attributable in the log.
+    logger.info('cancelled in-flight dispatches for agent', {
+      agentId,
+      cancelled,
+    })
     return c.json({ ok: true, cancelled }, 200)
   },
 )

--- a/packages/browseros-agent/apps/claw-server/src/routes/agents/service.ts
+++ b/packages/browseros-agent/apps/claw-server/src/routes/agents/service.ts
@@ -199,6 +199,11 @@ export async function create(input: NewAgentValues): Promise<CreatedAgent> {
       updatedAt: now,
     }
     await writeJson(fileFor(id), profile, storedAgentProfileSchema)
+    logger.info('agent profile created', {
+      id,
+      slug,
+      harness: profile.harness,
+    })
     // Best-effort harness install. A failure here does NOT roll back
     // the profile; the user can retry or fix the harness state and
     // we'll attempt again on the next create. The outcome rides
@@ -251,6 +256,11 @@ export async function update(
       updatedAt: nowIso(),
     }
     await writeJson(fileFor(id), next, storedAgentProfileSchema)
+    logger.info('agent profile updated', {
+      id,
+      slug: next.slug,
+      harness: next.harness,
+    })
     // Best-effort harness reconcile: if the harness or slug rotated,
     // wire the new entry into the new harness and drop the old one.
     // Failures are logged inside the helpers and do NOT roll back the
@@ -282,6 +292,11 @@ export async function remove(id: string): Promise<DeletedAgent | null> {
   // run uninstallForAgent and the loser would still report 404.
   const existed = await removeFile(fileFor(id))
   if (!existed) return null
+  logger.info('agent profile deleted', {
+    id,
+    slug: profile.slug,
+    harness: profile.harness,
+  })
   const harnessUninstall = await uninstallForAgent({
     slug: profile.slug,
     harness: profile.harness,
@@ -314,6 +329,11 @@ export async function regenerateMcpUrl(
       updatedAt: nowIso(),
     }
     await writeJson(fileFor(id), next, storedAgentProfileSchema)
+    logger.info('agent mcp url regenerated', {
+      id,
+      slug: next.slug,
+      previousSlug: existing.slug,
+    })
     // Rotating still changes the harness server name even though the
     // endpoint URL is shared; reconcile so the new slug entry replaces
     // the old one. Harness is unchanged so only the slug pair differs.

--- a/packages/browseros-agent/apps/claw-server/src/routes/site-rules/service.ts
+++ b/packages/browseros-agent/apps/claw-server/src/routes/site-rules/service.ts
@@ -17,6 +17,7 @@
 
 import { nanoid } from 'nanoid'
 import { AsyncMutex } from '../../lib/async-mutex'
+import { logger } from '../../lib/logger'
 import { matchDomain } from '../../lib/match-domain'
 import {
   fileExists,
@@ -70,6 +71,13 @@ export async function add(input: AddSiteRuleVariables): Promise<SiteRule> {
     }
     const next = [...existing, rule]
     await writeJson(FILE, next, siteRulesFileSchema)
+    // Rules clamp agent dispatches; the add/remove trail explains a
+    // later "blocked by site-rule" verdict.
+    logger.info('site rule added', {
+      id: rule.id,
+      action: rule.action,
+      domain: rule.domain,
+    })
     return rule
   })
 }
@@ -82,6 +90,7 @@ export async function remove(id: string): Promise<{ id: string } | null> {
     const next = existing.filter((rule) => rule.id !== id)
     if (next.length === existing.length) return null
     await writeJson(FILE, next, siteRulesFileSchema)
+    logger.info('site rule removed', { id })
     return { id }
   })
 }

--- a/packages/browseros-agent/apps/claw-server/src/server.ts
+++ b/packages/browseros-agent/apps/claw-server/src/server.ts
@@ -54,6 +54,31 @@ const app = new Hono()
 // fetching from `http://127.0.0.1:<port>`.
 app.use('*', cors({ origin: '*' }))
 
+// One structured line per failed request, however the failure was
+// produced: a router 404, a thrown HttpError, a direct 4xx/5xx JSON
+// return, or an unhandled error — hono materialises the onError
+// response before `next()` resolves, so `c.res.status` is final
+// here. Sub-400 traffic stays unlogged on purpose: the logger has no
+// level filtering and the claw-app polls several endpoints, so a
+// per-request access log would flood the rotating log file.
+app.use('*', async (c, next) => {
+  const start = Date.now()
+  await next()
+  const status = c.res.status
+  if (status < 400) return
+  const fields = {
+    method: c.req.method,
+    path: c.req.path,
+    status,
+    durationMs: Date.now() - start,
+  }
+  if (status >= 500) {
+    logger.error('request failed', fields)
+  } else {
+    logger.warn('request failed', fields)
+  }
+})
+
 // Catch-all for genuinely unexpected errors. Routes today resolve
 // their own expected failures (404s, validation) inline and return
 // structured 4xx JSON. Anything that escapes that lands here, gets

--- a/packages/browseros-agent/apps/claw-server/src/server.ts
+++ b/packages/browseros-agent/apps/claw-server/src/server.ts
@@ -13,6 +13,7 @@
  * recipe.
  */
 
+import type { MiddlewareHandler } from 'hono'
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
 import { HttpError } from './lib/errors'
@@ -61,7 +62,10 @@ app.use('*', cors({ origin: '*' }))
 // here. Sub-400 traffic stays unlogged on purpose: the logger has no
 // level filtering and the claw-app polls several endpoints, so a
 // per-request access log would flood the rotating log file.
-app.use('*', async (c, next) => {
+// Named export so tests can exercise the throwing paths on a fixture
+// app; this shared app's route matcher is already built (and frozen)
+// by the first test file that fetches through it.
+export const requestFailureLog: MiddlewareHandler = async (c, next) => {
   const start = Date.now()
   await next()
   const status = c.res.status
@@ -77,7 +81,9 @@ app.use('*', async (c, next) => {
   } else {
     logger.warn('request failed', fields)
   }
-})
+}
+
+app.use('*', requestFailureLog)
 
 // Catch-all for genuinely unexpected errors. Routes today resolve
 // their own expected failures (404s, validation) inline and return

--- a/packages/browseros-agent/apps/claw-server/tests/routes/request-logging.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/routes/request-logging.test.ts
@@ -79,6 +79,7 @@ describe('request-failure logging with thrown errors (fixture app)', () => {
     fx.get('/conflict', () => {
       throw new HttpError(409, 'already exists')
     })
+    fx.get('/direct', (c) => c.json({ error: 'gone' }, 410))
     fx.get('/ok', (c) => c.json({ ok: true }))
     return fx
   }
@@ -110,6 +111,18 @@ describe('request-failure logging with thrown errors (fixture app)', () => {
       method: 'GET',
       path: '/conflict',
       status: 409,
+    })
+  })
+
+  test('direct 4xx JSON return logs one warn with its status', async () => {
+    const res = await fixtureApp().fetch(new Request('http://localhost/direct'))
+    expect(res.status).toBe(410)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(errorSpy).not.toHaveBeenCalled()
+    expect(warnSpy.mock.calls[0]?.[1]).toMatchObject({
+      method: 'GET',
+      path: '/direct',
+      status: 410,
     })
   })
 

--- a/packages/browseros-agent/apps/claw-server/tests/routes/request-logging.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/routes/request-logging.test.ts
@@ -1,0 +1,98 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ *
+ * Tests for the request-failure log middleware in src/server.ts.
+ * Every >=400 response must produce exactly one structured
+ * 'request failed' line (warn for 4xx, error for 5xx) regardless of
+ * whether the failure was a router 404, a thrown HttpError, or an
+ * unhandled error resolved by `app.onError`; sub-400 traffic stays
+ * unlogged so polling endpoints cannot flood the rotating log file.
+ */
+
+import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test'
+import { HttpError } from '../../src/lib/errors'
+import { logger } from '../../src/lib/logger'
+import app from '../../src/server'
+
+// Throw-only fixtures under a /__test namespace so no real endpoint
+// is shadowed. Mounted once at module load; the app instance is the
+// module-cached singleton every route test shares.
+app.get('/__test/boom', () => {
+  throw new Error('boom')
+})
+app.get('/__test/conflict', () => {
+  throw new HttpError(409, 'already exists')
+})
+
+let warnSpy: ReturnType<typeof spyOn<typeof logger, 'warn'>>
+let errorSpy: ReturnType<typeof spyOn<typeof logger, 'error'>>
+
+beforeEach(() => {
+  warnSpy = spyOn(logger, 'warn')
+  errorSpy = spyOn(logger, 'error')
+})
+
+afterEach(() => {
+  warnSpy.mockRestore()
+  errorSpy.mockRestore()
+})
+
+function get(path: string): Promise<Response> {
+  return Promise.resolve(app.fetch(new Request(`http://localhost${path}`)))
+}
+
+describe('request-failure logging middleware', () => {
+  test('successful responses log nothing', async () => {
+    const res = await get('/system/health')
+    expect(res.status).toBe(200)
+    expect(warnSpy).not.toHaveBeenCalled()
+    expect(errorSpy).not.toHaveBeenCalled()
+  })
+
+  test('router 404 logs one warn with method, path, status, duration', async () => {
+    const res = await get('/__test/missing')
+    expect(res.status).toBe(404)
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(errorSpy).not.toHaveBeenCalled()
+    const [msg, fields] = warnSpy.mock.calls[0] ?? []
+    expect(msg).toBe('request failed')
+    expect(fields).toMatchObject({
+      method: 'GET',
+      path: '/__test/missing',
+      status: 404,
+    })
+    expect(fields?.durationMs).toBeGreaterThanOrEqual(0)
+  })
+
+  test('thrown HttpError logs one warn with its status', async () => {
+    const res = await get('/__test/conflict')
+    expect(res.status).toBe(409)
+    expect(await res.json()).toEqual({ error: 'already exists' })
+    expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy.mock.calls[0]?.[1]).toMatchObject({
+      method: 'GET',
+      path: '/__test/conflict',
+      status: 409,
+    })
+  })
+
+  test('unhandled error logs a 500 request line and keeps the onError line', async () => {
+    const res = await get('/__test/boom')
+    expect(res.status).toBe(500)
+    const messages = errorSpy.mock.calls.map((call) => call[0])
+    expect(messages).toContain('Unhandled route error')
+    expect(messages).toContain('request failed')
+    const requestLine = errorSpy.mock.calls.find(
+      (call) => call[0] === 'request failed',
+    )
+    expect(requestLine?.[1]).toMatchObject({
+      method: 'GET',
+      path: '/__test/boom',
+      status: 500,
+    })
+    expect(requestLine?.[1]?.durationMs).toBeGreaterThanOrEqual(0)
+    expect(warnSpy).not.toHaveBeenCalled()
+  })
+})

--- a/packages/browseros-agent/apps/claw-server/tests/routes/request-logging.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/routes/request-logging.test.ts
@@ -9,22 +9,18 @@
  * whether the failure was a router 404, a thrown HttpError, or an
  * unhandled error resolved by `app.onError`; sub-400 traffic stays
  * unlogged so polling endpoints cannot flood the rotating log file.
+ *
+ * The thrown-error paths run on a fixture app wired like server.ts
+ * (same middleware + an HttpError-aware onError): the shared app's
+ * route matcher is already built once any test file has fetched
+ * through it, so throw-only routes cannot be mounted there.
  */
 
 import { afterEach, beforeEach, describe, expect, spyOn, test } from 'bun:test'
+import { Hono } from 'hono'
 import { HttpError } from '../../src/lib/errors'
 import { logger } from '../../src/lib/logger'
-import app from '../../src/server'
-
-// Throw-only fixtures under a /__test namespace so no real endpoint
-// is shadowed. Mounted once at module load; the app instance is the
-// module-cached singleton every route test shares.
-app.get('/__test/boom', () => {
-  throw new Error('boom')
-})
-app.get('/__test/conflict', () => {
-  throw new HttpError(409, 'already exists')
-})
+import app, { requestFailureLog } from '../../src/server'
 
 let warnSpy: ReturnType<typeof spyOn<typeof logger, 'warn'>>
 let errorSpy: ReturnType<typeof spyOn<typeof logger, 'error'>>
@@ -39,20 +35,16 @@ afterEach(() => {
   errorSpy.mockRestore()
 })
 
-function get(path: string): Promise<Response> {
-  return Promise.resolve(app.fetch(new Request(`http://localhost${path}`)))
-}
-
-describe('request-failure logging middleware', () => {
+describe('request-failure logging on the live app', () => {
   test('successful responses log nothing', async () => {
-    const res = await get('/system/health')
+    const res = await app.fetch(new Request('http://localhost/system/health'))
     expect(res.status).toBe(200)
     expect(warnSpy).not.toHaveBeenCalled()
     expect(errorSpy).not.toHaveBeenCalled()
   })
 
   test('router 404 logs one warn with method, path, status, duration', async () => {
-    const res = await get('/__test/missing')
+    const res = await app.fetch(new Request('http://localhost/__no-such-route'))
     expect(res.status).toBe(404)
     expect(warnSpy).toHaveBeenCalledTimes(1)
     expect(errorSpy).not.toHaveBeenCalled()
@@ -60,39 +52,71 @@ describe('request-failure logging middleware', () => {
     expect(msg).toBe('request failed')
     expect(fields).toMatchObject({
       method: 'GET',
-      path: '/__test/missing',
+      path: '/__no-such-route',
       status: 404,
+    })
+    expect(fields?.durationMs).toBeGreaterThanOrEqual(0)
+  })
+})
+
+describe('request-failure logging with thrown errors (fixture app)', () => {
+  // Mirrors server.ts's composition: middleware before routes, and an
+  // onError that maps HttpError to its status and everything else to
+  // a 500 — so the middleware sees the same final statuses it would
+  // on the real app.
+  function fixtureApp(): Hono {
+    const fx = new Hono()
+    fx.onError((err, c) => {
+      if (err instanceof HttpError) {
+        return c.json({ error: err.message }, err.status as 400 | 404 | 409)
+      }
+      return c.json({ error: 'internal error' }, 500)
+    })
+    fx.use('*', requestFailureLog)
+    fx.get('/boom', () => {
+      throw new Error('boom')
+    })
+    fx.get('/conflict', () => {
+      throw new HttpError(409, 'already exists')
+    })
+    fx.get('/ok', (c) => c.json({ ok: true }))
+    return fx
+  }
+
+  test('unhandled error logs one error line with status 500', async () => {
+    const res = await fixtureApp().fetch(new Request('http://localhost/boom'))
+    expect(res.status).toBe(500)
+    expect(errorSpy).toHaveBeenCalledTimes(1)
+    expect(warnSpy).not.toHaveBeenCalled()
+    const [msg, fields] = errorSpy.mock.calls[0] ?? []
+    expect(msg).toBe('request failed')
+    expect(fields).toMatchObject({
+      method: 'GET',
+      path: '/boom',
+      status: 500,
     })
     expect(fields?.durationMs).toBeGreaterThanOrEqual(0)
   })
 
   test('thrown HttpError logs one warn with its status', async () => {
-    const res = await get('/__test/conflict')
+    const res = await fixtureApp().fetch(
+      new Request('http://localhost/conflict'),
+    )
     expect(res.status).toBe(409)
     expect(await res.json()).toEqual({ error: 'already exists' })
     expect(warnSpy).toHaveBeenCalledTimes(1)
+    expect(errorSpy).not.toHaveBeenCalled()
     expect(warnSpy.mock.calls[0]?.[1]).toMatchObject({
       method: 'GET',
-      path: '/__test/conflict',
+      path: '/conflict',
       status: 409,
     })
   })
 
-  test('unhandled error logs a 500 request line and keeps the onError line', async () => {
-    const res = await get('/__test/boom')
-    expect(res.status).toBe(500)
-    const messages = errorSpy.mock.calls.map((call) => call[0])
-    expect(messages).toContain('Unhandled route error')
-    expect(messages).toContain('request failed')
-    const requestLine = errorSpy.mock.calls.find(
-      (call) => call[0] === 'request failed',
-    )
-    expect(requestLine?.[1]).toMatchObject({
-      method: 'GET',
-      path: '/__test/boom',
-      status: 500,
-    })
-    expect(requestLine?.[1]?.durationMs).toBeGreaterThanOrEqual(0)
+  test('sub-400 responses log nothing', async () => {
+    const res = await fixtureApp().fetch(new Request('http://localhost/ok'))
+    expect(res.status).toBe(200)
     expect(warnSpy).not.toHaveBeenCalled()
+    expect(errorSpy).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## Summary
- One structured `request failed` line (warn 4xx / error 5xx, with method, path, status, durationMs) for every failed HTTP response — router 404s, thrown `HttpError`s, direct 4xx/5xx returns, and unhandled errors alike; sub-400 traffic stays unlogged so polling endpoints can't flood the 20MB rotating log.
- MCP v2 dispatch failures become visible: `isError` results (warn, with tool/sessionId/durationMs and error text capped at 200 chars), thrown dispatches (error, then rethrow unchanged), client aborts (info), and pre-dispatch rejections (blocked navigate scheme, browser session not connected).
- Session anomalies logged: unknown `mcp-session-id` rejections, transport `onerror`, idle sweeps (count).
- Lifecycle events logged once where state changes: audit DB open/migration failure, agent profile create/update/delete/URL-rotate, site-rule add/remove, operator cancel with count.

## Design
Failure-first logging at the seams via the existing structured `logger` (no new deps, no `console.*`, no behavior changes — all rethrows/returns preserved). The HTTP layer gets a single post-`next()` middleware in `server.ts`; Hono materialises the `onError` response before `next()` resolves, so one middleware observes the final status of every failure mode. Success paths (HTTP 2xx, successful dispatches) intentionally stay silent: the logger has no level filtering, and the audit SQLite DB already records dispatch history. Fields are ids, counts, durations, statuses, and error messages only — no payloads, names, or secrets.

## Test plan
- [x] New `tests/routes/request-logging.test.ts`: live-app 200-silent + 404-warn; fixture-app thrown-500, thrown-HttpError-409, direct-410, sub-400-silent (fixture needed because the shared app's route matcher freezes after first fetch).
- [x] `cd apps/claw-server && bun test` — 391 pass / 0 fail.
- [x] `bun run check` from `packages/browseros-agent` — exit 0 (lint + typecheck + Fallow; the one biome cognitive-complexity warning on the v2 dispatch handler pre-exists at base).
- [x] `bun run test` from `packages/browseros-agent` — every package green except `scripts/build/server/native-addon-policy.test.ts` ("prevents Bun from opening hidden temp native addons"), a darwin-only timing flake reproduced on base `808c01e0e` (2/4 isolated runs fail); CI runs that suite on ubuntu where the test self-skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)