### PR TITLE
chore(browseros-mcp): remove manual tab grouping instruction

### DIFF
--- a/packages/browseros-agent/crates/browseros-mcp/src/service.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/service.rs
@@ -42,7 +42,7 @@ pub const BROWSER_MCP_INSTRUCTIONS: &str = r#"BrowserOS MCP - you are driving th
 Shared environment. The user (and possibly other agents) are using this browser right now:
 - Open your own tab with tabs action="new" (use its returned page id everywhere); touch an existing tab only when the user points you at it.
 - Don't steal focus, close tabs you didn't open, or rearrange the user's windows.
-- Group your tabs with tab_groups so your work is visibly yours; close your tabs when done.
+- Close your tabs when done.
 
 Core loop: snapshot -> act -> verify.
 - snapshot renders the page as an accessibility tree; interactive elements carry [ref=eN] handles.

--- a/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
@@ -141,6 +141,12 @@ fn catalog_metadata_matches_claw_hook_contract() {
 }
 
 #[test]
+fn instructions_do_not_request_manual_tab_grouping() {
+    assert!(!BROWSER_MCP_INSTRUCTIONS.contains("tab_groups"));
+    assert!(BROWSER_MCP_INSTRUCTIONS.contains("Close your tabs when done."));
+}
+
+#[test]
 fn act_schema_stays_flat_at_top_level() {
     let act = catalog()
         .into_iter()


### PR DESCRIPTION
## Summary
- Remove the MCP initialize instruction telling clients to group tabs with `tab_groups`.
- Keep the separate cleanup guidance telling clients to close their own tabs when done.
- Add a regression test so `BROWSER_MCP_INSTRUCTIONS` does not reintroduce manual `tab_groups` guidance.

## Design
This is a narrow text-only MCP operating guide change. The `tab_groups` tool and catalog behavior remain unchanged; only the initialize instructions stop asking agents to group tabs manually.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo test -p browseros-mcp`
- [x] `cargo clippy -p browseros-mcp --all-targets -- -D warnings`
- [x] `rg -n "Group your tabs|group your tabs|group tabs|tab_groups so|visibly yours" packages/browseros-agent/crates/browseros-mcp`
