### PR TITLE
fix(ci): fetch CodeSignTool from SSLcom GitHub releases

### DIFF
--- a/.github/workflows/build-browseros.yml
+++ b/.github/workflows/build-browseros.yml
@@ -245,7 +245,9 @@ jobs:
         shell: pwsh
         run: |
           $ErrorActionPreference = 'Stop'
-          $uri = 'https://app.esigner.com/files/CodeSignTool-v1-3-2-windows/3954004a/download'
+          # Canonical source: the app.esigner.com file endpoint rejects the
+          # runner's Invoke-WebRequest (run 28835010397, OperationStopped).
+          $uri = 'https://github.com/SSLcom/CodeSignTool/releases/download/v1.3.2/CodeSignTool-v1.3.2-windows.zip'
           $zipPath = Join-Path $env:RUNNER_TEMP 'CodeSignTool-v1.3.2-windows.zip'
           $extractRoot = Join-Path $env:RUNNER_TEMP 'CodeSignTool-v1.3.2-windows'
           Invoke-WebRequest -Uri $uri -OutFile $zipPath


### PR DESCRIPTION
First signed windows run (28835010397) compiled fully, then died installing CodeSignTool: the hardcoded app.esigner.com endpoint returns OperationStopped to the runner's Invoke-WebRequest (works from curl — likely UA/JS gating). Pin the canonical GitHub release asset `SSLcom/CodeSignTool v1.3.2` instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)