### PR TITLE
chore(claw-server-rust): keep tab activity clippy-clean

### DIFF
--- a/packages/browseros-agent/apps/claw-server-rust/src/services/tab_activity.rs
+++ b/packages/browseros-agent/apps/claw-server-rust/src/services/tab_activity.rs
@@ -1,6 +1,7 @@
 use browseros_core::TargetId;
 use serde::Serialize;
 use std::{
+    cmp::Reverse,
     collections::{HashMap, VecDeque},
     sync::Arc,
     time::{Duration, SystemTime, UNIX_EPOCH},
@@ -156,7 +157,7 @@ impl TabActivityService {
                 },
             })
             .collect();
-        rows.sort_by(|a, b| b.last_tool_at.cmp(&a.last_tool_at));
+        rows.sort_by_key(|row| Reverse(row.last_tool_at));
         rows
     }
 }


### PR DESCRIPTION
## Summary
- `main` now already contains the requested Rust route unship via `6f4165c71 chore: unship unused Claw routes`: agents CRUD/regenerate, site-rules CRUD/service, permissions catalog, and tabs-focus are gone while `/agents/{agent_id}/cancel` stays.
- Keep the Rust verification gate green after that cleanup by switching tab activity sorting to `sort_by_key(Reverse(...))`, matching current clippy `-D warnings`.

## Verification
- `bun run fmt:rust`
- `bun run lint:rust`
- `bun run test:rust`
- `bun run check` (exits 0; prints existing unrelated Biome/fallow diagnostics)
- `bun run test`