### PR TITLE
feat(ci): signed macos release workflow with product + arch selection

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,3 @@
+self-hosted-runner:
+  labels:
+    - browseros-builder

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,0 +1,496 @@
+name: Release macOS Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      products:
+        description: Products to build
+        type: choice
+        default: browseros
+        options:
+          - browseros
+          - browserclaw
+          - all
+      arch:
+        description: macOS architecture to build
+        type: choice
+        default: arm64
+        options:
+          - arm64
+          - universal
+      bump:
+        description: Version bump level
+        type: choice
+        default: none
+        options:
+          - offset-only
+          - offset+build
+          - offset+patch
+          - none
+      commit_version:
+        description: Commit and push the version bump to the built branch
+        type: boolean
+        default: false
+      upload_to_r2:
+        description: Publish build to R2/CDN after packaging
+        type: boolean
+        default: true
+      ref:
+        description: Git ref to build; defaults to the repository default branch
+        type: string
+        default: ""
+  workflow_call:
+    inputs:
+      products:
+        description: Products to build (browseros, browserclaw, all)
+        type: string
+        default: browseros
+      arch:
+        description: macOS architecture to build (arm64, universal)
+        type: string
+        default: arm64
+      bump:
+        description: Version bump level (offset-only, offset+build, offset+patch, none)
+        type: string
+        default: none
+      commit_version:
+        description: Commit and push the version bump to the built branch
+        type: boolean
+        default: false
+      upload_to_r2:
+        description: Publish build to R2/CDN after packaging
+        type: boolean
+        default: true
+      ref:
+        description: Git ref to build; defaults to the repository default branch
+        type: string
+        default: ""
+
+permissions:
+  contents: read
+
+concurrency:
+  group: macos-build
+  cancel-in-progress: false
+
+jobs:
+  resolve_inputs:
+    runs-on: ubuntu-latest
+    outputs:
+      target_ref: ${{ steps.workflow_inputs.outputs.target_ref }}
+      product_ids: ${{ steps.workflow_inputs.outputs.product_ids }}
+      build_browseros: ${{ steps.workflow_inputs.outputs.build_browseros }}
+      build_browserclaw: ${{ steps.workflow_inputs.outputs.build_browserclaw }}
+      arch: ${{ steps.workflow_inputs.outputs.arch }}
+      bump_mode: ${{ steps.workflow_inputs.outputs.bump_mode }}
+      commit_version: ${{ steps.workflow_inputs.outputs.commit_version }}
+      upload_to_r2: ${{ steps.workflow_inputs.outputs.upload_to_r2 }}
+      timeout_minutes: ${{ steps.workflow_inputs.outputs.timeout_minutes }}
+    steps:
+      - name: Resolve workflow inputs
+        id: workflow_inputs
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          INPUT_PRODUCTS: ${{ inputs.products }}
+          INPUT_ARCH: ${{ inputs.arch }}
+          INPUT_BUMP: ${{ inputs.bump }}
+          INPUT_COMMIT_VERSION: ${{ inputs.commit_version }}
+          INPUT_UPLOAD_TO_R2: ${{ inputs.upload_to_r2 }}
+          INPUT_REF: ${{ inputs.ref }}
+        run: |
+          set -euo pipefail
+
+          products="${INPUT_PRODUCTS:-browseros}"
+          arch="${INPUT_ARCH:-arm64}"
+          bump_mode="${INPUT_BUMP:-none}"
+          commit_version="${INPUT_COMMIT_VERSION:-false}"
+          upload_to_r2="${INPUT_UPLOAD_TO_R2:-true}"
+          target_ref="${INPUT_REF:-$DEFAULT_BRANCH}"
+
+          case "$products" in
+            browseros)
+              product_ids="browseros"
+              build_browseros="true"
+              build_browserclaw="false"
+              ;;
+            browserclaw)
+              product_ids="browserclaw"
+              build_browseros="false"
+              build_browserclaw="true"
+              ;;
+            all)
+              product_ids="browseros browserclaw"
+              build_browseros="true"
+              build_browserclaw="true"
+              ;;
+            *)
+              echo "::error::Invalid products input: $products"
+              exit 1
+              ;;
+          esac
+
+          case "$arch" in
+            arm64|universal) ;;
+            *)
+              echo "::error::Invalid arch input: $arch"
+              exit 1
+              ;;
+          esac
+
+          case "$bump_mode" in
+            offset-only|offset+build|offset+patch|none) ;;
+            *)
+              echo "::error::Invalid bump input: $bump_mode"
+              exit 1
+              ;;
+          esac
+
+          case "$commit_version" in
+            true|false) ;;
+            *)
+              echo "::error::Invalid commit_version input: $commit_version"
+              exit 1
+              ;;
+          esac
+
+          case "$upload_to_r2" in
+            true|false) ;;
+            *)
+              echo "::error::Invalid upload_to_r2 input: $upload_to_r2"
+              exit 1
+              ;;
+          esac
+
+          timeout_minutes="600"
+          if [ "$products" = "all" ] || [ "$arch" = "universal" ]; then
+            timeout_minutes="1200"
+          fi
+
+          {
+            echo "target_ref=$target_ref"
+            echo "product_ids=$product_ids"
+            echo "build_browseros=$build_browseros"
+            echo "build_browserclaw=$build_browserclaw"
+            echo "arch=$arch"
+            echo "bump_mode=$bump_mode"
+            echo "commit_version=$commit_version"
+            echo "upload_to_r2=$upload_to_r2"
+            echo "timeout_minutes=$timeout_minutes"
+          } >> "$GITHUB_OUTPUT"
+
+  build:
+    needs: resolve_inputs
+    runs-on: [self-hosted, macOS, ARM64, browseros-builder]
+    permissions:
+      contents: write
+      pull-requests: write
+    timeout-minutes: ${{ fromJSON(needs.resolve_inputs.outputs.timeout_minutes) }}
+    env:
+      BROWSEROS_REPO: ${{ vars.BROWSEROS_REPO_PATH }}
+      CHROMIUM_SRC: ${{ vars.BROWSEROS_CHROMIUM_SRC }}
+    steps:
+      - name: Resolve build inputs
+        id: build_inputs
+        env:
+          TARGET_REF: ${{ needs.resolve_inputs.outputs.target_ref }}
+          PRODUCT_IDS: ${{ needs.resolve_inputs.outputs.product_ids }}
+          ARCH: ${{ needs.resolve_inputs.outputs.arch }}
+          BUMP_MODE: ${{ needs.resolve_inputs.outputs.bump_mode }}
+          COMMIT_VERSION: ${{ needs.resolve_inputs.outputs.commit_version }}
+          UPLOAD_TO_R2: ${{ needs.resolve_inputs.outputs.upload_to_r2 }}
+        run: |
+          set -euo pipefail
+
+          repo="${BROWSEROS_REPO:-}"
+          chromium_src="${CHROMIUM_SRC:-}"
+          if [ -z "$repo" ]; then
+            echo "::error::Set repository variable BROWSEROS_REPO_PATH"
+            exit 1
+          fi
+          if [ -z "$chromium_src" ]; then
+            echo "::error::Set repository variable BROWSEROS_CHROMIUM_SRC"
+            exit 1
+          fi
+
+          repo="${repo/#\~/$HOME}"
+          chromium_src="${chromium_src/#\~/$HOME}"
+          if [ ! -d "$repo/.git" ]; then
+            echo "::error::BROWSEROS_REPO_PATH does not point to a git checkout: $repo"
+            exit 1
+          fi
+          if [ ! -d "$chromium_src" ]; then
+            echo "::error::BROWSEROS_CHROMIUM_SRC does not exist: $chromium_src"
+            exit 1
+          fi
+
+          {
+            echo "browseros_repo=$repo"
+            echo "chromium_src=$chromium_src"
+            echo "target_ref=$TARGET_REF"
+            echo "product_ids=$PRODUCT_IDS"
+            echo "arch=$ARCH"
+            echo "bump_mode=$BUMP_MODE"
+            echo "commit_version=$COMMIT_VERSION"
+            echo "upload_to_r2=$UPLOAD_TO_R2"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Sync build repo to target ref
+        env:
+          BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
+          TARGET_REF: ${{ steps.build_inputs.outputs.target_ref }}
+        run: |
+          set -euo pipefail
+          cd "$BROWSEROS_REPO"
+          git fetch origin --tags --prune
+          # Wipe any local edits before switching refs. The builder's working
+          # tree can carry stray modifications to tracked files, which would
+          # otherwise make the checkout below abort before reset --hard runs.
+          git reset --hard
+          git clean -fd
+          if git show-ref --verify --quiet "refs/remotes/origin/$TARGET_REF"; then
+            git checkout -B "$TARGET_REF" "origin/$TARGET_REF"
+            git reset --hard "origin/$TARGET_REF"
+          else
+            git checkout -f "$TARGET_REF"
+            git reset --hard "$TARGET_REF"
+          fi
+
+      - name: Bump version
+        id: bump
+        env:
+          BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
+          BUMP_MODE: ${{ steps.build_inputs.outputs.bump_mode }}
+        run: |
+          set -euo pipefail
+          cd "$BROWSEROS_REPO/packages/browseros"
+          version="$(uv run python bos_build/scripts/bump_version.py --mode "$BUMP_MODE")"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Built version: $version"
+
+      - name: Commit version bump via pull request
+        if: ${{ steps.build_inputs.outputs.commit_version == 'true' && steps.build_inputs.outputs.bump_mode != 'none' }}
+        env:
+          BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
+          TARGET_REF: ${{ steps.build_inputs.outputs.target_ref }}
+          VERSION: ${{ steps.bump.outputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          cd "$BROWSEROS_REPO"
+          version_files=(
+            packages/browseros/resources/BROWSEROS_VERSION
+            packages/browseros/bos_build/config/BROWSEROS_BUILD_OFFSET
+          )
+          git add "${version_files[@]}"
+          if git diff --cached --quiet; then
+            echo "No version changes to commit."
+            exit 0
+          fi
+          git -c user.name="BrowserOS CI" -c user.email="ci@browseros.com" \
+            commit -m "chore(release): build v$VERSION [skip ci]"
+
+          safe_target_ref="${TARGET_REF//[^A-Za-z0-9._-]/-}"
+          branch="bot/release-macos-version-${safe_target_ref}-v${VERSION}"
+          expected_sha="$(git ls-remote --heads origin "$branch" | awk '{print $1}')"
+          if [ -n "$expected_sha" ]; then
+            git push --force-with-lease="refs/heads/$branch:$expected_sha" \
+              origin "HEAD:refs/heads/$branch"
+          else
+            git push origin "HEAD:refs/heads/$branch"
+          fi
+
+          pr_url="$(gh pr list \
+            --repo "$GITHUB_REPOSITORY" \
+            --base "$TARGET_REF" \
+            --head "$branch" \
+            --state open \
+            --json url \
+            --jq '.[0].url // ""')"
+          if [ -z "$pr_url" ]; then
+            pr_body="$(mktemp)"
+            trap 'rm -f "$pr_body"' EXIT
+            cat > "$pr_body" <<EOF
+          Automated release macOS version bump for v$VERSION.
+
+          Source run: $RUN_URL
+          Target ref: $TARGET_REF
+          EOF
+            pr_url="$(gh pr create \
+              --repo "$GITHUB_REPOSITORY" \
+              --base "$TARGET_REF" \
+              --head "$branch" \
+              --title "chore(release): build v$VERSION" \
+              --body-file "$pr_body")"
+          fi
+
+          echo "Version bump PR: $pr_url"
+          if gh pr merge "$pr_url" \
+            --repo "$GITHUB_REPOSITORY" \
+            --squash \
+            --delete-branch \
+            --subject "chore(release): build v$VERSION [skip ci]" \
+            --body "Automated release macOS version bump."; then
+            exit 0
+          fi
+
+          merge_state="$(gh pr view "$pr_url" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json mergeStateStatus \
+            --jq '.mergeStateStatus // "UNKNOWN"' || echo "UNKNOWN")"
+          failed_checks="$(gh pr view "$pr_url" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json statusCheckRollup \
+            --jq '[.statusCheckRollup[]? | select((.__typename == "CheckRun" and ((.conclusion // "") == "FAILURE" or (.conclusion // "") == "CANCELLED" or (.conclusion // "") == "TIMED_OUT" or (.conclusion // "") == "ACTION_REQUIRED")) or (.__typename == "StatusContext" and ((.state // "") == "FAILURE" or (.state // "") == "ERROR")))] | length' || echo "0")"
+          if [ "$merge_state" = "DIRTY" ] || [ "$failed_checks" -gt 0 ]; then
+            echo "::warning::Leaving version bump PR open (mergeStateStatus=$merge_state, failedChecks=$failed_checks): $pr_url"
+            exit 0
+          fi
+
+          if gh pr merge "$pr_url" \
+            --repo "$GITHUB_REPOSITORY" \
+            --auto \
+            --squash \
+            --delete-branch \
+            --subject "chore(release): build v$VERSION [skip ci]" \
+            --body "Automated release macOS version bump."; then
+            echo "Enabled auto-merge for version bump PR: $pr_url"
+          else
+            echo "::warning::Could not merge or enable auto-merge for version bump PR; leaving it open: $pr_url"
+          fi
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.6"
+
+      - name: Stage server resources for packaging
+        env:
+          BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
+        run: |
+          set -euo pipefail
+          agent_root="$BROWSEROS_REPO/packages/browseros-agent"
+          browseros_root="$BROWSEROS_REPO/packages/browseros"
+
+          cd "$agent_root"
+          bun ci
+          bun scripts/build/server.ts --target=darwin-arm64 --ci
+          bun scripts/build/claw-server.ts --target=darwin-arm64 --ci
+          bun scripts/build/claw-onboard.ts --ci
+
+          cd "$browseros_root"
+          AGENT_ROOT="$agent_root" BROWSEROS_ROOT="$browseros_root" uv run python - <<'PY'
+          import os
+          import shutil
+          from pathlib import Path
+
+          from bos_build.steps.storage.download import extract_artifact_zip
+
+          agent_root = Path(os.environ["AGENT_ROOT"])
+          browseros_root = Path(os.environ["BROWSEROS_ROOT"])
+          artifacts = [
+              (
+                  agent_root / "dist/prod/server/browseros-server-resources-darwin-arm64.zip",
+                  browseros_root / "resources/binaries/browseros_server/darwin-arm64",
+              ),
+              (
+                  agent_root / "dist/prod/claw-server/browseros-claw-server-resources-darwin-arm64.zip",
+                  browseros_root / "resources/binaries/browseros_claw_server/darwin-arm64",
+              ),
+              (
+                  agent_root / "dist/prod/claw-onboard/browseros-claw-onboard-resources.zip",
+                  browseros_root / "resources/binaries/browseros_claw_onboard",
+              ),
+          ]
+
+          for archive, destination in artifacts:
+              if not archive.is_file():
+                  raise SystemExit(f"Missing local server resource archive: {archive}")
+              if destination.exists():
+                  shutil.rmtree(destination)
+              extracted = extract_artifact_zip(archive, destination)
+              print(f"Staged {len(extracted)} file(s) from {archive.name}")
+          PY
+
+      - name: Build selected products
+        env:
+          BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
+          CHROMIUM_SRC: ${{ steps.build_inputs.outputs.chromium_src }}
+          PRODUCT_IDS: ${{ steps.build_inputs.outputs.product_ids }}
+          ARCH: ${{ steps.build_inputs.outputs.arch }}
+          UPLOAD_TO_R2: ${{ steps.build_inputs.outputs.upload_to_r2 }}
+        run: |
+          set -euo pipefail
+          cd "$BROWSEROS_REPO/packages/browseros"
+          # Server resources are staged locally by the previous step, so
+          # the R2 download is off; upload toggles with the run input.
+          for product in $PRODUCT_IDS; do
+            echo "Building $product for macOS $ARCH"
+            flags=(--preset release --product "$product" --arch "$ARCH" --no-download)
+            if [ "$UPLOAD_TO_R2" != "true" ]; then
+              flags+=(--no-upload)
+            fi
+            uv run browseros build "${flags[@]}" --chromium-src "$CHROMIUM_SRC"
+          done
+
+      - name: Upload BrowserOS DMG artifact
+        if: ${{ always() && steps.bump.outputs.version != '' && needs.resolve_inputs.outputs.build_browseros == 'true' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: BrowserOS_v${{ steps.bump.outputs.version }}_${{ needs.resolve_inputs.outputs.arch }}
+          path: ${{ steps.build_inputs.outputs.browseros_repo }}/packages/browseros/releases/${{ steps.bump.outputs.version }}/BrowserOS_*.dmg
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Upload BrowserClaw DMG artifact
+        if: ${{ always() && steps.bump.outputs.version != '' && needs.resolve_inputs.outputs.build_browserclaw == 'true' }}
+        uses: actions/upload-artifact@v7
+        with:
+          name: BrowserClaw_v${{ steps.bump.outputs.version }}_${{ needs.resolve_inputs.outputs.arch }}
+          path: ${{ steps.build_inputs.outputs.browseros_repo }}/packages/browseros/releases/${{ steps.bump.outputs.version }}/BrowserClaw_*.dmg
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Slack failure ping
+        if: ${{ failure() }}
+        env:
+          BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
+          TARGET_REF: ${{ steps.build_inputs.outputs.target_ref }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          hook="$(
+            python3 - <<'PY'
+          import os
+          from pathlib import Path
+
+          env_file = Path(os.environ["BROWSEROS_REPO"]) / "packages/browseros/.env"
+          if not env_file.exists():
+              raise SystemExit(0)
+          for line in env_file.read_text().splitlines():
+              if line.startswith("SLACK_WEBHOOK_URL="):
+                  print(line.split("=", 1)[1].strip().strip("'\""))
+                  break
+          PY
+          )"
+          if [ -z "$hook" ]; then
+            exit 0
+          fi
+          python3 - <<'PY' > /tmp/browseros-release-macos-slack-payload.json
+          import json
+          import os
+
+          print(
+              json.dumps(
+                  {
+                      "text": (
+                          ":x: Release macOS build failed on "
+                          f"`{os.environ['TARGET_REF']}` - {os.environ['RUN_URL']}"
+                      )
+                  }
+              )
+          )
+          PY
+          curl -fsS -X POST -H "Content-type: application/json" \
+            --data @/tmp/browseros-release-macos-slack-payload.json "$hook" || true

--- a/packages/browseros/bos_build/docs/nightly-macos-ci.md
+++ b/packages/browseros/bos_build/docs/nightly-macos-ci.md
@@ -22,6 +22,51 @@ uv run browseros build --preset release --arch arm64 --chromium-src "$CHROMIUM_S
 Set `upload_to_r2=false` in the manual dispatch form to run an artifact-only
 build without publishing to R2.
 
+## Release macOS Workflow
+
+`release-macos.yml` uses the same private Mac Mini, signing keychain, local
+`packages/browseros/.env`, Chromium checkout, and server-resource staging path
+as the nightly workflow. It has no schedule; run it manually with
+`workflow_dispatch` or call it from another workflow with `workflow_call`.
+
+Release runs default to rebuilding the current version files without bumping
+them:
+
+```text
+bump=none
+commit_version=false
+upload_to_r2=true
+products=browseros
+arch=arm64
+```
+
+Use `products=browserclaw` to build only BrowserClaw, or `products=all` to
+build BrowserOS first and BrowserClaw second in the same job. The workflow also
+accepts `arch=universal`; universal and two-product runs use a longer timeout
+because they run multiple Chromium build/package passes sequentially on the same
+machine.
+
+The release workflow stages all macOS server bundles locally before packaging,
+regardless of the selected product:
+
+```bash
+bun scripts/build/server.ts --target=darwin-arm64 --ci
+bun scripts/build/claw-server.ts --target=darwin-arm64 --ci
+bun scripts/build/claw-onboard.ts --ci
+```
+
+Each selected product then runs:
+
+```bash
+uv run browseros build --preset release --product <product> --arch <arch> \
+  --no-download --chromium-src "$CHROMIUM_SRC"
+```
+
+Set `upload_to_r2=false` to add `--no-upload` for artifact-only release
+verification. Signing, notarization, R2, and Slack values still come from the
+runner-local `packages/browseros/.env`; do not add those secrets to GitHub
+Actions.
+
 ## One-Time Runner Setup
 
 Register the Mac Mini as a repo-scoped self-hosted runner with the custom


### PR DESCRIPTION
## Summary
- Add `release-macos.yml` for signed macOS release builds on the private self-hosted Mac builder.
- Support manual and reusable triggers with product, architecture, bump, commit, upload, and ref inputs.
- Build selected products sequentially, stage all server bundles locally, and upload product-scoped DMG artifacts.

## Design
The workflow mirrors the proven nightly macOS runner path for local repo validation, checkout sync, version bumping, optional bot PR commits, Bun setup, server-resource staging, artifact uploads, and Slack failure pings. The new input resolver normalizes dispatch and workflow-call inputs, expands `products=all`, computes the longer timeout for universal or two-product runs, and keeps signing/R2 credentials runner-local via `packages/browseros/.env`.

## Test plan
- [x] `actionlint .github/workflows/release-macos.yml`
- [x] `actionlint .github/workflows/nightly-macos-build.yml .github/workflows/release-macos.yml`
- [x] `git diff --check HEAD~2..HEAD`
- [x] `uv run python bos_build/scripts/bump_version.py --mode none` from `packages/browseros`

No live workflow dispatch was run.