### PR TITLE
fix(ci): AGENT_RUNNER_JWT_SECRET is optional for server resource builds

### DIFF
--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -1,7 +1,7 @@
 # Required secrets for resource publishing: R2_ACCOUNT_ID, R2_ACCESS_KEY_ID,
 # R2_SECRET_ACCESS_KEY, R2_BUCKET, BROWSEROS_CONFIG_URL, POSTHOG_API_KEY,
-# SENTRY_DSN, AGENT_RUNNER_JWT_SECRET. Optional when publish_ota is true:
-# SPARKLE_PRIVATE_KEY.
+# SENTRY_DSN. Optional: AGENT_RUNNER_JWT_SECRET (inlined when present),
+# SPARKLE_PRIVATE_KEY (required only when publish_ota is true).
 name: Release BrowserOS Server
 
 on:
@@ -57,7 +57,7 @@ on:
       SENTRY_DSN:
         required: true
       AGENT_RUNNER_JWT_SECRET:
-        required: true
+        required: false
       SPARKLE_PRIVATE_KEY:
         required: false
 
@@ -186,8 +186,10 @@ jobs:
             BROWSEROS_CONFIG_URL
             POSTHOG_API_KEY
             SENTRY_DSN
-            AGENT_RUNNER_JWT_SECRET
           )
+          # AGENT_RUNNER_JWT_SECRET is inlined when present but not required —
+          # the descriptor's requiredInlineEnvKeys omits it
+          # (scripts/build/server/descriptor.ts).
           if [ "${PUBLISH_OTA:-false}" = "true" ]; then
             required+=(SPARKLE_PRIVATE_KEY)
           fi


### PR DESCRIPTION
Live verification of the reworked release-server pipeline (run 28725252205) failed preflight on AGENT_RUNNER_JWT_SECRET — but the build descriptor's `requiredInlineEnvKeys` omits it (`scripts/build/server/descriptor.ts`): it's inlined when present, not required. Relax the workflow preflight + workflow_call contract to match. BROWSEROS_CONFIG_URL and SENTRY_DSN repo secrets are now set, so the next run proceeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)