### PR TITLE
fix(ci): AGENT_RUNNER_JWT_SECRET optional in release-full preflight

### DIFF
--- a/.github/workflows/release-full.yml
+++ b/.github/workflows/release-full.yml
@@ -187,7 +187,8 @@ jobs:
             require_value BROWSEROS_CONFIG_URL
             require_value POSTHOG_API_KEY
             require_value SENTRY_DSN
-            require_value AGENT_RUNNER_JWT_SECRET
+            # AGENT_RUNNER_JWT_SECRET is inlined when present but optional —
+            # matches release-server.yml and the descriptor's requiredInlineEnvKeys.
           fi
 
           if platform_selected windows && [ "$INPUT_SIGN_WINDOWS" = "true" ]; then


### PR DESCRIPTION
Release Full run 28746080407 failed preflight on AGENT_RUNNER_JWT_SECRET — same over-requirement already relaxed in release-server.yml (#1587); the descriptor's `requiredInlineEnvKeys` omits it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)