### PR TITLE
chore(ci): group workflow display names by Release/Nightly/Reusable prefix

### DIFF
--- a/.github/workflows/build-browseros.yml
+++ b/.github/workflows/build-browseros.yml
@@ -1,4 +1,4 @@
-name: BrowserOS Chromium Build
+name: "Reusable: Chromium Browser Build"
 
 # Reusable WarpBuild job for one Chromium browser build. The Chromium checkout
 # cache is product-independent on purpose: it is captured immediately after

--- a/.github/workflows/nightly-macos-build.yml
+++ b/.github/workflows/nightly-macos-build.yml
@@ -1,4 +1,4 @@
-name: Nightly macOS Build
+name: "Nightly: macOS Browser (signed, self-hosted)"
 
 on:
   schedule:

--- a/.github/workflows/nightly-release.yml
+++ b/.github/workflows/nightly-release.yml
@@ -1,4 +1,4 @@
-name: Nightly Release Build
+name: "Nightly: All-Platform Browser (unsigned)"
 
 # Manual UNSIGNED release builds of BrowserOS for all three platforms on
 # WarpBuild runners. The shared Chromium/WarpBuild recipe lives in

--- a/.github/workflows/release-agent-extension.yml
+++ b/.github/workflows/release-agent-extension.yml
@@ -1,4 +1,4 @@
-name: Release BrowserOS Extension
+name: "Release: Agent Extension"
 
 on:
   push:

--- a/.github/workflows/release-claw-server.yml
+++ b/.github/workflows/release-claw-server.yml
@@ -1,7 +1,7 @@
 # Required secrets for resource publishing: R2_ACCOUNT_ID, R2_ACCESS_KEY_ID,
 # R2_SECRET_ACCESS_KEY, R2_BUCKET. Optional when publish_ota is true:
 # SPARKLE_PRIVATE_KEY.
-name: Release BrowserClaw Server
+name: "Release: BrowserClaw Server + Onboard"
 
 on:
   push:

--- a/.github/workflows/release-cli.yml
+++ b/.github/workflows/release-cli.yml
@@ -1,4 +1,4 @@
-name: Release BrowserOS CLI
+name: "Release: CLI"
 
 on:
   push:

--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -1,4 +1,4 @@
-name: Release Extensions
+name: "Release: Extensions (CRX + feeds)"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-full.yml
+++ b/.github/workflows/release-full.yml
@@ -8,7 +8,7 @@
 #   uv run browseros release appcast --version <version> --product browseros --publish
 #   uv run browseros release publish --version <version> --product browserclaw
 #   uv run browseros release appcast --version <version> --product browserclaw --publish
-name: Release Full
+name: "Release: Full (servers + browsers)"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-linux.yml
+++ b/.github/workflows/release-linux.yml
@@ -1,4 +1,4 @@
-name: Release Linux
+name: "Release: Linux Browser"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,4 +1,4 @@
-name: Release macOS Build
+name: "Release: macOS Browser (signed, self-hosted)"
 
 on:
   workflow_dispatch:

--- a/.github/workflows/release-server.yml
+++ b/.github/workflows/release-server.yml
@@ -2,7 +2,7 @@
 # R2_SECRET_ACCESS_KEY, R2_BUCKET, BROWSEROS_CONFIG_URL, POSTHOG_API_KEY,
 # SENTRY_DSN. Optional: AGENT_RUNNER_JWT_SECRET (inlined when present),
 # SPARKLE_PRIVATE_KEY (required only when publish_ota is true).
-name: Release BrowserOS Server
+name: "Release: BrowserOS Server"
 
 on:
   push:

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -1,4 +1,4 @@
-name: Release Windows
+name: "Release: Windows Browser"
 
 on:
   workflow_dispatch:

--- a/packages/browseros-agent/apps/app/README.md
+++ b/packages/browseros-agent/apps/app/README.md
@@ -142,7 +142,7 @@ GRAPHQL_SCHEMA_PATH=/path/to/api-repo/.../schema.graphql
 
 ## Release Flow
 
-Extension releases use annotated component tags. For the usual path, run the `Release BrowserOS Extension` workflow manually with the target version, for example `0.0.119`. The workflow bumps `packages/browseros-agent/apps/app/package.json`, updates the matching `bun.lock` workspace entry, commits that bump to the default branch, creates `agent-extension/vX.Y.Z`, and publishes the GitHub Release.
+Extension releases use annotated component tags. For the usual path, run the `Release: Agent Extension` workflow manually with the target version, for example `0.0.119`. The workflow bumps `packages/browseros-agent/apps/app/package.json`, updates the matching `bun.lock` workspace entry, commits that bump to the default branch, creates `agent-extension/vX.Y.Z`, and publishes the GitHub Release.
 
 To release from an existing version commit instead, tag the merged default-branch commit manually:
 

--- a/packages/browseros/bos_build/cli/ota.py
+++ b/packages/browseros/bos_build/cli/ota.py
@@ -92,7 +92,7 @@ def server_release(
         "browseros", "--product", help="Product whose server bundle to release"
     ),
 ):
-    """Release BrowserOS Server OTA update
+    """Publish BrowserOS server OTA update
 
     Downloads server binaries from R2 (artifacts/server/latest/),
     signs them, creates Sparkle update packages, and uploads to R2.

--- a/packages/browseros/bos_build/docs/nightly-macos-ci.md
+++ b/packages/browseros/bos_build/docs/nightly-macos-ci.md
@@ -164,8 +164,9 @@ packaging, then skips the R2 resource download module for that build run.
 
 ## Manual Branch Build
 
-Open Actions, choose `Nightly macOS Build`, click `Run workflow`, select the
-branch in GitHub's native branch picker, then set inputs:
+Open Actions, choose `Nightly: macOS Browser (signed, self-hosted)`, click
+`Run workflow`, select the branch in GitHub's native branch picker, then set
+inputs:
 
 - `bump`: `offset-only`, `offset+build`, `offset+patch`, or `none`
 - `commit_version`: commit and push the bumped version files

--- a/packages/browseros/bos_build/docs/nightly-warpbuild-ci.md
+++ b/packages/browseros/bos_build/docs/nightly-warpbuild-ci.md
@@ -1,11 +1,12 @@
 # Nightly WarpBuild Release Builds
 
-`.github/workflows/nightly-release.yml` builds UNSIGNED release artifacts for
-Linux x64, Windows x64, and macOS arm64 every night on WarpBuild cloud
-runners, uploads them to the Actions run, and refreshes a rolling `nightly`
-prerelease on GitHub. Its per-platform build job delegates to the reusable
-Chromium build workflow in `.github/workflows/build-browseros.yml`, so the
-WarpBuild checkout/cache/build recipe is shared with the release workflows.
+`.github/workflows/nightly-release.yml` (`Nightly: All-Platform Browser
+(unsigned)`) builds UNSIGNED release artifacts for Linux x64, Windows x64, and
+macOS arm64 every night on WarpBuild cloud runners, uploads them to the Actions
+run, and refreshes a rolling `nightly` prerelease on GitHub. Its per-platform
+build job delegates to the reusable Chromium build workflow in
+`.github/workflows/build-browseros.yml`, so the WarpBuild checkout/cache/build
+recipe is shared with the release workflows.
 It complements (does not replace) the signed self-hosted macOS nightly in
 `nightly-macos-build.yml`; once signing is wired up here, that workflow can
 be retired.
@@ -77,8 +78,8 @@ leaves `queued`:
    an active account.
 
 Smoke test after changing either:
-`gh workflow run "Nightly Release Build" -f platforms=linux`, then watch
-the build job leave `queued` within ~5 minutes (`gh run watch`).
+`gh workflow run nightly-release.yml -f platforms=linux`, then watch the build
+job leave `queued` within ~5 minutes (`gh run watch`).
 
 ## Per-night pipeline (per platform)
 
@@ -180,13 +181,13 @@ the build step. To enable signing:
 
 ```bash
 # Full run on all platforms (no prerelease update):
-gh workflow run "Nightly Release Build"
+gh workflow run nightly-release.yml
 
 # One platform while iterating:
-gh workflow run "Nightly Release Build" -f platforms=linux
+gh workflow run nightly-release.yml -f platforms=linux
 
 # Manual run that also refreshes the rolling prerelease (main only):
-gh workflow run "Nightly Release Build" -f publish_nightly=true
+gh workflow run nightly-release.yml -f publish_nightly=true
 ```
 
 The first run per platform is the cache warm-up; expect cold timings. If a

--- a/packages/browseros/bos_build/docs/release-ci.md
+++ b/packages/browseros/bos_build/docs/release-ci.md
@@ -124,8 +124,8 @@ Rules of thumb:
   can take 6 to 20 hours for all products or universal builds.
 - `preempt_nightly=true` cancels only queued or in-progress
   `.github/workflows/nightly-release.yml` runs. It does not cancel
-  `Nightly macOS Build`; the shared `macos-build` concurrency group serializes
-  self-hosted macOS work.
+  `Nightly: macOS Browser (signed, self-hosted)`; the shared `macos-build`
+  concurrency group serializes self-hosted macOS work.
 
 ## Draft GitHub Release
 


### PR DESCRIPTION
## Summary
- Renames the targeted release, nightly, and reusable workflow display names with the requested `Release:`, `Nightly:`, and `Reusable:` prefixes.
- Keeps workflow filenames, job names, concurrency groups, `uses:` paths, artifacts, tag patterns, and the `release-full.yml` nightly preflight filename reference unchanged.
- Updates release/nightly docs and extension release prose; display-name `gh workflow run` examples now use workflow filenames.

## Verification
- `actionlint .github/workflows/release-full.yml .github/workflows/release-linux.yml .github/workflows/release-windows.yml .github/workflows/release-macos.yml .github/workflows/release-server.yml .github/workflows/release-claw-server.yml .github/workflows/release-cli.yml .github/workflows/release-extensions.yml .github/workflows/release-agent-extension.yml .github/workflows/nightly-release.yml .github/workflows/nightly-macos-build.yml .github/workflows/build-browseros.yml`
- `grep -RIn --exclude-dir=.git --exclude-dir=.internal-docs -E 'Release Full|Release Linux|Release Windows|Release macOS Build|Release BrowserOS Server|Release BrowserClaw Server|Release BrowserOS CLI|Release Extensions|Release BrowserOS Extension|Nightly Release Build|Nightly macOS Build|BrowserOS Chromium Build' . || true`

## Final old-name grep output
```text
(no matches)
```