### PR TITLE
fix(ci): never CRLF-convert chromium-destined trees

### DIFF
--- a/packages/browseros/.gitattributes
+++ b/packages/browseros/.gitattributes
@@ -2,3 +2,10 @@
 resources/binaries/browseros_server/* filter=lfs diff=lfs merge=lfs -text
 resources/binaries/codex/ filter=lfs diff=lfs merge=lfs -text
 resources/binaries/browseros_server/ filter=lfs diff=lfs merge=lfs -text
+
+# Chromium-destined sources must keep LF byte-for-byte: Windows runners'
+# git autocrlf otherwise converts them at checkout and chromium's strict
+# parsers reject the \r (e.g. json_schema_compiler on browser_os.idl).
+chromium_files/** -text
+chromium_patches/** -text
+series_patches/** -text


### PR DESCRIPTION
Windows take 5 (run 28749156575) got past cache restore and WinSparkle, then compile failed in chromium codegen: `browser_os.idl(5): Scanning error. Illegal character '\r'` (same for side_panel.idl). The Windows runner's git autocrlf converts the BrowserOS-supplied chromium sources at checkout; `chromium_replace`/patches then copy CRLF files into the chromium tree whose strict parsers reject them. Mark `chromium_files/`, `chromium_patches/`, and `series_patches/` as `-text` so no platform ever rewrites them. Linux/mac unaffected (already LF).

🤖 Generated with [Claude Code](https://claude.com/claude-code)