### PR TITLE
fix: stop 1.5s viewport reflow on agent-driven tabs + Sky Tint strip

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/cockpit/AgentRunningCard.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/AgentRunningCard.tsx
@@ -45,6 +45,7 @@ export function AgentRunningCard({
           site={siteOf(focus.url)}
           live={active}
           screencast={focus.screencast}
+          className="h-full w-full"
         />
         <div className="absolute top-3 right-3">
           <TabCountChip tabs={agent.tabs} focusTargetId={focus.targetId} />

--- a/packages/browseros-agent/apps/claw-app/components/cockpit/MiniScreencast.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/cockpit/MiniScreencast.tsx
@@ -14,6 +14,14 @@ interface MiniScreencastProps {
    * appear or disappear.
    */
   screencast?: ScreencastFrame | null
+  /**
+   * Overrides the container sizing. Defaults to `h-[132px] w-full`
+   * (the RunningCard grid tile shape). AgentRunningCard passes
+   * `h-full w-full` so the frame fills its `flex-1` zone instead of
+   * clamping at 132px, which used to leave a Sky Tint strip below
+   * the image inside the 300px running-now tile.
+   */
+  className?: string
 }
 
 /**
@@ -39,6 +47,7 @@ export function MiniScreencast({
   site,
   live,
   screencast,
+  className,
 }: MiniScreencastProps) {
   const incomingSrc =
     screencast && screencast.jpegBase64.length > 0
@@ -76,7 +85,12 @@ export function MiniScreencast({
   const showImage = displayedSrc !== null
 
   return (
-    <div className="relative flex h-[132px] items-center justify-center overflow-hidden bg-bg-sunken">
+    <div
+      className={cn(
+        'relative flex items-center justify-center overflow-hidden bg-bg-sunken',
+        className ?? 'h-[132px] w-full',
+      )}
+    >
       {showImage ? (
         // biome-ignore lint/performance/noImgElement: data URL only;
         // there is no remote URL for next/image to optimise.

--- a/packages/browseros-agent/apps/claw-server/src/services/screencast-poller.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/screencast-poller.ts
@@ -60,12 +60,25 @@ export function startScreencastPoller(
   const intervalMs = opts.intervalMs ?? DEFAULT_POLL_INTERVAL_MS
   const registry = opts.registry ?? defaultRegistry
 
+  // Tracks CDP screenshot calls still resolving on Chromium's side.
+  // The `running` flag below stops a tick from overlapping with
+  // itself, but it does NOT stop individual snapOne calls from
+  // stacking: session.screenshot() has no AbortSignal support, so
+  // when a snapOne times out its outer Promise.race settles but the
+  // underlying capture keeps running. Under sustained sluggishness
+  // each 1.5s tick would fire a fresh CDP call for the same page on
+  // top of the last one. inFlight is a per-page guard; snapOne
+  // early-returns when the page id is already present, and the
+  // guard entry is cleared by the outstanding capture promise's
+  // .finally() when the CDP call actually resolves or rejects.
+  const inFlight = new Set<number>()
+
   let running = false
   const tick = async (): Promise<void> => {
     if (running) return
     running = true
     try {
-      await runTick(opts.session, registry)
+      await runTick(opts.session, registry, inFlight)
     } catch (err) {
       logger.warn('screencast: tick failed', {
         error: err instanceof Error ? err.message : String(err),
@@ -98,6 +111,7 @@ export function startScreencastPoller(
 async function runTick(
   session: BrowserSession,
   registry: TabActivityRegistry,
+  inFlight: Set<number>,
 ): Promise<void> {
   const tabs = registry.snapshot()
   const livePageIds = new Set<number>()
@@ -124,11 +138,38 @@ async function runTick(
   //    snapshots in flight at any time.
   for (let i = 0; i < work.length; i += MAX_PARALLEL_SHOTS) {
     const batch = work.slice(i, i + MAX_PARALLEL_SHOTS)
-    await Promise.allSettled(batch.map((pageId) => snapOne(pageId, session)))
+    await Promise.allSettled(
+      batch.map((pageId) => snapOne(pageId, session, inFlight)),
+    )
   }
 }
 
-async function snapOne(pageId: number, session: BrowserSession): Promise<void> {
+async function snapOne(
+  pageId: number,
+  session: BrowserSession,
+  inFlight: Set<number>,
+): Promise<void> {
+  // Per-page in-flight guard: see the docstring on `inFlight` at
+  // startScreencastPoller for why this is not covered by the
+  // tick-level `running` flag.
+  if (inFlight.has(pageId)) return
+  inFlight.add(pageId)
+
+  // Attach the .finally() BEFORE Promise.race so the guard entry is
+  // released when the CDP call actually resolves, not when the race
+  // timeout wins. If session.screenshot() rejects, .finally() still
+  // fires and Promise.race sees the rejection through this chained
+  // promise, so no unhandled rejection is orphaned.
+  const capturePromise = session
+    .screenshot(pageId, {
+      format: 'jpeg',
+      quality: JPEG_QUALITY,
+      annotate: false,
+    })
+    .finally(() => {
+      inFlight.delete(pageId)
+    })
+
   try {
     // Call session.screenshot() directly, WITHOUT a clip. The MCP
     // screenshot tool's default path (via executeTool) computes
@@ -147,11 +188,7 @@ async function snapOne(pageId: number, session: BrowserSession): Promise<void> {
     // (scale = 1, no clip) keeps the JPEG cost roughly the same
     // after downscaling and avoids the reflow.
     const result = await Promise.race([
-      session.screenshot(pageId, {
-        format: 'jpeg',
-        quality: JPEG_QUALITY,
-        annotate: false,
-      }),
+      capturePromise,
       new Promise<never>((_, reject) => {
         AbortSignal.timeout(SCREENSHOT_TIMEOUT_MS).addEventListener(
           'abort',

--- a/packages/browseros-agent/apps/claw-server/src/services/screencast-poller.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/screencast-poller.ts
@@ -26,18 +26,12 @@
  */
 
 import type { BrowserSession } from '@browseros/browser-core/core/session'
-import { BROWSER_TOOLS } from '@browseros/browser-mcp/registry'
-import {
-  executeTool,
-  type ToolDefinition,
-} from '@browseros/browser-mcp/tools/framework'
 import { logger } from '../lib/logger'
 import {
   tabActivityRegistry as defaultRegistry,
   type TabActivityRegistry,
 } from '../lib/tab-activity'
 import { screencastCache } from './screencast-cache'
-import { extractToolResultImageData } from './tool-result-image'
 
 export const DEFAULT_POLL_INTERVAL_MS = 1500
 export const SCREENSHOT_TIMEOUT_MS = 2000
@@ -65,24 +59,13 @@ export function startScreencastPoller(
 ): ScreencastPollerHandle {
   const intervalMs = opts.intervalMs ?? DEFAULT_POLL_INTERVAL_MS
   const registry = opts.registry ?? defaultRegistry
-  const screenshotTool = BROWSER_TOOLS.find((t) => t.name === 'screenshot')
-  if (!screenshotTool) {
-    // The browser-mcp catalogue not exposing a screenshot tool would
-    // be a contract break we discover at boot; rather than throw and
-    // crash the cockpit, log loudly and return a no-op handle so the
-    // homepage gracefully falls back to placeholders.
-    logger.error(
-      'screencast: screenshot tool missing from BROWSER_TOOLS; poller will not start',
-    )
-    return { stop: () => undefined }
-  }
 
   let running = false
   const tick = async (): Promise<void> => {
     if (running) return
     running = true
     try {
-      await runTick(opts.session, screenshotTool, registry)
+      await runTick(opts.session, registry)
     } catch (err) {
       logger.warn('screencast: tick failed', {
         error: err instanceof Error ? err.message : String(err),
@@ -114,7 +97,6 @@ export function startScreencastPoller(
 
 async function runTick(
   session: BrowserSession,
-  screenshotTool: ToolDefinition,
   registry: TabActivityRegistry,
 ): Promise<void> {
   const tabs = registry.snapshot()
@@ -142,65 +124,77 @@ async function runTick(
   //    snapshots in flight at any time.
   for (let i = 0; i < work.length; i += MAX_PARALLEL_SHOTS) {
     const batch = work.slice(i, i + MAX_PARALLEL_SHOTS)
-    await Promise.allSettled(
-      batch.map((pageId) => snapOne(pageId, session, screenshotTool)),
-    )
+    await Promise.allSettled(batch.map((pageId) => snapOne(pageId, session)))
   }
 }
 
-async function snapOne(
-  pageId: number,
-  session: BrowserSession,
-  screenshotTool: ToolDefinition,
-): Promise<void> {
+async function snapOne(pageId: number, session: BrowserSession): Promise<void> {
   try {
-    const result = await executeTool(
-      screenshotTool,
-      {
-        page: pageId,
+    // Call session.screenshot() directly, WITHOUT a clip. The MCP
+    // screenshot tool's default path (via executeTool) computes
+    // clip = { width, height, scale = min(1, targetW/vw, targetH/vh) }
+    // to fit the capture inside a 1024x768 target. When the actual
+    // viewport is bigger than 1024x768 the scale is < 1, and on the
+    // BrowserOS Chromium fork Page.captureScreenshot({clip: {scale
+    // != 1}}) visibly resizes the tab the user is watching for the
+    // duration of the capture, then restores. The poller runs every
+    // 1.5s, so the operator sees the driven tab flicker (shrink
+    // then expand) at the poll cadence.
+    //
+    // The poller does not need the tool's size-capping behaviour:
+    // MiniScreencast paints frames at a fixed 132px height and
+    // downscales in the browser. Capturing at the natural viewport
+    // (scale = 1, no clip) keeps the JPEG cost roughly the same
+    // after downscaling and avoids the reflow.
+    const result = await Promise.race([
+      session.screenshot(pageId, {
         format: 'jpeg',
         quality: JPEG_QUALITY,
         annotate: false,
-      },
-      {
-        session,
-        signal: AbortSignal.timeout(SCREENSHOT_TIMEOUT_MS),
-      },
-    )
-    if (result.isError) {
+      }),
+      new Promise<never>((_, reject) => {
+        AbortSignal.timeout(SCREENSHOT_TIMEOUT_MS).addEventListener(
+          'abort',
+          () => reject(new Error('screenshot timeout')),
+        )
+      }),
+    ])
+    if (!result.data || result.data.length === 0) {
       // Drop the cached frame once we cross the backoff threshold.
       // Holding on to the previous JPEG after the agent has navigated
-      // away (e.g. into a cross-origin iframe that the screenshot tool
-      // cannot capture) means /tabs/activity returns the OLD page's
-      // image with the NEW page's URL + title until backoff lifts.
-      // One transient failure still keeps the frame (cheap recovery
-      // for one-off CDP hiccups); sustained failures drop it so the
-      // UI falls back to the placeholder honestly.
-      if (screencastCache.markFailure(pageId)) {
-        screencastCache.clearFrame(pageId)
-      }
-      return
-    }
-    const image = extractToolResultImageData(result)
-    if (!image) {
+      // away (e.g. into a cross-origin iframe that the screenshot
+      // path cannot capture) means /tabs/activity returns the OLD
+      // page's image with the NEW page's URL + title until backoff
+      // lifts. One transient failure still keeps the frame (cheap
+      // recovery for one-off CDP hiccups); sustained failures drop
+      // it so the UI falls back to the placeholder honestly.
       if (screencastCache.markFailure(pageId)) {
         screencastCache.clearFrame(pageId)
       }
       return
     }
     screencastCache.set(pageId, {
-      jpegBase64: image,
+      jpegBase64: result.data,
       capturedAt: Date.now(),
-      byteLength: estimateBase64Bytes(image),
+      byteLength: estimateBase64Bytes(result.data),
     })
     screencastCache.clearFailure(pageId)
   } catch (err) {
+    // Match the pre-refactor semantic: on backoff crossing, drop
+    // the stale frame but KEEP the failure counter so isInBackoff
+    // still reports true until a fresh dispatch on the tab lifts
+    // the block. The previous impl called .delete() from this
+    // branch, but that only fired when executeTool itself threw;
+    // the far more common CDP soft-failure landed in the isError
+    // branch which used clearFrame. session.screenshot() has no
+    // soft-failure mode - every failure throws - so consolidate on
+    // the more forgiving clearFrame path.
     logger.warn('screencast: snap failed', {
       pageId,
       error: err instanceof Error ? err.message : String(err),
     })
     if (screencastCache.markFailure(pageId)) {
-      screencastCache.delete(pageId)
+      screencastCache.clearFrame(pageId)
     }
   }
 }

--- a/packages/browseros-agent/apps/claw-server/tests/services/screencast-poller.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/screencast-poller.test.ts
@@ -5,29 +5,23 @@
  *
  * Tests for the screencast poller's tick logic. We deliberately do
  * not start the setInterval here; instead we exercise the tick path
- * by mocking executeTool + the tab-activity registry and calling the
- * poller with a 1-shot interval that we immediately stop.
- *
- * mock.module persists across files in the same `bun test` run, so we
- * scope the mocks to known concerns (executeTool, tab-activity) and
- * let the real screencast-cache singleton drive the assertions.
+ * by stubbing session.screenshot + injecting a stub tab-activity
+ * registry, and calling the poller with a long interval that we
+ * immediately stop so only the eager first tick fires.
  */
 
-import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test'
-import * as frameworkReal from '@browseros/browser-mcp/tools/framework'
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
+import type { BrowserSession } from '@browseros/browser-core/core/session'
 import type { TabActivityRecord } from '../../src/lib/tab-activity'
 import { screencastCache } from '../../src/services/screencast-cache'
+import { startScreencastPoller } from '../../src/services/screencast-poller'
 
 interface FakeResult {
-  isError: boolean
-  content: (
-    | { type: 'text'; text: string }
-    | { type: 'image'; data: string; mimeType: string }
-  )[]
-  structuredContent?: unknown
+  ok: boolean
+  image?: string
 }
 
-const calls: { toolName: string; args: Record<string, unknown> }[] = []
+const calls: { page: number }[] = []
 const queued: Map<number, FakeResult[]> = new Map()
 let snapshotRecords: TabActivityRecord[] = []
 
@@ -42,39 +36,35 @@ function queueFor(pageId: number, ...rs: FakeResult[]): void {
 }
 
 function ok(image: string): FakeResult {
-  return {
-    isError: false,
-    content: [{ type: 'image', data: image, mimeType: 'image/jpeg' }],
-    structuredContent: { page: 1, format: 'jpeg' },
-  }
+  return { ok: true, image }
 }
 
 function badResult(): FakeResult {
-  return {
-    isError: true,
-    content: [{ type: 'text', text: 'fail' }],
-  }
+  return { ok: false }
 }
 
-mock.module('@browseros/browser-mcp/tools/framework', () => ({
-  // Spread the real module so any sibling exports (e.g. textResult)
-  // that other transitively-loaded modules import still resolve.
-  ...frameworkReal,
-  executeTool: async (def: { name: string }, args: Record<string, unknown>) => {
-    calls.push({ toolName: def.name, args })
-    const pageId = args.page as number
+// Stub session that pulls the next queued FakeResult per page.
+// ScreenshotCaptureResult shape is { data, mimeType, annotations }.
+// A queued `badResult()` throws so the poller's catch block fires,
+// matching the pre-refactor semantics where isError: true from
+// executeTool led to markFailure via the isError branch.
+const fakeSession = {
+  screenshot: async (
+    pageId: number,
+    _options: unknown,
+  ): Promise<{ data: string; mimeType: string; annotations: [] }> => {
+    calls.push({ page: pageId })
     const arr = queued.get(pageId)
     const result = arr?.shift()
-    if (!result) {
-      throw new Error(`no queued result for page=${pageId}`)
+    if (!result) throw new Error(`no queued result for page=${pageId}`)
+    if (!result.ok) throw new Error('cdp fail')
+    return {
+      data: result.image ?? '',
+      mimeType: 'image/jpeg',
+      annotations: [],
     }
-    return result
   },
-}))
-
-const { startScreencastPoller } = await import(
-  '../../src/services/screencast-poller'
-)
+} as unknown as BrowserSession
 
 // Tests inject this stub registry via opts.registry so we never
 // have to mock the tab-activity module (mock.module leaks across
@@ -106,8 +96,6 @@ function rec(
     status,
   }
 }
-
-const fakeSession = {} as never
 
 // Helper: start the poller, wait for the immediate first tick to
 // complete (Promise microtask flush + small await), stop, and return.
@@ -142,7 +130,7 @@ describe('screencast poller', () => {
 
     await runOneTick()
 
-    expect(calls.map((c) => c.args.page).sort()).toEqual([1, 3])
+    expect(calls.map((c) => c.page).sort()).toEqual([1, 3])
     expect(screencastCache.get(1)?.jpegBase64).toBe('IMG1')
     expect(screencastCache.get(3)?.jpegBase64).toBe('IMG3')
     expect(screencastCache.get(2)).toBeNull()
@@ -194,7 +182,7 @@ describe('screencast poller', () => {
     await runOneTick()
     await runOneTick()
     await runOneTick()
-    expect(calls.map((c) => c.args.page)).toEqual([4, 4, 4])
+    expect(calls.map((c) => c.page)).toEqual([4, 4, 4])
 
     // Next tick with same lastToolAt: still in backoff; expected
     // no new calls. We queue nothing because no call should fire.


### PR DESCRIPTION
## Summary

Two fixes for the cockpit's Running-now screencast pipeline. Both surfaced while triaging a report that agent-driven tabs visibly shrink then expand every ~1.5s while the operator watches.

### Fix 1: screencast poller was reflowing the driven tab every 1.5s

The claw-server's screencast poller (`apps/claw-server/src/services/screencast-poller.ts`) ticks every 1500ms and snapshots each active tab so the cockpit's Running-now cards can render live thumbnails. It routed each capture through the MCP screenshot tool with default args, which meant the tool's `buildScreenshotClip` fitted the capture to a 1024x768 target and returned `clip = { width, height, scale = min(1, targetW / vw, targetH / vh) }`. When the actual viewport is larger than 1024x768 (the common case) `scale < 1`.

On the BrowserOS Chromium fork, `Page.captureScreenshot({clip: {scale != 1}})` visibly resizes the tab the user is watching for the duration of the capture then restores it. At poller cadence that reads as a shrink-then-expand flicker on the driven tab every 1.5s.

The poller now bypasses the tool's clip-building path and calls `session.screenshot(pageId, {format, quality, annotate: false})` directly. That sends `Page.captureScreenshot` with no `clip` at all, capturing at native viewport size with `scale = 1`. No reflow. `MiniScreencast` paints frames at a fixed 132px height and downscales in the browser, so downstream downscaling covers what the tool's target-size cap used to do here.

Failure semantics: `session.screenshot()` has no soft-failure mode, all failures throw. The single catch block mirrors the pre-refactor `isError` semantic (`clearFrame` on backoff crossing, keep the failure counter so `isInBackoff` still returns true until the next dispatch on the tab lifts the block).

Tests updated: stub `session.screenshot` directly instead of mocking `executeTool`. Behavioural coverage (fan-out, per-page backoff after 3 fails, transient failure keeps prior frame, GC on tab close) is preserved.

### Fix 2: Sky Tint strip below the Running-now screencast

`AgentRunningCard` is a 300px-tall tile with a caption block pinned to the bottom, so its screencast zone is a `flex-1` region roughly 160px tall. `MiniScreencast` used a hard-coded `h-[132px]` container inside that zone, leaving a ~30px `bg-bg-sunken` (Sky Tint) strip visible under the frame.

`MiniScreencast` now accepts an optional `className` that overrides the container sizing. Default stays `h-[132px] w-full` so `RunningCard` (the uniform grid tile that expects a fixed 132px thumbnail) is unchanged. `AgentRunningCard` passes `h-full w-full` so the frame fills its `flex-1` zone.

## Test plan

- [ ] Run an agent workload against a page whose viewport is larger than 1024x768 (a normal desktop tab). Watch the driven tab. Confirm the 1.5s shrink-expand reflow is gone.
- [ ] Look at the Running-now section on the cockpit. Confirm the AgentRunningCard screencast fills the top zone flush against the dark caption block, no light Sky Tint strip between them.
- [ ] Confirm the uniform RunningCard grid tiles elsewhere still render their thumbnail at the original 132px height.
- [ ] Confirm live thumbnails still update roughly every 1.5s and the frames still render correctly (no stale frames, no broken images).