### PR TITLE
feat(claw-app): add bottom Help footer to sidebar

### DIFF
--- a/packages/browseros-agent/apps/claw-app/components/sidebar/AppSidebar.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/sidebar/AppSidebar.tsx
@@ -1,15 +1,13 @@
 import { cn } from '@/lib/utils'
 import { SidebarBranding } from './SidebarBranding'
+import { SidebarHelp } from './SidebarHelp'
 import { SidebarNavigation } from './SidebarNavigation'
 
 export interface AppSidebarProps {
   expanded?: boolean
 }
 
-/**
- * Wraps the branding + navigation. Room for a footer strip lands in a
- * follow-up when there is a real setting to surface.
- */
+/** Sidebar shell: branding, primary navigation, and a bottom help footer. */
 export function AppSidebar({ expanded = false }: AppSidebarProps) {
   return (
     <div
@@ -20,6 +18,7 @@ export function AppSidebar({ expanded = false }: AppSidebarProps) {
     >
       <SidebarBranding expanded={expanded} />
       <SidebarNavigation expanded={expanded} />
+      <SidebarHelp expanded={expanded} />
     </div>
   )
 }

--- a/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarHelp.test.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarHelp.test.tsx
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, mock } from 'bun:test'
+import { renderToStaticMarkup } from 'react-dom/server'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { helpItems, openHelpTarget, SidebarHelp } from './SidebarHelp'
+
+const originalChrome = globalThis.chrome
+
+afterEach(() => {
+  Object.defineProperty(globalThis, 'chrome', {
+    configurable: true,
+    value: originalChrome,
+  })
+})
+
+describe('SidebarHelp', () => {
+  it('renders the help label and both entries when expanded', () => {
+    const html = renderToStaticMarkup(
+      <TooltipProvider>
+        <SidebarHelp expanded />
+      </TooltipProvider>,
+    )
+    expect(html).toContain('Help')
+    expect(html).toContain('Docs')
+    expect(html).toContain('Revisit Onboarding')
+  })
+
+  it('pins Docs and onboarding to their exact targets', () => {
+    expect(helpItems.map((item) => [item.name, item.url])).toEqual([
+      ['Docs', 'https://docs.browseros.com/'],
+      ['Revisit Onboarding', 'chrome://browseros-onboarding'],
+    ])
+  })
+
+  it('opens a help target in a new tab via chrome.tabs.create', () => {
+    const create = mock((_args: { url: string }) => Promise.resolve({}))
+    Object.defineProperty(globalThis, 'chrome', {
+      configurable: true,
+      value: { tabs: { create } },
+    })
+
+    openHelpTarget('chrome://browseros-onboarding')
+
+    expect(create).toHaveBeenCalledTimes(1)
+    expect(create).toHaveBeenCalledWith({
+      url: 'chrome://browseros-onboarding',
+    })
+  })
+})

--- a/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarHelp.tsx
+++ b/packages/browseros-agent/apps/claw-app/components/sidebar/SidebarHelp.tsx
@@ -1,0 +1,86 @@
+import { BookOpen, RotateCcw } from 'lucide-react'
+import type { ComponentType, SVGProps } from 'react'
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+
+export interface SidebarHelpProps {
+  expanded?: boolean
+}
+
+interface HelpItem {
+  name: string
+  url: string
+  icon: ComponentType<SVGProps<SVGSVGElement>>
+}
+
+export const helpItems: HelpItem[] = [
+  { name: 'Docs', url: 'https://docs.browseros.com/', icon: BookOpen },
+  {
+    name: 'Revisit Onboarding',
+    url: 'chrome://browseros-onboarding',
+    icon: RotateCcw,
+  },
+]
+
+/**
+ * Opens a help target in a new tab. Uses `chrome.tabs.create` rather than
+ * an <a>/window.open because the onboarding target is a chrome:// URL,
+ * which the browser blocks from anchor navigations; the tabs API (the
+ * extension holds the `tabs` permission) is allowed to open it.
+ */
+export function openHelpTarget(url: string): void {
+  chrome.tabs.create({ url })
+}
+
+export function SidebarHelp({ expanded = false }: SidebarHelpProps) {
+  return (
+    <div className="overflow-hidden border-border border-t p-2">
+      <div
+        className={cn(
+          'mb-1 truncate px-2.5 font-semibold text-[10px] text-muted-foreground uppercase tracking-[0.18em] transition-opacity duration-200',
+          expanded ? 'opacity-100' : 'opacity-0',
+        )}
+      >
+        Help
+      </div>
+      <div className="space-y-1">
+        {helpItems.map((item) => {
+          const Icon = item.icon
+
+          const button = (
+            <button
+              type="button"
+              onClick={() => openHelpTarget(item.url)}
+              className="flex h-9 w-full items-center gap-3 overflow-hidden whitespace-nowrap rounded-md px-2.5 font-medium text-sm transition-colors hover:bg-sidebar-accent hover:text-sidebar-accent-foreground"
+            >
+              <Icon className="size-5 shrink-0" />
+              <span
+                className={cn(
+                  'truncate transition-opacity duration-200',
+                  expanded ? 'opacity-100' : 'opacity-0',
+                )}
+              >
+                {item.name}
+              </span>
+            </button>
+          )
+
+          if (!expanded) {
+            return (
+              <Tooltip key={item.url}>
+                <TooltipTrigger render={button} />
+                <TooltipContent side="right">{item.name}</TooltipContent>
+              </Tooltip>
+            )
+          }
+
+          return <div key={item.url}>{button}</div>
+        })}
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## What

Adds a bottom-pinned **Help** footer to the `claw-app` sidebar, matching the BrowserOS settings sidebar reference. Two entries:

- **Docs** → `https://docs.browseros.com/`
- **Revisit Onboarding** → `chrome://browseros-onboarding`

Scoped to Docs + Revisit Onboarding only (the reference screenshot's `Features` item was left out — there is no equivalent BrowserClaw target).

## How

- New `components/sidebar/SidebarHelp.tsx`, rendered by `AppSidebar` after `SidebarNavigation`. Since the nav is `flex-1`, the footer pins to the bottom with no extra layout plumbing.
- Visuals mirror `SidebarNavigation` exactly: `size-5` icon + label that fades via opacity with the `expanded` state, and a right-side tooltip when the rail is collapsed. A faded "Help" section label appears when expanded.
- Both entries open with `chrome.tabs.create({ url })` rather than an `<a>`/`window.open`. The onboarding target is a `chrome://` URL, which the browser blocks from anchor navigations; the tabs API is allowed to open it (the extension holds the `tabs` permission). This is the established idiom in this codebase (`ImportDataHint.tsx` opens `chrome://settings/importData` the same way).

### Note for reviewers
Using a uniform `<button>` + `chrome.tabs.create` model means **Docs** loses anchor affordances (middle-click / cmd-click to background). This is deliberate — it keeps a single render path since the `chrome://` target can't be an anchor, and matches how the rest of claw-app opens URLs. Happy to split Docs into a real `<a>` if preferred.

## Verification

From `packages/browseros-agent/apps/claw-app`:
- `bun test components/sidebar/` — 3 pass (label render, exact-URL regression guard, `chrome.tabs.create` handler)
- `bun run typecheck` — clean
- `bunx biome check components/sidebar/` — clean
- `bun run build:dev` — success

Collapsed/expanded behavior follows the proven `SidebarNavigation` fade + tooltip idiom.
