### PR TITLE
fix(claw-server): tag claude-code MCP entries type:http on write + add-only boot heal

### DIFF
--- a/packages/browseros-agent/apps/claw-server/src/main.ts
+++ b/packages/browseros-agent/apps/claw-server/src/main.ts
@@ -28,6 +28,7 @@ import { logger } from './lib/logger'
 import { migrateMcpUrls } from './lib/migrate-mcp-urls'
 import { setLocalServerUrl } from './local-server-url'
 import { createServer } from './server'
+import { healClaudeCodeBrowserOsHttpTransportTags } from './services/claude-code-heal'
 import { startScreencastPoller } from './services/screencast-poller'
 import { publicMcpUrl } from './shared/mcp-url'
 
@@ -54,6 +55,13 @@ async function start(): Promise<void> {
   const url = `http://${httpServer.hostname}:${httpServer.port}`
   setLocalServerUrl(url)
   logger.info('claw-server listening', { url })
+
+  const healedClaudeCodeTags = await healClaudeCodeBrowserOsHttpTransportTags()
+  if (healedClaudeCodeTags > 0) {
+    logger.info('healed Claude Code BrowserOS MCP transport tags', {
+      healed: healedClaudeCodeTags,
+    })
+  }
 
   // Attach to the BrowserOS Chromium so MCP `tools/call` dispatches
   // hit a real browser. The bootstrap soft-fails when BrowserOS is

--- a/packages/browseros-agent/apps/claw-server/src/services/claude-code-heal.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/claude-code-heal.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { ensureClaudeCodeHttpTransportTag } from '@browseros/shared/mcp/claude-code-transport-tag'
+import type { LoggerInterface } from '@browseros/shared/types/logger'
+import { resolveAgentMcpConfigPath } from 'agent-mcp-manager'
+import { logger } from '../lib/logger'
+
+const CLAUDE_CODE_BROWSEROS_SERVER_NAMES = ['BrowserClaw', 'browseros'] as const
+const LOCAL_BROWSEROS_MCP_URL = /^http:\/\/127\.0\.0\.1:\d+\/mcp$/
+
+export interface HealClaudeCodeBrowserOsHttpTransportTagsOptions {
+  configPath?: string
+  resolveConfigPath?: typeof resolveAgentMcpConfigPath
+  logger?: LoggerInterface
+}
+
+export async function healClaudeCodeBrowserOsHttpTransportTags(
+  options: HealClaudeCodeBrowserOsHttpTransportTagsOptions = {},
+): Promise<number> {
+  const log = options.logger ?? logger
+  try {
+    const configPath =
+      options.configPath ??
+      (await (options.resolveConfigPath ?? resolveAgentMcpConfigPath)(
+        'claude-code',
+        'system',
+      ))
+    let healed = 0
+    for (const serverName of CLAUDE_CODE_BROWSEROS_SERVER_NAMES) {
+      const changed = await ensureClaudeCodeHttpTransportTag({
+        configPath,
+        serverName,
+        expectedUrlPattern: LOCAL_BROWSEROS_MCP_URL,
+        onlyIfMissing: true,
+        logger: log,
+      })
+      if (changed) healed++
+    }
+    return healed
+  } catch (err) {
+    log.warn('Failed to heal Claude Code BrowserOS MCP transport tags', {
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return 0
+  }
+}

--- a/packages/browseros-agent/apps/claw-server/src/services/mcp-relink.ts
+++ b/packages/browseros-agent/apps/claw-server/src/services/mcp-relink.ts
@@ -4,6 +4,7 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
+import { ensureClaudeCodeHttpTransportTag } from '@browseros/shared/mcp/claude-code-transport-tag'
 import type {
   AgentId,
   LinkServerResult,
@@ -11,6 +12,7 @@ import type {
   McpServerLink,
   McpServerSpec,
 } from 'agent-mcp-manager'
+import { logger } from '../lib/logger'
 
 interface RelinkManagedServerOptions {
   mgr: McpManager
@@ -42,22 +44,30 @@ export async function relinkManagedServer({
         configPath: existingLink.configPath,
       })
     }
-    return await mgr.link({
+    const link = await mgr.link({
       serverName,
       agent,
       ...(existingLink ? { configPath: existingLink.configPath } : {}),
       ...(allowOverwrite ? { allowOverwrite } : {}),
     })
+    await tagClaudeCodeHttpEntry(agent, spec, serverName, link.configPath)
+    return link
   } catch (err) {
     if (existingLink && previousSpec) {
       try {
         await mgr.add({ name: serverName, spec: previousSpec })
-        await mgr.link({
+        const restoredLink = await mgr.link({
           serverName,
           agent,
           configPath: existingLink.configPath,
           ...(allowOverwrite ? { allowOverwrite } : {}),
         })
+        await tagClaudeCodeHttpEntry(
+          agent,
+          previousSpec,
+          serverName,
+          restoredLink.configPath,
+        )
       } catch (restoreErr) {
         const relinkMessage = err instanceof Error ? err.message : String(err)
         const restoreMessage =
@@ -69,6 +79,18 @@ export async function relinkManagedServer({
     }
     throw err
   }
+}
+
+async function tagClaudeCodeHttpEntry(
+  agent: AgentId,
+  spec: McpServerSpec,
+  serverName: string,
+  configPath: string | undefined,
+): Promise<void> {
+  if (agent !== 'claude-code' || spec.transport !== 'http' || !configPath) {
+    return
+  }
+  await ensureClaudeCodeHttpTransportTag({ configPath, serverName, logger })
 }
 
 async function findExistingLink(

--- a/packages/browseros-agent/apps/claw-server/tests/services/browseros-connect.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/browseros-connect.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it } from 'bun:test'
-import type { McpServerLink } from 'agent-mcp-manager'
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type { LinkServerOptions, McpServerLink } from 'agent-mcp-manager'
 import { env } from '../../src/env'
 import {
   resetMcpManagerForTesting,
@@ -18,6 +21,17 @@ function stubWithLinks(links: McpServerLink[]) {
   const stub = createStubMcpManager()
   stub.listLinks = async () => links
   return stub
+}
+
+async function withTempConfig<T>(
+  run: (path: string) => Promise<T>,
+): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), 'claw-claude-code-connect-'))
+  try {
+    return await run(join(dir, '.claude.json'))
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
 }
 
 describe('connectBrowserosToHarness', () => {
@@ -60,6 +74,64 @@ describe('connectBrowserosToHarness', () => {
     expect((link?.payload as { allowOverwrite?: boolean }).allowOverwrite).toBe(
       true,
     )
+  })
+
+  it('adds type http to the Claude Code entry after connect and stays idempotent on reconnect', async () => {
+    await withTempConfig(async (configPath) => {
+      const stub = createStubMcpManager()
+      stub.link = async (opts: LinkServerOptions) => {
+        stub.calls.push({ method: 'link', payload: opts })
+        await writeFile(
+          configPath,
+          JSON.stringify(
+            {
+              mcpServers: {
+                [opts.serverName]: {
+                  url: 'http://127.0.0.1:9200/mcp',
+                },
+              },
+            },
+            null,
+            2,
+          ) + '\n',
+          'utf8',
+        )
+        return {
+          serverName: opts.serverName,
+          agent: opts.agent,
+          configPath,
+          created: true,
+        }
+      }
+      setMcpManagerForTesting(stub)
+
+      await expect(
+        connectBrowserosToHarness('Claude Code'),
+      ).resolves.toMatchObject({
+        installed: true,
+        agentId: 'claude-code',
+        configPath,
+      })
+
+      const first = await readFile(configPath, 'utf8')
+      expect(JSON.parse(first)).toEqual({
+        mcpServers: {
+          BrowserClaw: {
+            url: 'http://127.0.0.1:9200/mcp',
+            type: 'http',
+          },
+        },
+      })
+
+      await expect(
+        connectBrowserosToHarness('Claude Code'),
+      ).resolves.toMatchObject({
+        installed: true,
+        agentId: 'claude-code',
+        configPath,
+      })
+      await expect(readFile(configPath, 'utf8')).resolves.toBe(first)
+    })
   })
 
   it('writes a direct HTTP spec for Codex (http-capable since agent-mcp-manager 0.0.3)', async () => {

--- a/packages/browseros-agent/apps/claw-server/tests/services/browseros-connect.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/browseros-connect.test.ts
@@ -83,7 +83,7 @@ describe('connectBrowserosToHarness', () => {
         stub.calls.push({ method: 'link', payload: opts })
         await writeFile(
           configPath,
-          JSON.stringify(
+          `${JSON.stringify(
             {
               mcpServers: {
                 [opts.serverName]: {
@@ -93,7 +93,7 @@ describe('connectBrowserosToHarness', () => {
             },
             null,
             2,
-          ) + '\n',
+          )}\n`,
           'utf8',
         )
         return {

--- a/packages/browseros-agent/apps/claw-server/tests/services/claude-code-heal.test.ts
+++ b/packages/browseros-agent/apps/claw-server/tests/services/claude-code-heal.test.ts
@@ -1,0 +1,152 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { describe, expect, test } from 'bun:test'
+import { mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { healClaudeCodeBrowserOsHttpTransportTags } from '../../src/services/claude-code-heal'
+
+async function withTempConfig<T>(
+  run: (path: string) => Promise<T>,
+): Promise<T> {
+  const dir = await mkdtemp(join(tmpdir(), 'claw-claude-code-heal-'))
+  try {
+    return await run(join(dir, '.claude.json'))
+  } finally {
+    await rm(dir, { recursive: true, force: true })
+  }
+}
+
+describe('healClaudeCodeBrowserOsHttpTransportTags', () => {
+  test('adds type http to both known BrowserOS local URL entries without removing either name', async () => {
+    await withTempConfig(async (configPath) => {
+      const before = `{
+  "theme": "dark",
+  "mcpServers": {
+    "browseros": {
+      "url": "http://127.0.0.1:9100/mcp"
+    },
+    "BrowserClaw": {
+      "url": "http://127.0.0.1:9200/mcp"
+    },
+    "browseros-stdio": {
+      "command": "npx",
+      "args": ["mcp-remote", "http://127.0.0.1:9200/mcp"]
+    },
+    "other": {
+      "url": "http://127.0.0.1:9200/mcp"
+    }
+  },
+  "history": ["keep"]
+}
+`
+      const expected = `{
+  "theme": "dark",
+  "mcpServers": {
+    "browseros": {
+      "url": "http://127.0.0.1:9100/mcp",
+      "type": "http"
+    },
+    "BrowserClaw": {
+      "url": "http://127.0.0.1:9200/mcp",
+      "type": "http"
+    },
+    "browseros-stdio": {
+      "command": "npx",
+      "args": ["mcp-remote", "http://127.0.0.1:9200/mcp"]
+    },
+    "other": {
+      "url": "http://127.0.0.1:9200/mcp"
+    }
+  },
+  "history": ["keep"]
+}
+`
+      await writeFile(configPath, before, 'utf8')
+
+      await expect(
+        healClaudeCodeBrowserOsHttpTransportTags({ configPath }),
+      ).resolves.toBe(2)
+
+      const after = await readFile(configPath, 'utf8')
+      expect(after).toBe(expected)
+      const parsed = JSON.parse(after)
+      expect(Object.keys(parsed.mcpServers)).toEqual([
+        'browseros',
+        'BrowserClaw',
+        'browseros-stdio',
+        'other',
+      ])
+      expect(parsed.mcpServers.browseros.type).toBe('http')
+      expect(parsed.mcpServers.BrowserClaw.type).toBe('http')
+      expect(parsed.mcpServers['browseros-stdio']).toEqual({
+        command: 'npx',
+        args: ['mcp-remote', 'http://127.0.0.1:9200/mcp'],
+      })
+      expect(parsed.mcpServers.other).toEqual({
+        url: 'http://127.0.0.1:9200/mcp',
+      })
+    })
+  })
+
+  test('does not write when known entries are already correct', async () => {
+    await withTempConfig(async (configPath) => {
+      const source = `{
+  "mcpServers": {
+    "BrowserClaw": {
+      "type": "http",
+      "url": "http://127.0.0.1:9200/mcp"
+    },
+    "browseros": {
+      "url": "http://127.0.0.1:9100/mcp",
+      "type": "http"
+    }
+  }
+}
+`
+      await writeFile(configPath, source, 'utf8')
+      const beforeStat = await stat(configPath)
+
+      await new Promise((resolve) => setTimeout(resolve, 20))
+      await expect(
+        healClaudeCodeBrowserOsHttpTransportTags({ configPath }),
+      ).resolves.toBe(0)
+
+      await expect(readFile(configPath, 'utf8')).resolves.toBe(source)
+      expect((await stat(configPath)).mtimeMs).toBe(beforeStat.mtimeMs)
+    })
+  })
+
+  test('ignores foreign names, non-local URLs, and entries that already declare a type', async () => {
+    await withTempConfig(async (configPath) => {
+      const source = `{
+  "mcpServers": {
+    "ForeignClaw": {
+      "url": "http://127.0.0.1:9200/mcp"
+    },
+    "BrowserClaw": {
+      "url": "https://example.com/mcp"
+    },
+    "browseros": {
+      "type": "sse",
+      "url": "http://127.0.0.1:9100/mcp"
+    },
+    "browseros-stdio": {
+      "command": "npx"
+    }
+  }
+}
+`
+      await writeFile(configPath, source, 'utf8')
+
+      await expect(
+        healClaudeCodeBrowserOsHttpTransportTags({ configPath }),
+      ).resolves.toBe(0)
+      await expect(readFile(configPath, 'utf8')).resolves.toBe(source)
+    })
+  })
+})

--- a/packages/browseros-agent/apps/server/src/lib/mcp-manager/transport-tag.ts
+++ b/packages/browseros-agent/apps/server/src/lib/mcp-manager/transport-tag.ts
@@ -4,26 +4,10 @@
  * SPDX-License-Identifier: AGPL-3.0-or-later
  */
 
-import { promises as fs } from 'node:fs'
-import { basename, dirname, join } from 'node:path'
+import { ensureClaudeCodeHttpTransportTag as ensureSharedClaudeCodeHttpTransportTag } from '@browseros/shared/mcp/claude-code-transport-tag'
 import { resolveAgentMcpConfigPath } from 'agent-mcp-manager'
-import {
-  applyEdits,
-  findNodeAtLocation,
-  getNodeValue,
-  modify,
-  type ParseError,
-  parseTree,
-} from 'jsonc-parser'
 import { logger } from '../logger'
 import { BROWSEROS_MCP_SERVER_NAME } from './manager'
-
-const FORMATTING = {
-  formattingOptions: {
-    insertSpaces: true,
-    tabSize: 2,
-  },
-}
 
 export interface EnsureClaudeCodeHttpTransportTagOptions {
   configPath?: string
@@ -38,85 +22,16 @@ export async function ensureClaudeCodeHttpTransportTag(
     const configPath =
       options.configPath ??
       (await resolveAgentMcpConfigPath('claude-code', 'system'))
-    const source = await readConfig(configPath)
-    if (source === null) {
-      logger.debug('Claude Code MCP config missing; skipping transport tag', {
-        configPath,
-        serverName,
-      })
-      return false
-    }
-
-    const parseErrors: ParseError[] = []
-    const tree = parseTree(source, parseErrors, { allowTrailingComma: true })
-    if (!tree || parseErrors.length > 0) {
-      logger.warn('Claude Code MCP config is not valid JSON; skipped tag', {
-        configPath,
-        serverName,
-      })
-      return false
-    }
-
-    const entryNode = findNodeAtLocation(tree, ['mcpServers', serverName])
-    if (entryNode?.type !== 'object') {
-      logger.debug('Claude Code BrowserOS MCP entry missing; skipping tag', {
-        configPath,
-        serverName,
-      })
-      return false
-    }
-
-    const typeNode = findNodeAtLocation(tree, [
-      'mcpServers',
+    return await ensureSharedClaudeCodeHttpTransportTag({
+      configPath,
       serverName,
-      'type',
-    ])
-    if (typeNode && getNodeValue(typeNode) === 'http') return false
-
-    const edits = modify(
-      source,
-      ['mcpServers', serverName, 'type'],
-      'http',
-      FORMATTING,
-    )
-    if (edits.length === 0) return false
-
-    await atomicWrite(configPath, applyEdits(source, edits))
-    return true
+      logger,
+    })
   } catch (err) {
     logger.warn('Failed to ensure Claude Code MCP transport tag', {
       serverName,
       error: err instanceof Error ? err.message : String(err),
     })
     return false
-  }
-}
-
-async function readConfig(configPath: string): Promise<string | null> {
-  try {
-    return await fs.readFile(configPath, 'utf8')
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null
-    throw err
-  }
-}
-
-async function atomicWrite(
-  configPath: string,
-  contents: string,
-): Promise<void> {
-  const dir = dirname(configPath)
-  const tmp = join(
-    dir,
-    `.${basename(configPath)}.tmp-${process.pid}-${Date.now()}-${Math.random()
-      .toString(16)
-      .slice(2)}`,
-  )
-  try {
-    await fs.writeFile(tmp, contents, 'utf8')
-    await fs.rename(tmp, configPath)
-  } catch (err) {
-    await fs.unlink(tmp).catch(() => {})
-    throw err
   }
 }

--- a/packages/browseros-agent/apps/server/tests/lib/mcp-manager/transport-tag.test.ts
+++ b/packages/browseros-agent/apps/server/tests/lib/mcp-manager/transport-tag.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, it } from 'bun:test'
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { ensureClaudeCodeHttpTransportTag as ensureSharedClaudeCodeHttpTransportTag } from '@browseros/shared/mcp/claude-code-transport-tag'
 import { ensureClaudeCodeHttpTransportTag } from '../../../src/lib/mcp-manager/transport-tag'
 
 async function withTempConfig<T>(
@@ -101,6 +102,76 @@ describe('ensureClaudeCodeHttpTransportTag', () => {
       await expect(
         ensureClaudeCodeHttpTransportTag({ configPath }),
       ).resolves.toBe(false)
+    })
+  })
+
+  it('shared utility requires the expected URL pattern when supplied', async () => {
+    await withTempConfig(async (configPath) => {
+      const before = `{
+  "mcpServers": {
+    "BrowserClaw": {
+      "url": "https://example.com/mcp"
+    }
+  }
+}
+`
+      const expected = `{
+  "mcpServers": {
+    "BrowserClaw": {
+      "url": "http://127.0.0.1:9200/mcp",
+      "type": "http"
+    }
+  }
+}
+`
+      await writeFile(configPath, before, 'utf8')
+
+      await expect(
+        ensureSharedClaudeCodeHttpTransportTag({
+          configPath,
+          serverName: 'BrowserClaw',
+          expectedUrlPattern: /^http:\/\/127\.0\.0\.1:\d+\/mcp$/,
+        }),
+      ).resolves.toBe(false)
+      await expect(readFile(configPath, 'utf8')).resolves.toBe(before)
+
+      await writeFile(
+        configPath,
+        before.replace('https://example.com/mcp', 'http://127.0.0.1:9200/mcp'),
+        'utf8',
+      )
+      await expect(
+        ensureSharedClaudeCodeHttpTransportTag({
+          configPath,
+          serverName: 'BrowserClaw',
+          expectedUrlPattern: /^http:\/\/127\.0\.0\.1:\d+\/mcp$/,
+        }),
+      ).resolves.toBe(true)
+      await expect(readFile(configPath, 'utf8')).resolves.toBe(expected)
+    })
+  })
+
+  it('shared utility can add only missing type fields', async () => {
+    await withTempConfig(async (configPath) => {
+      const source = `{
+  "mcpServers": {
+    "BrowserClaw": {
+      "type": "sse",
+      "url": "http://127.0.0.1:9200/mcp"
+    }
+  }
+}
+`
+      await writeFile(configPath, source, 'utf8')
+
+      await expect(
+        ensureSharedClaudeCodeHttpTransportTag({
+          configPath,
+          serverName: 'BrowserClaw',
+          onlyIfMissing: true,
+        }),
+      ).resolves.toBe(false)
+      await expect(readFile(configPath, 'utf8')).resolves.toBe(source)
     })
   })
 })

--- a/packages/browseros-agent/bun.lock
+++ b/packages/browseros-agent/bun.lock
@@ -341,6 +341,7 @@
       "name": "@browseros/shared",
       "version": "0.0.1",
       "dependencies": {
+        "jsonc-parser": "^3.3.1",
         "zod": "^3.25.76",
       },
     },

--- a/packages/browseros-agent/packages/shared/package.json
+++ b/packages/browseros-agent/packages/shared/package.json
@@ -6,6 +6,7 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "jsonc-parser": "^3.3.1",
     "zod": "^3.25.76"
   },
   "exports": {
@@ -56,6 +57,10 @@
     "./schemas/browser-context": {
       "types": "./src/schemas/browser-context.ts",
       "default": "./src/schemas/browser-context.ts"
+    },
+    "./mcp/claude-code-transport-tag": {
+      "types": "./src/mcp/claude-code-transport-tag.ts",
+      "default": "./src/mcp/claude-code-transport-tag.ts"
     },
     "./schemas/sidecar-config": {
       "types": "./src/schemas/sidecar-config.ts",

--- a/packages/browseros-agent/packages/shared/src/mcp/claude-code-transport-tag.ts
+++ b/packages/browseros-agent/packages/shared/src/mcp/claude-code-transport-tag.ts
@@ -1,0 +1,150 @@
+/**
+ * @license
+ * Copyright 2025 BrowserOS
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */
+
+import { promises as fs } from 'node:fs'
+import { basename, dirname, join } from 'node:path'
+import {
+  applyEdits,
+  findNodeAtLocation,
+  getNodeValue,
+  modify,
+  type ParseError,
+  parseTree,
+} from 'jsonc-parser'
+import type { LoggerInterface } from '../types/logger'
+
+const FORMATTING = {
+  formattingOptions: {
+    insertSpaces: true,
+    tabSize: 2,
+  },
+}
+
+export interface EnsureClaudeCodeHttpTransportTagOptions {
+  configPath: string
+  serverName: string
+  expectedUrl?: string
+  expectedUrlPattern?: RegExp
+  onlyIfMissing?: boolean
+  logger?: LoggerInterface
+}
+
+export async function ensureClaudeCodeHttpTransportTag({
+  configPath,
+  serverName,
+  expectedUrl,
+  expectedUrlPattern,
+  onlyIfMissing = false,
+  logger,
+}: EnsureClaudeCodeHttpTransportTagOptions): Promise<boolean> {
+  try {
+    const source = await readConfig(configPath)
+    if (source === null) {
+      logger?.debug('Claude Code MCP config missing; skipping transport tag', {
+        configPath,
+        serverName,
+      })
+      return false
+    }
+
+    const parseErrors: ParseError[] = []
+    const tree = parseTree(source, parseErrors, { allowTrailingComma: true })
+    if (!tree || parseErrors.length > 0) {
+      logger?.warn('Claude Code MCP config is not valid JSON; skipped tag', {
+        configPath,
+        serverName,
+      })
+      return false
+    }
+
+    const entryNode = findNodeAtLocation(tree, ['mcpServers', serverName])
+    if (entryNode?.type !== 'object') {
+      logger?.debug('Claude Code MCP entry missing; skipping tag', {
+        configPath,
+        serverName,
+      })
+      return false
+    }
+
+    const typeNode = findNodeAtLocation(tree, [
+      'mcpServers',
+      serverName,
+      'type',
+    ])
+    if (typeNode && (onlyIfMissing || getNodeValue(typeNode) === 'http')) {
+      return false
+    }
+
+    if (expectedUrl !== undefined || expectedUrlPattern !== undefined) {
+      const urlNode = findNodeAtLocation(tree, [
+        'mcpServers',
+        serverName,
+        'url',
+      ])
+      const url = urlNode?.type === 'string' ? getNodeValue(urlNode) : null
+      if (
+        typeof url !== 'string' ||
+        (expectedUrl !== undefined && url !== expectedUrl) ||
+        (expectedUrlPattern !== undefined && !expectedUrlPattern.test(url))
+      ) {
+        logger?.debug(
+          'Claude Code MCP entry URL mismatch; skipping transport tag',
+          {
+            configPath,
+            serverName,
+          },
+        )
+        return false
+      }
+    }
+
+    const edits = modify(
+      source,
+      ['mcpServers', serverName, 'type'],
+      'http',
+      FORMATTING,
+    )
+    if (edits.length === 0) return false
+
+    await atomicWrite(configPath, applyEdits(source, edits))
+    return true
+  } catch (err) {
+    logger?.warn('Failed to ensure Claude Code MCP transport tag', {
+      serverName,
+      error: err instanceof Error ? err.message : String(err),
+    })
+    return false
+  }
+}
+
+async function readConfig(configPath: string): Promise<string | null> {
+  try {
+    return await fs.readFile(configPath, 'utf8')
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null
+    throw err
+  }
+}
+
+async function atomicWrite(
+  configPath: string,
+  contents: string,
+): Promise<void> {
+  const dir = dirname(configPath)
+  const tmp = join(
+    dir,
+    `.${basename(configPath)}.tmp-${process.pid}-${Date.now()}-${Math.random()
+      .toString(16)
+      .slice(2)}`,
+  )
+  try {
+    await fs.writeFile(tmp, contents, 'utf8')
+    await fs.rename(tmp, configPath)
+  } catch (err) {
+    await fs.unlink(tmp).catch(() => {})
+    throw err
+  }
+}


### PR DESCRIPTION
## Summary
- Fixes Claude Code MCP config entries written by claw-server so HTTP entries include `type: "http"` instead of being silently treated as invalid stdio entries.
- Tags the just-linked Claude Code HTTP entry at the `relinkManagedServer` choke point, so both Connect and profile installs are covered using the actual `serverName` that was written.
- Adds an add-only startup heal for existing Claude Code `BrowserClaw`/`browseros` entries that point at local BrowserOS `/mcp` URLs and are missing `type`.

## Scope
- Deliberately does **not** sweep, rename, delete, merge, or canonicalize MCP entries.
- Multiple BrowserOS entries such as `browseros` and `BrowserClaw` may coexist; this preserves the maintainer decision after reverted #1578/#1579.
- Does not touch `browseros-stdio`, command/stdio entries, foreign names, entries with any existing `type`, or BrowserOS-named entries pointing elsewhere.

## Test plan
- [x] `cd packages/browseros-agent/apps/claw-server && bun test`
- [x] `cd packages/browseros-agent/apps/server && bunx bun@1.3.6 run test:all`
- [x] `cd packages/browseros-agent/apps/claw-server && bun run typecheck`
- [x] `cd packages/browseros-agent/packages/shared && bun run typecheck`
- [x] `cd packages/browseros-agent && bunx @biomejs/biome check apps/claw-server/src/main.ts apps/claw-server/src/services/claude-code-heal.ts apps/claw-server/src/services/mcp-relink.ts apps/claw-server/tests/services/browseros-connect.test.ts apps/claw-server/tests/services/claude-code-heal.test.ts apps/server/src/lib/mcp-manager/transport-tag.ts apps/server/tests/lib/mcp-manager/transport-tag.test.ts packages/shared/package.json packages/shared/src/mcp/claude-code-transport-tag.ts`
- [x] `git diff --check origin/main..HEAD`
