### PR TITLE
polish(claw-app): theme-following empty preview panes

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/audit/AuditHoverPreview.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/audit/AuditHoverPreview.tsx
@@ -70,8 +70,8 @@ export function AuditHoverPreview({ task }: AuditHoverPreviewProps) {
 function NoShotComposition({ task }: { task: TaskSummary }) {
   const verbs = task.toolSequence.slice(0, 5)
   return (
-    <div className="absolute inset-0 bg-gradient-to-br from-ink-deep via-ink-deep-2 to-ink-deep">
-      <div className="pointer-events-none absolute inset-0 flex flex-col justify-center gap-1 pl-6 font-mono text-[22px] text-white/15 leading-tight tracking-tight">
+    <div className="absolute inset-0 bg-gradient-to-br from-accent-tint via-secondary to-muted">
+      <div className="pointer-events-none absolute inset-0 flex flex-col justify-center gap-1 pl-6 font-mono text-[22px] text-ink/15 leading-tight tracking-tight">
         {verbs.map((verb, idx) => (
           <span
             // biome-ignore lint/suspicious/noArrayIndexKey: tool sequence is stable-ordered per session, not a reorderable list

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/LeadRunTile.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/LeadRunTile.tsx
@@ -128,14 +128,14 @@ function Caption({
 
 /**
  * When the lead session has no screenshot yet the top zone becomes
- * a dark composition of the tool sequence rendered as large mono
- * type. The absence of an image becomes a design opportunity.
+ * a theme-following wash with the tool sequence rendered as large
+ * mono type. The absence of an image becomes a design opportunity.
  */
 function LeadNoShotComposition({ task }: { task: TaskSummary }) {
   const verbs = task.toolSequence.slice(0, 5)
   return (
-    <div className="absolute inset-0 bg-gradient-to-br from-ink-deep via-ink-deep-2 to-ink-deep">
-      <div className="pointer-events-none absolute inset-0 flex flex-col justify-center gap-1 p-8 font-mono text-[30px] text-white/12 leading-[1.05] tracking-tight md:text-[38px]">
+    <div className="absolute inset-0 bg-gradient-to-br from-accent-tint via-secondary to-muted">
+      <div className="pointer-events-none absolute inset-0 flex flex-col justify-center gap-1 p-8 font-mono text-[30px] text-ink/12 leading-[1.05] tracking-tight md:text-[38px]">
         {verbs.map((verb, idx) => (
           <span
             // biome-ignore lint/suspicious/noArrayIndexKey: tool sequence is stable-ordered per session, not a reorderable list

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/SupportingTile.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/SupportingTile.tsx
@@ -100,11 +100,11 @@ function Caption({
 }
 
 function NoShotComposition({ task }: { task: TaskSummary }) {
-  // Uses the fixed ink-deep surface pair so the top zone stays dark in both themes.
+  // The wash follows the theme: pale in light mode, deep in dark mode.
   const verbs = task.toolSequence.slice(0, 4)
   return (
-    <div className="absolute inset-0 bg-gradient-to-br from-ink-deep via-ink-deep-2 to-ink-deep">
-      <div className="pointer-events-none absolute inset-0 flex flex-col justify-center gap-0.5 pl-4 font-mono text-[14px] text-white/18 leading-tight tracking-tight">
+    <div className="absolute inset-0 bg-gradient-to-br from-accent-tint via-secondary to-muted">
+      <div className="pointer-events-none absolute inset-0 flex flex-col justify-center gap-0.5 pl-4 font-mono text-[14px] text-ink/18 leading-tight tracking-tight">
         {verbs.map((verb, idx) => (
           <span
             // biome-ignore lint/suspicious/noArrayIndexKey: tool sequence is stable-ordered per session, not a reorderable list

--- a/packages/browseros-agent/apps/claw-app/entrypoints/newtab/styles.css
+++ b/packages/browseros-agent/apps/claw-app/entrypoints/newtab/styles.css
@@ -41,14 +41,13 @@
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
   --color-sidebar-border: var(--sidebar-border);
 
-  /* BrowserOS bespoke surfaces. ink-deep and its ink-deep-2 gradient
-     partner stay dark chips in both themes, elevated in dark so they read
-     as raised, not lost against the page. They carry hardcoded white text. */
+  /* BrowserOS bespoke surfaces. ink-deep stays a dark chip in both themes,
+     elevated in dark so it reads as raised, not lost against the page. It
+     carries hardcoded white text. */
   --color-bg-canvas: var(--bg-canvas);
   --color-bg-sunken: var(--bg-sunken);
   --color-card-tint: var(--card-tint);
   --color-ink-deep: var(--ink-deep);
-  --color-ink-deep-2: var(--ink-deep-2);
   --color-border-2: var(--border-2);
   --color-border-strong: var(--border-strong);
 
@@ -258,7 +257,6 @@ body {
   --bg-sunken: #eef3fb;
   --card-tint: #fbfcff;
   --ink-deep: #01123f;
-  --ink-deep-2: #0a2158;
   --border-2: #e3e9f4;
   --border-strong: #c7d3e8;
   --ink: #25242f;
@@ -321,7 +319,6 @@ body {
   --bg-sunken: #070b11;
   --card-tint: #151d2e;
   --ink-deep: #172138;
-  --ink-deep-2: #1f2c4a;
   --border-2: #253046;
   --border-strong: #34405c;
   --ink: #eef2f9;


### PR DESCRIPTION
## What

Follow-up to #1551. The cockpit/audit "no screenshot yet" preview panes were a fixed navy slab in both themes, so in **light** mode the bento grid read patchy — empty tiles were dark blocks sitting among screenshot tiles (light webpage top + navy caption strip).

Makes the no-shot **top zone** a theme-following wash (`from-accent-tint via-secondary to-muted`): pale blue in light mode so it harmonizes with the screenshot tiles, automatically deep navy in dark mode. Watermark verbs switched from `text-white/N` to `text-ink/N` so they stay a faint texture in both themes. Navy caption strips are unchanged. Removes the now-unused `--ink-deep-2` token introduced in #1551.

No layout changes — class + comment swaps in 3 components + token cleanup in `styles.css`.

## Verification

- `bun run typecheck` ✓ · `bunx biome check` ✓ · `bun test` ✓ (171) · `bun run build:dev` ✓.
- Verified via light+dark agent-browser screenshots of the cockpit grid: light empty panes now pale-blue and consistent with screenshot tiles; dark uniform navy; watermark legible in both.

Addresses the reviewer note carried over from #1551.