### PR TITLE
fix(ci): keep local extension bundling opt-in

### DIFF
--- a/.github/workflows/build-browseros.yml
+++ b/.github/workflows/build-browseros.yml
@@ -42,6 +42,11 @@ on:
         required: false
         type: boolean
         default: false
+      bundle-local-extensions:
+        description: "Prepare Bun and extension env for profiles that set bundle_local_extensions"
+        required: false
+        type: boolean
+        default: false
       ref:
         description: "Optional checkout ref override; empty uses the caller ref"
         required: false
@@ -100,7 +105,7 @@ jobs:
       - uses: astral-sh/setup-uv@v8.2.0
 
       - name: Setup Bun
-        if: inputs.profile == 'nightly-ci'
+        if: inputs['bundle-local-extensions']
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.6"
@@ -251,6 +256,47 @@ jobs:
           }
           "CODE_SIGN_TOOL_PATH=$($tool.Directory.FullName)" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
 
+      - name: Export bundled extension local-build env
+        if: inputs['bundle-local-extensions']
+        env:
+          BROWSEROS_AGENT_V2_KEY: ${{ secrets.BROWSEROS_AGENT_V2_KEY }}
+          BROWSERCLAW_KEY: ${{ secrets.BROWSERCLAW_KEY }}
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          VITE_PUBLIC_SENTRY_DSN: ${{ secrets.VITE_PUBLIC_SENTRY_DSN }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
+          VITE_PUBLIC_POSTHOG_KEY: ${{ secrets.VITE_PUBLIC_POSTHOG_KEY }}
+          VITE_PUBLIC_POSTHOG_HOST: ${{ secrets.VITE_PUBLIC_POSTHOG_HOST }}
+          VITE_PUBLIC_BROWSEROS_API: https://api.browseros.com
+          GRAPHQL_SCHEMA_PATH: apps/app/schema/graphql.schema.json
+          NODE_ENV: production
+        run: |
+          set -euo pipefail
+          write_env() {
+            local name="$1"
+            local value="${!name:-}"
+            local delimiter="${name}_EOF"
+            {
+              echo "$name<<$delimiter"
+              printf '%s\n' "$value"
+              echo "$delimiter"
+            } >> "$GITHUB_ENV"
+          }
+
+          write_env BROWSEROS_AGENT_V2_KEY
+          write_env BROWSERCLAW_KEY
+          write_env POSTHOG_API_KEY
+          write_env VITE_PUBLIC_SENTRY_DSN
+          write_env SENTRY_AUTH_TOKEN
+          write_env SENTRY_ORG
+          write_env SENTRY_PROJECT
+          write_env VITE_PUBLIC_POSTHOG_KEY
+          write_env VITE_PUBLIC_POSTHOG_HOST
+          write_env VITE_PUBLIC_BROWSEROS_API
+          write_env GRAPHQL_SCHEMA_PATH
+          write_env NODE_ENV
+
       - name: Build ${{ inputs.product }}
         working-directory: packages/browseros
         env:
@@ -275,22 +321,6 @@ jobs:
 
           # Sparkle/WinSparkle artifact signatures.
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-
-          # Bundled extension local-build mode (nightly-ci profile).
-          BROWSEROS_AGENT_V2_KEY: ${{ secrets.BROWSEROS_AGENT_V2_KEY }}
-          BROWSERCLAW_KEY: ${{ secrets.BROWSERCLAW_KEY }}
-
-          # Build-time env consumed by bundled extensions when built locally.
-          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
-          VITE_PUBLIC_SENTRY_DSN: ${{ secrets.VITE_PUBLIC_SENTRY_DSN }}
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
-          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
-          VITE_PUBLIC_POSTHOG_KEY: ${{ secrets.VITE_PUBLIC_POSTHOG_KEY }}
-          VITE_PUBLIC_POSTHOG_HOST: ${{ secrets.VITE_PUBLIC_POSTHOG_HOST }}
-          VITE_PUBLIC_BROWSEROS_API: https://api.browseros.com
-          GRAPHQL_SCHEMA_PATH: apps/app/schema/graphql.schema.json
-          NODE_ENV: production
         run: |
           set -euo pipefail
           sign_flag="--no-sign"

--- a/.github/workflows/build-browseros.yml
+++ b/.github/workflows/build-browseros.yml
@@ -276,7 +276,8 @@ jobs:
           write_env() {
             local name="$1"
             local value="${!name:-}"
-            local delimiter="${name}_EOF"
+            local delimiter
+            delimiter="${name}_$(openssl rand -hex 8)"
             {
               echo "$name<<$delimiter"
               printf '%s\n' "$value"

--- a/packages/browseros/bos_build/core/planner_test.py
+++ b/packages/browseros/bos_build/core/planner_test.py
@@ -642,7 +642,7 @@ class DownloadSwitchTest(unittest.TestCase):
         prof = load_profile(shipped)
         # Shipped profiles stay switch-based; modules: is a local-only opt-in.
         self.assertIsNone(prof.modules)
-        self.assertTrue(prof.switches.bundle_local_extensions)
+        self.assertFalse(prof.switches.bundle_local_extensions)
         for platform, arch in (
             ("macos", "arm64"),
             ("windows", "x64"),

--- a/packages/browseros/bos_build/docs/nightly-warpbuild-ci.md
+++ b/packages/browseros/bos_build/docs/nightly-warpbuild-ci.md
@@ -107,13 +107,13 @@ reusable workflow performs the per-platform recipe:
    prerelease for scheduled main runs.
 
 The `nightly-ci` profile is the release preset minus `clean`/
-`git_setup` (steps 4-5 replace them), minus `sign_*`/`upload`, with
-`bundle_local_extensions: true` so the bundled agent/browserclaw CRXs come
-from the checked-out tree. Why not run `git_setup` as-is: it does `git fetch
---tags`, which on the shallow CI clone would pull objects for all ~70k chromium
-tags; the script instead fetches exactly the pinned tag at depth 2. On Windows
-the new `mini_installer` module builds the installer that `sign_windows` would
-otherwise build.
+`git_setup` (steps 4-5 replace them), minus `sign_*`/`upload`. It keeps
+CDN-pinned bundled extensions because WarpBuild images do not provide the
+system Chrome binary required for local CRX packing. Why not run `git_setup`
+as-is: it does `git fetch --tags`, which on the shallow CI clone would pull
+objects for all ~70k chromium tags; the script instead fetches exactly the
+pinned tag at depth 2. On Windows the new `mini_installer` module builds the
+installer that `sign_windows` would otherwise build.
 
 ## Caching strategy
 

--- a/packages/browseros/bos_build/docs/release-ci.md
+++ b/packages/browseros/bos_build/docs/release-ci.md
@@ -67,9 +67,12 @@ release-windows.yml -> build-browseros.yml`, which stays below GitHub's limit
 of four workflow levels.
 
 The `bundle_local_extensions` profile switch defaults off for release
-reproducibility. `profiles/nightly-ci.yaml` sets it true so nightlies build and
-pack in-repo agent/browserclaw CRXs from the checked-out tree while external
-required extensions still come from the bundled CDN manifest.
+reproducibility. Existing CI profiles keep it off; a self-hosted macOS nightly
+profile can set it true to build and pack in-repo agent/browserclaw CRXs from
+the checked-out tree while external required extensions still come from the
+bundled CDN manifest. Reusable `build-browseros.yml` callers enabling such a
+profile must also pass `bundle-local-extensions: true` so Bun and extension
+signing/build env are prepared.
 
 ## Full Release Inputs
 

--- a/packages/browseros/bos_build/profiles/nightly-ci.yaml
+++ b/packages/browseros/bos_build/profiles/nightly-ci.yaml
@@ -7,4 +7,3 @@ clean: false
 provision: none
 sign: false
 upload: false
-bundle_local_extensions: true


### PR DESCRIPTION
## Summary
- keep the shipped `nightly-ci` profile on CDN-pinned bundled extensions
- add an explicit `bundle-local-extensions` reusable workflow input to prepare Bun and extension env only for callers that opt in
- update planner test/docs for the corrected existing-profile default

Follow-up to #1657.

## Verification
- `uv run --project packages/browseros python -m unittest discover -s packages/browseros/bos_build -t packages/browseros -p '*_test.py'`
- `uv run --project packages/browseros ruff check packages/browseros/bos_build`
- `actionlint .github/workflows/build-browseros.yml .github/workflows/nightly-release.yml .github/workflows/release-extensions.yml`
- `git diff --check`
- `uv run --project packages/browseros browseros build --profile nightly-ci --show-plan`
- `uv run --project packages/browseros browseros build --preset release --show-plan`
