### PR TITLE
feat(bos_build): stage claw server rust resources

### DIFF
--- a/packages/browseros/bos_build/config/copy_resources.yaml
+++ b/packages/browseros/bos_build/config/copy_resources.yaml
@@ -219,6 +219,42 @@ copy_operations:
     os: ["windows"]
     arch: ["x64"]
 
+  # BrowserOS Claw Rust Server resources - Platform & Architecture specific
+  - name: "BrowserOS Claw Rust Server Resources - macOS ARM64"
+    source: "resources/binaries/browseros_claw_server_rust/darwin-arm64/resources"
+    destination: "chrome/browser/browseros/claw_server_rust/resources"
+    type: "directory"
+    os: ["macos"]
+    arch: ["arm64"]
+
+  - name: "BrowserOS Claw Rust Server Resources - macOS x64"
+    source: "resources/binaries/browseros_claw_server_rust/darwin-x64/resources"
+    destination: "chrome/browser/browseros/claw_server_rust/resources"
+    type: "directory"
+    os: ["macos"]
+    arch: ["x64"]
+
+  - name: "BrowserOS Claw Rust Server Resources - Linux ARM64"
+    source: "resources/binaries/browseros_claw_server_rust/linux-arm64/resources"
+    destination: "chrome/browser/browseros/claw_server_rust/resources"
+    type: "directory"
+    os: ["linux"]
+    arch: ["arm64"]
+
+  - name: "BrowserOS Claw Rust Server Resources - Linux x64"
+    source: "resources/binaries/browseros_claw_server_rust/linux-x64/resources"
+    destination: "chrome/browser/browseros/claw_server_rust/resources"
+    type: "directory"
+    os: ["linux"]
+    arch: ["x64"]
+
+  - name: "BrowserOS Claw Rust Server Resources - Windows x64"
+    source: "resources/binaries/browseros_claw_server_rust/windows-x64/resources"
+    destination: "chrome/browser/browseros/claw_server_rust/resources"
+    type: "directory"
+    os: ["windows"]
+    arch: ["x64"]
+
   # BrowserOS Claw onboarding static resources - platform-independent dist
   # downloaded from R2, feeds the onboarding grit pak built for every product
   - name: "BrowserOS Claw Onboarding Resources"

--- a/packages/browseros/bos_build/config/download_resources.yaml
+++ b/packages/browseros/bos_build/config/download_resources.yaml
@@ -24,6 +24,7 @@
 # R2 Path Structure:
 #   artifacts/server/latest/browseros-server-resources-{target}.zip
 #   claw-server/prod-resources/latest/browseros-claw-server-resources-{target}.zip
+#   claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-{target}.zip
 #   claw-onboard/prod-resources/latest/browseros-claw-onboard-resources.zip
 #
 # Example:
@@ -103,6 +104,42 @@ download_operations:
   - name: "BrowserOS Claw Server Resources - Windows x64"
     r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-windows-x64.zip"
     destination: "resources/binaries/browseros_claw_server/windows-x64"
+    download_type: "artifact_zip"
+    os: ["windows"]
+    arch: ["x64"]
+
+  # BrowserOS Claw Rust Server resource bundles - Platform & Architecture specific
+  - name: "BrowserOS Claw Rust Server Resources - macOS ARM64"
+    r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-arm64.zip"
+    destination: "resources/binaries/browseros_claw_server_rust/darwin-arm64"
+    download_type: "artifact_zip"
+    os: ["macos"]
+    arch: ["arm64"]
+
+  - name: "BrowserOS Claw Rust Server Resources - macOS x64"
+    r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-x64.zip"
+    destination: "resources/binaries/browseros_claw_server_rust/darwin-x64"
+    download_type: "artifact_zip"
+    os: ["macos"]
+    arch: ["x64"]
+
+  - name: "BrowserOS Claw Rust Server Resources - Linux ARM64"
+    r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-linux-arm64.zip"
+    destination: "resources/binaries/browseros_claw_server_rust/linux-arm64"
+    download_type: "artifact_zip"
+    os: ["linux"]
+    arch: ["arm64"]
+
+  - name: "BrowserOS Claw Rust Server Resources - Linux x64"
+    r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-linux-x64.zip"
+    destination: "resources/binaries/browseros_claw_server_rust/linux-x64"
+    download_type: "artifact_zip"
+    os: ["linux"]
+    arch: ["x64"]
+
+  - name: "BrowserOS Claw Rust Server Resources - Windows x64"
+    r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-windows-x64.zip"
+    destination: "resources/binaries/browseros_claw_server_rust/windows-x64"
     download_type: "artifact_zip"
     os: ["windows"]
     arch: ["x64"]

--- a/packages/browseros/bos_build/steps/resources/resources_test.py
+++ b/packages/browseros/bos_build/steps/resources/resources_test.py
@@ -259,10 +259,20 @@ class CopyResourcesTest(unittest.TestCase):
             / "darwin-arm64"
             / "resources"
         )
+        claw_rust_source = (
+            self.root.root
+            / "resources"
+            / "binaries"
+            / "browseros_claw_server_rust"
+            / "darwin-arm64"
+            / "resources"
+        )
         (browseros_source / "bin").mkdir(parents=True)
         (browseros_source / "bin" / "browseros_server").write_text("browseros")
         (claw_source / "bin").mkdir(parents=True)
         (claw_source / "bin" / "browseros-claw-server").write_text("claw")
+        (claw_rust_source / "bin").mkdir(parents=True)
+        (claw_rust_source / "bin" / "browseros-claw-server-rs").write_text("claw-rust")
 
         with patch("bos_build.steps.resources.resources.get_platform", return_value="macos"):
             ctx = make_context(
@@ -293,8 +303,19 @@ class CopyResourcesTest(unittest.TestCase):
             / "bin"
             / "browseros-claw-server"
         )
+        claw_rust_dest = (
+            self.chromium.src
+            / "chrome"
+            / "browser"
+            / "browseros"
+            / "claw_server_rust"
+            / "resources"
+            / "bin"
+            / "browseros-claw-server-rs"
+        )
         self.assertEqual(browseros_dest.read_text(), "browseros")
         self.assertEqual(claw_dest.read_text(), "claw")
+        self.assertEqual(claw_rust_dest.read_text(), "claw-rust")
 
     def test_real_config_copies_server_resources_for_browserclaw_product(self):
         self.root.write_copy_config(self._real_copy_config())
@@ -314,10 +335,20 @@ class CopyResourcesTest(unittest.TestCase):
             / "darwin-arm64"
             / "resources"
         )
+        claw_rust_source = (
+            self.root.root
+            / "resources"
+            / "binaries"
+            / "browseros_claw_server_rust"
+            / "darwin-arm64"
+            / "resources"
+        )
         (browseros_source / "bin").mkdir(parents=True)
         (browseros_source / "bin" / "browseros_server").write_text("browseros")
         (claw_source / "bin").mkdir(parents=True)
         (claw_source / "bin" / "browseros-claw-server").write_text("claw")
+        (claw_rust_source / "bin").mkdir(parents=True)
+        (claw_rust_source / "bin" / "browseros-claw-server-rs").write_text("claw-rust")
 
         with patch("bos_build.steps.resources.resources.get_platform", return_value="macos"):
             ctx = make_context(
@@ -349,8 +380,19 @@ class CopyResourcesTest(unittest.TestCase):
             / "bin"
             / "browseros-claw-server"
         )
+        claw_rust_dest = (
+            self.chromium.src
+            / "chrome"
+            / "browser"
+            / "browseros"
+            / "claw_server_rust"
+            / "resources"
+            / "bin"
+            / "browseros-claw-server-rs"
+        )
         self.assertEqual(browseros_dest.read_text(), "browseros")
         self.assertEqual(claw_dest.read_text(), "claw")
+        self.assertEqual(claw_rust_dest.read_text(), "claw-rust")
 
     def test_real_config_copies_claw_onboard_resources_for_both_products(self):
         # The downloaded onboarding dist must land in the grit resources dir

--- a/packages/browseros/bos_build/steps/storage/download_test.py
+++ b/packages/browseros/bos_build/steps/storage/download_test.py
@@ -215,6 +215,11 @@ class DownloadResourceConfigTest(unittest.TestCase):
                         "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-arm64.zip",
                         "resources/binaries/browseros_claw_server/darwin-arm64",
                     ),
+                    (
+                        "BrowserOS Claw Rust Server Resources - macOS ARM64",
+                        "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-arm64.zip",
+                        "resources/binaries/browseros_claw_server_rust/darwin-arm64",
+                    ),
                 ],
             ),
             (
@@ -230,6 +235,11 @@ class DownloadResourceConfigTest(unittest.TestCase):
                         "BrowserOS Claw Server Resources - macOS x64",
                         "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-x64.zip",
                         "resources/binaries/browseros_claw_server/darwin-x64",
+                    ),
+                    (
+                        "BrowserOS Claw Rust Server Resources - macOS x64",
+                        "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-x64.zip",
+                        "resources/binaries/browseros_claw_server_rust/darwin-x64",
                     ),
                 ],
             ),
@@ -247,6 +257,11 @@ class DownloadResourceConfigTest(unittest.TestCase):
                         "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-arm64.zip",
                         "resources/binaries/browseros_claw_server/linux-arm64",
                     ),
+                    (
+                        "BrowserOS Claw Rust Server Resources - Linux ARM64",
+                        "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-linux-arm64.zip",
+                        "resources/binaries/browseros_claw_server_rust/linux-arm64",
+                    ),
                 ],
             ),
             (
@@ -263,6 +278,11 @@ class DownloadResourceConfigTest(unittest.TestCase):
                         "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-x64.zip",
                         "resources/binaries/browseros_claw_server/linux-x64",
                     ),
+                    (
+                        "BrowserOS Claw Rust Server Resources - Linux x64",
+                        "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-linux-x64.zip",
+                        "resources/binaries/browseros_claw_server_rust/linux-x64",
+                    ),
                 ],
             ),
             (
@@ -278,6 +298,11 @@ class DownloadResourceConfigTest(unittest.TestCase):
                         "BrowserOS Claw Server Resources - Windows x64",
                         "claw-server/prod-resources/latest/browseros-claw-server-resources-windows-x64.zip",
                         "resources/binaries/browseros_claw_server/windows-x64",
+                    ),
+                    (
+                        "BrowserOS Claw Rust Server Resources - Windows x64",
+                        "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-windows-x64.zip",
+                        "resources/binaries/browseros_claw_server_rust/windows-x64",
                     ),
                 ],
             ),
@@ -305,6 +330,8 @@ class DownloadResourceConfigTest(unittest.TestCase):
                 "BrowserOS Server Resources - macOS x64",
                 "BrowserOS Claw Server Resources - macOS ARM64",
                 "BrowserOS Claw Server Resources - macOS x64",
+                "BrowserOS Claw Rust Server Resources - macOS ARM64",
+                "BrowserOS Claw Rust Server Resources - macOS x64",
                 "BrowserOS Claw Onboarding Resources",
             ],
             [op["name"] for op in filtered],
@@ -364,7 +391,12 @@ class DownloadResourceConfigTest(unittest.TestCase):
                     "BrowserOS Claw Server Resources - macOS ARM64",
                     "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-arm64.zip",
                     "resources/binaries/browseros_claw_server/darwin-arm64",
-                )
+                ),
+                (
+                    "BrowserOS Claw Rust Server Resources - macOS ARM64",
+                    "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-arm64.zip",
+                    "resources/binaries/browseros_claw_server_rust/darwin-arm64",
+                ),
             ],
             [
                 (op["name"], op["r2_key"], op["destination"])


### PR DESCRIPTION
## Summary
- download BrowserClaw Rust server artifact_zips from `claw-server-rust/prod-resources/latest` into `resources/binaries/browseros_claw_server_rust/<target>`
- copy the staged Rust bundle into `chrome/browser/browseros/claw_server_rust/resources` without changing the active TS BrowserClaw server bundle
- extend bos_build config tests for the new R2 keys, destinations, and copy target

## Populate dependency
- Release workflow PR: https://github.com/browseros-ai/BrowserOS/pull/1648
- Successful populate run: https://github.com/browseros-ai/BrowserOS/actions/runs/28834336827
- Release: https://github.com/browseros-ai/BrowserOS/releases/tag/claw-server-rust/v0.1.0

## CDN HEAD checks
All required versioned and latest keys returned HTTP 200 before this config change landed:

- https://cdn.browseros.com/claw-server-rust/prod-resources/0.1.0/browseros-claw-server-rust-resources-darwin-arm64.zip
- https://cdn.browseros.com/claw-server-rust/prod-resources/0.1.0/browseros-claw-server-rust-resources-darwin-x64.zip
- https://cdn.browseros.com/claw-server-rust/prod-resources/0.1.0/browseros-claw-server-rust-resources-linux-arm64.zip
- https://cdn.browseros.com/claw-server-rust/prod-resources/0.1.0/browseros-claw-server-rust-resources-linux-x64.zip
- https://cdn.browseros.com/claw-server-rust/prod-resources/0.1.0/browseros-claw-server-rust-resources-windows-x64.zip
- https://cdn.browseros.com/claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-arm64.zip
- https://cdn.browseros.com/claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-x64.zip
- https://cdn.browseros.com/claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-linux-arm64.zip
- https://cdn.browseros.com/claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-linux-x64.zip
- https://cdn.browseros.com/claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-windows-x64.zip

## Verification
- `cd packages/browseros && uv run python -m unittest discover -s bos_build -t . -p "*_test.py"`
- `cd packages/browseros && uv run ruff check bos_build`
- `git diff --check`
