### PR TITLE
refactor(ci): nightly-release composes the reusable chromium build workflow

### DIFF
--- a/.github/workflows/build-browseros.yml
+++ b/.github/workflows/build-browseros.yml
@@ -47,6 +47,11 @@ on:
         required: false
         type: string
         default: ""
+      artifact-name:
+        description: "Optional upload artifact name override"
+        required: false
+        type: string
+        default: ""
 
 permissions:
   contents: read
@@ -291,7 +296,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ inputs.product }}-${{ inputs.profile }}-${{ inputs.platform }}-${{ inputs.arch }}
+          name: ${{ inputs.artifact-name || format('{0}-{1}-{2}-{3}', inputs.product, inputs.profile, inputs.platform, inputs.arch) }}
           if-no-files-found: error
           retention-days: 14
           compression-level: 0

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,12 +1,15 @@
 name: Nightly Release Build
 
 # Manual UNSIGNED release builds of BrowserOS for all three platforms on
-# WarpBuild runners. Signing is intentionally not wired up yet; see
-# packages/browseros/bos_build/docs/nightly-warpbuild-ci.md for the design and
-# the secret names that enable signing later.
+# WarpBuild runners. The shared Chromium/WarpBuild recipe lives in
+# .github/workflows/build-browseros.yml; this workflow resolves the nightly
+# matrix, invokes the reusable workflow with the nightly-ci profile, and
+# optionally refreshes the rolling nightly prerelease. Signing is intentionally
+# off for nightly; see packages/browseros/bos_build/docs/nightly-warpbuild-ci.md
+# for the design and the secret names that enable signing later.
 #
-# The pinned chromium checkout (packages/browseros/CHROMIUM_VERSION) is
-# cached post-`gclient sync`:
+# build-browseros.yml caches the pinned chromium checkout
+# (packages/browseros/CHROMIUM_VERSION) post-`gclient sync`:
 #   - Linux/macOS: WarpCache (WarpBuilds/cache, no size cap)
 #   - Windows:     R2 tarball via `browseros source cache` (WarpCache does
 #                  not support Windows runners; actions/cache caps at 10GB)
@@ -91,13 +94,14 @@ jobs:
       - name: Fail fast when no runner picks up the builds
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CONCURRENCY_GROUP: nightly-release
         run: |
           set -euo pipefail
           deadline=$(( $(date +%s) + 20 * 60 ))
           failures=0
           while :; do
             if jobs="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/jobs?per_page=100" \
-              --jq '[.jobs[] | select(.name | startswith("build (")) | {name, status}]')"; then
+              --jq '[.jobs[] | select(.name != "queue-watchdog") | select(.status != "completed") | {name, status}]')"; then
               failures=0
             else
               failures=$(( failures + 1 ))
@@ -118,17 +122,17 @@ jobs:
             if [ "$(date +%s)" -ge "$deadline" ]; then
               doc="packages/browseros/bos_build/docs/nightly-warpbuild-ci.md"
               if [ "$total" -eq 0 ]; then
-                echo "::error::queue-watchdog matched no 'build (' jobs — were the matrix job names changed? Fix the filter; not cancelling."
+                echo "::error::queue-watchdog matched no build jobs - were the matrix job names changed? Fix the filter; not cancelling."
                 exit 1
               fi
               stuck="$(jq -r '[.[] | select(.status == "queued") | .name] | join(", ")' <<<"$jobs")"
               # Cancel only when nothing is live: a queued job is then the
               # only thing keeping the run (and concurrency group) pinned.
-              if [ "$in_progress" -eq 0 ]; then
-                echo "::error::No build job is running and these never left the queue: $stuck. Check the runner-group public-repo setting, runner labels, and the WarpBuild dashboard — see $doc. Cancelling the run to free the nightly-release concurrency group."
+              if [ "$queued" -gt 0 ] && [ "$in_progress" -eq 0 ]; then
+                echo "::error::No build job is running and these never left the queue: $stuck. Check the runner-group public-repo setting, runner labels, and the WarpBuild dashboard - see $doc. Cancelling the run to free the $CONCURRENCY_GROUP concurrency group."
                 gh api -X POST "repos/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID/cancel"
               else
-                echo "::error::Still queued after 20 min: $stuck. In-progress builds keep running — see $doc."
+                echo "::error::Still queued after 20 min: $stuck. In-progress builds keep running - see $doc."
               fi
               exit 1
             fi
@@ -142,165 +146,18 @@ jobs:
       matrix:
         include: ${{ fromJSON(needs.plan.outputs.matrix) }}
     name: build (${{ matrix.platform }}-${{ matrix.arch }})
-    runs-on: ${{ matrix.runner }}
-    timeout-minutes: ${{ matrix.timeout }}
-    defaults:
-      run:
-        shell: bash
-    env:
-      # Windows runners pipe stdout as cp1252, which crashes the emoji-heavy
-      # build CLI with UnicodeEncodeError; force UTF-8 for python and all
-      # its subprocesses (gclient, hooks). No-op on Linux/macOS.
-      PYTHONUTF8: "1"
-    steps:
-      - uses: actions/checkout@v7
-
-      # v8.x.y releases exist but astral-sh publishes no floating `v8`
-      # major tag — `@v8` is unresolvable and kills the job in Set up job.
-      - uses: astral-sh/setup-uv@v8.2.0
-
-      - name: Resolve chromium pin and paths
-        id: pin
-        run: |
-          set -euo pipefail
-          . packages/browseros/CHROMIUM_VERSION
-          version="$MAJOR.$MINOR.$BUILD.$PATCH"
-
-          # Keep the checkout outside the workspace so actions/checkout
-          # never touches it. pwd -W yields a native path on Windows.
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            parent="$(cd "$GITHUB_WORKSPACE/.." && pwd -W)"
-          else
-            parent="$(cd "$GITHUB_WORKSPACE/.." && pwd)"
-          fi
-
-          {
-            echo "version=$version"
-            echo "cache_key=chromium-src-${{ matrix.platform }}-${{ matrix.arch }}-v1-$version"
-          } >> "$GITHUB_OUTPUT"
-          {
-            echo "CHROMIUM_ROOT=$parent/chromium"
-            echo "CHROMIUM_SRC=$parent/chromium/src"
-          } >> "$GITHUB_ENV"
-
-      - name: Restore chromium checkout (WarpCache)
-        if: runner.os != 'Windows'
-        id: warpcache
-        uses: WarpBuilds/cache/restore@v1
-        with:
-          path: ${{ env.CHROMIUM_ROOT }}
-          key: ${{ steps.pin.outputs.cache_key }}
-          restore-keys: |
-            chromium-src-${{ matrix.platform }}-${{ matrix.arch }}-v1-
-
-      - name: Restore chromium checkout (R2)
-        if: runner.os == 'Windows'
-        id: r2cache
-        env:
-          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          R2_BUCKET: ${{ secrets.R2_BUCKET }}
-        run: |
-          set -euo pipefail
-          uv run --project packages/browseros browseros source cache restore \
-            --key "${{ steps.pin.outputs.cache_key }}" \
-            --root "$CHROMIUM_ROOT"
-
-      - name: Ensure chromium checkout at pinned tag
-        run: |
-          set -euo pipefail
-          uv run --project packages/browseros browseros source ensure \
-            --root "$CHROMIUM_ROOT" --step checkout
-
-      - name: Reset chromium tree (clean module)
-        working-directory: packages/browseros
-        run: |
-          set -euo pipefail
-          uv run browseros build --modules clean \
-            --chromium-src "$CHROMIUM_SRC" \
-            --build-type release \
-            --arch "${{ matrix.arch }}"
-
-      - name: Sync chromium dependencies (gclient)
-        run: |
-          set -euo pipefail
-          uv run --project packages/browseros browseros source ensure \
-            --root "$CHROMIUM_ROOT" --step sync
-
-      # Save immediately after sync: the tree is pristine (no BrowserOS
-      # patches, no out/ dir), which keeps the cache deterministic and as
-      # small as possible.
-      - name: Save chromium checkout (WarpCache)
-        if: runner.os != 'Windows' && steps.warpcache.outputs.cache-hit != 'true'
-        uses: WarpBuilds/cache/save@v1
-        with:
-          path: ${{ env.CHROMIUM_ROOT }}
-          key: ${{ steps.pin.outputs.cache_key }}
-
-      - name: Save chromium checkout (R2)
-        if: runner.os == 'Windows' && steps.r2cache.outputs.cache-hit != 'true'
-        env:
-          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          R2_BUCKET: ${{ secrets.R2_BUCKET }}
-        run: |
-          set -euo pipefail
-          uv run --project packages/browseros browseros source cache save \
-            --key "${{ steps.pin.outputs.cache_key }}" \
-            --root "$CHROMIUM_ROOT"
-
-      - name: Install Linux build deps
-        if: matrix.platform == 'linux'
-        run: |
-          set -euo pipefail
-          sudo apt-get update
-          # libfuse2: appimagetool is itself an AppImage and needs FUSE
-          sudo apt-get install -y libfuse2
-          "$CHROMIUM_SRC/build/install-build-deps.sh" --no-prompt
-
-      - name: Build BrowserOS (unsigned)
-        working-directory: packages/browseros
-        env:
-          # download_resources pulls BrowserOS Server bundles from R2
-          R2_ACCOUNT_ID: ${{ secrets.R2_ACCOUNT_ID }}
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          R2_BUCKET: ${{ secrets.R2_BUCKET }}
-          # --- Signing placeholders (unused until signing is wired up) ---
-          # macOS (sign_macos + notarization):
-          #   MACOS_CERTIFICATE_P12 / MACOS_CERTIFICATE_PWD (import into a CI keychain)
-          #   MACOS_CERTIFICATE_NAME, MACOS_KEYCHAIN_PASSWORD
-          #   PROD_MACOS_NOTARIZATION_APPLE_ID / _TEAM_ID / _PWD
-          #   SPARKLE_PRIVATE_KEY (sparkle_sign)
-          # Windows (sign_windows via SSL.com CodeSignTool):
-          #   ESIGNER_USERNAME / ESIGNER_PASSWORD / ESIGNER_TOTP_SECRET
-          #   ESIGNER_CREDENTIAL_ID, CODE_SIGN_TOOL_PATH (tool install dir)
-        run: |
-          set -euo pipefail
-          uv run browseros build \
-            --profile nightly-ci \
-            --arch "${{ matrix.arch }}" \
-            --chromium-src "$CHROMIUM_SRC"
-
-      - name: Report disk usage
-        if: always()
-        run: df -h || true
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v7
-        with:
-          name: browseros-nightly-${{ matrix.platform }}-${{ matrix.arch }}
-          if-no-files-found: error
-          retention-days: 14
-          compression-level: 0
-          path: |
-            packages/browseros/releases/*/*.dmg
-            packages/browseros/releases/*/*.AppImage
-            packages/browseros/releases/*/*.deb
-            packages/browseros/releases/*/*_installer.exe
-            packages/browseros/releases/*/*_installer.zip
+    uses: ./.github/workflows/build-browseros.yml
+    with:
+      platform: ${{ matrix.platform }}
+      arch: ${{ matrix.arch }}
+      product: browseros
+      runner: ${{ matrix.runner }}
+      timeout-minutes: ${{ matrix.timeout }}
+      profile: nightly-ci
+      sign: false
+      upload: false
+      artifact-name: browseros-nightly-${{ matrix.platform }}-${{ matrix.arch }}
+    secrets: inherit
 
   publish:
     needs: [plan, build]

--- a/packages/browseros/bos_build/docs/nightly-warpbuild-ci.md
+++ b/packages/browseros/bos_build/docs/nightly-warpbuild-ci.md
@@ -3,9 +3,12 @@
 `.github/workflows/nightly-release.yml` builds UNSIGNED release artifacts for
 Linux x64, Windows x64, and macOS arm64 every night on WarpBuild cloud
 runners, uploads them to the Actions run, and refreshes a rolling `nightly`
-prerelease on GitHub. It complements (does not replace) the signed
-self-hosted macOS nightly in `nightly-macos-build.yml`; once signing is wired
-up here, that workflow can be retired.
+prerelease on GitHub. Its per-platform build job delegates to the reusable
+Chromium build workflow in `.github/workflows/build-browseros.yml`, so the
+WarpBuild checkout/cache/build recipe is shared with the release workflows.
+It complements (does not replace) the signed self-hosted macOS nightly in
+`nightly-macos-build.yml`; once signing is wired up here, that workflow can
+be retired.
 
 ## Runners
 
@@ -79,6 +82,12 @@ the build job leave `queued` within ~5 minutes (`gh run watch`).
 
 ## Per-night pipeline (per platform)
 
+`nightly-release.yml` resolves the platform matrix and then calls
+`.github/workflows/build-browseros.yml` once per selected platform with
+`product=browseros`, `profile=nightly-ci`, `sign=false`, `upload=false`, and
+the historical artifact name `browseros-nightly-<platform>-<arch>`. The
+reusable workflow performs the per-platform recipe:
+
 1. `actions/checkout` + `astral-sh/setup-uv`.
 2. Restore the pinned chromium checkout from cache (see below).
 3. `browseros source ensure --step checkout` — ensures depot_tools and
@@ -92,8 +101,9 @@ the build job leave `queued` within ~5 minutes (`gh run watch`).
 6. Save the cache (only when the restore missed, i.e. first run per pin).
 7. `uv run browseros build --profile nightly-ci --arch <arch>
    --chromium-src .../src`.
-8. Upload artifacts (14-day retention); a follow-up job recreates the
-   rolling `nightly` prerelease for scheduled main runs.
+8. Upload artifacts (14-day retention) using the nightly artifact name; a
+   follow-up job in `nightly-release.yml` recreates the rolling `nightly`
+   prerelease for scheduled main runs.
 
 The `nightly-ci` profile is the release preset minus `clean`/
 `git_setup` (steps 4-5 replace them), minus `sign_*`/`upload`. Why not run


### PR DESCRIPTION
## Summary
- Replace nightly's duplicated inline Chromium build job with a matrix reusable-workflow call to `.github/workflows/build-browseros.yml`.
- Add a default-preserving `artifact-name` input so nightly keeps publishing `browseros-nightly-<platform>-<arch>` artifacts while release callers keep their existing names.
- Update the nightly header docs, queue-watchdog filter, and WarpBuild CI docs to point at the reusable build recipe.

## Behavior preservation
- `plan` is unchanged: same platform choices, publish flag resolution, concurrency group, matrix entries, runner labels, arches, and timeouts.
- The nightly `build` matrix still uses `fromJSON(needs.plan.outputs.matrix)` and passes platform, arch, runner, and timeout from that matrix.
- Checkout, `PYTHONUTF8=1`, `astral-sh/setup-uv@v8.2.0`, checkout-outside-workspace path resolution, chromium pin/cache key, WarpCache restore/save, Windows R2 restore/save, checkout ensure, clean, sync, Linux deps, build, disk usage, artifact globs, retention, and compression now come from `build-browseros.yml`.
- Nightly passes `product=browseros`, `profile=nightly-ci`, `sign=false`, and `upload=false`, matching the unsigned browseros-only nightly behavior.
- Artifact names remain `browseros-nightly-<platform>-<arch>`, so the existing `publish` job's `download-artifact@v4` merge and dmg/AppImage/deb/installer globs keep working.
- `publish` is unchanged: it still depends on `plan` and `build`, downloads merged artifacts, and recreates the rolling `nightly` prerelease only when the publish flag is true.
- The queue watchdog now uses the same generalized non-completed-job filter as `release-linux.yml` and `release-windows.yml`, which covers reusable-workflow job names rendered as `<caller job> / <called job>`.

## Verification
- `actionlint .github/workflows/nightly-release.yml .github/workflows/build-browseros.yml`
- `git diff --check HEAD~1..HEAD`
- No workflow dispatches were run.