### PR TITLE
fix(bos_build): sparkle-sign signed macos plans

### DIFF
--- a/packages/browseros/bos_build/core/planner.py
+++ b/packages/browseros/bos_build/core/planner.py
@@ -90,10 +90,10 @@ def plan(switches: Switches, arch: str, platform: Optional[str] = None) -> List[
 
     Encodes what the release.*.yaml matrix used to spell out per file:
     sparkle_setup is a macOS build dependency even unsigned; WinSparkle
-    setup and the post-package sparkle_sign only exist on signed Windows
-    builds; unsigned Windows builds get mini_installer instead of
-    sign_windows. Universal is not a flat pipeline — plan_runs() expands
-    it into three sequential runs.
+    setup is a Windows build dependency; post-package sparkle_sign exists
+    on signed Windows and macOS builds; unsigned Windows builds get
+    mini_installer instead of sign_windows. Universal is not a flat
+    pipeline — plan_runs() expands it into three sequential runs.
     """
     if arch == "universal":
         raise ValueError("universal is planned as multiple runs; use plan_runs()")
@@ -163,8 +163,15 @@ def _plan_universal_runs(
         ]
     )
 
-    arch_tail = ["resources", "configure", "compile", "sign_macos", "package_macos"]
-    merge_run = ["merge_universal", "sign_macos", "package_macos"]
+    arch_tail = [
+        "resources",
+        "configure",
+        "compile",
+        "sign_macos",
+        "package_macos",
+        "sparkle_sign",
+    ]
+    merge_run = ["merge_universal", "sign_macos", "package_macos", "sparkle_sign"]
     if switches.upload:
         arch_tail.append("upload")
         merge_run.append("upload")
@@ -210,7 +217,7 @@ def _plan_release(switches: Switches, platform: str) -> List[str]:
 
     steps.append(f"package_{platform}")
 
-    if platform == "windows" and switches.sign:
+    if platform in ("macos", "windows") and switches.sign:
         steps.append("sparkle_sign")
     if switches.upload:
         steps.append("upload")

--- a/packages/browseros/bos_build/core/planner_test.py
+++ b/packages/browseros/bos_build/core/planner_test.py
@@ -42,6 +42,7 @@ class ReleaseGoldenTest(unittest.TestCase):
                 "compile",
                 "sign_macos",
                 "package_macos",
+                "sparkle_sign",
                 "upload",
             ],
         )
@@ -117,6 +118,7 @@ class ReleaseGoldenTest(unittest.TestCase):
                         "compile",
                         "sign_macos",
                         "package_macos",
+                        "sparkle_sign",
                         "upload",
                     ],
                 ),
@@ -128,12 +130,19 @@ class ReleaseGoldenTest(unittest.TestCase):
                         "compile",
                         "sign_macos",
                         "package_macos",
+                        "sparkle_sign",
                         "upload",
                     ],
                 ),
                 (
                     "universal",
-                    ["merge_universal", "sign_macos", "package_macos", "upload"],
+                    [
+                        "merge_universal",
+                        "sign_macos",
+                        "package_macos",
+                        "sparkle_sign",
+                        "upload",
+                    ],
                 ),
             ],
         )
@@ -143,9 +152,10 @@ class ReleaseGoldenTest(unittest.TestCase):
             plan_runs(UNIVERSAL, "linux")
 
     def test_noupload_variant(self):
-        # release.macos.arm64.noupload.yaml == release minus upload
+        # release.macos.arm64.noupload.yaml == release minus upload;
+        # signed artifacts are still Sparkle-signed like Windows.
         steps = plan(Switches(preset="release", upload=False), "arm64", "macos")
-        self.assertEqual(steps[-1], "package_macos")
+        self.assertEqual(steps[-2:], ["package_macos", "sparkle_sign"])
         self.assertNotIn("upload", steps)
 
 
@@ -338,7 +348,7 @@ class SliceFromTest(unittest.TestCase):
     def test_slices_composed_plan_from_step(self):
         self.assertEqual(
             slice_from(plan(RELEASE, "arm64", "macos"), "sign_macos"),
-            ["sign_macos", "package_macos", "upload"],
+            ["sign_macos", "package_macos", "sparkle_sign", "upload"],
         )
 
     def test_slice_from_first_step_is_identity(self):
@@ -374,7 +384,7 @@ class SliceRunsFromTest(unittest.TestCase):
         )
         self.assertEqual(
             slice_runs_from(runs, "sign_macos"),
-            [("arm64", ["sign_macos", "package_macos", "upload"])],
+            [("arm64", ["sign_macos", "package_macos", "sparkle_sign", "upload"])],
         )
 
     def test_universal_merge_failure_resumes_without_recompiling(self):
@@ -384,7 +394,13 @@ class SliceRunsFromTest(unittest.TestCase):
             [
                 (
                     "universal",
-                    ["merge_universal", "sign_macos", "package_macos", "upload"],
+                    [
+                        "merge_universal",
+                        "sign_macos",
+                        "package_macos",
+                        "sparkle_sign",
+                        "upload",
+                    ],
                 )
             ],
         )
@@ -395,7 +411,15 @@ class SliceRunsFromTest(unittest.TestCase):
         self.assertEqual(runs[0][0], "arm64")
         self.assertEqual(
             runs[0][1],
-            ["resources", "configure", "compile", "sign_macos", "package_macos", "upload"],
+            [
+                "resources",
+                "configure",
+                "compile",
+                "sign_macos",
+                "package_macos",
+                "sparkle_sign",
+                "upload",
+            ],
         )
         self.assertEqual(runs[1:], full[1:])
 
@@ -418,8 +442,7 @@ class SliceRunsFromTest(unittest.TestCase):
 
 
 class RequiredEnvTest(unittest.TestCase):
-    def test_signed_macos_requires_cert_and_notarization(self):
-        # parity with release.*.macos.*.yaml required_envs
+    def test_signed_macos_requires_cert_notarization_and_sparkle_key(self):
         env = required_env(plan(RELEASE, "arm64", "macos"))
         self.assertEqual(
             env,
@@ -428,6 +451,7 @@ class RequiredEnvTest(unittest.TestCase):
                 "PROD_MACOS_NOTARIZATION_APPLE_ID",
                 "PROD_MACOS_NOTARIZATION_TEAM_ID",
                 "PROD_MACOS_NOTARIZATION_PWD",
+                "SPARKLE_PRIVATE_KEY",
             ],
         )
 
@@ -652,7 +676,7 @@ class UniversalRunsTest(unittest.TestCase):
         self.assertEqual([arch for arch, _ in runs], ["arm64", "x64", "universal"])
         for arch, steps in runs:
             self.assertNotIn("upload", steps, arch)
-            self.assertEqual(steps[-1], "package_macos", arch)
+            self.assertEqual(steps[-2:], ["package_macos", "sparkle_sign"], arch)
 
     def test_non_universal_runs_match_flat_plan_per_arch(self):
         sw = Switches(preset="release", architectures=("x64", "arm64"))
@@ -663,8 +687,7 @@ class UniversalRunsTest(unittest.TestCase):
 
 
 class UniversalEnvTest(unittest.TestCase):
-    def test_universal_runs_require_signing_env_upfront(self):
-        # parity with the deleted release.*.macos.universal.yaml required_envs
+    def test_universal_runs_require_signing_and_sparkle_env_upfront(self):
         for arch, steps in plan_runs(UNIVERSAL, "macos"):
             self.assertEqual(
                 required_env(steps),
@@ -673,6 +696,7 @@ class UniversalEnvTest(unittest.TestCase):
                     "PROD_MACOS_NOTARIZATION_APPLE_ID",
                     "PROD_MACOS_NOTARIZATION_TEAM_ID",
                     "PROD_MACOS_NOTARIZATION_PWD",
+                    "SPARKLE_PRIVATE_KEY",
                 ],
                 arch,
             )

--- a/packages/browseros/bos_build/steps/storage/upload_test.py
+++ b/packages/browseros/bos_build/steps/storage/upload_test.py
@@ -2,8 +2,17 @@
 """Tests for release artifact upload metadata helpers."""
 
 import unittest
+import tempfile
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
 
-from bos_build.steps.storage.upload import _get_artifact_key, merge_release_metadata
+from bos_build.core.context import ArtifactRegistry
+from bos_build.steps.storage.upload import (
+    _get_artifact_key,
+    merge_release_metadata,
+    upload_release_artifacts,
+)
 
 
 class UploadMetadataTest(unittest.TestCase):
@@ -48,6 +57,50 @@ class UploadMetadataTest(unittest.TestCase):
             _get_artifact_key("BrowserOS_v1.2.3_arm64_installer.zip", "win"),
             "arm64_zip",
         )
+
+    def test_upload_attaches_macos_dmg_signature_metadata_by_filename(self) -> None:
+        with (
+            tempfile.TemporaryDirectory() as tmp,
+            mock.patch("bos_build.steps.storage.upload.BOTO3_AVAILABLE", True),
+            mock.patch("bos_build.steps.storage.upload.IS_MACOS", lambda: True),
+            mock.patch("bos_build.steps.storage.upload.IS_WINDOWS", lambda: False),
+            mock.patch(
+                "bos_build.steps.storage.upload.get_r2_client", return_value=object()
+            ),
+            mock.patch(
+                "bos_build.steps.storage.upload.upload_file_to_r2",
+                return_value=True,
+            ),
+        ):
+            dist_dir = Path(tmp)
+            dmg_name = "BrowserOS_v1.2.3_arm64.dmg"
+            (dist_dir / dmg_name).write_bytes(b"dmg")
+            ctx = SimpleNamespace(
+                env=SimpleNamespace(
+                    r2_bucket="browseros",
+                    r2_cdn_base_url="https://cdn.browseros.com",
+                    has_r2_config=lambda: True,
+                ),
+                artifact_registry=ArtifactRegistry(),
+                product=SimpleNamespace(id="browseros", display_name="BrowserOS"),
+                chromium_version="136.0.0.0",
+                browseros_chromium_version="136.0.0.0.1",
+                get_dist_dir=lambda: dist_dir,
+                get_semantic_version=lambda: "1.2.3",
+                get_sparkle_version=lambda: "10000.1.2.3",
+                get_release_path=lambda platform: f"releases/browseros/1.2.3/{platform}/",
+            )
+
+            success, release = upload_release_artifacts(
+                ctx,
+                {dmg_name: {"sparkle_signature": "SIG==", "sparkle_length": 3}},
+            )
+
+        self.assertTrue(success)
+        artifact = release["artifacts"]["arm64"]
+        self.assertEqual(artifact["filename"], dmg_name)
+        self.assertEqual(artifact["sparkle_signature"], "SIG==")
+        self.assertEqual(artifact["sparkle_length"], 3)
 
     def test_merge_release_metadata_preserves_existing_artifacts(self) -> None:
         existing = {


### PR DESCRIPTION
## Summary
- Schedule the existing `sparkle_sign` step after `package_macos` for signed macOS release plans.
- Add `sparkle_sign` to every universal macOS run that packages DMGs, including the merge run, before upload.
- Cover required env and filename-keyed upload metadata so DMGs carry `sparkle_signature` and `sparkle_length` into release.json.

## Design
The planner keeps owning pipeline shape: signed macOS now follows the same post-package Sparkle signing discipline as signed Windows. The existing Sparkle step already signs `*.dmg` files and declares `SPARKLE_PRIVATE_KEY`, so no step or workflow changes are needed. Upload continues attaching metadata by exact artifact filename.

## Test plan
- [x] `uv run python -m unittest discover -s bos_build -t . -p "*_test.py"`
- [x] `uv run ruff check bos_build`
- [x] `uv run browseros build --show-plan --preset release --product browseros --arch arm64`
- [x] `uv run browseros build --show-plan --preset release --product browseros --arch universal`

## arm64 show-plan
```text
Preset plan: preset=release product=browseros platform=macos
Switches: clean=True provision=full download=True sign=True upload=True

arm64 (16 steps):
   1. clean
   2. git_setup
   3. sparkle_setup
   4. download_resources
   5. resources
   6. bundled_extensions
   7. chromium_replace
   8. string_replaces
   9. series_patches
  10. patches
  11. configure
  12. compile
  13. sign_macos
  14. package_macos
  15. sparkle_sign
  16. upload

Required env (arm64):
  MACOS_CERTIFICATE_NAME  ✗ MISSING
  PROD_MACOS_NOTARIZATION_APPLE_ID  ✗ MISSING
  PROD_MACOS_NOTARIZATION_TEAM_ID  ✗ MISSING
  PROD_MACOS_NOTARIZATION_PWD  ✗ MISSING
  SPARKLE_PRIVATE_KEY  ✗ MISSING
```

## universal show-plan
```text
Preset plan: preset=release product=browseros platform=macos
Switches: clean=True provision=full download=True sign=True upload=True

arm64 (16 steps):
   1. clean
   2. git_setup
   3. sparkle_setup
   4. download_resources
   5. bundled_extensions
   6. chromium_replace
   7. string_replaces
   8. series_patches
   9. patches
  10. resources
  11. configure
  12. compile
  13. sign_macos
  14. package_macos
  15. sparkle_sign
  16. upload

Required env (arm64):
  MACOS_CERTIFICATE_NAME  ✗ MISSING
  PROD_MACOS_NOTARIZATION_APPLE_ID  ✗ MISSING
  PROD_MACOS_NOTARIZATION_TEAM_ID  ✗ MISSING
  PROD_MACOS_NOTARIZATION_PWD  ✗ MISSING
  SPARKLE_PRIVATE_KEY  ✗ MISSING

x64 (7 steps):
   1. resources
   2. configure
   3. compile
   4. sign_macos
   5. package_macos
   6. sparkle_sign
   7. upload

Required env (x64):
  MACOS_CERTIFICATE_NAME  ✗ MISSING
  PROD_MACOS_NOTARIZATION_APPLE_ID  ✗ MISSING
  PROD_MACOS_NOTARIZATION_TEAM_ID  ✗ MISSING
  PROD_MACOS_NOTARIZATION_PWD  ✗ MISSING
  SPARKLE_PRIVATE_KEY  ✗ MISSING

universal (5 steps):
   1. merge_universal
   2. sign_macos
   3. package_macos
   4. sparkle_sign
   5. upload

Required env (universal):
  MACOS_CERTIFICATE_NAME  ✗ MISSING
  PROD_MACOS_NOTARIZATION_APPLE_ID  ✗ MISSING
  PROD_MACOS_NOTARIZATION_TEAM_ID  ✗ MISSING
  PROD_MACOS_NOTARIZATION_PWD  ✗ MISSING
  SPARKLE_PRIVATE_KEY  ✗ MISSING
```