### PR TITLE
feat: implement Rust run tool with rquickjs

### DIFF
--- a/packages/browseros-agent/Cargo.lock
+++ b/packages/browseros-agent/Cargo.lock
@@ -24,6 +24,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -87,6 +93,17 @@ name = "anyhow"
 version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "async-trait"
@@ -229,6 +246,7 @@ dependencies = [
  "rand 0.9.4",
  "regex",
  "rmcp",
+ "rquickjs",
  "schemars",
  "serde",
  "serde_json",
@@ -377,6 +395,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -515,6 +542,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "fallible-iterator"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -537,6 +584,12 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -698,6 +751,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
@@ -1351,6 +1409,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6f6ff9a378485b298a5286656da665ba74413d36db0979633275d2e708145d4"
 
 [[package]]
+name = "relative-path"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bca40a312222d8ba74837cb474edef44b37f561da5f773981007a10bbaa992b0"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1444,6 +1511,36 @@ dependencies = [
  "quote",
  "serde_json",
  "syn",
+]
+
+[[package]]
+name = "rquickjs"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ce6b626d30ecbedaaf8097a04982bc3b081f958f5bdf9b8796be4ac00ee48bb"
+dependencies = [
+ "rquickjs-core",
+]
+
+[[package]]
+name = "rquickjs-core"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9334dd11023d5ae6c751f64496510a576208802ed1d022ef94afa7639c2c55e"
+dependencies = [
+ "async-lock",
+ "hashbrown 0.17.1",
+ "relative-path",
+ "rquickjs-sys",
+]
+
+[[package]]
+name = "rquickjs-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eef73520804cf5aa4876097ac5733058d628c769eba9678e0f4dba5a4ef79703"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/packages/browseros-agent/Cargo.toml
+++ b/packages/browseros-agent/Cargo.toml
@@ -37,6 +37,7 @@ regex = "1"
 rand = "0.9"
 uuid = { version = "1", features = ["v4", "serde"] }
 serde_path_to_error = "0.1"
+rquickjs = { version = "0.12.1", default-features = false, features = ["std", "futures", "parallel"] }
 clap = { version = "4.5", features = ["derive"] }
 rusqlite = { version = "0.32", features = ["bundled"] }
 rusqlite_migration = "=1.3.1"

--- a/packages/browseros-agent/crates/browseros-mcp/Cargo.toml
+++ b/packages/browseros-agent/crates/browseros-mcp/Cargo.toml
@@ -24,6 +24,7 @@ regex.workspace = true
 rand.workspace = true
 uuid.workspace = true
 serde_path_to_error.workspace = true
+rquickjs.workspace = true
 
 [dev-dependencies]
 anyhow.workspace = true

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
@@ -1,5 +1,6 @@
 use crate::framework::{
-    ToolCtx, ToolError, ToolExecResult, ToolResult, page_json, parse_args, text_result,
+    BrowserToolDefaults, ToolCtx, ToolError, ToolExecResult, ToolResult, page_json, parse_args,
+    text_result,
 };
 use browseros_core::{PageId, Ref, SessionId, input::ScrollDirection, pages::NewPageOptions};
 use futures_util::future::BoxFuture;
@@ -19,6 +20,13 @@ use std::{
 use tokio::time::{Instant, sleep_until};
 
 const DEFAULT_TIMEOUT_MS: f64 = 30_000.0;
+const MAX_TIMEOUT_MS: u64 = 30_000;
+const MIN_TIMEOUT_MS: u64 = 1;
+const RUN_MEMORY_LIMIT_BYTES: usize = 64 * 1024 * 1024;
+const RUN_STACK_SIZE_BYTES: usize = 512 * 1024;
+const MAX_LOG_ENTRIES: usize = 1_000;
+const MAX_LOG_BYTES: usize = 1_000_000;
+const MAX_RETURN_VALUE_BYTES: usize = 2_000_000;
 
 const DESCRIPTION: &str = r#"Run JavaScript against the `browser` SDK in the server runtime for multi-step flows and data extraction that would otherwise take many tool calls. `console.log` is captured; `return` a value to read it back; exceptions come back as a result, not a thrown error.
 
@@ -225,6 +233,7 @@ impl RunControl {
 #[derive(Clone)]
 struct BrowserBridge {
     session: Arc<browseros_core::BrowserSession>,
+    defaults: BrowserToolDefaults,
     control: RunControl,
 }
 
@@ -246,6 +255,20 @@ struct RunOutcome {
     return_text: Option<String>,
     logs: Vec<String>,
     error: Option<String>,
+}
+
+#[derive(Default)]
+struct CapturedLogs {
+    entries: Vec<String>,
+    bytes: usize,
+    limit_message: Option<String>,
+}
+
+type SharedLogs = Arc<Mutex<CapturedLogs>>;
+
+enum JsonValueError<'js> {
+    Js(CaughtError<'js>),
+    Limit(String),
 }
 
 impl RunOutcome {
@@ -294,10 +317,11 @@ impl RunOutcome {
 
 async fn execute_run(args: RunArgs, ctx: &ToolCtx) -> Result<RunOutcome, RunError> {
     ctx.throw_if_cancelled().map_err(|_| RunError::Cancelled)?;
-    let logs = Arc::new(Mutex::new(Vec::<String>::new()));
-    let duration = timeout_duration(args.timeout);
+    let logs = Arc::new(Mutex::new(CapturedLogs::default()));
+    let timeout_ms = normalized_timeout_ms(args.timeout);
+    let duration = Duration::from_millis(timeout_ms);
     let deadline = Instant::now() + duration;
-    let timeout_message: Arc<str> = Arc::from(format!("run exceeded {}ms", args.timeout));
+    let timeout_message: Arc<str> = Arc::from(format!("run exceeded {timeout_ms}ms"));
     let control = RunControl {
         cancel: ctx.cancel.clone(),
         deadline,
@@ -306,6 +330,7 @@ async fn execute_run(args: RunArgs, ctx: &ToolCtx) -> Result<RunOutcome, RunErro
     let run = execute_quickjs(
         args.code,
         ctx.session.clone(),
+        ctx.defaults.clone(),
         logs.clone(),
         control.clone(),
         duration,
@@ -320,11 +345,14 @@ async fn execute_run(args: RunArgs, ctx: &ToolCtx) -> Result<RunOutcome, RunErro
 async fn execute_quickjs(
     code: String,
     session: Arc<browseros_core::BrowserSession>,
-    logs: Arc<Mutex<Vec<String>>>,
+    defaults: BrowserToolDefaults,
+    logs: SharedLogs,
     control: RunControl,
     duration: Duration,
 ) -> Result<RunOutcome, RunError> {
     let runtime = AsyncRuntime::new().map_err(engine_error)?;
+    runtime.set_memory_limit(RUN_MEMORY_LIMIT_BYTES).await;
+    runtime.set_max_stack_size(RUN_STACK_SIZE_BYTES).await;
     let interrupt_control = control.clone();
     let interrupt_deadline = std::time::Instant::now() + duration;
     runtime
@@ -335,7 +363,7 @@ async fn execute_quickjs(
     let context = AsyncContext::full(&runtime).await.map_err(engine_error)?;
     let result = context
         .async_with(async |ctx| {
-            install_globals(&ctx, session, logs.clone(), control.clone())?;
+            install_globals(&ctx, session, defaults, logs.clone(), control.clone())?;
             ctx.eval::<(), _>(BOOTSTRAP_JS).catch(&ctx).map_err(|err| {
                 RunError::Engine(format!(
                     "failed to initialize run runtime: {}",
@@ -382,15 +410,19 @@ async fn execute_quickjs(
             };
 
             match promise.into_future::<JsValue<'_>>().await.catch(&ctx) {
-                Ok(value) => {
-                    let (value, return_text) = json_safe_value(&ctx, value)
-                        .map_err(|err| RunError::Engine(js_error_message(&ctx, err)))?;
-                    Ok(RunOutcome::success(
+                Ok(value) => match json_safe_value(&ctx, value) {
+                    Ok((value, return_text)) => Ok(RunOutcome::success(
                         value,
                         return_text,
                         logs_snapshot(&logs),
-                    ))
-                }
+                    )),
+                    Err(JsonValueError::Limit(message)) => {
+                        Ok(RunOutcome::failure(message, logs_snapshot(&logs)))
+                    }
+                    Err(JsonValueError::Js(err)) => {
+                        Err(RunError::Engine(js_error_message(&ctx, err)))
+                    }
+                },
                 Err(err) => {
                     if control.is_cancelled() {
                         Err(RunError::Cancelled)
@@ -416,10 +448,15 @@ async fn execute_quickjs(
 fn install_globals<'js>(
     ctx: &Ctx<'js>,
     session: Arc<browseros_core::BrowserSession>,
-    logs: Arc<Mutex<Vec<String>>>,
+    defaults: BrowserToolDefaults,
+    logs: SharedLogs,
     control: RunControl,
 ) -> Result<(), RunError> {
-    let bridge = BrowserBridge { session, control };
+    let bridge = BrowserBridge {
+        session,
+        defaults,
+        control,
+    };
     let call_bridge = {
         let bridge = bridge.clone();
         move |ctx: Ctx<'js>, method: String, args_json: String| {
@@ -433,8 +470,8 @@ fn install_globals<'js>(
             }
         }
     };
-    let push_log = move |line: String| {
-        push_log(&logs, line);
+    let push_log = move |ctx: Ctx<'js>, line: String| {
+        push_log(&logs, line).map_err(|message| Exception::throw_message(&ctx, &message))
     };
     let globals = ctx.globals();
     globals
@@ -467,8 +504,8 @@ impl BrowserBridge {
                         NewPageOptions {
                             background: None,
                             hidden: None,
-                            window_id: None,
-                            tab_group_id: None,
+                            window_id: self.defaults.default_window_id.clone(),
+                            tab_group_id: self.defaults.default_tab_group_id.clone(),
                         },
                     ))
                     .await?;
@@ -483,16 +520,11 @@ impl BrowserBridge {
                 let page_id = page_arg(&args, 0)?;
                 let info = self
                     .control
-                    .race(async {
-                        Ok(self
-                            .session
-                            .pages
-                            .get_info(page_id)
-                            .await
-                            .map(|page| page_json(&page)))
-                    })
+                    .race(self.session.pages.refresh(page_id))
                     .await?;
-                Ok(BrowserCallValue::Json(info.unwrap_or(Value::Null)))
+                Ok(BrowserCallValue::Json(
+                    info.map(|page| page_json(&page)).unwrap_or(Value::Null),
+                ))
             }
             "observe.snapshot" => {
                 let page_id = page_arg(&args, 0)?;
@@ -757,20 +789,39 @@ fn json_to_js<'js>(ctx: &Ctx<'js>, value: Value) -> rquickjs::Result<JsValue<'js
 fn json_safe_value<'js>(
     ctx: &Ctx<'js>,
     value: JsValue<'js>,
-) -> rquickjs::CaughtResult<'js, (Option<Value>, Option<String>)> {
-    let encode: Function<'_> = ctx.globals().get("__browserosJsonSafeString").catch(ctx)?;
-    let encoded: Option<String> = encode.call((value.clone(),)).catch(ctx)?;
+) -> Result<(Option<Value>, Option<String>), JsonValueError<'js>> {
+    let encode: Function<'_> = ctx
+        .globals()
+        .get("__browserosJsonSafeString")
+        .catch(ctx)
+        .map_err(JsonValueError::Js)?;
+    let encoded: Option<String> = encode
+        .call((value.clone(),))
+        .catch(ctx)
+        .map_err(JsonValueError::Js)?;
     let Some(encoded) = encoded else {
         return Ok((None, None));
     };
-    let display: Function<'_> = ctx.globals().get("__browserosSafeStringify").catch(ctx)?;
-    let return_text: String = display.call((value,)).catch(ctx)?;
+    if encoded.len() > MAX_RETURN_VALUE_BYTES {
+        return Err(JsonValueError::Limit(format!(
+            "run return value exceeded {MAX_RETURN_VALUE_BYTES} byte limit"
+        )));
+    }
+    let display: Function<'_> = ctx
+        .globals()
+        .get("__browserosSafeStringify")
+        .catch(ctx)
+        .map_err(JsonValueError::Js)?;
+    let return_text: String = display
+        .call((value,))
+        .catch(ctx)
+        .map_err(JsonValueError::Js)?;
     let value = serde_json::from_str(&encoded).map_err(|err| {
-        CaughtError::Error(rquickjs::Error::new_from_js_message(
+        JsonValueError::Js(CaughtError::Error(rquickjs::Error::new_from_js_message(
             "string",
             "JSON",
             err.to_string(),
-        ))
+        )))
     })?;
     Ok((Some(value), Some(return_text)))
 }
@@ -824,24 +875,39 @@ fn format_outcome(outcome: &RunOutcome) -> String {
     sections.join("\n")
 }
 
-fn timeout_duration(timeout_ms: f64) -> Duration {
+fn normalized_timeout_ms(timeout_ms: f64) -> u64 {
     if !timeout_ms.is_finite() || timeout_ms <= 0.0 {
-        Duration::from_millis(1)
+        MIN_TIMEOUT_MS
     } else {
-        Duration::from_secs_f64(timeout_ms / 1000.0)
+        timeout_ms.ceil().min(MAX_TIMEOUT_MS as f64) as u64
     }
 }
 
-fn logs_snapshot(logs: &Arc<Mutex<Vec<String>>>) -> Vec<String> {
+fn logs_snapshot(logs: &SharedLogs) -> Vec<String> {
     logs.lock()
-        .map(|logs| logs.clone())
+        .map(|logs| logs.entries.clone())
         .unwrap_or_else(|_| Vec::new())
 }
 
-fn push_log(logs: &Arc<Mutex<Vec<String>>>, line: String) {
-    if let Ok(mut logs) = logs.lock() {
-        logs.push(line);
+fn push_log(logs: &SharedLogs, line: String) -> Result<(), String> {
+    let mut logs = logs
+        .lock()
+        .map_err(|_| "run log capture unavailable".to_string())?;
+    if let Some(message) = &logs.limit_message {
+        return Err(message.clone());
     }
+    if logs.entries.len() >= MAX_LOG_ENTRIES
+        || logs.bytes.saturating_add(line.len()) > MAX_LOG_BYTES
+    {
+        let message = format!(
+            "run console output exceeded limit (max {MAX_LOG_ENTRIES} entries, {MAX_LOG_BYTES} bytes)"
+        );
+        logs.limit_message = Some(message.clone());
+        return Err(message);
+    }
+    logs.bytes = logs.bytes.saturating_add(line.len());
+    logs.entries.push(line);
+    Ok(())
 }
 
 fn engine_error(error: rquickjs::Error) -> RunError {
@@ -856,7 +922,7 @@ mod tests {
         output_file::create_browser_output_file_access,
     };
     use browseros_cdp::{CdpError, CdpEvent};
-    use browseros_core::{BrowserSession, BrowserSessionHooks, CdpConnection};
+    use browseros_core::{BrowserSession, BrowserSessionHooks, CdpConnection, WindowId};
     use futures_util::future::BoxFuture;
     use serde_json::json;
     use tokio::sync::broadcast;
@@ -864,12 +930,36 @@ mod tests {
 
     struct RunFakeConnection {
         sender: broadcast::Sender<CdpEvent>,
+        state: Arc<Mutex<RunFakeState>>,
+    }
+
+    #[derive(Default)]
+    struct RunFakeState {
+        create_tab_params: Vec<Value>,
+        add_group_params: Vec<Value>,
     }
 
     impl RunFakeConnection {
         fn new() -> Self {
             let (sender, _receiver) = broadcast::channel(8);
-            Self { sender }
+            Self {
+                sender,
+                state: Arc::new(Mutex::new(RunFakeState::default())),
+            }
+        }
+
+        fn create_tab_params(&self) -> Vec<Value> {
+            self.state
+                .lock()
+                .map(|state| state.create_tab_params.clone())
+                .unwrap_or_default()
+        }
+
+        fn add_group_params(&self) -> Vec<Value> {
+            self.state
+                .lock()
+                .map(|state| state.add_group_params.clone())
+                .unwrap_or_default()
         }
     }
 
@@ -877,26 +967,60 @@ mod tests {
         fn send<'a>(
             &'a self,
             method: &'a str,
-            _params: Value,
+            params: Value,
             _session: Option<&'a SessionId>,
         ) -> BoxFuture<'a, Result<Value, CdpError>> {
+            let state = self.state.clone();
             Box::pin(async move {
                 match method {
                     "Browser.getTabs" => Ok(json!({
-                        "tabs": [{
-                            "tabId": 7,
-                            "targetId": "target-7",
-                            "url": "https://example.com",
-                            "title": "Example",
-                            "isActive": true,
-                            "isLoading": false,
-                            "loadProgress": 1.0,
-                            "isPinned": false,
-                            "isHidden": false,
-                            "windowId": 1,
-                            "index": 0
-                        }]
+                        "tabs": [fake_tab_json(7, "target-7", "https://example.com", "Example", 1, 0)]
                     })),
+                    "Browser.createTab" => {
+                        if let Ok(mut state) = state.lock() {
+                            state.create_tab_params.push(params.clone());
+                        }
+                        Ok(json!({
+                            "tab": fake_tab_json(
+                                9,
+                                "target-9",
+                                params.get("url").and_then(Value::as_str).unwrap_or("about:blank"),
+                                "Created",
+                                params.get("windowId").and_then(Value::as_i64).unwrap_or(1),
+                                1
+                            )
+                        }))
+                    }
+                    "Browser.getTabInfo" => {
+                        let tab_id = params.get("tabId").and_then(Value::as_i64).unwrap_or(7);
+                        let tab = if tab_id == 9 {
+                            fake_tab_json(9, "target-9", "https://new.example", "Created", 42, 1)
+                        } else {
+                            fake_tab_json(7, "target-7", "https://example.com", "Example", 1, 0)
+                        };
+                        Ok(json!({ "tab": tab }))
+                    }
+                    "Browser.addTabsToGroup" => {
+                        if let Ok(mut state) = state.lock() {
+                            state.add_group_params.push(params.clone());
+                        }
+                        Ok(json!({
+                            "group": {
+                                "groupId": params
+                                    .get("groupId")
+                                    .and_then(Value::as_str)
+                                    .unwrap_or("group-1"),
+                                "windowId": 42,
+                                "title": "group",
+                                "color": "blue",
+                                "collapsed": false,
+                                "tabIds": params
+                                    .get("tabIds")
+                                    .cloned()
+                                    .unwrap_or_else(|| json!([]))
+                            }
+                        }))
+                    }
                     _ => Err(CdpError::Protocol {
                         code: -1,
                         message: format!("unexpected fake CDP call: {method}"),
@@ -933,24 +1057,37 @@ mod tests {
     }
 
     fn test_ctx() -> ToolCtx {
+        test_ctx_for(
+            Arc::new(RunFakeConnection::new()),
+            BrowserToolDefaults::default(),
+        )
+    }
+
+    fn test_ctx_for(connection: Arc<RunFakeConnection>, defaults: BrowserToolDefaults) -> ToolCtx {
         ToolCtx::new(BrowserToolOptions {
-            session: BrowserSession::new(
-                Arc::new(RunFakeConnection::new()),
-                BrowserSessionHooks::default(),
-            ),
-            defaults: BrowserToolDefaults::default(),
+            session: BrowserSession::new(connection, BrowserSessionHooks::default()),
+            defaults,
             cancel: CancellationToken::new(),
             output_files: create_browser_output_file_access(),
         })
     }
 
     async fn run_tool(code: &str, timeout: Option<f64>) -> anyhow::Result<ToolResult> {
+        let ctx = test_ctx();
+        run_tool_with_ctx(code, timeout, &ctx).await
+    }
+
+    async fn run_tool_with_ctx(
+        code: &str,
+        timeout: Option<f64>,
+        ctx: &ToolCtx,
+    ) -> anyhow::Result<ToolResult> {
         let mut args = json!({ "code": code });
         if let (Value::Object(object), Some(timeout)) = (&mut args, timeout) {
             object.insert("timeout".to_string(), json!(timeout));
         }
         let def = definition();
-        execute_tool(&def, args, &test_ctx())
+        execute_tool(&def, args, ctx)
             .await
             .map_err(|err| anyhow::anyhow!(err.to_string()))
     }
@@ -1049,6 +1186,61 @@ while (true) {}
     }
 
     #[tokio::test]
+    async fn run_clamps_pathological_timeout_values() -> anyhow::Result<()> {
+        let result = run_tool("return 'ok'", Some(f64::MAX)).await?;
+        assert!(!result.is_error);
+        assert_eq!(
+            result.structured_content,
+            Some(json!({
+                "ok": true,
+                "value": "ok",
+                "logs": []
+            }))
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_rejects_excessive_console_output_as_structured_error() -> anyhow::Result<()> {
+        let result = run_tool(
+            &format!("console.log('x'.repeat({}));", MAX_LOG_BYTES + 1),
+            None,
+        )
+        .await?;
+        assert!(result.is_error);
+        assert_eq!(
+            result.structured_content,
+            Some(json!({
+                "ok": false,
+                "logs": [],
+                "error": format!(
+                    "run console output exceeded limit (max {MAX_LOG_ENTRIES} entries, {MAX_LOG_BYTES} bytes)"
+                )
+            }))
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_rejects_excessive_return_output_as_structured_error() -> anyhow::Result<()> {
+        let result = run_tool(
+            &format!("return 'x'.repeat({});", MAX_RETURN_VALUE_BYTES + 1),
+            None,
+        )
+        .await?;
+        assert!(result.is_error);
+        assert_eq!(
+            result.structured_content,
+            Some(json!({
+                "ok": false,
+                "logs": [],
+                "error": format!("run return value exceeded {MAX_RETURN_VALUE_BYTES} byte limit")
+            }))
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn run_proxies_browser_pages_list() -> anyhow::Result<()> {
         let result = run_tool(
             r#"
@@ -1080,6 +1272,109 @@ return pages.map((page) => ({
         Ok(())
     }
 
+    #[tokio::test]
+    async fn run_proxies_browser_pages_get_info_with_refresh() -> anyhow::Result<()> {
+        let result = run_tool(
+            r#"
+const page = await browser.pages.getInfo(1);
+return { pageId: page.pageId, tabId: page.tabId, url: page.url, title: page.title };
+"#,
+            None,
+        )
+        .await?;
+        assert!(!result.is_error);
+        assert_eq!(
+            result.structured_content,
+            Some(json!({
+                "ok": true,
+                "value": {
+                    "pageId": 1,
+                    "tabId": 7,
+                    "url": "https://example.com",
+                    "title": "Example"
+                },
+                "logs": []
+            }))
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_pages_new_page_forwards_default_placement() -> anyhow::Result<()> {
+        let connection = Arc::new(RunFakeConnection::new());
+        let ctx = test_ctx_for(
+            connection.clone(),
+            BrowserToolDefaults {
+                default_window_id: Some(WindowId(42)),
+                default_tab_group_id: Some("group-1".to_string()),
+            },
+        );
+        let result = run_tool_with_ctx(
+            "return await browser.pages.newPage('https://new.example')",
+            None,
+            &ctx,
+        )
+        .await?;
+        assert!(!result.is_error);
+        assert_eq!(
+            result.structured_content,
+            Some(json!({
+                "ok": true,
+                "value": 1,
+                "logs": []
+            }))
+        );
+
+        let create_params = connection.create_tab_params();
+        assert_eq!(create_params.len(), 1);
+        assert_eq!(
+            create_params.first().and_then(|params| params.get("url")),
+            Some(&json!("https://new.example"))
+        );
+        assert_eq!(
+            create_params
+                .first()
+                .and_then(|params| params.get("windowId")),
+            Some(&json!(42))
+        );
+
+        let group_params = connection.add_group_params();
+        assert_eq!(group_params.len(), 1);
+        assert_eq!(
+            group_params
+                .first()
+                .and_then(|params| params.get("groupId")),
+            Some(&json!("group-1"))
+        );
+        assert_eq!(
+            group_params.first().and_then(|params| params.get("tabIds")),
+            Some(&json!([9]))
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_browser_api_failure_rejects_into_structured_error() -> anyhow::Result<()> {
+        let result = run_tool("await browser.cdp('Browser.nope')", None).await?;
+        assert!(result.is_error);
+        let structured = result
+            .structured_content
+            .as_ref()
+            .and_then(Value::as_object)
+            .ok_or_else(|| anyhow::anyhow!("missing structured object"))?;
+        assert_eq!(structured.get("ok"), Some(&json!(false)));
+        assert_eq!(structured.get("logs"), Some(&json!([])));
+        let error = structured
+            .get("error")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow::anyhow!("missing structured error"))?;
+        assert!(
+            error.contains("unexpected fake CDP call: Browser.nope"),
+            "unexpected error: {error}"
+        );
+        Ok(())
+    }
+
     fn result_text(result: &ToolResult) -> anyhow::Result<&str> {
         result
             .content
@@ -1087,5 +1382,28 @@ return pages.map((page) => ({
             .and_then(|content| content.as_text())
             .map(|content| content.text.as_str())
             .ok_or_else(|| anyhow::anyhow!("missing text result"))
+    }
+
+    fn fake_tab_json(
+        tab_id: i64,
+        target_id: &str,
+        url: &str,
+        title: &str,
+        window_id: i64,
+        index: i64,
+    ) -> Value {
+        json!({
+            "tabId": tab_id,
+            "targetId": target_id,
+            "url": url,
+            "title": title,
+            "isActive": true,
+            "isLoading": false,
+            "loadProgress": 1.0,
+            "isPinned": false,
+            "isHidden": false,
+            "windowId": window_id,
+            "index": index
+        })
     }
 }

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
@@ -2,7 +2,9 @@ use crate::framework::{
     BrowserToolDefaults, ToolCtx, ToolError, ToolExecResult, ToolResult, page_json, parse_args,
     text_result,
 };
-use browseros_core::{PageId, Ref, SessionId, input::ScrollDirection, pages::NewPageOptions};
+use browseros_core::{
+    PageId, Ref, SessionId, WindowId, input::ScrollDirection, pages::NewPageOptions,
+};
 use futures_util::future::BoxFuture;
 use rquickjs::{
     Array, AsyncContext, AsyncRuntime, CatchResultExt, CaughtError, Ctx, Exception, FromJs,
@@ -88,7 +90,7 @@ const BOOTSTRAP_JS: &str = r#"
   const browser = {
     pages: {
       list: () => call('pages.list', []),
-      newPage: (url) => call('pages.newPage', [url]),
+      newPage: (url, opts) => call('pages.newPage', [url, opts]),
       close: (pageId) => call('pages.close', [pageId]),
       getInfo: (pageId) => call('pages.getInfo', [pageId]),
     },
@@ -506,15 +508,21 @@ impl BrowserBridge {
             }
             "pages.newPage" => {
                 let url = string_arg(&args, 0, "url")?;
+                let opts = optional_object_arg(&args, 1)?;
+                let window_id = optional_i64_field(opts, "windowId")?
+                    .map(WindowId)
+                    .or_else(|| self.defaults.default_window_id.clone());
+                let tab_group_id = optional_string_field(opts, "tabGroupId")?
+                    .or_else(|| self.defaults.default_tab_group_id.clone());
                 let page_id = self
                     .control
                     .race(self.session.pages.new_page(
                         &url,
                         NewPageOptions {
-                            background: None,
-                            hidden: None,
-                            window_id: self.defaults.default_window_id.clone(),
-                            tab_group_id: self.defaults.default_tab_group_id.clone(),
+                            background: optional_bool_field(opts, "background")?,
+                            hidden: optional_bool_field(opts, "hidden")?,
+                            window_id,
+                            tab_group_id,
                         },
                     ))
                     .await?;
@@ -717,6 +725,53 @@ fn optional_json_arg(args: &[Value], index: usize) -> Option<Value> {
     match args.get(index) {
         None | Some(Value::Null) => None,
         Some(value) => Some(value.clone()),
+    }
+}
+
+fn optional_object_arg(
+    args: &[Value],
+    index: usize,
+) -> Result<Option<&Map<String, Value>>, String> {
+    match args.get(index) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Object(value)) => Ok(Some(value)),
+        Some(_) => Err(format!("argument {index} must be an object")),
+    }
+}
+
+fn optional_bool_field(
+    object: Option<&Map<String, Value>>,
+    name: &str,
+) -> Result<Option<bool>, String> {
+    match object.and_then(|object| object.get(name)) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Bool(value)) => Ok(Some(*value)),
+        Some(_) => Err(format!("{name} must be a boolean")),
+    }
+}
+
+fn optional_i64_field(
+    object: Option<&Map<String, Value>>,
+    name: &str,
+) -> Result<Option<i64>, String> {
+    match object.and_then(|object| object.get(name)) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::Number(value)) => value
+            .as_i64()
+            .map(Some)
+            .ok_or_else(|| format!("{name} must be an integer")),
+        Some(_) => Err(format!("{name} must be an integer")),
+    }
+}
+
+fn optional_string_field(
+    object: Option<&Map<String, Value>>,
+    name: &str,
+) -> Result<Option<String>, String> {
+    match object.and_then(|object| object.get(name)) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        Some(_) => Err(format!("{name} must be a string")),
     }
 }
 
@@ -946,6 +1001,7 @@ mod tests {
     struct RunFakeState {
         create_tab_params: Vec<Value>,
         add_group_params: Vec<Value>,
+        get_windows_calls: usize,
     }
 
     impl RunFakeConnection {
@@ -970,6 +1026,13 @@ mod tests {
                 .map(|state| state.add_group_params.clone())
                 .unwrap_or_default()
         }
+
+        fn get_windows_calls(&self) -> usize {
+            self.state
+                .lock()
+                .map(|state| state.get_windows_calls)
+                .unwrap_or_default()
+        }
     }
 
     impl CdpConnection for RunFakeConnection {
@@ -985,6 +1048,14 @@ mod tests {
                     "Browser.getTabs" => Ok(json!({
                         "tabs": [fake_tab_json(7, "target-7", "https://example.com", "Example", 1, 0)]
                     })),
+                    "Browser.getWindows" => {
+                        if let Ok(mut state) = state.lock() {
+                            state.get_windows_calls += 1;
+                        }
+                        Ok(json!({
+                            "windows": [fake_window_json(88, false)]
+                        }))
+                    }
                     "Browser.hang" => {
                         futures_util::future::pending::<Result<Value, CdpError>>().await
                     }
@@ -1424,6 +1495,70 @@ return { pageId: page.pageId, tabId: page.tabId, url: page.url, title: page.titl
     }
 
     #[tokio::test]
+    async fn run_pages_new_page_forwards_options_object() -> anyhow::Result<()> {
+        let connection = Arc::new(RunFakeConnection::new());
+        let ctx = test_ctx_for(
+            connection.clone(),
+            BrowserToolDefaults {
+                default_window_id: Some(WindowId(42)),
+                default_tab_group_id: Some("default-group".to_string()),
+            },
+        );
+        let result = run_tool_with_ctx(
+            r#"
+return await browser.pages.newPage('https://new.example', {
+  hidden: true,
+  background: true,
+  windowId: 88,
+  tabGroupId: 'group-opts',
+});
+"#,
+            None,
+            &ctx,
+        )
+        .await?;
+        assert!(!result.is_error);
+        assert_eq!(
+            result.structured_content,
+            Some(json!({
+                "ok": true,
+                "value": 1,
+                "logs": []
+            }))
+        );
+
+        let create_params = connection.create_tab_params();
+        assert_eq!(connection.get_windows_calls(), 1);
+        assert_eq!(create_params.len(), 1);
+        assert_eq!(
+            create_params.first().and_then(|params| params.get("url")),
+            Some(&json!("https://new.example"))
+        );
+        assert_eq!(
+            create_params
+                .first()
+                .and_then(|params| params.get("background")),
+            Some(&json!(true))
+        );
+        assert_eq!(
+            create_params
+                .first()
+                .and_then(|params| params.get("windowId")),
+            Some(&json!(88))
+        );
+
+        let group_params = connection.add_group_params();
+        assert_eq!(group_params.len(), 1);
+        assert_eq!(
+            group_params
+                .first()
+                .and_then(|params| params.get("groupId")),
+            Some(&json!("group-opts"))
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn run_exercises_remaining_browser_namespaces() -> anyhow::Result<()> {
         let result = run_tool(
             r#"
@@ -1527,6 +1662,17 @@ return seen;
             "isHidden": false,
             "windowId": window_id,
             "index": index
+        })
+    }
+
+    fn fake_window_json(window_id: i64, is_visible: bool) -> Value {
+        json!({
+            "windowId": window_id,
+            "windowType": "normal",
+            "bounds": {},
+            "isActive": !is_visible,
+            "isVisible": is_visible,
+            "tabCount": 0
         })
     }
 }

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
@@ -187,9 +187,7 @@ fn handler<'a>(
         let outcome = match execute_run(args, ctx).await {
             Ok(outcome) => outcome,
             Err(RunError::Syntax(message)) => {
-                return Ok(Some(crate::framework::error_result(format!(
-                    "run: syntax error - {message}"
-                ))));
+                RunOutcome::failure(format!("run: syntax error - {message}"), Vec::new())
             }
             Err(RunError::Cancelled) => return Err(ToolError::Cancelled),
             Err(RunError::Engine(message)) => return Err(ToolError::message(message)),
@@ -411,11 +409,22 @@ async fn execute_quickjs(
 
             match promise.into_future::<JsValue<'_>>().await.catch(&ctx) {
                 Ok(value) => match json_safe_value(&ctx, value) {
-                    Ok((value, return_text)) => Ok(RunOutcome::success(
-                        value,
-                        return_text,
-                        logs_snapshot(&logs),
-                    )),
+                    Ok((value, return_text)) => {
+                        if control.is_cancelled() {
+                            return Err(RunError::Cancelled);
+                        }
+                        if control.timed_out() {
+                            return Ok(RunOutcome::failure(
+                                control.timeout_message.to_string(),
+                                logs_snapshot(&logs),
+                            ));
+                        }
+                        Ok(RunOutcome::success(
+                            value,
+                            return_text,
+                            logs_snapshot(&logs),
+                        ))
+                    }
                     Err(JsonValueError::Limit(message)) => {
                         Ok(RunOutcome::failure(message, logs_snapshot(&logs)))
                     }
@@ -976,6 +985,9 @@ mod tests {
                     "Browser.getTabs" => Ok(json!({
                         "tabs": [fake_tab_json(7, "target-7", "https://example.com", "Example", 1, 0)]
                     })),
+                    "Browser.hang" => {
+                        futures_util::future::pending::<Result<Value, CdpError>>().await
+                    }
                     "Browser.createTab" => {
                         if let Ok(mut state) = state.lock() {
                             state.create_tab_params.push(params.clone());
@@ -1000,6 +1012,14 @@ mod tests {
                         };
                         Ok(json!({ "tab": tab }))
                     }
+                    "Target.attachToTarget" => Ok(json!({ "sessionId": "session-target-7" })),
+                    "Page.enable"
+                    | "DOM.enable"
+                    | "Runtime.enable"
+                    | "Accessibility.enable"
+                    | "Runtime.runIfWaitingForDebugger"
+                    | "Target.setAutoAttach"
+                    | "Page.reload" => Ok(json!({})),
                     "Browser.addTabsToGroup" => {
                         if let Ok(mut state) = state.lock() {
                             state.add_group_params.push(params.clone());
@@ -1036,10 +1056,13 @@ mod tests {
             _session: Option<&'a SessionId>,
         ) -> BoxFuture<'a, Result<String, CdpError>> {
             Box::pin(async move {
-                Err(CdpError::Protocol {
-                    code: -1,
-                    message: format!("unexpected fake CDP raw call: {method}"),
-                })
+                match method {
+                    "Runtime.evaluate" => Ok(json!({ "result": { "value": 3 } }).to_string()),
+                    _ => Err(CdpError::Protocol {
+                        code: -1,
+                        message: format!("unexpected fake CDP raw call: {method}"),
+                    }),
+                }
             })
         }
 
@@ -1164,6 +1187,28 @@ throw new Error('boom');
     }
 
     #[tokio::test]
+    async fn run_reports_syntax_error_as_structured_error() -> anyhow::Result<()> {
+        let result = run_tool("return (", None).await?;
+        assert!(result.is_error);
+        let structured = result
+            .structured_content
+            .as_ref()
+            .and_then(Value::as_object)
+            .ok_or_else(|| anyhow::anyhow!("missing structured object"))?;
+        assert_eq!(structured.get("ok"), Some(&json!(false)));
+        assert_eq!(structured.get("logs"), Some(&json!([])));
+        let error = structured
+            .get("error")
+            .and_then(Value::as_str)
+            .ok_or_else(|| anyhow::anyhow!("missing structured error"))?;
+        assert!(
+            error.starts_with("run: syntax error - "),
+            "unexpected error: {error}"
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn run_reports_timeout_with_logs_so_far() -> anyhow::Result<()> {
         let result = run_tool(
             r#"
@@ -1179,6 +1224,31 @@ while (true) {}
             Some(json!({
                 "ok": false,
                 "logs": ["before"],
+                "error": "run exceeded 10ms"
+            }))
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_timeout_cannot_be_caught_as_success() -> anyhow::Result<()> {
+        let result = run_tool(
+            r#"
+try {
+  await browser.cdp('Browser.hang');
+} catch (_err) {
+  return 'caught';
+}
+"#,
+            Some(10.0),
+        )
+        .await?;
+        assert!(result.is_error);
+        assert_eq!(
+            result.structured_content,
+            Some(json!({
+                "ok": false,
+                "logs": [],
                 "error": "run exceeded 10ms"
             }))
         );
@@ -1350,6 +1420,59 @@ return { pageId: page.pageId, tabId: page.tabId, url: page.url, title: page.titl
             group_params.first().and_then(|params| params.get("tabIds")),
             Some(&json!([9]))
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_exercises_remaining_browser_namespaces() -> anyhow::Result<()> {
+        let result = run_tool(
+            r#"
+const seen = {};
+seen.cdp = (await browser.cdp('Browser.getTabs')).tabs.length;
+seen.cdpJsonForPage = await browser.cdpJsonForPage(
+  1,
+  'Runtime.evaluate',
+  '{"expression":"1+1"}'
+);
+for (const [name, action] of Object.entries({
+  observe: () => browser.observe(999).snapshot(),
+  input: () => browser.input(999).type('x'),
+  nav: () => browser.nav(999).reload(),
+})) {
+  try {
+    await action();
+    seen[name] = 'ok';
+  } catch (err) {
+    seen[name] = String(err && err.message ? err.message : err);
+  }
+}
+return seen;
+"#,
+            None,
+        )
+        .await?;
+        assert!(!result.is_error);
+        let value = result
+            .structured_content
+            .as_ref()
+            .and_then(|structured| structured.get("value"))
+            .and_then(Value::as_object)
+            .ok_or_else(|| anyhow::anyhow!("missing structured value"))?;
+        assert_eq!(value.get("cdp"), Some(&json!(1)));
+        assert_eq!(
+            value.get("cdpJsonForPage"),
+            Some(&json!({ "result": { "value": 3 } }))
+        );
+        for namespace in ["observe", "input", "nav"] {
+            let error = value
+                .get(namespace)
+                .and_then(Value::as_str)
+                .ok_or_else(|| anyhow::anyhow!("missing {namespace} result"))?;
+            assert!(
+                error.contains("Unknown page 999"),
+                "unexpected {namespace} error: {error}"
+            );
+        }
         Ok(())
     }
 

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/run.rs
@@ -1,8 +1,22 @@
-use crate::framework::{ToolCtx, ToolExecResult, ToolResult, parse_args, text_result};
+use crate::framework::{
+    ToolCtx, ToolError, ToolExecResult, ToolResult, page_json, parse_args, text_result,
+};
+use browseros_core::{PageId, Ref, SessionId, input::ScrollDirection, pages::NewPageOptions};
 use futures_util::future::BoxFuture;
+use rquickjs::{
+    Array, AsyncContext, AsyncRuntime, CatchResultExt, CaughtError, Ctx, Exception, FromJs,
+    Function, IntoJs, Object, Promise, Value as JsValue,
+    function::{Async, Func},
+};
 use schemars::JsonSchema;
 use serde::Deserialize;
-use serde_json::{Value, json};
+use serde_json::{Map, Value, json};
+use std::{
+    future::Future,
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+use tokio::time::{Instant, sleep_until};
 
 const DEFAULT_TIMEOUT_MS: f64 = 30_000.0;
 
@@ -18,6 +32,114 @@ Available as `browser`:
   browser.cdp(method, params?, sessionId?)   // raw CDP escape hatch
   browser.cdpJsonForPage(pageId, method, paramsJson) // page-scoped raw CDP with validated JSON params
 Refs (eN) come from a snapshot's text/refs."#;
+
+const BOOTSTRAP_JS: &str = r#"
+(() => {
+  const AsyncFunction = Object.getPrototypeOf(async function() {}).constructor;
+
+  function safeStringify(value) {
+    if (value === undefined) return 'undefined';
+    try {
+      const encoded = JSON.stringify(value, null, 2);
+      return encoded ?? String(value);
+    } catch {
+      return String(value);
+    }
+  }
+
+  function jsonSafeString(value) {
+    const seen = new WeakSet();
+    let encoded;
+    try {
+      encoded = JSON.stringify(value, (_key, next) => {
+        if (typeof next === 'bigint') return next.toString();
+        if (typeof next === 'function' || typeof next === 'symbol') {
+          return String(next);
+        }
+        if (typeof next === 'number' && !Number.isFinite(next)) return null;
+        if (typeof next === 'object' && next !== null) {
+          if (seen.has(next)) return '[Circular]';
+          seen.add(next);
+        }
+        return next;
+      });
+    } catch {
+      return JSON.stringify(safeStringify(value));
+    }
+    return encoded;
+  }
+
+  function call(method, args) {
+    return __browserosCall(method, JSON.stringify(args ?? []));
+  }
+
+  function scoped(prefix, pageId) {
+    return (name, args) => call(`${prefix}.${name}`, [pageId, ...args]);
+  }
+
+  const browser = {
+    pages: {
+      list: () => call('pages.list', []),
+      newPage: (url) => call('pages.newPage', [url]),
+      close: (pageId) => call('pages.close', [pageId]),
+      getInfo: (pageId) => call('pages.getInfo', [pageId]),
+    },
+    observe: (pageId) => {
+      const run = scoped('observe', pageId);
+      return {
+        snapshot: () => run('snapshot', []),
+        diff: () => run('diff', []),
+        resolveRef: (ref) => run('resolveRef', [ref]),
+      };
+    },
+    input: (pageId) => {
+      const run = scoped('input', pageId);
+      return {
+        click: (ref) => run('click', [ref]),
+        fill: (ref, value) => run('fill', [ref, value]),
+        type: (text) => run('type', [text]),
+        press: (key) => run('press', [key]),
+        hover: (ref) => run('hover', [ref]),
+        selectOption: (ref, value) => run('selectOption', [ref, value]),
+        scroll: (dir, amount, ref) => run('scroll', [dir, amount, ref]),
+      };
+    },
+    nav: (pageId) => {
+      const run = scoped('nav', pageId);
+      return {
+        goto: (url) => run('goto', [url]),
+        back: () => run('back', []),
+        forward: () => run('forward', []),
+        reload: () => run('reload', []),
+      };
+    },
+    cdp: (method, params, sessionId) => call('cdp', [method, params, sessionId]),
+    cdpJsonForPage: (pageId, method, paramsJson) =>
+      call('cdpJsonForPage', [pageId, method, paramsJson]),
+  };
+
+  const sink = (level) => (...parts) => {
+    __browserosPushLog(
+      `${level}${parts
+        .map((part) => (typeof part === 'string' ? part : safeStringify(part)))
+        .join(' ')}`
+    );
+  };
+
+  globalThis.__browserosBrowser = browser;
+  globalThis.__browserosConsole = {
+    log: sink(''),
+    info: sink(''),
+    warn: sink('warn: '),
+    error: sink('error: '),
+    debug: sink(''),
+  };
+  globalThis.__browserosMakeRunFunction = (code) =>
+    new AsyncFunction('browser', 'console', `"use strict";\n${code}`);
+  globalThis.__browserosJsonSafeString = jsonSafeString;
+  globalThis.__browserosSafeStringify = safeStringify;
+})();
+"#;
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 struct RunArgs {
@@ -49,22 +171,921 @@ pub fn definition() -> crate::framework::ToolDef {
 
 fn handler<'a>(
     raw: Value,
-    _ctx: &'a ToolCtx,
+    ctx: &'a ToolCtx,
     _response: &'a mut crate::response::ToolResponse,
 ) -> BoxFuture<'a, ToolExecResult<Option<ToolResult>>> {
     Box::pin(async move {
         let args: RunArgs = parse_args(raw)?;
-        let _ = (args.code, args.timeout);
-        let error = "run is not yet supported in the Rust server";
-        let mut result = text_result(
-            error,
-            Some(json!({ "ok": false, "logs": [], "error": error })),
-        );
-        result.is_error = true;
-        Ok(Some(result))
+        let outcome = match execute_run(args, ctx).await {
+            Ok(outcome) => outcome,
+            Err(RunError::Syntax(message)) => {
+                return Ok(Some(crate::framework::error_result(format!(
+                    "run: syntax error - {message}"
+                ))));
+            }
+            Err(RunError::Cancelled) => return Err(ToolError::Cancelled),
+            Err(RunError::Engine(message)) => return Err(ToolError::message(message)),
+        };
+        Ok(Some(outcome.into_tool_result()))
     })
 }
 
 fn default_timeout() -> f64 {
     DEFAULT_TIMEOUT_MS
+}
+
+#[derive(Clone)]
+struct RunControl {
+    cancel: tokio_util::sync::CancellationToken,
+    deadline: Instant,
+    timeout_message: Arc<str>,
+}
+
+impl RunControl {
+    async fn race<F, T>(&self, future: F) -> Result<T, String>
+    where
+        F: Future<Output = Result<T, browseros_core::CoreError>>,
+    {
+        tokio::select! {
+            () = self.cancel.cancelled() => Err("cancelled".to_string()),
+            () = sleep_until(self.deadline) => Err(self.timeout_message.to_string()),
+            result = future => result.map_err(|err| err.to_string()),
+        }
+    }
+
+    fn is_cancelled(&self) -> bool {
+        self.cancel.is_cancelled()
+    }
+
+    fn timed_out(&self) -> bool {
+        Instant::now() >= self.deadline
+    }
+}
+
+#[derive(Clone)]
+struct BrowserBridge {
+    session: Arc<browseros_core::BrowserSession>,
+    control: RunControl,
+}
+
+enum BrowserCallValue {
+    Json(Value),
+    Undefined,
+}
+
+#[derive(Debug)]
+enum RunError {
+    Syntax(String),
+    Cancelled,
+    Engine(String),
+}
+
+struct RunOutcome {
+    ok: bool,
+    value: Option<Value>,
+    return_text: Option<String>,
+    logs: Vec<String>,
+    error: Option<String>,
+}
+
+impl RunOutcome {
+    fn success(value: Option<Value>, return_text: Option<String>, logs: Vec<String>) -> Self {
+        Self {
+            ok: true,
+            value,
+            return_text,
+            logs,
+            error: None,
+        }
+    }
+
+    fn failure(error: impl Into<String>, logs: Vec<String>) -> Self {
+        Self {
+            ok: false,
+            value: None,
+            return_text: None,
+            logs,
+            error: Some(error.into()),
+        }
+    }
+
+    fn into_tool_result(self) -> ToolResult {
+        let text = format_outcome(&self);
+        let structured = if self.ok {
+            let mut object = Map::new();
+            object.insert("ok".to_string(), json!(true));
+            if let Some(value) = self.value {
+                object.insert("value".to_string(), value);
+            }
+            object.insert("logs".to_string(), json!(self.logs));
+            Value::Object(object)
+        } else {
+            json!({
+                "ok": false,
+                "logs": self.logs,
+                "error": self.error,
+            })
+        };
+        let mut result = text_result(text, Some(structured));
+        result.is_error = !self.ok;
+        result
+    }
+}
+
+async fn execute_run(args: RunArgs, ctx: &ToolCtx) -> Result<RunOutcome, RunError> {
+    ctx.throw_if_cancelled().map_err(|_| RunError::Cancelled)?;
+    let logs = Arc::new(Mutex::new(Vec::<String>::new()));
+    let duration = timeout_duration(args.timeout);
+    let deadline = Instant::now() + duration;
+    let timeout_message: Arc<str> = Arc::from(format!("run exceeded {}ms", args.timeout));
+    let control = RunControl {
+        cancel: ctx.cancel.clone(),
+        deadline,
+        timeout_message: timeout_message.clone(),
+    };
+    let run = execute_quickjs(
+        args.code,
+        ctx.session.clone(),
+        logs.clone(),
+        control.clone(),
+        duration,
+    );
+    tokio::select! {
+        () = ctx.cancel.cancelled() => Err(RunError::Cancelled),
+        () = sleep_until(deadline) => Ok(RunOutcome::failure(timeout_message.to_string(), logs_snapshot(&logs))),
+        result = run => result,
+    }
+}
+
+async fn execute_quickjs(
+    code: String,
+    session: Arc<browseros_core::BrowserSession>,
+    logs: Arc<Mutex<Vec<String>>>,
+    control: RunControl,
+    duration: Duration,
+) -> Result<RunOutcome, RunError> {
+    let runtime = AsyncRuntime::new().map_err(engine_error)?;
+    let interrupt_control = control.clone();
+    let interrupt_deadline = std::time::Instant::now() + duration;
+    runtime
+        .set_interrupt_handler(Some(Box::new(move || {
+            interrupt_control.is_cancelled() || std::time::Instant::now() >= interrupt_deadline
+        })))
+        .await;
+    let context = AsyncContext::full(&runtime).await.map_err(engine_error)?;
+    let result = context
+        .async_with(async |ctx| {
+            install_globals(&ctx, session, logs.clone(), control.clone())?;
+            ctx.eval::<(), _>(BOOTSTRAP_JS).catch(&ctx).map_err(|err| {
+                RunError::Engine(format!(
+                    "failed to initialize run runtime: {}",
+                    js_error_message(&ctx, err)
+                ))
+            })?;
+
+            let make_run: Function<'_> = ctx
+                .globals()
+                .get("__browserosMakeRunFunction")
+                .catch(&ctx)
+                .map_err(|err| RunError::Engine(js_error_message(&ctx, err)))?;
+            let user_fn: Function<'_> = make_run
+                .call((code,))
+                .catch(&ctx)
+                .map_err(|err| RunError::Syntax(js_error_message(&ctx, err)))?;
+            let browser: Object<'_> = ctx
+                .globals()
+                .get("__browserosBrowser")
+                .catch(&ctx)
+                .map_err(|err| RunError::Engine(js_error_message(&ctx, err)))?;
+            let console: Object<'_> = ctx
+                .globals()
+                .get("__browserosConsole")
+                .catch(&ctx)
+                .map_err(|err| RunError::Engine(js_error_message(&ctx, err)))?;
+            let promise: Promise<'_> = match user_fn.call((browser, console)).catch(&ctx) {
+                Ok(promise) => promise,
+                Err(err) => {
+                    if control.is_cancelled() {
+                        return Err(RunError::Cancelled);
+                    }
+                    if control.timed_out() {
+                        return Ok(RunOutcome::failure(
+                            control.timeout_message.to_string(),
+                            logs_snapshot(&logs),
+                        ));
+                    }
+                    return Ok(RunOutcome::failure(
+                        js_error_message(&ctx, err),
+                        logs_snapshot(&logs),
+                    ));
+                }
+            };
+
+            match promise.into_future::<JsValue<'_>>().await.catch(&ctx) {
+                Ok(value) => {
+                    let (value, return_text) = json_safe_value(&ctx, value)
+                        .map_err(|err| RunError::Engine(js_error_message(&ctx, err)))?;
+                    Ok(RunOutcome::success(
+                        value,
+                        return_text,
+                        logs_snapshot(&logs),
+                    ))
+                }
+                Err(err) => {
+                    if control.is_cancelled() {
+                        Err(RunError::Cancelled)
+                    } else if control.timed_out() {
+                        Ok(RunOutcome::failure(
+                            control.timeout_message.to_string(),
+                            logs_snapshot(&logs),
+                        ))
+                    } else {
+                        Ok(RunOutcome::failure(
+                            js_error_message(&ctx, err),
+                            logs_snapshot(&logs),
+                        ))
+                    }
+                }
+            }
+        })
+        .await;
+    runtime.set_interrupt_handler(None).await;
+    result
+}
+
+fn install_globals<'js>(
+    ctx: &Ctx<'js>,
+    session: Arc<browseros_core::BrowserSession>,
+    logs: Arc<Mutex<Vec<String>>>,
+    control: RunControl,
+) -> Result<(), RunError> {
+    let bridge = BrowserBridge { session, control };
+    let call_bridge = {
+        let bridge = bridge.clone();
+        move |ctx: Ctx<'js>, method: String, args_json: String| {
+            let bridge = bridge.clone();
+            async move {
+                match bridge.call(&method, &args_json).await {
+                    Ok(BrowserCallValue::Json(value)) => json_to_js(&ctx, value),
+                    Ok(BrowserCallValue::Undefined) => Ok(JsValue::new_undefined(ctx.clone())),
+                    Err(message) => Err(Exception::throw_message(&ctx, &message)),
+                }
+            }
+        }
+    };
+    let push_log = move |line: String| {
+        push_log(&logs, line);
+    };
+    let globals = ctx.globals();
+    globals
+        .set("__browserosCall", Func::from(Async(call_bridge)))
+        .catch(ctx)
+        .map_err(|err| RunError::Engine(js_error_message(ctx, err)))?;
+    globals
+        .set("__browserosPushLog", Func::from(push_log))
+        .catch(ctx)
+        .map_err(|err| RunError::Engine(js_error_message(ctx, err)))?;
+    Ok(())
+}
+
+impl BrowserBridge {
+    async fn call(&self, method: &str, args_json: &str) -> Result<BrowserCallValue, String> {
+        let args = parse_bridge_args(args_json)?;
+        match method {
+            "pages.list" => {
+                let pages = self.control.race(self.session.pages.list()).await?;
+                Ok(BrowserCallValue::Json(Value::Array(
+                    pages.iter().map(page_json).collect(),
+                )))
+            }
+            "pages.newPage" => {
+                let url = string_arg(&args, 0, "url")?;
+                let page_id = self
+                    .control
+                    .race(self.session.pages.new_page(
+                        &url,
+                        NewPageOptions {
+                            background: None,
+                            hidden: None,
+                            window_id: None,
+                            tab_group_id: None,
+                        },
+                    ))
+                    .await?;
+                Ok(BrowserCallValue::Json(json!(page_id.0)))
+            }
+            "pages.close" => {
+                let page_id = page_arg(&args, 0)?;
+                self.control.race(self.session.pages.close(page_id)).await?;
+                Ok(BrowserCallValue::Undefined)
+            }
+            "pages.getInfo" => {
+                let page_id = page_arg(&args, 0)?;
+                let info = self
+                    .control
+                    .race(async {
+                        Ok(self
+                            .session
+                            .pages
+                            .get_info(page_id)
+                            .await
+                            .map(|page| page_json(&page)))
+                    })
+                    .await?;
+                Ok(BrowserCallValue::Json(info.unwrap_or(Value::Null)))
+            }
+            "observe.snapshot" => {
+                let page_id = page_arg(&args, 0)?;
+                let observer = self.session.observe(page_id).await;
+                let snapshot = self.control.race(observer.snapshot()).await?;
+                Ok(BrowserCallValue::Json(json!({
+                    "text": snapshot.text,
+                    "refs": refs_json(&snapshot.refs),
+                    "url": snapshot.url,
+                })))
+            }
+            "observe.diff" => {
+                let page_id = page_arg(&args, 0)?;
+                let observer = self.session.observe(page_id).await;
+                let diff = self.control.race(observer.diff()).await?;
+                Ok(BrowserCallValue::Json(diff_json(&diff)))
+            }
+            "observe.resolveRef" => {
+                let page_id = page_arg(&args, 0)?;
+                let ref_id = string_arg(&args, 1, "ref")?;
+                let observer = self.session.observe(page_id).await;
+                let resolved = self
+                    .control
+                    .race(observer.resolve_ref(&Ref(ref_id)))
+                    .await?;
+                Ok(BrowserCallValue::Json(json!({
+                    "backendNodeId": resolved.backend_node_id,
+                    "sessionId": resolved.session.session_id().map(ToString::to_string),
+                })))
+            }
+            "input.click" => {
+                let (page_id, ref_id) = page_ref_args(&args)?;
+                let input = self.session.input(page_id).await;
+                self.control
+                    .race(input.click(&Ref(ref_id), Default::default()))
+                    .await?;
+                Ok(BrowserCallValue::Undefined)
+            }
+            "input.fill" => {
+                let (page_id, ref_id) = page_ref_args(&args)?;
+                let value = string_arg(&args, 2, "value")?;
+                let input = self.session.input(page_id).await;
+                self.control
+                    .race(input.fill(&Ref(ref_id), &value, true))
+                    .await?;
+                Ok(BrowserCallValue::Undefined)
+            }
+            "input.type" => {
+                let page_id = page_arg(&args, 0)?;
+                let text = string_arg(&args, 1, "text")?;
+                let input = self.session.input(page_id).await;
+                self.control.race(input.type_text(&text)).await?;
+                Ok(BrowserCallValue::Undefined)
+            }
+            "input.press" => {
+                let page_id = page_arg(&args, 0)?;
+                let key = string_arg(&args, 1, "key")?;
+                let input = self.session.input(page_id).await;
+                self.control.race(input.press(&key)).await?;
+                Ok(BrowserCallValue::Undefined)
+            }
+            "input.hover" => {
+                let (page_id, ref_id) = page_ref_args(&args)?;
+                let input = self.session.input(page_id).await;
+                self.control.race(input.hover(&Ref(ref_id))).await?;
+                Ok(BrowserCallValue::Undefined)
+            }
+            "input.selectOption" => {
+                let (page_id, ref_id) = page_ref_args(&args)?;
+                let value = string_arg(&args, 2, "value")?;
+                let input = self.session.input(page_id).await;
+                let selected = self
+                    .control
+                    .race(input.select_option(&Ref(ref_id), &value))
+                    .await?;
+                Ok(BrowserCallValue::Json(json!(selected)))
+            }
+            "input.scroll" => {
+                let page_id = page_arg(&args, 0)?;
+                let direction = scroll_direction(&string_arg(&args, 1, "dir")?)?;
+                let amount = optional_f64_arg(&args, 2).unwrap_or(3.0).round() as i64;
+                let ref_id = optional_string_arg(&args, 3)?.map(Ref);
+                let input = self.session.input(page_id).await;
+                self.control
+                    .race(input.scroll(direction, amount, ref_id.as_ref()))
+                    .await?;
+                Ok(BrowserCallValue::Undefined)
+            }
+            "nav.goto" => {
+                let page_id = page_arg(&args, 0)?;
+                let url = string_arg(&args, 1, "url")?;
+                let nav = self.session.nav(page_id);
+                self.control.race(nav.goto(&url)).await?;
+                Ok(BrowserCallValue::Undefined)
+            }
+            "nav.back" => {
+                let page_id = page_arg(&args, 0)?;
+                let nav = self.session.nav(page_id);
+                self.control.race(nav.back()).await?;
+                Ok(BrowserCallValue::Undefined)
+            }
+            "nav.forward" => {
+                let page_id = page_arg(&args, 0)?;
+                let nav = self.session.nav(page_id);
+                self.control.race(nav.forward()).await?;
+                Ok(BrowserCallValue::Undefined)
+            }
+            "nav.reload" => {
+                let page_id = page_arg(&args, 0)?;
+                let nav = self.session.nav(page_id);
+                self.control.race(nav.reload()).await?;
+                Ok(BrowserCallValue::Undefined)
+            }
+            "cdp" => {
+                let method = string_arg(&args, 0, "method")?;
+                let params = optional_json_arg(&args, 1).unwrap_or_else(|| json!({}));
+                let session_id = optional_string_arg(&args, 2)?.map(SessionId::from);
+                let value = self
+                    .control
+                    .race(self.session.cdp(&method, params, session_id.as_ref()))
+                    .await?;
+                Ok(BrowserCallValue::Json(value))
+            }
+            "cdpJsonForPage" => {
+                let page_id = page_arg(&args, 0)?;
+                let method = string_arg(&args, 1, "method")?;
+                let params_json = string_arg(&args, 2, "paramsJson")?;
+                let raw = self
+                    .control
+                    .race(
+                        self.session
+                            .cdp_json_for_page(page_id, &method, &params_json),
+                    )
+                    .await?;
+                let value = serde_json::from_str(&raw).map_err(|err| err.to_string())?;
+                Ok(BrowserCallValue::Json(value))
+            }
+            _ => Err(format!("Unknown browser method {method}")),
+        }
+    }
+}
+
+fn parse_bridge_args(args_json: &str) -> Result<Vec<Value>, String> {
+    serde_json::from_str::<Vec<Value>>(args_json)
+        .map_err(|err| format!("Invalid browser call arguments: {err}"))
+}
+
+fn page_arg(args: &[Value], index: usize) -> Result<PageId, String> {
+    let raw = args
+        .get(index)
+        .and_then(Value::as_u64)
+        .ok_or_else(|| format!("pageId argument {index} is required"))?;
+    let page_id = u32::try_from(raw).map_err(|_| format!("pageId {raw} is out of range"))?;
+    Ok(PageId(page_id))
+}
+
+fn page_ref_args(args: &[Value]) -> Result<(PageId, String), String> {
+    Ok((page_arg(args, 0)?, string_arg(args, 1, "ref")?))
+}
+
+fn string_arg(args: &[Value], index: usize, name: &str) -> Result<String, String> {
+    args.get(index)
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .ok_or_else(|| format!("{name} argument is required"))
+}
+
+fn optional_string_arg(args: &[Value], index: usize) -> Result<Option<String>, String> {
+    match args.get(index) {
+        None | Some(Value::Null) => Ok(None),
+        Some(Value::String(value)) => Ok(Some(value.clone())),
+        Some(_) => Err(format!("argument {index} must be a string")),
+    }
+}
+
+fn optional_f64_arg(args: &[Value], index: usize) -> Option<f64> {
+    args.get(index).and_then(Value::as_f64)
+}
+
+fn optional_json_arg(args: &[Value], index: usize) -> Option<Value> {
+    match args.get(index) {
+        None | Some(Value::Null) => None,
+        Some(value) => Some(value.clone()),
+    }
+}
+
+fn scroll_direction(value: &str) -> Result<ScrollDirection, String> {
+    match value {
+        "up" => Ok(ScrollDirection::Up),
+        "down" => Ok(ScrollDirection::Down),
+        "left" => Ok(ScrollDirection::Left),
+        "right" => Ok(ScrollDirection::Right),
+        _ => Err(format!("Unknown scroll direction {value}")),
+    }
+}
+
+fn refs_json(refs: &browseros_core::snapshot::RefMap) -> Value {
+    Value::Array(
+        refs.entries_in_order()
+            .into_iter()
+            .map(|entry| {
+                let mut value = json!({
+                    "ref": entry.ref_id.as_str(),
+                    "backendNodeId": entry.backend_node_id,
+                    "role": entry.role,
+                    "name": entry.name,
+                    "nth": entry.nth,
+                });
+                if let (Value::Object(object), Some(frame_id)) = (&mut value, &entry.frame_id) {
+                    object.insert("frameId".to_string(), json!(frame_id.as_str()));
+                }
+                value
+            })
+            .collect(),
+    )
+}
+
+fn diff_json(diff: &browseros_core::snapshot::SnapshotDiff) -> Value {
+    let mut value = json!({
+        "text": diff.text,
+        "added": diff.added,
+        "removed": diff.removed,
+        "changed": diff.changed,
+    });
+    if let Value::Object(object) = &mut value {
+        if let Some(before_url) = &diff.before_url {
+            object.insert("beforeUrl".to_string(), json!(before_url));
+        }
+        if let Some(after_url) = &diff.after_url {
+            object.insert("afterUrl".to_string(), json!(after_url));
+        }
+    }
+    value
+}
+
+fn json_to_js<'js>(ctx: &Ctx<'js>, value: Value) -> rquickjs::Result<JsValue<'js>> {
+    match value {
+        Value::Null => Ok(JsValue::new_null(ctx.clone())),
+        Value::Bool(value) => Ok(JsValue::new_bool(ctx.clone(), value)),
+        Value::Number(value) => Ok(JsValue::new_number(
+            ctx.clone(),
+            value.as_f64().unwrap_or_default(),
+        )),
+        Value::String(value) => value.into_js(ctx),
+        Value::Array(values) => {
+            let array = Array::new(ctx.clone())?;
+            for (index, value) in values.into_iter().enumerate() {
+                array.set(index, json_to_js(ctx, value)?)?;
+            }
+            Ok(array.into_value())
+        }
+        Value::Object(values) => {
+            let object = Object::new(ctx.clone())?;
+            for (key, value) in values {
+                object.set(key, json_to_js(ctx, value)?)?;
+            }
+            Ok(object.into_value())
+        }
+    }
+}
+
+fn json_safe_value<'js>(
+    ctx: &Ctx<'js>,
+    value: JsValue<'js>,
+) -> rquickjs::CaughtResult<'js, (Option<Value>, Option<String>)> {
+    let encode: Function<'_> = ctx.globals().get("__browserosJsonSafeString").catch(ctx)?;
+    let encoded: Option<String> = encode.call((value.clone(),)).catch(ctx)?;
+    let Some(encoded) = encoded else {
+        return Ok((None, None));
+    };
+    let display: Function<'_> = ctx.globals().get("__browserosSafeStringify").catch(ctx)?;
+    let return_text: String = display.call((value,)).catch(ctx)?;
+    let value = serde_json::from_str(&encoded).map_err(|err| {
+        CaughtError::Error(rquickjs::Error::new_from_js_message(
+            "string",
+            "JSON",
+            err.to_string(),
+        ))
+    })?;
+    Ok((Some(value), Some(return_text)))
+}
+
+fn js_error_message<'js>(ctx: &Ctx<'js>, error: CaughtError<'js>) -> String {
+    match error {
+        CaughtError::Error(error) => error.to_string(),
+        CaughtError::Exception(exception) => {
+            exception.message().unwrap_or_else(|| exception.to_string())
+        }
+        CaughtError::Value(value) => js_value_string(ctx, value),
+    }
+}
+
+fn js_value_string<'js>(ctx: &Ctx<'js>, value: JsValue<'js>) -> String {
+    if value.is_undefined() {
+        return "undefined".to_string();
+    }
+    if value.is_null() {
+        return "null".to_string();
+    }
+    if let Some(value) = value.as_bool() {
+        return value.to_string();
+    }
+    if let Some(value) = value.as_number() {
+        return value.to_string();
+    }
+    if let Ok(value) = String::from_js(ctx, value.clone()) {
+        return value;
+    }
+    let string_constructor: rquickjs::Result<Function<'_>> = ctx.globals().get("String");
+    match string_constructor.and_then(|func| func.call((value,))) {
+        Ok(value) => value,
+        Err(err) => err.to_string(),
+    }
+}
+
+fn format_outcome(outcome: &RunOutcome) -> String {
+    let mut sections = Vec::new();
+    if let Some(error) = &outcome.error {
+        sections.push(format!("error: {error}"));
+    } else {
+        sections.push("ok".to_string());
+        if let Some(value) = &outcome.return_text {
+            sections.push(format!("return: {value}"));
+        }
+    }
+    if !outcome.logs.is_empty() {
+        sections.push(format!("logs:\n{}", outcome.logs.join("\n")));
+    }
+    sections.join("\n")
+}
+
+fn timeout_duration(timeout_ms: f64) -> Duration {
+    if !timeout_ms.is_finite() || timeout_ms <= 0.0 {
+        Duration::from_millis(1)
+    } else {
+        Duration::from_secs_f64(timeout_ms / 1000.0)
+    }
+}
+
+fn logs_snapshot(logs: &Arc<Mutex<Vec<String>>>) -> Vec<String> {
+    logs.lock()
+        .map(|logs| logs.clone())
+        .unwrap_or_else(|_| Vec::new())
+}
+
+fn push_log(logs: &Arc<Mutex<Vec<String>>>, line: String) {
+    if let Ok(mut logs) = logs.lock() {
+        logs.push(line);
+    }
+}
+
+fn engine_error(error: rquickjs::Error) -> RunError {
+    RunError::Engine(error.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        framework::{BrowserToolDefaults, BrowserToolOptions, ToolCtx, execute_tool},
+        output_file::create_browser_output_file_access,
+    };
+    use browseros_cdp::{CdpError, CdpEvent};
+    use browseros_core::{BrowserSession, BrowserSessionHooks, CdpConnection};
+    use futures_util::future::BoxFuture;
+    use serde_json::json;
+    use tokio::sync::broadcast;
+    use tokio_util::sync::CancellationToken;
+
+    struct RunFakeConnection {
+        sender: broadcast::Sender<CdpEvent>,
+    }
+
+    impl RunFakeConnection {
+        fn new() -> Self {
+            let (sender, _receiver) = broadcast::channel(8);
+            Self { sender }
+        }
+    }
+
+    impl CdpConnection for RunFakeConnection {
+        fn send<'a>(
+            &'a self,
+            method: &'a str,
+            _params: Value,
+            _session: Option<&'a SessionId>,
+        ) -> BoxFuture<'a, Result<Value, CdpError>> {
+            Box::pin(async move {
+                match method {
+                    "Browser.getTabs" => Ok(json!({
+                        "tabs": [{
+                            "tabId": 7,
+                            "targetId": "target-7",
+                            "url": "https://example.com",
+                            "title": "Example",
+                            "isActive": true,
+                            "isLoading": false,
+                            "loadProgress": 1.0,
+                            "isPinned": false,
+                            "isHidden": false,
+                            "windowId": 1,
+                            "index": 0
+                        }]
+                    })),
+                    _ => Err(CdpError::Protocol {
+                        code: -1,
+                        message: format!("unexpected fake CDP call: {method}"),
+                    }),
+                }
+            })
+        }
+
+        fn send_raw_json<'a>(
+            &'a self,
+            method: &'a str,
+            _params_json: &'a str,
+            _session: Option<&'a SessionId>,
+        ) -> BoxFuture<'a, Result<String, CdpError>> {
+            Box::pin(async move {
+                Err(CdpError::Protocol {
+                    code: -1,
+                    message: format!("unexpected fake CDP raw call: {method}"),
+                })
+            })
+        }
+
+        fn events(&self) -> broadcast::Receiver<CdpEvent> {
+            self.sender.subscribe()
+        }
+
+        fn is_connected(&self) -> bool {
+            true
+        }
+
+        fn connection_epoch(&self) -> u64 {
+            1
+        }
+    }
+
+    fn test_ctx() -> ToolCtx {
+        ToolCtx::new(BrowserToolOptions {
+            session: BrowserSession::new(
+                Arc::new(RunFakeConnection::new()),
+                BrowserSessionHooks::default(),
+            ),
+            defaults: BrowserToolDefaults::default(),
+            cancel: CancellationToken::new(),
+            output_files: create_browser_output_file_access(),
+        })
+    }
+
+    async fn run_tool(code: &str, timeout: Option<f64>) -> anyhow::Result<ToolResult> {
+        let mut args = json!({ "code": code });
+        if let (Value::Object(object), Some(timeout)) = (&mut args, timeout) {
+            object.insert("timeout".to_string(), json!(timeout));
+        }
+        let def = definition();
+        execute_tool(&def, args, &test_ctx())
+            .await
+            .map_err(|err| anyhow::anyhow!(err.to_string()))
+    }
+
+    #[tokio::test]
+    async fn run_returns_json_safe_value() -> anyhow::Result<()> {
+        let result = run_tool("return 1 + 1", None).await?;
+        assert!(!result.is_error);
+        assert_eq!(
+            result.structured_content,
+            Some(json!({
+                "ok": true,
+                "value": 2,
+                "logs": []
+            }))
+        );
+        let text = result_text(&result)?;
+        assert!(text.contains("ok"));
+        assert!(text.contains("return: 2"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_captures_console_output() -> anyhow::Result<()> {
+        let result = run_tool(
+            r#"
+console.log('a', { b: 1 });
+console.info('i');
+console.warn('w');
+console.error('e');
+return undefined;
+"#,
+            None,
+        )
+        .await?;
+        assert!(!result.is_error);
+        assert_eq!(
+            result.structured_content,
+            Some(json!({
+                "ok": true,
+                "logs": [
+                    "a {\n  \"b\": 1\n}",
+                    "i",
+                    "warn: w",
+                    "error: e"
+                ]
+            }))
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_reports_runtime_exception_as_structured_error() -> anyhow::Result<()> {
+        let result = run_tool(
+            r#"
+console.log('before');
+throw new Error('boom');
+"#,
+            None,
+        )
+        .await?;
+        assert!(result.is_error);
+        assert_eq!(
+            result.structured_content,
+            Some(json!({
+                "ok": false,
+                "logs": ["before"],
+                "error": "boom"
+            }))
+        );
+        let text = result_text(&result)?;
+        assert!(text.contains("error: boom"));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_reports_timeout_with_logs_so_far() -> anyhow::Result<()> {
+        let result = run_tool(
+            r#"
+console.log('before');
+while (true) {}
+"#,
+            Some(10.0),
+        )
+        .await?;
+        assert!(result.is_error);
+        assert_eq!(
+            result.structured_content,
+            Some(json!({
+                "ok": false,
+                "logs": ["before"],
+                "error": "run exceeded 10ms"
+            }))
+        );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn run_proxies_browser_pages_list() -> anyhow::Result<()> {
+        let result = run_tool(
+            r#"
+const pages = await browser.pages.list();
+return pages.map((page) => ({
+  pageId: page.pageId,
+  tabId: page.tabId,
+  url: page.url,
+  title: page.title,
+}));
+"#,
+            None,
+        )
+        .await?;
+        assert!(!result.is_error);
+        assert_eq!(
+            result.structured_content,
+            Some(json!({
+                "ok": true,
+                "value": [{
+                    "pageId": 1,
+                    "tabId": 7,
+                    "url": "https://example.com",
+                    "title": "Example"
+                }],
+                "logs": []
+            }))
+        );
+        Ok(())
+    }
+
+    fn result_text(result: &ToolResult) -> anyhow::Result<&str> {
+        result
+            .content
+            .first()
+            .and_then(|content| content.as_text())
+            .map(|content| content.text.as_str())
+            .ok_or_else(|| anyhow::anyhow!("missing text result"))
+    }
 }


### PR DESCRIPTION
## Summary
- Replace the Rust MCP run stub with a per-invocation rquickjs async runtime.
- Expose the browser SDK bridge for pages, observe, input, nav, raw CDP, and page-scoped raw CDP with TS-compatible structured RunOutput.
- Capture console output, return JSON-safe values, convert user exceptions/syntax/timeouts to structured run results, and bound runtime memory/stack/log/return output.
- Support browser.pages.newPage(url, opts) including hidden/background/windowId/tabGroupId for existing SDK/CLI compatibility.

## Design
rquickjs is the selected engine because it gives async promise/future bridging with a much smaller footprint than embedding V8. The dependency uses std, futures, and parallel features so browser futures can cross the runtime boundary safely. No boa fallback was needed.

## Verification
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check

Review loop ran three rounds; all concrete findings were fixed before opening this PR.