### PR TITLE
fix(ci): validate rust claw zips with uv

### DIFF
--- a/.github/workflows/release-claw-server-rust.yml
+++ b/.github/workflows/release-claw-server-rust.yml
@@ -189,22 +189,18 @@ jobs:
           fetch-depth: 0
           ref: ${{ needs.release.outputs.release_sha }}
 
+      - name: Setup uv
+        uses: astral-sh/setup-uv@v8.2.0
+
       - name: Setup Python
         shell: bash
         run: |
           set -euo pipefail
-
           if [ "$RUNNER_OS" = "Windows" ]; then
-            python -m venv .venv-bos-build
-            echo "PYTHON_BIN=.venv-bos-build/Scripts/python.exe" >> "$GITHUB_ENV"
+            echo "PYTHON_BIN=python" >> "$GITHUB_ENV"
           else
-            python3 -m venv .venv-bos-build
-            echo "PYTHON_BIN=.venv-bos-build/bin/python" >> "$GITHUB_ENV"
+            echo "PYTHON_BIN=python3" >> "$GITHUB_ENV"
           fi
-
-      - name: Install Python validation dependencies
-        shell: bash
-        run: "$PYTHON_BIN -m pip install ./packages/browseros"
 
       - name: Setup Rust
         shell: bash
@@ -343,7 +339,7 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          PYTHONPATH="$GITHUB_WORKSPACE/packages/browseros" "$PYTHON_BIN" <<'PY'
+          uv run --project packages/browseros python <<'PY'
           import os
           import tempfile
           from pathlib import Path

--- a/.github/workflows/release-claw-server-rust.yml
+++ b/.github/workflows/release-claw-server-rust.yml
@@ -193,15 +193,18 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+
           if [ "$RUNNER_OS" = "Windows" ]; then
-            echo "PYTHON_BIN=python" >> "$GITHUB_ENV"
+            python -m venv .venv-bos-build
+            echo "PYTHON_BIN=.venv-bos-build/Scripts/python.exe" >> "$GITHUB_ENV"
           else
-            echo "PYTHON_BIN=python3" >> "$GITHUB_ENV"
+            python3 -m venv .venv-bos-build
+            echo "PYTHON_BIN=.venv-bos-build/bin/python" >> "$GITHUB_ENV"
           fi
 
       - name: Install Python validation dependencies
         shell: bash
-        run: "$PYTHON_BIN -m pip install --user ./packages/browseros"
+        run: "$PYTHON_BIN -m pip install ./packages/browseros"
 
       - name: Setup Rust
         shell: bash

--- a/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
@@ -69,8 +69,12 @@ describe('release-claw-server-rust workflow', () => {
   it('uses matching artifact actions without unused Python dependencies', () => {
     expect(workflow).toContain('uses: actions/upload-artifact@v7')
     expect(workflow).toContain('uses: actions/download-artifact@v7')
+    expect(workflow).toContain('python3 -m venv .venv-bos-build')
+    expect(workflow).toContain('python -m venv .venv-bos-build')
+    expect(workflow).toContain('PYTHON_BIN=.venv-bos-build/bin/python')
+    expect(workflow).toContain('PYTHON_BIN=.venv-bos-build/Scripts/python.exe')
     expect(workflow).toContain(
-      '"$PYTHON_BIN -m pip install --user ./packages/browseros"',
+      '"$PYTHON_BIN -m pip install ./packages/browseros"',
     )
     expect(workflow).not.toContain('pyyaml')
   })

--- a/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
+++ b/packages/browseros-agent/scripts/release/release-claw-server-rust-workflow.test.ts
@@ -69,13 +69,11 @@ describe('release-claw-server-rust workflow', () => {
   it('uses matching artifact actions without unused Python dependencies', () => {
     expect(workflow).toContain('uses: actions/upload-artifact@v7')
     expect(workflow).toContain('uses: actions/download-artifact@v7')
-    expect(workflow).toContain('python3 -m venv .venv-bos-build')
-    expect(workflow).toContain('python -m venv .venv-bos-build')
-    expect(workflow).toContain('PYTHON_BIN=.venv-bos-build/bin/python')
-    expect(workflow).toContain('PYTHON_BIN=.venv-bos-build/Scripts/python.exe')
-    expect(workflow).toContain(
-      '"$PYTHON_BIN -m pip install ./packages/browseros"',
-    )
+    expect(workflow).toContain('uses: astral-sh/setup-uv@v8.2.0')
+    expect(workflow).toContain('uv run --project packages/browseros python')
+    expect(workflow).not.toContain('Install Python validation dependencies')
+    expect(workflow).not.toContain('pip install ./packages/browseros')
+    expect(workflow).not.toContain('.venv-bos-build')
     expect(workflow).not.toContain('pyyaml')
   })
 


### PR DESCRIPTION
## Summary
- use the repo-standard `astral-sh/setup-uv@v8.2.0` in the Rust claw build matrix
- run artifact zip validation through `uv run --project packages/browseros python` so it exercises the real bos_build implementation and dependencies
- remove the validator pip/venv path entirely; keep the existing publish-job AWS CLI install unchanged for R2 upload

## Why
The second populate run proved Linux and Windows validation/upload work, but both macOS runners failed at validator dependency install with PEP 668 externally-managed Python. Run: https://github.com/browseros-ai/BrowserOS/actions/runs/28833679719

## Verification
- `actionlint .github/workflows/release-claw-server-rust.yml`
- `uv run --project packages/browseros python -c "from bos_build.steps.storage.download import extract_artifact_zip; print(extract_artifact_zip.__name__)"`
- `cd packages/browseros-agent && bun test scripts/release/prepare-claw-server-rust-release.test.ts scripts/release/release-claw-server-rust-workflow.test.ts scripts/release/prepare-claw-server-release.test.ts scripts/release/release-claw-server-workflow.test.ts`
- `cd packages/browseros-agent && bunx @biomejs/biome check scripts/release/release-claw-server-rust-workflow.test.ts`
