### PR TITLE
fix(bpatch): ignore managed product identity outputs

### DIFF
--- a/packages/browseros/bos_build/features.yaml
+++ b/packages/browseros/bos_build/features.yaml
@@ -30,6 +30,9 @@ features:
   branding:
     description: "chore: browseros branding and identity"
     files:
+      # Product-generated identity outputs (BRANDING, updater branding,
+      # string replacements, chrome/VERSION, and logo binaries) are owned by
+      # bos_build product overlays/resources and filtered by bpatch annotate.
       # Version info
       - base/version_info/BUILD.gn
       - base/version_info/version_info.h

--- a/packages/browseros/tools/patch/cmd/annotate.go
+++ b/packages/browseros/tools/patch/cmd/annotate.go
@@ -74,7 +74,7 @@ func printAnnotateResult(ws workspace.Entry, result *engine.AnnotateResult) {
 		for _, rel := range result.Unclaimed {
 			fmt.Printf("  %s\n", rel)
 		}
-		fmt.Println(ui.Hint(`Claim them in bos_build/features.yaml, then re-run; "browseros-patch feature lint" checks coverage.`))
+		fmt.Println(ui.Hint(`Claim them in bos_build/features.yaml or a managed-output mechanism, then re-run; "browseros-patch feature lint" checks patch coverage.`))
 	}
 	if result.CommitsCreated == 0 {
 		fmt.Println(ui.Hint("No commits created."))

--- a/packages/browseros/tools/patch/cmd/common.go
+++ b/packages/browseros/tools/patch/cmd/common.go
@@ -88,7 +88,7 @@ Feature commit flow (turn checkout changes into feature commits):
 Annotation rules:
 - Filtered (-- files...) and --changed applies never auto-annotate; continue/skip finish a paused apply's annotation, excluding skipped conflicts.
 - apply, sync, refresh, and annotate refuse to start while a conflict resolution is pending; finish continue/skip/abort first.
-- Changes no feature claims are reported as "unclaimed" and left uncommitted; claim them in bos_build/features.yaml.
+- Changes no feature or managed-output mechanism claims are reported as "unclaimed" and left uncommitted; claim patch files in bos_build/features.yaml.
 
 Pool refresh flow (rebuild browseros branch before leasing a checkout):
 1. browseros-patch status ch1 --json       # check patches_freshness

--- a/packages/browseros/tools/patch/internal/engine/annotate.go
+++ b/packages/browseros/tools/patch/internal/engine/annotate.go
@@ -35,8 +35,8 @@ type AnnotateResult struct {
 	FeaturesSkipped int                        `json:"features_skipped"`
 	Committed       []AnnotateCommittedFeature `json:"committed"`
 	Skipped         []AnnotateSkippedFeature   `json:"skipped"`
-	// Unclaimed lists changed files no feature owns; they stay uncommitted
-	// so the checkout remains dirty until features.yaml claims them.
+	// Unclaimed lists changed files no feature or managed-output mechanism
+	// owns; they stay uncommitted until the pipeline claims them.
 	Unclaimed []string `json:"unclaimed,omitempty"`
 }
 
@@ -82,12 +82,18 @@ func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error
 	}
 	// One status snapshot serves the whole run; a full scan is seconds on a
 	// Chromium checkout. Each feature consumes the entries it matched —
-	// commitFeatureFiles settles them (committed, or staged clean) — so what
-	// remains at the end is exactly the unclaimed leftovers.
+	// commitFeatureFiles settles them (committed, or staged clean). Managed
+	// build outputs are filtered before feature partitioning, so what remains
+	// at the end is exactly the unclaimed leftovers.
 	changes, err := annotateChanges(ctx, opts.Workspace.Path, ignore, opts.Include, opts.Exclude)
 	if err != nil {
 		return nil, err
 	}
+	managedOutputs, err := loadManagedOutputPatterns(opts.Repo.Root)
+	if err != nil {
+		return nil, err
+	}
+	changes = filterManagedOutputChanges(changes, managedOutputs)
 	for _, feature := range features {
 		result.Processed++
 		reportProgress(opts.Progress, "Annotating feature %s", feature.Name)
@@ -135,6 +141,33 @@ func Annotate(ctx context.Context, opts AnnotateOptions) (*AnnotateResult, error
 	}
 	result.Unclaimed = uniqueReportPaths(changes)
 	return result, nil
+}
+
+func filterManagedOutputChanges(changes []git.FileChange, managedOutputs []string) []git.FileChange {
+	if len(managedOutputs) == 0 {
+		return changes
+	}
+	kept := changes[:0]
+	for _, change := range changes {
+		if annotateChangeIsManagedOutput(change, managedOutputs) {
+			continue
+		}
+		kept = append(kept, change)
+	}
+	return kept
+}
+
+func annotateChangeIsManagedOutput(change git.FileChange, managedOutputs []string) bool {
+	paths := changeReportPaths(change)
+	if len(paths) == 0 {
+		return false
+	}
+	for _, rel := range paths {
+		if !patch.PathMatches(rel, managedOutputs) {
+			return false
+		}
+	}
+	return true
 }
 
 func mappingValue(node *yaml.Node, key string) *yaml.Node {

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -735,6 +735,104 @@ features:
 	}
 }
 
+func TestAnnotateSkipsManagedGeneratedOutputs(t *testing.T) {
+	ctx := context.Background()
+	workspacePath := initGitRepo(t)
+	for _, rel := range []string{
+		"chrome/VERSION",
+		"chrome/BROWSEROS_VERSION",
+		"chrome/app/chromium_strings.grd",
+		"chrome/app/settings_chromium_strings.grdp",
+		"chrome/app/theme/chromium/BRANDING",
+		"chrome/app/theme/chromium/not_managed.txt",
+		"chrome/app/theme/chromium/product_logo_16.png",
+		"chrome/app/theme/chromium/chromeos/chrome_app_icon_32.png",
+		"chrome/browser/browseros/server/resources/bin/browseros_server",
+		"chrome/updater/branding.gni",
+		"content/render.cc",
+	} {
+		writeFile(t, filepath.Join(workspacePath, filepath.FromSlash(rel)), "base\n")
+	}
+	runGit(t, workspacePath, "add", ".")
+	runGit(t, workspacePath, "commit", "-m", "workspace base")
+	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
+
+	for _, rel := range []string{
+		"chrome/VERSION",
+		"chrome/BROWSEROS_VERSION",
+		"chrome/app/chromium_strings.grd",
+		"chrome/app/settings_chromium_strings.grdp",
+		"chrome/app/theme/chromium/BRANDING",
+		"chrome/app/theme/chromium/not_managed.txt",
+		"chrome/app/theme/chromium/product_logo_16.png",
+		"chrome/app/theme/chromium/chromeos/chrome_app_icon_32.png",
+		"chrome/browser/browseros/server/resources/bin/browseros_server",
+		"chrome/updater/branding.gni",
+		"content/render.cc",
+	} {
+		writeFile(t, filepath.Join(workspacePath, filepath.FromSlash(rel)), "changed\n")
+	}
+
+	repoInfo := newPatchRepo(t, baseCommit)
+	writeFeaturesYAML(t, repoInfo.Root, `version: "1.0"
+features:
+  browseros-core:
+    description: "chore: browseros core"
+    files:
+      - chrome/browser/core.cc
+`)
+	writeFile(t, filepath.Join(repoInfo.Root, "chromium_files", "products", "browseros", "chrome", "app", "theme", "chromium", "BRANDING.debug"), "overlay\n")
+	writeFile(t, filepath.Join(repoInfo.Root, "chromium_files", "products", "browseros", "chrome", "updater", "branding.gni"), "overlay\n")
+	writeFile(t, filepath.Join(repoInfo.Root, "resources", "browseros", "icons", "product_logo_16.png"), "icon\n")
+	writeFile(t, filepath.Join(repoInfo.Root, "bos_build", "config", "copy_resources.yaml"), `copy_operations:
+  - name: Version
+    source: resources/BROWSEROS_VERSION
+    destination: chrome/BROWSEROS_VERSION
+    type: file
+  - name: Product root icons
+    source: resources/browseros/icons/*.png
+    destination: chrome/app/theme/chromium/
+    type: files
+  - name: ChromeOS icons
+    source: resources/browseros/icons/chromeos
+    destination: chrome/app/theme/chromium/chromeos
+    type: directory
+  - name: Server resources
+    source: resources/binaries/browseros_server/darwin-arm64/resources
+    destination: chrome/browser/browseros/server/resources
+    type: directory
+`)
+	writeFile(t, filepath.Join(repoInfo.Root, "bos_build", "steps", "resources", "string_replaces.py"), `target_files = [
+    "chrome/app/chromium_strings.grd",
+    "chrome/app/settings_chromium_strings.grdp",
+]
+`)
+
+	result, err := Annotate(ctx, AnnotateOptions{
+		Workspace: workspace.Entry{Name: "ws", Path: workspacePath},
+		Repo:      repoInfo,
+	})
+	if err != nil {
+		t.Fatalf("Annotate: %v", err)
+	}
+	wantUnclaimed := []string{
+		"chrome/app/theme/chromium/not_managed.txt",
+		"content/render.cc",
+	}
+	if !slices.Equal(result.Unclaimed, wantUnclaimed) {
+		t.Fatalf("expected only unmanaged files unclaimed, got %v", result.Unclaimed)
+	}
+	if result.CommitsCreated != 0 {
+		t.Fatalf("managed output filtering should not create commits, got %+v", result.Committed)
+	}
+	if status := gitOutput(t, workspacePath, "status", "--porcelain", "--", "chrome/app/theme/chromium/product_logo_16.png"); status != "M chrome/app/theme/chromium/product_logo_16.png" {
+		t.Fatalf("managed output should stay modified for build pipeline, got %q", status)
+	}
+	if status := gitOutput(t, workspacePath, "status", "--porcelain", "--", "chrome/app/theme/chromium/not_managed.txt"); status != "M chrome/app/theme/chromium/not_managed.txt" {
+		t.Fatalf("unmanaged file should stay modified, got %q", status)
+	}
+}
+
 func TestAnnotateReportsUnclaimedChanges(t *testing.T) {
 	ctx := context.Background()
 	workspacePath := initGitRepo(t)

--- a/packages/browseros/tools/patch/internal/engine/managed_outputs.go
+++ b/packages/browseros/tools/patch/internal/engine/managed_outputs.go
@@ -1,0 +1,168 @@
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+
+	"github.com/browseros-ai/BrowserOS/packages/browseros/tools/patch/internal/patch"
+	"gopkg.in/yaml.v3"
+)
+
+type copyResourcesConfig struct {
+	CopyOperations []copyResourceOperation `yaml:"copy_operations"`
+}
+
+type copyResourceOperation struct {
+	Source      string `yaml:"source"`
+	Destination string `yaml:"destination"`
+	Type        string `yaml:"type"`
+}
+
+// loadManagedOutputPatterns returns Chromium checkout paths produced by
+// BrowserOS build steps rather than by chromium_patches feature commits.
+func loadManagedOutputPatterns(repoRoot string) ([]string, error) {
+	seen := map[string]bool{}
+	var patterns []string
+	add := func(rel string) {
+		appendManagedPattern(&patterns, seen, rel)
+	}
+
+	add("chrome/VERSION")
+	for _, rel := range managedOverlayPaths(repoRoot) {
+		add(rel)
+	}
+	resourcePaths, err := managedCopyResourcePaths(repoRoot)
+	if err != nil {
+		return nil, err
+	}
+	for _, rel := range resourcePaths {
+		add(rel)
+	}
+	for _, rel := range managedStringReplacementPaths(repoRoot) {
+		add(rel)
+	}
+	slices.Sort(patterns)
+	return patterns, nil
+}
+
+func managedOverlayPaths(repoRoot string) []string {
+	var roots []string
+	base := filepath.Join(repoRoot, "chromium_files")
+	roots = append(roots, filepath.Join(base, "common"))
+
+	productsRoot := filepath.Join(base, "products")
+	entries, err := os.ReadDir(productsRoot)
+	if err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() {
+				roots = append(roots, filepath.Join(productsRoot, entry.Name()))
+			}
+		}
+	}
+
+	var paths []string
+	for _, root := range roots {
+		info, err := os.Stat(root)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		_ = filepath.WalkDir(root, func(fullPath string, d os.DirEntry, walkErr error) error {
+			if walkErr != nil || d.IsDir() {
+				return walkErr
+			}
+			rel, err := filepath.Rel(root, fullPath)
+			if err != nil {
+				return err
+			}
+			normalized := patch.NormalizeChromiumPath(rel)
+			normalized = strings.TrimSuffix(normalized, ".debug")
+			normalized = strings.TrimSuffix(normalized, ".release")
+			paths = append(paths, normalized)
+			return nil
+		})
+	}
+	return paths
+}
+
+func managedCopyResourcePaths(repoRoot string) ([]string, error) {
+	configPath := filepath.Join(repoRoot, "bos_build", "config", "copy_resources.yaml")
+	body, err := os.ReadFile(configPath)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var config copyResourcesConfig
+	if err := yaml.Unmarshal(body, &config); err != nil {
+		return nil, err
+	}
+
+	var paths []string
+	for _, op := range config.CopyOperations {
+		if strings.TrimSpace(op.Destination) == "" {
+			continue
+		}
+		switch opType := strings.TrimSpace(op.Type); opType {
+		case "", "directory":
+			paths = append(paths, op.Destination)
+		case "file":
+			paths = append(paths, op.Destination)
+		case "files":
+			matches, err := filepath.Glob(filepath.Join(repoRoot, filepath.FromSlash(op.Source)))
+			if err != nil {
+				return nil, err
+			}
+			for _, match := range matches {
+				info, err := os.Stat(match)
+				if err != nil || info.IsDir() {
+					continue
+				}
+				paths = append(paths, filepath.ToSlash(filepath.Join(op.Destination, filepath.Base(match))))
+			}
+		}
+	}
+	return paths, nil
+}
+
+func managedStringReplacementPaths(repoRoot string) []string {
+	path := filepath.Join(repoRoot, "bos_build", "steps", "resources", "string_replaces.py")
+	body, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	content := string(body)
+	assignment := strings.Index(content, "target_files")
+	if assignment < 0 {
+		return nil
+	}
+	open := strings.Index(content[assignment:], "[")
+	if open < 0 {
+		return nil
+	}
+	start := assignment + open + 1
+	close := strings.Index(content[start:], "]")
+	if close < 0 {
+		return nil
+	}
+	block := content[start : start+close]
+	quoted := regexp.MustCompile(`["']([^"']+)["']`)
+	matches := quoted.FindAllStringSubmatch(block, -1)
+	paths := make([]string, 0, len(matches))
+	for _, match := range matches {
+		paths = append(paths, match[1])
+	}
+	return paths
+}
+
+func appendManagedPattern(patterns *[]string, seen map[string]bool, raw string) {
+	rel := patch.NormalizeChromiumPath(raw)
+	if rel == "." || rel == "" || patch.IsInternalPath(rel) || seen[rel] {
+		return
+	}
+	seen[rel] = true
+	*patterns = append(*patterns, rel)
+}


### PR DESCRIPTION
## Summary
- Teach `bpatch annotate` to filter BrowserOS-managed product identity outputs before feature partitioning.
- Derive managed paths from existing sources of truth: product overlays, `copy_resources.yaml`, string replacement targets, and `chrome/VERSION` stamping.
- Document in `features.yaml` that generated branding outputs are owned outside shared patch features.

## Design
The requested dangling files are product identity outputs, not all shared patch files. Logo binaries are copied from `resources/<product>/icons`, `BRANDING` and updater branding are product overlays, the string GRDs are generated by `string_replaces`, and `chrome/VERSION` is build-version stamped. Annotate now leaves those dirty for the build pipeline but no longer reports them as unclaimed or commits them into feature commits. Ordinary unmanaged changes still show as unclaimed.

## Test plan
- [x] `go test ./internal/engine` from `packages/browseros/tools/patch`
- [x] `go test ./...` from `packages/browseros/tools/patch`
- [x] `XDG_CONFIG_HOME=$(mktemp -d) go run . feature lint` from `packages/browseros/tools/patch`
- [x] `uv run python -m unittest discover -s bos_build -t . -p '*_test.py'` from `packages/browseros`
- [x] `uv run ruff check bos_build` from `packages/browseros`
- [x] Read-only classifier for the requested path list: 58/58 accounted for, zero unclaimed

Note: local git hooks reported `lefthook` missing from PATH, so verification was run manually.