### PR TITLE
fix(patches): forward MCP session headers through server proxy

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_proxy.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_proxy.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_proxy.cc b/chrome/browser/browseros/server/browseros_server_proxy.cc
 new file mode 100644
-index 0000000000000..17560c9a2c55a
+index 0000000000000..3a8c6b6ad13f4
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_proxy.cc
-@@ -0,0 +1,225 @@
+@@ -0,0 +1,247 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -167,8 +167,14 @@ index 0000000000000..17560c9a2c55a
 +  resource_request->method = info.method;
 +  resource_request->credentials_mode = network::mojom::CredentialsMode::kOmit;
 +
++  // MCP Streamable HTTP keeps session state in headers: the server assigns
++  // mcp-session-id on initialize and the client echoes it (plus
++  // mcp-protocol-version, and last-event-id on stream resume) on every
++  // later request. net::HttpServer lowercases header names.
 +  for (const auto& [name, value] : info.headers) {
-+    if (name == "content-type" || name == "accept" || name == "authorization") {
++    if (name == "content-type" || name == "accept" ||
++        name == "authorization" || name == "mcp-session-id" ||
++        name == "mcp-protocol-version" || name == "last-event-id") {
 +      resource_request->headers.SetHeader(name, value);
 +    }
 +  }
@@ -181,6 +187,11 @@ index 0000000000000..17560c9a2c55a
 +  }
 +
 +  loader->SetTimeoutDuration(base::Seconds(300));
++
++  // Relay backend 4xx/5xx (with bodies) instead of masking them as 503.
++  // Stateful MCP backends answer 4xx for session errors, and clients
++  // recover from the real status (e.g. re-initialize on 404).
++  loader->SetAllowHttpErrorResults(true);
 +
 +  auto* loader_ptr = loader.get();
 +  pending_loaders_[connection_id] = std::move(loader);
@@ -225,6 +236,17 @@ index 0000000000000..17560c9a2c55a
 +  net::HttpServerResponseInfo response(
 +      static_cast<net::HttpStatusCode>(response_code));
 +  response.SetBody(*response_body, content_type);
++
++  // Without the assigned mcp-session-id a stateful MCP client can never
++  // join its session, so relay it alongside the body.
++  if (response_info && response_info->headers) {
++    std::optional<std::string> session_id =
++        response_info->headers->GetNormalizedHeader("mcp-session-id");
++    if (session_id.has_value()) {
++      response.AddHeader("mcp-session-id", *session_id);
++    }
++  }
++
 +  server_->SendResponse(connection_id, response, GetProxyTrafficAnnotation());
 +}
 +

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_proxy.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_proxy.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_proxy.cc b/chrome/browser/browseros/server/browseros_server_proxy.cc
 new file mode 100644
-index 0000000000000..3a8c6b6ad13f4
+index 0000000000000..29bd72722ffde
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_proxy.cc
-@@ -0,0 +1,247 @@
+@@ -0,0 +1,249 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -169,8 +169,10 @@ index 0000000000000..3a8c6b6ad13f4
 +
 +  // MCP Streamable HTTP keeps session state in headers: the server assigns
 +  // mcp-session-id on initialize and the client echoes it (plus
-+  // mcp-protocol-version, and last-event-id on stream resume) on every
-+  // later request. net::HttpServer lowercases header names.
++  // mcp-protocol-version, and last-event-id) on every later request.
++  // last-event-id is forwarded for protocol completeness only; SSE stream
++  // resume still cannot traverse this buffering proxy (DownloadToString).
++  // net::HttpServer lowercases header names.
 +  for (const auto& [name, value] : info.headers) {
 +    if (name == "content-type" || name == "accept" ||
 +        name == "authorization" || name == "mcp-session-id" ||


### PR DESCRIPTION
## Summary
- Fixes the production symptom: BrowserClaw's stable MCP proxy port returned `503 Service Unavailable` for every `/mcp` request (browser MCP page "0 of 5 connected", `curl -i http://127.0.0.1:9001/mcp` → 503) while the managed claw-server itself was healthy (`claw-server listening http://127.0.0.1:9202`, `cockpit attached to browseros browser cdpPort 9100`).
- Root cause: `BrowserOSServerProxy` was an HTTP proxy but not an MCP proxy. It (1) forwarded only `content-type`/`accept`/`authorization` request headers — stripping `mcp-session-id`, (2) rebuilt responses with only `content-type` — stripping the `mcp-session-id` the server assigns on `initialize`, and (3) never called `SimpleURLLoader::SetAllowHttpErrorResults(true)`, so every non-2xx backend response lost its body and was masked as a blanket 503.
- Why apps/server worked and claw-server didn't: apps/server's `/mcp` is **stateless** (`sessionIdGenerator: undefined`, per-request transport — `apps/server/src/api/routes/mcp.ts`), so it never needs the session header round-trip and its happy path is always 2xx. claw-server's `/mcp` is **stateful** (`apps/claw-server/src/mcp/single-server.ts` keys sessions off the `mcp-session-id` header for per-agent identity): through the old proxy a client never received its session id, every post-initialize request was rejected 4xx by the MCP SDK, and the proxy converted those 4xxs into 503s.

## Design
Single-file change to the chromium patch `chrome/browser/browseros/server/browseros_server_proxy.cc`: extend the request-header allowlist with the MCP Streamable HTTP protocol headers (`mcp-session-id`, `mcp-protocol-version`, `last-event-id`), relay the backend's `mcp-session-id` response header to the client, and enable `SetAllowHttpErrorResults(true)` so real backend statuses/bodies pass through. 503 now means exactly "backend unset or unreachable" (`backend_port_ <= 0`, missing loader factory, or `response_code == 0`). The manager-owns-the-backend-port design is untouched — no routing, port, launch, descriptor, or readiness changes (the user's log proves the managed claw-server launches, binds `ports_.server`, and passes `/system/health` checks; those suspects were eliminated).

## Test plan
- [x] `git apply --check` of the modified patch in a clean repo (hunk line count and index blob hash regenerated and verified: 249 lines, `29bd72722ffde`).
- [x] `bun run check` from `packages/browseros-agent` — exit 0.
- [x] `bun run test` from `packages/browseros-agent` — exit 0, all groups pass (no TS changes; regression guard).
- [x] Adversarial review (context-free agent): 0 critical, 0 important; verified against chromium M148 that `net::HttpServer` lowercases header names, forwarded values can't trip `CHECK(HttpUtil::IsValidHeaderValue)`, `SetAllowHttpErrorResults` ordering matches sibling usage (`browseros_metrics_service.cc`), and `GetHttpReasonPhrase` handles non-enum status codes without `NOTREACHED()`.
- [ ] **Not run locally (requires a chromium build — not possible in this worktree):** compiling the patched `browseros_server_proxy.cc` and the `browseros_server_*_unittest.cc` targets (no proxy unittest exists; manager/config/utils unittests don't exercise forwarded headers). Manual verification on a BrowserClaw build: start the browser, then `curl -i -X POST http://127.0.0.1:<proxy>/mcp -H 'content-type: application/json' -H 'accept: application/json, text/event-stream' -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26","capabilities":{},"clientInfo":{"name":"probe","version":"0"}}}'` → expect 200 with an `mcp-session-id` response header; follow-up `tools/list` POST echoing that header → 200; agents on the MCP page should count as connected.

## Notes / follow-ups
- Long-lived SSE `GET /mcp` streams still cannot traverse the proxy (it buffers via `DownloadToString`); claw-server uses `enableJsonResponse: true` so all POST flows complete as JSON. Documented in-code.
- Possible follow-up: relay `WWW-Authenticate`/`Retry-After` response headers if MCP auth is ever served through the proxy (no consumer today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)