### PR TITLE
fix: point onboarding ready step to MCP setup

### DIFF
--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.test.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.test.tsx
@@ -4,7 +4,7 @@ import { MemoryRouter } from 'react-router'
 import {
   importPhaseFor,
   OnboardingV2,
-  openBrowserOsNewTab,
+  openBrowserOsMcpPage,
 } from './OnboardingV2'
 
 const originalWindow = globalThis.window
@@ -81,14 +81,14 @@ describe('OnboardingV2 shell', () => {
     expect(matches.length).toBe(3)
   })
 
-  it('opens BrowserOS new tab when onboarding completes', () => {
+  it('opens BrowserClaw MCP page when onboarding completes', () => {
     const getAssignedUrl = installAssignableWindow(
       '?apiUrl=http%3A%2F%2F127.0.0.1%3A9234',
     )
 
-    openBrowserOsNewTab()
+    openBrowserOsMcpPage()
 
-    expect(getAssignedUrl()).toBe('chrome://newtab')
+    expect(getAssignedUrl()).toBe('chrome://newtab/#/mcp')
   })
 
   it('does not treat failed or completed Chromium states as import success', () => {

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/OnboardingV2.tsx
@@ -30,7 +30,7 @@ import { ReadyStep } from './steps/ReadyStep'
 import { WelcomeStep } from './steps/WelcomeStep'
 
 const TOTAL_STEPS = 3
-const BROWSEROS_NEW_TAB_URL = 'chrome://newtab'
+const BROWSEROS_MCP_PAGE_URL = 'chrome://newtab/#/mcp'
 
 const initialOnboardingState: BrowserOSOnboardingState = {
   apiVersion: BROWSEROS_ONBOARDING_API_VERSION,
@@ -46,9 +46,9 @@ export function importPhaseFor(status: BrowserOSImportStatus): ImportPhase {
   return 'picker'
 }
 
-/** Leaves standalone onboarding for BrowserOS's Chromium new-tab page. */
-export function openBrowserOsNewTab() {
-  window.location.assign(BROWSEROS_NEW_TAB_URL)
+/** Leaves standalone onboarding for BrowserClaw's MCP connection page. */
+export function openBrowserOsMcpPage() {
+  window.location.assign(BROWSEROS_MCP_PAGE_URL)
 }
 
 /** Runs the standalone three-step BrowserClaw onboarding flow. */
@@ -114,7 +114,7 @@ export function OnboardingV2() {
 
   function finishOnboarding() {
     bridge.complete()
-    openBrowserOsNewTab()
+    openBrowserOsMcpPage()
   }
 
   return (
@@ -133,7 +133,9 @@ export function OnboardingV2() {
             onContinue={() => setStep(2)}
           />
         )}
-        {step === 2 && <ReadyStep onDone={finishOnboarding} />}
+        {step === 2 && (
+          <ReadyStep phase={importPhase} onDone={finishOnboarding} />
+        )}
       </OnboardingShell>
     </Form>
   )

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ReadyStep.test.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ReadyStep.test.tsx
@@ -2,23 +2,45 @@ import { describe, expect, it } from 'bun:test'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { MemoryRouter } from 'react-router'
 import { STARTER_PROMPTS } from '../onboarding-v2.helpers'
+import type { ImportPhase } from '../onboarding-v2.types'
 import { ReadyStep } from './ReadyStep'
 
-function render(): string {
+function render(phase: ImportPhase = 'imported'): string {
   return renderToStaticMarkup(
     <MemoryRouter>
-      <ReadyStep onDone={() => undefined} />
+      <ReadyStep phase={phase} onDone={() => undefined} />
     </MemoryRouter>,
   )
 }
 
 describe('ReadyStep', () => {
-  it('renders the Open BrowserClaw CTA', () => {
-    expect(render()).toContain('Open BrowserClaw')
+  it('confirms imported logins before pointing to MCP setup', () => {
+    const html = render('imported')
+
+    expect(html).toContain('Logins')
+    expect(html).toContain('imported')
+    expect(html).toContain('One step left: connect your agent.')
+    expect(html).toContain('Open MCP in BrowserClaw')
+    expect(html).toContain('Claude Code, Cursor, Codex')
+    expect(html).toContain('logged in as you')
   })
 
-  it('renders the first two starter prompts from the fixture', () => {
+  it('keeps skipped onboarding copy truthful', () => {
+    const html = render('picker')
+
+    expect(html).toContain('Almost')
+    expect(html).toContain('there')
+    expect(html).toContain('Connect your agent next.')
+    expect(html).not.toContain('Logins')
+  })
+
+  it('renders the MCP setup CTA', () => {
+    expect(render()).toContain('Connect your agent')
+  })
+
+  it('frames starter prompts as post-connection examples', () => {
     const html = render()
+    expect(html).toContain('Once connected, try one of these.')
     expect(html).toContain(STARTER_PROMPTS[0])
     expect(html).toContain(STARTER_PROMPTS[1])
   })

--- a/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ReadyStep.tsx
+++ b/packages/browseros-agent/apps/claw-onboard/src/onboarding/steps/ReadyStep.tsx
@@ -1,33 +1,47 @@
-import { Sparkles } from 'lucide-react'
+import { PlugZap } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { DisplayHeading, Em, StepCopy } from '../components/DisplayHeading'
 import { StarterPromptTile } from '../components/StarterPromptTile'
 import { StepWrap } from '../components/StepWrap'
 import { STARTER_PROMPTS } from '../onboarding-v2.helpers'
+import type { ImportPhase } from '../onboarding-v2.types'
 
 interface ReadyStepProps {
+  phase: ImportPhase
   onDone: () => void
 }
 
-/** Renders the final starter prompts and completion CTA. */
-export function ReadyStep({ onDone }: ReadyStepProps) {
+/** Renders the final MCP setup step and post-connection starter prompts. */
+export function ReadyStep({ phase, onDone }: ReadyStepProps) {
+  const didImportLogins = phase === 'imported'
+
   return (
     <StepWrap>
-      <DisplayHeading>
-        You&rsquo;re <Em>set</Em>.
-      </DisplayHeading>
+      {didImportLogins ? (
+        <DisplayHeading>
+          Logins <Em>imported</Em>.
+        </DisplayHeading>
+      ) : (
+        <DisplayHeading>
+          Almost <Em>there</Em>.
+        </DisplayHeading>
+      )}
       <StepCopy>
-        Open Claude and try one of these. The task runs here, in BrowserClaw.
-        You watch, approve, and audit.
+        {didImportLogins
+          ? 'One step left: connect your agent. Open MCP in BrowserClaw and link Claude Code, Cursor, Codex, or another harness. Then your agent runs tasks here, logged in as you. You watch, approve, and audit.'
+          : 'Connect your agent next. Open MCP in BrowserClaw and link Claude Code, Cursor, Codex, or another harness. Then your agent runs tasks in this browser. You watch, approve, and audit.'}
       </StepCopy>
+      <div className="mb-2.5 font-bold text-[12.5px] text-ink-2">
+        Once connected, try one of these.
+      </div>
       <div className="mb-6 flex flex-col gap-2.5">
         {STARTER_PROMPTS.slice(0, 2).map((prompt) => (
           <StarterPromptTile key={prompt} prompt={prompt} />
         ))}
       </div>
       <Button type="button" size="lg" onClick={onDone}>
-        <Sparkles className="size-4" />
-        Open BrowserClaw
+        <PlugZap className="size-4" />
+        Connect your agent
       </Button>
     </StepWrap>
   )


### PR DESCRIPTION
## Summary
- Rewrites the final BrowserClaw onboarding step around the real next action: connect an agent harness on MCP before trying starter prompts.
- Varies the heading by import state, so imported users see `Logins imported.` and skipped/reconnect users see truthful `Almost there.` copy.
- Renames the CTA to `Connect your agent` and exits to the existing `chrome://newtab/#/mcp` hash route.

## Design
The change stays in claw-onboard React code. `OnboardingV2` passes the existing import phase into `ReadyStep`, and completion assigns the new-tab MCP hash route because claw-app already owns `/mcp` through `HashRouter`. No native bridge or C++ changes were needed.

## Screenshot
![BrowserClaw onboarding ready step](https://gist.githubusercontent.com/shadowfax92/9ab3550c3d83124fde86e4c1718cf6c3/raw/23357ccab07bfeab5fc49fb674e88b0aedbb9e8a/ready-step-mcp.svg)

## Test plan
- [x] `bun test src/onboarding/steps/ReadyStep.test.tsx src/onboarding/OnboardingV2.test.tsx` from `packages/browseros-agent/apps/claw-onboard`
- [x] `bun run test` from `packages/browseros-agent/apps/claw-onboard`
- [x] `bun run build` from `packages/browseros-agent/apps/claw-onboard`
- [x] `bun run lint` from `packages/browseros-agent/apps/claw-onboard`
- [x] `bun run typecheck` from `packages/browseros-agent/apps/claw-onboard`
- [x] `bun run codegen:agent` from `packages/browseros-agent`
- [x] `bun run check` from `packages/browseros-agent`
- [x] `bun run test` from `packages/browseros-agent`