### PR TITLE
fix(bos_build): winsparkle_setup on all windows release builds

### DIFF
--- a/packages/browseros/bos_build/core/planner.py
+++ b/packages/browseros/bos_build/core/planner.py
@@ -181,7 +181,11 @@ def _plan_release(switches: Switches, platform: str) -> List[str]:
     steps.extend(_provision_steps(switches))
     if platform == "macos":
         steps.append("sparkle_setup")
-    if platform == "windows" and switches.sign:
+    if platform == "windows":
+        # The release GN config always links WinSparkle.dll — the compile
+        # needs the vendored library whether or not the build is signed
+        # (ninja: 'third_party/winsparkle/x64/Release/WinSparkle.dll'
+        # missing and no known rule to make it).
         steps.append("winsparkle_setup")
 
     if switches.download:

--- a/packages/browseros/bos_build/core/planner_test.py
+++ b/packages/browseros/bos_build/core/planner_test.py
@@ -170,10 +170,12 @@ class CiGoldenTest(unittest.TestCase):
         )
 
     def test_windows_ci_swaps_sign_for_mini_installer(self):
-        # release.windows.ci.yaml — no winsparkle_setup, no sparkle_sign
+        # release.windows.ci.yaml — no sparkle_sign; winsparkle_setup stays
+        # (the release GN config links WinSparkle.dll even unsigned)
         self.assertEqual(
             plan(CI, "x64", "windows"),
             [
+                "winsparkle_setup",
                 "download_resources",
                 "resources",
                 "bundled_extensions",


### PR DESCRIPTION
Windows unsigned release build (run 28747572792) got through the cache-restore fixes and then failed at compile: `ninja: error: '../../third_party/winsparkle/x64/Release/WinSparkle.dll', needed by 'WinSparkle.dll', missing and no known rule to make it`. The planner gated `winsparkle_setup` on `sign=true`, but the release GN config links WinSparkle unconditionally — the vendored library is a compile dependency, not a signing one. The step only downloads the WinSparkle release zip (no secrets). This also explains the June 13 nightly windows failure — the unsigned windows lane never had a green run.

625 tests + ruff green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)