### PR TITLE
fix(claw-onboard): brand user-visible surfaces as BrowserClaw

### DIFF
--- a/packages/browseros-agent/apps/claw-onboard/index.html
+++ b/packages/browseros-agent/apps/claw-onboard/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <link rel="icon" type="image/png" sizes="32x32" href="/icon/32.png" />
-    <title>BrowserOS Onboarding</title>
+    <title>BrowserClaw Onboarding</title>
   </head>
   <body>
     <div id="root"></div>

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.test.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.test.tsx
@@ -59,7 +59,7 @@ describe('OnboardingV2 shell', () => {
 
   it('renders the visual rail with the v2 quote and three feature blocks', () => {
     const html = renderApp()
-    expect(html).toContain('BrowserOS')
+    expect(html).toContain('BrowserClaw')
     expect(html).toContain('Let the agent you already run')
     expect(html).toContain('Fast &amp; token-cheap')
     expect(html).toContain('Logged in as you')
@@ -70,7 +70,7 @@ describe('OnboardingV2 shell', () => {
     const html = renderApp()
     expect(html).toContain('<main')
     expect(html).not.toContain('role="dialog"')
-    expect(html).not.toContain('Welcome to BrowserOS')
+    expect(html).not.toContain('Welcome to BrowserClaw')
     expect(html).not.toContain('#FF5F57')
   })
 

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/VisualRail.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/components/VisualRail.tsx
@@ -1,6 +1,6 @@
 import { Lock, ShieldCheck, Zap } from 'lucide-react'
 
-/** Renders the persistent BrowserOS visual rail beside the onboarding steps. */
+/** Renders the persistent BrowserClaw visual rail beside the onboarding steps. */
 export function VisualRail() {
   return (
     <div
@@ -23,7 +23,7 @@ export function VisualRail() {
           B
         </div>
         <div className="font-extrabold text-[17px] tracking-tight">
-          BrowserOS
+          BrowserClaw
         </div>
       </div>
       <div className="relative">

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ImportStep.tsx
@@ -115,7 +115,7 @@ export function ImportStep({
         Import your <Em>logins</Em>.
       </DisplayHeading>
       <StepCopy>
-        BrowserOS copies your saved Chrome sessions so the agent never has to
+        BrowserClaw copies your saved Chrome sessions so the agent never has to
         log in again. Sessions stay in a local vault on this Mac.
       </StepCopy>
 
@@ -220,7 +220,7 @@ export function ImportStep({
             </div>
             <div className="text-[12.5px] text-ink-2">
               {state.error?.message ??
-                'BrowserOS could not finish importing this profile.'}
+                'BrowserClaw could not finish importing this profile.'}
             </div>
           </div>
           <div className="flex flex-wrap gap-2.5">

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ReadyStep.test.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ReadyStep.test.tsx
@@ -13,8 +13,8 @@ function render(): string {
 }
 
 describe('ReadyStep', () => {
-  it('renders the Open BrowserOS CTA', () => {
-    expect(render()).toContain('Open BrowserOS')
+  it('renders the Open BrowserClaw CTA', () => {
+    expect(render()).toContain('Open BrowserClaw')
   })
 
   it('renders the first two starter prompts from the fixture', () => {

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ReadyStep.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ReadyStep.tsx
@@ -17,8 +17,8 @@ export function ReadyStep({ onDone }: ReadyStepProps) {
         You&rsquo;re <Em>set</Em>.
       </DisplayHeading>
       <StepCopy>
-        Open Claude and try one of these. The task runs here, in BrowserOS. You
-        watch, approve, and audit.
+        Open Claude and try one of these. The task runs here, in BrowserClaw.
+        You watch, approve, and audit.
       </StepCopy>
       <div className="mb-6 flex flex-col gap-2.5">
         {STARTER_PROMPTS.slice(0, 2).map((prompt) => (
@@ -27,7 +27,7 @@ export function ReadyStep({ onDone }: ReadyStepProps) {
       </div>
       <Button type="button" size="lg" onClick={onDone}>
         <Sparkles className="size-4" />
-        Open BrowserOS
+        Open BrowserClaw
       </Button>
     </StepWrap>
   )


### PR DESCRIPTION
## Summary
- The onboarding app's rail wordmark, page title, and Import/Ready step copy now read **BrowserClaw** instead of BrowserOS — claw-onboard brands itself as the product it actually is.
- Updated the matching test expectations (ReadyStep "Open BrowserClaw" CTA, OnboardingV2 rail-wordmark assertion).

## Design
Brand rename only — every **user-visible** "BrowserOS" string in `apps/claw-onboard` becomes BrowserClaw, using the repo-canonical casing (matches `Product::kBrowserClaw`, the `claude mcp add BrowserClaw` CLI snippet this app already emits, and the adjacent claw-app rename in #1572).

Technical identifiers are deliberately left untouched — no API/type churn: `BrowserOS*` TypeScript types, the `browseros-onboarding` bridge/api module names, the `openBrowserOsNewTab` navigation into Chromium's new-tab page, `@browseros/*` imports, copyright headers, and the `styles.css` token comments.

Kept minimal so it lands cleanly alongside the concurrent `feat/import-item-checkboxes` picker rewrite (touches the same ImportStep copy lines).

## Test plan
- [x] `bun run --filter @browseros/claw-onboard test` — 60 pass / 0 fail
- [x] `bun run --filter @browseros/claw-onboard build` — `tsc --noEmit` + vite build green
- [x] `bun run --filter @browseros/claw-onboard lint` — clean
- [x] Headless screenshot of the onboarding rail confirms the wordmark now renders "BrowserClaw"

🤖 Generated with [Claude Code](https://claude.com/claude-code)