### PR TITLE
ci: trigger internal-docs sync on push

### DIFF
--- a/.github/workflows/sync-internal-docs.yml
+++ b/.github/workflows/sync-internal-docs.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: '0 */4 * * *'
   workflow_dispatch:
+  repository_dispatch:
+    types: [internal-docs-updated]
 
 concurrency:
   group: sync-internal-docs


### PR DESCRIPTION
## Summary
- Adds a `repository_dispatch` listener for `internal-docs-updated` to the existing BrowserOS internal-docs sync workflow.
- Keeps the 4-hour cron and manual dispatch as backstops, and leaves the sync job's no-op/dedupe/concurrency/auto-merge behavior unchanged.
- Added `browseros-ai/internal-docs` workflow `.github/workflows/dispatch-browseros-sync.yml` on `main` in commit `2434d640611f0b48afeeb6c38f81c9cfd3e12942`; it dispatches this event on pushes to docs `main`.

## Design
BrowserOS remains the owner of the submodule pointer update. The docs repo only sends a cross-repo dispatch using `INTERNAL_DOCS_SYNC_TOKEN`; BrowserOS then runs the same concurrency-protected sync path used by cron/manual dispatch. Direct pushing BrowserOS `main` was not used because the active `main-branch` ruleset requires PR-based landing.

## Operations
- Set `INTERNAL_DOCS_SYNC_TOKEN` in `browseros-ai/internal-docs` for cross-repo dispatch auth.
- Rotated `INTERNAL_DOCS_SYNC_TOKEN` in `browseros-ai/BrowserOS` because recent scheduled syncs could push branches but failed PR creation with `Resource not accessible by personal access token`.
- Local clones still need to pull the updated superproject pointer, e.g. `git pull --recurse-submodules` or `git config submodule.recurse true`.

## Test plan
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/sync-internal-docs.yml"); puts "ok"'`
- [x] `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/dispatch-browseros-sync.yml"); puts "ok"'` in the internal-docs clone
- [x] Internal-docs initial push workflow ran successfully: https://github.com/browseros-ai/internal-docs/actions/runs/28829182245
- [x] Manual BrowserOS sync after secret rotation succeeded and merged pointer bump PR #1638: https://github.com/browseros-ai/BrowserOS/actions/runs/28829251799
- [x] Real push to `browseros-ai/internal-docs@main` (`3a6d35e98f8ecfddfd0b000af6b5e20632db628c`) triggered BrowserOS `repository_dispatch`: https://github.com/browseros-ai/BrowserOS/actions/runs/28829381593
- [x] That dispatch auto-merged BrowserOS pointer bump PR #1640: https://github.com/browseros-ai/BrowserOS/pull/1640