### PR TITLE
fix: defer onboarding keychain import prompt

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/onboarding/browseros_onboarding.cc b/chrome/browser/browseros/onboarding/browseros_onboarding.cc
 new file mode 100644
-index 0000000000000..6533bea65f850
+index 0000000000000..d530753f436a0
 --- /dev/null
 +++ b/chrome/browser/browseros/onboarding/browseros_onboarding.cc
-@@ -0,0 +1,713 @@
+@@ -0,0 +1,729 @@
 +// Copyright 2026 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -39,6 +39,8 @@ index 0000000000000..6533bea65f850
 +#include "chrome/grit/browseros_onboarding_resources.h"
 +#include "chrome/grit/browseros_onboarding_resources_map.h"
 +#include "components/user_data_importer/common/importer_data_types.h"
++#include "content/public/browser/visibility.h"
++#include "content/public/browser/web_contents.h"
 +#include "content/public/browser/web_ui.h"
 +#include "content/public/browser/web_ui_data_source.h"
 +#include "content/public/browser/web_ui_message_handler.h"
@@ -239,6 +241,13 @@ index 0000000000000..6533bea65f850
 +      return;
 +    }
 +
++    if (!CanStartImportFromCurrentWebContents()) {
++      SendFailure(
++          "ready", "user_interaction_required",
++          "Click Import from the visible onboarding window to continue.");
++      return;
++    }
++
 +    ResetImportState();
 +    if (!importer_list_loaded_ || !importer_list_ ||
 +        importer_list_->count() == 0) {
@@ -289,6 +298,13 @@ index 0000000000000..6533bea65f850
 +      completion_callback.Run();
 +      return;
 +    }
++  }
++
++  bool CanStartImportFromCurrentWebContents() {
++    content::WebContents* contents = web_ui()->GetWebContents();
++    return contents &&
++           contents->GetVisibility() == content::Visibility::VISIBLE &&
++           contents->HasRecentInteraction();
 +  }
 +
 +  void DetectSources() {

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_api.ts
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_api.ts
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/onboarding/browseros_onboarding_api.ts b/chrome/browser/browseros/onboarding/browseros_onboarding_api.ts
 new file mode 100644
-index 0000000000000..bb38f100d0c23
+index 0000000000000..83a1cb5ea28c7
 --- /dev/null
 +++ b/chrome/browser/browseros/onboarding/browseros_onboarding_api.ts
-@@ -0,0 +1,93 @@
+@@ -0,0 +1,99 @@
 +// Copyright 2026 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -74,7 +74,13 @@ index 0000000000000..bb38f100d0c23
 +  results?: BrowserOSImportSourceResult[];
 +}
 +
-+/** Starts one source or an ordered multi-source import queue. */
++/**
++ * Starts one source or an ordered multi-source import queue.
++ *
++ * Must be sent directly from the visible Import action. The browser process
++ * rejects hidden or non-interactive startImport messages because importing
++ * cookies/passwords can trigger the macOS Chrome Safe Storage keychain prompt.
++ */
 +export interface BrowserOSStartImportRequest {
 +  sourceId?: string;
 +  items?: BrowserOSImportItem[];

--- a/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_cookie_importer.cc
+++ b/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_cookie_importer.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/utility/importer/browseros/chrome_cookie_importer.cc b/chrome/utility/importer/browseros/chrome_cookie_importer.cc
 new file mode 100644
-index 0000000000000..f905d442b87ef
+index 0000000000000..44937aaa83494
 --- /dev/null
 +++ b/chrome/utility/importer/browseros/chrome_cookie_importer.cc
-@@ -0,0 +1,299 @@
+@@ -0,0 +1,300 @@
 +// Copyright 2024 AKW Technology Inc
 +// Chrome cookie importer implementation
 +
@@ -155,16 +155,6 @@ index 0000000000000..f905d442b87ef
 +    const base::FilePath& profile_path) {
 +  std::vector<ImportedCookieEntry> cookies;
 +
-+  // Extract encryption key (same key used for passwords and cookies)
-+  KeyExtractionResult key_result;
-+  std::string encryption_key = ExtractChromeKey(profile_path, &key_result);
-+
-+  if (encryption_key.empty()) {
-+    LOG(WARNING) << "browseros: Failed to extract encryption key, "
-+                 << "result: " << static_cast<int>(key_result);
-+    return cookies;
-+  }
-+
 +  // Path to Cookies database
 +  base::FilePath cookies_path = profile_path.AppendASCII(kCookiesFilename);
 +  if (!base::PathExists(cookies_path)) {
@@ -219,6 +209,17 @@ index 0000000000000..f905d442b87ef
 +    sql::Statement statement(db.GetUniqueStatement(kQuery));
 +    if (!statement.is_valid()) {
 +      LOG(WARNING) << "browseros: Failed to prepare query";
++      DeleteDatabaseTemp(temp_db_path);
++      return cookies;
++    }
++
++    // Extract encryption key only once the selected Cookies database is known
++    // to exist and have the schema we import.
++    KeyExtractionResult key_result;
++    std::string encryption_key = ExtractChromeKey(profile_path, &key_result);
++    if (encryption_key.empty()) {
++      LOG(WARNING) << "browseros: Failed to extract encryption key, "
++                   << "result: " << static_cast<int>(key_result);
 +      DeleteDatabaseTemp(temp_db_path);
 +      return cookies;
 +    }

--- a/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_password_importer.cc
+++ b/packages/browseros/chromium_patches/chrome/utility/importer/browseros/chrome_password_importer.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/utility/importer/browseros/chrome_password_importer.cc b/chrome/utility/importer/browseros/chrome_password_importer.cc
 new file mode 100644
-index 0000000000000..896f66db32980
+index 0000000000000..00528908da168
 --- /dev/null
 +++ b/chrome/utility/importer/browseros/chrome_password_importer.cc
-@@ -0,0 +1,147 @@
+@@ -0,0 +1,148 @@
 +// Copyright 2024 AKW Technology Inc
 +// Chrome password importer implementation
 +
@@ -33,16 +33,6 @@ index 0000000000000..896f66db32980
 +    const base::FilePath& profile_path) {
 +  std::vector<user_data_importer::ImportedPasswordForm> passwords;
 +
-+  // Extract encryption key
-+  KeyExtractionResult key_result;
-+  std::string encryption_key = ExtractChromeKey(profile_path, &key_result);
-+
-+  if (encryption_key.empty()) {
-+    LOG(WARNING) << "browseros: Failed to extract encryption key, "
-+                 << "result: " << static_cast<int>(key_result);
-+    return passwords;
-+  }
-+
 +  // Path to Login Data database
 +  base::FilePath login_data_path = profile_path.AppendASCII(kLoginDataFilename);
 +  if (!base::PathExists(login_data_path)) {
@@ -68,8 +58,8 @@ index 0000000000000..896f66db32980
 +  // Count of passwords skipped because they use App-Bound Encryption.
 +  int skipped_app_bound = 0;
 +
-+  // Query logins table - use scope block to ensure statement is destroyed before
-+  // db.Close() to avoid DCHECK failure
++  // Query logins table - use scope block to ensure statement is destroyed
++  // before db.Close() to avoid DCHECK failure
 +  {
 +    const char kQuery[] =
 +        "SELECT origin_url, action_url, username_element, username_value, "
@@ -79,6 +69,17 @@ index 0000000000000..896f66db32980
 +    sql::Statement statement(db.GetUniqueStatement(kQuery));
 +    if (!statement.is_valid()) {
 +      LOG(WARNING) << "browseros: Failed to prepare query";
++      DeleteDatabaseTemp(temp_db_path);
++      return passwords;
++    }
++
++    // Extract encryption key only once the selected Login Data database is
++    // known to exist and have the schema we import.
++    KeyExtractionResult key_result;
++    std::string encryption_key = ExtractChromeKey(profile_path, &key_result);
++    if (encryption_key.empty()) {
++      LOG(WARNING) << "browseros: Failed to extract encryption key, "
++                   << "result: " << static_cast<int>(key_result);
 +      DeleteDatabaseTemp(temp_db_path);
 +      return passwords;
 +    }


### PR DESCRIPTION
## Summary
- Reject hidden or non-interactive onboarding `startImport` WebUI messages using visible `WebContents` plus recent user interaction.
- Defer Chrome Safe Storage key extraction in cookie/password importers until the selected DB exists, copies, opens, and the expected query schema validates.
- Document the WebUI API contract that `startImport` must come directly from the visible Import action.
- No `features.yaml` entry was added because all four updated Chromium patch files are already claimed by existing feature layers.

## Root cause trace
Runtime interposer tracing on a fresh macOS profile showed startup and onboarding page load made zero Safe Storage keychain calls. Static/runtime tracing then narrowed Chrome Safe Storage access to the importer decryptor: cookie/password imports called `ExtractChromeKey()` at importer entry. That means any hidden or non-interactive `startImport` from a preloaded onboarding surface could trigger the macOS prompt before the visible education UI, even though page-ready source detection was keychain-free. The backend now rejects hidden/non-interactive starts and the importers defer key lookup behind the validated import path.

## Verification
- `git diff --check`
- `XDG_CONFIG_HOME=/tmp/bpatch-onboarding bpatch feature lint`
- `/Users/shadowfax/.skills/sf-mux/scripts/sfmux pool build -- autoninja -C out/Default_arm64 chrome`
- `/Users/shadowfax/.skills/sf-ch-extract/scripts/verify-patches.sh --chromium-src /Users/shadowfax/ch-1 --worktree /Users/shadowfax/worktrees/main/feat-onboarding-keychain-defer-patches --tip 1be7e8f90208c8b0d5eac4c428e927ee17439865 chrome/browser/browseros/onboarding/browseros_onboarding.cc chrome/browser/browseros/onboarding/browseros_onboarding_api.ts chrome/utility/importer/browseros/chrome_cookie_importer.cc chrome/utility/importer/browseros/chrome_password_importer.cc`
- Fresh-profile runtime interposer trace: launch/onboarding page load produced no Safe Storage keychain calls.