### PR TITLE
fix: limit onboarding to default profile

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc b/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
 new file mode 100644
-index 0000000000000..635f4df18b9f4
+index 0000000000000..ecf479d743ba8
 --- /dev/null
 +++ b/chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc
-@@ -0,0 +1,31 @@
+@@ -0,0 +1,37 @@
 +// Copyright 2026 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -12,12 +12,18 @@ index 0000000000000..635f4df18b9f4
 +
 +#include "chrome/browser/browseros/core/browseros_prefs.h"
 +#include "chrome/browser/profiles/profile.h"
++#include "chrome/common/chrome_constants.h"
 +#include "components/prefs/pref_service.h"
 +
 +namespace browseros::onboarding {
 +
 +bool ShouldShow(Profile* profile) {
 +  if (!profile || !profile->IsRegularProfile() || profile->IsOffTheRecord()) {
++    return false;
++  }
++
++  if (profile->GetBaseName() !=
++      base::FilePath().AppendASCII(chrome::kInitialProfile)) {
 +    return false;
 +  }
 +


### PR DESCRIPTION
## Summary
- limit BrowserOS onboarding `ShouldShow` to the initial/default profile directory
- keep the existing per-profile `kOnboardingCompleted` pref behavior for the default profile
- avoid touching the sibling onboarding import/keychain code path

## Verification
- `/Users/shadowfax/.skills/sf-mux/scripts/sfmux pool build -- autoninja -C out/Default_arm64 chrome` succeeded in `/Users/shadowfax/ch-1`
- `verify-patches.sh --chromium-src /Users/shadowfax/ch-1 --worktree /Users/shadowfax/worktrees/main/feat-onboarding-default-profile-only-patches --tip 127c781aec65b chrome/browser/browseros/onboarding/browseros_onboarding_prefs.cc` -> `MATCH APPLIES`
- `git diff --check`
- patch file remains registered under `onboarding-import` in `bos_build/features.yaml`
