### PR TITLE
chore: make MCP tool descriptions multiline

### DIFF
--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/act.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/act.rs
@@ -10,6 +10,12 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
+const DESCRIPTION: &str = "\
+Act on the page using refs from the last snapshot. \
+kinds: click, type (into focused element), fill (one field via ref+value, or many via fields[]), \
+press (a key/combo), hover, focus, check, uncheck, select (an option value), scroll, drag. \
+Reads back a diff of what changed - re-snapshot if you need fresh refs.";
+
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 enum ActKind {
@@ -118,12 +124,7 @@ struct ActArgs {
 }
 
 pub fn definition() -> crate::framework::ToolDef {
-    super::def::<ActArgs>(
-        "act",
-        "Act on the page using refs from the last snapshot. kinds: click, type (into focused element), fill (one field via ref+value, or many via fields[]), press (a key/combo), hover, focus, check, uncheck, select (an option value), scroll, drag. Reads back a diff of what changed - re-snapshot if you need fresh refs.",
-        None,
-        handler,
-    )
+    super::def::<ActArgs>("act", DESCRIPTION, None, handler)
 }
 
 fn handler<'a>(

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/diff.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/diff.rs
@@ -8,6 +8,10 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::Value;
 
+const DESCRIPTION: &str = "\
+Show what changed on the page since the last snapshot/diff - a cheap way to see \
+an action's effect without re-dumping the whole tree.";
+
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 struct DiffArgs {
     page: u32,
@@ -16,7 +20,7 @@ struct DiffArgs {
 pub fn definition() -> crate::framework::ToolDef {
     super::def::<DiffArgs>(
         "diff",
-        "Show what changed on the page since the last snapshot/diff - a cheap way to see an action's effect without re-dumping the whole tree.",
+        DESCRIPTION,
         Some(super::read_only_annotations()),
         handler,
     )

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/download.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/download.rs
@@ -10,6 +10,10 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 use std::path::PathBuf;
 
+const DESCRIPTION: &str = "\
+Click an element (by ref from the last snapshot) to trigger a file download, \
+and save it to a BrowserOS output file. Returns the saved path and filename.";
+
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 struct DownloadArgs {
     /// Page id from `tabs`.
@@ -19,12 +23,7 @@ struct DownloadArgs {
 }
 
 pub fn definition() -> crate::framework::ToolDef {
-    super::def::<DownloadArgs>(
-        "download",
-        "Click an element (by ref from the last snapshot) to trigger a file download, and save it to a BrowserOS output file. Returns the saved path and filename.",
-        None,
-        handler,
-    )
+    super::def::<DownloadArgs>("download", DESCRIPTION, None, handler)
 }
 
 fn handler<'a>(

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/evaluate.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/evaluate.rs
@@ -15,7 +15,10 @@ use serde_json::{Value, json};
 const DEFAULT_TIMEOUT_MS: u64 = 30_000;
 const MAX_TIMEOUT_MS: u64 = 30_000;
 
-const DESCRIPTION: &str = "Evaluate JavaScript in a page context through CDP Runtime.evaluate. Use this for page-state reads or small DOM scripts that are awkward with read/grep. Return a value to read it back.";
+const DESCRIPTION: &str = "\
+Evaluate JavaScript in a page context through CDP Runtime.evaluate. \
+Use this for page-state reads or small DOM scripts that are awkward with read/grep. \
+Return a value to read it back.";
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 struct EvaluateArgs {

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/grep.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/grep.rs
@@ -13,6 +13,9 @@ use serde_json::{Value, json};
 
 const DEFAULT_LIMIT: usize = 50;
 const LINE_TRUNCATION_MARKER: &str = "... [truncated]";
+const DESCRIPTION: &str = "\
+Search the page without dumping it. over=\"ax\" greps the snapshot lines \
+(matches keep their [ref=eN]); over=\"content\" greps visible text. Returns matching lines.";
 
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
@@ -46,7 +49,7 @@ struct RemoteObject {
 pub fn definition() -> crate::framework::ToolDef {
     super::def::<GrepArgs>(
         "grep",
-        "Search the page without dumping it. over=\"ax\" greps the snapshot lines (matches keep their [ref=eN]); over=\"content\" greps visible text. Returns matching lines.",
+        DESCRIPTION,
         Some(super::read_only_annotations()),
         handler,
     )

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/navigate.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/navigate.rs
@@ -5,6 +5,11 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::json;
 
+const DESCRIPTION: &str = "\
+Navigate a page: load a url, or go back/forward/reload. \
+Returns a fresh snapshot of the resulting page \
+(navigation invalidates refs, so old [ref=eN] handles no longer apply).";
+
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 enum NavigateAction {
@@ -26,12 +31,7 @@ struct NavigateArgs {
 }
 
 pub fn definition() -> crate::framework::ToolDef {
-    super::def::<NavigateArgs>(
-        "navigate",
-        "Navigate a page: load a url, or go back/forward/reload. Returns a fresh snapshot of the resulting page (navigation invalidates refs, so old [ref=eN] handles no longer apply).",
-        None,
-        handler,
-    )
+    super::def::<NavigateArgs>("navigate", DESCRIPTION, None, handler)
 }
 
 fn handler<'a>(

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/pdf.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/pdf.rs
@@ -9,6 +9,10 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
+const DESCRIPTION: &str = "\
+Print the page to a PDF and save it to a BrowserOS output file, returning the path. \
+Use for archiving or reading a page as a document; prefer read for extracting text.";
+
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 struct PdfArgs {
     /// Page id from `tabs`.
@@ -34,7 +38,7 @@ struct PrintToPdfResult {
 pub fn definition() -> crate::framework::ToolDef {
     super::def::<PdfArgs>(
         "pdf",
-        "Print the page to a PDF and save it to a BrowserOS output file, returning the path. Use for archiving or reading a page as a document; prefer read for extracting text.",
+        DESCRIPTION,
         Some(super::read_only_annotations()),
         handler,
     )

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/read.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/read.rs
@@ -13,6 +13,10 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
+const DESCRIPTION: &str = "\
+Extract page content as markdown (default), plain text, or a list of links. \
+For reading/scraping, not acting.";
+
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 enum ReadFormat {
@@ -62,7 +66,7 @@ struct ExceptionDetails {
 pub fn definition() -> crate::framework::ToolDef {
     super::def::<ReadArgs>(
         "read",
-        "Extract page content as markdown (default), plain text, or a list of links. For reading/scraping, not acting.",
+        DESCRIPTION,
         Some(super::read_only_annotations()),
         handler,
     )

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
@@ -6,7 +6,18 @@ use serde_json::{Value, json};
 
 const DEFAULT_TIMEOUT_MS: f64 = 30_000.0;
 
-const DESCRIPTION: &str = "Run JavaScript against the `browser` SDK in the server runtime for multi-step flows and data extraction that would otherwise take many tool calls. `console.log` is captured; `return` a value to read it back; exceptions come back as a result, not a thrown error.\n\nAvailable as `browser`:\n  browser.pages.list() / newPage(url) / close(pageId) / getInfo(pageId)\n  browser.observe(pageId).snapshot()  -> { text, refs }\n  browser.observe(pageId).diff()      -> { text, added, removed, changed }\n  browser.observe(pageId).resolveRef(ref)\n  browser.input(pageId).click(ref) / fill(ref,value) / type(text) / press(key) / hover(ref) / selectOption(ref,value) / scroll(dir,amount,ref?)\n  browser.nav(pageId).goto(url) / back() / forward() / reload()\n  browser.cdp(method, params?, sessionId?)   // raw CDP escape hatch\n  browser.cdpJsonForPage(pageId, method, paramsJson) // page-scoped raw CDP with validated JSON params\nRefs (eN) come from a snapshot's text/refs.";
+const DESCRIPTION: &str = r#"Run JavaScript against the `browser` SDK in the server runtime for multi-step flows and data extraction that would otherwise take many tool calls. `console.log` is captured; `return` a value to read it back; exceptions come back as a result, not a thrown error.
+
+Available as `browser`:
+  browser.pages.list() / newPage(url) / close(pageId) / getInfo(pageId)
+  browser.observe(pageId).snapshot()  -> { text, refs }
+  browser.observe(pageId).diff()      -> { text, added, removed, changed }
+  browser.observe(pageId).resolveRef(ref)
+  browser.input(pageId).click(ref) / fill(ref,value) / type(text) / press(key) / hover(ref) / selectOption(ref,value) / scroll(dir,amount,ref?)
+  browser.nav(pageId).goto(url) / back() / forward() / reload()
+  browser.cdp(method, params?, sessionId?)   // raw CDP escape hatch
+  browser.cdpJsonForPage(pageId, method, paramsJson) // page-scoped raw CDP with validated JSON params
+Refs (eN) come from a snapshot's text/refs."#;
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 struct RunArgs {

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/screenshot.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/screenshot.rs
@@ -10,6 +10,9 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 const DEFAULT_SCREENSHOT_QUALITY: i64 = 80;
+const DESCRIPTION: &str = "\
+Capture a screenshot of the page, returned inline. \
+Defaults to JPEG quality 80 around 1024x768; prefer snapshot for structure/actions.";
 
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
@@ -74,7 +77,7 @@ struct LayoutViewport {
 pub fn definition() -> crate::framework::ToolDef {
     super::def::<ScreenshotArgs>(
         "screenshot",
-        "Capture a screenshot of the page, returned inline. Defaults to JPEG quality 80 around 1024x768; prefer snapshot for structure/actions.",
+        DESCRIPTION,
         Some(super::read_only_annotations()),
         handler,
     )

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/snapshot.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/snapshot.rs
@@ -8,6 +8,13 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
+const DESCRIPTION: &str = "\
+Capture the page as an indented accessibility tree. \
+Each actionable element carries a stable [ref=eN] you pass to `act`. \
+Iframe content is stitched in inline. \
+Re-snapshot after navigation or large changes (refs are invalidated). \
+This is the start of the loop: snapshot -> act -> (reads back a diff).";
+
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 struct SnapshotArgs {
     /// Page id from `tabs` or `navigate`.
@@ -17,7 +24,7 @@ struct SnapshotArgs {
 pub fn definition() -> crate::framework::ToolDef {
     super::def::<SnapshotArgs>(
         "snapshot",
-        "Capture the page as an indented accessibility tree. Each actionable element carries a stable [ref=eN] you pass to `act`. Iframe content is stitched in inline. Re-snapshot after navigation or large changes (refs are invalidated). This is the start of the loop: snapshot -> act -> (reads back a diff).",
+        DESCRIPTION,
         Some(super::read_only_annotations()),
         handler,
     )

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/tab_groups.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/tab_groups.rs
@@ -8,6 +8,10 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
+const DESCRIPTION: &str = "\
+Manage tab groups: list groups, group pages, update a group (title/color/collapsed), \
+ungroup pages, or close a group. Page ids come from the tabs tool.";
+
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 enum TabGroupsAction {
@@ -74,7 +78,7 @@ struct GroupResult {
 pub fn definition() -> crate::framework::ToolDef {
     super::def::<TabGroupsArgs>(
         "tab_groups",
-        "Manage tab groups: list groups, group pages, update a group (title/color/collapsed), ungroup pages, or close a group. Page ids come from the tabs tool.",
+        DESCRIPTION,
         Some(super::open_world_annotations()),
         handler,
     )

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/tabs.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/tabs.rs
@@ -7,6 +7,10 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::json;
 
+const DESCRIPTION: &str = "\
+Manage browser tabs: list open pages (with their page ids), show the active page, \
+open a new page, or close one. Use the returned page id with snapshot/act/navigate.";
+
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
 enum TabsAction {
@@ -36,7 +40,7 @@ struct TabsArgs {
 pub fn definition() -> crate::framework::ToolDef {
     super::def::<TabsArgs>(
         "tabs",
-        "Manage browser tabs: list open pages (with their page ids), show the active page, open a new page, or close one. Use the returned page id with snapshot/act/navigate.",
+        DESCRIPTION,
         Some(super::open_world_annotations()),
         handler,
     )

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/upload.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/upload.rs
@@ -7,6 +7,10 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
+const DESCRIPTION: &str = "\
+Set local file path(s) on a file input using a ref from the last snapshot. \
+Use for <input type=\"file\"> upload flows; files must exist on the server filesystem.";
+
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 struct UploadArgs {
     /// Page id from `tabs`.
@@ -20,12 +24,7 @@ struct UploadArgs {
 }
 
 pub fn definition() -> crate::framework::ToolDef {
-    super::def::<UploadArgs>(
-        "upload",
-        "Set local file path(s) on a file input using a ref from the last snapshot. Use for <input type=\"file\"> upload flows; files must exist on the server filesystem.",
-        None,
-        handler,
-    )
+    super::def::<UploadArgs>("upload", DESCRIPTION, None, handler)
 }
 
 fn handler<'a>(

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/wait.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/wait.rs
@@ -12,6 +12,13 @@ use std::time::{Duration, Instant};
 pub const DEFAULT_PAUSE_MS: u64 = 2_000;
 const DEFAULT_WAIT_TIMEOUT_MS: u64 = 2_000;
 const MAX_WAIT_TIMEOUT_MS: u64 = 30_000;
+const DESCRIPTION: &str = "\
+Pause before continuing. Prefer acting directly and reading the diff; \
+use wait only when there is no reliable UI signal yet. \
+for=\"time\" (default) pauses for value ms; \"text\" waits for a substring to appear; \
+\"selector\" waits for a CSS selector to match. \
+value is optional — for \"time\" it defaults to 2000ms, \
+so calling wait with just a page pauses ~2s.";
 
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "lowercase")]
@@ -55,7 +62,7 @@ struct RemoteObject {
 pub fn definition() -> crate::framework::ToolDef {
     super::def::<WaitArgs>(
         "wait",
-        "Pause before continuing. Prefer acting directly and reading the diff; use wait only when there is no reliable UI signal yet. for=\"time\" (default) pauses for value ms; \"text\" waits for a substring to appear; \"selector\" waits for a CSS selector to match. value is optional — for \"time\" it defaults to 2000ms, so calling wait with just a page pauses ~2s.",
+        DESCRIPTION,
         Some(super::read_only_annotations()),
         handler,
     )

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/windows.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/windows.rs
@@ -7,6 +7,10 @@ use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
+const DESCRIPTION: &str = "\
+Manage browser windows: list windows, create visible or hidden windows, \
+close or activate a window, and show or hide windows.";
+
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 enum WindowsAction {
@@ -37,7 +41,7 @@ struct WindowsArgs {
 pub fn definition() -> crate::framework::ToolDef {
     super::def::<WindowsArgs>(
         "windows",
-        "Manage browser windows: list windows, create visible or hidden windows, close or activate a window, and show or hide windows.",
+        DESCRIPTION,
         Some(super::open_world_annotations()),
         handler,
     )


### PR DESCRIPTION
## Summary
- Move BrowserOS MCP tool descriptions into readable multiline Rust constants
- Preserve tool text/schema behavior while removing dense escaped description literals

## Verification
- cargo fmt
- cargo check -p browseros-mcp
- cargo test -p browseros-mcp
- rg -n "const DESCRIPTION: &str = \".*\\\\n" packages/browseros-agent/crates/browseros-mcp/src/tools