### PR TITLE
fix(bos_build): drop stale branding theme entry

### DIFF
--- a/packages/browseros/bos_build/features.yaml
+++ b/packages/browseros/bos_build/features.yaml
@@ -54,7 +54,6 @@ features:
       # Custom vector icons
       - components/vector_icons/BUILD.gn
       - components/vector_icons/chat_orange.icon
-      - chrome/app/theme/
 
   browserclaw-product-dir:
     description: "feat: per-product user-data dir via browseros_product buildflag"


### PR DESCRIPTION
## Summary
- remove the stale `chrome/app/theme/` directory entry from the `branding` patch registry
- keep the rust release workflow PR scoped by landing this unrelated bos_build doctor cleanup separately

## Verification
- `cd packages/browseros && uv run python -m unittest discover -s bos_build -t . -p "*_test.py"`
- `cd packages/browseros && uv run ruff check bos_build`
