### PR TITLE
fix(patches): post onboarding completion callback

### DIFF
--- a/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding.cc
+++ b/packages/browseros/chromium_patches/chrome/browser/browseros/onboarding/browseros_onboarding.cc
@@ -1,9 +1,9 @@
 diff --git a/chrome/browser/browseros/onboarding/browseros_onboarding.cc b/chrome/browser/browseros/onboarding/browseros_onboarding.cc
 new file mode 100644
-index 0000000000000..d530753f436a0
+index 0000000000000..64393248726cd
 --- /dev/null
 +++ b/chrome/browser/browseros/onboarding/browseros_onboarding.cc
-@@ -0,0 +1,729 @@
+@@ -0,0 +1,728 @@
 +// Copyright 2026 The Chromium Authors
 +// Use of this source code is governed by a BSD-style license that can be
 +// found in the LICENSE file.
@@ -293,10 +293,9 @@ index 0000000000000..d530753f436a0
 +  void HandleComplete(const base::ListValue& args) {
 +    SendState("completed");
 +
-+    base::RepeatingClosure completion_callback = completion_callback_;
-+    if (completion_callback) {
-+      completion_callback.Run();
-+      return;
++    if (completion_callback_) {
++      base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
++          FROM_HERE, completion_callback_);
 +    }
 +  }
 +


### PR DESCRIPTION
## Summary
- Updates the BrowserOS onboarding Chromium patch so `HandleComplete` posts `completion_callback_` instead of running it inline on the WebUI message dispatch stack.
- Keeps `SendState("completed")` synchronous and before the posted completion task.
- Leaves the generated onboarding app bundle untouched.

## Design
`BrowserOSOnboardingHandler::HandleComplete` now mirrors the file's existing `PostStartNextImport` pattern by using `base::SequencedTaskRunner::GetCurrentDefault()->PostTask(FROM_HERE, completion_callback_)`. The callback remains a copied `base::RepeatingClosure` bound through a WeakPtr on the first-run controller side.

## Test plan
- [x] `/Users/shadowfax/.skills/sf-mux/scripts/sfmux pool build -- autoninja -C out/Default_arm64 chrome`
- [x] `bpatch feature lint`
- [x] `/Users/shadowfax/.skills/sf-ch-extract/scripts/verify-patches.sh --chromium-src /Users/shadowfax/ch-1 --worktree /Users/shadowfax/worktrees/main/feat-onboarding-complete-posttask-patches --tip task/onboarding-complete-posttask chrome/browser/browseros/onboarding/browseros_onboarding.cc`