### PR TITLE
feat(bos_build): rehaul Slack notifier to phase-level narrative

### DIFF
--- a/packages/browseros/bos_build/README.md
+++ b/packages/browseros/bos_build/README.md
@@ -48,7 +48,7 @@ plan(preset, platform, arch, switches) -> [step names]
 - **Switches** are flat toggles: `product`, `arch`, `clean`,
   `provision` (none/full/shallow), `download`, `sign`, `upload`.
   Resolution: CLI > profile file > preset default.
-- **Steps** self-register with `@step(name, phase, platforms, notify,
+- **Steps** self-register with `@step(name, phase, platforms,
   env, optional)`. Required env vars derive from the selected steps and
   are preflighted before anything runs; within-phase order is the
   import order in `steps/__init__.py`.

--- a/packages/browseros/bos_build/cli/build.py
+++ b/packages/browseros/bos_build/cli/build.py
@@ -3,7 +3,6 @@
 
 import os
 import re
-import time
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Callable, List, Optional, Tuple
@@ -25,12 +24,7 @@ from ..core.planner import (
     slice_runs_from,
 )
 from ..core.resolver import resolve_config, resolve_pipeline
-from ..lib.notify import (
-    notify_pipeline_end,
-    notify_pipeline_error,
-    set_build_context,
-    slack_subscriber,
-)
+from ..lib.notify import slack_subscriber
 from ..core.runner import StepExecutionError, run as run_pipeline
 from ..core.step import (
     all_steps,
@@ -42,7 +36,6 @@ from ..lib.utils import (
     log_error,
     log_info,
     log_warning,
-    IS_MACOS,
     IS_WINDOWS,
 )
 
@@ -446,51 +439,29 @@ def _execute_runs(
         log_info(f"📍 Pipeline: {' → '.join(runs[0][1])}")
     log_info("=" * 70)
 
-    os_name = "macOS" if IS_MACOS() else "Windows" if IS_WINDOWS() else "Linux"
-
     # Execute once per architecture. Steps see a normal single-arch ctx;
-    # only this loop knows about multi-arch. For multi-arch invocations
-    # one extra whole-run terminal notification fires in the finally, so
-    # an interrupted second arch still reports.
+    # only this loop knows about multi-arch.
     multi_arch = len(runs) > 1
-    overall_status = "failed"
-    overall_error: Optional[str] = None
-    overall_start = time.time()
-    try:
-        for i, (arch_ctx, run_steps) in enumerate(runs, start=1):
-            if multi_arch:
-                log_info("\n" + "#" * 70)
-                log_info(f"# Architecture {i}/{len(runs)}: {arch_ctx.architecture}")
-                log_info(f"# Output: {arch_ctx.out_dir}")
-                log_info("#" * 70)
-
-            set_build_context(os_name, arch_ctx.architecture)
-            run_name = f"build[{arch_ctx.architecture}]" if multi_arch else "build"
-            try:
-                run_pipeline(
-                    arch_ctx,
-                    run_steps,
-                    name=run_name,
-                    subscribers=(slack_subscriber,),
-                    available=AVAILABLE_MODULES,
-                )
-            except StepExecutionError as e:
-                overall_error = str(e)
-                raise typer.Exit(1)
-            except KeyboardInterrupt:
-                overall_status = "interrupted"
-                overall_error = "Interrupted by user"
-                raise typer.Exit(130)
-        overall_status = "success"
-    finally:
+    for i, (arch_ctx, run_steps) in enumerate(runs, start=1):
         if multi_arch:
-            duration = time.time() - overall_start
-            if overall_status == "success":
-                notify_pipeline_end("build (all architectures)", duration)
-            else:
-                notify_pipeline_error(
-                    "build (all architectures)", overall_error or overall_status
-                )
+            log_info("\n" + "#" * 70)
+            log_info(f"# Architecture {i}/{len(runs)}: {arch_ctx.architecture}")
+            log_info(f"# Output: {arch_ctx.out_dir}")
+            log_info("#" * 70)
+
+        try:
+            run_pipeline(
+                arch_ctx,
+                run_steps,
+                name="build",
+                subscribers=(slack_subscriber(arch_ctx),),
+                available=AVAILABLE_MODULES,
+            )
+        except StepExecutionError as e:
+            log_error(str(e))
+            raise typer.Exit(1)
+        except KeyboardInterrupt:
+            raise typer.Exit(130)
 
 
 def _display_only_runs() -> List[Tuple[Context, List[str]]]:

--- a/packages/browseros/bos_build/cli/ext.py
+++ b/packages/browseros/bos_build/cli/ext.py
@@ -46,7 +46,7 @@ def _create_context(version: str) -> Context:
 
 def _execute(ctx: Context, steps: List) -> None:
     try:
-        run_steps(ctx, steps, name="ext-release", subscribers=(slack_subscriber,))
+        run_steps(ctx, steps, name="ext-release", subscribers=(slack_subscriber(ctx),))
     except StepExecutionError as e:
         log_error(str(e))
         raise typer.Exit(1)

--- a/packages/browseros/bos_build/cli/ota.py
+++ b/packages/browseros/bos_build/cli/ota.py
@@ -49,7 +49,7 @@ def create_ota_context() -> Context:
 def execute_module(ctx: Context, module) -> None:
     """Run a single OTA step through the shared runner"""
     try:
-        run_steps(ctx, [module], name="ota", subscribers=(slack_subscriber,))
+        run_steps(ctx, [module], name="ota", subscribers=(slack_subscriber(ctx),))
     except StepExecutionError as e:
         log_error(str(e))
         raise typer.Exit(1)

--- a/packages/browseros/bos_build/cli/release.py
+++ b/packages/browseros/bos_build/cli/release.py
@@ -80,7 +80,7 @@ def create_release_context(
 def execute_module(ctx: Context, module) -> None:
     """Run a single release step through the shared runner"""
     try:
-        run_steps(ctx, [module], name="release", subscribers=(slack_subscriber,))
+        run_steps(ctx, [module], name="release", subscribers=(slack_subscriber(ctx),))
     except StepExecutionError as e:
         log_error(str(e))
         raise typer.Exit(1)

--- a/packages/browseros/bos_build/cli/release_feeds.py
+++ b/packages/browseros/bos_build/cli/release_feeds.py
@@ -47,7 +47,7 @@ def _create_context(version: str = "", product: str = "browseros") -> Context:
 
 def _execute(ctx: Context, module) -> None:
     try:
-        run_steps(ctx, [module], name="release", subscribers=(slack_subscriber,))
+        run_steps(ctx, [module], name="release", subscribers=(slack_subscriber(ctx),))
     except StepExecutionError as e:
         log_error(str(e))
         raise typer.Exit(1)

--- a/packages/browseros/bos_build/core/events.py
+++ b/packages/browseros/bos_build/core/events.py
@@ -22,14 +22,14 @@ class RunStarted:
 class StepStarted:
     run: str
     step: str
-    notify: bool
+    phase: str
 
 
 @dataclass(frozen=True)
 class StepFinished:
     run: str
     step: str
-    notify: bool
+    phase: str
     status: RunStatus
     duration: float
     error: Optional[str] = None

--- a/packages/browseros/bos_build/core/runner.py
+++ b/packages/browseros/bos_build/core/runner.py
@@ -85,7 +85,7 @@ def run(
             log_info(f"🔧 Running step: {step_name}")
             log_info(f"{'=' * 70}")
 
-            _emit(subscribers, StepStarted(run=name, step=step_name, notify=step.notify))
+            _emit(subscribers, StepStarted(run=name, step=step_name, phase=step.phase))
             step_start = time.time()
             _warn_missing_requires(ctx, step, step_name)
 
@@ -178,13 +178,15 @@ def _finish_step(
 ) -> float:
     duration = time.time() - step_start
     status: RunStatus = "failed" if error else "success"
-    results.steps.append(StepResult(name=_step_name(step), status=status, duration=duration))
+    results.steps.append(
+        StepResult(name=_step_name(step), status=status, duration=duration)
+    )
     _emit(
         subscribers,
         StepFinished(
             run=run_name,
             step=_step_name(step),
-            notify=step.notify,
+            phase=step.phase,
             status=status,
             duration=duration,
             error=error,

--- a/packages/browseros/bos_build/core/runner_test.py
+++ b/packages/browseros/bos_build/core/runner_test.py
@@ -119,15 +119,17 @@ class RunnerEventTest(unittest.TestCase):
         with self.assertRaisesRegex(StepExecutionError, "unknown step"):
             run(_ctx(), ["definitely_not_a_step"], name="r", available={})
 
-    def test_notify_flag_carried_on_events(self):
+    def test_phase_carried_on_events(self):
         rec = _Recorder()
 
-        class NotifyStep(_OkStep):
-            notify = True
+        class PhaseStep(_OkStep):
+            phase = "build"
 
-        run(_ctx(), [NotifyStep()], name="r", subscribers=(rec,))
+        run(_ctx(), [PhaseStep()], name="r", subscribers=(rec,))
         started = [e for e in rec.events if isinstance(e, StepStarted)]
-        self.assertTrue(started[0].notify)
+        finished = [e for e in rec.events if isinstance(e, StepFinished)]
+        self.assertEqual(started[0].phase, "build")
+        self.assertEqual(finished[0].phase, "build")
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/core/step.py
+++ b/packages/browseros/bos_build/core/step.py
@@ -3,8 +3,8 @@
 
 A step is one discrete pipeline unit (clean, compile, sign_macos, ...).
 Classes register with the @step decorator, which attaches metadata the
-CLI and planner derive everything from: available steps, per-platform
-phase ordering, and notification hooks. Within a phase, order is
+CLI and planner derive everything from: available steps and per-platform
+phase ordering. Within a phase, order is
 registration order — bos_build/steps/__init__.py imports step modules
 in canonical pipeline order, so that file is the single place ordering
 lives.
@@ -50,7 +50,6 @@ class Step:
         name: Registry name (e.g. "sign_macos")
         phase: One of PHASES
         platforms: Platforms the step applies to; None = all
-        notify: Whether lifecycle notifications fire for this step
         env: Environment variable names the step needs (preflighted)
         optional: Excluded from phase-flag/preset expansion unless
             explicitly requested (e.g. series_patches, merge_universal)
@@ -69,7 +68,6 @@ class Step:
     name: str = ""
     phase: str = ""
     platforms: Optional[Tuple[str, ...]] = None
-    notify: bool = False
     env: Tuple[str, ...] = ()
     optional: bool = False
 
@@ -130,7 +128,6 @@ def step(
     *,
     phase: str,
     platforms: Optional[Tuple[str, ...]] = None,
-    notify: bool = False,
     env: Tuple[str, ...] = (),
     optional: bool = False,
 ):
@@ -149,7 +146,6 @@ def step(
         cls.name = name
         cls.phase = phase
         cls.platforms = platforms
-        cls.notify = notify
         cls.env = env
         cls.optional = optional
         _REGISTRY[name] = cls
@@ -185,12 +181,6 @@ def phase_steps(
         and (include_optional or not cls.optional)
         and (cls.platforms is None or platform in cls.platforms)
     ]
-
-
-def notify_step_names() -> List[str]:
-    """Names of steps that trigger lifecycle notifications."""
-    _ensure_loaded()
-    return [name for name, cls in _REGISTRY.items() if cls.notify]
 
 
 def _ensure_loaded() -> None:

--- a/packages/browseros/bos_build/core/step_test.py
+++ b/packages/browseros/bos_build/core/step_test.py
@@ -7,7 +7,6 @@ from bos_build.core import step as step_mod
 from bos_build.core.step import (
     Step,
     all_steps,
-    notify_step_names,
     phase_steps,
     step,
 )
@@ -86,22 +85,6 @@ class RegistryContentTest(unittest.TestCase):
         self.assertNotIn("merge_universal", phase_steps("build", "macos"))
         self.assertNotIn("mini_installer", phase_steps("sign", "windows"))
 
-    def test_notify_steps_match_legacy_notify_modules(self):
-        self.assertEqual(
-            set(notify_step_names()),
-            {
-                "compile",
-                "sign_macos",
-                "sign_windows",
-                "sign_linux",
-                "package_macos",
-                "package_windows",
-                "package_linux",
-                "upload",
-            },
-        )
-
-
 class RegistrationRulesTest(unittest.TestCase):
     def test_duplicate_name_raises(self):
         with self.assertRaisesRegex(ValueError, "Duplicate step name 'clean'"):
@@ -121,7 +104,6 @@ class RegistrationRulesTest(unittest.TestCase):
                 "temp_step_for_test",
                 phase="prep",
                 platforms=("linux",),
-                notify=True,
                 env=("SOME_VAR",),
                 optional=True,
             )
@@ -131,7 +113,6 @@ class RegistrationRulesTest(unittest.TestCase):
             self.assertEqual(TempStep.name, "temp_step_for_test")
             self.assertEqual(TempStep.phase, "prep")
             self.assertEqual(TempStep.platforms, ("linux",))
-            self.assertTrue(TempStep.notify)
             self.assertEqual(TempStep.env, ("SOME_VAR",))
             self.assertTrue(TempStep.optional)
             self.assertTrue(TempStep().applies_to("linux"))

--- a/packages/browseros/bos_build/docs/nightly-macos-ci.md
+++ b/packages/browseros/bos_build/docs/nightly-macos-ci.md
@@ -189,9 +189,14 @@ The workflow uploads matching DMGs as `BrowserOS_v<version>_arm64` with
 
 ## Slack
 
-The build already posts pipeline start, phase start/done, success, failure,
-package-created, and upload-complete messages when `SLACK_WEBHOOK_URL` is
-present in `.env`.
+When `SLACK_WEBHOOK_URL` is present in `.env`, the build posts one terse
+phase narrative for each run. The first message announces the product,
+version, OS/arch, and planned phases. Each later phase transition posts one
+humanized duration message, such as `✅ Build done (83m 26s) → Sign`.
+The terminal message is always sent synchronously: `🏁` success includes R2
+artifact links when upload ran, `❌` failure names the failing step and error,
+and `🛑` interrupt names the interrupted step. With no webhook configured,
+Slack notification is a silent no-op.
 
 The workflow only adds a CI-level failure ping for failures that happen before
 or around the build invocation, such as missing runner variables or sync errors.

--- a/packages/browseros/bos_build/lib/__init__.py
+++ b/packages/browseros/bos_build/lib/__init__.py
@@ -1,10 +1,9 @@
 """Cross-cutting plumbing shared by the build, release, and dev toolsets"""
 
 from .env import EnvConfig
-from .notify import Notifier, get_notifier
+from .notify import Notifier
 
 __all__ = [
     "EnvConfig",
     "Notifier",
-    "get_notifier",
 ]

--- a/packages/browseros/bos_build/lib/notify.py
+++ b/packages/browseros/bos_build/lib/notify.py
@@ -100,7 +100,7 @@ class Notifier:
 def format_duration(seconds: float) -> str:
     """Format seconds for Slack messages without leaking raw float durations."""
     total_seconds = max(0, int(round(seconds)))
-    if seconds < 60:
+    if total_seconds < 60:
         return f"{total_seconds}s"
 
     minutes, remaining_seconds = divmod(total_seconds, 60)

--- a/packages/browseros/bos_build/lib/notify.py
+++ b/packages/browseros/bos_build/lib/notify.py
@@ -135,11 +135,8 @@ class SlackRunSubscriber:
         self.last_failed_step: Optional[_FailedStep] = None
 
     def __call__(self, event) -> None:
-        """Consume a runner event; notification failures are intentionally silent."""
-        try:
-            self._handle(event)
-        except Exception:
-            pass
+        """Consume a runner event; runner._emit logs subscriber failures."""
+        self._handle(event)
 
     def _handle(self, event) -> None:
         from ..core.events import RunFinished, RunStarted, StepFinished, StepStarted
@@ -188,6 +185,8 @@ class SlackRunSubscriber:
                 phase=event.phase,
                 error=event.error or "",
             )
+        elif event.status == "success":
+            self.current_step = ""
 
     def _run_finished(self, event) -> None:
         if event.status == "success":
@@ -249,7 +248,21 @@ class SlackRunSubscriber:
         release_links = self.artifact_registry.get("release_links")
         if not release_links:
             return None
-        links = [f"<{url}|{filename}>" for filename, url in release_links]
+        try:
+            entries = iter(release_links)
+        except TypeError:
+            return None
+
+        links = []
+        for entry in entries:
+            if not isinstance(entry, (list, tuple)) or len(entry) != 2:
+                continue
+            filename, url = entry
+            if not filename or not url:
+                continue
+            links.append(f"<{url}|{filename}>")
+        if not links:
+            return None
         return {"Artifacts": "\n".join(links)}
 
     def _send(

--- a/packages/browseros/bos_build/lib/notify.py
+++ b/packages/browseros/bos_build/lib/notify.py
@@ -1,37 +1,23 @@
 #!/usr/bin/env python3
-"""Notification system for BrowserOS build pipeline"""
+"""Slack notifications for BrowserOS build pipeline lifecycle events."""
 
 import os
 import threading
-from typing import Optional, Dict, Any
+from dataclasses import dataclass
+from typing import Any, Dict, Optional, Sequence
+
+from .utils import IS_LINUX, IS_MACOS, IS_WINDOWS
 
 # Slack attachment colors
 COLOR_BLUE = "#2196F3"
 COLOR_GREEN = "#4CAF50"
 COLOR_RED = "#F44336"
 
-# Build context (set once at pipeline start)
-_build_context: Dict[str, str] = {}
-
-
-def set_build_context(os_name: str, arch: str) -> None:
-    """Set build context for all notifications"""
-    _build_context["os"] = os_name
-    _build_context["arch"] = arch
-
-
-def _get_context_prefix() -> str:
-    """Get [arch] prefix if context is set"""
-    if "arch" in _build_context:
-        return f"[{_build_context['arch']}] "
-    return ""
-
-
-def _get_context_footer() -> str:
-    """Get OS footer if context is set"""
-    if "os" in _build_context:
-        return f"BrowserOS Build System - {_build_context['os']}"
-    return "BrowserOS Build System"
+_OS_EMOJI = {
+    "macOS": "🍎",
+    "Windows": "🪟",
+    "Linux": "🐧",
+}
 
 
 class Notifier:
@@ -48,6 +34,7 @@ class Notifier:
         details: Optional[Dict[str, Any]] = None,
         color: str = "#36a64f",
         wait: bool = False,
+        footer: str = "BrowserOS Build System",
     ) -> None:
         """Send notification; fire-and-forget unless wait=True.
 
@@ -60,33 +47,34 @@ class Notifier:
             return
 
         if wait:
-            self._send_notification(event, message, details, color)
+            self._send_notification(event, message, details, color, footer)
             return
 
         thread = threading.Thread(
             target=self._send_notification,
-            args=(event, message, details, color),
-            daemon=True
+            args=(event, message, details, color, footer),
+            daemon=True,
         )
         thread.start()
 
-    def _send_notification(self, event: str, message: str, details: Optional[Dict[str, Any]], color: str) -> None:
+    def _send_notification(
+        self,
+        event: str,
+        message: str,
+        details: Optional[Dict[str, Any]],
+        color: str,
+        footer: str,
+    ) -> None:
         """Internal method to send notification (runs in background thread)"""
         try:
             import requests
-
-            # Build footer text
-            footer = f"🍎 {_get_context_footer()}" if _build_context.get("os") == "macOS" \
-                else f"🪟 {_get_context_footer()}" if _build_context.get("os") == "Windows" \
-                else f"🐧 {_get_context_footer()}" if _build_context.get("os") == "Linux" \
-                else _get_context_footer()
 
             # Use legacy attachment format for colored sidebar
             attachment = {
                 "color": color,
                 "mrkdwn_in": ["text", "fields"],
                 "text": f"*{event}*\n{message}",
-                "footer": footer
+                "footer": footer,
             }
 
             if details:
@@ -100,7 +88,7 @@ class Notifier:
             requests.post(
                 self.slack_webhook_url,
                 json=payload,
-                timeout=5  # Quick timeout for fire-and-forget
+                timeout=5,  # Quick timeout for fire-and-forget
             )
 
         except ImportError:
@@ -109,98 +97,226 @@ class Notifier:
             pass
 
 
-# Global notifier instance
-_notifier = None
+def format_duration(seconds: float) -> str:
+    """Format seconds for Slack messages without leaking raw float durations."""
+    total_seconds = max(0, int(round(seconds)))
+    if seconds < 60:
+        return f"{total_seconds}s"
+
+    minutes, remaining_seconds = divmod(total_seconds, 60)
+    if remaining_seconds == 0:
+        return f"{minutes}m"
+    return f"{minutes}m {remaining_seconds}s"
 
 
-def get_notifier() -> Notifier:
-    """Get global notifier instance"""
-    global _notifier
-    if _notifier is None:
-        _notifier = Notifier()
-    return _notifier
+@dataclass
+class _FailedStep:
+    step: str
+    phase: str
+    error: str
 
 
-def notify_pipeline_start(pipeline_name: str, modules: list) -> None:
-    """Notify that pipeline has started"""
-    notifier = get_notifier()
-    notifier.notify(
-        "🚀 Pipeline Started",
-        "Build pipeline started",
-        {"Modules": ", ".join(modules)},
-        color=COLOR_BLUE
-    )
+class SlackRunSubscriber:
+    """Stateful event-bus subscriber for one build/release run."""
 
+    def __init__(self, ctx, notifier: Optional[Notifier] = None):
+        self.notifier = notifier or Notifier()
+        self.display_name = ctx.product.display_name
+        self.version = ctx.release_version or ctx.semantic_version
+        self.os_name = _current_os_name()
+        self.architecture = ctx.architecture
+        self.identity = self._identity()
+        self.footer = self._footer()
+        self.artifact_registry = getattr(ctx, "artifact_registry", None)
 
-def notify_pipeline_end(pipeline_name: str, duration: float) -> None:
-    """Notify that pipeline completed successfully"""
-    notifier = get_notifier()
-    mins = int(duration / 60)
-    secs = int(duration % 60)
-    notifier.notify(
-        "🏁 Pipeline Completed",
-        f"Pipeline '{pipeline_name}' completed successfully",
-        {"Duration": f"{mins}m {secs}s"},
-        color=COLOR_GREEN,
-        wait=True,
-    )
+        self.current_phase = ""
+        self.current_step = ""
+        self.phase_durations: Dict[str, float] = {}
+        self.last_failed_step: Optional[_FailedStep] = None
 
+    def __call__(self, event) -> None:
+        """Consume a runner event; notification failures are intentionally silent."""
+        try:
+            self._handle(event)
+        except Exception:
+            pass
 
-def notify_pipeline_error(pipeline_name: str, error: str) -> None:
-    """Notify that pipeline failed with error"""
-    notifier = get_notifier()
-    notifier.notify(
-        "❌ Pipeline Failed",
-        f"Pipeline '{pipeline_name}' failed",
-        {"Error": error},
-        color=COLOR_RED,
-        wait=True,
-    )
+    def _handle(self, event) -> None:
+        from ..core.events import RunFinished, RunStarted, StepFinished, StepStarted
 
+        if isinstance(event, RunStarted):
+            self._run_started(event)
+        elif isinstance(event, StepStarted):
+            self._step_started(event)
+        elif isinstance(event, StepFinished):
+            self._step_finished(event)
+        elif isinstance(event, RunFinished):
+            self._run_finished(event)
 
-def notify_module_start(module_name: str) -> None:
-    """Notify that a module started executing"""
-    notifier = get_notifier()
-    prefix = _get_context_prefix()
-    notifier.notify(
-        "▶️ Module Started",
-        f"{prefix}Module '{module_name}' started",
-        None,
-        color=COLOR_BLUE
-    )
+    def _run_started(self, event) -> None:
+        title = f"🚀 {_run_label(event.run)} started — {self.identity}"
+        chain = _planned_phase_chain(event.steps)
+        self._send(title, chain, color=COLOR_BLUE)
 
+    def _step_started(self, event) -> None:
+        self.current_step = event.step
+        if not event.phase:
+            return
+        if not self.current_phase:
+            self.current_phase = event.phase
+            return
+        if event.phase == self.current_phase:
+            return
 
-def notify_module_completion(module_name: str, duration: float) -> None:
-    """Notify that a module completed successfully"""
-    notifier = get_notifier()
-    prefix = _get_context_prefix()
-    notifier.notify(
-        "✅ Module Completed",
-        f"{prefix}Module '{module_name}' completed",
-        {"Duration": f"{duration:.1f}s"},
-        color=COLOR_GREEN
-    )
+        previous_phase = self.current_phase
+        duration = self.phase_durations.get(previous_phase, 0.0)
+        title = (
+            f"✅ {_phase_label(previous_phase)} done ({format_duration(duration)}) "
+            f"→ {_phase_label(event.phase)}"
+        )
+        self._send(title, "", color=COLOR_GREEN)
+        self.current_phase = event.phase
 
+    def _step_finished(self, event) -> None:
+        if event.phase:
+            self.phase_durations[event.phase] = (
+                self.phase_durations.get(event.phase, 0.0) + event.duration
+            )
+        if event.status == "failed":
+            self.last_failed_step = _FailedStep(
+                step=event.step,
+                phase=event.phase,
+                error=event.error or "",
+            )
 
-def slack_subscriber(event) -> None:
-    """Route runner lifecycle events to Slack.
-
-    Attach to core.runner.run(subscribers=...). Step-level pings honor
-    each step's notify flag; run start/end always fire. Import is local
-    to avoid a notify → events cycle at module import time.
-    """
-    from ..core.events import RunFinished, RunStarted, StepFinished, StepStarted
-
-    if isinstance(event, RunStarted):
-        notify_pipeline_start(event.run, list(event.steps))
-    elif isinstance(event, StepStarted):
-        if event.notify:
-            notify_module_start(event.step)
-    elif isinstance(event, StepFinished):
-        if event.notify and event.status == "success":
-            notify_module_completion(event.step, event.duration)
-    elif isinstance(event, RunFinished):
+    def _run_finished(self, event) -> None:
         if event.status == "success":
-            notify_pipeline_end(event.run, event.duration)
+            self._run_succeeded(event)
+        elif event.status == "interrupted":
+            self._run_interrupted(event)
         else:
-            notify_pipeline_error(event.run, event.error or event.status)
+            self._run_failed(event)
+
+    def _run_succeeded(self, event) -> None:
+        details = self._artifact_fields()
+        self._send(
+            f"🏁 {_run_label(event.run)} completed — {self.identity}",
+            f"Completed in {format_duration(event.duration)}",
+            details=details,
+            color=COLOR_GREEN,
+            wait=True,
+        )
+
+    def _run_failed(self, event) -> None:
+        failed = self.last_failed_step
+        if failed and failed.step:
+            phase = f" ({_phase_label(failed.phase)} phase)" if failed.phase else ""
+            title = (
+                f"❌ {_run_label(event.run)} FAILED at '{failed.step}'{phase} "
+                f"— {self.identity}"
+            )
+            error = failed.error or event.error or event.status
+        else:
+            title = f"❌ {_run_label(event.run)} FAILED — {self.identity}"
+            error = event.error or event.status
+
+        self._send(
+            title,
+            f"Terminated after {format_duration(event.duration)}",
+            details={"Error": error},
+            color=COLOR_RED,
+            wait=True,
+        )
+
+    def _run_interrupted(self, event) -> None:
+        if self.current_step:
+            title = (
+                f"🛑 {_run_label(event.run)} interrupted at '{self.current_step}' "
+                f"— {self.identity}"
+            )
+        else:
+            title = f"🛑 {_run_label(event.run)} interrupted — {self.identity}"
+        self._send(
+            title,
+            f"after {format_duration(event.duration)}",
+            color=COLOR_RED,
+            wait=True,
+        )
+
+    def _artifact_fields(self) -> Optional[Dict[str, str]]:
+        if self.artifact_registry is None:
+            return None
+        release_links = self.artifact_registry.get("release_links")
+        if not release_links:
+            return None
+        links = [f"<{url}|{filename}>" for filename, url in release_links]
+        return {"Artifacts": "\n".join(links)}
+
+    def _send(
+        self,
+        title: str,
+        body: str,
+        *,
+        details: Optional[Dict[str, Any]] = None,
+        color: str,
+        wait: bool = False,
+    ) -> None:
+        self.notifier.notify(
+            title,
+            body,
+            details,
+            color=color,
+            wait=wait,
+            footer=self.footer,
+        )
+
+    def _identity(self) -> str:
+        parts = [f"{self.display_name} v{self.version}", f"· {self.os_name}"]
+        if self.architecture:
+            parts.append(self.architecture)
+        return " ".join(parts)
+
+    def _footer(self) -> str:
+        emoji = _OS_EMOJI.get(self.os_name, "")
+        prefix = f"{emoji} " if emoji else ""
+        return f"{prefix}{self.display_name} Build · {self.os_name}"
+
+
+def slack_subscriber(ctx) -> SlackRunSubscriber:
+    """Create a per-run Slack event subscriber bound to the run context."""
+    return SlackRunSubscriber(ctx)
+
+
+def _current_os_name() -> str:
+    if IS_MACOS():
+        return "macOS"
+    if IS_WINDOWS():
+        return "Windows"
+    if IS_LINUX():
+        return "Linux"
+    return "Unknown"
+
+
+def _planned_phase_chain(step_names: Sequence[str]) -> str:
+    from ..core.step import all_steps
+
+    registry = all_steps()
+    phases = []
+    seen = set()
+    for step_name in step_names:
+        step_cls = registry.get(step_name)
+        phase = step_cls.phase if step_cls else ""
+        if phase and phase not in seen:
+            phases.append(phase)
+            seen.add(phase)
+    return " → ".join(phases)
+
+
+def _phase_label(phase: str) -> str:
+    return phase.replace("_", " ").title()
+
+
+def _run_label(run: str) -> str:
+    if run.lower() == "ota":
+        return "OTA"
+    return " ".join(part.capitalize() for part in run.replace("_", "-").split("-"))

--- a/packages/browseros/bos_build/lib/notify_test.py
+++ b/packages/browseros/bos_build/lib/notify_test.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Tests for Slack build lifecycle notifications."""
+
+import os
+import unittest
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from bos_build.core.context import ArtifactRegistry
+from bos_build.core.events import RunFinished, RunStarted, StepFinished, StepStarted
+from bos_build.core.products import get_product_descriptor
+from bos_build.lib.notify import (
+    COLOR_BLUE,
+    COLOR_GREEN,
+    COLOR_RED,
+    Notifier,
+    SlackRunSubscriber,
+    format_duration,
+    slack_subscriber,
+)
+
+
+class _FakeNotifier:
+    def __init__(self):
+        self.messages = []
+
+    def notify(
+        self,
+        title,
+        body,
+        details=None,
+        color=COLOR_GREEN,
+        wait=False,
+        footer=None,
+    ):
+        self.messages.append(
+            {
+                "title": title,
+                "body": body,
+                "details": details,
+                "color": color,
+                "wait": wait,
+                "footer": footer,
+            }
+        )
+
+
+def _ctx(product="browseros", arch="arm64", release_version="", semantic_version="1.2.3"):
+    return SimpleNamespace(
+        product=get_product_descriptor(product),
+        architecture=arch,
+        release_version=release_version,
+        semantic_version=semantic_version,
+        artifact_registry=ArtifactRegistry(),
+    )
+
+
+class FormatDurationTest(unittest.TestCase):
+    def test_format_duration_humanizes_seconds(self):
+        self.assertEqual(format_duration(45.3), "45s")
+        self.assertEqual(format_duration(5006), "83m 26s")
+        self.assertEqual(format_duration(4980), "83m")
+        self.assertEqual(format_duration(0.4), "0s")
+
+
+class SlackRunSubscriberTest(unittest.TestCase):
+    def test_success_sequence_rolls_up_phase_transitions_and_terminal(self):
+        fake = _FakeNotifier()
+        sub = SlackRunSubscriber(_ctx(), notifier=fake)
+
+        sub(RunStarted(run="build", steps=("clean", "compile", "sign_macos")))
+        sub(StepStarted(run="build", step="clean", phase="setup"))
+        sub(
+            StepFinished(
+                run="build",
+                step="clean",
+                phase="setup",
+                status="success",
+                duration=12.2,
+            )
+        )
+        sub(StepStarted(run="build", step="compile", phase="build"))
+        sub(
+            StepFinished(
+                run="build",
+                step="compile",
+                phase="build",
+                status="success",
+                duration=5006,
+            )
+        )
+        sub(StepStarted(run="build", step="sign_macos", phase="sign"))
+        sub(
+            StepFinished(
+                run="build",
+                step="sign_macos",
+                phase="sign",
+                status="success",
+                duration=7.8,
+            )
+        )
+        sub(RunFinished(run="build", status="success", duration=5026.4))
+
+        self.assertEqual(
+            [m["title"].split(" — ", 1)[0] for m in fake.messages],
+            [
+                "🚀 Build started",
+                "✅ Setup done (12s) → Build",
+                "✅ Build done (83m 26s) → Sign",
+                "🏁 Build completed",
+            ],
+        )
+        self.assertEqual(fake.messages[0]["color"], COLOR_BLUE)
+        self.assertIn("setup → build → sign", fake.messages[0]["body"])
+        self.assertEqual(fake.messages[-1]["body"], "Completed in 83m 46s")
+        self.assertEqual(fake.messages[-1]["color"], COLOR_GREEN)
+        self.assertTrue(fake.messages[-1]["wait"])
+        self.assertIsNone(fake.messages[-1]["details"])
+
+    def test_success_includes_release_links_artifacts_field(self):
+        ctx = _ctx()
+        ctx.artifact_registry.add(
+            "release_links",
+            [
+                ("BrowserOS.dmg", "https://example.test/BrowserOS.dmg"),
+                ("release.json", "https://example.test/release.json"),
+            ],
+        )
+        fake = _FakeNotifier()
+        sub = SlackRunSubscriber(ctx, notifier=fake)
+
+        sub(RunStarted(run="build", steps=("compile",)))
+        sub(StepStarted(run="build", step="compile", phase="build"))
+        sub(
+            StepFinished(
+                run="build",
+                step="compile",
+                phase="build",
+                status="success",
+                duration=1.0,
+            )
+        )
+        sub(RunFinished(run="build", status="success", duration=2.0))
+
+        self.assertEqual(
+            fake.messages[-1]["details"],
+            {
+                "Artifacts": (
+                    "<https://example.test/BrowserOS.dmg|BrowserOS.dmg>\n"
+                    "<https://example.test/release.json|release.json>"
+                )
+            },
+        )
+
+    def test_failure_names_step_phase_error_and_waits(self):
+        fake = _FakeNotifier()
+        sub = SlackRunSubscriber(_ctx(), notifier=fake)
+
+        sub(RunStarted(run="build", steps=("compile", "sign_macos")))
+        sub(StepStarted(run="build", step="compile", phase="build"))
+        sub(
+            StepFinished(
+                run="build",
+                step="compile",
+                phase="build",
+                status="failed",
+                duration=83.0,
+                error="ninja failed",
+            )
+        )
+        sub(RunFinished(run="build", status="failed", duration=84.0, error="compile: ninja failed"))
+
+        self.assertEqual(len(fake.messages), 2)
+        terminal = fake.messages[-1]
+        self.assertIn("❌ Build FAILED at 'compile' (Build phase)", terminal["title"])
+        self.assertIn("BrowserOS v1.2.3", terminal["title"])
+        self.assertEqual(terminal["body"], "Terminated after 1m 24s")
+        self.assertEqual(terminal["details"], {"Error": "ninja failed"})
+        self.assertEqual(terminal["color"], COLOR_RED)
+        self.assertTrue(terminal["wait"])
+
+    def test_failure_without_failed_step_falls_back_to_run_error(self):
+        fake = _FakeNotifier()
+        sub = SlackRunSubscriber(_ctx(), notifier=fake)
+
+        sub(RunStarted(run="build", steps=("missing_step",)))
+        sub(RunFinished(run="build", status="failed", duration=5.0, error="unknown step"))
+
+        terminal = fake.messages[-1]
+        self.assertEqual(terminal["title"].split(" — ", 1)[0], "❌ Build FAILED")
+        self.assertEqual(terminal["details"], {"Error": "unknown step"})
+
+    def test_interrupted_names_current_step_and_waits(self):
+        fake = _FakeNotifier()
+        sub = SlackRunSubscriber(_ctx(), notifier=fake)
+
+        sub(RunStarted(run="build", steps=("compile",)))
+        sub(StepStarted(run="build", step="compile", phase="build"))
+        sub(RunFinished(run="build", status="interrupted", duration=65.0, error="Interrupted by user"))
+
+        terminal = fake.messages[-1]
+        self.assertIn("🛑 Build interrupted at 'compile'", terminal["title"])
+        self.assertEqual(terminal["body"], "after 1m 5s")
+        self.assertEqual(terminal["color"], COLOR_RED)
+        self.assertTrue(terminal["wait"])
+
+    def test_unregistered_empty_phase_steps_emit_start_and_terminal_only(self):
+        fake = _FakeNotifier()
+        sub = SlackRunSubscriber(_ctx(), notifier=fake)
+
+        sub(RunStarted(run="release", steps=("GithubModule",)))
+        sub(StepStarted(run="release", step="GithubModule", phase=""))
+        sub(
+            StepFinished(
+                run="release",
+                step="GithubModule",
+                phase="",
+                status="success",
+                duration=3.0,
+            )
+        )
+        sub(RunFinished(run="release", status="success", duration=4.0))
+
+        self.assertEqual(len(fake.messages), 2)
+        self.assertEqual(fake.messages[0]["title"].split(" — ", 1)[0], "🚀 Release started")
+        self.assertEqual(fake.messages[0]["body"], "")
+        self.assertEqual(fake.messages[1]["title"].split(" — ", 1)[0], "🏁 Release completed")
+
+    def test_factory_with_unset_webhook_is_silent_noop(self):
+        with patch.dict(os.environ, {}, clear=True):
+            sub = slack_subscriber(_ctx())
+            sub(RunStarted(run="build", steps=("compile",)))
+            sub(RunFinished(run="build", status="success", duration=1.0))
+
+            notifier = Notifier()
+            self.assertFalse(notifier.enabled)
+            notifier.notify("title", "body", wait=True)
+
+    def test_browserclaw_identity_and_footer_use_context_product(self):
+        fake = _FakeNotifier()
+        sub = SlackRunSubscriber(_ctx(product="browserclaw"), notifier=fake)
+
+        sub(RunStarted(run="build", steps=("compile",)))
+
+        self.assertIn("BrowserClaw", fake.messages[0]["title"])
+        self.assertIn("BrowserClaw Build", fake.messages[0]["footer"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/bos_build/lib/notify_test.py
+++ b/packages/browseros/bos_build/lib/notify_test.py
@@ -45,6 +45,11 @@ class _FakeNotifier:
         )
 
 
+class _RaisingNotifier:
+    def notify(self, *args, **kwargs):
+        raise RuntimeError("notify exploded")
+
+
 def _ctx(product="browseros", arch="arm64", release_version="", semantic_version="1.2.3"):
     return SimpleNamespace(
         product=get_product_descriptor(product),
@@ -153,6 +158,29 @@ class SlackRunSubscriberTest(unittest.TestCase):
             },
         )
 
+    def test_malformed_release_links_do_not_drop_terminal_success(self):
+        for release_links in (["not-a-pair"], object()):
+            with self.subTest(release_links=type(release_links).__name__):
+                ctx = _ctx()
+                ctx.artifact_registry.add("release_links", release_links)
+                fake = _FakeNotifier()
+                sub = SlackRunSubscriber(ctx, notifier=fake)
+
+                sub(RunFinished(run="build", status="success", duration=2.0))
+
+                self.assertEqual(len(fake.messages), 1)
+                self.assertEqual(
+                    fake.messages[0]["title"].split(" — ", 1)[0],
+                    "🏁 Build completed",
+                )
+                self.assertIsNone(fake.messages[0]["details"])
+
+    def test_notifier_failure_propagates_to_runner_guard(self):
+        sub = SlackRunSubscriber(_ctx(), notifier=_RaisingNotifier())
+
+        with self.assertRaisesRegex(RuntimeError, "notify exploded"):
+            sub(RunStarted(run="build", steps=("compile",)))
+
     def test_failure_names_step_phase_error_and_waits(self):
         fake = _FakeNotifier()
         sub = SlackRunSubscriber(_ctx(), notifier=fake)
@@ -204,6 +232,26 @@ class SlackRunSubscriberTest(unittest.TestCase):
         self.assertEqual(terminal["body"], "after 1m 5s")
         self.assertEqual(terminal["color"], COLOR_RED)
         self.assertTrue(terminal["wait"])
+
+    def test_interrupted_between_steps_omits_completed_step_name(self):
+        fake = _FakeNotifier()
+        sub = SlackRunSubscriber(_ctx(), notifier=fake)
+
+        sub(StepStarted(run="build", step="compile", phase="build"))
+        sub(
+            StepFinished(
+                run="build",
+                step="compile",
+                phase="build",
+                status="success",
+                duration=1.0,
+            )
+        )
+        sub(RunFinished(run="build", status="interrupted", duration=65.0))
+
+        terminal = fake.messages[-1]
+        self.assertIn("🛑 Build interrupted —", terminal["title"])
+        self.assertNotIn("at 'compile'", terminal["title"])
 
     def test_unregistered_empty_phase_steps_emit_start_and_terminal_only(self):
         fake = _FakeNotifier()

--- a/packages/browseros/bos_build/lib/notify_test.py
+++ b/packages/browseros/bos_build/lib/notify_test.py
@@ -61,6 +61,7 @@ class FormatDurationTest(unittest.TestCase):
         self.assertEqual(format_duration(5006), "83m 26s")
         self.assertEqual(format_duration(4980), "83m")
         self.assertEqual(format_duration(0.4), "0s")
+        self.assertEqual(format_duration(59.7), "1m")
 
 
 class SlackRunSubscriberTest(unittest.TestCase):

--- a/packages/browseros/bos_build/steps/compile/standard.py
+++ b/packages/browseros/bos_build/steps/compile/standard.py
@@ -102,7 +102,7 @@ def autoninja_command(
     return cmd + list(targets)
 
 
-@step("compile", phase="build", notify=True)
+@step("compile", phase="build")
 class CompileModule(Step):
     produces = ["built_app"]
     requires = []

--- a/packages/browseros/bos_build/steps/package/linux.py
+++ b/packages/browseros/bos_build/steps/package/linux.py
@@ -21,7 +21,6 @@ from ...lib.utils import (
     get_platform_arch,
     IS_LINUX,
 )
-from ...lib.notify import get_notifier, COLOR_GREEN
 
 # Target-arch packaging metadata. These describe the artifact we're
 # producing, not the build machine. `appimage_arch` is passed to
@@ -92,7 +91,7 @@ def appimage_icon_source(ctx: Context) -> Optional[Path]:
     return None
 
 
-@step("package_linux", phase="package", platforms=("linux",), notify=True)
+@step("package_linux", phase="package", platforms=("linux",))
 class LinuxPackageModule(Step):
     produces = ["appimage", "deb"]
     requires = []
@@ -138,23 +137,6 @@ class LinuxPackageModule(Step):
             log_warning("   Only AppImage created (.deb failed)")
         elif deb_path:
             log_warning("   Only .deb created (AppImage failed)")
-
-        # Send Slack notification
-        notifier = get_notifier()
-        artifacts = []
-        if appimage_path:
-            artifacts.append(appimage_path.name)
-        if deb_path:
-            artifacts.append(deb_path.name)
-        notifier.notify(
-            "📦 Package Created",
-            "Linux packages created successfully",
-            {
-                "Artifacts": ", ".join(artifacts),
-                "Version": ctx.semantic_version,
-            },
-            color=COLOR_GREEN,
-        )
 
     def _package_appimage(self, ctx: Context, package_dir: Path) -> Optional[Path]:
         return package_appimage(ctx, package_dir)

--- a/packages/browseros/bos_build/steps/package/macos.py
+++ b/packages/browseros/bos_build/steps/package/macos.py
@@ -7,10 +7,9 @@ from typing import Optional, List
 from ...core.step import Step, ValidationError, step
 from ...core.context import Context
 from ...lib.utils import run_command, log_info, log_error, log_success, IS_MACOS
-from ...lib.notify import get_notifier, COLOR_GREEN
 
 
-@step("package_macos", phase="package", platforms=("macos",), notify=True)
+@step("package_macos", phase="package", platforms=("macos",))
 class MacOSPackageModule(Step):
     produces = ["dmg"]
     requires = []
@@ -40,18 +39,6 @@ class MacOSPackageModule(Step):
 
         ctx.artifact_registry.add("dmg", dmg_path)
         log_success(f"DMG created: {dmg_name}")
-
-        notifier = get_notifier()
-        notifier.notify(
-            "📀 Package Created",
-            "DMG package created successfully",
-            {
-                "Artifact": dmg_name,
-                "Version": ctx.semantic_version,
-                "Path": str(dmg_path),
-            },
-            color=COLOR_GREEN,
-        )
 
     def _create_dmg(
         self, app_path: Path, dmg_path: Path, pkg_dmg_path: Path, ctx: Context

--- a/packages/browseros/bos_build/steps/package/windows.py
+++ b/packages/browseros/bos_build/steps/package/windows.py
@@ -15,7 +15,6 @@ from ...lib.utils import (
     join_paths,
     IS_WINDOWS,
 )
-from ...lib.notify import get_notifier, COLOR_GREEN
 from ..compile.standard import autoninja_command
 
 
@@ -48,7 +47,7 @@ class MiniInstallerModule(Step):
             raise RuntimeError("Failed to build mini_installer")
 
 
-@step("package_windows", phase="package", platforms=("windows",), notify=True)
+@step("package_windows", phase="package", platforms=("windows",))
 class WindowsPackageModule(Step):
     produces = ["installer", "installer_zip"]
     requires = []
@@ -74,17 +73,6 @@ class WindowsPackageModule(Step):
         context.artifact_registry.add("installer_zip", zip_path)
 
         log_success("Windows packages created successfully")
-
-        notifier = get_notifier()
-        notifier.notify(
-            "📦 Package Created",
-            "Windows packages created successfully",
-            {
-                "Artifacts": f"{installer_path.name}, {zip_path.name}",
-                "Version": context.semantic_version,
-            },
-            color=COLOR_GREEN,
-        )
 
     def _create_installer(self, ctx: Context) -> Path:
         build_output_dir = join_paths(ctx.chromium_src, ctx.out_dir)

--- a/packages/browseros/bos_build/steps/sign/linux.py
+++ b/packages/browseros/bos_build/steps/sign/linux.py
@@ -6,7 +6,7 @@ from ...core.context import Context
 from ...lib.utils import log_info
 
 
-@step("sign_linux", phase="sign", platforms=("linux",), notify=True)
+@step("sign_linux", phase="sign", platforms=("linux",))
 class LinuxSignModule(Step):
     produces = []
     requires = []

--- a/packages/browseros/bos_build/steps/sign/macos.py
+++ b/packages/browseros/bos_build/steps/sign/macos.py
@@ -155,7 +155,6 @@ def unlock_keychain(env: Optional[EnvConfig] = None) -> None:
     "sign_macos",
     phase="sign",
     platforms=("macos",),
-    notify=True,
     env=(
         "MACOS_CERTIFICATE_NAME",
         "PROD_MACOS_NOTARIZATION_APPLE_ID",

--- a/packages/browseros/bos_build/steps/sign/windows.py
+++ b/packages/browseros/bos_build/steps/sign/windows.py
@@ -26,7 +26,6 @@ from ...lib.utils import (
     "sign_windows",
     phase="sign",
     platforms=("windows",),
-    notify=True,
     env=(
         "CODE_SIGN_TOOL_PATH",
         "ESIGNER_USERNAME",

--- a/packages/browseros/bos_build/steps/storage/upload.py
+++ b/packages/browseros/bos_build/steps/storage/upload.py
@@ -16,7 +16,6 @@ from ...lib.utils import (
     IS_WINDOWS,
     IS_MACOS,
 )
-from ...lib.notify import get_notifier, COLOR_GREEN
 
 from ...lib.r2 import (
     BOTO3_AVAILABLE,
@@ -36,7 +35,7 @@ def _get_platform() -> str:
         return "linux"
 
 
-@step("upload", phase="upload", notify=True)
+@step("upload", phase="upload")
 class UploadModule(Step):
     """Upload build artifacts to Cloudflare R2"""
 
@@ -301,19 +300,10 @@ def upload_release_artifacts(
         log_info(f"  Sparkle version: {release_data.get('sparkle_version', 'N/A')}")
     log_info(f"  Artifacts: {list(release_data['artifacts'].keys())}")
 
-    notifier = get_notifier()
-    artifact_urls = [
-        f"{a['filename']}: {a['url']}" for a in release_data["artifacts"].values()
+    release_links = [
+        (artifact["filename"], artifact["url"])
+        for artifact in release_data["artifacts"].values()
     ]
-    notifier.notify(
-        "Upload Complete",
-        f"Uploaded {len(artifacts)} artifact(s) to R2",
-        {
-            "Version": release_data["version"],
-            "Platform": platform,
-            "Artifacts": "\n".join(artifact_urls),
-        },
-        color=COLOR_GREEN,
-    )
+    ctx.artifact_registry.add("release_links", release_links)
 
     return True, release_data


### PR DESCRIPTION
## Summary
- Replaces the per-module Slack spam (`[arm64] Module 'compile' completed — 10044.8s`) with one terse lifecycle narrative per build run: 🚀 start (product + version + OS/arch + planned phases) → one ✅ per phase transition with humanized duration → terminal 🏁 success **with the R2 artifact links folded in**, or a loud ❌ naming the failing step, its phase, and the error (🛑 for interrupts). Terminal messages always send with `wait=True`, so a dying process can't lose them.
- Rehauls the integration: the notifier now hangs off the event bus in exactly one place (`SlackRunSubscriber` via `slack_subscriber(ctx)`). Legacy helpers (`notify_pipeline_*`, `notify_module_*`, `set_build_context`) and every direct `get_notifier().notify()` call inside steps are deleted; `StepStarted`/`StepFinished` events carry `phase` instead of the retired `notify` flag.
- Identity is product-aware everywhere (`ctx.product.display_name` — BrowserOS vs BrowserClaw); durations humanized everywhere (`83m 26s`, never raw seconds); `SLACK_WEBHOOK_URL` absent stays a clean no-op; env/CLI contracts unchanged.

## Design
Per-run stateful subscriber bound to the build `Context`, with `phase` carried on step events. The subscriber derives the phase narrative from the real step graph (canonical `PHASES` in `core/step.py`) rather than inventing parallel state; phase durations are the sum of `StepFinished` durations, so tests need no clock patching. The upload step publishes `(filename, url)` pairs through `ctx.artifact_registry["release_links"]`, which the subscriber renders as Slack links on the final 🏁 message — the one detail-rich message worth keeping. The redundant multi-arch "build (all architectures)" extra notification was dropped: the runner emits `RunFinished` in a `finally`, so each arch run already reports terminally on success, failure, and interrupt. Subscriber exceptions now surface through the runner's logged warning instead of a silent inner swallow, and malformed artifact links degrade to a link-less terminal message rather than eating it.

## Demo (mock webhook dry-run)

Success scenario — messages as received, in order:

```
[1] *🚀 Build started — BrowserOS v0.47.4 · macOS arm64*
    setup → prep → build → sign → package → upload
[2] *✅ Setup done (0s) → Prep*
[3] *✅ Prep done (0s) → Build*
[4] *✅ Build done (0s) → Sign*
[5] *✅ Sign done (0s) → Package*
[6] *✅ Package done (0s) → Upload*
[7] *🏁 Build completed — BrowserOS v0.47.4 · macOS arm64*
    Completed in 0s
    Artifacts:
      <https://example.test/BrowserOS_v0.47.4_arm64.dmg|BrowserOS_v0.47.4_arm64.dmg>
      <https://example.test/release.json|release.json>
```

Failure scenario (compile raises):

```
[1] *🚀 Build started — BrowserOS v0.47.4 · macOS arm64*
    setup → prep → build → sign → package → upload
[2] *✅ Setup done (0s) → Prep*
[3] *✅ Prep done (0s) → Build*
[4] *❌ Build FAILED at 'compile' (Build phase) — BrowserOS v0.47.4 · macOS arm64*
    Terminated after 0s
    Error: ninja failed
```

(Durations are 0s because the demo's stub steps are instant; real runs show real humanized durations.)

## Test plan
- [x] `uv run python -m unittest discover -s bos_build -t . -p "*_test.py"` — 622 tests green (was 611; new `lib/notify_test.py` covers success/failure/interrupt sequences, artifact links incl. malformed-data degradation, phase math, duration formatting, webhook-absent no-op, BrowserClaw identity)
- [x] `uv run ruff check bos_build` — clean
- [x] `uv run browseros build --list` — CLI smoke passes
- [x] Mock-webhook dry-run demonstrates the full message contract (above)
- [x] `grep -rn "notify_pipeline|notify_module|set_build_context|notify=True|get_notifier"` — zero hits
- [ ] Next nightly run posts the new narrative to Slack

🤖 Generated with [Claude Code](https://claude.com/claude-code)
