### PR TITLE
fix(ci): provide wine wrapper for server release builds on ubuntu-24.04

### DIFF
--- a/.github/workflows/release-claw-server.yml
+++ b/.github/workflows/release-claw-server.yml
@@ -194,6 +194,11 @@ jobs:
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends wine64
+          # ubuntu-24.04's wine64 package ships only the wine64 binary; the
+          # build tooling spawns `wine` (scripts/patch-windows-exe.ts).
+          if ! command -v wine >/dev/null; then
+            sudo ln -s "$(command -v wine64)" /usr/local/bin/wine
+          fi
           wine --version
 
       - name: Install browseros-agent dependencies

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -216,6 +216,11 @@ jobs:
           set -euo pipefail
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends wine64
+          # ubuntu-24.04's wine64 package ships only the wine64 binary; the
+          # build tooling spawns `wine` (scripts/patch-windows-exe.ts).
+          if ! command -v wine >/dev/null; then
+            sudo ln -s "$(command -v wine64)" /usr/local/bin/wine
+          fi
           wine --version
 
       - name: Install browseros-agent dependencies


### PR DESCRIPTION
Live verification runs 28725252875 / 28725323394 failed at the Wine install step: `wine: command not found` — ubuntu-24.04's `wine64` package ships only the `wine64` binary, while the windows-x64 metadata patcher (`scripts/patch-windows-exe.ts`, spawned from build-server-tools compile) invokes `wine`. Symlink the wrapper when absent, in both server release workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)