### PR TITLE
feat(ci): per-product signed macos nightlies; release-macos consumes published bundles

### DIFF
--- a/.github/workflows/nightly-browserclaw.yml
+++ b/.github/workflows/nightly-browserclaw.yml
@@ -1,24 +1,11 @@
-name: "Nightly: macOS Browser (signed, self-hosted)"
+name: "Nightly: BrowserClaw macOS (signed)"
 
 on:
   schedule:
-    # About 9 PM US Pacific during daylight saving time. GitHub cron is UTC.
-    - cron: "0 4 * * *"
+    # Runs after BrowserOS; the shared macos-build concurrency group serializes.
+    - cron: "30 6 * * *"
   workflow_dispatch:
     inputs:
-      bump:
-        description: Version bump level
-        type: choice
-        default: offset+build
-        options:
-          - offset-only
-          - offset+build
-          - offset+patch
-          - none
-      commit_version:
-        description: Commit and push the version bump to the built branch
-        type: boolean
-        default: false
       upload_to_r2:
         description: Publish build to R2/CDN after packaging
         type: boolean
@@ -36,8 +23,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       target_ref: ${{ steps.workflow_inputs.outputs.target_ref }}
-      bump_mode: ${{ steps.workflow_inputs.outputs.bump_mode }}
-      commit_version: ${{ steps.workflow_inputs.outputs.commit_version }}
       upload_to_r2: ${{ steps.workflow_inputs.outputs.upload_to_r2 }}
     steps:
       - name: Resolve workflow inputs
@@ -46,8 +31,6 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           NIGHTLY_REF: ${{ vars.BROWSEROS_NIGHTLY_REF }}
-          DISPATCH_BUMP: ${{ inputs.bump }}
-          DISPATCH_COMMIT_VERSION: ${{ inputs.commit_version }}
           DISPATCH_UPLOAD_TO_R2: ${{ inputs.upload_to_r2 }}
           DISPATCH_REF: ${{ github.ref_name }}
         run: |
@@ -55,20 +38,14 @@ jobs:
 
           if [ "$EVENT_NAME" = "schedule" ]; then
             target_ref="${NIGHTLY_REF:-$DEFAULT_BRANCH}"
-            bump_mode="offset+build"
-            commit_version="true"
             upload_to_r2="true"
           else
             target_ref="$DISPATCH_REF"
-            bump_mode="${DISPATCH_BUMP:-offset+build}"
-            commit_version="${DISPATCH_COMMIT_VERSION:-false}"
             upload_to_r2="${DISPATCH_UPLOAD_TO_R2:-true}"
           fi
 
           {
             echo "target_ref=$target_ref"
-            echo "bump_mode=$bump_mode"
-            echo "commit_version=$commit_version"
             echo "upload_to_r2=$upload_to_r2"
           } >> "$GITHUB_OUTPUT"
 
@@ -87,8 +64,6 @@ jobs:
         id: build_inputs
         env:
           TARGET_REF: ${{ needs.resolve_inputs.outputs.target_ref }}
-          BUMP_MODE: ${{ needs.resolve_inputs.outputs.bump_mode }}
-          COMMIT_VERSION: ${{ needs.resolve_inputs.outputs.commit_version }}
           UPLOAD_TO_R2: ${{ needs.resolve_inputs.outputs.upload_to_r2 }}
         run: |
           set -euo pipefail
@@ -119,8 +94,6 @@ jobs:
             echo "browseros_repo=$repo"
             echo "chromium_src=$chromium_src"
             echo "target_ref=$TARGET_REF"
-            echo "bump_mode=$BUMP_MODE"
-            echo "commit_version=$COMMIT_VERSION"
             echo "upload_to_r2=$UPLOAD_TO_R2"
           } >> "$GITHUB_OUTPUT"
 
@@ -145,117 +118,23 @@ jobs:
             git reset --hard "$TARGET_REF"
           fi
 
-      - name: Bump version
-        id: bump
+      - name: Read version
+        id: version
         env:
           BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
-          BUMP_MODE: ${{ steps.build_inputs.outputs.bump_mode }}
         run: |
           set -euo pipefail
           cd "$BROWSEROS_REPO/packages/browseros"
-          version="$(uv run python bos_build/scripts/bump_version.py --mode "$BUMP_MODE")"
+          version="$(uv run python bos_build/scripts/bump_version.py --mode none)"
           echo "version=$version" >> "$GITHUB_OUTPUT"
           echo "Built version: $version"
-
-      - name: Commit version bump via pull request
-        if: ${{ steps.build_inputs.outputs.commit_version == 'true' }}
-        env:
-          BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
-          TARGET_REF: ${{ steps.build_inputs.outputs.target_ref }}
-          VERSION: ${{ steps.bump.outputs.version }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ github.repository }}
-          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        run: |
-          set -euo pipefail
-          cd "$BROWSEROS_REPO"
-          version_files=(
-            packages/browseros/resources/BROWSEROS_VERSION
-            packages/browseros/bos_build/config/BROWSEROS_BUILD_OFFSET
-          )
-          git add "${version_files[@]}"
-          if git diff --cached --quiet; then
-            echo "No version changes to commit."
-            exit 0
-          fi
-          git -c user.name="BrowserOS CI" -c user.email="ci@browseros.com" \
-            commit -m "chore(release): build v$VERSION [skip ci]"
-
-          safe_target_ref="${TARGET_REF//[^A-Za-z0-9._-]/-}"
-          branch="bot/nightly-macos-version-${safe_target_ref}-v${VERSION}"
-          expected_sha="$(git ls-remote --heads origin "$branch" | awk '{print $1}')"
-          if [ -n "$expected_sha" ]; then
-            git push --force-with-lease="refs/heads/$branch:$expected_sha" \
-              origin "HEAD:refs/heads/$branch"
-          else
-            git push origin "HEAD:refs/heads/$branch"
-          fi
-
-          pr_url="$(gh pr list \
-            --repo "$GITHUB_REPOSITORY" \
-            --base "$TARGET_REF" \
-            --head "$branch" \
-            --state open \
-            --json url \
-            --jq '.[0].url // ""')"
-          if [ -z "$pr_url" ]; then
-            pr_body="$(mktemp)"
-            trap 'rm -f "$pr_body"' EXIT
-            cat > "$pr_body" <<EOF
-          Automated nightly macOS version bump for v$VERSION.
-
-          Source run: $RUN_URL
-          Target ref: $TARGET_REF
-          EOF
-            pr_url="$(gh pr create \
-              --repo "$GITHUB_REPOSITORY" \
-              --base "$TARGET_REF" \
-              --head "$branch" \
-              --title "chore(release): build v$VERSION" \
-              --body-file "$pr_body")"
-          fi
-
-          echo "Version bump PR: $pr_url"
-          if gh pr merge "$pr_url" \
-            --repo "$GITHUB_REPOSITORY" \
-            --squash \
-            --delete-branch \
-            --subject "chore(release): build v$VERSION [skip ci]" \
-            --body "Automated nightly macOS version bump."; then
-            exit 0
-          fi
-
-          merge_state="$(gh pr view "$pr_url" \
-            --repo "$GITHUB_REPOSITORY" \
-            --json mergeStateStatus \
-            --jq '.mergeStateStatus // "UNKNOWN"' || echo "UNKNOWN")"
-          failed_checks="$(gh pr view "$pr_url" \
-            --repo "$GITHUB_REPOSITORY" \
-            --json statusCheckRollup \
-            --jq '[.statusCheckRollup[]? | select((.__typename == "CheckRun" and ((.conclusion // "") == "FAILURE" or (.conclusion // "") == "CANCELLED" or (.conclusion // "") == "TIMED_OUT" or (.conclusion // "") == "ACTION_REQUIRED")) or (.__typename == "StatusContext" and ((.state // "") == "FAILURE" or (.state // "") == "ERROR")))] | length' || echo "0")"
-          if [ "$merge_state" = "DIRTY" ] || [ "$failed_checks" -gt 0 ]; then
-            echo "::warning::Leaving version bump PR open (mergeStateStatus=$merge_state, failedChecks=$failed_checks): $pr_url"
-            exit 0
-          fi
-
-          if gh pr merge "$pr_url" \
-            --repo "$GITHUB_REPOSITORY" \
-            --auto \
-            --squash \
-            --delete-branch \
-            --subject "chore(release): build v$VERSION [skip ci]" \
-            --body "Automated nightly macOS version bump."; then
-            echo "Enabled auto-merge for version bump PR: $pr_url"
-          else
-            echo "::warning::Could not merge or enable auto-merge for version bump PR; leaving it open: $pr_url"
-          fi
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: "1.3.6"
 
-      - name: Stage server resources for packaging
+      - name: Stage BrowserClaw nightly resources
         env:
           BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
         run: |
@@ -266,11 +145,38 @@ jobs:
           cd "$agent_root"
           bun ci
           bun scripts/build/server.ts --target=darwin-arm64 --ci
-          bun scripts/build/claw-server.ts --target=darwin-arm64 --ci
           bun scripts/build/claw-onboard.ts --ci
 
+          use_rust="$(
+            BROWSEROS_ROOT="$browseros_root" python3 - <<'PY'
+          import yaml
+          import os
+          from pathlib import Path
+
+          config = yaml.safe_load(
+              (
+                  Path(os.environ["BROWSEROS_ROOT"])
+                  / "bos_build/config/build_flags.yaml"
+              ).read_text()
+          )
+          value = config.get("use_claw_server_rust")
+          if not isinstance(value, bool):
+              raise SystemExit("use_claw_server_rust must be a boolean")
+          print("true" if value else "false")
+          PY
+          )"
+
+          if [ "$use_rust" = "true" ]; then
+            "$agent_root/scripts/build/claw-server-rust-local.sh" \
+              --target darwin-arm64 \
+              --agent-root "$agent_root" \
+              --browseros-root "$browseros_root"
+          else
+            bun scripts/build/claw-server.ts --target=darwin-arm64 --ci
+          fi
+
           cd "$browseros_root"
-          AGENT_ROOT="$agent_root" BROWSEROS_ROOT="$browseros_root" uv run python - <<'PY'
+          AGENT_ROOT="$agent_root" BROWSEROS_ROOT="$browseros_root" USE_RUST="$use_rust" uv run python - <<'PY'
           import os
           import shutil
           from pathlib import Path
@@ -285,14 +191,19 @@ jobs:
                   browseros_root / "resources/binaries/browseros_server/darwin-arm64",
               ),
               (
-                  agent_root / "dist/prod/claw-server/browseros-claw-server-resources-darwin-arm64.zip",
-                  browseros_root / "resources/binaries/browseros_claw_server/darwin-arm64",
-              ),
-              (
                   agent_root / "dist/prod/claw-onboard/browseros-claw-onboard-resources.zip",
                   browseros_root / "resources/binaries/browseros_claw_onboard",
               ),
           ]
+          if os.environ["USE_RUST"] != "true":
+              artifacts.append(
+                  (
+                      agent_root
+                      / "dist/prod/claw-server/browseros-claw-server-resources-darwin-arm64.zip",
+                      browseros_root
+                      / "resources/binaries/browseros_claw_server/darwin-arm64",
+                  )
+              )
 
           for archive, destination in artifacts:
               if not archive.is_file():
@@ -303,7 +214,7 @@ jobs:
               print(f"Staged {len(extracted)} file(s) from {archive.name}")
           PY
 
-      - name: Build BrowserOS (macOS arm64)
+      - name: Build BrowserClaw (macOS arm64)
         env:
           BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
           CHROMIUM_SRC: ${{ steps.build_inputs.outputs.chromium_src }}
@@ -311,22 +222,59 @@ jobs:
         run: |
           set -euo pipefail
           cd "$BROWSEROS_REPO/packages/browseros"
-          # Server resources are staged locally by the previous step, so
-          # the R2 download is off; upload toggles with the run input.
-          flags=(--preset release --arch arm64 --no-download)
+          flags=(--profile nightly-macos --product browserclaw --arch arm64)
           if [ "$UPLOAD_TO_R2" != "true" ]; then
             flags+=(--no-upload)
           fi
           uv run browseros build "${flags[@]}" --chromium-src "$CHROMIUM_SRC"
 
       - name: Upload DMG artifact
-        if: ${{ always() && steps.bump.outputs.version != '' }}
+        if: ${{ always() && steps.version.outputs.version != '' }}
         uses: actions/upload-artifact@v7
         with:
-          name: BrowserOS_v${{ steps.bump.outputs.version }}_arm64
-          path: ${{ steps.build_inputs.outputs.browseros_repo }}/packages/browseros/releases/${{ steps.bump.outputs.version }}/*.dmg
+          name: BrowserClaw_v${{ steps.version.outputs.version }}_arm64
+          path: ${{ steps.build_inputs.outputs.browseros_repo }}/packages/browseros/releases/${{ steps.version.outputs.version }}/BrowserClaw_*.dmg
           retention-days: 14
           if-no-files-found: warn
+
+      - name: Update rolling BrowserClaw nightly prerelease
+        env:
+          BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
+          TARGET_REF: ${{ steps.build_inputs.outputs.target_ref }}
+          VERSION: ${{ steps.version.outputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=("$BROWSEROS_REPO"/packages/browseros/releases/"$VERSION"/BrowserClaw_*.dmg)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "::error::No BrowserClaw DMG found to publish"
+            exit 1
+          fi
+          printf 'Publishing:\n%s\n' "${files[@]}"
+
+          built_sha="$(git -C "$BROWSEROS_REPO" rev-parse HEAD)"
+          notes_file="$(mktemp)"
+          cat > "$notes_file" <<EOF
+          Automated signed BrowserClaw macOS arm64 nightly for v$VERSION.
+
+          Source ref: \`$TARGET_REF\`
+          Build commit: \`$built_sha\`
+          EOF
+
+          gh release delete nightly-browserclaw \
+            --repo "$GITHUB_REPOSITORY" \
+            --cleanup-tag \
+            --yes || true
+          gh release create nightly-browserclaw \
+            --repo "$GITHUB_REPOSITORY" \
+            --prerelease \
+            --latest=false \
+            --target "$built_sha" \
+            --title "BrowserClaw Nightly (signed macOS arm64) $(date -u +%Y-%m-%d)" \
+            --notes-file "$notes_file" \
+            "${files[@]}"
 
       - name: Slack failure ping
         if: ${{ failure() }}
@@ -353,7 +301,7 @@ jobs:
           if [ -z "$hook" ]; then
             exit 0
           fi
-          python3 - <<'PY' > /tmp/browseros-nightly-slack-payload.json
+          python3 - <<'PY' > /tmp/browserclaw-nightly-slack-payload.json
           import json
           import os
 
@@ -361,7 +309,7 @@ jobs:
               json.dumps(
                   {
                       "text": (
-                          ":x: Nightly macOS build failed on "
+                          ":x: BrowserClaw nightly macOS build failed on "
                           f"`{os.environ['TARGET_REF']}` - {os.environ['RUN_URL']}"
                       )
                   }
@@ -369,4 +317,4 @@ jobs:
           )
           PY
           curl -fsS -X POST -H "Content-type: application/json" \
-            --data @/tmp/browseros-nightly-slack-payload.json "$hook" || true
+            --data @/tmp/browserclaw-nightly-slack-payload.json "$hook" || true

--- a/.github/workflows/nightly-browserclaw.yml
+++ b/.github/workflows/nightly-browserclaw.yml
@@ -148,7 +148,7 @@ jobs:
           bun scripts/build/claw-onboard.ts --ci
 
           use_rust="$(
-            BROWSEROS_ROOT="$browseros_root" python3 - <<'PY'
+            BROWSEROS_ROOT="$browseros_root" uv --quiet run --project "$browseros_root" python - <<'PY'
           import yaml
           import os
           from pathlib import Path

--- a/.github/workflows/nightly-browseros.yml
+++ b/.github/workflows/nightly-browseros.yml
@@ -1,27 +1,15 @@
-name: "Release: macOS Browser (signed, self-hosted)"
+name: "Nightly: BrowserOS macOS (signed)"
 
 on:
+  schedule:
+    # About 9 PM US Pacific during daylight saving time. GitHub cron is UTC.
+    - cron: "0 4 * * *"
   workflow_dispatch:
     inputs:
-      products:
-        description: Products to build
-        type: choice
-        default: browseros
-        options:
-          - browseros
-          - browserclaw
-          - all
-      arch:
-        description: macOS architecture to build
-        type: choice
-        default: arm64
-        options:
-          - arm64
-          - universal
       bump:
         description: Version bump level
         type: choice
-        default: none
+        default: offset+build
         options:
           - offset-only
           - offset+build
@@ -35,36 +23,6 @@ on:
         description: Publish build to R2/CDN after packaging
         type: boolean
         default: true
-      ref:
-        description: Git ref to build; defaults to the repository default branch
-        type: string
-        default: ""
-  workflow_call:
-    inputs:
-      products:
-        description: Products to build (browseros, browserclaw, all)
-        type: string
-        default: browseros
-      arch:
-        description: macOS architecture to build (arm64, universal)
-        type: string
-        default: arm64
-      bump:
-        description: Version bump level (offset-only, offset+build, offset+patch, none)
-        type: string
-        default: none
-      commit_version:
-        description: Commit and push the version bump to the built branch
-        type: boolean
-        default: false
-      upload_to_r2:
-        description: Publish build to R2/CDN after packaging
-        type: boolean
-        default: true
-      ref:
-        description: Git ref to build; defaults to the repository default branch
-        type: string
-        default: ""
 
 permissions:
   contents: read
@@ -78,104 +36,40 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       target_ref: ${{ steps.workflow_inputs.outputs.target_ref }}
-      product_ids: ${{ steps.workflow_inputs.outputs.product_ids }}
-      build_browseros: ${{ steps.workflow_inputs.outputs.build_browseros }}
-      build_browserclaw: ${{ steps.workflow_inputs.outputs.build_browserclaw }}
-      arch: ${{ steps.workflow_inputs.outputs.arch }}
       bump_mode: ${{ steps.workflow_inputs.outputs.bump_mode }}
       commit_version: ${{ steps.workflow_inputs.outputs.commit_version }}
       upload_to_r2: ${{ steps.workflow_inputs.outputs.upload_to_r2 }}
-      timeout_minutes: ${{ steps.workflow_inputs.outputs.timeout_minutes }}
     steps:
       - name: Resolve workflow inputs
         id: workflow_inputs
         env:
+          EVENT_NAME: ${{ github.event_name }}
           DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
-          INPUT_PRODUCTS: ${{ inputs.products }}
-          INPUT_ARCH: ${{ inputs.arch }}
-          INPUT_BUMP: ${{ inputs.bump }}
-          INPUT_COMMIT_VERSION: ${{ inputs.commit_version }}
-          INPUT_UPLOAD_TO_R2: ${{ inputs.upload_to_r2 }}
-          INPUT_REF: ${{ inputs.ref }}
+          NIGHTLY_REF: ${{ vars.BROWSEROS_NIGHTLY_REF }}
+          DISPATCH_BUMP: ${{ inputs.bump }}
+          DISPATCH_COMMIT_VERSION: ${{ inputs.commit_version }}
+          DISPATCH_UPLOAD_TO_R2: ${{ inputs.upload_to_r2 }}
+          DISPATCH_REF: ${{ github.ref_name }}
         run: |
           set -euo pipefail
 
-          products="${INPUT_PRODUCTS:-browseros}"
-          arch="${INPUT_ARCH:-arm64}"
-          bump_mode="${INPUT_BUMP:-none}"
-          commit_version="${INPUT_COMMIT_VERSION:-false}"
-          upload_to_r2="${INPUT_UPLOAD_TO_R2:-true}"
-          target_ref="${INPUT_REF:-$DEFAULT_BRANCH}"
-
-          case "$products" in
-            browseros)
-              product_ids="browseros"
-              build_browseros="true"
-              build_browserclaw="false"
-              ;;
-            browserclaw)
-              product_ids="browserclaw"
-              build_browseros="false"
-              build_browserclaw="true"
-              ;;
-            all)
-              product_ids="browseros browserclaw"
-              build_browseros="true"
-              build_browserclaw="true"
-              ;;
-            *)
-              echo "::error::Invalid products input: $products"
-              exit 1
-              ;;
-          esac
-
-          case "$arch" in
-            arm64|universal) ;;
-            *)
-              echo "::error::Invalid arch input: $arch"
-              exit 1
-              ;;
-          esac
-
-          case "$bump_mode" in
-            offset-only|offset+build|offset+patch|none) ;;
-            *)
-              echo "::error::Invalid bump input: $bump_mode"
-              exit 1
-              ;;
-          esac
-
-          case "$commit_version" in
-            true|false) ;;
-            *)
-              echo "::error::Invalid commit_version input: $commit_version"
-              exit 1
-              ;;
-          esac
-
-          case "$upload_to_r2" in
-            true|false) ;;
-            *)
-              echo "::error::Invalid upload_to_r2 input: $upload_to_r2"
-              exit 1
-              ;;
-          esac
-
-          timeout_minutes="600"
-          if [ "$products" = "all" ] || [ "$arch" = "universal" ]; then
-            timeout_minutes="1200"
+          if [ "$EVENT_NAME" = "schedule" ]; then
+            target_ref="${NIGHTLY_REF:-$DEFAULT_BRANCH}"
+            bump_mode="offset+build"
+            commit_version="true"
+            upload_to_r2="true"
+          else
+            target_ref="$DISPATCH_REF"
+            bump_mode="${DISPATCH_BUMP:-offset+build}"
+            commit_version="${DISPATCH_COMMIT_VERSION:-false}"
+            upload_to_r2="${DISPATCH_UPLOAD_TO_R2:-true}"
           fi
 
           {
             echo "target_ref=$target_ref"
-            echo "product_ids=$product_ids"
-            echo "build_browseros=$build_browseros"
-            echo "build_browserclaw=$build_browserclaw"
-            echo "arch=$arch"
             echo "bump_mode=$bump_mode"
             echo "commit_version=$commit_version"
             echo "upload_to_r2=$upload_to_r2"
-            echo "timeout_minutes=$timeout_minutes"
           } >> "$GITHUB_OUTPUT"
 
   build:
@@ -184,7 +78,7 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    timeout-minutes: ${{ fromJSON(needs.resolve_inputs.outputs.timeout_minutes) }}
+    timeout-minutes: 600
     env:
       BROWSEROS_REPO: ${{ vars.BROWSEROS_REPO_PATH }}
       CHROMIUM_SRC: ${{ vars.BROWSEROS_CHROMIUM_SRC }}
@@ -193,8 +87,6 @@ jobs:
         id: build_inputs
         env:
           TARGET_REF: ${{ needs.resolve_inputs.outputs.target_ref }}
-          PRODUCT_IDS: ${{ needs.resolve_inputs.outputs.product_ids }}
-          ARCH: ${{ needs.resolve_inputs.outputs.arch }}
           BUMP_MODE: ${{ needs.resolve_inputs.outputs.bump_mode }}
           COMMIT_VERSION: ${{ needs.resolve_inputs.outputs.commit_version }}
           UPLOAD_TO_R2: ${{ needs.resolve_inputs.outputs.upload_to_r2 }}
@@ -227,8 +119,6 @@ jobs:
             echo "browseros_repo=$repo"
             echo "chromium_src=$chromium_src"
             echo "target_ref=$TARGET_REF"
-            echo "product_ids=$PRODUCT_IDS"
-            echo "arch=$ARCH"
             echo "bump_mode=$BUMP_MODE"
             echo "commit_version=$COMMIT_VERSION"
             echo "upload_to_r2=$UPLOAD_TO_R2"
@@ -292,7 +182,7 @@ jobs:
             commit -m "chore(release): build v$VERSION [skip ci]"
 
           safe_target_ref="${TARGET_REF//[^A-Za-z0-9._-]/-}"
-          branch="bot/release-macos-version-${safe_target_ref}-v${VERSION}"
+          branch="bot/nightly-macos-version-${safe_target_ref}-v${VERSION}"
           expected_sha="$(git ls-remote --heads origin "$branch" | awk '{print $1}')"
           if [ -n "$expected_sha" ]; then
             git push --force-with-lease="refs/heads/$branch:$expected_sha" \
@@ -312,7 +202,7 @@ jobs:
             pr_body="$(mktemp)"
             trap 'rm -f "$pr_body"' EXIT
             cat > "$pr_body" <<EOF
-          Automated release macOS version bump for v$VERSION.
+          Automated nightly macOS version bump for v$VERSION.
 
           Source run: $RUN_URL
           Target ref: $TARGET_REF
@@ -331,7 +221,7 @@ jobs:
             --squash \
             --delete-branch \
             --subject "chore(release): build v$VERSION [skip ci]" \
-            --body "Automated release macOS version bump."; then
+            --body "Automated nightly macOS version bump."; then
             exit 0
           fi
 
@@ -354,7 +244,7 @@ jobs:
             --squash \
             --delete-branch \
             --subject "chore(release): build v$VERSION [skip ci]" \
-            --body "Automated release macOS version bump."; then
+            --body "Automated nightly macOS version bump."; then
             echo "Enabled auto-merge for version bump PR: $pr_url"
           else
             echo "::warning::Could not merge or enable auto-merge for version bump PR; leaving it open: $pr_url"
@@ -365,42 +255,110 @@ jobs:
         with:
           bun-version: "1.3.6"
 
-      - name: Build selected products
+      - name: Stage BrowserOS nightly resources
+        env:
+          BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
+        run: |
+          set -euo pipefail
+          agent_root="$BROWSEROS_REPO/packages/browseros-agent"
+          browseros_root="$BROWSEROS_REPO/packages/browseros"
+
+          cd "$agent_root"
+          bun ci
+          bun scripts/build/server.ts --target=darwin-arm64 --ci
+          bun scripts/build/claw-onboard.ts --ci
+
+          cd "$browseros_root"
+          AGENT_ROOT="$agent_root" BROWSEROS_ROOT="$browseros_root" uv run python - <<'PY'
+          import os
+          import shutil
+          from pathlib import Path
+
+          from bos_build.steps.storage.download import extract_artifact_zip
+
+          agent_root = Path(os.environ["AGENT_ROOT"])
+          browseros_root = Path(os.environ["BROWSEROS_ROOT"])
+          artifacts = [
+              (
+                  agent_root / "dist/prod/server/browseros-server-resources-darwin-arm64.zip",
+                  browseros_root / "resources/binaries/browseros_server/darwin-arm64",
+              ),
+              (
+                  agent_root / "dist/prod/claw-onboard/browseros-claw-onboard-resources.zip",
+                  browseros_root / "resources/binaries/browseros_claw_onboard",
+              ),
+          ]
+
+          for archive, destination in artifacts:
+              if not archive.is_file():
+                  raise SystemExit(f"Missing local server resource archive: {archive}")
+              if destination.exists():
+                  shutil.rmtree(destination)
+              extracted = extract_artifact_zip(archive, destination)
+              print(f"Staged {len(extracted)} file(s) from {archive.name}")
+          PY
+
+      - name: Build BrowserOS (macOS arm64)
         env:
           BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
           CHROMIUM_SRC: ${{ steps.build_inputs.outputs.chromium_src }}
-          PRODUCT_IDS: ${{ steps.build_inputs.outputs.product_ids }}
-          ARCH: ${{ steps.build_inputs.outputs.arch }}
           UPLOAD_TO_R2: ${{ steps.build_inputs.outputs.upload_to_r2 }}
         run: |
           set -euo pipefail
           cd "$BROWSEROS_REPO/packages/browseros"
-          for product in $PRODUCT_IDS; do
-            echo "Building $product for macOS $ARCH"
-            flags=(--preset release --product "$product" --arch "$ARCH")
-            if [ "$UPLOAD_TO_R2" != "true" ]; then
-              flags+=(--no-upload)
-            fi
-            uv run browseros build "${flags[@]}" --chromium-src "$CHROMIUM_SRC"
-          done
+          flags=(--profile nightly-macos --product browseros --arch arm64)
+          if [ "$UPLOAD_TO_R2" != "true" ]; then
+            flags+=(--no-upload)
+          fi
+          uv run browseros build "${flags[@]}" --chromium-src "$CHROMIUM_SRC"
 
-      - name: Upload BrowserOS DMG artifact
-        if: ${{ always() && steps.bump.outputs.version != '' && needs.resolve_inputs.outputs.build_browseros == 'true' }}
+      - name: Upload DMG artifact
+        if: ${{ always() && steps.bump.outputs.version != '' }}
         uses: actions/upload-artifact@v7
         with:
-          name: BrowserOS_v${{ steps.bump.outputs.version }}_${{ needs.resolve_inputs.outputs.arch }}
+          name: BrowserOS_v${{ steps.bump.outputs.version }}_arm64
           path: ${{ steps.build_inputs.outputs.browseros_repo }}/packages/browseros/releases/${{ steps.bump.outputs.version }}/BrowserOS_*.dmg
           retention-days: 14
           if-no-files-found: warn
 
-      - name: Upload BrowserClaw DMG artifact
-        if: ${{ always() && steps.bump.outputs.version != '' && needs.resolve_inputs.outputs.build_browserclaw == 'true' }}
-        uses: actions/upload-artifact@v7
-        with:
-          name: BrowserClaw_v${{ steps.bump.outputs.version }}_${{ needs.resolve_inputs.outputs.arch }}
-          path: ${{ steps.build_inputs.outputs.browseros_repo }}/packages/browseros/releases/${{ steps.bump.outputs.version }}/BrowserClaw_*.dmg
-          retention-days: 14
-          if-no-files-found: warn
+      - name: Update rolling BrowserOS nightly prerelease
+        env:
+          BROWSEROS_REPO: ${{ steps.build_inputs.outputs.browseros_repo }}
+          TARGET_REF: ${{ steps.build_inputs.outputs.target_ref }}
+          VERSION: ${{ steps.bump.outputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          files=("$BROWSEROS_REPO"/packages/browseros/releases/"$VERSION"/BrowserOS_*.dmg)
+          if [ "${#files[@]}" -eq 0 ]; then
+            echo "::error::No BrowserOS DMG found to publish"
+            exit 1
+          fi
+          printf 'Publishing:\n%s\n' "${files[@]}"
+
+          built_sha="$(git -C "$BROWSEROS_REPO" rev-parse HEAD)"
+          notes_file="$(mktemp)"
+          cat > "$notes_file" <<EOF
+          Automated signed BrowserOS macOS arm64 nightly for v$VERSION.
+
+          Source ref: \`$TARGET_REF\`
+          Build commit: \`$built_sha\`
+          EOF
+
+          gh release delete nightly-browseros \
+            --repo "$GITHUB_REPOSITORY" \
+            --cleanup-tag \
+            --yes || true
+          gh release create nightly-browseros \
+            --repo "$GITHUB_REPOSITORY" \
+            --prerelease \
+            --latest=false \
+            --target "$built_sha" \
+            --title "BrowserOS Nightly (signed macOS arm64) $(date -u +%Y-%m-%d)" \
+            --notes-file "$notes_file" \
+            "${files[@]}"
 
       - name: Slack failure ping
         if: ${{ failure() }}
@@ -427,7 +385,7 @@ jobs:
           if [ -z "$hook" ]; then
             exit 0
           fi
-          python3 - <<'PY' > /tmp/browseros-release-macos-slack-payload.json
+          python3 - <<'PY' > /tmp/browseros-nightly-slack-payload.json
           import json
           import os
 
@@ -435,7 +393,7 @@ jobs:
               json.dumps(
                   {
                       "text": (
-                          ":x: Release macOS build failed on "
+                          ":x: BrowserOS nightly macOS build failed on "
                           f"`{os.environ['TARGET_REF']}` - {os.environ['RUN_URL']}"
                       )
                   }
@@ -443,4 +401,4 @@ jobs:
           )
           PY
           curl -fsS -X POST -H "Content-type: application/json" \
-            --data @/tmp/browseros-release-macos-slack-payload.json "$hook" || true
+            --data @/tmp/browseros-nightly-slack-payload.json "$hook" || true

--- a/packages/browseros-agent/scripts/build/claw-server-rust-local.sh
+++ b/packages/browseros-agent/scripts/build/claw-server-rust-local.sh
@@ -1,0 +1,155 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+target="darwin-arm64"
+agent_root=""
+browseros_root=""
+
+usage() {
+  cat <<'USAGE'
+Usage: claw-server-rust-local.sh [--target darwin-arm64] [--agent-root PATH] [--browseros-root PATH]
+
+Build the local Rust BrowserClaw server and stage it in the BrowserOS resource
+layout consumed by bos_build's resources step.
+USAGE
+}
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --target)
+      target="${2:?--target requires a value}"
+      shift 2
+      ;;
+    --agent-root)
+      agent_root="${2:?--agent-root requires a value}"
+      shift 2
+      ;;
+    --browseros-root)
+      browseros_root="${2:?--browseros-root requires a value}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+case "$target" in
+  darwin-arm64) ;;
+  *)
+    echo "Unsupported local Rust staging target: $target" >&2
+    exit 2
+    ;;
+esac
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [ -z "$agent_root" ]; then
+  agent_root="$(cd "$script_dir/../.." && pwd)"
+else
+  agent_root="$(cd "$agent_root" && pwd)"
+fi
+if [ -z "$browseros_root" ]; then
+  browseros_root="$(cd "$agent_root/../browseros" && pwd)"
+else
+  browseros_root="$(cd "$browseros_root" && pwd)"
+fi
+
+binary_name="browseros-claw-server-rs"
+binary_path="$agent_root/target/release/$binary_name"
+destination="$browseros_root/resources/binaries/browseros_claw_server_rust/$target"
+
+echo "Building Rust BrowserClaw server for $target..."
+cargo build --release -p claw-server-rust --bin "$binary_name" \
+  --manifest-path "$agent_root/Cargo.toml"
+
+if [ ! -f "$binary_path" ]; then
+  echo "Missing compiled binary: $binary_path" >&2
+  exit 1
+fi
+
+export BROWSEROS_AGENT_ROOT="$agent_root"
+export BROWSEROS_ROOT="$browseros_root"
+export BROWSEROS_TARGET="$target"
+export BROWSEROS_RUST_BINARY="$binary_path"
+
+uv run --project "$browseros_root" python <<'PY'
+import hashlib
+import json
+import os
+import shutil
+import stat
+import tempfile
+import zipfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from bos_build.steps.storage.download import extract_artifact_zip
+
+browseros_root = Path(os.environ["BROWSEROS_ROOT"])
+target = os.environ["BROWSEROS_TARGET"]
+binary_path = Path(os.environ["BROWSEROS_RUST_BINARY"])
+destination = (
+    browseros_root
+    / "resources/binaries/browseros_claw_server_rust"
+    / target
+)
+stage_binary = destination / "resources/bin/browseros-claw-server-rs"
+
+if destination.exists():
+    shutil.rmtree(destination)
+stage_binary.parent.mkdir(parents=True, exist_ok=True)
+shutil.copy2(binary_path, stage_binary)
+stage_binary.chmod(0o755)
+
+files = sorted(
+    path
+    for path in destination.rglob("*")
+    if path.is_file() and path.name != "artifact-metadata.json"
+)
+metadata = {
+    "version": "local",
+    "target": target,
+    "generatedAt": datetime.now(timezone.utc)
+    .isoformat(timespec="milliseconds")
+    .replace("+00:00", "Z"),
+    "files": [
+        {
+            "path": path.relative_to(destination).as_posix(),
+            "sha256": hashlib.sha256(path.read_bytes()).hexdigest(),
+            "size": path.stat().st_size,
+        }
+        for path in files
+    ],
+}
+metadata_path = destination / "artifact-metadata.json"
+metadata_path.write_text(json.dumps(metadata, indent=2) + "\n")
+
+with tempfile.TemporaryDirectory() as tmp:
+    archive_path = Path(tmp) / "browseros-claw-server-rust-resources.zip"
+    with zipfile.ZipFile(archive_path, "w", zipfile.ZIP_DEFLATED) as archive:
+        for path in [metadata_path, *files]:
+            relative = path.relative_to(destination).as_posix()
+            info = zipfile.ZipInfo(relative)
+            info.compress_type = zipfile.ZIP_DEFLATED
+            info.external_attr = (stat.S_IMODE(path.stat().st_mode) & 0o777) << 16
+            archive.writestr(info, path.read_bytes())
+
+    validate_destination = Path(tmp) / "validated"
+    extracted = extract_artifact_zip(archive_path, validate_destination)
+    extracted_rel = sorted(
+        path.relative_to(validate_destination).as_posix() for path in extracted
+    )
+    expected = ["resources/bin/browseros-claw-server-rs"]
+    if extracted_rel != expected:
+        raise SystemExit(
+            f"Expected extracted files {expected}, got {extracted_rel}"
+        )
+
+print(f"Staged Rust BrowserClaw server resources: {destination}")
+PY

--- a/packages/browseros-agent/scripts/build/claw-server-rust-local.sh
+++ b/packages/browseros-agent/scripts/build/claw-server-rust-local.sh
@@ -61,7 +61,8 @@ else
 fi
 
 binary_name="browseros-claw-server-rs"
-binary_path="$agent_root/target/release/$binary_name"
+cargo_target_dir="${CARGO_TARGET_DIR:-$agent_root/target}"
+binary_path="$cargo_target_dir/release/$binary_name"
 destination="$browseros_root/resources/binaries/browseros_claw_server_rust/$target"
 
 echo "Building Rust BrowserClaw server for $target..."

--- a/packages/browseros/bos_build/core/planner_test.py
+++ b/packages/browseros/bos_build/core/planner_test.py
@@ -493,6 +493,20 @@ class ProfileTest(unittest.TestCase):
             plan(prof.switches, "arm64", "macos"), plan(CI, "arm64", "macos")
         )
 
+    def test_nightly_macos_profile_keeps_signed_defaults_without_downloads(self):
+        profile_path = (
+            Path(__file__).resolve().parents[1] / "profiles" / "nightly-macos.yaml"
+        )
+        switches = load_profile(profile_path).switches.resolved()
+
+        self.assertTrue(switches.clean)
+        self.assertEqual("full", switches.provision)
+        self.assertFalse(switches.download)
+        self.assertTrue(switches.sign)
+        self.assertTrue(switches.upload)
+        self.assertTrue(switches.bundle_local_extensions)
+        self.assertNotIn("download_resources", plan(switches, "arm64", "macos"))
+
     def test_arch_list(self):
         prof = self._load("preset: release\narch: [x64, arm64]\n")
         self.assertEqual(prof.switches.architectures, ("x64", "arm64"))
@@ -631,8 +645,8 @@ class PreflightTest(unittest.TestCase):
 
 class DownloadSwitchTest(unittest.TestCase):
     def test_no_download_drops_resource_download_only(self):
-        # nightly-macos-build.yml stages server resources locally and used
-        # to rewrite the yaml to drop download_resources
+        # The signed macOS nightly profile stages server resources locally
+        # and disables only download_resources.
         with_dl = plan(RELEASE, "arm64", "macos")
         without = plan(Switches(preset="release", download=False), "arm64", "macos")
         self.assertEqual([s for s in with_dl if s != "download_resources"], without)

--- a/packages/browseros/bos_build/docs/nightly-macos-ci.md
+++ b/packages/browseros/bos_build/docs/nightly-macos-ci.md
@@ -1,33 +1,120 @@
 # Nightly macOS CI
 
-This workflow builds signed BrowserOS macOS arm64 DMGs on the dedicated Mac Mini.
-It runs nightly at 04:00 UTC, can be triggered manually from any branch, bumps
-build versions, uploads the DMG to the Actions run, and leaves build lifecycle
-Slack updates to the existing BrowserOS build notifier.
+Signed macOS nightlies are two self-hosted arm64 workflows:
 
-## What It Builds
+| Workflow | Product | Schedule | Version policy | Rolling prerelease |
+| --- | --- | --- | --- | --- |
+| `.github/workflows/nightly-browseros.yml` | BrowserOS | `0 4 * * *` | Scheduled runs bump `offset+build`, commit through the bot PR flow, and merge with `[skip ci]`. | `nightly-browseros` |
+| `.github/workflows/nightly-browserclaw.yml` | BrowserClaw | `30 6 * * *` | Always builds the current version on the selected ref; it does not commit version files. | `nightly-browserclaw` |
 
-Nightly runs execute this command from the persistent build repo clone:
+Both workflows share the `macos-build` concurrency group, so only one signed
+macOS build runs on the Mac Mini at a time. The old
+`.github/workflows/nightly-macos-build.yml` workflow has been retired.
+
+## What They Build
+
+Both nightlies build tip-of-tree resources from the persistent checkout and use
+the signed nightly profile:
 
 ```bash
-uv run browseros build --preset release --arch arm64 --chromium-src "$CHROMIUM_SRC"
+uv run browseros build --profile nightly-macos --product <product> --arch arm64 \
+  --chromium-src "$CHROMIUM_SRC"
 ```
 
-Manual runs default to the same publishing config:
+The profile is `packages/browseros/bos_build/profiles/nightly-macos.yaml`:
+
+```yaml
+preset: release
+download: false
+bundle_local_extensions: true
+```
+
+Release-preset defaults still apply for clean, provisioning, signing, package,
+Sparkle signing, and upload. Set `upload_to_r2=false` in a manual dispatch to
+add `--no-upload` and keep the build artifact-only.
+
+## Local Resource Staging
+
+The nightly profile disables R2 resource downloads because nightly builds are
+intended to test the current integration from the checked-out source tree.
+
+BrowserOS stages only the resources used by BrowserOS:
 
 ```bash
-uv run browseros build --preset release --arch arm64 --chromium-src "$CHROMIUM_SRC"
+bun scripts/build/server.ts --target=darwin-arm64 --ci
+bun scripts/build/claw-onboard.ts --ci
 ```
 
-Set `upload_to_r2=false` in the manual dispatch form to run an artifact-only
-build without publishing to R2.
+The workflow extracts those artifact zips through
+`bos_build.steps.storage.download.extract_artifact_zip` into:
+
+```text
+packages/browseros/resources/binaries/browseros_server/darwin-arm64
+packages/browseros/resources/binaries/browseros_claw_onboard
+```
+
+BrowserClaw stages the shared BrowserOS server bundle, the product-independent
+onboarding bundle, and the selected Claw server variant. The selected variant
+comes from
+`packages/browseros/bos_build/config/build_flags.yaml`.
+
+When `use_claw_server_rust: true`, the workflow runs:
+
+```bash
+packages/browseros-agent/scripts/build/claw-server-rust-local.sh \
+  --target darwin-arm64 \
+  --agent-root packages/browseros-agent \
+  --browseros-root packages/browseros
+```
+
+That helper builds the Rust server natively with Cargo and stages:
+
+```text
+packages/browseros/resources/binaries/browseros_claw_server_rust/darwin-arm64/
+  artifact-metadata.json
+  resources/bin/browseros-claw-server-rs
+```
+
+The normal resources step then copies this root into Chromium and renames
+`browseros-claw-server-rs` to the runtime name `browseros-claw-server`.
+
+When `use_claw_server_rust: false`, BrowserClaw falls back to:
+
+```bash
+bun scripts/build/claw-server.ts --target=darwin-arm64 --ci
+```
+
+and extracts the TypeScript/Bun resource zip into
+`resources/binaries/browseros_claw_server/darwin-arm64`.
+
+## Bundled Extensions
+
+`bundle_local_extensions: true` makes the `bundled_extensions` step build
+in-repo required extensions from the checkout while external required
+extensions still come from the CDN manifest. The build system loads
+`packages/browseros/.env` on import, so the runner-local PEM values such as
+`BROWSEROS_AGENT_V2_KEY` and `BROWSERCLAW_KEY` do not need to be exported in the
+workflow.
+
+Chrome must be installed on the Mac Mini because CRX packing resolves a Chrome
+binary locally.
 
 ## Release macOS Workflow
 
 `release-macos.yml` uses the same private Mac Mini, signing keychain, local
-`packages/browseros/.env`, Chromium checkout, and server-resource staging path
-as the nightly workflow. It has no schedule; run it manually with
-`workflow_dispatch` or call it from another workflow with `workflow_call`.
+`packages/browseros/.env`, and Chromium checkout. Unlike nightlies, releases do
+not build tip-of-tree server bundles. They run the normal release preset and let
+`download_resources` fetch the published R2 bundles:
+
+```bash
+uv run browseros build --preset release --product <product> --arch <arch> \
+  --chromium-src "$CHROMIUM_SRC"
+```
+
+For BrowserClaw, the downloaded Claw server bundle follows the same
+`use_claw_server_rust` flag: Rust resources come from
+`claw-server-rust/prod-resources/latest/`, and the TypeScript/Bun fallback comes
+from `claw-server/prod-resources/latest/`.
 
 Release runs default to rebuilding the current version files without bumping
 them:
@@ -43,29 +130,7 @@ arch=arm64
 Use `products=browserclaw` to build only BrowserClaw, or `products=all` to
 build BrowserOS first and BrowserClaw second in the same job. The workflow also
 accepts `arch=universal`; universal and two-product runs use a longer timeout
-because they run multiple Chromium build/package passes sequentially on the same
-machine.
-
-The release workflow stages all macOS server bundles locally before packaging,
-regardless of the selected product:
-
-```bash
-bun scripts/build/server.ts --target=darwin-arm64 --ci
-bun scripts/build/claw-server.ts --target=darwin-arm64 --ci
-bun scripts/build/claw-onboard.ts --ci
-```
-
-Each selected product then runs:
-
-```bash
-uv run browseros build --preset release --product <product> --arch <arch> \
-  --no-download --chromium-src "$CHROMIUM_SRC"
-```
-
-Set `upload_to_r2=false` to add `--no-upload` for artifact-only release
-verification. Signing, notarization, R2, and Slack values still come from the
-runner-local `packages/browseros/.env`; do not add those secrets to GitHub
-Actions.
+because they run multiple Chromium build/package passes sequentially.
 
 ## One-Time Runner Setup
 
@@ -80,15 +145,15 @@ cd ~/actions-runner
   --labels browseros-builder --name mac-mini-builder --work _work
 ```
 
-The workflow targets:
+The workflows target:
 
 ```yaml
 runs-on: [self-hosted, macOS, ARM64, browseros-builder]
 ```
 
 Run the service in the logged-in GUI user session, not as a boot-time daemon.
-Codesign and `xcrun notarytool` need access to the user's login keychain; daemon
-or SSH-only sessions commonly fail with `User interaction not allowed`.
+Codesign and `xcrun notarytool` need access to the user's login keychain;
+daemon or SSH-only sessions commonly fail with `User interaction not allowed`.
 
 ```bash
 ./svc.sh install
@@ -105,7 +170,7 @@ printf '%s\n' "$HOME/code/depot_tools:/opt/homebrew/bin:/usr/local/bin:$PATH" \
 ./svc.sh start
 ```
 
-Keep the runner current enough to run the action majors used by the workflow.
+Keep the runner current enough to run the action majors used by the workflows.
 
 ## Machine Prerequisites
 
@@ -113,12 +178,15 @@ The Mac Mini must already have:
 
 - Build repo clone, for example `/Users/<user>/code/browseros-release`
 - Chromium checkout, for example `/Users/<user>/code/chromium-release/src`
-- `uv`, `gh`, depot_tools, Xcode Command Line Tools, and signing/notarization tooling
-- `packages/browseros/.env` with signing, notarization, R2, and Slack values
+- `uv`, `gh`, `bun`, depot_tools, Xcode Command Line Tools, and signing/notarization tooling
+- Homebrew Cargo available on PATH for the BrowserClaw Rust nightly
+- Chrome installed for local CRX packing
+- `packages/browseros/.env` with signing, notarization, R2, Slack, and extension PEM values
 - `MACOS_KEYCHAIN_PASSWORD` in `.env` so the build can unlock the keychain
 
-Do not copy signing, notarization, R2, or Slack secrets into GitHub Actions.
-The workflow reuses the machine-local `.env`.
+Do not copy signing, notarization, R2, Slack, or extension PEM secrets into
+GitHub Actions for the self-hosted macOS nightlies. The workflows reuse the
+machine-local `.env`.
 
 ## Repository Variables
 
@@ -132,22 +200,25 @@ Add these in GitHub repo settings under Actions variables:
 
 ## Version Policy
 
-The workflow calls `build/scripts/bump_version.py`.
+Only the BrowserOS nightly calls `bos_build/scripts/bump_version.py` with a
+mutable bump mode.
 
-- Nightly schedule: 04:00 UTC, `offset+build`, commit and push enabled, R2 upload enabled
-- Manual dispatch default: `offset+build`, commit disabled, R2 upload enabled
-- Manual hotfix option: choose `offset+patch`
-- Manual dry run option: choose `none`
+- BrowserOS schedule: 04:00 UTC, `offset+build`, commit and push enabled, R2 upload enabled
+- BrowserOS manual default: `offset+build`, commit disabled, R2 upload enabled
+- BrowserOS manual hotfix option: choose `offset+patch`
+- BrowserOS manual dry run option: choose `none`
+- BrowserClaw schedule and manual runs: `none`; no version commit machinery
 
-04:00 UTC is 9 PM US Pacific during daylight saving time. GitHub cron schedules
-are UTC-only and do not track daylight saving changes.
+04:00 UTC is 9 PM US Pacific during daylight saving time. 06:30 UTC is 11:30 PM
+US Pacific during daylight saving time. GitHub cron schedules are UTC-only and
+do not track daylight saving changes.
 
 `BROWSEROS_BUILD_OFFSET` is the internal Chromium-build monotonic counter.
 `BROWSEROS_BUILD` advances the public nightly semantic version. `BROWSEROS_PATCH`
 is reserved for manual hotfix-style builds because setting both build and patch
 nonzero produces a four-part version.
 
-Nightly version commits use:
+BrowserOS nightly version commits use:
 
 ```text
 chore(release): build v<VERSION> [skip ci]
@@ -159,47 +230,47 @@ squash merge, then auto-merge, and leaves the PR open if GitHub will not merge i
 yet. The persistent clone must already have credentials that can push bot
 branches. The workflow's `GITHUB_TOKEN` has `contents: write` and
 `pull-requests: write` for the build job so it can create and merge those PRs.
-The workflow stages current macOS arm64 server resource archives locally before
-packaging, then skips the R2 resource download module for that build run.
 
 ## Manual Branch Build
 
-Open Actions, choose `Nightly: macOS Browser (signed, self-hosted)`, click
-`Run workflow`, select the branch in GitHub's native branch picker, then set
-inputs:
+Open Actions, choose the product workflow, click `Run workflow`, select the
+branch in GitHub's native branch picker, then set inputs:
 
-- `bump`: `offset-only`, `offset+build`, `offset+patch`, or `none`
-- `commit_version`: commit and push the bumped version files
-- `upload_to_r2`: publish to R2/CDN after packaging, enabled by default
+- BrowserOS: `bump`, `commit_version`, and `upload_to_r2`
+- BrowserClaw: `upload_to_r2`
 
-Manual dispatch requires approval through the `release-core` environment.
-Scheduled nightly runs bypass that approval job and run automatically.
-
-The DMG is always uploaded as a run artifact when packaging succeeds.
+The DMG is always uploaded as a run artifact when packaging succeeds. Successful
+builds also refresh the product's rolling prerelease tag.
 
 ## Artifacts
 
-The build writes:
+The builds write:
 
 ```text
 packages/browseros/releases/<version>/BrowserOS_v<version>_arm64.dmg
+packages/browseros/releases/<version>/BrowserClaw_v<version>_arm64.dmg
 ```
 
-The workflow uploads matching DMGs as `BrowserOS_v<version>_arm64` with
-14-day retention.
+The workflows upload matching DMGs with 14-day retention and refresh:
+
+```text
+nightly-browseros
+nightly-browserclaw
+```
+
+Both GitHub releases are rolling prereleases created with `--latest=false`.
 
 ## Slack
 
-When `SLACK_WEBHOOK_URL` is present in `.env`, the build posts one terse
-phase narrative for each run. The first message announces the product,
-version, OS/arch, and planned phases. Each later phase transition posts one
-humanized duration message, such as `✅ Build done (83m 26s) → Sign`.
-The terminal message is always sent synchronously: `🏁` success includes R2
-artifact links when upload ran, `❌` failure names the failing step and error,
-and `🛑` interrupt names the interrupted step. With no webhook configured,
+When `SLACK_WEBHOOK_URL` is present in `.env`, the build posts one terse phase
+narrative for each run. The first message announces the product, version,
+OS/arch, and planned phases. Each later phase transition posts one humanized
+duration message. The terminal message is always sent synchronously: success
+includes R2 artifact links when upload ran, failure names the failing step and
+error, and interrupt names the interrupted step. With no webhook configured,
 Slack notification is a silent no-op.
 
-The workflow only adds a CI-level failure ping for failures that happen before
+The workflows only add a CI-level failure ping for failures that happen before
 or around the build invocation, such as missing runner variables or sync errors.
 
 ## Troubleshooting
@@ -207,15 +278,15 @@ or around the build invocation, such as missing runner variables or sync errors.
 `User interaction not allowed`: run the runner as the logged-in GUI user and
 confirm `MACOS_KEYCHAIN_PASSWORD` is present in `packages/browseros/.env`.
 
-`uv`, `gclient`, `gn`, or `autoninja` not found: update `~/actions-runner/.path`
-and restart the runner service.
+`uv`, `gclient`, `gn`, `autoninja`, `bun`, `cargo`, or `chrome` not found:
+update `~/actions-runner/.path` and restart the runner service.
 
 Artifact-only manual run: set `upload_to_r2=false` to package the DMG without
 publishing it to R2.
 
-No version commit: check `commit_version`, the selected bump mode, the
-persistent clone's branch push credentials, and any open
+No BrowserOS version commit: check `commit_version`, the selected bump mode,
+the persistent clone's branch push credentials, and any open
 `bot/nightly-macos-version-*` PR.
 
 Long runtime: the release pipeline resets the Chromium tree and wipes
-`out/Default_arm64`, so multi-hour runs are expected.
+`out/Default_*`, so multi-hour runs are expected.

--- a/packages/browseros/bos_build/docs/nightly-warpbuild-ci.md
+++ b/packages/browseros/bos_build/docs/nightly-warpbuild-ci.md
@@ -7,9 +7,9 @@ run, and refreshes a rolling `nightly` prerelease on GitHub. Its per-platform
 build job delegates to the reusable Chromium build workflow in
 `.github/workflows/build-browseros.yml`, so the WarpBuild checkout/cache/build
 recipe is shared with the release workflows.
-It complements (does not replace) the signed self-hosted macOS nightly in
-`nightly-macos-build.yml`; once signing is wired up here, that workflow can
-be retired.
+It complements the signed self-hosted macOS product nightlies in
+`nightly-browseros.yml` and `nightly-browserclaw.yml`. Those dedicated Mac Mini
+workflows are the signed daily-test path for macOS arm64.
 
 ## Runners
 

--- a/packages/browseros/bos_build/docs/release-ci.md
+++ b/packages/browseros/bos_build/docs/release-ci.md
@@ -44,7 +44,7 @@ macOS builder.
 | `.github/workflows/release-extensions.yml` | Builds, signs, uploads, and optionally republishes extension CRX manifests for `agent`, `controller`, `bugreporter`, and `browserclaw`. | Manual and reusable | No; per-product orchestrators can call it with `secrets: inherit` |
 | `.github/workflows/release-linux.yml` | Builds Linux x64 browser artifacts on WarpBuild, one matrix entry per selected product. | Manual | Yes |
 | `.github/workflows/release-windows.yml` | Builds Windows x64 browser artifacts on WarpBuild and optionally signs them. | Manual | Yes |
-| `.github/workflows/release-macos.yml` | Builds signed macOS artifacts on the dedicated self-hosted builder. | Manual | Yes |
+| `.github/workflows/release-macos.yml` | Builds signed macOS artifacts on the dedicated self-hosted builder and downloads published server/onboard resource bundles from R2. | Manual | Yes |
 | `.github/workflows/release-full.yml` | Orchestrates servers, selected browser platforms, and draft GitHub release asset creation. | Manual only | No reusable entry point |
 
 Browser artifacts use the BrowserOS browser version from
@@ -72,17 +72,25 @@ The browser build downloads only the selected BrowserClaw variant. BrowserClaw
 server OTA feeds (`appcast-claw-server*.xml`) remain pinned to the TypeScript
 server bundle until a separate feed migration changes them.
 
+`release-macos.yml` follows this release rule too: it does not build server
+resources from the checked-out `packages/browseros-agent` tree. Its browser
+build command leaves downloads enabled, so `download_resources` fetches the
+published BrowserOS server bundle, selected BrowserClaw server bundle, and
+onboarding bundle from R2 using the runner-local `packages/browseros/.env` R2
+credentials.
+
 The reusable nesting depth is `release-full.yml -> release-linux.yml or
 release-windows.yml -> build-browseros.yml`, which stays below GitHub's limit
 of four workflow levels.
 
 The `bundle_local_extensions` profile switch defaults off for release
-reproducibility. Existing CI profiles keep it off; a self-hosted macOS nightly
-profile can set it true to build and pack in-repo agent/browserclaw CRXs from
-the checked-out tree while external required extensions still come from the
-bundled CDN manifest. Reusable `build-browseros.yml` callers enabling such a
-profile must also pass `bundle-local-extensions: true` so Bun and extension
-signing/build env are prepared.
+reproducibility. Release CI profiles keep it off and consume published extension
+bundles. The self-hosted macOS nightly profile sets it true to build and pack
+in-repo agent/browserclaw CRXs from the checked-out tree while external required
+extensions still come from the bundled CDN manifest. Reusable
+`build-browseros.yml` callers enabling such a profile must also pass
+`bundle-local-extensions: true` so Bun and extension signing/build env are
+prepared.
 
 ## Full Release Inputs
 
@@ -172,7 +180,8 @@ Rules of thumb:
   can take 6 to 20 hours for all products or universal builds.
 - `preempt_nightly=true` cancels only queued or in-progress
   `.github/workflows/nightly-release.yml` runs. It does not cancel
-  `Nightly: macOS Browser (signed, self-hosted)`; the shared `macos-build`
+  `.github/workflows/nightly-browseros.yml` or
+  `.github/workflows/nightly-browserclaw.yml`; the shared `macos-build`
   concurrency group serializes self-hosted macOS work.
 
 ## Draft GitHub Release

--- a/packages/browseros/bos_build/profiles/nightly-macos.yaml
+++ b/packages/browseros/bos_build/profiles/nightly-macos.yaml
@@ -1,0 +1,3 @@
+preset: release
+download: false
+bundle_local_extensions: true


### PR DESCRIPTION
## Summary
- Split the signed self-hosted macOS nightly into BrowserOS and BrowserClaw arm64 workflows with per-product rolling prereleases.
- Added the signed nightly profile plus a Rust BrowserClaw local staging helper that validates the artifact layout through extract_artifact_zip.
- Updated release-macos so releases download published server/onboard bundles from R2 instead of staging tip-of-tree local bundles.
- Updated macOS nightly/release docs for the new split, local extension bundling, Rust variant staging, and release download behavior.

## Verification
- `actionlint .github/workflows/nightly-browseros.yml .github/workflows/nightly-browserclaw.yml .github/workflows/release-macos.yml`
- `uv run --project packages/browseros ruff check packages/browseros/bos_build`
- `cd packages/browseros && uv run python -m unittest discover -s bos_build -t . -p '*_test.py'` (655 tests after merging current main)
- `CARGO_TARGET_DIR=packages/browseros-agent/target packages/browseros-agent/scripts/build/claw-server-rust-local.sh --target darwin-arm64 --agent-root packages/browseros-agent --browseros-root packages/browseros` (cargo build completed; staged metadata + resources/bin/browseros-claw-server-rs; generated staging dir removed afterward)
- BrowserClaw variant flag read smoke test with `uv --quiet run --project packages/browseros python` printed `true`
- `uv run --project packages/browseros browseros build --show-plan --profile nightly-macos --product browseros --arch arm64`
- `uv run --project packages/browseros browseros build --show-plan --profile nightly-macos --product browserclaw --arch arm64`

## BrowserOS show-plan
```text
Preset plan: preset=release product=browseros platform=macos
Switches: clean=True provision=full download=False sign=True upload=True bundle_local_extensions=True

arm64 (15 steps):
   1. clean
   2. git_setup
   3. sparkle_setup
   4. resources
   5. bundled_extensions
   6. chromium_replace
   7. string_replaces
   8. series_patches
   9. patches
  10. configure
  11. compile
  12. sign_macos
  13. package_macos
  14. sparkle_sign
  15. upload

Required env (arm64):
  MACOS_CERTIFICATE_NAME  ✗ MISSING
  PROD_MACOS_NOTARIZATION_APPLE_ID  ✗ MISSING
  PROD_MACOS_NOTARIZATION_TEAM_ID  ✗ MISSING
  PROD_MACOS_NOTARIZATION_PWD  ✗ MISSING
  SPARKLE_PRIVATE_KEY  ✗ MISSING
```

## BrowserClaw show-plan
```text
Preset plan: preset=release product=browserclaw platform=macos
Switches: clean=True provision=full download=False sign=True upload=True bundle_local_extensions=True

arm64 (15 steps):
   1. clean
   2. git_setup
   3. sparkle_setup
   4. resources
   5. bundled_extensions
   6. chromium_replace
   7. string_replaces
   8. series_patches
   9. patches
  10. configure
  11. compile
  12. sign_macos
  13. package_macos
  14. sparkle_sign
  15. upload

Required env (arm64):
  MACOS_CERTIFICATE_NAME  ✗ MISSING
  PROD_MACOS_NOTARIZATION_APPLE_ID  ✗ MISSING
  PROD_MACOS_NOTARIZATION_TEAM_ID  ✗ MISSING
  PROD_MACOS_NOTARIZATION_PWD  ✗ MISSING
  SPARKLE_PRIVATE_KEY  ✗ MISSING
```