### PR TITLE
refactor(patches): server proxy → pure TCP byte forwarder with HTTPS

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/BUILD.gn
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/BUILD.gn b/chrome/browser/browseros/server/BUILD.gn
 new file mode 100644
-index 0000000000000..8f1f42fae7854
+index 0000000000000..aed05041c83b4
 --- /dev/null
 +++ b/chrome/browser/browseros/server/BUILD.gn
-@@ -0,0 +1,173 @@
+@@ -0,0 +1,175 @@
 +# Copyright 2024 The Chromium Authors
 +# Use of this source code is governed by a BSD-style license that can be
 +# found in the LICENSE file.
@@ -110,6 +110,7 @@ index 0000000000000..8f1f42fae7854
 +    "browseros_appcast_parser_unittest.cc",
 +    "browseros_server_config_unittest.cc",
 +    "browseros_server_manager_unittest.cc",
++    "browseros_server_proxy_unittest.cc",
 +    "browseros_server_utils_unittest.cc",
 +  ]
 +
@@ -122,6 +123,7 @@ index 0000000000000..8f1f42fae7854
 +    "//chrome/browser/browseros/core",
 +    "//components/prefs:test_support",
 +    "//net",
++    "//net:test_support",
 +    "//testing/gmock",
 +    "//testing/gtest",
 +  ]

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_manager.cc b/chrome/browser/browseros/server/browseros_server_manager.cc
 new file mode 100644
-index 0000000000000..c39cdbe4f8f1c
+index 0000000000000..c5b8bd543d33a
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_manager.cc
-@@ -0,0 +1,1105 @@
+@@ -0,0 +1,1112 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -41,7 +41,6 @@ index 0000000000000..c39cdbe4f8f1c
 +#include "chrome/browser/browseros/server/server_state_store.h"
 +#include "chrome/browser/browseros/server/server_state_store_impl.h"
 +#include "chrome/browser/browseros/server/server_updater.h"
-+#include "chrome/browser/net/system_network_context_manager.h"
 +#include "chrome/browser/profiles/profile.h"
 +#include "chrome/browser/profiles/profile_manager.h"
 +#include "chrome/common/chrome_paths.h"
@@ -60,7 +59,6 @@ index 0000000000000..c39cdbe4f8f1c
 +#include "net/log/net_log_source.h"
 +#include "net/socket/tcp_server_socket.h"
 +#include "net/socket/tcp_socket.h"
-+#include "services/network/public/cpp/shared_url_loader_factory.h"
 +
 +namespace {
 +
@@ -264,6 +262,7 @@ index 0000000000000..c39cdbe4f8f1c
 +    ports_.cdp = browseros_server::kDefaultCDPPort;
 +    ports_.proxy = browseros_server::kDefaultProxyPort;
 +    ports_.server = browseros_server::kDefaultServerPort;
++    proxy_https_port_ = browseros_server::kDefaultProxyHttpsPort;
 +    allow_remote_in_mcp_ = false;
 +    return;
 +  }
@@ -286,6 +285,12 @@ index 0000000000000..c39cdbe4f8f1c
 +    }
 +  }
 +  ports_.proxy = proxy_port;
++
++  proxy_https_port_ =
++      local_state_->GetInteger(browseros_server::kProxyHttpsPort);
++  if (proxy_https_port_ <= 0) {
++    proxy_https_port_ = browseros_server::kDefaultProxyHttpsPort;
++  }
 +
 +  ports_.server = local_state_->GetInteger(browseros_server::kServerPort);
 +  if (ports_.server <= 0) {
@@ -352,6 +357,10 @@ index 0000000000000..c39cdbe4f8f1c
 +    assigned_ports.insert(ports_.server);
 +  }
 +
++  proxy_https_port_ = FindAvailableServerPort(proxy_https_port_, assigned_ports,
++                                              /*allow_reuse=*/true);
++  assigned_ports.insert(proxy_https_port_);
++
 +  LOG(INFO) << "browseros: Resolved ports for startup - "
 +            << ports_.DebugString();
 +}
@@ -390,6 +399,8 @@ index 0000000000000..c39cdbe4f8f1c
 +
 +  local_state_->SetInteger(browseros_server::kCDPServerPort, ports_.cdp);
 +  local_state_->SetInteger(browseros_server::kProxyPort, ports_.proxy);
++  local_state_->SetInteger(browseros_server::kProxyHttpsPort,
++                           proxy_https_port_);
 +  local_state_->SetInteger(browseros_server::kServerPort, ports_.server);
 +
 +  // DEPRECATED: keep mcp_port in sync with server port for backward compat
@@ -524,26 +535,20 @@ index 0000000000000..c39cdbe4f8f1c
 +void BrowserOSServerManager::StartProxy() {
 +  server_proxy_ = std::make_unique<BrowserOSServerProxy>();
 +
-+  // Clone the factory on the UI thread so it can be bound on the IO thread.
-+  auto pending_factory = g_browser_process->system_network_context_manager()
-+                             ->GetSharedURLLoaderFactory()
-+                             ->Clone();
-+
 +  content::GetIOThreadTaskRunner({})->PostTask(
-+      FROM_HERE,
-+      base::BindOnce(
-+          [](BrowserOSServerProxy* proxy, int port,
-+             std::unique_ptr<network::PendingSharedURLLoaderFactory> pending,
-+             bool allow_remote) {
-+            if (!proxy->Start(port, std::move(pending))) {
-+              LOG(ERROR) << "browseros: Failed to start MCP proxy on port "
-+                         << port;
-+              return;
-+            }
-+            proxy->SetAllowRemote(allow_remote);
-+          },
-+          server_proxy_.get(), ports_.proxy, std::move(pending_factory),
-+          allow_remote_in_mcp_));
++      FROM_HERE, base::BindOnce(
++                     [](BrowserOSServerProxy* proxy, int http_port,
++                        int https_port, bool allow_remote) {
++                       if (!proxy->Start(http_port, https_port)) {
++                         LOG(ERROR)
++                             << "browseros: Failed to start MCP proxy on port "
++                             << http_port;
++                         return;
++                       }
++                       proxy->SetAllowRemote(allow_remote);
++                     },
++                     server_proxy_.get(), ports_.proxy, proxy_https_port_,
++                     allow_remote_in_mcp_));
 +}
 +
 +void BrowserOSServerManager::StopProxy() {
@@ -876,6 +881,7 @@ index 0000000000000..c39cdbe4f8f1c
 +  std::set<int> assigned;
 +  assigned.insert(ports_.cdp);
 +  assigned.insert(ports_.proxy);
++  assigned.insert(proxy_https_port_);
 +
 +  const int previous_server_port = ports_.server;
 +  if (!cl->HasSwitch(browseros::kServerPort)) {
@@ -928,6 +934,7 @@ index 0000000000000..c39cdbe4f8f1c
 +  std::set<int> assigned;
 +  assigned.insert(ports_.cdp);
 +  assigned.insert(ports_.proxy);
++  assigned.insert(proxy_https_port_);
 +
 +  const int previous_server_port = ports_.server;
 +  if (!cl->HasSwitch(browseros::kServerPort)) {

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_manager.h b/chrome/browser/browseros/server/browseros_server_manager.h
 new file mode 100644
-index 0000000000000..6c9a7e03ebc0d
+index 0000000000000..36c2cc1a7f1e0
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_manager.h
-@@ -0,0 +1,167 @@
+@@ -0,0 +1,169 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -23,6 +23,7 @@ index 0000000000000..6c9a7e03ebc0d
 +#include "base/process/process.h"
 +#include "base/timer/timer.h"
 +#include "chrome/browser/browseros/server/browseros_server_config.h"
++#include "chrome/browser/browseros/server/browseros_server_prefs.h"
 +#include "chrome/browser/browseros/server/process_controller.h"
 +
 +class PrefChangeRegistrar;
@@ -147,6 +148,7 @@ index 0000000000000..6c9a7e03ebc0d
 +  base::File lock_file_;
 +  base::Process process_;
 +  ServerPorts ports_;
++  int proxy_https_port_ = browseros_server::kDefaultProxyHttpsPort;
 +  bool allow_remote_in_mcp_ = false;
 +  bool is_running_ = false;
 +  bool is_restarting_ = false;

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager_unittest.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_manager_unittest.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_manager_unittest.cc b/chrome/browser/browseros/server/browseros_server_manager_unittest.cc
 new file mode 100644
-index 0000000000000..aee8a1fadceaf
+index 0000000000000..0b48cea4baebe
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_manager_unittest.cc
-@@ -0,0 +1,543 @@
+@@ -0,0 +1,562 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -26,6 +26,7 @@ index 0000000000000..aee8a1fadceaf
 +#include "chrome/browser/browseros/server/test/mock_server_updater.h"
 +#include "components/prefs/pref_registry_simple.h"
 +#include "components/prefs/testing_pref_service.h"
++#include "content/public/common/content_switches.h"
 +#include "testing/gmock/include/gmock/gmock.h"
 +#include "testing/gtest/include/gtest/gtest.h"
 +
@@ -101,9 +102,9 @@ index 0000000000000..aee8a1fadceaf
 +
 +  void UseFakePortFinder(int return_port = 0) {
 +    fake_port_finder_return_port_ = return_port;
-+    manager_->SetPortFinderForTesting(base::BindRepeating(
-+        &BrowserOSServerManagerTest::FindPortForTesting,
-+        base::Unretained(this)));
++    manager_->SetPortFinderForTesting(
++        base::BindRepeating(&BrowserOSServerManagerTest::FindPortForTesting,
++                            base::Unretained(this)));
 +  }
 +
 +  int FindPortForTesting(int starting_port,
@@ -227,6 +228,8 @@ index 0000000000000..aee8a1fadceaf
 +TEST_F(BrowserOSServerManagerTest, DefaultPortsWhenPrefsEmpty) {
 +  EXPECT_EQ(browseros_server::kDefaultCDPPort,
 +            prefs_.GetInteger(browseros_server::kCDPServerPort));
++  EXPECT_EQ(browseros_server::kDefaultProxyHttpsPort,
++            prefs_.GetInteger(browseros_server::kProxyHttpsPort));
 +
 +  auto process_controller = std::make_unique<NiceMock<MockProcessController>>();
 +  auto state_store = std::make_unique<NiceMock<MockServerStateStore>>();
@@ -258,6 +261,8 @@ index 0000000000000..aee8a1fadceaf
 +  base::test::ScopedCommandLine scoped_command_line;
 +  scoped_command_line.GetProcessCommandLine()->AppendSwitch(
 +      browseros::kDisableServer);
++  scoped_command_line.GetProcessCommandLine()->AppendSwitch(
++      ::switches::kRemoteDebuggingPort);
 +
 +  auto process_controller = std::make_unique<NiceMock<MockProcessController>>();
 +  auto state_store = std::make_unique<NiceMock<MockServerStateStore>>();
@@ -278,10 +283,8 @@ index 0000000000000..aee8a1fadceaf
 +      std::move(process_controller), std::move(state_store),
 +      std::move(health_checker), std::move(updater), &prefs_);
 +
-+  // Start triggers LoadPortsFromPrefs which migrates
 +  manager->Start();
 +
-+  // Proxy port should have taken the old MCP port value
 +  EXPECT_EQ(9200, manager->GetProxyPort());
 +  manager->Shutdown();
 +}
@@ -292,6 +295,8 @@ index 0000000000000..aee8a1fadceaf
 +  base::test::ScopedCommandLine scoped_command_line;
 +  scoped_command_line.GetProcessCommandLine()->AppendSwitch(
 +      browseros::kDisableServer);
++  scoped_command_line.GetProcessCommandLine()->AppendSwitch(
++      ::switches::kRemoteDebuggingPort);
 +
 +  auto process_controller = std::make_unique<NiceMock<MockProcessController>>();
 +  auto state_store = std::make_unique<NiceMock<MockServerStateStore>>();
@@ -463,6 +468,8 @@ index 0000000000000..aee8a1fadceaf
 +  EXPECT_EQ(1u, port_finder_excluded_.count(browseros_server::kDefaultCDPPort));
 +  EXPECT_EQ(1u,
 +            port_finder_excluded_.count(browseros_server::kDefaultProxyPort));
++  EXPECT_EQ(1u, port_finder_excluded_.count(
++                    browseros_server::kDefaultProxyHttpsPort));
 +  EXPECT_TRUE(port_finder_allow_reuse_);
 +  EXPECT_EQ(manager_->GetServerPort(),
 +            prefs_.GetInteger(browseros_server::kServerPort));
@@ -483,6 +490,8 @@ index 0000000000000..aee8a1fadceaf
 +  EXPECT_EQ(1, port_finder_call_count_);
 +  EXPECT_EQ(browseros_server::kDefaultServerPort + 1,
 +            port_finder_starting_port_);
++  EXPECT_EQ(1u, port_finder_excluded_.count(
++                    browseros_server::kDefaultProxyHttpsPort));
 +  EXPECT_FALSE(port_finder_allow_reuse_);
 +  EXPECT_EQ(browseros_server::kDefaultServerPort + 1,
 +            manager_->GetServerPort());
@@ -503,9 +512,15 @@ index 0000000000000..aee8a1fadceaf
 +  EXPECT_EQ(1, port_finder_call_count_);
 +  EXPECT_EQ(browseros_server::kDefaultServerPort + 1,
 +            port_finder_starting_port_);
++  EXPECT_EQ(1u, port_finder_excluded_.count(
++                    browseros_server::kDefaultProxyHttpsPort));
 +  EXPECT_FALSE(port_finder_allow_reuse_);
 +  EXPECT_EQ(browseros_server::kDefaultServerPort + 1,
 +            manager_->GetServerPort());
++
++  // The mock launch does not create a process, so restore running state before
++  // simulating the next health-check restart.
++  manager_->SetRunningForTesting(true);
 +
 +  manager_->OnHealthCheckComplete(false);
 +  manager_->OnHealthCheckComplete(false);
@@ -514,6 +529,8 @@ index 0000000000000..aee8a1fadceaf
 +  EXPECT_EQ(2, port_finder_call_count_);
 +  EXPECT_EQ(browseros_server::kDefaultServerPort + 1,
 +            port_finder_starting_port_);
++  EXPECT_EQ(1u, port_finder_excluded_.count(
++                    browseros_server::kDefaultProxyHttpsPort));
 +  EXPECT_TRUE(port_finder_allow_reuse_);
 +  EXPECT_EQ(browseros_server::kDefaultServerPort + 1,
 +            manager_->GetServerPort());
@@ -538,6 +555,8 @@ index 0000000000000..aee8a1fadceaf
 +
 +  EXPECT_EQ(1, port_finder_call_count_);
 +  EXPECT_EQ(browseros_server::kDefaultServerPort, port_finder_starting_port_);
++  EXPECT_EQ(1u, port_finder_excluded_.count(
++                    browseros_server::kDefaultProxyHttpsPort));
 +  EXPECT_TRUE(port_finder_allow_reuse_);
 +  EXPECT_EQ(manager_->GetServerPort(),
 +            prefs_.GetInteger(browseros_server::kServerPort));

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_prefs.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_prefs.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_prefs.cc b/chrome/browser/browseros/server/browseros_server_prefs.cc
 new file mode 100644
-index 0000000000000..2dfba7e9914ab
+index 0000000000000..d1829772e773f
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_prefs.cc
-@@ -0,0 +1,45 @@
+@@ -0,0 +1,49 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -19,6 +19,9 @@ index 0000000000000..2dfba7e9914ab
 +
 +// Stable MCP proxy port
 +const char kProxyPort[] = "browseros.server.proxy_port";
++
++// Stable HTTPS MCP proxy port
++const char kProxyHttpsPort[] = "browseros.server.proxy_https_port";
 +
 +// Sidecar backend server port
 +const char kServerPort[] = "browseros.server.server_port";
@@ -39,6 +42,7 @@ index 0000000000000..2dfba7e9914ab
 +void RegisterLocalStatePrefs(PrefRegistrySimple* registry) {
 +  registry->RegisterIntegerPref(kCDPServerPort, kDefaultCDPPort);
 +  registry->RegisterIntegerPref(kProxyPort, kDefaultProxyPort);
++  registry->RegisterIntegerPref(kProxyHttpsPort, kDefaultProxyHttpsPort);
 +  registry->RegisterIntegerPref(kServerPort, kDefaultServerPort);
 +  registry->RegisterBooleanPref(kAllowRemoteInMCP, false);
 +  registry->RegisterBooleanPref(kRestartServerRequested, false);

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_prefs.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_prefs.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_prefs.h b/chrome/browser/browseros/server/browseros_server_prefs.h
 new file mode 100644
-index 0000000000000..0418034e7d0d6
+index 0000000000000..32c69f9b027fd
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_prefs.h
-@@ -0,0 +1,34 @@
+@@ -0,0 +1,36 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -18,19 +18,21 @@ index 0000000000000..0418034e7d0d6
 +// Default port values for BrowserOS server
 +inline constexpr int kDefaultCDPPort = 9100;
 +inline constexpr int kDefaultProxyPort = 9000;
++inline constexpr int kDefaultProxyHttpsPort = 9001;
 +inline constexpr int kDefaultServerPort = 9200;
 +
 +// Preference keys for BrowserOS server configuration
 +extern const char kCDPServerPort[];
 +extern const char kProxyPort[];
++extern const char kProxyHttpsPort[];
 +extern const char kServerPort[];
 +extern const char kAllowRemoteInMCP[];
 +extern const char kRestartServerRequested[];
 +extern const char kServerVersion[];
 +
 +// Deprecated prefs (kept for migration, will be removed in future)
-+extern const char kMCPServerPort[];       // DEPRECATED: migrated to kProxyPort
-+extern const char kMCPServerEnabled[];    // DEPRECATED: no longer used
++extern const char kMCPServerPort[];     // DEPRECATED: migrated to kProxyPort
++extern const char kMCPServerEnabled[];  // DEPRECATED: no longer used
 +
 +// Registers BrowserOS server preferences in Local State (browser-wide prefs)
 +void RegisterLocalStatePrefs(PrefRegistrySimple* registry);

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_proxy.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_proxy.cc
@@ -1,255 +1,655 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_proxy.cc b/chrome/browser/browseros/server/browseros_server_proxy.cc
 new file mode 100644
-index 0000000000000..29bd72722ffde
+index 0000000000000..557eedb4779c4
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_proxy.cc
-@@ -0,0 +1,249 @@
+@@ -0,0 +1,649 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
 +
 +#include "chrome/browser/browseros/server/browseros_server_proxy.h"
 +
-+#include <optional>
++#include <limits>
++#include <memory>
++#include <string>
++#include <utility>
 +
++#include "base/check.h"
++#include "base/containers/span.h"
 +#include "base/functional/bind.h"
++#include "base/functional/callback.h"
 +#include "base/logging.h"
-+#include "base/strings/string_number_conversions.h"
++#include "base/memory/ref_counted.h"
++#include "base/rand_util.h"
++#include "base/task/single_thread_task_runner.h"
++#include "base/time/time.h"
++#include "crypto/keypair.h"
++#include "net/base/address_list.h"
++#include "net/base/io_buffer.h"
 +#include "net/base/ip_address.h"
++#include "net/base/ip_endpoint.h"
 +#include "net/base/net_errors.h"
-+#include "net/http/http_status_code.h"
++#include "net/cert/x509_certificate.h"
++#include "net/cert/x509_util.h"
 +#include "net/log/net_log_source.h"
-+#include "net/server/http_server_request_info.h"
-+#include "net/server/http_server_response_info.h"
++#include "net/socket/ssl_server_socket.h"
++#include "net/socket/stream_socket.h"
++#include "net/socket/tcp_client_socket.h"
 +#include "net/socket/tcp_server_socket.h"
++#include "net/ssl/ssl_server_config.h"
 +#include "net/traffic_annotation/network_traffic_annotation.h"
-+#include "services/network/public/cpp/resource_request.h"
-+#include "services/network/public/cpp/shared_url_loader_factory.h"
-+#include "services/network/public/cpp/simple_url_loader.h"
-+#include "services/network/public/mojom/url_response_head.mojom.h"
-+#include "url/gurl.h"
 +
 +namespace browseros {
 +
 +namespace {
 +
 +constexpr int kBackLog = 10;
-+constexpr size_t kMaxResponseBodySize = 5 * 1024 * 1024;  // 5 MB
++constexpr int kBufferSize = 16 * 1024;
++constexpr char kServiceUnavailableResponse[] =
++    "HTTP/1.1 503 Service Unavailable\r\n"
++    "Content-Type: text/plain\r\n"
++    "Content-Length: 19\r\n"
++    "Connection: close\r\n"
++    "\r\n"
++    "Service Unavailable";
 +
-+net::NetworkTrafficAnnotationTag GetProxyTrafficAnnotation() {
-+  return net::DefineNetworkTrafficAnnotation("browseros_mcp_proxy", R"(
-+    semantics {
-+      sender: "BrowserOS MCP Proxy"
-+      description:
-+        "Forwards MCP requests from the stable proxy port to the sidecar's "
-+        "ephemeral backend port."
-+      trigger: "External MCP client sends POST /mcp to the proxy port."
-+      data: "MCP JSON-RPC request body."
-+      destination: LOCAL
-+    }
-+    policy {
-+      cookies_allowed: NO
-+      setting: "This feature cannot be disabled by settings."
-+      policy_exception_justification:
-+        "Internal proxy for BrowserOS MCP server functionality."
-+    })");
-+}
-+
-+void Send503(net::HttpServer* server, int connection_id) {
-+  net::HttpServerResponseInfo response(net::HTTP_SERVICE_UNAVAILABLE);
-+  response.SetBody("Service Unavailable", "text/plain");
-+  server->SendResponse(connection_id, response, GetProxyTrafficAnnotation());
-+}
++net::NetworkTrafficAnnotationTag kBrowserOSProxyPumpTrafficAnnotation =
++    net::DefineNetworkTrafficAnnotation("browseros_proxy_pump", R"(
++      semantics {
++        sender: "BrowserOS Server Proxy"
++        description:
++          "Copies raw HTTP bytes between clients connected to the BrowserOS "
++          "proxy port and the BrowserOS sidecar server on loopback."
++        trigger: "A client connects to the BrowserOS proxy port."
++        data: "HTTP requests and responses for BrowserOS server functionality."
++        destination: LOCAL
++      }
++      policy {
++        cookies_allowed: NO
++        setting: "This feature cannot be disabled by settings."
++        policy_exception_justification:
++          "Local proxy for BrowserOS server functionality."
++      })");
 +
 +}  // namespace
 +
-+BrowserOSServerProxy::BrowserOSServerProxy() = default;
++struct BrowserOSServerProxy::ListenerState {
++  explicit ListenerState(bool is_https) : is_https(is_https) {}
++
++  std::unique_ptr<net::TCPServerSocket> socket;
++  std::unique_ptr<net::StreamSocket> pending_accept_socket;
++  net::IPEndPoint pending_peer_address;
++  bool is_https;
++};
++
++class BrowserOSServerProxy::Connection {
++ public:
++  Connection(int id,
++             std::unique_ptr<net::StreamSocket> client_socket,
++             int backend_port,
++             base::RepeatingCallback<void(int)> finish_callback)
++      : id_(id),
++        client_socket_(std::move(client_socket)),
++        backend_port_(backend_port),
++        finish_callback_(std::move(finish_callback)) {}
++
++  Connection(const Connection&) = delete;
++  Connection& operator=(const Connection&) = delete;
++
++  ~Connection() { DCHECK_CALLED_ON_VALID_THREAD(thread_checker_); }
++
++  void Start() {
++    DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
++    if (backend_port_ <= 0) {
++      WriteServiceUnavailableAndClose();
++      return;
++    }
++
++    backend_socket_ = std::make_unique<net::TCPClientSocket>(
++        net::AddressList::CreateFromIPAddress(net::IPAddress::IPv4Localhost(),
++                                              backend_port_),
++        nullptr, nullptr, nullptr, net::NetLogSource());
++    int result = backend_socket_->Connect(
++        base::BindOnce(&Connection::OnConnected, base::Unretained(this)));
++    if (result != net::ERR_IO_PENDING) {
++      OnConnected(result);
++      return;
++    }
++  }
++
++ private:
++  void OnConnected(int result) {
++    DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
++    if (result != net::OK) {
++      WriteServiceUnavailableAndClose();
++      return;
++    }
++
++    ++pending_writes_;
++    Pump(client_socket_.get(), backend_socket_.get());
++    --pending_writes_;
++    if (pending_destruction_) {
++      RequestFinish();
++      return;
++    }
++
++    Pump(backend_socket_.get(), client_socket_.get());
++  }
++
++  void Pump(net::StreamSocket* from, net::StreamSocket* to) {
++    DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
++    auto buffer = base::MakeRefCounted<net::IOBufferWithSize>(kBufferSize);
++    int result =
++        from->Read(buffer.get(), kBufferSize,
++                   base::BindOnce(&Connection::OnRead, base::Unretained(this),
++                                  from, to, buffer));
++    if (result != net::ERR_IO_PENDING) {
++      OnRead(from, to, std::move(buffer), result);
++      return;
++    }
++  }
++
++  void OnRead(net::StreamSocket* from,
++              net::StreamSocket* to,
++              scoped_refptr<net::IOBuffer> buffer,
++              int result) {
++    DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
++    if (result <= 0) {
++      RequestFinish();
++      return;
++    }
++
++    auto drainable =
++        base::MakeRefCounted<net::DrainableIOBuffer>(std::move(buffer), result);
++
++    ++pending_writes_;
++    result =
++        to->Write(drainable.get(), result,
++                  base::BindOnce(&Connection::OnWritten, base::Unretained(this),
++                                 drainable, from, to),
++                  kBrowserOSProxyPumpTrafficAnnotation);
++    if (result != net::ERR_IO_PENDING) {
++      OnWritten(drainable, from, to, result);
++      return;
++    }
++  }
++
++  void OnWritten(scoped_refptr<net::DrainableIOBuffer> drainable,
++                 net::StreamSocket* from,
++                 net::StreamSocket* to,
++                 int result) {
++    DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
++    --pending_writes_;
++    if (result <= 0) {
++      RequestFinish();
++      return;
++    }
++
++    drainable->DidConsume(result);
++    if (drainable->BytesRemaining() > 0) {
++      ++pending_writes_;
++      result =
++          to->Write(drainable.get(), drainable->BytesRemaining(),
++                    base::BindOnce(&Connection::OnWritten,
++                                   base::Unretained(this), drainable, from, to),
++                    kBrowserOSProxyPumpTrafficAnnotation);
++      if (result != net::ERR_IO_PENDING) {
++        OnWritten(drainable, from, to, result);
++        return;
++      }
++      return;
++    }
++
++    if (pending_destruction_) {
++      RequestFinish();
++      return;
++    }
++
++    Pump(from, to);
++  }
++
++  void WriteServiceUnavailableAndClose() {
++    DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
++    service_unavailable_mode_ = true;
++    service_unavailable_write_done_ = false;
++    service_unavailable_drain_done_ = false;
++
++    auto buffer = base::MakeRefCounted<net::DrainableIOBuffer>(
++        base::MakeRefCounted<net::StringIOBuffer>(
++            std::string(kServiceUnavailableResponse)),
++        sizeof(kServiceUnavailableResponse) - 1);
++    DrainClientForClose();
++    WriteCloseBuffer(buffer);
++  }
++
++  void WriteCloseBuffer(scoped_refptr<net::DrainableIOBuffer> buffer) {
++    DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
++    ++pending_writes_;
++    int result =
++        client_socket_->Write(buffer.get(), buffer->BytesRemaining(),
++                              base::BindOnce(&Connection::OnCloseBufferWritten,
++                                             base::Unretained(this), buffer),
++                              kBrowserOSProxyPumpTrafficAnnotation);
++    if (result != net::ERR_IO_PENDING) {
++      OnCloseBufferWritten(buffer, result);
++      return;
++    }
++  }
++
++  void OnCloseBufferWritten(scoped_refptr<net::DrainableIOBuffer> buffer,
++                            int result) {
++    DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
++    --pending_writes_;
++    if (result <= 0) {
++      RequestFinish();
++      return;
++    }
++
++    buffer->DidConsume(result);
++    if (buffer->BytesRemaining() > 0) {
++      WriteCloseBuffer(buffer);
++      return;
++    }
++
++    if (!service_unavailable_mode_) {
++      RequestFinish();
++      return;
++    }
++
++    service_unavailable_write_done_ = true;
++    MaybeFinishServiceUnavailable();
++  }
++
++  void DrainClientForClose() {
++    DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
++    auto buffer = base::MakeRefCounted<net::IOBufferWithSize>(kBufferSize);
++    int result =
++        client_socket_->Read(buffer.get(), buffer->size(),
++                             base::BindOnce(&Connection::OnClientDrainRead,
++                                            base::Unretained(this), buffer));
++    if (result != net::ERR_IO_PENDING) {
++      OnClientDrainRead(buffer, result);
++      return;
++    }
++  }
++
++  void OnClientDrainRead(scoped_refptr<net::IOBuffer> buffer, int result) {
++    DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
++    if (result > 0) {
++      DrainClientForClose();
++      return;
++    }
++
++    service_unavailable_drain_done_ = true;
++    MaybeFinishServiceUnavailable();
++  }
++
++  void MaybeFinishServiceUnavailable() {
++    DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
++    if (service_unavailable_write_done_ && service_unavailable_drain_done_) {
++      RequestFinish();
++    }
++  }
++
++  // Running the callback erases this Connection from the proxy; callers must
++  // return immediately after requesting finish.
++  void RequestFinish() {
++    DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
++    if (pending_writes_ > 0) {
++      pending_destruction_ = true;
++      return;
++    }
++
++    finish_callback_.Run(id_);
++  }
++
++  const int id_;
++  std::unique_ptr<net::StreamSocket> client_socket_;
++  std::unique_ptr<net::TCPClientSocket> backend_socket_;
++  const int backend_port_;
++  base::RepeatingCallback<void(int)> finish_callback_;
++  int pending_writes_ = 0;
++  bool pending_destruction_ = false;
++  bool service_unavailable_mode_ = false;
++  bool service_unavailable_write_done_ = false;
++  bool service_unavailable_drain_done_ = false;
++
++  THREAD_CHECKER(thread_checker_);
++};
++
++BrowserOSServerProxy::BrowserOSServerProxy() {
++  DETACH_FROM_THREAD(thread_checker_);
++}
 +
 +BrowserOSServerProxy::~BrowserOSServerProxy() {
++  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
 +  Stop();
 +}
 +
-+bool BrowserOSServerProxy::Start(
-+    int port,
-+    std::unique_ptr<network::PendingSharedURLLoaderFactory> pending_factory) {
-+  if (server_) {
-+    LOG(WARNING) << "browseros: Proxy already started on port " << bound_port_;
++bool BrowserOSServerProxy::Start(int http_port, int https_port) {
++  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
++  if (http_listener_) {
++    LOG(WARNING) << "browseros: Proxy already started on port "
++                 << bound_http_port_;
 +    return false;
 +  }
 +
-+  // Bind the cloned factory on this (IO) thread.
-+  url_loader_factory_ =
-+      network::SharedURLLoaderFactory::Create(std::move(pending_factory));
++  if (!StartHttpListener(http_port)) {
++    return false;
++  }
 +
-+  auto server_socket =
++  if (https_port != 0) {
++    StartHttpsListener(https_port);
++  }
++
++  return true;
++}
++
++bool BrowserOSServerProxy::StartHttpListener(int http_port) {
++  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
++  if (http_port < 0 || http_port > 65535) {
++    LOG(ERROR) << "browseros: Proxy invalid HTTP port " << http_port;
++    return false;
++  }
++
++  auto listener = std::make_unique<ListenerState>(/*is_https=*/false);
++  listener->socket =
 +      std::make_unique<net::TCPServerSocket>(nullptr, net::NetLogSource());
-+  int result = server_socket->ListenWithAddressAndPort("0.0.0.0", port,
-+                                                        kBackLog);
++  int result = listener->socket->ListenWithAddressAndPort(
++      "0.0.0.0", static_cast<uint16_t>(http_port), kBackLog);
 +  if (result != net::OK) {
-+    LOG(ERROR) << "browseros: Proxy failed to bind 0.0.0.0:" << port
++    LOG(ERROR) << "browseros: Proxy failed to bind 0.0.0.0:" << http_port
 +               << " - " << net::ErrorToString(result);
 +    return false;
 +  }
 +
-+  server_ = std::make_unique<net::HttpServer>(std::move(server_socket), this);
-+  bound_port_ = port;
++  net::IPEndPoint local_address;
++  result = listener->socket->GetLocalAddress(&local_address);
++  if (result != net::OK) {
++    LOG(ERROR) << "browseros: Proxy failed to read bound port - "
++               << net::ErrorToString(result);
++    return false;
++  }
 +
-+  LOG(INFO) << "browseros: MCP proxy listening on 0.0.0.0:" << bound_port_;
++  http_listener_ = std::move(listener);
++  bound_http_port_ = local_address.port();
++  StartAccept(http_listener_.get());
++
++  LOG(INFO) << "browseros: MCP proxy listening on 0.0.0.0:" << bound_http_port_;
++  return true;
++}
++
++bool BrowserOSServerProxy::StartHttpsListener(int https_port) {
++  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
++  if (https_port < 0 || https_port > 65535) {
++    LOG(ERROR) << "browseros: Proxy invalid HTTPS port " << https_port
++               << ", continuing HTTP-only";
++    return false;
++  }
++
++  if (!GenerateTlsCredentials()) {
++    return false;
++  }
++
++  auto listener = std::make_unique<ListenerState>(/*is_https=*/true);
++  listener->socket =
++      std::make_unique<net::TCPServerSocket>(nullptr, net::NetLogSource());
++  int result = listener->socket->ListenWithAddressAndPort(
++      "0.0.0.0", static_cast<uint16_t>(https_port), kBackLog);
++  if (result != net::OK) {
++    LOG(ERROR) << "browseros: HTTPS proxy failed to bind 0.0.0.0:" << https_port
++               << " - " << net::ErrorToString(result)
++               << ", continuing HTTP-only";
++    tls_context_.reset();
++    tls_cert_.reset();
++    tls_key_.reset();
++    return false;
++  }
++
++  net::IPEndPoint local_address;
++  result = listener->socket->GetLocalAddress(&local_address);
++  if (result != net::OK) {
++    LOG(ERROR) << "browseros: HTTPS proxy failed to read bound port - "
++               << net::ErrorToString(result) << ", continuing HTTP-only";
++    tls_context_.reset();
++    tls_cert_.reset();
++    tls_key_.reset();
++    return false;
++  }
++
++  https_listener_ = std::move(listener);
++  bound_https_port_ = local_address.port();
++  StartAccept(https_listener_.get());
++
++  LOG(INFO) << "browseros: HTTPS MCP proxy listening on 0.0.0.0:"
++            << bound_https_port_;
++  return true;
++}
++
++bool BrowserOSServerProxy::GenerateTlsCredentials() {
++  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
++  tls_key_ = std::make_unique<crypto::keypair::PrivateKey>(
++      crypto::keypair::PrivateKey::GenerateEcP256());
++
++  std::string der_cert;
++  const base::Time now = base::Time::Now();
++  const uint32_t serial_number = static_cast<uint32_t>(
++      base::RandIntInclusive(1, std::numeric_limits<int>::max()));
++  if (!net::x509_util::CreateSelfSignedCert(
++          tls_key_->key(), net::x509_util::DIGEST_SHA256, "CN=localhost",
++          serial_number, now - base::Days(1), now + base::Days(3650), {},
++          &der_cert)) {
++    LOG(ERROR) << "browseros: HTTPS proxy failed to create certificate, "
++                  "continuing HTTP-only";
++    tls_key_.reset();
++    return false;
++  }
++
++  tls_cert_ =
++      net::X509Certificate::CreateFromBytes(base::as_byte_span(der_cert));
++  if (!tls_cert_) {
++    LOG(ERROR) << "browseros: HTTPS proxy failed to parse certificate, "
++                  "continuing HTTP-only";
++    tls_key_.reset();
++    return false;
++  }
++
++  tls_context_ = net::CreateSSLServerContext(tls_cert_.get(), tls_key_->key(),
++                                             net::SSLServerConfig());
++  if (!tls_context_) {
++    LOG(ERROR) << "browseros: HTTPS proxy failed to create SSL context, "
++                  "continuing HTTP-only";
++    tls_cert_.reset();
++    tls_key_.reset();
++    return false;
++  }
++
 +  return true;
 +}
 +
 +void BrowserOSServerProxy::Stop() {
-+  pending_loaders_.clear();
-+  if (server_) {
-+    LOG(INFO) << "browseros: Stopping MCP proxy on port " << bound_port_;
-+    server_.reset();
-+    bound_port_ = 0;
++  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
++  weak_factory_.InvalidateWeakPtrs();
++  connections_.clear();
++  tls_handshakes_.clear();
++
++  if (http_listener_) {
++    LOG(INFO) << "browseros: Stopping MCP proxy on port " << bound_http_port_;
++    http_listener_.reset();
 +  }
-+  url_loader_factory_.reset();
++
++  if (https_listener_) {
++    LOG(INFO) << "browseros: Stopping HTTPS MCP proxy on port "
++              << bound_https_port_;
++    https_listener_.reset();
++  }
++
++  tls_context_.reset();
++  tls_cert_.reset();
++  tls_key_.reset();
++  bound_http_port_ = 0;
++  bound_https_port_ = 0;
 +}
 +
 +void BrowserOSServerProxy::SetBackendPort(int port) {
++  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
 +  backend_port_ = port;
 +  LOG(INFO) << "browseros: Proxy backend port set to " << port;
 +}
 +
 +void BrowserOSServerProxy::SetAllowRemote(bool allow) {
++  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
 +  allow_remote_ = allow;
 +  LOG(INFO) << "browseros: Proxy allow_remote set to "
 +            << (allow ? "true" : "false");
 +}
 +
-+void BrowserOSServerProxy::OnConnect(int connection_id) {}
++void BrowserOSServerProxy::StartAccept(ListenerState* listener) {
++  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
 +
-+void BrowserOSServerProxy::OnHttpRequest(
-+    int connection_id,
-+    const net::HttpServerRequestInfo& info) {
-+  if (!allow_remote_ && !info.peer.address().IsLoopback()) {
-+    net::HttpServerResponseInfo response(net::HTTP_FORBIDDEN);
-+    response.SetBody("Remote connections not allowed", "text/plain");
-+    server_->SendResponse(connection_id, response,
-+                          GetProxyTrafficAnnotation());
-+    server_->Close(connection_id);
++  if (!listener || !listener->socket) {
 +    return;
 +  }
 +
-+  ForwardRequest(connection_id, info);
++  listener->pending_accept_socket.reset();
++  listener->pending_peer_address = net::IPEndPoint();
++  int result = listener->socket->Accept(
++      &listener->pending_accept_socket,
++      base::BindOnce(&BrowserOSServerProxy::OnAccept,
++                     weak_factory_.GetWeakPtr(), listener),
++      &listener->pending_peer_address);
++  if (result != net::ERR_IO_PENDING) {
++    OnAccept(listener, result);
++    return;
++  }
 +}
 +
-+void BrowserOSServerProxy::OnWebSocketRequest(
-+    int connection_id,
-+    const net::HttpServerRequestInfo& info) {
-+  server_->Close(connection_id);
-+}
++void BrowserOSServerProxy::OnAccept(ListenerState* listener, int result) {
++  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
 +
-+void BrowserOSServerProxy::OnWebSocketMessage(int connection_id,
-+                                               std::string data) {
-+  server_->Close(connection_id);
-+}
-+
-+void BrowserOSServerProxy::OnClose(int connection_id) {
-+  pending_loaders_.erase(connection_id);
-+}
-+
-+void BrowserOSServerProxy::ForwardRequest(
-+    int connection_id,
-+    const net::HttpServerRequestInfo& info) {
-+  if (backend_port_ <= 0 || !url_loader_factory_) {
-+    Send503(server_.get(), connection_id);
++  if (!listener || !listener->socket) {
 +    return;
 +  }
 +
-+  GURL backend_url("http://127.0.0.1:" + base::NumberToString(backend_port_) +
-+                    info.path);
-+
-+  auto resource_request = std::make_unique<network::ResourceRequest>();
-+  resource_request->url = backend_url;
-+  resource_request->method = info.method;
-+  resource_request->credentials_mode = network::mojom::CredentialsMode::kOmit;
-+
-+  // MCP Streamable HTTP keeps session state in headers: the server assigns
-+  // mcp-session-id on initialize and the client echoes it (plus
-+  // mcp-protocol-version, and last-event-id) on every later request.
-+  // last-event-id is forwarded for protocol completeness only; SSE stream
-+  // resume still cannot traverse this buffering proxy (DownloadToString).
-+  // net::HttpServer lowercases header names.
-+  for (const auto& [name, value] : info.headers) {
-+    if (name == "content-type" || name == "accept" ||
-+        name == "authorization" || name == "mcp-session-id" ||
-+        name == "mcp-protocol-version" || name == "last-event-id") {
-+      resource_request->headers.SetHeader(name, value);
-+    }
++  if (result != net::OK) {
++    LOG(ERROR) << "browseros: " << (listener->is_https ? "HTTPS " : "")
++               << "Proxy accept failed - " << net::ErrorToString(result);
++    base::SingleThreadTaskRunner::GetCurrentDefault()->PostDelayedTask(
++        FROM_HERE,
++        base::BindOnce(&BrowserOSServerProxy::StartAccept,
++                       weak_factory_.GetWeakPtr(), listener),
++        base::Milliseconds(100));
++    return;
 +  }
 +
-+  auto loader = network::SimpleURLLoader::Create(std::move(resource_request),
-+                                                  GetProxyTrafficAnnotation());
++  std::unique_ptr<net::StreamSocket> client_socket =
++      std::move(listener->pending_accept_socket);
++  net::IPEndPoint peer_address = listener->pending_peer_address;
++  listener->pending_peer_address = net::IPEndPoint();
 +
-+  if (!info.data.empty()) {
-+    loader->AttachStringForUpload(info.data);
++  if (!client_socket) {
++    StartAccept(listener);
++    return;
 +  }
 +
-+  loader->SetTimeoutDuration(base::Seconds(300));
++  if (!allow_remote_ && !peer_address.address().IsLoopback()) {
++    StartAccept(listener);
++    return;
++  }
 +
-+  // Relay backend 4xx/5xx (with bodies) instead of masking them as 503.
-+  // Stateful MCP backends answer 4xx for session errors, and clients
-+  // recover from the real status (e.g. re-initialize on 404).
-+  loader->SetAllowHttpErrorResults(true);
++  if (listener->is_https) {
++    StartTlsHandshake(std::move(client_socket));
++  } else {
++    StartConnection(std::move(client_socket));
++  }
 +
-+  auto* loader_ptr = loader.get();
-+  pending_loaders_[connection_id] = std::move(loader);
-+  loader_ptr->DownloadToString(
-+      url_loader_factory_.get(),
-+      base::BindOnce(&BrowserOSServerProxy::OnBackendResponse,
-+                     base::Unretained(this), connection_id),
-+      kMaxResponseBodySize);
++  StartAccept(listener);
 +}
 +
-+void BrowserOSServerProxy::OnBackendResponse(
-+    int connection_id,
-+    std::optional<std::string> response_body) {
-+  auto it = pending_loaders_.find(connection_id);
-+  if (it == pending_loaders_.end() || !server_) {
++void BrowserOSServerProxy::StartConnection(
++    std::unique_ptr<net::StreamSocket> client_socket) {
++  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
++  int connection_id = next_connection_id_++;
++  auto connection = std::make_unique<Connection>(
++      connection_id, std::move(client_socket), backend_port_,
++      base::BindRepeating(&BrowserOSServerProxy::OnConnectionFinished,
++                          base::Unretained(this)));
++  Connection* connection_ptr = connection.get();
++  connections_[connection_id] = std::move(connection);
++  connection_ptr->Start();
++}
++
++void BrowserOSServerProxy::StartTlsHandshake(
++    std::unique_ptr<net::StreamSocket> client_socket) {
++  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
++  if (!tls_context_) {
 +    return;
 +  }
 +
-+  auto loader = std::move(it->second);
-+  pending_loaders_.erase(it);
-+
-+  int response_code = 0;
-+  auto* response_info = loader->ResponseInfo();
-+  if (response_info && response_info->headers) {
-+    response_code = response_info->headers->response_code();
-+  }
-+
-+  if (!response_body.has_value() || response_code == 0) {
-+    Send503(server_.get(), connection_id);
++  std::unique_ptr<net::SSLServerSocket> ssl_socket =
++      tls_context_->CreateSSLServerSocket(std::move(client_socket));
++  if (!ssl_socket) {
 +    return;
 +  }
 +
-+  std::string content_type = "application/json";
-+  if (response_info && response_info->headers) {
-+    std::optional<std::string> ct =
-+        response_info->headers->GetNormalizedHeader("content-type");
-+    if (ct.has_value()) {
-+      content_type = std::move(*ct);
-+    }
++  int handshake_id = next_tls_handshake_id_++;
++  net::SSLServerSocket* ssl_socket_ptr = ssl_socket.get();
++  tls_handshakes_[handshake_id] = std::move(ssl_socket);
++  int result = ssl_socket_ptr->Handshake(
++      base::BindOnce(&BrowserOSServerProxy::OnTlsHandshakeDone,
++                     weak_factory_.GetWeakPtr(), handshake_id));
++  if (result != net::ERR_IO_PENDING) {
++    OnTlsHandshakeDone(handshake_id, result);
++    return;
++  }
++}
++
++void BrowserOSServerProxy::OnTlsHandshakeDone(int handshake_id, int result) {
++  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
++  auto it = tls_handshakes_.find(handshake_id);
++  if (it == tls_handshakes_.end()) {
++    return;
 +  }
 +
-+  net::HttpServerResponseInfo response(
-+      static_cast<net::HttpStatusCode>(response_code));
-+  response.SetBody(*response_body, content_type);
-+
-+  // Without the assigned mcp-session-id a stateful MCP client can never
-+  // join its session, so relay it alongside the body.
-+  if (response_info && response_info->headers) {
-+    std::optional<std::string> session_id =
-+        response_info->headers->GetNormalizedHeader("mcp-session-id");
-+    if (session_id.has_value()) {
-+      response.AddHeader("mcp-session-id", *session_id);
-+    }
++  if (result != net::OK) {
++    VLOG(1) << "browseros: HTTPS proxy handshake failed - "
++            << net::ErrorToString(result);
++    tls_handshakes_.erase(it);
++    return;
 +  }
 +
-+  server_->SendResponse(connection_id, response, GetProxyTrafficAnnotation());
++  std::unique_ptr<net::StreamSocket> client_socket = std::move(it->second);
++  tls_handshakes_.erase(it);
++  StartConnection(std::move(client_socket));
++}
++
++void BrowserOSServerProxy::OnConnectionFinished(int connection_id) {
++  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
++
++  connections_.erase(connection_id);
 +}
 +
 +}  // namespace browseros

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_proxy.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_proxy.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/server/browseros_server_proxy.h b/chrome/browser/browseros/server/browseros_server_proxy.h
 new file mode 100644
-index 0000000000000..586296d473849
+index 0000000000000..0e62a9f7995e1
 --- /dev/null
 +++ b/chrome/browser/browseros/server/browseros_server_proxy.h
-@@ -0,0 +1,79 @@
+@@ -0,0 +1,93 @@
 +// Copyright 2024 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -11,73 +11,87 @@ index 0000000000000..586296d473849
 +#ifndef CHROME_BROWSER_BROWSEROS_SERVER_BROWSEROS_SERVER_PROXY_H_
 +#define CHROME_BROWSER_BROWSEROS_SERVER_BROWSEROS_SERVER_PROXY_H_
 +
++#include <cstddef>
 +#include <memory>
-+#include <optional>
-+#include <string>
 +
 +#include "base/containers/flat_map.h"
 +#include "base/memory/scoped_refptr.h"
-+#include "net/server/http_server.h"
++#include "base/memory/weak_ptr.h"
++#include "base/threading/thread_checker.h"
 +
-+namespace network {
-+class PendingSharedURLLoaderFactory;
-+class SharedURLLoaderFactory;
-+class SimpleURLLoader;
-+}  // namespace network
++namespace net {
++class SSLServerContext;
++class SSLServerSocket;
++class StreamSocket;
++class TCPServerSocket;
++class X509Certificate;
++}  // namespace net
++
++namespace crypto::keypair {
++class PrivateKey;
++}  // namespace crypto::keypair
 +
 +namespace browseros {
 +
-+// HTTP proxy that binds a stable port and forwards all requests to the
-+// sidecar's ephemeral backend port. Returns 503 when no backend is configured.
++// HTTP and HTTPS proxy that fronts the BrowserOS sidecar without parsing or
++// rewriting traffic.
 +//
-+// Threading: The entire proxy runs on the IO thread. The manager obtains a
-+// SharedURLLoaderFactory on the UI thread, calls Clone() to get a
-+// PendingSharedURLLoaderFactory, and passes it to Start() on the IO thread.
-+// Start() binds it into a new SharedURLLoaderFactory usable from IO.
-+// This keeps net::HttpServer and SimpleURLLoader on the same thread.
-+class BrowserOSServerProxy : public net::HttpServer::Delegate {
++// HTTPS uses a per-start in-memory self-signed certificate. HTTPS setup
++// failures log and leave the proxy running HTTP-only.
++//
++// Threading: The entire proxy runs on the IO thread. The manager creates the
++// proxy on the UI thread, then starts, updates, stops, and destroys it on the
++// IO thread.
++class BrowserOSServerProxy {
 + public:
 +  BrowserOSServerProxy();
-+  ~BrowserOSServerProxy() override;
++  ~BrowserOSServerProxy();
 +
 +  BrowserOSServerProxy(const BrowserOSServerProxy&) = delete;
 +  BrowserOSServerProxy& operator=(const BrowserOSServerProxy&) = delete;
 +
-+  // Bind proxy on the given port. |pending_factory| is a cloned factory
-+  // that will be bound on the current (IO) thread. Returns true on success.
-+  bool Start(int port,
-+             std::unique_ptr<network::PendingSharedURLLoaderFactory>
-+                 pending_factory);
-+
++  // Binds the stable HTTP proxy port and starts accepting TCP connections.
++  bool Start(int http_port, int https_port);
 +  void Stop();
 +
 +  void SetBackendPort(int port);
 +  void SetAllowRemote(bool allow);
 +
-+  int GetPort() const { return bound_port_; }
++  int GetPort() const { return bound_http_port_; }
++  int GetHttpsPort() const { return bound_https_port_; }
++  size_t GetConnectionCountForTesting() const { return connections_.size(); }
 +
 + private:
-+  // net::HttpServer::Delegate
-+  void OnConnect(int connection_id) override;
-+  void OnHttpRequest(int connection_id,
-+                     const net::HttpServerRequestInfo& info) override;
-+  void OnWebSocketRequest(int connection_id,
-+                          const net::HttpServerRequestInfo& info) override;
-+  void OnWebSocketMessage(int connection_id, std::string data) override;
-+  void OnClose(int connection_id) override;
++  class Connection;
++  struct ListenerState;
 +
-+  void ForwardRequest(int connection_id,
-+                      const net::HttpServerRequestInfo& info);
-+  void OnBackendResponse(int connection_id,
-+                         std::optional<std::string> response_body);
++  bool StartHttpListener(int http_port);
++  bool StartHttpsListener(int https_port);
++  bool GenerateTlsCredentials();
++  void StartAccept(ListenerState* listener);
++  void OnAccept(ListenerState* listener, int result);
++  void StartConnection(std::unique_ptr<net::StreamSocket> client_socket);
++  void StartTlsHandshake(std::unique_ptr<net::StreamSocket> client_socket);
++  void OnTlsHandshakeDone(int handshake_id, int result);
++  void OnConnectionFinished(int connection_id);
 +
-+  std::unique_ptr<net::HttpServer> server_;
-+  base::flat_map<int, std::unique_ptr<network::SimpleURLLoader>>
-+      pending_loaders_;
-+  scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
++  std::unique_ptr<ListenerState> http_listener_;
++  std::unique_ptr<ListenerState> https_listener_;
++  base::flat_map<int, std::unique_ptr<Connection>> connections_;
++  base::flat_map<int, std::unique_ptr<net::SSLServerSocket>> tls_handshakes_;
++  int next_connection_id_ = 1;
++  int next_tls_handshake_id_ = 1;
 +  int backend_port_ = 0;
-+  int bound_port_ = 0;
++  int bound_http_port_ = 0;
++  int bound_https_port_ = 0;
 +  bool allow_remote_ = false;
++
++  std::unique_ptr<crypto::keypair::PrivateKey> tls_key_;
++  scoped_refptr<net::X509Certificate> tls_cert_;
++  std::unique_ptr<net::SSLServerContext> tls_context_;
++
++  THREAD_CHECKER(thread_checker_);
++  base::WeakPtrFactory<BrowserOSServerProxy> weak_factory_{this};
 +};
 +
 +}  // namespace browseros

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_proxy_unittest.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/server/browseros_server_proxy_unittest.cc
@@ -1,0 +1,1263 @@
+diff --git a/chrome/browser/browseros/server/browseros_server_proxy_unittest.cc b/chrome/browser/browseros/server/browseros_server_proxy_unittest.cc
+new file mode 100644
+index 0000000000000..522e6b7c49265
+--- /dev/null
++++ b/chrome/browser/browseros/server/browseros_server_proxy_unittest.cc
+@@ -0,0 +1,1257 @@
++// Copyright 2024 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "chrome/browser/browseros/server/browseros_server_proxy.h"
++
++#include <deque>
++#include <memory>
++#include <optional>
++#include <string>
++#include <string_view>
++#include <utility>
++
++#include "build/build_config.h"
++
++#if BUILDFLAG(IS_POSIX)
++#include <sys/socket.h>
++#endif
++
++#include "base/byte_count.h"
++#include "base/containers/span.h"
++#include "base/functional/bind.h"
++#include "base/functional/callback.h"
++#include "base/memory/ref_counted.h"
++#include "base/memory/weak_ptr.h"
++#include "base/run_loop.h"
++#include "base/strings/string_number_conversions.h"
++#include "base/synchronization/lock.h"
++#include "base/test/task_environment.h"
++#include "base/threading/thread.h"
++#include "base/time/time.h"
++#include "base/timer/timer.h"
++#include "net/base/address_list.h"
++#include "net/base/host_port_pair.h"
++#include "net/base/io_buffer.h"
++#include "net/base/ip_address.h"
++#include "net/base/ip_endpoint.h"
++#include "net/base/net_errors.h"
++#include "net/base/test_completion_callback.h"
++#include "net/cert/mock_cert_verifier.h"
++#include "net/http/http_response_headers.h"
++#include "net/http/http_status_code.h"
++#include "net/http/http_util.h"
++#include "net/http/transport_security_state.h"
++#include "net/log/net_log_source.h"
++#include "net/socket/socket_descriptor.h"
++#include "net/socket/ssl_client_socket.h"
++#include "net/socket/stream_socket.h"
++#include "net/socket/tcp_client_socket.h"
++#include "net/socket/tcp_server_socket.h"
++#include "net/ssl/ssl_client_session_cache.h"
++#include "net/ssl/ssl_config.h"
++#include "net/ssl/test_ssl_config_service.h"
++#include "net/test/embedded_test_server/embedded_test_server.h"
++#include "net/test/embedded_test_server/http_request.h"
++#include "net/test/embedded_test_server/http_response.h"
++#include "net/test/gtest_util.h"
++#include "net/traffic_annotation/network_traffic_annotation_test_helper.h"
++#include "testing/gmock/include/gmock/gmock.h"
++#include "testing/gtest/include/gtest/gtest.h"
++
++namespace browseros {
++namespace {
++
++using net::test::IsOk;
++using testing::HasSubstr;
++
++constexpr char kServiceUnavailableResponse[] =
++    "HTTP/1.1 503 Service Unavailable\r\n"
++    "Content-Type: text/plain\r\n"
++    "Content-Length: 19\r\n"
++    "Connection: close\r\n"
++    "\r\n"
++    "Service Unavailable";
++
++class ReadResultState : public base::RefCounted<ReadResultState> {
++ public:
++  void Complete(int read_result) {
++    result = read_result;
++    done = true;
++    if (quit) {
++      quit.Run();
++    }
++  }
++
++  int result = net::ERR_IO_PENDING;
++  bool done = false;
++  base::RepeatingClosure quit;
++
++ private:
++  friend class base::RefCounted<ReadResultState>;
++  ~ReadResultState() = default;
++};
++
++std::string ResponseWithBody(std::string_view body) {
++  return "HTTP/1.1 200 OK\r\nContent-Length: " +
++         base::NumberToString(body.size()) +
++         "\r\nContent-Type: text/plain\r\n\r\n" + std::string(body);
++}
++
++char PatternByte(size_t index) {
++  return static_cast<char>('!' + (index % 90));
++}
++
++std::string MakePattern(size_t size) {
++  std::string data(size, '\0');
++  for (size_t i = 0; i < data.size(); ++i) {
++    data[i] = PatternByte(i);
++  }
++  return data;
++}
++
++testing::AssertionResult HasPattern(std::string_view data) {
++  for (size_t i = 0; i < data.size(); ++i) {
++    if (data[i] != PatternByte(i)) {
++      return testing::AssertionFailure()
++             << "byte " << i << " expected " << static_cast<int>(PatternByte(i))
++             << " got " << static_cast<int>(data[i]);
++    }
++  }
++  return testing::AssertionSuccess();
++}
++
++class TestTcpClient {
++ public:
++  TestTcpClient() = default;
++
++  TestTcpClient(const TestTcpClient&) = delete;
++  TestTcpClient& operator=(const TestTcpClient&) = delete;
++
++  int Connect(int port) {
++    socket_ = std::make_unique<net::TCPClientSocket>(
++        net::AddressList(
++            net::IPEndPoint(net::IPAddress::IPv4Localhost(), port)),
++        nullptr, nullptr, nullptr, net::NetLogSource());
++
++    net::TestCompletionCallback callback;
++    int result = socket_->Connect(callback.callback());
++    return callback.GetResult(result);
++  }
++
++  bool Write(std::string_view data) {
++    auto buffer = base::MakeRefCounted<net::DrainableIOBuffer>(
++        base::MakeRefCounted<net::StringIOBuffer>(std::string(data)),
++        data.size());
++
++    while (buffer->BytesRemaining() > 0) {
++      net::TestCompletionCallback callback;
++      int result =
++          socket_->Write(buffer.get(), buffer->BytesRemaining(),
++                         callback.callback(), TRAFFIC_ANNOTATION_FOR_TESTS);
++      result = callback.GetResult(result);
++      if (result <= 0) {
++        return false;
++      }
++      buffer->DidConsume(result);
++    }
++
++    return true;
++  }
++
++  bool ReadExact(size_t byte_count,
++                 std::string* response,
++                 base::TimeDelta timeout = base::Seconds(10)) {
++    response->clear();
++    while (response->size() < byte_count) {
++      std::string chunk;
++      int result = ReadSome(&chunk, timeout);
++      if (result <= 0) {
++        return false;
++      }
++      response->append(chunk);
++    }
++    return true;
++  }
++
++  bool ReadHttpResponse(std::string* response) {
++    response->clear();
++    while (!IsCompleteHttpResponse(*response)) {
++      std::string chunk;
++      int result = ReadSome(&chunk, base::Seconds(10));
++      if (result <= 0) {
++        return false;
++      }
++      response->append(chunk);
++    }
++    return true;
++  }
++
++  std::string ReadUntilEOF() {
++    std::string response;
++    while (true) {
++      std::string chunk;
++      int result = ReadSome(&chunk, base::Seconds(10));
++      if (result <= 0) {
++        return response;
++      }
++      response.append(chunk);
++    }
++  }
++
++  bool ShutdownWrite() {
++#if BUILDFLAG(IS_POSIX)
++    return shutdown(socket_->SocketDescriptorForTesting(), SHUT_WR) == 0;
++#else
++    return false;
++#endif
++  }
++
++  void Close() { socket_.reset(); }
++
++ private:
++  int ReadSome(std::string* chunk, base::TimeDelta timeout) {
++    auto buffer = base::MakeRefCounted<net::IOBufferWithSize>(4096);
++    auto state = base::MakeRefCounted<ReadResultState>();
++    int result =
++        socket_->Read(buffer.get(), buffer->size(),
++                      base::BindOnce(&ReadResultState::Complete, state));
++    if (result == net::ERR_IO_PENDING) {
++      base::RunLoop run_loop;
++      base::OneShotTimer timer;
++      state->quit = run_loop.QuitClosure();
++      timer.Start(FROM_HERE, timeout, run_loop.QuitClosure());
++      run_loop.Run();
++      state->quit.Reset();
++      if (!state->done) {
++        socket_.reset();
++        chunk->clear();
++        return net::ERR_TIMED_OUT;
++      }
++      result = state->result;
++    }
++    if (result > 0) {
++      chunk->assign(buffer->data(), result);
++    } else {
++      chunk->clear();
++    }
++    return result;
++  }
++
++  bool IsCompleteHttpResponse(const std::string& response) {
++    size_t end_of_headers =
++        net::HttpUtil::LocateEndOfHeaders(base::as_byte_span(response));
++    if (end_of_headers == std::string::npos) {
++      return false;
++    }
++
++    auto headers = base::MakeRefCounted<net::HttpResponseHeaders>(
++        net::HttpUtil::AssembleRawHeaders(
++            std::string_view(response.data(), end_of_headers)));
++    std::optional<base::ByteCount> content_length = headers->GetContentLength();
++    if (!content_length.has_value()) {
++      return false;
++    }
++
++    return response.size() - end_of_headers >=
++           static_cast<size_t>(content_length->InBytes());
++  }
++
++  std::unique_ptr<net::TCPClientSocket> socket_;
++};
++
++class TestTlsClient {
++ public:
++  TestTlsClient()
++      : ssl_config_service_(net::SSLContextConfig()),
++        ssl_client_session_cache_(net::SSLClientSessionCache::Config()) {
++    cert_verifier_.set_default_result(net::OK);
++    ssl_client_context_ = std::make_unique<net::SSLClientContext>(
++        &ssl_config_service_, &cert_verifier_, &transport_security_state_,
++        &ssl_client_session_cache_, nullptr);
++  }
++
++  TestTlsClient(const TestTlsClient&) = delete;
++  TestTlsClient& operator=(const TestTlsClient&) = delete;
++
++  int Connect(int port) {
++    auto tcp_socket = std::make_unique<net::TCPClientSocket>(
++        net::AddressList(
++            net::IPEndPoint(net::IPAddress::IPv4Localhost(), port)),
++        nullptr, nullptr, nullptr, net::NetLogSource());
++
++    net::TestCompletionCallback tcp_callback;
++    int result = tcp_socket->Connect(tcp_callback.callback());
++    result = tcp_callback.GetResult(result);
++    if (result != net::OK) {
++      return result;
++    }
++
++    ssl_socket_ = ssl_client_context_->CreateSSLClientSocket(
++        std::move(tcp_socket), net::HostPortPair("localhost", port),
++        net::SSLConfig());
++    if (!ssl_socket_) {
++      return net::ERR_FAILED;
++    }
++
++    net::TestCompletionCallback ssl_callback;
++    result = ssl_socket_->Connect(ssl_callback.callback());
++    return ssl_callback.GetResult(result);
++  }
++
++  bool Write(std::string_view data) {
++    auto buffer = base::MakeRefCounted<net::DrainableIOBuffer>(
++        base::MakeRefCounted<net::StringIOBuffer>(std::string(data)),
++        data.size());
++
++    while (buffer->BytesRemaining() > 0) {
++      net::TestCompletionCallback callback;
++      int result =
++          ssl_socket_->Write(buffer.get(), buffer->BytesRemaining(),
++                             callback.callback(), TRAFFIC_ANNOTATION_FOR_TESTS);
++      result = callback.GetResult(result);
++      if (result <= 0) {
++        return false;
++      }
++      buffer->DidConsume(result);
++    }
++
++    return true;
++  }
++
++  bool ReadExact(size_t byte_count,
++                 std::string* response,
++                 base::TimeDelta timeout = base::Seconds(10)) {
++    response->clear();
++    while (response->size() < byte_count) {
++      std::string chunk;
++      int result = ReadSome(&chunk, timeout);
++      if (result <= 0) {
++        return false;
++      }
++      response->append(chunk);
++    }
++    return true;
++  }
++
++  std::string ReadUntilEOF() {
++    std::string response;
++    while (true) {
++      std::string chunk;
++      int result = ReadSome(&chunk, base::Seconds(10));
++      if (result <= 0) {
++        return response;
++      }
++      response.append(chunk);
++    }
++  }
++
++  void Close() { ssl_socket_.reset(); }
++
++ private:
++  int ReadSome(std::string* chunk, base::TimeDelta timeout) {
++    auto buffer = base::MakeRefCounted<net::IOBufferWithSize>(4096);
++    auto state = base::MakeRefCounted<ReadResultState>();
++    int result =
++        ssl_socket_->Read(buffer.get(), buffer->size(),
++                          base::BindOnce(&ReadResultState::Complete, state));
++    if (result == net::ERR_IO_PENDING) {
++      base::RunLoop run_loop;
++      base::OneShotTimer timer;
++      state->quit = run_loop.QuitClosure();
++      timer.Start(FROM_HERE, timeout, run_loop.QuitClosure());
++      run_loop.Run();
++      state->quit.Reset();
++      if (!state->done) {
++        ssl_socket_.reset();
++        chunk->clear();
++        return net::ERR_TIMED_OUT;
++      }
++      result = state->result;
++    }
++    if (result > 0) {
++      chunk->assign(buffer->data(), result);
++    } else {
++      chunk->clear();
++    }
++    return result;
++  }
++
++  net::TestSSLConfigService ssl_config_service_;
++  net::MockCertVerifier cert_verifier_;
++  net::TransportSecurityState transport_security_state_;
++  net::SSLClientSessionCache ssl_client_session_cache_;
++  std::unique_ptr<net::SSLClientContext> ssl_client_context_;
++  std::unique_ptr<net::SSLClientSocket> ssl_socket_;
++};
++
++class ScriptedTcpBackend {
++ public:
++  ScriptedTcpBackend() = default;
++
++  ScriptedTcpBackend(const ScriptedTcpBackend&) = delete;
++  ScriptedTcpBackend& operator=(const ScriptedTcpBackend&) = delete;
++
++  ~ScriptedTcpBackend() { Stop(); }
++
++  bool Start() {
++    server_socket_ =
++        std::make_unique<net::TCPServerSocket>(nullptr, net::NetLogSource());
++    int result = server_socket_->ListenWithAddressAndPort("127.0.0.1", 0, 1);
++    if (result != net::OK) {
++      return false;
++    }
++
++    net::IPEndPoint local_address;
++    result = server_socket_->GetLocalAddress(&local_address);
++    if (result != net::OK) {
++      return false;
++    }
++
++    port_ = local_address.port();
++    StartAccept();
++    return true;
++  }
++
++  void Stop() {
++    weak_factory_.InvalidateWeakPtrs();
++    accepted_socket_.reset();
++    pending_accept_socket_.reset();
++    server_socket_.reset();
++    read_buffer_.reset();
++    write_buffers_.clear();
++    writing_ = false;
++    close_after_writes_ = false;
++  }
++
++  bool QueueWrite(std::string data) {
++    if (!accepted_socket_) {
++      return false;
++    }
++
++    size_t data_size = data.size();
++    write_buffers_.push_back(base::MakeRefCounted<net::DrainableIOBuffer>(
++        base::MakeRefCounted<net::StringIOBuffer>(std::move(data)), data_size));
++    if (!writing_) {
++      WriteMore();
++    }
++    return true;
++  }
++
++  void CloseAfterPendingWrites() {
++    close_after_writes_ = true;
++    if (!writing_ && write_buffers_.empty()) {
++      accepted_socket_.reset();
++    }
++  }
++
++  int port() const { return port_; }
++  bool is_connected() const { return accepted_socket_ != nullptr; }
++  const std::string& received_bytes() const { return received_bytes_; }
++
++ private:
++  void StartAccept() {
++    int result = server_socket_->Accept(
++        &pending_accept_socket_, base::BindOnce(&ScriptedTcpBackend::OnAccept,
++                                                weak_factory_.GetWeakPtr()));
++    if (result != net::ERR_IO_PENDING) {
++      OnAccept(result);
++    }
++  }
++
++  void OnAccept(int result) {
++    if (result != net::OK) {
++      return;
++    }
++
++    accepted_socket_ = std::move(pending_accept_socket_);
++    StartRead();
++  }
++
++  void StartRead() {
++    if (!accepted_socket_) {
++      return;
++    }
++
++    read_buffer_ = base::MakeRefCounted<net::IOBufferWithSize>(4096);
++    int result =
++        accepted_socket_->Read(read_buffer_.get(), read_buffer_->size(),
++                               base::BindOnce(&ScriptedTcpBackend::OnRead,
++                                              weak_factory_.GetWeakPtr()));
++    if (result != net::ERR_IO_PENDING) {
++      OnRead(result);
++    }
++  }
++
++  void OnRead(int result) {
++    if (result <= 0) {
++      accepted_socket_.reset();
++      return;
++    }
++
++    received_bytes_.append(read_buffer_->data(), result);
++    StartRead();
++  }
++
++  void WriteMore() {
++    if (!accepted_socket_ || write_buffers_.empty()) {
++      writing_ = false;
++      if (close_after_writes_) {
++        accepted_socket_.reset();
++      }
++      return;
++    }
++
++    writing_ = true;
++    scoped_refptr<net::DrainableIOBuffer> buffer = write_buffers_.front();
++    int result =
++        accepted_socket_->Write(buffer.get(), buffer->BytesRemaining(),
++                                base::BindOnce(&ScriptedTcpBackend::OnWritten,
++                                               weak_factory_.GetWeakPtr()),
++                                TRAFFIC_ANNOTATION_FOR_TESTS);
++    if (result != net::ERR_IO_PENDING) {
++      OnWritten(result);
++    }
++  }
++
++  void OnWritten(int result) {
++    if (result <= 0) {
++      accepted_socket_.reset();
++      write_buffers_.clear();
++      writing_ = false;
++      return;
++    }
++
++    scoped_refptr<net::DrainableIOBuffer> buffer = write_buffers_.front();
++    buffer->DidConsume(result);
++    if (buffer->BytesRemaining() == 0) {
++      write_buffers_.pop_front();
++    }
++    WriteMore();
++  }
++
++  std::unique_ptr<net::TCPServerSocket> server_socket_;
++  std::unique_ptr<net::StreamSocket> pending_accept_socket_;
++  std::unique_ptr<net::StreamSocket> accepted_socket_;
++  scoped_refptr<net::IOBufferWithSize> read_buffer_;
++  std::deque<scoped_refptr<net::DrainableIOBuffer>> write_buffers_;
++  std::string received_bytes_;
++  int port_ = 0;
++  bool writing_ = false;
++  bool close_after_writes_ = false;
++  base::WeakPtrFactory<ScriptedTcpBackend> weak_factory_{this};
++};
++
++class KeepAliveBackend {
++ public:
++  KeepAliveBackend() = default;
++
++  KeepAliveBackend(const KeepAliveBackend&) = delete;
++  KeepAliveBackend& operator=(const KeepAliveBackend&) = delete;
++
++  ~KeepAliveBackend() { Stop(); }
++
++  bool Start() {
++    server_socket_ =
++        std::make_unique<net::TCPServerSocket>(nullptr, net::NetLogSource());
++    int result = server_socket_->ListenWithAddressAndPort("127.0.0.1", 0, 1);
++    if (result != net::OK) {
++      return false;
++    }
++
++    net::IPEndPoint local_address;
++    result = server_socket_->GetLocalAddress(&local_address);
++    if (result != net::OK) {
++      return false;
++    }
++
++    port_ = local_address.port();
++    StartAccept();
++    return true;
++  }
++
++  void Stop() {
++    weak_factory_.InvalidateWeakPtrs();
++    accepted_socket_.reset();
++    pending_accept_socket_.reset();
++    server_socket_.reset();
++    write_buffer_.reset();
++    read_buffer_.reset();
++  }
++
++  int port() const { return port_; }
++  int request_count() const { return request_count_; }
++
++ private:
++  void StartAccept() {
++    int result = server_socket_->Accept(
++        &pending_accept_socket_, base::BindOnce(&KeepAliveBackend::OnAccept,
++                                                weak_factory_.GetWeakPtr()));
++    if (result != net::ERR_IO_PENDING) {
++      OnAccept(result);
++    }
++  }
++
++  void OnAccept(int result) {
++    if (result != net::OK) {
++      return;
++    }
++
++    accepted_socket_ = std::move(pending_accept_socket_);
++    StartRead();
++  }
++
++  void StartRead() {
++    read_buffer_ = base::MakeRefCounted<net::IOBufferWithSize>(4096);
++    int result = accepted_socket_->Read(
++        read_buffer_.get(), read_buffer_->size(),
++        base::BindOnce(&KeepAliveBackend::OnRead, weak_factory_.GetWeakPtr()));
++    if (result != net::ERR_IO_PENDING) {
++      OnRead(result);
++    }
++  }
++
++  void OnRead(int result) {
++    if (result <= 0) {
++      accepted_socket_.reset();
++      return;
++    }
++
++    request_bytes_.append(read_buffer_->data(), result);
++    if (request_bytes_.find("\r\n\r\n") == std::string::npos) {
++      StartRead();
++      return;
++    }
++
++    request_bytes_.clear();
++    ++request_count_;
++    const bool close_after_write = request_count_ == 2;
++    std::string response = request_count_ == 1
++                               ? ResponseWithBody("first-body")
++                               : ResponseWithBody("second-body");
++    WriteResponse(std::move(response), close_after_write);
++  }
++
++  void WriteResponse(std::string response, bool close_after_write) {
++    size_t response_size = response.size();
++    write_buffer_ = base::MakeRefCounted<net::DrainableIOBuffer>(
++        base::MakeRefCounted<net::StringIOBuffer>(std::move(response)),
++        response_size);
++    close_after_write_ = close_after_write;
++    WriteMore();
++  }
++
++  void WriteMore() {
++    int result = accepted_socket_->Write(
++        write_buffer_.get(), write_buffer_->BytesRemaining(),
++        base::BindOnce(&KeepAliveBackend::OnWritten,
++                       weak_factory_.GetWeakPtr()),
++        TRAFFIC_ANNOTATION_FOR_TESTS);
++    if (result != net::ERR_IO_PENDING) {
++      OnWritten(result);
++    }
++  }
++
++  void OnWritten(int result) {
++    if (result <= 0) {
++      accepted_socket_.reset();
++      return;
++    }
++
++    write_buffer_->DidConsume(result);
++    if (write_buffer_->BytesRemaining() > 0) {
++      WriteMore();
++      return;
++    }
++
++    write_buffer_.reset();
++    if (close_after_write_) {
++      accepted_socket_.reset();
++      return;
++    }
++
++    StartRead();
++  }
++
++  std::unique_ptr<net::TCPServerSocket> server_socket_;
++  std::unique_ptr<net::StreamSocket> pending_accept_socket_;
++  std::unique_ptr<net::StreamSocket> accepted_socket_;
++  scoped_refptr<net::IOBufferWithSize> read_buffer_;
++  scoped_refptr<net::DrainableIOBuffer> write_buffer_;
++  std::string request_bytes_;
++  int port_ = 0;
++  int request_count_ = 0;
++  bool close_after_write_ = false;
++  base::WeakPtrFactory<KeepAliveBackend> weak_factory_{this};
++};
++
++class BrowserOSServerProxyTest : public testing::Test {
++ protected:
++  void SetUp() override {
++    ASSERT_TRUE(proxy_.Start(0, 0));
++    proxy_.SetAllowRemote(false);
++  }
++
++  void TearDown() override {
++    proxy_.Stop();
++    task_environment_.RunUntilIdle();
++  }
++
++  void StartEmbeddedBackend() {
++    ASSERT_TRUE(backend_.Start());
++    proxy_.SetBackendPort(backend_.port());
++  }
++
++  void RestartProxyWithHttps() {
++    proxy_.Stop();
++    task_environment_.RunUntilIdle();
++
++    for (int attempt = 0; attempt < 5; ++attempt) {
++      ASSERT_TRUE(proxy_.Start(0, GetUnusedLocalPort()));
++      proxy_.SetAllowRemote(false);
++      if (proxy_.GetHttpsPort() > 0) {
++        ASSERT_GT(proxy_.GetPort(), 0);
++        return;
++      }
++
++      proxy_.Stop();
++      task_environment_.RunUntilIdle();
++    }
++
++    FAIL() << "HTTPS listener failed to bind after retries";
++  }
++
++  int GetUnusedLocalPort() {
++    net::TCPServerSocket socket(nullptr, net::NetLogSource());
++    EXPECT_THAT(socket.ListenWithAddressAndPort("127.0.0.1", 0, 1), IsOk());
++
++    net::IPEndPoint local_address;
++    EXPECT_THAT(socket.GetLocalAddress(&local_address), IsOk());
++    return local_address.port();
++  }
++
++  template <typename Predicate>
++  bool RunUntil(Predicate predicate,
++                base::TimeDelta timeout = base::Seconds(10)) {
++    const base::TimeTicks deadline = base::TimeTicks::Now() + timeout;
++    while (!predicate()) {
++      if (base::TimeTicks::Now() >= deadline) {
++        return false;
++      }
++
++      base::RunLoop run_loop;
++      base::OneShotTimer timer;
++      timer.Start(FROM_HERE, base::Milliseconds(10), run_loop.QuitClosure());
++      run_loop.Run();
++    }
++    return true;
++  }
++
++  base::test::TaskEnvironment task_environment_{
++      base::test::TaskEnvironment::MainThreadType::IO};
++  BrowserOSServerProxy proxy_;
++  net::EmbeddedTestServer backend_;
++  base::Lock lock_;
++};
++
++TEST(BrowserOSServerProxyThreadingTest,
++     StartsOnIoThreadAfterConstructionOnAnotherThread) {
++  base::test::TaskEnvironment task_environment{
++      base::test::TaskEnvironment::MainThreadType::IO};
++  base::Thread construction_thread("proxy_construction_thread");
++  ASSERT_TRUE(construction_thread.Start());
++
++  std::unique_ptr<BrowserOSServerProxy> proxy;
++  base::RunLoop run_loop;
++  construction_thread.task_runner()->PostTask(
++      FROM_HERE, base::BindOnce(
++                     [](std::unique_ptr<BrowserOSServerProxy>* proxy,
++                        base::OnceClosure done) {
++                       *proxy = std::make_unique<BrowserOSServerProxy>();
++                       std::move(done).Run();
++                     },
++                     &proxy, run_loop.QuitClosure()));
++  run_loop.Run();
++  construction_thread.Stop();
++
++  ASSERT_TRUE(proxy);
++  ASSERT_TRUE(proxy->Start(0, 0));
++  EXPECT_GT(proxy->GetPort(), 0);
++  proxy->Stop();
++}
++
++TEST_F(BrowserOSServerProxyTest, GetForwardsRawResponseAndRequestHeaders) {
++  std::string received_custom_header;
++  backend_.RegisterRequestHandler(base::BindRepeating(
++      [](base::Lock* lock, std::string* received_custom_header,
++         const net::test_server::HttpRequest& request)
++          -> std::unique_ptr<net::test_server::HttpResponse> {
++        if (request.relative_url != "/get") {
++          return nullptr;
++        }
++
++        auto header = request.headers.find("x-custom-foo");
++        {
++          base::AutoLock auto_lock(*lock);
++          if (header != request.headers.end()) {
++            *received_custom_header = header->second;
++          }
++        }
++
++        auto response = std::make_unique<net::test_server::BasicHttpResponse>();
++        response->set_code(net::HTTP_CREATED);
++        response->set_content_type("text/plain");
++        response->set_content("get-body");
++        response->AddCustomHeader("X-Backend-Header", "get-value");
++        return response;
++      },
++      &lock_, &received_custom_header));
++  StartEmbeddedBackend();
++
++  TestTcpClient client;
++  ASSERT_THAT(client.Connect(proxy_.GetPort()), IsOk());
++  ASSERT_TRUE(
++      client.Write("GET /get HTTP/1.1\r\n"
++                   "Host: example.test\r\n"
++                   "x-custom-foo: bar\r\n"
++                   "Connection: close\r\n"
++                   "\r\n"));
++
++  EXPECT_EQ(
++      "HTTP/1.1 201 Created\r\n"
++      "Connection: close\r\n"
++      "Content-Length: 8\r\n"
++      "Content-Type: text/plain\r\n"
++      "X-Backend-Header: get-value\r\n"
++      "\r\n"
++      "get-body",
++      client.ReadUntilEOF());
++
++  {
++    base::AutoLock auto_lock(lock_);
++    EXPECT_EQ("bar", received_custom_header);
++  }
++}
++
++TEST_F(BrowserOSServerProxyTest, PostBodyReachesBackend) {
++  std::string received_body;
++  backend_.RegisterRequestHandler(base::BindRepeating(
++      [](base::Lock* lock, std::string* received_body,
++         const net::test_server::HttpRequest& request)
++          -> std::unique_ptr<net::test_server::HttpResponse> {
++        if (request.relative_url != "/post") {
++          return nullptr;
++        }
++
++        {
++          base::AutoLock auto_lock(*lock);
++          *received_body = request.content;
++        }
++
++        auto response = std::make_unique<net::test_server::BasicHttpResponse>();
++        response->set_code(net::HTTP_OK);
++        response->set_content_type("text/plain");
++        response->set_content("post-ok");
++        return response;
++      },
++      &lock_, &received_body));
++  StartEmbeddedBackend();
++
++  constexpr char kBody[] = "field=alpha&value=beta";
++  TestTcpClient client;
++  ASSERT_THAT(client.Connect(proxy_.GetPort()), IsOk());
++  ASSERT_TRUE(
++      client.Write("POST /post HTTP/1.1\r\n"
++                   "Host: example.test\r\n"
++                   "Content-Type: application/x-www-form-urlencoded\r\n"
++                   "Content-Length: 22\r\n"
++                   "Connection: close\r\n"
++                   "\r\n" +
++                   std::string(kBody)));
++
++  EXPECT_THAT(client.ReadUntilEOF(), HasSubstr("post-ok"));
++  {
++    base::AutoLock auto_lock(lock_);
++    EXPECT_EQ(kBody, received_body);
++  }
++}
++
++TEST_F(BrowserOSServerProxyTest, NoBackendConfiguredReturnsServiceUnavailable) {
++  TestTcpClient client;
++  ASSERT_THAT(client.Connect(proxy_.GetPort()), IsOk());
++  ASSERT_TRUE(
++      client.Write("GET /missing-backend HTTP/1.1\r\n"
++                   "Host: example.test\r\n"
++                   "Connection: close\r\n"
++                   "\r\n"));
++  ASSERT_TRUE(client.ShutdownWrite());
++
++  EXPECT_EQ(kServiceUnavailableResponse, client.ReadUntilEOF());
++}
++
++TEST_F(BrowserOSServerProxyTest,
++       BackendConnectFailureReturnsServiceUnavailable) {
++  proxy_.SetBackendPort(GetUnusedLocalPort());
++
++  TestTcpClient client;
++  ASSERT_THAT(client.Connect(proxy_.GetPort()), IsOk());
++  ASSERT_TRUE(
++      client.Write("GET /connect-failure HTTP/1.1\r\n"
++                   "Host: example.test\r\n"
++                   "Connection: close\r\n"
++                   "\r\n"));
++  ASSERT_TRUE(client.ShutdownWrite());
++
++  EXPECT_EQ(kServiceUnavailableResponse, client.ReadUntilEOF());
++}
++
++TEST_F(BrowserOSServerProxyTest, StartWithZeroPortBindsEphemeralPort) {
++  EXPECT_GT(proxy_.GetPort(), 0);
++  EXPECT_EQ(0, proxy_.GetHttpsPort());
++}
++
++TEST_F(BrowserOSServerProxyTest, HttpsForwardsBytesToBackend) {
++  RestartProxyWithHttps();
++
++  ScriptedTcpBackend backend;
++  ASSERT_TRUE(backend.Start());
++  proxy_.SetBackendPort(backend.port());
++
++  TestTlsClient client;
++  ASSERT_THAT(client.Connect(proxy_.GetHttpsPort()), IsOk());
++  ASSERT_TRUE(RunUntil([&] { return backend.is_connected(); }));
++
++  const std::string request =
++      "GET /secure HTTP/1.1\r\n"
++      "Host: secure.test\r\n"
++      "Connection: close\r\n"
++      "\r\n";
++  ASSERT_TRUE(client.Write(request));
++  ASSERT_TRUE(RunUntil(
++      [&] { return backend.received_bytes().size() >= request.size(); }));
++  EXPECT_EQ(request, backend.received_bytes().substr(0, request.size()));
++
++  const std::string response =
++      "HTTP/1.1 200 OK\r\n"
++      "Content-Type: text/plain\r\n"
++      "Content-Length: 12\r\n"
++      "Connection: close\r\n"
++      "\r\n"
++      "secure-body!";
++  ASSERT_TRUE(backend.QueueWrite(response));
++  backend.CloseAfterPendingWrites();
++
++  std::string observed_response;
++  ASSERT_TRUE(client.ReadExact(response.size(), &observed_response));
++  EXPECT_EQ(response, observed_response);
++  EXPECT_EQ("", client.ReadUntilEOF());
++}
++
++TEST_F(BrowserOSServerProxyTest, HttpsNoBackendReturnsServiceUnavailable) {
++  RestartProxyWithHttps();
++
++  TestTlsClient client;
++  ASSERT_THAT(client.Connect(proxy_.GetHttpsPort()), IsOk());
++  ASSERT_TRUE(
++      client.Write("GET /secure-missing-backend HTTP/1.1\r\n"
++                   "Host: secure.test\r\n"
++                   "Connection: close\r\n"
++                   "\r\n"));
++
++  std::string response;
++  ASSERT_TRUE(
++      client.ReadExact(sizeof(kServiceUnavailableResponse) - 1, &response));
++  EXPECT_EQ(kServiceUnavailableResponse, response);
++  client.Close();
++}
++
++TEST_F(BrowserOSServerProxyTest, HttpsEnabledLeavesHttpListenerLive) {
++  RestartProxyWithHttps();
++
++  ScriptedTcpBackend backend;
++  ASSERT_TRUE(backend.Start());
++  proxy_.SetBackendPort(backend.port());
++
++  TestTcpClient client;
++  ASSERT_THAT(client.Connect(proxy_.GetPort()), IsOk());
++  ASSERT_TRUE(RunUntil([&] { return backend.is_connected(); }));
++
++  const std::string request =
++      "GET /plain HTTP/1.1\r\n"
++      "Host: plain.test\r\n"
++      "Connection: close\r\n"
++      "\r\n";
++  ASSERT_TRUE(client.Write(request));
++  ASSERT_TRUE(RunUntil(
++      [&] { return backend.received_bytes().size() >= request.size(); }));
++  EXPECT_EQ(request, backend.received_bytes().substr(0, request.size()));
++
++  const std::string response = ResponseWithBody("plain-body");
++  ASSERT_TRUE(backend.QueueWrite(response));
++  backend.CloseAfterPendingWrites();
++
++  std::string observed_response;
++  ASSERT_TRUE(client.ReadExact(response.size(), &observed_response));
++  EXPECT_EQ(response, observed_response);
++  EXPECT_EQ("", client.ReadUntilEOF());
++}
++
++TEST_F(BrowserOSServerProxyTest,
++       HttpsBindFailureDegradesToHttpOnlyAndHttpStillWorks) {
++  proxy_.Stop();
++  task_environment_.RunUntilIdle();
++
++  net::TCPServerSocket occupied_socket(nullptr, net::NetLogSource());
++  ASSERT_THAT(occupied_socket.ListenWithAddressAndPort("0.0.0.0", 0, 1),
++              IsOk());
++  net::IPEndPoint occupied_address;
++  ASSERT_THAT(occupied_socket.GetLocalAddress(&occupied_address), IsOk());
++
++  ASSERT_TRUE(proxy_.Start(0, occupied_address.port()));
++  proxy_.SetAllowRemote(false);
++  EXPECT_GT(proxy_.GetPort(), 0);
++  EXPECT_EQ(0, proxy_.GetHttpsPort());
++
++  ScriptedTcpBackend backend;
++  ASSERT_TRUE(backend.Start());
++  proxy_.SetBackendPort(backend.port());
++
++  TestTcpClient client;
++  ASSERT_THAT(client.Connect(proxy_.GetPort()), IsOk());
++  ASSERT_TRUE(RunUntil([&] { return backend.is_connected(); }));
++
++  const std::string request =
++      "GET /http-after-https-failure HTTP/1.1\r\n"
++      "Host: plain.test\r\n"
++      "Connection: close\r\n"
++      "\r\n";
++  ASSERT_TRUE(client.Write(request));
++  ASSERT_TRUE(RunUntil(
++      [&] { return backend.received_bytes().size() >= request.size(); }));
++  EXPECT_EQ(request, backend.received_bytes().substr(0, request.size()));
++
++  const std::string response = ResponseWithBody("http-only-body");
++  ASSERT_TRUE(backend.QueueWrite(response));
++  backend.CloseAfterPendingWrites();
++
++  std::string observed_response;
++  ASSERT_TRUE(client.ReadExact(response.size(), &observed_response));
++  EXPECT_EQ(response, observed_response);
++  EXPECT_EQ("", client.ReadUntilEOF());
++}
++
++TEST_F(BrowserOSServerProxyTest, KeepAliveHandlesTwoRequestsOnOneConnection) {
++  KeepAliveBackend backend;
++  ASSERT_TRUE(backend.Start());
++  proxy_.SetBackendPort(backend.port());
++
++  TestTcpClient client;
++  ASSERT_THAT(client.Connect(proxy_.GetPort()), IsOk());
++  ASSERT_TRUE(
++      client.Write("GET /one HTTP/1.1\r\n"
++                   "Host: keep.test\r\n"
++                   "Connection: keep-alive\r\n"
++                   "\r\n"));
++
++  std::string first_response;
++  ASSERT_TRUE(client.ReadHttpResponse(&first_response));
++  EXPECT_THAT(first_response, HasSubstr("first-body"));
++
++  ASSERT_TRUE(
++      client.Write("GET /two HTTP/1.1\r\n"
++                   "Host: keep.test\r\n"
++                   "Connection: close\r\n"
++                   "\r\n"));
++
++  std::string second_response;
++  ASSERT_TRUE(client.ReadHttpResponse(&second_response));
++  EXPECT_THAT(second_response, HasSubstr("second-body"));
++  EXPECT_EQ(2, backend.request_count());
++}
++
++TEST_F(BrowserOSServerProxyTest, StreamsPartialResponseBeforeBackendCloses) {
++  ScriptedTcpBackend backend;
++  ASSERT_TRUE(backend.Start());
++  proxy_.SetBackendPort(backend.port());
++
++  TestTcpClient client;
++  ASSERT_THAT(client.Connect(proxy_.GetPort()), IsOk());
++  ASSERT_TRUE(RunUntil([&] { return backend.is_connected(); }));
++
++  ASSERT_TRUE(
++      client.Write("GET /stream HTTP/1.1\r\n"
++                   "Host: stream.test\r\n"
++                   "Accept: text/event-stream\r\n"
++                   "\r\n"));
++  ASSERT_TRUE(RunUntil([&] {
++    return backend.received_bytes().find("\r\n\r\n") != std::string::npos;
++  }));
++
++  const std::string first =
++      "HTTP/1.1 200 OK\r\n"
++      "Content-Type: text/event-stream\r\n"
++      "\r\n"
++      "data: first\n\n";
++  ASSERT_TRUE(backend.QueueWrite(first));
++
++  std::string observed_first;
++  ASSERT_TRUE(client.ReadExact(first.size(), &observed_first));
++  EXPECT_EQ(first, observed_first);
++  EXPECT_TRUE(backend.is_connected());
++  EXPECT_EQ(1u, proxy_.GetConnectionCountForTesting());
++
++  const std::string rest = "data: second\n\n";
++  ASSERT_TRUE(backend.QueueWrite(rest));
++  backend.CloseAfterPendingWrites();
++
++  std::string observed_rest;
++  ASSERT_TRUE(client.ReadExact(rest.size(), &observed_rest));
++  EXPECT_EQ(rest, observed_rest);
++  EXPECT_EQ("", client.ReadUntilEOF());
++}
++
++TEST_F(BrowserOSServerProxyTest, LargeRequestAndResponseRoundTripByteIntact) {
++  constexpr size_t kLargeBodySize = 6 * 1024 * 1024 + 137;
++
++  ScriptedTcpBackend backend;
++  ASSERT_TRUE(backend.Start());
++  proxy_.SetBackendPort(backend.port());
++
++  TestTcpClient client;
++  ASSERT_THAT(client.Connect(proxy_.GetPort()), IsOk());
++  ASSERT_TRUE(RunUntil([&] { return backend.is_connected(); }));
++
++  const std::string body = MakePattern(kLargeBodySize);
++  const std::string request_headers =
++      "POST /large HTTP/1.1\r\n"
++      "Host: large.test\r\n"
++      "Content-Type: application/octet-stream\r\n"
++      "Content-Length: " +
++      base::NumberToString(body.size()) + "\r\n\r\n";
++  ASSERT_TRUE(client.Write(request_headers + body));
++  ASSERT_TRUE(RunUntil(
++      [&] {
++        return backend.received_bytes().size() >=
++               request_headers.size() + body.size();
++      },
++      base::Seconds(30)));
++
++  const std::string& received = backend.received_bytes();
++  ASSERT_GE(received.size(), request_headers.size() + body.size());
++  EXPECT_EQ(request_headers, received.substr(0, request_headers.size()));
++  EXPECT_TRUE(HasPattern(
++      std::string_view(received).substr(request_headers.size(), body.size())));
++
++  const std::string response_headers =
++      "HTTP/1.1 200 OK\r\n"
++      "Content-Type: application/octet-stream\r\n"
++      "Content-Length: " +
++      base::NumberToString(body.size()) +
++      "\r\n"
++      "Connection: close\r\n"
++      "\r\n";
++  ASSERT_TRUE(backend.QueueWrite(response_headers + body));
++  backend.CloseAfterPendingWrites();
++
++  std::string response;
++  ASSERT_TRUE(client.ReadExact(response_headers.size() + body.size(), &response,
++                               base::Seconds(30)));
++  ASSERT_GE(response.size(), response_headers.size());
++  EXPECT_EQ(response_headers, response.substr(0, response_headers.size()));
++  EXPECT_TRUE(HasPattern(
++      std::string_view(response).substr(response_headers.size(), body.size())));
++  EXPECT_EQ("", client.ReadUntilEOF());
++}
++
++TEST_F(BrowserOSServerProxyTest, UpgradeStyleBidirectionalBytesAreTransparent) {
++  ScriptedTcpBackend backend;
++  ASSERT_TRUE(backend.Start());
++  proxy_.SetBackendPort(backend.port());
++
++  TestTcpClient client;
++  ASSERT_THAT(client.Connect(proxy_.GetPort()), IsOk());
++  ASSERT_TRUE(RunUntil([&] { return backend.is_connected(); }));
++
++  const std::string request =
++      "GET /socket HTTP/1.1\r\n"
++      "Host: upgrade.test\r\n"
++      "Connection: Upgrade\r\n"
++      "Upgrade: websocket\r\n"
++      "\r\n";
++  ASSERT_TRUE(client.Write(request));
++  ASSERT_TRUE(RunUntil(
++      [&] { return backend.received_bytes().size() >= request.size(); }));
++  EXPECT_EQ(request, backend.received_bytes().substr(0, request.size()));
++
++  const std::string switching =
++      "HTTP/1.1 101 Switching Protocols\r\n"
++      "Connection: Upgrade\r\n"
++      "Upgrade: websocket\r\n"
++      "\r\n";
++  ASSERT_TRUE(backend.QueueWrite(switching));
++
++  std::string observed_switching;
++  ASSERT_TRUE(client.ReadExact(switching.size(), &observed_switching));
++  EXPECT_EQ(switching, observed_switching);
++
++  std::string client_payload;
++  client_payload.push_back('\0');
++  client_payload.append("client-to-backend");
++  client_payload.push_back(static_cast<char>(0xff));
++  ASSERT_TRUE(client.Write(client_payload));
++  ASSERT_TRUE(RunUntil([&] {
++    return backend.received_bytes().size() >=
++           request.size() + client_payload.size();
++  }));
++  EXPECT_EQ(client_payload, backend.received_bytes().substr(
++                                request.size(), client_payload.size()));
++
++  std::string backend_payload;
++  backend_payload.push_back(static_cast<char>(0x81));
++  backend_payload.append("backend-to-client");
++  backend_payload.push_back('\0');
++  ASSERT_TRUE(backend.QueueWrite(backend_payload));
++
++  std::string observed_backend_payload;
++  ASSERT_TRUE(
++      client.ReadExact(backend_payload.size(), &observed_backend_payload));
++  EXPECT_EQ(backend_payload, observed_backend_payload);
++}
++
++TEST_F(BrowserOSServerProxyTest, ClientDisconnectMidStreamTearsDownConnection) {
++  ScriptedTcpBackend backend;
++  ASSERT_TRUE(backend.Start());
++  proxy_.SetBackendPort(backend.port());
++
++  TestTcpClient client;
++  ASSERT_THAT(client.Connect(proxy_.GetPort()), IsOk());
++  ASSERT_TRUE(RunUntil([&] { return backend.is_connected(); }));
++
++  ASSERT_TRUE(
++      client.Write("GET /stream HTTP/1.1\r\n"
++                   "Host: stream.test\r\n"
++                   "\r\n"));
++  ASSERT_TRUE(RunUntil([&] {
++    return backend.received_bytes().find("\r\n\r\n") != std::string::npos;
++  }));
++
++  const std::string partial =
++      "HTTP/1.1 200 OK\r\n"
++      "Content-Type: text/plain\r\n"
++      "\r\n"
++      "partial";
++  ASSERT_TRUE(backend.QueueWrite(partial));
++
++  std::string observed_partial;
++  ASSERT_TRUE(client.ReadExact(partial.size(), &observed_partial));
++  EXPECT_EQ(partial, observed_partial);
++  ASSERT_EQ(1u, proxy_.GetConnectionCountForTesting());
++  ASSERT_TRUE(backend.is_connected());
++
++  client.Close();
++  EXPECT_TRUE(
++      RunUntil([&] { return proxy_.GetConnectionCountForTesting() == 0; }));
++}
++
++}  // namespace
++}  // namespace browseros


### PR DESCRIPTION
## Summary
- Rewrites `BrowserOSServerProxy` from a request-re-issuing HTTP server (`net::HttpServer` + `SimpleURLLoader`: 5MB body cap, 300s timeout, header whitelist, WebSockets closed) into a transparent L4 byte forwarder between the stable proxy port and the sidecar backend — SSE/streaming, chunked, WebSocket upgrades, and unbounded bodies now traverse byte-intact with zero request/response mutation.
- Adds an HTTPS listener that terminates TLS with a per-start in-memory self-signed cert (EC P-256 + `net::x509_util::CreateSelfSignedCert` + `net::CreateSSLServerContext`), pref `browseros.server.proxy_https_port` (default 9001). Any TLS setup failure logs and degrades to HTTP-only.
- Manager simplification: the UI-thread `SharedURLLoaderFactory` clone dance is gone; proxy needs no network service at all.

## Design
Raw `net/` sockets on the IO thread, pump modeled on the in-tree devtools `SocketTunnel` (`port_forwarding_controller.cc`) but with proxy-owned connection lifetime so `Stop()` tears down deterministically. Both listeners share one protocol-agnostic `Connection` pump over `net::StreamSocket*`; the TLS path is just a handshake wrapper before the same pump. Preserved contracts: stable port, canned 503 during the no-backend startup window (now with lingering close so unread request bytes can't RST-clobber the response), loopback-only gate (moved to accept time — remote peers get connection-close instead of HTTP 403, deliberate for a forwarder that makes no protocol assumptions). Accept errors re-arm via delayed task instead of recursing.

## Test plan
- [x] 15 proxy unit tests incl. transparency proofs: streamed bytes observable while backend connection still open; 6MB+ bodies pattern-verified both directions; 101-upgrade then raw binary both ways; teardown drains connection map; TLS handshake+forward via `SSLClientContext`+`MockCertVerifier`; degrade-to-HTTP-only on occupied HTTPS port; construction-on-UI/start-on-IO thread affinity
- [x] `autoninja -C out/Default_arm64 chrome unit_tests` green; `unit_tests --gtest_filter='BrowserOSServerProxy*:BrowserOSServerManager*'` green (proxy filter ×5 repeats, no flakes)
- [x] Patch verification: 9/9 byte-match vs `git diff BASE..tip` and 9/9 apply-check onto bare BASE tree (`verify-patches: OK`)

## Notes
- Also repairs 3 `BrowserOSServerManager` tests that were broken at the current patch-store tip independent of this change (unit tests calling `Start()` tried to launch a real CDP server; restart test relied on running state the mock never set).
- Adversarial review ran locally pre-PR: 9 findings → 6 fixed (incl. a Critical thread-checker-binds-on-wrong-thread that crashed all `is_debug` builds), 3 dropped with rationale (buffer churn / sync recursion match SocketTunnel precedent; no-SAN cert is a documented non-goal).