### PR TITLE
feat(ci): warpbuild release workflows for linux/windows

### DIFF
--- a/.github/workflows/build-browseros.yml
+++ b/.github/workflows/build-browseros.yml
@@ -1,0 +1,303 @@
+name: BrowserOS Chromium Build
+
+# Reusable WarpBuild job for one Chromium browser build. The Chromium checkout
+# cache is product-independent on purpose: it is captured immediately after
+# gclient sync, before BrowserOS/BrowserClaw patches or build outputs touch it.
+
+on:
+  workflow_call:
+    inputs:
+      platform:
+        description: "Target platform: linux, windows, or macos"
+        required: true
+        type: string
+      arch:
+        description: "Target architecture"
+        required: true
+        type: string
+      product:
+        description: "Product to build: browseros or browserclaw"
+        required: true
+        type: string
+      runner:
+        description: "WarpBuild runner label"
+        required: true
+        type: string
+      timeout-minutes:
+        description: "Job timeout in minutes"
+        required: true
+        type: number
+      profile:
+        description: "bos_build profile name"
+        required: false
+        type: string
+        default: release-ci
+      sign:
+        description: "Run signing steps selected by the profile/preset"
+        required: false
+        type: boolean
+        default: false
+      upload:
+        description: "Run upload steps selected by the profile/preset"
+        required: false
+        type: boolean
+        default: false
+      ref:
+        description: "Optional checkout ref override; empty uses the caller ref"
+        required: false
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: build (${{ inputs.product }} ${{ inputs.platform }}-${{ inputs.arch }})
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: ${{ inputs.timeout-minutes }}
+    defaults:
+      run:
+        shell: bash
+    env:
+      # Windows runners pipe stdout as cp1252, which crashes the emoji-heavy
+      # build CLI with UnicodeEncodeError; force UTF-8 for python and all
+      # its subprocesses (gclient, hooks). No-op on Linux/macOS.
+      PYTHONUTF8: "1"
+    steps:
+      - name: Validate inputs
+        env:
+          PLATFORM: ${{ inputs.platform }}
+          PRODUCT: ${{ inputs.product }}
+        run: |
+          set -euo pipefail
+          case "$PLATFORM" in
+            linux|windows|macos) ;;
+            *)
+              echo "::error::platform must be one of: linux, windows, macos"
+              exit 1
+              ;;
+          esac
+          case "$PRODUCT" in
+            browseros|browserclaw) ;;
+            *)
+              echo "::error::product must be one of: browseros, browserclaw"
+              exit 1
+              ;;
+          esac
+
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      # v8.x.y releases exist but astral-sh publishes no floating `v8`
+      # major tag - `@v8` is unresolvable and kills the job in Set up job.
+      - uses: astral-sh/setup-uv@v8.2.0
+
+      - name: Resolve chromium pin and paths
+        id: pin
+        run: |
+          set -euo pipefail
+          . packages/browseros/CHROMIUM_VERSION
+          version="$MAJOR.$MINOR.$BUILD.$PATCH"
+
+          # Keep the checkout outside the workspace so actions/checkout
+          # never touches it. pwd -W yields a native path on Windows.
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            parent="$(cd "$GITHUB_WORKSPACE/.." && pwd -W)"
+          else
+            parent="$(cd "$GITHUB_WORKSPACE/.." && pwd)"
+          fi
+
+          {
+            echo "version=$version"
+            echo "cache_key=chromium-src-${{ inputs.platform }}-${{ inputs.arch }}-v1-$version"
+          } >> "$GITHUB_OUTPUT"
+          {
+            echo "CHROMIUM_ROOT=$parent/chromium"
+            echo "CHROMIUM_SRC=$parent/chromium/src"
+          } >> "$GITHUB_ENV"
+
+      - name: Restore chromium checkout (WarpCache)
+        if: runner.os != 'Windows'
+        id: warpcache
+        uses: WarpBuilds/cache/restore@v1
+        with:
+          path: ${{ env.CHROMIUM_ROOT }}
+          key: ${{ steps.pin.outputs.cache_key }}
+          restore-keys: |
+            chromium-src-${{ inputs.platform }}-${{ inputs.arch }}-v1-
+
+      - name: Restore chromium checkout (R2)
+        if: runner.os == 'Windows'
+        id: r2cache
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          set -euo pipefail
+          uv run --project packages/browseros browseros source cache restore \
+            --key "${{ steps.pin.outputs.cache_key }}" \
+            --root "$CHROMIUM_ROOT"
+
+      - name: Ensure chromium checkout at pinned tag
+        run: |
+          set -euo pipefail
+          uv run --project packages/browseros browseros source ensure \
+            --root "$CHROMIUM_ROOT" --step checkout
+
+      - name: Reset chromium tree (clean module)
+        working-directory: packages/browseros
+        run: |
+          set -euo pipefail
+          uv run browseros build --modules clean \
+            --chromium-src "$CHROMIUM_SRC" \
+            --build-type release \
+            --arch "${{ inputs.arch }}" \
+            --product "${{ inputs.product }}"
+
+      - name: Sync chromium dependencies (gclient)
+        run: |
+          set -euo pipefail
+          uv run --project packages/browseros browseros source ensure \
+            --root "$CHROMIUM_ROOT" --step sync
+
+      # Save immediately after sync: the tree is pristine (no BrowserOS or
+      # BrowserClaw patches, no out/ dir), which keeps the cache deterministic
+      # and as small as possible.
+      - name: Save chromium checkout (WarpCache)
+        if: runner.os != 'Windows' && steps.warpcache.outputs.cache-hit != 'true'
+        uses: WarpBuilds/cache/save@v1
+        with:
+          path: ${{ env.CHROMIUM_ROOT }}
+          key: ${{ steps.pin.outputs.cache_key }}
+
+      - name: Save chromium checkout (R2)
+        if: runner.os == 'Windows' && steps.r2cache.outputs.cache-hit != 'true'
+        env:
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+        run: |
+          set -euo pipefail
+          uv run --project packages/browseros browseros source cache save \
+            --key "${{ steps.pin.outputs.cache_key }}" \
+            --root "$CHROMIUM_ROOT"
+
+      - name: Install Linux build deps
+        if: inputs.platform == 'linux'
+        run: |
+          set -euo pipefail
+          sudo apt-get update
+          # libfuse2: appimagetool is itself an AppImage and needs FUSE
+          sudo apt-get install -y libfuse2
+          "$CHROMIUM_SRC/build/install-build-deps.sh" --no-prompt
+
+      - name: Import macOS signing certificate
+        if: inputs.sign && inputs.platform == 'macos'
+        env:
+          MACOS_CERTIFICATE_P12: ${{ secrets.MACOS_CERTIFICATE_P12 }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
+          MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          missing=()
+          [ -n "${MACOS_CERTIFICATE_P12:-}" ] || missing+=(MACOS_CERTIFICATE_P12)
+          [ -n "${MACOS_CERTIFICATE_PWD:-}" ] || missing+=(MACOS_CERTIFICATE_PWD)
+          [ -n "${MACOS_KEYCHAIN_PASSWORD:-}" ] || missing+=(MACOS_KEYCHAIN_PASSWORD)
+          if [ "${#missing[@]}" -gt 0 ]; then
+            printf '::error::macOS signing requested, but missing required secrets: %s\n' "${missing[*]}"
+            exit 1
+          fi
+
+          cert_path="$RUNNER_TEMP/browseros-signing-cert.p12"
+          keychain_path="$RUNNER_TEMP/browseros-ci-signing.keychain-db"
+          printf '%s' "$MACOS_CERTIFICATE_P12" | base64 --decode > "$cert_path"
+          security create-keychain -p "$MACOS_KEYCHAIN_PASSWORD" "$keychain_path"
+          security set-keychain-settings -lut 21600 "$keychain_path"
+          security unlock-keychain -p "$MACOS_KEYCHAIN_PASSWORD" "$keychain_path"
+          security import "$cert_path" -P "$MACOS_CERTIFICATE_PWD" -A -t cert -f pkcs12 -k "$keychain_path"
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_KEYCHAIN_PASSWORD" "$keychain_path"
+          security list-keychains -d user -s "$keychain_path"
+          security default-keychain -d user -s "$keychain_path"
+
+      - name: Install SSL.com CodeSignTool
+        if: inputs.sign && inputs.platform == 'windows'
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $uri = 'https://app.esigner.com/files/CodeSignTool-v1-3-2-windows/3954004a/download'
+          $zipPath = Join-Path $env:RUNNER_TEMP 'CodeSignTool-v1.3.2-windows.zip'
+          $extractRoot = Join-Path $env:RUNNER_TEMP 'CodeSignTool-v1.3.2-windows'
+          Invoke-WebRequest -Uri $uri -OutFile $zipPath
+          Expand-Archive -Path $zipPath -DestinationPath $extractRoot -Force
+          $tool = Get-ChildItem -Path $extractRoot -Filter CodeSignTool.bat -Recurse | Select-Object -First 1
+          if (-not $tool) {
+            throw "CodeSignTool.bat was not found after extracting $zipPath"
+          }
+          "CODE_SIGN_TOOL_PATH=$($tool.Directory.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+
+      - name: Build ${{ inputs.product }}
+        working-directory: packages/browseros
+        env:
+          # download_resources pulls product server bundles from R2.
+          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          R2_BUCKET: ${{ secrets.R2_BUCKET }}
+
+          # macOS signing and notarization.
+          MACOS_CERTIFICATE_NAME: ${{ secrets.MACOS_CERTIFICATE_NAME }}
+          MACOS_KEYCHAIN_PASSWORD: ${{ secrets.MACOS_KEYCHAIN_PASSWORD }}
+          PROD_MACOS_NOTARIZATION_APPLE_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_APPLE_ID }}
+          PROD_MACOS_NOTARIZATION_TEAM_ID: ${{ secrets.PROD_MACOS_NOTARIZATION_TEAM_ID }}
+          PROD_MACOS_NOTARIZATION_PWD: ${{ secrets.PROD_MACOS_NOTARIZATION_PWD }}
+
+          # Windows signing via SSL.com CodeSignTool.
+          ESIGNER_USERNAME: ${{ secrets.ESIGNER_USERNAME }}
+          ESIGNER_PASSWORD: ${{ secrets.ESIGNER_PASSWORD }}
+          ESIGNER_TOTP_SECRET: ${{ secrets.ESIGNER_TOTP_SECRET }}
+          ESIGNER_CREDENTIAL_ID: ${{ secrets.ESIGNER_CREDENTIAL_ID }}
+
+          # Sparkle/WinSparkle artifact signatures.
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          sign_flag="--no-sign"
+          upload_flag="--no-upload"
+          if [ "${{ inputs.sign }}" = "true" ]; then
+            sign_flag="--sign"
+          fi
+          if [ "${{ inputs.upload }}" = "true" ]; then
+            upload_flag="--upload"
+          fi
+
+          uv run browseros build \
+            --profile "${{ inputs.profile }}" \
+            --product "${{ inputs.product }}" \
+            --arch "${{ inputs.arch }}" \
+            "$sign_flag" \
+            "$upload_flag" \
+            --chromium-src "$CHROMIUM_SRC"
+
+      - name: Report disk usage
+        if: always()
+        run: df -h || true
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ inputs.product }}-${{ inputs.profile }}-${{ inputs.platform }}-${{ inputs.arch }}
+          if-no-files-found: error
+          retention-days: 14
+          compression-level: 0
+          path: |
+            packages/browseros/releases/*/*.dmg
+            packages/browseros/releases/*/*.AppImage
+            packages/browseros/releases/*/*.deb
+            packages/browseros/releases/*/*_installer.exe
+            packages/browseros/releases/*/*_installer.zip

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -1,0 +1,141 @@
+name: Release Linux
+
+on:
+  workflow_dispatch:
+    inputs:
+      products:
+        description: "Product set to build"
+        type: choice
+        default: browseros
+        options:
+          - browseros
+          - browserclaw
+          - all
+      upload_to_r2:
+        description: "Upload release metadata/artifacts to R2"
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      products:
+        description: "Product set to build: browseros, browserclaw, or all"
+        required: false
+        type: string
+        default: browseros
+      upload_to_r2:
+        description: "Upload release metadata/artifacts to R2"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-linux
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - name: Resolve product matrix
+        id: plan
+        env:
+          PRODUCTS: ${{ inputs.products || 'browseros' }}
+        run: |
+          set -euo pipefail
+          case "$PRODUCTS" in
+            all)
+              matrix='[{"product":"browseros"},{"product":"browserclaw"}]'
+              ;;
+            browseros|browserclaw)
+              matrix="$(jq -cn --arg product "$PRODUCTS" '[{product:$product}]')"
+              ;;
+            *)
+              echo "::error::products must be one of: browseros, browserclaw, all"
+              exit 1
+              ;;
+          esac
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  # WarpBuild provisions runners on demand via webhook; when none arrive
+  # (org runner-group policy, bad label, account issue) the build jobs sit
+  # queued until GitHub discards them 24h later, holding the release-linux
+  # concurrency group all day. Fail fast instead - see the troubleshooting
+  # section of packages/browseros/bos_build/docs/nightly-warpbuild-ci.md.
+  queue-watchdog:
+    needs: plan
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: write
+    steps:
+      - name: Fail fast when no runner picks up the builds
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONCURRENCY_GROUP: release-linux
+        run: |
+          set -euo pipefail
+          deadline=$(( $(date +%s) + 20 * 60 ))
+          failures=0
+          while :; do
+            if jobs="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs?per_page=100" \
+              --jq '[.jobs[] | select(.name != "queue-watchdog") | select(.status != "completed") | {name, status}]')"; then
+              failures=0
+            else
+              failures=$(( failures + 1 ))
+              if [ "$failures" -ge 3 ]; then
+                echo "::error::queue-watchdog could not list this run's jobs (3 consecutive failures); builds are unwatched this run."
+                exit 1
+              fi
+              sleep 120
+              continue
+            fi
+            total="$(jq 'length' <<<"$jobs")"
+            queued="$(jq '[.[] | select(.status == "queued")] | length' <<<"$jobs")"
+            in_progress="$(jq '[.[] | select(.status == "in_progress")] | length' <<<"$jobs")"
+            if [ "$total" -gt 0 ] && [ "$queued" -eq 0 ]; then
+              echo "All $total build jobs picked up by runners."
+              exit 0
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              doc="packages/browseros/bos_build/docs/nightly-warpbuild-ci.md"
+              if [ "$total" -eq 0 ]; then
+                echo "::error::queue-watchdog matched no build jobs - were the matrix job names changed? Fix the filter; not cancelling."
+                exit 1
+              fi
+              stuck="$(jq -r '[.[] | select(.status == "queued") | .name] | join(", ")' <<<"$jobs")"
+              # Cancel only when nothing is live: a queued job is then the
+              # only thing keeping the run (and concurrency group) pinned.
+              if [ "$queued" -gt 0 ] && [ "$in_progress" -eq 0 ]; then
+                echo "::error::No build job is running and these never left the queue: $stuck. Check the runner-group public-repo setting, runner labels, and the WarpBuild dashboard - see $doc. Cancelling the run to free the $CONCURRENCY_GROUP concurrency group."
+                gh api -X POST "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/cancel"
+              else
+                echo "::error::Still queued after 20 min: $stuck. In-progress builds keep running - see $doc."
+              fi
+              exit 1
+            fi
+            sleep 120
+          done
+
+  build:
+    needs: plan
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    name: build (${{ matrix.product }} linux-x64)
+    uses: ./.github/workflows/build-browseros.yml
+    with:
+      platform: linux
+      arch: x64
+      product: ${{ matrix.product }}
+      runner: warp-ubuntu-2204-x64-32x
+      timeout-minutes: 660
+      profile: release-ci
+      sign: false
+      upload: ${{ inputs.upload_to_r2 }}
+    secrets: inherit

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -1,0 +1,179 @@
+name: Release Windows
+
+on:
+  workflow_dispatch:
+    inputs:
+      products:
+        description: "Product set to build"
+        type: choice
+        default: browseros
+        options:
+          - browseros
+          - browserclaw
+          - all
+      upload_to_r2:
+        description: "Upload release metadata/artifacts to R2"
+        type: boolean
+        default: true
+      sign:
+        description: "Sign Windows binaries and update artifacts"
+        type: boolean
+        default: true
+  workflow_call:
+    inputs:
+      products:
+        description: "Product set to build: browseros, browserclaw, or all"
+        required: false
+        type: string
+        default: browseros
+      upload_to_r2:
+        description: "Upload release metadata/artifacts to R2"
+        required: false
+        type: boolean
+        default: true
+      sign:
+        description: "Sign Windows binaries and update artifacts"
+        required: false
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-windows
+  cancel-in-progress: false
+
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.plan.outputs.matrix }}
+    steps:
+      - name: Resolve product matrix
+        id: plan
+        env:
+          PRODUCTS: ${{ inputs.products || 'browseros' }}
+        run: |
+          set -euo pipefail
+          case "$PRODUCTS" in
+            all)
+              matrix='[{"product":"browseros"},{"product":"browserclaw"}]'
+              ;;
+            browseros|browserclaw)
+              matrix="$(jq -cn --arg product "$PRODUCTS" '[{product:$product}]')"
+              ;;
+            *)
+              echo "::error::products must be one of: browseros, browserclaw, all"
+              exit 1
+              ;;
+          esac
+          echo "matrix=$matrix" >> "$GITHUB_OUTPUT"
+
+  preflight:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check signing secrets
+        env:
+          SIGN: ${{ inputs.sign }}
+          ESIGNER_USERNAME: ${{ secrets.ESIGNER_USERNAME }}
+          ESIGNER_PASSWORD: ${{ secrets.ESIGNER_PASSWORD }}
+          ESIGNER_TOTP_SECRET: ${{ secrets.ESIGNER_TOTP_SECRET }}
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ "$SIGN" != "true" ]; then
+            echo "Windows signing disabled; skipping signing secret preflight."
+            exit 0
+          fi
+
+          missing=()
+          [ -n "${ESIGNER_USERNAME:-}" ] || missing+=(ESIGNER_USERNAME)
+          [ -n "${ESIGNER_PASSWORD:-}" ] || missing+=(ESIGNER_PASSWORD)
+          [ -n "${ESIGNER_TOTP_SECRET:-}" ] || missing+=(ESIGNER_TOTP_SECRET)
+          [ -n "${SPARKLE_PRIVATE_KEY:-}" ] || missing+=(SPARKLE_PRIVATE_KEY)
+
+          if [ "${#missing[@]}" -gt 0 ]; then
+            printf '::error::Windows signing requested, but missing required secrets: %s\n' "${missing[*]}"
+            echo "::error::Add the missing repository secrets or rerun this workflow with sign=false for an unsigned mini_installer build. ESIGNER_CREDENTIAL_ID is optional."
+            exit 1
+          fi
+
+  # WarpBuild provisions runners on demand via webhook; when none arrive
+  # (org runner-group policy, bad label, account issue) the build jobs sit
+  # queued until GitHub discards them 24h later, holding the release-windows
+  # concurrency group all day. Fail fast instead - see the troubleshooting
+  # section of packages/browseros/bos_build/docs/nightly-warpbuild-ci.md.
+  queue-watchdog:
+    needs: [plan, preflight]
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      actions: write
+    steps:
+      - name: Fail fast when no runner picks up the builds
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONCURRENCY_GROUP: release-windows
+        run: |
+          set -euo pipefail
+          deadline=$(( $(date +%s) + 20 * 60 ))
+          failures=0
+          while :; do
+            if jobs="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs?per_page=100" \
+              --jq '[.jobs[] | select(.name != "queue-watchdog") | select(.status != "completed") | {name, status}]')"; then
+              failures=0
+            else
+              failures=$(( failures + 1 ))
+              if [ "$failures" -ge 3 ]; then
+                echo "::error::queue-watchdog could not list this run's jobs (3 consecutive failures); builds are unwatched this run."
+                exit 1
+              fi
+              sleep 120
+              continue
+            fi
+            total="$(jq 'length' <<<"$jobs")"
+            queued="$(jq '[.[] | select(.status == "queued")] | length' <<<"$jobs")"
+            in_progress="$(jq '[.[] | select(.status == "in_progress")] | length' <<<"$jobs")"
+            if [ "$total" -gt 0 ] && [ "$queued" -eq 0 ]; then
+              echo "All $total build jobs picked up by runners."
+              exit 0
+            fi
+            if [ "$(date +%s)" -ge "$deadline" ]; then
+              doc="packages/browseros/bos_build/docs/nightly-warpbuild-ci.md"
+              if [ "$total" -eq 0 ]; then
+                echo "::error::queue-watchdog matched no build jobs - were the matrix job names changed? Fix the filter; not cancelling."
+                exit 1
+              fi
+              stuck="$(jq -r '[.[] | select(.status == "queued") | .name] | join(", ")' <<<"$jobs")"
+              # Cancel only when nothing is live: a queued job is then the
+              # only thing keeping the run (and concurrency group) pinned.
+              if [ "$queued" -gt 0 ] && [ "$in_progress" -eq 0 ]; then
+                echo "::error::No build job is running and these never left the queue: $stuck. Check the runner-group public-repo setting, runner labels, and the WarpBuild dashboard - see $doc. Cancelling the run to free the $CONCURRENCY_GROUP concurrency group."
+                gh api -X POST "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/cancel"
+              else
+                echo "::error::Still queued after 20 min: $stuck. In-progress builds keep running - see $doc."
+              fi
+              exit 1
+            fi
+            sleep 120
+          done
+
+  build:
+    needs: [plan, preflight]
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.plan.outputs.matrix) }}
+    name: build (${{ matrix.product }} windows-x64)
+    uses: ./.github/workflows/build-browseros.yml
+    with:
+      platform: windows
+      arch: x64
+      product: ${{ matrix.product }}
+      runner: warp-windows-2025-x64-32x
+      timeout-minutes: 780
+      profile: release-ci
+      sign: ${{ inputs.sign }}
+      upload: ${{ inputs.upload_to_r2 }}
+    secrets: inherit

--- a/packages/browseros/bos_build/profiles/release-ci.yaml
+++ b/packages/browseros/bos_build/profiles/release-ci.yaml
@@ -1,0 +1,7 @@
+# Release CI build on WarpBuild runners: the workflow provisions chromium
+# (checkout/clean/sync) itself, so clean and git_setup are off. Signing and
+# upload are controlled by explicit CLI flags from the release workflows.
+# Arch and product come from workflow inputs.
+preset: release
+clean: false
+provision: none


### PR DESCRIPTION
## Summary

- Add a reusable WarpBuild Chromium build workflow for BrowserOS/BrowserClaw with platform, arch, product, runner, timeout, profile, sign, upload, and ref inputs.
- Add dispatchable/callable Linux and Windows release workflows that matrix over selected products, call the reusable workflow, and include queue watchdogs for stuck WarpBuild jobs.
- Add Windows signing preflight for required eSigner/Sparkle secrets and a release-ci profile that leaves sign/upload to CLI flags.

## Verification

- `actionlint .github/workflows/build-browseros.yml .github/workflows/release-linux.yml .github/workflows/release-windows.yml`
- `uv run python -m unittest discover -s bos_build -t . -p "*_test.py"`
- `uv run ruff check bos_build`
- `release-ci` show-plan smokes below for BrowserOS and BrowserClaw across Linux x64, Windows x64, and macOS arm64. These invoke the BrowserOS Typer CLI entrypoint under patched `sys.platform` for static cross-platform verification; no Chromium checkout, GitHub Actions dispatch, or WarpBuild runner was used.

## SSL.com CodeSignTool source

- SSL.com downloads page lists the current `CodeSignTool-v1.3.2-windows` download: https://www.ssl.com/downloads/
- SSL.com CodeSignTool guide confirms the Windows package includes `CodeSignTool.bat`: https://www.ssl.com/guide/esigner-codesigntool-command-guide/

## release-ci show-plan smokes

<details>
<summary>Output</summary>

```text
===== linux/x64/browseros/sign=false/upload=true =====
$ browseros build --profile release-ci --product browseros --arch x64 --no-sign --upload --show-plan
Preset plan: preset=release product=browseros platform=linux
Switches: clean=False provision=none download=True sign=False upload=True

x64 (11 steps):
   1. download_resources
   2. resources
   3. bundled_extensions
   4. chromium_replace
   5. string_replaces
   6. series_patches
   7. patches
   8. configure
   9. compile
  10. package_linux
  11. upload

Required env (x64): none

===== windows/x64/browseros/sign=false/upload=true =====
$ browseros build --profile release-ci --product browseros --arch x64 --no-sign --upload --show-plan
Preset plan: preset=release product=browseros platform=windows
Switches: clean=False provision=none download=True sign=False upload=True

x64 (12 steps):
   1. download_resources
   2. resources
   3. bundled_extensions
   4. chromium_replace
   5. string_replaces
   6. series_patches
   7. patches
   8. configure
   9. compile
  10. mini_installer
  11. package_windows
  12. upload

Required env (x64): none

===== windows/x64/browseros/sign=true/upload=true =====
$ browseros build --profile release-ci --product browseros --arch x64 --sign --upload --show-plan
Preset plan: preset=release product=browseros platform=windows
Switches: clean=False provision=none download=True sign=True upload=True

x64 (14 steps):
   1. winsparkle_setup
   2. download_resources
   3. resources
   4. bundled_extensions
   5. chromium_replace
   6. string_replaces
   7. series_patches
   8. patches
   9. configure
  10. compile
  11. sign_windows
  12. package_windows
  13. sparkle_sign
  14. upload

Required env (x64):
  CODE_SIGN_TOOL_PATH  ✗ MISSING
  ESIGNER_USERNAME  ✗ MISSING
  ESIGNER_PASSWORD  ✗ MISSING
  ESIGNER_TOTP_SECRET  ✗ MISSING
  SPARKLE_PRIVATE_KEY  ✗ MISSING

===== windows/x64/browseros/sign=true/upload=false =====
$ browseros build --profile release-ci --product browseros --arch x64 --sign --no-upload --show-plan
Preset plan: preset=release product=browseros platform=windows
Switches: clean=False provision=none download=True sign=True upload=False

x64 (13 steps):
   1. winsparkle_setup
   2. download_resources
   3. resources
   4. bundled_extensions
   5. chromium_replace
   6. string_replaces
   7. series_patches
   8. patches
   9. configure
  10. compile
  11. sign_windows
  12. package_windows
  13. sparkle_sign

Required env (x64):
  CODE_SIGN_TOOL_PATH  ✗ MISSING
  ESIGNER_USERNAME  ✗ MISSING
  ESIGNER_PASSWORD  ✗ MISSING
  ESIGNER_TOTP_SECRET  ✗ MISSING
  SPARKLE_PRIVATE_KEY  ✗ MISSING

===== macos/arm64/browseros/sign=true/upload=true =====
$ browseros build --profile release-ci --product browseros --arch arm64 --sign --upload --show-plan
Preset plan: preset=release product=browseros platform=macos
Switches: clean=False provision=none download=True sign=True upload=True

arm64 (13 steps):
   1. sparkle_setup
   2. download_resources
   3. resources
   4. bundled_extensions
   5. chromium_replace
   6. string_replaces
   7. series_patches
   8. patches
   9. configure
  10. compile
  11. sign_macos
  12. package_macos
  13. upload

Required env (arm64):
  MACOS_CERTIFICATE_NAME  ✗ MISSING
  PROD_MACOS_NOTARIZATION_APPLE_ID  ✗ MISSING
  PROD_MACOS_NOTARIZATION_TEAM_ID  ✗ MISSING
  PROD_MACOS_NOTARIZATION_PWD  ✗ MISSING

===== macos/arm64/browseros/sign=true/upload=false =====
$ browseros build --profile release-ci --product browseros --arch arm64 --sign --no-upload --show-plan
Preset plan: preset=release product=browseros platform=macos
Switches: clean=False provision=none download=True sign=True upload=False

arm64 (12 steps):
   1. sparkle_setup
   2. download_resources
   3. resources
   4. bundled_extensions
   5. chromium_replace
   6. string_replaces
   7. series_patches
   8. patches
   9. configure
  10. compile
  11. sign_macos
  12. package_macos

Required env (arm64):
  MACOS_CERTIFICATE_NAME  ✗ MISSING
  PROD_MACOS_NOTARIZATION_APPLE_ID  ✗ MISSING
  PROD_MACOS_NOTARIZATION_TEAM_ID  ✗ MISSING
  PROD_MACOS_NOTARIZATION_PWD  ✗ MISSING

===== linux/x64/browserclaw/sign=false/upload=true =====
$ browseros build --profile release-ci --product browserclaw --arch x64 --no-sign --upload --show-plan
Preset plan: preset=release product=browserclaw platform=linux
Switches: clean=False provision=none download=True sign=False upload=True

x64 (11 steps):
   1. download_resources
   2. resources
   3. bundled_extensions
   4. chromium_replace
   5. string_replaces
   6. series_patches
   7. patches
   8. configure
   9. compile
  10. package_linux
  11. upload

Required env (x64): none

===== windows/x64/browserclaw/sign=false/upload=true =====
$ browseros build --profile release-ci --product browserclaw --arch x64 --no-sign --upload --show-plan
Preset plan: preset=release product=browserclaw platform=windows
Switches: clean=False provision=none download=True sign=False upload=True

x64 (12 steps):
   1. download_resources
   2. resources
   3. bundled_extensions
   4. chromium_replace
   5. string_replaces
   6. series_patches
   7. patches
   8. configure
   9. compile
  10. mini_installer
  11. package_windows
  12. upload

Required env (x64): none

===== windows/x64/browserclaw/sign=true/upload=true =====
$ browseros build --profile release-ci --product browserclaw --arch x64 --sign --upload --show-plan
Preset plan: preset=release product=browserclaw platform=windows
Switches: clean=False provision=none download=True sign=True upload=True

x64 (14 steps):
   1. winsparkle_setup
   2. download_resources
   3. resources
   4. bundled_extensions
   5. chromium_replace
   6. string_replaces
   7. series_patches
   8. patches
   9. configure
  10. compile
  11. sign_windows
  12. package_windows
  13. sparkle_sign
  14. upload

Required env (x64):
  CODE_SIGN_TOOL_PATH  ✗ MISSING
  ESIGNER_USERNAME  ✗ MISSING
  ESIGNER_PASSWORD  ✗ MISSING
  ESIGNER_TOTP_SECRET  ✗ MISSING
  SPARKLE_PRIVATE_KEY  ✗ MISSING

===== windows/x64/browserclaw/sign=true/upload=false =====
$ browseros build --profile release-ci --product browserclaw --arch x64 --sign --no-upload --show-plan
Preset plan: preset=release product=browserclaw platform=windows
Switches: clean=False provision=none download=True sign=True upload=False

x64 (13 steps):
   1. winsparkle_setup
   2. download_resources
   3. resources
   4. bundled_extensions
   5. chromium_replace
   6. string_replaces
   7. series_patches
   8. patches
   9. configure
  10. compile
  11. sign_windows
  12. package_windows
  13. sparkle_sign

Required env (x64):
  CODE_SIGN_TOOL_PATH  ✗ MISSING
  ESIGNER_USERNAME  ✗ MISSING
  ESIGNER_PASSWORD  ✗ MISSING
  ESIGNER_TOTP_SECRET  ✗ MISSING
  SPARKLE_PRIVATE_KEY  ✗ MISSING

===== macos/arm64/browserclaw/sign=true/upload=true =====
$ browseros build --profile release-ci --product browserclaw --arch arm64 --sign --upload --show-plan
Preset plan: preset=release product=browserclaw platform=macos
Switches: clean=False provision=none download=True sign=True upload=True

arm64 (13 steps):
   1. sparkle_setup
   2. download_resources
   3. resources
   4. bundled_extensions
   5. chromium_replace
   6. string_replaces
   7. series_patches
   8. patches
   9. configure
  10. compile
  11. sign_macos
  12. package_macos
  13. upload

Required env (arm64):
  MACOS_CERTIFICATE_NAME  ✗ MISSING
  PROD_MACOS_NOTARIZATION_APPLE_ID  ✗ MISSING
  PROD_MACOS_NOTARIZATION_TEAM_ID  ✗ MISSING
  PROD_MACOS_NOTARIZATION_PWD  ✗ MISSING

===== macos/arm64/browserclaw/sign=true/upload=false =====
$ browseros build --profile release-ci --product browserclaw --arch arm64 --sign --no-upload --show-plan
Preset plan: preset=release product=browserclaw platform=macos
Switches: clean=False provision=none download=True sign=True upload=False

arm64 (12 steps):
   1. sparkle_setup
   2. download_resources
   3. resources
   4. bundled_extensions
   5. chromium_replace
   6. string_replaces
   7. series_patches
   8. patches
   9. configure
  10. compile
  11. sign_macos
  12. package_macos

Required env (arm64):
  MACOS_CERTIFICATE_NAME  ✗ MISSING
  PROD_MACOS_NOTARIZATION_APPLE_ID  ✗ MISSING
  PROD_MACOS_NOTARIZATION_TEAM_ID  ✗ MISSING
  PROD_MACOS_NOTARIZATION_PWD  ✗ MISSING

All release-ci show-plan smokes passed.
```

</details>
