### PR TITLE
fix: normalize rust mcp schemas for Claude Code

### DIFF
--- a/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
@@ -230,18 +230,52 @@ pub fn input_schema<T>() -> Arc<JsonObject>
 where
     T: JsonSchema + std::any::Any,
 {
-    rmcp::handler::server::tool::schema_for_input::<T>().unwrap_or_else(|err| {
+    let schema = rmcp::handler::server::tool::schema_for_input::<T>().unwrap_or_else(|err| {
         panic!("invalid BrowserOS MCP input schema: {err}");
-    })
+    });
+    normalize_schema_object(schema)
 }
 
 pub fn output_schema<T>() -> Arc<JsonObject>
 where
     T: JsonSchema + std::any::Any,
 {
-    rmcp::handler::server::tool::schema_for_output::<T>().unwrap_or_else(|err| {
+    let schema = rmcp::handler::server::tool::schema_for_output::<T>().unwrap_or_else(|err| {
         panic!("invalid BrowserOS MCP output schema: {err}");
-    })
+    });
+    normalize_schema_object(schema)
+}
+
+/// Rewrites generated JSON Schema into the object-only form expected by strict MCP clients.
+fn normalize_schema_object(schema: Arc<JsonObject>) -> Arc<JsonObject> {
+    let mut value = Value::Object(schema.as_ref().clone());
+    normalize_schema_value(&mut value);
+    match value {
+        Value::Object(object) => Arc::new(object),
+        _ => panic!("BrowserOS MCP schema root should remain an object"),
+    }
+}
+
+/// Rewrites boolean schemas and removes boolean default annotations before MCP serialization.
+fn normalize_schema_value(value: &mut Value) {
+    match value {
+        Value::Bool(true) => *value = json!({}),
+        Value::Bool(false) => *value = json!({ "not": {} }),
+        Value::Array(items) => {
+            for item in items {
+                normalize_schema_value(item);
+            }
+        }
+        Value::Object(object) => {
+            if object.get("default").is_some_and(Value::is_boolean) {
+                object.remove("default");
+            }
+            for value in object.values_mut() {
+                normalize_schema_value(value);
+            }
+        }
+        _ => {}
+    }
 }
 
 #[must_use]

--- a/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
@@ -279,7 +279,7 @@ where
 }
 
 fn browseros_schema_settings() -> SchemaSettings {
-    SchemaSettings::draft2019_09().with(|settings| {
+    SchemaSettings::draft2020_12().with(|settings| {
         settings.inline_subschemas = true;
     })
 }
@@ -288,6 +288,9 @@ fn browseros_schema_settings() -> SchemaSettings {
 fn normalize_schema_object(schema: JsonObject) -> Arc<JsonObject> {
     let mut value = Value::Object(schema);
     normalize_schema_value(&mut value);
+    if let Some(path) = first_boolean_path(&value) {
+        panic!("unsupported boolean value in BrowserOS MCP schema at {path}");
+    }
     match value {
         Value::Object(object) => Arc::new(object),
         _ => panic!("BrowserOS MCP schema root should remain an object"),
@@ -299,20 +302,72 @@ fn normalize_schema_value(value: &mut Value) {
     match value {
         Value::Bool(true) => *value = json!({}),
         Value::Bool(false) => *value = json!({ "not": {} }),
-        Value::Array(items) => {
-            for item in items {
-                normalize_schema_value(item);
-            }
-        }
+        Value::Array(_) => {}
         Value::Object(object) => {
             if object.get("default").is_some_and(Value::is_boolean) {
                 object.remove("default");
             }
-            for value in object.values_mut() {
-                normalize_schema_value(value);
+
+            for key in [
+                "additionalItems",
+                "additionalProperties",
+                "contains",
+                "contentSchema",
+                "else",
+                "if",
+                "items",
+                "not",
+                "propertyNames",
+                "then",
+                "unevaluatedItems",
+                "unevaluatedProperties",
+            ] {
+                if let Some(value) = object.get_mut(key) {
+                    normalize_schema_value(value);
+                }
+            }
+
+            for key in ["allOf", "anyOf", "oneOf", "prefixItems"] {
+                if let Some(Value::Array(items)) = object.get_mut(key) {
+                    for item in items {
+                        normalize_schema_value(item);
+                    }
+                }
+            }
+
+            for key in [
+                "$defs",
+                "definitions",
+                "dependentSchemas",
+                "patternProperties",
+                "properties",
+            ] {
+                if let Some(Value::Object(schemas)) = object.get_mut(key) {
+                    for value in schemas.values_mut() {
+                        normalize_schema_value(value);
+                    }
+                }
             }
         }
         _ => {}
+    }
+}
+
+fn first_boolean_path(value: &Value) -> Option<String> {
+    first_boolean_path_inner(value, "$".to_string())
+}
+
+fn first_boolean_path_inner(value: &Value, path: String) -> Option<String> {
+    match value {
+        Value::Bool(_) => Some(path),
+        Value::Array(items) => items
+            .iter()
+            .enumerate()
+            .find_map(|(index, item)| first_boolean_path_inner(item, format!("{path}[{index}]"))),
+        Value::Object(object) => object
+            .iter()
+            .find_map(|(key, value)| first_boolean_path_inner(value, format!("{path}.{key}"))),
+        _ => None,
     }
 }
 

--- a/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
@@ -4,7 +4,7 @@ use crate::{response::ToolResponse, tools};
 use browseros_core::{BrowserSession, CoreError, PageId, WindowId};
 use futures_util::future::BoxFuture;
 use rmcp::model::{CallToolResult, ContentBlock, JsonObject, Tool, ToolAnnotations};
-use schemars::JsonSchema;
+use schemars::{JsonSchema, generate::SchemaSettings};
 use serde::de::DeserializeOwned;
 use serde_json::{Value, json};
 use std::{collections::HashSet, path::PathBuf, sync::Arc};
@@ -226,29 +226,67 @@ where
     }
 }
 
+/// Builds the normalized JSON object schema used for MCP tool arguments.
 pub fn input_schema<T>() -> Arc<JsonObject>
 where
     T: JsonSchema + std::any::Any,
 {
-    let schema = rmcp::handler::server::tool::schema_for_input::<T>().unwrap_or_else(|err| {
-        panic!("invalid BrowserOS MCP input schema: {err}");
-    });
-    normalize_schema_object(schema)
+    schema_for_mcp_tool::<T>("inputSchema")
 }
 
+/// Builds the normalized JSON object schema used for MCP structured output.
 pub fn output_schema<T>() -> Arc<JsonObject>
 where
     T: JsonSchema + std::any::Any,
 {
-    let schema = rmcp::handler::server::tool::schema_for_output::<T>().unwrap_or_else(|err| {
-        panic!("invalid BrowserOS MCP output schema: {err}");
-    });
-    normalize_schema_object(schema)
+    schema_for_mcp_tool::<T>("outputSchema")
+}
+
+/// Pins schema generation before applying compatibility rewrites for strict MCP clients.
+fn schema_for_mcp_tool<T>(purpose: &str) -> Arc<JsonObject>
+where
+    T: JsonSchema + std::any::Any,
+{
+    let schema = browseros_schema_settings()
+        .into_generator()
+        .into_root_schema_for::<T>();
+    let Value::Object(mut object) = serde_json::to_value(schema).unwrap_or_else(|err| {
+        panic!("invalid BrowserOS MCP {purpose}: schema should serialize: {err}");
+    }) else {
+        panic!("invalid BrowserOS MCP {purpose}: schema root should be an object");
+    };
+
+    match object.get("type") {
+        Some(Value::String(schema_type)) if schema_type == "object" => {}
+        Some(Value::String(schema_type)) => {
+            panic!(
+                "invalid BrowserOS MCP {purpose}: root type should be object, got {schema_type}"
+            );
+        }
+        Some(schema_type) => {
+            panic!(
+                "invalid BrowserOS MCP {purpose}: root type should be a string, got {schema_type}"
+            );
+        }
+        None => {
+            panic!("invalid BrowserOS MCP {purpose}: root type is missing");
+        }
+    }
+
+    object.remove("title");
+    object.remove("description");
+    normalize_schema_object(object)
+}
+
+fn browseros_schema_settings() -> SchemaSettings {
+    SchemaSettings::draft2019_09().with(|settings| {
+        settings.inline_subschemas = true;
+    })
 }
 
 /// Rewrites generated JSON Schema into the object-only form expected by strict MCP clients.
-fn normalize_schema_object(schema: Arc<JsonObject>) -> Arc<JsonObject> {
-    let mut value = Value::Object(schema.as_ref().clone());
+fn normalize_schema_object(schema: JsonObject) -> Arc<JsonObject> {
+    let mut value = Value::Object(schema);
     normalize_schema_value(&mut value);
     match value {
         Value::Object(object) => Arc::new(object),

--- a/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
@@ -125,6 +125,19 @@ fn act_schema_stays_flat_at_top_level() {
 }
 
 #[test]
+fn catalog_schemas_do_not_use_boolean_schema_nodes() {
+    for tool in catalog() {
+        let input_schema = Value::Object(tool.input_schema.as_ref().clone());
+        assert_no_boolean_schema_nodes(tool.name, "inputSchema", &input_schema);
+
+        if let Some(output_schema) = tool.output_schema {
+            let output_schema = Value::Object(output_schema.as_ref().clone());
+            assert_no_boolean_schema_nodes(tool.name, "outputSchema", &output_schema);
+        }
+    }
+}
+
+#[test]
 fn run_has_compat_output_schema() {
     let run = catalog()
         .into_iter()
@@ -136,9 +149,19 @@ fn run_has_compat_output_schema() {
             .as_ref()
             .clone(),
     );
-    assert!(schema.pointer("/properties/ok").is_some());
-    assert!(schema.pointer("/properties/logs").is_some());
-    assert!(schema.pointer("/properties/error").is_some());
+    let properties = schema
+        .pointer("/properties")
+        .and_then(Value::as_object)
+        .unwrap_or_else(|| panic!("run output schema should have object properties"));
+    for key in ["ok", "logs", "error", "value"] {
+        let property = properties
+            .get(key)
+            .unwrap_or_else(|| panic!("missing run output property: {key}"));
+        assert!(
+            property.is_object(),
+            "run output property `{key}` should use object schema form: {property}"
+        );
+    }
 }
 
 #[tokio::test]
@@ -227,4 +250,31 @@ fn wait_parse_ms_matches_ts_fallback_rules() {
     assert_eq!(wait::parse_wait_ms(Some(""), 2_000), 2_000);
     assert_eq!(wait::parse_wait_ms(Some("-1"), 2_000), 2_000);
     assert_eq!(wait::parse_wait_ms(Some("1500.6"), 2_000), 1_501);
+}
+
+fn assert_no_boolean_schema_nodes(tool_name: &str, schema_kind: &str, schema: &Value) {
+    let mut paths = Vec::new();
+    collect_boolean_paths(schema, "$".to_string(), &mut paths);
+    assert!(
+        paths.is_empty(),
+        "{tool_name}.{schema_kind} has boolean schema nodes at {}",
+        paths.join(", ")
+    );
+}
+
+fn collect_boolean_paths(value: &Value, path: String, paths: &mut Vec<String>) {
+    match value {
+        Value::Bool(_) => paths.push(path),
+        Value::Array(items) => {
+            for (index, item) in items.iter().enumerate() {
+                collect_boolean_paths(item, format!("{path}[{index}]"), paths);
+            }
+        }
+        Value::Object(object) => {
+            for (key, value) in object {
+                collect_boolean_paths(value, format!("{path}.{key}"), paths);
+            }
+        }
+        _ => {}
+    }
 }

--- a/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
@@ -138,6 +138,19 @@ fn catalog_schemas_do_not_use_boolean_schema_nodes() {
 }
 
 #[test]
+fn catalog_schemas_are_inlined() {
+    for tool in catalog() {
+        let input_schema = Value::Object(tool.input_schema.as_ref().clone());
+        assert_no_schema_references(tool.name, "inputSchema", &input_schema);
+
+        if let Some(output_schema) = tool.output_schema {
+            let output_schema = Value::Object(output_schema.as_ref().clone());
+            assert_no_schema_references(tool.name, "outputSchema", &output_schema);
+        }
+    }
+}
+
+#[test]
 fn run_has_compat_output_schema() {
     let run = catalog()
         .into_iter()
@@ -273,6 +286,35 @@ fn collect_boolean_paths(value: &Value, path: String, paths: &mut Vec<String>) {
         Value::Object(object) => {
             for (key, value) in object {
                 collect_boolean_paths(value, format!("{path}.{key}"), paths);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn assert_no_schema_references(tool_name: &str, schema_kind: &str, schema: &Value) {
+    let mut paths = Vec::new();
+    collect_schema_reference_paths(schema, "$".to_string(), &mut paths);
+    assert!(
+        paths.is_empty(),
+        "{tool_name}.{schema_kind} has schema references at {}",
+        paths.join(", ")
+    );
+}
+
+fn collect_schema_reference_paths(value: &Value, path: String, paths: &mut Vec<String>) {
+    match value {
+        Value::Array(items) => {
+            for (index, item) in items.iter().enumerate() {
+                collect_schema_reference_paths(item, format!("{path}[{index}]"), paths);
+            }
+        }
+        Value::Object(object) => {
+            for (key, value) in object {
+                if key == "$ref" || key == "$defs" {
+                    paths.push(format!("{path}.{key}"));
+                }
+                collect_schema_reference_paths(value, format!("{path}.{key}"), paths);
             }
         }
         _ => {}


### PR DESCRIPTION
## Summary
- Normalize generated Rust MCP schemas at the `browseros-mcp` boundary so boolean JSON Schema forms never reach `tools/list`.
- Pin schema generation to Draft 2020-12 with inline subschemas, preserving MCP-aligned schema generation while avoiding `$ref`/`$defs` output for strict clients.
- Add catalog-wide regressions that reject boolean schema values/references and assert the `run` output schema keeps object-form `ok`, `logs`, `error`, and `value` properties.

## Design
The Rust server was exposing `run.outputSchema.properties.value` as the legal JSON Schema boolean form `true` because `serde_json::Value` derives to an any-schema under schemars. Claude Code's MCP tools-list validation rejects non-object schema nodes, so one boolean subschema caused the entire tools list to fail. This fix normalizes schema-position boolean forms at the single framework boundary (`true` to `{}`, `false` to `{ "not": {} }`), removes boolean `default` annotations from the emitted compatibility schema, and fails loudly if any unsupported boolean value remains.

## Test plan
- [x] `cargo test -p browseros-mcp schema -- --nocapture` failed before the fix on boolean schema output and boolean input defaults.
- [x] `cargo test -p browseros-mcp --lib -- --nocapture`
- [x] `bun run fmt:rust`
- [x] `bun run lint:rust`
- [x] `bun run test:rust`
- [x] `bun run check` passes with existing warnings in unrelated app/fallow output.
- [x] `bun run test`
- [x] Live curl initialize/tools-list probe against `target/debug/browseros-claw-server-rs`: `tool_count=16`, `boolean_schema_values=0`, `schema_refs=0`, `schema_drafts=https://json-schema.org/draft/2020-12/schema`, `run_value_schema={}`.
