### PR TITLE
fix(ci): install wine metapackage for the /usr/bin/wine wrapper

### DIFF
--- a/.github/workflows/release-claw-server.yml
+++ b/.github/workflows/release-claw-server.yml
@@ -193,11 +193,12 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends wine64
-          # ubuntu-24.04's wine64 package ships only the wine64 binary; the
-          # build tooling spawns `wine` (scripts/patch-windows-exe.ts).
+          # The `wine` package provides the /usr/bin/wine wrapper that
+          # patch-windows-exe.ts spawns; ubuntu-24.04's wine64 alone ships
+          # only the loader at /usr/lib/wine/wine64 (no /usr/bin entry).
+          sudo apt-get install -y --no-install-recommends wine
           if ! command -v wine >/dev/null; then
-            sudo ln -s "$(command -v wine64)" /usr/local/bin/wine
+            sudo ln -s /usr/lib/wine/wine64 /usr/local/bin/wine
           fi
           wine --version
 

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -215,11 +215,12 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends wine64
-          # ubuntu-24.04's wine64 package ships only the wine64 binary; the
-          # build tooling spawns `wine` (scripts/patch-windows-exe.ts).
+          # The `wine` package provides the /usr/bin/wine wrapper that
+          # patch-windows-exe.ts spawns; ubuntu-24.04's wine64 alone ships
+          # only the loader at /usr/lib/wine/wine64 (no /usr/bin entry).
+          sudo apt-get install -y --no-install-recommends wine
           if ! command -v wine >/dev/null; then
-            sudo ln -s "$(command -v wine64)" /usr/local/bin/wine
+            sudo ln -s /usr/lib/wine/wine64 /usr/local/bin/wine
           fi
           wine --version
 


### PR DESCRIPTION
Second wine iteration from live verification (runs 28725370498 / 28725371090): ubuntu-24.04's `wine64` package ships only the loader at `/usr/lib/wine/wine64` — there is no `/usr/bin/wine64`, so `command -v wine64` was empty and the symlink pointed at ''. Install the `wine` metapackage (provides the `/usr/bin/wine` wrapper) and fall back to symlinking the loader path directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)