### PR TITLE
feat(bos_build): WinSparkle.dll packaging guard + Windows install verification checklist

### DIFF
--- a/packages/browseros/bos_build/docs/windows-install-verification.md
+++ b/packages/browseros/bos_build/docs/windows-install-verification.md
@@ -1,0 +1,44 @@
+# Windows Install Verification Checklist
+
+Use a Windows machine or VM with a clean user profile when verifying a fresh
+install. BrowserOS installs per-user; the Apps & Features entry is under:
+
+`HKCU\Software\Microsoft\Windows\CurrentVersion\Uninstall`
+
+## Fresh Install
+
+- [ ] Download the Windows installer artifact and double-click it.
+- [ ] A progress window appears with the title/text `Installing BrowserOS…`.
+- [ ] The installer window closes when installation completes.
+- [ ] BrowserOS launches automatically after the fresh install.
+- [ ] Apps & Features shows `BrowserOS`.
+- [ ] Apps & Features shows publisher `BrowserOS Software Inc`.
+- [ ] Apps & Features shows the BrowserOS icon.
+- [ ] Apps & Features shows the expected version.
+- [ ] A Start Menu shortcut exists and launches BrowserOS.
+- [ ] A desktop shortcut exists and launches BrowserOS.
+
+## Update Path
+
+- [ ] Install an older BrowserOS version.
+- [ ] Open `chrome://settings/help` and let WinSparkle find the newer update.
+- [ ] Start the update from the WinSparkle flow.
+- [ ] No installer progress window appears during the update.
+- [ ] BrowserOS does not auto-launch as part of the update install.
+- [ ] Relaunch BrowserOS after the update completes.
+- [ ] `chrome://settings/help` shows the new expected version.
+- [ ] `WinSparkle.dll` exists in
+      `%LOCALAPPDATA%\BrowserOS\Application\<version>\`.
+
+## Silent Fresh Install
+
+- [ ] Run the installer with `--silent` from Command Prompt or PowerShell.
+- [ ] No installer UI appears.
+- [ ] BrowserOS is installed successfully.
+- [ ] BrowserOS does not auto-launch during the silent install.
+
+## Portable Zip
+
+- [ ] Download the portable zip artifact.
+- [ ] Extract the zip.
+- [ ] The extracted contents include the Windows installer executable.

--- a/packages/browseros/bos_build/steps/package/windows.py
+++ b/packages/browseros/bos_build/steps/package/windows.py
@@ -59,9 +59,15 @@ class WindowsPackageModule(Step):
 
         build_output_dir = join_paths(context.chromium_src, context.out_dir)
         mini_installer_path = build_output_dir / "mini_installer.exe"
+        winsparkle_path = build_output_dir / "WinSparkle.dll"
 
         if not mini_installer_path.exists():
             raise ValidationError(f"mini_installer.exe not found: {mini_installer_path}")
+        if not winsparkle_path.exists():
+            raise ValidationError(
+                f"WinSparkle.dll not found: {winsparkle_path}. "
+                "WinSparkle auto-update won't ship without it."
+            )
 
     def execute(self, context: Context) -> None:
         log_info("\n📦 Creating Windows packages...")

--- a/packages/browseros/bos_build/steps/package/windows_test.py
+++ b/packages/browseros/bos_build/steps/package/windows_test.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """Tests for the Windows packaging module's autoninja routing."""
 
+import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
@@ -10,6 +11,7 @@ from unittest import mock
 from . import windows
 from ..compile import standard
 from ...core.context import Context
+from ...core.step import ValidationError
 
 
 class BuildMiniInstallerTest(unittest.TestCase):
@@ -33,6 +35,64 @@ class BuildMiniInstallerTest(unittest.TestCase):
         )
         # Artifacts were never produced (run_command is mocked), so it reports failure.
         self.assertFalse(result)
+
+
+class WindowsPackageModuleValidateTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.chromium_src = Path(self._tmp.name) / "chromium" / "src"
+        self.out_dir = "out/Default_x64"
+        self.build_output_dir = self.chromium_src / self.out_dir
+        self.build_output_dir.mkdir(parents=True)
+        self.ctx = cast(
+            Context,
+            SimpleNamespace(chromium_src=self.chromium_src, out_dir=self.out_dir),
+        )
+
+    def _touch_output(self, name: str) -> Path:
+        path = self.build_output_dir / name
+        path.write_text("")
+        return path
+
+    def test_validate_raises_when_winsparkle_dll_missing(self):
+        self._touch_output("mini_installer.exe")
+        winsparkle_path = self.build_output_dir / "WinSparkle.dll"
+
+        with mock.patch.object(windows, "IS_WINDOWS", return_value=True):
+            with self.assertRaises(ValidationError) as raised:
+                windows.WindowsPackageModule().validate(self.ctx)
+
+        message = str(raised.exception)
+        self.assertIn("WinSparkle.dll", message)
+        self.assertIn(str(winsparkle_path), message)
+        self.assertIn("WinSparkle auto-update won't ship without it", message)
+
+    def test_validate_passes_when_installer_and_winsparkle_dll_exist(self):
+        self._touch_output("mini_installer.exe")
+        self._touch_output("WinSparkle.dll")
+
+        with mock.patch.object(windows, "IS_WINDOWS", return_value=True):
+            windows.WindowsPackageModule().validate(self.ctx)
+
+    def test_validate_raises_when_mini_installer_missing(self):
+        self._touch_output("WinSparkle.dll")
+        mini_installer_path = self.build_output_dir / "mini_installer.exe"
+
+        with mock.patch.object(windows, "IS_WINDOWS", return_value=True):
+            with self.assertRaises(ValidationError) as raised:
+                windows.WindowsPackageModule().validate(self.ctx)
+
+        self.assertEqual(
+            str(raised.exception), f"mini_installer.exe not found: {mini_installer_path}"
+        )
+
+    def test_validate_raises_when_not_windows(self):
+        with mock.patch.object(windows, "IS_WINDOWS", return_value=False):
+            with self.assertRaisesRegex(
+                ValidationError, "Windows packaging requires Windows"
+            ):
+                windows.WindowsPackageModule().validate(self.ctx)
 
 
 if __name__ == "__main__":

--- a/packages/browseros/bos_build/steps/package/windows_test.py
+++ b/packages/browseros/bos_build/steps/package/windows_test.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for the Windows packaging module's autoninja routing."""
+"""Tests for the Windows packaging module (autoninja routing and validate())."""
 
 import tempfile
 import unittest
@@ -66,7 +66,7 @@ class WindowsPackageModuleValidateTest(unittest.TestCase):
         message = str(raised.exception)
         self.assertIn("WinSparkle.dll", message)
         self.assertIn(str(winsparkle_path), message)
-        self.assertIn("WinSparkle auto-update won't ship without it", message)
+        self.assertIn("auto-update", message)
 
     def test_validate_passes_when_installer_and_winsparkle_dll_exist(self):
         self._touch_output("mini_installer.exe")


### PR DESCRIPTION
## Summary
- `WindowsPackageModule.validate()` now fails packaging loudly when `WinSparkle.dll` is missing from the build output dir — a build regression in the WinSparkle bundling would otherwise ship a broken auto-updater silently.
- Adds colocated unittest coverage for the validate paths (dll missing, both artifacts present, mini_installer missing, non-Windows host).
- Adds `bos_build/docs/windows-install-verification.md`: a manual Windows checklist for the visible-install story (fresh install UI + Apps & Features entry + shortcuts, silent WinSparkle update path, `--silent`, portable zip).

## Design
BrowserOS ships Windows as chromium's mini_installer; WinSparkle.dll is built to `$root_out_dir` by the chromium-side patch and staged into the version dir via `chrome.release`. This PR is the BrowserOS-repo half of the visible-installer work: a cheap belt-and-braces guard at the packaging step (validate() already runs before execute() and converts ValidationError into a fatal step error) plus the runtime verification checklist. The chromium-side half (gated setup.exe progress UI, `--silent` semantics) lands separately via the patch stack; checklist items referencing the progress window / `--silent` become verifiable once that PR merges.

## Test plan
- [x] `uv run python -m unittest discover -s bos_build -t . -p "*_test.py"` → 642 tests OK (from `packages/browseros/`)
- [x] `uv run ruff check bos_build` → clean
- [ ] On a Windows build machine: run the new checklist end-to-end once the chromium-side installer-UI PR lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)