### PR TITLE
fix(bos_build): --force-local for windows cache tar extraction

### DIFF
--- a/packages/browseros/bos_build/steps/source/cache.py
+++ b/packages/browseros/bos_build/steps/source/cache.py
@@ -144,7 +144,9 @@ def _restore_windows_tarball(tarball: Path, root: Path) -> None:
         # Drop the compressed archive as soon as the rewindable tar exists.
         _unlink_if_exists(tarball)
 
-        tar_cmd = [find_tool("tar"), "-xf", str(tar_file)]
+        # --force-local: MSYS tar reads the colon in C:\... as a remote host
+        # ("Cannot connect to C: resolve failed") without it.
+        tar_cmd = [find_tool("tar"), "--force-local", "-xf", str(tar_file)]
         tar_env = {**os.environ, "MSYS": "winsymlinks:nativestrict"}
         _log("extract pass 1/2")
         first_rc = _run_command(tar_cmd, cwd=root, env=tar_env)

--- a/packages/browseros/bos_build/steps/source/cache_test.py
+++ b/packages/browseros/bos_build/steps/source/cache_test.py
@@ -130,8 +130,8 @@ class RestoreTest(unittest.TestCase):
             [call[0] for call in run_calls],
             [
                 ["zstd.exe", "-d", "-f", "-o", str(tar_file), str(tarball)],
-                ["tar.exe", "-xf", str(tar_file)],
-                ["tar.exe", "-xf", str(tar_file)],
+                ["tar.exe", "--force-local", "-xf", str(tar_file)],
+                ["tar.exe", "--force-local", "-xf", str(tar_file)],
             ],
         )
         self.assertNotIn("env", run_calls[0][1])
@@ -184,7 +184,7 @@ class RestoreTest(unittest.TestCase):
             [call[0] for call in run_calls],
             [
                 ["zstd.exe", "-d", "-f", "-o", str(tar_file), str(tarball)],
-                ["tar.exe", "-xf", str(tar_file)],
+                ["tar.exe", "--force-local", "-xf", str(tar_file)],
             ],
         )
 


### PR DESCRIPTION
Third and final layer of the windows cache-restore onion (run 28747422351): with the archive now passed as a file path, MSYS tar parses the drive-letter colon in `-f C:\...\chromium-cache.tar` as a remote-host spec — `Cannot connect to C: resolve failed`. `--force-local` is the canonical fix. Tests updated; 614 tests + ruff green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)