### PR TITLE
fix(ci): install rust claw validation deps

### DIFF
--- a/.github/workflows/release-claw-server-rust.yml
+++ b/.github/workflows/release-claw-server-rust.yml
@@ -199,6 +199,10 @@ jobs:
             echo "PYTHON_BIN=python3" >> "$GITHUB_ENV"
           fi
 
+      - name: Install Python validation dependencies
+        shell: bash
+        run: "$PYTHON_BIN -m pip install --user ./packages/browseros"
+
       - name: Setup Rust
         shell: bash
         run: |

--- a/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
@@ -69,6 +69,9 @@ describe('release-claw-server-rust workflow', () => {
   it('uses matching artifact actions without unused Python dependencies', () => {
     expect(workflow).toContain('uses: actions/upload-artifact@v7')
     expect(workflow).toContain('uses: actions/download-artifact@v7')
+    expect(workflow).toContain(
+      '"$PYTHON_BIN -m pip install --user ./packages/browseros"',
+    )
     expect(workflow).not.toContain('pyyaml')
   })
 


### PR DESCRIPTION
## Summary
- install the local `packages/browseros` Python package before the rust claw artifact validation step imports `extract_artifact_zip`
- keep the workflow test covering matching artifact action versions and the validator dependency setup

## Why
The first populate run failed in every build target at `Validate artifact zip` because importing `bos_build.steps.storage.download` loads broader bos_build modules that require `python-dotenv`. Run: https://github.com/browseros-ai/BrowserOS/actions/runs/28833168468

## Verification
- `actionlint .github/workflows/release-claw-server-rust.yml`
- `cd packages/browseros-agent && bun test scripts/release/prepare-claw-server-rust-release.test.ts scripts/release/release-claw-server-rust-workflow.test.ts scripts/release/prepare-claw-server-release.test.ts scripts/release/release-claw-server-workflow.test.ts`
- `cd packages/browseros-agent && bunx @biomejs/biome check scripts/release/release-claw-server-rust-workflow.test.ts`
