### PR TITLE
fix(ci): point internal-docs sync at main, dev branch is gone

### DIFF
--- a/.github/workflows/bos-build-tests.yml
+++ b/.github/workflows/bos-build-tests.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - dev
     paths:
       - "packages/browseros/bos_build/**"
       - "packages/browseros/tools/vendor_uploads/**"

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - dev
       - feat/claw-server-bootstrap
     paths:
       - "packages/browseros-agent/**"

--- a/.github/workflows/sync-internal-docs.yml
+++ b/.github/workflows/sync-internal-docs.yml
@@ -11,7 +11,7 @@ concurrency:
 
 jobs:
   sync:
-    name: Bump internal-docs submodule pointer on dev
+    name: Bump internal-docs submodule pointer on main
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -26,7 +26,7 @@ jobs:
         with:
           token: ${{ secrets.INTERNAL_DOCS_SYNC_TOKEN }}
           submodules: true
-          ref: dev
+          ref: main
           fetch-depth: 50
 
       - name: Open auto-merge PR if internal-docs has new commits
@@ -42,7 +42,7 @@ jobs:
           fi
 
           EXISTING_PR_URL=$(gh pr list \
-            --base dev \
+            --base main \
             --state open \
             --json headRefName,url \
             --jq '[.[] | select(.headRefName | startswith("bot/sync-internal-docs-")) | .url][0] // ""')
@@ -78,7 +78,7 @@ jobs:
           CLEANUP_BRANCH=1
 
           PR_URL=$(gh pr create \
-            --base dev \
+            --base main \
             --head "$BRANCH" \
             --title "chore: sync internal-docs submodule" \
             --body "Automated bump of the \`.internal-docs\` submodule pointer. Auto-merging.")


### PR DESCRIPTION
Every scheduled run of `sync-internal-docs.yml` has been failing at the checkout step with **"A branch or tag with the name 'dev' could not be found"** — the workflow still targets the removed `dev` branch (checkout ref, `gh pr list --base`, `gh pr create --base`).

This repoints all of them at `main`, the current default branch. No logic changes.

Verified: last 5 scheduled runs all failed at the same step (run 28718451951 and earlier); `git ls-remote` confirms no `dev` head exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HeZKoAHyhGFYi47Wq4T59w