### PR TITLE
fix(ci): nightly macos bump script moved to bos_build/scripts in #1499

### DIFF
--- a/.github/workflows/nightly-macos-build.yml
+++ b/.github/workflows/nightly-macos-build.yml
@@ -153,7 +153,7 @@ jobs:
         run: |
           set -euo pipefail
           cd "$BROWSEROS_REPO/packages/browseros"
-          version="$(uv run python build/scripts/bump_version.py --mode "$BUMP_MODE")"
+          version="$(uv run python bos_build/scripts/bump_version.py --mode "$BUMP_MODE")"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Built version: $version"
 


### PR DESCRIPTION
The bos_build refactor (#1499) relocated `build/scripts/bump_version.py` to `bos_build/scripts/bump_version.py`; the nightly workflow still calls the old path, so the bump step fails on any run that reaches it. The new `release-macos.yml` (#1581) already uses the relocated path — this aligns the nightly.

Context discovered while building the release workflows: the self-hosted mac runner has also been offline since ~June 27 (every nightly since then cancelled/queued), so this breakage was masked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)