### PR TITLE
fix(build): lock chromium checkout during release builds

### DIFF
--- a/packages/browseros/bos_build/cli/build.py
+++ b/packages/browseros/bos_build/cli/build.py
@@ -11,6 +11,7 @@ from typing import Callable, List, Optional, Tuple
 import typer
 
 from ..core.context import Context
+from ..core.checkout_lock import CheckoutLockError, ChromiumCheckoutLock
 from ..lib.paths import get_package_root
 from ..core.pipeline import validate_pipeline, show_available_modules
 from ..core.planner import (
@@ -53,7 +54,6 @@ EXECUTION_ORDER = [
     (phase, phase_steps(phase))
     for phase in ("setup", "prep", "build", "sign", "package", "upload")
 ]
-
 
 
 def main(
@@ -168,6 +168,12 @@ def main(
         "--chromium-src",
         "-S",
         help="Path to Chromium source directory",
+    ),
+    lock_wait: bool = typer.Option(
+        False,
+        "--lock-wait",
+        help="Wait for another BrowserOS build using the same Chromium checkout "
+        "instead of failing fast",
     ),
     gn_arg: Optional[List[str]] = typer.Option(
         None,
@@ -334,6 +340,54 @@ def main(
             raise typer.Exit(1)
         runs = [(ctx, pipeline) for ctx in arch_ctxs]
 
+    try:
+        _execute_runs_with_checkout_lock(
+            runs,
+            lock_wait=lock_wait,
+            has_flags=has_flags,
+            prep=prep,
+            root_dir=root_dir,
+        )
+    except CheckoutLockError as e:
+        log_error(str(e))
+        raise typer.Exit(1)
+
+
+def _execute_runs_with_checkout_lock(
+    runs: List[Tuple[Context, List[str]]],
+    *,
+    lock_wait: bool,
+    has_flags: bool,
+    prep: bool,
+    root_dir: Path,
+) -> None:
+    if not runs:
+        raise typer.Exit(1)
+
+    summary_ctx = runs[0][0]
+    log_info(f"🔒 Acquiring Chromium checkout lock: {summary_ctx.chromium_src}")
+    with ChromiumCheckoutLock(
+        summary_ctx.chromium_src,
+        product=summary_ctx.product.id,
+        wait=lock_wait,
+    ) as checkout_lock:
+        log_info(f"🔒 Chromium checkout lock acquired: {checkout_lock.lock_path}")
+
+        _execute_runs(
+            runs,
+            has_flags=has_flags,
+            prep=prep,
+            root_dir=root_dir,
+        )
+
+
+def _execute_runs(
+    runs: List[Tuple[Context, List[str]]],
+    *,
+    has_flags: bool,
+    prep: bool,
+    root_dir: Path,
+) -> None:
     if has_flags:
         log_info("\n📋 Execution Plan (auto-ordered):")
         log_info("-" * 70)
@@ -387,9 +441,7 @@ def main(
     if len(runs) > 1:
         # Runs may be heterogeneous (universal), so show each run's steps
         for run_ctx, run_steps in runs:
-            log_info(
-                f"📍 Pipeline[{run_ctx.architecture}]: {' → '.join(run_steps)}"
-            )
+            log_info(f"📍 Pipeline[{run_ctx.architecture}]: {' → '.join(run_steps)}")
     else:
         log_info(f"📍 Pipeline: {' → '.join(runs[0][1])}")
     log_info("=" * 70)
@@ -559,8 +611,7 @@ def _resolve_preset(
                 for run_arch, steps in arch_plans:
                     if not steps:
                         raise ValueError(
-                            f"plan for {run_arch} is empty after skip — "
-                            "nothing to run"
+                            f"plan for {run_arch} is empty after skip — nothing to run"
                         )
                 # Shallow provisioning creates the checkout itself, so the
                 # src dir may not exist yet on a fresh runner.
@@ -743,9 +794,7 @@ def _resolve_profile_path(profile: Path) -> Path:
     candidate = get_package_root() / "bos_build" / "profiles" / f"{profile.name}.yaml"
     if candidate.exists():
         return candidate
-    raise ValueError(
-        f"Profile not found: {profile} (also tried {candidate})"
-    )
+    raise ValueError(f"Profile not found: {profile} (also tried {candidate})")
 
 
 def _resolve_chromium_src(

--- a/packages/browseros/bos_build/cli/build_test.py
+++ b/packages/browseros/bos_build/cli/build_test.py
@@ -5,6 +5,7 @@ Every invocation scrubs CHROMIUM_SRC/ARCH from the environment, so a
 passing projection test proves the path never needs a chromium checkout.
 """
 
+import multiprocessing
 import os
 import re
 import tempfile
@@ -16,6 +17,7 @@ from typer.testing import CliRunner
 
 from bos_build.browseros import app
 from bos_build.cli.build import _resolve_preset
+from bos_build.core.checkout_lock import ChromiumCheckoutLock
 from bos_build.core.planner import Switches, plan
 from bos_build.lib.testing import MockChromium
 from bos_build.lib.utils import get_platform, get_platform_arch
@@ -46,6 +48,16 @@ def scrubbed_env(*extra: str):
     drop = {"CHROMIUM_SRC", "ARCH", *extra}
     clean = {k: v for k, v in os.environ.items() if k not in drop}
     return mock.patch.dict(os.environ, clean, clear=True)
+
+
+def _hold_checkout_lock(chromium_src: str, ready, release) -> None:
+    with ChromiumCheckoutLock(
+        Path(chromium_src),
+        product="browserclaw",
+        command=("test-holder",),
+    ):
+        ready.set()
+        release.wait(15)
 
 
 def plan_lines(output: str):
@@ -92,9 +104,7 @@ class ShowPlanPresetTest(_ProfileMixin):
 
     def test_from_reflected(self):
         with scrubbed_env():
-            result = invoke(
-                "--preset", "release", "--from", "configure", "--show-plan"
-            )
+            result = invoke("--preset", "release", "--from", "configure", "--show-plan")
         self.assertEqual(result.exit_code, 0, combined(result))
         self.assertEqual(plan_lines(result.output)[0], "configure")
 
@@ -154,7 +164,9 @@ class EmptyPlanTest(unittest.TestCase):
 
     def test_all_steps_skipped_fails_before_chromium(self):
         with scrubbed_env():
-            result = invoke("--preset", "debug", "--skip", ",".join(self._host_debug_plan()))
+            result = invoke(
+                "--preset", "debug", "--skip", ",".join(self._host_debug_plan())
+            )
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn("empty", combined(result).lower())
 
@@ -205,6 +217,36 @@ class ModeGuardTest(unittest.TestCase):
             result = invoke("--modules", "clean", "--arch", "bogus", "--show-plan")
         self.assertNotEqual(result.exit_code, 0)
         self.assertIn("Invalid architecture", combined(result))
+
+
+class CheckoutLockCliTest(unittest.TestCase):
+    def test_build_fails_fast_when_checkout_is_locked(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            m = MockChromium(Path(tmp))
+            ctx = multiprocessing.get_context("spawn")
+            ready = ctx.Event()
+            release = ctx.Event()
+            proc = ctx.Process(
+                target=_hold_checkout_lock,
+                args=(str(m.src), ready, release),
+            )
+            proc.start()
+            try:
+                self.assertTrue(ready.wait(5), f"lock holder exited: {proc.exitcode}")
+                with scrubbed_env():
+                    result = invoke("--modules", "clean", "--chromium-src", str(m.src))
+                self.assertNotEqual(result.exit_code, 0)
+                output = plain_output(result)
+                self.assertIn("Chromium checkout is already locked", output)
+                self.assertIn("product=browserclaw", output)
+                self.assertIn("--lock-wait", output)
+            finally:
+                release.set()
+                proc.join(5)
+                if proc.is_alive():
+                    proc.kill()
+                    proc.join(5)
+            self.assertEqual(proc.exitcode, 0)
 
 
 class ModulesProfileCliTest(_ProfileMixin):
@@ -322,7 +364,11 @@ class GnArgOptionTest(_ProfileMixin):
     def test_direct_show_plan_lists_overrides(self):
         with scrubbed_env():
             result = invoke(
-                "--modules", "clean,compile", "--gn-arg", "symbol_level=2", "--show-plan"
+                "--modules",
+                "clean,compile",
+                "--gn-arg",
+                "symbol_level=2",
+                "--show-plan",
             )
         self.assertEqual(result.exit_code, 0, combined(result))
         self.assertIn("GN arg overrides: symbol_level=2", result.output)

--- a/packages/browseros/bos_build/core/checkout_lock.py
+++ b/packages/browseros/bos_build/core/checkout_lock.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Exclusive lock for BrowserOS builds that mutate a Chromium checkout."""
+
+import errno
+import json
+import os
+import socket
+import sys
+from datetime import datetime, timezone
+from hashlib import sha256
+from pathlib import Path
+from typing import IO, Iterable, Optional
+
+if sys.platform == "win32":
+    import msvcrt
+else:
+    import fcntl
+
+
+class CheckoutLockError(RuntimeError):
+    """Raised when another build already owns the Chromium checkout lock."""
+
+
+class ChromiumCheckoutLock:
+    """Process-wide exclusive lock keyed to a resolved Chromium src path.
+
+    BrowserOS release builds run destructive setup (`git reset`, `git clean`,
+    patch application) and long compiles in one shared checkout. The lock file
+    lives next to the gclient checkout root, not under src/, so `git clean`
+    cannot delete it while the build is running.
+    """
+
+    def __init__(
+        self,
+        chromium_src: Path,
+        *,
+        product: str,
+        wait: bool = False,
+        command: Optional[Iterable[str]] = None,
+    ) -> None:
+        self.chromium_src = _resolved(chromium_src)
+        self.product = product
+        self.wait = wait
+        self.command = tuple(command) if command is not None else tuple(sys.argv)
+        self.lock_path = lock_path_for(self.chromium_src)
+        self._file: Optional[IO[str]] = None
+
+    def __enter__(self) -> "ChromiumCheckoutLock":
+        self.lock_path.parent.mkdir(parents=True, exist_ok=True)
+        self._file = self.lock_path.open("a+", encoding="utf-8")
+
+        if not _try_lock(self._file, wait=self.wait):
+            holder = _read_holder(self._file)
+            self._file.close()
+            self._file = None
+            raise CheckoutLockError(
+                _format_contention(
+                    chromium_src=self.chromium_src,
+                    lock_path=self.lock_path,
+                    holder=holder,
+                )
+            )
+
+        _write_holder(self._file, self._holder_metadata())
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:
+        if self._file is None:
+            return
+        try:
+            self._file.seek(0)
+            self._file.truncate()
+            self._file.flush()
+            os.fsync(self._file.fileno())
+        finally:
+            _unlock(self._file)
+            self._file.close()
+            self._file = None
+
+    def _holder_metadata(self) -> dict[str, object]:
+        return {
+            "pid": os.getpid(),
+            "product": self.product,
+            "started_at": datetime.now(timezone.utc)
+            .isoformat(timespec="seconds")
+            .replace("+00:00", "Z"),
+            "chromium_src": str(self.chromium_src),
+            "lock_path": str(self.lock_path),
+            "cwd": os.getcwd(),
+            "host": socket.gethostname(),
+            "command": list(self.command),
+        }
+
+
+def lock_path_for(chromium_src: Path) -> Path:
+    resolved = _resolved(chromium_src)
+    digest = sha256(str(resolved).encode("utf-8")).hexdigest()[:12]
+    return resolved.parent / ".browseros-build-locks" / f"{resolved.name}-{digest}.lock"
+
+
+def _resolved(path: Path) -> Path:
+    return Path(path).expanduser().resolve(strict=False)
+
+
+def _try_lock(file: IO[str], *, wait: bool) -> bool:
+    if sys.platform == "win32":
+        return _try_lock_windows(file, wait=wait)
+    flags = fcntl.LOCK_EX
+    if not wait:
+        flags |= fcntl.LOCK_NB
+    try:
+        fcntl.flock(file.fileno(), flags)
+        return True
+    except OSError as e:
+        if not wait and e.errno in (errno.EACCES, errno.EAGAIN):
+            return False
+        raise
+
+
+def _unlock(file: IO[str]) -> None:
+    if sys.platform == "win32":
+        file.seek(0)
+        msvcrt.locking(file.fileno(), msvcrt.LK_UNLCK, 1)
+        return
+    fcntl.flock(file.fileno(), fcntl.LOCK_UN)
+
+
+def _try_lock_windows(file: IO[str], *, wait: bool) -> bool:
+    # Windows locks byte ranges. Ensure there is at least one byte to lock.
+    file.seek(0, os.SEEK_END)
+    if file.tell() == 0:
+        file.write("\0")
+        file.flush()
+    file.seek(0)
+    mode = msvcrt.LK_LOCK if wait else msvcrt.LK_NBLCK
+    try:
+        msvcrt.locking(file.fileno(), mode, 1)
+        return True
+    except OSError as e:
+        if not wait and e.errno in (errno.EACCES, errno.EDEADLK):
+            return False
+        raise
+
+
+def _write_holder(file: IO[str], metadata: dict[str, object]) -> None:
+    file.seek(0)
+    file.truncate()
+    json.dump(metadata, file, indent=2, sort_keys=True)
+    file.write("\n")
+    file.flush()
+    os.fsync(file.fileno())
+
+
+def _read_holder(file: IO[str]) -> Optional[dict[str, object]]:
+    try:
+        file.seek(0)
+        content = file.read().strip("\0 \n\t")
+        if not content:
+            return None
+        data = json.loads(content)
+        return data if isinstance(data, dict) else None
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _format_contention(
+    *, chromium_src: Path, lock_path: Path, holder: Optional[dict[str, object]]
+) -> str:
+    lines = [
+        f"Chromium checkout is already locked: {chromium_src}",
+        "Another BrowserOS build is using this checkout; refusing to run because "
+        "setup, patch, compile, sign, and package steps mutate shared state.",
+    ]
+    if holder:
+        lines.append(
+            "Holder: "
+            f"pid={holder.get('pid', 'unknown')} "
+            f"product={holder.get('product', 'unknown')} "
+            f"started_at={holder.get('started_at', 'unknown')} "
+            f"host={holder.get('host', 'unknown')}"
+        )
+        cwd = holder.get("cwd")
+        if cwd:
+            lines.append(f"Holder cwd: {cwd}")
+        command = holder.get("command")
+        if isinstance(command, list) and command:
+            lines.append(f"Holder command: {' '.join(str(part) for part in command)}")
+    else:
+        lines.append("Holder: unknown")
+    lines.append(f"Lock file: {lock_path}")
+    lines.append("Use --lock-wait to wait for the current build to finish.")
+    return "\n".join(lines)

--- a/packages/browseros/bos_build/core/checkout_lock_test.py
+++ b/packages/browseros/bos_build/core/checkout_lock_test.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Tests for Chromium checkout build locking."""
+
+import json
+import multiprocessing
+import tempfile
+import unittest
+from pathlib import Path
+
+from bos_build.core.checkout_lock import CheckoutLockError, ChromiumCheckoutLock
+
+
+def _hold_checkout_lock(chromium_src: str, ready, release) -> None:
+    with ChromiumCheckoutLock(
+        Path(chromium_src),
+        product="browserclaw",
+        command=("test-holder",),
+    ):
+        ready.set()
+        release.wait(15)
+
+
+class ChromiumCheckoutLockTest(unittest.TestCase):
+    def test_records_holder_metadata_and_releases(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            chromium_src = Path(tmp) / "src"
+            chromium_src.mkdir()
+
+            with ChromiumCheckoutLock(
+                chromium_src,
+                product="browserclaw",
+                command=("browseros", "build"),
+            ) as lock:
+                metadata = json.loads(lock.lock_path.read_text())
+                self.assertEqual(metadata["product"], "browserclaw")
+                self.assertEqual(metadata["chromium_src"], str(chromium_src.resolve()))
+                self.assertEqual(metadata["command"], ["browseros", "build"])
+
+            with ChromiumCheckoutLock(chromium_src, product="browseros"):
+                pass
+
+    def test_contention_fails_with_holder_details(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            chromium_src = Path(tmp) / "src"
+            chromium_src.mkdir()
+
+            ctx = multiprocessing.get_context("spawn")
+            ready = ctx.Event()
+            release = ctx.Event()
+            proc = ctx.Process(
+                target=_hold_checkout_lock,
+                args=(str(chromium_src), ready, release),
+            )
+            proc.start()
+            self.addCleanup(proc.join, 5)
+            self.addCleanup(release.set)
+
+            self.assertTrue(ready.wait(5), f"lock holder exited: {proc.exitcode}")
+            with self.assertRaises(CheckoutLockError) as raised:
+                with ChromiumCheckoutLock(chromium_src, product="browseros"):
+                    pass
+
+            message = str(raised.exception)
+            self.assertIn("Chromium checkout is already locked", message)
+            self.assertIn("product=browserclaw", message)
+            self.assertIn("started_at=", message)
+            self.assertIn("--lock-wait", message)
+
+            release.set()
+            proc.join(5)
+            self.assertEqual(proc.exitcode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add an exclusive checkout lock keyed to the resolved Chromium src path, with holder metadata for pid/product/start time/host.
- Wrap `browseros build` before preflight and step execution so clean, git setup, patching, compile, sign, and package cannot run concurrently on the same checkout.
- Keep default behavior fail-fast with a clear contention error; add `--lock-wait` for deliberate serialization.

## Design
The lock file is stored beside the gclient checkout root under `.browseros-build-locks`, outside `src/`, so the existing `git clean -fdx` cannot delete it. A contending process reads the holder metadata and exits before touching the checkout unless `--lock-wait` is supplied.

## Test plan
- [x] `uv run python -m unittest bos_build.cli.build_test bos_build.core.checkout_lock_test`
- [x] `uv run --group dev ruff check bos_build/core/checkout_lock.py bos_build/core/checkout_lock_test.py bos_build/cli/build.py bos_build/cli/build_test.py`
- [x] `uv run --group dev ruff format --check bos_build/core/checkout_lock.py bos_build/core/checkout_lock_test.py bos_build/cli/build.py bos_build/cli/build_test.py`
- [x] `uv run python -m unittest discover -s bos_build -t . -p '*_test.py'`