### PR TITLE
fix(patch): cover generated branding output ownership

### DIFF
--- a/packages/browseros/bos_build/features.yaml
+++ b/packages/browseros/bos_build/features.yaml
@@ -30,19 +30,43 @@ features:
   branding:
     description: "chore: browseros branding and identity"
     files:
-      # Product-generated identity outputs (BRANDING, updater branding,
-      # string replacements, chrome/VERSION, and logo binaries) are owned by
-      # bos_build product overlays/resources and filtered by bpatch annotate.
+      # Generated branding outputs are explicit so Sparkle setup outputs in
+      # the same theme tree can remain separately owned.
       # Version info
+      - chrome/VERSION
       - base/version_info/BUILD.gn
       - base/version_info/version_info.h
       - base/version_info/version_info_values.h.version
       # Branding file paths
+      - chrome/app/chromium_strings.grd
+      - chrome/app/settings_chromium_strings.grdp
+      - chrome/app/theme/chromium/BRANDING
+      - chrome/app/theme/chromium/chromeos/
+      - chrome/app/theme/chromium/chromium.ai
+      - chrome/app/theme/chromium/linux/
+      - chrome/app/theme/chromium/mac/Assets.car
+      - chrome/app/theme/chromium/mac/Assets.xcassets/
+      - chrome/app/theme/chromium/mac/app.icns
+      - chrome/app/theme/chromium/product_logo.ai
+      - chrome/app/theme/chromium/product_logo.svg
+      - chrome/app/theme/chromium/product_logo_128.png
+      - chrome/app/theme/chromium/product_logo_16.png
+      - chrome/app/theme/chromium/product_logo_22_mono.png
+      - chrome/app/theme/chromium/product_logo_24.png
+      - chrome/app/theme/chromium/product_logo_256.png
+      - chrome/app/theme/chromium/product_logo_48.png
+      - chrome/app/theme/chromium/product_logo_64.png
+      - chrome/app/theme/chromium/product_logo_animation.svg
+      - chrome/app/theme/chromium/win/
+      - chrome/app/theme/default_100_percent/chromium/
+      - chrome/app/theme/default_200_percent/chromium/
       - chrome/common/chrome_constants.cc
       - chrome/common/chrome_paths.cc
       - chrome/common/chrome_paths.h
       - chrome/common/chrome_paths_linux.cc
+      - chrome/enterprise_companion/branding.gni
       - chrome/install_static/chromium_install_modes.h
+      - chrome/updater/branding.gni
       # About page (version + branding display)
       - chrome/browser/resources/settings/about_page/about_page.html
       - chrome/browser/resources/settings/about_page/about_page.ts
@@ -107,6 +131,24 @@ features:
       - chrome/browser/ui/webui/help/version_updater_mac.mm
       - chrome/browser/lifetime/application_lifetime.cc
       - chrome/browser/upgrade_detector/upgrade_detector_impl.cc
+
+  sparkle-setup:
+    description: "chore: sparkle setup resources"
+    files:
+      - chrome/BROWSEROS_VERSION
+      - chrome/app/theme/chromium/mac/AppIcon.icns
+      - chrome/app/theme/chromium/mac/document.icns
+      - chrome/app/theme/chromium/product_logo.png
+      - chrome/app/theme/chromium/product_logo_1024.png
+      - chrome/app/theme/chromium/product_logo_192.png
+      - chrome/app/theme/chromium/product_logo_22.png
+      - chrome/app/theme/chromium/product_logo_32.png
+      - chrome/app/theme/chromium/product_logo_name_22.png
+      - chrome/app/theme/chromium/product_logo_name_22_2x.png
+      - chrome/app/theme/chromium/product_logo_name_22_white.png
+      - chrome/app/theme/chromium/product_logo_name_22_white_2x.png
+      - chrome/browser/browseros/claw_server/
+      - chrome/browser/browseros/onboarding/resources/
 
   sparkle-third-party:
     description: "feat: sparkle third party framework (downloaded on-the-fly)"

--- a/packages/browseros/bos_build/features.yaml
+++ b/packages/browseros/bos_build/features.yaml
@@ -30,43 +30,18 @@ features:
   branding:
     description: "chore: browseros branding and identity"
     files:
-      # Generated branding outputs are explicit so Sparkle setup outputs in
-      # the same theme tree can remain separately owned.
+      # Generated branding outputs are owned by bos_build overlays/resources;
+      # list paths here only when a chromium_patches patch exists on disk.
       # Version info
-      - chrome/VERSION
       - base/version_info/BUILD.gn
       - base/version_info/version_info.h
       - base/version_info/version_info_values.h.version
       # Branding file paths
-      - chrome/app/chromium_strings.grd
-      - chrome/app/settings_chromium_strings.grdp
-      - chrome/app/theme/chromium/BRANDING
-      - chrome/app/theme/chromium/chromeos/
-      - chrome/app/theme/chromium/chromium.ai
-      - chrome/app/theme/chromium/linux/
-      - chrome/app/theme/chromium/mac/Assets.car
-      - chrome/app/theme/chromium/mac/Assets.xcassets/
-      - chrome/app/theme/chromium/mac/app.icns
-      - chrome/app/theme/chromium/product_logo.ai
-      - chrome/app/theme/chromium/product_logo.svg
-      - chrome/app/theme/chromium/product_logo_128.png
-      - chrome/app/theme/chromium/product_logo_16.png
-      - chrome/app/theme/chromium/product_logo_22_mono.png
-      - chrome/app/theme/chromium/product_logo_24.png
-      - chrome/app/theme/chromium/product_logo_256.png
-      - chrome/app/theme/chromium/product_logo_48.png
-      - chrome/app/theme/chromium/product_logo_64.png
-      - chrome/app/theme/chromium/product_logo_animation.svg
-      - chrome/app/theme/chromium/win/
-      - chrome/app/theme/default_100_percent/chromium/
-      - chrome/app/theme/default_200_percent/chromium/
       - chrome/common/chrome_constants.cc
       - chrome/common/chrome_paths.cc
       - chrome/common/chrome_paths.h
       - chrome/common/chrome_paths_linux.cc
-      - chrome/enterprise_companion/branding.gni
       - chrome/install_static/chromium_install_modes.h
-      - chrome/updater/branding.gni
       # About page (version + branding display)
       - chrome/browser/resources/settings/about_page/about_page.html
       - chrome/browser/resources/settings/about_page/about_page.ts
@@ -131,24 +106,6 @@ features:
       - chrome/browser/ui/webui/help/version_updater_mac.mm
       - chrome/browser/lifetime/application_lifetime.cc
       - chrome/browser/upgrade_detector/upgrade_detector_impl.cc
-
-  sparkle-setup:
-    description: "chore: sparkle setup resources"
-    files:
-      - chrome/BROWSEROS_VERSION
-      - chrome/app/theme/chromium/mac/AppIcon.icns
-      - chrome/app/theme/chromium/mac/document.icns
-      - chrome/app/theme/chromium/product_logo.png
-      - chrome/app/theme/chromium/product_logo_1024.png
-      - chrome/app/theme/chromium/product_logo_192.png
-      - chrome/app/theme/chromium/product_logo_22.png
-      - chrome/app/theme/chromium/product_logo_32.png
-      - chrome/app/theme/chromium/product_logo_name_22.png
-      - chrome/app/theme/chromium/product_logo_name_22_2x.png
-      - chrome/app/theme/chromium/product_logo_name_22_white.png
-      - chrome/app/theme/chromium/product_logo_name_22_white_2x.png
-      - chrome/browser/browseros/claw_server/
-      - chrome/browser/browseros/onboarding/resources/
 
   sparkle-third-party:
     description: "feat: sparkle third party framework (downloaded on-the-fly)"

--- a/packages/browseros/tools/patch/internal/engine/engine_test.go
+++ b/packages/browseros/tools/patch/internal/engine/engine_test.go
@@ -738,38 +738,56 @@ features:
 func TestAnnotateSkipsManagedGeneratedOutputs(t *testing.T) {
 	ctx := context.Background()
 	workspacePath := initGitRepo(t)
-	for _, rel := range []string{
+	managedGenerated := []string{
 		"chrome/VERSION",
 		"chrome/BROWSEROS_VERSION",
 		"chrome/app/chromium_strings.grd",
 		"chrome/app/settings_chromium_strings.grdp",
 		"chrome/app/theme/chromium/BRANDING",
-		"chrome/app/theme/chromium/not_managed.txt",
-		"chrome/app/theme/chromium/product_logo_16.png",
 		"chrome/app/theme/chromium/chromeos/chrome_app_icon_32.png",
+		"chrome/app/theme/chromium/chromium.ai",
+		"chrome/app/theme/chromium/linux/product_logo_32.xpm",
+		"chrome/app/theme/chromium/mac/AppIcon.icns",
+		"chrome/app/theme/chromium/mac/Assets.car",
+		"chrome/app/theme/chromium/mac/Assets.xcassets/AppIcon.appiconset/appicon_1024.png",
+		"chrome/app/theme/chromium/mac/app.icns",
+		"chrome/app/theme/chromium/mac/document.icns",
+		"chrome/app/theme/chromium/product_logo.ai",
+		"chrome/app/theme/chromium/product_logo.png",
+		"chrome/app/theme/chromium/product_logo.svg",
+		"chrome/app/theme/chromium/product_logo_1024.png",
+		"chrome/app/theme/chromium/product_logo_16.png",
+		"chrome/app/theme/chromium/product_logo_192.png",
+		"chrome/app/theme/chromium/product_logo_22.png",
+		"chrome/app/theme/chromium/product_logo_22_mono.png",
+		"chrome/app/theme/chromium/product_logo_32.png",
+		"chrome/app/theme/chromium/product_logo_animation.svg",
+		"chrome/app/theme/chromium/product_logo_name_22.png",
+		"chrome/app/theme/chromium/product_logo_name_22_2x.png",
+		"chrome/app/theme/chromium/product_logo_name_22_white.png",
+		"chrome/app/theme/chromium/product_logo_name_22_white_2x.png",
+		"chrome/app/theme/chromium/win/tiles/Logo.png",
+		"chrome/app/theme/default_100_percent/chromium/product_logo_32.png",
+		"chrome/app/theme/default_200_percent/chromium/product_logo_name_22_white.png",
+		"chrome/browser/browseros/claw_server/resources/bin/browseros-claw-server",
+		"chrome/browser/browseros/onboarding/resources/index.html",
 		"chrome/browser/browseros/server/resources/bin/browseros_server",
+		"chrome/enterprise_companion/branding.gni",
 		"chrome/updater/branding.gni",
+	}
+	allFiles := append([]string{}, managedGenerated...)
+	allFiles = append(allFiles,
+		"chrome/app/theme/chromium/not_managed.txt",
 		"content/render.cc",
-	} {
+	)
+	for _, rel := range allFiles {
 		writeFile(t, filepath.Join(workspacePath, filepath.FromSlash(rel)), "base\n")
 	}
 	runGit(t, workspacePath, "add", ".")
 	runGit(t, workspacePath, "commit", "-m", "workspace base")
 	baseCommit := gitOutput(t, workspacePath, "rev-parse", "HEAD")
 
-	for _, rel := range []string{
-		"chrome/VERSION",
-		"chrome/BROWSEROS_VERSION",
-		"chrome/app/chromium_strings.grd",
-		"chrome/app/settings_chromium_strings.grdp",
-		"chrome/app/theme/chromium/BRANDING",
-		"chrome/app/theme/chromium/not_managed.txt",
-		"chrome/app/theme/chromium/product_logo_16.png",
-		"chrome/app/theme/chromium/chromeos/chrome_app_icon_32.png",
-		"chrome/browser/browseros/server/resources/bin/browseros_server",
-		"chrome/updater/branding.gni",
-		"content/render.cc",
-	} {
+	for _, rel := range allFiles {
 		writeFile(t, filepath.Join(workspacePath, filepath.FromSlash(rel)), "changed\n")
 	}
 
@@ -782,8 +800,27 @@ features:
       - chrome/browser/core.cc
 `)
 	writeFile(t, filepath.Join(repoInfo.Root, "chromium_files", "products", "browseros", "chrome", "app", "theme", "chromium", "BRANDING.debug"), "overlay\n")
+	writeFile(t, filepath.Join(repoInfo.Root, "chromium_files", "products", "browseros", "chrome", "enterprise_companion", "branding.gni"), "overlay\n")
 	writeFile(t, filepath.Join(repoInfo.Root, "chromium_files", "products", "browseros", "chrome", "updater", "branding.gni"), "overlay\n")
-	writeFile(t, filepath.Join(repoInfo.Root, "resources", "browseros", "icons", "product_logo_16.png"), "icon\n")
+	for _, rel := range []string{
+		"resources/browseros/icons/chromium.ai",
+		"resources/browseros/icons/product_logo.ai",
+		"resources/browseros/icons/product_logo.png",
+		"resources/browseros/icons/product_logo.svg",
+		"resources/browseros/icons/product_logo_1024.png",
+		"resources/browseros/icons/product_logo_16.png",
+		"resources/browseros/icons/product_logo_192.png",
+		"resources/browseros/icons/product_logo_22.png",
+		"resources/browseros/icons/product_logo_22_mono.png",
+		"resources/browseros/icons/product_logo_32.png",
+		"resources/browseros/icons/product_logo_animation.svg",
+		"resources/browseros/icons/product_logo_name_22.png",
+		"resources/browseros/icons/product_logo_name_22_2x.png",
+		"resources/browseros/icons/product_logo_name_22_white.png",
+		"resources/browseros/icons/product_logo_name_22_white_2x.png",
+	} {
+		writeFile(t, filepath.Join(repoInfo.Root, filepath.FromSlash(rel)), "icon\n")
+	}
 	writeFile(t, filepath.Join(repoInfo.Root, "bos_build", "config", "copy_resources.yaml"), `copy_operations:
   - name: Version
     source: resources/BROWSEROS_VERSION
@@ -793,13 +830,49 @@ features:
     source: resources/browseros/icons/*.png
     destination: chrome/app/theme/chromium/
     type: files
+  - name: Product root AI
+    source: resources/browseros/icons/*.ai
+    destination: chrome/app/theme/chromium/
+    type: files
+  - name: Product root SVG
+    source: resources/browseros/icons/*.svg
+    destination: chrome/app/theme/chromium/
+    type: files
   - name: ChromeOS icons
     source: resources/browseros/icons/chromeos
     destination: chrome/app/theme/chromium/chromeos
     type: directory
+  - name: Linux icons
+    source: resources/browseros/icons/linux
+    destination: chrome/app/theme/chromium/linux
+    type: directory
+  - name: Mac icons
+    source: resources/browseros/icons/mac
+    destination: chrome/app/theme/chromium/mac
+    type: directory
+  - name: Windows icons
+    source: resources/browseros/icons/win
+    destination: chrome/app/theme/chromium/win
+    type: directory
+  - name: DPI 100 icons
+    source: resources/browseros/icons/default_100_percent
+    destination: chrome/app/theme/default_100_percent/chromium
+    type: directory
+  - name: DPI 200 icons
+    source: resources/browseros/icons/default_200_percent
+    destination: chrome/app/theme/default_200_percent/chromium
+    type: directory
   - name: Server resources
     source: resources/binaries/browseros_server/darwin-arm64/resources
     destination: chrome/browser/browseros/server/resources
+    type: directory
+  - name: Claw server resources
+    source: resources/binaries/browseros_claw_server/darwin-arm64/resources
+    destination: chrome/browser/browseros/claw_server/resources
+    type: directory
+  - name: Claw onboarding resources
+    source: resources/binaries/browseros_claw_onboard/resources
+    destination: chrome/browser/browseros/onboarding/resources
     type: directory
 `)
 	writeFile(t, filepath.Join(repoInfo.Root, "bos_build", "steps", "resources", "string_replaces.py"), `target_files = [


### PR DESCRIPTION
## Summary
- clarify in `features.yaml` that generated branding outputs are managed by bos_build overlays/resources, not feature-file claims unless a patch exists on disk
- expand the patch-tool managed-output regression test to cover the screenshot branding paths and Sparkle setup/resource paths
- leave `third_party/sparkle/` ownership on the existing `sparkle-third-party` feature to avoid duplicate claims

## Verification
- targeted screenshot-path managed-output/feature ownership check: branding/setup generated outputs are managed; `third_party/sparkle/...` is owned by `sparkle-third-party`; `.browseros-patch/` and `debug.log` are ignored
- `cd packages/browseros/tools/patch && go test ./internal/engine -run TestAnnotateSkipsManagedGeneratedOutputs -count=1 -v`
- `cd packages/browseros/tools/patch && go test ./...`
- `cd packages/browseros/tools/patch && make test`
- `cd packages/browseros/tools/patch && make build`
- `cd packages/browseros/tools/patch && XDG_CONFIG_HOME=<temp> ./browseros-patch feature lint`
- `cd packages/browseros && uv run python -m unittest discover -s bos_build -t . -p "*_test.py" -v`
- `cd packages/browseros && uv run ruff check bos_build`
- `cd packages/browseros && uv run browseros build --list > /dev/null && uv run browseros build --preset release --show-plan > /dev/null && uv run browseros product doctor`
- `cd packages/browseros/tools/vendor_uploads && uv run python -m unittest discover -s vendor_uploads -t . -p "*_test.py"`

Note: Directly adding those generated paths to `features.yaml` is invalid unless matching patch files exist under `chromium_patches/`; `bos_build` doctor rejects empty feature claims. The valid ownership mechanism for these screenshot paths is the managed-output layer.