### PR TITLE
feat: auto-annotate bpatch refresh

### DIFF
--- a/packages/browseros/tools/patch/cmd/apply.go
+++ b/packages/browseros/tools/patch/cmd/apply.go
@@ -64,11 +64,11 @@ func init() {
 					}
 					fmt.Println(ui.Hint(`Run "browseros-patch continue" after fixing the current conflict.`))
 				}
-				printAnnotateOutcome(ws, result)
+				printAnnotateOutcome(ws, &result.AnnotationOutcome, "Patches applied")
 			}); err != nil {
 				return err
 			}
-			if err := annotateFailureExit(result); err != nil {
+			if err := annotateFailureExit(&result.AnnotationOutcome); err != nil {
 				return err
 			}
 			return conflictPauseError(len(result.Conflicts) > 0)

--- a/packages/browseros/tools/patch/cmd/common.go
+++ b/packages/browseros/tools/patch/cmd/common.go
@@ -54,7 +54,7 @@ Rules:
 - Checkout commands work from anywhere when passed a checkout name: browseros-patch diff ch1.
 - browseros-patch list reads only registered Chromium checkouts; it does not inspect sync state.
 - Use browseros-patch status ch1 or browseros-patch diff ch1 before mutating.
-- Mutating commands: browseros-patch sync ch1 (alias: pull), browseros-patch apply ch1, browseros-patch extract ch1, browseros-patch annotate ch1.
+- Mutating commands: browseros-patch sync ch1 (alias: pull), browseros-patch apply ch1, browseros-patch refresh ch1, browseros-patch extract ch1, browseros-patch annotate ch1.
 - Pool commands: browseros-patch refresh ch1 rebuilds the local browseros branch as feature commits from canonical patches.
 - Feature registration commands: browseros-patch feature lint validates patch ownership; browseros-patch feature add registers a newly extracted task range.
 - Every command accepts --json for machine-readable output and never prompts.
@@ -83,17 +83,19 @@ Capture flow (turn checkout changes into patches):
 
 Feature commit flow (turn checkout changes into feature commits):
 1. browseros-patch apply ch1               # auto-annotates after a conflict-free apply (--no-annotate to skip)
-2. browseros-patch annotate ch1            # standalone: commit changed files for all bos_build/features.yaml features
+2. browseros-patch refresh ch1             # rebuilds browseros, then auto-annotates local changes (--no-annotate to skip)
+3. browseros-patch annotate ch1            # standalone: commit changed files for all bos_build/features.yaml features
 Annotation rules:
 - Filtered (-- files...) and --changed applies never auto-annotate; continue/skip finish a paused apply's annotation, excluding skipped conflicts.
-- apply, sync, and annotate refuse to start while a conflict resolution is pending; finish continue/skip/abort first.
+- apply, sync, refresh, and annotate refuse to start while a conflict resolution is pending; finish continue/skip/abort first.
 - Changes no feature claims are reported as "unclaimed" and left uncommitted; claim them in bos_build/features.yaml.
 
 Pool refresh flow (rebuild browseros branch before leasing a checkout):
 1. browseros-patch status ch1 --json       # check patches_freshness
-2. browseros-patch refresh ch1             # pull patch repo, rebuild browseros from BASE_COMMIT + features
+2. browseros-patch refresh ch1             # pull patch repo, rebuild browseros from BASE_COMMIT + features, auto-annotate local changes
 3. result "fresh" means the browseros tip already carries the current Patches-Rev trailer
-4. use --force only to abandon tracked state or a task/* lease; untracked files and out/ are left alone
+4. use --no-annotate to leave restored local changes dirty instead of committing them
+5. use --force only to abandon tracked state or a task/* lease; untracked files and out/ are left alone
 
 After extracting a task branch:
 1. browseros-patch extract ch1 --range browseros..task/my-feature --squash
@@ -135,28 +137,29 @@ func ensureRepoConfigured(override string) error {
 	return nil
 }
 
-// printAnnotateOutcome renders the auto-annotate section of an apply-family
-// result: the feature-commit summary on success, a recovery hint on failure.
-func printAnnotateOutcome(ws workspace.Entry, result *engine.ApplyResult) {
-	if result.Annotate != nil {
+// printAnnotateOutcome renders the auto-annotate section of a mutating
+// command result: the feature-commit summary on success, a recovery hint on
+// failure.
+func printAnnotateOutcome(ws workspace.Entry, outcome *engine.AnnotationOutcome, completedLabel string) {
+	if outcome.Annotate != nil {
 		fmt.Println()
-		printAnnotateResult(ws, result.Annotate)
+		printAnnotateResult(ws, outcome.Annotate)
 	}
-	if result.AnnotateSkipped != "" {
-		fmt.Println(ui.Hint(fmt.Sprintf("Annotation skipped: %s.", result.AnnotateSkipped)))
+	if outcome.AnnotateSkipped != "" {
+		fmt.Println(ui.Hint(fmt.Sprintf("Annotation skipped: %s.", outcome.AnnotateSkipped)))
 	}
-	if result.AnnotateError != "" {
-		fmt.Println(ui.Warning("Patches applied, but annotate failed"))
-		fmt.Printf("  %s\n", result.AnnotateError)
+	if outcome.AnnotateError != "" {
+		fmt.Println(ui.Warning(fmt.Sprintf("%s, but annotate failed", completedLabel)))
+		fmt.Printf("  %s\n", outcome.AnnotateError)
 		fmt.Println(ui.Hint(fmt.Sprintf(`Fix the cause, then run "browseros-patch annotate %s".`, ws.Name)))
 	}
 }
 
 // annotateFailureExit maps an auto-annotate failure to exit 1 after rendering,
-// so scripts notice the missing feature commits while the apply outcome stays
-// visible in the output.
-func annotateFailureExit(result *engine.ApplyResult) error {
-	if result.AnnotateError != "" {
+// so scripts notice the missing feature commits while the main command outcome
+// stays visible in the output.
+func annotateFailureExit(outcome *engine.AnnotationOutcome) error {
+	if outcome.AnnotateError != "" {
 		return &exitCodeError{code: 1}
 	}
 	return nil

--- a/packages/browseros/tools/patch/cmd/common_test.go
+++ b/packages/browseros/tools/patch/cmd/common_test.go
@@ -458,6 +458,20 @@ func TestSrcFlagExplainsDirectCheckoutPath(t *testing.T) {
 	}
 }
 
+func TestRefreshNoAnnotateFlagDocumentsOptOut(t *testing.T) {
+	cmd, _, err := rootCmd.Find([]string{"refresh"})
+	if err != nil {
+		t.Fatalf("find refresh: %v", err)
+	}
+	flag := cmd.Flags().Lookup("no-annotate")
+	if flag == nil {
+		t.Fatalf("refresh missing --no-annotate flag")
+	}
+	if !strings.Contains(flag.Usage, "annotation") {
+		t.Fatalf("refresh --no-annotate usage should explain annotation opt-out, got %q", flag.Usage)
+	}
+}
+
 func TestLLMTxtGuideContent(t *testing.T) {
 	text := llmTxtGuide()
 	for _, want := range []string{
@@ -471,8 +485,12 @@ func TestLLMTxtGuideContent(t *testing.T) {
 		"browseros-patch status ch1",
 		"browseros-patch sync ch1",
 		"browseros-patch apply ch1",
+		"browseros-patch refresh ch1",
 		"browseros-patch extract ch1",
 		"browseros-patch annotate ch1",
+		"auto-annotate local changes",
+		"--no-annotate",
+		"apply, sync, refresh, and annotate refuse",
 		"list reads only registered Chromium checkouts",
 		"does not inspect sync state",
 		// agent playbook

--- a/packages/browseros/tools/patch/cmd/continue.go
+++ b/packages/browseros/tools/patch/cmd/continue.go
@@ -35,12 +35,12 @@ func init() {
 						fmt.Printf("  %s\n", conflict.ChromiumPath)
 					}
 				}
-				printAnnotateOutcome(ws, result)
+				printAnnotateOutcome(ws, &result.AnnotationOutcome, "Patches applied")
 				printStashOutcome(result)
 			}); err != nil {
 				return err
 			}
-			if err := annotateFailureExit(result); err != nil {
+			if err := annotateFailureExit(&result.AnnotationOutcome); err != nil {
 				return err
 			}
 			return conflictPauseError(len(result.Conflicts) > 0 || result.StashConflict)

--- a/packages/browseros/tools/patch/cmd/refresh.go
+++ b/packages/browseros/tools/patch/cmd/refresh.go
@@ -14,12 +14,14 @@ func init() {
 	var force bool
 	var remote string
 	var noPull bool
+	var noAnnotate bool
 	command := &cobra.Command{
 		Use:         "refresh [checkout]",
 		Annotations: map[string]string{"group": "Core:"},
 		Short:       "Rebuild a checkout's browseros branch from canonical patches",
 		Example: `  browseros-patch refresh ch1
   browseros-patch refresh ch1 --force
+  browseros-patch refresh ch1 --no-annotate
   browseros-patch refresh --src /path/to/chromium/src`,
 		Args: cobra.MaximumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -36,20 +38,23 @@ func init() {
 			err = withPatchRepoLock(cmd, info, progress, func(lockedInfo *repo.Info) error {
 				var refreshErr error
 				result, refreshErr = engine.Refresh(cmd.Context(), engine.RefreshOptions{
-					Workspace: ws,
-					Repo:      lockedInfo,
-					Remote:    remote,
-					Force:     force,
-					Pull:      !noPull,
-					Progress:  progress,
+					Workspace:    ws,
+					Repo:         lockedInfo,
+					Remote:       remote,
+					Force:        force,
+					Pull:         !noPull,
+					AutoAnnotate: !noAnnotate,
+					Progress:     progress,
 				})
 				return refreshErr
 			})
 			if err != nil {
 				return err
 			}
-			return renderResult(result, func() {
-				if result.Result == "fresh" {
+			if err := renderResult(result, func() {
+				if result.StashConflict {
+					fmt.Println(ui.Warning(fmt.Sprintf("Refresh paused for %s", ws.Name)))
+				} else if result.Result == "fresh" {
 					fmt.Println(ui.Success(fmt.Sprintf("%s is fresh", ws.Name)))
 				} else {
 					fmt.Println(ui.Title(fmt.Sprintf("Refreshed %s", ws.Name)))
@@ -66,12 +71,30 @@ func init() {
 						fmt.Printf("  %-24s %s  %d %s\n", commit.Feature, shortCommit(commit.Commit), len(commit.Files), pluralFiles(len(commit.Files)))
 					}
 				}
-			})
+				switch {
+				case result.StashRestored:
+					fmt.Println(ui.Success("Local changes rebased on top of the refreshed patches."))
+				case result.StashConflict:
+					fmt.Println(ui.Warning("Local changes conflict with the refreshed patches"))
+					for _, file := range result.StashConflictFiles {
+						fmt.Printf("  %s\n", file)
+					}
+					fmt.Println(ui.Hint(`Resolve the conflicted files (markers, or restored content for delete conflicts), then "git stash drop" in the checkout.`))
+				}
+				printAnnotateOutcome(ws, &result.AnnotationOutcome, "Refresh completed")
+			}); err != nil {
+				return err
+			}
+			if err := annotateFailureExit(&result.AnnotationOutcome); err != nil {
+				return err
+			}
+			return conflictPauseError(result.StashConflict)
 		},
 	}
 	command.Flags().StringVar(&src, "src", "", srcFlagUsage)
 	command.Flags().BoolVar(&force, "force", false, "Abandon tracked checkout state before rebuilding")
 	command.Flags().BoolVar(&noPull, "no-pull", false, "Use the local patch repo state without pulling first")
+	command.Flags().BoolVar(&noAnnotate, "no-annotate", false, "Skip feature-commit annotation after refresh")
 	command.Flags().StringVar(&remote, "remote", "origin", "Remote to pull patch repo updates from")
 	rootCmd.AddCommand(command)
 }

--- a/packages/browseros/tools/patch/cmd/root.go
+++ b/packages/browseros/tools/patch/cmd/root.go
@@ -99,6 +99,7 @@ Pass a checkout name to run from anywhere, for example "browseros-patch diff ch1
 		"  browseros-patch sync ch1\n" +
 		"  browseros-patch extract ch1\n" +
 		"  browseros-patch refresh ch1\n" +
+		"  browseros-patch refresh ch1 --no-annotate\n" +
 		"  browseros-patch feature lint",
 	Version:       Version,
 	SilenceUsage:  true,

--- a/packages/browseros/tools/patch/cmd/skip.go
+++ b/packages/browseros/tools/patch/cmd/skip.go
@@ -35,12 +35,12 @@ func init() {
 						fmt.Printf("  %s\n", conflict.ChromiumPath)
 					}
 				}
-				printAnnotateOutcome(ws, result)
+				printAnnotateOutcome(ws, &result.AnnotationOutcome, "Patches applied")
 				printStashOutcome(result)
 			}); err != nil {
 				return err
 			}
-			if err := annotateFailureExit(result); err != nil {
+			if err := annotateFailureExit(&result.AnnotationOutcome); err != nil {
 				return err
 			}
 			return conflictPauseError(len(result.Conflicts) > 0 || result.StashConflict)

--- a/packages/browseros/tools/patch/internal/engine/annotate.go
+++ b/packages/browseros/tools/patch/internal/engine/annotate.go
@@ -15,6 +15,9 @@ import (
 type AnnotateOptions struct {
 	Workspace workspace.Entry
 	Repo      *repo.Info
+	// Include limits annotation to these checkout paths. Nil means all
+	// eligible working-tree changes.
+	Include []string
 	// Exclude lists checkout paths deliberately left uncommitted — skipped
 	// conflicts whose files may hold partially applied hunks.
 	Exclude []string
@@ -81,7 +84,7 @@ func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error
 	// Chromium checkout. Each feature consumes the entries it matched —
 	// commitFeatureFiles settles them (committed, or staged clean) — so what
 	// remains at the end is exactly the unclaimed leftovers.
-	changes, err := annotateChanges(ctx, opts.Workspace.Path, ignore, opts.Exclude)
+	changes, err := annotateChanges(ctx, opts.Workspace.Path, ignore, opts.Include, opts.Exclude)
 	if err != nil {
 		return nil, err
 	}
@@ -182,8 +185,8 @@ func stringSequence(node *yaml.Node, key string) []string {
 // Untracked junk (reject files, logs, .browseros-patchignore patterns) is
 // filtered like extract does; tracked modifications always pass through
 // unless explicitly excluded.
-func annotateChanges(ctx context.Context, workspacePath string, ignore *patch.IgnoreSet, exclude []string) ([]git.FileChange, error) {
-	changes, err := git.StatusPorcelain(ctx, workspacePath, nil)
+func annotateChanges(ctx context.Context, workspacePath string, ignore *patch.IgnoreSet, include []string, exclude []string) ([]git.FileChange, error) {
+	changes, err := git.StatusPorcelain(ctx, workspacePath, include)
 	if err != nil {
 		return nil, err
 	}

--- a/packages/browseros/tools/patch/internal/engine/annotate.go
+++ b/packages/browseros/tools/patch/internal/engine/annotate.go
@@ -17,8 +17,11 @@ type AnnotateOptions struct {
 	Repo      *repo.Info
 	// Exclude lists checkout paths deliberately left uncommitted — skipped
 	// conflicts whose files may hold partially applied hunks.
-	Exclude  []string
-	Progress Progress
+	Exclude []string
+	// CommitBody is appended to every feature commit. Refresh uses this to
+	// keep the browseros branch carrying its materialized Patches-Rev trailer.
+	CommitBody string
+	Progress   Progress
 }
 
 type AnnotateResult struct {
@@ -105,7 +108,7 @@ func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error
 			result.FeaturesSkipped++
 			continue
 		}
-		commit, committedFiles, committed, err := commitFeatureFiles(ctx, opts.Workspace.Path, feature.Description, files.stage, files.commit)
+		commit, committedFiles, committed, err := commitFeatureFiles(ctx, opts.Workspace.Path, feature.Description, opts.CommitBody, files.stage, files.commit)
 		if err != nil {
 			return nil, fmt.Errorf("commit feature %s: %w", feature.Name, err)
 		}
@@ -304,7 +307,7 @@ func appendUniquePath(paths *[]string, seen map[string]bool, rel string) {
 }
 
 // commitFeatureFiles normalizes selected paths into the index and commits only real HEAD deltas.
-func commitFeatureFiles(ctx context.Context, workspacePath string, message string, stagePaths []string, commitPaths []string) (string, []string, bool, error) {
+func commitFeatureFiles(ctx context.Context, workspacePath string, message string, body string, stagePaths []string, commitPaths []string) (string, []string, bool, error) {
 	if err := git.AddAllPaths(ctx, workspacePath, stagePaths); err != nil {
 		return "", nil, false, err
 	}
@@ -315,7 +318,7 @@ func commitFeatureFiles(ctx context.Context, workspacePath string, message strin
 	if !dirty {
 		return "", nil, false, nil
 	}
-	commit, err := git.CommitPaths(ctx, workspacePath, message, commitPaths)
+	commit, err := git.CommitPathsWithBody(ctx, workspacePath, message, body, commitPaths)
 	if err != nil {
 		return "", nil, false, err
 	}

--- a/packages/browseros/tools/patch/internal/engine/apply.go
+++ b/packages/browseros/tools/patch/internal/engine/apply.go
@@ -34,6 +34,17 @@ type ApplyOptions struct {
 	Progress     Progress
 }
 
+type AnnotationOutcome struct {
+	Annotate *AnnotateResult `json:"annotate,omitempty"`
+	// AnnotateError reports an auto-annotate failure without discarding the
+	// main command outcome: the patches landed and state is already settled,
+	// so the recovery is a standalone annotate, not a retry.
+	AnnotateError string `json:"annotate_error,omitempty"`
+	// AnnotateSkipped names why auto-annotate did not run, so a missing
+	// annotate section is explained.
+	AnnotateSkipped string `json:"annotate_skipped,omitempty"`
+}
+
 type ApplyResult struct {
 	Workspace          string              `json:"workspace"`
 	Mode               string              `json:"mode"`
@@ -46,14 +57,7 @@ type ApplyResult struct {
 	StashConflict      bool                `json:"stash_conflict,omitempty"`
 	StashConflictFiles []string            `json:"stash_conflict_files,omitempty"`
 	Conflicts          []resolve.Operation `json:"conflicts,omitempty"`
-	Annotate           *AnnotateResult     `json:"annotate,omitempty"`
-	// AnnotateError reports an auto-annotate failure without discarding the
-	// apply outcome: the patches landed and the resolve state is already
-	// settled, so the recovery is a standalone annotate, not a retry.
-	AnnotateError string `json:"annotate_error,omitempty"`
-	// AnnotateSkipped names why auto-annotate did not run (no features
-	// registry, pending stash) so a missing annotate section is explained.
-	AnnotateSkipped string `json:"annotate_skipped,omitempty"`
+	AnnotationOutcome
 }
 
 func Apply(ctx context.Context, opts ApplyOptions) (*ApplyResult, error) {
@@ -142,7 +146,7 @@ func finishApply(ctx context.Context, opts ApplyOptions, repoRev string, result 
 	if !opts.AutoAnnotate {
 		return nil
 	}
-	annotateApplied(ctx, opts.Workspace, opts.Repo, nil, result, opts.Progress)
+	annotateApplied(ctx, opts.Workspace, opts.Repo, nil, &result.AnnotationOutcome, opts.Progress)
 	return nil
 }
 
@@ -154,29 +158,34 @@ func finishApply(ctx context.Context, opts ApplyOptions, repoRev string, result 
 // sit in the stash, not the worktree, so the tree is pure patches and annotate
 // commits them correctly; the shared guard blocks the unsafe case (conflict
 // markers from a stash rebase) inside Annotate.
-func annotateApplied(ctx context.Context, ws workspace.Entry, repoInfo *repo.Info, exclude []string, result *ApplyResult, progress Progress) {
+func annotateApplied(ctx context.Context, ws workspace.Entry, repoInfo *repo.Info, exclude []string, outcome *AnnotationOutcome, progress Progress) {
+	annotateWorkspaceChanges(ctx, ws, repoInfo, exclude, outcome, progress, "")
+}
+
+func annotateWorkspaceChanges(ctx context.Context, ws workspace.Entry, repoInfo *repo.Info, exclude []string, outcome *AnnotationOutcome, progress Progress, commitBody string) {
 	if _, err := FeatureFilePath(repoInfo.Root); err != nil {
-		result.AnnotateSkipped = "no features registry"
+		outcome.AnnotateSkipped = "no features registry"
 		return
 	}
 	annotateResult, err := Annotate(ctx, AnnotateOptions{
-		Workspace: ws,
-		Repo:      repoInfo,
-		Exclude:   exclude,
-		Progress:  progress,
+		Workspace:  ws,
+		Repo:       repoInfo,
+		Exclude:    exclude,
+		CommitBody: commitBody,
+		Progress:   progress,
 	})
 	if err != nil {
-		result.AnnotateError = err.Error()
+		outcome.AnnotateError = err.Error()
 		if len(exclude) > 0 {
 			// A standalone annotate would not know about these: warn before
 			// the user follows the recovery hint and sweeps them in.
-			result.AnnotateError += fmt.Sprintf(
+			outcome.AnnotateError += fmt.Sprintf(
 				"; skipped conflicts remain uncommitted (%s) — resolve or reset them before annotating",
 				strings.Join(exclude, ", "))
 		}
 		return
 	}
-	result.Annotate = annotateResult
+	outcome.Annotate = annotateResult
 }
 
 type ContinueOptions struct {
@@ -280,7 +289,7 @@ func finishResolvedRun(ctx context.Context, ws workspace.Entry, repoInfo *repo.I
 		return err
 	}
 	if state.AutoAnnotate {
-		annotateApplied(ctx, ws, repoInfo, skippedExcludePaths(state), result, progress)
+		annotateApplied(ctx, ws, repoInfo, skippedExcludePaths(state), &result.AnnotationOutcome, progress)
 	}
 	if state.RestorePendingStash {
 		if err := restorePendingStash(ctx, ws.Path, result, progress); err != nil {

--- a/packages/browseros/tools/patch/internal/engine/apply.go
+++ b/packages/browseros/tools/patch/internal/engine/apply.go
@@ -113,6 +113,9 @@ func requireNoPendingResolution(ctx context.Context, ws workspace.Entry) error {
 			"conflict resolution is in progress for %s; finish it with \"browseros-patch continue\", \"browseros-patch skip\", or \"browseros-patch abort\" first",
 			ws.Name)
 	}
+	if err := requireNoPendingStashConflict(ctx, ws); err != nil {
+		return err
+	}
 	unmerged, err := git.UnmergedFiles(ctx, ws.Path)
 	if err != nil {
 		return err
@@ -132,6 +135,35 @@ func requireNoPendingResolution(ctx context.Context, ws workspace.Entry) error {
 			ws.Name, strings.Join(markers, ", "))
 	}
 	return nil
+}
+
+func requireNoPendingStashConflict(ctx context.Context, ws workspace.Entry) error {
+	state, err := workspace.LoadState(ws.Path)
+	if err != nil {
+		return err
+	}
+	if !state.PendingStashConflict {
+		return nil
+	}
+	if state.PendingStash != "" {
+		live, err := git.StashEntryExists(ctx, ws.Path, state.PendingStash)
+		if err != nil {
+			return err
+		}
+		if live {
+			files := strings.Join(state.PendingStashConflictFiles, ", ")
+			if files == "" {
+				files = "unknown files"
+			}
+			return fmt.Errorf(
+				"%s has unresolved stashed local changes (%s); resolve them, then \"git stash drop\" before running this command",
+				ws.Name, files)
+		}
+	}
+	state.PendingStash = ""
+	state.PendingStashConflict = false
+	state.PendingStashConflictFiles = nil
+	return workspace.SaveState(ws.Path, state)
 }
 
 // finishApply records completion state and, when requested, turns the applied
@@ -159,10 +191,10 @@ func finishApply(ctx context.Context, opts ApplyOptions, repoRev string, result 
 // commits them correctly; the shared guard blocks the unsafe case (conflict
 // markers from a stash rebase) inside Annotate.
 func annotateApplied(ctx context.Context, ws workspace.Entry, repoInfo *repo.Info, exclude []string, outcome *AnnotationOutcome, progress Progress) {
-	annotateWorkspaceChanges(ctx, ws, repoInfo, exclude, outcome, progress, "")
+	annotateWorkspaceChanges(ctx, ws, repoInfo, nil, exclude, outcome, progress, "")
 }
 
-func annotateWorkspaceChanges(ctx context.Context, ws workspace.Entry, repoInfo *repo.Info, exclude []string, outcome *AnnotationOutcome, progress Progress, commitBody string) {
+func annotateWorkspaceChanges(ctx context.Context, ws workspace.Entry, repoInfo *repo.Info, include []string, exclude []string, outcome *AnnotationOutcome, progress Progress, commitBody string) {
 	if _, err := FeatureFilePath(repoInfo.Root); err != nil {
 		outcome.AnnotateSkipped = "no features registry"
 		return
@@ -170,6 +202,7 @@ func annotateWorkspaceChanges(ctx context.Context, ws workspace.Entry, repoInfo 
 	annotateResult, err := Annotate(ctx, AnnotateOptions{
 		Workspace:  ws,
 		Repo:       repoInfo,
+		Include:    include,
 		Exclude:    exclude,
 		CommitBody: commitBody,
 		Progress:   progress,

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -2000,12 +2000,17 @@ features:
     description: "feat: local"
     files:
       - chrome/local.cc
+  untracked:
+    description: "feat: untracked"
+    files:
+      - chrome/untracked.cc
 `)
 	runGit(t, repoInfo.Root, "add", "chromium_patches", "bos_build/features.yaml")
 	runGit(t, repoInfo.Root, "commit", "-m", "patch stack")
 	repoHead := gitOutput(t, repoInfo.Root, "rev-parse", "HEAD")
 
 	writeFile(t, filepath.Join(workspacePath, "chrome", "local.cc"), "local changed\n")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "untracked.cc"), "do not sweep\n")
 	result, err := Refresh(ctx, RefreshOptions{
 		Workspace:    workspace.Entry{Name: "ws", Path: workspacePath},
 		Repo:         repoInfo,
@@ -2024,8 +2029,11 @@ features:
 	if !slices.Equal(result.Annotate.Committed[0].Files, []string{"chrome/local.cc"}) {
 		t.Fatalf("expected local file committed, got %v", result.Annotate.Committed[0].Files)
 	}
-	if status := gitOutput(t, workspacePath, "status", "--porcelain", "--", "chrome"); status != "" {
-		t.Fatalf("expected clean checkout after annotate, got %q", status)
+	if status := gitOutput(t, workspacePath, "status", "--porcelain", "--", "chrome/local.cc"); status != "" {
+		t.Fatalf("expected tracked local file clean after annotate, got %q", status)
+	}
+	if status := gitOutput(t, workspacePath, "status", "--porcelain", "--", "chrome/untracked.cc"); status != "?? chrome/untracked.cc" {
+		t.Fatalf("untracked file should stay out of refresh annotation, got %q", status)
 	}
 	if subject := gitOutput(t, workspacePath, "log", "-1", "--format=%s"); subject != "feat: local" {
 		t.Fatalf("unexpected HEAD subject %q", subject)
@@ -2045,6 +2053,51 @@ features:
 	}
 	if fresh.Result != "fresh" || fresh.Annotate != nil {
 		t.Fatalf("expected clean second refresh to stay a plain fresh no-op, got %+v", fresh)
+	}
+}
+
+func TestRefreshDoesNotAnnotateUntrackedOnlyChanges(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "a.cc"), "a base\n")
+	runGit(t, workspacePath, "add", "chrome/a.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writePatchFromEdit(t, ctx, workspacePath, repoInfo, baseCommit, "chrome/a.cc", "a patched\n")
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  canonical:
+    description: "feat: canonical"
+    files:
+      - chrome/a.cc
+  untracked:
+    description: "feat: untracked"
+    files:
+      - chrome/untracked.cc
+`)
+	runGit(t, repoInfo.Root, "add", "chromium_patches", "bos_build/features.yaml")
+	runGit(t, repoInfo.Root, "commit", "-m", "patch stack")
+
+	writeFile(t, filepath.Join(workspacePath, "chrome", "untracked.cc"), "local untracked\n")
+	result, err := Refresh(ctx, RefreshOptions{
+		Workspace:    workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:         repoInfo,
+		AutoAnnotate: true,
+		Pull:         false,
+	})
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if result.Annotate != nil {
+		t.Fatalf("untracked-only refresh must not auto-annotate, got %+v", result.Annotate)
+	}
+	if status := gitOutput(t, workspacePath, "status", "--porcelain", "--", "chrome/untracked.cc"); status != "?? chrome/untracked.cc" {
+		t.Fatalf("untracked file should stay uncommitted, got %q", status)
+	}
+	if subject := gitOutput(t, workspacePath, "log", "-1", "--format=%s"); subject != "feat: canonical" {
+		t.Fatalf("unexpected HEAD subject %q", subject)
 	}
 }
 
@@ -2091,6 +2144,66 @@ features:
 	}
 	if subject := gitOutput(t, workspacePath, "log", "-1", "--format=%s"); subject != "feat: canonical" {
 		t.Fatalf("unexpected HEAD subject %q", subject)
+	}
+}
+
+func TestRefreshStashConflictBlocksFollowupCommands(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	rel := "chrome/local.cc"
+	writeFile(t, filepath.Join(workspacePath, rel), "base\n")
+	runGit(t, workspacePath, "add", rel)
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	if err := os.Remove(filepath.Join(workspacePath, rel)); err != nil {
+		t.Fatalf("remove %s: %v", rel, err)
+	}
+	diff, err := git.DiffText(ctx, workspacePath, baseCommit, "--", rel)
+	if err != nil {
+		t.Fatalf("DiffText delete: %v", err)
+	}
+	writeFile(t, filepath.Join(repoInfo.PatchesDir, filepath.FromSlash(rel)), diff)
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  deleted:
+    description: "feat: delete local"
+    files:
+      - chrome/local.cc
+`)
+	runGit(t, repoInfo.Root, "add", "chromium_patches", "bos_build/features.yaml")
+	runGit(t, repoInfo.Root, "commit", "-m", "delete patch")
+	runGit(t, workspacePath, "checkout", baseCommit, "--", rel)
+
+	writeFile(t, filepath.Join(workspacePath, rel), "local edit\n")
+	ws := workspace.Entry{Name: "ws", Path: workspacePath}
+	result, err := Refresh(ctx, RefreshOptions{
+		Workspace:    ws,
+		Repo:         repoInfo,
+		AutoAnnotate: true,
+		Pull:         false,
+	})
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if !result.StashConflict || result.AnnotateSkipped == "" {
+		t.Fatalf("expected refresh stash conflict and annotation skip, got %+v", result)
+	}
+	state, err := workspace.LoadState(workspacePath)
+	if err != nil {
+		t.Fatalf("LoadState: %v", err)
+	}
+	if !state.PendingStashConflict || state.PendingStash == "" {
+		t.Fatalf("expected pending stash conflict recorded, got %+v", state)
+	}
+	if _, err := Annotate(ctx, AnnotateOptions{Workspace: ws, Repo: repoInfo}); err == nil || !strings.Contains(err.Error(), "unresolved stashed local changes") {
+		t.Fatalf("expected annotate to refuse pending stash conflict, got %v", err)
+	}
+
+	runGit(t, workspacePath, "stash", "drop")
+	if _, err := Annotate(ctx, AnnotateOptions{Workspace: ws, Repo: repoInfo}); err != nil {
+		t.Fatalf("expected stale pending stash conflict record to clear after stash drop, got %v", err)
 	}
 }
 

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -888,6 +888,9 @@ func TestApplyRefusesDuringConflictResolution(t *testing.T) {
 	if _, err := Sync(ctx, SyncOptions{Workspace: ws, Repo: repoInfo}); err == nil || !strings.Contains(err.Error(), "conflict resolution is in progress") {
 		t.Fatalf("expected sync to refuse during pending resolution, got %v", err)
 	}
+	if _, err := Refresh(ctx, RefreshOptions{Workspace: ws, Repo: repoInfo, Pull: false}); err == nil || !strings.Contains(err.Error(), "conflict resolution is in progress") {
+		t.Fatalf("expected refresh to refuse during pending resolution, got %v", err)
+	}
 	if !resolve.Exists(workspacePath) {
 		t.Fatalf("pending resolve state must survive the refused runs")
 	}
@@ -1973,6 +1976,121 @@ features:
 	assertFile(t, filepath.Join(workspacePath, "scratch.txt"), "keep me\n")
 	if got := gitOutput(t, workspacePath, "branch", "--show-current"); got != "browseros" {
 		t.Fatalf("branch = %q, want browseros", got)
+	}
+}
+
+func TestRefreshAutoAnnotatesPreservedLocalTrackedChanges(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "a.cc"), "a base\n")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "local.cc"), "local base\n")
+	runGit(t, workspacePath, "add", "chrome")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writePatchFromEdit(t, ctx, workspacePath, repoInfo, baseCommit, "chrome/a.cc", "a patched\n")
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  canonical:
+    description: "feat: canonical"
+    files:
+      - chrome/a.cc
+  local:
+    description: "feat: local"
+    files:
+      - chrome/local.cc
+`)
+	runGit(t, repoInfo.Root, "add", "chromium_patches", "bos_build/features.yaml")
+	runGit(t, repoInfo.Root, "commit", "-m", "patch stack")
+	repoHead := gitOutput(t, repoInfo.Root, "rev-parse", "HEAD")
+
+	writeFile(t, filepath.Join(workspacePath, "chrome", "local.cc"), "local changed\n")
+	result, err := Refresh(ctx, RefreshOptions{
+		Workspace:    workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:         repoInfo,
+		AutoAnnotate: true,
+		Pull:         false,
+	})
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if result.Annotate == nil || result.Annotate.CommitsCreated != 1 {
+		t.Fatalf("expected one auto-annotate commit, got %+v", result.Annotate)
+	}
+	if result.Annotate.Committed[0].Name != "local" {
+		t.Fatalf("expected local feature commit, got %+v", result.Annotate.Committed)
+	}
+	if !slices.Equal(result.Annotate.Committed[0].Files, []string{"chrome/local.cc"}) {
+		t.Fatalf("expected local file committed, got %v", result.Annotate.Committed[0].Files)
+	}
+	if status := gitOutput(t, workspacePath, "status", "--porcelain", "--", "chrome"); status != "" {
+		t.Fatalf("expected clean checkout after annotate, got %q", status)
+	}
+	if subject := gitOutput(t, workspacePath, "log", "-1", "--format=%s"); subject != "feat: local" {
+		t.Fatalf("unexpected HEAD subject %q", subject)
+	}
+	if body := gitOutput(t, workspacePath, "log", "-1", "--format=%B"); !strings.Contains(body, "Patches-Rev: "+repoHead) {
+		t.Fatalf("auto-annotate commit should preserve refresh trailer:\n%s", body)
+	}
+
+	fresh, err := Refresh(ctx, RefreshOptions{
+		Workspace:    workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:         repoInfo,
+		AutoAnnotate: true,
+		Pull:         false,
+	})
+	if err != nil {
+		t.Fatalf("second Refresh: %v", err)
+	}
+	if fresh.Result != "fresh" || fresh.Annotate != nil {
+		t.Fatalf("expected clean second refresh to stay a plain fresh no-op, got %+v", fresh)
+	}
+}
+
+func TestRefreshNoAnnotateRestoresLocalChangesDirty(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "a.cc"), "a base\n")
+	writeFile(t, filepath.Join(workspacePath, "chrome", "local.cc"), "local base\n")
+	runGit(t, workspacePath, "add", "chrome")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writePatchFromEdit(t, ctx, workspacePath, repoInfo, baseCommit, "chrome/a.cc", "a patched\n")
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  canonical:
+    description: "feat: canonical"
+    files:
+      - chrome/a.cc
+  local:
+    description: "feat: local"
+    files:
+      - chrome/local.cc
+`)
+	runGit(t, repoInfo.Root, "add", "chromium_patches", "bos_build/features.yaml")
+	runGit(t, repoInfo.Root, "commit", "-m", "patch stack")
+
+	writeFile(t, filepath.Join(workspacePath, "chrome", "local.cc"), "local changed\n")
+	result, err := Refresh(ctx, RefreshOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+		Pull:      false,
+	})
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if result.Annotate != nil || result.AnnotateError != "" {
+		t.Fatalf("expected annotation disabled, got %+v / %q", result.Annotate, result.AnnotateError)
+	}
+	assertFile(t, filepath.Join(workspacePath, "chrome", "local.cc"), "local changed\n")
+	if status := gitOutput(t, workspacePath, "status", "--porcelain", "--", "chrome/local.cc"); status != "M chrome/local.cc" {
+		t.Fatalf("expected restored local file to stay dirty, got %q", status)
+	}
+	if subject := gitOutput(t, workspacePath, "log", "-1", "--format=%s"); subject != "feat: canonical" {
+		t.Fatalf("unexpected HEAD subject %q", subject)
 	}
 }
 

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -2101,6 +2101,109 @@ features:
 	}
 }
 
+func TestRefreshAutoAnnotatesLocalRename(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "old.cc"), "base\n")
+	runGit(t, workspacePath, "add", "chrome/old.cc")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  rename:
+    description: "feat: rename local"
+    files:
+      - chrome/old.cc
+      - chrome/new.cc
+`)
+	runGit(t, repoInfo.Root, "add", "bos_build/features.yaml")
+	runGit(t, repoInfo.Root, "commit", "-m", "feature registry")
+
+	runGit(t, workspacePath, "mv", "chrome/old.cc", "chrome/new.cc")
+	result, err := Refresh(ctx, RefreshOptions{
+		Workspace:    workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:         repoInfo,
+		AutoAnnotate: true,
+		Pull:         false,
+	})
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if result.Annotate == nil || result.Annotate.CommitsCreated != 1 {
+		t.Fatalf("expected rename auto-annotate commit, got %+v", result.Annotate)
+	}
+	if _, err := os.Stat(filepath.Join(workspacePath, "chrome", "old.cc")); !os.IsNotExist(err) {
+		t.Fatalf("old path should stay deleted after refresh rename annotation, stat err=%v", err)
+	}
+	assertFile(t, filepath.Join(workspacePath, "chrome", "new.cc"), "base\n")
+	if status := gitOutput(t, workspacePath, "status", "--porcelain", "--", "chrome"); status != "" {
+		t.Fatalf("expected clean checkout after rename annotate, got %q", status)
+	}
+	oldInParent, err := git.FileExistsAtCommit(ctx, workspacePath, "HEAD^", "chrome/old.cc")
+	if err != nil {
+		t.Fatalf("FileExistsAtCommit parent old: %v", err)
+	}
+	oldInHead, err := git.FileExistsAtCommit(ctx, workspacePath, "HEAD", "chrome/old.cc")
+	if err != nil {
+		t.Fatalf("FileExistsAtCommit head old: %v", err)
+	}
+	newInHead, err := git.FileExistsAtCommit(ctx, workspacePath, "HEAD", "chrome/new.cc")
+	if err != nil {
+		t.Fatalf("FileExistsAtCommit head new: %v", err)
+	}
+	if !oldInParent || oldInHead || !newInHead {
+		t.Fatalf("rename tree state parentOld=%v headOld=%v headNew=%v", oldInParent, oldInHead, newInHead)
+	}
+}
+
+func TestRefreshAutoAnnotatesModeOnlyChange(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	writeFile(t, filepath.Join(workspacePath, "chrome", "tool.sh"), "#!/bin/sh\n")
+	runGit(t, workspacePath, "add", "chrome/tool.sh")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  tool:
+    description: "feat: executable tool"
+    files:
+      - chrome/tool.sh
+`)
+	runGit(t, repoInfo.Root, "add", "bos_build/features.yaml")
+	runGit(t, repoInfo.Root, "commit", "-m", "feature registry")
+
+	if err := os.Chmod(filepath.Join(workspacePath, "chrome", "tool.sh"), 0o755); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	result, err := Refresh(ctx, RefreshOptions{
+		Workspace:    workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:         repoInfo,
+		AutoAnnotate: true,
+		Pull:         false,
+	})
+	if err != nil {
+		t.Fatalf("Refresh: %v", err)
+	}
+	if result.Annotate == nil || result.Annotate.CommitsCreated != 1 {
+		t.Fatalf("expected mode auto-annotate commit, got %+v", result.Annotate)
+	}
+	mode, err := git.FileModeAtCommit(ctx, workspacePath, "HEAD", "chrome/tool.sh")
+	if err != nil {
+		t.Fatalf("FileModeAtCommit: %v", err)
+	}
+	if mode != "100755" {
+		t.Fatalf("HEAD tool mode = %q, want 100755", mode)
+	}
+	if status := gitOutput(t, workspacePath, "status", "--porcelain", "--", "chrome/tool.sh"); status != "" {
+		t.Fatalf("expected clean checkout after mode annotate, got %q", status)
+	}
+}
+
 func TestRefreshNoAnnotateRestoresLocalChangesDirty(t *testing.T) {
 	ctx := context.Background()
 	workspacePath := initGitRepo(t)

--- a/packages/browseros/tools/patch/internal/engine/refresh.go
+++ b/packages/browseros/tools/patch/internal/engine/refresh.go
@@ -104,6 +104,7 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 		return nil, err
 	}
 	refreshStashRef := ""
+	refreshChangePaths := []string{}
 	if dirty && opts.Force {
 		reportProgress(opts.Progress, "Resetting tracked checkout changes")
 		if err := git.ResetHard(ctx, opts.Workspace.Path); err != nil {
@@ -115,6 +116,11 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 		if !dirty || refreshStashRef != "" {
 			return nil
 		}
+		paths, err := trackedRefreshChangePaths(ctx, opts.Workspace.Path)
+		if err != nil {
+			return err
+		}
+		refreshChangePaths = paths
 		reportProgress(opts.Progress, "Stashing tracked checkout changes")
 		stashRef, err := git.StashPush(ctx, opts.Workspace.Path, "browseros-patch refresh stash", false, nil)
 		if err != nil {
@@ -127,7 +133,7 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 		if err == nil || refreshStashRef == "" {
 			return err
 		}
-		return fmt.Errorf("%w; tracked local changes are saved in stash %s", err, shortRev(refreshStashRef))
+		return fmt.Errorf("%w; tracked local changes are saved in stash %s", err, refreshStashRef)
 	}
 	materializeErr := func(step string, err error) error {
 		return withRefreshStashRecovery(refreshMaterializeError(step, err))
@@ -151,7 +157,7 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 			PatchesRev: repoRev,
 			Warnings:   []string{},
 		}
-		if err := finishRefresh(ctx, opts, repoInfo, result, refreshStashRef, repoRev); err != nil {
+		if err := finishRefresh(ctx, opts, repoInfo, result, refreshStashRef, refreshChangePaths, repoRev); err != nil {
 			return nil, withRefreshStashRecovery(err)
 		}
 		return result, nil
@@ -244,13 +250,13 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 	if err := workspace.SaveState(opts.Workspace.Path, state); err != nil {
 		return nil, withRefreshStashRecovery(err)
 	}
-	if err := finishRefresh(ctx, opts, repoInfo, result, refreshStashRef, repoRev); err != nil {
+	if err := finishRefresh(ctx, opts, repoInfo, result, refreshStashRef, refreshChangePaths, repoRev); err != nil {
 		return nil, withRefreshStashRecovery(err)
 	}
 	return result, nil
 }
 
-func finishRefresh(ctx context.Context, opts RefreshOptions, repoInfo *repo.Info, result *RefreshResult, refreshStashRef string, repoRev string) error {
+func finishRefresh(ctx context.Context, opts RefreshOptions, repoInfo *repo.Info, result *RefreshResult, refreshStashRef string, refreshChangePaths []string, repoRev string) error {
 	if refreshStashRef != "" {
 		reportProgress(opts.Progress, "Rebasing stashed local changes")
 		if err := git.StashRebase(ctx, opts.Workspace.Path, refreshStashRef); err != nil {
@@ -264,14 +270,14 @@ func finishRefresh(ctx context.Context, opts RefreshOptions, repoInfo *repo.Info
 			result.StashConflict = true
 			result.StashConflictFiles = conflict.Files
 			result.AnnotateSkipped = "local changes conflict after refresh"
-			return nil
+			return recordRefreshStashConflict(opts.Workspace.Path, refreshStashRef, conflict.Files)
 		}
 		result.StashRestored = true
 	}
-	if !opts.AutoAnnotate || result.StashConflict {
+	if !opts.AutoAnnotate || result.StashConflict || len(refreshChangePaths) == 0 {
 		return nil
 	}
-	hasChanges, err := hasAnnotatableChanges(ctx, opts.Workspace, repoInfo)
+	hasChanges, err := hasAnnotatableChanges(ctx, opts.Workspace, repoInfo, refreshChangePaths)
 	if err != nil {
 		result.AnnotateError = err.Error()
 		return nil
@@ -279,16 +285,46 @@ func finishRefresh(ctx context.Context, opts RefreshOptions, repoInfo *repo.Info
 	if !hasChanges {
 		return nil
 	}
-	annotateWorkspaceChanges(ctx, opts.Workspace, repoInfo, nil, &result.AnnotationOutcome, opts.Progress, patchesRevTrailer+": "+repoRev)
+	annotateWorkspaceChanges(ctx, opts.Workspace, repoInfo, refreshChangePaths, nil, &result.AnnotationOutcome, opts.Progress, patchesRevTrailer+": "+repoRev)
 	return nil
 }
 
-func hasAnnotatableChanges(ctx context.Context, ws workspace.Entry, repoInfo *repo.Info) (bool, error) {
+func trackedRefreshChangePaths(ctx context.Context, workspacePath string) ([]string, error) {
+	changes, err := git.StatusPorcelain(ctx, workspacePath, nil)
+	if err != nil {
+		return nil, err
+	}
+	seen := map[string]bool{}
+	var paths []string
+	for _, change := range changes {
+		if change.Status == "??" {
+			continue
+		}
+		for _, rel := range changeReportPaths(change) {
+			appendUniquePath(&paths, seen, rel)
+		}
+	}
+	slices.Sort(paths)
+	return paths, nil
+}
+
+func recordRefreshStashConflict(workspacePath string, stashRef string, files []string) error {
+	state, err := workspace.LoadState(workspacePath)
+	if err != nil {
+		return err
+	}
+	state.PendingStash = stashRef
+	state.PendingStashConflict = true
+	state.PendingStashConflictFiles = append([]string{}, files...)
+	return workspace.SaveState(workspacePath, state)
+}
+
+func hasAnnotatableChanges(ctx context.Context, ws workspace.Entry, repoInfo *repo.Info, include []string) (bool, error) {
 	ignore, err := patch.LoadIgnoreSet(repoInfo.Root, nil)
 	if err != nil {
 		return false, err
 	}
-	changes, err := annotateChanges(ctx, ws.Path, ignore, nil)
+	changes, err := annotateChanges(ctx, ws.Path, ignore, include, nil)
 	if err != nil {
 		return false, err
 	}

--- a/packages/browseros/tools/patch/internal/engine/refresh.go
+++ b/packages/browseros/tools/patch/internal/engine/refresh.go
@@ -2,6 +2,7 @@ package engine
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"path/filepath"
 	"slices"
@@ -25,7 +26,10 @@ type RefreshOptions struct {
 	Remote    string
 	Force     bool
 	Pull      bool
-	Progress  Progress
+	// AutoAnnotate creates feature commits for local checkout changes that
+	// survive the refresh rebuild.
+	AutoAnnotate bool
+	Progress     Progress
 }
 
 type RefreshCommit struct {
@@ -36,16 +40,23 @@ type RefreshCommit struct {
 }
 
 type RefreshResult struct {
-	Workspace  string          `json:"workspace"`
-	Result     string          `json:"result"`
-	Features   int             `json:"features"`
-	Commits    []RefreshCommit `json:"commits"`
-	PatchesRev string          `json:"patches_rev"`
-	Warnings   []string        `json:"warnings"`
+	Workspace          string          `json:"workspace"`
+	Result             string          `json:"result"`
+	Features           int             `json:"features"`
+	Commits            []RefreshCommit `json:"commits"`
+	PatchesRev         string          `json:"patches_rev"`
+	Warnings           []string        `json:"warnings"`
+	StashRestored      bool            `json:"stash_restored,omitempty"`
+	StashConflict      bool            `json:"stash_conflict,omitempty"`
+	StashConflictFiles []string        `json:"stash_conflict_files,omitempty"`
+	AnnotationOutcome
 }
 
 // Refresh rebuilds the local browseros branch as feature commits from the patch repo.
 func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
+	if err := requireNoPendingResolution(ctx, opts.Workspace); err != nil {
+		return nil, err
+	}
 	repoInfo := opts.Repo
 	if opts.Remote == "" {
 		opts.Remote = "origin"
@@ -92,31 +103,49 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 	if err != nil {
 		return nil, err
 	}
-	if dirty && !opts.Force {
-		return nil, fmt.Errorf("checkout %s has tracked changes; commit/stash them or use --force to reset tracked state", opts.Workspace.Name)
-	}
+	refreshStashRef := ""
 	if dirty && opts.Force {
 		reportProgress(opts.Progress, "Resetting tracked checkout changes")
 		if err := git.ResetHard(ctx, opts.Workspace.Path); err != nil {
 			return nil, err
 		}
+		dirty = false
+	}
+	stashTrackedChanges := func() error {
+		if !dirty || refreshStashRef != "" {
+			return nil
+		}
+		reportProgress(opts.Progress, "Stashing tracked checkout changes")
+		stashRef, err := git.StashPush(ctx, opts.Workspace.Path, "browseros-patch refresh stash", false, nil)
+		if err != nil {
+			return err
+		}
+		refreshStashRef = stashRef
+		return nil
 	}
 	if fresh, err := refreshIsFresh(ctx, opts.Workspace.Path, state, repoRev); err != nil {
 		return nil, err
 	} else if fresh {
+		if err := stashTrackedChanges(); err != nil {
+			return nil, err
+		}
 		if branch != browserOSBranch {
 			if err := git.CheckoutBranch(ctx, opts.Workspace.Path, browserOSBranch); err != nil {
 				return nil, err
 			}
 		}
-		return &RefreshResult{
+		result := &RefreshResult{
 			Workspace:  opts.Workspace.Name,
 			Result:     "fresh",
 			Features:   len(features),
 			Commits:    []RefreshCommit{},
 			PatchesRev: repoRev,
 			Warnings:   []string{},
-		}, nil
+		}
+		if err := finishRefresh(ctx, opts, repoInfo, result, refreshStashRef, repoRev); err != nil {
+			return nil, err
+		}
+		return result, nil
 	}
 	repoSet, err := patch.LoadRepoPatchSet(repoInfo.PatchesDir, nil)
 	if err != nil {
@@ -135,6 +164,9 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 		return nil, err
 	} else if !exists {
 		return nil, fmt.Errorf("BASE_COMMIT %s is not present in checkout %s", repoInfo.BaseCommit, opts.Workspace.Path)
+	}
+	if err := stashTrackedChanges(); err != nil {
+		return nil, err
 	}
 	if err := git.CheckoutDetached(ctx, opts.Workspace.Path, repoInfo.BaseCommit); err != nil {
 		return nil, err
@@ -203,7 +235,55 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 	if err := workspace.SaveState(opts.Workspace.Path, state); err != nil {
 		return nil, err
 	}
+	if err := finishRefresh(ctx, opts, repoInfo, result, refreshStashRef, repoRev); err != nil {
+		return nil, err
+	}
 	return result, nil
+}
+
+func finishRefresh(ctx context.Context, opts RefreshOptions, repoInfo *repo.Info, result *RefreshResult, refreshStashRef string, repoRev string) error {
+	if refreshStashRef != "" {
+		reportProgress(opts.Progress, "Rebasing stashed local changes")
+		if err := git.StashRebase(ctx, opts.Workspace.Path, refreshStashRef); err != nil {
+			if errors.Is(err, git.ErrStashNotFound) {
+				return nil
+			}
+			var conflict *git.StashConflictError
+			if !errors.As(err, &conflict) {
+				return err
+			}
+			result.StashConflict = true
+			result.StashConflictFiles = conflict.Files
+			result.AnnotateSkipped = "local changes conflict after refresh"
+			return nil
+		}
+		result.StashRestored = true
+	}
+	if !opts.AutoAnnotate || result.StashConflict {
+		return nil
+	}
+	hasChanges, err := hasAnnotatableChanges(ctx, opts.Workspace, repoInfo)
+	if err != nil {
+		result.AnnotateError = err.Error()
+		return nil
+	}
+	if !hasChanges {
+		return nil
+	}
+	annotateWorkspaceChanges(ctx, opts.Workspace, repoInfo, nil, &result.AnnotationOutcome, opts.Progress, patchesRevTrailer+": "+repoRev)
+	return nil
+}
+
+func hasAnnotatableChanges(ctx context.Context, ws workspace.Entry, repoInfo *repo.Info) (bool, error) {
+	ignore, err := patch.LoadIgnoreSet(repoInfo.Root, nil)
+	if err != nil {
+		return false, err
+	}
+	changes, err := annotateChanges(ctx, ws.Path, ignore, nil)
+	if err != nil {
+		return false, err
+	}
+	return len(changes) > 0, nil
 }
 
 func refreshMaterializeError(step string, err error) error {

--- a/packages/browseros/tools/patch/internal/engine/refresh.go
+++ b/packages/browseros/tools/patch/internal/engine/refresh.go
@@ -123,6 +123,15 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 		refreshStashRef = stashRef
 		return nil
 	}
+	withRefreshStashRecovery := func(err error) error {
+		if err == nil || refreshStashRef == "" {
+			return err
+		}
+		return fmt.Errorf("%w; tracked local changes are saved in stash %s", err, shortRev(refreshStashRef))
+	}
+	materializeErr := func(step string, err error) error {
+		return withRefreshStashRecovery(refreshMaterializeError(step, err))
+	}
 	if fresh, err := refreshIsFresh(ctx, opts.Workspace.Path, state, repoRev); err != nil {
 		return nil, err
 	} else if fresh {
@@ -131,7 +140,7 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 		}
 		if branch != browserOSBranch {
 			if err := git.CheckoutBranch(ctx, opts.Workspace.Path, browserOSBranch); err != nil {
-				return nil, err
+				return nil, withRefreshStashRecovery(err)
 			}
 		}
 		result := &RefreshResult{
@@ -143,7 +152,7 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 			Warnings:   []string{},
 		}
 		if err := finishRefresh(ctx, opts, repoInfo, result, refreshStashRef, repoRev); err != nil {
-			return nil, err
+			return nil, withRefreshStashRecovery(err)
 		}
 		return result, nil
 	}
@@ -169,7 +178,7 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 		return nil, err
 	}
 	if err := git.CheckoutDetached(ctx, opts.Workspace.Path, repoInfo.BaseCommit); err != nil {
-		return nil, err
+		return nil, withRefreshStashRecovery(err)
 	}
 	result := &RefreshResult{
 		Workspace:  opts.Workspace.Name,
@@ -186,22 +195,22 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 		}
 		reportProgress(opts.Progress, "Materializing feature %s", feature.Name)
 		if err := applyFeaturePatchSet(ctx, opts.Workspace.Path, repoInfo, repoSet, paths); err != nil {
-			return nil, refreshMaterializeError("apply feature "+feature.Name, err)
+			return nil, materializeErr("apply feature "+feature.Name, err)
 		}
 		stagePaths := stagePathsForPatches(repoSet, paths)
 		if err := git.AddAllPaths(ctx, opts.Workspace.Path, stagePaths); err != nil {
-			return nil, refreshMaterializeError("stage feature "+feature.Name, err)
+			return nil, materializeErr("stage feature "+feature.Name, err)
 		}
 		dirty, err := git.IsDirtyPaths(ctx, opts.Workspace.Path, stagePaths)
 		if err != nil {
-			return nil, refreshMaterializeError("check feature "+feature.Name, err)
+			return nil, materializeErr("check feature "+feature.Name, err)
 		}
 		if !dirty {
 			continue
 		}
 		commit, err := git.CommitIndexWithBodyEnv(ctx, opts.Workspace.Path, feature.Description, patchesRevTrailer+": "+repoRev, commitEnv)
 		if err != nil {
-			return nil, refreshMaterializeError("commit feature "+feature.Name, err)
+			return nil, materializeErr("commit feature "+feature.Name, err)
 		}
 		result.Commits = append(result.Commits, RefreshCommit{
 			Feature:     feature.Name,
@@ -213,7 +222,7 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 	if len(result.Commits) == 0 {
 		commit, err := git.CommitIndexWithBodyEnv(ctx, opts.Workspace.Path, "chore: materialize browseros patches", patchesRevTrailer+": "+repoRev, commitEnv)
 		if err != nil {
-			return nil, refreshMaterializeError("commit empty materialization", err)
+			return nil, materializeErr("commit empty materialization", err)
 		}
 		result.Commits = append(result.Commits, RefreshCommit{
 			Feature:     "materialization",
@@ -224,19 +233,19 @@ func Refresh(ctx context.Context, opts RefreshOptions) (*RefreshResult, error) {
 	}
 	reportProgress(opts.Progress, "Moving browseros branch")
 	if err := git.ForceBranch(ctx, opts.Workspace.Path, browserOSBranch, "HEAD"); err != nil {
-		return nil, refreshMaterializeError("move browseros branch", err)
+		return nil, materializeErr("move browseros branch", err)
 	}
 	if err := git.CheckoutBranch(ctx, opts.Workspace.Path, browserOSBranch); err != nil {
-		return nil, refreshMaterializeError("checkout browseros branch", err)
+		return nil, materializeErr("checkout browseros branch", err)
 	}
 	state.BaseCommit = repoInfo.BaseCommit
 	state.LastRefreshRev = repoRev
 	state.LastRefreshAt = time.Now().UTC()
 	if err := workspace.SaveState(opts.Workspace.Path, state); err != nil {
-		return nil, err
+		return nil, withRefreshStashRecovery(err)
 	}
 	if err := finishRefresh(ctx, opts, repoInfo, result, refreshStashRef, repoRev); err != nil {
-		return nil, err
+		return nil, withRefreshStashRecovery(err)
 	}
 	return result, nil
 }

--- a/packages/browseros/tools/patch/internal/git/git.go
+++ b/packages/browseros/tools/patch/internal/git/git.go
@@ -705,7 +705,7 @@ func StashRebase(ctx context.Context, dir string, stashRef string) error {
 }
 
 func stashTrackedFiles(ctx context.Context, dir string, stashRef string) ([]string, error) {
-	result, err := Run(ctx, dir, nil, "-c", "core.quotepath=false", "diff", "--name-only", stashRef+"^1", stashRef)
+	result, err := Run(ctx, dir, nil, "-c", "core.quotepath=false", "diff", "--name-only", "--no-renames", stashRef+"^1", stashRef)
 	if err != nil {
 		return nil, err
 	}
@@ -753,15 +753,39 @@ func restoreFromTree(ctx context.Context, dir string, treeish string, rel string
 	if err != nil {
 		return err
 	}
-	perm := os.FileMode(0o644)
-	if mode, modeErr := FileModeAtCommit(ctx, dir, treeish, rel); modeErr == nil && mode == "100755" {
-		perm = 0o755
+	perm, err := filePermAtTree(ctx, dir, treeish, rel)
+	if err != nil {
+		return err
 	}
 	workPath := filepath.Join(dir, filepath.FromSlash(rel))
 	if err := os.MkdirAll(filepath.Dir(workPath), 0o755); err != nil {
 		return err
 	}
+	if info, err := os.Lstat(workPath); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		if err := os.Remove(workPath); err != nil {
+			return err
+		}
+	}
 	return os.WriteFile(workPath, content, perm)
+}
+
+func filePermAtTree(ctx context.Context, dir string, treeish string, rel string) (os.FileMode, error) {
+	mode, err := FileModeAtCommit(ctx, dir, treeish, rel)
+	if err != nil {
+		return 0, err
+	}
+	if mode == "100755" {
+		return 0o755, nil
+	}
+	return 0o644, nil
+}
+
+func chmodFromTree(ctx context.Context, dir string, treeish string, rel string) error {
+	perm, err := filePermAtTree(ctx, dir, treeish, rel)
+	if err != nil {
+		return err
+	}
+	return os.Chmod(filepath.Join(dir, filepath.FromSlash(rel)), perm)
 }
 
 func rebaseStashedFile(ctx context.Context, dir string, stashRef string, rel string) (bool, error) {
@@ -810,7 +834,11 @@ func rebaseStashedFile(ctx context.Context, dir string, stashRef string, rel str
 		}
 		return baseExists, nil
 	}
-	return mergeIntoWorkingFile(ctx, dir, rel, base, theirs)
+	conflicted, err := mergeIntoWorkingFile(ctx, dir, rel, base, theirs)
+	if err != nil || conflicted {
+		return conflicted, err
+	}
+	return false, chmodFromTree(ctx, dir, stashRef, rel)
 }
 
 // mergeIntoWorkingFile 3-way merges stashed content into the working file.

--- a/packages/browseros/tools/patch/internal/git/git.go
+++ b/packages/browseros/tools/patch/internal/git/git.go
@@ -716,11 +716,18 @@ func stashTrackedFiles(ctx context.Context, dir string, stashRef string) ([]stri
 }
 
 func stashUntrackedFiles(ctx context.Context, dir string, stashRef string) ([]string, error) {
-	exists, err := CommitExists(ctx, dir, stashRef+"^3")
-	if err != nil || !exists {
+	parents, err := Run(ctx, dir, nil, "rev-list", "--parents", "-n", "1", stashRef)
+	if err != nil {
 		return nil, err
 	}
-	result, err := Run(ctx, dir, nil, "-c", "core.quotepath=false", "ls-tree", "-r", "--name-only", stashRef+"^3")
+	if parents.Code != 0 {
+		return nil, errors.New(strings.TrimSpace(parents.Stderr))
+	}
+	fields := strings.Fields(parents.Stdout)
+	if len(fields) < 4 {
+		return nil, nil
+	}
+	result, err := Run(ctx, dir, nil, "-c", "core.quotepath=false", "ls-tree", "-r", "--name-only", fields[3])
 	if err != nil {
 		return nil, err
 	}

--- a/packages/browseros/tools/patch/internal/git/git_test.go
+++ b/packages/browseros/tools/patch/internal/git/git_test.go
@@ -183,6 +183,61 @@ func TestStashRebaseFlagsModifyDeleteConflict(t *testing.T) {
 	}
 }
 
+func TestStashRebasePreservesRenameDeletion(t *testing.T) {
+	ctx := context.Background()
+	dir := initGitRepo(t)
+	writeFile(t, filepath.Join(dir, "old.txt"), "base\n")
+	runGit(t, dir, "add", "old.txt")
+	runGit(t, dir, "commit", "-m", "base")
+
+	runGit(t, dir, "mv", "old.txt", "new.txt")
+	sha, err := StashPush(ctx, dir, "rename", false, nil)
+	if err != nil {
+		t.Fatalf("StashPush: %v", err)
+	}
+
+	if err := StashRebase(ctx, dir, sha); err != nil {
+		t.Fatalf("StashRebase: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "old.txt")); !os.IsNotExist(err) {
+		t.Fatalf("old path should be deleted after rename replay, stat err=%v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "new.txt"))
+	if err != nil {
+		t.Fatalf("read new path: %v", err)
+	}
+	if string(data) != "base\n" {
+		t.Fatalf("new path contents = %q", string(data))
+	}
+}
+
+func TestStashRebasePreservesModeOnlyChange(t *testing.T) {
+	ctx := context.Background()
+	dir := initGitRepo(t)
+	writeFile(t, filepath.Join(dir, "tool.sh"), "#!/bin/sh\n")
+	runGit(t, dir, "add", "tool.sh")
+	runGit(t, dir, "commit", "-m", "base")
+
+	if err := os.Chmod(filepath.Join(dir, "tool.sh"), 0o755); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	sha, err := StashPush(ctx, dir, "chmod", false, nil)
+	if err != nil {
+		t.Fatalf("StashPush: %v", err)
+	}
+
+	if err := StashRebase(ctx, dir, sha); err != nil {
+		t.Fatalf("StashRebase: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(dir, "tool.sh"))
+	if err != nil {
+		t.Fatalf("stat tool: %v", err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Fatalf("tool mode = %o, want 755", info.Mode().Perm())
+	}
+}
+
 func TestStashRebaseRestoresUntrackedExecutableBySHA(t *testing.T) {
 	ctx := context.Background()
 	dir := initGitRepo(t)

--- a/packages/browseros/tools/patch/internal/workspace/state.go
+++ b/packages/browseros/tools/patch/internal/workspace/state.go
@@ -10,18 +10,23 @@ import (
 )
 
 type State struct {
-	Version        int       `yaml:"version" json:"version"`
-	Workspace      string    `yaml:"workspace,omitempty" json:"workspace,omitempty"`
-	BaseCommit     string    `yaml:"base_commit,omitempty" json:"base_commit,omitempty"`
-	LastApplyRev   string    `yaml:"last_apply_rev,omitempty" json:"last_apply_rev,omitempty"`
-	LastSyncRev    string    `yaml:"last_sync_rev,omitempty" json:"last_sync_rev,omitempty"`
-	LastExtractRev string    `yaml:"last_extract_rev,omitempty" json:"last_extract_rev,omitempty"`
-	LastRefreshRev string    `yaml:"last_refresh_rev,omitempty" json:"last_refresh_rev,omitempty"`
-	PendingStash   string    `yaml:"pending_stash,omitempty" json:"pending_stash,omitempty"`
-	LastApplyAt    time.Time `yaml:"last_apply_at,omitempty" json:"last_apply_at,omitempty"`
-	LastSyncAt     time.Time `yaml:"last_sync_at,omitempty" json:"last_sync_at,omitempty"`
-	LastExtractAt  time.Time `yaml:"last_extract_at,omitempty" json:"last_extract_at,omitempty"`
-	LastRefreshAt  time.Time `yaml:"last_refresh_at,omitempty" json:"last_refresh_at,omitempty"`
+	Version        int    `yaml:"version" json:"version"`
+	Workspace      string `yaml:"workspace,omitempty" json:"workspace,omitempty"`
+	BaseCommit     string `yaml:"base_commit,omitempty" json:"base_commit,omitempty"`
+	LastApplyRev   string `yaml:"last_apply_rev,omitempty" json:"last_apply_rev,omitempty"`
+	LastSyncRev    string `yaml:"last_sync_rev,omitempty" json:"last_sync_rev,omitempty"`
+	LastExtractRev string `yaml:"last_extract_rev,omitempty" json:"last_extract_rev,omitempty"`
+	LastRefreshRev string `yaml:"last_refresh_rev,omitempty" json:"last_refresh_rev,omitempty"`
+	PendingStash   string `yaml:"pending_stash,omitempty" json:"pending_stash,omitempty"`
+	// PendingStashConflict marks a stash replay conflict that is not
+	// represented by browseros-patch resolve state. It is cleared once the
+	// recorded stash entry is gone.
+	PendingStashConflict      bool      `yaml:"pending_stash_conflict,omitempty" json:"pending_stash_conflict,omitempty"`
+	PendingStashConflictFiles []string  `yaml:"pending_stash_conflict_files,omitempty" json:"pending_stash_conflict_files,omitempty"`
+	LastApplyAt               time.Time `yaml:"last_apply_at,omitempty" json:"last_apply_at,omitempty"`
+	LastSyncAt                time.Time `yaml:"last_sync_at,omitempty" json:"last_sync_at,omitempty"`
+	LastExtractAt             time.Time `yaml:"last_extract_at,omitempty" json:"last_extract_at,omitempty"`
+	LastRefreshAt             time.Time `yaml:"last_refresh_at,omitempty" json:"last_refresh_at,omitempty"`
 }
 
 func StateDir(workspacePath string) string {


### PR DESCRIPTION
## Summary
- Make `browseros-patch refresh` preserve tracked local checkout changes through the rebuild and auto-annotate them into feature commits by default.
- Add `refresh --no-annotate` to opt out, while keeping `--force` as tracked-state abandonment.
- Harden refresh safety around pending resolution, untracked files, stash replay conflicts, renames, and mode-only changes.

## Design
Refresh now stashes only tracked local changes after preflight checks, rebuilds the canonical `browseros` branch as before, restores the stash, and runs the shared annotation machinery scoped to the tracked paths it preserved. Stash replay conflicts are persisted in workspace state so later mutating commands refuse until the recorded stash is dropped. The CLI shares apply's annotate output/failure handling and docs cover the new default and opt-out.

## Test plan
- [x] `make test` from `packages/browseros/tools/patch`
- [x] Local adversarial review loop: 3 rounds, final clean