### PR TITLE
feat(bos_build): claw-server variant flag, rust by default

### DIFF
--- a/packages/browseros/bos_build/cli/ota.py
+++ b/packages/browseros/bos_build/cli/ota.py
@@ -21,7 +21,7 @@ from ..release.ota.common import (
 )
 from ..release.feeds.publisher import FeedPublisher
 from ..release.feeds.spec import server_feed
-from ..products.server_binaries import server_bundles_for_product
+from ..products.server_binaries import server_ota_bundles_for_product
 
 app = typer.Typer(
     help="OTA (Over-The-Air) update automation",
@@ -58,7 +58,7 @@ def execute_module(ctx: Context, module) -> None:
 
 
 def _server_bundle_id(product: str) -> str:
-    bundles = server_bundles_for_product(product)
+    bundles = server_ota_bundles_for_product(product)
     if not bundles:
         log_error(f"Product '{product}' has no server bundle")
         raise typer.Exit(1)

--- a/packages/browseros/bos_build/config/build_flags.yaml
+++ b/packages/browseros/bos_build/config/build_flags.yaml
@@ -1,0 +1,5 @@
+# Human-editable build switches.
+#
+# BrowserClaw only: true embeds the Rust claw-server artifact in browser
+# builds; false restores the TypeScript/Bun claw-server artifact.
+use_claw_server_rust: true

--- a/packages/browseros/bos_build/config/copy_resources.yaml
+++ b/packages/browseros/bos_build/config/copy_resources.yaml
@@ -192,6 +192,7 @@ copy_operations:
   - name: "BrowserOS Claw Server Resources - macOS ARM64"
     source: "resources/binaries/browseros_claw_server/darwin-arm64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
+    selected_clear_destination: true
     type: "directory"
     claw_server_variant: "typescript"
     os: ["macos"]
@@ -200,6 +201,7 @@ copy_operations:
   - name: "BrowserOS Claw Server Resources - macOS x64"
     source: "resources/binaries/browseros_claw_server/darwin-x64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
+    selected_clear_destination: true
     type: "directory"
     claw_server_variant: "typescript"
     os: ["macos"]
@@ -208,6 +210,7 @@ copy_operations:
   - name: "BrowserOS Claw Server Resources - Linux ARM64"
     source: "resources/binaries/browseros_claw_server/linux-arm64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
+    selected_clear_destination: true
     type: "directory"
     claw_server_variant: "typescript"
     os: ["linux"]
@@ -216,6 +219,7 @@ copy_operations:
   - name: "BrowserOS Claw Server Resources - Linux x64"
     source: "resources/binaries/browseros_claw_server/linux-x64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
+    selected_clear_destination: true
     type: "directory"
     claw_server_variant: "typescript"
     os: ["linux"]
@@ -224,6 +228,7 @@ copy_operations:
   - name: "BrowserOS Claw Server Resources - Windows x64"
     source: "resources/binaries/browseros_claw_server/windows-x64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
+    selected_clear_destination: true
     type: "directory"
     claw_server_variant: "typescript"
     os: ["windows"]

--- a/packages/browseros/bos_build/config/copy_resources.yaml
+++ b/packages/browseros/bos_build/config/copy_resources.yaml
@@ -11,6 +11,11 @@
 # - Use 'arch' field to specify target architectures
 #   - Supported values: x64, arm64
 #   - Operations without arch run for all architectures
+# - Use 'claw_server_variant' on BrowserClaw claw-server resources to select
+#   between 'typescript' and 'rust' via build_flags.yaml. A selected operation
+#   can override destination with 'selected_destination' and rename copied files
+#   with 'selected_renames'. Use 'selected_clear_destination: true' when the
+#   selected copy is mutually exclusive with another variant at the same path.
 #
 # Example:
 #   - name: "macOS-only Binary"
@@ -188,6 +193,7 @@ copy_operations:
     source: "resources/binaries/browseros_claw_server/darwin-arm64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
     type: "directory"
+    claw_server_variant: "typescript"
     os: ["macos"]
     arch: ["arm64"]
 
@@ -195,6 +201,7 @@ copy_operations:
     source: "resources/binaries/browseros_claw_server/darwin-x64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
     type: "directory"
+    claw_server_variant: "typescript"
     os: ["macos"]
     arch: ["x64"]
 
@@ -202,6 +209,7 @@ copy_operations:
     source: "resources/binaries/browseros_claw_server/linux-arm64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
     type: "directory"
+    claw_server_variant: "typescript"
     os: ["linux"]
     arch: ["arm64"]
 
@@ -209,6 +217,7 @@ copy_operations:
     source: "resources/binaries/browseros_claw_server/linux-x64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
     type: "directory"
+    claw_server_variant: "typescript"
     os: ["linux"]
     arch: ["x64"]
 
@@ -216,6 +225,7 @@ copy_operations:
     source: "resources/binaries/browseros_claw_server/windows-x64/resources"
     destination: "chrome/browser/browseros/claw_server/resources"
     type: "directory"
+    claw_server_variant: "typescript"
     os: ["windows"]
     arch: ["x64"]
 
@@ -223,35 +233,65 @@ copy_operations:
   - name: "BrowserOS Claw Rust Server Resources - macOS ARM64"
     source: "resources/binaries/browseros_claw_server_rust/darwin-arm64/resources"
     destination: "chrome/browser/browseros/claw_server_rust/resources"
+    selected_destination: "chrome/browser/browseros/claw_server/resources"
+    selected_clear_destination: true
+    selected_renames:
+      - from: "bin/browseros-claw-server-rs"
+        to: "bin/browseros-claw-server"
     type: "directory"
+    claw_server_variant: "rust"
     os: ["macos"]
     arch: ["arm64"]
 
   - name: "BrowserOS Claw Rust Server Resources - macOS x64"
     source: "resources/binaries/browseros_claw_server_rust/darwin-x64/resources"
     destination: "chrome/browser/browseros/claw_server_rust/resources"
+    selected_destination: "chrome/browser/browseros/claw_server/resources"
+    selected_clear_destination: true
+    selected_renames:
+      - from: "bin/browseros-claw-server-rs"
+        to: "bin/browseros-claw-server"
     type: "directory"
+    claw_server_variant: "rust"
     os: ["macos"]
     arch: ["x64"]
 
   - name: "BrowserOS Claw Rust Server Resources - Linux ARM64"
     source: "resources/binaries/browseros_claw_server_rust/linux-arm64/resources"
     destination: "chrome/browser/browseros/claw_server_rust/resources"
+    selected_destination: "chrome/browser/browseros/claw_server/resources"
+    selected_clear_destination: true
+    selected_renames:
+      - from: "bin/browseros-claw-server-rs"
+        to: "bin/browseros-claw-server"
     type: "directory"
+    claw_server_variant: "rust"
     os: ["linux"]
     arch: ["arm64"]
 
   - name: "BrowserOS Claw Rust Server Resources - Linux x64"
     source: "resources/binaries/browseros_claw_server_rust/linux-x64/resources"
     destination: "chrome/browser/browseros/claw_server_rust/resources"
+    selected_destination: "chrome/browser/browseros/claw_server/resources"
+    selected_clear_destination: true
+    selected_renames:
+      - from: "bin/browseros-claw-server-rs"
+        to: "bin/browseros-claw-server"
     type: "directory"
+    claw_server_variant: "rust"
     os: ["linux"]
     arch: ["x64"]
 
   - name: "BrowserOS Claw Rust Server Resources - Windows x64"
     source: "resources/binaries/browseros_claw_server_rust/windows-x64/resources"
     destination: "chrome/browser/browseros/claw_server_rust/resources"
+    selected_destination: "chrome/browser/browseros/claw_server/resources"
+    selected_clear_destination: true
+    selected_renames:
+      - from: "bin/browseros-claw-server-rs.exe"
+        to: "bin/browseros-claw-server.exe"
     type: "directory"
+    claw_server_variant: "rust"
     os: ["windows"]
     arch: ["x64"]
 

--- a/packages/browseros/bos_build/config/download_resources.yaml
+++ b/packages/browseros/bos_build/config/download_resources.yaml
@@ -20,6 +20,8 @@
 #   - Set to true for binaries (permissions are not preserved during download)
 # - Use 'download_type' field to switch from plain file download to archive extraction
 #   - Supported values: file, artifact_zip
+# - Use 'claw_server_variant' on BrowserClaw claw-server resources to select
+#   between 'typescript' and 'rust' via build_flags.yaml
 #
 # R2 Path Structure:
 #   artifacts/server/latest/browseros-server-resources-{target}.zip
@@ -77,6 +79,7 @@ download_operations:
     r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-arm64.zip"
     destination: "resources/binaries/browseros_claw_server/darwin-arm64"
     download_type: "artifact_zip"
+    claw_server_variant: "typescript"
     os: ["macos"]
     arch: ["arm64"]
 
@@ -84,6 +87,7 @@ download_operations:
     r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-x64.zip"
     destination: "resources/binaries/browseros_claw_server/darwin-x64"
     download_type: "artifact_zip"
+    claw_server_variant: "typescript"
     os: ["macos"]
     arch: ["x64"]
 
@@ -91,6 +95,7 @@ download_operations:
     r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-arm64.zip"
     destination: "resources/binaries/browseros_claw_server/linux-arm64"
     download_type: "artifact_zip"
+    claw_server_variant: "typescript"
     os: ["linux"]
     arch: ["arm64"]
 
@@ -98,6 +103,7 @@ download_operations:
     r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-linux-x64.zip"
     destination: "resources/binaries/browseros_claw_server/linux-x64"
     download_type: "artifact_zip"
+    claw_server_variant: "typescript"
     os: ["linux"]
     arch: ["x64"]
 
@@ -105,6 +111,7 @@ download_operations:
     r2_key: "claw-server/prod-resources/latest/browseros-claw-server-resources-windows-x64.zip"
     destination: "resources/binaries/browseros_claw_server/windows-x64"
     download_type: "artifact_zip"
+    claw_server_variant: "typescript"
     os: ["windows"]
     arch: ["x64"]
 
@@ -113,6 +120,7 @@ download_operations:
     r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-arm64.zip"
     destination: "resources/binaries/browseros_claw_server_rust/darwin-arm64"
     download_type: "artifact_zip"
+    claw_server_variant: "rust"
     os: ["macos"]
     arch: ["arm64"]
 
@@ -120,6 +128,7 @@ download_operations:
     r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-x64.zip"
     destination: "resources/binaries/browseros_claw_server_rust/darwin-x64"
     download_type: "artifact_zip"
+    claw_server_variant: "rust"
     os: ["macos"]
     arch: ["x64"]
 
@@ -127,6 +136,7 @@ download_operations:
     r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-linux-arm64.zip"
     destination: "resources/binaries/browseros_claw_server_rust/linux-arm64"
     download_type: "artifact_zip"
+    claw_server_variant: "rust"
     os: ["linux"]
     arch: ["arm64"]
 
@@ -134,6 +144,7 @@ download_operations:
     r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-linux-x64.zip"
     destination: "resources/binaries/browseros_claw_server_rust/linux-x64"
     download_type: "artifact_zip"
+    claw_server_variant: "rust"
     os: ["linux"]
     arch: ["x64"]
 
@@ -141,6 +152,7 @@ download_operations:
     r2_key: "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-windows-x64.zip"
     destination: "resources/binaries/browseros_claw_server_rust/windows-x64"
     download_type: "artifact_zip"
+    claw_server_variant: "rust"
     os: ["windows"]
     arch: ["x64"]
 

--- a/packages/browseros/bos_build/core/context.py
+++ b/packages/browseros/bos_build/core/context.py
@@ -14,6 +14,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, Optional
 
 from ..lib import versions as versions_mod
+from ..lib.build_flags import BuildFlags, load_build_flags
 from ..lib.env import EnvConfig
 from ..lib.paths import get_package_root
 from .products import (
@@ -88,6 +89,7 @@ class Context:
 
     artifact_registry: ArtifactRegistry = field(init=False)
     env: EnvConfig = field(init=False)
+    build_flags: BuildFlags = field(init=False)
 
     def __post_init__(self):
         if not isinstance(self.product, ProductDescriptor):
@@ -95,6 +97,7 @@ class Context:
 
         self.artifact_registry = ArtifactRegistry()
         self.env = EnvConfig()
+        self.build_flags = load_build_flags(self.root_dir)
 
         if not self.architecture:
             self.architecture = get_platform_arch()

--- a/packages/browseros/bos_build/core/context_test.py
+++ b/packages/browseros/bos_build/core/context_test.py
@@ -113,6 +113,21 @@ class GetAppPathTest(unittest.TestCase):
         self.assertEqual(ctx.product.id, "browserclaw")
         self.assertEqual(ctx.BROWSEROS_APP_BASE_NAME, "BrowserClaw")
 
+    def test_context_loads_build_flags_from_root(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = Path(tmp) / "bos_build" / "config" / "build_flags.yaml"
+            config.parent.mkdir(parents=True)
+            config.write_text("use_claw_server_rust: false\n")
+
+            ctx = Context(
+                root_dir=Path(tmp),
+                chromium_src=Path("/nonexistent-src"),
+                architecture="arm64",
+                build_type="release",
+            )
+
+        self.assertFalse(ctx.build_flags.use_claw_server_rust)
+
     def test_debug_gn_args_allow_override_and_package_all(self):
         ctx = Context(
             chromium_src=Path("/nonexistent-src"),

--- a/packages/browseros/bos_build/docs/release-ci.md
+++ b/packages/browseros/bos_build/docs/release-ci.md
@@ -18,8 +18,9 @@ release-full.yml
     - release-server.yml for browseros
     - release-claw-server.yml for browserclaw
     - release-claw-server-rust.yml exists as a separate manual/reusable lane
-      for BrowserClaw Rust server resources, but is not called by the full
-      release until the Rust server becomes the active embedded server
+      for BrowserClaw Rust server resources. BrowserClaw browser builds can
+      consume its latest resources via the bos_build claw-server variant flag,
+      but the full release server-resource orchestration stays separate
   browser builds
     - release-linux.yml -> build-browseros.yml
     - release-windows.yml -> build-browseros.yml
@@ -39,7 +40,7 @@ macOS builder.
 | --- | --- | --- | --- |
 | `.github/workflows/release-server.yml` | Builds BrowserOS server resource zips for every browser target, uploads versioned R2 resource keys, attaches server release assets, and reflects the server package version. | Manual and `agent-server/v*` tags | Yes, when `include_servers=true` and `products` includes `browseros` |
 | `.github/workflows/release-claw-server.yml` | Builds BrowserClaw server and onboard resource zips, uploads versioned R2 keys, attaches server release assets, and reflects Claw package versions. | Manual and `claw-server/v*` tags | Yes, when `include_servers=true` and `products` includes `browserclaw` |
-| `.github/workflows/release-claw-server-rust.yml` | Builds BrowserClaw Rust server resource zips for every browser target, uploads versioned R2 keys under `claw-server-rust/prod-resources`, and attaches Rust server release assets. | Manual, reusable, and `claw-server-rust/v*` tags | No; intentionally separate until BrowserClaw migrates from the TypeScript server |
+| `.github/workflows/release-claw-server-rust.yml` | Builds BrowserClaw Rust server resource zips for every browser target, uploads versioned R2 keys under `claw-server-rust/prod-resources`, and attaches Rust server release assets. | Manual, reusable, and `claw-server-rust/v*` tags | No; BrowserClaw browser builds read the latest Rust resources when the bos_build flag is enabled, but this resource lane remains explicitly dispatched |
 | `.github/workflows/release-linux.yml` | Builds Linux x64 browser artifacts on WarpBuild, one matrix entry per selected product. | Manual | Yes |
 | `.github/workflows/release-windows.yml` | Builds Windows x64 browser artifacts on WarpBuild and optionally signs them. | Manual | Yes |
 | `.github/workflows/release-macos.yml` | Builds signed macOS artifacts on the dedicated self-hosted builder. | Manual | Yes |
@@ -60,6 +61,15 @@ The Rust Claw server lane publishes to a distinct CDN/R2 prefix:
 `download_resources.yaml` entries that point at a new Rust server version until
 that workflow has populated the matching R2 objects; the bos_build download
 step fails the whole Chromium build when a configured key is missing.
+
+BrowserClaw browser builds select the embedded claw-server variant with
+`packages/browseros/bos_build/config/build_flags.yaml`:
+`use_claw_server_rust: true` embeds the Rust resources from
+`claw-server-rust/prod-resources/latest/`, and `false` rolls BrowserClaw browser
+builds back to the TypeScript/Bun resources from `claw-server/prod-resources/latest/`.
+The browser build downloads only the selected BrowserClaw variant. BrowserClaw
+server OTA feeds (`appcast-claw-server*.xml`) remain pinned to the TypeScript
+server bundle until a separate feed migration changes them.
 
 The reusable nesting depth is `release-full.yml -> release-linux.yml or
 release-windows.yml -> build-browseros.yml`, which stays below GitHub's limit

--- a/packages/browseros/bos_build/lib/build_flags.py
+++ b/packages/browseros/bos_build/lib/build_flags.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Human-editable build flags loaded from bos_build/config/build_flags.yaml."""
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from .paths import get_package_root
+
+BUILD_FLAGS_CONFIG = Path("bos_build/config/build_flags.yaml")
+
+
+@dataclass(frozen=True)
+class BuildFlags:
+    """Boolean switches that intentionally stay outside CLI/profile sprawl."""
+
+    use_claw_server_rust: bool = True
+
+
+def load_build_flags(root_dir: Path | None = None) -> BuildFlags:
+    """Load build flags, defaulting missing values to their dataclass defaults."""
+    root = Path(root_dir) if root_dir is not None else get_package_root()
+    config_path = root / BUILD_FLAGS_CONFIG
+    if not config_path.exists():
+        return BuildFlags()
+
+    with open(config_path, "r") as f:
+        raw = yaml.safe_load(f) or {}
+
+    if not isinstance(raw, dict):
+        raise ValueError(f"Build flags config must be a YAML mapping: {config_path}")
+
+    return BuildFlags(
+        use_claw_server_rust=_optional_bool(
+            raw,
+            "use_claw_server_rust",
+            BuildFlags.use_claw_server_rust,
+            config_path,
+        )
+    )
+
+
+def build_flags_for_context(context: Any) -> BuildFlags:
+    """Return flags already loaded on a Context-like object, or load by root_dir."""
+    flags = getattr(context, "build_flags", None)
+    if isinstance(flags, BuildFlags):
+        return flags
+    return load_build_flags(getattr(context, "root_dir", None))
+
+
+def _optional_bool(
+    raw: dict[str, Any], key: str, default: bool, config_path: Path
+) -> bool:
+    value = raw.get(key, default)
+    if not isinstance(value, bool):
+        raise ValueError(
+            f"{config_path}: {key} must be a boolean, got {type(value).__name__}"
+        )
+    return value

--- a/packages/browseros/bos_build/lib/build_flags_test.py
+++ b/packages/browseros/bos_build/lib/build_flags_test.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Tests for human-editable build flags."""
+
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+from .build_flags import BuildFlags, build_flags_for_context, load_build_flags
+
+
+class BuildFlagsTest(unittest.TestCase):
+    def test_missing_config_defaults_to_rust_claw_server(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            flags = load_build_flags(Path(tmp))
+
+        self.assertTrue(flags.use_claw_server_rust)
+
+    def test_missing_key_defaults_to_rust_claw_server(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = Path(tmp) / "bos_build" / "config" / "build_flags.yaml"
+            config.parent.mkdir(parents=True)
+            config.write_text("{}\n")
+
+            flags = load_build_flags(Path(tmp))
+
+        self.assertTrue(flags.use_claw_server_rust)
+
+    def test_explicit_false_disables_rust_claw_server(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = Path(tmp) / "bos_build" / "config" / "build_flags.yaml"
+            config.parent.mkdir(parents=True)
+            config.write_text("use_claw_server_rust: false\n")
+
+            flags = load_build_flags(Path(tmp))
+
+        self.assertFalse(flags.use_claw_server_rust)
+
+    def test_rejects_non_boolean_flag_value(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            config = Path(tmp) / "bos_build" / "config" / "build_flags.yaml"
+            config.parent.mkdir(parents=True)
+            config.write_text("use_claw_server_rust: rust\n")
+
+            with self.assertRaisesRegex(ValueError, "use_claw_server_rust"):
+                load_build_flags(Path(tmp))
+
+    def test_context_helper_reuses_loaded_flags(self):
+        ctx = SimpleNamespace(build_flags=BuildFlags(use_claw_server_rust=False))
+
+        self.assertFalse(build_flags_for_context(ctx).use_claw_server_rust)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/browseros/bos_build/products/__init__.py
+++ b/packages/browseros/bos_build/products/__init__.py
@@ -9,7 +9,11 @@ from typing import Dict
 
 from ..core.products import ProductDescriptor
 from .browseros.product import BROWSEROS_PRODUCT, BROWSEROS_SERVER_BUNDLE
-from .browserclaw.product import BROWSERCLAW_PRODUCT, BROWSERCLAW_SERVER_BUNDLE
+from .browserclaw.product import (
+    BROWSERCLAW_PRODUCT,
+    BROWSERCLAW_RUST_SERVER_BUNDLE,
+    BROWSERCLAW_SERVER_BUNDLE,
+)
 
 DEFAULT_PRODUCT_ID = BROWSEROS_PRODUCT.id
 
@@ -27,4 +31,5 @@ __all__ = [
     "SERVER_BUNDLES",
     "BROWSEROS_PRODUCT",
     "BROWSERCLAW_PRODUCT",
+    "BROWSERCLAW_RUST_SERVER_BUNDLE",
 ]

--- a/packages/browseros/bos_build/products/browserclaw/product.py
+++ b/packages/browseros/bos_build/products/browserclaw/product.py
@@ -37,3 +37,29 @@ BROWSERCLAW_SERVER_BUNDLE = ServerBundle(
     unsigned_artifact_prefix="claw-server/prod-resources",
     unsigned_artifact_base_name="browseros-claw-server-resources",
 )
+
+BROWSERCLAW_RUST_SERVER_BUNDLE = ServerBundle(
+    id="browserclaw-server-rust",
+    name="BrowserOS Claw Server (Rust)",
+    product_ids=("browserclaw",),
+    chromium_output_root="BrowserClawServer",
+    local_resources_root=Path("resources/binaries/browseros_claw_server_rust"),
+    # Chromium launches BrowserClaw through this existing resources root and
+    # expects the staged binary to be named browseros-claw-server.
+    chromium_resources_root=Path("chrome/browser/browseros/claw_server/resources"),
+    macos_bundle_resources_root=Path(
+        "Contents/Resources/BrowserClawServer/default/resources"
+    ),
+    windows_bundle_resources_root=Path("BrowserClawServer/default/resources"),
+    macos_binaries={
+        "browseros-claw-server": SignSpec(
+            "browseros_claw_server",
+            "runtime",
+            "browseros-executable-entitlements.plist",
+        ),
+    },
+    windows_binaries=("browseros-claw-server.exe",),
+    required_in_chromium_output=False,
+    unsigned_artifact_prefix="claw-server-rust/prod-resources",
+    unsigned_artifact_base_name="browseros-claw-server-rust-resources",
+)

--- a/packages/browseros/bos_build/products/server_binaries.py
+++ b/packages/browseros/bos_build/products/server_binaries.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
+from ..lib.build_flags import load_build_flags
+
 
 @dataclass(frozen=True)
 class SignSpec:
@@ -45,18 +47,37 @@ class ServerBundle:
         return f"{self.unsigned_artifact_prefix}/latest/{base_name}-{target}.zip"
 
 
-def all_server_bundles() -> Tuple[ServerBundle, ...]:
-    """Every product's server bundles, in product registry order."""
-    from . import SERVER_BUNDLES
-
-    return SERVER_BUNDLES
-
-
-def server_bundles_for_product(product_id: str) -> Tuple[ServerBundle, ...]:
-    """Return server bundles owned by one build product."""
+def all_server_bundles(
+    use_claw_server_rust: Optional[bool] = None,
+) -> Tuple[ServerBundle, ...]:
+    """Every product's active browser-build server bundles."""
+    use_rust = _resolve_claw_server_flag(use_claw_server_rust)
     return tuple(
         bundle
-        for bundle in all_server_bundles()
+        for bundle in _browser_build_server_bundles()
+        if _is_active_browserclaw_bundle(bundle, use_rust)
+    )
+
+
+def server_bundles_for_product(
+    product_id: str,
+    use_claw_server_rust: Optional[bool] = None,
+) -> Tuple[ServerBundle, ...]:
+    """Return active browser-build server bundles owned by one product."""
+    return tuple(
+        bundle
+        for bundle in all_server_bundles(use_claw_server_rust)
+        if product_id in bundle.product_ids
+    )
+
+
+def server_ota_bundles_for_product(product_id: str) -> Tuple[ServerBundle, ...]:
+    """Return server OTA bundles; BrowserClaw OTA stays on TypeScript for now."""
+    from . import SERVER_BUNDLES
+
+    return tuple(
+        bundle
+        for bundle in SERVER_BUNDLES
         if product_id in bundle.product_ids
     )
 
@@ -79,14 +100,43 @@ def expected_windows_binary_paths(server_bin_dir: Path) -> List[Path]:
 
 
 def expected_windows_bundle_binary_paths(
-    build_output_dir: Path, product_id: Optional[str] = None
+    build_output_dir: Path,
+    product_id: Optional[str] = None,
+    use_claw_server_rust: Optional[bool] = None,
 ) -> List[Path]:
     """Resolve all bundled server binaries under a Chromium build output dir."""
     paths: List[Path] = []
     bundles = (
-        server_bundles_for_product(product_id) if product_id else all_server_bundles()
+        server_bundles_for_product(product_id, use_claw_server_rust)
+        if product_id
+        else all_server_bundles(use_claw_server_rust)
     )
     for bundle in bundles:
         bin_dir = build_output_dir / bundle.windows_bundle_resources_root / "bin"
         paths.extend(bin_dir / rel for rel in bundle.windows_binaries)
     return paths
+
+
+def _browser_build_server_bundles() -> Tuple[ServerBundle, ...]:
+    from . import SERVER_BUNDLES
+    from .browserclaw.product import BROWSERCLAW_RUST_SERVER_BUNDLE
+
+    return (*SERVER_BUNDLES, BROWSERCLAW_RUST_SERVER_BUNDLE)
+
+
+def _resolve_claw_server_flag(use_claw_server_rust: Optional[bool]) -> bool:
+    if use_claw_server_rust is not None:
+        return use_claw_server_rust
+    return load_build_flags().use_claw_server_rust
+
+
+def _is_active_browserclaw_bundle(
+    bundle: ServerBundle, use_claw_server_rust: bool
+) -> bool:
+    if "browserclaw" not in bundle.product_ids:
+        return True
+    if bundle.id == "browserclaw-server":
+        return not use_claw_server_rust
+    if bundle.id == "browserclaw-server-rust":
+        return use_claw_server_rust
+    return True

--- a/packages/browseros/bos_build/products/server_binaries_test.py
+++ b/packages/browseros/bos_build/products/server_binaries_test.py
@@ -9,9 +9,11 @@ from .server_binaries import (
     expected_windows_bundle_binary_paths,
     expected_windows_binary_paths,
     macos_sign_spec_for,
+    server_ota_bundles_for_product,
     server_bundles_for_product,
 )
 from .browserclaw.product import (
+    BROWSERCLAW_RUST_SERVER_BUNDLE,
     BROWSERCLAW_SERVER_BUNDLE as BROWSEROS_CLAW_SERVER_BUNDLE,
 )
 from .browseros.product import BROWSEROS_SERVER_BUNDLE
@@ -28,9 +30,17 @@ ENTITLEMENTS_DIR = Path(__file__).resolve().parents[2] / "resources" / "entitlem
 
 
 class MacosServerBinariesTest(unittest.TestCase):
+    def test_server_bundles_select_rust_by_default(self):
+        self.assertEqual(
+            all_server_bundles(use_claw_server_rust=True),
+            (BROWSEROS_SERVER_BUNDLE, BROWSERCLAW_RUST_SERVER_BUNDLE),
+        )
+        self.assertEqual(
+            all_server_bundles(use_claw_server_rust=False),
+            (BROWSEROS_SERVER_BUNDLE, BROWSEROS_CLAW_SERVER_BUNDLE),
+        )
+
     def test_server_bundles_have_separate_resource_roots(self):
-        self.assertEqual(SERVER_BUNDLES[0], BROWSEROS_SERVER_BUNDLE)
-        self.assertEqual(SERVER_BUNDLES[1], BROWSEROS_CLAW_SERVER_BUNDLE)
         self.assertEqual(
             BROWSEROS_SERVER_BUNDLE.local_resources_root,
             Path("resources/binaries/browseros_server"),
@@ -38,6 +48,10 @@ class MacosServerBinariesTest(unittest.TestCase):
         self.assertEqual(
             BROWSEROS_CLAW_SERVER_BUNDLE.local_resources_root,
             Path("resources/binaries/browseros_claw_server"),
+        )
+        self.assertEqual(
+            BROWSERCLAW_RUST_SERVER_BUNDLE.local_resources_root,
+            Path("resources/binaries/browseros_claw_server_rust"),
         )
         self.assertEqual(
             BROWSEROS_SERVER_BUNDLE.chromium_resources_root,
@@ -48,6 +62,10 @@ class MacosServerBinariesTest(unittest.TestCase):
             Path("chrome/browser/browseros/claw_server/resources"),
         )
         self.assertEqual(
+            BROWSERCLAW_RUST_SERVER_BUNDLE.chromium_resources_root,
+            Path("chrome/browser/browseros/claw_server/resources"),
+        )
+        self.assertEqual(
             BROWSEROS_SERVER_BUNDLE.macos_bundle_resources_root,
             Path("Contents/Resources/BrowserOSServer/default/resources"),
         )
@@ -55,8 +73,13 @@ class MacosServerBinariesTest(unittest.TestCase):
             BROWSEROS_CLAW_SERVER_BUNDLE.macos_bundle_resources_root,
             Path("Contents/Resources/BrowserClawServer/default/resources"),
         )
+        self.assertEqual(
+            BROWSERCLAW_RUST_SERVER_BUNDLE.macos_bundle_resources_root,
+            Path("Contents/Resources/BrowserClawServer/default/resources"),
+        )
         self.assertTrue(BROWSEROS_SERVER_BUNDLE.required_in_chromium_output)
         self.assertFalse(BROWSEROS_CLAW_SERVER_BUNDLE.required_in_chromium_output)
+        self.assertFalse(BROWSERCLAW_RUST_SERVER_BUNDLE.required_in_chromium_output)
         self.assertEqual(
             BROWSEROS_SERVER_BUNDLE.unsigned_artifact_key("darwin-arm64"),
             "artifacts/server/latest/browseros-server-resources-darwin-arm64.zip",
@@ -65,13 +88,32 @@ class MacosServerBinariesTest(unittest.TestCase):
             BROWSEROS_CLAW_SERVER_BUNDLE.unsigned_artifact_key("darwin-arm64"),
             "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-arm64.zip",
         )
+        self.assertEqual(
+            BROWSERCLAW_RUST_SERVER_BUNDLE.unsigned_artifact_key("darwin-arm64"),
+            "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-arm64.zip",
+        )
 
     def test_server_bundles_filter_by_product(self):
         self.assertEqual(
-            server_bundles_for_product("browseros"), (BROWSEROS_SERVER_BUNDLE,)
+            server_bundles_for_product("browseros", use_claw_server_rust=True),
+            (BROWSEROS_SERVER_BUNDLE,),
         )
         self.assertEqual(
-            server_bundles_for_product("browserclaw"),
+            server_bundles_for_product("browseros", use_claw_server_rust=False),
+            (BROWSEROS_SERVER_BUNDLE,),
+        )
+        self.assertEqual(
+            server_bundles_for_product("browserclaw", use_claw_server_rust=True),
+            (BROWSERCLAW_RUST_SERVER_BUNDLE,),
+        )
+        self.assertEqual(
+            server_bundles_for_product("browserclaw", use_claw_server_rust=False),
+            (BROWSEROS_CLAW_SERVER_BUNDLE,),
+        )
+
+    def test_server_ota_bundles_stay_pinned_to_typescript_claw(self):
+        self.assertEqual(
+            server_ota_bundles_for_product("browserclaw"),
             (BROWSEROS_CLAW_SERVER_BUNDLE,),
         )
 

--- a/packages/browseros/bos_build/release/ota/server.py
+++ b/packages/browseros/bos_build/release/ota/server.py
@@ -33,7 +33,7 @@ from .sign_binary import (
 )
 from ..feeds.render import render_server_appcast
 from ..feeds.spec import CDN_BASE_URL, server_feed
-from ...products.server_binaries import ServerBundle, server_bundles_for_product
+from ...products.server_binaries import ServerBundle, server_ota_bundles_for_product
 from ...lib.r2 import get_r2_client, upload_file_to_r2, download_file_from_r2
 from ...steps.storage.download import extract_artifact_zip
 
@@ -64,7 +64,7 @@ class ServerOTAModule(Step):
 
     @property
     def bundle(self) -> ServerBundle:
-        bundles = server_bundles_for_product(self.product_id)
+        bundles = server_ota_bundles_for_product(self.product_id)
         if not bundles:
             raise RuntimeError(
                 f"Product '{self.product_id}' has no server bundle"
@@ -87,7 +87,7 @@ class ServerOTAModule(Step):
         if self.channel not in ["alpha", "prod"]:
             raise ValidationError("Channel must be 'alpha' or 'prod'")
 
-        if not server_bundles_for_product(self.product_id):
+        if not server_ota_bundles_for_product(self.product_id):
             raise ValidationError(
                 f"Product '{self.product_id}' has no server bundle"
             )

--- a/packages/browseros/bos_build/steps/package/linux.py
+++ b/packages/browseros/bos_build/steps/package/linux.py
@@ -226,7 +226,13 @@ def copy_browser_files(
 def _server_output_roots(ctx: Context) -> list[str]:
     """Return final server bundle roots for the active product."""
     product = getattr(ctx, "product", None)
-    bundles = server_bundles_for_product(product.id) if product else all_server_bundles()
+    flags = getattr(ctx, "build_flags", None)
+    use_rust = flags.use_claw_server_rust if flags is not None else None
+    bundles = (
+        server_bundles_for_product(product.id, use_rust)
+        if product
+        else all_server_bundles(use_rust)
+    )
     return [bundle.chromium_output_root for bundle in bundles]
 
 

--- a/packages/browseros/bos_build/steps/resources/resources.py
+++ b/packages/browseros/bos_build/steps/resources/resources.py
@@ -128,12 +128,12 @@ def copy_resources_impl(ctx: Context, commit_each: bool = False) -> bool:
 
         try:
             copied = False
+            if clear_destination:
+                clear_path(dst_base)
             if op_type == "directory":
                 # Copy entire directory
                 if src_path.exists() and src_path.is_dir():
                     dst_path = dst_base
-                    if clear_destination:
-                        clear_path(dst_path)
                     dst_path.mkdir(parents=True, exist_ok=True)
                     shutil.copytree(src_path, dst_path, dirs_exist_ok=True)
                     copied = True

--- a/packages/browseros/bos_build/steps/resources/resources.py
+++ b/packages/browseros/bos_build/steps/resources/resources.py
@@ -8,6 +8,7 @@ import subprocess
 from pathlib import Path
 from ...core.step import Step, ValidationError, step
 from ...core.context import Context
+from ...lib.build_flags import build_flags_for_context
 from ...lib.utils import log_info, log_success, log_error, log_warning, get_platform
 
 
@@ -52,6 +53,8 @@ def copy_resources_impl(ctx: Context, commit_each: bool = False) -> bool:
             "📝 Git commit mode enabled - will create a commit after each resource copy"
         )
 
+    all_ok = True
+
     # Process each copy operation
     for operation in config["copy_operations"]:
         name = operation.get("name", "Unnamed operation")
@@ -62,12 +65,36 @@ def copy_resources_impl(ctx: Context, commit_each: bool = False) -> bool:
         os_condition = operation.get("os")
         arch_condition = operation.get("arch")
         product_condition = operation.get("product")
+        variant_condition = operation.get("claw_server_variant")
 
         if not product_matches(product_condition, ctx.product.id):
             log_info(
                 f"  ⏭️  Skipping {name} (product: {product_condition}, current: {ctx.product.id})"
             )
             continue
+
+        if not claw_server_variant_matches(variant_condition, ctx):
+            log_info(
+                "  ⏭️  Skipping "
+                f"{name} (claw_server_variant: {variant_condition}, "
+                f"selected: {_selected_claw_server_variant(ctx)})"
+            )
+            continue
+
+        selected_claw_variant = is_selected_claw_server_variant(
+            variant_condition, ctx
+        )
+        if selected_claw_variant and operation.get("selected_destination"):
+            destination = operation["selected_destination"]
+        clear_destination = (
+            selected_claw_variant
+            and operation.get("selected_clear_destination", False)
+        )
+        renames = (
+            operation.get("selected_renames")
+            if selected_claw_variant
+            else operation.get("renames")
+        )
 
         # Skip operation if build_type condition doesn't match
         if build_type_condition and build_type_condition != ctx.build_type:
@@ -100,12 +127,16 @@ def copy_resources_impl(ctx: Context, commit_each: bool = False) -> bool:
         log_info(f"  • {name}")
 
         try:
+            copied = False
             if op_type == "directory":
                 # Copy entire directory
                 if src_path.exists() and src_path.is_dir():
                     dst_path = dst_base
+                    if clear_destination:
+                        clear_path(dst_path)
                     dst_path.mkdir(parents=True, exist_ok=True)
                     shutil.copytree(src_path, dst_path, dirs_exist_ok=True)
+                    copied = True
                     log_info(f"    ✓ Copied directory: {source} → {destination}")
                     if commit_each:
                         commit_resource_copy(
@@ -123,6 +154,7 @@ def copy_resources_impl(ctx: Context, commit_each: bool = False) -> bool:
                         file_path = Path(file_path)
                         if file_path.is_file():
                             shutil.copy2(file_path, dst_base)
+                            copied = True
                     log_info(
                         f"    ✓ Copied {len(files)} files: {source} → {destination}"
                     )
@@ -138,6 +170,7 @@ def copy_resources_impl(ctx: Context, commit_each: bool = False) -> bool:
                 if src_path.exists() and src_path.is_file():
                     dst_base.parent.mkdir(parents=True, exist_ok=True)
                     shutil.copy2(src_path, dst_base)
+                    copied = True
                     log_info(f"    ✓ Copied file: {source} → {destination}")
                     if commit_each:
                         commit_resource_copy(
@@ -146,11 +179,16 @@ def copy_resources_impl(ctx: Context, commit_each: bool = False) -> bool:
                 else:
                     log_warning(f"    Source file not found: {source}")
 
+            if copied and renames:
+                apply_renames(dst_base, renames)
+
         except Exception as e:
             log_error(f"    Error: {e}")
+            all_ok = False
 
-    log_success("Resources copied")
-    return True
+    if all_ok:
+        log_success("Resources copied")
+    return all_ok
 
 
 def product_matches(product_condition, product_id: str) -> bool:
@@ -163,6 +201,79 @@ def product_matches(product_condition, product_id: str) -> bool:
         [product_condition] if isinstance(product_condition, str) else product_condition
     )
     return product_id in products
+
+
+def claw_server_variant_matches(variant_condition, ctx: Context) -> bool:
+    """Return whether a BrowserClaw-only claw-server variant gate matches."""
+    if variant_condition is None:
+        return True
+    if ctx.product.id != "browserclaw":
+        return True
+    if variant_condition not in ("typescript", "rust"):
+        raise ValueError(
+            "claw_server_variant must be 'typescript' or 'rust', got "
+            f"{variant_condition!r}"
+        )
+    return variant_condition == _selected_claw_server_variant(ctx)
+
+
+def is_selected_claw_server_variant(variant_condition, ctx: Context) -> bool:
+    """Return true only for the selected BrowserClaw claw-server operation."""
+    return (
+        variant_condition is not None
+        and ctx.product.id == "browserclaw"
+        and variant_condition == _selected_claw_server_variant(ctx)
+    )
+
+
+def apply_renames(base: Path, renames) -> None:
+    """Rename declared relative paths under an already-copied destination."""
+    if not isinstance(renames, list):
+        raise ValueError("renames must be a list")
+
+    for rename in renames:
+        if not isinstance(rename, dict):
+            raise ValueError("rename entries must be mappings")
+        src_rel = _safe_relative_path(rename.get("from"), "from")
+        dst_rel = _safe_relative_path(rename.get("to"), "to")
+        src = base / src_rel
+        dst = base / dst_rel
+        if not src.is_file():
+            raise FileNotFoundError(f"rename source not found: {src_rel.as_posix()}")
+        dst.parent.mkdir(parents=True, exist_ok=True)
+        if dst.exists():
+            if dst.is_dir():
+                raise IsADirectoryError(f"rename target is a directory: {dst_rel}")
+            dst.unlink()
+        src.rename(dst)
+        log_info(f"    ✓ Renamed {src_rel.as_posix()} → {dst_rel.as_posix()}")
+
+
+def clear_path(path: Path) -> None:
+    """Remove an existing destination before a mutually exclusive copy."""
+    if not path.exists():
+        return
+    if path.is_dir():
+        shutil.rmtree(path)
+        return
+    path.unlink()
+
+
+def _selected_claw_server_variant(ctx: Context) -> str:
+    return (
+        "rust"
+        if build_flags_for_context(ctx).use_claw_server_rust
+        else "typescript"
+    )
+
+
+def _safe_relative_path(raw_path, field: str) -> Path:
+    if not isinstance(raw_path, str) or not raw_path:
+        raise ValueError(f"rename {field} must be a non-empty relative path")
+    rel = Path(raw_path)
+    if rel.is_absolute() or ".." in rel.parts or rel == Path("."):
+        raise ValueError(f"rename {field} is unsafe: {raw_path}")
+    return rel
 
 
 def commit_resource_copy(

--- a/packages/browseros/bos_build/steps/resources/resources_test.py
+++ b/packages/browseros/bos_build/steps/resources/resources_test.py
@@ -13,6 +13,7 @@ import yaml
 from .resources import ResourcesModule, copy_resources_impl
 from ...core.context import Context
 from ...core.step import ValidationError
+from ...lib.build_flags import BuildFlags
 from ...lib.testing import MockBrowserOSRoot, MockChromium, make_context
 from ...lib.utils import get_platform
 
@@ -317,7 +318,9 @@ class CopyResourcesTest(unittest.TestCase):
         self.assertEqual(claw_dest.read_text(), "claw")
         self.assertEqual(claw_rust_dest.read_text(), "claw-rust")
 
-    def test_real_config_copies_server_resources_for_browserclaw_product(self):
+    def test_real_config_copies_rust_server_resources_for_browserclaw_by_default(
+        self,
+    ):
         self.root.write_copy_config(self._real_copy_config())
         browseros_source = (
             self.root.root
@@ -349,6 +352,19 @@ class CopyResourcesTest(unittest.TestCase):
         (claw_source / "bin" / "browseros-claw-server").write_text("claw")
         (claw_rust_source / "bin").mkdir(parents=True)
         (claw_rust_source / "bin" / "browseros-claw-server-rs").write_text("claw-rust")
+        stale_ts_only_file = (
+            self.chromium.src
+            / "chrome"
+            / "browser"
+            / "browseros"
+            / "claw_server"
+            / "resources"
+            / "bin"
+            / "third_party"
+            / "bun"
+        )
+        stale_ts_only_file.parent.mkdir(parents=True)
+        stale_ts_only_file.write_text("stale")
 
         with patch("bos_build.steps.resources.resources.get_platform", return_value="macos"):
             ctx = make_context(
@@ -391,8 +407,81 @@ class CopyResourcesTest(unittest.TestCase):
             / "browseros-claw-server-rs"
         )
         self.assertEqual(browseros_dest.read_text(), "browseros")
+        self.assertEqual(claw_dest.read_text(), "claw-rust")
+        self.assertFalse(claw_rust_dest.exists())
+        self.assertFalse(stale_ts_only_file.exists())
+
+    def test_real_config_copies_typescript_server_resources_when_flag_false(self):
+        self.root.write_copy_config(self._real_copy_config())
+        browseros_source = (
+            self.root.root
+            / "resources"
+            / "binaries"
+            / "browseros_server"
+            / "darwin-arm64"
+            / "resources"
+        )
+        claw_source = (
+            self.root.root
+            / "resources"
+            / "binaries"
+            / "browseros_claw_server"
+            / "darwin-arm64"
+            / "resources"
+        )
+        claw_rust_source = (
+            self.root.root
+            / "resources"
+            / "binaries"
+            / "browseros_claw_server_rust"
+            / "darwin-arm64"
+            / "resources"
+        )
+        (browseros_source / "bin").mkdir(parents=True)
+        (browseros_source / "bin" / "browseros_server").write_text("browseros")
+        (claw_source / "bin").mkdir(parents=True)
+        (claw_source / "bin" / "browseros-claw-server").write_text("claw")
+        (claw_rust_source / "bin").mkdir(parents=True)
+        (claw_rust_source / "bin" / "browseros-claw-server-rs").write_text(
+            "claw-rust"
+        )
+
+        with patch(
+            "bos_build.steps.resources.resources.get_platform",
+            return_value="macos",
+        ):
+            ctx = make_context(
+                self.chromium,
+                self.root,
+                architecture="arm64",
+                build_type="release",
+                product="browserclaw",
+            )
+            ctx.build_flags = BuildFlags(use_claw_server_rust=False)
+            self.assertTrue(copy_resources_impl(ctx))
+
+        claw_dest = (
+            self.chromium.src
+            / "chrome"
+            / "browser"
+            / "browseros"
+            / "claw_server"
+            / "resources"
+            / "bin"
+            / "browseros-claw-server"
+        )
+        claw_rust_dest = (
+            self.chromium.src
+            / "chrome"
+            / "browser"
+            / "browseros"
+            / "claw_server_rust"
+            / "resources"
+            / "bin"
+            / "browseros-claw-server-rs"
+        )
         self.assertEqual(claw_dest.read_text(), "claw")
-        self.assertEqual(claw_rust_dest.read_text(), "claw-rust")
+        self.assertFalse(claw_rust_dest.exists())
 
     def test_real_config_copies_claw_onboard_resources_for_both_products(self):
         # The downloaded onboarding dist must land in the grit resources dir

--- a/packages/browseros/bos_build/steps/resources/resources_test.py
+++ b/packages/browseros/bos_build/steps/resources/resources_test.py
@@ -445,6 +445,18 @@ class CopyResourcesTest(unittest.TestCase):
         (claw_rust_source / "bin" / "browseros-claw-server-rs").write_text(
             "claw-rust"
         )
+        stale_rust_file = (
+            self.chromium.src
+            / "chrome"
+            / "browser"
+            / "browseros"
+            / "claw_server"
+            / "resources"
+            / "bin"
+            / "browseros-claw-server-rs"
+        )
+        stale_rust_file.parent.mkdir(parents=True)
+        stale_rust_file.write_text("stale-rust")
 
         with patch(
             "bos_build.steps.resources.resources.get_platform",
@@ -482,6 +494,7 @@ class CopyResourcesTest(unittest.TestCase):
         )
         self.assertEqual(claw_dest.read_text(), "claw")
         self.assertFalse(claw_rust_dest.exists())
+        self.assertFalse(stale_rust_file.exists())
 
     def test_real_config_copies_claw_onboard_resources_for_both_products(self):
         # The downloaded onboarding dist must land in the grit resources dir

--- a/packages/browseros/bos_build/steps/setup/configure.py
+++ b/packages/browseros/bos_build/steps/setup/configure.py
@@ -88,7 +88,7 @@ class ConfigureModule(Step):
         # Debug sets browseros_package_all_server_resources, so ninja needs
         # every product's server resources staged; a missing set otherwise
         # surfaces much later as a cryptic missing-input error.
-        for bundle in all_server_bundles():
+        for bundle in all_server_bundles(ctx.build_flags.use_claw_server_rust):
             resources_dir = ctx.chromium_src / bundle.chromium_resources_root
             if not resources_dir.exists():
                 log_warning(

--- a/packages/browseros/bos_build/steps/sign/macos.py
+++ b/packages/browseros/bos_build/steps/sign/macos.py
@@ -48,11 +48,18 @@ SERVER_RESOURCES_JUNK_FILES = {".DS_Store"}
 
 
 def verify_server_resources_bundle(
-    app_path: Path, chromium_src: Path, product_id: Optional[str] = None
+    app_path: Path,
+    chromium_src: Path,
+    product_id: Optional[str] = None,
+    use_claw_server_rust: Optional[bool] = None,
 ) -> List[str]:
     """Check bundled server resources match what the build staged."""
     problems: List[str] = []
-    bundles = server_bundles_for_product(product_id) if product_id else all_server_bundles()
+    bundles = (
+        server_bundles_for_product(product_id, use_claw_server_rust)
+        if product_id
+        else all_server_bundles(use_claw_server_rust)
+    )
     for bundle in bundles:
         problems.extend(_verify_server_resource_bundle(bundle, app_path, chromium_src))
     return problems
@@ -222,7 +229,10 @@ class MacOSSignModule(Step):
 
     def _verify_server_resources(self, app_path: Path, ctx: Context) -> None:
         problems = verify_server_resources_bundle(
-            app_path, ctx.chromium_src, ctx.product.id
+            app_path,
+            ctx.chromium_src,
+            ctx.product.id,
+            ctx.build_flags.use_claw_server_rust,
         )
         if problems:
             raise RuntimeError(
@@ -401,7 +411,13 @@ def find_components_to_sign(
         if nested_app not in components["helpers"]:
             components["apps"].append(nested_app)
 
-    bundles = server_bundles_for_product(ctx.product.id) if ctx else all_server_bundles()
+    flags = getattr(ctx, "build_flags", None) if ctx else None
+    use_rust = flags.use_claw_server_rust if flags is not None else None
+    bundles = (
+        server_bundles_for_product(ctx.product.id, use_rust)
+        if ctx
+        else all_server_bundles(use_rust)
+    )
     for bundle in bundles:
         bundle_root = app_path / bundle.macos_bundle_resources_root
         if not bundle_root.exists():

--- a/packages/browseros/bos_build/steps/sign/windows.py
+++ b/packages/browseros/bos_build/steps/sign/windows.py
@@ -77,13 +77,15 @@ class WindowsSignModule(Step):
         log_info("\nStep 1/3: Signing executables before packaging...")
         env = ctx.env
         binaries_to_sign_first = [build_output_dir / "chrome.exe"]
+        flags = getattr(ctx, "build_flags", None)
+        use_rust = getattr(flags, "use_claw_server_rust", None)
         binaries_to_sign_first.extend(
             get_existing_browseros_server_binary_paths(
-                build_output_dir, ctx.product.id
+                build_output_dir, ctx.product.id, use_rust
             )
         )
         missing = get_missing_required_browseros_server_binary_paths(
-            build_output_dir, ctx.product.id
+            build_output_dir, ctx.product.id, use_rust
         )
         if missing:
             raise RuntimeError(
@@ -123,29 +125,43 @@ class WindowsSignModule(Step):
 
 
 def get_browseros_server_binary_paths(
-    build_output_dir: Path, product_id: str | None = None
+    build_output_dir: Path,
+    product_id: str | None = None,
+    use_claw_server_rust: bool | None = None,
 ) -> List[Path]:
     """Return absolute paths to bundled server binaries for signing."""
-    return expected_windows_bundle_binary_paths(build_output_dir, product_id)
+    return expected_windows_bundle_binary_paths(
+        build_output_dir, product_id, use_claw_server_rust
+    )
 
 
 def get_existing_browseros_server_binary_paths(
-    build_output_dir: Path, product_id: str | None = None
+    build_output_dir: Path,
+    product_id: str | None = None,
+    use_claw_server_rust: bool | None = None,
 ) -> List[Path]:
     """Return bundled server binary paths that exist in a build output dir."""
     return [
         path
-        for path in expected_windows_bundle_binary_paths(build_output_dir, product_id)
+        for path in expected_windows_bundle_binary_paths(
+            build_output_dir, product_id, use_claw_server_rust
+        )
         if path.exists()
     ]
 
 
 def get_missing_required_browseros_server_binary_paths(
-    build_output_dir: Path, product_id: str | None = None
+    build_output_dir: Path,
+    product_id: str | None = None,
+    use_claw_server_rust: bool | None = None,
 ) -> List[Path]:
     """Return missing bundled server binaries that should already be packaged."""
     missing: List[Path] = []
-    bundles = server_bundles_for_product(product_id) if product_id else all_server_bundles()
+    bundles = (
+        server_bundles_for_product(product_id, use_claw_server_rust)
+        if product_id
+        else all_server_bundles(use_claw_server_rust)
+    )
     for bundle in bundles:
         bundle_root = build_output_dir / bundle.windows_bundle_resources_root
         should_exist = (

--- a/packages/browseros/bos_build/steps/storage/download.py
+++ b/packages/browseros/bos_build/steps/storage/download.py
@@ -12,6 +12,7 @@ from typing import Any, List
 
 from ...core.step import Step, ValidationError, step
 from ...core.context import Context
+from ...lib.build_flags import build_flags_for_context
 from ...lib.utils import (
     log_info,
     log_success,
@@ -334,6 +335,10 @@ class DownloadResourcesModule(Step):
             if not _product_matches(product_condition, context.product.id):
                 continue
 
+            variant_condition = op.get("claw_server_variant")
+            if not _claw_server_variant_matches(variant_condition, context):
+                continue
+
             filtered.append(op)
 
         return filtered
@@ -349,3 +354,25 @@ def _product_matches(product_condition: Any, product_id: str) -> bool:
         [product_condition] if isinstance(product_condition, str) else product_condition
     )
     return product_id in products
+
+
+def _claw_server_variant_matches(
+    variant_condition: Any, context: Context
+) -> bool:
+    """Return whether a BrowserClaw-only claw-server variant gate matches."""
+    if variant_condition is None:
+        return True
+    if context.product.id != "browserclaw":
+        return True
+    if variant_condition not in ("typescript", "rust"):
+        raise ValueError(
+            "claw_server_variant must be 'typescript' or 'rust', got "
+            f"{variant_condition!r}"
+        )
+
+    selected = (
+        "rust"
+        if build_flags_for_context(context).use_claw_server_rust
+        else "typescript"
+    )
+    return variant_condition == selected

--- a/packages/browseros/bos_build/steps/storage/download_test.py
+++ b/packages/browseros/bos_build/steps/storage/download_test.py
@@ -16,6 +16,7 @@ from unittest.mock import patch
 import yaml
 from bos_build.core.context import Context
 from bos_build.core.products import get_product_descriptor
+from bos_build.lib.build_flags import BuildFlags
 from bos_build.steps.storage.download import (
     ARTIFACT_METADATA_NAME,
     DownloadResourcesModule,
@@ -373,11 +374,50 @@ class DownloadResourceConfigTest(unittest.TestCase):
                     ]
                     self.assertEqual([expected], actual)
 
-    def test_real_config_includes_server_artifacts_for_browserclaw_product(self) -> None:
+    def test_real_config_downloads_rust_claw_server_for_browserclaw_by_default(
+        self,
+    ) -> None:
         operations = self._real_download_operations()
 
         filtered = self._filter_operations(
-            operations, "macos", "arm64", product="browserclaw"
+            operations,
+            "macos",
+            "arm64",
+            product="browserclaw",
+            use_claw_server_rust=True,
+        )
+
+        self.assertEqual(
+            [
+                (
+                    "BrowserOS Server Resources - macOS ARM64",
+                    "artifacts/server/latest/browseros-server-resources-darwin-arm64.zip",
+                    "resources/binaries/browseros_server/darwin-arm64",
+                ),
+                (
+                    "BrowserOS Claw Rust Server Resources - macOS ARM64",
+                    "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-arm64.zip",
+                    "resources/binaries/browseros_claw_server_rust/darwin-arm64",
+                ),
+            ],
+            [
+                (op["name"], op["r2_key"], op["destination"])
+                for op in filtered
+                if "Server Resources" in op["name"]
+            ],
+        )
+
+    def test_real_config_downloads_typescript_claw_server_when_flag_false(
+        self,
+    ) -> None:
+        operations = self._real_download_operations()
+
+        filtered = self._filter_operations(
+            operations,
+            "macos",
+            "arm64",
+            product="browserclaw",
+            use_claw_server_rust=False,
         )
 
         self.assertEqual(
@@ -391,11 +431,6 @@ class DownloadResourceConfigTest(unittest.TestCase):
                     "BrowserOS Claw Server Resources - macOS ARM64",
                     "claw-server/prod-resources/latest/browseros-claw-server-resources-darwin-arm64.zip",
                     "resources/binaries/browseros_claw_server/darwin-arm64",
-                ),
-                (
-                    "BrowserOS Claw Rust Server Resources - macOS ARM64",
-                    "claw-server-rust/prod-resources/latest/browseros-claw-server-rust-resources-darwin-arm64.zip",
-                    "resources/binaries/browseros_claw_server_rust/darwin-arm64",
                 ),
             ],
             [
@@ -418,6 +453,7 @@ class DownloadResourceConfigTest(unittest.TestCase):
         platform: str,
         architecture: str,
         product: str = "browseros",
+        use_claw_server_rust: bool = True,
     ) -> list[dict]:
         ctx = cast(
             Context,
@@ -425,6 +461,9 @@ class DownloadResourceConfigTest(unittest.TestCase):
                 architecture=architecture,
                 build_type="release",
                 product=get_product_descriptor(product),
+                build_flags=BuildFlags(
+                    use_claw_server_rust=use_claw_server_rust
+                ),
             ),
         )
         with patch("bos_build.steps.storage.download.get_platform", return_value=platform):


### PR DESCRIPTION
## Summary
- Adds `bos_build/config/build_flags.yaml` with `use_claw_server_rust: true` as the BrowserClaw migration valve.
- Adds a Rust BrowserClaw server bundle and makes BrowserClaw browser-build bundle/download/resource/signing resolution select exactly one variant; BrowserOS is unaffected.
- Stages the Rust artifact into Chromium's existing `chrome/browser/browseros/claw_server/resources` path and renames the Rust binary to the browser's expected launch name, clearing stale variant files on flips.
- Keeps BrowserClaw server OTA/appcast resolution pinned to the TypeScript bundle for this lane.

## Design
The flag is loaded once into `Context.build_flags`, then bundle consumers pass that value into active server-bundle resolution. `download_resources.yaml` and `copy_resources.yaml` carry `claw_server_variant` gates so BrowserClaw only fetches and stages the selected variant. Rust artifacts keep their source root (`browseros_claw_server_rust`) but selected BrowserClaw staging copies them into the existing `claw_server/resources` tree and renames `browseros-claw-server-rs[.exe]` to `browseros-claw-server[.exe]` because Chromium hardcodes that launch name.

## Evidence
- CDN zip inspected: `browseros-claw-server-rust-resources-darwin-arm64.zip` contains `artifact-metadata.json` and `resources/bin/browseros-claw-server-rs`; metadata version `0.1.0`, target `darwin-arm64`.
- CDN zip inspected: `browseros-claw-server-rust-resources-windows-x64.zip` contains `resources/bin/browseros-claw-server-rs.exe`.
- Chromium patch expectation checked: `packages/browseros/chromium_patches/chrome/browser/browseros/server/BUILD.gn` and `browseros_server_config.cc` expect `chrome/browser/browseros/claw_server/resources` and binary `browseros-claw-server` (plus `.exe` on Windows).
- R2 standalone download was not run because this worktree has no `packages/browseros/.env` and `EnvConfig.has_r2_config()` returned false; no credentials were printed.

## Test plan
- [x] `uv run python -m unittest bos_build.lib.build_flags_test bos_build.core.context_test bos_build.products.server_binaries_test bos_build.steps.storage.download_test bos_build.steps.resources.resources_test bos_build.steps.sign.macos_test bos_build.steps.sign.windows_test bos_build.release.ota.feeds_alignment_test`
- [x] `uv run ruff check bos_build`
- [x] `uv run python -m unittest discover -s bos_build -p '*_test.py' -t .`
- [x] `uv run browseros build --show-plan --preset release --product browserclaw --arch arm64`
- [x] Context-free review round 1 found stale variant cleanup; fixed.
- [x] Context-free review round 2 clean.