### PR TITLE
feat(mcp): add compact snapshot modes

### DIFF
--- a/packages/browseros-agent/crates/browseros-core/src/observer.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/observer.rs
@@ -4,7 +4,8 @@ use crate::{
     pages::PageManager,
     snapshot::{
         AxNode, DiffOptions, DocumentId, RefEntry, RefMap, RenderOptions, SnapshotDiff,
-        SnapshotObservation, diff_snapshot_observations, render_snapshot,
+        SnapshotObservation, SnapshotOptions, apply_snapshot_options, diff_snapshot_observations,
+        render_snapshot,
     },
 };
 use futures_util::future::BoxFuture;
@@ -78,10 +79,18 @@ impl Observer {
     }
 
     pub async fn snapshot(&self) -> Result<SnapshotResult, CoreError> {
+        self.snapshot_with_options(SnapshotOptions::default()).await
+    }
+
+    pub async fn snapshot_with_options(
+        &self,
+        options: SnapshotOptions,
+    ) -> Result<SnapshotResult, CoreError> {
         let result = self.capture().await?;
+        let text = apply_snapshot_options(&result.text, options);
         self.commit(result.clone()).await;
         Ok(SnapshotResult {
-            text: result.text,
+            text,
             refs: result.refs,
             url: result.url,
         })
@@ -668,7 +677,7 @@ mod tests {
     use crate::{
         BrowserSession, BrowserSessionHooks, CoreError, ProtocolSession,
         connection::CdpConnection,
-        snapshot::{AxNode, AxValue, refs::MintRef},
+        snapshot::{AxNode, AxValue, SnapshotMode, SnapshotOptions, refs::MintRef},
     };
     use browseros_cdp::{CdpError, CdpEvent};
     use futures_util::future::BoxFuture;
@@ -751,6 +760,17 @@ mod tests {
             role: Some(AxValue::role("button")),
             name: Some(AxValue::string(name)),
             backend_dom_node_id: Some(backend_id),
+            ..AxNode::default()
+        }
+    }
+
+    fn ax_named(node_id: &str, role: &str, name: &str, children: &[&str]) -> AxNode {
+        AxNode {
+            node_id: node_id.to_string(),
+            role: Some(AxValue::role(role)),
+            name: (!name.is_empty()).then(|| AxValue::string(name)),
+            child_ids: (!children.is_empty())
+                .then(|| children.iter().map(|child| (*child).to_string()).collect()),
             ..AxNode::default()
         }
     }
@@ -1119,6 +1139,42 @@ mod tests {
             ]
             .join("\n")
         );
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn observer_interactive_snapshot_commits_full_baseline_for_diff() -> Result<(), CoreError>
+    {
+        let state = harness_state(vec![
+            root_with(&["2"]),
+            ax_named("2", "main", "", &["3", "4"]),
+            ax_named("3", "paragraph", "Intro", &[]),
+            ax_button("4", "Save", 1),
+        ]);
+        let (connection, observer) = observer_harness(state).await?;
+        let snapshot = observer
+            .snapshot_with_options(SnapshotOptions {
+                mode: SnapshotMode::Interactive,
+                depth: None,
+            })
+            .await?;
+        assert_eq!(snapshot.text, "- main\n  - button \"Save\" [ref=e1]");
+
+        if let Ok(mut state) = connection.state.lock() {
+            state.nodes = vec![
+                root_with(&["2"]),
+                ax_named("2", "main", "", &["3", "4", "5"]),
+                ax_named("3", "paragraph", "Intro", &[]),
+                ax_button("4", "Save", 1),
+                ax_button("5", "Cancel", 2),
+            ];
+        }
+
+        let diff = observer.diff().await?;
+        assert_eq!(diff.added, 1);
+        assert_eq!(diff.removed, 0);
+        assert!(diff.text.contains("+   button \"Cancel\" [ref=e2]"));
+        assert!(!diff.text.contains("+   paragraph \"Intro\""));
         Ok(())
     }
 }

--- a/packages/browseros-agent/crates/browseros-core/src/snapshot/mod.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/snapshot/mod.rs
@@ -9,4 +9,7 @@ pub use diff::{
     DiffOptions, SnapshotDiff, SnapshotObservation, diff_snapshot_observations, diff_snapshots,
 };
 pub use refs::{DocumentId, RefEntry, RefMap};
-pub use render::{IframeStitch, RenderOptions, RenderResult, render_snapshot};
+pub use render::{
+    IframeStitch, RenderOptions, RenderResult, SnapshotMode, SnapshotOptions,
+    apply_snapshot_options, render_snapshot,
+};

--- a/packages/browseros-agent/crates/browseros-core/src/snapshot/render.rs
+++ b/packages/browseros-agent/crates/browseros-core/src/snapshot/render.rs
@@ -24,6 +24,19 @@ pub struct RenderResult {
     pub iframes: Vec<IframeStitch>,
 }
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum SnapshotMode {
+    #[default]
+    Full,
+    Interactive,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct SnapshotOptions {
+    pub mode: SnapshotMode,
+    pub depth: Option<usize>,
+}
+
 pub struct RenderOptions<'a> {
     pub refs: &'a mut RefMap,
     pub frame_id: Option<FrameId>,
@@ -51,6 +64,19 @@ pub fn render_snapshot<'a>(nodes: &'a [AxNode], opts: &mut RenderOptions<'a>) ->
     RenderResult {
         text: ctx.lines.join("\n"),
         iframes: ctx.iframes,
+    }
+}
+
+#[must_use]
+pub fn apply_snapshot_options(text: &str, options: SnapshotOptions) -> String {
+    let text = match options.mode {
+        SnapshotMode::Full => text.to_string(),
+        SnapshotMode::Interactive => filter_interactive_lines(text),
+    };
+    if let Some(max_depth) = options.depth {
+        filter_depth_lines(&text, max_depth)
+    } else {
+        text
     }
 }
 
@@ -147,6 +173,77 @@ fn is_dropped(role: Option<&str>, name: &str, is_cursor_hit: bool) -> bool {
         return true;
     }
     (role == "generic" || role == "group") && name.is_empty() && !is_cursor_hit
+}
+
+fn filter_interactive_lines(text: &str) -> String {
+    let lines = split_rendered_lines(text);
+    if lines.is_empty() {
+        return String::new();
+    }
+
+    let mut keep = vec![false; lines.len()];
+    let mut ancestors = Vec::<usize>::new();
+    for (index, line) in lines.iter().enumerate() {
+        let depth = rendered_depth(line);
+        if ancestors.len() > depth {
+            ancestors.truncate(depth);
+        }
+
+        if index == 0 || has_ref(line) || rendered_role(line) == Some("heading") {
+            keep[index] = true;
+            for ancestor in &ancestors {
+                keep[*ancestor] = true;
+            }
+        }
+
+        if ancestors.len() == depth {
+            ancestors.push(index);
+        } else if depth < ancestors.len() {
+            ancestors[depth] = index;
+        } else {
+            ancestors.resize(depth, index);
+            ancestors.push(index);
+        }
+    }
+
+    lines
+        .into_iter()
+        .enumerate()
+        .filter_map(|(index, line)| keep[index].then_some(line))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn filter_depth_lines(text: &str, max_depth: usize) -> String {
+    split_rendered_lines(text)
+        .into_iter()
+        .filter(|line| rendered_depth(line) <= max_depth)
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn split_rendered_lines(text: &str) -> Vec<&str> {
+    if text.is_empty() {
+        Vec::new()
+    } else {
+        text.split('\n').collect()
+    }
+}
+
+fn rendered_depth(line: &str) -> usize {
+    line.chars().take_while(|ch| *ch == ' ').count() / 2
+}
+
+fn rendered_role(line: &str) -> Option<&str> {
+    let body = line.trim_start().strip_prefix("- ")?;
+    let end = body
+        .find(|ch: char| ch.is_whitespace() || ch == '[' || ch == ':')
+        .unwrap_or(body.len());
+    Some(&body[..end])
+}
+
+fn has_ref(line: &str) -> bool {
+    line.contains(" [ref=e")
 }
 
 fn format_line(
@@ -273,7 +370,9 @@ fn json_quote(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::{RenderOptions, render_snapshot};
+    use super::{
+        RenderOptions, SnapshotMode, SnapshotOptions, apply_snapshot_options, render_snapshot,
+    };
     use crate::snapshot::{AxNode, AxProperty, AxValue, refs::RefMap};
     use serde_json::json;
     use std::collections::HashMap;
@@ -301,6 +400,14 @@ mod tests {
             base_depth: 0,
         };
         render_snapshot(nodes, &mut opts).text
+    }
+
+    fn render_with_snapshot_options(
+        nodes: &[AxNode],
+        refs: &mut RefMap,
+        options: SnapshotOptions,
+    ) -> String {
+        apply_snapshot_options(&render(nodes, refs), options)
     }
 
     #[test]
@@ -542,5 +649,162 @@ mod tests {
             render_snapshot(&nodes, &mut opts).text,
             "- generic [ref=e1] [cursor=pointer]"
         );
+    }
+
+    #[test]
+    fn interactive_mode_keeps_refs_headings_first_line_and_ancestors() {
+        let mut nodes = vec![
+            ax("1", "RootWebArea", &["2"]),
+            ax("2", "main", &["3", "4", "5"]),
+            ax("3", "paragraph", &[]),
+            ax("4", "section", &["6"]),
+            ax("5", "heading", &[]),
+            ax("6", "button", &[]),
+        ];
+        nodes[1].name = Some(name("App"));
+        nodes[2].name = Some(name("Intro copy"));
+        nodes[3].name = Some(name("Actions"));
+        nodes[4].name = Some(name("Results"));
+        nodes[5].name = Some(name("Save"));
+        nodes[5].backend_dom_node_id = Some(10);
+
+        let text = render_with_snapshot_options(
+            &nodes,
+            &mut RefMap::new(),
+            SnapshotOptions {
+                mode: SnapshotMode::Interactive,
+                depth: None,
+            },
+        );
+
+        assert_eq!(
+            text,
+            [
+                "- main \"App\"",
+                "  - section \"Actions\"",
+                "    - button \"Save\" [ref=e1]",
+                "  - heading \"Results\"",
+            ]
+            .join("\n")
+        );
+    }
+
+    #[test]
+    fn depth_cap_drops_lines_nested_deeper_than_limit() {
+        let mut nodes = vec![
+            ax("1", "RootWebArea", &["2"]),
+            ax("2", "main", &["3"]),
+            ax("3", "section", &["4"]),
+            ax("4", "button", &[]),
+        ];
+        nodes[3].name = Some(name("Deep"));
+        nodes[3].backend_dom_node_id = Some(10);
+
+        let text = render_with_snapshot_options(
+            &nodes,
+            &mut RefMap::new(),
+            SnapshotOptions {
+                mode: SnapshotMode::Full,
+                depth: Some(1),
+            },
+        );
+
+        assert_eq!(text, ["- main", "  - section"].join("\n"));
+    }
+
+    #[test]
+    fn interactive_filter_runs_before_depth_cap() {
+        let mut nodes = vec![
+            ax("1", "RootWebArea", &["2"]),
+            ax("2", "main", &["3", "5"]),
+            ax("3", "section", &["4"]),
+            ax("4", "button", &[]),
+            ax("5", "paragraph", &[]),
+        ];
+        nodes[3].name = Some(name("Deep"));
+        nodes[3].backend_dom_node_id = Some(10);
+        nodes[4].name = Some(name("Static"));
+
+        let text = render_with_snapshot_options(
+            &nodes,
+            &mut RefMap::new(),
+            SnapshotOptions {
+                mode: SnapshotMode::Interactive,
+                depth: Some(1),
+            },
+        );
+
+        assert_eq!(text, ["- main", "  - section"].join("\n"));
+    }
+
+    #[test]
+    fn refs_are_identical_across_full_and_interactive_modes() {
+        let mut nodes = vec![
+            ax("1", "RootWebArea", &["2"]),
+            ax("2", "main", &["3", "4", "5"]),
+            ax("3", "paragraph", &[]),
+            ax("4", "button", &[]),
+            ax("5", "link", &[]),
+        ];
+        nodes[2].name = Some(name("Static"));
+        nodes[3].name = Some(name("Save"));
+        nodes[3].backend_dom_node_id = Some(10);
+        nodes[4].name = Some(name("Home"));
+        nodes[4].backend_dom_node_id = Some(11);
+
+        let mut full_refs = RefMap::new();
+        let full = render_with_snapshot_options(
+            &nodes,
+            &mut full_refs,
+            SnapshotOptions {
+                mode: SnapshotMode::Full,
+                depth: None,
+            },
+        );
+        let mut interactive_refs = RefMap::new();
+        let interactive = render_with_snapshot_options(
+            &nodes,
+            &mut interactive_refs,
+            SnapshotOptions {
+                mode: SnapshotMode::Interactive,
+                depth: None,
+            },
+        );
+
+        assert_eq!(
+            full_refs
+                .entries_in_order()
+                .into_iter()
+                .map(|entry| (entry.ref_id.as_str().to_string(), entry.backend_node_id))
+                .collect::<Vec<_>>(),
+            interactive_refs
+                .entries_in_order()
+                .into_iter()
+                .map(|entry| (entry.ref_id.as_str().to_string(), entry.backend_node_id))
+                .collect::<Vec<_>>()
+        );
+        assert!(full.contains("paragraph \"Static\""));
+        assert!(!interactive.contains("paragraph \"Static\""));
+        assert!(interactive.contains("button \"Save\" [ref=e1]"));
+        assert!(interactive.contains("link \"Home\" [ref=e2]"));
+    }
+
+    #[test]
+    fn default_snapshot_options_preserve_full_output_byte_for_byte() {
+        let mut nodes = vec![
+            ax("1", "RootWebArea", &["2"]),
+            ax("2", "main", &["3", "4"]),
+            ax("3", "paragraph", &[]),
+            ax("4", "button", &[]),
+        ];
+        nodes[2].name = Some(name("Static"));
+        nodes[3].name = Some(name("Save"));
+        nodes[3].backend_dom_node_id = Some(10);
+
+        let mut refs = RefMap::new();
+        let full = render(&nodes, &mut refs);
+        let with_defaults = apply_snapshot_options(&full, SnapshotOptions::default());
+
+        assert_eq!(with_defaults, full);
     }
 }

--- a/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tests.rs
@@ -4,11 +4,12 @@ use crate::{
     output_file::create_browser_output_file_access,
     response::ToolResponse,
     service::{BROWSER_MCP_INSTRUCTIONS, BrowserMcpService, BrowserMcpServiceOptions},
-    tools::{grep, wait},
+    tools::{grep, snapshot, wait},
 };
 use browseros_cdp::{CdpError, CdpEvent};
 use browseros_core::{
-    BrowserSession, BrowserSessionHooks, CdpConnection, SessionId, snapshot::SnapshotDiff,
+    BrowserSession, BrowserSessionHooks, CdpConnection, SessionId,
+    snapshot::{AxNode, AxValue, SnapshotDiff},
 };
 use futures_util::future::BoxFuture;
 use rmcp::handler::server::ServerHandler;
@@ -77,13 +78,142 @@ fn fake_session() -> Arc<BrowserSession> {
     )
 }
 
-fn fake_ctx() -> ToolCtx {
+fn ctx_for_session(session: Arc<BrowserSession>) -> ToolCtx {
     ToolCtx::new(BrowserToolOptions {
-        session: fake_session(),
+        session,
         defaults: BrowserToolDefaults::default(),
         cancel: CancellationToken::new(),
         output_files: create_browser_output_file_access(),
     })
+}
+
+fn fake_ctx() -> ToolCtx {
+    ctx_for_session(fake_session())
+}
+
+struct SnapshotConnection {
+    sender: broadcast::Sender<CdpEvent>,
+}
+
+impl SnapshotConnection {
+    fn new() -> Self {
+        let (sender, _receiver) = broadcast::channel(8);
+        Self { sender }
+    }
+}
+
+impl CdpConnection for SnapshotConnection {
+    fn send<'a>(
+        &'a self,
+        method: &'a str,
+        params: Value,
+        _session: Option<&'a SessionId>,
+    ) -> BoxFuture<'a, Result<Value, CdpError>> {
+        Box::pin(async move {
+            match method {
+                "Browser.getTabs" => Ok(json!({
+                    "tabs": [{
+                        "tabId": 9,
+                        "targetId": "target-1",
+                        "url": "https://example.com/current",
+                        "title": "Current",
+                        "isActive": true,
+                        "isLoading": false,
+                        "loadProgress": 1,
+                        "isPinned": false,
+                        "isHidden": false,
+                        "windowId": 1
+                    }]
+                })),
+                "Target.attachToTarget" => Ok(json!({ "sessionId": "session-1" })),
+                "Page.enable"
+                | "DOM.enable"
+                | "Runtime.enable"
+                | "Accessibility.enable"
+                | "Runtime.runIfWaitingForDebugger"
+                | "Target.setAutoAttach" => Ok(json!({})),
+                "Page.getFrameTree" => Ok(json!({
+                    "frameTree": {
+                        "frame": {
+                            "id": "main",
+                            "loaderId": "loader-1",
+                            "url": "https://example.com/current"
+                        }
+                    }
+                })),
+                "Accessibility.getFullAXTree" => {
+                    assert_eq!(params, json!({}));
+                    Ok(json!({ "nodes": snapshot_nodes() }))
+                }
+                "Runtime.evaluate" => Ok(json!({ "result": { "value": [] } })),
+                _ => Err(CdpError::Protocol {
+                    code: -1,
+                    message: format!("unexpected snapshot CDP call: {method}"),
+                }),
+            }
+        })
+    }
+
+    fn send_raw_json<'a>(
+        &'a self,
+        method: &'a str,
+        _params_json: &'a str,
+        _session: Option<&'a SessionId>,
+    ) -> BoxFuture<'a, Result<String, CdpError>> {
+        Box::pin(async move {
+            Err(CdpError::Protocol {
+                code: -1,
+                message: format!("unexpected snapshot CDP raw call: {method}"),
+            })
+        })
+    }
+
+    fn events(&self) -> broadcast::Receiver<CdpEvent> {
+        self.sender.subscribe()
+    }
+
+    fn is_connected(&self) -> bool {
+        true
+    }
+
+    fn connection_epoch(&self) -> u64 {
+        1
+    }
+}
+
+fn snapshot_nodes() -> Vec<AxNode> {
+    vec![
+        ax("1", "RootWebArea", &["2"]),
+        ax("2", "main", &["3", "4", "5"]),
+        named_ax("3", "paragraph", "Intro", &[]),
+        named_ax("4", "section", "Actions", &["6"]),
+        named_ax("5", "heading", "Title", &[]),
+        button_ax("6", "Save", 10),
+    ]
+}
+
+fn ax(node_id: &str, role: &str, children: &[&str]) -> AxNode {
+    AxNode {
+        node_id: node_id.to_string(),
+        role: Some(AxValue::role(role)),
+        child_ids: (!children.is_empty())
+            .then(|| children.iter().map(|child| (*child).to_string()).collect()),
+        ..AxNode::default()
+    }
+}
+
+fn named_ax(node_id: &str, role: &str, name: &str, children: &[&str]) -> AxNode {
+    AxNode {
+        name: Some(AxValue::string(name)),
+        ..ax(node_id, role, children)
+    }
+}
+
+fn button_ax(node_id: &str, name: &str, backend_id: i64) -> AxNode {
+    AxNode {
+        backend_dom_node_id: Some(backend_id),
+        ..named_ax(node_id, "button", name, &[])
+    }
 }
 
 #[test]
@@ -277,6 +407,42 @@ async fn snapshot_formatter_wraps_small_page_content() {
         formatted.structured.get("writtenToFile"),
         Some(&json!(false))
     );
+}
+
+#[tokio::test]
+async fn snapshot_tool_plumbs_mode_depth_and_structured_fields() {
+    let session = BrowserSession::new(
+        Arc::new(SnapshotConnection::new()),
+        BrowserSessionHooks::default(),
+    );
+    let ctx = ctx_for_session(session);
+    let result = execute_tool(
+        &snapshot::definition(),
+        json!({ "page": 1, "mode": "interactive", "depth": 1.9 }),
+        &ctx,
+    )
+    .await
+    .unwrap_or_else(|err| panic!("snapshot should execute: {err}"));
+
+    let text = result
+        .content
+        .first()
+        .and_then(|content| content.as_text())
+        .map(|content| content.text.to_string())
+        .unwrap_or_else(|| panic!("snapshot should return text"));
+    assert!(text.contains("- main"));
+    assert!(text.contains("  - section \"Actions\""));
+    assert!(text.contains("  - heading \"Title\""));
+    assert!(!text.contains("button \"Save\""));
+    assert!(!text.contains("paragraph \"Intro\""));
+
+    let structured = result
+        .structured_content
+        .unwrap_or_else(|| panic!("snapshot should return structured content"));
+    assert_eq!(structured.get("page"), Some(&json!(1)));
+    assert_eq!(structured.get("mode"), Some(&json!("interactive")));
+    assert_eq!(structured.get("depth"), Some(&json!(1)));
+    assert_eq!(structured.get("writtenToFile"), Some(&json!(false)));
 }
 
 #[tokio::test]

--- a/packages/browseros-agent/crates/browseros-mcp/src/tools/snapshot.rs
+++ b/packages/browseros-agent/crates/browseros-mcp/src/tools/snapshot.rs
@@ -2,23 +2,59 @@ use crate::{
     format::snapshot::format_snapshot_result,
     framework::{ToolCtx, ToolExecResult, ToolResult, parse_args, text_result},
 };
-use browseros_core::PageId;
+use browseros_core::{
+    PageId,
+    snapshot::{SnapshotMode, SnapshotOptions},
+};
 use futures_util::future::BoxFuture;
 use schemars::JsonSchema;
 use serde::Deserialize;
 use serde_json::{Value, json};
 
+const MAX_DEPTH: usize = 100;
 const DESCRIPTION: &str = "\
 Capture the page as an indented accessibility tree. \
 Each actionable element carries a stable [ref=eN] you pass to `act`. \
-Iframe content is stitched in inline. \
+mode=\"interactive\" returns actionables plus headings and ancestor context; depth caps nesting. \
+Default mode=\"full\" is unchanged; iframe content is stitched inline. \
 Re-snapshot after navigation or large changes (refs are invalidated). \
 This is the start of the loop: snapshot -> act -> (reads back a diff).";
+
+#[derive(Debug, Clone, Copy, Default, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+enum SnapshotModeArg {
+    #[default]
+    Full,
+    Interactive,
+}
+
+impl SnapshotModeArg {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Full => "full",
+            Self::Interactive => "interactive",
+        }
+    }
+}
+
+impl From<SnapshotModeArg> for SnapshotMode {
+    fn from(value: SnapshotModeArg) -> Self {
+        match value {
+            SnapshotModeArg::Full => Self::Full,
+            SnapshotModeArg::Interactive => Self::Interactive,
+        }
+    }
+}
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]
 struct SnapshotArgs {
     /// Page id from `tabs` or `navigate`.
     page: u32,
+    /// Snapshot compactness mode. Defaults to full.
+    #[serde(default)]
+    mode: SnapshotModeArg,
+    /// Maximum rendered tree depth. Values are floored and clamped to 1..=100.
+    depth: Option<f64>,
 }
 
 pub fn definition() -> crate::framework::ToolDef {
@@ -37,17 +73,32 @@ fn handler<'a>(
 ) -> BoxFuture<'a, ToolExecResult<Option<ToolResult>>> {
     Box::pin(async move {
         let args: SnapshotArgs = parse_args(raw)?;
+        let depth = args.depth.map(clamp_depth);
         let snapshot = ctx
             .session
             .observe(PageId(args.page))
             .await
-            .snapshot()
+            .snapshot_with_options(SnapshotOptions {
+                mode: args.mode.into(),
+                depth,
+            })
             .await?;
         let formatted = format_snapshot_result(&snapshot.text, &snapshot.url, ctx).await;
         let mut structured = formatted.structured;
         if let Value::Object(object) = &mut structured {
             object.insert("page".to_string(), json!(args.page));
+            object.insert("mode".to_string(), json!(args.mode.as_str()));
+            if let Some(depth) = depth {
+                object.insert("depth".to_string(), json!(depth));
+            }
         }
         Ok(Some(text_result(formatted.text, Some(structured))))
     })
+}
+
+fn clamp_depth(depth: f64) -> usize {
+    if !depth.is_finite() {
+        return MAX_DEPTH;
+    }
+    depth.floor().clamp(1.0, MAX_DEPTH as f64) as usize
 }


### PR DESCRIPTION
## Summary
- add opt-in snapshot mode=interactive and render-side depth cap while keeping full mode as the default
- preserve full render/ref minting for stable refs and full diff baselines, then filter only returned snapshot text
- include mode and clamped depth in snapshot structured output

## Verification
- cargo build --workspace
- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- cargo fmt --all -- --check