### PR TITLE
Surface MCP dialogs and console errors

### DIFF
--- a/packages/browseros-agent/crates/browseros-core/src/lib.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod frames;
 pub mod input;
 pub mod navigation;
 pub mod observer;
+pub mod page_signals;
 pub mod pages;
 pub mod screenshot;
 pub mod settle;
@@ -17,6 +18,7 @@ pub mod windows;
 pub use browser::Browser;
 pub use connection::{CdpConnection, ProtocolSession};
 pub use error::CoreError;
+pub use page_signals::{ConsoleEntry, ConsoleLevel, PageDialog, PageSignals};
 pub use session::{BrowserSession, BrowserSessionHooks};
 pub use types::{FrameId, PageId, Ref, SessionId, TabId, TargetId, WindowId};
 

--- a/packages/browseros-agent/crates/browseros-core/src/navigation.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/navigation.rs
@@ -1,33 +1,42 @@
-use crate::{CoreError, PageId, ProtocolSession, pages::PageManager, timeouts};
+use crate::{
+    CoreError, PageId, ProtocolSession, page_signals::PageSignals, pages::PageManager, timeouts,
+};
 use serde::Deserialize;
 use serde_json::{Value, json};
 use std::sync::Arc;
-use tokio::time::sleep;
+use tokio::time::{sleep, timeout};
 
 pub struct Navigation {
     pages: Arc<PageManager>,
+    page_signals: Arc<PageSignals>,
     page_id: PageId,
 }
 
 impl Navigation {
     #[must_use]
-    pub fn new(pages: Arc<PageManager>, page_id: PageId) -> Self {
-        Self { pages, page_id }
+    pub fn new(pages: Arc<PageManager>, page_signals: Arc<PageSignals>, page_id: PageId) -> Self {
+        Self {
+            pages,
+            page_signals,
+            page_id,
+        }
     }
 
     pub async fn goto(&self, url: &str) -> Result<(), CoreError> {
+        self.throw_if_dialog_open()?;
         let page = self.pages.get_session(self.page_id.clone()).await?;
         let _: Value = page
             .session
             .send("Page.navigate", json!({ "url": url }))
             .await?;
-        wait_for_load(&page.session).await
+        wait_for_load(&page.session, &self.page_signals, &self.page_id).await
     }
 
     pub async fn reload(&self) -> Result<(), CoreError> {
+        self.throw_if_dialog_open()?;
         let page = self.pages.get_session(self.page_id.clone()).await?;
         let _: Value = page.session.send("Page.reload", json!({})).await?;
-        wait_for_load(&page.session).await
+        wait_for_load(&page.session, &self.page_signals, &self.page_id).await
     }
 
     pub async fn back(&self) -> Result<(), CoreError> {
@@ -39,6 +48,7 @@ impl Navigation {
     }
 
     async fn history(&self, direction: &str) -> Result<(), CoreError> {
+        self.throw_if_dialog_open()?;
         let page = self.pages.get_session(self.page_id.clone()).await?;
         let _: Value = page
             .session
@@ -47,7 +57,15 @@ impl Navigation {
                 json!({ "expression": format!("history.{direction}()"), "awaitPromise": true }),
             )
             .await?;
-        wait_for_load(&page.session).await
+        wait_for_load(&page.session, &self.page_signals, &self.page_id).await
+    }
+
+    fn throw_if_dialog_open(&self) -> Result<(), CoreError> {
+        if let Some(message) = self.page_signals.pending_dialog_line(&self.page_id) {
+            Err(CoreError::Message(message))
+        } else {
+            Ok(())
+        }
     }
 }
 
@@ -61,17 +79,26 @@ struct RemoteObject {
     value: Option<Value>,
 }
 
-async fn wait_for_load(session: &ProtocolSession) -> Result<(), CoreError> {
+async fn wait_for_load(
+    session: &ProtocolSession,
+    page_signals: &PageSignals,
+    page_id: &PageId,
+) -> Result<(), CoreError> {
     sleep(timeouts::WAIT_FOR_CONNECTION_POLL).await;
     let deadline = tokio::time::Instant::now() + timeouts::WAIT_FOR_LOAD_TIMEOUT;
     while tokio::time::Instant::now() < deadline {
-        let result = session
-            .send::<_, EvaluateResult>(
+        if let Some(message) = page_signals.pending_dialog_line(page_id) {
+            return Err(CoreError::Message(message));
+        }
+        let result = timeout(
+            timeouts::ACTION_SETTLE_CDP_CALL_TIMEOUT,
+            session.send::<_, EvaluateResult>(
                 "Runtime.evaluate",
                 json!({ "expression": "document.readyState", "returnByValue": true }),
-            )
-            .await;
-        if let Ok(result) = result
+            ),
+        )
+        .await;
+        if let Ok(Ok(result)) = result
             && result.result.value.as_ref().and_then(Value::as_str) == Some("complete")
         {
             return Ok(());

--- a/packages/browseros-agent/crates/browseros-core/src/page_signals.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/page_signals.rs
@@ -1,0 +1,713 @@
+use crate::{PageId, SessionId, connection::CdpConnection};
+use browseros_cdp::CdpEvent;
+use serde_json::{Value, json};
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::{Arc, Mutex, MutexGuard},
+};
+use tokio::sync::broadcast;
+use tracing::{debug, warn};
+
+const CONSOLE_RING_CAPACITY: usize = 50;
+const ALERT_NOTE_CAPACITY: usize = 10;
+const SUMMARY_TEXT_MAX_CHARS: usize = 240;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PageDialog {
+    pub kind: String,
+    pub message: String,
+    pub default_prompt: Option<String>,
+    pub url: Option<String>,
+}
+
+impl PageDialog {
+    #[must_use]
+    pub fn is_alert(&self) -> bool {
+        self.kind == "alert"
+    }
+
+    #[must_use]
+    pub fn line(&self, page_id: &PageId) -> String {
+        let mut line = format!(
+            "[page {} dialog open] {}: {}",
+            page_id.0,
+            self.kind,
+            quote(&self.message)
+        );
+        if self.kind == "prompt"
+            && let Some(default_prompt) = self
+                .default_prompt
+                .as_deref()
+                .filter(|value| !value.is_empty())
+        {
+            line.push_str(&format!(" (default: {})", quote(default_prompt)));
+        }
+        line.push_str(
+            " - use act kind=\"dialog_accept\" or \"dialog_dismiss\" before other actions on this page.",
+        );
+        line
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConsoleLevel {
+    Warning,
+    Error,
+    Exception,
+}
+
+impl ConsoleLevel {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Warning => "warning",
+            Self::Error => "error",
+            Self::Exception => "exception",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConsoleEntry {
+    pub sequence: u64,
+    pub level: ConsoleLevel,
+    pub text: String,
+    pub source: Option<String>,
+    pub line: Option<u64>,
+    pub column: Option<u64>,
+}
+
+impl ConsoleEntry {
+    #[must_use]
+    pub fn line(&self) -> String {
+        let mut line = format!("{}: {}", self.level.as_str(), compact_text(&self.text));
+        if let Some(location) = self.location() {
+            line.push_str(&format!(" ({location})"));
+        }
+        line
+    }
+
+    #[must_use]
+    pub fn summary_text(&self) -> String {
+        compact_text(&clamp_chars(&self.text, SUMMARY_TEXT_MAX_CHARS))
+    }
+
+    #[must_use]
+    pub fn is_warning(&self) -> bool {
+        self.level == ConsoleLevel::Warning
+    }
+
+    fn location(&self) -> Option<String> {
+        let source = self.source.as_deref().filter(|source| !source.is_empty())?;
+        Some(match self.line {
+            Some(line) => format!("{source}:{line}"),
+            None => source.to_string(),
+        })
+    }
+}
+
+#[derive(Default)]
+struct PageSignalState {
+    pending_dialog: Option<PageDialog>,
+    alert_notes: VecDeque<String>,
+    console_entries: VecDeque<ConsoleEntry>,
+    next_console_sequence: u64,
+}
+
+#[derive(Default)]
+struct SignalsState {
+    sessions: HashMap<SessionId, PageId>,
+    pages: HashMap<PageId, PageSignalState>,
+}
+
+pub struct PageSignals {
+    cdp: Arc<dyn CdpConnection>,
+    state: Mutex<SignalsState>,
+}
+
+impl PageSignals {
+    #[must_use]
+    pub fn new(cdp: Arc<dyn CdpConnection>) -> Arc<Self> {
+        let signals = Arc::new(Self {
+            cdp,
+            state: Mutex::new(SignalsState::default()),
+        });
+        Self::spawn_event_listener(signals.clone());
+        signals
+    }
+
+    pub fn attach_page(&self, page_id: PageId, session_id: SessionId) {
+        let mut state = self.state();
+        state
+            .pages
+            .entry(page_id.clone())
+            .or_default()
+            .pending_dialog = None;
+        state.sessions.insert(session_id, page_id);
+    }
+
+    pub fn detach_session(&self, session_id: &SessionId) {
+        let mut state = self.state();
+        let Some(page_id) = state.sessions.remove(session_id) else {
+            return;
+        };
+        if let Some(page) = state.pages.get_mut(&page_id) {
+            page.pending_dialog = None;
+        }
+    }
+
+    pub fn forget_page(&self, page_id: &PageId) {
+        let mut state = self.state();
+        state.sessions.retain(|_, existing| existing != page_id);
+        state.pages.remove(page_id);
+    }
+
+    #[must_use]
+    pub fn pending_dialog(&self, page_id: &PageId) -> Option<PageDialog> {
+        self.state()
+            .pages
+            .get(page_id)
+            .and_then(|page| page.pending_dialog.clone())
+    }
+
+    #[must_use]
+    pub fn pending_dialog_line(&self, page_id: &PageId) -> Option<String> {
+        self.pending_dialog(page_id)
+            .map(|dialog| dialog.line(page_id))
+    }
+
+    pub fn clear_dialog(&self, page_id: &PageId) {
+        if let Some(page) = self.state().pages.get_mut(page_id) {
+            page.pending_dialog = None;
+        }
+    }
+
+    #[must_use]
+    pub fn console_mark(&self, page_id: &PageId) -> u64 {
+        self.state()
+            .pages
+            .get(page_id)
+            .map(|page| page.next_console_sequence)
+            .unwrap_or(0)
+    }
+
+    #[must_use]
+    pub fn console_entries(&self, page_id: &PageId) -> Vec<ConsoleEntry> {
+        self.state()
+            .pages
+            .get(page_id)
+            .map(|page| page.console_entries.iter().cloned().collect())
+            .unwrap_or_default()
+    }
+
+    #[must_use]
+    pub fn console_entries_since(&self, page_id: &PageId, sequence: u64) -> Vec<ConsoleEntry> {
+        self.state()
+            .pages
+            .get(page_id)
+            .map(|page| {
+                page.console_entries
+                    .iter()
+                    .filter(|entry| entry.sequence >= sequence)
+                    .cloned()
+                    .collect()
+            })
+            .unwrap_or_default()
+    }
+
+    pub fn take_alert_note_lines(&self, page_id: &PageId) -> Vec<String> {
+        let mut state = self.state();
+        let Some(page) = state.pages.get_mut(page_id) else {
+            return Vec::new();
+        };
+        page.alert_notes
+            .drain(..)
+            .map(|message| {
+                format!(
+                    "[page {} dismissed an alert: {}]",
+                    page_id.0,
+                    quote(&message)
+                )
+            })
+            .collect()
+    }
+
+    fn spawn_event_listener(signals: Arc<Self>) {
+        let mut events = signals.cdp.events();
+        tokio::spawn(async move {
+            loop {
+                match events.recv().await {
+                    Ok(event) => signals.handle_event(event).await,
+                    Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                        warn!("browser page signal listener lagged by {skipped} CDP event(s)");
+                    }
+                    Err(broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+    }
+
+    async fn handle_event(&self, event: CdpEvent) {
+        match event.method.as_str() {
+            "Page.javascriptDialogOpening" => self.handle_dialog_opening(event).await,
+            "Page.javascriptDialogClosed" => self.handle_dialog_closed(event),
+            "Runtime.consoleAPICalled" => self.handle_console_api_called(event),
+            "Runtime.exceptionThrown" => self.handle_exception_thrown(event),
+            _ => {}
+        }
+    }
+
+    async fn handle_dialog_opening(&self, event: CdpEvent) {
+        let Some((page_id, session_id)) = self.page_for_event(&event) else {
+            return;
+        };
+        let dialog = dialog_from_params(&event.params);
+        if dialog.is_alert() {
+            self.record_alert_note(&page_id, dialog.message.clone());
+            self.accept_alert(session_id).await;
+            return;
+        }
+        let mut state = self.state();
+        state.pages.entry(page_id).or_default().pending_dialog = Some(dialog);
+    }
+
+    fn handle_dialog_closed(&self, event: CdpEvent) {
+        let Some((page_id, _session_id)) = self.page_for_event(&event) else {
+            return;
+        };
+        self.clear_dialog(&page_id);
+    }
+
+    fn handle_console_api_called(&self, event: CdpEvent) {
+        let Some((page_id, _session_id)) = self.page_for_event(&event) else {
+            return;
+        };
+        let Some(entry) = console_entry_from_params(&event.params) else {
+            return;
+        };
+        self.push_console_entry(&page_id, entry);
+    }
+
+    fn handle_exception_thrown(&self, event: CdpEvent) {
+        let Some((page_id, _session_id)) = self.page_for_event(&event) else {
+            return;
+        };
+        let entry = exception_entry_from_params(&event.params);
+        self.push_console_entry(&page_id, entry);
+    }
+
+    fn page_for_event(&self, event: &CdpEvent) -> Option<(PageId, SessionId)> {
+        let session_id = event.session_id.clone()?;
+        let page_id = self.state().sessions.get(&session_id).cloned()?;
+        Some((page_id, session_id))
+    }
+
+    async fn accept_alert(&self, session_id: SessionId) {
+        let result = self
+            .cdp
+            .send(
+                "Page.handleJavaScriptDialog",
+                json!({ "accept": true }),
+                Some(&session_id),
+            )
+            .await;
+        if let Err(err) = result {
+            debug!("failed to auto-accept JavaScript alert: {err}");
+        }
+    }
+
+    fn record_alert_note(&self, page_id: &PageId, message: String) {
+        let mut state = self.state();
+        let page = state.pages.entry(page_id.clone()).or_default();
+        page.pending_dialog = None;
+        if page.alert_notes.len() == ALERT_NOTE_CAPACITY {
+            page.alert_notes.pop_front();
+        }
+        page.alert_notes.push_back(message);
+    }
+
+    fn push_console_entry(&self, page_id: &PageId, mut entry: ConsoleEntry) {
+        let mut state = self.state();
+        let page = state.pages.entry(page_id.clone()).or_default();
+        entry.sequence = page.next_console_sequence;
+        page.next_console_sequence = page.next_console_sequence.saturating_add(1);
+        if page.console_entries.len() == CONSOLE_RING_CAPACITY {
+            page.console_entries.pop_front();
+        }
+        page.console_entries.push_back(entry);
+    }
+
+    fn state(&self) -> MutexGuard<'_, SignalsState> {
+        self.state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+    }
+}
+
+fn dialog_from_params(params: &Value) -> PageDialog {
+    PageDialog {
+        kind: params
+            .get("type")
+            .and_then(Value::as_str)
+            .unwrap_or("dialog")
+            .to_string(),
+        message: params
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or_default()
+            .to_string(),
+        default_prompt: params
+            .get("defaultPrompt")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        url: params
+            .get("url")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+    }
+}
+
+fn console_entry_from_params(params: &Value) -> Option<ConsoleEntry> {
+    let level = match params.get("type").and_then(Value::as_str) {
+        Some("warning") => ConsoleLevel::Warning,
+        Some("error") => ConsoleLevel::Error,
+        _ => return None,
+    };
+    let text = params
+        .get("args")
+        .and_then(Value::as_array)
+        .map(|args| {
+            args.iter()
+                .map(remote_object_text)
+                .filter(|value| !value.is_empty())
+                .collect::<Vec<_>>()
+                .join(" ")
+        })
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| {
+            params
+                .get("type")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string()
+        });
+    let (source, line, column) = stack_location(params.get("stackTrace"));
+    Some(ConsoleEntry {
+        sequence: 0,
+        level,
+        text,
+        source,
+        line,
+        column,
+    })
+}
+
+fn exception_entry_from_params(params: &Value) -> ConsoleEntry {
+    let details = params.get("exceptionDetails").unwrap_or(params);
+    let text = details
+        .get("exception")
+        .and_then(|exception| {
+            exception
+                .get("description")
+                .or_else(|| exception.get("value"))
+                .map(remote_object_text)
+        })
+        .filter(|value| !value.is_empty())
+        .or_else(|| {
+            details
+                .get("text")
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+        })
+        .unwrap_or_else(|| "Uncaught exception".to_string());
+    let (stack_source, stack_line, stack_column) = stack_location(details.get("stackTrace"));
+    ConsoleEntry {
+        sequence: 0,
+        level: ConsoleLevel::Exception,
+        text,
+        source: stack_source.or_else(|| {
+            details
+                .get("url")
+                .and_then(Value::as_str)
+                .map(ToString::to_string)
+        }),
+        line: stack_line.or_else(|| one_based(details.get("lineNumber"))),
+        column: stack_column.or_else(|| one_based(details.get("columnNumber"))),
+    }
+}
+
+fn remote_object_text(value: &Value) -> String {
+    if let Some(text) = value.as_str() {
+        return text.to_string();
+    }
+    if value.is_number() || value.is_boolean() {
+        return value.to_string();
+    }
+    if let Some(text) = value.get("value") {
+        return remote_object_text(text);
+    }
+    for key in ["description", "unserializableValue", "type"] {
+        if let Some(text) = value.get(key).and_then(Value::as_str) {
+            return text.to_string();
+        }
+    }
+    if value.is_null() {
+        String::new()
+    } else {
+        value.to_string()
+    }
+}
+
+fn stack_location(stack_trace: Option<&Value>) -> (Option<String>, Option<u64>, Option<u64>) {
+    let Some(frame) = stack_trace
+        .and_then(|stack| stack.get("callFrames"))
+        .and_then(Value::as_array)
+        .and_then(|frames| frames.first())
+    else {
+        return (None, None, None);
+    };
+    (
+        frame
+            .get("url")
+            .and_then(Value::as_str)
+            .map(ToString::to_string),
+        one_based(frame.get("lineNumber")),
+        one_based(frame.get("columnNumber")),
+    )
+}
+
+fn one_based(value: Option<&Value>) -> Option<u64> {
+    value.and_then(Value::as_u64).map(|value| value + 1)
+}
+
+fn quote(value: &str) -> String {
+    serde_json::to_string(value).unwrap_or_else(|_err| format!("\"{value}\""))
+}
+
+fn compact_text(value: &str) -> String {
+    value.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn clamp_chars(value: &str, max_chars: usize) -> String {
+    if value.chars().count() <= max_chars {
+        return value.to_string();
+    }
+    value.chars().take(max_chars).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PageSignals;
+    use crate::{CdpConnection, PageId, SessionId};
+    use browseros_cdp::{CdpError, CdpEvent};
+    use futures_util::future::BoxFuture;
+    use serde_json::{Value, json};
+    use std::{
+        sync::{Arc, Mutex},
+        time::Duration,
+    };
+    use tokio::sync::broadcast;
+
+    #[derive(Debug, Clone)]
+    struct SentCall {
+        method: String,
+        params: Value,
+        session: Option<SessionId>,
+    }
+
+    struct TestConnection {
+        sender: broadcast::Sender<CdpEvent>,
+        sent: Mutex<Vec<SentCall>>,
+    }
+
+    impl TestConnection {
+        fn new() -> Arc<Self> {
+            let (sender, _receiver) = broadcast::channel(128);
+            Arc::new(Self {
+                sender,
+                sent: Mutex::new(Vec::new()),
+            })
+        }
+
+        fn emit(&self, method: &str, params: Value, session_id: Option<&str>) {
+            let _ = self.sender.send(CdpEvent {
+                method: method.to_string(),
+                params,
+                session_id: session_id.map(SessionId::from),
+            });
+        }
+
+        fn sent_calls(&self) -> Vec<SentCall> {
+            self.sent
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .clone()
+        }
+    }
+
+    impl CdpConnection for TestConnection {
+        fn send<'a>(
+            &'a self,
+            method: &'a str,
+            params: Value,
+            session: Option<&'a SessionId>,
+        ) -> BoxFuture<'a, Result<Value, CdpError>> {
+            Box::pin(async move {
+                self.sent
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .push(SentCall {
+                        method: method.to_string(),
+                        params,
+                        session: session.cloned(),
+                    });
+                Ok(json!({}))
+            })
+        }
+
+        fn send_raw_json<'a>(
+            &'a self,
+            method: &'a str,
+            _params_json: &'a str,
+            _session: Option<&'a SessionId>,
+        ) -> BoxFuture<'a, Result<String, CdpError>> {
+            Box::pin(async move {
+                Err(CdpError::Protocol {
+                    code: -1,
+                    message: format!("unexpected raw call: {method}"),
+                })
+            })
+        }
+
+        fn events(&self) -> broadcast::Receiver<CdpEvent> {
+            self.sender.subscribe()
+        }
+
+        fn is_connected(&self) -> bool {
+            true
+        }
+
+        fn connection_epoch(&self) -> u64 {
+            1
+        }
+    }
+
+    fn harness() -> (Arc<PageSignals>, Arc<TestConnection>, PageId) {
+        let connection = TestConnection::new();
+        let signals = PageSignals::new(connection.clone());
+        let page_id = PageId(7);
+        signals.attach_page(page_id.clone(), SessionId::from("session-7"));
+        (signals, connection, page_id)
+    }
+
+    async fn eventually(mut condition: impl FnMut() -> bool) {
+        for _attempt in 0..50 {
+            if condition() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert!(condition());
+    }
+
+    #[tokio::test]
+    async fn tracks_pending_dialog_and_clears_on_close() {
+        let (signals, connection, page_id) = harness();
+        connection.emit(
+            "Page.javascriptDialogOpening",
+            json!({
+                "type": "confirm",
+                "message": "Leave site?",
+                "url": "https://example.test/"
+            }),
+            Some("session-7"),
+        );
+
+        eventually(|| signals.pending_dialog(&page_id).is_some()).await;
+        let line = signals.pending_dialog_line(&page_id).unwrap_or_default();
+        assert!(line.contains("[page 7 dialog open] confirm: \"Leave site?\""));
+        assert!(line.contains("act kind=\"dialog_accept\""));
+
+        connection.emit("Page.javascriptDialogClosed", json!({}), Some("session-7"));
+        eventually(|| signals.pending_dialog(&page_id).is_none()).await;
+    }
+
+    #[tokio::test]
+    async fn auto_accepts_alert_and_records_next_response_note() {
+        let (signals, connection, page_id) = harness();
+        connection.emit(
+            "Page.javascriptDialogOpening",
+            json!({
+                "type": "alert",
+                "message": "Saved",
+                "url": "https://example.test/"
+            }),
+            Some("session-7"),
+        );
+
+        eventually(|| {
+            connection.sent_calls().iter().any(|call| {
+                call.method == "Page.handleJavaScriptDialog"
+                    && call.params.get("accept").and_then(Value::as_bool) == Some(true)
+                    && call.session.as_ref() == Some(&SessionId::from("session-7"))
+            })
+        })
+        .await;
+        assert!(signals.pending_dialog(&page_id).is_none());
+        assert_eq!(
+            signals.take_alert_note_lines(&page_id),
+            vec!["[page 7 dismissed an alert: \"Saved\"]"]
+        );
+        assert!(signals.take_alert_note_lines(&page_id).is_empty());
+    }
+
+    #[tokio::test]
+    async fn captures_console_ring_with_exceptions_newest_last() {
+        let (signals, connection, page_id) = harness();
+        for index in 0..55 {
+            connection.emit(
+                "Runtime.consoleAPICalled",
+                json!({
+                    "type": "error",
+                    "args": [{ "type": "string", "value": format!("boom {index}") }],
+                    "stackTrace": {
+                        "callFrames": [{
+                            "url": "https://example.test/app.js",
+                            "lineNumber": index,
+                            "columnNumber": 0
+                        }]
+                    }
+                }),
+                Some("session-7"),
+            );
+        }
+        connection.emit(
+            "Runtime.exceptionThrown",
+            json!({
+                "exceptionDetails": {
+                    "text": "Uncaught",
+                    "url": "https://example.test/app.js",
+                    "lineNumber": 99,
+                    "columnNumber": 2,
+                    "exception": {
+                        "description": "TypeError: x is undefined"
+                    }
+                }
+            }),
+            Some("session-7"),
+        );
+
+        eventually(|| signals.console_entries(&page_id).len() == 50).await;
+        let entries = signals.console_entries(&page_id);
+        assert_eq!(entries.len(), 50);
+        assert_eq!(entries.first().map(|entry| entry.sequence), Some(6));
+        assert_eq!(entries.last().map(|entry| entry.sequence), Some(55));
+        assert_eq!(
+            entries.last().map(super::ConsoleEntry::line),
+            Some(
+                "exception: TypeError: x is undefined (https://example.test/app.js:100)"
+                    .to_string()
+            )
+        );
+    }
+}

--- a/packages/browseros-agent/crates/browseros-core/src/session.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/session.rs
@@ -5,6 +5,7 @@ use crate::{
     input::Input,
     navigation::Navigation,
     observer::Observer,
+    page_signals::PageSignals,
     pages::{PageManager, PageManagerHooks},
     screenshot::{
         ScreenshotCaptureOptions, ScreenshotCaptureResult, capture_screenshot_with_annotations,
@@ -24,6 +25,7 @@ pub struct BrowserSessionHooks {
 pub struct BrowserSession {
     connection: Arc<dyn CdpConnection>,
     pub pages: Arc<PageManager>,
+    pub page_signals: Arc<PageSignals>,
     pub windows: Arc<WindowManager>,
     frames: Arc<FrameRegistry>,
     observers: Mutex<HashMap<PageId, Arc<Observer>>>,
@@ -33,16 +35,20 @@ impl BrowserSession {
     #[must_use]
     pub fn new(connection: Arc<dyn CdpConnection>, hooks: BrowserSessionHooks) -> Arc<Self> {
         let frames = FrameRegistry::new(connection.clone());
+        let page_signals = PageSignals::new(connection.clone());
         let frame_hook = {
             let frames = frames.clone();
+            let page_signals = page_signals.clone();
             let user_hook = hooks.page_manager.on_session_attached.clone();
             Arc::new(
                 move |session: crate::ProtocolSession,
                       page_id: PageId,
                       session_id: crate::SessionId| {
                     let frames = frames.clone();
+                    let page_signals = page_signals.clone();
                     let user_hook = user_hook.clone();
                     Box::pin(async move {
+                        page_signals.attach_page(page_id.clone(), session_id.clone());
                         frames
                             .register_page(session.clone(), page_id.clone(), session_id.clone())
                             .await?;
@@ -55,15 +61,26 @@ impl BrowserSession {
                 },
             )
         };
+        let detach_hook = {
+            let page_signals = page_signals.clone();
+            let user_hook = hooks.page_manager.on_page_detached.clone();
+            Arc::new(move |page_id: PageId| {
+                page_signals.forget_page(&page_id);
+                if let Some(user_hook) = &user_hook {
+                    user_hook(page_id);
+                }
+            })
+        };
         let page_hooks = PageManagerHooks {
             on_session_attached: Some(frame_hook),
-            on_page_detached: hooks.page_manager.on_page_detached,
+            on_page_detached: Some(detach_hook),
         };
         let pages = Arc::new(PageManager::new(connection.clone(), page_hooks));
         let windows = Arc::new(WindowManager::new(connection.clone()));
         let session = Arc::new(Self {
             connection: connection.clone(),
             pages,
+            page_signals,
             windows,
             frames,
             observers: Mutex::new(HashMap::new()),
@@ -96,7 +113,7 @@ impl BrowserSession {
 
     #[must_use]
     pub fn nav(&self, page_id: PageId) -> Navigation {
-        Navigation::new(self.pages.clone(), page_id)
+        Navigation::new(self.pages.clone(), self.page_signals.clone(), page_id)
     }
 
     pub async fn screenshot(
@@ -180,6 +197,7 @@ async fn handle_detached_event(session: &BrowserSession, event: CdpEvent) {
         .and_then(Value::as_str)
         .map(crate::SessionId::from);
     if let Some(session_id) = session_id {
+        session.page_signals.detach_session(&session_id);
         session.pages.detach_session(&session_id).await;
     }
 }

--- a/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/framework.rs
@@ -207,6 +207,7 @@ pub async fn execute_tool(
     ctx: &ToolCtx,
 ) -> ToolExecResult<ToolResult> {
     ctx.throw_if_cancelled()?;
+    let primary_page = raw_arg_page_id(def.metadata.accepts_page_arg, &raw_args).map(PageId);
     let mut response = ToolResponse::new();
     match (def.handler)(raw_args, ctx, &mut response).await {
         Ok(Some(result)) => response.append_result(result),
@@ -220,7 +221,7 @@ pub async fn execute_tool(
         Err(err) => response.error(format!("{} failed: {err}", def.name)),
     }
     ctx.throw_if_cancelled()?;
-    let mut result = response.build_for_session(ctx).await?;
+    let mut result = response.build_for_session(ctx, primary_page).await?;
     ctx.throw_if_cancelled()?;
 
     if let Some(page_id) = result_page_id(&result)
@@ -229,6 +230,26 @@ pub async fn execute_tool(
         result.metadata_tab_id = Some(tab_id.0);
     }
     Ok(result.into_tool_result())
+}
+
+#[must_use]
+pub fn pending_dialog_result(ctx: &ToolCtx, page: PageId) -> Option<ToolResult> {
+    ctx.session
+        .page_signals
+        .pending_dialog_line(&page)
+        .map(ToolResult::error)
+}
+
+#[must_use]
+pub fn raw_arg_page_id(accepts_page_arg: bool, raw_args: &Value) -> Option<u32> {
+    if !accepts_page_arg {
+        return None;
+    }
+    raw_args
+        .get("page")
+        .and_then(Value::as_u64)
+        .and_then(|value| u32::try_from(value).ok())
+        .filter(|value| *value >= 1)
 }
 
 #[must_use]

--- a/packages/browseros-agent/crates/browseros-mcp/src/response.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/response.rs
@@ -3,7 +3,7 @@ use crate::{
     format::{diff::format_diff_result, snapshot::format_snapshot_result},
     framework::{ToolCtx, ToolError, ToolExecResult, ToolResult, merge_structured},
 };
-use browseros_core::{PageId, settle::SettleOutcome};
+use browseros_core::{ConsoleEntry, PageId, settle::SettleOutcome};
 use rmcp::model::ContentBlock;
 use serde_json::{Value, json};
 
@@ -15,12 +15,19 @@ enum PostAction {
     Screenshot { page: u32 },
 }
 
+#[derive(Debug, Clone)]
+struct ConsoleSummary {
+    page: u32,
+    since: u64,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct ToolResponse {
     content: Vec<ContentBlock>,
     has_error: bool,
     structured_content: Option<Value>,
     post_actions: Vec<PostAction>,
+    console_summaries: Vec<ConsoleSummary>,
 }
 
 #[derive(Debug, Clone)]
@@ -83,7 +90,15 @@ impl ToolResponse {
         self.post_actions.push(PostAction::Screenshot { page });
     }
 
-    pub async fn build_for_session(&mut self, ctx: &ToolCtx) -> ToolExecResult<BuiltToolResponse> {
+    pub fn include_console_summary(&mut self, page: u32, since: u64) {
+        self.console_summaries.push(ConsoleSummary { page, since });
+    }
+
+    pub async fn build_for_session(
+        &mut self,
+        ctx: &ToolCtx,
+        primary_page: Option<PageId>,
+    ) -> ToolExecResult<BuiltToolResponse> {
         if !self.post_actions.is_empty() {
             self.text("\n--- Additional context (auto-included) ---");
         }
@@ -118,6 +133,11 @@ impl ToolResponse {
             }
         }
 
+        for summary in self.console_summaries.clone() {
+            self.append_console_summary(ctx, summary);
+        }
+        self.prepend_page_signal_lines(ctx, primary_page);
+
         Ok(BuiltToolResponse {
             content: self.content.clone(),
             is_error: self.has_error,
@@ -133,6 +153,7 @@ impl ToolResponse {
     ) -> ToolExecResult<()> {
         match action {
             PostAction::Snapshot { page } => {
+                self.throw_if_dialog_open(ctx, page)?;
                 let observer = ctx.session.observe(browseros_core::PageId(page)).await;
                 let snapshot = observer.snapshot().await?;
                 let formatted = format_snapshot_result(&snapshot.text, &snapshot.url, ctx).await;
@@ -143,6 +164,7 @@ impl ToolResponse {
                 page,
                 include_structured,
             } => {
+                self.throw_if_dialog_open(ctx, page)?;
                 let diff = ctx
                     .session
                     .observe(browseros_core::PageId(page))
@@ -238,6 +260,15 @@ impl ToolResponse {
         let Some(page) = action.settle_page() else {
             return Ok(());
         };
+        if ctx
+            .session
+            .page_signals
+            .pending_dialog_line(&PageId(page))
+            .is_some()
+        {
+            tracing::debug!("browser MCP post-action settle skipped for page {page}: dialog open");
+            return Ok(());
+        }
         let outcome = tokio::select! {
             () = ctx.cancel.cancelled() => return Err(ToolError::Cancelled),
             outcome = browseros_core::settle::wait_for_action_settle(
@@ -256,6 +287,78 @@ impl ToolResponse {
             }
         }
         Ok(())
+    }
+
+    fn append_console_summary(&mut self, ctx: &ToolCtx, summary: ConsoleSummary) {
+        let entries = ctx
+            .session
+            .page_signals
+            .console_entries_since(&PageId(summary.page), summary.since);
+        let Some(line) = console_summary_line(summary.page, &entries) else {
+            return;
+        };
+        self.text(line);
+    }
+
+    fn prepend_page_signal_lines(&mut self, ctx: &ToolCtx, primary_page: Option<PageId>) {
+        let mut pages = Vec::new();
+        if let Some(page) = primary_page {
+            push_page_once(&mut pages, page);
+        }
+        if let Some(page) = self.structured_page_id() {
+            push_page_once(&mut pages, page);
+        }
+        for action in &self.post_actions {
+            if let Some(page) = action.page() {
+                push_page_once(&mut pages, PageId(page));
+            }
+        }
+
+        let mut lines = Vec::new();
+        for page in pages {
+            lines.extend(ctx.session.page_signals.take_alert_note_lines(&page));
+            if let Some(line) = ctx.session.page_signals.pending_dialog_line(&page) {
+                lines.push(line);
+            }
+        }
+        self.prepend_lines(lines);
+    }
+
+    fn prepend_lines(&mut self, lines: Vec<String>) {
+        if lines.is_empty() {
+            return;
+        }
+        let existing_first_text: &str = self
+            .content
+            .first()
+            .and_then(|content| content.as_text())
+            .map(|content| content.text.as_ref())
+            .unwrap_or_default();
+        let missing = lines
+            .into_iter()
+            .filter(|line| !existing_first_text.starts_with(line))
+            .collect::<Vec<_>>();
+        if missing.is_empty() {
+            return;
+        }
+        self.content
+            .insert(0, ContentBlock::text(missing.join("\n")));
+    }
+
+    fn structured_page_id(&self) -> Option<PageId> {
+        self.structured_content
+            .as_ref()
+            .and_then(|value| value.get("page"))
+            .and_then(Value::as_u64)
+            .and_then(|value| u32::try_from(value).ok())
+            .map(PageId)
+    }
+
+    fn throw_if_dialog_open(&self, ctx: &ToolCtx, page: u32) -> ToolExecResult<()> {
+        match ctx.session.page_signals.pending_dialog_line(&PageId(page)) {
+            Some(message) => Err(ToolError::message(message)),
+            None => Ok(()),
+        }
     }
 }
 
@@ -279,6 +382,15 @@ impl PostAction {
         }
     }
 
+    fn page(&self) -> Option<u32> {
+        match self {
+            Self::Snapshot { page } | Self::Diff { page, .. } | Self::Screenshot { page } => {
+                Some(*page)
+            }
+            Self::Pages => None,
+        }
+    }
+
     fn unavailable_text(&self, reason: impl AsRef<str>) -> String {
         let reason = reason.as_ref();
         match self {
@@ -288,4 +400,25 @@ impl PostAction {
             Self::Screenshot { page } => format!("[page {page} screenshot unavailable: {reason}]"),
         }
     }
+}
+
+fn push_page_once(pages: &mut Vec<PageId>, page: PageId) {
+    if !pages.contains(&page) {
+        pages.push(page);
+    }
+}
+
+fn console_summary_line(page: u32, entries: &[ConsoleEntry]) -> Option<String> {
+    let first = entries.first()?;
+    let noun = if entries.iter().all(ConsoleEntry::is_warning) {
+        "warning"
+    } else {
+        "error"
+    };
+    let suffix = if entries.len() == 1 { "" } else { "s" };
+    Some(format!(
+        "[page {page} console] {} {noun}{suffix} during action, e.g.: {}",
+        entries.len(),
+        first.summary_text()
+    ))
 }

--- a/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
@@ -8,12 +8,16 @@ use crate::{
 };
 use browseros_cdp::{CdpError, CdpEvent};
 use browseros_core::{
-    BrowserSession, BrowserSessionHooks, CdpConnection, SessionId, snapshot::SnapshotDiff,
+    BrowserSession, BrowserSessionHooks, CdpConnection, PageId, SessionId, snapshot::SnapshotDiff,
 };
 use futures_util::future::BoxFuture;
 use rmcp::handler::server::ServerHandler;
 use serde_json::{Value, json};
-use std::sync::Arc;
+use std::sync::{
+    Arc, Mutex,
+    atomic::{AtomicBool, Ordering},
+};
+use std::time::Duration;
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 
@@ -84,6 +88,206 @@ fn fake_ctx() -> ToolCtx {
         cancel: CancellationToken::new(),
         output_files: create_browser_output_file_access(),
     })
+}
+
+#[derive(Debug, Clone)]
+struct HarnessCall {
+    method: String,
+    params: Value,
+    session: Option<SessionId>,
+}
+
+struct HarnessConnection {
+    sender: broadcast::Sender<CdpEvent>,
+    calls: Mutex<Vec<HarnessCall>>,
+    emit_console_on_input: AtomicBool,
+}
+
+impl HarnessConnection {
+    fn new() -> Arc<Self> {
+        let (sender, _receiver) = broadcast::channel(64);
+        Arc::new(Self {
+            sender,
+            calls: Mutex::new(Vec::new()),
+            emit_console_on_input: AtomicBool::new(false),
+        })
+    }
+
+    fn emit(&self, method: &str, params: Value, session_id: Option<&str>) {
+        let _ = self.sender.send(CdpEvent {
+            method: method.to_string(),
+            params,
+            session_id: session_id.map(SessionId::from),
+        });
+    }
+
+    fn calls(&self) -> Vec<HarnessCall> {
+        self.calls
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone()
+    }
+
+    fn enable_console_on_input(&self) {
+        self.emit_console_on_input.store(true, Ordering::SeqCst);
+    }
+}
+
+impl CdpConnection for HarnessConnection {
+    fn send<'a>(
+        &'a self,
+        method: &'a str,
+        params: Value,
+        session: Option<&'a SessionId>,
+    ) -> BoxFuture<'a, Result<Value, CdpError>> {
+        Box::pin(async move {
+            self.calls
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .push(HarnessCall {
+                    method: method.to_string(),
+                    params: params.clone(),
+                    session: session.cloned(),
+                });
+            match method {
+                "Browser.getTabs" => Ok(json!({ "tabs": [harness_tab()] })),
+                "Browser.getTabInfo" => Ok(json!({ "tab": harness_tab() })),
+                "Target.attachToTarget" => Ok(json!({ "sessionId": "session-1" })),
+                "Page.enable"
+                | "DOM.enable"
+                | "Runtime.enable"
+                | "Accessibility.enable"
+                | "Runtime.runIfWaitingForDebugger"
+                | "Target.setAutoAttach"
+                | "Page.handleJavaScriptDialog" => Ok(json!({})),
+                "Runtime.evaluate" => Ok(json!({ "result": { "value": 0 } })),
+                "Input.dispatchKeyEvent" => {
+                    if self.emit_console_on_input.swap(false, Ordering::SeqCst) {
+                        self.emit(
+                            "Runtime.consoleAPICalled",
+                            json!({
+                                "type": "error",
+                                "args": [{ "type": "string", "value": "TypeError: act failed" }],
+                                "stackTrace": {
+                                    "callFrames": [{
+                                        "url": "https://example.test/app.js",
+                                        "lineNumber": 4,
+                                        "columnNumber": 0
+                                    }]
+                                }
+                            }),
+                            session.map(SessionId::as_str),
+                        );
+                        tokio::task::yield_now().await;
+                    }
+                    Ok(json!({}))
+                }
+                _ => Err(CdpError::Protocol {
+                    code: -1,
+                    message: format!("unexpected harness CDP call: {method}"),
+                }),
+            }
+        })
+    }
+
+    fn send_raw_json<'a>(
+        &'a self,
+        method: &'a str,
+        _params_json: &'a str,
+        _session: Option<&'a SessionId>,
+    ) -> BoxFuture<'a, Result<String, CdpError>> {
+        Box::pin(async move {
+            Err(CdpError::Protocol {
+                code: -1,
+                message: format!("unexpected harness raw call: {method}"),
+            })
+        })
+    }
+
+    fn events(&self) -> broadcast::Receiver<CdpEvent> {
+        self.sender.subscribe()
+    }
+
+    fn is_connected(&self) -> bool {
+        true
+    }
+
+    fn connection_epoch(&self) -> u64 {
+        1
+    }
+}
+
+fn harness_tab() -> Value {
+    json!({
+        "tabId": 101,
+        "targetId": "target-1",
+        "url": "https://example.test/",
+        "title": "Example",
+        "isActive": true,
+        "isLoading": false,
+        "loadProgress": 1.0,
+        "isPinned": false,
+        "isHidden": false,
+        "windowId": 1,
+        "index": 0
+    })
+}
+
+async fn harness_ctx() -> (ToolCtx, Arc<HarnessConnection>, u32) {
+    let connection = HarnessConnection::new();
+    let session = BrowserSession::new(connection.clone(), BrowserSessionHooks::default());
+    let pages = session
+        .pages
+        .list()
+        .await
+        .unwrap_or_else(|err| panic!("harness should list pages: {err}"));
+    let page = pages
+        .first()
+        .unwrap_or_else(|| panic!("harness should create a page"))
+        .page_id
+        .0;
+    session
+        .pages
+        .get_session(browseros_core::PageId(page))
+        .await
+        .unwrap_or_else(|err| panic!("harness should attach page session: {err}"));
+    (
+        ToolCtx::new(BrowserToolOptions {
+            session,
+            defaults: BrowserToolDefaults::default(),
+            cancel: CancellationToken::new(),
+            output_files: create_browser_output_file_access(),
+        }),
+        connection,
+        page,
+    )
+}
+
+async fn eventually(mut condition: impl FnMut() -> bool) {
+    for _attempt in 0..50 {
+        if condition() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(10)).await;
+    }
+    assert!(condition());
+}
+
+fn tool_by_name(name: &str) -> crate::framework::ToolDef {
+    catalog()
+        .into_iter()
+        .find(|tool| tool.name == name)
+        .unwrap_or_else(|| panic!("missing {name} tool"))
+}
+
+fn result_text(result: &crate::framework::ToolResult) -> String {
+    result
+        .content
+        .iter()
+        .filter_map(|content| content.as_text())
+        .map(|content| content.text.as_ref())
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 #[test]
@@ -263,6 +467,194 @@ async fn invalid_arguments_are_tool_error_results() {
 }
 
 #[tokio::test]
+async fn snapshot_fails_fast_when_dialog_is_open() {
+    let (ctx, connection, page) = harness_ctx().await;
+    connection.emit(
+        "Page.javascriptDialogOpening",
+        json!({
+            "type": "confirm",
+            "message": "Leave site?",
+            "url": "https://example.test/"
+        }),
+        Some("session-1"),
+    );
+    eventually(|| {
+        ctx.session
+            .page_signals
+            .pending_dialog_line(&PageId(page))
+            .is_some()
+    })
+    .await;
+
+    let snapshot = tool_by_name("snapshot");
+    let result = execute_tool(&snapshot, json!({ "page": page }), &ctx)
+        .await
+        .unwrap_or_else(|err| panic!("snapshot should return a tool result: {err}"));
+    let text = result_text(&result);
+    assert!(result.is_error);
+    assert!(text.starts_with("[page 1 dialog open] confirm: \"Leave site?\""));
+    assert!(text.contains("act kind=\"dialog_accept\""));
+    assert!(
+        !connection
+            .calls()
+            .iter()
+            .any(|call| call.method == "Accessibility.getFullAXTree")
+    );
+}
+
+#[tokio::test]
+async fn act_dialog_accept_sends_cdp_and_clears_pending_dialog() {
+    let (ctx, connection, page) = harness_ctx().await;
+    connection.emit(
+        "Page.javascriptDialogOpening",
+        json!({
+            "type": "prompt",
+            "message": "Name?",
+            "defaultPrompt": "Alice",
+            "url": "https://example.test/"
+        }),
+        Some("session-1"),
+    );
+    eventually(|| {
+        ctx.session
+            .page_signals
+            .pending_dialog_line(&PageId(page))
+            .is_some()
+    })
+    .await;
+
+    let act = tool_by_name("act");
+    let result = execute_tool(
+        &act,
+        json!({ "page": page, "kind": "dialog_accept", "text": "BrowserOS" }),
+        &ctx,
+    )
+    .await
+    .unwrap_or_else(|err| panic!("act should return a tool result: {err}"));
+
+    assert!(!result.is_error);
+    assert!(
+        ctx.session
+            .page_signals
+            .pending_dialog(&PageId(page))
+            .is_none()
+    );
+    assert!(connection.calls().iter().any(|call| {
+        call.method == "Page.handleJavaScriptDialog"
+            && call.params.get("accept").and_then(Value::as_bool) == Some(true)
+            && call.params.get("promptText").and_then(Value::as_str) == Some("BrowserOS")
+            && call.session.as_ref() == Some(&SessionId::from("session-1"))
+    }));
+}
+
+#[tokio::test]
+async fn alert_auto_accept_note_is_prepended_to_next_page_response() {
+    let (ctx, connection, page) = harness_ctx().await;
+    connection.emit(
+        "Page.javascriptDialogOpening",
+        json!({
+            "type": "alert",
+            "message": "Saved",
+            "url": "https://example.test/"
+        }),
+        Some("session-1"),
+    );
+    eventually(|| {
+        connection
+            .calls()
+            .iter()
+            .any(|call| call.method == "Page.handleJavaScriptDialog")
+    })
+    .await;
+
+    let wait = tool_by_name("wait");
+    let result = execute_tool(
+        &wait,
+        json!({ "page": page, "for": "time", "value": 0 }),
+        &ctx,
+    )
+    .await
+    .unwrap_or_else(|err| panic!("wait should return a tool result: {err}"));
+    let text = result_text(&result);
+    assert!(text.starts_with("[page 1 dismissed an alert: \"Saved\"]"));
+    assert!(text.contains("waited 0ms"));
+}
+
+#[tokio::test]
+async fn read_console_returns_captured_ring() {
+    let (ctx, connection, page) = harness_ctx().await;
+    connection.emit(
+        "Runtime.consoleAPICalled",
+        json!({
+            "type": "warning",
+            "args": [{ "type": "string", "value": "deprecated API" }],
+            "stackTrace": {
+                "callFrames": [{
+                    "url": "https://example.test/app.js",
+                    "lineNumber": 9,
+                    "columnNumber": 0
+                }]
+            }
+        }),
+        Some("session-1"),
+    );
+    connection.emit(
+        "Runtime.exceptionThrown",
+        json!({
+            "exceptionDetails": {
+                "text": "Uncaught",
+                "url": "https://example.test/app.js",
+                "lineNumber": 12,
+                "columnNumber": 0,
+                "exception": { "description": "TypeError: x is undefined" }
+            }
+        }),
+        Some("session-1"),
+    );
+    eventually(|| {
+        ctx.session
+            .page_signals
+            .console_entries(&PageId(page))
+            .len()
+            == 2
+    })
+    .await;
+
+    let read = tool_by_name("read");
+    let result = execute_tool(&read, json!({ "page": page, "format": "console" }), &ctx)
+        .await
+        .unwrap_or_else(|err| panic!("read should return a tool result: {err}"));
+    let text = result_text(&result);
+    assert!(text.contains("warning: deprecated API (https://example.test/app.js:10)"));
+    assert!(text.contains("exception: TypeError: x is undefined (https://example.test/app.js:13)"));
+    assert_eq!(
+        result
+            .structured_content
+            .as_ref()
+            .and_then(|value| value.get("format")),
+        Some(&json!("console"))
+    );
+}
+
+#[tokio::test]
+async fn act_appends_console_error_summary_for_action_window() {
+    let (ctx, connection, page) = harness_ctx().await;
+    connection.enable_console_on_input();
+
+    let act = tool_by_name("act");
+    let result = execute_tool(
+        &act,
+        json!({ "page": page, "kind": "press", "key": "Enter" }),
+        &ctx,
+    )
+    .await
+    .unwrap_or_else(|err| panic!("act should return a tool result: {err}"));
+    let text = result_text(&result);
+    assert!(text.contains("[page 1 console] 1 error during action, e.g.: TypeError: act failed"));
+    assert!(!result.is_error);
+}
+
+#[tokio::test]
 async fn snapshot_formatter_wraps_small_page_content() {
     let formatted = format_snapshot_result(
         "- button \"Save\" [ref=e1]",
@@ -300,7 +692,7 @@ async fn diff_post_action_failure_is_visible() {
     let mut response = ToolResponse::new();
     response.include_diff(7, true);
     let built = response
-        .build_for_session(&ctx)
+        .build_for_session(&ctx, None)
         .await
         .unwrap_or_else(|err| panic!("post-action failure should not fail response: {err}"));
     let text = built

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/act.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/act.rs
@@ -1,5 +1,6 @@
 use crate::framework::{
-    ToolCtx, ToolExecResult, ToolResult, error_result, parse_args, text_result,
+    ToolCtx, ToolExecResult, ToolResult, error_result, parse_args, pending_dialog_result,
+    text_result,
 };
 use browseros_core::{
     PageId, Ref,
@@ -14,6 +15,7 @@ const DESCRIPTION: &str = "\
 Act on the page using refs from the last snapshot. \
 kinds: click, type (into focused element), fill (one field via ref+value, or many via fields[]), \
 press (a key/combo), hover, focus, check, uncheck, select (an option value), scroll, drag. \
+dialog_accept/dialog_dismiss handle pending JavaScript dialogs. \
 Reads back a diff of what changed - re-snapshot if you need fresh refs.";
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -34,6 +36,8 @@ enum ActKind {
     Scroll,
     Drag,
     DragAt,
+    DialogAccept,
+    DialogDismiss,
 }
 
 impl ActKind {
@@ -54,7 +58,13 @@ impl ActKind {
             Self::Scroll => "scroll",
             Self::Drag => "drag",
             Self::DragAt => "drag_at",
+            Self::DialogAccept => "dialog_accept",
+            Self::DialogDismiss => "dialog_dismiss",
         }
+    }
+
+    fn is_dialog(&self) -> bool {
+        matches!(self, Self::DialogAccept | Self::DialogDismiss)
     }
 }
 
@@ -134,12 +144,23 @@ fn handler<'a>(
 ) -> BoxFuture<'a, ToolExecResult<Option<ToolResult>>> {
     Box::pin(async move {
         let args: ActArgs = parse_args(raw)?;
-        let input = ctx.session.input(PageId(args.page)).await;
+        let page_id = PageId(args.page);
+        if !args.kind.is_dialog()
+            && let Some(result) = pending_dialog_result(ctx, page_id.clone())
+        {
+            return Ok(Some(result));
+        }
+        let console_start = ctx.session.page_signals.console_mark(&page_id);
+        let input = ctx.session.input(page_id.clone()).await;
         if let Some(err) = run_kind(&args, &input).await? {
             return Ok(Some(err));
         }
+        if args.kind.is_dialog() {
+            ctx.session.page_signals.clear_dialog(&page_id);
+        }
         response.data(json!({ "kind": args.kind.as_str() }));
         response.include_diff(args.page, true);
+        response.include_console_summary(args.page, console_start);
         Ok(Some(text_result(
             format!("ok ({})", args.kind.as_str()),
             None,
@@ -291,6 +312,12 @@ async fn run_kind(
                     Point { x: end_x, y: end_y },
                 )
                 .await?;
+        }
+        ActKind::DialogAccept => {
+            input.handle_dialog(true, args.text.as_deref()).await?;
+        }
+        ActKind::DialogDismiss => {
+            input.handle_dialog(false, None).await?;
         }
     }
     Ok(None)

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/diff.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/diff.rs
@@ -1,6 +1,8 @@
 use crate::{
     format::diff::format_diff_result,
-    framework::{ToolCtx, ToolExecResult, ToolResult, parse_args, text_result},
+    framework::{
+        ToolCtx, ToolExecResult, ToolResult, parse_args, pending_dialog_result, text_result,
+    },
 };
 use browseros_core::PageId;
 use futures_util::future::BoxFuture;
@@ -33,6 +35,9 @@ fn handler<'a>(
 ) -> BoxFuture<'a, ToolExecResult<Option<ToolResult>>> {
     Box::pin(async move {
         let args: DiffArgs = parse_args(raw)?;
+        if let Some(result) = pending_dialog_result(ctx, PageId(args.page)) {
+            return Ok(Some(result));
+        }
         let diff = ctx.session.observe(PageId(args.page)).await.diff().await?;
         let origin = diff.after_url.as_deref().map(ToString::to_string);
         let origin = match origin {

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/download.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/download.rs
@@ -1,6 +1,9 @@
 use crate::{
     constants::DOWNLOAD_TIMEOUT,
-    framework::{ToolCtx, ToolError, ToolExecResult, ToolResult, parse_args, text_result},
+    framework::{
+        ToolCtx, ToolError, ToolExecResult, ToolResult, parse_args, pending_dialog_result,
+        text_result,
+    },
     output_file::{create_download_output_dir, record_browser_output_file},
 };
 use browseros_core::{PageId, Ref, SessionId};
@@ -34,6 +37,9 @@ fn handler<'a>(
     Box::pin(async move {
         let args: DownloadArgs = parse_args(raw)?;
         let page_id = PageId(args.page);
+        if let Some(result) = pending_dialog_result(ctx, page_id.clone()) {
+            return Ok(Some(result));
+        }
         let page_session = ctx.session.pages.get_session(page_id.clone()).await?;
         let download_dir = create_download_output_dir().await?;
         page_session

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/evaluate.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/evaluate.rs
@@ -1,7 +1,8 @@
 use crate::{
     constants::INLINE_PAGE_CONTENT_MAX_CHARS,
     framework::{
-        ToolCtx, ToolExecResult, ToolResult, clamp_timeout, error_result, parse_args, text_result,
+        ToolCtx, ToolExecResult, ToolResult, clamp_timeout, error_result, parse_args,
+        pending_dialog_result, text_result,
     },
     output_file::write_temp_tool_output_file,
     trust_boundary::wrap_untrusted,
@@ -65,6 +66,9 @@ fn handler<'a>(
 ) -> BoxFuture<'a, ToolExecResult<Option<ToolResult>>> {
     Box::pin(async move {
         let args: EvaluateArgs = parse_args(raw)?;
+        if let Some(result) = pending_dialog_result(ctx, PageId(args.page)) {
+            return Ok(Some(result));
+        }
         let page = ctx.session.pages.get_session(PageId(args.page)).await?;
         let timeout = clamp_timeout(args.timeout, DEFAULT_TIMEOUT_MS, MAX_TIMEOUT_MS);
         let result: EvaluateResult = page

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/grep.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/grep.rs
@@ -1,6 +1,9 @@
 use crate::{
     constants::{GREP_MATCH_LINE_MAX_CHARS, GREP_MAX_MATCHES, INLINE_PAGE_CONTENT_MAX_CHARS},
-    framework::{ToolCtx, ToolExecResult, ToolResult, error_result, parse_args, text_result},
+    framework::{
+        ToolCtx, ToolExecResult, ToolResult, error_result, parse_args, pending_dialog_result,
+        text_result,
+    },
     output_file::write_temp_tool_output_file,
     trust_boundary::wrap_untrusted,
 };
@@ -69,6 +72,9 @@ fn handler<'a>(
             Ok(regex) => regex,
             Err(err) => return Ok(Some(error_result(format!("grep: invalid regex - {err}")))),
         };
+        if let Some(result) = pending_dialog_result(ctx, PageId(args.page)) {
+            return Ok(Some(result));
+        }
         let haystack = match args.over {
             GrepOver::Ax => {
                 ctx.session

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/read.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/read.rs
@@ -1,6 +1,9 @@
 use crate::{
     constants::INLINE_PAGE_CONTENT_MAX_CHARS,
-    framework::{ToolCtx, ToolExecResult, ToolResult, error_result, parse_args, text_result},
+    framework::{
+        ToolCtx, ToolExecResult, ToolResult, error_result, parse_args, pending_dialog_result,
+        text_result,
+    },
     output_file::write_temp_tool_output_file,
     trust_boundary::wrap_untrusted,
 };
@@ -14,7 +17,7 @@ use serde::Deserialize;
 use serde_json::{Value, json};
 
 const DESCRIPTION: &str = "\
-Extract page content as markdown (default), plain text, or a list of links. \
+Extract page content as markdown (default), plain text, links, or console errors. \
 For reading/scraping, not acting.";
 
 #[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
@@ -24,6 +27,7 @@ enum ReadFormat {
     Markdown,
     Text,
     Links,
+    Console,
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
@@ -79,6 +83,36 @@ fn handler<'a>(
 ) -> BoxFuture<'a, ToolExecResult<Option<ToolResult>>> {
     Box::pin(async move {
         let args: ReadArgs = parse_args(raw)?;
+        let origin = ctx
+            .session
+            .pages
+            .get_info(PageId(args.page))
+            .await
+            .map(|info| info.url)
+            .unwrap_or_else(|| "unknown".to_string());
+        if matches!(args.format, ReadFormat::Console) {
+            let entries = ctx.session.page_signals.console_entries(&PageId(args.page));
+            let text = if entries.is_empty() {
+                "(no console errors or warnings)".to_string()
+            } else {
+                entries
+                    .iter()
+                    .map(browseros_core::ConsoleEntry::line)
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            };
+            return Ok(Some(text_result(
+                wrap_untrusted(&text, &origin),
+                Some(json!({
+                    "page": args.page,
+                    "format": format_name(&args.format),
+                    "count": entries.len()
+                })),
+            )));
+        }
+        if let Some(result) = pending_dialog_result(ctx, PageId(args.page)) {
+            return Ok(Some(result));
+        }
         let page = ctx.session.pages.get_session(PageId(args.page)).await?;
         let expression = expression_for(&args)?;
         let result: EvaluateResult = page
@@ -100,13 +134,6 @@ fn handler<'a>(
             .and_then(|value| value.as_str().map(ToString::to_string))
             .or(result.result.description)
             .unwrap_or_default();
-        let origin = ctx
-            .session
-            .pages
-            .get_info(PageId(args.page))
-            .await
-            .map(|info| info.url)
-            .unwrap_or_else(|| "unknown".to_string());
         if text.len() <= INLINE_PAGE_CONTENT_MAX_CHARS {
             return Ok(Some(text_result(
                 wrap_untrusted(if text.is_empty() { "(empty)" } else { &text }, &origin),
@@ -169,6 +196,7 @@ fn expression_for(args: &ReadArgs) -> ToolExecResult<String> {
                 "[...({root}?.querySelectorAll('a[href]') ?? [])].map(function(a){{return '[' + (a.textContent||'').trim() + '](' + a.href + ')'}}).join('\\n')"
             )
         }
+        ReadFormat::Console => unreachable!("console reads are served from captured page signals"),
     })
 }
 
@@ -194,6 +222,7 @@ fn format_name(format: &ReadFormat) -> &'static str {
         ReadFormat::Markdown => "markdown",
         ReadFormat::Text => "text",
         ReadFormat::Links => "links",
+        ReadFormat::Console => "console",
     }
 }
 

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/screenshot.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/screenshot.rs
@@ -1,4 +1,4 @@
-use crate::framework::{ToolCtx, ToolExecResult, ToolResult, parse_args};
+use crate::framework::{ToolCtx, ToolExecResult, ToolResult, parse_args, pending_dialog_result};
 use base64::Engine;
 use browseros_core::{
     PageId,
@@ -91,6 +91,11 @@ fn handler<'a>(
     Box::pin(async move {
         let args: ScreenshotArgs = parse_args(raw)?;
         validate_args(&args)?;
+        if args.annotate.unwrap_or(false)
+            && let Some(result) = pending_dialog_result(ctx, PageId(args.page))
+        {
+            return Ok(Some(result));
+        }
         let full_page = args.full_page.unwrap_or(false);
         let mut options = ScreenshotCaptureOptions {
             format: Some(core_format(&args.format)),

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/snapshot.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/snapshot.rs
@@ -1,6 +1,8 @@
 use crate::{
     format::snapshot::format_snapshot_result,
-    framework::{ToolCtx, ToolExecResult, ToolResult, parse_args, text_result},
+    framework::{
+        ToolCtx, ToolExecResult, ToolResult, parse_args, pending_dialog_result, text_result,
+    },
 };
 use browseros_core::PageId;
 use futures_util::future::BoxFuture;
@@ -37,6 +39,9 @@ fn handler<'a>(
 ) -> BoxFuture<'a, ToolExecResult<Option<ToolResult>>> {
     Box::pin(async move {
         let args: SnapshotArgs = parse_args(raw)?;
+        if let Some(result) = pending_dialog_result(ctx, PageId(args.page)) {
+            return Ok(Some(result));
+        }
         let snapshot = ctx
             .session
             .observe(PageId(args.page))

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/upload.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/upload.rs
@@ -1,5 +1,6 @@
 use crate::framework::{
-    ToolCtx, ToolExecResult, ToolResult, error_result, parse_args, text_result,
+    ToolCtx, ToolExecResult, ToolResult, error_result, parse_args, pending_dialog_result,
+    text_result,
 };
 use browseros_core::{PageId, Ref};
 use futures_util::future::BoxFuture;
@@ -34,6 +35,9 @@ fn handler<'a>(
 ) -> BoxFuture<'a, ToolExecResult<Option<ToolResult>>> {
     Box::pin(async move {
         let args: UploadArgs = parse_args(raw)?;
+        if let Some(result) = pending_dialog_result(ctx, PageId(args.page)) {
+            return Ok(Some(result));
+        }
         let files = args
             .files
             .unwrap_or_else(|| args.file.clone().into_iter().collect::<Vec<_>>());

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/wait.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/wait.rs
@@ -1,6 +1,6 @@
 use crate::framework::{
     ToolCtx, ToolExecResult, ToolResult, abortable_delay, clamp_timeout, error_result, parse_args,
-    text_result,
+    pending_dialog_result, text_result,
 };
 use browseros_core::PageId;
 use futures_util::future::BoxFuture;
@@ -91,6 +91,9 @@ fn handler<'a>(
                 wait_for_name(&args.wait_for)
             ))));
         };
+        if let Some(result) = pending_dialog_result(ctx, PageId(args.page)) {
+            return Ok(Some(result));
+        }
         let page = ctx.session.pages.get_session(PageId(args.page)).await?;
         let expression = match args.wait_for {
             WaitFor::Text => format!(


### PR DESCRIPTION
## Summary
- add per-page BrowserOS core signal tracking for JavaScript dialogs, alert auto-accept notes, and console error/warning/exception rings
- surface pending dialogs in MCP responses, fail fast for dialog-sensitive page operations, and add act dialog_accept/dialog_dismiss
- add read format="console" plus act-time console error summaries

## Verification
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check

Note: local git hook runner reported `lefthook` missing from PATH, so verification was run directly with the commands above.