### PR TITLE
fix(bos_build): create appimagetool dir with parents on fresh checkouts

### DIFF
--- a/packages/browseros/bos_build/steps/package/linux.py
+++ b/packages/browseros/bos_build/steps/package/linux.py
@@ -367,7 +367,9 @@ def download_appimagetool(ctx: Context) -> Optional[Path]:
     arch is communicated via the ARCH env var in create_appimage().
     """
     tool_dir = Path(join_paths(ctx.root_dir, "build", "tools"))
-    tool_dir.mkdir(exist_ok=True)
+    # build/ left the repo in the bos_build refactor (#1499) — on a fresh CI
+    # checkout the parent doesn't exist, so create the whole chain.
+    tool_dir.mkdir(parents=True, exist_ok=True)
 
     tool_filename, url = get_host_appimagetool()
     tool_path = Path(join_paths(tool_dir, tool_filename))


### PR DESCRIPTION
Both linux builds in run 28746161022 compiled all ~57k targets and then died in `package_linux`: `[Errno 2] No such file or directory: 'packages/browseros/build/tools'`. The `build/` tree left the repo in the #1499 bos_build refactor (same family as the nightly bump-script path, #1582); on developer machines the leftover untracked dir masks it, on a fresh CI checkout `mkdir(exist_ok=True)` has no parent. `parents=True` fixes it. Sibling `mkdir(exist_ok=True)` sites checked — all create dirs under parents that exist by construction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)