### PR TITLE
feat: hide BrowserClaw tab group chips

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/BUILD.gn
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/core/BUILD.gn b/chrome/browser/browseros/core/BUILD.gn
 new file mode 100644
-index 0000000000000..b939da059b981
+index 0000000000000..fe42a921e2eef
 --- /dev/null
 +++ b/chrome/browser/browseros/core/BUILD.gn
-@@ -0,0 +1,61 @@
+@@ -0,0 +1,81 @@
 +# Copyright 2024 The Chromium Authors
 +# Use of this source code is governed by a BSD-style license that can be
 +# found in the LICENSE file.
@@ -41,12 +41,32 @@ index 0000000000000..b939da059b981
 +  ]
 +
 +  deps = [
++    ":core",
++    ":product",
 +    "//base",
 +    "//chrome/browser/ui/actions:actions_headers",
 +    "//chrome/common:constants",
++    "//components/bookmarks/common",
 +    "//components/pref_registry",
 +    "//components/prefs",
 +    "//ui/actions:actions_headers",
++  ]
++}
++
++source_set("unit_tests") {
++  testonly = true
++  sources = [ "browseros_prefs_unittest.cc" ]
++
++  deps = [
++    ":prefs",
++    ":product",
++    "//base/test:test_support",
++    "//chrome/browser/browseros:buildflags",
++    "//components/bookmarks/browser",
++    "//components/bookmarks/common",
++    "//components/pref_registry",
++    "//components/sync_preferences:test_support",
++    "//testing/gtest",
 +  ]
 +}
 +

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/core/browseros_prefs.cc b/chrome/browser/browseros/core/browseros_prefs.cc
 new file mode 100644
-index 0000000000000..6bc685afcc530
+index 0000000000000..437809a5bf4cf
 --- /dev/null
 +++ b/chrome/browser/browseros/core/browseros_prefs.cc
-@@ -0,0 +1,106 @@
+@@ -0,0 +1,131 @@
 +// Copyright 2025 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -11,8 +11,10 @@ index 0000000000000..6bc685afcc530
 +#include "chrome/browser/browseros/core/browseros_prefs.h"
 +
 +#include "chrome/browser/browseros/core/browseros_constants.h"
++#include "chrome/browser/browseros/core/browseros_product.h"
 +#include "chrome/browser/ui/actions/chrome_action_id.h"
 +#include "chrome/common/pref_names.h"
++#include "components/bookmarks/common/bookmark_pref_names.h"
 +#include "components/pref_registry/pref_registry_syncable.h"
 +#include "third_party/skia/include/core/SkColor.h"
 +#include "ui/base/mojom/themes.mojom.h"
@@ -21,6 +23,8 @@ index 0000000000000..6bc685afcc530
 +
 +void RegisterProfilePrefs(user_prefs::PrefRegistrySyncable* registry) {
 +  const bool show_toolbar_controls_by_default = !IsBrowserClawProduct();
++  const bool show_tab_groups_in_bookmark_bar_by_default =
++      !IsBrowserClawProduct();
 +
 +  registry->RegisterBooleanPref(prefs::kShowLLMChat,
 +                                show_toolbar_controls_by_default);
@@ -29,6 +33,8 @@ index 0000000000000..6bc685afcc530
 +  registry->RegisterBooleanPref(prefs::kShowToolbarLabels,
 +                                show_toolbar_controls_by_default);
 +  registry->RegisterBooleanPref(prefs::kVerticalTabsEnabled, true);
++  registry->RegisterBooleanPref(prefs::kShowTabGroupsInBookmarkBar,
++                                show_tab_groups_in_bookmark_bar_by_default);
 +
 +  registry->RegisterStringPref(prefs::kProviders, "");
 +  registry->RegisterStringPref(prefs::kCustomProviders, "[]");
@@ -54,6 +60,10 @@ index 0000000000000..6bc685afcc530
 +  return pref_service->GetBoolean(prefs::kVerticalTabsEnabled);
 +}
 +
++bool ShouldShowTabGroupsInBookmarkBar(PrefService* pref_service) {
++  return pref_service->GetBoolean(prefs::kShowTabGroupsInBookmarkBar);
++}
++
 +void SyncVerticalTabsPref(PrefService* pref_service) {
 +  const bool browseros_enabled =
 +      pref_service->GetBoolean(prefs::kVerticalTabsEnabled);
@@ -64,14 +74,29 @@ index 0000000000000..6bc685afcc530
 +  }
 +}
 +
++void ApplyShowTabGroupsInBookmarkBarPref(PrefService* pref_service) {
++  pref_service->SetBoolean(bookmarks::prefs::kShowTabGroupsInBookmarkBar,
++                           ShouldShowTabGroupsInBookmarkBar(pref_service));
++}
++
++void SyncShowTabGroupsInBookmarkBarPref(PrefService* pref_service) {
++  const bool browseros_enabled = ShouldShowTabGroupsInBookmarkBar(pref_service);
++  const PrefService::Preference* upstream_pref = pref_service->FindPreference(
++      bookmarks::prefs::kShowTabGroupsInBookmarkBar);
++  if (upstream_pref && upstream_pref->IsDefaultValue() &&
++      pref_service->GetBoolean(bookmarks::prefs::kShowTabGroupsInBookmarkBar) !=
++          browseros_enabled) {
++    ApplyShowTabGroupsInBookmarkBarPref(pref_service);
++  }
++}
++
 +void SyncDefaultTheme(PrefService* pref_service) {
 +  const PrefService::Preference* user_color_pref =
 +      pref_service->FindPreference(::prefs::kUserColor);
 +  if (user_color_pref && user_color_pref->IsDefaultValue()) {
 +    pref_service->SetInteger(::prefs::kUserColor,
 +                             static_cast<int>(SkColorSetRGB(136, 136, 136)));
-+    pref_service->SetString(::prefs::kCurrentThemeID,
-+                            "user_color_theme_id");
++    pref_service->SetString(::prefs::kCurrentThemeID, "user_color_theme_id");
 +    pref_service->SetInteger(
 +        ::prefs::kBrowserColorVariant,
 +        static_cast<int>(ui::mojom::BrowserColorVariant::kNeutral));

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.h
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs.h
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/core/browseros_prefs.h b/chrome/browser/browseros/core/browseros_prefs.h
 new file mode 100644
-index 0000000000000..fe576bc18a041
+index 0000000000000..9ea1d4683fc35
 --- /dev/null
 +++ b/chrome/browser/browseros/core/browseros_prefs.h
-@@ -0,0 +1,95 @@
+@@ -0,0 +1,112 @@
 +// Copyright 2025 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -35,7 +35,13 @@ index 0000000000000..fe576bc18a041
 +inline constexpr char kShowToolbarLabels[] = "browseros.show_toolbar_labels";
 +
 +// Boolean: Enable vertical tabs (default: true)
-+inline constexpr char kVerticalTabsEnabled[] = "browseros.vertical_tabs_enabled";
++inline constexpr char kVerticalTabsEnabled[] =
++    "browseros.vertical_tabs_enabled";
++
++// Boolean: Show saved tab groups in the bookmark bar (default: true, false for
++// BrowserClaw).
++inline constexpr char kShowTabGroupsInBookmarkBar[] =
++    "browseros.show_tab_groups_in_bookmark_bar";
 +
 +// AI Provider prefs
 +// JSON string containing the list of AI providers and configuration
@@ -69,10 +75,21 @@ index 0000000000000..fe576bc18a041
 +// Check if vertical tabs should be enabled.
 +bool IsVerticalTabsEnabled(PrefService* pref_service);
 +
++// Check if saved tab groups should be shown in the bookmark bar.
++bool ShouldShowTabGroupsInBookmarkBar(PrefService* pref_service);
++
 +// Syncs the BrowserOS vertical tabs pref to the upstream Chrome pref.
 +// Call this early (e.g. during controller init) so the upstream pref
 +// reflects BrowserOS's default.
 +void SyncVerticalTabsPref(PrefService* pref_service);
++
++// Applies the BrowserOS saved tab groups bookmark bar pref to the upstream
++// Chrome pref.
++void ApplyShowTabGroupsInBookmarkBarPref(PrefService* pref_service);
++
++// Syncs the BrowserOS saved tab groups bookmark bar pref to the upstream Chrome
++// pref only while the upstream pref is still at its default value.
++void SyncShowTabGroupsInBookmarkBarPref(PrefService* pref_service);
 +
 +// Sets the default BrowserOS theme (blue tonal spot) on first run
 +// when the user hasn't customized the theme yet.

--- a/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs_unittest.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/core/browseros_prefs_unittest.cc
@@ -1,0 +1,137 @@
+diff --git a/chrome/browser/browseros/core/browseros_prefs_unittest.cc b/chrome/browser/browseros/core/browseros_prefs_unittest.cc
+new file mode 100644
+index 0000000000000..88f9feadd5d8d
+--- /dev/null
++++ b/chrome/browser/browseros/core/browseros_prefs_unittest.cc
+@@ -0,0 +1,131 @@
++// Copyright 2026 The Chromium Authors
++// Use of this source code is governed by a BSD-style license that can be
++// found in the LICENSE file.
++
++#include "chrome/browser/browseros/core/browseros_prefs.h"
++
++#include "base/test/scoped_command_line.h"
++#include "chrome/browser/browseros/buildflags.h"
++#include "chrome/browser/browseros/core/browseros_product.h"
++#include "chrome/browser/browseros/core/browseros_switches.h"
++#include "components/bookmarks/browser/bookmark_utils.h"
++#include "components/bookmarks/common/bookmark_pref_names.h"
++#include "components/pref_registry/pref_registry_syncable.h"
++#include "components/sync_preferences/testing_pref_service_syncable.h"
++#include "testing/gtest/include/gtest/gtest.h"
++
++namespace browseros {
++namespace {
++
++void RegisterPrefs(sync_preferences::TestingPrefServiceSyncable* pref_service) {
++  bookmarks::RegisterProfilePrefs(pref_service->registry());
++  RegisterProfilePrefs(pref_service->registry());
++}
++
++#if BUILDFLAG(BROWSEROS_ALLOW_RUNTIME_PRODUCT_OVERRIDE)
++void SetProductOverride(base::test::ScopedCommandLine* scoped_command_line,
++                        Product product) {
++  scoped_command_line->GetProcessCommandLine()->AppendSwitchASCII(
++      kBrowserOSProduct, product == Product::kBrowserClaw
++                             ? kBrowserClawProductValue
++                             : kBrowserOSProductValue);
++}
++#endif  // BUILDFLAG(BROWSEROS_ALLOW_RUNTIME_PRODUCT_OVERRIDE)
++
++TEST(BrowserOSPrefsTest, ShowTabGroupsInBookmarkBarDefaultMatchesBakedProduct) {
++  sync_preferences::TestingPrefServiceSyncable pref_service;
++  RegisterPrefs(&pref_service);
++
++  EXPECT_EQ(!IsBrowserClawProduct(),
++            pref_service.GetBoolean(prefs::kShowTabGroupsInBookmarkBar));
++}
++
++#if BUILDFLAG(BROWSEROS_ALLOW_RUNTIME_PRODUCT_OVERRIDE)
++TEST(BrowserOSPrefsTest, BrowserClawDefaultsToHidingTabGroupsInBookmarkBar) {
++  base::test::ScopedCommandLine scoped_command_line;
++  SetProductOverride(&scoped_command_line, Product::kBrowserClaw);
++  sync_preferences::TestingPrefServiceSyncable pref_service;
++  RegisterPrefs(&pref_service);
++
++  EXPECT_FALSE(pref_service.GetBoolean(prefs::kShowTabGroupsInBookmarkBar));
++}
++
++TEST(BrowserOSPrefsTest, BrowserOSDefaultsToShowingTabGroupsInBookmarkBar) {
++  base::test::ScopedCommandLine scoped_command_line;
++  SetProductOverride(&scoped_command_line, Product::kBrowserOS);
++  sync_preferences::TestingPrefServiceSyncable pref_service;
++  RegisterPrefs(&pref_service);
++
++  EXPECT_TRUE(pref_service.GetBoolean(prefs::kShowTabGroupsInBookmarkBar));
++}
++#endif  // BUILDFLAG(BROWSEROS_ALLOW_RUNTIME_PRODUCT_OVERRIDE)
++
++TEST(BrowserOSPrefsTest,
++     SyncShowTabGroupsInBookmarkBarPrefAppliesBrowserOSDefault) {
++  sync_preferences::TestingPrefServiceSyncable pref_service;
++  RegisterPrefs(&pref_service);
++  pref_service.SetBoolean(prefs::kShowTabGroupsInBookmarkBar, false);
++
++  ASSERT_TRUE(pref_service
++                  .FindPreference(bookmarks::prefs::kShowTabGroupsInBookmarkBar)
++                  ->IsDefaultValue());
++  SyncShowTabGroupsInBookmarkBarPref(&pref_service);
++
++  EXPECT_FALSE(
++      pref_service.GetBoolean(bookmarks::prefs::kShowTabGroupsInBookmarkBar));
++}
++
++TEST(BrowserOSPrefsTest,
++     SyncShowTabGroupsInBookmarkBarPrefPreservesUserOverride) {
++  sync_preferences::TestingPrefServiceSyncable pref_service;
++  RegisterPrefs(&pref_service);
++  pref_service.SetBoolean(prefs::kShowTabGroupsInBookmarkBar, true);
++  pref_service.SetBoolean(bookmarks::prefs::kShowTabGroupsInBookmarkBar, false);
++
++  ASSERT_FALSE(
++      pref_service
++          .FindPreference(bookmarks::prefs::kShowTabGroupsInBookmarkBar)
++          ->IsDefaultValue());
++  SyncShowTabGroupsInBookmarkBarPref(&pref_service);
++
++  EXPECT_FALSE(
++      pref_service.GetBoolean(bookmarks::prefs::kShowTabGroupsInBookmarkBar));
++}
++
++TEST(BrowserOSPrefsTest,
++     SyncShowTabGroupsInBookmarkBarPrefLeavesMatchingDefaultUntouched) {
++  sync_preferences::TestingPrefServiceSyncable pref_service;
++  RegisterPrefs(&pref_service);
++  pref_service.SetBoolean(prefs::kShowTabGroupsInBookmarkBar, true);
++
++  const PrefService::Preference* upstream_pref = pref_service.FindPreference(
++      bookmarks::prefs::kShowTabGroupsInBookmarkBar);
++  ASSERT_TRUE(upstream_pref->IsDefaultValue());
++  ASSERT_TRUE(
++      pref_service.GetBoolean(bookmarks::prefs::kShowTabGroupsInBookmarkBar));
++
++  SyncShowTabGroupsInBookmarkBarPref(&pref_service);
++
++  EXPECT_TRUE(upstream_pref->IsDefaultValue());
++  EXPECT_TRUE(
++      pref_service.GetBoolean(bookmarks::prefs::kShowTabGroupsInBookmarkBar));
++}
++
++TEST(BrowserOSPrefsTest,
++     ApplyShowTabGroupsInBookmarkBarPrefUpdatesUpstreamPref) {
++  sync_preferences::TestingPrefServiceSyncable pref_service;
++  RegisterPrefs(&pref_service);
++
++  pref_service.SetBoolean(prefs::kShowTabGroupsInBookmarkBar, false);
++  ApplyShowTabGroupsInBookmarkBarPref(&pref_service);
++  EXPECT_FALSE(
++      pref_service.GetBoolean(bookmarks::prefs::kShowTabGroupsInBookmarkBar));
++
++  pref_service.SetBoolean(prefs::kShowTabGroupsInBookmarkBar, true);
++  ApplyShowTabGroupsInBookmarkBarPref(&pref_service);
++  EXPECT_TRUE(
++      pref_service.GetBoolean(bookmarks::prefs::kShowTabGroupsInBookmarkBar));
++}
++
++}  // namespace
++}  // namespace browseros

--- a/packages/browseros/chromium_patches/chrome/browser/extensions/api/settings_private/prefs_util.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/extensions/api/settings_private/prefs_util.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/extensions/api/settings_private/prefs_util.cc b/chrome/browser/extensions/api/settings_private/prefs_util.cc
-index 7238955992d8c..34a90ffe0c372 100644
+index 7238955992d8c..2eaf93b8d4d0e 100644
 --- a/chrome/browser/extensions/api/settings_private/prefs_util.cc
 +++ b/chrome/browser/extensions/api/settings_private/prefs_util.cc
 @@ -14,6 +14,7 @@
@@ -10,7 +10,7 @@ index 7238955992d8c..34a90ffe0c372 100644
  #include "chrome/browser/content_settings/generated_cookie_prefs.h"
  #include "chrome/browser/content_settings/generated_javascript_optimizer_pref.h"
  #include "chrome/browser/content_settings/generated_permission_prompting_behavior_pref.h"
-@@ -626,6 +627,18 @@ const PrefsUtil::TypedPrefMap& PrefsUtil::GetAllowlistedKeys() {
+@@ -626,6 +627,20 @@ const PrefsUtil::TypedPrefMap& PrefsUtil::GetAllowlistedKeys() {
    (*s_allowlist)[::prefs::kCaretBrowsingEnabled] =
        settings_api::PrefType::kBoolean;
  
@@ -25,11 +25,13 @@ index 7238955992d8c..34a90ffe0c372 100644
 +      settings_api::PrefType::kBoolean;
 +  (*s_allowlist)[browseros::prefs::kShowAssistant] =
 +      settings_api::PrefType::kBoolean;
++  (*s_allowlist)[browseros::prefs::kShowTabGroupsInBookmarkBar] =
++      settings_api::PrefType::kBoolean;
 +
  #if BUILDFLAG(IS_CHROMEOS)
    // Accounts / Users / People.
    (*s_allowlist)[ash::kAccountsPrefAllowGuest] =
-@@ -1205,6 +1218,10 @@ const PrefsUtil::TypedPrefMap& PrefsUtil::GetAllowlistedKeys() {
+@@ -1205,6 +1220,10 @@ const PrefsUtil::TypedPrefMap& PrefsUtil::GetAllowlistedKeys() {
        settings_api::PrefType::kBoolean;
    (*s_allowlist)[::prefs::kImportDialogSearchEngine] =
        settings_api::PrefType::kBoolean;

--- a/packages/browseros/chromium_patches/chrome/browser/ui/browser.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/ui/browser.cc
@@ -1,5 +1,5 @@
 diff --git a/chrome/browser/ui/browser.cc b/chrome/browser/ui/browser.cc
-index 9603137595182..736e1cea7e970 100644
+index 9603137595182..a784a545bda52 100644
 --- a/chrome/browser/ui/browser.cc
 +++ b/chrome/browser/ui/browser.cc
 @@ -45,6 +45,7 @@
@@ -18,7 +18,25 @@ index 9603137595182..736e1cea7e970 100644
        should_trigger_session_restore_(params.should_trigger_session_restore),
        cancel_download_confirmation_state_(
            CancelDownloadConfirmationState::kNotPrompted),
-@@ -685,6 +687,10 @@ Browser::Browser(const CreateParams& params)
+@@ -623,11 +625,17 @@ Browser::Browser(const CreateParams& params)
+ 
+   tab_strip_model_->AddObserver(this);
+ 
++  browseros::SyncShowTabGroupsInBookmarkBarPref(profile_->GetPrefs());
++
+   profile_pref_registrar_.Init(profile_->GetPrefs());
+   profile_pref_registrar_.Add(
+       prefs::kDevToolsAvailability,
+       base::BindRepeating(&Browser::OnDevToolsAvailabilityChanged,
+                           base::Unretained(this)));
++  profile_pref_registrar_.Add(
++      browseros::prefs::kShowTabGroupsInBookmarkBar,
++      base::BindRepeating(&browseros::ApplyShowTabGroupsInBookmarkBarPref,
++                          base::Unretained(profile_->GetPrefs())));
+ 
+   ProfileMetrics::LogProfileLaunch(profile_);
+ 
+@@ -685,6 +693,10 @@ Browser::Browser(const CreateParams& params)
  }
  
  Browser::~Browser() {
@@ -29,7 +47,7 @@ index 9603137595182..736e1cea7e970 100644
    if (!is_delete_scheduled_) {
      // Guarantee the Browser has performed the necessary cleanup in the
      // `OnWindowClosing()` lifecycle hook. This may not be invoked during
-@@ -1516,6 +1522,19 @@ WebContents* Browser::OpenURL(
+@@ -1516,6 +1528,19 @@ WebContents* Browser::OpenURL(
  ///////////////////////////////////////////////////////////////////////////////
  // Browser, TabStripModelObserver implementation:
  
@@ -49,7 +67,7 @@ index 9603137595182..736e1cea7e970 100644
  void Browser::OnTabStripModelChanged(TabStripModel* tab_strip_model,
                                       const TabStripModelChange& change,
                                       const TabStripSelectionChange& selection) {
-@@ -1533,6 +1552,9 @@ void Browser::OnTabStripModelChanged(TabStripModel* tab_strip_model,
+@@ -1533,6 +1558,9 @@ void Browser::OnTabStripModelChanged(TabStripModel* tab_strip_model,
        }
        for (const auto& contents : change.GetInsert()->contents) {
          OnTabInsertedAt(contents.contents, contents.index);
@@ -59,7 +77,7 @@ index 9603137595182..736e1cea7e970 100644
        }
        break;
      }
-@@ -1543,6 +1565,9 @@ void Browser::OnTabStripModelChanged(TabStripModel* tab_strip_model,
+@@ -1543,6 +1571,9 @@ void Browser::OnTabStripModelChanged(TabStripModel* tab_strip_model,
          }
          OnTabDetached(contents.contents,
                        contents.contents == selection.old_contents);
@@ -69,7 +87,7 @@ index 9603137595182..736e1cea7e970 100644
        }
        break;
      }
-@@ -1555,6 +1580,10 @@ void Browser::OnTabStripModelChanged(TabStripModel* tab_strip_model,
+@@ -1555,6 +1586,10 @@ void Browser::OnTabStripModelChanged(TabStripModel* tab_strip_model,
        auto* replace = change.GetReplace();
        OnTabReplacedAt(replace->old_contents, replace->new_contents,
                        replace->index);
@@ -80,7 +98,7 @@ index 9603137595182..736e1cea7e970 100644
        break;
      }
      case TabStripModelChange::kSelectionOnly:
-@@ -2287,6 +2316,11 @@ bool Browser::ShouldFocusLocationBarByDefault(WebContents* source) {
+@@ -2287,6 +2322,11 @@ bool Browser::ShouldFocusLocationBarByDefault(WebContents* source) {
        source->GetController().GetPendingEntry()
            ? source->GetController().GetPendingEntry()
            : source->GetController().GetLastCommittedEntry();
@@ -92,7 +110,7 @@ index 9603137595182..736e1cea7e970 100644
    if (entry) {
      const GURL& url = entry->GetURL();
      const GURL& virtual_url = entry->GetVirtualURL();
-@@ -2299,15 +2333,18 @@ bool Browser::ShouldFocusLocationBarByDefault(WebContents* source) {
+@@ -2299,15 +2339,18 @@ bool Browser::ShouldFocusLocationBarByDefault(WebContents* source) {
           url.host() == chrome::kChromeUINewTabHost) ||
          (virtual_url.SchemeIs(content::kChromeUIScheme) &&
           virtual_url.host() == chrome::kChromeUINewTabHost)) {

--- a/packages/browseros/chromium_patches/chrome/test/BUILD.gn
+++ b/packages/browseros/chromium_patches/chrome/test/BUILD.gn
@@ -1,16 +1,17 @@
 diff --git a/chrome/test/BUILD.gn b/chrome/test/BUILD.gn
-index 5870101f9e55d..c590c94e5b142 100644
+index 5870101f9e55d..0bf6ecf5f0bdc 100644
 --- a/chrome/test/BUILD.gn
 +++ b/chrome/test/BUILD.gn
-@@ -7040,6 +7040,7 @@ test("unit_tests") {
+@@ -7040,6 +7040,8 @@ test("unit_tests") {
      "//chrome/browser/breadcrumbs",
      "//chrome/browser/breadcrumbs:unit_tests",
      "//chrome/browser/browsing_data:constants",
++    "//chrome/browser/browseros/core:unit_tests",
 +    "//chrome/browser/browseros/server:unit_tests",
      "//chrome/browser/btm:unit_tests",
      "//chrome/browser/chooser_controller:unit_tests",
      "//chrome/browser/collaboration",
-@@ -7884,6 +7885,10 @@ test("unit_tests") {
+@@ -7884,6 +7886,10 @@ test("unit_tests") {
      # but when we tried to pull it up to the common.gypi level, it broke
      # other things like the ui and startup tests. *shrug*
      ldflags = [ "-Wl,-ObjC" ]


### PR DESCRIPTION
## Summary
- Adds BrowserOS patch-store updates for a BrowserClaw-only default that hides saved tab group chips in the bookmark bar.
- Adds BrowserOS pref plumbing that syncs to Chromium's existing `bookmarks::prefs::kShowTabGroupsInBookmarkBar` without clobbering explicit upstream user choices.
- Adds unit coverage for BrowserClaw/BrowserOS defaults, initial sync, user override preservation, and live apply behavior.

## Design
The Chromium patch introduces `browseros.show_tab_groups_in_bookmark_bar`, defaulting false only for BrowserClaw. Browser startup syncs that value into the existing Chromium bookmark-bar pref only while the upstream pref is still default, and observes the BrowserOS pref for live updates.

## Test plan
- [x] `/Users/shadowfax/.skills/sf-mux/scripts/sfmux pool build -- autoninja -C out/Default_arm64 unit_tests`
- [x] `/Users/shadowfax/.skills/sf-mux/scripts/sfmux pool build -- out/Default_arm64/unit_tests '--gtest_filter=BrowserOSPrefsTest.*'`
- [x] `/Users/shadowfax/.skills/sf-mux/scripts/sfmux pool build -- autoninja -C out/Default_arm64 chrome`
- [x] `/Users/shadowfax/.skills/sf-ch-extract/scripts/verify-patches.sh --chromium-src /Users/shadowfax/ch-1 --worktree /Users/shadowfax/worktrees/main/feat-claw-hide-tab-groups-patches --tip 39b96c47a330f`