### PR TITLE
feat(bos_build): bundle local nightly extensions

### DIFF
--- a/.github/workflows/build-browseros.yml
+++ b/.github/workflows/build-browseros.yml
@@ -99,6 +99,12 @@ jobs:
       # major tag - `@v8` is unresolvable and kills the job in Set up job.
       - uses: astral-sh/setup-uv@v8.2.0
 
+      - name: Setup Bun
+        if: inputs.profile == 'nightly-ci'
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.6"
+
       - name: Resolve chromium pin and paths
         id: pin
         run: |
@@ -269,6 +275,22 @@ jobs:
 
           # Sparkle/WinSparkle artifact signatures.
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+
+          # Bundled extension local-build mode (nightly-ci profile).
+          BROWSEROS_AGENT_V2_KEY: ${{ secrets.BROWSEROS_AGENT_V2_KEY }}
+          BROWSERCLAW_KEY: ${{ secrets.BROWSERCLAW_KEY }}
+
+          # Build-time env consumed by bundled extensions when built locally.
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          VITE_PUBLIC_SENTRY_DSN: ${{ secrets.VITE_PUBLIC_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          VITE_PUBLIC_POSTHOG_KEY: ${{ secrets.VITE_PUBLIC_POSTHOG_KEY }}
+          VITE_PUBLIC_POSTHOG_HOST: ${{ secrets.VITE_PUBLIC_POSTHOG_HOST }}
+          VITE_PUBLIC_BROWSEROS_API: https://api.browseros.com
+          GRAPHQL_SCHEMA_PATH: apps/app/schema/graphql.schema.json
+          NODE_ENV: production
         run: |
           set -euo pipefail
           sign_flag="--no-sign"

--- a/.github/workflows/release-extensions.yml
+++ b/.github/workflows/release-extensions.yml
@@ -36,6 +36,65 @@ on:
         required: false
         type: boolean
         default: false
+  workflow_call:
+    inputs:
+      version:
+        description: "Version stamped on every selected extension (e.g., 0.0.118)"
+        required: true
+        type: string
+      extension:
+        description: "Extension to release: all, agent, controller, bugreporter, or browserclaw"
+        required: false
+        type: string
+        default: "all"
+      channel:
+        description: "Update-feed channel to regenerate: alpha or prod"
+        required: false
+        type: string
+        default: "alpha"
+      branch:
+        description: "Branch override (checkout ref for in-repo builds, clone branch for external repos)"
+        required: false
+        type: string
+        default: ""
+      publish_manifest:
+        description: "Write regenerated update manifests to R2"
+        required: false
+        type: boolean
+        default: false
+    secrets:
+      GH_TOKEN:
+        required: false
+      R2_ACCOUNT_ID:
+        required: true
+      R2_ACCESS_KEY_ID:
+        required: true
+      R2_SECRET_ACCESS_KEY:
+        required: true
+      R2_BUCKET:
+        required: true
+      BROWSEROS_AGENT_V2_KEY:
+        required: false
+      BROWSEROS_CONTROLLER_KEY:
+        required: false
+      BUGREPORTER_KEY:
+        required: false
+      BROWSERCLAW_KEY:
+        required: false
+      POSTHOG_API_KEY:
+        required: false
+      VITE_PUBLIC_SENTRY_DSN:
+        required: false
+      SENTRY_AUTH_TOKEN:
+        required: false
+      SENTRY_ORG:
+        required: false
+      SENTRY_PROJECT:
+        required: false
+      VITE_PUBLIC_POSTHOG_KEY:
+        required: false
+      VITE_PUBLIC_POSTHOG_HOST:
+        required: false
 
 concurrency:
   group: release-extensions

--- a/packages/browseros/bos_build/cli/build.py
+++ b/packages/browseros/bos_build/cli/build.py
@@ -568,7 +568,8 @@ def _resolve_preset(
             f"platform={get_platform()}",
             f"Switches: clean={switches.clean} provision={switches.provision} "
             f"download={switches.download} sign={switches.sign} "
-            f"upload={switches.upload}",
+            f"upload={switches.upload} "
+            f"bundle_local_extensions={switches.bundle_local_extensions}",
         ]
         if switches.skip:
             header.append(f"Skip: {', '.join(switches.skip)}")
@@ -596,7 +597,8 @@ def _resolve_preset(
                 log_info(
                     f"✓ PRESET MODE: clean={switches.clean} "
                     f"provision={switches.provision} download={switches.download} "
-                    f"sign={switches.sign} upload={switches.upload}"
+                    f"sign={switches.sign} upload={switches.upload} "
+                    f"bundle_local_extensions={switches.bundle_local_extensions}"
                 )
                 if switches.skip:
                     log_info(f"✓ PRESET MODE: skip={','.join(switches.skip)}")
@@ -614,6 +616,7 @@ def _resolve_preset(
                             build_type=switches.build_type,
                             product=switches.product,
                             extra_gn_args=extra_gn_args,
+                            bundle_local_extensions=switches.bundle_local_extensions,
                         ),
                         steps,
                     )

--- a/packages/browseros/bos_build/cli/build_test.py
+++ b/packages/browseros/bos_build/cli/build_test.py
@@ -116,6 +116,13 @@ class ShowPlanPresetTest(_ProfileMixin):
         self.assertIn("x64 (", result.output)
         self.assertIn("arm64 (", result.output)
 
+    def test_bundle_local_extensions_switch_reflected(self):
+        path = self._profile("preset: release\nbundle_local_extensions: true\n")
+        with scrubbed_env():
+            result = invoke("--profile", str(path), "--show-plan")
+        self.assertEqual(result.exit_code, 0, combined(result))
+        self.assertIn("bundle_local_extensions=True", result.output)
+
     def test_profile_skip_unions_with_cli_skip(self):
         path = self._profile("preset: release\nskip: [upload]\n")
         with scrubbed_env():
@@ -417,6 +424,19 @@ class GnArgPlumbingTest(_ProfileMixin):
         self.assertTrue(runs)
         for ctx, _steps in runs:
             self.assertEqual(ctx.extra_gn_args, ("symbol_level=2",))
+
+    def test_preset_build_runs_carry_bundle_local_extensions(self):
+        profile_path = self._profile("preset: release\nbundle_local_extensions: true\n")
+        with tempfile.TemporaryDirectory() as tmp:
+            m = MockChromium(Path(tmp))
+            with scrubbed_env():
+                projection = _resolve_preset(
+                    **self._preset_kwargs(profile=profile_path, chromium_src=m.src)
+                )
+                runs = projection.build_runs()
+        self.assertTrue(runs)
+        for ctx, _steps in runs:
+            self.assertTrue(ctx.bundle_local_extensions)
 
     def test_modules_profile_build_runs_carry_extra_gn_args(self):
         profile_path = self._profile("modules: [clean]\n")

--- a/packages/browseros/bos_build/core/context.py
+++ b/packages/browseros/bos_build/core/context.py
@@ -81,6 +81,9 @@ class Context:
     # Per-invocation --gn-arg overrides; configure appends them last in
     # args.gn (GN last-write-wins). Never persisted to profiles.
     extra_gn_args: tuple[str, ...] = ()
+    # Nightly-only opt-in: build in-repo bundled extensions from this checkout
+    # instead of using their CDN-pinned CRX entries.
+    bundle_local_extensions: bool = False
 
     # Third party pins
     SPARKLE_VERSION: str = "2.7.0"

--- a/packages/browseros/bos_build/core/context_test.py
+++ b/packages/browseros/bos_build/core/context_test.py
@@ -25,6 +25,15 @@ class GetAppPathTest(unittest.TestCase):
             "https://cdn.browseros.com/extensions/bundled-manifest.xml",
         )
 
+    def test_bundle_local_extensions_defaults_off(self):
+        ctx = Context(
+            chromium_src=Path("/nonexistent-src"),
+            architecture="arm64",
+            build_type="release",
+        )
+
+        self.assertFalse(ctx.bundle_local_extensions)
+
     def test_arch_build_ignores_stale_universal_app(self):
         # Regression: a leftover out/Default_universal app must never hijack
         # an arch-specific build's sign/package stages.
@@ -56,9 +65,7 @@ class GetAppPathTest(unittest.TestCase):
             build_type="release",
         )
 
-        expected = (
-            Path("/nonexistent-src") / ctx.out_dir / ctx.BROWSEROS_APP_NAME
-        )
+        expected = Path("/nonexistent-src") / ctx.out_dir / ctx.BROWSEROS_APP_NAME
         self.assertTrue(str(ctx.out_dir).endswith("Default_browseros_universal"))
         self.assertEqual(ctx.get_app_path(), expected)
 

--- a/packages/browseros/bos_build/core/planner.py
+++ b/packages/browseros/bos_build/core/planner.py
@@ -34,6 +34,7 @@ class Switches:
     download: Optional[bool] = None
     sign: Optional[bool] = None
     upload: Optional[bool] = None
+    bundle_local_extensions: bool = False
     skip: Tuple[str, ...] = ()
 
     def resolved(self) -> "Switches":
@@ -336,7 +337,16 @@ class Profile:
 
 
 # Planner-owned keys: meaningless once modules: enumerates the pipeline.
-_PLANNER_KEYS = ("preset", "clean", "provision", "download", "sign", "upload", "skip")
+_PLANNER_KEYS = (
+    "preset",
+    "clean",
+    "provision",
+    "download",
+    "sign",
+    "upload",
+    "bundle_local_extensions",
+    "skip",
+)
 
 
 def load_profile(path: Path) -> Profile:
@@ -381,6 +391,7 @@ def load_profile(path: Path) -> Profile:
             download=data.get("download"),
             sign=data.get("sign"),
             upload=data.get("upload"),
+            bundle_local_extensions=data.get("bundle_local_extensions", False),
             skip=_as_tuple(data.get("skip")),
         )
     )

--- a/packages/browseros/bos_build/core/planner_test.py
+++ b/packages/browseros/bos_build/core/planner_test.py
@@ -260,6 +260,13 @@ class SwitchesTest(unittest.TestCase):
         self.assertEqual(Switches(preset="release").build_type, "release")
         self.assertEqual(Switches(preset="debug").build_type, "debug")
 
+    def test_bundle_local_extensions_defaults_off(self):
+        self.assertFalse(Switches().resolved().bundle_local_extensions)
+
+    def test_bundle_local_extensions_does_not_change_step_order(self):
+        local = Switches(preset="release", bundle_local_extensions=True)
+        self.assertEqual(plan(local, "x64", "linux"), plan(RELEASE, "x64", "linux"))
+
 
 class SkipTest(unittest.TestCase):
     def test_skip_subtracts_from_composed_plan(self):
@@ -360,18 +367,14 @@ class SliceFromTest(unittest.TestCase):
         self.assertIn("sign_macos", message)
 
     def test_from_a_skipped_step_rejected(self):
-        steps = plan(
-            Switches(preset="release", skip=("sign_macos",)), "arm64", "macos"
-        )
+        steps = plan(Switches(preset="release", skip=("sign_macos",)), "arm64", "macos")
         with self.assertRaisesRegex(ValueError, "not in the composed plan"):
             slice_from(steps, "sign_macos")
 
 
 class SliceRunsFromTest(unittest.TestCase):
     def test_single_arch_run_sliced(self):
-        runs = plan_runs(
-            Switches(preset="release", architectures=("arm64",)), "macos"
-        )
+        runs = plan_runs(Switches(preset="release", architectures=("arm64",)), "macos")
         self.assertEqual(
             slice_runs_from(runs, "sign_macos"),
             [("arm64", ["sign_macos", "package_macos", "upload"])],
@@ -395,7 +398,14 @@ class SliceRunsFromTest(unittest.TestCase):
         self.assertEqual(runs[0][0], "arm64")
         self.assertEqual(
             runs[0][1],
-            ["resources", "configure", "compile", "sign_macos", "package_macos", "upload"],
+            [
+                "resources",
+                "configure",
+                "compile",
+                "sign_macos",
+                "package_macos",
+                "upload",
+            ],
         )
         self.assertEqual(runs[1:], full[1:])
 
@@ -479,6 +489,10 @@ class ProfileTest(unittest.TestCase):
         self.assertEqual(prof.switches.skip, ("upload", "series_patches"))
         self.assertEqual(self._load("skip: upload\n").switches.skip, ("upload",))
 
+    def test_bundle_local_extensions_profile_key(self):
+        prof = self._load("preset: release\nbundle_local_extensions: true\n")
+        self.assertTrue(prof.switches.bundle_local_extensions)
+
     def test_flat_profile_has_no_modules(self):
         self.assertIsNone(self._load("preset: release\n").modules)
 
@@ -508,6 +522,7 @@ class ProfileTest(unittest.TestCase):
             ("download", "false"),
             ("sign", "false"),
             ("upload", "false"),
+            ("bundle_local_extensions", "true"),
             ("skip", "[upload]"),
         ):
             with self.assertRaisesRegex(ValueError, "do not combine", msg=key):
@@ -533,8 +548,6 @@ class ProfileTest(unittest.TestCase):
     def test_modules_arch_list_rejected(self):
         with self.assertRaisesRegex(ValueError, "single-arch"):
             self._load("modules: [compile]\narch: [x64, arm64]\n")
-
-
 
 
 class PreflightTest(unittest.TestCase):
@@ -605,24 +618,24 @@ class DownloadSwitchTest(unittest.TestCase):
         # to rewrite the yaml to drop download_resources
         with_dl = plan(RELEASE, "arm64", "macos")
         without = plan(Switches(preset="release", download=False), "arm64", "macos")
-        self.assertEqual(
-            [s for s in with_dl if s != "download_resources"], without
-        )
+        self.assertEqual([s for s in with_dl if s != "download_resources"], without)
 
     def test_shipped_nightly_ci_profile_matches_ci_switches(self):
-        shipped = (
-            Path(__file__).resolve().parents[1] / "profiles" / "nightly-ci.yaml"
-        )
+        shipped = Path(__file__).resolve().parents[1] / "profiles" / "nightly-ci.yaml"
         prof = load_profile(shipped)
         # Shipped profiles stay switch-based; modules: is a local-only opt-in.
         self.assertIsNone(prof.modules)
-        for platform, arch in (("macos", "arm64"), ("windows", "x64"), ("linux", "x64")):
+        self.assertTrue(prof.switches.bundle_local_extensions)
+        for platform, arch in (
+            ("macos", "arm64"),
+            ("windows", "x64"),
+            ("linux", "x64"),
+        ):
             self.assertEqual(
                 plan(prof.switches, arch, platform),
                 plan(CI, arch, platform),
                 f"profile drift on {platform}/{arch}",
             )
-
 
 
 class UniversalRunsTest(unittest.TestCase):
@@ -676,6 +689,7 @@ class UniversalEnvTest(unittest.TestCase):
                 ],
                 arch,
             )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/packages/browseros/bos_build/docs/nightly-warpbuild-ci.md
+++ b/packages/browseros/bos_build/docs/nightly-warpbuild-ci.md
@@ -107,11 +107,13 @@ reusable workflow performs the per-platform recipe:
    prerelease for scheduled main runs.
 
 The `nightly-ci` profile is the release preset minus `clean`/
-`git_setup` (steps 4-5 replace them), minus `sign_*`/`upload`. Why not run
-`git_setup` as-is: it does `git fetch --tags`, which on the shallow CI clone
-would pull objects for all ~70k chromium tags; the script instead fetches
-exactly the pinned tag at depth 2. On Windows the new `mini_installer`
-module builds the installer that `sign_windows` would otherwise build.
+`git_setup` (steps 4-5 replace them), minus `sign_*`/`upload`, with
+`bundle_local_extensions: true` so the bundled agent/browserclaw CRXs come
+from the checked-out tree. Why not run `git_setup` as-is: it does `git fetch
+--tags`, which on the shallow CI clone would pull objects for all ~70k chromium
+tags; the script instead fetches exactly the pinned tag at depth 2. On Windows
+the new `mini_installer` module builds the installer that `sign_windows` would
+otherwise build.
 
 ## Caching strategy
 

--- a/packages/browseros/bos_build/docs/release-ci.md
+++ b/packages/browseros/bos_build/docs/release-ci.md
@@ -40,6 +40,7 @@ macOS builder.
 | `.github/workflows/release-server.yml` | Builds BrowserOS server resource zips for every browser target, uploads versioned R2 resource keys, attaches server release assets, and reflects the server package version. | Manual and `agent-server/v*` tags | Yes, when `include_servers=true` and `products` includes `browseros` |
 | `.github/workflows/release-claw-server.yml` | Builds BrowserClaw server and onboard resource zips, uploads versioned R2 keys, attaches server release assets, and reflects Claw package versions. | Manual and `claw-server/v*` tags | Yes, when `include_servers=true` and `products` includes `browserclaw` |
 | `.github/workflows/release-claw-server-rust.yml` | Builds BrowserClaw Rust server resource zips for every browser target, uploads versioned R2 keys under `claw-server-rust/prod-resources`, and attaches Rust server release assets. | Manual, reusable, and `claw-server-rust/v*` tags | No; intentionally separate until BrowserClaw migrates from the TypeScript server |
+| `.github/workflows/release-extensions.yml` | Builds, signs, uploads, and optionally republishes extension CRX manifests for `agent`, `controller`, `bugreporter`, and `browserclaw`. | Manual and reusable | No; per-product orchestrators can call it with `secrets: inherit` |
 | `.github/workflows/release-linux.yml` | Builds Linux x64 browser artifacts on WarpBuild, one matrix entry per selected product. | Manual | Yes |
 | `.github/workflows/release-windows.yml` | Builds Windows x64 browser artifacts on WarpBuild and optionally signs them. | Manual | Yes |
 | `.github/workflows/release-macos.yml` | Builds signed macOS artifacts on the dedicated self-hosted builder. | Manual | Yes |
@@ -64,6 +65,11 @@ step fails the whole Chromium build when a configured key is missing.
 The reusable nesting depth is `release-full.yml -> release-linux.yml or
 release-windows.yml -> build-browseros.yml`, which stays below GitHub's limit
 of four workflow levels.
+
+The `bundle_local_extensions` profile switch defaults off for release
+reproducibility. `profiles/nightly-ci.yaml` sets it true so nightlies build and
+pack in-repo agent/browserclaw CRXs from the checked-out tree while external
+required extensions still come from the bundled CDN manifest.
 
 ## Full Release Inputs
 

--- a/packages/browseros/bos_build/profiles/nightly-ci.yaml
+++ b/packages/browseros/bos_build/profiles/nightly-ci.yaml
@@ -7,3 +7,4 @@ clean: false
 provision: none
 sign: false
 upload: false
+bundle_local_extensions: true

--- a/packages/browseros/bos_build/release/extensions/crx.py
+++ b/packages/browseros/bos_build/release/extensions/crx.py
@@ -22,15 +22,18 @@ _LINUX_CANDIDATES = (
     "chromium-browser",
     "chromium",
 )
+_WINDOWS_CANDIDATES = (
+    r"C:\Program Files\Google\Chrome\Application\chrome.exe",
+    r"C:\Program Files (x86)\Google\Chrome\Application\chrome.exe",
+    "chrome",
+)
 
 
 def _is_valid_binary(path: str) -> bool:
     p = Path(path)
     if p.exists() and p.is_file():
         return os.access(p, os.X_OK)
-    return (
-        subprocess.run(["which", path], capture_output=True).returncode == 0
-    )
+    return subprocess.run(["which", path], capture_output=True).returncode == 0
 
 
 def find_chrome_binary(
@@ -58,6 +61,8 @@ def find_chrome_binary(
         candidates = _DARWIN_CANDIDATES
     elif system == "Linux":
         candidates = _LINUX_CANDIDATES
+    elif system == "Windows":
+        candidates = _WINDOWS_CANDIDATES
     else:
         raise RuntimeError(f"Unsupported platform for CRX packing: {system}")
 
@@ -105,9 +110,7 @@ def pack_crx(
 
     log_info(f"Packing CRX from {dist_dir} with {chrome_binary}")
 
-    with tempfile.NamedTemporaryFile(
-        mode="w", suffix=".pem", delete=False
-    ) as key_file:
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".pem", delete=False) as key_file:
         key_file.write(signing_key_contents)
         key_path = Path(key_file.name)
 
@@ -115,21 +118,17 @@ def pack_crx(
         result = run(pack_extension_command(chrome_binary, dist_dir, key_path))
         if result.returncode != 0:
             raise RuntimeError(
-                f"chrome --pack-extension failed ({result.returncode}): "
-                f"{result.stderr}"
+                f"chrome --pack-extension failed ({result.returncode}): {result.stderr}"
             )
 
         generated = Path(f"{dist_dir}.crx")
         if not generated.exists():
-            raise RuntimeError(
-                f"Expected crx not found after packing: {generated}"
-            )
+            raise RuntimeError(f"Expected crx not found after packing: {generated}")
 
         output_path.parent.mkdir(parents=True, exist_ok=True)
         generated.replace(output_path)
         log_success(
-            f"CRX created: {output_path} "
-            f"({output_path.stat().st_size / 1024:.1f} KB)"
+            f"CRX created: {output_path} ({output_path.stat().st_size / 1024:.1f} KB)"
         )
         return output_path
     finally:

--- a/packages/browseros/bos_build/release/extensions/crx_test.py
+++ b/packages/browseros/bos_build/release/extensions/crx_test.py
@@ -44,6 +44,20 @@ class FindChromeBinaryTest(unittest.TestCase):
                     None, is_valid=lambda p: False, platform_name="Darwin"
                 )
 
+    def test_windows_candidate_supported(self):
+        import os
+
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("CHROME_BINARY", None)
+            found = find_chrome_binary(
+                None,
+                is_valid=lambda p: p.endswith(r"Google\Chrome\Application\chrome.exe"),
+                platform_name="Windows",
+            )
+        self.assertEqual(
+            found, r"C:\Program Files\Google\Chrome\Application\chrome.exe"
+        )
+
     def test_invalid_explicit_binary_raises(self):
         with self.assertRaisesRegex(RuntimeError, "/broken/path"):
             find_chrome_binary(

--- a/packages/browseros/bos_build/steps/extensions/bundled_extensions.py
+++ b/packages/browseros/bos_build/steps/extensions/bundled_extensions.py
@@ -1,17 +1,36 @@
 #!/usr/bin/env python3
-"""Bundled Extensions Module - Download and bundle extensions from CDN manifest"""
+"""Bundled Extensions Module - stage bundled extension CRXs.
+
+Default release builds download every required CRX from the CDN bundled
+manifest. Nightly profiles can opt into `bundle_local_extensions: true`; in
+that mode in-repo extension specs are built and packed from the local checkout,
+while required external extensions continue to download from the CDN manifest.
+"""
 
 import json
+import os
 import sys
 import xml.etree.ElementTree as ET
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Dict, List, NamedTuple
+from typing import Dict, List, NamedTuple, Union
 
 import requests
 
 from ...core.context import Context
 from ...core.step import Step, ValidationError, step
 from ...lib.utils import log_info, log_success
+from ...release.extensions.crx import find_chrome_binary, pack_crx
+from ...release.extensions.specs import (
+    EXTENSION_SPECS,
+    ExtensionSpec,
+    InRepoSource,
+)
+from ...release.extensions.workspace import (
+    resolve_source,
+    run_command,
+    write_env_file,
+)
 
 
 class ExtensionInfo(NamedTuple):
@@ -22,22 +41,56 @@ class ExtensionInfo(NamedTuple):
     codebase: str
 
 
+@dataclass(frozen=True)
+class ManifestBundle:
+    """A required extension staged by downloading the CDN-pinned CRX."""
+
+    name: str
+    extension: ExtensionInfo
+
+
+@dataclass(frozen=True)
+class LocalBundle:
+    """A required extension staged by building an in-repo extension spec."""
+
+    name: str
+    spec: ExtensionSpec
+
+
+BundlePlan = Union[ManifestBundle, LocalBundle]
+
+
 @step("bundled_extensions", phase="prep")
 class BundledExtensionsModule(Step):
-    """Download extensions from CDN manifest and create bundled_extensions.json"""
+    """Stage bundled CRXs and create bundled_extensions.json.
+
+    Profile switch: `bundle_local_extensions: true` builds in-repo required
+    extensions (agent/browserclaw) from the local checkout and packs them with
+    their canonical signing key env vars. Required external extensions still
+    come from the bundled CDN manifest.
+    """
 
     produces = ["bundled_extensions"]
     requires = []
-    description = "Download and bundle extensions from CDN update manifest"
+    description = "Stage bundled extension CRXs from CDN or local builds"
+
+    def preflight(self, ctx: Context) -> None:
+        if self._use_local_bundles(ctx):
+            self._validate_local_bundle_requirements(ctx)
 
     def validate(self, ctx: Context) -> None:
         if not ctx.chromium_src or not ctx.chromium_src.exists():
             raise ValidationError(
                 f"Chromium source directory not found: {ctx.chromium_src}"
             )
+        if self._use_local_bundles(ctx):
+            self._validate_local_bundle_requirements(ctx)
 
     def execute(self, ctx: Context) -> None:
-        log_info("\n📦 Bundling extensions from CDN manifest...")
+        if self._use_local_bundles(ctx):
+            log_info("\n📦 Bundling extensions from local builds + CDN manifest...")
+        else:
+            log_info("\n📦 Bundling extensions from CDN manifest...")
 
         manifest_url = ctx.get_extensions_manifest_url()
         output_dir = self._get_output_dir(ctx)
@@ -48,16 +101,25 @@ class BundledExtensionsModule(Step):
         extensions = self._fetch_and_parse_manifest(manifest_url)
         if not extensions:
             raise RuntimeError("No extensions found in manifest")
-        extensions = self._select_product_extensions(extensions, ctx)
 
-        log_info(f"  Selected {len(extensions)} extension(s) for {ctx.product.display_name}")
+        if self._use_local_bundles(ctx):
+            planned = self._plan_hybrid_bundles(extensions, ctx)
+            log_info(
+                f"  Selected {len(planned)} extension(s) for {ctx.product.display_name}"
+            )
+            staged = self._stage_hybrid_bundles(planned, ctx, output_dir)
+        else:
+            staged = self._select_product_extensions(extensions, ctx)
+            log_info(
+                f"  Selected {len(staged)} extension(s) for {ctx.product.display_name}"
+            )
 
-        for ext in extensions:
-            self._download_extension(ext, output_dir)
+            for ext in staged:
+                self._download_extension(ext, output_dir)
 
-        self._generate_json(extensions, output_dir)
+        self._generate_json(staged, output_dir)
 
-        log_success(f"Bundled {len(extensions)} extensions successfully")
+        log_success(f"Bundled {len(staged)} extensions successfully")
 
     def _get_output_dir(self, ctx: Context) -> Path:
         """Get the bundled extensions output directory in Chromium source"""
@@ -123,7 +185,9 @@ class BundledExtensionsModule(Step):
     ) -> List[ExtensionInfo]:
         """Return manifest entries required by the active product."""
         self._validate_required_extensions(extensions, ctx)
-        required_ids = {extension_id for extension_id, _ in ctx.product.required_extension_ids}
+        required_ids = {
+            extension_id for extension_id, _ in ctx.product.required_extension_ids
+        }
         return [ext for ext in extensions if ext.id in required_ids]
 
     def _validate_required_extensions(
@@ -141,6 +205,147 @@ class BundledExtensionsModule(Step):
                 "Bundled extension manifest missing required entries: "
                 + ", ".join(missing)
             )
+
+    def _use_local_bundles(self, ctx: Context) -> bool:
+        return bool(getattr(ctx, "bundle_local_extensions", False))
+
+    def _plan_hybrid_bundles(
+        self, extensions: List[ExtensionInfo], ctx: Context
+    ) -> List[BundlePlan]:
+        """Choose local-build or manifest-download source per required ID."""
+        manifest_by_id = {ext.id: ext for ext in extensions}
+        local_specs_by_id = self._local_specs_by_id()
+        planned: List[BundlePlan] = []
+        missing: List[str] = []
+
+        for extension_id, name in ctx.product.required_extension_ids:
+            spec = local_specs_by_id.get(extension_id)
+            if spec is not None:
+                planned.append(LocalBundle(name=name, spec=spec))
+                continue
+
+            ext = manifest_by_id.get(extension_id)
+            if ext is not None:
+                planned.append(ManifestBundle(name=name, extension=ext))
+                continue
+
+            missing.append(f"{name} ({extension_id})")
+
+        if missing:
+            raise RuntimeError(
+                "Bundled extensions missing required local or manifest entries: "
+                + ", ".join(missing)
+            )
+        return planned
+
+    def _local_specs_by_id(self) -> Dict[str, ExtensionSpec]:
+        """Specs buildable from this repository, keyed by canonical CRX ID."""
+        return {
+            spec.extension_id: spec
+            for spec in EXTENSION_SPECS
+            if isinstance(spec.source, InRepoSource)
+        }
+
+    def _stage_hybrid_bundles(
+        self, planned: List[BundlePlan], ctx: Context, output_dir: Path
+    ) -> List[ExtensionInfo]:
+        chrome = (
+            find_chrome_binary()
+            if any(isinstance(item, LocalBundle) for item in planned)
+            else ""
+        )
+        staged: List[ExtensionInfo] = []
+        for item in planned:
+            if isinstance(item, ManifestBundle):
+                self._download_extension(item.extension, output_dir)
+                staged.append(item.extension)
+            else:
+                staged.append(
+                    self._build_and_pack_local_extension(
+                        item.spec, ctx, output_dir, chrome
+                    )
+                )
+        return staged
+
+    def _build_and_pack_local_extension(
+        self,
+        spec: ExtensionSpec,
+        ctx: Context,
+        output_dir: Path,
+        chrome_binary: str,
+    ) -> ExtensionInfo:
+        """Build an in-repo extension spec and pack it as <extension id>.crx."""
+        package_root = ctx.root_dir
+        monorepo_root = package_root.parent.parent
+        work_root = package_root / "build" / "bundled_extensions"
+
+        log_info(f"  Building local extension {spec.name}...")
+        source_root = resolve_source(
+            spec,
+            monorepo_root=monorepo_root,
+            work_root=work_root,
+            branch_override=None,
+        )
+        version = self._read_manifest_version(source_root / spec.manifest_path)
+        if spec.env:
+            env_dir = source_root / spec.env_dir if spec.env_dir else source_root
+            write_env_file(env_dir, spec.env)
+        if spec.pre_build:
+            run_command(spec.pre_build, source_root)
+        run_command(spec.build, source_root)
+
+        pack_crx(
+            source_root / spec.dist_path,
+            self._require_signing_key(spec),
+            chrome_binary,
+            output_dir / f"{spec.extension_id}.crx",
+        )
+        return ExtensionInfo(
+            id=spec.extension_id,
+            version=version,
+            codebase=f"local://{spec.name}",
+        )
+
+    def _read_manifest_version(self, manifest_path: Path) -> str:
+        if not manifest_path.exists():
+            raise FileNotFoundError(f"Extension manifest not found: {manifest_path}")
+        version = json.loads(manifest_path.read_text()).get("version")
+        if not isinstance(version, str) or not version:
+            raise RuntimeError(f"Extension manifest missing version: {manifest_path}")
+        return version
+
+    def _require_signing_key(self, spec: ExtensionSpec) -> str:
+        value = os.environ.get(spec.signing_key_env, "").strip()
+        if len(value) <= 1:
+            raise RuntimeError(
+                f"Missing or empty environment variable: {spec.signing_key_env}"
+            )
+        return value
+
+    def _validate_local_bundle_requirements(self, ctx: Context) -> None:
+        missing = []
+        local_specs_by_id = self._local_specs_by_id()
+        has_local_required = False
+        for extension_id, name in ctx.product.required_extension_ids:
+            spec = local_specs_by_id.get(extension_id)
+            if spec is None:
+                continue
+            has_local_required = True
+            try:
+                self._require_signing_key(spec)
+            except RuntimeError:
+                missing.append(f"{name}: {spec.signing_key_env}")
+        if missing:
+            raise ValidationError(
+                "Local bundled extension signing key env var(s) missing: "
+                + ", ".join(missing)
+            )
+        if not has_local_required:
+            return
+        try:
+            find_chrome_binary()
+        except RuntimeError as e:
+            raise ValidationError(str(e))
 
     def _download_extension(self, ext: ExtensionInfo, output_dir: Path) -> None:
         """Download a single extension .crx file"""

--- a/packages/browseros/bos_build/steps/extensions/bundled_extensions_test.py
+++ b/packages/browseros/bos_build/steps/extensions/bundled_extensions_test.py
@@ -2,20 +2,32 @@
 """Tests for bundled extension manifest handling."""
 
 import json
+import os
 import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
 from typing import cast
+from unittest.mock import MagicMock, patch
 
 from bos_build.core.context import Context
+from bos_build.core.products import (
+    BROWSEROS_AGENT_EXTENSION_ID,
+    BROWSEROS_BUG_REPORTER_EXTENSION_ID,
+    BROWSERCLAW_EXTENSION_ID,
+)
 from bos_build.core.products import get_product_descriptor
+from bos_build.core.step import ValidationError
+from bos_build.release.extensions.specs import spec_by_name
 from bos_build.steps.extensions.bundled_extensions import (
     BundledExtensionsModule,
     ExtensionInfo,
+    LocalBundle,
+    ManifestBundle,
 )
 
 CLAW_EXTENSION_ID = "pjimfkbpehlcllblajnpfamdfjhhlgkc"
+MODULE = "bos_build.steps.extensions.bundled_extensions"
 
 
 class BundledExtensionsManifestTest(unittest.TestCase):
@@ -68,8 +80,7 @@ class BundledExtensionsManifestTest(unittest.TestCase):
                         id=CLAW_EXTENSION_ID,
                         version="0.0.1",
                         codebase=(
-                            "https://cdn.browseros.com/extensions/"
-                            "browserclaw-0.0.1.crx"
+                            "https://cdn.browseros.com/extensions/browserclaw-0.0.1.crx"
                         ),
                     )
                 ],
@@ -141,9 +152,150 @@ class BundledExtensionsManifestTest(unittest.TestCase):
             ],
         )
 
-    def _ctx(self, product: str):
+    def test_hybrid_mode_builds_in_repo_and_downloads_external_required(self) -> None:
+        plan = BundledExtensionsModule()._plan_hybrid_bundles(
+            [
+                ExtensionInfo(
+                    id=BROWSEROS_BUG_REPORTER_EXTENSION_ID,
+                    version="52.0.0.0",
+                    codebase="https://cdn.browseros.com/extensions/bugreporter.crx",
+                ),
+                # Local-buildable IDs may still appear in the manifest; local wins.
+                ExtensionInfo(
+                    id=BROWSEROS_AGENT_EXTENSION_ID,
+                    version="0.0.115.0",
+                    codebase="https://cdn.browseros.com/extensions/agent.crx",
+                ),
+                ExtensionInfo(
+                    id=BROWSERCLAW_EXTENSION_ID,
+                    version="0.0.1",
+                    codebase="https://cdn.browseros.com/extensions/browserclaw.crx",
+                ),
+            ],
+            self._ctx("browseros", bundle_local_extensions=True),
+        )
+
+        self.assertIsInstance(plan[0], ManifestBundle)
+        self.assertIsInstance(plan[1], LocalBundle)
+        self.assertIsInstance(plan[2], LocalBundle)
+        self.assertEqual(
+            cast(ManifestBundle, plan[0]).extension.id,
+            BROWSEROS_BUG_REPORTER_EXTENSION_ID,
+        )
+        self.assertEqual(cast(LocalBundle, plan[1]).spec.name, "agent")
+        self.assertEqual(cast(LocalBundle, plan[2]).spec.name, "browserclaw")
+
+    def test_hybrid_mode_fails_when_external_required_missing(self) -> None:
+        with self.assertRaisesRegex(RuntimeError, "BrowserOS bug reporter"):
+            BundledExtensionsModule()._plan_hybrid_bundles(
+                [
+                    ExtensionInfo(
+                        id=BROWSEROS_AGENT_EXTENSION_ID,
+                        version="0.0.115.0",
+                        codebase="https://cdn.browseros.com/extensions/agent.crx",
+                    ),
+                    ExtensionInfo(
+                        id=BROWSERCLAW_EXTENSION_ID,
+                        version="0.0.1",
+                        codebase="https://cdn.browseros.com/extensions/browserclaw.crx",
+                    ),
+                ],
+                self._ctx("browseros", bundle_local_extensions=True),
+            )
+
+    def test_build_local_extension_uses_spec_recipe_without_version_stamp(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            package_root = root / "repo" / "packages" / "browseros"
+            source_root = root / "repo" / "packages" / "browseros-agent"
+            manifest = source_root / "apps" / "app" / "package.json"
+            manifest.parent.mkdir(parents=True)
+            manifest.write_text(json.dumps({"version": "0.0.123"}))
+            output_dir = root / "chromium" / "bundled_extensions"
+            output_dir.mkdir(parents=True)
+            ctx = cast(Context, SimpleNamespace(root_dir=package_root))
+
+            patches = {
+                "resolve_source": MagicMock(return_value=source_root),
+                "write_env_file": MagicMock(),
+                "run_command": MagicMock(),
+                "pack_crx": MagicMock(),
+            }
+            with (
+                patch.dict(os.environ, {"BROWSEROS_AGENT_V2_KEY": "agent-pem"}),
+                patch(f"{MODULE}.resolve_source", patches["resolve_source"]),
+                patch(f"{MODULE}.write_env_file", patches["write_env_file"]),
+                patch(f"{MODULE}.run_command", patches["run_command"]),
+                patch(f"{MODULE}.pack_crx", patches["pack_crx"]),
+            ):
+                info = BundledExtensionsModule()._build_and_pack_local_extension(
+                    spec_by_name("agent"), ctx, output_dir, "chrome-bin"
+                )
+
+        self.assertEqual(info.id, BROWSEROS_AGENT_EXTENSION_ID)
+        self.assertEqual(info.version, "0.0.123")
+        patches["resolve_source"].assert_called_once()
+        commands = [call.args for call in patches["run_command"].call_args_list]
+        self.assertEqual(
+            commands,
+            [
+                ("bun ci", source_root),
+                ("bun run build:agent", source_root),
+            ],
+        )
+        pack_args = patches["pack_crx"].call_args.args
+        self.assertEqual(pack_args[0], source_root / "apps/app/dist/chrome-mv3")
+        self.assertEqual(pack_args[1], "agent-pem")
+        self.assertEqual(pack_args[2], "chrome-bin")
+        self.assertEqual(
+            pack_args[3],
+            output_dir / f"{BROWSEROS_AGENT_EXTENSION_ID}.crx",
+        )
+
+    def test_local_mode_preflight_requires_only_local_signing_keys(self) -> None:
+        with (
+            patch.dict(
+                os.environ,
+                {
+                    "BROWSEROS_AGENT_V2_KEY": "agent-pem",
+                    "BROWSERCLAW_KEY": "claw-pem",
+                },
+                clear=False,
+            ),
+            patch(f"{MODULE}.find_chrome_binary", return_value="chrome-bin"),
+        ):
+            BundledExtensionsModule().preflight(
+                self._ctx("browseros", bundle_local_extensions=True)
+            )
+
+    def test_local_mode_preflight_names_missing_local_signing_key(self) -> None:
+        env = {
+            k: v
+            for k, v in os.environ.items()
+            if k not in ("BROWSEROS_AGENT_V2_KEY", "BROWSERCLAW_KEY")
+        }
+        with (
+            patch.dict(os.environ, env, clear=True),
+            patch(f"{MODULE}.find_chrome_binary", return_value="chrome-bin"),
+            self.assertRaisesRegex(ValidationError, "BROWSEROS_AGENT_V2_KEY"),
+        ):
+            BundledExtensionsModule().preflight(
+                self._ctx("browseros", bundle_local_extensions=True)
+            )
+
+    def _ctx(
+        self,
+        product: str,
+        bundle_local_extensions: bool = False,
+        root_dir: Path | None = None,
+    ):
         return cast(
-            Context, SimpleNamespace(product=get_product_descriptor(product))
+            Context,
+            SimpleNamespace(
+                product=get_product_descriptor(product),
+                bundle_local_extensions=bundle_local_extensions,
+                root_dir=root_dir or Path("/repo/packages/browseros"),
+            ),
         )
 
 


### PR DESCRIPTION
## Summary
- make release-extensions reusable via workflow_call with explicit inputs and secrets for secrets: inherit callers
- add bundle_local_extensions planner/profile switch and enable it in nightly-ci
- build in-repo agent/browserclaw CRXs locally for bundled browser builds, while downloading external required extensions from the CDN manifest
- pass local extension build env through nightly browser builds and extend CRX Chrome resolution to Windows

## Verification
- actionlint .github/workflows/release-extensions.yml .github/workflows/build-browseros.yml .github/workflows/bos-build-tests.yml
- uv run --project packages/browseros python -m unittest discover -s packages/browseros/bos_build -t packages/browseros -p '*_test.py'
- uv run --project packages/browseros ruff check packages/browseros/bos_build tools/release_secrets
- uv run --project packages/browseros browseros build --preset release --show-plan
- uv run --project packages/browseros browseros build --profile nightly-ci --show-plan
- uv run --project packages/browseros browseros build --profile nightly-ci --product browserclaw --show-plan
- bun ci && bun run build:agent (packages/browseros-agent; produced apps/app/dist/chrome-mv3/manifest.json v0.0.100)

No workflow dispatches run.