### PR TITLE
fix: canonical system health and shutdown paths

### DIFF
--- a/packages/browseros-agent/README.md
+++ b/packages/browseros-agent/README.md
@@ -43,7 +43,7 @@ packages/
 │                                                                          │
 │   /mcp ─────── MCP tool endpoints                                        │
 │   /chat ────── Agent streaming                                           │
-│   /health ─── Health check                                               │
+│   /system/health ─ Health check                                          │
 │                                                                          │
 │   Tools:                                                                 │
 │   └── CDP-backed browser tools (tabs, navigation, input, screenshots,   │

--- a/packages/browseros-agent/apps/app/lib/browseros/helpers.test.ts
+++ b/packages/browseros-agent/apps/app/lib/browseros/helpers.test.ts
@@ -81,7 +81,7 @@ describe('BrowserOS helper URLs', () => {
     const { getHealthCheckUrl } = await import('./helpers')
 
     await expect(getHealthCheckUrl()).resolves.toBe(
-      'http://127.0.0.1:9106/health',
+      'http://127.0.0.1:9106/system/health',
     )
   })
 })

--- a/packages/browseros-agent/apps/app/lib/browseros/helpers.ts
+++ b/packages/browseros-agent/apps/app/lib/browseros/helpers.ts
@@ -63,5 +63,5 @@ export async function getProxyPort(): Promise<number> {
 /** Returns the MCP proxy health-check endpoint. */
 export async function getHealthCheckUrl(): Promise<string> {
   const port = await getProxyPort()
-  return `http://127.0.0.1:${port}/health`
+  return `http://127.0.0.1:${port}/system/health`
 }

--- a/packages/browseros-agent/apps/app/lib/schedules/provider-resolution.test.ts
+++ b/packages/browseros-agent/apps/app/lib/schedules/provider-resolution.test.ts
@@ -43,7 +43,7 @@ mock.module('@/lib/llm-providers/storage', () => ({
 mock.module('@/lib/browseros/helpers', () => ({
   getAgentServerUrl: async () => 'http://127.0.0.1:9105',
   getMcpServerUrl: async () => 'http://127.0.0.1:9106/mcp',
-  getHealthCheckUrl: async () => 'http://127.0.0.1:9106/health',
+  getHealthCheckUrl: async () => 'http://127.0.0.1:9106/system/health',
   getProxyPort: async () => 9106,
 }))
 

--- a/packages/browseros-agent/apps/claw-server/src/main.ts
+++ b/packages/browseros-agent/apps/claw-server/src/main.ts
@@ -27,7 +27,7 @@ import { getClawServerDir } from './lib/browseros-dir'
 import { logger } from './lib/logger'
 import { migrateMcpUrls } from './lib/migrate-mcp-urls'
 import { setLocalServerUrl } from './local-server-url'
-import server from './server'
+import { createServer } from './server'
 import { startScreencastPoller } from './services/screencast-poller'
 import { publicMcpUrl } from './shared/mcp-url'
 
@@ -40,10 +40,12 @@ async function start(): Promise<void> {
   }
   applyClawConfig(config.value)
 
+  let shutdown = (): void => process.exit(0)
+  const app = createServer({ onShutdown: () => shutdown() })
   const httpServer = Bun.serve({
     hostname: '127.0.0.1',
     port: env.serverPort,
-    fetch: server.fetch,
+    fetch: app.fetch,
   })
   // File sink attaches only after the port bind succeeds: the bind is
   // the de-facto singleton lock, so a second accidental launch dies on
@@ -89,6 +91,7 @@ async function start(): Promise<void> {
       setTimeout(() => process.exit(1), 5_000).unref()
       bootstrap.disconnect().finally(() => process.exit(0))
     }
+    shutdown = cleanup
     process.once('SIGINT', cleanup)
     process.once('SIGTERM', cleanup)
   }

--- a/packages/browseros-agent/apps/claw-server/src/routes/system.ts
+++ b/packages/browseros-agent/apps/claw-server/src/routes/system.ts
@@ -10,9 +10,21 @@ import { Hono } from 'hono'
 import pkg from '../../package.json' with { type: 'json' }
 import { getLocalServerUrl } from '../local-server-url'
 
-export const systemRoute = new Hono()
-  .get('/system/health', (c) => c.json({ status: 'ok' as const }))
-  .get('/system/version', (c) =>
-    c.json({ name: pkg.name, version: pkg.version }),
-  )
-  .get('/system/url', (c) => c.json({ url: getLocalServerUrl() }))
+interface SystemRouteConfig {
+  onShutdown?: () => void
+}
+
+export function createSystemRoute(config: SystemRouteConfig = {}) {
+  return new Hono()
+    .get('/system/health', (c) => c.json({ status: 'ok' as const }))
+    .post('/system/shutdown', (c) => {
+      setImmediate(() => config.onShutdown?.())
+      return c.json({ status: 'ok' as const })
+    })
+    .get('/system/version', (c) =>
+      c.json({ name: pkg.name, version: pkg.version }),
+    )
+    .get('/system/url', (c) => c.json({ url: getLocalServerUrl() }))
+}
+
+export const systemRoute = createSystemRoute()

--- a/packages/browseros-agent/apps/claw-server/src/server.ts
+++ b/packages/browseros-agent/apps/claw-server/src/server.ts
@@ -29,7 +29,7 @@ import { connectionsRoute } from './routes/connections'
 import { mcpV2Route } from './routes/mcp-v2'
 import { permissionsRoute } from './routes/permissions'
 import { siteRulesRoute } from './routes/site-rules'
-import { systemRoute } from './routes/system'
+import { createSystemRoute } from './routes/system'
 import { tabsRoute } from './routes/tabs'
 import { tabsFocusRoute } from './routes/tabs-focus'
 
@@ -48,23 +48,6 @@ export function setRouteErrorHandler(fn: RouteErrorHandler): void {
   captureRouteError = fn
 }
 
-const app = new Hono()
-
-// Loopback-only bind (see main.ts) makes wildcard CORS safe and
-// dodges the `null` Origin a chrome-extension:// page sends when
-// fetching from `http://127.0.0.1:<port>`.
-app.use('*', cors({ origin: '*' }))
-
-// One structured line per failed request, however the failure was
-// produced: a router 404, a thrown HttpError, a direct 4xx/5xx JSON
-// return, or an unhandled error — hono materialises the onError
-// response before `next()` resolves, so `c.res.status` is final
-// here. Sub-400 traffic stays unlogged on purpose: the logger has no
-// level filtering and the claw-app polls several endpoints, so a
-// per-request access log would flood the rotating log file.
-// Named export so tests can exercise the throwing paths on a fixture
-// app; this shared app's route matcher is already built (and frozen)
-// by the first test file that fetches through it.
 export const requestFailureLog: MiddlewareHandler = async (c, next) => {
   const start = Date.now()
   await next()
@@ -83,43 +66,65 @@ export const requestFailureLog: MiddlewareHandler = async (c, next) => {
   }
 }
 
-app.use('*', requestFailureLog)
+interface CreateServerOptions {
+  onShutdown?: () => void
+}
 
-// Catch-all for genuinely unexpected errors. Routes today resolve
-// their own expected failures (404s, validation) inline and return
-// structured 4xx JSON. Anything that escapes that lands here, gets
-// reported via the injected capture, and turns into a structured 5xx
-// JSON body.
-app.onError((err, c) => {
-  captureRouteError(err, c.req.path, c.req.method)
-  if (err instanceof HttpError) {
-    return c.json({ error: err.message }, err.status as 400 | 404 | 409 | 500)
-  }
-  const message = err instanceof Error ? err.message : 'internal error'
-  logger.error('Unhandled route error', {
-    path: c.req.path,
-    method: c.req.method,
-    error: message,
+export function createServer(options: CreateServerOptions = {}) {
+  const app = new Hono()
+
+  // Loopback-only bind (see main.ts) makes wildcard CORS safe and
+  // dodges the `null` Origin a chrome-extension:// page sends when
+  // fetching from `http://127.0.0.1:<port>`.
+  app.use('*', cors({ origin: '*' }))
+
+  // One structured line per failed request, however the failure was
+  // produced: a router 404, a thrown HttpError, a direct 4xx/5xx JSON
+  // return, or an unhandled error — hono materialises the onError
+  // response before `next()` resolves, so `c.res.status` is final
+  // here. Sub-400 traffic stays unlogged on purpose: the logger has no
+  // level filtering and the claw-app polls several endpoints, so a
+  // per-request access log would flood the rotating log file.
+  app.use('*', requestFailureLog)
+
+  // Catch-all for genuinely unexpected errors. Routes today resolve
+  // their own expected failures (404s, validation) inline and return
+  // structured 4xx JSON. Anything that escapes that lands here, gets
+  // reported via the injected capture, and turns into a structured 5xx
+  // JSON body.
+  app.onError((err, c) => {
+    captureRouteError(err, c.req.path, c.req.method)
+    if (err instanceof HttpError) {
+      return c.json({ error: err.message }, err.status as 400 | 404 | 409 | 500)
+    }
+    const message = err instanceof Error ? err.message : 'internal error'
+    logger.error('Unhandled route error', {
+      path: c.req.path,
+      method: c.req.method,
+      error: message,
+    })
+    return c.json({ error: message }, 500)
   })
-  return c.json({ error: message }, 500)
-})
 
-// The single MCP endpoint mounts at `/mcp`.
-const routes = app
-  .route('/', systemRoute)
-  .route('/', agentsRoute)
-  .route('/', siteRulesRoute)
-  .route('/', permissionsRoute)
-  .route('/', mcpV2Route)
-  .route('/', tabsRoute)
-  .route('/', tabsFocusRoute)
-  .route('/', agentsControlRoute)
-  .route('/', connectionsRoute)
-  .route('/', auditRoute)
-  .route('/', auditTasksRoute)
-  .route('/', auditScreenshotsRoute)
-  .route('/', auditReplayRoute)
-  .route('/', replayTabsRoute)
+  // The single MCP endpoint mounts at `/mcp`.
+  return app
+    .route('/', createSystemRoute({ onShutdown: options.onShutdown }))
+    .route('/', agentsRoute)
+    .route('/', siteRulesRoute)
+    .route('/', permissionsRoute)
+    .route('/', mcpV2Route)
+    .route('/', tabsRoute)
+    .route('/', tabsFocusRoute)
+    .route('/', agentsControlRoute)
+    .route('/', connectionsRoute)
+    .route('/', auditRoute)
+    .route('/', auditTasksRoute)
+    .route('/', auditScreenshotsRoute)
+    .route('/', auditReplayRoute)
+    .route('/', replayTabsRoute)
+}
+
+const routes = createServer()
 
 export type AppType = typeof routes
 export default routes

--- a/packages/browseros-agent/apps/claw-server/tests/routes/system.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/routes/system.test.ts
@@ -1,0 +1,34 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, mock, test } from 'bun:test'
+import app, { createServer } from '../../src/server'
+
+describe('system routes', () => {
+  test('default server exposes system health', async () => {
+    const res = await app.fetch(new Request('http://localhost/system/health'))
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ status: 'ok' })
+  })
+
+  test('system shutdown responds before invoking the shutdown hook', async () => {
+    const onShutdown = mock(() => {})
+    const server = createServer({ onShutdown })
+
+    const res = await server.fetch(
+      new Request('http://localhost/system/shutdown', { method: 'POST' }),
+    )
+
+    expect(res.status).toBe(200)
+    await expect(res.json()).resolves.toEqual({ status: 'ok' })
+    expect(onShutdown).not.toHaveBeenCalled()
+
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(onShutdown).toHaveBeenCalledTimes(1)
+  })
+})

--- a/packages/browseros-agent/apps/cli/cmd/launch.go
+++ b/packages/browseros-agent/apps/cli/cmd/launch.go
@@ -95,12 +95,25 @@ func probeRunningServer() string {
 }
 
 func checkServerHealth(client *http.Client, baseURL string) bool {
-	resp, err := client.Get(baseURL + "/health")
-	if err != nil {
+	status, ok := getHealthStatus(client, baseURL+"/system/health")
+	if ok && status == http.StatusOK {
+		return true
+	}
+	if ok && status != http.StatusNotFound {
 		return false
 	}
+
+	status, ok = getHealthStatus(client, baseURL+"/health")
+	return ok && status == http.StatusOK
+}
+
+func getHealthStatus(client *http.Client, url string) (int, bool) {
+	resp, err := client.Get(url)
+	if err != nil {
+		return 0, false
+	}
 	resp.Body.Close()
-	return resp.StatusCode == 200
+	return resp.StatusCode, true
 }
 
 func probeCommonServerPorts(client *http.Client) string {

--- a/packages/browseros-agent/apps/cli/cmd/launch_test.go
+++ b/packages/browseros-agent/apps/cli/cmd/launch_test.go
@@ -70,7 +70,7 @@ func newHealthyServer(t *testing.T) *httptest.Server {
 	t.Helper()
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/health" {
+		if r.URL.Path != "/system/health" {
 			http.NotFound(w, r)
 			return
 		}

--- a/packages/browseros-agent/apps/cli/cmd/snap.go
+++ b/packages/browseros-agent/apps/cli/cmd/snap.go
@@ -25,7 +25,12 @@ func init() {
 				output.Error(err.Error(), 1)
 			}
 			if jsonOut {
-				output.JSON(result)
+				data := map[string]any{}
+				for key, value := range result.StructuredContent {
+					data[key] = value
+				}
+				data["snapshot"] = result.TextContent()
+				output.JSONRaw(data)
 			} else {
 				output.Text(result)
 			}

--- a/packages/browseros-agent/apps/cli/integration_test.go
+++ b/packages/browseros-agent/apps/cli/integration_test.go
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 	}
 
 	client := &http.Client{Timeout: 3 * time.Second}
-	resp, err := client.Get(serverURL + "/health")
+	resp, err := client.Get(serverURL + "/system/health")
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Skipping integration tests: server not reachable at %s\n", serverURL)
 		os.Exit(0)

--- a/packages/browseros-agent/apps/cli/mcp/client.go
+++ b/packages/browseros-agent/apps/cli/mcp/client.go
@@ -139,9 +139,9 @@ func convertResult(r *sdkmcp.CallToolResult) *ToolResult {
 
 // Health checks BrowserOS-compatible REST health endpoints.
 func (c *Client) Health() (map[string]any, error) {
-	data, err := c.restGET("/health")
+	data, err := c.restGET("/system/health")
 	if isHTTPStatus(err, http.StatusNotFound) {
-		return c.restGET("/system/health")
+		return c.restGET("/health")
 	}
 	return data, err
 }

--- a/packages/browseros-agent/apps/cli/mcp/client_test.go
+++ b/packages/browseros-agent/apps/cli/mcp/client_test.go
@@ -9,11 +9,11 @@ import (
 	"time"
 )
 
-func TestHealthUsesBrowserOSHealthEndpoint(t *testing.T) {
+func TestHealthUsesCanonicalSystemHealthEndpoint(t *testing.T) {
 	var paths []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		paths = append(paths, r.URL.Path)
-		if r.URL.Path != "/health" {
+		if r.URL.Path != "/system/health" {
 			http.NotFound(w, r)
 			return
 		}
@@ -28,17 +28,17 @@ func TestHealthUsesBrowserOSHealthEndpoint(t *testing.T) {
 	if data["status"] != "ok" {
 		t.Fatalf("Health() status = %v, want ok", data["status"])
 	}
-	assertPaths(t, paths, []string{"/health"})
+	assertPaths(t, paths, []string{"/system/health"})
 }
 
-func TestHealthFallsBackToClawSystemHealthEndpoint(t *testing.T) {
+func TestHealthFallsBackToLegacyRootHealthEndpoint(t *testing.T) {
 	var paths []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		paths = append(paths, r.URL.Path)
 		switch r.URL.Path {
-		case "/health":
-			http.NotFound(w, r)
 		case "/system/health":
+			http.NotFound(w, r)
+		case "/health":
 			fmt.Fprint(w, `{"status":"ok"}`)
 		default:
 			http.NotFound(w, r)
@@ -53,14 +53,14 @@ func TestHealthFallsBackToClawSystemHealthEndpoint(t *testing.T) {
 	if data["status"] != "ok" {
 		t.Fatalf("Health() status = %v, want ok", data["status"])
 	}
-	assertPaths(t, paths, []string{"/health", "/system/health"})
+	assertPaths(t, paths, []string{"/system/health", "/health"})
 }
 
-func TestHealthDoesNotFallbackOnBrowserOSHealthFailure(t *testing.T) {
+func TestHealthDoesNotFallbackOnCanonicalHealthFailure(t *testing.T) {
 	var paths []string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		paths = append(paths, r.URL.Path)
-		if r.URL.Path == "/health" {
+		if r.URL.Path == "/system/health" {
 			http.Error(w, "boom", http.StatusInternalServerError)
 			return
 		}
@@ -75,7 +75,7 @@ func TestHealthDoesNotFallbackOnBrowserOSHealthFailure(t *testing.T) {
 	if !strings.Contains(err.Error(), "HTTP 500") {
 		t.Fatalf("Health() error = %q, want HTTP 500", err)
 	}
-	assertPaths(t, paths, []string{"/health"})
+	assertPaths(t, paths, []string{"/system/health"})
 }
 
 func assertPaths(t *testing.T, got, want []string) {

--- a/packages/browseros-agent/apps/eval/src/runner/browseros-app-manager.ts
+++ b/packages/browseros-agent/apps/eval/src/runner/browseros-app-manager.ts
@@ -284,7 +284,7 @@ export class BrowserOSAppManager {
     while (Date.now() - startTime < SERVER_HEALTH_TIMEOUT_MS) {
       try {
         const res = await fetch(
-          `http://127.0.0.1:${this.ports.server}/health`,
+          `http://127.0.0.1:${this.ports.server}/system/health`,
           { signal: AbortSignal.timeout(1000) },
         )
         if (res.ok) return true

--- a/packages/browseros-agent/apps/server/README.md
+++ b/packages/browseros-agent/apps/server/README.md
@@ -19,7 +19,7 @@ MCP server and AI agent loop powering BrowserOS browser automation. This is the 
 │                                                                      │
 │   /mcp ─────── MCP tool endpoints (53+ tools)                       │
 │   /chat ────── Agent streaming (AI SDK)                              │
-│   /health ─── Health check                                           │
+│   /system/health ─ Health check                                      │
 │                                                                      │
 │   ┌─────────────────────────────────────────────────────────────┐   │
 │   │  Agent Loop                                                  │   │

--- a/packages/browseros-agent/apps/server/src/api/routes/index.ts
+++ b/packages/browseros-agent/apps/server/src/api/routes/index.ts
@@ -69,6 +69,10 @@ export function createApiRoutes(deps: CreateApiRoutesDeps) {
     new Hono<Env>()
       .use('/*', cors(defaultCorsConfig))
       .use('/*', requireTrustedOrigin())
+      .route('/system/health', createHealthRoute({ browser }))
+      .route('/system/shutdown', createShutdownRoute({ onShutdown }))
+      // Compatibility aliases for shipped browsers that still probe root paths
+      // while the server binary can update independently during OTA.
       .route('/health', createHealthRoute({ browser }))
       .route('/shutdown', createShutdownRoute({ onShutdown }))
       .route('/status', createStatusRoute({ browser, activity }))

--- a/packages/browseros-agent/apps/server/src/main.ts
+++ b/packages/browseros-agent/apps/server/src/main.ts
@@ -134,7 +134,7 @@ export class Application {
       `HTTP server listening on http://127.0.0.1:${this.config.serverPort}`,
     )
     logger.info(
-      `Health endpoint: http://127.0.0.1:${this.config.serverPort}/health`,
+      `Health endpoint: http://127.0.0.1:${this.config.serverPort}/system/health`,
     )
 
     this.logStartupSummary()

--- a/packages/browseros-agent/apps/server/tests/__helpers__/server.ts
+++ b/packages/browseros-agent/apps/server/tests/__helpers__/server.ts
@@ -75,7 +75,7 @@ function formatStartupFailure(
 
 export async function isServerRunning(port: number): Promise<boolean> {
   try {
-    const response = await fetch(`http://127.0.0.1:${port}/health`, {
+    const response = await fetch(`http://127.0.0.1:${port}/system/health`, {
       signal: AbortSignal.timeout(1000),
     })
     return response.ok
@@ -101,7 +101,7 @@ async function waitForHealth(
         port,
         stdoutBuffer,
         stderrBuffer,
-        'Server process exited before /health became ready.',
+        'Server process exited before /system/health became ready.',
       )
     }
     await new Promise((resolve) => setTimeout(resolve, 500))
@@ -111,7 +111,7 @@ async function waitForHealth(
     port,
     stdoutBuffer,
     stderrBuffer,
-    'Timed out waiting for /health to become ready.',
+    'Timed out waiting for /system/health to become ready.',
   )
 }
 

--- a/packages/browseros-agent/apps/server/tests/api/routes/index.test.ts
+++ b/packages/browseros-agent/apps/server/tests/api/routes/index.test.ts
@@ -51,7 +51,17 @@ function createTestApp(
 }
 
 describe('createApiRoutes', () => {
-  it('mounts the health route', async () => {
+  it('mounts the canonical system health route', async () => {
+    const response = await createTestApp().request('/system/health')
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      status: 'ok',
+      cdpConnected: false,
+    })
+  })
+
+  it('keeps the health compatibility route', async () => {
     const response = await createTestApp().request('/health')
 
     expect(response.status).toBe(200)
@@ -61,7 +71,24 @@ describe('createApiRoutes', () => {
     })
   })
 
-  it('mounts the shutdown compatibility route', async () => {
+  it('mounts the canonical system shutdown route', async () => {
+    const onShutdown = mock(() => {})
+    const response = await createTestApp(undefined, onShutdown).request(
+      '/system/shutdown',
+      {
+        method: 'POST',
+      },
+    )
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ status: 'ok' })
+
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(onShutdown).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the shutdown compatibility route', async () => {
     const onShutdown = mock(() => {})
     const response = await createTestApp(undefined, onShutdown).request(
       '/shutdown',

--- a/packages/browseros-agent/apps/server/tests/server.integration.test.ts
+++ b/packages/browseros-agent/apps/server/tests/server.integration.test.ts
@@ -58,7 +58,7 @@ describe('HTTP Server Integration Tests', () => {
 
   describe('Health endpoint', () => {
     it('responds with 200 OK', async () => {
-      const response = await fetch(`${getBaseUrl()}/health`)
+      const response = await fetch(`${getBaseUrl()}/system/health`)
       assert.strictEqual(response.status, 200)
 
       const json = await response.json()

--- a/packages/browseros-agent/scripts/build/server/native-addon-policy.test.ts
+++ b/packages/browseros-agent/scripts/build/server/native-addon-policy.test.ts
@@ -97,7 +97,7 @@ describe('compiled server native addon policy', () => {
       stdout: 'pipe',
       stderr: 'pipe',
     })
-    await Bun.sleep(500)
+    await Bun.sleep(1000)
 
     const openFiles = await collectProcess(
       Bun.spawn(['lsof', '-p', String(app.pid)], {

--- a/packages/browseros-agent/tools/dev/server/health.go
+++ b/packages/browseros-agent/tools/dev/server/health.go
@@ -9,7 +9,7 @@ import (
 
 func WaitForHealth(ctx context.Context, port int, maxAttempts int) bool {
 	client := &http.Client{Timeout: time.Second}
-	url := fmt.Sprintf("http://127.0.0.1:%d/health", port)
+	url := fmt.Sprintf("http://127.0.0.1:%d/system/health", port)
 
 	for range maxAttempts {
 		if ctx.Err() != nil {

--- a/packages/browseros-agent/tools/dogfood/cmd/daemon.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/daemon.go
@@ -553,8 +553,5 @@ func waitForServerHealth(ctx context.Context, cfg config.Config, maxAttempts int
 }
 
 func healthURL(cfg config.Config) string {
-	if cfg.Target == config.TargetClaw {
-		return fmt.Sprintf("http://127.0.0.1:%d/system/health", cfg.Ports.Server)
-	}
-	return fmt.Sprintf("http://127.0.0.1:%d/health", cfg.Ports.Server)
+	return fmt.Sprintf("http://127.0.0.1:%d/system/health", cfg.Ports.Server)
 }

--- a/packages/browseros-agent/tools/dogfood/cmd/daemon_test.go
+++ b/packages/browseros-agent/tools/dogfood/cmd/daemon_test.go
@@ -110,10 +110,9 @@ func TestWaitForServerHealthAcceptsMissingCDPConnected(t *testing.T) {
 	}
 }
 
-func TestHealthURLUsesClawSystemHealth(t *testing.T) {
+func TestHealthURLUsesSystemHealth(t *testing.T) {
 	got := healthURL(config.Config{
-		Target: config.TargetClaw,
-		Ports:  config.Ports{Server: 9200},
+		Ports: config.Ports{Server: 9200},
 	})
 	if got != "http://127.0.0.1:9200/system/health" {
 		t.Fatalf("got %q", got)

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config.cc
@@ -22,7 +22,7 @@ index 0000000000000..6fe71062a9c96
 +    FILE_PATH_LITERAL("BrowserOSServer"),
 +    FILE_PATH_LITERAL("browseros_server"),
 +    FILE_PATH_LITERAL("config.json"),
-+    "/health",
++    "/system/health",
 +    true,
 +    {
 +        // Empty state dir keeps the legacy .browseros/current_version layout.
@@ -46,8 +46,8 @@ index 0000000000000..6fe71062a9c96
 +        FILE_PATH_LITERAL("BrowserClawServer"),
 +        "https://cdn.browseros.com/appcast-claw-server.xml",
 +        "https://cdn.browseros.com/appcast-claw-server.alpha.xml",
-+        // Claw exposes /system/health but not the {can_update} readiness
-+        // contract yet; empty skips readiness and restarts after verification.
++        // Claw does not expose the {can_update} readiness contract yet; empty
++        // skips readiness and restarts after verification.
 +        "",
 +    },
 +};

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config_unittest.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_config_unittest.cc
@@ -49,7 +49,7 @@ index 0000000000000..9a25f32a0da56
 +ServerLaunchConfig BuildLaunchConfig() {
 +  ServerLaunchConfig config;
 +  config.config_file_name = FILE_PATH_LITERAL("config.json");
-+  config.health_path = "/health";
++  config.health_path = "/system/health";
 +  config.log_name = "test server";
 +  config.enable_updater = true;
 +
@@ -111,7 +111,7 @@ index 0000000000000..9a25f32a0da56
 +            ToPathString(descriptor.binary_name));
 +  EXPECT_EQ(base::FilePath::StringType(FILE_PATH_LITERAL("config.json")),
 +            ToPathString(descriptor.config_file_name));
-+  EXPECT_EQ(std::string_view("/health"), descriptor.health_path);
++  EXPECT_EQ(std::string_view("/system/health"), descriptor.health_path);
 +  EXPECT_TRUE(descriptor.enable_updater);
 +
 +  // Empty state dir preserves the legacy .browseros/current_version layout.


### PR DESCRIPTION
## Summary
- expose `apps/server` health/shutdown at `/system/health` and `/system/shutdown` while keeping `/health` and `/shutdown` root aliases for shipped browser/server OTA skew
- add `apps/claw-server` `POST /system/shutdown` using the same async shutdown hook pattern as `apps/server`, and keep Claw health at `/system/health`
- update first-party probes and Chromium patch descriptors/tests to prefer canonical `/system/health`
- keep the existing agent suite green with a CLI snapshot JSON fix and a less racy native-addon policy test wait

## Rollout / compatibility
`apps/server` keeps the legacy root routes because old Chromium builds may still call `/health` or `/shutdown` while the server binary can update independently during OTA. New callers and the Chromium patch descriptors use `/system/*`. Claw remains loopback-bound like its existing system API surface.

## Tests
- `cd packages/browseros-agent/apps/cli && go vet ./... && go build ./... && go test ./...`
- `cd packages/browseros-agent/tools/dogfood && go vet ./... && go build ./... && go test ./...`
- `cd packages/browseros-agent/tools/dev && go vet ./... && go build ./... && go test ./...`
- `cd packages/browseros-agent && bun test apps/server/tests/api/routes/index.test.ts apps/claw-server/tests/routes/system.test.ts apps/app/lib/browseros/helpers.test.ts`
- `cd packages/browseros-agent && bun test apps/app/lib/schedules/provider-resolution.test.ts`
- `cd packages/browseros-agent && bun run check`
- `cd packages/browseros-agent && bun run test`
- `rg -n '"/health"|"/shutdown"' packages/browseros/chromium_patches/chrome/browser/browseros/server || true`
