### PR TITLE
feat(rust-port): claw-server-rust scaffold — axum app, domain model, storage, routes (phase C)

### DIFF
--- a/packages/browseros-agent/Cargo.lock
+++ b/packages/browseros-agent/Cargo.lock
@@ -3,10 +3,139 @@
 version = 4
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anyhow"
+version = "1.0.103"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "axum"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
+dependencies = [
+ "axum-core",
+ "bytes",
+ "form_urlencoded",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde_core",
+ "serde_json",
+ "serde_path_to_error",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08c78f31d7b1291f7ee735c1c6780ccde7785daae9a9206026862dab7d8792d1"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
 
 [[package]]
 name = "base64"
@@ -106,6 +235,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "claw-server-rust"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "base64",
+ "browseros-cdp",
+ "browseros-core",
+ "clap",
+ "futures-util",
+ "rusqlite",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror",
+ "time",
+ "tokio",
+ "tokio-util",
+ "toml",
+ "tower",
+ "tracing",
+ "tracing-appender",
+ "tracing-subscriber",
+ "ulid",
+ "url",
+]
+
+[[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -124,6 +327,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -138,6 +356,12 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 
 [[package]]
 name = "digest"
@@ -161,6 +385,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -169,6 +399,24 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -287,6 +535,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.14.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+
+[[package]]
+name = "hashlink"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba4ff7128dee98c7dc9794b6a411377e1404dba1c97deb8d1a55297bd25d8af"
+dependencies = [
+ "hashbrown 0.14.5",
+]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
 name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +604,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
 
 [[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
+
+[[package]]
 name = "hyper"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -338,6 +622,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -488,10 +773,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "indexmap"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
@@ -511,10 +812,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -535,10 +859,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
+name = "matchit"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
 name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "mio"
@@ -552,10 +897,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "percent-encoding"
@@ -570,6 +936,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -577,6 +949,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -729,6 +1107,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -781,10 +1176,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7753b721174eb8ff87a9a0e799e2d7bc3749323e773db92e0984debb00019d6e"
+dependencies = [
+ "bitflags",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b1e7f9a428571be2dc5bc0505c13fb6bf936822b894ec87abf8a08a4e51742d"
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "rustls"
@@ -877,6 +1299,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -897,6 +1339,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.2.17",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -944,10 +1395,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
 
 [[package]]
 name = "syn"
@@ -981,6 +1444,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -998,6 +1474,45 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "time"
+version = "0.3.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18dfaaeddcb932337b5e7866ee7d0ce9b76d2fd092997146f187ec09b4558a50"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
+
+[[package]]
+name = "time-macros"
+version = "0.2.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c431b87111666e491a90baa837f914fb45cd5dc3c268591b0220ff5057f2085f"
+dependencies = [
+ "num-conv",
+ "time-core",
 ]
 
 [[package]]
@@ -1093,6 +1608,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "tower"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1105,6 +1661,7 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -1143,9 +1700,23 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -1166,6 +1737,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -1199,6 +1800,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "ulid"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "470dbf6591da1b39d43c14523b2b469c86879a53e8b758c8e090a470fe7b1fbe"
+dependencies = [
+ "rand 0.9.4",
+ "web-time",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1227,6 +1838,24 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"
@@ -1438,6 +2067,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/packages/browseros-agent/Cargo.toml
+++ b/packages/browseros-agent/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/*"]
+members = ["crates/*", "apps/claw-server-rust"]
 resolver = "3"
 
 [workspace.package]
@@ -12,7 +12,7 @@ repository = "https://github.com/browseros-ai/BrowserOS"
 browseros-cdp = { path = "crates/browseros-cdp" }
 browseros-core = { path = "crates/browseros-core" }
 
-tokio = { version = "1.52", features = ["rt-multi-thread", "macros", "net", "io-util", "time", "sync", "signal", "process"] }
+tokio = { version = "1.52", features = ["rt-multi-thread", "macros", "net", "io-util", "time", "sync", "signal", "process", "fs"] }
 tokio-tungstenite = { version = "0.29", features = ["rustls-tls-webpki-roots"] }
 futures-util = "0.3"
 serde = { version = "1", features = ["derive"] }
@@ -20,16 +20,23 @@ serde_json = "1"
 rmcp = { version = "2.1", features = ["server", "transport-io", "transport-streamable-http-server"] }
 schemars = "1.0"
 axum = "0.8"
-tower = "0.5"
+tower = { version = "0.5", features = ["util"] }
 reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls-webpki-roots"] }
 thiserror = "2"
 anyhow = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-appender = "0.2"
 socket2 = "0.6"
 url = "2"
 base64 = "0.22"
 tokio-util = { version = "0.7", features = ["rt"] }
+clap = { version = "4.5", features = ["derive"] }
+rusqlite = { version = "0.32", features = ["bundled"] }
+ulid = "1.2"
+time = { version = "0.3", features = ["formatting"] }
+tempfile = "3.14"
+toml = "0.8"
 
 [workspace.lints.rust]
 unsafe_code = "deny"

--- a/packages/browseros-agent/apps/claw-server-rust/Cargo.toml
+++ b/packages/browseros-agent/apps/claw-server-rust/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "claw-server-rust"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[[bin]]
+name = "browseros-claw-server-rs"
+path = "src/main.rs"
+
+[dependencies]
+browseros-cdp.workspace = true
+browseros-core.workspace = true
+
+anyhow.workspace = true
+axum.workspace = true
+base64.workspace = true
+clap.workspace = true
+futures-util.workspace = true
+rusqlite.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+thiserror.workspace = true
+time.workspace = true
+tokio.workspace = true
+tokio-util.workspace = true
+toml.workspace = true
+tower.workspace = true
+tracing.workspace = true
+tracing-appender.workspace = true
+tracing-subscriber.workspace = true
+ulid.workspace = true
+url.workspace = true
+
+[dev-dependencies]
+tempfile.workspace = true
+tokio = { workspace = true, features = ["test-util"] }
+
+[lints]
+workspace = true

--- a/packages/browseros-agent/apps/claw-server-rust/src/app.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/app.rs
@@ -1,0 +1,94 @@
+use crate::{
+    config::Config,
+    domain::SessionRegistry,
+    error::AppResult,
+    routes,
+    services::{
+        agents::AgentService, audit::AuditService, browser::BrowserService,
+        harness::HarnessService, replay::ReplayService, screenshots::ScreenshotService,
+        site_rules::SiteRulesService, tab_activity::TabActivityService,
+    },
+    storage::JsonStore,
+};
+use axum::{Router, middleware};
+use std::{env, path::PathBuf, sync::Arc, time::Duration};
+use tokio::sync::{Mutex, oneshot};
+
+#[derive(Clone)]
+pub struct AppState {
+    pub config: Arc<Config>,
+    pub audit: Arc<AuditService>,
+    pub replay: Arc<ReplayService>,
+    pub screenshots: Arc<ScreenshotService>,
+    pub tab_activity: Arc<TabActivityService>,
+    pub harness: Arc<HarnessService>,
+    pub agents: Arc<AgentService>,
+    pub site_rules: Arc<SiteRulesService>,
+    pub sessions: Arc<SessionRegistry>,
+    pub browser: Arc<BrowserService>,
+    pub shutdown: Arc<Mutex<Option<oneshot::Sender<()>>>>,
+}
+
+impl AppState {
+    pub async fn new(
+        config: Arc<Config>,
+        shutdown_tx: Option<oneshot::Sender<()>>,
+    ) -> AppResult<Self> {
+        let home = env::var_os("HOME")
+            .map(PathBuf::from)
+            .unwrap_or_else(|| config.browseros_dir.clone());
+        Self::new_with_home(config, shutdown_tx, home).await
+    }
+
+    pub async fn new_with_home(
+        config: Arc<Config>,
+        shutdown_tx: Option<oneshot::Sender<()>>,
+        home_dir: PathBuf,
+    ) -> AppResult<Self> {
+        tokio::fs::create_dir_all(&config.claw_dir).await?;
+        let store = JsonStore::new(config.claw_dir.clone());
+        let audit = Arc::new(AuditService::open(config.claw_dir.join("audit.sqlite")).await?);
+        let replay = Arc::new(ReplayService::new(
+            config.claw_dir.join("replays"),
+            50,
+            Duration::from_secs(30),
+        ));
+        let screenshots = Arc::new(ScreenshotService::new(config.claw_dir.join("screenshots")));
+        let harness = Arc::new(HarnessService::new(
+            config.claw_dir.join("mcp-manager"),
+            home_dir,
+        ));
+        let agents = Arc::new(AgentService::new(
+            store.clone(),
+            harness.clone(),
+            config.public_mcp_url(),
+        ));
+        let site_rules = Arc::new(SiteRulesService::new(store));
+        let sessions = SessionRegistry::new(
+            audit.clone(),
+            replay.clone(),
+            config.session_idle,
+            config.session_sweep_interval,
+        );
+        let browser = BrowserService::new(config.cdp_port);
+        Ok(Self {
+            config,
+            audit,
+            replay,
+            screenshots,
+            tab_activity: Arc::new(TabActivityService::default()),
+            harness,
+            agents,
+            site_rules,
+            sessions,
+            browser,
+            shutdown: Arc::new(Mutex::new(shutdown_tx)),
+        })
+    }
+}
+
+pub fn build_router(state: AppState) -> Router {
+    routes::router()
+        .with_state(state)
+        .layer(middleware::from_fn(routes::request_context))
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/config.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/config.rs
@@ -1,0 +1,278 @@
+use clap::Parser;
+use serde::Deserialize;
+use std::{
+    collections::BTreeMap,
+    env, fs,
+    num::NonZeroU16,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+
+const DEFAULT_SERVER_PORT: u16 = 9200;
+const DEFAULT_CDP_PORT: u16 = 49337;
+const DEFAULT_SESSION_IDLE_MS: u64 = 5 * 60 * 1000;
+const DEFAULT_SESSION_SWEEP_INTERVAL_MS: u64 = 60 * 1000;
+
+#[derive(Debug, Parser)]
+#[command(name = "browseros-claw-server-rs")]
+pub struct Cli {
+    #[arg(long)]
+    pub config: PathBuf,
+}
+
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub server_port: u16,
+    pub cdp_port: u16,
+    pub proxy_port: Option<u16>,
+    pub resources_dir: PathBuf,
+    pub browseros_dir: PathBuf,
+    pub claw_dir: PathBuf,
+    pub session_idle: Duration,
+    pub session_sweep_interval: Duration,
+    pub screencast_screenshot_fallback: bool,
+    pub dev_mode: bool,
+    pub auth_token: Option<String>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ConfigEnv {
+    vars: BTreeMap<String, String>,
+    home_dir: Option<PathBuf>,
+}
+
+impl ConfigEnv {
+    #[must_use]
+    pub fn from_process() -> Self {
+        Self {
+            vars: env::vars().collect(),
+            home_dir: env::var_os("HOME").map(PathBuf::from),
+        }
+    }
+
+    #[must_use]
+    pub fn with_vars(vars: BTreeMap<String, String>, home_dir: PathBuf) -> Self {
+        Self {
+            vars,
+            home_dir: Some(home_dir),
+        }
+    }
+
+    fn get(&self, key: &str) -> Option<&str> {
+        self.vars.get(key).map(String::as_str)
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct SidecarConfig {
+    #[serde(default)]
+    ports: SidecarPorts,
+    #[serde(default)]
+    directories: SidecarDirectories,
+    #[serde(default)]
+    flags: SidecarFlags,
+    #[serde(default)]
+    auth: SidecarAuth,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SidecarPorts {
+    server: Option<NonZeroU16>,
+    cdp: Option<NonZeroU16>,
+    proxy: Option<NonZeroU16>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SidecarDirectories {
+    resources: Option<PathBuf>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SidecarFlags {
+    dev_mode: Option<bool>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct SidecarAuth {
+    token: Option<String>,
+}
+
+impl Config {
+    pub fn load(path: impl AsRef<Path>) -> anyhow::Result<Self> {
+        Self::load_with_env(path, &ConfigEnv::from_process())
+    }
+
+    pub fn load_with_env(path: impl AsRef<Path>, env: &ConfigEnv) -> anyhow::Result<Self> {
+        let path = path.as_ref();
+        let raw = fs::read_to_string(path)?;
+        let sidecar: SidecarConfig = serde_json::from_str(&raw)?;
+        let cwd = path
+            .parent()
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|| PathBuf::from("."));
+        let server_port = sidecar
+            .ports
+            .server
+            .map(NonZeroU16::get)
+            .unwrap_or(DEFAULT_SERVER_PORT);
+        let cdp_port = sidecar
+            .ports
+            .cdp
+            .map(NonZeroU16::get)
+            .unwrap_or(DEFAULT_CDP_PORT);
+        let proxy_port = sidecar.ports.proxy.map(NonZeroU16::get);
+        let resources_dir = sidecar
+            .directories
+            .resources
+            .map(|path| resolve_path(&cwd, path))
+            .unwrap_or_else(|| cwd.join("resources"));
+        let dev_mode = sidecar.flags.dev_mode.unwrap_or_else(|| {
+            env.get("NODE_ENV")
+                .map(|value| value == "development")
+                .unwrap_or(false)
+        });
+        let browseros_dir = resolve_browseros_dir(env, dev_mode, &cwd);
+        let claw_dir = browseros_dir.join("claw-server");
+        let auth_token = sidecar
+            .auth
+            .token
+            .and_then(|token| clean_string(token.as_str()));
+
+        Ok(Self {
+            server_port,
+            cdp_port,
+            proxy_port,
+            resources_dir,
+            browseros_dir,
+            claw_dir,
+            session_idle: Duration::from_millis(read_positive_ms(
+                env,
+                "CLAW_SESSION_IDLE_MS",
+                DEFAULT_SESSION_IDLE_MS,
+            )),
+            session_sweep_interval: Duration::from_millis(read_positive_ms(
+                env,
+                "CLAW_SESSION_SWEEP_INTERVAL_MS",
+                DEFAULT_SESSION_SWEEP_INTERVAL_MS,
+            )),
+            screencast_screenshot_fallback: read_bool_default_true(
+                env,
+                "CLAW_SCREENCAST_SCREENSHOT_FALLBACK",
+            ),
+            dev_mode,
+            auth_token,
+        })
+    }
+
+    #[must_use]
+    pub fn public_mcp_url(&self) -> String {
+        format!(
+            "http://127.0.0.1:{}/mcp",
+            self.proxy_port.unwrap_or(self.server_port)
+        )
+    }
+
+    #[must_use]
+    pub fn local_server_url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.server_port)
+    }
+}
+
+fn resolve_path(cwd: &Path, path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        path
+    } else {
+        cwd.join(path)
+    }
+}
+
+fn resolve_browseros_dir(env: &ConfigEnv, dev_mode: bool, cwd: &Path) -> PathBuf {
+    if let Some(raw) = env.get("BROWSEROS_DIR").and_then(clean_string) {
+        return PathBuf::from(raw);
+    }
+    let home = env.home_dir.clone().unwrap_or_else(|| cwd.to_path_buf());
+    home.join(if dev_mode {
+        ".browseros-dev"
+    } else {
+        ".browseros"
+    })
+}
+
+fn read_positive_ms(env: &ConfigEnv, key: &str, fallback: u64) -> u64 {
+    let Some(raw) = env.get(key) else {
+        return fallback;
+    };
+    raw.parse::<u64>()
+        .ok()
+        .filter(|value| *value > 0)
+        .unwrap_or(fallback)
+}
+
+fn read_bool_default_true(env: &ConfigEnv, key: &str) -> bool {
+    let Some(raw) = env.get(key) else {
+        return true;
+    };
+    let normalized = raw.trim().to_ascii_lowercase();
+    normalized != "0" && normalized != "false"
+}
+
+fn clean_string(value: &str) -> Option<String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Config, ConfigEnv};
+    use std::{collections::BTreeMap, fs, path::PathBuf, time::Duration};
+    use tempfile::tempdir;
+
+    #[test]
+    fn parses_sidecar_defaults_and_browseros_dir_override() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let config_path = dir.path().join("sidecar.json");
+        fs::write(&config_path, r#"{"ports":{},"directories":{}}"#)?;
+        let mut vars = BTreeMap::new();
+        vars.insert(
+            "BROWSEROS_DIR".to_string(),
+            dir.path().join("browseros").to_string_lossy().to_string(),
+        );
+        vars.insert("CLAW_SESSION_IDLE_MS".to_string(), "1000".to_string());
+        let cfg = Config::load_with_env(
+            &config_path,
+            &ConfigEnv::with_vars(vars, PathBuf::from("/tmp/home")),
+        )?;
+        assert_eq!(cfg.server_port, 9200);
+        assert_eq!(cfg.cdp_port, 49337);
+        assert_eq!(cfg.proxy_port, None);
+        assert_eq!(cfg.session_idle, Duration::from_millis(1000));
+        assert!(cfg.browseros_dir.ends_with("browseros"));
+        assert_eq!(cfg.public_mcp_url(), "http://127.0.0.1:9200/mcp");
+        Ok(())
+    }
+
+    #[test]
+    fn honors_ports_proxy_and_development_dir() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let config_path = dir.path().join("sidecar.json");
+        fs::write(
+            &config_path,
+            r#"{"ports":{"server":9300,"cdp":49338,"proxy":9444},"flags":{"devMode":true}}"#,
+        )?;
+        let cfg = Config::load_with_env(
+            &config_path,
+            &ConfigEnv::with_vars(BTreeMap::new(), dir.path().join("home")),
+        )?;
+        assert_eq!(cfg.server_port, 9300);
+        assert_eq!(cfg.cdp_port, 49338);
+        assert_eq!(cfg.proxy_port, Some(9444));
+        assert!(cfg.browseros_dir.ends_with(".browseros-dev"));
+        assert_eq!(cfg.public_mcp_url(), "http://127.0.0.1:9444/mcp");
+        Ok(())
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/domain/agent_ref.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/domain/agent_ref.rs
@@ -1,0 +1,218 @@
+use crate::{
+    domain::ids::{AgentId, ProfileId, SessionId},
+    services::agents::StoredAgentProfile,
+};
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct ClientInfo {
+    pub name: String,
+    pub version: String,
+    pub title: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "kind", rename_all = "camelCase")]
+pub enum AgentRef {
+    Profile {
+        profile_id: ProfileId,
+        agent_id: AgentId,
+        slug: String,
+        label: String,
+    },
+    Ephemeral {
+        agent_id: AgentId,
+        slug: String,
+        label: String,
+    },
+}
+
+impl AgentRef {
+    #[must_use]
+    pub fn resolve(
+        session_id: &SessionId,
+        client_info: &ClientInfo,
+        profiles: &[StoredAgentProfile],
+    ) -> Self {
+        let client_slug = slugify_client_name(&client_info.name)
+            .unwrap_or_else(|| fallback_slug_for_session(session_id));
+        if let Some(profile) = profiles.iter().find(|profile| {
+            profile.slug == client_slug
+                || names_match(profile.name.as_str(), client_info.name.as_str())
+        }) {
+            return Self::Profile {
+                profile_id: ProfileId::new(profile.id.clone()),
+                agent_id: AgentId::new(format!(
+                    "{}-{}",
+                    profile.slug,
+                    hash_tail(session_id.as_str())
+                )),
+                slug: profile.slug.clone(),
+                label: profile.name.clone(),
+            };
+        }
+        let label = clean_label(&client_info.name).unwrap_or_else(|| client_slug.clone());
+        Self::Ephemeral {
+            agent_id: AgentId::new(format!(
+                "{}-{}",
+                client_slug,
+                hash_tail(session_id.as_str())
+            )),
+            slug: client_slug,
+            label,
+        }
+    }
+
+    #[must_use]
+    pub fn agent_id(&self) -> &AgentId {
+        match self {
+            Self::Profile { agent_id, .. } | Self::Ephemeral { agent_id, .. } => agent_id,
+        }
+    }
+
+    #[must_use]
+    pub fn slug(&self) -> &str {
+        match self {
+            Self::Profile { slug, .. } | Self::Ephemeral { slug, .. } => slug,
+        }
+    }
+
+    #[must_use]
+    pub fn label(&self) -> &str {
+        match self {
+            Self::Profile { label, .. } | Self::Ephemeral { label, .. } => label,
+        }
+    }
+}
+
+#[must_use]
+pub fn slugify_client_name(raw: &str) -> Option<String> {
+    let mut out = String::new();
+    let mut pending_dash = false;
+    for ch in raw.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            if pending_dash && !out.is_empty() {
+                out.push('-');
+            }
+            pending_dash = false;
+            out.push(ch);
+            if out.len() >= 64 {
+                break;
+            }
+        } else {
+            pending_dash = true;
+        }
+    }
+    let trimmed = out.trim_matches('-').to_string();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+fn fallback_slug_for_session(session_id: &SessionId) -> String {
+    format!("unknown-{}", hash_tail(session_id.as_str()))
+}
+
+fn clean_label(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed.to_string())
+    }
+}
+
+fn names_match(profile_name: &str, client_name: &str) -> bool {
+    slugify_client_name(profile_name).as_deref() == slugify_client_name(client_name).as_deref()
+}
+
+fn hash_tail(input: &str) -> String {
+    let mut hash = 0x811c9dc5_u32;
+    for byte in input.as_bytes() {
+        hash ^= u32::from(*byte);
+        hash = hash.wrapping_add(
+            (hash << 1)
+                .wrapping_add(hash << 4)
+                .wrapping_add(hash << 7)
+                .wrapping_add(hash << 8)
+                .wrapping_add(hash << 24),
+        );
+    }
+    format!("{hash:08x}").chars().take(6).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{AgentRef, ClientInfo, slugify_client_name};
+    use crate::{domain::SessionId, services::agents::StoredAgentProfile};
+    use std::collections::BTreeMap;
+
+    fn profile() -> StoredAgentProfile {
+        StoredAgentProfile {
+            id: "p1".to_string(),
+            name: "Finance Ops".to_string(),
+            harness: crate::services::agents::Harness::Codex,
+            login_mode: crate::services::agents::LoginMode::Profile,
+            selected_sites: Vec::new(),
+            approvals: BTreeMap::new(),
+            acl_rule_ids: Vec::new(),
+            custom_acl_rules: Vec::new(),
+            slug: "finance-ops".to_string(),
+            mcp_url: "http://127.0.0.1:9200/mcp".to_string(),
+            status: crate::services::agents::ProfileStatus::Configured,
+            created_at: "now".to_string(),
+            updated_at: "now".to_string(),
+        }
+    }
+
+    #[test]
+    fn slugify_matches_ts_identity_rules() {
+        assert_eq!(
+            slugify_client_name("Cowork . Finance ops").as_deref(),
+            Some("cowork-finance-ops")
+        );
+        assert_eq!(slugify_client_name("..."), None);
+    }
+
+    #[test]
+    fn resolves_profile_when_client_name_matches_slug() {
+        let resolved = AgentRef::resolve(
+            &SessionId::new("s1"),
+            &ClientInfo {
+                name: "finance ops".to_string(),
+                version: "1".to_string(),
+                title: None,
+            },
+            &[profile()],
+        );
+        match resolved {
+            AgentRef::Profile {
+                profile_id, slug, ..
+            } => {
+                assert_eq!(profile_id.as_str(), "p1");
+                assert_eq!(slug, "finance-ops");
+            }
+            AgentRef::Ephemeral { .. } => panic!("expected profile"),
+        }
+    }
+
+    #[test]
+    fn falls_back_to_ephemeral_for_unknown_client() {
+        let resolved = AgentRef::resolve(
+            &SessionId::new("s1"),
+            &ClientInfo {
+                name: "Other".to_string(),
+                version: "1".to_string(),
+                title: None,
+            },
+            &[profile()],
+        );
+        match resolved {
+            AgentRef::Ephemeral { slug, .. } => assert_eq!(slug, "other"),
+            AgentRef::Profile { .. } => panic!("expected ephemeral"),
+        }
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/domain/ids.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/domain/ids.rs
@@ -1,0 +1,103 @@
+use serde::{Deserialize, Serialize};
+use std::{fmt, str::FromStr};
+use ulid::Ulid;
+
+macro_rules! string_id {
+    ($name:ident) => {
+        #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+        #[serde(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            #[must_use]
+            pub fn new(value: impl Into<String>) -> Self {
+                Self(value.into())
+            }
+
+            #[must_use]
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+
+            #[must_use]
+            pub fn into_inner(self) -> String {
+                self.0
+            }
+        }
+
+        impl fmt::Display for $name {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                f.write_str(&self.0)
+            }
+        }
+
+        impl From<String> for $name {
+            fn from(value: String) -> Self {
+                Self(value)
+            }
+        }
+
+        impl From<&str> for $name {
+            fn from(value: &str) -> Self {
+                Self(value.to_string())
+            }
+        }
+
+        impl FromStr for $name {
+            type Err = std::convert::Infallible;
+
+            fn from_str(value: &str) -> Result<Self, Self::Err> {
+                Ok(Self(value.to_string()))
+            }
+        }
+    };
+}
+
+string_id!(SessionId);
+string_id!(AgentId);
+string_id!(ProfileId);
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct DispatchId(String);
+
+impl DispatchId {
+    #[must_use]
+    pub fn new() -> Self {
+        Self(Ulid::new().to_string())
+    }
+
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn into_inner(self) -> String {
+        self.0
+    }
+}
+
+impl Default for DispatchId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for DispatchId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<String> for DispatchId {
+    fn from(value: String) -> Self {
+        Self(value)
+    }
+}
+
+impl From<&str> for DispatchId {
+    fn from(value: &str) -> Self {
+        Self(value.to_string())
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/domain/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/domain/mod.rs
@@ -1,0 +1,9 @@
+pub mod agent_ref;
+pub mod ids;
+pub mod registry;
+pub mod session;
+
+pub use agent_ref::{AgentRef, ClientInfo};
+pub use ids::{AgentId, DispatchId, ProfileId, SessionId};
+pub use registry::SessionRegistry;
+pub use session::Session;

--- a/packages/browseros-agent/apps/claw-server-rust/src/domain/registry.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/domain/registry.rs
@@ -1,0 +1,258 @@
+use crate::{
+    domain::{AgentRef, ClientInfo, Session, SessionId},
+    error::AppResult,
+    services::{audit::AuditService, replay::ReplayService},
+};
+use std::{collections::HashMap, sync::Arc, time::Duration};
+use tokio::{
+    sync::RwLock,
+    task::JoinHandle,
+    time::{Instant, MissedTickBehavior, interval},
+};
+use tracing::{debug, warn};
+use ulid::Ulid;
+
+pub struct SessionRegistry {
+    sessions: RwLock<HashMap<SessionId, Arc<Session>>>,
+    audit: Arc<AuditService>,
+    replay: Arc<ReplayService>,
+    idle_after: Duration,
+    sweep_interval: Duration,
+}
+
+impl SessionRegistry {
+    #[must_use]
+    pub fn new(
+        audit: Arc<AuditService>,
+        replay: Arc<ReplayService>,
+        idle_after: Duration,
+        sweep_interval: Duration,
+    ) -> Arc<Self> {
+        Arc::new(Self {
+            sessions: RwLock::new(HashMap::new()),
+            audit,
+            replay,
+            idle_after,
+            sweep_interval,
+        })
+    }
+
+    pub async fn mint(
+        self: &Arc<Self>,
+        agent: AgentRef,
+        client: ClientInfo,
+    ) -> AppResult<Arc<Session>> {
+        let id = SessionId::new(Ulid::new().to_string());
+        let session = Session::new(id.clone(), agent, Instant::now());
+        self.audit
+            .record_session_start(
+                id.as_str(),
+                session.agent().agent_id().as_str(),
+                session.agent().slug(),
+                session.agent().label(),
+                client.name.as_str(),
+                client.version.as_str(),
+            )
+            .await?;
+        self.sessions.write().await.insert(id, session.clone());
+        Ok(session)
+    }
+
+    pub async fn insert_for_testing(&self, session: Arc<Session>) {
+        self.sessions
+            .write()
+            .await
+            .insert(session.id().clone(), session);
+    }
+
+    pub async fn lookup(&self, id: &SessionId) -> Option<Arc<Session>> {
+        self.sessions.read().await.get(id).cloned()
+    }
+
+    pub async fn contains(&self, id: &SessionId) -> bool {
+        self.sessions.read().await.contains_key(id)
+    }
+
+    pub async fn touch(&self, id: &SessionId) -> bool {
+        let Some(session) = self.lookup(id).await else {
+            return false;
+        };
+        session.touch(Instant::now()).await;
+        true
+    }
+
+    pub async fn count(&self) -> usize {
+        self.sessions.read().await.len()
+    }
+
+    pub async fn cancel_by_agent(&self, agent_id: &str) -> usize {
+        let sessions: Vec<Arc<Session>> = self.sessions.read().await.values().cloned().collect();
+        let mut cancelled = 0;
+        for session in sessions {
+            if session.agent().agent_id().as_str() == agent_id {
+                session.cancel();
+                cancelled += 1;
+            }
+        }
+        cancelled
+    }
+
+    pub async fn remove(
+        &self,
+        id: &SessionId,
+        kind: &str,
+        reason: Option<&str>,
+    ) -> AppResult<bool> {
+        let session = self.sessions.write().await.remove(id);
+        if let Some(session) = session {
+            self.teardown(session, kind, reason).await?;
+            return Ok(true);
+        }
+        Ok(false)
+    }
+
+    pub async fn sweep_idle(&self) -> AppResult<usize> {
+        let now = Instant::now();
+        let sessions: Vec<(SessionId, Arc<Session>)> = self
+            .sessions
+            .read()
+            .await
+            .iter()
+            .map(|(id, session)| (id.clone(), session.clone()))
+            .collect();
+        let mut expired = Vec::new();
+        for (id, session) in sessions {
+            if session.idle_for(now).await >= self.idle_after {
+                expired.push(id);
+            }
+        }
+        let mut removed = 0;
+        for id in expired {
+            if self.remove(&id, "closed", Some("idle timeout")).await? {
+                removed += 1;
+            }
+        }
+        Ok(removed)
+    }
+
+    pub async fn shutdown(&self) -> AppResult<usize> {
+        let sessions = {
+            let mut guard = self.sessions.write().await;
+            std::mem::take(&mut *guard)
+        };
+        let mut count = 0;
+        for session in sessions.into_values() {
+            self.teardown(session, "closed", Some("server shutdown"))
+                .await?;
+            count += 1;
+        }
+        Ok(count)
+    }
+
+    pub fn spawn_idle_sweeper(self: Arc<Self>) -> JoinHandle<()> {
+        tokio::spawn(async move {
+            let mut ticker = interval(self.sweep_interval);
+            ticker.set_missed_tick_behavior(MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                match self.sweep_idle().await {
+                    Ok(count) if count > 0 => debug!(count, "swept idle sessions"),
+                    Ok(_) => {}
+                    Err(err) => warn!(error = %err, "session idle sweep failed"),
+                }
+            }
+        })
+    }
+
+    async fn teardown(
+        &self,
+        session: Arc<Session>,
+        kind: &str,
+        reason: Option<&str>,
+    ) -> AppResult<()> {
+        session.cancel();
+        self.replay.close_session(session.id().as_str()).await?;
+        self.audit
+            .record_session_end(session.id().as_str(), kind, reason)
+            .await?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::SessionRegistry;
+    use crate::{
+        domain::{AgentRef, ClientInfo, Session, SessionId},
+        services::{audit::AuditService, replay::ReplayService},
+    };
+    use std::{sync::Arc, time::Duration};
+    use tempfile::tempdir;
+    use tokio::time::Instant;
+
+    #[tokio::test(start_paused = true)]
+    async fn sweep_removes_idle_sessions_and_writes_end_row() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let audit = Arc::new(AuditService::open(dir.path().join("audit.sqlite")).await?);
+        let replay = Arc::new(ReplayService::new(
+            dir.path().join("replays"),
+            50,
+            Duration::from_secs(30),
+        ));
+        let registry = SessionRegistry::new(
+            audit.clone(),
+            replay,
+            Duration::from_secs(5),
+            Duration::from_secs(1),
+        );
+        let session = Session::new(
+            SessionId::new("s1"),
+            AgentRef::Ephemeral {
+                agent_id: crate::domain::AgentId::new("a1"),
+                slug: "a1".to_string(),
+                label: "A1".to_string(),
+            },
+            Instant::now(),
+        );
+        registry.insert_for_testing(session).await;
+        tokio::time::advance(Duration::from_secs(6)).await;
+        assert_eq!(registry.sweep_idle().await?, 1);
+        assert_eq!(registry.count().await, 0);
+        let detail = audit.get_task("s1").await?;
+        assert!(detail.is_none());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn mint_registers_live_session() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let audit = Arc::new(AuditService::open(dir.path().join("audit.sqlite")).await?);
+        let replay = Arc::new(ReplayService::new(
+            dir.path().join("replays"),
+            50,
+            Duration::from_secs(30),
+        ));
+        let registry = SessionRegistry::new(
+            audit,
+            replay,
+            Duration::from_secs(60),
+            Duration::from_secs(1),
+        );
+        let session = registry
+            .mint(
+                AgentRef::Ephemeral {
+                    agent_id: crate::domain::AgentId::new("agent-1"),
+                    slug: "agent".to_string(),
+                    label: "Agent".to_string(),
+                },
+                ClientInfo {
+                    name: "Agent".to_string(),
+                    version: "1".to_string(),
+                    title: None,
+                },
+            )
+            .await?;
+        assert!(registry.lookup(session.id()).await.is_some());
+        Ok(())
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/domain/session.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/domain/session.rs
@@ -1,0 +1,76 @@
+use crate::domain::{AgentRef, SessionId};
+use browseros_core::PageId;
+use std::{collections::BTreeSet, sync::Arc, time::Duration};
+use tokio::{
+    sync::{Mutex, RwLock},
+    time::Instant,
+};
+use tokio_util::sync::CancellationToken;
+
+pub struct Session {
+    id: SessionId,
+    agent: AgentRef,
+    owned_pages: RwLock<BTreeSet<PageId>>,
+    cancel: CancellationToken,
+    tab_group_ref: Mutex<Option<String>>,
+    replay_handle: Mutex<Option<String>>,
+    last_activity: Mutex<Instant>,
+}
+
+impl Session {
+    #[must_use]
+    pub fn new(id: SessionId, agent: AgentRef, now: Instant) -> Arc<Self> {
+        Arc::new(Self {
+            id,
+            agent,
+            owned_pages: RwLock::new(BTreeSet::new()),
+            cancel: CancellationToken::new(),
+            tab_group_ref: Mutex::new(None),
+            replay_handle: Mutex::new(None),
+            last_activity: Mutex::new(now),
+        })
+    }
+
+    #[must_use]
+    pub fn id(&self) -> &SessionId {
+        &self.id
+    }
+
+    #[must_use]
+    pub fn agent(&self) -> &AgentRef {
+        &self.agent
+    }
+
+    pub async fn touch(&self, now: Instant) {
+        *self.last_activity.lock().await = now;
+    }
+
+    pub async fn idle_for(&self, now: Instant) -> Duration {
+        now.saturating_duration_since(*self.last_activity.lock().await)
+    }
+
+    pub async fn add_owned_page(&self, page_id: PageId) {
+        self.owned_pages.write().await.insert(page_id);
+    }
+
+    pub async fn owned_pages(&self) -> Vec<PageId> {
+        self.owned_pages.read().await.iter().cloned().collect()
+    }
+
+    pub async fn set_tab_group_ref(&self, value: Option<String>) {
+        *self.tab_group_ref.lock().await = value;
+    }
+
+    pub async fn set_replay_handle(&self, value: Option<String>) {
+        *self.replay_handle.lock().await = value;
+    }
+
+    pub fn cancel(&self) {
+        self.cancel.cancel();
+    }
+
+    #[must_use]
+    pub fn child_token(&self) -> CancellationToken {
+        self.cancel.child_token()
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/error.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/error.rs
@@ -1,0 +1,112 @@
+use axum::{
+    Json,
+    http::StatusCode,
+    response::{IntoResponse, Response},
+};
+use serde::Serialize;
+use std::{io, path::PathBuf};
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum AppError {
+    #[error("{message}")]
+    Http { status: StatusCode, message: String },
+    #[error("storage path escapes claw-server root: {0}")]
+    InvalidStoragePath(String),
+    #[error("storage file not found: {0}")]
+    StorageNotFound(String),
+    #[error("storage json is invalid at {path}: {source}")]
+    StorageCorrupt {
+        path: String,
+        source: serde_json::Error,
+    },
+    #[error("io error at {path:?}: {source}")]
+    Io {
+        path: Option<PathBuf>,
+        source: io::Error,
+    },
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
+    #[error(transparent)]
+    Sql(#[from] rusqlite::Error),
+    #[error(transparent)]
+    Join(#[from] tokio::task::JoinError),
+    #[error("{0}")]
+    Internal(String),
+}
+
+#[derive(Serialize)]
+struct ErrorBody<'a> {
+    error: &'a str,
+}
+
+impl AppError {
+    #[must_use]
+    pub fn bad_request(message: impl Into<String>) -> Self {
+        Self::Http {
+            status: StatusCode::BAD_REQUEST,
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn not_found(message: impl Into<String>) -> Self {
+        Self::Http {
+            status: StatusCode::NOT_FOUND,
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn gone(message: impl Into<String>) -> Self {
+        Self::Http {
+            status: StatusCode::GONE,
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn unavailable(message: impl Into<String>) -> Self {
+        Self::Http {
+            status: StatusCode::SERVICE_UNAVAILABLE,
+            message: message.into(),
+        }
+    }
+
+    #[must_use]
+    pub fn status(&self) -> StatusCode {
+        match self {
+            Self::Http { status, .. } => *status,
+            Self::InvalidStoragePath(_) | Self::StorageCorrupt { .. } | Self::Json(_) => {
+                StatusCode::BAD_REQUEST
+            }
+            Self::StorageNotFound(_) => StatusCode::NOT_FOUND,
+            Self::Io { .. } | Self::Sql(_) | Self::Join(_) | Self::Internal(_) => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        }
+    }
+}
+
+impl IntoResponse for AppError {
+    fn into_response(self) -> Response {
+        let status = self.status();
+        let message = self.to_string();
+        (status, Json(ErrorBody { error: &message })).into_response()
+    }
+}
+
+pub type AppResult<T> = Result<T, AppError>;
+
+pub trait IoPath<T> {
+    fn with_path(self, path: impl Into<PathBuf>) -> AppResult<T>;
+}
+
+impl<T> IoPath<T> for Result<T, io::Error> {
+    fn with_path(self, path: impl Into<PathBuf>) -> AppResult<T> {
+        self.map_err(|source| AppError::Io {
+            path: Some(path.into()),
+            source,
+        })
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/lib.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/lib.rs
@@ -1,0 +1,9 @@
+pub mod app;
+pub mod config;
+pub mod domain;
+pub mod error;
+pub mod routes;
+pub mod services;
+pub mod storage;
+
+pub use app::{AppState, build_router};

--- a/packages/browseros-agent/apps/claw-server-rust/src/main.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/main.rs
@@ -1,0 +1,79 @@
+use anyhow::Context;
+use axum::Router;
+use clap::Parser;
+use claw_server_rust::{AppState, build_router, config::Cli};
+use std::{io, net::SocketAddr, sync::Arc};
+use tokio::{net::TcpListener, sync::oneshot};
+use tracing::{error, info};
+use tracing_appender::non_blocking::WorkerGuard;
+use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let cli = Cli::parse();
+    let config = Arc::new(claw_server_rust::config::Config::load(&cli.config)?);
+    let _guard = init_tracing(config.clone())?;
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    let state = AppState::new(config.clone(), Some(shutdown_tx)).await?;
+    state.browser.start();
+    state.sessions.clone().spawn_idle_sweeper();
+    heal_boot_config(&state).await;
+    serve(build_router(state), config, shutdown_rx).await
+}
+
+fn init_tracing(config: Arc<claw_server_rust::config::Config>) -> anyhow::Result<WorkerGuard> {
+    std::fs::create_dir_all(config.claw_dir.join("logs")).with_context(|| {
+        format!(
+            "failed to create log directory {}",
+            config.claw_dir.join("logs").display()
+        )
+    })?;
+    let file_appender =
+        tracing_appender::rolling::daily(config.claw_dir.join("logs"), "claw-server.log");
+    let (file_writer, guard) = tracing_appender::non_blocking(file_appender);
+    let env_filter = EnvFilter::try_from_env("CLAW_LOG").unwrap_or_else(|_| EnvFilter::new("info"));
+    tracing_subscriber::registry()
+        .with(env_filter)
+        .with(tracing_subscriber::fmt::layer().with_writer(io::stderr))
+        .with(
+            tracing_subscriber::fmt::layer()
+                .with_ansi(false)
+                .with_writer(file_writer),
+        )
+        .try_init()
+        .context("failed to initialize tracing subscriber")?;
+    Ok(guard)
+}
+
+async fn serve(
+    app: Router,
+    config: Arc<claw_server_rust::config::Config>,
+    shutdown_rx: oneshot::Receiver<()>,
+) -> anyhow::Result<()> {
+    let addr = SocketAddr::from(([127, 0, 0, 1], config.server_port));
+    let listener = match TcpListener::bind(addr).await {
+        Ok(listener) => listener,
+        Err(err) if err.kind() == io::ErrorKind::AddrInUse => {
+            anyhow::bail!(
+                "claw-server singleton is already running on 127.0.0.1:{}",
+                config.server_port
+            );
+        }
+        Err(err) => return Err(err).context("failed to bind claw-server listener"),
+    };
+    info!(%addr, "claw-server-rust listening");
+    axum::serve(listener, app)
+        .with_graceful_shutdown(async move {
+            let _ = shutdown_rx.await;
+        })
+        .await
+        .context("claw-server listener failed")
+}
+
+async fn heal_boot_config(state: &AppState) {
+    match state.harness.heal_claude_code_http_tags().await {
+        Ok(changed) if changed > 0 => info!(changed, "healed Claude Code MCP transport tags"),
+        Ok(_) => {}
+        Err(err) => error!(error = %err, "Claude Code MCP transport heal failed"),
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/routes/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/routes/mod.rs
@@ -1,0 +1,485 @@
+use crate::{
+    AppState,
+    domain::SessionId,
+    error::{AppError, AppResult},
+    services::{
+        agents::{Harness, NewAgentValues},
+        audit::{ListDispatchesQuery, ListTasksQuery, TaskStatus},
+        replay::ReplayService,
+        site_rules::AddSiteRule,
+        tab_activity::EnrichedTabRecord,
+    },
+};
+use axum::{
+    Json, Router,
+    body::Body,
+    extract::{Path, Query, Request, State, rejection::JsonRejection},
+    http::{HeaderValue, Method, StatusCode, header},
+    middleware::Next,
+    response::{IntoResponse, Response},
+    routing::{any, delete, get, options, post},
+};
+use serde::Deserialize;
+use serde_json::{Value, json};
+use std::str::FromStr;
+use tracing::{Instrument, info_span};
+use ulid::Ulid;
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/system/health", get(system_health))
+        .route("/system/shutdown", post(system_shutdown))
+        .route("/system/version", get(system_version))
+        .route("/system/url", get(system_url))
+        .route("/agents", post(agents_create).get(agents_list))
+        .route(
+            "/agents/{id}",
+            get(agents_detail)
+                .patch(agents_update)
+                .delete(agents_delete),
+        )
+        .route("/agents/{id}/mcp-url:regenerate", post(agents_regenerate))
+        .route("/agents/{agent_id}/cancel", post(agents_cancel))
+        .route("/site-rules", get(site_rules_list).post(site_rules_create))
+        .route("/site-rules/{id}", delete(site_rules_delete))
+        .route("/permissions/catalog", get(permissions_catalog))
+        .route("/tabs/activity", get(tabs_activity))
+        .route("/tabs/focus/{agent_id}", post(tabs_focus))
+        .route("/connections", get(connections_list))
+        .route("/connections/{harness}/connect", post(connections_connect))
+        .route(
+            "/connections/{harness}/disconnect",
+            post(connections_disconnect),
+        )
+        .route("/audit/dispatches", get(audit_dispatches))
+        .route("/audit/tasks", get(audit_tasks))
+        .route("/audit/tasks/{session_id}", get(audit_task_detail))
+        .route("/audit/screenshot/{dispatch_id}", get(audit_screenshot))
+        .route(
+            "/audit/replay/{session_id}/events",
+            post(replay_post_events),
+        )
+        .route("/audit/replay/{session_id}", get(replay_get))
+        .route("/audit/replay/{session_id}/exists", get(replay_exists))
+        .route("/replay/tabs", get(replay_tabs))
+        .route("/mcp", any(mcp_stub))
+        .route("/{*path}", options(preflight))
+}
+
+pub async fn request_context(req: Request, next: Next) -> Response {
+    let request_id = Ulid::new().to_string();
+    let method = req.method().clone();
+    let path = req.uri().path().to_string();
+    let span = info_span!("http_request", %request_id, %method, %path);
+    async move {
+        let mut response = next.run(req).await;
+        let headers = response.headers_mut();
+        headers.insert(
+            header::ACCESS_CONTROL_ALLOW_ORIGIN,
+            HeaderValue::from_static("*"),
+        );
+        headers.insert(
+            header::ACCESS_CONTROL_ALLOW_METHODS,
+            HeaderValue::from_static("GET,POST,PATCH,DELETE,OPTIONS"),
+        );
+        headers.insert(
+            header::ACCESS_CONTROL_ALLOW_HEADERS,
+            HeaderValue::from_static("content-type,authorization,mcp-session-id"),
+        );
+        if let Ok(value) = HeaderValue::from_str(&request_id) {
+            headers.insert("x-request-id", value);
+        }
+        response
+    }
+    .instrument(span)
+    .await
+}
+
+async fn preflight() -> StatusCode {
+    StatusCode::NO_CONTENT
+}
+
+async fn system_health(State(state): State<AppState>) -> Json<Value> {
+    let cdp = state.browser.state();
+    Json(json!({
+        "status": "ok",
+        "cdp": cdp,
+        "sessions": {
+            "count": state.sessions.count().await
+        }
+    }))
+}
+
+async fn system_shutdown(State(state): State<AppState>) -> AppResult<Json<Value>> {
+    let drained = state.sessions.shutdown().await?;
+    state.browser.stop();
+    if let Some(tx) = state.shutdown.lock().await.take() {
+        let _ = tx.send(());
+    }
+    Ok(Json(json!({ "status": "ok", "drainedSessions": drained })))
+}
+
+async fn system_version() -> Json<Value> {
+    Json(json!({
+        "name": env!("CARGO_PKG_NAME"),
+        "version": env!("CARGO_PKG_VERSION"),
+    }))
+}
+
+async fn system_url(State(state): State<AppState>) -> Json<Value> {
+    Json(json!({ "url": state.config.local_server_url() }))
+}
+
+async fn agents_create(
+    State(state): State<AppState>,
+    payload: Result<Json<NewAgentValues>, JsonRejection>,
+) -> AppResult<impl IntoResponse> {
+    let Json(body) = json_body(payload)?;
+    let created = state.agents.create(body).await?;
+    Ok((StatusCode::CREATED, Json(created)))
+}
+
+async fn agents_list(State(state): State<AppState>) -> AppResult<Json<Value>> {
+    Ok(Json(serde_json::to_value(state.agents.list().await?)?))
+}
+
+async fn agents_detail(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> AppResult<Json<Value>> {
+    let detail = state
+        .agents
+        .get_detail(&id)
+        .await?
+        .ok_or_else(|| AppError::not_found("agent not found"))?;
+    Ok(Json(serde_json::to_value(detail)?))
+}
+
+async fn agents_update(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    payload: Result<Json<NewAgentValues>, JsonRejection>,
+) -> AppResult<Json<Value>> {
+    let Json(body) = json_body(payload)?;
+    let updated = state
+        .agents
+        .update(&id, body)
+        .await?
+        .ok_or_else(|| AppError::not_found("agent not found"))?;
+    Ok(Json(serde_json::to_value(updated)?))
+}
+
+async fn agents_delete(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> AppResult<Json<Value>> {
+    let deleted = state
+        .agents
+        .remove(&id)
+        .await?
+        .ok_or_else(|| AppError::not_found("agent not found"))?;
+    Ok(Json(serde_json::to_value(deleted)?))
+}
+
+async fn agents_regenerate(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> AppResult<Json<Value>> {
+    let rotated = state
+        .agents
+        .regenerate_mcp_url(&id)
+        .await?
+        .ok_or_else(|| AppError::not_found("agent not found"))?;
+    Ok(Json(serde_json::to_value(rotated)?))
+}
+
+async fn agents_cancel(
+    State(state): State<AppState>,
+    Path(agent_id): Path<String>,
+) -> AppResult<Json<Value>> {
+    let cancelled = state.sessions.cancel_by_agent(&agent_id).await;
+    if cancelled == 0 {
+        return Err(AppError::not_found("no active dispatches for this agent"));
+    }
+    Ok(Json(json!({ "ok": true, "cancelled": cancelled })))
+}
+
+async fn site_rules_list(State(state): State<AppState>) -> AppResult<Json<Value>> {
+    Ok(Json(serde_json::to_value(state.site_rules.list().await?)?))
+}
+
+async fn site_rules_create(
+    State(state): State<AppState>,
+    payload: Result<Json<AddSiteRule>, JsonRejection>,
+) -> AppResult<impl IntoResponse> {
+    let Json(body) = json_body(payload)?;
+    let created = state.site_rules.add(body).await?;
+    Ok((StatusCode::CREATED, Json(created)))
+}
+
+async fn site_rules_delete(
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> AppResult<Json<Value>> {
+    let deleted = state
+        .site_rules
+        .remove(&id)
+        .await?
+        .ok_or_else(|| AppError::not_found("site rule not found"))?;
+    Ok(Json(deleted))
+}
+
+async fn permissions_catalog() -> Json<Value> {
+    Json(json!([
+        { "id": "submit", "name": "Submit / send / post", "defaultVerdict": "Ask", "allowAuto": true },
+        { "id": "payment", "name": "Payments & checkout", "defaultVerdict": "Block", "allowAuto": false },
+        { "id": "delete", "name": "Delete / destructive", "defaultVerdict": "Ask", "allowAuto": true },
+        { "id": "upload", "name": "File upload", "defaultVerdict": "Ask", "allowAuto": true },
+        { "id": "navigate", "name": "Navigate to a new site", "defaultVerdict": "Ask", "allowAuto": true },
+        { "id": "input", "name": "Click & type", "defaultVerdict": "Auto", "allowAuto": true }
+    ]))
+}
+
+async fn tabs_activity(State(state): State<AppState>) -> AppResult<Json<Value>> {
+    let profiles = state.agents.list().await?;
+    let tabs = state.tab_activity.snapshot().await;
+    let enriched: Vec<EnrichedTabRecord> = tabs
+        .into_iter()
+        .map(|record| {
+            let profile = profiles.iter().find(|profile| {
+                profile.id == record.agent_id || profile.mcp_url.contains(&record.slug)
+            });
+            EnrichedTabRecord {
+                agent_label: profile
+                    .map(|profile| profile.name.clone())
+                    .unwrap_or_else(|| record.slug.clone()),
+                harness: profile.map(|profile| profile.harness.to_string()),
+                color: None,
+                screencast: None,
+                record,
+            }
+        })
+        .collect();
+    Ok(Json(json!({ "tabs": enriched })))
+}
+
+async fn tabs_focus(
+    State(state): State<AppState>,
+    Path(agent_id): Path<String>,
+) -> AppResult<Response> {
+    if state.browser.session().await.is_none() {
+        return Ok((
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(json!({ "ok": false, "reason": "browser session not connected" })),
+        )
+            .into_response());
+    }
+    Ok((
+        StatusCode::NOT_FOUND,
+        Json(json!({
+            "ok": false,
+            "reason": format!("no tab group registered for {agent_id}")
+        })),
+    )
+        .into_response())
+}
+
+async fn connections_list(State(state): State<AppState>) -> AppResult<Json<Value>> {
+    Ok(Json(json!({
+        "connections": state.harness.list_browseros_connections().await?
+    })))
+}
+
+async fn connections_connect(
+    State(state): State<AppState>,
+    Path(harness): Path<String>,
+) -> AppResult<Json<Value>> {
+    let harness = Harness::from_str(&harness)?;
+    let result = state
+        .harness
+        .connect_browseros(harness, &state.config.public_mcp_url())
+        .await?;
+    Ok(Json(serde_json::to_value(result)?))
+}
+
+async fn connections_disconnect(
+    State(state): State<AppState>,
+    Path(harness): Path<String>,
+) -> AppResult<Json<Value>> {
+    let harness = Harness::from_str(&harness)?;
+    let result = state.harness.disconnect_browseros(harness).await?;
+    Ok(Json(serde_json::to_value(result)?))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct DispatchesQuery {
+    agent_id: Option<String>,
+    session_id: Option<String>,
+    cursor: Option<i64>,
+    limit: Option<i64>,
+}
+
+async fn audit_dispatches(
+    State(state): State<AppState>,
+    Query(query): Query<DispatchesQuery>,
+) -> AppResult<Json<Value>> {
+    validate_limit(query.limit, 500)?;
+    let result = state
+        .audit
+        .list_dispatches(ListDispatchesQuery {
+            agent_id: query.agent_id,
+            session_id: query.session_id,
+            cursor: query.cursor,
+            limit: query.limit,
+        })
+        .await?;
+    Ok(Json(serde_json::to_value(result)?))
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TasksQuery {
+    agent_id: Option<String>,
+    status: Option<TaskStatus>,
+    site: Option<String>,
+    search: Option<String>,
+    since: Option<i64>,
+    cursor: Option<i64>,
+    limit: Option<i64>,
+}
+
+async fn audit_tasks(
+    State(state): State<AppState>,
+    Query(query): Query<TasksQuery>,
+) -> AppResult<Json<Value>> {
+    validate_limit(query.limit, 100)?;
+    let result = state
+        .audit
+        .list_tasks(ListTasksQuery {
+            agent_id: query.agent_id,
+            status: query.status,
+            site: query.site,
+            search: query.search,
+            since: query.since,
+            cursor: query.cursor,
+            limit: query.limit,
+        })
+        .await?;
+    Ok(Json(serde_json::to_value(result)?))
+}
+
+async fn audit_task_detail(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> AppResult<Json<Value>> {
+    let task = state
+        .audit
+        .get_task(&session_id)
+        .await?
+        .ok_or_else(|| AppError::not_found("not found"))?;
+    Ok(Json(serde_json::to_value(task)?))
+}
+
+async fn audit_screenshot(
+    State(state): State<AppState>,
+    Path(dispatch_id): Path<String>,
+) -> AppResult<impl IntoResponse> {
+    let bytes = state.screenshots.read(&dispatch_id).await?;
+    Ok((
+        [
+            (header::CONTENT_TYPE, HeaderValue::from_static("image/jpeg")),
+            (
+                header::CACHE_CONTROL,
+                HeaderValue::from_static("public, max-age=86400, immutable"),
+            ),
+        ],
+        bytes,
+    ))
+}
+
+async fn replay_post_events(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+    body: String,
+) -> AppResult<Json<Value>> {
+    if !state
+        .sessions
+        .contains(&SessionId::new(session_id.clone()))
+        .await
+    {
+        return Err(AppError::gone("session not live"));
+    }
+    if body.is_empty() {
+        return Ok(Json(json!({ "ok": true, "accepted": 0 })));
+    }
+    let lines: Vec<String> = body
+        .lines()
+        .filter(|line| !line.is_empty())
+        .map(|line| ReplayService::annotate_with_session_id(line, &session_id))
+        .collect();
+    let accepted = lines.len();
+    state.replay.append_events(&session_id, &lines).await?;
+    Ok(Json(json!({ "ok": true, "accepted": accepted })))
+}
+
+async fn replay_get(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> AppResult<Response> {
+    let stat = state.replay.stat_session(&session_id).await?;
+    if !stat.has_data {
+        return Err(AppError::not_found("no replay for this session"));
+    }
+    let bytes = state.replay.read_events(&session_id).await?;
+    let mut response = Response::new(Body::from(bytes));
+    let headers = response.headers_mut();
+    headers.insert(
+        header::CONTENT_TYPE,
+        HeaderValue::from_static("application/x-ndjson"),
+    );
+    if let Ok(value) = HeaderValue::from_str(&stat.size_bytes.to_string()) {
+        headers.insert(header::CONTENT_LENGTH, value);
+    }
+    headers.insert(header::ACCEPT_RANGES, HeaderValue::from_static("bytes"));
+    Ok(response)
+}
+
+async fn replay_exists(
+    State(state): State<AppState>,
+    Path(session_id): Path<String>,
+) -> AppResult<Json<Value>> {
+    let stat = state.replay.stat_session(&session_id).await?;
+    let mut value = serde_json::to_value(stat)?;
+    if let Value::Object(obj) = &mut value {
+        obj.insert("ok".to_string(), Value::Bool(true));
+    }
+    Ok(Json(value))
+}
+
+async fn replay_tabs() -> Json<Value> {
+    Json(json!({ "tabs": [] }))
+}
+
+async fn mcp_stub() -> impl IntoResponse {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(json!({ "error": "mcp endpoint lands in phase D" })),
+    )
+}
+
+fn json_body<T>(payload: Result<Json<T>, JsonRejection>) -> AppResult<Json<T>> {
+    payload.map_err(|err| AppError::bad_request(err.body_text()))
+}
+
+fn validate_limit(limit: Option<i64>, cap: i64) -> AppResult<()> {
+    if let Some(limit) = limit
+        && (limit <= 0 || limit > cap)
+    {
+        return Err(AppError::bad_request("limit out of range"));
+    }
+    Ok(())
+}
+
+#[allow(dead_code)]
+fn _method(_: Method) {}

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/agents.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/agents.rs
@@ -1,0 +1,493 @@
+use crate::{
+    error::{AppError, AppResult},
+    services::{harness::HarnessService, now_iso, slugify},
+    storage::JsonStore,
+};
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, fmt, str::FromStr, sync::Arc};
+use tokio::sync::Mutex;
+use ulid::Ulid;
+
+const AGENTS_SUBDIR: &str = "agents";
+const TOTAL_PROFILE_LOGINS: usize = 47;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Harness {
+    #[serde(rename = "Claude Code")]
+    ClaudeCode,
+    #[serde(rename = "Claude Desktop")]
+    ClaudeDesktop,
+    #[serde(rename = "Cursor")]
+    Cursor,
+    #[serde(rename = "VS Code")]
+    VsCode,
+    #[serde(rename = "Zed")]
+    Zed,
+    #[serde(rename = "Codex")]
+    Codex,
+    #[serde(rename = "Gemini CLI")]
+    GeminiCli,
+    #[serde(rename = "Hermes")]
+    Hermes,
+    #[serde(rename = "OpenClaw")]
+    OpenClaw,
+}
+
+impl Harness {
+    pub const ALL: [Harness; 9] = [
+        Harness::ClaudeCode,
+        Harness::ClaudeDesktop,
+        Harness::Cursor,
+        Harness::VsCode,
+        Harness::Zed,
+        Harness::Codex,
+        Harness::GeminiCli,
+        Harness::Hermes,
+        Harness::OpenClaw,
+    ];
+
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ClaudeCode => "Claude Code",
+            Self::ClaudeDesktop => "Claude Desktop",
+            Self::Cursor => "Cursor",
+            Self::VsCode => "VS Code",
+            Self::Zed => "Zed",
+            Self::Codex => "Codex",
+            Self::GeminiCli => "Gemini CLI",
+            Self::Hermes => "Hermes",
+            Self::OpenClaw => "OpenClaw",
+        }
+    }
+
+    #[must_use]
+    pub fn agent_id(self) -> Option<&'static str> {
+        match self {
+            Self::ClaudeCode => Some("claude-code"),
+            Self::ClaudeDesktop => Some("claude-desktop"),
+            Self::Cursor => Some("cursor"),
+            Self::VsCode => Some("vscode"),
+            Self::Zed => Some("zed"),
+            Self::Codex => Some("codex"),
+            Self::GeminiCli => Some("gemini"),
+            Self::Hermes | Self::OpenClaw => None,
+        }
+    }
+}
+
+impl fmt::Display for Harness {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl FromStr for Harness {
+    type Err = AppError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        let decoded = value.replace("%20", " ");
+        match decoded.as_str() {
+            "Claude Code" => Ok(Self::ClaudeCode),
+            "Claude Desktop" => Ok(Self::ClaudeDesktop),
+            "Cursor" => Ok(Self::Cursor),
+            "VS Code" => Ok(Self::VsCode),
+            "Zed" => Ok(Self::Zed),
+            "Codex" => Ok(Self::Codex),
+            "Gemini CLI" => Ok(Self::GeminiCli),
+            "Hermes" => Ok(Self::Hermes),
+            "OpenClaw" => Ok(Self::OpenClaw),
+            _ => Err(AppError::bad_request("unsupported harness")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum LoginMode {
+    Profile,
+    All,
+    Selective,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ApprovalVerdict {
+    Auto,
+    Ask,
+    Block,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ProfileStatus {
+    Configured,
+    Paused,
+    Disabled,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CustomAclRule {
+    pub id: String,
+    pub label: String,
+    pub domain: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct NewAgentValues {
+    pub name: String,
+    pub harness: Harness,
+    pub login_mode: LoginMode,
+    pub selected_sites: Vec<String>,
+    pub approvals: BTreeMap<String, ApprovalVerdict>,
+    pub acl_rule_ids: Vec<String>,
+    pub custom_acl_rules: Vec<CustomAclRule>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct StoredAgentProfile {
+    pub name: String,
+    pub harness: Harness,
+    pub login_mode: LoginMode,
+    pub selected_sites: Vec<String>,
+    pub approvals: BTreeMap<String, ApprovalVerdict>,
+    pub acl_rule_ids: Vec<String>,
+    pub custom_acl_rules: Vec<CustomAclRule>,
+    pub id: String,
+    pub slug: String,
+    pub mcp_url: String,
+    pub status: ProfileStatus,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AgentProfileSummary {
+    pub id: String,
+    pub name: String,
+    pub harness: Harness,
+    pub login_scope_label: String,
+    pub login_count: usize,
+    pub acl_rule_count: usize,
+    pub blocked_action_count: usize,
+    pub always_allow_count: usize,
+    pub last_run_at: String,
+    pub status: ProfileStatus,
+    pub mcp_url: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HarnessInstallOutcome {
+    pub installed: bool,
+    pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub agent: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_path: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CreatedAgent {
+    pub id: String,
+    pub name: String,
+    pub harness: Harness,
+    pub slug: String,
+    pub mcp_url: String,
+    pub cli_command: String,
+    pub harness_install: HarnessInstallOutcome,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DeletedAgent {
+    pub id: String,
+    pub harness_uninstall: HarnessInstallOutcome,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RegeneratedMcpUrl {
+    pub id: String,
+    pub mcp_url: String,
+}
+
+#[derive(Clone)]
+pub struct AgentService {
+    store: JsonStore,
+    harness: Arc<HarnessService>,
+    public_mcp_url: String,
+    slug_mutex: Arc<Mutex<()>>,
+}
+
+impl AgentService {
+    #[must_use]
+    pub fn new(store: JsonStore, harness: Arc<HarnessService>, public_mcp_url: String) -> Self {
+        Self {
+            store,
+            harness,
+            public_mcp_url,
+            slug_mutex: Arc::new(Mutex::new(())),
+        }
+    }
+
+    pub async fn list_profiles(&self) -> AppResult<Vec<StoredAgentProfile>> {
+        let names = self.store.list_files(AGENTS_SUBDIR, ".json").await?;
+        let mut out = Vec::new();
+        for name in names {
+            let rel = format!("{AGENTS_SUBDIR}/{name}");
+            match self.store.read_json::<StoredAgentProfile>(&rel).await {
+                Ok(profile) => out.push(profile),
+                Err(err) => {
+                    tracing::warn!(file = %rel, error = %err, "skipping unreadable agent profile")
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    pub async fn list(&self) -> AppResult<Vec<AgentProfileSummary>> {
+        let mut profiles = self.list_profiles().await?;
+        profiles.sort_by(|a, b| b.updated_at.cmp(&a.updated_at));
+        Ok(profiles
+            .iter()
+            .map(|profile| self.summarize(profile))
+            .collect())
+    }
+
+    pub async fn get_detail(&self, id: &str) -> AppResult<Option<NewAgentValues>> {
+        Ok(self
+            .load_by_id(id)
+            .await?
+            .map(|profile| profile.into_new_values()))
+    }
+
+    pub async fn load_by_id(&self, id: &str) -> AppResult<Option<StoredAgentProfile>> {
+        if !is_valid_id(id) {
+            return Ok(None);
+        }
+        let rel = file_for(id);
+        match self.store.read_json(&rel).await {
+            Ok(profile) => Ok(Some(profile)),
+            Err(AppError::StorageNotFound(_)) | Err(AppError::InvalidStoragePath(_)) => Ok(None),
+            Err(err) => Err(err),
+        }
+    }
+
+    pub async fn create(&self, input: NewAgentValues) -> AppResult<CreatedAgent> {
+        input.validate()?;
+        let _guard = self.slug_mutex.lock().await;
+        let id = Ulid::new().to_string();
+        let existing = self.list_profiles().await?;
+        let slug = unique_slug(
+            &slugify(&input.name),
+            existing.iter().map(|p| p.slug.as_str()),
+        );
+        let now = now_iso();
+        let profile = StoredAgentProfile {
+            name: input.name,
+            harness: input.harness,
+            login_mode: input.login_mode,
+            selected_sites: input.selected_sites,
+            approvals: input.approvals,
+            acl_rule_ids: input.acl_rule_ids,
+            custom_acl_rules: input.custom_acl_rules,
+            id: id.clone(),
+            slug: slug.clone(),
+            mcp_url: self.public_mcp_url.clone(),
+            status: ProfileStatus::Configured,
+            created_at: now.clone(),
+            updated_at: now,
+        };
+        self.store.write_json(&file_for(&id), &profile).await?;
+        let harness_install = self.harness.install_for_agent(&profile).await;
+        Ok(CreatedAgent {
+            id,
+            name: profile.name,
+            harness: profile.harness,
+            slug: slug.clone(),
+            mcp_url: profile.mcp_url,
+            cli_command: format!("mcp add {slug}"),
+            harness_install,
+        })
+    }
+
+    pub async fn update(
+        &self,
+        id: &str,
+        input: NewAgentValues,
+    ) -> AppResult<Option<StoredAgentProfile>> {
+        input.validate()?;
+        let _guard = self.slug_mutex.lock().await;
+        let Some(existing) = self.load_by_id(id).await? else {
+            return Ok(None);
+        };
+        let profiles = self.list_profiles().await?;
+        let name_slug = slugify(&input.name);
+        let slug = if name_slug == slugify(&existing.name) {
+            existing.slug.clone()
+        } else {
+            unique_slug(
+                &name_slug,
+                profiles
+                    .iter()
+                    .filter(|profile| profile.id != id)
+                    .map(|profile| profile.slug.as_str()),
+            )
+        };
+        let next = StoredAgentProfile {
+            name: input.name,
+            harness: input.harness,
+            login_mode: input.login_mode,
+            selected_sites: input.selected_sites,
+            approvals: input.approvals,
+            acl_rule_ids: input.acl_rule_ids,
+            custom_acl_rules: input.custom_acl_rules,
+            id: id.to_string(),
+            slug,
+            mcp_url: self.public_mcp_url.clone(),
+            status: existing.status,
+            created_at: existing.created_at.clone(),
+            updated_at: now_iso(),
+        };
+        self.store.write_json(&file_for(id), &next).await?;
+        self.harness.reconcile_agent_link(&existing, &next).await;
+        Ok(Some(next))
+    }
+
+    pub async fn remove(&self, id: &str) -> AppResult<Option<DeletedAgent>> {
+        if !is_valid_id(id) {
+            return Ok(None);
+        }
+        let Some(profile) = self.load_by_id(id).await? else {
+            return Ok(None);
+        };
+        if !self.store.remove_file(&file_for(id)).await? {
+            return Ok(None);
+        }
+        let harness_uninstall = self.harness.uninstall_for_agent(&profile).await;
+        Ok(Some(DeletedAgent {
+            id: id.to_string(),
+            harness_uninstall,
+        }))
+    }
+
+    pub async fn regenerate_mcp_url(&self, id: &str) -> AppResult<Option<RegeneratedMcpUrl>> {
+        let _guard = self.slug_mutex.lock().await;
+        let Some(existing) = self.load_by_id(id).await? else {
+            return Ok(None);
+        };
+        let profiles = self.list_profiles().await?;
+        let base = slugify(&format!("{} {}", existing.name, Ulid::new()));
+        let slug = unique_slug(
+            &base,
+            profiles
+                .iter()
+                .filter(|profile| profile.id != id)
+                .map(|profile| profile.slug.as_str()),
+        );
+        let next = StoredAgentProfile {
+            slug,
+            mcp_url: self.public_mcp_url.clone(),
+            updated_at: now_iso(),
+            ..existing.clone()
+        };
+        self.store.write_json(&file_for(id), &next).await?;
+        self.harness.reconcile_agent_link(&existing, &next).await;
+        Ok(Some(RegeneratedMcpUrl {
+            id: id.to_string(),
+            mcp_url: next.mcp_url,
+        }))
+    }
+
+    fn summarize(&self, profile: &StoredAgentProfile) -> AgentProfileSummary {
+        let blocked_action_count = profile
+            .approvals
+            .values()
+            .filter(|value| matches!(value, ApprovalVerdict::Block))
+            .count();
+        let login_count = match profile.login_mode {
+            LoginMode::Selective => profile.selected_sites.len(),
+            LoginMode::Profile | LoginMode::All => TOTAL_PROFILE_LOGINS,
+        };
+        let login_scope_label = match profile.login_mode {
+            LoginMode::Selective => format!("Selective ({})", profile.selected_sites.len()),
+            LoginMode::All => format!("All my logins ({TOTAL_PROFILE_LOGINS})"),
+            LoginMode::Profile => format!("Current profile ({TOTAL_PROFILE_LOGINS})"),
+        };
+        AgentProfileSummary {
+            id: profile.id.clone(),
+            name: profile.name.clone(),
+            harness: profile.harness,
+            login_scope_label,
+            login_count,
+            acl_rule_count: profile.acl_rule_ids.len(),
+            blocked_action_count,
+            always_allow_count: 0,
+            last_run_at: "Never run".to_string(),
+            status: profile.status,
+            mcp_url: self.public_mcp_url.clone(),
+        }
+    }
+}
+
+impl NewAgentValues {
+    pub fn validate(&self) -> AppResult<()> {
+        if self.name.trim().is_empty() {
+            return Err(AppError::bad_request("name is required"));
+        }
+        for rule in &self.custom_acl_rules {
+            if rule.label.trim().is_empty() || rule.domain.trim().is_empty() {
+                return Err(AppError::bad_request(
+                    "custom ACL rules require label and domain",
+                ));
+            }
+        }
+        Ok(())
+    }
+}
+
+impl StoredAgentProfile {
+    #[must_use]
+    pub fn into_new_values(self) -> NewAgentValues {
+        NewAgentValues {
+            name: self.name,
+            harness: self.harness,
+            login_mode: self.login_mode,
+            selected_sites: self.selected_sites,
+            approvals: self.approvals,
+            acl_rule_ids: self.acl_rule_ids,
+            custom_acl_rules: self.custom_acl_rules,
+        }
+    }
+}
+
+fn file_for(id: &str) -> String {
+    format!("{AGENTS_SUBDIR}/{id}.json")
+}
+
+fn is_valid_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 64
+        && id
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+}
+
+fn unique_slug<'a>(base: &str, existing: impl Iterator<Item = &'a str>) -> String {
+    let existing: std::collections::BTreeSet<&str> = existing.collect();
+    if !existing.contains(base) {
+        return base.to_string();
+    }
+    for suffix in 2..=99 {
+        let candidate = format!("{base}-{suffix}");
+        if !existing.contains(candidate.as_str()) {
+            return candidate;
+        }
+    }
+    format!("{base}-{}", Ulid::new())
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/audit.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/audit.rs
@@ -1,0 +1,888 @@
+use crate::{
+    domain::DispatchId,
+    error::{AppError, AppResult, IoPath},
+    services::now_epoch_ms,
+};
+use rusqlite::{Connection, OptionalExtension, params, types::Value};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use std::{
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use tokio::sync::Mutex;
+use url::Url;
+
+const DRIZZLE_0000: &str =
+    include_str!("../../../claw-server/drizzle/0000_add_tool_dispatches.sql");
+const DRIZZLE_0001: &str =
+    include_str!("../../../claw-server/drizzle/0001_add_agent_session_events.sql");
+const ARGS_JSON_MAX: usize = 4096;
+
+#[derive(Clone)]
+pub struct AuditService {
+    conn: Arc<Mutex<Connection>>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolDispatchRow {
+    pub id: i64,
+    pub created_at: i64,
+    pub agent_id: String,
+    pub slug: String,
+    pub agent_label: String,
+    pub session_id: String,
+    pub tool_name: String,
+    pub page_id: Option<i64>,
+    pub target_id: Option<String>,
+    pub url: Option<String>,
+    pub title: Option<String>,
+    pub args_json: Option<String>,
+    pub result_meta: Option<String>,
+    pub duration_ms: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dispatch_id: Option<String>,
+    pub has_screenshot: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct RecordToolDispatchInput {
+    pub agent_id: String,
+    pub slug: String,
+    pub agent_label: String,
+    pub session_id: String,
+    pub tool_name: String,
+    pub page_id: Option<i64>,
+    pub target_id: Option<String>,
+    pub url: Option<String>,
+    pub title: Option<String>,
+    pub raw_args: serde_json::Value,
+    pub duration_ms: i64,
+    pub result: DispatchResultSummary,
+}
+
+#[derive(Debug, Clone)]
+pub struct DispatchResultSummary {
+    pub is_error: bool,
+    pub structured_content: serde_json::Value,
+    pub content: serde_json::Value,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListDispatchesResult {
+    pub rows: Vec<ToolDispatchRow>,
+    pub next_cursor: Option<i64>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ListDispatchesQuery {
+    pub agent_id: Option<String>,
+    pub session_id: Option<String>,
+    pub cursor: Option<i64>,
+    pub limit: Option<i64>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum TaskStatus {
+    Live,
+    Done,
+    Failed,
+}
+
+impl TaskStatus {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Live => "live",
+            Self::Done => "done",
+            Self::Failed => "failed",
+        }
+    }
+
+    fn from_db(value: String) -> Self {
+        match value.as_str() {
+            "done" => Self::Done,
+            "failed" => Self::Failed,
+            _ => Self::Live,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskSummary {
+    pub session_id: String,
+    pub agent_id: String,
+    pub slug: String,
+    pub agent_label: String,
+    pub title: String,
+    pub site: Option<String>,
+    pub started_at: i64,
+    pub ended_at: Option<i64>,
+    pub duration_ms: i64,
+    pub dispatch_count: i64,
+    pub tool_sequence: Vec<String>,
+    pub status: TaskStatus,
+    pub error_count: i64,
+    pub last_screenshot_dispatch_id: Option<i64>,
+    pub cursor_id: i64,
+    pub has_screenshots: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskDetail {
+    #[serde(flatten)]
+    pub summary: TaskSummary,
+    pub dispatches: Vec<ToolDispatchRow>,
+    pub screenshot_dispatch_ids: Vec<i64>,
+    pub start_event: Option<SessionStartEvent>,
+    pub end_event: Option<SessionEndEvent>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionStartEvent {
+    pub created_at: i64,
+    pub client_name: String,
+    pub client_version: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionEndEvent {
+    pub created_at: i64,
+    pub kind: String,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ListTasksResult {
+    pub tasks: Vec<TaskSummary>,
+    pub next_cursor: Option<i64>,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct ListTasksQuery {
+    pub agent_id: Option<String>,
+    pub status: Option<TaskStatus>,
+    pub site: Option<String>,
+    pub search: Option<String>,
+    pub since: Option<i64>,
+    pub cursor: Option<i64>,
+    pub limit: Option<i64>,
+}
+
+impl AuditService {
+    pub async fn open(path: impl AsRef<Path>) -> AppResult<Self> {
+        let path = path.as_ref().to_path_buf();
+        if let Some(parent) = path.parent() {
+            tokio::fs::create_dir_all(parent).await.with_path(parent)?;
+        }
+        let conn = tokio::task::spawn_blocking(move || open_connection(path)).await??;
+        Ok(Self {
+            conn: Arc::new(Mutex::new(conn)),
+        })
+    }
+
+    pub async fn record_tool_dispatch(&self, input: RecordToolDispatchInput) -> AppResult<i64> {
+        let mut conn = self.conn.lock().await;
+        let tx = conn.transaction()?;
+        let args_json = truncate(&safe_stringify(&input.raw_args));
+        let result_meta = summarize_result(&input.result);
+        let dispatch_id = DispatchId::new().into_inner();
+        tx.execute(
+            "INSERT INTO tool_dispatches
+                (agent_id, slug, agent_label, session_id, tool_name, page_id, target_id, url, title, args_json, result_meta, duration_ms, dispatch_id, has_screenshot)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, 0)",
+            params![
+                input.agent_id,
+                input.slug,
+                input.agent_label,
+                input.session_id,
+                input.tool_name,
+                input.page_id,
+                input.target_id,
+                input.url,
+                input.title,
+                args_json,
+                result_meta,
+                input.duration_ms,
+                dispatch_id,
+            ],
+        )?;
+        let id = tx.last_insert_rowid();
+        recompute_task(&tx, input.session_id.as_str())?;
+        tx.commit()?;
+        Ok(id)
+    }
+
+    pub async fn mark_screenshot(&self, dispatch_id: i64) -> AppResult<()> {
+        let mut conn = self.conn.lock().await;
+        let tx = conn.transaction()?;
+        let session_id: Option<String> = tx
+            .query_row(
+                "SELECT session_id FROM tool_dispatches WHERE id = ?1",
+                params![dispatch_id],
+                |row| row.get(0),
+            )
+            .optional()?;
+        tx.execute(
+            "UPDATE tool_dispatches SET has_screenshot = 1 WHERE id = ?1",
+            params![dispatch_id],
+        )?;
+        if let Some(session_id) = session_id {
+            recompute_task(&tx, session_id.as_str())?;
+        }
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub async fn record_session_start(
+        &self,
+        session_id: &str,
+        agent_id: &str,
+        slug: &str,
+        agent_label: &str,
+        client_name: &str,
+        client_version: &str,
+    ) -> AppResult<()> {
+        let mut conn = self.conn.lock().await;
+        let tx = conn.transaction()?;
+        tx.execute(
+            "INSERT INTO agent_session_starts
+                (session_id, agent_id, slug, agent_label, client_name, client_version)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            params![
+                session_id,
+                agent_id,
+                slug,
+                agent_label,
+                client_name,
+                client_version
+            ],
+        )?;
+        recompute_task(&tx, session_id)?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub async fn record_session_end(
+        &self,
+        session_id: &str,
+        kind: &str,
+        reason: Option<&str>,
+    ) -> AppResult<()> {
+        let mut conn = self.conn.lock().await;
+        let tx = conn.transaction()?;
+        tx.execute(
+            "INSERT INTO agent_session_ends (session_id, kind, reason) VALUES (?1, ?2, ?3)",
+            params![session_id, kind, reason],
+        )?;
+        recompute_task(&tx, session_id)?;
+        tx.commit()?;
+        Ok(())
+    }
+
+    pub async fn list_dispatches(
+        &self,
+        query: ListDispatchesQuery,
+    ) -> AppResult<ListDispatchesResult> {
+        let limit = query.limit.unwrap_or(100).clamp(1, 500);
+        let mut values = Vec::new();
+        let mut sql = String::from(
+            "SELECT id, created_at, agent_id, slug, agent_label, session_id, tool_name, page_id, target_id, url, title, args_json, result_meta, duration_ms, dispatch_id, has_screenshot FROM tool_dispatches WHERE 1 = 1",
+        );
+        if let Some(agent_id) = query.agent_id {
+            sql.push_str(" AND agent_id = ?");
+            values.push(Value::from(agent_id));
+        }
+        if let Some(session_id) = query.session_id {
+            sql.push_str(" AND session_id = ?");
+            values.push(Value::from(session_id));
+        }
+        if let Some(cursor) = query.cursor {
+            sql.push_str(" AND id < ?");
+            values.push(Value::from(cursor));
+        }
+        sql.push_str(" ORDER BY id DESC LIMIT ?");
+        values.push(Value::from(limit + 1));
+        let conn = self.conn.lock().await;
+        let mut stmt = conn.prepare(&sql)?;
+        let mut rows = stmt
+            .query_map(rusqlite::params_from_iter(values.iter()), map_dispatch_row)?
+            .collect::<Result<Vec<_>, _>>()?;
+        let next_cursor = if rows.len() > usize::try_from(limit).unwrap_or(500) {
+            rows.truncate(usize::try_from(limit).unwrap_or(500));
+            rows.last().map(|row| row.id)
+        } else {
+            None
+        };
+        Ok(ListDispatchesResult { rows, next_cursor })
+    }
+
+    pub async fn list_tasks(&self, query: ListTasksQuery) -> AppResult<ListTasksResult> {
+        let limit = query.limit.unwrap_or(25).clamp(1, 100);
+        let mut values = Vec::new();
+        let mut sql = String::from(
+            "SELECT session_id, agent_id, slug, agent_label, title, site, started_at, ended_at, duration_ms, dispatch_count, tool_sequence_json, status, error_count, last_screenshot_dispatch_id, cursor_id, has_screenshots FROM tasks WHERE 1 = 1",
+        );
+        if let Some(agent_id) = query.agent_id {
+            sql.push_str(" AND agent_id = ?");
+            values.push(Value::from(agent_id));
+        }
+        if let Some(status) = query.status {
+            sql.push_str(" AND status = ?");
+            values.push(Value::from(status.as_str().to_string()));
+        }
+        if let Some(site) = query.site {
+            sql.push_str(" AND site = ?");
+            values.push(Value::from(site));
+        }
+        if let Some(since) = query.since {
+            sql.push_str(" AND started_at >= ?");
+            values.push(Value::from(since));
+        }
+        if let Some(search) = query.search {
+            sql.push_str(" AND (lower(title) LIKE ? OR lower(agent_label) LIKE ? OR lower(coalesce(site, '')) LIKE ?)");
+            let pattern = format!("%{}%", search.to_ascii_lowercase());
+            values.push(Value::from(pattern.clone()));
+            values.push(Value::from(pattern.clone()));
+            values.push(Value::from(pattern));
+        }
+        if let Some(cursor) = query.cursor {
+            sql.push_str(" AND cursor_id < ?");
+            values.push(Value::from(cursor));
+        }
+        sql.push_str(" ORDER BY cursor_id DESC, started_at DESC LIMIT ?");
+        values.push(Value::from(limit + 1));
+        let conn = self.conn.lock().await;
+        let mut stmt = conn.prepare(&sql)?;
+        let mut tasks = stmt
+            .query_map(rusqlite::params_from_iter(values.iter()), map_task_summary)?
+            .collect::<Result<Vec<_>, _>>()?;
+        let next_cursor = if tasks.len() > usize::try_from(limit).unwrap_or(100) {
+            tasks.truncate(usize::try_from(limit).unwrap_or(100));
+            tasks.last().map(|task| task.cursor_id)
+        } else {
+            None
+        };
+        Ok(ListTasksResult { tasks, next_cursor })
+    }
+
+    pub async fn get_task(&self, session_id: &str) -> AppResult<Option<TaskDetail>> {
+        let conn = self.conn.lock().await;
+        let summary = conn
+            .query_row(
+                "SELECT session_id, agent_id, slug, agent_label, title, site, started_at, ended_at, duration_ms, dispatch_count, tool_sequence_json, status, error_count, last_screenshot_dispatch_id, cursor_id, has_screenshots FROM tasks WHERE session_id = ?1",
+                params![session_id],
+                map_task_summary,
+            )
+            .optional()?;
+        let Some(summary) = summary else {
+            return Ok(None);
+        };
+        let dispatches = query_dispatches_for_session(&conn, session_id)?;
+        let screenshot_dispatch_ids = dispatches
+            .iter()
+            .filter(|row| row.has_screenshot && !result_is_error(row.result_meta.as_deref()))
+            .map(|row| row.id)
+            .collect();
+        let start_event = conn
+            .query_row(
+                "SELECT created_at, client_name, client_version FROM agent_session_starts WHERE session_id = ?1 ORDER BY id LIMIT 1",
+                params![session_id],
+                |row| {
+                    Ok(SessionStartEvent {
+                        created_at: row.get(0)?,
+                        client_name: row.get(1)?,
+                        client_version: row.get(2)?,
+                    })
+                },
+            )
+            .optional()?;
+        let end_event = conn
+            .query_row(
+                "SELECT created_at, kind, reason FROM agent_session_ends WHERE session_id = ?1 ORDER BY id LIMIT 1",
+                params![session_id],
+                |row| {
+                    Ok(SessionEndEvent {
+                        created_at: row.get(0)?,
+                        kind: row.get(1)?,
+                        reason: row.get(2)?,
+                    })
+                },
+            )
+            .optional()?;
+        Ok(Some(TaskDetail {
+            summary,
+            dispatches,
+            screenshot_dispatch_ids,
+            start_event,
+            end_event,
+        }))
+    }
+}
+
+fn open_connection(path: PathBuf) -> AppResult<Connection> {
+    let conn = Connection::open(path)?;
+    conn.pragma_update(None, "journal_mode", "WAL")?;
+    conn.pragma_update(None, "synchronous", "NORMAL")?;
+    conn.pragma_update(None, "foreign_keys", "ON")?;
+    run_migrations(&conn)?;
+    Ok(conn)
+}
+
+fn run_migrations(conn: &Connection) -> AppResult<()> {
+    let existing: Option<String> = conn
+        .query_row(
+            "SELECT name FROM sqlite_master WHERE type = 'table' AND name = 'tool_dispatches'",
+            [],
+            |row| row.get(0),
+        )
+        .optional()?;
+    if existing.is_none() {
+        conn.execute_batch(DRIZZLE_0000)?;
+        conn.execute_batch(DRIZZLE_0001)?;
+        conn.execute_batch(
+            r#"CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                hash text NOT NULL,
+                created_at numeric
+            );"#,
+        )?;
+        conn.execute(
+            "INSERT INTO __drizzle_migrations (hash, created_at)
+             SELECT ?1, ?2 WHERE NOT EXISTS (SELECT 1 FROM __drizzle_migrations WHERE created_at = ?2)",
+            params!["0000_add_tool_dispatches", 1782320133071_i64],
+        )?;
+        conn.execute(
+            "INSERT INTO __drizzle_migrations (hash, created_at)
+             SELECT ?1, ?2 WHERE NOT EXISTS (SELECT 1 FROM __drizzle_migrations WHERE created_at = ?2)",
+            params!["0001_add_agent_session_events", 1782387594647_i64],
+        )?;
+    }
+    add_column_if_missing(conn, "tool_dispatches", "dispatch_id", "TEXT")?;
+    add_column_if_missing(
+        conn,
+        "tool_dispatches",
+        "has_screenshot",
+        "INTEGER NOT NULL DEFAULT 0",
+    )?;
+    conn.execute_batch(
+        r#"
+        CREATE TABLE IF NOT EXISTS tasks (
+            session_id TEXT PRIMARY KEY NOT NULL,
+            agent_id TEXT NOT NULL,
+            slug TEXT NOT NULL,
+            agent_label TEXT NOT NULL,
+            title TEXT NOT NULL,
+            site TEXT,
+            started_at INTEGER NOT NULL,
+            ended_at INTEGER,
+            duration_ms INTEGER NOT NULL,
+            dispatch_count INTEGER NOT NULL,
+            tool_sequence_json TEXT NOT NULL,
+            status TEXT NOT NULL,
+            error_count INTEGER NOT NULL,
+            last_screenshot_dispatch_id INTEGER,
+            cursor_id INTEGER NOT NULL,
+            has_screenshots INTEGER NOT NULL DEFAULT 0,
+            updated_at INTEGER NOT NULL
+        );
+        CREATE INDEX IF NOT EXISTS tasks_cursor_idx ON tasks (cursor_id DESC);
+        CREATE INDEX IF NOT EXISTS tasks_agent_cursor_idx ON tasks (agent_id, cursor_id DESC);
+        CREATE INDEX IF NOT EXISTS tasks_status_cursor_idx ON tasks (status, cursor_id DESC);
+        CREATE INDEX IF NOT EXISTS tasks_site_cursor_idx ON tasks (site, cursor_id DESC);
+        CREATE INDEX IF NOT EXISTS tasks_started_idx ON tasks (started_at);
+        "#,
+    )?;
+    Ok(())
+}
+
+fn add_column_if_missing(conn: &Connection, table: &str, column: &str, ddl: &str) -> AppResult<()> {
+    let mut stmt = conn.prepare(&format!("PRAGMA table_info({table})"))?;
+    let exists = stmt
+        .query_map([], |row| row.get::<_, String>(1))?
+        .collect::<Result<Vec<_>, _>>()?
+        .iter()
+        .any(|name| name == column);
+    if !exists {
+        conn.execute_batch(&format!("ALTER TABLE {table} ADD COLUMN {column} {ddl};"))?;
+    }
+    Ok(())
+}
+
+fn recompute_task(conn: &Connection, session_id: &str) -> AppResult<()> {
+    let dispatches = query_dispatches_for_session(conn, session_id)?;
+    let start = query_start(conn, session_id)?;
+    let end = query_end(conn, session_id)?;
+    if dispatches.is_empty() && start.is_none() {
+        return Ok(());
+    }
+    let first_dispatch = dispatches.first();
+    let last_dispatch = dispatches.last();
+    let started_at = start
+        .as_ref()
+        .map(|event| event.created_at)
+        .or_else(|| first_dispatch.map(|row| row.created_at))
+        .unwrap_or_else(now_epoch_ms);
+    let ended_at = end.as_ref().map(|event| event.created_at);
+    let agent_id = first_dispatch
+        .map(|row| row.agent_id.clone())
+        .or_else(|| start.as_ref().map(|event| event.agent_id.clone()))
+        .unwrap_or_default();
+    let slug = first_dispatch
+        .map(|row| row.slug.clone())
+        .or_else(|| start.as_ref().map(|event| event.slug.clone()))
+        .unwrap_or_default();
+    let agent_label = first_dispatch
+        .map(|row| row.agent_label.clone())
+        .or_else(|| start.as_ref().map(|event| event.agent_label.clone()))
+        .unwrap_or_else(|| "agent".to_string());
+    let site = first_site_of(&dispatches);
+    let title = site
+        .as_ref()
+        .map(|site| format!("Browsed {site}"))
+        .unwrap_or_else(|| format!("Session on {agent_label}"));
+    let cursor_id = last_dispatch.map(|row| row.id).unwrap_or(0);
+    let last_at = last_dispatch
+        .map(|row| row.created_at)
+        .unwrap_or(started_at);
+    let duration_ms = ended_at.unwrap_or(last_at).saturating_sub(started_at);
+    let error_count = dispatches
+        .iter()
+        .filter(|row| result_is_error(row.result_meta.as_deref()))
+        .count() as i64;
+    let status = derive_status(error_count, end.as_ref());
+    let tool_sequence: Vec<String> = dispatches.iter().map(|row| row.tool_name.clone()).collect();
+    let screenshot_ids: Vec<i64> = dispatches
+        .iter()
+        .filter(|row| row.has_screenshot && !result_is_error(row.result_meta.as_deref()))
+        .map(|row| row.id)
+        .collect();
+    let last_screenshot_dispatch_id = screenshot_ids.last().copied();
+    conn.execute(
+        "INSERT INTO tasks
+            (session_id, agent_id, slug, agent_label, title, site, started_at, ended_at, duration_ms, dispatch_count, tool_sequence_json, status, error_count, last_screenshot_dispatch_id, cursor_id, has_screenshots, updated_at)
+         VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
+         ON CONFLICT(session_id) DO UPDATE SET
+            agent_id = excluded.agent_id,
+            slug = excluded.slug,
+            agent_label = excluded.agent_label,
+            title = excluded.title,
+            site = excluded.site,
+            started_at = excluded.started_at,
+            ended_at = excluded.ended_at,
+            duration_ms = excluded.duration_ms,
+            dispatch_count = excluded.dispatch_count,
+            tool_sequence_json = excluded.tool_sequence_json,
+            status = excluded.status,
+            error_count = excluded.error_count,
+            last_screenshot_dispatch_id = excluded.last_screenshot_dispatch_id,
+            cursor_id = excluded.cursor_id,
+            has_screenshots = excluded.has_screenshots,
+            updated_at = excluded.updated_at",
+        params![
+            session_id,
+            agent_id,
+            slug,
+            agent_label,
+            title,
+            site,
+            started_at,
+            ended_at,
+            duration_ms,
+            i64::try_from(dispatches.len()).unwrap_or(i64::MAX),
+            serde_json::to_string(&tool_sequence)?,
+            status.as_str(),
+            error_count,
+            last_screenshot_dispatch_id,
+            cursor_id,
+            if screenshot_ids.is_empty() { 0 } else { 1 },
+            now_epoch_ms(),
+        ],
+    )?;
+    Ok(())
+}
+
+fn query_dispatches_for_session(
+    conn: &Connection,
+    session_id: &str,
+) -> AppResult<Vec<ToolDispatchRow>> {
+    let mut stmt = conn.prepare("SELECT id, created_at, agent_id, slug, agent_label, session_id, tool_name, page_id, target_id, url, title, args_json, result_meta, duration_ms, dispatch_id, has_screenshot FROM tool_dispatches WHERE session_id = ?1 ORDER BY id")?;
+    let rows = stmt
+        .query_map(params![session_id], map_dispatch_row)?
+        .collect::<Result<Vec<_>, _>>()?;
+    Ok(rows)
+}
+
+#[derive(Debug)]
+struct StartRow {
+    created_at: i64,
+    agent_id: String,
+    slug: String,
+    agent_label: String,
+}
+
+fn query_start(conn: &Connection, session_id: &str) -> AppResult<Option<StartRow>> {
+    conn.query_row(
+        "SELECT created_at, agent_id, slug, agent_label FROM agent_session_starts WHERE session_id = ?1 ORDER BY id LIMIT 1",
+        params![session_id],
+        |row| {
+            Ok(StartRow {
+                created_at: row.get(0)?,
+                agent_id: row.get(1)?,
+                slug: row.get(2)?,
+                agent_label: row.get(3)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(AppError::from)
+}
+
+fn query_end(conn: &Connection, session_id: &str) -> AppResult<Option<SessionEndEvent>> {
+    conn.query_row(
+        "SELECT created_at, kind, reason FROM agent_session_ends WHERE session_id = ?1 ORDER BY id LIMIT 1",
+        params![session_id],
+        |row| {
+            Ok(SessionEndEvent {
+                created_at: row.get(0)?,
+                kind: row.get(1)?,
+                reason: row.get(2)?,
+            })
+        },
+    )
+    .optional()
+    .map_err(AppError::from)
+}
+
+fn map_dispatch_row(row: &rusqlite::Row<'_>) -> rusqlite::Result<ToolDispatchRow> {
+    Ok(ToolDispatchRow {
+        id: row.get(0)?,
+        created_at: row.get(1)?,
+        agent_id: row.get(2)?,
+        slug: row.get(3)?,
+        agent_label: row.get(4)?,
+        session_id: row.get(5)?,
+        tool_name: row.get(6)?,
+        page_id: row.get(7)?,
+        target_id: row.get(8)?,
+        url: row.get(9)?,
+        title: row.get(10)?,
+        args_json: row.get(11)?,
+        result_meta: row.get(12)?,
+        duration_ms: row.get(13)?,
+        dispatch_id: row.get(14)?,
+        has_screenshot: row.get::<_, i64>(15)? != 0,
+    })
+}
+
+fn map_task_summary(row: &rusqlite::Row<'_>) -> rusqlite::Result<TaskSummary> {
+    let tool_sequence_json: String = row.get(10)?;
+    let tool_sequence =
+        serde_json::from_str::<Vec<String>>(&tool_sequence_json).unwrap_or_default();
+    Ok(TaskSummary {
+        session_id: row.get(0)?,
+        agent_id: row.get(1)?,
+        slug: row.get(2)?,
+        agent_label: row.get(3)?,
+        title: row.get(4)?,
+        site: row.get(5)?,
+        started_at: row.get(6)?,
+        ended_at: row.get(7)?,
+        duration_ms: row.get(8)?,
+        dispatch_count: row.get(9)?,
+        tool_sequence,
+        status: TaskStatus::from_db(row.get(11)?),
+        error_count: row.get(12)?,
+        last_screenshot_dispatch_id: row.get(13)?,
+        cursor_id: row.get(14)?,
+        has_screenshots: row.get::<_, i64>(15)? != 0,
+    })
+}
+
+fn derive_status(error_count: i64, end: Option<&SessionEndEvent>) -> TaskStatus {
+    if end.map(|event| event.kind.as_str()) == Some("errored") || error_count > 0 {
+        TaskStatus::Failed
+    } else if end.map(|event| event.kind.as_str()) == Some("closed") {
+        TaskStatus::Done
+    } else {
+        TaskStatus::Live
+    }
+}
+
+fn first_site_of(dispatches: &[ToolDispatchRow]) -> Option<String> {
+    for row in dispatches {
+        if let Some(url) = row.url.as_deref().and_then(hostname_of) {
+            return Some(url);
+        }
+    }
+    for row in dispatches {
+        if let Some(url) = row
+            .args_json
+            .as_deref()
+            .and_then(url_from_args)
+            .and_then(|url| hostname_of(&url))
+        {
+            return Some(url);
+        }
+    }
+    None
+}
+
+fn hostname_of(raw: &str) -> Option<String> {
+    Url::parse(raw)
+        .ok()
+        .and_then(|url| url.host_str().map(str::to_string))
+}
+
+fn url_from_args(raw: &str) -> Option<String> {
+    serde_json::from_str::<serde_json::Value>(raw)
+        .ok()
+        .and_then(|value| {
+            value
+                .get("url")
+                .and_then(serde_json::Value::as_str)
+                .map(str::to_string)
+        })
+}
+
+fn result_is_error(result_meta: Option<&str>) -> bool {
+    result_meta
+        .and_then(|raw| serde_json::from_str::<serde_json::Value>(raw).ok())
+        .and_then(|value| value.get("isError").and_then(serde_json::Value::as_bool))
+        .unwrap_or(false)
+}
+
+fn safe_stringify(value: &serde_json::Value) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_| "\"<unserialisable>\"".to_string())
+}
+
+fn truncate(value: &str) -> String {
+    if value.len() <= ARGS_JSON_MAX {
+        value.to_string()
+    } else {
+        format!("{}~", &value[..ARGS_JSON_MAX - 1])
+    }
+}
+
+fn summarize_result(result: &DispatchResultSummary) -> String {
+    let structured_keys: Vec<String> = result
+        .structured_content
+        .as_object()
+        .map(|obj| obj.keys().cloned().collect())
+        .unwrap_or_default();
+    let content_summary = result
+        .content
+        .as_array()
+        .map(|items| format!("{} block(s)", items.len()))
+        .unwrap_or_else(|| "unknown".to_string());
+    json!({
+        "isError": result.is_error,
+        "contentSummary": content_summary,
+        "structuredKeys": structured_keys,
+    })
+    .to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        AuditService, DispatchResultSummary, ListTasksQuery, RecordToolDispatchInput, TaskStatus,
+    };
+    use serde_json::json;
+    use tempfile::tempdir;
+
+    fn dispatch(session_id: &str, url: &str, is_error: bool) -> RecordToolDispatchInput {
+        RecordToolDispatchInput {
+            agent_id: if session_id.starts_with("a") {
+                "agent-a"
+            } else {
+                "agent-b"
+            }
+            .to_string(),
+            slug: "agent".to_string(),
+            agent_label: "Agent".to_string(),
+            session_id: session_id.to_string(),
+            tool_name: "navigate".to_string(),
+            page_id: Some(1),
+            target_id: Some("target".to_string()),
+            url: Some(url.to_string()),
+            title: None,
+            raw_args: json!({ "url": url }),
+            duration_ms: 10,
+            result: DispatchResultSummary {
+                is_error,
+                structured_content: json!({ "page": 1 }),
+                content: json!([{ "type": "text", "text": "ok" }]),
+            },
+        }
+    }
+
+    #[tokio::test]
+    async fn migrations_and_dispatch_pagination_work() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let audit = AuditService::open(dir.path().join("audit.sqlite")).await?;
+        assert!(
+            audit
+                .list_dispatches(Default::default())
+                .await?
+                .rows
+                .is_empty()
+        );
+        for idx in 0..5 {
+            let url = format!("https://example{idx}.com");
+            audit
+                .record_tool_dispatch(dispatch("a1", &url, false))
+                .await?;
+        }
+        let first = audit
+            .list_dispatches(super::ListDispatchesQuery {
+                limit: Some(2),
+                ..Default::default()
+            })
+            .await?;
+        assert_eq!(first.rows.len(), 2);
+        assert!(first.next_cursor.is_some());
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn task_filters_compose_before_pagination() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let audit = AuditService::open(dir.path().join("audit.sqlite")).await?;
+        audit
+            .record_tool_dispatch(dispatch("a1", "https://alpha.example.com", false))
+            .await?;
+        audit.record_session_end("a1", "closed", None).await?;
+        audit
+            .record_tool_dispatch(dispatch("b1", "https://beta.example.com", true))
+            .await?;
+        let done = audit
+            .list_tasks(ListTasksQuery {
+                status: Some(TaskStatus::Done),
+                search: Some("alpha".to_string()),
+                limit: Some(1),
+                ..Default::default()
+            })
+            .await?;
+        assert_eq!(done.tasks.len(), 1);
+        assert_eq!(done.tasks[0].session_id, "a1");
+        assert_eq!(done.next_cursor, None);
+        let failed = audit
+            .list_tasks(ListTasksQuery {
+                status: Some(TaskStatus::Failed),
+                site: Some("beta.example.com".to_string()),
+                ..Default::default()
+            })
+            .await?;
+        assert_eq!(failed.tasks.len(), 1);
+        assert_eq!(failed.tasks[0].session_id, "b1");
+        Ok(())
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/browser.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/browser.rs
@@ -1,0 +1,136 @@
+use browseros_cdp::{CdpClient, ConnectOptions, ReconnectPolicy};
+use browseros_core::Browser;
+use serde::Serialize;
+use std::{sync::Arc, time::Duration};
+use tokio::{
+    sync::{RwLock, watch},
+    task::JoinHandle,
+};
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, warn};
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct BrowserConnectionState {
+    pub connected: bool,
+    pub epoch: u64,
+    pub last_error: Option<String>,
+}
+
+pub struct BrowserService {
+    cdp_port: u16,
+    state_tx: watch::Sender<BrowserConnectionState>,
+    session: Arc<RwLock<Option<Arc<browseros_core::BrowserSession>>>>,
+    cancel: CancellationToken,
+}
+
+impl BrowserService {
+    #[must_use]
+    pub fn new(cdp_port: u16) -> Arc<Self> {
+        let (state_tx, _) = watch::channel(BrowserConnectionState {
+            connected: false,
+            epoch: 0,
+            last_error: None,
+        });
+        Arc::new(Self {
+            cdp_port,
+            state_tx,
+            session: Arc::new(RwLock::new(None)),
+            cancel: CancellationToken::new(),
+        })
+    }
+
+    pub fn start(self: &Arc<Self>) -> JoinHandle<()> {
+        let service = self.clone();
+        tokio::spawn(async move {
+            service.reattach_loop().await;
+        })
+    }
+
+    #[must_use]
+    pub fn state(&self) -> BrowserConnectionState {
+        self.state_tx.borrow().clone()
+    }
+
+    pub async fn session(&self) -> Option<Arc<browseros_core::BrowserSession>> {
+        self.session.read().await.clone()
+    }
+
+    pub fn stop(&self) {
+        self.cancel.cancel();
+    }
+
+    async fn reattach_loop(self: Arc<Self>) {
+        let mut backoff = Duration::from_secs(1);
+        loop {
+            if self.cancel.is_cancelled() {
+                return;
+            }
+            let opts = ConnectOptions {
+                port: self.cdp_port,
+                connect_timeout: Duration::from_secs(2),
+                connect_max_retries: 1,
+                reconnect_policy: ReconnectPolicy::KeepTrying,
+                reconnect_delay: Duration::from_secs(1),
+                reconnect_max_retries: usize::MAX,
+                ..ConnectOptions::new(self.cdp_port)
+            };
+            match CdpClient::connect(opts).await {
+                Ok(client) => {
+                    let browser = Browser::new(Arc::new(client.clone()));
+                    let session = browser.session();
+                    *self.session.write().await = Some(session);
+                    let epoch = client.epoch();
+                    let _ = self.state_tx.send(BrowserConnectionState {
+                        connected: true,
+                        epoch,
+                        last_error: None,
+                    });
+                    debug!(epoch, "connected to BrowserOS CDP");
+                    self.monitor_client(client).await;
+                    *self.session.write().await = None;
+                    backoff = Duration::from_secs(1);
+                }
+                Err(err) => {
+                    let _ = self.state_tx.send(BrowserConnectionState {
+                        connected: false,
+                        epoch: self.state_tx.borrow().epoch,
+                        last_error: Some(err.to_string()),
+                    });
+                    warn!(error = %err, retry_ms = backoff.as_millis(), "CDP connect failed; retrying");
+                    tokio::select! {
+                        () = self.cancel.cancelled() => return,
+                        () = tokio::time::sleep(backoff) => {}
+                    }
+                    backoff = (backoff * 2).min(Duration::from_secs(30));
+                }
+            }
+        }
+    }
+
+    async fn monitor_client(&self, client: CdpClient) {
+        let mut last_connected = true;
+        let mut last_epoch = client.epoch();
+        loop {
+            tokio::select! {
+                () = self.cancel.cancelled() => {
+                    client.disconnect().await;
+                    return;
+                }
+                () = tokio::time::sleep(Duration::from_secs(1)) => {
+                    let connected = client.is_connected();
+                    let epoch = client.epoch();
+                    if connected != last_connected || epoch != last_epoch {
+                        let _ = self.state_tx.send(BrowserConnectionState {
+                            connected,
+                            epoch,
+                            last_error: if connected { None } else { Some("CDP disconnected; reconnecting".to_string()) },
+                        });
+                        last_connected = connected;
+                        last_epoch = epoch;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/harness/manifest.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/harness/manifest.rs
@@ -1,0 +1,101 @@
+use crate::{
+    error::{AppError, AppResult, IoPath},
+    services::harness::surfaces::McpServerSpec,
+};
+use serde::{Deserialize, Serialize};
+use std::{collections::BTreeMap, path::Path};
+use tokio::fs;
+
+const MANIFEST_FILE: &str = "manifest.json";
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HarnessManifest {
+    pub version: u32,
+    pub servers: BTreeMap<String, HarnessServer>,
+    pub links: Vec<HarnessLink>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HarnessServer {
+    pub spec: McpServerSpec,
+    pub added_at: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct HarnessLink {
+    pub server_name: String,
+    pub agent: String,
+    pub config_path: String,
+}
+
+impl Default for HarnessManifest {
+    fn default() -> Self {
+        Self {
+            version: 1,
+            servers: BTreeMap::new(),
+            links: Vec::new(),
+        }
+    }
+}
+
+impl HarnessManifest {
+    pub async fn load(workspace_dir: &Path) -> AppResult<Self> {
+        let path = workspace_dir.join(MANIFEST_FILE);
+        match fs::read_to_string(&path).await {
+            Ok(raw) => serde_json::from_str(&raw).map_err(AppError::from),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(source) => Err(AppError::Io {
+                path: Some(path),
+                source,
+            }),
+        }
+    }
+
+    pub async fn save(&self, workspace_dir: &Path) -> AppResult<()> {
+        fs::create_dir_all(workspace_dir)
+            .await
+            .with_path(workspace_dir)?;
+        let path = workspace_dir.join(MANIFEST_FILE);
+        let tmp = workspace_dir.join("manifest.json.tmp");
+        fs::write(&tmp, serde_json::to_string_pretty(self)?)
+            .await
+            .with_path(tmp.clone())?;
+        fs::rename(&tmp, &path).await.with_path(path)
+    }
+
+    pub fn upsert_server(&mut self, name: &str, spec: McpServerSpec) {
+        self.servers.insert(
+            name.to_string(),
+            HarnessServer {
+                spec,
+                added_at: crate::services::now_iso(),
+            },
+        );
+    }
+
+    pub fn remove_server(&mut self, name: &str) {
+        self.servers.remove(name);
+    }
+
+    pub fn upsert_link(&mut self, link: HarnessLink) {
+        self.links.retain(|existing| {
+            !(existing.server_name == link.server_name && existing.agent == link.agent)
+        });
+        self.links.push(link);
+    }
+
+    pub fn remove_link(&mut self, server_name: &str, agent: &str) {
+        self.links
+            .retain(|link| !(link.server_name == server_name && link.agent == agent));
+    }
+
+    #[must_use]
+    pub fn has_links(&self, server_name: &str) -> bool {
+        self.links
+            .iter()
+            .any(|link| link.server_name == server_name)
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/harness/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/harness/mod.rs
@@ -1,0 +1,340 @@
+pub mod manifest;
+pub mod plan;
+pub mod surfaces;
+
+use crate::{
+    error::{AppError, AppResult},
+    services::agents::{Harness, HarnessInstallOutcome, StoredAgentProfile},
+};
+use manifest::{HarnessLink, HarnessManifest};
+use plan::{PlanAction, PlanOutcome};
+use std::{collections::BTreeMap, path::PathBuf, sync::Arc};
+use surfaces::{McpServerSpec, SurfacePaths, config_path_for};
+use tokio::sync::Mutex;
+use tracing::warn;
+
+pub const BROWSEROS_MCP_SERVER_NAME: &str = "BrowserClaw";
+
+#[derive(Clone)]
+pub struct HarnessService {
+    workspace_dir: PathBuf,
+    home_dir: PathBuf,
+    paths: SurfacePaths,
+    mutex: Arc<Mutex<()>>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConnectionState {
+    pub harness: Harness,
+    pub installed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config_path: Option<String>,
+    pub agent_id: Option<String>,
+    pub message: String,
+}
+
+impl HarnessService {
+    #[must_use]
+    pub fn new(workspace_dir: PathBuf, home_dir: PathBuf) -> Self {
+        Self {
+            workspace_dir,
+            home_dir,
+            paths: SurfacePaths::default(),
+            mutex: Arc::new(Mutex::new(())),
+        }
+    }
+
+    #[must_use]
+    pub fn with_paths(workspace_dir: PathBuf, home_dir: PathBuf, paths: SurfacePaths) -> Self {
+        Self {
+            workspace_dir,
+            home_dir,
+            paths,
+            mutex: Arc::new(Mutex::new(())),
+        }
+    }
+
+    pub async fn install_for_agent(&self, profile: &StoredAgentProfile) -> HarnessInstallOutcome {
+        match self
+            .connect(
+                profile.harness,
+                profile.slug.as_str(),
+                profile.mcp_url.as_str(),
+                false,
+            )
+            .await
+        {
+            Ok(state) => HarnessInstallOutcome {
+                installed: state.installed,
+                message: if state.installed {
+                    format!("Endpoint registered with {}.", profile.harness)
+                } else {
+                    state.message
+                },
+                agent: state.agent_id,
+                config_path: state.config_path,
+            },
+            Err(err) => HarnessInstallOutcome {
+                installed: false,
+                message: format!(
+                    "Could not register endpoint with {}: {err}",
+                    profile.harness
+                ),
+                agent: profile.harness.agent_id().map(str::to_string),
+                config_path: None,
+            },
+        }
+    }
+
+    pub async fn uninstall_for_agent(&self, profile: &StoredAgentProfile) -> HarnessInstallOutcome {
+        match self
+            .disconnect(profile.harness, profile.slug.as_str())
+            .await
+        {
+            Ok(state) => HarnessInstallOutcome {
+                installed: state.installed,
+                message: if state.installed {
+                    state.message
+                } else {
+                    format!("Endpoint unregistered from {}.", profile.harness)
+                },
+                agent: state.agent_id,
+                config_path: state.config_path,
+            },
+            Err(err) => HarnessInstallOutcome {
+                installed: false,
+                message: format!(
+                    "Could not unregister endpoint from {}: {err}",
+                    profile.harness
+                ),
+                agent: profile.harness.agent_id().map(str::to_string),
+                config_path: None,
+            },
+        }
+    }
+
+    pub async fn reconcile_agent_link(
+        &self,
+        before: &StoredAgentProfile,
+        after: &StoredAgentProfile,
+    ) {
+        if before.harness == after.harness
+            && before.slug == after.slug
+            && before.mcp_url == after.mcp_url
+        {
+            return;
+        }
+        if let Err(err) = self
+            .connect(
+                after.harness,
+                after.slug.as_str(),
+                after.mcp_url.as_str(),
+                false,
+            )
+            .await
+        {
+            warn!(error = %err, "agent harness relink install failed");
+        }
+        if (before.harness != after.harness || before.slug != after.slug)
+            && let Err(err) = self.disconnect(before.harness, before.slug.as_str()).await
+        {
+            warn!(error = %err, "agent harness relink uninstall failed");
+        }
+    }
+
+    pub async fn connect_browseros(
+        &self,
+        harness: Harness,
+        mcp_url: &str,
+    ) -> AppResult<ConnectionState> {
+        self.connect(harness, BROWSEROS_MCP_SERVER_NAME, mcp_url, true)
+            .await
+    }
+
+    pub async fn disconnect_browseros(&self, harness: Harness) -> AppResult<ConnectionState> {
+        self.disconnect(harness, BROWSEROS_MCP_SERVER_NAME).await
+    }
+
+    pub async fn list_browseros_connections(&self) -> AppResult<Vec<ConnectionState>> {
+        let manifest = self.load_manifest().await?;
+        let mut by_agent: BTreeMap<String, HarnessLink> = BTreeMap::new();
+        for link in manifest.links {
+            if link.server_name == BROWSEROS_MCP_SERVER_NAME {
+                by_agent.insert(link.agent.clone(), link);
+            }
+        }
+        Ok(Harness::ALL
+            .iter()
+            .copied()
+            .map(|harness| {
+                let Some(agent_id) = harness.agent_id() else {
+                    return ConnectionState {
+                        harness,
+                        installed: true,
+                        config_path: None,
+                        agent_id: None,
+                        message: format!("{harness} runs inside BrowserOS."),
+                    };
+                };
+                if let Some(link) = by_agent.get(agent_id) {
+                    return ConnectionState {
+                        harness,
+                        installed: true,
+                        config_path: Some(link.config_path.clone()),
+                        agent_id: Some(agent_id.to_string()),
+                        message: format!("Configured in {harness}."),
+                    };
+                }
+                ConnectionState {
+                    harness,
+                    installed: false,
+                    config_path: None,
+                    agent_id: Some(agent_id.to_string()),
+                    message: format!("{harness} is not configured."),
+                }
+            })
+            .collect())
+    }
+
+    pub async fn dry_run(
+        &self,
+        harness: Harness,
+        server_name: &str,
+        mcp_url: &str,
+    ) -> AppResult<PlanOutcome> {
+        let spec = spec_for(harness, mcp_url);
+        let config_path = config_path_for(harness, &self.home_dir, &self.paths)?;
+        plan::build_plan(PlanAction::Connect, harness, server_name, spec, config_path).await
+    }
+
+    pub async fn heal_claude_code_http_tags(&self) -> AppResult<usize> {
+        let path = config_path_for(Harness::ClaudeCode, &self.home_dir, &self.paths)?;
+        surfaces::heal_claude_code_http_tags(&path).await
+    }
+
+    async fn connect(
+        &self,
+        harness: Harness,
+        server_name: &str,
+        mcp_url: &str,
+        allow_overwrite: bool,
+    ) -> AppResult<ConnectionState> {
+        let Some(agent_id) = harness.agent_id() else {
+            return Ok(ConnectionState {
+                harness,
+                installed: true,
+                config_path: None,
+                agent_id: None,
+                message: format!("{harness} runs inside BrowserOS; no harness config to write."),
+            });
+        };
+        let _guard = self.mutex.lock().await;
+        let spec = spec_for(harness, mcp_url);
+        let config_path = config_path_for(harness, &self.home_dir, &self.paths)?;
+        let outcome = plan::build_plan(
+            PlanAction::Connect,
+            harness,
+            server_name,
+            spec.clone(),
+            config_path.clone(),
+        )
+        .await?;
+        outcome.apply(allow_overwrite).await?;
+        let mut manifest = self.load_manifest().await?;
+        manifest.upsert_server(server_name, spec);
+        manifest.upsert_link(HarnessLink {
+            server_name: server_name.to_string(),
+            agent: agent_id.to_string(),
+            config_path: config_path.to_string_lossy().to_string(),
+        });
+        self.save_manifest(&manifest).await?;
+        Ok(ConnectionState {
+            harness,
+            installed: true,
+            config_path: Some(config_path.to_string_lossy().to_string()),
+            agent_id: Some(agent_id.to_string()),
+            message: format!("BrowserOS registered as an MCP server in {harness}."),
+        })
+    }
+
+    async fn disconnect(&self, harness: Harness, server_name: &str) -> AppResult<ConnectionState> {
+        let Some(agent_id) = harness.agent_id() else {
+            return Ok(ConnectionState {
+                harness,
+                installed: false,
+                config_path: None,
+                agent_id: None,
+                message: format!("{harness} runs inside BrowserOS; nothing to disconnect."),
+            });
+        };
+        let _guard = self.mutex.lock().await;
+        let config_path = config_path_for(harness, &self.home_dir, &self.paths)?;
+        let outcome = plan::build_plan(
+            PlanAction::Disconnect,
+            harness,
+            server_name,
+            McpServerSpec::Http {
+                url: String::new(),
+                headers: BTreeMap::new(),
+            },
+            config_path.clone(),
+        )
+        .await?;
+        outcome.apply(false).await?;
+        let mut manifest = self.load_manifest().await?;
+        manifest.remove_link(server_name, agent_id);
+        if !manifest.has_links(server_name) {
+            manifest.remove_server(server_name);
+        }
+        self.save_manifest(&manifest).await?;
+        Ok(ConnectionState {
+            harness,
+            installed: false,
+            config_path: Some(config_path.to_string_lossy().to_string()),
+            agent_id: Some(agent_id.to_string()),
+            message: format!("BrowserOS unregistered from {harness}."),
+        })
+    }
+
+    async fn load_manifest(&self) -> AppResult<HarnessManifest> {
+        HarnessManifest::load(&self.workspace_dir).await
+    }
+
+    async fn save_manifest(&self, manifest: &HarnessManifest) -> AppResult<()> {
+        manifest.save(&self.workspace_dir).await
+    }
+}
+
+#[must_use]
+pub fn spec_for(harness: Harness, mcp_url: &str) -> McpServerSpec {
+    if supports_http(harness) {
+        return McpServerSpec::Http {
+            url: mcp_url.to_string(),
+            headers: BTreeMap::new(),
+        };
+    }
+    McpServerSpec::Stdio {
+        command: "npx".to_string(),
+        args: vec!["mcp-remote".to_string(), mcp_url.to_string()],
+        env: BTreeMap::new(),
+    }
+}
+
+fn supports_http(harness: Harness) -> bool {
+    matches!(
+        harness,
+        Harness::ClaudeCode
+            | Harness::Cursor
+            | Harness::VsCode
+            | Harness::Zed
+            | Harness::Codex
+            | Harness::GeminiCli
+    )
+}
+
+impl From<std::io::Error> for AppError {
+    fn from(source: std::io::Error) -> Self {
+        AppError::Io { path: None, source }
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/harness/plan.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/harness/plan.rs
@@ -1,0 +1,127 @@
+use crate::{
+    error::AppResult,
+    services::{agents::Harness, harness::surfaces},
+};
+use std::path::PathBuf;
+use surfaces::McpServerSpec;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PlanAction {
+    Connect,
+    Disconnect,
+}
+
+#[derive(Debug, Clone)]
+pub struct PlanOutcome {
+    pub action: PlanAction,
+    pub harness: Harness,
+    pub server_name: String,
+    pub spec: McpServerSpec,
+    pub config_path: PathBuf,
+}
+
+pub async fn build_plan(
+    action: PlanAction,
+    harness: Harness,
+    server_name: &str,
+    spec: McpServerSpec,
+    config_path: PathBuf,
+) -> AppResult<PlanOutcome> {
+    Ok(PlanOutcome {
+        action,
+        harness,
+        server_name: server_name.to_string(),
+        spec,
+        config_path,
+    })
+}
+
+impl PlanOutcome {
+    pub async fn verify(&self) -> AppResult<bool> {
+        surfaces::has_entry(self.harness, &self.config_path, &self.server_name).await
+    }
+
+    pub async fn apply(&self, allow_overwrite: bool) -> AppResult<()> {
+        match self.action {
+            PlanAction::Connect => {
+                let before = tokio::fs::read(&self.config_path).await.ok();
+                let result = surfaces::write_entry(
+                    self.harness,
+                    &self.config_path,
+                    &self.server_name,
+                    &self.spec,
+                    allow_overwrite,
+                )
+                .await;
+                if let Err(err) = result {
+                    self.rollback(before).await?;
+                    return Err(err);
+                }
+            }
+            PlanAction::Disconnect => {
+                surfaces::remove_entry(self.harness, &self.config_path, &self.server_name).await?;
+            }
+        }
+        Ok(())
+    }
+
+    pub async fn rollback(&self, before: Option<Vec<u8>>) -> AppResult<()> {
+        match before {
+            Some(bytes) => {
+                if let Some(parent) = self.config_path.parent() {
+                    tokio::fs::create_dir_all(parent).await?;
+                }
+                tokio::fs::write(&self.config_path, bytes).await?;
+            }
+            None => {
+                let _ = tokio::fs::remove_file(&self.config_path).await;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::services::{
+        agents::Harness,
+        harness::{HarnessService, surfaces::SurfacePaths},
+    };
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn dry_run_and_apply_for_each_surface() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let paths = SurfacePaths {
+            claude_code: Some(dir.path().join("claude.json")),
+            claude_desktop: Some(dir.path().join("claude_desktop.json")),
+            cursor: Some(dir.path().join("cursor.json")),
+            vscode: Some(dir.path().join("vscode.json")),
+            zed: Some(dir.path().join("zed.json")),
+            codex: Some(dir.path().join("config.toml")),
+            gemini: Some(dir.path().join("gemini.json")),
+        };
+        let service = HarnessService::with_paths(
+            dir.path().join("mcp-manager"),
+            dir.path().to_path_buf(),
+            paths,
+        );
+        for harness in [
+            Harness::ClaudeCode,
+            Harness::ClaudeDesktop,
+            Harness::Cursor,
+            Harness::VsCode,
+            Harness::Zed,
+            Harness::Codex,
+            Harness::GeminiCli,
+        ] {
+            let plan = service
+                .dry_run(harness, "BrowserClaw", "http://127.0.0.1:9200/mcp")
+                .await?;
+            assert!(!plan.verify().await?);
+            plan.apply(true).await?;
+            assert!(plan.verify().await?);
+        }
+        Ok(())
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/harness/surfaces.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/harness/surfaces.rs
@@ -1,0 +1,415 @@
+use crate::{
+    error::{AppError, AppResult, IoPath},
+    services::agents::Harness,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::{Map, Value, json};
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+use tokio::fs;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "transport", rename_all = "lowercase")]
+pub enum McpServerSpec {
+    Http {
+        url: String,
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        headers: BTreeMap<String, String>,
+    },
+    Stdio {
+        command: String,
+        #[serde(default)]
+        args: Vec<String>,
+        #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+        env: BTreeMap<String, String>,
+    },
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SurfacePaths {
+    pub claude_code: Option<PathBuf>,
+    pub claude_desktop: Option<PathBuf>,
+    pub cursor: Option<PathBuf>,
+    pub vscode: Option<PathBuf>,
+    pub zed: Option<PathBuf>,
+    pub codex: Option<PathBuf>,
+    pub gemini: Option<PathBuf>,
+}
+
+pub fn config_path_for(harness: Harness, home: &Path, paths: &SurfacePaths) -> AppResult<PathBuf> {
+    let path = match harness {
+        Harness::ClaudeCode => paths
+            .claude_code
+            .clone()
+            .unwrap_or_else(|| home.join(".claude.json")),
+        Harness::ClaudeDesktop => paths.claude_desktop.clone().unwrap_or_else(|| {
+            home.join("Library")
+                .join("Application Support")
+                .join("Claude")
+                .join("claude_desktop_config.json")
+        }),
+        Harness::Cursor => paths
+            .cursor
+            .clone()
+            .unwrap_or_else(|| home.join(".cursor").join("mcp.json")),
+        Harness::VsCode => paths.vscode.clone().unwrap_or_else(|| {
+            home.join("Library")
+                .join("Application Support")
+                .join("Code")
+                .join("User")
+                .join("mcp.json")
+        }),
+        Harness::Zed => paths
+            .zed
+            .clone()
+            .unwrap_or_else(|| home.join(".config").join("zed").join("settings.json")),
+        Harness::Codex => paths
+            .codex
+            .clone()
+            .unwrap_or_else(|| home.join(".codex").join("config.toml")),
+        Harness::GeminiCli => paths
+            .gemini
+            .clone()
+            .unwrap_or_else(|| home.join(".gemini").join("settings.json")),
+        Harness::Hermes | Harness::OpenClaw => {
+            return Err(AppError::bad_request("internal harness has no config path"));
+        }
+    };
+    Ok(path)
+}
+
+pub async fn write_entry(
+    harness: Harness,
+    path: &Path,
+    server_name: &str,
+    spec: &McpServerSpec,
+    allow_overwrite: bool,
+) -> AppResult<()> {
+    match harness {
+        Harness::Codex => write_codex_entry(path, server_name, spec, allow_overwrite).await,
+        Harness::VsCode => {
+            write_json_entry(
+                path,
+                "servers",
+                server_name,
+                spec,
+                allow_overwrite,
+                vs_code_entry,
+            )
+            .await
+        }
+        Harness::Zed => {
+            write_json_entry(
+                path,
+                "context_servers",
+                server_name,
+                spec,
+                allow_overwrite,
+                zed_entry,
+            )
+            .await
+        }
+        Harness::ClaudeCode => {
+            write_json_entry(
+                path,
+                "mcpServers",
+                server_name,
+                spec,
+                allow_overwrite,
+                claude_code_entry,
+            )
+            .await
+        }
+        Harness::ClaudeDesktop | Harness::Cursor | Harness::GeminiCli => {
+            write_json_entry(
+                path,
+                "mcpServers",
+                server_name,
+                spec,
+                allow_overwrite,
+                generic_entry,
+            )
+            .await
+        }
+        Harness::Hermes | Harness::OpenClaw => Ok(()),
+    }
+}
+
+pub async fn remove_entry(harness: Harness, path: &Path, server_name: &str) -> AppResult<()> {
+    match harness {
+        Harness::Codex => remove_codex_entry(path, server_name).await,
+        Harness::VsCode => remove_json_entry(path, "servers", server_name).await,
+        Harness::Zed => remove_json_entry(path, "context_servers", server_name).await,
+        Harness::ClaudeCode | Harness::ClaudeDesktop | Harness::Cursor | Harness::GeminiCli => {
+            remove_json_entry(path, "mcpServers", server_name).await
+        }
+        Harness::Hermes | Harness::OpenClaw => Ok(()),
+    }
+}
+
+pub async fn has_entry(harness: Harness, path: &Path, server_name: &str) -> AppResult<bool> {
+    match harness {
+        Harness::Codex => {
+            let value = read_toml_value(path).await?;
+            Ok(value
+                .get("mcp_servers")
+                .and_then(toml::Value::as_table)
+                .and_then(|table| table.get(server_name))
+                .is_some())
+        }
+        Harness::VsCode => json_has_entry(path, "servers", server_name).await,
+        Harness::Zed => json_has_entry(path, "context_servers", server_name).await,
+        Harness::ClaudeCode | Harness::ClaudeDesktop | Harness::Cursor | Harness::GeminiCli => {
+            json_has_entry(path, "mcpServers", server_name).await
+        }
+        Harness::Hermes | Harness::OpenClaw => Ok(true),
+    }
+}
+
+pub async fn heal_claude_code_http_tags(path: &Path) -> AppResult<usize> {
+    let mut root = read_json_value(path).await?;
+    let Some(servers) = root.get_mut("mcpServers").and_then(Value::as_object_mut) else {
+        return Ok(0);
+    };
+    let mut changed = 0;
+    for name in ["BrowserClaw", "browseros"] {
+        let Some(entry) = servers.get_mut(name).and_then(Value::as_object_mut) else {
+            continue;
+        };
+        let is_local = entry
+            .get("url")
+            .and_then(Value::as_str)
+            .map(is_local_mcp_url)
+            .unwrap_or(false);
+        if is_local && !entry.contains_key("type") {
+            entry.insert("type".to_string(), Value::String("http".to_string()));
+            changed += 1;
+        }
+    }
+    if changed > 0 {
+        write_json_value(path, &root).await?;
+    }
+    Ok(changed)
+}
+
+fn generic_entry(spec: &McpServerSpec) -> Value {
+    match spec {
+        McpServerSpec::Http { url, .. } => json!({ "url": url }),
+        McpServerSpec::Stdio { command, args, env } => {
+            let mut value = json!({ "command": command, "args": args });
+            if !env.is_empty()
+                && let Some(obj) = value.as_object_mut()
+            {
+                obj.insert("env".to_string(), json!(env));
+            }
+            value
+        }
+    }
+}
+
+fn claude_code_entry(spec: &McpServerSpec) -> Value {
+    match spec {
+        McpServerSpec::Http { url, .. } => json!({ "type": "http", "url": url }),
+        McpServerSpec::Stdio { command, args, env } => {
+            let mut value = json!({ "type": "stdio", "command": command, "args": args });
+            if !env.is_empty()
+                && let Some(obj) = value.as_object_mut()
+            {
+                obj.insert("env".to_string(), json!(env));
+            }
+            value
+        }
+    }
+}
+
+fn vs_code_entry(spec: &McpServerSpec) -> Value {
+    let mut value = generic_entry(spec);
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert(
+            "type".to_string(),
+            Value::String(
+                match spec {
+                    McpServerSpec::Http { .. } => "http",
+                    McpServerSpec::Stdio { .. } => "stdio",
+                }
+                .to_string(),
+            ),
+        );
+    }
+    value
+}
+
+fn zed_entry(spec: &McpServerSpec) -> Value {
+    let mut value = generic_entry(spec);
+    if let Some(obj) = value.as_object_mut() {
+        obj.insert("source".to_string(), Value::String("custom".to_string()));
+        obj.insert("enabled".to_string(), Value::Bool(true));
+    }
+    value
+}
+
+async fn write_json_entry(
+    path: &Path,
+    key: &str,
+    server_name: &str,
+    spec: &McpServerSpec,
+    _allow_overwrite: bool,
+    render: fn(&McpServerSpec) -> Value,
+) -> AppResult<()> {
+    let mut root = read_json_value(path).await?;
+    let object = ensure_object(&mut root);
+    let servers = object
+        .entry(key.to_string())
+        .or_insert_with(|| Value::Object(Map::new()));
+    let Some(server_map) = servers.as_object_mut() else {
+        return Err(AppError::bad_request(format!("{key} must be an object")));
+    };
+    server_map.insert(server_name.to_string(), render(spec));
+    write_json_value(path, &root).await
+}
+
+async fn remove_json_entry(path: &Path, key: &str, server_name: &str) -> AppResult<()> {
+    let mut root = read_json_value(path).await?;
+    if let Some(map) = root.get_mut(key).and_then(Value::as_object_mut) {
+        map.remove(server_name);
+    }
+    write_json_value(path, &root).await
+}
+
+async fn json_has_entry(path: &Path, key: &str, server_name: &str) -> AppResult<bool> {
+    let root = read_json_value(path).await?;
+    Ok(root
+        .get(key)
+        .and_then(Value::as_object)
+        .map(|map| map.contains_key(server_name))
+        .unwrap_or(false))
+}
+
+async fn write_codex_entry(
+    path: &Path,
+    server_name: &str,
+    spec: &McpServerSpec,
+    _allow_overwrite: bool,
+) -> AppResult<()> {
+    let mut root = read_toml_value(path).await?;
+    let table = root
+        .as_table_mut()
+        .ok_or_else(|| AppError::bad_request("Codex config root must be a TOML table"))?;
+    let servers = table
+        .entry("mcp_servers".to_string())
+        .or_insert_with(|| toml::Value::Table(toml::map::Map::new()));
+    let Some(server_table) = servers.as_table_mut() else {
+        return Err(AppError::bad_request("mcp_servers must be a TOML table"));
+    };
+    server_table.insert(server_name.to_string(), spec_to_toml(spec));
+    write_toml_value(path, &root).await
+}
+
+async fn remove_codex_entry(path: &Path, server_name: &str) -> AppResult<()> {
+    let mut root = read_toml_value(path).await?;
+    if let Some(map) = root
+        .get_mut("mcp_servers")
+        .and_then(toml::Value::as_table_mut)
+    {
+        map.remove(server_name);
+    }
+    write_toml_value(path, &root).await
+}
+
+fn spec_to_toml(spec: &McpServerSpec) -> toml::Value {
+    let mut table = toml::map::Map::new();
+    match spec {
+        McpServerSpec::Http { url, headers } => {
+            table.insert("url".to_string(), toml::Value::String(url.clone()));
+            if !headers.is_empty() {
+                table.insert(
+                    "http_headers".to_string(),
+                    toml::Value::try_from(headers)
+                        .unwrap_or_else(|_| toml::Value::Table(toml::map::Map::new())),
+                );
+            }
+        }
+        McpServerSpec::Stdio { command, args, env } => {
+            table.insert("command".to_string(), toml::Value::String(command.clone()));
+            table.insert(
+                "args".to_string(),
+                toml::Value::Array(args.iter().cloned().map(toml::Value::String).collect()),
+            );
+            if !env.is_empty() {
+                table.insert(
+                    "env".to_string(),
+                    toml::Value::try_from(env)
+                        .unwrap_or_else(|_| toml::Value::Table(toml::map::Map::new())),
+                );
+            }
+        }
+    }
+    toml::Value::Table(table)
+}
+
+async fn read_json_value(path: &Path) -> AppResult<Value> {
+    match fs::read_to_string(path).await {
+        Ok(raw) if raw.trim().is_empty() => Ok(Value::Object(Map::new())),
+        Ok(raw) => serde_json::from_str(&raw).map_err(AppError::from),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Value::Object(Map::new())),
+        Err(source) => Err(AppError::Io {
+            path: Some(path.to_path_buf()),
+            source,
+        }),
+    }
+}
+
+async fn write_json_value(path: &Path, value: &Value) -> AppResult<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).await.with_path(parent)?;
+    }
+    let body = serde_json::to_string_pretty(value)?;
+    fs::write(path, format!("{body}\n")).await.with_path(path)
+}
+
+async fn read_toml_value(path: &Path) -> AppResult<toml::Value> {
+    match fs::read_to_string(path).await {
+        Ok(raw) if raw.trim().is_empty() => Ok(toml::Value::Table(toml::map::Map::new())),
+        Ok(raw) => raw.parse::<toml::Value>().map_err(|err| {
+            AppError::Internal(format!("invalid TOML at {}: {err}", path.display()))
+        }),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            Ok(toml::Value::Table(toml::map::Map::new()))
+        }
+        Err(source) => Err(AppError::Io {
+            path: Some(path.to_path_buf()),
+            source,
+        }),
+    }
+}
+
+async fn write_toml_value(path: &Path, value: &toml::Value) -> AppResult<()> {
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).await.with_path(parent)?;
+    }
+    let body = toml::to_string_pretty(value)
+        .map_err(|err| AppError::Internal(format!("failed to encode TOML: {err}")))?;
+    fs::write(path, body).await.with_path(path)
+}
+
+fn ensure_object(value: &mut Value) -> &mut Map<String, Value> {
+    if !value.is_object() {
+        *value = Value::Object(Map::new());
+    }
+    match value {
+        Value::Object(map) => map,
+        _ => unreachable!("value forced to object"),
+    }
+}
+
+fn is_local_mcp_url(value: &str) -> bool {
+    let Some(rest) = value.strip_prefix("http://127.0.0.1:") else {
+        return false;
+    };
+    let Some(port) = rest.strip_suffix("/mcp") else {
+        return false;
+    };
+    !port.is_empty() && port.chars().all(|ch| ch.is_ascii_digit())
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/mod.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/mod.rs
@@ -1,0 +1,45 @@
+pub mod agents;
+pub mod audit;
+pub mod browser;
+pub mod harness;
+pub mod replay;
+pub mod screenshots;
+pub mod site_rules;
+pub mod tab_activity;
+
+pub(crate) fn now_epoch_ms() -> i64 {
+    match std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH) {
+        Ok(duration) => i64::try_from(duration.as_millis()).unwrap_or(i64::MAX),
+        Err(_) => 0,
+    }
+}
+
+pub(crate) fn now_iso() -> String {
+    let now = time::OffsetDateTime::now_utc();
+    match now.format(&time::format_description::well_known::Rfc3339) {
+        Ok(value) => value,
+        Err(_) => now.unix_timestamp().to_string(),
+    }
+}
+
+pub(crate) fn slugify(input: &str) -> String {
+    let mut out = String::new();
+    let mut pending_dash = false;
+    for ch in input.chars().flat_map(char::to_lowercase) {
+        if ch.is_ascii_alphanumeric() {
+            if pending_dash && !out.is_empty() {
+                out.push('-');
+            }
+            pending_dash = false;
+            out.push(ch);
+        } else {
+            pending_dash = true;
+        }
+    }
+    let trimmed = out.trim_matches('-').to_string();
+    if trimmed.is_empty() {
+        "agent".to_string()
+    } else {
+        trimmed
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/replay.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/replay.rs
@@ -1,0 +1,252 @@
+use crate::error::{AppError, AppResult, IoPath};
+use serde::Serialize;
+use serde_json::Value;
+use std::{
+    collections::{BTreeSet, HashMap, VecDeque},
+    path::{Path, PathBuf},
+    sync::Arc,
+    time::{Duration, Instant},
+};
+use tokio::{fs, io::AsyncWriteExt, sync::Mutex};
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ReplayMetadata {
+    pub has_data: bool,
+    pub size_bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub first_event_at: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_event_at: Option<i64>,
+    pub tab_page_ids: Vec<i64>,
+}
+
+pub struct ReplayService {
+    root: PathBuf,
+    max_open_handles: usize,
+    idle_handle: Duration,
+    inner: Mutex<ReplayInner>,
+}
+
+struct ReplayInner {
+    locks: HashMap<String, Arc<Mutex<()>>>,
+    lru: VecDeque<(String, Instant)>,
+}
+
+impl ReplayService {
+    #[must_use]
+    pub fn new(root: PathBuf, max_open_handles: usize, idle_handle: Duration) -> Self {
+        Self {
+            root,
+            max_open_handles,
+            idle_handle,
+            inner: Mutex::new(ReplayInner {
+                locks: HashMap::new(),
+                lru: VecDeque::new(),
+            }),
+        }
+    }
+
+    pub async fn append_events(&self, session_id: &str, lines: &[String]) -> AppResult<()> {
+        if lines.is_empty() {
+            return Ok(());
+        }
+        let lock = self.lock_for(session_id).await;
+        let _guard = lock.lock().await;
+        let path = self.path_for(session_id);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).await.with_path(parent)?;
+        }
+        let mut file = fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+            .await
+            .with_path(path.clone())?;
+        let mut payload = lines.join("\n");
+        payload.push('\n');
+        file.write_all(payload.as_bytes()).await.with_path(path)?;
+        self.bump_lru(session_id).await;
+        Ok(())
+    }
+
+    pub async fn read_events(&self, session_id: &str) -> AppResult<Vec<u8>> {
+        let path = self.path_for(session_id);
+        match fs::read(&path).await {
+            Ok(bytes) => Ok(bytes),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(Vec::new()),
+            Err(source) => Err(AppError::Io {
+                path: Some(path),
+                source,
+            }),
+        }
+    }
+
+    pub async fn stat_session(&self, session_id: &str) -> AppResult<ReplayMetadata> {
+        let path = self.path_for(session_id);
+        let meta = match fs::metadata(&path).await {
+            Ok(meta) => meta,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(empty_meta()),
+            Err(source) => {
+                return Err(AppError::Io {
+                    path: Some(path),
+                    source,
+                });
+            }
+        };
+        if meta.len() == 0 {
+            return Ok(empty_meta());
+        }
+        let raw = fs::read_to_string(&path).await.with_path(path)?;
+        let mut first_event_at = None;
+        let mut last_event_at = None;
+        let mut tab_page_ids = BTreeSet::new();
+        for line in raw.lines().filter(|line| !line.trim().is_empty()) {
+            if let Ok(value) = serde_json::from_str::<Value>(line) {
+                if first_event_at.is_none() {
+                    first_event_at = value.get("ts").and_then(Value::as_i64);
+                }
+                if let Some(ts) = value.get("ts").and_then(Value::as_i64) {
+                    last_event_at = Some(ts);
+                }
+                if let Some(id) = value.get("tabPageId").and_then(Value::as_i64) {
+                    tab_page_ids.insert(id);
+                }
+            }
+        }
+        Ok(ReplayMetadata {
+            has_data: true,
+            size_bytes: meta.len(),
+            first_event_at,
+            last_event_at,
+            tab_page_ids: tab_page_ids.into_iter().collect(),
+        })
+    }
+
+    pub async fn delete_session(&self, session_id: &str) -> AppResult<()> {
+        let path = self.path_for(session_id);
+        match fs::remove_file(&path).await {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(source) => Err(AppError::Io {
+                path: Some(path),
+                source,
+            }),
+        }
+    }
+
+    pub async fn close_session(&self, session_id: &str) -> AppResult<()> {
+        let mut inner = self.inner.lock().await;
+        inner.locks.remove(&sanitize_session_id(session_id));
+        inner
+            .lru
+            .retain(|(id, _)| id != &sanitize_session_id(session_id));
+        Ok(())
+    }
+
+    #[must_use]
+    pub fn annotate_with_session_id(line: &str, session_id: &str) -> String {
+        match serde_json::from_str::<Value>(line) {
+            Ok(Value::Object(mut obj)) => {
+                obj.insert(
+                    "sessionId".to_string(),
+                    Value::String(session_id.to_string()),
+                );
+                Value::Object(obj).to_string()
+            }
+            _ => line.to_string(),
+        }
+    }
+
+    async fn lock_for(&self, session_id: &str) -> Arc<Mutex<()>> {
+        let key = sanitize_session_id(session_id);
+        let mut inner = self.inner.lock().await;
+        inner
+            .locks
+            .entry(key)
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone()
+    }
+
+    async fn bump_lru(&self, session_id: &str) {
+        let key = sanitize_session_id(session_id);
+        let mut inner = self.inner.lock().await;
+        let now = Instant::now();
+        inner.lru.retain(|(id, at)| {
+            id != &key && now.saturating_duration_since(*at) <= self.idle_handle
+        });
+        inner.lru.push_back((key.clone(), now));
+        while inner.lru.len() > self.max_open_handles {
+            if let Some((old, _)) = inner.lru.pop_front() {
+                inner.locks.remove(&old);
+            }
+        }
+    }
+
+    fn path_for(&self, session_id: &str) -> PathBuf {
+        self.root
+            .join(format!("{}.ndjson", sanitize_session_id(session_id)))
+    }
+}
+
+fn empty_meta() -> ReplayMetadata {
+    ReplayMetadata {
+        has_data: false,
+        size_bytes: 0,
+        first_event_at: None,
+        last_event_at: None,
+        tab_page_ids: Vec::new(),
+    }
+}
+
+fn sanitize_session_id(session_id: &str) -> String {
+    session_id
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() || ch == '.' || ch == '_' || ch == '-' {
+                ch
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+#[allow(dead_code)]
+fn _assert_path(_: &Path) {}
+
+#[cfg(test)]
+mod tests {
+    use super::ReplayService;
+    use std::time::Duration;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn appends_and_stats_replay_lines() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let replay = ReplayService::new(dir.path().to_path_buf(), 50, Duration::from_secs(30));
+        let lines = vec![
+            ReplayService::annotate_with_session_id(r#"{"tabPageId":1,"ts":100}"#, "s1"),
+            ReplayService::annotate_with_session_id(r#"{"tabPageId":2,"ts":200}"#, "s1"),
+        ];
+        replay.append_events("s1", &lines).await?;
+        let meta = replay.stat_session("s1").await?;
+        assert!(meta.has_data);
+        assert_eq!(meta.first_event_at, Some(100));
+        assert_eq!(meta.last_event_at, Some(200));
+        assert_eq!(meta.tab_page_ids, vec![1, 2]);
+        let text = String::from_utf8(replay.read_events("s1").await?)?;
+        assert!(text.contains(r#""sessionId":"s1""#));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn unknown_replay_has_empty_metadata() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let replay = ReplayService::new(dir.path().to_path_buf(), 50, Duration::from_secs(30));
+        let meta = replay.stat_session("missing").await?;
+        assert!(!meta.has_data);
+        assert_eq!(meta.size_bytes, 0);
+        Ok(())
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/screenshots.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/screenshots.rs
@@ -1,0 +1,42 @@
+use crate::error::{AppError, AppResult, IoPath};
+use std::path::PathBuf;
+use tokio::fs;
+
+#[derive(Clone)]
+pub struct ScreenshotService {
+    root: PathBuf,
+}
+
+impl ScreenshotService {
+    #[must_use]
+    pub fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    #[must_use]
+    pub fn path_for(&self, dispatch_id: &str) -> PathBuf {
+        self.root.join(format!("{dispatch_id}.jpg"))
+    }
+
+    pub async fn read(&self, dispatch_id: &str) -> AppResult<Vec<u8>> {
+        let path = self.path_for(dispatch_id);
+        match fs::read(&path).await {
+            Ok(bytes) => Ok(bytes),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                Err(AppError::not_found("not found"))
+            }
+            Err(source) => Err(AppError::Io {
+                path: Some(path),
+                source,
+            }),
+        }
+    }
+
+    pub async fn write(&self, dispatch_id: &str, bytes: &[u8]) -> AppResult<()> {
+        let path = self.path_for(dispatch_id);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).await.with_path(parent)?;
+        }
+        fs::write(&path, bytes).await.with_path(path)
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/site_rules.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/site_rules.rs
@@ -1,0 +1,144 @@
+use crate::{
+    error::{AppError, AppResult},
+    storage::JsonStore,
+};
+use serde::{Deserialize, Serialize};
+use std::{fmt, str::FromStr, sync::Arc};
+use tokio::sync::Mutex;
+use ulid::Ulid;
+
+const FILE: &str = "site-rules.json";
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SiteRuleAction {
+    Payments,
+    Submit,
+    Delete,
+    Navigate,
+    Upload,
+    Admin,
+}
+
+impl fmt::Display for SiteRuleAction {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::Payments => "payments",
+            Self::Submit => "submit",
+            Self::Delete => "delete",
+            Self::Navigate => "navigate",
+            Self::Upload => "upload",
+            Self::Admin => "admin",
+        })
+    }
+}
+
+impl FromStr for SiteRuleAction {
+    type Err = AppError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "payments" => Ok(Self::Payments),
+            "submit" => Ok(Self::Submit),
+            "delete" => Ok(Self::Delete),
+            "navigate" => Ok(Self::Navigate),
+            "upload" => Ok(Self::Upload),
+            "admin" => Ok(Self::Admin),
+            _ => Err(AppError::bad_request("unsupported site-rule action")),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AddSiteRule {
+    pub label: String,
+    pub domain: String,
+    pub action: SiteRuleAction,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SiteRule {
+    pub id: String,
+    pub label: String,
+    pub domain: String,
+    pub action: SiteRuleAction,
+}
+
+#[derive(Clone)]
+pub struct SiteRulesService {
+    store: JsonStore,
+    mutex: Arc<Mutex<()>>,
+}
+
+impl SiteRulesService {
+    #[must_use]
+    pub fn new(store: JsonStore) -> Self {
+        Self {
+            store,
+            mutex: Arc::new(Mutex::new(())),
+        }
+    }
+
+    pub async fn list(&self) -> AppResult<Vec<SiteRule>> {
+        match self.store.read_json(FILE).await {
+            Ok(rules) => Ok(rules),
+            Err(AppError::StorageNotFound(_)) => Ok(Vec::new()),
+            Err(err) => Err(err),
+        }
+    }
+
+    pub async fn add(&self, input: AddSiteRule) -> AppResult<SiteRule> {
+        input.validate()?;
+        let _guard = self.mutex.lock().await;
+        let mut rules = self.list().await?;
+        let rule = SiteRule {
+            id: Ulid::new().to_string(),
+            label: input.label,
+            domain: input.domain,
+            action: input.action,
+        };
+        rules.push(rule.clone());
+        self.store.write_json(FILE, &rules).await?;
+        Ok(rule)
+    }
+
+    pub async fn remove(&self, id: &str) -> AppResult<Option<serde_json::Value>> {
+        if !is_valid_id(id) {
+            return Ok(None);
+        }
+        let _guard = self.mutex.lock().await;
+        if !self.store.file_exists(FILE).await? {
+            return Ok(None);
+        }
+        let rules = self.list().await?;
+        let original_len = rules.len();
+        let next: Vec<SiteRule> = rules.into_iter().filter(|rule| rule.id != id).collect();
+        if next.len() == original_len {
+            return Ok(None);
+        }
+        self.store.write_json(FILE, &next).await?;
+        Ok(Some(serde_json::json!({ "id": id })))
+    }
+}
+
+impl AddSiteRule {
+    fn validate(&self) -> AppResult<()> {
+        if self.label.trim().is_empty() {
+            return Err(AppError::bad_request("label is required"));
+        }
+        if self.domain.trim().is_empty() {
+            return Err(AppError::bad_request("domain is required"));
+        }
+        Ok(())
+    }
+}
+
+fn is_valid_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 64
+        && id
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || ch == '_' || ch == '-')
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/services/tab_activity.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/tab_activity.rs
@@ -1,0 +1,169 @@
+use browseros_core::TargetId;
+use serde::Serialize;
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+use tokio::sync::Mutex;
+
+const ACTIVE_WINDOW: Duration = Duration::from_secs(30);
+const RECENT_TOOLS_CAP: usize = 8;
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ToolEvent {
+    pub name: String,
+    pub at: i64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TabActivityRecord {
+    pub target_id: String,
+    pub page_id: u32,
+    pub url: String,
+    pub title: String,
+    pub agent_id: String,
+    pub slug: String,
+    pub first_tool_at: i64,
+    pub last_tool_at: i64,
+    pub last_tool_name: String,
+    pub tool_count: usize,
+    pub recent_tools: Vec<ToolEvent>,
+    pub status: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EnrichedTabRecord {
+    #[serde(flatten)]
+    pub record: TabActivityRecord,
+    pub agent_label: String,
+    pub harness: Option<String>,
+    pub color: Option<String>,
+    pub screencast: Option<ScreencastFrame>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ScreencastFrame {
+    pub jpeg_base64: String,
+    pub captured_at: i64,
+}
+
+#[derive(Debug, Clone)]
+struct RawRecord {
+    target_id: String,
+    page_id: u32,
+    url: String,
+    title: String,
+    agent_id: String,
+    slug: String,
+    first_tool_at: i64,
+    last_tool_at: i64,
+    last_tool_name: String,
+    tool_count: usize,
+    recent_tools: VecDeque<ToolEvent>,
+}
+
+#[derive(Clone, Default)]
+pub struct TabActivityService {
+    records: Arc<Mutex<HashMap<String, RawRecord>>>,
+}
+
+pub struct RecordToolInput {
+    pub target_id: TargetId,
+    pub page_id: u32,
+    pub url: String,
+    pub title: String,
+    pub agent_id: String,
+    pub slug: String,
+    pub tool_name: String,
+}
+
+impl TabActivityService {
+    pub async fn record_tool(&self, input: RecordToolInput) {
+        let now = now_ms();
+        let target_key = input.target_id.into_inner();
+        let mut records = self.records.lock().await;
+        if let Some(existing) = records.get_mut(&target_key) {
+            existing.page_id = input.page_id;
+            existing.url = input.url;
+            existing.title = input.title;
+            existing.agent_id = input.agent_id;
+            existing.slug = input.slug;
+            existing.last_tool_at = now;
+            existing.last_tool_name = input.tool_name.clone();
+            existing.tool_count += 1;
+            existing.recent_tools.push_back(ToolEvent {
+                name: input.tool_name,
+                at: now,
+            });
+            while existing.recent_tools.len() > RECENT_TOOLS_CAP {
+                existing.recent_tools.pop_front();
+            }
+            return;
+        }
+        let mut recent_tools = VecDeque::new();
+        recent_tools.push_back(ToolEvent {
+            name: input.tool_name.clone(),
+            at: now,
+        });
+        records.insert(
+            target_key.clone(),
+            RawRecord {
+                target_id: target_key,
+                page_id: input.page_id,
+                url: input.url,
+                title: input.title,
+                agent_id: input.agent_id,
+                slug: input.slug,
+                first_tool_at: now,
+                last_tool_at: now,
+                last_tool_name: input.tool_name,
+                tool_count: 1,
+                recent_tools,
+            },
+        );
+    }
+
+    pub async fn snapshot(&self) -> Vec<TabActivityRecord> {
+        let now = now_ms();
+        let mut rows: Vec<_> = self
+            .records
+            .lock()
+            .await
+            .values()
+            .map(|record| TabActivityRecord {
+                target_id: record.target_id.clone(),
+                page_id: record.page_id,
+                url: record.url.clone(),
+                title: record.title.clone(),
+                agent_id: record.agent_id.clone(),
+                slug: record.slug.clone(),
+                first_tool_at: record.first_tool_at,
+                last_tool_at: record.last_tool_at,
+                last_tool_name: record.last_tool_name.clone(),
+                tool_count: record.tool_count,
+                recent_tools: record.recent_tools.iter().cloned().collect(),
+                status: if now.saturating_sub(record.last_tool_at)
+                    < i64::try_from(ACTIVE_WINDOW.as_millis()).unwrap_or(30_000)
+                {
+                    "active"
+                } else {
+                    "idle"
+                },
+            })
+            .collect();
+        rows.sort_by(|a, b| b.last_tool_at.cmp(&a.last_tool_at));
+        rows
+    }
+}
+
+fn now_ms() -> i64 {
+    match SystemTime::now().duration_since(UNIX_EPOCH) {
+        Ok(duration) => i64::try_from(duration.as_millis()).unwrap_or(i64::MAX),
+        Err(_) => 0,
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/src/storage.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/storage.rs
@@ -1,0 +1,202 @@
+use crate::error::{AppError, AppResult, IoPath};
+use serde::{Serialize, de::DeserializeOwned};
+use std::{
+    ffi::OsStr,
+    path::{Component, Path, PathBuf},
+    sync::Arc,
+};
+use tokio::fs;
+
+#[derive(Debug, Clone)]
+pub struct JsonStore {
+    root: Arc<PathBuf>,
+}
+
+impl JsonStore {
+    #[must_use]
+    pub fn new(root: PathBuf) -> Self {
+        Self {
+            root: Arc::new(root),
+        }
+    }
+
+    #[must_use]
+    pub fn root(&self) -> &Path {
+        self.root.as_ref()
+    }
+
+    pub async fn ensure_dir(&self, rel_dir: &str) -> AppResult<()> {
+        let abs = self.resolve(rel_dir)?;
+        fs::create_dir_all(&abs).await.with_path(abs)
+    }
+
+    pub async fn read_json<T>(&self, rel_path: &str) -> AppResult<T>
+    where
+        T: DeserializeOwned,
+    {
+        let abs = self.resolve(rel_path)?;
+        let raw = match fs::read_to_string(&abs).await {
+            Ok(raw) => raw,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                return Err(AppError::StorageNotFound(rel_path.to_string()));
+            }
+            Err(source) => {
+                return Err(AppError::Io {
+                    path: Some(abs),
+                    source,
+                });
+            }
+        };
+        serde_json::from_str(&raw).map_err(|source| AppError::StorageCorrupt {
+            path: rel_path.to_string(),
+            source,
+        })
+    }
+
+    pub async fn write_json<T>(&self, rel_path: &str, value: &T) -> AppResult<()>
+    where
+        T: Serialize,
+    {
+        let abs = self.resolve(rel_path)?;
+        let parent = abs
+            .parent()
+            .map(Path::to_path_buf)
+            .ok_or_else(|| AppError::InvalidStoragePath(rel_path.to_string()))?;
+        fs::create_dir_all(&parent).await.with_path(parent)?;
+        let tmp = abs.with_extension(tmp_extension(abs.extension()));
+        let body = serde_json::to_string_pretty(value)?;
+        fs::write(&tmp, body).await.with_path(tmp.clone())?;
+        fs::rename(&tmp, &abs).await.with_path(abs)
+    }
+
+    pub async fn remove_file(&self, rel_path: &str) -> AppResult<bool> {
+        let abs = self.resolve(rel_path)?;
+        match fs::remove_file(&abs).await {
+            Ok(()) => Ok(true),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(source) => Err(AppError::Io {
+                path: Some(abs),
+                source,
+            }),
+        }
+    }
+
+    pub async fn file_exists(&self, rel_path: &str) -> AppResult<bool> {
+        let abs = self.resolve(rel_path)?;
+        match fs::metadata(&abs).await {
+            Ok(meta) => Ok(meta.is_file()),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(false),
+            Err(source) => Err(AppError::Io {
+                path: Some(abs),
+                source,
+            }),
+        }
+    }
+
+    pub async fn list_files(&self, rel_dir: &str, extension: &str) -> AppResult<Vec<String>> {
+        let abs = self.resolve(rel_dir)?;
+        let mut out = Vec::new();
+        let mut entries = match fs::read_dir(&abs).await {
+            Ok(entries) => entries,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(out),
+            Err(source) => {
+                return Err(AppError::Io {
+                    path: Some(abs),
+                    source,
+                });
+            }
+        };
+        while let Some(entry) = entries.next_entry().await.with_path(&abs)? {
+            let file_type = entry.file_type().await.with_path(entry.path())?;
+            if file_type.is_file() {
+                let name = entry.file_name().to_string_lossy().to_string();
+                if name.ends_with(extension) {
+                    out.push(name);
+                }
+            }
+        }
+        Ok(out)
+    }
+
+    pub fn resolve(&self, rel_path: &str) -> AppResult<PathBuf> {
+        guard_relative_path(rel_path)?;
+        Ok(self.root.join(rel_path))
+    }
+}
+
+fn guard_relative_path(rel_path: &str) -> AppResult<()> {
+    let path = Path::new(rel_path);
+    if path.is_absolute() {
+        return Err(AppError::InvalidStoragePath(rel_path.to_string()));
+    }
+    for component in path.components() {
+        if matches!(
+            component,
+            Component::ParentDir | Component::RootDir | Component::Prefix(_)
+        ) {
+            return Err(AppError::InvalidStoragePath(rel_path.to_string()));
+        }
+    }
+    Ok(())
+}
+
+fn tmp_extension(existing: Option<&OsStr>) -> String {
+    match existing.and_then(OsStr::to_str) {
+        Some(ext) if !ext.is_empty() => format!("{ext}.tmp"),
+        _ => "tmp".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::JsonStore;
+    use serde::{Deserialize, Serialize};
+    use tempfile::tempdir;
+
+    #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+    struct Row {
+        id: String,
+    }
+
+    #[tokio::test]
+    async fn atomic_json_roundtrip() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let store = JsonStore::new(dir.path().join("claw-server"));
+        store
+            .write_json(
+                "agents/a.json",
+                &Row {
+                    id: "a".to_string(),
+                },
+            )
+            .await?;
+        let row: Row = store.read_json("agents/a.json").await?;
+        assert_eq!(
+            row,
+            Row {
+                id: "a".to_string()
+            }
+        );
+        assert!(store.file_exists("agents/a.json").await?);
+        assert_eq!(store.list_files("agents", ".json").await?, vec!["a.json"]);
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn rejects_escape_paths() -> anyhow::Result<()> {
+        let dir = tempdir()?;
+        let store = JsonStore::new(dir.path().to_path_buf());
+        assert!(
+            store
+                .write_json(
+                    "../x.json",
+                    &Row {
+                        id: "x".to_string()
+                    }
+                )
+                .await
+                .is_err()
+        );
+        Ok(())
+    }
+}

--- a/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/tests/routes.rs
@@ -1,0 +1,198 @@
+use axum::{
+    Router,
+    body::{Body, to_bytes},
+    http::{Request, StatusCode, header},
+};
+use claw_server_rust::{AppState, build_router, config::Config};
+use serde_json::{Value, json};
+use std::{sync::Arc, time::Duration};
+use tempfile::TempDir;
+use tower::ServiceExt;
+
+struct TestApp {
+    router: Router,
+    _dir: TempDir,
+}
+
+async fn test_app() -> anyhow::Result<TestApp> {
+    let dir = tempfile::tempdir()?;
+    let root = dir.path().join("browseros");
+    let config = Arc::new(Config {
+        server_port: 9200,
+        cdp_port: 49337,
+        proxy_port: None,
+        resources_dir: dir.path().join("resources"),
+        browseros_dir: root.clone(),
+        claw_dir: root.join("claw-server"),
+        session_idle: Duration::from_secs(300),
+        session_sweep_interval: Duration::from_secs(60),
+        screencast_screenshot_fallback: true,
+        dev_mode: false,
+        auth_token: None,
+    });
+    let state = AppState::new_with_home(config, None, dir.path().join("home")).await?;
+    Ok(TestApp {
+        router: build_router(state),
+        _dir: dir,
+    })
+}
+
+async fn request_json(
+    router: &Router,
+    method: &str,
+    uri: &str,
+    body: Option<Value>,
+) -> anyhow::Result<(StatusCode, Value)> {
+    let mut builder = Request::builder().method(method).uri(uri);
+    let request_body = if let Some(body) = body {
+        builder = builder.header(header::CONTENT_TYPE, "application/json");
+        Body::from(body.to_string())
+    } else {
+        Body::empty()
+    };
+    let response = router.clone().oneshot(builder.body(request_body)?).await?;
+    let status = response.status();
+    let bytes = to_bytes(response.into_body(), usize::MAX).await?;
+    let value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes)?
+    };
+    Ok((status, value))
+}
+
+fn agent_body(name: &str) -> Value {
+    json!({
+        "name": name,
+        "harness": "Codex",
+        "loginMode": "profile",
+        "selectedSites": [],
+        "approvals": {
+            "submit": "Ask",
+            "payment": "Block",
+            "delete": "Ask",
+            "upload": "Ask",
+            "navigate": "Ask",
+            "input": "Auto"
+        },
+        "aclRuleIds": [],
+        "customAclRules": []
+    })
+}
+
+#[tokio::test]
+async fn health_survives_cdp_down() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let (status, body) = request_json(&app.router, "GET", "/system/health", None).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["status"], "ok");
+    assert_eq!(body["cdp"]["connected"], false);
+    Ok(())
+}
+
+#[tokio::test]
+async fn agents_crud_roundtrip() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let (status, created) = request_json(
+        &app.router,
+        "POST",
+        "/agents",
+        Some(agent_body("Finance Ops")),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::CREATED);
+    assert_eq!(created["slug"], "finance-ops");
+    let id = created["id"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("missing id"))?;
+
+    let (status, list) = request_json(&app.router, "GET", "/agents", None).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        list.as_array()
+            .ok_or_else(|| anyhow::anyhow!("list not array"))?
+            .len(),
+        1
+    );
+
+    let detail_path = format!("/agents/{id}");
+    let (status, detail) = request_json(&app.router, "GET", &detail_path, None).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(detail["name"], "Finance Ops");
+
+    let (status, updated) = request_json(
+        &app.router,
+        "PATCH",
+        &detail_path,
+        Some(agent_body("Renamed")),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(updated["slug"], "renamed");
+
+    let regen_path = format!("/agents/{id}/mcp-url:regenerate");
+    let (status, regen) = request_json(&app.router, "POST", &regen_path, None).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(regen["id"], id);
+
+    let (status, deleted) = request_json(&app.router, "DELETE", &detail_path, None).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(deleted["id"], id);
+    Ok(())
+}
+
+#[tokio::test]
+async fn site_rules_roundtrip() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let (status, empty) = request_json(&app.router, "GET", "/site-rules", None).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        empty
+            .as_array()
+            .ok_or_else(|| anyhow::anyhow!("site rules not array"))?
+            .len(),
+        0
+    );
+    let (status, created) = request_json(
+        &app.router,
+        "POST",
+        "/site-rules",
+        Some(json!({ "label": "Wire transfers", "domain": "mercury.com", "action": "payments" })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::CREATED);
+    let id = created["id"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("missing id"))?;
+    let delete_path = format!("/site-rules/{id}");
+    let (status, deleted) = request_json(&app.router, "DELETE", &delete_path, None).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(deleted["id"], id);
+    Ok(())
+}
+
+#[tokio::test]
+async fn audit_empty_and_replay_gone() -> anyhow::Result<()> {
+    let app = test_app().await?;
+    let (status, dispatches) = request_json(&app.router, "GET", "/audit/dispatches", None).await?;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        dispatches["rows"]
+            .as_array()
+            .ok_or_else(|| anyhow::anyhow!("rows not array"))?
+            .len(),
+        0
+    );
+    assert!(dispatches["nextCursor"].is_null());
+
+    let (status, body) = request_json(
+        &app.router,
+        "POST",
+        "/audit/replay/missing/events",
+        Some(json!({ "type": 3 })),
+    )
+    .await?;
+    assert_eq!(status, StatusCode::GONE);
+    assert_eq!(body["error"], "session not live");
+    Ok(())
+}

--- a/packages/browseros-agent/package.json
+++ b/packages/browseros-agent/package.json
@@ -36,6 +36,7 @@
     "build:claw-server": "FORCE_COLOR=1 bun scripts/build/claw-server.ts --target=all",
     "build:claw-server:ci": "FORCE_COLOR=1 bun scripts/build/claw-server.ts --target=all --ci",
     "build:claw-server:test": "FORCE_COLOR=1 bun scripts/build/claw-server.ts --target=darwin-arm64 --no-upload",
+    "build:claw-server-rust": "cargo build --release -p claw-server-rust",
     "build:rust": "cargo build --workspace",
     "test:rust": "cargo test --workspace",
     "lint:rust": "cargo clippy --workspace --all-targets -- -D warnings",


### PR DESCRIPTION
## Summary
- Adds `apps/claw-server-rust` as the Phase C axum binary crate (`browseros-claw-server-rs`) with immutable sidecar config, tracing, loopback bind, graceful shutdown, and a supervised CDP reattach loop.
- Implements redesigned domain/session registry, file-backed agent profiles and site rules, rusqlite audit storage with Drizzle-compatible base migrations plus materialized `tasks`, replay/screenshot/tab-activity services, and native harness config state machine.
- Mirrors the non-MCP REST routes and wire names used by claw-app; `/mcp` intentionally returns a Phase D 503 stub. `/tabs/activity` is passive in this phase, so screencast data is returned as `null` until the Phase D poller lands.
- Adds `bun run build:claw-server-rust` and wires the crate into the Cargo workspace.

## Verification
- `cargo build --workspace`
- `cargo test --workspace`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo fmt --all --check`
- Boot smoke: temp sidecar + temp `BROWSEROS_DIR`, health OK with CDP down, `/system/shutdown` exited 0
- `bun run build:claw-server-rust`
