### PR TITLE
feat(tools): release-secrets sync from .env.production with allowlist

### DIFF
--- a/.github/workflows/bos-build-tests.yml
+++ b/.github/workflows/bos-build-tests.yml
@@ -10,6 +10,7 @@ on:
       - "packages/browseros/chromium_files/products/**"
       - "packages/browseros/pyproject.toml"
       - "packages/browseros/uv.lock"
+      - "tools/release_secrets/**"
       - ".github/workflows/bos-build-tests.yml"
 
 jobs:
@@ -30,6 +31,10 @@ jobs:
 
       - name: Run bos_build tests
         run: uv run python -m unittest discover -s bos_build -t . -p "*_test.py" -v
+
+      - name: Run release secrets tests
+        working-directory: ${{ github.workspace }}
+        run: python3 -m unittest discover -s tools/release_secrets -t . -p "*_test.py" -v
 
       - name: Ruff
         run: uv run ruff check bos_build

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@
 nxtscape-cli-access.json
 gclient.json
 .env
+.env.production
 .grove/
 AGENTS.md
 **/resources/binaries/

--- a/packages/browseros/bos_build/docs/release-ci.md
+++ b/packages/browseros/bos_build/docs/release-ci.md
@@ -119,12 +119,8 @@ release secrets from the operator's local `.env.production` into repo-level
 GitHub secrets:
 
 ```bash
-tools/release_secrets/sync.py \
-  --env-file /Users/shadowfax/code/browseros-release/.env.production \
-  --dry-run
-tools/release_secrets/sync.py \
-  --env-file /Users/shadowfax/code/browseros-release/.env.production \
-  --apply
+tools/release_secrets/sync.py --env-file .env.production --dry-run
+tools/release_secrets/sync.py --env-file .env.production --apply
 tools/release_secrets/sync.py --check
 ```
 

--- a/packages/browseros/bos_build/docs/release-ci.md
+++ b/packages/browseros/bos_build/docs/release-ci.md
@@ -114,14 +114,33 @@ gh workflow run release-macos.yml -f products=all -f arch=arm64
 Repository secret and variable names were checked when this document was
 added. Values are never needed locally to inspect this matrix.
 
+Use `tools/release_secrets/sync.py` from the repo root to sync allowlisted
+release secrets from the operator's local `.env.production` into repo-level
+GitHub secrets:
+
+```bash
+tools/release_secrets/sync.py \
+  --env-file /Users/shadowfax/code/browseros-release/.env.production \
+  --dry-run
+tools/release_secrets/sync.py \
+  --env-file /Users/shadowfax/code/browseros-release/.env.production \
+  --apply
+tools/release_secrets/sync.py --check
+```
+
+The sync is allowlist-only and keeps values off argv, logs, and temp files by
+piping each value to `gh secret set` over stdin. It deliberately excludes local
+paths and unrelated API keys from `.env.production`.
+
 | Lane | Required names | Current repo status | Notes |
 | --- | --- | --- | --- |
 | R2 browser artifacts and final draft release | `R2_ACCOUNT_ID`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, `R2_BUCKET` | Present | Used by Linux/Windows browser downloads and uploads, server resource uploads, and the draft GitHub release asset step. |
-| BrowserOS server resources | R2 names plus `BROWSEROS_CONFIG_URL`, `POSTHOG_API_KEY`, `SENTRY_DSN`, `AGENT_RUNNER_JWT_SECRET` | R2 and `POSTHOG_API_KEY` present; `BROWSEROS_CONFIG_URL`, `SENTRY_DSN`, and `AGENT_RUNNER_JWT_SECRET` missing | `release-full.yml` fails in preflight before cancelling nightlies or starting paid builds if selected required names are absent. |
+| BrowserOS server resources | R2 names plus `BROWSEROS_CONFIG_URL`, `POSTHOG_API_KEY`, `SENTRY_DSN` | Present | `AGENT_RUNNER_JWT_SECRET` is optional and inlined only when present. `release-full.yml` fails in preflight before cancelling nightlies or starting paid builds if selected required names are absent. |
 | BrowserClaw server resources | R2 names | Present | `SPARKLE_PRIVATE_KEY` is optional for server OTA publishing; the orchestrator passes `publish_ota=false`. |
 | BrowserClaw Rust server resources | R2 names | Present | Uses only GitHub-hosted runners and writes `claw-server-rust/prod-resources`; no signing or OTA secrets are required. |
-| Windows signing | `ESIGNER_USERNAME`, `ESIGNER_PASSWORD`, `ESIGNER_TOTP_SECRET`, `SPARKLE_PRIVATE_KEY` | Missing | `ESIGNER_CREDENTIAL_ID` is optional. Use `sign_windows=false` only for unsigned verification, not a signed release. |
-| macOS release builder | Repository variables `BROWSEROS_REPO_PATH`, `BROWSEROS_CHROMIUM_SRC` | Present | Signing, notarization, R2, and Slack values live in the runner-local `packages/browseros/.env`; do not copy them into GitHub secrets. |
+| Windows signing | `ESIGNER_USERNAME`, `ESIGNER_PASSWORD`, `ESIGNER_TOTP_SECRET`, `SPARKLE_PRIVATE_KEY` | Present after running `tools/release_secrets/sync.py --apply` | `ESIGNER_CREDENTIAL_ID` is optional and is also synced when present. Use `sign_windows=false` only for unsigned verification, not a signed release. |
+| Extension releases | R2 names plus `GH_TOKEN`, `BROWSEROS_AGENT_V2_KEY`, `BROWSEROS_CONTROLLER_KEY`, `BUGREPORTER_KEY`, `BROWSERCLAW_KEY`, `POSTHOG_API_KEY`, `VITE_PUBLIC_SENTRY_DSN`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`, `VITE_PUBLIC_POSTHOG_KEY`, `VITE_PUBLIC_POSTHOG_HOST` | Extension signing, Sentry, and PostHog names are synced by `tools/release_secrets/sync.py`; `GH_TOKEN` is external | `GH_TOKEN` is for private extension repo clones and is not sourced from `.env.production`. |
+| macOS release builder | Repository variables `BROWSEROS_REPO_PATH`, `BROWSEROS_CHROMIUM_SRC` | Present | The reusable browser build also reads `MACOS_CERTIFICATE_NAME` and `PROD_MACOS_NOTARIZATION_*` from repo secrets when selected; the certificate P12, certificate password, and keychain password remain external to `.env.production`. |
 | GitHub release assets | `GITHUB_TOKEN` | Automatic | Finalize uses it through `GH_TOKEN`. |
 
 ## Runner Cost And Time

--- a/tools/release_secrets/README.md
+++ b/tools/release_secrets/README.md
@@ -8,16 +8,15 @@ dotenv file, and it never prints secret values. Apply mode sends values to
 `gh secret set` over stdin.
 
 ```bash
-tools/release_secrets/sync.py \
-  --env-file /Users/shadowfax/code/browseros-release/.env.production \
-  --dry-run
+tools/release_secrets/sync.py --env-file .env.production --dry-run
 
-tools/release_secrets/sync.py \
-  --env-file /Users/shadowfax/code/browseros-release/.env.production \
-  --apply
+tools/release_secrets/sync.py --env-file .env.production --apply
 
 tools/release_secrets/sync.py --check
 ```
+
+When syncing from an operator checkout outside this repo, pass that file with
+`--env-file /path/to/.env.production`.
 
 `--check` scans the release workflow secret references and compares names
 against `gh secret list`. Known non-dotenv names such as `GITHUB_TOKEN`,

--- a/tools/release_secrets/README.md
+++ b/tools/release_secrets/README.md
@@ -1,0 +1,25 @@
+# Release Secrets Sync
+
+`sync.py` syncs the release-workflow GitHub secrets from a local dotenv file to
+repo-level secrets on `browseros-ai/BrowserOS`.
+
+The tool is intentionally allowlist-only. It does not upload every key in the
+dotenv file, and it never prints secret values. Apply mode sends values to
+`gh secret set` over stdin.
+
+```bash
+tools/release_secrets/sync.py \
+  --env-file /Users/shadowfax/code/browseros-release/.env.production \
+  --dry-run
+
+tools/release_secrets/sync.py \
+  --env-file /Users/shadowfax/code/browseros-release/.env.production \
+  --apply
+
+tools/release_secrets/sync.py --check
+```
+
+`--check` scans the release workflow secret references and compares names
+against `gh secret list`. Known non-dotenv names such as `GITHUB_TOKEN`,
+`GH_TOKEN`, and the macOS certificate P12/password/keychain secrets are reported
+separately from required missing repo secrets.

--- a/tools/release_secrets/__init__.py
+++ b/tools/release_secrets/__init__.py
@@ -1,0 +1,1 @@
+"""Release secret sync tooling."""

--- a/tools/release_secrets/sync.py
+++ b/tools/release_secrets/sync.py
@@ -16,9 +16,9 @@ from pathlib import Path
 from typing import Mapping, Sequence
 
 
-DEFAULT_ENV_FILE = Path("/Users/shadowfax/code/browseros-release/.env.production")
 DEFAULT_REPO = "browseros-ai/BrowserOS"
 REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_ENV_FILE = REPO_ROOT / ".env.production"
 
 RELEASE_WORKFLOW_FILES = (
     Path(".github/workflows/build-browseros.yml"),
@@ -51,6 +51,15 @@ class PlannedSecret:
     name: str
     status: str
     consumers: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class CheckResult:
+    present: list[str]
+    automatic: list[str]
+    external: list[str]
+    optional: list[str]
+    missing_required: list[str]
 
 
 ALLOWLIST: tuple[SecretSpec, ...] = (
@@ -188,10 +197,6 @@ ALLOWLIST: tuple[SecretSpec, ...] = (
         "VITE_PUBLIC_POSTHOG_HOST",
         ("release-extensions.yml",),
     ),  # Extension build-time PostHog host.
-    SecretSpec(
-        "SLACK_WEBHOOK_URL",
-        ("release notifications",),
-    ),  # Existing notification secret carried by release operators.
 )
 
 KNOWN_AUTOMATIC_SECRETS = frozenset({"GITHUB_TOKEN"})
@@ -203,7 +208,9 @@ KNOWN_EXTERNAL_SECRETS = frozenset(
         "MACOS_KEYCHAIN_PASSWORD",
     }
 )
-KNOWN_OPTIONAL_SECRETS = frozenset({"AGENT_RUNNER_JWT_SECRET"})
+KNOWN_OPTIONAL_SECRETS = frozenset(
+    {"AGENT_RUNNER_JWT_SECRET", "ESIGNER_CREDENTIAL_ID"}
+)
 
 
 def parse_dotenv_file(path: Path) -> dict[str, str]:
@@ -288,6 +295,13 @@ def _parse_quoted_value(
             chars.append(_decode_double_quoted_escape(escaped))
             pos += 2
             continue
+
+        if quote == "'" and char == "\\" and pos + 1 < len(text):
+            escaped = text[pos + 1]
+            if escaped in ("'", "\\"):
+                chars.append(escaped)
+                pos += 2
+                continue
 
         if char == quote:
             return "".join(chars), pos + 1, line_no
@@ -456,26 +470,31 @@ def scan_workflow_secret_refs(repo_root: Path) -> set[str]:
 def print_check(repo: str, repo_root: Path) -> int:
     referenced = scan_workflow_secret_refs(repo_root)
     existing = gh_secret_names(repo)
-
-    present = sorted(referenced & existing)
-    automatic = sorted((referenced - existing) & KNOWN_AUTOMATIC_SECRETS)
-    external = sorted((referenced - existing) & KNOWN_EXTERNAL_SECRETS)
-    optional = sorted((referenced - existing) & KNOWN_OPTIONAL_SECRETS)
-    missing_required = sorted(
-        referenced
-        - existing
-        - KNOWN_AUTOMATIC_SECRETS
-        - KNOWN_EXTERNAL_SECRETS
-        - KNOWN_OPTIONAL_SECRETS
-    )
+    result = build_check_result(referenced, existing)
 
     print(f"target repo: {repo}")
-    _print_name_group("present", present)
-    _print_name_group("automatic", automatic)
-    _print_name_group("missing external", external)
-    _print_name_group("missing optional", optional)
-    _print_name_group("missing required", missing_required)
-    return 1 if missing_required else 0
+    _print_name_group("present", result.present)
+    _print_name_group("automatic", result.automatic)
+    _print_name_group("missing external", result.external)
+    _print_name_group("missing optional", result.optional)
+    _print_name_group("missing required", result.missing_required)
+    return 1 if result.missing_required else 0
+
+
+def build_check_result(referenced: set[str], existing: set[str]) -> CheckResult:
+    missing = referenced - existing
+    return CheckResult(
+        present=sorted(referenced & existing),
+        automatic=sorted(missing & KNOWN_AUTOMATIC_SECRETS),
+        external=sorted(missing & KNOWN_EXTERNAL_SECRETS),
+        optional=sorted(missing & KNOWN_OPTIONAL_SECRETS),
+        missing_required=sorted(
+            missing
+            - KNOWN_AUTOMATIC_SECRETS
+            - KNOWN_EXTERNAL_SECRETS
+            - KNOWN_OPTIONAL_SECRETS
+        ),
+    )
 
 
 def _print_name_group(label: str, names: Sequence[str]) -> None:

--- a/tools/release_secrets/sync.py
+++ b/tools/release_secrets/sync.py
@@ -116,6 +116,10 @@ ALLOWLIST: tuple[SecretSpec, ...] = (
         ("release-full.yml", "release-server.yml"),
     ),  # BrowserOS server inline Sentry DSN.
     SecretSpec(
+        "AGENT_RUNNER_JWT_SECRET",
+        ("release-full.yml", "release-server.yml"),
+    ),  # Optional BrowserOS server remote-agent JWT signing secret.
+    SecretSpec(
         "ESIGNER_USERNAME",
         ("build-browseros.yml", "release-windows.yml", "release-full.yml"),
     ),  # Windows signing preflight and CodeSignTool auth.

--- a/tools/release_secrets/sync.py
+++ b/tools/release_secrets/sync.py
@@ -1,0 +1,544 @@
+#!/usr/bin/env python3
+"""Sync allowlisted release workflow secrets from a local dotenv file.
+
+Values are never printed. Apply mode sends each value to `gh secret set` over
+stdin so secret material does not enter argv, shell history, or temp files.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Mapping, Sequence
+
+
+DEFAULT_ENV_FILE = Path("/Users/shadowfax/code/browseros-release/.env.production")
+DEFAULT_REPO = "browseros-ai/BrowserOS"
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+RELEASE_WORKFLOW_FILES = (
+    Path(".github/workflows/build-browseros.yml"),
+    Path(".github/workflows/release-windows.yml"),
+    Path(".github/workflows/release-full.yml"),
+    Path(".github/workflows/release-extensions.yml"),
+    Path(".github/workflows/release-server.yml"),
+    Path(".github/workflows/release-claw-server.yml"),
+)
+
+KEY_RE = re.compile(r"[ \t]*(?:export[ \t]+)?([A-Za-z_][A-Za-z0-9_]*)[ \t]*=")
+SECRET_REF_RE = re.compile(
+    r"secrets\.([A-Za-z_][A-Za-z0-9_]*)"
+    r"|secrets\[['\"]([A-Za-z_][A-Za-z0-9_]*)['\"]\]"
+)
+
+
+class DotenvParseError(ValueError):
+    """Raised when the dotenv file cannot be parsed safely."""
+
+
+@dataclass(frozen=True)
+class SecretSpec:
+    name: str
+    consumers: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class PlannedSecret:
+    name: str
+    status: str
+    consumers: tuple[str, ...]
+
+
+ALLOWLIST: tuple[SecretSpec, ...] = (
+    SecretSpec(
+        "R2_ACCOUNT_ID",
+        (
+            "build-browseros.yml",
+            "release-full.yml",
+            "release-server.yml",
+            "release-claw-server.yml",
+            "release-extensions.yml",
+        ),
+    ),  # Release artifact downloads/uploads.
+    SecretSpec(
+        "R2_ACCESS_KEY_ID",
+        (
+            "build-browseros.yml",
+            "release-full.yml",
+            "release-server.yml",
+            "release-claw-server.yml",
+            "release-extensions.yml",
+        ),
+    ),  # Release artifact downloads/uploads.
+    SecretSpec(
+        "R2_SECRET_ACCESS_KEY",
+        (
+            "build-browseros.yml",
+            "release-full.yml",
+            "release-server.yml",
+            "release-claw-server.yml",
+            "release-extensions.yml",
+        ),
+    ),  # Release artifact downloads/uploads.
+    SecretSpec(
+        "R2_BUCKET",
+        (
+            "build-browseros.yml",
+            "release-full.yml",
+            "release-server.yml",
+            "release-claw-server.yml",
+            "release-extensions.yml",
+        ),
+    ),  # Release artifact downloads/uploads.
+    SecretSpec(
+        "BROWSEROS_CONFIG_URL",
+        ("release-full.yml", "release-server.yml"),
+    ),  # BrowserOS server inline production config URL.
+    SecretSpec(
+        "POSTHOG_API_KEY",
+        ("release-full.yml", "release-server.yml", "release-extensions.yml"),
+    ),  # Server and extension release analytics key.
+    SecretSpec(
+        "SENTRY_DSN",
+        ("release-full.yml", "release-server.yml"),
+    ),  # BrowserOS server inline Sentry DSN.
+    SecretSpec(
+        "ESIGNER_USERNAME",
+        ("build-browseros.yml", "release-windows.yml", "release-full.yml"),
+    ),  # Windows signing preflight and CodeSignTool auth.
+    SecretSpec(
+        "ESIGNER_PASSWORD",
+        ("build-browseros.yml", "release-windows.yml", "release-full.yml"),
+    ),  # Windows signing preflight and CodeSignTool auth.
+    SecretSpec(
+        "ESIGNER_TOTP_SECRET",
+        ("build-browseros.yml", "release-windows.yml", "release-full.yml"),
+    ),  # Windows signing preflight and CodeSignTool auth.
+    SecretSpec(
+        "ESIGNER_CREDENTIAL_ID",
+        ("build-browseros.yml",),
+    ),  # Optional SSL.com credential selector used by the builder.
+    SecretSpec(
+        "SPARKLE_PRIVATE_KEY",
+        (
+            "build-browseros.yml",
+            "release-windows.yml",
+            "release-full.yml",
+            "release-server.yml",
+            "release-claw-server.yml",
+        ),
+    ),  # Sparkle/WinSparkle artifact signatures and optional server OTA.
+    SecretSpec(
+        "MACOS_CERTIFICATE_NAME",
+        ("build-browseros.yml",),
+    ),  # macOS signing certificate identity.
+    SecretSpec(
+        "PROD_MACOS_NOTARIZATION_APPLE_ID",
+        ("build-browseros.yml",),
+    ),  # macOS notarization account.
+    SecretSpec(
+        "PROD_MACOS_NOTARIZATION_TEAM_ID",
+        ("build-browseros.yml",),
+    ),  # macOS notarization team.
+    SecretSpec(
+        "PROD_MACOS_NOTARIZATION_PWD",
+        ("build-browseros.yml",),
+    ),  # macOS notarization app-specific password.
+    SecretSpec(
+        "BROWSEROS_AGENT_V2_KEY",
+        ("release-extensions.yml",),
+    ),  # BrowserOS agent extension signing key.
+    SecretSpec(
+        "BROWSEROS_CONTROLLER_KEY",
+        ("release-extensions.yml",),
+    ),  # BrowserOS controller extension signing key.
+    SecretSpec(
+        "BUGREPORTER_KEY",
+        ("release-extensions.yml",),
+    ),  # Bug Reporter extension signing key.
+    SecretSpec(
+        "BROWSERCLAW_KEY",
+        ("release-extensions.yml",),
+    ),  # BrowserClaw extension signing key.
+    SecretSpec(
+        "VITE_PUBLIC_SENTRY_DSN",
+        ("release-extensions.yml",),
+    ),  # Extension build-time Sentry DSN.
+    SecretSpec(
+        "SENTRY_AUTH_TOKEN",
+        ("release-extensions.yml",),
+    ),  # Extension sourcemap upload auth.
+    SecretSpec(
+        "SENTRY_ORG",
+        ("release-extensions.yml",),
+    ),  # Extension sourcemap upload org.
+    SecretSpec(
+        "SENTRY_PROJECT",
+        ("release-extensions.yml",),
+    ),  # Extension sourcemap upload project.
+    SecretSpec(
+        "VITE_PUBLIC_POSTHOG_KEY",
+        ("release-extensions.yml",),
+    ),  # Extension build-time PostHog key.
+    SecretSpec(
+        "VITE_PUBLIC_POSTHOG_HOST",
+        ("release-extensions.yml",),
+    ),  # Extension build-time PostHog host.
+    SecretSpec(
+        "SLACK_WEBHOOK_URL",
+        ("release notifications",),
+    ),  # Existing notification secret carried by release operators.
+)
+
+KNOWN_AUTOMATIC_SECRETS = frozenset({"GITHUB_TOKEN"})
+KNOWN_EXTERNAL_SECRETS = frozenset(
+    {
+        "GH_TOKEN",
+        "MACOS_CERTIFICATE_P12",
+        "MACOS_CERTIFICATE_PWD",
+        "MACOS_KEYCHAIN_PASSWORD",
+    }
+)
+KNOWN_OPTIONAL_SECRETS = frozenset({"AGENT_RUNNER_JWT_SECRET"})
+
+
+def parse_dotenv_file(path: Path) -> dict[str, str]:
+    return parse_dotenv_text(path.read_text(encoding="utf-8"))
+
+
+def parse_dotenv_text(text: str) -> dict[str, str]:
+    """Parse dotenv text with quoted multi-line value support."""
+    text = text.lstrip("\ufeff").replace("\r\n", "\n").replace("\r", "\n")
+    entries: dict[str, str] = {}
+    pos = 0
+    line_no = 1
+
+    while pos < len(text):
+        pos, line_no = _skip_blank_and_comment_lines(text, pos, line_no)
+        if pos >= len(text):
+            break
+
+        match = KEY_RE.match(text, pos)
+        if not match:
+            raise DotenvParseError(f"Invalid dotenv syntax at line {line_no}")
+
+        key = match.group(1)
+        pos = match.end()
+        while pos < len(text) and text[pos] in " \t":
+            pos += 1
+
+        if pos < len(text) and text[pos] in ("'", '"'):
+            value, pos, line_no = _parse_quoted_value(text, pos, line_no)
+            pos, line_no = _consume_trailing_comment(text, pos, line_no)
+        else:
+            value, pos, line_no = _parse_unquoted_value(text, pos, line_no)
+
+        entries[key] = value
+
+    return entries
+
+
+def _skip_blank_and_comment_lines(
+    text: str, pos: int, line_no: int
+) -> tuple[int, int]:
+    while pos < len(text):
+        cursor = pos
+        while cursor < len(text) and text[cursor] in " \t":
+            cursor += 1
+        if cursor >= len(text):
+            return cursor, line_no
+        if text[cursor] == "\n":
+            pos = cursor + 1
+            line_no += 1
+            continue
+        if text[cursor] == "#":
+            newline = text.find("\n", cursor)
+            if newline == -1:
+                return len(text), line_no
+            pos = newline + 1
+            line_no += 1
+            continue
+        return pos, line_no
+    return pos, line_no
+
+
+def _parse_quoted_value(
+    text: str, pos: int, line_no: int
+) -> tuple[str, int, int]:
+    quote = text[pos]
+    start_line = line_no
+    pos += 1
+    chars: list[str] = []
+
+    while pos < len(text):
+        char = text[pos]
+
+        if quote == '"' and char == "\\":
+            if pos + 1 >= len(text):
+                chars.append("\\")
+                pos += 1
+                continue
+            escaped = text[pos + 1]
+            if escaped == "\n":
+                line_no += 1
+            chars.append(_decode_double_quoted_escape(escaped))
+            pos += 2
+            continue
+
+        if char == quote:
+            return "".join(chars), pos + 1, line_no
+
+        if char == "\n":
+            line_no += 1
+        chars.append(char)
+        pos += 1
+
+    raise DotenvParseError(f"Unterminated quoted value starting at line {start_line}")
+
+
+def _decode_double_quoted_escape(char: str) -> str:
+    replacements = {
+        "n": "\n",
+        "r": "\r",
+        "t": "\t",
+        '"': '"',
+        "\\": "\\",
+        "$": "$",
+        "`": "`",
+    }
+    if char in replacements:
+        return replacements[char]
+    return f"\\{char}"
+
+
+def _consume_trailing_comment(
+    text: str, pos: int, line_no: int
+) -> tuple[int, int]:
+    while pos < len(text) and text[pos] in " \t":
+        pos += 1
+    if pos < len(text) and text[pos] == "#":
+        newline = text.find("\n", pos)
+        if newline == -1:
+            return len(text), line_no
+        return newline + 1, line_no + 1
+    if pos < len(text) and text[pos] == "\n":
+        return pos + 1, line_no + 1
+    if pos < len(text):
+        raise DotenvParseError(
+            f"Unexpected characters after quoted value at line {line_no}"
+        )
+    return pos, line_no
+
+
+def _parse_unquoted_value(
+    text: str, pos: int, line_no: int
+) -> tuple[str, int, int]:
+    newline = text.find("\n", pos)
+    if newline == -1:
+        raw = text[pos:]
+        pos = len(text)
+    else:
+        raw = text[pos:newline]
+        pos = newline + 1
+        line_no += 1
+
+    value = raw.strip()
+    for index, char in enumerate(value):
+        if char == "#" and (index == 0 or value[index - 1] in " \t"):
+            value = value[:index].rstrip()
+            break
+    return value, pos, line_no
+
+
+def serialize_dotenv_values(values: Mapping[str, str]) -> str:
+    lines = []
+    for key, value in values.items():
+        escaped = value.replace("\\", "\\\\").replace('"', '\\"').replace("\r", "\\r")
+        lines.append(f'{key}="{escaped}"')
+    return "\n".join(lines) + "\n"
+
+
+def verify_dotenv_round_trip(values: Mapping[str, str]) -> None:
+    reparsed = parse_dotenv_text(serialize_dotenv_values(values))
+    if dict(values) != reparsed:
+        raise DotenvParseError("Dotenv parser round-trip check failed")
+
+
+def gh_secret_names(repo: str) -> set[str]:
+    result = run_gh(
+        ("secret", "list", "--repo", repo, "--json", "name", "--jq", ".[].name")
+    )
+    return {line.strip() for line in result.stdout.splitlines() if line.strip()}
+
+
+def run_gh(
+    args: Sequence[str], input_text: str | None = None
+) -> subprocess.CompletedProcess:
+    try:
+        result = subprocess.run(
+            ("gh", *args),
+            input=input_text,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("gh CLI not found on PATH") from exc
+
+    if result.returncode != 0:
+        stderr = result.stderr.strip() or result.stdout.strip() or "no gh output"
+        raise RuntimeError(f"gh {' '.join(args)} failed: {stderr}")
+    return result
+
+
+def build_plan(
+    env_values: Mapping[str, str], existing_names: set[str]
+) -> list[PlannedSecret]:
+    plan: list[PlannedSecret] = []
+    for spec in ALLOWLIST:
+        if spec.name not in env_values:
+            status = "skip missing-env"
+        elif env_values[spec.name] == "":
+            status = "skip empty"
+        elif spec.name in existing_names:
+            status = "update"
+        else:
+            status = "set"
+        plan.append(PlannedSecret(spec.name, status, spec.consumers))
+    return plan
+
+
+def print_plan(plan: Sequence[PlannedSecret], repo: str, env_file: Path) -> None:
+    print(f"target repo: {repo}")
+    print(f"env file: {env_file}")
+    print("plan:")
+    for item in plan:
+        consumers = ", ".join(item.consumers)
+        print(f"  {item.status:<16} {item.name} ({consumers})")
+
+
+def apply_plan(
+    plan: Sequence[PlannedSecret], env_values: Mapping[str, str], repo: str
+) -> None:
+    for item in plan:
+        if item.status not in {"set", "update"}:
+            print(f"{item.status.upper()} {item.name}")
+            continue
+
+        run_gh(
+            ("secret", "set", item.name, "--repo", repo),
+            input_text=env_values[item.name],
+        )
+        print(f"{item.status.upper()} {item.name}")
+
+
+def scan_secret_refs_from_text(text: str) -> set[str]:
+    refs: set[str] = set()
+    for match in SECRET_REF_RE.finditer(text):
+        refs.add(match.group(1) or match.group(2))
+    return refs
+
+
+def scan_workflow_secret_refs(repo_root: Path) -> set[str]:
+    refs: set[str] = set()
+    for relative_path in RELEASE_WORKFLOW_FILES:
+        workflow_path = repo_root / relative_path
+        refs.update(
+            scan_secret_refs_from_text(workflow_path.read_text(encoding="utf-8"))
+        )
+    return refs
+
+
+def print_check(repo: str, repo_root: Path) -> int:
+    referenced = scan_workflow_secret_refs(repo_root)
+    existing = gh_secret_names(repo)
+
+    present = sorted(referenced & existing)
+    automatic = sorted((referenced - existing) & KNOWN_AUTOMATIC_SECRETS)
+    external = sorted((referenced - existing) & KNOWN_EXTERNAL_SECRETS)
+    optional = sorted((referenced - existing) & KNOWN_OPTIONAL_SECRETS)
+    missing_required = sorted(
+        referenced
+        - existing
+        - KNOWN_AUTOMATIC_SECRETS
+        - KNOWN_EXTERNAL_SECRETS
+        - KNOWN_OPTIONAL_SECRETS
+    )
+
+    print(f"target repo: {repo}")
+    _print_name_group("present", present)
+    _print_name_group("automatic", automatic)
+    _print_name_group("missing external", external)
+    _print_name_group("missing optional", optional)
+    _print_name_group("missing required", missing_required)
+    return 1 if missing_required else 0
+
+
+def _print_name_group(label: str, names: Sequence[str]) -> None:
+    print(f"{label}:")
+    if not names:
+        print("  (none)")
+        return
+    for name in names:
+        print(f"  {name}")
+
+
+def load_env_for_sync(env_file: Path) -> dict[str, str]:
+    if not env_file.exists():
+        raise FileNotFoundError(f"env file not found: {env_file}")
+    env_values = parse_dotenv_file(env_file)
+    verify_dotenv_round_trip(env_values)
+    return env_values
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Sync allowlisted release workflow secrets from .env.production."
+    )
+    parser.add_argument(
+        "--repo", default=DEFAULT_REPO, help=f"target repo (default: {DEFAULT_REPO})"
+    )
+    parser.add_argument(
+        "--env-file",
+        type=Path,
+        default=DEFAULT_ENV_FILE,
+        help=f"dotenv file for dry-run/apply (default: {DEFAULT_ENV_FILE})",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="repo root used by --check workflow scanning",
+    )
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", action="store_const", const="dry-run", dest="mode")
+    mode.add_argument("--apply", action="store_const", const="apply", dest="mode")
+    mode.add_argument("--check", action="store_const", const="check", dest="mode")
+    parser.set_defaults(mode="dry-run")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    try:
+        if args.mode == "check":
+            return print_check(args.repo, args.repo_root)
+
+        env_values = load_env_for_sync(args.env_file)
+        existing_names = gh_secret_names(args.repo)
+        plan = build_plan(env_values, existing_names)
+        print_plan(plan, args.repo, args.env_file)
+        if args.mode == "apply":
+            apply_plan(plan, env_values, args.repo)
+        return 0
+    except (DotenvParseError, FileNotFoundError, RuntimeError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/release_secrets/sync_test.py
+++ b/tools/release_secrets/sync_test.py
@@ -93,6 +93,18 @@ class SecretPlanTest(unittest.TestCase):
         self.assertEqual(["ESIGNER_CREDENTIAL_ID"], result.optional)
         self.assertEqual([], result.missing_required)
 
+    def test_optional_agent_runner_secret_syncs_when_env_provides_it(self):
+        plan = build_plan({"AGENT_RUNNER_JWT_SECRET": "jwt-secret"}, set())
+
+        self.assertEqual(
+            ("AGENT_RUNNER_JWT_SECRET", "set"),
+            next(
+                (item.name, item.status)
+                for item in plan
+                if item.name == "AGENT_RUNNER_JWT_SECRET"
+            ),
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tools/release_secrets/sync_test.py
+++ b/tools/release_secrets/sync_test.py
@@ -1,0 +1,77 @@
+import unittest
+
+from tools.release_secrets.sync import (
+    DotenvParseError,
+    parse_dotenv_text,
+    scan_secret_refs_from_text,
+    verify_dotenv_round_trip,
+)
+
+
+class DotenvParserTest(unittest.TestCase):
+    def test_multiline_quoted_values_round_trip(self):
+        parsed = parse_dotenv_text(
+            'SPARKLE_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----\n'
+            "line-one\n"
+            "line-two\n"
+            '-----END PRIVATE KEY-----"\n'
+            "BROWSEROS_AGENT_V2_KEY='-----BEGIN KEY-----\n"
+            "agent-line\n"
+            "-----END KEY-----'\n"
+        )
+
+        self.assertEqual(
+            "-----BEGIN PRIVATE KEY-----\nline-one\nline-two\n-----END PRIVATE KEY-----",
+            parsed["SPARKLE_PRIVATE_KEY"],
+        )
+        self.assertEqual(
+            "-----BEGIN KEY-----\nagent-line\n-----END KEY-----",
+            parsed["BROWSEROS_AGENT_V2_KEY"],
+        )
+        verify_dotenv_round_trip(parsed)
+
+    def test_quotes_escapes_and_inline_comments(self):
+        parsed = parse_dotenv_text(
+            'DOUBLE="line\\nquote \\" ok \\\\ done"\n'
+            "SINGLE='raw\\nvalue'\n"
+            "UNQUOTED=value # ignored comment\n"
+            "HASH=abc#def\n"
+            "export EXPORTED = spaced\n"
+        )
+
+        self.assertEqual('line\nquote " ok \\ done', parsed["DOUBLE"])
+        self.assertEqual("raw\\nvalue", parsed["SINGLE"])
+        self.assertEqual("value", parsed["UNQUOTED"])
+        self.assertEqual("abc#def", parsed["HASH"])
+        self.assertEqual("spaced", parsed["EXPORTED"])
+
+    def test_crlf_input_normalizes_multiline_values(self):
+        parsed = parse_dotenv_text('A="one\r\ntwo"\r\nB=three\r\n')
+
+        self.assertEqual("one\ntwo", parsed["A"])
+        self.assertEqual("three", parsed["B"])
+        verify_dotenv_round_trip(parsed)
+
+    def test_unterminated_quote_raises_without_value_echo(self):
+        with self.assertRaises(DotenvParseError) as ctx:
+            parse_dotenv_text('SECRET="do-not-echo\n')
+
+        self.assertIn("line 1", str(ctx.exception))
+        self.assertNotIn("do-not-echo", str(ctx.exception))
+
+
+class WorkflowSecretScannerTest(unittest.TestCase):
+    def test_scans_dotted_and_bracket_secret_references(self):
+        refs = scan_secret_refs_from_text(
+            "env:\n"
+            "  A: ${{ secrets.FOO }}\n"
+            '  B: ${{ secrets["BAR_BAZ"] }}\n'
+            "  C: ${{ secrets['QUX'] }}\n"
+            "  D: ${{ vars.NOT_A_SECRET }}\n"
+        )
+
+        self.assertEqual({"BAR_BAZ", "FOO", "QUX"}, refs)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/release_secrets/sync_test.py
+++ b/tools/release_secrets/sync_test.py
@@ -2,6 +2,8 @@ import unittest
 
 from tools.release_secrets.sync import (
     DotenvParseError,
+    build_check_result,
+    build_plan,
     parse_dotenv_text,
     scan_secret_refs_from_text,
     verify_dotenv_round_trip,
@@ -34,6 +36,7 @@ class DotenvParserTest(unittest.TestCase):
         parsed = parse_dotenv_text(
             'DOUBLE="line\\nquote \\" ok \\\\ done"\n'
             "SINGLE='raw\\nvalue'\n"
+            "SINGLE_ESCAPED='can\\'t \\\\ stop'\n"
             "UNQUOTED=value # ignored comment\n"
             "HASH=abc#def\n"
             "export EXPORTED = spaced\n"
@@ -41,6 +44,7 @@ class DotenvParserTest(unittest.TestCase):
 
         self.assertEqual('line\nquote " ok \\ done', parsed["DOUBLE"])
         self.assertEqual("raw\\nvalue", parsed["SINGLE"])
+        self.assertEqual("can't \\ stop", parsed["SINGLE_ESCAPED"])
         self.assertEqual("value", parsed["UNQUOTED"])
         self.assertEqual("abc#def", parsed["HASH"])
         self.assertEqual("spaced", parsed["EXPORTED"])
@@ -71,6 +75,23 @@ class WorkflowSecretScannerTest(unittest.TestCase):
         )
 
         self.assertEqual({"BAR_BAZ", "FOO", "QUX"}, refs)
+
+
+class SecretPlanTest(unittest.TestCase):
+    def test_slack_webhook_is_not_in_release_workflow_allowlist(self):
+        plan = build_plan({"SLACK_WEBHOOK_URL": "unused"}, set())
+
+        self.assertNotIn("SLACK_WEBHOOK_URL", {item.name for item in plan})
+
+    def test_esigner_credential_id_is_optional_in_check(self):
+        result = build_check_result(
+            referenced={"ESIGNER_CREDENTIAL_ID", "ESIGNER_USERNAME"},
+            existing={"ESIGNER_USERNAME"},
+        )
+
+        self.assertEqual(["ESIGNER_USERNAME"], result.present)
+        self.assertEqual(["ESIGNER_CREDENTIAL_ID"], result.optional)
+        self.assertEqual([], result.missing_required)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds `tools/release_secrets/sync.py`, a dependency-light allowlist-only sync tool for release workflow secrets from `.env.production` to repo-level GitHub secrets.
- Parses quoted multi-line dotenv values in memory and applies secrets via `gh secret set NAME --repo browseros-ai/BrowserOS` using stdin only.
- Ignores `.env.production`, documents the release secret process, and wires parser tests into the build-system CI workflow.

## Design
The sync tool scans the scoped release workflow secret references, uses an explicit audited allowlist with workflow-consumer comments, and separates automatic, external, optional, and required missing names in `--check`. Dry-run and apply print only names/statuses, never values.

## Live Sync
- Ran `tools/release_secrets/sync.py --env-file /Users/shadowfax/code/browseros-release/.env.production --dry-run`.
- Ran `tools/release_secrets/sync.py --env-file /Users/shadowfax/code/browseros-release/.env.production --apply` against `browseros-ai/BrowserOS`.
- Ran `tools/release_secrets/sync.py --check` after apply.
- No release workflows were dispatched.

## Check Output
```text
target repo: browseros-ai/BrowserOS
present:
  BROWSERCLAW_KEY
  BROWSEROS_AGENT_V2_KEY
  BROWSEROS_CONFIG_URL
  BROWSEROS_CONTROLLER_KEY
  BUGREPORTER_KEY
  ESIGNER_CREDENTIAL_ID
  ESIGNER_PASSWORD
  ESIGNER_TOTP_SECRET
  ESIGNER_USERNAME
  MACOS_CERTIFICATE_NAME
  POSTHOG_API_KEY
  PROD_MACOS_NOTARIZATION_APPLE_ID
  PROD_MACOS_NOTARIZATION_PWD
  PROD_MACOS_NOTARIZATION_TEAM_ID
  R2_ACCESS_KEY_ID
  R2_ACCOUNT_ID
  R2_BUCKET
  R2_SECRET_ACCESS_KEY
  SENTRY_AUTH_TOKEN
  SENTRY_DSN
  SENTRY_ORG
  SENTRY_PROJECT
  SPARKLE_PRIVATE_KEY
  VITE_PUBLIC_POSTHOG_HOST
  VITE_PUBLIC_POSTHOG_KEY
  VITE_PUBLIC_SENTRY_DSN
automatic:
  GITHUB_TOKEN
missing external:
  GH_TOKEN
  MACOS_CERTIFICATE_P12
  MACOS_CERTIFICATE_PWD
  MACOS_KEYCHAIN_PASSWORD
missing optional:
  AGENT_RUNNER_JWT_SECRET
missing required:
  (none)
```

## Test Plan
- [x] `python3 -m unittest discover -s tools/release_secrets -t . -p '*_test.py' -v`
- [x] `git check-ignore .env.production`
- [x] `git diff --check origin/main...HEAD`
- [x] `tools/release_secrets/sync.py --check`