### PR TITLE
fix(bos_build): two-pass windows cache extract for symlink entries

### DIFF
--- a/packages/browseros/bos_build/steps/source/cache.py
+++ b/packages/browseros/bos_build/steps/source/cache.py
@@ -115,6 +115,56 @@ def _run_pipeline(
         )
 
 
+def _run_command(
+    cmd,
+    *,
+    cwd: Path | None = None,
+    env: dict[str, str] | None = None,
+) -> int:
+    _log(f"$ {_format_pipeline_command(cmd, cwd)}")
+    return subprocess.run(cmd, cwd=cwd, env=env, check=False).returncode
+
+
+def _unlink_if_exists(path: Path) -> None:
+    try:
+        path.unlink()
+    except FileNotFoundError:
+        pass
+
+
+def _restore_windows_tarball(tarball: Path, root: Path) -> None:
+    tar_file = tarball.with_suffix("")
+    try:
+        rc = _run_command(
+            [find_tool("zstd"), "-d", "-f", "-o", str(tar_file), str(tarball)]
+        )
+        if rc != 0:
+            raise SystemExit(f"[source.cache] zstd decompression failed (rc={rc})")
+
+        # Drop the compressed archive as soon as the rewindable tar exists.
+        _unlink_if_exists(tarball)
+
+        tar_cmd = [find_tool("tar"), "-xf", str(tar_file)]
+        tar_env = {**os.environ, "MSYS": "winsymlinks:nativestrict"}
+        _log("extract pass 1/2")
+        first_rc = _run_command(tar_cmd, cwd=root, env=tar_env)
+        if first_rc == 0:
+            return
+
+        _log("extract pass 1/2 failed; retrying full archive")
+        _log("extract pass 2/2")
+        second_rc = _run_command(tar_cmd, cwd=root, env=tar_env)
+        if second_rc == 0:
+            return
+
+        raise SystemExit(
+            "[source.cache] tar extraction failed after retry "
+            f"(pass1={first_rc}, pass2={second_rc})"
+        )
+    finally:
+        _unlink_if_exists(tar_file)
+
+
 def restore(key: str, root: Path) -> bool:
     """Restore the cached checkout; returns cache-hit."""
     r2 = _get_r2_client()
@@ -141,12 +191,15 @@ def restore(key: str, root: Path) -> bool:
     size_gb = tarball.stat().st_size / 1024**3
     _log(f"Downloaded {size_gb:.1f} GiB; extracting to {root}")
 
-    _run_pipeline(
-        [find_tool("zstd"), "-d", "-c", str(tarball)],
-        [find_tool("tar"), "-xf", "-"],
-        consumer_cwd=root,
-    )
-    tarball.unlink()
+    if sys.platform == "win32":
+        _restore_windows_tarball(tarball, root)
+    else:
+        _run_pipeline(
+            [find_tool("zstd"), "-d", "-c", str(tarball)],
+            [find_tool("tar"), "-xf", "-"],
+            consumer_cwd=root,
+        )
+        tarball.unlink()
     write_github_output("cache-hit", "true")
     return True
 

--- a/packages/browseros/bos_build/steps/source/cache_test.py
+++ b/packages/browseros/bos_build/steps/source/cache_test.py
@@ -41,7 +41,7 @@ class PipelineTest(unittest.TestCase):
 
 
 class RestoreTest(unittest.TestCase):
-    def test_restore_creates_root_and_extracts_with_tar_cwd(self):
+    def test_restore_posix_creates_root_and_extracts_with_streaming_pipeline(self):
         client = mock.Mock()
 
         def fake_download(bucket, key, filename, Config=None):
@@ -64,6 +64,7 @@ class RestoreTest(unittest.TestCase):
                 mock.patch.object(
                     cache, "find_tool", side_effect=lambda name: f"{name}.exe"
                 ),
+                mock.patch.object(cache.sys, "platform", "linux"),
                 mock.patch.object(cache.tempfile, "gettempdir", return_value=tmp),
                 mock.patch.object(cache, "_run_pipeline") as run_pipeline,
                 mock.patch.object(cache, "write_github_output"),
@@ -77,6 +78,156 @@ class RestoreTest(unittest.TestCase):
             consumer_cwd=expected_root,
         )
         self.assertNotIn("-C", run_pipeline.call_args.args[1])
+
+    def test_restore_windows_retries_tar_once_with_msys_env(self):
+        client = mock.Mock()
+
+        def fake_download(bucket, key, filename, Config=None):
+            Path(filename).write_bytes(b"tarball")
+
+        tar_attempts = []
+
+        def fake_run(cmd, *, cwd=None, env=None):
+            if cmd[0] == "zstd.exe":
+                Path(cmd[cmd.index("-o") + 1]).write_bytes(b"tar")
+                return 0
+            tar_attempts.append(cmd)
+            return 1 if len(tar_attempts) == 1 else 0
+
+        client.download_file.side_effect = fake_download
+        transfer_config = object()
+        run_calls = []
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            root = tmp_path / "chromium"
+            expected_root = root.resolve()
+            tarball = tmp_path / "chromium-cache.tar.zst"
+            tar_file = tmp_path / "chromium-cache.tar"
+
+            with (
+                mock.patch.object(
+                    cache, "_get_r2_client", return_value=(client, transfer_config)
+                ),
+                mock.patch.object(cache, "_object_exists", return_value=True),
+                mock.patch.object(
+                    cache, "find_tool", side_effect=lambda name: f"{name}.exe"
+                ),
+                mock.patch.object(cache.sys, "platform", "win32"),
+                mock.patch.object(cache.tempfile, "gettempdir", return_value=tmp),
+                mock.patch.object(cache, "write_github_output"),
+                mock.patch.dict(
+                    cache.os.environ, {"KEEP_ENV": "1", "MSYS": "old"}, clear=False
+                ),
+                mock.patch.object(cache, "_run_command") as run_command,
+            ):
+                run_command.side_effect = lambda cmd, **kwargs: (
+                    run_calls.append((cmd, kwargs)) or fake_run(cmd, **kwargs)
+                )
+                self.assertTrue(cache.restore("win-key", root))
+
+        self.assertEqual(
+            [call[0] for call in run_calls],
+            [
+                ["zstd.exe", "-d", "-f", "-o", str(tar_file), str(tarball)],
+                ["tar.exe", "-xf", str(tar_file)],
+                ["tar.exe", "-xf", str(tar_file)],
+            ],
+        )
+        self.assertNotIn("env", run_calls[0][1])
+        for _, kwargs in run_calls[1:]:
+            self.assertEqual(kwargs["cwd"], expected_root)
+            self.assertEqual(kwargs["env"]["KEEP_ENV"], "1")
+            self.assertEqual(kwargs["env"]["MSYS"], "winsymlinks:nativestrict")
+        self.assertFalse(tarball.exists())
+        self.assertFalse(tar_file.exists())
+
+    def test_restore_windows_skips_second_pass_when_first_tar_succeeds(self):
+        client = mock.Mock()
+
+        def fake_download(bucket, key, filename, Config=None):
+            Path(filename).write_bytes(b"tarball")
+
+        def fake_run(cmd, **kwargs):
+            if cmd[0] == "zstd.exe":
+                Path(cmd[cmd.index("-o") + 1]).write_bytes(b"tar")
+            return 0
+
+        client.download_file.side_effect = fake_download
+        transfer_config = object()
+        run_calls = []
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "chromium"
+            tarball = Path(tmp) / "chromium-cache.tar.zst"
+            tar_file = Path(tmp) / "chromium-cache.tar"
+
+            with (
+                mock.patch.object(
+                    cache, "_get_r2_client", return_value=(client, transfer_config)
+                ),
+                mock.patch.object(cache, "_object_exists", return_value=True),
+                mock.patch.object(
+                    cache, "find_tool", side_effect=lambda name: f"{name}.exe"
+                ),
+                mock.patch.object(cache.sys, "platform", "win32"),
+                mock.patch.object(cache.tempfile, "gettempdir", return_value=tmp),
+                mock.patch.object(cache, "write_github_output"),
+                mock.patch.object(cache, "_run_command") as run_command,
+            ):
+                run_command.side_effect = lambda cmd, **kwargs: (
+                    run_calls.append((cmd, kwargs)) or fake_run(cmd, **kwargs)
+                )
+                self.assertTrue(cache.restore("win-key", root))
+
+        self.assertEqual(
+            [call[0] for call in run_calls],
+            [
+                ["zstd.exe", "-d", "-f", "-o", str(tar_file), str(tarball)],
+                ["tar.exe", "-xf", str(tar_file)],
+            ],
+        )
+
+    def test_restore_windows_fails_when_retry_tar_pass_fails(self):
+        client = mock.Mock()
+
+        def fake_download(bucket, key, filename, Config=None):
+            Path(filename).write_bytes(b"tarball")
+
+        def fake_run(cmd, **kwargs):
+            if cmd[0] == "zstd.exe":
+                Path(cmd[cmd.index("-o") + 1]).write_bytes(b"tar")
+                return 0
+            return 1
+
+        client.download_file.side_effect = fake_download
+        transfer_config = object()
+
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "chromium"
+            tar_file = Path(tmp) / "chromium-cache.tar"
+
+            with (
+                mock.patch.object(
+                    cache, "_get_r2_client", return_value=(client, transfer_config)
+                ),
+                mock.patch.object(cache, "_object_exists", return_value=True),
+                mock.patch.object(
+                    cache, "find_tool", side_effect=lambda name: f"{name}.exe"
+                ),
+                mock.patch.object(cache.sys, "platform", "win32"),
+                mock.patch.object(cache.tempfile, "gettempdir", return_value=tmp),
+                mock.patch.object(cache, "write_github_output"),
+                mock.patch.object(
+                    cache, "_run_command", side_effect=fake_run
+                ) as run_command,
+            ):
+                with self.assertRaises(SystemExit):
+                    cache.restore("win-key", root)
+
+            self.assertFalse(tar_file.exists())
+
+        self.assertEqual(run_command.call_count, 3)
 
     def test_restore_returns_miss_without_r2_credentials(self):
         with mock.patch.object(cache, "_get_r2_client", return_value=None):


### PR DESCRIPTION
## Summary
- Add a Windows-only cache restore path that decompresses the downloaded `.tar.zst` to a rewindable `.tar` before extraction.
- Run Git tar with `MSYS=winsymlinks:nativestrict` and retry one full extraction pass after a first-pass failure.
- Keep POSIX restore and cache save on the existing streaming pipeline and preserve the cache object format.

## Design
Windows restore now uses a restore-only command runner for `zstd -d -f -o <tar> <tar.zst>` and `tar -xf <tar>` from the resolved chromium root. The compressed file is removed after successful decompression, the temporary tar is removed in cleanup, and tar extraction remains fatal if the retry also fails.

## Test plan
- [x] `uv run python -m unittest discover -s bos_build -t . -p "*_test.py"`
- [x] `uv run ruff check bos_build`