### PR TITLE
chore(claw-onboard): render light-only, matching claw-app

### DIFF
--- a/packages/browseros-agent/apps/claw-onboard/src/main.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/main.tsx
@@ -4,30 +4,6 @@ import { BrowserRouter } from 'react-router'
 import { App } from './App'
 import './styles.css'
 
-// Track the OS color preference and mirror it onto <html> as `.dark`, which
-// flips the palette variables and the shadcn `dark:` variants. Applied as early
-// as the single inlined bundle allows — before React mounts, so app content
-// never renders on the wrong theme — and kept live via a change listener so
-// flipping OS appearance mid-onboarding updates immediately. The bundle is
-// deferred, so dark-mode users may still see a brief first-paint flash of the
-// light body gradient; a blocking inline <script> would avoid it but is
-// disallowed by the strict WebUI/extension CSP (the same reason claw-app
-// extracts its theme script to a module chunk, which this app's single-bundle
-// chromium contract also rules out). Onboarding is a first-run flow with no
-// theme toggle and the host bridge carries no theme signal, so
-// `prefers-color-scheme` is the source of truth.
-if (
-  typeof document !== 'undefined' &&
-  typeof window !== 'undefined' &&
-  typeof window.matchMedia === 'function'
-) {
-  const media = window.matchMedia('(prefers-color-scheme: dark)')
-  const applyTheme = (dark: boolean) =>
-    document.documentElement.classList.toggle('dark', dark)
-  applyTheme(media.matches)
-  media.addEventListener('change', (event) => applyTheme(event.matches))
-}
-
 const root = document.getElementById('root')
 if (!root) throw new Error('Root element not found')
 

--- a/packages/browseros-agent/apps/claw-onboard/src/styles.css
+++ b/packages/browseros-agent/apps/claw-onboard/src/styles.css
@@ -145,6 +145,10 @@ body {
   text-rendering: optimizeLegibility;
 }
 
+/* Dark wash, kept as a non-runtime fallback. The onboarding flow is
+   light-only — nothing applies `.dark` at runtime — but the block is kept so
+   any downstream tool or embedding scope that opts into `.dark` still gets a
+   coherent palette, mirroring claw-app. */
 .dark body {
   background:
     radial-gradient(
@@ -221,7 +225,10 @@ body {
   --blue: #0e7490;
 }
 
-/* Dark theme values; the ink scale inverts, tints go from pale washes to deep washes. */
+/* Dark theme values, not applied at runtime. The onboarding flow is light-only
+   (OS-theme mirroring was removed); the block is kept as the canonical palette
+   reference for any downstream tool or embedding scope that opts in via `.dark`,
+   mirroring claw-app. The ink scale inverts and tints go from pale to deep. */
 .dark {
   color-scheme: dark;
   --background: #0b0f17;


### PR DESCRIPTION
## Summary
- `claw-onboard` no longer mirrors the OS `prefers-color-scheme` onto `<html class="dark">`; it renders **light-only**, matching `claw-app`.
- Removed the runtime theme block (and its long explanatory comment) from `src/main.tsx` — the entry now mounts React directly, exactly like `claw-app`'s newtab `main.tsx`, which applies no theme at runtime.
- Kept the `.dark` CSS as a documented **non-runtime fallback**, re-pointing the comments to explain it's no longer applied at runtime.

## Design
The user asked to remove onboard's dark theme ("we just have light theme") and to "see how claw-app does this." `claw-app` is light-locked purely by **never applying `.dark` at runtime** (its `main.tsx` has zero theme code) while **retaining** the `.dark {}` token block, `.dark body` wash, `@custom-variant dark`, and the inert shadcn `dark:` variants as a canonical palette reference for any downstream tool/embedding that opts into `.dark`.

This PR mirrors that exactly:
- **Removed** onboard's `matchMedia('(prefers-color-scheme: dark)')` listener that toggled `.dark` on `<html>` → nothing triggers dark anymore, so the flow is light-only.
- **Retained + re-documented** the `.dark` token block, `.dark body`, and `@custom-variant dark` in `styles.css` as a non-runtime fallback.
- **Left untouched** the inert `dark:` utility variants in `components/ui/button.tsx` and `checkbox.tsx` — they're standard shadcn scaffolding, inert without a `.dark` ancestor, and `claw-app` keeps them too. Removing them would be a larger, unjustified change.

Net diff: 2 files, +8/-25.

## Test plan
- [x] `bun run typecheck` — clean
- [x] `bun run lint` (biome) — clean, 45 files
- [x] `bun test` — 59 pass / 0 fail (incl. `tests/build.test.ts` universal-build integration)
- [x] `bun run build:chromium` — tsc + chromium-mode vite build + WebUI resource-contract verifier all pass (single `app.js`/`app.css`/`index.html` bundle)
- [x] Grep confirms no residual `prefers-color-scheme` / `matchMedia` / `.dark` runtime application in `src/`